### PR TITLE
Enable xpu for TestWrapperSubclassAliasing.

### DIFF
--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -2926,7 +2926,7 @@ class TestWrapperSubclassAliasing(TestCase):
             self._test_wrapper_subclass_aliasing(torch.ops.aten.fft_fft2, args, kwargs)
 
 
-instantiate_device_type_tests(TestWrapperSubclassAliasing, globals())
+instantiate_device_type_tests(TestWrapperSubclassAliasing, globals(), allow_xpu=True)
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
For https://github.com/pytorch/pytorch/issues/114850, we will port distributed tests to Intel GPU.
We could enable Intel GPU with following methods and try the best to keep the original code styles:

use "instantiate_device_type_tests" to enabl XPU for some test path

cc @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @aditvenk @weifengpy @xmfan @H-Huang @ezyang @gujinghui @EikanWang @fengyuan14 @guangyey