### PR TITLE
linear_cross_entropy: remove the `balanced` acc_policy

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7486,9 +7486,10 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         adjusted = options._adjust(128, 4096, 50000, torch.float32)
         self.assertEqual(adjusted.batch_chunk_size, 16)
 
-    @parametrize_test("acc_policy", ["unknown", "Memory", ""])
+    @parametrize_test("acc_policy", ["unknown", "Memory", "balanced", ""])
     def test_linear_cross_entropy_options_invalid_acc_policy_raises(self, acc_policy):
-        """__post_init__ rejects acc_policy outside the documented set."""
+        """__post_init__ rejects acc_policy outside the documented set
+        (``"balanced"`` was removed; ``"compact"`` supersedes it)."""
         with self.assertRaisesRegex(ValueError, "acc_policy"):
             nn.LinearCrossEntropyOptions(acc_policy=acc_policy)
 
@@ -7633,7 +7634,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         for d in (torch.bfloat16, torch.float16):
             self.assertEqual(opts._adjust(128, 4096, 50000, d, cpu).acc_dtype, torch.float32)
         self.assertEqual(opts._adjust(128, 4096, 50000, torch.float32, cpu).acc_dtype, torch.float32)
-        opts_explicit = nn.LinearCrossEntropyOptions(acc_policy="balanced")
+        opts_explicit = nn.LinearCrossEntropyOptions(acc_policy="compact")
         self.assertEqual(
             opts_explicit._adjust(128, 4096, 50000, torch.bfloat16, cpu).acc_dtype,
             torch.bfloat16,
@@ -14853,8 +14854,8 @@ if __name__ == '__main__':
             # every device. Observed maxima (input_grad / weight):
             # fp32 cpu 9229/914 (aarch64; x86_64 4619), cuda 189/131
             # (NVIDIA ig 189 / w 106, ROCm ig 105 / w 131), mps 98/29;
-            # fp16 balanced/compact ig 60-93 / w 17-58 (mps 67/14); bf16
-            # balanced/compact ig 6 / w 3 (mps 0); accurate fp16/bf16 ~0.
+            # fp16 compact ig 60-93 / w 17-58 (mps 67/14); bf16
+            # compact ig 6 / w 3 (mps 0); accurate fp16/bf16 ~0.
             # No bias=True prob samples, so the bias-grad cap stays 0.
             expected_max_ulp_diff = 4
             if dtype == torch.float32:
@@ -14870,10 +14871,10 @@ if __name__ == '__main__':
             elif _resolved_policy == "accurate":
                 expected_input_grad_max_ulp_diff = 4
                 expected_weight_grad_max_ulp_diff = 4
-            elif dtype == torch.bfloat16:  # balanced / compact, bf16
+            elif dtype == torch.bfloat16:  # compact, bf16
                 expected_input_grad_max_ulp_diff = 16
                 expected_weight_grad_max_ulp_diff = 8
-            else:  # balanced / compact, fp16
+            else:  # compact, fp16
                 expected_input_grad_max_ulp_diff = 192
                 expected_weight_grad_max_ulp_diff = 128
             expected_linear_bias_grad_max_ulp_diff = 0
@@ -14887,18 +14888,14 @@ if __name__ == '__main__':
             # device-specific near-zero inflation. bias=True has no none
             # samples (bias coverage is reduction='mean' only), so the
             # bias-grad cap stays at the default 0. Observed maxima:
-            # accurate 0/0; balanced bf16 4/0, fp16 25/27; compact bf16
-            # 4/4, fp16 25/85 (input_grad/weight).
+            # accurate 0/0; compact bf16 4/4, fp16 25/85 (input_grad/weight).
             expected_max_ulp_diff = 8
             if _resolved_policy == "accurate":
                 expected_input_grad_max_ulp_diff = 4
                 expected_weight_grad_max_ulp_diff = 4
-            elif dtype == torch.bfloat16:  # balanced / compact, bf16
+            elif dtype == torch.bfloat16:  # compact, bf16
                 expected_input_grad_max_ulp_diff = 8
                 expected_weight_grad_max_ulp_diff = 8
-            elif _resolved_policy == "balanced":  # fp16
-                expected_input_grad_max_ulp_diff = 48
-                expected_weight_grad_max_ulp_diff = 48
             else:  # compact, fp16
                 expected_input_grad_max_ulp_diff = 48
                 expected_weight_grad_max_ulp_diff = 128
@@ -14955,43 +14952,6 @@ if __name__ == '__main__':
                         expected_input_grad_max_ulp_diff = 0
                         expected_weight_grad_max_ulp_diff = 0
                         expected_linear_bias_grad_max_ulp_diff = 0
-        elif _resolved_policy == "balanced":
-            if "cpu" in device:
-                if dtype == torch.float16:
-                    expected_max_ulp_diff = 1
-                    expected_input_grad_max_ulp_diff = 204   # x86_64 119
-                    expected_weight_grad_max_ulp_diff = 191  # x86_64 150
-                    expected_linear_bias_grad_max_ulp_diff = 1 if bias else 0
-                else:  # dtype == torch.bfloat16
-                    expected_max_ulp_diff = 1
-                    if bias:
-                        expected_input_grad_max_ulp_diff = 10
-                        expected_weight_grad_max_ulp_diff = 12
-                        expected_linear_bias_grad_max_ulp_diff = 1
-                    else:
-                        expected_input_grad_max_ulp_diff = 0
-                        expected_weight_grad_max_ulp_diff = 0
-                        expected_linear_bias_grad_max_ulp_diff = 0
-            else:
-                if dtype == torch.float16:
-                    if "mps" in device:
-                        expected_max_ulp_diff = 2
-                        expected_input_grad_max_ulp_diff = 232
-                        expected_weight_grad_max_ulp_diff = 190
-                        expected_linear_bias_grad_max_ulp_diff = 16 if bias else 0
-                    else:  # CUDA/...
-                        expected_max_ulp_diff = 1
-                        expected_input_grad_max_ulp_diff = 90
-                        expected_weight_grad_max_ulp_diff = 50  # x86_64 41
-                        expected_linear_bias_grad_max_ulp_diff = 16 if bias else 0
-                else:  # dtype == torch.bfloat16
-                    expected_max_ulp_diff = 2
-                    expected_input_grad_max_ulp_diff = 90
-                    if "mps" in device:
-                        expected_weight_grad_max_ulp_diff = 36 if bias else 0
-                    else:  # CUDA
-                        expected_weight_grad_max_ulp_diff = 4 if bias else 0  # A100
-                    expected_linear_bias_grad_max_ulp_diff = 17 if bias else 0  # A100
         elif _resolved_policy == "compact":
             # Loss output is genuinely bounded (O(1), no cancellation); the
             # +1 on MPS is its lower-precision fp16 matmul.
@@ -15217,7 +15177,7 @@ if __name__ == '__main__':
         self._test_linear_cross_entropy_loss(device=device, dtype=dtype, bias=bias)
 
     @parametrize_test("prob_target", [False, True])
-    @parametrize_test("acc_policy", ["accurate", "balanced", "compact", "auto"])
+    @parametrize_test("acc_policy", ["accurate", "compact", "auto"])
     @parametrize_test("bias", [False, True])
     def test_linear_cross_entropy_chunked_gradcheck(
         self, device, acc_policy, bias, prob_target
@@ -15285,7 +15245,7 @@ if __name__ == '__main__':
 
         torch.autograd.gradcheck(f, (inp, weight, linear_bias) if bias else (inp, weight))
 
-    @parametrize_test("acc_policy", ["accurate", "balanced", "compact", "auto"])
+    @parametrize_test("acc_policy", ["accurate", "compact", "auto"])
     def test_linear_cross_entropy_loss_no_grad(self, device, acc_policy):
         """Forward-only path under torch.no_grad(): exercises the
         rank-empty grad-buffer branches (compute_*_grad both False).
@@ -15641,7 +15601,7 @@ if __name__ == '__main__':
 
     @parametrize_test("bias", [False, True])
     @parametrize_test("dtype", [torch.float16, torch.bfloat16])
-    @parametrize_test("acc_policy", ["accurate", "balanced", "compact", "auto"])
+    @parametrize_test("acc_policy", ["accurate", "compact", "auto"])
     def test_linear_cross_entropy_loss_with_acc_dtype(self, device, dtype, acc_policy, bias):
         if dtype == torch.bfloat16 and "cuda" in device and not SM80OrLater:
             self.skipTest("bf16 requires SM80+ on CUDA")
@@ -15652,7 +15612,7 @@ if __name__ == '__main__':
 
     @parametrize_test("bias", [False, True])
     @parametrize_test("dtype", [torch.float16, torch.bfloat16])
-    @parametrize_test("acc_policy", ["accurate", "balanced", "compact", "auto"])
+    @parametrize_test("acc_policy", ["accurate", "compact", "auto"])
     def test_linear_cross_entropy_loss_none_reduction_with_acc_dtype(
         self, device, dtype, acc_policy, bias
     ):
@@ -15669,7 +15629,7 @@ if __name__ == '__main__':
             acc_dtype={torch.float16: torch.float32, torch.bfloat16: torch.float32}[dtype],
             bias=bias, none_reduction=True)
 
-    @parametrize_test("acc_policy", ["accurate", "balanced", "compact", "auto"])
+    @parametrize_test("acc_policy", ["accurate", "compact", "auto"])
     @dtypes(torch.float32)
     def test_linear_cross_entropy_loss_prob_target(self, device, dtype, acc_policy):
         # Probability-target counterpart of the scalar harness legs:
@@ -15681,7 +15641,7 @@ if __name__ == '__main__':
             device=device, dtype=dtype, acc_policy=acc_policy, prob_target=True)
 
     @parametrize_test("dtype", [torch.float16, torch.bfloat16])
-    @parametrize_test("acc_policy", ["accurate", "balanced", "compact", "auto"])
+    @parametrize_test("acc_policy", ["accurate", "compact", "auto"])
     def test_linear_cross_entropy_loss_prob_target_with_acc_dtype(
         self, device, dtype, acc_policy
     ):
@@ -15695,7 +15655,7 @@ if __name__ == '__main__':
             acc_dtype={torch.float16: torch.float32, torch.bfloat16: torch.float32}[dtype],
             prob_target=True)
 
-    @parametrize_test("acc_policy", ["auto", "compact", "balanced", "accurate"])
+    @parametrize_test("acc_policy", ["auto", "compact", "accurate"])
     def test_linear_cross_entropy_prob_large_vocab_fp16_denom(self, device, acc_policy):
         # Regression: the softmax denominator sum_v exp(shifted) sums
         # ~num_classes terms near 1, so for a large vocabulary it overflows
@@ -15722,7 +15682,7 @@ if __name__ == '__main__':
         ref = (torch.logsumexp(z, 1) - (p.cpu().double() * z).sum(1)).mean()
         self.assertEqual(loss.cpu().double(), ref, atol=0.05, rtol=5e-3)
 
-    @parametrize_test("acc_policy", ["compact", "balanced", "auto"])
+    @parametrize_test("acc_policy", ["compact", "auto"])
     def test_linear_cross_entropy_prob_large_magnitude_fp16_loss_term(self, device, acc_policy):
         # Regression: the prob loss target term sum_{n,c} (w*t)*x_shifted was a
         # flat torch.dot whose fp16 result overflows (>65504) mid-accumulation

--- a/torch/nn/modules/linear_cross_entropy.py
+++ b/torch/nn/modules/linear_cross_entropy.py
@@ -483,9 +483,9 @@ class _ChunkContext:
             )
         use_acc_dtype = dtype != acc_dtype
 
-        # Internal dtype layout. ``compact`` reuses ``balanced``'s layout;
-        # its savings come from skipping the weight_grad_chunk scratch, not dtype.
-        is_memory_like = acc_policy in {"balanced", "compact"}
+        # Internal dtype layout shared by the memory-like policy. ``compact``'s
+        # savings come from skipping the weight_grad_chunk scratch, not dtype.
+        is_memory_like = acc_policy == "compact"
         if use_acc_dtype:
             output_dtype = acc_dtype if dtype == torch.float16 else dtype
             grad_input_dtype = dtype if is_memory_like else acc_dtype
@@ -503,7 +503,7 @@ class _ChunkContext:
             )
 
         # ===== Dispatch flags =====
-        # CUDA + balanced uses cuBLAS out_dtype= directly; no cast.
+        # CUDA + compact uses cuBLAS out_dtype= directly; no cast.
         needs_linear_weight_cast = use_acc_dtype and (
             not is_cuda or (compute_input_grad and grad_input_dtype == logits_buf_dtype)
         )
@@ -899,7 +899,7 @@ def _linear_cross_entropy_batch_chunked_accumulator(
             # Loss target term sum_{n,c} (w*t)*x_shifted, read BEFORE
             # ``sumexp_`` (it ``exp_``s logits in place). torch.dot returns its
             # scalar at the operand dtype, so when the logits buffer is fp16
-            # (CUDA balanced/compact) the sum overflows fp16 (>65504) for a
+            # (CUDA compact) the sum overflows fp16 (>65504) for a
             # large batch of max-shifted (<=0) logits; a per-row einsum summed
             # across rows in fp32 stays finite (same cost as the dot). bf16/fp32
             # operands return a wide-enough scalar, so keep the flat dot.

--- a/torch/nn/modules/linear_cross_entropy_options.py
+++ b/torch/nn/modules/linear_cross_entropy_options.py
@@ -7,6 +7,9 @@ import torch
 __all__ = ["LinearCrossEntropyOptions"]
 
 
+_VALID_ACC_POLICIES = ("auto", "accurate", "compact")
+
+
 def _auto_acc_policy(device_type: str | None, dtype: torch.dtype) -> str:
     """Resolve the ``acc_policy`` ``"auto"`` sentinel from device and dtype.
 
@@ -136,10 +139,10 @@ class LinearCrossEntropyOptions:
     """
 
     def __post_init__(self):
-        if self.acc_policy not in {"auto", "accurate", "compact"}:
+        if self.acc_policy not in _VALID_ACC_POLICIES:
             raise ValueError(
-                f"invalid acc_policy: {self.acc_policy!r}; expected one of"
-                " 'auto', 'accurate', 'compact'"
+                f"invalid acc_policy: {self.acc_policy!r}; expected one of "
+                f"{', '.join(map(repr, _VALID_ACC_POLICIES))}"
             )
         if self.chunking_method is not None and self.chunking_method != "auto":
             name, sep, factor = self.chunking_method.partition(":")

--- a/torch/nn/modules/linear_cross_entropy_options.py
+++ b/torch/nn/modules/linear_cross_entropy_options.py
@@ -11,7 +11,7 @@ def _auto_acc_policy(device_type: str | None, dtype: torch.dtype) -> str:
     """Resolve the ``acc_policy`` ``"auto"`` sentinel from device and dtype.
 
     Only CPU + low-precision input (fp16/bf16) picks ``"accurate"``: there
-    ``compact``/``balanced`` run the weight-grad GEMM in the input dtype,
+    ``compact`` runs the weight-grad GEMM in the input dtype,
     hitting CPU's emulated low-precision matmul (~20-50x slower), so
     ``"accurate"`` keeps it in fp32. Everything else picks ``"compact"`` --
     accelerators have hardware-native low-precision GEMMs, and for fp32/fp64
@@ -95,7 +95,6 @@ class LinearCrossEntropyOptions:
 
     acc_policy: Literal[
         "accurate",
-        "balanced",
         "compact",
         "auto",
     ] = "auto"
@@ -113,21 +112,18 @@ class LinearCrossEntropyOptions:
       policies on CUDA. Only chunked policy whose weight-grad matmul
       runs in fp32 on CPU (other policies hit CPU's emulated
       low-precision path, ~20-50x slower).
-    - ``"balanced"`` -- :attr:`acc_dtype` only where needed for gradient
-      correctness; keeps a ``(num_classes, in_features)``
-      :attr:`acc_dtype` scratch for cross-chunk weight-grad accumulation.
-      Same precision as ``"accurate"`` in bf16, slightly looser in fp16,
-      faster than ``"accurate"`` in both.
-    - ``"compact"`` -- like ``"balanced"`` but drops the weight-grad
-      scratch and accumulates per-chunk directly via ``addmm_`` (cuBLAS
-      uses an fp32 internal accumulator, so bulk precision matches
-      ``"balanced"``). Saves ``num_classes * in_features *
-      sizeof(acc_dtype)`` -- typically several hundred MB for an LLM
-      head. On non-CUDA mixed-precision falls back to ``"balanced"``.
+    - ``"compact"`` -- :attr:`acc_dtype` only where needed for gradient
+      correctness; accumulates the weight gradient per chunk directly via
+      ``addmm_`` instead of a ``(num_classes, in_features)``
+      :attr:`acc_dtype` scratch (on CUDA cuBLAS uses an fp32 internal
+      accumulator, so bulk precision is unchanged). Saves
+      ``num_classes * in_features * sizeof(acc_dtype)`` -- typically
+      several hundred MB for an LLM head. On non-CUDA mixed-precision it
+      retains that scratch for the cross-chunk accumulation.
 
-    Policy effects (``"balanced"`` vs ``"accurate"``) are visible only
-    when :attr:`acc_dtype` differs from the input dtype; ``"compact"``
-    saves memory in both regimes.
+    The precision difference between ``"compact"`` and ``"accurate"`` is
+    visible only when :attr:`acc_dtype` differs from the input dtype;
+    ``"compact"`` saves memory in both regimes.
     """
 
     acc_dtype: torch.dtype | None = None
@@ -140,8 +136,11 @@ class LinearCrossEntropyOptions:
     """
 
     def __post_init__(self):
-        if self.acc_policy not in {"auto", "accurate", "balanced", "compact"}:
-            raise ValueError(f"invalid acc_policy: {self.acc_policy!r}")
+        if self.acc_policy not in {"auto", "accurate", "compact"}:
+            raise ValueError(
+                f"invalid acc_policy: {self.acc_policy!r}; expected one of"
+                " 'auto', 'accurate', 'compact'"
+            )
         if self.chunking_method is not None and self.chunking_method != "auto":
             name, sep, factor = self.chunking_method.partition(":")
             if not sep:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #188283

`balanced` is removed as a public acc_policy, leaving {auto, accurate,
compact}. It was Pareto-dominated by `compact`: on CUDA, compact's
per-chunk addmm_ already accumulates in cuBLAS's fp32 internal
accumulator, matching balanced's weight-grad precision at strictly lower
memory; on non-CUDA mixed precision, compact already falls back to
balanced's (num_classes, in_features) acc_dtype scratch layout; and auto
never selected balanced. Nothing was reachable only via balanced that
compact does not already cover.

This is an API/BC change kept to its own focused PR (agreed with the
reviewer on #187838). The internal "balanced layout" stays as compact's
non-CUDA fallback; only the public enum value, its validation entry, and
its now-dead test branches are removed. __post_init__ rejects
acc_policy="balanced" with a message listing the valid options.

Test Plan:

    CUDA_VISIBLE_DEVICES="" python test/test_nn.py -k linear_cross_entropy -v
    CUDA_VISIBLE_DEVICES="" python test/test_nn.py -k linear_cross_entropy_options -v

Authored with the assistance of Claude (AI coding assistant).