### PR TITLE
Allow tuple subclasses for run_backward inputs

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1210,6 +1210,15 @@ class TestAutograd(TestCase):
 
         self.assertEqual(ref, new)
 
+    def test_grad_accepts_tuple_subclass_inputs(self):
+        class InputsTuple(tuple):
+            pass
+
+        x = torch.rand(2, requires_grad=True)
+        y = (x * x).sum()
+        grads = torch.autograd.grad(y, InputsTuple((x,)))
+        self.assertEqual(grads, (2 * x,))
+
     def test_grad_to_node_materialize(self):
         x = torch.rand(2, requires_grad=True).clone()
         edge_x = GradientEdge(x.grad_fn, x.output_nr)

--- a/torch/csrc/autograd/python_engine.cpp
+++ b/torch/csrc/autograd/python_engine.cpp
@@ -298,7 +298,7 @@ static PyObject* THPEngine_run_backward(
   std::vector<Edge> output_edges;
   if (inputs != nullptr) {
     TORCH_CHECK(
-        PyTuple_CheckExact(inputs), "inputs to run_backward must be a tuple");
+        PyTuple_Check(inputs), "inputs to run_backward must be a tuple");
     int num_inputs = PyTuple_GET_SIZE(inputs);
     output_edges.reserve(num_inputs);
     for (const auto i : c10::irange(num_inputs)) {


### PR DESCRIPTION
## Summary
- Relax `run_backward` input validation from `PyTuple_CheckExact` to `PyTuple_Check` so tuple subclasses are accepted, matching the existing behavior for other tuple arguments.
- Add an autograd regression test covering tuple-subclass inputs to `torch.autograd.grad`.

Co-authored-by: Cursor

## Test plan
- Attempted local targeted test in repo venv:
  - `python test/test_autograd.py -k test_grad_accepts_tuple_subclass_inputs`
- Local PyTorch editable build is currently blocked in this environment while running:
  - `python -m pip install -e . -v --no-build-isolation`
  - Failure seen: `make: Makefile: No such file or directory` during build step.