### PR TITLE
Fix GradientEdge None-grad error message formatting

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1372,6 +1372,15 @@ class TestAutograd(TestCase):
                 tmp_edge, inputs=(x,), grad_tensors=torch.tensor([1.0, 2.0, 3.0, 4.0])
             )
 
+    def test_gradient_edge_none_grad_error_message(self):
+        x = torch.rand(2, requires_grad=True).clone()
+        edge = GradientEdge(x.grad_fn, x.output_nr)
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "GradientEdge\\. This is not supported\\.",
+        ):
+            torch.autograd.backward((edge,), grad_tensors=(None,))
+
     def test_gradient_edge_graph_ownership(self):
         # Ensure we own the graph properly
         class Clone(torch.autograd.Function):

--- a/torch/csrc/autograd/python_engine.cpp
+++ b/torch/csrc/autograd/python_engine.cpp
@@ -286,7 +286,7 @@ static PyObject* THPEngine_run_backward(
           "element ",
           i,
           " of gradients tuple is None, but the corresponding output is a GradientEdge."
-          "This is not supported.");
+          " This is not supported.");
       TORCH_CHECK(
           !mb_output.value().requires_grad(),
           "element ",


### PR DESCRIPTION
## Summary
- Fix a missing space in the `run_backward` user-facing error message for `GradientEdge` when the corresponding gradient is `None`.
- Add a focused regression test to lock in the corrected error text.

Co-authored-by: Cursor

## Test plan
- Attempted local targeted test in repo venv:
  - `python test/test_autograd.py -k test_gradient_edge_none_grad_error_message`
- Local PyTorch editable build is currently blocked in this environment while running:
  - `python -m pip install -e . -v --no-build-isolation`
  - Failure seen: `make: Makefile: No such file or directory` during build step.