### PR TITLE
Fix cummin/cummax silently ignoring invalid dims on zero-size tensors

### DIFF
--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -849,6 +849,8 @@ std::tuple<Tensor&, Tensor&> cummax_out(const Tensor& self, int64_t dim, Tensor&
   check_scalar_type_device_layout_equal(indices, at::empty({0}, self.options().dtype(at::kLong)));
   if (self.dim() == 0) {
     at::native::zero_numel_check_dims(self, dim, "cummax()");
+  } else {
+    dim = maybe_wrap_dim(dim, self.dim());
   }
 
   {
@@ -858,7 +860,6 @@ std::tuple<Tensor&, Tensor&> cummax_out(const Tensor& self, int64_t dim, Tensor&
       values.fill_(self);
       indices.fill_(0);
     } else if(self.numel() != 0) {
-      dim = maybe_wrap_dim(dim, self.dim());
       at::_cummax_helper(self, values, indices, dim);
     }
   }
@@ -885,6 +886,8 @@ std::tuple<Tensor&, Tensor&> cummin_out(const Tensor& self, int64_t dim, Tensor&
   check_scalar_type_device_layout_equal(indices, at::empty({0}, self.options().dtype(at::kLong)));
   if (self.dim() == 0) {
     at::native::zero_numel_check_dims(self, dim, "cummin()");
+  } else {
+    dim = maybe_wrap_dim(dim, self.dim());
   }
 
   {
@@ -894,7 +897,6 @@ std::tuple<Tensor&, Tensor&> cummin_out(const Tensor& self, int64_t dim, Tensor&
       values.fill_(self);
       indices.fill_(0);
     } else if(self.numel() != 0) {
-      dim = maybe_wrap_dim(dim, self.dim());
       at::_cummin_helper(self, values, indices, dim);
     }
   }

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2817,6 +2817,14 @@ class TestTorchDeviceType(TestCase):
                     'Expected reduction dim -1 or 0 for scalar but got 100'):
                 op(x, dim)
 
+            # Check that zero-size tensors with invalid dims raise IndexError
+            # consistently, matching non-zero tensor behavior
+            x = torch.tensor([], device=device)
+            with self.assertRaisesRegex(
+                    IndexError,
+                    'Dimension out of range'):
+                op(x, -46)
+
             # Check that op over a zero length dimension doesn't crash on backprop.
             # Also check that op over other dimensions in a tensor with a zero-length
             # dimension also works


### PR DESCRIPTION
Fixes #188224

## Summary

`cummin` and `cummax` skipped dimension validation for empty non-scalar tensors.

For tensors with `numel() == 0`, the implementation returned early without
calling `maybe_wrap_dim()`, so invalid dimensions such as `-46` were silently
accepted. The same invalid dimensions correctly raised `IndexError` for
non-empty tensors, resulting in inconsistent eager behavior and a mismatch with
Inductor, which validates dimensions during lowering.

This change moves dimension validation before the `numel()` check so that
invalid dimensions are rejected consistently regardless of tensor size.

## Testing

- Added a regression test verifying that `cummin` and `cummax` raise
  `IndexError` for invalid dimensions on empty tensors.