### PR TITLE
[spmd_types] infer R@FSDP axes from active mesh for empty params

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_spmd_types.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_spmd_types.py
@@ -232,6 +232,47 @@ class TestFullyShardSpmdTypes(TestCase):
                     2,
                 )
 
+    def test_active_spmd_mesh_infers_unannotated_fsdp_axes(self):
+        class DpCpLinear(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = nn.Parameter(torch.randn(16, 16))
+                self.compute_param_type = None
+
+            def forward(self, x):
+                self.compute_param_type = dict(spmd.get_local_type(self.weight))
+                return (x @ self.weight).sum()
+
+        model = DpCpLinear()
+        dp_cp_mesh = self.dense_type_mesh["dp", "cp"]
+
+        with spmd.set_current_mesh(dp_cp_mesh):
+            fully_shard(
+                model,
+                mesh=dp_cp_mesh,
+                dp_mesh_dims=DataParallelMeshDims(shard=("dp", "cp")),
+            )
+
+        inp = torch.randn(4, 8, 16, requires_grad=True)
+        with (
+            spmd.set_current_mesh(dp_cp_mesh),
+            typecheck(strict_mode="strict", local=False),
+        ):
+            spmd.assert_type(
+                inp,
+                {"dp": spmd.V, "cp": spmd.V},
+                partition_spec=spmd.PartitionSpec("dp", "cp", None),
+            )
+            loss = model(inp)
+            self.assertEqual(
+                dict(spmd.get_local_type(loss)),
+                {self.dp_axis: spmd.P, self.cp_axis: spmd.P},
+            )
+        self.assertEqual(
+            model.compute_param_type,
+            {self.dp_axis: spmd.R, self.cp_axis: spmd.R},
+        )
+
     def test_full_param_annotations_do_not_require_init_compute_mesh(self):
         """Full per-axis annotations are enough without an init compute mesh."""
         model = SpmdLinear(self.dense_type_mesh, seq_parallel=False)

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
@@ -291,8 +291,11 @@ class FSDPParam:
         # this remains true even if spmd typechecking is disabled at runtime.
         self.is_spmd_types = (
             dist._is_spmd_types_available()
-            and bool(spmd_local_type := spmd.get_local_type(param))
             and not isinstance(param, DTensor)
+            and (
+                bool(spmd_local_type := spmd.get_local_type(param))
+                or spmd.current_mesh() is not None
+            )
         )
         if self.is_spmd_types:
             param = self._resolve_spmd_types_for_storage(

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -1143,6 +1143,20 @@ class RegisterPostBackwardFunction(torch.autograd.Function):
         return inputs
 
     @staticmethod
+    def typecheck_forward(param_group: FSDPParamGroup, *inputs: torch.Tensor):
+        import spmd_types
+        from spmd_types.runtime import get_partition_spec
+
+        outputs = RegisterPostBackwardFunction.apply(param_group, *inputs)
+        for output, input in zip(outputs, inputs):
+            spmd_types.assert_type(
+                output,
+                dict(spmd_types.get_local_type(input)),
+                partition_spec=get_partition_spec(input),
+            )
+        return outputs
+
+    @staticmethod
     def setup_context(ctx, inputs: tuple[Any, ...], output: Any) -> None:
         param_group, *_ = inputs
         ctx.param_group = param_group
@@ -1167,4 +1181,4 @@ class RegisterPostBackwardFunction(torch.autograd.Function):
 if dist._is_spmd_types_available():
     import spmd_types
 
-    spmd_types.register_local_autograd_function(RegisterPostBackwardFunction)
+    spmd_types.register_autograd_function(RegisterPostBackwardFunction)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #188464

https://github.com/pytorch/pytorch/pull/181519 added the ability to infer missing DP/CP axes spmd type annotations. However, it only supported the case where the param was partially annotated (e.g. TP-only), and not the empty annotation case.

We encountered this in TorchTitan FLUX, which only supports FSDP & CP. To support, we extend the "is spmd_types" branch in FSDP to check if an active current mesh exists, so we can do:
```
with spmd.current_mesh(dp ,cp):
    fully_shard(...)  # with completely unannotated plain parameters
```

Hopefully this is not a footgun?