### PR TITLE
Add all_gather_single and reduce_scatter_single to PyProcessGroup

### DIFF
--- a/test/distributed/test_c10d_common.py
+++ b/test/distributed/test_c10d_common.py
@@ -1768,6 +1768,9 @@ class DummyProcessGroup(dist.ProcessGroup):
         self.group_size = args[1]
         self._aborted = False
         self._shutdown = False
+        # Records the name of every collective dispatched into this PG, so a
+        # test can assert a given collective routed through the trampoline.
+        self.collectives_called = set()
 
     def rank(self):
         return self.global_rank
@@ -1806,6 +1809,7 @@ class DummyProcessGroup(dist.ProcessGroup):
         return "Dummy"
 
     def allgather(self, output_tensor_lists, input_tensor_list, opts=None):
+        self.collectives_called.add("allgather")
         for output_tensor_list, input_tensor in zip(
             output_tensor_lists, input_tensor_list
         ):
@@ -1815,6 +1819,7 @@ class DummyProcessGroup(dist.ProcessGroup):
         return DummyWork()
 
     def allreduce(self, tensor_list, opts=None):
+        self.collectives_called.add("allreduce")
         for tensor in tensor_list:
             tensor.add_(2)
 
@@ -1840,16 +1845,31 @@ class DummyProcessGroup(dist.ProcessGroup):
         return DummyWork()
 
     def broadcast(self, tensor_list, opts=None):
+        self.collectives_called.add("broadcast")
         for tensor in tensor_list:
             tensor.add_(1)
 
         return DummyWork()
 
     def reduce_scatter(self, output_tensor_list, input_tensor_lists, opts=None):
+        self.collectives_called.add("reduce_scatter")
         for output_tensor, input_tensor_list in zip(
             output_tensor_list, input_tensor_lists
         ):
             output_tensor.copy_(input_tensor_list[self.rank()])
+
+        return DummyWork()
+
+    def all_gather_single(self, output_tensor, input_tensor, opts=None):
+        self.collectives_called.add("all_gather_single")
+        for chunk in output_tensor.chunk(self.size()):
+            chunk.copy_(input_tensor)
+
+        return DummyWork()
+
+    def reduce_scatter_single(self, output_tensor, input_tensor, opts=None):
+        self.collectives_called.add("reduce_scatter_single")
+        output_tensor.copy_(input_tensor.chunk(self.size())[self.rank()])
 
         return DummyWork()
 

--- a/test/distributed/test_c10d_pypg.py
+++ b/test/distributed/test_c10d_pypg.py
@@ -15,6 +15,8 @@ from torch._C._distributed_c10d import _create_work_from_future
 from torch.distributed.distributed_c10d import (
     _coalescing_manager,
     _get_default_group,
+    _register_process_group,
+    _unregister_process_group,
     ReconfigureOptions,
 )
 from torch.futures import Future
@@ -320,6 +322,37 @@ class TestPyProcessGroup(TestCase):
         self.assertEqual(pg.name(), "store-pg")
         self.assertEqual(pg.rank(), 0)
         self.assertEqual(pg.size(), 1)
+
+    def test_all_gather_single(self):
+        # all_gather_into_tensor_out calls group->all_gather_single(...) in C++,
+        # which dispatches through the PyProcessGroup trampoline into the Python
+        # DummyProcessGroup.all_gather_single override (it copies the input into
+        # each chunk). Without the override the base impl needs a backend and
+        # raises, so a correct output proves the override the PR adds was hit.
+        pg = test_c10d_common.DummyProcessGroup(0, 1)
+        _register_process_group("test_all_gather_single", pg)
+        try:
+            input = torch.ones(2)
+            output = torch.empty(2)
+            torch.ops._c10d_functional.all_gather_into_tensor_out(
+                input, 1, "test_all_gather_single", out=output
+            )
+            torch.ops._c10d_functional.wait_tensor(output)
+            self.assertIn("all_gather_single", pg.collectives_called)
+            self.assertEqual(output, torch.ones(2))
+        finally:
+            _unregister_process_group("test_all_gather_single")
+
+    def test_reduce_scatter_single(self):
+        # No functional collective dispatches to reduce_scatter_single (they use
+        # the coalesced variant), so this is a direct sanity check that the
+        # override runs and forwards its buffers.
+        pg = test_c10d_common.DummyProcessGroup(0, 1)
+        input = torch.ones(2)
+        output = torch.zeros(2)
+        pg.reduce_scatter_single(output, input).wait()
+        self.assertIn("reduce_scatter_single", pg.collectives_called)
+        self.assertEqual(output, torch.ones(2))
 
     def test_coalescing_manager(self):
         # The coalescing manager calls _start_coalescing / _end_coalescing, which

--- a/torch/csrc/distributed/c10d/PyProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/PyProcessGroup.hpp
@@ -50,7 +50,7 @@ class PyProcessGroup : public ProcessGroup {
         pybind11::get_override(static_cast<const cname*>(this), #name); \
     if (override) {                                                     \
       auto o = override(__VA_ARGS__);                                   \
-      return c10::make_intrusive<PyWorkHolder>(o);                      \
+      return c10::make_intrusive<PyWorkHolder>(std::move(o));           \
     }                                                                   \
     return cname::name(__VA_ARGS__);                                    \
   } while (false)
@@ -195,6 +195,18 @@ class PyProcessGroup : public ProcessGroup {
         opts);
   }
 
+  c10::intrusive_ptr<Work> all_gather_single(
+      at::Tensor& outputBuffer,
+      at::Tensor& inputBuffer,
+      const AllgatherOptions& opts = AllgatherOptions()) override {
+    WORK_OVERRIDE(
+        ProcessGroup, /* Parent class */
+        all_gather_single, /* Name of function in C++ */
+        outputBuffer,
+        inputBuffer,
+        opts);
+  }
+
   c10::intrusive_ptr<Work> all_gather_single_coalesced(
       std::vector<at::Tensor>& outputTensors,
       std::vector<at::Tensor>& inputTensors,
@@ -291,6 +303,18 @@ class PyProcessGroup : public ProcessGroup {
         reduce_scatter, /* Name of function in C++ */
         outputTensors,
         inputTensors,
+        opts);
+  }
+
+  c10::intrusive_ptr<Work> reduce_scatter_single(
+      at::Tensor& outputBuffer,
+      at::Tensor& inputBuffer,
+      const ReduceScatterOptions& opts = ReduceScatterOptions()) override {
+    WORK_OVERRIDE(
+        ProcessGroup, /* Parent class */
+        reduce_scatter_single, /* Name of function in C++ */
+        outputBuffer,
+        inputBuffer,
         opts);
   }
 


### PR DESCRIPTION
As raised in https://github.com/pytorch/pytorch/issues/188542, PyProcessGroup is missing a few collectives -- adding implementations for `all_gather_single` and `reduce_scatter_single`.

## Test plan

```
pytest test/distributed/test_c10d_pypg.py -v -k single
```