### PR TITLE
[MPS] Parallelize Welford reduction in Metal codegen

### DIFF
--- a/c10/metal/reduction_utils.h
+++ b/c10/metal/reduction_utils.h
@@ -323,20 +323,6 @@ T threadgroup_min(threadgroup T* data, T val, unsigned idx, unsigned size) {
   return data[0];
 }
 
-template <typename T>
-float3 threadgroup_welford_reduce(threadgroup T* data, unsigned size) {
-  ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
-  float m = data[0];
-  float m2 = 0;
-  for (unsigned idx = 1; idx < size; ++idx) {
-    float delta = data[idx] - m;
-    m += delta / (idx + 1);
-    m2 += delta * (data[idx] - m);
-  }
-  ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
-  return float3(m, m2, size);
-}
-
 // Each vec3type is tuple of mean, m2 and weight
 template <typename T>
 float3 welford_combine(T a, T b) {
@@ -350,14 +336,22 @@ float3 welford_combine(T a, T b) {
 }
 
 template <typename T>
-float3 threadgroup_welford_combine(threadgroup T* data, unsigned size) {
-  ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
-  float3 rc = data[0];
-  for (unsigned idx = 1; idx < size; ++idx) {
-    rc = welford_combine(rc, data[idx]);
+float3 threadgroup_welford_combine(
+    threadgroup T* data,
+    unsigned idx,
+    unsigned size) {
+  unsigned stride = 1;
+  while (stride < size) {
+    stride <<= 1;
+  }
+  for (stride >>= 1; stride > 0; stride >>= 1) {
+    ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
+    if (idx < stride && idx + stride < size) {
+      data[idx] = welford_combine(data[idx], data[idx + stride]);
+    }
   }
   ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
-  return rc;
+  return data[0];
 }
 
 template <typename ARG_T, typename IDX_T>

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -800,11 +800,13 @@ class MetalKernel(SIMDKernel):
             )
         if reduction_type == "welford_reduce":
             if not self.multistage_reduction_entry:
-                acc_buf = self._new_idxvar(src_dtype, acc_buf_alloc_size)
-                self.compute.splice(f"{acc_buf}[{reduction_idx}] = {value};")
+                acc_buf = self._new_idxvar("float3", acc_buf_alloc_size)
+                self.compute.splice(
+                    f"{acc_buf}[{reduction_idx}] = float3({value}, 0.0, 1.0);"
+                )
                 wf_res = self.cse.generate(
                     self.compute,
-                    f"c10::metal::threadgroup_{reduction_type}({acc_buf}, {acc_buf_size_str})",
+                    f"c10::metal::threadgroup_welford_combine({acc_buf}, {reduction_idx}, {acc_buf_size_str})",
                     dtype=torch.float32,
                 )
                 return _unwrap_helper(wf_res)
@@ -816,7 +818,7 @@ class MetalKernel(SIMDKernel):
             )
             wf_res = self.cse.generate(
                 self.stores,
-                f"c10::metal::threadgroup_welford_combine({acc_buf}, {acc_buf_size_str})",
+                f"c10::metal::threadgroup_welford_combine({acc_buf}, {reduction_idx}, {acc_buf_size_str})",
                 dtype=torch.float32,
             )
             return _unwrap_helper(wf_res)
@@ -836,7 +838,7 @@ class MetalKernel(SIMDKernel):
                 self.compute.writeline(f"{acc_thread_var} = {inp_value};")
             wf_res = self.cse.generate(
                 self.stores if self.multistage_reduction_entry else self.compute,
-                f"c10::metal::threadgroup_{reduction_type}({acc_buf}, {acc_buf_size_str})",
+                f"c10::metal::threadgroup_welford_combine({acc_buf}, {reduction_idx}, {acc_buf_size_str})",
                 dtype=torch.float32,
             )
             return _unwrap_helper(wf_res)


### PR DESCRIPTION
Parallelize Welford reduction in Metal codegen. MPS Inductor backend computed Welford variance with a serial loop run redundantly by every threadgroup lane. This replaces it with a parallel tree reduction over per-thread (mean, m2, weight) triples, making var/std/LayerNorm/BatchNorm/GroupNorm under torch.compile up to 144x faster.

### fp32

| op | layout | D | before (ms) | after (ms) | speedup |
|---|---|---:|---:|---:|---:|
| var | contiguous | 2048 | 132.84 | 0.932 | 142.5x |
| var | contiguous | 1024 | 243.57 | 1.789 | 136.2x |
| var | sliced | 1024 | 249.39 | 1.842 | 135.4x |
| layernorm | contiguous | 1024 | 242.47 | 1.838 | 131.9x |
| layernorm | contiguous | 2048 | 134.03 | 1.059 | 126.5x |
| var | contiguous | 4096 | 66.65 | 0.538 | 123.8x |
| var | contiguous | 768 | 182.48 | 1.807 | 101.0x |
| layernorm | contiguous | 768 | 182.14 | 1.955 | 93.2x |
| var | transposed | 1024 | 251.31 | 2.817 | 89.2x |
| var | contiguous | 512 | 122.42 | 1.588 | 77.1x |
| layernorm | transposed | 1024 | 244.06 | 3.284 | 74.3x |
| layernorm | contiguous | 512 | 121.49 | 1.664 | 73.0x |
| var | contiguous | 8192 | 33.26 | 0.466 | 71.3x |
| var | sliced | 4096 | 66.42 | 0.955 | 69.6x |
| layernorm | contiguous | 4096 | 66.82 | 1.075 | 62.1x |
| var | contiguous | 256 | 60.95 | 1.494 | 40.8x |
| var | sliced | 256 | 60.68 | 1.506 | 40.3x |
| layernorm | contiguous | 256 | 60.71 | 1.524 | 39.8x |
| var | transposed | 256 | 61.92 | 1.777 | 34.9x |
| layernorm | contiguous | 8192 | 33.45 | 0.997 | 33.6x |
| layernorm | transposed | 256 | 60.70 | 1.966 | 30.9x |
| var | transposed | 4096 | 66.69 | 2.256 | 29.6x |
| layernorm | transposed | 4096 | 66.47 | 2.545 | 26.1x |
| layernorm | contiguous | 128 | 34.97 | 1.653 | 21.2x |
| var | contiguous | 128 | 34.71 | 1.656 | 21.0x |
| var | contiguous | 64 | 15.23 | 1.786 | 8.5x |
| layernorm | contiguous | 64 | 15.15 | 1.787 | 8.5x |
| layernorm | contiguous | 32 | 8.75 | 2.205 | 4.0x |
| var | contiguous | 32 | 8.70 | 2.208 | 3.9x |
| layernorm | contiguous | 16 | 5.03 | 3.165 | 1.6x |
| var | contiguous | 16 | 4.96 | 3.208 | 1.5x |

### bf16

| op | layout | D | before (ms) | after (ms) | speedup |
|---|---|---:|---:|---:|---:|
| var | contiguous | 2048 | 132.40 | 0.920 | 143.8x |
| var | contiguous | 1024 | 243.52 | 1.764 | 138.1x |
| var | contiguous | 4096 | 66.17 | 0.488 | 135.5x |
| var | sliced | 1024 | 243.49 | 1.815 | 134.2x |
| layernorm | contiguous | 1024 | 243.59 | 1.817 | 134.1x |
| layernorm | contiguous | 2048 | 132.94 | 0.998 | 133.2x |
| layernorm | contiguous | 4096 | 67.01 | 0.569 | 117.7x |
| var | sliced | 4096 | 66.42 | 0.600 | 110.7x |
| var | contiguous | 8192 | 33.23 | 0.306 | 108.5x |
| layernorm | transposed | 1024 | 243.70 | 2.410 | 101.1x |
| var | contiguous | 768 | 182.50 | 1.809 | 100.9x |
| var | transposed | 1024 | 242.55 | 2.547 | 95.2x |
| layernorm | contiguous | 768 | 182.90 | 1.962 | 93.2x |
| layernorm | contiguous | 512 | 121.86 | 1.659 | 73.5x |
| var | contiguous | 512 | 122.11 | 1.665 | 73.3x |
| layernorm | contiguous | 8192 | 33.46 | 0.575 | 58.2x |
| layernorm | contiguous | 256 | 60.54 | 1.509 | 40.1x |
| var | sliced | 256 | 60.90 | 1.520 | 40.1x |
| var | contiguous | 256 | 60.97 | 1.524 | 40.0x |
| var | transposed | 256 | 60.86 | 1.568 | 38.8x |
| layernorm | transposed | 256 | 60.80 | 1.655 | 36.7x |
| var | transposed | 4096 | 66.31 | 2.248 | 29.5x |
| layernorm | transposed | 4096 | 66.48 | 2.374 | 28.0x |
| layernorm | contiguous | 128 | 35.19 | 1.686 | 20.9x |
| var | contiguous | 128 | 34.87 | 1.702 | 20.5x |
| layernorm | contiguous | 64 | 15.15 | 1.788 | 8.5x |
| var | contiguous | 64 | 15.27 | 1.810 | 8.4x |
| layernorm | contiguous | 32 | 8.75 | 2.222 | 3.9x |
| var | contiguous | 32 | 8.73 | 2.236 | 3.9x |
| layernorm | contiguous | 16 | 5.01 | 3.187 | 1.6x |
| var | contiguous | 16 | 5.00 | 3.231 | 1.5x |


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo