### PR TITLE
test: add Linear module error inputs

### DIFF
--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -287,6 +287,30 @@ def module_inputs_torch_nn_Linear(module_info, device, dtype, requires_grad, tra
     return module_inputs
 
 
+def module_error_inputs_torch_nn_Linear(module_info, device, dtype, requires_grad, training, **kwargs):
+    make_input = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)
+    return [
+        ErrorModuleInput(
+            ModuleInput(
+                constructor_input=FunctionInput(10, 8),
+                forward_input=FunctionInput(make_input((4, 5))),
+            ),
+            error_on=ModuleErrorEnum.FORWARD_ERROR,
+            error_type=RuntimeError,
+            error_regex="mat1 and mat2 shapes cannot be multiplied",
+        ),
+        ErrorModuleInput(
+            ModuleInput(
+                constructor_input=FunctionInput(-1, 8),
+                forward_input=FunctionInput(make_input((4, 10))),
+            ),
+            error_on=ModuleErrorEnum.CONSTRUCTION_ERROR,
+            error_type=RuntimeError,
+            error_regex="Trying to create tensor with negative dimension",
+        ),
+    ]
+
+
 def module_inputs_torch_nn_Bilinear(module_info, device, dtype, requires_grad, training, **kwargs):
     make_input = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)
 
@@ -4508,6 +4532,7 @@ module_db: list[ModuleInfo] = [
                )),
     ModuleInfo(torch.nn.Linear,
                module_inputs_func=module_inputs_torch_nn_Linear,
+               module_error_inputs_func=module_error_inputs_torch_nn_Linear,
                skips=(
                    # No channels_last support for Linear currently.
                    DecorateInfo(unittest.skip("Skipped!"), 'TestModule', 'test_memory_format'),)

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -287,6 +287,30 @@ def module_inputs_torch_nn_Linear(module_info, device, dtype, requires_grad, tra
     return module_inputs
 
 
+def module_error_inputs_torch_nn_Linear(module_info, device, dtype, requires_grad, training, **kwargs):
+    make_input = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)
+    return [
+        ErrorModuleInput(
+            ModuleInput(
+                constructor_input=FunctionInput(10, 8),
+                forward_input=FunctionInput(make_input((4, 5))),
+            ),
+            error_on=ModuleErrorEnum.FORWARD_ERROR,
+            error_type=RuntimeError,
+            error_regex="mat1 and mat2 shapes cannot be multiplied",
+        ),
+        ErrorModuleInput(
+            ModuleInput(
+                constructor_input=FunctionInput(-1, 8),
+                forward_input=FunctionInput(make_input((4, 10))),
+            ),
+            error_on=ModuleErrorEnum.CONSTRUCTION_ERROR,
+            error_type=RuntimeError,
+            error_regex="Trying to create tensor with negative dimension",
+        ),
+    ]
+
+
 def module_inputs_torch_nn_Bilinear(module_info, device, dtype, requires_grad, training, **kwargs):
     make_input = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)
 
@@ -4501,6 +4525,7 @@ module_db: list[ModuleInfo] = [
                )),
     ModuleInfo(torch.nn.Linear,
                module_inputs_func=module_inputs_torch_nn_Linear,
+               module_error_inputs_func=module_error_inputs_torch_nn_Linear,
                skips=(
                    # No channels_last support for Linear currently.
                    DecorateInfo(unittest.skip("Skipped!"), 'TestModule', 'test_memory_format'),)


### PR DESCRIPTION
Fixes #174177

Summary:
- Adds `module_error_inputs_torch_nn_Linear` and wires it into the `torch.nn.Linear` `ModuleInfo`.
- Covers the Linear error paths for wrong trailing input features and negative `in_features`.
- Intentionally does not add the scalar-input error case because `test_linear_raise_on_scalar_input` already covers it in `test/test_nn.py`.

Test Plan:
- `python3 -m py_compile torch/testing/_internal/common_modules.py` - passed
- `git diff --check` - passed
- `python3 test/test_nn.py TestModuleCPU.test_errors --subprocess -v` - attempted, but this local sparse checkout cannot import `torch`
