### PR TITLE
docker-builds: drop release-runners group, keep mt-rel-* labels

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -87,4 +87,5 @@ self-hosted-runner:
     # OSDC ARC (multi-tenant) runners
     - mt-l-x86iavx512-2-4
     - mt-rel-l-x86iavx512-8-64
+    - mt-rel-l-arm64g4-16-62
     - mt-l-x86iamx-22-225-h100

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -82,13 +82,12 @@ jobs:
             buildkit_addr: "tcp://buildkitd-arm64.buildkit:1234"
             timeout-minutes: 600
             runner_label: mt-rel-l-arm64g4-16-62
-    # Use the release runner pool: its nodes carry osdc.io/runner-class=release,
-    # which exempts them from the cache-enforcer DaemonSet's iptables block on
-    # outbound ghcr.io traffic so the "Mirror image to GHCR" step can succeed.
-    # The regular mt-l-* pool blocks ghcr.io egress at the host iptables layer.
-    runs-on:
-      group: release-runners
-      labels: ${{ matrix.runner_label || 'mt-rel-l-x86iavx512-8-64' }}
+    # Use the mt-rel-* release runner labels: their nodes carry
+    # osdc.io/runner-class=release, which exempts them from the cache-enforcer
+    # DaemonSet's iptables block on outbound ghcr.io traffic so the "Mirror image
+    # to GHCR" step can succeed. The regular mt-l-* pool blocks ghcr.io egress at
+    # the host iptables layer.
+    runs-on: ${{ matrix.runner_label || 'mt-rel-l-x86iavx512-8-64' }}
     container:
       image: ghcr.io/actions/actions-runner:latest
     steps:


### PR DESCRIPTION
## Summary

The `docker-build` job pinned its runner via `runs-on.group: release-runners` plus the `mt-rel-*` labels. The group selector is redundant: the `mt-rel-*` labels already resolve uniquely to the release runner pool whose nodes carry `osdc.io/runner-class=release` (the property that exempts them from the cache-enforcer iptables block on outbound ghcr.io traffic). Dropping the `group:` key lets the job schedule on those same nodes by label alone, so GHCR mirroring keeps working without depending on the runner-group config.

`mt-rel-l-arm64g4-16-62` is added to the actionlint `self-hosted-runner` allowlist since it is referenced by the arm64 matrix entries but was not previously listed.

## Test Plan

```
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/docker-builds.yml')); yaml.safe_load(open('.github/actionlint.yaml')); print('YAML OK')"
```

Functional validation is the docker-build jobs scheduling on the `mt-rel-*` release runners and the "Mirror image to GHCR" step succeeding on a push-to-branch / `ciflow/docker` run.

Authored with the assistance of an AI coding agent (Claude Code).