### PR TITLE
Add DTensor sharding strategy for FFT c2c

### DIFF
--- a/test/distributed/tensor/test_dtensor_fft_ops.py
+++ b/test/distributed/tensor/test_dtensor_fft_ops.py
@@ -1,0 +1,37 @@
+# Owner(s): ["oncall: distributed"]
+
+import sys
+
+import torch
+
+from torch.distributed.tensor import Shard, distribute_tensor
+from torch.testing._internal.common_utils import TEST_WITH_DEV_DBG_ASAN, run_tests
+from torch.testing._internal.distributed._tensor.common_dtensor import (
+    DTensorTestBase,
+    create_local_tensor_test_class,
+    with_comms,
+)
+
+if TEST_WITH_DEV_DBG_ASAN:
+    print("Skip dev-asan", file=sys.stderr)
+    sys.exit(0)
+
+
+class TestDTensorFFTOps(DTensorTestBase):
+    @with_comms
+    def test_fft2_preserves_batch_shard(self):
+        mesh = self.build_device_mesh()
+
+        x = torch.randn(8, 4, 4, device=self.device_type, dtype=torch.cfloat)
+        dt = distribute_tensor(x, mesh, [Shard(0)])
+
+        out = torch.fft.fft2(dt, dim=(-2, -1))
+
+        self.assertEqual(out.placements, (Shard(0),))
+        self.assertEqual(out.full_tensor(), torch.fft.fft2(x, dim=(-2, -1)))
+
+
+instantiate_device_type_tests = create_local_tensor_test_class(TestDTensorFFTOps)
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/tensor/test_dtensor_fft_ops.py
+++ b/test/distributed/tensor/test_dtensor_fft_ops.py
@@ -3,14 +3,14 @@
 import sys
 
 import torch
-
-from torch.distributed.tensor import Shard, distribute_tensor
-from torch.testing._internal.common_utils import TEST_WITH_DEV_DBG_ASAN, run_tests
+from torch.distributed.tensor import distribute_tensor, Shard
+from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
 from torch.testing._internal.distributed._tensor.common_dtensor import (
-    DTensorTestBase,
     create_local_tensor_test_class,
+    DTensorTestBase,
     with_comms,
 )
+
 
 if TEST_WITH_DEV_DBG_ASAN:
     print("Skip dev-asan", file=sys.stderr)

--- a/torch/distributed/tensor/_ops/__init__.py
+++ b/torch/distributed/tensor/_ops/__init__.py
@@ -8,6 +8,7 @@ from ._random_ops import *  # noqa: F403
 from ._tensor_ops import *  # noqa: F403
 from ._view_ops import *  # noqa: F403
 from .autogen import auto_register_op_variants
+from ._fft_ops import *  # noqa: F403
 
 
 auto_register_op_variants()

--- a/torch/distributed/tensor/_ops/__init__.py
+++ b/torch/distributed/tensor/_ops/__init__.py
@@ -1,6 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 from ._conv_ops import *  # noqa: F403
 from ._embedding_ops import *  # noqa: F403
+from ._fft_ops import *  # noqa: F403
 from ._math_ops import *  # noqa: F403
 from ._matrix_ops import *  # noqa: F403
 from ._pointwise_ops import *  # noqa: F403
@@ -8,7 +9,6 @@ from ._random_ops import *  # noqa: F403
 from ._tensor_ops import *  # noqa: F403
 from ._view_ops import *  # noqa: F403
 from .autogen import auto_register_op_variants
-from ._fft_ops import *  # noqa: F403
 
 
 auto_register_op_variants()

--- a/torch/distributed/tensor/_ops/_fft_ops.py
+++ b/torch/distributed/tensor/_ops/_fft_ops.py
@@ -1,0 +1,45 @@
+# mypy: allow-untyped-defs
+# Copyright (c) Meta Platforms, Inc. and affiliates
+
+from typing import Any
+
+import torch
+
+from torch.distributed.tensor._dtensor_spec import TensorMeta
+from torch.distributed.tensor._ops.single_dim_strategy import (
+    _ShardingPlaceholder,
+    register_single_dim_strategy,
+)
+from torch.distributed.tensor._ops.utils import normalize_dims
+from torch.distributed.tensor.placement_types import Placement
+
+aten = torch.ops.aten
+
+
+@register_single_dim_strategy(
+    [aten._fft_c2c.default],
+    allow_uneven_sharding=True,
+    allow_unbacked_sharding=False,
+)
+def fft_c2c_single_dim_strategy(
+    _op: torch._ops.OpOverload,
+    args_schema: tuple[Any, ...],
+    _kwargs_schema: dict[str, Any],
+) -> list[list[Placement | _ShardingPlaceholder]]:
+    input_meta = args_schema[0]
+    if not isinstance(input_meta, TensorMeta):
+        raise AssertionError(f"Expected TensorMeta, got {type(input_meta)}")
+
+    ndim = len(input_meta.shape)
+
+    dims_arg = args_schema[1]
+    if not isinstance(dims_arg, (int, list, tuple)):
+        raise AssertionError(f"Expected int/list/tuple FFT dims, got {type(dims_arg)}")
+
+    fft_dims = set(normalize_dims(dims_arg, ndim))
+
+    return [
+        [_ShardingPlaceholder(d), _ShardingPlaceholder(d)]
+        for d in range(ndim)
+        if d not in fft_dims
+    ]

--- a/torch/distributed/tensor/_ops/_fft_ops.py
+++ b/torch/distributed/tensor/_ops/_fft_ops.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 # Copyright (c) Meta Platforms, Inc. and affiliates
 
-from typing import Any
+from typing import cast
 
 import torch
 from torch.distributed.tensor._dtensor_spec import TensorMeta
@@ -11,6 +11,7 @@ from torch.distributed.tensor._ops.single_dim_strategy import (
 )
 from torch.distributed.tensor._ops.utils import normalize_dims
 from torch.distributed.tensor.placement_types import Placement
+
 
 aten = torch.ops.aten
 
@@ -22,18 +23,13 @@ aten = torch.ops.aten
 )
 def fft_c2c_single_dim_strategy(
     _op: torch._ops.OpOverload,
-    args_schema: tuple[
-        TensorMeta,
-        int | list[int] | tuple[int, ...],
-        Any,
-        Any,
-    ],
-    _kwargs_schema: dict[str, Any],
+    args_schema: tuple[object, ...],
+    _kwargs_schema: dict[str, object],
 ) -> list[list[Placement | _ShardingPlaceholder]]:
-    input_meta = args_schema[0]
-    ndim = len(input_meta.shape)
+    input_meta = cast(TensorMeta, args_schema[0])
+    dims_arg = cast(int | list[int] | tuple[int, ...], args_schema[1])
 
-    dims_arg = args_schema[1]
+    ndim = len(input_meta.shape)
     fft_dims = set(normalize_dims(dims_arg, ndim))
 
     return [

--- a/torch/distributed/tensor/_ops/_fft_ops.py
+++ b/torch/distributed/tensor/_ops/_fft_ops.py
@@ -4,7 +4,6 @@
 from typing import Any
 
 import torch
-
 from torch.distributed.tensor._dtensor_spec import TensorMeta
 from torch.distributed.tensor._ops.single_dim_strategy import (
     _ShardingPlaceholder,
@@ -23,19 +22,18 @@ aten = torch.ops.aten
 )
 def fft_c2c_single_dim_strategy(
     _op: torch._ops.OpOverload,
-    args_schema: tuple[Any, ...],
+    args_schema: tuple[
+        TensorMeta,
+        int | list[int] | tuple[int, ...],
+        Any,
+        Any,
+    ],
     _kwargs_schema: dict[str, Any],
 ) -> list[list[Placement | _ShardingPlaceholder]]:
     input_meta = args_schema[0]
-    if not isinstance(input_meta, TensorMeta):
-        raise AssertionError(f"Expected TensorMeta, got {type(input_meta)}")
-
     ndim = len(input_meta.shape)
 
     dims_arg = args_schema[1]
-    if not isinstance(dims_arg, (int, list, tuple)):
-        raise AssertionError(f"Expected int/list/tuple FFT dims, got {type(dims_arg)}")
-
     fft_dims = set(normalize_dims(dims_arg, ndim))
 
     return [


### PR DESCRIPTION
## Summary

Fixes #188182

This PR adds a DTensor sharding strategy for `aten._fft_c2c.default`, which is the underlying operator used by complex FFT calls such as `torch.fft.fft2`. The strategy preserves sharding on dimensions that are not transformed by the FFT, and avoids sharding on the FFT dimensions themselves. This addresses the reported failure where `torch.fft.fft2(...)` on a DTensor errors with: Operator aten._fft_c2c.default does not have a sharding strategy registered. For an FFT over dimensions such as `dim=(-2, -1)`, the transformed dimensions need access to the full signal along those axes. Sharding those FFT dimensions would be unsafe without additional redistribution or collective logic.  

However, sharding a separate batch dimension is safe. For example, with an input shaped like:

```python
x.shape == (batch, height, width)
```

and:

```python
torch.fft.fft2(x, dim=(-2, -1))
```

Each batch shard can independently run the same 2D FFT over its local `height` and `width` data. The batch dimension is not part of the FFT transform, so the output can keep the same batch sharding. This PR adds that rule so sharding is preserved on non-FFT dimensions and sharding isnt allowed on FFT dimensions. The FFT operation already works on normal tensors so the issue isn't an FFT kernel problem. The failure happened because DTensor didn't know which sharding layouts are valid for `aten._fft_c2c.default`. This PR teaches DTensor that valid layout rule and adds the sharding strategy needed for DTensor propagation.

## Tests

```bash
python test/distributed/tensor/test_dtensor_fft_ops.py instantiate_device_type_tests.test_fft2_preserves_batch_shard -v
```

The local DTensor test passes and verifies that `torch.fft.fft2` preserves batch-dimension sharding while matching the regular dense FFT result.