### PR TITLE
Optimize all-gather copy-in with a flat parameter buffer

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_comm.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_comm.py
@@ -7,6 +7,7 @@ import os
 import tempfile
 import unittest
 from collections.abc import Callable
+from typing import cast
 from unittest.mock import MagicMock
 
 import torch
@@ -129,8 +130,11 @@ class TestFullyShardCollectiveOps(FSDPTestMultiThread):
         return orig_params
 
     def _init_fsdp_param_group(
-        self, params: list[nn.Parameter], reshard_after_forward: bool | int
-    ):
+        self,
+        params: list[nn.Parameter],
+        reshard_after_forward: bool | int,
+        mp_policy: MixedPrecisionPolicy | None = None,
+    ) -> FSDPParamGroup:
         module = nn.ParameterList([param.detach().clone() for param in params])
         mesh_info = FSDPMeshInfo(_init_default_fully_shard_mesh(), shard_mesh_dim=0)
         post_forward_mesh_info = _get_post_forward_mesh_info(
@@ -143,7 +147,7 @@ class TestFullyShardCollectiveOps(FSDPTestMultiThread):
             post_forward_mesh_info,
             self.device,
             None,  # shard_placement_fn
-            MixedPrecisionPolicy(),
+            mp_policy if mp_policy is not None else MixedPrecisionPolicy(),
             OffloadPolicy(),
         )
         fsdp_param_group.lazy_init()
@@ -175,6 +179,81 @@ class TestFullyShardCollectiveOps(FSDPTestMultiThread):
                 async_op=async_op,
                 all_gather_copy_in_stream=all_gather_copy_in_stream,
                 all_gather_stream=all_gather_stream,
+            )
+
+    @skip_if_lt_x_gpu(1)
+    @parametrize("param_dtype", [None, torch.bfloat16])
+    def test_all_gather_uses_flat_param_buffer(
+        self, param_dtype: torch.dtype | None
+    ) -> None:
+        class RecordingAllGather(DefaultAllGather):
+            def __init__(self) -> None:
+                self.input_tensor: torch.Tensor | None = None
+
+            def __call__(
+                self,
+                output_tensor: torch.Tensor,
+                input_tensor: torch.Tensor,
+                group: dist.ProcessGroup,
+                async_op: bool = False,
+            ) -> dist.Work | None:
+                self.input_tensor = input_tensor
+                return super().__call__(output_tensor, input_tensor, group, async_op)
+
+        orig_params = self._init_params(self._get_param_sizes())
+        fsdp_param_group = self._init_fsdp_param_group(
+            orig_params,
+            reshard_after_forward=True,
+            mp_policy=MixedPrecisionPolicy(param_dtype=param_dtype),
+        )
+        flat_param_buffer = fsdp_param_group._flat_param_buffer
+        self.assertIsNotNone(flat_param_buffer)
+        flat_param_buffer = cast(torch.Tensor, flat_param_buffer)
+        self.assertEqual(flat_param_buffer.dtype, orig_params[0].dtype)
+        offset = 0
+        for fsdp_param in fsdp_param_group.fsdp_params:
+            sharded_param_data = fsdp_param._sharded_param_data
+            self.assertEqual(
+                sharded_param_data.untyped_storage().data_ptr(),
+                flat_param_buffer.untyped_storage().data_ptr(),
+            )
+            self.assertEqual(sharded_param_data.storage_offset(), offset)
+            offset += sharded_param_data.numel()
+
+        all_gather_comm = RecordingAllGather()
+        all_gather_result = foreach_all_gather(
+            fsdp_param_group.fsdp_params,
+            fsdp_param_group.mesh_info.shard_process_group,
+            async_op=False,
+            all_gather_copy_in_stream=device_module.current_stream(),
+            all_gather_stream=device_module.current_stream(),
+            device=self.device,
+            all_gather_comm=all_gather_comm,
+        )
+        if param_dtype is None:
+            self.assertIs(all_gather_comm.input_tensor, flat_param_buffer)
+            self.assertIsNone(fsdp_param_group._flat_cast_buffer)
+        else:
+            flat_cast_buffer = fsdp_param_group._flat_cast_buffer
+            self.assertIsNotNone(flat_cast_buffer)
+            flat_cast_buffer = cast(torch.Tensor, flat_cast_buffer)
+            self.assertIs(all_gather_comm.input_tensor, flat_cast_buffer)
+            self.assertEqual(flat_cast_buffer.dtype, param_dtype)
+            self.assertEqual(flat_cast_buffer, flat_param_buffer.to(param_dtype))
+        foreach_all_gather_copy_out(
+            all_gather_result,
+            fsdp_param_group.fsdp_params,
+            fsdp_param_group.mesh_info.shard_process_group,
+        )
+        for fsdp_param in fsdp_param_group.fsdp_params:
+            fsdp_param.init_unsharded_param()
+        fsdp_param_group._to_unsharded()
+        for orig_param, param in zip(
+            orig_params, fsdp_param_group.modules[0].parameters()
+        ):
+            self.assertEqual(
+                param,
+                orig_param if param_dtype is None else orig_param.to(param_dtype),
             )
 
     def _test_all_gather(
@@ -336,6 +415,9 @@ class TestFullyShardCollectiveOps(FSDPTestMultiThread):
             sharded_grad = fsdp_param.sharded_param.grad
             self.assertIsInstance(sharded_grad, DTensor)
             self.assertEqual(sharded_grad.full_tensor(), reduced_grad)
+
+
+instantiate_parametrized_tests(TestFullyShardCollectiveOps)
 
 
 class TestFullyShardCommunication(FSDPTest):

--- a/test/distributed/_composable/fsdp/test_fully_shard_comm.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_comm.py
@@ -6,6 +6,7 @@ import itertools
 import os
 import tempfile
 import unittest
+import weakref
 from collections.abc import Callable
 from typing import cast
 from unittest.mock import MagicMock
@@ -134,6 +135,7 @@ class TestFullyShardCollectiveOps(FSDPTestMultiThread):
         params: list[nn.Parameter],
         reshard_after_forward: bool | int,
         mp_policy: MixedPrecisionPolicy | None = None,
+        lazy_init: bool = True,
     ) -> FSDPParamGroup:
         module = nn.ParameterList([param.detach().clone() for param in params])
         mesh_info = FSDPMeshInfo(_init_default_fully_shard_mesh(), shard_mesh_dim=0)
@@ -150,7 +152,8 @@ class TestFullyShardCollectiveOps(FSDPTestMultiThread):
             mp_policy if mp_policy is not None else MixedPrecisionPolicy(),
             OffloadPolicy(),
         )
-        fsdp_param_group.lazy_init()
+        if lazy_init:
+            fsdp_param_group.lazy_init()
         return fsdp_param_group
 
     @skip_if_lt_x_gpu(1)
@@ -182,12 +185,66 @@ class TestFullyShardCollectiveOps(FSDPTestMultiThread):
             )
 
     @skip_if_lt_x_gpu(1)
+    def test_flat_param_buffer_layout_and_param_identity(self) -> None:
+        orig_params = self._init_params(self._get_param_sizes())
+        fsdp_param_group = self._init_fsdp_param_group(
+            orig_params,
+            reshard_after_forward=True,
+            lazy_init=False,
+        )
+        sharded_params = [param.sharded_param for param in fsdp_param_group.fsdp_params]
+        optimizer = torch.optim.SGD(sharded_params, lr=0.1)
+        fsdp_param_group.lazy_init()
+        for optim_param, sharded_param, fsdp_param in zip(
+            optimizer.param_groups[0]["params"],
+            sharded_params,
+            fsdp_param_group.fsdp_params,
+        ):
+            self.assertIs(sharded_param, fsdp_param.sharded_param)
+            self.assertIs(optim_param, sharded_param)
+
+        flat_param_buffer = fsdp_param_group._flat_param_buffer
+        self.assertIsNotNone(flat_param_buffer)
+        flat_param_buffer = cast(torch.Tensor, flat_param_buffer)
+        self.assertEqual(flat_param_buffer.dtype, orig_params[0].dtype)
+        offset = 0
+        for fsdp_param in fsdp_param_group.fsdp_params:
+            sharded_param = fsdp_param.sharded_param
+            self.assertIsInstance(sharded_param, DTensor)
+            sharded_param = cast(DTensor, sharded_param)
+            self.assertEqual(
+                sharded_param._local_tensor.untyped_storage().data_ptr(),
+                flat_param_buffer.untyped_storage().data_ptr(),
+            )
+            self.assertEqual(sharded_param.storage_offset(), offset)
+            self.assertEqual(sharded_param._local_tensor.storage_offset(), offset)
+            offset += fsdp_param._sharded_param_data.numel()
+
+    @skip_if_lt_x_gpu(1)
+    def test_flat_param_buffer_falls_back_for_weakref(self) -> None:
+        orig_params = self._init_params(self._get_param_sizes())
+        fsdp_param_group = self._init_fsdp_param_group(
+            orig_params,
+            reshard_after_forward=True,
+            lazy_init=False,
+        )
+        sharded_param = fsdp_param_group.fsdp_params[0].sharded_param
+        param_ref = weakref.ref(sharded_param)
+
+        fsdp_param_group.lazy_init()
+
+        self.assertIsNone(fsdp_param_group._flat_param_buffer)
+        self.assertFalse(fsdp_param_group._flat_param_buffer_supported)
+        self.assertIs(param_ref(), sharded_param)
+
+    @skip_if_lt_x_gpu(1)
     @parametrize("param_dtype", [None, torch.bfloat16])
