### PR TITLE
[Test] Refactor tensor_creation_ops and foreach.py to be device-agnostic.

### DIFF
--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -39,6 +39,7 @@ from torch.testing._internal.common_methods_invocations import (
 )
 from torch.testing._internal.common_utils import (
     gradcheck,
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
@@ -164,6 +165,8 @@ def get_transform_func(num_tensors, dtype, device, is_fastpath):
 # as the pair would go through `multi_tensor_apply_kernel` if inputs are not zero size.
 @unittest.mock.patch.dict(os.environ, {"KINETO_LOG_LEVEL": "5"})
 class TestForeach(TestCase):
+    hw_classification = HardwareClassification.DEVICE_GENERIC
+
     @property
     def is_cuda(self):
         return self.device_type == "cuda"
@@ -1947,7 +1950,7 @@ _FOREACH_MM_SHAPES = [
 ]
 
 
-class TestForeachMM(TestCase):
+class _ForeachMMCheckMixin:
     def _check(self, shapes, dtype, device):
         A = [torch.randn(M, K, dtype=dtype, device=device) for M, _, K in shapes]
         B = [torch.randn(K, N, dtype=dtype, device=device) for _, N, K in shapes]
@@ -1960,6 +1963,10 @@ class TestForeachMM(TestCase):
         for i, (r, o) in enumerate(zip(ref, out)):
             self.assertEqual(o, r, msg=f"mismatch at group {i}", **kwargs)
 
+
+class TestForeachMMGeneric(_ForeachMMCheckMixin, TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @parametrize(
         "label,shapes",
         _FOREACH_MM_SHAPES,
@@ -1967,16 +1974,6 @@ class TestForeachMM(TestCase):
     )
     def test_foreach_mm_cpu(self, label, shapes):
         self._check(shapes, torch.float32, "cpu")
-
-    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
-    @parametrize(
-        "label,shapes",
-        _FOREACH_MM_SHAPES,
-        name_fn=lambda label, shapes: label,
-    )
-    @parametrize("dtype", [torch.bfloat16, torch.float32])
-    def test_foreach_mm_cuda(self, label, shapes, dtype):
-        self._check(shapes, dtype, "cuda")
 
     def test_foreach_mm_gradcheck(self):
         G = 4
@@ -2076,9 +2073,21 @@ class TestForeachMM(TestCase):
         ):
             self.assertEqual(impl._foreach_mm_route(A, B), expected)
 
-    @unittest.skipUnless(
-        torch.cuda.is_available() and SM90OrLater, "requires CUDA SM90+"
+
+@unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+class TestForeachMMCUDA(_ForeachMMCheckMixin, TestCase):
+    hw_classification = HardwareClassification.CUDA
+
+    @parametrize(
+        "label,shapes",
+        _FOREACH_MM_SHAPES,
+        name_fn=lambda label, shapes: label,
     )
+    @parametrize("dtype", [torch.bfloat16, torch.float32])
+    def test_foreach_mm_cuda(self, label, shapes, dtype):
+        self._check(shapes, dtype, "cuda")
+
+    @unittest.skipUnless(SM90OrLater, "requires SM90+")
     @parametrize(
         "label,a_shape,b_shape,a_dtype,b_dtype",
         [
@@ -2099,9 +2108,7 @@ class TestForeachMM(TestCase):
         B = [torch.randn(*b_shape, dtype=b_dtype, device="cuda") for _ in range(2)]
         self.assertFalse(_foreach_mm_cond(A, B))
 
-    @unittest.skipUnless(
-        torch.cuda.is_available() and SM90OrLater, "requires CUDA SM90+"
-    )
+    @unittest.skipUnless(SM90OrLater, "requires SM90+")
     @parametrize(
         "label,shapes",
         [
@@ -2133,9 +2140,7 @@ class TestForeachMM(TestCase):
             self.assertEqual(o, r)
 
     @skipIfNoNvmath
-    @unittest.skipUnless(
-        torch.cuda.is_available() and SM90OrLater, "requires CUDA SM90+"
-    )
+    @unittest.skipUnless(SM90OrLater, "requires SM90+")
     @parametrize(
         "label,shapes",
         [
@@ -2162,7 +2167,8 @@ class TestForeachMM(TestCase):
         self._check(shapes, torch.bfloat16, "cuda")
 
 
-instantiate_parametrized_tests(TestForeachMM)
+instantiate_parametrized_tests(TestForeachMMGeneric)
+instantiate_parametrized_tests(TestForeachMMCUDA)
 
 
 if __name__ == "__main__":

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from torch.testing import make_tensor
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     TestCase,
     run_tests,
     do_test_empty_full,
@@ -96,6 +97,7 @@ def _rand_shape(dim, min_size, max_size):
 # See https://pytorch.org/docs/main/torch.html#creation-ops
 
 class TestTensorCreation(TestCase):
+    hw_classification = HardwareClassification.DEVICE_GENERIC
     exact_dtype = True
 
     @onlyCPU
@@ -3320,6 +3322,7 @@ class TestTensorCreation(TestCase):
 
 # Class for testing random tensor creation ops, like torch.randint
 class TestRandomTensorCreation(TestCase):
+    hw_classification = HardwareClassification.DEVICE_GENERIC
     exact_dtype = True
 
     # TODO: add torch.complex64, torch.complex128
@@ -3774,6 +3777,7 @@ class TestRandomTensorCreation(TestCase):
 
 # Class for testing *like ops, like torch.ones_like
 class TestLikeTensorCreation(TestCase):
+    hw_classification = HardwareClassification.DEVICE_GENERIC
     exact_dtype = True
 
     # TODO: this test should be updated
@@ -3973,6 +3977,8 @@ def get_dtype_size(dtype):
     return int(torch.empty((), dtype=dtype).element_size())
 
 class TestBufferProtocol(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _run_test(self, shape, dtype, count=-1, first=0, offset=None, **kwargs):
         numpy_dtype = torch_to_numpy_dtype_dict[dtype]
 
@@ -4128,6 +4134,8 @@ class TestBufferProtocol(TestCase):
         self.assertSequenceEqual(tensor, [255, 255])
 
 class TestFromBlob(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _make_data(self, dtype, numel):
         numpy_dtype = torch_to_numpy_dtype_dict[dtype]
         arr = np.arange(1, numel + 1, dtype=numpy_dtype)
@@ -4211,6 +4219,8 @@ def to_memview(tensor):
     return memoryview(to_numpy(tensor))
 
 class TestAsArray(TestCase):
+    hw_classification = HardwareClassification.DEVICE_GENERIC
+
     def _check(self, original, cvt=lambda t: t, is_alias=True, same_dtype=True, same_device=True, **kwargs):
         """Check the output of 'asarray', given its input and assertion information.
 


### PR DESCRIPTION
Add hw_classification attributes to all test classes in both files as part of the device-agnostic test refactoring initiative.

test_tensor_creation_ops.py: Annotation of 6 existing classes — 4 as DEVICE_GENERIC (already wired through instantiate_device_type_tests) and 2 as GENERIC (CPU-only via only_for=cpu).

test_foreach.py: split TestForeachMM into TestForeachMMGeneric and TestForeachMMCUDA. Extracted the shared _check helper into a _ForeachMMCheckMixin to avoid duplication. Lifted the class-level CUDA skip guard onto TestForeachMMCUDA, simplifying per-method decorators.

Test Plan:
test_tensor_creation_ops.py : 1071 passed, 145 skipped test_foreach.py : 6511 passed, 969 skipped, 61 xfailed