### PR TITLE
[nn] Fix RReLU noise tensor not being set in eval mode

### DIFF
--- a/aten/src/ATen/native/Activation.cpp
+++ b/aten/src/ATen/native/Activation.cpp
@@ -623,11 +623,12 @@ Tensor& rrelu_with_noise_out_cpu(const Tensor& self,
     });
     return output;
   } else {
-    auto lower_tensor = scalar_to_tensor(lower);
-    auto upper_tensor = scalar_to_tensor(upper);
-    auto negative = (lower_tensor + upper_tensor) / 2;
-    Scalar negative_slope = negative.item();
-    return at::leaky_relu_out(output, self, negative_slope);
+    auto negative_slope_val = (lower.to<double>() + upper.to<double>()) / 2;
+    Scalar negative_slope(negative_slope_val);
+    at::leaky_relu_out(output, self, negative_slope);
+    noise.fill_(negative_slope_val);
+    noise.masked_fill_(self > 0, 1.0);
+    return output;
   }
 }
 

--- a/aten/src/ATen/native/cuda/RreluWithNoise.cu
+++ b/aten/src/ATen/native/cuda/RreluWithNoise.cu
@@ -1,5 +1,6 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/core/Tensor.h>
+#include <ATen/TensorOperators.h>
 #include <ATen/cuda/CUDAGeneratorImpl.h>
 #include <ATen/native/cuda/DistributionTemplates.h>
 #include <ATen/native/Resize.h>
@@ -157,10 +158,11 @@ Tensor& rrelu_with_noise_out_cuda(const Tensor& self,
         });
   }
   else {
-    auto lower_tensor = lower.to<double>();
-    auto upper_tensor = upper.to<double>();
-    Scalar negative_slope = (lower_tensor + upper_tensor) / 2;
+    auto negative_slope_val = (lower.to<double>() + upper.to<double>()) / 2;
+    Scalar negative_slope(negative_slope_val);
     at::leaky_relu_out(output, self, negative_slope);
+    noise.fill_(negative_slope_val);
+    noise.masked_fill_(self > 0, 1.0);
   }
   return output;
 }

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -13762,7 +13762,7 @@ if __name__ == '__main__':
         with self.assertRaisesRegex(RuntimeError, "Lower bound should be less than or equal to the upper bound"):
             F.rrelu(x, lower=0.5, upper=0.3)
 
-    @onlyCPU
+
     def test_rrelu_eval_mode_noise_and_output(self, device):
         """Test that RReLU in eval mode correctly fills noise tensor and produces
         expected output using the fixed midpoint slope (lower + upper) / 2."""

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -13763,6 +13763,33 @@ if __name__ == '__main__':
             F.rrelu(x, lower=0.5, upper=0.3)
 
     @onlyCPU
+    def test_rrelu_eval_mode_noise_and_output(self, device):
+        """Test that RReLU in eval mode correctly fills noise tensor and produces
+        expected output using the fixed midpoint slope (lower + upper) / 2."""
+        lower, upper = 0.1, 0.3
+        midpoint = (lower + upper) / 2
+
+        x = torch.tensor(
+            [[0.4967, -0.1383, 0.6477], [1.5230, -0.2342, -0.2341]],
+            device=device,
+        )
+
+        noise = torch.empty_like(x)
+        output = torch.ops.aten.rrelu_with_noise(x, noise, lower, upper, False)
+
+        expected_output = torch.where(x > 0, x, x * midpoint)
+        self.assertEqual(output, expected_output)
+
+        expected_noise = torch.where(x > 0, torch.ones_like(x), torch.full_like(x, midpoint))
+        self.assertEqual(noise, expected_noise)
+
+        # Also verify through the nn.Module interface
+        m = torch.nn.RReLU(lower=lower, upper=upper)
+        m.eval()
+        module_output = m(x)
+        self.assertEqual(module_output, expected_output)
+
+    @onlyCPU
     def test_softshrink(self, device):
         x = torch.tensor([[1.21, 0.56, 0.5001, 0.4999, 1.2357, -0.4999, -0.5001, -1.154,
                            0.254, -0.24, -0.225, 0.104, 0.002, -0.001, 0.0574, 1.2344,

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -1327,7 +1327,9 @@ def rrelu_with_noise_functional(
     else:
         negative_slope = (lower + upper) / 2
         output = aten.leaky_relu(self, negative_slope)
-        noise_out = torch.where(self <= 0, negative_slope, 1.0)
+        noise_out = torch.where(
+            self <= 0, self.new_full((), negative_slope), self.new_full((), 1.0)
+        )
         return output, noise_out
 
 

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -1326,7 +1326,9 @@ def rrelu_with_noise_functional(
         return output, noise_out
     else:
         negative_slope = (lower + upper) / 2
-        return aten.leaky_relu(self, negative_slope), torch.Tensor()
+        output = aten.leaky_relu(self, negative_slope)
+        noise_out = torch.where(self <= 0, negative_slope, 1.0)
+        return output, noise_out
 
 
 @register_decomposition(aten.repeat_interleave.Tensor)


### PR DESCRIPTION
Fixes #176381

## Summary
- In eval mode, `rrelu_with_noise` was leaving the `noise` tensor uninitialized (containing garbage values) while only computing the output via `leaky_relu`. This breaks the API contract where noise should reflect the slopes applied.
- Fixed all three dispatch paths (CPU, CUDA, inductor decomposition) to properly fill the noise tensor in eval mode:
  - For elements where `input > 0`: `noise = 1.0`
  - For elements where `input <= 0`: `noise = (lower + upper) / 2`
- Simplified the CPU eval path by computing the midpoint directly from scalar arithmetic instead of creating intermediate tensors via `scalar_to_tensor`.

## Test plan
- Added `test_rrelu_eval_mode_noise_and_output` in `test/test_nn.py`
- Verifies output matches `leaky_relu(x, (lower+upper)/2)` in eval mode
- Verifies noise tensor is correctly filled (midpoint for non-positive inputs, 1.0 for positive inputs)
- Verifies consistency through `nn.RReLU` module interface
cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @eqy @syed-ahmed @Aidyn-A  

