### PR TITLE
[PU1] Add output_size parameter to torch.bincount for eager-meta support.

### DIFF
--- a/aten/src/ATen/native/SummaryOps.cpp
+++ b/aten/src/ATen/native/SummaryOps.cpp
@@ -20,15 +20,30 @@ namespace at::native {
 ///////////////// bincount /////////////////
 namespace {
 
+static void check_bincount_output_size(
+    std::optional<int64_t> output_size,
+    int64_t nbins) {
+  if (output_size) {
+    TORCH_CHECK(
+        *output_size == nbins,
+        "bincount: Invalid output_size, expected ",
+        nbins,
+        " but got ",
+        *output_size);
+  }
+}
+
 template <typename input_t, typename weights_t>
 Tensor _bincount_cpu_template(
     const Tensor& self,
     const Tensor& weights,
-    int64_t minlength) {
+    int64_t minlength,
+    std::optional<int64_t> output_size) {
   if (minlength < 0) {
     TORCH_CHECK(false, "minlength should be >= 0");
   }
   if (self.dim() == 1 && self.numel() == 0) {
+    check_bincount_output_size(output_size, minlength);
     return at::zeros({minlength}, kLong);
   }
   if (self.dim() != 1 || *self.min().const_data_ptr<input_t>() < 0) {
@@ -55,6 +70,7 @@ Tensor _bincount_cpu_template(
   int64_t self_size = self.size(0);
   int64_t nbins = static_cast<int64_t>(max_val) + 1L;
   nbins = std::max(nbins, minlength); // at least minlength # of bins
+  check_bincount_output_size(output_size, nbins);
 
   const input_t* self_p = self.const_data_ptr<input_t>();
   if (has_weights) {
@@ -81,7 +97,7 @@ Tensor _bincount_cpu_template(
 } // namespace
 
 Tensor
-_bincount_cpu(const Tensor& self, const std::optional<Tensor>& weights_opt, int64_t minlength) {
+_bincount_cpu(const Tensor& self, const std::optional<Tensor>& weights_opt, int64_t minlength, std::optional<int64_t> output_size) {
   // See [Note: hacky wrapper removal for optional tensor]
   c10::MaybeOwned<Tensor> weights_maybe_owned = at::borrow_from_optional_tensor(weights_opt);
   const Tensor& weights = *weights_maybe_owned;
@@ -89,9 +105,9 @@ _bincount_cpu(const Tensor& self, const std::optional<Tensor>& weights_opt, int6
   return AT_DISPATCH_INTEGRAL_TYPES(self.scalar_type(), "bincount_cpu", [&] {
     const auto scalar = weights.scalar_type();
     if (scalar == ScalarType::Undefined || scalar == ScalarType::Float)
-      return _bincount_cpu_template<scalar_t, float>(self.contiguous(), weights.contiguous(), minlength);
+      return _bincount_cpu_template<scalar_t, float>(self.contiguous(), weights.contiguous(), minlength, output_size);
     return _bincount_cpu_template<scalar_t, double>(
-        self.contiguous(), weights.contiguous().to(kDouble), minlength);
+        self.contiguous(), weights.contiguous().to(kDouble), minlength, output_size);
   });
 }
 

--- a/aten/src/ATen/native/cuda/SummaryOps.cu
+++ b/aten/src/ATen/native/cuda/SummaryOps.cu
@@ -246,16 +246,32 @@ bool CUDA_tensor_histogram(
 } // namespace cuda
 
 namespace {
+
+static void check_bincount_output_size(
+    std::optional<int64_t> output_size,
+    int64_t nbins) {
+  if (output_size) {
+    TORCH_CHECK(
+        *output_size == nbins,
+        "bincount: Invalid output_size, expected ",
+        nbins,
+        " but got ",
+        *output_size);
+  }
+}
+
 ///////////////// bincount /////////////////
 template <typename input_t, typename weights_t>
 Tensor _bincount_cuda_template(
     const Tensor& self,
     const Tensor& weights,
-    int64_t minlength) {
+    int64_t minlength,
+    std::optional<int64_t> output_size) {
   if (minlength < 0) {
     TORCH_CHECK(false, "minlength should be >= 0");
   }
   if (self.dim() == 1 && self.numel() == 0) {
+    check_bincount_output_size(output_size, minlength);
     return at::zeros(
         {minlength},
         kLong,
@@ -278,6 +294,7 @@ Tensor _bincount_cuda_template(
 
   const int64_t nbins =
       std::max(self_max.item<input_t>() + (int64_t)1, minlength);
+  check_bincount_output_size(output_size, nbins);
 
   // we are using acc_type for the bounds, in particular int64_t for integers
   // in order to avoid overflows (e.g. using 256 bins for dtype uint8)
@@ -380,7 +397,7 @@ Tensor _histc_cuda_template(
 namespace native {
 Tensor _bincount_cuda(
     const Tensor& self, const std::optional<Tensor>& weights_opt,
-    int64_t minlength) {
+    int64_t minlength, std::optional<int64_t> output_size) {
   // See [Note: hacky wrapper removal for optional tensor]
   c10::MaybeOwned<Tensor> weights_maybe_owned = at::borrow_from_optional_tensor(weights_opt);
   const Tensor& weights = *weights_maybe_owned;
@@ -394,9 +411,9 @@ Tensor _bincount_cuda(
   return AT_DISPATCH_INTEGRAL_TYPES(self.scalar_type(), "bincount_cuda", [&] {
     const auto scalar = weights.scalar_type();
     if (scalar == ScalarType::Undefined || scalar == ScalarType::Float)
-      return _bincount_cuda_template<scalar_t, float>(self, weights, minlength);
+      return _bincount_cuda_template<scalar_t, float>(self, weights, minlength, output_size);
     return _bincount_cuda_template<scalar_t, double>(
-        self, weights.to(kDouble), minlength);
+        self, weights.to(kDouble), minlength, output_size);
   });
 }
 

--- a/aten/src/ATen/native/mps/operations/SummaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/SummaryOps.mm
@@ -77,7 +77,20 @@ static Tensor& bincount_mps_impl(const Tensor& self, const Tensor& weights, Tens
   return output;
 }
 
-Tensor _bincount_mps(const Tensor& self, const std::optional<Tensor>& weights_opt, int64_t minlength) {
+static void check_bincount_output_size(
+    std::optional<int64_t> output_size,
+    int64_t nbins) {
+  if (output_size) {
+    TORCH_CHECK(
+        *output_size == nbins,
+        "bincount: Invalid output_size, expected ",
+        nbins,
+        " but got ",
+        *output_size);
+  }
+}
+
+Tensor _bincount_mps(const Tensor& self, const std::optional<Tensor>& weights_opt, int64_t minlength, std::optional<int64_t> output_size) {
   // See [Note: hacky wrapper removal for optional tensor]
   c10::MaybeOwned<Tensor> weights_maybe_owned = at::borrow_from_optional_tensor(weights_opt);
   const Tensor& weights = *weights_maybe_owned;
@@ -86,6 +99,7 @@ Tensor _bincount_mps(const Tensor& self, const std::optional<Tensor>& weights_op
   TORCH_CHECK(minlength >= 0, "minlength should be >= 0");
 
   if (self.dim() == 1 && self.numel() == 0) {
+    check_bincount_output_size(output_size, minlength);
     return at::zeros({minlength}, kLong, std::nullopt /* layout */, kMPS, std::nullopt /* pin_memory */);
   }
   TORCH_CHECK(self.dim() == 1 && self.min().item<int64_t>() >= 0,
@@ -96,6 +110,7 @@ Tensor _bincount_mps(const Tensor& self, const std::optional<Tensor>& weights_op
               "weights should be 1-d and have the same length as input");
 
   const int64_t nbins = std::max(self.max().item<int64_t>() + 1L, minlength);
+  check_bincount_output_size(output_size, nbins);
   Tensor output;
 
   Tensor weights_ = weights;

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1185,7 +1185,7 @@
     CompositeExplicitAutograd: binary_cross_entropy_with_logits
   autogen: binary_cross_entropy_with_logits.out
 
-- func: bincount(Tensor self, Tensor? weights=None, SymInt minlength=0) -> Tensor
+- func: bincount(Tensor self, Tensor? weights=None, SymInt minlength=0, *, SymInt? output_size=None) -> Tensor
   variants: function, method
   dispatch:
     CPU: _bincount_cpu

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -2239,6 +2239,25 @@ assert not torch.cuda.is_initialized()
         self.assertEqual(fake_inverse.shape, x.shape)
         self.assertTrue(free_unbacked_symbols(fake_unique.shape[0]))
 
+    def test_bincount_explicit_output_size(self):
+        x = torch.tensor([0, 1, 1, 3, 2, 4], dtype=torch.int64)
+
+        with FakeTensorMode() as mode:
+            fake_x = mode.from_tensor(x)
+            fake_result = torch.bincount(fake_x, output_size=5)
+
+        self.assertEqual(fake_result.dtype, torch.long)
+        self.assertEqual(fake_result.shape, torch.Size([5]))
+
+        weights = torch.tensor([0.5, 1.0, 1.5, 2.0, 2.5, 3.0])
+        with FakeTensorMode() as mode:
+            fake_x = mode.from_tensor(x)
+            fake_w = mode.from_tensor(weights)
+            fake_result_w = torch.bincount(fake_x, weights=fake_w, output_size=5)
+
+        self.assertEqual(fake_result_w.dtype, torch.float32)
+        self.assertEqual(fake_result_w.shape, torch.Size([5]))
+
     def test_select_out_of_bounds(self):
         with FakeTensorMode():
             x = torch.randn(3, 4)

--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -2158,6 +2158,24 @@ class TestMetaKernelRegistrations(TestCase):
         self.assertEqual(cpu_result.dtype, meta_result.dtype)
 
     @skipIfTorchDynamo("tests raw meta kernel, not dynamo")
+    def test_bincount_output_size(self):
+        input_meta = torch.empty(5, dtype=torch.int64, device="meta")
+
+        with self.assertRaisesRegex(
+            RuntimeError, "cannot bincount a meta tensor without output_size"
+        ):
+            torch.bincount(input_meta)
+
+        meta_result = torch.bincount(input_meta, output_size=8)
+        self.assertEqual(meta_result.shape, torch.Size([8]))
+        self.assertEqual(meta_result.dtype, torch.long)
+
+        weights_meta = torch.empty(5, dtype=torch.float32, device="meta")
+        meta_result_w = torch.bincount(input_meta, weights=weights_meta, output_size=8)
+        self.assertEqual(meta_result_w.shape, torch.Size([8]))
+        self.assertEqual(meta_result_w.dtype, torch.float32)
+
+    @skipIfTorchDynamo("tests raw meta kernel, not dynamo")
     def test_segment_reduce_batched_shape(self):
         # axis=1 with 2D lengths exercises the shape fix (using data.shape
         # as base instead of lengths.shape). CPU segfaults for this case

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3824,6 +3824,36 @@ class TestTorchDeviceType(TestCase):
         a_masked = a.masked_select(mask_copy_3_times)
         self.assertEqual(a_masked, a.unsqueeze(0).expand(3, 100).flatten())
 
+    def test_bincount_output_size(self, device):
+        input = torch.tensor([0, 1, 1, 3, 2, 4], dtype=torch.int64, device=device)
+        expected = torch.tensor([1, 2, 1, 1, 1], dtype=torch.long, device=device)
+
+        self.assertEqual(torch.bincount(input, output_size=5), expected)
+        self.assertEqual(input.bincount(output_size=5), expected)
+
+        weights = torch.tensor([0.5, 1.0, 1.5, 2.0, 2.5, 3.0], device=device)
+        expected_w = torch.tensor([0.5, 2.5, 2.5, 2.0, 3.0], device=device)
+        self.assertEqual(torch.bincount(input, weights=weights, output_size=5), expected_w)
+
+        with self.assertRaisesRegex(RuntimeError, "bincount: Invalid output_size"):
+            torch.bincount(input, output_size=3)
+
+        # minlength extends the output beyond max(input)+1
+        result_ml = torch.bincount(input, minlength=10, output_size=10)
+        self.assertEqual(result_ml.shape, torch.Size([10]))
+        self.assertEqual(result_ml[:5], expected)
+        self.assertEqual(result_ml[5:], torch.zeros(5, dtype=torch.long, device=device))
+
+        with self.assertRaisesRegex(RuntimeError, "bincount: Invalid output_size"):
+            torch.bincount(input, minlength=10, output_size=5)
+
+        # empty input: nbins == minlength
+        empty = torch.tensor([], dtype=torch.int64, device=device)
+        self.assertEqual(torch.bincount(empty, minlength=4, output_size=4), torch.zeros(4, dtype=torch.long, device=device))
+
+        with self.assertRaisesRegex(RuntimeError, "bincount: Invalid output_size"):
+            torch.bincount(empty, minlength=4, output_size=2)
+
     # FIXME: find a test suite for the masked select operator
     def test_masked_select_discontiguous(self, device):
         for size in (10, 200):

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -3746,6 +3746,19 @@ def meta_repeat_interleave_Tensor(repeats, output_size=None):
     return repeats.new_empty(output_size)
 
 
+@register_meta([aten.bincount.default, aten.bincount.out])
+@out_wrapper()
+def meta_bincount(self, weights=None, minlength=0, *, output_size=None):
+    if output_size is None:
+        raise RuntimeError("cannot bincount a meta tensor without output_size")
+    if weights is None:
+        return self.new_empty((output_size,), dtype=torch.long)
+    elif weights.dtype == torch.float32:
+        return self.new_empty((output_size,), dtype=torch.float32)
+    else:
+        return self.new_empty((output_size,), dtype=torch.float64)
+
+
 @register_meta([aten.complex.default, aten.complex.out])
 @out_wrapper()
 def meta_complex(real, imag):

--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -1901,12 +1901,21 @@ def bincount(
     inputs: FakeTensor,
     weights: FakeTensor | None = None,
     minlength: IntLikeType = 0,
+    *,
+    output_size: IntLikeType | None = None,
 ) -> FakeTensor:
+    if output_size is not None:
+        if weights is None:
+            return inputs.new_empty(output_size, dtype=torch.long)  # type: ignore[return]
+        elif weights.dtype == torch.float32:
+            return inputs.new_empty(output_size, dtype=torch.float32)  # type: ignore[return]
+        else:
+            return inputs.new_empty(output_size, dtype=torch.float64)  # type: ignore[return]
+
     if (
         fake_mode.shape_env is None
         or not fake_mode.shape_env.allow_dynamic_output_shape_ops
     ):
-        # Without symints/symfloats, cannot handle this
         raise DynamicOutputShapeException(func)
 
     new_size = fake_mode.shape_env.create_unbacked_symint()

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1493,7 +1493,7 @@ Example::
 add_docstr(
     torch.bincount,
     r"""
-bincount(input, weights=None, minlength=0) -> Tensor
+bincount(input, weights=None, minlength=0, *, output_size=None) -> Tensor
 
 Count the frequency of each value in an array of non-negative ints.
 
@@ -1513,6 +1513,13 @@ Arguments:
     weights (Tensor): optional, weight for each value in the input tensor.
         Should be of same size as input tensor.
     minlength (int): optional, minimum number of bins. Should be non-negative.
+
+Keyword args:
+    output_size (int, optional): the expected number of output bins.
+        Must equal ``max(input) + 1`` (or :attr:`minlength`, whichever
+        is larger). A :class:`RuntimeError` is raised on mismatch.
+        Required when running on a meta-device tensor, where the
+        data-dependent bin count cannot be inferred.
 
 Returns:
     output (Tensor): a tensor of shape ``Size([max(input) + 1])`` if

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -505,7 +505,7 @@ def get_testing_overrides() -> dict[Callable, Callable]:
         torch.binary_cross_entropy_with_logits: (
             lambda input, target, weight=None, size_average=None, reduce=None, reduction="mean", pos_weight=None: -1
         ),
-        torch.bincount: lambda input, weights=None, minlength=0: -1,
+        torch.bincount: lambda input, weights=None, minlength=0, *, output_size=None: -1,
         torch.binomial: lambda count, prob, generator=None: -1,
         torch.bitwise_and: lambda input, other, out=None: -1,
         torch.bitwise_not: lambda input, out=None: -1,


### PR DESCRIPTION
OOT accelerators that use device="meta" as an eager shape oracle cannot run bincount on meta tensors because the output size depends on max(input), which is unavailable without real data. This adds an optional output_size keyword argument that lets callers specify the expected number of bins explicitly, following the same pattern already established by repeat_interleave(output_size=...) and nonzero_static(size=...).

When output_size is omitted, behavior is unchanged. When provided on a real tensor it is validated against the actual bin count; when provided on a meta tensor it is used directly as the output shape.

Part of #188370.