### PR TITLE
Propagate override_cudagraphs annotation across graph-break frame boundaries

### DIFF
--- a/test/dynamo/test_decorators.py
+++ b/test/dynamo/test_decorators.py
@@ -2519,6 +2519,168 @@ Detected recompile when torch.compile stance is 'fail_on_recompile'. filename: '
         ):
             compiled(torch.randn(4))
 
+    def test_override_cudagraphs_annotation_nested_graph_break(self):
+        # override_cudagraphs must propagate its annotation onto every compiled
+        # subgraph even when the graph break happens inside a nested callee
+        # that is compiled as a separate frame (it cannot be inlined). This is a
+        # device-independent check on gm.meta, so it does not require CUDA.
+        annotations = []
+
+        def backend(gm, example_inputs):
+            annotations.append(gm.meta.get("cudagraph_annotation"))
+            return gm.forward
+
+        def callee(x):
+            y = x + 1
+            torch._dynamo.graph_break()
+            return y * 2
+
+        def ctx_mgr(x):
+            with torch._dynamo.override_cudagraphs(fwd=True, bwd=False):
+                return callee(x)
+
+        torch._dynamo.reset()
+        torch.compile(ctx_mgr, backend=backend)(torch.randn(4))
+        # Both segments of the callee (before and after the break) carry it.
+        self.assertEqual(len(annotations), 2)
+        for ann in annotations:
+            self.assertIsNotNone(ann)
+            self.assertEqual((ann.fwd, ann.bwd), (True, False))
+
+    def test_override_cudagraphs_annotation_decorator_graph_break(self):
+        # Decorator form: a decorated function whose body contains a graph break
+        # is split into multiple compiled segments. Every segment must carry the
+        # annotation, even though the decorator's `with` lives in the wrapper
+        # frame and the body is compiled as a separate frame. Device-independent
+        # check on gm.meta, so it does not require CUDA.
+        annotations = []
+
+        def backend(gm, example_inputs):
+            annotations.append(gm.meta.get("cudagraph_annotation"))
+            return gm.forward
+
+        @torch._dynamo.override_cudagraphs(fwd=True, bwd=False)
+        def inner(x):
+            y = x + 1
+            torch._dynamo.graph_break()
+            return y * 2
+
+        def model(x):
+            return inner(x)
+
+        torch._dynamo.reset()
+        torch.compile(model, backend=backend)(torch.randn(4))
+        self.assertEqual(len(annotations), 2)
+        for ann in annotations:
+            self.assertIsNotNone(ann)
+            self.assertEqual((ann.fwd, ann.bwd), (True, False))
+
+    def test_override_cudagraphs_annotation_disable_graph_break(self):
+        # The disable case (fwd=False) flows through the same separate-frame
+        # seeding path and must also propagate across a graph break in a
+        # separately-compiled callee. Device-independent check on gm.meta.
+        annotations = []
+
+        def backend(gm, example_inputs):
+            annotations.append(gm.meta.get("cudagraph_annotation"))
+            return gm.forward
+
+        def callee(x):
+            y = x + 1
+            torch._dynamo.graph_break()
+            return y * 2
+
+        def model(x):
+            with torch._dynamo.override_cudagraphs(fwd=False, bwd=False):
+                return callee(x)
+
+        torch._dynamo.reset()
+        torch.compile(model, backend=backend)(torch.randn(4))
+        self.assertEqual(len(annotations), 2)
+        for ann in annotations:
+            self.assertIsNotNone(ann)
+            self.assertEqual((ann.fwd, ann.bwd), (False, False))
+
+    def test_override_cudagraphs_annotation_nested_overrides_graph_break(self):
+        # Nested overrides: the innermost (most recently entered) override wins
+        # while active, and on exit the runtime stack restores the outer one so
+        # a later separately-compiled callee sees it. Each callee graph-breaks,
+        # so it is compiled as a separate frame seeded from the runtime
+        # top-of-stack override. inner_callee and outer_callee are distinct code
+        # objects (reusing one callee would be a sticky cache hit and would not
+        # recompile under the restored override). Device-independent.
+        annotations = []
+
+        def backend(gm, example_inputs):
+            annotations.append(gm.meta.get("cudagraph_annotation"))
+            return gm.forward
+
+        def inner_callee(x):
+            y = x + 1
+            torch._dynamo.graph_break()
+            return y * 2
+
+        def outer_callee(x):
+            y = x + 1
+            torch._dynamo.graph_break()
+            return y * 2
+
+        def model(x):
+            with torch._dynamo.override_cudagraphs(fwd=True, bwd=False):
+                with torch._dynamo.override_cudagraphs(fwd=False, bwd=True):
+                    z = inner_callee(x)
+                # Inner override popped here; outer (True, False) is restored.
+                return outer_callee(z)
+
+        torch._dynamo.reset()
+        torch.compile(model, backend=backend)(torch.randn(4))
+        for ann in annotations:
+            self.assertIsNotNone(ann)
+        vals = [(ann.fwd, ann.bwd) for ann in annotations]
+        # Every segment carries one of the two overrides, never None or a
+        # partial/leaked value (segment counts depend on nested_graph_breaks).
+        self.assertTrue(all(v in {(False, True), (True, False)} for v in vals))
+        # Inner override wins while active (inner_callee's segments).
+        self.assertIn((False, True), vals)
+        # After the inner `with` exits, __exit__ restores the outer override so
+        # outer_callee sees it. Absent if __exit__ fails to pop/restore.
+        self.assertIn((True, False), vals)
+
+    def test_override_cudagraphs_annotation_not_guarded_first_compile_wins(self):
+        # We intentionally do NOT guard on the dynamo global cudagraph override
+        # state. The annotation is therefore sticky per code object: the first
+        # compile wins, and toggling the override on a later call does NOT
+        # recompile. This pins that intentional behavior; if a guard is added
+        # later this test will flip (the second call would recompile).
+        annotations = []
+
+        def backend(gm, example_inputs):
+            annotations.append(gm.meta.get("cudagraph_annotation"))
+            return gm.forward
+
+        @torch.compile(backend=backend)
+        def callee(x):
+            y = x + 1
+            torch._dynamo.graph_break()
+            return y * 2
+
+        torch._dynamo.reset()
+        # First reach callee from inside an override; its two segments compile
+        # with the override annotation baked in.
+        with torch._dynamo.override_cudagraphs(fwd=True, bwd=True):
+            callee(torch.randn(4))
+        self.assertEqual(len(annotations), 2)
+        for ann in annotations:
+            self.assertIsNotNone(ann)
+            self.assertEqual((ann.fwd, ann.bwd), (True, True))
+
+        annotations.clear()
+        # Reach the same callee with no active override. Because the override
+        # state is not guarded, callee is not recompiled: the backend is not
+        # invoked again and the first-compile annotation sticks.
+        callee(torch.randn(4))
+        self.assertEqual(annotations, [])
+
 
 instantiate_parametrized_tests(DecoratorTests)
 

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -3442,6 +3442,110 @@ if HAS_CUDA_AND_TRITON:
             # g2 and g3 use cudagraphs (2 graphs recorded)
             self.assertEqual(self.get_manager().new_graph_id().id, 2)
 
+        @torch._inductor.config.patch("triton.cudagraphs", False)
+        def test_cudagraph_annotation_enable_nested_callee_graph_break(self):
+            """Context manager enables cudagraphs across a graph break that
+            occurs inside a nested callee, even though the `with` block lives
+            in the caller's frame and the callee is compiled as a separate
+            frame (it cannot be inlined because it contains a graph break)."""
+
+            def callee(x):
+                y = x + 1  # segment 1 (inside override) -> cudagraphs
+                torch._dynamo.graph_break()
+                return y * 2  # segment 2 (inside override) -> cudagraphs
+
+            def model(x):
+                with torch._dynamo.override_cudagraphs(fwd=True, bwd=True):
+                    return callee(x)
+
+            compiled = torch.compile(model)
+            for _ in range(3):
+                inp = torch.randn(4, 4, device="cuda")
+                torch.compiler.cudagraph_mark_step_begin()
+                out = compiled(inp)
+
+            self.assertEqual(out, (inp + 1) * 2)
+            self.assertIsNotNone(self.get_manager())
+            # both callee segments use cudagraphs (2 graphs recorded)
+            self.assertEqual(self.get_manager().new_graph_id().id, 2)
+
+        @torch._inductor.config.patch("triton.cudagraphs", False)
+        def test_cudagraph_annotation_enable_module_forward_graph_break(self):
+            """Decorator on a module's forward enables cudagraphs for every
+            segment even when the forward contains a graph break (the forward
+            is compiled as a separate frame from its caller)."""
+
+            class MyModule(torch.nn.Module):
+                @torch._dynamo.override_cudagraphs(fwd=True, bwd=True)
+                def forward(self, x):
+                    y = x + 1  # segment 1 -> cudagraphs
+                    torch._dynamo.graph_break()
+                    return y * 2  # segment 2 -> cudagraphs
+
+            mod = MyModule().cuda()
+
+            def model(x):
+                return mod(x)
+
+            compiled = torch.compile(model)
+            for _ in range(3):
+                inp = torch.randn(4, 4, device="cuda")
+                torch.compiler.cudagraph_mark_step_begin()
+                out = compiled(inp)
+
+            self.assertEqual(out, (inp + 1) * 2)
+            self.assertIsNotNone(self.get_manager())
+            self.assertEqual(self.get_manager().new_graph_id().id, 2)
+
+        def test_cudagraph_annotation_disable_nested_callee_graph_break(self):
+            """Context manager disables cudagraphs across a graph break inside a
+            nested callee compiled as a separate frame, even though the default
+            (reduce-overhead) config would otherwise record cudagraphs."""
+
+            def callee(x):
+                y = x + 1  # segment 1 (inside override) -> no cudagraphs
+                torch._dynamo.graph_break()
+                return y * 2  # segment 2 (inside override) -> no cudagraphs
+
+            def model(x):
+                with torch._dynamo.override_cudagraphs(fwd=False, bwd=False):
+                    return callee(x)
+
+            inp = torch.randn(4, 4, device="cuda")
+            compiled = torch.compile(model, mode="reduce-overhead")
+            out = compiled(inp)
+
+            self.assertEqual(out, (inp + 1) * 2)
+            # No callee segment is recorded despite reduce-overhead default.
+            self.assertIsNone(self.get_manager())
+
+        def test_cudagraph_annotation_disable_bwd_nested_callee_graph_break(self):
+            """Asymmetric override (fwd=True, bwd=False) propagates across a
+            graph break in a separately-compiled callee: both forward segments
+            record cudagraphs while the backward is disabled."""
+
+            def callee(x):
+                y = (x * x).sin()  # forward segment 1
+                torch._dynamo.graph_break()
+                return y + 1  # forward segment 2
+
+            def model(x):
+                with torch._dynamo.override_cudagraphs(fwd=True, bwd=False):
+                    return callee(x)
+
+            compiled = torch.compile(model, mode="reduce-overhead")
+            for _ in range(3):
+                inp = torch.randn(4, 4, device="cuda", requires_grad=True)
+                torch.compiler.cudagraph_mark_step_begin()
+                out = compiled(inp)
+                out.sum().backward()
+
+            self.assertEqual(out, (inp.detach().pow(2).sin()) + 1)
+            self.assertIsNotNone(self.get_manager())
+            # Two forward segments record; backward is disabled (no bwd graphs),
+            # matching the forward-only count of the enable variant above.
+            self.assertEqual(self.get_manager().new_graph_id().id, 2)
+
         def test_cudagraph_min_partition_size_skip_small(self):
             """Partitions with fewer kernels than the threshold are skipped."""
 

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -36,7 +36,9 @@ from .external_utils import (
     wrap_dunder_call_ctx_manager,
 )
 from .utils import (
+    _get_cudagraph_override,
     _get_error_on_graph_break,
+    _set_cudagraph_override,
     _set_error_on_graph_break,
     allow_lru_cache_wrapper_trace_without_warning,
     is_function,
@@ -1675,11 +1677,19 @@ class CudagraphOverrideContextManager:
     def __init__(self, fwd: bool | None = None, bwd: bool | None = None) -> None:
         self.fwd = fwd
         self.bwd = bwd
+        self.prev_cudagraph_override: list[tuple[bool | None, bool | None] | None] = []
 
     __call__ = wrap_dunder_call_ctx_manager
 
     def __enter__(self) -> None:
-        pass
+        # Set the override at runtime so it follows the dynamic call stack.
+        # Dynamo handles the lexical `with` symbolically and does not run this
+        # __enter__ at trace time; it runs when the generated/resumed bytecode
+        # re-enters the context, before invoking callees that are compiled as
+        # separate frames. OutputGraph seeds its annotation from this value via
+        # _get_cudagraph_override. Mirrors ErrorOnGraphBreakDecoratorContextManager.
+        self.prev_cudagraph_override.append(_get_cudagraph_override())
+        _set_cudagraph_override((self.fwd, self.bwd))
 
     def __exit__(
         self,
@@ -1687,7 +1697,7 @@ class CudagraphOverrideContextManager:
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> None:
-        pass
+        _set_cudagraph_override(self.prev_cudagraph_override.pop())
 
 
 def override_cudagraphs(

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -145,6 +145,7 @@ from .source import (
 )
 from .utils import (
     _extract_tensor_dict,
+    _get_cudagraph_override,
     checkpoint_params,
     CleanupHook,
     clone_inputs,
@@ -802,10 +803,21 @@ class OutputGraph(OutputGraphCommon):
             "co_firstlineno": f_code.co_firstlineno,
         }
 
-        # Cudagraph annotation is set during inlining in
-        # InliningInstructionTranslator.build_inline_tracer when a decorated
-        # function is inlined.
+        # The cudagraph annotation is normally set while tracing an
+        # `override_cudagraphs` context manager / decorator within this
+        # frame (see CudagraphOverrideVariable). Seed it here from any
+        # runtime-active override so a callee compiled as a separate frame
+        # (e.g. because it contains a graph break and cannot be inlined)
+        # inherits the override that lives lexically in a caller's frame.
+        # NOTE: we intentionally do not guard on the override state, so the
+        # override is sticky per code object (first compile wins): a function
+        # reached both inside and outside an override keeps whichever override
+        # was active when it first compiled.
         self.cudagraph_annotation: _CudagraphAnnotation | None = None
+        if (_override := _get_cudagraph_override()) is not None:
+            from torch._inductor import _CudagraphAnnotation as _CGA
+
+            self.cudagraph_annotation = _CGA(fwd=_override[0], bwd=_override[1])
 
         self.region_tracker = GraphRegionTracker()
         self._emit_debugger_breakpoint: bool = False

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -5743,6 +5743,28 @@ def record_pregraph_bytecode_exit(cm: AbstractContextManager[None]) -> None:
     cm.__exit__(None, None, None)
 
 
+# Active `torch._dynamo.override_cudagraphs` override, set/restored at RUNTIME by
+# CudagraphOverrideContextManager.__enter__/__exit__ (mirrors _error_on_graph_break
+# above). This lets the override follow the dynamic call stack: a callee that
+# cannot be inlined (e.g. it contains a graph break) is compiled as a separate
+# frame and would otherwise not inherit the override, which lives lexically in a
+# caller's `with` block / decorator. OutputGraph seeds its cudagraph_annotation
+# from this value. None means no override is active; otherwise it is the
+# (fwd, bwd) pair. NOTE: we intentionally do not guard on this, so the override
+# is sticky per code object (first compile wins) for functions reached both
+# inside and outside it.
+_cudagraph_override: tuple[bool | None, bool | None] | None = None
+
+
+def _get_cudagraph_override() -> tuple[bool | None, bool | None] | None:
+    return _cudagraph_override
+
+
+def _set_cudagraph_override(value: tuple[bool | None, bool | None] | None) -> None:
+    global _cudagraph_override
+    _cudagraph_override = value
+
+
 # Returns a set of code objects present traced in the current TracingContext, or None
 # if there is no current TracingContext.
 def get_traced_code() -> list[CodeType] | None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

Fix override_cudagraphs so its cudagraph annotation reaches callees that are
compiled as separate frames.

Root cause: the cudagraph annotation was only set while tracing the
override_cudagraphs context manager / decorator within a frame (and during
inlining). A callee that cannot be inlined -- e.g. because it contains a graph
break -- is compiled as its own frame, so it never inherited the override that
lives lexically in a caller's `with` block / decorator. Those segments silently
ignored the override.

Fix: mirror the existing _error_on_graph_break mechanism. Add a module-global
_cudagraph_override in torch/_dynamo/utils.py that CudagraphOverrideContextManager
sets/restores at runtime in __enter__/__exit__ (using a per-instance list as a
push/pop stack so a reused decorator instance stays balanced under reentrancy).
OutputGraph.__init__ seeds its cudagraph_annotation from this runtime-active
override, so a separately-compiled callee frame inherits the override that is
active on the dynamic call stack.

This override state is intentionally not guarded: the annotation is sticky per
code object (first compile wins) for a function reached both inside and outside
an override. This matches the _error_on_graph_break precedent and is documented
inline.

Review order: utils.py (the runtime state), then decorators.py (set/restore),
then output_graph.py (seed the annotation).

Test Plan:

Device-independent gm.meta checks (no GPU required):

```
python test/dynamo/test_decorators.py \
  DecoratorTests.test_override_cudagraphs_annotation_nested_graph_break \
  DecoratorTests.test_override_cudagraphs_annotation_decorator_graph_break \
  DecoratorTests.test_override_cudagraphs_annotation_disable_graph_break \
  DecoratorTests.test_override_cudagraphs_annotation_nested_overrides_graph_break \
  DecoratorTests.test_override_cudagraphs_annotation_not_guarded_first_compile_wins
```

End-to-end cudagraph recording (CUDA + triton):

```
python test/inductor/test_cudagraph_trees.py \
  CudaGraphTreeTests.test_cudagraph_annotation_enable_nested_callee_graph_break \
  CudaGraphTreeTests.test_cudagraph_annotation_enable_module_forward_graph_break \
  CudaGraphTreeTests.test_cudagraph_annotation_disable_nested_callee_graph_break \
  CudaGraphTreeTests.test_cudagraph_annotation_disable_bwd_nested_callee_graph_break
```

Regression check over the full pre-existing annotation suite:

```
python test/inductor/test_cudagraph_trees.py -k cudagraph_annotation
```

All of the above pass locally (5 dynamo tests; 17 cudagraph_trees tests
including the 4 new graph-break tests).

This change was authored with the assistance of Claude Code.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98