### PR TITLE
[BE] Fix compilation warnings

### DIFF
--- a/aten/src/ATen/native/mps/kernels/LossOps.metal
+++ b/aten/src/ATen/native/mps/kernels/LossOps.metal
@@ -46,9 +46,9 @@ static void calc_log_alpha_beta(
     device T* log_alpha,
     constant T* log_probs,
     constant T_target* targets,
-    constant T_index* input_lengths,
-    constant T_index* target_lengths,
-    constant T_index* target_batch_offsets,
+    constant T_index*,
+    constant T_index*,
+    constant T_index*,
     constant CTCLossParams<T_index>& params,
     uint tid,
     uint tptg,
@@ -103,7 +103,7 @@ static void calc_log_alpha_beta(
     if (s < S && target_length > 0) {
       target_token =
           get_target_prime(targets, params.tg_target_stride, s, params.BLANK);
-      if constexpr (beta) {
+      if IF_CONSTEXPR (beta) {
         use_C = ((s + 2) < S) &&
             (get_target_prime(
                  targets, params.tg_target_stride, s + 2, params.BLANK) !=


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #188416

Metal-3 does not suppot `if constexpr`, so use `IF_CONSTEXPR` which appropriately guards it
Remove name from unused vars during template specialization

Before this change followng was emitted
```
[91/1123] Compiling /Users/malfet/git/pytorch/pytorch/aten/src/ATen/native/mps/kernels/LossOps.metal to LossOps_31.air
/Users/malfet/git/pytorch/pytorch/aten/src/ATen/native/mps/kernels/LossOps.metal:106:10: warning: constexpr if is a C++17 extension [-Wc++17-extensions]
      if constexpr (beta) {
         ^
/Users/malfet/git/pytorch/pytorch/aten/src/ATen/native/mps/kernels/LossOps.metal:49:23: warning: unused parameter 'input_lengths' [-Wunused-parameter]
    constant T_index* input_lengths,
                      ^
/Users/malfet/git/pytorch/pytorch/aten/src/ATen/native/mps/kernels/LossOps.metal:50:23: warning: unused parameter 'target_lengths' [-Wunused-parameter]
    constant T_index* target_lengths,
                      ^
/Users/malfet/git/pytorch/pytorch/aten/src/ATen/native/mps/kernels/LossOps.metal:51:23: warning: unused parameter 'target_batch_offsets' [-Wunused-parameter]
    constant T_index* target_batch_offsets,
                      ^
4 warnings generated.
```