-    def test_all_gather_uses_flat_param_buffer(
+    def test_all_gather_with_flat_param_buffer(
         self, param_dtype: torch.dtype | None
     ) -> None:
         class RecordingAllGather(DefaultAllGather):
             def __init__(self) -> None:
+                self.output_tensor: torch.Tensor | None = None
                 self.input_tensor: torch.Tensor | None = None
 
             def __call__(
@@ -197,6 +254,7 @@ class TestFullyShardCollectiveOps(FSDPTestMultiThread):
                 group: dist.ProcessGroup,
                 async_op: bool = False,
             ) -> dist.Work | None:
+                self.output_tensor = output_tensor
                 self.input_tensor = input_tensor
                 return super().__call__(output_tensor, input_tensor, group, async_op)
 
@@ -209,16 +267,6 @@ class TestFullyShardCollectiveOps(FSDPTestMultiThread):
         flat_param_buffer = fsdp_param_group._flat_param_buffer
         self.assertIsNotNone(flat_param_buffer)
         flat_param_buffer = cast(torch.Tensor, flat_param_buffer)
-        self.assertEqual(flat_param_buffer.dtype, orig_params[0].dtype)
-        offset = 0
-        for fsdp_param in fsdp_param_group.fsdp_params:
-            sharded_param_data = fsdp_param._sharded_param_data
-            self.assertEqual(
-                sharded_param_data.untyped_storage().data_ptr(),
-                flat_param_buffer.untyped_storage().data_ptr(),
-            )
-            self.assertEqual(sharded_param_data.storage_offset(), offset)
-            offset += sharded_param_data.numel()
 
         all_gather_comm = RecordingAllGather()
         all_gather_result = foreach_all_gather(
@@ -230,16 +278,24 @@ class TestFullyShardCollectiveOps(FSDPTestMultiThread):
             device=self.device,
             all_gather_comm=all_gather_comm,
         )
-        if param_dtype is None:
-            self.assertIs(all_gather_comm.input_tensor, flat_param_buffer)
-            self.assertIsNone(fsdp_param_group._flat_cast_buffer)
-        else:
-            flat_cast_buffer = fsdp_param_group._flat_cast_buffer
-            self.assertIsNotNone(flat_cast_buffer)
-            flat_cast_buffer = cast(torch.Tensor, flat_cast_buffer)
-            self.assertIs(all_gather_comm.input_tensor, flat_cast_buffer)
-            self.assertEqual(flat_cast_buffer.dtype, param_dtype)
-            self.assertEqual(flat_cast_buffer, flat_param_buffer.to(param_dtype))
+        all_gather_input = all_gather_comm.input_tensor
+        all_gather_output = all_gather_comm.output_tensor
+        self.assertIsNotNone(all_gather_input)
+        self.assertIsNotNone(all_gather_output)
+        all_gather_input = cast(torch.Tensor, all_gather_input)
+        all_gather_output = cast(torch.Tensor, all_gather_output)
+        self.assertEqual(
+            all_gather_input.untyped_storage().data_ptr(),
+            all_gather_output.untyped_storage().data_ptr(),
+        )
+        self.assertEqual(
+            all_gather_input.storage_offset(),
+            fsdp_param_group.mesh_info.shard_process_group.rank()
+            * flat_param_buffer.numel(),
+        )
+        all_gather_dtype = param_dtype or flat_param_buffer.dtype
+        self.assertEqual(all_gather_input.dtype, all_gather_dtype)
+        self.assertEqual(all_gather_input, flat_param_buffer.to(all_gather_dtype))
         foreach_all_gather_copy_out(
             all_gather_result,
             fsdp_param_group.fsdp_params,

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
@@ -334,31 +334,44 @@ def foreach_all_gather(
     world_size, rank = group.size(), group.rank()
     device_handle = _get_device_handle(device.type)
     with device_handle.stream(all_gather_copy_in_stream):
-        param_all_gather_inputs = _get_param_all_gather_inputs(fsdp_params)
-        (
-            param_all_gather_input_dtypes,
-            param_all_gather_input_numels,
-            dtype,
-        ) = _get_all_gather_input_metadatas(param_all_gather_inputs)
-        if dtype == torch.uint8:
-            all_gather_inputs = [
-                t.view(torch.uint8) for ts in param_all_gather_inputs for t in ts
-            ]
+        all_gather_input = _get_flat_param_all_gather_input(fsdp_params)
+        if all_gather_input is not None:
+            (
+                param_all_gather_input_dtypes,
+                param_all_gather_input_numels,
+                dtype,
+                inp_split_sizes,
+            ) = _get_flat_param_all_gather_input_metadatas(fsdp_params)
+            all_gather_input_numel = all_gather_input.numel()
+            all_gather_output = all_gather_comm.allocate(
+                (all_gather_input_numel * world_size,), dtype=dtype, device=device
+            )
         else:
-            all_gather_inputs = [*chain.from_iterable(param_all_gather_inputs)]
-        inp_split_sizes = [t.numel() for t in all_gather_inputs]
-        all_gather_input_numel = sum(inp_split_sizes)
-        all_gather_output = all_gather_comm.allocate(
-            (all_gather_input_numel * world_size,), dtype=dtype, device=device
-        )
-        all_gather_input, all_gather_output = torch.ops.fsdp.all_gather_copy_in(
-            all_gather_inputs,
-            all_gather_output,
-            inp_split_sizes,
-            all_gather_input_numel,
-            rank,
-        )
-        del param_all_gather_inputs
+            param_all_gather_inputs = _get_param_all_gather_inputs(fsdp_params)
+            (
+                param_all_gather_input_dtypes,
+                param_all_gather_input_numels,
+                dtype,
+            ) = _get_all_gather_input_metadatas(param_all_gather_inputs)
+            if dtype == torch.uint8:
+                all_gather_inputs = [
+                    t.view(torch.uint8) for ts in param_all_gather_inputs for t in ts
+                ]
+            else:
+                all_gather_inputs = [*chain.from_iterable(param_all_gather_inputs)]
+            inp_split_sizes = [t.numel() for t in all_gather_inputs]
+            all_gather_input_numel = sum(inp_split_sizes)
+            all_gather_output = all_gather_comm.allocate(
+                (all_gather_input_numel * world_size,), dtype=dtype, device=device
+            )
+            all_gather_input, all_gather_output = torch.ops.fsdp.all_gather_copy_in(
+                all_gather_inputs,
+                all_gather_output,
+                inp_split_sizes,
+                all_gather_input_numel,
+                rank,
+            )
+            del param_all_gather_inputs
     all_gather_stream.wait_stream(all_gather_copy_in_stream)
     with device_handle.stream(all_gather_stream):
         all_gather_work = all_gather_comm(
@@ -376,6 +389,48 @@ def foreach_all_gather(
             param_all_gather_input_numels,
             inp_split_sizes,
         )
+
+
+@torch.no_grad()
+def _get_flat_param_all_gather_input(
+    fsdp_params: list[FSDPParam],
+) -> torch.Tensor | None:
+    if not fsdp_params:
+        return None
+    param_group = getattr(fsdp_params[0], "_flat_param_group", None)
+    if param_group is None or not param_group._is_flat_param_buffer_ready():
+        return None
+
+    flat_param_buffer = param_group._flat_param_buffer
+    if flat_param_buffer is None:
+        return None
+    dtype = fsdp_params[0].param_dtype or fsdp_params[0].orig_dtype
+    if flat_param_buffer.dtype == dtype:
+        return flat_param_buffer
+    flat_cast_buffer = param_group._flat_cast_buffer
+    if flat_cast_buffer is None or flat_cast_buffer.dtype != dtype:
+        flat_cast_buffer = torch.empty_like(flat_param_buffer, dtype=dtype)
+        param_group._flat_cast_buffer = flat_cast_buffer
+    flat_cast_buffer.copy_(flat_param_buffer)
+    return flat_cast_buffer
+
+
+def _get_flat_param_all_gather_input_metadatas(
+    fsdp_params: list[FSDPParam],
+) -> tuple[list[list[torch.dtype]], list[list[int]], torch.dtype, list[int]]:
+    param_group = getattr(fsdp_params[0], "_flat_param_group", None)
+    if param_group is None or param_group._flat_param_numels is None:
+        raise AssertionError("Expects flat parameter metadata to be initialized")
+    flat_param_numels = param_group._flat_param_numels
+    all_gather_dtype = fsdp_params[0].param_dtype or fsdp_params[0].orig_dtype
+    param_all_gather_input_dtypes = [[all_gather_dtype] for _ in fsdp_params]
+    param_all_gather_input_numels = [[numel] for numel in flat_param_numels]
+    return (
+        param_all_gather_input_dtypes,
+        param_all_gather_input_numels,
+        all_gather_dtype,
+        flat_param_numels,
+    )
 
 
 @torch.no_grad()

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
@@ -334,17 +334,24 @@ def foreach_all_gather(
     world_size, rank = group.size(), group.rank()
     device_handle = _get_device_handle(device.type)
     with device_handle.stream(all_gather_copy_in_stream):
-        all_gather_input = _get_flat_param_all_gather_input(fsdp_params)
-        if all_gather_input is not None:
+        flat_param_buffer = _get_flat_param_buffer(fsdp_params)
+        if flat_param_buffer is not None:
             (
                 param_all_gather_input_dtypes,
                 param_all_gather_input_numels,
                 dtype,
                 inp_split_sizes,
             ) = _get_flat_param_all_gather_input_metadatas(fsdp_params)
-            all_gather_input_numel = all_gather_input.numel()
+            all_gather_input_numel = flat_param_buffer.numel()
             all_gather_output = all_gather_comm.allocate(
                 (all_gather_input_numel * world_size,), dtype=dtype, device=device
+            )
+            all_gather_input, all_gather_output = torch.ops.fsdp.all_gather_copy_in(
+                [flat_param_buffer],
+                all_gather_output,
+                [all_gather_input_numel],
+                all_gather_input_numel,
+                rank,
             )
         else:
             param_all_gather_inputs = _get_param_all_gather_inputs(fsdp_params)
@@ -392,33 +399,21 @@ def foreach_all_gather(
 
 
 @torch.no_grad()
-def _get_flat_param_all_gather_input(
+def _get_flat_param_buffer(
     fsdp_params: list[FSDPParam],
 ) -> torch.Tensor | None:
     if not fsdp_params:
         return None
-    param_group = getattr(fsdp_params[0], "_flat_param_group", None)
+    param_group = fsdp_params[0]._flat_param_group
     if param_group is None or not param_group._is_flat_param_buffer_ready():
         return None
-
-    flat_param_buffer = param_group._flat_param_buffer
-    if flat_param_buffer is None:
-        return None
-    dtype = fsdp_params[0].param_dtype or fsdp_params[0].orig_dtype
-    if flat_param_buffer.dtype == dtype:
-        return flat_param_buffer
-    flat_cast_buffer = param_group._flat_cast_buffer
-    if flat_cast_buffer is None or flat_cast_buffer.dtype != dtype:
-        flat_cast_buffer = torch.empty_like(flat_param_buffer, dtype=dtype)
-        param_group._flat_cast_buffer = flat_cast_buffer
-    flat_cast_buffer.copy_(flat_param_buffer)
-    return flat_cast_buffer
+    return param_group._flat_param_buffer
 
 
 def _get_flat_param_all_gather_input_metadatas(
     fsdp_params: list[FSDPParam],
 ) -> tuple[list[list[torch.dtype]], list[list[int]], torch.dtype, list[int]]:
-    param_group = getattr(fsdp_params[0], "_flat_param_group", None)
+    param_group = fsdp_params[0]._flat_param_group
     if param_group is None or param_group._flat_param_numels is None:
         raise AssertionError("Expects flat parameter metadata to be initialized")
     flat_param_numels = param_group._flat_param_numels

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
@@ -237,6 +237,7 @@ class FSDPParam:
         self.all_gather_outputs: list[torch.Tensor] = []
         self.unsharded_accumulated_grad = None
         self._param_fqn: str | None = None  # prefixed from root module
+        self._flat_param_group: Any | None = None
         # TODO: Remove this padding logic once DTensor pads the local tensor:
         # https://github.com/pytorch/pytorch/issues/113045
         self._post_load_hook_handle = (
@@ -1230,6 +1231,8 @@ class FSDPParam:
         # For ops like `nn.Module._apply` or `load_state_dict(assign=True)`
         # that change the sharded parameter tensor, we may need to re-pad the
         # sharded local tensor and re-save the reference.
+        if self._flat_param_group is not None:
+            self._flat_param_group._invalidate_flat_param_buffer()
         module_info = self._module_info
         new_param = getattr(module_info.module, module_info.param_name)
         if new_param is not self.sharded_param:

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -7,6 +7,7 @@ from typing import Any, cast, Literal, NamedTuple, TYPE_CHECKING
 from typing_extensions import TypeVarTuple, Unpack
 
 import torch
+import torch._dynamo.compiled_autograd as compiled_autograd
 import torch.distributed as dist
 import torch.nn as nn
 from torch.distributed import _spmd_no_typecheck
@@ -16,6 +17,7 @@ from torch.distributed.fsdp._common_utils import (
     collect_grad_tensors,
     replace_grad_tensors,
 )
+from torch.distributed.tensor import DTensor
 from torch.profiler import record_function
 from torch.utils.hooks import RemovableHandle
 
@@ -181,6 +183,8 @@ class FSDPParamGroup:
             )
             for param, module_info in zip(params, param_module_infos)
         ]
+        for fsdp_param in self.fsdp_params:
+            fsdp_param._flat_param_group = self
         self.mesh_info = mesh_info
         self.post_forward_mesh_info = post_forward_mesh_info
         self.device = device
@@ -201,6 +205,10 @@ class FSDPParamGroup:
         self._all_reduce_hook: Callable[[torch.Tensor], None] | None = None
         self._all_gather_comm: AllGather = DefaultAllGather()
         self._all_gather_output = torch.empty(0, device=self.device)
+        self._flat_param_buffer: torch.Tensor | None = None
+        self._flat_param_numels: list[int] | None = None
+        self._flat_cast_buffer: torch.Tensor | None = None
+        self._flat_param_buffer_supported: bool | None = None
         self._reduce_scatter_comm: ReduceScatter = DefaultReduceScatter()
         # Optional stream to run the user-defined all-reduce hook in
         # Saved here and not in the comm. context because we allow the user to
@@ -321,7 +329,119 @@ class FSDPParamGroup:
         # Initialize mixed precision attributes lazily in case the user changes
         # the parameter dtypes after construction time but before forward
         self._init_mp_dtypes()
+        self._init_flat_param_buffer()
         self._register_state_dict_hooks()
+
+    def _invalidate_flat_param_buffer(
+        self, reset_support_check: bool = True
+    ) -> None:
+        self._flat_param_buffer = None
+        self._flat_param_numels = None
+        self._flat_cast_buffer = None
+        if reset_support_check:
+            self._flat_param_buffer_supported = None
+
+    def _can_use_flat_param_buffer(self) -> bool:
+        if not self.fsdp_params or compiled_autograd.compiled_autograd_enabled:
+            return False
+        if self._flat_param_buffer_supported is not None:
+            return self._flat_param_buffer_supported
+        first_fsdp_param = self.fsdp_params[0]
+        input_dtype = first_fsdp_param.param_dtype or first_fsdp_param.orig_dtype
+        orig_dtype = first_fsdp_param.orig_dtype
+        for fsdp_param in self.fsdp_params:
+            if (
+                fsdp_param.sharded_state != ShardedState.SHARDED
+                or fsdp_param.offload_to_cpu
+                or fsdp_param._sharded_param_data.is_meta
+                or fsdp_param.orig_dtype != orig_dtype
+                or (fsdp_param.param_dtype or fsdp_param.orig_dtype) != input_dtype
+                or not isinstance(fsdp_param.sharded_param, DTensor)
+                or hasattr(fsdp_param._sharded_local_tensor, "fsdp_pre_all_gather")
+                or hasattr(fsdp_param._sharded_local_tensor, "fsdp_post_all_gather")
+            ):
+                self._flat_param_buffer_supported = False
+                return False
+        self._flat_param_buffer_supported = True
+        return True
+
+    def _is_flat_param_buffer_ready(self) -> bool:
+        if compiled_autograd.compiled_autograd_enabled:
+            return False
+        flat_param_buffer = self._flat_param_buffer
+        flat_param_numels = self._flat_param_numels
+        if (
+            flat_param_buffer is None
+            or flat_param_numels is None
+            or not self.fsdp_params
+        ):
+            return False
+        first_fsdp_param = self.fsdp_params[0]
+        return (
+            first_fsdp_param.sharded_state == ShardedState.SHARDED
+            and first_fsdp_param._sharded_param_data.untyped_storage().data_ptr()
+            == flat_param_buffer.untyped_storage().data_ptr()
+        )
+
+    def _validate_flat_param_buffer(self) -> None:
+        flat_param_buffer = self._flat_param_buffer
+        flat_param_numels = self._flat_param_numels
+        if flat_param_buffer is None or flat_param_numels is None:
+            raise AssertionError("Expects the FSDP flat parameter buffer to exist")
+        expected_ptr = flat_param_buffer.untyped_storage().data_ptr()
+        expected_offset = 0
+        for fsdp_param, expected_numel in zip(self.fsdp_params, flat_param_numels):
+            if (
+                fsdp_param.sharded_state != ShardedState.SHARDED
+                or fsdp_param._sharded_param_data.untyped_storage().data_ptr()
+                != expected_ptr
+                or fsdp_param._sharded_param_data.storage_offset() != expected_offset
+                or fsdp_param._sharded_param_data.numel() != expected_numel
+            ):
+                raise AssertionError("Invalid FSDP flat parameter buffer")
+            expected_offset += expected_numel
+
+    def _init_flat_param_buffer(self) -> None:
+        if self._is_flat_param_buffer_ready():
+            return
+        if not self._can_use_flat_param_buffer():
+            return
+        self._invalidate_flat_param_buffer(reset_support_check=False)
+
+        flat_param_numels = [
+            fsdp_param._sharded_param_data.numel() for fsdp_param in self.fsdp_params
+        ]
+        flat_param_buffer = torch.empty(
+            (sum(flat_param_numels),),
+            dtype=self.fsdp_params[0].orig_dtype,
+            device=self.device,
+        )
+        offset = 0
+        for fsdp_param, numel in zip(self.fsdp_params, flat_param_numels):
+            sharded_param_data = fsdp_param._sharded_param_data
+            flat_param_slice = flat_param_buffer.narrow(0, offset, numel)
+            if numel > 0:
+                flat_param_slice.copy_(sharded_param_data)
+            fsdp_param._sharded_param_data = flat_param_slice
+
+            shard_dim = fsdp_param.fsdp_placement.dim
+            local_shard_length = (
+                fsdp_param.sharded_size[shard_dim] if numel > 0 else 0
+            )
+            padded_local_tensor = flat_param_slice.view(
+                fsdp_param.padded_sharded_param_size
+            )
+            sharded_param = cast(DTensor, fsdp_param.sharded_param)
+            sharded_param._local_tensor = padded_local_tensor.narrow(
+                dim=shard_dim,
+                start=0,
+                length=local_shard_length,
+            )
+            offset += numel
+
+        self._flat_param_buffer = flat_param_buffer
+        self._flat_param_numels = flat_param_numels
+        self._validate_flat_param_buffer()
 
     def set_symm_mem(self, backend: Literal["NCCL"] = "NCCL") -> None:
         if not isinstance(self._all_gather_comm, (DefaultAllGather | SymmMemAllGather)):

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -332,9 +332,7 @@ class FSDPParamGroup:
         self._init_flat_param_buffer()
         self._register_state_dict_hooks()
 
-    def _invalidate_flat_param_buffer(
-        self, reset_support_check: bool = True
-    ) -> None:
+    def _invalidate_flat_param_buffer(self, reset_support_check: bool = True) -> None:
         self._flat_param_buffer = None
         self._flat_param_numels = None
         self._flat_cast_buffer = None
@@ -425,13 +423,13 @@ class FSDPParamGroup:
             fsdp_param._sharded_param_data = flat_param_slice
 
             shard_dim = fsdp_param.fsdp_placement.dim
-            local_shard_length = (
-                fsdp_param.sharded_size[shard_dim] if numel > 0 else 0
-            )
+            local_shard_length = fsdp_param.sharded_size[shard_dim] if numel > 0 else 0
             padded_local_tensor = flat_param_slice.view(
                 fsdp_param.padded_sharded_param_size
             )
-            sharded_param = cast(DTensor, fsdp_param.sharded_param)
+            sharded_param = fsdp_param.sharded_param
+            if not isinstance(sharded_param, DTensor):
+                raise AssertionError(f"Expected DTensor, got {type(sharded_param)}")
             sharded_param._local_tensor = padded_local_tensor.narrow(
                 dim=shard_dim,
                 start=0,

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import weakref
 from typing import Any, cast, Literal, NamedTuple, TYPE_CHECKING
 from typing_extensions import TypeVarTuple, Unpack
 
@@ -207,7 +208,6 @@ class FSDPParamGroup:
         self._all_gather_output = torch.empty(0, device=self.device)
         self._flat_param_buffer: torch.Tensor | None = None
         self._flat_param_numels: list[int] | None = None
-        self._flat_cast_buffer: torch.Tensor | None = None
         self._flat_param_buffer_supported: bool | None = None
         self._reduce_scatter_comm: ReduceScatter = DefaultReduceScatter()
         # Optional stream to run the user-defined all-reduce hook in
@@ -335,7 +335,6 @@ class FSDPParamGroup:
     def _invalidate_flat_param_buffer(self, reset_support_check: bool = True) -> None:
         self._flat_param_buffer = None
         self._flat_param_numels = None
-        self._flat_cast_buffer = None
         if reset_support_check:
             self._flat_param_buffer_supported = None
 
@@ -354,7 +353,7 @@ class FSDPParamGroup:
                 or fsdp_param._sharded_param_data.is_meta
                 or fsdp_param.orig_dtype != orig_dtype
                 or (fsdp_param.param_dtype or fsdp_param.orig_dtype) != input_dtype
-                or not isinstance(fsdp_param.sharded_param, DTensor)
+                or not self._can_swap_sharded_param(fsdp_param.sharded_param)
                 or hasattr(fsdp_param._sharded_local_tensor, "fsdp_pre_all_gather")
                 or hasattr(fsdp_param._sharded_local_tensor, "fsdp_post_all_gather")
             ):
@@ -362,6 +361,20 @@ class FSDPParamGroup:
                 return False
         self._flat_param_buffer_supported = True
         return True
+
+    @staticmethod
+    def _can_swap_sharded_param(sharded_param: nn.Parameter) -> bool:
+        # Preflight swap_tensors() for the entire group before rebasing any
+        # parameter. It rejects weakrefs/use counts, and swapping a fresh
+        # TensorImpl would not preserve existing autograd hook bindings.
+        return (
+            type(sharded_param) is DTensor
+            and not weakref.getweakrefs(sharded_param)
+            and sharded_param._use_count() == 1
+            and sharded_param.grad is None
+            and not getattr(sharded_param, "_backward_hooks", None)
+            and not getattr(sharded_param, "_post_accumulate_grad_hooks", None)
+        )
 
     def _is_flat_param_buffer_ready(self) -> bool:
         if compiled_autograd.compiled_autograd_enabled:
@@ -399,6 +412,23 @@ class FSDPParamGroup:
                 raise AssertionError("Invalid FSDP flat parameter buffer")
             expected_offset += expected_numel
 
+    @staticmethod
+    def _rebase_sharded_param(
+        fsdp_param: FSDPParam, sharded_local_tensor: torch.Tensor
+    ) -> None:
+        sharded_param = fsdp_param.sharded_param
+        if not isinstance(sharded_param, DTensor):
+            raise AssertionError(f"Expected DTensor, got {type(sharded_param)}")
+        new_sharded_param = nn.Parameter(
+            fsdp_param.to_sharded_dtensor(sharded_local_tensor),
+            requires_grad=sharded_param.requires_grad,
+        )
+        new_sharded_param.__dict__.update(sharded_param.__dict__)
+        # Swap the complete DTensor instead of only replacing _local_tensor so
+        # its outer TensorImpl has the same storage aliasing. FakeTensor relies
+        # on this consistency when tracing optimizers.
+        torch.utils.swap_tensors(sharded_param, new_sharded_param)
+
     def _init_flat_param_buffer(self) -> None:
         if self._is_flat_param_buffer_ready():
             return
@@ -427,14 +457,12 @@ class FSDPParamGroup:
             padded_local_tensor = flat_param_slice.view(
                 fsdp_param.padded_sharded_param_size
             )
-            sharded_param = fsdp_param.sharded_param
-            if not isinstance(sharded_param, DTensor):
-                raise AssertionError(f"Expected DTensor, got {type(sharded_param)}")
-            sharded_param._local_tensor = padded_local_tensor.narrow(
+            sharded_local_tensor = padded_local_tensor.narrow(
                 dim=shard_dim,
                 start=0,
                 length=local_shard_length,
             )
+            self._rebase_sharded_param(fsdp_param, sharded_local_tensor)
             offset += numel
 
         self._flat_param_buffer = flat_param_buffer


### PR DESCRIPTION
FSDP2 currently packs parameter shards into a contiguous communication buffer on every `foreach_all_gather`.

This PR places eligible sharded parameters in a single contiguous flat storage during lazy initialization. During all-gather copy-in, FSDP copies this flat buffer directly into the rank-local slice of the all-gather output.

This preserves the existing in-place all-gather contract while replacing per-parameter packing with a single contiguous copy. Under mixed precision, the same copy also performs the conversion from the original parameter dtype to `param_dtype`, avoiding a separate cast buffer.

The fast path:
- Checks and caches eligibility during lazy initialization.
- Preserves parameter object identity when rebasing DTensor storage, so existing optimizer references remain valid.
- Uses an O(1) readiness check in the all-gather path.
- Falls back to the existing path for CPU offload, meta parameters, non-uniform dtypes, FSDP pre/post-all-gather extensions, compiled autograd, and parameters that cannot be safely rebased.
- Preserves the existing in-place all-gather input/output aliasing.
- Does not change the existing copy-out path.

Per-all-gather local copy count:

| Configuration | Before | After |
|---|---:|---:|
| No mixed precision | 1 foreach copy | 1 contiguous copy |
| Mixed precision | 2 foreach copies | 1 contiguous cast copy |