### PR TITLE
Migrate build-almalinux-images to OSDC via remote BuildKit

### DIFF
--- a/.ci/docker/almalinux/build.sh
+++ b/.ci/docker/almalinux/build.sh
@@ -45,15 +45,76 @@ case ${DOCKER_TAG_PREFIX} in
     ;;
 esac
 
+export DOCKER_BUILDKIT=1
+TOPDIR=$(git rev-parse --show-toplevel)
+tmp_tag=$(basename "$(mktemp -u)" | tr '[:upper:]' '[:lower:]')
+
+# On a remote buildkit builder (OSDC) there is no local Docker daemon, so build
+# with `docker buildx` and push straight to the registry. Locally we keep using
+# the host daemon (`docker build`) and load the image for the post-build checks.
+# The caller passes the target tag(s) as trailing `-t ...` args ("$@").
+if [[ -n "${REMOTE_BUILDKIT:-}" ]]; then
+  # No host daemon to tweak / restart on remote buildkit.
+  output_flag=""
+  # WITH_PUSH gates whether we publish: push events publish, PRs only validate
+  # the build (remote driver with no output keeps the result in the build cache).
+  if [[ "${WITH_PUSH:-false}" == "true" ]]; then
+    output_flag="--push"
+  fi
+
+  build_image() {
+    docker buildx build \
+      --target final \
+      --progress plain \
+      --build-arg "BASE_TARGET=${BASE_TARGET}" \
+      --build-arg "DEVTOOLSET_VERSION=13" \
+      ${EXTRA_BUILD_ARGS} \
+      ${output_flag} \
+      "$@" \
+      -f "${TOPDIR}/.ci/docker/almalinux/Dockerfile" \
+      "${TOPDIR}/.ci/docker/"
+  }
+
+  # The autoscaled buildkit pool may be cold / at capacity at start, where
+  # buildx's ~20s connect (gRPC default) fails before scale-up. Retry connection
+  # failures (not build errors) for ~2h so a capacity-limited build waits for a
+  # free pod instead of hard-failing — still within the job timeout. Mirrors the
+  # retry loop in .ci/docker/build.sh.
+  attempts="${REMOTE_BUILDKIT_CONNECT_ATTEMPTS:-360}"
+  delay="${REMOTE_BUILDKIT_CONNECT_DELAY:-15}"
+  for attempt in $(seq 1 "${attempts}"); do
+    build_log="$(mktemp)"
+    set +e
+    build_image "$@" 2>&1 | tee "${build_log}"
+    rc="${PIPESTATUS[0]}"
+    set -e
+    if [[ "${rc}" -eq 0 ]]; then
+      rm -f "${build_log}"
+      break
+    fi
+    if [[ "${attempt}" -lt "${attempts}" ]] && grep -qiE \
+      "waiting for connection|context deadline exceeded|server preface|failed to (dial|list workers)|connection (refused|reset)|no such host|transport: Error|i/o timeout|use of closed network connection|EOF" \
+      "${build_log}"; then
+      echo "Remote BuildKit not ready yet (attempt ${attempt}/${attempts}); retrying in ${delay}s..." >&2
+      rm -f "${build_log}"
+      sleep "${delay}"
+      continue
+    fi
+    rm -f "${build_log}"
+    exit "${rc}"
+  done
+
+  # The image was pushed (not loaded), so it is not present in any local daemon;
+  # skip the local `docker run` sanity check.
+  echo "REMOTE_BUILDKIT set: skipping local nvcc sanity check (image was pushed, not loaded)."
+  exit 0
+fi
+
 # TODO: Remove LimitNOFILE=1048576 patch once https://github.com/pytorch/test-infra/issues/5712
 # is resolved. This patch is required in order to fix timing out of Docker build on Amazon Linux 2023.
 sudo sed -i s/LimitNOFILE=infinity/LimitNOFILE=1048576/ /usr/lib/systemd/system/docker.service
 sudo systemctl daemon-reload
 sudo systemctl restart docker
-
-export DOCKER_BUILDKIT=1
-TOPDIR=$(git rev-parse --show-toplevel)
-tmp_tag=$(basename "$(mktemp -u)" | tr '[:upper:]' '[:lower:]')
 
 docker build \
   --target final \

