### PR TITLE
Add Literal aliases for Dynamo string vocabularies

### DIFF
--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -4074,8 +4074,8 @@ class CompiledAutograd0(torch.nn.Module):
         getitem_18 = packed_data[0]
         getitem_19 = hooks[1]
         getitem_20 = packed_data[1]
-        call_hook = torch__dynamo_external_utils_call_hook(getitem_17, getitem_18, hook_type = 'unpack_hook');  getitem_17 = getitem_18 = None
-        call_hook_1 = torch__dynamo_external_utils_call_hook(getitem_19, getitem_20, hook_type = 'unpack_hook');  getitem_19 = getitem_20 = None
+        call_hook = torch__dynamo_external_utils_call_hook(getitem_17, 'unpack_hook', getitem_18);  getitem_17 = getitem_18 = None
+        call_hook_1 = torch__dynamo_external_utils_call_hook(getitem_19, 'unpack_hook', getitem_20);  getitem_19 = getitem_20 = None
         mul_backward0 = torch__dynamo_compiled_autograd_ops_MulBackward0([getitem_16], [True, True], call_hook, 6, call_hook_1, 6);  getitem_16 = call_hook = call_hook_1 = None
         getitem_21 = mul_backward0[0]
         getitem_22 = mul_backward0[1];  mul_backward0 = None
@@ -4085,7 +4085,7 @@ class CompiledAutograd0(torch.nn.Module):
 
         getitem_25 = hooks[2]
         getitem_26 = packed_data[2]
-        call_hook_2 = torch__dynamo_external_utils_call_hook(getitem_25, getitem_26, hook_type = 'unpack_hook');  getitem_25 = getitem_26 = None
+        call_hook_2 = torch__dynamo_external_utils_call_hook(getitem_25, 'unpack_hook', getitem_26);  getitem_25 = getitem_26 = None
         cos_backward0 = torch__dynamo_compiled_autograd_ops_CosBackward0([getitem_24], [True], call_hook_2);  getitem_24 = call_hook_2 = None
         getitem_27 = cos_backward0[0];  cos_backward0 = None
         validate_outputs_3 = torch__dynamo_compiled_autograd_ops_validate_outputs([getitem_27], [((None, None, device(type='cpu'), 6, 0, None), [unwrap_maybe_dynamic_int_8, unwrap_maybe_dynamic_int_9], False, 6)]);  getitem_27 = unwrap_maybe_dynamic_int_8 = unwrap_maybe_dynamic_int_9 = None
@@ -4094,7 +4094,7 @@ class CompiledAutograd0(torch.nn.Module):
 
         getitem_29 = hooks[3];  hooks = None
         getitem_30 = packed_data[3];  packed_data = None
-        call_hook_3 = torch__dynamo_external_utils_call_hook(getitem_29, getitem_30, hook_type = 'unpack_hook');  getitem_29 = getitem_30 = None
+        call_hook_3 = torch__dynamo_external_utils_call_hook(getitem_29, 'unpack_hook', getitem_30);  getitem_29 = getitem_30 = None
         sin_backward0 = torch__dynamo_compiled_autograd_ops_SinBackward0([add], [True], call_hook_3);  add = call_hook_3 = None
         getitem_31 = sin_backward0[0];  sin_backward0 = None
         validate_outputs_4 = torch__dynamo_compiled_autograd_ops_validate_outputs([getitem_31], [((None, None, device(type='cpu'), 6, 0, None), [unwrap_maybe_dynamic_int_10, unwrap_maybe_dynamic_int_11], False, 6)]);  getitem_31 = unwrap_maybe_dynamic_int_10 = unwrap_maybe_dynamic_int_11 = None
@@ -4169,7 +4169,7 @@ class CompiledAutograd1(torch.nn.Module):
         getitem_8 = hooks[0]
         getitem_9 = packed_data[0];  packed_data = None
         getitem_10 = hooks[1];  hooks = None
