### PR TITLE
[sparse] Add size validation in _convert_indices_from_coo_to_csr

### DIFF
--- a/aten/src/ATen/native/sparse/SparseCsrTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseCsrTensorMath.cpp
@@ -141,6 +141,7 @@ TORCH_META_FUNC(_convert_indices_from_coo_to_csr)
 (const Tensor& self, const int64_t size, const bool out_int32) {
   TORCH_CHECK(self.dim() <= 1, "Input is supposed to be a vector, but got ",
               self.dim(), " dimensional tensor.");
+  TORCH_CHECK(size >= 0, "size must be non-negative, got ", size);
   ScalarType scalar_type = out_int32 ? ScalarType::Int : ScalarType::Long;
   c10::TensorOptions options =
       TensorOptions().device(self.options().device()).dtype(scalar_type);

--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -1406,6 +1406,11 @@ class TestSparseCSR(TestCase):
                 torch.randint(100, (5, 5), device=device),
                 size=100)
 
+        with self.assertRaisesRegex(RuntimeError, "size must be non-negative"):
+            torch._convert_indices_from_coo_to_csr(
+                torch.tensor([1, 2, 3], device=device),
+                size=-1)
+
         size = (5, 5)
         sparse_dim = 2
         nnz = 10


### PR DESCRIPTION
## Summary

Fixes #182064 - Adds input validation for negative `size` parameter in `_convert_indices_from_coo_to_csr` to prevent illegal memory writes.

## Problem

When `_convert_indices_from_coo_to_csr` is called with `size=-1`, it allocates a zero-element output tensor (`size + 1 = 0`) and then writes beyond its bounds, causing:
- **CUDA**: Illegal global write at address 0x0
- **CPU**: Heap overflow

This manifests as a hard crash on both backends.

## Solution

Added `TORCH_CHECK(size >= 0, ...)` in the meta function, placed next to the existing dimension validation. This is an O(1) host-side check that:
- Costs nothing measurable (single comparison before kernel launch)
- Converts undefined behavior into a clean `RuntimeError`
- Follows PyTorch's design philosophy for internal ops (as confirmed by @pearu)

## Scope

**What this fixes**: Converts `size < 0` UB → clean `RuntimeError`  
**What this doesn't fix**: Does NOT validate `max(self) <= size` (would require expensive device sync)  
**Impact**: Op remains "trust the caller" for index-vs-size relationship

All internal callers already pass valid values (e.g., `self.size(0)`), so this only affects direct calls with invalid inputs (e.g., fuzzing).

## Test Plan

- Added test case in `test_sparse_csr.py` for `size < 0`
- Verified original crash case now raises `RuntimeError: size must be non-negative, got -1`
- Verified existing dimension validation still works
- Ran tests with valid inputs to confirm no regression

```python
# Original crash case (from issue #182064)
tensor_0 = torch.full((1,), 2147480000, dtype=torch.int64, device='cuda')
torch.ops.aten._convert_indices_from_coo_to_csr(tensor_0, -1, out_int32=False)
# Before: Illegal memory write at 0x0 (hard crash)
# After:  RuntimeError: size must be non-negative, got -1
```
