### PR TITLE
Preserve pipeline buffers during dynamic metadata inference

### DIFF
--- a/test/distributed/pipelining/test_stage.py
+++ b/test/distributed/pipelining/test_stage.py
@@ -1,6 +1,9 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 # Owner(s): ["oncall: distributed"]
 
+import os
+import tempfile
+
 from model_registry import ExampleCode, ModelWithKwargs, MultiMLP
 
 import torch
@@ -11,7 +14,7 @@ from torch.distributed.pipelining import (
     PipelineStage,
     ScheduleGPipe,
 )
-from torch.distributed.pipelining._utils import PipeliningMetadataError
+from torch.distributed.pipelining._utils import InferenceMode, PipeliningMetadataError
 from torch.testing._internal.common_distributed import (
     MultiProcContinuousTest,
     requires_accelerator_dist_backend,
@@ -22,6 +25,7 @@ from torch.testing._internal.common_utils import (
     run_tests,
     skip_but_pass_in_sandcastle_if,
     TEST_MULTIACCELERATOR,
+    TestCase,
 )
 from torch.utils._pytree import tree_map_only
 
@@ -34,6 +38,63 @@ device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else 
 backend = dist.get_default_backend_for_device(device_type)
 
 torch.manual_seed(0)
+
+
+class PipelineStageMetadataInferenceTest(TestCase):
+    def test_dynamic_metadata_inference_restores_module_buffers(self):
+        class BufferMutatingModule(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear = torch.nn.Linear(4, 4)
+                self.register_buffer("counter", torch.zeros(4))
+
+            def forward(self, x):
+                with torch.no_grad():
+                    self.counter.add_(1)
+                out = self.linear(x)
+                if out.requires_grad:
+                    out.register_hook(self._backward_hook)
+                return out
+
+            def _backward_hook(self, grad):
+                with torch.no_grad():
+                    self.counter.add_(10)
+                return grad
+
+        device = torch.device("cpu")
+        init_pg = not dist.is_initialized()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            if init_pg:
+                dist.init_process_group(
+                    "gloo",
+                    init_method=f"file://{os.path.join(tmpdir, 'pg')}",
+                    rank=0,
+                    world_size=1,
+                )
+            try:
+                mod = BufferMutatingModule().to(device)
+                stage = PipelineStage(
+                    mod,
+                    stage_index=0,
+                    num_stages=1,
+                    device=device,
+                )
+                stage._inference_mode = InferenceMode.DYNAMIC
+
+                initial_counter = mod.counter.clone()
+                x = torch.randn(2, 4, device=device, requires_grad=True)
+                stage._prepare_forward_infra(1, (x,), {}, has_backward=True)
+                self.assertEqual(mod.counter, initial_counter)
+
+                def loss_fn(out, target):
+                    return out.sum() + target.sum() * 0
+
+                target = torch.zeros((), device=device)
+                stage._prepare_backward_infra(1, loss_fn=loss_fn, target=target)
+                self.assertEqual(mod.counter, initial_counter)
+            finally:
+                if init_pg:
+                    dist.destroy_process_group()
 
 
 def get_dtype_change_hook(new_dtype):

--- a/test/distributed/pipelining/test_stage.py
+++ b/test/distributed/pipelining/test_stage.py
@@ -14,7 +14,7 @@ from torch.distributed.pipelining import (
     PipelineStage,
     ScheduleGPipe,
 )
-from torch.distributed.pipelining._utils import InferenceMode, PipeliningMetadataError
+from torch.distributed.pipelining._utils import PipeliningMetadataError
 from torch.testing._internal.common_distributed import (
     MultiProcContinuousTest,
     requires_accelerator_dist_backend,
@@ -47,11 +47,12 @@ class PipelineStageMetadataInferenceTest(TestCase):
                 super().__init__()
                 self.linear = torch.nn.Linear(4, 4)
                 self.register_buffer("counter", torch.zeros(4))
+                self.register_buffer("scale", torch.ones(4))
 
             def forward(self, x):
                 with torch.no_grad():
                     self.counter.add_(1)
-                out = self.linear(x)
+                out = self.linear(x) * self.scale
                 if out.requires_grad:
                     out.register_hook(self._backward_hook)
                 return out
@@ -79,19 +80,24 @@ class PipelineStageMetadataInferenceTest(TestCase):
                     num_stages=1,
                     device=device,
                 )
-                stage._inference_mode = InferenceMode.DYNAMIC
+                schedule = ScheduleGPipe(
+                    stage,
+                    n_microbatches=1,
+                    loss_fn=lambda out, target: out.sum() + target.sum() * 0,
+                )
 
                 initial_counter = mod.counter.clone()
+                initial_scale = mod.scale.clone()
                 x = torch.randn(2, 4, device=device, requires_grad=True)
-                stage._prepare_forward_infra(1, (x,), {}, has_backward=True)
-                self.assertEqual(mod.counter, initial_counter)
-
-                def loss_fn(out, target):
-                    return out.sum() + target.sum() * 0
-
                 target = torch.zeros((), device=device)
-                stage._prepare_backward_infra(1, loss_fn=loss_fn, target=target)
+
+                # This exercises the full metadata-inference lifecycle. The
+                # scale buffer is saved by autograd, so restoring buffers before
+                # backward metadata inference would bump its version counter.
+                schedule._initialize_stage((x,), {}, target=target)
+
                 self.assertEqual(mod.counter, initial_counter)
+                self.assertEqual(mod.scale, initial_scale)
             finally:
                 if init_pg:
                     dist.destroy_process_group()

--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -448,33 +448,39 @@ class _PipelineSchedule(ABC):
                 "All stages must have the same device type for RNG forking. "
                 f"Found device types: {device_types}"
             )
-        with torch.random.fork_rng(devices=devices, device_type=device_type):
-            if needs_fwd:
-                next_stage_args: Any = None
-                for stage in stages:
-                    stage_args = args if stage.is_first else next_stage_args
-                    next_stage_args = stage._prepare_forward_infra(
-                        self._n_microbatches,
-                        stage_args,
-                        kwargs,
-                        has_backward=self._has_backward,
-                    )
-                fwd_initialized = True
+        pipeline_stages = [
+            stage for stage in stages if isinstance(stage, PipelineStage)
+        ]
+        for stage in pipeline_stages:
+            stage._pre_metadata_inference_backup()
 
-            if needs_bwd:
-                prev_stage_grad_meta: Any = None
-                for stage in reversed(stages):
-                    prev_stage_grad_meta = stage._prepare_backward_infra(
-                        self._n_microbatches,
-                        loss_fn=self._loss_fn,
-                        target=target,
-                        received_grad_meta=prev_stage_grad_meta,
-                        loss_kwargs=loss_kwargs,
-                    )
-                bwd_initialized = True
+        try:
+            with torch.random.fork_rng(devices=devices, device_type=device_type):
+                if needs_fwd:
+                    next_stage_args: Any = None
+                    for stage in stages:
+                        stage_args = args if stage.is_first else next_stage_args
+                        next_stage_args = stage._prepare_forward_infra(
+                            self._n_microbatches,
+                            stage_args,
+                            kwargs,
+                            has_backward=self._has_backward,
+                        )
+                    fwd_initialized = True
 
-        for stage in stages:
-            if isinstance(stage, PipelineStage):
+                if needs_bwd:
+                    prev_stage_grad_meta: Any = None
+                    for stage in reversed(stages):
+                        prev_stage_grad_meta = stage._prepare_backward_infra(
+                            self._n_microbatches,
+                            loss_fn=self._loss_fn,
+                            target=target,
+                            received_grad_meta=prev_stage_grad_meta,
+                            loss_kwargs=loss_kwargs,
+                        )
+                    bwd_initialized = True
+        finally:
+            for stage in pipeline_stages:
                 stage._post_metadata_inference_cleanup()
 
         return fwd_initialized, bwd_initialized

--- a/torch/distributed/pipelining/stage.py
+++ b/torch/distributed/pipelining/stage.py
@@ -1,11 +1,12 @@
 # mypy: allow-untyped-defs
 # Copyright (c) Meta Platforms, Inc. and affiliates
+import contextlib
 import logging
 import operator
 import warnings
 import weakref
 from abc import ABC, abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from typing import Any, cast
 
 import torch
@@ -1972,6 +1973,26 @@ class PipelineStage(_PipelineStageBase):
             )
         return local_ones
 
+    @contextlib.contextmanager
+    def _preserve_module_buffers(self) -> Iterator[None]:
+        """Restore module buffers after dynamic metadata inference.
+
+        Dynamic metadata inference executes representative real forwards and
+        backwards before the first runtime microbatch. Those executions are
+        allowed to observe module buffers, but they must not publish training
+        state updates such as running counters or routing statistics.
+        """
+        saved_buffers = [
+            (buffer, buffer.detach().clone())
+            for _, buffer in self.submod.named_buffers(remove_duplicate=False)
+        ]
+        try:
+            yield
+        finally:
+            with torch.no_grad():
+                for buffer, saved_buffer in saved_buffers:
+                    buffer.copy_(saved_buffer)
+
     def _forward_metadata_inference(
         self,
         args: tuple[torch.Tensor, ...] | _StageForwardMeta | None,
@@ -2234,12 +2255,13 @@ class PipelineStage(_PipelineStageBase):
         if self._inference_mode == InferenceMode.DYNAMIC:
             # DYNAMIC mode: run backward metadata inference
             # received_grad_meta is used for same-rank V-schedule stages
-            grad_meta_result = self._backward_metadata_inference(
-                loss_fn=loss_fn,
-                target=target,
-                received_grad_meta=received_grad_meta,
-                loss_kwargs=loss_kwargs,
-            )
+            with self._preserve_module_buffers():
+                grad_meta_result = self._backward_metadata_inference(
+                    loss_fn=loss_fn,
+                    target=target,
+                    received_grad_meta=received_grad_meta,
+                    loss_kwargs=loss_kwargs,
+                )
             # Validate dynamically inferred metadata against user-provided metadata
             self._validate_inferred_metadata()
         else:
@@ -2316,9 +2338,10 @@ class PipelineStage(_PipelineStageBase):
         if self._inference_mode == InferenceMode.DYNAMIC:
             # DYNAMIC mode: run forward metadata inference
             # args may be _StageForwardMeta for same-rank V-schedule stages
-            fwd_meta_output = self._forward_metadata_inference(
-                args, kwargs, has_backward
-            )
+            with self._preserve_module_buffers():
+                fwd_meta_output = self._forward_metadata_inference(
+                    args, kwargs, has_backward
+                )
             # Validate dynamically inferred metadata against user-provided metadata
             self._validate_inferred_metadata()
         # STATIC mode: metadata comes from user inputs, no validation needed

--- a/torch/distributed/pipelining/stage.py
+++ b/torch/distributed/pipelining/stage.py
@@ -1,12 +1,11 @@
 # mypy: allow-untyped-defs
 # Copyright (c) Meta Platforms, Inc. and affiliates
-import contextlib
 import logging
 import operator
 import warnings
 import weakref
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Iterator
+from collections.abc import Callable
 from typing import Any, cast
 
 import torch
@@ -1780,6 +1779,9 @@ class PipelineStage(_PipelineStageBase):
         self._fwd_outputs_for_bwd_meta: tuple[torch.Tensor, ...] | None = None
         self._fwd_inputs_for_bwd_meta: tuple[torch.Tensor, ...] | None = None
         self._fwd_kwargs_tensors_for_bwd_meta: tuple[torch.Tensor, ...] | None = None
+        self._metadata_inference_buffer_backup: (
+            list[tuple[torch.Tensor, torch.Tensor]] | None
+        ) = None
 
         # Validate and normalize args to tuples
         inputs = validate_and_normalize_to_tuple(input_args)
@@ -1973,25 +1975,25 @@ class PipelineStage(_PipelineStageBase):
             )
         return local_ones
 
-    @contextlib.contextmanager
-    def _preserve_module_buffers(self) -> Iterator[None]:
-        """Restore module buffers after dynamic metadata inference.
+    def _pre_metadata_inference_backup(self) -> None:
+        """Back up state that dynamic metadata inference must not publish.
 
         Dynamic metadata inference executes representative real forwards and
         backwards before the first runtime microbatch. Those executions are
         allowed to observe module buffers, but they must not publish training
         state updates such as running counters or routing statistics.
         """
-        saved_buffers = [
+        if self._inference_mode != InferenceMode.DYNAMIC:
+            return
+        if self._metadata_inference_buffer_backup is not None:
+            raise RuntimeError(
+                "Metadata inference buffer backup already exists. "
+                "Run _post_metadata_inference_cleanup before backing up again."
+            )
+        self._metadata_inference_buffer_backup = [
             (buffer, buffer.detach().clone())
             for _, buffer in self.submod.named_buffers(remove_duplicate=False)
         ]
-        try:
-            yield
-        finally:
-            with torch.no_grad():
-                for buffer, saved_buffer in saved_buffers:
-                    buffer.copy_(saved_buffer)
 
     def _forward_metadata_inference(
         self,
@@ -2222,9 +2224,19 @@ class PipelineStage(_PipelineStageBase):
             return None
 
     def _post_metadata_inference_cleanup(self) -> None:
-        """Clean up FSDP side effects (unsharded params, stale grads, stored
-        tensors) after metadata inference with real tensors.
+        """Restore state and clean up side effects from metadata inference.
+
+        Buffer restore is intentionally delayed until after both forward and
+        backward metadata inference. Restoring immediately after forward can
+        bump autograd version counters for buffers saved by the forward graph.
         """
