### PR TITLE
test-osdc: read shared HF cache offline, refresh it to S3 on refresh runs

### DIFF
--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -729,6 +729,21 @@ jobs:
         run: |
           echo "timeout=$((JOB_TIMEOUT-30))" >> "${GITHUB_OUTPUT}"
 
+      - name: Resolve HF cache mode
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "schedule" \
+             || "${{ github.event_name }}" == "workflow_dispatch" \
+             || "${{ contains(steps.keep-going.outputs.labels, 'ci-refresh-hf-cache') }}" == "true" ]]; then
+            OFFLINE=0
+          else
+            OFFLINE=1
+          fi
+          {
+            echo "TRANSFORMERS_OFFLINE=${OFFLINE}"
+            echo "HF_DATASETS_OFFLINE=${OFFLINE}"
+          } >> "${GITHUB_ENV}"
+
       - name: Test
         id: test
         timeout-minutes: ${{ fromJson(steps.test-timeout.outputs.timeout) }}
@@ -769,8 +784,6 @@ jobs:
           ENABLE_TORCH_TRACE: ${{ inputs.enable-torch-trace }}
           VLLM_TEST_HUGGING_FACE_TOKEN: ${{ secrets.VLLM_TEST_HUGGING_FACE_TOKEN }}
           HF_CACHE: /mnt/hf_cache
-          TRANSFORMERS_OFFLINE: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(steps.keep-going.outputs.labels, 'ci-refresh-hf-cache')) && '0' || '1' }}
-          HF_DATASETS_OFFLINE: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(steps.keep-going.outputs.labels, 'ci-refresh-hf-cache')) && '0' || '1' }}
           HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
           SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
           ARTIFACTS_FILE_SUFFIX: ${{ github.job }}-${{ matrix.config }}-${{ matrix.shard }}-${{ matrix.num_shards }}-${{ matrix.runner }}_${{ steps.setup-linux.outputs.job-id }}
@@ -786,14 +799,17 @@ jobs:
             TEST_COMMAND=.ci/pytorch/test.sh
           fi
 
-          # Just create an empty HF_CACHE dir if it doesn't exist. This dir is not
-          # used for anything besides vLLM jobs
-          if [[ ! -d "${HF_CACHE}" ]]; then
+          # HF model cache. Offline (the default for PRs): read the shared, pre-seeded
+          # read-only cache mounted at /mnt/hf_cache. Online (refresh runs: schedule,
+          # workflow_dispatch, or the ci-refresh-hf-cache label): download into a
+          # writable dir that the "Refresh the HF cache in S3" step below syncs back
+          # into the shared bucket. Also fall back to online+writable if the mount is
+          # absent (e.g. a runner without the shared cache).
+          if [[ "${TRANSFORMERS_OFFLINE}" == "1" && -d /mnt/hf_cache ]]; then
+            export HF_CACHE=/mnt/hf_cache
+          else
             export HF_CACHE="${RUNNER_TEMP}/hf_cache"
             mkdir -p "${HF_CACHE}"
-
-            # When there is no cache directory, e.g. benchmark, the job has no
-            # way but to reach out to HF if needed
             export TRANSFORMERS_OFFLINE=0
             export HF_DATASETS_OFFLINE=0
           fi
@@ -843,3 +859,29 @@ jobs:
           file-suffix: ${{ github.job }}-${{ matrix.config }}-${{ matrix.shard }}-${{ matrix.num_shards }}-${{ matrix.runner }}_${{ steps.setup-linux.outputs.job-id }}
           use-gha: ${{ inputs.use-gha }}
           s3-bucket: ${{ inputs.s3-bucket }}
+
+      - name: Authenticate to refresh the HF cache in S3
+        if: always() && steps.test.conclusion && env.TRANSFORMERS_OFFLINE == '0'
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_hf-cache-write
+          aws-region: us-east-1
+
+      - name: Refresh the HF cache in S3
+        if: always() && steps.test.conclusion && env.TRANSFORMERS_OFFLINE == '0'
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -x
+          HF_CACHE="${RUNNER_TEMP}/hf_cache"
+          if [[ -z "${HF_CACHE_S3_BUCKET:-}" ]]; then
+            echo "HF_CACHE_S3_BUCKET unset (not an hf-cache runner) - skipping sync"
+            exit 0
+          fi
+          if [[ ! -d "${HF_CACHE}/hub" ]]; then
+            echo "No ${HF_CACHE}/hub to sync - skipping"
+            exit 0
+          fi
+          aws s3 sync "${HF_CACHE}/hub" "s3://${HF_CACHE_S3_BUCKET}/hub" \
+            --region "${HF_CACHE_S3_REGION}" --no-progress

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -875,8 +875,8 @@ jobs:
         run: |
           set -x
           HF_CACHE="${RUNNER_TEMP}/hf_cache"
-          if [[ -z "${HF_CACHE_S3_BUCKET:-}" ]]; then
-            echo "HF_CACHE_S3_BUCKET unset (not an hf-cache runner) - skipping sync"
+          if [[ -z "${HF_CACHE_S3_BUCKET:-}" || -z "${HF_CACHE_S3_REGION:-}" ]]; then
+            echo "HF_CACHE_S3_BUCKET/REGION unset (not an hf-cache runner) - skipping sync"
             exit 0
           fi
           if [[ ! -d "${HF_CACHE}/hub" ]]; then

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -814,6 +814,12 @@ jobs:
             export HF_DATASETS_OFFLINE=0
           fi
 
+          # The datasets library writes its arrow build + lock files even in offline
+          # mode and even for local datasets (e.g. torchtitan's c4_test), so keep its
+          # cache off the read-only /mnt/hf_cache mount.
+          export HF_DATASETS_CACHE="${RUNNER_TEMP}/hf_datasets"
+          mkdir -p "${HF_DATASETS_CACHE}"
+
           # shellcheck disable=SC2046
           python3 -m pip install $(echo dist/*.whl)[opt-einsum]
           ${TEST_COMMAND}

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -815,10 +815,14 @@ jobs:
           fi
 
           # The datasets library writes its arrow build + lock files even in offline
-          # mode and even for local datasets (e.g. torchtitan's c4_test), so keep its
-          # cache off the read-only /mnt/hf_cache mount.
+          # mode and even for local datasets, so it can't use the read-only mount
+          # directly. Use a writable dir warmed from the seeded /mnt/hf_cache/datasets
+          # (so offline Hub datasets resolve); the refresh step syncs it back to S3.
           export HF_DATASETS_CACHE="${RUNNER_TEMP}/hf_datasets"
           mkdir -p "${HF_DATASETS_CACHE}"
+          if [[ -d /mnt/hf_cache/datasets ]]; then
+            cp -a /mnt/hf_cache/datasets/. "${HF_DATASETS_CACHE}/" 2>/dev/null || true
+          fi
 
           # shellcheck disable=SC2046
           python3 -m pip install $(echo dist/*.whl)[opt-einsum]
@@ -880,13 +884,8 @@ jobs:
         shell: bash
         run: |
           set -x
-          HF_CACHE="${RUNNER_TEMP}/hf_cache"
           if [[ -z "${HF_CACHE_S3_BUCKET:-}" || -z "${HF_CACHE_S3_REGION:-}" ]]; then
             echo "HF_CACHE_S3_BUCKET/REGION unset (not an hf-cache runner) - skipping sync"
-            exit 0
-          fi
-          if [[ ! -d "${HF_CACHE}/hub" ]]; then
-            echo "No ${HF_CACHE}/hub to sync - skipping"
             exit 0
           fi
           # The test image doesn't ship the AWS CLI (awscli is excluded from
@@ -897,5 +896,12 @@ jobs:
             /tmp/awscli-venv/bin/pip install --quiet awscli==1.45.39
             AWS=/tmp/awscli-venv/bin/aws
           fi
-          "${AWS}" s3 sync "${HF_CACHE}/hub" "s3://${HF_CACHE_S3_BUCKET}/hub" \
-            --region "${HF_CACHE_S3_REGION}" --no-progress
+          # Sync model snapshots (hub/) and the datasets build cache (datasets/) to S3.
+          if [[ -d "${RUNNER_TEMP}/hf_cache/hub" ]]; then
+            "${AWS}" s3 sync "${RUNNER_TEMP}/hf_cache/hub" "s3://${HF_CACHE_S3_BUCKET}/hub" \
+              --region "${HF_CACHE_S3_REGION}" --no-progress
+          fi
+          if [[ -d "${RUNNER_TEMP}/hf_datasets" ]]; then
+            "${AWS}" s3 sync "${RUNNER_TEMP}/hf_datasets" "s3://${HF_CACHE_S3_BUCKET}/datasets" \
+              --region "${HF_CACHE_S3_REGION}" --no-progress
+          fi

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -888,7 +888,7 @@ jobs:
           AWS=aws
           if ! command -v aws >/dev/null 2>&1; then
             python3 -m venv /tmp/awscli-venv
-            /tmp/awscli-venv/bin/pip install --quiet awscli
+            /tmp/awscli-venv/bin/pip install --quiet awscli==1.45.39
             AWS=/tmp/awscli-venv/bin/aws
           fi
           "${AWS}" s3 sync "${HF_CACHE}/hub" "s3://${HF_CACHE_S3_BUCKET}/hub" \

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -883,5 +883,13 @@ jobs:
             echo "No ${HF_CACHE}/hub to sync - skipping"
             exit 0
           fi
-          aws s3 sync "${HF_CACHE}/hub" "s3://${HF_CACHE_S3_BUCKET}/hub" \
+          # The test image doesn't ship the AWS CLI (awscli is excluded from
+          # requirements-ci.txt), so fall back to a throwaway venv when it's absent.
+          AWS=aws
+          if ! command -v aws >/dev/null 2>&1; then
+            python3 -m venv /tmp/awscli-venv
+            /tmp/awscli-venv/bin/pip install --quiet awscli
+            AWS=/tmp/awscli-venv/bin/aws
+          fi
+          "${AWS}" s3 sync "${HF_CACHE}/hub" "s3://${HF_CACHE_S3_BUCKET}/hub" \
             --region "${HF_CACHE_S3_REGION}" --no-progress


### PR DESCRIPTION
On the `test-osdc` job, branch the HF model cache on `TRANSFORMERS_OFFLINE`:

- **offline** (default for PRs): read the shared, pre-seeded read-only cache at `/mnt/hf_cache`.
- **online** (refresh runs — `schedule` / `workflow_dispatch` / `ci-refresh-hf-cache` label): download into a writable `${RUNNER_TEMP}/hf_cache`, then `aws s3 sync` it back to the shared bucket so later offline runs pick it up.

The sync assumes `gha_workflow_hf-cache-write` via OIDC (the runner's hf-cache IRSA is read-only) and is gated to refresh runs; both new steps are `continue-on-error`. The EC2 `test` job is unchanged.

Requires the `gha_workflow_hf-cache-write` role trust policy to allow this workflow's OIDC subject.

### Testing

https://github.com/pytorch/pytorch/actions/runs/28510092903

Another round

https://github.com/pytorch/pytorch/actions/runs/28554502600
