### PR TITLE
[inductor] Enable EFC disk cache reuse for NVGEMM epilogue kernels

### DIFF
--- a/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_kernel.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_kernel.py
@@ -413,17 +413,41 @@ def _unwrap_efc_compiled_obj(compiled_obj):
     return compiled_obj
 
 
-def _rewrap_efc_compiled_obj(compiled_fn, kernel):
+def _init_efc_jit(kernel, epilogue_args):
+    """Lightweight EFC JIT init from epilogue args, without a full kernel.compile().
+
+    EFC.compile() calls analyze_epilogue_with_arguments() then creates the JIT
+    object. We replicate just those two steps so that disk-cached artifacts can
+    be rewrapped without recompiling the CuTe DSL kernel.
+    """
+    from cutlass_api.providers.cutedsl.evt.common_efc import EFC
+    from cutlass_api.utils import TensorWrapper
+
+    efc = kernel.impl.efc
+    params = [
+        e.compile_time_tensor if isinstance(e, TensorWrapper) else e
+        for e in epilogue_args.parameters
+    ]
+    efc.analyze_epilogue_with_arguments(params)
+    efc.jit = EFC.JIT(efc, efc.epilogue_parameter_names)
+
+
+def _rewrap_efc_compiled_obj(compiled_fn, kernel, epilogue_args=None):
     """Reconstruct the EFC wrapped_launch closure from a loaded JIT function.
 
-    Returns None if the kernel's EFC JIT state is not yet initialized
-    (e.g. when loading from disk cache before kernel.compile has run),
-    signaling the caller to fall through and recompile.
+    When epilogue_args is provided and efc.jit is missing, performs a
+    lightweight initialization (analyze + JIT creation) so that
+    disk-cached EFC artifacts can be reused without a full recompile.
+    Falls back to returning None (triggering recompile) only when
+    epilogue_args is not available.
     """
     if not hasattr(kernel, "impl") or not hasattr(kernel.impl, "efc"):
         return compiled_fn
     if not hasattr(kernel.impl.efc, "jit"):
-        return None
+        if epilogue_args is not None:
+            _init_efc_jit(kernel, epilogue_args)
+        else:
+            return None
 
     from cutlass_api.providers.cutedsl.gemm.sm100_static_persistent_efc import (
         KernelOperand,
@@ -501,7 +525,11 @@ def _nvgemm_run(
                 dev_idx,
             )
             if compiled_fn is not None:
-                compiled_fn = _rewrap_efc_compiled_obj(compiled_fn, kernel)
+                compiled_fn = _rewrap_efc_compiled_obj(
+                    compiled_fn,
+                    kernel,
+                    epilogue_args=epilogue_args,
+                )
             if compiled_fn is not None:
                 return CompiledArtifact(compiled_fn, kernel)
             return None


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #188615
* __->__ #188614
* #188303

Previously, EFC (Epilogue Fusion Compiler) kernel artifacts were written
to disk cache but could never be loaded back. The rewrap step needs
kernel.impl.efc.jit to reconstruct the wrapped_launch closure, but
efc.jit is only initialized during kernel.compile() -- which is skipped
on a cache hit. The result: every EFC kernel recompiled from scratch on
every run, and the disk cache write was wasted work.

This adds _init_efc_jit(), a lightweight alternative that replicates
just the two cheap steps of EFC.compile() that set up the JIT object:
analyze_epilogue_with_arguments() (determines which params are
tensors/read/written) and EFC.JIT construction (builds the parameter
dataclass for pack_arguments()). The expensive CuTe DSL compilation is
skipped entirely.

_rewrap_efc_compiled_obj now accepts an optional epilogue_args parameter.
When efc.jit is missing and epilogue_args is provided, it calls
_init_efc_jit to initialize the JIT state, then proceeds with the
normal rewrap. The existing None-return fallback is preserved for
callers that don't have epilogue_args (e.g. the benchmark path).

Test Plan:
This is tested via the existing NVGEMM EFC epilogue tests:

```
python test/inductor/test_nv_universal_gemm.py -v -k efc
```

Co-authored-by: Claude Code (Anthropic AI assistant)