### PR TITLE
[ROCm] [Inductor] Unskipped two codegen tests for ROCm

### DIFF
--- a/test/inductor/test_gpu_cpp_wrapper.py
+++ b/test/inductor/test_gpu_cpp_wrapper.py
@@ -281,10 +281,8 @@ class TestGpuWrapper(InductorTestCase):
                 'aoti_torch_call_dispatcher("mylib_symint::add_symint"', code
             )
 
+    @skipIfXpu(msg="tests CUDA/ROCm CUDADeviceOpOverrides codegen")
     def test_cpp_scratch_scales_with_grid_size_for_tma(self):
-        if GPU_TYPE != "cuda" or torch.version.hip:
-            self.skipTest("CUDA-only codegen test")
-
         scratch_def, scratch_var = CUDADeviceOpOverrides().cpp_scratch(
             0,
             TritonScratchWorkspace(
@@ -297,10 +295,8 @@ class TestGpuWrapper(InductorTestCase):
             "static_cast<int64_t>(256) * grid_0 * grid_1 * grid_2", scratch_def[0]
         )
 
+    @skipIfXpu(msg="tests CUDA/ROCm CUDADeviceOpOverrides codegen")
     def test_triton_wrapper_scales_scratch_with_num_ctas(self):
-        if GPU_TYPE != "cuda" or torch.version.hip:
-            self.skipTest("CUDA-only codegen test")
-
         class FakeWrapper:
             device = "cuda"
 


### PR DESCRIPTION
### Unskip GPU CPP wrapper codegen tests on ROCm

Redesign the skip on `test_cpp_scratch_scales_with_grid_size_for_tma` and `test_triton_wrapper_scales_scratch_with_num_ctas`: replace the `GPU_TYPE != "cuda" or torch.version.hip` guard with `@skipIfXpu`. These are pure codegen string tests over `CUDADeviceOpOverrides`, which is also the backend ROCm registers under `"cuda"`, so they run and pass on ROCm. XPU has its own `cpp_scratch` implementation, so it stays skipped.

FIXES #176822

Also re-enabling the profiler test from #176822: it was disabled as a flaky/consistent ROCm CI failure back in March, but no longer reproduces (16/16 passes locally on MI300X), so the disable is probably stale. Let's look at CI results.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben