### PR TITLE
[flex_attention] [inductor] Add TLX flex attention template for Blackwell GPUs

### DIFF
--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -176,6 +176,24 @@ class InductorChoices:
         flex_heuristics = self.get_config_heuristics(device_type)
         return flex_heuristics.get_flex_decode_configs(head_dim, dtype)
 
+    def append_flex_attention_choices(
+        self,
+        choices: list[Any],
+        configs: list[Any],
+        input_nodes: list[Any],
+        subgraphs: list[Any],
+        layout: Any,
+        kernel_options: dict[str, Any],
+        sparse_q_block_size: int,
+        sparse_kv_block_size: int,
+    ) -> list[Any]:
+        """Append backend-specific flex-attention template choices.
+
+        Default is a no-op. Subclasses may override to inject additional
+        autotuning candidates (e.g. TLX templates in fbcode).
+        """
+        return choices
+
     def _logging_context(self) -> dict[str, Any]:
         """Extra fields for the per-shape log row. Subclasses may override."""
         return {}

--- a/torch/_inductor/kernel/flex/flex_attention.py
+++ b/torch/_inductor/kernel/flex/flex_attention.py
@@ -532,6 +532,29 @@ def flex_attention(
         if error is not None and len(configs) == 1:
             raise error
 
+    # Let the active choices handler append any backend-specific flex-attention
+    # template choices (e.g. TLX on Blackwell in fbcode). No-op by default.
+    choices = V.choices.append_flex_attention_choices(
+        choices,
+        configs,
+        [
+            query,
+            key,
+            value,
+            logsumexp,
+            max_scores,
+            kv_num_blocks,
+            kv_indices,
+            full_kv_num_blocks,
+            full_kv_indices,
+        ],
+        [subgraph_buffer, mask_graph_buffer],
+        layout,
+        original_kernel_options,
+        SPARSE_Q_BLOCK_SIZE,
+        SPARSE_KV_BLOCK_SIZE,
+    )
+
     if not choices and invalid_block_options is not None:
         raise_flex_kernel_options_error(
             "forward",


### PR DESCRIPTION
Summary:
This diff adds a TLX (Triton Language eXtensions) flex attention template targeting Blackwell GPUs.

The implementation:
- Gates the feature via `tlx_config.tlx_mode` (kept out of the OSS inductor config)
- Creates a new TritonTemplate (`tlx_flex_attention_template`) that uses TMA descriptors for Q, K, V loads
- Integrates the TLX template into the autotune choices in `flex_attention.py` when enabled

Test Plan:
Added comprehensive unit tests in `test_tlx_flex_attention.py`


Performance Vs existing triton template:
```
Shape                               Mask               TLX TFLOPS  Triton TFLOPS    Ratio
-----------------------------------------------------------------------------------------
(8,16,1024,16,1024,128)             alibi                  251.18         256.00    0.981
(8,16,1024,16,1024,128)             causal                 270.26         276.55    0.977
(8,16,1024,16,1024,128)             head_bias              364.17         376.64    0.967
(8,16,1024,16,1024,128)             noop                   364.17         380.63    0.957
(8,16,1024,16,1024,128)             prefix_lm              269.06         274.42    0.980
(8,16,1024,16,1024,128)             rel                    352.38         348.96    1.010
(8,16,1024,16,1024,128)             sliding_window         265.30         269.12    0.986
(8,16,1024,16,1024,128)             softcap                246.08         251.23    0.980
(8,16,128,16,128,128)               alibi                   11.19          12.23    0.915
(8,16,128,16,128,128)               causal                  11.41          12.59    0.907
(8,16,128,16,128,128)               head_bias                7.81           8.68    0.899
(8,16,128,16,128,128)               noop                     6.86           8.70    0.789
(8,16,128,16,128,128)               prefix_lm                9.92          12.23    0.811
(8,16,128,16,128,128)               rel                      8.00           8.44    0.947
(8,16,128,16,128,128)               sliding_window          11.52          11.92    0.967
(8,16,128,16,128,128)               softcap                 11.14          12.34    0.902
(8,16,16384,16,16384,128)           alibi                  508.46         450.14    1.130
(8,16,16384,16,16384,128)           causal                 581.68         503.99    1.154
(8,16,16384,16,16384,128)           head_bias              604.56         539.30    1.121
(8,16,16384,16,16384,128)           noop                   600.73         537.41    1.118
(8,16,16384,16,16384,128)           prefix_lm              582.83         505.96    1.152
(8,16,16384,16,16384,128)           rel                    570.85         478.52    1.193
(8,16,16384,16,16384,128)           sliding_window         539.70         480.39    1.123
(8,16,16384,16,16384,128)           softcap                500.80         434.11    1.154
(8,16,2048,16,2048,128)             alibi                  345.73         336.04    1.029
(8,16,2048,16,2048,128)             causal                 382.66         367.12    1.042
(8,16,2048,16,2048,128)             head_bias              475.41         462.21    1.029
(8,16,2048,16,2048,128)             noop                   475.38         460.68    1.032
(8,16,2048,16,2048,128)             prefix_lm              381.64         365.24    1.045
(8,16,2048,16,2048,128)             rel                    453.56         416.47    1.089
(8,16,2048,16,2048,128)             sliding_window         377.80         361.50    1.045
(8,16,2048,16,2048,128)             softcap                339.27         326.83    1.038
(8,16,256,16,256,128)               alibi                   32.83          36.59    0.897
(8,16,256,16,256,128)               causal                  33.10          35.09    0.943
(8,16,256,16,256,128)               head_bias               29.62          34.08    0.869
(8,16,256,16,256,128)               noop                    27.64          33.90    0.815
(8,16,256,16,256,128)               prefix_lm               33.79          37.18    0.909
(8,16,256,16,256,128)               rel                     30.62          34.15    0.897
(8,16,256,16,256,128)               sliding_window          33.22          37.19    0.893
(8,16,256,16,256,128)               softcap                 32.63          35.90    0.909
(8,16,4096,16,4096,128)             alibi                  423.05         394.73    1.072
(8,16,4096,16,4096,128)             causal                 479.07         437.28    1.096
(8,16,4096,16,4096,128)             head_bias              546.61         505.32    1.082
(8,16,4096,16,4096,128)             noop                   547.72         503.47    1.088
(8,16,4096,16,4096,128)             prefix_lm              477.91         435.60    1.097
(8,16,4096,16,4096,128)             rel                    515.76         451.21    1.143
(8,16,4096,16,4096,128)             sliding_window         475.46         432.82    1.099
(8,16,4096,16,4096,128)             softcap                416.95         382.52    1.090
(8,16,512,16,512,128)               alibi                  109.62         105.37    1.040
(8,16,512,16,512,128)               causal                 107.42         106.36    1.010
(8,16,512,16,512,128)               head_bias              118.61         127.60    0.930
(8,16,512,16,512,128)               noop                   117.78         126.43    0.932
(8,16,512,16,512,128)               prefix_lm              106.43         120.78    0.881
(8,16,512,16,512,128)               rel                    120.28         116.96    1.028
(8,16,512,16,512,128)               sliding_window         106.36         121.00    0.879
(8,16,512,16,512,128)               softcap                105.27         118.28    0.890
(8,16,8192,16,8192,128)             alibi                  475.58         431.44    1.102
(8,16,8192,16,8192,128)             causal                 547.24         481.44    1.137
(8,16,8192,16,8192,128)             head_bias              585.52         525.69    1.114
(8,16,8192,16,8192,128)             noop                   586.55         524.10    1.119
(8,16,8192,16,8192,128)             prefix_lm              546.03         480.50    1.136
(8,16,8192,16,8192,128)             rel                    549.68         467.55    1.176
(8,16,8192,16,8192,128)             sliding_window         527.02         469.83    1.122
(8,16,8192,16,8192,128)             softcap                469.75         416.81    1.127
```

TLX now beats triton at large sequence lengths:

Seq Len	Avg TLX/Triton Ratio	Best Case
128	0.89x	sliding_window 0.97x
256	0.89x	causal 0.94x
512	0.96x	alibi 1.04x
1024	0.98x	rel 1.01x
2048	1.04x	rel 1.09x
4096	1.09x	rel 1.14x
8192	1.12x	rel 1.18x
16384	1.13x	rel 1.19x

TLX beats Triton baseline on 40 of 64 data points (62.5%), and dominates at seq_len ≥ 2048 where it's 4-13% faster across all mask types.

The remaining gap at small seq lengths (128-256) is expected — the 4-task warp specialization overhead (16 warps, barriers, TMEM) doesn't amortize over few iterations. The baseline's simpler single-loop design wins when there are only 2-4 KV blocks to process.



Correctness:
```
TORCHINDUCTOR_TLX_MODE=allow buck2 test @//mode/opt -m ovr_config//triton:beta -c fbcode.nvcc_arch=b200a -c fbcode.enable_gpu_sections=true -c fbcode.platform010_cuda_version=12.8 fbcode//caffe2/test/inductor/fb/tlx:test_tlx_flex_attention

Tests finished: Pass 10. Fail 0. Timeout 0. Fatal 0. Skip 0. Omit 0. Infra Failure 0. Build failure 0
```


```
TORCHINDUCTOR_TLX_MODE=allow buck2 run @//mode/opt -m ovr_config//triton:beta -c fbcode.nvcc_arch=b200a -c fbcode.enable_gpu_sections=true -c fbcode.platform010_cuda_version=12.8 //pytorch/tritonbench:run -- --op flex_attention --metrics tflops,latency
```

Reviewed By: dshi7

Differential Revision: D94284002




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo