### PR TITLE
 [ATen] Use castRaw in TensorType::isSubtypeOfExt to avoid shared_ptr refcount overhead

### DIFF
--- a/aten/src/ATen/core/tensor_type.cpp
+++ b/aten/src/ATen/core/tensor_type.cpp
@@ -461,9 +461,9 @@ const SymbolicShape& TensorType::symbolic_sizes() const {
 }
 
 bool TensorType::isSubtypeOfExt(const Type& rhs, std::ostream* why_not) const {
-  if (auto rhs_p = rhs.cast<TensorType>()) {
+  if (auto* rhs_p = rhs.castRaw<TensorType>()) {
     // if we have the same pointer, avoid computing the merge
-    if (this == rhs_p.get()) {
+    if (this == rhs_p) {
       return true;
     }
     return *merge(*rhs_p) == *rhs_p;


### PR DESCRIPTION
TensorType::isSubtypeOfExt previously used rhs.cast(), which returns
an owning shared_ptr via shared_from_this() -- incurring an atomic refcount
increment/decrement plus a shared_ptr destruction on every call -- even though
ownership of rhs is never needed here (rhs is a live const reference, used only
transiently).

This replaces it with rhs.castRaw(), the standard cast->castRaw
idiom: a plain kind() check plus a static_cast returning a raw pointer, with no
refcount traffic. The pointer comparison is updated from this == rhs_p.get()
to this == rhs_p accordingly.

Behavior is identical: both cast and castRaw gate on the same T::Kind == kind()
condition and yield the same address, and shared_from_this() can never throw here
since all TensorType instances are shared_ptr-managed via private constructors +
static create() factories. This is a pure performance change -- it removes the
atomic refcount and shared_ptr teardown from a hot subtyping check
(TensorType::isSubtypeOfExt is the dominant callee of c10::Type::isSubtypeOf).

Summary: Pull Request resolved: https://github.com/pytorch/pytorch/pull/188511

Reviewed By: MatzeB

Differential Revision: D109921948


