### PR TITLE
[CI] Fix test-times lookup for test-osdc jobs

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -70,6 +70,7 @@ from tools.testing.target_determination.heuristics.utils import get_pr_number
 from tools.testing.test_run import TestRun
 from tools.testing.test_selections import (
     calculate_shards,
+    get_job_base_name,
     get_test_case_configs,
     NUM_PROCS,
     ShardedTest,
@@ -1923,7 +1924,7 @@ def load_test_times_from_file(file: str) -> dict[str, Any]:
         # If job name isn't available, use build environment as a backup
         job_name = build_env
     else:
-        job_name = job_name.split(" / test (")[0]
+        job_name = get_job_base_name(job_name)
     test_config = os.environ.get("TEST_CONFIG")
     print_to_stderr(f"JOB_NAME={raw_job_name}")
     print_to_stderr(f"BUILD_ENVIRONMENT={build_env}")

--- a/tools/test/test_test_selections.py
+++ b/tools/test/test_test_selections.py
@@ -13,7 +13,11 @@ try:
     # using tools/ to optimize test run.
     sys.path.append(str(REPO_ROOT))
     from tools.testing.test_run import ShardedTest, TestRun
-    from tools.testing.test_selections import calculate_shards, THRESHOLD
+    from tools.testing.test_selections import (
+        calculate_shards,
+        get_job_base_name,
+        THRESHOLD,
+    )
 except ModuleNotFoundError:
     print("Can't import required modules, exiting")
     sys.exit(1)
@@ -547,6 +551,52 @@ class TestCalculateShards(unittest.TestCase):
                 )
                 # All the tests should be represented by some shard
                 self.assertEqual(sorted_tests, [x.name for x in sorted_shard_tests])
+
+
+class TestGetJobBaseName(unittest.TestCase):
+    def test_strips_test_target(self) -> None:
+        self.assertEqual(
+            get_job_base_name(
+                "linux-jammy-py3.10-clang18 / test (dynamo_wrapped, 1, 3, lf-l-x86)"
+            ),
+            "linux-jammy-py3.10-clang18",
+        )
+
+    def test_strips_test_osdc_target(self) -> None:
+        self.assertEqual(
+            get_job_base_name(
+                "linux-jammy-py3.14t-clang18 / test-osdc (dynamo_wrapped, 1, 3, mt-l-x86)"
+            ),
+            "linux-jammy-py3.14t-clang18",
+        )
+
+    def test_build_env_with_test_substring_is_preserved(self) -> None:
+        # The build env itself contains "-test-"; only the target suffix is stripped.
+        self.assertEqual(
+            get_job_base_name(
+                "cross-compile-linux-test-cuda13 / test-osdc (aoti, 1, 1, r, win)"
+            ),
+            "cross-compile-linux-test-cuda13",
+        )
+
+    def test_multi_segment_name_keeps_full_prefix(self) -> None:
+        # Only the final target is split; the rest is the key.
+        self.assertEqual(
+            get_job_base_name(
+                "unit-test / inductor-test / test-osdc (inductor, 2, 2, mt-l-x86)"
+            ),
+            "unit-test / inductor-test",
+        )
+
+    def test_unrelated_targets_are_not_matched(self) -> None:
+        # Non-test/test-osdc targets are left intact so they miss the lookup.
+        for name in (
+            "env / test-foo (default, 1, 1, r)",
+            "env / testbar (default, 1, 1, r)",
+            "env / inductor-cpu-core-test (3.11)",
+            "env / build",
+        ):
+            self.assertEqual(get_job_base_name(name), name)
 
 
 if __name__ == "__main__":

--- a/tools/testing/test_selections.py
+++ b/tools/testing/test_selections.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import math
 import os
+import re
 import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -272,3 +273,12 @@ def calculate_shards(
 
 def get_test_case_configs(dirpath: str) -> None:
     get_disabled_tests(dirpath=dirpath)
+
+
+# Strip the "test"/"test-osdc" target suffix to recover the build env, the key
+# tools/torchci writes to test-times.json. Must match the write-side extraction.
+JOB_BASE_NAME_RE = re.compile(r" / test(?:-osdc)? \(")
+
+
+def get_job_base_name(job_name: str) -> str:
+    return JOB_BASE_NAME_RE.split(job_name, maxsplit=1)[0]


### PR DESCRIPTION
OSDC jobs are named "<env> / test-osdc (...)", which load_test_times_from_file's job-name split did not match, so sharding fell back to default test times. Add get_job_base_name() to strip the "test" and "test-osdc" targets and use it. Associated with https://github.com/pytorch/test-infra/pull/8233.

Test Plan:
```
  python -m pytest tools/test/test_test_selections.py -k JobBaseName
```

Authored with assistance from Claude.