### PR TITLE
Fix gpt_fast layer_norm micro-benchmark dtype mismatch

### DIFF
--- a/benchmarks/gpt_fast/benchmark.py
+++ b/benchmarks/gpt_fast/benchmark.py
@@ -93,7 +93,7 @@ def run_layer_norm(device: str = "cuda"):
     for dtype, expected_memory_bandwidth in dtype_memory_bandwidth_map.items():
         memory_bandwidth = 0
         for D in input_shapes:
-            mod = nn.LayerNorm(D).to(device)
+            mod = nn.LayerNorm(D).to(device=device, dtype=dtype)
 
             x = torch.randn(BS, D, device=device, dtype=dtype)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #188503

The layer_norm micro-benchmark created an nn.LayerNorm with default
(fp32) affine parameters and fed it a bf16 input, relying on the
native_layer_norm decomposition silently promoting the parameters.
PR #185693 (320a72cd220) made that decomposition mirror the eager CUDA
kernel, which requires the affine parameters to match the input dtype,
so torch.compile now raises "expected scalar type BFloat16 but found
Float" and the inductor-micro-benchmark CI job fails.

Cast the module to the input dtype so the weight and bias are bf16,
matching the input. This is the correct fix on the benchmark side: the
program the benchmark expressed was already rejected by eager CUDA and
only worked because the decomposition was permissive.

Test Plan:
lintrunner passed on the changed file. The micro-benchmark requires a
CUDA A100 and was not run locally; the inductor-micro-benchmark CI job
exercises it.

Authored with Claude.