### PR TITLE
[Profiler] Exclude Python function events from key_averages() by default

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -4388,6 +4388,30 @@ class TestProfilerEventsParity(TestCase):
             self.assertEqual(fe_mod.python_parent_id, args["Python parent id"])
             self.assertEqual(fe_mod.python_module_id, args["Python module id"])
 
+    def test_key_averages_excludes_python_functions_by_default(self):
+        """key_averages() must not include Python function events (e.g. threading.py: wait)
+        by default; they can be opted in with include_python_functions=True."""
+        t = threading.Thread(target=lambda: time.sleep(0.05))
+        with profile(activities=[ProfilerActivity.CPU], with_stack=True) as prof:
+            t.start()
+            t.join()
+
+        avgs = prof.key_averages()
+        threading_entries = [e for e in avgs if "threading" in e.key]
+        self.assertEqual(
+            len(threading_entries),
+            0,
+            f"key_averages() should not include threading.py events by default, got: {[e.key for e in threading_entries]}",
+        )
+
+        avgs_with_py = prof.key_averages(include_python_functions=True)
+        threading_entries_with_py = [e for e in avgs_with_py if "threading" in e.key]
+        self.assertGreater(
+            len(threading_entries_with_py),
+            0,
+            "key_averages(include_python_functions=True) should include threading.py events",
+        )
+
     def test_profiler_flow_events_parity(self):
         """Verify that async CPU->GPU flow fields on events() match Chrome trace JSON."""
         with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as prof:

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -1004,12 +1004,16 @@ class profile:
         group_by_input_shape=False,
         group_by_stack_n=0,
         group_by_overload_name=False,
+        include_python_functions=False,
     ):
         self._ensure_function_events()
         if self._function_events is None:
             raise AssertionError("Expected profiling results")
         return self._function_events.key_averages(
-            group_by_input_shape, group_by_stack_n, group_by_overload_name
+            group_by_input_shape,
+            group_by_stack_n,
+            group_by_overload_name,
+            include_python_functions,
         )
 
     key_averages.__doc__ = EventList.key_averages.__doc__

--- a/torch/autograd/profiler_util.py
+++ b/torch/autograd/profiler_util.py
@@ -378,6 +378,7 @@ class EventList(list):
         group_by_input_shapes=False,
         group_by_stack_n=0,
         group_by_overload_name=False,
+        include_python_functions=False,
     ):
         """Averages all function events over their keys.
 
@@ -392,6 +393,13 @@ class EventList(list):
 
             group_by_overload_name: Differentiate operators by their overload name e.g. aten::add.Tensor
             and aten::add.out will be aggregated separately
+
+            include_python_functions: include Python function events (e.g. individual
+                Python callsite entries captured with ``with_stack=True``) in the
+                averages. By default these are excluded because they tend to appear as
+                misleading hotspots (e.g. ``threading.py: wait``) that obscure the
+                real operator-level breakdown. Set to ``True`` to restore the raw
+                per-callsite view.
 
         Returns:
             An EventList containing FunctionEventAvg objects.
@@ -421,6 +429,8 @@ class EventList(list):
             return tuple(key)
 
         for evt in self:
+            if evt.is_python_function and not include_python_functions:
+                continue
             stats[
                 get_key(
                     evt, group_by_input_shapes, group_by_stack_n, group_by_overload_name

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -544,6 +544,7 @@ class _KinetoProfile:
         group_by_input_shape: bool = False,
         group_by_stack_n: int = 0,
         group_by_overload_name: bool = False,
+        include_python_functions: bool = False,
     ):
         """Averages events, grouping them by operator name and (optionally) input shapes, stack
         and overload name.
@@ -559,7 +560,10 @@ class _KinetoProfile:
                 "Profiler must be initialized before getting key averages"
             )
         return self.profiler.key_averages(
-            group_by_input_shape, group_by_stack_n, group_by_overload_name
+            group_by_input_shape,
+            group_by_stack_n,
+            group_by_overload_name,
+            include_python_functions,
         )
 
     def events(self):


### PR DESCRIPTION
Fixes #188520.

Root cause: PR #178168 (`43edd9ee5fc`) removed the `isPythonFunction()` filter from `materializeOpEvents` for `events()`/Chrome Trace parity, but `key_averages()` inherited the same events, causing Python-internal frames like `threading.py: wait` to appear as top hotspots.

Fix adds `include_python_functions=False` to `key_averages()` so these are excluded by default, with opt-in via `include_python_functions=True`.