### PR TITLE
Preserve tied parameter and buffer aliasing in load_state_dict(assign=True)

### DIFF
--- a/test/nn/test_load_state_dict.py
+++ b/test/nn/test_load_state_dict.py
@@ -284,6 +284,45 @@ class TestLoadStateDict(NNTestCase):
         self.assertEqual(mm[0].param[0].item(), 10)
         self.assertEqual(mm[0].sub.weight[0, 0].item(), 555)
 
+    def test_load_state_dict_assign_preserves_tied_buffers(self):
+        class MyModule(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                buffer = torch.ones(1)
+                self.register_buffer("buffer1", buffer)
+                self.register_buffer("buffer2", buffer)
+
+        source = MyModule()
+        target = MyModule()
+        self.assertIs(target.buffer1, target.buffer2)
+
+        target.load_state_dict(source.state_dict(), assign=True)
+        self.assertIs(target.buffer1, target.buffer2)
+        self.assertEqual([name for name, _ in target.named_buffers()], ["buffer1"])
+
+    def test_load_state_dict_assign_preserves_tied_parameters_across_submodules(self):
+        class Sub(torch.nn.Module):
+            def __init__(self, weight) -> None:
+                super().__init__()
+                self.weight = weight
+
+        class MyModule(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                weight = nn.Parameter(torch.ones(2, 2))
+                self.embed = Sub(weight)
+                self.proj = Sub(weight)
+
+        source = MyModule()
+        target = MyModule()
+        self.assertIs(target.embed.weight, target.proj.weight)
+
+        target.load_state_dict(source.state_dict(), assign=True)
+        self.assertIs(target.embed.weight, target.proj.weight)
+        self.assertEqual(
+            [name for name, _ in target.named_parameters()], ["embed.weight"]
+        )
+
     @swap([True, False])
     @parametrize("keep_vars", [True, False])
     def test_load_state_dict_assign_meta(self, keep_vars):

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -2615,8 +2615,31 @@ class Module:
                         "it should be done inplace."
                     )
 
+        # Assign mode reassigns each name its own object, breaking aliasing
+        # between names that shared one tied parameter or buffer. Record the
+        # tied groups here and restore them after the load below.
+        tied_names: list[list[str]] = []
+        if assign:
+            grouped: dict[int, list[str]] = {}
+            for tensor_name, tensor in itertools.chain(
+                self.named_parameters(remove_duplicate=False),
+                self.named_buffers(remove_duplicate=False),
+            ):
+                if tensor_name in state_dict:
+                    grouped.setdefault(id(tensor), []).append(tensor_name)
+            tied_names = [names for names in grouped.values() if len(names) > 1]
+
         load(self, state_dict)
         del load
+
+        for names in tied_names:
+            module_path, _, attr = names[0].rpartition(".")
+            submodule = self.get_submodule(module_path) if module_path else self
+            canonical = getattr(submodule, attr)
+            for name in names[1:]:
+                module_path, _, attr = name.rpartition(".")
+                submodule = self.get_submodule(module_path) if module_path else self
+                setattr(submodule, attr, canonical)
 
         if strict:
             if len(unexpected_keys) > 0:


### PR DESCRIPTION
## Issue

Fixes #188346

## Summary

See the linked issue for the bug and repro. In assign mode each name is reassigned its own object via `setattr`, so names sharing one tied `Parameter`/buffer become distinct objects (copy mode preserves tying by copying in place), and `_load_from_state_dict` runs per module so it cannot see cross-submodule tying. This records the tied name groups in `load_state_dict` before the load and re-points each group's later names to the first name's loaded object afterwards, restoring tying within a module and across submodules. Copy mode and the per-parameter assign loop are untouched.

<details>
<summary>Reproduction and before/after (CPU)</summary>

```python
import torch
import torch.nn as nn

class Sub(nn.Module):
    def __init__(self, weight):
        super().__init__()
        self.weight = weight

class Model(nn.Module):
    def __init__(self):
        super().__init__()
        w = nn.Parameter(torch.ones(2, 2))
        self.embed = Sub(w)
        self.proj = Sub(w)

src, dst = Model(), Model()
dst.load_state_dict(src.state_dict(), assign=True)
print(dst.embed.weight is dst.proj.weight)
print([n for n, _ in dst.named_parameters()])
```

Before this change:

```
False
['embed.weight', 'proj.weight']
```

After this change:

```
True
['embed.weight']
```

Regression tests cover tied buffers within a module and tied parameters across submodules. They fail on the unpatched module and pass with the fix; the full `test/nn/test_load_state_dict.py` suite (31 tests) passes.

</details>

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [ ] Updated documentation (not applicable)
- [ ] Included benchmark results (not perf-related)

## BC-breaking?

No. The only observable change is that an assign-mode load of a module with tied parameters or buffers keeps them tied (a single entry in `named_parameters()` / `named_buffers()` / `state_dict()`), restoring the copy-mode and pre-load behavior instead of silently splitting them into independent objects.

cc @mikaylagawarecki
