### PR TITLE
Mark two CPU AMP freezing Detectron2 baselines as failing

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/cpu_inductor_amp_freezing_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/cpu_inductor_amp_freezing_torchbench_inference.csv
@@ -82,11 +82,11 @@ detectron2_maskrcnn_r_101_c4,fail_accuracy,57
 
 
 
-detectron2_maskrcnn_r_101_fpn,pass,63
+detectron2_maskrcnn_r_101_fpn,fail_accuracy,63
 
 
 
-detectron2_maskrcnn_r_50_c4,pass,57
+detectron2_maskrcnn_r_50_c4,fail_accuracy,57
 
 
 

--- a/benchmarks/dynamo/test.py
+++ b/benchmarks/dynamo/test.py
@@ -8,6 +8,9 @@ import unittest
 from contextlib import redirect_stdout
 from unittest import mock
 
+import pandas as pd
+
+from .check_accuracy import check_accuracy
 from .common import parse_args, run
 from .torchbench import setup_torchbench_cwd, TorchBenchmarkRunner
 
@@ -128,6 +131,29 @@ class TestDynamoBenchmark(unittest.TestCase):
         ):
             self.assertTrue(runner.use_iou_for_bool_accuracy(name))
             self.assertEqual(runner.get_iou_threshold(name), 0.99)
+
+    def test_cpu_amp_freezing_detectron2_maskrcnn_expected_failures(self) -> None:
+        expected_filename = os.path.join(
+            os.path.dirname(__file__),
+            "ci_expected_accuracy",
+            "cpu_inductor_amp_freezing_torchbench_inference.csv",
+        )
+        actual = pd.read_csv(
+            io.StringIO(
+                "\n".join(
+                    [
+                        "name,accuracy,graph_breaks",
+                        "detectron2_maskrcnn_r_101_fpn,fail_accuracy,63",
+                        "detectron2_maskrcnn_r_50_c4,fail_accuracy,57",
+                    ]
+                )
+            )
+        )
+        expected = pd.read_csv(expected_filename)
+
+        failed, msg = check_accuracy(actual, expected, expected_filename)
+
+        self.assertFalse(failed, msg)
 
     @unittest.skipIf(is_asan_or_tsan(), "ASAN/TSAN not supported")
     def test_benchmark_infra_runs(self) -> None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #188634

The CPU Inductor AMP freezing periodic benchmark has consistently reported
fail_accuracy for detectron2_maskrcnn_r_101_fpn and
detectron2_maskrcnn_r_50_c4 since mid-June.  PR #186441 enabled the bool-mask
IoU comparator for these models and updated the baseline to pass, but the
current failures are not pred_masks IoU misses: the benchmark cannot generate an
fp64 reference because the Detectron2/TorchVision NMS fp64 path hits the existing
`dets should have the same type as scores` error, then falls back to cosine and
fails while comparing Detectron2 Instances/pred_boxes.

Without a valid fp64 reference, relaxing the boxes comparator would be
speculative.  Restore these two CPU AMP freezing TorchBench expectations to
fail_accuracy, matching the observed periodic result and the sibling Detectron2
Mask R-CNN entries that are already accepted as fail_accuracy.  Add a targeted
benchmark-infra regression test that feeds the observed statuses through
check_accuracy so future accidental baseline flips are caught locally.

Fixes #188514

Generated by my agent

Test Plan:
python -m unittest benchmarks.dynamo.test.TestDynamoBenchmark.test_cpu_amp_freezing_detectron2_maskrcnn_expected_failures benchmarks.dynamo.test.TestDynamoBenchmark.test_detectron2_maskrcnn_uses_iou_for_bool_masks
python test/dynamo/test_utils.py -k TestUtils.test_same_iou_for_bool_propagates_to_instances
git diff --cached --check
lintrunner -a

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98