### PR TITLE
[SymmMem] Allocate symmetric memory through the CUDACachingAllocator v2

### DIFF
--- a/test/distributed/test_nccl.py
+++ b/test/distributed/test_nccl.py
@@ -440,7 +440,6 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
         with torch.cuda.graph(graph_all_reduce):
             c10d.all_reduce(out)
         graph_all_reduce.replay()
-        torch.cuda.synchronize()
         self.assertEqual(
             out, torch.full_like(out, (self.world_size - 1) * self.world_size / 2)
         )
@@ -465,6 +464,69 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
             graph_one_shot_all_reduce.replay()
             self.assertEqual(out, torch.full_like(out, expected_sum))
             self.assertEqual(res, out)
+
+    @skip_but_pass_in_sandcastle_if(TEST_WITH_ROCM, "Skip NCCL tests for ROCm")
+    @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
+    @requires_nccl_version(
+        (2, 28), "NCCL Symmetric Memory support device API from nccl 2.28"
+    )
+    @skip_if_lt_x_gpu(2)
+    def test_nccl_symmem_tensor_creation_and_collective_cuda_graph(self):
+        symm_mem.set_backend("NCCL")
+        torch.cuda.set_device(self.rank)
+        c10d.all_reduce(torch.ones(1, device=self.device))
+        group_name = c10d.group.WORLD.group_name
+
+        dtype = torch.float
+        numel = 1024
+        capture_offset = torch.tensor(1, dtype=dtype, device=self.device)
+        capture_stream = torch.cuda.Stream(device=self.device)
+
+        # Warm up on the same stream that will be captured. This establishes
+        # NCCL window metadata for the symmetric block that capture reuses.
+        with torch.cuda.stream(capture_stream):
+            inp = symm_mem.empty(numel, dtype=dtype, device=self.device)
+            out = torch.empty(numel, dtype=dtype, device=self.device)
+            for warmup_idx in range(3):
+                offset = 1 + warmup_idx
+                capture_offset.fill_(self.rank + offset)
+                inp = symm_mem.empty(numel, dtype=dtype, device=self.device)
+                out = torch.empty(numel, dtype=dtype, device=self.device)
+                inp.fill_(capture_offset)
+                out.fill_(0.0)
+                torch.ops.symm_mem.one_shot_all_reduce_out(inp, "sum", group_name, out)
+                expected_sum = float(
+                    self.world_size * offset
+                    + self.world_size * (self.world_size - 1) / 2
+                )
+                self.assertEqual(out, torch.full_like(out, expected_sum))
+            del inp, out
+        capture_stream.synchronize()
+
+        graph = torch.cuda.CUDAGraph()
+        offset = 13
+        capture_offset.fill_(self.rank + offset)
+        with torch.cuda.graph(graph, stream=capture_stream):
+            inp = symm_mem.empty(numel, dtype=dtype, device=self.device)
+            out = torch.empty(numel, dtype=dtype, device=self.device)
+            inp.fill_(capture_offset)
+            out.fill_(0.0)
+            torch.ops.symm_mem.one_shot_all_reduce_out(inp, "sum", group_name, out)
+
+        graph.replay()
+        expected_sum = float(
+            self.world_size * offset + self.world_size * (self.world_size - 1) / 2
+        )
+        self.assertEqual(out, torch.full_like(out, expected_sum))
+
+        for repeat in range(3):
+            offset = 20 + repeat
+            capture_offset.fill_(self.rank + offset)
+            graph.replay()
+            expected_sum = float(
+                self.world_size * offset + self.world_size * (self.world_size - 1) / 2
+            )
+            self.assertEqual(out, torch.full_like(out, expected_sum))
 
     @skip_but_pass_in_sandcastle_if(TEST_WITH_ROCM, "Skip NCCL tests for ROCm")
     @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")

--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -2024,6 +2024,59 @@ class SymmMemPoolTest(MultiProcContinuousTest):
         expected = torch.mm(x, w) * self.world_size
         self.assertEqual(y, expected)
 
+    @skipIf(TEST_WITH_ROCM, "https://github.com/pytorch/pytorch/issues/180464")
+    @skipIf(
+        not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
+    )
+    @skip_if_lt_x_gpu(2)
+    def test_mempool_storage_reuse(self):
+        """MemPool with no_split=True returns the same VA for same-size allocs."""
+        self._init_process()
+
+        mempool = symm_mem.get_mem_pool(self.device)
+        numel = 1024
+        dtype = torch.float
+
+        with torch.cuda.use_mem_pool(mempool):
+            t1 = torch.empty(numel, dtype=dtype, device=self.device)
+        ptr1 = t1.data_ptr()
+        del t1
+
+        with torch.cuda.use_mem_pool(mempool):
+            t2 = torch.empty(numel, dtype=dtype, device=self.device)
+        ptr2 = t2.data_ptr()
+
+        self.assertEqual(
+            ptr1,
+            ptr2,
+            "MemPool should return the same storage block for same-size re-allocation",
+        )
+
+    @skipIf(TEST_WITH_ROCM, "https://github.com/pytorch/pytorch/issues/180464")
+    @skipIf(
+        not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
+    )
+    @skip_if_lt_x_gpu(2)
+    def test_symm_mem_empty_storage_reuse(self):
+        """symm_mem.empty() reuses storage across alloc/free cycles via the MemPool."""
+        self._init_process()
+
+        numel = 1024
+        dtype = torch.float
+
+        t1 = symm_mem.empty(numel, dtype=dtype, device=self.device)
+        ptr1 = t1.data_ptr()
+        del t1
+
+        t2 = symm_mem.empty(numel, dtype=dtype, device=self.device)
+        ptr2 = t2.data_ptr()
+
+        self.assertEqual(
+            ptr1,
+            ptr2,
+            "symm_mem.empty() should reuse the same storage block via the implicit MemPool",
+        )
+
 
 @instantiate_parametrized_tests
 @requires_cuda_p2p_access()

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
@@ -843,9 +843,36 @@ c10::intrusive_ptr<CUDAPeerAllocInfo> make_peer_alloc_info(
 
 } // namespace
 
+
+bool cache_entry_matches_storage(const c10::StorageImpl* storage_impl, const Block::RendezvousCacheEntry& entry) {
+  if (storage_impl == nullptr) {
+    return true;
+  }
+  if (!entry.storage.has_value()) {
+    return false;
+  }
+  auto cached_storage = entry.storage->lock();
+  return cached_storage != nullptr && cached_storage.get() == storage_impl;
+}
 c10::intrusive_ptr<SymmetricMemory> CUDASymmetricMemoryAllocator::rendezvous(
     void* ptr,
     const std::optional<std::string>& group_name) {
+  return rendezvous_impl(ptr, group_name, std::nullopt);
+}
+
+c10::intrusive_ptr<SymmetricMemory> CUDASymmetricMemoryAllocator::rendezvous(
+    const at::Tensor& tensor,
+    const std::optional<std::string>& group_name) {
+  auto storage = tensor.storage();
+  return rendezvous_impl(
+      storage.data_ptr().get(), group_name, storage.getWeakStorageImpl());
+}
+
+c10::intrusive_ptr<SymmetricMemory>
+CUDASymmetricMemoryAllocator::rendezvous_impl(
+    void* ptr,
+    const std::optional<std::string>& group_name,
+    std::optional<c10::weak_intrusive_ptr<c10::StorageImpl>> storage) {
   // In case of MemPool, the `ptr` passed in (i.e. tensor storage ptr) may not
   // be the same as the allocation base pointer, so we need to find the block
   // that covers the `ptr`
@@ -874,23 +901,64 @@ c10::intrusive_ptr<SymmetricMemory> CUDASymmetricMemoryAllocator::rendezvous(
     group_name_ = *block->default_group_name;
   }
 
-  // If found, this block has been rendezvous by the given group
+  c10::intrusive_ptr<c10::StorageImpl> storage_ref;
+  c10::StorageImpl* storage_impl = nullptr;
+  if (storage.has_value()) {
+    storage_ref = storage->lock();
+    storage_impl = storage_ref.get();
+    TORCH_INTERNAL_ASSERT(storage_impl != nullptr);
+    for (auto iter = block->symm_mems.begin();
+         iter != block->symm_mems.end();) {
+      if (iter->second.storage.has_value() &&
+          iter->second.storage->expired()) {
+        iter = block->symm_mems.erase(iter);
+      } else {
+        ++iter;
+      }
+    }
+  }
+
+  c10::intrusive_ptr<CUDAPeerAllocInfo> pai;
+  // If found, this block has been rendezvous by the given group.
   auto it = block->symm_mems.find(group_name_);
-  if (it == block->symm_mems.end()) {
+  if (it != block->symm_mems.end()) {
+    if (cache_entry_matches_storage(storage_impl, it->second)) {
+      pai = it->second.symm_mem;
+    }
+  }
+  if (pai == nullptr) {
+    if (storage_impl != nullptr) {
+      auto has_cache_for_storage = std::any_of(
+          block->symm_mems.begin(),
+          block->symm_mems.end(),
+          [&](const auto& entry) {
+            return cache_entry_matches_storage(storage_impl, entry.second);
+          });
+      if (!has_cache_for_storage) {
+        c10::cuda::CUDAGuard guard(block->device_idx);
+        AT_CUDA_CHECK(cudaMemset(
+            static_cast<char*>(block->alloc_ref->ptr) + block->signal_pad_offset,
+            0,
+            block->block_size - block->signal_pad_offset));
+      }
+    }
     // Create PeerAllocInfo for this block (this is the costly part)
     TORCH_INTERNAL_ASSERT(
         handle_type_ != Expandable_Segments_Handle_Type::UNSPECIFIED)
     bool use_fabric =
         handle_type_ == Expandable_Segments_Handle_Type::FABRIC_HANDLE;
     // PeerAllocInfo captures this block's rendezvous info
-    auto pai = use_fabric ? make_peer_alloc_info<true>(ptr, block, group_name_)
-                          : make_peer_alloc_info<false>(ptr, block, group_name_);
+    pai = use_fabric ? make_peer_alloc_info<true>(ptr, block, group_name_)
+                     : make_peer_alloc_info<false>(ptr, block, group_name_);
     // Cache it with the group name
-    it = block->symm_mems.emplace(group_name_, pai).first;
+    block->symm_mems.insert_or_assign(
+        group_name_,
+        Block::RendezvousCacheEntry{
+            std::move(storage),
+            pai});
   }
 
   // Create symm mem handle for this tensor, specified by its offset
-  auto pai = it->second;
   return c10::make_intrusive<CUDASymmetricMemory>(pai, offset);
 }
 

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ATen/ATen.h>
+#include <c10/core/StorageImpl.h>
 #include <c10/cuda/CUDAAllocatorConfig.h>
 #include <torch/csrc/distributed/c10d/Store.hpp>
 #include <torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryTypes.hpp>
@@ -115,7 +116,11 @@ struct Block : public c10::intrusive_ptr_target {
   size_t buffer_size;
   size_t signal_pad_offset;
   std::optional<std::string> default_group_name;
-  std::map<std::string, c10::intrusive_ptr<CUDAPeerAllocInfo>> symm_mems;
+  struct RendezvousCacheEntry {
+    std::optional<c10::weak_intrusive_ptr<c10::StorageImpl>> storage;
+    c10::intrusive_ptr<CUDAPeerAllocInfo> symm_mem;
+  };
+  std::map<std::string, RendezvousCacheEntry> symm_mems;
 
   Block(
       c10::intrusive_ptr<AllocationRef> alloc_ref,
@@ -138,6 +143,9 @@ class CUDASymmetricMemoryAllocator : public SymmetricMemoryAllocator {
   c10::intrusive_ptr<SymmetricMemory> rendezvous(
       void* ptr,
       const std::optional<std::string>& group_name) override;
+  c10::intrusive_ptr<SymmetricMemory> rendezvous(
+      const at::Tensor& tensor,
+      const std::optional<std::string>& group_name) override;
   bool has_multicast_support(int device_idx) override;
   bool has_allocation(void* ptr) override;
   c10::DeviceType supported_device_type() override;
@@ -146,6 +154,10 @@ class CUDASymmetricMemoryAllocator : public SymmetricMemoryAllocator {
  private:
   c10::intrusive_ptr<Block> find_block(void* ptr);
   c10::intrusive_ptr<Block> find_block_covering(void* ptr, size_t& offset);
+  c10::intrusive_ptr<SymmetricMemory> rendezvous_impl(
+      void* ptr,
+      const std::optional<std::string>& group_name,
+      std::optional<c10::weak_intrusive_ptr<c10::StorageImpl>> storage);
 
   std::shared_mutex mutex_;
   std::unordered_map<void*, c10::intrusive_ptr<Block>> ptr_to_block_;

--- a/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
@@ -482,6 +482,8 @@ std::string NCCLSymmetricMemory::get_group_name() {
 
 class NCCLSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
  public:
+  using SymmetricMemoryAllocator::rendezvous;
+
   void* alloc(
       size_t size,
       int device_idx,

--- a/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cpp
@@ -362,6 +362,8 @@ static void initialize_nvshmem_with_store(
 
 class NVSHMEMSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
  public:
+  using SymmetricMemoryAllocator::rendezvous;
+
   void* alloc(
       size_t size,
       int device_idx,

--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
@@ -292,7 +292,7 @@ TORCH_API c10::intrusive_ptr<SymmetricMemory> rendezvous(
     const at::Tensor& tensor,
     const std::optional<std::string>& group_name) {
   auto allocator = get_allocator(tensor.device().type());
-  return allocator->rendezvous(tensor.storage().data_ptr().get(), group_name);
+  return allocator->rendezvous(tensor, group_name);
 }
 
 TORCH_API bool is_symm_mem_tensor(const at::Tensor& tensor) {

--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp
@@ -110,6 +110,11 @@ class SymmetricMemoryAllocator : public c10::intrusive_ptr_target {
   virtual c10::intrusive_ptr<SymmetricMemory> rendezvous(
       void* ptr,
       const std::optional<std::string>& group_name) = 0;
+  virtual c10::intrusive_ptr<SymmetricMemory> rendezvous(
+      const at::Tensor& tensor,
+      const std::optional<std::string>& group_name) {
+    return rendezvous(tensor.storage().data_ptr().get(), group_name);
+  }
   virtual bool has_multicast_support(int device_idx) = 0;
   virtual c10::DeviceType supported_device_type() = 0;
   virtual std::string name() = 0;

--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -1976,12 +1976,13 @@ def empty(  # type: ignore[misc]
     stride = torch._prims_common.make_contiguous_strides_for(size)
 
     if _should_use_implicit_mempool() and device.type == "cuda":
-        # Allocate tensor from an implicit memory pool
+        # Allocate through the CUDACachingAllocator so symmetric allocations
+        # can participate in MemPool and CUDAGraph private-pool reuse.
         mempool = get_mem_pool(device)
         # TODO: this path can be made device-agnostic if `use_mem_pool` is
         # elevated from torch.cuda to torch accelerator.
         with torch.cuda.use_mem_pool(mempool):
-            return _SymmetricMemory.empty_strided_p2p(size, stride, dtype, device)
+            return torch.empty_strided(size, stride, dtype=dtype, device=device)
     else:
         return _SymmetricMemory.empty_strided_p2p(size, stride, dtype, device)
 


### PR DESCRIPTION
This is a follow up to my original PR #187054.
The original descrioption:
>This PR makes symm_mem.empty() allocate through the CUDACachingAllocator when using the implicit symmetric memory pool. This lets symmetric-memory allocations participate in CUDAGraph private-pool reuse, enabling symm_mem.empty() inside CUDAGraph capture region.

In addition to that, this PR proposes an enhancement for symmetric memory caching on CUDA back-end: it adds a tensor-aware `SymmetricMemoryAllocator::rendezvous` overload. The CUDA backend now stores the tensor storage identity as a weak reference alongside the cached rendezvous state. Cached rendezvous state is reused only if the current tensor storage matches the cached storage; otherwise the backend performs a fresh rendezvous and replaces the stale cache entry.

the pointer-level rendezvous behavior is kept unchanged.

cc @kwen2501 @ngimel 


Some commits were co-authored with @Codex (model GPT v5.5).