### PR TITLE
[Inductor][XPU] Allow all memory type pointers known by driver in static launcher.

### DIFF
--- a/torch/csrc/inductor/static_launcher/xpu.cpp
+++ b/torch/csrc/inductor/static_launcher/xpu.cpp
@@ -96,9 +96,9 @@ syclDevicePtr_t getPointer(
           static_cast<int>(res)));
 
   TORCH_CHECK(
-      prop.type == ZE_MEMORY_TYPE_DEVICE,
+      prop.type != ZE_MEMORY_TYPE_UNKNOWN,
       fmt::format(
-          "Pointer argument doesn't reference XPU device memory at {}-th argument, err={}",
+          "Pointer argument references unknown type of memory at {}-th argument, err={}",
           idx,
           static_cast<int>(res)));
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #188240

