### PR TITLE
[native] Add TLParse-based compile/cache instrumentation for native DSL ops

### DIFF
--- a/test/python_native/test_instrumentation.py
+++ b/test/python_native/test_instrumentation.py
@@ -1,0 +1,408 @@
+# Owner(s): ["module: dsl-native-ops"]
+
+import json
+import logging
+import shutil
+import subprocess
+import tempfile
+import unittest
+from collections import namedtuple
+
+from torch._logging._internal import TorchLogsFormatter, trace_log
+from torch._native.instrumentation import (
+    CompileEvent,
+    instrument_cutedsl_compile,
+    instrument_triton_launch,
+)
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+# No shared tlparse harness exists in torch (see test/dynamo/test_structured_trace.py,
+# which defines these locally too), so mirror its minimal pattern here.
+HAS_TLPARSE = shutil.which("tlparse") is not None
+requires_tlparse = unittest.skipUnless(HAS_TLPARSE, "requires tlparse")
+
+
+# Mirror of torch._vendor.quack.cache.CacheInfo. Defined locally so the test
+# doesn't import quack (which pulls in cutlass, absent on CPU-only builds).
+_CacheInfo = namedtuple("CacheInfo", ["hits", "misses", "maxsize", "currsize"])
+
+
+class _FakeJITFunction:
+    """Stand-in for a ``@triton.jit`` kernel's cache surface.
+
+    ``instrument_triton_launch`` watches ``device_caches[dev][0]`` (the dict
+    of compiled variants). We model a single fake device and grow the dict
+    on each distinct ``key`` to simulate a Triton compile (miss); repeated
+    keys leave it unchanged (hit). GPU- and Triton-free.
+    """
+
+    def __init__(self):
+        # defaultdict-like: one device "cuda:0", value is a (cache_dict, ...) tuple.
+        self._cache: dict = {}
+        self.device_caches = {"cuda:0": (self._cache, None)}
+
+    def launch(self, key):
+        if key not in self._cache:
+            self._cache[key] = object()
+
+
+# Module-level kernel + launcher: instrument_triton_launch resolves watched
+# kernels from the launcher's module globals, so both must live here.
+_FAKE_KERNEL = _FakeJITFunction()
+
+
+def _fake_launch(key="v0"):
+    _FAKE_KERNEL.launch(key)
+    return "launched"
+
+
+class _FakeJitCache:
+    """Stand-in for a ``@jit_cache``-decorated compile function.
+
+    Mimics the bits ``instrument_cutedsl_compile`` observes: a ``cache_info()``
+    whose ``misses`` advances on a cold key, plus a controllable wall time
+    via the compiled callable. Keeps the test GPU- and CuTeDSL-free.
+    """
+
+    def __init__(self):
+        self._cache: dict = {}
+        self.hits = 0
+        self.misses = 0
+        self.raise_on_call = False
+
+    def __call__(self, *args, **kwargs):
+        if self.raise_on_call:
+            raise RuntimeError("boom")
+        key = args + tuple(sorted(kwargs.items()))
+        if key in self._cache:
+            self.hits += 1
+        else:
+            self.misses += 1
+            self._cache[key] = object()
+        return self._cache[key]
+
+    def cache_info(self):
+        return _CacheInfo(
+            hits=self.hits,
+            misses=self.misses,
+            maxsize=None,
+            currsize=len(self._cache),
+        )
+
+
+class _CapturingHandler(logging.Handler):
+    def __init__(self):
+        super().__init__()
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record):
+        self.records.append(record)
+
+
+class _LoggerCaptureTest(TestCase):
+    """Captures the native_dsl logger so tests can assert on emitted lines."""
+
+    def setUp(self):
+        super().setUp()
+        self.log = logging.getLogger("torch._native.instrumentation")
+        self._orig_level = self.log.level
+        self._orig_propagate = self.log.propagate
+        self.log.setLevel(logging.INFO)
+        self.log.propagate = False
+        self.handler = _CapturingHandler()
+        self.log.addHandler(self.handler)
+
+    def tearDown(self):
+        self.log.removeHandler(self.handler)
+        self.log.setLevel(self._orig_level)
+        self.log.propagate = self._orig_propagate
+        super().tearDown()
+
+    @property
+    def messages(self):
+        return [r.getMessage() for r in self.handler.records]
+
+
+class TestInstrumentation(_LoggerCaptureTest):
+    def test_first_call_reports_compiled(self):
+        fake = _FakeJitCache()
+        compile_fn = instrument_cutedsl_compile("aten::topk")(fake)
+
+        compile_fn(256, 64)
+
+        self.assertEqual(len(self.messages), 1)
+        msg = self.messages[0]
+        self.assertIn("aten::topk", msg)
+        self.assertIn("[cutedsl]", msg)
+        self.assertIn("compiled", msg)
+        self.assertIn("misses=1", msg)
+
+    def test_second_call_reports_cache_hit(self):
+        fake = _FakeJitCache()
+        compile_fn = instrument_cutedsl_compile("aten::topk")(fake)
+
+        compile_fn(256, 64)
+        compile_fn(256, 64)
+
+        self.assertEqual(len(self.messages), 2)
+        self.assertIn("compiled", self.messages[0])
+        self.assertIn("cache_hit", self.messages[1])
+        self.assertIn("hits=1", self.messages[1])
+
+    def test_distinct_keys_each_compile(self):
+        fake = _FakeJitCache()
+        compile_fn = instrument_cutedsl_compile("aten::topk")(fake)
+
+        compile_fn(256, 64)
+        compile_fn(512, 128)
+
+        self.assertEqual(fake.misses, 2)
+        for msg in self.messages:
+            self.assertIn("compiled", msg)
+
+    def test_key_fn_used_in_log(self):
+        fake = _FakeJitCache()
+        compile_fn = instrument_cutedsl_compile(
+            "aten::topk", key_fn=lambda N, K: f"radix N={N} K={K}"
+        )(fake)
+
+        compile_fn(256, 64)
+
+        self.assertIn("radix N=256 K=64", self.messages[0])
+
+    def test_error_is_reported_and_reraised(self):
+        fake = _FakeJitCache()
+        fake.raise_on_call = True
+        compile_fn = instrument_cutedsl_compile("aten::topk")(fake)
+
+        with self.assertRaises(RuntimeError):
+            compile_fn(256, 64)
+
+        self.assertEqual(len(self.messages), 1)
+        self.assertIn("error", self.messages[0])
+
+    def test_cache_attrs_forwarded(self):
+        fake = _FakeJitCache()
+        compile_fn = instrument_cutedsl_compile("aten::topk")(fake)
+
+        # jit_cache exposes cache_info / cache_clear; the wrapper must keep
+        # them reachable so it's a drop-in replacement.
+        self.assertTrue(hasattr(compile_fn, "cache_info"))
+        self.assertEqual(compile_fn.cache_info().misses, 0)
+
+    def test_works_without_cache_info(self):
+        # A plain callable (no cache_info) must still be timed and reported,
+        # just without compiled/cache_hit ground truth (defaults to cache_hit).
+        calls = []
+
+        def plain(N, K):
+            calls.append((N, K))
+            return "ok"
+
+        compile_fn = instrument_cutedsl_compile("aten::topk")(plain)
+        self.assertEqual(compile_fn(256, 64), "ok")
+        self.assertEqual(calls, [(256, 64)])
+        self.assertEqual(len(self.messages), 1)
+
+    def test_compile_event_json_roundtrip(self):
+        event = CompileEvent(
+            op="aten::topk",
+            dsl="cutedsl",
+            outcome="compiled",
+            compiled=True,
+            wall_ms=12.5,
+            key="radix N=256 K=64",
+            hits=0,
+            misses=1,
+        )
+        loaded = json.loads(json.dumps(event.as_dict(), sort_keys=True))
+        self.assertEqual(loaded["op"], "aten::topk")
+        self.assertEqual(loaded["compiled"], True)
+        self.assertEqual(loaded["misses"], 1)
+
+
+class TestTritonLaunchInstrumentation(_LoggerCaptureTest):
+    def setUp(self):
+        super().setUp()
+        _FAKE_KERNEL._cache.clear()
+
+    def tearDown(self):
+        _FAKE_KERNEL._cache.clear()
+        super().tearDown()
+
+    def test_first_launch_reports_compiled(self):
+        launch = instrument_triton_launch("aten::bmm")(_fake_launch)
+
+        self.assertEqual(launch(), "launched")
+
+        self.assertEqual(len(self.messages), 1)
+        msg = self.messages[0]
+        self.assertIn("aten::bmm", msg)
+        self.assertIn("[triton]", msg)
+        self.assertIn("compiled", msg)
+
+    def test_repeated_launch_reports_cache_hit(self):
+        launch = instrument_triton_launch("aten::bmm")(_fake_launch)
+
+        launch(key="v0")
+        launch(key="v0")
+
+        self.assertIn("compiled", self.messages[0])
+        self.assertIn("cache_hit", self.messages[1])
+
+    def test_new_variant_recompiles(self):
+        launch = instrument_triton_launch("aten::bmm")(_fake_launch)
+
+        launch(key="v0")
+        launch(key="v1")
+
+        for msg in self.messages:
+            self.assertIn("compiled", msg)
+        # Running variant count surfaces as misses=2 on the second compile.
+        self.assertIn("misses=2", self.messages[1])
+
+    def test_error_is_reported_and_reraised(self):
+        def boom():
+            raise RuntimeError("kaboom")
+
+        launch = instrument_triton_launch("aten::bmm")(boom)
+        with self.assertRaises(RuntimeError):
+            launch()
+
+        self.assertEqual(len(self.messages), 1)
+        self.assertIn("error", self.messages[0])
+
+    def test_key_fn_used_in_log(self):
+        launch = instrument_triton_launch(
+            "aten::bmm", key_fn=lambda key="v0": f"variant={key}"
+        )(_fake_launch)
+
+        launch(key="abc")
+
+        self.assertIn("variant=abc", self.messages[0])
+
+
+class TestTlparseOutput(TestCase):
+    """The instrumentation's whole point on production jobs is tlparse-
+    retrievable artifacts. Assert the structured-trace plumbing actually
+    fires and that tlparse parses the emitted artifact in --strict mode.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.old_level = trace_log.level
+        trace_log.setLevel(logging.DEBUG)
+
+        # Raw trace file in the on-disk format tlparse consumes, written via
+        # the same TorchLogsFormatter(trace=True) that TORCH_TRACE installs.
+        # NB: this handler must be registered BEFORE the capture handler --
+        # TorchLogsFormatter(trace=True) populates record.metadata as a side
+        # effect of formatting, and the capture handler reads that field.
+        self.raw_file = tempfile.NamedTemporaryFile(  # noqa: SIM115
+            mode="w", delete=True
+        )
+        self.raw_handler = logging.StreamHandler(self.raw_file)
+        self.raw_handler.setFormatter(TorchLogsFormatter(trace=True))
+        trace_log.addHandler(self.raw_handler)
+
+        # Capture the records so we can assert on metadata/payload without
+        # re-parsing the raw file.
+        self.records: list[logging.LogRecord] = []
+        self.capture = _CapturingHandler()
+        self.capture.records = self.records
+        trace_log.addHandler(self.capture)
+
+    def tearDown(self):
+        trace_log.removeHandler(self.capture)
+        trace_log.removeHandler(self.raw_handler)
+        self.raw_file.close()
+        trace_log.setLevel(self.old_level)
+        super().tearDown()
+
+    def _emit_one(self):
+        fake = _FakeJitCache()
+        compile_fn = instrument_cutedsl_compile(
+            "aten::topk", key_fn=lambda N, K: f"radix N={N} K={K}"
+        )(fake)
+        compile_fn(256, 64)
+        self.raw_file.flush()
+
+    def _artifact_records(self):
+        return [
+            r
+            for r in self.records
+            if getattr(r, "metadata", {}).get("artifact", {}).get("name")
+            == "native_dsl_compile"
+        ]
+
+    def test_emits_artifact_record(self):
+        self._emit_one()
+
+        recs = self._artifact_records()
+        self.assertEqual(len(recs), 1)
+        meta = recs[0].metadata["artifact"]
+        self.assertEqual(meta["encoding"], "json")
+        # Payload must be valid JSON carrying the CompileEvent fields.
+        payload = json.loads(recs[0].payload)
+        self.assertEqual(payload["op"], "aten::topk")
+        self.assertEqual(payload["dsl"], "cutedsl")
+        self.assertTrue(payload["compiled"])
+        self.assertEqual(payload["key"], "radix N=256 K=64")
+
+    def test_eager_record_has_no_compile_context(self):
+        # In eager dispatch there's no live CompileContext, so the record
+        # carries no frame id (and -- via expect_trace_id=False -- no
+        # diagnostic stack either).
+        self._emit_one()
+
+        meta = self._artifact_records()[0].metadata
+        self.assertNotIn("frame_id", meta)
+        self.assertNotIn("stack", meta)
+
+    def test_picks_up_live_compile_context(self):
+        # When a native op compiles inside a torch.compile (CompileContext is
+        # live), the artifact is auto-tagged with the ambient frame ids so it
+        # nests under that compile in tlparse -- like a Dynamo artifact.
+        from torch._guards import compile_context, CompileContext, CompileId
+
+        cid = CompileId(frame_id=7, frame_compile_id=3)
+        with compile_context(CompileContext(cid)):
+            self._emit_one()
+
+        meta = self._artifact_records()[0].metadata
+        self.assertEqual(meta["frame_id"], 7)
+        self.assertEqual(meta["frame_compile_id"], 3)
+        self.assertEqual(meta["attempt"], 0)
+
+    @requires_tlparse
+    def test_tlparse_parses_artifact(self):
+        self._emit_one()
+
+        # Guard against a false pass: --strict over an empty file exits 0, so
+        # assert the artifact was actually written before parsing it.
+        with open(self.raw_file.name) as f:
+            raw = f.read()
+        self.assertIn("native_dsl_compile", raw)
+
+        out = tempfile.mkdtemp()
+        try:
+            # --strict makes tlparse exit non-zero on any unparsable line, so
+            # check_call alone is the assertion.
+            subprocess.check_call(
+                [
+                    "tlparse",
+                    "-o",
+                    out,
+                    "--overwrite",
+                    "--no-browser",
+                    "--strict",
+                    self.raw_file.name,
+                ]
+            )
+        finally:
+            shutil.rmtree(out, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/python_native/test_instrumentation.py
+++ b/test/python_native/test_instrumentation.py
@@ -1,7 +1,9 @@
 # Owner(s): ["module: dsl-native-ops"]
 
+import ast
 import json
 import logging
+import os
 import shutil
 import subprocess
 import tempfile
@@ -12,7 +14,7 @@ from torch._logging._internal import TorchLogsFormatter, trace_log
 from torch._native.instrumentation import (
     CompileEvent,
     instrument_cutedsl_compile,
-    instrument_triton_launch,
+    instrument_triton_kernel,
 )
 from torch.testing._internal.common_utils import run_tests, TestCase
 
@@ -29,32 +31,30 @@ _CacheInfo = namedtuple("CacheInfo", ["hits", "misses", "maxsize", "currsize"])
 
 
 class _FakeJITFunction:
-    """Stand-in for a ``@triton.jit`` kernel's cache surface.
+    """Stand-in for a ``@triton.jit`` kernel. GPU- and Triton-free.
 
-    ``instrument_triton_launch`` watches ``device_caches[dev][0]`` (the dict
-    of compiled variants). We model a single fake device and grow the dict
-    on each distinct ``key`` to simulate a Triton compile (miss); repeated
-    keys leave it unchanged (hit). GPU- and Triton-free.
+    ``instrument_triton_kernel`` watches ``device_caches[dev][0]`` (the dict
+    of compiled variants) and launches via ``kernel[grid](*args)``. We model
+    one fake device whose cache grows on each distinct ``variant`` kwarg (a
+    fresh Triton compile / miss); a repeated variant leaves it unchanged (a
+    cache hit).
     """
 
     def __init__(self):
         # defaultdict-like: one device "cuda:0", value is a (cache_dict, ...) tuple.
         self._cache: dict = {}
         self.device_caches = {"cuda:0": (self._cache, None)}
