### PR TITLE
[dynamo] Add polyfills for operator.contains and operator.call

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -3910,6 +3910,27 @@ class GraphModule(torch.nn.Module):
         opt_fn = torch.compile(fn, fullgraph=True)
         self.assertEqual(opt_fn([1, 2, 3], [4, 5, 6]), [1, 2, 3, 4, 5, 6])
 
+    def test_operator_contains(self):
+        for seq_type in (list, tuple):
+            with self.subTest(seq_type=seq_type):
+
+                def fn(a, b):
+                    return operator.contains(a, b)
+
+                opt_fn = torch.compile(fn, fullgraph=True, backend="eager")
+                seq = seq_type([1, 2, 3])
+                self.assertEqual(opt_fn(seq, 2), fn(seq, 2))
+                self.assertEqual(opt_fn(seq, 99), fn(seq, 99))
+
+    @unittest.skipIf(sys.version_info < (3, 11), "operator.call added in Python 3.11")
+    def test_operator_call(self):
+        def fn(x):
+            return operator.call(torch.abs, x)
+
+        opt_fn = torch.compile(fn, fullgraph=True, backend="eager")
+        x = torch.randn(3, 4)
+        self.assertEqual(opt_fn(x), fn(x))
+
     def test_attrgetter(self):
         for attrs in (
             ("shape",),

--- a/torch/_dynamo/polyfills/operator.py
+++ b/torch/_dynamo/polyfills/operator.py
@@ -5,6 +5,7 @@ Python polyfills for operator
 from __future__ import annotations
 
 import operator
+import sys
 from typing import Any, overload, TYPE_CHECKING, TypeVar
 from typing_extensions import TypeVarTuple, Unpack
 
@@ -16,7 +17,7 @@ if TYPE_CHECKING:
 
 
 # Most unary and binary operators are handled by BuiltinVariable (e.g., `pos`, `add`)
-__all__ = ["attrgetter", "concat", "countOf", "iconcat", "itemgetter", "methodcaller"]
+__all__ = ["attrgetter", "concat", "contains", "countOf", "iconcat", "itemgetter", "methodcaller"]
 
 
 _T = TypeVar("_T")
@@ -75,6 +76,13 @@ def concat(a: Sequence[_T], b: Sequence[_T2], /) -> Sequence[_T | _T2]:
     return a + b  # type: ignore[operator]
 
 
+# Reference: https://docs.python.org/3/library/operator.html#operator.contains
+# Note: operands are reversed vs the `in` operator: contains(a, b) == (b in a)
+@substitute_in_graph(operator.contains, can_constant_fold_through=True)  # type: ignore[arg-type]
+def contains(a: Any, b: Any, /) -> bool:
+    return b in a
+
+
 # Reference: https://docs.python.org/3/library/operator.html#operator.countOf
 @substitute_in_graph(operator.countOf, can_constant_fold_through=True)  # type: ignore[arg-type,misc]
 def countOf(a: Iterable[_T], b: _T, /) -> int:
@@ -130,3 +138,14 @@ def methodcaller(name: str, /, *args: Any, **kwargs: Any) -> Callable[[Any], Any
         return getattr(obj, name)(*args, **kwargs)
 
     return caller
+
+
+# operator.call was added in Python 3.11
+if sys.version_info >= (3, 11):
+
+    # Reference: https://docs.python.org/3/library/operator.html#operator.call
+    @substitute_in_graph(operator.call)  # type: ignore[attr-defined,arg-type]
+    def call(obj: Callable[..., _U], /, *args: Any, **kwargs: Any) -> _U:
+        return obj(*args, **kwargs)
+
+    __all__ += ["call"]


### PR DESCRIPTION
Fixes part of #116396

## Summary

`operator.contains` and `operator.call` currently cause a graph break inside `torch.compile` regions because they are C builtins with no traceable Python implementation:

```
Failed to trace builtin operator contains with argument types [...]
```

This PR adds `substitute_in_graph` polyfills following the same pattern used for `operator.concat`, `operator.countOf`, `operator.attrgetter`, etc.

- **`operator.contains(a, b)`** — equivalent to `b in a` (note: reversed operands vs the `in` keyword). Marked `can_constant_fold_through=True` so Dynamo can evaluate it at compile time when both args are constants.
- **`operator.call(obj, /, *args, **kwargs)`** — equivalent to `obj(*args, **kwargs)`. Added in Python 3.11, so gated with `sys.version_info >= (3, 11)`.

## Test Plan

```bash
python test/dynamo/test_functions.py FunctionTests.test_operator_contains
python test/dynamo/test_functions.py FunctionTests.test_operator_call
```

Both new tests use `fullgraph=True` to confirm there are no graph breaks.

---
*This PR was authored with the assistance of an AI assistant.*

Made with [Cursor](https://cursor.com)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98