### PR TITLE
Allow from_blob / TensorMaker to attach BackendMeta at construction

### DIFF
--- a/aten/src/ATen/ops/from_blob.h
+++ b/aten/src/ATen/ops/from_blob.h
@@ -1,5 +1,7 @@
 #pragma once
 #include <ATen/core/Tensor.h>
+#include <c10/core/TensorImpl.h>
+#include <c10/util/intrusive_ptr.h>
 
 namespace at {
 
@@ -74,6 +76,13 @@ class TORCH_API TensorMaker {
     return *this;
   }
 
+  TensorMaker& backend_meta(
+      c10::intrusive_ptr<c10::BackendMeta> value) noexcept {
+    backend_meta_ = std::move(value);
+
+    return *this;
+  }
+
   Tensor make_tensor();
 
  private:
@@ -98,6 +107,7 @@ class TORCH_API TensorMaker {
   TensorOptions opts_;
   bool resizeable_{};
   c10::Allocator* allocator_{};
+  c10::intrusive_ptr<c10::BackendMeta> backend_meta_{};
 };
 
 inline TensorMaker for_blob(void* data, IntArrayRef sizes) noexcept {

--- a/aten/src/ATen/ops/from_blob.h
+++ b/aten/src/ATen/ops/from_blob.h
@@ -120,12 +120,14 @@ inline Tensor from_blob(
     IntArrayRef strides,
     const std::function<void(void*)>& deleter,
     const TensorOptions& options = {},
-    const std::optional<Device> target_device = std::nullopt) {
+    const std::optional<Device> target_device = std::nullopt,
+    c10::intrusive_ptr<c10::BackendMeta> backend_meta = {}) {
   return for_blob(data, sizes)
       .strides(strides)
       .deleter(deleter)
       .options(options)
       .target_device(target_device)
+      .backend_meta(std::move(backend_meta))
       .make_tensor();
 }
 
@@ -136,13 +138,15 @@ inline Tensor from_blob(
     int64_t storage_offset,
     const std::function<void(void*)>& deleter,
     const TensorOptions& options = {},
-    const std::optional<Device> target_device = std::nullopt) {
+    const std::optional<Device> target_device = std::nullopt,
+    c10::intrusive_ptr<c10::BackendMeta> backend_meta = {}) {
   return for_blob(data, sizes)
       .strides(strides)
       .storage_offset(storage_offset)
       .deleter(deleter)
       .options(options)
       .target_device(target_device)
+      .backend_meta(std::move(backend_meta))
       .make_tensor();
 }
 
@@ -151,11 +155,13 @@ inline Tensor from_blob(
     IntArrayRef sizes,
     std::function<void(void*)> deleter,
     const TensorOptions& options = {},
-    const std::optional<Device> target_device = std::nullopt) {
+    const std::optional<Device> target_device = std::nullopt,
+    c10::intrusive_ptr<c10::BackendMeta> backend_meta = {}) {
   return for_blob(data, sizes)
       .deleter(std::move(deleter))
       .options(options)
       .target_device(target_device)
+      .backend_meta(std::move(backend_meta))
       .make_tensor();
 }
 
@@ -163,15 +169,24 @@ inline Tensor from_blob(
     void* data,
     IntArrayRef sizes,
     IntArrayRef strides,
-    const TensorOptions& options = {}) {
-  return for_blob(data, sizes).strides(strides).options(options).make_tensor();
+    const TensorOptions& options = {},
+    c10::intrusive_ptr<c10::BackendMeta> backend_meta = {}) {
+  return for_blob(data, sizes)
+      .strides(strides)
+      .options(options)
+      .backend_meta(std::move(backend_meta))
+      .make_tensor();
 }
 
 inline Tensor from_blob(
     void* data,
     IntArrayRef sizes,
-    const TensorOptions& options = {}) {
-  return for_blob(data, sizes).options(options).make_tensor();
+    const TensorOptions& options = {},
+    c10::intrusive_ptr<c10::BackendMeta> backend_meta = {}) {
+  return for_blob(data, sizes)
+      .options(options)
+      .backend_meta(std::move(backend_meta))
+      .make_tensor();
 }
 
 } // namespace at

--- a/aten/src/ATen/templates/Functions.cpp
+++ b/aten/src/ATen/templates/Functions.cpp
@@ -55,6 +55,11 @@ Tensor TensorMaker::make_tensor() {
 
   tensor_impl->set_requires_grad(opts_.requires_grad());
 
+  // Only touch ExtraMeta when a backend meta was provided (zero-cost default).
+  if (backend_meta_) {
+    tensor_impl->set_backend_meta(std::move(backend_meta_));
+  }
+
   return tensor;
  }
 

--- a/aten/src/ATen/test/basic.cpp
+++ b/aten/src/ATen/test/basic.cpp
@@ -572,3 +572,26 @@ TEST(BasicTest, TestForBlobBackendMeta) {
   ASSERT_EQ(t.unsafeGetTensorImpl()->get_backend_meta(), meta.get());
   ASSERT_EQ(static_cast<TestBackendMeta*>(t.unsafeGetTensorImpl()->get_backend_meta())->tag_, 29);
 }
+
+TEST(BasicTest, TestFromBlobBackendMeta) {
+  std::array<int32_t, 6> storage;
+  std::iota(storage.begin(), storage.end(), 1);
+
+  // Existing from_blob calls (no backend_meta arg) attach no meta -- the new
+  // trailing parameter is optional and backward compatible.
+  auto plain = at::from_blob(storage.data(), {3,}, c10::TensorOptions(kInt));
+  ASSERT_EQ(plain.unsafeGetTensorImpl()->get_backend_meta(), nullptr);
+
+  // Passing the optional backend_meta attaches it through from_blob.
+  auto meta = c10::make_intrusive<TestBackendMeta>(29);
+  auto t = at::from_blob(
+      storage.data(),
+      {3,},
+      /*strides=*/{1,},
+      /*deleter=*/[](void*) {},
+      c10::TensorOptions(kInt),
+      /*target_device=*/std::nullopt,
+      meta);
+  ASSERT_EQ(t.unsafeGetTensorImpl()->get_backend_meta(), meta.get());
+  ASSERT_EQ(static_cast<TestBackendMeta*>(t.unsafeGetTensorImpl()->get_backend_meta())->tag_, 29);
+}

--- a/aten/src/ATen/test/basic.cpp
+++ b/aten/src/ATen/test/basic.cpp
@@ -550,3 +550,25 @@ TEST(BasicTest, TestForBlobStridesOverflow) {
       at::for_blob(storage.data(), {2,}).strides({huge,}).options(c10::TensorOptions(kInt)).make_tensor());
 #endif
 }
