### PR TITLE
[ROCm] Support USE_ASAN=1 build

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1555,6 +1555,27 @@ if(USE_ROCM)
         target_compile_definitions(torch_rocshmem PUBLIC USE_NVSHMEM USE_ROCM)
 
         target_link_libraries(torch_rocshmem PRIVATE roc::rocshmem)
+
+        # The ASAN ROCm SDK ships the __device__ implementations of the rocSHMEM
+        # API in per-arch bitcode (librocshmem_device_<arch>.bc), separate from
+        # the host archive. Pass it straight to the device (offload) linker so it
+        # joins the device LTO link as bitcode and the symbols our kernels
+        # reference stay live. Routing it through the normal HIP input path
+        # instead recompiles it in isolation with -fvisibility=hidden and
+        # -amdgpu-internalize-symbols, which dead-strips the library symbols
+        # before the consumer's references are ever seen.
+        if(USE_ASAN)
+          foreach(_arch ${_torch_rocshmem_build_arches})
+            string(REGEX REPLACE ":.*" "" _arch_base "${_arch}")
+            set(_dev_bc "${ROCM_PATH}/lib/librocshmem_device_${_arch_base}.bc")
+            if(EXISTS "${_dev_bc}")
+              target_link_options(torch_rocshmem PRIVATE "SHELL:-Xoffload-linker ${_dev_bc}")
+            else()
+              message(WARNING "rocSHMEM device bitcode not found for ${_arch_base}: ${_dev_bc}")
+            endif()
+          endforeach()
+        endif()
+
         target_link_libraries(torch_hip PRIVATE torch_rocshmem)
 
         install(TARGETS torch_rocshmem EXPORT Caffe2Targets DESTINATION

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -683,6 +683,17 @@ if(BUILD_TEST OR BUILD_MOBILE_BENCHMARK OR BUILD_MOBILE_TEST)
   set(BENCHMARK_ENABLE_INSTALL OFF CACHE BOOL "Disable benchmark install to avoid overwriting vendor install.")
   if(NOT USE_SYSTEM_BENCHMARK)
     add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../third_party/benchmark)
+    # Clang 23+ classifies __COUNTER__ in preprocessor conditions as a C2y
+    # extension. benchmark enables -Werror so this becomes fatal. Suppress
+    # only that warning on affected compilers without touching the submodule.
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "23.0")
+      if(TARGET benchmark)
+        target_compile_options(benchmark PRIVATE -Wno-c2y-extensions)
+      endif()
+      if(TARGET benchmark_main)
+        target_compile_options(benchmark_main PRIVATE -Wno-c2y-extensions)
+      endif()
+    endif()
   else()
     add_library(benchmark SHARED IMPORTED)
     find_library(BENCHMARK_LIBRARY benchmark)

--- a/cmake/EnvVarForwarding.cmake
+++ b/cmake/EnvVarForwarding.cmake
@@ -70,33 +70,61 @@ foreach(_var IN LISTS _ENV_PASSTHROUGH)
   endif()
 endforeach()
 
-# Forward all BUILD_*, USE_*, CMAKE_* env vars not already set as CMake
-# variables, plus vars ending in EXITCODE or EXITCODE__TRYRUN_OUTPUT.
-# This matches the existing behavior where setup.py passed everything with
-# these prefixes/suffixes through to CMake.
-# We use execute_process + env to get the full list since CMake has no
-# built-in way to enumerate environment variables.
-execute_process(
-  COMMAND "${CMAKE_COMMAND}" -E environment
-  OUTPUT_VARIABLE _all_env
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-string(REPLACE "\n" ";" _env_lines "${_all_env}")
-foreach(_line IN LISTS _env_lines)
-  if(_line MATCHES "^([A-Za-z_0-9]+)=(.*)")
-    set(_var_name "${CMAKE_MATCH_1}")
-    set(_var_value "${CMAKE_MATCH_2}")
-    # Only forward vars with BUILD_/USE_/CMAKE_ prefix or *EXITCODE* suffix.
-    string(REGEX MATCH "^(BUILD_|USE_|CMAKE_)" _has_prefix "${_var_name}")
-    string(REGEX MATCH "(EXITCODE|EXITCODE__TRYRUN_OUTPUT)$" _has_suffix "${_var_name}")
-    if(NOT _has_prefix AND NOT _has_suffix)
-      continue()
-    endif()
-    if(NOT DEFINED ${_var_name})
-      set(${_var_name} "${_var_value}" CACHE STRING "From environment" FORCE)
-    endif()
+# Forward all BUILD_*, USE_*, CMAKE_* environment variables (plus names ending
+# in EXITCODE / EXITCODE__TRYRUN_OUTPUT) into the CMake cache, mirroring the -D
+# flags setup.py used to pass.
+#
+# CMake cannot enumerate environment variables, and serializing the whole
+# environment to text and re-parsing it in CMake is unsafe: values such as PS1
+# contain ';' and '\' (and some exported shell functions even contain newlines),
+# all of which collide with CMake's list, escape, and line semantics and
+# silently corrupt unrelated variables. The top-level CMakeLists.txt already
+# requires Python (find_package(Python COMPONENTS Interpreter REQUIRED)) before
+# including this module, so read os.environ directly there -- the full
+# environment is never serialized -- and have it emit only the selected,
+# properly escaped cache assignments for CMake to evaluate.
+
+# Applies one forwarded variable. An explicitly-set environment variable takes
+# priority, matching the -D semantics this module emulates: override the cache
+# (do not merely fill when undefined) so a value left by an earlier env-less
+# configure -- an option() default or a ninja-triggered reconfigure -- cannot
+# permanently shadow the environment.
+function(_envfwd_apply _name _value)
+  if(NOT DEFINED ${_name} OR NOT "${${_name}}" STREQUAL "${_value}")
+    set(${_name} "${_value}" CACHE STRING "From environment" FORCE)
   endif()
-endforeach()
+endfunction()
+
+# Reads os.environ and prints `_envfwd_apply("<name>" "<value>")` for each
+# selected variable, escaping the value for a CMake double-quoted argument.
+set(_envfwd_script [==[
+import os, re, sys
+
+select = re.compile(r"^(BUILD_|USE_|CMAKE_)|(EXITCODE|EXITCODE__TRYRUN_OUTPUT)$")
+
+def q(s):
+    # Escape for a CMake double-quoted argument. Backslash and quote are
+    # structural; '$' is escaped to suppress ${}/$ENV{} expansion. ';' and
+    # newlines are literal inside quotes and need no escaping.
+    return s.replace("\\", "\\\\").replace('"', '\\"').replace("$", "\\$")
+
+sys.stdout.write("\n".join(
+    '_envfwd_apply("%s" "%s")' % (q(name), q(value))
+    for name, value in os.environ.items()
+    if select.search(name)
+))
+]==])
+
+execute_process(
+  COMMAND "${Python_EXECUTABLE}" -c "${_envfwd_script}"
+  OUTPUT_VARIABLE _envfwd_code
+  RESULT_VARIABLE _envfwd_rc
+)
+if(NOT _envfwd_rc EQUAL 0)
+  message(FATAL_ERROR
+    "EnvVarForwarding: failed to read the environment via Python (exit ${_envfwd_rc}).")
+endif()
+cmake_language(EVAL CODE "${_envfwd_code}")
 
 # Low-priority aliases
 foreach(_alias IN LISTS _LOW_PRIORITY_ALIASES)

--- a/cmake/External/aotriton.cmake
+++ b/cmake/External/aotriton.cmake
@@ -10,6 +10,7 @@ if(NOT __AOTRITON_INCLUDED)
   # Note packages information may have versions skipped (due to no ABI breaks)
   # But they must be listed from lower version to higher version
   set(__AOTRITON_VER "0.13b")
+  set(__AOTRITON_BUILD_VARIANTS "")
   set(__AOTRITON_MANYLINUX_LIST
       "manylinux_2_28"  # rocm6.4
       "manylinux_2_28"  # rocm7.0
@@ -57,6 +58,31 @@ if(NOT __AOTRITON_INCLUDED)
      "6a465dbc03148bba8a2d78c4c2a3cb83155eca00f4f7f749e676402d7660968c" # amd-gfx120x
      "4aaf71d6e510549d593757e5f88598df1e4a29cbcd91f70750ee8a76f65c027f" # amd-gfx1250
      )
+  if(USE_ASAN)
+    set(__AOTRITON_BUILD_VARIANTS "+asan")
+    set(__AOTRITON_MANYLINUX_LIST
+        "manylinux_2_28"  # rocm7.14
+        "manylinux_2_28"  # rocm7.15
+        )
+    # ASAN only supports rocm7.14
+    set(__AOTRITON_ROCM_LIST
+        "rocm7.14"
+        "rocm7.15"
+        )
+    set(__AOTRITON_SHA256_LIST
+        "3f5cfba6c42261a3e3b44022c66083ec859fcc98296faa4646b65373fead3448"  # rocm7.14+asan
+        "7a7928d881d6341fc0b8ffb3ad7077f62438a8412ec57f97fb4b4dfbc73b3e64"  # rocm7.15+asan
+        )
+    # ASAN only supports gfx942+gfx950
+    set(__AOTRITON_IMAGE_LIST
+        "amd-gfx942"
+        "amd-gfx950"
+       )
+    set(__AOTRITON_IMAGE_SHA256_LIST
+       "563d2e4c41b367725c7b8e12fdfd04df4d1b1ff15947e011e2452818f3a43d26" # amd-gfx942+asan
+       "b428dfe6eef7a1dcfac54ac2408dd136dbd622016331dc863e87ce9ea84c8054" # amd-gfx950+asan
+       )
+  endif()
   set(__AOTRITON_BASE_URL "$ENV{PYTORCH_AOTRITON_BASE_URL}")
   if(NOT __AOTRITON_BASE_URL)
     set(__AOTRITON_BASE_URL "https://github.com/ROCm/aotriton/releases/download/")  # @lint-ignore
@@ -179,7 +205,9 @@ if(NOT __AOTRITON_INCLUDED)
     list(GET __AOTRITON_SHA256_LIST ${index} __AOTRITON_SHA256)
 
     string(CONCAT __AOTRITON_FILE "aotriton-"
-                                  "${__AOTRITON_VER}-${__AOTRITON_MANYLINUX}"
+                                  "${__AOTRITON_VER}"
+                                  "${__AOTRITON_BUILD_VARIANTS}-"
+                                  "${__AOTRITON_MANYLINUX}"
                                   "_${__AOTRITON_ARCH}-${__AOTRITON_ROCM}"
                                   "-shared.tar.${__AOTRITON_Z}")
     string(CONCAT __AOTRITON_URL
@@ -205,7 +233,7 @@ if(NOT __AOTRITON_INCLUDED)
     list(GET __AOTRITON_IMAGE_SHA256_LIST ${index} __AOTRITON_SHA256)
 
     string(CONCAT __AOTRITON_FILE
-           "aotriton-${__AOTRITON_VER}-images-"
+           "aotriton-${__AOTRITON_VER}${__AOTRITON_BUILD_VARIANTS}-images-"
            "${image}.tar.${__AOTRITON_Z}")
     string(CONCAT __AOTRITON_URL
            "${__AOTRITON_BASE_URL}"

--- a/cmake/Modules/FindOpenMP.cmake
+++ b/cmake/Modules/FindOpenMP.cmake
@@ -289,6 +289,24 @@ function(_OPENMP_GET_FLAGS LANG FLAG_MODE OPENMP_FLAG_VAR OPENMP_LIB_NAMES_VAR)
       mark_as_advanced(OpenMP_libomp_LIBRARY)
     endif()
 
+    # For Clang, ask the compiler where it keeps libomp.so before falling back
+    # to the generic search. This avoids picking up GCC's libgomp (which lacks
+    # the __kmpc_* ABI) when libomp lives in a non-standard location (e.g.
+    # inside a ROCm venv SDK directory not in CMAKE_IMPLICIT_LINK_DIRECTORIES).
+    if (NOT OpenMP_libomp_LIBRARY AND CMAKE_${LANG}_COMPILER_ID MATCHES "Clang")
+      execute_process(
+        COMMAND "${CMAKE_${LANG}_COMPILER}" -print-file-name=libomp.so
+        OUTPUT_VARIABLE _omp_clang_lib
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+      )
+      if(_omp_clang_lib AND NOT _omp_clang_lib STREQUAL "libomp.so")
+        set(OpenMP_libomp_LIBRARY "${_omp_clang_lib}" CACHE STRING "libomp location for OpenMP")
+        mark_as_advanced(OpenMP_libomp_LIBRARY)
+      endif()
+      unset(_omp_clang_lib)
+    endif()
+
     if (NOT OpenMP_libomp_LIBRARY)
       find_library(OpenMP_libomp_LIBRARY
         NAMES omp gomp iomp5

--- a/cmake/Modules/FindSanitizer.cmake
+++ b/cmake/Modules/FindSanitizer.cmake
@@ -30,6 +30,7 @@ foreach(sanitizer_name IN ITEMS address thread undefined leak memory)
 
   set(CMAKE_REQUIRED_FLAGS
       "-fsanitize=${sanitizer_name};-fno-omit-frame-pointer")
+  set(CMAKE_REQUIRED_LINK_OPTIONS "")
   if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" OR CMAKE_C_COMPILER_ID STREQUAL
                                               "MSVC")
     if(sanitizer_name STREQUAL "address")
@@ -38,10 +39,27 @@ foreach(sanitizer_name IN ITEMS address thread undefined leak memory)
       continue()
     endif()
   endif()
+  set(_asan_rpath_flag "")
   if(sanitizer_name STREQUAL "address")
     if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_C_COMPILER_ID STREQUAL
                                                  "Clang")
       list(APPEND CMAKE_REQUIRED_FLAGS "-shared-libasan")
+      # -shared-libasan needs libclang_rt.asan-<arch>.so at runtime. On toolchains
+      # that keep it in a non-default directory (e.g. a ROCm SDK), the probe binary
+      # below cannot load it, check_cxx_source_runs() fails, and ASAN is silently
+      # disabled. Add an rpath to the runtime's directory so the probe runs; the
+      # same flag is later attached to Sanitizer::address so real targets load it.
+      execute_process(
+        COMMAND "${CMAKE_CXX_COMPILER}" -print-file-name=libclang_rt.asan-${CMAKE_HOST_SYSTEM_PROCESSOR}.so
+        OUTPUT_VARIABLE _asan_runtime_path
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+      )
+      if(_asan_runtime_path AND NOT _asan_runtime_path STREQUAL "libclang_rt.asan-${CMAKE_HOST_SYSTEM_PROCESSOR}.so")
+        get_filename_component(_asan_runtime_dir "${_asan_runtime_path}" DIRECTORY)
+        set(_asan_rpath_flag "-Wl,-rpath,${_asan_runtime_dir}")
+        list(APPEND CMAKE_REQUIRED_LINK_OPTIONS "${_asan_rpath_flag}")
+      endif()
     endif()
   endif()
   if(sanitizer_name STREQUAL "undefined" AND UBSAN_FLAGS)
@@ -128,6 +146,13 @@ foreach(sanitizer_name IN ITEMS address thread undefined leak memory)
         $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<BOOL:$__CXX_${sanitizer_name}_res>,$<CXX_COMPILER_ID:GNU>>:-lasan>
         $<$<AND:$<COMPILE_LANGUAGE:C>,$<BOOL:$__C_${sanitizer_name}_res>,$<C_COMPILER_ID:GNU>>:-lasan>
       )
+      # Carry the rpath to the shared ASAN runtime (set above when probing with
+      # -shared-libasan) onto real targets, so libraries and executables linking
+      # Sanitizer::address can load libclang_rt.asan-<arch>.so from its
+      # non-default toolchain directory at runtime.
+      if(_asan_rpath_flag)
+        target_link_options(Sanitizer::${sanitizer_name} INTERFACE "${_asan_rpath_flag}")
+      endif()
     endif()
     if(sanitizer_name STREQUAL "undefined")
       target_link_options(

--- a/cmake/public/LoadHIP.cmake
+++ b/cmake/public/LoadHIP.cmake
@@ -118,6 +118,24 @@ if(WIN32)
   set(CMAKE_HIP_COMPILER_FRONTEND_VARIANT "GNU")
 endif()
 
+# CMake populates CMAKE_<LANG>_USING_LINKER_<TYPE> for C/CXX (Clang) but not for
+# HIP, so a global CMAKE_LINKER_TYPE (e.g. LLD) leaks into enable_language(HIP)'s
+# ABI probe and aborts with "LINKER_TYPE '<TYPE>' is unknown or not supported by
+# this toolchain". HIP here is the same clang++ driver as CXX, so reuse the CXX
+# linker-type mapping; fall back to the standard -fuse-ld flag if CXX has none.
+if(CMAKE_LINKER_TYPE AND NOT DEFINED CMAKE_HIP_USING_LINKER_${CMAKE_LINKER_TYPE})
+  if(DEFINED CMAKE_CXX_USING_LINKER_${CMAKE_LINKER_TYPE})
+    set(CMAKE_HIP_USING_LINKER_${CMAKE_LINKER_TYPE}
+        "${CMAKE_CXX_USING_LINKER_${CMAKE_LINKER_TYPE}}")
+    if(DEFINED CMAKE_CXX_USING_LINKER_MODE)
+      set(CMAKE_HIP_USING_LINKER_MODE "${CMAKE_CXX_USING_LINKER_MODE}")
+    endif()
+  else()
+    string(TOLOWER "${CMAKE_LINKER_TYPE}" _hip_linker_lc)
+    set(CMAKE_HIP_USING_LINKER_${CMAKE_LINKER_TYPE} "-fuse-ld=${_hip_linker_lc}")
+  endif()
+endif()
+
 enable_language(HIP)
 message(STATUS "HIP language enabled with compiler: ${CMAKE_HIP_COMPILER}")
 message(STATUS "HIP architectures: ${CMAKE_HIP_ARCHITECTURES}")

--- a/cmake/public/mkldnn.cmake
+++ b/cmake/public/mkldnn.cmake
@@ -16,3 +16,15 @@ set_property(
 set_property(
   TARGET caffe2::mkldnn PROPERTY INTERFACE_LINK_LIBRARIES
   ${MKLDNN_LIBRARIES})
+
+# oneDNN compiles the static dnnl library with -fopenmp but, for the non-SYCL
+# OMP runtime, adds no OpenMP link dependency to the target, expecting consumers
+# to provide it. PyTorch only propagates Intel's iomp5 via MKL_OPENMP_LIBRARY,
+# so a non-MKL OpenMP build leaves nothing linking libomp and binaries that pull
+# dnnl objects (e.g. the C++ test executables) fail to resolve omp_*/__kmpc_*
+# symbols. Carry the detected OpenMP runtime on the interface to cover that case.
+if(MKLDNN_FOUND AND TARGET caffe2::openmp)
+  set_property(
+    TARGET caffe2::mkldnn APPEND PROPERTY INTERFACE_LINK_LIBRARIES
+    caffe2::openmp)
+endif()


### PR DESCRIPTION
Notable New Features:

* ROCm PyTorch now supports ASAN build with TheRock 7.14 SDK
  + Use clang from TheRock 7.14 as the host compiler
  + integration builds cleanly; tests unvalidated due to crashing during the early-initialization phase of the ROCm ASAN runtime.
  + Build of CK SDPA with ASAN is not tested
  + Select ASAN build of AOTriton for SDPA

Notable Bug Fixes:

* Rewrites env var parsers in `cmake/EnvVarForwarding.cmake` with python script
  + The old parser is error-prone and failed to handle complicated `PS1` env var like `${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$` (This is DEFAULT `PS1` from Ubuntu 24.04)
  + An outcome of this buggy parser is: `USE_ASAN` is never set if `PS1` contains `;` and occurs earlier than `USE_ASAN` in env vars.
  + **Breaking** the new parser now honors exported env vars over cmake command-line -D and/or CMakeCache.txt
* Other related ASAN build fixes on TheRock 7.14+Clang Environment

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil