### PR TITLE
error checking: validate _pdist_forward dimensions

### DIFF
--- a/aten/src/ATen/native/Distance.cpp
+++ b/aten/src/ATen/native/Distance.cpp
@@ -241,6 +241,11 @@ Tensor _cdist_backward(const Tensor& _grad, const Tensor& _x1, const Tensor& _x2
 }
 
 Tensor _pdist_forward(const Tensor& self, const double p) {
+  TORCH_CHECK(
+      self.dim() == 2,
+      "_pdist_forward only supports 2D tensors, got: ",
+      self.dim(),
+      "D");
   TORCH_CHECK(self.is_contiguous(), "_pdist_forward requires contiguous input");
   auto device = self.device().type();
   TORCH_CHECK(device == kCPU || device == kCUDA || device == kXPU || device == kPrivateUse1, "_pdist_forward only supports CPU, XPU, CUDA and PrivateUse1 devices, got: ", device);

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2592,6 +2592,10 @@ class TestTorchDeviceType(TestCase):
         x = torch.randn(shape, device=device)
         self.assertEqual(torch.zeros(3, device=device), torch.pdist(x))
 
+        x = torch.randn((11, 15, 0), device=device)
+        with self.assertRaisesRegex(RuntimeError, "_pdist_forward only supports 2D tensors"):
+            torch.ops.aten._pdist_forward(x, 2.0)
+
     def test_cdist_empty(self, device):
         x = torch.randn((0, 5), device=device)
         y = torch.randn((4, 5), device=device)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2465,6 +2465,10 @@ class TestTorchDeviceType(TestCase):
         x = torch.randn(shape, device=device)
         self.assertEqual(torch.zeros(3, device=device), torch.pdist(x))
 
+        x = torch.randn((11, 15, 0), device=device)
+        with self.assertRaisesRegex(RuntimeError, "_pdist_forward only supports 2D tensors"):
+            torch.ops.aten._pdist_forward(x, 2.0)
+
     def test_cdist_empty(self, device):
         x = torch.randn((0, 5), device=device)
         y = torch.randn((4, 5), device=device)


### PR DESCRIPTION
Fixes #145064

Summary:
- Adds the missing dimensionality check to the internal `_pdist_forward` op so non-2D inputs raise a normal `RuntimeError` instead of reaching the native kernel with bad indexing.
- Preserves the existing public `torch.pdist` behavior for valid 2D empty-column inputs such as shape `(3, 0)`, which still returns zeros.
- Adds a regression assertion to the existing `test_pdist_empty` coverage.

Test Plan:
- `python3 -m py_compile test/test_torch.py` - passed
- `git diff --check` - passed
- `python3 test/test_torch.py TestTorchDeviceTypeCPU.test_pdist_empty_cpu -v` - attempted, but this local sparse checkout cannot import `torch`
