### PR TITLE
[Dynamo] Add UNSPECIFIED_BACKEND lint rule requiring explicit backend=

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -1936,3 +1936,15 @@ command = [
     '--',
     '@{{PATHSFILE}}'
 ]
+
+[[linter]]
+code = 'UNSPECIFIED_BACKEND'
+include_patterns = [
+    'test/dynamo/**/*.py',
+]
+command = [
+    'python3',
+    'tools/linter/adapters/unspecified_backend_linter.py',
+    '--',
+    '@{{PATHSFILE}}',
+]

--- a/test/dynamo/_test_compiler_bisector_run_helper.py
+++ b/test/dynamo/_test_compiler_bisector_run_helper.py
@@ -48,7 +48,7 @@ def vq(x):
 
 def test_fn():
     with patch_exp_decomp():
-        vq_compiled = torch.compile(vq)
+        vq_compiled = torch.compile(vq)  # noqa: UNSPECIFIED_BACKEND
         x = torch.randn(4, 400, 256, device=GPU_TYPE)
         out_compiled = vq_compiled(x)
 

--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -1841,7 +1841,7 @@ Non-primal fwd outputs from model w/o backward hook: {mod_no_hook_fwd_outputs_no
                 x, x, x, None, True, dropout_p=0.0
             )[0]
 
-        @torch.compile(mode="reduce-overhead")
+        @torch.compile(mode="reduce-overhead")  # noqa: UNSPECIFIED_BACKEND
         def attn(x):
             return eager_attn(x)
 
@@ -3538,7 +3538,7 @@ class ActivationCheckpointingNestedCompileTests(torch._dynamo.test_case.TestCase
         from torch.fx.experimental.proxy_tensor import make_fx
         from torch.fx.traceback import preserve_node_meta
 
-        compiled_f = torch.compile(lambda x: x.sin().cos(), fullgraph=True)
+        compiled_f = torch.compile(lambda x: x.sin().cos(), fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
 
         @contextlib.contextmanager
         def skip_nested_compile():

--- a/test/dynamo/test_activation_offloading.py
+++ b/test/dynamo/test_activation_offloading.py
@@ -114,7 +114,7 @@ def forward(self, cos, cpu_offload_cos_1, cos_2, tangents_1):
         torch._dynamo.reset()
 
         def run_compiled():
-            return torch.compile(self.fn)(self.x)
+            return torch.compile(self.fn)(self.x)  # noqa: UNSPECIFIED_BACKEND
 
         with torch._functorch.config.patch(
             enable_activation_offloading=True,
@@ -454,7 +454,7 @@ def forward(self, cos, cpu_offload_cos_1, cos_2, tangents_1):
         torch._dynamo.reset()
 
         def run_compiled():
-            return torch.compile(self.fn)(self.x)
+            return torch.compile(self.fn)(self.x)  # noqa: UNSPECIFIED_BACKEND
 
         with torch._functorch.config.patch(
             enable_activation_offloading=True,

--- a/test/dynamo/test_after_aot.py
+++ b/test/dynamo/test_after_aot.py
@@ -59,7 +59,7 @@ class TestAfterAot(torch._dynamo.test_case.TestCase):
             ),
             functorch_config.patch({"enable_autograd_cache": False}),
         ):
-            opt_fn = torch.compile(fn, dynamic=True)
+            opt_fn = torch.compile(fn, dynamic=True)  # noqa: UNSPECIFIED_BACKEND
             inp = torch.randn(4)
             self.assertEqual(opt_fn(inp), fn(inp))
 

--- a/test/dynamo/test_aot_autograd.py
+++ b/test/dynamo/test_aot_autograd.py
@@ -1261,7 +1261,7 @@ SeqNr|OrigAten|SrcFn|FwdSrcFn
     def test_donated_buffer1(self):
         logger_name = "torch._functorch._aot_autograd.graph_compile"
 
-        @torch.compile()
+        @torch.compile()  # noqa: UNSPECIFIED_BACKEND
         def relu(x):
             return torch.nn.functional.relu(x)
 
@@ -1282,7 +1282,7 @@ SeqNr|OrigAten|SrcFn|FwdSrcFn
         logger_name = "torch._functorch._aot_autograd.graph_compile"
 
         # we will reuse the graph for g across f1 and f2
-        @torch.compile()
+        @torch.compile()  # noqa: UNSPECIFIED_BACKEND
         def g(activation, param2):
             return torch.matmul(activation, param2)
 
@@ -1304,7 +1304,7 @@ SeqNr|OrigAten|SrcFn|FwdSrcFn
         logger_name = "torch._functorch._aot_autograd.graph_compile"
 
         # we will reuse the graph for g across f1 and f2
-        @torch.compile()
+        @torch.compile()  # noqa: UNSPECIFIED_BACKEND
         def g(activation, param2):
             return torch.matmul(activation, param2)
 
@@ -1335,7 +1335,7 @@ SeqNr|OrigAten|SrcFn|FwdSrcFn
                 return torch.nn.functional.relu(x) + self.param
 
         mod = Mod()
-        mod = torch.compile(mod)
+        mod = torch.compile(mod)  # noqa: UNSPECIFIED_BACKEND
 
         inp = torch.ones([2, 2], requires_grad=True)
 
@@ -1357,7 +1357,7 @@ SeqNr|OrigAten|SrcFn|FwdSrcFn
     def test_donated_buffer5(self):
         logger_name = "torch._functorch._aot_autograd.graph_compile"
 
-        @torch.compile()
+        @torch.compile()  # noqa: UNSPECIFIED_BACKEND
         def f(x, z):
             y = x.view(2, 3)
             z = torch.nn.functional.relu(z)
@@ -1399,7 +1399,7 @@ SeqNr|OrigAten|SrcFn|FwdSrcFn
             p = torch.nn.Parameter(x + 123)
             return p, p.sin()
 
-        opt = torch.compile(fn, fullgraph=True)
+        opt = torch.compile(fn, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         x = torch.randn(16)
 
         with self.assertLogs(logger_name, level="INFO") as captured:
@@ -1421,7 +1421,7 @@ SeqNr|OrigAten|SrcFn|FwdSrcFn
 
         inp = torch.randn(3, 3, requires_grad=True)
 
-        mod = torch.compile(Mod())
+        mod = torch.compile(Mod())  # noqa: UNSPECIFIED_BACKEND
         for _ in range(5):
             mod(inp).sum().backward()
 
@@ -1438,7 +1438,7 @@ SeqNr|OrigAten|SrcFn|FwdSrcFn
 
         inp = torch.randn(3, 3, requires_grad=True)
 
-        mod = torch.compile(Mod())
+        mod = torch.compile(Mod())  # noqa: UNSPECIFIED_BACKEND
         out = mod(inp).sum()
         for _ in range(5):
             out.backward(retain_graph=True)
@@ -1457,7 +1457,7 @@ SeqNr|OrigAten|SrcFn|FwdSrcFn
 
         inp = torch.randn(3, 3, requires_grad=True)
 
-        mod = torch.compile(Mod())
+        mod = torch.compile(Mod())  # noqa: UNSPECIFIED_BACKEND
         mod(inp).sum().backward(create_graph=True)
         out = mod(inp).sum()
         for _ in range(5):
@@ -1504,7 +1504,7 @@ SeqNr|OrigAten|SrcFn|FwdSrcFn
 
         inp = torch.randn(3, 3, requires_grad=True)
 
-        mod = torch.compile(Mod())
+        mod = torch.compile(Mod())  # noqa: UNSPECIFIED_BACKEND
         mod(inp).sum().backward()
         out = mod(inp).sum()
         with self.assertRaisesRegex(
@@ -1758,7 +1758,7 @@ SeqNr|OrigAten|SrcFn|FwdSrcFn
 
         result_original = fuzzed_program(*args)
 
-        compiled_program = torch.compile(fuzzed_program, fullgraph=True, dynamic=True)
+        compiled_program = torch.compile(fuzzed_program, fullgraph=True, dynamic=True)  # noqa: UNSPECIFIED_BACKEND
         result_compiled = compiled_program(*args)
 
         self.assertTrue(torch.allclose(result_original, result_compiled))
@@ -1863,7 +1863,7 @@ SeqNr|OrigAten|SrcFn|FwdSrcFn
             patch.object(P, "_sync_decision_cross_ranks", inject_symbool_nodes),
             patch.object(functorch_config, "_sync_decision_cross_ranks", True),
         ):
-            compiled_fn = torch.compile(fn)
+            compiled_fn = torch.compile(fn)  # noqa: UNSPECIFIED_BACKEND
             loss = compiled_fn(x, splits_tensor, mask)
             # Without the fix, this raises:
             # InductorError: Unsupported inductor graph input type:
@@ -1914,7 +1914,7 @@ SeqNr|OrigAten|SrcFn|FwdSrcFn
                 return (x @ w).sum()
 
         torch._dynamo.reset()
-        result = torch.compile(f)(x, w)
+        result = torch.compile(f)(x, w)  # noqa: UNSPECIFIED_BACKEND
         self.assertIsInstance(result, torch.Tensor)
 
 

--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -337,7 +337,7 @@ class AOTAutogradCacheTests(CacheKeyEquivalenceMixin, InductorTestCase):
         def fn(x, y):
             return x * 2 + y
 
-        compiled_fn = torch.compile(fn)
+        compiled_fn = torch.compile(fn)  # noqa: UNSPECIFIED_BACKEND
         a = torch.rand(25)
         b = torch.rand(25)
         compiled_fn(a, b)
@@ -383,7 +383,7 @@ class AOTAutogradCacheTests(CacheKeyEquivalenceMixin, InductorTestCase):
 
         # Record artifacts
         with fresh_cache():
-            compiled_fn = torch.compile(fn, dynamic=dynamic)
+            compiled_fn = torch.compile(fn, dynamic=dynamic)  # noqa: UNSPECIFIED_BACKEND
 
             # A first call should miss in the cache.
             eager_result = fn(a, b)
@@ -807,7 +807,7 @@ class AOTAutogradCacheTests(CacheKeyEquivalenceMixin, InductorTestCase):
             return a, tmp
 
         with torch.autograd._force_original_view_tracking(True):
-            compiled_fn = torch.compile(fn)
+            compiled_fn = torch.compile(fn)  # noqa: UNSPECIFIED_BACKEND
 
         def run_and_check(miss, hit, bypass):
             self._clear_dynamo_and_codecache()
@@ -862,7 +862,7 @@ class AOTAutogradCacheTests(CacheKeyEquivalenceMixin, InductorTestCase):
                 torch._dynamo.graph_break()
                 return x.sin()
 
-        @torch.compile
+        @torch.compile  # noqa: UNSPECIFIED_BACKEND
         def fn(x, y, z):
             return AllowInGraphFunc.apply(x)
 
@@ -1695,7 +1695,7 @@ class AOTAutogradCacheTests(CacheKeyEquivalenceMixin, InductorTestCase):
         """
         torch._dynamo.eval_frame.clear_dynamo_tls()
 
-        @torch.compile
+        @torch.compile  # noqa: UNSPECIFIED_BACKEND
         def fn(x):
             # Calls x.sum().backward() during forward execution of fn
             (x_grad,) = torch.autograd.grad(x.sum(), x)
@@ -1834,7 +1834,7 @@ class AOTAutogradCacheTests(CacheKeyEquivalenceMixin, InductorTestCase):
             )
             return res
 
-        compiled_fn = torch.compile(fn, dynamic=True)
+        compiled_fn = torch.compile(fn, dynamic=True)  # noqa: UNSPECIFIED_BACKEND
 
         a_shape = (5, 6)
         b_shape = (7, 8)
@@ -1899,7 +1899,7 @@ class AOTAutogradCacheTests(CacheKeyEquivalenceMixin, InductorTestCase):
         def fn(x, y):
             return (x + x, y + y)
 
-        compiled_fn = torch.compile(fn, dynamic=True)
+        compiled_fn = torch.compile(fn, dynamic=True)  # noqa: UNSPECIFIED_BACKEND
 
         # Iterate over different shapes, varying whether the total
         # size is below or above int32. For each combination, we expect
@@ -2057,7 +2057,7 @@ class AOTAutogradCacheTests(CacheKeyEquivalenceMixin, InductorTestCase):
         """
         from torch._inductor.async_compile import CompiledTritonKernels
 
-        @torch.compile
+        @torch.compile  # noqa: UNSPECIFIED_BACKEND
         def f(x, y):
             return x.sin() + y
 
@@ -2317,14 +2317,14 @@ class AOTAutogradCacheTests(CacheKeyEquivalenceMixin, InductorTestCase):
 
         # Record artifacts
         with fresh_cache():
-            compiled_fn = torch.compile(fn, dynamic=dynamic)
+            compiled_fn = torch.compile(fn, dynamic=dynamic)  # noqa: UNSPECIFIED_BACKEND
 
             # A first call should miss in the cache.
             eager_result = fn(a, b)
             expected_grads = torch.autograd.grad(eager_result.sum(), inputs=(a, b))
             compiled_result = compiled_fn(a, b)
             with torch._dynamo.compiled_autograd._enable(
-                torch.compile(dynamic=dynamic)
+                torch.compile(dynamic=dynamic)  # noqa: UNSPECIFIED_BACKEND
             ):
                 actual_grads = torch.autograd.grad(compiled_result.sum(), inputs=(a, b))
             if hasattr(a, "_dynamo_propagated_dynamic_indices"):
@@ -2384,7 +2384,7 @@ class AOTAutogradCacheTests(CacheKeyEquivalenceMixin, InductorTestCase):
                 expected_grads = torch.autograd.grad(eager_result.sum(), inputs=(a, b))
                 compiled_result = compiled_fn(a, b)
                 with torch._dynamo.compiled_autograd._enable(
-                    torch.compile(dynamic=dynamic)
+                    torch.compile(dynamic=dynamic)  # noqa: UNSPECIFIED_BACKEND
                 ):
                     actual_grads = torch.autograd.grad(
                         compiled_result.sum(), inputs=(a, b)
@@ -2966,7 +2966,7 @@ class AOTAutogradCacheTests(CacheKeyEquivalenceMixin, InductorTestCase):
             self._clear_all_caches()
 
             # First compilation - expect cache miss.
-            compiled = torch.compile(target)
+            compiled = torch.compile(target)  # noqa: UNSPECIFIED_BACKEND
             result1 = compiled(*inputs)
 
             # Assert cache miss.
@@ -2986,7 +2986,7 @@ class AOTAutogradCacheTests(CacheKeyEquivalenceMixin, InductorTestCase):
             torch._dynamo.reset()
 
             # Second compilation - expect cache hit.
-            compiled2 = torch.compile(target)
+            compiled2 = torch.compile(target)  # noqa: UNSPECIFIED_BACKEND
             result2 = compiled2(*inputs)
 
             # Assert cache hit.
@@ -3022,7 +3022,7 @@ class AOTAutogradCacheTests(CacheKeyEquivalenceMixin, InductorTestCase):
 
         with inductor_config.patch("pre_grad_custom_pass", NoUuidPass()):
             self._clear_all_caches()
-            compiled_fn = torch.compile(fn)
+            compiled_fn = torch.compile(fn)  # noqa: UNSPECIFIED_BACKEND
             with self.assertRaisesRegex(
                 RuntimeError, "pre_grad_custom_pass.*NoUuidPass must implement uuid"
             ):
@@ -3058,7 +3058,7 @@ class AOTAutogradCacheTests(CacheKeyEquivalenceMixin, InductorTestCase):
             self._clear_all_caches()
 
             # First compilation — should warn.
-            compiled_fn = torch.compile(fn)
+            compiled_fn = torch.compile(fn)  # noqa: UNSPECIFIED_BACKEND
             with self.assertLogs(
                 "torch._inductor.codecache", level="WARNING"
             ) as log_cm:
@@ -3070,7 +3070,7 @@ class AOTAutogradCacheTests(CacheKeyEquivalenceMixin, InductorTestCase):
 
             # Second compilation — same pass class, should not warn again.
             torch._dynamo.reset()
-            compiled_fn2 = torch.compile(fn)
+            compiled_fn2 = torch.compile(fn)  # noqa: UNSPECIFIED_BACKEND
             with self.assertNoLogs("torch._inductor.codecache", level="WARNING"):
                 compiled_fn2(x, y)
 
@@ -4585,7 +4585,7 @@ class CacheKeyAPITests(torch._dynamo.test_case.TestCase):
                     side_effect=capturing_cache_key,
                 ),
             ):
-                torch.compile(fn, fullgraph=True)(*args)
+                torch.compile(fn, fullgraph=True)(*args)  # noqa: UNSPECIFIED_BACKEND
 
         self.assertIsNotNone(captured_key)
         return captured_key, captured_gm, captured_example_inputs

--- a/test/dynamo/test_aot_compile.py
+++ b/test/dynamo/test_aot_compile.py
@@ -158,14 +158,14 @@ class MultiHeadSelfAttention(nn.Module):
         }
         compile_key = tuple(sorted(compile_spec.items()))
         if compile_key not in MultiHeadSelfAttention._flex_attention_cache:
-            MultiHeadSelfAttention._flex_attention_cache[compile_key] = torch.compile(
+            MultiHeadSelfAttention._flex_attention_cache[compile_key] = torch.compile(  # noqa: UNSPECIFIED_BACKEND
                 flex_attention, **compile_spec
             )
         self._flex_attention = MultiHeadSelfAttention._flex_attention_cache[compile_key]
 
         # Also compile create_block_mask
         if MultiHeadSelfAttention._create_block_mask_fn is None:
-            MultiHeadSelfAttention._create_block_mask_fn = torch.compile(
+            MultiHeadSelfAttention._create_block_mask_fn = torch.compile(  # noqa: UNSPECIFIED_BACKEND
                 create_block_mask, dynamic=False, fullgraph=True
             )
 
@@ -404,7 +404,7 @@ def _subprocess_disable_guard_check():
         def fn(x, y):
             return x + y
 
-        compiled_fn = torch.compile(fn, fullgraph=True).aot_compile(
+        compiled_fn = torch.compile(fn, fullgraph=True).aot_compile(  # noqa: UNSPECIFIED_BACKEND
             ((torch.randn(3, 4), torch.randn(3, 4)), {})
         )
         inputs = (torch.randn(3, 4), torch.randn(3, 4))
@@ -441,13 +441,13 @@ def _subprocess_grad_mode_after_prior_compile():
         def target_fn(x, y):
             return x - y
 
-        torch.compile(warmup_fn, fullgraph=True).aot_compile(
+        torch.compile(warmup_fn, fullgraph=True).aot_compile(  # noqa: UNSPECIFIED_BACKEND
             ((torch.randn(3, 4), torch.randn(3, 4)), {})
         )
         torch._dynamo.reset()
 
         with torch.no_grad():
-            compiled_fn = torch.compile(target_fn, fullgraph=True).aot_compile(
+            compiled_fn = torch.compile(target_fn, fullgraph=True).aot_compile(  # noqa: UNSPECIFIED_BACKEND
                 ((torch.randn(3, 4), torch.randn(3, 4)), {})
             )
 
@@ -789,7 +789,7 @@ class TestAOTCompile(torch._inductor.test_case.TestCase):
         def fn(x, y):
             return MY_LAMBDA(x) + y
 
-        compiled_fn = torch.compile(fn, fullgraph=True).aot_compile(
+        compiled_fn = torch.compile(fn, fullgraph=True).aot_compile(  # noqa: UNSPECIFIED_BACKEND
             ((torch.randn(3, 4), torch.randn(3, 4)), {})
         )
 
@@ -845,7 +845,7 @@ class TestAOTCompile(torch._inductor.test_case.TestCase):
 
         self.assertExpectedInlineMunged(
             Unsupported,
-            lambda: torch.compile(foo, fullgraph=True).aot_compile(
+            lambda: torch.compile(foo, fullgraph=True).aot_compile(  # noqa: UNSPECIFIED_BACKEND
                 ((torch.ones(3), torch.ones(3)), {})
             ),
             """\
@@ -943,7 +943,7 @@ from user code:
         def fn(xy):
             return xy[0] + xy[1]
 
-        compiled_fn = torch.compile(
+        compiled_fn = torch.compile(  # noqa: UNSPECIFIED_BACKEND
             fn,
             fullgraph=True,
             options={"guard_filter_fn": torch.compiler.keep_portable_guards_unsafe},
@@ -1113,7 +1113,7 @@ from user code:
         def fn(x, y):
             return x + y + tmp
 
-        compiled_fn = torch.compile(fn, fullgraph=True).aot_compile(
+        compiled_fn = torch.compile(fn, fullgraph=True).aot_compile(  # noqa: UNSPECIFIED_BACKEND
             ((torch.randn(3, 4), torch.randn(3, 4)), {})
         )
         inputs = (torch.randn(3, 4), torch.randn(3, 4))
@@ -1128,7 +1128,7 @@ from user code:
 
     def test_aot_compile_with_super_call(self):
         fn = TestVLLMModel()
-        compiled_fn = torch.compile(fn.forward, fullgraph=True).aot_compile(
+        compiled_fn = torch.compile(fn.forward, fullgraph=True).aot_compile(  # noqa: UNSPECIFIED_BACKEND
             ((torch.randn(3, 4),), {})
         )
         self.assertEqual(fn.forward.__code__.co_freevars, ("__class__",))
@@ -1149,7 +1149,7 @@ from user code:
         def make_inputs():
             return (torch.randn(3, 4), torch.randn(3, 4))
 
-        compiled_fn = torch.compile(fn, fullgraph=True).aot_compile((make_inputs(), {}))
+        compiled_fn = torch.compile(fn, fullgraph=True).aot_compile((make_inputs(), {}))  # noqa: UNSPECIFIED_BACKEND
 
         test_inputs = make_inputs()
         self.assertEqual(compiled_fn(*test_inputs), fn(*test_inputs))
@@ -1158,7 +1158,7 @@ from user code:
         def fn(x, y=1):
             return x + x
 
-        compiled_fn = torch.compile(fn, fullgraph=True).aot_compile(
+        compiled_fn = torch.compile(fn, fullgraph=True).aot_compile(  # noqa: UNSPECIFIED_BACKEND
             ((torch.randn(3, 4),), {})
         )
         inputs = (torch.randn(3, 4),)
@@ -1243,7 +1243,7 @@ from user code:
             def make_inputs():
                 return (torch.randn(3, 4), torch.randn(3, 4))
 
-            compiled_fn = torch.compile(
+            compiled_fn = torch.compile(  # noqa: UNSPECIFIED_BACKEND
                 fn, fullgraph=True, options={"use_aoti": True}
             ).aot_compile((make_inputs(), {}))
             test_inputs = make_inputs()
@@ -1274,7 +1274,7 @@ from user code:
             d_input_tensor = DTensor.from_local(input_tensor, mesh, placements)
             mod = RedistributeModel()
 
-            compiled_fn = torch.compile(
+            compiled_fn = torch.compile(  # noqa: UNSPECIFIED_BACKEND
                 mod,
                 fullgraph=True,
             ).forward.aot_compile(((input_tensor, d_input_tensor, mesh), {}))
@@ -1305,7 +1305,7 @@ from user code:
         fn = wrap_forward_function(fn)
         mod.forward = fn
 
-        compiled_fn = torch.compile(fn, fullgraph=True).aot_compile(
+        compiled_fn = torch.compile(fn, fullgraph=True).aot_compile(  # noqa: UNSPECIFIED_BACKEND
             ((torch.randn(4, 3),), {})
         )
         mod.forward = compiled_fn
@@ -1344,7 +1344,7 @@ from user code:
 
         fn = wrap_forward_function(fn)
 
-        compiled_fn = torch.compile(fn, fullgraph=True).aot_compile(
+        compiled_fn = torch.compile(fn, fullgraph=True).aot_compile(  # noqa: UNSPECIFIED_BACKEND
             ((torch.randn(4, 3),), {})
         )
         mod.forward = compiled_fn
@@ -1380,7 +1380,7 @@ from user code:
 
             return checkpoint(compute, x, y, use_reentrant=False)
 
-        compiled_fn = torch.compile(fn, fullgraph=True).aot_compile(
+        compiled_fn = torch.compile(fn, fullgraph=True).aot_compile(  # noqa: UNSPECIFIED_BACKEND
             ((torch.randn(3, 4), torch.randn(3, 4)), {})
         )
         inputs = (torch.randn(3, 4), torch.randn(3, 4))
@@ -1404,7 +1404,7 @@ from user code:
         def make_inputs():
             return (torch.randn(3, 4), torch.randn(3, 4))
 
-        compiled_fn = torch.compile(fn, fullgraph=True).aot_compile((make_inputs(), {}))
+        compiled_fn = torch.compile(fn, fullgraph=True).aot_compile((make_inputs(), {}))  # noqa: UNSPECIFIED_BACKEND
         test_inputs = make_inputs()
         expected = fn(*test_inputs)
         actual = compiled_fn(*test_inputs)
@@ -1429,7 +1429,7 @@ from user code:
             return x + 1, type
 
         x = torch.randn(4)
-        compiled_fn = torch.compile(fn, fullgraph=True).aot_compile(((x,), {}))
+        compiled_fn = torch.compile(fn, fullgraph=True).aot_compile(((x,), {}))  # noqa: UNSPECIFIED_BACKEND
 
         # Save and reload without f_globals
         compiled_fn.save_compiled_function(self.path())
@@ -1456,7 +1456,7 @@ from user code:
                 torch.randn(3, 4, device=GPU_TYPE, requires_grad=True),
                 torch.randn(3, 4, device=GPU_TYPE, requires_grad=True),
             )
-        compiled_fn = torch.compile(
+        compiled_fn = torch.compile(  # noqa: UNSPECIFIED_BACKEND
             fn,
             fullgraph=True,
         ).aot_compile((fake_inputs, {}))

--- a/test/dynamo/test_backends.py
+++ b/test/dynamo/test_backends.py
@@ -466,7 +466,7 @@ class TestDefaultBackend(torch._dynamo.test_case.TestCase):
         def f(x):
             return torch.relu(x)
 
-        opt_f = torch.compile(f)
+        opt_f = torch.compile(f)  # noqa: UNSPECIFIED_BACKEND
         opt_f(torch.randn(3, 3))
         self.assertEqual(cnt.frame_count, 1)
 

--- a/test/dynamo/test_callback.py
+++ b/test/dynamo/test_callback.py
@@ -94,7 +94,7 @@ class CallbackTests(TestCase):
                 return self.fc2(temp)
 
         model = TinyModel().to(device_type)
-        compiled_model = torch.compile(model, mode="max-autotune")
+        compiled_model = torch.compile(model, mode="max-autotune")  # noqa: UNSPECIFIED_BACKEND
         x = torch.randn(10, 10, device=device_type)
 
         loss = compiled_model(x).sum()

--- a/test/dynamo/test_compiler_bisector.py
+++ b/test/dynamo/test_compiler_bisector.py
@@ -84,7 +84,7 @@ class TestCompilerBisector(TestCase):
         def test_fn():
             torch._dynamo.reset()
             with patch_exp_decomp():
-                vq_compiled = torch.compile(vq)
+                vq_compiled = torch.compile(vq)  # noqa: UNSPECIFIED_BACKEND
                 x = torch.randn(4, 400, 256, device=GPU_TYPE)
                 with torch._dynamo.utils.preserve_rng_state():
                     vq(x)
@@ -125,7 +125,7 @@ class TestCompilerBisector(TestCase):
             inp = torch.rand([10])
 
             out = foo(inp)
-            out_c = torch.compile(foo)(inp)
+            out_c = torch.compile(foo)(inp)  # noqa: UNSPECIFIED_BACKEND
 
             return torch.allclose(out, out_c)
 
@@ -162,7 +162,7 @@ class TestCompilerBisector(TestCase):
             inp = torch.rand([10], device=GPU_TYPE)
 
             out = foo(inp)
-            out_c = torch.compile(foo)(inp)
+            out_c = torch.compile(foo)(inp)  # noqa: UNSPECIFIED_BACKEND
 
             return torch.allclose(out, out_c)
 
@@ -183,7 +183,7 @@ class TestCompilerBisector(TestCase):
             with preserve_rng_state():
                 out = foo()
             with preserve_rng_state():
-                out_c = torch.compile(foo)()
+                out_c = torch.compile(foo)()  # noqa: UNSPECIFIED_BACKEND
 
             return torch.allclose(out, out_c)
 
@@ -229,7 +229,7 @@ class TestCompilerBisector(TestCase):
                 torch._dynamo.reset()
 
                 try:
-                    torch.testing.assert_close(torch.compile(op)(x), op(x))
+                    torch.testing.assert_close(torch.compile(op)(x), op(x))  # noqa: UNSPECIFIED_BACKEND
                 except Exception:
                     return False
                 return True
@@ -251,7 +251,7 @@ class TestCompilerBisector(TestCase):
             torch.manual_seed(0)
             inp = torch.randn(16, 16, 768, dtype=dtype, device=GPU_TYPE)
             eager_scale = calculate_scale(inp)
-            compile_scale = torch.compile(calculate_scale)(inp)
+            compile_scale = torch.compile(calculate_scale)(inp)  # noqa: UNSPECIFIED_BACKEND
 
             return torch.equal(eager_scale, compile_scale)
 
@@ -269,7 +269,7 @@ class TestCompilerBisector(TestCase):
 
                 inp = torch.rand([100], device=GPU_TYPE)
 
-                return torch.allclose(torch.compile(my_func)(inp), my_func(inp))
+                return torch.allclose(torch.compile(my_func)(inp), my_func(inp))  # noqa: UNSPECIFIED_BACKEND
 
         out = CompilerBisector.do_bisect(test_fn)
         self.assertEqual(out.backend, "inductor")
@@ -367,8 +367,8 @@ class TestCompilerBisector(TestCase):
             counters.clear()
             CompilerBisector.bisection_enabled = True
             try:
-                foo_c = torch.compile(foo, mode="reduce-overhead")
-                bar_c = torch.compile(bar, mode="reduce-overhead")
+                foo_c = torch.compile(foo, mode="reduce-overhead")  # noqa: UNSPECIFIED_BACKEND
+                bar_c = torch.compile(bar, mode="reduce-overhead")  # noqa: UNSPECIFIED_BACKEND
                 x = torch.randn(10, device=GPU_TYPE)
                 foo_c(x)
                 bar_c(x)

--- a/test/dynamo/test_complex.py
+++ b/test/dynamo/test_complex.py
@@ -25,7 +25,7 @@ def sample_function(a: torch.Tensor, b: torch.Tensor, x: torch.Tensor) -> torch.
 
 class ComplexTests(ComplexDynamoTestCase):
     def test_simple(self):
-        fn_c = torch.compile(sample_function, fullgraph=True)
+        fn_c = torch.compile(sample_function, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         a = torch.randn(2, 2, dtype=torch.complex64)
         b = torch.randn(2, 2, dtype=torch.complex64)
         x = torch.randn(2, 2)
@@ -39,7 +39,7 @@ class ComplexTests(ComplexDynamoTestCase):
 
         re = torch.randn(2, 2, dtype=torch.float32)
         im = torch.randn(2, 2, dtype=torch.float32)
-        fn_c = torch.compile(f, fullgraph=True)
+        fn_c = torch.compile(f, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         self.assertEqual(fn_c(re, im), f(re, im))
 
     def test_no_complex_inputs(self):
@@ -48,7 +48,7 @@ class ComplexTests(ComplexDynamoTestCase):
             b = torch.complex(torch.cos(x), torch.sin(y))
             return sample_function(a, b, x)
 
-        fn_c = torch.compile(f, fullgraph=True)
+        fn_c = torch.compile(f, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
 
         x = torch.randn(2, 2)
         y = torch.randn(2, 2)
@@ -58,7 +58,7 @@ class ComplexTests(ComplexDynamoTestCase):
         def f(a, b, x):
             return [sample_function(a, b, x), sample_function(b, a, x)]
 
-        fn_c = torch.compile(f, fullgraph=True)
+        fn_c = torch.compile(f, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
 
         a = torch.randn(2, 2, dtype=torch.complex64)
         b = torch.randn(2, 2, dtype=torch.complex64)
@@ -74,7 +74,7 @@ class ComplexTests(ComplexDynamoTestCase):
             return out
 
         a = torch.randn(2, 2, dtype=torch.complex64)
-        fn_c = torch.compile(f, fullgraph=True)
+        fn_c = torch.compile(f, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         self.assertRaises(RuntimeError, fn_c, a)
 
     @unittest.expectedFailure
@@ -86,7 +86,7 @@ class ComplexTests(ComplexDynamoTestCase):
             return out
 
         a = torch.randn(2, 2, dtype=torch.complex64)
-        fn_c = torch.compile(f, fullgraph=True)
+        fn_c = torch.compile(f, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         ref = f(a)
         test = fn_c(a)
         self.assertEqual(ref, test)
@@ -98,7 +98,7 @@ class ComplexTests(ComplexDynamoTestCase):
             b[...] = torch.ones_like(b)
             return a
 
-        fn_c = torch.compile(f, fullgraph=True)
+        fn_c = torch.compile(f, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         self.assertEqual(f(), fn_c())
 
     def test_neg_alias(self):
@@ -108,7 +108,7 @@ class ComplexTests(ComplexDynamoTestCase):
             b[...] = torch.ones_like(b)
             return a
 
-        fn_c = torch.compile(f, fullgraph=True)
+        fn_c = torch.compile(f, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         self.assertEqual(f(), fn_c())
 
     def test_complex_output_aliases_input(self):
@@ -117,7 +117,7 @@ class ComplexTests(ComplexDynamoTestCase):
             return a[...]
 
         a = torch.randn(2, 2, dtype=torch.complex64)
-        fn_c = torch.compile(f, fullgraph=True)
+        fn_c = torch.compile(f, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         ref = f(a)
         test = fn_c(a)
         self.assertEqual(ref, test)
@@ -132,7 +132,7 @@ class ComplexTests(ComplexDynamoTestCase):
         a = torch.randn(2, 2, dtype=torch.complex64)
         b = torch.randn(2, 2, dtype=torch.complex64)
 
-        fn_c = torch.compile(f, fullgraph=True)
+        fn_c = torch.compile(f, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         self.assertRaises(RuntimeError, fn_c, a, b)
 
     @unittest.expectedFailure
@@ -145,7 +145,7 @@ class ComplexTests(ComplexDynamoTestCase):
         a = torch.randn(2, 2, dtype=torch.complex64)
         b = torch.randn(2, 2, dtype=torch.complex64)
 
-        fn_c = torch.compile(f, fullgraph=True)
+        fn_c = torch.compile(f, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
 
         a_ref = a.clone()
         a_test = a.clone()
@@ -159,7 +159,7 @@ class ComplexTests(ComplexDynamoTestCase):
             a[...] = torch.zeros_like(a)
             return out
 
-        mutate_c = torch.compile(mutate, fullgraph=True)
+        mutate_c = torch.compile(mutate, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         self.assertEqual(mutate(), mutate_c())
 
     def test_view_as_real(self):
@@ -168,7 +168,7 @@ class ComplexTests(ComplexDynamoTestCase):
             b = torch.zeros(2, 2, dtype=torch.complex64)
             return torch.view_as_real(a).clone(), b
 
-        fn_c = torch.compile(f, fullgraph=True)
+        fn_c = torch.compile(f, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         self.assertEqual(f(), fn_c())
 
     def test_rope(self):
@@ -211,7 +211,7 @@ class ComplexTests(ComplexDynamoTestCase):
         xq = torch.randn(4, 32, 64, generator=g)
         xk = torch.randn(4, 32, 64, generator=g)
 
-        fn_c = torch.compile(f, fullgraph=True)
+        fn_c = torch.compile(f, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         self.assertEqual(f(xq, xk), fn_c(xq, xk))
 
 

--- a/test/dynamo/test_debug_utils.py
+++ b/test/dynamo/test_debug_utils.py
@@ -819,7 +819,7 @@ class TestInductorConfigOverrideIntegration(TestCase):
             patch.object(compile_fx_mod, "compile_fx", tracking_compile_fx),
             patch.object(torch._functorch.config, "enable_autograd_cache", False),
         ):
-            compiled_fn = torch.compile(fn)
+            compiled_fn = torch.compile(fn)  # noqa: UNSPECIFIED_BACKEND
             x = torch.randn(10, device=device, requires_grad=True)
             result = compiled_fn(x)
             result.backward()

--- a/test/dynamo/test_decorators.py
+++ b/test/dynamo/test_decorators.py
@@ -1750,7 +1750,7 @@ Detected recompile when torch.compile stance is 'fail_on_recompile'. filename: '
             g(torch.ones(3))
 
     def test_set_stance_force_backend(self):
-        @torch.compile
+        @torch.compile  # noqa: UNSPECIFIED_BACKEND
         def a(x):
             return x + 1
 
@@ -2493,7 +2493,7 @@ Detected recompile when torch.compile stance is 'fail_on_recompile'. filename: '
             wrapped_fn = torch.compiler.allow_in_graph(my_custom_function)
             return wrapped_fn(x)
 
-        compiled = torch.compile(forward, fullgraph=True)
+        compiled = torch.compile(forward, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         with self.assertRaisesRegex(
             torch._dynamo.exc.Unsupported,
             "allow_in_graph",

--- a/test/dynamo/test_dynamic_spec.py
+++ b/test/dynamo/test_dynamic_spec.py
@@ -692,7 +692,7 @@ class TestShapeVarCompile(TestCase):
         with self.assertRaisesRegex(
             TypeError, "dynamic spec expects a dict, ShapesSpec, or ParamsSpec"
         ):
-            torch.compile(lambda x: x, shapes_spec="not a spec")
+            torch.compile(lambda x: x, shapes_spec="not a spec")  # noqa: UNSPECIFIED_BACKEND
 
     @_fx_experimental_config.patch(no_data_dependent_graph_break=True)
     def test_min_max_bypasses_dde_on_branching(self):
@@ -2038,7 +2038,7 @@ class TestDynamicSpecDecoratorCompile(TestCase):
             ValueError,
             r"`@dynamic_spec\(\.\.\.\)` is attached.*AND a `dynamic_shapes=`",
         ):
-            torch.compile(
+            torch.compile(  # noqa: UNSPECIFIED_BACKEND
                 fn,
                 shapes_spec=ParamsSpec({"x": TensorSpec([ShapeVar("Z"), STATIC])}),
             )(torch.randn(8, 3))

--- a/test/dynamo/test_dynamo_decompositions.py
+++ b/test/dynamo/test_dynamo_decompositions.py
@@ -613,7 +613,7 @@ class TestDynamoDecompositionsNumerics(TestCase):
         value = torch.tensor(0.5, device=device)
 
         expected = fn(x.clone(), tensor1, tensor2, value)
-        actual = torch.compile(fn, fullgraph=True)(x.clone(), tensor1, tensor2, value)
+        actual = torch.compile(fn, fullgraph=True)(x.clone(), tensor1, tensor2, value)  # noqa: UNSPECIFIED_BACKEND
         self.assertEqual(expected, actual)
 
     @skipIfCrossRef
@@ -691,7 +691,7 @@ class TestDynamoDecompositionsNumerics(TestCase):
         value = torch.tensor(0.5, device=device)
 
         expected = fn(x.clone(), tensor1, tensor2, value)
-        actual = torch.compile(fn, fullgraph=True)(x.clone(), tensor1, tensor2, value)
+        actual = torch.compile(fn, fullgraph=True)(x.clone(), tensor1, tensor2, value)  # noqa: UNSPECIFIED_BACKEND
         self.assertEqual(expected, actual)
 
     @skipIfCrossRef
@@ -768,7 +768,7 @@ class TestDynamoDecompositionsNumerics(TestCase):
         alpha = torch.tensor(2.0, device=device)
 
         expected = fn(x.clone(), other, alpha)
-        actual = torch.compile(fn, fullgraph=True)(x.clone(), other, alpha)
+        actual = torch.compile(fn, fullgraph=True)(x.clone(), other, alpha)  # noqa: UNSPECIFIED_BACKEND
         self.assertEqual(expected, actual, atol=0, rtol=0)
 
     @skipIfCrossRef
@@ -785,7 +785,7 @@ class TestDynamoDecompositionsNumerics(TestCase):
             return x.add_(other, alpha=alpha)
 
         expected = fn(x.clone(), other, alpha)
-        actual = torch.compile(fn, fullgraph=True)(x.clone(), other, alpha)
+        actual = torch.compile(fn, fullgraph=True)(x.clone(), other, alpha)  # noqa: UNSPECIFIED_BACKEND
         self.assertEqual(expected, actual, atol=0, rtol=0)
 
     @skipIfCrossRef
@@ -806,7 +806,7 @@ class TestDynamoDecompositionsNumerics(TestCase):
             return x.addcmul_(t1, t1, value=1)
 
         expected = fn(x.clone(), t1)
-        actual = torch.compile(fn, fullgraph=True)(x.clone(), t1)
+        actual = torch.compile(fn, fullgraph=True)(x.clone(), t1)  # noqa: UNSPECIFIED_BACKEND
         self.assertEqual(expected, actual)
 
     @skipIfCrossRef
@@ -822,7 +822,7 @@ class TestDynamoDecompositionsNumerics(TestCase):
             return x.addcmul_(t1, t2, value=0.5)
 
         expected = fn(x.clone(), t1, t2)
-        actual = torch.compile(fn, fullgraph=True)(x.clone(), t1, t2)
+        actual = torch.compile(fn, fullgraph=True)(x.clone(), t1, t2)  # noqa: UNSPECIFIED_BACKEND
         self.assertEqual(expected, actual)
 
     @skipIfCrossRef
@@ -839,7 +839,7 @@ class TestDynamoDecompositionsNumerics(TestCase):
             return x.addcmul_(t1, t2, value=value)
 
         expected = fn(x.clone(), t1, t2, value)
-        actual = torch.compile(fn, fullgraph=True)(x.clone(), t1, t2, value)
+        actual = torch.compile(fn, fullgraph=True)(x.clone(), t1, t2, value)  # noqa: UNSPECIFIED_BACKEND
         self.assertEqual(expected, actual)
 
     @skipIfCrossRef
@@ -860,7 +860,7 @@ class TestDynamoDecompositionsNumerics(TestCase):
             return x.addcdiv_(t1, t2, value=-0.01)
 
         expected = fn(x.clone(), t1, t2)
-        actual = torch.compile(fn, fullgraph=True)(x.clone(), t1, t2)
+        actual = torch.compile(fn, fullgraph=True)(x.clone(), t1, t2)  # noqa: UNSPECIFIED_BACKEND
         self.assertEqual(expected, actual)
 
     @skipIfCrossRef
@@ -882,7 +882,7 @@ class TestDynamoDecompositionsNumerics(TestCase):
             return x.addcdiv_(t1, t2, value=value)
 
         expected = fn(x.clone(), t1, t2, value)
-        actual = torch.compile(fn, fullgraph=True)(x.clone(), t1, t2, value)
+        actual = torch.compile(fn, fullgraph=True)(x.clone(), t1, t2, value)  # noqa: UNSPECIFIED_BACKEND
         self.assertEqual(expected, actual)
 
     @skipIfCrossRef
@@ -897,7 +897,7 @@ class TestDynamoDecompositionsNumerics(TestCase):
             return x.add_(other, alpha=2.3)
 
         expected = fn(x.clone(), other)
-        actual = torch.compile(fn, fullgraph=True)(x.clone(), other)
+        actual = torch.compile(fn, fullgraph=True)(x.clone(), other)  # noqa: UNSPECIFIED_BACKEND
         self.assertEqual(expected, actual)
 
 

--- a/test/dynamo/test_exc.py
+++ b/test/dynamo/test_exc.py
@@ -383,7 +383,7 @@ ReluCompileError:""",
     def test_trigger_on_error(self):
         from torch.fx.experimental.validator import ValidationException
 
-        @torch.compile
+        @torch.compile  # noqa: UNSPECIFIED_BACKEND
         def fn(x, shape):
             return x.split(shape)
 
@@ -445,7 +445,7 @@ Failed Source Expressions:
     def test_trigger_bisect_on_error(self):
         from torch.fx.experimental.validator import BisectValidationException
 
-        @torch.compile
+        @torch.compile  # noqa: UNSPECIFIED_BACKEND
         def fn(x, shape):
             return x.split(shape)
 

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -3544,7 +3544,7 @@ class GraphModule(torch.nn.Module):
                 with self.subTest(seed_fn=f"{seed_fn.__module__}.{seed_fn.__name__}"):
                     torch._dynamo.reset()
 
-                    @torch.compile
+                    @torch.compile  # noqa: UNSPECIFIED_BACKEND
                     def foo():
                         seed_fn(3)
                         return torch.rand(4, device="cuda")
@@ -3820,7 +3820,7 @@ class GraphModule(torch.nn.Module):
                 def fn(a, b):
                     return operator.concat(a, b)
 
-                opt_fn = torch.compile(fn, fullgraph=True)
+                opt_fn = torch.compile(fn, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
                 a = seq_type([1, 2, 3])
                 b = seq_type([4, 5, 6])
                 self.assertEqual(opt_fn(a, b), fn(a, b))
@@ -3829,7 +3829,7 @@ class GraphModule(torch.nn.Module):
         def fn(a, b):
             return operator.iconcat(a, b)
 
-        opt_fn = torch.compile(fn, fullgraph=True)
+        opt_fn = torch.compile(fn, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         self.assertEqual(opt_fn([1, 2, 3], [4, 5, 6]), [1, 2, 3, 4, 5, 6])
 
     def test_attrgetter(self):
@@ -4189,7 +4189,7 @@ class GraphModule(torch.nn.Module):
         t = torch.rand((2, 2)) * scale + zero_point
 
         result = fn(t, scale, zero_point)
-        compiled_fn = torch.compile(fn, fullgraph=True)
+        compiled_fn = torch.compile(fn, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         compiled_result = compiled_fn(t, scale, zero_point)
         self.assertEqual(compiled_result, result)
 

--- a/test/dynamo/test_fx_graph_runnable.py
+++ b/test/dynamo/test_fx_graph_runnable.py
@@ -199,7 +199,7 @@ class FxGraphRunnableTest(TestCase):
         def f(x):
             return x + 1
 
-        torch.compile(f)(torch.randn(4))
+        torch.compile(f)(torch.randn(4))  # noqa: UNSPECIFIED_BACKEND
         self._exec_and_verify_payload()
 
     @unittest.skipUnless(has_triton(), "Triton not available")
@@ -221,7 +221,7 @@ class FxGraphRunnableTest(TestCase):
         x = torch.ones((4096,), device=GPU_TYPE, dtype=torch.float16)
         y = torch.ones((4096,), device=GPU_TYPE, dtype=torch.float16)
 
-        torch.compile(add)(x, y)
+        torch.compile(add)(x, y)  # noqa: UNSPECIFIED_BACKEND
         self._exec_and_verify_payload()
 
     @unittest.skipUnless(has_triton(), "Triton not available")
@@ -236,7 +236,7 @@ class FxGraphRunnableTest(TestCase):
         x = torch.ones((4096,), device=GPU_TYPE, dtype=torch.float16)
         y = torch.ones((4096,), device=GPU_TYPE, dtype=torch.float16)
 
-        torch.compile(add)(x, y)
+        torch.compile(add)(x, y)  # noqa: UNSPECIFIED_BACKEND
         self._exec_and_verify_payload()
 
     @unittest.skipUnless(has_triton(), "Triton not available")
@@ -253,7 +253,7 @@ class FxGraphRunnableTest(TestCase):
         x = torch.ones((4096,), device=GPU_TYPE, dtype=torch.float16)
         y = torch.ones((4096,), device=GPU_TYPE, dtype=torch.float16) * 0.5
 
-        torch.compile(subtract_nested)(x, y)
+        torch.compile(subtract_nested)(x, y)  # noqa: UNSPECIFIED_BACKEND
         self._exec_and_verify_payload()
 
     @unittest.skipUnless(has_triton(), "Triton not available")
@@ -276,7 +276,7 @@ class FxGraphRunnableTest(TestCase):
         x = torch.ones((4096,), device=GPU_TYPE, dtype=torch.float16)
         y = torch.ones((4096,), device=GPU_TYPE, dtype=torch.float16) * 0.5
 
-        torch.compile(f)(x, y)
+        torch.compile(f)(x, y)  # noqa: UNSPECIFIED_BACKEND
         self._exec_and_verify_payload()
 
     @unittest.skipUnless(has_triton(), "Triton not available")
@@ -308,7 +308,7 @@ class FxGraphRunnableTest(TestCase):
         x = torch.ones((4096,), device=GPU_TYPE, dtype=torch.float16)
         y = torch.ones((4096,), device=GPU_TYPE, dtype=torch.float16) * 0.5
 
-        torch.compile(f)(x, y)
+        torch.compile(f)(x, y)  # noqa: UNSPECIFIED_BACKEND
         self._exec_and_verify_payload()
 
     def test_two_inputs_matmul(self):
@@ -316,14 +316,14 @@ class FxGraphRunnableTest(TestCase):
             return (a @ b).relu()
 
         a, b = torch.randn(2, 3), torch.randn(3, 4)
-        torch.compile(f)(a, b)
+        torch.compile(f)(a, b)  # noqa: UNSPECIFIED_BACKEND
         self._exec_and_verify_payload()
 
     def test_scalar_multiply(self):
         def f(x):
             return x * 2
 
-        torch.compile(f)(torch.randn(5))
+        torch.compile(f)(torch.randn(5))  # noqa: UNSPECIFIED_BACKEND
         self._exec_and_verify_payload()
 
     # testing dynamic shapes
@@ -335,7 +335,7 @@ class FxGraphRunnableTest(TestCase):
         torch._dynamo.mark_dynamic(a, 0)
         torch._dynamo.mark_dynamic(a, 1)
 
-        torch.compile(f)(a)
+        torch.compile(f)(a)  # noqa: UNSPECIFIED_BACKEND
         self._exec_and_verify_payload()
 
     def test_broadcast_add_dynamic(self):
@@ -347,7 +347,7 @@ class FxGraphRunnableTest(TestCase):
         torch._dynamo.mark_dynamic(x, 0)
         torch._dynamo.mark_dynamic(y, 1)
 
-        torch.compile(f)(x, y)
+        torch.compile(f)(x, y)  # noqa: UNSPECIFIED_BACKEND
         self._exec_and_verify_payload()
 
     def test_toy_model_basic(self):
@@ -355,7 +355,7 @@ class FxGraphRunnableTest(TestCase):
         model.eval()  # Set to eval mode to avoid dropout randomness
 
         x = torch.randn(3, 8)
-        torch.compile(model)(x)
+        torch.compile(model)(x)  # noqa: UNSPECIFIED_BACKEND
         self._exec_and_verify_payload()
 
     def test_toy_model_batch_processing(self):
@@ -363,7 +363,7 @@ class FxGraphRunnableTest(TestCase):
         model.eval()
 
         x = torch.randn(16, 12)
-        torch.compile(model)(x)
+        torch.compile(model)(x)  # noqa: UNSPECIFIED_BACKEND
         self._exec_and_verify_payload()
 
     def test_toy_model_dynamic_batch(self):
@@ -373,7 +373,7 @@ class FxGraphRunnableTest(TestCase):
         x = torch.randn(7, 10)
         torch._dynamo.mark_dynamic(x, 0)
 
-        torch.compile(model)(x)
+        torch.compile(model)(x)  # noqa: UNSPECIFIED_BACKEND
         self._exec_and_verify_payload()
 
     # Distributed collectives tests with FakeProcessGroup
@@ -391,7 +391,7 @@ class FxGraphRunnableTest(TestCase):
 
         try:
             x = torch.randn(4, 4)
-            torch.compile(f)(x)
+            torch.compile(f)(x)  # noqa: UNSPECIFIED_BACKEND
         finally:
             dist.destroy_process_group()
 
@@ -412,7 +412,7 @@ class FxGraphRunnableTest(TestCase):
 
         try:
             x = torch.randn(3, 3)
-            torch.compile(f)(x)
+            torch.compile(f)(x)  # noqa: UNSPECIFIED_BACKEND
         finally:
             dist.destroy_process_group()
 
@@ -432,7 +432,7 @@ class FxGraphRunnableTest(TestCase):
 
         try:
             x = torch.randn(5, 5)
-            torch.compile(f)(x)
+            torch.compile(f)(x)  # noqa: UNSPECIFIED_BACKEND
         finally:
             dist.destroy_process_group()
 
@@ -454,7 +454,7 @@ class FxGraphRunnableTest(TestCase):
 
         try:
             x = torch.randn(4, 4)
-            torch.compile(f)(x)
+            torch.compile(f)(x)  # noqa: UNSPECIFIED_BACKEND
         finally:
             dist.destroy_process_group()
 
@@ -480,7 +480,7 @@ class FxGraphRunnableTest(TestCase):
         try:
             x = torch.arange(8, dtype=torch.float32)
             y = torch.arange(8, dtype=torch.float32)
-            torch.compile(f)(x, y)
+            torch.compile(f)(x, y)  # noqa: UNSPECIFIED_BACKEND
         finally:
             dist.destroy_process_group()
 
@@ -502,7 +502,7 @@ class FxGraphRunnableTest(TestCase):
             {"trace.enabled": True, "trace.provenance_tracking_level": 1}
         ):
             x = torch.randn(4, 4)
-            torch.compile(f)(x)
+            torch.compile(f)(x)  # noqa: UNSPECIFIED_BACKEND
             self._exec_and_verify_payload()
 
     @torch._dynamo.config.patch(assume_static_by_default=False)
@@ -517,7 +517,7 @@ class FxGraphRunnableTest(TestCase):
             ), torch.ops.aten._adaptive_avg_pool2d(x + 1, (2, 5))
 
         x = torch.randn(2, 4, 16, 16)
-        torch.compile(f)(x)
+        torch.compile(f)(x)  # noqa: UNSPECIFIED_BACKEND
         self._exec_and_verify_payload()
 
     @torch._dynamo.config.patch(assume_static_by_default=False)
@@ -548,7 +548,7 @@ class FxGraphRunnableTest(TestCase):
         s2 = weights.shape[0]
         view = flat.as_strided((s2, 16), (16, 1))
 
-        torch.compile(f)(view, weights)
+        torch.compile(f)(view, weights)  # noqa: UNSPECIFIED_BACKEND
         self._exec_and_verify_payload()
 
     @torch._dynamo.config.patch(assume_static_by_default=False)
@@ -562,7 +562,7 @@ class FxGraphRunnableTest(TestCase):
         repeats = torch.randint(5, 15, (num_segments,), dtype=torch.int64)
         output_size = repeats.sum()
 
-        torch.compile(f, dynamic=True)(data, repeats, output_size)
+        torch.compile(f, dynamic=True)(data, repeats, output_size)  # noqa: UNSPECIFIED_BACKEND
 
         self._exec_and_verify_payload()
 
@@ -584,7 +584,7 @@ class FxGraphRunnableTest(TestCase):
         data = torch.randn(1000, 16)
         repeats = torch.full((num_segments,), 10, dtype=torch.int64)
 
-        torch.compile(f)(data, repeats)
+        torch.compile(f)(data, repeats)  # noqa: UNSPECIFIED_BACKEND
         self._exec_and_verify_payload()
         payload = self.buffer.getvalue().strip()
         self.assertNotIn("# Fixup: ensure sum(repeats) == output_size", payload)

--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -6018,11 +6018,11 @@ class GraphModule(torch.nn.Module):
             return grad_res
 
         compile_options = dict(backend="eager", fullgraph=True, dynamic=False)
-        compiled_fn = torch.compile(fn, **compile_options)
+        compiled_fn = torch.compile(fn, **compile_options)  # noqa: UNSPECIFIED_BACKEND
         vmapped_fn = torch.vmap(compiled_fn)
         for attr in _DYNAMO_WRAPPER_ATTRS:
             self.assertFalse(hasattr(vmapped_fn, attr), attr)
-        compiled_vmapped_fn = torch.compile(vmapped_fn, **compile_options)
+        compiled_vmapped_fn = torch.compile(vmapped_fn, **compile_options)  # noqa: UNSPECIFIED_BACKEND
 
         x = torch.randn(8, dtype=torch.float64)
         expected = vmapped_fn(x)
@@ -6054,12 +6054,12 @@ class GraphModule(torch.nn.Module):
         )
         for transform, fn, x in cases:
             with self.subTest(transform=transform.__name__):
-                compiled_fn = torch.compile(fn, **compile_options)
+                compiled_fn = torch.compile(fn, **compile_options)  # noqa: UNSPECIFIED_BACKEND
                 transformed_fn = transform(compiled_fn)
                 for attr in _DYNAMO_WRAPPER_ATTRS:
                     self.assertFalse(hasattr(transformed_fn, attr), attr)
 
-                compiled_transformed_fn = torch.compile(
+                compiled_transformed_fn = torch.compile(  # noqa: UNSPECIFIED_BACKEND
                     transformed_fn, **compile_options
                 )
 

--- a/test/dynamo/test_hooks.py
+++ b/test/dynamo/test_hooks.py
@@ -1168,12 +1168,12 @@ def forward(self, L_x_ : torch.Tensor):
             torch._dynamo.reset()
             counters.clear()
             x = torch.randn(4, device="cuda", requires_grad=True)
-            torch.compile(fn, fullgraph=True)(x).backward()
+            torch.compile(fn, fullgraph=True)(x).backward()  # noqa: UNSPECIFIED_BACKEND
 
             # Second compile (force recompile to test cache)
             torch._dynamo.reset()
             x2 = torch.randn(4, device="cuda", requires_grad=True)
-            torch.compile(fn, fullgraph=True)(x2).backward()
+            torch.compile(fn, fullgraph=True)(x2).backward()  # noqa: UNSPECIFIED_BACKEND
 
             aot_counters = counters["aot_autograd"]
             self.assertEqual(aot_counters.get("autograd_cache_bypass", 0), 0)
@@ -1201,11 +1201,11 @@ def forward(self, L_x_ : torch.Tensor):
 
             # Compile fn_a
             x = torch.randn(4, device="cuda", requires_grad=True)
-            torch.compile(fn_a, fullgraph=True)(x).backward()
+            torch.compile(fn_a, fullgraph=True)(x).backward()  # noqa: UNSPECIFIED_BACKEND
 
             # Compile fn_b (different hook — must NOT cache hit from fn_a)
             x2 = torch.randn(4, device="cuda", requires_grad=True)
-            torch.compile(fn_b, fullgraph=True)(x2).backward()
+            torch.compile(fn_b, fullgraph=True)(x2).backward()  # noqa: UNSPECIFIED_BACKEND
 
             # fn_b should give grad = 2 * 3.0 = 6.0, not 2 * 0.5 = 1.0
             self.assertEqual(x2.grad, torch.tensor([6.0] * 4, device="cuda"))

--- a/test/dynamo/test_logging.py
+++ b/test/dynamo/test_logging.py
@@ -190,7 +190,7 @@ class LoggingTests(LoggingTestCase):
     @requires_cuda_and_triton
     @make_logging_test(cudagraphs=True)
     def test_cudagraphs(self, records):
-        fn_opt = torch.compile(mode="reduce-overhead")(inductor_schedule_fn)
+        fn_opt = torch.compile(mode="reduce-overhead")(inductor_schedule_fn)  # noqa: UNSPECIFIED_BACKEND
         fn_opt(torch.ones(1000, 1000, device=device_type))
         self.assertGreater(len(records), 0)
         self.assertLess(len(records), 8)
@@ -1329,7 +1329,7 @@ TRACE FX call mul from test_logging.py:N in fn (LoggingTests.test_trace_call_pre
 
     @make_logging_test(cudagraph_static_inputs=True)
     def test_cudagraph_static_inputs(self, records):
-        @torch.compile(mode="reduce-overhead")
+        @torch.compile(mode="reduce-overhead")  # noqa: UNSPECIFIED_BACKEND
         def fn(x):
             return x + 1
 
@@ -1347,7 +1347,7 @@ TRACE FX call mul from test_logging.py:N in fn (LoggingTests.test_trace_call_pre
         for param in params:
             param.grad = torch.zeros_like(param)
         opt = torch.optim.Adam(params)
-        compiled_opt_step = torch.compile(opt.step, mode="reduce-overhead")
+        compiled_opt_step = torch.compile(opt.step, mode="reduce-overhead")  # noqa: UNSPECIFIED_BACKEND
         compiled_opt_step()
         self.assertGreater(len(records), 0)
         self.assertLess(len(records), 3)
@@ -1361,7 +1361,7 @@ TRACE FX call mul from test_logging.py:N in fn (LoggingTests.test_trace_call_pre
             def f(a, b):
                 return torch.mm(a, b)
 
-            f = torch.compile(f, mode="max-autotune-no-cudagraphs")
+            f = torch.compile(f, mode="max-autotune-no-cudagraphs")  # noqa: UNSPECIFIED_BACKEND
             f(
                 torch.randn(10, 10, device=device_type),
                 torch.randn(10, 10, device=device_type),
@@ -1481,7 +1481,7 @@ fn(torch.randn(5))
 
         foo()
 
-        @torch.compile
+        @torch.compile  # noqa: UNSPECIFIED_BACKEND
         def baz(x):
             return x + 1
 

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1903,7 +1903,7 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
             b = max((1, 2), (3, 4))
             return a, b
 
-        opt_fn = torch.compile(fn, fullgraph=True)
+        opt_fn = torch.compile(fn, fullgraph=True, backend="eager")
         result = opt_fn()
         self.assertEqual(result, ((1, 2), (3, 4)))
 
@@ -9854,7 +9854,7 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
         )
         torch._dynamo.mark_dynamic(x, 0)
         torch._dynamo.mark_dynamic(y, 0)
-        opt = torch.compile(fn, fullgraph=True)
+        opt = torch.compile(fn, fullgraph=True, backend="eager")
         opt(*inputs)
         with self.assertRaises(RuntimeError):
             inputs = (
@@ -15213,7 +15213,7 @@ fn
     @unittest.expectedFailure
     @torch._dynamo.config.patch(enable_trace_load_build_class=True)
     def test_return_obj___build_class__(self):
-        @torch.compile(fullgraph=True)
+        @torch.compile(fullgraph=True, backend="eager")
         def fn(t):
             # class is created with an EphemeralSource and
             # UserDefinedClassVariable has no `reconstruct` method
@@ -15930,7 +15930,7 @@ with torch.library._scoped_library("mylib_ci", "FRAGMENT") as lib:
             torch._dynamo.exc.Unsupported,
             r"requires_grad_\(\)(.|\n)*\.detach\(\)",
         ):
-            torch.compile(fn, fullgraph=True)(x)
+            torch.compile(fn, fullgraph=True, backend="eager")(x)
 
         # Without fullgraph, falls back to eager and is correct
         result = torch.compile(fn, backend="eager")(x)
@@ -15950,7 +15950,7 @@ with torch.library._scoped_library("mylib_ci", "FRAGMENT") as lib:
             torch._dynamo.exc.Unsupported,
             r"requires_grad_\(\)(.|\n)*\.detach\(\)",
         ):
-            torch.compile(fn, fullgraph=True)(x)
+            torch.compile(fn, fullgraph=True, backend="eager")(x)
 
         # Without fullgraph, falls back to eager and is correct
         result = torch.compile(fn, backend="eager")(x)

--- a/test/dynamo/test_modes.py
+++ b/test/dynamo/test_modes.py
@@ -243,7 +243,7 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
         try:
             with m, m1:
 
-                @torch.compile(fullgraph=True)
+                @torch.compile(fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
                 def fn(x):
                     torch.set_default_device("cpu")
                     _pop_torch_function_stack()
@@ -260,7 +260,7 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
             torch.set_default_device(None)
 
     def test_stack_state_clear_default_device(self):
-        @torch.compile(fullgraph=True)
+        @torch.compile(fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         def fn(x):
             torch.set_default_device(None)
             return x + 1
@@ -275,7 +275,7 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
         # Stack populated, add device
         with m, m1:
 
-            @torch.compile(fullgraph=True)
+            @torch.compile(fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
             def fn(x):
                 torch.set_default_device("cpu")
                 torch.set_default_device(None)
@@ -292,7 +292,7 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
         torch.set_default_device("cpu")
         with m, m1:
 
-            @torch.compile(fullgraph=True)
+            @torch.compile(fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
             def fn(x):
                 torch.set_default_device(None)
                 return x + 1
@@ -302,7 +302,7 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
             self.assertIs(stack[0], m)
             self.assertIs(stack[1], m1)
 
-        @torch.compile(fullgraph=True)
+        @torch.compile(fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         def fn(x):
             torch.set_default_device("cpu")
             torch.set_default_device("cpu")
@@ -317,7 +317,7 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
         m = BaseTorchFunctionMode()
         with m:
 
-            @torch.compile(fullgraph=True)
+            @torch.compile(fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
             def fn(x):
                 _pop_torch_function_stack()
                 return x + 1
@@ -331,7 +331,7 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(_len_torch_function_stack(), 0)
 
     def test_is_torch_function_all_disabled(self):
-        @torch.compile(fullgraph=True)
+        @torch.compile(fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         def fn(x):
             return (
                 torch._C._is_torch_function_all_disabled(),
@@ -343,7 +343,7 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
         self.assertFalse(res)
 
     def test_error_empty_stack_pop_torch_function_mode(self):
-        @torch.compile(fullgraph=True)
+        @torch.compile(fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         def fn(x):
             _pop_torch_function_stack()
             return x + 1
@@ -358,7 +358,7 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
         m = BaseTorchFunctionMode()
         with m:
 
-            @torch.compile(fullgraph=True)
+            @torch.compile(fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
             def fn(x, m):
                 _push_on_torch_function_stack(m)
                 return x + 1
@@ -375,7 +375,7 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
         m = BaseTorchFunctionMode()
         with m:
 
-            @torch.compile(fullgraph=True)
+            @torch.compile(fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
             def fn(x):
                 z = _len_torch_function_stack()
                 return x + z
@@ -389,7 +389,7 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
             def __init__(self, x):
                 self.x = x
 
-        @torch.compile(fullgraph=True)
+        @torch.compile(fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         def fn(x):
             z = TestMode(2)
             z.y = 2
@@ -461,7 +461,7 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
         inp = torch.ones(2, 2) + 1
 
         for fn_i in [fn, fn_2]:
-            fn_opt = torch.compile(fn_i, fullgraph=True)
+            fn_opt = torch.compile(fn_i, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
             with TestMode1(), TestMode2():
                 expected = fn_i(inp), mode_1_called, mode_2_called
                 reset_state()
@@ -495,7 +495,7 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
 
         inp = (torch.ones(2, 2) + 1).as_subclass(TestSubclass)
 
-        fn_opt = torch.compile(fn, fullgraph=True)
+        fn_opt = torch.compile(fn, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         with TestMode():
             with torch._C.DisableTorchFunctionSubclass():
                 expected = fn(inp)
@@ -524,7 +524,7 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
 
         inp = (torch.ones(2, 2) + 1).as_subclass(TestSubclass)
 
-        fn_opt = torch.compile(fn, fullgraph=True)
+        fn_opt = torch.compile(fn, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         with TestMode():
             expected = fn(inp)
             actual = fn_opt(inp)
@@ -539,7 +539,7 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
             return torch.add(o, y)
 
         inp = (torch.ones(2, 2) + 1, torch.ones(2, 2) + 2)
-        fn_opt = torch.compile(fn, fullgraph=True)
+        fn_opt = torch.compile(fn, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
 
         expected = fn(*inp)
         actual = fn_opt(*inp)
@@ -555,7 +555,7 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
             return torch.add(o, y)
 
         inp = (torch.ones(2, 2) + 1, torch.ones(2, 2) + 2)
-        fn_opt = torch.compile(fn)
+        fn_opt = torch.compile(fn)  # noqa: UNSPECIFIED_BACKEND
 
         expected = fn(*inp)
         actual = fn_opt(*inp)
@@ -573,7 +573,7 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
             return torch.add(o, y)
 
         inp = (torch.ones(2, 2) + 1, torch.ones(2, 2) + 2)
-        fn_opt = torch.compile(fn)
+        fn_opt = torch.compile(fn)  # noqa: UNSPECIFIED_BACKEND
 
         expected = fn(*inp)
         actual = fn_opt(*inp)
@@ -585,7 +585,7 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
         def err():
             raise RuntimeError("test")
 
-        @torch.compile()
+        @torch.compile()  # noqa: UNSPECIFIED_BACKEND
         def fn(x):
             with TestMode():
                 x += 1
@@ -612,7 +612,7 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
             return torch.add(o, y)
 
         inp = (torch.ones(2, 2) + 1, torch.ones(2, 2) + 2)
-        fn_opt = torch.compile(fn)
+        fn_opt = torch.compile(fn)  # noqa: UNSPECIFIED_BACKEND
 
         expected = fn(*inp)
         actual = fn_opt(*inp)
@@ -679,23 +679,23 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
         inp0_int = torch.ones(1, 1, dtype=torch.int32)
         inp1_int = torch.ones(1, 1, dtype=torch.int32)
 
-        @torch.compile(fullgraph=True)
+        @torch.compile(fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         def fn_un(op, inp):
             return op(inp)
 
-        @torch.compile(fullgraph=True)
+        @torch.compile(fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         def fn_un_int(op, inp):
             return op(inp)
 
-        @torch.compile(fullgraph=True)
+        @torch.compile(fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         def fn_bin(op, inp0, inp1):
             return op(inp0, inp1)
 
-        @torch.compile(fullgraph=True)
+        @torch.compile(fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         def fn_bin_int(op, inp0, inp1):
             return op(inp0, inp1)
 
-        @torch.compile(fullgraph=True)
+        @torch.compile(fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         def fn_tensor_and_int(op, inp0, inp1):
             return op(inp0, inp1)
 
@@ -754,7 +754,7 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
         # https://github.com/pytorch/pytorch/issues/141232
         with torch.device("cpu"):
 
-            @torch.compile(fullgraph=True)
+            @torch.compile(fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
             def func(a):
                 d = TransformedDistribution(
                     Normal(a, 1),
@@ -773,7 +773,7 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
         try:
             torch.set_default_device(device_type)
 
-            flex_attention = torch.compile(flex_attention, dynamic=False)
+            flex_attention = torch.compile(flex_attention, dynamic=False)  # noqa: UNSPECIFIED_BACKEND
 
             prefix_lengths = torch.arange(8)
 
@@ -806,7 +806,7 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
         x = torch.ones(4, requires_grad=True)
 
         with torch.device("cpu"):
-            torch.compile(mod, fullgraph=True)(x)
+            torch.compile(mod, fullgraph=True)(x)  # noqa: UNSPECIFIED_BACKEND
 
     def test_tensor_unflatten_with_default_device(self):
         def fn(x):
@@ -828,7 +828,7 @@ class TorchFunctionModeTests(torch._dynamo.test_case.TestCase):
         )
 
         with torch.device(device_type):
-            flex_attention = torch.compile(flex_attention_eager, dynamic=False)
+            flex_attention = torch.compile(flex_attention_eager, dynamic=False)  # noqa: UNSPECIFIED_BACKEND
 
             with self.assertRaisesRegex(
                 torch._dynamo.exc.Unsupported,

--- a/test/dynamo/test_package.py
+++ b/test/dynamo/test_package.py
@@ -409,8 +409,8 @@ def add(x, y):
         arg1 = torch.randn(3, 2, device=device)
         arg2 = torch.randn(5, 2, device=device)
         expected = [fn(arg1), fn2(arg2)]
-        compiled_fn1 = torch.compile(fn)
-        compiled_fn2 = torch.compile(fn2)
+        compiled_fn1 = torch.compile(fn)  # noqa: UNSPECIFIED_BACKEND
+        compiled_fn2 = torch.compile(fn2)  # noqa: UNSPECIFIED_BACKEND
         result = [compiled_fn1(arg1), compiled_fn2(arg2)]
         self.assertEqual(expected, result)
         DynamoCache.clear()
@@ -418,8 +418,8 @@ def add(x, y):
 
         self._save_and_reload(expected_backends=2, expected_dynamo=2)
 
-        compiled_fn1 = torch.compile(fn)
-        compiled_fn2 = torch.compile(fn2)
+        compiled_fn1 = torch.compile(fn)  # noqa: UNSPECIFIED_BACKEND
+        compiled_fn2 = torch.compile(fn2)  # noqa: UNSPECIFIED_BACKEND
         with torch.compiler.set_stance("fail_on_recompile"):
             result1 = compiled_fn1(arg1)
             result2 = compiled_fn2(arg2)
@@ -439,7 +439,7 @@ def add(x, y):
 
         arg1 = torch.randn(3, 2, device=device)
         arg2 = torch.randn(5, 2, device=device)
-        compiled_fn = torch.compile(fn)
+        compiled_fn = torch.compile(fn)  # noqa: UNSPECIFIED_BACKEND
         expected1 = compiled_fn(arg1)
 
         # Should cause a recompile
@@ -448,7 +448,7 @@ def add(x, y):
 
         self._save_and_reload(expected_backends=2, expected_dynamo=1)
 
-        compiled_fn = torch.compile(fn)
+        compiled_fn = torch.compile(fn)  # noqa: UNSPECIFIED_BACKEND
         with torch.compiler.set_stance("fail_on_recompile"):
             result1 = compiled_fn(arg1)
             result2 = compiled_fn(arg2)
@@ -524,14 +524,14 @@ def add(x, y):
         arg1 = torch.randn(3, 2, device=device, requires_grad=True)
         arg2 = arg1.clone().detach_().requires_grad_(True)
 
-        compiled_fn = torch.compile(fn)
+        compiled_fn = torch.compile(fn)  # noqa: UNSPECIFIED_BACKEND
         expected1 = compiled_fn(arg1)
         expected1.sum().backward()
         total_frames = torch._dynamo.convert_frame.FRAME_COUNTER
 
         self._save_and_reload(expected_backends=1, expected_dynamo=1)
 
-        compiled_fn = torch.compile(fn)
+        compiled_fn = torch.compile(fn)  # noqa: UNSPECIFIED_BACKEND
         # Run it again, no recompile needed
         with torch.compiler.set_stance("fail_on_recompile"):
             expected2 = compiled_fn(arg2)
@@ -554,7 +554,7 @@ def add(x, y):
 
         arg1 = torch.randn(3, 2, device=device, requires_grad=True)
         arg2 = arg1.clone().detach_().requires_grad_(True)
-        compiled_fn = torch.compile(fn)
+        compiled_fn = torch.compile(fn)  # noqa: UNSPECIFIED_BACKEND
         expected1 = compiled_fn(arg1)
         expected1.sum().backward()
         total_frames = torch._dynamo.convert_frame.FRAME_COUNTER
@@ -577,7 +577,7 @@ def add(x, y):
 
         self._save_and_reload(expected_backends=1, expected_dynamo=1)
 
-        compiled_fn = torch.compile(fn)
+        compiled_fn = torch.compile(fn)  # noqa: UNSPECIFIED_BACKEND
         # Run it again. There will be a recompile because one of the backends is deleted, but it should
         # still work.
         expected2 = compiled_fn(arg2)
@@ -601,13 +601,13 @@ def add(x, y):
             return None
 
         args = (torch.randn(3, 2, device=device), mod)
-        compiled_fn = torch.compile(foo)
+        compiled_fn = torch.compile(foo)  # noqa: UNSPECIFIED_BACKEND
         compiled_fn(*args)
         total_frames = torch._dynamo.convert_frame.FRAME_COUNTER
 
         self._save_and_reload(expected_backends=1, expected_dynamo=1)
 
-        compiled_fn = torch.compile(foo)
+        compiled_fn = torch.compile(foo)  # noqa: UNSPECIFIED_BACKEND
         # Run it again, no recompile needed
         with torch.compiler.set_stance("fail_on_recompile"):
             compiled_fn(*args)
@@ -631,7 +631,7 @@ def add(x, y):
             return torch.cat(set_of_x, dim=0)
 
         args = ([torch.randn(3, 2, device=device) for _ in range(3)],)
-        compiled_fn = torch.compile(foo)
+        compiled_fn = torch.compile(foo)  # noqa: UNSPECIFIED_BACKEND
         compiled_fn(*args)
         self._save_and_reload(expected_backends=1, expected_dynamo=1)
 
@@ -750,7 +750,7 @@ def add(x, y):
         x = torch.rand(10, device=device)
         model = TestPackage._tempNetForQualName()
         model.forward(x)
-        compiled_fn = torch.compile(
+        compiled_fn = torch.compile(  # noqa: UNSPECIFIED_BACKEND
             model.forward,
             options=dict(guard_filter_fn=torch.compiler.skip_guard_on_globals_unsafe),
         )

--- a/test/dynamo/test_precompile_context.py
+++ b/test/dynamo/test_precompile_context.py
@@ -34,7 +34,7 @@ class PrecompileContextTests(InductorTestCase):
         def simple_function(x):
             return x.sin() + x.cos()
 
-        compiled_fn = torch.compile(simple_function)
+        compiled_fn = torch.compile(simple_function)  # noqa: UNSPECIFIED_BACKEND
 
         # Run the compiled function
         x = torch.randn(10, device=GPU_TYPE, requires_grad=True)
@@ -50,7 +50,7 @@ class PrecompileContextTests(InductorTestCase):
         def simple_function(x):
             return x.sin() + x.cos()
 
-        compiled_fn = torch.compile(simple_function)
+        compiled_fn = torch.compile(simple_function)  # noqa: UNSPECIFIED_BACKEND
 
         # Run the compiled function
         x = torch.randn(10, device=GPU_TYPE, requires_grad=True)
@@ -80,7 +80,7 @@ class PrecompileContextTests(InductorTestCase):
         def simple_function(x):
             return x.sin() + x.cos()
 
-        compiled_fn = torch.compile(simple_function)
+        compiled_fn = torch.compile(simple_function)  # noqa: UNSPECIFIED_BACKEND
 
         # Run the compiled function
         x = torch.randn(10, device=GPU_TYPE, requires_grad=True)

--- a/test/dynamo/test_recompile_ux.py
+++ b/test/dynamo/test_recompile_ux.py
@@ -515,7 +515,7 @@ class IsolateRecompilesTests(torch._dynamo.test_case.TestCase):
 
         @cache
         def factory(key):
-            @torch.compile(fullgraph=True, dynamic=False, isolate_recompiles=True)
+            @torch.compile(fullgraph=True, dynamic=False, isolate_recompiles=True)  # noqa: UNSPECIFIED_BACKEND
             def frontend(x, n):
                 return core(x) + n
 

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -7318,7 +7318,7 @@ def forward(self, s77 : torch.SymInt, s27 : torch.SymInt, L_x_ : torch.Tensor):
                 k = processed.view(batch_size, 1, seq_len, self.dim).detach()
                 v = processed.view(batch_size, 1, seq_len, self.dim).detach()
 
-                out = torch.compile(flex_attention)(q, k, v, block_mask=block_mask)
+                out = torch.compile(flex_attention)(q, k, v, block_mask=block_mask)  # noqa: UNSPECIFIED_BACKEND
                 out = flex_attention(q, k, v, block_mask=block_mask)
 
                 return out
@@ -7993,7 +7993,7 @@ SavedForBackwardsAOTOutput(idx=5)""",
         # https://github.com/pytorch/pytorch/issues/144211
         # torch.compile(one_hot) should raise on out-of-bounds indices,
         # not silently produce wrong results.
-        one_hot = torch.compile(torch.nn.functional.one_hot, fullgraph=True)
+        one_hot = torch.compile(torch.nn.functional.one_hot, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
 
         a = torch.arange(0, 5) % 3  # [0, 1, 2, 0, 1]
         with self.assertRaises(RuntimeError):
@@ -8150,7 +8150,7 @@ SavedForBackwardsAOTOutput(idx=5)""",
             warnings.simplefilter("always")
             eager_result = f(size, out_wrong.clone())
 
-        cf = torch.compile(f, dynamic=True)
+        cf = torch.compile(f, dynamic=True)  # noqa: UNSPECIFIED_BACKEND
         with warnings.catch_warnings(record=True):
             warnings.simplefilter("always")
             compiled_result = cf(size, out_wrong.clone())
@@ -8377,7 +8377,7 @@ class ReproTestsDevice(torch._dynamo.test_case.TestCase):
         mod = Repro()
         x = torch.arange(9, device=torch.device(device))
 
-        @torch.compile
+        @torch.compile  # noqa: UNSPECIFIED_BACKEND
         def f(x):
             return mod(x)
 
@@ -9343,7 +9343,7 @@ class ReproTestsDevice(torch._dynamo.test_case.TestCase):
         if not has_triton():
             self.skipTest("requires triton")
 
-        @torch.compile(fullgraph=True)
+        @torch.compile(fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         def flex_chunk(q, k, v, block_mask, scale):
             out, aux = flex_attention(
                 q,
@@ -9362,7 +9362,7 @@ class ReproTestsDevice(torch._dynamo.test_case.TestCase):
             d = e0 + e1
             return (out * e0 + new_out * e1) / d, (mx + torch.log(d)).squeeze(-1)
 
-        @torch.compile(fullgraph=True)
+        @torch.compile(fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         def ref_attn(q, k, v, block_mask, scale):
             return flex_attention(q, k, v, block_mask=block_mask, scale=scale)
 

--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -218,7 +218,7 @@ class <lambda>(torch.nn.Module):
 
         inp = (torch.ones(2, 2) + 1, torch.ones(2, 2), torch.Stream(device="cuda"))
         expected = fn(*inp)
-        fn_opt = torch.compile(fn, fullgraph=True)
+        fn_opt = torch.compile(fn, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         actual = fn_opt(*inp)
         self.assertEqual(expected, actual)
 
@@ -231,7 +231,7 @@ class <lambda>(torch.nn.Module):
             return y, s
 
         inp = (torch.ones(2, 2) + 1, torch.ones(2, 2))
-        fn_opt = torch.compile(fn, fullgraph=True)
+        fn_opt = torch.compile(fn, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         _, s0 = fn_opt(*inp)
         _, s1 = fn_opt(*inp)
         # Streams will be different values for each invocation
@@ -249,7 +249,7 @@ class <lambda>(torch.nn.Module):
 
         s_inp = torch.Stream(device="cuda")
         inp = (torch.ones(2, 2) + 1, s_inp)
-        fn_opt = torch.compile(fn, fullgraph=True)
+        fn_opt = torch.compile(fn, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         _, s0 = fn_opt(*inp)
         _, s1 = fn_opt(*inp)
         self.assertEqual(s_inp, s0)
@@ -1646,7 +1646,7 @@ class GraphModule(torch.nn.Module):
     def test_inductor_lowering(self):
         with patch("torch._inductor.config.implicit_fallbacks", False):
 
-            @torch.compile()
+            @torch.compile()  # noqa: UNSPECIFIED_BACKEND
             def fn(x):
                 e = torch.Event()
                 x += x + 1
@@ -1953,7 +1953,7 @@ class <lambda>(torch.nn.Module):
     def test_event_synchronize_inductor_lowering(self):
         with patch("torch._inductor.config.implicit_fallbacks", False):
 
-            @torch.compile()
+            @torch.compile()  # noqa: UNSPECIFIED_BACKEND
             def fn(x):
                 e = torch.Event()
                 x = x + 1
@@ -2177,7 +2177,7 @@ class <lambda>(torch.nn.Module):
 
         inp = torch.ones(2, 2, device="cuda")
         eager_result = f(inp)
-        compiled_result = torch.compile(f)(inp)
+        compiled_result = torch.compile(f)(inp)  # noqa: UNSPECIFIED_BACKEND
         self.assertEqual(eager_result, compiled_result)
 
     @requires_cuda
@@ -2197,7 +2197,7 @@ class <lambda>(torch.nn.Module):
 
             return torch.cat(a_cpu_list)
 
-        f_compiled = torch.compile(f)
+        f_compiled = torch.compile(f)  # noqa: UNSPECIFIED_BACKEND
         inputs = [
             torch.rand(100, dtype=torch.float16, device="cuda") for _ in range(10)
         ]
@@ -2215,7 +2215,7 @@ class <lambda>(torch.nn.Module):
             e.wait()
             return y + 1
 
-        f_compiled = torch.compile(f)
+        f_compiled = torch.compile(f)  # noqa: UNSPECIFIED_BACKEND
         x = torch.randn(10, device="cuda")
         eager_result = f(x)
         compiled_result = f_compiled(x)

--- a/test/dynamo/test_structured_trace.py
+++ b/test/dynamo/test_structured_trace.py
@@ -357,7 +357,7 @@ class StructuredTraceTest(TestCase):
 
     @requires_cuda_and_triton
     def test_cudagraphs(self):
-        fn_opt = torch.compile(mode="reduce-overhead")(inductor_schedule_fn)
+        fn_opt = torch.compile(mode="reduce-overhead")(inductor_schedule_fn)  # noqa: UNSPECIFIED_BACKEND
         fn_opt(torch.ones(1000, 1000, device="cuda"))
         self.assertExpectedInline(
             self.buffer.getvalue(),
@@ -1123,7 +1123,7 @@ def forward(self, x_1: "f32[2][1]cpu"):
 
             return grads
 
-        fn_opt = torch.compile(fn)
+        fn_opt = torch.compile(fn)  # noqa: UNSPECIFIED_BACKEND
         fn_opt()
         self.assertParses()
         expected = [
@@ -1165,7 +1165,7 @@ def forward(self, x_1: "f32[2][1]cpu"):
         def f(x):
             return x + 1
 
-        f = torch.compile(f)
+        f = torch.compile(f)  # noqa: UNSPECIFIED_BACKEND
 
         def user_context() -> str:
             nonlocal num_calls
@@ -1199,7 +1199,7 @@ def forward(self, x_1: "f32[2][1]cpu"):
         def f(x):
             return x + 1
 
-        f = torch.compile(f)
+        f = torch.compile(f)  # noqa: UNSPECIFIED_BACKEND
 
         def user_context() -> str:
             return "user_context: " + str(step.step)

--- a/test/dynamo/test_subclasses.py
+++ b/test/dynamo/test_subclasses.py
@@ -1122,7 +1122,7 @@ class SubclassTests(_SubclassCompileCheckMixin, torch._dynamo.test_case.TestCase
         inp = torch.ones(4, 4)
         x = inp.as_subclass(TestTensor)
         torch._dynamo.mark_dynamic(x, 0)
-        compiled_fn = torch.compile(fn, fullgraph=True)
+        compiled_fn = torch.compile(fn, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         out = compiled_fn(x)
         self.assertEqual(out, torch.ones(4, 4) * 2)
 

--- a/test/dynamo/test_unspec.py
+++ b/test/dynamo/test_unspec.py
@@ -576,7 +576,7 @@ class UnspecTests(torch._dynamo.test_case.TestCase):
         x = torch.randn(20)
         torch._dynamo.mark_dynamic(x, 0)
 
-        @torch.compile()
+        @torch.compile()  # noqa: UNSPECIFIED_BACKEND
         def fn(x):
             y = x * 2
             comptime.graph_break()
@@ -971,7 +971,7 @@ class UnspecTests(torch._dynamo.test_case.TestCase):
                 return x * 2
 
         main_model = TestModel()
-        opt_model = torch.compile(main_model, mode="max-autotune", dynamic=True)
+        opt_model = torch.compile(main_model, mode="max-autotune", dynamic=True)  # noqa: UNSPECIFIED_BACKEND
 
         x1 = torch.rand(3, 5, 4, 8)
         x2 = torch.rand(1, 5, 4, 8)
@@ -1014,7 +1014,7 @@ class UnspecTests(torch._dynamo.test_case.TestCase):
                 return x * 2
 
         main_model = TestModel()
-        opt_model = torch.compile(main_model, mode="max-autotune", dynamic=True)
+        opt_model = torch.compile(main_model, mode="max-autotune", dynamic=True)  # noqa: UNSPECIFIED_BACKEND
 
         x1 = torch.rand(3, 5, 4, 8).to(memory_format=torch.channels_last)
         x2 = torch.rand(1, 5, 4, 8).to(memory_format=torch.channels_last)
@@ -1048,7 +1048,7 @@ class UnspecTests(torch._dynamo.test_case.TestCase):
         log_stream, ctx = logs_to_string("torch._dynamo.guards", "guards")
         with ctx():
             for key in [1.0, 2.0, 3.0]:
-                model = torch.compile(Module(key))
+                model = torch.compile(Module(key))  # noqa: UNSPECIFIED_BACKEND
                 model(x)
 
         guard_log = log_stream.getvalue()

--- a/test/dynamo/test_user_defined_object.py
+++ b/test/dynamo/test_user_defined_object.py
@@ -843,7 +843,7 @@ class TestClassSetattr(TestCase):
             MyModule.x = 20
             return MyModule.x
 
-        opt_fn = torch.compile(fn, fullgraph=True)
+        opt_fn = torch.compile(fn, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
         result = opt_fn()
         self.assertEqual(result, 20)
 

--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -115,7 +115,7 @@ class TestUtils(TestCase):
         """
 
         def run_forward_backward():
-            model = torch.compile(TestModel())
+            model = torch.compile(TestModel())  # noqa: UNSPECIFIED_BACKEND
             x = torch.rand([3], requires_grad=True)
             output = model(x)
             loss_fn = torch.nn.MSELoss()
@@ -349,7 +349,7 @@ class TestDynamoTimed(TestCase):
             torch._dynamo.reset_recompile_user_contexts()
 
     def run_forward_backward(self):
-        model = torch.compile(TestModel())
+        model = torch.compile(TestModel())  # noqa: UNSPECIFIED_BACKEND
         x = torch.rand([3], requires_grad=True)
         output = model(x)
         loss_fn = torch.nn.MSELoss()
@@ -1112,7 +1112,7 @@ class TestDynamoTimed(TestCase):
 
         compilation_events = []
         with mock.patch("torch._dynamo.utils.log_compilation_event") as log_event:
-            torch.compile(test1)(torch.randn(1))
+            torch.compile(test1)(torch.randn(1))  # noqa: UNSPECIFIED_BACKEND
             compilation_events = [arg[0][0] for arg in log_event.call_args_list]
         self.assertIn(
             '"job_id": "test_job_id"',
@@ -1144,7 +1144,7 @@ class TestDynamoTimed(TestCase):
 
         compilation_events = []
         with mock.patch("torch._dynamo.utils.log_compilation_event") as log_event:
-            torch.compile(test1)(torch.randn(10, 10))
+            torch.compile(test1)(torch.randn(10, 10))  # noqa: UNSPECIFIED_BACKEND
             compilation_events = [arg[0][0] for arg in log_event.call_args_list]
         self.assertEqual(compilation_events[0].ir_count, first)
 
@@ -1154,7 +1154,7 @@ class TestDynamoTimed(TestCase):
 
         compilation_events = []
         with mock.patch("torch._dynamo.utils.log_compilation_event") as log_event:
-            torch.compile(test2)(torch.randn(10, 10))
+            torch.compile(test2)(torch.randn(10, 10))  # noqa: UNSPECIFIED_BACKEND
             compilation_events = [arg[0][0] for arg in log_event.call_args_list]
         self.assertEqual(compilation_events[0].ir_count, second)
 
@@ -1172,7 +1172,7 @@ class TestDynamoTimed(TestCase):
 
         compilation_events = []
         with mock.patch("torch._dynamo.utils.log_compilation_event") as log_event:
-            torch.compile(graph_module)(torch.randn(6, 6))
+            torch.compile(graph_module)(torch.randn(6, 6))  # noqa: UNSPECIFIED_BACKEND
             compilation_events = [arg[0][0] for arg in log_event.call_args_list]
         self.assertEqual(
             compilation_events[0].inductor_provenance,
@@ -1185,7 +1185,7 @@ class TestDynamoTimed(TestCase):
         compilation_events = []
         with mock.patch("torch._dynamo.utils.log_compilation_event") as log_event:
 
-            @torch.compile()
+            @torch.compile()  # noqa: UNSPECIFIED_BACKEND
             def f(x):
                 return x * x
 
@@ -1204,7 +1204,7 @@ class TestDynamoTimed(TestCase):
             mock.patch("torch._dynamo.utils.log_compilation_event") as log_event,
         ):
 
-            @torch.compile()
+            @torch.compile()  # noqa: UNSPECIFIED_BACKEND
             def f(x):
                 return x * x
 
@@ -1235,7 +1235,7 @@ class TestDynamoTimed(TestCase):
         compilation_events = []
         with mock.patch("torch._dynamo.utils.log_compilation_event") as log_event:
             m = ModelSimple()
-            torch.compile(m)(torch.randn(1, 10, 10))
+            torch.compile(m)(torch.randn(1, 10, 10))  # noqa: UNSPECIFIED_BACKEND
             compilation_events = [arg[0][0] for arg in log_event.call_args_list]
         self.assertEqual(compilation_events[0].param_numel, 520)
         self.assertEqual(compilation_events[0].param_bytes, 4 * 520)
@@ -1253,7 +1253,7 @@ class TestDynamoTimed(TestCase):
         compilation_events = []
         with mock.patch("torch._dynamo.utils.log_compilation_event") as log_event:
             m = ModelWrapped()
-            torch.compile(m)(torch.randn(1, 10, 10))
+            torch.compile(m)(torch.randn(1, 10, 10))  # noqa: UNSPECIFIED_BACKEND
             compilation_events = [arg[0][0] for arg in log_event.call_args_list]
         self.assertEqual(compilation_events[0].param_numel, 1040)
         self.assertEqual(compilation_events[0].param_bytes, 4 * 1040)
@@ -1265,7 +1265,7 @@ class TestDynamoTimed(TestCase):
         m = nn.Sequential(l1, nn.Sequential(l1, l2))
         self.assertEqual([x.numel() for x in m.parameters()], [16, 4, 16, 4])
         with mock.patch("torch._dynamo.utils.log_compilation_event") as log_event:
-            torch.compile(m)(torch.randn(4, 4))
+            torch.compile(m)(torch.randn(4, 4))  # noqa: UNSPECIFIED_BACKEND
             compilation_events = [arg[0][0] for arg in log_event.call_args_list]
         self.assertEqual(compilation_events[0].param_numel, 40)
         self.assertEqual(compilation_events[0].param_bytes, 4 * 40)
@@ -1278,7 +1278,7 @@ class TestDynamoTimed(TestCase):
         m = nn.Sequential(l1, nn.Sequential(l2))
         self.assertEqual([x.numel() for x in m.parameters()], [16, 4, 4])
         with mock.patch("torch._dynamo.utils.log_compilation_event") as log_event:
-            torch.compile(m)(torch.randn(4, 4))
+            torch.compile(m)(torch.randn(4, 4))  # noqa: UNSPECIFIED_BACKEND
             compilation_events = [arg[0][0] for arg in log_event.call_args_list]
         self.assertEqual(compilation_events[0].param_numel, 24)
         self.assertEqual(compilation_events[0].param_bytes, 4 * 24)

--- a/test/dynamo/test_wrap_inductor_compiled_regions.py
+++ b/test/dynamo/test_wrap_inductor_compiled_regions.py
@@ -1164,7 +1164,7 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
             with inductor_config.patch({"wrap_inductor_compiled_regions": True}):
                 # This should now work - the inductor_compiled_code HOP will
                 # use the stored FX graph to propagate fake tensors
-                result = torch.compile(model)(inp)
+                result = torch.compile(model)(inp)  # noqa: UNSPECIFIED_BACKEND
                 # Verify the result has the expected shape
                 self.assertEqual(result.shape, (4, 4))
 
@@ -1413,11 +1413,11 @@ class TestWrapInductorCompiledRegions(torch._dynamo.test_case.TestCase):
         try:
             mesh = init_device_mesh("cpu", mesh_shape=(1,), mesh_dim_names=("dp",))
 
-            @torch.compile(dynamic=False, fullgraph=True)
+            @torch.compile(dynamic=False, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
             def compute_int_stuff(n):
                 return torch.arange(n, dtype=torch.int32)
 
-            @torch.compile(dynamic=False, fullgraph=True)
+            @torch.compile(dynamic=False, fullgraph=True)  # noqa: UNSPECIFIED_BACKEND
             def compute_float(q, cached_ints):
                 ql = q.to_local()
                 out = ql * cached_ints.float().sum()

--- a/tools/linter/adapters/unspecified_backend_linter.py
+++ b/tools/linter/adapters/unspecified_backend_linter.py
@@ -1,0 +1,157 @@
+"""
+Lints test/dynamo test files for ``torch.compile`` uses that do not pass an
+explicit ``backend=``.
+
+The default backend of ``torch.compile`` is ``inductor``, which pulls in the
+full codegen stack.  Most Dynamo tests only exercise tracing/correctness and do
+not need Inductor, so relying on the implicit default needlessly slows the
+tests down and couples them to codegen flakiness.  This linter forces every
+``torch.compile`` in a Dynamo test to consciously pick a backend (``eager``,
+``aot_eager``, ``inductor``, ...).
+
+Suppress a deliberate use with a trailing ``# noqa: UNSPECIFIED_BACKEND``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import multiprocessing as mp
+from enum import Enum
+from typing import NamedTuple
+
+
+LINTER_CODE = "UNSPECIFIED_BACKEND"
+
+
+class LintSeverity(str, Enum):
+    ERROR = "error"
+    WARNING = "warning"
+    ADVICE = "advice"
+    DISABLED = "disabled"
+
+
+class LintMessage(NamedTuple):
+    path: str | None
+    line: int | None
+    char: int | None
+    code: str
+    severity: LintSeverity
+    name: str
+    original: str | None
+    replacement: str | None
+    description: str | None
+
+
+def _is_torch_compile(func: ast.expr) -> bool:
+    # Matches ``torch.compile`` (the attribute access), whether called or used
+    # bare as a decorator.
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr == "compile"
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "torch"
+    )
+
+
+def _has_backend_kwarg(call: ast.Call) -> bool:
+    return any(kw.arg == "backend" for kw in call.keywords)
+
+
+def _suppressed(source_lines: list[str], start: int, end: int) -> bool:
+    # start/end are 1-based inclusive line numbers spanning the call.
+    for lineno in range(start, end + 1):
+        if f"noqa: {LINTER_CODE}" in source_lines[lineno - 1]:
+            return True
+    return False
+
+
+def check_file(filename: str) -> list[LintMessage]:
+    with open(filename) as f:
+        source = f.read()
+    source_lines = source.splitlines()
+
+    try:
+        tree = ast.parse(source, filename=filename)
+    except SyntaxError as err:
+        return [
+            LintMessage(
+                path=filename,
+                line=err.lineno,
+                char=err.offset,
+                code=LINTER_CODE,
+                severity=LintSeverity.ERROR,
+                name="syntax-error",
+                original=None,
+                replacement=None,
+                description=f"Failed to parse file: {err}",
+            )
+        ]
+
+    # Collect offending nodes: (node-to-report, span-end-line).
+    offenders: list[ast.expr] = []
+
+    # ``torch.compile(...)`` call form. This also covers the
+    # ``@torch.compile(...)`` call-decorator form, since a decorator call is an
+    # ast.Call reachable from ast.walk.
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and _is_torch_compile(node.func)
+            and not _has_backend_kwarg(node)
+        ):
+            offenders.append(node)
+
+    # Bare ``@torch.compile`` decorator (Attribute, not a Call -> default
+    # backend). Only reachable via decorator_list.
+    for node in ast.walk(tree):
+        for dec in getattr(node, "decorator_list", []):
+            if isinstance(dec, ast.Attribute) and _is_torch_compile(dec):
+                offenders.append(dec)
+
+    messages: list[LintMessage] = []
+    for node in offenders:
+        end = getattr(node, "end_lineno", None) or node.lineno
+        if _suppressed(source_lines, node.lineno, end):
+            continue
+        messages.append(
+            LintMessage(
+                path=filename,
+                line=node.lineno,
+                char=node.col_offset + 1,
+                code=LINTER_CODE,
+                severity=LintSeverity.ERROR,
+                name="implicit-inductor-backend",
+                original=None,
+                replacement=None,
+                description=(
+                    "torch.compile in a Dynamo test must pass an explicit "
+                    'backend= (e.g. backend="eager"). The implicit default is '
+                    '"inductor", which most Dynamo tests do not need. Suppress '
+                    "a deliberate use with `# noqa: UNSPECIFIED_BACKEND`."
+                ),
+            )
+        )
+
+    return messages
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Dynamo test torch.compile backend linter",
+        fromfile_prefix_chars="@",
+    )
+    parser.add_argument("filenames", nargs="+", help="paths to lint")
+    args = parser.parse_args()
+
+    with mp.Pool(8) as pool:
+        results = pool.map(check_file, args.filenames)
+
+    for sublist in results:
+        for lint_message in sublist:
+            print(json.dumps(lint_message._asdict()), flush=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #188441
* #188068

Follow-up to the test_misc.py eager-backend cleanup, addressing @williamwen42's
review ask for a lint rule on test/dynamo tests.

This PR was authored with the assistance of an AI coding assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98