### PR TITLE
[MPS] Fix BatchNorm channels_last backward crash

### DIFF
--- a/aten/src/ATen/native/mps/operations/Normalization.mm
+++ b/aten/src/ATen/native/mps/operations/Normalization.mm
@@ -872,7 +872,11 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_mps(const Tensor& grad_ou
       newCachedGraph->gradBiasTensor_ = gradBiasTensor;
     });
 
-    auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input, input_shape);
+    // For channels_last, input_shape is the NHWC-packed shape; feed the raw buffer directly instead of
+    // viewing the NCHW tensor to NHWC (which view() rejects). Mirrors the forward pass.
+    const auto needs_gather = memory_format != MemoryFormat::ChannelsLast;
+    auto inputPlaceholder =
+        Placeholder(cachedGraph->inputTensor_, input, input_shape, needs_gather, MPSDataTypeInvalid, needs_gather);
     auto gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_out, input_shape_readonly);
     auto weightPlaceholder = Placeholder();
     if (has_weight)
@@ -892,7 +896,8 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_mps(const Tensor& grad_ou
 
     auto gradInputPlaceholder = Placeholder();
     if (grad_input_mask[0])
-      gradInputPlaceholder = Placeholder(cachedGraph->gradInputTensor_, grad_input, input_shape);
+      gradInputPlaceholder =
+          Placeholder(cachedGraph->gradInputTensor_, grad_input, input_shape, false, MPSDataTypeInvalid, needs_gather);
     auto gradWeightPlaceholder = Placeholder();
     if (grad_input_mask[1])
       gradWeightPlaceholder = Placeholder(cachedGraph->gradWeightTensor_, grad_weight);

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4946,55 +4946,6 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         x_grad_ref = torch.where(mask, grad, z)
         self.assertEqual(x.grad, x_grad_ref)
 
-    def test_batchnorm_nhwc_cpu(self):
-        def helper(self, mod, size, dtype, mixed_dtype=False, format=torch.channels_last, precision=None):
-            channels = size[1]
-            input = torch.randn(size, dtype=dtype, device='cpu', requires_grad=True)
-            input = input.contiguous(memory_format=format).to(dtype)
-            input.retain_grad()
-            grad = torch.randn(size, dtype=dtype, device='cpu')
-            grad = grad.contiguous(memory_format=format)
-            bn = mod(channels).cpu().to(dtype)
-            bn.weight.data.uniform_()
-            bn.bias.data.uniform_()
-
-            ref_input = input.detach().clone().contiguous().requires_grad_(True)
-            ref_grad = grad.detach().clone().contiguous()
-            ref_bn = mod(channels).cpu().to(dtype)
-            ref_bn.load_state_dict(bn.state_dict())
-
-            if mixed_dtype:
-                bn.float()
-                ref_bn.float()
-
-            out = bn(input)
-            out.backward(grad)
-            ref_out = ref_bn(ref_input)
-            ref_out.backward(ref_grad)
-
-            self.assertTrue(out.is_contiguous(memory_format=format))
-            self.assertTrue(ref_out.is_contiguous())
-            self.assertEqual(out, ref_out)
-            self.assertEqual(bn.weight.grad, ref_bn.weight.grad, atol=precision, rtol=precision)
-            self.assertEqual(bn.bias.grad, ref_bn.bias.grad)
-            self.assertEqual(input.grad, ref_input.grad)
-
-        # test NC11 and N1HW; test mixed dtype
-        for shape in [(4, 8, 10, 10), (4, 1, 9, 9), (4, 9, 1, 1)]:
-            for dtype in [torch.float, torch.bfloat16, torch.float16]:
-                for mixed_dtype in [False, True]:
-                    if dtype == torch.float:
-                        mixed_dtype = False
-                    helper(self, nn.BatchNorm2d, shape, dtype, mixed_dtype, torch.channels_last)
-
-        precisons = {torch.float: 1e-4, torch.bfloat16: 1e-4, torch.float16: None}
-        for shape in [(4, 8, 2, 10, 10), (4, 1, 2, 9, 9), (4, 9, 1, 1, 1)]:
-            for dtype in [torch.float, torch.bfloat16, torch.float16]:
-                for mixed_dtype in [False, True]:
-                    if dtype == torch.float:
-                        mixed_dtype = False
-                    helper(self, nn.BatchNorm3d, shape, dtype, mixed_dtype, torch.channels_last_3d, precisons[dtype])
-
     def test_batchnorm_half_overflow(self):
         def helper(self, mod, size, param_dtype, fwd_format, bwd_format):
             channels = size[1]
@@ -9227,6 +9178,55 @@ class TestNNDeviceType(NNTestCase):
         bn = nn.BatchNorm2d(1).to(device, dtype)
         data = torch.rand(880801, 1, 1, 1, device=device, dtype=dtype)
         out = bn(data).sum().backward()
+
+    def test_batchnorm_nhwc(self, device):
+        def helper(self, mod, size, dtype, mixed_dtype=False, format=torch.channels_last, precision=None):
+            channels = size[1]
+            input = torch.randn(size, dtype=dtype, device=device, requires_grad=True)
+            input = input.contiguous(memory_format=format).to(dtype)
+            input.retain_grad()
+            grad = torch.randn(size, dtype=dtype, device=device)
+            grad = grad.contiguous(memory_format=format)
+            bn = mod(channels).to(device).to(dtype)
+            bn.weight.data.uniform_()
+            bn.bias.data.uniform_()
+
+            ref_input = input.detach().clone().contiguous().requires_grad_(True)
+            ref_grad = grad.detach().clone().contiguous()
+            ref_bn = mod(channels).to(device).to(dtype)
+            ref_bn.load_state_dict(bn.state_dict())
+
+            if mixed_dtype:
+                bn.float()
+                ref_bn.float()
+
+            out = bn(input)
+            out.backward(grad)
+            ref_out = ref_bn(ref_input)
+            ref_out.backward(ref_grad)
+
+            self.assertTrue(out.is_contiguous(memory_format=format))
+            self.assertTrue(ref_out.is_contiguous())
+            self.assertEqual(out, ref_out)
+            self.assertEqual(bn.weight.grad, ref_bn.weight.grad, atol=precision, rtol=precision)
+            self.assertEqual(bn.bias.grad, ref_bn.bias.grad)
+            self.assertEqual(input.grad, ref_input.grad)
+
+        # test NC11 and N1HW; test mixed dtype
+        for shape in [(4, 8, 10, 10), (4, 1, 9, 9), (4, 9, 1, 1)]:
+            for dtype in [torch.float, torch.bfloat16, torch.float16]:
+                for mixed_dtype in [False, True]:
+                    if dtype == torch.float:
+                        mixed_dtype = False
+                    helper(self, nn.BatchNorm2d, shape, dtype, mixed_dtype, torch.channels_last)
+
+        precisons = {torch.float: 1e-4, torch.bfloat16: 1e-4, torch.float16: None}
+        for shape in [(4, 8, 2, 10, 10), (4, 1, 2, 9, 9), (4, 9, 1, 1, 1)]:
+            for dtype in [torch.float, torch.bfloat16, torch.float16]:
+                for mixed_dtype in [False, True]:
+                    if dtype == torch.float:
+                        mixed_dtype = False
+                    helper(self, nn.BatchNorm3d, shape, dtype, mixed_dtype, torch.channels_last_3d, precisons[dtype])
 
     @dtypesIfCUDA(torch.float, torch.double, torch.half, torch.complex128)
     @dtypesIfMPS(torch.float, torch.half, torch.complex64)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4946,6 +4946,55 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         x_grad_ref = torch.where(mask, grad, z)
         self.assertEqual(x.grad, x_grad_ref)
 
+    def test_batchnorm_nhwc_cpu(self):
+        def helper(self, mod, size, dtype, mixed_dtype=False, format=torch.channels_last, precision=None):
+            channels = size[1]
+            input = torch.randn(size, dtype=dtype, device='cpu', requires_grad=True)
+            input = input.contiguous(memory_format=format).to(dtype)
+            input.retain_grad()
+            grad = torch.randn(size, dtype=dtype, device='cpu')
+            grad = grad.contiguous(memory_format=format)
+            bn = mod(channels).cpu().to(dtype)
+            bn.weight.data.uniform_()
+            bn.bias.data.uniform_()
+
+            ref_input = input.detach().clone().contiguous().requires_grad_(True)
+            ref_grad = grad.detach().clone().contiguous()
+            ref_bn = mod(channels).cpu().to(dtype)
+            ref_bn.load_state_dict(bn.state_dict())
+
+            if mixed_dtype:
+                bn.float()
+                ref_bn.float()
+
+            out = bn(input)
+            out.backward(grad)
+            ref_out = ref_bn(ref_input)
+            ref_out.backward(ref_grad)
+
+            self.assertTrue(out.is_contiguous(memory_format=format))
+            self.assertTrue(ref_out.is_contiguous())
+            self.assertEqual(out, ref_out)
+            self.assertEqual(bn.weight.grad, ref_bn.weight.grad, atol=precision, rtol=precision)
+            self.assertEqual(bn.bias.grad, ref_bn.bias.grad)
+            self.assertEqual(input.grad, ref_input.grad)
+
+        # test NC11 and N1HW; test mixed dtype
+        for shape in [(4, 8, 10, 10), (4, 1, 9, 9), (4, 9, 1, 1)]:
+            for dtype in [torch.float, torch.bfloat16, torch.float16]:
+                for mixed_dtype in [False, True]:
+                    if dtype == torch.float:
+                        mixed_dtype = False
+                    helper(self, nn.BatchNorm2d, shape, dtype, mixed_dtype, torch.channels_last)
+
+        precisons = {torch.float: 1e-4, torch.bfloat16: 1e-4, torch.float16: None}
+        for shape in [(4, 8, 2, 10, 10), (4, 1, 2, 9, 9), (4, 9, 1, 1, 1)]:
+            for dtype in [torch.float, torch.bfloat16, torch.float16]:
+                for mixed_dtype in [False, True]:
+                    if dtype == torch.float:
+                        mixed_dtype = False
+                    helper(self, nn.BatchNorm3d, shape, dtype, mixed_dtype, torch.channels_last_3d, precisons[dtype])
+
     def test_batchnorm_half_overflow(self):
         def helper(self, mod, size, param_dtype, fwd_format, bwd_format):
             channels = size[1]
@@ -9178,55 +9227,6 @@ class TestNNDeviceType(NNTestCase):
         bn = nn.BatchNorm2d(1).to(device, dtype)
         data = torch.rand(880801, 1, 1, 1, device=device, dtype=dtype)
         out = bn(data).sum().backward()
-
-    def test_batchnorm_nhwc(self, device):
-        def helper(self, mod, size, dtype, mixed_dtype=False, format=torch.channels_last, precision=None):
-            channels = size[1]
-            input = torch.randn(size, dtype=dtype, device=device, requires_grad=True)
-            input = input.contiguous(memory_format=format).to(dtype)
-            input.retain_grad()
-            grad = torch.randn(size, dtype=dtype, device=device)
-            grad = grad.contiguous(memory_format=format)
-            bn = mod(channels).to(device).to(dtype)
-            bn.weight.data.uniform_()
-            bn.bias.data.uniform_()
-
-            ref_input = input.detach().clone().contiguous().requires_grad_(True)
-            ref_grad = grad.detach().clone().contiguous()
-            ref_bn = mod(channels).to(device).to(dtype)
-            ref_bn.load_state_dict(bn.state_dict())
-
-            if mixed_dtype:
-                bn.float()
-                ref_bn.float()
-
-            out = bn(input)
-            out.backward(grad)
-            ref_out = ref_bn(ref_input)
-            ref_out.backward(ref_grad)
-
-            self.assertTrue(out.is_contiguous(memory_format=format))
-            self.assertTrue(ref_out.is_contiguous())
-            self.assertEqual(out, ref_out)
-            self.assertEqual(bn.weight.grad, ref_bn.weight.grad, atol=precision, rtol=precision)
-            self.assertEqual(bn.bias.grad, ref_bn.bias.grad)
-            self.assertEqual(input.grad, ref_input.grad)
-
-        # test NC11 and N1HW; test mixed dtype
-        for shape in [(4, 8, 10, 10), (4, 1, 9, 9), (4, 9, 1, 1)]:
-            for dtype in [torch.float, torch.bfloat16, torch.float16]:
-                for mixed_dtype in [False, True]:
-                    if dtype == torch.float:
-                        mixed_dtype = False
-                    helper(self, nn.BatchNorm2d, shape, dtype, mixed_dtype, torch.channels_last)
-
-        precisons = {torch.float: 1e-4, torch.bfloat16: 1e-4, torch.float16: None}
-        for shape in [(4, 8, 2, 10, 10), (4, 1, 2, 9, 9), (4, 9, 1, 1, 1)]:
-            for dtype in [torch.float, torch.bfloat16, torch.float16]:
-                for mixed_dtype in [False, True]:
-                    if dtype == torch.float:
-                        mixed_dtype = False
-                    helper(self, nn.BatchNorm3d, shape, dtype, mixed_dtype, torch.channels_last_3d, precisons[dtype])
 
     @dtypesIfCUDA(torch.float, torch.double, torch.half, torch.complex128)
     @dtypesIfMPS(torch.float, torch.half, torch.complex64)

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -4229,8 +4229,6 @@ module_db: list[ModuleInfo] = [
                module_inputs_func=module_inputs_torch_nn_BatchNorm2d,
                module_error_inputs_func=module_error_inputs_torch_nn_BatchNorm1d_2d_3d,
                skips=(
-                   # See https://github.com/pytorch/pytorch/issues/134580
-                   DecorateInfo(expectedFailureMPS, 'TestModule', 'test_memory_format', active_if=operator.itemgetter('training')),
                    # tracking here rather than in the list in test_aotdispatch.py as eval mode passes
                    # RuntimeError: tried to get Double out of SymInt
                    DecorateInfo(


### PR DESCRIPTION
This currently fails on main:
```
import torch
import torch.nn as nn

torch.manual_seed(0)

N, C, H, W = 4, 8, 16, 16

x = torch.randn(N, C, H, W).to(memory_format=torch.channels_last)
bn = nn.BatchNorm2d(C)

# CPU
xc = x.clone().requires_grad_()
bnc = bn
yc = bnc(xc)
yc.sum().backward()

# MPS
xm = x.clone().to("mps").requires_grad_()
bnm = nn.BatchNorm2d(C).to("mps")
bnm.load_state_dict(bn.state_dict())
ym = bnm(xm)
ym.sum().backward()

print("grad max abs diff:", (xc.grad - xm.grad.cpu()).abs().max().item())
```
with:
```
RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.
```

PR fixes it and moves the test which was CPU specific to device type tests so it gets tested on CUDA/MPS as well