### PR TITLE
[release/2.13] Revert "dynamo: round-trip torch.cuda.stream ctx mgr across graph breaks (#184487)"

### DIFF
--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -3,7 +3,6 @@ import gc
 import re
 import unittest
 import weakref
-from typing import Any
 from unittest.mock import patch
 
 import torch
@@ -182,6 +181,7 @@ class <lambda>(torch.nn.Module):
         )
 
     @requires_cuda
+    @unittest.skip("Needs graph break support with annotation context")
     def test_stream_context_graph_break(self):
         def fn(x, y):
             s2 = torch.Stream()
@@ -206,85 +206,8 @@ class <lambda>(torch.nn.Module):
         ) = extract_graph(fn, *inp)
         self.assertEqual(expected, actual)
         self.assertEqual(len(fw_graphs), 2)
-        self.assertExpectedInline(
-            print_graph(fw_graphs[0]),
-            """\
-class <lambda>(torch.nn.Module):
-    def forward(self, arg0_1: "f32[2, 2]", arg1_1: "f32[2, 2]"):
-        # Annotation: {'stream': 2}
-        add: "f32[2, 2]" = torch.ops.aten.add.Tensor(arg0_1, arg1_1)
-
-        # Annotation: {'stream': 1}
-        add_1: "f32[2, 2]" = torch.ops.aten.add.Tensor(arg0_1, arg1_1);  arg0_1 = arg1_1 = None
-
-        # Annotation: {'stream': 1}
-        add_2: "f32[2, 2]" = torch.ops.aten.add.Tensor(add_1, 2);  add_1 = None
-        add_3: "f32[2, 2]" = torch.ops.aten.add.Tensor(add_2, add);  add_2 = add = None
-        return (add_3,)
-""",
-        )
-        self.assertExpectedInline(
-            print_graph(fw_graphs[1]),
-            """\
-class <lambda>(torch.nn.Module):
-    def forward(self, arg0_1: "f32[2, 2]"):
-        # Annotation: {'stream': 1}
-        add: "f32[2, 2]" = torch.ops.aten.add.Tensor(arg0_1, 1);  arg0_1 = None
-        return (add,)
-""",
-        )
-
-    @requires_cuda
-    def test_target_values_dict_round_trips_through_graph_break(self):
-        # Regression test for a dict-vs-tuple issue interpreting
-        # `target_values`. This was initially a tuple and got repurposed as a
-        # dict, but some oft-unexecuted paths still assumed it was a tuple.
-        # Here we ensure that an in-use stream gets properly reconstructed on
-        # the other side of a graph break.
-        def fn(x):
-            s = torch.cuda.Stream()
-            with torch.cuda.stream(s):
-                z = x + 1
-                torch._dynamo.graph_break()
-                z = z + 2
-            return z
-
-        inp = (torch.ones(2, 2, device="cuda"),)
-        expected = fn(*inp)
-        actual, _, fw_graphs, _ = extract_graph(fn, *inp)
-        self.assertEqual(expected, actual)
-        # A graceful graph break inside with torch.cuda.stream(s):
-        # should split into two graph fragments.  Without the fix the
-        # post-break code is dropped and only the pre-break fragment is
-        # captured (or the whole frame falls back to eager and zero are
-        # captured).
-        self.assertEqual(
-            len(fw_graphs),
-            2,
-            f"expected 2 graph fragments after a graceful graph break "
-            f"inside 'with torch.cuda.stream(s):', got {len(fw_graphs)} "
-            f"-- the post-break body was likely dropped",
-        )
-
-        # Both halves of the round-trip should carry a stream annotation
-        # referring to the one and only stream `s` entered via
-        # `with torch.cuda.stream(s):`.  We do not pin the exact index, only
-        # that both adds are annotated with the same stream (i.e. `s`).
-        def add_node_stream(gm) -> int:
-            adds: list[torch.fx.Node] = [
-                n
-                for n in gm.graph.nodes
-                if n.op == "call_function" and n.target is torch.ops.aten.add.Tensor
-            ]
-            self.assertEqual(len(adds), 1)
-            custom: dict[str, Any] = adds[0].meta.get("custom", {})
-            self.assertIn("stream", custom)
-            return custom["stream"]
-
-        pre_break_stream = add_node_stream(fw_graphs[0])
-        post_break_stream = add_node_stream(fw_graphs[1])
-        # The same stream `s` annotates the add on both sides of the break.
-        self.assertEqual(pre_break_stream, post_break_stream)
+        self.assertExpectedInline(print_graph(fw_graphs[0]), """""")
+        self.assertExpectedInline(print_graph(fw_graphs[1]), """""")
 
     @requires_cuda
     def test_stream_input(self):

--- a/torch/_dynamo/variables/streams.py
+++ b/torch/_dynamo/variables/streams.py
@@ -1,6 +1,4 @@
 import collections
-import contextlib
-import functools
 from collections.abc import Callable
 from typing import Any, Optional
 
@@ -22,7 +20,7 @@ from ..graph_bytecode_inputs import (
 from ..source import CurrentStreamSource
 from .base import VariableTracker
 from .constant import ConstantVariable
-from .ctx_manager import ContextWrappingVariable
+from .ctx_manager import FxTracebackAnnotateVariable
 from .lazy import LazyVariableTracker
 
 
@@ -321,7 +319,7 @@ class SymbolicStreamState:
         return id(stream.value)
 
 
-class StreamContextVariable(ContextWrappingVariable):
+class StreamContextVariable(FxTracebackAnnotateVariable):
     """This represents torch.cuda.StreamContext"""
 
     @staticmethod
@@ -338,7 +336,7 @@ class StreamContextVariable(ContextWrappingVariable):
     def __init__(self, stream: Optional["StreamVariable"], **kwargs: Any) -> None:
         self.stream = stream
         super().__init__(
-            target_values=(),
+            target_values={"stream": self.get_stream().user_object_index},
             initial_values=None,
             **kwargs,
         )
@@ -346,22 +344,10 @@ class StreamContextVariable(ContextWrappingVariable):
     def enter(
         self, tx: "InstructionTranslatorBase", *args: VariableTracker
     ) -> VariableTracker:
-        strm: StreamVariable = self.get_stream()
         # to stream, from stream is the order of the arguments
         # we are entering the target, and leaving the initial stream
-        tx.symbolic_stream_state.enter_stream(strm)
-
-        # annotate + preserve_node_meta: this ensures the captured
-        # nodes have appropriate node.meta["custom"]["stream"] annotations.
-        if strm.user_object_index is None:
-            raise AssertionError("stream not registered")
-        stream_idx: int = strm.user_object_index
-        annotation: dict[str, Any] = {"stream": stream_idx}
-        stack = contextlib.ExitStack()
-        stack.enter_context(torch.fx.traceback.annotate(annotation))
-        stack.enter_context(torch.fx.traceback.preserve_node_meta())
-        self.set_cleanup_hook(tx, lambda: stack.close())
-        return ConstantVariable.create(None)
+        tx.symbolic_stream_state.enter_stream(self.get_stream())
+        return super().enter(tx)
 
     def exit(
         self, tx: "InstructionTranslatorBase", *args: VariableTracker
@@ -376,36 +362,6 @@ class StreamContextVariable(ContextWrappingVariable):
 
     def supports_graph_breaks(self) -> bool:
         return True
-
-    def reconstruct_type(self, codegen: "PyCodegen") -> None:
-        # Override our parent's reconstruct_type, as that implementation tries
-        # to access "torch._C.fn_name()" which does not exist. Unfortunately we
-        # cannot just directly reference the stream in the generated code.
-        #
-        # Instead, we push a 0-arg callable that returns the ctx mgr value
-        # at runtime.  The partial is installed as a global on the compiled
-        # function so the resume prologue can LOAD_GLOBAL it.
-
-        # self.stream is None when we're really a StreamVariable
-        # entering itself as a ctx mgr (with foo: where foo is a
-        # bare Stream), in which case self IS the stream and
-        # self.value holds it.  Otherwise we're a true
-        # StreamContextVariable wrapping someone else's StreamVariable
-        # and the value lives on the wrapped stream.
-        if self.stream is not None:
-            stream_value = self.stream.value
-        else:
-            stream_value = getattr(self, "value", None)
-        if stream_value is None:
-            raise AssertionError(
-                "StreamContextVariable.reconstruct_type called without a "
-                "stream value to rebuild; this should be impossible for "
-                "a properly-constructed ctx manager."
-            )
-
-        thunk = functools.partial(torch.cuda.stream, stream_value)
-        name = codegen.tx.output.install_global_by_id("_stream_ctx_thunk", thunk)
-        codegen.append_output(codegen.create_load_global(name, add=True))
 
     def get_stream(self) -> "StreamVariable":
         if not self.stream:


### PR DESCRIPTION
Cherry-pick of the revert of #184487 onto `release/2.13`.

The original commit (`b0a67c7495bb11ecb23e556058db059ba48354af`, "dynamo: round-trip torch.cuda.stream ctx mgr across graph breaks (#184487)") is present in the v2.13.0 release candidates but was reverted on `main` in commit `697514a9a58fab57644c60118cff15ae5cf4749b`:

> Reverted https://github.com/pytorch/pytorch/pull/184487 on behalf of williamwen42 due to **Breaks internal builds**

This brings the revert to the release branch so the RC does not ship the reverted change. Detected by the test-infra `github_analyze.py --analyze-missing-reverts-from-branch` (reverts on main not present in release/2.13). Cherry-pick applied cleanly (2 files, +8/-129).


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98