### PR TITLE
[xpu] Refine power handle for power_draw via pyzes 0.1.2

### DIFF
--- a/torch/xpu/__init__.py
+++ b/torch/xpu/__init__.py
@@ -1050,16 +1050,21 @@ def _get_zes_power_handle(device: Device = None) -> c_void_p:
             pyzes.zesPowerGetProperties(pwr_handle, byref(pwr_props)),
             "Can't get Level Zero Sysman power properties.",
         )
-        if ext_pwr_props.domain != pyzes.ZES_POWER_DOMAIN_CARD:
+        if ext_pwr_props.domain not in (
+            pyzes.ZES_POWER_DOMAIN_CARD,
+            pyzes.ZES_POWER_DOMAIN_PACKAGE,
+        ):
             continue
         if subdevice_id is not None:
             if pwr_props.onSubdevice and pwr_props.subdeviceId == subdevice_id:
                 power_handle = pwr_handle
-                break
+                if ext_pwr_props.domain == pyzes.ZES_POWER_DOMAIN_CARD:
+                    break
         else:
             if not pwr_props.onSubdevice:
                 power_handle = pwr_handle
-                break
+                if ext_pwr_props.domain == pyzes.ZES_POWER_DOMAIN_CARD:
+                    break
 
     if power_handle is None:
         raise RuntimeError("No Level Zero Sysman GPU power handle found.")
@@ -1083,7 +1088,8 @@ def power_draw(device: Device = None) -> float:
 
     .. note:: This API may require elevated privileges (e.g. ``sudo``) to access GPU power information.
 
-    .. note:: This API is currently only supported on Intel Xe2 and newer GPUs.
+    .. note:: On Intel Xe2 and newer GPUs, card-level power is reported directly. On older GPUs,
+        package-level power is used as a fallback and may not reflect the full card power draw.
     """
     power_handle = _get_zes_power_handle(device)
 

--- a/torch/xpu/__init__.py
+++ b/torch/xpu/__init__.py
@@ -1016,6 +1016,7 @@ def _get_zes_power_handle(device: Device = None) -> c_void_p:
         return info.power_handle
 
     device_handle = info.device_handle
+    subdevice_id = info.subdevice_id
 
     # Enumerate all power domains under this device handle.
     power_count = c_uint32(0)
@@ -1033,10 +1034,32 @@ def _get_zes_power_handle(device: Device = None) -> c_void_p:
         "Can't get Level Zero Sysman power domain handles.",
     )
 
-    # TODO: pyzes lacks zesPowerGetProperties, so we cannot filter by
-    # subdevice or domain type. We assume index 0 (ZES_POWER_DOMAIN_CARD)
-    # is the GPU card power domain.
-    power_handle = power_handles[0]
+    if _get_pyzes_version() < (0, 1, 2):
+        power_handle = power_handles[0]
+        info.power_handle = power_handle
+        return power_handle
+
+    power_handle = None
+    for pwr_handle in power_handles:
+        pwr_props = pyzes.zes_power_properties_t()
+        pwr_props.stype = pyzes.ZES_STRUCTURE_TYPE_POWER_PROPERTIES
+        _zes_check(
+            pyzes.zesPowerGetProperties(pwr_handle, byref(pwr_props)),
+            "Can't get Level Zero Sysman power properties.",
+        )
+        if pwr_props.type != pyzes.ZES_POWER_DOMAIN_CARD:
+            continue
+        if subdevice_id is not None:
+            if pwr_props.onSubdevice and pwr_props.subdeviceId == subdevice_id:
+                power_handle = pwr_handle
+                break
+        else:
+            if not pwr_props.onSubdevice:
+                power_handle = pwr_handle
+                break
+
+    if power_handle is None:
+        raise RuntimeError("No Level Zero Sysman GPU power handle found.")
     info.power_handle = power_handle
     return power_handle
 

--- a/torch/xpu/__init__.py
+++ b/torch/xpu/__init__.py
@@ -1043,11 +1043,14 @@ def _get_zes_power_handle(device: Device = None) -> c_void_p:
     for pwr_handle in power_handles:
         pwr_props = pyzes.zes_power_properties_t()
         pwr_props.stype = pyzes.ZES_STRUCTURE_TYPE_POWER_PROPERTIES
+        ext_pwr_props = pyzes.zes_power_ext_properties_t()
+        ext_pwr_props.stype = pyzes.ZES_STRUCTURE_TYPE_POWER_EXT_PROPERTIES
+        pwr_props.pNext = cast(pointer(ext_pwr_props), c_void_p)
         _zes_check(
             pyzes.zesPowerGetProperties(pwr_handle, byref(pwr_props)),
             "Can't get Level Zero Sysman power properties.",
         )
-        if pwr_props.type != pyzes.ZES_POWER_DOMAIN_CARD:
+        if ext_pwr_props.domain != pyzes.ZES_POWER_DOMAIN_CARD:
             continue
         if subdevice_id is not None:
             if pwr_props.onSubdevice and pwr_props.subdeviceId == subdevice_id:

--- a/torch/xpu/__init__.py
+++ b/torch/xpu/__init__.py
@@ -1082,6 +1082,8 @@ def power_draw(device: Device = None) -> float:
         sampling interval required to compute an accurate power reading.
 
     .. note:: This API may require elevated privileges (e.g. ``sudo``) to access GPU power information.
+
+    .. note:: This API is currently only supported on Intel Xe2 and newer GPUs.
     """
     power_handle = _get_zes_power_handle(device)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #188256
* #188248

# Motivation
This PR aims to refine the power handle explicitly via `zesPowerGetProperties` that is added in pyzes 0.1.2. And we have to keep compatible with pyzes 0.1.1 for at least 1 PyTorch release version. Plan to drop the 0.11 support when PyTorch 2.15