-        call_hook = torch__dynamo_external_utils_call_hook(getitem_8, getitem_9, hook_type = 'unpack_hook');  getitem_8 = getitem_9 = None
+        call_hook = torch__dynamo_external_utils_call_hook(getitem_8, 'unpack_hook', getitem_9);  getitem_8 = getitem_9 = None
         call_backward = torch__dynamo_external_utils_call_backward(getitem_10, (call_hook,), getitem_7);  getitem_10 = call_hook = getitem_7 = None
         getitem_12 = call_backward[0];  call_backward = None
         validate_outputs_2 = torch__dynamo_compiled_autograd_ops_validate_outputs([getitem_12], [((None, None, device(type='cuda', index=0), 6, 0, None), [getitem_3], False)]);  getitem_12 = getitem_3 = None
@@ -4254,7 +4254,7 @@ class CompiledAutograd1(torch.nn.Module):
         getitem_7 = hooks[0]
         getitem_8 = packed_data[0];  packed_data = None
         getitem_9 = hooks[1];  hooks = None
-        call_hook = torch__dynamo_external_utils_call_hook(getitem_7, getitem_8, hook_type = 'unpack_hook');  getitem_7 = getitem_8 = None
+        call_hook = torch__dynamo_external_utils_call_hook(getitem_7, 'unpack_hook', getitem_8);  getitem_7 = getitem_8 = None
         call_backward = torch__dynamo_external_utils_call_backward(getitem_9, (call_hook,), getitem_6);  getitem_9 = call_hook = getitem_6 = None
         getitem_11 = call_backward[0];  call_backward = None
         validate_outputs_2 = torch__dynamo_compiled_autograd_ops_validate_outputs([getitem_11], [((None, None, device(type='cpu'), 6, 0, None), [getitem_3], False)]);  getitem_11 = getitem_3 = None

--- a/torch/_compiler_types.py
+++ b/torch/_compiler_types.py
@@ -1,0 +1,35 @@
+from typing import Literal, TypeAlias
+
+
+StanceStr: TypeAlias = Literal[
+    "default",
+    "eager_then_compile",
+    "aot_eager_then_compile",
+    "force_eager",
+    "eager_on_recompile",
+    "fail_on_recompile",
+]
+
+SetSubgraphInputs: TypeAlias = Literal[
+    "automatic",
+    "automatic_with_forced_inputs",
+    "flatten_manual",
+    "manual",
+]
+
+StaticAddressType: TypeAlias = Literal["guarded", "unguarded"]
+
+OptimizeDdpMode: TypeAlias = Literal[
+    "ddp_optimizer",
+    "python_reducer",
+    "python_reducer_without_compiled_forward",
+    "no_optimization",
+]
+
+HookType: TypeAlias = Literal[
+    "unpack_hook",
+    "tensor_pre_hook",
+    "pre_hook",
+    "post_hook",
+    "post_acc_grad_hook",
+]

--- a/torch/_dynamo/compiled_autograd.py
+++ b/torch/_dynamo/compiled_autograd.py
@@ -21,10 +21,11 @@ import operator
 import time
 from collections import Counter, defaultdict
 from collections.abc import Callable, Generator, Sequence
-from typing import Any, Literal, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 import torch
 import torch.utils._pytree as pytree
+from torch._compiler_types import HookType
 from torch._dispatch.python import enable_python_dispatcher
 from torch._dynamo.external_utils import (
     call_accumulate_grad,
@@ -78,15 +79,6 @@ TURN_OFF_MSG = """You can turn off compiled autograd by either:
 
 compiled_autograd_log = getArtifactLogger(__name__, "compiled_autograd")
 verbose_log = getArtifactLogger(__name__, "compiled_autograd_verbose")
-
-HookType = Literal[
-    "unpack_hook",
-    "tensor_pre_hook",
-    "pre_hook",
-    "post_hook",
-    "post_acc_grad_hook",
-]
-
 
 def snapshot_verbose_logging_enabled() -> bool:
     return torch._logging._internal.log_state.is_artifact_enabled(

--- a/torch/_dynamo/compiled_autograd.py
+++ b/torch/_dynamo/compiled_autograd.py
@@ -21,7 +21,7 @@ import operator
 import time
 from collections import Counter, defaultdict
 from collections.abc import Callable, Generator, Sequence
-from typing import Any, TYPE_CHECKING
+from typing import Any, Literal, TYPE_CHECKING
 
 import torch
 import torch.utils._pytree as pytree
@@ -78,6 +78,14 @@ TURN_OFF_MSG = """You can turn off compiled autograd by either:
 
 compiled_autograd_log = getArtifactLogger(__name__, "compiled_autograd")
 verbose_log = getArtifactLogger(__name__, "compiled_autograd_verbose")
+
+HookType = Literal[
+    "unpack_hook",
+    "tensor_pre_hook",
+    "pre_hook",
+    "post_hook",
+    "post_acc_grad_hook",
+]
 
 
 def snapshot_verbose_logging_enabled() -> bool:
@@ -884,16 +892,17 @@ class AutogradCompilerInstance:
         return result
 
     def proxy_call_hook(
-        self, hook: Callable[..., Any], *args: Any, **kwargs: Any
+        self, hook: Callable[..., Any], hook_type: HookType, *args: Any
     ) -> torch.fx.Proxy:
         return self.fx_tracer.create_proxy(
             "call_function",
             call_hook,
             (
                 hook,
+                hook_type,
                 *[self.to_proxy(x) for x in args],
             ),
-            kwargs,
+            {},
         )
 
     def unpack_hook(self, hook_id: int, data_id: int) -> torch.Tensor:
@@ -903,8 +912,8 @@ class AutogradCompilerInstance:
         data = self.packed_data_proxy[data_id]  # type: ignore[index]
         proxy = self.proxy_call_hook(
             hook,
+            "unpack_hook",
             data,
-            hook_type="unpack_hook",
         )
         out = self.allocate_dummy()
         self.bind_objects_to_proxies([out], [proxy])
@@ -918,8 +927,8 @@ class AutogradCompilerInstance:
         hook = self.hooks_proxy[hook_id]  # type: ignore[index]
         proxy = self.proxy_call_hook(
             hook,
+            "tensor_pre_hook",
             inputs[i],
-            hook_type="tensor_pre_hook",
         )
         with disable_proxy_modes_tracing():
             inputs[i] = maybe_clone(inputs[i])  # type: ignore[assignment]
@@ -946,8 +955,8 @@ class AutogradCompilerInstance:
         hook = self.hooks_proxy[hook_id]  # type: ignore[index]
         proxies = self.proxy_call_hook(
             hook,
+            "pre_hook",
             inputs,
-            hook_type="pre_hook",
         )
         with disable_proxy_modes_tracing():
             inputs = [maybe_clone(x) for x in inputs]
@@ -962,9 +971,9 @@ class AutogradCompilerInstance:
         hook = self.hooks_proxy[hook_id]  # type: ignore[index]
         proxies = self.proxy_call_hook(
             hook,
+            "post_hook",
             outputs,
             inputs,
-            hook_type="post_hook",
         )
         with disable_proxy_modes_tracing():
             outputs = [maybe_clone(x) for x in outputs]  # type: ignore[misc]
@@ -981,8 +990,8 @@ class AutogradCompilerInstance:
         hook = self.hooks_proxy[hook_id]  # type: ignore[index]
         proxy = self.proxy_call_hook(
             hook,
+            "post_acc_grad_hook",
             input,
-            hook_type="post_acc_grad_hook",
         )
         with disable_proxy_modes_tracing():
             res = [maybe_clone(input)]
@@ -1311,7 +1320,7 @@ class AutogradCompilerInstance:
         for node in self.fx_tracer.graph.find_nodes(
             op="call_function", target=call_hook
         ):
-            if node.kwargs.get("hook_type", None) != "unpack_hook":
+            if node.args[1] != "unpack_hook":
                 continue
 
             first_user = min(node.users)
@@ -1327,11 +1336,11 @@ class AutogradCompilerInstance:
         for node in self.fx_tracer.graph.find_nodes(
             op="call_function", target=call_hook
         ):
-            if node.kwargs.get("hook_type", None) != "tensor_pre_hook":
+            if node.args[1] != "tensor_pre_hook":
                 continue
 
             getitem_node = node.args[0]
-            input_node = node.args[1]  # tensor_pre_hook handle only one grad tensor
+            input_node = node.args[2]  # tensor_pre_hook handle only one grad tensor
 
             if input_node is not node.prev and not self.is_placeholder(input_node):
                 input_node.append(getitem_node)
@@ -1348,12 +1357,12 @@ class AutogradCompilerInstance:
         for node in self.fx_tracer.graph.find_nodes(
             op="call_function", target=call_hook
         ):
-            if node.kwargs.get("hook_type", None) != "pre_hook":
+            if node.args[1] != "pre_hook":
                 continue
 
             getitem_node = node.args[0]
             # pre_hook handle a tuple of grad tensors
-            input_nodes = self.get_all_nodes(node.args[1])
+            input_nodes = self.get_all_nodes(node.args[2])
 
             to_remove = []
             to_append = []
@@ -1384,7 +1393,7 @@ class AutogradCompilerInstance:
         for node in self.fx_tracer.graph.find_nodes(
             op="call_function", target=call_hook
         ):
-            if node.kwargs.get("hook_type", None) != "pre_hook":
+            if node.args[1] != "pre_hook":
                 continue
             pre_hooks.append(node)
 
@@ -1422,7 +1431,7 @@ class AutogradCompilerInstance:
         for node in self.fx_tracer.graph.find_nodes(
             op="call_function", target=call_hook
         ):
-            if node.kwargs.get("hook_type", None) != "post_acc_grad_hook":
+            if node.args[1] != "post_acc_grad_hook":
                 continue
             post_acc_grad_hooks.append(node)
 
@@ -1430,7 +1439,7 @@ class AutogradCompilerInstance:
         # to same node, we should keep their relative order
         for node in reversed(post_acc_grad_hooks):
             getitem_node = node.args[0]
-            param_node = node.args[1]  # post_acc_grad_hook handle one param
+            param_node = node.args[2]  # post_acc_grad_hook handle one param
 
             # find the corresponding acc_grad node
             acc_grad_node = None
@@ -1459,14 +1468,14 @@ class AutogradCompilerInstance:
         for node in self.fx_tracer.graph.find_nodes(
             op="call_function", target=call_hook
         ):
-            if node.kwargs.get("hook_type", None) != "post_hook":
+            if node.args[1] != "post_hook":
                 continue
             post_hooks.append(node)
 
         for node in reversed(post_hooks):
             getitem_node = node.args[0]
-            output_nodes = node.args[1]
-            input_nodes = node.args[2]
+            output_nodes = node.args[2]
+            input_nodes = node.args[3]
 
             if len(output_nodes) > 0:
                 continue
@@ -1481,7 +1490,7 @@ class AutogradCompilerInstance:
                     if not (
                         user.op == "call_function"
                         and user.target is call_hook
-                        and node.kwargs.get("hook_type", None) == "post_hook"
+                        and node.args[1] == "post_hook"
                     )
                 )
 
