### PR TITLE
Don't gate distributed backend entry points on USE_DISTRIBUTED

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1096,18 +1096,18 @@ def configure_extension_build() -> tuple[
         ],
     }
 
-    if cmake_cache_vars["USE_DISTRIBUTED"]:
-        # Only enable fr_trace command if distributed is enabled
-        entry_points["console_scripts"].append(
-            "torchfrtrace = torch.distributed.flight_recorder.fr_trace:main",
-        )
-        entry_points["torch.distributed.backends"] = [
-            "mpi = torch.distributed.distributed_c10d:_register_builtin_mpi_backend",
-            "gloo = torch.distributed.distributed_c10d:_register_builtin_gloo_backend",
-            "nccl = torch.distributed.distributed_c10d:_register_builtin_nccl_backend",
-            "ucc = torch.distributed.distributed_c10d:_register_builtin_ucc_backend",
-            "xccl = torch.distributed.distributed_c10d:_register_builtin_xccl_backend",
-        ]
+    # Not gated on USE_DISTRIBUTED: the CMake cache is empty during the pip
+    # metadata phase, so gating would drop these from the wheel metadata.
+    entry_points["console_scripts"].append(
+        "torchfrtrace = torch.distributed.flight_recorder.fr_trace:main",
+    )
+    entry_points["torch.distributed.backends"] = [
+        "mpi = torch.distributed.distributed_c10d:_register_builtin_mpi_backend",
+        "gloo = torch.distributed.distributed_c10d:_register_builtin_gloo_backend",
+        "nccl = torch.distributed.distributed_c10d:_register_builtin_nccl_backend",
+        "ucc = torch.distributed.distributed_c10d:_register_builtin_ucc_backend",
+        "xccl = torch.distributed.distributed_c10d:_register_builtin_xccl_backend",
+    ]
     return ext_modules, cmdclass, packages, entry_points, extra_install_requires
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #188488

#187388 moved the builtin c10d backends (`mpi`, `gloo`, `nccl`, `ucc`, `xccl`) from eager registration at import time to lazy registration via the `torch.distributed.backends` entry point group: `Backend._ensure_backend_registered(name)` scans `importlib.metadata.entry_points(group="torch.distributed.backends")` the first time a backend is requested.

Those entry points are emitted by `setup.py` only under `if cmake_cache_vars["USE_DISTRIBUTED"]:`. A PEP 517 frontend (`pip install .`) generates the wheel metadata via the `dist_info`/`egg_info` command, which `setup.py` runs with `RUN_BUILD_DEPS=False`. CMake never configures during that phase, so `build/CMakeCache.txt` does not exist and `get_cmake_cache_vars()` falls back to `defaultdict(lambda: False)`. `cmake_cache_vars["USE_DISTRIBUTED"]` therefore reads falsy at metadata time and the `[torch.distributed.backends]` group (and the `torchfrtrace` console script) is silently dropped from the installed `*.dist-info/entry_points.txt`.

At runtime `_ensure_backend_registered("nccl")` then finds no entry point, NCCL is never added to `Backend.backend_type_map`, and `init_process_group(backend="nccl")` fails in `_new_process_group_helper` with `AssertionError: Unknown c10d backend type NCCL`. This breaks from-source builds installed with `pip install .`. The `BackendEntryPointTest` added in #187388 did not catch it because it mocks `importlib.metadata.entry_points`.

Fix: emit the `torch.distributed.backends` entry points (and `torchfrtrace`) unconditionally instead of gating on the CMake cache, which is unavailable during the metadata phase. The builtin registrars already self-guard with `is_<backend>_available()`, so advertising a backend that was not compiled is harmless.

Authored with assistance from Claude (Claude Code).

Differential Revision: [D110105485](https://our.internmc.facebook.com/intern/diff/D110105485/)