### PR TITLE
[ROCm] Enable cholesky_ex via hipSOLVER xgeev (ROCm >= 7.14) & remove Magma dependency for autogenerated tests

### DIFF
--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
@@ -1283,6 +1283,7 @@ void linalg_eig_kernel(Tensor& eigenvalues, Tensor& eigenvectors, Tensor& infos,
   _warn_once_magma_deprecation("linalg.eig");
   linalg_eig_cusolver_xgeev(eigenvalues, eigenvectors, input, infos, compute_eigenvectors);
 #else
+  // hipSolver < 3.5.0 does not have `geev`
   _warn_once_magma_deprecation("linalg.eig", /*force_cusolver=*/false);
   linalg_eig_magma(eigenvalues, eigenvectors, infos, input, compute_eigenvectors);
 #endif

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
@@ -1541,7 +1541,8 @@ void linalg_eigh_cusolver(const Tensor& eigenvalues, const Tensor& eigenvectors,
 #endif
 }
 
-// cuSOLVER Xgeev (requires cuSOLVER >= 11.7.2, i.e. CUDA 12.8+; requires ROCm >= 7.14 for hipsolver)
+// cuSOLVER Xgeev (requires cuSOLVER >= 11.7.2, i.e. CUDA 12.8+)
+// hipSOLVER Xgeev (requires ROCm >= 7.14)
 #if (defined(CUSOLVER_VERSION) && (CUSOLVER_VERSION >= 11702)) || (defined(USE_ROCM) && ROCM_VERSION >= 71400)
 
 template <typename scalar_t>

--- a/aten/src/ATen/native/cuda/linalg/CUDASolver.cpp
+++ b/aten/src/ATen/native/cuda/linalg/CUDASolver.cpp
@@ -1805,6 +1805,7 @@ void xsyevd<c10::complex<double>, double>(
 #endif // USE_CUSOLVER_64_BIT
 
 // cuSOLVER Xgeev bindings (requires cuSOLVER >= 11.7.2, i.e. CUDA 12.8+)
+// hipSOLVER Xgeev bindings (requires ROCm >= 7.14)
 #if (defined(CUSOLVER_VERSION) && (CUSOLVER_VERSION >= 11702)) || (defined(USE_ROCM) && ROCM_VERSION >= 71400)
 
 template <>

--- a/aten/src/ATen/native/cuda/linalg/CUDASolver.h
+++ b/aten/src/ATen/native/cuda/linalg/CUDASolver.h
@@ -651,8 +651,6 @@ void xsyevd<c10::complex<double>, double>(
 
 #endif // USE_CUSOLVER_64_BIT
 
-#endif // USE_CUSOLVER_64_BIT
-
 // cuSOLVER Xgeev (non-Hermitian eigen decomposition, CUDA >= 12.8)
 // hipSOLVER Xgeev (non-Hermitian eigen decomposition, ROCm >= 7.14)
 #if (defined(CUSOLVER_VERSION) && (CUSOLVER_VERSION >= 11702)) || (defined(USE_ROCM) && ROCM_VERSION >= 71400)

--- a/aten/src/ATen/native/cuda/linalg/CUDASolver.h
+++ b/aten/src/ATen/native/cuda/linalg/CUDASolver.h
@@ -651,7 +651,10 @@ void xsyevd<c10::complex<double>, double>(
 
 #endif // USE_CUSOLVER_64_BIT
 
+#endif // USE_CUSOLVER_64_BIT
+
 // cuSOLVER Xgeev (non-Hermitian eigen decomposition, CUDA >= 12.8)
+// hipSOLVER Xgeev (non-Hermitian eigen decomposition, ROCm >= 7.14)
 #if (defined(CUSOLVER_VERSION) && (CUSOLVER_VERSION >= 11702)) || (defined(USE_ROCM) && ROCM_VERSION >= 71400)
 
 #define CUDASOLVER_XGEEV_BUFFERSIZE_ARGTYPES(scalar_t)                        \

--- a/test/inductor/test_compile_subprocess.py
+++ b/test/inductor/test_compile_subprocess.py
@@ -83,11 +83,6 @@ test_failures = {
     ),
 }
 
-if TEST_WITH_ROCM and not torch.cuda.has_magma:
-    test_failures["test_linalg_eig_stride_consistency"] = TestFailure(
-        ("cuda",), is_skip=True
-    )
-
 
 class TestSubprocess(TestCase):
     def setUp(self):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -7849,10 +7849,6 @@ for dtype in (torch.int32, torch.int64):
             reference_in_float=False,
         )
 
-    @unittest.skipIf(
-        TEST_WITH_ROCM and not torch.cuda.has_magma,
-        "ROCm hipsolver backend does not currently support eig",
-    )
     @xfail_if_mps_unimplemented  # aten::linalg_eig not implemented for MPS
     @skipIfNoLapack
     def test_linalg_eig_stride_consistency(self):

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -33,7 +33,7 @@ from torch.testing._internal.common_utils import \
 from torch.testing._internal.common_device_type import \
     (instantiate_device_type_tests, dtypes, has_cusolver, onlyCPU, skipCPUIfNoLapack, precisionOverride,
      skipCUDAIf,
-     skipCUDAIfNoCusolver, skipCUDAIfNoMagmaAndNoCusolver, skipCUDAIfNoMagmaAndNoLinalgsolver, onlyNativeDeviceTypes, dtypesIfCUDA,
+     skipCUDAIfNoCusolver, skipCUDAIfNoMagmaAndNoLinalgsolver, onlyNativeDeviceTypes, dtypesIfCUDA,
      onlyCUDA, onlyAccelerator, skipMeta, skipCUDAIfNotRocm, dtypesIfMPS, largeTensorTest,
      e4m3_type, e5m2_type)
 from torch.testing import make_tensor
@@ -697,7 +697,7 @@ class TestLinalg(TestCase):
             with self.assertRaisesRegex(RuntimeError, "Expected all tensors to be on the same device"):
                 torch.linalg.cholesky(A, out=out)
 
-    @skipCUDAIfNoMagmaAndNoCusolver
+    @skipCUDAIfNoMagmaAndNoLinalgsolver
     @skipCPUIfNoLapack
     @dtypes(*floating_and_complex_types())
     def test_cholesky_ex(self, device, dtype):

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -28,9 +28,10 @@ from torch.testing._internal.common_dtype import (
     highest_precision_float,
 )
 from torch.testing._internal.common_device_type import (
-    onlyCPU, onlyCUDA, onlyNativeDeviceTypes, disablecuDNN, skipCUDAIfNoMagma, skipCUDAIfNoMagmaAndNoCusolver,
+    onlyCPU, onlyCUDA, onlyNativeDeviceTypes, disablecuDNN,
     skipCUDAIfNoCusolver, skipCPUIfNoLapack, skipCPUIfNoFFT, skipCUDAIf, precisionOverride,
     skipCPUIfNoMklSparse, toleranceOverride, tol, skipXPU, e4m3_type, E4M3_MAX_POS, E5M2_MAX_POS,
+    skipCUDAIfNoMagmaAndNoLinalgsolver,
 )
 from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_FLASH_ATTENTION, PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
@@ -13834,7 +13835,7 @@ op_db: list[OpInfo] = [
            sample_inputs_func=sample_inputs_linalg_cholesky_inverse,
            gradcheck_wrapper=gradcheck_wrapper_triangular_input_real_positive_diagonal,
            decorators=[
-               skipCUDAIfNoMagma,
+               skipCUDAIfNoMagmaAndNoLinalgsolver,
                skipCPUIfNoLapack,
                DecorateInfo(
                    toleranceOverride({
@@ -13879,7 +13880,7 @@ op_db: list[OpInfo] = [
            supports_forward_ad=True,
            supports_fwgrad_bwgrad=True,
            gradcheck_wrapper=lambda *args, **kwargs: gradcheck_wrapper_triangular_input(*args, idx=1, **kwargs),
-           decorators=[skipCUDAIfNoMagma, skipCPUIfNoLapack],
+           decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack],
            skips=(
                # https://github.com/pytorch/pytorch/issues/165294
                DecorateInfo(skipIfRocm, "TestCommon", "test_noncontiguous_samples", dtypes=(torch.complex64,)),
@@ -14910,7 +14911,7 @@ op_db: list[OpInfo] = [
     OpInfo('geqrf',
            dtypes=floating_and_complex_types(),
            sample_inputs_func=sample_inputs_linalg_qr_geqrf,
-           decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack],
+           decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack],
            supports_autograd=False,
            skips=(
                # FIXME: geqrf can't forward with complex inputs that require grad
@@ -15287,7 +15288,7 @@ op_db: list[OpInfo] = [
            # https://github.com/pytorch/pytorch/issues/66357
            check_batched_forward_grad=False,
            sample_inputs_func=sample_inputs_lu,
-           decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack],
+           decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack],
            skips=(
                # we skip jit tests because `lu` is a torch function
                # RuntimeError:
@@ -15324,7 +15325,7 @@ op_db: list[OpInfo] = [
                DecorateInfo(unittest.expectedFailure, 'TestCommon', device_type='mps', dtypes=(torch.complex64,)),
                DecorateInfo(unittest.skip("Tests different backward paths"),
                             "TestCommon", "test_floating_inputs_are_differentiable"),),
-           decorators=[skipCPUIfNoLapack, skipCUDAIfNoMagmaAndNoCusolver]),
+           decorators=[skipCPUIfNoLapack, skipCUDAIfNoMagmaAndNoLinalgsolver]),
     OpInfo('masked_fill',
            dtypes=all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16, torch.chalf),
            dtypesIfHpu=custom_types(torch.float32, torch.bfloat16, torch.int8, torch.bool, torch.int32),
@@ -19722,7 +19723,7 @@ op_db: list[OpInfo] = [
            supports_fwgrad_bwgrad=True,
            gradcheck_wrapper=lambda *args, **kwargs: gradcheck_wrapper_triangular_input(*args, idx=1, **kwargs),
            decorators=[
-               skipCUDAIfNoMagma,
+               skipCUDAIfNoMagmaAndNoLinalgsolver,
                skipCPUIfNoLapack,
                DecorateInfo(
                    toleranceOverride({torch.float32: tol(atol=3e-5, rtol=3e-6)}),
@@ -20033,7 +20034,7 @@ op_db: list[OpInfo] = [
            # We're using at::allclose, which does not have a batching rule
            check_batched_grad=False,
            check_batched_gradgrad=False,
-           decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack, with_tf32_off],
+           decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack, with_tf32_off],
            skips=(
                # Issue with conj and torch dispatch, see https://github.com/pytorch/pytorch/issues/82479
                DecorateInfo(
@@ -20357,7 +20358,7 @@ op_db: list[OpInfo] = [
            gradcheck_nondet_tol=GRADCHECK_NONDET_TOL,
            supports_out=False,
            sample_inputs_func=sample_inputs_linalg_invertible,
-           decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack],
+           decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack],
            skips=(
                DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_variant_consistency_eager',
                             device_type='mps', dtypes=[torch.float32]),
@@ -22259,7 +22260,7 @@ op_db: list[OpInfo] = [
             DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes', device_type='mps'),
             DecorateInfo(unittest.expectedFailure, 'TestCommon', device_type='mps', dtypes=(torch.complex64,)),
         ),
-        decorators=[skipCUDAIfNoMagma, skipCPUIfNoLapack]),
+        decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack]),
     # `log_softmax` supports different dtypes based on whether `dtype` argument,
     # is passed or not. Hence two OpInfo entries, one with dtype and other without.
     OpInfo(
@@ -22544,7 +22545,7 @@ op_db: list[OpInfo] = [
     OpInfo('norm',
            variant_test_name='nuc',
            sample_inputs_func=sample_inputs_norm_nuc,
-           decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack],
+           decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack],
            check_batched_gradgrad=False,
            # torch.autograd.gradcheck.GradcheckError: While computing batched gradients
            # got: Could not allocate memory to change Tensor SizesAndStrides!

--- a/torch/testing/_internal/opinfo/definitions/linalg.py
+++ b/torch/testing/_internal/opinfo/definitions/linalg.py
@@ -13,6 +13,7 @@ from numpy import inf
 import torch
 from torch.testing import make_tensor
 
+
 _ROCM_VERSION = (
     tuple(int(v) for v in torch.version.hip.split(".")[:2])
     if torch.version.hip
@@ -1251,7 +1252,11 @@ op_db: list[OpInfo] = [
         supports_fwgrad_bwgrad=True,
         # autogen .out exists but is not exercised here (mirrors linalg.matrix_exp).
         supports_out=False,
-        decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack, with_tf32_off],
+        decorators=[
+            skipCUDAIfNoMagmaAndNoLinalgsolver,
+            skipCPUIfNoLapack,
+            with_tf32_off,
+        ],
         skips=(
             # The operator 'aten::linalg_matrix_sqrth' is not implemented for MPS.
             DecorateInfo(unittest.expectedFailure, "TestCommon", device_type="mps"),
@@ -1351,7 +1356,11 @@ op_db: list[OpInfo] = [
         supports_forward_ad=True,
         supports_fwgrad_bwgrad=True,
         gradcheck_nondet_tol=GRADCHECK_NONDET_TOL,
-        decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack, with_tf32_off],
+        decorators=[
+            skipCUDAIfNoMagmaAndNoLinalgsolver,
+            skipCPUIfNoLapack,
+            with_tf32_off,
+        ],
         skips=(
             DecorateInfo(
                 unittest.skip("Skipped!"),
@@ -1416,7 +1425,11 @@ op_db: list[OpInfo] = [
                 active_if=TEST_WITH_ROCM and _ROCM_VERSION < (7, 14),
             ),
         ),
-        decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack, with_tf32_off],
+        decorators=[
+            skipCUDAIfNoMagmaAndNoLinalgsolver,
+            skipCPUIfNoLapack,
+            with_tf32_off,
+        ],
     ),
     OpInfo(
         "linalg.eigvals",
@@ -1472,7 +1485,11 @@ op_db: list[OpInfo] = [
         check_batched_gradgrad=False,
         supports_forward_ad=True,
         supports_fwgrad_bwgrad=True,
-        decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack, with_tf32_off],
+        decorators=[
+            skipCUDAIfNoMagmaAndNoLinalgsolver,
+            skipCPUIfNoLapack,
+            with_tf32_off,
+        ],
         skips=(
             DecorateInfo(
                 unittest.skip("Skipped!"),
@@ -1728,7 +1745,11 @@ op_db: list[OpInfo] = [
         supports_forward_ad=True,
         supports_fwgrad_bwgrad=True,
         check_batched_grad=False,
-        decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack, with_tf32_off],
+        decorators=[
+            skipCUDAIfNoMagmaAndNoLinalgsolver,
+            skipCPUIfNoLapack,
+            with_tf32_off,
+        ],
         skips=(
             DecorateInfo(
                 toleranceOverride({torch.float32: tol(atol=8e-5, rtol=2e-6)}),
@@ -1812,7 +1833,11 @@ op_db: list[OpInfo] = [
         aten_name="linalg_norm",
         op=torch.linalg.norm,
         dtypes=floating_and_complex_types_and(torch.float16, torch.bfloat16),
-        decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack, with_tf32_off],
+        decorators=[
+            skipCUDAIfNoMagmaAndNoLinalgsolver,
+            skipCPUIfNoLapack,
+            with_tf32_off,
+        ],
         sample_inputs_func=sample_inputs_linalg_norm,
         supports_forward_ad=True,
         check_batched_forward_grad=False,
@@ -1844,7 +1869,11 @@ op_db: list[OpInfo] = [
         op=torch.linalg.norm,
         variant_test_name="subgradients_at_zero",
         dtypes=floating_and_complex_types_and(torch.float16, torch.bfloat16),
-        decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack, with_tf32_off],
+        decorators=[
+            skipCUDAIfNoMagmaAndNoLinalgsolver,
+            skipCPUIfNoLapack,
+            with_tf32_off,
+        ],
         sample_inputs_func=partial(
             sample_inputs_linalg_norm, variant="subgradient_at_zero"
         ),
@@ -1877,7 +1906,11 @@ op_db: list[OpInfo] = [
         check_batched_forward_grad=False,
         check_batched_gradgrad=False,
         supports_fwgrad_bwgrad=True,
-        decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack, with_tf32_off],
+        decorators=[
+            skipCUDAIfNoMagmaAndNoLinalgsolver,
+            skipCPUIfNoLapack,
+            with_tf32_off,
+        ],
         sample_inputs_func=sample_inputs_linalg_matrix_norm,
         skips=(
             DecorateInfo(
@@ -2531,7 +2564,11 @@ op_db: list[OpInfo] = [
         check_batched_grad=False,
         check_batched_gradgrad=False,
         sample_inputs_func=sample_inputs_svd,
-        decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack, with_tf32_off],
+        decorators=[
+            skipCUDAIfNoMagmaAndNoLinalgsolver,
+            skipCPUIfNoLapack,
+            with_tf32_off,
+        ],
         skips=(
             DecorateInfo(
                 unittest.skip("Skipped!"),
@@ -2563,7 +2600,11 @@ op_db: list[OpInfo] = [
         # We're using at::allclose, which does not have a batching rule
         check_batched_gradgrad=False,
         sample_inputs_func=sample_inputs_linalg_svdvals,
-        decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack, with_tf32_off],
+        decorators=[
+            skipCUDAIfNoMagmaAndNoLinalgsolver,
+            skipCPUIfNoLapack,
+            with_tf32_off,
+        ],
         skips=(
             DecorateInfo(
                 unittest.skip("Skipped!"),

--- a/torch/testing/_internal/opinfo/definitions/linalg.py
+++ b/torch/testing/_internal/opinfo/definitions/linalg.py
@@ -12,13 +12,17 @@ from numpy import inf
 
 import torch
 from torch.testing import make_tensor
+
+_ROCM_VERSION = (
+    tuple(int(v) for v in torch.version.hip.split(".")[:2])
+    if torch.version.hip
+    else (0, 0)
+)
 from torch.testing._internal.common_cuda import _get_magma_version, with_tf32_off
 from torch.testing._internal.common_device_type import (
     has_cusolver,
     skipCPUIfNoLapack,
     skipCUDAIfNoCusolver,
-    skipCUDAIfNoMagma,
-    skipCUDAIfNoMagmaAndNoCusolver,
     skipCUDAIfNoMagmaAndNoLinalgsolver,
     skipCUDAIfRocm,
     tol,
@@ -1208,7 +1212,7 @@ op_db: list[OpInfo] = [
         supports_forward_ad=True,
         supports_fwgrad_bwgrad=True,
         sample_inputs_func=sample_inputs_linalg_det_logdet_slogdet,
-        decorators=[skipCPUIfNoLapack, skipCUDAIfNoMagmaAndNoCusolver],
+        decorators=[skipCPUIfNoLapack, skipCUDAIfNoMagmaAndNoLinalgsolver],
         check_batched_gradgrad=False,
         skips=(
             # Exception: linalg.lu_factor(): MPS doesn't support complex types.
@@ -1247,7 +1251,7 @@ op_db: list[OpInfo] = [
         supports_fwgrad_bwgrad=True,
         # autogen .out exists but is not exercised here (mirrors linalg.matrix_exp).
         supports_out=False,
-        decorators=[skipCUDAIfNoMagma, skipCPUIfNoLapack, with_tf32_off],
+        decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack, with_tf32_off],
         skips=(
             # The operator 'aten::linalg_matrix_sqrth' is not implemented for MPS.
             DecorateInfo(unittest.expectedFailure, "TestCommon", device_type="mps"),
@@ -1263,7 +1267,7 @@ op_db: list[OpInfo] = [
         check_batched_forward_grad=False,
         sample_inputs_func=sample_inputs_linalg_cholesky,
         gradcheck_wrapper=gradcheck_wrapper_hermitian_input,
-        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack],
+        decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack],
         skips=(
             # linalg.solve.triangular(); Only float is supported!
             DecorateInfo(
@@ -1288,7 +1292,7 @@ op_db: list[OpInfo] = [
         check_batched_forward_grad=False,
         sample_inputs_func=sample_inputs_linalg_cholesky,
         gradcheck_wrapper=gradcheck_wrapper_hermitian_input,
-        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack],
+        decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack],
         skips=(
             # The following dtypes worked in forward but are not listed by the
             # OpInfo: {torch.bfloat16, torch.float16}. The following dtypes did
@@ -1347,7 +1351,7 @@ op_db: list[OpInfo] = [
         supports_forward_ad=True,
         supports_fwgrad_bwgrad=True,
         gradcheck_nondet_tol=GRADCHECK_NONDET_TOL,
-        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack, with_tf32_off],
+        decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack, with_tf32_off],
         skips=(
             DecorateInfo(
                 unittest.skip("Skipped!"),
@@ -1406,8 +1410,13 @@ op_db: list[OpInfo] = [
             ),
             # Exception: The operator 'aten::linalg_eig' is not currently implemented for the MPS device
             DecorateInfo(unittest.expectedFailure, "TestCommon", device_type="mps"),
+            # hipSOLVER xgeev requires ROCm >= 7.14; older ROCm without MAGMA has no geev support
+            DecorateInfo(
+                unittest.skip("hipSOLVER xgeev requires ROCm >= 7.14"),
+                active_if=TEST_WITH_ROCM and _ROCM_VERSION < (7, 14),
+            ),
         ),
-        decorators=[skipCUDAIfNoMagma, skipCPUIfNoLapack, with_tf32_off],
+        decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack, with_tf32_off],
     ),
     OpInfo(
         "linalg.eigvals",
@@ -1420,7 +1429,7 @@ op_db: list[OpInfo] = [
         check_batched_gradgrad=False,
         supports_forward_ad=True,
         supports_fwgrad_bwgrad=True,
-        decorators=[skipCUDAIfNoMagma, skipCPUIfNoLapack],
+        decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack],
         skips=(
             DecorateInfo(
                 unittest.skip("Skipped!"),
@@ -1445,6 +1454,11 @@ op_db: list[OpInfo] = [
             ),
             # Exception: The operator 'aten::linalg_eig' is not currently implemented for the MPS device
             DecorateInfo(unittest.expectedFailure, "TestCommon", device_type="mps"),
+            # hipSOLVER xgeev requires ROCm >= 7.14; older ROCm without MAGMA has no geev support
+            DecorateInfo(
+                unittest.skip("hipSOLVER xgeev requires ROCm >= 7.14"),
+                active_if=TEST_WITH_ROCM and _ROCM_VERSION < (7, 14),
+            ),
         ),
     ),
     OpInfo(
@@ -1458,7 +1472,7 @@ op_db: list[OpInfo] = [
         check_batched_gradgrad=False,
         supports_forward_ad=True,
         supports_fwgrad_bwgrad=True,
-        decorators=[skipCUDAIfNoMagma, skipCPUIfNoLapack, with_tf32_off],
+        decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack, with_tf32_off],
         skips=(
             DecorateInfo(
                 unittest.skip("Skipped!"),
@@ -1494,7 +1508,7 @@ op_db: list[OpInfo] = [
         check_batched_gradgrad=False,
         supports_forward_ad=True,
         supports_fwgrad_bwgrad=True,
-        decorators=[skipCUDAIfNoMagma, skipCPUIfNoLapack],
+        decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack],
         skips=(
             # Pre-existing condition; Needs to be fixed
             DecorateInfo(
@@ -1633,7 +1647,7 @@ op_db: list[OpInfo] = [
         supports_out=True,
         sample_inputs_func=sample_inputs_linalg_lstsq,
         error_inputs_func=error_inputs_lstsq,
-        decorators=[skipCUDAIfNoMagma, skipCPUIfNoLapack],
+        decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack],
         skips=(
             # we skip gradient checks for this suite as they are tested in
             # variant_test_name='grad_oriented'
@@ -1690,7 +1704,7 @@ op_db: list[OpInfo] = [
         supports_autograd=True,
         supports_forward_ad=True,
         supports_fwgrad_bwgrad=True,
-        decorators=[skipCUDAIfNoMagma, skipCPUIfNoLapack],
+        decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack],
         skips=(
             # tests do not work with passing lambda for op
             DecorateInfo(
@@ -1714,7 +1728,7 @@ op_db: list[OpInfo] = [
         supports_forward_ad=True,
         supports_fwgrad_bwgrad=True,
         check_batched_grad=False,
-        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack, with_tf32_off],
+        decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack, with_tf32_off],
         skips=(
             DecorateInfo(
                 toleranceOverride({torch.float32: tol(atol=8e-5, rtol=2e-6)}),
@@ -1798,7 +1812,7 @@ op_db: list[OpInfo] = [
         aten_name="linalg_norm",
         op=torch.linalg.norm,
         dtypes=floating_and_complex_types_and(torch.float16, torch.bfloat16),
-        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack, with_tf32_off],
+        decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack, with_tf32_off],
         sample_inputs_func=sample_inputs_linalg_norm,
         supports_forward_ad=True,
         check_batched_forward_grad=False,
@@ -1830,7 +1844,7 @@ op_db: list[OpInfo] = [
         op=torch.linalg.norm,
         variant_test_name="subgradients_at_zero",
         dtypes=floating_and_complex_types_and(torch.float16, torch.bfloat16),
-        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack, with_tf32_off],
+        decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack, with_tf32_off],
         sample_inputs_func=partial(
             sample_inputs_linalg_norm, variant="subgradient_at_zero"
         ),
@@ -1863,7 +1877,7 @@ op_db: list[OpInfo] = [
         check_batched_forward_grad=False,
         check_batched_gradgrad=False,
         supports_fwgrad_bwgrad=True,
-        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack, with_tf32_off],
+        decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack, with_tf32_off],
         sample_inputs_func=sample_inputs_linalg_matrix_norm,
         skips=(
             DecorateInfo(
@@ -1923,7 +1937,7 @@ op_db: list[OpInfo] = [
         supports_forward_ad=True,
         supports_fwgrad_bwgrad=True,
         sample_inputs_func=sample_inputs_linalg_det_logdet_slogdet,
-        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack],
+        decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack],
         skips=(
             # Exception: linalg.lu_factor(): MPS doesn't support complex types.
             DecorateInfo(
@@ -1982,7 +1996,7 @@ op_db: list[OpInfo] = [
         supports_forward_ad=True,
         supports_fwgrad_bwgrad=True,
         sample_inputs_func=sample_inputs_linalg_lu,
-        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack],
+        decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack],
         skips=(
             # linalg.lu_factor: LU without pivoting is not implemented on the CPU
             DecorateInfo(
@@ -2013,7 +2027,7 @@ op_db: list[OpInfo] = [
         supports_forward_ad=True,
         supports_fwgrad_bwgrad=True,
         sample_inputs_func=sample_inputs_linalg_lu,
-        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack],
+        decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack],
         skips=(
             # linalg.lu_factor: LU without pivoting is not implemented on the CPU
             DecorateInfo(
@@ -2045,7 +2059,7 @@ op_db: list[OpInfo] = [
         supports_forward_ad=True,
         supports_fwgrad_bwgrad=True,
         sample_inputs_func=sample_inputs_linalg_lu,
-        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack],
+        decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack],
         skips=(
             # linalg.lu_factor: LU without pivoting is not implemented on the CPU
             DecorateInfo(
@@ -2099,7 +2113,7 @@ op_db: list[OpInfo] = [
                 dtypes=(torch.complex64,),
             ),
         ),
-        decorators=[skipCPUIfNoLapack, skipCUDAIfNoMagmaAndNoCusolver],
+        decorators=[skipCPUIfNoLapack, skipCUDAIfNoMagmaAndNoLinalgsolver],
     ),
     OpInfo(
         "linalg.inv",
@@ -2111,7 +2125,7 @@ op_db: list[OpInfo] = [
         check_batched_gradgrad=False,
         supports_forward_ad=True,
         supports_fwgrad_bwgrad=True,
-        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack],
+        decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack],
         skips=(
             DecorateInfo(
                 unittest.skip("Skipped!"),
@@ -2155,7 +2169,7 @@ op_db: list[OpInfo] = [
         check_batched_gradgrad=False,
         supports_forward_ad=True,
         supports_fwgrad_bwgrad=True,
-        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack],
+        decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack],
         skips=(
             DecorateInfo(
                 unittest.skip("Skipped!"),
@@ -2201,7 +2215,7 @@ op_db: list[OpInfo] = [
         supports_forward_ad=True,
         supports_fwgrad_bwgrad=True,
         decorators=[
-            skipCUDAIfNoMagmaAndNoCusolver,
+            skipCUDAIfNoMagmaAndNoLinalgsolver,
             skipCPUIfNoLapack,
             DecorateInfo(
                 toleranceOverride({torch.float32: tol(atol=1.3e-05, rtol=6e-04)}),
@@ -2253,7 +2267,7 @@ op_db: list[OpInfo] = [
         supports_forward_ad=True,
         supports_fwgrad_bwgrad=True,
         decorators=[
-            skipCUDAIfNoMagmaAndNoCusolver,
+            skipCUDAIfNoMagmaAndNoLinalgsolver,
             skipCPUIfNoLapack,
             DecorateInfo(
                 toleranceOverride({torch.float32: tol(atol=1.3e-05, rtol=6e-04)}),
@@ -2329,7 +2343,7 @@ op_db: list[OpInfo] = [
         dtypes=floating_and_complex_types(),
         supports_autograd=False,
         sample_inputs_func=sample_inputs_matrix_rank,
-        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack],
+        decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack],
         skips=(
             DecorateInfo(
                 unittest.skip("Skipped!"),
@@ -2361,7 +2375,7 @@ op_db: list[OpInfo] = [
         dtypes=floating_and_complex_types(),
         supports_autograd=False,
         sample_inputs_func=sample_inputs_linalg_pinv_hermitian,
-        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack],
+        decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack],
         skips=(
             DecorateInfo(
                 unittest.skip("Skipped!"),
@@ -2391,7 +2405,7 @@ op_db: list[OpInfo] = [
         supports_forward_ad=True,
         supports_fwgrad_bwgrad=True,
         sample_inputs_func=sample_inputs_linalg_pinv,
-        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack],
+        decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack],
         skips=(
             # errors with "leaked XXXX bytes CUDA memory on device 0"
             DecorateInfo(
@@ -2456,7 +2470,7 @@ op_db: list[OpInfo] = [
         check_batched_forward_grad=False,
         sample_inputs_func=sample_inputs_linalg_pinv_hermitian,
         gradcheck_wrapper=gradcheck_wrapper_hermitian_input,
-        decorators=[skipCUDAIfNoMagma, skipCPUIfNoLapack],
+        decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack],
         skips=(
             DecorateInfo(
                 unittest.skip("Skipped!"),
@@ -2517,7 +2531,7 @@ op_db: list[OpInfo] = [
         check_batched_grad=False,
         check_batched_gradgrad=False,
         sample_inputs_func=sample_inputs_svd,
-        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack, with_tf32_off],
+        decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack, with_tf32_off],
         skips=(
             DecorateInfo(
                 unittest.skip("Skipped!"),
@@ -2549,7 +2563,7 @@ op_db: list[OpInfo] = [
         # We're using at::allclose, which does not have a batching rule
         check_batched_gradgrad=False,
         sample_inputs_func=sample_inputs_linalg_svdvals,
-        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack, with_tf32_off],
+        decorators=[skipCUDAIfNoMagmaAndNoLinalgsolver, skipCPUIfNoLapack, with_tf32_off],
         skips=(
             DecorateInfo(
                 unittest.skip("Skipped!"),
@@ -2578,7 +2592,7 @@ op_db: list[OpInfo] = [
         supports_fwgrad_bwgrad=True,
         # See https://github.com/pytorch/pytorch/pull/78358
         check_batched_forward_grad=False,
-        decorators=[skipCPUIfNoLapack, skipCUDAIfNoMagmaAndNoCusolver],
+        decorators=[skipCPUIfNoLapack, skipCUDAIfNoMagmaAndNoLinalgsolver],
         skips=(
             DecorateInfo(
                 unittest.skip("Unsupported on MPS for now"),
@@ -2620,7 +2634,7 @@ op_db: list[OpInfo] = [
         supports_forward_ad=True,
         supports_fwgrad_bwgrad=True,
         decorators=[
-            skipCUDAIfNoMagmaAndNoCusolver,
+            skipCUDAIfNoMagmaAndNoLinalgsolver,
             skipCPUIfNoLapack,
             DecorateInfo(
                 toleranceOverride({torch.float32: tol(atol=1e-03, rtol=1e-03)}),

--- a/torch/testing/_internal/opinfo/definitions/linalg.py
+++ b/torch/testing/_internal/opinfo/definitions/linalg.py
@@ -12,14 +12,7 @@ from numpy import inf
 
 import torch
 from torch.testing import make_tensor
-
-
-_ROCM_VERSION = (
-    tuple(int(v) for v in torch.version.hip.split(".")[:2])
-    if torch.version.hip
-    else (0, 0)
-)
-from torch.testing._internal.common_cuda import _get_magma_version, with_tf32_off
+from torch.testing._internal.common_cuda import _get_magma_version, ROCM_VERSION, with_tf32_off
 from torch.testing._internal.common_device_type import (
     has_cusolver,
     skipCPUIfNoLapack,
@@ -1422,7 +1415,7 @@ op_db: list[OpInfo] = [
             # hipSOLVER xgeev requires ROCm >= 7.14; older ROCm without MAGMA has no geev support
             DecorateInfo(
                 unittest.skip("hipSOLVER xgeev requires ROCm >= 7.14"),
-                active_if=TEST_WITH_ROCM and _ROCM_VERSION < (7, 14),
+                active_if=TEST_WITH_ROCM and ROCM_VERSION < (7, 14),
             ),
         ),
         decorators=[
@@ -1470,7 +1463,7 @@ op_db: list[OpInfo] = [
             # hipSOLVER xgeev requires ROCm >= 7.14; older ROCm without MAGMA has no geev support
             DecorateInfo(
                 unittest.skip("hipSOLVER xgeev requires ROCm >= 7.14"),
-                active_if=TEST_WITH_ROCM and _ROCM_VERSION < (7, 14),
+                active_if=TEST_WITH_ROCM and ROCM_VERSION < (7, 14),
             ),
         ),
     ),

--- a/torch/testing/_internal/opinfo/definitions/linalg.py
+++ b/torch/testing/_internal/opinfo/definitions/linalg.py
@@ -12,7 +12,11 @@ from numpy import inf
 
 import torch
 from torch.testing import make_tensor
-from torch.testing._internal.common_cuda import _get_magma_version, ROCM_VERSION, with_tf32_off
+from torch.testing._internal.common_cuda import (
+    _get_magma_version,
+    ROCM_VERSION,
+    with_tf32_off,
+)
 from torch.testing._internal.common_device_type import (
     has_cusolver,
     skipCPUIfNoLapack,

--- a/torch/utils/hipify/cuda_to_hip_mappings.py
+++ b/torch/utils/hipify/cuda_to_hip_mappings.py
@@ -3327,8 +3327,6 @@ CUDA_SPECIAL_MAP = collections.OrderedDict([
     ("cusolverDnXsyevBatched_bufferSize", "hipsolverDnXsyevBatched_bufferSize"),
     ("cusolverDnXsyevd", "hipsolverDnXsyevd"),
     ("cusolverDnXsyevd_bufferSize", "hipsolverDnXsyevd_bufferSize"),
-    ("cusolverDnXgeev", "hipsolverDnXgeev"),
-    ("cusolverDnXgeev_bufferSize", "hipsolverDnXgeev_bufferSize"),
     ("cusolverDnZgeqrf", "hipsolverDnZgeqrf"),
     ("cusolverDnZgeqrf_bufferSize", "hipsolverDnZgeqrf_bufferSize"),
     ("cusolverDnZgesvd", "hipsolverDnZgesvd"),

--- a/torch/utils/hipify/cuda_to_hip_mappings.py
+++ b/torch/utils/hipify/cuda_to_hip_mappings.py
@@ -3327,6 +3327,8 @@ CUDA_SPECIAL_MAP = collections.OrderedDict([
     ("cusolverDnXsyevBatched_bufferSize", "hipsolverDnXsyevBatched_bufferSize"),
     ("cusolverDnXsyevd", "hipsolverDnXsyevd"),
     ("cusolverDnXsyevd_bufferSize", "hipsolverDnXsyevd_bufferSize"),
+    ("cusolverDnXgeev", "hipsolverDnXgeev"),
+    ("cusolverDnXgeev_bufferSize", "hipsolverDnXgeev_bufferSize"),
     ("cusolverDnZgeqrf", "hipsolverDnZgeqrf"),
     ("cusolverDnZgeqrf_bufferSize", "hipsolverDnZgeqrf_bufferSize"),
     ("cusolverDnZgesvd", "hipsolverDnZgesvd"),


### PR DESCRIPTION
hipSOLVER >= 3.5.0 (ROCm >= 7.14) introduced hipsolverDnXgeev, the ROCm equivalent of cuSOLVER's cusolverDnXgeev. This PR leverages that support to enable non-Hermitian eigendecomposition (linalg.eig) and cholesky_ex on ROCm without requiring MAGMA.

Here is the status of the PR-
Confirmed the status of all enabled tests (cholesky_ex & autogenerated tests) from logs downloaded from https://github.com/pytorch/pytorch/actions/runs/28910025721/job/85778404018?pr=188720
For 6 shards, there are 6 sets containing multiple log files-
[logs-runattempt1-test-default-1-6-linux.rocm.gpu.gfx942.1_85778404018.zip](https://github.com/pytorch/pytorch/actions/runs/28910025721/artifacts/8160032112)
[logs-runattempt1-test-default-2-6-linux.rocm.gpu.gfx942.1_85778404014.zip](https://github.com/pytorch/pytorch/actions/runs/28910025721/artifacts/8160160292)
[logs-runattempt1-test-default-3-6-linux.rocm.gpu.gfx942.1_85778403989.zip](https://github.com/pytorch/pytorch/actions/runs/28910025721/artifacts/8159877291)
[logs-runattempt1-test-default-4-6-linux.rocm.gpu.gfx942.1_85778404005.zip](https://github.com/pytorch/pytorch/actions/runs/28910025721/artifacts/8160331467)
[logs-runattempt1-test-default-5-6-linux.rocm.gpu.gfx942.1_85778404001.zip](https://github.com/pytorch/pytorch/actions/runs/28910025721/artifacts/8159922006)
[logs-runattempt1-test-default-6-6-linux.rocm.gpu.gfx942.1_85778403985.zip](https://github.com/pytorch/pytorch/actions/runs/28910025721/artifacts/8160273064)

**cholesky_ex test is passing:** 
See the status of it in comment https://github.com/pytorch/pytorch/pull/188720#issuecomment-4929775133

**Successfully remove Magma dependency for autogenerated tests:**
Here is the status of autogenerated tests for which Magma dependency was removed: 
 
| Status | Count | Notes |
|---|---|---|
| ✅ Passed | 1,525 | Fully passing all dtype variants |
| ✅ Passed (some skipped) | 7 | Passing overall, some dtype variants skipped |
| ⏭ Skipped | 585 | Expected skips: inplace variants (linalg ops have no in-place), `@onlyCPU` CUDA tests, NNC ops not fused, no-gradient ops, multi-GPU (only 1 GPU) |
| 🔶 XFAIL | 17 | Pre-existing expected failures (e.g., `lu`, `norm_nuc` JIT, `compare_cpu_linalg_lu*`) — not regressions |
| ❌ FAILED | 0 | ✅ Zero failures |
| ➖ Not in logs | 22 | Test not generated for that op (e.g., `geqrf`/`linalg_matrix_rank` have no backward, no out-requires-grad, etc.) |
| **Total** | **2,156** | |

**Bottom line:**
- **0 tests failed**
- **1,532 tests passing** (1,525 + 7 "passed with some skipped")
- **585 tests skipped** (all expected / pre-existing)
- **17 XFAIL** (pre-existing expected failures, not regressions)
- **22 not generated** (N/A — ops that don't support those test types)

**Skip Reason-**
| Category | Skipped Patterns |
|---|---|
| `test_meta.py` inplace variants (linalg has no in-place ops) | 168 |
| `test_ops_gradients.py` inplace variants (linalg has no in-place ops) | 84 |
| Other (op/dtype-specific limitations) | 123 |
| `test_fx_experimental.py` (`@onlyCPU` decorator) | 42 |
| `test_jit_fuser_te.py` (NNC doesn't fuse linalg ops) | 42 |
| `test_ops.py` multi-device (only 1 GPU in CI) | 42 |
| `test_ops.py` test_tags (linalg ops have no tags) | 42 |
| `test_ops_gradients.py` test_fn_fail_gradgrad (op supports gradgrad) | 42 |
| **Total** | **585** |

**The trunk failure is unrelated to PR change. The test_extension_utils timed out (ran 33 min, exceeded the 30-min limit → exit code 124). It's a ROCm infra flakiness — pytest hung during collection/import, not a test logic failure. Unrelated to the PR.** 
https://github.com/pytorch/pytorch/actions/runs/28910027855/job/85767842211?pr=188720

**The lint failure is not due to my PR changes:** https://github.com/pytorch/pytorch/actions/runs/28910028195/job/86188389813?pr=188720#step:5:155

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben