### PR TITLE
Speed up CPU quantile/nanquantile with partial selection

### DIFF
--- a/aten/src/ATen/native/Sorting.cpp
+++ b/aten/src/ATen/native/Sorting.cpp
@@ -25,6 +25,7 @@
 #include <ATen/ops/arange.h>
 #include <ATen/ops/argsort_native.h>
 #include <ATen/ops/broadcast_tensors.h>
+#include <ATen/ops/cat.h>
 #include <ATen/ops/empty.h>
 #include <ATen/ops/full.h>
 #include <ATen/ops/full_like.h>
@@ -44,7 +45,10 @@
 #include <ATen/ops/topk_native.h>
 #endif
 
+#include <algorithm>
+#include <numeric>
 #include <utility>
+#include <vector>
 
 namespace at::meta {
 
@@ -184,6 +188,85 @@ void quick_select_template(
 
 namespace {
 
+// Resolve the order statistics at the requested `ranks` (distinct, ascending) for one
+// row: nth_element around the middle rank, then recurse into the lower/upper rank
+// subsets. `idx` is a 0..L-1 scratch permutation; on return idx[r] is the original
+// column of the r-th smallest. NaN sorts last to match sort(). ~O(L log U), not a sort.
+template <typename scalar_t>
+void quantile_select_recurse(
+    int64_t* idx,
+    const scalar_t* data,
+    const int64_t* ranks,
+    int64_t lo,
+    int64_t hi,
+    int64_t ulo,
+    int64_t uhi) {
+  if (ulo >= uhi) {
+    return;
+  }
+  const int64_t umid = ulo + (uhi - ulo) / 2;
+  const int64_t r = ranks[umid];
+  std::nth_element(
+      idx + lo, idx + r, idx + hi, [data](int64_t a, int64_t b) {
+        const scalar_t x = data[a];
+        const scalar_t y = data[b];
+        return !_isnan(x) && (_isnan(y) || x < y);
+      });
+  quantile_select_recurse(idx, data, ranks, lo, r, ulo, umid);
+  quantile_select_recurse(idx, data, ranks, r + 1, hi, umid + 1, uhi);
+}
+
+// CPU fast path: for contiguous `reduced` [..., L], return the original column index of
+// the order statistic at each rank in `ranks` [..., M]. The caller gathers these, so the
+// result stays autograd-differentiable through gather and no full sort is materialized.
+Tensor quantile_select_indices_cpu(const Tensor& reduced, const Tensor& ranks) {
+  const int64_t L = reduced.size(-1);
+  const int64_t M = ranks.size(-1);
+  if (M == 0) {
+    return at::empty(ranks.sizes(), ranks.options());
+  }
+  TORCH_INTERNAL_ASSERT(reduced.is_contiguous());
+  const int64_t R = reduced.numel() / L;
+  const auto ranks2d = ranks.reshape({R, M});
+  auto out = at::empty({R, M}, ranks.options());
+  const int64_t grain =
+      std::max<int64_t>(1, at::internal::GRAIN_SIZE / std::max<int64_t>(L, 1));
+  // Accessors read ranks and write out by stride, so neither is forced
+  // contiguous; the hot per-row select still uses the raw data pointer below.
+  const auto rk = ranks2d.accessor<int64_t, 2>();
+  auto outp = out.accessor<int64_t, 2>();
+  AT_DISPATCH_FLOATING_TYPES(
+      reduced.scalar_type(), "quantile_select_indices_cpu", [&]() {
+        const scalar_t* data = reduced.const_data_ptr<scalar_t>();
+        at::parallel_for(0, R, grain, [&](int64_t r0, int64_t r1) {
+          std::vector<int64_t> idx(L);
+          std::vector<int64_t> sorted_ranks(M);
+          for (const auto r : c10::irange(r0, r1)) {
+            const scalar_t* drow = data + r * L;
+            const auto rkrow = rk[r];
+            auto outrow = outp[r];
+            for (const auto m : c10::irange(M)) {
+              sorted_ranks[m] = rkrow[m];
+            }
+            std::sort(sorted_ranks.begin(), sorted_ranks.end());
+            const int64_t U =
+                std::unique(sorted_ranks.begin(), sorted_ranks.end()) -
+                sorted_ranks.begin();
+            TORCH_INTERNAL_ASSERT(
+                sorted_ranks[0] >= 0 && sorted_ranks[U - 1] < L,
+                "quantile() rank out of range");
+            std::iota(idx.begin(), idx.end(), int64_t{0});
+            quantile_select_recurse<scalar_t>(
+                idx.data(), drow, sorted_ranks.data(), 0, L, 0, U);
+            for (const auto m : c10::irange(M)) {
+              outrow[m] = idx[rkrow[m]];
+            }
+          }
+        });
+      });
+  return out.reshape(ranks.sizes());
+}
+
 QUANTILE_INTERPOLATION_MODE get_quantile_interpolation_mode(
     const std::string_view interpolation) {
   if (interpolation == "linear") {
@@ -264,14 +347,14 @@ Tensor quantile_compute(
   }
 
   // Flatten input if no dim provided else move dim to reduce as last dimension.
-  // Sort to efficiently query kth values.
-  Tensor sorted;
+  // Left unsorted: the fast path selects directly, the fallback sorts.
+  Tensor reduced;
   if (!orginal_dim) {
-    sorted = std::get<0>(self.flatten().sort());
+    reduced = self.flatten();
   } else if (wrapped_dim == self.dim() - 1) {
-    sorted = std::get<0>(self.sort());
+    reduced = self;
   } else {
-    sorted = std::get<0>(self.unsqueeze(-1).transpose(wrapped_dim, -1).sort());
+    reduced = self.unsqueeze(-1).transpose(wrapped_dim, -1);
   }
 
   // Treat q as a 1D tensor for the following computations
@@ -282,8 +365,8 @@ Tensor quantile_compute(
   // View input as reduced_size + size of dim to reduce
   std::vector<c10::SymInt> in_shape(out_shape.size());
   std::copy(out_shape.begin() + 1, out_shape.end(), in_shape.begin());
-  in_shape[in_shape.size() - 1] = sorted.sym_size(-1);
-  sorted = sorted.view_symint(in_shape);
+  in_shape[in_shape.size() - 1] = reduced.sym_size(-1);
+  reduced = reduced.reshape_symint(in_shape);
 
   // quantile maps q to ranks via q * (size - 1), rounded to gather indices, so
   // size must be exactly representable in the rank dtype. float32 reaches only
@@ -299,21 +382,22 @@ Tensor quantile_compute(
       ? (1LL << std::numeric_limits<double>::digits)
       : (1LL << std::numeric_limits<float>::digits);
   TORCH_SYM_CHECK(
-      sorted.sym_size(-1).sym_le(max_size),
+      reduced.sym_size(-1).sym_le(max_size),
       "quantile() input tensor is too large for ",
       self.scalar_type(),
       " dtype: the dimension being reduced has ",
-      sorted.sym_size(-1),
+      reduced.sym_size(-1),
       " elements but at most ",
       max_size,
       " are supported");
 
-  // Convert q in [0, 1] to ranks in [0, reduction_size)
+  // Convert q in [0, 1] to ranks in [0, reduction_size). isnan reductions are order
+  // independent, so the unsorted input yields the same ranks as the fallback's sort.
   Tensor ranks;
   if (ignore_nan) {
     // For nanquantile, compute ranks based on number of non-nan values.
     // If all values are nan, set rank to 0 so the quantile computed is nan.
-    ranks = q.to(rank_dtype) * (sorted.isnan().logical_not_().sum(-1, true) - 1);
+    ranks = q.to(rank_dtype) * (reduced.isnan().logical_not_().sum(-1, true) - 1);
     // For Composite Compliance,
     // if `ranks` is `CCT` but it's tangent is a regular Tensor,
     // then while computing jvp, we end calling `masked_fill_`
@@ -327,9 +411,9 @@ Tensor quantile_compute(
   } else {
     // For quantile, compute ranks based on reduction size. If there is nan
     // set rank to last index so the quantile computed will be nan.
-    auto last_index = sorted.sym_size(-1) - 1;
+    auto last_index = reduced.sym_size(-1) - 1;
     std::vector<Tensor> tl = at::broadcast_tensors(
-        {q.to(rank_dtype) * last_index, sorted.isnan().any(-1, true)});
+        {q.to(rank_dtype) * last_index, reduced.isnan().any(-1, true)});
     ranks = at::masked_fill(tl[0], tl[1], last_index);
   }
 
@@ -343,21 +427,56 @@ Tensor quantile_compute(
   }
 
   Tensor ranks_below = ranks.toType(kLong);
-  Tensor values_below = sorted.gather(-1, ranks_below);
+  const bool interpolate =
+      interpolation == QUANTILE_INTERPOLATION_MODE::LINEAR ||
+      interpolation == QUANTILE_INTERPOLATION_MODE::MIDPOINT;
 
-  // Actual interpolation is only needed for the liner and midpoint modes
-  if (interpolation == QUANTILE_INTERPOLATION_MODE::LINEAR ||
-      interpolation == QUANTILE_INTERPOLATION_MODE::MIDPOINT) {
-    // calculate weights for linear and midpoint
-    // ranks may be double while values stay float32; the lerp weight must match
-    // the value dtype or the interpolation upcasts the output.
-    Tensor weights = interpolation == QUANTILE_INTERPOLATION_MODE::MIDPOINT
+  // Weights and the upper ranks are shared by both value-acquisition paths.
+  // ranks may be double while values stay float32; the lerp weight must match
+  // the value dtype or the interpolation upcasts the output.
+  Tensor weights, ranks_above;
+  if (interpolate) {
+    weights = interpolation == QUANTILE_INTERPOLATION_MODE::MIDPOINT
         ? at::full_like(ranks, 0.5, self.options())
         : (ranks - ranks_below).to(self.scalar_type());
+    ranks_above = ranks.ceil_().toType(kLong);
+  }
 
-    // Interpolate to compute quantiles and store in values_below
-    Tensor ranks_above = ranks.ceil_().toType(kLong);
-    Tensor values_above = sorted.gather(-1, ranks_above);
+  // Acquire the values at the requested ranks. On CPU with real (non-subclass) tensors,
+  // select the order statistics and gather them: skips the sort, keeps autograd through
+  // gather. Subclass-like inputs (other backends, tracing, vmap) and large rank sets fall
+  // back to the sort, gated by num_ranks <= 100 and num_ranks^2 <= L (where selection wins).
+  Tensor values_below, values_above;
+  bool use_fast_path =
+      self.device().is_cpu() && !areAnyTensorSubclassLike({self, q});
+  if (use_fast_path) {
+    // Sizes are concrete here: tracing uses subclass-like tensors, excluded above.
+    const int64_t num_ranks = (interpolate ? 2 : 1) * ranks_below.size(-1);
+    use_fast_path =
+        num_ranks <= 100 && num_ranks * num_ranks <= reduced.size(-1);
+  }
+  if (use_fast_path) {
+    const Tensor reduced_contig = reduced.contiguous();
+    if (interpolate) {
+      const Tensor idx = quantile_select_indices_cpu(
+          reduced_contig, at::cat({ranks_below, ranks_above}, -1));
+      const int64_t k = ranks_below.size(-1);
+      values_below = reduced_contig.gather(-1, idx.narrow(-1, 0, k));
+      values_above = reduced_contig.gather(-1, idx.narrow(-1, k, k));
+    } else {
+      values_below = reduced_contig.gather(
+          -1, quantile_select_indices_cpu(reduced_contig, ranks_below));
+    }
+  } else {
+    const Tensor sorted = std::get<0>(reduced.sort());
+    values_below = sorted.gather(-1, ranks_below);
+    if (interpolate) {
+      values_above = sorted.gather(-1, ranks_above);
+    }
+  }
+
+  // Actual interpolation is only needed for the linear and midpoint modes
+  if (interpolate) {
     // For Composite Compliance,
     // if either `values_below`, `values_above` or `weights` are a CCT
     // or tangents of `value_above` and `weights` are a CCT,

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -21,6 +21,7 @@ from torch.testing._internal.common_dtype import (
 from torch.testing._internal.common_utils import (
     TestCase, run_tests, skipIfNoSciPy, slowTest, torch_to_numpy_dtype_dict,
     parametrize,
+    gradcheck, gradgradcheck,
     skipIfMPS,
     skipIfTorchDynamo,
     IS_WINDOWS)
@@ -2860,6 +2861,133 @@ class TestReductions(TestCase):
                 torch.quantile(torch.empty(over_cap, dtype=torch.float32, device=device), 0.5)
         else:
             torch.quantile(torch.empty(over_cap, dtype=torch.float32, device=device), 0.5)
+
+    @dtypes(torch.float, torch.double)
+    @dtypesIfMPS(torch.float)  # no float64 on MPS; exercises the sort fallback
+    def test_quantile_partial_selection(self, device, dtype):
+        # Stresses the CPU shared-pass selection (and the sort fallback on CUDA):
+        # many quantiles (deep recursion), adversarial value layouts, and batched
+        # ragged nan counts. Oracle is numpy.
+        torch.manual_seed(0)
+        np.random.seed(0)
+        all_interps = ('linear', 'lower', 'higher', 'midpoint', 'nearest')
+
+        def check(a, q, dim, keepdim, op='quantile', interps=all_interps):
+            tq, nq = getattr(torch, op), getattr(np, op)
+            qt = torch.tensor(q, dtype=dtype, device=device)
+            for interp in interps:
+                r = tq(a, qt, dim=dim, keepdim=keepdim, interpolation=interp)
+                e = nq(a.cpu().numpy(), np.asarray(q), dim, method=interp, keepdims=keepdim)
+                self.assertEqual(r.cpu(), torch.from_numpy(np.asarray(e)).to(r.dtype))
+
+        # Many quantiles exercise the recursion depth (K under the rank cap on long
+        # rows so the selection runs). The non-interpolating modes round q * (L - 1) in
+        # the input dtype, which can straddle an integer differently from numpy's
+        # float64 for arbitrary q, so the recursion is checked with 'linear' (the value
+        # is continuous in the rank there); the rounding modes are covered below on
+        # integer ranks.
+        qmany = sorted(np.random.rand(50).tolist())
+        for shape, dim in [((16384,), None), ((16384,), 0), ((8, 16384), 1), ((4, 4, 16384), 2)]:
+            a = torch.randn(*shape, dtype=dtype, device=device)
+            check(a, qmany, dim, False, interps=('linear',))
+            check(a, [0.0, 1.0], dim, True)
+        # Past the cap (and on short rows) the sort fallback must still match numpy.
+        check(torch.randn(500, dtype=dtype, device=device), qmany + qmany, 0, False, interps=('linear',))
+        check(torch.randn(40, 30, dtype=dtype, device=device), qmany, 1, False, interps=('linear',))
+
+        # Adversarial value layouts (n - 1 divisible by 4 keeps the ranks integral).
+        base = torch.randn(257, dtype=dtype, device=device)
+        for a in (torch.randint(0, 5, (257,), device=device).to(dtype),
+                  base.sort().values, base.sort(descending=True).values,
+                  torch.zeros(257, dtype=dtype, device=device)):
+            check(a, [0.0, 0.25, 0.5, 0.75, 1.0], 0, False)
+
+        # Batched ragged nan: every row a different valid-count, plus an all-nan row.
+        a = torch.randn(12, 401, dtype=dtype, device=device)
+        for i in range(12):
+            a[i, :i * 33] = float('nan')
+        a[0] = float('nan')
+        check(a, [0.0, 0.25, 0.5, 0.75, 1.0], 1, False, op='nanquantile')
+        check(a, [0.0, 0.25, 0.5, 0.75, 1.0], 1, True, op='nanquantile')
+
+        # A single valid element per row.
+        a = torch.full((4, 5), float('nan'), dtype=dtype, device=device)
+        a[:, 2] = torch.randn(4, dtype=dtype, device=device)
+        check(a, [0.0, 0.5, 1.0], 1, False, op='nanquantile')
+
+    # gradcheck's undefined-grad probe feeds None grads that compiled autograd
+    # cannot add; this is an eager-only autograd correctness check.
+    @skipIfTorchDynamo("gradcheck undefined-grad is unsupported under compiled autograd")
+    @skipIfMPS  # MPS has no float64; gradcheck requires double
+    @dtypes(torch.double)
+    def test_quantile_partial_selection_autograd(self, device, dtype):
+        # The CPU fast path computes order-statistic indices and gathers them, so the
+        # gradient flows through the same gather as the sort path. Inputs are sized to
+        # trip the fast path (num_ranks^2 <= reduction_len, num_ranks <= 100, where
+        # num_ranks = (2 if interpolating else 1) * num_q); the same cases exercise the
+        # sort fallback on CUDA. Values are distinct and >=~0.75 apart so the selected
+        # rank is stable under gradcheck's perturbation (the quantile gradient is
+        # ill-defined at ties regardless of which path runs).
+        gen = torch.Generator(device=device).manual_seed(0)
+
+        def separated(*shape):
+            n = int(np.prod(shape))
+            perm = torch.randperm(n, generator=gen, device=device).to(dtype)
+            noise = 0.25 * torch.rand(n, generator=gen, device=device, dtype=dtype)
+            return (perm + noise).reshape(shape)
+
+        def sort_ref(a, q, interpolation, ignore_nan):
+            # The pre-change algorithm for 1D input: full sort (NaN last), gather at the
+            # integer ranks, lerp. Same ranks and weights as quantile_compute, so for
+            # distinct values it must match the fast path bit for bit.
+            s = a.sort().values
+            last = (~a.isnan()).sum() - 1 if ignore_nan else a.numel() - 1
+            ranks = q * last
+            if interpolation == 'lower':
+                return s.gather(0, ranks.floor().long())
+            if interpolation == 'higher':
+                return s.gather(0, ranks.ceil().long())
+            if interpolation == 'nearest':
+                return s.gather(0, ranks.round().long())
+            below = ranks.floor()
+            vb = s.gather(0, below.long())
+            va = s.gather(0, ranks.ceil().long())
+            w = torch.full_like(ranks, 0.5) if interpolation == 'midpoint' else ranks - below
+            return torch.lerp(vb, va, w)
+
+        interps = ('linear', 'lower', 'higher', 'midpoint', 'nearest')
+
+        # 1D: forward and gradient must match the sort reference exactly (distinct
+        # values mean the fast path and the sort select the same elements).
+        for L, qv in [(64, [0.2, 0.5, 0.8]), (100, [0.1, 0.3, 0.5, 0.7, 0.9])]:
+            q = torch.tensor(qv, device=device, dtype=dtype)
+            for op, ignore_nan in (('quantile', False), ('nanquantile', True)):
+                base = separated(L)
+                if ignore_nan:
+                    base[:7] = float('nan')  # some (not all) NaN: ragged valid count
+                for interp in interps:
+                    x1 = base.clone().requires_grad_(True)
+                    x2 = base.clone().requires_grad_(True)
+                    out = getattr(torch, op)(x1, q, interpolation=interp)
+                    ref = sort_ref(x2, q, interp, ignore_nan)
+                    self.assertEqual(out, ref, atol=0, rtol=0)
+                    go = torch.randn(out.shape, generator=gen, device=device, dtype=dtype)
+                    out.backward(go)
+                    ref.backward(go)
+                    self.assertEqual(x1.grad, x2.grad, atol=0, rtol=0)
+
+        # Batched / multi-dim: numerical gradcheck, plus one double-backward check.
+        for shape, dim, qv, interp in [
+            ((4, 96), 1, [0.25, 0.75], 'linear'),
+            ((3, 64), 1, [0.2, 0.5, 0.8], 'midpoint'),
+            ((2, 3, 100), 2, [0.1, 0.9], 'lower'),
+        ]:
+            q = torch.tensor(qv, device=device, dtype=dtype)
+            x = separated(*shape).requires_grad_(True)
+            self.assertTrue(gradcheck(lambda t: torch.quantile(t, q, dim=dim, interpolation=interp), (x,)))
+        x = separated(4, 96).requires_grad_(True)
+        q = torch.tensor([0.25, 0.75], device=device, dtype=dtype)
+        self.assertTrue(gradgradcheck(lambda t: torch.quantile(t, q, dim=1, interpolation='linear'), (x,)))
 
     def test_std_mean(self, device):
         x = torch.rand(100, 50, 20, device=device)


### PR DESCRIPTION
## Summary

Closes #64947. 
**(Part 2/2)** 
(float32 size-limit fix landed in #187574.)

`torch.quantile` / `torch.nanquantile` fully sort the reduced dimension just to read back a few order statistics. This replaces the sort with a CPU partial selection, making the common cases (median, quartiles, a handful of quantiles, batched/flattened `nanquantile`) **2-8x faster and ~60% lighter**, bit-identical to the sort.

## Root cause

For a few quantiles, `quantile_compute` runs a full `self.sort()` (O(n log n)) plus an n-element index tensor it immediately discards, then gathers a few ranks. The sort dominates the cost.

## Approach

On CPU, in eager mode, with no tensor subclasses and few requested ranks, select the order statistics instead of sorting:

- A helper resolves all requested ranks of a row in shared `std::nth_element` passes over an index permutation (recursing into the lower/upper rank subsets), NaN ordered last to match `sort`. Cost is ~O(n log K), not O(n log n).
- It returns the original indices; the existing `gather` reads the values. So there is no new operator and no new autograd formula, and the forward output is bit-identical to the sort. The gradient matches too for distinct values; at tied values the subgradient is inherently non-unique (it already varies across non-stable CPU sort runs and vs CUDA).
- Per-row ranks let `quantile`, flattened `nanquantile`, and ragged batched `nanquantile` share one helper with no special cases.

Everything else keeps the sort path: CUDA/MPS (device sorts already win), compile/export and vmap (gated behind `!areAnyTensorSubclassLike`), and large rank sets (`num_ranks <= 100 && num_ranks^2 <= L`). NaN semantics, the #187574 size cap, interpolation, and output shapes are untouched.

## Before / after

Apple M5 (4 perf cores), `torch.float64`, base `12a9ea264bf` + this commit. Median wall time; `sort` is the pre-change sort+gather+lerp path.

| n | num_q | sort | quantile | speedup |
|---|---|---|---|---|
| 10M | 1 | 1308 ms | 170 ms | 7.7x |
| 10M | 3 | 1309 ms | 313 ms | 4.2x |
| 10M | 10 | 1305 ms | 581 ms | 2.3x |
| 16.7M | 1 | 2254 ms | 278 ms | 8.1x |
| 16.7M | 3 | 2257 ms | 594 ms | 3.8x |
| 16.7M | 10 | 2252 ms | 1011 ms | 2.2x |

Peak RSS (16.7M, 3 quantiles): **147 MB vs 385 MB**. Past the cap the selection falls back to the sort with no regression; `nanquantile` and batched inputs see the same win.

## Verification

`python test/test_reductions.py -k quantile` (built CPU+MPS on Apple M5, all pass):

- **Bit-identical to the sort.** `test_quantile_partial_selection_autograd` pins forward and gradient equal to an explicit sort/gather/lerp reference across all five interpolation modes for `quantile` and `nanquantile`, plus `gradcheck`/`gradgradcheck`.
- **Forward coverage.** `test_quantile_partial_selection` (device-generic): many-quantile recursion, adversarial layouts, ragged-NaN batches, single-valid rows, sort fallback.
- The fast path is gated off for subclass-like inputs, so compile/export/vmap and CUDA/MPS are unchanged; the device-generic tests also run on CUDA in CI.

cc @ngimel @Skylion007
