### PR TITLE
[ROCm] Fixed memory errors in SymmetricMemory caused by repeated call of hipMemMap

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryUtils.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryUtils.cpp
@@ -291,12 +291,6 @@ void map_block(
       0,
       reinterpret_cast<hipMemGenericAllocationHandle_t>(handle),
       0ULL));
-  C10_CUDA_CHECK(hipMemMap(
-      *ptr,
-      size,
-      0,
-      reinterpret_cast<hipMemGenericAllocationHandle_t>(handle),
-      0ULL));
 
   hipMemAccessDesc desc;
   desc.location.type = hipMemLocationTypeDevice;


### PR DESCRIPTION
Repeated call of hipMemMap is causing the errors in SymmetricMemory. Fixing that.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang