### PR TITLE
[dynamic_shapes][bugfix] Rebuild sympy.Pow in proxy tracing (#188278)

### DIFF
--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -1319,6 +1319,69 @@ def forward(self, x_1):
                 gm = fx.GraphModule(tracer.root, tracer.graph)
                 self.assertEqual(gm(2, 3, 4), expected)
 
+    def test_build_proxy_for_pow(self):
+        """
+        Test that _build_proxy_for_sym_expr correctly handles sympy.Pow.
+
+        sympy canonicalizes x * x into Pow(x, 2), so a reduction numel over a
+        tensor whose two dims duck-share a symbol becomes a nonlinear product
+        like s0 * s1**2. _build_proxy_for_sym_expr must rebuild it; without a
+        Pow handler the Pow factor has no proxy and get_proxy_slot raises
+        "is not tracked with proxy".
+        """
+        import sympy
+
+        import torch.fx as fx
+        from torch.fx.experimental.proxy_tensor import (
+            _build_proxy_for_sym_expr,
+            _SympyExprTrackerValue,
+            PythonKeyTracer,
+            set_meta,
+        )
+        from torch.utils._thunk import Thunk
+
+        # Cover more than just the square: the exponent is passed straight to
+        # the handler, so any natural power must rebuild (s1**2, s1**3, ...).
+        for exp in (2, 3):
+            with self.subTest(exp=exp):
+                shape_env = ShapeEnv()
+                # Unbacked symints keep the expression symbolic (backed symints
+                # would specialize the power away).
+                u0 = shape_env.create_unbacked_symint()
+                u1 = shape_env.create_unbacked_symint()
+
+                prod = u0 * u1**exp
+                self.assertTrue(prod.node.expr.has(sympy.Pow))
+
+                # Case 1: out=None must rebuild the Pow expr, not return None.
+                tracer_none = PythonKeyTracer()
+                for sym in [u0, u1]:
+                    tracer_none.sympy_expr_tracker[sym.node.expr] = (
+                        _SympyExprTrackerValue(proxy=sym, value=sym)
+                    )
+                result = _build_proxy_for_sym_expr(tracer_none, prod.node.expr)
+                self.assertEqual(result.node.expr, prod.node.expr)
+
+                # Case 2: out=prod (the typical get_proxy_slot path). The rebuilt
+                # node must execute correctly: u0 * u1**exp with u0=2, u1=3.
+                tracer = PythonKeyTracer()
+                tracer.root = torch.nn.Module()
+                tracer.graph = fx.Graph(tracer_cls=PythonKeyTracer)
+                for sym, name in [(u0, "u0"), (u1, "u1")]:
+                    node = tracer.graph.placeholder(name)
+                    proxy = fx.Proxy(node, tracer)
+                    set_meta(proxy, sym)
+                    tracer.sympy_expr_tracker[sym.node.expr] = _SympyExprTrackerValue(
+                        proxy=proxy, value=sym
+                    )
+                    tracer.symnode_tracker[sym] = Thunk(lambda p=proxy: p)
+
+                _build_proxy_for_sym_expr(tracer, prod.node.expr, out=prod)
+                out_proxy = tracer.symnode_tracker[prod].force()
+                tracer.graph.output(out_proxy.node)
+                gm = fx.GraphModule(tracer.root, tracer.graph)
+                self.assertEqual(gm(2, 3), 2 * 3**exp)
+
     def test_sym_max_multi_max_simplify(self):
         shape_env = ShapeEnv()
         u0 = shape_env.create_unbacked_symint()

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -573,6 +573,13 @@ def _sympy_handlers() -> dict[type[sympy.Expr], Callable[..., Any]]:
             handlers[k] = _nary_sym_max
         elif v == "minimum":
             handlers[k] = _nary_sym_min
+        # sympy.Pow / PowByNatural map to the interp name "pow_by_natural",
+        # which has no operator.* equivalent. sympy canonicalizes x * x into
+        # Pow(x, 2), so without this _build_proxy_for_sym_expr cannot rebuild
+        # any repeated-symbol product (e.g. a reduction numel s0 * s1**2 when
+        # two equal dims duck-share a symbol).
+        elif v == "pow_by_natural":
+            handlers[k] = operator.pow
 
     # sympy.Add is n-ary (e.g. Add(a, b, c)) but operator.add is binary.
     # torch.sym_sum handles n-ary integer addition and accepts both


### PR DESCRIPTION
Summary:

`_build_proxy_for_sym_expr` could not rebuild a `sympy.Pow` expression, so any derived `SymInt` that contains a power and reaches the proxy tracer without a pre-existing proxy raised `RuntimeError: <expr> is not tracked with proxy`. `_sympy_handlers()` builds its op table as `getattr(operator, <interp-name>)`, and `sympy.Pow`/`PowByNatural` map to the interp name `pow_by_natural`, which has no `operator.*` equivalent, so `Pow` got no handler and `_build_proxy_for_sym_expr` returned `None` for any sub-expression containing it.

This bites whenever sympy canonicalizes a repeated factor into a power: e.g. a full reduction over a tensor whose two dynamic dims duck-share a symbol produces a flattened numel `s0 * s1**2`, and the `s1**2` factor cannot be rebuilt even though `s0`/`s1` are tracked. On MTIA this surfaced as `torch.any` (and other full reductions) failing to compile under auto dynamic shapes with `InductorKernelError` on inputs that have two equal-sized non-unit dims (e.g. shape [3, 2, 1, 2]).

The fix maps `pow_by_natural` to `operator.pow` in `_sympy_handlers()`, mirroring the existing `maximum`/`minimum` special-cases. The exponent is passed straight through, so this generalizes to any natural power (`s1**2`, `s1**3`, ...), not just squares. `FloatPow` already routed to `operator.pow` via the interp name `pow`, so this only fills the integer-power gap.

Authored with assistance from Claude Code.

Test Plan:
# Unit test
```bash
buck2 test fbcode//caffe2/test:dynamic_shapes -- -r test_build_proxy_for_pow
```
https://www.internalfb.com/intern/testinfra/testrun/19984723375211536

Added `test_build_proxy_for_pow` (covers `s0*s1**2` and `s0*s1**3`): asserts `_build_proxy_for_sym_expr` rebuilds the Pow expr (out=None path) and that the rebuilt FX graph executes to the correct numeric value (out=expr path).

Differential Revision: D109852898


