### PR TITLE
Fix XPU C++ test libc10_xpu.so not found after OSDC migration

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1543,6 +1543,10 @@ test_xpu_bin(){
   TEST_REPORTS_DIR=$(pwd)/test/test-reports
   mkdir -p "$TEST_REPORTS_DIR"
 
+  # Build binaries carry absolute RPATHs that don't exist on the test runner;
+  # point LD_LIBRARY_PATH at the installed torch libs so the linker finds them.
+  export LD_LIBRARY_PATH="${TORCH_LIB_DIR}:${LD_LIBRARY_PATH}"
+
   for xpu_case in "${BUILD_BIN_DIR}"/*{xpu,sycl}*; do
     if [[ "$xpu_case" != *"*"* && "$xpu_case" != *.so && "$xpu_case" != *.a ]]; then
       case_name=$(basename "$xpu_case")


### PR DESCRIPTION
## Summary

The OSDC migration (PR #187993) moved XPU Linux builds from EC2 to OSDC runners using GitHub Actions' native `container:` directive. This changed the workspace path inside the build container from `/var/lib/jenkins/workspace` (the EC2 docker mount) to the GHA default (`/__w/pytorch/pytorch`).

Because `CMAKE_BUILD_RPATH_USE_ORIGIN` is not set, CMake embeds **absolute** BUILD RPATHs. The test binaries now carry RPATHs pointing to `/__w/.../build/lib/` -- a path that does not exist on the XPU test machine. As a result, `c10_xpu_XPUAllocatorTraceTrackerTest` (and other XPU C++ tests) fail at runtime with `libc10_xpu.so: cannot open shared object file`.

**Fix:** Add `export LD_LIBRARY_PATH="${TORCH_LIB_DIR}:${LD_LIBRARY_PATH}"` to `test_xpu_bin()`, matching the established pattern used by `test_libtorch_profiler`, `test_inductor_aoti_cpp`, and other C++ test functions in `test.sh`.

## Test Plan

Verifiable by running the XPU CI workflow -- the `c10_xpu_XPUAllocatorTraceTrackerTest` and other XPU C++ tests in `build/bin` should find `libc10_xpu.so` at the installed location under `site-packages/torch/lib/`.