### PR TITLE
Validate target range [0, 1] in binary_cross_entropy_with_logits

### DIFF
--- a/aten/src/ATen/native/Loss.cpp
+++ b/aten/src/ATen/native/Loss.cpp
@@ -347,9 +347,12 @@ Tensor& binary_cross_entropy_backward_out_cpu(const Tensor& grad, const Tensor& 
 }
 
 Tensor binary_cross_entropy_with_logits(const Tensor& input, const Tensor& target, const std::optional<Tensor>& weight_opt, const std::optional<Tensor>& pos_weight_opt, int64_t reduction) {
-  TORCH_CHECK(
-      target.numel() == 0 || (at::all(target >= 0).item<bool>() && at::all(target <= 1).item<bool>()),
-      "all elements of target should be between 0 and 1");
+  if (target.numel() > 0) {
+    auto [min_val, max_val] = at::aminmax(target);
+    TORCH_CHECK(
+        min_val.item<double>() >= 0 && max_val.item<double>() <= 1,
+        "all elements of target should be between 0 and 1");
+  }
   auto log_sigmoid_input = at::log_sigmoid(input);
   if (pos_weight_opt.has_value() && pos_weight_opt->defined()) {
       // pos_weight need to be broadcasted, thus mul(target) is not inplace.

--- a/aten/src/ATen/native/Loss.cpp
+++ b/aten/src/ATen/native/Loss.cpp
@@ -347,6 +347,9 @@ Tensor& binary_cross_entropy_backward_out_cpu(const Tensor& grad, const Tensor& 
 }
 
 Tensor binary_cross_entropy_with_logits(const Tensor& input, const Tensor& target, const std::optional<Tensor>& weight_opt, const std::optional<Tensor>& pos_weight_opt, int64_t reduction) {
+  TORCH_CHECK(
+      target.numel() == 0 || (at::all(target >= 0).item<bool>() && at::all(target <= 1).item<bool>()),
+      "all elements of target should be between 0 and 1");
   auto log_sigmoid_input = at::log_sigmoid(input);
   if (pos_weight_opt.has_value() && pos_weight_opt->defined()) {
       // pos_weight need to be broadcasted, thus mul(target) is not inplace.

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4900,6 +4900,19 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         out2 = nn.BCEWithLogitsLoss(pos_weight=pos_weight)(output, target)
         self.assertTrue(torch.isfinite(out2).all().item())
 
+    def test_bce_with_logits_target_range(self):
+        output = torch.randn(25, 25)
+        target_valid = torch.rand(25, 25)
+        target_too_negative = target_valid - 1.0
+        target_too_positive = target_valid + 1.0
+
+        nn.BCEWithLogitsLoss()(output, target_valid)
+
+        with self.assertRaisesRegex(RuntimeError, "between 0 and 1"):
+            nn.BCEWithLogitsLoss()(output, target_too_negative)
+        with self.assertRaisesRegex(RuntimeError, "between 0 and 1"):
+            nn.BCEWithLogitsLoss()(output, target_too_positive)
+
     def test_bce_loss_broadcasts_weights(self):
         sigmoid = nn.Sigmoid()
         target = torch.rand(16, 4)

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -4824,6 +4824,10 @@ def mv(self, vec):
 def binary_cross_entropy_with_logits(
     self, target, weight=None, pos_weight=None, reduction=Reduction.MEAN.value
 ):
+    torch._check(
+        target.numel() == 0 or (target >= 0).all() and (target <= 1).all(),
+        lambda: "all elements of target should be between 0 and 1",
+    )
     if pos_weight is not None:
         log_weight = (pos_weight - 1) * target + 1
         loss = (1 - target) * self - (log_weight * F.logsigmoid(self))


### PR DESCRIPTION
Fixes #110865

`BCELoss` validates that target values are in `[0, 1]` (per-element TORCH_CHECK on CPU, CUDA_KERNEL_ASSERT on CUDA), but `BCEWithLogitsLoss` does not, silently accepting any target value and producing meaningless loss values. As @mikaylagawarecki noted: "Since we validate target for BCELoss it seems reasonable to add the same validation for BCEWithLogitsLoss."

```python
loss = nn.BCEWithLogitsLoss()
loss(torch.randn(5), torch.tensor([0., 1., 2., -1., 0.5]))  # silently succeeds
```

**Fix** across both eager and torch.compile paths:
- `aten/src/ATen/native/Loss.cpp`: Add `TORCH_CHECK` at the entry of `binary_cross_entropy_with_logits` (single dispatch point for all devices via CompositeExplicitAutograd)
- `torch/_decomp/decompositions.py`: Add `torch._check` in the decomposition for the torch.compile path
- `test/test_nn.py`: Add `test_bce_with_logits_target_range` following the existing `test_bce_loss_input_range` pattern

Two prior PRs (#177506, #113433) attempted this fix but went stale without merge.

cc @mikaylagawarecki @jbschlosser @albanD