--- a/.github/actions/binary-docker-build/action.yml
+++ b/.github/actions/binary-docker-build/action.yml
@@ -12,6 +12,22 @@ inputs:
   custom-tag-prefix:
     description: Custom tag prefix for the docker image
     required: false
+  use-remote-buildkit:
+    description: |
+      Build on a remote BuildKit builder (OSDC/ARC, which has no host docker
+      daemon) and push straight to docker.io, instead of building on a local
+      docker daemon. The referenced <docker-build-dir>/build.sh must honor the
+      REMOTE_BUILDKIT env var (see .ci/docker/build.sh).
+    required: false
+    default: 'false'
+  buildkit-addr:
+    description: Address of the remote BuildKit builder (used when use-remote-buildkit is true).
+    required: false
+    default: 'tcp://buildkitd-amd64.buildkit:1234'
+  docker-repository:
+    description: Target registry/repository for the published image.
+    required: false
+    default: 'docker.io/pytorch'
   DOCKER_TOKEN:
     description: Docker token for authentication
     required: true
@@ -25,8 +41,75 @@ runs:
     - name: Checkout PyTorch
       uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
 
+    # ── Remote BuildKit path (OSDC/ARC, no host docker daemon) ──────────
+    - name: Set up Docker Buildx (remote, no bootstrap)
+      if: ${{ inputs.use-remote-buildkit == 'true' }}
+      shell: bash
+      # NOT docker/setup-buildx-action: it runs `buildx inspect --bootstrap`,
+      # whose ~20s connect timeout fails on a cold/burst start before the
+      # autoscaled pool can add a pod. `create` (no --bootstrap) just registers
+      # the builder; build.sh retries the build to wait out scale-up.
+      run: |
+        set -ex
+        docker buildx create \
+          --name remote-buildkit \
+          --driver remote \
+          --use \
+          "${{ inputs.buildkit-addr }}"
+
+    - name: Build (and, on push, publish) via remote BuildKit
+      if: ${{ inputs.use-remote-buildkit == 'true' }}
+      env:
+        REMOTE_BUILDKIT: "1"
+        CI: "1"
+        DOCKER_TOKEN: ${{ inputs.DOCKER_TOKEN }}
+        DOCKER_ID: ${{ inputs.DOCKER_ID }}
+        DOCKER_IMAGE_NAME: ${{ inputs.docker-image-name }}
+        DOCKER_IMAGE_PREFIX: ${{ inputs.custom-tag-prefix }}
+        DOCKER_BUILD_DIR: ${{ inputs.docker-build-dir }}
+        DOCKER_REPOSITORY: ${{ inputs.docker-repository }}
+      shell: bash
+      run: |
+        set -euxo pipefail
+
+        # checkout-pytorch may leave the tree owned by a different uid than the
+        # step user on ARC; avoid git's "dubious ownership" error for rev-parse.
+        git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+
+        GITHUB_REF=${GITHUB_REF:-$(git symbolic-ref -q HEAD || git describe --tags --exact-match)}
+        GIT_BRANCH_NAME=${GITHUB_REF##*/}
+        GIT_COMMIT_SHA=${GITHUB_SHA:-$(git rev-parse HEAD)}
+        CI_FOLDER_SHA=$(git rev-parse HEAD:.ci/docker)
+
+        # Same tag set the local-daemon path publishes: branch / commit /
+        # .ci/docker-hash tags are always produced; the floating ${prefix} tag is
+        # only published from main so a release-branch rebuild can't clobber the
+        # image main CI consumes.
+        PREFIX="${DOCKER_REPOSITORY}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_PREFIX}"
+        TAGS=(
+          -t "${PREFIX}-${GIT_BRANCH_NAME}"
+          -t "${PREFIX}-${GIT_COMMIT_SHA}"
+          -t "${PREFIX}-${CI_FOLDER_SHA}"
+        )
+        if [[ "${GIT_BRANCH_NAME}" == "main" ]]; then
+          TAGS+=(-t "${PREFIX}")
+        fi
+
+        # WITH_PUSH gates publishing (build.sh pushes when it is true; PRs just
+        # validate the build). Log in only when we are going to push.
+        set +x
+        if [[ "${WITH_PUSH:-false}" == "true" ]]; then
+          echo "${DOCKER_TOKEN}" | docker login -u "${DOCKER_ID}" --password-stdin
+        fi
+        set -x
+
+        # build.sh reads REMOTE_BUILDKIT and buildx-pushes the passed -t tags.
+        ".ci/docker/${DOCKER_BUILD_DIR}/build.sh" "${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_PREFIX}" "${TAGS[@]}"
+
+    # ── Local docker daemon path (EC2) ──────────────────────────────────
     - name: Calculate docker image
       id: calculate-docker-image
+      if: ${{ inputs.use-remote-buildkit != 'true' }}
       uses: pytorch/test-infra/.github/actions/calculate-docker-image@main
       with:
         docker-image-name: ${{ inputs.docker-image-name }}
@@ -37,6 +120,7 @@ runs:
         push: true
 
     - name: Tag and (if WITH_PUSH) push docker image to docker.io
+      if: ${{ inputs.use-remote-buildkit != 'true' }}
       env:
         DOCKER_TOKEN: ${{ inputs.DOCKER_TOKEN }}
         DOCKER_ID: ${{ inputs.DOCKER_ID }}

--- a/.github/workflows/build-almalinux-images.yml
+++ b/.github/workflows/build-almalinux-images.yml
@@ -22,7 +22,6 @@ on:
       - .github/actions/binary-docker-build/**
 
 env:
-  DOCKER_REGISTRY: "docker.io"
   DOCKER_BUILDKIT: 1
   WITH_PUSH: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/tags/v')) }}
 
@@ -34,7 +33,15 @@ jobs:
   build-docker:
     if: github.repository_owner == 'pytorch'
     environment: ${{ (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/tags/v')) && 'docker-build') || '' }}
-    runs-on: linux.9xlarge.ephemeral
+    # OSDC/ARC release runner: the almalinux-builder images are x86-only, and the
+    # mt-rel-* pool's nodes carry osdc.io/runner-class=release, which exempts them
+    # from the cache-enforcer DaemonSet's iptables block on outbound docker.io
+    # traffic so the push can succeed (same rationale as docker-builds.yml's GHCR
+    # mirror). The build itself runs on the remote BuildKit builder.
+    runs-on: mt-rel-l-x86iavx512-8-64
+    container:
+      image: ghcr.io/actions/actions-runner:latest
+    timeout-minutes: 240
     strategy:
       matrix:
         tag: ["cuda12.6", "cuda13.0", "cuda13.2", "rocm7.1", "rocm7.2", "cpu"]
@@ -43,7 +50,8 @@ jobs:
         uses: pytorch/pytorch/.github/actions/binary-docker-build@main
         with:
           docker-image-name: almalinux-builder
-          custom-tag-prefix: ${{matrix.tag}}
+          custom-tag-prefix: ${{ matrix.tag }}
           docker-build-dir: almalinux
+          use-remote-buildkit: true
           DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
           DOCKER_ID: ${{ secrets.DOCKER_ID }}


### PR DESCRIPTION
Moves the `build-almalinux-images.yml` image build off the EC2 `linux.9xlarge.ephemeral` fleet onto OSDC/ARC.

The build went through the `binary-docker-build` composite action, which needs a host docker daemon (`docker build` / `tag` / `push`, `systemctl restart docker`). OSDC/ARC pods have no host daemon, so this follows the `docker-builds.yml` precedent — build on a **remote BuildKit** builder and push straight to the registry.

- **`.ci/docker/almalinux/build.sh`**: add a `REMOTE_BUILDKIT` path that builds with `docker buildx` against the remote builder (no daemon tweaks, no local `nvcc` sanity check) and pushes when `WITH_PUSH`; PRs only validate the build (no output exported). Reuses the cold-pool connect-retry loop from `.ci/docker/build.sh`. The local `docker build` path is unchanged.
- **`build-almalinux-images.yml`**: run on the egress-exempt `mt-rel-*` OSDC release runner inside the `actions-runner` container, register a remote buildx builder, and publish the same `docker.io/pytorch/almalinux-builder` tag set the old action produced (branch / commit / `.ci/docker`-hash always; the floating tag only from `main`).