### PR TITLE
[ROCm] Make amdsmi discovery robust to TheRock ROCm wheels layout

### DIFF
--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -11,7 +11,9 @@ It is lazily initialized, so you can always import it, and use
 :ref:`cuda-semantics` has more details about working with CUDA.
 """
 
+import glob
 import importlib
+import importlib.util
 import os
 import platform
 import threading
@@ -90,12 +92,37 @@ try:
                     paths = ["libamd_smi.so"]
                     if rocm_home := os.getenv("ROCM_HOME", os.getenv("ROCM_PATH")):
                         paths = [os.path.join(rocm_home, "lib/libamd_smi.so")] + paths
+                    # TheRock ROCm wheels install the amdsmi python package in
+                    # site-packages/amdsmi and ship the native library under the
+                    # _rocm_sdk_core wheel (site-packages/_rocm_sdk_core/lib)
+                    # rather than on the loader path or under $ROCM_HOME. The
+                    # file there is a versioned soname (e.g. libamd_smi.so.26),
+                    # so amdsmi's bare CDLL("libamd_smi.so") can't find it. Locate
+                    # the package and append the concrete versioned files as a
+                    # last-resort fallback so the hook can redirect to them.
+                    if platform.system() == "Linux":
+                        paths = paths + self._rocm_sdk_core_amdsmi_paths()
                     self.paths: list[str] = paths
+
+                @staticmethod
+                def _rocm_sdk_core_amdsmi_paths() -> list[str]:
+                    try:
+                        spec = importlib.util.find_spec("_rocm_sdk_core")
+                    except (ImportError, ValueError):
+                        return []
+                    if spec is None or not spec.submodule_search_locations:
+                        return []
+                    found: list[str] = []
+                    for location in spec.submodule_search_locations:
+                        found += glob.glob(
+                            os.path.join(location, "lib", "libamd_smi.so*")
+                        )
+                    return sorted(found)
 
                 def hooked_CDLL(
                     self, name: str | Path | None, *args: Any, **kwargs: Any
                 ) -> ctypes.CDLL:
-                    if name and Path(name).name == "libamd_smi.so":
+                    if name and Path(name).name.startswith("libamd_smi.so"):
                         for path in self.paths:
                             try:
                                 return self.original_CDLL(path, *args, **kwargs)
@@ -116,6 +143,17 @@ try:
             except ModuleNotFoundError as err:
                 _AMDSMI_ERR = err
                 raise
+            except (KeyError, OSError) as err:
+                # The amdsmi python package is installed but its native library
+                # (libamd_smi.so) could not be discovered/loaded -- e.g. TheRock
+                # ROCm wheels lay amdsmi out so that its own find_smi_library()
+                # misses the versioned libamd_smi.so.* and raises KeyError. Treat
+                # this like a missing optional dependency (degrade to
+                # _HAS_AMDSMI=False) instead of aborting `import torch`.
+                _AMDSMI_ERR = err
+                raise ModuleNotFoundError(
+                    "amdsmi is installed but libamd_smi.so could not be loaded"
+                ) from err
 
         _HAS_PYNVML = True
     except ModuleNotFoundError:


### PR DESCRIPTION
## Summary

On a TheRock-wheels ROCm build, `import torch` aborts during
`_C._initExtension` with `KeyError: 'libamd_smi.so'`. This is the downstream
follow-up to the `_preload_rocm_deps()` work (#188454) for the TheRock wheels
world: once `librocm_sysdeps` is preloaded, the next thing that breaks
`import torch` is amdsmi discovery.

### Failure log

Run [28524549808](https://github.com/pytorch/pytorch/actions/runs/28524549808) /
job [84592180921](https://github.com/pytorch/pytorch/actions/runs/28524549808/job/84592180921)
(rocm-preview distributed shard, head `e112afd4ced`):

```
/var/lib/jenkins/workspace/libamd_smi.so: cannot open shared object file: No such file or directory
Unable to find libamd_smi.so library try installing amd-smi-lib from your package manager
Traceback (most recent call last):
  File "/var/lib/jenkins/workspace/.ci/pytorch/rocm_preflight.py", line 21, in <module>
    import torch
  File ".../site-packages/torch/__init__.py", line 2646, in <module>
    _C._initExtension(_manager_path())
  File ".../site-packages/torch/cuda/__init__.py", line 114, in <module>
    import amdsmi  # type: ignore[import]
  File ".../site-packages/amdsmi/__init__.py", line 24, in <module>
    from .amdsmi_interface import amdsmi_init
  File ".../site-packages/amdsmi/amdsmi_interface.py", line 32, in <module>
    from . import amdsmi_wrapper
  File ".../site-packages/amdsmi/amdsmi_wrapper.py", line 218, in <module>
    amdsmi_free_name_value_pairs = _libraries['libamd_smi.so'].amdsmi_free_name_value_pairs
                                   ~~~~~~~~~~^^^^^^^^^^^^^^^^^
KeyError: 'libamd_smi.so'
```

### Root cause

The `amdsmi` python binding's `find_smi_library()` tries several locations for
`libamd_smi.so`. On TheRock wheels all of them miss:

- a relative `parent×4/lib/libamd_smi.so.26` assuming the wrapper lives under
  `_rocm_sdk_core/share/amd_smi/amdsmi`, but TheRock installs the wrapper in
  `site-packages/amdsmi`, so the relative path miscomputes;
- `$ROCM_HOME`/`$ROCM_PATH` `lib/libamd_smi.so` — env is unset in the direct
  `python` preflight;
- bare `libamd_smi.so` via the loader path — `LD_LIBRARY_PATH`/ldconfig unset,
  and this can't match the versioned `.so.26` anyway;
- the wrapper dir / cwd.

All miss, so `amdsmi_wrapper.py` line 218 does `_libraries['libamd_smi.so']`
and raises `KeyError`. torch's existing `_amdsmi_cdll_hook` only rewrote names
whose basename was **exactly** `libamd_smi.so`, only added an extra path when
`ROCM_HOME`/`ROCM_PATH` was set, and the surrounding `import amdsmi` guard only
tolerated `ModuleNotFoundError` — so a half-installed amdsmi (python package
present, `.so` undiscoverable) was **fatal** to `import torch`. The
`/opt/rocm` tarball world is unaffected because `ROCM_PATH=/opt/rocm` is set and
apt `amd-smi-lib` ships an unversioned `/opt/rocm/lib/libamd_smi.so` symlink.

### Fix (two parts, torch-side, mirrors `_preload_rocm_deps()` philosophy)

1. **Make `_amdsmi_cdll_hook` TheRock-aware** (`torch/cuda/__init__.py`):
   locate `_rocm_sdk_core` via `importlib.util.find_spec` and append its
   `lib/libamd_smi.so*` (glob, incl. versioned sonames like `libamd_smi.so.26`)
   as last-resort candidate paths; match names whose basename **starts with**
   `libamd_smi.so` (not just exact) so amdsmi's bare `CDLL("libamd_smi.so")` is
   redirected to the real versioned file. Existing `ROCM_HOME`/`ROCM_PATH`
   behavior is preserved; the TheRock lookup is guarded to Linux and no-ops
   otherwise.
2. **Make a non-discoverable amdsmi non-fatal**: broaden the guard so
   `KeyError`/`OSError` (not just `ModuleNotFoundError`) degrade gracefully to
   `_HAS_AMDSMI=False` instead of killing `import torch`, matching the existing
   missing-module path (`_get_amdsmi_handler` still raises a clear
   `ModuleNotFoundError` chained from the original error when actually used).

## Test plan

- Static: `python -c "import ast; ast.parse(open('torch/cuda/__init__.py').read())"` passes.
- Simulated the discovery + match logic off-target: with a fake
  `_rocm_sdk_core/lib/libamd_smi.so.26` on `sys.path`, `find_spec` + glob
  discovers the versioned soname and `basename.startswith("libamd_smi.so")`
  matches both `libamd_smi.so` and `libamd_smi.so.26` while rejecting unrelated
  libs; with the package absent, discovery returns `[]` (no-op).
- ROCm CI on this PR (TheRock/rocm-preview shards) validates the end-to-end
  `import torch` fix on a real build.

Made with Cursor

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang