### PR TITLE
[DO NOT MERGE] Verify #188510 lint-urls fix on hud.pytorch.org

### DIFF
--- a/VERIFY_HUD_LINT_188510.md
+++ b/VERIFY_HUD_LINT_188510.md
@@ -1,0 +1,6 @@
+# Verification probe for pytorch/pytorch#188510
+
+This temporary file exists only to make the `lint-urls` check exercise a
+hud.pytorch.org URL after the #188518 fix landed. It will be removed.
+
+Probe URL: https://hud.pytorch.org/api/hud/pytorch/pytorch


### PR DESCRIPTION
Temporary verification PR. Adds a single `https://hud.pytorch.org` URL so the `Link checks / lint-urls` job exercises the path fixed in #188518. Will be closed once the lint-urls result is observed. Do not merge.