### PR TITLE
Dispatch `index_put_` to `masked_fill_.Scalar` when possible

### DIFF
--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -338,6 +338,48 @@ inline c10::List<::std::optional<Tensor>> typeConvertIndices(
   return converted_inds;
 }
 
+inline std::tuple<bool, Tensor> canDispatchToMaskedFill(
+    const Tensor& self,
+    const torch::List<std::optional<at::Tensor>>& indices) {
+  int64_t num_ind = 0;
+  Tensor mask;
+  auto self_device = self.device();
+  for (const std::optional<Tensor>& i : indices) {
+    if (!i.has_value() || !(*i).defined()) {
+      if (!mask.defined()) {
+        num_ind++;
+      }
+    } else {
+      const Tensor& index = *i;
+      if ((index.scalar_type() != kByte && index.scalar_type() != kBool) ||
+          index.device() != self_device || mask.defined()) {
+        return std::make_tuple(false, Tensor());
+      } else {
+        mask = index;
+        for (const auto j : c10::irange(index.dim())) {
+          int64_t srcIdx = num_ind + j;
+          TORCH_CHECK_INDEX(
+              index.size(j) == self.size(srcIdx),
+              "The shape of the mask ",
+              index.sizes(),
+              " at index ",
+              j,
+              " does not match the shape of the indexed tensor ",
+              self.sizes(),
+              " at index ",
+              srcIdx);
+        }
+        num_ind += mask.ndimension();
+      }
+    }
+  }
+  for ([[maybe_unused]] const auto i :
+       c10::irange(num_ind, self.ndimension())) {
+    mask = mask.unsqueeze(-1);
+  }
+  return std::make_tuple(true, std::move(mask));
+}
+
 // NOTE: Why do we mirror instead of replace the `count_specified_dimensions`
 // function in torch/csrc/autograd/python_variable_indexing.cpp? It's because
 // `count_specified_dimensions` is on the hot path of Python tensor multi-dim
@@ -402,14 +444,11 @@ inline Tensor asTensor(const Tensor& value, const Tensor& target) {
 }
 inline Tensor asTensor(const Scalar& value, const Tensor& target) {
   at::AutoDispatchBelowADInplaceOrView guard;
-  at::Device target_device = target.device();
   // TODO: This qint special case looks very suspicious...
   if (isQIntType(target.scalar_type())) {
     return scalarToTensor(value, device(kCPU).dtype(kFloat), at::Device(kCPU));
-  } else if (target_device.is_cuda()) {
-    return scalarToTensor(value, target.options(), at::Device(kCPU));
   } else {
-    return scalarToTensor(value, target.options(), target_device);
+    return scalarToTensor(value, target.options(), target.device());
   }
 }
 
@@ -629,6 +668,23 @@ inline Tensor dispatch_index_put_(
       impl::typeConvertIndices(self, std::move(indices)), value);
 }
 
+inline bool try_dispatch_masked_fill_(
+    Tensor& self,
+    std::vector<Tensor> indices,
+    const Scalar& value) {
+  // Remove trailing null elements from indices
+  while (!indices.empty() && !indices.back().defined()) {
+    indices.pop_back();
+  }
+  auto list_indices = impl::typeConvertIndices(self, std::move(indices));
+  auto [can_dispatch, mask] = impl::canDispatchToMaskedFill(self, list_indices);
+  if (can_dispatch) {
+    self.masked_fill_(mask, value);
+    return true;
+  }
+  return false;
+}
+
 // NOTE [ Setting `disable_slice_optimization` when calling C++ tensor indexing
 // functions from Python ]
 //
@@ -787,6 +843,12 @@ inline void set_item(
   if (tensorIndices.empty()) {
     copy_to(sliced, value);
     return;
+  }
+
+  if constexpr (std::is_same_v<T, Scalar>) {
+    if (try_dispatch_masked_fill_(sliced, tensorIndices, value)) {
+      return;
+    }
   }
 
   Tensor valueTensor = asTensor(value, self);

--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -338,6 +338,48 @@ inline c10::List<::std::optional<Tensor>> typeConvertIndices(
   return converted_inds;
 }
 
+inline std::tuple<bool, Tensor> canDispatchToMaskedFill(
+    const Tensor& self,
+    const torch::List<std::optional<at::Tensor>>& indices) {
+  int64_t num_ind = 0;
+  Tensor mask;
+  auto self_device = self.device();
+  for (const std::optional<Tensor> i : indices) {
+    if (!i.has_value() || !(*i).defined()) {
+      if (!mask.defined()) {
+        num_ind++;
+      }
+    } else {
+      const Tensor& index = *i;
+      if ((index.scalar_type() != kByte && index.scalar_type() != kBool) ||
+          index.device() != self_device || mask.defined()) {
+        return std::make_tuple(false, Tensor());
+      } else {
+        mask = index;
+        for (const auto j : c10::irange(index.dim())) {
+          int64_t srcIdx = num_ind + j;
+          TORCH_CHECK_INDEX(
+              index.size(j) == self.size(srcIdx),
+              "The shape of the mask ",
+              index.sizes(),
+              " at index ",
+              j,
+              " does not match the shape of the indexed tensor ",
+              self.sizes(),
+              " at index ",
+              srcIdx);
+        }
+        num_ind += mask.ndimension();
+      }
+    }
+  }
+  for ([[maybe_unused]] const auto i :
+       c10::irange(num_ind, self.ndimension())) {
+    mask = mask.unsqueeze(-1);
+  }
+  return std::make_tuple(true, std::move(mask));
+}
+
 // NOTE: Why do we mirror instead of replace the `count_specified_dimensions`
 // function in torch/csrc/autograd/python_variable_indexing.cpp? It's because
 // `count_specified_dimensions` is on the hot path of Python tensor multi-dim
@@ -402,15 +444,12 @@ inline Tensor asTensor(const Tensor& value, const Tensor& target) {
 }
 inline Tensor asTensor(const Scalar& value, const Tensor& target) {
   at::AutoDispatchBelowADInplaceOrView guard;
-  at::Device target_device = target.device();
   // TODO: This qint special case looks very suspicious...
   if (isQIntType(target.scalar_type())) {
     return scalarToTensor(
         value, at::device(kCPU).dtype(kFloat), at::Device(kCPU));
-  } else if (target_device.is_cuda() || target_device.is_mps()) {
-    return scalarToTensor(value, target.options(), at::Device(kCPU));
   } else {
-    return scalarToTensor(value, target.options(), target_device);
+    return scalarToTensor(value, target.options(), target.device());
   }
 }
 
@@ -630,6 +669,23 @@ inline Tensor dispatch_index_put_(
       impl::typeConvertIndices(self, std::move(indices)), value);
 }
 
+inline bool try_dispatch_masked_fill_(
+    Tensor& self,
+    std::vector<Tensor> indices,
+    const Scalar& value) {
+  // Remove trailing null elements from indices
+  while (!indices.empty() && !indices.back().defined()) {
+    indices.pop_back();
+  }
+  auto list_indices = impl::typeConvertIndices(self, std::move(indices));
+  auto [can_dispatch, mask] = impl::canDispatchToMaskedFill(self, list_indices);
+  if (can_dispatch) {
+    self.masked_fill_(mask, value);
+    return true;
+  }
+  return false;
+}
+
 // NOTE [ Setting `disable_slice_optimization` when calling C++ tensor indexing
 // functions from Python ]
 //
@@ -788,6 +844,12 @@ inline void set_item(
   if (tensorIndices.empty()) {
     copy_to(sliced, value);
     return;
+  }
+
+  if constexpr (std::is_same_v<T, Scalar>) {
+    if (try_dispatch_masked_fill_(sliced, tensorIndices, value)) {
+      return;
+    }
   }
 
   Tensor valueTensor = asTensor(value, self);

--- a/aten/src/ATen/native/TensorAdvancedIndexingUtils.h
+++ b/aten/src/ATen/native/TensorAdvancedIndexingUtils.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <ATen/TensorIndexing.h>
 #include <ATen/core/Tensor.h>
 #include <ATen/native/IndexingUtils.h>
 #include <ATen/native/TensorIterator.h>
@@ -30,43 +31,7 @@ inline std::tuple<bool, Tensor> canDispatchToMaskedFill(
   if (!(value.numel() == 1 && value.device().is_cpu())) {
     return std::make_tuple(false, Tensor());
   }
-  int64_t num_ind = 0;
-  Tensor mask;
-  auto self_device = self.device();
-  for (const std::optional<Tensor>& i : indices) {
-    if (!i.has_value() || !(*i).defined()) {
-      if (!mask.defined()) {
-        num_ind++;
-      }
-    } else {
-      const Tensor& index = *i;
-      if ((index.scalar_type() != kByte && index.scalar_type() != kBool) ||
-          index.device() != self_device || mask.defined()) {
-        return std::make_tuple(false, Tensor());
-      } else {
-        mask = index;
-        for (const auto j : c10::irange(index.dim())) {
-          int64_t srcIdx = num_ind + j;
-          TORCH_CHECK_INDEX(
-              index.size(j) == self.size(srcIdx),
-              "The shape of the mask ",
-              index.sizes(),
-              " at index ",
-              j,
-              " does not match the shape of the indexed tensor ",
-              self.sizes(),
-              " at index ",
-              srcIdx);
-        }
-        num_ind += mask.ndimension();
-      }
-    }
-  }
-  for ([[maybe_unused]] const auto i :
-       c10::irange(num_ind, self.ndimension())) {
-    mask = mask.unsqueeze(-1);
-  }
-  return std::make_tuple(true, std::move(mask));
+  return at::indexing::impl::canDispatchToMaskedFill(self, indices);
 }
 
 inline AdvancedIndex make_info(Tensor self, IOptTensorListRef orig) {

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2701,6 +2701,36 @@ torch.cuda.synchronize()
     @unittest.skipIf(
         not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
     )
+    def test_graph_masked_fill_scalar_assignment(self):
+        x = torch.zeros(2, 2, device="cuda")
+        mask = torch.tensor([[True, False], [False, True]], device="cuda")
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g):
+            x[mask] = 5.0
+
+        x.zero_()  # Reset the side-effect of capture execution
+        g.replay()
+        expected = torch.tensor([[5.0, 0.0], [0.0, 5.0]], device="cuda")
+        self.assertEqual(x, expected)
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    def test_graph_advanced_index_scalar_assignment(self):
+        x = torch.zeros(2, 2, device="cuda")
+        indices = torch.tensor([0, 1], device="cuda")
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g):
+            x[indices, indices] = 5.0
+
+        x.zero_()  # Reset the side-effect of capture execution
+        g.replay()
+        expected = torch.tensor([[5.0, 0.0], [0.0, 5.0]], device="cuda")
+        self.assertEqual(x, expected)
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
     def test_graph_capture_stale_default_stream_error(self):
         """Default-stream warmup + side-stream capture raises a clear error
         (not an opaque CUDA crash) when override is not enabled."""

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2788,6 +2788,36 @@ torch.cuda.synchronize()
     @unittest.skipIf(
         not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
     )
