### PR TITLE
Migrate target-determination-indexer to OSDC

### DIFF
--- a/.github/workflows/target-determination-indexer.yml
+++ b/.github/workflows/target-determination-indexer.yml
@@ -52,6 +52,27 @@ jobs:
           ref: v0.0.2
           path: llm-target-determinator
 
+      - name: Set up sibling workspace for the indexer
+        shell: bash
+        run: |
+          set -eux
+          # llm-target-determinator@v0.0.2 (config.py) resolves its own realpath
+          # and then reads the corpus from `<parent>/pytorch` and the model from
+          # `<parent>/codellama` — i.e. it expects pytorch / codellama / itself to
+          # be sibling dirs. setup-linux checks pytorch out at GITHUB_WORKSPACE and
+          # the two helper repos as subdirs, so the realpath-based lookup misses
+          # the corpus. Move the helper repos into a clean workspace and point
+          # `pytorch` at the checkout via a symlink. Because `.resolve()` follows
+          # symlinks, the helper repos must be *real* dirs here (not symlinks).
+          # Moving them out of the pytorch tree also keeps them out of the
+          # indexer's os.walk corpus.
+          WS="${RUNNER_TEMP}/td-workspace"
+          mkdir -p "${WS}"
+          mv "${GITHUB_WORKSPACE}/codellama" "${WS}/codellama"
+          mv "${GITHUB_WORKSPACE}/llm-target-determinator" "${WS}/llm-target-determinator"
+          ln -sfn "${GITHUB_WORKSPACE}" "${WS}/pytorch"
+          echo "TD_WORKSPACE=${WS}" >> "${GITHUB_ENV}"
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
         with:
@@ -64,29 +85,26 @@ jobs:
           AWS_DEFAULT_REGION: us-east-1
         run: |
           # Do this outside of docker so I don't have to put env vars in
-          pip3 install awscli==1.29.40
-          cd codellama
+          pip3 install -q awscli==1.29.40
+          cd "${TD_WORKSPACE}/codellama"
           mkdir "CodeLlama-7b-Python"
+          # --quiet: the checkpoint is many files; without it the per-object
+          # "download:" lines flood the log.
           aws s3 cp \
             "s3://target-determinator-assets/CodeLlama-7b-Python" \
             "CodeLlama-7b-Python" \
-            --recursive
+            --recursive \
+            --quiet
 
       - name: Run indexer
         shell: bash -l {0}
         env:
           AWS_DEFAULT_REGION: us-east-1
         run: |
-          # Runs inside the CI image (container:). td_llm_indexer.sh / indexer.py
-          # expect pytorch, codellama and llm-target-determinator as sibling dirs,
-          # but setup-linux checks pytorch out directly at GITHUB_WORKSPACE (with
-          # the other two as subdirs). Recreate the sibling layout with symlinks.
-          WS="${RUNNER_TEMP}/td-workspace"
-          mkdir -p "${WS}"
-          ln -sfn "${GITHUB_WORKSPACE}" "${WS}/pytorch"
-          ln -sfn "${GITHUB_WORKSPACE}/codellama" "${WS}/codellama"
-          ln -sfn "${GITHUB_WORKSPACE}/llm-target-determinator" "${WS}/llm-target-determinator"
-          cd "${WS}"
+          # Sibling layout (pytorch / codellama / llm-target-determinator) was
+          # set up in "Set up sibling workspace for the indexer". `pytorch` is a
+          # symlink to the checkout; the script cd's between the siblings.
+          cd "${TD_WORKSPACE}"
           bash pytorch/.github/scripts/td_llm_indexer.sh
 
       - name: Upload to s3
@@ -94,7 +112,7 @@ jobs:
         env:
           AWS_DEFAULT_REGION: us-east-1
         run: |
-          cd llm-target-determinator/assets
+          cd "${TD_WORKSPACE}/llm-target-determinator/assets"
 
           TIMESTAMP=$(date -Iseconds)
           ZIP_NAME="indexer-files-${TIMESTAMP}.zip"

--- a/.github/workflows/target-determination-indexer.yml
+++ b/.github/workflows/target-determination-indexer.yml
@@ -20,42 +20,23 @@ jobs:
       issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
+      check_experiments: "arc,lf"
 
   index:
     needs: get-label-type
-    runs-on: "${{ needs.get-label-type.outputs.label-type }}linux.g5.4xlarge.nvidia.gpu" # 1 GPU A10G 24GB each
+    # OSDC A10G GPU runner (equivalent of linux.g5.4xlarge.nvidia.gpu).
+    runs-on: "${{ needs.get-label-type.outputs.label-type }}l-x86aavx2-29-113-a10g"
     environment: target-determinator-env
+    # Run inside the CUDA CI image on OSDC (ARC has no host docker daemon). The
+    # public GHCR mirror needs no ECR creds; --gpus all exposes the A10G.
+    container:
+      image: ghcr.io/pytorch/ci-image:pytorch-linux-jammy-cuda13.0-cudnn9-py3-gcc11-${{ needs.get-label-type.outputs.ci-docker-hash }}
+      options: "--gpus all"
     steps:
       - name: Setup Linux
         uses: pytorch/pytorch/.github/actions/setup-linux@main
-
-      - name: Login to ECR
-        uses: ./.github/actions/ecr-login
-
-      - name: Calculate docker image
-        id: calculate-docker-image
-        uses: pytorch/test-infra/.github/actions/calculate-docker-image@main
         with:
-          docker-image-name: ci-image:pytorch-linux-jammy-cuda13.0-cudnn9-py3-gcc11
-          working-directory: .
-
-      - name: Use following to pull public copy of the image
-        id: print-ghcr-mirror
-        env:
-          ECR_DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image }}
-        shell: bash
-        run: |
-          tag=${ECR_DOCKER_IMAGE##*:}
-          echo "docker pull ghcr.io/pytorch/ci-image:${tag/:/-}"
-
-      - name: Pull docker image
-        uses: pytorch/test-infra/.github/actions/pull-docker-image@main
-        with:
-          docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}
-
-      - name: Install nvidia driver, nvidia-docker runtime, set GPU_FLAG
-        id: install-nvidia-driver
-        uses: pytorch/test-infra/.github/actions/setup-nvidia@main
+          use-arc: true
 
       - name: Clone CodeLlama
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -94,34 +75,19 @@ jobs:
       - name: Run indexer
         shell: bash -l {0}
         env:
-          DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image }}
-          GITHUB_RUN_ID: ${{ github.run_id }}
           AWS_DEFAULT_REGION: us-east-1
         run: |
-          # detached container should get cleaned up by teardown_ec2_linux
-          # Disable shellcheck warning for GPU_FLAG
-          # shellcheck disable=SC2086
-          # setup-linux checks out pytorch directly at GITHUB_WORKSPACE, but
-          # llm-target-determinator@v0.0.2 expects `pytorch/` as a sibling of
-          # its own checkout, so remap the layout inside the container.
-          container_name=$(docker run \
-            ${GPU_FLAG:-} \
-            -e MAX_JOBS="$(nproc --ignore=2)" \
-            -e AWS_DEFAULT_REGION \
-            --env-file="/tmp/github_env_${GITHUB_RUN_ID}" \
-            --security-opt seccomp=unconfined \
-            --cap-add=SYS_PTRACE \
-            --tty \
-            --detach \
-            --user jenkins \
-            -v "${GITHUB_WORKSPACE}:/var/lib/jenkins/workspace/pytorch" \
-            -v "${GITHUB_WORKSPACE}/codellama:/var/lib/jenkins/workspace/codellama" \
-            -v "${GITHUB_WORKSPACE}/llm-target-determinator:/var/lib/jenkins/workspace/llm-target-determinator" \
-            -w /var/lib/jenkins/workspace \
-            "${DOCKER_IMAGE}"
-          )
-          chmod +x .github/scripts/td_llm_indexer.sh
-          docker exec -t "${container_name}" sh -c 'pytorch/.github/scripts/td_llm_indexer.sh'
+          # Runs inside the CI image (container:). td_llm_indexer.sh / indexer.py
+          # expect pytorch, codellama and llm-target-determinator as sibling dirs,
+          # but setup-linux checks pytorch out directly at GITHUB_WORKSPACE (with
+          # the other two as subdirs). Recreate the sibling layout with symlinks.
+          WS="${RUNNER_TEMP}/td-workspace"
+          mkdir -p "${WS}"
+          ln -sfn "${GITHUB_WORKSPACE}" "${WS}/pytorch"
+          ln -sfn "${GITHUB_WORKSPACE}/codellama" "${WS}/codellama"
+          ln -sfn "${GITHUB_WORKSPACE}/llm-target-determinator" "${WS}/llm-target-determinator"
+          cd "${WS}"
+          bash pytorch/.github/scripts/td_llm_indexer.sh
 
       - name: Upload to s3
         shell: bash -l {0}
@@ -151,10 +117,6 @@ jobs:
           aws s3 cp \
             "${ZIP_NAME}" \
             "s3://target-determinator-assets/indexes/latest/${ZIP_NAME}"
-
-      - name: Teardown Linux
-        uses: pytorch/test-infra/.github/actions/teardown-linux@main
-        if: always()
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
Run the nightly GPU indexer inside the CUDA CI image via `container:` on an OSDC A10G runner (`l-x86aavx2-29-113-a10g`), instead of `docker run`/`docker exec` on an EC2 host — ARC has no host docker daemon.

- Image from the **public GHCR mirror** (`ghcr.io/pytorch/ci-image:…-${ci-docker-hash}`), so no ECR creds; `options: --gpus all` exposes the A10G.
- Recreate the sibling `pytorch`/`codellama`/`llm-target-determinator` layout (that `indexer.py` expects) with symlinks.
- Dropped `ecr-login`, `calculate-docker-image`, `pull-docker-image`, `setup-nvidia`, `teardown-linux`.
- Keeps the `gha_target_determinator_s3_read_write` OIDC role for the index publish (write).

### Testing

https://github.com/pytorch/pytorch/actions/runs/28482704033