### PR TITLE
[MPS] Fix F.linear dropping bias for vector-shaped inputs

### DIFF
--- a/aten/src/ATen/native/mps/operations/Linear.mm
+++ b/aten/src/ATen/native/mps/operations/Linear.mm
@@ -131,12 +131,23 @@ Tensor _mps_linear(const Tensor& input, const Tensor& weight_arg, const std::opt
   const bool is_contiguous = input.is_contiguous() && weight.is_contiguous() && bias.is_contiguous();
 
   if (is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS) && is_contiguous && !is_complex) {
-    if (needs_nd_workaround(input) && (!is_bias_defined || bias.dim() <= 1)) {
+    // The fused 3-source kernel drops the bias for vector-shaped (M==1) inputs on the M1
+    // (Apple7) family on macOS 26; add it separately there. Fixed in macOS 27.
+    static const bool decompose_bias = is_apple_family_or_newer(AppleGPUFamily::APPLE_7_PLUS) &&
+        !is_apple_family_or_newer(AppleGPUFamily::APPLE_8_PLUS) &&
+        is_macos_13_or_newer(MacOSVersion::MACOS_VER_26_0_PLUS) &&
+        !is_macos_13_or_newer(MacOSVersion::MACOS_VER_27_0_PLUS);
+    const bool add_bias_after = is_bias_defined && decompose_bias;
+    const Tensor kernel_bias = add_bias_after ? Tensor() : bias;
+    if (needs_nd_workaround(input) && (!kernel_bias.defined() || kernel_bias.dim() <= 1)) {
       auto input2d = input.flatten(0, -2);
       auto output2d = output.flatten(0, -2);
-      _mps_linear_nograph(input2d, weight, bias, output2d);
+      _mps_linear_nograph(input2d, weight, kernel_bias, output2d);
     } else {
-      _mps_linear_nograph(input, weight, bias, output);
+      _mps_linear_nograph(input, weight, kernel_bias, output);
+    }
+    if (add_bias_after) {
+      output.add_(bias);
     }
     // Squeeze last dim of 1D linear
     return weight_arg.dim() != 1 ? output : output.squeeze(-1);

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1705,23 +1705,6 @@ class TestMPS(TestCaseMPS):
         second = F.linear(x, w).clone()
         self.assertEqual(first, second, atol=0, rtol=0)
 
-    @parametrize("bias", [True, False])
-    @parametrize("in_features,out_features,shape", [
-        (2, 192, (80, 1, 2)),
-        (4, 192, (80, 1, 4)),
-        (2, 768, (80, 1, 2)),
-        (2, 192, (80, 4, 2)),
-    ])
-    def test_linear_bias_vector_shaped(self, in_features, out_features, shape, bias):
-        # Regression test: F.linear with bias and a penultimate input dim of 1 dropped the
-        # bias on some MPS GPU families (fused matmul routed to GEMV); decomposition fixes it.
-        torch.manual_seed(0)
-        cpu_linear = nn.Linear(in_features, out_features, bias=bias)
-        mps_linear = nn.Linear(in_features, out_features, bias=bias).to("mps")
-        mps_linear.load_state_dict(cpu_linear.state_dict())
-        x = torch.randn(*shape)
-        self.assertEqual(cpu_linear(x), mps_linear(x.to("mps")).cpu())
-
     def test_uniform(self):
         low = torch.zeros(5, 5, requires_grad=True)
         high = (torch.ones(5, 5) * 3).requires_grad_()

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1705,6 +1705,23 @@ class TestMPS(TestCaseMPS):
         second = F.linear(x, w).clone()
         self.assertEqual(first, second, atol=0, rtol=0)
 
+    @parametrize("bias", [True, False])
+    @parametrize("in_features,out_features,shape", [
+        (2, 192, (80, 1, 2)),
+        (4, 192, (80, 1, 4)),
+        (2, 768, (80, 1, 2)),
+        (2, 192, (80, 4, 2)),
+    ])
+    def test_linear_bias_vector_shaped(self, in_features, out_features, shape, bias):
+        # Regression test: F.linear with bias and a penultimate input dim of 1 dropped the
+        # bias on some MPS GPU families (fused matmul routed to GEMV); decomposition fixes it.
+        torch.manual_seed(0)
+        cpu_linear = nn.Linear(in_features, out_features, bias=bias)
+        mps_linear = nn.Linear(in_features, out_features, bias=bias).to("mps")
+        mps_linear.load_state_dict(cpu_linear.state_dict())
+        x = torch.randn(*shape)
+        self.assertEqual(cpu_linear(x), mps_linear(x.to("mps")).cpu())
+
     def test_uniform(self):
         low = torch.zeros(5, 5, requires_grad=True)
         high = (torch.ones(5, 5) * 3).requires_grad_()


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/188438

The issue takes place on macOS26 when the fusing of bias add fails on vector shaped input. The matmul itself is correct just the bias add has an issue. This PR decomposes the matmul+bias add on macOS26 where the issue seems to be localized. Verified that macOS27 beta regains the correct behavior.

Adds a regression test with the vector shaped case.