### PR TITLE
[cpu] Address clang-tidy issues in vec_base.h

### DIFF
--- a/aten/src/ATen/cpu/vec/vec_base.h
+++ b/aten/src/ATen/cpu/vec/vec_base.h
@@ -91,9 +91,8 @@ Windows llvm will not have this definition.
 #define int_vector __m256i
 #endif // CPU_CAPABILITY_AVX512
 
-namespace at::vec {
 // See Note [CPU_CAPABILITY namespace]
-inline namespace CPU_CAPABILITY {
+namespace at::vec::inline CPU_CAPABILITY {
 // at::Half and at::BFloat16 should be treated as floating point
 template <typename T>
 struct is_floating_point
@@ -179,7 +178,7 @@ template <class T>
 #endif
 struct Vectorized {
  private:
-  __at_align__ T values[VECTOR_WIDTH / sizeof(T)];
+  __at_align__ std::array<T, VECTOR_WIDTH / sizeof(T)> values{};
 
  public:
   using value_type = T;
@@ -189,30 +188,28 @@ struct Vectorized {
   static constexpr size_type size() {
     return kSize;
   }
-  Vectorized() : values{static_cast<T>(0)} {}
+  Vectorized() = default;
   Vectorized(T val) {
-    for (int i = 0; i != size(); i++) {
-      values[i] = val;
-    }
+    values.fill(val);
   }
   template <
       typename... Args,
       typename = std::enable_if_t<(sizeof...(Args) == size())>>
   Vectorized(Args... vals) : values{vals...} {}
-  Vectorized(const T (&arr)[kSize]) {
-    std::memcpy(values, arr, sizeof(values));
+  Vectorized(const T (&arr)[kSize]) { // NOLINT(*-avoid-c-arrays)
+    std::memcpy(values.data(), arr, sizeof(values));
   }
   // This also implies const T& operator[](int idx) const
   inline operator const T*() const {
-    return values;
+    return values.data();
   }
   // This also implies T& operator[](int idx)
   inline operator T*() {
-    return values;
+    return values.data();
   }
   // Return the values as char* for type punning
   auto as_bytes() const -> const char* {
-    return reinterpret_cast<const char*>(values);
+    return reinterpret_cast<const char*>(values.data());
   }
   template <int64_t mask_>
   static Vectorized<T> blend(const Vectorized<T>& a, const Vectorized<T>& b) {
@@ -240,8 +237,8 @@ struct Vectorized {
       const Vectorized<T>& b,
       const Vectorized<T>& mask) {
     Vectorized vector;
-    int_same_size_t<T> buffer[size()];
-    mask.store(buffer);
+    std::array<int_same_size_t<T>, size()> buffer;
+    mask.store(buffer.data());
     for (const auto i : c10::irange(size())) {
       if (buffer[i] & 0x01) {
         vector[i] = b[i];
@@ -278,13 +275,15 @@ struct Vectorized {
   }
   static Vectorized<T> loadu(const void* ptr) {
     Vectorized vector;
-    std::memcpy(vector.values, ptr, VECTOR_WIDTH);
+    std::memcpy(vector.values.data(), ptr, VECTOR_WIDTH);
     return vector;
   }
   static Vectorized<T> loadu(const void* ptr, int64_t count) {
     Vectorized vector;
     std::memcpy(
-        vector.values, ptr, std::min<int64_t>(count, size()) * sizeof(T));
+        vector.values.data(),
+        ptr,
+        std::min<int64_t>(count, size()) * sizeof(T));
     return vector;
   }
   static Vectorized<T> loadu_one_fourth(const void* ptr) {
@@ -295,7 +294,8 @@ struct Vectorized {
   }
 
   void store(void* ptr, int count = size()) const {
-    std::memcpy(ptr, values, std::min<int64_t>(count, size()) * sizeof(T));
+    std::memcpy(
+        ptr, values.data(), std::min<int64_t>(count, size()) * sizeof(T));
   }
   int zero_mask() const {
     // returns an integer mask where all zero elements are translated to 1-bit
@@ -312,9 +312,9 @@ struct Vectorized {
     Vectorized<T> vector;
     for (int64_t i = 0; i != size(); i++) {
       if (_isnan(values[i])) {
-        std::memset(static_cast<void*>(vector.values + i), 0xFF, sizeof(T));
+        std::memset(&vector.values[i], 0xFF, sizeof(T));
       } else {
-        std::memset(static_cast<void*>(vector.values + i), 0, sizeof(T));
+        std::memset(&vector.values[i], 0, sizeof(T));
       }
     }
     return vector;
@@ -592,7 +592,7 @@ struct Vectorized {
     // complex_t_log2 is for SFINAE and clarity. Make sure it is not changed.
     static_assert(
         std::is_same_v<complex_t_log2, T>, "complex_t_log2 must be T");
-    const T log_2 = T(std::log(2.0));
+    const T log_2 = T(std::log(2.0)); // NOLINT(modernize-use-std-numbers)
     return Vectorized(map(std::log)) / Vectorized(log_2);
   }
   Vectorized<T> ceil() const {
@@ -703,9 +703,9 @@ struct Vectorized {
     Vectorized<T> vector;
     for (int64_t i = 0; i != size(); i++) {
       if (op(values[i], other.values[i])) {
-        std::memset(static_cast<void*>(vector.values + i), 0xFF, sizeof(T));
+        std::memset(&vector.values[i], 0xFF, sizeof(T));
       } else {
-        std::memset(static_cast<void*>(vector.values + i), 0, sizeof(T));
+        std::memset(&vector.values[i], 0, sizeof(T));
       }
     }
     return vector;
@@ -1031,21 +1031,20 @@ static inline Vectorized<T> bitwise_binary_op(
       _mm512_load_si512(reinterpret_cast<const int_vector*>((const T*)b));
 #endif
   buffer = op(a_buffer, b_buffer);
-  __at_align__ T results[Vectorized<T>::size()];
+  __at_align__ std::array<T, Vectorized<T>::size()> results{};
 
 #if defined(CPU_CAPABILITY_AVX2)
-  _mm256_store_si256(reinterpret_cast<int_vector*>(results), buffer);
+  _mm256_store_si256(reinterpret_cast<int_vector*>(results.data()), buffer);
 #elif defined(CPU_CAPABILITY_AVX512)
-  _mm512_store_si512(reinterpret_cast<int_vector*>(results), buffer);
+  _mm512_store_si512(reinterpret_cast<int_vector*>(results.data()), buffer);
 #endif
-  return Vectorized<T>::loadu(results);
+  return Vectorized<T>::loadu(results.data());
 }
 
 template <
     class T,
-    typename std::enable_if_t<
-        !std::is_base_of<Vectorizedi, Vectorized<T>>::value,
-        int> = 0>
+    typename std::
+        enable_if_t<!std::is_base_of_v<Vectorizedi, Vectorized<T>>, int> = 0>
 inline Vectorized<T> operator&(const Vectorized<T>& a, const Vectorized<T>& b) {
   // We enclose _mm512_and_si512 or _mm256_and_si256 with lambda because it is
   // always_inline
@@ -1059,9 +1058,8 @@ inline Vectorized<T> operator&(const Vectorized<T>& a, const Vectorized<T>& b) {
 }
 template <
     class T,
-    typename std::enable_if_t<
-        !std::is_base_of<Vectorizedi, Vectorized<T>>::value,
-        int> = 0>
+    typename std::
+        enable_if_t<!std::is_base_of_v<Vectorizedi, Vectorized<T>>, int> = 0>
 inline Vectorized<T> operator|(const Vectorized<T>& a, const Vectorized<T>& b) {
   // We enclose _mm512_or_si512 or _mm256_or_si256 with lambda because it is
   // always_inline
@@ -1075,9 +1073,8 @@ inline Vectorized<T> operator|(const Vectorized<T>& a, const Vectorized<T>& b) {
 }
 template <
     class T,
-    typename std::enable_if_t<
-        !std::is_base_of<Vectorizedi, Vectorized<T>>::value,
-        int> = 0>
+    typename std::
+        enable_if_t<!std::is_base_of_v<Vectorizedi, Vectorized<T>>, int> = 0>
 inline Vectorized<T> operator^(const Vectorized<T>& a, const Vectorized<T>& b) {
   // We enclose _mm512_xor_si512 or _mm256_xor_si256 with lambda because it is
   // always_inline
@@ -1105,7 +1102,7 @@ static inline Vectorized<T> bitwise_binary_op(
     const Vectorized<T>& b,
     Op op) {
   static constexpr uint32_t element_no = VECTOR_WIDTH / sizeof(intmax_t);
-  __at_align__ intmax_t buffer[element_no];
+  __at_align__ std::array<intmax_t, element_no> buffer{};
   static_assert(
       VECTOR_WIDTH % sizeof(intmax_t) == 0,
       "VECTOR_WIDTH not a multiple of sizeof(intmax_t)");
@@ -1126,7 +1123,7 @@ static inline Vectorized<T> bitwise_binary_op(
   }
   assert(a_data == a.as_bytes() + sizeof(a));
   assert(b_data == b.as_bytes() + sizeof(b));
-  return Vectorized<T>::loadu(buffer);
+  return Vectorized<T>::loadu(buffer.data());
 }
 
 template <
@@ -1134,21 +1131,21 @@ template <
     typename std::
         enable_if_t<!std::is_base_of_v<Vectorizedi, Vectorized<T>>, int> = 0>
 inline Vectorized<T> operator&(const Vectorized<T>& a, const Vectorized<T>& b) {
-  return bitwise_binary_op(a, b, std::bit_and<intmax_t>());
+  return bitwise_binary_op(a, b, std::bit_and<>());
 }
 template <
     class T,
     typename std::
         enable_if_t<!std::is_base_of_v<Vectorizedi, Vectorized<T>>, int> = 0>
 inline Vectorized<T> operator|(const Vectorized<T>& a, const Vectorized<T>& b) {
-  return bitwise_binary_op(a, b, std::bit_or<intmax_t>());
+  return bitwise_binary_op(a, b, std::bit_or<>());
 }
 template <
     class T,
     typename std::
         enable_if_t<!std::is_base_of_v<Vectorizedi, Vectorized<T>>, int> = 0>
 inline Vectorized<T> operator^(const Vectorized<T>& a, const Vectorized<T>& b) {
-  return bitwise_binary_op(a, b, std::bit_xor<intmax_t>());
+  return bitwise_binary_op(a, b, std::bit_xor<>());
 }
 
 #endif // defined(CPU_CAPABILITY_AVX2) || defined(CPU_CAPABILITY_AVX512)
@@ -1301,13 +1298,13 @@ std::enable_if_t<
     Vectorized<
         T>> inline gather(T const* base_addr, const Vectorized<int_same_size_t<T>>& vindex) {
   static constexpr int size = Vectorized<T>::size();
-  int_same_size_t<T> index_arr[size];
-  vindex.store(static_cast<void*>(index_arr));
-  T buffer[size];
+  std::array<int_same_size_t<T>, size> index_arr{};
+  vindex.store(index_arr.data());
+  std::array<T, size> buffer{};
   for (const auto i : c10::irange(size)) {
     buffer[i] = base_addr[index_arr[i] * scale / sizeof(T)];
   }
-  return Vectorized<T>::loadu(static_cast<void*>(buffer));
+  return Vectorized<T>::loadu(buffer.data());
 }
 
 template <int64_t scale = 1, typename T = void>
@@ -1318,13 +1315,14 @@ std::
         const Vectorized<int_same_size_t<T>>& vindex,
         Vectorized<T>& mask) {
   static constexpr int size = Vectorized<T>::size();
-  T src_arr[size];
-  int_same_size_t<T> mask_arr[size]; // use int type so we can logical and
-  int_same_size_t<T> index_arr[size];
-  src.store(static_cast<void*>(src_arr));
-  mask.store(static_cast<void*>(mask_arr));
-  vindex.store(static_cast<void*>(index_arr));
-  T buffer[size];
+  std::array<T, size> src_arr{};
+  // use int type so we can logical and
+  std::array<int_same_size_t<T>, size> mask_arr{};
+  std::array<int_same_size_t<T>, size> index_arr{};
+  src.store(src_arr.data());
+  mask.store(mask_arr.data());
+  vindex.store(index_arr.data());
+  std::array<T, size> buffer{};
   for (const auto i : c10::irange(size)) {
     if (mask_arr[i] & 0x01) { // check highest bit
       buffer[i] = base_addr[index_arr[i] * scale / sizeof(T)];
@@ -1333,7 +1331,7 @@ std::
     }
   }
   mask = Vectorized<T>(static_cast<T>(0)); // "zero out" mask
-  return Vectorized<T>::loadu(static_cast<void*>(buffer));
+  return Vectorized<T>::loadu(buffer.data());
 }
 
 // Cast a given vector to another type without changing the bits representation.
@@ -1346,9 +1344,9 @@ std::
 template <typename dst_t, typename src_t>
 struct CastImpl {
   static inline Vectorized<dst_t> apply(const Vectorized<src_t>& src) {
-    src_t src_arr[Vectorized<src_t>::size()];
-    src.store(static_cast<void*>(src_arr));
-    return Vectorized<dst_t>::loadu(static_cast<const void*>(src_arr));
+    std::array<src_t, Vectorized<src_t>::size()> src_arr{};
+    src.store(src_arr.data());
+    return Vectorized<dst_t>::loadu(src_arr.data());
   }
 };
 
@@ -1415,12 +1413,12 @@ inline std::enable_if_t<
 deinterleave2(const Vectorized<T>& a, const Vectorized<T>& b) {
   static constexpr int size = Vectorized<T>::size();
   static constexpr int half_size = size / 2;
-  T a_arr[size];
-  T b_arr[size];
-  T buffer1[size];
-  T buffer2[size];
-  a.store(static_cast<void*>(a_arr));
-  b.store(static_cast<void*>(b_arr));
+  std::array<T, size> a_arr{};
+  std::array<T, size> b_arr{};
+  std::array<T, size> buffer1{};
+  std::array<T, size> buffer2{};
+  a.store(a_arr.data());
+  b.store(b_arr.data());
   for (const auto i : c10::irange(half_size)) {
     buffer1[i] = a_arr[i * 2];
     buffer1[half_size + i] = b_arr[i * 2];
@@ -1428,8 +1426,8 @@ deinterleave2(const Vectorized<T>& a, const Vectorized<T>& b) {
     buffer2[half_size + i] = b_arr[i * 2 + 1];
   }
   return std::make_pair(
-      Vectorized<T>::loadu(static_cast<void*>(buffer1)),
-      Vectorized<T>::loadu(static_cast<void*>(buffer2)));
+      Vectorized<T>::loadu(buffer1.data()),
+      Vectorized<T>::loadu(buffer2.data()));
 }
 
 VECTORIZED_SUPPORT_SCALARS_FOR_BINARY_FUNC(deinterleave2)
@@ -1454,12 +1452,12 @@ inline std::enable_if_t<
 interleave2(const Vectorized<T>& a, const Vectorized<T>& b) {
   static constexpr int size = Vectorized<T>::size();
   static constexpr int half_size = size / 2;
-  T a_arr[size];
-  T b_arr[size];
-  T buffer1[size];
-  T buffer2[size];
-  a.store(static_cast<void*>(a_arr));
-  b.store(static_cast<void*>(b_arr));
+  std::array<T, size> a_arr{};
+  std::array<T, size> b_arr{};
+  std::array<T, size> buffer1{};
+  std::array<T, size> buffer2{};
+  a.store(a_arr.data());
+  b.store(b_arr.data());
   for (const auto i : c10::irange(half_size)) {
     buffer1[i * 2] = a_arr[i];
     buffer1[i * 2 + 1] = b_arr[i];
@@ -1467,8 +1465,8 @@ interleave2(const Vectorized<T>& a, const Vectorized<T>& b) {
     buffer2[i * 2 + 1] = b_arr[half_size + i];
   }
   return std::make_pair(
-      Vectorized<T>::loadu(static_cast<void*>(buffer1)),
-      Vectorized<T>::loadu(static_cast<void*>(buffer2)));
+      Vectorized<T>::loadu(buffer1.data()),
+      Vectorized<T>::loadu(buffer2.data()));
 }
 
 VECTORIZED_SUPPORT_SCALARS_FOR_BINARY_FUNC(interleave2)
@@ -1492,13 +1490,13 @@ inline void convert(const src_T* src, dst_T* dst, int64_t n) {
 template <typename T>
 inline Vectorized<T> flip(const Vectorized<T>& data) {
   static constexpr int size = Vectorized<T>::size();
-  T output[size];
-  T buffer[size];
-  data.store(static_cast<void*>(buffer));
+  std::array<T, size> output{};
+  std::array<T, size> buffer{};
+  data.store(buffer.data());
   for (const auto i : c10::irange(size)) {
     output[i] = buffer[size - i - 1];
   }
-  return Vectorized<T>::loadu(static_cast<void*>(output));
+  return Vectorized<T>::loadu(output.data());
 }
 
 // Transpose the `src` buffer of type `T` and size (M,N) into the `dst` buffer.
@@ -1543,8 +1541,8 @@ inline std::ostream& operator<<(std::ostream& stream, const c10::quint8& val) {
 
 template <typename T>
 std::ostream& operator<<(std::ostream& stream, const Vectorized<T>& vec) {
-  T buf[Vectorized<T>::size()];
-  vec.store(buf);
+  std::array<T, Vectorized<T>::size()> buf{};
+  vec.store(buf.data());
   stream << "vec[";
   for (int i = 0; i != Vectorized<T>::size(); i++) {
     if (i != 0) {
@@ -1556,8 +1554,7 @@ std::ostream& operator<<(std::ostream& stream, const Vectorized<T>& vec) {
   return stream;
 }
 
-} // namespace CPU_CAPABILITY
-} // namespace at::vec
+} // namespace at::vec::inline CPU_CAPABILITY
 
 // additional headers for more operations that depend on vec_base
 #include <ATen/cpu/vec/vec_convert.h>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #188452
* #188451
* #188450
* __->__ #188449

Silences a number of compiler warnings.


Pull-Request: https://github.com/pytorch/pytorch/pull/188310