### PR TITLE
Fix 64-bit indexing in avg_pool3d backward atomic kernel

### DIFF
--- a/aten/src/ATen/native/cuda/AveragePool3d.cu
+++ b/aten/src/ATen/native/cuda/AveragePool3d.cu
@@ -220,7 +220,7 @@ __global__ void avg_pool3d_cuda_update_grad_input_atomic(
   int dT, int dH, int dW,
   int padT, int padH, int padW,
   bool count_include_pad,
-  int offsetZ, int divisor_override, const int gradInput_numel)
+  int offsetZ, int divisor_override, const int64_t gradInput_numel)
 {
   int oCol   = blockIdx.x * blockDim.x + threadIdx.x;
   int oRow   = blockIdx.y * blockDim.y + threadIdx.y;
@@ -263,7 +263,7 @@ __global__ void avg_pool3d_cuda_update_grad_input_atomic(
       {
         for (int iCol = wstart; iCol < wend; ++iCol)
         {
-          const int index = slice * gradInput.stride(0) + iFrame * gradInput.stride(1) + iRow * gradInput.stride(2) + iCol * gradInput.stride(3);
+          const int64_t index = slice * gradInput.stride(0) + iFrame * gradInput.stride(1) + iRow * gradInput.stride(2) + iCol * gradInput.stride(3);
           fastAtomicAdd(gradInput.data(), index, gradInput_numel, val, true);
         }
       }

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -13798,6 +13798,24 @@ if __name__ == '__main__':
             self.assertEqual(out[0, 0, 0], 1 / numel)
 
     @onlyCUDA
+    @largeTensorTest("24GB", "cuda")
+    def test_avg_pool3d_backward_64bit_indexing(self, device):
+        # The overlapping-window avg_pool3d backward path scatters gradients
+        # through an atomicAdd kernel that computed the destination offset with
+        # 32-bit ints, so on inputs with more than INT_MAX elements the offset
+        # wrapped around and silently corrupted the gradient. Use the smallest
+        # overlapping config (kernel 2, stride 1) that pushes the per-element
+        # offset past INT_MAX.
+        x = torch.ones((1, 1, 240000000, 3, 3), device=device, dtype=torch.float16, requires_grad=True)
+        out = F.avg_pool3d(x, kernel_size=2, stride=1)
+        out.backward(torch.ones_like(out))
+        # An interior voxel near the end of the buffer sits at an offset above
+        # INT_MAX and is covered by all 2**3 windows, so its gradient must be
+        # exactly 1.0; with the 32-bit offset it stays ~0 because the atomic
+        # adds land at wrapped-around locations instead.
+        self.assertEqual(x.grad[0, 0, -2, 1, 1], 1.0)
+
+    @onlyCUDA
     def test_softmax_backward_smem(self, device):
         torch.manual_seed(0)
         # We use smem for tensors that have > 1024 elements and size >= 4096 bytes.

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -13808,7 +13808,7 @@ if __name__ == '__main__':
         # offset past INT_MAX.
         x = torch.ones((1, 1, 240000000, 3, 3), device=device, dtype=torch.float16, requires_grad=True)
         out = F.avg_pool3d(x, kernel_size=2, stride=1)
-        out.backward(torch.ones_like(out))
+        out.sum().backward()
         # An interior voxel near the end of the buffer sits at an offset above
         # INT_MAX and is covered by all 2**3 windows, so its gradient must be
         # exactly 1.0; with the 32-bit offset it stays ~0 because the atomic


### PR DESCRIPTION
### Summary

`avg_pool3d` backward silently corrupts the gradient on inputs with more than
`INT_MAX` elements, even though the forward pass handles them.

When the pooling windows overlap (`stride < kernel_size`), the backward pass
scatters each output gradient into its input window with
`avg_pool3d_cuda_update_grad_input_atomic`. That kernel computes the flat
destination offset, and takes the bounds-check `numel`, as 32-bit `int`:

```cpp
__global__ void avg_pool3d_cuda_update_grad_input_atomic(
    ...
    int offsetZ, int divisor_override, const int gradInput_numel)
{
    ...
    const int index = slice * gradInput.stride(0) + iFrame * gradInput.stride(1)
                    + iRow * gradInput.stride(2) + iCol * gradInput.stride(3);
    fastAtomicAdd(gradInput.data(), index, gradInput_numel, val, true);
}
```

`gradInput.stride(...)` already returns `int64_t`, so the products are computed
in 64-bit, but the result is truncated when it is stored back into `int index`
(and `gradInput_numel` is truncated at the call site). Once `gradInput` has more
than `2**31` elements, the high offsets wrap around: the `atomicAdd`s land at the
wrong locations, so the gradient near the end of the buffer is left at ~0 and
some low-offset region gets spurious contributions.

This is the overlapping-window analogue of the large-tensor index fixes already
in `avg_pool2d` backward, which dispatches its index type via
`canUse32BitIndexMath`.

### Fix

Widen `index` and the `gradInput_numel` parameter to `int64_t`. The stride
products are already 64-bit and the launch site already passes an `int64_t`
`numel()`, so this just stops the truncation. Because this kernel only runs on
the overlapping path and is dominated by the global `atomicAdd`, the index math
is not on a hot path, so an unconditional `int64_t` keeps the change minimal
rather than threading an `index_t` template through the launcher.

The non-atomic backward kernel (`avg_pool3d_cuda_update_grad_input`) is
unaffected: it addresses `gradInput` through the accessor's `operator[]`, which
is already 64-bit safe. Only the manual offset arithmetic in the atomic path was
wrong.

### Test

Added `test_avg_pool3d_backward_64bit_indexing`: an overlapping `avg_pool3d`
(kernel 2, stride 1) over an input whose element count crosses `INT_MAX`. An
interior voxel near the end of the buffer is covered by all `2**3` windows, so
its gradient must be exactly `1.0`; with the 32-bit offset it stays ~0.

This is a `largeTensorTest` that needs a large-memory GPU (~24 GB). I do not have
one to run it on locally, so I validated the fix by code inspection and against
the `avg_pool2d` precedent rather than executing it; it is included so CI / a
maintainer on suitable hardware can exercise the regression.
