### PR TITLE
Align softmax path for half_to_float

### DIFF
--- a/aten/src/ATen/native/cuda/PersistentSoftmax.cuh
+++ b/aten/src/ATen/native/cuda/PersistentSoftmax.cuh
@@ -44,7 +44,7 @@ __device__ __forceinline__ void warp_reduce(acc_t* sum) {
 }
 
 // The softmax_warp_* methods perform softmax forward and backward propagation on samples spanning the fast dimension.
-// Each sample contains element_count scalar elements. element_count can be any integer value <= 1024.
+// Each sample contains element_count scalar elements. Forward supports values up to 2048; backward supports values up to 1024.
 // The template arguments have the following meaning:
 // One "WARP" works on one "BATCH". One "BATCH" contains "WARP_BATCH" samples.
 // WARP_BATCH is equal to 1 when element_count is large, and > 1 when element_count is small.

--- a/aten/src/ATen/native/cuda/SoftMax.cu
+++ b/aten/src/ATen/native/cuda/SoftMax.cu
@@ -1185,7 +1185,7 @@ Tensor host_softmax(const Tensor & input_, const int64_t dim_, const bool half_t
         } else {
           auto output_ptr = output.mutable_data_ptr<accscalar_t>();
           auto input_ptr = input.const_data_ptr<scalar_t>();
-          if (dim_size <= 1024 && dim_size*sizeof(scalar_t) <= 4096) {
+          if (dim_size <= 2048 && dim_size*sizeof(scalar_t) <= 8192) {
             int64_t remaining = outer_size;
             int64_t chunk_size = (1<<30) / dim_size;
             while(remaining > 0) {

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11757,6 +11757,15 @@ class TestNNDeviceType(NNTestCase):
                         self.assertEqual(input.grad, ref_input.grad)
 
     @onlyCUDA
+    @dtypes(torch.half)
+    def test_softmax_half_to_float_matches_half(self, device, dtype):
+        input = torch.randn((4, 1025), generator=torch.Generator().manual_seed(10), dtype=torch.float32)
+        input = (input * 4).to(device=device, dtype=dtype)
+        expected = F.softmax(input, dim=-1)
+        actual = F.softmax(input, dim=-1, dtype=torch.float32).to(dtype)
+        self.assertEqual(actual, expected, atol=0, rtol=0)
+
+    @onlyCUDA
     @dtypes(torch.float, torch.half)
     @largeTensorTest("20GB")
     @largeTensorTest("64GB", "cpu")


### PR DESCRIPTION
## Human Note
Okay this one is pretty interesting. I was going through old issues and noticed this one. Felt like a good one for codex. Turns out that at certain sizes what shoudl be 
equivalent invocations of softmax with float16 vs float16 | out_dtype=32 were not for certain sizes. We/I think they should be the same since scalar_t in teh kernel and 
intermediaries will be upcast. Turns out that they half_to_float path is getting routed to a differnet implemnation for ceratins sizes e.g. [1024, 2048] and from doing some code
crawls this does not look intentinoal. As well perf is generally better and so is correctenss is kept. Seems like an overall win win win

## Agent Report
# Report: pytorch/pytorch#123911

## PR topline

This fixes a stale CUDA softmax dispatch threshold for fp16 input with `dtype=torch.float32`. The persistent softmax kernel originally supported only up to 1024 elements, but forward support was later expanded to 2048 in `1e32842324c` (`Improve softmax's perf in cuda (#144679)`). That commit updated the normal fp16-output caller but left the `half_to_float` caller at the old 1024 cutoff. As a result, for dimensions like 1238, `torch.softmax(x_half)` and `torch.softmax(x_half, dtype=torch.float32).to(torch.float16)` used different reduction kernels and produced small fp16 rounding differences.

The fix makes the forward `half_to_float` caller use the same supported persistent range as the normal fp16 caller (`<=2048` and `<=8192` input bytes). This is supported by the persistent forward dispatcher and by the original kernel contract, which explicitly documents `input_t=half, acc_t=float, output_t=float`. Backward is intentionally unchanged because the persistent backward dispatcher still only instantiates through 1024.

Transformer-nuggets benchmarking on GB200 shows the fixed path is also faster around the issue size:

| N | old `<=1024` threshold | fixed `<=2048` threshold | result |
|---:|---:|---:|---:|
| 1024 | 15.488 us | 15.456 us | same path / unchanged |
| 1025 | 45.056 us | 27.328 us | 1.65x faster |
| 1238 | 49.152 us | 29.664 us | 1.66x faster |
| 1536 | 38.912 us | 33.760 us | 1.15x faster |
| 2048 | 38.912 us | 41.696 us | 0.93x, persistent slightly slower |

## Summary

Fixed the CUDA fp16 softmax dtype-upcast path so that:

```python
torch.softmax(x, dim=-1, dtype=torch.float32).to(torch.float16)
```

matches:

```python
torch.softmax(x, dim=-1)
```

for fp16 CUDA inputs with softmax dimension sizes in the persistent-kernel range above 1024 and up to 2048.

## Root cause

`torch.softmax(half_cuda_input, dtype=torch.float32)` is routed through the CUDA `half_to_float` softmax path. For last-dimension softmax, the normal fp16 forward path used the persistent warp softmax kernel up to `dim_size <= 2048`, but the `half_to_float` path only used it up to `dim_size <= 1024`.

For the issue shape with `dim_size == 1238`, this meant:

- `torch.softmax(x, dim=-1)` used `softmax_warp_forward<c10::Half, c10::Half, float, 11, ...>`.
- `torch.softmax(x, dim=-1, dtype=torch.float32)` used generic `cunn_SoftMaxForward<..., c10::Half, float, float, ...>`.

Those kernels reduce in different orders, producing small fp16 rounding differences after casting the float output back to fp16.

## Why the old float-output cutoff was stale

The 1024 cutoff came from the original persistent softmax commit:

```text
e098878d751 Cuda persistent softmax (#20827)
```

At that point the persistent forward and backward dispatchers both only supported 1024 elements. The original kernel comments already documented the float-output case:

```text
input_t=half, acc_t=float, output_t=float => read half tensor, float accumulators, write float tensor.
```

Later, forward support was expanded:

```text
1e32842324c Improve softmax's perf in cuda (#144679)
```

That commit changed the forward dispatcher assert to `softmax_elements <= 2048` and added the `LAUNCH_SOFTMAX_WARP_FORWARD(11)` instantiation for 2048, but only updated the normal fp16-output caller threshold. The `half_to_float` caller kept the old `<=1024` gate. I did not find evidence that this was because fp32 output cannot use the persistent forward kernel; the dispatcher supports it, the template supports it, and the issue-sized benchmark improves with it.

Backward is different: the persistent backward dispatcher still asserts `softmax_elements <= 1024` and only instantiates through `LAUNCH_SOFTMAX_WARP_BACKWARD(10)`, so this patch deliberately leaves backward thresholds unchanged.

## Fix

- Updated `aten/src/ATen/native/cuda/SoftMax.cu` so the forward `half_to_float` path uses the persistent warp softmax kernel for the same supported size range as the normal fp16 forward path: `dim_size <= 2048 && dim_size * sizeof(scalar_t) <= 8192`.
- Updated the stale persistent softmax comment in `PersistentSoftmax.cuh` to note that forward supports up to 2048 while backward supports up to 1024.
- Added a CUDA fp16 regression test in `test/test_nn.py` that fails under the old threshold with an exact mismatch of `0.00048828125` and passes with the fix.

## Repro Script

<details>
<summary>Repro Script</summary>

```python
import math
import torch

query = torch.load("query_states_sdpa_3.pt")
key = torch.load("key_states_sdpa_3.pt")
scale_factor = math.sqrt(1 / math.sqrt(query.size(-1)))

with torch.no_grad():
    softmax_inp = (query * scale_factor) @ ((key * scale_factor).transpose(-2, -1))
    res_softmax_0 = torch.softmax(softmax_inp, dim=-1)
    res_softmax_1 = torch.softmax(softmax_inp, dim=-1, dtype=torch.float32).to(torch.float16)
    diff = (res_softmax_0 - res_softmax_1).abs()
    print("max absdiff", diff.max())
    print("count > 0", (diff > 0).sum())
    print("count > 1e-4", (diff > 1e-4).sum())
```

Pre-fix output:

```text
max absdiff tensor(0.0005, device='cuda:0', dtype=torch.float16)
count > 0 tensor(3132, device='cuda:0')
count > 1e-4 tensor(12, device='cuda:0')
```

Post-fix output:

```text
max absdiff tensor(0., device='cuda:0', dtype=torch.float16)
count > 0 tensor(0, device='cuda:0')
count > 1e-4 tensor(0, device='cuda:0')
```

</details>

## Validation

### Build / prerequisite checks

- Rebuilt PyTorch after the CUDA change:

```bash
bash /home/drisspg/.ptq_workspace/scripts/rebuild.sh /home/drisspg/.ptq_workspace/jobs/20260625-pytorch-123911/pytorch
```

- `git diff --check` passed.
- `spin fixlint` was run as requested by the PTQ instructions, but failed on unrelated pre-existing lint issues in files not touched by this patch, including `.ci/pytorch/test.sh`, `torch/headeronly/util/Half.h`, and `torch/headeronly/util/complex.h`.

### Tests

- Verified the new regression fails before the fix:

```bash
cd /home/drisspg/.ptq_workspace/jobs/20260625-pytorch-123911/pytorch && /home/drisspg/.ptq_workspace/jobs/20260625-pytorch-123911/.venv/bin/python test/test_nn.py TestNNDeviceTypeCUDA.test_softmax_half_to_float_matches_half_cuda_float16
```

Pre-fix result: failed with greatest absolute difference `0.00048828125`.

- Verified the new regression passes after the fix:

```bash
cd /home/drisspg/.ptq_workspace/jobs/20260625-pytorch-123911/pytorch && /home/drisspg/.ptq_workspace/jobs/20260625-pytorch-123911/.venv/bin/python test/test_nn.py TestNNDeviceTypeCUDA.test_softmax_half_to_float_matches_half_cuda_float16
```

Post-fix result: `OK`.

- Ran the broader existing CUDA half softmax test:

```bash
cd /home/drisspg/.ptq_workspace/jobs/20260625-pytorch-123911/pytorch && /home/drisspg/.ptq_workspace/jobs/20260625-pytorch-123911/.venv/bin/python test/test_nn.py TestNNDeviceTypeCUDA.test_softmax_results_cuda_float16
```

Result: `OK`.

### Transformer-nuggets benchmark check

With user permission, used the local checkout at `/home/drisspg/meta/transformer_nuggets` and `benchmark_cuda_function_stats` to compare the old `<=1024` threshold with the fixed `<=2048` threshold for `torch.softmax(x, dim=-1, dtype=torch.float32)`.

Measurement contract: GB200, CUDA 13.1, `torch==2.14.0a0+git2f596e8`, shape `(4096, N)`, fp16 input, fp32 output, 50 memory warmup iterations, 200 measured iterations, median of samples in microseconds.

| N | old threshold median us | fixed threshold median us | result |
|---:|---:|---:|---:|
| 1024 | 15.488 | 15.456 | same path / unchanged |
| 1025 | 45.056 | 27.328 | 1.65x faster |
| 1238 | 49.152 | 29.664 | 1.66x faster |
| 1536 | 38.912 | 33.760 | 1.15x faster |
| 2048 | 38.912 | 41.696 | 0.93x, persistent slightly slower |

The benchmark supports that the old `1024` cutoff was not clearly an output-float resource requirement: for the issue-sized range around 1238, the fixed persistent path is both numerically aligned and faster. The 2048 endpoint is slightly slower for fp32 output on this GB200 measurement, so this is not a universal performance win at every size.

<details>
<summary>Fixed threshold benchmark log</summary>

```text
torch 2.14.0a0+git2f596e8
device NVIDIA GB200
contract shape=(4096, N) input=float16 output=float32 op=torch.softmax(x, dim=-1, dtype=torch.float32) NUM_ITERS=200 MEMORY_WARMUP_ITERS=50
N=1024 median_us=15.456 p05_us=14.432 p95_us=15.520 ci95_us=(15.456,15.456)
N=1025 median_us=27.328 p05_us=25.376 p95_us=27.712 ci95_us=(26.864,27.328)
N=1238 median_us=29.664 p05_us=28.672 p95_us=29.728 ci95_us=(29.664,29.696)
N=1536 median_us=33.760 p05_us=33.378 p95_us=33.824 ci95_us=(33.728,33.760)
N=2048 median_us=41.696 p05_us=41.362 p95_us=42.082 ci95_us=(41.696,41.696)
```

</details>

<details>
<summary>Old threshold benchmark log</summary>

```text
torch 2.14.0a0+git2f596e8
device NVIDIA GB200
contract shape=(4096, N) input=float16 output=float32 op=torch.softmax(x, dim=-1, dtype=torch.float32) NUM_ITERS=200 MEMORY_WARMUP_ITERS=50
N=1024 median_us=15.488 p05_us=15.038 p95_us=15.552 ci95_us=(15.488,15.488)
N=1025 median_us=45.056 p05_us=43.264 p95_us=45.110 ci95_us=(45.040,45.056)
N=1238 median_us=49.152 p05_us=47.392 p95_us=49.184 ci95_us=(49.152,49.184)
N=1536 median_us=38.912 p05_us=37.216 p95_us=39.619 ci95_us=(38.912,38.912)
N=2048 median_us=38.912 p05_us=38.912 p95_us=39.936 ci95_us=(38.912,38.912)
```

</details>

## Remaining notes

The full issue script still reports SDPA-vs-eager output differences on this current checkout, but after the fix the eager cast and eager no-cast paths are bitwise equal. The remaining SDPA delta is independent of the dtype-cast softmax mismatch fixed here.


Fixes #123911


<details>
<summary>Repro Script</summary>

```python
import torch
import math

query = torch.load("query_states_sdpa_3.pt")
key = torch.load("key_states_sdpa_3.pt")
value = torch.load("value_states_sdpa_3.pt")

print("query", query.device, query.dtype, query.is_contiguous(), query.shape)
print("key", key.device, key.dtype, key.is_contiguous(), key.shape)
print("value", value.device, value.dtype, value.is_contiguous(), value.shape)

torch.set_printoptions(threshold=1000000, precision=6)

def scaled_dot_product_attention(query, key, value, is_causal: bool, custom_cast: bool):
    scale_factor = math.sqrt(1 / math.sqrt(query.size(-1)))
    assert not is_causal

    softmax_inp = ((query * scale_factor) @ ((key * scale_factor).transpose(-2, -1)))

    if custom_cast:
        attn_weight = torch.softmax(
            softmax_inp,
            dim=-1,
            dtype=torch.float32
        ).to(query.dtype)
    else:
        attn_weight = torch.softmax(softmax_inp, dim=-1)

    return attn_weight @ value, softmax_inp

is_causal = False

with torch.no_grad():
    with torch.backends.cuda.sdp_kernel(enable_flash=False, enable_math=True, enable_mem_efficient=False):
        res_sdpa = torch.nn.functional.scaled_dot_product_attention(query, key, value, is_causal=is_causal, attn_mask=None)

        res_eager_cast, softmax_inp = scaled_dot_product_attention(query, key, value, is_causal=is_causal, custom_cast=True)

        res_eager_no_cast, _ = scaled_dot_product_attention(query, key, value, is_causal=is_causal, custom_cast=False)

res_softmax_0 = torch.softmax(softmax_inp, dim=-1)
res_softmax_1 = torch.softmax(softmax_inp, dim=-1, dtype=torch.float32).to(torch.float16)

print("-----")

absdiff = (res_softmax_0 - res_softmax_1).abs()
print("max absdiff softmax", absdiff.max())
print("median absdiff softmax", absdiff.median())

print("-----")

# These cast do not seem to matter.
res_sdpa = res_sdpa.to(torch.float32)
res_eager_cast = res_eager_cast.to(torch.float32)
res_eager_no_cast = res_eager_no_cast.to(torch.float32)

absdiff_nocast = (res_sdpa - res_eager_no_cast).abs()
absdiff_cast = (res_sdpa - res_eager_cast).abs()
print("SDPA max absdiff (no cast):", absdiff_nocast.max())
print("SDPA max absdiff (with cast):", absdiff_cast.max())
print("argwhere absdiff no cast > 0.0001", torch.argwhere(absdiff_nocast > 1e-4))
print("argwhere absdiff with cast > 0.0001", torch.argwhere(absdiff_cast > 1e-4))
```

</details>


<details>
<summary>Agent Worklog</summary>

## Run 1

### Loaded handoff context
Read prime/PTQ context, issue prompt, repo AGENTS, and checked the source worktree state. The PyTorch checkout is clean at `2f596e89442` on detached `HEAD`.

### Initial repro attempt
Ran the provided `repro.py` with the job venv from the job directory. It failed before exercising softmax because the issue tensor files (`query_states_sdpa_3.pt`, `key_states_sdpa_3.pt`, `value_states_sdpa_3.pt`) are not present in the job directory.

### Downloaded tensors and reproduced
Downloaded the three issue tensors from the Hugging Face link into the job directory. The full repro now runs and shows the reported softmax mismatch. A compact run reported `max absdiff softmax tensor(0.0005, dtype=torch.float16)`, `count absdiff > 0` of 3132, and `count absdiff > 1e-4` of 12 for the `[1, 32, 1238, 1238]` softmax input.

### Source path investigation
Traced `torch.softmax(half_cuda, dtype=torch.float32)` through `aten/src/ATen/native/SoftMax.cpp` to the CUDA `half_to_float` path. For dim size 1238, normal fp16 softmax uses the persistent warp softmax forward path, while `half_to_float` falls through to the generic CUDA softmax path because its persistent-kernel threshold is still `<=1024`/4096 bytes. The persistent forward dispatcher supports up to 2048 and documents half input with float output, so the likely fix is to align the forward half-to-float threshold with the non-half-to-float threshold.

### Implemented and rebuilt
Changed the CUDA forward `half_to_float` softmax threshold to match the normal fp16 forward threshold (`<=2048` and `<=8192` input bytes) and updated the persistent softmax comment to distinguish forward and backward limits. Rebuilt PyTorch with the PTQ rebuild script after an interrupted foreground rebuild; the final rebuild completed successfully.

### Regression test and validation
Added `TestNNDeviceTypeCUDA.test_softmax_half_to_float_matches_half_cuda_float16`, using a deterministic `(4, 1025)` fp16 CUDA input that failed under the old threshold with max difference `0.00048828125`. With the fix, the new test passes, `test_softmax_results_cuda_float16` passes, and the issue softmax input reports zero softmax differences. The full issue script still reports SDPA-vs-eager differences on this current checkout, but eager cast vs eager no-cast is now bitwise equal; that remaining SDPA delta is independent of the dtype-cast softmax path fixed here.

### Transformer-nuggets benchmark
With user permission, used `/home/drisspg/meta/transformer_nuggets` via a direct local import and installed the missing `rich` dependency into the job venv. Benchmarked `torch.softmax(x, dim=-1, dtype=torch.float32)` with `transformer_nuggets.utils.benchmark.benchmark_cuda_function_stats` on GB200, shape `(4096, N)`, fp16 input, fp32 output, 50 warmup iterations, and 200 measured iterations. Old vs fixed median microseconds: N=1024 15.488 vs 15.456, N=1025 45.056 vs 27.328, N=1238 49.152 vs 29.664, N=1536 38.912 vs 33.760, N=2048 38.912 vs 41.696. Restored the source to the fixed `<=2048` threshold and rebuilt afterward; the new regression test passes again.

### Checked why the float-output path stopped at 1024
Inspected git history for the CUDA softmax thresholds. Persistent softmax was introduced in `e098878d751` with a real `<=1024` forward/backward limit and comments documenting support for `input_t=half, acc_t=float, output_t=float`. Later commit `1e32842324c` expanded the forward dispatcher itself to `<=2048` and added `LAUNCH_SOFTMAX_WARP_FORWARD(11)`, but only updated the non-`half_to_float` caller threshold. The `half_to_float` caller appears to have kept the old `<=1024` gate by omission rather than because the forward kernel cannot handle float output. Backward still only instantiates through 1024, so the patch intentionally leaves backward thresholds unchanged.

</details>

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*

cc @ptrblck @msaroufim @eqy @tinglvv @nWEIdia