### PR TITLE
Don't auto-apply ci: disable-autorevert label from the disable-autorevert issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/disable-autorevert.md
+++ b/.github/ISSUE_TEMPLATE/disable-autorevert.md
@@ -2,12 +2,17 @@
 name: "D❌​\U0001F519​ ISABLE AUTOREVERT"
 about: Disables autorevert when open
 title: "[DISABLE AUTOREVERT]"
-labels: 'ci: disable-autorevert'
+labels: ''
 assignees: ''
 
 ---
 
-This issue, while open, disables the autorevert functionality.
+> NOTE: Opening this issue does NOT disable autorevert on its own. A maintainer must
+>       manually add the `ci: disable-autorevert` label for it to take effect. The label is
+>       intentionally not auto-applied by this template, so only users with write/triage
+>       permission can trip the killswitch.
+
+This issue, while open **and** labeled `ci: disable-autorevert`, disables the autorevert functionality.
 
 More details can be found [here](https://github.com/pytorch/test-infra/blob/main/aws/lambda/pytorch-auto-revert/README.md)
 


### PR DESCRIPTION
## Summary

The `[DISABLE AUTOREVERT]` issue template carried `labels: 'ci: disable-autorevert'` in its front matter. GitHub applies a template's labels at issue creation **regardless of the author's permissions**, and an open issue with that label disables autorevert for the whole repo. So **any** user who can open an issue could trip the global autorevert killswitch.

This happened in #188383: a `NONE`-permission user opened the issue from the template, auto-applying the label and disabling autorevert for ~15h until a maintainer removed it.

## Change

- Remove `labels: 'ci: disable-autorevert'` from the template front matter, so opening the issue no longer auto-applies the killswitch label.
- A maintainer must now add the `ci: disable-autorevert` label manually for the issue to take effect. Adding a label requires triage/write access, which naturally gates the killswitch to authorized people — the template auto-apply was the only vector by which a non-write user could attach it.
- Reword the template with a `> NOTE:` blockquote + an HTML comment (mirroring the existing `ci-sev` template) spelling out exactly which label must be added by hand.

Friction cost: a maintainer takes one extra action (add the label) after opening the issue. That's the point.

## Companion PR

Defense-in-depth at the consumer: pytorch/test-infra#8229 makes the autorevert lambda only honor a `ci: disable-autorevert` issue when the label was **applied by a write-access user**, so the killswitch is safe even if a label slips on via some other path.

Fixes the disable vector reported in #188383.