### PR TITLE
optim: remove redundant Adafactor assert

### DIFF
--- a/torch/optim/_adafactor.py
+++ b/torch/optim/_adafactor.py
@@ -1,6 +1,6 @@
 # mypy: allow-untyped-decorators
 # mypy: allow-untyped-defs
-from typing import cast, TYPE_CHECKING
+from typing import cast
 
 import torch
 from torch import Tensor
@@ -501,9 +501,6 @@ def _multi_tensor_adafactor(
         if eps1 is None:
             eps_dtype = dtype if dtype is not None else device_params[0].dtype
             eps1 = torch.finfo(eps_dtype).eps
-
-        if TYPE_CHECKING:
-            assert device_state_steps[0] is not None
 
         if maximize:
             device_grads = torch._foreach_neg(device_grads)  # type: ignore[assignment]


### PR DESCRIPTION
Part of #164878

Summary:
- Removes a redundant plain assert from the Adafactor foreach path.
- Drops the now-unused TYPE_CHECKING import.
- Keeps runtime behavior unchanged; the removed assert only lived under TYPE_CHECKING and `device_state_steps` is already cast to `list[Tensor]`.

Test Plan:
- `git diff --check` - passed
- `python3 -m py_compile torch/optim/_adafactor.py` - passed
- `rg -n "^\s*assert\b|TYPE_CHECKING" torch/optim/_adafactor.py` - no matches