### PR TITLE
[inductor] Fix inductor dropping ordering dep between effectful ops with different kernel types

### DIFF
--- a/test/higher_order_ops/test_with_effects.py
+++ b/test/higher_order_ops/test_with_effects.py
@@ -291,6 +291,107 @@ def forward(self, arg0_1, arg1_1, arg2_1):
             res = torch.compile(f, backend="inductor")(*inputs)
             self.assertTrue(torch.allclose(res, f(*inputs)))
 
+    @unittest.skipIf(IS_WINDOWS, "Skipped on Windows!")
+    @skipIfNoDynamoSupport
+    def test_inductor_preserves_effect_order_across_kernel_types(self):
+        # Two ORDERED-effectful ops must keep program order even when they lower
+        # to different inductor kernel types (op_a -> FallbackKernel, op_b ->
+        # _CollectiveKernel).
+        import torch.utils._pytree as pytree
+        from torch._inductor import ir
+        from torch._inductor.lowering import lowerings, register_lowering
+        from torch._inductor.utils import run_and_get_code
+
+        with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
+            torch.library.define("mylib::op_a", "(Tensor x) -> ()", lib=lib)
+            torch.library.define("mylib::op_b", "(Tensor x) -> Tensor", lib=lib)
+            lib.impl("op_a", lambda x: None, "CompositeExplicitAutograd")
+            lib.impl("op_a", lambda x: None, "Meta")
+            lib.impl("op_b", lambda x: x + 1, "CompositeExplicitAutograd")
+            lib.impl("op_b", lambda x: torch.empty_like(x), "Meta")
+            torch.library._register_effectful_op(
+                "mylib::op_a", _EffectType.ORDERED, lib=lib
+            )
+            torch.library._register_effectful_op(
+                "mylib::op_b", _EffectType.ORDERED, lib=lib
+            )
+
+            op_b = torch.ops.mylib.op_b.default
+
+            def op_b_lowering(*args):
+                return pytree.tree_map(
+                    lambda t: ir.TensorBox.create(t) if isinstance(t, ir.IRNode) else t,
+                    ir._CollectiveKernel.create_out_of_place(op_b, *args),
+                )
+
+            register_lowering(op_b)(op_b_lowering)
+            try:
+
+                def f(x):
+                    torch.ops.mylib.op_a(x)
+                    y = torch.ops.mylib.op_b(x)
+                    return y * 10
+
+                torch._dynamo.reset()
+                _, (code,) = run_and_get_code(
+                    torch.compile(f, fullgraph=True, backend="inductor"),
+                    torch.ones(8),
+                )
+                # op_a must be emitted before op_b; a dropped ordering dep lets
+                # the scheduler reorder op_b ahead of op_a.
+                pos_a = code.find("op_a")
+                pos_b = code.find("op_b")
+                self.assertNotEqual(pos_a, -1, "op_a missing from generated code")
+                self.assertNotEqual(pos_b, -1, "op_b missing from generated code")
+                self.assertLess(pos_a, pos_b, "op_a must be emitted before op_b")
+            finally:
+                del lowerings[op_b]
+
+    @unittest.skipIf(IS_WINDOWS, "Skipped on Windows!")
+    @skipIfNoDynamoSupport
+    def test_inductor_effect_order_does_not_extend_lifetimes(self):
+        # The effect edge between two ORDERED ops is an ordering constraint only.
+        # It must not be modelled as a real read of the previous op's output
+        # buffer: that would count as a use, keep the buffer live until the
+        # later op runs, and suppress its deallocation.
+        #
+        # keep() produces a real output buffer, and stash() is ordered after it
+        # while also consuming a value derived from that buffer, so stash cannot
+        # be hoisted above the buffer's last true use. With a weak ordering dep
+        # the buffer is freed right after that use; modelling the effect edge as
+        # a real read holds it live across the stash call instead.
+        from torch._inductor.utils import run_and_get_code
+
+        with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
+            torch.library.define("mylib::keep", "(Tensor x) -> Tensor", lib=lib)
+            torch.library.define("mylib::stash", "(Tensor x) -> ()", lib=lib)
+            lib.impl("keep", lambda x: x.clone(), "CompositeExplicitAutograd")
+            lib.impl("keep", lambda x: torch.empty_like(x), "Meta")
+            lib.impl("stash", lambda x: None, "CompositeExplicitAutograd")
+            lib.impl("stash", lambda x: None, "Meta")
+            for name in ("keep", "stash"):
+                torch.library._register_effectful_op(
+                    f"mylib::{name}", _EffectType.ORDERED, lib=lib
+                )
+
+            def f(x):
+                y = torch.ops.mylib.keep(x)
+                z = y * 2
+                torch.ops.mylib.stash(z)
+                return z + 1
+
+            x = torch.arange(64, dtype=torch.float32)
+            torch._dynamo.reset()
+            code = run_and_get_code(
+                torch.compile(f, fullgraph=True, backend="inductor"), x
+            )[1][0]
+
+            # Both effectful ops still run, in program order.
+            FileCheck().check("keep").check("stash").run(code)
+            # keep's output buffer is freed before the stash it is ordered
+            # before, rather than being held live by the effect edge.
+            FileCheck().check("keep").check("del buf0").check("stash").run(code)
+
     def test_compile_aot_eager_requires_grad(self):
         def f(x):
             torch.ops.aten._print("moo")

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1168,6 +1168,11 @@ class FreeIfNotReusedLine(MemoryPlanningLine):
             raise AssertionError("expected line to not be reused")
         if self.node.get_name() in V.graph.removed_buffers:
             return NullLine(self.wrapper)
+        if self.node.get_name() in V.graph.never_reuse_but_free_buffers:
+            # Emit the free but keep the storage out of the reuse pool: freeing
+            # only drops inductor's own reference, so a tensor retained behind
+            # inductor's back (stashed away by an effectful op) survives.
+            return self
         if config.allow_buffer_reuse:
             if self.comm_buffer:
                 # Comm buffers use separate pool (comm-comm reuse only)
@@ -4559,13 +4564,13 @@ class PythonWrapperCodegen(CodeGen):
             self.writeline(FreeIfNotReusedLine(self, buffer, comm_buffer=True))
             return
 
-        if not self.can_reuse(buffer):
+        if not self.can_free(buffer):
             return
         self.freed.add(name)
 
         self.writeline(FreeIfNotReusedLine(self, buffer))
 
-    def can_reuse(self, input_buffer, output_buffer=None):
+    def can_free(self, input_buffer):
         name = input_buffer.get_name()
         return not (
             name in V.graph.removed_buffers
@@ -4579,6 +4584,11 @@ class PythonWrapperCodegen(CodeGen):
             or name in V.graph.torchbind_constants
             or name in V.graph.never_reuse_buffers
             or name in self.freed
+        )
+
+    def can_reuse(self, input_buffer, output_buffer=None):
+        return self.can_free(input_buffer) and (
+            input_buffer.get_name() not in V.graph.never_reuse_but_free_buffers
         )
 
     def did_reuse(self, buffer, reused_buffer):

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -472,7 +472,6 @@ class GraphLowering(torch.fx.Interpreter):
         self.additional_buffer_deps: dict[str, OrderedSet[str]] = defaultdict(
             OrderedSet
         )
-        self.additional_star_deps: dict[str, OrderedSet[str]] = defaultdict(OrderedSet)
         # Maps control_deps FX node to operation names created when lowering it,
         # for void ops (e.g. record_event) that return None and therefore cannot
         # be referenced by name in subsequent control_deps ordering constraints.
@@ -518,7 +517,13 @@ class GraphLowering(torch.fx.Interpreter):
         self.removed_inplace_buffers: OrderedSet[str] = OrderedSet()
         self.mutated_buffers: OrderedSet[str] = OrderedSet()
         self.sdpa_constraint_cache: dict[tuple, ir.IRNode] = {}
+        # Buffers that are neither recycled nor freed. Aliasing kernels rely on
+        # the second half: some have no output variable to free at all.
         self.never_reuse_buffers: OrderedSet[str] = OrderedSet()
+        # Buffers withheld from the reuse pool but still freed, for storage that
+        # may be retained behind inductor's back. Freeing only drops inductor's
+        # own reference, so a retained tensor survives; recycling would not.
+        self.never_reuse_but_free_buffers: OrderedSet[str] = OrderedSet()
         self.inplaced_to_remove: OrderedSet[str] = OrderedSet()
         self.device_ops: DeviceOpOverrides = None  # type: ignore[assignment]
         self.wrapper_code: PythonWrapperCodegen = None  # type: ignore[assignment]

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -9426,6 +9426,25 @@ def with_effects(token, op, *args, **kwargs):
                         raise AssertionError("Multiple effects NYI")
                     effect_type = next(iter(effects))
 
+    # An effectful op may retain its tensor inputs in state inductor cannot see
+    # (e.g. pushing a tensor onto a torchbind queue), so the input buffers must
+    # never have their storage recycled for another buffer. This is retention,
+    # not ordering: no dependency edge can express "the callee kept a reference",
+    # so the ordering dep below (deliberately weak) does not cover it. We pin the
+    # inputs of every ORDERED op rather than only those that can actually retain
+    # them, since there is no reliable "retains inputs" signal: retention happens
+    # inside the op implementation, so it is absent from the schema (queue_push
+    # reports alias_info=None), the EffectType enum only encodes ordering, and a
+    # ScriptObject argument merely triggers the default effect. Under-pinning
+    # silently miscompiles, so the bounded over-pinning is the intended tradeoff.
+    # never_reuse_but_free_buffers rather than never_reuse_buffers: dropping
+    # inductor's own reference is safe here, only recycling the storage is not.
+    if effect_type:
+        for arg in pytree.tree_leaves((args, kwargs)):
+            if isinstance(arg, TensorBox):
+                arg.realize()
+                V.graph.never_reuse_but_free_buffers.add(arg.get_name())
+
     # Track operations before
     operation_len = len(V.graph.operations)
 
@@ -9443,8 +9462,13 @@ def with_effects(token, op, *args, **kwargs):
             wrap_tensors, ir.FallbackKernel.create(op, *args, **kwargs)
         )
 
