### PR TITLE
Fix Dynamo stream/event variable python_type

### DIFF
--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -42,6 +42,27 @@ class TestStreams(torch._dynamo.test_case.TestCase):
     def tearDownClass(cls):
         super().tearDownClass()
 
+    def test_stream_event_variable_python_type_uses_wrapped_value_type(self):
+        from torch._dynamo.variables.streams import EventVariable, StreamVariable
+
+        class FakeStream:
+            device = torch.device("cpu")
+
+        class FakeEvent:
+            pass
+
+        stream = FakeStream()
+        event = FakeEvent()
+
+        self.assertIs(
+            StreamVariable(None, stream).python_type(),  # type: ignore[arg-type]
+            FakeStream,
+        )
+        self.assertIs(
+            EventVariable(None, event, None).python_type(),  # type: ignore[arg-type]
+            FakeEvent,
+        )
+
     @requires_cuda
     def test_stream_weakref(self):
         s = torch.Stream()

--- a/torch/_dynamo/variables/streams.py
+++ b/torch/_dynamo/variables/streams.py
@@ -400,7 +400,7 @@ class StreamVariable(StreamContextVariable):
         super().__init__(None, **kwargs)
 
     def python_type(self) -> type:
-        return self._cpython_type
+        return type(self.value)
 
     def var_getattr(
         self, tx: "InstructionTranslatorBase", name: str
@@ -633,7 +633,7 @@ class EventVariable(VariableTracker):
         return object_richcompare(self, tx, other, op)
 
     def python_type(self) -> type:
-        return torch.Event
+        return type(self.value)
 
     def get_real_python_backed_value(self) -> object:
         return self.value


### PR DESCRIPTION
Fixes #188325.

## Summary
- Make `StreamVariable.python_type()` and `EventVariable.python_type()` report the wrapped runtime value type instead of hard-coded base classes.
- Add a CUDA-free regression covering both wrappers with fake stream/event objects.

## Why
`SuperVariable` and other type/MRO-based Dynamo paths rely on `python_type()` matching the actual wrapped object. Returning `torch.Event` or the class-level stream type can make a valid wrapped CUDA/XPU object look unrelated to the requested super type and surface downstream as MRO/super resolution errors.

## Validation
- `python3.12 -m py_compile torch/_dynamo/variables/streams.py test/dynamo/test_streams.py`
- `git diff --check`

I could not run the targeted Dynamo test in this local checkout: `PYTHONPATH=. python3.12 test/dynamo/test_streams.py -k test_stream_event_variable_python_type_uses_wrapped_value_type` stops at missing `typing_extensions`, and both available Homebrew pip installs fail before installing packages due a local `pyexpat`/libexpat symbol mismatch. System Python 3.9 is too old for this checkout (`typing.TypeAlias`).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98