### PR TITLE
Fix Adjust to only read valid entries

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -7031,6 +7031,18 @@ class TestBlockMask(InductorTestCase):
         self.assertTrue(block_mask[0].sparsity() > block_mask[1].sparsity())
 
     @supported_platform
+    def test_adjust_block_mask_ignores_entries_past_num_blocks(self, device):
+        def mask_mod(b, h, q, kv):
+            return (kv < 128) | ((kv >= 384) & (kv < 512))
+
+        block_mask = create_block_mask(mask_mod, 1, 1, 128, 640, device=device)
+        adjusted = block_mask._adjust(128, 384)
+        expected = create_block_mask(mask_mod, 1, 1, 128, 384, device=device)
+
+        self.assertEqual(adjusted.full_kv_num_blocks, expected.full_kv_num_blocks)
+        self.assertEqual(adjusted.to_dense(), expected.to_dense())
+
+    @supported_platform
     @common_utils.parametrize("BLOCK_SIZE", [32, 64, 128, 256, (32, 64), (64, 32)])
     def test_block_size_changes(self, device, BLOCK_SIZE: int | tuple[int, int]):
         B, H, Q_LEN, KV_LEN = 4, 2, 2048, 2048

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -445,10 +445,16 @@ def _adjust_num_blocks_and_indices(
     new_num_rows: int,
     new_num_cols: int,
 ) -> tuple[Tensor, Tensor]:
+    """Crop an ordered block list while ignoring undefined entries past num_blocks."""
     indices = indices[:, :, :new_num_rows, :new_num_cols]
     num_blocks = num_blocks[:, :, :new_num_rows]
-    num_blocks = torch.where(num_blocks < new_num_cols, num_blocks, new_num_cols)
-    num_blocks = torch.sum(indices < num_blocks[:, :, :, None], dim=-1).to(torch.int32)
+    valid_entries = (
+        torch.arange(indices.shape[-1], dtype=num_blocks.dtype, device=indices.device)
+        < num_blocks[..., None]
+    )
+    num_blocks = torch.sum(valid_entries & (indices < new_num_cols), dim=-1).to(
+        torch.int32
+    )
     return num_blocks, indices
 
 


### PR DESCRIPTION
## Human Note
This one is simple and relativley straightforward we had a dumb bug where we not properly masking entries prior to adjusting num cols. So if you had N cols but only V were valid from the num-blocks metadata and then you adjusted to N' it was possible that there are entries past V that should be masked but instead show up as valid now since they are still less than N'. In this case we now properly mask those out as well 

fixes: #139117

## Agent Report
# Report: pytorch/pytorch#139117

## Summary

`_adjust_num_blocks_and_indices` counted indices from the undefined tail of each block-index row after cropping a `BlockMask`. For the issue repro, that caused `full_kv_num_blocks` to stay at `2` even though only one originally valid full KV block remains inside the adjusted KV length.

## Root cause

The block-mask format defines entries after `num_blocks` as undefined. The old adjustment code first truncated `indices` to `new_num_cols` and then counted `indices < min(num_blocks, new_num_cols)`. If an undefined tail entry happened to be less than the adjusted column count, it was counted as a real block.

In the repro, the original valid full blocks are `[0, 3]`, but the stored row is `[0, 3, 1, 2, 4]`. After cropping to three columns, the undefined `1` remained in the truncated row and was incorrectly counted.

## Fix

`_adjust_num_blocks_and_indices` now builds a validity mask from the original per-row `num_blocks` before counting entries that survive the column crop. It only counts `indices` positions that were valid in the original row and whose block index is less than `new_num_cols`, then returns the cropped indices tensor.

A regression test was added in `test/inductor/test_flex_attention.py` to compare the adjusted block mask against one constructed directly at the smaller KV length.

## Repro Script

<details>
<summary>Repro Script</summary>

```python
import torch
from torch.nn.attention.flex_attention import (
    _adjust_num_blocks_and_indices,
    create_block_mask,
)
def mask_mod(b, h, q, kv):
    b1 = torch.where(kv >= 0, True, False) & torch.where(kv < 128, True, False)
    b2 = torch.where(kv >= 384, True, False) & torch.where(kv < 512, True, False)
    return b1 | b2
block_mask = create_block_mask(mask_mod, 1, 1, 128, 640)
adjusted_full_kv_num_blocks, adjusted_full_kv_indices = _adjust_num_blocks_and_indices(
    block_mask.full_kv_num_blocks,
    block_mask.full_kv_indices,
    new_num_rows=1,
    new_num_cols=3,
)
print(f"original full_kv_num_blocks: {block_mask.full_kv_num_blocks}")
print(f"original full_kv_indices: {block_mask.full_kv_indices}")
print(f"adjusted full_kv_num_blocks: {adjusted_full_kv_num_blocks}")
print(f"adjusted full_kv_indices: {adjusted_full_kv_indices}")
```

Output after the fix:

```text
original full_kv_num_blocks: tensor([[[2]]], device='cuda:0', dtype=torch.int32)
original full_kv_indices: tensor([[[[0, 3, 1, 2, 4]]]], device='cuda:0', dtype=torch.int32)
adjusted full_kv_num_blocks: tensor([[[1]]], device='cuda:0', dtype=torch.int32)
adjusted full_kv_indices: tensor([[[[0, 3, 1]]]], device='cuda:0', dtype=torch.int32)
```

</details>

## Test results

Behavioral tests:

