### PR TITLE
Fix dims docstring for torch.flip and torch.rot90 (axes, element type)

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -11557,7 +11557,7 @@ Reverse the order of an n-D tensor along given axis in dims.
 
 Args:
     {input}
-    dims (a list or tuple): axis to flip on
+    dims (a list or tuple of ints): axes to flip on
 
 Example::
 
@@ -11703,7 +11703,7 @@ Rotation direction is from the first towards the second axis if k > 0, and from 
 Args:
     {input}
     k (int): number of times to rotate. Default value is 1
-    dims (a list or tuple): axis to rotate. Default value is [0, 1]
+    dims (a list or tuple of ints): axes to rotate. Default value is [0, 1]
 
 Example::
 


### PR DESCRIPTION
Fixes #130641.

`torch.flip`'s docstring describes `dims` as:

```
dims (a list or tuple): axis to flip on
```

`dims` is a list/tuple of dimensions, so "axis" should be plural ("axes"), and the element type can be named, consistent with how `torch.permute` documents its `dims` argument (`tuple of int or list of int`). `torch.rot90` in the same file has the identical wording (`axis to rotate`), so this fixes both:

```
- dims (a list or tuple): axis to flip on
+ dims (a list or tuple of ints): axes to flip on

- dims (a list or tuple): axis to rotate. Default value is [0, 1]
+ dims (a list or tuple of ints): axes to rotate. Default value is [0, 1]
```

Docstring-only, no runtime change. (Like `torch.permute`'s functional docstring, this documents the list/tuple form; the positional-varargs convenience for single `int[]` arguments is a general behavior not spelled out at the functional level.)
