### PR TITLE
[MPS] proper error for batch norm when input is unsupported dtype

### DIFF
--- a/aten/src/ATen/native/mps/operations/Normalization.mm
+++ b/aten/src/ATen/native/mps/operations/Normalization.mm
@@ -114,9 +114,8 @@ std::tuple<Tensor&, Tensor&, Tensor&> batch_norm_mps_out(const Tensor& self,
                               save_var);
   }
 
-  TORCH_CHECK_NOT_IMPLEMENTED(self.scalar_type() != kLong, "Long batch norm is not supported with MPS");
-  TORCH_CHECK_NOT_IMPLEMENTED(!c10::isComplexType(self.scalar_type()),
-                              "Batch norm for complex is not supported for MPS");
+  TORCH_CHECK_NOT_IMPLEMENTED(
+      isFloatingType(self.scalar_type()), "batch_norm is not implemented for ", self.scalar_type(), " on MPS");
   using namespace at::native::mps;
   struct CachedGraph : public MPSCachedGraph {
     CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -13041,16 +13041,6 @@ class TestNNDeviceType(NNTestCase):
             with torch.backends.cudnn.flags(enabled=False):
                 self._test_batchnorm_update_stats(device)
 
-    @dtypes(torch.bool, torch.uint8, torch.int16, torch.int32, torch.int64)
-    def test_batchnorm_unsupported_dtype(self, device, dtype):
-        # Non-floating inputs must raise cleanly instead of crashing the process.
-        # Regression test for https://github.com/pytorch/pytorch/issues/188243
-        x = torch.zeros(2, 16, 4, 4, dtype=dtype, device=device)
-        running_mean = torch.zeros(16, device=device)
-        running_var = torch.ones(16, device=device)
-        with self.assertRaisesRegex(RuntimeError, "batch_norm.*not implemented"):
-            F.batch_norm(x, running_mean, running_var, None, None, training=False)
-
     @onlyCPU
     @dtypes(torch.bfloat16, torch.float16)
     def test_activations_bfloat16_half_cpu(self, device, dtype):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -13041,6 +13041,16 @@ class TestNNDeviceType(NNTestCase):
             with torch.backends.cudnn.flags(enabled=False):
                 self._test_batchnorm_update_stats(device)
 
+    @dtypes(torch.bool, torch.uint8, torch.int16, torch.int32, torch.int64)
+    def test_batchnorm_unsupported_dtype(self, device, dtype):
+        # Non-floating inputs must raise cleanly instead of crashing the process.
+        # Regression test for https://github.com/pytorch/pytorch/issues/188243
+        x = torch.zeros(2, 16, 4, 4, dtype=dtype, device=device)
+        running_mean = torch.zeros(16, device=device)
+        running_var = torch.ones(16, device=device)
+        with self.assertRaisesRegex(RuntimeError, "batch_norm.*not implemented"):
+            F.batch_norm(x, running_mean, running_var, None, None, training=False)
+
     @onlyCPU
     @dtypes(torch.bfloat16, torch.float16)
     def test_activations_bfloat16_half_cpu(self, device, dtype):

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -16312,9 +16312,6 @@ op_db: list[OpInfo] = [
            aten_name='native_batch_norm',
            dtypes=floating_types_and(torch.float16, torch.bfloat16),
            dtypesIfHpu=custom_types(torch.float32, torch.bfloat16),
-           dtypesIfMPS=floating_types_and(
-               torch.float16, torch.bfloat16, torch.uint8, torch.bool, torch.int8, torch.int16, torch.int32
-           ),
            supports_forward_ad=True,
            supports_fwgrad_bwgrad=True,
            assert_jit_shape_analysis=True,
@@ -16367,10 +16364,6 @@ op_db: list[OpInfo] = [
                DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_compare_cpu'),
                DecorateInfo(toleranceOverride({torch.float32: tol(atol=5e-5, rtol=5e-5)}),
                             "TestCompositeCompliance", "test_forward_ad"),
-               # The following dtypes worked in forward but are not listed by
-               # the OpInfo: {torch.uint8, torch.bool, torch.int8, torch.int16,
-               # torch.int32}.
-               DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes', device_type='mps'),
                # FIXME: AssertionError: The values for attribute 'shape' do not match
                DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out', device_type='mps'),
                DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out_warning', device_type='mps'),
@@ -16408,10 +16401,6 @@ op_db: list[OpInfo] = [
                # aten out variants do not accept out= kwarg, only python out variants
                DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out'),
                DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out_warning'),
-               # The following dtypes worked in forward but are not listed by
-               # the OpInfo: {torch.uint8, torch.bool, torch.int8, torch.int16,
-               # torch.int32}.
-               DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes', device_type='mps'),
            )
            ),
     OpInfo('nn.functional.cosine_similarity',
@@ -18516,9 +18505,6 @@ op_db: list[OpInfo] = [
     OpInfo('nn.functional.batch_norm',
            aten_name='batch_norm',
            dtypes=floating_types_and(torch.float16, torch.bfloat16),
-           dtypesIfMPS=floating_types_and(
-               torch.float16, torch.bfloat16, torch.uint8, torch.bool, torch.int8, torch.int16, torch.int32
-           ),
            supports_out=False,
            supports_forward_ad=True,
            supports_fwgrad_bwgrad=True,


### PR DESCRIPTION
Fixes #188243