### PR TITLE
[Inductor] Fix ValueRangeError in Inductor for zero-iteration loops

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -7446,6 +7446,22 @@ class CPUReproTests(TestCase):
         )
         self.assertTrue(cuda_storage.has_exceeded_max_reads())
 
+    def test_fractional_max_pool2d_negative_kernel_issue_188226(self):
+        # https://github.com/pytorch/pytorch/issues/188226
+        # FractionalMaxPool2d with negative kernel_size creates zero-iteration
+        # reduction ranges that cause ValueRangeError in inductor's
+        # index propagation. The loop body never executes, so we should
+        # just skip constructing ValueRanges for such variables.
+        mod = torch.nn.FractionalMaxPool2d(
+            -60, output_size=(2, 2), return_indices=False
+        ).eval()
+        inp = torch.randn([2, 16, 5, 5])
+
+        def fn(x):
+            return mod(x)
+
+        self.common(fn, (inp,))
+
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests

--- a/torch/_inductor/bounds.py
+++ b/torch/_inductor/bounds.py
@@ -41,8 +41,9 @@ class BoundVars:
 
         self.loop_body = loop_body
         self.replacement_vals = {
-            k: ValueRanges[Expr](0, upper_bound(v) - 1)
+            k: ValueRanges[Expr](0, ub)
             for k, v in loop_body.var_ranges.items()
+            if (ub := upper_bound(v) - 1) >= 0
         }
         # avoid computing these values, pessimistically assume that they are unbounded
         self.unbounded_vars = dominated_nodes(

--- a/torch/_inductor/index_propagation.py
+++ b/torch/_inductor/index_propagation.py
@@ -339,8 +339,9 @@ class IndexPropagation(DefaultHandler):
         var_to_range = (
             *self.var_to_range,
             *(
-                (k, ValueRanges(0, upper_bound(v) - 1))
+                (k, ValueRanges(0, ub))
                 for k, v in self.indirect_var_ranges.items()
+                if (ub := upper_bound(v) - 1) >= 0
             ),
         )
         # pyrefly: ignore [bad-argument-type]

--- a/torch/_inductor/index_propagation.py
+++ b/torch/_inductor/index_propagation.py
@@ -222,7 +222,9 @@ class IndexPropagation(DefaultHandler):
         self.shape_env = V.graph.sizevars.shape_env
 
         var_to_range = {
-            k: ValueRanges(0, upper_bound(v) - 1) for k, v in iter_ranges.items()
+            k: ValueRanges(0, ub)
+            for k, v in iter_ranges.items()
+            if (ub := upper_bound(v) - 1) >= 0
         }
         self.var_to_range = tuple(
             itertools.chain(self.shape_env.var_to_range.items(), var_to_range.items())


### PR DESCRIPTION
Fixes #188226

When inductor encounters a reduction with zero iterations (e.g.,
`FractionalMaxPool2d` with output_size=-60, it causes reduction ranges
of `[-60, -60]`), and constructs a `ValueRanges(0, upper_bound(v) - 1)` object.

This produces an invalid range of `[0:-61]` since `upper_bound(v) - 1` is
negative, raising a `ValueRangeError`.

The pattern appeared in three locations:

- `IndexPropagation.__init__` — var_to_range for loop iteration
  variables
- `BoundVars.__init__` — replacement_vals for loop body var ranges
- `IndexPropagation.statically_true()` — var_to_range for indirect
  var ranges

Fix: skip entries where `upper_bound(v) - 1 < 0` using a walrus
operator guard. The loop body never executes in this case, so no
var_to_range entry is needed.

Test plan:
- Reproducer: `FractionalMaxPool2d(-60, ...)` with `torch.compile`
- Eager path passes, inductor compile now passes
- `pytest test/test_sympy_utils.py -x -q` — all passing
- `ruff check` clean on changed files

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo