### PR TITLE
Fix infinite recursion with pybind11 enum conversions

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -231,32 +231,20 @@ class MiscTests(torch._inductor.test_case.TestCase):
         entries = _debug_get_cache_entry_list(torch._dynamo.graph_break)
         self.assertEqual(len(entries), 0)
 
-    def test_pybind11_enum_conversion(self):
-        import importlib.util
-        import os
-        import subprocess
-        import sysconfig
-        import tempfile
+    @torch.testing._internal.common_utils.scoped_load_inline
+    def test_pybind11_enum_conversion(self, load_inline):
+        cpp_source = """
+        #include <torch/extension.h>
 
-        try:
-            d = tempfile.mkdtemp()
-            s = os.path.join(d, "e.cpp")
-            with open(s, "w") as f:
-                f.write(
-                    '#include <pybind11/pybind11.h>\nnamespace py = pybind11;\nenum class E { A = 0, B = 1 };\nPYBIND11_MODULE(e, m) { py::enum_<E>(m, "E").value("A", E::A).value("B", E::B); }'
-                )
-            o = os.path.join(d, f"e{sysconfig.get_config_var('EXT_SUFFIX')}")
-            subprocess.check_call(
-                f"g++ -O2 -shared -fPIC -std=c++17 {subprocess.check_output(['python', '-m', 'pybind11', '--includes'], text=True).strip()} {s} -o {o}",
-                shell=True,
-                stderr=subprocess.DEVNULL,
-                stdout=subprocess.DEVNULL,
-            )
-            spec = importlib.util.spec_from_file_location("e", o)
-            mod = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(mod)
-        except Exception:
-            self.skipTest("pybind11 unavailable")
+        enum class E { A = 0, B = 1 };
+
+        PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+            py::enum_<E>(m, "E")
+                .value("A", E::A)
+                .value("B", E::B);
+        }
+        """
+        mod = load_inline(name="pybind11_enum_test", cpp_sources=cpp_source)
         e = mod.E.A
         self.assertEqual(torch.compile(lambda x: int(x), backend="eager")(e), 0)
         self.assertEqual(torch.compile(lambda x: float(x), backend="eager")(e), 0.0)

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -231,6 +231,25 @@ class MiscTests(torch._inductor.test_case.TestCase):
         entries = _debug_get_cache_entry_list(torch._dynamo.graph_break)
         self.assertEqual(len(entries), 0)
 
+    def test_pybind11_enum_conversion(self):
+        import importlib.util, os, subprocess, sysconfig, tempfile
+        try:
+            d = tempfile.mkdtemp()
+            s = os.path.join(d, "e.cpp")
+            with open(s, "w") as f:
+                f.write('#include <pybind11/pybind11.h>\nnamespace py = pybind11;\nenum class E { A = 0, B = 1 };\nPYBIND11_MODULE(e, m) { py::enum_<E>(m, "E").value("A", E::A).value("B", E::B); }')
+            o = os.path.join(d, f"e{sysconfig.get_config_var('EXT_SUFFIX')}")
+            subprocess.check_call(f"g++ -O2 -shared -fPIC -std=c++17 {subprocess.check_output(['python', '-m', 'pybind11', '--includes'], text=True).strip()} {s} -o {o}", shell=True, stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL)
+            spec = importlib.util.spec_from_file_location("e", o)
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+        except Exception:
+            self.skipTest("pybind11 unavailable")
+        e = mod.E.A
+        self.assertEqual(torch.compile(lambda x: int(x), backend="eager")(e), 0)
+        self.assertEqual(torch.compile(lambda x: float(x), backend="eager")(e), 0.0)
+        self.assertEqual(torch.compile(lambda x: [10, 20][x], backend="eager")(mod.E.B), 20)
+
     def test_boolarg(self):
         def boolarg(aa, bb, flag):
             if flag:

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -246,10 +246,17 @@ class MiscTests(torch._inductor.test_case.TestCase):
         """
         mod = load_inline(name="pybind11_enum_test", cpp_sources=cpp_source)
         e = mod.E.A
-        self.assertEqual(torch.compile(lambda x: int(x), backend="eager")(e), 0)
-        self.assertEqual(torch.compile(lambda x: float(x), backend="eager")(e), 0.0)
         self.assertEqual(
-            torch.compile(lambda x: [10, 20][x], backend="eager")(mod.E.B), 20
+            torch.compile(lambda x: int(x), backend="eager", fullgraph=True)(e), 0
+        )
+        self.assertEqual(
+            torch.compile(lambda x: float(x), backend="eager", fullgraph=True)(e), 0.0
+        )
+        self.assertEqual(
+            torch.compile(lambda x: [10, 20][x], backend="eager", fullgraph=True)(
+                mod.E.B
+            ),
+            20,
         )
 
     def test_boolarg(self):

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -232,14 +232,26 @@ class MiscTests(torch._inductor.test_case.TestCase):
         self.assertEqual(len(entries), 0)
 
     def test_pybind11_enum_conversion(self):
-        import importlib.util, os, subprocess, sysconfig, tempfile
+        import importlib.util
+        import os
+        import subprocess
+        import sysconfig
+        import tempfile
+
         try:
             d = tempfile.mkdtemp()
             s = os.path.join(d, "e.cpp")
             with open(s, "w") as f:
-                f.write('#include <pybind11/pybind11.h>\nnamespace py = pybind11;\nenum class E { A = 0, B = 1 };\nPYBIND11_MODULE(e, m) { py::enum_<E>(m, "E").value("A", E::A).value("B", E::B); }')
+                f.write(
+                    '#include <pybind11/pybind11.h>\nnamespace py = pybind11;\nenum class E { A = 0, B = 1 };\nPYBIND11_MODULE(e, m) { py::enum_<E>(m, "E").value("A", E::A).value("B", E::B); }'
+                )
             o = os.path.join(d, f"e{sysconfig.get_config_var('EXT_SUFFIX')}")
-            subprocess.check_call(f"g++ -O2 -shared -fPIC -std=c++17 {subprocess.check_output(['python', '-m', 'pybind11', '--includes'], text=True).strip()} {s} -o {o}", shell=True, stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL)
+            subprocess.check_call(
+                f"g++ -O2 -shared -fPIC -std=c++17 {subprocess.check_output(['python', '-m', 'pybind11', '--includes'], text=True).strip()} {s} -o {o}",
+                shell=True,
+                stderr=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+            )
             spec = importlib.util.spec_from_file_location("e", o)
             mod = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(mod)
@@ -248,7 +260,9 @@ class MiscTests(torch._inductor.test_case.TestCase):
         e = mod.E.A
         self.assertEqual(torch.compile(lambda x: int(x), backend="eager")(e), 0)
         self.assertEqual(torch.compile(lambda x: float(x), backend="eager")(e), 0.0)
-        self.assertEqual(torch.compile(lambda x: [10, 20][x], backend="eager")(mod.E.B), 20)
+        self.assertEqual(
+            torch.compile(lambda x: [10, 20][x], backend="eager")(mod.E.B), 20
+        )
 
     def test_boolarg(self):
         def boolarg(aa, bb, flag):

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -1991,7 +1991,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
                 skip_frame=True,
             )
 
-    def _call_method_var_or_direct(
+    def _call_method_var_or_const_fold(
         self,
         tx: "InstructionTranslatorBase",
         method_var: VariableTracker,
@@ -2013,7 +2013,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         if type_attr is NO_SUCH_SUBOBJ:
             return super().nb_index_impl(tx)
         method_var = self.resolve_type_attr(tx, "__index__", type_attr, source)
-        result = self._call_method_var_or_direct(tx, method_var, operator.index)
+        result = self._call_method_var_or_const_fold(tx, method_var, operator.index)
         # CPython validates that __index__ returns an int.
         # https://github.com/python/cpython/blob/c09ccd9c429/Objects/abstract.c#L1433-L1438
         if result.is_python_constant() and not isinstance(
@@ -2038,7 +2038,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         if type_attr is NO_SUCH_SUBOBJ:
             return super().nb_int_impl(tx)
         method_var = self.resolve_type_attr(tx, "__int__", type_attr, source)
-        result = self._call_method_var_or_direct(tx, method_var, int)
+        result = self._call_method_var_or_const_fold(tx, method_var, int)
         if not issubclass(result.python_type(), int):
             raise_observed_exception(
                 TypeError,
@@ -2059,7 +2059,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         if type_attr is NO_SUCH_SUBOBJ:
             return super().nb_float_impl(tx)
         method_var = self.resolve_type_attr(tx, "__float__", type_attr, source)
-        result = self._call_method_var_or_direct(tx, method_var, float)
+        result = self._call_method_var_or_const_fold(tx, method_var, float)
         if not issubclass(result.python_type(), float):
             raise_observed_exception(
                 TypeError,

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -29,6 +29,7 @@ import dataclasses
 import enum
 import functools
 import inspect
+import operator
 import random
 import sys
 import threading
@@ -1990,6 +1991,16 @@ class UserDefinedObjectVariable(UserDefinedVariable):
                 skip_frame=True,
             )
 
+    def _call_method_var_or_direct(
+        self,
+        tx: "InstructionTranslatorBase",
+        method_var: VariableTracker,
+        direct_fn: Any,
+    ) -> VariableTracker:
+        if isinstance(method_var, variables.GetAttrVariable) and self.is_python_constant():
+            return variables.ConstantVariable.create(direct_fn(self.value))
+        return method_var.call_function(tx, [], {})
+
     def nb_index_impl(
         self,
         tx: "InstructionTranslatorBase",
@@ -1999,7 +2010,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         if type_attr is NO_SUCH_SUBOBJ:
             return super().nb_index_impl(tx)
         method_var = self.resolve_type_attr(tx, "__index__", type_attr, source)
-        result = method_var.call_function(tx, [], {})
+        result = self._call_method_var_or_direct(tx, method_var, operator.index)
         # CPython validates that __index__ returns an int.
         # https://github.com/python/cpython/blob/c09ccd9c429/Objects/abstract.c#L1433-L1438
         if result.is_python_constant() and not isinstance(
@@ -2024,7 +2035,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         if type_attr is NO_SUCH_SUBOBJ:
             return super().nb_int_impl(tx)
         method_var = self.resolve_type_attr(tx, "__int__", type_attr, source)
-        result = method_var.call_function(tx, [], {})
+        result = self._call_method_var_or_direct(tx, method_var, int)
         if not issubclass(result.python_type(), int):
             raise_observed_exception(
                 TypeError,
@@ -2045,7 +2056,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         if type_attr is NO_SUCH_SUBOBJ:
             return super().nb_float_impl(tx)
         method_var = self.resolve_type_attr(tx, "__float__", type_attr, source)
-        result = method_var.call_function(tx, [], {})
+        result = self._call_method_var_or_direct(tx, method_var, float)
         if not issubclass(result.python_type(), float):
             raise_observed_exception(
                 TypeError,

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -1997,7 +1997,10 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         method_var: VariableTracker,
         direct_fn: Any,
     ) -> VariableTracker:
-        if isinstance(method_var, variables.GetAttrVariable) and self.is_python_constant():
+        if (
+            isinstance(method_var, variables.GetAttrVariable)
+            and self.is_python_constant()
+        ):
             return variables.ConstantVariable.create(direct_fn(self.value))
         return method_var.call_function(tx, [], {})
 

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -2001,7 +2001,9 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             isinstance(method_var, variables.GetAttrVariable)
             and self.is_python_constant()
         ):
-            return variables.ConstantVariable.create(direct_fn(self.value))
+            return variables.ConstantVariable.create(
+                direct_fn(self.as_python_constant())
+            )
         return method_var.call_function(tx, [], {})
 
     def nb_index_impl(


### PR DESCRIPTION
Fixes #188547 
Fixes infinite recursion when calling int( ), float( ), or indexing pybind11 enums in compiled functions. Basically detects GetAttrVariable from pybind11 instancemethods and directly evaluates conversions on constants instead of recursing through call_method which previously led to infinite recursion

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98