### PR TITLE
Allow grads for attn_bias only

### DIFF
--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -640,6 +640,18 @@ bool should_compute_logsumexp(const Tensor& query, const Tensor& key, const Tens
   return any_inputs_require_grad && gradmode_enabled;
 }
 
+bool should_compute_logsumexp_with_attn_mask(
+    const Tensor& query,
+    const Tensor& key,
+    const Tensor& value,
+    const std::optional<Tensor>& attn_mask) {
+  const bool any_inputs_require_grad = query.requires_grad() ||
+      key.requires_grad() || value.requires_grad() ||
+      (attn_mask.has_value() && attn_mask->requires_grad());
+  const bool gradmode_enabled = at::GradMode::is_enabled();
+  return any_inputs_require_grad && gradmode_enabled;
+}
+
 std::tuple<at::Tensor, at::Tensor> pre_process_group_query_attention_input(
     const at::Tensor& query,
     const at::Tensor& key,
@@ -757,6 +769,7 @@ Tensor scaled_dot_product_attention(
   auto attn_mask = convert_boolean_attn_mask(attn_mask_, query_.dtype());
   switch (backend) {
     case SDPBackend::cudnn_attention: {
+      // cuDNN SDPA backward does not support an attn_bias gradient.
       bool compute_logsumexp = should_compute_logsumexp(query_, key, value);
       auto out_lse_softmax = at::_scaled_dot_product_cudnn_attention(
           query_, key, value, attn_mask, compute_logsumexp, dropout_p, is_causal, false /*return_debug_mask*/, scale);
@@ -781,10 +794,10 @@ Tensor scaled_dot_product_attention(
           query_, key, value, dropout_p, is_causal, attn_mask, scale));
     }
     case SDPBackend::efficient_attention: {
-      bool compute_logsumexp = should_compute_logsumexp(query_, key, value);
       if (attn_mask.has_value()) {
         attn_mask.value() = preprocess_mask(attn_mask.value(), query_, key, value);;
       }
+      bool compute_logsumexp = should_compute_logsumexp_with_attn_mask(query_, key, value, attn_mask);
       auto out_and_lse = at::_scaled_dot_product_efficient_attention(
           query_, key, value, attn_mask, compute_logsumexp, dropout_p, is_causal, scale);
       return std::get<0>(out_and_lse);

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -3500,6 +3500,26 @@ class TestSDPACudaOnly(NNTestCase):
         out.sum().backward()
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION, "Fused SDPA was not built for this system")
+    def test_mem_eff_attention_mask_only_requires_grad(self, device):
+        torch.manual_seed(0)
+        query, key, value = (torch.randn((1, 1, 64, 16), device=device) for _ in range(3))
+        mask = torch.randn((1, 1, 64, 64), device=device)
+
+        actual_mask = mask.detach().clone().requires_grad_()
+        with sdpa_kernel(backends=[SDPBackend.EFFICIENT_ATTENTION]):
+            actual = F.scaled_dot_product_attention(query, key, value, actual_mask)
+        actual.sum().backward()
+        torch.cuda.synchronize()
+
+        expected_mask = mask.detach().clone().requires_grad_()
+        with sdpa_kernel(backends=[SDPBackend.MATH]):
+            expected = F.scaled_dot_product_attention(query, key, value, expected_mask)
+        expected.sum().backward()
+
+        self.assertEqual(actual, expected, atol=1e-5, rtol=1e-5)
+        self.assertEqual(actual_mask.grad, expected_mask.grad, atol=1e-5, rtol=1e-5)
+
+    @unittest.skipIf(not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION, "Fused SDPA was not built for this system")
     @parametrize("dtype", [torch.float, torch.float16])
     def test_mem_eff_attention_non_contiguous_mask(self, device, dtype):
         make_tensor = partial(torch.rand, device=device, dtype=dtype, requires_grad=True)


### PR DESCRIPTION
## Human Note
Another pretty straightforward one just calcualte whether we need to save logsumexp based over all possible things that can support grads

## Agent Report
# PTQ Report: pytorch/pytorch#148476

## Summary

Fixed a CUDA illegal memory access in `torch.nn.functional.scaled_dot_product_attention` when the float attention mask is the only input requiring gradients. The failing path used the memory-efficient SDPA backend and crashed during backward while computing the attention-mask gradient.

## Root cause

The top-level SDPA wrapper only requested `logsumexp` from fused forward when `query`, `key`, or `value` required gradients. In the issue repro, those tensors do not require gradients, but `attn_mask` does.

Memory-efficient attention backward still needs the forward `logsumexp` tensor to compute the bias/attention-mask gradient. Because forward skipped it, backward received an empty `logsumexp` tensor and the CUDA kernel read through a null pointer. `compute-sanitizer` identified invalid global reads from `fmha_cutlassB_f32_aligned_64x64_k32_sm80` at null addresses.

## Fix

Updated `aten/src/ATen/native/transformers/attention.cpp` so `should_compute_logsumexp` also considers a gradient-requiring attention mask. For the memory-efficient branch, the check now happens after mask preprocessing so padded/expanded masks preserve their autograd requirement before deciding whether to save `logsumexp`.

Added a CUDA regression test in `test/test_transformers.py` that forces `SDPBackend.EFFICIENT_ATTENTION`, leaves `query`/`key`/`value` without gradients, requires grad only on the mask, synchronizes after backward, and compares the mask gradient with the math backend.

## Repro Script

<details>
<summary>Repro Script</summary>

```python
import torch

q, k, v = (torch.randn((1, 1, 64, 16), device="cuda") for _ in range(3))
mask = torch.randn((1, 1, 64, 64), device="cuda", requires_grad=True)

o = torch.nn.functional.scaled_dot_product_attention(q, k, v, attn_mask=mask)

o.sum().backward()

print(mask.grad)
```

Before the fix with `CUDA_LAUNCH_BLOCKING=1`, this failed at `o.sum().backward()` with:

```text
torch.AcceleratorError: CUDA error: an illegal memory access was encountered
```

After the fix, the same script prints `mask.grad` successfully, e.g.:

```text
tensor([[[[ 2.1773e-02, -3.9849e-03,  3.5381e-02,  ...,  1.7331e-02,
            3.1027e-03, -1.8923e-01],
          [ 4.3033e-02, -5.4581e-02, -1.3842e-02,  ...,  2.1241e-03,
           -1.0355e-02, -8.4679e-02],
          [ 1.6725e-01, -1.0495e-03,  6.0237e-02,  ...,  1.6715e-01,
            8.2152e-03, -1.1444e-02],
          ...,
          [ 9.5836e-04, -3.6872e-03,  4.7719e-03,  ...,  1.4795e-01,
           -1.0260e-02, -8.6759e-02],
          [ 8.4794e-03, -2.7048e-03, -1.2979e-04,  ...,  7.2288e-03,
           -8.8836e-03, -1.1616e-02],
          [ 2.0411e-01, -4.1839e-04,  1.4768e-03,  ...,  2.1131e-02,
            4.1152e-02, -2.1360e-02]]]], device='cuda:0')
```

</details>

## Validation

### Tests

- `~/.ptq_workspace/jobs/20260626-pytorch-148476/.venv/bin/python test/test_transformers.py -k test_mem_eff_attention_mask_only_requires_grad_cuda`  
  Result: `Ran 1 test ... OK`.

### Repro and CUDA memory checks

- `~/.ptq_workspace/jobs/20260626-pytorch-148476/.venv/bin/python ~/.ptq_workspace/jobs/20260626-pytorch-148476/repro.py`  
  Result: passed; printed `mask.grad`.
- `CUDA_LAUNCH_BLOCKING=1 ~/.ptq_workspace/jobs/20260626-pytorch-148476/.venv/bin/python ~/.ptq_workspace/jobs/20260626-pytorch-148476/repro.py`  
  Result: passed; no synchronous CUDA error.
- `CUDA_LAUNCH_BLOCKING=1 PYTORCH_NO_CUDA_MEMORY_CACHING=1 compute-sanitizer --tool memcheck --error-exitcode=99 ~/.ptq_workspace/jobs/20260626-pytorch-148476/.venv/bin/python ~/.ptq_workspace/jobs/20260626-pytorch-148476/repro.py`  
  Result: `ERROR SUMMARY: 0 errors`.

### cuDNN backend check

The PTQ job build cannot execute the cuDNN path: `torch.backends.cudnn.is_available()` is `False` and `torch.backends.cudnn.version()` is `None`. Forcing `SDPBackend.CUDNN_ATTENTION` on the mask-only repro reports `Torch was not compiled with cuDNN attention` and raises `RuntimeError: No available kernel. Aborting execution.`

The user also ran the same backend-forcing check in a separate nightly env (`torch 2.14.0.dev20260625+cu132`, cuDNN `92301`). There, forcing `SDPBackend.CUDNN_ATTENTION` still raised `RuntimeError: No available kernel. Aborting execution`, while forcing `SDPBackend.EFFICIENT_ATTENTION` reproduced the CUDA illegal memory access. This confirms the repro does not exercise a cuDNN execution path even when cuDNN is available; the crash is on the memory-efficient backend.

### Prerequisite/build/lint checks

- Rebuilt C++ changes with `bash ~/.ptq_workspace/scripts/rebuild.sh ~/.ptq_workspace/jobs/20260626-pytorch-148476/pytorch`.
- `spin quickfix` and `spin quicklint` passed with `ok No lint issues` on the changed-file set.
- `git diff --check` passed.
- `spin fixlint` was attempted but failed on pre-existing repository-wide lint findings in unrelated files (`.ci/pytorch/test.sh`, `torch/headeronly/util/Half.h`, and `torch/headeronly/util/complex.h`).

## Artifacts

- Patch: `~/.ptq_workspace/jobs/20260626-pytorch-148476/fix.diff`


Fixes #148476


<details>
<summary>Repro Script</summary>

```python
import torch

q, k, v = (torch.randn((1, 1, 64, 16), device="cuda") for _ in range(3))
mask = torch.randn((1, 1, 64, 64), device="cuda", requires_grad=True)

o = torch.nn.functional.scaled_dot_product_attention(q, k, v, attn_mask=mask)

o.sum().backward()

print(mask.grad)
```

</details>


<details>
<summary>Agent Worklog</summary>

## Run 1

### Primed job and reproduced failure
Read `prime.md`, `PTQ_CONTEXT.md`, `system_prompt.md`, and `pytorch/AGENTS.md`. Confirmed `report.md` is not present yet and the source checkout is a clean detached HEAD at `2f596e89442`.

Ran the provided `repro.py` with the job venv. The backward completes far enough to populate `mask.grad`, but printing the CUDA tensor hits `torch.AcceleratorError: CUDA error: an illegal memory access was encountered`, matching the reported CUDA memory fault.

### Identified missing logsumexp for mask-only gradients
With `CUDA_LAUNCH_BLOCKING=1`, the fault is reported from `o.sum().backward()`. `compute-sanitizer --tool memcheck` shows invalid global reads from the `fmha_cutlassB_f32_aligned_64x64_k32_sm80` memory-efficient attention backward kernel at null addresses.

The SDPA wrapper only requested `logsumexp` from fused forward when `query`, `key`, or `value` required gradients. For the reported case only `attn_mask` requires grad, so memory-efficient backward received an empty logsumexp tensor and the CUDA kernel read through a null pointer while computing the bias gradient. Updated `should_compute_logsumexp` to include a gradient-requiring attention mask, and moved the efficient-attention check after mask preprocessing.

### Rebuilt and validated fix
Rebuilt the C++ change with `bash ~/.ptq_workspace/scripts/rebuild.sh ~/.ptq_workspace/jobs/20260626-pytorch-148476/pytorch`.

Validation passed:
- Original `repro.py` now prints `mask.grad` without a CUDA error.
- `CUDA_LAUNCH_BLOCKING=1 repro.py` also passes.
- `compute-sanitizer --tool memcheck --error-exitcode=99 repro.py` reports `ERROR SUMMARY: 0 errors`.
- Added and ran `test_mem_eff_attention_mask_only_requires_grad_cuda`, which compares efficient-attention mask-only gradients against the math backend.
- `git diff --check` passed.

Lint status:
- `spin fixlint` was attempted as requested by the PTQ prompt, but failed on pre-existing repository-wide lint findings in unrelated files such as `.ci/pytorch/test.sh`, `torch/headeronly/util/Half.h`, and `torch/headeronly/util/complex.h`.
- `spin quickfix` and `spin quicklint` on the changed-file set completed with `ok No lint issues`.

Generated `fix.diff` at `~/.ptq_workspace/jobs/20260626-pytorch-148476/fix.diff` and wrote the final report at `~/.ptq_workspace/jobs/20260626-pytorch-148476/report.md`.

### cuDNN backend availability check
User asked to test the cuDNN path. I checked with the PTQ job Python (the job prompt forbids using any other Python/env). This build reports `torch.backends.cudnn.is_available() == False` and `torch.backends.cudnn.version() == None`. Forcing `SDPBackend.CUDNN_ATTENTION` on the mask-only repro emits `Torch was not compiled with cuDNN attention` and raises `RuntimeError: No available kernel. Aborting execution.` No cuDNN execution path was available in this job environment.

User then ran the repro in their nightly env (`torch 2.14.0.dev20260625+cu132`, cuDNN `92301`). In that env, forcing `SDPBackend.CUDNN_ATTENTION` also raises `RuntimeError: No available kernel. Aborting execution`, while forcing `SDPBackend.EFFICIENT_ATTENTION` reproduces the CUDA illegal memory access. This indicates the repro is not taking a cuDNN execution path even when cuDNN is available; the observed crash remains the memory-efficient backend.

</details>

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*

cc @liangel-02 @howardzhang-cv