+        buffer_backup = self._metadata_inference_buffer_backup
+        if buffer_backup is not None:
+            with torch.no_grad():
+                for buffer, saved_buffer in buffer_backup:
+                    buffer.copy_(saved_buffer)
+            self._metadata_inference_buffer_backup = None
+
         # Clear stored inference tensors (frees autograd graph + activations)
         self._fwd_outputs_for_bwd_meta = None
         self._fwd_inputs_for_bwd_meta = None
@@ -2255,13 +2267,12 @@ class PipelineStage(_PipelineStageBase):
         if self._inference_mode == InferenceMode.DYNAMIC:
             # DYNAMIC mode: run backward metadata inference
             # received_grad_meta is used for same-rank V-schedule stages
-            with self._preserve_module_buffers():
-                grad_meta_result = self._backward_metadata_inference(
-                    loss_fn=loss_fn,
-                    target=target,
-                    received_grad_meta=received_grad_meta,
-                    loss_kwargs=loss_kwargs,
-                )
+            grad_meta_result = self._backward_metadata_inference(
+                loss_fn=loss_fn,
+                target=target,
+                received_grad_meta=received_grad_meta,
+                loss_kwargs=loss_kwargs,
+            )
             # Validate dynamically inferred metadata against user-provided metadata
             self._validate_inferred_metadata()
         else:
@@ -2338,10 +2349,9 @@ class PipelineStage(_PipelineStageBase):
         if self._inference_mode == InferenceMode.DYNAMIC:
             # DYNAMIC mode: run forward metadata inference
             # args may be _StageForwardMeta for same-rank V-schedule stages
-            with self._preserve_module_buffers():
-                fwd_meta_output = self._forward_metadata_inference(
-                    args, kwargs, has_backward
-                )
+            fwd_meta_output = self._forward_metadata_inference(
+                args, kwargs, has_backward
+            )
             # Validate dynamically inferred metadata against user-provided metadata
             self._validate_inferred_metadata()
         # STATIC mode: metadata comes from user inputs, no validation needed


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #188500
* __->__ #188558

PipelineStage dynamic metadata inference runs representative forwards and backwards before the first runtime microbatch. That is needed to infer runtime metadata, but the eager executions can mutate module buffers through forward code or backward hooks. Those mutations leak into the real training step even though metadata inference is not part of training.

Save and restore the stage module buffers around dynamic forward and backward metadata inference so those eager probes can observe the same buffer values without publishing their mutations. The restore is scoped to dynamic inference only; static metadata still avoids the eager probes entirely.

Add a regression test with a module that mutates a buffer in both forward and a backward hook, then verifies PipelineStage preparation leaves the buffer unchanged.

Test Plan:

```bash
conda run -n pt-dev python test/distributed/pipelining/test_stage.py -k dynamic_metadata_inference_restores_module_buffers
conda run -n pt-dev lintrunner -a
```

Authored with an AI assistant.