### PR TITLE
[release_notes] Map sub-area labels to per-area worksheets

### DIFF
--- a/scripts/release_notes/commitlist.py
+++ b/scripts/release_notes/commitlist.py
@@ -151,8 +151,11 @@ class CommitList:
         if category in common.quantization.categories:
             category = common.quantization.name
             return category
-        if category in common.distributed.categories:
-            category = common.distributed.name
+        if category in common.optimizer.categories:
+            category = common.optimizer.name
+            return category
+        if category in common.aotdispatcher.categories:
+            category = common.aotdispatcher.name
             return category
         return category
 
@@ -179,7 +182,7 @@ class CommitList:
             ("[nn]", "nn_frontend"),
             ("[complex]", "complex_frontend"),
             ("[mps]", "mps"),
-            ("[optimizer]", "optimizer_frontend"),
+            ("[optimizer]", "optim"),
             ("[xla]", "xla"),
         ]
         title_lower = title.lower()

--- a/scripts/release_notes/common.py
+++ b/scripts/release_notes/common.py
@@ -31,7 +31,6 @@ frontend_categories = [
     "dataloader",
     "sparse",
     "nested tensor",
-    "optimizer",
 ]
 
 pytorch_2_categories = [
@@ -49,7 +48,8 @@ quantization = CategoryGroup(
     ],
 )
 
-# Distributed has a number of release note labels we want to map to one
+# Distributed has a number of release note sub-area labels. Each sub-area
+# label is kept as its own category so it gets its own worksheet file.
 distributed = CategoryGroup(
     name="distributed",
     categories=[
@@ -58,8 +58,32 @@ distributed = CategoryGroup(
         "distributed (composable)",
         "distributed (ddp)",
         "distributed (fsdp)",
+        "distributed (fsdp2)",
+        "distributed (dtensor)",
+        "distributed (checkpoint)",
         "distributed (rpc)",
         "distributed (sharded)",
+        "distributed (pipeline)",
+        "distributed (torchelastic)",
+        "distributed (symm_mem)",
+    ],
+)
+
+# "optim" and "optimizer" are duplicate labels for the same area; map to one
+optimizer = CategoryGroup(
+    name="optim",
+    categories=[
+        "optim",
+        "optimizer",
+    ],
+)
+
+# "aot autograd" and "aotdispatcher" are the same subsystem; map to one
+aotdispatcher = CategoryGroup(
+    name="aotdispatcher",
+    categories=[
+        "aot autograd",
+        "aotdispatcher",
     ],
 )
 
@@ -101,7 +125,9 @@ categories = (
     + [f"{category}_frontend" for category in frontend_categories]
     + pytorch_2_categories
     + [quantization.name]
-    + [distributed.name]
+    + distributed.categories
+    + [optimizer.name]
+    + [aotdispatcher.name]
 )
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #188453

Improve how scripts/release_notes assigns `release notes:` labels to worksheet
files in three related ways:

- Distributed: previously every `distributed (...)` sub-area label was collapsed
  into a single `distributed` category, so the generator produced one combined
  result_distributed.md. Keep each sub-area label as its own category so a
  separate `result_distributed (<subarea>).md` is emitted per area (c10d,
  dtensor, fsdp, fsdp2, checkpoint, pipeline, torchelastic, symm_mem, ddp,
  composable, rpc, sharded). Done by appending `distributed.categories` to the
  master category list and dropping the collapse branch in `category_remapper`.

- Optimizer: `optim` and `optimizer` are duplicate labels for the same area.
  Add an `optim` CategoryGroup mapping both to `optim`, remove the stale
  `optimizer` frontend category, and point the `[optimizer]` title heuristic at
  `optim`.

- AOTDispatcher: `aot autograd` and `aotdispatcher` name the same subsystem; add
  a CategoryGroup mapping both to `aotdispatcher`.

The resulting `common.categories` contains no duplicates and drops no
previously-handled category; other areas are unaffected.