### PR TITLE
[inductor] Fix circular import between quantized_lowerings and lowering

### DIFF
--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -9342,11 +9342,13 @@ import_submodule(kernel)
 from . import (
     jagged_lowerings,
     mkldnn_lowerings,  # noqa: F401  # registers oneDNN fusion ops on import
-    quantized_lowerings,  # noqa: F401  # registers quantized ops on import
+    quantized_lowerings,
 )
 
 
 jagged_lowerings.register_jagged_ops()
+quantized_lowerings.register_quantized_ops()
+quantized_lowerings.register_woq_mm_ops()
 
 
 @contextlib.contextmanager

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -9339,15 +9339,10 @@ from . import kernel
 
 import_submodule(kernel)
 
-from . import quantized_lowerings
-
-
-quantized_lowerings.register_quantized_ops()
-quantized_lowerings.register_woq_mm_ops()
-
 from . import (
     jagged_lowerings,
     mkldnn_lowerings,  # noqa: F401  # registers oneDNN fusion ops on import
+    quantized_lowerings,  # noqa: F401  # registers quantized ops on import
 )
 
 

--- a/torch/_inductor/quantized_lowerings.py
+++ b/torch/_inductor/quantized_lowerings.py
@@ -4,10 +4,9 @@ from typing import Any
 import torch
 from torch._inductor.kernel.mm_common import mm_args
 
-from . import config, lowering
+from . import config
 from .codegen.cpp_gemm_template import CppGemmTemplate, CppWoqInt4GemmTemplate
 from .codegen.cpp_utils import create_epilogue_with_attr
-from .lowering import expand, register_lowering
 from .mkldnn_ir import WeightInt4PackMatmul
 from .select_algorithm import (
     autotune_select_algorithm,
@@ -37,6 +36,8 @@ aten = torch.ops.aten
 
 
 def register_quantized_ops() -> None:
+    from . import lowering
+
     lowering.add_needs_realized_inputs(
         [
             quantized.max_pool2d,
@@ -50,6 +51,10 @@ def register_quantized_ops() -> None:
 
 
 def register_woq_mm_ops() -> None:
+    """Register weight-only quantized matmul lowerings."""
+    from . import lowering
+    from .lowering import expand, register_lowering
+
     @register_lowering(aten._weight_int8pack_mm, type_promotion_kind=None)  # type: ignore[misc]
     def int8pack_mm(
         input: torch.Tensor,
@@ -178,7 +183,3 @@ def register_woq_mm_ops() -> None:
 
     lowering.make_fallback(aten._dyn_quant_matmul_4bit)
     lowering.make_fallback(aten._dyn_quant_pack_4bit_weight)
-
-
-register_quantized_ops()
-register_woq_mm_ops()

--- a/torch/_inductor/quantized_lowerings.py
+++ b/torch/_inductor/quantized_lowerings.py
@@ -178,3 +178,7 @@ def register_woq_mm_ops() -> None:
 
     lowering.make_fallback(aten._dyn_quant_matmul_4bit)
     lowering.make_fallback(aten._dyn_quant_pack_4bit_weight)
+
+
+register_quantized_ops()
+register_woq_mm_ops()


### PR DESCRIPTION
Similar change to https://github.com/pytorch/pytorch/pull/182189

Encountered this problem in this CI job: https://github.com/pytorch/pytorch/actions/runs/28511622872/job/84516440058?pr=186204.

```txt
=================================== FAILURES ===================================
____________________ TestImports.test_circular_dependencies ____________________
Traceback (most recent call last):
  File "/var/lib/jenkins/workspace/test/test_testing.py", line 2518, in test_circular_dependencies
    mod = importlib.import_module(mod_name)
  File "/opt/conda/envs/py_3.10/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/torch/_inductor/quantized_lowerings.py", line 7, in <module>
    from . import config, lowering
  File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/torch/_inductor/lowering.py", line 9345, in <module>
    quantized_lowerings.register_quantized_ops()
AttributeError: partially initialized module 'torch._inductor.quantized_lowerings' has no attribute 'register_quantized_ops' (most likely due to a circular import)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/var/lib/jenkins/workspace/test/test_testing.py", line 2520, in test_circular_dependencies
    raise RuntimeError(f"Failed to import {mod_name}: {e}") from e
RuntimeError: Failed to import torch._inductor.quantized_lowerings: partially initialized module 'torch._inductor.quantized_lowerings' has no attribute 'register_quantized_ops' (most likely due to a circular import)

To execute this test, run the following from the base repo dir:
    PYTORCH_TEST_WITH_ROCM=1 python test/test_testing.py TestImports.test_circular_dependencies
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo