### PR TITLE
Fix #171905: Use typing_extensions.TypeAliasType for better reexport of `__module__

### DIFF
--- a/torch/ao/quantization/__init__.py
+++ b/torch/ao/quantization/__init__.py
@@ -24,6 +24,7 @@ from .stubs import *  # noqa: F403
 ObserverOrFakeQuantize = TypeAliasType(
     "ObserverOrFakeQuantize", ObserverBase | FakeQuantizeBase
 )
+QConfigAny = TypeAliasType("QConfigAny", QConfig | None)
 
 
 __all__ = [


### PR DESCRIPTION
Fixes #171905

In `torch/ao/quantization/__init__.py`, replaced the wildcard-imported `QConfigAny` (which had `__module__ = "torch.ao.quantization.qconfig"`) with an explicit `TypeAliasType("QConfigAny", QConfig | None)` definition, giving it the correct `__module__ = "torch.ao.quantization"` so type checkers can properly resolve the re-exported alias.

Local test infra unavailable in CI sandbox.

---
This change was prepared with AI assistance under human direction and review.