### PR TITLE
[MPS] copy for contiguous same-dtype using a compute kernel

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Copy.metal
+++ b/aten/src/ATen/native/mps/kernels/Copy.metal
@@ -71,9 +71,9 @@ REGISTER_UNARY_OP(copy_conj_neg, float2, float2);
 REGISTER_UNARY_OP(copy_conj_neg, half2, half2);
 
 // Byte-erased identity copy of an inner-contiguous view: a same-dtype copy has
-// no functor, so move the contiguous inner run as raw bytes with the widest
-// aligned vector (uint4 -> ushort -> byte ladder) regardless of element dtype.
-// grid.x indexes 16-byte chunks of the inner run.
+// no functor, so move the contiguous inner run as raw bytes via
+// copy_bytes_aligned regardless of element dtype. grid.x indexes 16-byte chunks
+// of the inner run.
 kernel void inner_contiguous_copy(
     device uchar* output [[buffer(0)]],
     constant uchar* input [[buffer(1)]],
@@ -84,7 +84,7 @@ kernel void inner_contiguous_copy(
     uint2 thread_pos [[thread_position_in_grid]]) {
   const uint ndim_outer = ndim_outer_inner_bytes.x;
   const uint inner_bytes = ndim_outer_inner_bytes.y;
-  uint pos = thread_pos.x * 16;
+  const uint pos = thread_pos.x * 16;
   if (pos >= inner_bytes) {
     return;
   }
@@ -95,35 +95,5 @@ kernel void inner_contiguous_copy(
       offset_from_coord(opos, output_outer_strides, ndim_outer);
   device uchar* o = output + out_base + pos;
   constant uchar* in = input + in_base + pos;
-  uint n = min(16u, inner_bytes - pos);
-  if (n < 16) {
-    for (uint k = 0; k < n; ++k) {
-      o[k] = in[k];
-    }
-    return;
-  }
-  uint align = (reinterpret_cast<ulong>(o) | reinterpret_cast<ulong>(in)) & 15;
-  if (align == 0) {
-    *reinterpret_cast<device uint4*>(o) =
-        *reinterpret_cast<constant uint4*>(in);
-  } else if ((align & 7) == 0) {
-    for (uint k = 0; k < 2; ++k) {
-      reinterpret_cast<device uint2*>(o)[k] =
-          reinterpret_cast<constant uint2*>(in)[k];
-    }
-  } else if ((align & 3) == 0) {
-    for (uint k = 0; k < 4; ++k) {
-      reinterpret_cast<device uint*>(o)[k] =
-          reinterpret_cast<constant uint*>(in)[k];
-    }
-  } else if ((align & 1) == 0) {
-    for (uint k = 0; k < 8; ++k) {
-      reinterpret_cast<device ushort*>(o)[k] =
-          reinterpret_cast<constant ushort*>(in)[k];
-    }
-  } else {
-    for (uint k = 0; k < 16; ++k) {
-      o[k] = in[k];
-    }
-  }
+  copy_bytes_aligned(o, in, min(16u, inner_bytes - pos));
 }

--- a/aten/src/ATen/native/mps/kernels/Copy.metal
+++ b/aten/src/ATen/native/mps/kernels/Copy.metal
@@ -97,3 +97,20 @@ kernel void inner_contiguous_copy(
   constant uchar* in = input + in_base + pos;
   copy_bytes_aligned(o, in, min(16u, inner_bytes - pos));
 }
+
+// Fully contiguous same-dtype copy: a flat byte run, so no outer offsets to
+// compute. The host issues one dispatch per <=2GB chunk (base is the chunk's
+// byte offset, chunk_bytes its size), matching the blit path's chunking.
+kernel void contiguous_byte_copy(
+    device uchar* out [[buffer(0)]],
+    constant uchar* in [[buffer(1)]],
+    constant uint& chunk_bytes [[buffer(2)]],
+    constant ulong& base [[buffer(3)]],
+    uint tid [[thread_position_in_grid]]) {
+  const uint pos = tid * 16;
+  if (pos >= chunk_bytes) {
+    return;
+  }
+  copy_bytes_aligned(
+      out + base + pos, in + base + pos, min(16u, chunk_bytes - pos));
+}

--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -62,11 +62,12 @@ static void copy_cast_kernel_mps(at::Tensor& dst, const at::Tensor& src) {
 }
 
 // Byte-erased compute copy, not a blit: faster at small sizes and avoids the encoder switch.
-// One dispatch per <=2GB chunk keeps chunk_bytes in uint.
+// One dispatch per <=2GB chunk keeps chunk_bytes in uint. Callers must pass contiguous src and
+// dst with equal nbytes (both are treated as flat byte runs).
 static void contiguous_copy_kernel_mps(at::Tensor& dst, const at::Tensor& src, bool non_blocking) {
   uint64_t profile_id = getMPSProfiler().beginProfileCopy(
       getMTLBufferStorage(src), getMTLBufferStorage(dst), src, dst, src.nbytes(), non_blocking, /*usesBlitter=*/false);
-  auto kernel = lib.getKernelFunction("contiguous_byte_copy");
+  auto* kernel = lib.getCachedKernelFunctionPtr("contiguous_byte_copy");
   constexpr size_t max_chunk = 0x80000000; // 2GB
   const size_t total = src.nbytes();
   kernel->runCommandBlock([&] {

--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -61,6 +61,31 @@ static void copy_cast_kernel_mps(at::Tensor& dst, const at::Tensor& src) {
   lib.exec_unary_kernel(iter, std::string(name), std::nullopt, std::nullopt, /*ilp_threshold=*/131072u);
 }
 
+// Byte-erased compute copy, not a blit: faster at small sizes and avoids the encoder switch.
+// One dispatch per <=2GB chunk keeps chunk_bytes in uint.
+static void contiguous_copy_kernel_mps(at::Tensor& dst, const at::Tensor& src, bool non_blocking) {
+  uint64_t profile_id = getMPSProfiler().beginProfileCopy(
+      getMTLBufferStorage(src), getMTLBufferStorage(dst), src, dst, src.nbytes(), non_blocking, /*usesBlitter=*/false);
+  auto kernel = lib.getKernelFunction("contiguous_byte_copy");
+  constexpr size_t max_chunk = 0x80000000; // 2GB
+  const size_t total = src.nbytes();
+  kernel->runCommandBlock([&] {
+    kernel->startEncoding();
+    kernel->setArg(0, dst);
+    kernel->setArg(1, src);
+    for (size_t base = 0; base < total;) {
+      const uint32_t chunk = static_cast<uint32_t>(std::min(max_chunk, total - base));
+      kernel->setArg(2, chunk);
+      kernel->setArg(3, static_cast<uint64_t>(base));
+      kernel->dispatch((chunk + 15) / 16);
+      base += chunk;
+    }
+  });
+  if (profile_id) {
+    getMPSProfiler().endProfileCopy(profile_id, SyncType::NONE);
+  }
+}
+
 static void* pageAlignedBlockPtr(const void* ptr, NSUInteger size, NSUInteger* alignedBlockSize) {
   uintptr_t address = (uintptr_t)ptr;
   uintptr_t alignedAddress = address & ~(PAGE_SIZE - 1);
@@ -251,11 +276,10 @@ void copy_blit_mps(void* dst, const void* src, size_t size) {
 }
 
 static at::Tensor& copy_kernel_mps(at::Tensor& dst_, const at::Tensor& src_, bool non_blocking) {
-  auto src_byte_offset = src_.storage_offset() * src_.itemsize();
   auto dst_byte_offset = dst_.storage_offset() * dst_.itemsize();
 
   // If dst is contiguous and there is no byte offset, we can save directly the result of
-  // gather into dst. This reduces the overhead of doing an additional blit for most cases.
+  // gather into dst. This reduces the overhead of doing an additional copy for most cases.
   bool returnGatherOutput = dst_.is_contiguous();
   Tensor src;
   auto sameMemFormat =
@@ -273,21 +297,15 @@ static at::Tensor& copy_kernel_mps(at::Tensor& dst_, const at::Tensor& src_, boo
       if (returnGatherOutput) {
         return dst_;
       }
-
-      src_byte_offset = 0;
     } else {
       src = src_.expand_as(dst_).contiguous();
-      src_byte_offset = src.storage_offset() * src.itemsize();
     }
   } else {
     src = src_;
   }
   id<MTLBuffer> destBuffer = getMTLBufferStorage(dst_);
-  id<MTLBuffer> sourceBuffer = getMTLBufferStorage(src);
 
-  // Scatter to `dst` if the memory is not contiguous
-  // If the memory is not contiguous, it means that the tensor has strides and we would not be
-  // able to do the copy using a single blit
+  // Strided dst can't be written as one contiguous run: route it through the scatter kernel.
   if (!dst_.is_contiguous(MemoryFormat::Contiguous) && !sameMemFormat) {
     return scatterViewTensor(src, dst_);
   }
@@ -296,9 +314,7 @@ static at::Tensor& copy_kernel_mps(at::Tensor& dst_, const at::Tensor& src_, boo
 
   MPSStream* stream = getCurrentMPSStream();
   if (sameDataType) {
-    uint64_t profile_id = getMPSProfiler().beginProfileCopy(sourceBuffer, destBuffer, src, dst_, src.nbytes(), true);
-    // for GPU to GPU copies we only encode to stream's command buffer (no flushing)
-    stream->copy(sourceBuffer, destBuffer, src.nbytes(), src_byte_offset, dst_byte_offset, profile_id);
+    contiguous_copy_kernel_mps(dst_, src, non_blocking);
   } else {
     if (dst_byte_offset) {
       auto maybeCastedSource =

--- a/c10/metal/utils.h
+++ b/c10/metal/utils.h
@@ -560,5 +560,37 @@ inline float hypot(float a_, float b_) {
   MACRO(half);                             \
   MACRO(bfloat);
 
+// Copy n bytes from src to dst using the widest vector their combined alignment
+// allows (uint4 -> uint2 -> uint -> ushort -> byte), with a scalar tail.
+inline void copy_bytes_aligned(device uchar* dst, constant uchar* src, uint n) {
+  const uint align =
+      (reinterpret_cast<ulong>(dst) | reinterpret_cast<ulong>(src)) & 15;
+  uint i = 0;
+  if (align == 0) {
+    for (; i + 16 <= n; i += 16) {
+      *reinterpret_cast<device uint4*>(dst + i) =
+          *reinterpret_cast<constant uint4*>(src + i);
+    }
+  } else if ((align & 7) == 0) {
+    for (; i + 8 <= n; i += 8) {
+      *reinterpret_cast<device uint2*>(dst + i) =
+          *reinterpret_cast<constant uint2*>(src + i);
+    }
+  } else if ((align & 3) == 0) {
+    for (; i + 4 <= n; i += 4) {
+      *reinterpret_cast<device uint*>(dst + i) =
+          *reinterpret_cast<constant uint*>(src + i);
+    }
+  } else if ((align & 1) == 0) {
+    for (; i + 2 <= n; i += 2) {
+      *reinterpret_cast<device ushort*>(dst + i) =
+          *reinterpret_cast<constant ushort*>(src + i);
+    }
+  }
+  for (; i < n; ++i) {
+    dst[i] = src[i];
+  }
+}
+
 } // namespace metal
 } // namespace c10

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -10075,6 +10075,22 @@ class TestInnerContiguous(TestCaseMPS):
         # whole-buffer compare also proves the copy leaves neighbors untouched
         self.assertEqual(dst_dev.cpu(), dst_cpu)
 
+    @parametrize("dtype", [torch.int8, torch.int16, torch.float32, torch.complex64])
+    @parametrize("offset", [0, 1, 2, 4])
+    def test_contiguous_copy(self, device, dtype, offset):
+        # Fully contiguous same-dtype clone hits contiguous_byte_copy; offset varies the
+        # base byte alignment and n spans sub-16B totals through the vectorized path.
+        torch.manual_seed(0)
+        for n in (1, 7, 16, 17, 1000):
+            if dtype.is_complex:
+                full = torch.randn(offset + n, dtype=dtype)
+            elif dtype.is_floating_point:
+                full = torch.randn(offset + n).to(dtype)
+            else:
+                full = torch.randint(-100, 100, (offset + n,), dtype=dtype)
+            dev = full.to(device)
+            self.assertEqual(dev[offset:].clone().cpu(), full[offset:])
+
 
 class TestLargeTensors(TestCaseMPS):
     @serialTest()

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -10060,10 +10060,11 @@ class TestInnerContiguous(TestCaseMPS):
 
     @parametrize("dtype", [torch.int8, torch.int16, torch.float32])
     @parametrize("offset", [0, 1, 2, 4, 8])
-    @parametrize("inner", [17, 31, 48])
+    @parametrize("inner", [17, 20, 24, 28, 31, 48])
     def test_byte_copy(self, device, dtype, offset, inner):
         # offset varies the per-row base alignment to exercise the ladder, and
-        # odd inner extents make inner_bytes % 16 != 0 for narrow dtypes.
+        # the inner extents span final-chunk byte remainders (inner_bytes % 16)
+        # across 0, [4,8) and [8,16) so the partial-tail vector paths are hit.
         torch.manual_seed(0)
         R, full_w = 24, offset + inner + 8
         src = _conformance_make_tensor((R, inner), dtype)


### PR DESCRIPTION
Route contiguous same-dtype MPS→MPS copies through a compute kernel instead of a blit. 

`copy_kernel_mps`'s `sameDataType` branch now dispatches a new `contiguous_byte_copy` kernel. Extracted the byte-copy alignment ladder into a reusable c10::metal::copy_bytes_aligned utility (introduced in https://github.com/pytorch/pytorch/pull/188483)

This improves performance of contiguous same type copies. Measured on M2 Max, GB/s = read + write. Consistent across int8 / bfloat16 / float32.

  | size              | blit (GB/s) | compute (GB/s) | speedup    |
  | ----------------- | ----------: | -------------: | ---------- |
  | ≤ 256 KB          |  (latency-bound) |  (latency-bound) | ~1.0× (wash) |
  | 1 MB              |        9–14 |          12–15 | ~1.1–1.3×  |
  | 16 MB             |       75–79 |        149–156 | **~2.0×**  |
  | 64 MB             |        ~111 |        237–242 | **~2.1×**  |
  | 256 MB            |     128–129 |        317–322 | **~2.5×**  |
  | 3 GB (multi-chunk)|        ~135 |        352–362 | **~2.6×**  |

Repro script for measurements: 
[bench_copy_pr.py](https://github.com/user-attachments/files/29525202/bench_copy_pr.py)
