### PR TITLE
[dynamo] Accept module-level functions (and any constant) as torch._check messages

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -134,6 +134,12 @@ TPFLAGS_MAPPING = 1 << 6
 GLOBAL_INT = 1
 
 
+# Module-level function used as a torch._check message (UserFunctionVariable,
+# as opposed to a nested closure defined inside the compiled region).
+def global_check_message():
+    return "global check message"
+
+
 # Specializes a test to run only if translation validation is set.
 def onlyIfTranslationValidation(fn: typing.Callable) -> typing.Callable:
     @functools.wraps(fn)
@@ -2098,6 +2104,92 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
             RuntimeError, f"{GLOBAL_INT} is not greater than 3"
         ):
             f(x)
+
+    def test_check_compiles_when_predicate_true_and_message_module_level_fn(self):
+        @torch.compile(backend="eager", fullgraph=True)
+        def f(x):
+            torch._check(x.shape[0] > 3, global_check_message)
+            return x + 1
+
+        x = torch.randn(4)
+        torch._dynamo.maybe_mark_dynamic(x, 0)
+
+        y = f(x)
+        self.assertEqual(y.shape, x.shape)
+
+    def test_check_raises_at_runtime_when_predicate_false_and_message_module_level_fn(
+        self,
+    ):
+        @torch.compile(backend="eager", fullgraph=True)
+        def f(x):
+            torch._check(x.shape[0] > 3, global_check_message)
+            return x + 1
+
+        x = torch.randn(3)
+        torch._dynamo.maybe_mark_dynamic(x, 0)
+
+        with self.assertRaisesRegex(RuntimeError, "global check message"):
+            f(x)
+
+    def test_check_compiles_when_predicate_true_and_message_non_str_constant(self):
+        @torch.compile(backend="eager", fullgraph=True)
+        def f(x):
+            torch._check(x.shape[0] > 3, 12345)
+            return x + 1
+
+        x = torch.randn(4)
+        torch._dynamo.maybe_mark_dynamic(x, 0)
+
+        y = f(x)
+        self.assertEqual(y.shape, x.shape)
+
+    def test_check_raises_at_runtime_when_predicate_false_and_message_non_str_constant(
+        self,
+    ):
+        @torch.compile(backend="eager", fullgraph=True)
+        def f(x):
+            torch._check(x.shape[0] > 3, 12345)
+            return x + 1
+
+        x = torch.randn(3)
+        torch._dynamo.maybe_mark_dynamic(x, 0)
+
+        with self.assertRaisesRegex(RuntimeError, "12345"):
+            f(x)
+
+    def test_check_graph_breaks_when_message_is_unsupported_type(self):
+        # A tensor message is neither a constant nor a function.
+        @torch.compile(backend="eager", fullgraph=True)
+        def f(x):
+            torch._check(x.shape[0] > 3, x)
+            return x + 1
+
+        x = torch.randn(4)
+        torch._dynamo.maybe_mark_dynamic(x, 0)
+
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.Unsupported, "Can't extract message from torch._check"
+        ):
+            f(x)
+
+    def test_check_graph_breaks_when_message_is_bound_method(self):
+        # A bound method is a function-VT subclass whose reconstructed function
+        # drops the receiver, so it is rejected rather than mis-evaluated.
+        class M:
+            def msg(self):
+                return "bound method message"
+
+            def forward(self, x):
+                torch._check(x.shape[0] > 3, self.msg)
+                return x + 1
+
+        x = torch.randn(4)
+        torch._dynamo.maybe_mark_dynamic(x, 0)
+
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.Unsupported, "Can't extract message from torch._check"
+        ):
+            torch.compile(M().forward, backend="eager", fullgraph=True)(x)
 
     def test_check_raises_at_runtime_when_predicate_false_and_message_None(self):
         @torch.compile(backend="eager", fullgraph=True)

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -3941,6 +3941,14 @@
     {
       "Gb_type": "Can't extract message from torch._check*()",
       "Context": "str(message_vt)",
+      "Explanation": "The message argument of torch._check*() must be a string, None, or a function.",
+      "Hints": [
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
+    },
+    {
+      "Gb_type": "Can't extract message from torch._check*()",
+      "Context": "str(message_vt)",
       "Explanation": "The message argument of torch._check*() must be a string, None, or a function defined within the torch.compile region.",
       "Hints": [
         "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -2548,10 +2548,9 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
             match message_vt:
                 case None:
                     pass
-                case _ if type(message_vt) in (
-                    NestedUserFunctionVariable,
-                    UserFunctionVariable,
-                ):
+                case NestedUserFunctionVariable() | UserFunctionVariable() if type(
+                    message_vt
+                ) in (NestedUserFunctionVariable, UserFunctionVariable):
                     # These report is_python_constant() True (as_python_constant
                     # returns the underlying fn), so this arm must precede the
                     # constant arm below. Restrict to exact types: other

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -97,6 +97,7 @@ from .functions import (
     bind_args_cached,
     ClosureConversionError,
     NestedUserFunctionVariable,
+    UserFunctionVariable,
 )
 from .lists import ListVariable, TupleVariable
 from .object_protocol import vt_is_iterable
@@ -2540,25 +2541,24 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
             message_eager = None
             message_graph_arg = None
+            # Realize a possible LazyVariableTracker so the exact-type checks
+            # below see the underlying VariableTracker rather than the wrapper.
+            if message_vt is not None:
+                message_vt = message_vt.realize()
             match message_vt:
                 case None:
                     pass
-                case ConstantVariable():
-                    message_eager = message_vt.as_python_constant()
-                    if message_eager is not None and not isinstance(message_eager, str):
-                        unimplemented(
-                            gb_type="Can't extract message from torch._check*()",
-                            context=str(message_vt),
-                            explanation=(
-                                "The message argument of torch._check*() must be a string, None, "
-                                "or a function defined within the torch.compile region."
-                            ),
-                            hints=[
-                                *graph_break_hints.SUPPORTABLE,
-                            ],
-                        )
-                    message_graph_arg = message_eager
-                case NestedUserFunctionVariable():
+                case _ if type(message_vt) in (
+                    NestedUserFunctionVariable,
+                    UserFunctionVariable,
+                ):
+                    # These report is_python_constant() True (as_python_constant
+                    # returns the underlying fn), so this arm must precede the
+                    # constant arm below. Restrict to exact types: other
+                    # function-VT subclasses (e.g. bound methods, whose
+                    # get_function drops the receiver) cannot be faithfully
+                    # reconstructed as a zero-arg message callable, so they fall
+                    # through to the graph-break arm.
                     try:
                         message_eager = message_vt.get_function()
                     except ClosureConversionError:
@@ -2579,13 +2579,19 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
                     message_graph_arg = tx.output.register_static_attr_and_return_proxy(
                         "_check_message", message_eager
                     )
+                case _ if message_vt.is_python_constant():
+                    # Mirror eager torch._check, which accepts any constant and
+                    # stringifies it; None means "use the default message".
+                    message_eager = message_vt.as_python_constant()
+                    if message_eager is not None:
+                        message_graph_arg = str(message_eager)
                 case _:
                     unimplemented(
                         gb_type="Can't extract message from torch._check*()",
                         context=str(message_vt),
                         explanation=(
                             "The message argument of torch._check*() must be a string, None, "
-                            "or a function defined within the torch.compile region."
+                            "or a function."
                         ),
                         hints=[
                             *graph_break_hints.SUPPORTABLE,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #188576

eager torch._check accepts `str | Callable[[], object] | None` as the message and
evaluates it as `str(message() if callable(message) else message)`. Dynamo's
handler only accepted an inline closure (NestedUserFunctionVariable) or, after
#188177, a str/None constant: a plain module-level function graph-broke and
non-str constants were rejected. This generalizes the handler to match eager.

After realizing a possible LazyVariableTracker, the message is lowered in two
buckets: an exact UserFunctionVariable or NestedUserFunctionVariable is
reconstructed via get_function() and stored as the `_check_message` graph
attribute (a module-level function is picklable by reference, so it does not
reintroduce the FlexAttention "Failed to pickle cache key" cache bypass that
#183838's local closures caused and #188177 worked around); any python constant
is stringified and embedded inline; everything else graph-breaks.

The match keys on the exact VariableTracker types rather than the
BaseUserFunctionVariable base class. Function VTs report is_python_constant()
True (their as_python_constant returns the underlying fn), so the callable arm
must precede the constant arm. Matching the base class would wrongly accept bound
methods (UserMethodVariable.get_function drops the receiver, yielding a callable
that errors when invoked with no args) and other subclasses whose get_function is
unimplemented; restricting to exact types routes those to a clean graph break
instead. Realizing first is required because the message arrives as a
LazyVariableTracker whose type() is the wrapper rather than the underlying VT.

Builds on #188177.

This PR was authored with assistance from an AI assistant.

Test Plan:

```bash
python test/dynamo/test_misc.py -k test_check
```

32 passed (26 existing + 6 new): module-level function and non-str constant
messages each covered for predicate-true (compiles) and predicate-false (raises
with the message), plus graph-break tests for an unsupported tensor message and a
bound-method message.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98