### PR TITLE
Fix URL lint false-FAIL on bot-protected hosts (hud.pytorch.org)

### DIFF
--- a/scripts/lint_urls.sh
+++ b/scripts/lint_urls.sh
@@ -36,7 +36,14 @@ while IFS=: read -r filepath url; do
             "https://check-host.net/check-result/$request_id" \
             | jq -r -e '.[][0][3]') || new_code=000
           [[ "$new_code" =~ ^[0-9]+$ ]] || new_code=000
-          if [ "$new_code" -ge 200 ] && [ "$new_code" -lt 400 ]; then
+          # check-host.net reports 000 only while a node has not produced a
+          # result yet (or the host is genuinely unreachable); any real HTTP
+          # status it returns is authoritative, so adopt it and let the
+          # WARN/FAIL/OK logic below classify it. Previously this accepted only
+          # 2xx/3xx, which discarded the 403/429/503 WAF responses we treat as
+          # WARN -- yielding a false FAIL for live-but-bot-protected hosts such
+          # as hud.pytorch.org (pytorch/pytorch#188510).
+          if [ "$new_code" -ge 100 ] && [ "$new_code" -le 599 ]; then
             code=$new_code
             break
           fi


### PR DESCRIPTION
## Summary

`scripts/lint_urls.sh` hard-fails on URLs pointing at `https://hud.pytorch.org` (and any other live host behind an anti-bot WAF), even though the site is reachable for real users. See #188510.

## Root cause

The linter already tolerates WAF responses — `403/429/503` are printed as `WARN` (pass), not `FAIL`. The problem is a gap in the **check-host.net fallback**, the external prober used when the runner's own `curl` can't get a status:

```bash
new_code=$(... check-host.net/check-result/$request_id | jq -r -e '.[][0][3]') || new_code=000
[[ "$new_code" =~ ^[0-9]+$ ]] || new_code=000
if [ "$new_code" -ge 200 ] && [ "$new_code" -lt 400 ]; then   # <-- only 2xx/3xx adopted
  code=$new_code
  break
fi
```

On the Meta-hosted lint runner the two direct `curl` attempts to `hud.pytorch.org` return `http_code 000` (no status captured). The check-host.net fallback then **does** observe the real status — `429` from the Vercel WAF — but the acceptance condition only adopts `2xx/3xx`, so the `429` is thrown away, `code` stays `000`, and the URL falls through to the hard `FAIL` branch.

Verified:
- CI log of the failing run (`Link checks / lint-urls`, job 84156364669): `FAIL 000 https://hud.pytorch.org`.
- The exact check-host.net invocation this script uses (`us3.node.check-host.net`, `max_nodes=1`) returns `429` on the first poll for both `https://hud.pytorch.org` and `https://hud.pytorch.org/api/hud/pytorch/pytorch` — i.e. the fallback already has the information needed to WARN-pass; it was just being discarded.

## Fix

Adopt **any real HTTP status (100–599)** reported by check-host.net and let the existing `WARN`/`FAIL`/`OK` logic below classify it. `000` remains the "no result yet / unreachable" sentinel that keeps the poll loop going, so genuinely dead links still `FAIL` as before.

This also makes diagnostics more accurate: a check-host-observed `404`/`500` now surfaces as `FAIL 404`/`FAIL 500` instead of a misleading `FAIL 000`.

## Test plan

- `bash -n scripts/lint_urls.sh` passes.
- A URL behind a WAF that returns `403/429/503` via check-host.net now reports `WARN` instead of `FAIL`.
- A genuinely broken URL (no HTTP response anywhere → `000`) still reports `FAIL`.
- The `Link checks / lint-urls` job on this PR exercises the path (this PR touches a checked file).