### PR TITLE
[fx] _iterate_exprs: treat device/dtype/layout/memory_format as symbol-free

### DIFF
--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -3879,6 +3879,22 @@ class TestUnbacked(TestCase):
         # empty dict
         self.assertEqual(list(_iterate_exprs({})), [])
 
+    def test_iterate_exprs_scalar_metadata(self):
+        """_iterate_exprs treats non-symbolic scalar metadata as having no symbols.
+
+        torch.device/dtype/memory_format/layout can appear in fx graphs (e.g.
+        coor::current_device emits a torch.device under compile-on-one-rank), so
+        free_symbols over such a graph must not raise on them.
+        """
+        for val in (
+            torch.device("cpu"),
+            torch.float32,
+            torch.contiguous_format,
+            torch.strided,
+        ):
+            self.assertEqual(list(_iterate_exprs(val)), [])
+            self.assertEqual(free_symbols(val), set())
+
     @skipIfTorchDynamo("https://github.com/pytorch/pytorch/issues/156135")
     @torch._dynamo.config.patch("capture_scalar_outputs", True)
     @parametrize("backend", ["inductor", "eager"])

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -1011,6 +1011,12 @@ def _iterate_exprs(val: IterateExprs) -> Iterator[sympy.Basic]:
         pass
     elif isinstance(val, FakeScriptObject):
         pass
+    # Non-symbolic scalar metadata (e.g. coor::current_device emits a
+    # torch.device under compile-on-one-rank) carries no free symbols.
+    elif isinstance(
+        val, (torch.device, torch.dtype, torch.memory_format, torch.layout)
+    ):
+        pass
     else:
         raise AssertionError(f"cannot extract sympy expressions from {val} {type(val)}")
 


### PR DESCRIPTION
## Summary

`_iterate_exprs` (used by `free_symbols` / `has_free_symbols` in
`torch/fx/experimental/symbolic_shapes.py`) raised
`AssertionError("cannot extract sympy expressions from ...")` on `torch.device`,
`torch.dtype`, `torch.memory_format`, and `torch.layout` values. These are
non-symbolic scalar metadata and carry no free symbols.

They can appear in fx graphs -- e.g. `coor::current_device` emits a
`torch.device` under compile-on-one-rank (CooR) -- so calling `free_symbols`
over such a graph crashed. This treats them like the other no-symbol leaves
already handled just above (e.g. `FakeScriptObject`) and skips them.

The four types are exactly the scalar `node.meta["val"]` values that
`torch._export.verifier._check_correct_val` already blesses
(`(torch.memory_format, torch.dtype, torch.device, torch.layout)`), so this
aligns `_iterate_exprs` with the existing fx contract rather than inventing a
new set.

## Context

Surfaced while adding precompile support for GraphPP in torchtitan
(pytorch/torchtitan#3815): the CooR save process traces stage graphs that carry
a `torch.device` from `coor::current_device`, and the GraphPP graph-surgery
passes call `free_symbols` over those graphs.

## Test

`test/test_dynamic_shapes.py -k test_iterate_exprs_scalar_metadata` asserts
`_iterate_exprs` and `free_symbols` return no symbols (and do not raise) for
`torch.device` / `dtype` / `memory_format` / `layout`.

Draft for now pending CI.
