### PR TITLE
Validate queue_callback input is callable

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -8616,6 +8616,10 @@ for shape in [(1,), ()]:
 
         self.assertEqual(called[0], 2)
 
+    def test_queue_callback_requires_callable(self):
+        with self.assertRaisesRegex(RuntimeError, "queue_callback expects a callable"):
+            Variable._execution_engine.queue_callback(123)
+
     @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
     def test_callback_propagates_errors_from_device_thread(self):
         def callback():

--- a/torch/csrc/autograd/python_engine.cpp
+++ b/torch/csrc/autograd/python_engine.cpp
@@ -380,6 +380,7 @@ static PyObject* THPEngine_run_backward(
 static PyObject* THPEngine_queue_callback(PyObject* self, PyObject* _callback) {
   HANDLE_TH_ERRORS
   auto& engine = python::PythonEngine::get_python_engine();
+  TORCH_CHECK(PyCallable_Check(_callback), "queue_callback expects a callable");
   std::shared_ptr<PyObject> callback(_callback, [](PyObject* obj) {
     pybind11::gil_scoped_acquire gil;
     Py_DECREF(obj);


### PR DESCRIPTION
## Summary
- Add explicit callable validation in `THPEngine_queue_callback` so invalid callback arguments fail immediately on the caller thread.
- Add a targeted autograd regression test asserting a clear error for non-callable callback inputs.

Co-authored-by: Cursor

## Test plan
- Attempted local targeted test in repo venv:
  - `python test/test_autograd.py -k test_queue_callback_requires_callable`
- Local PyTorch editable build is currently blocked in this environment while running:
  - `python -m pip install -e . -v --no-build-isolation`
  - Failure seen: `make: Makefile: No such file or directory` during build step.