### PR TITLE
optimize split reduction heuristics on GB200

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -83,7 +83,6 @@ from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_FLASH_ATTENTION,
     PLATFORM_SUPPORTS_FP8,
     PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
-    SM100OrLater,
     SM80OrLater,
     SM90OrLater,
     TEST_CUDNN,
@@ -19370,11 +19369,6 @@ if RUN_GPU:
                 expected_divisible = {
                     # one kernel, with extra workspace/semaphore args
                     0: (0, 1, 2, 3, 5),
-                }
-            elif SM100OrLater:
-                self.assertEqual(len(kernels), 1)
-                expected_divisible = {
-                    0: (0, 1, 3),
                 }
             else:
                 self.assertEqual(len(kernels), 2)

--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -58,8 +58,10 @@ max_block: int = TRITON_MAX_BLOCK["X"]
 def _get_no_split_threshold() -> int:
     if torch.cuda.is_available():
         props = torch.cuda.get_device_properties(torch.cuda.current_device())
-        if props.major is not None and props.major >= 10:
-            return 524288
+        # These tests reduce the whole view to one output, so xnumel is 1.
+        return InductorChoices._inner_reduction_no_split_threshold(
+            props, xnumel=1, num_sm=props.multi_processor_count
+        )
     return 8192
 
 

--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -59,7 +59,7 @@ def _get_no_split_threshold() -> int:
     if torch.cuda.is_available():
         props = torch.cuda.get_device_properties(torch.cuda.current_device())
         # These tests reduce the whole view to one output, so xnumel is 1.
-        return InductorChoices._inner_reduction_no_split_threshold(
+        return V.choices._inner_reduction_no_split_threshold(
             props, xnumel=1, num_sm=props.multi_processor_count
         )
     return 8192

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -498,8 +498,8 @@ class InductorChoices:
             features.reduction_numel, threshold
         )  # type: ignore[arg-types]
 
-    @staticmethod
     def _inner_reduction_no_split_threshold(
+        self,
         props: DeviceProperties,
         xnumel: int,
         num_sm: int,
@@ -521,8 +521,8 @@ class InductorChoices:
             return 40960
         return 8192
 
-    @staticmethod
     def reduction_split_factor(
+        self,
         device: torch.device,
         reduction_numel_hint: int,
         numel_hint: int,
@@ -552,7 +552,7 @@ class InductorChoices:
             # we leak reduction autotune configs here, and will need to refactor to avoid this later
             if numel_hint >= 2 * num_sm:  # don't split if there are enough outputs
                 return 1
-            no_split_threshold = InductorChoices._inner_reduction_no_split_threshold(
+            no_split_threshold = self._inner_reduction_no_split_threshold(
                 props, numel_hint, num_sm
             )
             if reduction_numel_hint <= no_split_threshold:

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -499,6 +499,29 @@ class InductorChoices:
         )  # type: ignore[arg-types]
 
     @staticmethod
+    def _inner_reduction_no_split_threshold(
+        props: DeviceProperties,
+        xnumel: int,
+        num_sm: int,
+    ) -> int:
+        # Benchmark results from two scenarios:
+        # (1) Standalone ops/small models: CPU wall time measures end-to-end
+        #     latency and generally prefers a large no-split threshold.
+        # (2) Sections inside large compiled models: kernel/device time is the
+        #     local codegen signal and prefers the smaller xnumel-dependent
+        #     threshold. Kernel launch overhead is amortized by cuda-graph.
+        # Benchmarked ops: sum, entropy, RMSNorm, Welford, GroupNorm(+SiLU),
+        # plus Stable Diffusion v1.5 UNet batch-1/8 validation.
+        # Chosen GB200 thresholds: 32768 for xnumel < num_sm, otherwise 40960.
+        # Reducing these thresholds further did not improve scenario (2), but
+        # hurts scenario (1).
+        if props.major is not None and props.major >= 10:
+            if xnumel < num_sm:
+                return 32768
+            return 40960
+        return 8192
+
+    @staticmethod
     def reduction_split_factor(
         device: torch.device,
         reduction_numel_hint: int,
@@ -529,10 +552,8 @@ class InductorChoices:
             # we leak reduction autotune configs here, and will need to refactor to avoid this later
             if numel_hint >= 2 * num_sm:  # don't split if there are enough outputs
                 return 1
-            # based on sum(x[N]) on GB200, split reduction provides higher performance when N >= 1M
-            # TODO: test more hardwares
-            no_split_threshold = (
-                524288 if props.major is not None and props.major >= 10 else 8192
+            no_split_threshold = InductorChoices._inner_reduction_no_split_threshold(
+                props, numel_hint, num_sm
             )
             if reduction_numel_hint <= no_split_threshold:
                 return 1


### PR DESCRIPTION
Fix https://github.com/pytorch/pytorch/issues/188578

## Summary

- Add an `xnumel`-aware inner-reduction no-split threshold for GB200.
- Use `32768` when `xnumel < num_sm`, otherwise `40960`.
- Update affected Inductor tests for the new SM100 split behavior.

## Motivation

PR #179729 raised the Blackwell+ no-split threshold to `524288`, which helps
standalone/small-model CPU wall-time cases but regresses large CUDA-graph
workloads. In SD v1.5 UNet GroupNorm, `xnumel=32, rnumel=40960` benefits
significantly from splitting, while `xnumel=256, rnumel=40960` regresses when
split.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo