### PR TITLE
[HOP] Adding input mutation support for switch (1/2)

### DIFF
--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -11432,6 +11432,94 @@ class TestHopSchema(TestCase):
             """cond(SymBool pred, Any true_fn, Any false_fn, Tensor operand0) -> ((Tensor))""",
         )
 
+    def test_switch_gen_schema_tensor_inputs(self):
+        schema = torch.ops.higher_order.switch.gen_schema(
+            torch.tensor(0),
+            (lambda x: x.sin(), lambda x: x.cos(), lambda x: x.tan()),
+            (torch.randn(3, 4),),
+        )
+        self.assertExpectedInline(
+            str(schema),
+            """switch(Tensor index, Any branch0_fn, Any branch1_fn, Any branch2_fn, Tensor operand0) -> ((Tensor))""",
+        )
+
+    def test_switch_gen_schema_symint_inputs(self):
+        from torch._subclasses.fake_tensor import FakeTensorMode
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        fake_mode = FakeTensorMode(shape_env=ShapeEnv())
+        with fake_mode, fake_mode.shape_env.ignore_fresh_unbacked_symbols():
+            sym_int = torch.randn(3, 4).nonzero().size(0)
+
+        schema = torch.ops.higher_order.switch.gen_schema(
+            sym_int,
+            (lambda x: x.sin(), lambda x: x.cos()),
+            (torch.randn(3, 4),),
+        )
+        self.assertExpectedInline(
+            str(schema),
+            """switch(SymInt index, Any branch0_fn, Any branch1_fn, Tensor operand0) -> ((Tensor))""",
+        )
+
+    def test_switch_gen_schema_multiple_operands(self):
+        schema = torch.ops.higher_order.switch.gen_schema(
+            torch.tensor(1),
+            (lambda x, y: (x + y, x * y), lambda x, y: (x - y, x / y)),
+            (torch.randn(3, 4), torch.randn(3, 4)),
+        )
+        self.assertExpectedInline(
+            str(schema),
+            """switch(Tensor index, Any branch0_fn, Any branch1_fn, Tensor operand0, Tensor operand1) -> (Tensor, Tensor)""",
+        )
+
+    def test_switch_gen_schema_with_input_mutation(self):
+        def branch0(x, y):
+            x.add_(1)
+            return x + y
+
+        def branch1(x, y):
+            return x - y
+
+        schema = torch.ops.higher_order.switch.gen_schema(
+            torch.tensor(0),
+            (branch0, branch1),
+            (torch.randn(3, 4), torch.randn(3, 4)),
+        )
+        self.assertExpectedInline(
+            str(schema),
+            """switch(Tensor index, Any branch0_fn, Any branch1_fn, Tensor(a3!) operand0, Tensor operand1) -> ((Tensor))""",
+        )
+
+    def test_switch_gen_schema_with_disjoint_branch_mutation(self):
+        def branch0(x, y):
+            x.add_(1)
+            return x + y
+
+        def branch1(x, y):
+            y.sub_(1)
+            return x - y
+
+        schema = torch.ops.higher_order.switch.gen_schema(
+            torch.tensor(0),
+            (branch0, branch1),
+            (torch.randn(3, 4), torch.randn(3, 4)),
+        )
+        self.assertExpectedInline(
+            str(schema),
+            """switch(Tensor index, Any branch0_fn, Any branch1_fn, Tensor(a3!) operand0, Tensor(a4!) operand1) -> ((Tensor))""",
+        )
+
+    def test_switch_gen_schema_int_index(self):
+        schema = torch.ops.higher_order.switch.gen_schema(
+            0,
+            (lambda x: x.sin(), lambda x: x.cos()),
+            (torch.randn(3, 4),),
+        )
+        self.assertExpectedInline(
+            str(schema),
+            """switch(int index, Any branch0_fn, Any branch1_fn, Tensor operand0) -> ((Tensor))""",
+        )
+
     def test_while_loop_gen_schema_tensor_inputs(self):
         def cond_fn(x, y):
             return x.sum() < 10

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -11520,6 +11520,43 @@ class TestHopSchema(TestCase):
             """switch(int index, Any branch0_fn, Any branch1_fn, Tensor operand0) -> ((Tensor))""",
         )
 
+    def test_switch_gen_schema_differing_int_symint_outputs(self):
+        def branch0(x):
+            return x.sin(), 5
+
+        def branch1(x):
+            return x.cos(), 7
+
+        def branch2(x):
+            return x.tan(), 9
+
+        schema = torch.ops.higher_order.switch.gen_schema(
+            torch.tensor(0),
+            (branch0, branch1, branch2),
+            (torch.randn(3, 4),),
+        )
+        self.assertExpectedInline(
+            str(schema),
+            """switch(Tensor index, Any branch0_fn, Any branch1_fn, Any branch2_fn, Tensor operand0) -> (Tensor, SymInt)""",
+        )
+
+    def test_switch_gen_schema_matching_int_int_outputs(self):
+        def branch0(x):
+            return x.sin(), 5
+
+        def branch1(x):
+            return x.cos(), 5
+
+        schema = torch.ops.higher_order.switch.gen_schema(
+            torch.tensor(0),
+            (branch0, branch1),
+            (torch.randn(3, 4),),
+        )
+        self.assertExpectedInline(
+            str(schema),
+            """switch(Tensor index, Any branch0_fn, Any branch1_fn, Tensor operand0) -> (Tensor, int)""",
+        )
+
     def test_while_loop_gen_schema_tensor_inputs(self):
         def cond_fn(x, y):
             return x.sum() < 10

