### PR TITLE
Fix linspace/logspace docstrings: start/end are Number, not float

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -5946,8 +5946,8 @@ spaced from :attr:`start` to :attr:`end`, inclusive. That is, the value are:
 From PyTorch 1.11 linspace requires the steps argument. Use steps=100 to restore the previous behavior.
 
 Args:
-    start (float or Tensor): the starting value for the set of points. If `Tensor`, it must be 0-dimensional
-    end (float or Tensor): the ending value for the set of points. If `Tensor`, it must be 0-dimensional
+    start (Number or Tensor): the starting value for the set of points. If `Tensor`, it must be 0-dimensional
+    end (Number or Tensor): the ending value for the set of points. If `Tensor`, it must be 0-dimensional
     steps (int): size of the constructed tensor
 
 Keyword arguments:
@@ -6308,8 +6308,8 @@ with base :attr:`base`. That is, the values are:
 From PyTorch 1.11 logspace requires the steps argument. Use steps=100 to restore the previous behavior.
 
 Args:
-    start (float or Tensor): the starting value for the set of points. If `Tensor`, it must be 0-dimensional
-    end (float or Tensor): the ending value for the set of points. If `Tensor`, it must be 0-dimensional
+    start (Number or Tensor): the starting value for the set of points. If `Tensor`, it must be 0-dimensional
+    end (Number or Tensor): the ending value for the set of points. If `Tensor`, it must be 0-dimensional
     steps (int): size of the constructed tensor
     base (float, optional): base of the logarithm function. Default: ``10.0``.
 


### PR DESCRIPTION
Fixes #129338. Also covers `torch.logspace` (#130254), which has the identical wording.

`torch.linspace` and `torch.logspace` document `start` and `end` as `float or Tensor`:

```
start (float or Tensor): the starting value for the set of points. ...
end (float or Tensor): the ending value for the set of points. ...
```

But this is narrower than what the functions accept and is inconsistent with the same docstring's own dtype note, which already contemplates complex inputs:

```
... and corresponding complex dtype when either is complex.
```

`int` and `bool` work too (`bool` is a subclass of `int`, `int`/`float`/`complex` are all `numbers.Number`). The sibling factory `torch.arange` already documents `start`/`end`/`step` as `Number`.

This aligns the `start`/`end` type label with `Number or Tensor`, matching `arange` and the functions' own complex-aware dtype note. Docstring-only, `+4/-4`, no runtime change. (Scoped to `start`/`end`; `logspace`'s `base` is left unchanged.)
