### PR TITLE
[release/2.13] Bump binary build timeout 280 -> 400 minutes

### DIFF
--- a/.github/templates/common.yml.j2
+++ b/.github/templates/common.yml.j2
@@ -3,7 +3,7 @@
 {%- set upload_artifact_action = "actions/upload-artifact@v4.4.0" -%}
 {%- set download_artifact_action = "actions/download-artifact@v4.1.7" -%}
 
-{%- set timeout_minutes = 280 -%}
+{%- set timeout_minutes = 400 -%}
 {%- set timeout_minutes_windows_binary = 360 -%}
 
 {%- macro concurrency(build_environment) -%}

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -53,7 +53,7 @@ jobs:
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: get-label-type
     runs-on: "${{ needs.get-label-type.outputs.label-type }}linux.12xlarge.memory.ephemeral"
-    timeout-minutes: 280
+    timeout-minutes: 400
     container:
       image: pytorch/manylinux2_28-builder:cpu-78e737ad29420ffc4800e677c51e2a852caf8359
     env:
@@ -141,7 +141,7 @@ jobs:
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: get-label-type
     runs-on: "${{ needs.get-label-type.outputs.label-type }}linux.12xlarge.memory.ephemeral"
-    timeout-minutes: 280
+    timeout-minutes: 400
     container:
       image: pytorch/manylinux2_28-builder:cuda12.6-78e737ad29420ffc4800e677c51e2a852caf8359
     env:
@@ -230,7 +230,7 @@ jobs:
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: get-label-type
     runs-on: "${{ needs.get-label-type.outputs.label-type }}linux.12xlarge.memory.ephemeral"
-    timeout-minutes: 280
+    timeout-minutes: 400
     container:
       image: pytorch/manylinux2_28-builder:cuda12.9-78e737ad29420ffc4800e677c51e2a852caf8359
     env:
@@ -319,7 +319,7 @@ jobs:
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: get-label-type
     runs-on: "${{ needs.get-label-type.outputs.label-type }}linux.12xlarge.memory.ephemeral"
-    timeout-minutes: 280
+    timeout-minutes: 400
     container:
       image: pytorch/manylinux2_28-builder:cuda13.0-78e737ad29420ffc4800e677c51e2a852caf8359
     env:
@@ -408,7 +408,7 @@ jobs:
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: get-label-type
     runs-on: "${{ needs.get-label-type.outputs.label-type }}linux.12xlarge.memory.ephemeral"
-    timeout-minutes: 280
+    timeout-minutes: 400
     container:
       image: pytorch/manylinux2_28-builder:cuda13.2-78e737ad29420ffc4800e677c51e2a852caf8359
     env:
@@ -526,7 +526,7 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "xpu-78e737ad29420ffc4800e677c51e2a852caf8359"
             build_name: "manywheel-py3_10-xpu"
-            timeout_minutes: 280
+            timeout_minutes: 400
             pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2026.0.0 | intel-cmplr-lib-ur==2026.0.0 | intel-cmplr-lic-rt==2026.0.0 | intel-sycl-rt==2026.0.0 | oneccl-devel==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.18.0; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2026.0.0 | onemkl-sycl-blas==2026.0.0 | onemkl-sycl-dft==2026.0.0 | onemkl-sycl-lapack==2026.0.0 | onemkl-sycl-rng==2026.0.0 | onemkl-sycl-sparse==2026.0.0 | dpcpp-cpp-rt==2026.0.0 | intel-opencl-rt==2026.0.0 | mkl==2026.0.0 | intel-openmp==2026.0.0 | tbb==2023.0.0 | tcmlib==1.5.0 | umf==1.1.0 | intel-pti==0.17.0 | pyzes==0.1.1; platform_system == 'Linux' and platform_machine == 'x86_64'"
           - desired_python: "3.11"
             desired_cuda: "rocm7.1"
@@ -553,7 +553,7 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "xpu-78e737ad29420ffc4800e677c51e2a852caf8359"
             build_name: "manywheel-py3_11-xpu"
-            timeout_minutes: 280
+            timeout_minutes: 400
             pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2026.0.0 | intel-cmplr-lib-ur==2026.0.0 | intel-cmplr-lic-rt==2026.0.0 | intel-sycl-rt==2026.0.0 | oneccl-devel==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.18.0; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2026.0.0 | onemkl-sycl-blas==2026.0.0 | onemkl-sycl-dft==2026.0.0 | onemkl-sycl-lapack==2026.0.0 | onemkl-sycl-rng==2026.0.0 | onemkl-sycl-sparse==2026.0.0 | dpcpp-cpp-rt==2026.0.0 | intel-opencl-rt==2026.0.0 | mkl==2026.0.0 | intel-openmp==2026.0.0 | tbb==2023.0.0 | tcmlib==1.5.0 | umf==1.1.0 | intel-pti==0.17.0 | pyzes==0.1.1; platform_system == 'Linux' and platform_machine == 'x86_64'"
           - desired_python: "3.12"
             desired_cuda: "rocm7.1"
@@ -580,7 +580,7 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "xpu-78e737ad29420ffc4800e677c51e2a852caf8359"
             build_name: "manywheel-py3_12-xpu"
-            timeout_minutes: 280
+            timeout_minutes: 400
             pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2026.0.0 | intel-cmplr-lib-ur==2026.0.0 | intel-cmplr-lic-rt==2026.0.0 | intel-sycl-rt==2026.0.0 | oneccl-devel==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.18.0; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2026.0.0 | onemkl-sycl-blas==2026.0.0 | onemkl-sycl-dft==2026.0.0 | onemkl-sycl-lapack==2026.0.0 | onemkl-sycl-rng==2026.0.0 | onemkl-sycl-sparse==2026.0.0 | dpcpp-cpp-rt==2026.0.0 | intel-opencl-rt==2026.0.0 | mkl==2026.0.0 | intel-openmp==2026.0.0 | tbb==2023.0.0 | tcmlib==1.5.0 | umf==1.1.0 | intel-pti==0.17.0 | pyzes==0.1.1; platform_system == 'Linux' and platform_machine == 'x86_64'"
           - desired_python: "3.13"
             desired_cuda: "rocm7.1"
@@ -607,7 +607,7 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "xpu-78e737ad29420ffc4800e677c51e2a852caf8359"
             build_name: "manywheel-py3_13-xpu"
-            timeout_minutes: 280
+            timeout_minutes: 400
             pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2026.0.0 | intel-cmplr-lib-ur==2026.0.0 | intel-cmplr-lic-rt==2026.0.0 | intel-sycl-rt==2026.0.0 | oneccl-devel==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.18.0; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2026.0.0 | onemkl-sycl-blas==2026.0.0 | onemkl-sycl-dft==2026.0.0 | onemkl-sycl-lapack==2026.0.0 | onemkl-sycl-rng==2026.0.0 | onemkl-sycl-sparse==2026.0.0 | dpcpp-cpp-rt==2026.0.0 | intel-opencl-rt==2026.0.0 | mkl==2026.0.0 | intel-openmp==2026.0.0 | tbb==2023.0.0 | tcmlib==1.5.0 | umf==1.1.0 | intel-pti==0.17.0 | pyzes==0.1.1; platform_system == 'Linux' and platform_machine == 'x86_64'"
           - desired_python: "3.14"
             desired_cuda: "rocm7.1"
@@ -634,7 +634,7 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "xpu-78e737ad29420ffc4800e677c51e2a852caf8359"
             build_name: "manywheel-py3_14-xpu"
-            timeout_minutes: 280
+            timeout_minutes: 400
             pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2026.0.0 | intel-cmplr-lib-ur==2026.0.0 | intel-cmplr-lic-rt==2026.0.0 | intel-sycl-rt==2026.0.0 | oneccl-devel==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.18.0; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2026.0.0 | onemkl-sycl-blas==2026.0.0 | onemkl-sycl-dft==2026.0.0 | onemkl-sycl-lapack==2026.0.0 | onemkl-sycl-rng==2026.0.0 | onemkl-sycl-sparse==2026.0.0 | dpcpp-cpp-rt==2026.0.0 | intel-opencl-rt==2026.0.0 | mkl==2026.0.0 | intel-openmp==2026.0.0 | tbb==2023.0.0 | tcmlib==1.5.0 | umf==1.1.0 | intel-pti==0.17.0 | pyzes==0.1.1; platform_system == 'Linux' and platform_machine == 'x86_64'"
           - desired_python: "3.14t"
             desired_cuda: "rocm7.1"
@@ -661,7 +661,7 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "xpu-78e737ad29420ffc4800e677c51e2a852caf8359"
             build_name: "manywheel-py3_14t-xpu"
-            timeout_minutes: 280
+            timeout_minutes: 400
             pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2026.0.0 | intel-cmplr-lib-ur==2026.0.0 | intel-cmplr-lic-rt==2026.0.0 | intel-sycl-rt==2026.0.0 | oneccl-devel==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.18.0; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2026.0.0 | onemkl-sycl-blas==2026.0.0 | onemkl-sycl-dft==2026.0.0 | onemkl-sycl-lapack==2026.0.0 | onemkl-sycl-rng==2026.0.0 | onemkl-sycl-sparse==2026.0.0 | dpcpp-cpp-rt==2026.0.0 | intel-opencl-rt==2026.0.0 | mkl==2026.0.0 | intel-openmp==2026.0.0 | tbb==2023.0.0 | tcmlib==1.5.0 | umf==1.1.0 | intel-pti==0.17.0 | pyzes==0.1.1; platform_system == 'Linux' and platform_machine == 'x86_64'"
           - desired_python: "3.15"
             desired_cuda: "rocm7.1"
@@ -688,7 +688,7 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "xpu-78e737ad29420ffc4800e677c51e2a852caf8359"
             build_name: "manywheel-py3_15-xpu"
-            timeout_minutes: 280
+            timeout_minutes: 400
             pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2026.0.0 | intel-cmplr-lib-ur==2026.0.0 | intel-cmplr-lic-rt==2026.0.0 | intel-sycl-rt==2026.0.0 | oneccl-devel==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.18.0; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2026.0.0 | onemkl-sycl-blas==2026.0.0 | onemkl-sycl-dft==2026.0.0 | onemkl-sycl-lapack==2026.0.0 | onemkl-sycl-rng==2026.0.0 | onemkl-sycl-sparse==2026.0.0 | dpcpp-cpp-rt==2026.0.0 | intel-opencl-rt==2026.0.0 | mkl==2026.0.0 | intel-openmp==2026.0.0 | tbb==2023.0.0 | tcmlib==1.5.0 | umf==1.1.0 | intel-pti==0.17.0 | pyzes==0.1.1; platform_system == 'Linux' and platform_machine == 'x86_64'"
           - desired_python: "3.15t"
             desired_cuda: "rocm7.1"
@@ -715,7 +715,7 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "xpu-78e737ad29420ffc4800e677c51e2a852caf8359"
             build_name: "manywheel-py3_15t-xpu"
-            timeout_minutes: 280
+            timeout_minutes: 400
             pytorch_extra_install_requirements: "intel-cmplr-lib-rt==2026.0.0 | intel-cmplr-lib-ur==2026.0.0 | intel-cmplr-lic-rt==2026.0.0 | intel-sycl-rt==2026.0.0 | oneccl-devel==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | oneccl==2022.0.0; platform_system == 'Linux' and platform_machine == 'x86_64' | impi-rt==2021.18.0; platform_system == 'Linux' and platform_machine == 'x86_64' | onemkl-license==2026.0.0 | onemkl-sycl-blas==2026.0.0 | onemkl-sycl-dft==2026.0.0 | onemkl-sycl-lapack==2026.0.0 | onemkl-sycl-rng==2026.0.0 | onemkl-sycl-sparse==2026.0.0 | dpcpp-cpp-rt==2026.0.0 | intel-opencl-rt==2026.0.0 | mkl==2026.0.0 | intel-openmp==2026.0.0 | tbb==2023.0.0 | tcmlib==1.5.0 | umf==1.1.0 | intel-pti==0.17.0 | pyzes==0.1.1; platform_system == 'Linux' and platform_machine == 'x86_64'"
     with:
       PYTORCH_ROOT: /pytorch

--- a/.github/workflows/generated-macos-arm64-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-macos-arm64-binary-wheel-nightly.yml
@@ -39,7 +39,7 @@ jobs:
   wheel-build:
     if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: macos-26-xlarge
-    timeout-minutes: 280
+    timeout-minutes: 400
     env:
       PYTORCH_ROOT: ${{ github.workspace }}
       PACKAGE_TYPE: wheel


### PR DESCRIPTION
## Summary

The `manywheel-cuda-cu129-build` job on the v2.13.0 RCs is being cancelled by the **280-minute** job timeout (e.g. https://github.com/pytorch/pytorch/actions/runs/28392838558/job/84124039474). It is **not hung and not a build error** — the build progresses steadily and was at `[707/712] Install the project` on the final wheel when killed, i.e. essentially complete after ~285 minutes.

## Root cause

The first wheel does a full from-scratch CUDA compile of the whole arch list (`7.5;8.0;8.6;9.0;10.0;12.0+PTX`), which now includes the Blackwell `sm_100`/`sm_120` arches added for 12.9 (#188443). That first build takes ~3h (the flash_attention CUDA TUs dominate); the remaining ~5 Python wheels reuse the objects at ~18 min each, totaling just over the 280-minute cap. Release binary builds don't use sccache, so the first build is always from scratch.

## Fix

Rather than trim the arch list (Blackwell support is intended for 12.9), give the builds 2 more hours of headroom: raise the shared `common.timeout_minutes` from **280 → 400**.

Scope of the regenerated diff (only `timeout-minutes` values change):
- Linux manywheel builds: cpu / cu126 / **cu129** / cu130 / cu132
- macOS-arm64 wheel build (shares the same value)

This only raises a ceiling — it has no effect on builds that finish sooner. Windows binary builds use a separate value (`timeout_minutes_windows_binary=360`) and are unchanged. libtorch builds use their own 420-minute override and are unchanged.

## Test plan

```
python3 .github/scripts/generate_ci_workflows.py
git diff .github/workflows/   # only "timeout-minutes: 280" -> "400"
```

Failing job: https://github.com/pytorch/pytorch/actions/runs/28392838558/job/84124039474

Authored with assistance from Claude.