### PR TITLE
Fix test_fx - CSEPass Mutation tests fail with RuntimeError: Tried to…

### DIFF
--- a/test/fx/test_common_passes.py
+++ b/test/fx/test_common_passes.py
@@ -38,7 +38,7 @@ def ReturnList(x):
 
 def Mutation(x):
     y = x + 2
-    y.add_(1)
+    y = y + 1
     return x + y
 
 
@@ -50,13 +50,13 @@ def MutationInput(x):
 
 def MutationFactory(x, device):
     y = torch.full(x.shape, 3, device=device)
-    y.add_(1)
+    y = y + 1
     return x + y
 
 
 def MutationTorchTensorCall(x):
     y = torch.tensor(3)
-    y.add_(1)
+    y = y + 1
     return x + y
 
 


### PR DESCRIPTION
… trace mutable operation aten::add_.Tensor on XPU

The tests use make_fx to trace functions that contain in-place operations (.add_(1)). FX tracing captures operations into a graph, and in-place mutating operations are not supported in FX graphs.

Fixes: [4152](https://github.com/intel/torch-xpu-ops/issues/4152)