### PR TITLE
Don't CSE factory ops feeding distinct auto_functionalized mutation bases (#170160)

### DIFF
--- a/test/inductor/test_inplacing_pass.py
+++ b/test/inductor/test_inplacing_pass.py
@@ -527,8 +527,7 @@ class TestReinplacingPassCorrectness(InductorTestCase):
     @parametrize(
         "factory_op",
         [
-            # Skipping because of https://github.com/pytorch/pytorch/issues/170160
-            # subtest(torch.ones_like, name="ones_like"),
+            subtest(torch.ones_like, name="ones_like"),
             subtest(torch.empty_like, name="empty_like"),
         ],
     )

--- a/torch/_functorch/compile_utils.py
+++ b/torch/_functorch/compile_utils.py
@@ -118,7 +118,15 @@ def fx_graph_cse(
         torch.ops.higher_order.auto_functionalized,
         torch.ops.higher_order.auto_functionalized_v2,
     )
-    triton_wrapper_target = torch.ops.higher_order.triton_kernel_wrapper_functional
+    # triton_kernel_wrapper_functional is registered lazily, so reference it
+    # from its defining module rather than torch.ops.higher_order (which may not
+    # have the attribute yet when no triton kernel has been traced).
+    try:
+        from torch._higher_order_ops.triton_kernel_wrap import (
+            triton_kernel_wrapper_functional as triton_wrapper_target,
+        )
+    except ImportError:
+        triton_wrapper_target = None
     nodes_used_as_mutation_base: set[fx.Node] = set()
     for n in fx_g.nodes:
         if n.op != "call_function":
@@ -127,7 +135,7 @@ def fx_graph_cse(
             for base in n.kwargs.get("_all_bases", ()):
                 if isinstance(base, fx.Node):
                     nodes_used_as_mutation_base.add(base)
-        elif n.target is triton_wrapper_target:
+        elif triton_wrapper_target is not None and n.target is triton_wrapper_target:
             inner_kwargs = n.kwargs.get("kwargs", {})
             for name in n.kwargs.get("tensors_to_clone", ()):
                 base = inner_kwargs.get(name)

--- a/torch/_functorch/compile_utils.py
+++ b/torch/_functorch/compile_utils.py
@@ -103,6 +103,37 @@ def fx_graph_cse(
         and StorageWeakRef(n.meta["val"].untyped_storage()) in output_storages
     }
 
+    # Collect the nodes that are used as the mutable base of an op that mutates
+    # in place behind a functional wrapper (auto_functionalized /
+    # auto_functionalized_v2's ``_all_bases``, or triton_kernel_wrapper_functional's
+    # cloned ``out`` tensors). Each such base is a distinct buffer that the op
+    # mutates, so two identical factory ops (e.g. the forward and backward
+    # ``aten.full`` from a pair of ``ones_like`` calls) must NOT be CSE-merged
+    # into one shared buffer. Merging them makes the later (backward) mutation
+    # alias a buffer that still has a live downstream view, which the reinplacing
+    # pass then refuses to reinplace. This mirrors why aten.empty is excluded
+    # below: each mutable destination buffer must stay independent.
+    # See pytorch/pytorch#170160.
+    auto_functionalized_targets = (
+        torch.ops.higher_order.auto_functionalized,
+        torch.ops.higher_order.auto_functionalized_v2,
+    )
+    triton_wrapper_target = torch.ops.higher_order.triton_kernel_wrapper_functional
+    nodes_used_as_mutation_base: set[fx.Node] = set()
+    for n in fx_g.nodes:
+        if n.op != "call_function":
+            continue
+        if n.target in auto_functionalized_targets:
+            for base in n.kwargs.get("_all_bases", ()):
+                if isinstance(base, fx.Node):
+                    nodes_used_as_mutation_base.add(base)
+        elif n.target is triton_wrapper_target:
+            inner_kwargs = n.kwargs.get("kwargs", {})
+            for name in n.kwargs.get("tensors_to_clone", ()):
+                base = inner_kwargs.get(name)
+                if isinstance(base, fx.Node):
+                    nodes_used_as_mutation_base.add(base)
+
     for n in fx_g.nodes:
         # The placeholder, output, and get_attr nodes are copied to the new graph without change
         # do not CSE away random operations
@@ -116,6 +147,10 @@ def fx_graph_cse(
             # so it's not worth CSEing.
             or get_aten_target(n) is aten.empty
             or n in nodes_that_alias_outputs
+            # Don't CSE-merge factory ops that feed distinct auto_functionalized
+            # mutation bases; each mutable buffer must stay independent so the
+            # reinplacing pass can reinplace each one. See pytorch/pytorch#170160.
+            or n in nodes_used_as_mutation_base
             # This CSE pass currently doesn't handle re-propagation of unbacked
             # meta where it'll sometimes eliminate a _local_scalar_dense but not
             # replace the meta of downstream users. eg. one bug we've seen is:

--- a/torch/_functorch/compile_utils.py
+++ b/torch/_functorch/compile_utils.py
@@ -103,44 +103,41 @@ def fx_graph_cse(
         and StorageWeakRef(n.meta["val"].untyped_storage()) in output_storages
     }
 
-    # Collect the nodes that are used as the mutable base of an op that mutates
-    # in place behind a functional wrapper (auto_functionalized /
-    # auto_functionalized_v2's ``_all_bases``, or triton_kernel_wrapper_functional's
-    # cloned ``out`` tensors). Each such base is a distinct buffer that the op
-    # mutates, so two identical factory ops (e.g. the forward and backward
-    # ``aten.full`` from a pair of ``ones_like`` calls) must NOT be CSE-merged
-    # into one shared buffer. Merging them makes the later (backward) mutation
-    # alias a buffer that still has a live downstream view, which the reinplacing
-    # pass then refuses to reinplace. This mirrors why aten.empty is excluded
-    # below: each mutable destination buffer must stay independent.
-    # See pytorch/pytorch#170160.
-    auto_functionalized_targets = (
-        torch.ops.higher_order.auto_functionalized,
-        torch.ops.higher_order.auto_functionalized_v2,
+    # A node used as the mutable base of a functional-wrapper op is a distinct
+    # mutable buffer. Two identical factory ops feeding distinct bases (e.g. the
+    # forward and backward ``aten.full`` from a pair of ``ones_like`` calls) must
+    # not be CSE-merged, or the later mutation aliases a buffer that still has a
+    # live downstream view and reinplacing fails (mirrors the aten.empty
+    # exclusion below). See pytorch/pytorch#170160.
+    from torch._higher_order_ops.auto_functionalize import get_mutable_args
+    from torch._higher_order_ops.triton_kernel_wrap import (
+        triton_kernel_wrapper_functional,
     )
-    # triton_kernel_wrapper_functional is registered lazily, so reference it
-    # from its defining module rather than torch.ops.higher_order (which may not
-    # have the attribute yet when no triton kernel has been traced).
-    try:
-        from torch._higher_order_ops.triton_kernel_wrap import (
-            triton_kernel_wrapper_functional as triton_wrapper_target,
-        )
-    except ImportError:
-        triton_wrapper_target = None
+
+    def _add_base(node: Any, bases: set[fx.Node]) -> None:
+        for b in node if isinstance(node, (list, tuple)) else (node,):
+            if isinstance(b, fx.Node):
+                bases.add(b)
+
     nodes_used_as_mutation_base: set[fx.Node] = set()
     for n in fx_g.nodes:
         if n.op != "call_function":
             continue
-        if n.target in auto_functionalized_targets:
+        if n.target is torch.ops.higher_order.auto_functionalized_v2:
+            # v2 lists its mutable buffers explicitly in ``_all_bases``.
             for base in n.kwargs.get("_all_bases", ()):
-                if isinstance(base, fx.Node):
-                    nodes_used_as_mutation_base.add(base)
-        elif triton_wrapper_target is not None and n.target is triton_wrapper_target:
+                _add_base(base, nodes_used_as_mutation_base)
+        elif n.target is torch.ops.higher_order.auto_functionalized:
+            # v1 has no ``_all_bases``; the mutated tensors are the args named by
+            # the wrapped op's schema (``_mutable_op`` is the first positional).
+            mutable_op = n.args[0]
+            mutable_args_names, _ = get_mutable_args(mutable_op)
+            for name in mutable_args_names:
+                _add_base(n.kwargs.get(name), nodes_used_as_mutation_base)
+        elif n.target is triton_kernel_wrapper_functional:
             inner_kwargs = n.kwargs.get("kwargs", {})
             for name in n.kwargs.get("tensors_to_clone", ()):
-                base = inner_kwargs.get(name)
-                if isinstance(base, fx.Node):
-                    nodes_used_as_mutation_base.add(base)
+                _add_base(inner_kwargs.get(name), nodes_used_as_mutation_base)
 
     for n in fx_g.nodes:
         # The placeholder, output, and get_attr nodes are copied to the new graph without change
@@ -155,9 +152,7 @@ def fx_graph_cse(
             # so it's not worth CSEing.
             or get_aten_target(n) is aten.empty
             or n in nodes_that_alias_outputs
-            # Don't CSE-merge factory ops that feed distinct auto_functionalized
-            # mutation bases; each mutable buffer must stay independent so the
-            # reinplacing pass can reinplace each one. See pytorch/pytorch#170160.
+            # Keep distinct functional-wrapper mutation bases independent.
             or n in nodes_used_as_mutation_base
             # This CSE pass currently doesn't handle re-propagation of unbacked
             # meta where it'll sometimes eliminate a _local_scalar_dense but not

--- a/torch/_functorch/compile_utils.py
+++ b/torch/_functorch/compile_utils.py
@@ -120,24 +120,27 @@ def fx_graph_cse(
                 bases.add(b)
 
     nodes_used_as_mutation_base: set[fx.Node] = set()
-    for n in fx_g.nodes:
-        if n.op != "call_function":
-            continue
-        if n.target is torch.ops.higher_order.auto_functionalized_v2:
-            # v2 lists its mutable buffers explicitly in ``_all_bases``.
-            for base in n.kwargs.get("_all_bases", ()):
-                _add_base(base, nodes_used_as_mutation_base)
-        elif n.target is torch.ops.higher_order.auto_functionalized:
-            # v1 has no ``_all_bases``; the mutated tensors are the args named by
-            # the wrapped op's schema (``_mutable_op`` is the first positional).
-            mutable_op = n.args[0]
-            mutable_args_names, _ = get_mutable_args(mutable_op)
-            for name in mutable_args_names:
-                _add_base(n.kwargs.get(name), nodes_used_as_mutation_base)
-        elif n.target is triton_kernel_wrapper_functional:
-            inner_kwargs = n.kwargs.get("kwargs", {})
-            for name in n.kwargs.get("tensors_to_clone", ()):
-                _add_base(inner_kwargs.get(name), nodes_used_as_mutation_base)
+    for n in fx_g.find_nodes(
+        op="call_function", target=torch.ops.higher_order.auto_functionalized_v2
+    ):
+        # v2 lists its mutable buffers explicitly in ``_all_bases``.
+        for base in n.kwargs.get("_all_bases", ()):
+            _add_base(base, nodes_used_as_mutation_base)
+    for n in fx_g.find_nodes(
+        op="call_function", target=torch.ops.higher_order.auto_functionalized
+    ):
+        # v1 has no ``_all_bases``; the mutated tensors are the args named by the
+        # wrapped op's schema (``_mutable_op`` is the first positional).
+        mutable_op = n.args[0]
+        mutable_args_names, _ = get_mutable_args(mutable_op)
+        for name in mutable_args_names:
+            _add_base(n.kwargs.get(name), nodes_used_as_mutation_base)
+    for n in fx_g.find_nodes(
+        op="call_function", target=triton_kernel_wrapper_functional
+    ):
+        inner_kwargs = n.kwargs.get("kwargs", {})
+        for name in n.kwargs.get("tensors_to_clone", ()):
+            _add_base(inner_kwargs.get(name), nodes_used_as_mutation_base)
 
     for n in fx_g.nodes:
         # The placeholder, output, and get_attr nodes are copied to the new graph without change


### PR DESCRIPTION
## Summary

Fixes #170160 — `[auto functionalize][partitioner] ones_like is not getting recomputed`.

`fx_graph_cse` was merging two identical factory ops (e.g. the forward and backward `aten.full` produced by a pair of `torch.ones_like` calls) into a single shared buffer. When that buffer is the mutation base of an `auto_functionalized` / `auto_functionalized_v2` op (or the cloned `out` of a `triton_kernel_wrapper_functional`), the two logically-distinct mutable destinations collapse into one. The later (backward) mutation then aliases a buffer that still has a live downstream view, so the reinplacing pass refuses to reinplace it, producing a spurious `num_reinplacing_failures()`.

`torch.empty_like` does not hit this because `aten.empty` is already excluded from CSE; `torch.ones_like` decomposes to `aten.full`, which was not.

## Fix

Exclude from CSE any node used as a mutable base of these functional-wrapper ops, mirroring the existing `aten.empty` exclusion, so each mutable destination buffer stays independent and can be reinplaced.

## Root cause detail

Joint graph before CSE has two independent factory buffers:
```
full_default   = aten.full([3], 1)          # num_users=1  (fwd)
auto_functionalized_v2(..., _all_bases=[full_default])
full_default_1 = aten.full([3], 1)          # num_users=1  (bwd)
auto_functionalized_v2_1(..., _all_bases=[full_default_1])
```
CSE merged them into one shared `full_default` (num_users=2) feeding both ops. After the fix they stay independent, and the post-grad graph gives the backward op its own private buffer — mirroring what `empty_like` already produces — so reinplacing succeeds and the miss count is 0.

## Test

Re-enables the `ones_like` subtest of `test_partitioner_recomputes_factory` (both `sin_op` and `sin_triton` variants), which was skipped pending this fix.

```
python test/inductor/test_inplacing_pass.py TestReinplacingPassCorrectness
```
All `test_partitioner_recomputes_factory_*` subtests pass; verified the fix is device-independent (reproduced and fixed on CPU and on Intel Arc B580 / XPU). Confirmed normal CSE deduplication is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo