### PR TITLE
[torchfuzz] Let templates customize seed-setting codegen

### DIFF
--- a/tools/experimental/torchfuzz/codegen.py
+++ b/tools/experimental/torchfuzz/codegen.py
@@ -143,6 +143,10 @@ class FuzzTemplate:
         """Return flag/setup lines emitted at the top of the generated file."""
         return []
 
+    def setseed_codegen(self, seed: int):
+        """Return lines emitted to set the random seed."""
+        return [f"torch.manual_seed({seed})", ""]
+
     def epilogue_codegen(self):
         """Return lines emitted at the very end of the generated file."""
         return []
@@ -467,8 +471,7 @@ def convert_graph_to_python_code(
 
     # Add single seed at the top if seed is provided
     if seed is not None:
-        code_lines.append(f"torch.manual_seed({seed})")
-        code_lines.append("")
+        code_lines.extend(fuzz_template.setseed_codegen(seed))
 
     code_lines.append(function_signature + ":")
 


### PR DESCRIPTION
Summary:
Extract the random-seed emission in `codegen.py` into a new `FuzzTemplate.setseed_codegen(seed)` hook instead of hardcoding `torch.manual_seed(seed)` inline. The generator now calls `fuzz_template.setseed_codegen(seed)` and extends the output with whatever lines it returns, with the base implementation preserving the previous behavior.

This lets downstream templates override seed setting code if needed.

Test Plan: Existing torchfuzz codegen behavior is unchanged for templates that do not override `setseed_codegen` (base returns the same two lines as before).

Differential Revision: D110056865