+    def test_graph_masked_fill_scalar_assignment(self):
+        x = torch.zeros(2, 2, device="cuda")
+        mask = torch.tensor([[True, False], [False, True]], device="cuda")
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g):
+            x[mask] = 5.0
+
+        x.zero_()  # Reset the side-effect of capture execution
+        g.replay()
+        expected = torch.tensor([[5.0, 0.0], [0.0, 5.0]], device="cuda")
+        self.assertEqual(x, expected)
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    def test_graph_advanced_index_scalar_assignment(self):
+        x = torch.zeros(2, 2, device="cuda")
+        indices = torch.tensor([0, 1], device="cuda")
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g):
+            x[indices, indices] = 5.0
+
+        x.zero_()  # Reset the side-effect of capture execution
+        g.replay()
+        expected = torch.tensor([[5.0, 0.0], [0.0, 5.0]], device="cuda")
+        self.assertEqual(x, expected)
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
     def test_graph_capture_stale_default_stream_error(self):
         """Default-stream warmup + side-stream capture raises a clear error
         (not an opaque CUDA crash) when override is not enabled."""

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2067,6 +2067,7 @@ class TestTorchDeviceType(TestCase):
         expect_no_sync = (lambda: _ind_put_fn(x, mask, 1.),
                           lambda: _ind_put_fn(x, mask_cpu, y),
                           lambda: _ind_put_fn(x, ind, y),
+                          lambda: _ind_put_fn(x, ind, 1.),
                           lambda: _ind_put_fn(x, 0, 5.),
                           lambda: _ind_put_fn(x, slice(0, 1), 5.),
                           lambda: _ind_get_fn(x, mask_cpu),

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2125,6 +2125,7 @@ class TestTorchDeviceType(TestCase):
         expect_no_sync = (lambda: _ind_put_fn(x, mask, 1.),
                           lambda: _ind_put_fn(x, mask_cpu, y),
                           lambda: _ind_put_fn(x, ind, y),
+                          lambda: _ind_put_fn(x, ind, 1.),
                           lambda: _ind_put_fn(x, 0, 5.),
                           lambda: _ind_put_fn(x, slice(0, 1), 5.),
                           lambda: _ind_get_fn(x, mask_cpu),

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -595,6 +595,12 @@ static int THPVariable_setitem_impl(
 
   {
     pybind11::gil_scoped_release no_gil;
+    if constexpr (std::is_same_v<T, Scalar>) {
+      if (at::indexing::try_dispatch_masked_fill_(
+              sliced, variableIndices, value)) {
+        return 0;
+      }
+    }
     Tensor valueTensor = asTensor(value, self_);
     SymIntArrayRef valueSizes = valueTensor.sym_sizes();
     SymIntArrayRef slicedValueSizes =


### PR DESCRIPTION
This is a followup on #188267 and #61612 and tries to dispatch `index_put_` to `masked_fill_.Scalar` where possible - e.g. `gpu_tensor[mask] = 1.0` - instead of converting the scalar to a CPU tensor first.

While this prevents an unnecessary CPU tensor, it has the main advantage that we don't need any special handling for `scalarToTensor` anymore. Instead, we can directly convert scalars to a GPU tensor, so that advanced indexing - e.g. `gpu_tensor[indices] = 1.0`, which can't be dispatched to `masked_fill_` - won't cause a CPU-GPU sync anymore.

/cc @eqy @ngimel 