### PR TITLE
Forward backend through dist.new_group delegation to custom PGs

### DIFF
--- a/test/distributed/test_c10d_common.py
+++ b/test/distributed/test_c10d_common.py
@@ -2220,19 +2220,22 @@ class PythonProcessGroupExtensionTest(MultiProcessTestCase):
 
         new_group_called = False
         new_group_ranks = None
+        new_group_backend = None
 
         class _DelegatingPG(DummyProcessGroup):
             def new_group(
                 self,
                 ranks,
                 timeout=None,
+                backend=None,
                 pg_options=None,
                 group_name=None,
                 group_desc=None,
             ):
-                nonlocal new_group_called, new_group_ranks
+                nonlocal new_group_called, new_group_ranks, new_group_backend
                 new_group_called = True
                 new_group_ranks = list(ranks)
+                new_group_backend = backend
                 my_rank = self.rank()
                 if my_rank not in ranks:
                     return None
@@ -2256,6 +2259,7 @@ class PythonProcessGroupExtensionTest(MultiProcessTestCase):
             sub_pg = dist.new_group(ranks=[0])
             self.assertTrue(new_group_called)
             self.assertEqual(new_group_ranks, [0])
+            self.assertEqual(new_group_backend, "delegating")
 
             if self.rank == 0:
                 self.assertIsNotNone(sub_pg)
@@ -2267,6 +2271,54 @@ class PythonProcessGroupExtensionTest(MultiProcessTestCase):
                     sub_pg is None
                     or sub_pg == dist.distributed_c10d.GroupMember.NON_GROUP_MEMBER
                 )
+        finally:
+            dist.destroy_process_group()
+
+    def test_new_group_delegates_to_pg_explicit_backend(self):
+        """dist.new_group forwards an explicit multi-backend string to the
+        delegated default_pg.new_group."""
+
+        new_group_called = False
+        new_group_backend = None
+
+        class _DelegatingPG(DummyProcessGroup):
+            def new_group(
+                self,
+                ranks,
+                timeout=None,
+                backend=None,
+                pg_options=None,
+                group_name=None,
+                group_desc=None,
+            ):
+                nonlocal new_group_called, new_group_backend
+                new_group_called = True
+                new_group_backend = backend
+                my_rank = self.rank()
+                if my_rank not in ranks:
+                    return None
+                return DummyProcessGroup(ranks.index(my_rank), len(ranks))
+
+        dist.Backend.register_backend(
+            "delegating",
+            lambda *args, **kwargs: _DelegatingPG(
+                args[0].group_rank, args[0].group_size
+            ),
+            extended_api=True,
+            devices=["cpu", "cuda"],
+        )
+
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "6789"
+        dist.init_process_group(
+            "delegating", rank=self.rank, world_size=self.world_size
+        )
+
+        try:
+            backend = "cpu:delegating,cuda:delegating"
+            dist.new_group(ranks=[0], backend=backend)
+            self.assertTrue(new_group_called)
+            self.assertEqual(new_group_backend, backend)
         finally:
             dist.destroy_process_group()
 

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -6394,6 +6394,7 @@ def _new_group_with_tag(
         pg_or_none = default_pg.new_group(
             ranks,
             timeout=timeout,
+            backend=backend,
             pg_options=backend_options,
             group_name=group_name,
             group_desc=group_desc,


### PR DESCRIPTION
## Summary

When the default process group implements its own `new_group` method,
`_new_group_with_tag` delegates subgroup creation to it (added in #184262)
instead of going through `_new_process_group_helper`. That delegation
forwarded `ranks`, `timeout`, `pg_options`, `group_name` and `group_desc`
but dropped the resolved `backend`, so a custom Python PG subclass had no
way to know which backend the subgroup was requested with.

This passes `backend` through to the delegated `new_group` call (already
defaulted to the default group's backend when unspecified) so subclasses
can construct the subgroup with the correct backend.

Note: custom PG subclasses that define `new_group` must now accept a
`backend` keyword argument.

## Test Plan

```
python test/distributed/test_c10d_common.py PythonProcessGroupExtensionTest.test_new_group_delegates_to_pg
```

The `test_new_group_delegates_to_pg` test is extended to assert the
delegated `new_group` receives the backend.