### PR TITLE
[pytree] Preserve tuple mapping keys across treespec_dumps/loads

### DIFF
--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -1056,6 +1056,29 @@ if "optree" in sys.modules:
         self.assertIsInstance(serialized_spec, str)
         self.assertEqual(spec, python_pytree.treespec_loads(serialized_spec))
 
+    def test_pytree_serialize_mapping_tuple_key(self):
+        for tree in (
+            {(1, 2): 3},
+            OrderedDict({(1, 2): 3}),
+            defaultdict(list, {(1, 2): 3}),
+            {(1, (2, 3)): 4},
+        ):
+            leaves, spec = python_pytree.tree_flatten(tree)
+            roundtrip = python_pytree.treespec_loads(python_pytree.treespec_dumps(spec))
+            self.assertEqual(roundtrip, spec)
+            self.assertEqual(python_pytree.tree_unflatten(leaves, roundtrip), tree)
+
+    def test_pytree_serialize_dict_legacy_string_context(self):
+        # A dict spec serialized before tuple-key escaping stored its context as
+        # a JSON string; loading it must still work.
+        legacy = (
+            '[1, {"type": "builtins.dict", "context": "[\\"a\\"]", '
+            '"children_spec": [{"type": null, "context": null, '
+            '"children_spec": []}]}]'
+        )
+        spec = python_pytree.treespec_loads(legacy)
+        self.assertEqual(python_pytree.tree_unflatten([1], spec), {"a": 1})
+
     def test_pytree_serialize_defaultdict_enum(self):
         spec = python_pytree.TreeSpec(
             defaultdict,

--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -834,6 +834,39 @@ def _dict_flatten_with_keys(
     return [(MappingKey(k), v) for k, v in zip(context, values, strict=True)], context
 
 
+_MAPPING_KEY_TUPLE_MARKER = "__torch_pytree_tuple_key__"
+
+
+def _mapping_key_to_dumpable(key: Any) -> Any:
+    # JSON has no tuple type, so a tuple mapping key would load back as a list
+    # and break unflatten because lists are unhashable. Escape tuple keys with
+    # an explicit marker and restore them on load.
+    if isinstance(key, tuple):
+        return {_MAPPING_KEY_TUPLE_MARKER: [_mapping_key_to_dumpable(k) for k in key]}
+    return key
+
+
+def _mapping_key_from_dumpable(key: Any) -> Any:
+    if isinstance(key, dict) and tuple(key) == (_MAPPING_KEY_TUPLE_MARKER,):
+        return tuple(
+            _mapping_key_from_dumpable(k) for k in key[_MAPPING_KEY_TUPLE_MARKER]
+        )
+    return key
+
+
+def _dict_serialize(context: Context) -> DumpableContext:
+    if isinstance(context, list):
+        context = [_mapping_key_to_dumpable(key) for key in context]
+    return json.dumps(context, cls=EnumEncoder)
+
+
+def _dict_deserialize(dumpable_context: DumpableContext) -> Context:
+    context = json.loads(dumpable_context, object_hook=enum_object_hook)
+    if isinstance(context, list):
+        context = [_mapping_key_from_dumpable(key) for key in context]
+    return context
+
+
 def _dict_unflatten(values: Iterable[T], context: Context) -> dict[Any, T]:
     return dict(zip(context, values, strict=True))
 
@@ -943,7 +976,7 @@ def _defaultdict_serialize(context: Context) -> DumpableContext:
     json_defaultdict = {
         "default_factory_module": default_factory.__module__,
         "default_factory_name": default_factory.__qualname__,
-        "dict_context": dict_context,
+        "dict_context": [_mapping_key_to_dumpable(key) for key in dict_context],
     }
     return json_defaultdict
 
@@ -971,7 +1004,9 @@ def _defaultdict_deserialize(dumpable_context: DumpableContext) -> Context:
     module = importlib.import_module(default_factory_module)
     default_factory = getattr(module, default_factory_name)
 
-    dict_context = dumpable_context["dict_context"]
+    dict_context = [
+        _mapping_key_from_dumpable(key) for key in dumpable_context["dict_context"]
+    ]
     return [default_factory, dict_context]
 
 
@@ -1010,6 +1045,8 @@ _private_register_pytree_node(
     _dict_flatten,
     _dict_unflatten,
     serialized_type_name="builtins.dict",
+    to_dumpable_context=_dict_serialize,
+    from_dumpable_context=_dict_deserialize,
     flatten_with_keys_fn=_dict_flatten_with_keys,
 )
 _private_register_pytree_node(
@@ -1026,6 +1063,8 @@ _private_register_pytree_node(
     _ordereddict_flatten,
     _ordereddict_unflatten,
     serialized_type_name="collections.OrderedDict",
+    to_dumpable_context=_dict_serialize,
+    from_dumpable_context=_dict_deserialize,
     flatten_with_keys_fn=_ordereddict_flatten_with_keys,
 )
 _private_register_pytree_node(


### PR DESCRIPTION

## Issue

Fixes #188648

## Summary

`dict`, `OrderedDict`, and `defaultdict` mapping contexts are serialized through `json.dumps`/`json.loads`, which cannot round-trip a tuple key: `{(1, 2): x}` comes back as `{[1, 2]: x}` and `tree_unflatten` then raises `TypeError: unhashable type: 'list'`.

This escapes tuple mapping keys with an explicit marker when serializing those three container contexts and restores them on load. Non-tuple keys serialize byte-for-byte as before, so the change is limited to keys that previously could not round-trip at all. Because treespec serialization uses the shared `SUPPORTED_SERIALIZED_TYPES` registry, this also fixes the optree-backed `_cxx_pytree` path.

<details>
<summary>repro (before/after, CPU)</summary>

```python
import torch.utils._pytree as pytree

tree = {(1, 2): 0}
leaves, spec = pytree.tree_flatten(tree)
spec2 = pytree.treespec_loads(pytree.treespec_dumps(spec))
print(spec2.context)
print(pytree.tree_unflatten(leaves, spec2))
```

Before:

```
[[1, 2]]
Traceback (most recent call last):
  ...
  File "torch/utils/_pytree.py", line 838, in _dict_unflatten
    return dict(zip(context, values, strict=True))
TypeError: unhashable type: 'list'
```

After:

```
[(1, 2)]
{(1, 2): 0}
```

`OrderedDict`, `defaultdict`, and nested tuple keys (`{(1, (2, 3)): 0}`) round-trip the same way. A dict spec serialized in the old string-context format still loads (covered by `test_pytree_serialize_dict_legacy_string_context`). Full `python test/test_pytree.py`: 106 passed.

</details>

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No. The serialized form of every non-tuple key is unchanged, and specs serialized by older versions still load; only tuple keys, which previously failed to round-trip, change.

cc @zou3519 @XuehaiPan
