### PR TITLE
Fix positional arg overflow in TritonBenchmarkRequest when template inputs are deduplicated

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -32,6 +32,7 @@ from torch._inductor.autotune_process import (
     AutotuneProcessPool,
     ExternKernelBenchmarkRequest,
     get_visible_devices_env_var,
+    TensorMeta,
     TritonBenchmarkRequest,
     TuningProcess,
     TuningProcessPool,

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -24,7 +24,7 @@ from torch._dynamo import reset
 from torch._dynamo.device_interface import get_interface_for_device
 from torch._dynamo.exc import BackendCompilerFailed
 from torch._dynamo.testing import rand_strided, reset_rng_state
-from torch._dynamo.utils import counters, same
+from torch._dynamo.utils import counters, identity, same
 from torch._inductor import config
 from torch._inductor.autotune_process import (
     _TestBenchmarkRequest,
@@ -70,6 +70,7 @@ from torch._inductor.select_algorithm import (
     clear_feedback_savers,
     clear_preprocessing_fns,
     ExternKernelCaller,
+    GeneratedCodeCache,
     NoValidChoicesError,
     TritonTemplate,
     TritonTemplateCaller,
@@ -2557,6 +2558,7 @@ class TestMaxAutotune(TestCase):
                         'input_nodes':[
                             "[[10,22],[22,1],torch.float32,device(type='cuda',index=0),0]",
                             "[[22,30],[30,1],torch.float32,device(type='cuda',index=0),0]"],
+                        'input_aliasing':(0,1),
                         'num_stages':1,'num_warps':2,'prefix_args':0,'suffix_args':0,'call_sizes':[10,30],
                         'layout':"[[10,30],[30,1],torch.float32,device(type='cuda',index=0),0]",
                         'num_consumer_groups':0,'num_buffers_warp_spec':0,'epilogue_fn_hash':'identity','tma_store':False,
@@ -2599,6 +2601,7 @@ class TestMaxAutotune(TestCase):
                     'input_nodes':[
                         "[[s77,s27],[s27,1],torch.float32,device(type='cuda',index=0),0]",
                         "[[s27,s94],[s94,1],torch.float32,device(type='cuda',index=0),0]"],
+                    'input_aliasing':(0,1),
                     'num_stages':1,'num_warps':2,'prefix_args':0,'suffix_args':0,'call_sizes':[s77,s94],
                     'layout':"[[s77,s94],[s94,1],torch.float32,device(type='cuda',index=0),0]",'num_consumer_groups':0,
                     'num_buffers_warp_spec':0,'epilogue_fn_hash':'identity','tma_store':False,
@@ -2766,6 +2769,82 @@ class TestMaxAutotune(TestCase):
             self.assertEqual(compile_results, eager_results, atol=0.05, rtol=0.05)
             self.assertEqual(hits(), 4)
             self.assertEqual(misses(), 4)
+
+    def test_generated_code_cache_key_input_aliasing(self):
+        """make_key must distinguish aliased inputs, e.g. mm(x, x), from
+        distinct inputs with identical layouts, and stay name-insensitive."""
+
+        def make_layout():
+            return FixedLayout(torch.device("cpu"), torch.float32, [8, 8], [8, 1])
+
+        a = Buffer(name="buf_a", layout=make_layout())
+        b = Buffer(name="buf_b", layout=make_layout())
+
+        def key(*input_nodes):
+            return GeneratedCodeCache().make_key(
+                input_nodes=input_nodes,
+                num_stages=1,
+                num_warps=4,
+                call_sizes=[8, 8],
+                prefix_args=0,
+                suffix_args=0,
+                epilogue_fn=identity,
+                epilogue_fn_hash=None,
+                tma_store=False,
+                tma_load_for_template_epilogue=False,
+                transpose_discontiguous_tensor_descriptors_override=None,
+                subgraphs=None,
+                workspace_arg=None,
+                layout=make_layout(),
+                num_consumer_groups=0,
+                num_buffers_warp_spec=0,
+                kwargs={},
+            )
+
+        # Identical layouts but different aliasing must not collide.
+        self.assertNotEqual(key(a, a), key(a, b))
+        # The aliasing pattern is insensitive to buffer names.
+        self.assertEqual(key(a, a), key(b, b))
+        self.assertEqual(key(a, b), key(b, a))
+        self.assertIn("'input_aliasing': (0, 1)", key(a, b))
+
+    @unittest.skipUnless(HAS_CUDA_AND_TRITON, "requires CUDA and Triton")
+    @config.patch(
+        {
+            "test_configs.max_mm_configs": 4,
+            "max_autotune_gemm_backends": "TRITON",
+        }
+    )
+    def test_bmm_template_cache_aliased_then_distinct_inputs(self):
+        """A bmm whose operands alias one buffer must not share generated-code
+        cache entries with a bmm over distinct operands of identical layouts.
+
+        def_kernel collapses aliased operands into a single kernel argument,
+        so before the aliasing-aware cache key the distinct-operand bmm
+        reused the one-argument cached kernels; the class-level
+        TritonTemplate.test_cache patch turns that reuse into a hard error.
+        See https://github.com/pytorch/pytorch/issues/188069.
+        """
+
+        def f(x, a, b):
+            return torch.bmm(x, x), torch.bmm(a, b)
+
+        B, N = 2, 128
+        with fresh_cache():
+            x = torch.randn(B, N, N, device=GPU_TYPE)
+            a = torch.randn(B, N, N, device=GPU_TYPE)
+            b = torch.randn(B, N, N, device=GPU_TYPE)
+
+            compiled = torch.compile(
+                f,
+                fullgraph=True,
+                dynamic=False,
+                mode="max-autotune-no-cudagraphs",
+            )
+            aliased, distinct = compiled(x, a, b)
+
+            self.assertEqual(aliased, torch.bmm(x, x), atol=0.1, rtol=0.05)
+            self.assertEqual(distinct, torch.bmm(a, b), atol=0.1, rtol=0.05)
 
     @fresh_cache()
     @unittest.skipIf(

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -2718,7 +2718,7 @@ class TestMaxAutotune(TestCase):
             torch.compile(update, **compile_kwargs)(grad, m0, m1, 0.999)
             result = torch.compile(project, **compile_kwargs)(grad, q0, q1)
 
-            self.assertEqual(result, project(grad, q0, q1), atol=1e-2, rtol=1e-2)
+            self.assertEqual(result, project(grad, q0, q1), atol=0.5, rtol=0.05)
 
     @fresh_cache()
     @unittest.skipIf(

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -2682,43 +2682,35 @@ class TestMaxAutotune(TestCase):
         }
     )
     def test_bmm_template_cache_aliased_then_distinct_inputs(self):
-        """Cached template code generated for aliased bmm operands must not
-        be reused for distinct operands with identical layouts.
+        """A bmm whose operands alias one buffer must not share generated-code
+        cache entries with a bmm over distinct operands of identical layouts.
 
-        The first compilation caches bmm kernels whose operands alias one
-        buffer (codegen collapses them into a single kernel argument). The
-        second compilation autotunes bmm nodes with distinct operands of the
-        same layouts; before the aliasing-aware cache key those hit the
-        one-argument cached kernels and crashed during benchmarking.
+        def_kernel collapses aliased operands into a single kernel argument,
+        so before the aliasing-aware cache key the distinct-operand bmm
+        reused the one-argument cached kernels; the class-level
+        TritonTemplate.test_cache patch turns that reuse into a hard error.
         See https://github.com/pytorch/pytorch/issues/188069.
         """
 
-        def update(grad, m0, m1, beta):
-            outer0 = torch.einsum("...ab,...Ab->...aA", grad, grad)
-            m0.lerp_(outer0, 1 - beta)
-            outer1 = torch.einsum("...ab,...aB->...bB", grad, grad)
-            m1.lerp_(outer1, 1 - beta)
-
-        def project(grad, q0, q1):
-            return torch.einsum("...ab,...aA,...bB->...AB", grad, q0, q1)
+        def f(x, a, b):
+            return torch.bmm(x, x), torch.bmm(a, b)
 
         B, N = 2, 128
         with fresh_cache():
-            grad = torch.randn(B, N, N, device=GPU_TYPE)
-            m0 = torch.randn(B, N, N, device=GPU_TYPE)
-            m1 = torch.randn(B, N, N, device=GPU_TYPE)
-            q0 = torch.randn(B, N, N, device=GPU_TYPE)
-            q1 = torch.randn(B, N, N, device=GPU_TYPE)
+            x = torch.randn(B, N, N, device=GPU_TYPE)
+            a = torch.randn(B, N, N, device=GPU_TYPE)
+            b = torch.randn(B, N, N, device=GPU_TYPE)
 
-            compile_kwargs = {
-                "fullgraph": True,
-                "dynamic": False,
-                "mode": "max-autotune-no-cudagraphs",
-            }
-            torch.compile(update, **compile_kwargs)(grad, m0, m1, 0.999)
-            result = torch.compile(project, **compile_kwargs)(grad, q0, q1)
+            compiled = torch.compile(
+                f,
+                fullgraph=True,
+                dynamic=False,
+                mode="max-autotune-no-cudagraphs",
+            )
+            aliased, distinct = compiled(x, a, b)
 
-            self.assertEqual(result, project(grad, q0, q1), atol=0.5, rtol=0.05)
+            self.assertEqual(aliased, torch.bmm(x, x), atol=0.1, rtol=0.05)
+            self.assertEqual(distinct, torch.bmm(a, b), atol=0.1, rtol=0.05)
 
     @fresh_cache()
     @unittest.skipIf(

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -24,7 +24,7 @@ from torch._dynamo import reset
 from torch._dynamo.device_interface import get_interface_for_device
 from torch._dynamo.exc import BackendCompilerFailed
 from torch._dynamo.testing import rand_strided, reset_rng_state
-from torch._dynamo.utils import counters, same
+from torch._dynamo.utils import counters, identity, same
 from torch._inductor import config
 from torch._inductor.autotune_process import (
     _TestBenchmarkRequest,
@@ -32,7 +32,6 @@ from torch._inductor.autotune_process import (
     AutotuneProcessPool,
     ExternKernelBenchmarkRequest,
     get_visible_devices_env_var,
-    TensorMeta,
     TritonBenchmarkRequest,
     TuningProcess,
     TuningProcessPool,
@@ -68,6 +67,7 @@ from torch._inductor.select_algorithm import (
     clear_feedback_savers,
     clear_preprocessing_fns,
     ExternKernelCaller,
+    GeneratedCodeCache,
     NoValidChoicesError,
     TritonTemplate,
     TritonTemplateCaller,
@@ -2424,6 +2424,7 @@ class TestMaxAutotune(TestCase):
                         'input_nodes':[
                             "[[10,22],[22,1],torch.float32,device(type='cuda',index=0),0]",
                             "[[22,30],[30,1],torch.float32,device(type='cuda',index=0),0]"],
+                        'input_aliasing':(0,1),
                         'num_stages':1,'num_warps':2,'prefix_args':0,'suffix_args':0,'call_sizes':[10,30],
                         'layout':"[[10,30],[30,1],torch.float32,device(type='cuda',index=0),0]",
                         'num_consumer_groups':0,'num_buffers_warp_spec':0,'epilogue_fn_hash':'identity','tma_store':False,
@@ -2466,6 +2467,7 @@ class TestMaxAutotune(TestCase):
                     'input_nodes':[
                         "[[s77,s27],[s27,1],torch.float32,device(type='cuda',index=0),0]",
                         "[[s27,s94],[s94,1],torch.float32,device(type='cuda',index=0),0]"],
+                    'input_aliasing':(0,1),
                     'num_stages':1,'num_warps':2,'prefix_args':0,'suffix_args':0,'call_sizes':[s77,s94],
                     'layout':"[[s77,s94],[s94,1],torch.float32,device(type='cuda',index=0),0]",'num_consumer_groups':0,
                     'num_buffers_warp_spec':0,'epilogue_fn_hash':'identity','tma_store':False,
@@ -2633,6 +2635,90 @@ class TestMaxAutotune(TestCase):
             self.assertEqual(compile_results, eager_results, atol=0.05, rtol=0.05)
             self.assertEqual(hits(), 4)
             self.assertEqual(misses(), 4)
+
+    def test_generated_code_cache_key_input_aliasing(self):
+        """make_key must distinguish aliased inputs, e.g. mm(x, x), from
+        distinct inputs with identical layouts, and stay name-insensitive."""
+
+        def make_layout():
+            return FixedLayout(torch.device("cpu"), torch.float32, [8, 8], [8, 1])
+
+        a = Buffer(name="buf_a", layout=make_layout())
+        b = Buffer(name="buf_b", layout=make_layout())
+
+        def key(*input_nodes):
+            return GeneratedCodeCache().make_key(
+                input_nodes=input_nodes,
+                num_stages=1,
+                num_warps=4,
+                call_sizes=[8, 8],
+                prefix_args=0,
+                suffix_args=0,
+                epilogue_fn=identity,
+                epilogue_fn_hash=None,
+                tma_store=False,
+                tma_load_for_template_epilogue=False,
+                transpose_discontiguous_tensor_descriptors_override=None,
+                subgraphs=None,
+                workspace_arg=None,
+                layout=make_layout(),
+                num_consumer_groups=0,
+                num_buffers_warp_spec=0,
+                kwargs={},
+            )
+
+        # Identical layouts but different aliasing must not collide.
+        self.assertNotEqual(key(a, a), key(a, b))
+        # The aliasing pattern is insensitive to buffer names.
+        self.assertEqual(key(a, a), key(b, b))
+        self.assertEqual(key(a, b), key(b, a))
+        self.assertIn("'input_aliasing': (0, 1)", key(a, b))
+
+    @unittest.skipUnless(HAS_CUDA_AND_TRITON, "requires CUDA and Triton")
+    @config.patch(
+        {
+            "test_configs.max_mm_configs": 4,
+            "max_autotune_gemm_backends": "TRITON",
+        }
+    )
+    def test_bmm_template_cache_aliased_then_distinct_inputs(self):
+        """Cached template code generated for aliased bmm operands must not
+        be reused for distinct operands with identical layouts.
+
+        The first compilation caches bmm kernels whose operands alias one
+        buffer (codegen collapses them into a single kernel argument). The
+        second compilation autotunes bmm nodes with distinct operands of the
+        same layouts; before the aliasing-aware cache key those hit the
+        one-argument cached kernels and crashed during benchmarking.
+        See https://github.com/pytorch/pytorch/issues/188069.
+        """
+
+        def update(grad, m0, m1, beta):
+            outer0 = torch.einsum("...ab,...Ab->...aA", grad, grad)
+            m0.lerp_(outer0, 1 - beta)
+            outer1 = torch.einsum("...ab,...aB->...bB", grad, grad)
+            m1.lerp_(outer1, 1 - beta)
+
+        def project(grad, q0, q1):
+            return torch.einsum("...ab,...aA,...bB->...AB", grad, q0, q1)
+
+        B, N = 2, 128
+        with fresh_cache():
+            grad = torch.randn(B, N, N, device=GPU_TYPE)
+            m0 = torch.randn(B, N, N, device=GPU_TYPE)
+            m1 = torch.randn(B, N, N, device=GPU_TYPE)
+            q0 = torch.randn(B, N, N, device=GPU_TYPE)
+            q1 = torch.randn(B, N, N, device=GPU_TYPE)
+
+            compile_kwargs = {
+                "fullgraph": True,
+                "dynamic": False,
+                "mode": "max-autotune-no-cudagraphs",
+            }
+            torch.compile(update, **compile_kwargs)(grad, m0, m1, 0.999)
+            result = torch.compile(project, **compile_kwargs)(grad, q0, q1)
+
+            self.assertEqual(result, project(grad, q0, q1), atol=1e-2, rtol=1e-2)
 
     @fresh_cache()
     @unittest.skipIf(
@@ -3496,114 +3582,6 @@ class TestMaxAutotune(TestCase):
         # No truncation casts should exist since there are no fused epilogue ops
         self.assertNotIn("acc.to(tl.float16)", code[0])
         self.assertNotIn("acc.to(tl.bfloat16)", code[0])
-
-    @unittest.skipUnless(HAS_CUDA_AND_TRITON, "requires CUDA and Triton")
-    def test_bmm_input_dedup_no_stream_overflow(self):
-        """Autotuning bmm after a self-referential bmm must not crash.
-
-        The first compilation produces template kernels where both operands
-        alias the same buffer (input deduplication).  The second compilation's
-        autotuning must handle the reduced parameter count without overflowing
-        positional args into the stream keyword.
-        """
-        dev = GPU_TYPE
-        B, N = 2, 128
-
-        grad = torch.randn(B, N, N, device=dev)
-        m0 = torch.randn(B, N, N, device=dev)
-        m1 = torch.randn(B, N, N, device=dev)
-        q0 = torch.randn(B, N, N, device=dev)
-        q1 = torch.randn(B, N, N, device=dev)
-
-        @torch.compile(fullgraph=True, dynamic=False, mode="max-autotune-no-cudagraphs")
-        def update(grad, m0, m1, beta):
-            outer0 = torch.einsum("...ab,...Ab->...aA", grad, grad)
-            m0.lerp_(outer0, 1 - beta)
-            outer1 = torch.einsum("...ab,...aB->...bB", grad, grad)
-            m1.lerp_(outer1, 1 - beta)
-
-        @torch.compile(fullgraph=True, dynamic=False, mode="max-autotune-no-cudagraphs")
-        def project(grad, q0, q1):
-            return torch.einsum("...ab,...aA,...bB->...AB", grad, q0, q1)
-
-        update(grad, m0, m1, 0.999)
-        result = project(grad.float(), q0.float(), q1.float())
-        expected = torch.einsum("...ab,...aA,...bB->...AB", grad.float(), q0.float(), q1.float())
-        torch.testing.assert_close(result, expected)
-
-    @unittest.skipUnless(HAS_CUDA_AND_TRITON, "requires CUDA and Triton")
-    def test_nontail_input_dedup_trimming(self):
-        """Non-tail deduplication must keep trailing tensors, not truncate.
-
-        Simulates a 4-input template (A, B, C, D) where B (index 1) was
-        deduplicated to A. The kernel signature has 3 input pointers:
-        arg_A, arg_C, arg_D. A naive tail-truncation would drop D (index 3)
-        instead of B (index 1). The name_to_idx logic must keep [0, 2, 3].
-        """
-        dev = GPU_TYPE
-        t_A = torch.randn(4, 4, device=dev)
-        t_B = torch.randn(4, 4, device=dev)
-        t_C = torch.randn(4, 4, device=dev)
-        t_D = torch.randn(4, 4, device=dev)
-        out = torch.empty(4, 4, device=dev)
-
-        class FakeKernelSelf:
-            with_bandwidth_info = False
-
-        def fake_run(*args, **kwargs):
-            pass
-
-        fake_run.__self__ = FakeKernelSelf()
-
-        class FakeKernel:
-            run = fake_run
-            triton_meta = {
-                "signature": {
-                    "arg_A": "*fp32",
-                    "arg_C": "*fp32",
-                    "arg_D": "*fp32",
-                    "out_ptr0": "*fp32",
-                    "ks0": "i32",
-                    "ks1": "i32",
-                },
-            }
-
-        class FakeModule:
-            triton_mm_plus_mm = FakeKernel()
-
-        input_meta = [
-            TensorMeta(device=t.device, dtype=t.dtype, sizes=t.shape,
-                       strides=t.stride(), offset=0)
-            for t in [t_A, t_B, t_C, t_D]
-        ]
-        output_meta = TensorMeta(
-            device=out.device, dtype=out.dtype, sizes=out.shape,
-            strides=out.stride(), offset=0,
-        )
-
-        req = TritonBenchmarkRequest(
-            kernel_name="triton_mm_plus_mm",
-            input_tensor_meta=input_meta,
-            output_tensor_meta=output_meta,
-            extra_args=[1, 1, 1],
-            module_path="/dev/null",
-            module_cache_key="fake_key",
-            num_stages=1,
-            num_warps=4,
-            input_param_names=("arg_A", "arg_B", "arg_C", "arg_D"),
-        )
-
-        with patch(
-            "torch._inductor.autotune_process.PyCodeCache.load_by_key_path",
-            return_value=FakeModule(),
-        ):
-            fn = req.make_run_fn(t_A, t_B, t_C, t_D, out=out)
-
-        kept = fn.args[:3]
-        self.assertEqual(len(kept), 3)
-        self.assertIs(kept[0], t_A)
-        self.assertIs(kept[1], t_C)
-        self.assertIs(kept[2], t_D)
 
 
 @instantiate_parametrized_tests

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -3496,6 +3496,40 @@ class TestMaxAutotune(TestCase):
         self.assertNotIn("acc.to(tl.float16)", code[0])
         self.assertNotIn("acc.to(tl.bfloat16)", code[0])
 
+    @unittest.skipUnless(HAS_CUDA_AND_TRITON, "requires CUDA and Triton")
+    def test_bmm_input_dedup_no_stream_overflow(self):
+        """Autotuning bmm after a self-referential bmm must not crash.
+
+        The first compilation produces template kernels where both operands
+        alias the same buffer (input deduplication).  The second compilation's
+        autotuning must handle the reduced parameter count without overflowing
+        positional args into the stream keyword.
+        """
+        dev = GPU_TYPE
+        B, N = 2, 128
+
+        grad = torch.randn(B, N, N, device=dev)
+        m0 = torch.randn(B, N, N, device=dev)
+        m1 = torch.randn(B, N, N, device=dev)
+        q0 = torch.randn(B, N, N, device=dev)
+        q1 = torch.randn(B, N, N, device=dev)
+
+        @torch.compile(fullgraph=True, dynamic=False, mode="max-autotune-no-cudagraphs")
+        def update(grad, m0, m1, beta):
+            outer0 = torch.einsum("...ab,...Ab->...aA", grad, grad)
+            m0.lerp_(outer0, 1 - beta)
+            outer1 = torch.einsum("...ab,...aB->...bB", grad, grad)
+            m1.lerp_(outer1, 1 - beta)
+
+        @torch.compile(fullgraph=True, dynamic=False, mode="max-autotune-no-cudagraphs")
+        def project(grad, q0, q1):
+            return torch.einsum("...ab,...aA,...bB->...AB", grad, q0, q1)
+
+        update(grad, m0, m1, 0.999)
+        result = project(grad.float(), q0.float(), q1.float())
+        expected = torch.einsum("...ab,...aA,...bB->...AB", grad.float(), q0.float(), q1.float())
+        torch.testing.assert_close(result, expected)
+
 
 @instantiate_parametrized_tests
 class TestTemplateConfigPruning(TestCase):

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -3530,6 +3530,80 @@ class TestMaxAutotune(TestCase):
         expected = torch.einsum("...ab,...aA,...bB->...AB", grad.float(), q0.float(), q1.float())
         torch.testing.assert_close(result, expected)
 
+    @unittest.skipUnless(HAS_CUDA_AND_TRITON, "requires CUDA and Triton")
+    def test_nontail_input_dedup_trimming(self):
+        """Non-tail deduplication must keep trailing tensors, not truncate.
+
+        Simulates a 4-input template (A, B, C, D) where B (index 1) was
+        deduplicated to A. The kernel signature has 3 input pointers:
+        arg_A, arg_C, arg_D. A naive tail-truncation would drop D (index 3)
+        instead of B (index 1). The name_to_idx logic must keep [0, 2, 3].
+        """
+        dev = GPU_TYPE
+        t_A = torch.randn(4, 4, device=dev)
+        t_B = torch.randn(4, 4, device=dev)
+        t_C = torch.randn(4, 4, device=dev)
+        t_D = torch.randn(4, 4, device=dev)
+        out = torch.empty(4, 4, device=dev)
+
+        class FakeKernelSelf:
+            with_bandwidth_info = False
+
+        def fake_run(*args, **kwargs):
+            pass
+
+        fake_run.__self__ = FakeKernelSelf()
+
+        class FakeKernel:
+            run = fake_run
+            triton_meta = {
+                "signature": {
+                    "arg_A": "*fp32",
+                    "arg_C": "*fp32",
+                    "arg_D": "*fp32",
+                    "out_ptr0": "*fp32",
+                    "ks0": "i32",
+                    "ks1": "i32",
+                },
+            }
+
+        class FakeModule:
+            triton_mm_plus_mm = FakeKernel()
+
+        input_meta = [
+            TensorMeta(device=t.device, dtype=t.dtype, sizes=t.shape,
+                       strides=t.stride(), offset=0)
+            for t in [t_A, t_B, t_C, t_D]
+        ]
+        output_meta = TensorMeta(
+            device=out.device, dtype=out.dtype, sizes=out.shape,
+            strides=out.stride(), offset=0,
+        )
+
+        req = TritonBenchmarkRequest(
+            kernel_name="triton_mm_plus_mm",
+            input_tensor_meta=input_meta,
+            output_tensor_meta=output_meta,
+            extra_args=[1, 1, 1],
+            module_path="/dev/null",
+            module_cache_key="fake_key",
+            num_stages=1,
+            num_warps=4,
+            input_param_names=("arg_A", "arg_B", "arg_C", "arg_D"),
+        )
+
+        with patch(
+            "torch._inductor.autotune_process.PyCodeCache.load_by_key_path",
+            return_value=FakeModule(),
+        ):
+            fn = req.make_run_fn(t_A, t_B, t_C, t_D, out=out)
+
+        kept = fn.args[:3]
+        self.assertEqual(len(kept), 3)
+        self.assertIs(kept[0], t_A)
+        self.assertIs(kept[1], t_C)
+        self.assertIs(kept[2], t_D)
+
 
 @instantiate_parametrized_tests
 class TestTemplateConfigPruning(TestCase):
@@ -3804,41 +3878,6 @@ class TestTemplateConfigPruning(TestCase):
                     captured_smem <= smem_estimation,
                     lambda msg: f"{msg}\nEstimated maximum smem should exceed actual smem used for config {c}",
                 )
-
-
-    @unittest.skipUnless(HAS_CUDA_AND_TRITON, "requires CUDA and Triton")
-    def test_bmm_input_dedup_no_stream_overflow(self):
-        """Autotuning bmm after a self-referential bmm must not crash.
-
-        The first compilation produces template kernels where both operands
-        alias the same buffer (input deduplication).  The second compilation's
-        autotuning must handle the reduced parameter count without overflowing
-        positional args into the stream keyword.
-        """
-        dev = GPU_TYPE
-        B, N = 2, 128
-
-        grad = torch.randn(B, N, N, device=dev)
-        m0 = torch.randn(B, N, N, device=dev)
-        m1 = torch.randn(B, N, N, device=dev)
-        q0 = torch.randn(B, N, N, device=dev)
-        q1 = torch.randn(B, N, N, device=dev)
-
-        @torch.compile(fullgraph=True, dynamic=False, mode="max-autotune-no-cudagraphs")
-        def update(grad, m0, m1, beta):
-            outer0 = torch.einsum("...ab,...Ab->...aA", grad, grad)
-            m0.lerp_(outer0, 1 - beta)
-            outer1 = torch.einsum("...ab,...aB->...bB", grad, grad)
-            m1.lerp_(outer1, 1 - beta)
-
-        @torch.compile(fullgraph=True, dynamic=False, mode="max-autotune-no-cudagraphs")
-        def project(grad, q0, q1):
-            return torch.einsum("...ab,...aA,...bB->...AB", grad, q0, q1)
-
-        update(grad, m0, m1, 0.999)
-        result = project(grad.float(), q0.float(), q1.float())
-        expected = torch.einsum("...ab,...aA,...bB->...AB", grad.float(), q0.float(), q1.float())
-        torch.testing.assert_close(result, expected)
 
 
 class TestMaxAutotunePrecompile(TestCase):

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -3772,6 +3772,41 @@ class TestTemplateConfigPruning(TestCase):
                 )
 
 
+    @unittest.skipUnless(HAS_CUDA_AND_TRITON, "requires CUDA and Triton")
+    def test_bmm_input_dedup_no_stream_overflow(self):
+        """Autotuning bmm after a self-referential bmm must not crash.
+
+        The first compilation produces template kernels where both operands
+        alias the same buffer (input deduplication).  The second compilation's
+        autotuning must handle the reduced parameter count without overflowing
+        positional args into the stream keyword.
+        """
+        dev = GPU_TYPE
+        B, N = 2, 128
+
+        grad = torch.randn(B, N, N, device=dev)
+        m0 = torch.randn(B, N, N, device=dev)
+        m1 = torch.randn(B, N, N, device=dev)
+        q0 = torch.randn(B, N, N, device=dev)
+        q1 = torch.randn(B, N, N, device=dev)
+
+        @torch.compile(fullgraph=True, dynamic=False, mode="max-autotune-no-cudagraphs")
+        def update(grad, m0, m1, beta):
+            outer0 = torch.einsum("...ab,...Ab->...aA", grad, grad)
+            m0.lerp_(outer0, 1 - beta)
+            outer1 = torch.einsum("...ab,...aB->...bB", grad, grad)
+            m1.lerp_(outer1, 1 - beta)
+
+        @torch.compile(fullgraph=True, dynamic=False, mode="max-autotune-no-cudagraphs")
+        def project(grad, q0, q1):
+            return torch.einsum("...ab,...aA,...bB->...AB", grad, q0, q1)
+
+        update(grad, m0, m1, 0.999)
+        result = project(grad.float(), q0.float(), q1.float())
+        expected = torch.einsum("...ab,...aA,...bB->...AB", grad.float(), q0.float(), q1.float())
+        torch.testing.assert_close(result, expected)
+
+
 class TestMaxAutotunePrecompile(TestCase):
     def test_precompilation_threads(self):
         import threading

--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -687,7 +687,6 @@ class TritonBenchmarkRequest(BenchmarkRequest):
         kpack: int = 0,  # ROCm specific gemm parameter
         workspace_size: int | None = None,  # size of workspace buffer in bytes
         workspace_zero_fill: bool = False,  # whether to zero-fill workspace
-        input_param_names: tuple[str, ...] | None = None,
     ) -> None:
         super().__init__(kernel_name, input_tensor_meta, output_tensor_meta, extra_args)
         self.module_path = module_path
@@ -701,7 +700,6 @@ class TritonBenchmarkRequest(BenchmarkRequest):
         self.kpack = kpack
         self.workspace_size = workspace_size
         self.workspace_zero_fill = workspace_zero_fill
-        self.input_param_names = input_param_names
         self._benchmark_module: Any | None = None
 
     @override
@@ -720,36 +718,7 @@ class TritonBenchmarkRequest(BenchmarkRequest):
             self.module_path,
         )
 
-        kernel = getattr(mod, self.kernel_name)
-        run_method = kernel.run
-
-        # Template input deduplication can reduce the kernel's parameter
-        # count below len(input_tensors) when a cached candidate compiled
-        # with aliased inputs is benchmarked for a graph with distinct
-        # inputs.  Match by param name to keep the right tensors.
-        triton_meta = getattr(kernel, "triton_meta", None)
-        if triton_meta is not None:
-            sig = triton_meta.get("signature", {})
-            kernel_input_names = [
-                k
-                for k, v in sig.items()
-                if v.startswith("*")
-                and not k.startswith(("out_ptr", "in_out_ptr", "ws_ptr"))
-            ]
-            if len(input_tensors) > len(kernel_input_names):
-                if self.input_param_names is not None:
-                    name_to_idx = {
-                        n: i for i, n in enumerate(self.input_param_names)
-                    }
-                    keep = [name_to_idx[k] for k in kernel_input_names]
-                else:
-                    keep = list(range(len(kernel_input_names)))
-                autotuning_log.debug(
-                    "Trimming input_tensors from %d to %d for %s",
-                    len(input_tensors), len(keep), self.kernel_name,
-                )
-                input_tensors = tuple(input_tensors[i] for i in keep)
-
+        run_method = getattr(mod, self.kernel_name).run
         extra_args = list(self.extra_args)
 
         # Recreate workspace tensor if needed (for TMA templates)

--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -718,7 +718,24 @@ class TritonBenchmarkRequest(BenchmarkRequest):
             self.module_path,
         )
 
-        run_method = getattr(mod, self.kernel_name).run
+        kernel = getattr(mod, self.kernel_name)
+        run_method = kernel.run
+
+        # Template input deduplication can reduce the kernel's parameter
+        # count below len(input_tensors) when a cached candidate compiled
+        # with aliased inputs is benchmarked for a graph with distinct
+        # inputs.  Read the compiled signature to detect the mismatch.
+        triton_meta = getattr(kernel, "triton_meta", None)
+        if triton_meta is not None:
+            n_kernel_args = len(triton_meta.get("signature", {}))
+            n_expected_inputs = max(n_kernel_args - 1, 0)
+            if len(input_tensors) > n_expected_inputs:
+                autotuning_log.debug(
+                    "Trimming input_tensors from %d to %d for %s",
+                    len(input_tensors), n_expected_inputs, self.kernel_name,
+                )
+                input_tensors = input_tensors[:n_expected_inputs]
+
         extra_args = list(self.extra_args)
 
         # Recreate workspace tensor if needed (for TMA templates)

--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -687,6 +687,7 @@ class TritonBenchmarkRequest(BenchmarkRequest):
         kpack: int = 0,  # ROCm specific gemm parameter
         workspace_size: int | None = None,  # size of workspace buffer in bytes
         workspace_zero_fill: bool = False,  # whether to zero-fill workspace
+        input_param_names: tuple[str, ...] | None = None,
     ) -> None:
         super().__init__(kernel_name, input_tensor_meta, output_tensor_meta, extra_args)
         self.module_path = module_path
@@ -700,6 +701,7 @@ class TritonBenchmarkRequest(BenchmarkRequest):
         self.kpack = kpack
         self.workspace_size = workspace_size
         self.workspace_zero_fill = workspace_zero_fill
+        self.input_param_names = input_param_names
         self._benchmark_module: Any | None = None
 
     @override
@@ -724,17 +726,29 @@ class TritonBenchmarkRequest(BenchmarkRequest):
         # Template input deduplication can reduce the kernel's parameter
         # count below len(input_tensors) when a cached candidate compiled
         # with aliased inputs is benchmarked for a graph with distinct
-        # inputs.  Read the compiled signature to detect the mismatch.
+        # inputs.  Match by param name to keep the right tensors.
         triton_meta = getattr(kernel, "triton_meta", None)
         if triton_meta is not None:
-            n_kernel_args = len(triton_meta.get("signature", {}))
-            n_expected_inputs = max(n_kernel_args - 1, 0)
-            if len(input_tensors) > n_expected_inputs:
+            sig = triton_meta.get("signature", {})
+            kernel_input_names = [
+                k
+                for k, v in sig.items()
+                if v.startswith("*")
+                and not k.startswith(("out_ptr", "in_out_ptr", "ws_ptr"))
+            ]
+            if len(input_tensors) > len(kernel_input_names):
+                if self.input_param_names is not None:
+                    name_to_idx = {
+                        n: i for i, n in enumerate(self.input_param_names)
+                    }
+                    keep = [name_to_idx[k] for k in kernel_input_names]
+                else:
+                    keep = list(range(len(kernel_input_names)))
                 autotuning_log.debug(
                     "Trimming input_tensors from %d to %d for %s",
-                    len(input_tensors), n_expected_inputs, self.kernel_name,
+                    len(input_tensors), len(keep), self.kernel_name,
                 )
-                input_tensors = input_tensors[:n_expected_inputs]
+                input_tensors = tuple(input_tensors[i] for i in keep)
 
         extra_args = list(self.extra_args)
 

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2632,11 +2632,29 @@ class GeneratedCodeCache:
         ):
             return None
 
+        # def_kernel deduplicates kernel arguments by buffer name, so inputs
+        # with identical layouts can still generate different code depending
+        # on which of them alias the same buffer, e.g. mm(x, x) (one kernel
+        # arg) vs mm(a, b) (two). Key the aliasing structure name-insensitively.
+        #
+        # def_kernel also drops inputs found in V.graph.removed_buffers or in
+        # kernel.prologue_fused_inputs, but neither needs keying: the cache is
+        # only read and written while lowering generates autotune choices, and
+        # both sets are populated only later, during scheduling, whose template
+        # renders (SIMDScheduling.codegen_template via make_kernel_render)
+        # bypass this cache entirely.
+        names = [node.get_name() for node in input_nodes]
+        first_seen: dict[str, int] = {}
+        input_aliasing = tuple(
+            first_seen.setdefault(name, i) for i, name in enumerate(names)
+        )
+
         return repr(
             {
                 "input_nodes": [
                     layout_key(input.get_layout()) for input in input_nodes
                 ],
+                "input_aliasing": input_aliasing,
                 "num_stages": num_stages,
                 "num_warps": num_warps,
                 "prefix_args": prefix_args,

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2833,6 +2833,13 @@ class GeneratedCodeCache:
         # with identical layouts can still generate different code depending
         # on which of them alias the same buffer, e.g. mm(x, x) (one kernel
         # arg) vs mm(a, b) (two). Key the aliasing structure name-insensitively.
+        #
+        # def_kernel also drops inputs found in V.graph.removed_buffers or in
+        # kernel.prologue_fused_inputs, but neither needs keying: the cache is
+        # only read and written while lowering generates autotune choices, and
+        # both sets are populated only later, during scheduling, whose template
+        # renders (SIMDScheduling.codegen_template via make_kernel_render)
+        # bypass this cache entirely.
         names = [node.get_name() for node in input_nodes]
         first_seen: dict[str, int] = {}
         input_aliasing = tuple(

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2720,7 +2720,6 @@ class GenerateAndLoadResult(NamedTuple):
     prologue_supported_inputs: OrderedSet[str]
     kernel_args_sizevars_keys: tuple[sympy.Expr, ...]
     kernel_options: dict[str, Any]
-    input_param_names: tuple[str, ...]
 
 
 class GeneratedCodeCacheEntry(NamedTuple):
@@ -2830,11 +2829,22 @@ class GeneratedCodeCache:
         ):
             return None
 
+        # def_kernel deduplicates kernel arguments by buffer name, so inputs
+        # with identical layouts can still generate different code depending
+        # on which of them alias the same buffer, e.g. mm(x, x) (one kernel
+        # arg) vs mm(a, b) (two). Key the aliasing structure name-insensitively.
+        names = [node.get_name() for node in input_nodes]
+        first_seen: dict[str, int] = {}
+        input_aliasing = tuple(
+            first_seen.setdefault(name, i) for i, name in enumerate(names)
+        )
+
         return repr(
             {
                 "input_nodes": [
                     layout_key(input.get_layout()) for input in input_nodes
                 ],
+                "input_aliasing": input_aliasing,
                 "num_stages": num_stages,
                 "num_warps": num_warps,
                 "prefix_args": prefix_args,
@@ -3161,7 +3171,6 @@ class TritonTemplate(KernelTemplate):
         mod = PyCodeCache.load(code, extra, set_sys_modules=False)
 
         input_call_args = tuple(kernel.args.input_buffers.keys())
-        input_param_names = tuple(kernel.args.input_buffers.values())
         prologue_supported_inputs = kernel.prologue_supported_inputs.copy()
         kernel_args_sizevars_keys = tuple(kernel.args.sizevars.keys())
 
@@ -3175,7 +3184,6 @@ class TritonTemplate(KernelTemplate):
             prologue_supported_inputs,
             kernel_args_sizevars_keys,
             kernel_options,
-            input_param_names,
         )
 
     def generate(  # type: ignore[override]
@@ -3370,7 +3378,6 @@ class TritonTemplate(KernelTemplate):
             workspace_zero_fill=workspace_zero_fill,
             input_tensor_meta=TensorMeta.from_irnodes(kernel_input_nodes),  # type: ignore[arg-type]
             output_tensor_meta=TensorMeta.from_irnodes(layout),
-            input_param_names=result.input_param_names,
         )
 
         # Convolution-specific parameters to include in logging

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2720,6 +2720,7 @@ class GenerateAndLoadResult(NamedTuple):
     prologue_supported_inputs: OrderedSet[str]
     kernel_args_sizevars_keys: tuple[sympy.Expr, ...]
     kernel_options: dict[str, Any]
+    input_param_names: tuple[str, ...]
 
 
 class GeneratedCodeCacheEntry(NamedTuple):
@@ -3160,6 +3161,7 @@ class TritonTemplate(KernelTemplate):
         mod = PyCodeCache.load(code, extra, set_sys_modules=False)
 
         input_call_args = tuple(kernel.args.input_buffers.keys())
+        input_param_names = tuple(kernel.args.input_buffers.values())
         prologue_supported_inputs = kernel.prologue_supported_inputs.copy()
         kernel_args_sizevars_keys = tuple(kernel.args.sizevars.keys())
 
@@ -3173,6 +3175,7 @@ class TritonTemplate(KernelTemplate):
             prologue_supported_inputs,
             kernel_args_sizevars_keys,
             kernel_options,
+            input_param_names,
         )
 
     def generate(  # type: ignore[override]
@@ -3367,6 +3370,7 @@ class TritonTemplate(KernelTemplate):
             workspace_zero_fill=workspace_zero_fill,
             input_tensor_meta=TensorMeta.from_irnodes(kernel_input_nodes),  # type: ignore[arg-type]
             output_tensor_meta=TensorMeta.from_irnodes(layout),
+            input_param_names=result.input_param_names,
         )
 
         # Convolution-specific parameters to include in logging


### PR DESCRIPTION
# Fix positional arg overflow in `TritonBenchmarkRequest` when template inputs are deduplicated

Fixes #188069

When bmm template codegen deduplicates kernel inputs (both operands alias the same buffer, e.g. `einsum("...ab,...Ab->...aA", grad, grad)`), the compiled kernel expects fewer positional parameters than `TritonBenchmarkRequest.make_run_fn()` provides. The excess tensor overflows into the `stream` parameter slot, producing `TypeError: too many positional arguments`.

This happens when two compilations run in sequence: the first caches a deduplicated bmm kernel, the second's autotuner reuses that cached candidate but passes more input tensors than the kernel accepts.

The CUTLASS path handles a similar case via `dict.fromkeys` on `input_tensor_meta` names, but that doesn't work here because the meta reflects the *current* graph's inputs (2 unique names), not the *cached* kernel's actual param count (1 input after dedup). Tested it and it still crashes 4/5 on 2.12.0.

This PR reads `triton_meta["signature"]` from the loaded kernel to get its actual parameter count and trims `input_tensors` to match. The check is a no-op when counts already agree.

Tested on RTX 3090, 5 trials per configuration with isolated caches:

| | Baseline | Patched |
|---|---|---|
| 2.12.0+cu130 | 1-2/5 crash | 0/5 |
| Nightly 2.14.0.dev20260625 | 0-2/5 crash | 0/5 |


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @jananisriram 