### PR TITLE
[AOTI] Add external constants API for zero-copy weight sharing (#188643)

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -7309,6 +7309,90 @@ class AOTInductorTestsTemplate:
 
         runner.free_inactive_constant_buffer()
 
+    def test_create_with_external_constants(self):
+        # AOTInductorModelContainerCreateWithExternalConstants: a runner
+        # built from caller-supplied weights must use those weights at
+        # inference time, not the constants baked into the .so.
+        class Model(torch.nn.Module):
+            def __init__(self, n, k, device):
+                super().__init__()
+                self.weight = torch.randn(n, k, device=device)
+                self.bias = torch.randn(n, device=device)
+
+            def forward(self, a):
+                return torch.nn.functional.linear(a, self.weight, self.bias)
+
+        M, N, K = 8, 6, 16
+        model = Model(N, K, self.device)
+        a = torch.randn(M, K, device=self.device)
+        example_inputs = (a,)
+        with torch.no_grad(), config.patch({"always_keep_tensor_constants": True}):
+            so_path = AOTIRunnerUtil.legacy_compile(
+                model=model,
+                example_inputs=example_inputs,
+            )
+
+        # Caller-allocated weights distinct from the .so-baked ones.
+        external_weights = {
+            "L__self___weight": torch.randn(N, K, device=self.device),
+            "L__self___bias": torch.randn(N, device=self.device),
+        }
+
+        if self.device == "cpu":
+            normal_runner = torch._C._aoti.AOTIModelContainerRunnerCpu(so_path, 1)
+            self.assertTrue(normal_runner.did_call_load_constants())
+            del normal_runner
+            runner = torch._C._aoti.AOTIModelContainerRunnerCpu(
+                so_path, 1, external_weights
+            )
+        elif self.device == "xpu":
+            normal_runner = torch._C._aoti.AOTIModelContainerRunnerXpu(
+                so_path, 1, self.device
+            )
+            self.assertTrue(normal_runner.did_call_load_constants())
+            del normal_runner
+            runner = torch._C._aoti.AOTIModelContainerRunnerXpu(
+                so_path, 1, self.device, "", external_weights
+            )
+        elif self.device == "mps":
+            raise unittest.SkipTest("external-constants ctor not bound on MPS runner")
+        else:
+            normal_runner = torch._C._aoti.AOTIModelContainerRunnerCuda(
+                so_path, 1, self.device
+            )
+            self.assertTrue(normal_runner.did_call_load_constants())
+            del normal_runner
+            runner = torch._C._aoti.AOTIModelContainerRunnerCuda(
+                so_path, 1, self.device, "", external_weights
+            )
+        self.assertFalse(runner.did_call_load_constants())
+
+        def runner_call(*args, **kwargs):
+            import torch.fx._pytree as fx_pytree
+
+            call_spec = runner.get_call_spec()
+            in_spec = pytree.treespec_loads(call_spec[0])
+            out_spec = pytree.treespec_loads(call_spec[1])
+            flat_inputs = fx_pytree.tree_flatten_spec((args, kwargs), in_spec)
+            flat_inputs = [x for x in flat_inputs if isinstance(x, torch.Tensor)]
+            flat_outputs = runner.run(flat_inputs)
+            return pytree.tree_unflatten(flat_outputs, out_spec)
+
+        test_inputs = torch.randn(M, K, device=self.device)
+        # If the runner ignored external_weights and used .so-baked weights,
+        # output would equal model(test_inputs) with the original (different)
+        # weights, and this assertion would fail. The external constructor also
+        # calls the release_* path after disabling blob release, so this checks
+        # that no-op release did not drop caller-owned constants.
+        expected = torch.nn.functional.linear(
+            test_inputs,
+            external_weights["L__self___weight"],
+            external_weights["L__self___bias"],
+        )
+        output = runner_call(test_inputs)
+        self.assertEqual(expected, output)
+        self.assertFalse(runner.did_call_load_constants())
+
     def test_update_user_managed_buffer(self):
         if self.device not in ["cuda", "xpu"]:
             raise unittest.SkipTest("requires CUDA/XPU")

--- a/torch/_inductor/codegen/aoti_runtime/interface.cpp
+++ b/torch/_inductor/codegen/aoti_runtime/interface.cpp
@@ -138,6 +138,44 @@ AOTIRuntimeError AOTInductorModelContainerCreateWithDevice(
 }
 
 
+AOTIRuntimeError AOTInductorModelContainerCreateWithExternalConstants(
+    AOTInductorModelContainerHandle* container_handle,
+    size_t num_models,
+    const char* device_str,
+    const char* cubin_dir,
+    const AOTInductorConstantMapEntry* constant_entries,
+    size_t num_constant_entries) {
+  if (num_models == 0) {
+    std::cerr << "Error: num_models must be positive, but got 0\n";
+    return AOTI_RUNTIME_FAILURE;
+  }
+  if (num_constant_entries != 0 && constant_entries == nullptr) {
+    std::cerr << "Error: constant_entries is null but num_constant_entries is "
+              << num_constant_entries << "\n";
+    return AOTI_RUNTIME_FAILURE;
+  }
+  CONVERT_EXCEPTION_TO_ERROR_CODE({
+    std::optional<std::string> cubin_dir_opt;
+    if (cubin_dir != nullptr) {
+      cubin_dir_opt.emplace(cubin_dir);
+    }
+    // Rebuild the std map on the DSO side of the boundary so no std container
+    // crosses the ABI; the entries are C-compatible (name + AtenTensorHandle).
+    std::unordered_map<std::string, AtenTensorHandle> constants;
+    constants.reserve(num_constant_entries);
+    for (size_t i = 0; i < num_constant_entries; ++i) {
+      constants.emplace(constant_entries[i].name, constant_entries[i].handle);
+    }
+    auto* container = new torch::aot_inductor::AOTInductorModelContainer(
+        num_models,
+        std::string(device_str),
+        constants,
+        cubin_dir_opt);
+    *container_handle =
+        reinterpret_cast<AOTInductorModelContainerHandle>(container);
+  })
+}
+
 AOTIRuntimeError AOTInductorModelContainerDelete(
     AOTInductorModelContainerHandle container_handle) {
   CONVERT_EXCEPTION_TO_ERROR_CODE({
@@ -635,6 +673,16 @@ AOTIRuntimeError AOTInductorModelContainerGetConstantsBlobSize(
           container_handle);
   CONVERT_EXCEPTION_TO_ERROR_CODE(
       { *ret_size = container->constant_blob_size(); })
+}
+
+AOTIRuntimeError AOTInductorModelContainerDidCallLoadConstants(
+    AOTInductorModelContainerHandle container_handle,
+    bool* did_call_load_constants) {
+  auto* container =
+      reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
+          container_handle);
+  CONVERT_EXCEPTION_TO_ERROR_CODE(
+      { *did_call_load_constants = container->did_call_load_constants(); })
 }
 
 

--- a/torch/csrc/inductor/aoti_runner/model_container_runner.cpp
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner.cpp
@@ -40,6 +40,51 @@ AOTIModelContainerRunner::AOTIModelContainerRunner(
         num_models >= 1,
         "num_models must be >=1 when run_single_threaded is false");
   }
+  load_aoti_symbols(model_so_path, device_str, run_single_threaded);
+
+  AOTI_RUNTIME_ERROR_CODE_CHECK(create_func_(
+      &container_handle_,
+      num_models,
+      device_str.c_str(),
+      cubin_dir.empty() ? nullptr : cubin_dir.c_str()));
+}
+
+AOTIModelContainerRunner::AOTIModelContainerRunner(
+    const std::string& model_so_path,
+    size_t num_models,
+    const std::string& device_str,
+    const std::string& cubin_dir,
+    std::unordered_map<std::string, at::Tensor>& constants) {
+  TORCH_CHECK(num_models >= 1, "num_models must be >=1");
+  load_aoti_symbols(model_so_path, device_str, /*run_single_threaded=*/false);
+  TORCH_CHECK(
+      create_with_external_constants_func_ != nullptr,
+      "AOTInductorModelContainerCreateWithExternalConstants symbol not found "
+      "in .so. Rebuild the model with the latest AOTInductor.");
+
+  // Pass constants as C-ABI-safe entries (name + AtenTensorHandle) so no std
+  // container crosses the .so boundary. AtenTensorHandle borrows the caller's
+  // at::Tensor; the caller retains ownership (tensors must outlive the runner).
+  std::vector<AOTInductorConstantMapEntry> entries;
+  entries.reserve(constants.size());
+  for (auto& [name, tensor] : constants) {
+    entries.push_back(
+        {name.c_str(),
+         torch::aot_inductor::tensor_pointer_to_tensor_handle(&tensor)});
+  }
+  AOTI_RUNTIME_ERROR_CODE_CHECK(create_with_external_constants_func_(
+      &container_handle_,
+      num_models,
+      device_str.c_str(),
+      cubin_dir.empty() ? nullptr : cubin_dir.c_str(),
+      entries.data(),
+      entries.size()));
+}
+
+void AOTIModelContainerRunner::load_aoti_symbols(
+    const std::string& model_so_path,
+    const std::string& device_str,
+    bool run_single_threaded) {
   model_so_ = std::make_unique<at::DynamicLibrary>(model_so_path.c_str());
   TORCH_CHECK(model_so_, "Failed to load model: ", model_so_path);
 
@@ -108,9 +153,15 @@ consider rebuild your model with the latest AOTInductor.");
       get_constants_blob_size_func_,
       "AOTInductorModelContainerGetConstantsBlobSize")
   TRY_LOAD_SYMBOL(
+      did_call_load_constants_func_,
+      "AOTInductorModelContainerDidCallLoadConstants")
+  TRY_LOAD_SYMBOL(
       update_constants_from_blob_func_,
       "AOTInductorModelUpdateConstantsFromBlob")
   TRY_LOAD_SYMBOL(get_last_error_func_, "AOTInductorGetLastError")
