### PR TITLE
[inductor] Bucket all_reduce in the manual overlap scheduler

### DIFF
--- a/test/distributed/test_aten_comm_compute_reordering.py
+++ b/test/distributed/test_aten_comm_compute_reordering.py
@@ -1462,22 +1462,26 @@ def apply_manual_reordering_and_get_graph(
     )
 
     for node in list(gm.graph.nodes):
-        # Handle both all-gather and reduce-scatter nodes for module_1
+        # Handle all-gather, reduce-scatter, and all-reduce nodes for module_1
         if node.name in (
             "all_gather_into_tensor",
             "all_gather_into_tensor_1",
             "reduce_scatter_tensor",
             "reduce_scatter_tensor_1",
+            "all_reduce",
+            "all_reduce_1",
             "wait_tensor",
             "wait_tensor_1",
         ):
             node.meta["nn_module_stack"] = {"test": ["module_1", ""]}
-        # Handle both all-gather and reduce-scatter nodes for module_2
+        # Handle all-gather, reduce-scatter, and all-reduce nodes for module_2
         if node.name in (
             "all_gather_into_tensor_2",
             "all_gather_into_tensor_3",
             "reduce_scatter_tensor_2",
             "reduce_scatter_tensor_3",
+            "all_reduce_2",
+            "all_reduce_3",
             "wait_tensor_2",
             "wait_tensor_3",
         ):
@@ -1567,6 +1571,63 @@ class TestManualOverlapBucketing(TestComputeCommReorderingMultiProc):
             return rs1, rs2, rs3, rs4
 
         return func
+
+    def _get_all_reduce_test_func(self):
+        """Return the all-reduce test function used by bucketing tests.
+
+        All-reduce is the HSDP replicate-axis / DDP gradient sync. As with the
+        reduce-scatter case the waits are returned directly as outputs so the
+        manual bucketer can pair each launch with its wait.
+        """
+
+        def func(a, b, c, d):
+            # All 4 all-reduces are independent - COULD be bucketed together
+            ar1 = _functional_collectives.all_reduce(a, "sum", "0")
+            ar2 = _functional_collectives.all_reduce(b, "sum", "0")
+            ar3 = _functional_collectives.all_reduce(c, "sum", "0")
+            ar4 = _functional_collectives.all_reduce(d, "sum", "0")
+
+            # Return all-reduce results directly as outputs (DDP gradient pattern)
+            return ar1, ar2, ar3, ar4
+
+        return func
+
+    def _run_all_reduce_bucketing_test(
+        self, module_bucket_plans, expected_num_all_reduce
+    ):
+        """Bucket independent all-reduces per ``module_bucket_plans`` and assert
+        the surviving all-reduce count plus numerical equivalence."""
+        with _dynamo_dist_per_rank_init(
+            self.rank,
+            self.world_size,
+            self.backend(device_type),
+            fake_pg=not at_least_x_gpu(2),
+        ):
+            a = torch.ones(8, 8, dtype=torch.float, device=device_type)
+            b = torch.ones(8, 8, dtype=torch.float, device=device_type) * 2
+            c = torch.ones(8, 8, dtype=torch.float, device=device_type) * 3
+            d = torch.ones(8, 8, dtype=torch.float, device=device_type) * 4
+
+            func = self._get_all_reduce_test_func()
+            compiled = torch.compile(func)
+            out, aten_graph = run_and_get_manual_aten_graph(
+                compiled, module_bucket_plans, a, b, c, d
+            )
+
+            # Bucketed all-reduces are emitted as the in-place
+            # ``all_reduce_`` op (operating on the cat buffer); unbucketed
+            # ones stay as the functional ``all_reduce``. Count both forms.
+            all_reduce_targets = (
+                torch.ops._c10d_functional.all_reduce.default,
+                torch.ops._c10d_functional.all_reduce_.default,
+            )
+            num_all_reduce = sum(
+                1
+                for node in aten_graph.nodes
+                if node.op == "call_function" and node.target in all_reduce_targets
+            )
+            self.assertEqual(num_all_reduce, expected_num_all_reduce)
+            self.assertTrue(same(out, func(a, b, c, d)))
 
     def _run_manual_bucketing_test(
         self,
@@ -1937,6 +1998,30 @@ class TestManualOverlapBucketing(TestComputeCommReorderingMultiProc):
                 "wait_tensor_2",
                 "wait_tensor_3",
             ],
+        )
+
+    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+    def test_manual_bucketing_reordering_pass_all_reduce_separate_buckets(self):
+        # One bucket per module: 4 all-reduces collapse to 2 (one per module).
+        self._run_all_reduce_bucketing_test(
+            module_bucket_plans=["module_1", "module_2"],
+            expected_num_all_reduce=2,
+        )
+
+    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+    def test_manual_bucketing_reordering_pass_all_reduce_single_bucket(self):
+        # Both modules in one bucket: 4 all-reduces collapse to 1.
+        self._run_all_reduce_bucketing_test(
+            module_bucket_plans=[["module_1", "module_2"]],
+            expected_num_all_reduce=1,
+        )
+
+    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+    def test_manual_bucketing_reordering_pass_all_reduce_no_bucket(self):
+        # Empty plan: all 4 all-reduces remain unbucketed.
+        self._run_all_reduce_bucketing_test(
+            module_bucket_plans=[],
+            expected_num_all_reduce=4,
         )
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")

--- a/test/distributed/test_overlap_bucketing_unit.py
+++ b/test/distributed/test_overlap_bucketing_unit.py
@@ -469,6 +469,82 @@ class TestOverlapPreservingBucketing(InductorTestCase):
             "split_with_sizes"
         ).check_count("%mm", 2).run(graph_str)
 
+    def test_manual_bucket_splits_dependent_all_reduce(self):
+        """Bucketing must split dependent same-key all_reduces, not fuse them.
+
+        Reproduces the loss-parallel cross-entropy pattern with two independent
+        chunks: a "sumexp" all_reduce whose result feeds a "result" all_reduce.
+        All four are sum/same-group/same-dtype (one bucket key), but fusing a
+        sumexp with its dependent result would make the merged collective's
+        input depend on its own output -- a cycle that failed region
+        topological sort ("stable topological sort of region failed").
+
+        Correct partitioning fuses the two independent sumexps into one bucket
+        and the two independent results into another, so four all_reduces
+        collapse to exactly two bucketed all_reduces (via two cats), no cycle.
+        """
+
+        def func(a, b, c, d):
+            group_name = "0"
+            ar = torch.ops._c10d_functional.all_reduce
+            wait = torch.ops._c10d_functional.wait_tensor
+            sumexp0 = wait(ar(a, "sum", group_name))
+            sumexp1 = wait(ar(b, "sum", group_name))
+            result0 = wait(ar(sumexp0 + c, "sum", group_name))
+            result1 = wait(ar(sumexp1 + d, "sum", group_name))
+            return result0.sum() + result1.sum()
+
+        with FakeTensorMode():
+            a = torch.ones(4, 4, device=self.device)
+            b = torch.ones(4, 4, device=self.device)
+            c = torch.ones(4, 4, device=self.device)
+            d = torch.ones(4, 4, device=self.device)
+            traced = make_fx(func)(a, b, c, d)
+
+        collective_info = build_collective_info(traced.graph, {})
+        scheduled = OrderedSet(traced.graph.nodes)
+
+        from torch._inductor.fx_passes.overlap_manual_scheduling import (
+            ManualOverlapPreservingBucketer,
+        )
+
+        bucketer = ManualOverlapPreservingBucketer(
+            traced.graph, collective_info, scheduled
+        )
+
+        # find_nodes returns nodes in graph (topological) order.
+        sumexp0, sumexp1, result0, result1 = traced.graph.find_nodes(
+            op="call_function",
+            target=torch.ops._c10d_functional.all_reduce.default,
+        )
+
+        # The partition itself: independent sumexps in one bucket, dependent
+        # results in another -- a sumexp is never grouped with its own result.
+        buckets = bucketer._split_independent_collectives(
+            OrderedSet([sumexp0, sumexp1, result0, result1]),
+            list(traced.graph.nodes),
+        )
+        bucket_sets = [set(b) for b in buckets]
+        self.assertEqual(len(buckets), 2)
+        self.assertIn({sumexp0, sumexp1}, bucket_sets)
+        self.assertIn({result0, result1}, bucket_sets)
+
+        # End to end: bucketing must not raise, and the partition above means the
+        # two independent pairs each fuse (two cats) while the dependent pairs
+        # stay separate, so four all_reduces collapse to exactly two.
+        bucketer.manual_bucket_collectives(list(traced.graph.nodes))
+        traced.graph.lint()
+
+        all_reduces = traced.graph.find_nodes(
+            op="call_function",
+            target=torch.ops._c10d_functional.all_reduce.default,
+        )
+        cats = traced.graph.find_nodes(
+            op="call_function", target=torch.ops.aten.cat.default
+        )
+        self.assertEqual(len(all_reduces), 2)
+        self.assertEqual(len(cats), 2)
+
     def test_no_cross_type_bucketing_ar_and_rs(self):
         """
         Test that all_reduce and reduce_scatter on the same PG with

--- a/torch/_inductor/fx_passes/overlap_manual_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_manual_scheduling.py
@@ -12,10 +12,12 @@ from torch._inductor.fx_passes.bucketing import (
     BucketMode,
     has_mergeable_all_gather_convert_dtype,
     is_all_gather_into_tensor as is_all_gather,
+    is_all_reduce_tensor,
     is_fsdp_all_gather,
     is_fsdp_reduce_scatter,
     is_reduce_scatter_tensor as is_reduce_scatter,
     merge_all_gather_bucket,
+    merge_all_reduce_bucket,
     merge_reduce_scatter_bucket,
 )
 from torch._inductor.fx_passes.overlap_preserving_bucketer import (
@@ -102,6 +104,11 @@ def _reduce_scatter_bucket_trace_inputs(coll_node: fx.Node) -> list[fx.Node]:
     return _bucket_trace_inputs(coll_node, coll_node.args[0], group_name_arg=3)
 
 
+def _all_reduce_bucket_trace_inputs(coll_node: fx.Node) -> list[fx.Node]:
+    # all_reduce(tensor, reduce_op, group_name): tensor at 0, group_name at 2.
+    return _bucket_trace_inputs(coll_node, coll_node.args[0], group_name_arg=2)
+
+
 def _move_wait_users_after_latest_inputs(
     graph: fx.Graph,
     replacements: dict[fx.Node, fx.Node],
@@ -162,7 +169,9 @@ def _move_overlap_nodes(
     for target, sources in overlap_deps.items():
         for source in sources:
             source_type = bucketed_node_types.get(source, "")
-            if source_type.startswith("bucketed_reduce_scatter"):
+            if source_type.startswith(
+                ("bucketed_reduce_scatter", "bucketed_all_reduce")
+            ):
                 rs_defer[target].append(source)
             elif source_type.startswith("bucketed_all_gather"):
                 ag_prefetch[target].append(source)
@@ -226,9 +235,13 @@ class ManualOverlapPreservingBucketer(OverlapPreservingBucketer):
             bucket_trace_inputs = _reduce_scatter_bucket_trace_inputs
             merge_bucket = merge_reduce_scatter_bucket
             node_type = "bucketed_reduce_scatter"
+        elif is_all_reduce_tensor(first):
+            bucket_trace_inputs = _all_reduce_bucket_trace_inputs
+            merge_bucket = merge_all_reduce_bucket
+            node_type = "bucketed_all_reduce"
         else:
             raise ValueError(
-                "bucket non all_gather/reduce_scatter node is not supported"
+                "bucket non all_gather/reduce_scatter/all_reduce node is not supported"
             )
 
         # coll_nodes order is used for tensor packing and may differ from
@@ -295,6 +308,7 @@ class ManualOverlapPreservingBucketer(OverlapPreservingBucketer):
             if not (
                 is_fsdp_all_gather(node, self.node_ancestors)
                 or is_fsdp_reduce_scatter(node)
+                or is_all_reduce_tensor(node)
             ):
                 continue
             key = get_full_bucket_key(node, "custom_ops")
@@ -435,13 +449,17 @@ class ManualOverlapScheduler(OverlapScheduler):
             if node in self.scheduled:
                 continue
 
-            if node_type == "bucketed_reduce_scatter":
-                # Collect reduce scatter start nodes (pre_bucket_rs and rs)
+            if node_type in ("bucketed_reduce_scatter", "bucketed_all_reduce"):
+                # Collect grad-reduction start nodes (pre_bucket_rs and rs, or
+                # the HSDP/DDP replicate all_reduce).
                 current_rs_start_nodes.append(node)
 
-            elif node_type == "bucketed_reduce_scatter_wait":
-                # When we see a wait node from a new RS, flush delayed waits
-                # with dependencies on previously collected RS start nodes
+            elif node_type in (
+                "bucketed_reduce_scatter_wait",
+                "bucketed_all_reduce_wait",
+            ):
+                # When we see a wait node from a new RS/AR, flush delayed waits
+                # with dependencies on previously collected start nodes
                 if current_rs_start_nodes:
                     for delayed in delayed_rs_wait_nodes:
                         for rs_start in current_rs_start_nodes:

--- a/torch/_inductor/fx_passes/overlap_manual_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_manual_scheduling.py
@@ -295,6 +295,54 @@ class ManualOverlapPreservingBucketer(OverlapPreservingBucketer):
             elif n is new_start:
                 self.bucketed_node_types[n] = node_type
 
+    def _split_independent_collectives(
+        self, coll_nodes: OrderedSet[fx.Node], scope_nodes: list[fx.Node]
+    ) -> list[list[fx.Node]]:
+        """Partition same-key collectives so no bucket contains a collective that
+        depends on another member's result.
+
+        Bucketing fuses collectives into one op: inputs are concatenated before
+        the fused collective and outputs split after. If collective B's input
+        depends on collective A's output (A's wait), fusing A and B makes the
+        merged collective's input depend on its own output -- a graph cycle that
+        later fails region topological sort. This arises e.g. in loss-parallel
+        cross-entropy, which emits a sumexp and a result sum-all_reduce on the
+        same (group, reduce_op, dtype) key where result depends on sumexp.
+
+        Each collective is placed in the bucket equal to the longest chain of
+        same-key collectives ending at it (its Mirsky level). Collectives at the
+        same level are mutually independent, so grouping by level gives the
+        minimum number of dependency-free buckets. Levels are computed with a
+        single topological forward pass over ``scope_nodes`` that propagates,
+        along real graph edges, the deepest same-key chain reaching each node --
+        O(len(scope_nodes)) rather than O(len(coll_nodes)^2) pairwise ancestor
+        queries. This is exact because same-key collectives in one bucketing
+        scope depend on each other only through in-scope nodes.
+        """
+        wait_to_start = {self.collective_info[c].wait_node: c for c in coll_nodes}
+
+        # ``reach[node]`` = deepest same-key collective chain in node's cone;
+        # ``level[c]`` = that chain length including c (its bucket index + 1).
+        reach: dict[fx.Node, int] = {}
+        level: dict[fx.Node, int] = {}
+        for node in sorted(scope_nodes, key=lambda n: self.node_idx[n]):
+            incoming = max(
+                (reach.get(inp, 0) for inp in node.all_input_nodes), default=0
+            )
+            node_reach = incoming
+            if node in coll_nodes:
+                level[node] = incoming + 1
+            # A collective's chain becomes reachable through its wait (its result).
+            start = wait_to_start.get(node)
+            if start is not None:
+                node_reach = max(node_reach, level[start])
+            reach[node] = node_reach
+
+        buckets: dict[int, list[fx.Node]] = defaultdict(list)
+        for c in coll_nodes:
+            buckets[level[c]].append(c)
+        return [buckets[lvl] for lvl in sorted(buckets)]
+
     def manual_bucket_collectives(self, nodes: list[fx.Node]) -> None:
         """
         Bucket all all-gather/reduce-scatter nodes from nodes into one all-gather/reduce-scatter.
@@ -315,8 +363,14 @@ class ManualOverlapPreservingBucketer(OverlapPreservingBucketer):
             if key is not None:
                 grouped_collectives[key].add(node)
 
-        for key, nodes in grouped_collectives.items():  # type: ignore[arg-type]
-            self._bucket_group(list(nodes))
+        # Split each key-group into dependency-free sub-buckets so fusing never
+        # makes a bucketed collective's input depend on its own output.
+        sub_buckets: list[list[fx.Node]] = []
+        for key, key_nodes in grouped_collectives.items():
+            sub_buckets.extend(self._split_independent_collectives(key_nodes, nodes))
+
+        for sub_bucket in sub_buckets:
+            self._bucket_group(sub_bucket)
 
 
 class ManualOverlapScheduler(OverlapScheduler):


### PR DESCRIPTION
The manual overlap bucketer (ManualOverlapPreservingBucketer) only handled all_gather and reduce_scatter and silently skipped all_reduce. As a result the HSDP replicate-axis / DDP gradient all_reduce was left unbucketed (one launch per parameter) and never scheduled to overlap compute.

Teach the manual scheduler to treat all_reduce like reduce_scatter (both are backward gradient collectives whose wait can be deferred past compute):
- bucket it via merge_all_reduce_bucket in _bucket_group
- accept it in manual_bucket_collectives
- defer its wait in _move_overlap_nodes and the base _manual_reorder_graph loop

merge_all_reduce_bucket and the all_reduce bucket key already exist in bucketing.py and the auto bucketer already supports all_reduce; only the manual path was missing it.

Add manual-bucketing tests covering all_reduce (no-bucket, separate buckets, single bucket).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo