### PR TITLE
[cuBLAS] Fix thread-local workspace merge with user-configurable sizes

### DIFF
--- a/aten/src/ATen/cuda/CublasHandlePool.cpp
+++ b/aten/src/ATen/cuda/CublasHandlePool.cpp
@@ -309,7 +309,8 @@ void setCublasWorkspace(cublasHandle_t handle, c10::cuda::CUDAStream stream) {
     return;
   }
 
-  auto [it, _] = workspace_map.emplace(key, std::make_pair(getNewWorkspace(), workspace_size));
+  auto [it, _] = workspace_map.insert_or_assign(
+      key, std::make_pair(getNewWorkspace(), workspace_size));
   TORCH_CUDABLAS_CHECK(
       cublasSetWorkspace(handle, it->second.first.get(), workspace_size));
 }
@@ -322,20 +323,24 @@ void* getCUDABlasLtWorkspace() {
 #ifndef USE_ROCM
   if (unified_cublas_and_lt_workspaces()) {
     auto& workspace_map = at::cuda::cublas_stream_to_workspace();
+    size_t workspace_size = getChosenWorkspaceSize();
     auto workspace_it = workspace_map.find(key);
-    if (workspace_it != workspace_map.end()) {
+    if (workspace_it != workspace_map.end() && workspace_it->second.second >= workspace_size) {
       return workspace_it->second.first.mutable_get();
     }
-    auto [it, _] = workspace_map.emplace(key, std::make_pair(getNewWorkspace(), getChosenWorkspaceSize()));
+    auto [it, _] = workspace_map.insert_or_assign(
+        key, std::make_pair(getNewWorkspace(), workspace_size));
     return it->second.first.mutable_get();
   }
 #endif
   auto& workspace_map = cublaslt_stream_to_workspace();
+  size_t workspace_size = getCUDABlasLtWorkspaceSize();
   auto workspace_it = workspace_map.find(key);
-  if (workspace_it != workspace_map.end()) {
+  if (workspace_it != workspace_map.end() && workspace_it->second.second >= workspace_size) {
     return workspace_it->second.first.mutable_get();
   }
-  auto [it, _] = workspace_map.emplace(key, std::make_pair(getNewCUDABlasLtWorkspace(), getCUDABlasLtWorkspaceSize()));
+  auto [it, _] = workspace_map.insert_or_assign(
+      key, std::make_pair(getNewCUDABlasLtWorkspace(), workspace_size));
   return it->second.first.mutable_get();
 }
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1057,10 +1057,14 @@ print(t.is_pinned())
 
     @unittest.skipIf(TEST_CUDAMALLOCASYNC, "temporarily disabled for async")
     @setBlasBackendsToDefaultFinally
-    def test_cublas_workspace_lazy_reallocation(self):
-        torch.backends.cuda.preferred_blas_library("cublas")
-
-        original_size = torch.backends.cuda.cublas_workspace_size()
+    @parametrize("backend", ("cublas", "cublaslt"))
+    def test_cublas_workspace_lazy_reallocation(self, backend):
+        torch.backends.cuda.preferred_blas_library(backend)
+        small_size = 1024
+        bigger_size = 64 * 1024 * 1024
+        if backend == "cublaslt":
+            torch.backends.cuda.cublas_workspace_size(small_size)
+        torch.backends.cuda.blas_workspace_size(small_size, backend=backend)
         torch.cuda._clear_cublas_workspaces()
 
         # Trigger initial allocation with matmul
@@ -1068,21 +1072,22 @@ print(t.is_pinned())
         with torch.no_grad():
             torch.matmul(a, a)
 
-        mem_after_first = torch.cuda.memory_stats()["active_bytes.all.allocated"]
+        mem_after_first = torch.cuda.memory_stats()["active_bytes.all.current"]
 
         # Increase workspace size
-        bigger_size = original_size + 32 * 1024 * 1024  # +32 MiB
-        torch.backends.cuda.cublas_workspace_size(bigger_size)
+        if backend == "cublaslt":
+            torch.backends.cuda.cublas_workspace_size(bigger_size)
+        torch.backends.cuda.blas_workspace_size(bigger_size, backend=backend)
 
         # No immediate memory change (lazy reallocation)
-        mem_after_set = torch.cuda.memory_stats()["active_bytes.all.allocated"]
+        mem_after_set = torch.cuda.memory_stats()["active_bytes.all.current"]
         self.assertEqual(mem_after_first, mem_after_set)
 
         # Next matmul triggers reallocation
         with torch.no_grad():
             torch.matmul(a, a)
 
-        mem_after_realloc = torch.cuda.memory_stats()["active_bytes.all.allocated"]
+        mem_after_realloc = torch.cuda.memory_stats()["active_bytes.all.current"]
         self.assertGreater(mem_after_realloc, mem_after_first)
 
     def test_cublas_allow_tf32_get_set(self):


### PR DESCRIPTION
authored with codex, https://github.com/pytorch/pytorch/pull/180283 was merged partially incorrectly with user-configurable workspace size

CC @BoyuanFeng I discovered this when looking into the IMA with cudagraph trees but unfortunately I don't think this is the root cause of your issue

cc @csarofeen @ptrblck @nWEIdia