### PR TITLE
[pytorch][triton_op] Honor caller-provided schema in triton_op

### DIFF
--- a/torch/_library/triton.py
+++ b/torch/_library/triton.py
@@ -402,7 +402,11 @@ def triton_op(
             name,
             backend_fn,
             mutates_args=mutates_args,
-            schema=infer_schema(fn, mutates_args=mutates_args),
+            schema=(
+                schema
+                if schema is not None
+                else infer_schema(fn, mutates_args=mutates_args)
+            ),
         )
         from .._subclasses.functional_tensor import FunctionalTensorMode
 


### PR DESCRIPTION
Summary:
torch.library.triton_op exposes and documents a `schema` parameter but ignores it: the body unconditionally computes `infer_schema(fn, mutates_args=mutates_args)` and passes that to custom_op. This makes it impossible to register a triton_op whose signature infer_schema cannot express, e.g. an optional-tensor return `(Tensor, Tensor?)`.

Gate on the caller-provided `schema` when present, falling back to `infer_schema(...)` otherwise, matching what torch.library.custom_op already does. When `schema is None` (the default) the behavior is byte-identical, so this is a pure widening. The fbcode and xplat copies of caffe2/torch/_library/triton.py are updated in lockstep.

Differential Revision: D110283291


