### PR TITLE
Fix LoggingTestCase._handler_watcher to count only torch-owned handlers

### DIFF
--- a/torch/testing/_internal/logging_utils.py
+++ b/torch/testing/_internal/logging_utils.py
@@ -163,10 +163,18 @@ class LoggingTestCase(torch._dynamo.test_case.TestCase):
             nonlocal record_list
             record_list.append(record)
 
-        # registered logs are the only ones with handlers, so patch those
+        # Registered logs are the only ones with handlers, so patch those. Count and
+        # patch only torch-owned handlers: when running under pytest (or any framework
+        # that attaches its own capture handlers to these loggers), those foreign
+        # handlers must not count against torch's own handler budget.
         for log_qname in torch._logging._internal.log_registry.get_log_qnames():
             logger = logging.getLogger(log_qname)
-            num_handlers = len(logger.handlers)
+            torch_handlers = [
+                h
+                for h in logger.handlers
+                if torch._logging._internal._is_torch_handler(h)
+            ]
+            num_handlers = len(torch_handlers)
             self.assertLessEqual(
                 num_handlers,
                 2,
@@ -175,7 +183,7 @@ class LoggingTestCase(torch._dynamo.test_case.TestCase):
 
             self.assertGreater(num_handlers, 0, "All pt2 loggers should have more than zero handlers")
 
-            for handler in logger.handlers:
+            for handler in torch_handlers:
                 old_emit = handler.emit
 
                 def new_emit(record):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #188241

_handler_watcher asserts every registered pt2 logger has <= 2 handlers
("debug artifacts and messages above debug level"), implicitly assuming
torch owns every handler on those loggers.

Under pytest 9.x the logging plugin attaches its own capture handlers
(_LiveLoggingNullHandler, _FileHandler, two LogCaptureHandlers) directly
onto the pt2 loggers (which have propagate=False), so the count hit 5 and
the assertion failed with "5 not less than or equal to 2". This only
showed up in the inductor-benchmarks CI image, where torchbench's unpinned
`pytest` requirement upgrades pytest past the repo's pinned 7.3.2 -- which
is why it never reproduced locally or on other lanes.

Fix: count and patch only torch-owned handlers (via
torch._logging._internal._is_torch_handler), preserving the original
intent -- catching torch duplicating its OWN handlers -- while ignoring
handlers installed by the test framework.

Test Plan:
Validated on the OSDC inductor lane that had been red ~500 commits, via a
throwaway dispatch that overlaid this change and ran only the logging
tests (run 28211815361): AOTInductorLoggingTest passed, 0 failures.

Local check that the watcher tolerates foreign handlers but still trips
when torch itself has > 2 of its own:

    python - <<'PY'
    import logging, torch, unittest
    import torch._logging._internal as L
    import torch.testing._internal.logging_utils as m
    class S:
        assertLessEqual = unittest.TestCase().assertLessEqual
        assertGreater = unittest.TestCase().assertGreater
    L._init_logs()
    lg = logging.getLogger("torch._dynamo")
    for _ in range(4):
        lg.addHandler(logging.NullHandler())
    m.LoggingTestCase._handler_watcher(S(), []).close()   # foreign handlers ignored
    PY

Authored with Claude.