### PR TITLE
torch/fx: fix _format_target to handle Python keywords and embedded quotes

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -1783,6 +1783,36 @@ class TestFX(JitTestCase):
         ref = torch.sin(mod.linear(input) + mod.bias)
         self.assertEqual(r, ref)
 
+    def test_format_target_special_names(self):
+        # Python keywords as submodule names must use getattr(), not dot notation
+        class ModWithKeyword(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.seq = torch.nn.Sequential(collections.OrderedDict([("class", torch.nn.Identity())]))
+
+            def forward(self, x):
+                return getattr(self.seq, "class")(x)
+
+        m = ModWithKeyword()
+        traced = symbolic_trace(m)
+        x = torch.rand(3)
+        self.assertEqual(traced(x), m(x))
+        self.assertIn("getattr(self.seq, 'class')", traced.code)
+
+        # Names with embedded quotes must be properly escaped in getattr()
+        class ModWithQuote(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.add_module('key"name', torch.nn.Identity())
+
+            def forward(self, x):
+                return getattr(self, 'key"name')(x)
+
+        m = ModWithQuote()
+        traced = symbolic_trace(m)
+        self.assertEqual(traced(x), m(x))
+        self.assertIn("getattr(self, 'key\"name')", traced.code)
+
     def test_remove_uses(self):
         g: torch.fx.Graph = Graph()
         x: torch.fx.Node = g.placeholder("x")

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -262,8 +262,8 @@ def _format_target(base: str, target: str) -> str:
     elems = target.split(".")
     r = base
     for e in elems:
-        if not e.isidentifier():
-            r = f'getattr({r}, "{e}")'
+        if not e.isidentifier() or keyword.iskeyword(e):
+            r = f"getattr({r}, {e!r})"
         else:
             r = f"{r}.{e}"
     return r


### PR DESCRIPTION
Fixes #188538.

## Root cause

`_format_target` in `torch/fx/graph.py` generates Python source for module attribute accesses in FX graphs. It uses `str.isidentifier()` to decide between dot notation (`self.foo`) and `getattr` notation, but this has two bugs:

1. **Python keywords** like `"class"` pass `isidentifier()` but are invalid as attribute names — `self.seq.class` is a `SyntaxError`.
2. **Embedded double quotes** in names were interpolated directly into a double-quoted string literal, producing malformed code like `getattr(self, "key"name")`.

## Fix

- Add `keyword.iskeyword(e)` to the condition (the `keyword` module was already imported in `graph.py`).
- Switch from `f'getattr({r}, "{e}")'` to `f"getattr({r}, {e!r})"` so Python's `repr()` handles all quoting and escaping.

## Test plan

New test `TestFX.test_format_target_special_names` in `test/test_fx.py` covers:
- A submodule named `"class"` (Python keyword) — verifies the traced module produces correct output and the generated code uses `getattr(self.seq, 'class')`.
- A submodule named `'key"name'` (embedded double quote) — verifies the traced module produces correct output and the generated code uses `getattr(self, 'key"name')`.