+        self.raise_on_launch = False
 
-    def launch(self, key):
-        if key not in self._cache:
-            self._cache[key] = object()
+    def __getitem__(self, grid):
+        def launcher(*args, variant="v0", **kwargs):
+            if self.raise_on_launch:
+                raise RuntimeError("kaboom")
+            if variant not in self._cache:
+                self._cache[variant] = object()
+            return "launched"
 
-
-# Module-level kernel + launcher: instrument_triton_launch resolves watched
-# kernels from the launcher's module globals, so both must live here.
-_FAKE_KERNEL = _FakeJITFunction()
-
-
-def _fake_launch(key="v0"):
-    _FAKE_KERNEL.launch(key)
-    return "launched"
+        return launcher
 
 
 class _FakeJitCache:
@@ -205,6 +205,33 @@ class TestInstrumentation(_LoggerCaptureTest):
         self.assertEqual(calls, [(256, 64)])
         self.assertEqual(len(self.messages), 1)
 
+    def test_no_work_when_not_listening(self):
+        # With no listener (logger above INFO, no trace handlers), the wrapper
+        # must run the wrapped fn but skip all instrumentation: no log line,
+        # and crucially no key_fn call (user code we shouldn't run for nothing).
+        key_calls = []
+
+        def key_fn(N, K):
+            key_calls.append((N, K))
+            return "k"
+
+        fake = _FakeJitCache()
+        compile_fn = instrument_cutedsl_compile("aten::topk", key_fn=key_fn)(fake)
+
+        self.log.setLevel(logging.WARNING)
+        saved = list(trace_log.handlers)
+        for h in saved:
+            trace_log.removeHandler(h)
+        try:
+            compile_fn(256, 64)
+        finally:
+            for h in saved:
+                trace_log.addHandler(h)
+
+        self.assertEqual(fake.misses, 1)  # wrapped fn still ran
+        self.assertEqual(key_calls, [])  # ... but no instrumentation work
+        self.assertEqual(self.messages, [])
+
     def test_compile_event_json_roundtrip(self):
         event = CompileEvent(
             op="aten::topk",
@@ -222,19 +249,16 @@ class TestInstrumentation(_LoggerCaptureTest):
         self.assertEqual(loaded["misses"], 1)
 
 
-class TestTritonLaunchInstrumentation(_LoggerCaptureTest):
-    def setUp(self):
-        super().setUp()
-        _FAKE_KERNEL._cache.clear()
+class TestTritonKernelInstrumentation(_LoggerCaptureTest):
+    GRID = (1,)
 
-    def tearDown(self):
-        _FAKE_KERNEL._cache.clear()
-        super().tearDown()
+    def _kernel(self, op="aten::bmm", key_fn=None):
+        return instrument_triton_kernel(op, key_fn=key_fn)(_FakeJITFunction())
 
     def test_first_launch_reports_compiled(self):
-        launch = instrument_triton_launch("aten::bmm")(_fake_launch)
+        kernel = self._kernel()
 
-        self.assertEqual(launch(), "launched")
+        self.assertEqual(kernel[self.GRID](), "launched")
 
         self.assertEqual(len(self.messages), 1)
         msg = self.messages[0]
@@ -243,44 +267,77 @@ class TestTritonLaunchInstrumentation(_LoggerCaptureTest):
         self.assertIn("compiled", msg)
 
     def test_repeated_launch_reports_cache_hit(self):
-        launch = instrument_triton_launch("aten::bmm")(_fake_launch)
+        kernel = self._kernel()
 
-        launch(key="v0")
-        launch(key="v0")
+        kernel[self.GRID](variant="v0")
+        kernel[self.GRID](variant="v0")
 
         self.assertIn("compiled", self.messages[0])
         self.assertIn("cache_hit", self.messages[1])
 
     def test_new_variant_recompiles(self):
-        launch = instrument_triton_launch("aten::bmm")(_fake_launch)
+        kernel = self._kernel()
 
-        launch(key="v0")
-        launch(key="v1")
+        kernel[self.GRID](variant="v0")
+        kernel[self.GRID](variant="v1")
 
         for msg in self.messages:
             self.assertIn("compiled", msg)
-        # Running variant count surfaces as misses=2 on the second compile.
+        # This kernel's running variant count surfaces as misses=2.
         self.assertIn("misses=2", self.messages[1])
 
     def test_error_is_reported_and_reraised(self):
-        def boom():
-            raise RuntimeError("kaboom")
+        fake = _FakeJITFunction()
+        fake.raise_on_launch = True
+        kernel = instrument_triton_kernel("aten::bmm")(fake)
 
-        launch = instrument_triton_launch("aten::bmm")(boom)
         with self.assertRaises(RuntimeError):
-            launch()
+            kernel[self.GRID]()
 
         self.assertEqual(len(self.messages), 1)
         self.assertIn("error", self.messages[0])
 
     def test_key_fn_used_in_log(self):
-        launch = instrument_triton_launch(
-            "aten::bmm", key_fn=lambda key="v0": f"variant={key}"
-        )(_fake_launch)
+        kernel = self._kernel(key_fn=lambda variant="v0": f"variant={variant}")
 
-        launch(key="abc")
+        kernel[self.GRID](variant="abc")
 
         self.assertIn("variant=abc", self.messages[0])
+
+    def test_two_kernels_in_one_module_dont_collide(self):
+        # The core guarantee of per-kernel scoping: each kernel watches only
+        # its own cache, so compiling kernel B must NOT make kernel A look
+        # like it compiled. The old module-scan summed both and would here
+        # falsely report A as "compiled" on its second call.
+        kernel_a = self._kernel(op="aten::a", key_fn=lambda variant="v0": "A")
+        kernel_b = self._kernel(op="aten::b", key_fn=lambda variant="v0": "B")
+
+        kernel_a[self.GRID](variant="v0")  # A compiles
+        kernel_b[self.GRID](variant="v0")  # B compiles (must not touch A)
+        kernel_a[self.GRID](variant="v0")  # A hit -- NOT a recompile
+
+        a_msgs = [m for m in self.messages if "aten::a" in m]
+        b_msgs = [m for m in self.messages if "aten::b" in m]
+        self.assertEqual(len(a_msgs), 2)
+        self.assertEqual(len(b_msgs), 1)
+        self.assertIn("compiled", a_msgs[0])
+        self.assertIn("cache_hit", a_msgs[1])  # would be "compiled" if collided
+        self.assertIn("compiled", b_msgs[0])
+        # Each reports its own variant count, not the module-wide sum.
+        self.assertIn("misses=1", a_msgs[1])
+
+    def test_jit_kernel_exposes_raw_kernel(self):
+        # wrap_triton needs the raw JITFunction; the proxy exposes it.
+        fake = _FakeJITFunction()
+        kernel = instrument_triton_kernel("aten::bmm")(fake)
+        self.assertIs(kernel.jit_kernel, fake)
+
+    def test_attribute_passthrough(self):
+        # Non-launch attribute access is delegated to the wrapped kernel.
+        fake = _FakeJITFunction()
+        fake.cache_key = "abc123"
+        kernel = instrument_triton_kernel("aten::bmm")(fake)
+        self.assertEqual(kernel.cache_key, "abc123")
 
 
 class TestTlparseOutput(TestCase):
@@ -299,8 +356,10 @@ class TestTlparseOutput(TestCase):
         # NB: this handler must be registered BEFORE the capture handler --
         # TorchLogsFormatter(trace=True) populates record.metadata as a side
         # effect of formatting, and the capture handler reads that field.
+        # delete=False: the file is reopened by name (for tlparse and the
+        # raw-content read), so don't let close() unlink it; tearDown removes it.
         self.raw_file = tempfile.NamedTemporaryFile(  # noqa: SIM115
-            mode="w", delete=True
+            mode="w", delete=False
         )
         self.raw_handler = logging.StreamHandler(self.raw_file)
         self.raw_handler.setFormatter(TorchLogsFormatter(trace=True))
@@ -317,6 +376,7 @@ class TestTlparseOutput(TestCase):
         trace_log.removeHandler(self.capture)
         trace_log.removeHandler(self.raw_handler)
         self.raw_file.close()
+        os.unlink(self.raw_file.name)
         trace_log.setLevel(self.old_level)
         super().tearDown()
 
@@ -402,6 +462,274 @@ class TestTlparseOutput(TestCase):
             )
         finally:
             shutil.rmtree(out, ignore_errors=True)
+
+
+def _dotted(node):
+    """Dotted name of an AST expression, e.g. ``cute.compile`` / ``triton.jit``.
+
+    Unwraps a Call to its callee, so ``@deco(...)`` and ``deco(...)`` both
+    resolve to ``"deco"``. Returns "" for anything we don't model.
+    """
+    if isinstance(node, ast.Call):
+        return _dotted(node.func)
+    if isinstance(node, ast.Attribute):
+        return f"{_dotted(node.value)}.{node.attr}"
+    if isinstance(node, ast.Name):
+        return node.id
+    return ""
+
+
+def _decorator_names(fn_node):
+    """Set of dotted decorator names on a FunctionDef node.
+
+    e.g. ``@triton.jit`` -> "triton.jit", ``@instrument_triton_kernel(...)``
+    -> "instrument_triton_kernel".
+    """
+    return {_dotted(d) for d in fn_node.decorator_list}
+
+
+# One rule per DSL. ``jit_decorator`` is the DSL's raw cache/jit decorator;
+# ``instrument_decorator`` is the explicit instrumentation wrapper; and
+# ``combined_decorator`` is the one-decorator form that applies both. A
+# compile site satisfies the guard if it carries the combined decorator, OR
+# both the jit and instrument decorators explicitly. To onboard a new DSL,
+# add a row -- every scan and existence check below picks it up. All three
+# decorator names must be real entry points in torch._native.instrumentation
+# (instrument names) / the DSL (jit name); test_required_decorators_exist
+# enforces the instrumentation ones.
+_DSL_INSTRUMENTATION_RULES = (
+    # (dsl, jit_decorator, instrument_decorator, combined_decorator)
+    ("triton", "triton.jit", "instrument_triton_kernel", "instrumented_triton_cache"),
+    (
+        "cutedsl",
+        "jit_cache",
+        "instrument_cutedsl_compile",
+        "instrumented_cutedsl_cache",
+    ),
+)
+
+
+def _is_instrumented(decos, jit_deco, instrument_deco, combined_deco):
+    """True if a function's decorator set satisfies a DSL rule.
+
+    Either the one-shot combined decorator, or the explicit jit + instrument
+    stack.
+    """
+    return combined_deco in decos or (jit_deco in decos and instrument_deco in decos)
+
+
+def _scan_for_missing_instrumentation(source, label):
+    """Return (violations, n_compile_sites) for one Python source string.
+
+    A compile site is any function carrying a DSL rule's ``jit_decorator`` or
+    its ``combined_decorator``. A violation is such a site that isn't fully
+    instrumented (see :func:`_is_instrumented`). ``n_compile_sites`` lets
+    callers assert the scan saw something rather than passing vacuously.
+    """
+    violations = []
+    n_compile_sites = 0
+    tree = ast.parse(source, filename=label)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        decos = _decorator_names(node)
+        for _, jit_deco, instrument_deco, combined_deco in _DSL_INSTRUMENTATION_RULES:
+            if jit_deco in decos or combined_deco in decos:
+                n_compile_sites += 1
+                if not _is_instrumented(
+                    decos, jit_deco, instrument_deco, combined_deco
+                ):
+                    violations.append(
+                        f"{label}:{node.lineno} {node.name} has @{jit_deco} but "
+                        f"is not instrumented (use @{combined_deco}, or add "
+                        f"@{instrument_deco})"
+                    )
+    return violations, n_compile_sites
+
+
+# cute.compile must be cached so it is also instrumented: the enclosing
+# function must carry @jit_cache or the combined @instrumented_cutedsl_cache.
+# A raw call elsewhere would compile uncached *and* invisibly to the
+# instrumentation, so it is banned.
+_CACHED_COMPILE_CALL = "cute.compile"
+_CACHE_DECORATORS = ("jit_cache", "instrumented_cutedsl_cache")
+
+
+def _scan_for_raw_cute_compile(source, label):
+    """Return (violations, n_calls) for one Python source string.
+
+    A violation is a ``cute.compile`` call whose nearest enclosing function
+    carries neither ``@jit_cache`` nor ``@instrumented_cutedsl_cache`` (or
+    that sits at module level). ``n_calls`` counts compile calls seen.
+    """
+    tree = ast.parse(source, filename=label)
+    # Map each node to its parent so we can climb to the nearest FunctionDef.
+    parent = {}
+    for node in ast.walk(tree):
+        for child in ast.iter_child_nodes(node):
+            parent[child] = node
+
+    def enclosing_function(node):
+        cur = parent.get(node)
+        while cur is not None:
+            if isinstance(cur, ast.FunctionDef):
+                return cur
+            cur = parent.get(cur)
+        return None
+
+    violations = []
+    n_calls = 0
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call) and _dotted(node) == _CACHED_COMPILE_CALL):
+            continue
+        n_calls += 1
+        fn = enclosing_function(node)
+        cached = fn is not None and any(
+            d in _decorator_names(fn) for d in _CACHE_DECORATORS
+        )
+        if not cached:
+            where = fn.name if fn is not None else "<module level>"
+            allowed = " or ".join(f"@{d}" for d in _CACHE_DECORATORS)
+            violations.append(
+                f"{label}:{node.lineno} {_CACHED_COMPILE_CALL}() in {where} is "
+                f"not wrapped by {allowed}"
+            )
+    return violations, n_calls
+
+
+class TestInstrumentationCoverage(TestCase):
+    """CI guard: every DSL compile site must carry its instrumentation.
+
+    Static AST scan of ``torch/_native/ops`` -- adding a kernel for a known
+    DSL (per :data:`_DSL_INSTRUMENTATION_RULES`) without the matching
+    instrumentation decorator turns this test (and thus CI) red.
+
+    Extending to a new DSL: add a row to ``_DSL_INSTRUMENTATION_RULES``.
+
+    For CuTeDSL this also enforces the full chain: every ``cute.compile()``
+    must be wrapped by ``@jit_cache`` (``test_no_raw_cute_compile_calls``),
+    and every ``@jit_cache`` must be instrumented -- so no compile can escape
+    caching or instrumentation.
+
+    Out of scope by construction: ops that wrap *vendored* compile fns at the
+    call site (e.g. norm's rmsnorm, which has no local ``@jit_cache`` or
+    ``cute.compile``) aren't decorator/call sites here -- they have their own
+    tests.
+    """
+
+    def _ops_files(self):
+        import torch._native
+
+        ops_dir = os.path.join(os.path.dirname(torch._native.__file__), "ops")
+        for root, _, files in os.walk(ops_dir):
+            for name in files:
+                if name.endswith(".py"):
+                    yield os.path.join(root, name)
+
+    def test_required_decorators_exist(self):
+        # Ties each rule to the real API: a typo'd or removed instrumentation
+        # entry point fails here rather than letting the scan pass vacuously.
+        import torch._native.instrumentation as instr
+
+        for dsl, _, instrument_deco, combined_deco in _DSL_INSTRUMENTATION_RULES:
+            for name in (instrument_deco, combined_deco):
+                self.assertTrue(
+                    hasattr(instr, name),
+                    f"rule for DSL {dsl!r} names {name!r}, which is not in "
+                    f"torch._native.instrumentation",
+                )
+
+    def test_every_compile_site_is_instrumented(self):
+        missing = []
+        checked = 0
+        for path in self._ops_files():
+            with open(path) as f:
+                violations, n = _scan_for_missing_instrumentation(
+                    f.read(), os.path.relpath(path)
+                )
+            missing += violations
+            checked += n
+
+        self.assertTrue(checked, "scan found no compile sites -- test is stale")
+        self.assertEqual(
+            missing,
+            [],
+            "DSL compile sites missing instrumentation:\n" + "\n".join(missing),
+        )
+
+    def test_scan_flags_uninstrumented_kernel_per_dsl(self):
+        # Meta-test: prove the guard fires. For each DSL: a bare jit decorator
+        # (no instrumentation) must be flagged, while BOTH accepted forms --
+        # the explicit jit+instrument stack and the one-shot combined
+        # decorator -- must pass.
+        templates = {
+            # dsl: (bad, explicit_ok, combined_ok)
+            "triton": (
+                "@triton.jit\ndef k(): ...\n",
+                "@instrument_triton_kernel('aten::x')\n@triton.jit\ndef k(): ...\n",
+                "@instrumented_triton_cache('aten::x')\ndef k(): ...\n",
+            ),
+            "cutedsl": (
+                "@jit_cache\ndef c(): ...\n",
+                "@instrument_cutedsl_compile('aten::x')\n@jit_cache\ndef c(): ...\n",
+                "@instrumented_cutedsl_cache('aten::x')\ndef c(): ...\n",
+            ),
+        }
+        for dsl, (bad, explicit_ok, combined_ok) in templates.items():
+            bad_v, bad_n = _scan_for_missing_instrumentation(bad, f"<{dsl}-bad>")
+            self.assertEqual(bad_n, 1, f"{dsl}: scan didn't see the compile site")
+            self.assertEqual(
+                len(bad_v), 1, f"{dsl}: uninstrumented kernel was NOT flagged"
+            )
+
+            for form, src in (("explicit", explicit_ok), ("combined", combined_ok)):
+                v, n = _scan_for_missing_instrumentation(src, f"<{dsl}-{form}>")
+                self.assertEqual(n, 1, f"{dsl}/{form}: scan missed the site")
+                self.assertEqual(v, [], f"{dsl}/{form}: wrongly flagged")
+
+    def test_no_raw_cute_compile_calls(self):
+        # Caching is compulsory for cutedsl compiles: every cute.compile() must
+        # sit inside a function decorated with @jit_cache or the combined
+        # @instrumented_cutedsl_cache. A raw call would be uncached and
+        # invisible to instrumentation.
+        bad = []
+        seen = 0
+        for path in self._ops_files():
+            with open(path) as f:
+                violations, n = _scan_for_raw_cute_compile(
+                    f.read(), os.path.relpath(path)
+                )
+            bad += violations
+            seen += n
+
+        self.assertTrue(seen, "scan found no cute.compile calls -- test is stale")
+        self.assertEqual(
+            bad,
+            [],
+            "uncached cute.compile() calls:\n" + "\n".join(bad),
+        )
+
+    def test_scan_flags_raw_cute_compile(self):
+        # Meta-test: prove the caching requirement fires, and that both the raw
+        # @jit_cache and the combined decorator satisfy it.
+        raw = "def f():\n    return cute.compile(k)\n"
+        raw_v, raw_n = _scan_for_raw_cute_compile(raw, "<raw>")
+        self.assertEqual(raw_n, 1, "scan didn't see the cute.compile call")
+        self.assertEqual(len(raw_v), 1, "raw cute.compile was NOT flagged")
+
+        module_level = "x = cute.compile(k)\n"
+        ml_v, ml_n = _scan_for_raw_cute_compile(module_level, "<module>")
+        self.assertEqual(ml_n, 1)
+        self.assertEqual(len(ml_v), 1, "module-level cute.compile was NOT flagged")
+
+        for form, deco in (
+            ("jit_cache", "@jit_cache"),
+            ("combined", "@instrumented_cutedsl_cache('aten::x')"),
+        ):
+            src = f"{deco}\ndef f():\n    return cute.compile(k)\n"
+            v, n = _scan_for_raw_cute_compile(src, f"<{form}>")
+            self.assertEqual(n, 1)
+            self.assertEqual(v, [], f"{form}-wrapped cute.compile was wrongly flagged")
 
 
 if __name__ == "__main__":

--- a/torch/_native/instrumentation.py
+++ b/torch/_native/instrumentation.py
@@ -1,0 +1,342 @@
+"""Structured compile/cache instrumentation for ``torch._native`` ops.
+
+Native DSL ops compile device kernels lazily on first call. Those compiles
+are the dominant first-call latency, and a silent cache miss is a common
+"why is this slow again?" question. This module surfaces both, with no
+runtime cost when neither ``TORCH_LOGS`` nor structured tracing is enabled.
+
+Two sinks, both fed by a single :class:`CompileEvent`:
+
+* The ``native_dsl`` logger (``TORCH_LOGS=+native_dsl``): a one-line
+  human-readable summary per compile -- outcome, wall time, and running
+  hit/miss totals.
+* ``trace_structured`` artifacts (tlparse): a JSON record per compile, for
+  production jobs where only the structured trace is retrievable.
+
+Two DSLs compile through different machinery, so there are two entry points.
+Both reduce to the same shared core (:func:`_make_wrapper`): snapshot the
+cache, time the call, snapshot again, and flag ``compiled`` when the miss
+counter advanced. They differ only in how a snapshot is sampled:
+
+* :func:`instrument_cutedsl_compile` -- for CuTeDSL, stacked *above* the
+  vendored ``quack`` ``@jit_cache`` decorator. It reads the cache wrapper's
+  ``cache_info()`` and times the wrapped ``cute.compile`` call::
+
+      @instrument_cutedsl_compile("aten::topk")
+      @jit_cache
+      def _compile_topk_radix(N, K, deterministic): ...
+
+  A ``cache_info().misses`` delta means the cache ran a real
+  ``cute.compile``, so the measured wall time *is* the compile time;
+  otherwise the key was served from the in-memory or on-disk ``.o`` cache.
+
+* :func:`instrument_triton_launch` -- for Triton ``@triton.jit`` kernels,
+  which compile *and* launch in one ``kernel[grid](...)`` call and keep
+  their own per-kernel cache (``JITFunction.device_caches``). The wrapper
+  watches that cache's running variant count, which plays the role of the
+  miss counter: a new entry means a fresh Triton compile fired this call.
+  Because compile and launch are fused, ``wall_ms`` on a miss is compile +
+  host-launch latency (compile dominates); on a hit it is just host-launch
+  latency.
+
+Both DSLs only expose miss-side signal directly (CuTeDSL's vendored cache
+reports aggregate counters; Triton's cache only grows), so finer reasons
+(disk-hit vs lock-timeout, Triton's on-disk cache) are not distinguished
+here -- the boolean ``compiled`` flag plus wall time covers the common case.
+
+Neither entry point touches the underlying DSL/vendored code, and neither
+hijacks Triton's process-global ``knobs.runtime`` hooks (those would also
+capture Inductor's unrelated Triton compiles).
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+import time
+import weakref
+from dataclasses import asdict, dataclass
+from typing import Any, TYPE_CHECKING, TypeVar
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+__all__ = [
+    "CompileEvent",
+    "instrument_cutedsl_compile",
+    "instrument_triton_launch",
+]
+
+log = logging.getLogger(__name__)
+
+# tlparse artifact name. The "artifact" envelope (see trace_structured_artifact)
+# is the well-supported transport; the name lets tlparse group these events.
+_ARTIFACT_NAME = "native_dsl_compile"
+
+R = TypeVar("R")
+
+
+@dataclass(frozen=True)
+class CompileEvent:
+    """One compile-function invocation, as recorded to logs and tlparse.
+
+    ``compiled`` is the ground truth (did the cache run a real compile);
+    ``outcome`` is its human-readable form. ``hits`` / ``misses`` are the
+    cache's running totals *after* this call, useful for spotting churn
+    (e.g. misses climbing across calls of the same shape => keys not
+    stable, or the persistent cache is disabled).
+    """
+
+    op: str
+    dsl: str
+    outcome: str
+    compiled: bool
+    wall_ms: float
+    key: str
+    hits: int
+    misses: int
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _emit(event: CompileEvent) -> None:
+    """Fan the event out to the native_dsl logger and tlparse.
+
+    Both sinks self-gate (logging on level, trace_structured on
+    ``trace_log.handlers``), so this is cheap when nothing is listening.
+    """
+    log.info(
+        "%s [%s] %s in %.1fms (key=%s, cache hits=%d misses=%d)",
+        event.op,
+        event.dsl,
+        event.outcome,
+        event.wall_ms,
+        event.key,
+        event.hits,
+        event.misses,
+    )
+
+    # Local import keeps `import torch._native` from pulling torch._logging's
+    # heavier transitive imports at registration time.
+    from torch._logging._internal import trace_structured
+
+    # Same "artifact" envelope as Dynamo's trace_structured_artifact(); we call
+    # trace_structured directly only to pass expect_trace_id=False, since that
+    # helper would capture an expensive stack on every eager event (no live
+    # CompileContext). trace_structured still reads the live trace id, so a
+    # native op compiling inside torch.compile is auto-tagged with the ambient
+    # frame ids and nests under that compile in tlparse.
+    trace_structured(
+        "artifact",
+        metadata_fn=lambda: {"name": _ARTIFACT_NAME, "encoding": "json"},
+        expect_trace_id=False,
+        payload_fn=lambda: _json_payload(event),
+    )
+
+
+def _json_payload(event: CompileEvent) -> str:
+    import json
+
+    return json.dumps(event.as_dict(), sort_keys=True)
+
+
+def _format_key(args: tuple, kwargs: dict, key_fn: Callable | None) -> str:
+    if key_fn is not None:
+        try:
+            return key_fn(*args, **kwargs)
+        except Exception:
+            pass
+    parts = [repr(a) for a in args]
+    parts += [f"{k}={v!r}" for k, v in sorted(kwargs.items())]
+    return "(" + ", ".join(parts) + ")"
+
+
+def _make_wrapper(
+    fn: Callable[..., R],
+    op: str,
+    dsl: str,
+    key_fn: Callable[..., str] | None,
+    sample: Callable[[], tuple[int | None, int | None]],
+) -> Callable[..., R]:
+    """Shared instrumentation core for both DSL entry points.
+
+    ``sample()`` returns a ``(hits, misses)`` snapshot of the relevant cache;
+    a ``misses`` increase across the call means a real compile fired. Timing,
+    error handling, classification, and emission are identical across DSLs --
+    only ``sample`` (and the reported ``dsl``) differ.
+    """
+
+    @functools.wraps(fn)
+    def wrapper(*args: Any, **kwargs: Any) -> R:
+        _, misses_before = sample()
+        start = time.perf_counter()
+        try:
+            result = fn(*args, **kwargs)
+            outcome_is_error = False
+        except Exception:
+            outcome_is_error = True
+            raise
+        finally:
+            wall_ms = (time.perf_counter() - start) * 1e3
+            hits_after, misses_after = sample()
+            compiled = (
+                not outcome_is_error
+                and misses_before is not None
+                and misses_after is not None
+                and misses_after > misses_before
+            )
+            if outcome_is_error:
+                outcome = "error"
+            else:
+                outcome = "compiled" if compiled else "cache_hit"
+            _emit(
+                CompileEvent(
+                    op=op,
+                    dsl=dsl,
+                    outcome=outcome,
+                    compiled=compiled,
+                    wall_ms=wall_ms,
+                    key=_format_key(args, kwargs, key_fn),
+                    hits=hits_after or 0,
+                    misses=misses_after or 0,
+                )
+            )
+        return result
+
+    return wrapper
+
+
+def _cache_info_sampler(fn: Any) -> Callable[[], tuple[int | None, int | None]]:
+    """Sampler reading ``(hits, misses)`` from a ``jit_cache`` wrapper.
+
+    Defensive: the wrapped callable may not be ``jit_cache``-decorated (e.g.
+    a plain function in tests). Then we report ``(None, None)`` and the core
+    still times the call, just without compile/hit classification.
+    """
+
+    def sample() -> tuple[int | None, int | None]:
+        info = getattr(fn, "cache_info", None)
+        if info is None:
+            return None, None
+        try:
+            ci = info()
+            return ci.hits, ci.misses
+        except Exception:
+            return None, None
+
+    return sample
+
+
+def instrument_cutedsl_compile(
+    op: str,
+    *,
+    key_fn: Callable[..., str] | None = None,
+) -> Callable[[Callable[..., R]], Callable[..., R]]:
+    """Instrument a CuTeDSL (``@jit_cache``-decorated) compile function.
+
+    Args:
+        op: Operator symbol being compiled for, e.g. ``"aten::topk"``.
+        key_fn: Optional callable with the wrapped function's signature
+            returning a short string describing the compile key for logs.
+            Defaults to a repr of the args/kwargs.
+
+    Returns a decorator. The decorated function behaves identically to the
+    original (same return value, same caching); it only adds a log line and
+    a tlparse artifact per call. Errors raised by the wrapped compile are
+    timed, reported with ``outcome="error"``, and re-raised unchanged.
+    """
+
+    def decorator(fn: Callable[..., R]) -> Callable[..., R]:
+        wrapper = _make_wrapper(fn, op, "cutedsl", key_fn, _cache_info_sampler(fn))
+        # Forward jit_cache's bespoke attributes (functools.wraps doesn't copy
+        # them) so the instrumented function stays a drop-in for callers that
+        # introspect the cache.
+        for attr in ("cache", "cache_clear", "cache_info"):
+            if hasattr(fn, attr):
+                setattr(wrapper, attr, getattr(fn, attr))
+        return wrapper
+
+    return decorator
+
+
+def _triton_cache_size(kernel: Any) -> int | None:
+    """Total compiled-variant count across a JITFunction's per-device caches.
+
+    Triton stores one entry per specialized variant in
+    ``JITFunction.device_caches[device]``, a ``(kernel_cache, ...)`` tuple
+    whose first element is the dict of compiled kernels. The count grows by
+    one each time a new (signature, constexpr, options) variant compiles, so
+    a delta across a launch tells us whether this call triggered a compile.
+    Returns None if the object doesn't expose ``device_caches`` (e.g. a
+    plain callable in tests, or a future Triton that renames this).
+    """
+    caches = getattr(kernel, "device_caches", None)
+    if caches is None:
+        return None
+    try:
+        return sum(len(per_device[0]) for per_device in caches.values())
+    except Exception:
+        return None
+
+
+def instrument_triton_launch(
+    op: str,
+    *,
+    key_fn: Callable[..., str] | None = None,
+) -> Callable[[Callable[..., R]], Callable[..., R]]:
+    """Instrument a function that launches a Triton kernel.
+
+    Unlike CuTeDSL, a Triton ``@triton.jit`` kernel compiles lazily *inside*
+    its ``kernel[grid](...)`` launch and caches variants on the kernel
+    object itself. So rather than wrapping a separate compile function, wrap
+    the op's launch helper and pass the ``@triton.jit`` kernel(s) whose cache
+    should be watched.
+
+    Args:
+        op: Operator symbol being compiled for, e.g. ``"aten::bmm"``.
+        key_fn: Optional callable with the wrapped launcher's signature
+            returning a short string describing the launch for logs.
+
+    The kernel(s) to watch are discovered lazily from the wrapped function's
+    module globals on first call (every ``@triton.jit`` object defined
+    there). This keeps the decorator import-light: no Triton import happens
+    at registration time, only on first launch.
+
+    Errors raised by the launch are timed, reported with ``outcome="error"``,
+    and re-raised unchanged.
+    """
+
+    def decorator(fn: Callable[..., R]) -> Callable[..., R]:
+        # Resolved once on first call and cached. weakref so we never keep a
+        # JITFunction alive past its module.
+        watched: list[weakref.ref] = []
+        resolved = False
+
+        def sample() -> tuple[int | None, int | None]:
+            # Triton has no hit counter; the total variant count across watched
+            # kernels stands in for `misses`, so a delta means a fresh compile.
+            nonlocal resolved
+            if not resolved:
+                resolved = True
+                module = __import__(fn.__module__, fromlist=["*"])
+                for value in vars(module).values():
+                    if _triton_cache_size(value) is not None:
+                        watched.append(weakref.ref(value))
+            total = 0
+            saw_any = False
+            for ref in watched:
+                kernel = ref()
+                if kernel is None:
+                    continue
+                size = _triton_cache_size(kernel)
+                if size is not None:
+                    saw_any = True
+                    total += size
+            return None, (total if saw_any else None)
+
+        return _make_wrapper(fn, op, "triton", key_fn, sample)
+
+    return decorator

--- a/torch/_native/instrumentation.py
+++ b/torch/_native/instrumentation.py
@@ -30,14 +30,15 @@ counter advanced. They differ only in how a snapshot is sampled:
   ``cute.compile``, so the measured wall time *is* the compile time;
   otherwise the key was served from the in-memory or on-disk ``.o`` cache.
 
-* :func:`instrument_triton_launch` -- for Triton ``@triton.jit`` kernels,
+* :func:`instrument_triton_kernel` -- for Triton ``@triton.jit`` kernels,
   which compile *and* launch in one ``kernel[grid](...)`` call and keep
-  their own per-kernel cache (``JITFunction.device_caches``). The wrapper
-  watches that cache's running variant count, which plays the role of the
-  miss counter: a new entry means a fresh Triton compile fired this call.
-  Because compile and launch are fused, ``wall_ms`` on a miss is compile +
-  host-launch latency (compile dominates); on a hit it is just host-launch
-  latency.
+  their own per-kernel cache (``JITFunction.device_caches``). Stacked above
+  ``@triton.jit``, it wraps the kernel in a transparent proxy that watches
+  *that one kernel's* variant count; a launch that grows it means a fresh
+  compile. Scoping to the single kernel gives clean per-kernel attribution --
+  two kernels in one module never collide. Because compile and launch are
+  fused, ``wall_ms`` on a miss is compile + host-launch latency (compile
+  dominates); on a hit it is just host-launch latency.
 
 Both DSLs only expose miss-side signal directly (CuTeDSL's vendored cache
 reports aggregate counters; Triton's cache only grows), so finer reasons
@@ -54,7 +55,6 @@ from __future__ import annotations
 import functools
 import logging
 import time
-import weakref
 from dataclasses import asdict, dataclass
 from typing import Any, TYPE_CHECKING, TypeVar
 
@@ -65,8 +65,11 @@ if TYPE_CHECKING:
 
 __all__ = [
     "CompileEvent",
+    "InstrumentedTritonKernel",
     "instrument_cutedsl_compile",
-    "instrument_triton_launch",
+    "instrument_triton_kernel",
+    "instrumented_cutedsl_cache",
+    "instrumented_triton_cache",
 ]
 
 log = logging.getLogger(__name__)
@@ -100,6 +103,23 @@ class CompileEvent:
 
     def as_dict(self) -> dict[str, Any]:
         return asdict(self)
+
+
+def _listening() -> bool:
+    """True if either sink would record an event.
+
+    Lets the wrapper skip all instrumentation work (cache sampling, timing,
+    key formatting, event construction) on the hot path when nothing is
+    listening -- important because the CuTeDSL wrapper sits on the compile
+    *cache* and so runs on every op call, cache hits included.
+
+    Mirrors the gates the sinks apply internally: the logger on its effective
+    level, and structured tracing on ``trace_log.handlers`` (the documented
+    "is tracing enabled" idiom, also used by ``trace_structured`` itself).
+    """
+    from torch._logging._internal import trace_log
+
+    return log.isEnabledFor(logging.INFO) or bool(trace_log.handlers)
 
 
 def _emit(event: CompileEvent) -> None:
@@ -171,6 +191,12 @@ def _make_wrapper(
 
     @functools.wraps(fn)
     def wrapper(*args: Any, **kwargs: Any) -> R:
+        # Fast path: do nothing extra unless a sink is listening. This runs on
+        # every call to the wrapped fn (for CuTeDSL, every op invocation), so
+        # the no-listener cost must stay at one predicate check.
+        if not _listening():
+            return fn(*args, **kwargs)
+
         _, misses_before = sample()
         start = time.perf_counter()
         try:
@@ -263,15 +289,15 @@ def instrument_cutedsl_compile(
 
 
 def _triton_cache_size(kernel: Any) -> int | None:
-    """Total compiled-variant count across a JITFunction's per-device caches.
+    """Compiled-variant count across one JITFunction's per-device caches.
 
     Triton stores one entry per specialized variant in
     ``JITFunction.device_caches[device]``, a ``(kernel_cache, ...)`` tuple
     whose first element is the dict of compiled kernels. The count grows by
     one each time a new (signature, constexpr, options) variant compiles, so
-    a delta across a launch tells us whether this call triggered a compile.
-    Returns None if the object doesn't expose ``device_caches`` (e.g. a
-    plain callable in tests, or a future Triton that renames this).
+    a delta across a launch tells us whether *this* kernel compiled. Returns
+    None if the object doesn't expose ``device_caches`` (a future Triton that
+    renames this, or a non-kernel in tests).
     """
     caches = getattr(kernel, "device_caches", None)
     if caches is None:
@@ -282,61 +308,139 @@ def _triton_cache_size(kernel: Any) -> int | None:
         return None
 
 
-def instrument_triton_launch(
+class InstrumentedTritonKernel:
+    """Transparent proxy over a single ``@triton.jit`` kernel.
+
+    Watches only this kernel's ``device_caches``, so a launch that grows the
+    variant count is unambiguously *this* kernel compiling -- two kernels in
+    one module never collide. All attribute access except the ``kernel[grid]``
+    launch path is delegated to the wrapped kernel, so the proxy is a drop-in
+    for the original ``JITFunction`` for attribute/method use (``.warmup``,
+    ``.cache_key``).
+
+    Composition with ``torch.library.wrap_triton``: that API does a strict
+    ``isinstance(JITFunction)`` check and would reject this proxy, but it
+    targets a different path (export/tracing, where the compile does not run
+    through our eager launch). When a native op needs ``wrap_triton``, pass the
+    raw kernel via :attr:`jit_kernel`: ``wrap_triton(my_kernel.jit_kernel)``.
+    """
+
+    def __init__(
+        self,
+        kernel: Any,
+        op: str,
+        key_fn: Callable[..., str] | None,
+    ) -> None:
+        self._kernel = kernel
+        self._op = op
+        self._key_fn = key_fn
+
+    @property
+    def jit_kernel(self) -> Any:
+        """The wrapped raw ``JITFunction`` (e.g. for ``wrap_triton``)."""
+        return self._kernel
+
+    def _sample(self) -> tuple[int | None, int | None]:
+        # Triton has no hit counter; this kernel's variant count stands in for
+        # `misses`, so a delta across the launch means a fresh compile.
+        return None, _triton_cache_size(self._kernel)
+
+    def __getitem__(self, grid: Any) -> Callable[..., Any]:
+        # kernel[grid](*args) is the launch path -- wrap the bound launcher in
+        # the shared core so the compile that may fire inside it is recorded.
+        launcher = self._kernel[grid]
+        return _make_wrapper(launcher, self._op, "triton", self._key_fn, self._sample)
+
+    def __getattr__(self, name: str) -> Any:
+        # Delegate everything else (warmup, cache_key, wrap_triton hooks, ...)
+        # to the real kernel. Only triggered for names not set on the proxy.
+        return getattr(self._kernel, name)
+
+
+def instrument_triton_kernel(
+    op: str,
+    *,
+    key_fn: Callable[..., str] | None = None,
+) -> Callable[[Any], InstrumentedTritonKernel]:
+    """Instrument a single ``@triton.jit`` kernel, stacked above the jit::
+
+        @instrument_triton_kernel("aten::bmm")
+        @triton.jit
+        def _bmm_kernel(...): ...
+
+    Unlike CuTeDSL, a Triton kernel compiles lazily *inside* its
+    ``kernel[grid](...)`` launch and caches variants on the kernel object. So
+    rather than wrap a separate compile fn, wrap the kernel itself: the proxy
+    watches that one kernel's variant count and records a compile when the
+    launch grows it. Because compile and launch are fused, ``wall_ms`` on a
+    miss is compile + host-launch latency (compile dominates); on a hit it is
+    just host-launch latency.
+
+    Args:
+        op: Operator symbol being compiled for, e.g. ``"aten::bmm"``.
+        key_fn: Optional callable with the kernel's launch-arg signature
+            returning a short string for logs (the constexprs it sees, e.g.
+            ``BLOCK``, are the actual compile key). Defaults to a repr.
+    """
+
+    def decorator(kernel: Any) -> InstrumentedTritonKernel:
+        return InstrumentedTritonKernel(kernel, op, key_fn)
+
+    return decorator
+
+
+# ---------------------------------------------------------------------------
+# Combined decorators: the recommended one-decorator surface for native ops.
+# They apply the DSL's own cache/jit *and* the instrumentation, so the op
+# author writes a single decorator on a bare function and can't get the
+# stacking order wrong. The lower-level instrument_* helpers above remain for
+# custom composition.
+# ---------------------------------------------------------------------------
+
+
+def instrumented_cutedsl_cache(
     op: str,
     *,
     key_fn: Callable[..., str] | None = None,
 ) -> Callable[[Callable[..., R]], Callable[..., R]]:
-    """Instrument a function that launches a Triton kernel.
+    """Cache + instrument a CuTeDSL compile function in one decorator::
 
-    Unlike CuTeDSL, a Triton ``@triton.jit`` kernel compiles lazily *inside*
-    its ``kernel[grid](...)`` launch and caches variants on the kernel
-    object itself. So rather than wrapping a separate compile function, wrap
-    the op's launch helper and pass the ``@triton.jit`` kernel(s) whose cache
-    should be watched.
+        @instrumented_cutedsl_cache("aten::topk")
+        def _compile_topk_radix(N, K, deterministic):
+            return cute.compile(...)
 
-    Args:
-        op: Operator symbol being compiled for, e.g. ``"aten::bmm"``.
-        key_fn: Optional callable with the wrapped launcher's signature
-            returning a short string describing the launch for logs.
-
-    The kernel(s) to watch are discovered lazily from the wrapped function's
-    module globals on first call (every ``@triton.jit`` object defined
-    there). This keeps the decorator import-light: no Triton import happens
-    at registration time, only on first launch.
-
-    Errors raised by the launch are timed, reported with ``outcome="error"``,
-    and re-raised unchanged.
+    Equivalent to ``instrument_cutedsl_compile(op) `` stacked above the
+    vendored ``@jit_cache``. ``jit_cache`` is imported lazily so plain
+    ``import torch._native`` doesn't pull in the CuTeDSL runtime.
     """
+    # Lazy import: quack.cache pulls in cutlass, absent on CPU-only builds.
+    from torch._vendor.quack.cache import jit_cache
 
     def decorator(fn: Callable[..., R]) -> Callable[..., R]:
-        # Resolved once on first call and cached. weakref so we never keep a
-        # JITFunction alive past its module.
-        watched: list[weakref.ref] = []
-        resolved = False
+        return instrument_cutedsl_compile(op, key_fn=key_fn)(jit_cache(fn))
 
-        def sample() -> tuple[int | None, int | None]:
-            # Triton has no hit counter; the total variant count across watched
-            # kernels stands in for `misses`, so a delta means a fresh compile.
-            nonlocal resolved
-            if not resolved:
-                resolved = True
-                module = __import__(fn.__module__, fromlist=["*"])
-                for value in vars(module).values():
-                    if _triton_cache_size(value) is not None:
-                        watched.append(weakref.ref(value))
-            total = 0
-            saw_any = False
-            for ref in watched:
-                kernel = ref()
-                if kernel is None:
-                    continue
-                size = _triton_cache_size(kernel)
-                if size is not None:
-                    saw_any = True
-                    total += size
-            return None, (total if saw_any else None)
+    return decorator
 
-        return _make_wrapper(fn, op, "triton", key_fn, sample)
+
+def instrumented_triton_cache(
+    op: str,
+    *,
+    key_fn: Callable[..., str] | None = None,
+) -> Callable[[Callable[..., R]], InstrumentedTritonKernel]:
+    """JIT + instrument a Triton kernel in one decorator::
+
+        @instrumented_triton_cache("aten::bmm")
+        def _bmm_kernel(...):  # bare kernel body, no @triton.jit
+            ...
+
+    Equivalent to ``instrument_triton_kernel(op)`` stacked above
+    ``@triton.jit``. ``triton`` is imported lazily so plain
+    ``import torch._native`` doesn't pull in the Triton runtime.
+    """
+    # Lazy import: keep Triton out of `import torch._native`.
+    import triton
+
+    def decorator(fn: Callable[..., R]) -> InstrumentedTritonKernel:
+        return instrument_triton_kernel(op, key_fn=key_fn)(triton.jit(fn))
 
     return decorator

--- a/torch/_native/ops/bmm_outer_product/triton_kernels.py
+++ b/torch/_native/ops/bmm_outer_product/triton_kernels.py
@@ -2,6 +2,7 @@ import triton
 import triton.language as tl
 
 import torch
+from torch._native.instrumentation import instrument_triton_launch
 
 
 @triton.jit
@@ -65,6 +66,11 @@ def _pick_block_sizes(m: int, n: int) -> tuple[int, int]:
     return block_m, min(triton.next_power_of_2(n), 128)
 
 
+def _bmm_log_key(a: torch.Tensor, b: torch.Tensor) -> str:
+    return f"bmm_outer B={a.shape[0]} M={a.shape[1]} N={b.shape[2]} {a.dtype}"
+
+
+@instrument_triton_launch("aten::bmm", key_fn=_bmm_log_key)
 def bmm_outer_product(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
     B, M, _ = a.shape
     N = b.shape[2]

--- a/torch/_native/ops/bmm_outer_product/triton_kernels.py
+++ b/torch/_native/ops/bmm_outer_product/triton_kernels.py
@@ -2,10 +2,16 @@ import triton
 import triton.language as tl
 
 import torch
-from torch._native.instrumentation import instrument_triton_launch
+from torch._native.instrumentation import instrumented_triton_cache
 
 
-@triton.jit
+def _bmm_log_key(a, b, out, B, M, N, *strides, BLOCK_M, BLOCK_N) -> str:
+    # Receives the kernel's launch args; BLOCK_M/BLOCK_N are the constexprs
+    # that (with shapes/dtype) form the Triton compile key.
+    return f"bmm_outer B={B} M={M} N={N} {a.dtype} BLOCK_M={BLOCK_M} BLOCK_N={BLOCK_N}"
+
+
+@instrumented_triton_cache("aten::bmm", key_fn=_bmm_log_key)
 def _bmm_outer_product_kernel(
     A_ptr,
     B_ptr,
@@ -66,11 +72,6 @@ def _pick_block_sizes(m: int, n: int) -> tuple[int, int]:
     return block_m, min(triton.next_power_of_2(n), 128)
 
 
-def _bmm_log_key(a: torch.Tensor, b: torch.Tensor) -> str:
-    return f"bmm_outer B={a.shape[0]} M={a.shape[1]} N={b.shape[2]} {a.dtype}"
-
-
-@instrument_triton_launch("aten::bmm", key_fn=_bmm_log_key)
 def bmm_outer_product(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
     B, M, _ = a.shape
     N = b.shape[2]

--- a/torch/_native/ops/norm/norms.py
+++ b/torch/_native/ops/norm/norms.py
@@ -7,9 +7,35 @@ to avoid dispatcher overhead).
 
 from __future__ import annotations
 
+import functools
 import math
 
 import torch
+from torch._native.instrumentation import instrument_cutedsl_compile
+
+
+# quack's rmsnorm compile fns are vendored, so we can't decorate them in
+# place. Wrap them once at the call site instead -- they're @jit_cache so
+# the instrumentation reads their cache_info(). Memoized so the wrapper (and
+# its forwarded cache_info) is stable across calls. N is positional arg 6 in
+# the fwd compile signature and arg 0 in the bwd one.
+@functools.cache
+def _instrumented_rmsnorm_fwd():
+    from torch._vendor.quack.rmsnorm import _compile_rmsnorm_fwd
+
+    return instrument_cutedsl_compile(
+        "aten::_fused_rms_norm", key_fn=lambda *a, **k: f"fwd N={a[6]}"
+    )(_compile_rmsnorm_fwd)
+
+
+@functools.cache
+def _instrumented_rmsnorm_bwd():
+    from torch._vendor.quack.rmsnorm import _compile_rmsnorm_bwd
+
+    return instrument_cutedsl_compile(
+        "aten::_fused_rms_norm_backward",
+        key_fn=lambda *a, **k: f"bwd N={a[0]}",
+    )(_compile_rmsnorm_bwd)
 
 
 # quack imports `cutlass`, which is only installed on CUDA-enabled x86 Linux
@@ -87,9 +113,7 @@ def quack_rmsnorm_fwd(
     out_dtype = _torch2cute(out)
     weight_dtype = _torch2cute(weight)
 
-    from torch._vendor.quack.rmsnorm import _compile_rmsnorm_fwd
-
-    kernel = _compile_rmsnorm_fwd(
+    kernel = _instrumented_rmsnorm_fwd()(
         dtype,
         out_dtype,
         None,
@@ -128,7 +152,6 @@ def quack_rmsnorm_bwd(
     rstd_flat = _flatten_rstd(rstd, M)
 
     dx = torch.empty_like(x)
-    from torch._vendor.quack.rmsnorm import _compile_rmsnorm_bwd
     from torch._vendor.quack.rmsnorm_config import get_sm_count
 
     sm_count = get_sm_count(N, x.device)
@@ -150,7 +173,7 @@ def quack_rmsnorm_bwd(
     dx_dtype = _torch2cute(dx)
     weight_dtype = _torch2cute(weight)
 
-    kernel = _compile_rmsnorm_bwd(
+    kernel = _instrumented_rmsnorm_bwd()(
         N,
         dtype,
         dout_dtype,

--- a/torch/_native/ops/scatter_add/tma_kernel.py
+++ b/torch/_native/ops/scatter_add/tma_kernel.py
@@ -59,6 +59,7 @@ import cutlass.pipeline as pipeline
 from cutlass import BFloat16, const_expr, Float16, Float32, Int32, Int64
 
 import torch
+from torch._native.instrumentation import instrument_cutedsl_compile
 from torch._vendor.quack.cache import jit_cache
 
 from ._ptx import cvta_smem, make_bulk_reduce_add
@@ -341,6 +342,10 @@ def _chunk_elems_for(torch_dtype: torch.dtype, N: int) -> int:
     return chunk_bytes // elem_bytes
 
 
+@instrument_cutedsl_compile(
+    "aten::scatter_add",
+    key_fn=lambda torch_dtype, N, contig: f"tma {torch_dtype} N={N} contig={contig}",
+)
 @jit_cache
 def _compile_tma_scatter(torch_dtype: torch.dtype, N: int, contig: bool):
     dtype = _TORCH_TO_CUTE[torch_dtype]

--- a/torch/_native/ops/scatter_add/tma_kernel.py
+++ b/torch/_native/ops/scatter_add/tma_kernel.py
@@ -59,8 +59,7 @@ import cutlass.pipeline as pipeline
 from cutlass import BFloat16, const_expr, Float16, Float32, Int32, Int64
 
 import torch
-from torch._native.instrumentation import instrument_cutedsl_compile
-from torch._vendor.quack.cache import jit_cache
+from torch._native.instrumentation import instrumented_cutedsl_cache
 
 from ._ptx import cvta_smem, make_bulk_reduce_add
 
@@ -342,11 +341,10 @@ def _chunk_elems_for(torch_dtype: torch.dtype, N: int) -> int:
     return chunk_bytes // elem_bytes
 
 
-@instrument_cutedsl_compile(
+@instrumented_cutedsl_cache(
     "aten::scatter_add",
     key_fn=lambda torch_dtype, N, contig: f"tma {torch_dtype} N={N} contig={contig}",
 )
-@jit_cache
 def _compile_tma_scatter(torch_dtype: torch.dtype, N: int, contig: bool):
     dtype = _TORCH_TO_CUTE[torch_dtype]
     elem_bytes = dtype.width // 8

--- a/torch/_native/ops/scatter_add/vec_scatter_kernel.py
+++ b/torch/_native/ops/scatter_add/vec_scatter_kernel.py
@@ -24,6 +24,7 @@ from cutlass._mlir.dialects import llvm, vector as mlir_vector
 from cutlass.cutlass_dsl import dsl_user_op, T
 
 import torch
+from torch._native.instrumentation import instrument_cutedsl_compile
 from torch._vendor.quack.cache import jit_cache
 
 from ._ptx import make_packed_half_atomic_add
@@ -190,6 +191,10 @@ def _make_kernel(dtype, elem_bytes: int, vec_elems: int, contig: bool):
     return _launch
 
 
+@instrument_cutedsl_compile(
+    "aten::scatter_add",
+    key_fn=lambda torch_dtype, N, contig: f"vec {torch_dtype} N={N} contig={contig}",
+)
 @jit_cache
 def _compile_vec_scatter(torch_dtype: torch.dtype, N: int, contig: bool):
     dtype = _TORCH_TO_CUTE[torch_dtype]

--- a/torch/_native/ops/scatter_add/vec_scatter_kernel.py
+++ b/torch/_native/ops/scatter_add/vec_scatter_kernel.py
@@ -24,8 +24,7 @@ from cutlass._mlir.dialects import llvm, vector as mlir_vector
 from cutlass.cutlass_dsl import dsl_user_op, T
 
 import torch
-from torch._native.instrumentation import instrument_cutedsl_compile
-from torch._vendor.quack.cache import jit_cache
+from torch._native.instrumentation import instrumented_cutedsl_cache
 
 from ._ptx import make_packed_half_atomic_add
 
@@ -191,11 +190,10 @@ def _make_kernel(dtype, elem_bytes: int, vec_elems: int, contig: bool):
     return _launch
 
 
-@instrument_cutedsl_compile(
+@instrumented_cutedsl_cache(
     "aten::scatter_add",
     key_fn=lambda torch_dtype, N, contig: f"vec {torch_dtype} N={N} contig={contig}",
 )
-@jit_cache
 def _compile_vec_scatter(torch_dtype: torch.dtype, N: int, contig: bool):
     dtype = _TORCH_TO_CUTE[torch_dtype]
     elem_bytes = dtype.width // 8

--- a/torch/_native/ops/topk/cutedsl_kernels.py
+++ b/torch/_native/ops/topk/cutedsl_kernels.py
@@ -45,6 +45,7 @@ from cutlass._mlir.dialects import llvm
 from cutlass.cutlass_dsl import dsl_user_op, T
 
 import torch
+from torch._native.instrumentation import instrument_cutedsl_compile
 from torch._vendor.quack.cache import jit_cache
 
 
@@ -625,6 +626,10 @@ def _make_fake_tensor(dtype, shape, divisibility=1):
     )
 
 
+@instrument_cutedsl_compile(
+    "aten::topk",
+    key_fn=lambda N, K, deterministic: f"radix N={N} K={K} det={deterministic}",
+)
 @jit_cache
 def _compile_topk_radix(N: int, K: int, deterministic: bool):
     batch_sym = cute.sym_int()
@@ -839,6 +844,7 @@ class _RegisterTopK:
                 mIndices[row, i] = idx
 
 
+@instrument_cutedsl_compile("aten::topk", key_fn=lambda N, K: f"register N={N} K={K}")
 @jit_cache
 def _compile_topk_register(N: int, K: int):
     batch_sym = cute.sym_int()

--- a/torch/_native/ops/topk/cutedsl_kernels.py
+++ b/torch/_native/ops/topk/cutedsl_kernels.py
@@ -45,8 +45,7 @@ from cutlass._mlir.dialects import llvm
 from cutlass.cutlass_dsl import dsl_user_op, T
 
 import torch
-from torch._native.instrumentation import instrument_cutedsl_compile
-from torch._vendor.quack.cache import jit_cache
+from torch._native.instrumentation import instrumented_cutedsl_cache
 
 
 _NEG_INF_BITS: int = 0xFF800000
@@ -626,11 +625,10 @@ def _make_fake_tensor(dtype, shape, divisibility=1):
     )
 
 
-@instrument_cutedsl_compile(
+@instrumented_cutedsl_cache(
     "aten::topk",
     key_fn=lambda N, K, deterministic: f"radix N={N} K={K} det={deterministic}",
 )
-@jit_cache
 def _compile_topk_radix(N: int, K: int, deterministic: bool):
     batch_sym = cute.sym_int()
     div_n = math.gcd(4, N)
@@ -844,8 +842,7 @@ class _RegisterTopK:
                 mIndices[row, i] = idx
 
 
-@instrument_cutedsl_compile("aten::topk", key_fn=lambda N, K: f"register N={N} K={K}")
-@jit_cache
+@instrumented_cutedsl_cache("aten::topk", key_fn=lambda N, K: f"register N={N} K={K}")
 def _compile_topk_register(N: int, K: int):
     batch_sym = cute.sym_int()
     div_n = math.gcd(4, N)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #188186

Adds an instrumentation layer that surfaces on a per compile basis, the
outcome (compiled / cache_hit / error), the wall time, and running cache
hit/miss totals. Each event goes to both the native_dsl logger
(TORCH_LOGS=+native_dsl) and a structured record for tlparse.

Test Plan:

Unit tests - The tlparse case requires the `tlparse` binary and is skipped otherwise:

```
  python test/python_native/test_instrumentation.py
```

End-to-end, confirming each site emits with the correct DSL tag,
compile time, and cache classification, and that the artifact is written to
and parsed from a real structured trace:

```
  TORCH_LOGS=+native_dsl python -c "import torch; torch.topk(torch.randn(8192,4096,device='cuda'), 64)"
  TORCH_TRACE=/tmp/nd_trace python -c "import torch; torch.topk(torch.randn(8192,4096,device='cuda'), 64)"
  tlparse --strict /tmp/nd_trace/dedicated_log_torch_trace_*.log
```

This PR was authored with the assistance of an AI coding assistant.