### PR TITLE
[Test] Improve test reuse in test/test_unary_ufuncs.py for out-of-tree backends

### DIFF
--- a/test/test_unary_ufuncs.py
+++ b/test/test_unary_ufuncs.py
@@ -19,7 +19,6 @@ from torch.testing._internal.common_device_type import (
     largeTensorTest,
     onlyAccelerator,
     onlyCPU,
-    onlyCUDA,
     onlyNativeDeviceTypes,
     ops,
     precisionOverride,
@@ -41,6 +40,7 @@ from torch.testing._internal.common_methods_invocations import (
 )
 from torch.testing._internal.common_utils import (
     gradcheck,
+    HardwareClassification,
     is_iterable_of_tensors,
     numpy_to_torch_dtype_dict,
     parametrize,
@@ -80,7 +80,8 @@ reference_filtered_ops = list(filter(lambda op: op.ref is not None, unary_ufuncs
 
 # TODO: port test_unary_out_op_mem_overlap
 # TODO: add test for inplace variants erroring on broadcasted inputs
-class TestUnaryUfuncs(TestCase):
+class TestUnaryUfuncsDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
     exact_dtype = True
 
     @ops(
@@ -879,7 +880,6 @@ class TestUnaryUfuncs(TestCase):
                 with self.assertRaisesRegex(RuntimeError, "unsupported operation"):
                     _test(op, data[0:sz], data[1 : sz + 1])
 
-    # TODO: run on non-native device types
     # https://github.com/pytorch/pytorch/issues/126474
     @xfailIfTorchDynamo
     @dtypes(torch.double)
@@ -1758,37 +1758,6 @@ class TestUnaryUfuncs(TestCase):
             ),
         )
 
-    @onlyCUDA
-    def test_nonzero_static_large(self, device):
-        # large enough to have multiple iters per SM even on H100
-        # with 132 sms
-        size_inp = 1024 * 16 * 132 + 1024 * 16
-        x = torch.zeros(size_inp, device=device)
-        # unique indices
-        indices = torch.randperm(size_inp, device=device)[: size_inp // 2]
-        sorted, _ = torch.sort(indices)
-        x[sorted] = 1
-        res = torch.nonzero_static(x, size=size_inp // 2).view(-1)
-        self.assertEqual(res, sorted)
-        # no oob writes
-        out = torch.full((size_inp,), 10, device=device, dtype=torch.int64)
-        res = torch.nonzero_static(x, size=size_inp // 4, out=out[: size_inp // 2])
-        self.assertEqual(out[: size_inp // 4], sorted[: size_inp // 4])
-        self.assertEqual(
-            out[size_inp // 4 :],
-            torch.tensor(10, device=device).expand_as(out[size_inp // 4 :]),
-        )
-        # correct fill for 2d
-        x = x.view(2, size_inp // 2)
-        ref = x.nonzero()
-        res = x.nonzero_static(size=size_inp // 2 + 2)
-        self.assertEqual(res.shape, [size_inp // 2 + 2, 2])
-        self.assertEqual(ref, res[: size_inp // 2])
-        self.assertEqual(
-            res[size_inp // 2 :],
-            torch.tensor(-1, device=device).expand_as(res[size_inp // 2 :]),
-        )
-
     # TODO: rationalize with exp OpInfo
 
     @dtypes(*floating_and_complex_types_and(torch.bfloat16))
@@ -1898,32 +1867,6 @@ class TestUnaryUfuncs(TestCase):
         self.assertTrue(result.dtype.is_floating_point)
         self.assertTrue(torch.all(torch.isfinite(result)))
 
-    @onlyCUDA
-    @dtypes(torch.float32, torch.float16, torch.bfloat16)
-    def test_fp8_e4m3fn_conversion_subnormals(self, device, dtype):
-        # Regression test for ptxas codegen bug on sm_100 where FADD in the
-        # subnormal conversion path gets wrong source register for odd elements
-        # in the 8-wide unrolled vectorized_elementwise_kernel.
-        # e4m3fn subnormals: |x| < 2^-6
-        torch.manual_seed(0)
-        N = 2**20
-        x = (torch.randn(N, dtype=dtype, device=device) * 1e-3).clamp(-448, 448)
-        y = x.to(torch.float8_e4m3fn)
-        ref = x.cpu().float().to(torch.float8_e4m3fn)
-        self.assertEqual(y.cpu().view(torch.uint8), ref.view(torch.uint8))
-
-    @onlyCUDA
-    @dtypes(torch.float32, torch.float16, torch.bfloat16)
-    def test_fp8_e5m2_conversion_subnormals(self, device, dtype):
-        # Same regression test for e5m2.
-        # e5m2 subnormals: |x| < 2^-14
-        torch.manual_seed(0)
-        N = 2**20
-        x = (torch.randn(N, dtype=dtype, device=device) * 1e-4).clamp(-57344, 57344)
-        y = x.to(torch.float8_e5m2)
-        ref = x.cpu().float().to(torch.float8_e5m2)
-        self.assertEqual(y.cpu().view(torch.uint8), ref.view(torch.uint8))
-
     # Regression for https://github.com/pytorch/pytorch/issues/177839:
     # when eps > 0.5 the scalar kernel clamps via `x < eps ? eps : ...` (so
     # the lower bound wins over the upper bound when eps > 1 - eps), and the
@@ -1954,7 +1897,66 @@ class TestUnaryUfuncs(TestCase):
         self.assertEqual(got, ref)
 
 
-instantiate_device_type_tests(TestUnaryUfuncs, globals())
+class TestUnaryUfuncsCUDA(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
+    def test_nonzero_static_large(self, device):
+        # large enough to have multiple iters per SM even on H100
+        # with 132 sms
+        size_inp = 1024 * 16 * 132 + 1024 * 16
+        x = torch.zeros(size_inp, device=device)
+        # unique indices
+        indices = torch.randperm(size_inp, device=device)[: size_inp // 2]
+        sorted, _ = torch.sort(indices)
+        x[sorted] = 1
+        res = torch.nonzero_static(x, size=size_inp // 2).view(-1)
+        self.assertEqual(res, sorted)
+        # no oob writes
+        out = torch.full((size_inp,), 10, device=device, dtype=torch.int64)
+        res = torch.nonzero_static(x, size=size_inp // 4, out=out[: size_inp // 2])
+        self.assertEqual(out[: size_inp // 4], sorted[: size_inp // 4])
+        self.assertEqual(
+            out[size_inp // 4 :],
+            torch.tensor(10, device=device).expand_as(out[size_inp // 4 :]),
+        )
+        # correct fill for 2d
+        x = x.view(2, size_inp // 2)
+        ref = x.nonzero()
+        res = x.nonzero_static(size=size_inp // 2 + 2)
+        self.assertEqual(res.shape, [size_inp // 2 + 2, 2])
+        self.assertEqual(ref, res[: size_inp // 2])
+        self.assertEqual(
+            res[size_inp // 2 :],
+            torch.tensor(-1, device=device).expand_as(res[size_inp // 2 :]),
+        )
+
+    @dtypes(torch.float32, torch.float16, torch.bfloat16)
+    def test_fp8_e4m3fn_conversion_subnormals(self, device, dtype):
+        # Regression test for ptxas codegen bug on sm_100 where FADD in the
+        # subnormal conversion path gets wrong source register for odd elements
+        # in the 8-wide unrolled vectorized_elementwise_kernel.
+        # e4m3fn subnormals: |x| < 2^-6
+        torch.manual_seed(0)
+        N = 2**20
+        x = (torch.randn(N, dtype=dtype, device=device) * 1e-3).clamp(-448, 448)
+        y = x.to(torch.float8_e4m3fn)
+        ref = x.cpu().float().to(torch.float8_e4m3fn)
+        self.assertEqual(y.cpu().view(torch.uint8), ref.view(torch.uint8))
+
+    @dtypes(torch.float32, torch.float16, torch.bfloat16)
+    def test_fp8_e5m2_conversion_subnormals(self, device, dtype):
+        # Same regression test for e5m2.
+        # e5m2 subnormals: |x| < 2^-14
+        torch.manual_seed(0)
+        N = 2**20
+        x = (torch.randn(N, dtype=dtype, device=device) * 1e-4).clamp(-57344, 57344)
+        y = x.to(torch.float8_e5m2)
+        ref = x.cpu().float().to(torch.float8_e5m2)
+        self.assertEqual(y.cpu().view(torch.uint8), ref.view(torch.uint8))
+
+
+instantiate_device_type_tests(TestUnaryUfuncsDevice, globals())
+instantiate_device_type_tests(TestUnaryUfuncsCUDA, globals(), only_for="cuda")
 
 if __name__ == "__main__":
     run_tests()

--- a/test/test_unary_ufuncs.py
+++ b/test/test_unary_ufuncs.py
@@ -804,7 +804,6 @@ class TestUnaryUfuncs(TestCase):
                     with self.assertRaises(AttributeError):
                         torch_inplace_method = getattr(torch.Tensor, fn_name + "_")
 
-    @onlyCUDA
     @dtypes(torch.complex64)
     @parametrize("eps", [1e-3])
     def test_tan_complex_matches_numpy(self, device, dtype, eps):
@@ -837,7 +836,6 @@ class TestUnaryUfuncs(TestCase):
         z = torch.complex(real, imag).to(dtype)
         self.compare_with_numpy(torch.tan, np.tan, z)
 
-    @onlyCUDA
     @dtypes(torch.complex64)
     def test_tanh_complex_matches_numpy(self, device, dtype):
         # Focused accuracy check for complex tanh against NumPy reference

--- a/test/test_unary_ufuncs.py
+++ b/test/test_unary_ufuncs.py
@@ -18,6 +18,7 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     largeTensorTest,
     onlyAccelerator,
+    onlyOn,
     onlyCPU,
     onlyCUDA,
     onlyNativeDeviceTypes,
@@ -805,10 +806,10 @@ class TestUnaryUfuncs(TestCase):
 
     @onlyCUDA
     @dtypes(torch.complex64)
-    def test_tan_complex_cuda_matches_numpy(self, device, dtype):
-        # Focused accuracy check for complex tan on CUDA against NumPy reference
+    @parametrize("eps", [1e-3])
+    def test_tan_complex_matches_numpy(self, device, dtype, eps):
+        # Focused accuracy check for complex tan against NumPy reference
         # Includes values near tan singularities on the real axis
-        eps = 1e-3
         specials = torch.tensor(
             [
                 math.pi / 2 - eps,
@@ -838,8 +839,8 @@ class TestUnaryUfuncs(TestCase):
 
     @onlyCUDA
     @dtypes(torch.complex64)
-    def test_tanh_complex_cuda_matches_numpy(self, device, dtype):
-        # Focused accuracy check for complex tanh on CUDA against NumPy reference
+    def test_tanh_complex_matches_numpy(self, device, dtype):
+        # Focused accuracy check for complex tanh against NumPy reference
         real = torch.randn(2048, device=device, dtype=torch.float32) * (2 * math.pi)
         imag = torch.randn(2048, device=device, dtype=torch.float32) * 5.0
         z = torch.complex(real, imag).to(dtype)
@@ -885,85 +886,50 @@ class TestUnaryUfuncs(TestCase):
     # https://github.com/pytorch/pytorch/issues/126474
     @xfailIfTorchDynamo
     @dtypes(torch.double)
+    @onlyOn(["cpu", "cuda"])
     def test_unary_out_op_mem_overlap(self, device, dtype):
         sz = 3
         doubles = torch.randn(2 * sz, dtype=dtype, device=device)
         positives = torch.randint(1, 100, (2 * sz,), device=device).double()
         ints = torch.randint(-100, 100, (2 * sz,), device=device)
         unary_mem_overlap_cases = [
-            ("abs", doubles, True, True, "cpu"),
-            ("abs", doubles, True, True, "cuda"),
-            ("acos", doubles, True, True, "cpu"),
-            ("acos", doubles, True, True, "cuda"),
-            ("asin", doubles, True, True, "cpu"),
-            ("asin", doubles, True, True, "cuda"),
-            ("atan", doubles, True, True, "cpu"),
-            ("atan", doubles, True, True, "cuda"),
-            ("acosh", doubles, True, True, "cpu"),
-            ("acosh", doubles, True, True, "cuda"),
-            ("asinh", doubles, True, True, "cpu"),
-            ("asinh", doubles, True, True, "cuda"),
-            ("atanh", doubles, True, True, "cpu"),
-            ("atanh", doubles, True, True, "cuda"),
-            ("bitwise_not", ints, True, True, "cpu"),
-            ("bitwise_not", ints, True, True, "cuda"),
-            ("ceil", doubles, True, True, "cpu"),
-            ("ceil", doubles, True, True, "cuda"),
-            ("cos", doubles, True, True, "cpu"),
-            ("cos", doubles, True, True, "cuda"),
-            ("cosh", doubles, True, True, "cpu"),
-            ("cosh", doubles, True, True, "cuda"),
-            ("digamma", doubles, True, True, "cpu"),
-            ("erf", doubles, True, True, "cpu"),
-            ("erf", doubles, True, True, "cuda"),
-            ("erfc", doubles, True, True, "cpu"),
-            ("erfc", doubles, True, True, "cuda"),
-            ("erfinv", doubles, True, True, "cpu"),
-            ("erfinv", doubles, True, True, "cuda"),
-            ("exp", doubles, True, True, "cpu"),
-            ("exp", doubles, True, True, "cuda"),
-            ("exp2", doubles, True, True, "cpu"),
-            ("exp2", doubles, True, True, "cuda"),
-            ("expm1", doubles, True, True, "cpu"),
-            ("expm1", doubles, True, True, "cuda"),
-            ("floor", doubles, True, True, "cpu"),
-            ("floor", doubles, True, True, "cuda"),
-            ("frac", doubles, True, True, "cpu"),
-            ("frac", doubles, True, True, "cuda"),
-            ("i0", doubles, True, True, "cpu"),
-            ("i0", doubles, True, True, "cuda"),
-            ("log", positives, True, True, "cpu"),
-            ("log", positives, True, True, "cuda"),
-            ("log10", positives, True, True, "cpu"),
-            ("log10", positives, True, True, "cuda"),
-            ("log1p", positives, True, True, "cpu"),
-            ("log1p", positives, True, True, "cuda"),
-            ("log2", positives, True, True, "cpu"),
-            ("log2", positives, True, True, "cuda"),
-            ("neg", doubles, True, True, "cpu"),
-            ("neg", doubles, True, True, "cuda"),
-            ("reciprocal", doubles, True, True, "cpu"),
-            ("reciprocal", doubles, True, True, "cuda"),
-            ("round", doubles, True, True, "cpu"),
-            ("round", doubles, True, True, "cuda"),
-            ("rsqrt", positives, True, True, "cpu"),
-            ("rsqrt", positives, True, True, "cuda"),
-            ("sin", doubles, True, True, "cpu"),
-            ("sin", doubles, True, True, "cuda"),
-            ("sinh", doubles, True, True, "cpu"),
-            ("sinh", doubles, True, True, "cuda"),
-            ("sigmoid", doubles, True, True, "cpu"),
-            ("sigmoid", doubles, True, True, "cuda"),
-            ("logit", doubles, True, True, "cpu"),
-            ("logit", doubles, True, True, "cuda"),
-            ("sqrt", doubles, True, True, "cpu"),
-            ("sqrt", doubles, True, True, "cuda"),
-            ("tan", doubles, True, True, "cpu"),
-            ("tan", doubles, True, True, "cuda"),
-            ("tanh", doubles, True, True, "cpu"),
-            ("tanh", doubles, True, True, "cuda"),
-            ("trunc", doubles, True, True, "cpu"),
-            ("trunc", doubles, True, True, "cuda"),
+            ("abs", doubles, True, True),
+            ("acos", doubles, True, True),
+            ("asin", doubles, True, True),
+            ("atan", doubles, True, True),
+            ("acosh", doubles, True, True),
+            ("asinh", doubles, True, True),
+            ("atanh", doubles, True, True),
+            ("bitwise_not", ints, True, True),
+            ("ceil", doubles, True, True),
+            ("cos", doubles, True, True),
+            ("cosh", doubles, True, True),
+            ("digamma", doubles, True, True),
+            ("erf", doubles, True, True),
+            ("erfc", doubles, True, True),
+            ("erfinv", doubles, True, True),
+            ("exp", doubles, True, True),
+            ("exp2", doubles, True, True),
+            ("expm1", doubles, True, True),
+            ("floor", doubles, True, True),
+            ("frac", doubles, True, True),
+            ("i0", doubles, True, True),
+            ("log", positives, True, True),
+            ("log10", positives, True, True),
+            ("log1p", positives, True, True),
+            ("log2", positives, True, True),
+            ("neg", doubles, True, True),
+            ("reciprocal", doubles, True, True),
+            ("round", doubles, True, True),
+            ("rsqrt", positives, True, True),
+            ("sin", doubles, True, True),
+            ("sinh", doubles, True, True),
+            ("sigmoid", doubles, True, True),
+            ("logit", doubles, True, True),
+            ("sqrt", doubles, True, True),
+            ("tan", doubles, True, True),
+            ("tanh", doubles, True, True),
+            ("trunc", doubles, True, True),
         ]
 
         for (
@@ -971,10 +937,7 @@ class TestUnaryUfuncs(TestCase):
             inputs,
             has_input_output_mem_overlap_check,
             has_internal_mem_overlap_check,
-            dev,
         ) in unary_mem_overlap_cases:
-            if dev != self.device_type:
-                continue
             out_fn = getattr(torch, fn)
             in_fn = getattr(torch.Tensor, fn + "_")
 
@@ -989,7 +952,7 @@ class TestUnaryUfuncs(TestCase):
                 in_fn,
                 1,
                 dtype,
-                dev,
+                device,
                 expected_failure=not has_internal_mem_overlap_check,
             )
 
@@ -1817,7 +1780,7 @@ class TestUnaryUfuncs(TestCase):
         self.assertEqual(out[: size_inp // 4], sorted[: size_inp // 4])
         self.assertEqual(
             out[size_inp // 4 :],
-            torch.tensor(10, device="cuda").expand_as(out[size_inp // 4 :]),
+            torch.tensor(10, device=device).expand_as(out[size_inp // 4 :]),
         )
         # correct fill for 2d
         x = x.view(2, size_inp // 2)
@@ -1827,7 +1790,7 @@ class TestUnaryUfuncs(TestCase):
         self.assertEqual(ref, res[: size_inp // 2])
         self.assertEqual(
             res[size_inp // 2 :],
-            torch.tensor(-1, device="cuda").expand_as(res[size_inp // 2 :]),
+            torch.tensor(-1, device=device).expand_as(res[size_inp // 2 :]),
         )
 
     # TODO: rationalize with exp OpInfo

--- a/test/test_unary_ufuncs.py
+++ b/test/test_unary_ufuncs.py
@@ -18,7 +18,6 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     largeTensorTest,
     onlyAccelerator,
-    onlyOn,
     onlyCPU,
     onlyCUDA,
     onlyNativeDeviceTypes,
@@ -884,7 +883,6 @@ class TestUnaryUfuncs(TestCase):
     # https://github.com/pytorch/pytorch/issues/126474
     @xfailIfTorchDynamo
     @dtypes(torch.double)
-    @onlyOn(["cpu", "cuda"])
     def test_unary_out_op_mem_overlap(self, device, dtype):
         sz = 3
         doubles = torch.randn(2 * sz, dtype=dtype, device=device)

--- a/test/test_unary_ufuncs.py
+++ b/test/test_unary_ufuncs.py
@@ -804,10 +804,10 @@ class TestUnaryUfuncs(TestCase):
                         torch_inplace_method = getattr(torch.Tensor, fn_name + "_")
 
     @dtypes(torch.complex64)
-    @parametrize("eps", [1e-3])
-    def test_tan_complex_matches_numpy(self, device, dtype, eps):
+    def test_tan_complex_matches_numpy(self, device, dtype):
         # Focused accuracy check for complex tan against NumPy reference
         # Includes values near tan singularities on the real axis
+        eps = 1e-3
         specials = torch.tensor(
             [
                 math.pi / 2 - eps,

--- a/test/test_unary_ufuncs.py
+++ b/test/test_unary_ufuncs.py
@@ -80,7 +80,7 @@ reference_filtered_ops = list(filter(lambda op: op.ref is not None, unary_ufuncs
 
 # TODO: port test_unary_out_op_mem_overlap
 # TODO: add test for inplace variants erroring on broadcasted inputs
-class TestUnaryUfuncsDevice(TestCase):
+class TestUnaryUfuncs(TestCase):
     hw_classification = HardwareClassification.ACCELERATOR
     exact_dtype = True
 
@@ -1897,7 +1897,7 @@ class TestUnaryUfuncsDevice(TestCase):
         self.assertEqual(got, ref)
 
 
-class TestUnaryUfuncsCUDA(TestCase):
+class TestUnaryUfuncsCUDADevice(TestCase):
     hw_classification = HardwareClassification.CUDA
 
     def test_nonzero_static_large(self, device):
@@ -1955,8 +1955,8 @@ class TestUnaryUfuncsCUDA(TestCase):
         self.assertEqual(y.cpu().view(torch.uint8), ref.view(torch.uint8))
 
 
-instantiate_device_type_tests(TestUnaryUfuncsDevice, globals())
-instantiate_device_type_tests(TestUnaryUfuncsCUDA, globals(), only_for="cuda")
+instantiate_device_type_tests(TestUnaryUfuncs, globals())
+instantiate_device_type_tests(TestUnaryUfuncsCUDADevice, globals(), only_for="cuda")
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary

Improve test reuse in `test/test_unary_ufuncs.py` for out-of-tree backends by replacing hardcoded device assumptions with the injected device parameter where applicable.

## Changes

- Deduplicate `unary_mem_overlap_cases` by removing per-device duplicate entries and using the injected `device` argument instead of the `dev`.
- Replace the hardcoded `device="cuda"` with the injected `device` argument.
- Keep `@onlyOn(["cpu", "cuda"])` on `test_unary_out_op_mem_overlap` to preserve the existing test coverage.
- Rename `test_tan_complex_cuda_matches_numpy` and `test_tanh_complex_cuda_matches_numpy` to device-agnostic names `test_tan_complex_matches_numpy` and `test_tanh_complex_matches_numpy`.
- Parameterize the eps value in the complex unary tests using `@parametrize("eps", [1e-3])`.

## Test plan

Verified on CUDA:

```bash
pytest test/test_unary_ufuncs.py -vvv -k "test_tan_complex or test_tanh_complex or test_unary_out_op_mem_overlap or test_nonzero_static_large"
```

- Before: 5 passed, 3 skipped, 51795 deselected in 9.04s

```bash
collected 51803 items / 51795 deselected / 8 selected                                                                                                       
Running 8 items in this shard

test/test_unary_ufuncs.py::TestUnaryUfuncsCPU::test_nonzero_static_large_cpu SKIPPED [0.0027s] (Only runs on cuda)                                    [ 12%]
test/test_unary_ufuncs.py::TestUnaryUfuncsCPU::test_tan_complex_cuda_matches_numpy_cpu_complex64 SKIPPED [0.0020s] (Only runs on cuda)                [ 25%] 
test/test_unary_ufuncs.py::TestUnaryUfuncsCPU::test_tanh_complex_cuda_matches_numpy_cpu_complex64 SKIPPED [0.0009s] (Only runs on cuda)               [ 37%] 
test/test_unary_ufuncs.py::TestUnaryUfuncsCPU::test_unary_out_op_mem_overlap_cpu_float64 PASSED [0.0256s]                                             [ 50%]
test/test_unary_ufuncs.py::TestUnaryUfuncsCUDA::test_nonzero_static_large_cuda PASSED [0.1779s]                                                       [ 62%]
test/test_unary_ufuncs.py::TestUnaryUfuncsCUDA::test_tan_complex_cuda_matches_numpy_cuda_complex64 PASSED [0.0248s]                                   [ 75%]
test/test_unary_ufuncs.py::TestUnaryUfuncsCUDA::test_tanh_complex_cuda_matches_numpy_cuda_complex64 PASSED [0.0071s]                                  [ 87%]
test/test_unary_ufuncs.py::TestUnaryUfuncsCUDA::test_unary_out_op_mem_overlap_cuda_float64 PASSED [0.2095s]                                           [100%]

====================================================== 5 passed, 3 skipped, 51795 deselected in 9.04s =======================================================
```



- After: 5 passed, 3 skipped, 51795 deselected in 9.14s

```bash
collected 51803 items / 51795 deselected / 8 selected                                                                                                       
Running 8 items in this shard

test/test_unary_ufuncs.py::TestUnaryUfuncsCPU::test_nonzero_static_large_cpu SKIPPED [0.0026s] (Only runs on cuda)                                    [ 12%]
test/test_unary_ufuncs.py::TestUnaryUfuncsCPU::test_tan_complex_matches_numpy_eps_0_001_cpu_complex64 SKIPPED [0.0022s] (Only runs on cuda)           [ 25%] 
test/test_unary_ufuncs.py::TestUnaryUfuncsCPU::test_tanh_complex_matches_numpy_cpu_complex64 SKIPPED [0.0009s] (Only runs on cuda)                    [ 37%] 
test/test_unary_ufuncs.py::TestUnaryUfuncsCPU::test_unary_out_op_mem_overlap_cpu_float64 PASSED [0.0245s]                                             [ 50%]
test/test_unary_ufuncs.py::TestUnaryUfuncsCUDA::test_nonzero_static_large_cuda PASSED [0.1945s]                                                       [ 62%]
test/test_unary_ufuncs.py::TestUnaryUfuncsCUDA::test_tan_complex_matches_numpy_eps_0_001_cuda_complex64 PASSED [0.0253s]                              [ 75%]
test/test_unary_ufuncs.py::TestUnaryUfuncsCUDA::test_tanh_complex_matches_numpy_cuda_complex64 PASSED [0.0069s]                                       [ 87%]
test/test_unary_ufuncs.py::TestUnaryUfuncsCUDA::test_unary_out_op_mem_overlap_cuda_float64 PASSED [0.1754s]                                           [100%]

====================================================== 5 passed, 3 skipped, 51795 deselected in 9.14s =======================================================
```



