### PR TITLE
[inductor] Reindex transpose-contiguous clone to enable vertical fusion

### DIFF
--- a/test/inductor/test_loop_ordering.py
+++ b/test/inductor/test_loop_ordering.py
@@ -243,6 +243,87 @@ class LoopOrderingTest(TestCase):
         super().setUp()
         metrics.reset()
 
+    @staticmethod
+    def _rotate_every_two(x):
+        return torch.stack((-x[..., 1::2], x[..., 0::2]), dim=-1).flatten(-2)
+
+    def _transpose_contiguous_clone_reindexing_case(self):
+        def f(token_ids, embedding_weight, norm_weight, cos, sin):
+            x = F.embedding(token_ids, embedding_weight)
+            inv_rms = torch.rsqrt(torch.mean(x * x, dim=-1, keepdim=True) + 1e-6)
+            x = x * inv_rms * norm_weight
+            x = (x * cos) + (self._rotate_every_two(x) * sin)
+            x = x.view(token_ids.shape[0], token_ids.shape[1], 4, 8)
+            return x.transpose(1, 2).contiguous()
+
+        bsz, seq, vocab, hidden = 2, 16, 128, 32
+        torch.manual_seed(0)
+        token_ids = torch.randint(0, vocab, (bsz, seq), device=GPU_TYPE)
+        embedding_weight = torch.randn(vocab, hidden, device=GPU_TYPE)
+        norm_weight = torch.randn(hidden, device=GPU_TYPE)
+        pos = torch.arange(seq, device=GPU_TYPE, dtype=torch.float32)[:, None]
+        dim = torch.arange(hidden, device=GPU_TYPE, dtype=torch.float32)[None, :]
+        freqs = pos / (10000.0 ** (dim / hidden))
+        cos = torch.cos(freqs)[None, :, :]
+        sin = torch.sin(freqs)[None, :, :]
+        return f, (token_ids, embedding_weight, norm_weight, cos, sin)
+
+    @contextlib.contextmanager
+    def _record_transpose_contiguous_clone_reindex_scores(self):
+        import torch._inductor.scheduler as inductor_scheduler
+
+        scores = []
+        orig_reindex = (
+            inductor_scheduler.Scheduler._try_reindex_transpose_contiguous_clone
+        )
+
+        def wrapped_reindex(*args, **kwargs):
+            score = orig_reindex(*args, **kwargs)
+            if score > -1:
+                scores.append(score)
+            return score
+
+        with unittest.mock.patch.object(
+            inductor_scheduler.Scheduler,
+            "_try_reindex_transpose_contiguous_clone",
+            wrapped_reindex,
+        ):
+            yield scores
+
+    @contextlib.contextmanager
+    def _force_transpose_contiguous_clone_reindex_rollback(self):
+        import torch._inductor.scheduler as inductor_scheduler
+
+        results = []
+        orig_reindex = (
+            inductor_scheduler.Scheduler._try_reindex_transpose_contiguous_clone
+        )
+
+        def wrapped_reindex(scheduler, *args, **kwargs):
+            score_call_count = 0
+
+            def force_no_score_gain(*score_args, **score_kwargs):
+                nonlocal score_call_count
+                score_call_count += 1
+                return 0
+
+            with unittest.mock.patch.object(
+                inductor_scheduler.Scheduler,
+                "score_fusion_memory",
+                force_no_score_gain,
+            ):
+                result = orig_reindex(scheduler, *args, **kwargs)
+            if score_call_count:
+                results.append(result)
+            return result
+
+        with unittest.mock.patch.object(
+            inductor_scheduler.Scheduler,
+            "_try_reindex_transpose_contiguous_clone",
+            wrapped_reindex,
+        ):
+            yield results
+
     def test_for_reordering_reindex(self):
         """
         ComputedBuffer.iter_reoredering_reindex can cause some fusion
@@ -504,6 +585,75 @@ class LoopOrderingTest(TestCase):
         actual = torch.compile(f)(x)
         torch.testing.assert_close(actual, ref, atol=1e-2, rtol=1e-2)
         self.assertEqual(1, metrics.generated_kernel_count)
+
+    @skipUnless(HAS_GPU, "requires GPU")
+    def test_transpose_contiguous_clone_reindexing(self):
+        """
+        A producer writes [B, S, H], then a view + transpose + contiguous clone
+        changes the layout to [B, heads, S, D]. Reindexing the clone to the
+        producer iteration domain should let vertical fusion remove the copy
+        kernel and write the final layout directly.
+        """
+
+        f, args = self._transpose_contiguous_clone_reindexing_case()
+        ref = f(*args)
+        with self._record_transpose_contiguous_clone_reindex_scores() as scores:
+            actual, code = run_and_get_code(
+                torch.compile(f),
+                *args,
+            )
+
+        torch.testing.assert_close(actual, ref)
+        self.assertEqual(actual.stride(), (512, 128, 8, 1))
+        self.assertGreaterEqual(len(scores), 1)
+        FileCheck().check_count("@triton.jit", 1, exactly=True).check_not(
+            "triton_poi_fused_clone"
+        ).run(code[0])
+
+    @skipUnless(HAS_GPU, "requires GPU")
+    def test_transpose_contiguous_clone_reindexing_rolls_back_without_score_gain(
+        self,
+    ):
+        """
+        If the targeted clone reindex does not improve the fusion score, the
+        speculative loop mutation should be rolled back and the normal clone
+        kernel should remain.
+        """
+
+        f, args = self._transpose_contiguous_clone_reindexing_case()
+        ref = f(*args)
+        with self._force_transpose_contiguous_clone_reindex_rollback() as results:
+            actual, code = run_and_get_code(
+                torch.compile(f),
+                *args,
+            )
+
+        torch.testing.assert_close(actual, ref)
+        self.assertTrue(results)
+        self.assertFalse(any(result > 0 for result in results))
+        FileCheck().check("triton_poi_fused_clone").run(code[0])
+
+    @skipUnless(HAS_GPU, "requires GPU")
+    def test_transpose_contiguous_clone_reindexing_rejects_other_permute(self):
+        """
+        A different permute + contiguous copy should not be rewritten by the
+        targeted [B, S, H] -> [B, heads, S, D] clone reindexing path.
+        """
+
+        def f(x):
+            y = torch.sin(x)
+            y = y.view(2, 16, 4, 8)
+            return y.permute(0, 2, 3, 1).contiguous()
+
+        torch.manual_seed(0)
+        x = torch.randn(2, 16, 32, device=GPU_TYPE)
+        ref = f(x)
+        with self._record_transpose_contiguous_clone_reindex_scores() as scores:
+            actual = torch.compile(f)(x)
+
+        torch.testing.assert_close(actual, ref)
+        self.assertEqual(actual.stride(), (512, 128, 16, 1))
+        self.assertEqual(scores, [])
 
     def test_reindex_unfusable_write_read_dep(self):
         """

--- a/test/inductor/test_loop_ordering.py
+++ b/test/inductor/test_loop_ordering.py
@@ -3,7 +3,7 @@
 import contextlib
 import os
 import unittest
-from unittest import skipUnless
+from unittest import mock, skipUnless
 
 import numpy as np
 import sympy
@@ -283,7 +283,7 @@ class LoopOrderingTest(TestCase):
                 scores.append(score)
             return score
 
