### PR TITLE
Add opt-in rocm-mi350-do-validation workflow to exercise DO MI350X (gfx950) runner scale sets

### DIFF
--- a/.github/pytorch-probot.yml
+++ b/.github/pytorch-probot.yml
@@ -37,6 +37,7 @@ ciflow_push_tags:
 - ciflow/riscv64
 - ciflow/rocm-mi200
 - ciflow/rocm-mi300
+- ciflow/rocm-mi350-do-validation
 - ciflow/rocm-navi31
 - ciflow/rocm-nightly
 - ciflow/s390

--- a/.github/workflows/rocm-mi350-do-validation.yml
+++ b/.github/workflows/rocm-mi350-do-validation.yml
@@ -1,0 +1,81 @@
+# Owner(s): ["module: rocm"]
+# Opt-in validation workflow for the DigitalOcean MI350X (gfx950) ARC runner
+# scale sets added in ROCm/rocOps#626. Those scale sets register the canonical
+# `linux.rocm.gpu.gfx950.*` labels (runner group linux.rocm.gpu.group) on the DO
+# cluster, so a job that requests `linux.rocm.gpu.gfx950.N` directly (no amd-do
+# experiment prefix) can land on the new DO fleet and exercise it end to end.
+#
+# This workflow is intentionally NON-required and OPT-IN: it only runs on the
+# ciflow/rocm-mi350-do-validation push tag or manual workflow_dispatch, never on
+# every push/PR, so it can never become a blocking/required check and the PR that
+# adds it does not need a force-merge.
+#
+# NOTE: the canonical gfx950 label is also served by the existing ROCm MI350
+# fleet, so a green run confirms the label works but does not by itself guarantee
+# the job ran on the DO cluster. To pin to the DO experiment fleet specifically,
+# use the amd-do- prefixed label (see rocm-mi350.yml).
+name: rocm-mi350-do-validation
+
+on:
+  push:
+    tags:
+      - ciflow/rocm-mi350-do-validation/*
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
+  actions: read
+
+jobs:
+  target-determination:
+    if: github.repository_owner == 'pytorch'
+    name: before-test
+    uses: ./.github/workflows/target_determination.yml
+
+  get-label-type:
+    name: get-label-type
+    uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
+    if: ${{ github.repository_owner == 'pytorch' }}
+    with:
+      triggering_actor: ${{ github.triggering_actor }}
+      issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
+      curr_branch: ${{ github.head_ref || github.ref_name }}
+      curr_ref_type: ${{ github.ref_type }}
+
+  linux-noble-rocm-py3_12-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
+    name: linux-noble-rocm-py3.12-mi350-do-validation
+    uses: ./.github/workflows/_linux-build.yml
+    needs: get-label-type
+    with:
+      runner_prefix: "mt-"
+      ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
+      use-arc: true
+      build-environment: linux-noble-rocm-py3.12-mi350
+      docker-image-name: ci-image:pytorch-linux-noble-rocm-n-py3
+      # Keep this minimal: a single shard on the 1-GPU canonical gfx950 label so
+      # we exercise the new DO scale set without consuming much GPU time.
+      test-matrix: |
+        { include: [
+          { config: "default", shard: 1, num_shards: 1, runner: "linux.rocm.gpu.gfx950.1" },
+        ]}
+    secrets: inherit
+
+  linux-noble-rocm-py3_12-test:
+    name: linux-noble-rocm-py3.12-mi350-do-validation
+    uses: ./.github/workflows/_rocm-test.yml
+    needs:
+      - linux-noble-rocm-py3_12-build
+      - target-determination
+    with:
+      build-environment: ${{ needs.linux-noble-rocm-py3_12-build.outputs.build-environment }}
+      docker-image: ${{ needs.linux-noble-rocm-py3_12-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-noble-rocm-py3_12-build.outputs.test-matrix }}
+      # Run a small but real suite so the runner is genuinely exercised.
+      tests-to-include: "test_autograd"
+    secrets: inherit


### PR DESCRIPTION
## What

Adds a new, **opt-in / non-required** workflow `.github/workflows/rocm-mi350-do-validation.yml` to validate the four new ARC runner scale sets introduced in [ROCm/rocOps#626](https://github.com/ROCm/rocOps/pull/626) on the DigitalOcean MI350X (gfx950) cluster:

- `linux.rocm.gpu.gfx950.1` / `.2` / `.4` / `.8`

Those scale sets register the **canonical** `linux.rocm.gpu.gfx950.*` labels (runner group `linux.rocm.gpu.group`, registered to `github.com/pytorch`). So a job that requests `linux.rocm.gpu.gfx950.N` directly — **without** the `amd-do-` experiment prefix used by `rocm-mi350.yml`/`periodic-rocm-mi350.yml` — can land on and exercise the new DO fleet. This workflow runs a small but real PyTorch test suite (`test_autograd`, single shard, 1 GPU) so the runners are genuinely exercised, not just an `echo`.

## Why it does NOT need a force-merge

- It adds a **new dedicated workflow** and does not modify any existing/required workflow.
- It is triggered **only** by the opt-in `ciflow/rocm-mi350-do-validation` push tag **or** manual `workflow_dispatch`. It never runs on every push/PR, so it can never become a required/blocking check.
- The only other change is registering the new ciflow label in `.github/pytorch-probot.yml` (additive, one line).
- The `linux.rocm.gpu.gfx950.*` labels are already known to `actionlint` (`.github/actionlint.yaml`) and `.github/arc.yaml`, so lint passes.

## How to trigger

Either:
- Apply the **`ciflow/rocm-mi350-do-validation`** label to a PR (the bot pushes the `ciflow/rocm-mi350-do-validation/<pr>` tag), **or**
- Run it manually: `gh workflow run rocm-mi350-do-validation.yml --repo pytorch/pytorch --ref main`

## Caveat (routing)

The canonical `linux.rocm.gpu.gfx950.*` label is **also** served by the existing ROCm MI350 fleet. A green run therefore confirms the label works and jobs run successfully, but does **not** by itself guarantee the job ran on the new DO cluster. To pin to the DO experiment fleet specifically, use the `amd-do-` prefixed label (as `rocm-mi350.yml` does via the `amd-do` runner-determinator experiment).

## Files changed

- **`.github/workflows/rocm-mi350-do-validation.yml`** (new): build `linux-noble-rocm-py3.12-mi350` + single-shard `test_autograd` run on `linux.rocm.gpu.gfx950.1`; triggers on `ciflow/rocm-mi350-do-validation/*` and `workflow_dispatch`; mirrors `rocm-mi350.yml` conventions (`_linux-build.yml` + `_rocm-test.yml`, `use-arc`, `runner_prefix: mt-`, permissions, concurrency).
- **`.github/pytorch-probot.yml`**: register the new `ciflow/rocm-mi350-do-validation` label.

Made with Cursor


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang