### PR TITLE
[dynamo/bench] Fix --profile-details JSON serialization error and add XPU profiler support

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -4678,15 +4678,20 @@ def run(runner, args, original_dir=None):
     args.profile_details = {}
     if args.export_profiler_trace:
         if should_profile_details:
+            device_activity = {
+                "cuda": torch.profiler.ProfilerActivity.CUDA,
+                "xpu": torch.profiler.ProfilerActivity.XPU,
+            }
+            activities = [torch.profiler.ProfilerActivity.CPU]
+            for dev in args.devices:
+                if dev in device_activity:
+                    activities.append(device_activity[dev])
             args.profile_details = {
                 "record_shapes": True,
                 "profile_memory": True,
                 "with_stack": True,
                 "with_modules": True,
-                "activities": [
-                    torch.profiler.ProfilerActivity.CPU,
-                    torch.profiler.ProfilerActivity.CUDA,
-                ],
+                "activities": activities,
             }
 
         if args.profiler_trace_name is None:

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -464,6 +464,7 @@ def output_signpost(data, args, suite, error=None):
         "disable_output",
         "export_profiler_trace",
         "profiler_trace_name",
+        "profile_details",
         "explain",
         "stats",
         "print_memory",

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -423,7 +423,7 @@ def output_json(filename, headers, row):
                     "benchmark_values": [value],
                 }
 
-            print(json.dumps(record), file=f)
+            print(json.dumps(record, default=str), file=f)
 
 
 def get_suite_from_model_iter_fn(model_iter_fn):


### PR DESCRIPTION
Running --export-profiler-trace --profile-details crashes with:
```
python benchmarks/dynamo/timm_models.py     --float16 --training     --performance     -d xpu     -n 10     --cold-start-latency     --timeout 10800     --disable-cudagraphs     --export-profiler-trace     --profile-details     --only ese_vovnet19b_dw     --backend=eager 
loading model: 0it [00:06, ?it/s]
xpu  train ese_vovnet19b_dw                   
running benchmark: 100%|██████████████████████████████████████████| 10/10 [00:04<00:00,  2.39it/s]
USDT:2026-06-26 15:55:48 2395:2395 ActivityProfilerController.cpp:415] profiler_start
USDT:2026-06-26 15:55:48 2395:2395 ActivityProfilerController.cpp:455] profiler_stop
Traceback (most recent call last):
  File "/data/pytorch/benchmarks/dynamo/timm_models.py", line 384, in <module>
    timm_main()
  File "/data/pytorch/benchmarks/dynamo/timm_models.py", line 380, in timm_main
    main(TimmRunner())
  File "/data/pytorch/benchmarks/dynamo/common.py", line 4026, in main
    process_entry(0, runner, original_dir, args)
  File "/data/pytorch/benchmarks/dynamo/common.py", line 3948, in process_entry
    result = run(runner, args, original_dir)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/pytorch/benchmarks/dynamo/common.py", line 4905, in run
    runner.run_one_model(
  File "/data/pytorch/benchmarks/dynamo/common.py", line 3226, in run_one_model
    status = self.run_performance_test(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/pytorch/benchmarks/dynamo/common.py", line 3128, in run_performance_test
    experiment(
  File "/data/pytorch/benchmarks/dynamo/common.py", line 1228, in speedup_experiment
    write_outputs(
  File "/data/pytorch/benchmarks/dynamo/common.py", line 341, in write_outputs
    output_json(filename, headers, row)
  File "/data/pytorch/benchmarks/dynamo/common.py", line 426, in output_json
    print(json.dumps(record), file=f)
          ^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/encoder.py", line 200, in encode
    chunks = self.iterencode(o, _one_shot=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/encoder.py", line 258, in iterencode
    return _iterencode(o, 0)
           ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/encoder.py", line 180, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type ProfilerActivity is not JSON serializable
```
Root cause: args.profile_details contains ProfilerActivity enum values for the profiler. output_signpost() serializes the full vars(args) to JSON, and ProfilerActivity enums are not JSON-serializable. Additionally, the profiler activities were hardcoded to CPU + CUDA, which is incorrect for XPU devices.

Add "profile_details" to the exclusion list in output_signpost(), alongside the already-excluded "export_profiler_trace" and "profiler_trace_name".
Dynamically select profiler activities based on args.devices instead of hardcoding CUDA, so --profile-details -d xpu correctly uses ProfilerActivity.XPU.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98