### PR TITLE
Fix test_comm_analysis NCCL tests failing on nogpu runners

### DIFF
--- a/test/inductor/test_comm_analysis.py
+++ b/test/inductor/test_comm_analysis.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: inductor"]
 
 import sys
+import unittest
 import warnings
 
 import torch
@@ -12,15 +13,13 @@ if not dist.is_available() or not dist.is_nccl_available():
     sys.exit(0)
 
 try:
-    from torch.testing._internal.common_distributed import (
-        requires_nccl,
-        skip_if_lt_x_gpu,
-    )
+    from torch.testing._internal.common_distributed import requires_nccl
 except ImportError:
     print("common_distributed not importable, skipping tests", file=sys.stderr)
     sys.exit(0)
 
 from torch.fx.experimental.proxy_tensor import make_fx
+from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 
@@ -94,7 +93,7 @@ class TestNcclEstimateDeviceResolution(TestCase):
             self._destroy_pg()
 
     @requires_nccl()
-    @skip_if_lt_x_gpu(1)
+    @unittest.skipUnless(TEST_CUDA, "requires CUDA")
     def test_multi_backend_pg_resolves_to_nccl(self):
         """
         Multi-backend PG ("cpu:gloo,cuda:nccl"): We should resolve to the cuda device's backend.
@@ -118,7 +117,7 @@ class TestNcclEstimateDeviceResolution(TestCase):
             self._destroy_pg()
 
     @requires_nccl()
-    @skip_if_lt_x_gpu(1)
+    @unittest.skipUnless(TEST_CUDA, "requires CUDA")
     def test_single_nccl_backend_resolves_correctly(self):
         """Single NCCL backend PG: cuda device resolves to NCCL with time estimation."""
         torch.cuda.set_device(0)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #188504

The TestNcclEstimateDeviceResolution tests were guarded with
@skip_if_lt_x_gpu(1), a helper from common_distributed intended for
multiprocess distributed tests. Its skip path calls sys.exit(75) (the
distributed skip exit code), which is only interpreted as a skip by the
multiprocess launcher. These tests are plain TestCase methods collected
directly by pytest, so on a CPU/nogpu runner the sys.exit(75) surfaces
as an uncaught SystemExit and pytest records it as a hard failure rather
than a skip. This made the periodic nogpu_NO_AVX2 shard fail
consistently.

Replace the decorator with the pytest-native
@unittest.skipUnless(TEST_CUDA, "requires CUDA"), which raises SkipTest
properly. @requires_nccl() is left in place: NCCL is compiled into the
CUDA build so it does not skip, and it was never the cause of the
failure.

Test Plan:
On a GPU host the tests run and pass; simulating a nogpu runner with
CUDA_VISIBLE_DEVICES="" they now skip instead of erroring.

```
python -m pytest test/inductor/test_comm_analysis.py -v -rsf
# -> 3 passed (GPU present)

CUDA_VISIBLE_DEVICES="" python -m pytest test/inductor/test_comm_analysis.py -v -rsf
# -> 1 passed, 2 skipped ("requires CUDA")
```

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo