### PR TITLE
[MPS] Fix incorrect conv2d output for kernel size >= 256

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Convolution.h
+++ b/aten/src/ATen/native/mps/kernels/Convolution.h
@@ -1,0 +1,23 @@
+#pragma once
+#include <c10/metal/common.h>
+
+struct Conv2DParams {
+  int32_t N;
+  int32_t C_in;
+  int32_t C_out;
+  int32_t H;
+  int32_t W;
+  int32_t outH;
+  int32_t outW;
+  int32_t kH;
+  int32_t kW;
+  int32_t sH;
+  int32_t sW;
+  int32_t padH;
+  int32_t padW;
+  int32_t dH;
+  int32_t dW;
+  int32_t C_in_per_group;
+  int32_t C_out_per_group;
+  bool has_bias;
+};

--- a/aten/src/ATen/native/mps/kernels/Convolution.metal
+++ b/aten/src/ATen/native/mps/kernels/Convolution.metal
@@ -1,0 +1,96 @@
+#include <ATen/native/mps/kernels/Convolution.h>
+#include <c10/metal/utils.h>
+#include <metal_stdlib>
+
+using namespace metal;
+
+// Direct NCHW conv fallback for filter dims >= 256 (MPSGraph miscomputes); each
+// thread does R consecutive ow outputs. I is int when all numels fit in int32.
+template <typename T, typename I, int R>
+kernel void conv2d(
+    constant T* input [[buffer(0)]],
+    constant T* weight [[buffer(1)]],
+    constant T* bias [[buffer(2)]],
+    device T* output [[buffer(3)]],
+    constant Conv2DParams& p [[buffer(4)]],
+    uint tid [[thread_position_in_grid]]) {
+  using acc_t = ::c10::metal::accum_t<T>;
+
+  const uint owBlocks = (uint(p.outW) + R - 1) / R;
+  uint rem = tid;
+  const int ow0 = int(rem % owBlocks) * R;
+  rem /= owBlocks;
+  const int oh = int(rem % uint(p.outH));
+  rem /= uint(p.outH);
+  const int co = int(rem % uint(p.C_out));
+  const int n = int(rem / uint(p.C_out));
+
+  const int cin_base = (co / p.C_out_per_group) * p.C_in_per_group;
+  const int ih0 = oh * p.sH - p.padH;
+  const int iw_base = ow0 * p.sW - p.padW;
+  // Full unit-stride block: loads need no per-lane bounds checks and merge.
+  const bool full = (ow0 + R <= p.outW) && (p.sW == 1);
+
+  const acc_t b = p.has_bias ? static_cast<acc_t>(bias[co]) : acc_t(0);
+  acc_t acc[R];
+  for (int r = 0; r < R; ++r) {
+    acc[r] = b;
+  }
+
+  const I in_n_off = static_cast<I>(n) * p.C_in * p.H * p.W;
+  const I w_co_off = static_cast<I>(co) * p.C_in_per_group * p.kH * p.kW;
+  for (int ci = 0; ci < p.C_in_per_group; ++ci) {
+    const I in_c_off = in_n_off + static_cast<I>(cin_base + ci) * p.H * p.W;
+    const I w_c_off = w_co_off + static_cast<I>(ci) * p.kH * p.kW;
+    for (int kh = 0; kh < p.kH; ++kh) {
+      const int ih = ih0 + kh * p.dH;
+      if (ih < 0 || ih >= p.H) {
+        continue;
+      }
+      const I in_row = in_c_off + static_cast<I>(ih) * p.W;
+      const I w_row = w_c_off + static_cast<I>(kh) * p.kW;
+      for (int kw = 0; kw < p.kW; ++kw) {
+        const int iw = iw_base + kw * p.dW;
+        const acc_t wv = static_cast<acc_t>(weight[w_row + kw]);
+        if (full && iw >= 0 && iw + R <= p.W) {
+          for (int r = 0; r < R; ++r) {
+            acc[r] += static_cast<acc_t>(input[in_row + iw + r]) * wv;
+          }
+        } else {
+          for (int r = 0; r < R; ++r) {
+            const int iwr = iw + r * p.sW;
+            if (ow0 + r < p.outW && iwr >= 0 && iwr < p.W) {
+              acc[r] += static_cast<acc_t>(input[in_row + iwr]) * wv;
+            }
+          }
+        }
+      }
+    }
+  }
+  const I out_row = ((static_cast<I>(n) * p.C_out + co) * p.outH + oh) * p.outW;
+  for (int r = 0; r < R; ++r) {
+    if (ow0 + r < p.outW) {
+      output[out_row + ow0 + r] = static_cast<T>(acc[r]);
+    }
+  }
+}
+
+#define REGISTER_CONV2D_OP(DTYPE, ITYPE, INAME, R)                    \
+  template [[host_name("conv2d_r" #R "_" INAME "_" #DTYPE)]] kernel void \
+  conv2d<DTYPE, ITYPE, R>(                                            \
+      constant DTYPE * input [[buffer(0)]],                           \
+      constant DTYPE * weight [[buffer(1)]],                          \
+      constant DTYPE * bias [[buffer(2)]],                            \
+      device DTYPE * output [[buffer(3)]],                            \
+      constant Conv2DParams & p [[buffer(4)]],                        \
+      uint tid [[thread_position_in_grid]]);
+
+#define REGISTER_CONV2D_DTYPE(DTYPE)          \
+  REGISTER_CONV2D_OP(DTYPE, int, "i32", 1);   \
+  REGISTER_CONV2D_OP(DTYPE, int, "i32", 4);   \
+  REGISTER_CONV2D_OP(DTYPE, long, "i64", 1);  \
+  REGISTER_CONV2D_OP(DTYPE, long, "i64", 4);
+
+REGISTER_CONV2D_DTYPE(float);
+REGISTER_CONV2D_DTYPE(half);
+REGISTER_CONV2D_DTYPE(bfloat);

--- a/aten/src/ATen/native/mps/kernels/Convolution.metal
+++ b/aten/src/ATen/native/mps/kernels/Convolution.metal
@@ -75,20 +75,20 @@ kernel void conv2d(
   }
 }
 
-#define REGISTER_CONV2D_OP(DTYPE, ITYPE, INAME, R)                    \
+#define REGISTER_CONV2D_OP(DTYPE, ITYPE, INAME, R)                       \
   template [[host_name("conv2d_r" #R "_" INAME "_" #DTYPE)]] kernel void \
-  conv2d<DTYPE, ITYPE, R>(                                            \
-      constant DTYPE * input [[buffer(0)]],                           \
-      constant DTYPE * weight [[buffer(1)]],                          \
-      constant DTYPE * bias [[buffer(2)]],                            \
-      device DTYPE * output [[buffer(3)]],                            \
-      constant Conv2DParams & p [[buffer(4)]],                        \
+  conv2d<DTYPE, ITYPE, R>(                                               \
+      constant DTYPE * input [[buffer(0)]],                              \
+      constant DTYPE * weight [[buffer(1)]],                             \
+      constant DTYPE * bias [[buffer(2)]],                               \
+      device DTYPE * output [[buffer(3)]],                               \
+      constant Conv2DParams & p [[buffer(4)]],                           \
       uint tid [[thread_position_in_grid]]);
 
-#define REGISTER_CONV2D_DTYPE(DTYPE)          \
-  REGISTER_CONV2D_OP(DTYPE, int, "i32", 1);   \
-  REGISTER_CONV2D_OP(DTYPE, int, "i32", 4);   \
-  REGISTER_CONV2D_OP(DTYPE, long, "i64", 1);  \
+#define REGISTER_CONV2D_DTYPE(DTYPE)         \
+  REGISTER_CONV2D_OP(DTYPE, int, "i32", 1);  \
+  REGISTER_CONV2D_OP(DTYPE, int, "i32", 4);  \
+  REGISTER_CONV2D_OP(DTYPE, long, "i64", 1); \
   REGISTER_CONV2D_OP(DTYPE, long, "i64", 4);
 
 REGISTER_CONV2D_DTYPE(float);

--- a/aten/src/ATen/native/mps/operations/Convolution.mm
+++ b/aten/src/ATen/native/mps/operations/Convolution.mm
@@ -4,6 +4,7 @@
 #include <ATen/native/mps/OperationUtils.h>
 #include <ATen/ops/_mps_convolution_native.h>
 #include <ATen/ops/_mps_convolution_transpose_native.h>
+#include <ATen/ops/constant_pad_nd.h>
 #include <ATen/ops/mps_convolution_backward_native.h>
 #include <ATen/ops/mps_convolution_transpose_backward_native.h>
 #include <fmt/format.h>
@@ -152,6 +153,38 @@ static Tensor _mps_convolution_impl(const Tensor& input_t,
                                     IntArrayRef dilation,
                                     int64_t groups,
                                     std::optional<IntArrayRef> input_shape) {
+  // MPSGraph 2D convolution miscomputes the output once a filter dimension reaches 256
+  // since this is not a regular shape that would be seen in regular models, this is fine
+  // i.e. no custom metal kernel needed
+  if (input_t.dim() == 4 && (weight_t.size(2) >= 256 || weight_t.size(3) >= 256)) {
+    constexpr int64_t kChunk = 128;
+    const int64_t sH = stride[0], sW = stride[1];
+    const int64_t dH = dilation[0], dW = dilation[1];
+    const int64_t kH = weight_t.size(2), kW = weight_t.size(3);
+    const int64_t outH = (input_t.size(2) + 2 * padding[0] - dH * (kH - 1) - 1) / sH + 1;
+    const int64_t outW = (input_t.size(3) + 2 * padding[1] - dW * (kW - 1) - 1) / sW + 1;
+    // Degenerate shapes (filter larger than the padded input) fall through to the normal path's shape check.
+    if (outH >= 1 && outW >= 1) {
+      const auto padded = at::constant_pad_nd(input_t, {padding[1], padding[1], padding[0], padding[0]}, 0);
+      Tensor output_t;
+      for (int64_t hs = 0; hs < kH; hs += kChunk) {
+        const int64_t ch = std::min(kChunk, kH - hs);
+        const auto rows = padded.narrow(2, hs * dH, (outH - 1) * sH + dH * (ch - 1) + 1);
+        for (int64_t ws = 0; ws < kW; ws += kChunk) {
+          const int64_t cw = std::min(kChunk, kW - ws);
+          const auto x_chunk = rows.narrow(3, ws * dW, (outW - 1) * sW + dW * (cw - 1) + 1).contiguous();
+          const auto w_chunk = weight_t.narrow(2, hs, ch).narrow(3, ws, cw).contiguous();
+          auto part =
+              _mps_convolution_impl(x_chunk, w_chunk, std::nullopt, {0, 0}, stride, dilation, groups, std::nullopt);
+          output_t = output_t.defined() ? output_t.add(part) : std::move(part);
+        }
+      }
+      if (bias_opt && bias_opt->defined()) {
+        output_t = output_t.add(bias_opt->view({1, -1, 1, 1}));
+      }
+      return output_t;
+    }
+  }
   constexpr auto kChannelsLast = MemoryFormat::ChannelsLast;
   constexpr auto kChannelsLast3d = MemoryFormat::ChannelsLast3d;
   constexpr auto kContiguous = MemoryFormat::Contiguous;

--- a/aten/src/ATen/native/mps/operations/Convolution.mm
+++ b/aten/src/ATen/native/mps/operations/Convolution.mm
@@ -4,6 +4,7 @@
 #include <ATen/native/mps/OperationUtils.h>
 #include <ATen/ops/_mps_convolution_native.h>
 #include <ATen/ops/_mps_convolution_transpose_native.h>
+#include <ATen/ops/cat.h>
 #include <ATen/ops/constant_pad_nd.h>
 #include <ATen/ops/mps_convolution_backward_native.h>
 #include <ATen/ops/mps_convolution_transpose_backward_native.h>
@@ -157,6 +158,26 @@ static Tensor _mps_convolution_impl(const Tensor& input_t,
   // since this is not a regular shape that would be seen in regular models, this is fine
   // i.e. no custom metal kernel needed
   if (input_t.dim() == 4 && (weight_t.size(2) >= 256 || weight_t.size(3) >= 256)) {
+    // The MPSGraph conv's threadgroup staging grows with the batch as well as the
+    // filter size, so split the batch and recurse; each chunk then takes the
+    // sub-256 filter path below.
+    constexpr int64_t kBatchChunk = 8;
+    const int64_t N = input_t.size(0);
+    if (N > kBatchChunk) {
+      std::vector<Tensor> parts;
+      parts.reserve((N + kBatchChunk - 1) / kBatchChunk);
+      for (int64_t ns = 0; ns < N; ns += kBatchChunk) {
+        parts.push_back(_mps_convolution_impl(input_t.narrow(0, ns, std::min(kBatchChunk, N - ns)),
+                                              weight_t,
+                                              bias_opt,
+                                              padding,
+                                              stride,
+                                              dilation,
+                                              groups,
+                                              std::nullopt));
+      }
+      return at::cat(parts, 0);
+    }
     constexpr int64_t kChunk = 128;
     const int64_t sH = stride[0], sW = stride[1];
     const int64_t dH = dilation[0], dW = dilation[1];

--- a/aten/src/ATen/native/mps/operations/Convolution.mm
+++ b/aten/src/ATen/native/mps/operations/Convolution.mm
@@ -197,13 +197,14 @@ static Tensor _mps_convolution_impl(const Tensor& input_t,
           const auto w_chunk = weight_t.narrow(2, hs, ch).narrow(3, ws, cw).contiguous();
           auto part =
               _mps_convolution_impl(x_chunk, w_chunk, std::nullopt, {0, 0}, stride, dilation, groups, std::nullopt);
-          output_t = output_t.defined() ? output_t.add(part) : std::move(part);
+          // accumulate in fp32 to avoid aggregating rounding errors from half types
+          output_t = output_t.defined() ? output_t.add(part) : part.to(at::kFloat);
         }
       }
       if (bias_opt && bias_opt->defined()) {
         output_t = output_t.add(bias_opt->view({1, -1, 1, 1}));
       }
-      return output_t;
+      return output_t.to(input_t.scalar_type());
     }
   }
   constexpr auto kChannelsLast = MemoryFormat::ChannelsLast;

--- a/aten/src/ATen/native/mps/operations/Convolution.mm
+++ b/aten/src/ATen/native/mps/operations/Convolution.mm
@@ -1,16 +1,22 @@
 //  Copyright © 2022 Apple Inc.
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/native/CanUse32BitIndexMath.h>
 #include <ATen/native/ConvUtils.h>
 #include <ATen/native/mps/OperationUtils.h>
+#include <ATen/native/mps/kernels/Convolution.h>
 #include <ATen/ops/_mps_convolution_native.h>
 #include <ATen/ops/_mps_convolution_transpose_native.h>
-#include <ATen/ops/cat.h>
-#include <ATen/ops/constant_pad_nd.h>
 #include <ATen/ops/mps_convolution_backward_native.h>
 #include <ATen/ops/mps_convolution_transpose_backward_native.h>
 #include <fmt/format.h>
 
 namespace at::native {
+
+#ifndef PYTORCH_JIT_COMPILE_SHADERS
+static auto& lib = mps::MetalShaderLibrary::getBundledLibrary();
+#else
+#include <ATen/native/mps/Convolution_metallib.h>
+#endif
 
 // `memory_format` selects NDHWC vs NCDHW; `use_dhwio` selects DHWIO vs OIDHW
 // (caller must insert the matching in-graph weight transpose).
@@ -146,6 +152,66 @@ static void fill_conv_desc(MPSGraphConvolution2DOpDescriptor* descriptor_,
   descriptor_.groups = groups;
 }
 
+// Forward-only Metal conv for filter dims >= 256 (MPSGraph miscomputes those); backward is unaffected.
+static Tensor mps_convolution_2d_large_kernel(const Tensor& input_t,
+                                              const Tensor& weight_t,
+                                              const std::optional<Tensor>& bias_opt,
+                                              IntArrayRef padding,
+                                              IntArrayRef stride,
+                                              IntArrayRef dilation,
+                                              int64_t groups) {
+  using namespace mps;
+  const auto input = input_t.contiguous();
+  const auto weight = weight_t.contiguous();
+  const bool has_bias = bias_opt && bias_opt->defined();
+  const auto bias = has_bias ? bias_opt->contiguous() : Tensor();
+
+  auto output = at::empty(conv_output_size(input.sizes(), weight.sizes(), padding, stride, dilation), input.options());
+  if (output.numel() == 0) {
+    return output;
+  }
+
+  Conv2DParams params;
+  params.N = static_cast<int32_t>(input.size(0));
+  params.C_in = static_cast<int32_t>(input.size(1));
+  params.C_out = static_cast<int32_t>(weight.size(0));
+  params.H = static_cast<int32_t>(input.size(2));
+  params.W = static_cast<int32_t>(input.size(3));
+  params.outH = static_cast<int32_t>(output.size(2));
+  params.outW = static_cast<int32_t>(output.size(3));
+  params.kH = static_cast<int32_t>(weight.size(2));
+  params.kW = static_cast<int32_t>(weight.size(3));
+  params.sH = static_cast<int32_t>(stride[0]);
+  params.sW = static_cast<int32_t>(stride[1]);
+  params.padH = static_cast<int32_t>(padding[0]);
+  params.padW = static_cast<int32_t>(padding[1]);
+  params.dH = static_cast<int32_t>(dilation[0]);
+  params.dW = static_cast<int32_t>(dilation[1]);
+  params.C_in_per_group = static_cast<int32_t>(weight.size(1));
+  params.C_out_per_group = params.C_out / static_cast<int32_t>(groups);
+  params.has_bias = has_bias;
+
+  // ow-blocking quarters the thread count; only use it when the grid still saturates the GPU.
+  const auto outRows = output.numel() / output.size(3);
+  const auto blockedThreads = outRows * ((output.size(3) + 3) / 4);
+  const bool blocked = blockedThreads >= 32768;
+  const auto nThreads = blocked ? blockedThreads : output.numel();
+  const bool i32 = canUse32BitIndexMath(input) && canUse32BitIndexMath(weight) && canUse32BitIndexMath(output);
+
+  MPSStream* stream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      auto computeEncoder = stream->commandEncoder();
+      auto PSO = lib.getPipelineStateForFunc(
+          fmt::format("conv2d_r{}_{}_{}", blocked ? 4 : 1, i32 ? "i32" : "i64", scalarToMetalTypeString(input)));
+      [computeEncoder setComputePipelineState:PSO];
+      mtl_setArgs(computeEncoder, input, weight, has_bias ? std::optional<Tensor>(bias) : std::nullopt, output, params);
+      mtl_dispatch1DJob(computeEncoder, PSO, nThreads);
+    }
+  });
+  return output;
+}
+
 static Tensor _mps_convolution_impl(const Tensor& input_t,
                                     const Tensor& weight_t,
                                     const std::optional<Tensor>& bias_opt,
@@ -154,57 +220,13 @@ static Tensor _mps_convolution_impl(const Tensor& input_t,
                                     IntArrayRef dilation,
                                     int64_t groups,
                                     std::optional<IntArrayRef> input_shape) {
-  // MPSGraph 2D convolution miscomputes the output once a filter dimension reaches 256
-  // since this is not a regular shape that would be seen in regular models, this is fine
-  // i.e. no custom metal kernel needed
+  // MPSGraph 2D conv miscomputes the output once a filter spatial dim reaches 256; use a Metal kernel instead.
   if (input_t.dim() == 4 && (weight_t.size(2) >= 256 || weight_t.size(3) >= 256)) {
-    // The MPSGraph conv's threadgroup staging grows with the batch as well as the
-    // filter size, so split the batch and recurse; each chunk then takes the
-    // sub-256 filter path below.
-    constexpr int64_t kBatchChunk = 8;
-    const int64_t N = input_t.size(0);
-    if (N > kBatchChunk) {
-      std::vector<Tensor> parts;
-      parts.reserve((N + kBatchChunk - 1) / kBatchChunk);
-      for (int64_t ns = 0; ns < N; ns += kBatchChunk) {
-        parts.push_back(_mps_convolution_impl(input_t.narrow(0, ns, std::min(kBatchChunk, N - ns)),
-                                              weight_t,
-                                              bias_opt,
-                                              padding,
-                                              stride,
-                                              dilation,
-                                              groups,
-                                              std::nullopt));
-      }
-      return at::cat(parts, 0);
-    }
-    constexpr int64_t kChunk = 128;
-    const int64_t sH = stride[0], sW = stride[1];
-    const int64_t dH = dilation[0], dW = dilation[1];
-    const int64_t kH = weight_t.size(2), kW = weight_t.size(3);
-    const int64_t outH = (input_t.size(2) + 2 * padding[0] - dH * (kH - 1) - 1) / sH + 1;
-    const int64_t outW = (input_t.size(3) + 2 * padding[1] - dW * (kW - 1) - 1) / sW + 1;
-    // Degenerate shapes (filter larger than the padded input) fall through to the normal path's shape check.
+    const auto outH = (input_t.size(2) + 2 * padding[0] - dilation[0] * (weight_t.size(2) - 1) - 1) / stride[0] + 1;
+    const auto outW = (input_t.size(3) + 2 * padding[1] - dilation[1] * (weight_t.size(3) - 1) - 1) / stride[1] + 1;
+    // Degenerate shapes fall through to the normal path's shape check.
     if (outH >= 1 && outW >= 1) {
-      const auto padded = at::constant_pad_nd(input_t, {padding[1], padding[1], padding[0], padding[0]}, 0);
-      Tensor output_t;
-      for (int64_t hs = 0; hs < kH; hs += kChunk) {
-        const int64_t ch = std::min(kChunk, kH - hs);
-        const auto rows = padded.narrow(2, hs * dH, (outH - 1) * sH + dH * (ch - 1) + 1);
-        for (int64_t ws = 0; ws < kW; ws += kChunk) {
-          const int64_t cw = std::min(kChunk, kW - ws);
-          const auto x_chunk = rows.narrow(3, ws * dW, (outW - 1) * sW + dW * (cw - 1) + 1).contiguous();
-          const auto w_chunk = weight_t.narrow(2, hs, ch).narrow(3, ws, cw).contiguous();
-          auto part =
-              _mps_convolution_impl(x_chunk, w_chunk, std::nullopt, {0, 0}, stride, dilation, groups, std::nullopt);
-          // accumulate in fp32 to avoid aggregating rounding errors from half types
-          output_t = output_t.defined() ? output_t.add(part) : part.to(at::kFloat);
-        }
-      }
-      if (bias_opt && bias_opt->defined()) {
-        output_t = output_t.add(bias_opt->view({1, -1, 1, 1}));
-      }
-      return output_t.to(input_t.scalar_type());
+      return mps_convolution_2d_large_kernel(input_t, weight_t, bias_opt, padding, stride, dilation, groups);
     }
   }
   constexpr auto kChannelsLast = MemoryFormat::ChannelsLast;

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -2961,6 +2961,34 @@ class TestMPS(TestCaseMPS):
             helper((N, C_in * 2, H * 2, W * 2), (C_out * 2, (C_in * 2) // groups,
                    kH + 2, kW + 2), bias_shape=(C_out * 2), groups=groups)
 
+    @parametrize("batch_size", [1, 2])
+    @parametrize("conv_config", [
+        (8, 16, 8, 256, 1),  # reported case: in/groups=1, channel multiplier 2
+        (8, 8, 8, 256, 1),   # true depthwise (1->1 per group)
+        (1, 1, 1, 256, 1),   # single channel
+        (8, 8, 8, 512, 1),   # tall filter, wrong even at batch 1
+        (8, 8, 8, 256, 3),
+        (8, 8, 8, 3, 256),
+    ])
+    def test_conv2d_filter_dim_ge_256(self, conv_config, batch_size):
+        # Regression: MPSGraph 2D conv miscomputes output once a filter dim reaches 256 (split into sub-256 chunks).
+        in_channels, out_channels, groups, kH, kW = conv_config
+        H = kH if kH >= 256 else kH + 70
+        W = kW if kW >= 256 else kW + 70
+        conv_cpu = nn.Conv2d(in_channels, out_channels, (kH, kW), groups=groups, bias=True)
+        conv_mps = copy.deepcopy(conv_cpu).to("mps")
+        x_cpu = torch.randn(batch_size, in_channels, H, W, requires_grad=True)
+        x_mps = x_cpu.detach().clone().to("mps").requires_grad_()
+        out_cpu = conv_cpu(x_cpu)
+        out_mps = conv_mps(x_mps)
+        self.assertEqual(out_cpu, out_mps, rtol=2.6e-05, atol=2e-04)
+        grad = torch.randn_like(out_cpu)
+        out_cpu.backward(grad)
+        out_mps.backward(grad.to("mps"))
+        self.assertEqual(x_cpu.grad, x_mps.grad, rtol=2.6e-05, atol=2e-04)
+        self.assertEqual(conv_cpu.weight.grad, conv_mps.weight.grad, atol=8e-04, rtol=10.4e-05)
+        self.assertEqual(conv_cpu.bias.grad, conv_mps.bias.grad, atol=8e-04, rtol=10.4e-05)
+
     # Test conv transpose 2d
     def test_conv_transpose2d(self):
         def helper(input_shape, wt_shape,

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -2961,7 +2961,7 @@ class TestMPS(TestCaseMPS):
             helper((N, C_in * 2, H * 2, W * 2), (C_out * 2, (C_in * 2) // groups,
                    kH + 2, kW + 2), bias_shape=(C_out * 2), groups=groups)
 
-    @parametrize("batch_size", [1, 2])
+    @parametrize("batch_size", [1, 2, 16, 32])
     @parametrize("conv_config", [
         (8, 16, 8, 256, 1),  # reported case: in/groups=1, channel multiplier 2
         (8, 8, 8, 256, 1),   # true depthwise (1->1 per group)

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -2971,7 +2971,7 @@ class TestMPS(TestCaseMPS):
         (8, 8, 8, 3, 256),
     ])
     def test_conv2d_filter_dim_ge_256(self, conv_config, batch_size):
-        # Regression: MPSGraph 2D conv miscomputes output once a filter dim reaches 256 (split into sub-256 chunks).
+        # Regression: MPSGraph 2D conv miscomputes output once a filter dim reaches 256 (routed to a Metal kernel).
         in_channels, out_channels, groups, kH, kW = conv_config
         H = kH if kH >= 256 else kH + 70
         W = kW if kW >= 256 else kW + 70


### PR DESCRIPTION
Fixes #188335

MPSGraph's 2D conv returns wrong results when a kernel spatial dim reaches 256, decompose into sub-256 kernel chunks summed over a padded input so every sub-conv stays correct. While perf won't be ideal, this kernel shape isn't something one will see while training regular computer vision models so this is fine