### PR TITLE
Handle reciprocal SymPy powers in shape range eval

### DIFF
--- a/test/inductor/test_unbacked_symints.py
+++ b/test/inductor/test_unbacked_symints.py
@@ -22,6 +22,7 @@ from torch.testing._internal.common_device_type import (
 )
 from torch.testing._internal.common_utils import parametrize, skipIfXpu
 from torch.testing._internal.inductor_utils import HAS_GPU
+from torch.utils._sympy.functions import FloorDiv
 
 
 class TestUnbackedSymints(InductorTestCase):
@@ -1102,6 +1103,33 @@ class TestUnbackedSymints(InductorTestCase):
                 side_effect=AssertionError("unexpected optimization hint"),
             ):
                 self.assertFalse(layout.is_stride_ordered([1, 0]))
+
+    def test_stride_ordered_handles_reciprocal_in_divisibility_check(self, device):
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        shape_env = ShapeEnv()
+        seq = shape_env.create_unbacked_symint().node.expr
+        shape_env.constrain_symbol_range(seq, 4, 1024)
+        half = FloorDiv(seq, 2)
+        reduced = FloorDiv(half**2, half)
+        left = 16 * reduced - 30
+        right = 16 * (64 * half * reduced - 120 * half - 120 * reduced + 225)
+        sizevars = SizeVarAllocator(shape_env)
+        graph = mock.Mock(sizevars=sizevars)
+
+        layout = ir.FixedLayout(
+            torch.device(device),
+            torch.float32,
+            size=[seq, 2],
+            stride=[left, right],
+        )
+        with V.set_graph_handler(graph):
+            with mock.patch.object(
+                sizevars,
+                "optimization_hint",
+                side_effect=AssertionError("unexpected optimization hint"),
+            ):
+                self.assertTrue(layout.is_stride_ordered([0, 1]))
 
     @skipGPUIf(not HAS_GPU, "requires gpu and triton")
     @dynamo_config.patch({"capture_dynamic_output_shape_ops": True})

--- a/torch/utils/_sympy/interp.py
+++ b/torch/utils/_sympy/interp.py
@@ -79,13 +79,12 @@ def handlers():
         sympy.Mul: "mul",
         FloatPow: "pow",
         PowByNatural: "pow_by_natural",
-        # sympy simplifies x * x into Pow(x, 2), so we need to handle this.
-        # Do NOT use builtin Pow for floats
+        # sympy.Pow is handled specially in _run_sympy_handler because
+        # only nonnegative integer exponents can use pow_by_natural.
         # TODO: There is a hazard here, if we have float * float it will
         # also get turned into Pow(float, 2) but we don't want this because
         # pow_by_natural is assumed to only be integers.  Probably the fix is
         # to add a FloatMul to impede this optimization
-        sympy.Pow: "pow_by_natural",
         Mod: "mod",
         PythonMod: "python_mod",
         # TODO: Inductor can generate these, but it's ill-specified which
@@ -124,11 +123,16 @@ ASSOCIATIVE_OPS = {"minimum", "maximum", "mul", "add", "and_", "or_"}
 
 def _run_sympy_handler(analysis, args, expr, index_dtype=torch.int64):
     # Special cases
-    if isinstance(expr, sympy.Pow) and isinstance(
-        expr.args[1], sympy.core.numbers.Half
-    ):
-        return analysis.sqrt(args[0])
-    if isinstance(expr, ToFloat):
+    handler_name = None
+    if isinstance(expr, sympy.Pow):
+        exponent = expr.args[1]
+        if isinstance(exponent, sympy.core.numbers.Half):
+            return analysis.sqrt(args[0])
+        if exponent.is_integer is True and exponent.is_nonnegative is True:
+            handler_name = "pow_by_natural"
+        else:
+            handler_name = "pow"
+    elif isinstance(expr, ToFloat):
         return analysis.to_dtype(args[0], torch.float64)
 
     # These handlers are special because they take an extra dtype argument
@@ -146,7 +150,10 @@ def _run_sympy_handler(analysis, args, expr, index_dtype=torch.int64):
         CeilToInt: "ceil_to_int",
         RoundToInt: "round_to_int",
     }
-    if (handler_name := INDEX_DTYPE_HANDLERS.get(expr.func)) is not None:
+    if (
+        handler_name is None
+        and (handler_name := INDEX_DTYPE_HANDLERS.get(expr.func)) is not None
+    ):
         return getattr(analysis, handler_name)(*args, index_dtype)
 
     # Fastpath for n-ary integral addition
@@ -155,10 +162,11 @@ def _run_sympy_handler(analysis, args, expr, index_dtype=torch.int64):
         log.debug("sym_sum(%s) -> %s", args, r)
         return r
 
-    if hasattr(expr.func, "_torch_handler_name"):
-        handler_name = expr.func._torch_handler_name
-    else:
-        handler_name = handlers()[expr.func]
+    if handler_name is None:
+        if hasattr(expr.func, "_torch_handler_name"):
+            handler_name = expr.func._torch_handler_name
+        else:
+            handler_name = handlers()[expr.func]
     handler = getattr(analysis, handler_name)
     try:
         if handler_name in ASSOCIATIVE_OPS:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #188636

Inductor stride-order checks ask the symbolic shape environment to evaluate
modulo divisibility guards. For the Sapiens2 dynamic SDPA case in
transformers, SymPy simplifies part of one of those guards into a plain
sympy.Pow with exponent -1. The SymPy interpreter previously routed every
plain sympy.Pow through pow_by_natural because x * x can simplify to
Pow(x, 2), but the value range implementation of pow_by_natural assumes a
nonnegative exponent and eventually calls safe_pow. That made the guard
evaluation raise ValueError instead of conservatively returning an unknown
range.

Dispatch plain sympy.Pow to pow_by_natural only when SymPy proves the
exponent is a nonnegative integer. Other powers, including reciprocals from
SymPy simplification, now use the generic pow handler, which keeps value
range analysis conservative instead of crashing. The existing sqrt special
case remains unchanged.

Added a regression test that builds the same symbolic divisibility shape as
the issue stack trace and verifies FixedLayout.is_stride_ordered can evaluate
it without falling back to optimization hints or raising.

Fixes #188423
Fixes #188422
Generated by my agent

Test Plan:
- python test/inductor/test_unbacked_symints.py -k stride_ordered_handles_reciprocal_in_divisibility_check -v
- python test/inductor/test_unbacked_symints.py -k stride_ordered -v
- python test/test_sympy_utils.py -k TestSympyInterp -v
- lintrunner -a torch/utils/_sympy/interp.py test/inductor/test_unbacked_symints.py

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo
