### PR TITLE
Fix inplace modification error with softmax when combining forward and backward AD

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -12930,6 +12930,23 @@ class TestAutogradForwardMode(TestCase):
         b = torch.randn(1, 2)
         check(a, b)
 
+    def test_softmax_forward_backward_ad(self):
+        # Regression test for gh-162350
+        ops = {
+            "softmax": lambda x: x.softmax(dim=-1),
+            "log_softmax": lambda x: x.log_softmax(dim=-1),
+            "logsumexp": lambda x: x.logsumexp(dim=-1),
+        }
+        for name, op in ops.items():
+            with self.subTest(op=name):
+                acts = torch.randn(3, 6, 16, requires_grad=True)
+                with fwAD.dual_level():
+                    dual_input = fwAD.make_dual(acts, torch.randn_like(acts))
+                    x = op(dual_input)
+                    x = x + fwAD.unpack_dual(x).tangent
+                    primal, _ = fwAD.unpack_dual(x)
+                    primal.sum().backward()
+
     def test_backward_graph_destruction(self):
         def fn():
             a = torch.rand(10, requires_grad=True)

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -7091,7 +7091,7 @@ Tensor logsumexp_jvp(
   //     that only have one differentiable input, because that means self_t are
   //     never zerotensors
   TORCH_INTERNAL_ASSERT(!self_t._is_zerotensor())
-  if (areAnyTensorSubclassLike({self_p, self_t})) {
+  if (areAnyTensorSubclassLike({self_p, self_t}) || self_p_exp.requires_grad()) {
     auto result = (self_p_exp * self_t).sum(dim, keepdim);
     result /= sumexp_p;
     return result;


### PR DESCRIPTION
Fixes #162350

## Summary

- `logsumexp_jvp` did an inplace `*=` on the output of `.exp()`, which bumped the version counter. When backward AD was also active, `ExpBackward0` needed that tensor at version 0 and crashed.
- Added `|| self_p_exp.requires_grad()` to the existing branch condition so the non-inplace path is taken when the tensor is tracked by backward AD. The inplace fast path is preserved for forward-AD-only.
- Covers `softmax`, `log_softmax`, `logsumexp`, and `_safe_softmax` (via `safe_logsumexp_jvp` which delegates to `logsumexp_jvp`).

## Test plan

```
python test/test_autograd.py TestAutogradForwardMode.test_softmax_forward_backward_ad -v
python test/test_autograd.py TestAutogradForwardMode -v
python test/test_autograd.py TestAutogradForwardModeBatchedGrad -v
```