### PR TITLE
[release/2.13] Revert "Tighten generalized scatter graph target (#184075)"

### DIFF
--- a/test/inductor/test_inplacing_pass.py
+++ b/test/inductor/test_inplacing_pass.py
@@ -11,19 +11,13 @@ from torch._higher_order_ops.auto_functionalize import (
     auto_functionalized,
     auto_functionalized_v2,
 )
-from torch._inductor.fx_passes.reinplace import (
-    _generalized_scatter,
-    canonicalize_view_scatter_ops,
-    decompose_generalized_scatter,
-    reinplace_inplaceable_ops_core,
-)
+from torch._inductor.fx_passes.reinplace import reinplace_inplaceable_ops_core
 from torch._inductor.test_case import run_tests, TestCase as InductorTestCase
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     IS_LINUX,
     parametrize,
     subtest,
-    TEST_Z3,
 )
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
 from torch.testing._internal.logging_utils import logs_to_string
@@ -529,164 +523,6 @@ class TestReinplacingPassCorrectness(InductorTestCase):
         expected = fn(x)
         result = torch.compile(fn, fullgraph=True, backend="inductor")(x)
         self.assertEqual(result, expected)
-
-    def test_generalized_scatter_target_is_operator(self):
-        from torch._guards import detect_fake_mode
-        from torch._inductor.virtualized import V
-        from torch.func import functionalize
-
-        def fn(x, y):
-            z = x.sin()
-            z[:, 0].copy_(y)
-            return z.cos()
-
-        x = torch.randn(2, 3)
-        y = torch.randn(2)
-        gm = make_fx(functionalize(fn), tracing_mode="fake")(x, y)
-        fake_mode = detect_fake_mode(
-            [node.meta["val"] for node in gm.graph.nodes if "val" in node.meta]
-        )
-
-        with V.set_fake_mode(fake_mode):
-            canonicalize_view_scatter_ops(gm.graph)
-
-        generalized_scatter_nodes = [
-            node
-            for node in gm.graph.nodes
-            if node.op == "call_function" and node.target is _generalized_scatter
-        ]
-        self.assertEqual(len(generalized_scatter_nodes), 1)
-
-        unexpected_targets = [
-            node.target
-            for node in gm.graph.nodes
-            if node.op == "call_function"
-            and not isinstance(node.target, torch._ops.OpOverload)
-            and node.target is not operator.getitem
-        ]
-        self.assertFalse(
-            unexpected_targets, f"unexpected targets: {unexpected_targets}"
-        )
-
-        with V.set_fake_mode(fake_mode):
-            decompose_generalized_scatter(gm.graph)
-
-        remaining_generalized_scatter_nodes = [
-            node
-            for node in gm.graph.nodes
-            if node.op == "call_function" and node.target is _generalized_scatter
-        ]
-        self.assertFalse(remaining_generalized_scatter_nodes)
-
-    def test_generalized_scatter_symbolic_view_args(self):
-        from torch._guards import detect_fake_mode
-        from torch._inductor.virtualized import V
-        from torch.func import functionalize
-        from torch.utils import _pytree as pytree
-
-        def fn(x, y):
-            z = x.sin()
-            z[: y.shape[0], 0].copy_(y)
-            return z.cos()
-
-        x = torch.randn(4, 3)
-        y = torch.randn(2)
-        torch._dynamo.mark_dynamic(y, 0)
-        gm = make_fx(functionalize(fn), tracing_mode="symbolic")(x, y)
-        fake_mode = detect_fake_mode(
-            [node.meta["val"] for node in gm.graph.nodes if "val" in node.meta]
-        )
-
-        with V.set_fake_mode(fake_mode):
-            canonicalize_view_scatter_ops(gm.graph)
-
-        generalized_scatter_nodes = [
-            node
-            for node in gm.graph.nodes
-            if node.op == "call_function" and node.target is _generalized_scatter
-        ]
-        self.assertEqual(len(generalized_scatter_nodes), 1)
-
-        node = generalized_scatter_nodes[0]
-        fake_args, fake_kwargs = pytree.tree_map(
-            lambda arg: arg.meta["val"] if isinstance(arg, torch.fx.Node) else arg,
-            (node.args, node.kwargs),
-        )
-        fake_result = node.target(*fake_args, **fake_kwargs)
-        self.assertEqual(fake_result.shape, fake_args[0].shape)
-
-    def test_generalized_scatter_dynamic_clamped_slice(self):
-        def fn(x, y):
-            z = x.sin()
-            z[:9223372036854775807].copy_(y)
-            return z.cos()
-
-        x = torch.randn(4, 3)
-        y = torch.randn(4, 3)
-        torch._dynamo.mark_dynamic(x, 0)
-        torch._dynamo.mark_dynamic(y, 0)
-
-        expected = fn(x, y)
-        result = torch.compile(fn, fullgraph=True, backend="inductor")(x, y)
-        self.assertEqual(result, expected)
-
-    def test_generalized_scatter_dynamic_clamped_slice_translation_validation(self):
-        if not TEST_Z3:
-            self.skipTest("requires z3-solver")
-
-        import torch.fx.experimental._config as fx_config
-
-        def fn(x, y):
-            z = x.sin()
-            z[:9223372036854775807].copy_(y)
-            return z.cos()
-
-        x = torch.randn(4, 3)
-        y = torch.randn(4, 3)
-        torch._dynamo.mark_dynamic(x, 0)
-        torch._dynamo.mark_dynamic(y, 0)
-
-        expected = fn(x, y)
-        with fx_config.patch(translation_validation=True):
-            result = torch.compile(fn, fullgraph=True, backend="inductor")(x, y)
-        self.assertEqual(result, expected)
-
-    def test_generalized_scatter_dynamic_negative_slice(self):
-        def fn(x, y):
-            z = x.sin()
-            z[-y.shape[0] :].copy_(y)
-            return z.cos()
-
-        x = torch.randn(4, 3)
-        y = torch.randn(2, 3)
-        torch._dynamo.mark_dynamic(x, 0)
-        torch._dynamo.mark_dynamic(y, 0)
-
-        expected = fn(x, y)
-        result = torch.compile(fn, fullgraph=True, backend="inductor")(x, y)
-        self.assertEqual(result, expected)
-
-    def test_generalized_scatter_ignores_unrelated_view_ops(self):
-        from torch._guards import detect_fake_mode
-        from torch._inductor.virtualized import V
-        from torch.func import functionalize
-
-        def fn(x, y):
-            z = x.sin()
-            t = x.t()
-            z[:, 0].copy_(y)
-            return z.cos(), t
-
-        x = torch.randn(2, 3)
-        y = torch.randn(2)
-        gm = make_fx(functionalize(fn), tracing_mode="fake")(x, y)
-        fake_mode = detect_fake_mode(
-            [node.meta["val"] for node in gm.graph.nodes if "val" in node.meta]
-        )
-
-        with V.set_fake_mode(fake_mode):
-            canonicalize_view_scatter_ops(gm.graph)
-            decompose_generalized_scatter(gm.graph)
 
     @parametrize(
         "factory_op",

--- a/test/test_fx_experimental.py
+++ b/test/test_fx_experimental.py
@@ -2374,10 +2374,6 @@ if TEST_Z3:
                     Mod(s2, s0**3),
                     z2 - z3.ToReal(z3.ToInt(z3.ToReal(z2) / z0**3)) * z0**3,
                 ),
-                (
-                    sympy.Piecewise((s0 + s1, sympy.Eq(s0, 5)), (s2, True)),
-                    z3.If(z3.IntVal(5) == z0, z0 + z1, z2),
-                ),
             ]
 
             toZ3 = SympyToZ3(validator)

--- a/torch/_inductor/fx_passes/reinplace.py
+++ b/torch/_inductor/fx_passes/reinplace.py
@@ -3,7 +3,7 @@ import itertools
 import logging
 import operator
 from collections import defaultdict
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Sequence
 from contextlib import nullcontext
 from dataclasses import dataclass
 from typing import Any, cast
@@ -82,286 +82,27 @@ def graph_call_function(graph: torch.fx.Graph, fn, *args, **kwargs):
 class ViewOp:
     target: torch._ops.OpOverload
     args: tuple[Any, ...]
-    kwargs: Mapping[str, Any]
+    kwargs: dict[str, Any]
 
 
-EncodedViewOps = tuple[
-    tuple[int, ...],
-    tuple[Any, ...],
-    tuple[int, ...],
-    tuple[bool, ...],
-]
-
-_VIEW_OPS = tuple(_VIEW_OP_TO_SCATTER)
-_VIEW_OP_TO_CODE = {target: idx for idx, target in enumerate(_VIEW_OPS)}
-
-
-_MISSING = object()
-
-
-def _get_view_arg(
-    target: torch._ops.OpOverload,
-    args: tuple[Any, ...],
-    kwargs: Mapping[str, Any],
-    name: str,
-    index: int,
-    default: object = _MISSING,
-) -> Any:
-    if index < len(args):
-        return args[index]
-    if name in kwargs:
-        return kwargs[name]
-    if default is not _MISSING:
-        return default
-    raise AssertionError(f"missing argument {name} for {target}")
-
-
-def _normalize_view_op(
-    target: torch._ops.OpOverload, args: Sequence[Any], kwargs: Mapping[str, Any]
-) -> ViewOp:
-    args = tuple(args)
-    if target is aten.diagonal.default:
-        names = ("offset", "dim1", "dim2")
-        defaults = (0, 0, 1)
-    elif target is aten.select.int:
-        names = ("dim", "index")
-        defaults = (_MISSING, _MISSING)
-    elif target is aten.slice.Tensor:
-        names = ("dim", "start", "end", "step")
-        defaults = (0, None, None, 1)
-    elif target is aten.as_strided.default:
-        names = ("size", "stride", "storage_offset")
-        defaults = (_MISSING, _MISSING, None)
-    else:
-        raise AssertionError(f"unsupported view op {target}")
-
-    unexpected_kwargs = [name for name in kwargs if name not in names]
-    assert not unexpected_kwargs, f"unexpected kwargs for {target}: {unexpected_kwargs}"
-    normalized_args = tuple(
-        _get_view_arg(target, args, kwargs, name, idx, default)
-        for idx, (name, default) in enumerate(zip(names, defaults))
-    )
-    if target is aten.as_strided.default:
-        size, stride, storage_offset = normalized_args
-        normalized_args = (tuple(size), tuple(stride), storage_offset)
-    return ViewOp(target, normalized_args, {})
-
-
-def _flatten_view_op_args(view_op: ViewOp) -> tuple[Any, ...]:
-    if view_op.target is aten.as_strided.default:
-        size, stride, storage_offset = view_op.args
-        return (len(size), *size, len(stride), *stride, storage_offset)
-    return view_op.args
-
-
-def _encode_view_ops(view_ops: Sequence[ViewOp]) -> EncodedViewOps:
-    view_codes = []
-    view_args = []
-    view_arg_counts = []
-    view_arg_none = []
-
-    for view_op in view_ops:
-        view_codes.append(_VIEW_OP_TO_CODE[view_op.target])
-        flattened_args = _flatten_view_op_args(view_op)
-        view_arg_counts.append(len(flattened_args))
-        for arg in flattened_args:
-            view_arg_none.append(arg is None)
-            view_args.append(0 if arg is None else arg)
-
-    return (
-        tuple(view_codes),
-        tuple(view_args),
-        tuple(view_arg_counts),
-        tuple(view_arg_none),
-    )
-
-
-def _unflatten_view_op_args(
-    target: torch._ops.OpOverload, flattened_args: Sequence[Any]
-) -> tuple[Any, ...]:
-    if target is aten.as_strided.default:
-        size_len = int(flattened_args[0])
-        stride_len_idx = 1 + size_len
-        stride_len = int(flattened_args[stride_len_idx])
-        stride_start = stride_len_idx + 1
-        storage_offset_idx = stride_start + stride_len
-        return (
-            tuple(flattened_args[1:stride_len_idx]),
-            tuple(flattened_args[stride_start:storage_offset_idx]),
-            flattened_args[storage_offset_idx],
-        )
-    return tuple(flattened_args)
-
-
-def _decode_view_op(target_code: int, flattened_args: Sequence[Any]) -> ViewOp:
-    target = _VIEW_OPS[target_code]
-    return ViewOp(target, _unflatten_view_op_args(target, flattened_args), {})
-
-
-def _decode_view_ops(view_ops: EncodedViewOps) -> tuple[ViewOp, ...]:
-    view_codes, view_args, view_arg_counts, view_arg_none = view_ops
-    assert len(view_codes) == len(view_arg_counts)
-    assert len(view_args) == len(view_arg_none)
-
-    arg_offset = 0
-    decoded_view_ops = []
-    for target_code, arg_count in zip(view_codes, view_arg_counts):
-        flattened_args = tuple(
-            None if view_arg_none[idx] else view_args[idx]
-            for idx in range(arg_offset, arg_offset + arg_count)
-        )
-        decoded_view_ops.append(_decode_view_op(target_code, flattened_args))
-        arg_offset += arg_count
-
-    assert arg_offset == len(view_args)
-    return tuple(decoded_view_ops)
-
-
-def _apply_view_ops(
-    inp: torch.Tensor,
-    view_codes: Sequence[int],
-    view_args: Sequence[Any],
-    view_arg_counts: Sequence[int],
-    view_arg_none: Sequence[bool],
+def _inplace_generalized_scatter(
+    inp: torch.Tensor, src: torch.Tensor, view_ops: list[ViewOp]
 ) -> torch.Tensor:
     tmp = inp
-    fake_mode = detect_fake_mode((inp, view_args))
-    with fake_mode if fake_mode else nullcontext():
-        for view in _decode_view_ops(
-            (
-                tuple(view_codes),
-                tuple(view_args),
-                tuple(view_arg_counts),
-                tuple(view_arg_none),
-            )
+    for view in view_ops:
+        fake_args, fake_kwargs = pytree.tree_map(
+            lambda node: node.meta["val"] if isinstance(node, torch.fx.Node) else node,
+            (view.args, view.kwargs),
+        )
+        # slice and select can allocate new unbacked symints, but those won't be reflected
+        # in the output of this function, hence shall be ignored.
+        fake_mode = detect_fake_mode(fake_args)
+        with (
+            fake_mode.shape_env.ignore_fresh_unbacked_symbols()
+            if fake_mode and fake_mode.shape_env
+            else nullcontext()
         ):
-            fake_args, fake_kwargs = pytree.tree_map(
-                lambda node: node.meta["val"]
-                if isinstance(node, torch.fx.Node)
-                else node,
-                (view.args, view.kwargs),
-            )
-            # slice and select can allocate new unbacked symints, but those won't
-            # be reflected in the output of this function, hence shall be ignored.
-            with (
-                fake_mode.shape_env.ignore_fresh_unbacked_symbols()
-                if fake_mode and fake_mode.shape_env
-                else nullcontext()
-            ):
-                tmp = view.target(tmp, *fake_args, **fake_kwargs)
-    return tmp
-
-
-def _canonicalize_view_dim(rank: int, dim: int) -> int:
-    orig_dim = dim
-    dim = int(dim)
-    if dim < 0:
-        dim += rank
-    if dim < 0 or dim >= rank:
-        raise IndexError(
-            f"Dimension out of range (expected to be in range of "
-            f"[{-rank}, {rank - 1}], but got {orig_dim})"
-        )
-    return dim
-
-
-def _slice_view_length(
-    dim_size: Any, start: Any, end: Any, step: Any
-) -> int | torch.SymInt:
-    def wrap_negative_bound(val: Any) -> Any:
-        if isinstance(val, int):
-            return val + dim_size if val < 0 else val
-        if isinstance(val, torch.SymInt):
-            return torch.sym_ite(val < 0, val + dim_size, val)
-        return val
-
-    start = 0 if start is None else wrap_negative_bound(start)
-    end = dim_size if end is None else wrap_negative_bound(end)
-    step = 1 if step is None else step
-
-    if isinstance(step, int) and step <= 0:
-        raise ValueError(f"slice step must be positive, got {step}")
-
-    start = torch.sym_min(torch.sym_max(start, 0), dim_size)
-    end = torch.sym_min(torch.sym_max(end, start), dim_size)
-
-    return (end - start + (step - 1)) // step
-
-
-def _diagonal_view_length(
-    dim1_size: Any, dim2_size: Any, offset: int
-) -> int | torch.SymInt:
-    offset = int(offset)
-    if offset >= 0:
-        diag_size = torch.sym_min(dim1_size, dim2_size - offset)
-    else:
-        diag_size = torch.sym_min(dim1_size + offset, dim2_size)
-    return torch.sym_max(0, diag_size)
-
-
-def _view_ops_shape(
-    inp: torch.Tensor,
-    view_codes: Sequence[int],
-    view_args: Sequence[Any],
-    view_arg_counts: Sequence[int],
-    view_arg_none: Sequence[bool],
-) -> tuple[Any, ...]:
-    shape = tuple(inp.shape)
-    for view in _decode_view_ops(
-        (
-            tuple(view_codes),
-            tuple(view_args),
-            tuple(view_arg_counts),
-            tuple(view_arg_none),
-        )
-    ):
-        if view.target is aten.diagonal.default:
-            offset, dim1, dim2 = view.args
-            rank = len(shape)
-            dim1 = _canonicalize_view_dim(rank, dim1)
-            dim2 = _canonicalize_view_dim(rank, dim2)
-            if dim1 == dim2:
-                raise RuntimeError("diagonal dimensions cannot be identical")
-            diag_size = _diagonal_view_length(shape[dim1], shape[dim2], offset)
-            shape = tuple(
-                size for idx, size in enumerate(shape) if idx not in (dim1, dim2)
-            ) + (diag_size,)
-        elif view.target is aten.select.int:
-            dim = _canonicalize_view_dim(len(shape), view.args[0])
-            shape = shape[:dim] + shape[dim + 1 :]
-        elif view.target is aten.slice.Tensor:
-            dim, start, end, step = view.args
-            dim = _canonicalize_view_dim(len(shape), dim)
-            new_shape = list(shape)
-            new_shape[dim] = _slice_view_length(shape[dim], start, end, step)
-            shape = tuple(new_shape)
-        elif view.target is aten.as_strided.default:
-            size, _stride, _storage_offset = view.args
-            shape = tuple(size)
-        else:
-            raise AssertionError(f"unsupported view op {view.target}")
-    return shape
-
-
-def _validate_scatter_src_shape(src: torch.Tensor, dst: Sequence[Any]) -> None:
-    dst_shape = torch.Size(dst)
-    try:
-        torch._refs.expand(src, dst_shape)
-    except RuntimeError as e:
-        raise RuntimeError(
-            f"shape error in scatter op, can not broadcast {src.shape} to {dst_shape}"
-        ) from e
-
-
-def _inplace_generalized_scatter_impl(
-    inp: torch.Tensor,
-    src: torch.Tensor,
-    view_codes: Sequence[int],
-    view_args: Sequence[Any],
-    view_arg_counts: Sequence[int],
-    view_arg_none: Sequence[bool],
-) -> torch.Tensor:
-    tmp = _apply_view_ops(inp, view_codes, view_args, view_arg_counts, view_arg_none)
+            tmp = view.target(tmp, *fake_args, **fake_kwargs)
     try:
         tmp.copy_(src)
     except RuntimeError as e:
@@ -371,86 +112,18 @@ def _inplace_generalized_scatter_impl(
     return inp
 
 
-def _generalized_scatter_impl(
-    inp: torch.Tensor,
-    src: torch.Tensor,
-    view_codes: Sequence[int],
-    view_args: Sequence[Any],
-    view_arg_counts: Sequence[int],
-    view_arg_none: Sequence[bool],
+def _generalized_scatter(
+    inp: torch.Tensor, src: torch.Tensor, view_ops: list[ViewOp]
 ) -> torch.Tensor:
     out = inp.clone()
-    return _inplace_generalized_scatter_impl(
-        out, src, view_codes, view_args, view_arg_counts, view_arg_none
-    )
-
-
-def _generalized_scatter_meta(
-    inp: torch.Tensor,
-    src: torch.Tensor,
-    view_codes: Sequence[int],
-    view_args: Sequence[Any],
-    view_arg_counts: Sequence[int],
-    view_arg_none: Sequence[bool],
-) -> torch.Tensor:
-    tmp_shape = _view_ops_shape(
-        inp, view_codes, view_args, view_arg_counts, view_arg_none
-    )
-    _validate_scatter_src_shape(src, tmp_shape)
-    return torch.empty_strided(
-        inp.size(), inp.stride(), dtype=inp.dtype, device=inp.device
-    )
-
-
-def _inplace_generalized_scatter_meta(
-    inp: torch.Tensor,
-    src: torch.Tensor,
-    view_codes: Sequence[int],
-    view_args: Sequence[Any],
-    view_arg_counts: Sequence[int],
-    view_arg_none: Sequence[bool],
-) -> torch.Tensor:
-    tmp_shape = _view_ops_shape(
-        inp, view_codes, view_args, view_arg_counts, view_arg_none
-    )
-    _validate_scatter_src_shape(src, tmp_shape)
-    return inp
-
-
-_reinplace_lib = torch.library.Library("_inductor_reinplace", "FRAGMENT")
-_reinplace_lib.define(
-    "generalized_scatter(Tensor inp, Tensor src, int[] view_codes, SymInt[] view_args, int[] view_arg_counts, bool[] view_arg_none) -> Tensor"
-)
-_reinplace_lib.define(
-    "inplace_generalized_scatter_(Tensor(a!) inp, Tensor src, int[] view_codes, SymInt[] view_args, int[] view_arg_counts, bool[] view_arg_none) -> Tensor(a!)"
-)
-_reinplace_lib.impl(
-    "generalized_scatter",
-    _generalized_scatter_impl,
-    "CompositeExplicitAutograd",
-)
-_reinplace_lib.impl(
-    "inplace_generalized_scatter_",
-    _inplace_generalized_scatter_impl,
-    "CompositeExplicitAutograd",
-)
-_reinplace_lib.impl("generalized_scatter", _generalized_scatter_meta, "Meta")
-_reinplace_lib.impl(
-    "inplace_generalized_scatter_",
-    _inplace_generalized_scatter_meta,
-    "Meta",
-)
-_generalized_scatter = torch.ops._inductor_reinplace.generalized_scatter.default
-_inplace_generalized_scatter = (
-    torch.ops._inductor_reinplace.inplace_generalized_scatter_.default
-)
+    return _inplace_generalized_scatter(out, src, view_ops)
 
 
 def _decompose_scatter_functional_helper(
     graph: torch.fx.Graph,
-    inp: Any,
-    src: Any,
-    view_ops: Sequence[ViewOp],
+    inp: torch.Tensor,
+    src: torch.Tensor,
+    view_ops: list[ViewOp],
 ) -> torch.fx.Node:
     view_op, view_ops_tail = view_ops[0], view_ops[1:]
 
@@ -458,7 +131,7 @@ def _decompose_scatter_functional_helper(
         view = graph_call_function(
             graph, view_op.target, inp, *view_op.args, **view_op.kwargs
         )
-        src = _decompose_scatter_functional_helper(graph, view, src, view_ops_tail)  # type: ignore[assignment]
+        src = _decompose_scatter_functional_helper(graph, view, src, view_ops[1:])  # type: ignore[assignment]
 
     return graph_call_function(
         graph,
@@ -484,10 +157,7 @@ def _decompose_scatter_functional(
     inp_updated = aten.slice_scatter(inp, view_updated, 0, 0, 10)
     """
     assert node.target is _generalized_scatter
-    inp, src, *view_ops = node.args
-    return _decompose_scatter_functional_helper(
-        graph, inp, src, _decode_view_ops(cast(EncodedViewOps, tuple(view_ops)))
-    )  # type: ignore[arg-type]
+    return _decompose_scatter_functional_helper(graph, *node.args)  # type: ignore[arg-type]
 
 
 def _decompose_scatter_mutating(
@@ -506,14 +176,14 @@ def _decompose_scatter_mutating(
 
     """
     assert node.target in (_generalized_scatter, _inplace_generalized_scatter)
-    inp, src, *view_ops = node.args
+    inp, src, view_ops = node.args
     assert not node.kwargs
 
     if node.target is _generalized_scatter:
         inp = graph_call_function(graph, aten.clone, inp)
 
     tmp = inp
-    for view in _decode_view_ops(cast(EncodedViewOps, tuple(view_ops))):
+    for view in view_ops:  # type: ignore[union-attr]
         tmp = graph_call_function(graph, view.target, tmp, *view.args, **view.kwargs)  # type: ignore[union-attr]
         # we need to set unbacked bindings that could have been created in the view ops.
         if (V.fake_mode.shape_env) and (
@@ -538,9 +208,12 @@ _ALWAYS_MUTATING_SCATTER_OPS = OrderedSet(
 
 
 def scatter_always_uses_mutation(node: torch.fx.Node) -> bool:
+    _, _, view_ops = node.args
+    view_ops = cast(Sequence[torch.fx.node.Argument], view_ops)
     return any(
-        view.target in _ALWAYS_MUTATING_SCATTER_OPS
-        for view in _decode_view_ops(cast(EncodedViewOps, tuple(node.args[2:])))
+        target in _ALWAYS_MUTATING_SCATTER_OPS
+        for view in view_ops
+        if isinstance(target := getattr(view, "target", None), torch._ops.OpOverload)
     )
 
 
@@ -552,7 +225,7 @@ def should_reinplace_scatter(node: torch.fx.Node) -> bool:
     input and output would have been realized anyway.
 
     """
-    inp = node.args[0]
+    inp, _src, _view_ops = node.args
 
     # Mutating scatter ops unconditionally realize input and output
     if scatter_always_uses_mutation(node):
@@ -638,19 +311,11 @@ def canonicalize_view_scatter_ops(graph: torch.fx.Graph) -> None:
             args=node.args[2:],
             kwargs=node.kwargs,
         )
-        encoded_scatter_view_op = _normalize_view_op(
-            scatter_view_op.target,
-            scatter_view_op.args,
-            scatter_view_op.kwargs,
-        )
 
         def can_fuse():
-            if (
-                not isinstance(src, torch.fx.Node)
-                or src.target is not _generalized_scatter
-            ):
+            if src.target is not _generalized_scatter:  # type: ignore[union-attr]
                 return False
-            src_inp = src.args[0]
+            src_inp, _src_src, _src_scatter_view_op = src.args  # type: ignore[union-attr]
 
             inp_base = node_to_view_base.get(inp, inp)  # type: ignore[arg-type]
             src_base = node_to_view_base.get(src_inp, src_inp)  # type: ignore[arg-type]
@@ -666,23 +331,20 @@ def canonicalize_view_scatter_ops(graph: torch.fx.Graph) -> None:
                     _generalized_scatter,
                     inp,
                     src,
-                    *_encode_view_ops((encoded_scatter_view_op,)),
+                    [scatter_view_op],
                 )
             node.replace_all_uses_with(new_node)
             graph.erase_node(node)
             return
 
-        _src_inp, src_src, *src_scatter_view_ops = src.args  # type: ignore[union-attr]
-        src_scatter_view_ops = _decode_view_ops(
-            cast(EncodedViewOps, tuple(src_scatter_view_ops))
-        )
+        _src_inp, src_src, src_scatter_view_op = src.args  # type: ignore[union-attr]
         with graph.inserting_before(src):  # type: ignore[arg-type]
             new_node = graph_call_function(
                 graph,
                 _generalized_scatter,
                 inp,
                 src_src,
-                *_encode_view_ops((encoded_scatter_view_op, *src_scatter_view_ops)),
+                [scatter_view_op, *src_scatter_view_op],  # type: ignore[misc]
             )
             node.replace_all_uses_with(new_node)
             graph.erase_node(node)

--- a/torch/fx/experimental/validator.py
+++ b/torch/fx/experimental/validator.py
@@ -457,19 +457,6 @@ try:
         def floor_to_int(self, x: z3.ArithRef, dtype: torch.dtype) -> z3.ArithRef:
             return self._ops.floor(x)
 
-        def expr_cond_pair(
-            self, expr: z3.ExprRef, cond: z3.BoolRef
-        ) -> tuple[z3.ExprRef, z3.BoolRef]:
-            return (expr, cond)
-
-        def piecewise(self, *pairs: tuple[z3.ExprRef, z3.BoolRef]) -> z3.ExprRef:
-            if not pairs:
-                raise AssertionError("expected at least one Piecewise pair")
-            result = pairs[-1][0]
-            for expr, cond in reversed(pairs[:-1]):
-                result = z3.If(cond, expr, result)
-            return result
-
         def __getattr__(self, name: str) -> Any:
             REPLACEMENT = {
                 "and_": z3.And,


### PR DESCRIPTION
Release-branch (`release/2.13`) revert of #184075 "Tighten generalized scatter graph target". This is the cherry-pick counterpart of the main-branch revert #188219.

#184075 reworked Inductor's temporary generalized scatter form to use private OpOverload targets (a `torch.library` FRAGMENT registering `generalized_scatter` / `inplace_generalized_scatter_` with flattened, encoded view-op arguments) and added matching Piecewise support in the z3 validator. This revert restores the prior representation that passes view ops as a list of `ViewOp` dataclasses directly as `call_function` args.

### Conflict resolution
`reinplace.py` conflicted against the release branch. All hunks were resolved to the pre-PR form with **bare `assert`s** (no `# noqa: S101`), because `torch/_inductor/**` is still `S101`-exempt on `release/2.13` (`RUF100` would flag an unused noqa). Net effect is purely the inverse of #184075 (39 insertions / 558 deletions), removing the encode/decode machinery, the `torch.library` registration, and the z3 validator additions.

### Test Plan
```
lintrunner torch/_inductor/fx_passes/reinplace.py
```

This PR was authored with the assistance of an AI agent.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo