### PR TITLE
Fix quantized ONNX gather export

### DIFF
--- a/torch/onnx/_internal/torchscript_exporter/symbolic_opset11.py
+++ b/torch/onnx/_internal/torchscript_exporter/symbolic_opset11.py
@@ -386,6 +386,7 @@ def __interpolate(
 
 
 @_onnx_symbolic("aten::gather")
+@symbolic_helper.quantized_args(True)
 @symbolic_helper.parse_args("v", "i", "v", "v")
 def gather(g: jit_utils.GraphContext, self, dim, index, sparse_grad=False):
     if symbolic_helper._maybe_get_const(sparse_grad, "i"):


### PR DESCRIPTION
## Issue

Fixes #157490

## Summary

Quantized `gather` export should unpack the quantized tensor input before lowering. This adds the same `quantized_args` handling used by similar tensor-input symbolics, while leaving the integer index unchanged.

This is intentionally a one-line symbolic fix without a new regression test: eager `aten::gather` has no QuantizedCPU kernel, so a functional export test fails before reaching this symbolic. Existing precedent for similar decorator-only support (for example `select`) does not add a functional quantized test.

## Checklist

- [x] Passes lint (`python scripts/lintrunner.py -a`)
- [ ] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No.
