### PR TITLE
[inductor] cpp_wrapper: box None as undefined tensor for non-optional Tensor args (#188485)

### DIFF
--- a/test/inductor/custom_ops.cpp
+++ b/test/inductor/custom_ops.cpp
@@ -1,5 +1,7 @@
 #include <torch/csrc/api/include/torch/types.h>  // @manual=fbcode//caffe2:libtorch
 
+#include <ATen/core/dispatch/Dispatcher.h> // @manual
+
 #include <torch/csrc/inductor/aoti_torch/c/shim.h> // @manual
 #include <torch/csrc/inductor/aoti_torch/utils.h> // @manual
 
@@ -381,6 +383,40 @@ Tensor fn_square_impl(const Tensor& tensor) {
 Tensor fn_square_meta(const Tensor& tensor) {
   return at::empty_like(tensor);
 }
+
+Tensor forward_maybe_weighted_impl(
+    const Tensor& x,
+    const Tensor& weight,
+    c10::SymInt /*n*/) {
+  // weight is undefined in the "unweighted" case, mirroring fbgemm TBE's
+  // indice_weights.  Boxed dispatch must hand us an undefined tensor here, not
+  // None.
+  if (weight.defined()) {
+    return x + weight;
+  }
+  return x.clone();
+}
+
+Tensor forward_maybe_weighted_meta(
+    const Tensor& x,
+    const Tensor& /*weight*/,
+    c10::SymInt /*n*/) {
+  return at::empty_like(x);
+}
+
+Tensor maybe_weighted_impl(
+    const Tensor& x,
+    const std::optional<Tensor>& weight,
+    c10::SymInt n) {
+  // Mirror fbgemm's autograd wrapper: materialize an undefined tensor from the
+  // absent optional via value_or(Tensor()), then dispatch the inner op so it
+  // (and its undefined non-optional Tensor arg) lands in the traced graph.
+  static auto op =
+      c10::Dispatcher::singleton()
+          .findSchemaOrThrow("aoti_custom_ops::forward_maybe_weighted", "")
+          .typed<Tensor(const Tensor&, const Tensor&, c10::SymInt)>();
+  return op.call(x, weight.value_or(at::Tensor()), n);
+}
 } // namespace at
 
 
@@ -466,6 +502,8 @@ TORCH_LIBRARY(aoti_custom_ops, m) {
 
   m.def("fn_out_variant_without_return(Tensor x, Tensor(a!) out) -> ()");
   m.def("fn_square(Tensor x) -> Tensor");
+  m.def("forward_maybe_weighted(Tensor x, Tensor weight, SymInt n) -> Tensor");
+  m.def("maybe_weighted(Tensor x, Tensor? weight, SymInt n) -> Tensor");
 }
 
 TORCH_LIBRARY_IMPL(aoti_custom_ops, CompositeExplicitAutograd, m) {
@@ -482,6 +520,11 @@ TORCH_LIBRARY_IMPL(aoti_custom_ops, CompositeExplicitAutograd, m) {
   m.impl("fn_with_input_mutation", at::fn_with_input_mutation_impl);
   m.impl("fn_out_variant_without_return", at::fn_out_variant_without_return_impl);
   m.impl("fn_square", at::fn_square_impl);
+  m.impl("forward_maybe_weighted", at::forward_maybe_weighted_impl);
+}
+
+TORCH_LIBRARY_IMPL(aoti_custom_ops, CompositeImplicitAutograd, m) {
+  m.impl("maybe_weighted", at::maybe_weighted_impl);
 }
 
 TORCH_LIBRARY_IMPL(aoti_custom_ops, Meta, m) {
@@ -497,4 +540,5 @@ TORCH_LIBRARY_IMPL(aoti_custom_ops, Meta, m) {
   m.impl("fn_with_input_mutation", at::fn_with_input_mutation_meta);
   m.impl("fn_out_variant_without_return", at::fn_out_variant_without_return_meta);
   m.impl("fn_square", at::fn_square_meta);
+  m.impl("forward_maybe_weighted", at::forward_maybe_weighted_meta);
 }

--- a/test/inductor/test_gpu_cpp_wrapper.py
+++ b/test/inductor/test_gpu_cpp_wrapper.py
@@ -22,7 +22,12 @@ from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import IndentedBuffer
 from torch._inductor.virtualized import V
 from torch.testing._internal.common_utils import (
+    find_library_location,
     instantiate_parametrized_tests,
+    IS_FBCODE,
+    IS_MACOS,
+    IS_SANDCASTLE,
+    IS_WINDOWS,
     parametrize,
     skipIfXpu,
     slowTest,
@@ -280,6 +285,38 @@ class TestGpuWrapper(InductorTestCase):
             self.assertNotIn(
                 'aoti_torch_call_dispatcher("mylib_symint::add_symint"', code
             )
+
+    @config.patch(implicit_fallbacks=True)
+    def test_custom_op_fallback_boxes_none_as_undefined_tensor(self):
+        if not RUN_GPU:
+            self.skipTest("GPU not available")
+        if IS_FBCODE or IS_SANDCASTLE:
+            torch.ops.load_library("//caffe2/test/inductor:custom_ops")
+        elif IS_MACOS:
+            self.skipTest("non-portable load_library call used in test")
+        else:
+            lib_path = find_library_location("libaoti_custom_ops.so")
+            if IS_WINDOWS:
+                lib_path = find_library_location("aoti_custom_ops.dll")
+            if not os.path.exists(lib_path):
+                self.skipTest("libaoti_custom_ops not built")
+            torch.ops.load_library(str(lib_path))
+
+        device = self.device
+
+        def fn(x):
+            return torch.ops.aoti_custom_ops.maybe_weighted(x, None, x.shape[0])
+
+        x = torch.randn(8, 4, device=device)
+        torch._dynamo.mark_dynamic(x, 0)
+        expected = fn(x)
+        compiled = torch.compile(fullgraph=True, options={"cpp_wrapper": True})(fn)
+        actual, code = test_torchinductor.run_and_get_cpp_code(compiled, x)
+        self.assertEqual(actual, expected)
+        # The composite must decompose to the inner op, which is boxed-dispatched
+        # with its undefined weight materialized as an undefined tensor, not None.
+        self.assertIn("aoti_custom_ops::forward_maybe_weighted", code)
+        self.assertIn("c10::IValue(at::Tensor())", code)
 
     @skipIfXpu(msg="tests CUDA/ROCm CUDADeviceOpOverrides codegen")
     def test_cpp_scratch_scales_with_grid_size_for_tma(self):

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -3787,6 +3787,12 @@ if (!custom_op_wrapper) {
 
             def codegen_ivalue(raw_arg: Any, arg_type: torch.JitType) -> str:
                 if raw_arg is None:
+                    # A None at a non-optional Tensor arg means an absent tensor.
+                    # Box it as an undefined at::Tensor (ATen's absent-tensor
+                    # sentinel, matching eager value_or(Tensor())); boxing None
+                    # would fail to unbox as `const Tensor&`.  Optionals stay None.
+                    if isinstance(arg_type, torch.TensorType):
+                        return "c10::IValue(at::Tensor())"
                     return "c10::IValue()"
 
                 if isinstance(arg_type, torch.OptionalType):


### PR DESCRIPTION
Summary:

When cpp_wrapper boxed-dispatches a custom op (the path that SymInt-bearing ops take), a `None` at a non-optional `Tensor` argument was boxed as `c10::IValue()` (None), which fails to unbox as `const Tensor&` with `RuntimeError: Expected Tensor but got None`. This hit fbgemm TBE ops such as `split_embedding_codegen_forward_unweighted_pt2_wrapper`, whose `indice_weights` is `None` in the unweighted case: eager materializes it to an undefined tensor via `value_or(Tensor())`, but that C++ materialization is absent from the compiled graph.

Fix: in `codegen_ivalue`, box a `None` at a non-optional `Tensor` arg as an undefined `at::Tensor()` (ATen's canonical absent-tensor sentinel), matching eager. Genuine `Tensor?` optionals still box as `None`.

Authored with AI assistance.

Reviewed By: kqfu

Differential Revision: D109651557




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo