### PR TITLE
Tighten torch._check (and friends) to take a LiteralString rather than str

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -36,6 +36,7 @@ from typing import (
 )
 from typing_extensions import (
     deprecated as _deprecated,
+    LiteralString as _LiteralString,
     Never as _Never,
     ParamSpec as _ParamSpec,
     Self as _Self,
@@ -2051,7 +2052,7 @@ def is_warn_always_enabled() -> builtins.bool:
 def _check_with(
     error_type: type[BaseException],
     cond: builtins.bool | SymBool,
-    message: str | _Callable[[], object] | None,
+    message: _LiteralString | _Callable[[], object] | None,
 ) -> None:
     if not isinstance(cond, (builtins.bool, SymBool)):
         if isinstance(cond, torch.Tensor):
@@ -2089,7 +2090,8 @@ def _check_with(
 
 
 def _check(
-    cond: builtins.bool | SymBool, message: str | _Callable[[], object] | None = None
+    cond: builtins.bool | SymBool,
+    message: _LiteralString | _Callable[[], object] | None = None,
 ) -> None:
     r"""Throws error containing an optional message if the specified condition
     is False.
@@ -2101,9 +2103,10 @@ def _check(
     Args:
         cond (:class:`bool`): If False, throw error
 
-        message (str or Callable, optional): A string, or a callable that
-            returns a string or an object with a ``__str__()`` method, to be
-            used as the error message. Default: ``None``
+        message (LiteralString or Callable, optional): A literal string, or a
+            callable that returns a string or an object with a ``__str__()``
+            method, to be used as the error message. Use the callable form for a
+            dynamically constructed message. Default: ``None``
     """
     _check_with(RuntimeError, cond, message)
 
@@ -2115,7 +2118,7 @@ def _check(
 )
 def _check_is_size(
     i: "IntLikeType",
-    message: str | _Callable[[], object] | None = None,
+    message: _LiteralString | _Callable[[], object] | None = None,
     *,
     max: "IntLikeType | None" = None,
 ) -> None:
@@ -2150,7 +2153,8 @@ def _check_is_size(
 
 
 def _check_index(
-    cond: builtins.bool | SymBool, message: str | _Callable[[], object] | None = None
+    cond: builtins.bool | SymBool,
+    message: _LiteralString | _Callable[[], object] | None = None,
 ) -> None:
     r"""Throws error containing an optional message if the specified condition
     is False.
@@ -2162,15 +2166,17 @@ def _check_index(
     Args:
         cond (:class:`bool`): If False, throw error
 
-        message (str or Callable, optional): A string, or a callable that
-            returns a string or an object with a ``__str__()`` method, to be
-            used as the error message. Default: ``None``
+        message (LiteralString or Callable, optional): A literal string, or a
+            callable that returns a string or an object with a ``__str__()``
+            method, to be used as the error message. Use the callable form for a
+            dynamically constructed message. Default: ``None``
     """
     _check_with(IndexError, cond, message)
 
 
 def _check_value(
-    cond: builtins.bool | SymBool, message: str | _Callable[[], object] | None = None
+    cond: builtins.bool | SymBool,
+    message: _LiteralString | _Callable[[], object] | None = None,
 ) -> None:
     r"""Throws error containing an optional message if the specified condition
     is False.
@@ -2182,15 +2188,17 @@ def _check_value(
     Args:
         cond (:class:`bool`): If False, throw error
 
-        message (str or Callable, optional): A string, or a callable that
-            returns a string or an object with a ``__str__()`` method, to be
-            used as the error message. Default: ``None``
+        message (LiteralString or Callable, optional): A literal string, or a
+            callable that returns a string or an object with a ``__str__()``
+            method, to be used as the error message. Use the callable form for a
+            dynamically constructed message. Default: ``None``
     """
     _check_with(ValueError, cond, message)
 
 
 def _check_type(
-    cond: builtins.bool | SymBool, message: str | _Callable[[], object] | None = None
+    cond: builtins.bool | SymBool,
+    message: _LiteralString | _Callable[[], object] | None = None,
 ) -> None:
     r"""Throws error containing an optional message if the specified condition
     is False.
@@ -2202,15 +2210,17 @@ def _check_type(
     Args:
         cond (:class:`bool`): If False, throw error
 
-        message (str or Callable, optional): A string, or a callable that
-            returns a string or an object with a ``__str__()`` method, to be
-            used as the error message. Default: ``None``
+        message (LiteralString or Callable, optional): A literal string, or a
+            callable that returns a string or an object with a ``__str__()``
+            method, to be used as the error message. Use the callable form for a
+            dynamically constructed message. Default: ``None``
     """
     _check_with(TypeError, cond, message)
 
 
 def _check_not_implemented(
-    cond: builtins.bool | SymBool, message: str | _Callable[[], object] | None = None
+    cond: builtins.bool | SymBool,
+    message: _LiteralString | _Callable[[], object] | None = None,
 ) -> None:
     r"""Throws error containing an optional message if the specified condition
     is False.
@@ -2222,9 +2232,10 @@ def _check_not_implemented(
     Args:
         cond (:class:`bool`): If False, throw error
 
-        message (str or Callable, optional): A string, or a callable that
-            returns a string or an object with a ``__str__()`` method, to be
-            used as the error message. Default: ``None``
+        message (LiteralString or Callable, optional): A literal string, or a
+            callable that returns a string or an object with a ``__str__()``
+            method, to be used as the error message. Use the callable form for a
+            dynamically constructed message. Default: ``None``
     """
     _check_with(NotImplementedError, cond, message)
 
@@ -2232,7 +2243,7 @@ def _check_not_implemented(
 def _check_tensor_all_with(
     error_type: type[BaseException],
     cond: "torch.Tensor",
-    message: str | _Callable[[], object] | None = None,
+    message: _LiteralString | _Callable[[], object] | None = None,
 ) -> None:
     if not is_tensor(cond):
         raise TypeError(f"cond must be a tensor, but got {type(cond)}")
@@ -2245,7 +2256,8 @@ def _check_tensor_all_with(
 
 # C++ equivalent: `TORCH_CHECK_TENSOR_ALL`
 def _check_tensor_all(
-    cond: "torch.Tensor", message: str | _Callable[[], object] | None = None
+    cond: "torch.Tensor",
+    message: _LiteralString | _Callable[[], object] | None = None,
 ) -> None:
     r"""Throws error containing an optional message if the specified condition
     is False.
@@ -2258,9 +2270,10 @@ def _check_tensor_all(
         cond (:class:`torch.Tensor`): Tensor of dtype ``torch.bool``. If any
             element is ``False``, throw error
 
-        message (str or Callable, optional): A string, or a callable that
-            returns a string or an object with a ``__str__()`` method, to be
-            used as the error message. Default: ``None``
+        message (LiteralString or Callable, optional): A literal string, or a
+            callable that returns a string or an object with a ``__str__()``
+            method, to be used as the error message. Use the callable form for a
+            dynamically constructed message. Default: ``None``
     """
     _check_tensor_all_with(RuntimeError, cond, message)
 


### PR DESCRIPTION
Prior to #186323 `torch._check` didn't accept a literal string message but many callers were passing a string and it wasn't caught because there was no type annotation. Worse than that if you passed a string you only got the error message ("message must be a callable") when the check failed (without your original message - so you lost logging information for that run).

#186323 added support for strings but it exposes the problem that the original API was trying to avoid: pre-computing unnecessary formatted strings.

This tightens the API to require that if you pass a string it's a `LiteralString` - so the common case of a literal string will succeed but if you want a formatted string you should use a lambda.

Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #188274

