### PR TITLE
save_on_cpu memeff_bias

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/attention_backward.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention_backward.cu
@@ -71,11 +71,13 @@ namespace at::native {
 
 namespace {
 
-constexpr int64_t kMemEffAttentionBiasAlignment = 8;
+int64_t mem_eff_attention_backward_bias_alignment(const Tensor& bias) {
+  return bias.element_size() == 4 ? 4 : 8;
+}
 
-bool has_mem_eff_attention_bias_alignment(const Tensor& bias) {
+bool has_mem_eff_attention_bias_alignment(const Tensor& bias, int64_t alignment) {
   for (const auto dim : c10::irange(bias.dim() - 1)) {
-    if (bias.stride(dim) % kMemEffAttentionBiasAlignment != 0) {
+    if (bias.stride(dim) % alignment != 0) {
       return false;
     }
   }
@@ -83,13 +85,13 @@ bool has_mem_eff_attention_bias_alignment(const Tensor& bias) {
 }
 
 Tensor ensure_mem_eff_attention_bias_alignment(const Tensor& bias) {
-  if (bias.dim() != 4 || has_mem_eff_attention_bias_alignment(bias)) {
+  const auto alignment = mem_eff_attention_backward_bias_alignment(bias);
+  if (bias.dim() != 4 || has_mem_eff_attention_bias_alignment(bias, alignment)) {
     return bias;
   }
 
   const auto last_dim_size = bias.size(-1);
-  const auto pad_count = kMemEffAttentionBiasAlignment -
-      (last_dim_size % kMemEffAttentionBiasAlignment);
+  const auto pad_count = alignment - (last_dim_size % alignment);
   return at::pad(bias, {0, pad_count}).slice(-1, 0, last_dim_size);
 }
 

--- a/aten/src/ATen/native/transformers/cuda/attention_backward.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention_backward.cu
@@ -28,6 +28,7 @@
 #include <ATen/ops/zeros_like.h>
 #include <ATen/ops/empty_strided.h>
 #include <ATen/ops/empty_permuted.h>
+#include <ATen/ops/pad.h>
 #include <ATen/ops/_cudnn_attention_backward.h>
 #include <ATen/ops/_cudnn_attention_backward_native.h>
 #include <ATen/ops/_flash_attention_backward.h>
@@ -67,6 +68,32 @@
 #endif
 
 namespace at::native {
+
+namespace {
+
+constexpr int64_t kMemEffAttentionBiasAlignment = 8;
+
+bool has_mem_eff_attention_bias_alignment(const Tensor& bias) {
+  for (const auto dim : c10::irange(bias.dim() - 1)) {
+    if (bias.stride(dim) % kMemEffAttentionBiasAlignment != 0) {
+      return false;
+    }
+  }
+  return bias.stride(-1) == 1;
+}
+
+Tensor ensure_mem_eff_attention_bias_alignment(const Tensor& bias) {
+  if (bias.dim() != 4 || has_mem_eff_attention_bias_alignment(bias)) {
+    return bias;
+  }
+
+  const auto last_dim_size = bias.size(-1);
+  const auto pad_count = kMemEffAttentionBiasAlignment -
+      (last_dim_size % kMemEffAttentionBiasAlignment);
+  return at::pad(bias, {0, pad_count}).slice(-1, 0, last_dim_size);
+}
+
+} // namespace
 
 std::tuple<Tensor, Tensor, Tensor> _flash_attention_backward(
     const Tensor& grad_out,
@@ -1014,7 +1041,7 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> _scaled_dot_product_e
   // std::optional to undefined tensor
   std::optional<Tensor> kernel_bias;
   if (attn_bias_chunk.has_value() && attn_bias_chunk.value().defined()) {
-    kernel_bias = attn_bias_chunk.value();
+    kernel_bias = ensure_mem_eff_attention_bias_alignment(attn_bias_chunk.value());
   }
   // Will add with signauter changes for dropout and bias
   // We are only handling Dense inputs, but this should be passed

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -3563,6 +3563,37 @@ class TestSDPACudaOnly(NNTestCase):
         max_diff = (out - out_contig).abs().mean()
         self.assertTrue(max_diff.item() < 1e-7)
 
+    @unittest.skipIf(not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION, "Fused SDPA was not built for this system")
+    def test_mem_eff_attention_save_on_cpu_unaligned_bias_stride(self, device):
+        dtype = torch.float16
+        make_tensor = partial(torch.rand, device=device, dtype=dtype, requires_grad=True)
+        batch, num_heads, seq_len_q, seq_len_kv, head_dim = 1, 8, 1, 361, 64
+        query = make_tensor(SdpaShape(batch, num_heads, seq_len_q, head_dim))
+        kv_shape = SdpaShape(batch, num_heads, seq_len_kv, head_dim)
+        key, value = make_tensor(kv_shape), make_tensor(kv_shape)
+        attn_mask = torch.randn((batch, 1, seq_len_q, seq_len_kv), device=device, dtype=dtype, requires_grad=True)
+        self.assertEqual(attn_mask.stride(1), 361)
+        ref_query = query.detach().clone().requires_grad_()
+        ref_key = key.detach().clone().requires_grad_()
+        ref_value = value.detach().clone().requires_grad_()
+        ref_attn_mask = attn_mask.detach().clone().requires_grad_()
+
+        with sdpa_kernel(backends=[SDPBackend.EFFICIENT_ATTENTION]):
+            ref_out = F.scaled_dot_product_attention(ref_query, ref_key, ref_value, ref_attn_mask)
+            ref_out.sum().backward()
+            with torch.autograd.graph.save_on_cpu():
+                out = F.scaled_dot_product_attention(query, key, value, attn_mask)
+        out.sum().backward()
+
+        self.assertEqual(out, ref_out)
+        for actual, expected in (
+            (query.grad, ref_query.grad),
+            (key.grad, ref_key.grad),
+            (value.grad, ref_value.grad),
+            (attn_mask.grad, ref_attn_mask.grad),
+        ):
+            self.assertEqual(actual, expected)
+
     @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Fused SDPA was not built for this system")
     def test_singelton_head_dim_stride_ne_1(self, device):
         query = torch.tensor([[[[1, 2]]]], dtype=torch.float16, device=device)


### PR DESCRIPTION
## Human Note
So we do all the nice alignment checks via sdp utils but it is opossible for users to use atuograd to save to cpu(first time seeing this api tbh). This api asserts all things are the same about saved tensors except strides and view relationships in this case we lose the broadcast type. Instead of trying to make it preserving i think we jsut add an excape hatch that will pad up. This should be a noop in the default case

## Agent Report
# Report: pytorch/pytorch#134995

## Summary

`torch.nn.functional.scaled_dot_product_attention` with the memory-efficient CUDA backend could fail in backward when run under `torch.autograd.graph.save_on_cpu()`. The failure was reproduced with an attention mask whose key sequence length is 361:

```text
RuntimeError: attn_bias is not correctly aligned (strideH) .attn_bias.stride(1) = 361, and should be a multiple of 4.
```

## Root cause

The top-level SDPA memory-efficient path preprocesses explicit masks before forward by padding and slicing the last dimension. That preserves the logical mask shape while creating strides aligned for the memory-efficient attention kernels.

For the repro mask, the preprocessed saved bias has logical shape `(1, 8, 1, 361)` and an aligned expanded layout such as `(368, 0, 368, 1)`. Under `save_on_cpu()`, saved tensor hooks move this tensor through `tensor.cpu()` and later `tensor.to(device)`. A direct probe confirmed this round trip:

```text
original (368, 0, 368, 1)
cpu (2888, 361, 361, 1)
unpacked (2888, 361, 361, 1)
```

For this expanded/sliced view, the CPU round trip materializes a value-equivalent contiguous tensor. The memory-efficient backward wrapper then passed that restored bias directly to `_efficient_attention_backward`, whose CUDA kernel requires aligned batch/head/query bias strides and rejected `stride(1) == 361`.

`save_on_cpu()` only documents value/size/dtype/device preservation for saved tensor hooks, not stride preservation, so the memory-efficient SDPA backward path needs to re-establish its own kernel layout contract.

## Fix

Changed `aten/src/ATen/native/transformers/cuda/attention_backward.cu` so `_scaled_dot_product_efficient_attention_backward_cuda` checks a defined 4D saved `attn_bias` before calling `_efficient_attention_backward`.

If the bias does not satisfy the memory-efficient attention bias layout requirements, backward now creates a temporary aligned logical equivalent with the same pad-then-slice strategy used by forward. The temporary has the same shape and values, but aligned strides, so the existing CUDA backward kernel can run. The repair is dtype-aware: 16-bit biases use 8-element row alignment, while 32-bit biases use 4-element row alignment. Non-4D lower-level bias inputs are left unchanged so existing shape validation reports them.

Added a regression test in `test/test_transformers.py`:

- `TestSDPACudaOnly.test_mem_eff_attention_save_on_cpu_unaligned_bias_stride`

The test forces `SDPBackend.EFFICIENT_ATTENTION`, uses the `361` mask width from the issue, wraps forward in `save_on_cpu()`, and checks output plus gradients against a non-`save_on_cpu` reference.

<details>
<summary>Repro Script</summary>

```python
import torch
import torch.nn.functional as F
from torch.nn.attention import SDPBackend, sdpa_kernel

print("torch", torch.__version__, "cuda", torch.version.cuda, "available", torch.cuda.is_available())
if torch.cuda.is_available():
    print("device", torch.cuda.get_device_name(0))

B, H, Q, K, D = 1, 8, 1, 361, 64
dtype = torch.float16
device = "cuda"

torch.manual_seed(0)
query = torch.randn(B, H, Q, D, device=device, dtype=dtype, requires_grad=True)
key = torch.randn(B, H, K, D, device=device, dtype=dtype, requires_grad=True)
value = torch.randn(B, H, K, D, device=device, dtype=dtype, requires_grad=True)
attn_mask = torch.zeros(B, 1, Q, K, device=device, dtype=dtype)
print("attn_mask shape", tuple(attn_mask.shape), "stride", attn_mask.stride())

with sdpa_kernel(backends=[SDPBackend.EFFICIENT_ATTENTION]):
    with torch.autograd.graph.save_on_cpu():
        out = F.scaled_dot_product_attention(query, key, value, attn_mask=attn_mask, dropout_p=0.0)
    print("out", tuple(out.shape), out.dtype)
    out.sum().backward()
print("backward ok")
```

Output after the fix:

```text
torch 2.14.0a0+git7cfe8e0 cuda 13.1 available True
device NVIDIA GB200
attn_mask shape (1, 1, 1, 361) stride (361, 361, 361, 1)
out (1, 8, 1, 64) torch.float16
backward ok
```

</details>

## Validation

### Behavioral tests

Passed:

```text
/home/drisspg/.ptq_workspace/jobs/20260625-pytorch-134995/.venv/bin/python repro.py
```

Passed:

```text
cd pytorch && /home/drisspg/.ptq_workspace/jobs/20260625-pytorch-134995/.venv/bin/python test/test_transformers.py -v -k test_mem_eff_attention_save_on_cpu_unaligned_bias_stride
```

Result: 1 test run, 1 passed.

Passed nearby mask coverage:

```text
cd pytorch && /home/drisspg/.ptq_workspace/jobs/20260625-pytorch-134995/.venv/bin/python test/test_transformers.py -v -k test_mem_eff_attention_non_contiguous_mask
cd pytorch && /home/drisspg/.ptq_workspace/jobs/20260625-pytorch-134995/.venv/bin/python test/test_transformers.py -v -k test_mem_efficient_attention_mask_variants
```

Result: 2 tests passed for non-contiguous masks, and 4 tests passed for mask variants.

Confirmed the default path is a no-op for the new escape hatch by profiling backward only with non-grad masks across a shape sweep:

```text
no_mask_q1_k361: {}
broadcast_q1_k361: {}
broadcast_q16_k17: {}
mask2d_q16_k17: {}
mask3d_q16_k17: {}
full_q7_k33: {}
full_aligned_q16_k32: {}
bool2d_q16_k17: {}
bf16_broadcast_q16_k17: {}
```

The same shape sweep under `save_on_cpu()` invoked one `aten::pad`/`aten::constant_pad_nd` pair only for cases where the CPU round trip produced an unaligned saved bias; no-mask and already-aligned full-mask cases stayed at `{}`.

A follow-up sweep checked the Codex review case across dtypes. A naive 4-element repair caused CUDA misaligned-address failures for fp16 `K=361` and `K=364`, so the final repair keeps 8-element alignment for fp16/bf16 and uses 4-element alignment for fp32. With the dtype-aware repair:

```text
fp16/bf16 K=364 save_on_cpu: pads once
fp32 K=364 save_on_cpu: no pad
fp16/bf16/fp32 K=361 save_on_cpu: pads once
fp16/bf16/fp32 K=368 save_on_cpu: no pad
```

`CUDA_LAUNCH_BLOCKING=1` checks passed for fp16, bf16, and fp32; `K=361` and `K=364`; and masks with `requires_grad` both false and true. A correctness fuzz over 570 cases covering dtype, key length, mask rank/kind, and mask-gradient on/off passed against a non-`save_on_cpu` reference.

The same dtype-aware edge matrix was also run under the user's `sanitize` helper, which wraps compute-sanitizer. All 12 runs completed with `========= ERROR SUMMARY: 0 errors`:

```text
fp16/bf16/fp32 x K=361/364 x mask_requires_grad=false/true
```

Ran an A/B default-case benchmark by rebuilding the parent implementation, timing the default no-`save_on_cpu` path, then restoring/rebuilding this fix and timing the same harness. CUDA medians from `transformer_nuggets.utils.benchmark.benchmark_cuda_function_in_microseconds` were unchanged within noise:

```text
case                    parent cuda us  fixed cuda us  delta
broadcast_q1_k361              35.406         35.436  +0.09%
broadcast_q16_k17              15.258         15.284  +0.17%
mask2d_q64_k65                 18.701         18.717  +0.08%
full_aligned_q64_k64           11.679         11.674  -0.05%
```

Synchronized wall timings were also not worse in this run, but are noisier because they include Python/autograd overhead.

### Build and prerequisite checks

Rebuilt C++ changes with:

```text
bash /home/drisspg/.ptq_workspace/scripts/rebuild.sh /home/drisspg/.ptq_workspace/jobs/20260625-pytorch-134995/pytorch
```

`spin fixlint` was attempted, but full-repo lint failed on unrelated existing shellcheck findings in `.ci/pytorch/*.sh` and `PermissionError` executing `.lintbin/clang-tidy`. Focused changed-file checks passed:

```text
cd pytorch && /home/drisspg/.ptq_workspace/jobs/20260625-pytorch-134995/.venv/bin/spin quickfix
cd pytorch && /home/drisspg/.ptq_workspace/jobs/20260625-pytorch-134995/.venv/bin/spin quicklint
```

Both completed with `ok No lint issues`.

## Remaining uncertainty

The fix intentionally does not change the broader `save_on_cpu()` layout semantics. It makes memory-efficient SDPA backward robust to value-equivalent saved tensor hooks that do not preserve the aligned bias strides established by forward.


Fixes #134995


<details>
<summary>Repro Script</summary>

```python
import torch
import torch.nn.functional as F
from torch.nn.attention import SDPBackend, sdpa_kernel

print("torch", torch.__version__, "cuda", torch.version.cuda, "available", torch.cuda.is_available())
if torch.cuda.is_available():
    print("device", torch.cuda.get_device_name(0))

B, H, Q, K, D = 1, 8, 1, 361, 64
dtype = torch.float16
device = "cuda"

torch.manual_seed(0)
query = torch.randn(B, H, Q, D, device=device, dtype=dtype, requires_grad=True)
key = torch.randn(B, H, K, D, device=device, dtype=dtype, requires_grad=True)
value = torch.randn(B, H, K, D, device=device, dtype=dtype, requires_grad=True)
attn_mask = torch.zeros(B, 1, Q, K, device=device, dtype=dtype)
print("attn_mask shape", tuple(attn_mask.shape), "stride", attn_mask.stride())

with sdpa_kernel(backends=[SDPBackend.EFFICIENT_ATTENTION]):
    with torch.autograd.graph.save_on_cpu():
        out = F.scaled_dot_product_attention(query, key, value, attn_mask=attn_mask, dropout_p=0.0)
    print("out", tuple(out.shape), out.dtype)
    out.sum().backward()
print("backward ok")
```

</details>


<details>
<summary>Agent Worklog</summary>

## Run 1

### Initial context and environment check
Read prime/PTQ context/system prompt/worklog/repo instructions. No existing `repro.py` was present. The job venv imports PyTorch `2.14.0a0+git2f596e8` with CUDA 13.1, and CUDA is available on an NVIDIA GB200.

### Reproduced SDPA save_on_cpu failure
Created `repro.py` with `query/key/value` shapes `(1, 8, 1, 64)`, `(1, 8, 361, 64)`, `(1, 8, 361, 64)` and a contiguous mask of shape `(1, 1, 1, 361)` under `torch.autograd.graph.save_on_cpu()`. Forward succeeds, but `out.sum().backward()` fails with `RuntimeError: attn_bias is not correctly aligned (strideH) .attn_bias.stride(1) = 361, and should be a multiple of 4.`

### Confirmed save_on_cpu stride compaction
A direct stride probe showed the forward-style aligned view has stride `(368, 0, 368, 1)`, but `tensor.cpu()` compacts it to `(2888, 361, 361, 1)`, and copying back to CUDA preserves the compacted stride. This matches the failing backward stride.

### Added failing regression test
Added `TestSDPACudaOnly.test_mem_eff_attention_save_on_cpu_unaligned_bias_stride` in `pytorch/test/test_transformers.py`. Running `/home/drisspg/.ptq_workspace/jobs/20260625-pytorch-134995/.venv/bin/python test/test_transformers.py -v -k test_mem_eff_attention_save_on_cpu_unaligned_bias_stride` fails before the fix with the same `attn_bias.stride(1) = 361` alignment error.

### Implemented SDPA backward layout fix
Changed `aten/src/ATen/native/transformers/cuda/attention_backward.cu` so `_scaled_dot_product_efficient_attention_backward_cuda` checks the saved 4D bias layout before calling `_efficient_attention_backward`. If saved tensor hooks returned a value-equivalent but stride-unaligned bias, backward now pads and slices the last dimension to re-establish the memory-efficient kernel alignment contract. Non-4D lower-level bias inputs are left unchanged so existing shape checks report them.

### Rebuilt and validated targeted behavior
Rebuilt with `bash ~/.ptq_workspace/scripts/rebuild.sh ~/.ptq_workspace/jobs/20260625-pytorch-134995/pytorch`. After rebuild, `repro.py` passes. The new targeted test passes and compares outputs/gradients against a non-`save_on_cpu` reference. Nearby mem-efficient mask tests `test_mem_eff_attention_non_contiguous_mask` and `test_mem_efficient_attention_mask_variants` also pass. One attempted combined unittest `-k` expression collected zero tests; the tests were rerun individually and passed.

### Confirmed default backward remains no-op
Profiled backward only with non-grad masks to avoid forward pad backward noise. The default no-`save_on_cpu` path showed no `pad` events for no-mask, broadcast, 2D, 3D, full 4D, bool, bf16, aligned, and unaligned key-length cases. The `save_on_cpu` path showed exactly one `aten::pad`/`aten::constant_pad_nd` pair only for cases where the CPU round trip made the saved bias unaligned; no-mask and already-aligned full-mask cases still showed no pad events.

### Checked default performance against parent
Temporarily restored the parent versions of `attention_backward.cu` and `test_transformers.py`, rebuilt, and benchmarked default no-`save_on_cpu` SDPA with `transformer_nuggets.utils.benchmark.benchmark_cuda_function_in_microseconds`. Then restored this fix, rebuilt, and reran the same harness. CUDA medians were unchanged within noise: `broadcast_q1_k361` +0.09%, `broadcast_q16_k17` +0.17%, `mask2d_q64_k65` +0.08%, and `full_aligned_q64_k64` -0.05%. Synchronized wall timings were not worse in this run but are noisier due to Python/autograd overhead.

### Fetched and tested Codex review comment
Fetched the Codex inline PR comment on `attention_backward.cu`: it points out the backward repair check is hard-coded to 8 while the CUDA backward kernel reports `kMinimumAlignment` 4 on common paths. A naive change from 8 to 4 rebuilt successfully but failed under `CUDA_LAUNCH_BLOCKING=1` with CUDA misaligned-address for fp16 `K=361` and `K=364`, both with and without mask gradients. Float32 works with 4. Updated the repair to be dtype-aware instead: 8 elements for 16-bit bias and 4 elements for 32-bit bias.

### Validated dtype-aware alignment
After rebuilding the dtype-aware repair, `CUDA_LAUNCH_BLOCKING=1` checks passed for fp16, bf16, and fp32; `K=361` and `K=364`; and masks with `requires_grad` both false and true. Profiling showed fp16/bf16 `K=364` still pads under `save_on_cpu` (needed to avoid the misaligned-address failure), while fp32 `K=364` no longer pads. A correctness fuzz over 570 cases covering dtypes, key lengths, mask ranks/kinds, and mask-gradient on/off passed against a non-`save_on_cpu` reference.

### Compute-sanitizer confirmation
Ran the user's `sanitize` zsh helper on the dtype-aware edge-case matrix: fp16, bf16, fp32; `K=361` and `K=364`; mask `requires_grad` false and true. All 12 runs completed with `========= ERROR SUMMARY: 0 errors`; the mask-gradient cases produced the expected `(1, 1, 1, K)` mask gradients.

### Lint status
`spin fixlint` was attempted as required, but the full-repo lint failed on pre-existing/unrelated shellcheck findings in `.ci/pytorch/*.sh` and `PermissionError` executing `.lintbin/clang-tidy`. Focused changed-file linting with `spin quickfix` and `spin quicklint` completed with `ok No lint issues`; `spin quickfix`/`spin quicklint` were rerun after the dtype-aware follow-up and still passed.

</details>

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*

cc @liangel-02 @howardzhang-cv