-    # Get all the operations created during the lowering above, and add StarDeps
-    # to the previous node with the same effect
+    # Get all the operations created during the lowering above, and order them
+    # after the previous op with the same effect. This is an ordering constraint
+    # only: an effect edge says nothing about whether this op reads the previous
+    # one's buffer, so it goes through additional_buffer_deps, which the
+    # scheduler installs as WeakDep(is_fake=True). A strong dep would be counted
+    # as a real read and would extend the previous buffer's lifetime past its
+    # last true use, defeating both reuse and deallocation.
     if len(V.graph.operations[operation_len:]) <= 0:
         raise AssertionError(
             f"No operation nodes were generated when lowering effectful operator {op}."
@@ -9455,8 +9479,12 @@ def with_effects(token, op, *args, **kwargs):
             # Patch has_side_effects to return True
             new_op.has_side_effects = lambda: True  # pyrefly: ignore[missing-attribute]
             if prev_effect_buffer:
-                op_name = new_op.get_name()  # pyrefly: ignore[missing-attribute]
-                V.graph.additional_star_deps[op_name].add(prev_effect_buffer.get_name())
+                op_name = (
+                    new_op.get_operation_name()
+                )  # pyrefly: ignore[missing-attribute]
+                V.graph.additional_buffer_deps[op_name].add(
+                    prev_effect_buffer.get_name()
+                )
         # Update the effectful ops chain to point to the latest operation
         V.graph.effectful_ops[effect_type] = (
             new_op  # pyrefly: ignore[unsupported-operation]

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -4944,10 +4944,6 @@ class Scheduler:
                 # they should not extend buffer lifetimes
                 node.add_fake_dep(WeakDep(add_dep, node.get_name(), is_fake=True))
 
-            for add_dep in V.graph.additional_star_deps[node.get_name()]:
-                add_user(add_dep, node, is_weak=False)  # Strong dependency
-                node.add_fake_dep(StarDep(add_dep))
-
             # add normal non-mutation dependencies
             for read in node.read_writes.reads:
                 if not isinstance(read, WeakDep):


### PR DESCRIPTION
`with_effects` records an ordering edge between consecutive ORDERED-effectful ops so the scheduler preserves their program order. That edge was both dropped and, when it did apply, too strong. Fixing the strength then exposed a latent conflation in how pinned buffers are freed.

**The edge was dropped.** It was recorded in `V.graph.additional_star_deps` keyed by `new_op.get_name()` (a buffer name), but the scheduler reads it back by operation name. Ops lowering to the same kernel type gave names that coincided, masking the mismatch; different kernel types (e.g. an `ExternKernel` followed by a `_CollectiveKernel`) made the key miss, so the dep vanished and the scheduler could reorder `op_b` ahead of `op_a`. Fixed by keying on `get_operation_name()`.

**The edge was too strong.** `additional_star_deps` is installed as a `StarDep`, which asserts ordering *and* liveness, so an effect edge counted as a real read of the previous op's output buffer and held it live past its last true use, blocking reuse and deallocation. An effect edge carries no data, so it belongs in `additional_buffer_deps`, installed as `WeakDep(is_fake=True)`, filtered out of `used_or_aliased_buffer_names`, so it orders without extending lifetimes. This is the pattern `OrderingBarrier` already documents. `additional_star_deps` had no other users and is removed.

**Retention is a separate concern, and also needed.** The above is about the *previous* op's output buffer. Independently, *this* op's inputs may be retained in state inductor cannot see (`tq.push(x)` stashes a tensor in a torchbind queue), and no dependency edge can express "the callee kept a reference", so those inputs must not have their storage recycled. The axes are independent: without the pin `test_torchbind_queue` gives silently wrong numerics under either dep strength.

**Pinning must block recycling without blocking deallocation,** since freeing only drops inductor's own reference and storage retained behind its back survives. That distinction did not exist: `never_reuse_buffers` both withheld a buffer from the reuse pool and suppressed its free. Putting retention pins there would therefore keep every effectful op's input allocated for the whole graph, and peak memory grows with the number of effectful ops — measured locally, though the memory test is not part of this PR. But the suppression half is load-bearing elsewhere: `ShallowCopyDataKernel` pins its own output, which in the cpp wrapper has no output variable at all (the call is emitted bare), so emitting a free for it generates a `reset()` on an undeclared name and fails to compile. Rather than redefine the existing set, retention pins go in a new `never_reuse_but_free_buffers`, and the split is expressed as `can_free` (body unchanged from the old `can_reuse`, so every pre-existing pin site behaves exactly as before) plus `can_reuse` (`can_free` and not retention-pinned).

Review `lowering.py` first for the keying fix, the weakened dep, and the pin; then `scheduler.py` for the dep the switch now goes through, and `graph.py` / `wrapper.py` for the two sets and the `can_free`/`can_reuse` split.

## Test plan

`test_inductor_preserves_effect_order_across_kernel_types` covers the keying fix: two ORDERED ops lowering to different kernel types (`op_a` -> `FallbackKernel`, `op_b` -> `_CollectiveKernel`), asserting `op_a` is emitted first. It fails without the fix because the dropped dep lets the scheduler reorder them.

`test_inductor_effect_order_does_not_extend_lifetimes` covers the dep strength. To discriminate it needs an effectful op with a real output buffer for a strong dep to over-retain, plus a later effectful op consuming a value derived from that buffer so it cannot be hoisted above the buffer's last use; it then asserts the buffer is freed before that later op. Verified to fail with `is_fake=False` and pass with `is_fake=True`.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo