### PR TITLE
[Metal] Mark read-only pointers for scalar params in binary_dense_scalar kernels as `const`

### DIFF
--- a/.ci/pytorch/macos-test.sh
+++ b/.ci/pytorch/macos-test.sh
@@ -41,7 +41,13 @@ test_python_mps() {
   setup_test_python
 
   time PYTORCH_TEST_WITH_SLOW=1 python test/run_test.py --verbose --mps
-  MTL_CAPTURE_ENABLED=1 python3 test/test_mps.py --verbose -k test_metal_capture
+  # Run scalar binary ops under the Metal shader validation layer to catch
+  # bad buffer address spaces (e.g. read-only setBytes bound to a writable arg).
+  MTL_DEBUG_LAYER=1 MTL_SHADER_VALIDATION=1 python3 test/test_mps.py --verbose -k test_add_sub
+  # Metal capture is flaky, so retry it a few times before giving up.
+  for _ in 1 2 3; do
+    MTL_CAPTURE_ENABLED=1 python3 test/test_mps.py --verbose -k test_metal_capture && break
+  done
 
   assert_git_not_dirty
 }

--- a/c10/metal/indexing.h
+++ b/c10/metal/indexing.h
@@ -68,8 +68,11 @@ inline T val_at_offs(constant void* ptr, long offs) {
 }
 
 template <typename T>
-inline T val_at_offs(device void* ptr, long offs) {
-  return *reinterpret_cast<device T*>(static_cast<device char*>(ptr) + offs);
+inline T val_at_offs(device const void* ptr, long offs) {
+  // A non-const `device` pointer coerces to this overload; the separate
+  // `constant` overload above is required because address spaces don't convert.
+  return *reinterpret_cast<device const T*>(
+      static_cast<device const char*>(ptr) + offs);
 }
 
 template <typename T>
@@ -1027,7 +1030,7 @@ template <typename T, typename F, typename om_t = opmath_t<T>>
 kernel void binary_dense_scalar(
     device result_of<F, T, T>* out [[buffer(0)]],
     constant T* input [[buffer(1)]],
-    device T* scalar [[buffer(2)]],
+    device const T* scalar [[buffer(2)]],
     uint tid [[thread_position_in_grid]]) {
   F f;
   using res_t = result_of<F, T, T>;
@@ -1037,7 +1040,7 @@ kernel void binary_dense_scalar(
 template <typename T, typename F, typename om_t = opmath_t<T>>
 kernel void binary_dense_scalar_lhs(
     device result_of<F, T, T>* out [[buffer(0)]],
-    device T* scalar [[buffer(1)]],
+    device const T* scalar [[buffer(1)]],
     constant T* input [[buffer(2)]],
     uint tid [[thread_position_in_grid]]) {
   F f;
@@ -1049,7 +1052,7 @@ template <typename T, typename F, typename om_t = T>
 kernel void binary_dense_scalar_cast(
     device result_of<F, T, T>* out [[buffer(0)]],
     constant void* input [[buffer(1)]],
-    device void* scalar [[buffer(2)]],
+    device const void* scalar [[buffer(2)]],
     constant uint4& sizes_types [[buffer(3)]],
     uint tid [[thread_position_in_grid]]) {
   F f;
@@ -1064,7 +1067,7 @@ kernel void binary_dense_scalar_cast(
 template <typename T, typename F, typename om_t = T>
 kernel void binary_dense_scalar_lhs_cast(
     device result_of<F, T, T>* out [[buffer(0)]],
-    device void* scalar [[buffer(1)]],
+    device const void* scalar [[buffer(1)]],
     constant void* input [[buffer(2)]],
     constant uint4& sizes_types [[buffer(3)]],
     uint tid [[thread_position_in_grid]]) {
@@ -1081,7 +1084,7 @@ template <typename T, typename T2, typename F>
 kernel void binary_alpha_dense_scalar(
     device result_of<F, T, T, T2>* out [[buffer(0)]],
     constant T* input [[buffer(1)]],
-    device T* scalar [[buffer(2)]],
+    device const T* scalar [[buffer(2)]],
     constant T2& alpha [[buffer(3)]],
     uint tid [[thread_position_in_grid]]) {
   F f;
@@ -1091,7 +1094,7 @@ kernel void binary_alpha_dense_scalar(
 template <typename T, typename T2, typename F>
 kernel void binary_alpha_dense_scalar_lhs(
     device result_of<F, T, T, T2>* out [[buffer(0)]],
-    device T* scalar [[buffer(1)]],
+    device const T* scalar [[buffer(1)]],
     constant T* input [[buffer(2)]],
     constant T2& alpha [[buffer(3)]],
     uint tid [[thread_position_in_grid]]) {
@@ -1103,7 +1106,7 @@ template <typename T, typename T2, typename F>
 kernel void binary_alpha_dense_scalar_cast(
     device result_of<F, T, T, T2>* out [[buffer(0)]],
     constant void* input [[buffer(1)]],
-    device void* scalar [[buffer(2)]],
+    device const void* scalar [[buffer(2)]],
     constant T2& alpha [[buffer(3)]],
     constant uint4& sizes_types [[buffer(4)]],
     uint tid [[thread_position_in_grid]]) {
@@ -1118,7 +1121,7 @@ kernel void binary_alpha_dense_scalar_cast(
 template <typename T, typename T2, typename F>
 kernel void binary_alpha_dense_scalar_lhs_cast(
     device result_of<F, T, T, T2>* out [[buffer(0)]],
-    device void* scalar [[buffer(1)]],
+    device const void* scalar [[buffer(1)]],
     constant void* input [[buffer(2)]],
     constant T2& alpha [[buffer(3)]],
     constant uint4& sizes_types [[buffer(4)]],
@@ -1239,15 +1242,15 @@ kernel void binary_alpha_dense_scalar_lhs_cast(
   kernel void ::c10::metal::binary_dense_scalar<DTYPEI, NAME##_functor, OMT>(  \
       device ::c10::metal::result_of<NAME##_functor, DTYPEI, DTYPEI> * out_,   \
       constant DTYPEI * input_,                                                \
-      device DTYPEI * scalar_,                                                 \
+      device const DTYPEI* scalar_,                                            \
       uint tid);                                                               \
   template [[host_name(#NAME "_dense_scalar_lhs_" #DTYPEO "_" #DTYPEI)]]       \
   kernel void ::c10::metal::                                                   \
       binary_dense_scalar_lhs<DTYPEI, NAME##_functor, OMT>(                    \
           device ::c10::metal::result_of<NAME##_functor, DTYPEI, DTYPEI> *     \
               out_,                                                            \
-          device DTYPEI * scalar_,                                             \
-          constant DTYPEI * input_,                                            \
+          device const DTYPEI* scalar_,                                        \
+          constant DTYPEI* input_,                                             \
           uint tid);                                                           \
   template [[host_name(#NAME "_dense_scalar_cast_" #DTYPEO "_" #DTYPEI)]]      \
   kernel void ::c10::metal::                                                   \
@@ -1255,7 +1258,7 @@ kernel void binary_alpha_dense_scalar_lhs_cast(
           device ::c10::metal::result_of<NAME##_functor, DTYPEI, DTYPEI> *     \
               out_,                                                            \
           constant void* input_,                                               \
-          device void* scalar_,                                                \
+          device const void* scalar_,                                          \
           constant uint4& sizes_types,                                         \
           uint tid);                                                           \
   template [[host_name(#NAME "_dense_scalar_lhs_cast_" #DTYPEO                 \
@@ -1263,7 +1266,7 @@ kernel void binary_alpha_dense_scalar_lhs_cast(
       binary_dense_scalar_lhs_cast<DTYPEI, NAME##_functor, OMT>(               \
           device ::c10::metal::result_of<NAME##_functor, DTYPEI, DTYPEI> *     \
               out_,                                                            \
-          device void* scalar_,                                                \
+          device const void* scalar_,                                          \
           constant void* input_,                                               \
           constant uint4& sizes_types,                                         \
           uint tid)
@@ -1400,8 +1403,8 @@ kernel void binary_alpha_dense_scalar_lhs_cast(
                   result_of<NAME##_functor, DTYPEI, DTYPEI, DTYPEA> *         \
               out_,                                                           \
           constant DTYPEI * input_,                                           \
-          device DTYPEI * scalar_,                                            \
-          constant DTYPEA & alpha,                                            \
+          device const DTYPEI* scalar_,                                       \
+          constant DTYPEA& alpha,                                             \
           uint tid);                                                          \
   template [[host_name(#NAME "_dense_scalar_lhs_" #DTYPEO "_" #DTYPEI         \
                              "_" #DTYPEA)]] kernel void ::c10::metal::        \
@@ -1409,9 +1412,9 @@ kernel void binary_alpha_dense_scalar_lhs_cast(
           device ::c10::metal::                                               \
                   result_of<NAME##_functor, DTYPEI, DTYPEI, DTYPEA> *         \
               out_,                                                           \
-          device DTYPEI * scalar_,                                            \
-          constant DTYPEI * input_,                                           \
-          constant DTYPEA & alpha,                                            \
+          device const DTYPEI* scalar_,                                       \
+          constant DTYPEI* input_,                                            \
+          constant DTYPEA& alpha,                                             \
           uint tid);                                                          \
   template [[host_name(#NAME "_dense_scalar_cast_" #DTYPEO "_" #DTYPEI        \
                              "_" #DTYPEA)]] kernel void ::c10::metal::        \
@@ -1420,7 +1423,7 @@ kernel void binary_alpha_dense_scalar_lhs_cast(
                   result_of<NAME##_functor, DTYPEI, DTYPEI, DTYPEA> *         \
               out_,                                                           \
           constant void* input_,                                              \
-          device void* scalar_,                                               \
+          device const void* scalar_,                                         \
           constant DTYPEA& alpha,                                             \
           constant uint4& sizes_types,                                        \
           uint tid);                                                          \
@@ -1430,7 +1433,7 @@ kernel void binary_alpha_dense_scalar_lhs_cast(
           device ::c10::metal::                                               \
                   result_of<NAME##_functor, DTYPEI, DTYPEI, DTYPEA> *         \
               out_,                                                           \
-          device void* scalar_,                                               \
+          device const void* scalar_,                                         \
           constant void* input_,                                              \
           constant DTYPEA& alpha,                                             \
           constant uint4& sizes_types,                                        \


### PR DESCRIPTION
The 8 `binary_dense_scalar*` kernels in `c10/metal/indexing.h` declared the CPU scalar operand as `device T*` (read-write). Scalars are bound via `setBytes:` (read-only), so the Metal shader validation layer aborts:

```
Read-only bytes are being bound at index N to a shader argument with write access enabled
```

The original fix moved the operand to `constant T*`. That is **wrong**: the `constant` address space requires 4-byte-aligned buffer offsets, which `setBytes:` does not guarantee — a 2-byte `half` scalar is then misread and silently corrupts results (regressing `test_non_contiguous_tensors_nn_Bilinear_mps_float16`).

@malfet reworked the change to use `device const *`, which marks the argument read-only (satisfying the validation layer) while keeping it in the byte-addressable `device` address space, which has no such alignment requirement.

### Testing

Instead of a dedicated test, CI runs the existing `TestMPS.test_add_sub` under the validation layer (`.ci/pytorch/macos-test.sh`) — it aborts before the fix and passes after:

```bash
MTL_DEBUG_LAYER=1 MTL_SHADER_VALIDATION=1 python3 test/test_mps.py -k test_add_sub
```
