### PR TITLE
vllm-benchmark: read shared HF cache offline, refresh on nightly

### DIFF
--- a/.github/workflows/_vllm-benchmark.yml
+++ b/.github/workflows/_vllm-benchmark.yml
@@ -48,8 +48,10 @@ jobs:
     container:
       image: ${{ inputs.docker_image }}
       options: --gpus all --ipc=host --tty
-      volumes:
-        - /mnt/hf_cache:/mnt/hf_cache
+      # OSDC runners get /mnt/hf_cache injected by the runner hook (declaring it here
+      # would break the hook's bind-mount check). DGX B200 (non-OSDC) has no injection,
+      # so bind-mount its writable host cache dir instead.
+      volumes: ${{ contains(inputs.runner, 'b200') && fromJSON('["/mnt/hf_cache:/mnt/hf_cache"]') || fromJSON('[]') }}
     steps:
       - name: Install system dependencies
         run: |
@@ -199,20 +201,48 @@ jobs:
           find .buildkite/performance-benchmarks/tests -type f -exec cat {} \;
           popd
 
+      - name: Resolve HF cache mode
+        shell: bash
+        run: |
+          OFFLINE=1
+          if [[ "${{ inputs.is_nightly }}" == "true" ]]; then
+            OFFLINE=0
+          fi
+          {
+            echo "TRANSFORMERS_OFFLINE=${OFFLINE}"
+            echo "HF_DATASETS_OFFLINE=${OFFLINE}"
+          } >> "${GITHUB_ENV}"
+
       - name: Run vLLM benchmark
+        id: run-benchmark
         working-directory: vllm-project/vllm
         env:
-          FLASHINFER_WORKSPACE_BASE: /mnt/hf_cache
           HF_TOKEN: ${{ secrets.VLLM_TEST_HUGGING_FACE_TOKEN }}
-          HF_HOME: /mnt/hf_cache
-          # Nightly runs download from HF to periodically refresh the local cache
-          TRANSFORMERS_OFFLINE: ${{ inputs.is_nightly && '0' || '1' }}
-          # vLLM-related environment variables
           ENGINE_VERSION: v1
           SAVE_TO_PYTORCH_BENCHMARK_FORMAT: 1
         shell: bash
         run: |
           set -eux
+
+          # HF models + FlashInfer workspace share one cache root at /mnt/hf_cache:
+          # a read-only rclone mount on OSDC, a writable host dir on DGX B200.
+          #   - offline (default): read /mnt/hf_cache in place.
+          #   - online + writable mount (B200): refresh /mnt/hf_cache in place.
+          #   - online + read-only/absent mount (OSDC): download into a writable dir
+          #     that "Refresh the HF cache in S3" syncs back to the bucket.
+          if [[ "${TRANSFORMERS_OFFLINE}" == "1" && -d /mnt/hf_cache ]]; then
+            export HF_HOME=/mnt/hf_cache
+          elif [[ -w /mnt/hf_cache ]]; then
+            export HF_HOME=/mnt/hf_cache
+            mkdir -p "${HF_HOME}/flashinfer"
+          else
+            export HF_HOME="${RUNNER_TEMP}/hf_cache"
+            mkdir -p "${HF_HOME}/flashinfer"
+            export TRANSFORMERS_OFFLINE=0
+            export HF_DATASETS_OFFLINE=0
+          fi
+          export FLASHINFER_WORKSPACE_BASE="${HF_HOME}/flashinfer"
+
           bash .buildkite/performance-benchmarks/scripts/run-performance-benchmarks.sh
 
       - name: Check the benchmark results
@@ -242,3 +272,31 @@ jobs:
           dry-run: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
           if-no-files-found: error
+
+      - name: Authenticate to refresh the HF cache in S3
+        if: always() && steps.run-benchmark.conclusion && env.TRANSFORMERS_OFFLINE == '0'
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_hf-cache-write
+          aws-region: us-east-1
+
+      - name: Refresh the HF cache in S3
+        if: always() && steps.run-benchmark.conclusion && env.TRANSFORMERS_OFFLINE == '0'
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -x
+          HF_CACHE="${RUNNER_TEMP}/hf_cache"
+          if [[ -z "${HF_CACHE_S3_BUCKET:-}" ]]; then
+            echo "HF_CACHE_S3_BUCKET unset (not an hf-cache runner) - skipping sync"
+            exit 0
+          fi
+          for sub in hub flashinfer; do
+            if [[ -d "${HF_CACHE}/${sub}" ]]; then
+              aws s3 sync "${HF_CACHE}/${sub}" "s3://${HF_CACHE_S3_BUCKET}/${sub}" \
+                --region "${HF_CACHE_S3_REGION}" --no-progress
+            else
+              echo "No ${HF_CACHE}/${sub} to sync - skipping"
+            fi
+          done

--- a/.github/workflows/_vllm-benchmark.yml
+++ b/.github/workflows/_vllm-benchmark.yml
@@ -224,24 +224,33 @@ jobs:
         run: |
           set -eux
 
-          # HF models + FlashInfer workspace share one cache root at /mnt/hf_cache:
-          # a read-only rclone mount on OSDC, a writable host dir on DGX B200.
-          #   - offline (default): read /mnt/hf_cache in place.
-          #   - online + writable mount (B200): refresh /mnt/hf_cache in place.
-          #   - online + read-only/absent mount (OSDC): download into a writable dir
-          #     that "Refresh the HF cache in S3" syncs back to the bucket.
+          # HF model cache: offline reads /mnt/hf_cache in place (read-only on OSDC,
+          # writable host dir on B200); online (nightly) downloads into a writable dir.
           if [[ "${TRANSFORMERS_OFFLINE}" == "1" && -d /mnt/hf_cache ]]; then
             export HF_HOME=/mnt/hf_cache
           elif [[ -w /mnt/hf_cache ]]; then
             export HF_HOME=/mnt/hf_cache
-            mkdir -p "${HF_HOME}/flashinfer"
           else
             export HF_HOME="${RUNNER_TEMP}/hf_cache"
-            mkdir -p "${HF_HOME}/flashinfer"
+            mkdir -p "${HF_HOME}"
             export TRANSFORMERS_OFFLINE=0
             export HF_DATASETS_OFFLINE=0
           fi
-          export FLASHINFER_WORKSPACE_BASE="${HF_HOME}/flashinfer"
+
+          # FlashInfer JIT-compiles into its workspace, so it always needs a writable
+          # dir (never the read-only OSDC mount). B200: compile in place on the host
+          # mount. OSDC: compile in a local dir warmed from the cached kernels, which
+          # the refresh step syncs back to S3 on nightly. A cold cache just recompiles.
+          if [[ -w /mnt/hf_cache ]]; then
+            export FLASHINFER_WORKSPACE_BASE=/mnt/hf_cache/flashinfer
+            mkdir -p "${FLASHINFER_WORKSPACE_BASE}"
+          else
+            export FLASHINFER_WORKSPACE_BASE="${RUNNER_TEMP}/hf_cache/flashinfer"
+            mkdir -p "${FLASHINFER_WORKSPACE_BASE}"
+            if [[ -d /mnt/hf_cache/flashinfer ]]; then
+              cp -a /mnt/hf_cache/flashinfer/. "${FLASHINFER_WORKSPACE_BASE}/" 2>/dev/null || true
+            fi
+          fi
 
           bash .buildkite/performance-benchmarks/scripts/run-performance-benchmarks.sh
 

--- a/.github/workflows/_vllm-benchmark.yml
+++ b/.github/workflows/_vllm-benchmark.yml
@@ -59,6 +59,16 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y git unzip
 
+      # OSDC runner pods reuse the workspace across jobs, leaving root-owned
+      # content that actions/checkout can't delete (uid mismatch: GH hook 1001 vs
+      # CI image 1000). Same fix as setup-linux's "Fix workspace permissions".
+      - name: Fix workspace permissions
+        if: ${{ !contains(inputs.runner, 'b200') }}
+        shell: bash
+        run: |
+          sudo chmod -R 777 "$GITHUB_WORKSPACE"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Checkout PyTorch
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/_vllm-benchmark.yml
+++ b/.github/workflows/_vllm-benchmark.yml
@@ -33,10 +33,10 @@ on:
         type: string
         description: A JSON string for vLLM --compilation-config, applied to all benchmark tests.
         default: ''
-      is_nightly:
+      refresh_hf_cache:
         required: false
         type: boolean
-        description: Whether this is a nightly scheduled run. When true, TRANSFORMERS_OFFLINE is disabled.
+        description: When true, download from HF (online) and refresh the cache; otherwise read the offline cache.
         default: false
 
 jobs:
@@ -215,7 +215,7 @@ jobs:
         shell: bash
         run: |
           OFFLINE=1
-          if [[ "${{ inputs.is_nightly }}" == "true" ]]; then
+          if [[ "${{ inputs.refresh_hf_cache }}" == "true" ]]; then
             OFFLINE=0
           fi
           {

--- a/.github/workflows/_vllm-benchmark.yml
+++ b/.github/workflows/_vllm-benchmark.yml
@@ -297,8 +297,8 @@ jobs:
         run: |
           set -x
           HF_CACHE="${RUNNER_TEMP}/hf_cache"
-          if [[ -z "${HF_CACHE_S3_BUCKET:-}" ]]; then
-            echo "HF_CACHE_S3_BUCKET unset (not an hf-cache runner) - skipping sync"
+          if [[ -z "${HF_CACHE_S3_BUCKET:-}" || -z "${HF_CACHE_S3_REGION:-}" ]]; then
+            echo "HF_CACHE_S3_BUCKET/REGION unset (not an hf-cache runner) - skipping sync"
             exit 0
           fi
           # The benchmark image may not ship the AWS CLI, so fall back to a

--- a/.github/workflows/_vllm-benchmark.yml
+++ b/.github/workflows/_vllm-benchmark.yml
@@ -92,9 +92,6 @@ jobs:
           submodules: recursive
           show-progress: false
 
-      # role/arc reads gha-artifacts and is assumable from any pytorch/pytorch OIDC
-      # (OSDC and DGX alike), so one ungated auth covers the artifact download for all
-      # runners. Results upload re-auths to upload-benchmark-results further down.
       - name: Authenticate with AWS
         uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
         with:

--- a/.github/workflows/_vllm-benchmark.yml
+++ b/.github/workflows/_vllm-benchmark.yml
@@ -42,8 +42,8 @@ on:
 jobs:
   benchmark:
     runs-on: ${{ inputs.runner }}
-    # Heavy models (e.g. int4 27B) can run for hours; raise above the 6h default.
-    timeout-minutes: 480
+    # Heavy models (e.g. int4 27B) can run ~8h+; raise well above the 6h default.
+    timeout-minutes: 600
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/_vllm-benchmark.yml
+++ b/.github/workflows/_vllm-benchmark.yml
@@ -306,7 +306,7 @@ jobs:
           AWS=aws
           if ! command -v aws >/dev/null 2>&1; then
             python3 -m venv /tmp/awscli-venv
-            /tmp/awscli-venv/bin/pip install --quiet awscli
+            /tmp/awscli-venv/bin/pip install --quiet awscli==1.45.39
             AWS=/tmp/awscli-venv/bin/aws
           fi
           for sub in hub flashinfer; do

--- a/.github/workflows/_vllm-benchmark.yml
+++ b/.github/workflows/_vllm-benchmark.yml
@@ -42,6 +42,8 @@ on:
 jobs:
   benchmark:
     runs-on: ${{ inputs.runner }}
+    # Heavy models (e.g. int4 27B) can run for hours; raise above the 6h default.
+    timeout-minutes: 480
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/_vllm-benchmark.yml
+++ b/.github/workflows/_vllm-benchmark.yml
@@ -301,9 +301,17 @@ jobs:
             echo "HF_CACHE_S3_BUCKET unset (not an hf-cache runner) - skipping sync"
             exit 0
           fi
+          # The benchmark image may not ship the AWS CLI, so fall back to a
+          # throwaway venv when it's absent.
+          AWS=aws
+          if ! command -v aws >/dev/null 2>&1; then
+            python3 -m venv /tmp/awscli-venv
+            /tmp/awscli-venv/bin/pip install --quiet awscli
+            AWS=/tmp/awscli-venv/bin/aws
+          fi
           for sub in hub flashinfer; do
             if [[ -d "${HF_CACHE}/${sub}" ]]; then
-              aws s3 sync "${HF_CACHE}/${sub}" "s3://${HF_CACHE_S3_BUCKET}/${sub}" \
+              "${AWS}" s3 sync "${HF_CACHE}/${sub}" "s3://${HF_CACHE_S3_BUCKET}/${sub}" \
                 --region "${HF_CACHE_S3_REGION}" --no-progress
             else
               echo "No ${HF_CACHE}/${sub} to sync - skipping"

--- a/.github/workflows/_vllm-benchmark.yml
+++ b/.github/workflows/_vllm-benchmark.yml
@@ -47,11 +47,12 @@ jobs:
       contents: read
     container:
       image: ${{ inputs.docker_image }}
-      # OSDC runners get /mnt/hf_cache injected by the runner hook (a bind mount here
-      # would break the hook's mount check). DGX B200 (non-OSDC) has no injection, so
-      # bind-mount its writable host cache dir via -v. Set on options (a scalar) rather
-      # than volumes (a sequence) so the conditional expression stays valid YAML.
-      options: ${{ contains(inputs.runner, 'b200') && '--gpus all --ipc=host --tty -v /mnt/hf_cache:/mnt/hf_cache' || '--gpus all --ipc=host --tty' }}
+      # OSDC runners (h100 and OSDC b200) get /mnt/hf_cache injected by the runner
+      # hook — a bind mount here would break the hook's mount check. Only non-OSDC
+      # DGX (linux.dgx.*) has no injection, so bind-mount its writable host cache dir
+      # via -v. Discriminate on 'dgx', not 'b200' (OSDC b200 behaves like h100). Set
+      # on options (a scalar) not volumes (a sequence) so the expression is valid YAML.
+      options: ${{ contains(inputs.runner, 'dgx') && '--gpus all --ipc=host --tty -v /mnt/hf_cache:/mnt/hf_cache' || '--gpus all --ipc=host --tty' }}
     steps:
       - name: Install system dependencies
         run: |
@@ -63,7 +64,7 @@ jobs:
       # content that actions/checkout can't delete (uid mismatch: GH hook 1001 vs
       # CI image 1000). Same fix as setup-linux's "Fix workspace permissions".
       - name: Fix workspace permissions
-        if: ${{ !contains(inputs.runner, 'b200') }}
+        if: ${{ !contains(inputs.runner, 'dgx') }}
         shell: bash
         run: |
           sudo chmod -R 777 "$GITHUB_WORKSPACE"
@@ -91,8 +92,8 @@ jobs:
           submodules: recursive
           show-progress: false
 
-      - name: Authenticate with AWS
-        if: ${{ always() && contains(inputs.runner, 'b200') }}
+      - name: Authenticate with AWS (DGX)
+        if: ${{ always() && contains(inputs.runner, 'dgx') }}
         uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
         with:
           role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_upload-benchmark-results
@@ -103,7 +104,7 @@ jobs:
       # OSDC runners have no ambient AWS creds; assume the ARC OIDC role so the
       # S3 artifact download below can authenticate (mirrors _linux-test test-osdc).
       - name: Authenticate with AWS (OSDC)
-        if: ${{ !contains(inputs.runner, 'b200') }}
+        if: ${{ !contains(inputs.runner, 'dgx') }}
         uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
         with:
           role-to-assume: arn:aws:iam::308535385114:role/arc

--- a/.github/workflows/_vllm-benchmark.yml
+++ b/.github/workflows/_vllm-benchmark.yml
@@ -100,6 +100,16 @@ jobs:
           role-duration-seconds: 18000
           aws-region: us-east-1
 
+      # OSDC runners have no ambient AWS creds; assume the ARC OIDC role so the
+      # S3 artifact download below can authenticate (mirrors _linux-test test-osdc).
+      - name: Authenticate with AWS (OSDC)
+        if: ${{ !contains(inputs.runner, 'b200') }}
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/arc
+          role-duration-seconds: 18000
+          aws-region: us-east-1
+
       - name: Download build artifacts
         # Full repo path, not ./ — local actions don't resolve on the OSDC ARC runner.
         uses: pytorch/pytorch/.github/actions/download-build-artifacts@main

--- a/.github/workflows/_vllm-benchmark.yml
+++ b/.github/workflows/_vllm-benchmark.yml
@@ -101,7 +101,8 @@ jobs:
           aws-region: us-east-1
 
       - name: Download build artifacts
-        uses: ./.github/actions/download-build-artifacts
+        # Full repo path, not ./ — local actions don't resolve on the OSDC ARC runner.
+        uses: pytorch/pytorch/.github/actions/download-build-artifacts@main
         with:
           name: ${{ inputs.build_environment }}
           s3-bucket: gha-artifacts

--- a/.github/workflows/_vllm-benchmark.yml
+++ b/.github/workflows/_vllm-benchmark.yml
@@ -47,11 +47,11 @@ jobs:
       contents: read
     container:
       image: ${{ inputs.docker_image }}
-      options: --gpus all --ipc=host --tty
-      # OSDC runners get /mnt/hf_cache injected by the runner hook (declaring it here
-      # would break the hook's bind-mount check). DGX B200 (non-OSDC) has no injection,
-      # so bind-mount its writable host cache dir instead.
-      volumes: ${{ contains(inputs.runner, 'b200') && fromJSON('["/mnt/hf_cache:/mnt/hf_cache"]') || fromJSON('[]') }}
+      # OSDC runners get /mnt/hf_cache injected by the runner hook (a bind mount here
+      # would break the hook's mount check). DGX B200 (non-OSDC) has no injection, so
+      # bind-mount its writable host cache dir via -v. Set on options (a scalar) rather
+      # than volumes (a sequence) so the conditional expression stays valid YAML.
+      options: ${{ contains(inputs.runner, 'b200') && '--gpus all --ipc=host --tty -v /mnt/hf_cache:/mnt/hf_cache' || '--gpus all --ipc=host --tty' }}
     steps:
       - name: Install system dependencies
         run: |

--- a/.github/workflows/_vllm-benchmark.yml
+++ b/.github/workflows/_vllm-benchmark.yml
@@ -92,19 +92,10 @@ jobs:
           submodules: recursive
           show-progress: false
 
-      - name: Authenticate with AWS (DGX)
-        if: ${{ always() && contains(inputs.runner, 'dgx') }}
-        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
-        with:
-          role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_upload-benchmark-results
-          # The max duration enforced by the server side
-          role-duration-seconds: 18000
-          aws-region: us-east-1
-
-      # OSDC runners have no ambient AWS creds; assume the ARC OIDC role so the
-      # S3 artifact download below can authenticate (mirrors _linux-test test-osdc).
-      - name: Authenticate with AWS (OSDC)
-        if: ${{ !contains(inputs.runner, 'dgx') }}
+      # role/arc reads gha-artifacts and is assumable from any pytorch/pytorch OIDC
+      # (OSDC and DGX alike), so one ungated auth covers the artifact download for all
+      # runners. Results upload re-auths to upload-benchmark-results further down.
+      - name: Authenticate with AWS
         uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
         with:
           role-to-assume: arn:aws:iam::308535385114:role/arc

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -133,5 +133,5 @@ jobs:
       pytorch_commit: ${{ inputs.pytorch_commit }}
       models: ${{ matrix.models }}
       compilation_config: ${{ inputs.compilation_config }}
-      is_nightly: ${{ github.event_name == 'schedule' || inputs.refresh_hf_cache }}
+      refresh_hf_cache: ${{ inputs.refresh_hf_cache || false }}
     secrets: inherit

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -32,6 +32,12 @@ on:
         required: true
         type: string
         default: h100,b200
+      refresh_hf_cache:
+        description: |
+          Download models from HF (online) and sync the shared HF cache back to S3, instead of reading the offline cache. Scheduled runs always refresh.
+        required: false
+        type: boolean
+        default: false
   schedule:
     # Run daily at 5:15 AM PST
     - cron: '15 13 * * *'
@@ -127,5 +133,5 @@ jobs:
       pytorch_commit: ${{ inputs.pytorch_commit }}
       models: ${{ matrix.models }}
       compilation_config: ${{ inputs.compilation_config }}
-      is_nightly: ${{ github.event_name == 'schedule' }}
+      is_nightly: ${{ github.event_name == 'schedule' || inputs.refresh_hf_cache }}
     secrets: inherit


### PR DESCRIPTION
Mirror the `test-osdc` HF-cache pattern (#188654) in the vLLM benchmark: offline reads the shared read-only `/mnt/hf_cache`; nightly refreshes it — in place on DGX B200 (writable host mount) or download + `aws s3 sync` back to the bucket on OSDC. FlashInfer's JIT workspace is cached the same way (warmed from the shared cache, synced on nightly) but always compiles into a writable dir, since the OSDC mount is read-only.

The unconditional `/mnt/hf_cache` bind mount is dropped on OSDC — the runner hook already injects a read-only mount, and the extra bind mount made `runner-container-hooks` fail `lstat('/mnt/hf_cache')` in the runner pod, failing every run and retry. It's kept only for non-OSDC B200, which has no injection and needs the host bind mount.

### Testing

https://github.com/pytorch/pytorch/actions/runs/28606132504

Another round

https://github.com/pytorch/pytorch/actions/runs/28621594034

Everything

https://github.com/pytorch/pytorch/actions/runs/28639471616
