### PR TITLE
[CUDA] [GreenContext] deprecate set/pop context

### DIFF
--- a/docs/source/cuda.md
+++ b/docs/source/cuda.md
@@ -300,7 +300,23 @@ CUDA 13.1 or newer.
 Install instructions for `cuda.bindings` can be found here:
 https://nvidia.github.io/cuda-python/
 
-See the docs for {class}`~torch.cuda.green_contexts.GreenContext` for an example of how to use these.
+Create streams from the green context and use them like other custom CUDA
+streams:
+
+```python
+ctx = GreenContext(...)
+stream = ctx.Stream()
+with torch.cuda.stream(stream):
+    # torch operations here are using resources from `ctx`
+    pass
+```
+
+Synchronization between green-context streams and other streams is the user's
+responsibility. Use CUDA events to order work, just as you would for any other
+custom stream.
+
+The `GreenContext.set_context()` and `GreenContext.pop_context()` methods are
+deprecated compatibility APIs.
 
 ```{eval-rst}
 .. currentmodule:: torch.cuda.green_contexts

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -10438,45 +10438,40 @@ class TestCudaGreenContexts(TestCase):
     def tearDown(self):
         super().tearDown()
 
-    def test_greencontext_restores_stream(self):
+    def test_greencontext_set_pop_context_deprecation(self):
         # need to start on a side stream as we are comparing pointers and want to avoid
         # two NULL streams...
         s = torch.cuda.Stream()
         with torch.cuda.stream(s):
             start_stream = torch.cuda.current_stream()
             ctx = torch.cuda.green_contexts.GreenContext(num_sms=1)
-            ctx.set_context()
+            with self.assertWarnsRegex(FutureWarning, "GreenContext.set_context"):
+                ctx.set_context()
             context_stream = torch.cuda.current_stream()
-            ctx.pop_context()
+            with self.assertWarnsRegex(FutureWarning, "GreenContext.pop_context"):
+                ctx.pop_context()
             end_stream = torch.cuda.current_stream()
             self.assertEqual(start_stream.cuda_stream, end_stream.cuda_stream)
             self.assertNotEqual(start_stream.cuda_stream, context_stream.cuda_stream)
 
-    @serialTest()
-    def test_greencontext_carveout(self):
-        # By default, everything is performed on the current device
-        a = torch.randn(4096, 4096, device="cuda", dtype=torch.bfloat16)
-        ctx = torch.cuda.green_contexts.GreenContext(num_sms=1)
-        ctx.set_context()
-        torch.matmul(a, a)
-        torch.cuda.synchronize()
-        t0 = time.perf_counter()
-        partial_res = torch.matmul(a, a)
-        torch.cuda.synchronize()
-        t1 = time.perf_counter()
-        ctx.pop_context()
-        torch.matmul(a, a)
-        torch.cuda.synchronize()
-        t2 = time.perf_counter()
-        full_res = torch.matmul(a, a)
-        torch.cuda.synchronize()
-        t3 = time.perf_counter()
-        self.assertEqual(partial_res, full_res)
-        self.assertGreater(t1 - t0, t3 - t2)
+    def test_greencontext_stream_context_restores_stream(self):
+        # need to start on a side stream as we are comparing pointers and
+        # want to avoid the NULL stream
+        s = torch.cuda.Stream()
+        with torch.cuda.stream(s):
+            start_stream = torch.cuda.current_stream()
+            ctx = torch.cuda.green_contexts.GreenContext(num_sms=1)
+            ctx_stream = ctx.Stream()
+            stream_context = torch.cuda.stream(ctx_stream)
+            with stream_context as context_value:
+                self.assertIsNone(context_value)
+                context_stream = torch.cuda.current_stream()
+            end_stream = torch.cuda.current_stream()
+            self.assertIsInstance(stream_context, torch.cuda.StreamContext)
+            self.assertEqual(ctx_stream.cuda_stream, context_stream.cuda_stream)
+            self.assertEqual(start_stream.cuda_stream, end_stream.cuda_stream)
+            self.assertNotEqual(start_stream.cuda_stream, context_stream.cuda_stream)
 
-    @unittest.skipIf(
-        IS_LINUX or TEST_WITH_SLOW, "https://github.com/pytorch/pytorch/issues/181370"
-    )
     @serialTest()
     def test_greencontext_stream_carveout(self):
         # By default, everything is performed on the current device
@@ -10501,24 +10496,21 @@ class TestCudaGreenContexts(TestCase):
 
     @serialTest()
     def test_greencontext_graphs(self):
-        # By default, everything is performed on the current device
         a = torch.randn(4096, 4096, device="cuda", dtype=torch.bfloat16)
         ctx = torch.cuda.green_contexts.GreenContext(num_sms=1)
-        ctx.set_context()
-        partial_res = torch.matmul(a, a)
-        ctx.pop_context()
+        ctx_stream = ctx.Stream()
+        with torch.cuda.stream(ctx_stream):
+            partial_res = torch.matmul(a, a)
         full_res = torch.matmul(a, a)
         full_res.zero_()
         partial_res.zero_()
         torch.cuda.synchronize()
 
         g = torch.cuda.CUDAGraph()
-        with torch.cuda.graph(g):
-            ctx.set_context()
+        with torch.cuda.graph(g, stream=ctx_stream):
             partial_res = torch.matmul(a, a)
-            ctx.pop_context()
-            full_res = torch.matmul(a, a)
         g.replay()
+        full_res = torch.matmul(a, a)
         self.assertEqual(partial_res, full_res)
 
     @unittest.skipIf(
@@ -10569,12 +10561,10 @@ class TestCudaGreenContexts(TestCase):
             workqueue_scope="balanced",
             workqueue_concurrency_limit=1,
         )
-        ctx.set_context()
         green_streams = [ctx.Stream() for _ in range(n_streams)]
         t2 = time.perf_counter()
         run_multi_stream_sleep(green_streams)
         t3 = time.perf_counter()
-        ctx.pop_context()
         limited_time = t3 - t2
 
         self.assertGreater(limited_time, baseline_time)

--- a/torch/cuda/green_contexts.py
+++ b/torch/cuda/green_contexts.py
@@ -4,6 +4,7 @@ import functools
 import sys
 import warnings
 from typing import Any
+from typing_extensions import deprecated
 
 import torch
 from torch.cuda._utils import (
@@ -24,6 +25,12 @@ _WORKQUEUE_SCOPE_VALUES = {
     "device_ctx": 0,
     "balanced": 1,
 }
+
+_CONTEXT_STACK_DEPRECATION = (
+    "`GreenContext.set_context` and `GreenContext.pop_context` are deprecated. "
+    "Please create a stream with `GreenContext.Stream()` and use "
+    "`torch.cuda.stream(stream)` instead."
+)
 
 
 # note: this can safely be cached in a process/thread because
@@ -76,6 +83,20 @@ class GreenContext:
 
     .. warning::
        This API is in beta and may change in future releases.
+
+    CUDA work should be placed on streams created from the green context:
+
+    .. code-block:: python
+
+        ctx = GreenContext(...)
+        stream = ctx.Stream()
+        with torch.cuda.stream(stream):
+            # torch operations here are using resources from `ctx`
+            pass
+
+    Green-context streams are custom CUDA streams. Synchronization with other
+    streams is the user's responsibility and should be handled with CUDA events,
+    as with any other custom stream.
     """
 
     def __init__(
@@ -284,8 +305,13 @@ class GreenContext:
         if self._green_ctx is None or self._context is None:
             raise RuntimeError("GreenContext has been destroyed")
 
+    @deprecated(_CONTEXT_STACK_DEPRECATION, category=FutureWarning)
     def set_context(self) -> None:
-        r"""Make the green context the current context."""
+        r"""Make the green context the current context.
+
+        Deprecated. Create streams with :meth:`Stream` and use
+        :func:`torch.cuda.stream` instead.
+        """
         self._ensure_alive()
         if self._parent_stream is not None:
             raise RuntimeError("set_context called twice before pop_context")
@@ -308,9 +334,13 @@ class GreenContext:
         event.wait(green_ctx_stream)
         torch.cuda.set_stream(green_ctx_stream)
 
+    @deprecated(_CONTEXT_STACK_DEPRECATION, category=FutureWarning)
     def pop_context(self) -> None:
         r"""Assuming the green context is the current context, pop it from the
         context stack and restore the previous context.
+
+        Deprecated. Create streams with :meth:`Stream` and use
+        :func:`torch.cuda.stream` instead.
         """
         try:
             self._ensure_alive()
@@ -332,7 +362,12 @@ class GreenContext:
             self._parent_stream = None
 
     def Stream(self) -> torch.cuda.Stream:
-        r"""Return the CUDA Stream used by the green context."""
+        r"""Return a CUDA stream associated with this green context.
+
+        Use the returned stream with :func:`torch.cuda.stream` to run work on
+        the green context. Synchronization with other streams is not automatic;
+        use CUDA events as with any other custom stream.
+        """
         self._ensure_alive()
         curr_idx = self._curr_stream_idx + 1
         idx = curr_idx % _STREAMS_PER_GREEN_CONTEXT_POOL


### PR DESCRIPTION
This PR deprecates the `set_context` and `pop_context` methods for `GreenContext`.

These APIs are used to push/pop the green context as a CUDA context on the thread level context stack. This causes unnecessary overheads and ambiguity of the `NULL` stream semantics.
We now recommend everyone to use custom streams to activate a green context.

CC @galv @ngimel @eqy 