### PR TITLE
Refactor Dynamo side effect replay into registry dispatcher

### DIFF
--- a/test/dynamo/test_side_effect_replay_registry.py
+++ b/test/dynamo/test_side_effect_replay_registry.py
@@ -11,7 +11,11 @@ from torch._dynamo.side_effects import (
 )
 from torch._dynamo.test_case import run_tests, TestCase
 from torch._dynamo.variables import CellVariable
-from torch._dynamo.variables.base import AttributeMutationNew, VariableTracker
+from torch._dynamo.variables.base import (
+    AttributeMutation,
+    AttributeMutationNew,
+    VariableTracker,
+)
 
 
 class SideEffectReplayRegistryTests(TestCase):
@@ -19,7 +23,7 @@ class SideEffectReplayRegistryTests(TestCase):
     def make_context(var: VariableTracker | None = None) -> SideEffectReplayContext:
         side_effects = Mock(spec=SideEffects)
         side_effects.is_attribute_mutation.side_effect = lambda item: isinstance(
-            item.mutation_type, AttributeMutationNew
+            item.mutation_type, AttributeMutation
         )
         return SideEffectReplayContext(
             side_effects=side_effects,

--- a/test/dynamo/test_side_effect_replay_registry.py
+++ b/test/dynamo/test_side_effect_replay_registry.py
@@ -1,0 +1,92 @@
+# Owner(s): ["module: dynamo"]
+
+from unittest.mock import Mock
+
+from torch._dynamo.side_effects import (
+    _side_effect_replay_registry,
+    _SideEffectReplayRegistry,
+    SideEffectReplayContext,
+    SideEffectReplayHandler,
+    SideEffects,
+)
+from torch._dynamo.test_case import run_tests, TestCase
+from torch._dynamo.variables import CellVariable
+from torch._dynamo.variables.base import AttributeMutationNew, VariableTracker
+
+
+class SideEffectReplayRegistryTests(TestCase):
+    @staticmethod
+    def make_context(var: VariableTracker | None = None) -> SideEffectReplayContext:
+        side_effects = Mock(spec=SideEffects)
+        side_effects.is_attribute_mutation.side_effect = lambda item: isinstance(
+            item.mutation_type, AttributeMutationNew
+        )
+        return SideEffectReplayContext(
+            side_effects=side_effects,
+            codegen=Mock(),
+            var=var if var is not None else VariableTracker(),
+            suffixes=[],
+            log=Mock(),
+        )
+
+    def test_priority_wins_independent_of_registration_order(self) -> None:
+        registry = _SideEffectReplayRegistry()
+        ctx = self.make_context()
+        lower = SideEffectReplayHandler("lower", lambda _: True, Mock(), priority=1)
+        higher = SideEffectReplayHandler("higher", lambda _: True, Mock(), priority=2)
+
+        registry.register_handler(lower)
+        higher_handle = registry.register_handler(higher)
+        self.assertIs(registry.lookup_handler(ctx), higher)
+
+        higher_handle.destroy()
+        self.assertIs(registry.lookup_handler(ctx), lower)
+
+    def test_equal_priority_matches_are_ambiguous(self) -> None:
+        registry = _SideEffectReplayRegistry()
+        ctx = self.make_context()
+        registry.register_handler(
+            SideEffectReplayHandler("first", lambda _: True, Mock(), priority=1)
+        )
+        registry.register_handler(
+            SideEffectReplayHandler("second", lambda _: True, Mock(), priority=1)
+        )
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "Ambiguous side effect replay handler for VariableTracker: "
+            r"\['first', 'second'\]",
+        ):
+            registry.lookup_handler(ctx)
+
+    def test_builtin_priorities_preserve_legacy_dispatch_order(self) -> None:
+        self.assertEqual(
+            [
+                (handler.name, handler.priority)
+                for handler in _side_effect_replay_registry.handlers
+            ],
+            [
+                ("list_mutation", 90),
+                ("deque_mutation", 80),
+                ("const_dict_or_set_mutation", 70),
+                ("torch_function_mode_stack_mutation", 60),
+                ("cell_mutation", 50),
+                ("attribute_mutation", 40),
+                ("list_iterator_mutation", 30),
+                ("count_iterator_mutation", 20),
+                ("random_mutation", 10),
+            ],
+        )
+
+    def test_cell_handler_wins_attribute_mutation_overlap(self) -> None:
+        cell = CellVariable(mutation_type=AttributeMutationNew())
+        cell.local_name = "cell"
+
+        handler = _side_effect_replay_registry.lookup_handler(self.make_context(cell))
+
+        self.assertIsNotNone(handler)
+        self.assertEqual(handler.name, "cell_mutation")
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -30,9 +30,9 @@ import logging
 import textwrap
 import traceback
 import weakref
-from collections.abc import Callable, Generator, Hashable, MutableMapping
+from collections.abc import Callable, Generator, MutableMapping
 from types import CellType
-from typing import Any, overload, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 import torch
 import torch.nn
@@ -81,12 +81,6 @@ if TYPE_CHECKING:
 side_effects_log = torch._logging.getArtifactLogger(__name__, "side_effects")
 
 
-class SideEffectReplayAction(enum.Enum):
-    REPLAY = "replay"
-    NON_REPLAYABLE = "non_replayable"
-    ERROR = "error"
-
-
 @dataclasses.dataclass(frozen=True)
 class SideEffectReplayContext:
     side_effects: "SideEffects"
@@ -102,25 +96,9 @@ class SideEffectReplayContext:
 
 SideEffectReplayMatcher = Callable[[SideEffectReplayContext], bool]
 SideEffectReplayCodegen = Callable[[SideEffectReplayContext], None]
-SideEffectReplayRuleOperation = Callable[
-    [SideEffectReplayContext], SideEffectReplayAction
-]
-SideEffectReplayRuleDecorator = Callable[
-    [SideEffectReplayRuleOperation], SideEffectReplayRuleOperation
-]
 SideEffectReplayHandlerDecorator = Callable[
     [SideEffectReplayCodegen], SideEffectReplayCodegen
 ]
-
-
-@dataclasses.dataclass(frozen=True)
-class SideEffectReplayRule:
-    name: str
-    matcher: SideEffectReplayMatcher
-    operation: SideEffectReplayRuleOperation
-    reason: str
-    cache_key: Hashable
-    priority: int = 0
 
 
 @dataclasses.dataclass(frozen=True)
@@ -133,16 +111,7 @@ class SideEffectReplayHandler:
 
 class _SideEffectReplayRegistry:
     def __init__(self) -> None:
-        self.rules: list[SideEffectReplayRule] = []
         self.handlers: list[SideEffectReplayHandler] = []
-
-    def register_rule(self, rule: SideEffectReplayRule) -> RegistrationHandle:
-        self.rules.append(rule)
-
-        def deregister() -> None:
-            self.rules.remove(rule)
-
-        return RegistrationHandle(deregister)
 
     def register_handler(self, handler: SideEffectReplayHandler) -> RegistrationHandle:
         self.handlers.append(handler)
@@ -152,97 +121,26 @@ class _SideEffectReplayRegistry:
 
         return RegistrationHandle(deregister)
 
-    def lookup_rule(self, ctx: SideEffectReplayContext) -> SideEffectReplayRule | None:
-        return self._lookup_unique("side effect replay rule", self.rules, ctx)
-
     def lookup_handler(
         self, ctx: SideEffectReplayContext
     ) -> SideEffectReplayHandler | None:
-        return self._lookup_unique("side effect replay handler", self.handlers, ctx)
-
-    def get_cache_key(self) -> tuple[Hashable, ...]:
-        return tuple(rule.cache_key for rule in self.rules)
-
-    @staticmethod
-    def _lookup_unique(
-        kind: str,
-        entries: list[Any],
-        ctx: SideEffectReplayContext,
-    ) -> Any | None:
-        matches = [entry for entry in entries if entry.matcher(ctx)]
+        matches = [handler for handler in self.handlers if handler.matcher(ctx)]
         if not matches:
             return None
-        matches.sort(key=lambda entry: entry.priority, reverse=True)
+        matches.sort(key=lambda handler: handler.priority, reverse=True)
         top = matches[0]
         if len(matches) > 1 and matches[1].priority == top.priority:
-            names = [entry.name for entry in matches if entry.priority == top.priority]
+            names = [
+                handler.name for handler in matches if handler.priority == top.priority
+            ]
             raise RuntimeError(
-                f"Ambiguous {kind} for {type(ctx.var).__name__}: {names}"
+                f"Ambiguous side effect replay handler for "
+                f"{type(ctx.var).__name__}: {names}"
             )
         return top
 
 
 _side_effect_replay_registry = _SideEffectReplayRegistry()
-
-
-@overload
-def register_side_effect_replay_rule(
-    rule: SideEffectReplayRule,
-) -> RegistrationHandle: ...
-
-
-@overload
-def register_side_effect_replay_rule(
-    *,
-    name: str,
-    matcher: SideEffectReplayMatcher,
-    reason: str,
-    cache_key: Hashable,
-    priority: int = 0,
-) -> SideEffectReplayRuleDecorator: ...
-
-
-def register_side_effect_replay_rule(
-    rule: SideEffectReplayRule | None = None,
-    *,
-    name: str | None = None,
-    matcher: SideEffectReplayMatcher | None = None,
-    reason: str | None = None,
-    cache_key: Hashable | None = None,
-    priority: int = 0,
-) -> RegistrationHandle | SideEffectReplayRuleDecorator:
-    if rule is not None:
-        return _side_effect_replay_registry.register_rule(rule)
-
-    if name is None:
-        raise AssertionError("side effect replay rule name must be set")
-    if matcher is None:
-        raise AssertionError("side effect replay rule matcher must be set")
-    if reason is None:
-        raise AssertionError("side effect replay rule reason must be set")
-    if cache_key is None:
-        raise AssertionError("side effect replay rule cache key must be set")
-
-    def decorator(
-        operation: SideEffectReplayRuleOperation,
-    ) -> SideEffectReplayRuleOperation:
-        _side_effect_replay_registry.register_rule(
-            SideEffectReplayRule(
-                name=name,
-                matcher=matcher,
-                operation=operation,
-                reason=reason,
-                cache_key=cache_key,
-                priority=priority,
-            )
-        )
-        return operation
-
-    return decorator
-
-
-def get_side_effect_replay_rule_cache_key() -> tuple[Hashable, ...]:
-    return _side_effect_replay_registry.get_cache_key()
 
 
 def _register_side_effect_replay_handler(
@@ -1593,17 +1491,6 @@ class SideEffects:
                 suffixes=suffixes,
                 log=_maybe_log_side_effect,
             )
-            rule = _side_effect_replay_registry.lookup_rule(ctx)
-            if rule is not None:
-                action = rule.operation(ctx)
-                if action is SideEffectReplayAction.NON_REPLAYABLE:
-                    continue
-                if action is SideEffectReplayAction.ERROR:
-                    raise RuntimeError(
-                        f"Side effect replay rule {rule.name!r} rejected "
-                        f"{type(var).__name__}: {rule.reason}"
-                    )
-
             handler = _side_effect_replay_registry.lookup_handler(ctx)
             if handler is None:
                 raise AssertionError(type(var))

--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -23,18 +23,20 @@ while enabling optimizations where safe.
 
 import collections
 import contextlib
+import dataclasses
 import enum
 import inspect
 import logging
 import textwrap
 import traceback
 import weakref
-from collections.abc import Generator, MutableMapping
+from collections.abc import Callable, Generator, Hashable, MutableMapping
 from types import CellType
-from typing import Any, TYPE_CHECKING
+from typing import Any, overload, TYPE_CHECKING
 
 import torch
 import torch.nn
+from torch._library.utils import RegistrationHandle
 from torch._dynamo.variables.misc import AutogradFunctionContextVariable
 from torch.utils._ordered_set import OrderedSet
 from torch.utils._pytree import is_structseq_class
@@ -45,6 +47,7 @@ from .bytecode_transformation import (
     create_call_function,
     create_call_method,
     create_instruction,
+    Instruction,
 )
 from .codegen import PyCodegen
 from .exc import collapse_resume_frames, get_stack_above_dynamo, unimplemented
@@ -76,6 +79,204 @@ if TYPE_CHECKING:
 
 
 side_effects_log = torch._logging.getArtifactLogger(__name__, "side_effects")
+
+
+class SideEffectReplayAction(enum.Enum):
+    REPLAY = "replay"
+    NON_REPLAYABLE = "non_replayable"
+    ERROR = "error"
+
+
+@dataclasses.dataclass(frozen=True)
+class SideEffectReplayContext:
+    side_effects: "SideEffects"
+    codegen: PyCodegen
+    var: VariableTracker
+    suffixes: list[list[Instruction]]
+    log: Callable[[VariableTracker], None]
+
+    @property
+    def tx(self) -> "InstructionTranslatorBase":
+        return self.codegen.tx
+
+
+SideEffectReplayMatcher = Callable[[SideEffectReplayContext], bool]
+SideEffectReplayCodegen = Callable[[SideEffectReplayContext], None]
+SideEffectReplayRuleOperation = Callable[
+    [SideEffectReplayContext], SideEffectReplayAction
+]
+SideEffectReplayRuleDecorator = Callable[
+    [SideEffectReplayRuleOperation], SideEffectReplayRuleOperation
+]
+SideEffectReplayHandlerDecorator = Callable[
+    [SideEffectReplayCodegen], SideEffectReplayCodegen
+]
+
+
+@dataclasses.dataclass(frozen=True)
+class SideEffectReplayRule:
+    name: str
+    matcher: SideEffectReplayMatcher
+    operation: SideEffectReplayRuleOperation
+    reason: str
+    cache_key: Hashable
+    priority: int = 0
+
+
+@dataclasses.dataclass(frozen=True)
+class SideEffectReplayHandler:
+    name: str
+    matcher: SideEffectReplayMatcher
+    codegen: SideEffectReplayCodegen
+    priority: int = 0
+
+
+class _SideEffectReplayRegistry:
+    def __init__(self) -> None:
+        self.rules: list[SideEffectReplayRule] = []
+        self.handlers: list[SideEffectReplayHandler] = []
+
+    def register_rule(self, rule: SideEffectReplayRule) -> RegistrationHandle:
+        self.rules.append(rule)
+
+        def deregister() -> None:
+            self.rules.remove(rule)
+
+        return RegistrationHandle(deregister)
+
+    def register_handler(self, handler: SideEffectReplayHandler) -> RegistrationHandle:
+        self.handlers.append(handler)
+
+        def deregister() -> None:
+            self.handlers.remove(handler)
+
+        return RegistrationHandle(deregister)
+
+    def lookup_rule(
+        self, ctx: SideEffectReplayContext
+    ) -> SideEffectReplayRule | None:
+        return self._lookup_unique("side effect replay rule", self.rules, ctx)
+
+    def lookup_handler(
+        self, ctx: SideEffectReplayContext
+    ) -> SideEffectReplayHandler | None:
+        return self._lookup_unique("side effect replay handler", self.handlers, ctx)
+
+    def get_cache_key(self) -> tuple[Hashable, ...]:
+        return tuple(rule.cache_key for rule in self.rules)
+
+    @staticmethod
+    def _lookup_unique(
+        kind: str,
+        entries: list[Any],
+        ctx: SideEffectReplayContext,
+    ) -> Any | None:
+        matches = [entry for entry in entries if entry.matcher(ctx)]
+        if not matches:
+            return None
+        matches.sort(key=lambda entry: entry.priority, reverse=True)
+        top = matches[0]
+        if len(matches) > 1 and matches[1].priority == top.priority:
+            names = [entry.name for entry in matches if entry.priority == top.priority]
+            raise RuntimeError(
+                f"Ambiguous {kind} for {type(ctx.var).__name__}: {names}"
+            )
+        return top
+
+
+_side_effect_replay_registry = _SideEffectReplayRegistry()
+
+
+def _attach_registration_handle(fn: Callable[..., Any], handle: RegistrationHandle) -> None:
+    setattr(fn, "_side_effect_replay_handle", handle)
+
+
+@overload
+def register_side_effect_replay_rule(
+    rule: SideEffectReplayRule,
+) -> RegistrationHandle:
+    ...
+
+
+@overload
+def register_side_effect_replay_rule(
+    *,
+    name: str,
+    matcher: SideEffectReplayMatcher,
+    reason: str,
+    cache_key: Hashable,
+    priority: int = 0,
+) -> SideEffectReplayRuleDecorator:
+    ...
+
+
+def register_side_effect_replay_rule(
+    rule: SideEffectReplayRule | None = None,
+    *,
+    name: str | None = None,
+    matcher: SideEffectReplayMatcher | None = None,
+    reason: str | None = None,
+    cache_key: Hashable | None = None,
+    priority: int = 0,
+) -> RegistrationHandle | SideEffectReplayRuleDecorator:
+    if rule is not None:
+        return _side_effect_replay_registry.register_rule(rule)
+
+    assert name is not None
+    assert matcher is not None
+    assert reason is not None
+    assert cache_key is not None
+
+    def decorator(
+        operation: SideEffectReplayRuleOperation,
+    ) -> SideEffectReplayRuleOperation:
+        handle = _side_effect_replay_registry.register_rule(
+            SideEffectReplayRule(
+                name=name,
+                matcher=matcher,
+                operation=operation,
+                reason=reason,
+                cache_key=cache_key,
+                priority=priority,
+            )
+        )
+        _attach_registration_handle(operation, handle)
+        return operation
+
+    return decorator
+
+
+def get_side_effect_replay_rule_cache_key() -> tuple[Hashable, ...]:
+    return _side_effect_replay_registry.get_cache_key()
+
+
+def _register_side_effect_replay_handler(
+    handler: SideEffectReplayHandler,
+) -> RegistrationHandle:
+    return _side_effect_replay_registry.register_handler(handler)
+
+
+def register_side_effect_replay_handler(
+    *,
+    name: str,
+    matcher: SideEffectReplayMatcher,
+    priority: int = 0,
+) -> SideEffectReplayHandlerDecorator:
+    def decorator(
+        codegen: SideEffectReplayCodegen,
+    ) -> SideEffectReplayCodegen:
+        handle = _register_side_effect_replay_handler(
+            SideEffectReplayHandler(
+                name=name,
+                matcher=matcher,
+                codegen=codegen,
+                priority=priority,
+            )
+        )
+        _attach_registration_handle(codegen, handle)
+        return codegen
+
+    return decorator
 
 
 def _manual_dict_setitem(
@@ -1383,456 +1584,36 @@ class SideEffects:
                 msg = self._format_side_effect_message(var)
                 side_effect_messages.append(msg)
 
-        suffixes = []
+        suffixes: list[list[Instruction]] = []
         for var in self._get_modified_vars():
             # When replay_side_effects=False, only update variables with TempLocalSource
             if not config.replay_side_effects and not isinstance(
                 var.source, TempLocalSource
             ):
                 continue
-            if isinstance(var, variables.ListVariable):
-                # old[:] = new
-                cg(var, allow_cache=False)  # Don't codegen via source
-                cg(var.source)  # type: ignore[attr-defined]
-                cg.extend_output(
-                    [
-                        cg.create_load_const(None),
-                        cg.create_load_const(None),
-                        create_instruction("BUILD_SLICE", arg=2),
-                    ]
-                )
-                suffixes.append([create_instruction("STORE_SUBSCR")])
-                _maybe_log_side_effect(var)
-            elif isinstance(var, variables.lists.DequeVariable):
-                # For limited maxlen, the order of operations matter for side
-                # effect, but we currently don't track the order, so no support.
-                if not var.maxlen.is_constant_none():
-                    unimplemented(
-                        gb_type="Side effect on existing deque with limited maxlen",
-                        context="",
-                        explanation="This is not supported.",
-                        hints=[
-                            "Don't use a deque with `maxlen` specified.",
-                        ],
-                    )
 
-                # old.extend(new), this runs last
-                cg(var.source)
-                cg.load_method("extend")
-                cg(var, allow_cache=False)  # Don't codegen via source
-                suffixes.append(
-                    [
-                        *create_call_method(1),
-                        create_instruction("POP_TOP"),
-                    ]
-                )
-
-                # old.clear(), this runs first
-                cg(var.source)
-                cg.load_method("clear")
-                suffixes.append(
-                    [
-                        *create_call_method(0),
-                        create_instruction("POP_TOP"),
-                    ]
-                )
-                _maybe_log_side_effect(var)
-
-            elif isinstance(var, (variables.ConstDictVariable, variables.SetVariable)):
-                # Reconstruct works as follow:
-                # (1) Skip codegen if there are no new items
-                # (2) codegen(...) each pair of key/value
-                # (3) create a new dictionary with the pairs of key/values above
-                # (4) clear the original dictionary
-                #   + only if a key was removed from the input dict
-                # (5) update the original dictionary with the dict created in (2)
-
-                if var.has_new_items():
-                    cg(var.source)  # type: ignore[attr-defined]
-                    cg.load_method("update")
-                    cg(var, allow_cache=False)  # Don't codegen via source
-
-                    if var.should_reconstruct_all:
-                        cg(var.source)  # type: ignore[attr-defined]
-                        cg.load_method("clear")
-
-                    suffixes.append(
-                        [
-                            *create_call_method(1),  # update
-                            create_instruction("POP_TOP"),
-                        ]
-                    )
-
-                    if var.should_reconstruct_all:
-                        # clear will appear before "update" as the suffixes are
-                        # applied in reverse order.
-                        suffixes.append(
-                            [
-                                *create_call_method(0),  # clear
-                                create_instruction("POP_TOP"),
-                            ]
-                        )
-                    _maybe_log_side_effect(var)
-
-            elif isinstance(
-                var, variables.torch_function.TorchFunctionModeStackVariable
-            ):
-                cg.add_push_null(
-                    lambda: cg.load_import_from(
-                        utils.__name__, "set_torch_function_mode_stack"
-                    )
-                )
-
-                cg.foreach(var.symbolic_stack)
-                cg.append_output(
-                    create_instruction("BUILD_LIST", arg=len(var.symbolic_stack))
-                )
-                cg.call_function(1, False)
-                cg.append_output(create_instruction("POP_TOP"))
-                _maybe_log_side_effect(var)
-
-            elif isinstance(var, variables.CellVariable) and var.local_name is not None:
-                # Emit more readable and performant bytecode.
-                # TODO generalize this for cells created during inlining.
-                if var in self.store_attr_mutations:
-                    contents_var = self.load_cell(var)
-                    cg(contents_var)
-                    suffixes.append([cg.create_store_deref(var.local_name)])
-                    _maybe_log_side_effect(var)
-
-            elif self.is_attribute_mutation(var):
-                # FrozenDataClassVariable attributes were emitted in
-                # codegen_save_tempvars right after __new__. Skip here to
-                # avoid double-emitting.
-                if isinstance(var.mutation_type, AttributeMutationNew) and isinstance(
-                    var, variables.FrozenDataClassVariable
-                ):
+            ctx = SideEffectReplayContext(
+                side_effects=self,
+                codegen=cg,
+                var=var,
+                suffixes=suffixes,
+                log=_maybe_log_side_effect,
+            )
+            rule = _side_effect_replay_registry.lookup_rule(ctx)
+            if rule is not None:
+                action = rule.operation(ctx)
+                if action is SideEffectReplayAction.NON_REPLAYABLE:
                     continue
-
-                # Sourceless enum members: mutations (like _inverted_ caching)
-                # already happened on the real object during tracing.
-                if (
-                    var.is_python_constant()
-                    and isinstance(var.mutation_type, AttributeMutationNew)
-                    and isinstance(var, variables.UserDefinedObjectVariable)
-                    and (
-                        isinstance(
-                            var.value,
-                            (
-                                enum.Enum,
-                                torch.DispatchKey,
-                                torch._C._functorch.TransformType,
-                            ),
-                        )
-                        or is_pybind11_enum_member(var.value)
-                    )
-                ):
-                    continue
-
-                if (
-                    isinstance(
-                        var,
-                        variables.UserDefinedDictVariable,
-                    )
-                    and self.is_modified(
-                        var._base_vt  # pyrefly: ignore[bad-argument-type]
-                    )
-                    and var._base_vt.has_new_items(  # pyrefly: ignore[union-attr,missing-attribute]
-                    )
-                ):
-                    # Do dict related update manually here. The store_attr
-                    # mutations will be applied later.
-                    varname_map = {}
-                    for name in _manual_dict_setitem.__code__.co_varnames:
-                        varname_map[name] = cg.tx.output.new_var()
-
-                    try:
-                        mro_index = type(var.value).__mro__.index(
-                            collections.OrderedDict
-                        )
-                    except ValueError:
-                        mro_index = type(var.value).__mro__.index(dict)
-
-                    cg.extend_output(
-                        [
-                            create_instruction("LOAD_CONST", argval=mro_index),
-                            create_instruction(
-                                "STORE_FAST", argval=varname_map["mro_index"]
-                            ),
-                        ]
+                if action is SideEffectReplayAction.ERROR:
+                    raise RuntimeError(
+                        f"Side effect replay rule {rule.name!r} rejected "
+                        f"{type(var).__name__}: {rule.reason}"
                     )
 
-                    cg(var.source)  # type: ignore[attr-defined]
-                    cg.extend_output(
-                        [
-                            create_instruction(
-                                "STORE_FAST", argval=varname_map["dict_to"]
-                            )
-                        ]
-                    )
-
-                    # Reconstruct all items — _manual_dict_setitem clears
-                    # dict_to first, so we need every key/value, not just
-                    # the ones that differ from original_items.
-                    var._base_vt.should_reconstruct_all = True  # type: ignore[union-attr]
-                    cg(var._base_vt, allow_cache=False)  # Don't codegen via source
-                    cg.extend_output(
-                        [
-                            create_instruction(
-                                "STORE_FAST", argval=varname_map["dict_from"]
-                            )
-                        ]
-                    )
-
-                    dict_update_insts = bytecode_from_template(
-                        _manual_dict_setitem, varname_map=varname_map
-                    )
-
-                    suffixes.append(
-                        [
-                            *dict_update_insts,
-                            create_instruction("POP_TOP"),
-                        ]
-                    )
-                    _maybe_log_side_effect(
-                        var._base_vt  # pyrefly: ignore[bad-argument-type]
-                    )
-                elif isinstance(
-                    var,
-                    variables.UserDefinedListVariable,
-                ) and self.is_modified(
-                    var._base_vt  # pyrefly: ignore[bad-argument-type]
-                ):
-                    # Update the list to the updated items. Be careful in
-                    # calling the list methods and not the overridden methods.
-                    varname_map = {}
-                    for name in _manual_list_update.__code__.co_varnames:
-                        varname_map[name] = cg.tx.output.new_var()
-
-                    cg(var.source)  # type: ignore[attr-defined]
-                    cg.extend_output(
-                        [
-                            create_instruction(
-                                "STORE_FAST", argval=varname_map["list_to"]
-                            )
-                        ]
-                    )
-
-                    cg(var._base_vt, allow_cache=False)  # Don't codegen via source
-                    cg.extend_output(
-                        [
-                            create_instruction(
-                                "STORE_FAST", argval=varname_map["list_from"]
-                            )
-                        ]
-                    )
-
-                    list_update_insts = bytecode_from_template(
-                        _manual_list_update, varname_map=varname_map
-                    )
-
-                    suffixes.append(
-                        [
-                            *list_update_insts,
-                            create_instruction("POP_TOP"),
-                        ]
-                    )
-                    _maybe_log_side_effect(
-                        var._base_vt  # pyrefly: ignore[bad-argument-type]
-                    )
-                elif isinstance(
-                    var,
-                    variables.UserDefinedDequeVariable,
-                ) and self.is_modified(
-                    var._base_vt  # pyrefly: ignore[bad-argument-type]
-                ):
-                    # Update the deque to the updated items. Be careful in
-                    # calling the deque methods and not the overridden methods.
-                    varname_map = {}
-                    for name in _manual_deque_update.__code__.co_varnames:
-                        varname_map[name] = cg.tx.output.new_var()
-
-                    cg(var.source)  # type: ignore[attr-defined]
-                    cg.extend_output(
-                        [
-                            create_instruction(
-                                "STORE_FAST", argval=varname_map["deque_to"]
-                            )
-                        ]
-                    )
-
-                    cg(var._base_vt, allow_cache=False)  # Don't codegen via source
-                    cg.extend_output(
-                        [
-                            create_instruction(
-                                "STORE_FAST", argval=varname_map["deque_from"]
-                            )
-                        ]
-                    )
-
-                    deque_update_insts = bytecode_from_template(
-                        _manual_deque_update, varname_map=varname_map
-                    )
-
-                    suffixes.append(
-                        [
-                            *deque_update_insts,
-                            create_instruction("POP_TOP"),
-                        ]
-                    )
-                    _maybe_log_side_effect(
-                        var._base_vt  # pyrefly: ignore[bad-argument-type]
-                    )
-
-                # Applying mutations involves two steps: 1) Push all
-                # reconstructed objects onto the stack.  2) Call STORE_ATTR to
-                # apply the mutations.
-                #
-                # Dynamo must ensure that mutations are applied in the same
-                # order as in the original program. Therefore, two reverse
-                # operations occur below.
-                #
-                # The first reverse operation concerns `suffixes`. We apply
-                # suffixes in reverse order due to the way Python handles the
-                # stack. In Step 1, we push all reconstructed objects onto the
-                # stack, but the item at the top of the stack refers to the last
-                # attribute in the mutation order. If not fixed, this will apply
-                # the mutations of attributes in the reverse order.  To account
-                # for this reversal, we iterate through the mutable attributes
-                # in reverse order.
-                side_effect_occurred = False
-                for name, value in reversed(
-                    self.store_attr_mutations.get(var, {}).items()
-                ):
-                    mutation_kind = self.get_attr_mutation_kind(var, name)
-                    if isinstance(var, variables.NewGlobalVariable):
-                        cg.tx.output.update_co_names(name)
-                        cg(value)
-                        if not isinstance(var.source, GlobalSource):  # type: ignore[attr-defined]
-                            raise AssertionError(
-                                f"Expected GlobalSource for NewGlobalVariable, "
-                                f"got {type(var.source)}"  # type: ignore[attr-defined]
-                            )
-                        suffixes.append(
-                            [create_instruction("STORE_GLOBAL", argval=name)]
-                        )
-                        side_effect_occurred = True
-                    elif isinstance(value, variables.DeletedVariable):
-                        if (
-                            isinstance(var, variables.UserDefinedObjectVariable)
-                            and mutation_kind is AttrMutationKind.INSTANCE_DICT
-                        ):
-                            original_dict = getattr(
-                                getattr(var, "value", None), "__dict__", {}
-                            )
-                            # If the key only existed in the traced instance
-                            # dict, the add/delete sequence is a replay no-op.
-                            if name in original_dict:
-                                cg.add_push_null(
-                                    lambda: cg.load_import_from(
-                                        utils.__name__,
-                                        "object_delattr_ignore_descriptor",
-                                    )
-                                )
-                                cg(var.source)  # type: ignore[attr-defined]
-                                cg(variables.ConstantVariable(name))
-                                suffixes.append(
-                                    [
-                                        *create_call_function(2, False),
-                                        create_instruction("POP_TOP"),
-                                    ]
-                                )
-                                side_effect_occurred = True
-                        # GENERIC_SETATTR deletions on UDOV fall through to the
-                        # normal DELETE_ATTR path below so descriptor semantics
-                        # are preserved during replay.
-                        elif isinstance(
-                            var.mutation_type, AttributeMutationExisting
-                        ) and hasattr(getattr(var, "value", None), name):
-                            cg.tx.output.update_co_names(name)
-                            cg(var.source)
-                            suffixes.append(
-                                [create_instruction("DELETE_ATTR", argval=name)]
-                            )
-                            side_effect_occurred = True
-                    elif (
-                        isinstance(var, variables.UserDefinedObjectVariable)
-                        and mutation_kind is AttrMutationKind.INSTANCE_DICT
-                    ):
-                        cg.add_push_null(
-                            lambda: cg.load_import_from(
-                                utils.__name__, "object_setattr_ignore_descriptor"
-                            )
-                        )
-                        cg(var.source)  # type: ignore[attr-defined]
-                        cg(variables.ConstantVariable(name))
-                        cg(value)
-                        suffixes.append(
-                            [
-                                *create_call_function(3, False),
-                                create_instruction("POP_TOP"),
-                            ]
-                        )
-                        side_effect_occurred = True
-                    elif (
-                        isinstance(var, variables.UserDefinedObjectVariable)
-                        and var.needs_slow_setattr()
-                    ):
-                        # __setattr__ is defined on this object, so call object.__setattr__ directly
-                        cg.load_import_from("builtins", "object")
-                        cg.load_method("__setattr__")
-                        cg(var.source)  # type: ignore[attr-defined]
-                        cg(variables.ConstantVariable(name))
-                        cg(value)
-                        suffixes.append(
-                            [*create_call_method(3), create_instruction("POP_TOP")]
-                        )
-                        side_effect_occurred = True
-                    else:
-                        cg.tx.output.update_co_names(name)
-                        cg(value)
-                        cg(var)
-                        suffixes.append([create_instruction("STORE_ATTR", argval=name)])
-                        side_effect_occurred = True
-
-                if side_effect_occurred:
-                    _maybe_log_side_effect(var)
-            elif isinstance(var, variables.ListIteratorVariable):
-                for _ in range(var.index):
-                    cg.add_push_null(
-                        lambda: cg.load_import_from(utils.__name__, "iter_next")
-                    )
-                    cg(var.source)  # type: ignore[attr-defined]
-                    cg.call_function(1, False)
-                    cg.pop_top()
-                _maybe_log_side_effect(var)
-            elif isinstance(var, variables.CountIteratorVariable):
-                for _ in range(var.advance_count):
-                    cg.add_push_null(
-                        lambda: cg.load_import_from(utils.__name__, "iter_next")
-                    )
-                    cg(var.source)  # type: ignore[attr-defined]
-                    cg.call_function(1, False)
-                    cg.pop_top()
-                _maybe_log_side_effect(var)
-            elif isinstance(var, variables.RandomVariable):
-                # set correct random seed state
-                def gen_fn() -> None:
-                    cg(var.source)  # type: ignore[attr-defined]
-                    cg.load_attr("setstate")
-
-                cg.add_push_null(gen_fn)
-                cg(var.wrap_state(var.random.getstate()))
-
-                suffixes.append(
-                    [
-                        *create_call_function(1, False),  # setstate
-                        create_instruction("POP_TOP"),
-                    ]
-                )
-                _maybe_log_side_effect(var)
-            else:
+            handler = _side_effect_replay_registry.lookup_handler(ctx)
+            if handler is None:
                 raise AssertionError(type(var))
+            handler.codegen(ctx)
 
         # do all the actual mutations at the very end to handle dependencies
         for suffix in reversed(suffixes):
@@ -1862,6 +1643,515 @@ class SideEffects:
     def clear(self) -> None:
         self.keepalive.clear()
         self.id_to_variable.clear()
+
+
+@register_side_effect_replay_handler(
+    name="list_mutation",
+    matcher=lambda ctx: isinstance(ctx.var, variables.ListVariable),
+)
+def _codegen_list_mutation(ctx: SideEffectReplayContext) -> None:
+    cg = ctx.codegen
+    var = ctx.var
+    assert isinstance(var, variables.ListVariable)
+    # old[:] = new
+    cg(var, allow_cache=False)  # Don't codegen via source
+    cg(var.source)  # type: ignore[attr-defined]
+    cg.extend_output(
+        [
+            cg.create_load_const(None),
+            cg.create_load_const(None),
+            create_instruction("BUILD_SLICE", arg=2),
+        ]
+    )
+    ctx.suffixes.append([create_instruction("STORE_SUBSCR")])
+    ctx.log(var)
+
+
+@register_side_effect_replay_handler(
+    name="deque_mutation",
+    matcher=lambda ctx: isinstance(ctx.var, variables.lists.DequeVariable),
+)
+def _codegen_deque_mutation(ctx: SideEffectReplayContext) -> None:
+    cg = ctx.codegen
+    var = ctx.var
+    assert isinstance(var, variables.lists.DequeVariable)
+    # For limited maxlen, the order of operations matter for side effect, but we
+    # currently don't track the order, so no support.
+    if not var.maxlen.is_constant_none():
+        unimplemented(
+            gb_type="Side effect on existing deque with limited maxlen",
+            context="",
+            explanation="This is not supported.",
+            hints=[
+                "Don't use a deque with `maxlen` specified.",
+            ],
+        )
+
+    # old.extend(new), this runs last
+    cg(var.source)
+    cg.load_method("extend")
+    cg(var, allow_cache=False)  # Don't codegen via source
+    ctx.suffixes.append(
+        [
+            *create_call_method(1),
+            create_instruction("POP_TOP"),
+        ]
+    )
+
+    # old.clear(), this runs first
+    cg(var.source)
+    cg.load_method("clear")
+    ctx.suffixes.append(
+        [
+            *create_call_method(0),
+            create_instruction("POP_TOP"),
+        ]
+    )
+    ctx.log(var)
+
+
+@register_side_effect_replay_handler(
+    name="const_dict_or_set_mutation",
+    matcher=lambda ctx: isinstance(
+        ctx.var, (variables.ConstDictVariable, variables.SetVariable)
+    ),
+)
+def _codegen_const_dict_or_set_mutation(ctx: SideEffectReplayContext) -> None:
+    cg = ctx.codegen
+    var = ctx.var
+    assert isinstance(var, (variables.ConstDictVariable, variables.SetVariable))
+    # Reconstruct works as follow:
+    # (1) Skip codegen if there are no new items
+    # (2) codegen(...) each pair of key/value
+    # (3) create a new dictionary with the pairs of key/values above
+    # (4) clear the original dictionary
+    #   + only if a key was removed from the input dict
+    # (5) update the original dictionary with the dict created in (2)
+    if var.has_new_items():
+        cg(var.source)  # type: ignore[attr-defined]
+        cg.load_method("update")
+        cg(var, allow_cache=False)  # Don't codegen via source
+
+        if var.should_reconstruct_all:
+            cg(var.source)  # type: ignore[attr-defined]
+            cg.load_method("clear")
+
+        ctx.suffixes.append(
+            [
+                *create_call_method(1),  # update
+                create_instruction("POP_TOP"),
+            ]
+        )
+
+        if var.should_reconstruct_all:
+            # clear will appear before "update" as the suffixes are applied in
+            # reverse order.
+            ctx.suffixes.append(
+                [
+                    *create_call_method(0),  # clear
+                    create_instruction("POP_TOP"),
+                ]
+            )
+        ctx.log(var)
+
+
+@register_side_effect_replay_handler(
+    name="torch_function_mode_stack_mutation",
+    matcher=lambda ctx: isinstance(
+        ctx.var, variables.torch_function.TorchFunctionModeStackVariable
+    ),
+)
+def _codegen_torch_function_mode_stack_mutation(
+    ctx: SideEffectReplayContext,
+) -> None:
+    cg = ctx.codegen
+    var = ctx.var
+    assert isinstance(var, variables.torch_function.TorchFunctionModeStackVariable)
+    cg.add_push_null(
+        lambda: cg.load_import_from(
+            utils.__name__, "set_torch_function_mode_stack"
+        )
+    )
+
+    cg.foreach(var.symbolic_stack)
+    cg.append_output(create_instruction("BUILD_LIST", arg=len(var.symbolic_stack)))
+    cg.call_function(1, False)
+    cg.append_output(create_instruction("POP_TOP"))
+    ctx.log(var)
+
+
+@register_side_effect_replay_handler(
+    name="cell_mutation",
+    matcher=lambda ctx: isinstance(ctx.var, variables.CellVariable)
+    and ctx.var.local_name is not None,
+    priority=10,
+)
+def _codegen_cell_mutation(ctx: SideEffectReplayContext) -> None:
+    cg = ctx.codegen
+    var = ctx.var
+    assert isinstance(var, variables.CellVariable)
+    assert var.local_name is not None
+    # Emit more readable and performant bytecode.
+    # TODO generalize this for cells created during inlining.
+    if var in ctx.side_effects.store_attr_mutations:
+        contents_var = ctx.side_effects.load_cell(var)
+        cg(contents_var)
+        ctx.suffixes.append([cg.create_store_deref(var.local_name)])
+        ctx.log(var)
+
+
+def _codegen_user_defined_dict_mutation(ctx: SideEffectReplayContext) -> None:
+    cg = ctx.codegen
+    var = ctx.var
+    assert isinstance(var, variables.UserDefinedDictVariable)
+    # Do dict related update manually here. The store_attr mutations will be
+    # applied later.
+    varname_map = {}
+    for name in _manual_dict_setitem.__code__.co_varnames:
+        varname_map[name] = cg.tx.output.new_var()
+
+    try:
+        mro_index = type(var.value).__mro__.index(collections.OrderedDict)
+    except ValueError:
+        mro_index = type(var.value).__mro__.index(dict)
+
+    cg.extend_output(
+        [
+            create_instruction("LOAD_CONST", argval=mro_index),
+            create_instruction("STORE_FAST", argval=varname_map["mro_index"]),
+        ]
+    )
+
+    cg(var.source)  # type: ignore[attr-defined]
+    cg.extend_output(
+        [
+            create_instruction("STORE_FAST", argval=varname_map["dict_to"]),
+        ]
+    )
+
+    # Reconstruct all items - _manual_dict_setitem clears dict_to first, so we
+    # need every key/value, not just the ones that differ from original_items.
+    var._base_vt.should_reconstruct_all = True  # type: ignore[union-attr]
+    cg(var._base_vt, allow_cache=False)  # Don't codegen via source
+    cg.extend_output(
+        [
+            create_instruction("STORE_FAST", argval=varname_map["dict_from"]),
+        ]
+    )
+
+    dict_update_insts = bytecode_from_template(
+        _manual_dict_setitem, varname_map=varname_map
+    )
+
+    ctx.suffixes.append(
+        [
+            *dict_update_insts,
+            create_instruction("POP_TOP"),
+        ]
+    )
+    ctx.log(
+        var._base_vt  # pyrefly: ignore[bad-argument-type]
+    )
+
+
+def _codegen_user_defined_list_mutation(ctx: SideEffectReplayContext) -> None:
+    cg = ctx.codegen
+    var = ctx.var
+    assert isinstance(var, variables.UserDefinedListVariable)
+    # Update the list to the updated items. Be careful in calling the list
+    # methods and not the overridden methods.
+    varname_map = {}
+    for name in _manual_list_update.__code__.co_varnames:
+        varname_map[name] = cg.tx.output.new_var()
+
+    cg(var.source)  # type: ignore[attr-defined]
+    cg.extend_output(
+        [
+            create_instruction("STORE_FAST", argval=varname_map["list_to"]),
+        ]
+    )
+
+    cg(var._base_vt, allow_cache=False)  # Don't codegen via source
+    cg.extend_output(
+        [
+            create_instruction("STORE_FAST", argval=varname_map["list_from"]),
+        ]
+    )
+
+    list_update_insts = bytecode_from_template(
+        _manual_list_update, varname_map=varname_map
+    )
+
+    ctx.suffixes.append(
+        [
+            *list_update_insts,
+            create_instruction("POP_TOP"),
+        ]
+    )
+    ctx.log(
+        var._base_vt  # pyrefly: ignore[bad-argument-type]
+    )
+
+
+def _codegen_user_defined_deque_mutation(ctx: SideEffectReplayContext) -> None:
+    cg = ctx.codegen
+    var = ctx.var
+    assert isinstance(var, variables.UserDefinedDequeVariable)
+    # Update the deque to the updated items. Be careful in calling the deque
+    # methods and not the overridden methods.
+    varname_map = {}
+    for name in _manual_deque_update.__code__.co_varnames:
+        varname_map[name] = cg.tx.output.new_var()
+
+    cg(var.source)  # type: ignore[attr-defined]
+    cg.extend_output(
+        [
+            create_instruction("STORE_FAST", argval=varname_map["deque_to"]),
+        ]
+    )
+
+    cg(var._base_vt, allow_cache=False)  # Don't codegen via source
+    cg.extend_output(
+        [
+            create_instruction("STORE_FAST", argval=varname_map["deque_from"]),
+        ]
+    )
+
+    deque_update_insts = bytecode_from_template(
+        _manual_deque_update, varname_map=varname_map
+    )
+
+    ctx.suffixes.append(
+        [
+            *deque_update_insts,
+            create_instruction("POP_TOP"),
+        ]
+    )
+    ctx.log(
+        var._base_vt  # pyrefly: ignore[bad-argument-type]
+    )
+
+
+def _skip_attribute_mutation_replay(var: VariableTracker) -> bool:
+    # FrozenDataClassVariable attributes were emitted in codegen_save_tempvars
+    # right after __new__. Skip here to avoid double-emitting.
+    if isinstance(var.mutation_type, AttributeMutationNew) and isinstance(
+        var, variables.FrozenDataClassVariable
+    ):
+        return True
+
+    # Sourceless enum members: mutations (like _inverted_ caching) already
+    # happened on the real object during tracing.
+    return (
+        var.is_python_constant()
+        and isinstance(var.mutation_type, AttributeMutationNew)
+        and isinstance(var, variables.UserDefinedObjectVariable)
+        and (
+            isinstance(
+                var.value,
+                (
+                    enum.Enum,
+                    torch.DispatchKey,
+                    torch._C._functorch.TransformType,
+                ),
+            )
+            or is_pybind11_enum_member(var.value)
+        )
+    )
+
+
+@register_side_effect_replay_handler(
+    name="attribute_mutation",
+    matcher=lambda ctx: ctx.side_effects.is_attribute_mutation(ctx.var),
+)
+def _codegen_attribute_mutation(ctx: SideEffectReplayContext) -> None:
+    cg = ctx.codegen
+    var = ctx.var
+    side_effects = ctx.side_effects
+    if _skip_attribute_mutation_replay(var):
+        return
+
+    if (
+        isinstance(var, variables.UserDefinedDictVariable)
+        and side_effects.is_modified(
+            var._base_vt  # pyrefly: ignore[bad-argument-type]
+        )
+        and var._base_vt.has_new_items()  # type: ignore[union-attr]
+    ):
+        _codegen_user_defined_dict_mutation(ctx)
+    elif (
+        isinstance(var, variables.UserDefinedListVariable)
+        and side_effects.is_modified(
+            var._base_vt  # pyrefly: ignore[bad-argument-type]
+        )
+    ):
+        _codegen_user_defined_list_mutation(ctx)
+    elif (
+        isinstance(var, variables.UserDefinedDequeVariable)
+        and side_effects.is_modified(
+            var._base_vt  # pyrefly: ignore[bad-argument-type]
+        )
+    ):
+        _codegen_user_defined_deque_mutation(ctx)
+
+    # Applying mutations involves two steps: 1) Push all reconstructed objects
+    # onto the stack. 2) Call STORE_ATTR to apply the mutations.
+    #
+    # Dynamo must ensure that mutations are applied in the same order as in the
+    # original program. Therefore, two reverse operations occur below.
+    #
+    # The first reverse operation concerns `suffixes`. We apply suffixes in
+    # reverse order due to the way Python handles the stack. In Step 1, we push
+    # all reconstructed objects onto the stack, but the item at the top of the
+    # stack refers to the last attribute in the mutation order. If not fixed,
+    # this will apply the mutations of attributes in the reverse order. To
+    # account for this reversal, we iterate through the mutable attributes in
+    # reverse order.
+    side_effect_occurred = False
+    for name, value in reversed(side_effects.store_attr_mutations.get(var, {}).items()):
+        mutation_kind = side_effects.get_attr_mutation_kind(var, name)
+        if isinstance(var, variables.NewGlobalVariable):
+            cg.tx.output.update_co_names(name)
+            cg(value)
+            if not isinstance(var.source, GlobalSource):  # type: ignore[attr-defined]
+                raise AssertionError(
+                    f"Expected GlobalSource for NewGlobalVariable, "
+                    f"got {type(var.source)}"  # type: ignore[attr-defined]
+                )
+            ctx.suffixes.append([create_instruction("STORE_GLOBAL", argval=name)])
+            side_effect_occurred = True
+        elif isinstance(value, variables.DeletedVariable):
+            if (
+                isinstance(var, variables.UserDefinedObjectVariable)
+                and mutation_kind is AttrMutationKind.INSTANCE_DICT
+            ):
+                original_dict = getattr(getattr(var, "value", None), "__dict__", {})
+                # If the key only existed in the traced instance dict, the
+                # add/delete sequence is a replay no-op.
+                if name in original_dict:
+                    cg.add_push_null(
+                        lambda: cg.load_import_from(
+                            utils.__name__,
+                            "object_delattr_ignore_descriptor",
+                        )
+                    )
+                    cg(var.source)  # type: ignore[attr-defined]
+                    cg(variables.ConstantVariable(name))
+                    ctx.suffixes.append(
+                        [
+                            *create_call_function(2, False),
+                            create_instruction("POP_TOP"),
+                        ]
+                    )
+                    side_effect_occurred = True
+            # GENERIC_SETATTR deletions on UDOV fall through to the normal
+            # DELETE_ATTR path below so descriptor semantics are preserved
+            # during replay.
+            elif isinstance(var.mutation_type, AttributeMutationExisting) and hasattr(
+                getattr(var, "value", None), name
+            ):
+                cg.tx.output.update_co_names(name)
+                cg(var.source)
+                ctx.suffixes.append([create_instruction("DELETE_ATTR", argval=name)])
+                side_effect_occurred = True
+        elif (
+            isinstance(var, variables.UserDefinedObjectVariable)
+            and mutation_kind is AttrMutationKind.INSTANCE_DICT
+        ):
+            cg.add_push_null(
+                lambda: cg.load_import_from(
+                    utils.__name__, "object_setattr_ignore_descriptor"
+                )
+            )
+            cg(var.source)  # type: ignore[attr-defined]
+            cg(variables.ConstantVariable(name))
+            cg(value)
+            ctx.suffixes.append(
+                [
+                    *create_call_function(3, False),
+                    create_instruction("POP_TOP"),
+                ]
+            )
+            side_effect_occurred = True
+        elif (
+            isinstance(var, variables.UserDefinedObjectVariable)
+            and var.needs_slow_setattr()
+        ):
+            # __setattr__ is defined on this object, so call object.__setattr__
+            # directly.
+            cg.load_import_from("builtins", "object")
+            cg.load_method("__setattr__")
+            cg(var.source)  # type: ignore[attr-defined]
+            cg(variables.ConstantVariable(name))
+            cg(value)
+            ctx.suffixes.append([*create_call_method(3), create_instruction("POP_TOP")])
+            side_effect_occurred = True
+        else:
+            cg.tx.output.update_co_names(name)
+            cg(value)
+            cg(var)
+            ctx.suffixes.append([create_instruction("STORE_ATTR", argval=name)])
+            side_effect_occurred = True
+
+    if side_effect_occurred:
+        ctx.log(var)
+
+
+@register_side_effect_replay_handler(
+    name="list_iterator_mutation",
+    matcher=lambda ctx: isinstance(ctx.var, variables.ListIteratorVariable),
+)
+def _codegen_list_iterator_mutation(ctx: SideEffectReplayContext) -> None:
+    cg = ctx.codegen
+    var = ctx.var
+    assert isinstance(var, variables.ListIteratorVariable)
+    for _ in range(var.index):
+        cg.add_push_null(lambda: cg.load_import_from(utils.__name__, "iter_next"))
+        cg(var.source)  # type: ignore[attr-defined]
+        cg.call_function(1, False)
+        cg.pop_top()
+    ctx.log(var)
+
+
+@register_side_effect_replay_handler(
+    name="count_iterator_mutation",
+    matcher=lambda ctx: isinstance(ctx.var, variables.CountIteratorVariable),
+)
+def _codegen_count_iterator_mutation(ctx: SideEffectReplayContext) -> None:
+    cg = ctx.codegen
+    var = ctx.var
+    assert isinstance(var, variables.CountIteratorVariable)
+    for _ in range(var.advance_count):
+        cg.add_push_null(lambda: cg.load_import_from(utils.__name__, "iter_next"))
+        cg(var.source)  # type: ignore[attr-defined]
+        cg.call_function(1, False)
+        cg.pop_top()
+    ctx.log(var)
+
+
+@register_side_effect_replay_handler(
+    name="random_mutation",
+    matcher=lambda ctx: isinstance(ctx.var, variables.RandomVariable),
+)
+def _codegen_random_mutation(ctx: SideEffectReplayContext) -> None:
+    cg = ctx.codegen
+    var = ctx.var
+    assert isinstance(var, variables.RandomVariable)
+
+    def gen_fn() -> None:
+        cg(var.source)  # type: ignore[attr-defined]
+        cg.load_attr("setstate")
+
+    cg.add_push_null(gen_fn)
+    cg(var.wrap_state(var.random.getstate()))
+
+    ctx.suffixes.append(
+        [
+            *create_call_function(1, False),  # setstate
+            create_instruction("POP_TOP"),
+        ]
+    )
+    ctx.log(var)
 
 
 @contextlib.contextmanager

--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -89,10 +89,6 @@ class SideEffectReplayContext:
     suffixes: list[list[Instruction]]
     log: Callable[[VariableTracker], None]
 
-    @property
-    def tx(self) -> "InstructionTranslatorBase":
-        return self.codegen.tx
-
 
 SideEffectReplayMatcher = Callable[[SideEffectReplayContext], bool]
 SideEffectReplayCodegen = Callable[[SideEffectReplayContext], None]

--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -36,8 +36,8 @@ from typing import Any, overload, TYPE_CHECKING
 
 import torch
 import torch.nn
-from torch._library.utils import RegistrationHandle
 from torch._dynamo.variables.misc import AutogradFunctionContextVariable
+from torch._library.utils import RegistrationHandle
 from torch.utils._ordered_set import OrderedSet
 from torch.utils._pytree import is_structseq_class
 
@@ -152,9 +152,7 @@ class _SideEffectReplayRegistry:
 
         return RegistrationHandle(deregister)
 
-    def lookup_rule(
-        self, ctx: SideEffectReplayContext
-    ) -> SideEffectReplayRule | None:
+    def lookup_rule(self, ctx: SideEffectReplayContext) -> SideEffectReplayRule | None:
         return self._lookup_unique("side effect replay rule", self.rules, ctx)
 
     def lookup_handler(
@@ -187,15 +185,10 @@ class _SideEffectReplayRegistry:
 _side_effect_replay_registry = _SideEffectReplayRegistry()
 
 
-def _attach_registration_handle(fn: Callable[..., Any], handle: RegistrationHandle) -> None:
-    setattr(fn, "_side_effect_replay_handle", handle)
-
-
 @overload
 def register_side_effect_replay_rule(
     rule: SideEffectReplayRule,
-) -> RegistrationHandle:
-    ...
+) -> RegistrationHandle: ...
 
 
 @overload
@@ -206,8 +199,7 @@ def register_side_effect_replay_rule(
     reason: str,
     cache_key: Hashable,
     priority: int = 0,
-) -> SideEffectReplayRuleDecorator:
-    ...
+) -> SideEffectReplayRuleDecorator: ...
 
 
 def register_side_effect_replay_rule(
@@ -222,15 +214,19 @@ def register_side_effect_replay_rule(
     if rule is not None:
         return _side_effect_replay_registry.register_rule(rule)
 
-    assert name is not None
-    assert matcher is not None
-    assert reason is not None
-    assert cache_key is not None
+    if name is None:
+        raise AssertionError("side effect replay rule name must be set")
+    if matcher is None:
+        raise AssertionError("side effect replay rule matcher must be set")
+    if reason is None:
+        raise AssertionError("side effect replay rule reason must be set")
+    if cache_key is None:
+        raise AssertionError("side effect replay rule cache key must be set")
 
     def decorator(
         operation: SideEffectReplayRuleOperation,
     ) -> SideEffectReplayRuleOperation:
-        handle = _side_effect_replay_registry.register_rule(
+        _side_effect_replay_registry.register_rule(
             SideEffectReplayRule(
                 name=name,
                 matcher=matcher,
@@ -240,7 +236,6 @@ def register_side_effect_replay_rule(
                 priority=priority,
             )
         )
-        _attach_registration_handle(operation, handle)
         return operation
 
     return decorator
@@ -265,7 +260,7 @@ def register_side_effect_replay_handler(
     def decorator(
         codegen: SideEffectReplayCodegen,
     ) -> SideEffectReplayCodegen:
-        handle = _register_side_effect_replay_handler(
+        _register_side_effect_replay_handler(
             SideEffectReplayHandler(
                 name=name,
                 matcher=matcher,
@@ -273,7 +268,6 @@ def register_side_effect_replay_handler(
                 priority=priority,
             )
         )
-        _attach_registration_handle(codegen, handle)
         return codegen
 
     return decorator
@@ -1648,11 +1642,13 @@ class SideEffects:
 @register_side_effect_replay_handler(
     name="list_mutation",
     matcher=lambda ctx: isinstance(ctx.var, variables.ListVariable),
+    priority=90,
 )
 def _codegen_list_mutation(ctx: SideEffectReplayContext) -> None:
     cg = ctx.codegen
     var = ctx.var
-    assert isinstance(var, variables.ListVariable)
+    if not isinstance(var, variables.ListVariable):
+        raise AssertionError(type(var))
     # old[:] = new
     cg(var, allow_cache=False)  # Don't codegen via source
     cg(var.source)  # type: ignore[attr-defined]
@@ -1670,11 +1666,13 @@ def _codegen_list_mutation(ctx: SideEffectReplayContext) -> None:
 @register_side_effect_replay_handler(
     name="deque_mutation",
     matcher=lambda ctx: isinstance(ctx.var, variables.lists.DequeVariable),
+    priority=80,
 )
 def _codegen_deque_mutation(ctx: SideEffectReplayContext) -> None:
     cg = ctx.codegen
     var = ctx.var
-    assert isinstance(var, variables.lists.DequeVariable)
+    if not isinstance(var, variables.lists.DequeVariable):
+        raise AssertionError(type(var))
     # For limited maxlen, the order of operations matter for side effect, but we
     # currently don't track the order, so no support.
     if not var.maxlen.is_constant_none():
@@ -1715,11 +1713,13 @@ def _codegen_deque_mutation(ctx: SideEffectReplayContext) -> None:
     matcher=lambda ctx: isinstance(
         ctx.var, (variables.ConstDictVariable, variables.SetVariable)
     ),
+    priority=70,
 )
 def _codegen_const_dict_or_set_mutation(ctx: SideEffectReplayContext) -> None:
     cg = ctx.codegen
     var = ctx.var
-    assert isinstance(var, (variables.ConstDictVariable, variables.SetVariable))
+    if not isinstance(var, (variables.ConstDictVariable, variables.SetVariable)):
+        raise AssertionError(type(var))
     # Reconstruct works as follow:
     # (1) Skip codegen if there are no new items
     # (2) codegen(...) each pair of key/value
@@ -1760,17 +1760,17 @@ def _codegen_const_dict_or_set_mutation(ctx: SideEffectReplayContext) -> None:
     matcher=lambda ctx: isinstance(
         ctx.var, variables.torch_function.TorchFunctionModeStackVariable
     ),
+    priority=60,
 )
 def _codegen_torch_function_mode_stack_mutation(
     ctx: SideEffectReplayContext,
 ) -> None:
     cg = ctx.codegen
     var = ctx.var
-    assert isinstance(var, variables.torch_function.TorchFunctionModeStackVariable)
+    if not isinstance(var, variables.torch_function.TorchFunctionModeStackVariable):
+        raise AssertionError(type(var))
     cg.add_push_null(
-        lambda: cg.load_import_from(
-            utils.__name__, "set_torch_function_mode_stack"
-        )
+        lambda: cg.load_import_from(utils.__name__, "set_torch_function_mode_stack")
     )
 
     cg.foreach(var.symbolic_stack)
@@ -1784,13 +1784,15 @@ def _codegen_torch_function_mode_stack_mutation(
     name="cell_mutation",
     matcher=lambda ctx: isinstance(ctx.var, variables.CellVariable)
     and ctx.var.local_name is not None,
-    priority=10,
+    priority=50,
 )
 def _codegen_cell_mutation(ctx: SideEffectReplayContext) -> None:
     cg = ctx.codegen
     var = ctx.var
-    assert isinstance(var, variables.CellVariable)
-    assert var.local_name is not None
+    if not isinstance(var, variables.CellVariable):
+        raise AssertionError(type(var))
+    if var.local_name is None:
+        raise AssertionError("cell mutation local name must be set")
     # Emit more readable and performant bytecode.
     # TODO generalize this for cells created during inlining.
     if var in ctx.side_effects.store_attr_mutations:
@@ -1803,7 +1805,8 @@ def _codegen_cell_mutation(ctx: SideEffectReplayContext) -> None:
 def _codegen_user_defined_dict_mutation(ctx: SideEffectReplayContext) -> None:
     cg = ctx.codegen
     var = ctx.var
-    assert isinstance(var, variables.UserDefinedDictVariable)
+    if not isinstance(var, variables.UserDefinedDictVariable):
+        raise AssertionError(type(var))
     # Do dict related update manually here. The store_attr mutations will be
     # applied later.
     varname_map = {}
@@ -1857,7 +1860,8 @@ def _codegen_user_defined_dict_mutation(ctx: SideEffectReplayContext) -> None:
 def _codegen_user_defined_list_mutation(ctx: SideEffectReplayContext) -> None:
     cg = ctx.codegen
     var = ctx.var
-    assert isinstance(var, variables.UserDefinedListVariable)
+    if not isinstance(var, variables.UserDefinedListVariable):
+        raise AssertionError(type(var))
     # Update the list to the updated items. Be careful in calling the list
     # methods and not the overridden methods.
     varname_map = {}
@@ -1896,7 +1900,8 @@ def _codegen_user_defined_list_mutation(ctx: SideEffectReplayContext) -> None:
 def _codegen_user_defined_deque_mutation(ctx: SideEffectReplayContext) -> None:
     cg = ctx.codegen
     var = ctx.var
-    assert isinstance(var, variables.UserDefinedDequeVariable)
+    if not isinstance(var, variables.UserDefinedDequeVariable):
+        raise AssertionError(type(var))
     # Update the deque to the updated items. Be careful in calling the deque
     # methods and not the overridden methods.
     varname_map = {}
@@ -1963,6 +1968,7 @@ def _skip_attribute_mutation_replay(var: VariableTracker) -> bool:
 @register_side_effect_replay_handler(
     name="attribute_mutation",
     matcher=lambda ctx: ctx.side_effects.is_attribute_mutation(ctx.var),
+    priority=40,
 )
 def _codegen_attribute_mutation(ctx: SideEffectReplayContext) -> None:
     cg = ctx.codegen
@@ -1979,18 +1985,16 @@ def _codegen_attribute_mutation(ctx: SideEffectReplayContext) -> None:
         and var._base_vt.has_new_items()  # type: ignore[union-attr]
     ):
         _codegen_user_defined_dict_mutation(ctx)
-    elif (
-        isinstance(var, variables.UserDefinedListVariable)
-        and side_effects.is_modified(
-            var._base_vt  # pyrefly: ignore[bad-argument-type]
-        )
+    elif isinstance(
+        var, variables.UserDefinedListVariable
+    ) and side_effects.is_modified(
+        var._base_vt  # pyrefly: ignore[bad-argument-type]
     ):
         _codegen_user_defined_list_mutation(ctx)
-    elif (
-        isinstance(var, variables.UserDefinedDequeVariable)
-        and side_effects.is_modified(
-            var._base_vt  # pyrefly: ignore[bad-argument-type]
-        )
+    elif isinstance(
+        var, variables.UserDefinedDequeVariable
+    ) and side_effects.is_modified(
+        var._base_vt  # pyrefly: ignore[bad-argument-type]
     ):
         _codegen_user_defined_deque_mutation(ctx)
 
@@ -2100,11 +2104,13 @@ def _codegen_attribute_mutation(ctx: SideEffectReplayContext) -> None:
 @register_side_effect_replay_handler(
     name="list_iterator_mutation",
     matcher=lambda ctx: isinstance(ctx.var, variables.ListIteratorVariable),
+    priority=30,
 )
 def _codegen_list_iterator_mutation(ctx: SideEffectReplayContext) -> None:
     cg = ctx.codegen
     var = ctx.var
-    assert isinstance(var, variables.ListIteratorVariable)
+    if not isinstance(var, variables.ListIteratorVariable):
+        raise AssertionError(type(var))
     for _ in range(var.index):
         cg.add_push_null(lambda: cg.load_import_from(utils.__name__, "iter_next"))
         cg(var.source)  # type: ignore[attr-defined]
@@ -2116,11 +2122,13 @@ def _codegen_list_iterator_mutation(ctx: SideEffectReplayContext) -> None:
 @register_side_effect_replay_handler(
     name="count_iterator_mutation",
     matcher=lambda ctx: isinstance(ctx.var, variables.CountIteratorVariable),
+    priority=20,
 )
 def _codegen_count_iterator_mutation(ctx: SideEffectReplayContext) -> None:
     cg = ctx.codegen
     var = ctx.var
-    assert isinstance(var, variables.CountIteratorVariable)
+    if not isinstance(var, variables.CountIteratorVariable):
+        raise AssertionError(type(var))
     for _ in range(var.advance_count):
         cg.add_push_null(lambda: cg.load_import_from(utils.__name__, "iter_next"))
         cg(var.source)  # type: ignore[attr-defined]
@@ -2132,11 +2140,13 @@ def _codegen_count_iterator_mutation(ctx: SideEffectReplayContext) -> None:
 @register_side_effect_replay_handler(
     name="random_mutation",
     matcher=lambda ctx: isinstance(ctx.var, variables.RandomVariable),
+    priority=10,
 )
 def _codegen_random_mutation(ctx: SideEffectReplayContext) -> None:
     cg = ctx.codegen
     var = ctx.var
-    assert isinstance(var, variables.RandomVariable)
+    if not isinstance(var, variables.RandomVariable):
+        raise AssertionError(type(var))
 
     def gen_fn() -> None:
         cg(var.source)  # type: ignore[attr-defined]


### PR DESCRIPTION
This refactors Dynamo side-effect replay from a hard-coded type-dispatch block in `codegen_update_mutated` into an explicit registry-driven dispatcher.

The existing replay branches are moved into built-in registered handlers, so the default replay behavior is intended to remain unchanged. The new registry also provides a structured place for future replay policies to declare whether a matched side effect should be replayed, skipped as non-replayable, or rejected with a reason.

While porting this to current `main`, I also converted the existing `CountIteratorVariable` replay branch into a registered handler so the refactor covers the current upstream side-effect replay surface.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98