### PR TITLE
[Inductor][CUTLASS] Don't generate INT8 MM on `sm103`, skip int8mm CUTLASS tests

### DIFF
--- a/test/inductor/test_cutlass_backend.py
+++ b/test/inductor/test_cutlass_backend.py
@@ -77,11 +77,11 @@ from torch.sparse import SparseSemiStructuredTensor, to_sparse_semi_structured
 from torch.testing import FileCheck
 from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_FP8,
+    skipIfSM103,
     SM100OrLater,
     SM120OrLater,
     SM80OrLater,
     SM90OrLater,
-    skipIfSM103,
     xfailIfSM120OrLater,
 )
 from torch.testing._internal.common_device_type import skipCUDAIf, skipXPUIf
@@ -332,11 +332,7 @@ class TestCutlassBackend(TestCase):
 
         ops = pytree.tree_flatten(_gen_ops_cached("103", "13.3", "cuda"))[0]
         cutlass_ops = [op for op in ops if hasattr(op, "configuration_name")]
-        int8_ops = [
-            op
-            for op in cutlass_ops
-            if "s8_s8_s32" in op.configuration_name()
-        ]
+        int8_ops = [op for op in cutlass_ops if "s8_s8_s32" in op.configuration_name()]
         self.assertGreater(len(cutlass_ops), 0)
         self.assertEqual(int8_ops, [])
 

--- a/test/inductor/test_cutlass_backend.py
+++ b/test/inductor/test_cutlass_backend.py
@@ -81,6 +81,7 @@ from torch.testing._internal.common_cuda import (
     SM120OrLater,
     SM80OrLater,
     SM90OrLater,
+    skipIfSM103,
     xfailIfSM120OrLater,
 )
 from torch.testing._internal.common_device_type import skipCUDAIf, skipXPUIf
@@ -322,6 +323,22 @@ class TestCutlassBackend(TestCase):
         from torch._inductor.codecache import cutlass_key
 
         self.assertIsNotNone(cutlass_key())
+
+    @skipXPUIf(True, "CUDA-specific CUTLASS arch feature set")
+    def test_sm103_cutlass_ops_skip_int8_umma(self):
+        from torch.utils import _pytree as pytree
+
+        self.assertTrue(try_import_cutlass())
+
+        ops = pytree.tree_flatten(_gen_ops_cached("103", "13.3", "cuda"))[0]
+        cutlass_ops = [op for op in ops if hasattr(op, "configuration_name")]
+        int8_ops = [
+            op
+            for op in cutlass_ops
+            if "s8_s8_s32" in op.configuration_name()
+        ]
+        self.assertGreater(len(cutlass_ops), 0)
+        self.assertEqual(int8_ops, [])
 
     @skipXPUIf(not Xe2_Or_Later, "")
     @skipCUDAIf(not SM90OrLater, "need sm_90")
@@ -1271,6 +1288,7 @@ class TestCutlassBackend(TestCase):
     @skipXPUIf(True, "int_mm not supported on xpu cutlass backend")
     # TODO: Enable dynamic test cases when dynamic support is added.
     @skipCUDAIf(not SM90OrLater, "need sm_90")
+    @skipIfSM103
     @xfailIfSM120OrLater
     @parametrize("dynamic", (False,))
     @mock.patch.dict(os.environ, {"PATH": _get_path_without_sccache()})

--- a/torch/_inductor/codegen/cutlass/utils.py
+++ b/torch/_inductor/codegen/cutlass/utils.py
@@ -296,12 +296,13 @@ def _gen_ops_cached(arch: str, version: str, device_type: str) -> dict[Any, Any]
         )
         return {}
 
