### PR TITLE
Draft: Update CUTLASS fence proxy API usage 

### DIFF
--- a/.ci/pytorch/common_utils.sh
+++ b/.ci/pytorch/common_utils.sh
@@ -373,6 +373,32 @@ function install_cutlass_api() {
   pushd cutlass-build
   git checkout "${cutlass_commit}"
 
+  # Keep cutlass_api compatible with the pinned nvidia-cutlass-dsl wheel.
+  python3 - <<'PY'
+from pathlib import Path
+import re
+
+path = Path(
+    "python/cutlass_api/cutlass_api/providers/cutedsl/gemm/implementations/"
+    "sm100_static_persistent_impl.py"
+)
+text = path.read_text()
+pattern = re.compile(
+    r"(?P<indent>[ \t]*)cute\.arch\.fence_proxy\(\n"
+    r"(?P=indent)[ \t]*cute\.arch\.ProxyKind\.async_shared,\n"
+    r"(?P=indent)[ \t]*space=cute\.arch\.SharedSpace\.shared_cta,\n"
+    r"(?P=indent)\)"
+)
+text, count = pattern.subn(
+    r'\g<indent>cute.arch.fence_proxy("async.shared", space="cta")',
+    text,
+    count=1,
+)
+if count != 1:
+    raise RuntimeError(f"Expected deprecated CUTLASS API pattern not found in {path}")
+path.write_text(text)
+PY
+
   # Install cutlass_api with torch extras
   pip_install "python/cutlass_api[torch]"
   popd

--- a/torch/_inductor/kernel/vendored_templates/cutedsl/dense_blockscaled_gemm_persistent.py
+++ b/torch/_inductor/kernel/vendored_templates/cutedsl/dense_blockscaled_gemm_persistent.py
@@ -1502,10 +1502,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                         tRS_sC[(None, None, None, c_buffer)],
                     )
                     # Fence and barrier to make sure shared memory store is visible to TMA store
-                    cute.arch.fence_proxy(
-                        cute.arch.ProxyKind.async_shared,
-                        space=cute.arch.SharedSpace.shared_cta,
-                    )
+                    cute.arch.fence_proxy("async.shared", space="cta")
                     self.epilog_sync_barrier.arrive_and_wait()
 
                     #


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/188477 

The B200 smoke job installs cutlass_api from NVIDIA's floating cutlass_api branch while nvidia-cutlass-dsl is pinned to 4.5.2. The downloaded CUTLASS provider still used the older cute.arch.ProxyKind.async_shared and cute.arch.SharedSpace.shared_cta enum API, which is not available in the pinned DSL wheel. Patch the downloaded provider immediately after checkout to use the supported string API, cute.arch.fence_proxy("async.shared", space="cta"), and update the matching local vendored CuTeDSL template to the same API.

Test Plan: Run B200 smoke test

Authored with an AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo