### PR TITLE
[Inductor] Use CUDA toolkit's libdevice by default, fallback to Triton's bundled if not found

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -3044,16 +3044,18 @@ class eager_numerics:
 
     disable_ftz: bool = False
 
-    # Use the CUDA toolkit's libdevice instead of Triton's bundled version.
-    # Triton bundles its own libdevice.10.bc which may use different polynomial
-    # approximations than the installed CUDA toolkit, causing ~1 ULP differences
-    # in transcendental functions such as pow and erf.  The erf difference is
-    # particularly visible in explicit GELU kernels
-    # (0.5 * x * (1 + erf(x * sqrt(0.5)))) where a 1 ULP change in erf output
-    # can flip the result of a subsequent ceil(log2(...)) and produce a
-    # different uint8 encoded value (see gh-178045).
-    # This can be enabled directly; Inductor also enables it while
-    # emulate_precision_casts is active.
+    # Require CUDA toolkit libdevice behavior for eager-like numerics.
+    # Inductor prefers the CUDA toolkit's libdevice over Triton's bundled
+    # libdevice by default when the toolkit file is discoverable.  This flag
+    # still controls numerics-sensitive libdevice routing and requests a warning
+    # if the toolkit libdevice cannot be found.  Triton's bundled libdevice.10.bc
+    # may use different polynomial approximations than the installed CUDA
+    # toolkit, causing ~1 ULP differences in transcendental functions such as
+    # pow and erf.  The erf difference is particularly visible in explicit GELU
+    # kernels (0.5 * x * (1 + erf(x * sqrt(0.5)))) where a 1 ULP change in erf
+    # output can flip the result of a subsequent ceil(log2(...)) and produce a
+    # different uint8 encoded value (see gh-178045).  Inductor also enables this
+    # while emulate_precision_casts is active.
     use_pytorch_libdevice: bool = False
 
 

--- a/torch/_inductor/runtime/compile_tasks.py
+++ b/torch/_inductor/runtime/compile_tasks.py
@@ -53,22 +53,25 @@ def _set_triton_ptxas_path() -> None:
 
 def _set_triton_libdevice_path() -> None:
     """
-    Use the CUDA toolkit's libdevice instead of Triton's bundled version.
-    This ensures Triton's libdevice calls match CUDA eager numerics for bitwise
-    precision.  Gated by config.eager_numerics.use_pytorch_libdevice and by
-    config.emulate_precision_casts, which also requests eager-like numerics.
+    Prefer the CUDA toolkit's libdevice instead of Triton's bundled version.
+    Triton's bundled libdevice can lag the installed CUDA toolkit.  Missing
+    toolkit libdevice only warns when eager-like numerics explicitly require it.
     """
     from torch._inductor import config
 
-    if not (
+    require_toolkit_libdevice = (
         config.eager_numerics.use_pytorch_libdevice or config.emulate_precision_casts
-    ):
-        return
+    )
 
-    _set_triton_libdevice_path_impl()
+    _set_triton_libdevice_path_impl(
+        require_toolkit_libdevice=require_toolkit_libdevice,
+    )
 
 
-def _set_triton_libdevice_path_impl() -> None:
+def _set_triton_libdevice_path_impl(
+    *,
+    require_toolkit_libdevice: bool,
+) -> None:
     import torch
 
     if torch.version.cuda is None:
@@ -91,35 +94,45 @@ def _set_triton_libdevice_path_impl() -> None:
         from torch.utils.cpp_extension import CUDA_HOME
 
         if CUDA_HOME is None:
-            warnings.warn(
-                "CUDA_HOME not set; using Triton's bundled libdevice which may "
-                "cause minor precision differences in pow operations. "
-                "To fix: set TRITON_LIBDEVICE_PATH to your CUDA toolkit's libdevice, "
-                "e.g., export TRITON_LIBDEVICE_PATH=/usr/local/cuda/nvvm/libdevice/libdevice.10.bc",
-                stacklevel=3,
-            )
+            if require_toolkit_libdevice:
+                warnings.warn(
+                    "CUDA_HOME not set; using Triton's bundled libdevice which may "
+                    "cause minor precision differences in pow operations. "
+                    "To fix: set TRITON_LIBDEVICE_PATH to your CUDA "
+                    "toolkit's libdevice, "
+                    "e.g., export TRITON_LIBDEVICE_PATH=/usr/local/cuda/nvvm/"
+                    "libdevice/libdevice.10.bc",
+                    stacklevel=3,
+                )
             return
         libdevice = Path(CUDA_HOME) / "nvvm" / "libdevice" / "libdevice.10.bc"
         if libdevice.is_file():
             knobs.nvidia.libdevice_path = str(libdevice)
             # Also set env var so subprocess compile workers inherit it
             os.environ["TRITON_LIBDEVICE_PATH"] = str(libdevice)
-        else:
+        elif require_toolkit_libdevice:
             warnings.warn(
                 f"CUDA libdevice not found at {libdevice}; using Triton's bundled "
-                "libdevice which may cause minor precision differences in pow operations. "
-                "To fix: set TRITON_LIBDEVICE_PATH to your CUDA toolkit's libdevice, "
-                "e.g., export TRITON_LIBDEVICE_PATH=/usr/local/cuda/nvvm/libdevice/libdevice.10.bc",
+                "libdevice which may cause minor precision "
+                "differences in pow operations. "
+                "To fix: set TRITON_LIBDEVICE_PATH to your CUDA "
+                "toolkit's libdevice, "
+                "e.g., export TRITON_LIBDEVICE_PATH=/usr/local/cuda/nvvm/"
+                "libdevice/libdevice.10.bc",
                 stacklevel=3,
             )
     except ImportError:
-        warnings.warn(
-            "torch.utils.cpp_extension not available; using Triton's bundled "
-            "libdevice which may cause minor precision differences in pow operations. "
-            "To fix: set TRITON_LIBDEVICE_PATH to your CUDA toolkit's libdevice, "
-            "e.g., export TRITON_LIBDEVICE_PATH=/usr/local/cuda/nvvm/libdevice/libdevice.10.bc",
-            stacklevel=3,
-        )
+        if require_toolkit_libdevice:
+            warnings.warn(
+                "torch.utils.cpp_extension not available; using Triton's bundled "
+                "libdevice which may cause minor precision "
+                "differences in pow operations. "
+                "To fix: set TRITON_LIBDEVICE_PATH to your CUDA "
+                "toolkit's libdevice, "
+                "e.g., export TRITON_LIBDEVICE_PATH=/usr/local/cuda/nvvm/"
+                "libdevice/libdevice.10.bc",
+                stacklevel=3,
+            )
 
 
 def _worker_compile_pycodecache_kernel(


### PR DESCRIPTION
For https://github.com/pytorch/pytorch/issues/188672

The main motivation is to use the most current compatible CUDA libdevice.10.bc available on the system. Triton bundles its own copy of libdevice.10.bc, but that **bundled copy can lag the installed CUDA toolkit**. When it lags, Inductor-generated Triton kernels may **miss fixes, numerical updates, or target-specific codegen improvements** that are already present in the CUDA toolkit libdevice.

A concrete example is optimized branchless tanh introduced since cuda-12.8, the toolkit version leads to 1.24x speedup for `F.gelu(x + bias, approximate="tanh")`. on GB200.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo