### PR TITLE
[dynamo] Replace Any with concrete types on core driver + VariableTracker params

### DIFF
--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -189,6 +189,7 @@ from .variables.user_defined import UserDefinedDictVariable
 if TYPE_CHECKING:
     from torch._dynamo.dynamo_profiler import DynamoProfilerState
     from torch._dynamo.package import CompilePackage
+    from torch._dynamo.pgo import FrameStateSizeEntry
     from torch._dynamo.symbolic_convert import InstructionTranslatorBase
     from torch._inductor import _CudagraphAnnotation
     from torch.multiprocessing.reductions import StorageWeakRef
@@ -751,8 +752,8 @@ class OutputGraph(OutputGraphCommon):
         compiler_fn: CompilerFn | None,
         root_tx: "InstructionTranslatorBase",
         export: bool,
-        export_constraints: Sequence[_ConstraintTarget],
-        frame_state: Any,
+        export_constraints: Sequence[_ConstraintTarget] | None,
+        frame_state: "dict[str, int | FrameStateSizeEntry] | None",
         local_scope: Scope,
         global_scope: Scope,
         f_code: CodeType,
@@ -2670,7 +2671,7 @@ class OutputGraph(OutputGraphCommon):
             if len(device_types) != 1:
                 raise AssertionError(
                     "Expect only one device type but got {}".format(
-                        "+".join(device_types)
+                        "+".join(d.type for d in device_types)
                     )
                 )
             with (
@@ -3671,7 +3672,7 @@ class DynamoTracerOutput:
     f_globals: dict[str, Any]
 
     def __init__(
-        self, tracer: "InstructionTranslatorBase", error: Any | None = None
+        self, tracer: "InstructionTranslatorBase", error: bool = False
     ) -> None:
         self.error_on_graph_break = tracer.error_on_graph_break
         self.is_tracing_resume_prologue = tracer.is_tracing_resume_prologue

--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -31,7 +31,7 @@ import traceback
 import weakref
 from collections.abc import Generator, MutableMapping
 from types import CellType
-from typing import Any, TYPE_CHECKING
+from typing import Any, cast, TYPE_CHECKING
 
 import torch
 import torch.nn
@@ -754,7 +754,7 @@ class SideEffects:
             obj = nn_module_new(user_cls)
         else:
             if isinstance(base_cls_vt, variables.BuiltinVariable):
-                base_cls = base_cls_vt.fn
+                base_cls = cast("type[Any]", base_cls_vt.fn)
             elif isinstance(base_cls_vt, variables.DictBuiltinVariable):
                 base_cls = dict
             elif isinstance(base_cls_vt, variables.ListBuiltinVariable):

--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -754,7 +754,7 @@ class SideEffects:
             obj = nn_module_new(user_cls)
         else:
             if isinstance(base_cls_vt, variables.BuiltinVariable):
-                base_cls = cast("type[Any]", base_cls_vt.fn)
+                base_cls = cast(Any, base_cls_vt.fn)
             elif isinstance(base_cls_vt, variables.DictBuiltinVariable):
                 base_cls = dict
             elif isinstance(base_cls_vt, variables.ListBuiltinVariable):

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -207,10 +207,12 @@ from .variables.user_defined import (
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Generator
+    from collections.abc import Callable, Generator, Sequence
 
     from torch._subclasses.fake_tensor import FakeTensorMode
+    from torch.export.dynamic_shapes import _ConstraintTarget
 
+    from .backends.registry import CompilerFn
     from .package import CompilePackage
 
 log = logging.getLogger(__name__)
@@ -393,7 +395,7 @@ class LocalState:
 # Mutable box that is shared across restarts
 @dataclasses.dataclass
 class DistributedState:
-    compile_pg: Any
+    compile_pg: torch.distributed.ProcessGroup
     local_state: LocalState
     all_states: list[LocalState] | None = None
 
@@ -5337,7 +5339,7 @@ class InstructionTranslatorBase(
         if sys.version_info < (3, 11):
             push_types |= CO_GENERATOR
         if f_code.co_flags & (push_types):
-            self.push(BuiltinVariable(None))
+            self.push(BuiltinVariable(None))  # type: ignore[arg-type]
 
         self.inline_depth = inline_depth
         self.inconsistent_side_effects = False
@@ -5379,13 +5381,13 @@ class InstructionTranslator(InstructionTranslatorBase):
         f_globals: dict[str, Any],
         f_builtins: dict[str, Any],
         closure: tuple[Any, ...] | None,
-        torch_function_mode_stack: Any,
+        torch_function_mode_stack: list[torch.overrides.TorchFunctionMode],
         code_options: CodeOptions,
-        compiler_fn: Any,
+        compiler_fn: CompilerFn | None,
         one_graph: bool,
         export: bool,
-        export_constraints: Any,
-        frame_state: Any,
+        export_constraints: Sequence[_ConstraintTarget] | None,
+        frame_state: dict[str, int | FrameStateSizeEntry] | None,
         speculation_log: SpeculationLog,
         exn_vt_stack: ExceptionStack,
         distributed_state: DistributedState | None,

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1462,7 +1462,7 @@ class VariableBuilder:
             )
             return GetAttrVariable(
                 AutogradFunctionVariable(
-                    value.__self__,
+                    cast("type[torch.autograd.Function]", value.__self__),
                     source=AttrSource(self.source, member="__self__"),
                 ),
                 "apply",
@@ -5106,7 +5106,7 @@ class SourcelessBuilder:
             and value.node.expr in tx.output.bound_symbols
         ):
             proxy = tx.output.bound_symbols[value.node.expr]
-            return SymNodeVariable.create(tx, proxy)
+            return SymNodeVariable.create(tx, cast("torch.fx.Proxy", proxy))
         elif isinstance(value, slice):
             items = [
                 SourcelessBuilder.create(tx, getattr(value, k))

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -344,7 +344,7 @@ class BaseBuiltinVariable(VariableTracker):
     and overrides as_python_constant / reconstruct / var_getattr accordingly.
     """
 
-    _fn: Any = None
+    _fn: Callable[..., Any] | None = None
 
     @classmethod
     def create_with_source(cls, value: Any, source: Source) -> "BaseBuiltinVariable":
@@ -884,7 +884,7 @@ class BuiltinVariable(BaseBuiltinVariable):
         {dict, getattr, hasattr, iter, list, setattr}
     )
 
-    def __init__(self, fn: Any, **kwargs: Any) -> None:
+    def __init__(self, fn: Callable[..., Any], **kwargs: Any) -> None:
         if fn in self.MUST_USE_SPECIALIZED:
             raise AssertionError(
                 f"Use the specialized VT class for {fn!r}, not BuiltinVariable. "
@@ -1670,7 +1670,7 @@ class BuiltinVariable(BaseBuiltinVariable):
                     tx=tx,
                 )
 
-        if name in _BUILTIN_CONSTANT_FOLDABLE_METHODS.get(self.fn, ()):
+        if name in _BUILTIN_CONSTANT_FOLDABLE_METHODS.get(self.fn, ()):  # type: ignore[arg-type]
             if all(a.is_python_constant() for a in args) and all(
                 v.is_python_constant() for v in kwargs.values()
             ):

--- a/torch/_dynamo/variables/constant.py
+++ b/torch/_dynamo/variables/constant.py
@@ -30,6 +30,7 @@ from .base import ValueMutationNew, VariableTracker
 
 
 if TYPE_CHECKING:
+    from torch._dynamo.codegen import PyCodegen
     from torch._dynamo.symbolic_convert import InstructionTranslatorBase
 
     from .functions import UserFunctionVariable
@@ -448,7 +449,7 @@ class ConstantVariable(VariableTracker):
             tree_map_kwargs,
         )
 
-    def reconstruct_pycode(self, codegen) -> str:
+    def reconstruct_pycode(self, codegen: PyCodegen) -> str:
         return repr(self.value)
 
     @override
@@ -935,7 +936,7 @@ class FakeIdVariable(VariableTracker):
             ],
         )
 
-    def reconstruct(self, codegen: Any) -> None:
+    def reconstruct(self, codegen: PyCodegen) -> None:
         unimplemented(
             gb_type="Reconstruction of FakeIdVariable",
             context=str(self.value),

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -793,9 +793,9 @@ class InferenceModeVariable(ContextWrappingVariable):
 class GenericDeviceVariable(ContextWrappingVariable):
     """Abstract base for device context managers that swap the active device index."""
 
-    _exchange_fn: Any
-    _maybe_exchange_fn: Any
-    _get_device_index_fn: Any
+    _exchange_fn: Callable[..., Any]
+    _maybe_exchange_fn: Callable[..., Any]
+    _get_device_index_fn: Callable[..., Any]
 
     @classmethod
     def create(

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -917,7 +917,7 @@ class AutogradFunctionVariable(VariableTracker):
         *VariableTracker._nonvar_fields,
     }
 
-    def __init__(self, fn_cls: Any, **kwargs: Any) -> None:
+    def __init__(self, fn_cls: type[torch.autograd.Function], **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.fn_cls = fn_cls
 

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -44,6 +44,7 @@ from torch.fx.experimental.symbolic_shapes import (
     is_symbolic,
     SymTypes,
 )
+from torch.types import PySymType
 from torch.utils._python_dispatch import is_traceable_wrapper_subclass
 
 from .. import config, graph_break_hints, variables
@@ -2560,8 +2561,8 @@ class SymNodeVariable(VariableTracker):
     def create(
         cls,
         tx: "InstructionTranslatorBase",
-        proxy: Any,
-        sym_num: Any | None = None,
+        proxy: torch.fx.Proxy,
+        sym_num: PySymType | int | bool | sympy.Integer | None = None,
         **options: Any,
     ) -> "VariableTracker":
         if sym_num is None:
@@ -2582,7 +2583,12 @@ class SymNodeVariable(VariableTracker):
             tx.output.current_tracer.record_proxyable_vt(out)
         return out
 
-    def __init__(self, proxy: Any, sym_num: Any, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        proxy: torch.fx.Proxy,
+        sym_num: PySymType | int | bool | sympy.Integer,
+        **kwargs: Any,
+    ) -> None:
         super().__init__(**kwargs)
         self.proxy = proxy
         # TODO: Should we allow non SymTypes here?  Today it is allowed

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -33,7 +33,7 @@ import math
 import re
 from collections.abc import Callable, Iterable
 from contextlib import nullcontext
-from typing import Any, NoReturn, TYPE_CHECKING, TypeVar, Union
+from typing import Any, cast, NoReturn, TYPE_CHECKING, TypeVar, Union
 from typing_extensions import TypeIs
 
 import torch._C
@@ -2103,12 +2103,11 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
             self, tx: "InstructionTranslatorBase", *terms: VariableTracker
         ) -> VariableTracker | None:
             if all(isinstance(x, SymNodeVariable) for x in terms):
+                proxy = torch.fx.experimental.symbolic_shapes.sym_and(
+                    *(x.as_proxy() for x in terms)
+                )
                 return SymNodeVariable.create(
-                    tx,
-                    torch.fx.experimental.symbolic_shapes.sym_and(
-                        *(x.as_proxy() for x in terms)
-                    ),
-                    sym_num=None,
+                    tx, cast("torch.fx.Proxy", proxy), sym_num=None
                 )
             return None
 
@@ -2117,12 +2116,11 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
             self, tx: "InstructionTranslatorBase", *terms: VariableTracker
         ) -> VariableTracker | None:
             if all(isinstance(x, SymNodeVariable) for x in terms):
+                proxy = torch.fx.experimental.symbolic_shapes.sym_or(
+                    *(x.as_proxy() for x in terms)
+                )
                 return SymNodeVariable.create(
-                    tx,
-                    torch.fx.experimental.symbolic_shapes.sym_or(
-                        *(x.as_proxy() for x in terms)
-                    ),
-                    sym_num=None,
+                    tx, cast("torch.fx.Proxy", proxy), sym_num=None
                 )
             return None
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #188497

Replaces `Any` annotations with concrete types (or small unions) on
constructor parameters and dataclass fields that are provably a single
concrete class, threading each type through its immediate call chain.

The bulk of the change is the InstructionTranslator -> OutputGraph
constructor chain (compiler_fn, torch_function_mode_stack,
export_constraints, frame_state), which already had concrete types at the
convert_frame.py producers and on the OutputGraph side; this just makes
the InstructionTranslator entry point and the two remaining OutputGraph
params agree. The rest are independent one-line annotations on a couple
of small dataclasses and VariableTracker subclasses: DistributedState
(compile_pg), DynamoTracerOutput (error), BuiltinVariable /
BaseBuiltinVariable (fn / _fn), AutogradFunctionVariable (fn_cls),
GenericDeviceVariable (the three exchange callables), SymNodeVariable
(proxy / sym_num), and ConstantVariable / FakeIdVariable (codegen).

Typing DistributedState.compile_pg as ProcessGroup surfaced a latent bug
in the compiler-collective error path: `"+".join(device_types)` was
joining a `list[torch.device]`, which raises at runtime; it now joins
`d.type`. Three call sites pass values that are correct at runtime but
statically broader than the new parameter types -- the sym_and / sym_or
results (a Proxy at runtime, but annotated SymBool | bool) and an
autograd Function class reached via a bound method's __self__ (typed
object) -- and get a narrowing cast. The generator-frame stack sentinel
`BuiltinVariable(None)` and a lookup into a type-keyed dict with a
Callable key get targeted `# type: ignore`s.

Test Plan:

Type-check the changed files (and, separately, the entire torch/_dynamo
tree) with no new errors attributable to these files; the only remaining
pyrefly errors live in unrelated files and predate this change.

```
lintrunner --take PYFMT,RUFF,PYREFLY,CODESPELL,FLAKE8 \
    torch/_dynamo/symbolic_convert.py \
    torch/_dynamo/output_graph.py \
    torch/_dynamo/variables/builtin.py \
    torch/_dynamo/variables/misc.py \
    torch/_dynamo/variables/ctx_manager.py \
    torch/_dynamo/variables/tensor.py \
    torch/_dynamo/variables/constant.py \
    torch/_dynamo/variables/builder.py \
    torch/_dynamo/variables/torch.py
```

Authored with an AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98