### PR TITLE
Fix inductor scatter crash with empty index

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -8196,6 +8196,18 @@ for dtype in (torch.int32, torch.int64):
 
         self.common(fn, (value, mask, source))
 
+    def test_scatter_empty_index(self):
+        def fn(x):
+            m = torch.nn.AdaptiveMaxPool1d((0,), return_indices=False).eval()
+            y = torch.special.ndtri(x)
+            empty_tensor = m(y)
+            result = torch.scatter(empty_tensor, -1, empty_tensor, empty_tensor)
+            result = torch.nn.functional.hardswish(result, inplace=False)
+            return result
+
+        x = torch.rand([4, 8], dtype=torch.float32, device=self.device)
+        self.common(fn, (x,))
+
     def test_fill1(self):
         def fn(x):
             tmp = torch.ones_like(x)

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -8199,8 +8199,7 @@ for dtype in (torch.int32, torch.int64):
     def test_scatter_empty_index(self):
         def fn(x):
             m = torch.nn.AdaptiveMaxPool1d((0,), return_indices=False).eval()
-            y = torch.special.ndtri(x)
-            empty_tensor = m(y)
+            empty_tensor = m(x)
             result = torch.scatter(empty_tensor, -1, empty_tensor, empty_tensor)
             result = torch.nn.functional.hardswish(result, inplace=False)
             return result

--- a/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
@@ -134,6 +134,9 @@ test_failures = {
     "test_cat_empty_1d_negative_dim_zero_output_dynamic_shapes": TestFailure(
         ("cpu", "cuda", "xpu"), is_skip=True
     ),
+    "test_scatter_empty_index_dynamic_shapes": TestFailure(
+        ("cpu", "cuda", "xpu"), is_skip=True
+    ),
     #
     # Failed to find dynamic for loop variable:
     #

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -5197,8 +5197,6 @@ def scatter_reduce_(self, dim: int, index, src, reduce, *, include_self: bool = 
 
     if not (isinstance(self, TensorBox)):
         raise AssertionError("expected: isinstance(self, TensorBox)")
-    if "int" not in str(index.get_dtype()):
-        raise AssertionError('expected: "int" in str(index.get_dtype())')
 
     ndim = len(self.get_size())
     if ndim == 0:
@@ -5212,6 +5210,9 @@ def scatter_reduce_(self, dim: int, index, src, reduce, *, include_self: bool = 
 
     if index.get_numel() == 0:
         return self
+
+    if "int" not in str(index.get_dtype()):
+        raise AssertionError('expected: "int" in str(index.get_dtype())')
 
     dim = _validate_dim(self, dim)
 


### PR DESCRIPTION
Fixes #188213 
Fixes inductor scatter crash when scatter receives empty index tensors by moving dtype validation after the empty-check, which matches eager mode's early return behavior for zero-element indices  

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo