### PR TITLE
Add DTensor sharding strategy for searchsorted

### DIFF
--- a/test/distributed/tensor/test_op_strategy.py
+++ b/test/distributed/tensor/test_op_strategy.py
@@ -32,6 +32,7 @@ from torch.distributed.tensor._ops._einsum_strategy import (
 )
 from torch.distributed.tensor._ops._math_ops import common_reduction_strategy
 from torch.distributed.tensor._ops.utils import replicate_op_strategy
+from torch.distributed.tensor._utils import ExplicitRedistributionContext
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.distributed.tensor.placement_types import _StridedShard
 from torch.testing._internal.common_utils import run_tests, TestCase
@@ -1871,6 +1872,84 @@ class TestUnsupportedDTensorOp(TestCase):
             r"Operator.*testlib\.unsupported_cat.*does not have a sharding strategy registered",
         ):
             _ = torch.ops.testlib.unsupported_cat([x_dt, y_dt], dim=0)
+
+
+class TestSearchsortedStrategy(DTensorTestBase):
+    @property
+    def world_size(self):
+        return 4
+
+    def _check(
+        self,
+        mesh,
+        ss,
+        vals,
+        ss_p,
+        vals_p,
+        expected_out,
+        sorter=None,
+        sorter_p=None,
+        **kw,
+    ):
+        ref = torch.searchsorted(ss, vals, sorter=sorter, **kw)
+        ss_dt = distribute_tensor(ss, mesh, [ss_p])
+        vals_dt = distribute_tensor(vals, mesh, [vals_p])
+        if sorter is not None:
+            kw["sorter"] = distribute_tensor(sorter, mesh, [sorter_p])
+        # Inputs are pre-placed to match a rule, so no implicit redistribution.
+        with ExplicitRedistributionContext():
+            out = torch.searchsorted(ss_dt, vals_dt, **kw)
+        self.assertEqual(out.placements, (expected_out,))
+        self.assertEqual(out.full_tensor(), ref)
+
+    @with_comms
+    def test_broadcast_shard_values(self):
+        mesh = self.build_device_mesh()
+        ss = torch.sort(torch.randn(16, device=self.device_type))[0]
+        vals = torch.randn(8, device=self.device_type)
+        self._check(mesh, ss, vals, Replicate(), Shard(0), Shard(0))
+
+    @with_comms
+    def test_broadcast_partial_sum(self):
+        # Sharding the (globally sorted) searched dim sums local index counts.
+        mesh = self.build_device_mesh()
+        ss = torch.sort(torch.randn(16, device=self.device_type))[0]
+        vals = torch.randn(8, device=self.device_type)
+        self._check(mesh, ss, vals, Shard(0), Replicate(), Partial("sum"), right=True)
+
+    @with_comms
+    def test_batched_shard_batch(self):
+        mesh = self.build_device_mesh()
+        ss = torch.sort(torch.randn(8, 10, device=self.device_type), dim=-1)[0]
+        vals = torch.randn(8, 5, device=self.device_type)
+        self._check(mesh, ss, vals, Shard(0), Shard(0), Shard(0))
+
+    @with_comms
+    def test_batched_shard_value_dim(self):
+        mesh = self.build_device_mesh()
+        ss = torch.sort(torch.randn(8, 10, device=self.device_type), dim=-1)[0]
+        vals = torch.randn(8, 8, device=self.device_type)
+        self._check(mesh, ss, vals, Replicate(), Shard(1), Shard(1))
+
+    @with_comms
+    def test_batched_sorter_consistent(self):
+        # sorter is keyword-only and is never redistributed by the dispatcher, so
+        # it must arrive with a placement matching sorted_sequence (here both shard
+        # the batch dim).
+        mesh = self.build_device_mesh()
+        ss = torch.randn(8, 10, device=self.device_type)
+        sorter = torch.argsort(ss, dim=-1)
+        vals = torch.randn(8, 5, device=self.device_type)
+        self._check(
+            mesh,
+            ss,
+            vals,
+            Shard(0),
+            Shard(0),
+            Shard(0),
+            sorter=sorter,
+            sorter_p=Shard(0),
+        )
 
 
 if __name__ == "__main__":

--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -280,6 +280,85 @@ def bucketize_single_dim_strategy(
     return strategies
 
 
+@register_single_dim_strategy(aten.searchsorted.Tensor)
+def searchsorted_tensor_single_dim_strategy(
+    op: OpOverload, args_schema: ArgsType, kwargs_schema: KwargsType
+) -> list[list[Placement | _ShardingPlaceholder]]:
+    """searchsorted(sorted_sequence, self) returns insertion indices of self
+    into sorted_sequence, which is sorted along its last dim. The output has
+    self's shape. sorted_sequence is either 1-D (broadcast over all of self) or
+    N-D with the same batch dims (all but the last) as self.
+
+    Placement order: [output, sorted_sequence, self, sorter?]. sorter (optional,
+    same shape as sorted_sequence) mirrors sorted_sequence's placement.
+
+    Families of strategies:
+    1. Batch-dim sharding (N-D sorted_sequence only): shard a leading dim shared
+       by sorted_sequence, self, and output. Each batch row is independent.
+    2. Self value-dim sharding: shard a dim of self that is not searched over
+       (every dim in the broadcast case, only the last dim in the N-D case),
+       keeping sorted_sequence replicated. Output follows self.
+    3. Partial("sum") output: shard sorted_sequence on its last (searched) dim,
+       replicate self. The shards are contiguous and globally ordered, so each
+       rank's local index count sums to the global index. Disabled when sorter
+       is present, since sorter holds global indices that are invalid per shard.
+    4. Partial(max/min) self and output: searchsorted is monotonically
+       non-decreasing in self's values, so reducing local indices with max (or
+       min) matches searching the reduced value.
+    """
+    ss_meta, self_meta = args_schema[0], args_schema[1]
+    if not isinstance(ss_meta, TensorMeta) or not isinstance(self_meta, TensorMeta):
+        raise AssertionError(f"Expected TensorMeta, got {ss_meta}, {self_meta}")
+    has_sorter = isinstance(kwargs_schema.get("sorter"), TensorMeta)
+    ss_ndim = len(ss_meta.shape)
+    out_ndim = len(self_meta.shape)
+    search_dim = ss_ndim - 1
+    is_broadcast = ss_ndim == 1
+    SP = _ShardingPlaceholder
+
+    # sorter (same shape/role as sorted_sequence) always shares its placement.
+    # It is keyword-only, and the dispatcher never reshards kwargs, so sorter
+    # must already arrive matching sorted_sequence's placement.
+    def rule(out_p, ss_p, self_p):
+        placements: list[Placement | _ShardingPlaceholder] = [out_p, ss_p, self_p]
+        if has_sorter:
+            placements.append(ss_p)
+        return placements
+
+    strategies: list[list[Placement | _ShardingPlaceholder]] = []
+    # Family 1: batch dims (shared leading dims) of N-D sorted_sequence.
+    if not is_broadcast:
+        for dim in range(ss_ndim - 1):
+            strategies.append(rule(SP(dim), SP(dim), SP(dim)))
+    # Family 2: self value dims (all dims if broadcast, else only the last).
+    self_value_dims = range(out_ndim) if is_broadcast else (out_ndim - 1,)
+    for dim in self_value_dims:
+        strategies.append(rule(SP(dim), Replicate(), SP(dim)))
+    # Family 3: shard the searched dim, sum partial over it.
+    if not has_sorter:
+        strategies.append([Partial("sum"), SP(search_dim), Replicate()])
+    # Family 4: monotonicity of searchsorted in self's values.
+    for reduce_op in ("max", "min"):
+        strategies.append(rule(Partial(reduce_op), Replicate(), Partial(reduce_op)))
+    return strategies
+
+
+@register_single_dim_strategy(aten.searchsorted.Scalar)
+def searchsorted_scalar_single_dim_strategy(
+    op: OpOverload, args_schema: ArgsType, kwargs_schema: KwargsType
+) -> list[list[Placement | _ShardingPlaceholder]]:
+    """searchsorted with a scalar query value: sorted_sequence is 1-D and the
+    output is a scalar. The only non-trivial sharding shards sorted_sequence on
+    its searched dim and sums the local index counts (see Family 3 above).
+    Disabled when sorter is present.
+
+    Placement order: [output, sorted_sequence].
+    """
+    if isinstance(kwargs_schema.get("sorter"), TensorMeta):
+        return []
+    return [[Partial("sum"), _ShardingPlaceholder(0)]]
+
+
 @register_single_dim_strategy(
     aten.select.int,
     schema_info=RuntimeSchemaInfo(1),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #188448
* #188447

Register single-dim strategies for aten.searchsorted.Tensor and
aten.searchsorted.Scalar. searchsorted(sorted_sequence, self) returns
insertion indices of self into sorted_sequence (sorted along its last,
"searched" dim); the output has self's shape. sorted_sequence is either
1-D (broadcast over all of self) or N-D sharing self's batch dims.

Rules: (1) batch-dim sharding shared by sorted_sequence/self/output for
N-D inputs; (2) value-dim passthrough sharding of self with replicated
sorted_sequence; (3) sharding the searched dim with a Partial("sum")
output, since contiguous globally-ordered shards let local index counts
sum to the global index (disabled when a sorter is present, since sorter
holds global indices invalid per shard); (4) Partial(max/min) on self by
monotonicity of searchsorted in its values.

The optional sorter is keyword-only and the dispatcher never reshards
kwargs, so the strategy requires it to arrive matching sorted_sequence's
placement. The test/distributed/tensor/test_dtensor_ops.py OpInfo
crossref shards sorter across all combinations, which this limitation
cannot satisfy, so searchsorted stays xfail there; the dedicated tests
below cover the cases the strategy supports.

Test Plan:

```bash
python -m torch.distributed.tensor._ops.strategy_validation --op searchsorted --incorrect-only

python -m torch.distributed.tensor._ops.strategy_validation --op searchsorted --max-samples 20

python test/distributed/tensor/test_op_strategy.py -k TestSearchsortedStrategy
```

Authored with the assistance of an AI assistant.