### PR TITLE
Fix avg_pool2d CUDA backward for channels_last inputs with padding

### DIFF
--- a/aten/src/ATen/native/cuda/AveragePool2d.cu
+++ b/aten/src/ATen/native/cuda/AveragePool2d.cu
@@ -194,8 +194,8 @@ __global__ void avg_pool2d_backward_out_cuda_frame_nhwc(const index_t nthreads,
     bool count_include_pad, bool use_divisor) {
   CUDA_KERNEL_LOOP_TYPE(index, nthreads, index_t) {
     const int c = index % channels;
-    const int w = (index / channels) % width;
-    const int h = (index / channels / width) % height;
+    const int w = (index / channels) % width + pad_w;
+    const int h = (index / channels / width) % height + pad_h;
     const int n = index / channels / width / height;
 
     const int phstart = (h < kernel_h) ? 0 : (h - kernel_h) / stride_h + 1;

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -1141,7 +1141,7 @@ torch.cuda.synchronize()
             torch.cuda.empty_cache()
         helper(200, 512, 28, 28, 2)
         helper(4, 8, 7, 7, 3, stride=1)
-        helper(4, 8, 7, 7, 3, padding=2, stride=1)
+        helper(4, 8, 7, 7, 5, padding=2, stride=1)
         helper(10, 512, 31, 31, 3, stride=2)
         helper(1, 129, 8, 8, 3, stride=2)
 

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -1097,14 +1097,15 @@ torch.cuda.synchronize()
             grad = torch.randn(
                 n,
                 c,
-                (h - kernel_size) // stride + 1,
-                (w - kernel_size) // stride + 1,
+                (h + 2 * padding - kernel_size) // stride + 1,
+                (w + 2 * padding - kernel_size) // stride + 1,
                 dtype=dtype,
                 device=device,
             )
             pool = torch.nn.AvgPool2d(
                 kernel_size,
                 stride=stride,
+                padding=padding,
                 count_include_pad=count_include_pad,
                 divisor_override=divisor_override,
             ).to(device)
@@ -1114,6 +1115,7 @@ torch.cuda.synchronize()
             ref_pool = torch.nn.AvgPool2d(
                 kernel_size,
                 stride=stride,
+                padding=padding,
                 count_include_pad=count_include_pad,
                 divisor_override=divisor_override,
             ).to(device)
@@ -1130,7 +1132,8 @@ torch.cuda.synchronize()
 
         helper(4, 8, 8, 8, 3)
         helper(4, 8, 8, 8, 3, count_include_pad=False, padding=1)
-        helper(4, 8, 8, 8, 3, count_include_pad=False, padding=2, stride=2)
+        helper(4, 8, 8, 8, 5, count_include_pad=False, padding=2, stride=2)
+        helper(4, 8, 8, 8, 3, padding=1)
         helper(4, 8, 8, 8, 3, divisor_override=42)
         helper(4, 8, 8, 8, 7)
         # ROCm 16GB MI25 hits OOM error. Clear caching allocator prior to running large subtest.

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -4185,17 +4185,7 @@ module_db: list[ModuleInfo] = [
                ),
     ModuleInfo(torch.nn.AvgPool2d,
                module_inputs_func=module_inputs_torch_nn_AvgPool2d,
-               skips=(
-                   # The difference between channels last backward and
-                   # channels first backward of AvgPool2d on CUDA is too large
-                   # See https://github.com/pytorch/pytorch/issues/107201
-                   DecorateInfo(
-                       unittest.expectedFailure,
-                       'TestModule',
-                       'test_memory_format',
-                       active_if=operator.itemgetter('training'),
-                       device_type='cuda',),
-               ),),
+               ),
     ModuleInfo(torch.nn.AvgPool3d,
                module_inputs_func=module_inputs_torch_nn_AvgPool3d,
                gradcheck_nondet_tol=GRADCHECK_NONDET_TOL,


### PR DESCRIPTION

## Issue

Fixes #188344

## Summary

The channels_last (NHWC) CUDA backward kernel `avg_pool2d_backward_out_cuda_frame_nhwc` recovered the input pixel coordinates from the flat index without the padding offset (`const int w = (index / channels) % width;`), while the `phstart/phend/pwstart/pwend` window formulas it then uses require padded coordinates. The contiguous (NCHW) kernel `avg_pool2d_backward_out_cuda_frame` adds the offset (`+ pad_w` / `+ pad_h`); the NHWC kernel did not, so for `padding > 0` it mapped each input pixel to the wrong set of output windows and returned silently wrong input gradients. `padding = 0` was unaffected because the two coordinate systems coincide. This adds the missing `+ pad_w` / `+ pad_h`, matching the NCHW kernel.

`test_avg_pool2d_nhwc` did not catch this because its `helper` accepted a `padding` argument but never forwarded it to `AvgPool2d` (nor into the grad-output shape), so its `padding=1` / `padding=2` cases actually ran with `padding=0`. This PR forwards `padding` so those cases exercise the path, fixes the one call whose `padding=2, kernel_size=3` combination is invalid once padding is applied (`pad` must be `<= kernel_size / 2`), and adds a `count_include_pad=True` padded case. The repaired test fails on the current kernel and passes with the fix.

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No. This corrects silently-wrong gradients; only incorrect outputs change.
