### PR TITLE
Skip MANIFEST.in processing for non-sdist builds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -284,6 +284,7 @@ from typing import Any, ClassVar, IO
 
 import setuptools.command.bdist_wheel
 import setuptools.command.build_ext
+import setuptools.command.egg_info
 import setuptools.errors
 from setuptools import Command, Extension, find_packages, setup
 from setuptools.dist import Distribution
@@ -899,6 +900,24 @@ def check_pydep(importname: str, module: str) -> None:
         ) from e
 
 
+class egg_info(setuptools.command.egg_info.egg_info):
+    """Skip MANIFEST.in processing for non-sdist builds.
+
+    SOURCES.txt (the output of find_sources) is only consumed by sdist.
+    Processing MANIFEST.in for editable/wheel builds is pure waste: it
+    walks 121k files in third_party/ twice per build, costing ~5s.
+    """
+
+    def find_sources(self) -> None:
+        if "sdist" in (getattr(self.distribution, "commands", None) or []):
+            return super().find_sources()
+        manifest = os.path.join(self.egg_info, "SOURCES.txt")
+        if not os.path.exists(manifest):
+            os.makedirs(os.path.dirname(manifest), exist_ok=True)
+            open(manifest, "w").close()
+        self.filelist = setuptools.command.egg_info.FileList()
+
+
 class build_ext(setuptools.command.build_ext.build_ext):
     def run(self) -> None:
         # Report build options. This is run after the build completes so # `CMakeCache.txt` exists
@@ -1082,6 +1101,7 @@ def configure_extension_build() -> tuple[
     packages = find_packages(include=includes, exclude=excludes)
 
     cmdclass = {
+        "egg_info": egg_info,
         "bdist_wheel": bdist_wheel,
         "build_ext": build_ext,
         "clean": clean,


### PR DESCRIPTION
## Author Notes

Makes my local warm build 10s -> 5s.

## Agent Notes

The `egg_info` command's `find_sources()` processes `MANIFEST.in` to generate `SOURCES.txt`, which is only consumed by `sdist`. During editable installs and wheel builds, this work is discarded -- but it's expensive because `graft third_party` walks 121k files (2.1GB), and setuptools runs this **twice** per `pip install -e` (once for PEP 660 metadata, once inside `build_editable`).

This PR overrides `egg_info` to skip `find_sources()` when `sdist` is not the active command. The override checks `self.distribution.commands` which is populated by setuptools' `parse_command_line()` before any command runs:
- **sdist builds**: `commands=['sdist']` → full MANIFEST.in processing (unchanged)
- **editable/wheel builds**: `commands=['editable_wheel']` or `['bdist_wheel']` → skip, write empty SOURCES.txt

When skipping, an empty `SOURCES.txt` is created if one doesn't exist (some code checks for it), and `self.filelist` is set to an empty `FileList` to avoid `AttributeError` if anything reads it.

Measured on a warm no-op editable install (CPU-only, BUILD_CONFIG):
- **Before**: 11.5s (MANIFEST.in scanning accounts for ~5s)
- **After**: 5.3s (54% faster)
