### PR TITLE
cpu: support small integer repeat_interleave counts

### DIFF
--- a/aten/src/ATen/native/Repeat.cpp
+++ b/aten/src/ATen/native/Repeat.cpp
@@ -87,8 +87,13 @@ Tensor repeat_interleave_symint(
     TORCH_CHECK(false, "repeats must be 0-dim or 1-dim tensor");
   }
 
-  auto ret = input.index_select(
-      dim.value(), at::repeat_interleave_symint(repeats_, std::move(output_size)));
+  Tensor repeat_indices =
+      at::repeat_interleave_symint(repeats_, std::move(output_size));
+  if (repeat_indices.scalar_type() != at::kLong &&
+      repeat_indices.scalar_type() != at::kInt) {
+    repeat_indices = repeat_indices.to(at::kLong);
+  }
+  auto ret = input.index_select(dim.value(), repeat_indices);
   // Restore conj and neg bits
   if (conj) {
     ret = ret.conj();

--- a/aten/src/ATen/native/Repeat.cpp
+++ b/aten/src/ATen/native/Repeat.cpp
@@ -43,10 +43,11 @@ Tensor repeat_interleave_cpu(
     const Tensor& repeat,
     std::optional<int64_t> output_size) {
   Tensor output;
-  AT_DISPATCH_INDEX_TYPES(repeat.scalar_type(), "repeat_interleave_cpu", [&]() {
-    output = repeat_interleave_common<index_t, compute_cpu<index_t>>(
-        repeat, output_size);
-  });
+  AT_DISPATCH_INTEGRAL_TYPES(
+      repeat.scalar_type(), "repeat_interleave_cpu", [&]() {
+        output = repeat_interleave_common<scalar_t, compute_cpu<scalar_t>>(
+            repeat, output_size);
+      });
 
   return output;
 }

--- a/aten/src/ATen/native/Repeat.h
+++ b/aten/src/ATen/native/Repeat.h
@@ -21,8 +21,12 @@ static inline Tensor repeat_interleave_common(
   TORCH_CHECK(
       repeats.dim() == 1, "repeat_interleave only accept 1D vector as repeat");
   TORCH_CHECK(
-      repeats.scalar_type() == at::kLong || repeats.scalar_type() == at::kInt,
-      "repeats has to be Long or Int tensor");
+      repeats.scalar_type() == at::kLong ||
+          repeats.scalar_type() == at::kInt ||
+          repeats.scalar_type() == at::kShort ||
+          repeats.scalar_type() == at::kChar ||
+          repeats.scalar_type() == at::kByte,
+      "repeats has to be Long, Int, Short, Char, or Byte tensor");
   if (repeats.size(0) == 0) {
     return at::empty_like(repeats, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
   }

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2126,6 +2126,16 @@ class TestTorchDeviceType(TestCase):
             self.assertEqual(a_with_output.dtype, y.dtype)
             self.assertEqual(a_with_output.size(), torch.Size([3, 2]))
 
+    @onlyCPU
+    def test_repeat_interleave_cpu_small_integer_repeats(self, device):
+        y = torch.tensor([[1, 2], [3, 4]], device=device)
+        expected = torch.tensor([[1, 2], [3, 4], [3, 4]], device=device)
+
+        for dtype in (torch.int8, torch.uint8, torch.int16):
+            lengths = torch.tensor([1, 2], dtype=dtype, device=device)
+            self.assertEqual(
+                torch.repeat_interleave(y, lengths, dim=0), expected)
+
     @dtypes(*floating_types())
     @dtypesIfCPU(*floating_types_and(torch.bfloat16, torch.half))
     @dtypesIfCUDA(*floating_types_and(torch.half))

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2106,7 +2106,11 @@ class TestTorchDeviceType(TestCase):
         temp = y.repeat_interleave(2)
         self.assertEqual(torch.Size([8]), temp.size())
 
-        for dtype in [torch.int, torch.long]:
+        repeat_dtypes = [torch.int, torch.long]
+        if device == "cpu":
+            repeat_dtypes.extend([torch.int8, torch.uint8, torch.int16])
+
+        for dtype in repeat_dtypes:
             lengths = torch.tensor([1, 2], dtype=dtype, device=device)
             output_size = torch.sum(lengths)
             a = torch.repeat_interleave(
@@ -2125,16 +2129,6 @@ class TestTorchDeviceType(TestCase):
             )
             self.assertEqual(a_with_output.dtype, y.dtype)
             self.assertEqual(a_with_output.size(), torch.Size([3, 2]))
-
-    @onlyCPU
-    def test_repeat_interleave_cpu_small_integer_repeats(self, device):
-        y = torch.tensor([[1, 2], [3, 4]], device=device)
-        expected = torch.tensor([[1, 2], [3, 4], [3, 4]], device=device)
-
-        for dtype in (torch.int8, torch.uint8, torch.int16):
-            lengths = torch.tensor([1, 2], dtype=dtype, device=device)
-            self.assertEqual(
-                torch.repeat_interleave(y, lengths, dim=0), expected)
 
     @dtypes(*floating_types())
     @dtypesIfCPU(*floating_types_and(torch.bfloat16, torch.half))


### PR DESCRIPTION
Fixes #151311

Summary:
- Extends the CPU repeat_interleave repeat-count path to dispatch over the integral repeat dtypes instead of only index dtypes.
- Allows int8, uint8, and int16 repeat tensors to use the existing CPU implementation without promoting the input or changing global dispatch macros.
- Adds focused CPU coverage in the existing repeat_interleave test.

Prior art:
- #152762 attempted this by promoting small integer repeat tensors and editing Dispatch.h. Review feedback asked for proper dispatch instead. This PR keeps the change local to repeat_interleave and dispatches the needed dtypes directly.

Test Plan:
- `git diff --check` - passed
- `python3 -m py_compile test/test_torch.py` - passed
- `python3 test/test_torch.py TestTorchDeviceTypeCPU.test_repeat_interleave_cpu_small_integer_repeats_cpu -v` - attempted, blocked locally because this sparse checkout cannot import torch (`ModuleNotFoundError: No module named 'torch'`).