### PR TITLE
Support all remaining unsupported collectives in PyProcessGroup

### DIFF
--- a/test/distributed/test_c10d_common.py
+++ b/test/distributed/test_c10d_common.py
@@ -1873,6 +1873,46 @@ class DummyProcessGroup(dist.ProcessGroup):
 
         return DummyWork()
 
+    def reduce(self, tensor_list, opts=None):
+        self.collectives_called.add("reduce")
+        for tensor in tensor_list:
+            tensor.add_(3)
+
+        return DummyWork()
+
+    def gather(self, output_tensor_lists, input_tensor_list, opts=None):
+        self.collectives_called.add("gather")
+        for output_tensor_list, input_tensor in zip(
+            output_tensor_lists, input_tensor_list
+        ):
+            for output_tensor in output_tensor_list:
+                output_tensor.copy_(input_tensor)
+
+        return DummyWork()
+
+    def scatter(self, output_tensor_list, input_tensor_lists, opts=None):
+        self.collectives_called.add("scatter")
+        for output_tensor, input_tensor_list in zip(
+            output_tensor_list, input_tensor_lists
+        ):
+            output_tensor.copy_(input_tensor_list[self.rank()])
+
+        return DummyWork()
+
+    def alltoall(self, output_tensor_list, input_tensor_list, opts=None):
+        self.collectives_called.add("alltoall")
+        for output_tensor, input_tensor in zip(output_tensor_list, input_tensor_list):
+            output_tensor.copy_(input_tensor)
+
+        return DummyWork()
+
+    def recvAnysource(self, tensor_list, tag):
+        self.collectives_called.add("recvAnysource")
+        for tensor in tensor_list:
+            tensor.add_(4)
+
+        return DummyWork()
+
     def send(self, tensor_list, dst, tag=0):
         for tensor in tensor_list:
             tensor.add_(1)

--- a/test/distributed/test_c10d_pypg.py
+++ b/test/distributed/test_c10d_pypg.py
@@ -354,6 +354,54 @@ class TestPyProcessGroup(TestCase):
         self.assertIn("reduce_scatter_single", pg.collectives_called)
         self.assertEqual(output, torch.ones(2))
 
+    # reduce / gather / scatter / alltoall share their Python name with the
+    # bound method, so a plain instance call hits the Python override directly
+    # (a sanity check that it runs and forwards its buffers; no functional
+    # collective dispatches to these as ProcessGroup virtuals). recvAnysource is
+    # bound under the non-shadowed name recv_anysource, so pg.recv_anysource()
+    # routes through the C++ virtual into the trampoline. DummyProcessGroup
+    # records each dispatched collective and applies a recognizable mutation
+    # (reduce adds 3, recvAnysource adds 4, gather/scatter/alltoall copy).
+    def test_reduce(self):
+        pg = test_c10d_common.DummyProcessGroup(0, 1)
+        tensor = torch.zeros(4)
+        pg.reduce([tensor]).wait()
+        self.assertIn("reduce", pg.collectives_called)
+        self.assertEqual(tensor, torch.zeros(4) + 3)
+
+    def test_gather(self):
+        pg = test_c10d_common.DummyProcessGroup(0, 1)
+        input = torch.arange(4, dtype=torch.float32)
+        output = torch.zeros(4)
+        pg.gather([[output]], [input]).wait()
+        self.assertIn("gather", pg.collectives_called)
+        self.assertEqual(output, input)
+
+    def test_scatter(self):
+        pg = test_c10d_common.DummyProcessGroup(0, 1)
+        input = torch.arange(4, dtype=torch.float32)
+        output = torch.zeros(4)
+        pg.scatter([output], [[input]]).wait()
+        self.assertIn("scatter", pg.collectives_called)
+        self.assertEqual(output, input)
+
+    def test_alltoall(self):
+        pg = test_c10d_common.DummyProcessGroup(0, 1)
+        input = torch.arange(4, dtype=torch.float32)
+        output = torch.zeros(4)
+        pg.alltoall([output], [input]).wait()
+        self.assertIn("alltoall", pg.collectives_called)
+        self.assertEqual(output, input)
+
+    def test_recv_anysource(self):
+        # recv_anysource is bound to the recvAnysource virtual under a different
+        # name, so this routes through the C++ trampoline into the override.
+        pg = test_c10d_common.DummyProcessGroup(0, 1)
+        tensor = torch.zeros(4)
+        pg.recv_anysource([tensor], 7).wait()
+        self.assertIn("recvAnysource", pg.collectives_called)
+        self.assertEqual(tensor, torch.zeros(4) + 4)
+
     def test_coalescing_manager(self):
         # The coalescing manager calls _start_coalescing / _end_coalescing, which
         # route through the C++ virtual into the PyProcessGroup trampoline and

--- a/torch/csrc/distributed/c10d/PyProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/PyProcessGroup.hpp
@@ -252,6 +252,28 @@ class PyProcessGroup : public ProcessGroup {
         opts);
   }
 
+  c10::intrusive_ptr<Work> reduce(
+      std::vector<at::Tensor>& tensors,
+      const ReduceOptions& opts = ReduceOptions()) override {
+    WORK_OVERRIDE(
+        ProcessGroup, /* Parent class */
+        reduce, /* Name of function in C++ */
+        tensors,
+        opts);
+  }
+
+  c10::intrusive_ptr<Work> alltoall(
+      std::vector<at::Tensor>& outputTensors,
+      std::vector<at::Tensor>& inputTensors,
+      const AllToAllOptions& opts = AllToAllOptions()) override {
+    WORK_OVERRIDE(
+        ProcessGroup, /* Parent class */
+        alltoall, /* Name of function in C++ */
+        outputTensors,
+        inputTensors,
+        opts);
+  }
+
   c10::intrusive_ptr<Work> all_to_all_single(
       at::Tensor& outputBuffer,
       at::Tensor& inputBuffer,
@@ -291,6 +313,30 @@ class PyProcessGroup : public ProcessGroup {
         ProcessGroup, /* Parent class */
         broadcast, /* Name of function in C++ */
         tensors,
+        opts);
+  }
+
+  c10::intrusive_ptr<Work> gather(
+      std::vector<std::vector<at::Tensor>>& outputTensors,
+      std::vector<at::Tensor>& inputTensors,
+      const GatherOptions& opts = GatherOptions()) override {
+    WORK_OVERRIDE(
+        ProcessGroup, /* Parent class */
+        gather, /* Name of function in C++ */
+        outputTensors,
+        inputTensors,
+        opts);
+  }
+
+  c10::intrusive_ptr<Work> scatter(
+      std::vector<at::Tensor>& outputTensors,
+      std::vector<std::vector<at::Tensor>>& inputTensors,
+      const ScatterOptions& opts = ScatterOptions()) override {
+    WORK_OVERRIDE(
+        ProcessGroup, /* Parent class */
+        scatter, /* Name of function in C++ */
+        outputTensors,
+        inputTensors,
         opts);
   }
 
@@ -363,6 +409,16 @@ class PyProcessGroup : public ProcessGroup {
         recv, /* Name of function in C++ */
         tensors,
         srcRank,
+        tag);
+  }
+
+  c10::intrusive_ptr<Work> recvAnysource(
+      std::vector<at::Tensor>& tensors,
+      int tag) override {
+    WORK_OVERRIDE(
+        ProcessGroup, /* Parent class */
+        recvAnysource, /* Name of function in C++ */
+        tensors,
         tag);
   }
 


### PR DESCRIPTION
As raised in https://github.com/pytorch/pytorch/issues/188542, PyProcessGroup is missing a few collectives -- supporting remaining collectives in addition to the ones in https://github.com/pytorch/pytorch/pull/188548

## Test plan

```
pytest test/distributed/test_c10d_pypg.py::TestPyProcessGroup -v -k "reduce or gather or scatter or alltoall or recv"
```