### PR TITLE
FakeTensorModeTLS

### DIFF
--- a/c10/core/impl/FakeTensorModeTLS.cpp
+++ b/c10/core/impl/FakeTensorModeTLS.cpp
@@ -1,0 +1,43 @@
+#include <c10/core/impl/FakeTensorModeTLS.h>
+#include <c10/core/impl/LocalDispatchKeySet.h>
+
+namespace c10::impl {
+
+static thread_local std::shared_ptr<FakeTensorMode> fakeTensorModeState;
+
+void FakeTensorModeTLS::set_state(std::shared_ptr<FakeTensorMode> state) {
+  if (state) {
+    tls_set_dispatch_key_included(DispatchKey::Fake, true);
+  } else {
+    reset_state();
+    return;
+  }
+  fakeTensorModeState = std::move(state);
+}
+
+void FakeTensorModeTLS::create_state(std::shared_ptr<FakeTensorMode> state) {
+  fakeTensorModeState = std::move(state);
+}
+
+void FakeTensorModeTLS::activate() {
+  TORCH_INTERNAL_ASSERT(
+      fakeTensorModeState, "activate() called with no FakeTensorMode state");
+  tls_set_dispatch_key_included(DispatchKey::Fake, true);
+}
+
+void FakeTensorModeTLS::deactivate() {
+  TORCH_INTERNAL_ASSERT(
+      fakeTensorModeState, "deactivate() called with no FakeTensorMode state");
+  tls_set_dispatch_key_included(DispatchKey::Fake, false);
+}
+
+std::shared_ptr<FakeTensorMode> FakeTensorModeTLS::get_state() {
+  return fakeTensorModeState;
+}
+
+void FakeTensorModeTLS::reset_state() {
+  fakeTensorModeState = nullptr;
+  tls_set_dispatch_key_included(DispatchKey::Fake, false);
+}
+
+} // namespace c10::impl

--- a/c10/core/impl/FakeTensorModeTLS.h
+++ b/c10/core/impl/FakeTensorModeTLS.h
@@ -1,0 +1,17 @@
+#pragma once
+#include <c10/core/TensorImpl.h>
+#include <c10/macros/Export.h>
+
+namespace c10::impl {
+
+class C10_API FakeTensorModeTLS {
+ public:
+  static void set_state(std::shared_ptr<FakeTensorMode> state);
+  static void create_state(std::shared_ptr<FakeTensorMode> state);
+  static void activate();
+  static void deactivate();
+  static std::shared_ptr<FakeTensorMode> get_state();
+  static void reset_state();
+};
+
+} // namespace c10::impl


### PR DESCRIPTION
this PR adds two new files for `FakeTensorModeTLS` which will hold the C++ FakeTensorMode state. this follows the pattern of other TLS files in https://github.com/pytorch/pytorch/tree/main/c10/core/impl