### PR TITLE
[dynamo] Use Literal types for fixed string vocabularies

### DIFF
--- a/torch/_dynamo/compiled_autograd.py
+++ b/torch/_dynamo/compiled_autograd.py
@@ -21,7 +21,7 @@ import operator
 import time
 from collections import Counter, defaultdict
 from collections.abc import Callable, Generator, Sequence
-from typing import Any, TYPE_CHECKING
+from typing import Any, Literal, TYPE_CHECKING
 
 import torch
 import torch.utils._pytree as pytree
@@ -78,6 +78,17 @@ TURN_OFF_MSG = """You can turn off compiled autograd by either:
 
 compiled_autograd_log = getArtifactLogger(__name__, "compiled_autograd")
 verbose_log = getArtifactLogger(__name__, "compiled_autograd_verbose")
+
+# The kind of autograd hook being proxied. Threaded through proxy_call_hook into
+# the fx node's kwargs, where the graph post-processing passes read it back to
+# match nodes (e.g. node.kwargs["hook_type"] == "post_hook").
+HookType = Literal[
+    "unpack_hook",
+    "tensor_pre_hook",
+    "pre_hook",
+    "post_hook",
+    "post_acc_grad_hook",
+]
 
 
 def snapshot_verbose_logging_enabled() -> bool:
@@ -884,7 +895,7 @@ class AutogradCompilerInstance:
         return result
 
     def proxy_call_hook(
-        self, hook: Callable[..., Any], *args: Any, **kwargs: Any
+        self, hook: Callable[..., Any], *args: Any, hook_type: HookType
     ) -> torch.fx.Proxy:
         return self.fx_tracer.create_proxy(
             "call_function",
@@ -893,7 +904,7 @@ class AutogradCompilerInstance:
                 hook,
                 *[self.to_proxy(x) for x in args],
             ),
-            kwargs,
+            {"hook_type": hook_type},
         )
 
     def unpack_hook(self, hook_id: int, data_id: int) -> torch.Tensor:

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -30,6 +30,7 @@ from .eval_frame import (
     innermost_fn,
     RunOnlyContext,
     skip_code,
+    StanceStr,
 )
 from .external_utils import (
     get_nonrecursive_disable_wrapper,
@@ -152,7 +153,7 @@ class set_stance(_DecoratorContextManager):
 
     def __init__(
         self,
-        stance: str = "default",
+        stance: StanceStr = "default",
         *,
         skip_guard_eval_unsafe: bool = False,
         force_backend: str | Callable[..., Any] | None = None,

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -44,7 +44,7 @@ from collections.abc import Generator, Sized
 from dataclasses import dataclass
 from enum import Enum
 from os.path import dirname, join
-from typing import Any, NamedTuple, TYPE_CHECKING
+from typing import Any, Literal, NamedTuple, TYPE_CHECKING
 from unittest.mock import patch
 
 import sympy
@@ -179,9 +179,22 @@ else:
             return set_eval_frame(callback)
 
 
+# The set of valid stance strings accepted by torch.compiler.set_stance. Kept as
+# a shared alias so producers (set_stance) and the exhaustive consumer
+# (_callback_from_stance) stay in sync at type-check time.
+StanceStr = Literal[
+    "default",
+    "eager_then_compile",
+    "aot_eager_then_compile",
+    "force_eager",
+    "eager_on_recompile",
+    "fail_on_recompile",
+]
+
+
 @dataclass
 class DynamoStance:
-    stance: str = "default"
+    stance: StanceStr = "default"
     skip_guard_eval_unsafe: bool = False
     backend: str | Callable[..., Any] | None = None
 
@@ -339,7 +352,7 @@ def _get_or_add_example_inputs(frame: DynamoFrameType) -> list[Any]:
 
 
 def _create_delayed_compile_callback(
-    callback: DynamoCallback, stance: str
+    callback: DynamoCallback, stance: StanceStr
 ) -> Callable[..., Any]:
     def callback_fn(*args: Any, **kwargs: Any) -> convert_frame.ConvertFrameReturn:
         frame = args[0]

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -5191,7 +5191,12 @@ def get_instruction_source_311(code: types.CodeType, inst: Instruction) -> str:
     )
 
 
-def get_static_address_type(t: Any) -> Any:
+# The two flavors of mark_static_address: "guarded" recompiles when the data_ptr
+# changes, "unguarded" re-records cudagraphs instead. Set in decorators.py.
+StaticInputType = Literal["guarded", "unguarded"]
+
+
+def get_static_address_type(t: Any) -> StaticInputType | None:
     if isinstance(t, torch.Tensor):
         return getattr(t, "_dynamo_static_input_type", None)
 
@@ -5641,7 +5646,14 @@ def set_feature_use(feature: str, usage: bool) -> None:
         get_metrics_context().set_key_value("feature_usage", feature, usage)
 
 
-_ddp_optimization_mode: tuple[str, ...] = (
+OptimizeDDPMode = Literal[
+    "ddp_optimizer",
+    "python_reducer",
+    "python_reducer_without_compiled_forward",
+    "no_optimization",
+]
+
+_ddp_optimization_mode: tuple[OptimizeDDPMode, ...] = (
     "ddp_optimizer",
     "python_reducer",  # experimental mode
     "python_reducer_without_compiled_forward",
@@ -5649,7 +5661,7 @@ _ddp_optimization_mode: tuple[str, ...] = (
 )
 
 
-def get_optimize_ddp_mode() -> str:
+def get_optimize_ddp_mode() -> OptimizeDDPMode:
     optimize_ddp = config.optimize_ddp
     if isinstance(optimize_ddp, bool):
         mode = "ddp_optimizer" if optimize_ddp else "no_optimization"
@@ -5662,7 +5674,7 @@ def get_optimize_ddp_mode() -> str:
 
     if mode not in _ddp_optimization_mode:
         raise AssertionError(f"Invalid dynamo config optimize_ddp value {mode=}")
-    return mode
+    return cast("OptimizeDDPMode", mode)
 
 
 @contextmanager

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -29,7 +29,7 @@ import warnings
 from collections import Counter
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import Any, cast, Literal, Optional, TYPE_CHECKING, Union
+from typing import Any, cast, get_args, Literal, Optional, TYPE_CHECKING, Union
 
 import torch._C
 import torch.fx
@@ -85,6 +85,13 @@ HOP_VT_Alias = TypeVar("HOP_VT_Alias", bound="TorchHigherOrderOperatorVariable")
 
 log = logging.getLogger(__name__)
 hc_log = torch._logging.getArtifactLogger(__name__, "hierarchical_compile")
+
+# How speculate_subgraph constructs subgraph placeholders from sub_args. See
+# NOTE [argument `set_subgraph_inputs`] below for the meaning of each value. This
+# is the single source of truth for the runtime asserts that validate the value.
+SetSubgraphInputs = Literal[
+    "automatic", "automatic_with_forced_inputs", "flatten_manual", "manual"
+]
 
 
 @dataclass
@@ -1131,7 +1138,7 @@ def validate_args_and_maybe_create_graph_inputs(
     sub_args: list[VariableTracker],
     tracer: "SubgraphTracer",
     tx: "InstructionTranslatorBase",
-    set_subgraph_inputs: str,
+    set_subgraph_inputs: SetSubgraphInputs,
     description: str,
     sub_args_names: Sequence[str] | None = None,
 ) -> list[Any]:
@@ -1598,7 +1605,7 @@ def get_hop_args(
     subtracer: "SubgraphTracer",
     sub_args: list[VariableTracker],
     sub_kwargs: dict[str, VariableTracker],
-    set_subgraph_inputs: str,
+    set_subgraph_inputs: SetSubgraphInputs,
     description: str,
 ) -> list[VariableTracker]:
     sub_args_names = maybe_positional_arg_names(f)
@@ -1650,9 +1657,7 @@ def speculate_subgraph_with_auto_output_flattening(
     # order they are see while tracing). This is useful for autograd.Function
     # backward where we do need to account for all the inputs of the backwards
     # to be lifted as inputs for making the fwd-bwd graph consistent.
-    set_subgraph_inputs: Literal[
-        "automatic", "automatic_with_forced_inputs", "flatten_manual", "manual"
-    ] = "automatic",
+    set_subgraph_inputs: SetSubgraphInputs = "automatic",
     # If True, exposes intermediates to subgraph outputs to allow later tensor ops to
     # access intermediates from the subgraph, this is useful for mutation
     allow_side_effects: bool = False,
@@ -1781,12 +1786,7 @@ def speculate_subgraph_with_auto_output_flattening(
     if sub_kwargs is None:
         sub_kwargs = {}
 
-    if set_subgraph_inputs not in {
-        "automatic",
-        "automatic_with_forced_inputs",
-        "flatten_manual",
-        "manual",
-    }:
+    if set_subgraph_inputs not in get_args(SetSubgraphInputs):
         raise AssertionError(
             "Please use one of the supported set_subgraph_inputs options."
         )
@@ -2022,9 +2022,7 @@ def speculate_subgraph(
     # 3. if your HOP must preserve inputs that are not tensor or symnode as placeholders e.g. AutogradFunctionContextVariable
     # use set_subgraph_inputs="manual" (not recommended). We do not recommend it in general because it has the
     # restriction that user need to manually control how to create placeholders and VariableTrackers for the args.
-    set_subgraph_inputs: Literal[
-        "automatic", "semi_automatic", "flatten_manual", "manual"
-    ] = "automatic",
+    set_subgraph_inputs: SetSubgraphInputs = "automatic",
     restore_side_effects: bool = True,
     should_flatten_outputs: bool = False,
     # if should_flatten_outputs is True, `remove_consts_from_outputs` remove the
@@ -2042,12 +2040,7 @@ def speculate_subgraph(
 
     from .builder import SourcelessBuilder
 
-    if set_subgraph_inputs not in {
-        "automatic",
-        "automatic_with_forced_inputs",
-        "flatten_manual",
-        "manual",
-    }:
+    if set_subgraph_inputs not in get_args(SetSubgraphInputs):
         raise AssertionError(
             "Please use one of the supported set_subgraph_inputs options."
         )

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -2087,7 +2087,7 @@ class TensorVariable(VariableTracker):
                         "register_hook",
                         source_target=None,
                         enable_grad=None,
-                        set_subgraph_inputs="automatic_with_forced_inputs",  # pyrefly: ignore[bad-argument-type]
+                        set_subgraph_inputs="automatic_with_forced_inputs",
                         restore_side_effects=True,
                     )
             except torch._dynamo.exc.UnknownPropertiesDuringBackwardTrace:

--- a/torch/compiler/__init__.py
+++ b/torch/compiler/__init__.py
@@ -2,7 +2,7 @@
 import contextlib
 import io
 from collections.abc import Callable
-from typing import Any, TypeVar
+from typing import Any, TYPE_CHECKING, TypeVar
 from typing_extensions import ParamSpec
 
 import torch
@@ -10,6 +10,10 @@ from torch._higher_order_ops.invoke_subgraph import NestedCompileRegionOptions
 
 from . import config
 from ._cache import CacheInfo
+
+
+if TYPE_CHECKING:
+    from torch._dynamo.eval_frame import StanceStr
 
 
 __all__ = [
@@ -368,7 +372,7 @@ def get_default_backend() -> str | Callable[..., Any]:
 
 
 def set_stance(
-    stance: str = "default",
+    stance: "StanceStr" = "default",
     *,
     skip_guard_eval_unsafe: bool = False,
     force_backend: str | Callable[..., Any] | None = None,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #188486

Several internal dynamo APIs accept or return strings drawn from a small,
fixed set of valid values, but were typed as bare `str` (or `Any`). This
replaces those with shared `typing.Literal` aliases so that an invalid
value is caught at type-check time (pyrefly) instead of slipping through
to a runtime assert or silent misbehavior.

Five vocabularies are covered:

- `StanceStr` (eval_frame.py): the `torch.compiler.set_stance` values,
  applied to `set_stance` (both the dynamo decorator and the public
  `torch.compiler` wrapper), `DynamoStance.stance`, and
  `_create_delayed_compile_callback`. These are already validated
  exhaustively in `_callback_from_stance`.
- `SetSubgraphInputs` (higher_order_ops.py): the subgraph-input modes for
  `speculate_subgraph`. Two helpers were typed `str`; two call sites
  already had inline `Literal`s, one of which incorrectly listed
  `"semi_automatic"` -- a value that does not exist and would always trip
  the runtime assert. Consolidating onto a single alias fixes that drift,
  and the two runtime asserts now derive their accepted set from the alias
  via `typing.get_args` so they can never fall out of sync again.
- `StaticInputType` (utils.py): `get_static_address_type` now returns
  `Literal["guarded", "unguarded"] | None` instead of `Any`.
- `OptimizeDDPMode` (utils.py): `get_optimize_ddp_mode` is typed to the
  four DDP optimization modes, and the `_ddp_optimization_mode` tuple it
  validates against is typed to match.
- `HookType` (compiled_autograd.py): `proxy_call_hook`'s `hook_type` is
  lifted out of `**kwargs` into an explicit keyword-only parameter. The fx
  node kwargs it constructs are unchanged (`{"hook_type": hook_type}`), so
  this is behavior-preserving; it just makes the five call sites
  type-checked.

The only call-signature change is `proxy_call_hook`; review that one
closely. It is behavior-preserving because all five callers already passed
`hook_type` as their sole keyword argument, so the dict handed to
`create_proxy` is identical before and after.

Test Plan:

This is a typing-only change plus the one behavior-preserving signature
refactor noted above. Validated with lintrunner; pyrefly reports no errors
in the touched files:

```
lintrunner --take PYFMT,RUFF,PYREFLY,CODESPELL,FLAKE8 \
  torch/_dynamo/decorators.py \
  torch/_dynamo/eval_frame.py \
  torch/_dynamo/utils.py \
  torch/_dynamo/variables/higher_order_ops.py \
  torch/_dynamo/compiled_autograd.py \
  torch/compiler/__init__.py
```

Runtime behavior is unchanged; the existing suites (test/dynamo and
test/inductor/test_compiled_autograd.py) exercise these paths in CI.

Authored with the help of an AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @xmfan @aditvenk