### PR TITLE
docs: fix broken gpu_direct_storage tutorial URL in serialization notes

### DIFF
--- a/docs/source/notes/serialization.rst
+++ b/docs/source/notes/serialization.rst
@@ -251,7 +251,7 @@ the checkpoint, enabling direct checkpoint manipulation.
       # offset of the storage in the checkpoint
       print(f"key={k}, checkpoint_offset={v.untyped_storage()._checkpoint_offset}")
 
-For more information, `this tutorial <https://docs.pytorch.org/tutorials/prototype/gpu_direct_storage.html>`_
+For more information, `this tutorial <https://docs.pytorch.org/tutorials/unstable/gpu_direct_storage.html>`_
 offers a comprehensive example of using these features to manipulate a checkpoint.
 
 


### PR DESCRIPTION
## Summary

Fixes #188245

The `prototype` path for the GPU Direct Storage tutorial was removed; the tutorial now lives under `unstable`. This PR updates the link in `docs/source/notes/serialization.rst` so the Layout Control section no longer points to a 404.

- Old URL (broken): `https://docs.pytorch.org/tutorials/prototype/gpu_direct_storage.html`
- New URL (working): `https://docs.pytorch.org/tutorials/unstable/gpu_direct_storage.html`

Note: the equivalent fix on `main` already went in as part of the rST → MyST Markdown conversion (#182905), which rewrote the file to `serialization.md` using the `unstable` path.

## Test plan

- [ ] Manually verified the new URL returns HTTP 200 and renders the expected tutorial content.

