### PR TITLE
Remove stale xfailIfSM100OrLater on test_divisible_by_16_covers_numel…

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -82,7 +82,6 @@ from torch.testing._internal.common_cuda import (
     TEST_CUDNN,
     tf32_on_and_off,
     with_tf32_off,
-    xfailIfSM100OrLater,
 )
 from torch.testing._internal.common_device_type import (
     expectedFailureXPU,
@@ -18818,10 +18817,6 @@ if RUN_GPU:
 
             return kernels
 
-        # On Blackwell+, #179729 raised the split-reduction no-split threshold to 524288,
-        # so the 256*256=65536-element reduction below no longer splits and produces 1 kernel
-        # instead of the expected 2.
-        @xfailIfSM100OrLater
         def test_divisible_by_16_covers_numel_args(self):
             torch._dynamo.reset()
 


### PR DESCRIPTION
…_args

#181635 fixed this test for Blackwell by adding an `elif SM100OrLater` branch asserting 1 kernel (matching the raised threshold from #179729), but left the @xfailIfSM100OrLater from the earlier #181639 workaround in place. The test now passes on B200, so the decorator reports an "unexpected success" and reds the B200 smoke tests. Remove the decorator and its unused import; the SM100OrLater branch is the source of truth.

Test Plan:
```
lintrunner -a test/inductor/test_torchinductor.py  # ok No lint issues.
```

Authored-with: Claude (Anthropic AI assistant)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo