### PR TITLE
[test stats] Sanitize empty-file pytest rows at the upload boundary

### DIFF
--- a/tools/stats/upload_test_stats.py
+++ b/tools/stats/upload_test_stats.py
@@ -34,6 +34,57 @@ def should_upload_full_test_run(head_branch: str | None, head_repository: str) -
     )
 
 
+# pytest's xunit2 schema (_pytest/junitxml.py) drops the file/line attributes
+# from each <testcase> and emits a dotted, package-path classname such as
+# "test.test_ops.TestForeachCPU". torch/testing/_internal/common_utils.py::
+# sanitize_pytest_xml normally rewrites these in-process right after pytest runs,
+# re-deriving `file` from the classname. But pytest.main() and that sanitize pass
+# are sequential statements in the same subprocess, so if the subprocess is
+# killed in between (shard timeout, OOM, teardown crash) the XML is uploaded
+# unsanitized: empty `file` + dotted classname. Those rows break every downstream
+# consumer that keys on `file`. Re-apply the same transformation here, at the
+# single upload chokepoint that feeds both the streaming (upload_artifacts.py)
+# and post-job backfill paths.
+#
+# Regex matches sanitize_pytest_xml's: an optional "test." package prefix, the
+# module path (dots -> slashes) captured as `file`, and the trailing dotless
+# segment as the bare classname. Unlike that in-process pass (which only ever
+# sees freshly-generated pytest XML), this runs at the upload boundary over
+# archived artifacts, so it additionally declines degenerate matches (empty
+# module or class, e.g. ".Foo" or "test.bar.") rather than writing a nonsensical
+# file.
+_PYTEST_DOTTED_CLASSNAME_RE = re.compile(
+    r"^(test\.)?(?P<file>.*)\.(?P<classname>[^\.]*)$"
+)
+
+
+def sanitize_case_inplace(case: dict[str, Any]) -> None:
+    """Backfill an empty ``file`` from a dotted pytest ``classname``, in place.
+
+    Idempotent and conservative: a case that already carries a non-empty
+    ``file`` (unittest reports, or pytest XML sanitized in-process) is left
+    untouched, as is a classname with no ``.`` (already sanitized, or not a
+    pytest classname). Only the known-broken shape -- empty ``file`` + dotted
+    classname -- is rewritten, so healthy rows are never modified.
+    """
+    if case.get("file"):
+        return
+    classname = case.get("classname")
+    if not isinstance(classname, str):
+        return
+    match = _PYTEST_DOTTED_CLASSNAME_RE.search(classname)
+    if match is None:
+        return
+    file = match.group("file")
+    bare_classname = match.group("classname")
+    if not file or not bare_classname:
+        # Degenerate classname (leading/trailing dot) -- leave it alone rather
+        # than emit a ".py" file or an empty classname.
+        return
+    case["classname"] = bare_classname
+    case["file"] = f"{file.replace('.', '/')}.py"
+
+
 def parse_xml_report(
     tag: str,
     report: Path,
@@ -53,6 +104,7 @@ def parse_xml_report(
     root = ET.parse(report)
     for test_case in root.iter(tag):
         case = process_xml_element(test_case)
+        sanitize_case_inplace(case)
         case["workflow_id"] = workflow_id
         case["workflow_run_attempt"] = workflow_run_attempt
         case["job_id"] = job_id

--- a/tools/test/test_upload_test_stats.py
+++ b/tools/test/test_upload_test_stats.py
@@ -7,6 +7,8 @@ from unittest import mock
 from tools.stats.upload_test_stats import (
     backfill_test_jsons_while_running,
     get_tests,
+    parse_xml_report,
+    sanitize_case_inplace,
     summarize_test_cases,
 )
 
@@ -15,6 +17,16 @@ IN_CI = os.environ.get("CI")
 
 _MINIMAL_JUNIT_XML = (
     '<testsuite><testcase classname="C" name="t" time="0"/></testsuite>'
+)
+
+# A raw pytest xunit2 testcase: dotted package-path classname and no `file`
+# attribute. This is the shape that leaks to ClickHouse with file='' when the
+# in-process sanitize pass (common_utils.sanitize_pytest_xml) is skipped because
+# the test subprocess was killed (shard timeout, OOM, teardown crash).
+_UNSANITIZED_PYTEST_XML = (
+    "<testsuite>"
+    '<testcase classname="test.test_ops.TestCommonCPU" name="test_foo_cpu" time="1.5"/>'
+    "</testsuite>"
 )
 
 
@@ -80,6 +92,91 @@ class TestUploadTestStats(unittest.TestCase):
             self.assertEqual(len(uploaded_keys), 1)
             self.assertIn("foo-1", uploaded_keys[0])
             self.assertFalse(any("bar-1" in key for key in uploaded_keys))
+
+
+class TestSanitizeCaseInplace(unittest.TestCase):
+    def test_backfills_file_from_dotted_classname(self) -> None:
+        case = {"classname": "test.test_ops.TestCommonCPU", "name": "test_foo"}
+        sanitize_case_inplace(case)
+        self.assertEqual(case["file"], "test_ops.py")
+        self.assertEqual(case["classname"], "TestCommonCPU")
+
+    def test_nested_module_path_becomes_directory(self) -> None:
+        case = {"classname": "test.inductor.test_torchinductor.TestInductorCPU"}
+        sanitize_case_inplace(case)
+        self.assertEqual(case["file"], "inductor/test_torchinductor.py")
+        self.assertEqual(case["classname"], "TestInductorCPU")
+
+    def test_no_test_prefix(self) -> None:
+        # classname without the leading "test." package prefix still resolves.
+        case = {"classname": "test_ops.TestCommonCPU"}
+        sanitize_case_inplace(case)
+        self.assertEqual(case["file"], "test_ops.py")
+        self.assertEqual(case["classname"], "TestCommonCPU")
+
+    def test_idempotent(self) -> None:
+        case = {"classname": "test.test_ops.TestCommonCPU"}
+        sanitize_case_inplace(case)
+        first = dict(case)
+        sanitize_case_inplace(case)  # second pass must be a no-op
+        self.assertEqual(case, first)
+
+    def test_leaves_already_sanitized_case_untouched(self) -> None:
+        case = {"classname": "TestCommonCPU", "file": "test_ops.py"}
+        before = dict(case)
+        sanitize_case_inplace(case)
+        self.assertEqual(case, before)
+
+    def test_never_overwrites_a_populated_file(self) -> None:
+        # Defensive: even with a dotted classname, an existing file wins.
+        case = {"classname": "test.weird.Thing", "file": "real_file.py"}
+        before = dict(case)
+        sanitize_case_inplace(case)
+        self.assertEqual(case, before)
+
+    def test_dotless_classname_without_file_is_left_alone(self) -> None:
+        # No dot -> nothing to derive -> leave the row as-is rather than guess.
+        case = {"classname": "TestCommonCPU"}
+        sanitize_case_inplace(case)
+        self.assertNotIn("file", case)
+        self.assertEqual(case["classname"], "TestCommonCPU")
+
+    def test_degenerate_dotted_classname_left_alone(self) -> None:
+        # Leading/trailing-dot classnames are malformed; don't emit a
+        # nonsensical ".py" file or an empty classname -- leave them untouched.
+        for bad in (".TestFoo", "test.test_ops."):
+            case = {"classname": bad}
+            sanitize_case_inplace(case)
+            self.assertNotIn("file", case)
+            self.assertEqual(case["classname"], bad)
+
+    def test_non_string_classname_ignored(self) -> None:
+        case = {"classname": 123}
+        sanitize_case_inplace(case)
+        self.assertNotIn("file", case)
+
+    def test_missing_classname_ignored(self) -> None:
+        case: dict = {"name": "t"}
+        sanitize_case_inplace(case)
+        self.assertNotIn("file", case)
+
+
+class TestParseXmlReportSanitizes(unittest.TestCase):
+    def test_parse_xml_report_backfills_empty_file(self) -> None:
+        """End-to-end: an unsanitized pytest XML parses into a case with `file`
+        backfilled and the classname stripped to its bare form.
+        """
+        with tempfile.TemporaryDirectory() as raw:
+            report = Path(raw) / "test_ops" / "python-pytest_test_ops.xml"
+            report.parent.mkdir(parents=True)
+            report.write_text(_UNSANITIZED_PYTEST_XML)
+
+            cases = parse_xml_report("testcase", report, 99, 1, job_id=7)
+
+            self.assertEqual(len(cases), 1)
+            self.assertEqual(cases[0]["file"], "test_ops.py")
+            self.assertEqual(cases[0]["classname"], "TestCommonCPU")
+            self.assertEqual(cases[0]["job_id"], 7)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Test-stat rows for pytest test cases sometimes reach ClickHouse (`tests.all_test_runs`) with an empty `file` and a dotted, package-path `classname` (e.g. `classname="test.test_ops.TestCommonCPU"`, `file=""`). This re-applies the `file`-derivation that `sanitize_pytest_xml` already does in-process, but at the single upload chokepoint (`parse_xml_report`), so the bad shape can never leak to S3/ClickHouse.

## Root cause

- pytest's `xunit2` schema (`_pytest/junitxml.py`) drops the `file`/`line` attributes from each `<testcase>` and emits a dotted package-path `classname`.
- `torch/testing/_internal/common_utils.py::sanitize_pytest_xml` is the post-run pass that re-derives `file` from that classname. But `pytest.main()` and `sanitize_pytest_xml()` are sequential statements in the **same subprocess** — if that subprocess is killed between them (shard timeout, OOM, teardown crash), the XML is uploaded unsanitized.
- Both upload paths — the streaming `tools/testing/upload_artifacts.py` and the post-job `backfill_test_jsons_while_running` — route through `parse_xml_report`, so sanitizing there is a single chokepoint that covers both.

The affected cohort is exactly the long-running parametrized op-test files (`test_ops`, `test_unary_ufuncs`, `test_meta`, …) whose pytest sessions run near the full shard timeout.

## Why it matters

Downstream consumers key on `file`. The `pytorch-auto-revert` lambda builds `test_key = f"{file}::{name}" if file else name`; an empty `file` collapses the key to a bare method name, which then gets dispatched as an invalid `tests-to-include` target and reds trunk. (The lambda-side fail-safe shipped separately in pytorch/test-infra#8037; this PR is the source-side cleanup that stops new bad rows at the origin.)

## The fix

`sanitize_case_inplace(case)` runs the **same regex** as `sanitize_pytest_xml` on the parsed case dict. It is idempotent and conservative:
- skips any case that already has a non-empty `file` (unittest reports, or pytest XML sanitized in-process) — healthy rows are never touched;
- a classname with no `.` (already sanitized) doesn't match the regex and is left alone;
- declines degenerate classnames (leading/trailing dot, e.g. `.Foo` or `test.bar.`) rather than emit a nonsensical `.py` file or an empty classname — this runs at the upload boundary over archived artifacts, a wider input surface than the in-process pass;
- only the known-broken shape (empty `file` + dotted classname) is rewritten.

The early-out (`if case.get("file"): return`) short-circuits the healthy majority before the regex, so the only added per-case cost on the hot path is one dict lookup.

## Test plan

`python tools/test/test_upload_test_stats.py` — added `TestSanitizeCaseInplace` (10 cases: backfill, nested module path → directory, no-`test.`-prefix, idempotence, already-sanitized untouched, never-overwrite-populated-file, dotless-classname left alone, degenerate leading/trailing-dot classname left alone, non-string classname, missing classname) and `TestParseXmlReportSanitizes` (end-to-end through `parse_xml_report`). All 11 pass.