### PR TITLE
[PT2 Export] Fix `SymNumberMemoDescriptor` to support inference FakeTensors (#188575)

### DIFF
--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -3255,6 +3255,35 @@ class FakeTensorPropTest(TestCase):
             for k in sd:
                 _read_tensor_and_check(k, sd_loaded, sd, all_bytes, "cpu")
 
+    def test_inference_mode_nonzero_memo(self):
+        """D106102842: nonzero() memo must be stored for inference FakeTensors.
+
+        Without the fix, SymNumberMemoDescriptor.__set__ skipped memo storage
+        for inference tensors, so each boolean indexing (x[mask]) allocated a
+        fresh unbacked symint. Two tensors filtered by the same mask would get
+        independent symbols, causing GuardOnDataDependentSymNode failures.
+        """
+        shape_env = ShapeEnv()
+        fake_mode = FakeTensorMode(shape_env=shape_env)
+        with fake_mode:
+            with torch.inference_mode():
+                x = torch.randn(10, 3)
+                y = torch.randn(10, 5)
+                mask = torch.randn(10) > 0
+
+                self.assertIsInstance(x, FakeTensor)
+                self.assertTrue(x.is_inference())
+
+                filtered_x = x[mask]
+                filtered_y = y[mask]
+
+                sx = filtered_x.shape[0]
+                sy = filtered_y.shape[0]
+
+                # Both shapes should be the same unified symbol because
+                # mask.nonzero() is memoized.
+                self.assertTrue(statically_known_true(sx == sy))
+
 
 make_propagate_real_tensors_cls(FakeTensorPropTest)
 

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -754,22 +754,25 @@ class SymNumberMemoDescriptor:
             return None
 
         # Version counter based tracking isn't 100% sound but it's close
-        # enough
-        if not self._is_nested_int and getattr(obj, self._memo_vc(obj)) != obj._version:
-            setattr(obj, self._memo(obj), None)
-            return None
+        # enough.  Inference tensors don't track version counters, so
+        # skip that check for them.
+        if not self._is_nested_int and not obj.is_inference():
+            if getattr(obj, self._memo_vc(obj), None) != obj._version:
+                setattr(obj, self._memo(obj), None)
+                return None
 
-        # Backed SymFloats are stable across retracing epochs. Keep this after
-        # the version check so tensor mutation still invalidates the memo.
+        # Backed SymFloats are stable across retracing epochs, but tensor
+        # mutation (version counter check above) still invalidates the memo.
         if isinstance(r, torch.SymFloat) and r.node.hint is not None:
             return r
 
         if (
             not self._is_nested_int
-            and getattr(obj, self._memo_epoch(obj)) != obj.fake_mode.epoch
+            and getattr(obj, self._memo_epoch(obj), None) != obj.fake_mode.epoch
         ):
             setattr(obj, self._memo(obj), None)
             return None
+
         return r
 
     def __set__(
@@ -781,9 +784,9 @@ class SymNumberMemoDescriptor:
             setattr(obj, self._memo(obj), None)
             setattr(obj, self._memo_vc(obj), None)
             setattr(obj, self._memo_epoch(obj), None)
-        elif not obj.is_inference() or self._is_nested_int:
+        else:
             setattr(obj, self._memo(obj), value)
-            if not self._is_nested_int:
+            if not self._is_nested_int and not obj.is_inference():
                 setattr(obj, self._memo_vc(obj), obj._version)
             setattr(obj, self._memo_epoch(obj), obj.fake_mode.epoch)
 


### PR DESCRIPTION
Summary:

`SymNumberMemoDescriptor.__set__` previously skipped memo storage for inference
FakeTensors (guarded by `elif not obj.is_inference()`). This caused every
`nonzero()` call on inference-mode boolean mask tensors to allocate a fresh
unbacked symint, even when the same mask was reused across multiple boolean
indexing operations.

This led to `GuardOnDataDependentSymNode` errors during AOTINDUCTOR lowering
when `torch.export` tried to verify that two tensors filtered by the same
boolean mask had equal sizes -- the tracer saw independent symbols (e.g.,
`Eq(u2322 + 1, u2323 + 1)`) instead of the same unified symbol.

The fix:
- `__set__`: Always store the memo value. Skip only the `_version` storage
  for inference tensors (since they do not track version counters).
- `__get__`: Skip the version counter staleness check for inference tensors.
  Only validate the epoch. Use `getattr(..., None)` defaults for safety.

Test Plan:
UT:
```
buck2 test fbcode//mode/dev-nosan fbcode//caffe2/test:fake_tensor -- -- -k test_inference_mode_nonzero_memo 
```

Without the fix, this UT fails at `self.assertTrue(statically_known_true(sx == sy))`

E2E:

Built ephemeral `ien.lower.cpu` package with this fix
- Ran RE client lowering repro for model 1060790975 snapshot 31
- Verified `GuardOnDataDependentSymNode` error is eliminated
- Export completes successfully, lowering proceeds to AOTI compilation
- Local `torch.export` tests with boolean indexing continue to pass
- Debug paste: https://fburl.com/everpaste/8gzt64ng

Differential Revision: D106102842


