### PR TITLE
Restore graph-break baselines for conv training models zeroed during cuDNN outage

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/inductor_timm_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/inductor_timm_training.csv
@@ -34,7 +34,7 @@ inception_v3,pass,6
 
 
 
-mobilenetv2_100,pass,0
+mobilenetv2_100,pass,7
 
 
 
@@ -58,7 +58,7 @@ swin_base_patch4_window7_224,pass,7
 
 
 
-tf_efficientnet_b0,pass,0
+tf_efficientnet_b0,pass,6
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_training.csv
@@ -90,11 +90,11 @@ microbench_unbacked_tolist_sum,pass,9
 
 
 
-mnasnet1_0,pass,0
+mnasnet1_0,pass,7
 
 
 
-mobilenet_v2,pass,0
+mobilenet_v2,pass,6
 
 
 
@@ -162,7 +162,7 @@ sam,eager_fail_to_run,0
 
 
 
-shufflenet_v2_x1_0,pass,0
+shufflenet_v2_x1_0,pass,6
 
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #188507

Five convolutional training benchmarks regressed CI on the
check_graph_breaks step:

  inductor_timm_training:       mobilenetv2_100 (7), tf_efficientnet_b0 (6)
  inductor_torchbench_training: mnasnet1_0 (7), mobilenet_v2 (6), shufflenet_v2_x1_0 (6)

all reporting "graph_breaks=N, expected=0".

Root cause: the expected=0 baselines are wrong. These models have carried
6-7 training graph breaks (from the optimizer step) for a long time. The
0 was introduced only on 2026-06-23 (#187651) and 2026-06-25 (#185739),
during the window when the cuDNN Fwd Engine 5 bug in backend 9.23.1 was
silently breaking these CNNs in training: with no compiled graph produced,
runs recorded a degenerate 0 graph breaks, and update_expected.py runs in
those two PRs baked the 0 into the baselines. (The #185739 CSV edits are
incidental to its actual change -- a Dynamo guard for HuggingFace-Accelerate
partial-patched module forwards -- and cannot have reduced these plain
torchvision/timm CNN counts, since those models do not use partial-patched
forwards.)

The cuDNN engine was disabled in #188318 (2026-06-29), which re-enabled the
models; they now compile correctly and emit their true 6/7 graph breaks,
failing against the stale 0 baseline. This restores the historical counts.

The graph-break owners whose baseline edits this corrects (#185739, #187651)
should confirm 6/7 is the intended steady-state count rather than 0.

Test Plan:

Confirmed the failing CI counts from the inductor_timm and inductor_torchbench
training jobs:

```
mobilenetv2_100     FAIL: graph_breaks=7, expected=0
tf_efficientnet_b0  FAIL: graph_breaks=6, expected=0
mnasnet1_0          FAIL: graph_breaks=7, expected=0
mobilenet_v2        FAIL: graph_breaks=6, expected=0
shufflenet_v2_x1_0  FAIL: graph_breaks=6, expected=0
```

Verified the prior baselines via git history (6-7 for years; zeroed only
2026-06-23/06-25):

```
git log -L <line>,<line>:benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_training.csv
```

Lint:

```
lintrunner benchmarks/dynamo/ci_expected_accuracy/inductor_timm_training.csv \
           benchmarks/dynamo/ci_expected_accuracy/inductor_torchbench_training.csv
```

Authored with assistance from Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98