### PR TITLE
Fix matrix_exp crash on non-contiguous (channels-last) inputs

### DIFF
--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -2723,8 +2723,10 @@ Tensor mexp_impl(
 
 // matrix exponential
 Tensor mexp(const Tensor& a, bool compute_highest_degree_approx = false) {
-  // squash batch dimensions to one dimension for simplicity
-  const auto a_3d = a.view({-1, a.size(-2), a.size(-1)});
+  // squash batch dimensions to one dimension for simplicity. Use reshape
+  // rather than view: a may be non-contiguous (e.g. a channels-last conv
+  // output) in a way where the batch dims cannot be folded without a copy.
+  const auto a_3d = a.reshape({-1, a.size(-2), a.size(-1)});
 
   if (a.scalar_type() == at::ScalarType::Float
       || a.scalar_type() == at::ScalarType::ComplexFloat) {

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -7721,6 +7721,19 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
     @skipCUDAIfNoMagmaAndNoLinalgsolver
     @skipCPUIfNoLapack
     @dtypes(torch.float, torch.double, torch.complex64, torch.complex128)
+    def test_linalg_matrix_exp_non_contiguous(self, device, dtype):
+        # matrix_exp should handle non-view-foldable inputs such
+        # as channels-last tensors without raising on its internal batch fold.
+        expm = torch.linalg.matrix_exp
+
+        ref = make_tensor((3, 4, 8, 8), dtype=dtype, device=device)
+        x_cl = ref.to(memory_format=torch.channels_last)
+        self.assertFalse(x_cl.is_contiguous())
+        self.assertEqual(expm(x_cl), expm(ref))
+
+    @skipCUDAIfNoMagmaAndNoLinalgsolver
+    @skipCPUIfNoLapack
+    @dtypes(torch.float, torch.double, torch.complex64, torch.complex128)
     def test_matrix_exp_backward_input_validation(self, device, dtype):
 
         scalar_tensor = torch.tensor(1.0, dtype=dtype, device=device)


### PR DESCRIPTION
### Summary

Make `matrix_exp` support non-contiguous inputs.

### Current Situation

**Eager**:

`matrix_exp` performs batch squash `const auto a_3d = a.view({-1, a.size(-2), a.size(-1)});`

So `channel_last` will trigger an error.
```python
import torch

x = torch.rand(8, 3, 10, 10)
x = x.to(memory_format=torch.channels_last)
x = torch.matrix_exp(x)
print(x)
```

```
Traceback (most recent call last):
  File "/home/chz34/temp/m_exp.py", line 7, in <module>
    x = torch.matrix_exp(x)
        ^^^^^^^^^^^^^^^^^^^
RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.
```

The error message seems not so relevant and confusing.

**Inductor**

From this issue: https://github.com/pytorch/pytorch/issues/188222 
Since `conv` in inductor will choose channels_last by default, so the following `matrix_exp` will fail. 

### Fix
By using `reshape` instead of `view`, `matrix_exp` now supports non-contiguous inputs.
`Reshape` will act as `view` by default, and automatically do copy for not viewable inputs.

### Tests

Check the non-contiguous inputs should return exactly same as the contiguous one. 