### PR TITLE
Sync ROCm dynamic huggingface training graph-break baselines

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamic_inductor_huggingface_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamic_inductor_huggingface_training.csv
@@ -10,7 +10,7 @@ AllenaiLongformerBase,pass,9
 
 
 
-BartForCausalLM,pass,6
+BartForCausalLM,pass,7
 
 
 
@@ -30,7 +30,7 @@ DistilBertForMaskedLM,pass,5
 
 
 
-DistillGPT2,fail_accuracy,7
+DistillGPT2,pass,8
 
 
 
@@ -50,11 +50,11 @@ LayoutLMForMaskedLM,pass,5
 
 
 
-M2M100ForConditionalGeneration,pass,11
+M2M100ForConditionalGeneration,pass,4
 
 
 
-MBartForCausalLM,pass,6
+MBartForCausalLM,pass,7
 
 
 
@@ -70,15 +70,15 @@ MobileBertForMaskedLM,pass,3
 
 
 
-OPTForCausalLM,pass,8
+OPTForCausalLM,pass,7
 
 
 
-PLBartForCausalLM,pass,6
+PLBartForCausalLM,pass,7
 
 
 
-PegasusForCausalLM,pass,6
+PegasusForCausalLM,pass,7
 
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #188512

The periodic rocm-periodic-dynamo-benchmarks-test job
(dynamic_inductor_huggingface training, gfx950) fails the
check_graph_breaks step:

  BartForCausalLM     graph_breaks=7, expected=6
  DistillGPT2         graph_breaks=8, expected=7
  MBartForCausalLM    graph_breaks=7, expected=6
  PLBartForCausalLM   graph_breaks=7, expected=6
  PegasusForCausalLM  graph_breaks=7, expected=6

Root cause: this is graph-break baseline drift on the HuggingFace decoder
models, not a new regression and not ROCm-specific. The +1 break on these
models was already rebaselined in the non-ROCm CSV via routine updates
(PegasusForCausalLM #184259, DistillGPT2 #180738, PLBartForCausalLM
#188478), but the ROCm expected file was never kept in sync, so the
less-frequent periodic ROCm job accumulated the lag and now trips on all
five at once.

This syncs rocm/dynamic_inductor_huggingface_training.csv to the values the
job currently produces, matching what update_expected.py would write:

  - raise the five new-graph-break counts above to match actuals
  - DistillGPT2: fail_accuracy,7 -> pass,8 (accuracy now passes; count is 8)
  - pull in the two improvements the same run reports so the baseline stays
    tight: M2M100ForConditionalGeneration 11 -> 4, OPTForCausalLM 8 -> 7

The EAGER_FAILED models in the same job (Blenderbot, DebertaV2, Qwen3-0.6B,
gemma-2-2b, Llama-3.2-1B, whisper-tiny) are expected (XFAIL) and do not
affect this check.

Test Plan:

Counts taken directly from the failing job's check_accuracy.py and
check_graph_breaks.py output against
rocm/dynamic_inductor_huggingface_training.csv:

```
BartForCausalLM     FAIL: graph_breaks=7, expected=6
DistillGPT2         FAIL: graph_breaks=8, expected=7   IMPROVED: accuracy=pass
MBartForCausalLM    FAIL: graph_breaks=7, expected=6
PLBartForCausalLM   FAIL: graph_breaks=7, expected=6
PegasusForCausalLM  FAIL: graph_breaks=7, expected=6
M2M100ForConditionalGeneration  IMPROVED: graph_breaks=4, expected=11
OPTForCausalLM                   IMPROVED: graph_breaks=7, expected=8
```

Lint:

```
lintrunner benchmarks/dynamo/ci_expected_accuracy/rocm/dynamic_inductor_huggingface_training.csv
```

Authored with assistance from Claude.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @azahed98