### PR TITLE
Treat in-progress (pending) HUD runs as no-data in failure streaks

### DIFF
--- a/scripts/hud/analyze_failing_jobs.py
+++ b/scripts/hud/analyze_failing_jobs.py
@@ -42,8 +42,11 @@ HUD_API = "https://hud.pytorch.org/api/hud/pytorch/pytorch"
 # we fetch whole pages and trim to the exact commit count requested.
 PER_PAGE = 100
 
-# Conclusions that don't represent a real signal for a commit/job pair.
-SKIPPED_CONCLUSIONS = {"neutral", "skipped"}
+# Conclusions without a completed signal for a commit/job pair. "pending" is an
+# in-progress run (no result yet), so it is treated as no-data rather than
+# breaking a streak -- otherwise an in-flight rerun at the tip would reset the
+# streak of a job that is otherwise consistently failing.
+SKIPPED_CONCLUSIONS = {"neutral", "skipped", "pending"}
 # Two failures whose captured error text is at least this similar are treated
 # as the same underlying failure.
 SIMILARITY_THRESHOLD = 0.75
@@ -139,8 +142,8 @@ def summarize_job(
         "current_streak": len(streak),
         "failing_since_sha": streak[-1].get("sha") if streak else None,
         # Clipped means the true start may predate the window, so more --commits
-        # could help. That needs two things: (A) no success/pending anywhere in
-        # the observed runs, so nothing pins the start (len(streak) == len(real)),
+        # could help. That needs two things: (A) every completed run in the
+        # window is a failure, so nothing pins the start (len(streak) == len(real)),
         # and (B) the job still has data at the oldest fetched commit, so older
         # data plausibly exists. (B) uses the oldest cell, not the oldest failure,
         # to tolerate no-data gaps at the window edge. A job that simply stopped


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #188562

analyze_failing_jobs.py computes a job's current failure streak by walking its
results newest-to-oldest. A "pending" (in-progress) run was classified as
neither a failure nor no-data, so it hit the streak-terminating branch and
reset the streak to 0. Jobs that almost always have an in-flight rerun at the
tip -- common for flaky ROCm jobs -- were therefore dropped by the default
--filter-min-streak even when every completed run in the window had failed.

Classify "pending" as no-data (add it to SKIPPED_CONCLUSIONS) so the streak
walk looks past in-flight runs to the last completed result, and a rerun in
progress no longer masks a consistently failing job. is_failure already
excluded "pending", so this only affects the skip path.

Test Plan:

Before the fix, this consistently-failing job was missing from the report
because its newest run was pending; after, it is reported with streak 42:

    HUD_INTERNAL_BOT_TOKEN=<token> python scripts/hud/analyze_failing_jobs.py \
        --commits 200 --filter-job-name ".*navi31.*test \(default, 1, 2.*"

    lintrunner -a scripts/hud/analyze_failing_jobs.py

Authored with Claude.