### PR TITLE
[ROCm] Preload TheRock ROCm deps so wheels are self-contained (`_preload_rocm_deps`)

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -381,6 +381,90 @@ def _preload_cuda_deps(err: OSError | None = None, required: bool = True) -> Non
     _preload_cuda_lib("nvtx", "libnvToolsExt.so.*[0-9]", required=False)
 
 
+# ROCm runtime libs a TheRock-built libtorch DT_NEEDEDs, mirroring the set
+# bundled by .ci/manywheel/repair_wheel.py::ROCM_SO_FILES. Ordered leaf-first so
+# that RTLD_GLOBAL preloading satisfies inter-lib NEEDED entries as we go.
+_rocm_core_libs: list[str] = [
+    "libamd_comgr.so",
+    "libhsa-runtime64.so",
+    "libamdhip64.so",
+    "libhiprtc.so",
+    "librocm-core.so",
+    "librocm_smi64.so",
+    "libroctx64.so",
+    "libroctracer64.so",
+    "librocblas.so",
+    "libhipblas.so",
+    "libhipblaslt.so",
+    "librocfft.so",
+    "libhipfft.so",
+    "librocrand.so",
+    "libhiprand.so",
+    "librocsolver.so",
+    "libhipsolver.so",
+    "librocsparse.so",
+    "libhipsparse.so",
+    "libhipsparselt.so",
+    "libMIOpen.so",
+    "librccl.so",
+]
+
+
+def _preload_rocm_deps() -> None:
+    """Preload TheRock ROCm runtime libs, the ROCm analogue of _preload_cuda_deps.
+
+    TheRock ships the ROCm runtime as the ``rocm`` pip package, unpacked to
+    ``<site-packages>/_rocm_sdk_core`` (a sibling of ``torch/``; the same layout
+    torch.utils.cpp_extension._find_rocm_home() keys off). Its runtime libs live
+    in ``_rocm_sdk_core/lib`` and the vendored OS-side "sysdeps" (libdrm, liblzma,
+    ... renamed to ``librocm_sysdeps_*.so``) live in
+    ``_rocm_sdk_core/lib/rocm_sysdeps/lib``. Neither dir is on the default loader
+    search path, so a wheel built against TheRock -- whose torch .so files carry
+    NEEDED entries such as ``librocm_sysdeps_liblzma.so.5`` and
+    ``libamdhip64.so`` -- is only importable when those dirs are reachable
+    (e.g. via LD_LIBRARY_PATH from /etc/rocm_env.sh). Preloading the libs here
+    (RTLD_GLOBAL, before ``import torch._C``) makes the wheel self-resolving
+    regardless of the environment, the same way _preload_cuda_deps handles the
+    nvidia-*-cu12 wheels. Because this lives in torch source it travels with any
+    build (bare ``setup.py`` / ``python -m build``), not just the CI script.
+
+    No-ops on non-Linux, on non-ROCm builds (``torch.version.hip is None`` covers
+    CUDA and CPU), and on OS-managed ROCm where ``_rocm_sdk_core`` is absent
+    (the apt/``/opt/rocm`` path, whose libs are already on the loader path).
+    """
+    if platform.system() != "Linux":
+        return
+
+    from torch.version import hip as hip_version
+
+    if hip_version is None:
+        return
+
+    import importlib.util
+
+    spec = importlib.util.find_spec("_rocm_sdk_core")
+    if spec is None or spec.origin is None:
+        return
+    root_lib = os.path.join(os.path.dirname(spec.origin), "lib")
+    sysdeps_lib = os.path.join(root_lib, "rocm_sysdeps", "lib")
+
+    def _preload(pattern: str) -> None:
+        # Best-effort: preload every match with RTLD_GLOBAL so its symbols/soname
+        # satisfy libtorch's NEEDED entries. A lib whose own deps are not yet
+        # resolvable just fails silently; preloading the rest still lets the
+        # loader resolve libtorch.
+        for sofile in sorted(glob.glob(pattern)):
+            try:
+                ctypes.CDLL(sofile, mode=ctypes.RTLD_GLOBAL)
+            except OSError:
+                pass
+
+    # sysdeps first: the core libs (and libtorch) depend on them.
+    _preload(os.path.join(sysdeps_lib, "librocm_sysdeps_*.so*"))
+    for base in _rocm_core_libs:
+        _preload(os.path.join(root_lib, base + "*"))
+
+
 # See Note [Global dependencies]
 def _load_global_deps() -> None:
     if platform.system() == "Windows":
@@ -391,6 +475,12 @@ def _load_global_deps() -> None:
     lib_name = f"libtorch_global_deps{lib_ext}"
     here = os.path.abspath(__file__)
     global_deps_lib_path = os.path.join(os.path.dirname(here), "lib", lib_name)
+
+    # TheRock ROCm wheels keep the runtime in _rocm_sdk_core, which is not on the
+    # loader search path; front-load it so libtorch_global_deps' NEEDED entries
+    # (and, further down, libtorch_hip's) resolve. No-ops for CUDA/CPU builds and
+    # for OS-managed ROCm. See _preload_rocm_deps.
+    _preload_rocm_deps()
 
     try:
         ctypes.CDLL(global_deps_lib_path, mode=ctypes.RTLD_GLOBAL)

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -11,7 +11,9 @@ It is lazily initialized, so you can always import it, and use
 :ref:`cuda-semantics` has more details about working with CUDA.
 """
 
+import glob
 import importlib
+import importlib.util
 import os
 import platform
 import threading
@@ -90,12 +92,37 @@ try:
                     paths = ["libamd_smi.so"]
                     if rocm_home := os.getenv("ROCM_HOME", os.getenv("ROCM_PATH")):
                         paths = [os.path.join(rocm_home, "lib/libamd_smi.so")] + paths
+                    # TheRock ROCm wheels install the amdsmi python package in
+                    # site-packages/amdsmi and ship the native library under the
+                    # _rocm_sdk_core wheel (site-packages/_rocm_sdk_core/lib)
+                    # rather than on the loader path or under $ROCM_HOME. The
+                    # file there is a versioned soname (e.g. libamd_smi.so.26),
+                    # so amdsmi's bare CDLL("libamd_smi.so") can't find it. Locate
+                    # the package and append the concrete versioned files as a
+                    # last-resort fallback so the hook can redirect to them.
+                    if platform.system() == "Linux":
+                        paths = paths + self._rocm_sdk_core_amdsmi_paths()
                     self.paths: list[str] = paths
+
+                @staticmethod
+                def _rocm_sdk_core_amdsmi_paths() -> list[str]:
+                    try:
+                        spec = importlib.util.find_spec("_rocm_sdk_core")
+                    except (ImportError, ValueError):
+                        return []
+                    if spec is None or not spec.submodule_search_locations:
+                        return []
+                    found: list[str] = []
+                    for location in spec.submodule_search_locations:
+                        found += glob.glob(
+                            os.path.join(location, "lib", "libamd_smi.so*")
+                        )
+                    return sorted(found)
 
                 def hooked_CDLL(
                     self, name: str | Path | None, *args: Any, **kwargs: Any
                 ) -> ctypes.CDLL:
-                    if name and Path(name).name == "libamd_smi.so":
+                    if name and Path(name).name.startswith("libamd_smi.so"):
                         for path in self.paths:
                             try:
                                 return self.original_CDLL(path, *args, **kwargs)
@@ -116,6 +143,17 @@ try:
             except ModuleNotFoundError as err:
                 _AMDSMI_ERR = err
                 raise
+            except (KeyError, OSError) as err:
+                # The amdsmi python package is installed but its native library
+                # (libamd_smi.so) could not be discovered/loaded -- e.g. TheRock
+                # ROCm wheels lay amdsmi out so that its own find_smi_library()
+                # misses the versioned libamd_smi.so.* and raises KeyError. Treat
+                # this like a missing optional dependency (degrade to
+                # _HAS_AMDSMI=False) instead of aborting `import torch`.
+                _AMDSMI_ERR = err
+                raise ModuleNotFoundError(
+                    "amdsmi is installed but libamd_smi.so could not be loaded"
+                ) from err
 
         _HAS_PYNVML = True
     except ModuleNotFoundError:


### PR DESCRIPTION
## Summary

This PR makes PyTorch ROCm/TheRock wheels **self-contained**: it fixes the two `import torch` failures that occur on the wheel (`_rocm_sdk_*` site-packages) layout, so `import torch` works without `LD_LIBRARY_PATH` or a sourced ROCm env (e.g. the ROCm distributed preflight `python .ci/pytorch/rocm_preflight.py`, which never sources `/etc/rocm_env.sh`).

Both fixes live in torch **source**, so they travel with any build (including a bare `python -m build` in a TheRock env), not just CI-produced wheels. This is the **minimal, consolidated PR** carrying **both** import-discovery fixes — a **two-file** diff (`torch/__init__.py` + `torch/cuda/__init__.py`).

Both changes are **no-ops on the traditional tarball `/opt/rocm` install**: each early-returns when the wheel package's `_rocm_sdk_core` is absent, so non-wheel ROCm CI (apt/`/opt/rocm`, whose libs are already on the loader path), CUDA, and CPU builds are unaffected.

## Fixes

### 1. `torch/__init__.py` — `_preload_rocm_deps()`

Fixes `ImportError: librocm_sysdeps_liblzma.so.5: cannot open shared object file` at `from torch._C import *`

- Adds `_preload_rocm_deps()`, the ROCm analogue of `_preload_cuda_deps()` (which handles the `nvidia-*-cu12` wheels). At import time, **before** `import torch._C`, it locates the `rocm` pip package's `_rocm_sdk_core` via `importlib.util.find_spec` (the same anchor `torch.utils.cpp_extension._find_rocm_home()` uses) and `ctypes.CDLL`-preloads (`RTLD_GLOBAL`) the vendored sysdeps (`librocm_sysdeps_*`) and core ROCm runtime libs from `_rocm_sdk_core/lib` and `_rocm_sdk_core/lib/rocm_sysdeps/lib`. Wired into `_load_global_deps()`.
- Guarded to no-op on non-Linux, on non-ROCm builds (`torch.version.hip is None` → CUDA/CPU), and on OS-managed ROCm where `_rocm_sdk_core` is absent (the apt/`/opt/rocm` path).

### 2. `torch/cuda/__init__.py` — amdsmi / `libamd_smi.so` discovery hook + non-fatal guard

Fixes the *next* failure that surfaces once `_preload_rocm_deps()` gets `import torch` past the `librocm_sysdeps` error: `KeyError: 'libamd_smi.so'` raised from the `amdsmi` Python binding at `import amdsmi` (inside `_C._initExtension`)

On TheRock wheels the amdsmi package installs the native library as a versioned soname under `_rocm_sdk_core/lib` (e.g. `libamd_smi.so.26`), which amdsmi's own `find_smi_library()` fails to locate when `$ROCM_HOME`/`$ROCM_PATH` and the loader path are unset; its wrapper then does `_libraries['libamd_smi.so']` → `KeyError`, which escaped the existing guard (only `ModuleNotFoundError` was tolerated) and killed `import torch`. Two-part torch-side hardening:

- Make `_amdsmi_cdll_hook` **TheRock-aware**: locate `_rocm_sdk_core` via `importlib.util.find_spec` and add its `lib/libamd_smi.so*` (glob, incl. versioned sonames) as last-resort candidate paths; match names whose basename **starts with** `libamd_smi.so` so amdsmi's bare `CDLL("libamd_smi.so")` is redirected to the real versioned file. Existing `ROCM_HOME`/`ROCM_PATH` behavior preserved; guarded to Linux.
- Make a non-discoverable amdsmi **non-fatal**: broaden the guard so `KeyError`/`OSError` degrade to `_HAS_AMDSMI=False` instead of aborting `import torch`, matching the existing missing-module path.

## Consolidation note

The amdsmi discovery fix (#2 above) originally shipped as standalone PR #188724. That PR has been **closed** and folded into this PR so **both** import-discovery fixes travel together in a single minimal two-file change.

Scope note: the TheRock tarball→wheels migration and the earlier CI-only RPATH/ldconfig workarounds are **not** part of this PR. The wheels migration is tracked separately by #188429, which rebases on top of this change.

## Validation (TheRock wheel path) — PASSED

Validated end-to-end by **temporarily** stacking Ethan's wheels-migration PR #188429 (which adds the `rocm-preview` wheel CI) on top of the two source fixes and running `ciflow/rocm-preview` (run [28581558341](https://github.com/pytorch/pytorch/actions/runs/28581558341)) on the stacked head. The temporary stack was then **removed**, so this PR remains the minimal two-file source diff.

- **`build-osdc` (TheRock wheel-path build): SUCCESS** — [job 84742887851](https://github.com/pytorch/pytorch/actions/runs/28581558341/job/84742887851).
- **`import torch` works on the `_rocm_sdk_*` wheel layout** — proven by the passing shard [`test (default, 5/6)` job 84772673709](https://github.com/pytorch/pytorch/actions/runs/28581558341/job/84772673709), which imports torch and prints the HIP 7.14 / MIOpen 3.5.2 build config.
- **No** `ImportError: librocm_sysdeps*` (incl. `librocm_sysdeps_liblzma`) and **no** `KeyError: 'libamd_smi.so'` anywhere in the run → **both** fixes are validated on the **real TheRock wheel path**.
- Remaining rocm-preview shard failures were **unrelated** to this PR — test-content failures (`test_CTCLoss_cudnn_cuda`, `test_cxx_flags` `RuntimeError map::at`, `test_hip_device_count`, `test_lazy_imports_are_lazy`) and infra (`ROCm pre-flight: no GPUs visible to the container` on the distributed shards).
- Run: https://github.com/pytorch/pytorch/actions/runs/28581558341

### rocm-preview distributed shards (register fat binary failed)

Reference/evidence for the `register fat binary failed` (`code_object.cpp:1038`) investigation — the rocm-preview (TheRock wheel-path) distributed shards from run [28581558341](https://github.com/pytorch/pytorch/actions/runs/28581558341) (`linux-noble-rocm-preview-py3.12-gfx942`), all FAILED:

- distributed 1/3: https://github.com/pytorch/pytorch/actions/runs/28581558341/job/84772673683 (`test (distributed, 1, 3, linux.rocm.gpu.gfx942.4, module:rocm, oncall:distributed)`)
- distributed 2/3: https://github.com/pytorch/pytorch/actions/runs/28581558341/job/84772673678 (`test (distributed, 2, 3, linux.rocm.gpu.gfx942.4, module:rocm, oncall:distributed)`)
- distributed 3/3: https://github.com/pytorch/pytorch/actions/runs/28581558341/job/84772673727 (`test (distributed, 3, 3, linux.rocm.gpu.gfx942.4, module:rocm, oncall:distributed)`)

<details>
<summary>Failure log the amdsmi fix addresses (pre-fix, run 28524549808)</summary>

```
/var/lib/jenkins/workspace/libamd_smi.so: cannot open shared object file: No such file or directory
Unable to find libamd_smi.so library try installing amd-smi-lib from your package manager
Traceback (most recent call last):
  File "/var/lib/jenkins/workspace/.ci/pytorch/rocm_preflight.py", line 21, in <module>
    import torch
  File ".../site-packages/torch/cuda/__init__.py", line 114, in <module>
    import amdsmi  # type: ignore[import]
  File ".../site-packages/amdsmi/amdsmi_wrapper.py", line 218, in <module>
    amdsmi_free_name_value_pairs = _libraries['libamd_smi.so'].amdsmi_free_name_value_pairs
KeyError: 'libamd_smi.so'
```

</details>

## Notes: amdsmi discovery + fat-binary logs

- **Bare `CDLL("libamd_smi.so")`** comes from amdsmi's own `find_smi_library()` (unversioned candidate), not torch; torch's `_amdsmi_cdll_hook` intercepts it and retries the versioned `_rocm_sdk_core/lib/libamd_smi.so*`.
- **Not just preload amdsmi via `_rocm_core_libs`:** amdsmi resolves by exact filename, so an RTLD_GLOBAL versioned `libamd_smi.so.26` won't satisfy it, and eager-preloading a non-`DT_NEEDED` lib reintroduces the ODR double-load the hook prevents — the CDLL-redirect hook is the correct fix.
- **`E0702 … code_object.cpp:1038 register fat binary failed` is not caused by this PR:** it's emitted by the HIP/clr C++ runtime, appears ambiently (~4,774×/run across rocm-preview gfx942 jobs incl. the distributed shards above), and is non-fatal — a pre-existing TheRock rocm-preview build/toolchain matter, orthogonal to these two Python-only changes.
- **Fix-plan pointer (fat-binary):** prove pre-existing on a PR-free `main` rocm-preview baseline → localize via `AMD_LOG_LEVEL=3/4` → scoped clr-log suppress/demote (escalate to clr/comgr pin or `PYTORCH_ROCM_ARCH` only on a real running-arch failure) → validate via `ciflow/rocm-preview`. Belongs in the build/CI layer, not torch source. Tracked in ROCm/frameworks-internal #17160.

## Test plan

- [x] Validate on the TheRock wheel path via `ciflow/rocm-preview` (see **Validation** above).
- [x] `ast.parse` both changed files (`torch/__init__.py`, `torch/cuda/__init__.py`).
- [x] Confirm CUDA and CPU builds are unaffected (both fixes no-op when `torch.version.hip is None` / `_rocm_sdk_core` absent).

Fixes #188561

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang

Made with Cursor


