### PR TITLE
Fix OrderingBarrier additional_buffer_deps key mismatch in control_deps lowering

### DIFF
--- a/test/inductor/test_control_deps.py
+++ b/test/inductor/test_control_deps.py
@@ -556,6 +556,12 @@ class TestControlDeps(InductorTestCase):
                 {
                     "barriers": barriers,
                     "barrier_source_names": [b.mutation_names[0] for b in barriers],
+                    "additional_buffer_deps": dict(V.graph.additional_buffer_deps),
+                    "buffer_names": {
+                        name
+                        for op in V.graph.operations
+                        if (name := op.get_buffer_name()) is not None
+                    },
                     "ordering_only_flags": [b.ordering_only for b in barriers],
                     "mutated_buffers": set(V.graph.mutated_buffers),
                 }
@@ -586,6 +592,27 @@ class TestControlDeps(InductorTestCase):
                 all(c["ordering_only_flags"]),
                 "all OrderingBarrier nodes must have ordering_only=True",
             )
+            for barrier in c["barriers"]:
+                barrier_op = barrier.get_operation_name()
+                barrier_name = barrier.get_name()
+                self.assertIn(
+                    barrier_op,
+                    c["additional_buffer_deps"],
+                    "OrderingBarrier deps must be keyed by operation name",
+                )
+                self.assertNotIn(
+                    barrier_name,
+                    c["additional_buffer_deps"],
+                    "OrderingBarrier deps must not be keyed by buffer name",
+                )
+                self.assertTrue(
+                    c["additional_buffer_deps"][barrier_op],
+                    "OrderingBarrier should depend on subgraph ops",
+                )
+                self.assertTrue(
+                    c["additional_buffer_deps"][barrier_op] <= c["buffer_names"],
+                    "OrderingBarrier deps must contain buffer names",
+                )
             for source_name in c["barrier_source_names"]:
                 self.assertNotIn(
                     source_name,


### PR DESCRIPTION
## Summary

Fix a key mismatch in `control_deps_op_lowering` that caused `OrderingBarrier`'s `additional_buffer_deps` to be silently dropped by the scheduler, breaking stream synchronization ordering.

`OrderingBarrier` inherits from `OperationBuffer`, which has distinct buffer and operation names (assigned by `register_buffer()` and `register_operation()` respectively). The lowering stored deps under the buffer name via `barrier.get_name()` (→ `Buffer.get_name()`, e.g. `"buf5"`), but the scheduler looks them up via `node.get_name()` on `NopKernelSchedulerNode` (→ `get_operation_name()`, e.g. `"op2"`). Since these keys differ, the `additional_buffer_deps` were never found.

```python
# Before: key is buffer name, scheduler queries operation name -> silent miss
V.graph.additional_buffer_deps[barrier.get_name()].add(op_name)

# After: key is operation name, matches scheduler lookup
barrier_op = barrier.get_operation_name()
V.graph.additional_buffer_deps[barrier_op].add(op_name)
```

Without these deps, barriers had no ordering constraint relative to the sync ops (`record_event`/`wait_event`) they were supposed to be sequenced after. In bidirectional stream sync patterns (stream A computes + records event, stream B waits + computes + records back, stream A waits again), the scheduler could place compute kernels before `wait_event` calls, causing GPU reads of data not yet produced by the other stream -- a race condition manifesting as flaky numerical mismatches.

## Test Plan

```
python -m pytest test/inductor/test_user_streams.py::TestUserStreamCompile::test_bidirectional_stream_sync -xvs
```

Fixes #188513

Authored with an AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo