### PR TITLE
[ci] Re-enable cuDSS installation in CI Docker images so CUDA CI can actually build and run cuDSS tests

### DIFF
--- a/.ci/docker/common/install_cudss.sh
+++ b/.ci/docker/common/install_cudss.sh
@@ -5,16 +5,23 @@ set -ex
 # cudss license: https://docs.nvidia.com/cuda/cudss/license.html
 mkdir tmp_cudss && cd tmp_cudss
 
-if [[ ${CUDA_VERSION:0:4} =~ ^12\.[1-4]$ ]]; then
-    arch_path='sbsa'
-    export TARGETARCH=${TARGETARCH:-$(uname -m)}
-    if [ ${TARGETARCH} = 'amd64' ] || [ "${TARGETARCH}" = 'x86_64' ]; then
-        arch_path='x86_64'
-    fi
-    CUDSS_NAME="libcudss-linux-${arch_path}-0.3.0.9_cuda12-archive"
+arch_path='sbsa'
+export TARGETARCH=${TARGETARCH:-$(uname -m)}
+if [ "${TARGETARCH}" = 'amd64' ] || [ "${TARGETARCH}" = 'x86_64' ]; then
+    arch_path='x86_64'
+fi
+
+if [[ ${CUDA_VERSION:0:2} == "13" ]]; then
+    CUDSS_NAME="libcudss-linux-${arch_path}-0.7.1.4_cuda13-archive"
+elif [[ ${CUDA_VERSION:0:4} =~ ^12\.[1-9]$ ]]; then
+    CUDSS_NAME="libcudss-linux-${arch_path}-0.7.1.4_cuda12-archive"
+else
+    CUDSS_NAME=""
+fi
+
+if [ -n "${CUDSS_NAME}" ]; then
     curl --retry 3 -OLs https://developer.download.nvidia.com/compute/cudss/redist/libcudss/linux-${arch_path}/${CUDSS_NAME}.tar.xz
 
-    # only for cuda 12
     tar xf ${CUDSS_NAME}.tar.xz
     cp -a ${CUDSS_NAME}/include/* /usr/local/cuda/include/
     cp -a ${CUDSS_NAME}/lib/* /usr/local/cuda/lib64/

--- a/.ci/docker/ubuntu/Dockerfile
+++ b/.ci/docker/ubuntu/Dockerfile
@@ -59,6 +59,8 @@ COPY ./common/install_nccl.sh install_nccl.sh
 COPY ./ci_commit_pins/nccl* /ci_commit_pins/
 COPY ./common/install_cusparselt.sh install_cusparselt.sh
 RUN bash ./install_cuda.sh ${CUDA_VERSION} && rm install_cuda.sh install_nccl.sh /ci_commit_pins/nccl* install_cusparselt.sh
+COPY ./common/install_cudss.sh install_cudss.sh
+RUN bash ./install_cudss.sh && rm install_cudss.sh
 ENV DESIRED_CUDA=${CUDA_VERSION}
 ENV PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:$PATH
 

--- a/.ci/docker/ubuntu/Dockerfile
+++ b/.ci/docker/ubuntu/Dockerfile
@@ -64,6 +64,8 @@ COPY ./common/install_nccl.sh install_nccl.sh
 COPY ./ci_commit_pins/nccl* /ci_commit_pins/
 COPY ./common/install_cusparselt.sh install_cusparselt.sh
 RUN bash ./install_cuda.sh ${CUDA_VERSION} && rm install_cuda.sh install_nccl.sh /ci_commit_pins/nccl* install_cusparselt.sh
+COPY ./common/install_cudss.sh install_cudss.sh
+RUN bash ./install_cudss.sh && rm install_cudss.sh
 ENV DESIRED_CUDA=${CUDA_VERSION}
 ENV PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:$PATH
 


### PR DESCRIPTION
Re-enable cuDSS installation in CI Docker images so CUDA CI can actually build and run cuDSS-covered tests.

This is a dependency for merging #171035. That PR adds coverage for `test_linalg_solve_sparse_csr_cusolver`, but the test is currently skipped on CI because PyTorch is not built with cuDSS support: `install_cudss.sh` exists, but it is no longer invoked by the Ubuntu Docker image after the focal-to-jammy migration.

This PR:
- wires `install_cudss.sh` back into `.ci/docker/ubuntu/Dockerfile` after CUDA installation
- bumps cuDSS to `0.7.1.4`
- adds CUDA 13 archive selection, since CUDA 13.0 is the current GPU test image and cuDSS `0.3.0.9` does not provide CUDA 13 archives
- keeps CUDA 12 support and leaves non-CUDA/unmatched images as no-ops

cc: @huydhn 