### PR TITLE
Add @onlyAccelerator to MXFP8/NVFP4 compile and numerics tests

### DIFF
--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -1987,6 +1987,7 @@ class TestFP8Matmul(TestCase):
         if sqnr.item() <= approx_match_sqnr_target:
             raise AssertionError(f"sqnr {sqnr.item()} should be > {approx_match_sqnr_target}")
 
+    @onlyAccelerator
     @unittest.skipIf(not PLATFORM_SUPPORTS_MX_GEMM, mx_skip_msg)
     @parametrize("test_case_name", [
         "a_eye_b_eye",
@@ -2619,6 +2620,7 @@ class TestFP8Matmul(TestCase):
                 self.scaled_grouped_mm_helper(a, blist, scale_a, bscalelist, outlist, fast_accum)
 
 
+    @onlyAccelerator
     @unittest.skipIf(not PLATFORM_SUPPORTS_MX_GEMM, mx_skip_msg)
     def test_blockwise_mxfp8_compile(self, device) -> None:
 
@@ -2647,6 +2649,7 @@ class TestFP8Matmul(TestCase):
         torch.testing.assert_close(C, C_ref, atol=0, rtol=0)
 
 
+    @onlyAccelerator
     @unittest.skipIf(not PLATFORM_SUPPORTS_MX_GEMM, mx_skip_msg)
     def test_blockwise_nvfp4_compile(self, device) -> None:
 


### PR DESCRIPTION
Add ```@onlyAccelerator``` to the ```MXFP8/NVFP4 compile``` tests in ```test_scaled_matmul_cuda.py```, which was intended to be added by [184771](https://github.com/pytorch/pytorch/pull/184771): "...Add @onlyAccelerator to grouped GEMM and compile tests."  

In [184771](https://github.com/pytorch/pytorch/pull/184771), ```@onlyAccelerator``` was added to previously CUDA-only tests (```device = "cuda"``` was hardcoded in their bodies, as shown in the PR diff) that were made device-generic (e.g., ```_scaled_grouped_gemm_```) for out-of-tree accelerators. This change adds the decorator to the remaining tests that were previously assumed to be CUDA-only before  [184771](https://github.com/pytorch/pytorch/pull/184771) so they are skipped for CPU.

cc @nkhasbag-nv 