### PR TITLE
[ROCm][inductor] Support grouped GEMM Triton lowering

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -19240,7 +19240,6 @@ if RUN_GPU:
 
         @skipCUDAIf(not SM90OrLater, "Requires sm90")
         @requires_cuda_and_triton
-        @unittest.skipIf(TEST_WITH_ROCM, "no grouped_mm support")
         @config.patch(implicit_fallbacks=True)
         def test_grouped_mm(self):
             @torch.compile(fullgraph=True)

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -727,7 +727,6 @@ class TestMatmulCuda(InductorTestCase):
                 start = offs_cpu[i]
             self.grouped_mm_helper(a, blist, gOlist, agradlist, bgradlist, outlist)
 
-    @unittest.skipIf(TEST_WITH_ROCM, "ROCm doesn't support CUTLASS")
     # TODO(future PR): enable compile for torch.nn.functional.grouped_mm fallback path
     @unittest.skipIf(not SM90OrLater, "Grouped gemm with compile supported on SM90")
     @parametrize("op", ["2d/2d", "2d/3d", "3d/2d", "3d/3d"])

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -839,6 +839,12 @@ class TestMatmulCuda(InductorTestCase):
             raise AssertionError(f"Invalid op: {op}")
 
         C_ref = f_ref(A, B.transpose(-2, -1), offs=offs)
+        if TEST_WITH_ROCM:
+            # Inductor's ROCm extern layout for grouped_mm must match ATen,
+            # which returns contiguous outputs on ROCm rather than CUDA's
+            # TMA-aligned padded strides.
+            contiguous_stride = torch.empty_like(C_ref).stride()
+            self.assertEqual(C_ref.stride(), contiguous_stride)
         if not IS_BIG_GPU and max_autotune:
             with self.assertRaisesRegex(torch._inductor.exc.InductorError, "NoValidChoicesError"):
                 C = f(A, B.transpose(-2, -1), offs=offs)

--- a/torch/_inductor/kernel/mm_grouped.py
+++ b/torch/_inductor/kernel/mm_grouped.py
@@ -142,6 +142,15 @@ cutedsl_grouped_mm_template = CuteDSLTemplate(
     source=load_kernel_template("cutedsl_mm_grouped"),
 )
 
+def has_grouped_mm_triton_support() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    if torch.version.hip:
+        # ROCm grouped_mm always has the ATen fallback: a loop over mm_out/bmm_out,
+        # which uses hipBLASLt where available and rocBLAS otherwise.
+        return True
+    return torch.cuda.get_device_capability() >= (9, 0)
+
 
 def grouped_mm_args(
     mat1: TensorBox,
@@ -182,11 +191,20 @@ def grouped_mm_args(
                 out_size = [mat1_size[1], mat2_size[1]]
             else:
                 out_size = [mat1_size[0], mat1_size[1], mat2_size[-1]]
-        size_padded = (out_size[-1] + alignment - 1) // alignment * alignment
-        if len(out_size) == 2:
-            out_stride = [size_padded, 1]
+        # Match the ATen extern output layout: CUDA pads grouped GEMM outputs for
+        # TMA alignment, while ROCm's ATen path returns contiguous tensors.
+        # TODO: Revisit whether 16-byte alignment would be beneficial for gfx1250.
+        if torch.version.hip:
+            if len(out_size) == 2:
+                out_stride = [out_size[1], 1]
+            else:
+                out_stride = [out_size[1] * out_size[2], out_size[2], 1]
         else:
-            out_stride = [out_size[1] * size_padded, size_padded, 1]
+            size_padded = (out_size[-1] + alignment - 1) // alignment * alignment
+            if len(out_size) == 2:
+                out_stride = [size_padded, 1]
+            else:
+                out_stride = [out_size[1] * size_padded, size_padded, 1]
 
         layout = FixedLayout(
             mat1.get_device(),
@@ -224,11 +242,7 @@ def can_use_triton_kernel(
     bias: TensorBox | None,
     scale_result: TensorBox | None,
 ) -> bool:
-    if not (
-        torch.cuda.is_available()
-        and torch.cuda.get_device_capability() >= (9, 0)
-        and not torch.version.hip
-    ):
+    if not has_grouped_mm_triton_support():
         return False
     if not has_triton():
         return False

--- a/torch/_inductor/kernel/mm_grouped.py
+++ b/torch/_inductor/kernel/mm_grouped.py
@@ -142,6 +142,7 @@ cutedsl_grouped_mm_template = CuteDSLTemplate(
     source=load_kernel_template("cutedsl_mm_grouped"),
 )
 
+
 def has_grouped_mm_triton_support() -> bool:
     if not torch.cuda.is_available():
         return False

--- a/torch/_inductor/kernel/mm_grouped.py
+++ b/torch/_inductor/kernel/mm_grouped.py
@@ -147,8 +147,8 @@ def has_grouped_mm_triton_support() -> bool:
     if not torch.cuda.is_available():
         return False
     if torch.version.hip:
-        # ROCm grouped_mm always has the ATen fallback: a loop over mm_out/bmm_out,
-        # which uses hipBLASLt where available and rocBLAS otherwise.
+        # The grouped GEMM Triton template is supported on ROCm too. ATen
+        # remains a separate autotune choice when fallback kernels are enabled.
         return True
     return torch.cuda.get_device_capability() >= (9, 0)
 


### PR DESCRIPTION
## Summary
- Allow Inductor's grouped GEMM Triton lowering on ROCm instead of gating it to NVIDIA SM90+ only.
- Match ROCm ATen extern output layout by using contiguous grouped GEMM output strides on HIP while preserving CUDA's TMA-aligned padded strides.
- Enable existing grouped GEMM compile tests on ROCm.

## Test plan
- `python test/inductor/test_torchinductor.py TritonCodeGenTests.test_grouped_mm`
- Ran all unscaled grouped GEMM CUDA variants from `test/test_matmul_cuda.py`: `129 passed, 0 failed, 0 skipped`
- Ran `test_grouped_gemm_compiled` generated variants: `32 passed, 0 failed, 0 skipped`


Made with [Cursor](https://cursor.com)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben