### PR TITLE
[ROCm] Add MIOpen convolution ops to FORBIDDEN_CUDAGRAPH_OPS for cudagraph safety

### DIFF
--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -1433,6 +1433,50 @@ if HAS_CUDA_AND_TRITON:
                     "incompatible op aten.topk.default"
                 ).run(log_stream.getvalue())
 
+        # Pin graph_partition=False so the "disabling cudagraphs due to
+        # incompatible op ..." log line is actually emitted. With
+        # graph_partition=True (OSS default), incompatible ops are handled
+        # by partitioning rather than disabling cudagraphs, and the FileCheck
+        # pattern below never appears.
+        @torch._inductor.config.patch("graph_partition", False)
+        def test_conv_transpose1d_skips_cudagraph_on_hip(self):
+            # rocm workaround: MIOpen convolution kernels are not cudagraph-safe.
+            # See https://github.com/pytorch/pytorch/issues/188338
+            IN_CHANNELS = 4
+            OUT_CHANNELS = 8
+            KERNEL_SIZE = 3
+            STRIDE = 2
+
+            @torch.no_grad()
+            def f(x, weight):
+                return torch.nn.functional.conv_transpose1d(
+                    x, weight, stride=STRIDE
+                )
+
+            compiled = torch.compile(f, fullgraph=True, mode="reduce-overhead")
+
+            log_stream, ctx = logs_to_string(
+                "torch._inductor.cudagraph_utils", "cudagraphs"
+            )
+            with ctx():
+                for _ in range(3):
+                    torch.compiler.cudagraph_mark_step_begin()
+                    x = torch.randn(
+                        2, IN_CHANNELS, 16, device="cuda", dtype=torch.float32
+                    )
+                    weight = torch.randn(
+                        IN_CHANNELS, OUT_CHANNELS // 1, KERNEL_SIZE,
+                        device="cuda", dtype=torch.float32
+                    )
+                    compiled(x, weight)
+                    torch.cuda.synchronize()
+
+            if torch.version.hip is not None:
+                FileCheck().check(
+                    "skipping cudagraphs due to disabling cudagraphs due to "
+                    "incompatible op aten.convolution.default"
+                ).run(log_stream.getvalue())
+
         @torch._inductor.config.patch("graph_partition", True)
         @torch._inductor.config.patch("implicit_fallbacks", True)
         def test_graph_partition_with_memory_plan_reuse(self):

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1324,6 +1324,17 @@ FORBIDDEN_CUDAGRAPH_OPS = frozenset(
         # on the 2nd replay of a recorded graph.
         [
             "aten.topk.default",
+            # rocm workaround: MIOpen convolution kernels are not cudagraph-safe.
+            # See https://rocm.docs.amd.com/en/latest/reference/graph-safe-support.html
+            # and https://github.com/pytorch/pytorch/issues/188338
+            # aten.convolution routes through MIOpen on ROCm when the ATEN
+            # fallback is used (e.g. transposed convs with no Triton template).
+            "aten.convolution.default",
+            "aten.convolution_backward.default",
+            # Direct MIOpen ops in case they appear in FX graphs.
+            "aten.miopen_convolution.default",
+            "aten.miopen_convolution_transpose.default",
+            "aten.miopen_depthwise_convolution.default",
         ]
         if torch.version.hip is not None
         else []


### PR DESCRIPTION
## Summary

MIOpen convolution kernels are not cudagraph-safe on ROCm (see AMD documentation: https://rocm.docs.amd.com/en/latest/reference/graph-safe-support.html). When aten.convolution routes through MIOpen (e.g. transposed convs with no Triton template), it causes faults during CUDA graph replay.

This adds the following ops to FORBIDDEN_CUDAGRAPH_OPS under the existing torch.version.hip conditional, following the same pattern as the aten.topk.default ROCm workaround:

- aten.convolution.default
- aten.convolution_backward.default
- aten.miopen_convolution.default
- aten.miopen_convolution_transpose.default
- aten.miopen_depthwise_convolution.default

## Test

Added test_conv_transpose1d_skips_cudagraph_on_hip mirroring test_topk_skips_cudagraph_on_hip, verifying that F.conv_transpose1d triggers cudagraph disable on ROCm.

Fixes #188338

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @mcarilli @ezyang @eellison