### PR TITLE
[TEST] Account for debug-build assert in `test_stream_invalid_device_index

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1411,8 +1411,8 @@ print(t.is_pinned())
         # out-of-range device_index must not OOB-index the static stream pool.
         num_devices = torch.cuda.device_count()
         for di in (-2, -8, num_devices, num_devices + 16, 128):
-            s = torch.cuda.Stream(stream_id=3, device_index=di, device_type=1)
-            with self.assertRaisesRegex(RuntimeError, "Device index value"):
+            with self.assertRaisesRegex(RuntimeError, "Device index (must be|value)"):
+                s = torch.cuda.Stream(stream_id=3, device_index=di, device_type=1)
                 _ = s.cuda_stream
 
     def test_stream_event_repr(self):


### PR DESCRIPTION
for https://github.com/pytorch/pytorch/issues/188691

debug builds have an assert that fires earlier in `c10/core/Device.h`, move the stream construction within the context manager and handle its assert message, otherwise we see failures like https://www.torch-ci.com/failure?failureCaptures=%5B%22test%2Ftest_cuda.py%3A%3ATestCuda%3A%3Atest_stream_invalid_device_index%22%5D in debug builds

authored with Codex

cc @mruberry