### PR TITLE
Migrate llm-retrieval to OSDC

### DIFF
--- a/.github/workflows/llm_td_retrieval.yml
+++ b/.github/workflows/llm_td_retrieval.yml
@@ -5,7 +5,6 @@ on:
   workflow_call:
 
 permissions:
-  id-token: write
   contents: read
 
 jobs:
@@ -19,16 +18,29 @@ jobs:
       issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
+      check_experiments: "arc,lf"
 
   llm-retrieval:
     # Don't run on forked repos
     if: github.repository_owner == 'pytorch'
-    runs-on: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge"
+    runs-on: "${{ needs.get-label-type.outputs.label-type }}l-x86iavx512-16-128"
     continue-on-error: true
     needs: get-label-type
+    container:
+      image: ghcr.io/actions/actions-runner:latest
     steps:
       - name: Setup Linux
         uses: pytorch/pytorch/.github/actions/setup-linux@main
+        with:
+          use-arc: true
+
+      - name: Setup uv
+        uses: pytorch/test-infra/.github/actions/setup-uv@main
+        with:
+          # torch==2.0.1 (pinned by llm-target-determinator) only ships wheels up to cp311
+          python-version: "3.11"
+          activate-environment: true
+          enable-cache: true
 
       - name: Clone CodeLlama
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -48,9 +60,12 @@ jobs:
         shell: bash
         run: |
           set -euxo pipefail
-          python3 -m pip install -r llm-target-determinator/requirements.txt
+          # aws CLI is preinstalled on EC2 hosts but not in the container; install it
+          # here so the checkpoint-fetch step below has it.
+          uv pip install awscli==1.29.40
+          uv pip install -r llm-target-determinator/requirements.txt
           cd "${GITHUB_WORKSPACE}/codellama"
-          python3 -m pip install -e .
+          uv pip install -e .
 
       - name: Fetch CodeLlama Checkpoint
         shell: bash
@@ -58,7 +73,9 @@ jobs:
           set -euxo pipefail
           cd "${GITHUB_WORKSPACE}/codellama"
           mkdir "CodeLlama-7b-Python"
-          aws s3 cp "s3://target-determinator-assets/CodeLlama-7b-Python" "CodeLlama-7b-Python" --recursive --no-progress
+          # target-determinator-assets is a public bucket; download anonymously so
+          # we don't need S3 credentials for the read.
+          aws s3 cp "s3://target-determinator-assets/CodeLlama-7b-Python" "CodeLlama-7b-Python" --recursive --no-progress --no-sign-request
 
       - name: Fetch indexes
         uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
@@ -69,9 +86,9 @@ jobs:
           shell: bash
           command: |
             set -euxo pipefail
-            python3 -m pip install awscli==1.29.40
+            uv pip install awscli==1.29.40
             cd "${GITHUB_WORKSPACE}"/llm-target-determinator/assets
-            aws s3 cp "s3://target-determinator-assets/indexes/latest" . --recursive
+            aws s3 cp "s3://target-determinator-assets/indexes/latest" . --recursive --no-sign-request
 
             unzip -o indexer-files\*.zip
             rm indexer-files*.zip
@@ -94,21 +111,11 @@ jobs:
           cd assets
           zip -r mappings.zip mappings
 
-      - name: Upload results to s3
-        uses: seemethere/upload-artifact-s3@baba72d0712b404f646cebe0730933554ebce96a # v5.1.0
+      - name: Upload results
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: ${{ steps.run_retriever.outcome == 'success' }}
         with:
           name: llm_results
-          retention-days: 14
+          retention-days: 1
           if-no-files-found: warn
           path: llm-target-determinator/assets/mappings.zip
-        env:
-          AWS_ACCESS_KEY_ID: ""
-          AWS_SECRET_ACCESS_KEY: ""
-          AWS_SESSION_TOKEN: ""
-          AWS_DEFAULT_REGION: ""
-          AWS_REGION: ""
-
-      - name: Teardown Linux
-        uses: pytorch/test-infra/.github/actions/teardown-linux@main
-        if: always()


### PR DESCRIPTION
Run the `llm-retrieval` (Target Determination retriever) job on an OSDC runner (`l-x86iavx512-16-128`, the equivalent of `linux.4xlarge`) in a container, instead of EC2 `linux.4xlarge`.

OSDC is always on (`use-arc: true`); the runner determinator picks the fleet — Meta (`mt-`) by default, LF (`lf-`) when the `lf` experiment selects it.