### PR TITLE
[test] Fix test_torch_binomial_dtype_errors: use device_type instead of hardcoded "cuda"

### DIFF
--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -4690,7 +4690,7 @@ class TestDistributionsGPU(DistributionsTestCase):
     @unittest.skipIf(not TEST_CUDA and not TEST_XPU, "CUDA and XPU not found")
     def test_torch_binomial_dtype_errors(self):
         dtypes = [torch.int, torch.long, torch.short]
-        device = "cuda"
+        device = device_type
 
         for count_dtype in dtypes:
             total_count = torch.tensor([10, 10], dtype=count_dtype, device=device)


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/187030

## Root Cause

`test_torch_binomial_dtype_errors` hardcoded `device = "cuda"`, which fails on XPU machines without CUDA. The test validates dtype error handling in `torch.binomial` — device-agnostic logic.

## Fix

Changed `device = "cuda"` → `device = device_type`, which correctly resolves to the available accelerator (`"xpu"` on XPU, `"cuda"` on CUDA). All other tests in `TestDistributionsGPU` already use the module-level `device_type` variable.

## Changes

- `test/distributions/test_distributions.py`: 1 line changed

## Verification

```bash
# CPU (dtype error, no device needed):
python -c "import torch; torch.binomial(torch.tensor([10],dtype=torch.int), torch.tensor([0.5]))"

# XPU:
python test/distributions/test_distributions.py TestDistributionsGPU.test_torch_binomial_dtype_errors
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>