### PR TITLE
cuda: reject negative caching allocator sizes

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -529,6 +529,12 @@ print(t.is_pinned())
         with self.assertRaisesRegex(ValueError, "Invalid memory size"):
             torch.cuda.memory.caching_allocator_alloc(-1024)
 
+    def test_caching_allocator_alloc_non_integer_size(self):
+        with self.assertRaisesRegex(TypeError, "integer"):
+            torch.cuda.memory.caching_allocator_alloc(1.5)
+        with self.assertRaisesRegex(TypeError, "integer"):
+            torch.cuda.memory.caching_allocator_alloc(torch.tensor(1))
+
     def test_memory_metadata_supported(self):
         # The native caching allocator records user metadata; cudaMallocAsync
         # (and pluggable allocators) do not.

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -525,6 +525,10 @@ print(t.is_pinned())
         with self.assertRaisesRegex(ValueError, "Invalid memory size"):
             torch.cuda.memory.caching_allocator_alloc(-1024)
 
+    def test_caching_allocator_alloc_non_integer_size(self):
+        with self.assertRaisesRegex(TypeError, "integer"):
+            torch.cuda.memory.caching_allocator_alloc(1.5)
+
     def test_memory_metadata_supported(self):
         # The native caching allocator records user metadata; cudaMallocAsync
         # (and pluggable allocators) do not.

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -528,6 +528,8 @@ print(t.is_pinned())
     def test_caching_allocator_alloc_non_integer_size(self):
         with self.assertRaisesRegex(TypeError, "integer"):
             torch.cuda.memory.caching_allocator_alloc(1.5)
+        with self.assertRaisesRegex(TypeError, "integer"):
+            torch.cuda.memory.caching_allocator_alloc(torch.tensor(1))
 
     def test_memory_metadata_supported(self):
         # The native caching allocator records user metadata; cudaMallocAsync

--- a/torch/cuda/memory.py
+++ b/torch/cuda/memory.py
@@ -119,6 +119,13 @@ def caching_allocator_alloc(size, device: "Device" = None, stream=None):
         See :ref:`cuda-memory-management` for more details about GPU memory
         management.
     """
+    if not isinstance(size, int):
+        raise TypeError("Invalid type for size argument, must be an integer")
+    if size < 0:
+        raise ValueError(
+            f"Invalid memory size: {size}. "
+            "caching_allocator_alloc requires a non-negative size."
+        )
     if device is None:
         device = torch.cuda.current_device()
     device = _get_device_index(device)

--- a/torch/cuda/memory.py
+++ b/torch/cuda/memory.py
@@ -119,6 +119,11 @@ def caching_allocator_alloc(size, device: "Device" = None, stream=None):
         See :ref:`cuda-memory-management` for more details about GPU memory
         management.
     """
+    if size < 0:
+        raise ValueError(
+            f"Invalid memory size: {size}. "
+            "caching_allocator_alloc requires a non-negative size."
+        )
     if device is None:
         device = torch.cuda.current_device()
     device = _get_device_index(device)

--- a/torch/cuda/memory.py
+++ b/torch/cuda/memory.py
@@ -4,7 +4,6 @@ r"""This package adds support for device memory management implemented in CUDA."
 import collections
 import contextlib
 import ctypes
-import operator
 import pickle
 import sys
 import threading
@@ -120,7 +119,8 @@ def caching_allocator_alloc(size, device: "Device" = None, stream=None):
         See :ref:`cuda-memory-management` for more details about GPU memory
         management.
     """
-    size = operator.index(size)
+    if not isinstance(size, int):
+        raise TypeError("Invalid type for size argument, must be an integer")
     if size < 0:
         raise ValueError(
             f"Invalid memory size: {size}. "

--- a/torch/cuda/memory.py
+++ b/torch/cuda/memory.py
@@ -4,6 +4,7 @@ r"""This package adds support for device memory management implemented in CUDA."
 import collections
 import contextlib
 import ctypes
+import operator
 import pickle
 import sys
 import threading
@@ -119,6 +120,7 @@ def caching_allocator_alloc(size, device: "Device" = None, stream=None):
         See :ref:`cuda-memory-management` for more details about GPU memory
         management.
     """
+    size = operator.index(size)
     if size < 0:
         raise ValueError(
             f"Invalid memory size: {size}. "


### PR DESCRIPTION
Fixes #177827

Summary:
- Adds Python-side validation in `torch.cuda.memory.caching_allocator_alloc` before resolving the CUDA device/stream or calling the raw caching allocator.
- Rejects negative integer allocation sizes with a clear `ValueError`.
- Rejects non-`int` sizes with `TypeError`, including float values and tensor scalar values, without broadening the API to accept `__index__`-only inputs.
- Release-note behavior note: float sizes now fail with `TypeError` from the Python validation instead of reaching the previous lower-level failure path.

Test Plan:
- `git diff --check` - passed
- `python3 -m py_compile torch/cuda/memory.py test/test_cuda.py` - passed
- `python3 test/test_cuda.py TestCuda.test_caching_allocator_alloc_non_integer_size TestCuda.test_caching_allocator_alloc_negative_size -v` - attempted, but this local environment is missing `psutil` before the CUDA test harness can run
