### PR TITLE
[xpu] Refine frequency handle for clock_rate via pyzes 0.1.2

### DIFF
--- a/torch/xpu/__init__.py
+++ b/torch/xpu/__init__.py
@@ -927,6 +927,7 @@ def _get_zes_frequency_handle(device: Device = None) -> c_void_p:
         return info.frequency_handle
 
     device_handle = info.device_handle
+    subdevice_id = info.subdevice_id
 
     # Enumerate all frequency domains under this device handle.
     freq_count = c_uint32(0)
@@ -944,10 +945,32 @@ def _get_zes_frequency_handle(device: Device = None) -> c_void_p:
         "Can't get Level Zero Sysman frequency domain handles.",
     )
 
-    # TODO: pyzes lacks zesFrequencyGetProperties, so we cannot filter by
-    # subdevice or domain type. We assume index 0 (ZES_FREQ_DOMAIN_GPU)
-    # is the GPU frequency domain.
-    frequency_handle = freq_handles[0]
+    if _get_pyzes_version() < (0, 1, 2):
+        frequency_handle = freq_handles[0]
+        info.frequency_handle = frequency_handle
+        return frequency_handle
+
+    frequency_handle = None
+    for freq_handle in freq_handles:
+        freq_props = pyzes.zes_freq_properties_t()
+        freq_props.stype = pyzes.ZES_STRUCTURE_TYPE_FREQ_PROPERTIES
+        _zes_check(
+            pyzes.zesFrequencyGetProperties(freq_handle, byref(freq_props)),
+            "Can't get Level Zero Sysman frequency properties.",
+        )
+        if freq_props.type != pyzes.ZES_FREQ_DOMAIN_GPU:
+            continue
+        if subdevice_id is not None:
+            if freq_props.onSubdevice and freq_props.subdeviceId == subdevice_id:
+                frequency_handle = freq_handle
+                break
+        else:
+            if not freq_props.onSubdevice:
+                frequency_handle = freq_handle
+                break
+
+    if frequency_handle is None:
+        raise RuntimeError("No Level Zero Sysman GPU frequency handle found.")
     info.frequency_handle = frequency_handle
     return frequency_handle
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #188256
* __->__ #188248

# Motivation
This PR aims to refine the frequency handle explicitly via `zesFrequencyGetProperties` that is added in pyzes 0.1.2. And we have to keep compatible with pyzes 0.1.1 for at least 1 PyTorch release version. Plan to drop the 0.11 support when PyTorch 2.15
