### PR TITLE
Allow PrivateUse1 backends to opt out of CEA decomposition

### DIFF
--- a/aten/src/ATen/core/dispatch/Dispatcher.cpp
+++ b/aten/src/ATen/core/dispatch/Dispatcher.cpp
@@ -479,6 +479,27 @@ void Dispatcher::deregisterFallback_(DispatchKey dispatchKey) {
   }
 }
 
+RegistrationHandleRAII Dispatcher::setPrivateUse1SkipCEA() {
+  std::lock_guard<std::mutex> lock(guard_->mutex);
+  TORCH_CHECK(
+      !privateuse1_skip_cea_.load(std::memory_order_relaxed),
+      "Attempted to register PrivateUse1 CEA skip, but one is already active. "
+      "Release the existing handle before registering a new one.");
+  privateuse1_skip_cea_.store(true, std::memory_order_relaxed);
+  for (auto& op : operators_) {
+    op.op.updateFallback(*this, DispatchKey::PrivateUse1);
+  }
+  return RegistrationHandleRAII([guard = this->guard_, this] {
+    std::lock_guard<std::mutex> lock(guard->mutex);
+    if (!guard->alive.load()) {
+      return;
+    }
+    privateuse1_skip_cea_.store(false, std::memory_order_relaxed);
+    for (auto& op : operators_) {
+      op.op.updateFallback(*this, DispatchKey::PrivateUse1);
+    }
+  });
+}
 
 RegistrationHandleRAII Dispatcher::addRegistrationListener(std::unique_ptr<OpRegistrationListener> listener) {
   std::lock_guard<std::mutex> lock(guard_->mutex);

--- a/aten/src/ATen/core/dispatch/Dispatcher.h
+++ b/aten/src/ATen/core/dispatch/Dispatcher.h
@@ -10,6 +10,7 @@
 #include <c10/core/SafePyObject.h>
 #include <c10/util/Exception.h>
 #include <c10/util/LeftRight.h>
+#include <atomic>
 #include <condition_variable>
 #include <list>
 #include <mutex>
@@ -297,6 +298,34 @@ class TORCH_API Dispatcher final {
       std::string debug);
 
   /**
+   * Opt the PrivateUse1 backend out of CompositeExplicitAutograd (CEA) and
+   * CompositeExplicitAutogradNonFunctional (CEANF) decompositions.
+   *
+   * By default the dispatch table resolves CEA kernels before the backend
+   * fallback, so a PrivateUse1 backend that registers a catch-all fallback
+   * never sees composite ops — it only receives the decomposed primitives
+   * (e.g. softmax -> _softmax).  Calling this function causes the dispatcher
+   * to skip the CEA/CEANF alias lookup for PrivateUse1 and route directly to
+   * the registered backend fallback instead.
+   *
+   * Direct PrivateUse1 kernel registrations are unaffected and always take
+   * priority over both CEA and the fallback.
+   *
+   * Returns a RAII handle.  The opt-out is active for as long as the handle
+   * is alive; destroying it restores the previous behavior and refreshes the
+   * PrivateUse1 dispatch table entries for all operators.
+   *
+   * Only one opt-out may be active at a time; attempting to register a second
+   * one before releasing the first raises an error.
+   */
+  TORCH_API RegistrationHandleRAII setPrivateUse1SkipCEA();
+
+  // Returns true if PrivateUse1 is currently opted out of CEA decompositions.
+  bool privateuse1SkipCEA() const {
+    return privateuse1_skip_cea_.load(std::memory_order_relaxed);
+  }
+
+  /**
    * Use to register whenever we had a TORCH_LIBRARY declaration in the frontend
    * API.  These invocations are only permitted once per program, so we raise
    * an error if this is called again for the same namespace.
@@ -411,6 +440,16 @@ class TORCH_API Dispatcher final {
 
   std::array<impl::AnnotatedKernel, num_runtime_entries>
       backendFallbackKernels_;
+
+  // When true, the CEA and CEANF alias lookup steps are skipped for
+  // PrivateUse1 during dispatch table computation, allowing ops to fall
+  // through to the registered backend fallback instead.
+  // Written under guard_->mutex alongside the dispatch table refresh loop.
+  // Read via relaxed atomic load — both inside
+  // computeDispatchTableEntryWithDebug() (called under the mutex during table
+  // rebuilds) and from the public privateuse1SkipCEA() getter (called without
+  // the mutex).
+  std::atomic<bool> privateuse1_skip_cea_{false};
 
   std::unique_ptr<detail::RegistrationListenerList> listeners_;
 

--- a/aten/src/ATen/core/dispatch/OperatorEntry.cpp
+++ b/aten/src/ATen/core/dispatch/OperatorEntry.cpp
@@ -389,9 +389,15 @@ std::pair<const AnnotatedKernel&, const char*> OperatorEntry::computeDispatchTab
     return {*direct_registration, "kernel"};
   }
 
+  // Skip CEA/CEANF alias lookups for PrivateUse1 when the opt-out is active.
+  const bool skip_cea = (dispatch_key == DispatchKey::PrivateUse1 &&
+                         dispatcher.privateuse1SkipCEA());
+
   // 2.1 Use CompositeExplicitAutogradNonFunctional kernel if available.
   //     See Note [Undefined in dispatchTable_] for the special handling for Undefined.
-  if (dispatch_key == DispatchKey::Undefined || isIncludedInAlias(dispatch_key, DispatchKey::CompositeExplicitAutogradNonFunctional)) {
+  if (!skip_cea &&
+      (dispatch_key == DispatchKey::Undefined ||
+       isIncludedInAlias(dispatch_key, DispatchKey::CompositeExplicitAutogradNonFunctional))) {
     if (auto default_backend_registration = getKernelForDispatchKey(DispatchKey::CompositeExplicitAutogradNonFunctional)) {
       return {*default_backend_registration, "default backend kernel"};
     }
@@ -399,7 +405,9 @@ std::pair<const AnnotatedKernel&, const char*> OperatorEntry::computeDispatchTab
 
   // 2.2 Use CompositeExplicitAutograd kernel if available.
   //     See Note [Undefined in dispatchTable_] for the special handling for Undefined.
-  if (dispatch_key == DispatchKey::Undefined || isIncludedInAlias(dispatch_key, DispatchKey::CompositeExplicitAutograd)) {
+  if (!skip_cea &&
+      (dispatch_key == DispatchKey::Undefined ||
+       isIncludedInAlias(dispatch_key, DispatchKey::CompositeExplicitAutograd))) {
     if (auto default_backend_registration = getKernelForDispatchKey(DispatchKey::CompositeExplicitAutograd)) {
       return {*default_backend_registration, "default backend kernel"};
     }

--- a/docs/source/utils.md
+++ b/docs/source/utils.md
@@ -29,6 +29,7 @@
 
     generate_methods_for_privateuse1_backend
     rename_privateuse1_backend
+    skip_cea_decomposition_for_privateuse1
 ```
 
 # torch.utils.hooks

--- a/test/test_dispatch.py
+++ b/test/test_dispatch.py
@@ -5,10 +5,13 @@ import os
 import re
 from collections import namedtuple
 
+import torch
 import torch._C as C
+import torch.utils
 import torch.utils.cpp_extension
 from torch._python_dispatcher import PythonDispatcher
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.library import _scoped_library
+from torch.testing._internal.common_utils import run_tests, skipIfTorchDynamo, TestCase
 
 
 # TODO: Expand the dispatcher API to be a generic API for interfacing with
@@ -1146,6 +1149,173 @@ CompositeImplicitAutograd[alias] fn_CompositeImplicitAutograd
             "Could not run 'aten::bmm.out' with arguments from the 'QuantizedCPU' backend.",
             lambda: torch.bmm(qx, qy),
         )
+
+
+def _privateuse1_has_backend_fallback() -> bool:
+    handle = torch.utils.skip_cea_decomposition_for_privateuse1()
+    try:
+        dump = torch._C._dispatch_dump_table("aten::convolution")
+        for line in dump.splitlines():
+            if line.strip().startswith("PrivateUse1:"):
+                return "[backend fallback]" in line
+        return False
+    finally:
+        del handle
+
+
+@skipIfTorchDynamo("RAII handle release via del is not reliable under Dynamo")
+class TestPrivateUse1SkipCEAFlag(TestCase):
+    """Tests for the skip_cea_decomposition_for_privateuse1() RAII API."""
+
+    def test_flag_is_false_by_default(self):
+        self.assertFalse(torch._C._dispatch_privateuse1_skip_cea_enabled())
+
+    def test_handle_activates_flag(self):
+        handle = torch.utils.skip_cea_decomposition_for_privateuse1()
+        try:
+            self.assertTrue(torch._C._dispatch_privateuse1_skip_cea_enabled())
+        finally:
+            del handle
+
+    def test_handle_restores_flag_on_delete(self):
+        handle = torch.utils.skip_cea_decomposition_for_privateuse1()
+        del handle
+        self.assertFalse(torch._C._dispatch_privateuse1_skip_cea_enabled())
+
+    def test_handle_restores_flag_after_exception(self):
+        handle = torch.utils.skip_cea_decomposition_for_privateuse1()
+        try:
+            raise RuntimeError("simulated error")
+        except RuntimeError:
+            pass
+        finally:
+            del handle
+        self.assertFalse(torch._C._dispatch_privateuse1_skip_cea_enabled())
+
+    def test_double_registration_raises(self):
+        handle = torch.utils.skip_cea_decomposition_for_privateuse1()
+        try:
+            with self.assertRaisesRegex(RuntimeError, "already active"):
+                torch.utils.skip_cea_decomposition_for_privateuse1()
+        finally:
+            del handle
+
+    def test_flag_can_be_re_enabled_after_release(self):
+        handle1 = torch.utils.skip_cea_decomposition_for_privateuse1()
+        del handle1
+        handle2 = torch.utils.skip_cea_decomposition_for_privateuse1()
+        self.assertTrue(torch._C._dispatch_privateuse1_skip_cea_enabled())
+        del handle2
+        self.assertFalse(torch._C._dispatch_privateuse1_skip_cea_enabled())
+
+
+@skipIfTorchDynamo("RAII handle release via del is not reliable under Dynamo")
+class TestPrivateUse1SkipCEATableInspection(TestCase):
+    """Tests that skip_cea changes dispatch table entries for CEA ops only."""
+
+    _pu1_fallback_ctx = None
+
+    @classmethod
+    def setUpClass(cls):
+        if _privateuse1_has_backend_fallback():
+            cls._pu1_fallback_ctx = None
+        else:
+            cls._pu1_fallback_ctx = _scoped_library("_", "IMPL", "PrivateUse1")
+            lib = cls._pu1_fallback_ctx.__enter__()
+
+            def _privateuse1_test_fallback(op, *args, **kwargs):
+                raise NotImplementedError(f"PrivateUse1 test fallback for {op.name()}")
+
+            lib.fallback(_privateuse1_test_fallback, "PrivateUse1")
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls._pu1_fallback_ctx is not None:
+            cls._pu1_fallback_ctx.__exit__(None, None, None)
+            cls._pu1_fallback_ctx = None
+
+    def _pu1_entry(self, op_name: str) -> str:
+        dump = torch._C._dispatch_dump_table(op_name)
+        for line in dump.splitlines():
+            if line.strip().startswith("PrivateUse1:"):
+                return line.strip()
+        self.fail(f"PrivateUse1 entry not found in dispatch table for {op_name!r}")
+
+    def test_cea_op_shows_default_backend_kernel_without_skip(self):
+        entry = self._pu1_entry("aten::convolution")
+        self.assertIn(
+            "[default backend kernel]",
+            entry,
+            f"Expected CEA ([default backend kernel]) for convolution; got: {entry!r}",
+        )
+
+    def test_cea_op_shows_backend_fallback_with_skip(self):
+        handle = torch.utils.skip_cea_decomposition_for_privateuse1()
+        try:
+            entry = self._pu1_entry("aten::convolution")
+            self.assertIn(
+                "[backend fallback]",
+                entry,
+                f"Expected [backend fallback] for convolution with skip; got: {entry!r}",
+            )
+        finally:
+            del handle
+
+    def test_cea_table_entry_restored_after_handle_released(self):
+        handle = torch.utils.skip_cea_decomposition_for_privateuse1()
+        del handle
+        entry = self._pu1_entry("aten::convolution")
+        self.assertIn(
+            "[default backend kernel]",
+            entry,
+            f"Expected CEA restored after del handle; got: {entry!r}",
+        )
+
+    def test_cia_op_table_entry_unchanged_by_skip(self):
+        entry_before = self._pu1_entry("aten::softmax.int")
+        handle = torch.utils.skip_cea_decomposition_for_privateuse1()
+        try:
+            entry_after = self._pu1_entry("aten::softmax.int")
+            self.assertIn("[math kernel]", entry_before)
+            self.assertEqual(
+                entry_before,
+                entry_after,
+                "softmax.int (CIA) dispatch table entry must not change with skip_cea",
+            )
+        finally:
+            del handle
+
+    def _backend_entry(self, op_name: str, key: str) -> str:
+        dump = torch._C._dispatch_dump_table(op_name)
+        for line in dump.splitlines():
+            if line.strip().startswith(key):
+                return line.strip()
+        self.fail(f"{key} entry not found in dispatch table for {op_name!r}")
+
+    def test_cpu_cuda_slots_unaffected_by_skip(self):
+        cpu_before = self._backend_entry("aten::convolution", "CPU:")
+        cuda_before = (
+            self._backend_entry("aten::convolution", "CUDA:")
+            if torch.cuda.is_available()
+            else None
+        )
+        handle = torch.utils.skip_cea_decomposition_for_privateuse1()
+        try:
+            cpu_after = self._backend_entry("aten::convolution", "CPU:")
+            self.assertEqual(
+                cpu_before,
+                cpu_after,
+                "CPU dispatch table entry for convolution must not change with skip_cea",
+            )
+            if cuda_before is not None:
+                cuda_after = self._backend_entry("aten::convolution", "CUDA:")
+                self.assertEqual(
+                    cuda_before,
+                    cuda_after,
+                    "CUDA dispatch table entry for convolution must not change with skip_cea",
+                )
+        finally:
+            del handle
 
 
 if __name__ == "__main__":

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -847,6 +847,34 @@ static PyObject* THModule_get_privateuse1_backend_name(
   END_HANDLE_TH_ERRORS
 }
 
+// Opt the PrivateUse1 backend out of CEA/CEANF decompositions.
+// Returns a PyCapsule holding the RAII handle; destroying it restores the
+// previous behavior.
+static PyObject* THModule_set_privateuse1_skip_cea(
+    PyObject* _unused,
+    PyObject* noargs) {
+  HANDLE_TH_ERRORS
+  auto handle = new c10::RegistrationHandleRAII(
+      c10::Dispatcher::singleton().setPrivateUse1SkipCEA());
+  return PyCapsule_New(handle, "PrivateUse1SkipCEAHandle", [](PyObject* cap) {
+    delete static_cast<c10::RegistrationHandleRAII*>(
+        PyCapsule_GetPointer(cap, "PrivateUse1SkipCEAHandle"));
+  });
+  END_HANDLE_TH_ERRORS
+}
+
+// Returns True if PrivateUse1 is currently opted out of CEA decompositions.
+static PyObject* THModule_privateuse1_skip_cea_enabled(
+    PyObject* _unused,
+    PyObject* noargs) {
+  HANDLE_TH_ERRORS
+  if (c10::Dispatcher::singleton().privateuse1SkipCEA()) {
+    Py_RETURN_TRUE;
+  }
+  Py_RETURN_FALSE;
+  END_HANDLE_TH_ERRORS
+}
+
 static PyObject* THPModule_setAllowTF32CuDNN(PyObject* _unused, PyObject* arg) {
   HANDLE_TH_ERRORS
   TORCH_CHECK(
@@ -2185,6 +2213,14 @@ static std::initializer_list<PyMethodDef> TorchMethods = {
      nullptr},
     {"_get_privateuse1_backend_name",
      THModule_get_privateuse1_backend_name,
+     METH_NOARGS,
+     nullptr},
+    {"_dispatch_set_privateuse1_skip_cea",
+     THModule_set_privateuse1_skip_cea,
+     METH_NOARGS,
+     nullptr},
+    {"_dispatch_privateuse1_skip_cea_enabled",
+     THModule_privateuse1_skip_cea_enabled,
      METH_NOARGS,
      nullptr},
     {"set_flush_denormal", THPModule_setFlushDenormal, METH_O, nullptr},

--- a/torch/utils/__init__.py
+++ b/torch/utils/__init__.py
@@ -15,6 +15,7 @@ from torch.utils import (
 from torch.utils.backend_registration import (
     generate_methods_for_privateuse1_backend,
     rename_privateuse1_backend,
+    skip_cea_decomposition_for_privateuse1,
 )
 from torch.utils.cpp_backtrace import get_cpp_backtrace
 from torch.utils.throughput_benchmark import ThroughputBenchmark

--- a/torch/utils/backend_registration.py
+++ b/torch/utils/backend_registration.py
@@ -8,6 +8,7 @@ from torch.overrides import handle_torch_function, has_torch_function_unary
 __all__ = [
     "rename_privateuse1_backend",
     "generate_methods_for_privateuse1_backend",
+    "skip_cea_decomposition_for_privateuse1",
 ]
 
 # TODO: Should use `torch._C._get_privateuse1_backend_name()` to get
@@ -501,6 +502,40 @@ def _get_custom_mod_func(func_name: str):
         message += f"BackendModule needs to have the following API's:\n `{func_name}(*args, **kwargs)`. \n"
         raise RuntimeError(message)
     return function
+
+
+def skip_cea_decomposition_for_privateuse1():
+    r"""Opt the PrivateUse1 backend out of CompositeExplicitAutograd decompositions.
+
+    By default, PyTorch resolves CompositeExplicitAutograd (CEA) kernels
+    *before* the backend fallback in the dispatch table.  A PrivateUse1 backend
+    that registers a single catch-all fallback therefore never sees composite
+    ops — it only receives the already-decomposed primitives (e.g. ``softmax``
+    becomes ``_softmax``).
+
+    Calling this function tells the dispatcher to skip the CEA and
+    CompositeExplicitAutogradNonFunctional alias lookups for PrivateUse1 so
+    that ops with only a CEA kernel fall through to the registered backend
+    fallback instead.  Ops that have a direct PrivateUse1 kernel registered
+    are unaffected (direct registrations always take priority).
+
+    Returns an opaque handle.  The opt-out is active for as long as the handle
+    is alive.  Releasing it (``del handle``) restores the previous behavior and
+    refreshes all affected dispatch table entries automatically.
+
+    Only one opt-out may be active at a time.  Calling this function again
+    before releasing the existing handle raises :class:`RuntimeError`.
+
+    Example::
+
+        >>> # xdoctest: +SKIP("requires PrivateUse1 backend registration")
+        >>> handle = torch.utils.skip_cea_decomposition_for_privateuse1()
+        >>> # CEA-covered ops (softmax, conv, layer_norm, …) now route to
+        >>> # the PrivateUse1 fallback unchanged.
+        >>> del handle  # restore previous behavior
+
+    """
+    return torch._C._dispatch_set_privateuse1_skip_cea()  # type: ignore[attr-defined]
 
 
 class _DummyBackendModule:


### PR DESCRIPTION
## Background

Fixes #188052

PyTorch's dispatch table resolves CEA/CEANF kernels before the backend fallback. PrivateUse1 backends that register a single catch-all fallback never see composite ops intact — e.g. `convolution` is silently decomposed to `convolution_overrideable` (a stub that raises `NotImplementedError`) before the fallback fires. There is no way to bypass this without registering a per-op stub for every CEA-aliased op, a list that grows silently with each PyTorch release.

## Solution

A new atomic flag `privateuse1_skip_cea_` on the `Dispatcher`, checked during `computeDispatchTableEntryWithDebug()`. When set, alias lookups for steps 2.1 (CEANF) and 2.2 (CEA) are skipped for PrivateUse1, letting the dispatch table entry fall through to the backend fallback. The flag is written once under the dispatcher mutex along with a full table refresh — **zero hot-path overhead**.

Returns a RAII handle whose destructor restores the previous behavior and refreshes the table. `CompositeImplicitAutograd` (CIA) is intentionally unaffected — skipping it would break autograd for ops like `conv2d` and `layer_norm`.

```python
handle = torch.utils.skip_cea_decomposition_for_privateuse1()
torch._C._dispatch_privateuse1_skip_cea_enabled()  # True
del handle  # restores previous behavior
```

## Testing

Two new test classes in `test/test_dispatch.py`:

- **`TestPrivateUse1SkipCEAFlag`** — flag/RAII semantics: enable, query, RAII restore, double-registration guard, re-enable after release.
- **`TestPrivateUse1SkipCEATableInspection`** — dispatch table: CEA slot changes on skip, CIA slot unaffected, table restored after release, CPU/CUDA slots unaffected.

All 11 new tests pass. No physical device required.