### PR TITLE
[MPS] Vectorize elementwise ops on inner-contiguous (sliced/strided) views

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -989,6 +989,29 @@ class BundledShaderLibrary : public MetalShaderLibrary {
   }
 };
 
+// Inner extent below which the per-element strided kernel beats the ILP tile.
+static constexpr int64_t INNER_CONTIGUOUS_MIN_EXTENT = 16;
+
+// True for a strided view whose innermost coalesced dim is unit-stride for every
+// operand, which the inner_contiguous kernels exploit.
+static bool isInnerContiguous(const TensorIteratorBase& iter) {
+  return iter.ndim() >= 2 && !iter.is_contiguous() && iter.has_contiguous_first_dim();
+}
+
+// Binds outer sizes then each operand's outer strides in kernel buffer order,
+// returning the next free buffer index for the caller's packed dims.
+static unsigned bindInnerContiguousOuter(id<MTLComputeCommandEncoder> encoder,
+                                         const TensorIteratorBase& iter,
+                                         unsigned base,
+                                         std::initializer_list<int> arg_order) {
+  mtl_setBytes(encoder, iter.shape().slice(1), base);
+  unsigned idx = base + 1;
+  for (int arg : arg_order) {
+    mtl_setBytes(encoder, iter.strides(arg).slice(1), idx++);
+  }
+  return idx;
+}
+
 void MetalShaderLibrary::exec_unary_kernel(TensorIteratorBase& iter,
                                            const std::string& name,
                                            std::optional<c10::Scalar> alpha,
@@ -1027,20 +1050,36 @@ void MetalShaderLibrary::exec_unary_kernel(TensorIteratorBase& iter,
   const bool ilp_eligible_dtype = c10::isFloatingType(outputTensor.scalar_type()) || ilp_threshold.has_value();
   bool dense_ilp = is_contiguous && !alpha.has_value() && ilp_eligible_dtype &&
       length >= ilp_threshold.value_or(ILP_DISPATCH_THRESHOLD);
-  // Bench-only override: force ILP or scalar dispatch.
-  if (is_contiguous && !alpha.has_value()) {
-    if (auto force = c10::utils::get_env("PYTORCH_UNARY_FORCE_FLAVOR")) {
-      if (force.value() == "ilp")
-        dense_ilp = true;
-      else if (force.value() == "scalar")
-        dense_ilp = false;
-    }
+  // Bench-only override (PYTORCH_UNARY_FORCE_FLAVOR): pin a flavor for A/B.
+  const auto force_flavor = c10::utils::get_env("PYTORCH_UNARY_FORCE_FLAVOR");
+  if (is_contiguous && !alpha.has_value() && force_flavor) {
+    if (*force_flavor == "ilp")
+      dense_ilp = true;
+    else if (*force_flavor == "scalar")
+      dense_ilp = false;
   }
   const auto alpha_type = scalar_arg_type.has_value() ? scalar_arg_type.value() : iter.common_dtype();
+  // Prefer the ILP inner_contiguous kernel over the per-element strided one once
+  // the contiguous inner run amortizes the per-run outer-offset calc.
+  bool inner_contiguous = !is_contiguous && !alpha.has_value() &&
+      iter.shape()[0] >= INNER_CONTIGUOUS_MIN_EXTENT && isInnerContiguous(iter);
+  if (!is_contiguous && !alpha.has_value() && force_flavor) {
+    if (*force_flavor == "strided")
+      inner_contiguous = false;
+    else if (*force_flavor == "inner_contiguous")
+      inner_contiguous = isInnerContiguous(iter);
+  }
+  // Same-dtype identity copy has no functor: move the inner run as raw bytes
+  // (widest aligned vector) so a narrow-dtype copy isn't capped at the typed
+  // sizeof(T)*ILP bytes/thread.
+  const bool byte_copy = inner_contiguous && name == "copy_identity" &&
+      outputTensor.scalar_type() == inputTensor.scalar_type();
   // alpha kernels are registered under "_dense_" (unary_alpha_dense); only the
   // plain unary path has the new "_dense_scalar_" / "_dense_" (ILP) split.
   std::string_view dense_suffix;
-  if (!is_contiguous) {
+  if (inner_contiguous) {
+    dense_suffix = "inner_contiguous";
+  } else if (!is_contiguous) {
     dense_suffix = "strided";
   } else if (dense_ilp || alpha.has_value()) {
     dense_suffix = "dense";
@@ -1070,11 +1109,17 @@ void MetalShaderLibrary::exec_unary_kernel(TensorIteratorBase& iter,
     cast_ilp = is_contiguous && ilp_threshold.has_value() && length >= ilp_threshold.value();
     if (cast_ilp) {
       dense_suffix = "dense_castout_ilp";
+    } else if (inner_contiguous) {
+      dense_suffix = "inner_contiguous_castout";
     } else {
       dense_suffix = is_contiguous ? "dense_castout" : "strided_castout";
     }
     dense_ilp = false;
     kernel_name = fmt::format("{}_{}_{}", name, dense_suffix, scalarToMetalTypeString(inputTensor));
+  }
+  // The byte-erased copy kernel is type-agnostic (one kernel, not per-dtype).
+  if (byte_copy) {
+    kernel_name = "inner_contiguous_copy";
   }
   @autoreleasepool {
     auto cplState = getPipelineStateForFunc(kernel_name);
@@ -1110,6 +1155,16 @@ void MetalShaderLibrary::exec_unary_kernel(TensorIteratorBase& iter,
                                                   out_type};
           mtl_setBytes(computeEncoder, size_outtype, 2);
           mtl_dispatch1DJob(computeEncoder, cplState, length);
+        } else if (inner_contiguous) {
+          const auto inner = static_cast<uint32_t>(iter.shape()[0]);
+          const std::array<uint32_t, 4> packed = {static_cast<uint32_t>(iter.ndim() - 1),
+                                                   inner,
+                                                   static_cast<uint32_t>(c10::elementSize(outputTensor.scalar_type())),
+                                                   out_type};
+          mtl_setBytes(computeEncoder, packed, bindInnerContiguousOuter(computeEncoder, iter, 2, {1, 0}));
+          const auto inner_tiles =
+              (static_cast<NSUInteger>(inner) + c10::metal::ILP_PER_THREAD - 1) / c10::metal::ILP_PER_THREAD;
+          mtl_dispatch2DJob(computeEncoder, cplState, inner_tiles, static_cast<NSUInteger>(length) / inner);
         } else {
           std::array<uint32_t, 2> ndim_outtype = {static_cast<uint32_t>(iter.ndim()), out_type};
           mtl_setArgs<2>(computeEncoder, iter.shape(), iter.strides(1), iter.strides(0), ndim_outtype);
@@ -1119,6 +1174,21 @@ void MetalShaderLibrary::exec_unary_kernel(TensorIteratorBase& iter,
         mtl_setBytes(computeEncoder, length, 2);
         mtl_dispatch1DJob(
             computeEncoder, cplState, (length + c10::metal::ILP_PER_THREAD - 1) / c10::metal::ILP_PER_THREAD);
+      } else if (inner_contiguous) {
+        const auto inner = static_cast<uint32_t>(iter.shape()[0]);
+        const auto outer = static_cast<NSUInteger>(length) / inner;
+        if (byte_copy) {
+          const auto inner_bytes = inner * static_cast<uint32_t>(iter.element_size(0));
+          const std::array<uint32_t, 2> packed = {static_cast<uint32_t>(iter.ndim() - 1), inner_bytes};
+          mtl_setBytes(computeEncoder, packed, bindInnerContiguousOuter(computeEncoder, iter, 2, {1, 0}));
+          mtl_dispatch2DJob(computeEncoder, cplState, (static_cast<NSUInteger>(inner_bytes) + 15) / 16, outer);
+        } else {
+          const std::array<uint32_t, 2> packed = {static_cast<uint32_t>(iter.ndim() - 1), inner};
+          mtl_setBytes(computeEncoder, packed, bindInnerContiguousOuter(computeEncoder, iter, 2, {1, 0}));
+          const auto inner_tiles =
+              (static_cast<NSUInteger>(inner) + c10::metal::ILP_PER_THREAD - 1) / c10::metal::ILP_PER_THREAD;
+          mtl_dispatch2DJob(computeEncoder, cplState, inner_tiles, outer);
+        }
       } else {
         if (!is_contiguous) {
           mtl_setArgs<2>(
@@ -1325,6 +1395,21 @@ void MetalShaderLibrary::exec_binary_kernel(TensorIteratorBase& iter,
     }
   }
 
+  // Inner-contiguous: a strided iterator whose innermost (coalesced) dim is unit
+  // stride for every operand, with no cast/scalar/broadcast/alpha. Prefer the
+  // ILP inner_contiguous kernel over the per-element strided one.
+  const bool ic_applicable = !use_scalar_kernel && !use_broadcast_kernel && !cast_needed && !alpha.has_value() &&
+      !output_cast_needed && !iter.is_contiguous() && isInnerContiguous(iter);
+  bool inner_contiguous = ic_applicable && iter.shape()[0] >= INNER_CONTIGUOUS_MIN_EXTENT;
+  if (ic_applicable) {
+    if (auto force = c10::utils::get_env("PYTORCH_BINARY_FORCE_FLAVOR")) {
+      if (force.value() == "strided")
+        inner_contiguous = false;
+      else if (force.value() == "inner_contiguous")
+        inner_contiguous = true;
+    }
+  }
+
   // Both cast and non-cast variants use a `_{DTYPEO}_{DTYPEI}` suffix.
   // Conceptually the second suffix is the kernel's compute precision (= the
   // iterator's common dtype). For arithmetic ops out and common coincide in
@@ -1378,8 +1463,9 @@ void MetalShaderLibrary::exec_binary_kernel(TensorIteratorBase& iter,
     // TODO: Implicitly pass both input and output types to non-cast kernels
     // The ILP suffix carries the unroll width (e.g. dense_ilp4) so future
     // variants (ilp8, ...) can coexist; see C10_METAL_ILP_PER_THREAD_STR.
-    const auto suffix =
-        iter.is_contiguous() ? (dense_ilp ? "dense_ilp" C10_METAL_ILP_PER_THREAD_STR : "dense") : "strided";
+    const auto suffix = iter.is_contiguous()
+        ? (dense_ilp ? "dense_ilp" C10_METAL_ILP_PER_THREAD_STR : "dense")
+        : (inner_contiguous ? "inner_contiguous" : "strided");
     kernel_name = cast_needed ? fmt::format("{}_{}_cast_{}{}", name, suffix, cast_suffix_type, alpha_suffix)
                               : fmt::format("{}_{}_{}_{}{}",
                                             name,
@@ -1452,6 +1538,10 @@ void MetalShaderLibrary::exec_binary_kernel(TensorIteratorBase& iter,
                                                  static_cast<int>(other.scalar_type())};
             mtl_setBytes(computeEncoder, size_and_types, alpha ? 4 : 3);
           }
+        } else if (inner_contiguous) {
+          const auto inner = static_cast<uint32_t>(iter.shape()[0]);
+          const std::array<uint32_t, 2> packed = {static_cast<uint32_t>(iter.ndim() - 1), inner};
+          mtl_setBytes(computeEncoder, packed, bindInnerContiguousOuter(computeEncoder, iter, 3, {0, 1, 2}));
         } else {
           // Please note that shapes and strides of the iterator might be
           // different than that of its operands, for example binary op
@@ -1474,9 +1564,16 @@ void MetalShaderLibrary::exec_binary_kernel(TensorIteratorBase& iter,
           }
         }
       }
-      const auto dispatch_n =
-          dense_ilp ? (iter.numel() + c10::metal::ILP_PER_THREAD - 1) / c10::metal::ILP_PER_THREAD : iter.numel();
-      mtl_dispatch1DJob(computeEncoder, binaryPSO, dispatch_n);
+      if (inner_contiguous) {
+        const auto inner = static_cast<uint32_t>(iter.shape()[0]);
+        const auto inner_tiles =
+            (static_cast<NSUInteger>(inner) + c10::metal::ILP_PER_THREAD - 1) / c10::metal::ILP_PER_THREAD;
+        mtl_dispatch2DJob(computeEncoder, binaryPSO, inner_tiles, static_cast<NSUInteger>(iter.numel()) / inner);
+      } else {
+        const auto dispatch_n =
+            dense_ilp ? (iter.numel() + c10::metal::ILP_PER_THREAD - 1) / c10::metal::ILP_PER_THREAD : iter.numel();
+        mtl_dispatch1DJob(computeEncoder, binaryPSO, dispatch_n);
+      }
       getMPSProfiler().endProfileKernel(binaryPSO);
     }
   });

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -1061,8 +1061,8 @@ void MetalShaderLibrary::exec_unary_kernel(TensorIteratorBase& iter,
   const auto alpha_type = scalar_arg_type.has_value() ? scalar_arg_type.value() : iter.common_dtype();
   // Prefer the ILP inner_contiguous kernel over the per-element strided one once
   // the contiguous inner run amortizes the per-run outer-offset calc.
-  bool inner_contiguous = !is_contiguous && !alpha.has_value() &&
-      iter.shape()[0] >= INNER_CONTIGUOUS_MIN_EXTENT && isInnerContiguous(iter);
+  bool inner_contiguous =
+      !is_contiguous && !alpha.has_value() && iter.shape()[0] >= INNER_CONTIGUOUS_MIN_EXTENT && isInnerContiguous(iter);
   if (!is_contiguous && !alpha.has_value() && force_flavor) {
     if (*force_flavor == "strided")
       inner_contiguous = false;
@@ -1072,8 +1072,8 @@ void MetalShaderLibrary::exec_unary_kernel(TensorIteratorBase& iter,
   // Same-dtype identity copy has no functor: move the inner run as raw bytes
   // (widest aligned vector) so a narrow-dtype copy isn't capped at the typed
   // sizeof(T)*ILP bytes/thread.
-  const bool byte_copy = inner_contiguous && name == "copy_identity" &&
-      outputTensor.scalar_type() == inputTensor.scalar_type();
+  const bool byte_copy =
+      inner_contiguous && name == "copy_identity" && outputTensor.scalar_type() == inputTensor.scalar_type();
   // alpha kernels are registered under "_dense_" (unary_alpha_dense); only the
   // plain unary path has the new "_dense_scalar_" / "_dense_" (ILP) split.
   std::string_view dense_suffix;
@@ -1158,9 +1158,9 @@ void MetalShaderLibrary::exec_unary_kernel(TensorIteratorBase& iter,
         } else if (inner_contiguous) {
           const auto inner = static_cast<uint32_t>(iter.shape()[0]);
           const std::array<uint32_t, 4> packed = {static_cast<uint32_t>(iter.ndim() - 1),
-                                                   inner,
-                                                   static_cast<uint32_t>(c10::elementSize(outputTensor.scalar_type())),
-                                                   out_type};
+                                                  inner,
+                                                  static_cast<uint32_t>(c10::elementSize(outputTensor.scalar_type())),
+                                                  out_type};
           mtl_setBytes(computeEncoder, packed, bindInnerContiguousOuter(computeEncoder, iter, 2, {1, 0}));
           const auto inner_tiles =
               (static_cast<NSUInteger>(inner) + c10::metal::ILP_PER_THREAD - 1) / c10::metal::ILP_PER_THREAD;
@@ -1463,9 +1463,8 @@ void MetalShaderLibrary::exec_binary_kernel(TensorIteratorBase& iter,
     // TODO: Implicitly pass both input and output types to non-cast kernels
     // The ILP suffix carries the unroll width (e.g. dense_ilp4) so future
     // variants (ilp8, ...) can coexist; see C10_METAL_ILP_PER_THREAD_STR.
-    const auto suffix = iter.is_contiguous()
-        ? (dense_ilp ? "dense_ilp" C10_METAL_ILP_PER_THREAD_STR : "dense")
-        : (inner_contiguous ? "inner_contiguous" : "strided");
+    const auto suffix = iter.is_contiguous() ? (dense_ilp ? "dense_ilp" C10_METAL_ILP_PER_THREAD_STR : "dense")
+                                             : (inner_contiguous ? "inner_contiguous" : "strided");
     kernel_name = cast_needed ? fmt::format("{}_{}_cast_{}{}", name, suffix, cast_suffix_type, alpha_suffix)
                               : fmt::format("{}_{}_{}_{}{}",
                                             name,

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -990,6 +990,7 @@ class BundledShaderLibrary : public MetalShaderLibrary {
 };
 
 // Inner extent below which the per-element strided kernel beats the ILP tile.
+// Measured safe for both unary and binary, so a single shared value suffices.
 static constexpr int64_t INNER_CONTIGUOUS_MIN_EXTENT = 16;
 
 // True for a strided view whose innermost coalesced dim is unit-stride for every

--- a/aten/src/ATen/native/mps/kernels/Copy.metal
+++ b/aten/src/ATen/native/mps/kernels/Copy.metal
@@ -102,9 +102,7 @@ kernel void inner_contiguous_copy(
     }
     return;
   }
-  uint align = (reinterpret_cast<device ulong>(o) |
-                reinterpret_cast<constant ulong>(in)) &
-      15;
+  uint align = (reinterpret_cast<ulong>(o) | reinterpret_cast<ulong>(in)) & 15;
   if (align == 0) {
     *reinterpret_cast<device uint4*>(o) =
         *reinterpret_cast<constant uint4*>(in);

--- a/aten/src/ATen/native/mps/kernels/Copy.metal
+++ b/aten/src/ATen/native/mps/kernels/Copy.metal
@@ -91,7 +91,8 @@ kernel void inner_contiguous_copy(
   int opos[max_ndim];
   pos_from_thread_index(int(thread_pos.y), opos, outer_sizes, ndim_outer);
   const auto in_base = offset_from_coord(opos, input_outer_strides, ndim_outer);
-  const auto out_base = offset_from_coord(opos, output_outer_strides, ndim_outer);
+  const auto out_base =
+      offset_from_coord(opos, output_outer_strides, ndim_outer);
   device uchar* o = output + out_base + pos;
   constant uchar* in = input + in_base + pos;
   uint n = min(16u, inner_bytes - pos);
@@ -101,20 +102,26 @@ kernel void inner_contiguous_copy(
     }
     return;
   }
-  uint align = (reinterpret_cast<device ulong>(o) | reinterpret_cast<constant ulong>(in)) & 15;
+  uint align = (reinterpret_cast<device ulong>(o) |
+                reinterpret_cast<constant ulong>(in)) &
+      15;
   if (align == 0) {
-    *reinterpret_cast<device uint4*>(o) = *reinterpret_cast<constant uint4*>(in);
+    *reinterpret_cast<device uint4*>(o) =
+        *reinterpret_cast<constant uint4*>(in);
   } else if ((align & 7) == 0) {
     for (uint k = 0; k < 2; ++k) {
-      reinterpret_cast<device uint2*>(o)[k] = reinterpret_cast<constant uint2*>(in)[k];
+      reinterpret_cast<device uint2*>(o)[k] =
+          reinterpret_cast<constant uint2*>(in)[k];
     }
   } else if ((align & 3) == 0) {
     for (uint k = 0; k < 4; ++k) {
-      reinterpret_cast<device uint*>(o)[k] = reinterpret_cast<constant uint*>(in)[k];
+      reinterpret_cast<device uint*>(o)[k] =
+          reinterpret_cast<constant uint*>(in)[k];
     }
   } else if ((align & 1) == 0) {
     for (uint k = 0; k < 8; ++k) {
-      reinterpret_cast<device ushort*>(o)[k] = reinterpret_cast<constant ushort*>(in)[k];
+      reinterpret_cast<device ushort*>(o)[k] =
+          reinterpret_cast<constant ushort*>(in)[k];
     }
   } else {
     for (uint k = 0; k < 16; ++k) {

--- a/aten/src/ATen/native/mps/kernels/Copy.metal
+++ b/aten/src/ATen/native/mps/kernels/Copy.metal
@@ -69,3 +69,56 @@ REGISTER_COPY_CASTOUT(half2);
 
 REGISTER_UNARY_OP(copy_conj_neg, float2, float2);
 REGISTER_UNARY_OP(copy_conj_neg, half2, half2);
+
+// Byte-erased identity copy of an inner-contiguous view: a same-dtype copy has
+// no functor, so move the contiguous inner run as raw bytes with the widest
+// aligned vector (uint4 -> ushort -> byte ladder) regardless of element dtype.
+// grid.x indexes 16-byte chunks of the inner run.
+kernel void inner_contiguous_copy(
+    device uchar* output [[buffer(0)]],
+    constant uchar* input [[buffer(1)]],
+    constant long* outer_sizes [[buffer(2)]],
+    constant long* input_outer_strides [[buffer(3)]],
+    constant long* output_outer_strides [[buffer(4)]],
+    constant uint2& ndim_outer_inner_bytes [[buffer(5)]],
+    uint2 thread_pos [[thread_position_in_grid]]) {
+  const uint ndim_outer = ndim_outer_inner_bytes.x;
+  const uint inner_bytes = ndim_outer_inner_bytes.y;
+  uint pos = thread_pos.x * 16;
+  if (pos >= inner_bytes) {
+    return;
+  }
+  int opos[max_ndim];
+  pos_from_thread_index(int(thread_pos.y), opos, outer_sizes, ndim_outer);
+  const auto in_base = offset_from_coord(opos, input_outer_strides, ndim_outer);
+  const auto out_base = offset_from_coord(opos, output_outer_strides, ndim_outer);
+  device uchar* o = output + out_base + pos;
+  constant uchar* in = input + in_base + pos;
+  uint n = min(16u, inner_bytes - pos);
+  if (n < 16) {
+    for (uint k = 0; k < n; ++k) {
+      o[k] = in[k];
+    }
+    return;
+  }
+  uint align = (reinterpret_cast<device ulong>(o) | reinterpret_cast<constant ulong>(in)) & 15;
+  if (align == 0) {
+    *reinterpret_cast<device uint4*>(o) = *reinterpret_cast<constant uint4*>(in);
+  } else if ((align & 7) == 0) {
+    for (uint k = 0; k < 2; ++k) {
+      reinterpret_cast<device uint2*>(o)[k] = reinterpret_cast<constant uint2*>(in)[k];
+    }
+  } else if ((align & 3) == 0) {
+    for (uint k = 0; k < 4; ++k) {
+      reinterpret_cast<device uint*>(o)[k] = reinterpret_cast<constant uint*>(in)[k];
+    }
+  } else if ((align & 1) == 0) {
+    for (uint k = 0; k < 8; ++k) {
+      reinterpret_cast<device ushort*>(o)[k] = reinterpret_cast<constant ushort*>(in)[k];
+    }
+  } else {
+    for (uint k = 0; k < 16; ++k) {
+      o[k] = in[k];
+    }
+  }
+}

--- a/c10/metal/indexing.h
+++ b/c10/metal/indexing.h
@@ -165,11 +165,12 @@ kernel void unary_inner_contiguous(
   int pos[max_ndim];
   pos_from_thread_index(int(thread_pos.y), pos, outer_sizes, ndim_outer);
   const auto in_base = offset_from_coord(pos, input_outer_strides, ndim_outer);
-  const auto out_base = offset_from_coord(pos, output_outer_strides, ndim_outer);
+  const auto out_base =
+      offset_from_coord(pos, output_outer_strides, ndim_outer);
   constant T* in = reinterpret_cast<constant T*>(
       static_cast<constant char*>(input) + in_base);
-  device res_t* out =
-      reinterpret_cast<device res_t*>(static_cast<device char*>(output) + out_base);
+  device res_t* out = reinterpret_cast<device res_t*>(
+      static_cast<device char*>(output) + out_base);
   uint base = thread_pos.x * ILP_PER_THREAD;
   if (base + ILP_PER_THREAD <= inner) {
     array<T, ILP_PER_THREAD> tmp_in;
@@ -295,14 +296,15 @@ kernel void unary_inner_contiguous_castout(
           constant uint2& ndim_outtype,                                        \
           uint2 thread_pos);                                                   \
   template [[host_name(#NAME "_inner_contiguous_castout_" #DTYPE0)]]           \
-  kernel void ::c10::metal::unary_inner_contiguous_castout<DTYPE0, NAME##_functor>( \
-      device void* output,                                                     \
-      constant void* input,                                                    \
-      constant long* outer_sizes,                                              \
-      constant long* input_outer_strides,                                      \
-      constant long* output_outer_strides,                                     \
-      constant uint4& ndimO_inner_elem_outtype,                                \
-      uint2 thread_pos)
+  kernel void ::c10::metal::                                                   \
+      unary_inner_contiguous_castout<DTYPE0, NAME##_functor>(                  \
+          device void* output,                                                 \
+          constant void* input,                                                \
+          constant long* outer_sizes,                                          \
+          constant long* input_outer_strides,                                  \
+          constant long* output_outer_strides,                                 \
+          constant uint4& ndimO_inner_elem_outtype,                            \
+          uint2 thread_pos)
 
 #define DEFINE_UNARY_FLOATING_FUNCTOR(NAME)                                     \
   struct NAME##_functor {                                                       \
@@ -517,9 +519,10 @@ kernel void unary_inner_contiguous_castout(
   int pos[max_ndim];
   pos_from_thread_index(int(thread_pos.y), pos, outer_sizes, ndim_outer);
   const auto in_base = offset_from_coord(pos, input_outer_strides, ndim_outer);
-  const auto out_base = offset_from_coord(pos, output_outer_strides, ndim_outer);
-  constant Tin* in =
-      reinterpret_cast<constant Tin*>(static_cast<constant char*>(input) + in_base);
+  const auto out_base =
+      offset_from_coord(pos, output_outer_strides, ndim_outer);
+  constant Tin* in = reinterpret_cast<constant Tin*>(
+      static_cast<constant char*>(input) + in_base);
   uint base = thread_pos.x * ILP_PER_THREAD;
   if (base + ILP_PER_THREAD <= inner) {
     array<Tin, ILP_PER_THREAD> tmp_in;
@@ -534,11 +537,13 @@ kernel void unary_inner_contiguous_castout(
     }
 #pragma unroll
     for (uint j = 0; j < ILP_PER_THREAD; ++j) {
-      store_at_offs<res_t>(output, out_base + long(base + j) * elem, out_type, tmp_out[j]);
+      store_at_offs<res_t>(
+          output, out_base + long(base + j) * elem, out_type, tmp_out[j]);
     }
   } else {
     for (uint j = base; j < inner; ++j) {
-      store_at_offs<res_t>(output, out_base + long(j) * elem, out_type, f(in[j]));
+      store_at_offs<res_t>(
+          output, out_base + long(j) * elem, out_type, f(in[j]));
     }
   }
 }
@@ -771,15 +776,16 @@ kernel void binary_inner_contiguous(
   const uint inner = ndim_outer_inner.y;
   int pos[max_ndim];
   pos_from_thread_index(int(thread_pos.y), pos, outer_sizes, ndim_outer);
-  const auto out_base = offset_from_coord(pos, output_outer_strides, ndim_outer);
+  const auto out_base =
+      offset_from_coord(pos, output_outer_strides, ndim_outer);
   const auto in_base = offset_from_coord(pos, input_outer_strides, ndim_outer);
   const auto oth_base = offset_from_coord(pos, other_outer_strides, ndim_outer);
-  device res_t* out =
-      reinterpret_cast<device res_t*>(static_cast<device char*>(output) + out_base);
-  constant T* a =
-      reinterpret_cast<constant T*>(static_cast<constant char*>(input) + in_base);
-  constant T* b =
-      reinterpret_cast<constant T*>(static_cast<constant char*>(other) + oth_base);
+  device res_t* out = reinterpret_cast<device res_t*>(
+      static_cast<device char*>(output) + out_base);
+  constant T* a = reinterpret_cast<constant T*>(
+      static_cast<constant char*>(input) + in_base);
+  constant T* b = reinterpret_cast<constant T*>(
+      static_cast<constant char*>(other) + oth_base);
   uint base = thread_pos.x * ILP_PER_THREAD;
   if (base + ILP_PER_THREAD <= inner) {
     array<T, ILP_PER_THREAD> ta;
@@ -1100,16 +1106,17 @@ kernel void binary_alpha_dense_scalar_lhs_cast(
           constant uint3& ndim,                                                \
           uint tid);                                                           \
   template [[host_name(#NAME "_inner_contiguous_" #DTYPEO "_" #DTYPEI)]]       \
-  kernel void ::c10::metal::binary_inner_contiguous<DTYPEI, NAME##_functor, OMT>( \
-      device void* out,                                                        \
-      constant void* input,                                                    \
-      constant void* other,                                                    \
-      constant long* outer_sizes,                                              \
-      constant long* output_outer_strides,                                     \
-      constant long* input_outer_strides,                                      \
-      constant long* other_outer_strides,                                      \
-      constant uint2& ndim_outer_inner,                                        \
-      uint2 thread_pos);                                                       \
+  kernel void ::c10::metal::                                                   \
+      binary_inner_contiguous<DTYPEI, NAME##_functor, OMT>(                    \
+          device void* out,                                                    \
+          constant void* input,                                                \
+          constant void* other,                                                \
+          constant long* outer_sizes,                                          \
+          constant long* output_outer_strides,                                 \
+          constant long* input_outer_strides,                                  \
+          constant long* other_outer_strides,                                  \
+          constant uint2& ndim_outer_inner,                                    \
+          uint2 thread_pos);                                                   \
   template                                                                     \
       [[host_name(#NAME "_strided_cast_" #DTYPEO "_" #DTYPEI)]] kernel void :: \
           c10::metal::binary_strided_cast<DTYPEI, NAME##_functor, OMT>(        \

--- a/c10/metal/indexing.h
+++ b/c10/metal/indexing.h
@@ -144,6 +144,55 @@ kernel void unary_strided(
       f(val_at_offs<T>(input, input_offs));
 }
 
+// Innermost dim is unit-stride for both operands (a slice/narrow view): compute
+// each operand's outer base offset once, then run unary_dense's ILP tile over
+// the contiguous inner run. Sits between unary_dense (fully contiguous) and
+// unary_strided (per-element offset calc). grid.x = inner tile, grid.y = linear
+// outer index; outer_* describe dims [1..ndim), inner is dim 0.
+template <typename T, typename F>
+kernel void unary_inner_contiguous(
+    device void* output [[buffer(0)]],
+    constant void* input [[buffer(1)]],
+    constant long* outer_sizes [[buffer(2)]],
+    constant long* input_outer_strides [[buffer(3)]],
+    constant long* output_outer_strides [[buffer(4)]],
+    constant uint2& ndim_outer_inner [[buffer(5)]],
+    uint2 thread_pos [[thread_position_in_grid]]) {
+  F f;
+  using res_t = result_of<F, T>;
+  const uint ndim_outer = ndim_outer_inner.x;
+  const uint inner = ndim_outer_inner.y;
+  int pos[max_ndim];
+  pos_from_thread_index(int(thread_pos.y), pos, outer_sizes, ndim_outer);
+  const auto in_base = offset_from_coord(pos, input_outer_strides, ndim_outer);
+  const auto out_base = offset_from_coord(pos, output_outer_strides, ndim_outer);
+  constant T* in = reinterpret_cast<constant T*>(
+      static_cast<constant char*>(input) + in_base);
+  device res_t* out =
+      reinterpret_cast<device res_t*>(static_cast<device char*>(output) + out_base);
+  uint base = thread_pos.x * ILP_PER_THREAD;
+  if (base + ILP_PER_THREAD <= inner) {
+    array<T, ILP_PER_THREAD> tmp_in;
+    array<res_t, ILP_PER_THREAD> tmp_out;
+#pragma unroll
+    for (uint j = 0; j < ILP_PER_THREAD; ++j) {
+      tmp_in[j] = in[base + j];
+    }
+#pragma unroll
+    for (uint j = 0; j < ILP_PER_THREAD; ++j) {
+      tmp_out[j] = f(tmp_in[j]);
+    }
+#pragma unroll
+    for (uint j = 0; j < ILP_PER_THREAD; ++j) {
+      out[base + j] = tmp_out[j];
+    }
+  } else {
+    for (uint j = base; j < inner; ++j) {
+      out[j] = f(in[j]);
+    }
+  }
+}
+
 // Forward declarations for the castout templates (defined after store_at_offs,
 // which they call). REGISTER_UNARY_OP expands to explicit template
 // instantiations of these, so they must be declared before the macro is used.
@@ -170,6 +219,16 @@ kernel void unary_strided_castout(
     constant long* input_strides,
     constant long* output_strides,
     constant uint2& ndim_outtype,
+    uint2 thread_pos);
+
+template <typename Tin, typename F>
+kernel void unary_inner_contiguous_castout(
+    device void* output,
+    constant void* input,
+    constant long* outer_sizes,
+    constant long* input_outer_strides,
+    constant long* output_outer_strides,
+    constant uint4& ndimO_inner_elem_outtype,
     uint2 thread_pos);
 
 // Registers the direct per-(out,in) unary kernels and the castout variants
@@ -205,6 +264,15 @@ kernel void unary_strided_castout(
           constant long* output_strides,                                       \
           constant uint& ndim,                                                 \
           uint2 thread_pos);                                                   \
+  template [[host_name(#NAME "_inner_contiguous_" #DTYPE1 "_" #DTYPE0)]]       \
+  kernel void ::c10::metal::unary_inner_contiguous<DTYPE0, NAME##_functor>(    \
+      device void* output,                                                     \
+      constant void* input,                                                    \
+      constant long* outer_sizes,                                              \
+      constant long* input_outer_strides,                                      \
+      constant long* output_outer_strides,                                     \
+      constant uint2& ndim_outer_inner,                                        \
+      uint2 thread_pos);                                                       \
   template [[host_name(#NAME "_dense_castout_" #DTYPE0)]] kernel void ::c10::  \
       metal::unary_dense_castout<DTYPE0, NAME##_functor>(                      \
           device void* output,                                                 \
@@ -225,7 +293,16 @@ kernel void unary_strided_castout(
           constant long* input_strides,                                        \
           constant long* output_strides,                                       \
           constant uint2& ndim_outtype,                                        \
-          uint2 thread_pos)
+          uint2 thread_pos);                                                   \
+  template [[host_name(#NAME "_inner_contiguous_castout_" #DTYPE0)]]           \
+  kernel void ::c10::metal::unary_inner_contiguous_castout<DTYPE0, NAME##_functor>( \
+      device void* output,                                                     \
+      constant void* input,                                                    \
+      constant long* outer_sizes,                                              \
+      constant long* input_outer_strides,                                      \
+      constant long* output_outer_strides,                                     \
+      constant uint4& ndimO_inner_elem_outtype,                                \
+      uint2 thread_pos)
 
 #define DEFINE_UNARY_FLOATING_FUNCTOR(NAME)                                     \
   struct NAME##_functor {                                                       \
@@ -419,12 +496,61 @@ kernel void unary_strided_castout(
       f(val_at_offs<Tin>(input, input_offs)));
 }
 
+// Castout variant of unary_inner_contiguous: output dtype is runtime (stored
+// via store_at_offs). ndimO_inner_elem_outtype = {outer ndim, inner extent,
+// output elem size (bytes), output ScalarType}.
+template <typename Tin, typename F>
+kernel void unary_inner_contiguous_castout(
+    device void* output [[buffer(0)]],
+    constant void* input [[buffer(1)]],
+    constant long* outer_sizes [[buffer(2)]],
+    constant long* input_outer_strides [[buffer(3)]],
+    constant long* output_outer_strides [[buffer(4)]],
+    constant uint4& ndimO_inner_elem_outtype [[buffer(5)]],
+    uint2 thread_pos [[thread_position_in_grid]]) {
+  F f;
+  using res_t = result_of<F, Tin>;
+  const uint ndim_outer = ndimO_inner_elem_outtype.x;
+  const uint inner = ndimO_inner_elem_outtype.y;
+  const uint elem = ndimO_inner_elem_outtype.z;
+  const auto out_type = static_cast<ScalarType>(ndimO_inner_elem_outtype.w);
+  int pos[max_ndim];
+  pos_from_thread_index(int(thread_pos.y), pos, outer_sizes, ndim_outer);
+  const auto in_base = offset_from_coord(pos, input_outer_strides, ndim_outer);
+  const auto out_base = offset_from_coord(pos, output_outer_strides, ndim_outer);
+  constant Tin* in =
+      reinterpret_cast<constant Tin*>(static_cast<constant char*>(input) + in_base);
+  uint base = thread_pos.x * ILP_PER_THREAD;
+  if (base + ILP_PER_THREAD <= inner) {
+    array<Tin, ILP_PER_THREAD> tmp_in;
+    array<res_t, ILP_PER_THREAD> tmp_out;
+#pragma unroll
+    for (uint j = 0; j < ILP_PER_THREAD; ++j) {
+      tmp_in[j] = in[base + j];
+    }
+#pragma unroll
+    for (uint j = 0; j < ILP_PER_THREAD; ++j) {
+      tmp_out[j] = f(tmp_in[j]);
+    }
+#pragma unroll
+    for (uint j = 0; j < ILP_PER_THREAD; ++j) {
+      store_at_offs<res_t>(output, out_base + long(base + j) * elem, out_type, tmp_out[j]);
+    }
+  } else {
+    for (uint j = base; j < inner; ++j) {
+      store_at_offs<res_t>(output, out_base + long(j) * elem, out_type, f(in[j]));
+    }
+  }
+}
+
 // Binary elementwise ops kernels
-// Right now there are 4 flavors available:
+// Right now the following flavors are available:
 // - binary_dense where both input, other and output are dense and share the
 // same type
 // - binary_strided when all inputs are of the same types, but some elements are
 // strided
+// - binary_inner_contiguous - strided, but the innermost dim is unit-stride for
+// every operand (a slice/narrow view)
 // - binary_dense_cast - inputs are dense, but of different dtypes
 // - binary_strided_cast - inputs or output are strided and of different dtypes
 // - binary_dense_broadcast - one input is dense, another one is broadcastable
@@ -621,6 +747,60 @@ kernel void binary_dense_ilp(
   } else {
     for (uint i = base; i < numel; ++i) {
       out[i] = static_cast<res_t>(f(om_t(input[i]), om_t(other[i])));
+    }
+  }
+}
+
+// Inner-contiguous binary: like unary_inner_contiguous, but runs
+// binary_dense_ilp's tile over the contiguous inner run (all three operands
+// unit-stride in dim 0).
+template <typename T, typename F, typename om_t = opmath_t<T>>
+kernel void binary_inner_contiguous(
+    device void* output [[buffer(0)]],
+    constant void* input [[buffer(1)]],
+    constant void* other [[buffer(2)]],
+    constant long* outer_sizes [[buffer(3)]],
+    constant long* output_outer_strides [[buffer(4)]],
+    constant long* input_outer_strides [[buffer(5)]],
+    constant long* other_outer_strides [[buffer(6)]],
+    constant uint2& ndim_outer_inner [[buffer(7)]],
+    uint2 thread_pos [[thread_position_in_grid]]) {
+  F f;
+  using res_t = result_of<F, T, T>;
+  const uint ndim_outer = ndim_outer_inner.x;
+  const uint inner = ndim_outer_inner.y;
+  int pos[max_ndim];
+  pos_from_thread_index(int(thread_pos.y), pos, outer_sizes, ndim_outer);
+  const auto out_base = offset_from_coord(pos, output_outer_strides, ndim_outer);
+  const auto in_base = offset_from_coord(pos, input_outer_strides, ndim_outer);
+  const auto oth_base = offset_from_coord(pos, other_outer_strides, ndim_outer);
+  device res_t* out =
+      reinterpret_cast<device res_t*>(static_cast<device char*>(output) + out_base);
+  constant T* a =
+      reinterpret_cast<constant T*>(static_cast<constant char*>(input) + in_base);
+  constant T* b =
+      reinterpret_cast<constant T*>(static_cast<constant char*>(other) + oth_base);
+  uint base = thread_pos.x * ILP_PER_THREAD;
+  if (base + ILP_PER_THREAD <= inner) {
+    array<T, ILP_PER_THREAD> ta;
+    array<T, ILP_PER_THREAD> tb;
+    array<res_t, ILP_PER_THREAD> to;
+#pragma unroll
+    for (uint j = 0; j < ILP_PER_THREAD; ++j) {
+      ta[j] = a[base + j];
+      tb[j] = b[base + j];
+    }
+#pragma unroll
+    for (uint j = 0; j < ILP_PER_THREAD; ++j) {
+      to[j] = static_cast<res_t>(f(om_t(ta[j]), om_t(tb[j])));
+    }
+#pragma unroll
+    for (uint j = 0; j < ILP_PER_THREAD; ++j) {
+      out[base + j] = to[j];
+    }
+  } else {
+    for (uint j = base; j < inner; ++j) {
+      out[j] = static_cast<res_t>(f(om_t(a[j]), om_t(b[j])));
     }
   }
 }
@@ -919,6 +1099,17 @@ kernel void binary_alpha_dense_scalar_lhs_cast(
           constant long* other_strides,                                        \
           constant uint3& ndim,                                                \
           uint tid);                                                           \
+  template [[host_name(#NAME "_inner_contiguous_" #DTYPEO "_" #DTYPEI)]]       \
+  kernel void ::c10::metal::binary_inner_contiguous<DTYPEI, NAME##_functor, OMT>( \
+      device void* out,                                                        \
+      constant void* input,                                                    \
+      constant void* other,                                                    \
+      constant long* outer_sizes,                                              \
+      constant long* output_outer_strides,                                     \
+      constant long* input_outer_strides,                                      \
+      constant long* other_outer_strides,                                      \
+      constant uint2& ndim_outer_inner,                                        \
+      uint2 thread_pos);                                                       \
   template                                                                     \
       [[host_name(#NAME "_strided_cast_" #DTYPEO "_" #DTYPEI)]] kernel void :: \
           c10::metal::binary_strided_cast<DTYPEI, NAME##_functor, OMT>(        \

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -10010,6 +10010,53 @@ class TestBinaryDispatchRouting(TestCaseMPS):
             "probe_dense_bool_float")
 
 
+# Sliced/narrowed views route through the inner_contiguous kernels once
+# shape()[0] >= 16. Locks in the two paths op tests miss: castout (out dtype !=
+# compute dtype) and the byte-erased same-dtype copy (tail + alignment ladder).
+class TestInnerContiguous(TestCaseMPS):
+    _SHAPES = [(48, 64), (8, 6, 40), (3, 4, 5, 24)]
+
+    @parametrize("in_dtype,out_dtype", [
+        (torch.float32, torch.float16),
+        (torch.float32, torch.bfloat16),
+        (torch.float32, torch.int32),
+        (torch.int32, torch.float32),
+        (torch.int8, torch.float32),
+    ])
+    def test_castout(self, device, in_dtype, out_dtype):
+        torch.manual_seed(0)
+        for shape in self._SHAPES:
+            inner = shape[-1] - 8  # drop the tail so the view is strided
+            full = _conformance_make_tensor(shape, in_dtype)
+            src_cpu = full[..., :inner]
+            src_dev = full.to(device)[..., :inner]
+            self.assertFalse(src_dev.is_contiguous())
+            # input-sliced: cast-copy reads the strided view, writes contiguous out
+            self.assertEqual(src_dev.to(out_dtype).cpu(), src_cpu.to(out_dtype))
+            # output-sliced: cast-copy writes into the strided view
+            dst_cpu = torch.zeros(shape, dtype=out_dtype)
+            dst_dev = torch.zeros(shape, dtype=out_dtype, device=device)
+            dst_cpu[..., :inner].copy_(src_cpu)
+            dst_dev[..., :inner].copy_(src_dev)
+            self.assertEqual(dst_dev.cpu(), dst_cpu)
+
+    @parametrize("dtype", [torch.int8, torch.int16, torch.float32])
+    @parametrize("offset", [0, 1, 2, 4, 8])
+    @parametrize("inner", [17, 31, 48])
+    def test_byte_copy(self, device, dtype, offset, inner):
+        # offset varies the per-row base alignment to exercise the ladder, and
+        # odd inner extents make inner_bytes % 16 != 0 for narrow dtypes.
+        torch.manual_seed(0)
+        R, full_w = 24, offset + inner + 8
+        src = _conformance_make_tensor((R, inner), dtype)
+        buf = _conformance_make_tensor((R, full_w), dtype)
+        dst_cpu, dst_dev = buf.clone(), buf.to(device)
+        dst_cpu[:, offset:offset + inner].copy_(src)
+        dst_dev[:, offset:offset + inner].copy_(src.to(device))
+        # whole-buffer compare also proves the copy leaves neighbors untouched
+        self.assertEqual(dst_dev.cpu(), dst_cpu)
+
+
 class TestLargeTensors(TestCaseMPS):
     @serialTest()
     def test_64bit_binops(self):
@@ -16133,6 +16180,7 @@ instantiate_device_type_tests(TestConsistency, globals(), allow_mps=True, only_f
 instantiate_device_type_tests(TestErrorInputs, globals(), allow_mps=True, only_for="mps")
 instantiate_device_type_tests(TestCommon, globals(), allow_mps=True, only_for="mps")
 instantiate_device_type_tests(TestLinalgMPS, globals(), allow_mps=True, only_for="mps")
+instantiate_device_type_tests(TestInnerContiguous, globals(), allow_mps=True, only_for="mps")
 instantiate_parametrized_tests(TestAdvancedIndexing)
 instantiate_parametrized_tests(TestAutocastMPS)
 instantiate_parametrized_tests(TestBinaryIteratorConformance)


### PR DESCRIPTION
Fixes: https://github.com/pytorch/pytorch/issues/188482

This adds a new TensorIterator kernel flavor inner_contiguous. It is selected when the iterator is non-contiguous but its coalesced innermost dimension is unit-stride for every operand (TensorIterator::has_contiguous_first_dim()), ndim ≥ 2 and the inner extent clears a small threshold. 

The kernel computes each operand's outer offset once per contiguous run and then applies the existing ILP scheme (4 elements/thread) across the inner span to give coalesced accesses instead of per-element scalar traffic. When the inner dimension isn't contiguous it falls back to the strided kernel

For the special case of a same-dtype identity copy it dispatches one untyped kernel that moves the inner run as the widest aligned vector.


### Benchmarking
The op level S-curve for speedups for before/after attached below  as well as the script to reproduce the results using the PR branch. Tested using M2 Max on macOS27 beta. The ops tested there are:

**Unary:** neg, abs, sign, relu, exp, log, sqrt, rsqrt, sin, cos, tanh, sigmoid, erf, expm1, log1p, floor, trunc, reciprocal, i0, bitwise_not
  
**Binary:** mul, add, sub, maximum, minimum, eq, lt, remainder, fmod, div, fmax, pow, atan2, hypot, copysign, logaddexp, xlogy, gcd, bitwise_and, bitwise_or

**Copy:** copy_

<img width="2600" height="1000" alt="speedup" src="https://github.com/user-attachments/assets/182e8e90-6f6f-416d-bebe-7a81037ad200" />

[plot_speedup.py](https://github.com/user-attachments/files/29481639/plot_speedup.py)
