### PR TITLE
pooling: guard max_pool1d integer parameters

### DIFF
--- a/aten/src/ATen/native/MaxPooling.h
+++ b/aten/src/ATen/native/MaxPooling.h
@@ -40,6 +40,11 @@ inline void check_max_pool1d(
     stride = kernel_size;
   }
 
+  safe_downcast<int, int64_t>(kernel_size[0]);
+  safe_downcast<int, int64_t>(stride[0]);
+  safe_downcast<int, int64_t>(padding[0]);
+  safe_downcast<int, int64_t>(dilation[0]);
+
   TORCH_CHECK(
       kernel_size[0] > 0,
       "max_pool1d() kernel_size must be greater than zero, but got ",

--- a/aten/src/ATen/native/MaxPooling.h
+++ b/aten/src/ATen/native/MaxPooling.h
@@ -5,6 +5,8 @@
 #include <ATen/native/DispatchStub.h>
 #include <ATen/native/Pool.h>
 
+#include <limits>
+
 namespace at::native {
 
 inline void check_max_pool1d(
@@ -40,10 +42,17 @@ inline void check_max_pool1d(
     stride = kernel_size;
   }
 
-  safe_downcast<int, int64_t>(kernel_size[0]);
-  safe_downcast<int, int64_t>(stride[0]);
-  safe_downcast<int, int64_t>(padding[0]);
-  safe_downcast<int, int64_t>(dilation[0]);
+  const auto check_int_range = [](int64_t value, const char* name) {
+    TORCH_CHECK(
+        value <= std::numeric_limits<int>::max(),
+        "max_pool1d() ",
+        name,
+        " causes integer overflow because it cannot be represented as int, but got ",
+        value);
+  };
+  check_int_range(kernel_size[0], "kernel_size");
+  check_int_range(stride[0], "stride");
+  check_int_range(dilation[0], "dilation");
 
   TORCH_CHECK(
       kernel_size[0] > 0,

--- a/aten/src/ATen/native/MaxPooling.h
+++ b/aten/src/ATen/native/MaxPooling.h
@@ -5,6 +5,8 @@
 #include <ATen/native/DispatchStub.h>
 #include <ATen/native/Pool.h>
 
+#include <limits>
+
 namespace at::native {
 
 inline void check_max_pool1d(
@@ -40,10 +42,19 @@ inline void check_max_pool1d(
     stride = kernel_size;
   }
 
-  safe_downcast<int, int64_t>(kernel_size[0]);
-  safe_downcast<int, int64_t>(stride[0]);
-  safe_downcast<int, int64_t>(padding[0]);
-  safe_downcast<int, int64_t>(dilation[0]);
+  const auto check_int_range = [](int64_t value, const char* name) {
+    TORCH_CHECK(
+        value >= std::numeric_limits<int>::min() &&
+            value <= std::numeric_limits<int>::max(),
+        "max_pool1d() ",
+        name,
+        " causes integer overflow because it cannot be represented as int, but got ",
+        value);
+  };
+  check_int_range(kernel_size[0], "kernel_size");
+  check_int_range(stride[0], "stride");
+  check_int_range(padding[0], "padding");
+  check_int_range(dilation[0], "dilation");
 
   TORCH_CHECK(
       kernel_size[0] > 0,

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -6464,21 +6464,6 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         with self.assertRaises(RuntimeError):
             res = arg_class(*arg_4)
 
-    def test_max_pool1d_int_overflow(self):
-        x = torch.randn(1, 1, 4)
-        too_large = 2**63 - 1
-
-        cases = (
-            {"kernel_size": too_large},
-            {"kernel_size": 1, "stride": too_large},
-            {"kernel_size": 1, "padding": too_large},
-            {"kernel_size": 1, "dilation": too_large},
-        )
-        for kwargs in cases:
-            with self.subTest(kwargs=kwargs):
-                with self.assertRaisesRegex(RuntimeError, "overflow"):
-                    F.max_pool1d(x, **kwargs)
-
     def test_lp_pool_inf_norm_type(self):
         cases = [
             (

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -6464,6 +6464,21 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         with self.assertRaises(RuntimeError):
             res = arg_class(*arg_4)
 
+    def test_max_pool1d_int_overflow(self):
+        x = torch.randn(1, 1, 4)
+        too_large = 2**63 - 1
+
+        cases = (
+            {"kernel_size": too_large},
+            {"kernel_size": 1, "stride": too_large},
+            {"kernel_size": 1, "padding": too_large},
+            {"kernel_size": 1, "dilation": too_large},
+        )
+        for kwargs in cases:
+            with self.subTest(kwargs=kwargs):
+                with self.assertRaisesRegex(RuntimeError, "overflow"):
+                    F.max_pool1d(x, **kwargs)
+
     def test_lp_pool_inf_norm_type(self):
         cases = [
             (

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7768,6 +7768,21 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         with self.assertRaises(RuntimeError):
             res = arg_class(*arg_4)
 
+    def test_max_pool1d_int_overflow(self):
+        x = torch.randn(1, 1, 4)
+        too_large = 2**63 - 1
+
+        cases = (
+            {"kernel_size": too_large},
+            {"kernel_size": 1, "stride": too_large},
+            {"kernel_size": 1, "padding": too_large},
+            {"kernel_size": 1, "dilation": too_large},
+        )
+        for kwargs in cases:
+            with self.subTest(kwargs=kwargs):
+                with self.assertRaisesRegex(RuntimeError, "overflow"):
+                    F.max_pool1d(x, **kwargs)
+
     def test_lp_pool_inf_norm_type(self):
         cases = [
             (

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -3835,6 +3835,7 @@ def error_inputs_max_pool1d(op_info, device, **kwargs):
     # based on whether `requires_grad` is set or not.
     for requires_grad in (True, False):
         make_arg = partial(make_tensor, device=device, dtype=torch.float, requires_grad=requires_grad)
+        too_large = 2**63 - 1
         # error inputs when pad is negative
         x = make_arg((0, 1, 49))
         yield ErrorInput(SampleInput(x, kwargs={'kernel_size': 2, 'stride': 50, 'padding': -1, 'return_indices': True}),
@@ -3908,6 +3909,16 @@ def error_inputs_max_pool1d(op_info, device, **kwargs):
         error_msg = 'kernel_size must be greater than zero'
         yield ErrorInput(SampleInput(x, kwargs={'kernel_size': 0}),
                          error_regex=error_msg)
+
+        # error inputs when parameters overflow the int range used by the 1D kernel
+        yield ErrorInput(SampleInput(x, kwargs={'kernel_size': too_large}),
+                         error_regex='kernel_size causes integer overflow')
+
+        yield ErrorInput(SampleInput(x, kwargs={'kernel_size': 2, 'stride': too_large}),
+                         error_regex='stride causes integer overflow')
+
+        yield ErrorInput(SampleInput(x, kwargs={'kernel_size': 2, 'dilation': too_large}),
+                         error_regex='dilation causes integer overflow')
 
         # error inputs for strides > 0
         error_msg = 'stride must be greater than zero'


### PR DESCRIPTION
Fixes #142454

Summary:
- Adds explicit `TORCH_CHECK` validation for max_pool1d `kernel_size`, `stride`, and `dilation` before output-size math, while preserving the existing padding validation path.
- Reports which checked integer argument cannot be represented as `int`.
- Adds regression coverage through the `nn.functional.max_pool1d` OpInfo error inputs for int64 values that would overflow the native int path.

Test Plan:
- `git diff --check upstream/main...HEAD` - passed
- `python3 -m py_compile torch/testing/_internal/common_methods_invocations.py torch/testing/_internal/common_modules.py test/test_nn.py` - passed
- `python3 test/test_ops.py TestCommonCPU.test_errors_cpu_nn_functional_max_pool1d_cpu_float32` - attempted, blocked locally because this checkout cannot import torch (`ModuleNotFoundError: No module named 'torch'`).