--- a/torch/_higher_order_ops/switch.py
+++ b/torch/_higher_order_ops/switch.py
@@ -12,6 +12,7 @@ from torch._functorch.utils import exposed_in
 from torch._higher_order_ops.utils import (
     _maybe_compile_and_run_fn,
     _maybe_run_with_interpreter,
+    check_input_alias_and_mutation_return_outputs,
     reenter_make_fx,
     unique_graph_id,
     validate_subgraph_args_types,
@@ -33,6 +34,44 @@ class SwitchOp(HigherOrderOperator):
         validate_subgraph_args_types(operands)
         # pyrefly: ignore [missing-attribute]
         return super().__call__(index, branches, operands)
+
+    # pyrefly: ignore [bad-override]
+    def gen_schema(self, index, branches, operands):
+        from torch._higher_order_ops.schema import HopSchemaGenerator
+        from torch._higher_order_ops.utils import materialize_as_graph
+
+        branch_gms: list[torch.fx.GraphModule] = [
+            branch
+            if isinstance(branch, torch.fx.GraphModule)
+            else materialize_as_graph(branch, operands)
+            for branch in branches
+        ]
+
+        mutated_inputs: set[int] = set()
+        first_branch_outputs: tuple[Any, ...] | list[Any] = ()
+        for i, gm in enumerate(branch_gms):
+            (
+                _,
+                _,
+                _,
+                branch_mutated_inputs,
+                branch_outputs,
+            ) = check_input_alias_and_mutation_return_outputs(gm)
+            mutated_inputs |= set(branch_mutated_inputs)
+            if i == 0:
+                first_branch_outputs = branch_outputs
+
+        schema_gen = HopSchemaGenerator(self)
+        schema_gen.add_arg("index", index)
+        for i, gm in enumerate(branch_gms):
+            schema_gen.add_arg(f"branch{i}_fn", gm)
+        for idx, arg in enumerate(operands):
+            schema_gen.add_arg(f"operand{idx}", arg, is_mutated=idx in mutated_inputs)
+
+        for out in first_branch_outputs:
+            schema_gen.add_output(out)
+        schema_gen.add_schema_tree_spec(index, branches, operands)
+        return schema_gen.gen_schema()
 
 
 switch_op = SwitchOp()

--- a/torch/_higher_order_ops/switch.py
+++ b/torch/_higher_order_ops/switch.py
@@ -37,19 +37,19 @@ class SwitchOp(HigherOrderOperator):
 
     # pyrefly: ignore [bad-override]
     def gen_schema(self, index, branches, operands):
+        from torch._guards import detect_fake_mode
         from torch._higher_order_ops.schema import HopSchemaGenerator
         from torch._higher_order_ops.utils import materialize_as_graph
 
-        branch_gms: list[torch.fx.GraphModule] = [
-            branch
-            if isinstance(branch, torch.fx.GraphModule)
-            else materialize_as_graph(branch, operands)
-            for branch in branches
-        ]
-
+        branch_gms: list[torch.fx.GraphModule] = []
+        all_branch_outputs: list[tuple[Any, ...] | list[Any]] = []
         mutated_inputs: set[int] = set()
-        first_branch_outputs: tuple[Any, ...] | list[Any] = ()
-        for i, gm in enumerate(branch_gms):
+        for branch in branches:
+            gm = (
+                branch
+                if isinstance(branch, torch.fx.GraphModule)
+                else materialize_as_graph(branch, operands)
+            )
             (
                 _,
                 _,
@@ -57,9 +57,22 @@ class SwitchOp(HigherOrderOperator):
                 branch_mutated_inputs,
                 branch_outputs,
             ) = check_input_alias_and_mutation_return_outputs(gm)
+            branch_gms.append(gm)
+            all_branch_outputs.append(branch_outputs)
             mutated_inputs |= set(branch_mutated_inputs)
-            if i == 0:
-                first_branch_outputs = branch_outputs
+
+        # Merge outputs to detect int -> SymInt change
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        fake_mode = detect_fake_mode(operands)
+        if fake_mode is None or fake_mode.shape_env is None:
+            fake_mode = FakeTensorMode(shape_env=ShapeEnv())
+        # pyrefly: ignore [missing-attribute]
+        with fake_mode, fake_mode.shape_env.ignore_fresh_unbacked_symbols():
+            merged_outputs = [
+                _merge_output(branch_outs, fake_mode)
+                for branch_outs in zip(*all_branch_outputs)
+            ]
 
         schema_gen = HopSchemaGenerator(self)
         schema_gen.add_arg("index", index)
@@ -68,7 +81,7 @@ class SwitchOp(HigherOrderOperator):
         for idx, arg in enumerate(operands):
             schema_gen.add_arg(f"operand{idx}", arg, is_mutated=idx in mutated_inputs)
 
-        for out in first_branch_outputs:
+        for out in merged_outputs:
             schema_gen.add_output(out)
         schema_gen.add_schema_tree_spec(index, branches, operands)
         return schema_gen.gen_schema()


### PR DESCRIPTION
This PR introduces the first part, `gen_schema`, for the `switch` HOP. The input mutation contract is identical to `cond` and allows all operands to be in-place mutated.

This change was authored with the assistance of an AI coding assistant (Claude).

cc @ydwu4 