+  TRY_LOAD_SYMBOL(
+      create_with_external_constants_func_,
+      "AOTInductorModelContainerCreateWithExternalConstants")
 #undef TRY_LOAD_SYMBOL
 
   // Hack to find the json file name from the model so file
@@ -125,12 +176,6 @@ consider rebuild your model with the latest AOTInductor.");
   } else {
     proxy_executor_handle_ = nullptr;
   }
-
-  AOTI_RUNTIME_ERROR_CODE_CHECK(create_func_(
-      &container_handle_,
-      num_models,
-      device_str.c_str(),
-      cubin_dir.empty() ? nullptr : cubin_dir.c_str()));
 }
 
 AOTIModelContainerRunner::~AOTIModelContainerRunner() {
@@ -411,6 +456,16 @@ void AOTIModelContainerRunner::free_inactive_constant_buffer() {
       "No free_inactive_constant_buffer in .so! Consider rebuild your model with the latest AOTInductor.");
   AOTI_RUNTIME_ERROR_CODE_CHECK(
       free_inactive_constant_buffer_func_(container_handle_));
+}
+
+bool AOTIModelContainerRunner::did_call_load_constants() const {
+  TORCH_CHECK(
+      did_call_load_constants_func_ != nullptr,
+      "No did_call_load_constants in .so! Consider rebuild your model with the latest AOTInductor.");
+  bool did_call_load_constants = false;
+  AOTI_RUNTIME_ERROR_CODE_CHECK(did_call_load_constants_func_(
+      container_handle_, &did_call_load_constants));
+  return did_call_load_constants;
 }
 
 std::vector<std::string> AOTIModelContainerRunner::get_call_spec() {

--- a/torch/csrc/inductor/aoti_runner/model_container_runner.h
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner.h
@@ -65,6 +65,7 @@ class TORCH_API AOTIModelContainerRunner {
   void swap_constant_buffer();
   void free_inactive_constant_buffer();
   void update_constant_buffer_from_blob(const std::string& weights_path);
+  bool did_call_load_constants() const;
 
   std::vector<std::string> get_call_spec();
 
@@ -85,6 +86,16 @@ class TORCH_API AOTIModelContainerRunner {
       const std::string& device_str,
       const std::string& cubin_dir,
       const bool run_single_threaded);
+
+  // Construct with externally-provided weights. Skips the .so weight load
+  // entirely (no GPU allocation) and seeds the container's constants map
+  // from the caller-supplied tensors. The caller retains ownership.
+  AOTIModelContainerRunner(
+      const std::string& model_so_path,
+      size_t num_models,
+      const std::string& device_str,
+      const std::string& cubin_dir,
+      std::unordered_map<std::string, at::Tensor>& constants);
 
   // Default constructor for custom device implementations that don't
   // use .so files. Derived classes must override run_impl().
@@ -127,15 +138,24 @@ class TORCH_API AOTIModelContainerRunner {
   decltype(&AOTInductorModelContainerGetCallSpec) get_call_spec_func_{nullptr};
   decltype(&AOTInductorModelContainerGetConstantsBlobSize)
       get_constants_blob_size_func_{nullptr};
+  decltype(&AOTInductorModelContainerDidCallLoadConstants)
+      did_call_load_constants_func_{nullptr};
   decltype(&AOTInductorModelUpdateConstantsFromBlob)
       update_constants_from_blob_func_{nullptr};
   decltype(&AOTInductorGetLastError) get_last_error_func_{nullptr};
+  decltype(&AOTInductorModelContainerCreateWithExternalConstants)
+      create_with_external_constants_func_{nullptr};
 
   AOTInductorModelContainerHandle container_handle_ = nullptr;
 
   AOTIProxyExecutorHandle proxy_executor_handle_ = nullptr;
 
  private:
+  void load_aoti_symbols(
+      const std::string& model_so_path,
+      const std::string& device_str,
+      bool run_single_threaded);
+
   std::unique_ptr<torch::aot_inductor::ProxyExecutor> proxy_executor_;
 };
 

--- a/torch/csrc/inductor/aoti_runner/model_container_runner_cpu.cpp
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner_cpu.cpp
@@ -16,6 +16,17 @@ AOTIModelContainerRunnerCpu::AOTIModelContainerRunnerCpu(
           "",
           run_single_threaded) {}
 
+AOTIModelContainerRunnerCpu::AOTIModelContainerRunnerCpu(
+    const std::string& model_so_path,
+    size_t num_models,
+    std::unordered_map<std::string, at::Tensor>& constants)
+    : AOTIModelContainerRunner(
+          model_so_path,
+          num_models,
+          "cpu",
+          "",
+          constants) {}
+
 AOTIModelContainerRunnerCpu::~AOTIModelContainerRunnerCpu() = default;
 
 namespace {

--- a/torch/csrc/inductor/aoti_runner/model_container_runner_cpu.h
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner_cpu.h
@@ -11,6 +11,14 @@ class TORCH_API AOTIModelContainerRunnerCpu : public AOTIModelContainerRunner {
       size_t num_models = 1,
       const bool run_single_threaded = false);
 
+  // Construct with externally-provided weights (zero CPU allocation for
+  // constants — the .so weights are not loaded). Caller retains tensor
+  // ownership; tensors must outlive the runner.
+  AOTIModelContainerRunnerCpu(
+      const std::string& model_so_path,
+      size_t num_models,
+      std::unordered_map<std::string, at::Tensor>& constants);
+
   ~AOTIModelContainerRunnerCpu() override;
 };
 

--- a/torch/csrc/inductor/aoti_runner/model_container_runner_cuda.cpp
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner_cuda.cpp
@@ -16,6 +16,19 @@ AOTIModelContainerRunnerCuda::AOTIModelContainerRunnerCuda(
           cubin_dir,
           run_single_threaded) {}
 
+AOTIModelContainerRunnerCuda::AOTIModelContainerRunnerCuda(
+    const std::string& model_so_path,
+    size_t num_models,
+    const std::string& device_str,
+    const std::string& cubin_dir,
+    std::unordered_map<std::string, at::Tensor>& constants)
+    : AOTIModelContainerRunner(
+          model_so_path,
+          num_models,
+          device_str,
+          cubin_dir,
+          constants) {}
+
 AOTIModelContainerRunnerCuda::~AOTIModelContainerRunnerCuda() = default;
 
 std::vector<at::Tensor> AOTIModelContainerRunnerCuda::run_impl(

--- a/torch/csrc/inductor/aoti_runner/model_container_runner_cuda.h
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner_cuda.h
@@ -20,6 +20,16 @@ class TORCH_CUDA_CPP_API AOTIModelContainerRunnerCuda
       const std::string& cubin_dir = "",
       const bool run_single_threaded = false);
 
+  // Construct with externally-provided weights (zero GPU allocation for
+  // constants — the .so weights are not loaded). Caller retains tensor
+  // ownership; tensors must outlive the runner.
+  AOTIModelContainerRunnerCuda(
+      const std::string& model_so_path,
+      size_t num_models,
+      const std::string& device_str,
+      const std::string& cubin_dir,
+      std::unordered_map<std::string, at::Tensor>& constants);
+
   ~AOTIModelContainerRunnerCuda() override;
 
   std::vector<at::Tensor> run_impl(

--- a/torch/csrc/inductor/aoti_runner/model_container_runner_xpu.cpp
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner_xpu.cpp
@@ -16,6 +16,19 @@ AOTIModelContainerRunnerXpu::AOTIModelContainerRunnerXpu(
           kernel_bin_dir,
           run_single_threaded) {}
 
+AOTIModelContainerRunnerXpu::AOTIModelContainerRunnerXpu(
+    const std::string& model_so_path,
+    size_t num_models,
+    const std::string& device_str,
+    const std::string& kernel_bin_dir,
+    std::unordered_map<std::string, at::Tensor>& constants)
+    : AOTIModelContainerRunner(
+          model_so_path,
+          num_models,
+          device_str,
+          kernel_bin_dir,
+          constants) {}
+
 AOTIModelContainerRunnerXpu::~AOTIModelContainerRunnerXpu() = default;
 
 std::vector<at::Tensor> AOTIModelContainerRunnerXpu::run_impl(

--- a/torch/csrc/inductor/aoti_runner/model_container_runner_xpu.h
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner_xpu.h
@@ -22,6 +22,13 @@ class C10_EXPORT AOTIModelContainerRunnerXpu : public AOTIModelContainerRunner {
       const std::string& kernel_bin_dir = "",
       const bool run_single_threaded = false);
 
+  AOTIModelContainerRunnerXpu(
+      const std::string& model_so_path,
+      size_t num_models,
+      const std::string& device_str,
+      const std::string& kernel_bin_dir,
+      std::unordered_map<std::string, at::Tensor>& constants);
+
   ~AOTIModelContainerRunnerXpu() override;
 
   std::vector<at::Tensor> run_impl(

--- a/torch/csrc/inductor/aoti_runner/pybind.cpp
+++ b/torch/csrc/inductor/aoti_runner/pybind.cpp
@@ -23,6 +23,14 @@ void initAOTIRunnerBindings(PyObject* module) {
   py::class_<AOTIModelContainerRunnerCpu>(m, "AOTIModelContainerRunnerCpu")
       .def(py::init<const std::string&, int>())
       .def(
+          py::init<
+              const std::string&,
+              size_t,
+              std::unordered_map<std::string, at::Tensor>&>(),
+          py::arg("model_so_path"),
+          py::arg("num_models"),
+          py::arg("constants"))
+      .def(
           "run",
           &AOTIModelContainerRunnerCpu::run,
           py::arg("inputs"),
@@ -53,6 +61,9 @@ void initAOTIRunnerBindings(PyObject* module) {
           "free_inactive_constant_buffer",
           &AOTIModelContainerRunnerCpu::free_inactive_constant_buffer)
       .def(
+          "did_call_load_constants",
+          &AOTIModelContainerRunnerCpu::did_call_load_constants)
+      .def(
           "update_constant_buffer_from_blob",
           &AOTIModelContainerRunnerCpu::update_constant_buffer_from_blob,
           py::arg("weights_path"));
@@ -72,6 +83,18 @@ void initAOTIRunnerBindings(PyObject* module) {
            const std::string&,
            const std::string&,
            const bool>())
+      .def(
+          py::init<
+              const std::string&,
+              size_t,
+              const std::string&,
+              const std::string&,
+              std::unordered_map<std::string, at::Tensor>&>(),
+          py::arg("model_so_path"),
+          py::arg("num_models"),
+          py::arg("device_str"),
+          py::arg("cubin_dir"),
+          py::arg("constants"))
       .def(
           "run",
           &AOTIModelContainerRunnerCuda::run,
@@ -111,6 +134,9 @@ void initAOTIRunnerBindings(PyObject* module) {
           "free_inactive_constant_buffer",
           &AOTIModelContainerRunnerCuda::free_inactive_constant_buffer)
       .def(
+          "did_call_load_constants",
+          &AOTIModelContainerRunnerCuda::did_call_load_constants)
+      .def(
           "update_constant_buffer_from_blob",
           &AOTIModelContainerRunnerCuda::update_constant_buffer_from_blob,
           py::arg("weights_path"));
@@ -124,6 +150,18 @@ void initAOTIRunnerBindings(PyObject* module) {
            int,
            const std::string&,
            const std::string&>())
+      .def(
+          py::init<
+              const std::string&,
+              size_t,
+              const std::string&,
+              const std::string&,
+              std::unordered_map<std::string, at::Tensor>&>(),
+          py::arg("model_so_path"),
+          py::arg("num_models"),
+          py::arg("device_str"),
+          py::arg("cubin_dir"),
+          py::arg("constants"))
       .def(
           "run",
           &AOTIModelContainerRunnerXpu::run,
@@ -162,6 +200,9 @@ void initAOTIRunnerBindings(PyObject* module) {
       .def(
           "free_inactive_constant_buffer",
           &AOTIModelContainerRunnerXpu::free_inactive_constant_buffer)
+      .def(
+          "did_call_load_constants",
+          &AOTIModelContainerRunnerXpu::did_call_load_constants)
       .def(
           "update_constant_buffer_from_blob",
           &AOTIModelContainerRunnerXpu::update_constant_buffer_from_blob,
@@ -209,6 +250,9 @@ void initAOTIRunnerBindings(PyObject* module) {
       .def(
           "free_inactive_constant_buffer",
           &AOTIModelContainerRunnerMps::free_inactive_constant_buffer)
+      .def(
+          "did_call_load_constants",
+          &AOTIModelContainerRunnerMps::did_call_load_constants)
       .def(
           "update_constant_buffer_from_blob",
           &AOTIModelContainerRunnerMps::update_constant_buffer_from_blob,

--- a/torch/csrc/inductor/aoti_runtime/interface.h
+++ b/torch/csrc/inductor/aoti_runtime/interface.h
@@ -102,6 +102,22 @@ AOTI_API AOTIRuntimeError AOTInductorModelContainerCreateWithDevice(
     const char* device_str,
     const char* cubin_dir);
 
+// Creates an AOTInductor model container with externally-provided weights.
+// No weights are loaded from the .so: the provided constants are used directly
+// (zero-copy of tensor storage, user retains ownership). Constant folding runs
+// at creation time so the container is ready for inference immediately.
+// Constants are passed as a flat array of ABI-stable
+// AOTInductorConstantMapEntry (name -> AtenTensorHandle) rather than
+// AOTInductorConstantMapHandle, which is not ABI stable across the DSO
+// boundary.
+AOTI_API AOTIRuntimeError AOTInductorModelContainerCreateWithExternalConstants(
+    AOTInductorModelContainerHandle* container_handle,
+    size_t num_models,
+    const char* device_str,
+    const char* cubin_dir,
+    const AOTInductorConstantMapEntry* constant_entries,
+    size_t num_constant_entries);
+
 // Deletes the AOTInductor model container.
 AOTI_API AOTIRuntimeError AOTInductorModelContainerDelete(
     AOTInductorModelContainerHandle container_handle);
@@ -366,6 +382,11 @@ AOTI_API AOTIRuntimeError AOTInductorModelUpdateConstantsMapV2(
 AOTI_API AOTIRuntimeError AOTInductorModelContainerGetConstantsBlobSize(
     AOTInductorModelContainerHandle container_handle,
     uint64_t* ret_size);
+
+// Returns whether the container's model invoked load_constants().
+AOTI_API AOTIRuntimeError AOTInductorModelContainerDidCallLoadConstants(
+    AOTInductorModelContainerHandle container_handle,
+    bool* did_call_load_constants);
 
 // Load weights from a single blob in weight_blob_ptr
 AOTI_API AOTIRuntimeError AOTInductorModelUpdateConstantsFromBlob(

--- a/torch/csrc/inductor/aoti_runtime/model_base.h
+++ b/torch/csrc/inductor/aoti_runtime/model_base.h
@@ -954,6 +954,7 @@ class AOTInductorModelBase {
   }
 
   void load_constants(bool force = false) {
+    did_call_load_constants_ = true;
     size_t num_constants = this->num_constants();
     size_t num_folded_constants = this->num_folded_constants();
     constants_map_->reserve(num_constants);
@@ -1113,11 +1114,21 @@ class AOTInductorModelBase {
     }
   }
 
-  RAIIDataPtr&& release_constant_blob() {
+  void set_constant_blob_releasable(bool releasable) {
+    constant_blob_releasable_ = releasable;
+  }
+
+  RAIIDataPtr release_constant_blob() {
+    if (!constant_blob_releasable_) {
+      return RAIIDataPtr{};
+    }
     return std::move(constant_blob_);
   }
 
-  RAIIDataPtr&& release_aux_cpu_constant_blob() {
+  RAIIDataPtr release_aux_cpu_constant_blob() {
+    if (!constant_blob_releasable_) {
+      return RAIIDataPtr{};
+    }
     return std::move(aux_cpu_constant_blob_);
   }
 
@@ -1321,6 +1332,10 @@ class AOTInductorModelBase {
 #endif
   }
 
+  bool did_call_load_constants() const {
+    return did_call_load_constants_;
+  }
+
   void update_constants_array_from_map() {
     if (!constants_map_) {
       throw std::runtime_error{
@@ -1517,6 +1532,10 @@ class AOTInductorModelBase {
   // If True, we would prepare the weight when loading the model, otherwise the
   // model will be loaded without weights, and need to be provided by the user.
   bool include_weights;
+  bool did_call_load_constants_{false};
+  // External-constants containers borrow tensor handles from the caller; their
+  // release_* calls intentionally return empty handles.
+  bool constant_blob_releasable_{true};
 
   // Record if the model finishes an inference run so that its owning
   // AOTModelContainer can reuse this instance.

--- a/torch/csrc/inductor/aoti_runtime/model_container.h
+++ b/torch/csrc/inductor/aoti_runtime/model_container.h
@@ -154,6 +154,72 @@ class AOTInductorModelContainer {
     out_spec_ = model->get_out_spec();
   }
 
+  // Construct with externally-provided weights (e.g. from CUDA IPC).
+  // Skips load_constants entirely — no GPU allocation for weights.
+  // The caller retains ownership of the provided tensor handles.
+  AOTInductorModelContainer(
+      size_t num_models,
+      const std::string& device_str,
+      const std::unordered_map<std::string, AtenTensorHandle>& constants,
+      const std::optional<std::string>& cubin_dir = std::nullopt) {
+    buffers_[0].map = std::make_shared<ConstantMap>();
+    buffers_[0].array = std::make_shared<std::vector<ConstantHandle>>();
+
+    models_.reserve(num_models);
+    available_models_.reserve(num_models);
+    for (size_t i = 0; i < num_models; ++i) {
+      models_.push_back(AOTInductorModel::Create(
+          buffers_[0].map, buffers_[0].array, device_str, cubin_dir));
+      models_.back()->set_constant_blob_releasable(false);
+      available_models_.push_back(models_.back().get());
+    }
+
+    auto* model = available_models_[0];
+    size_t num_inputs = model->num_inputs();
+    input_names_.reserve(num_inputs);
+    for (size_t i = 0; i < num_inputs; i++) {
+      input_names_.emplace_back(model->input_name(static_cast<int64_t>(i)));
+    }
+
+    size_t num_outputs = model->num_outputs();
+    output_names_.reserve(num_outputs);
+    for (size_t i = 0; i < num_outputs; i++) {
+      output_names_.emplace_back(model->output_name(static_cast<int64_t>(i)));
+    }
+
+    // This path must not call load_constants(): caller-owned tensors below are
+    // the only source of weight storage. release_* is disabled above so common
+    // setup code can call it and get an empty handle.
+    buffers_[0].blob = model->release_constant_blob();
+    buffers_[0].aux_cpu_blob = model->release_aux_cpu_constant_blob();
+    buffers_[0].array->resize(model->num_constants());
+    buffers_[1].map = std::make_shared<ConstantMap>();
+    buffers_[1].array =
+        std::make_shared<std::vector<ConstantHandle>>(model->num_constants());
+    constants_internal_offset_.resize(
+        model->num_constants() - model->num_folded_constants());
+    aux_cpu_constants_internal_offset_.resize(
+        model->num_constants() - model->num_folded_constants());
+    model->compute_constant_blob(
+        blob_size_,
+        constants_internal_offset_,
+        aux_cpu_blob_size_,
+        aux_cpu_constants_internal_offset_);
+
+    for (auto& m : models_) {
+      m->update_constants_map(buffers_[0].map);
+    }
+
+    // Populate the constants map with user-managed handles.
+    update_constant_buffer(constants, false, false, /*user_managed=*/true);
+
+    // Run constant folding and mark as done so run() won't re-fold.
+    run_const_fold(false, nullptr, nullptr);
+
+    in_spec_ = model->get_in_spec();
+    out_spec_ = model->get_out_spec();
+  }
+
   void run(
       AtenTensorHandle*
           input_handles, // array of input AtenTensorHandle; handles
@@ -353,6 +419,13 @@ class AOTInductorModelContainer {
       throw std::runtime_error("No available models in container!");
     }
     return models_[0]->constant_blob_size();
+  }
+
+  bool did_call_load_constants() const {
+    if (this->num_models() == 0) {
+      throw std::runtime_error("No available models in container!");
+    }
+    return models_[0]->did_call_load_constants();
   }
 
   void update_constants_from_blob(const uint8_t* weight_blob_ptr) {

--- a/torch/nativert/executor/AOTInductorDelegateExecutor.cpp
+++ b/torch/nativert/executor/AOTInductorDelegateExecutor.cpp
@@ -133,13 +133,15 @@ AOTIDelegateExecutor::AOTIDelegateExecutor(
   // commitWeights here because it's invoked from Executor's ctor already.
 }
 
-void AOTIDelegateExecutor::initWeights(std::shared_ptr<Weights> weights) {
+void AOTIDelegateExecutor::initWeights(
+    const std::shared_ptr<Weights>& weights) {
   // Do nothing for AOTI, as AOTI's .so already contains the weights.
   LOG(INFO)
       << "Skipping initWeights for AOTI to use original weights from .so file.";
 }
 
-void AOTIDelegateExecutor::processWeights(std::shared_ptr<Weights> weights) {
+void AOTIDelegateExecutor::processWeights(
+    const std::shared_ptr<Weights>& weights) {
   LOG(INFO) << "AOTIDelegateExecutor processing weights";
   std::unordered_map<std::string, at::Tensor*> new_weights;
   for (const auto& [original_fqn, name] : weight_names_map_) {

--- a/torch/nativert/executor/AOTInductorDelegateExecutor.h
+++ b/torch/nativert/executor/AOTInductorDelegateExecutor.h
@@ -21,8 +21,8 @@ class AOTIDelegateExecutor : public ETDelegateExecutor {
       const MakeProxyExecutorFn& makeProxyExecutorFunc);
   ~AOTIDelegateExecutor() override = default;
 
-  void processWeights(std::shared_ptr<Weights> weights) override;
-  void initWeights(std::shared_ptr<Weights> weights) override;
+  void processWeights(const std::shared_ptr<Weights>& weights) override;
+  void initWeights(const std::shared_ptr<Weights>& weights) override;
   void commitWeights() override;
 
   std::vector<at::Tensor> run(std::vector<at::Tensor>& inputs) override;

--- a/torch/nativert/executor/DelegateExecutor.h
+++ b/torch/nativert/executor/DelegateExecutor.h
@@ -41,12 +41,12 @@ class DelegateExecutor {
   // also release the refcount for weight tensor if it's no longer active. The
   // underlying storage for weight tensors will be freed when the refcount
   // reaches 0.
-  virtual void processWeights(std::shared_ptr<Weights> weights) = 0;
+  virtual void processWeights(const std::shared_ptr<Weights>& weights) = 0;
 
   // This call activates the processed weights.
   virtual void commitWeights() = 0;
 
-  virtual void initWeights(std::shared_ptr<Weights> weights) = 0;
+  virtual void initWeights(const std::shared_ptr<Weights>& weights) = 0;
 
   virtual std::vector<at::Tensor> run(std::vector<at::Tensor>& inputs) = 0;
 };

--- a/torch/nativert/executor/Weights.h
+++ b/torch/nativert/executor/Weights.h
@@ -113,6 +113,17 @@ class Weights {
     return hasCachedWeights_;
   }
 
+  // AOTI constant name mapping (original FQN → AOTI constant name).
+  // Set by the parent process after reading from the AOTI model,
+  // serialized with weight export, and used by the child to create
+  // the AOTI container with external constants (zero GPU allocation).
+  const std::unordered_map<std::string, std::string>& getAotiNameMap() const {
+    return aotiNameMap_;
+  }
+  void setAotiNameMap(std::unordered_map<std::string, std::string> map) {
+    aotiNameMap_ = std::move(map);
+  }
+
   std::string toString() const;
 
   WeightVersion version() const {
@@ -148,6 +159,8 @@ class Weights {
   static WeightVersion globalVersion_;
 
   bool hasCachedWeights_ = false;
+
+  std::unordered_map<std::string, std::string> aotiNameMap_;
 
   std::function<bool(const std::string&)> skipSizeCheck_;
   std::function<bool(const std::string&)> skipDtypeCheck_;


### PR DESCRIPTION
Summary:

Add a new AOTI C API, AOTInductorModelContainerCreateWithExternalConstants, that creates a model container with caller-provided weight tensors instead of loading from the .so file. The caller retains ownership (user_managed=true), enabling zero-copy weight sharing via CUDA IPC.

The new ExternalConstantsTag constructor:
- Skips load_constants() entirely (no GPU allocation for weights)
- Populates constants map with user-managed tensor handles
- Runs constant folding and marks state as FOLDED

On the sigmoid side, AOTInductorModelImpl accepts an optional externalConstants parameter. AOTIDelegateExecutor uses this when hasCachedWeights() is true: it first creates a normal container to read constant metadata (name→FQN mapping), then recreates with external constants for zero-copy.

Existing code paths are unchanged — the new API is only used when external constants are explicitly provided.

Test Plan:
Added/updated `test_create_with_external_constants` in `fbcode/caffe2/test/inductor/test_aot_inductor.py` and the xplat mirror to verify `AOTInductorModelContainerCreateWithExternalConstants` uses caller-provided constants, `did_call_load_constants()` remains false before and after inference, and the external constructor can call disabled `release_constant_blob()`/`release_aux_cpu_constant_blob()` without dropping caller-owned constants. The normal container path still reports `did_call_load_constants()` true.

`arc lint -a`
`arc f`
`buck2 test fbcode//mode/opt fbcode//caffe2/test/inductor:test_aot_inductor -- test_create_with_external_constants` (CPU and CUDA passed; MPS skipped because no MPS backend was available. Buck output: Pass 3, Fail 0, Timeout 0, Infra Failure 0, Build failure 0, Skip 1. The Buck process exited with code 64 despite the successful test summary.)

Reviewed By: desertfire

Differential Revision: D102063846




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo