### PR TITLE
Fix misleading error for complex order in torch.linalg.cond

### DIFF
--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -3307,6 +3307,8 @@ static Tensor _linalg_cond_empty_matrix(const Tensor& self, c10::ScalarType dtyp
 static void _linalg_cond_check_ord(std::variant<Scalar, std::string_view> ord_variant) {
   if (ord_variant.index() == 0) {
     Scalar* ord = std::get_if<Scalar>(&ord_variant);
+    TORCH_CHECK(!at::isComplexType(ord->type()),
+      "linalg.cond: Expected a non-complex scalar as the order of norm.");
     double abs_ord = std::abs(ord->toDouble());
     TORCH_CHECK(abs_ord == 2.0 || abs_ord == 1.0 || abs_ord == INFINITY,
       "linalg.cond got an invalid norm type: ", ord->toDouble());

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -3307,14 +3307,14 @@ static Tensor _linalg_cond_empty_matrix(const Tensor& self, c10::ScalarType dtyp
 static void _linalg_cond_check_ord(std::variant<Scalar, std::string_view> ord_variant) {
   if (ord_variant.index() == 0) {
     Scalar* ord = std::get_if<Scalar>(&ord_variant);
-    TORCH_CHECK(!at::isComplexType(ord->type()),
+    TORCH_CHECK_VALUE(!at::isComplexType(ord->type()),
       "linalg.cond: Expected a non-complex scalar as the order of norm.");
     double abs_ord = std::abs(ord->toDouble());
-    TORCH_CHECK(abs_ord == 2.0 || abs_ord == 1.0 || abs_ord == INFINITY,
+    TORCH_CHECK_VALUE(abs_ord == 2.0 || abs_ord == 1.0 || abs_ord == INFINITY,
       "linalg.cond got an invalid norm type: ", ord->toDouble());
   } else if (ord_variant.index() == 1) {
     std::string_view* ord = std::get_if<std::string_view>(&ord_variant);
-    TORCH_CHECK(*ord == "fro" || *ord == "nuc",
+    TORCH_CHECK_VALUE(*ord == "fro" || *ord == "nuc",
       "linalg.cond got an invalid norm type: ", *ord);
   } else {
     TORCH_CHECK(false,

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1647,14 +1647,14 @@ class TestLinalg(TestCase):
         # check invalid norm type
         a = torch.ones(3, 3, dtype=dtype, device=device)
         for p in ['wrong_norm', 5]:
-            with self.assertRaisesRegex(RuntimeError, f"linalg.cond got an invalid norm type: {p}"):
+            with self.assertRaisesRegex(ValueError, f"linalg.cond got an invalid norm type: {p}"):
                 torch.linalg.cond(a, p)
 
         # a complex scalar is not a valid order of norm
         # https://github.com/pytorch/pytorch/issues/137466
         a = torch.ones(3, 3, dtype=dtype, device=device)
         for p in [1j, 2 + 2j]:
-            with self.assertRaisesRegex(RuntimeError, "Expected a non-complex scalar as the order of norm"):
+            with self.assertRaisesRegex(ValueError, "Expected a non-complex scalar as the order of norm"):
                 torch.linalg.cond(a, p)
 
     # This test calls torch.linalg.norm and numpy.linalg.norm with illegal arguments

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1650,6 +1650,13 @@ class TestLinalg(TestCase):
             with self.assertRaisesRegex(RuntimeError, f"linalg.cond got an invalid norm type: {p}"):
                 torch.linalg.cond(a, p)
 
+        # a complex scalar is not a valid order of norm
+        # https://github.com/pytorch/pytorch/issues/137466
+        a = torch.ones(3, 3, dtype=dtype, device=device)
+        for p in [1j, 2 + 2j]:
+            with self.assertRaisesRegex(RuntimeError, "Expected a non-complex scalar as the order of norm"):
+                torch.linalg.cond(a, p)
+
     # This test calls torch.linalg.norm and numpy.linalg.norm with illegal arguments
     # to ensure that they both throw errors
     @dtypes(torch.float, torch.double)


### PR DESCRIPTION
## Issue

Fixes #137466

## Summary

Passing a complex-valued `p` (order of norm) to `torch.linalg.cond` raised a
misleading `RuntimeError: value cannot be converted to type double without
overflow` instead of a clear message. As discussed in the issue, a complex
order of norm is not meaningful.

**Root cause:** `_linalg_cond_check_ord` in
`aten/src/ATen/native/LinearAlgebra.cpp` calls `Scalar::toDouble()` on `p`
*before* validating it. For a complex `Scalar` that conversion itself throws the
overflow error, so the existing "invalid norm type" check is never reached.

**Fix:** reject a complex `p` up front, mirroring the complex-order checks in
`linalg_matrix_norm` and `linalg_vector_norm`. The order-validation checks in
`_linalg_cond_check_ord` now use `TORCH_CHECK_VALUE`, so an invalid `ord` raises
`ValueError`, matching NumPy (`numpy.linalg.cond` raises `ValueError` for an
invalid order). The complex case now reports
`linalg.cond: Expected a non-complex scalar as the order of norm.`

## Test Plan

Extended `test_cond_errors_and_warnings` with a complex-`p` case. The test is
device- and dtype-generic (`instantiate_device_type_tests`,
`floating_and_complex_types`), so it covers real and complex inputs.

```
python test/test_linalg.py -k test_cond -v
```

All 8 instantiations pass. Before the fix the complex-`p` cases raised
`value cannot be converted to type double without overflow`; after, they raise
`linalg.cond: Expected a non-complex scalar as the order of norm.`, and the
existing `test_cond` numerics are unchanged.

## Checklist

- [x] Passes lint (`lintrunner`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No functional break: `torch.linalg.cond` rejects the same inputs as before. The
exception type for an invalid `ord` (including a complex one) is now `ValueError`
instead of `RuntimeError`, which aligns with NumPy. Valid `p` values (1, -1, 2,
-2, inf, -inf, "fro", "nuc", None) are unaffected.