### PR TITLE
Handle negative integer exponents in SymPy utilities

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -17967,6 +17967,77 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         compiled = torch.compile(fn, backend="inductor", dynamic=True)(a, b)
         self.assertEqual(eager, compiled)
 
+    def test_dynamic_negative_exponent_convolution_regression(self):
+        # Regression test for #188323.
+        # This pattern triggers SymPy generation of Pow(..., -1) during
+        # dynamic shape analysis in convolution lowering.
+        def fn(output, target, act, skip, w_first, w_g2, w1, w2, w3):
+            batch_size = output.size(0)
+
+            _, predicted = torch.topk(output, 1, dim=1)
+            correct = torch.eq(
+                predicted.t(),
+                target.view(1, -1).expand_as(predicted.t()),
+            )
+            scalar = (
+                correct[:1]
+                .contiguous()
+                .view(-1)
+                .float()
+                .sum(dim=0, keepdim=True)
+                .mul(100.0 / batch_size)
+            )
+
+            feature = torch.cat([act, skip], dim=1)
+            feature = F.conv2d(feature, w_first, padding=1)
+            feature = F.leaky_relu(feature, 0.1)
+
+            pointwise = F.relu(scalar - feature) + feature
+
+            hidden = F.leaky_relu(F.conv2d(pointwise, w_g2), 0.2)
+
+            out = F.conv2d(hidden, w1)
+            out = F.conv2d(out, w2, padding=1)
+            out = F.conv2d(out, w3)
+            out = out + hidden
+
+            return out
+
+        output = torch.randn(8, 10)
+        target = torch.zeros(8, dtype=torch.int64)
+
+        act = torch.randn(2, 3, 8, 8)
+        skip = torch.randn(2, 3, 8, 8)
+
+        w_first = torch.randn(3, 6, 3, 3)
+        w_g2 = torch.randn(16, 3, 1, 1)
+
+        w1 = torch.randn(4, 16, 1, 1)
+        w2 = torch.randn(4, 4, 3, 3)
+        w3 = torch.randn(16, 4, 1, 1)
+
+        eager = fn(output, target, act, skip, w_first, w_g2, w1, w2, w3)
+
+        compiled = torch.compile(
+            fn,
+            backend="inductor",
+            dynamic=True,
+        )
+
+        result = compiled(
+            output,
+            target,
+            act,
+            skip,
+            w_first,
+            w_g2,
+            w1,
+            w2,
+            w3,
+        )
+
+        self.assertEqual(eager, result)
+
     def test_cpu_scalar_with_cpu_tensor(self):
         def fn(a, b):
             return a + b[0]

--- a/test/test_sympy_utils.py
+++ b/test/test_sympy_utils.py
@@ -33,7 +33,7 @@ from torch.utils._sympy.functions import (
 )
 from torch.utils._sympy.interp import sympy_interp
 from torch.utils._sympy.numbers import int_oo, IntInfinity, NegativeIntInfinity
-from torch.utils._sympy.printers import CppPrinter
+from torch.utils._sympy.printers import CppPrinter, ExprPrinter
 from torch.utils._sympy.reference import (
     PythonReferenceAnalysis,
     ReferenceAnalysis,
@@ -257,6 +257,18 @@ class TestCppPrinter(TestCase):
         printed = CppPrinter().doprint(TorchSymMax(sympy.Integer(4), s0))
         self.assertIn("std::max", printed)
         self.assertIn("static_cast<int64_t>", printed)
+
+
+class TestExprPrinter(TestCase):
+    def test_negative_integer_pow(self):
+        x = sympy.Symbol("x", integer=True)
+        printer = ExprPrinter()
+
+        self.assertEqual(printer.doprint(x**-1), "1/x")
+        self.assertEqual(printer.doprint(x**-2), "1/(x*x)")
+        self.assertEqual(printer.doprint(x**-3), "1/(x*x*x)")
+        self.assertEqual(printer.doprint(x**0), "1")
+        self.assertEqual(printer.doprint(x**2), "x*x")
 
 
 class TestValueRanges(TestCase):
@@ -504,6 +516,17 @@ class TestValueRanges(TestCase):
 
 
 class TestSympyInterp(TestCase):
+    def test_negative_integer_pow_uses_float_pow(self):
+        x = sympy.Symbol("x")
+
+        result = sympy_interp(
+            ValueRangeAnalysis,
+            {x: ValueRanges.wrap(2)},
+            x**-1,
+        )
+
+        self.assertEqual(result, ValueRanges.unknown())
+
     @parametrize(
         "fn", UNARY_OPS + BINARY_OPS + UNARY_BOOL_OPS + BINARY_BOOL_OPS + COMPARE_OPS
     )

--- a/torch/utils/_sympy/interp.py
+++ b/torch/utils/_sympy/interp.py
@@ -128,6 +128,19 @@ def _run_sympy_handler(analysis, args, expr, index_dtype=torch.int64):
         expr.args[1], sympy.core.numbers.Half
     ):
         return analysis.sqrt(args[0])
+    # sympy.Pow is mapped to pow_by_natural (which only handles non-negative
+    # integer exponents), but SymPy can produce Pow(x, -n) for negative
+    # integer n — e.g. 1/x is represented as Pow(x, -1) — when simplifying
+    # expressions like stride-divisibility checks.  Route negative-integer
+    # exponents to pow() instead; for ValueRangeAnalysis that conservatively
+    # returns ValueRanges.unknown(), which is correct: the range of 1/x is
+    # not representable as an integer range.
+    if (
+        isinstance(expr, sympy.Pow)
+        and isinstance(expr.args[1], sympy.Integer)
+        and expr.args[1] < 0
+    ):
+        return analysis.pow(args[0], args[1])
     if isinstance(expr, ToFloat):
         return analysis.to_dtype(args[0], torch.float64)
 

--- a/torch/utils/_sympy/printers.py
+++ b/torch/utils/_sympy/printers.py
@@ -76,11 +76,16 @@ class ExprPrinter(StrPrinter):
         if exp != int(exp):
             raise AssertionError(exp)
         exp = int(exp)
-        if exp < 0:
-            raise AssertionError(f"exponent must be non-negative, got {exp}")
         if exp > 0:
             return self.stringify([base] * exp, "*", PRECEDENCE["Mul"])
-        return "1"
+        elif exp < -1:
+            return (
+                "1/(" + self.stringify([base] * abs(exp), "*", PRECEDENCE["Mul"]) + ")"
+            )
+        elif exp == -1:
+            return "1/" + self.parenthesize(base, PRECEDENCE["Mul"])
+        else:
+            return "1"
 
     # Explicit NotImplemented functions are to prevent default sympy printing
     # behavior, which will just barf out ToFloat(...) to your IR.  The error


### PR DESCRIPTION
Fixes #188323

## Summary

Fix handling of negative integer exponents in SymPy utilities.

SymPy can represent expressions such as `1/x` as `Pow(x, -1)`. However,
`sympy.Pow` is currently dispatched to `pow_by_natural`, which assumes a
non-negative integer exponent. This could trigger assertions when symbolic
expressions containing negative integer powers are encountered during dynamic
shape analysis.

This change:
- routes `sympy.Pow` with negative integer exponents to `analysis.pow()`
  instead of `pow_by_natural()`
- extends `ExprPrinter` to support printing negative integer powers, matching
  the existing behavior of `CppPrinter`
- adds regression tests covering both changes

## Testing

Added regression tests for:
- negative integer exponent dispatch in `sympy_interp`
- printing negative integer powers in `ExprPrinter`

Passed:

```bash
python repro.py
python test/test_sympy_utils.py
python test/test_dynamic_shapes.py -k "pow"
python test/test_dynamic_shapes.py -k "constraint"
python test/inductor/test_unbacked_symints.py
python test/inductor/test_torchinductor.py -k "dynamic"
python test/inductor/test_torchinductor.py -k "channels_last"

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo