### PR TITLE
[CI][DO NOT MERGE] pull: A/B control (original shard counts)

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -1,4 +1,5 @@
 # Owner(s): ["module: ci"]
+# ci-shard-experiment: A/B control (original shard counts)
 name: pull
 
 on:


### PR DESCRIPTION
Baseline for ci-shard-experiment-staged: no-op comment to trigger a comparable pull run with the original shard counts.

Test Plan: compare per-shard runtimes vs the treatment branch.

Authored with assistance from Claude.