### PR TITLE
[ROCm] Add skipIfRocmVersionAtLeast([7, 14]) skips for ROCm 7.14 known failures

### DIFF
--- a/.ci/docker/common/install_rocm.sh
+++ b/.ci/docker/common/install_rocm.sh
@@ -46,6 +46,7 @@ install_ubuntu() {
       fi
 
       # Auto-detect latest nightly version if not pinned
+      THEROCK_VERSION=7.14.0
       VERSION="${THEROCK_VERSION:-}"
       if [[ -z "${VERSION}" ]]; then
         VERSION=$(curl -fsSL "https://rocm.nightlies.amd.com/tarball/" \
@@ -62,7 +63,7 @@ install_ubuntu() {
       # URL-encode '+' as '%2B' in VERSION (required for devreleases)
       VERSION_ENCODED="${VERSION//+/%2B}"
 
-      TARBALL_URL="https://rocm.nightlies.amd.com/tarball/therock-dist-linux-${AMDGPU_FAMILY}-${VERSION_ENCODED}.tar.gz"
+      TARBALL_URL="https://repo.amd.com/rocm/tarball-multi-arch/therock-dist-linux-multiarch-${VERSION_ENCODED}.tar.gz"
 
       echo "=============================================="
       echo "ROCm Tarball Installation"
@@ -105,7 +106,7 @@ install_ubuntu() {
 
       # Verify bin and lib folder exists after extraction
       echo "Verifying installation..."
-      for dir in bin clients include lib libexec share; do
+      for dir in bin include lib libexec share; do
         if [ ! -d "$ROCM_INSTALL_DIR/$dir" ]; then
           echo "Error: ROCm $dir directory not found"
           exit 1

--- a/.ci/docker/common/install_rocm.sh
+++ b/.ci/docker/common/install_rocm.sh
@@ -46,7 +46,6 @@ install_ubuntu() {
       fi
 
       # Auto-detect latest nightly version if not pinned
-      THEROCK_VERSION=7.14.0
       VERSION="${THEROCK_VERSION:-}"
       if [[ -z "${VERSION}" ]]; then
         VERSION=$(curl -fsSL "https://rocm.nightlies.amd.com/tarball/" \
@@ -63,7 +62,7 @@ install_ubuntu() {
       # URL-encode '+' as '%2B' in VERSION (required for devreleases)
       VERSION_ENCODED="${VERSION//+/%2B}"
 
-      TARBALL_URL="https://repo.amd.com/rocm/tarball-multi-arch/therock-dist-linux-multiarch-${VERSION_ENCODED}.tar.gz"
+      TARBALL_URL="https://rocm.nightlies.amd.com/tarball/therock-dist-linux-${AMDGPU_FAMILY}-${VERSION_ENCODED}.tar.gz"
 
       echo "=============================================="
       echo "ROCm Tarball Installation"
@@ -106,7 +105,7 @@ install_ubuntu() {
 
       # Verify bin and lib folder exists after extraction
       echo "Verifying installation..."
-      for dir in bin include lib libexec share; do
+      for dir in bin clients include lib libexec share; do
         if [ ! -d "$ROCM_INSTALL_DIR/$dir" ]; then
           echo "Error: ROCm $dir directory not found"
           exit 1

--- a/.github/workflows/rocm-nightly.yml
+++ b/.github/workflows/rocm-nightly.yml
@@ -49,12 +49,14 @@ jobs:
       docker-image-name: ci-image:pytorch-linux-noble-rocm-nightly-py3
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 2, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 3, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 4, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 5, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 6, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 1, num_shards: 8, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 2, num_shards: 8, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 3, num_shards: 8, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 4, num_shards: 8, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 5, num_shards: 8, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 6, num_shards: 8, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 7, num_shards: 8, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 8, num_shards: 8, runner: "linux.rocm.gpu.gfx950.1" },
           { config: "distributed", shard: 1, num_shards: 3, runner: "linux.rocm.gpu.gfx950.2", owners: ["module:rocm", "oncall:distributed"] },
           { config: "distributed", shard: 2, num_shards: 3, runner: "linux.rocm.gpu.gfx950.2", owners: ["module:rocm", "oncall:distributed"] },
           { config: "distributed", shard: 3, num_shards: 3, runner: "linux.rocm.gpu.gfx950.2", owners: ["module:rocm", "oncall:distributed"] },

--- a/.github/workflows/rocm-nightly.yml
+++ b/.github/workflows/rocm-nightly.yml
@@ -49,14 +49,12 @@ jobs:
       docker-image-name: ci-image:pytorch-linux-noble-rocm-nightly-py3
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 8, runner: "linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 2, num_shards: 8, runner: "linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 3, num_shards: 8, runner: "linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 4, num_shards: 8, runner: "linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 5, num_shards: 8, runner: "linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 6, num_shards: 8, runner: "linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 7, num_shards: 8, runner: "linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 8, num_shards: 8, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 1, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 2, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 3, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 4, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 5, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 6, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
           { config: "distributed", shard: 1, num_shards: 3, runner: "linux.rocm.gpu.gfx950.2", owners: ["module:rocm", "oncall:distributed"] },
           { config: "distributed", shard: 2, num_shards: 3, runner: "linux.rocm.gpu.gfx950.2", owners: ["module:rocm", "oncall:distributed"] },
           { config: "distributed", shard: 3, num_shards: 3, runner: "linux.rocm.gpu.gfx950.2", owners: ["module:rocm", "oncall:distributed"] },

--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -42,6 +42,7 @@ from torch.distributed.tensor.debug import CommDebugMode
 from torch.testing._internal.common_distributed import (
     skip_if_lt_x_gpu,
     skip_if_rocm_arch_multiprocess,
+    skip_if_rocm_ver_atleast_multiprocess,
 )
 from torch.testing._internal.common_fsdp import (
     check_sharded_parity,
@@ -738,6 +739,7 @@ class TestFullyShard1DTrainingCore(FSDPTest):
         not hasattr(torch.get_device_module(device_type), "_sleep"),
         "Sleep is not supported on this device",
     )
+    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
     def test_post_optim_event(self):
         torch.manual_seed(42)
         model_args = ModelArgs(dropout_p=0.0)

--- a/test/distributed/_composable/test_replicate_with_compiler.py
+++ b/test/distributed/_composable/test_replicate_with_compiler.py
@@ -28,6 +28,7 @@ from torch.nn.parallel.distributed import DistributedDataParallel as DDP
 from torch.testing._internal.common_distributed import (
     DistributedTestBase,
     skip_if_lt_x_gpu,
+    skip_if_rocm_ver_atleast_multiprocess,
     sm_is_or_higher_than,
 )
 from torch.testing._internal.common_fsdp import get_devtype
@@ -197,6 +198,7 @@ class ReplicateTest(MultiProcessInductorTestCase):
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @skip_if_lt_x_gpu(2)
+    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
     @torch._inductor.config.patch(
         reorder_for_locality=False, reorder_for_peak_memory=False
     )
@@ -233,6 +235,7 @@ class ReplicateTest(MultiProcessInductorTestCase):
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @skip_if_lt_x_gpu(2)
+    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
     def test_compile_fp16(self):
         def setup(model, compiled_replicate_model, compiled_ddp_model) -> None:
             model.register_comm_hook(None, ddp_default_hooks.fp16_compress_hook)

--- a/test/distributed/launcher/test_run.py
+++ b/test/distributed/launcher/test_run.py
@@ -28,6 +28,9 @@ from torch.distributed.elastic.multiprocessing import DefaultLogsSpecs
 from torch.distributed.elastic.multiprocessing.errors import ChildFailedError
 from torch.distributed.elastic.utils import get_socket_with_port
 from torch.distributed.elastic.utils.distributed import get_free_port
+from torch.testing._internal.common_distributed import (
+    skip_if_rocm_ver_atleast_multiprocess,
+)
 from torch.testing._internal.common_utils import (
     run_tests,
     skip_but_pass_in_sandcastle_if,
@@ -692,6 +695,7 @@ class ElasticLaunchTest(TestCase):
     # happens via torchrun, not MultiProcessTestCase, so the conftest heuristic
     # (see test/conftest.py) can't detect it; mark it multigpu explicitly.
     @pytest.mark.multigpu
+    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
     def test_virtual_local_rank(self):
         """
         Test that virtual-local-rank ensures consistent device IDs across ranks.

--- a/test/distributed/tensor/test_attention.py
+++ b/test/distributed/tensor/test_attention.py
@@ -56,7 +56,10 @@ from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_FUSED_ATTENTION,
     PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
 )
-from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+from torch.testing._internal.common_distributed import (
+    skip_if_lt_x_gpu,
+    skip_if_rocm_ver_atleast_multiprocess,
+)
 from torch.testing._internal.common_utils import run_tests, skipIfRocm, TestCase
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
@@ -681,6 +684,7 @@ class CPFlexAttentionTest(DTensorTestBase):
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Does not support flash attention"
     )
+    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
     def test_cp_flex_attention_causal_mask(self) -> None:
         seq_length_list = [256 * self.world_size, 2048]
         load_balance_type_list = [
@@ -748,6 +752,7 @@ class CPFlexAttentionTest(DTensorTestBase):
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Does not support flash attention"
     )
+    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
     def test_cp_flex_attention_document_mask(self) -> None:
         random.seed(10)
 

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -61,6 +61,7 @@ from torch.testing._internal.common_distributed import (
     requires_nccl_version,
     requires_world_size,
     skip_if_lt_x_gpu,
+    skip_if_rocm_ver_atleast_multiprocess,
     sm_is_or_higher_than,
     TEST_SKIPS,
     with_dist_debug_levels,
@@ -4990,6 +4991,7 @@ class CommTest(test_c10d_common.AbstractCommTest, MultiProcessTestCase):
 
     @requires_nccl()
     @skip_if_lt_x_gpu(2)
+    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
     @parametrize("use_python_export", [False, True])
     def test_profiler_nccl_annotations_on_gpu_kernels(self, use_python_export):
         store = c10d.FileStore(self.file_name, self.world_size)

--- a/test/distributed/test_c10d_nccl2.py
+++ b/test/distributed/test_c10d_nccl2.py
@@ -10,6 +10,7 @@ from torch.testing._internal.common_distributed import (
     MultiProcContinuousTest,
     requires_nccl,
     skip_if_lt_x_gpu,
+    skip_if_rocm_ver_atleast_multiprocess,
 )
 from torch.testing._internal.common_utils import run_tests, TEST_CUDA
 
@@ -126,6 +127,7 @@ class ProcessGroupNCCL2ExpandableSegmentsTest(MultiProcContinuousTest):
 
     @requires_nccl()
     @skip_if_lt_x_gpu(2)
+    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
     def test_large_in_place_all_gather(self) -> None:
         numel = 16 * 1024 * 1024
         output = torch.empty(

--- a/test/distributed/test_c10d_window.py
+++ b/test/distributed/test_c10d_window.py
@@ -19,7 +19,10 @@ if not dist.is_available():
     print("distributed package not available, skipping tests", file=sys.stderr)
     sys.exit(0)
 
-from torch.testing._internal.common_distributed import MultiProcessTestCase, skip_if_rocm_ver_atleast_multiprocess
+from torch.testing._internal.common_distributed import (
+    MultiProcessTestCase,
+    skip_if_rocm_ver_atleast_multiprocess,
+)
 from torch.testing._internal.common_utils import run_tests, TEST_CUDA
 
 

--- a/test/distributed/test_c10d_window.py
+++ b/test/distributed/test_c10d_window.py
@@ -19,7 +19,7 @@ if not dist.is_available():
     print("distributed package not available, skipping tests", file=sys.stderr)
     sys.exit(0)
 
-from torch.testing._internal.common_distributed import MultiProcessTestCase
+from torch.testing._internal.common_distributed import MultiProcessTestCase, skip_if_rocm_ver_atleast_multiprocess
 from torch.testing._internal.common_utils import run_tests, TEST_CUDA
 
 
@@ -183,6 +183,7 @@ class AbstractWindowTest:
         self.assertIsInstance(attr.access_type, WindowAccessType)
         win.tensor_deregister()
 
+    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
     def test_register_errors(self):
         self._init_pg()
         pool = self._make_pool()

--- a/test/distributed/test_ce_colls.py
+++ b/test/distributed/test_ce_colls.py
@@ -8,6 +8,7 @@ from torch.testing._internal.common_distributed import (
     MultiProcContinuousTest,
     requires_nccl_version,
     skip_if_lt_x_gpu,
+    skip_if_rocm_ver_atleast_multiprocess,
 )
 from torch.testing._internal.common_utils import requires_cuda_p2p_access, run_tests
 
@@ -60,6 +61,7 @@ class NCCLCopyEngineCollectives(MultiProcContinuousTest):
         return group_name, prof
 
     @skip_if_lt_x_gpu(2)
+    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
     def test_ce_allgather(self):
         group_name, prof = self._init()
         dtype = torch.float
@@ -103,6 +105,7 @@ class NCCLCopyEngineCollectives(MultiProcContinuousTest):
         #     prof.export_chrome_trace("test_ce_allgather.json")
 
     @skip_if_lt_x_gpu(2)
+    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
     def test_ce_alltoall(self):
         group_name, prof = self._init()
         dtype = torch.float

--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -429,6 +429,7 @@ class SymmetricMemoryTest(MultiProcContinuousTest):
         not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
     )
     @skip_if_lt_x_gpu(2)
+    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
     @parametrize("symm_mem_input", [True, False])
     def test_low_contention_all_gather(self, symm_mem_input: bool) -> None:
         self._init_process()
@@ -704,6 +705,7 @@ class SymmetricMemoryTest(MultiProcContinuousTest):
         not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
     )
     @skip_if_lt_x_gpu(2)
+    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
     def test_dispatcher_torchbind_symmetric_memory(self) -> None:
         self._init_process()
         group_name = dist.group.WORLD.group_name

--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -228,6 +228,7 @@ class SymmetricMemoryTest(MultiProcContinuousTest):
         not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
     )
     @skip_if_lt_x_gpu(2)
+    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
     def test_get_signal_pad(self) -> None:
         self._init_process()
 
@@ -292,6 +293,7 @@ class SymmetricMemoryTest(MultiProcContinuousTest):
         not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
     )
     @skip_if_lt_x_gpu(2)
+    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
     def test_rendezvous_via_pg_allgather(self) -> None:
         import pickle
 
@@ -339,6 +341,7 @@ class SymmetricMemoryTest(MultiProcContinuousTest):
         not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
     )
     @skip_if_lt_x_gpu(2)
+    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
     def test_rendezvous_custom_backend(self) -> None:
         # Simulate the ncclx multi-backend setup.  NCCLXStub wraps NCCL
         # (CUDA-only, like ncclx) and registers via extended_api=True.
@@ -403,6 +406,7 @@ class SymmetricMemoryTest(MultiProcContinuousTest):
         not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
     )
     @skip_if_lt_x_gpu(2)
+    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
     def test_pg_rendezvous_abort_after(self) -> None:
         self._init_process()
 
@@ -551,6 +555,7 @@ class SymmetricMemoryTest(MultiProcContinuousTest):
         not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
     )
     @skip_if_lt_x_gpu(2)
+    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
     @parametrize("reduce_op", ["sum", "avg"])
     @parametrize("symm_mem_input", [True, False])
     def test_low_contention_reduce_scatter(
@@ -1156,6 +1161,7 @@ class SymmMemEmptySetDeviceTest(MultiProcessTestCase):
         not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
     )
     @skip_if_lt_x_gpu(2)
+    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
     @parametrize("set_device", [True, False])
     def test_empty_strided_p2p(self, set_device: bool) -> None:
         self._init_process(set_device)
@@ -1177,6 +1183,7 @@ class SymmMemEmptySetDeviceTest(MultiProcessTestCase):
     )
     @skip_if_rocm_ver_lessthan_multiprocess((7, 0))
     @skip_if_lt_x_gpu(2)
+    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
     @parametrize("set_device", [True, False])
     def test_empty_strided_p2p_persistent(self, set_device: bool) -> None:
         self._init_process(set_device)
@@ -2305,6 +2312,7 @@ class SymmMemPoolTest(MultiProcContinuousTest):
         not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
     )
     @skip_if_lt_x_gpu(2)
+    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
     def test_mempool_compute_ops(self):
         self._init_process()
         group_name = dist.group.WORLD.group_name

--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -49,6 +49,7 @@ from torch.testing._internal.common_distributed import (
     setup_torchcomms_pg,
     skip_if_lt_x_gpu,
     skip_if_rocm_multiprocess,
+    skip_if_rocm_ver_atleast_multiprocess,
     skip_if_rocm_ver_lessthan_multiprocess,
 )
 from torch.testing._internal.common_utils import (
@@ -1475,6 +1476,7 @@ class SymmMemCollectiveTest(MultiProcContinuousTest):
         not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
     )
     @skip_if_lt_x_gpu(4)
+    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
     def test_two_shot_all_reduce(self) -> None:
         self._init_process()
         group_name = dist.group.WORLD.group_name

--- a/test/export/test_export_opinfo.py
+++ b/test/export/test_export_opinfo.py
@@ -23,6 +23,7 @@ from torch.testing._internal.common_utils import (
     IS_WINDOWS,
     run_tests,
     skipIfRocm,
+    skipIfRocmVersionAtLeast,
     TestCase,
 )
 from torch.utils import _pytree as pytree
@@ -145,6 +146,7 @@ selected_ops = {
 selected_op_db = [op for op in op_db if op.name in selected_ops]
 
 
+@skipIfRocmVersionAtLeast([7, 14])
 class TestExportOnFakeCuda(TestCase):
     # In CI, this test runs on a CUDA machine with cuda build
     # We set CUDA_VISIBLE_DEVICES="" to simulate a CPU machine with cuda build

--- a/test/inductor/test_ck_backend.py
+++ b/test/inductor/test_ck_backend.py
@@ -18,6 +18,8 @@ from torch.testing._internal.common_cuda import tf32_off
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
+    skipIfRocmVersionAtLeast,
+    subtest,
 )
 from torch.testing._internal.inductor_utils import (
     _quantize_rowwise,
@@ -67,7 +69,11 @@ class TestCKBackend(TestCase):
     @unittest.mock.patch.dict(os.environ, _test_env)
     @parametrize(
         "max_autotune_gemm_backends",
-        ("CK", "CKTILE", "ATen,CK"),
+        (
+            subtest("CK", decorators=[skipIfRocmVersionAtLeast([7, 14])]),
+            subtest("CKTILE", decorators=[skipIfRocmVersionAtLeast([7, 14])]),
+            "ATen,CK",
+        ),
         name_fn=lambda b: {
             "CK": "standalone_ck",
             "CKTILE": "standalone_cktile",
@@ -128,7 +134,7 @@ class TestCKBackend(TestCase):
     @unittest.mock.patch.dict(os.environ, _test_env)
     @parametrize(
         "max_autotune_gemm_backends",
-        ("CK", "ATen,CK"),
+        (subtest("CK", decorators=[skipIfRocmVersionAtLeast([7, 14])]), "ATen,CK"),
         name_fn=lambda b: "standalone" if b == "CK" else "fallback",
     )
     @parametrize("autotune_in_subproc", (True,))
@@ -236,7 +242,7 @@ class TestCKBackend(TestCase):
     @unittest.mock.patch.dict(os.environ, _test_env)
     @parametrize(
         "max_autotune_gemm_backends",
-        ("CK", "ATen,CK"),
+        (subtest("CK", decorators=[skipIfRocmVersionAtLeast([7, 14])]), "ATen,CK"),
         name_fn=lambda b: "standalone" if b == "CK" else "fallback",
     )
     def test_max_autotune_precompile_preselected(self, max_autotune_gemm_backends):
@@ -315,7 +321,7 @@ class TestCKBackend(TestCase):
     @unittest.mock.patch.dict(os.environ, _test_env)
     @parametrize(
         "max_autotune_gemm_backends",
-        ("CK", "ATen,CK"),
+        (subtest("CK", decorators=[skipIfRocmVersionAtLeast([7, 14])]), "ATen,CK"),
         name_fn=lambda b: "standalone" if b == "CK" else "fallback",
     )
     @parametrize(
@@ -467,7 +473,7 @@ class TestCKBackend(TestCase):
     )
     @parametrize(
         "max_autotune_conv_backends",
-        ("CK", "ATEN,CK"),
+        (subtest("CK", decorators=[skipIfRocmVersionAtLeast([7, 14])]), "ATEN,CK"),
         name_fn=lambda b: "standalone" if b == "CK" else "fallback",
     )
     def test_max_autotune_conv2d(self, max_autotune_conv_backends):
@@ -508,7 +514,7 @@ class TestCKBackend(TestCase):
     @unittest.mock.patch.dict(os.environ, _test_env)
     @parametrize(
         "max_autotune_gemm_backends",
-        ("CK", "ATen,CK"),
+        (subtest("CK", decorators=[skipIfRocmVersionAtLeast([7, 14])]), "ATen,CK"),
         name_fn=lambda b: "standalone" if b == "CK" else "fallback",
     )
     def test_max_autotune_precompile_bmm(

--- a/test/inductor/test_gpu_cpp_wrapper.py
+++ b/test/inductor/test_gpu_cpp_wrapper.py
@@ -29,6 +29,7 @@ from torch.testing._internal.common_utils import (
     IS_SANDCASTLE,
     IS_WINDOWS,
     parametrize,
+    skipIfRocmVersionAtLeast,
     skipIfXpu,
     slowTest,
 )
@@ -522,6 +523,8 @@ class TestGpuWrapper(InductorTestCase):
         self.assertEqual(actual, expected)
         self.assertIn("needs_vec_isa=False", code)
 
+    # The vec-ISA probe child cannot resolve ROCm SDK libraries in CI.
+    @skipIfRocmVersionAtLeast([7, 14])
     def test_cuda_cpp_wrapper_keeps_vec_isa_for_host_vectorized_code(self):
         if not RUN_GPU:
             self.skipTest("GPU not available")

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -21303,7 +21303,9 @@ if RUN_GPU:
                 "'XBLOCK': 'constexpr'"
             ).run(code[0])
 
-        @skipIfRocmVersionAtLeast([7, 14])  # ck/config.h missing on ROCm 7.14+ wheel stack
+        @skipIfRocmVersionAtLeast(
+            [7, 14]
+        )  # ck/config.h missing on ROCm 7.14+ wheel stack
         @unittest.skipIf(
             not (IS_SM90 or (TEST_WITH_ROCM and PLATFORM_SUPPORTS_FP8)),
             "no scaled_grouped_mm support",

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -124,6 +124,7 @@ from torch.testing._internal.common_utils import (
     skipIfNoLapack,
     skipIfRocm,
     skipIfRocmArch,
+    skipIfRocmVersionAtLeast,
     skipIfTorchInductor,
     skipIfWindows,
     skipIfXpu,
@@ -21302,6 +21303,7 @@ if RUN_GPU:
                 "'XBLOCK': 'constexpr'"
             ).run(code[0])
 
+        @skipIfRocmVersionAtLeast([7, 14])  # ck/config.h missing on ROCm 7.14+ wheel stack
         @unittest.skipIf(
             not (IS_SM90 or (TEST_WITH_ROCM and PLATFORM_SUPPORTS_FP8)),
             "no scaled_grouped_mm support",

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6337,6 +6337,9 @@ for dtype in (torch.int32, torch.int64):
     )
     @parametrize("nhwc", (False, True))
     @with_tf32_off
+    @skipIfRocmVersionAtLeast(
+        [7, 14]
+    )  # ROCm 7.14+ Triton conv2d backward accuracy issue in this UT family
     def test_conv2d_backward_parametrized(
         self,
         channels_groups: list,

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -33,6 +33,7 @@ from torch.testing._internal.common_utils import (
     parametrize,
     serialTest,
     skipIfRocmArch,
+    skipIfRocmVersionAtLeast,
     TEST_CUDA_MEM_LEAK_CHECK,
     TEST_WITH_ASAN,
 )
@@ -198,6 +199,16 @@ if HAS_CPU:
                 self.assertEqual(actual[1], expected[1])
 
     copy_tests(DynamicShapesCommonTemplate, DynamicShapesCpuTests, "cpu", test_failures)
+
+    if hasattr(
+        DynamicShapesCpuTests, "test_tmp_not_defined_issue3_dynamic_shapes_cpu"
+    ):
+        # The vec-ISA probe child cannot resolve ROCm SDK libraries in CI.
+        DynamicShapesCpuTests.test_tmp_not_defined_issue3_dynamic_shapes_cpu = (
+            skipIfRocmVersionAtLeast([7, 14])(
+                DynamicShapesCpuTests.test_tmp_not_defined_issue3_dynamic_shapes_cpu
+            )
+        )
 
 
 if (HAS_GPU or HAS_MPS) and not TEST_WITH_ASAN:

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -200,9 +200,7 @@ if HAS_CPU:
 
     copy_tests(DynamicShapesCommonTemplate, DynamicShapesCpuTests, "cpu", test_failures)
 
-    if hasattr(
-        DynamicShapesCpuTests, "test_tmp_not_defined_issue3_dynamic_shapes_cpu"
-    ):
+    if hasattr(DynamicShapesCpuTests, "test_tmp_not_defined_issue3_dynamic_shapes_cpu"):
         # The vec-ISA probe child cannot resolve ROCm SDK libraries in CI.
         DynamicShapesCpuTests.test_tmp_not_defined_issue3_dynamic_shapes_cpu = (
             skipIfRocmVersionAtLeast([7, 14])(

--- a/test/inductor/test_torchinductor_opinfo_properties.py
+++ b/test/inductor/test_torchinductor_opinfo_properties.py
@@ -54,11 +54,13 @@ from torch.testing._internal.common_methods_invocations import (
     unary_ufuncs,
 )
 from torch.testing._internal.common_utils import (
+    getRocmVersion,
     IS_FBCODE,
     IS_WINDOWS,
     parametrize,
     skipIfTorchDynamo,
     TEST_WITH_ASAN,
+    TEST_WITH_ROCM,
 )
 from torch.testing._internal.inductor_utils import HAS_GPU
 from torch.testing._internal.opinfo.core import _filter_unary_elementwise_tensor
@@ -946,6 +948,14 @@ class TestOpInfoProperties(TestCase):
 
         Verifies bitwise equivalence between eager and compiled execution.
         """
+        if (
+            TEST_WITH_ROCM
+            and getRocmVersion() >= (7, 14)
+            and op.name == "log10"
+            and dtype in (torch.float16, torch.float32)
+            and backend in ("inductor_default", "inductor_numerics")
+        ):
+            self.skipTest("known log10 eager-vs-compiled failure on ROCm 7.14")
         torch._dynamo.reset()
         device_type = torch.device(device).type
 

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -58,6 +58,7 @@ from torch.testing._internal.common_utils import (
     run_tests,
     serialTest,
     set_default_dtype,
+    skipIfRocmVersionAtLeast,
     subtest,
     TEST_SCIPY,
     TEST_WITH_ROCM,
@@ -3299,6 +3300,7 @@ class TestConvolutionNNDeviceType(NNTestCase):
             out2 = conv1(input_c)
             self.assertEqual(out1, out2)
 
+    @skipIfRocmVersionAtLeast([7, 14])
     @onlyAccelerator
     @largeTensorTest("12GB")
     @serialTest()

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -627,11 +627,7 @@ print(t.is_pinned())
         IS_JETSON, "oom reporting has issues on jetson igx due to partial nvml support"
     )
     def test_out_of_memory(self):
-        if (
-            TEST_WITH_ROCM
-            and getRocmVersion() >= (7, 14)
-            and EXPANDABLE_SEGMENTS
-        ):
+        if TEST_WITH_ROCM and getRocmVersion() >= (7, 14) and EXPANDABLE_SEGMENTS:
             self.skipTest(
                 "TestCuda.test_out_of_memory: OOM tensor flag is False on ROCm "
                 "expandable segments (7.14+)"

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -687,6 +687,12 @@ print(t.is_pinned())
         IS_JETSON, "oom reporting has issues on jetson igx due to partial nvml support"
     )
     def test_set_per_process_memory_fraction(self):
+        if TEST_WITH_ROCM and getRocmVersion() >= (7, 14) and EXPANDABLE_SEGMENTS:
+            self.skipTest(
+                "ROCm 7.14+ expandable segments reports OOM below the expected "
+                "per-process memory fraction limit"
+            )
+
         torch.cuda.empty_cache()
         orig = torch.cuda.get_per_process_memory_fraction(0)
         torch.cuda.reset_peak_memory_stats(0)
@@ -9483,6 +9489,12 @@ class TestMemPool(TestCase):
           1. Default pool -- OOM recovery releases cached blocks, succeeds.
           2. use_mem_pool -- same recovery should work (the fix).
         """
+        if TEST_WITH_ROCM and getRocmVersion() >= (7, 14) and EXPANDABLE_SEGMENTS:
+            self.skipTest(
+                "ROCm 7.14+ expandable segments OOMs before mempool cached "
+                "blocks can be recovered"
+            )
+
         MB = 1024 * 1024
         device = torch.device("cuda:0")
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -7255,6 +7255,7 @@ print(value, end="")
         finally:
             random.setstate(state)
 
+    @skipIfRocmVersionAtLeast([7, 14])
     @unittest.skipIf(not TEST_PYNVML, "pynvml/amdsmi is not available")
     def test_nvml_get_handler(self):
         if not torch.version.hip:
@@ -7262,10 +7263,12 @@ print(value, end="")
         else:
             self.assertTrue(torch.cuda._get_amdsmi_handler() is not None)
 
+    @skipIfRocmVersionAtLeast([7, 14])
     @unittest.skipIf(not TEST_PYNVML, "pynvml/amdsmi is not available")
     def test_temperature(self):
         self.assertTrue(0 <= torch.cuda.temperature() <= 150)
 
+    @skipIfRocmVersionAtLeast([7, 14])
     @unittest.skipIf(not TEST_PYNVML, "pynvml/amdsmi is not available")
     def test_device_memory_used(self):
         """
@@ -7299,14 +7302,17 @@ print(value, end="")
             # test the order of magnitude
             self.assertTrue(num_bytes // 32 <= mem_bytes <= num_bytes * 32)
 
+    @skipIfRocmVersionAtLeast([7, 14])
     @unittest.skipIf(not TEST_PYNVML, "pynvml/amdsmi is not available")
     def test_power_draw(self):
         self.assertTrue(torch.cuda.power_draw() >= 0)
 
+    @skipIfRocmVersionAtLeast([7, 14])
     @unittest.skipIf(not TEST_PYNVML, "pynvml/amdsmi is not available")
     def test_clock_speed(self):
         self.assertTrue(torch.cuda.clock_rate() >= 0)
 
+    @skipIfRocmVersionAtLeast([7, 14])
     @unittest.skipIf(not TEST_PYNVML, "pynvml/amdsmi is not available")
     @unittest.skipIf(not TEST_WITH_ROCM, "amdsmi specific test")
     def test_raw_amdsmi_device_count(self):

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -70,6 +70,7 @@ from torch.testing._internal.common_utils import (
     freeze_rng_state,
     gcIfJetson,
     get_cycles_per_ms,
+    getRocmVersion,
     instantiate_parametrized_tests,
     IS_ARM64,
     IS_FBCODE,
@@ -91,6 +92,7 @@ from torch.testing._internal.common_utils import (
     skipCUDANonDefaultStreamIf,
     skipIfRocm,
     skipIfRocmArch,
+    skipIfRocmVersionAtLeast,
     skipIfRocmVersionLessThan,
     slowTest,
     subtest,
@@ -625,6 +627,15 @@ print(t.is_pinned())
         IS_JETSON, "oom reporting has issues on jetson igx due to partial nvml support"
     )
     def test_out_of_memory(self):
+        if (
+            TEST_WITH_ROCM
+            and getRocmVersion() >= (7, 14)
+            and EXPANDABLE_SEGMENTS
+        ):
+            self.skipTest(
+                "TestCuda.test_out_of_memory: OOM tensor flag is False on ROCm "
+                "expandable segments (7.14+)"
+            )
         tensor = torch.zeros(1024, device="cuda")
 
         oom_regex = (
@@ -5625,6 +5636,7 @@ with torch.cuda.graph(g):
             self.assertEqual(rc, "3")
 
     @unittest.skipIf(not TEST_WITH_ROCM, "not relevant for CUDA testing")
+    @skipIfRocmVersionAtLeast([7, 14])
     def test_hip_device_count(self):
         """Validate device_count works with both CUDA/HIP visible devices"""
         test_script = """\
@@ -6996,6 +7008,7 @@ class TestCudaAllocator(TestCase):
                 "throw_on_cudamalloc_oom:False,per_process_memory_fraction:1.0"
             )
 
+    @skipIfRocmVersionAtLeast([7, 14])
     def test_allocator_backend(self):
         def subprocess_env():
             if IS_WINDOWS:

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -27,7 +27,7 @@ from torch.testing._internal.common_utils import \
      TEST_WITH_ROCM, IS_FBCODE, IS_REMOTE_GPU, iter_indices,
      make_fullrank_matrices_with_distinct_singular_values,
      freeze_rng_state, IS_ARM64, IS_SANDCASTLE, TEST_OPT_EINSUM, isRocmArchAnyOf, parametrize, skipIfTorchDynamo,
-     skipIfRocmArch, setBlasBackendsToDefaultFinally, setLinalgBackendsToDefaultFinally, serialTest, skipIfRocm,
+     skipIfRocmArch, skipIfRocmVersionAtLeast, setBlasBackendsToDefaultFinally, setLinalgBackendsToDefaultFinally, serialTest, skipIfRocm,
      runOnRocmArch, MI200_ARCH, MI300_ARCH, MI350_ARCH, NAVI_ARCH, TEST_CUDA,
      skipIfNoNvmath)
 from torch.testing._internal.common_device_type import \
@@ -3077,6 +3077,7 @@ class TestLinalg(TestCase):
 
     @skipCUDAIfNoCusolver
     @skipCPUIfNoLapack
+    @skipIfRocmVersionAtLeast([7, 14])
     @dtypes(*floating_and_complex_types())
     @precisionOverride({torch.float32: 1e-3, torch.complex64: 1e-3,
                         torch.float64: 1e-8, torch.complex128: 1e-8})

--- a/test/test_multiprocessing.py
+++ b/test/test_multiprocessing.py
@@ -25,6 +25,7 @@ from torch.testing._internal.common_utils import (
     load_tests,
     run_tests,
     skipIfRocm,
+    skipIfRocmVersionAtLeast,
     slowTest,
     TEST_WITH_ASAN,
     TEST_WITH_ROCM,
@@ -646,6 +647,8 @@ class TestMultiprocessing(_MultiprocessingTestMixin, TestCase):
     def test_fd_pool(self):
         self._test_pool(repeat=TEST_REPEATS)
 
+    # torch_shm_manager cannot resolve librocprofiler-sdk.so.1 in CI child processes.
+    @skipIfRocmVersionAtLeast([7, 14])
     @unittest.skipIf(
         TEST_WITH_ASAN,
         "seems to hang with ASAN, see https://github.com/pytorch/pytorch/issues/5326",
@@ -657,14 +660,17 @@ class TestMultiprocessing(_MultiprocessingTestMixin, TestCase):
             repeat = 1 if IS_MACOS else TEST_REPEATS
             self._test_sharing(repeat=repeat)
 
+    @skipIfRocmVersionAtLeast([7, 14])
     def test_fs_preserve_sharing(self):
         with fs_sharing():
             self._test_preserve_sharing(repeat=TEST_REPEATS)
 
+    @skipIfRocmVersionAtLeast([7, 14])
     def test_fs_pool(self):
         with fs_sharing():
             self._test_pool(repeat=TEST_REPEATS)
 
+    @skipIfRocmVersionAtLeast([7, 14])
     @unittest.skipIf(not HAS_SHM_FILES, "don't not how to check if shm files exist")
     def test_fs(self):
         def queue_put():
@@ -1076,6 +1082,8 @@ if __name__ == "__main__":
     def test_is_shared(self):
         self._test_is_shared()
 
+    # torch_shm_manager cannot resolve librocprofiler-sdk.so.1 in CI child processes.
+    @skipIfRocmVersionAtLeast([7, 14])
     def test_fs_is_shared(self):
         with fs_sharing():
             self._test_is_shared()

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -35,7 +35,7 @@ from torch.nn import Buffer, Parameter
 from torch.nn.parallel._functions import Broadcast
 from torch.testing._internal.common_dtype import integral_types, get_all_math_dtypes, floating_types
 from torch.testing._internal.common_utils import dtype_name, freeze_rng_state, run_tests, TestCase, \
-    skipIfNoLapack, skipIfRocm, skipIfRocmVersionLessThan, TEST_NUMPY, TEST_SCIPY, TEST_WITH_CROSSREF, TEST_WITH_ROCM, TEST_MULTIACCELERATOR, \
+    skipIfNoLapack, skipIfRocm, skipIfRocmVersionLessThan, getRocmVersion, TEST_NUMPY, TEST_SCIPY, TEST_WITH_CROSSREF, TEST_WITH_ROCM, TEST_MULTIACCELERATOR, \
     download_file, get_function_arglist, load_tests, skipIfMPS, MACOS_VERSION, \
     IS_PPC, IS_ARM64, IS_MACOS, IS_WINDOWS, IS_CPU_CAPABILITY_SVE, IS_CPU_EXT_SVE_SUPPORTED, xfailIf, \
     parametrize as parametrize_test, subtest, instantiate_parametrized_tests, \
@@ -13063,6 +13063,17 @@ if __name__ == '__main__':
     @dtypesIfMPS(torch.float32)
     @dtypes(torch.float32, torch.float64)
     def test_module_to_empty(self, device, dtype):
+        if (
+            TEST_WITH_ROCM
+            and getRocmVersion() >= (7, 14)
+            and torch.device(device).type == "cuda"
+            and dtype == torch.float32
+        ):
+            self.skipTest(
+                "order/state-dependent NotImplementedError regex mismatch on "
+                "ROCm 7.14+ (cuda, float32)"
+            )
+
         class MyModule(nn.Module):
             def __init__(self, in_features, out_features, device=None, dtype=None):
                 super().__init__()
@@ -14172,6 +14183,16 @@ if __name__ == '__main__':
     @parametrize_test("bias", [False, True])
     @dtypes(torch.float32)
     def test_linear_cross_entropy_loss_default(self, device, dtype, bias):
+        if (
+            TEST_WITH_ROCM
+            and getRocmVersion() >= (7, 14)
+            and not bias
+            and dtype == torch.float32
+        ):
+            self.skipTest(
+                "input-grad ULP worst case exceeds tolerance on ROCm 7.14+ "
+                "(bias=False, float32)"
+            )
         self._test_linear_cross_entropy_loss(device=device, dtype=dtype, bias=bias)
 
     @parametrize_test("prob_target", [False, True])

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -58,6 +58,7 @@ from torch.testing._internal.common_methods_invocations import (
 from torch.testing._internal.common_utils import (
     clone_input_helper,
     first_sample,
+    getRocmVersion,
     IS_CI,
     IS_FBCODE,
     is_iterable_of_tensors,
@@ -70,6 +71,7 @@ from torch.testing._internal.common_utils import (
     skipIfTorchDynamo,
     skipIfTorchInductor,
     suppress_warnings,
+    TEST_WITH_ROCM,
     TEST_WITH_TORCHDYNAMO,
     TEST_WITH_TORCHINDUCTOR,
     TestCase,
@@ -1606,6 +1608,8 @@ class TestCommon(TestCase):
     @onlyNativeDeviceTypesAnd(["hpu"])
     @ops(ops_and_refs, dtypes=OpDTypes.none)
     def test_dtypes(self, device, op):
+        if TEST_WITH_ROCM and getRocmVersion() >= (7, 14) and op.name == "sparse.sampled_addmm":
+            self.skipTest("stale sparse.sampled_addmm OpInfo dtypes on ROCm 7.14")
         # Check complex32 support only if the op claims.
         # TODO: Once the complex32 support is better, we should add check for complex32 unconditionally.
         device_type = torch.device(device).type

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1608,7 +1608,11 @@ class TestCommon(TestCase):
     @onlyNativeDeviceTypesAnd(["hpu"])
     @ops(ops_and_refs, dtypes=OpDTypes.none)
     def test_dtypes(self, device, op):
-        if TEST_WITH_ROCM and getRocmVersion() >= (7, 14) and op.name == "sparse.sampled_addmm":
+        if (
+            TEST_WITH_ROCM
+            and getRocmVersion() >= (7, 14)
+            and op.name == "sparse.sampled_addmm"
+        ):
             self.skipTest("stale sparse.sampled_addmm OpInfo dtypes on ROCm 7.14")
         # Check complex32 support only if the op claims.
         # TODO: Once the complex32 support is better, we should add check for complex32 unconditionally.

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -41,6 +41,7 @@ from torch.testing._internal.common_optimizers import (
     TensorTracker,
 )
 from torch.testing._internal.common_utils import (
+    getRocmVersion,
     markDynamoStrictTest,
     parametrize,
     run_tests,
@@ -452,6 +453,19 @@ class TestOptimRenewed(TestCase):
     )
     def test_rosenbrock_sparse(self, device, dtype, optim_info, with_lrsched):
         optim_cls = optim_info.optim_cls
+
+        if (
+            TEST_WITH_ROCM
+            and getRocmVersion() >= (7, 14)
+            and optim_cls.__name__ == "SGD"
+            and not with_lrsched
+            and torch.device(device).type == "cuda"
+            and dtype == torch.float64
+        ):
+            self.skipTest(
+                "order/state-dependent sparse SGD step timeout on ROCm 7.14+ "
+                "(with_lrsched=False, SGD, cuda, float64)"
+            )
 
         # Skip differentiable testing for now, see https://github.com/pytorch/pytorch/issues/116490
         # Fused impls do not support sparse gradients

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -39,7 +39,7 @@ from torch.testing._internal.common_utils import (  # type: ignore[attr-defined]
     IS_SANDCASTLE, IS_FBCODE, IS_REMOTE_GPU, skipIfRocmArch, skipIfTorchInductor, load_tests, slowTest, slowTestIf,
     skipIfCrossRef, TEST_WITH_CROSSREF, skipIfTorchDynamo, set_default_dtype,
     skipCUDAMemoryLeakCheckIf, BytesIOContext,
-    skipIfRocm, skipIfNoSciPy, TemporaryFileName, TemporaryDirectoryName,
+    skipIfRocm, skipIfRocmVersionAtLeast, skipIfNoSciPy, TemporaryFileName, TemporaryDirectoryName,
     wrapDeterministicFlagAPITest, DeterministicGuard, CudaSyncGuard,
     bytes_to_scalar, parametrize, noncontiguous_like,
     AlwaysWarnTypedStorageRemoval, TEST_WITH_TORCHDYNAMO, xfailIfTorchDynamo,
@@ -8757,6 +8757,7 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
         torch.__config__.show()
 
     @unittest.skipIf(IS_FBCODE, "CXX_FLAGS is only for OSS build.")
+    @skipIfRocmVersionAtLeast([7, 14])
     def test_cxx_flags(self):
         torch.__config__._cxx_flags()
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -34,6 +34,7 @@ from torch.testing._internal.common_utils import (  # type: ignore[attr-defined]
     IS_SANDCASTLE,
     IS_WINDOWS,
     load_tests,
+    skipIfRocmVersionAtLeast,
     skipIfTorchDynamo,
     TEST_WITH_ASAN,
 )
@@ -781,6 +782,8 @@ class TestAssert(TestCase):
 
 @unittest.skipIf(IS_SANDCASTLE, "cpp_extension is OSS only")
 class TestStandaloneCPPJIT(TestCase):
+    # The standalone binary cannot resolve librocprofiler-sdk.so.1 in CI.
+    @skipIfRocmVersionAtLeast([7, 14])
     def test_load_standalone(self):
         build_dir = tempfile.mkdtemp()
         try:

--- a/tools/testing/test_selections.py
+++ b/tools/testing/test_selections.py
@@ -12,9 +12,12 @@ from tools.testing.test_run import ShardedTest, TestRun
 
 
 try:
+    import torch
+
     from torch.testing._internal.common_cuda import SM80OrLater
     from torch.testing._internal.common_utils import TEST_CUDA
 except ImportError:
+    torch = None
     TEST_CUDA = False
     SM80OrLater = False
 
@@ -32,15 +35,18 @@ BUILD_ENVIRONMENT = os.getenv("BUILD_ENVIRONMENT", "")
 # to ensure that sharding is consistent, NUM_PROCS is the actual number of procs
 # used to run tests.  If they are not equal, the only consequence should be
 # unequal shards.
-IS_ROCM = os.path.exists("/opt/rocm")
+# Detect ROCm via torch.version.hip, which is set for both system installs and
+# ROCm wheels (e.g. TheRock preview wheels which have no /opt/rocm). This must
+# reach the rocminfo-based NUM_PROCS clamp below; otherwise NUM_PROCS stays
+# >GPU-count and maybe_set_hip_visible_devies() in run_test.py assigns workers
+# to nonexistent device indices -> torch.cuda.device_count()==0.
+IS_ROCM = torch is not None and torch.version.hip is not None
 NUM_PROCS = 1 if IS_MEM_LEAK_CHECK else 3 if not TEST_CUDA or SM80OrLater else 2
 NUM_PROCS_FOR_SHARDING_CALC = NUM_PROCS if not IS_ROCM or IS_MEM_LEAK_CHECK else 2
 THRESHOLD = 60 * 10  # 10 minutes
 
 # See Note [ROCm parallel CI testing]
 # Special logic for ROCm GHA runners to query number of GPUs available.
-# torch.version.hip was not available to check if this was a ROCm self-hosted runner.
-# Must check for ROCm runner in another way. We look for /opt/rocm directory.
 if IS_ROCM and not IS_MEM_LEAK_CHECK:
     try:
         # This is the same logic used in GHA health check, see .github/templates/common.yml.j2

--- a/tools/testing/test_selections.py
+++ b/tools/testing/test_selections.py
@@ -13,7 +13,6 @@ from tools.testing.test_run import ShardedTest, TestRun
 
 try:
     import torch
-
     from torch.testing._internal.common_cuda import SM80OrLater
     from torch.testing._internal.common_utils import TEST_CUDA
 except ImportError:

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -644,6 +644,23 @@ def skip_if_rocm_ver_lessthan_multiprocess(version=None):
     return decorator
 
 
+def skip_if_rocm_ver_atleast_multiprocess(version=None):
+    """Skips a test for ROCm if the version is at least the given tuple - multiprocess UTs"""
+
+    def decorator(func):
+        reason = None
+        if TEST_WITH_ROCM:
+            rocm_version = str(torch.version.hip)
+            rocm_version = rocm_version.split("-", maxsplit=1)[0]  # ignore git sha
+            rocm_version_tuple = tuple(int(x) for x in rocm_version.split("."))
+            if version is not None and rocm_version_tuple >= tuple(version):
+                reason = f"skip_if_rocm_ver_atleast_multiprocess: known failure on ROCm {rocm_version_tuple} (>= {version})"
+
+        return unittest.skipIf(reason is not None, reason)(func)
+
+    return decorator
+
+
 def skip_if_win32():
     return skip_but_pass_in_sandcastle_if(
         sys.platform == "win32",

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -2550,6 +2550,22 @@ def skipIfRocmVersionLessThan(version=None):
         )
     return lazy_skip_if(_should_skip, f"ROCm version less than {version} required")
 
+# Skips a test on ROCm if the version is at least the given major.minor tuple.
+# Use for failures introduced in a ROCm release that pass on older versions,
+# e.g. skipIfRocmVersionAtLeast([7, 14]) skips on 7.14+ but runs on 7.2.x.
+# Built on lazy_skip_if so it works on both test methods and test classes.
+def skipIfRocmVersionAtLeast(version=None):
+    def _should_skip():
+        if not TEST_WITH_ROCM:
+            return False
+        rocm_version_tuple = getRocmVersion()
+        return (
+            rocm_version_tuple is not None
+            and version is not None
+            and rocm_version_tuple >= tuple(version)
+        )
+    return lazy_skip_if(_should_skip, f"ROCm version at least {version}: known failure")
+
 def skipIfNotMiopenSuggestNHWC(fn):
     return lazy_skip_if(
         lambda: not TEST_WITH_MIOPEN_SUGGEST_NHWC,


### PR DESCRIPTION
Temporarily skips tests that newly fail in ROCm 7.14 preview CI while remaining green in the current ROCm 7.2 CI. The skips activate automatically during the 7.14 transition and do not affect CUDA, CPU, or older ROCm jobs.

Adds two decorators mirroring the existing `lessthan` pattern:

- `skipIfRocmVersionAtLeast(version)` in `common_utils.py`
- `skip_if_rocm_ver_atleast_multiprocess(version)` in `common_distributed.py`

### Scope of the temporary skips

These failures were observed while validating the ROCm 7.14 preview CI configuration. They do not all represent ROCm runtime regressions; the causes span PyTorch test assumptions, wheel packaging, CI configuration, and component-specific behavior changes.

The version-gated skips address the following concrete cases:

- **MIOpen numerical behavior:** selected CTC-loss and convolution cases exceed existing PyTorch tolerances under the ROCm 7.14 library stack.
- **rocBLAS large-batch behavior:** `test_cholesky_solve_batched_many_batches` encounters incorrect results at the 65,536-batch boundary.
- **Inductor numerical expectations:** the `log10` tests either differ from eager execution under strict bitwise equality or unexpectedly pass stale strict-xfail metadata.
- **ROCm SDK library discovery:** spawned native processes cannot locate wheel-provided libraries such as `librocprofiler-sdk.so.1` and `libamdhip64.so.7`. This affects:
  - `torch_shm_manager` filesystem-sharing tests
  - `TestStandaloneCPPJIT.test_load_standalone`
  - Inductor’s CPU vec-ISA probe used by dynamic-shape and GPU-wrapper tests
- **Device visibility and diagnostics:** some tests assume CUDA-style visibility or exact assertion behavior that differs when ROCm 7.14 initializes and enumerates GPU agents.
- **Unexpected runtime logging:** ROCm agent visibility warnings enter log streams used by tests that require exact stderr or logging matches.
- **RCCL/NCCL functionality:** Copy Engine collectives, symmetric-memory registration, and selected profiler annotations are unavailable or unstable in the tested configuration.
- **Distributed execution:** isolated FSDP, replicate, and context-parallel attention tests show small numerical differences, while selected symmetric-memory tests hang during rendezvous or teardown.
- **Wheel build metadata:** selected tests expect compiler configuration metadata or runtime paths that are not currently present in the ROCm 7.14 wheel environment.

These skips are narrowly scoped compatibility measures for the CI transition. They do not disable the corresponding functionality globally and do not affect CUDA, CPU, or earlier ROCm jobs. Each skip is intended to be removed when its underlying PyTorch, library, or CI-integration issue is resolved.

## Validation

At commit [c943656](https://github.com/pytorch/pytorch/pull/188593/changes/c94365619afd2e857cdf2d109ca620f16bb90793), the rocm-nightly workflow [ran all tests successfully](https://github.com/pytorch/pytorch/actions/runs/30931664854/job/92110010729) using ROCm7.14 GA.
Post that commit, the temporary changes to install_rocm.sh and rocm-nightly.yml were reverted, as they will be part of a follow-up PR: https://github.com/pytorch/pytorch/pull/188429

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @azahed98