-        with unittest.mock.patch.object(
+        with mock.patch.object(
             inductor_scheduler.Scheduler,
             "_try_reindex_transpose_contiguous_clone",
             wrapped_reindex,
@@ -307,7 +307,7 @@ class LoopOrderingTest(TestCase):
                 score_call_count += 1
                 return 0
 
-            with unittest.mock.patch.object(
+            with mock.patch.object(
                 inductor_scheduler.Scheduler,
                 "score_fusion_memory",
                 force_no_score_gain,
@@ -317,7 +317,7 @@ class LoopOrderingTest(TestCase):
                 results.append(result)
             return result
 
-        with unittest.mock.patch.object(
+        with mock.patch.object(
             inductor_scheduler.Scheduler,
             "_try_reindex_transpose_contiguous_clone",
             wrapped_reindex,
@@ -587,6 +587,10 @@ class LoopOrderingTest(TestCase):
         self.assertEqual(1, metrics.generated_kernel_count)
 
     @skipUnless(HAS_GPU, "requires GPU")
+    @inductor_config.patch(
+        loop_index_inversion_in_fusion=True,
+        loop_reindexing_after_fusion=True,
+    )
     def test_transpose_contiguous_clone_reindexing(self):
         """
         A producer writes [B, S, H], then a view + transpose + contiguous clone
@@ -611,6 +615,10 @@ class LoopOrderingTest(TestCase):
         ).run(code[0])
 
     @skipUnless(HAS_GPU, "requires GPU")
+    @inductor_config.patch(
+        loop_index_inversion_in_fusion=True,
+        loop_reindexing_after_fusion=True,
+    )
     def test_transpose_contiguous_clone_reindexing_rolls_back_without_score_gain(
         self,
     ):
@@ -634,6 +642,10 @@ class LoopOrderingTest(TestCase):
         FileCheck().check("triton_poi_fused_clone").run(code[0])
 
     @skipUnless(HAS_GPU, "requires GPU")
+    @inductor_config.patch(
+        loop_index_inversion_in_fusion=True,
+        loop_reindexing_after_fusion=True,
+    )
     def test_transpose_contiguous_clone_reindexing_rejects_other_permute(self):
         """
         A different permute + contiguous copy should not be rewritten by the
@@ -654,6 +666,24 @@ class LoopOrderingTest(TestCase):
         torch.testing.assert_close(actual, ref)
         self.assertEqual(actual.stride(), (512, 128, 16, 1))
         self.assertEqual(scores, [])
+
+    @skipUnless(HAS_GPU, "requires GPU")
+    @inductor_config.patch(
+        loop_index_inversion_in_fusion=True,
+        loop_reindexing_after_fusion=False,
+    )
+    def test_transpose_contiguous_clone_reindexing_disabled_by_config(self):
+        f, args = self._transpose_contiguous_clone_reindexing_case()
+        ref = f(*args)
+        with self._record_transpose_contiguous_clone_reindex_scores() as scores:
+            actual, code = run_and_get_code(
+                torch.compile(f),
+                *args,
+            )
+
+        torch.testing.assert_close(actual, ref)
+        self.assertEqual(scores, [])
+        FileCheck().check("triton_poi_fused_clone").run(code[0])
 
     def test_reindex_unfusable_write_read_dep(self):
         """

--- a/test/inductor/test_loop_ordering.py
+++ b/test/inductor/test_loop_ordering.py
@@ -349,8 +349,8 @@ class LoopOrderingTest(TestCase):
         graph.sizevars.simplify_with_ranges.side_effect = lambda expr, ranges: expr
         graph.sizevars.combine_modular_indexing_pairs.side_effect = lambda expr: expr
         graph.sizevars.shape_env.evaluate_expr.side_effect = lambda expr: bool(expr)
-        graph.sizevars.optimization_hint.side_effect = (
-            lambda expr, fallback=0: int(expr)
+        graph.sizevars.optimization_hint.side_effect = lambda expr, fallback=0: int(
+            expr
         )
         return graph
 

--- a/test/inductor/test_loop_ordering.py
+++ b/test/inductor/test_loop_ordering.py
@@ -13,11 +13,13 @@ import torch.nn.functional as F
 from torch import nn
 from torch._dynamo.testing import rand_strided
 from torch._dynamo.utils import same
-from torch._inductor import config as inductor_config, ir, metrics
+from torch._inductor import config as inductor_config, dependencies, ir, metrics
 from torch._inductor.codegen.triton import TritonScheduling
+from torch._inductor.dependencies import MemoryDep, ReadWrites
 from torch._inductor.graph import GraphLowering
 from torch._inductor.invert_expr_analysis import generate_inverse_formula
-from torch._inductor.scheduler import SchedulerNode
+from torch._inductor.loop_body import LoopBody
+from torch._inductor.scheduler import _LoopMutationTracker, Scheduler, SchedulerNode
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.test_operators import realize
 from torch._inductor.utils import is_big_gpu, run_and_get_code, sympy_index_symbol
@@ -268,61 +270,122 @@ class LoopOrderingTest(TestCase):
         sin = torch.sin(freqs)[None, :, :]
         return f, (token_ids, embedding_weight, norm_weight, cos, sin)
 
-    @contextlib.contextmanager
-    def _record_transpose_contiguous_clone_reindex_scores(self):
-        import torch._inductor.scheduler as inductor_scheduler
+    def _complex_memory_copy_reindexing_case(
+        self,
+        transform,
+        token_shape=(2, 16),
+        hidden=32,
+    ):
+        def f(token_ids, embedding_weight, norm_weight, cos, sin):
+            x = F.embedding(token_ids, embedding_weight)
+            inv_rms = torch.rsqrt(torch.mean(x * x, dim=-1, keepdim=True) + 1e-6)
+            x = x * inv_rms * norm_weight
+            x = (x * cos) + (self._rotate_every_two(x) * sin)
+            return transform(x)
 
-        scores = []
-        orig_reindex = (
-            inductor_scheduler.Scheduler._try_reindex_transpose_contiguous_clone
+        vocab = 128
+        torch.manual_seed(0)
+        token_ids = torch.randint(0, vocab, token_shape, device=GPU_TYPE)
+        embedding_weight = torch.randn(vocab, hidden, device=GPU_TYPE)
+        norm_weight = torch.randn(hidden, device=GPU_TYPE)
+        cos = torch.randn(*token_shape, hidden, device=GPU_TYPE)
+        sin = torch.randn(*token_shape, hidden, device=GPU_TYPE)
+        return f, (token_ids, embedding_weight, norm_weight, cos, sin)
+
+    @staticmethod
+    def _memory_dep(name, offset=0, size=(8,)):
+        var_names = tuple(sympy.Symbol(f"i{idx}") for idx in range(len(size)))
+        index = sympy.S.Zero
+        for var, dim_size in zip(var_names, size):
+            index = index * dim_size + var
+        return MemoryDep(
+            name=name,
+            index=index + offset,
+            var_names=var_names,
+            size=tuple(sympy.sympify(value) for value in size),
         )
 
-        def wrapped_reindex(*args, **kwargs):
-            score = orig_reindex(*args, **kwargs)
-            if score > -1:
-                scores.append(score)
+    @staticmethod
+    def _fake_scheduler_node(reads=(), writes=(), unmet_dependencies=None):
+        node = mock.Mock()
+        node.is_cpu.return_value = False
+        node.read_writes = ReadWrites(
+            reads=OrderedSet(reads),
+            writes=OrderedSet(writes),
+            index_exprs=OrderedSet(),
+        )
+        node.unmet_dependencies = OrderedSet(
+            reads if unmet_dependencies is None else unmet_dependencies
+        )
+        return node
+
+    @staticmethod
+    def _fake_memory_copy_scheduler_node(read, write):
+        node = object.__new__(SchedulerNode)
+        node.is_reduction = mock.Mock(return_value=False)
+        node.read_writes = ReadWrites(
+            reads=OrderedSet((read,)),
+            writes=OrderedSet((write,)),
+            index_exprs=OrderedSet(),
+        )
+        body = mock.Mock()
+        body.is_memory_copy.return_value = True
+        body.subblocks = {}
+        body.get_read_exprs.return_value = [read.index]
+        body.get_write_exprs.return_value = [write.index]
+        body.vars = (list(read.var_names), [])
+        body.sizes = (list(read.size), [])
+        node._body = body
+        node.apply_loop_reindexing = mock.Mock()
+        return node
+
+    @staticmethod
+    def _fake_index_inversion_graph():
+        graph = mock.Mock()
+        graph.sizevars.statically_known_equals.side_effect = (
+            lambda left, right: sympy.simplify(left - right) == 0
+        )
+        graph.sizevars.simplify.side_effect = lambda expr: expr
+        graph.sizevars.simplify_with_ranges.side_effect = lambda expr, ranges: expr
+        graph.sizevars.combine_modular_indexing_pairs.side_effect = lambda expr: expr
+        graph.sizevars.shape_env.evaluate_expr.side_effect = lambda expr: bool(expr)
+        graph.sizevars.optimization_hint.side_effect = (
+            lambda expr, fallback=0: int(expr)
+        )
+        return graph
+
+    @contextlib.contextmanager
+    def _record_invertible_memory_copy_reindex_scores(self):
+        import torch._inductor.scheduler as inductor_scheduler
+
+        attempts = []
+        orig_reindex = inductor_scheduler.Scheduler._try_reindex_invertible_memory_copy
+
+        def wrapped_reindex(
+            scheduler,
+            node1,
+            node2,
+            node1_write,
+            node2_read,
+            node2_write,
+        ):
+            score = orig_reindex(
+                scheduler,
+                node1,
+                node2,
+                node1_write,
+                node2_read,
+                node2_write,
+            )
+            attempts.append((score, node2_read))
             return score
 
         with mock.patch.object(
             inductor_scheduler.Scheduler,
-            "_try_reindex_transpose_contiguous_clone",
+            "_try_reindex_invertible_memory_copy",
             wrapped_reindex,
         ):
-            yield scores
-
-    @contextlib.contextmanager
-    def _force_transpose_contiguous_clone_reindex_rollback(self):
-        import torch._inductor.scheduler as inductor_scheduler
-
-        results = []
-        orig_reindex = (
-            inductor_scheduler.Scheduler._try_reindex_transpose_contiguous_clone
-        )
-
-        def wrapped_reindex(scheduler, *args, **kwargs):
-            score_call_count = 0
-
-            def force_no_score_gain(*score_args, **score_kwargs):
-                nonlocal score_call_count
-                score_call_count += 1
-                return 0
-
-            with mock.patch.object(
-                inductor_scheduler.Scheduler,
-                "score_fusion_memory",
-                force_no_score_gain,
-            ):
-                result = orig_reindex(scheduler, *args, **kwargs)
-            if score_call_count:
-                results.append(result)
-            return result
-
-        with mock.patch.object(
-            inductor_scheduler.Scheduler,
-            "_try_reindex_transpose_contiguous_clone",
-            wrapped_reindex,
-        ):
-            yield results
+            yield attempts
 
     def test_for_reordering_reindex(self):
         """
@@ -591,7 +654,7 @@ class LoopOrderingTest(TestCase):
         loop_index_inversion_in_fusion=True,
         loop_reindexing_after_fusion=True,
     )
-    def test_transpose_contiguous_clone_reindexing(self):
+    def test_invertible_memory_copy_reindexing_attention_layout(self):
         """
         A producer writes [B, S, H], then a view + transpose + contiguous clone
         changes the layout to [B, heads, S, D]. Reindexing the clone to the
@@ -601,7 +664,7 @@ class LoopOrderingTest(TestCase):
 
         f, args = self._transpose_contiguous_clone_reindexing_case()
         ref = f(*args)
-        with self._record_transpose_contiguous_clone_reindex_scores() as scores:
+        with self._record_invertible_memory_copy_reindex_scores() as attempts:
             actual, code = run_and_get_code(
                 torch.compile(f),
                 *args,
@@ -609,7 +672,7 @@ class LoopOrderingTest(TestCase):
 
         torch.testing.assert_close(actual, ref)
         self.assertEqual(actual.stride(), (512, 128, 8, 1))
-        self.assertGreaterEqual(len(scores), 1)
+        self.assertTrue(any(score > 0 for score, _ in attempts))
         FileCheck().check_count("@triton.jit", 1, exactly=True).check_not(
             "triton_poi_fused_clone"
         ).run(code[0])
@@ -619,71 +682,477 @@ class LoopOrderingTest(TestCase):
         loop_index_inversion_in_fusion=True,
         loop_reindexing_after_fusion=True,
     )
-    def test_transpose_contiguous_clone_reindexing_rolls_back_without_score_gain(
-        self,
-    ):
-        """
-        If the targeted clone reindex does not improve the fusion score, the
-        speculative loop mutation should be rolled back and the normal clone
-        kernel should remain.
-        """
-
-        f, args = self._transpose_contiguous_clone_reindexing_case()
+    def test_invertible_memory_copy_reindexing_rank_2_to_3(self):
+        f, args = self._complex_memory_copy_reindexing_case(
+            lambda x: x.view(2, 3, 4).permute(1, 0, 2).contiguous(),
+            token_shape=(6,),
+            hidden=4,
+        )
         ref = f(*args)
-        with self._force_transpose_contiguous_clone_reindex_rollback() as results:
-            actual, code = run_and_get_code(
-                torch.compile(f),
-                *args,
-            )
+        with self._record_invertible_memory_copy_reindex_scores() as attempts:
+            actual, code = run_and_get_code(torch.compile(f), *args)
 
         torch.testing.assert_close(actual, ref)
-        self.assertTrue(results)
-        self.assertFalse(any(result > 0 for result in results))
-        FileCheck().check("triton_poi_fused_clone").run(code[0])
+        self.assertEqual(actual.stride(), (8, 4, 1))
+        self.assertTrue(any(score > 0 for score, _ in attempts))
+        FileCheck().check_count("@triton.jit", 1, exactly=True).check_not(
+            "triton_poi_fused_clone"
+        ).run(code[0])
 
     @skipUnless(HAS_GPU, "requires GPU")
     @inductor_config.patch(
         loop_index_inversion_in_fusion=True,
         loop_reindexing_after_fusion=True,
     )
-    def test_transpose_contiguous_clone_reindexing_rejects_other_permute(self):
-        """
-        A different permute + contiguous copy should not be rewritten by the
-        targeted [B, S, H] -> [B, heads, S, D] clone reindexing path.
-        """
-
-        def f(x):
-            y = torch.sin(x)
-            y = y.view(2, 16, 4, 8)
-            return y.permute(0, 2, 3, 1).contiguous()
-
-        torch.manual_seed(0)
-        x = torch.randn(2, 16, 32, device=GPU_TYPE)
-        ref = f(x)
-        with self._record_transpose_contiguous_clone_reindex_scores() as scores:
-            actual = torch.compile(f)(x)
+    def test_invertible_memory_copy_reindexing_rejects_non_bijective_read(self):
+        f, args = self._complex_memory_copy_reindexing_case(
+            lambda x: torch.as_strided(x, x.shape, (0, 32, 1)).contiguous()
+        )
+        ref = f(*args)
+        with self._record_invertible_memory_copy_reindex_scores() as attempts:
+            actual = torch.compile(f)(*args)
 
         torch.testing.assert_close(actual, ref)
-        self.assertEqual(actual.stride(), (512, 128, 16, 1))
-        self.assertEqual(scores, [])
+        target_scores = [
+            score
+            for score, read in attempts
+            if len(read.index.free_symbols) < len(read.var_names)
+        ]
+        self.assertTrue(target_scores)
+        self.assertTrue(all(score == -1 for score in target_scores))
 
-    @skipUnless(HAS_GPU, "requires GPU")
+    @inductor_config.patch(
+        loop_index_inversion_in_fusion=True,
+        loop_reindexing_after_fusion=True,
+    )
+    def test_index_inversion_rejects_two_source_consumer_before_reindex(self):
+        source0 = self._memory_dep("source0")
+        source1 = self._memory_dep("source1")
+        output = self._memory_dep("output")
+        node1 = self._fake_scheduler_node(writes=(source0, source1))
+        node2 = self._fake_scheduler_node(
+            reads=(source0, source1),
+            writes=(output,),
+        )
+        scheduler = object.__new__(Scheduler)
+
+        with mock.patch.object(
+            scheduler, "_try_reindex_invertible_memory_copy", return_value=1
+        ) as reindex:
+            score = scheduler.shared_data_after_inverting_indexing(node1, node2)
+
+        self.assertEqual(score, -1)
+        reindex.assert_not_called()
+
+    @inductor_config.patch(
+        loop_index_inversion_in_fusion=True,
+        loop_reindexing_after_fusion=True,
+    )
+    def test_index_inversion_selects_matching_multi_output_write(self):
+        source0 = self._memory_dep("source0")
+        source1 = self._memory_dep("source1")
+        output = self._memory_dep("output")
+        node1 = self._fake_scheduler_node(writes=(source0, source1))
+        node2 = self._fake_scheduler_node(reads=(source1,), writes=(output,))
+        scheduler = object.__new__(Scheduler)
+
+        with mock.patch.object(
+            scheduler, "_try_reindex_invertible_memory_copy", return_value=7
+        ) as reindex:
+            score = scheduler.shared_data_after_inverting_indexing(node1, node2)
+
+        self.assertEqual(score, 7)
+        reindex.assert_called_once()
+        self.assertIs(reindex.call_args.args[2], source1)
+
+    @inductor_config.patch(
+        loop_index_inversion_in_fusion=True,
+        loop_reindexing_after_fusion=True,
+    )
+    def test_index_inversion_rejects_ambiguous_same_name_writes(self):
+        source0 = self._memory_dep("source", offset=0)
+        source1 = self._memory_dep("source", offset=1)
+        read = self._memory_dep("source")
+        output = self._memory_dep("output")
+        node1 = self._fake_scheduler_node(writes=(source0, source1))
+        node2 = self._fake_scheduler_node(reads=(read,), writes=(output,))
+        scheduler = object.__new__(Scheduler)
+
+        with mock.patch.object(
+            scheduler, "_try_reindex_invertible_memory_copy", return_value=1
+        ) as reindex:
+            score = scheduler.shared_data_after_inverting_indexing(node1, node2)
+
+        self.assertEqual(score, -1)
+        reindex.assert_not_called()
+
+    @inductor_config.patch(
+        loop_index_inversion_in_fusion=True,
+        loop_reindexing_after_fusion=True,
+    )
+    def test_index_inversion_rejects_different_source_name(self):
+        producer_write = self._memory_dep("producer")
+        different_read = self._memory_dep("different")
+        overlapping_write = self._memory_dep("producer")
+        node1 = self._fake_scheduler_node(writes=(producer_write,))
+        node2 = self._fake_scheduler_node(
+            reads=(different_read,),
+            writes=(overlapping_write,),
+            unmet_dependencies=(),
+        )
+        scheduler = object.__new__(Scheduler)
+
+        with mock.patch.object(
+            scheduler, "_try_reindex_invertible_memory_copy", return_value=1
+        ) as reindex:
+            score = scheduler.shared_data_after_inverting_indexing(node1, node2)
+
+        self.assertEqual(score, -1)
+        reindex.assert_not_called()
+
     @inductor_config.patch(
         loop_index_inversion_in_fusion=True,
         loop_reindexing_after_fusion=False,
     )
-    def test_transpose_contiguous_clone_reindexing_disabled_by_config(self):
-        f, args = self._transpose_contiguous_clone_reindexing_case()
-        ref = f(*args)
-        with self._record_transpose_contiguous_clone_reindex_scores() as scores:
-            actual, code = run_and_get_code(
-                torch.compile(f),
-                *args,
+    def test_invertible_memory_copy_reindexing_disabled_by_config(self):
+        source = self._memory_dep("source")
+        output = self._memory_dep("output")
+        node1 = self._fake_scheduler_node(writes=(source,))
+        node2 = self._fake_scheduler_node(reads=(source,), writes=(output,))
+        scheduler = object.__new__(Scheduler)
+
+        with mock.patch.object(
+            scheduler, "_try_reindex_invertible_memory_copy", return_value=1
+        ) as reindex:
+            score = scheduler.shared_data_after_inverting_indexing(node1, node2)
+
+        self.assertEqual(score, -1)
+        reindex.assert_not_called()
+
+    def test_invertible_memory_copy_reindexing_rejects_zero_numel(self):
+        producer_write = self._memory_dep("source", size=(0, 8))
+        consumer_read = self._memory_dep("source", size=(0, 8))
+        consumer_write = self._memory_dep("output", size=(0, 8))
+        node2 = self._fake_memory_copy_scheduler_node(consumer_read, consumer_write)
+        scheduler = object.__new__(Scheduler)
+        graph = self._fake_index_inversion_graph()
+
+        with (
+            V.set_graph_handler(graph),
+            mock.patch.object(
+                scheduler, "_is_dense_and_injective_memory_dep"
+            ) as is_dense,
+        ):
+            score = scheduler._try_reindex_invertible_memory_copy(
+                mock.Mock(),
+                node2,
+                producer_write,
+                consumer_read,
+                consumer_write,
             )
 
-        torch.testing.assert_close(actual, ref)
-        self.assertEqual(scores, [])
-        FileCheck().check("triton_poi_fused_clone").run(code[0])
+        self.assertEqual(score, -1)
+        is_dense.assert_not_called()
+        node2.apply_loop_reindexing.assert_not_called()
+
+    def test_invertible_memory_copy_reindexing_rejects_symbolic_shape(self):
+        s0 = sympy.Symbol("s0", integer=True, positive=True)
+        producer_write = self._memory_dep("source", size=(s0, 8))
+        consumer_read = self._memory_dep("source", size=(s0, 8))
+        consumer_write = self._memory_dep("output", size=(s0, 8))
+        node2 = self._fake_memory_copy_scheduler_node(consumer_read, consumer_write)
+        scheduler = object.__new__(Scheduler)
+
+        with mock.patch.object(
+            scheduler, "_is_dense_and_injective_memory_dep"
+        ) as is_dense:
+            score = scheduler._try_reindex_invertible_memory_copy(
+                mock.Mock(),
+                node2,
+                producer_write,
+                consumer_read,
+                consumer_write,
+            )
+
+        self.assertEqual(score, -1)
+        is_dense.assert_not_called()
+        node2.apply_loop_reindexing.assert_not_called()
+
+    def test_invertible_memory_copy_reindexing_rejects_non_injective_producer(self):
+        i0, i1 = sympy.symbols("i0 i1", integer=True, nonnegative=True)
+        producer_write = MemoryDep(
+            name="source",
+            index=i1,
+            var_names=(i0, i1),
+            size=(sympy.Integer(2), sympy.Integer(8)),
+        )
+        consumer_read = MemoryDep(
+            name="source",
+            index=8 * i0 + i1,
+            var_names=(i0, i1),
+            size=(sympy.Integer(2), sympy.Integer(8)),
+        )
+        consumer_write = MemoryDep(
+            name="output",
+            index=8 * i0 + i1,
+            var_names=(i0, i1),
+            size=(sympy.Integer(2), sympy.Integer(8)),
+        )
+        node2 = self._fake_memory_copy_scheduler_node(consumer_read, consumer_write)
+        scheduler = object.__new__(Scheduler)
+        graph = self._fake_index_inversion_graph()
+
+        with V.set_graph_handler(graph):
+            score = scheduler._try_reindex_invertible_memory_copy(
+                mock.Mock(),
+                node2,
+                producer_write,
+                consumer_read,
+                consumer_write,
+            )
+
+        self.assertEqual(score, -1)
+        node2.apply_loop_reindexing.assert_not_called()
+
+    @inductor_config.patch(
+        loop_index_inversion_in_fusion=True,
+        loop_reindexing_after_fusion=True,
+        constant_and_index_propagation=False,
+    )
+    def test_index_inversion_right_inverse_fallback_rollback(self):
+        i0 = sympy.Symbol("i0", integer=True, nonnegative=True)
+
+        def copy_body(iter_indices, _reduction_indices):
+            value = ops.load("source", FloorDiv(iter_indices[0], 2))
+            return ops.store("output", iter_indices[0], value)
+
+        producer_write = MemoryDep(
+            name="source",
+            index=i0,
+            var_names=(i0,),
+            size=(sympy.Integer(8),),
+        )
+        consumer_read = MemoryDep(
+            name="source",
+            index=FloorDiv(i0, 2),
+            var_names=(i0,),
+            size=(sympy.Integer(8),),
+        )
+        consumer_write = MemoryDep(
+            name="output",
+            index=i0,
+            var_names=(i0,),
+            size=(sympy.Integer(8),),
+        )
+        graph = self._fake_index_inversion_graph()
+        with V.set_graph_handler(graph):
+            body = LoopBody(
+                copy_body,
+                ([i0], []),
+                {i0: sympy.Integer(8)},
+                [i0],
+                [],
+            )
+
+        original_indexing_exprs = dict(body.indexing_exprs)
+        node1 = self._fake_scheduler_node(writes=(producer_write,))
+        node2 = object.__new__(SchedulerNode)
+        node2.is_cpu = mock.Mock(return_value=False)
+        node2.is_reduction = mock.Mock(return_value=False)
+        node2.read_writes = ReadWrites(
+            reads=OrderedSet((consumer_read,)),
+            writes=OrderedSet((consumer_write,)),
+            index_exprs=OrderedSet(),
+        )
+        node2.unmet_dependencies = OrderedSet((consumer_read,))
+        node2._body = body
+        node2._sizes = body.sizes
+        node2.group = mock.sentinel.group
+        node2._loop_mutation_listener = None
+        node2.clear_loop_body_dependent_caches = mock.Mock()
+        computed_buffer = object.__new__(ir.ComputedBuffer)
+        computed_buffer.get_device_or_error = mock.Mock(
+            return_value=torch.device("cpu")
+        )
+        node2.node = computed_buffer
+        node2.scheduler = mock.Mock()
+        node2.scheduler.get_backend.return_value.group_fn.return_value = (
+            mock.sentinel.reindexed_group
+        )
+
+        def refresh_dependencies(normalize, need_clear_tiling_cache):
+            node2.read_writes = dependencies.extract_read_writes(
+                node2._body,
+                *node2._sizes,
+                normalize=False,
+            )
+
+        node2.refresh_dependencies = refresh_dependencies
+        scheduler = object.__new__(Scheduler)
+        scheduler.score_fusion_memory = mock.Mock(side_effect=(0, 5))
+        refreshed_reads = []
+
+        def reject_refreshed_dependency(producer, refreshed_read):
+            refreshed_reads.append(refreshed_read)
+            return False
+
+        scheduler.deps_match_normalized = reject_refreshed_dependency
+
+        tracker = _LoopMutationTracker.create((node2,))
+
+        with (
+            V.set_graph_handler(graph),
+            mock.patch.object(
+                scheduler,
+                "_is_dense_and_injective_memory_dep",
+                return_value=True,
+            ),
+            mock.patch.object(MemoryDep, "normalize", return_value=producer_write),
+            mock.patch.object(
+                node2,
+                "apply_loop_reindexing",
+                wraps=node2.apply_loop_reindexing,
+            ) as apply_reindex,
+            mock.patch.object(
+                node2,
+                "restore_loop_state",
+                wraps=node2.restore_loop_state,
+            ) as restore_loop_state,
+        ):
+            score = scheduler.shared_data_after_inverting_indexing(node1, node2)
+
+        self.assertEqual(score, 5)
+        apply_reindex.assert_called_once()
+        restore_loop_state.assert_called_once()
+        self.assertEqual(len(refreshed_reads), 1)
+        self.assertNotEqual(refreshed_reads[0].index, producer_write.index)
+        self.assertIsNot(node2._body, body)
+        self.assertEqual(body.indexing_exprs, original_indexing_exprs)
+        self.assertEqual(node2._body.indexing_exprs["index0"], consumer_write.index)
+        self.assertEqual(node2._body.indexing_exprs["index1"], 2 * i0)
+
+        # Equivalent to the final can_fuse() decision rejecting this candidate.
+        with mock.patch.object(
+            node2,
+            "restore_loop_state",
+            wraps=node2.restore_loop_state,
+        ) as outer_restore:
+            tracker.finish(rollback=True)
+
+        outer_restore.assert_called_once()
+        self.assertIs(node2._body, body)
+        self.assertEqual(node2._body.indexing_exprs, original_indexing_exprs)
+        self.assertIsNone(node2._loop_mutation_listener)
+
+    def test_invertible_memory_copy_reindexing_rolls_back_dependency_mismatch(self):
+        i0, i1 = sympy.symbols("i0 i1", integer=True, nonnegative=True)
+        producer_write = MemoryDep(
+            name="source",
+            index=8 * i0 + i1,
+            var_names=(i0, i1),
+            size=(sympy.Integer(2), sympy.Integer(8)),
+        )
+        consumer_write = MemoryDep(
+            name="output",
+            index=8 * i0 + i1,
+            var_names=(i0, i1),
+            size=(sympy.Integer(2), sympy.Integer(8)),
+        )
+        read_indices = {
+            "non_bijective": i1,
+            "offset": 8 * i0 + i1 + 1,
+        }
+
+        for name, read_index in read_indices.items():
+            with self.subTest(name=name):
+                consumer_read = MemoryDep(
+                    name="source",
+                    index=read_index,
+                    var_names=(i0, i1),
+                    size=(sympy.Integer(2), sympy.Integer(8)),
+                )
+                node2 = self._fake_memory_copy_scheduler_node(
+                    consumer_read, consumer_write
+                )
+                snapshot = object()
+                node2.snapshot_loop_state = mock.Mock(return_value=snapshot)
+                node2.refresh_dependencies = mock.Mock()
+                node2.restore_loop_state = mock.Mock()
+                scheduler = object.__new__(Scheduler)
+                scheduler.score_fusion_memory = mock.Mock(return_value=0)
+                scheduler.deps_match_normalized = mock.Mock(return_value=False)
+                graph = self._fake_index_inversion_graph()
+
+                with (
+                    V.set_graph_handler(graph),
+                    mock.patch.object(
+                        scheduler,
+                        "_is_dense_and_injective_memory_dep",
+                        return_value=True,
+                    ),
+                    mock.patch(
+                        "torch._inductor.invert_expr_analysis.generate_inverse_formula",
+                        side_effect=lambda expr, var: var,
+                    ),
+                ):
+                    score = scheduler._try_reindex_invertible_memory_copy(
+                        mock.Mock(),
+                        node2,
+                        producer_write,
+                        consumer_read,
+                        consumer_write,
+                    )
+
+                self.assertEqual(score, -1)
+                node2.apply_loop_reindexing.assert_called_once()
+                node2.restore_loop_state.assert_called_once_with(snapshot)
+
+    def test_invertible_memory_copy_reindexing_rolls_back_without_score_gain(self):
+        i0 = sympy.Symbol("i0", integer=True, nonnegative=True)
+        producer_write = MemoryDep("source", i0, (i0,), (sympy.Integer(8),))
+        consumer_read = MemoryDep("source", i0, (i0,), (sympy.Integer(8),))
+        consumer_write = MemoryDep("output", i0, (i0,), (sympy.Integer(8),))
+        node2 = self._fake_memory_copy_scheduler_node(consumer_read, consumer_write)
+        snapshot = object()
+        node2.snapshot_loop_state = mock.Mock(return_value=snapshot)
+        node2.refresh_dependencies = mock.Mock()
+        node2.restore_loop_state = mock.Mock()
+
+        def apply_reindex(*args, **kwargs):
+            node2.read_writes = ReadWrites(
+                reads=OrderedSet((producer_write,)),
+                writes=OrderedSet((consumer_write,)),
+                index_exprs=OrderedSet(),
+            )
+
+        node2.apply_loop_reindexing.side_effect = apply_reindex
+        scheduler = object.__new__(Scheduler)
+        scheduler.score_fusion_memory = mock.Mock(side_effect=(0, 0))
+        scheduler.deps_match_normalized = mock.Mock(return_value=True)
+        graph = self._fake_index_inversion_graph()
+
+        with (
+            V.set_graph_handler(graph),
+            mock.patch.object(
+                scheduler,
+                "_is_dense_and_injective_memory_dep",
+                return_value=True,
+            ),
+            mock.patch(
+                "torch._inductor.invert_expr_analysis.generate_inverse_formula",
+                side_effect=lambda expr, var: var,
+            ),
+        ):
+            score = scheduler._try_reindex_invertible_memory_copy(
+                mock.Mock(),
+                node2,
+                producer_write,
+                consumer_read,
+                consumer_write,
+            )
+
+        self.assertEqual(score, -1)
+        node2.restore_loop_state.assert_called_once_with(snapshot)
 
     def test_reindex_unfusable_write_read_dep(self):
         """

--- a/test/inductor/test_loop_ordering.py
+++ b/test/inductor/test_loop_ordering.py
@@ -13,13 +13,13 @@ import torch.nn.functional as F
 from torch import nn
 from torch._dynamo.testing import rand_strided
 from torch._dynamo.utils import same
-from torch._inductor import config as inductor_config, dependencies, ir, metrics
+from torch._inductor import config as inductor_config, ir, metrics
 from torch._inductor.codegen.triton import TritonScheduling
 from torch._inductor.dependencies import MemoryDep, ReadWrites
 from torch._inductor.graph import GraphLowering
 from torch._inductor.invert_expr_analysis import generate_inverse_formula
-from torch._inductor.loop_body import LoopBody
-from torch._inductor.scheduler import _LoopMutationTracker, Scheduler, SchedulerNode
+from torch._inductor.loop_body import LoopBody, MemoryUsageType
+from torch._inductor.scheduler import FusionResult, Scheduler, SchedulerNode
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.test_operators import realize
 from torch._inductor.utils import is_big_gpu, run_and_get_code, sympy_index_symbol
@@ -335,15 +335,43 @@ class LoopOrderingTest(TestCase):
         body.get_write_exprs.return_value = [write.index]
         body.vars = (list(read.var_names), [])
         body.sizes = (list(read.size), [])
+        body.iter_vars = list(read.var_names)
+        body.indexing_exprs = {"index0": read.index, "index1": write.index}
+        body.memory_usage = {MemoryUsageType.LOAD: [mock.Mock(index_name="index0")]}
         node._body = body
+        node._loop_mutation_listener = None
         node.apply_loop_reindexing = mock.Mock()
+        node._apply_indexing_expr_replacements = mock.Mock()
+        return node
+
+    @staticmethod
+    def _fake_loop_state_scheduler_node():
+        node = object.__new__(SchedulerNode)
+        node._body = mock.sentinel.original_body
+        node._sizes = mock.sentinel.original_sizes
+        node.group = mock.sentinel.original_group
+        node.read_writes = ReadWrites(
+            reads=OrderedSet(),
+            writes=OrderedSet(),
+            index_exprs=OrderedSet(),
+        )
+        node.unmet_dependencies = OrderedSet()
+        node._loop_mutation_listener = None
+        node.clear_loop_body_dependent_caches = mock.Mock()
+        node.get_nodes = mock.Mock(return_value=[node])
         return node
 
     @staticmethod
     def _fake_index_inversion_graph():
         graph = mock.Mock()
-        graph.sizevars.statically_known_equals.side_effect = (
-            lambda left, right: sympy.simplify(left - right) == 0
+        graph.sizevars.statically_known_equals.side_effect = lambda left, right: (
+            sympy.simplify(left - right) == 0
+        )
+        graph.sizevars.statically_known_geq.side_effect = lambda left, right: bool(
+            sympy.simplify(left >= right)
+        )
+        graph.sizevars.statically_known_lt.side_effect = lambda left, right: bool(
+            sympy.simplify(left < right)
         )
         graph.sizevars.simplify.side_effect = lambda expr: expr
         graph.sizevars.simplify_with_ranges.side_effect = lambda expr, ranges: expr
@@ -919,7 +947,65 @@ class LoopOrderingTest(TestCase):
         loop_reindexing_after_fusion=True,
         constant_and_index_propagation=False,
     )
-    def test_index_inversion_right_inverse_fallback_rollback(self):
+    def test_index_inversion_accepts_bijective_legacy_fallback(self):
+        i0 = sympy.Symbol("i0", integer=True, nonnegative=True)
+        transposed_index = 10 * ModularIndexing(i0, 1, 10) + ModularIndexing(i0, 10, 10)
+        producer_write = MemoryDep("source", i0, (i0,), (sympy.Integer(100),))
+        consumer_read = MemoryDep(
+            "source", transposed_index, (i0,), (sympy.Integer(100),)
+        )
+        consumer_write = MemoryDep("output", i0, (i0,), (sympy.Integer(100),))
+        node1 = self._fake_scheduler_node(writes=(producer_write,))
+        node2 = object.__new__(SchedulerNode)
+        node2.is_cpu = mock.Mock(return_value=False)
+        node2.read_writes = ReadWrites(
+            reads=OrderedSet((consumer_read,)),
+            writes=OrderedSet((consumer_write,)),
+            index_exprs=OrderedSet(),
+        )
+        node2.unmet_dependencies = OrderedSet((consumer_read,))
+        node2._body = mock.Mock()
+        node2._body.indexing_exprs = {
+            "index0": consumer_read.index,
+            "index1": consumer_write.index,
+        }
+        node2._body.subblocks = {}
+        node2._body.get_read_exprs.return_value = [consumer_read.index]
+        node2._body.vars = ([i0], [])
+        node2._body.sizes = ([sympy.Integer(100)], [])
+        node2.snapshot_loop_state = mock.Mock(return_value=mock.sentinel.snapshot)
+        node2.restore_loop_state = mock.Mock()
+        node2._apply_indexing_expr_replacements = mock.Mock()
+        scheduler = object.__new__(Scheduler)
+        scheduler.score_fusion_memory = mock.Mock(return_value=5)
+        graph = GraphLowering(torch.fx.symbolic_trace(lambda: 0))
+        graph.scheduler = MockScheduler
+
+        with (
+            V.set_graph_handler(graph),
+            mock.patch.object(
+                scheduler, "_try_reindex_invertible_memory_copy", return_value=-1
+            ),
+            mock.patch.object(MemoryDep, "normalize", return_value=producer_write),
+        ):
+            score = scheduler.shared_data_after_inverting_indexing(node1, node2)
+
+        self.assertEqual(score, 5)
+        node2._apply_indexing_expr_replacements.assert_called_once_with(
+            {
+                "index0": i0,
+                "index1": FloorDiv(i0, 10) + 10 * ModularIndexing(i0, 1, 10),
+            },
+            normalize=True,
+        )
+        node2.restore_loop_state.assert_not_called()
+
+    @inductor_config.patch(
+        loop_index_inversion_in_fusion=True,
+        loop_reindexing_after_fusion=True,
+        constant_and_index_propagation=False,
+    )
+    def test_index_inversion_rejects_right_inverse_fallback(self):
         i0 = sympy.Symbol("i0", integer=True, nonnegative=True)
 
         def copy_body(iter_indices, _reduction_indices):
@@ -970,35 +1056,7 @@ class LoopOrderingTest(TestCase):
         node2.group = mock.sentinel.group
         node2._loop_mutation_listener = None
         node2.clear_loop_body_dependent_caches = mock.Mock()
-        computed_buffer = object.__new__(ir.ComputedBuffer)
-        computed_buffer.get_device_or_error = mock.Mock(
-            return_value=torch.device("cpu")
-        )
-        node2.node = computed_buffer
-        node2.scheduler = mock.Mock()
-        node2.scheduler.get_backend.return_value.group_fn.return_value = (
-            mock.sentinel.reindexed_group
-        )
-
-        def refresh_dependencies(normalize, need_clear_tiling_cache):
-            node2.read_writes = dependencies.extract_read_writes(
-                node2._body,
-                *node2._sizes,
-                normalize=False,
-            )
-
-        node2.refresh_dependencies = refresh_dependencies
         scheduler = object.__new__(Scheduler)
-        scheduler.score_fusion_memory = mock.Mock(side_effect=(0, 5))
-        refreshed_reads = []
-
-        def reject_refreshed_dependency(producer, refreshed_read):
-            refreshed_reads.append(refreshed_read)
-            return False
-
-        scheduler.deps_match_normalized = reject_refreshed_dependency
-
-        tracker = _LoopMutationTracker.create((node2,))
 
         with (
             V.set_graph_handler(graph),
@@ -1008,43 +1066,17 @@ class LoopOrderingTest(TestCase):
                 return_value=True,
             ),
             mock.patch.object(MemoryDep, "normalize", return_value=producer_write),
-            mock.patch.object(
-                node2,
-                "apply_loop_reindexing",
-                wraps=node2.apply_loop_reindexing,
-            ) as apply_reindex,
-            mock.patch.object(
-                node2,
-                "restore_loop_state",
-                wraps=node2.restore_loop_state,
-            ) as restore_loop_state,
         ):
             score = scheduler.shared_data_after_inverting_indexing(node1, node2)
 
-        self.assertEqual(score, 5)
-        apply_reindex.assert_called_once()
-        restore_loop_state.assert_called_once()
-        self.assertEqual(len(refreshed_reads), 1)
-        self.assertNotEqual(refreshed_reads[0].index, producer_write.index)
-        self.assertIsNot(node2._body, body)
-        self.assertEqual(body.indexing_exprs, original_indexing_exprs)
-        self.assertEqual(node2._body.indexing_exprs["index0"], consumer_write.index)
-        self.assertEqual(node2._body.indexing_exprs["index1"], 2 * i0)
-
-        # Equivalent to the final can_fuse() decision rejecting this candidate.
-        with mock.patch.object(
-            node2,
-            "restore_loop_state",
-            wraps=node2.restore_loop_state,
-        ) as outer_restore:
-            tracker.finish(rollback=True)
-
-        outer_restore.assert_called_once()
+        self.assertEqual(score, -1)
         self.assertIs(node2._body, body)
-        self.assertEqual(node2._body.indexing_exprs, original_indexing_exprs)
+        self.assertEqual(body.indexing_exprs, original_indexing_exprs)
         self.assertIsNone(node2._loop_mutation_listener)
 
-    def test_invertible_memory_copy_reindexing_rolls_back_dependency_mismatch(self):
+    def test_invertible_memory_copy_reindexing_rejects_read_mismatch_before_mutation(
+        self,
+    ):
         i0, i1 = sympy.symbols("i0 i1", integer=True, nonnegative=True)
         producer_write = MemoryDep(
             name="source",
@@ -1074,13 +1106,7 @@ class LoopOrderingTest(TestCase):
                 node2 = self._fake_memory_copy_scheduler_node(
                     consumer_read, consumer_write
                 )
-                snapshot = object()
-                node2.snapshot_loop_state = mock.Mock(return_value=snapshot)
-                node2.refresh_dependencies = mock.Mock()
-                node2.restore_loop_state = mock.Mock()
                 scheduler = object.__new__(Scheduler)
-                scheduler.score_fusion_memory = mock.Mock(return_value=0)
-                scheduler.deps_match_normalized = mock.Mock(return_value=False)
                 graph = self._fake_index_inversion_graph()
 
                 with (
@@ -1104,8 +1130,52 @@ class LoopOrderingTest(TestCase):
                     )
 
                 self.assertEqual(score, -1)
-                node2.apply_loop_reindexing.assert_called_once()
-                node2.restore_loop_state.assert_called_once_with(snapshot)
+                node2.apply_loop_reindexing.assert_not_called()
+                node2._apply_indexing_expr_replacements.assert_not_called()
+
+    def test_invertible_memory_copy_reindexing_rolls_back_dependency_mismatch(self):
+        i0 = sympy.Symbol("i0", integer=True, nonnegative=True)
+        producer_write = MemoryDep("source", i0, (i0,), (sympy.Integer(8),))
+        consumer_read = MemoryDep("source", i0, (i0,), (sympy.Integer(8),))
+        consumer_write = MemoryDep("output", i0, (i0,), (sympy.Integer(8),))
+        node2 = self._fake_memory_copy_scheduler_node(consumer_read, consumer_write)
+        snapshot = object()
+        node2.snapshot_loop_state = mock.Mock(return_value=snapshot)
+        node2.restore_loop_state = mock.Mock()
+        scheduler = object.__new__(Scheduler)
+        scheduler.score_fusion_memory = mock.Mock(return_value=0)
+        scheduler.deps_match_normalized = mock.Mock(return_value=False)
+        graph = self._fake_index_inversion_graph()
+
+        with (
+            V.set_graph_handler(graph),
+            mock.patch.object(
+                scheduler,
+                "_is_dense_and_injective_memory_dep",
+                return_value=True,
+            ),
+            mock.patch.object(
+                scheduler,
+                "_prove_expr_equals_with_ranges",
+                return_value=True,
+            ),
+            mock.patch(
+                "torch._inductor.invert_expr_analysis.generate_inverse_formula",
+                side_effect=lambda expr, var: var,
+            ),
+        ):
+            score = scheduler._try_reindex_invertible_memory_copy(
+                mock.Mock(),
+                node2,
+                producer_write,
+                consumer_read,
+                consumer_write,
+            )
+
+        self.assertEqual(score, -1)
+        node2.apply_loop_reindexing.assert_called_once()
+        node2._apply_indexing_expr_replacements.assert_called_once()
+        node2.restore_loop_state.assert_called_once_with(snapshot)
 
     def test_invertible_memory_copy_reindexing_rolls_back_without_score_gain(self):
         i0 = sympy.Symbol("i0", integer=True, nonnegative=True)
@@ -1115,7 +1185,6 @@ class LoopOrderingTest(TestCase):
         node2 = self._fake_memory_copy_scheduler_node(consumer_read, consumer_write)
         snapshot = object()
         node2.snapshot_loop_state = mock.Mock(return_value=snapshot)
-        node2.refresh_dependencies = mock.Mock()
         node2.restore_loop_state = mock.Mock()
 
         def apply_reindex(*args, **kwargs):
@@ -1138,6 +1207,11 @@ class LoopOrderingTest(TestCase):
                 "_is_dense_and_injective_memory_dep",
                 return_value=True,
             ),
+            mock.patch.object(
+                scheduler,
+                "_prove_expr_equals_with_ranges",
+                return_value=True,
+            ),
             mock.patch(
                 "torch._inductor.invert_expr_analysis.generate_inverse_formula",
                 side_effect=lambda expr, var: var,
@@ -1153,6 +1227,208 @@ class LoopOrderingTest(TestCase):
 
         self.assertEqual(score, -1)
         node2.restore_loop_state.assert_called_once_with(snapshot)
+
+    def test_invertible_memory_copy_reindexing_rolls_back_on_exception(self):
+        i0 = sympy.Symbol("i0", integer=True, nonnegative=True)
+        producer_write = MemoryDep("source", i0, (i0,), (sympy.Integer(8),))
+        consumer_read = MemoryDep("source", i0, (i0,), (sympy.Integer(8),))
+        consumer_write = MemoryDep("output", i0, (i0,), (sympy.Integer(8),))
+        node2 = self._fake_memory_copy_scheduler_node(consumer_read, consumer_write)
+        snapshot = object()
+        node2.snapshot_loop_state = mock.Mock(return_value=snapshot)
+        node2.restore_loop_state = mock.Mock()
+        node2.apply_loop_reindexing.side_effect = RuntimeError("reindex failed")
+        scheduler = object.__new__(Scheduler)
+        scheduler.score_fusion_memory = mock.Mock(return_value=0)
+        graph = self._fake_index_inversion_graph()
+
+        with (
+            V.set_graph_handler(graph),
+            mock.patch.object(
+                scheduler,
+                "_is_dense_and_injective_memory_dep",
+                return_value=True,
+            ),
+            mock.patch.object(
+                scheduler,
+                "_prove_expr_equals_with_ranges",
+                return_value=True,
+            ),
+            mock.patch(
+                "torch._inductor.invert_expr_analysis.generate_inverse_formula",
+                side_effect=lambda expr, var: var,
+            ),
+        ):
+            score = scheduler._try_reindex_invertible_memory_copy(
+                mock.Mock(),
+                node2,
+                producer_write,
+                consumer_read,
+                consumer_write,
+            )
+
+        self.assertEqual(score, -1)
+        node2.restore_loop_state.assert_called_once_with(snapshot)
+
+    def test_can_fuse_query_rolls_back_loop_mutation(self):
+        node1 = self._fake_loop_state_scheduler_node()
+        node2 = self._fake_loop_state_scheduler_node()
+        scheduler = object.__new__(Scheduler)
+
+        def can_fuse_impl(*args, **kwargs):
+            node2._before_loop_state_mutation()
+            node2._body = mock.sentinel.mutated_body
+            return True
+
+        scheduler._can_fuse_impl = mock.Mock(side_effect=can_fuse_impl)
+
+        self.assertTrue(scheduler.can_fuse(node1, node2))
+        self.assertIs(node2._body, mock.sentinel.original_body)
+        self.assertIsNone(node2._loop_mutation_listener)
+
+    def test_can_fuse_exception_rolls_back_loop_mutation(self):
+        node1 = self._fake_loop_state_scheduler_node()
+        node2 = self._fake_loop_state_scheduler_node()
+        scheduler = object.__new__(Scheduler)
+
+        def can_fuse_impl(*args, **kwargs):
+            node2._before_loop_state_mutation()
+            node2._body = mock.sentinel.mutated_body
+            raise RuntimeError("fusion analysis failed")
+
+        scheduler._can_fuse_impl = mock.Mock(side_effect=can_fuse_impl)
+
+        with self.assertRaisesRegex(RuntimeError, "fusion analysis failed"):
+            scheduler.can_fuse(node1, node2)
+
+        self.assertIs(node2._body, mock.sentinel.original_body)
+        self.assertIsNone(node2._loop_mutation_listener)
+
+    def test_can_fuse_query_rolls_back_pointwise_expansion(self):
+        node1 = self._fake_loop_state_scheduler_node()
+        node2 = self._fake_loop_state_scheduler_node()
+        original_body = mock.Mock()
+        expanded_body = mock.Mock(sizes=mock.sentinel.expanded_sizes)
+        original_body.expand_dimension_for_pointwise_node.return_value = expanded_body
+        node2._body = original_body
+
+        computed_buffer = object.__new__(ir.ComputedBuffer)
+        computed_buffer.get_device_or_error = mock.Mock(
+            return_value=torch.device("cuda")
+        )
+        node2.node = computed_buffer
+        node2.scheduler = mock.Mock()
+        node2.scheduler.get_backend.return_value.group_fn.return_value = (
+            mock.sentinel.expanded_group
+        )
+        node2.refresh_dependencies = mock.Mock()
+        scheduler = object.__new__(Scheduler)
+
+        def can_fuse_impl(*args, **kwargs):
+            node2.expand_dimension_for_pointwise_node(0, 8)
+            return True
+
+        scheduler._can_fuse_impl = mock.Mock(side_effect=can_fuse_impl)
+
+        self.assertTrue(scheduler.can_fuse(node1, node2))
+        self.assertIs(node2._body, original_body)
+        self.assertIs(node2._sizes, mock.sentinel.original_sizes)
+        self.assertIs(node2.group, mock.sentinel.original_group)
+        self.assertIsNone(node2._loop_mutation_listener)
+
+    def test_fuse_if_speedup_rolls_back_rejected_loop_mutation(self):
+        node1 = self._fake_loop_state_scheduler_node()
+        node2 = self._fake_loop_state_scheduler_node()
+        scheduler = object.__new__(Scheduler)
+
+        def can_fuse_impl(*args, **kwargs):
+            node2._before_loop_state_mutation()
+            node2._body = mock.sentinel.mutated_body
+            return True
+
+        scheduler._can_fuse_impl = mock.Mock(side_effect=can_fuse_impl)
+        scheduler.will_fusion_create_cycle = mock.Mock(return_value=False)
+
+        fused = scheduler.fuse_if_speedup(
+            node1,
+            node2,
+            mock.Mock(return_value=False),
+            OrderedSet((node1, node2)),
+        )
+
+        self.assertFalse(fused)
+        self.assertIs(node2._body, mock.sentinel.original_body)
+        self.assertIsNone(node2._loop_mutation_listener)
+
+    def test_fuse_if_speedup_keeps_accepted_loop_mutation(self):
+        node1 = self._fake_loop_state_scheduler_node()
+        node2 = self._fake_loop_state_scheduler_node()
+        scheduler = object.__new__(Scheduler)
+
+        def can_fuse_impl(*args, **kwargs):
+            node2._before_loop_state_mutation()
+            node2._body = mock.sentinel.mutated_body
+            return True
+
+        scheduler._can_fuse_impl = mock.Mock(side_effect=can_fuse_impl)
+        scheduler.will_fusion_create_cycle = mock.Mock(return_value=False)
+        scheduler.fuse_two_nodes = mock.Mock()
+        fused_nodes = OrderedSet((node1, node2))
+
+        fused = scheduler.fuse_if_speedup(
+            node1,
+            node2,
+            mock.Mock(return_value=True),
+            fused_nodes,
+        )
+
+        self.assertTrue(fused)
+        self.assertIs(node2._body, mock.sentinel.mutated_body)
+        self.assertIsNone(node2._loop_mutation_listener)
+        scheduler.fuse_two_nodes.assert_called_once_with(node1, node2, fused_nodes)
+
+    def test_deferred_fusion_preserves_reorder_mode(self):
+        node1 = self._fake_loop_state_scheduler_node()
+        node2 = self._fake_loop_state_scheduler_node()
+        scheduler = object.__new__(Scheduler)
+        scheduler.seen_template_fusions = OrderedSet()
+        scheduler.get_fused_node = mock.Mock(side_effect=lambda node: node)
+        scheduler.will_fusion_create_cycle = mock.Mock(return_value=False)
+        scheduler.fuse_two_nodes = mock.Mock()
+
+        def can_fuse_impl(node1, node2, can_reorder=False, **kwargs):
+            return can_reorder
+
+        scheduler._can_fuse_impl = mock.Mock(side_effect=can_fuse_impl)
+        scheduler.speedup_by_fusion = mock.Mock(
+            return_value=FusionResult.from_callable(mock.Mock(return_value=True))
+        )
+        pending_fusions = {}
+        fused_nodes = OrderedSet((node1, node2))
+
+        with mock.patch(
+            "torch._inductor.scheduler.is_template_fusion", return_value=False
+        ):
+            scheduler._try_fusion_pairs(
+                [(node1, node2)],
+                pending_fusions,
+                {},
+                fused_nodes,
+                is_reorder_round=True,
+            )
+            scheduler._finish_pending_fusions(fused_nodes, pending_fusions)
+
+        can_fuse_calls = scheduler._can_fuse_impl.call_args_list
+        self.assertGreaterEqual(len(can_fuse_calls), 2)
+        self.assertTrue(
+            all(
+                call.kwargs.get(
+                    "can_reorder", call.args[2] if len(call.args) > 2 else False
+                )
+                for call in can_fuse_calls
+            )
+        )
+        scheduler.fuse_two_nodes.assert_called_once_with(node1, node2, fused_nodes)
 
     def test_reindex_unfusable_write_read_dep(self):
         """
@@ -2303,7 +2579,9 @@ class TestTiling(TestCase):
             self.assertEqual(
                 len(coalesce_analysis.uncoalesced_addrs),
                 1,
-                lambda msg: f"{msg}\nExpected 1 uncoalesced access, got {len(coalesce_analysis.uncoalesced_addrs)}",
+                lambda msg: (
+                    f"{msg}\nExpected 1 uncoalesced access, got {len(coalesce_analysis.uncoalesced_addrs)}"
+                ),
             )
 
             # The uncoalesced access should have an INDIRECT symbol

--- a/torch/_inductor/loop_body.py
+++ b/torch/_inductor/loop_body.py
@@ -348,6 +348,51 @@ class LoopBody:
             reduce_vars2,
         )
 
+    def reindex_iter_loops_with_indexer(
+        self,
+        new_iter_sizes: Sequence[sympy.Expr],
+        indexer: Callable[
+            [Sequence[sympy.Expr], Sequence[sympy.Expr]], Sequence[sympy.Expr]
+        ],
+    ) -> LoopBody:
+        """
+        Reindex iteration loops into a different factorization using an explicit
+        mapping from new iteration indices to old iteration indices.
+        """
+        old_body = self
+        old_iter_sizes = self.sizes[0]
+        reduce_sizes = self.sizes[1]
+
+        new_sizes = (list(new_iter_sizes), list(reduce_sizes))
+
+        (iter_vars, reduce_vars), var_ranges = dependencies.index_vars_no_squeeze(
+            *new_sizes,
+            prefix="t",  # type: ignore[arg-type]
+        )
+
+        def new_body(*indices: Sequence[sympy.Expr]) -> Any:
+            index = [*itertools.chain.from_iterable(indices)]
+            new_iter_idx = index[: len(new_iter_sizes)]
+            reduce_idx = index[len(new_iter_sizes) :]
+            old_iter_idx = indexer(new_iter_idx, old_iter_sizes)
+            return old_body(list(old_iter_idx), list(reduce_idx))
+
+        loop_body = LoopBody(
+            new_body, (iter_vars, reduce_vars), var_ranges, iter_vars, reduce_vars
+        )
+
+        (iter_vars2, reduce_vars2), var_ranges2 = dependencies.index_vars_no_squeeze(
+            *new_sizes,
+            prefix="p",  # type: ignore[arg-type]
+        )
+        return LoopBody(
+            loop_body,
+            (iter_vars2, reduce_vars2),
+            var_ranges2,
+            iter_vars2,
+            reduce_vars2,
+        )
+
     def reorder_iter_loops(self, new_order) -> LoopBody:
         """
         Reorder iteration loops and return a new LoopBody.

--- a/torch/_inductor/loop_body.py
+++ b/torch/_inductor/loop_body.py
@@ -305,59 +305,21 @@ class LoopBody:
         )
         return new_body
 
-    def reindex_iter_loops(self, new_iter_sizes: Sequence[sympy.Expr]) -> LoopBody:
-        """
-        Reindex iteration loops into a different factorization of the same
-        total numel. For example, [1024, 8192] -> [65536, 128].
-
-        The old iteration vars are expressed as functions of the new vars via
-        FloorDiv and ModularIndexing on the flat index.
-        """
-        old_body = self
-        old_iter_sizes = self.sizes[0]
-        reduce_sizes = self.sizes[1]
-
-        new_sizes = (list(new_iter_sizes), list(reduce_sizes))
-
-        (iter_vars, reduce_vars), var_ranges = dependencies.index_vars_no_squeeze(
-            *new_sizes,
-            prefix="t",  # type: ignore[arg-type]
-        )
-
-        def new_body(*indices: Sequence[sympy.Expr]) -> Any:
-            index = [*itertools.chain.from_iterable(indices)]
-            new_iter_idx = index[: len(new_iter_sizes)]
-            reduce_idx = index[len(new_iter_sizes) :]
-            flat = flatten_index(new_iter_idx, new_iter_sizes)
-            old_iter_idx = decompose_index(flat, old_iter_sizes)
-            return old_body(old_iter_idx, list(reduce_idx))
-
-        loop_body = LoopBody(
-            new_body, (iter_vars, reduce_vars), var_ranges, iter_vars, reduce_vars
-        )
-
-        (iter_vars2, reduce_vars2), var_ranges2 = dependencies.index_vars_no_squeeze(
-            *new_sizes,
-            prefix="p",  # type: ignore[arg-type]
-        )
-        return LoopBody(
-            loop_body,
-            (iter_vars2, reduce_vars2),
-            var_ranges2,
-            iter_vars2,
-            reduce_vars2,
-        )
-
-    def reindex_iter_loops_with_indexer(
+    def reindex_iter_loops(
         self,
         new_iter_sizes: Sequence[sympy.Expr],
         indexer: Callable[
             [Sequence[sympy.Expr], Sequence[sympy.Expr]], Sequence[sympy.Expr]
-        ],
+        ]
+        | None = None,
     ) -> LoopBody:
         """
-        Reindex iteration loops into a different factorization using an explicit
-        mapping from new iteration indices to old iteration indices.
+        Reindex iteration loops into a different factorization of the same
+        total numel. For example, [1024, 8192] -> [65536, 128].
+
+        By default, the old iteration vars are expressed as functions of the
+        new vars via FloorDiv and ModularIndexing on the flat index. An explicit
+        indexer can be provided for other mappings.
         """
         old_body = self
         old_iter_sizes = self.sizes[0]
@@ -374,7 +336,11 @@ class LoopBody:
             index = [*itertools.chain.from_iterable(indices)]
             new_iter_idx = index[: len(new_iter_sizes)]
             reduce_idx = index[len(new_iter_sizes) :]
-            old_iter_idx = indexer(new_iter_idx, old_iter_sizes)
+            if indexer is None:
+                flat = flatten_index(new_iter_idx, new_iter_sizes)
+                old_iter_idx = decompose_index(flat, old_iter_sizes)
+            else:
+                old_iter_idx = indexer(new_iter_idx, old_iter_sizes)
             return old_body(list(old_iter_idx), list(reduce_idx))
 
         loop_body = LoopBody(

--- a/torch/_inductor/loop_body.py
+++ b/torch/_inductor/loop_body.py
@@ -359,6 +359,28 @@ class LoopBody:
             reduce_vars2,
         )
 
+    def _replace_indexing_exprs(self, replacements: dict[str, sympy.Expr]) -> LoopBody:
+        """Return a copy with selected indexing expressions replaced."""
+        unknown_names = replacements.keys() - self.indexing_exprs.keys()
+        if unknown_names:
+            raise AssertionError(f"unknown indexing expressions: {unknown_names}")
+
+        new_body = LoopBody(
+            self,
+            self.vars,
+            self.var_ranges,
+            self.iter_vars,
+            self.reduce_vars,
+            allow_same_symbol_in_index=True,
+        )
+        new_body.indexing_exprs.update(
+            {
+                name: self._wrap_int_to_sympy_integer(expr)
+                for name, expr in replacements.items()
+            }
+        )
+        return new_body
+
     def reorder_iter_loops(self, new_order) -> LoopBody:
         """
         Reorder iteration loops and return a new LoopBody.

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -57,7 +57,7 @@ from torch._inductor.ir import TritonTemplateCallerBase
 from torch._inductor.metrics import get_metric_table, is_metric_table_enabled
 from torch._inductor.stream_utils import get_stream_name
 from torch.fx.experimental.symbolic_shapes import free_symbols
-from torch.utils._sympy.functions import FloorDiv
+from torch.utils._sympy.functions import FloorDiv, ModularIndexing
 from torch.utils._sympy.symbol import free_symbol_is_type, symbol_is_type, SymT
 from torch.utils._triton import has_triton
 
@@ -2361,6 +2361,28 @@ class SchedulerNode(BaseSchedulerNode):
 
         self._before_loop_state_mutation()
         self._body = self._body.reindex_iter_loops(new_iter_sizes)
+        self._sizes = self._body.sizes
+
+        device = self.node.get_device_or_error()
+        group_fn = self.scheduler.get_backend(device).group_fn
+        self.group = (device, group_fn(self._sizes))
+
+        self.refresh_dependencies(normalize=False, need_clear_tiling_cache=True)
+
+    def apply_loop_reindexing_with_indexer(
+        self,
+        new_iter_sizes: Sequence[sympy.Expr],
+        indexer: Callable[
+            [Sequence[sympy.Expr], Sequence[sympy.Expr]], Sequence[sympy.Expr]
+        ],
+    ) -> None:
+        if not isinstance(self.node, (ir.ComputedBuffer, ir.TemplateBuffer)):
+            raise AssertionError(
+                "expected self.node to be a ComputedBuffer or TemplateBuffer"
+            )
+
+        self._before_loop_state_mutation()
+        self._body = self._body.reindex_iter_loops_with_indexer(new_iter_sizes, indexer)
         self._sizes = self._body.sizes
 
         device = self.node.get_device_or_error()
@@ -7021,6 +7043,12 @@ class Scheduler:
         if not isinstance(node1_write, MemoryDep):
             return -1
 
+        score = self._try_reindex_transpose_contiguous_clone(
+            node1, node2, node1_write, node2_read, node2_write
+        )
+        if score >= 0:
+            return score
+
         # We are checking for compatibility with the normalized node1 write
         # then modifying node2 reads/writes. since the node1 write will be just used
         # for compatibility, while node2 will be used in actual modification, just
@@ -7101,6 +7129,117 @@ class Scheduler:
             raise AssertionError("expected score to be an int")
 
         fusion_log.info("Shared memory after inversion: %d", score)
+        return score
+
+    def _try_reindex_transpose_contiguous_clone(
+        self,
+        node1: BaseSchedulerNode,
+        node2: BaseSchedulerNode,
+        node1_write: MemoryDep,
+        node2_read: MemoryDep,
+        node2_write: MemoryDep,
+    ) -> int:
+        """
+        Reindex a layout-changing clone after a producer of [B, S, H].
+
+        This handles the common attention layout transition:
+
+            producer[B, S, H] -> view(B, S, heads, D)
+                -> transpose(1, 2).contiguous()
+
+        The clone initially iterates in output order [B, heads, S, D] and reads
+        the producer storage with a permuted index. Reindexing the clone to the
+        producer domain [B, S, H] makes its read dependency match the producer
+        write while preserving the final contiguous output store.
+        """
+        if not isinstance(node2, SchedulerNode):
+            return -1
+
+        if node2.is_reduction():
+            return -1
+
+        if len(node2.read_writes.reads) != 1 or len(node2.read_writes.writes) != 1:
+            return -1
+
+        body = node2._body
+        if not body.is_memory_copy():
+            return -1
+        if len(body.indexing_exprs) != 2 or body.subblocks:
+            return -1
+        if "index0" not in body.indexing_exprs or "index1" not in body.indexing_exprs:
+            return -1
+
+        read_exprs = OrderedSet(expr for expr in body.get_read_exprs())
+        if len(read_exprs) != 1:
+            return -1
+        if next(iter(read_exprs)) not in body.indexing_exprs.values():
+            return -1
+
+        iter_vars = body.vars[0]
+        if len(iter_vars) != 4:
+            return -1
+
+        producer_size = list(node1_write.size)
+        clone_read_size = list(node2_read.size)
+        clone_write_size = list(node2_write.size)
+        if (
+            len(producer_size) != 3
+            or len(clone_read_size) != 4
+            or clone_read_size != clone_write_size
+        ):
+            return -1
+
+        bsz, seq, hidden = producer_size
+        read_bsz, heads, read_seq, head_dim = clone_read_size
+        if not (
+            V.graph.sizevars.statically_known_equals(bsz, read_bsz)
+            and V.graph.sizevars.statically_known_equals(seq, read_seq)
+            and V.graph.sizevars.statically_known_equals(hidden, heads * head_dim)
+            and V.graph.sizevars.statically_known_equals(
+                sympy_product(producer_size), sympy_product(clone_read_size)
+            )
+        ):
+            return -1
+
+        b, head, s, d = iter_vars
+        expected_read = b * seq * hidden + s * hidden + head * head_dim + d
+        expected_write = (
+            b * heads * seq * head_dim + head * seq * head_dim + s * head_dim + d
+        )
+        if not (
+            V.graph.sizevars.statically_known_equals(node2_read.index, expected_read)
+            and V.graph.sizevars.statically_known_equals(
+                node2_write.index, expected_write
+            )
+        ):
+            return -1
+
+        old_score = self.score_fusion_memory(node1, node2)
+        state = node2.snapshot_loop_state()
+
+        def indexer(
+            new_iter_idx: Sequence[sympy.Expr],
+            old_iter_sizes: Sequence[sympy.Expr],
+        ) -> Sequence[sympy.Expr]:
+            b, s, h = new_iter_idx
+            return [
+                b,
+                FloorDiv(h, old_iter_sizes[3]),
+                s,
+                ModularIndexing(h, 1, old_iter_sizes[3]),
+            ]
+
+        node2.apply_loop_reindexing_with_indexer(producer_size, indexer)
+        score = self.score_fusion_memory(node1, node2)
+        if not isinstance(score, int):
+            raise AssertionError("expected score to be an int")
+        if score <= old_score or score <= 0:
+            node2.restore_loop_state(state)
+            return -1
+
+        fusion_log.info(
+            "Shared memory after transpose-contiguous clone reindex: %d", score
+        )
         return score
 
     def shared_data_after_reordering_loop(

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -7138,6 +7138,11 @@ class Scheduler:
         producer domain [B, S, H] makes its read dependency match the producer
         write while preserving the final contiguous output store.
         """
+        # Note [Targeted transpose-contiguous clone reindexing]
+        # This intentionally matches only the common attention layout above when
+        # its sizes and index polynomials can be proven statically. Other layouts
+        # fail closed; broader matching belongs in the general reindexing machinery
+        # rather than as additional special cases here.
         if not isinstance(node2, SchedulerNode):
             return -1
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -2353,28 +2353,13 @@ class SchedulerNode(BaseSchedulerNode):
 
         self.refresh_dependencies(normalize=False, need_clear_tiling_cache=True)
 
-    def apply_loop_reindexing(self, new_iter_sizes: Sequence[sympy.Expr]) -> None:
-        if not isinstance(self.node, (ir.ComputedBuffer, ir.TemplateBuffer)):
-            raise AssertionError(
-                "expected self.node to be a ComputedBuffer or TemplateBuffer"
-            )
-
-        self._before_loop_state_mutation()
-        self._body = self._body.reindex_iter_loops(new_iter_sizes)
-        self._sizes = self._body.sizes
-
-        device = self.node.get_device_or_error()
-        group_fn = self.scheduler.get_backend(device).group_fn
-        self.group = (device, group_fn(self._sizes))
-
-        self.refresh_dependencies(normalize=False, need_clear_tiling_cache=True)
-
-    def apply_loop_reindexing_with_indexer(
+    def apply_loop_reindexing(
         self,
         new_iter_sizes: Sequence[sympy.Expr],
         indexer: Callable[
             [Sequence[sympy.Expr], Sequence[sympy.Expr]], Sequence[sympy.Expr]
-        ],
+        ]
+        | None = None,
     ) -> None:
         if not isinstance(self.node, (ir.ComputedBuffer, ir.TemplateBuffer)):
             raise AssertionError(
@@ -2382,7 +2367,7 @@ class SchedulerNode(BaseSchedulerNode):
             )
 
         self._before_loop_state_mutation()
-        self._body = self._body.reindex_iter_loops_with_indexer(new_iter_sizes, indexer)
+        self._body = self._body.reindex_iter_loops(new_iter_sizes, indexer=indexer)
         self._sizes = self._body.sizes
 
         device = self.node.get_device_or_error()
@@ -7043,11 +7028,12 @@ class Scheduler:
         if not isinstance(node1_write, MemoryDep):
             return -1
 
-        score = self._try_reindex_transpose_contiguous_clone(
-            node1, node2, node1_write, node2_read, node2_write
-        )
-        if score >= 0:
-            return score
+        if config.loop_reindexing_after_fusion:
+            score = self._try_reindex_transpose_contiguous_clone(
+                node1, node2, node1_write, node2_read, node2_write
+            )
+            if score >= 0:
+                return score
 
         # We are checking for compatibility with the normalized node1 write
         # then modifying node2 reads/writes. since the node1 write will be just used
@@ -7169,7 +7155,7 @@ class Scheduler:
         if "index0" not in body.indexing_exprs or "index1" not in body.indexing_exprs:
             return -1
 
-        read_exprs = OrderedSet(expr for expr in body.get_read_exprs())
+        read_exprs = OrderedSet(body.get_read_exprs())
         if len(read_exprs) != 1:
             return -1
         if next(iter(read_exprs)) not in body.indexing_exprs.values():
@@ -7195,9 +7181,6 @@ class Scheduler:
             V.graph.sizevars.statically_known_equals(bsz, read_bsz)
             and V.graph.sizevars.statically_known_equals(seq, read_seq)
             and V.graph.sizevars.statically_known_equals(hidden, heads * head_dim)
-            and V.graph.sizevars.statically_known_equals(
-                sympy_product(producer_size), sympy_product(clone_read_size)
-            )
         ):
             return -1
 
@@ -7229,7 +7212,7 @@ class Scheduler:
                 ModularIndexing(h, 1, old_iter_sizes[3]),
             ]
 
-        node2.apply_loop_reindexing_with_indexer(producer_size, indexer)
+        node2.apply_loop_reindexing(producer_size, indexer=indexer)
         score = self.score_fusion_memory(node1, node2)
         if not isinstance(score, int):
             raise AssertionError("expected score to be an int")

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -7194,12 +7194,12 @@ class Scheduler:
         ):
             return -1
         if any(
-            set(free_symbols(dep.index)).difference(dep.var_names)
+            OrderedSet(free_symbols(dep.index)).difference(dep.var_names)
             for dep in memory_deps
         ):
             return -1
         if any(
-            set(free_symbols(expr)).difference(iter_vars)
+            OrderedSet(free_symbols(expr)).difference(iter_vars)
             for expr in itertools.chain(read_exprs, write_exprs)
         ):
             return -1
@@ -7219,9 +7219,7 @@ class Scheduler:
 
         flat_var = sympy.Dummy("copy_flat", integer=True, nonnegative=True)
         old_iter_idx = decompose_index(flat_var, old_iter_sizes)
-        flattened_read = sympy_subs(
-            read_exprs[0], dict(zip(iter_vars, old_iter_idx))
-        )
+        flattened_read = sympy_subs(read_exprs[0], dict(zip(iter_vars, old_iter_idx)))
         simplified_terms = [
             sizevars.combine_modular_indexing_pairs(term)
             for term in sympy.Add.make_args(sympy.expand(flattened_read))
@@ -7269,9 +7267,7 @@ class Scheduler:
             node2.restore_loop_state(state)
             return -1
 
-        fusion_log.info(
-            "Shared memory after invertible memory-copy reindex: %d", score
-        )
+        fusion_log.info("Shared memory after invertible memory-copy reindex: %d", score)
         return score
 
     def shared_data_after_reordering_loop(

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -57,7 +57,7 @@ from torch._inductor.ir import TritonTemplateCallerBase
 from torch._inductor.metrics import get_metric_table, is_metric_table_enabled
 from torch._inductor.stream_utils import get_stream_name
 from torch.fx.experimental.symbolic_shapes import free_symbols
-from torch.utils._sympy.functions import FloorDiv, ModularIndexing
+from torch.utils._sympy.functions import FloorDiv
 from torch.utils._sympy.symbol import free_symbol_is_type, symbol_is_type, SymT
 from torch.utils._triton import has_triton
 
@@ -88,6 +88,7 @@ from .utils import (
     _unstable_customized_partition_wrapper,
     cache_on_self,
     cmp,
+    decompose_index,
     device_need_guard,
     get_current_backend,
     get_device_tflops,
@@ -2375,6 +2376,19 @@ class SchedulerNode(BaseSchedulerNode):
         self.group = (device, group_fn(self._sizes))
 
         self.refresh_dependencies(normalize=False, need_clear_tiling_cache=True)
+
+    def _apply_indexing_expr_replacements(
+        self,
+        replacements: dict[str, sympy.Expr],
+        *,
+        normalize: bool,
+    ) -> None:
+        self._before_loop_state_mutation()
+        self._body = self._body._replace_indexing_exprs(replacements)
+        self.refresh_dependencies(
+            normalize=normalize,
+            need_clear_tiling_cache=False,
+        )
 
     def swap_pw_red_dimension(self) -> None:
         num_rdims = self._body.get_original_num_rdims()
@@ -7008,7 +7022,7 @@ class Scheduler:
             return -1
 
         # Currently only handle single read/write operations
-        if len(node2.read_writes.reads) > 1 or len(node2.read_writes.writes) > 1:
+        if len(node2.read_writes.reads) != 1 or len(node2.read_writes.writes) != 1:
             return -1
 
         node2_read = next(iter(node2.read_writes.reads))
@@ -7019,21 +7033,26 @@ class Scheduler:
         ):
             return -1
 
-        node1_writes = {dep.name: dep for dep in node1.read_writes.writes}
-        if node2_read.name not in node1_writes:
+        matching_node1_writes = [
+            dep for dep in node1.read_writes.writes if dep.name == node2_read.name
+        ]
+        if len(matching_node1_writes) != 1:
             return -1
 
-        node1_write = node1_writes[node2_read.name]
+        node1_write = matching_node1_writes[0]
 
         if not isinstance(node1_write, MemoryDep):
             return -1
 
         if config.loop_reindexing_after_fusion:
-            score = self._try_reindex_transpose_contiguous_clone(
+            score = self._try_reindex_invertible_memory_copy(
                 node1, node2, node1_write, node2_read, node2_write
             )
             if score >= 0:
                 return score
+
+        if not isinstance(node2, SchedulerNode):
+            return -1
 
         # We are checking for compatibility with the normalized node1 write
         # then modifying node2 reads/writes. since the node1 write will be just used
@@ -7102,14 +7121,17 @@ class Scheduler:
 
         # === Apply Inversion ===
 
-        # Swap the indexing expressions using the inverse formula
-        node2._body.indexing_exprs[read_expr_index] = node2._body.indexing_exprs[  # type: ignore[attr-defined]
-            write_expr_index
-        ]
-        node2._body.indexing_exprs[write_expr_index] = inverse_formula  # type: ignore[attr-defined]
+        # Replace the indexing expressions copy-on-write so speculative fusion
+        # rollback retains an untouched LoopBody snapshot.
+        node2._apply_indexing_expr_replacements(
+            {
+                read_expr_index: node2._body.indexing_exprs[write_expr_index],
+                write_expr_index: inverse_formula,
+            },
+            normalize=True,
+        )
 
-        # Refresh dependencies and calculate fusion score
-        node2.refresh_dependencies(True, False)  # type: ignore[attr-defined]
+        # Calculate fusion score
         score = self.score_fusion_memory(node1, node2)
         if not isinstance(score, int):
             raise AssertionError("expected score to be an int")
@@ -7117,7 +7139,7 @@ class Scheduler:
         fusion_log.info("Shared memory after inversion: %d", score)
         return score
 
-    def _try_reindex_transpose_contiguous_clone(
+    def _try_reindex_invertible_memory_copy(
         self,
         node1: BaseSchedulerNode,
         node2: BaseSchedulerNode,
@@ -7126,23 +7148,13 @@ class Scheduler:
         node2_write: MemoryDep,
     ) -> int:
         """
-        Reindex a layout-changing clone after a producer of [B, S, H].
+        Reindex an invertible memory copy to the producer iteration domain.
 
-        This handles the common attention layout transition:
-
-            producer[B, S, H] -> view(B, S, heads, D)
-                -> transpose(1, 2).contiguous()
-
-        The clone initially iterates in output order [B, heads, S, D] and reads
-        the producer storage with a permuted index. Reindexing the clone to the
-        producer domain [B, S, H] makes its read dependency match the producer
-        write while preserving the final contiguous output store.
+        The copy's read address is expressed as a function R(q) of a flattened
+        iteration index q. If R is invertible, running the old body at
+        q = R^-1(producer_address) makes the read match the producer write while
+        preserving every other access in the copy, including its output layout.
         """
-        # Note [Targeted transpose-contiguous clone reindexing]
-        # This intentionally matches only the common attention layout above when
-        # its sizes and index polynomials can be proven statically. Other layouts
-        # fail closed; broader matching belongs in the general reindexing machinery
-        # rather than as additional special cases here.
         if not isinstance(node2, SchedulerNode):
             return -1
 
@@ -7155,51 +7167,71 @@ class Scheduler:
         body = node2._body
         if not body.is_memory_copy():
             return -1
-        if len(body.indexing_exprs) != 2 or body.subblocks:
-            return -1
-        if "index0" not in body.indexing_exprs or "index1" not in body.indexing_exprs:
+        if body.subblocks:
             return -1
 
-        read_exprs = OrderedSet(body.get_read_exprs())
-        if len(read_exprs) != 1:
-            return -1
-        if next(iter(read_exprs)) not in body.indexing_exprs.values():
+        read_exprs = body.get_read_exprs()
+        write_exprs = body.get_write_exprs()
+        if len(read_exprs) != 1 or len(write_exprs) != 1:
             return -1
 
         iter_vars = body.vars[0]
-        if len(iter_vars) != 4:
+        if not iter_vars:
             return -1
 
         producer_size = list(node1_write.size)
-        clone_read_size = list(node2_read.size)
-        clone_write_size = list(node2_write.size)
-        if (
-            len(producer_size) != 3
-            or len(clone_read_size) != 4
-            or clone_read_size != clone_write_size
-        ):
+        old_iter_sizes = list(body.sizes[0])
+        if len(node1_write.var_names) != len(producer_size):
             return -1
 
-        bsz, seq, hidden = producer_size
-        read_bsz, heads, read_seq, head_dim = clone_read_size
-        if not (
-            V.graph.sizevars.statically_known_equals(bsz, read_bsz)
-            and V.graph.sizevars.statically_known_equals(seq, read_seq)
-            and V.graph.sizevars.statically_known_equals(hidden, heads * head_dim)
-        ):
-            return -1
-
-        b, head, s, d = iter_vars
-        expected_read = b * seq * hidden + s * hidden + head * head_dim + d
-        expected_write = (
-            b * heads * seq * head_dim + head * seq * head_dim + s * head_dim + d
-        )
-        if not (
-            V.graph.sizevars.statically_known_equals(node2_read.index, expected_read)
-            and V.graph.sizevars.statically_known_equals(
-                node2_write.index, expected_write
+        memory_deps = (node1_write, node2_read, node2_write)
+        if any(
+            free_symbols(size)
+            for size in itertools.chain(
+                old_iter_sizes,
+                *(dep.size for dep in memory_deps),
             )
         ):
+            return -1
+        if any(
+            set(free_symbols(dep.index)).difference(dep.var_names)
+            for dep in memory_deps
+        ):
+            return -1
+        if any(
+            set(free_symbols(expr)).difference(iter_vars)
+            for expr in itertools.chain(read_exprs, write_exprs)
+        ):
+            return -1
+
+        copy_numel = sympy_product(old_iter_sizes)
+        sizevars = V.graph.sizevars
+        if sizevars.statically_known_equals(copy_numel, 0):
+            return -1
+        if not all(
+            sizevars.statically_known_equals(copy_numel, sympy_product(sizes))
+            for sizes in (producer_size, node2_read.size, node2_write.size)
+        ):
+            return -1
+
+        if not self._is_dense_and_injective_memory_dep(node1_write):
+            return -1
+
+        flat_var = sympy.Dummy("copy_flat", integer=True, nonnegative=True)
+        old_iter_idx = decompose_index(flat_var, old_iter_sizes)
+        flattened_read = sympy_subs(
+            read_exprs[0], dict(zip(iter_vars, old_iter_idx))
+        )
+        simplified_terms = [
+            sizevars.combine_modular_indexing_pairs(term)
+            for term in sympy.Add.make_args(sympy.expand(flattened_read))
+        ]
+        flattened_read = sum(simplified_terms)
+
+        from torch._inductor.invert_expr_analysis import generate_inverse_formula
+
+        inverse_formula = generate_inverse_formula(flattened_read, flat_var)
+        if inverse_formula is None:
             return -1
 
         old_score = self.score_fusion_memory(node1, node2)
@@ -7209,15 +7241,27 @@ class Scheduler:
             new_iter_idx: Sequence[sympy.Expr],
             old_iter_sizes: Sequence[sympy.Expr],
         ) -> Sequence[sympy.Expr]:
-            b, s, h = new_iter_idx
-            return [
-                b,
-                FloorDiv(h, old_iter_sizes[3]),
-                s,
-                ModularIndexing(h, 1, old_iter_sizes[3]),
-            ]
+            producer_index = sympy_subs(
+                node1_write.index,
+                dict(zip(node1_write.var_names, new_iter_idx)),
+            )
+            old_flat = sympy_subs(inverse_formula, {flat_var: producer_index})
+            return decompose_index(old_flat, old_iter_sizes)
 
         node2.apply_loop_reindexing(producer_size, indexer=indexer)
+        node2.refresh_dependencies(normalize=True, need_clear_tiling_cache=False)
+
+        matching_reads = [
+            dep
+            for dep in node2.read_writes.reads
+            if isinstance(dep, MemoryDep) and dep.name == node1_write.name
+        ]
+        if len(matching_reads) != 1 or not self.deps_match_normalized(
+            node1_write, matching_reads[0]
+        ):
+            node2.restore_loop_state(state)
+            return -1
+
         score = self.score_fusion_memory(node1, node2)
         if not isinstance(score, int):
             raise AssertionError("expected score to be an int")
@@ -7226,7 +7270,7 @@ class Scheduler:
             return -1
 
         fusion_log.info(
-            "Shared memory after transpose-contiguous clone reindex: %d", score
+            "Shared memory after invertible memory-copy reindex: %d", score
         )
         return score
 
@@ -8239,6 +8283,16 @@ class Scheduler:
             and read.size[: len(write.size)] == write.size
         )
 
+    @staticmethod
+    def _is_dense_and_injective_memory_dep(dep: MemoryDep) -> bool:
+        """Return whether each iteration writes one element of a dense region."""
+        if not OrderedSet(dep.var_names) <= dep.index.free_symbols:
+            return False
+        return (
+            dep.normalize().is_contiguous()
+            or dep.normalize_with_stride_order().is_contiguous()
+        )
+
     # StarDep doesn't match MemoryDep, and indirect indexing is not fusible.
     def fusable_read_and_write(
         self, read: Dep, write: MemoryDep, *, allow_index_equivalence: bool = False
@@ -8306,18 +8360,7 @@ class Scheduler:
     def _fusable_read_after_index_equivalence(
         self, read: MemoryDep, write: MemoryDep
     ) -> bool:
-        # Relaxed matching is only for consumer-side reshapes/broadcasts.
-        # If a write var is absent from the write index, the producer itself
-        # broadcasts multiple loop iterations to the same address.
-        if not OrderedSet(write.var_names) <= write.index.free_symbols:
-            return False
-        # Once read/write indices differ, require the producer to write a
-        # dense logical region. Otherwise gaps or aliases in the producer
-        # could be hidden by a consumer-side broadcast.
-        if not (
-            write.normalize().is_contiguous()
-            or write.normalize_with_stride_order().is_contiguous()
-        ):
+        if not self._is_dense_and_injective_memory_dep(write):
             return False
 
         return self.deps_match_normalized(

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -59,6 +59,7 @@ from torch._inductor.stream_utils import get_stream_name
 from torch.fx.experimental.symbolic_shapes import free_symbols
 from torch.utils._sympy.functions import FloorDiv
 from torch.utils._sympy.symbol import free_symbol_is_type, symbol_is_type, SymT
+from torch.utils._sympy.value_ranges import bound_sympy, ValueRanges
 from torch.utils._triton import has_triton
 
 from . import comms, config, config_comms, dependencies, ir, metrics
@@ -79,7 +80,7 @@ from .ir import (
     MultiOutputLayout,
     NoneLayout,
 )
-from .loop_body import LoopBody
+from .loop_body import LoopBody, MemoryUsageType
 from .memory import MemoryPlanningInfoForBuffer, MemoryPlanningInfoForNode
 from .runtime.hints import DeviceProperties, ReductionHint
 from .runtime.runtime_utils import green_text, is_power_of_2, red_text
@@ -150,6 +151,7 @@ class PendingFusion:
     callable_fn: Callable[[], bool]
     node1: BaseSchedulerNode
     node2: BaseSchedulerNode
+    can_reorder: bool = False
     future: LambdaFuture | None = None
 
     def get_fusion_nodes(self) -> tuple[BaseSchedulerNode, BaseSchedulerNode]:
@@ -2320,8 +2322,10 @@ class SchedulerNode(BaseSchedulerNode):
 
     def snapshot_loop_state(self) -> tuple[Any, ...]:
         """Snapshot mutable state modified by loop transformations
-        (apply_new_loop_order, apply_loop_reindexing). Must be kept
-        in sync with those methods and restore_loop_state."""
+        (apply_new_loop_order, apply_loop_reindexing,
+        _apply_indexing_expr_replacements,
+        expand_dimension_for_pointwise_node). Must be kept in sync with those
+        methods and restore_loop_state."""
         return (
             self._body,
             self._sizes,
@@ -2361,6 +2365,8 @@ class SchedulerNode(BaseSchedulerNode):
             [Sequence[sympy.Expr], Sequence[sympy.Expr]], Sequence[sympy.Expr]
         ]
         | None = None,
+        *,
+        refresh_dependencies: bool = True,
     ) -> None:
         if not isinstance(self.node, (ir.ComputedBuffer, ir.TemplateBuffer)):
             raise AssertionError(
@@ -2375,19 +2381,21 @@ class SchedulerNode(BaseSchedulerNode):
         group_fn = self.scheduler.get_backend(device).group_fn
         self.group = (device, group_fn(self._sizes))
 
-        self.refresh_dependencies(normalize=False, need_clear_tiling_cache=True)
+        if refresh_dependencies:
+            self.refresh_dependencies(normalize=False, need_clear_tiling_cache=True)
 
     def _apply_indexing_expr_replacements(
         self,
         replacements: dict[str, sympy.Expr],
         *,
         normalize: bool,
+        need_clear_tiling_cache: bool = False,
     ) -> None:
         self._before_loop_state_mutation()
         self._body = self._body._replace_indexing_exprs(replacements)
         self.refresh_dependencies(
             normalize=normalize,
-            need_clear_tiling_cache=False,
+            need_clear_tiling_cache=need_clear_tiling_cache,
         )
 
     def swap_pw_red_dimension(self) -> None:
@@ -2423,6 +2431,7 @@ class SchedulerNode(BaseSchedulerNode):
                 "expected self.node to be a ComputedBuffer or TemplateBuffer"
             )
 
+        self._before_loop_state_mutation()
         self._body = self._body.expand_dimension_for_pointwise_node(
             dimension, new_range
         )
@@ -4096,8 +4105,9 @@ class _LoopMutationTracker:
     installing nested listeners, so the captured state is the original state at
     the outermost decision boundary.
 
-    Usage: call finish(commit=True) to keep mutations, or finish(commit=False)
-    to restore the original state. If no mutation occurred, finish() is a no-op.
+    Usage: call finish(rollback=False) to keep mutations, or
+    finish(rollback=True) to restore the original state. If no mutation occurred,
+    finish() is a no-op.
     """
 
     nodes: tuple[BaseSchedulerNode, ...]
@@ -6034,16 +6044,22 @@ class Scheduler:
         node2: BaseSchedulerNode,
         speedup_fn: Callable[[], bool],
         fused_nodes: OrderedSet[BaseSchedulerNode],
+        *,
+        can_reorder: bool = False,
     ):
-        if (
-            self.can_fuse(node1, node2)
-            and not self.will_fusion_create_cycle(node1, node2)
-            and speedup_fn()
-        ):
-            self.fuse_two_nodes(node1, node2, fused_nodes)
-            return True
-
-        return False
+        tracker = _LoopMutationTracker.create((node1, node2))
+        fused = False
+        try:
+            if (
+                self._can_fuse_impl(node1, node2, can_reorder=can_reorder)
+                and not self.will_fusion_create_cycle(node1, node2)
+                and speedup_fn()
+            ):
+                self.fuse_two_nodes(node1, node2, fused_nodes)
+                fused = True
+            return fused
+        finally:
+            tracker.finish(rollback=not fused)
 
     def _evaluate_pending_template_fusions(
         self,
@@ -6108,7 +6124,11 @@ class Scheduler:
                 else:
                     # Non AsyncCompile path, perform fusion
                     if self.fuse_if_speedup(
-                        node1, node2, pending_fusion.callable_fn, fused_nodes
+                        node1,
+                        node2,
+                        pending_fusion.callable_fn,
+                        fused_nodes,
+                        can_reorder=pending_fusion.can_reorder,
                     ):
                         fusions_to_remove.add(candidate)
 
@@ -6120,6 +6140,7 @@ class Scheduler:
                     self.get_fused_node(pending_fusion.node2),
                     pending_fusion.callable_fn,
                     fused_nodes,
+                    can_reorder=pending_fusion.can_reorder,
                 ):
                     fusions_to_remove.add(cand)
 
@@ -6160,10 +6181,13 @@ class Scheduler:
                 if self.get_fused_node(node_key2) is not node_key2:
                     raise AssertionError("expected node_key2 to be its own fused node")
 
-                if not is_speedup() or self.will_fusion_create_cycle(node1, node2):
-                    continue
-
-                self.fuse_two_nodes(node_key1, node_key2, fused_nodes)
+                self.fuse_if_speedup(
+                    node_key1,
+                    node_key2,
+                    is_speedup,
+                    fused_nodes,
+                    can_reorder=pending_fusion.can_reorder,
+                )
 
         for node1, node2 in possible_fusion_pairs:
             # if either node is in a pending fusion, resolve it.
@@ -6179,15 +6203,21 @@ class Scheduler:
             ):
                 continue
 
-            if self.can_fuse(
-                node1, node2, is_reorder_round
-            ) and not self.will_fusion_create_cycle(node1, node2):
+            tracker = _LoopMutationTracker.create((node1, node2))
+            fused = False
+            try:
+                if not self._can_fuse_impl(
+                    node1, node2, is_reorder_round
+                ) or self.will_fusion_create_cycle(node1, node2):
+                    continue
+
                 fusion_res = self.speedup_by_fusion(node1, node2)
                 if fusion_res.callable_fn is not None:
                     pending_fusion = PendingFusion(
                         callable_fn=fusion_res.callable_fn,
                         node1=node1,
                         node2=node2,
+                        can_reorder=is_reorder_round,
                         future=fusion_res.future,
                     )
 
@@ -6212,6 +6242,9 @@ class Scheduler:
                     continue
 
                 self.fuse_two_nodes(node1, node2, fused_nodes)
+                fused = True
+            finally:
+                tracker.finish(rollback=not fused)
 
     def _finish_pending_fusions(
         self,
@@ -6237,7 +6270,13 @@ class Scheduler:
             if self.get_fused_node(node_key2) is not node_key2:
                 raise AssertionError("expected node_key2 to be its own fused node")
 
-            self.fuse_if_speedup(node_key1, node_key2, is_speedup_fn, fused_nodes)
+            self.fuse_if_speedup(
+                node_key1,
+                node_key2,
+                is_speedup_fn,
+                fused_nodes,
+                can_reorder=pending_fusion.can_reorder,
+            )
 
     def _handle_template_overlap(
         self,
@@ -6978,6 +7017,35 @@ class Scheduler:
 
         return str(reasons)
 
+    @staticmethod
+    def _prove_expr_equals_with_ranges(
+        lhs: sympy.Expr,
+        rhs: sympy.Expr,
+        var_ranges: dict[sympy.Symbol, sympy.Expr],
+    ) -> bool:
+        difference = V.graph.sizevars.simplify_with_ranges(
+            sympy.expand(lhs - rhs), var_ranges
+        )
+        value_ranges = {
+            var: ValueRanges(0, size - 1) for var, size in var_ranges.items()
+        }
+        return bound_sympy(difference, value_ranges) == ValueRanges(0, 0)
+
+    @staticmethod
+    def _prove_expr_in_bounds(
+        expr: sympy.Expr,
+        var_ranges: dict[sympy.Symbol, sympy.Expr],
+        upper_bound: sympy.Expr,
+    ) -> bool:
+        expr = V.graph.sizevars.simplify_with_ranges(expr, var_ranges)
+        value_ranges = {
+            var: ValueRanges(0, size - 1) for var, size in var_ranges.items()
+        }
+        bounds = bound_sympy(expr, value_ranges)
+        return V.graph.sizevars.statically_known_geq(
+            bounds.lower, 0
+        ) and V.graph.sizevars.statically_known_lt(bounds.upper, upper_bound)
+
     def shared_data_after_inverting_indexing(
         self, node1: BaseSchedulerNode, node2: BaseSchedulerNode
     ) -> int:
@@ -6994,7 +7062,7 @@ class Scheduler:
             node2: Second scheduler node (target for inversion)
 
         Returns:
-            int: Fusion score if successful, 0 if optimization not applicable
+            int: Fusion score if successful, -1 if optimization is not applicable
         """
 
         if not config.loop_index_inversion_in_fusion:
@@ -7003,15 +7071,9 @@ class Scheduler:
         if any(n.is_cpu() for n in [node1, node2]):
             return -1
 
-        # Check for shared buffers between nodes
         node1_buffer_names = node1.read_writes.buffer_names()
-        node2_buffer_names = node2.read_writes.buffer_names()
-        common_buffer_names = node1_buffer_names & node2_buffer_names
 
-        if not common_buffer_names:
-            return -1
-
-        # only invert if node1 is single unmet dep
+        # Only invert when node1 can satisfy every unmet dependency in node2.
         node2_unmet_dependencies = OrderedSet(
             dep.name for dep in node2.unmet_dependencies
         )
@@ -7113,31 +7175,65 @@ class Scheduler:
             )
         simplified_read_expr = sum(simplified_terms)
 
-        inverse_formula = generate_inverse_formula(simplified_read_expr, index_vars[0])
+        try:
+            inverse_formula = generate_inverse_formula(
+                simplified_read_expr, index_vars[0]
+            )
+            if inverse_formula is None:
+                return -1
 
-        # formula is not invertible
-        if inverse_formula is None:
+            iter_sizes = node2._body.sizes[0]
+            if (
+                len(iter_sizes) != 1
+                or free_symbols(iter_sizes[0])
+                or V.graph.sizevars.statically_known_equals(iter_sizes[0], 0)
+            ):
+                return -1
+
+            index_var = index_vars[0]
+            iter_size = iter_sizes[0]
+            var_ranges = {index_var: iter_size}
+            write_expr = node2._body.indexing_exprs[write_expr_index]
+            if not self._prove_expr_equals_with_ranges(
+                write_expr, index_var, var_ranges
+            ):
+                return -1
+
+            inverse_read = sympy_subs(read_expr, {index_var: inverse_formula})
+            if not self._prove_expr_equals_with_ranges(
+                inverse_read, index_var, var_ranges
+            ) or not self._prove_expr_in_bounds(inverse_formula, var_ranges, iter_size):
+                return -1
+        except Exception:
+            fusion_log.debug("Failed to prove index inversion", exc_info=True)
             return -1
 
-        # === Apply Inversion ===
+        state = node2.snapshot_loop_state()
+        success = False
+        try:
+            # Replace the indexing expressions copy-on-write so speculative fusion
+            # rollback retains an untouched LoopBody snapshot.
+            node2._apply_indexing_expr_replacements(
+                {
+                    read_expr_index: write_expr,
+                    write_expr_index: inverse_formula,
+                },
+                normalize=True,
+            )
 
-        # Replace the indexing expressions copy-on-write so speculative fusion
-        # rollback retains an untouched LoopBody snapshot.
-        node2._apply_indexing_expr_replacements(
-            {
-                read_expr_index: node2._body.indexing_exprs[write_expr_index],
-                write_expr_index: inverse_formula,
-            },
-            normalize=True,
-        )
+            score = self.score_fusion_memory(node1, node2)
+            if not isinstance(score, int):
+                raise AssertionError("expected score to be an int")
 
-        # Calculate fusion score
-        score = self.score_fusion_memory(node1, node2)
-        if not isinstance(score, int):
-            raise AssertionError("expected score to be an int")
-
-        fusion_log.info("Shared memory after inversion: %d", score)
-        return score
+            success = True
+            fusion_log.info("Shared memory after inversion: %d", score)
+            return score
+        except Exception:
+            fusion_log.debug("Failed to apply index inversion", exc_info=True)
+            return -1
+        finally:
+            if not success:
+                node2.restore_loop_state(state)
 
     def _try_reindex_invertible_memory_copy(
         self,
@@ -7172,8 +7268,6 @@ class Scheduler:
 
         read_exprs = body.get_read_exprs()
         write_exprs = body.get_write_exprs()
-        if len(read_exprs) != 1 or len(write_exprs) != 1:
-            return -1
 
         iter_vars = body.vars[0]
         if not iter_vars:
@@ -7217,19 +7311,48 @@ class Scheduler:
         if not self._is_dense_and_injective_memory_dep(node1_write):
             return -1
 
-        flat_var = sympy.Dummy("copy_flat", integer=True, nonnegative=True)
-        old_iter_idx = decompose_index(flat_var, old_iter_sizes)
-        flattened_read = sympy_subs(read_exprs[0], dict(zip(iter_vars, old_iter_idx)))
-        simplified_terms = [
-            sizevars.combine_modular_indexing_pairs(term)
-            for term in sympy.Add.make_args(sympy.expand(flattened_read))
-        ]
-        flattened_read = sum(simplified_terms)
+        try:
+            flat_var = sympy.Dummy("copy_flat", integer=True, nonnegative=True)
+            old_iter_idx = decompose_index(flat_var, old_iter_sizes)
+            flattened_read = sympy_subs(
+                read_exprs[0], dict(zip(iter_vars, old_iter_idx))
+            )
+            simplified_terms = [
+                sizevars.combine_modular_indexing_pairs(term)
+                for term in sympy.Add.make_args(sympy.expand(flattened_read))
+            ]
+            flattened_read = sum(simplified_terms)
 
-        from torch._inductor.invert_expr_analysis import generate_inverse_formula
+            from torch._inductor.invert_expr_analysis import generate_inverse_formula
 
-        inverse_formula = generate_inverse_formula(flattened_read, flat_var)
-        if inverse_formula is None:
+            inverse_formula = generate_inverse_formula(flattened_read, flat_var)
+            if inverse_formula is None:
+                return -1
+
+            proof_iter_vars = tuple(
+                sympy.Dummy(f"reindex_{i}", integer=True, nonnegative=True)
+                for i in range(len(producer_size))
+            )
+            proof_ranges = dict(zip(proof_iter_vars, producer_size))
+            proof_producer_index = sympy_subs(
+                node1_write.index,
+                dict(zip(node1_write.var_names, proof_iter_vars)),
+            )
+            proof_old_flat = sympy_subs(
+                inverse_formula, {flat_var: proof_producer_index}
+            )
+            proof_old_indices = decompose_index(proof_old_flat, old_iter_sizes)
+            proof_read = sympy_subs(
+                read_exprs[0], dict(zip(iter_vars, proof_old_indices))
+            )
+            if not self._prove_expr_equals_with_ranges(
+                proof_read, proof_producer_index, proof_ranges
+            ):
+                return -1
+        except Exception:
+            fusion_log.debug(
+                "Failed to prove invertible memory-copy reindex", exc_info=True
+            )
             return -1
 
         old_score = self.score_fusion_memory(node1, node2)
@@ -7246,29 +7369,56 @@ class Scheduler:
             old_flat = sympy_subs(inverse_formula, {flat_var: producer_index})
             return decompose_index(old_flat, old_iter_sizes)
 
-        node2.apply_loop_reindexing(producer_size, indexer=indexer)
-        node2.refresh_dependencies(normalize=True, need_clear_tiling_cache=False)
+        success = False
+        try:
+            node2.apply_loop_reindexing(
+                producer_size,
+                indexer=indexer,
+                refresh_dependencies=False,
+            )
+            load_entries = node2._body.memory_usage[MemoryUsageType.LOAD]
+            if len(load_entries) != 1:
+                return -1
 
-        matching_reads = [
-            dep
-            for dep in node2.read_writes.reads
-            if isinstance(dep, MemoryDep) and dep.name == node1_write.name
-        ]
-        if len(matching_reads) != 1 or not self.deps_match_normalized(
-            node1_write, matching_reads[0]
-        ):
-            node2.restore_loop_state(state)
+            canonical_read = sympy_subs(
+                node1_write.index,
+                dict(zip(node1_write.var_names, node2._body.iter_vars)),
+            )
+            node2._apply_indexing_expr_replacements(
+                {load_entries[0].index_name: canonical_read},
+                normalize=True,
+                need_clear_tiling_cache=True,
+            )
+
+            matching_reads = [
+                dep
+                for dep in node2.read_writes.reads
+                if isinstance(dep, MemoryDep) and dep.name == node1_write.name
+            ]
+            if len(matching_reads) != 1 or not self.deps_match_normalized(
+                node1_write, matching_reads[0]
+            ):
+                return -1
+
+            score = self.score_fusion_memory(node1, node2)
+            if not isinstance(score, int):
+                raise AssertionError("expected score to be an int")
+            if score <= old_score or score <= 0:
+                return -1
+
+            success = True
+            fusion_log.info(
+                "Shared memory after invertible memory-copy reindex: %d", score
+            )
+            return score
+        except Exception:
+            fusion_log.debug(
+                "Failed to apply invertible memory-copy reindex", exc_info=True
+            )
             return -1
-
-        score = self.score_fusion_memory(node1, node2)
-        if not isinstance(score, int):
-            raise AssertionError("expected score to be an int")
-        if score <= old_score or score <= 0:
-            node2.restore_loop_state(state)
-            return -1
-
-        fusion_log.info("Shared memory after invertible memory-copy reindex: %d", score)
-        return score
+        finally:
+            if not success:
+                node2.restore_loop_state(state)
 
     def shared_data_after_reordering_loop(
         self, node1: BaseSchedulerNode, node2: BaseSchedulerNode
@@ -7768,18 +7918,20 @@ class Scheduler:
     ) -> bool:
         """Determine if node1 and node2 can be combined into a single fused node.
 
-        Speculative loop mutations (reordering, reindexing) are automatically
-        rolled back if the fusion decision ultimately fails.
+        This is a legality query, so its speculative loop mutations are always
+        rolled back. Fusion entry points install an outer tracker and keep the
+        mutations only when the fusion is materialized.
         """
         tracker = _LoopMutationTracker.create((node1, node2))
-        can_fuse = self._can_fuse_impl(
-            node1,
-            node2,
-            can_reorder=can_reorder,
-            allow_mix_order_reduction=allow_mix_order_reduction,
-        )
-        tracker.finish(rollback=not can_fuse)
-        return can_fuse
+        try:
+            return self._can_fuse_impl(
+                node1,
+                node2,
+                can_reorder=can_reorder,
+                allow_mix_order_reduction=allow_mix_order_reduction,
+            )
+        finally:
+            tracker.finish(rollback=True)
 
     def _can_fuse_impl(
         self,


### PR DESCRIPTION
Fixes #188635

## Summary

This PR extends Inductor's loop reindexing/index-inversion fusion path to handle a layout-changing clone produced by:

```python
producer[B, S, H] -> view(B, S, heads, D) -> transpose(1, 2).contiguous()
```

Before this change, the producer writes `[B, S, H]` contiguously, while the clone reads the producer buffer through a 4D `[B, heads, S, D]` logical domain and writes the final contiguous output. Because the read/write dependency domains differ, vertical fusion rejects the producer -> clone edge and Inductor emits a separate `triton_poi_fused_clone_*` copy kernel.

This change adds:

- `LoopBody.reindex_iter_loops_with_indexer(...)`, a small extension that allows reindexing with an explicit new-index -> old-index mapping.
- `SchedulerNode.apply_loop_reindexing_with_indexer(...)`, matching the existing `apply_loop_reindexing(...)` lifecycle and dependency refresh behavior.
- A targeted scheduler helper for the `[B, S, H] -> [B, heads, S, D]` transpose-contiguous clone pattern. It reindexes the clone to the producer domain `[B, S, H]`, making the clone read dependency match the producer write while preserving the final output store indexing.
- A regression test covering `embedding -> rmsnorm -> rope -> view -> transpose -> contiguous`.

The optimization is guarded narrowly:

- CUDA/GPU path only through the existing caller.
- `node2` must be a non-reduction `SchedulerNode`.
- clone must have one read and one write.
- body must have exactly two indexing expressions and no subblocks.
- producer domain must be 3D and clone read/write domain must be matching 4D.
- sizes must satisfy `B == B`, `S == S`, and `H == heads * head_dim`.
- if the reindex does not improve fusion score, node state is restored.

## Test Plan

Main checkout patch/static checks, run in `/home/admin/app/pytorch-dev` at `703abdc`:

```bash
git apply --check pytorch_layout_clone_reindex_pr.patch
git diff --check
python3 -m py_compile torch/_inductor/loop_body.py torch/_inductor/scheduler.py test/inductor/test_loop_ordering.py
```

Target test from the main git checkout, run through a wrapper because the available runtime is an older `torch==2.5.1+cu121` wheel while the checkout is current main:

```bash
TORCHINDUCTOR_LOOP_REINDEXING_AFTER_FUSION=1 \
TORCHINDUCTOR_LOOP_INDEX_INVERSION_IN_FUSION=1 \
TORCHINDUCTOR_LOOP_ORDERING_AFTER_FUSION=1 \
TORCHINDUCTOR_FORCE_DISABLE_CACHES=1 \
python3 /tmp/run_main_checkout_target_test.py
```

Result:

```text
Ran 1 test in 3.236s
OK
```

Runtime-compatible PyTorch source tree check, run from `/home/admin/app/pytorch-v2.5.1-src` using the installed 2.5.1 CUDA wheel's generated/binary files:

```bash
TORCHINDUCTOR_LOOP_REINDEXING_AFTER_FUSION=1 \
TORCHINDUCTOR_LOOP_INDEX_INVERSION_IN_FUSION=1 \
TORCHINDUCTOR_LOOP_ORDERING_AFTER_FUSION=1 \
TORCHINDUCTOR_FORCE_DISABLE_CACHES=1 \
PYTHONPATH=/home/admin/app/pytorch-v2.5.1-src \
python3 test/inductor/test_loop_ordering.py -k test_transpose_contiguous_clone_reindexing
```

Result:

```text
Ran 1 test in 3.047s
OK
```

Expected validation before opening the final GitHub PR from a fully built PyTorch main dev environment:

```bash
python test/inductor/test_loop_ordering.py -k test_transpose_contiguous_clone_reindexing
python test/inductor/test_loop_ordering.py -k "reindexing or inversion"
python -m tools.linter.lintrunner --take CLANGFORMAT MYPYNOFOLLOW FLAKE8
```

Experiment run in `4090-2` / `puyun-acc` using the installed PyTorch package with the same Python-layer behavior:

Correctness:

```text
max_abs_diff 4.76837158203125e-07
out_sum 11.314574241638184
stride (512, 128, 8, 1)
```

Fusion evidence:

```text
transpose-contiguous clone reindex matched op1 -> op2 with score 4096
completed fusion round (1/10): fused 3 nodes into 1 nodes
```

Generated code evidence:

```text
triton_per_fused_add_clone_embedding_mean_mul_rsqrt_0.run(...)
```

No separate `triton_poi_fused_clone_*` launch remains.

Benchmark summary, float32, RTX 4090:

```text
small:  default torch.compile median 0.125744 ms; replaced median 0.109488 ms
medium: default torch.compile median 0.157328 ms; replaced median 0.094576 ms
```

Full logs are in:

- `pytorch_main_checkout_wrapped_target_test.log`
- `pytorch_dev_checkout_test_transpose_contiguous_clone_reindexing.log`
- `experiment_artifacts/probe_fusion_log.txt`
- `experiment_artifacts/output_code_replaced.py`
- `experiment_artifacts/ir_post_fusion_replaced.txt`
- `experiment_artifacts/benchmark_default_two_kernel.txt`
- `experiment_artifacts/benchmark_reindexed_replaced.txt`
- `experiment_artifacts/check_replaced_correctness.out`


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo