### PR TITLE
[dcp] Free staged dict on caller thread via weakref.finalize in async_save (#188434)

### DIFF
--- a/torch/distributed/checkpoint/state_dict_saver.py
+++ b/torch/distributed/checkpoint/state_dict_saver.py
@@ -4,6 +4,7 @@ import contextlib
 import inspect
 import os
 import warnings
+import weakref
 from concurrent.futures import Future
 from dataclasses import dataclass
 from enum import Enum
@@ -357,9 +358,37 @@ def async_save(
         )
 
         if owned_async_stager is not None:
-            upload_future.add_done_callback(lambda _: maybe_close_owned_async_stager())
-            # in the success path transfer cleanup ownership to the upload future
+            # Success path: do not close the stager here (ExitStack unwind) nor
+            # on the upload worker. close() frees the staged CPU buffers, which
+            # were allocated on THIS (caller) thread. With mimalloc (default on
+            # aarch64) a free performed on a different thread than the allocator
+            # is parked on the owner-heap's delayed-free list and effectively
+            # never reclaimed (https://github.com/microsoft/mimalloc/issues/1187),
+            # so the free must run on the caller thread. We bind close() to the
+            # lifetime of the handle returned to the caller via weakref.finalize
+            # (see _free_staged_on_caller_thread); it runs on the caller thread
+            # when the handle is dropped.
             stack.pop_all()
+
+    def _free_staged_on_caller_thread(handle):
+        # Free the staged CPU buffers on the caller (allocating) thread, not on
+        # the upload worker: a cross-thread free is parked on mimalloc's
+        # owner-heap delayed-free list and effectively never reclaimed
+        # (https://github.com/microsoft/mimalloc/issues/1187). finalize() runs
+        # when the caller drops `handle`, on the caller's own thread. We pin the
+        # staged state_dict in the finalizer so its final decref happens there
+        # rather than racing the upload worker's work-item release, and close()
+        # the owned stager (which clears its staging cache) on that thread too.
+        if owned_async_stager is None:
+            return handle
+
+        staged = staging_future_or_state_dict
+
+        def _cleanup(_staged=staged):
+            maybe_close_owned_async_stager()
+
+        weakref.finalize(handle, _cleanup)
+        return handle
 
     if isinstance(staging_future_or_state_dict, Future):
         staging_future = staging_future_or_state_dict
@@ -381,8 +410,11 @@ def async_save(
             return_staging_future.set_result(None)
 
         # return new AsyncSaveResponse for users using new ZOC implementation
-        return AsyncSaveResponse(
-            staging_completion=return_staging_future, upload_completion=upload_future
+        return _free_staged_on_caller_thread(
+            AsyncSaveResponse(
+                staging_completion=return_staging_future,
+                upload_completion=upload_future,
+            )
         )
     else:
 
@@ -392,7 +424,7 @@ def async_save(
                 async_stager.synchronize_staging()
 
         maybe_synchronize_staging()
-        return upload_future
+        return _free_staged_on_caller_thread(upload_future)
 
 
 @_dcp_method_logger(log_exceptions=True)


### PR DESCRIPTION
Summary:

`_ThreadBasedAsyncCheckpointExecutor.execute_save` submits the staged state-dict to a worker thread for the upload, then returns the Future to the caller. The worker holds the only strong reference to the staged dict (via the ThreadPool WorkItem's args), so when `save_wrapper` returns the dict's CPU storages get destructed on the worker — a different thread from the one that allocated them in `DefaultStager._stage`.

On Linux with mimalloc loaded (the default for aarch64 PyTorch builds on GB200/GB300), this is a remote free: `mi_free` appends the block to the owner-heap's delayed-free list instead of actually decommitting. The owner thread (main) only drains that list during its own mimalloc calls, and the training loop's main thread doesn't make enough mimalloc-managed allocations between `async_save` calls to trip the drain. Each save leaks a fresh mimalloc segment — 128 MB committed RSS per save in the regression test, 640 MB across 5 iterations (test threshold: 154 MB).

Fix (per fegin's suggestion on the previous revision): bind cleanup of the staged CPU buffers to the lifetime of the handle returned by `async_save()` via `weakref.finalize`. The finalizer runs on the thread that drops the last reference to the handle — the caller's main (allocating) thread in the common case — so `mi_free` is a same-thread free that mimalloc reclaims immediately. The staged state_dict is pinned in the finalizer closure so its final decref happens on that same thread rather than racing the upload worker's work-item release, and the owned stager's `close()` is also invoked on that thread. The old `upload_future.add_done_callback(maybe_close_owned_async_stager)` path is removed — it ran the close on the worker thread and was the source of the cross-thread free.

No API change, no allocator-specific code; the fix is structurally correct ("alloc and free on the same thread") regardless of whether the underlying allocator is mimalloc, glibc, or jemalloc. The process-based executor (`_async_process_executor.py`) is unaffected — it crosses processes, not threads, and the staged dict has its own lifetime inside the writer subprocess.

Upstream context: mimalloc maintainers confirm the delayed-free semantics are intentional. See https://github.com/microsoft/mimalloc/issues/1187 for a near-identical pattern (vector freed from non-owner thread, owner-heap delayed-free list never drains).

Test Plan:
Before: aarch64 GB300 host, conda env `xlformers_gbunified_conda:54`.

`python test/distributed/checkpoint/test_state_dict_stager.py TestDTensorStateDictStager.test_async_save_no_memory_leak`
→ FAIL: `AssertionError: 640.3125 not less than 153.6 : Memory grew 640MB over 5 saves (baseline=1084MB). This indicates a memory leak. Max allowed: 154MB`

After patch:
→ PASS: `Ran 1 test in 5.558s OK`

Probe `/proc/self/maps` per iteration (single-process repro):

| iter | RSS delta before patch | RSS delta after patch |
| 0    | +128 MB                | 0                     |
| 1    | +256 MB                | 0                     |
| 2    | +384 MB                | 0                     |
| 3    | +512 MB                | 0                     |
| 4    | +640 MB                | 0                     |

mimalloc still reserves a fresh 1024 MB VMA per save (virtual address space, not committed pages); RSS stays flat at baseline because every page in the prior segment gets decommitted on free. This is expected mimalloc segment allocator behavior and is harmless — virtual address space is essentially free.

Differential Revision: D109769560


