### PR TITLE
Fix __qualname__ for OpOverloadPacket

### DIFF
--- a/test/test_per_overload_api.py
+++ b/test/test_per_overload_api.py
@@ -13,6 +13,7 @@ class TestPerOverloadAPI(TestCase):
 
         # class attributes
         self.assertEqual(add_packet.__name__, "add")
+        self.assertEqual(add_packet.__qualname__, "aten::add")
         self.assertEqual(str(add_packet), "aten.add")
 
         # callable
@@ -40,6 +41,7 @@ class TestPerOverloadAPI(TestCase):
         # class attributes
         self.assertEqual(str(add_tensoroverload), "aten.add.Tensor")
         self.assertEqual(add_tensoroverload.__name__, "add.Tensor")
+        self.assertEqual(add_tensoroverload.__qualname__, "aten::add.Tensor")
         self.assertEqual(add_tensoroverload.overloadpacket, add_packet)
 
         # deepcopy is a no-op

--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -1178,6 +1178,7 @@ class OpOverloadPacket(Generic[_P, _T]):
         # defined below but are immutable
         self._qualified_op_name = qualified_op_name
         self.__name__ = op_name
+        self.__qualname__ = qualified_op_name
         self._op = op
         self._overload_names = overload_names
         self._dir: list[str] = []


### PR DESCRIPTION
Fixes #186140

`OpOverloadPacket.__getattr__` forwards dunder lookups to the underlying pybind11 operator, so `__qualname__` returned the pybind function-record name instead of the op name:

```python
>>> torch.ops.aten.add.__qualname__
'pybind11_detail_function_record_v1_system_libstdcpp_gxx_abi_1xxx_use_cxx11_abi_1.add'
```

`OpOverload` already sets a sensible `__qualname__` (`self._name`, added in #85133), but the analogous `OpOverloadPacket` was never given one. This sets it to the qualified op name, mirroring that precedent:

```python
>>> torch.ops.aten.add.__qualname__
'aten::add'
>>> torch.ops.aten.add.Tensor.__qualname__
'aten::add.Tensor'
```

Added assertions to the existing `test_per_overload_api.py` tests.