### PR TITLE
[ROCm] Fix round-robin counter reset in initSingleStream under GPUTrace

### DIFF
--- a/c10/cuda/CUDAStream.cpp
+++ b/c10/cuda/CUDAStream.cpp
@@ -208,7 +208,6 @@ void initSingleStream(int p, DeviceIndex device_index, int i) {
   if (C10_UNLIKELY(interp)) {
     (*interp)->trace_gpu_stream_creation(
         c10::kCUDA, reinterpret_cast<uintptr_t>(stream));
-    priority_counters[p][device_index] = 0;
   }
 }
 

--- a/test/test_cuda_trace.py
+++ b/test/test_cuda_trace.py
@@ -86,6 +86,12 @@ class TestCudaTrace(TestCase):
 
         self.mock.assert_called()
 
+    def test_stream_pool_round_robin(self):
+        # Under an active trace, lazy init used to reset the round-robin
+        # counter on each stream's first touch, see Note [HIP Lazy Streams].
+        handles = [torch.cuda.Stream().cuda_stream for _ in range(3)]
+        self.assertEqual(len(set(handles)), len(handles))
+
     def test_device_synchronization_callback(self):
         gpu_trace.register_callback_for_device_synchronization(self.mock)
 


### PR DESCRIPTION
Lazily creating a stream reset priority_counters to 0, so later getStreamFromPool calls re-issued low indices and returned the same hipStream_t, defeating the pool's round-robin guarantee. The reset is a no-op on CUDA (eager init finishes before get_idx) and unrelated to the trace call above it; it only bites under the GPU trace on ROCm, introduced by the lazy-stream refactor in #119996.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang