### PR TITLE
Fix linalg.vector_norm docstring: ord does not accept 'fro'/'nuc'

### DIFF
--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -1535,7 +1535,7 @@ Args:
     x (Tensor): tensor, flattened by default, but this behavior can be
         controlled using :attr:`dim`.  (Note: the keyword argument
         `input` can also be used as an alias for `x`.)
-    ord (int, float, inf, -inf, 'fro', 'nuc', optional): order of norm. Default: `2`
+    ord (int, float, inf, -inf, optional): order of norm. Default: `2`
     dim (int, Tuple[int], optional): dimensions over which to compute
         the norm. See above for the behavior when :attr:`dim`\ `= None`.
         Default: `None`


### PR DESCRIPTION
Fixes #136563.

`torch.linalg.vector_norm`'s docstring lists `'fro'` and `'nuc'` as accepted values for `ord`, but they are not valid for a vector norm and raise `TypeError`:

```python
>>> torch.linalg.vector_norm(torch.randn(3), ord='fro')
TypeError: linalg_vector_norm(): argument 'ord' must be Number, not str
```

This is provable from the ATen schema: `linalg_vector_norm` takes a `Scalar ord` with no string overload:

```
- func: linalg_vector_norm(Tensor self, Scalar ord=2, ...) -> Tensor
```

The `'fro'`/`'nuc'` string values only apply to matrix norms. `linalg.matrix_norm` has the dedicated `.str_ord` overload (`str ord='fro'`), and `linalg.norm` accepts them for matrix inputs, so both of those docstrings correctly continue to list them. This was a copy-paste leftover in the `vector_norm` docstring.

The fix drops `'fro', 'nuc'` from the `vector_norm` `ord` description only; `matrix_norm` and `linalg.norm` are untouched. Docstring-only, no runtime change.