@@ -1493,7 +1502,7 @@ class AutogradCompilerInstance:
                     if (
                         n.op == "call_function"
                         and n.target is call_hook
-                        and n.kwargs.get("hook_type", None) == "post_acc_grad_hook"
+                        and n.args[1] == "post_acc_grad_hook"
                     ):
                         post_acc_grad_hook_node = n
 

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -30,6 +30,7 @@ from .eval_frame import (
     innermost_fn,
     RunOnlyContext,
     skip_code,
+    StanceStr,
 )
 from .external_utils import (
     get_nonrecursive_disable_wrapper,
@@ -152,7 +153,7 @@ class set_stance(_DecoratorContextManager):
 
     def __init__(
         self,
-        stance: str = "default",
+        stance: StanceStr = "default",
         *,
         skip_guard_eval_unsafe: bool = False,
         force_backend: str | Callable[..., Any] | None = None,

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -13,6 +13,7 @@ from typing_extensions import ParamSpec
 
 import torch
 import torch.utils._pytree as pytree
+from torch._compiler_types import StanceStr
 from torch._opaque_base import OpaqueBase
 from torch._vendor.packaging.version import InvalidVersion, Version
 from torch.compiler import is_compiling
@@ -30,7 +31,6 @@ from .eval_frame import (
     innermost_fn,
     RunOnlyContext,
     skip_code,
-    StanceStr,
 )
 from .external_utils import (
     get_nonrecursive_disable_wrapper,

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -44,7 +44,7 @@ from collections.abc import Generator, Sized
 from dataclasses import dataclass
 from enum import Enum
 from os.path import dirname, join
-from typing import Any, Literal, NamedTuple, TYPE_CHECKING
+from typing import Any, NamedTuple, TYPE_CHECKING
 from unittest.mock import patch
 
 import sympy
@@ -69,6 +69,7 @@ from torch._C._dynamo.eval_frame import (  # noqa: F401
     set_skip_guard_eval_unsafe,
     unsupported,
 )
+from torch._compiler_types import StanceStr
 from torch._dispatch.python import enable_python_dispatcher
 from torch._dynamo.types import ConvertFrameReturn, FrameAction, FrameExecStrategy
 from torch._export.utils import _compiling_state_context
@@ -177,16 +178,6 @@ else:
             return callback
         else:
             return set_eval_frame(callback)
-
-
-StanceStr = Literal[
-    "default",
-    "eager_then_compile",
-    "aot_eager_then_compile",
-    "force_eager",
-    "eager_on_recompile",
-    "fail_on_recompile",
-]
 
 
 @dataclass

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -44,7 +44,7 @@ from collections.abc import Generator, Sized
 from dataclasses import dataclass
 from enum import Enum
 from os.path import dirname, join
-from typing import Any, NamedTuple, TYPE_CHECKING
+from typing import Any, Literal, NamedTuple, TYPE_CHECKING
 from unittest.mock import patch
 
 import sympy
@@ -179,9 +179,19 @@ else:
             return set_eval_frame(callback)
 
 
+StanceStr = Literal[
+    "default",
+    "eager_then_compile",
+    "aot_eager_then_compile",
+    "force_eager",
+    "eager_on_recompile",
+    "fail_on_recompile",
+]
+
+
 @dataclass
 class DynamoStance:
-    stance: str = "default"
+    stance: StanceStr = "default"
     skip_guard_eval_unsafe: bool = False
     backend: str | Callable[..., Any] | None = None
 

--- a/torch/_dynamo/external_utils.py
+++ b/torch/_dynamo/external_utils.py
@@ -72,7 +72,7 @@ def wrap_inline(fn: Callable[_P, _R]) -> Callable[_P, _R]:
 
 
 def call_hook(
-    hook: Callable[..., torch.Tensor | None], *args: Any, **kwargs: Any
+    hook: Callable[..., torch.Tensor | None], hook_type: str, *args: Any
 ) -> torch.Tensor:
     """
     Used by compiled autograd to handle hook returning None.
@@ -80,7 +80,7 @@ def call_hook(
     result = hook(*args)
     if result is None:
         return args[0]
-    elif kwargs.get("hook_type") == "post_acc_grad_hook":
+    elif hook_type == "post_acc_grad_hook":
         raise RuntimeError("Tensor post accumulate grad hooks should return None.")
     return result
 

--- a/torch/_dynamo/external_utils.py
+++ b/torch/_dynamo/external_utils.py
@@ -28,6 +28,7 @@ from typing_extensions import deprecated, ParamSpec
 
 import torch
 import torch.utils._pytree as pytree
+from torch._compiler_types import HookType
 
 
 try:
@@ -72,7 +73,7 @@ def wrap_inline(fn: Callable[_P, _R]) -> Callable[_P, _R]:
 
 
 def call_hook(
-    hook: Callable[..., torch.Tensor | None], hook_type: str, *args: Any
+    hook: Callable[..., torch.Tensor | None], hook_type: HookType, *args: Any
 ) -> torch.Tensor:
     """
     Used by compiled autograd to handle hook returning None.

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -5191,7 +5191,10 @@ def get_instruction_source_311(code: types.CodeType, inst: Instruction) -> str:
     )
 
 
-def get_static_address_type(t: Any) -> Any:
+StaticAddressType: TypeAlias = Literal["guarded", "unguarded"]
+
+
+def get_static_address_type(t: Any) -> StaticAddressType | None:
     if isinstance(t, torch.Tensor):
         return getattr(t, "_dynamo_static_input_type", None)
 
@@ -5641,7 +5644,14 @@ def set_feature_use(feature: str, usage: bool) -> None:
         get_metrics_context().set_key_value("feature_usage", feature, usage)
 
 
-_ddp_optimization_mode: tuple[str, ...] = (
+OptimizeDdpMode: TypeAlias = Literal[
+    "ddp_optimizer",
+    "python_reducer",
+    "python_reducer_without_compiled_forward",
+    "no_optimization",
+]
+
+_ddp_optimization_mode: tuple[OptimizeDdpMode, ...] = (
     "ddp_optimizer",
     "python_reducer",  # experimental mode
     "python_reducer_without_compiled_forward",
@@ -5649,7 +5659,7 @@ _ddp_optimization_mode: tuple[str, ...] = (
 )
 
 
-def get_optimize_ddp_mode() -> str:
+def get_optimize_ddp_mode() -> OptimizeDdpMode:
     optimize_ddp = config.optimize_ddp
     if isinstance(optimize_ddp, bool):
         mode = "ddp_optimizer" if optimize_ddp else "no_optimization"
@@ -5662,7 +5672,7 @@ def get_optimize_ddp_mode() -> str:
 
     if mode not in _ddp_optimization_mode:
         raise AssertionError(f"Invalid dynamo config optimize_ddp value {mode=}")
-    return mode
+    return cast(OptimizeDdpMode, mode)
 
 
 @contextmanager

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -68,6 +68,7 @@ import torch._functorch.config
 import torch.fx.experimental.symbolic_shapes
 import torch.utils._pytree as pytree
 from torch import fx
+from torch._compiler_types import OptimizeDdpMode, StaticAddressType
 from torch._C import (
     _instruction_counter,
     _len_torch_function_stack,
@@ -5191,9 +5192,6 @@ def get_instruction_source_311(code: types.CodeType, inst: Instruction) -> str:
     )
 
 
-StaticAddressType: TypeAlias = Literal["guarded", "unguarded"]
-
-
 def get_static_address_type(t: Any) -> StaticAddressType | None:
     if isinstance(t, torch.Tensor):
         return getattr(t, "_dynamo_static_input_type", None)
@@ -5643,13 +5641,6 @@ def set_feature_use(feature: str, usage: bool) -> None:
     if get_metrics_context().in_progress():
         get_metrics_context().set_key_value("feature_usage", feature, usage)
 
-
-OptimizeDdpMode: TypeAlias = Literal[
-    "ddp_optimizer",
-    "python_reducer",
-    "python_reducer_without_compiled_forward",
-    "no_optimization",
-]
 
 _ddp_optimization_mode: tuple[OptimizeDdpMode, ...] = (
     "ddp_optimizer",

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -82,6 +82,9 @@ from typing import ParamSpec, TypeVar
 P = ParamSpec("P")
 R = TypeVar("R")
 HOP_VT_Alias = TypeVar("HOP_VT_Alias", bound="TorchHigherOrderOperatorVariable")
+SetSubgraphInputs = Literal[
+    "automatic", "automatic_with_forced_inputs", "flatten_manual", "manual"
+]
 
 log = logging.getLogger(__name__)
 hc_log = torch._logging.getArtifactLogger(__name__, "hierarchical_compile")
@@ -1131,7 +1134,7 @@ def validate_args_and_maybe_create_graph_inputs(
     sub_args: list[VariableTracker],
     tracer: "SubgraphTracer",
     tx: "InstructionTranslatorBase",
-    set_subgraph_inputs: str,
+    set_subgraph_inputs: SetSubgraphInputs,
     description: str,
     sub_args_names: Sequence[str] | None = None,
 ) -> list[Any]:
@@ -1598,7 +1601,7 @@ def get_hop_args(
     subtracer: "SubgraphTracer",
     sub_args: list[VariableTracker],
     sub_kwargs: dict[str, VariableTracker],
-    set_subgraph_inputs: str,
+    set_subgraph_inputs: SetSubgraphInputs,
     description: str,
 ) -> list[VariableTracker]:
     sub_args_names = maybe_positional_arg_names(f)
@@ -1650,9 +1653,7 @@ def speculate_subgraph_with_auto_output_flattening(
     # order they are see while tracing). This is useful for autograd.Function
     # backward where we do need to account for all the inputs of the backwards
     # to be lifted as inputs for making the fwd-bwd graph consistent.
-    set_subgraph_inputs: Literal[
-        "automatic", "automatic_with_forced_inputs", "flatten_manual", "manual"
-    ] = "automatic",
+    set_subgraph_inputs: SetSubgraphInputs = "automatic",
     # If True, exposes intermediates to subgraph outputs to allow later tensor ops to
     # access intermediates from the subgraph, this is useful for mutation
     allow_side_effects: bool = False,
@@ -2022,9 +2023,7 @@ def speculate_subgraph(
     # 3. if your HOP must preserve inputs that are not tensor or symnode as placeholders e.g. AutogradFunctionContextVariable
     # use set_subgraph_inputs="manual" (not recommended). We do not recommend it in general because it has the
     # restriction that user need to manually control how to create placeholders and VariableTrackers for the args.
-    set_subgraph_inputs: Literal[
-        "automatic", "semi_automatic", "flatten_manual", "manual"
-    ] = "automatic",
+    set_subgraph_inputs: SetSubgraphInputs = "automatic",
     restore_side_effects: bool = True,
     should_flatten_outputs: bool = False,
     # if should_flatten_outputs is True, `remove_consts_from_outputs` remove the
@@ -3836,9 +3835,7 @@ class WrapHigherOrderVariable(TorchHigherOrderOperatorVariable):
         description: str,
         *,
         subgraph_name: str = "wrap_body",
-        set_subgraph_inputs: Literal[
-            "automatic", "automatic_with_forced_inputs"
-        ] = "automatic",
+        set_subgraph_inputs: SetSubgraphInputs = "automatic",
     ) -> tuple[
         tuple[Proxy, ...],
         dict[str, VariableTracker],

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -29,8 +29,9 @@ import warnings
 from collections import Counter
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import Any, cast, Literal, Optional, TYPE_CHECKING, Union
+from typing import Any, cast, Optional, TYPE_CHECKING, Union
 
+from torch._compiler_types import SetSubgraphInputs
 import torch._C
 import torch.fx
 import torch.nn
@@ -82,9 +83,6 @@ from typing import ParamSpec, TypeVar
 P = ParamSpec("P")
 R = TypeVar("R")
 HOP_VT_Alias = TypeVar("HOP_VT_Alias", bound="TorchHigherOrderOperatorVariable")
-SetSubgraphInputs = Literal[
-    "automatic", "automatic_with_forced_inputs", "flatten_manual", "manual"
-]
 
 log = logging.getLogger(__name__)
 hc_log = torch._logging.getArtifactLogger(__name__, "hierarchical_compile")

--- a/torch/compiler/__init__.py
+++ b/torch/compiler/__init__.py
@@ -6,6 +6,7 @@ from typing import Any, TypeVar
 from typing_extensions import ParamSpec
 
 import torch
+from torch._compiler_types import StanceStr
 from torch._higher_order_ops.invoke_subgraph import NestedCompileRegionOptions
 
 from . import config
@@ -368,7 +369,7 @@ def get_default_backend() -> str | Callable[..., Any]:
 
 
 def set_stance(
-    stance: str = "default",
+    stance: StanceStr = "default",
     *,
     skip_guard_eval_unsafe: bool = False,
     force_backend: str | Callable[..., Any] | None = None,


### PR DESCRIPTION
Introduce shared Literal aliases for fixed Dynamo string vocabularies and thread them through the relevant producers, consumers, and assertions.

Summary:
- Add `StanceStr`, `SetSubgraphInputs`, `StaticAddressType`, `OptimizeDdpMode`, and compiled-autograd `HookType` annotations.
- Reconcile `set_subgraph_inputs` annotations with the runtime-accepted vocabulary, removing the stale `semi_automatic` type spelling.
- Move compiled-autograd hook kind metadata from `call_hook` FX kwargs into an explicit positional argument and update generated-code expectations.

Validation:
- `python3 -m py_compile torch/_dynamo/eval_frame.py torch/_dynamo/decorators.py torch/_dynamo/utils.py torch/_dynamo/external_utils.py torch/_dynamo/compiled_autograd.py torch/_dynamo/variables/higher_order_ops.py test/inductor/test_compiled_autograd.py`
- `git diff --check`

Could not run targeted test files in this checkout because system Python cannot import `torch`: it is missing `typing_extensions`. `scripts/lintrunner.py` also could not run because `.git/hooks/linter/.venv` is not set up.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98 @xmfan @aditvenk

Drafted via Codex, published after manual review by @bobrenjc93
