### PR TITLE
Fix _foreach_{add,mul,div}.Tensor autograd

### DIFF
--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -1276,6 +1276,38 @@ class TestForeach(TestCase):
         self.assertIsNotNone(sample.input[0].grad)
         self.assertIsNone(sample.input[1].grad)
 
+    @dtypes(torch.float64)
+    def test_tensor_overload_shared_tensor_grad(self, device, dtype):
+        # Regression test for https://github.com/pytorch/pytorch/issues/144580
+        # _foreach_{add,mul,div}.Tensor share one 0-dim Tensor across every list
+        # element, so backward must reduce the per-element gradients into a
+        # single Tensor for that argument rather than emitting a length-N
+        # TensorList (which previously raised "inconsistent range for
+        # TensorList output" for lists longer than one element). The input
+        # tensors deliberately have different shapes to exercise the reduction.
+        shapes = [(2, 3), (4,), (5, 1)]
+        for foreach_op, ref_op in (
+            (torch._foreach_add, torch.add),
+            (torch._foreach_mul, torch.mul),
+            (torch._foreach_div, torch.div),
+        ):
+            self_tensors = [make_tensor(s, device=device, dtype=dtype) for s in shapes]
+            other = make_tensor((), device=device, dtype=dtype, low=0.5)
+
+            inputs = [t.detach().clone().requires_grad_() for t in self_tensors]
+            shared = other.detach().clone().requires_grad_()
+            outputs = foreach_op(inputs, shared)
+            torch.stack([out.sum() for out in outputs]).sum().backward()
+
+            ref_inputs = [t.detach().clone().requires_grad_() for t in self_tensors]
+            ref_shared = other.detach().clone().requires_grad_()
+            ref_outputs = [ref_op(t, ref_shared) for t in ref_inputs]
+            torch.stack([out.sum() for out in ref_outputs]).sum().backward()
+
+            self.assertEqual(shared.grad, ref_shared.grad)
+            for inp, ref_inp in zip(inputs, ref_inputs):
+                self.assertEqual(inp.grad, ref_inp.grad)
+
     @ops(
         filter(
             lambda op: op.backward_requires_result,

--- a/tools/autograd/gen_autograd_functions.py
+++ b/tools/autograd/gen_autograd_functions.py
@@ -212,6 +212,26 @@ if (needs_input_grad[/*${name}*/${idx}]) {  // ${name}
 """
 )
 
+# note(crcrpar): A foreach function whose differentiable input is a single
+# (non-list) Tensor, e.g. `other` of `_foreach_{add,mul,div}.Tensor`, shares
+# that Tensor across every list element. Its gradient is therefore the sum over
+# the list of the per-element contributions, each reduced to the argument's
+# shape to handle broadcasting.
+DERIVATIVE_SINGLE_FOREACH_TENSOR = CodeTemplate(
+    """\
+if (needs_input_grad[/*${name}*/${idx}]) {  // ${name}
+  Tensor grad_result;
+  for (const auto & i : c10::irange(grads.size())) {
+    if (grads[i].defined()) {
+      auto grad_part = at::sum_to(${derivative}, ${name}.sym_sizes());
+      grad_result = grad_result.defined() ? grad_result + grad_part : std::move(grad_part);
+    }
+  }
+  copy_range(grad_inputs, ${name}_ix, grad_result);
+}
+"""
+)
+
 DERIVATIVE_MULTI_COPY_RANGE = CodeTemplate(
     """\
   if (needs_input_grad[/*${name}*/${idx}]) {
@@ -941,20 +961,32 @@ static PyObject* THP${op}_${name}_getter(THPCppFunction *self, void *_unused) {
 
         if len(var_names) == 1:
             checks_any_grad_defined = False
-            if "not_implemented" not in formula:
-                matching_args = [
-                    arg for arg in args_with_derivatives if arg.name == var_names[0]
-                ]
-                if len(matching_args) == 1:
-                    # We can add undefined grad support if the input variable is a Tensor
-                    arg = matching_args[0]
-                    if isinstance(arg.argument, Argument) and str(
-                        arg.argument.type
-                    ) in ("Tensor", "Tensor?"):
-                        formula = "any_grad_defined ? (" + formula + ") : Tensor()"
-                        checks_any_grad_defined = True
-            if info.name.startswith("_foreach_"):
-                derivative_template = DERIVATIVE_SINGLE_FOREACH
+            is_foreach = info.name.startswith("_foreach_")
+            matching_args = [
+                arg for arg in args_with_derivatives if arg.name == var_names[0]
+            ]
+            # A single (non-list) Tensor input, e.g. `other` of
+            # `_foreach_{add,mul,div}.Tensor`, needs its per-element gradients
+            # reduced into one Tensor rather than emitted as a list.
+            is_single_tensor_arg = (
+                len(matching_args) == 1
+                and isinstance(matching_args[0].argument, Argument)
+                and str(matching_args[0].argument.type) in ("Tensor", "Tensor?")
+            )
+            if (
+                "not_implemented" not in formula
+                and is_single_tensor_arg
+                and not is_foreach
+            ):
+                # We can add undefined grad support if the input variable is a Tensor
+                formula = "any_grad_defined ? (" + formula + ") : Tensor()"
+                checks_any_grad_defined = True
+            if is_foreach:
+                derivative_template = (
+                    DERIVATIVE_SINGLE_FOREACH_TENSOR
+                    if is_single_tensor_arg
+                    else DERIVATIVE_SINGLE_FOREACH
+                )
             else:
                 derivative_template = DERIVATIVE_SINGLE
             return (


### PR DESCRIPTION
## Issue

Fixes #144580

## Summary

backward through `_foreach_{add,mul,div}.Tensor` crashed with `inconsistent range for TensorList output` for lists longer than one element. The foreach codegen always emitted an N-length gradient list and `copy_range`d it into the arg's index range which is right for the TensorList `self` (range N) but wrong for the shared single Tensor `other` (range 1) so the `1 == N` check failed for N>1. This adds a `DERIVATIVE_SINGLE_FOREACH_TENSOR` template for a non-list Tensor arg that instead sums the per-element gradients each `at::sum_to`'d to the arg's shape. TensorList args were unchanged.

## Test plan

Added `test_tensor_overload_shared_tensor_grad` (add/mul/div `.Tensor`, differently-shaped list, grads checked against a per-element loop).

```
python test/test_foreach.py -k test_tensor_overload_shared_tensor_grad
```
Full `test/test_foreach.py` passes (3795 ran, 0 failures).

## Checklist

- [x] Passes lint (`lintrunner`)
- [x] Added/updated tests

## BC-breaking?

No. These overloads used to crash in backward.