### PR TITLE
Fix `int32` overflow in `embedding_bag(mode="max")` backward pass

### DIFF
--- a/aten/src/ATen/native/cuda/EmbeddingBag.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBag.cu
@@ -246,7 +246,7 @@ template <typename scalar_t, typename index_t>
 __global__ void EmbeddingBag_accGradParametersKernel_max(
     const index_t *max_indices, const scalar_t *gradOutput,
     scalar_t *gradWeight, int64_t stride, int64_t numBags,
-    index_t padding_idx, const index_t numel) {
+    index_t padding_idx, const int64_t numel) {
 
   using accscalar_t = acc_type<scalar_t, true>;
 
@@ -264,7 +264,7 @@ __global__ void EmbeddingBag_accGradParametersKernel_max(
       if (word_idx >= 0 && word_idx != padding_idx) {
         // If bag is empty, we have max_indices[idx] set to -1 in forward.
         fastAtomicAdd(
-            gradWeight, static_cast<index_t>(word_idx * stride + featureDim),
+            gradWeight, static_cast<int64_t>(word_idx) * stride + featureDim,
             numel, gradOutput[bag * stride + featureDim], true);
       }
     }

--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -963,6 +963,29 @@ class TestEmbeddingNNDeviceType(NNTestCase):
                 f"Expected grad_weight.dtype == torch.bfloat16, got {grad_weight.dtype}"
             )
 
+    # https://github.com/pytorch/pytorch/issues/188467
+    @onlyOn(["cuda"])
+    @dtypes(torch.int32, torch.int64)
+    @largeTensorTest("20GB", device="cuda")
+    def test_embedding_bag_max_backward_large_offset_overflow(self, device, dtype):
+        # chosen to guarantee an int32 overflow
+        dim = 2**16
+        r = 2**15
+
+        def grad_at_r(idx_dtype):
+            w = torch.zeros(r + 1, dim, device=device, requires_grad=True)
+
+            # make the final row contain the matrix's max value
+            with torch.no_grad():
+                w[r, :] = 1.0
+
+            idx = torch.tensor([0, r], device=device, dtype=idx_dtype)
+            off = torch.tensor([0], device=device, dtype=idx_dtype)
+            F.embedding_bag(idx, w, off, mode="max").sum().backward()
+            return w.grad[r].clone()
+
+        torch.testing.assert_close(torch.ones(dim, device=device), grad_at_r(dtype))
+
     # Check correctness of torch.nn.functional.embedding_bag forward and
     # backward functions with padding_idx, given a 2D indices input. Compare
     # against torch.nn.functional.embedding followed by a reduction.


### PR DESCRIPTION
The `embedding_bag(mode="max")` backwards pass overflows for the `int32` indices. 

Fixes https://github.com/pytorch/pytorch/issues/188467