### PR TITLE
Migrate target-determination to OSDC

### DIFF
--- a/.github/scripts/file_io_utils.py
+++ b/.github/scripts/file_io_utils.py
@@ -78,7 +78,16 @@ def upload_file_to_s3(file_name: Path, bucket: str, key: str) -> None:
 def download_s3_objects_with_prefix(
     bucket_name: str, prefix: str, download_folder: Path
 ) -> list[Path]:
-    s3 = boto3.resource("s3")
+    # The artifacts bucket is public-read. If no credentials are available (e.g.
+    # fork PRs that can't assume an OIDC role), fall back to anonymous/unsigned
+    # requests so the (best-effort) download still works.
+    if boto3.Session().get_credentials() is None:
+        from botocore import UNSIGNED
+        from botocore.config import Config
+
+        s3 = boto3.resource("s3", config=Config(signature_version=UNSIGNED))
+    else:
+        s3 = boto3.resource("s3")
     bucket = s3.Bucket(bucket_name)
 
     downloads = []

--- a/.github/workflows/target_determination.yml
+++ b/.github/workflows/target_determination.yml
@@ -4,6 +4,10 @@ name: target-determination
 on:
   workflow_call:
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
 
   get-label-type:
@@ -16,34 +20,53 @@ jobs:
       issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
+      check_experiments: "arc,lf"
 
   target-determination:
     # Don't run on forked repos
     if: github.repository_owner == 'pytorch'
-    runs-on: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge"
+    runs-on: "${{ needs.get-label-type.outputs.label-type }}l-x86iavx512-8-64"
     needs: get-label-type
+    container:
+      image: ghcr.io/actions/actions-runner:latest
     steps:
       - name: Setup Linux
         uses: pytorch/pytorch/.github/actions/setup-linux@main
         with:
           submodules: false
+          use-arc: true
+
+      - name: Setup uv
+        uses: pytorch/test-infra/.github/actions/setup-uv@main
+        with:
+          enable-cache: true
+
+      - name: Configure AWS credentials
+        id: aws-creds
+        # Fork PRs can't assume the OIDC role; fall back to GHA-native artifacts below.
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/arc
+          aws-region: us-east-1
 
       - name: Get workflow job id
         id: get-job-id
-        uses: ./.github/actions/get-workflow-job-id
+        uses: pytorch/pytorch/.github/actions/get-workflow-job-id@main
         if: always()
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download pytest cache
-        uses: ./.github/actions/pytest-cache-download
+        uses: pytorch/pytorch/.github/actions/pytest-cache-download@main
+        # Public-read bucket; works without creds (anonymous fallback) on fork PRs.
         continue-on-error: true
         with:
           cache_dir: .pytest_cache
           job_identifier: ${{ github.workflow }}
 
-      - name: Download LLM Artifacts from S3
-        uses: seemethere/download-artifact-s3@1da556a7aa0a088e3153970611f6c432d58e80e6 # v4.2.0
+      - name: Download LLM Artifacts
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         continue-on-error: true
         with:
           name: llm_results
@@ -65,15 +88,16 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           unzip -o .additional_ci_files/llm_results/mappings.zip -d .additional_ci_files/llm_results || true
-          python3 -m pip install boto3==1.35.42
-          python3 tools/testing/do_target_determination_for_s3.py
+          # Dependencies are declared inline in the script via PEP 723.
+          uv run --no-project --python 3.12 tools/testing/do_target_determination_for_s3.py
 
       - name: Upload TD results to s3
         uses: seemethere/upload-artifact-s3@baba72d0712b404f646cebe0730933554ebce96a # v5.1.0
-        if: steps.td.outcome == 'success'
+        # Skipped on fork PRs (no S3 creds); the GHA-native upload below is the fallback.
+        if: steps.td.outcome == 'success' && steps.aws-creds.outcome == 'success'
         with:
           name: td_results
-          retention-days: 14
+          retention-days: 1
           if-no-files-found: error
           path: td_results.json
 
@@ -82,6 +106,6 @@ jobs:
         if: steps.td.outcome == 'success'
         with:
           name: td_results.json
-          retention-days: 14
+          retention-days: 1
           if-no-files-found: error
           path: td_results.json

--- a/tools/testing/do_target_determination_for_s3.py
+++ b/tools/testing/do_target_determination_for_s3.py
@@ -1,3 +1,6 @@
+# /// script
+# dependencies = ["boto3==1.35.42"]
+# ///
 import json
 import os
 import sys


### PR DESCRIPTION
Run the `target-determination` job on an OSDC runner (`l-x86iavx512-8-64`, the equivalent of `linux.2xlarge`) in a container, instead of EC2 `linux.2xlarge`.

OSDC is always on (`use-arc: true`). The runner determinator is kept only to pick the fleet — Meta (`mt-`) by default, LF (`lf-`) when the `lf` experiment selects it.