### PR TITLE
Remove deprecated torch.utils.mobile_optimizer from API index

### DIFF
--- a/docs/source/mobile_optimizer.md
+++ b/docs/source/mobile_optimizer.md
@@ -1,4 +1,5 @@
 ---
+orphan: true
 robots: noindex
 ---
 # torch.utils.mobile_optimizer

--- a/docs/source/pytorch-api.md
+++ b/docs/source/pytorch-api.md
@@ -83,7 +83,6 @@ torch.utils.data <data>
 torch.utils.deterministic <deterministic>
 torch.utils.jit <jit_utils>
 torch.utils.dlpack <dlpack>
-torch.utils.mobile_optimizer <mobile_optimizer>
 torch.utils.model_zoo <model_zoo>
 torch.utils.tensorboard <tensorboard>
 torch.utils.module_tracker <module_tracker>


### PR DESCRIPTION
Fixes #188398.

This PR removes the deprecated `torch.utils.mobile_optimizer` entry from the 2.7 Python API index to resolve inconsistent navigation behavior.

Removes `torch.utils.mobile_optimizer` from the API index list in pytorch-api.md
Aligns API index with the intentional deprecation and ExecuTorch migration introduced in PR #153664
Prevents misleading navigation where users are directed to ExecuTorch instead of an API documentation page

These changes improve consistency in the API documentation and remove a confusing or broken entry point.