### PR TITLE
Fix stale codegen golden string in test_extension_backend

### DIFF
--- a/test/inductor/test_extension_backend.py
+++ b/test/inductor/test_extension_backend.py
@@ -166,7 +166,7 @@ class ExtensionBackendTests(BaseExtensionBackendTests):
                 ):
                     load_expr = "loadu"
                 else:
-                    load_expr = " = in_ptr0[static_cast<long>(i0)];"
+                    load_expr = " = in_ptr0[static_cast<int64_t>(x0)];"
                 FileCheck().check("void").check(load_expr).check(
                     "extension_device"
                 ).run(code)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #188509

test_open_device_registration uses a FileCheck to assert the generated
CPU C++ wrapper contains a scalar load expression. The expected string
was " = in_ptr0[static_cast<long>(i0)];", but inductor CPU codegen now
emits " = in_ptr0[static_cast<int64_t>(x0)];": the index cast changed
from long to int64_t and the loop variable was renamed from i0 to x0.
The golden string was never updated, so the check fails on the
nogpu_NO_AVX2 periodic shard, which forces the scalar (non-vectorized)
load path via ATEN_CPU_CAPABILITY=default.

Rebaseline the expected string to match the current codegen output.

Test Plan:
Reproduced the shard's codegen path locally by forcing the scalar load
branch, which fails before this change and passes after:

```
ATEN_CPU_CAPABILITY=default python -m pytest \
  test/inductor/test_extension_backend.py::ExtensionBackendTests::test_open_device_registration -v
# -> 1 passed
```

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo