### PR TITLE
check_binary_symbols: only check win32-headers.h on Windows

### DIFF
--- a/.ci/pytorch/smoke_test/check_binary_symbols.py
+++ b/.ci/pytorch/smoke_test/check_binary_symbols.py
@@ -322,8 +322,11 @@ def check_headeronly_symbols(install_root: Path) -> None:
     # Filter out platform-specific headers that may not compile everywhere
     platform_specific_keywords = [
         "cpu/vec",
-        "win32-headers.h",
     ]
+    # win32-headers.h pulls in <windows.h>; only include it in the check on
+    # Windows so it is exercised there but does not break the Linux/macOS check.
+    if os.name != "nt":
+        platform_specific_keywords.append("win32-headers.h")
 
     filtered_headers = []
     for header in headeronly_headers:


### PR DESCRIPTION
## Summary

Implements @janeyx99's suggestion: handle the Windows-only header in the `check_headeronly` job rather than touching the header.

`check_binary_symbols.py::check_headeronly_symbols` compiles a TU that includes every `torch/headeronly` header. `torch/headeronly/util/win32-headers.h` pulls in `<windows.h>`/`<dbghelp.h>` and only compiles on Windows, so on Linux it fails with:

```
torch/include/torch/headeronly/util/win32-headers.h:39:10: fatal error: windows.h: No such file or directory
```

#187655 already excludes `win32-headers.h` from the check, but unconditionally (so it is never exercised, even on Windows). This refines that to exclude it **only when not on Windows** (`os.name != "nt"`), so the header is still checked on Windows while the Linux/macOS check stays green.

## Test plan

- Linux/macOS: `win32-headers.h` is skipped, header-only check compiles.
- Windows: `win32-headers.h` is included and compiled.

Surfaced by the `release/2.13` Python 3.15 binary validation. This is intended to be cherry-picked to `release/2.13`, whose `check_binary_symbols.py` does not exclude `win32-headers.h` at all yet.
