### PR TITLE
[TEST] Refactor test_profiler_tree.py with hw_classification

### DIFF
--- a/test/profiler/test_profiler_tree.py
+++ b/test/profiler/test_profiler_tree.py
@@ -12,6 +12,7 @@ import expecttest
 import torch
 from torch._C._profiler import _ExtraFields_PyCall, _ExtraFields_PyCCall
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_ARM64,
     IS_WINDOWS,
     run_tests,
@@ -231,8 +232,7 @@ class ProfilerTree:
                     raise AssertionError(f"{parent_name} vs. {caller_name}")
 
 
-@unittest.skipIf(IS_ARM64, "Not working on ARM")
-class TestProfilerTree(TestCase):
+class ProfilerTreeTestMixin:
     def assertTreesMatch(self, actual: str, expected: str, allow_failure: bool = False):
         # Warning: Here be dragons
         #   Different platforms will have subtly different behavior for Python
@@ -274,6 +274,11 @@ class TestProfilerTree(TestCase):
                     print(msg.split("AssertionError:")[-1])
                 else:
                     raise
+
+
+@unittest.skipIf(IS_ARM64, "Not working on ARM")
+class TestProfilerTree(ProfilerTreeTestMixin, TestCase):
+    hw_classification = HardwareClassification.GENERIC
 
     # TODO: Add logic for CUDA version of test
     @ProfilerTree.test
@@ -786,6 +791,11 @@ class TestProfilerTree(TestCase):
                 torch/profiler/profiler.py(...): stop
                   ...""",
         )
+
+
+@unittest.skipIf(IS_ARM64, "Not working on ARM")
+class TestProfilerTreeCUDA(ProfilerTreeTestMixin, TestCase):
+    hw_classification = HardwareClassification.CUDA
 
     @unittest.skip("https://github.com/pytorch/pytorch/issues/83606")
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")


### PR DESCRIPTION
Extract duplicated assertTreesMatch helper into a
ProfilerTreeTestMixin shared by both test classes, and add hw_classification attributes: GENERIC for TestProfilerTree, CUDA for TestProfilerTreeCUDA.

Test Cases:
Before and after:
10 tests collected.
3 passed, 7 skipped.