### PR TITLE
[inductor] Log cudagraph skips for non-CUDA GPU backends

### DIFF
--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -52,6 +52,7 @@ from torch._inductor.utils import (
     CUDAGraphWrapperMetadata,
     GraphPartitionMap,
     InputType,
+    is_gpu,
     output_node,
     set_tracing_context_output_strides,
 )
@@ -296,7 +297,7 @@ def cudagraph_post_compile(
         BoxedBool.disable(cudagraphs)
         maybe_handle_backward_generation(compiled_graph, boxed_forward_device_index)
 
-        if "cuda" in compiled_graph.device_types:
+        if any(is_gpu(device) for device in compiled_graph.device_types):
             # prefer better disable_cudagraphs_reason bc stack trace
             # TODO: migrate all disable reasons to stack trace, refactor
             if compiled_graph.disabled_cudagraphs_reason:
@@ -631,7 +632,7 @@ class CompiledFxGraph(OutputCode):
         if cudagraphs:
             # check cudagraph disabling reasons from inductor lowering
             if self.disabled_cudagraphs_reason:
-                if "cuda" in self.device_types:
+                if any(is_gpu(device) for device in self.device_types):
                     log_cudagraph_skip_and_bump_counter(
                         f"skipping cudagraphs due to {self.disabled_cudagraphs_reason}"
                     )
@@ -874,7 +875,7 @@ class CompiledFxGraph(OutputCode):
             # during a previous compilation we're loading from the cache.
             # If so, we need to disable it on this new process too.
             if self.disabled_cudagraphs_reason:
-                if "cuda" in self.device_types:
+                if any(is_gpu(device) for device in self.device_types):
                     log_cudagraph_skip_and_bump_counter(
                         f"skipping cudagraphs due to {self.disabled_cudagraphs_reason}"
                     )


### PR DESCRIPTION
Fixes #180951

Based on #180971 by @Bhuvan1527. That PR was already approved but remained blocked on a lint/import-order issue, so this resubmits the same minimal fix on top of current `main` with the lint issue addressed.

Summary:
- Replace hardcoded `"cuda"` checks in `torch/_inductor/output_code.py` cudagraph-skip logging paths with `is_gpu()`.
- Match the existing GPU-type helper used by `torch/_inductor/scheduler.py`.
- Preserve the existing counter-only behavior for CPU-only graphs.

Test Plan:
- `git diff --check`
- `python3 -m compileall -q torch/_inductor/output_code.py`
- `lintrunner --take PYFMT -a torch/_inductor/output_code.py`
- `lintrunner --take IMPORT_LINTER -a torch/_inductor/output_code.py`

No new test is added; this is a narrow code-inspection fix for the device-type gate and does not require non-CUDA GPU hardware to exercise the helper substitution.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo