### PR TITLE
Enable xpu for TestRefs and TestDecomp.

### DIFF
--- a/test/test_prims.py
+++ b/test/test_prims.py
@@ -436,7 +436,7 @@ class TestRefs(TestCase):
 
 
 
-instantiate_device_type_tests(TestRefs, globals())
+instantiate_device_type_tests(TestRefs, globals(), allow_xpu=True)
 
 
 class TestDecomp(TestCase):
@@ -482,7 +482,7 @@ class TestDecomp(TestCase):
         self.assertEqual(res, expected)
 
 
-instantiate_device_type_tests(TestDecomp, globals())
+instantiate_device_type_tests(TestDecomp, globals(), allow_xpu=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
For https://github.com/pytorch/pytorch/issues/114850, we will port distributed tests to Intel GPU.
We could enable Intel GPU with following methods and try the best to keep the original code styles:

use "instantiate_device_type_tests" to enabl XPU for some test path

cc @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @pragupta @msaroufim @dcci @aditvenk @weifengpy @xmfan @H-Huang @ezyang @gujinghui @EikanWang @fengyuan14 @guangyey