### PR TITLE
Migrate stale.yml to a GitHub-hosted runner

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   stale:
     if: ${{ github.repository == 'pytorch/pytorch' }}
-    runs-on: linux.large
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
The stale workflow is a single `actions/github-script` step that only calls the GitHub API (no PyTorch source, AWS, or Docker), so run it on `ubuntu-latest` instead of the `linux.large` EC2 runner.

Branch pushed to the base repo (not a fork) so `workflow_dispatch` can be used to test it.

### Testing

https://github.com/pytorch/pytorch/actions/runs/28461670447/job/84350853156