### PR TITLE
[docs] Document iteration order for Module.parameters(), named_parameters(), buffers(), named_buffers()

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -2675,6 +2675,12 @@ class Module:
         Yields:
             Parameter: module parameter
 
+        Note:
+            Parameters are yielded in a consistent order. With
+            ``recurse=True``, this module's own parameters come first
+            (in registration order), then each submodule's parameters in
+            the order the submodules were registered (depth-first).
+
         Example::
 
             >>> # xdoctest: +SKIP("undefined vars")
@@ -2703,6 +2709,12 @@ class Module:
         Yields:
             (str, Parameter): Tuple containing the name and parameter
 
+        Note:
+            Parameters are yielded in a consistent order. With
+            ``recurse=True``, this module's own parameters come first
+            (in registration order), then each submodule's parameters in
+            the order the submodules were registered (depth-first).
+
         Example::
 
             >>> # xdoctest: +SKIP("undefined vars")
@@ -2730,6 +2742,12 @@ class Module:
         Yields:
             torch.Tensor: module buffer
 
+        Note:
+            Buffers are yielded in a consistent order. With
+            ``recurse=True``, this module's own buffers come first
+            (in registration order), then each submodule's buffers in
+            the order the submodules were registered (depth-first).
+
         Example::
 
             >>> # xdoctest: +SKIP("undefined vars")
@@ -2756,6 +2774,12 @@ class Module:
 
         Yields:
             (str, torch.Tensor): Tuple containing the name and buffer
+
+        Note:
+            Buffers are yielded in a consistent order. With
+            ``recurse=True``, this module's own buffers come first
+            (in registration order), then each submodule's buffers in
+            the order the submodules were registered (depth-first).
 
         Example::
 


### PR DESCRIPTION
Fixes #188389.

## Summary

The docstrings for `Module.parameters()`, `named_parameters()`, `buffers()`, and `named_buffers()` did not specify whether members are yielded in a deterministic order.

Added a `Note` to each docstring clarifying the actual behavior: members are yielded consistently, with this module's own members appearing first (in registration order), followed by each submodule's members in the order the submodules were registered, traversed depth-first. This matches the implementation: `_parameters` and `_modules` are both `OrderedDict`s, and `named_modules()` performs a DFS pre-order traversal.

## Test Plan

Docs-only change; no functional change.