```text
~/.ptq_workspace/jobs/20260625-pytorch-139117/.venv/bin/python ~/.ptq_workspace/jobs/20260625-pytorch-139117/repro.py
# adjusted full_kv_num_blocks: tensor([[[1]]], device='cuda:0', dtype=torch.int32)

cd ~/.ptq_workspace/jobs/20260625-pytorch-139117/pytorch && ~/.ptq_workspace/jobs/20260625-pytorch-139117/.venv/bin/python test/inductor/test_flex_attention.py -k test_adjust_block_mask_ignores_entries_past_num_blocks
# Ran 1 test in 0.257s -- OK

cd ~/.ptq_workspace/jobs/20260625-pytorch-139117/pytorch && ~/.ptq_workspace/jobs/20260625-pytorch-139117/.venv/bin/python test/inductor/test_flex_attention.py TestBlockMaskCUDA
# Ran 43 tests in 36.185s -- OK
```

Pre-fix regression confirmation:

```text
cd ~/.ptq_workspace/jobs/20260625-pytorch-139117/pytorch && ~/.ptq_workspace/jobs/20260625-pytorch-139117/.venv/bin/python test/inductor/test_flex_attention.py -k test_adjust_block_mask_ignores_entries_past_num_blocks
# Failed before the source fix: adjusted full_kv_num_blocks was 2 instead of 1.
```

Prerequisite checks:

```text
cd ~/.ptq_workspace/jobs/20260625-pytorch-139117/pytorch && spin quickfix
# ok No lint issues.

cd ~/.ptq_workspace/jobs/20260625-pytorch-139117/pytorch && spin quicklint
# ok No lint issues.

git -C ~/.ptq_workspace/jobs/20260625-pytorch-139117/pytorch diff --check
# passed
```

`spin fixlint` was also run as requested by the job instructions, but it failed on unrelated pre-existing shellcheck issues in repository shell scripts such as `.ci/pytorch/test.sh`. No C++ rebuild was needed because the change is Python-only.


Fixes #139117


<details>
<summary>Repro Script</summary>

```python
import torch
from torch.nn.attention.flex_attention import (
    _adjust_num_blocks_and_indices,
    create_block_mask,
)
def mask_mod(b, h, q, kv):
    b1 = torch.where(kv >= 0, True, False) & torch.where(kv < 128, True, False)
    b2 = torch.where(kv >= 384, True, False) & torch.where(kv < 512, True, False)
    return b1 | b2
block_mask = create_block_mask(mask_mod, 1, 1, 128, 640)
adjusted_full_kv_num_blocks, adjusted_full_kv_indices = _adjust_num_blocks_and_indices(
    block_mask.full_kv_num_blocks,
    block_mask.full_kv_indices,
    new_num_rows=1,
    new_num_cols=3,
)
print(f"original full_kv_num_blocks: {block_mask.full_kv_num_blocks}")
print(f"original full_kv_indices: {block_mask.full_kv_indices}")
print(f"adjusted full_kv_num_blocks: {adjusted_full_kv_num_blocks}")
print(f"adjusted full_kv_indices: {adjusted_full_kv_indices}")

"""
original full_kv_num_blocks: tensor([[[2]]], device='cuda:0', dtype=torch.int32)
original full_kv_indices: tensor([[[[0, 3, 1, 2, 4]]]], device='cuda:0', dtype=torch.int32)
adjusted full_kv_num_blocks: tensor([[[2]]], device='cuda:0', dtype=torch.int32)
adjusted full_kv_indices: tensor([[[[0, 3, 1]]]], device='cuda:0', dtype=torch.int32)
Expected adjusted full_kv_num_blocks: tensor([[[1]]], device='cuda:0', dtype=torch.int32)
"""
```

</details>


<details>
<summary>Agent Worklog</summary>

## Run 1

### Reproduced reported mask adjustment bug
Ran the provided `repro.py` with the job venv on the local GB200 CUDA environment. The adjusted `full_kv_num_blocks` remained `tensor([[[2]]])` while `full_kv_indices` was truncated to three columns, matching the issue's reported failure and confirming the bug is observable here.

### Added failing regression test
Added `TestBlockMask.test_adjust_block_mask_ignores_entries_past_num_blocks`, which compares an adjusted block mask against one built directly at the smaller KV length. The targeted test fails before the fix because adjusted `full_kv_num_blocks` is `2` instead of `1`.

### Fixed adjustment count and validated
Updated `_adjust_num_blocks_and_indices` to count only original entries before each row's `num_blocks`, so undefined tail indices no longer affect the adjusted count. The repro now reports adjusted `full_kv_num_blocks: tensor([[[1]]])`; the new targeted test passes, and the full `TestBlockMaskCUDA` class passes. `spin fixlint` was run but failed on pre-existing shellcheck issues in unrelated shell scripts; `spin quickfix`, `spin quicklint`, and `git diff --check` passed for the changed files.

### Wrote final artifacts
Wrote `report.md` with the root cause, fix summary, repro output, and validation results. Generated `fix.diff` from the PyTorch worktree diff.

### Extra semantic spot-check
Ran a randomized equivalence check on CPU and CUDA comparing adjusted ordered block lists against dense-mask cropping followed by `_dense_to_ordered`. The helper matched the reference for multiple batch/head sizes, row/column counts, and crop sizes.

</details>

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Chillee @yanboliang @BoyuanFeng @liangel-02 @howardzhang-cv