### PR TITLE
[profiler] Validate chrome trace by event name, not fixed offset

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -3140,8 +3140,8 @@ class TestProfilerDevice(TestCase):
         # and are not bounded by the PyTorch profiler window, so they must be
         # ignored when validating the trace.
         name = traceEvent.get("name", "")
-        return name.startswith("__xpu_profiler__") or name.startswith(
-            "Iteration Start: __xpu_profiler__"
+        return name.startswith(
+            ("__xpu_profiler__", "Iteration Start: __xpu_profiler__")
         )
 
     def _validate_basic_json(self, traceEvents, device_available=False):

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -3132,35 +3132,60 @@ class TestProfilerDevice(TestCase):
         for i in range(max_gpu_count):
             self.assertEqual(gpu_dict["GPU " + str(i)], 1)
 
+    def _is_secondary_profiler_event(self, traceEvent):
+        # On a device build (e.g. XPU) the trace contains, in addition to the
+        # "PyTorch Profiler (0)" instance, a secondary profiler instance such as
+        # "__xpu_profiler__ (N)" plus its own "Iteration Start: __xpu_profiler__"
+        # marker. These are emitted regardless of which activities are requested
+        # and are not bounded by the PyTorch profiler window, so they must be
+        # ignored when validating the trace.
+        name = traceEvent.get("name", "")
+        return name.startswith("__") and "_profiler__" in name or name.startswith(
+            "Iteration Start: __"
+        )
+
     def _validate_basic_json(self, traceEvents, device_available=False):
         MAX_GPU_COUNT = 8
-        PROFILER_IDX = -4
-        RECORD_END = -1
-        RECORD_START = -2
-        traceEventProfiler = traceEvents[PROFILER_IDX]
 
-        self.assertTrue(traceEventProfiler["name"] == "PyTorch Profiler (0)")
-        self.assertTrue(traceEvents[RECORD_END]["name"] == "Record Window End")
-        self.assertTrue(
-            traceEvents[RECORD_START]["name"] == "Iteration Start: PyTorch Profiler"
+        # Locate the PyTorch profiler markers by name rather than by fixed
+        # negative offsets: a device build appends a secondary profiler instance
+        # to the trace, which shifts the previously assumed -4/-2/-1 positions.
+        def _find_event(name):
+            for event in traceEvents:
+                if event.get("name") == name:
+                    return event
+            return None
+
+        traceEventProfiler = _find_event("PyTorch Profiler (0)")
+        recordStart = _find_event("Iteration Start: PyTorch Profiler")
+        recordEnd = _find_event("Record Window End")
+
+        self.assertIsNotNone(
+            traceEventProfiler, "missing 'PyTorch Profiler (0)' trace event"
         )
+        self.assertIsNotNone(
+            recordStart, "missing 'Iteration Start: PyTorch Profiler' trace event"
+        )
+        self.assertIsNotNone(recordEnd, "missing 'Record Window End' trace event")
+
         self.assertGreaterEqual(
             traceEventProfiler["ts"],
-            traceEvents[RECORD_START]["ts"],
+            recordStart["ts"],
             "Profiler starts before record!",
         )
         self.assertLessEqual(
             traceEventProfiler["ts"] + traceEventProfiler["dur"],
-            traceEvents[RECORD_END]["ts"],
+            recordEnd["ts"],
             "Profiler ends after record end!",
         )
 
         gpu_dict = collections.defaultdict(int)
         for i, traceEvent in enumerate(traceEvents):
-            if (
-                i == len(traceEvents) + RECORD_END
-                or i == len(traceEvents) + RECORD_START
-            ):
+            if traceEvent is recordStart or traceEvent is recordEnd:
+                continue
+            # Skip the secondary device profiler instance, which lives outside the
+            # PyTorch profiler window and would otherwise trip the bounds checks.
+            if self._is_secondary_profiler_event(traceEvent):
                 continue
             if "ts" in traceEvent:
                 self.assertGreaterEqual(
@@ -3171,7 +3196,7 @@ class TestProfilerDevice(TestCase):
             if "dur" in traceEvent:
                 self.assertLessEqual(
                     traceEvent["ts"] + traceEvent["dur"],
-                    traceEvents[RECORD_END]["ts"],
+                    recordEnd["ts"],
                     "Trace event ends too late!",
                 )
             gpu_value = traceEvent.get("args", {}).get("labels", None)

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -3133,23 +3133,20 @@ class TestProfilerDevice(TestCase):
             self.assertEqual(gpu_dict["GPU " + str(i)], 1)
 
     def _is_secondary_profiler_event(self, traceEvent):
-        # On a device build (e.g. XPU) the trace contains, in addition to the
-        # "PyTorch Profiler (0)" instance, a secondary profiler instance such as
+        # On an XPU build the trace contains, in addition to the
+        # "PyTorch Profiler (0)" instance, the XPU profiler instance
         # "__xpu_profiler__ (N)" plus its own "Iteration Start: __xpu_profiler__"
         # marker. These are emitted regardless of which activities are requested
         # and are not bounded by the PyTorch profiler window, so they must be
         # ignored when validating the trace.
         name = traceEvent.get("name", "")
-        return name.startswith("__") and "_profiler__" in name or name.startswith(
-            "Iteration Start: __"
+        return name.startswith("__xpu_profiler__") or name.startswith(
+            "Iteration Start: __xpu_profiler__"
         )
 
     def _validate_basic_json(self, traceEvents, device_available=False):
         MAX_GPU_COUNT = 8
 
-        # Locate the PyTorch profiler markers by name rather than by fixed
-        # negative offsets: a device build appends a secondary profiler instance
-        # to the trace, which shifts the previously assumed -4/-2/-1 positions.
         def _find_event(name):
             for event in traceEvents:
                 if event.get("name") == name:


### PR DESCRIPTION
`_validate_basic_json` (used by `test_basic_chrome_trace`) located the `"PyTorch Profiler (0)"`, `"Iteration Start: PyTorch Profiler"` and `"Record Window End"` markers at fixed negative indices `-4`/`-2`/`-1` of the trace event list.

On a device build that emits a **second** profiler instance this no longer holds. A `USE_XPU=1` build appends an `__xpu_profiler__ (N)` event plus its own `Iteration Start: __xpu_profiler__` marker to the trace, so `traceEvents[-4]` is now the secondary profiler event and the assertion `traceEvents[-4]["name"] == "PyTorch Profiler (0)"` fails. The secondary instance is emitted regardless of the requested activities, and it is not bounded by the PyTorch profiler window, so it also trips the in-window bounds check (`"Trace event ends too late!"`).

This change locates the three PyTorch profiler markers by name instead of by offset, and skips the secondary device profiler's events when validating the window. CPU and CUDA traces are unaffected (no secondary instance is emitted there), and the GPU-label / `sort_index` checks are preserved.

Surfaced by the Kineto XPU CI, which runs `test/profiler/` from a `USE_XPU=1` build (pytorch/kineto#1451 deselects this test until this fix reaches `viable/strict`).

## Test plan

Verified on an Intel Data Center GPU Max (PVC) `USE_XPU=1` build: `test_basic_chrome_trace_cpu` passes with this change and fails without it (`AssertionError: False is not true` on the `traceEvents[-4]` name check).