-    gen_arch = (
-        "100" if arch == "103" else arch
-    )  # CUTLASS SM103 generator only covers NVFB4; fallback to SM100 set
+    # SM103 reuses the SM100 generator, but the CUTLASS manifest must keep
+    # the 103a feature arch so unsupported arch-conditional kernels are skipped.
+    gen_arch = "100" if arch == "103" else arch
+    manifest_arch = "103a" if arch == "103" else gen_arch
     instantiation_level: str = config.cutlass.cutlass_instantiation_level
     args = CUTLASSArgs(
-        architectures=gen_arch,
+        architectures=manifest_arch,
         toolkit_version=version,
         instantiation_level=instantiation_level,
         operations=CUTLASS_OPERATION_KIND,

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -43,6 +43,7 @@ IS_JETSON = LazyVal(lambda: torch.cuda.is_available() and (torch.cuda.get_device
 IS_SM89 = LazyVal(lambda: torch.cuda.is_available() and torch.cuda.get_device_capability() == (8, 9))
 IS_SM90 = LazyVal(lambda: torch.cuda.is_available() and torch.cuda.get_device_capability() == (9, 0))
 IS_SM100 = LazyVal(lambda: torch.cuda.is_available() and torch.cuda.get_device_capability() == (10, 0))
+IS_SM103 = LazyVal(lambda: torch.cuda.is_available() and torch.cuda.get_device_capability() == (10, 3))
 IS_SM10X = LazyVal(lambda: torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 10)
 IS_SM12X = LazyVal(lambda: torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 12)
 
@@ -475,6 +476,11 @@ def xfailIfSM120OrLater(func):
     if TEST_WITH_ROCM:
         return func
     return func if not SM120OrLater else unittest.expectedFailure(func)
+
+def skipIfSM103(func):
+    if TEST_WITH_ROCM:
+        return func
+    return unittest.skip("Test skipped on SM103")(func) if IS_SM103 else func
 
 def xfailIfSM12X(func):
     return func if not IS_SM12X else unittest.expectedFailure(func)


### PR DESCRIPTION
SM 10.3 doesn't have these instructions, otherwise we see failures like

```
Traceback (most recent call last):
  File "/usr/lib/python3.12/unittest/case.py", line 58, in testPartExecutor
    yield
  File "/usr/lib/python3.12/unittest/case.py", line 634, in run
    self._callTestMethod(testMethod)
  File "/usr/lib/python3.12/unittest/case.py", line 589, in _callTestMethod
    if method() is not None:
       ^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_utils.py", line 3553, in wrapper
    method(*args, **kwargs)
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_utils.py", line 618, in instantiated_test
    test(self, **param_kwargs)
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_device_type.py", line 1448, in dep_fn
    return fn(slf, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_device_type.py", line 1448, in dep_fn
    return fn(slf, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_device_type.py", line 1448, in dep_fn
    return fn(slf, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/unittest/mock.py", line 1843, in _inner
    return f(*args, **kw)
           ^^^^^^^^^^^^^^
  File "/opt/pytorch/pytorch/test/inductor/test_cutlass_backend.py", line 1277, in test_max_autotune_cutlass_backend_int_mm
    Y_compiled = torch.compile(mm, dynamic=dynamic)(a, b)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/eval_frame.py", line 1183, in compile_wrapper
    raise e.remove_dynamo_frames() from None  # see TORCHDYNAMO_VERBOSE=1
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/compile_fx.py", line 1079, in _compile_fx_inner
    raise InductorError(e, currentframe()).with_traceback(
  File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/compile_fx.py", line 1059, in _compile_fx_inner
    mb_compiled_graph = fx_codegen_and_compile(
                        ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/compile_fx.py", line 1847, in fx_codegen_and_compile
    return scheme.codegen_and_compile(gm, example_inputs, inputs_to_check, graph_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/compile_fx.py", line 1608, in codegen_and_compile
    compiled_module = graph.compile_to_module()
                      ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/graph.py", line 2657, in compile_to_module
    return self._compile_to_module()
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/graph.py", line 2663, in _compile_to_module
    self.codegen_with_cpp_wrapper() if self.cpp_wrapper else self.codegen()
                                                             ^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/graph.py", line 2595, in codegen
    self._update_scheduler()
  File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/graph.py", line 2589, in _update_scheduler
    self.scheduler = Scheduler(self.operations)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/scheduler.py", line 4036, in __init__
    self._init(nodes)
  File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/scheduler.py", line 4153, in _init
    self.finalize_multi_template_buffers()
  File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/scheduler.py", line 5141, in finalize_multi_template_buffers
    min_node_unfused, _ = multi_node.get_min_choice()
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/ir.py", line 6090, in get_min_choice
    timings = self.choice_timings(hint_override=hint_override)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/ir.py", line 6062, in choice_timings
    self._choice_timings[hint_override] = self._choice_timings_fn(hint_override)
                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/select_algorithm.py", line 3988, in get_timings
    timings = self.do_autotuning(
              ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/select_algorithm.py", line 4405, in do_autotuning
    raise NoValidChoicesError
torch._inductor.exc.InductorError: NoValidChoicesError: 

Set TORCHDYNAMO_VERBOSE=1 for the internal stack trace (please do this especially if you're reporting a bug to PyTorch). For even more developer context, set TORCH_LOGS="+dynamo"


To execute this test, run the following from the base repo dir:
    python test/inductor/test_cutlass_backend.py TestCutlassBackend.test_max_autotune_cutlass_backend_int_mm_dynamic_False
    ```
    
    authored with codex

cc @ptrblck @msaroufim @tinglvv @nWEIdia @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo