### PR TITLE
Add kernel_size > 0 validation to FractionalMaxPool2d matching Fracti…

### DIFF
--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -658,6 +658,18 @@ class TestPoolingNNDeviceType(NNTestCase):
         with self.assertRaisesRegex(RuntimeError, "Expect _random_samples"):
             mod(inp1)
 
+    def test_FractionalMaxPool2d_errors(self, device):
+        samples = torch.rand([0, 16, 2], device=device)
+        with self.assertRaisesRegex(ValueError, "kernel_size must be greater than 0"):
+            nn.FractionalMaxPool2d(0, output_size=[1, 1], _random_samples=samples)
+        with self.assertRaisesRegex(ValueError, "kernel_size must be greater than 0"):
+            nn.FractionalMaxPool2d([0, 0], output_size=[1, 1], _random_samples=samples)
+        with self.assertRaisesRegex(ValueError, "kernel_size must be greater than 0"):
+            nn.FractionalMaxPool2d(
+                kernel_size=-1,
+                output_size=[1, 1],
+            )
+
     def test_FractionalMaxPool3d_errors(self, device):
         samples = torch.rand([0, 16, 3], device=device)
         with self.assertRaisesRegex(ValueError, "kernel_size must be greater than 0"):

--- a/torch/nn/modules/pooling.py
+++ b/torch/nn/modules/pooling.py
@@ -968,6 +968,13 @@ class FractionalMaxPool2d(Module):
         _random_samples=None,
     ) -> None:
         super().__init__()
+        if (isinstance(kernel_size, int) and kernel_size <= 0) or (
+            isinstance(kernel_size, (tuple, list))
+            and not all(k > 0 for k in kernel_size)
+        ):
+            raise ValueError(
+                f"kernel_size must be greater than 0, but got {kernel_size}"
+            )
         self.kernel_size = _pair(kernel_size)
         self.return_indices = return_indices
         self.register_buffer("_random_samples", _random_samples)


### PR DESCRIPTION
Fixes #188217, #188218, #188226

## Summary

`FractionalMaxPool3d` validates that `kernel_size > 0` in `__init__` but `FractionalMaxPool2d` was missing the equivalent check. Non-positive kernel sizes were silently accepted in eager forward, producing invalid intermediate values that caused Inductor to crash in three different ways depending on downstream ops:

- #188217 — `reduce()` over empty iterable in IR registration
- #188218 — `max not supported for zero-dimension tensors` in lowering  
- #188226 — `ValueRangeError: Invalid ranges [0:-61]` in index propagation

This change adds the same validation block from `FractionalMaxPool3d` to `FractionalMaxPool2d`, rejecting non-positive kernel sizes at construction time with a clear error message.

**Before:**
```python
nn.FractionalMaxPool2d(-2, output_size=(2, 2))  # silently accepted, crashed Inductor
```
**After:**
```python
nn.FractionalMaxPool2d(-2, output_size=(2, 2))  # ValueError: kernel_size must be greater than 0, but got -2
```

## Testing

Added `test_FractionalMaxPool2d_errors` covering scalar zero, tuple zero, and negative kernel sizes, matching the existing `test_FractionalMaxPool3d_errors`.