### PR TITLE
Enforce 1D tensor validation for batch_norm parameters

### DIFF
--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -87,9 +87,11 @@ DEFINE_DISPATCH(batch_norm_cpu_backward_stub);
 DEFINE_DISPATCH(renorm_scale_factor_stub);
 
 namespace {
-  void check_dims_match_num_input_features(const char* arg_name, const SymInt& expected, const SymInt& actual){
-    TORCH_CHECK(actual == expected,
-             arg_name, " should contain ", expected, " elements not ", actual);
+  void check_dims_match_num_input_features(const char* arg_name, const SymInt& expected, const Tensor& tensor){
+    TORCH_CHECK(tensor.dim() == 1,
+             arg_name, " should be a 1D tensor, but got a tensor with ", tensor.dim(), " dims");
+    TORCH_CHECK(tensor.sym_numel() == expected,
+             arg_name, " should contain ", expected, " elements not ", tensor.sym_numel());
   }
 
   inline Tensor repeat_if_defined(const Tensor& t, const SymInt& repeat) {
@@ -590,20 +592,20 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, int64_t> _batch_norm_impl_index(
   }
 
   if (running_mean.defined()) {
-    check_dims_match_num_input_features("running_mean", num_features, running_mean.sym_numel());
+    check_dims_match_num_input_features("running_mean", num_features, running_mean);
   } else if (!training) {
     TORCH_CHECK(false, "running_mean must be defined in evaluation mode");
   }
   if (running_var.defined()) {
-    check_dims_match_num_input_features("running_var", num_features, running_var.sym_numel());
+    check_dims_match_num_input_features("running_var", num_features, running_var);
   } else if (!training) {
     TORCH_CHECK(false, "running_var must be defined in evaluation mode");
   }
   if (weight.defined()) {
-    check_dims_match_num_input_features("weight", num_features, weight.sym_numel());
+    check_dims_match_num_input_features("weight", num_features, weight);
   }
   if (bias.defined()) {
-    check_dims_match_num_input_features("bias", std::move(num_features), bias.sym_numel());
+    check_dims_match_num_input_features("bias", std::move(num_features), bias);
   }
 
   BatchNormBackend backend = _select_batch_norm_backend(input, weight, bias, running_mean, running_var, training, eps);


### PR DESCRIPTION
Fixes #188358

## Description
This PR addresses an inconsistency where `F.batch_norm` would silently succeed in eager mode when provided with multidimensional (e.g., 2D/3D) tensors for `bias`, `weight`, `running_mean`, or `running_var`, but would subsequently crash with a `RuntimeError` deep in the native ATen kernels or during tracing with `torch.compile(backend="aot_eager")`. 

The root cause was that eager mode only verified the total number of elements (`sym_numel()`) without verifying the tensor rank, allowing mathematically invalid multidimensional tensors to pass through until they hit `TensorAccessor` which strictly expects 1D.

**Changes:**
- Updated `check_dims_match_num_input_features` in `aten/src/ATen/native/Normalization.cpp` to accept `const Tensor&` instead of just `sym_numel()`.
- Added a strict `tensor.dim() == 1` validation check before verifying the element count.
- Updated caller sites in `_batch_norm_impl_index` to pass the tensor object.

**Results:**
Eager mode now explicitly rejects improperly shaped tensors upfront with a clear error:
`RuntimeError: bias should be a 1D tensor, but got a tensor with 3 dims`. 
This behavior is now fully consistent with `torch.compile`, which safely catches the exact same shape mismatch during graph tracing.

## Testing
- Verified manually using the reproduction script provided in the issue.
- Designed and ran an extensive stress test across 42 edge cases (including valid 3D/4D/5D inputs, non-contiguous 1D views, training/eval modes, dtypes, and various invalid shapes). 
- Confirmed 100% consistent behavior (both successes and failures) between Eager mode and `torch.compile(backend="aot_eager")`.
<details>
<summary><b>Click to expand the 42-case Stress Test Script used for verification</b></summary>

```python
"""
Stress-test edge cases for the batch_norm 1D dimension validation fix.
Tests consistency between eager and torch.compile(backend='aot_eager').
"""
import traceback
import torch
import torch.nn.functional as F

device = "cuda" if torch.cuda.is_available() else "cpu"

# ---------------------------------------------------------------------------
#  Helpers
# ---------------------------------------------------------------------------
def _run_eager(fn, *args, **kwargs):
    try:
        out = fn(*args, **kwargs)
        return True, out.shape, None
    except Exception as e:
        return False, None, type(e).__name__

def _run_compiled(fn, *args, **kwargs):
    try:
        out = fn(*args, **kwargs)
        return True, out.shape, None
    except Exception as e:
        return False, None, type(e).__name__

def check(name, eager_result, compiled_result):
    e_ok, e_shape, e_err = eager_result
    c_ok, c_shape, c_err = compiled_result

    consistent = (e_ok == c_ok)
    if e_ok and c_ok:
        consistent = consistent and (e_shape == c_shape)

    status = "[PASS]" if consistent else "[FAIL]"
    detail = ""
    if e_ok and c_ok:
        detail = f"both OK  shape={e_shape}"
    elif not e_ok and not c_ok:
        detail = f"both ERR eager={e_err} compiled={c_err}"
    else:
        detail = (f"MISMATCH eager={'OK' if e_ok else e_err} "
                  f"compiled={'OK' if c_ok else c_err}")
    print(f"  {status} {name:.<60s} {detail}")
    return consistent


# ---------------------------------------------------------------------------
#  Test runner
# ---------------------------------------------------------------------------
def stress_test():
    results = []
    C = 16  # small channel count for speed

    # Base valid tensors
    def make(shape, **kw):
        return torch.randn(shape, device=device, dtype=kw.get("dtype", torch.float32))

    def zeros(shape, **kw):
        return torch.zeros(shape, device=device, dtype=kw.get("dtype", torch.float32))

    def ones(shape, **kw):
        return torch.ones(shape, device=device, dtype=kw.get("dtype", torch.float32))

    # -----------------------------------------------------------------------
    #  GROUP 1: Valid inputs that MUST succeed
    # -----------------------------------------------------------------------
    print("\n=== GROUP 1: Valid inputs (should succeed) ===")

    valid_cases = [
        ("4D input (BatchNorm2d)",        make((2, C, 4, 4)),  zeros(C), ones(C), ones(C), zeros(C)),
        ("3D input (BatchNorm1d)",         make((2, C, 8)),     zeros(C), ones(C), ones(C), zeros(C)),
        ("5D input (BatchNorm3d)",         make((2, C, 2, 2, 2)), zeros(C), ones(C), ones(C), zeros(C)),
        ("None weight, None bias",         make((2, C, 4, 4)),  zeros(C), ones(C), None,    None),
        ("None weight only",               make((2, C, 4, 4)),  zeros(C), ones(C), None,    zeros(C)),
        ("None bias only",                 make((2, C, 4, 4)),  zeros(C), ones(C), ones(C), None),
        ("C=1 single channel",             make((2, 1, 4, 4)),  zeros(1), ones(1), ones(1), zeros(1)),
        ("Large C=512",                    make((1, 512, 2, 2)), zeros(512), ones(512), ones(512), zeros(512)),
        ("Non-contiguous 1D weight (view of 2D)", 
         make((2, C, 4, 4)), zeros(C), ones(C),
         torch.ones(C, 2, device=device)[:, 0],   # 1D view of a 2D tensor
         zeros(C)),
        ("Non-contiguous 1D bias (stride != 1)",
         make((2, C, 4, 4)), zeros(C), ones(C), ones(C),
         torch.zeros(C * 2, device=device)[::2]),  # 1D but stride=2
    ]

    for name, x, rm, rv, w, b in valid_cases:
        def fn(x, rm, rv, w, b):
            return F.batch_norm(x, rm, rv, weight=w, bias=b, training=False)
        compiled = torch.compile(fn, backend="aot_eager")
        e = _run_eager(fn, x, rm, rv, w, b)
        c = _run_compiled(compiled, x, rm, rv, w, b)
        results.append(check(name, e, c))

    # -----------------------------------------------------------------------
    #  GROUP 2: Invalid dimension shapes (should fail consistently)
    # -----------------------------------------------------------------------
    print("\n=== GROUP 2: Invalid dimension shapes (should fail) ===")

    x = make((2, C, 4, 4))
    rm_ok, rv_ok, w_ok, b_ok = zeros(C), ones(C), ones(C), zeros(C)

    invalid_dim_cases = [
        ("2D bias (numel matches C)",       x, rm_ok, rv_ok, w_ok, zeros((4, 4))),
        ("3D bias (original bug report)",   x, rm_ok, rv_ok, w_ok, zeros((2, 4, 2))),
        ("4D bias",                         x, rm_ok, rv_ok, w_ok, zeros((2, 2, 2, 2))),
        ("0D scalar bias",                  x, rm_ok, rv_ok, w_ok, torch.tensor(0.0, device=device)),
        ("2D weight (numel matches C)",     x, rm_ok, rv_ok, ones((4, 4)), b_ok),
        ("3D weight",                       x, rm_ok, rv_ok, ones((2, 2, 4)), b_ok),
        ("0D scalar weight",               x, rm_ok, rv_ok, torch.tensor(1.0, device=device), b_ok),
        ("2D running_mean",                 x, zeros((4, 4)), rv_ok, w_ok, b_ok),
        ("3D running_mean",                 x, zeros((2, 2, 4)), rv_ok, w_ok, b_ok),
        ("2D running_var",                  x, rm_ok, ones((4, 4)), w_ok, b_ok),
        ("4D running_var",                  x, rm_ok, ones((2, 2, 2, 2)), w_ok, b_ok),
        ("All params 2D",                  x, zeros((4,4)), ones((4,4)), ones((4,4)), zeros((4,4))),
        ("bias shape (1, C) - 2D",         x, rm_ok, rv_ok, w_ok, zeros((1, C))),
        ("weight shape (C, 1) - 2D",       x, rm_ok, rv_ok, ones((C, 1)), b_ok),
    ]

    for name, x_, rm_, rv_, w_, b_ in invalid_dim_cases:
        def fn(x, rm, rv, w, b):
            return F.batch_norm(x, rm, rv, weight=w, bias=b, training=False)
        compiled = torch.compile(fn, backend="aot_eager")
        e = _run_eager(fn, x_, rm_, rv_, w_, b_)
        c = _run_compiled(compiled, x_, rm_, rv_, w_, b_)
        results.append(check(name, e, c))

    # -----------------------------------------------------------------------
    #  GROUP 3: Size mismatches (1D but wrong numel)
    # -----------------------------------------------------------------------
    print("\n=== GROUP 3: 1D but wrong element count ===")

    size_mismatch_cases = [
        ("bias has C-1 elements",           x, rm_ok, rv_ok, w_ok, zeros(C - 1)),
        ("bias has C+1 elements",           x, rm_ok, rv_ok, w_ok, zeros(C + 1)),
        ("bias has 1 element",              x, rm_ok, rv_ok, w_ok, zeros(1)),
        ("weight has C*2 elements",         x, rm_ok, rv_ok, ones(C * 2), b_ok),
        ("running_mean has 1 element",      x, zeros(1), rv_ok, w_ok, b_ok),
        ("running_var has C+10 elements",   x, rm_ok, ones(C + 10), w_ok, b_ok),
    ]

    for name, x_, rm_, rv_, w_, b_ in size_mismatch_cases:
        def fn(x, rm, rv, w, b):
            return F.batch_norm(x, rm, rv, weight=w, bias=b, training=False)
        compiled = torch.compile(fn, backend="aot_eager")
        e = _run_eager(fn, x_, rm_, rv_, w_, b_)
        c = _run_compiled(compiled, x_, rm_, rv_, w_, b_)
        results.append(check(name, e, c))

    # -----------------------------------------------------------------------
    #  GROUP 4: Dtype edge cases (valid shapes)
    # -----------------------------------------------------------------------
    print("\n=== GROUP 4: Dtype edge cases ===")

    dtype_cases = [
        ("float64 all params",
         make((2, C, 4, 4), dtype=torch.float64),
         zeros(C, dtype=torch.float64), ones(C, dtype=torch.float64),
         ones(C, dtype=torch.float64), zeros(C, dtype=torch.float64)),
        ("float16 all params",
         make((2, C, 4, 4), dtype=torch.float16),
         zeros(C, dtype=torch.float16), ones(C, dtype=torch.float16),
         ones(C, dtype=torch.float16), zeros(C, dtype=torch.float16)),
    ]

    for name, x_, rm_, rv_, w_, b_ in dtype_cases:
        def fn(x, rm, rv, w, b):
            return F.batch_norm(x, rm, rv, weight=w, bias=b, training=False)
        compiled = torch.compile(fn, backend="aot_eager")
        e = _run_eager(fn, x_, rm_, rv_, w_, b_)
        c = _run_compiled(compiled, x_, rm_, rv_, w_, b_)
        results.append(check(name, e, c))

    # -----------------------------------------------------------------------
    #  GROUP 5: Training mode edge cases
    # -----------------------------------------------------------------------
    print("\n=== GROUP 5: Training mode ===")

    training_cases = [
        ("training=True, valid params",
         make((2, C, 4, 4)), zeros(C), ones(C), ones(C), zeros(C), True),
        ("training=True, 2D bias (invalid)",
         make((2, C, 4, 4)), zeros(C), ones(C), ones(C), zeros((4, 4)), True),
        ("training=True, 3D weight (invalid)",
         make((2, C, 4, 4)), zeros(C), ones(C), ones((2, 2, 4)), zeros(C), True),
    ]

    for name, x_, rm_, rv_, w_, b_, tr in training_cases:
        def fn(x, rm, rv, w, b):
            return F.batch_norm(x, rm, rv, weight=w, bias=b, training=tr)
        compiled = torch.compile(fn, backend="aot_eager")
        e = _run_eager(fn, x_, rm_, rv_, w_, b_)
        c = _run_compiled(compiled, x_, rm_, rv_, w_, b_)
        results.append(check(name, e, c))

    # -----------------------------------------------------------------------
    #  GROUP 6: Empty / degenerate tensors
    # -----------------------------------------------------------------------
    print("\n=== GROUP 6: Empty and degenerate tensors ===")

    empty_cases = [
        ("Empty input batch (N=0)",
         torch.randn(0, C, 4, 4, device=device), zeros(C), ones(C), ones(C), zeros(C)),
        ("Empty spatial dims (H=0, W=0)",
         torch.randn(2, C, 0, 0, device=device), zeros(C), ones(C), ones(C), zeros(C)),
        ("C=0 everything empty",
         torch.randn(2, 0, 4, 4, device=device), zeros(0), ones(0), ones(0), zeros(0)),
        ("Empty 1D bias (C=0)",
         torch.randn(2, 0, 4, 4, device=device), zeros(0), ones(0), ones(0), zeros(0)),
    ]

    for name, x_, rm_, rv_, w_, b_ in empty_cases:
        def fn(x, rm, rv, w, b):
            return F.batch_norm(x, rm, rv, weight=w, bias=b, training=False)
        compiled = torch.compile(fn, backend="aot_eager")
        e = _run_eager(fn, x_, rm_, rv_, w_, b_)
        c = _run_compiled(compiled, x_, rm_, rv_, w_, b_)
        results.append(check(name, e, c))

    # -----------------------------------------------------------------------
    #  GROUP 7: Gradient-carrying parameters
    # -----------------------------------------------------------------------
    print("\n=== GROUP 7: Parameters with requires_grad ===")

    grad_cases = [
        ("weight requires_grad, valid",
         make((2, C, 4, 4)), zeros(C), ones(C),
         torch.ones(C, device=device, requires_grad=True), zeros(C)),
        ("bias requires_grad, valid",
         make((2, C, 4, 4)), zeros(C), ones(C), ones(C),
         torch.zeros(C, device=device, requires_grad=True)),
        ("2D weight requires_grad (invalid dim)",
         make((2, C, 4, 4)), zeros(C), ones(C),
         torch.ones(4, 4, device=device, requires_grad=True), zeros(C)),
    ]

    for name, x_, rm_, rv_, w_, b_ in grad_cases:
        def fn(x, rm, rv, w, b):
            return F.batch_norm(x, rm, rv, weight=w, bias=b, training=False)
        compiled = torch.compile(fn, backend="aot_eager")
        e = _run_eager(fn, x_, rm_, rv_, w_, b_)
        c = _run_compiled(compiled, x_, rm_, rv_, w_, b_)
        results.append(check(name, e, c))

    # -----------------------------------------------------------------------
    #  Summary
    # -----------------------------------------------------------------------
    total = len(results)
    passed = sum(results)
    failed = total - passed
    print(f"\n{'='*70}")
    print(f"  TOTAL: {total}  |  PASSED: {passed}  |  FAILED: {failed}")
    print(f"{'='*70}")
    if failed == 0:
        print("  ALL EDGE CASES CONSISTENT BETWEEN EAGER AND COMPILED")
    else:
        print("  INCONSISTENCIES DETECTED -- see [FAIL] entries above")


if __name__ == "__main__":
    stress_test()
 
" The root-cause investigation and stress-testing scripts for this PR were developed with AI assistance."