### PR TITLE
[inductor] Fix bool equality value range analysis

### DIFF
--- a/test/test_sympy_utils.py
+++ b/test/test_sympy_utils.py
@@ -365,6 +365,43 @@ class TestValueRanges(TestCase):
                 else:
                     self.assertEqual(len(unique), 2)
 
+    @parametrize("fn", ("eq", "ne"))
+    def test_bool_compare_ref_range(self, fn):
+        vals = [sympy.false, sympy.true]
+        for a, b in itertools.product(generate_range(vals), repeat=2):
+            with self.subTest(a=a, b=b):
+                ref_r = getattr(ValueRangeAnalysis, fn)(a, b)
+                unique = set()
+                for a0, b0 in itertools.product(vals, repeat=2):
+                    if a0 not in a or b0 not in b:
+                        continue
+                    with self.subTest(a0=a0, b0=b0):
+                        if fn == "eq":
+                            r = sympy.true if a0 == b0 else sympy.false
+                        else:
+                            r = sympy.true if a0 != b0 else sympy.false
+                        self.assertIn(r, ref_r)
+                        unique.add(r)
+                if ref_r.lower == ref_r.upper:
+                    self.assertEqual(len(unique), 1)
+                else:
+                    self.assertEqual(len(unique), 2)
+
+    def test_bool_compare_non_bool_range(self):
+        for a, b in (
+            (ValueRanges.unknown_bool(), ValueRanges(0, 1)),
+            (ValueRanges(0, 1), ValueRanges.unknown_bool()),
+        ):
+            with self.subTest(a=a, b=b):
+                self.assertEqual(
+                    ValueRangeAnalysis.eq(a, b),
+                    ValueRanges.wrap(sympy.false),
+                )
+                self.assertEqual(
+                    ValueRangeAnalysis.ne(a, b),
+                    ValueRanges.wrap(sympy.true),
+                )
+
     @parametrize("fn", UNARY_OPS)
     def test_unary_ref_range(self, fn):
         # TODO: bring back sympy.oo testing for float unary fns

--- a/torch/utils/_sympy/value_ranges.py
+++ b/torch/utils/_sympy/value_ranges.py
@@ -605,6 +605,14 @@ class SymPyValueRangeAnalysis:
     def eq(a, b):
         a = ValueRanges.wrap(a)
         b = ValueRanges.wrap(b)
+        if a.is_bool or b.is_bool:
+            if a.is_bool != b.is_bool:
+                return ValueRanges.wrap(sympy.false)
+            if a.is_singleton() and b.is_singleton():
+                return ValueRanges.wrap(
+                    sympy.true if a.lower == b.lower else sympy.false
+                )
+            return ValueRanges(sympy.false, sympy.true)
         if a.is_singleton() and b.is_singleton() and a.lower == b.lower:
             return ValueRanges.wrap(sympy.true)
         elif a.lower > b.upper or b.lower > a.upper:  # ranges disjoint


### PR DESCRIPTION
Inductor C++ codegen asks bounds analysis to interpret lowered loop bodies before emitting kernels. The torch.isclose reference path starts by comparing its inputs with eq, and bool tensor inputs can therefore reach ValueRanges.eq as boolean ranges. ValueRanges.eq only handled the numeric interval case, so it tried to prove disjointness with ordered comparisons like a.lower > b.upper. SymPy rejects ordered relationals on boolean atoms, which produced the reported TypeError during CPP codegen.

Handle boolean operands in ValueRanges.eq before the numeric disjointness check. Bool/non-bool ranges are conservatively unequal, singleton bool ranges are resolved directly, disjoint bool singleton ranges return false, and overlapping bool ranges return the unknown bool range. This keeps boolean ranges out of ordered SymPy relationals while preserving the existing numeric path.

Fix: #188231

Test Plan:

python test/test_sympy_utils.py -k bool_compare -v
python test/test_sympy_utils.py TestValueRanges -v
lintrunner -a

All tests passed locally.

Authored with assistance from Codex.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01