### PR TITLE
test: centralize optimizer comparison tolerances

### DIFF
--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -145,6 +145,29 @@ class TestOptimRenewed(TestCase):
 
     hw_classification = HardwareClassification.ACCELERATOR
 
+    _default_optim_tolerance_multiplier = 5
+
+    def _get_optim_tolerances(
+        self,
+        dtype,
+        *,
+        multiplier=_default_optim_tolerance_multiplier,
+        rtol=None,
+        atol=None,
+    ):
+        if rtol is not None and atol is not None:
+            return rtol, atol
+
+        single_rtol, single_atol = torch.testing._comparison.get_tolerances(
+            dtype, rtol=rtol, atol=atol
+        )
+        return multiplier * single_rtol, multiplier * single_atol
+
+    def assertEqualWithOptimTolerances(self, actual, expected, dtype, **kwargs):
+        rtol, atol = self._get_optim_tolerances(dtype, **kwargs)
+        self.assertEqual(actual, expected, rtol=rtol, atol=atol)
+
+    @onlyCPU
     @optims(optim_db)
     def test_optim_infos_do_not_specify_global_cliquey_kwargs(
         self, device, dtype, optim_info
@@ -565,7 +588,13 @@ class TestOptimRenewed(TestCase):
                             scheduler.step()
                     # Tolerance is increased due to floating point error from different
                     # code path for dense case: x v.s. x - x / 4.0 + x / 4.0
-                    self.assertEqual(params, params_c, atol=5e-6, rtol=5e-6)
+                    self.assertEqualWithOptimTolerances(
+                        params,
+                        params_c,
+                        dtype,
+                        rtol=5e-6,
+                        atol=5e-6,
+                    )
 
             if not kwargs.get("maximize", False):
                 self.assertLessEqual(
@@ -983,15 +1012,7 @@ class TestOptimRenewed(TestCase):
 
             og_state, new_state = state
             for og_p, new_p in zip(updated_params[0], updated_params[1]):
-                # Increasing the tolerance as we are collating lots of ops together for optimizers and
-                # the designated tolerances are for single op only.
-                single_rtol, single_atol = torch.testing._comparison.get_tolerances(
-                    new_p.dtype, rtol=None, atol=None
-                )
-                rtol = 5 * single_rtol
-                atol = 5 * single_atol
-
-                self.assertEqual(og_p, new_p, rtol=rtol, atol=atol)
+                self.assertEqualWithOptimTolerances(og_p, new_p, new_p.dtype)
 
                 # check that optimizer states are the same
                 og_p_state = og_state[og_p]
@@ -999,7 +1020,9 @@ class TestOptimRenewed(TestCase):
 
                 for k in og_p_state:
                     actual = new_p_state[k]
-                    self.assertEqual(og_p_state[k], actual, rtol=rtol, atol=atol)
+                    self.assertEqualWithOptimTolerances(
+                        og_p_state[k], actual, new_p.dtype
+                    )
 
     @skipMPS  # MPS does not support float64
     @onlyAccelerator

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -143,6 +143,28 @@ class TestOptimRenewed(TestCase):
         * Grads can also be None, empty, or zero-valued, and this should not disrupt training.
     """
 
+    _default_optim_tolerance_multiplier = 5
+
+    def _get_optim_tolerances(
+        self,
+        dtype,
+        *,
+        multiplier=_default_optim_tolerance_multiplier,
+        rtol=None,
+        atol=None,
+    ):
+        if rtol is not None and atol is not None:
+            return rtol, atol
+
+        single_rtol, single_atol = torch.testing._comparison.get_tolerances(
+            dtype, rtol=rtol, atol=atol
+        )
+        return multiplier * single_rtol, multiplier * single_atol
+
+    def assertEqualWithOptimTolerances(self, actual, expected, dtype, **kwargs):
+        rtol, atol = self._get_optim_tolerances(dtype, **kwargs)
+        self.assertEqual(actual, expected, rtol=rtol, atol=atol)
+
     @onlyCPU
     @optims(optim_db)
     def test_optim_infos_do_not_specify_global_cliquey_kwargs(
@@ -551,7 +573,13 @@ class TestOptimRenewed(TestCase):
                             scheduler.step()
                     # Tolerance is increased due to floating point error from different
                     # code path for dense case: x v.s. x - x / 4.0 + x / 4.0
-                    self.assertEqual(params, params_c, atol=5e-6, rtol=5e-6)
+                    self.assertEqualWithOptimTolerances(
+                        params,
+                        params_c,
+                        dtype,
+                        rtol=5e-6,
+                        atol=5e-6,
+                    )
 
             if not kwargs.get("maximize", False):
                 self.assertLessEqual(
@@ -949,15 +977,7 @@ class TestOptimRenewed(TestCase):
 
             og_state, new_state = state
             for og_p, new_p in zip(updated_params[0], updated_params[1]):
-                # Increasing the tolerance as we are collating lots of ops together for optimizers and
-                # the designated tolerances are for single op only.
-                single_rtol, single_atol = torch.testing._comparison.get_tolerances(
-                    new_p.dtype, rtol=None, atol=None
-                )
-                rtol = 5 * single_rtol
-                atol = 5 * single_atol
-
-                self.assertEqual(og_p, new_p, rtol=rtol, atol=atol)
+                self.assertEqualWithOptimTolerances(og_p, new_p, new_p.dtype)
 
                 # check that optimizer states are the same
                 og_p_state = og_state[og_p]
@@ -965,7 +985,9 @@ class TestOptimRenewed(TestCase):
 
                 for k in og_p_state:
                     actual = new_p_state[k]
-                    self.assertEqual(og_p_state[k], actual, rtol=rtol, atol=atol)
+                    self.assertEqualWithOptimTolerances(
+                        og_p_state[k], actual, new_p.dtype
+                    )
 
     @onlyCUDA
     @optims(


### PR DESCRIPTION
Fixes #116203

Summary:
- Adds a shared optimizer-test helper for widened comparison tolerances.
- Reuses it for the existing sparse-vs-dense comparison and foreach-vs-for-loop parameter/state comparisons.
- Keeps the current numeric thresholds unchanged; this is only a test refactor to make future optimizer tolerance handling less scattered.

Test Plan:
- `python3 -m py_compile test/test_optim.py` - passed
- `git diff --check` - passed
- `python3 test/test_optim.py -k test_forloop_goes_directionally_correct -v` - attempted, but this local sparse checkout cannot import `torch`
