### PR TITLE
aten: add output_size kwarg to masked_select for meta/eager shape oracle support

### DIFF
--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -2602,13 +2602,37 @@ static Tensor& masked_select_out_impl_cpu(
 Tensor& masked_select_out_cpu(
     const Tensor& self,
     const Tensor& mask,
+    std::optional<c10::SymInt> output_size,
     Tensor& result) {
-  return masked_select_out_impl_cpu(result, self, mask);
+  masked_select_out_impl_cpu(result, self, mask);
+  if (output_size.has_value()) {
+    TORCH_CHECK(
+        output_size.value().expect_int() == result.numel(),
+        "masked_select: output_size=",
+        output_size.value(),
+        " does not match the number of selected elements (",
+        result.numel(),
+        ")");
+  }
+  return result;
 }
 
-Tensor masked_select_cpu(const Tensor& self, const Tensor& mask) {
+Tensor masked_select_cpu(
+    const Tensor& self,
+    const Tensor& mask,
+    std::optional<c10::SymInt> output_size) {
   Tensor result = at::empty({0}, self.options());
-  return at::native::masked_select_out_cpu(self, mask, result);
+  at::native::masked_select_out_cpu(self, mask, result);
+  if (output_size.has_value()) {
+    TORCH_CHECK(
+        output_size.value().expect_int() == result.numel(),
+        "masked_select: output_size=",
+        output_size.value(),
+        " does not match the number of selected elements (",
+        result.numel(),
+        ")");
+  }
+  return result;
 }
 
 Tensor masked_select_backward(

--- a/aten/src/ATen/native/cuda/IndexKernel.cpp
+++ b/aten/src/ATen/native/cuda/IndexKernel.cpp
@@ -45,13 +45,33 @@ static Tensor & masked_select_out_cuda_impl(Tensor & result, const Tensor & self
   return result;
 }
 
-Tensor masked_select_cuda(const Tensor & self, const Tensor & mask) {
+Tensor masked_select_cuda(const Tensor & self, const Tensor & mask, std::optional<c10::SymInt> output_size) {
   Tensor result = at::empty({0}, self.options());
-  return masked_select_out_cuda_impl(result, self, mask);
+  masked_select_out_cuda_impl(result, self, mask);
+  if (output_size.has_value()) {
+    TORCH_CHECK(
+        output_size.value().expect_int() == result.numel(),
+        "masked_select: output_size=",
+        output_size.value(),
+        " does not match the number of selected elements (",
+        result.numel(),
+        ")");
+  }
+  return result;
 }
 
-Tensor & masked_select_out_cuda(const Tensor & self, const Tensor & mask, Tensor & result) {
-  return masked_select_out_cuda_impl(result, self, mask);
+Tensor & masked_select_out_cuda(const Tensor & self, const Tensor & mask, std::optional<c10::SymInt> output_size, Tensor & result) {
+  masked_select_out_cuda_impl(result, self, mask);
+  if (output_size.has_value()) {
+    TORCH_CHECK(
+        output_size.value().expect_int() == result.numel(),
+        "masked_select: output_size=",
+        output_size.value(),
+        " does not match the number of selected elements (",
+        result.numel(),
+        ")");
+  }
+  return result;
 }
 
 Tensor & masked_scatter__cuda(Tensor& self, const Tensor& mask, const Tensor& source) {

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -474,13 +474,33 @@ Tensor nonzero_static_mps(const Tensor& self, int64_t size, int64_t fill_value) 
   return result;
 }
 
-Tensor masked_select_mps(const Tensor& self, const Tensor& mask) {
+Tensor masked_select_mps(const Tensor& self, const Tensor& mask, std::optional<c10::SymInt> output_size) {
   Tensor result = at::empty({0}, self.options());
-  return mps::masked_select_out_mps_impl(result, self, mask);
+  mps::masked_select_out_mps_impl(result, self, mask);
+  if (output_size.has_value()) {
+    TORCH_CHECK(
+        output_size.value().expect_int() == result.numel(),
+        "masked_select: output_size=",
+        output_size.value(),
+        " does not match the number of selected elements (",
+        result.numel(),
+        ")");
+  }
+  return result;
 }
 
-Tensor& masked_select_out_mps(const Tensor& self, const Tensor& mask, Tensor& result) {
-  return mps::masked_select_out_mps_impl(result, self, mask);
+Tensor& masked_select_out_mps(const Tensor& self, const Tensor& mask, std::optional<c10::SymInt> output_size, Tensor& result) {
+  mps::masked_select_out_mps_impl(result, self, mask);
+  if (output_size.has_value()) {
+    TORCH_CHECK(
+        output_size.value().expect_int() == result.numel(),
+        "masked_select: output_size=",
+        output_size.value(),
+        " does not match the number of selected elements (",
+        result.numel(),
+        ")");
+  }
+  return result;
 }
 
 Tensor flip_mps(const Tensor& self, IntArrayRef dims) {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -9284,7 +9284,7 @@
   dispatch:
     CompositeImplicitAutograd: index_select_backward_symint
 
-- func: masked_select.out(Tensor self, Tensor mask, *, Tensor(a!) out) -> Tensor(a!)
+- func: masked_select.out(Tensor self, Tensor mask, *, SymInt? output_size=None, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: masked_select_out_cpu
     CUDA: masked_select_out_cuda
@@ -9292,7 +9292,7 @@
     XPU: masked_select_out_xpu
   tags: dynamic_output_shape
 
-- func: masked_select(Tensor self, Tensor mask) -> Tensor
+- func: masked_select(Tensor self, Tensor mask, *, SymInt? output_size=None) -> Tensor
   variants: method, function
   dispatch:
     CPU: masked_select_cpu

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3824,6 +3824,21 @@ class TestTorchDeviceType(TestCase):
         a_masked = a.masked_select(mask_copy_3_times)
         self.assertEqual(a_masked, a.unsqueeze(0).expand(3, 100).flatten())
 
+    @dtypes(*all_types_and_complex_and(torch.half, torch.bool, torch.bfloat16))
+    def test_masked_select_output_size(self, device, dtype):
+        # output_size lets meta/data-dependent backends pre-size the result.
+        src = torch.tensor([1, 2, 3, 4], dtype=dtype, device=device)
+        mask = torch.tensor([True, False, True, False], device=device)
+        dst = torch.masked_select(src, mask, output_size=2)
+        self.assertEqual(dst, torch.tensor([1, 3], dtype=dtype, device=device))
+
+        # When omitted, behavior is unchanged on a real device.
+        self.assertEqual(torch.masked_select(src, mask), torch.tensor([1, 3], dtype=dtype, device=device))
+
+        # A wrong output_size is rejected on a real device.
+        with self.assertRaisesRegex(RuntimeError, "does not match the number of selected elements"):
+            torch.masked_select(src, mask, output_size=999)
+
     # FIXME: find a test suite for the masked select operator
     def test_masked_select_discontiguous(self, device):
         for size in (10, 200):
@@ -6708,6 +6723,19 @@ class TestTorch(TestCase):
 
     def test_dir(self):
         dir(torch)
+
+    def test_masked_select_meta(self):
+        data_meta = torch.empty(4, 4, device="meta")
+        mask_meta = torch.empty(4, 4, dtype=torch.bool, device="meta")
+
+        # With output_size, the meta kernel can produce output metadata.
+        result = data_meta.masked_select(mask_meta, output_size=8)
+        self.assertEqual(result.shape, torch.Size([8]))
+        self.assertEqual(result.device.type, "meta")
+
+        # Without output_size the output shape is data-dependent and unknowable.
+        with self.assertRaisesRegex(RuntimeError, "cannot masked_select a meta tensor without output_size"):
+            data_meta.masked_select(mask_meta)
 
     def test_wildcard_import(self):
         exec('from torch import *')

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1110,7 +1110,7 @@
   mask: non_differentiable
   result: masked_scatter_backward(grad_output_t, mask, grad_output_t.sizes())
 
-- name: masked_select(Tensor self, Tensor mask) -> Tensor
+- name: masked_select(Tensor self, Tensor mask, *, SymInt? output_size=None) -> Tensor
   self: masked_select_backward(grad, self, mask)
   mask: non_differentiable
   result: auto_linear

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -3701,6 +3701,13 @@ def meta_repeat_interleave_Tensor(repeats, output_size=None):
     return repeats.new_empty(output_size)
 
 
+@register_meta(aten.masked_select.default)
+def meta_masked_select(self, mask, *, output_size=None):
+    if output_size is None:
+        raise RuntimeError("cannot masked_select a meta tensor without output_size")
+    return self.new_empty(output_size)
+
+
 @register_meta([aten.complex.default, aten.complex.out])
 @out_wrapper()
 def meta_complex(real, imag):

--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -1458,8 +1458,15 @@ def slice_forward(
 
 @register_op_impl(torch.ops.aten.masked_select.default)
 def masked_select(
-    fake_mode: FakeTensorMode, func: OpOverload, self: FakeTensor, mask: FakeTensor
+    fake_mode: FakeTensorMode,
+    func: OpOverload,
+    self: FakeTensor,
+    mask: FakeTensor,
+    output_size: IntLikeType | None = None,
 ) -> FakeTensor:
+    if output_size is not None:
+        return self.new_empty((output_size,))  # type: ignore[return]
+
     if (
         fake_mode.shape_env is None
         or not fake_mode.shape_env.allow_dynamic_output_shape_ops

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -6506,7 +6506,7 @@ Example::
 add_docstr(
     torch.masked_select,
     r"""
-masked_select(input, mask, *, out=None) -> Tensor
+masked_select(input, mask, *, output_size=None, out=None) -> Tensor
 
 Returns a new 1-D tensor which indexes the :attr:`input` tensor according to
 the boolean mask :attr:`mask` which is a `BoolTensor`.

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -774,7 +774,7 @@ def get_testing_overrides() -> dict[Callable, Callable]:
         torch.margin_ranking_loss: lambda input1, input2, target, margin=0, size_average=None, reduce=None, reduction="mean": -1,  # type: ignore[attr-defined]
         torch.masked_fill: lambda input, mask, value: -1,
         torch.masked_scatter: lambda input, mask, source: -1,
-        torch.masked_select: lambda input, mask, out=None: -1,
+        torch.masked_select: lambda input, mask, *, output_size=None, out=None: -1,
         torch.matmul: lambda input, other, out=None: -1,
         torch.linalg.lu: lambda input, pivot=True, out=None: -1,
         torch.linalg.lu_factor: lambda input, pivot=True, out=None: -1,


### PR DESCRIPTION
## Summary

- Adds an optional `output_size` (SymInt?) keyword argument to `masked_select`, following the `repeat_interleave.Tensor` precedent.
- When `output_size` is provided on a `device="meta"` tensor, the meta kernel uses it to produce output metadata — enabling OOT accelerators to use `masked_select` in their eager shape-oracle loop without synchronizing.
- When omitted, behavior is completely unchanged on both meta and real devices.
- Real-device kernels (CPU/CUDA/MPS) validate the provided `output_size` against the actual selected count so meta and eager cannot silently diverge.
- The `FakeTensor` path short-circuits to `new_empty((output_size,))` when `output_size` is provided, keeping `torch.compile`/export working without a shape environment.
- `torch/overrides.py`, `torch/_torch_docs.py`, `tools/autograd/derivatives.yaml`, and `torch/_subclasses/fake_impls.py` all updated to reflect the new signature.

Closes https://github.com/pytorch/pytorch/issues/188370

## Test plan

- [ ] `test_masked_select_output_size` (device-generic, all dtypes) — correctness with matching `output_size`, unchanged behavior without it, error on mismatching `output_size`
- [ ] `test_masked_select_meta` — meta tensor returns correct shape/device with `output_size`; raises informative `RuntimeError` without it

```bash
python test/test_torch.py TestTorchDeviceTypeCPU.test_masked_select_output_size_cpu
python test/test_torch.py TestTorch.test_masked_select_meta
```