+
+namespace {
+struct TestBackendMeta : public c10::BackendMeta {
+  explicit TestBackendMeta(int tag) : tag_(tag) {}
+  int tag_;
+};
+} // namespace
+
+TEST(BasicTest, TestForBlobBackendMeta) {
+  std::array<int32_t, 6> storage;
+  std::iota(storage.begin(), storage.end(), 1);
+
+  // Without the setter, no backend meta is attached.
+  auto plain = at::for_blob(storage.data(), {3,}).options(c10::TensorOptions(kInt)).make_tensor();
+  ASSERT_EQ(plain.unsafeGetTensorImpl()->get_backend_meta(), nullptr);
+
+  // With the setter, the meta is folded in at construction.
+  auto meta = c10::make_intrusive<TestBackendMeta>(29);
+  auto t = at::for_blob(storage.data(), {3,}).options(c10::TensorOptions(kInt)).backend_meta(meta).make_tensor();
+  ASSERT_EQ(t.unsafeGetTensorImpl()->get_backend_meta(), meta.get());
+  ASSERT_EQ(static_cast<TestBackendMeta*>(t.unsafeGetTensorImpl()->get_backend_meta())->tag_, 29);
+}

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/CMakeLists.txt
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/CMakeLists.txt
@@ -34,6 +34,15 @@ if(USE_TEST AND kineto_LIBRARY)
     add_test(NAME ${PROFILER_TEST_TARGET} COMMAND ${PROFILER_TEST_TARGET})
 endif()
 
+if(USE_TEST)
+    set(BACKEND_META_TEST_TARGET openreg_backend_meta_tests)
+    add_executable(${BACKEND_META_TEST_TARGET}
+        ${PROJECT_SOURCE_DIR}/tests/cpp/test_openreg_backend_meta.cpp)
+    target_link_libraries(${BACKEND_META_TEST_TARGET}
+        PRIVATE torch_openreg torch_cpu_library openreg gtest gtest_main)
+    add_test(NAME ${BACKEND_META_TEST_TARGET} COMMAND ${BACKEND_META_TEST_TARGET})
+endif()
+
 install(TARGETS ${LIBRARY_NAME}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/CMakeLists.txt
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/CMakeLists.txt
@@ -40,6 +40,11 @@ if(USE_TEST)
         ${PROJECT_SOURCE_DIR}/tests/cpp/test_openreg_backend_meta.cpp)
     target_link_libraries(${BACKEND_META_TEST_TARGET}
         PRIVATE torch_openreg torch_cpu_library openreg gtest gtest_main)
+    # This standalone binary links libtorch_cpu, which lives in the torch
+    # install dir rather than next to the executable. Derive its rpath from the
+    # linked library locations instead of hardcoding the torch lib path.
+    set_target_properties(${BACKEND_META_TEST_TARGET} PROPERTIES
+        INSTALL_RPATH_USE_LINK_PATH TRUE)
     add_test(NAME ${BACKEND_META_TEST_TARGET} COMMAND ${BACKEND_META_TEST_TARGET})
 endif()
 

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/CMakeLists.txt
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/CMakeLists.txt
@@ -38,11 +38,14 @@ if(USE_TEST)
     set(BACKEND_META_TEST_TARGET openreg_backend_meta_tests)
     add_executable(${BACKEND_META_TEST_TARGET}
         ${PROJECT_SOURCE_DIR}/tests/cpp/test_openreg_backend_meta.cpp)
+    # OpenRegBackendMeta is header-only: link only ATen + gtest (an unused
+    # libopenreg.so link breaks clang's standalone run) and add the header dir.
+    target_include_directories(${BACKEND_META_TEST_TARGET}
+        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
     target_link_libraries(${BACKEND_META_TEST_TARGET}
-        PRIVATE torch_openreg torch_cpu_library openreg gtest gtest_main)
-    # This standalone binary links libtorch_cpu, which lives in the torch
-    # install dir rather than next to the executable. Derive its rpath from the
-    # linked library locations instead of hardcoding the torch lib path.
+        PRIVATE torch_cpu_library gtest gtest_main)
+    # libtorch_cpu lives in the torch install dir, not by the exe: derive its
+    # rpath from the linked library locations.
     set_target_properties(${BACKEND_META_TEST_TARGET} PROPERTIES
         INSTALL_RPATH_USE_LINK_PATH TRUE)
     add_test(NAME ${BACKEND_META_TEST_TARGET} COMMAND ${BACKEND_META_TEST_TARGET})

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegSerialization.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegSerialization.cpp
@@ -1,14 +1,6 @@
 #include "OpenRegSerialization.h"
 
 namespace c10::openreg {
-struct OpenRegBackendMeta : public c10::BackendMeta {
-  OpenRegBackendMeta(int version_number, int format_number)
-      : version_number_(version_number), format_number_(format_number) {}
-
-  int version_number_{-1};
-  int format_number_{-1};
-};
-
 void for_serialization(
     const at::Tensor& t,
     std::unordered_map<std::string, bool>& m) {

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegSerialization.h
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/csrc/runtime/OpenRegSerialization.h
@@ -1,6 +1,17 @@
 #pragma once
 
+#include <c10/core/TensorImpl.h>
 #include <torch/csrc/jit/serialization/pickler.h>
+
+namespace c10::openreg {
+struct OpenRegBackendMeta : public c10::BackendMeta {
+  OpenRegBackendMeta(int version_number, int format_number)
+      : version_number_(version_number), format_number_(format_number) {}
+
+  int version_number_{-1};
+  int format_number_{-1};
+};
+} // namespace c10::openreg
 
 #define REGISTER_PRIVATEUSE1_SERIALIZATION(                                    \
     FOR_SERIALIZATION, FOR_DESERIALIZATION)                                    \

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/cpp/test_openreg_backend_meta.cpp
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/cpp/test_openreg_backend_meta.cpp
@@ -1,0 +1,68 @@
+#include <gtest/gtest.h>
+
+#include <ATen/ATen.h>
+#include <ATen/ops/from_blob.h>
+
+#include "runtime/OpenRegSerialization.h"
+
+namespace c10::openreg {
+namespace {
+
+OpenRegBackendMeta* getMeta(const at::Tensor& t) {
+  return dynamic_cast<OpenRegBackendMeta*>(
+      t.unsafeGetTensorImpl()->get_backend_meta());
+}
+
+} // namespace
+
+TEST(OpenRegBackendMetaTest, ForBlobSetterAttachesMeta) {
+  std::array<int32_t, 3> storage{1, 2, 3};
+  auto options = at::TensorOptions().dtype(at::kInt);
+
+  // Without the setter, no backend meta is attached (zero-cost default).
+  auto plain =
+      at::for_blob(storage.data(), {3}).options(options).make_tensor();
+  EXPECT_EQ(plain.unsafeGetTensorImpl()->get_backend_meta(), nullptr);
+
+  // The setter folds the exact OpenRegBackendMeta in at construction.
+  auto meta = c10::make_intrusive<OpenRegBackendMeta>(1, 29);
+  auto t = at::for_blob(storage.data(), {3})
+               .options(options)
+               .backend_meta(meta)
+               .make_tensor();
+  EXPECT_EQ(t.unsafeGetTensorImpl()->get_backend_meta(), meta.get());
+  ASSERT_NE(getMeta(t), nullptr);
+  EXPECT_EQ(getMeta(t)->version_number_, 1);
+  EXPECT_EQ(getMeta(t)->format_number_, 29);
+}
+
+TEST(OpenRegBackendMetaTest, SetterMatchesPostHoc) {
+  std::array<int32_t, 3> storage{1, 2, 3};
+  auto options = at::TensorOptions().dtype(at::kInt);
+
+  // Post-hoc idiom (what for_deserialization uses): build, then set.
+  auto postHocMeta = c10::make_intrusive<OpenRegBackendMeta>(1, 29);
+  auto postHoc =
+      at::for_blob(storage.data(), {3}).options(options).make_tensor();
+  postHoc.unsafeGetTensorImpl()->set_backend_meta(postHocMeta);
+
+  // Setter idiom: fold a distinct meta in at construction.
+  auto setterMeta = c10::make_intrusive<OpenRegBackendMeta>(2, 30);
+  auto viaSetter = at::for_blob(storage.data(), {3})
+                       .options(options)
+                       .backend_meta(setterMeta)
+                       .make_tensor();
+
+  // Both attach exactly the object they were handed, in the same slot.
+  EXPECT_EQ(
+      postHoc.unsafeGetTensorImpl()->get_backend_meta(), postHocMeta.get());
+  EXPECT_EQ(
+      viaSetter.unsafeGetTensorImpl()->get_backend_meta(), setterMeta.get());
+
+  // The setter preserves its own distinct payload, not the post-hoc one.
+  ASSERT_NE(getMeta(viaSetter), nullptr);
+  EXPECT_EQ(getMeta(viaSetter)->version_number_, 2);
+  EXPECT_EQ(getMeta(viaSetter)->format_number_, 30);
+}
+
+} // namespace c10::openreg

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -993,21 +993,15 @@ def test_openreg(test_module, test_directory, options):
         return return_code
 
     # Run the openreg C++ unit tests (gtest) built by cmake.
-    ortests_bin = os.path.join(
-        openreg_dir, "build", "third_party", "openreg", "ortests"
-    )
-    if os.path.isfile(ortests_bin):
-        return_code = shell([ortests_bin], cwd=openreg_dir)
-        if return_code != 0:
-            return return_code
-
-    backend_meta_tests_bin = os.path.join(
-        openreg_dir, "build", "csrc", "openreg_backend_meta_tests"
-    )
-    if os.path.isfile(backend_meta_tests_bin):
-        return_code = shell([backend_meta_tests_bin], cwd=openreg_dir)
-        if return_code != 0:
-            return return_code
+    cpp_test_bins = [
+        os.path.join(openreg_dir, "build", "third_party", "openreg", "ortests"),
+        os.path.join(openreg_dir, "build", "csrc", "openreg_backend_meta_tests"),
+    ]
+    for cpp_test_bin in cpp_test_bins:
+        if os.path.isfile(cpp_test_bin):
+            return_code = shell([cpp_test_bin], cwd=openreg_dir)
+            if return_code != 0:
+                return return_code
 
     with extend_python_path([install_dir]):
         cmd = [

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1001,6 +1001,14 @@ def test_openreg(test_module, test_directory, options):
         if return_code != 0:
             return return_code
 
+    backend_meta_tests_bin = os.path.join(
+        openreg_dir, "build", "csrc", "openreg_backend_meta_tests"
+    )
+    if os.path.isfile(backend_meta_tests_bin):
+        return_code = shell([backend_meta_tests_bin], cwd=openreg_dir)
+        if return_code != 0:
+            return return_code
+
     with extend_python_path([install_dir]):
         cmd = [
             sys.executable,


### PR DESCRIPTION
Today, attaching a `BackendMeta` to a tensor built from external memory is a
two-step dance: call `from_blob(...)` (or `for_blob(...).make_tensor()`), then
reach back in with `set_backend_meta()`:

```cpp
auto t = at::from_blob(ptr, sizes, strides, deleter, opts, device);
t.unsafeGetTensorImpl()->set_backend_meta(c10::make_intrusive<MyMeta>(...));
```

`set_backend_meta()` is only reachable through `unsafeGetTensorImpl()`, is easy
to forget, and leaves a meta-less tensor as an observable intermediate. This is
the one `TensorImpl` construction knob the builder/`from_blob` does not expose,
even though `BackendMeta` is a first-class `TensorImpl` capability
(`get_backend_meta` / `set_backend_meta`) -- unlike `strides`, `storage_offset`,
`deleter`, `target_device`, `options`, `allocator`, which all are.

This folds the `set_backend_meta()` step into construction:

- a fluent `TensorMaker::backend_meta()` setter (applied in `make_tensor()`), and
- an optional trailing `backend_meta` parameter on all five `at::from_blob`
  overloads.

```cpp
auto t = at::for_blob(ptr, sizes).options(opts)
             .backend_meta(c10::make_intrusive<MyMeta>(...)).make_tensor();

auto t2 = at::from_blob(ptr, sizes, strides, deleter, opts, device,
                        c10::make_intrusive<MyMeta>(...));
```

Internally this just calls the existing `set_backend_meta()` at construction
time, so it is zero-cost when unused (null default -> no `ExtraMeta` allocated,
byte-for-byte identical construction) and backward compatible (the `from_blob`
parameter is defaulted and trailing; the overloads are `inline`, so no ABI break).

Test Plan:
```
# core (aten)
python -m pip install -e . --no-build-isolation
build/bin/basic --gtest_filter='*BlobBackendMeta*'

# openreg reference PrivateUse1 backend
python test/run_test.py --openreg
```

`TestForBlobBackendMeta` / `TestFromBlobBackendMeta`: without a meta arg,
`get_backend_meta()` is `nullptr` (no `ExtraMeta` allocated); with one, the exact
meta is attached; the `from_blob` test also covers the backward-compatible
default. `openreg_backend_meta_tests` (run by `test_openreg`): with the real
`OpenRegBackendMeta`, attaching via the new path is equivalent to the post-hoc
`set_backend_meta()` that `for_deserialization` already uses.
