### PR TITLE
Simplify waiting using std::latch + fix iOS PACKAGE modifier (#188279)

### DIFF
--- a/aten/src/ATen/ParallelNative.cpp
+++ b/aten/src/ATen/ParallelNative.cpp
@@ -12,6 +12,7 @@
 #endif // C10_MOBILE
 
 #include <atomic>
+#include <latch>
 #include <utility>
 
 #ifdef _OPENMP
@@ -152,16 +153,11 @@ void invoke_parallel(
   std::tie(num_tasks, chunk_size) =
       internal::calc_num_tasks_and_chunk_size(begin, end, grain_size);
 
-  struct {
-    std::atomic_flag err_flag = ATOMIC_FLAG_INIT;
-    std::exception_ptr eptr;
-    std::mutex mutex;
-    std::atomic_size_t remaining{0};
-    std::condition_variable cv;
-  } state;
+  std::atomic_flag err_flag = ATOMIC_FLAG_INIT;
+  std::exception_ptr eptr;
+  std::latch latch(static_cast<ptrdiff_t>(num_tasks));
 
-  auto task = [f, &state, begin, end, chunk_size]
-      (size_t task_id) {
+  auto task = [&, f, begin, end, chunk_size](size_t task_id) {
     int64_t local_start = static_cast<int64_t>(begin + task_id * chunk_size);
     if (local_start < end) {
       int64_t local_end = std::min(end, static_cast<int64_t>(chunk_size + local_start));
@@ -169,30 +165,19 @@ void invoke_parallel(
         ParallelRegionGuard guard(static_cast<int>(task_id));
         f(local_start, local_end);
       } catch (...) {
-        if (!state.err_flag.test_and_set()) {
-          state.eptr = std::current_exception();
+        if (!err_flag.test_and_set()) {
+          eptr = std::current_exception();
         }
       }
     }
-    {
-      std::unique_lock<std::mutex> lk(state.mutex);
-      if (--state.remaining == 0) {
-        state.cv.notify_one();
-      }
-    }
+    latch.count_down();
   };
-  state.remaining = num_tasks;
   _run_with_pool(std::move(task), num_tasks);
 
   // Wait for all tasks to finish.
-  {
-    std::unique_lock<std::mutex> lk(state.mutex);
-    if (state.remaining != 0) {
-      state.cv.wait(lk);
-    }
-  }
-  if (state.eptr) {
-    std::rethrow_exception(state.eptr);
+  latch.wait();
+  if (eptr) {
+    std::rethrow_exception(eptr);
   }
 }
 


### PR DESCRIPTION
Summary:

This diff combines two changes:

1. **[c++20] Simplify waiting using std::latch** (originally D108538999, reverted due to iOS build failure): replaces the atomic + mutex + condvar state struct in `ParallelNative.cpp` with a single `std::latch`.

2. (Internally) - fixes iOS compatibility issues

Reviewed By: 8Keep, huydhn

Differential Revision: D109093550

@diff-train-skip-merge


