### PR TITLE
[DO NOT MERGE][ROCm][CI] trunk: validate DO MI350X (gfx950) runner scale sets

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -332,6 +332,29 @@ jobs:
       tests-to-include: ${{ github.event.inputs.tests-to-include || '' }}
     secrets: inherit
 
+  # TEMPORARY: validate rocOps#626 DO MI350X gfx950 runners - revert before merge
+  # Exercises the canonical (non-amd-do) linux.rocm.gpu.gfx950.1 label that the
+  # new DigitalOcean MI350X scale sets serve. Reuses the existing MI350 build
+  # (linux-jammy-rocm-py3_10-build) to avoid a redundant build, and runs a single
+  # quick shard (test_autograd) to keep GPU usage minimal. This added job does not
+  # alter any existing trunk job.
+  linux-jammy-rocm-py3_10-gfx950-do-validation-test:
+    name: linux-jammy-rocm-py3.10-mi350-gfx950-do-validation
+    uses: ./.github/workflows/_rocm-test.yml
+    needs:
+      - linux-jammy-rocm-py3_10-build
+      - target-determination
+      - job-filter
+    with:
+      build-environment: ${{ needs.linux-jammy-rocm-py3_10-build.outputs.build-environment }}
+      docker-image: ${{ needs.linux-jammy-rocm-py3_10-build.outputs.docker-image }}
+      test-matrix: |
+        { include: [
+          { config: "default", shard: 1, num_shards: 1, runner: "linux.rocm.gpu.gfx950.1" },
+        ]}
+      tests-to-include: "test_autograd"
+    secrets: inherit
+
   inductor-build:
     if: ${{ needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' inductor-build ') }}
     name: inductor-build


### PR DESCRIPTION
## What (TEMPORARY — do not merge permanently)

This PR makes a **temporary, for-testing** edit to `.github/workflows/trunk.yml` to validate the four new ARC runner scale sets introduced in [ROCm/rocOps#626](https://github.com/ROCm/rocOps/pull/626) on the DigitalOcean MI350X (gfx950) cluster (`linux.rocm.gpu.gfx950.1` / `.2` / `.4` / `.8`).

It adds **one** extra ROCm test job to trunk:

- `linux-jammy-rocm-py3.10-mi350-gfx950-do-validation`
- Requests the **canonical** `linux.rocm.gpu.gfx950.1` label **directly** (no `amd-do-` experiment prefix), which is exactly what the new DO scale sets serve, so the job can land on and exercise the new fleet.
- **Reuses** the existing `linux-jammy-rocm-py3.10-mi350` build (`linux-jammy-rocm-py3_10-build`) — no redundant build.
- Runs a single quick shard (`config: default, num_shards: 1`, `tests-to-include: test_autograd`) to keep GPU usage minimal while still being a real test run.

The added job is clearly marked with a `# TEMPORARY: validate rocOps#626 DO MI350X gfx950 runners - revert before merge` comment for easy reversion.

## Why this approach / how it triggers

The job runs as part of trunk CI on this PR — no new ciflow label or standalone workflow is needed; it rides the existing trunk MI350 build/test pipeline. **Note:** `trunk.yml` runs on a PR when the `ciflow/trunk` tag/label is present (trunk has no plain `pull_request` trigger), so apply/keep the **`ciflow/trunk`** label on this PR to launch the run. Once trunk runs, this added job executes automatically alongside the existing MI350 job.

## Does NOT alter existing jobs

Only a new job is added; no existing trunk job is modified or removed. The `linux.rocm.gpu.gfx950.*` labels are already registered in `.github/actionlint.yaml` and `.github/arc.yaml`, so lint passes.

## Routing caveat

The canonical `linux.rocm.gpu.gfx950.*` label is **also** served by the existing ROCm MI350 fleet. A green run therefore confirms the label resolves and jobs run successfully, but does **not** by itself guarantee the job ran on the new DO cluster. To pin to the DO experiment fleet specifically, use the `amd-do-` prefixed label (as the existing `linux-jammy-rocm-py3.10-mi350` job does via the `amd-do` runner-determinator experiment).

## Supersedes

Replaces #188421 (the standalone opt-in workflow approach) with this trunk-based validation that runs in the PR's own CI.

Made with Cursor


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang