### PR TITLE
Create a skill to get CI metrics

### DIFF
--- a/.claude/skills/ci-metrics/SKILL.md
+++ b/.claude/skills/ci-metrics/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: ci-metrics
+description: Query PyTorch CI, GitHub Actions, HUD, Grafana, and infrastructure metrics. Use when users ask about CI duration, job failures, queue times, workflow trends, runner health, dashboard data, or PyTorch infrastructure metrics.
+---
+
+# PyTorch CI Metrics
+
+PyTorch CI and infrastructure metrics are exposed through Grafana. Use [.claude/skills/ci-metrics/gcx-wrapper.sh](gcx-wrapper.sh) for all Grafana access; it configures the PyTorch Grafana server, context, and authentication. Only users with write permission to the repo have access to Grafana. The authentication only provides read only access.
+
+## Requirements
+
+The wrapper needs these tools on PATH:
+  * `go` - runs the `gcx` CLI.
+  * `gh` - fetches the Grafana token and must be authenticated; if not, run `gh auth login --hostname github.com --git-protocol ssh --web`.
+  * `curl` - fetches the token from HUD.
+
+On first use the wrapper authenticates automatically. If a tool is missing or `gh` is not authenticated, it exits with an error describing what to fix.
+
+## Datasources
+
+Get the list of datasources available:
+
+```
+.claude/skills/ci-metrics/gcx-wrapper.sh datasources list
+```
+
+The data contains metrics for many repos owned by the PyTorch repo. When possible, restrict queries to just the `pytorch/pytorch` repository.
+
+## CI and Test Run Data
+
+CI and test run data are stored in `grafana-clickhouse-datasource`. List all the available tables:
+
+```
+.claude/skills/ci-metrics/gcx-wrapper.sh datasources clickhouse list-tables
+```
+
+Important dataset:
+  * GitHub webhook data
+    * Database: default
+      * Note: the default database also contains other non-webhook related tables.
+    * Learn more about the event and payload: https://docs.github.com/en/webhooks/webhook-events-and-payloads
+  * Tests
+    * Database: tests
+    * tests.all_test_runs - contains every test run. This is an extremely large table, so be considerate with filtering and timing.
+    * Do not use tests.test_run_s3 as it contains partial data only.
+
+To get additional guidance on common queries, clone https://github.com/pytorch/test-infra into a temporary directory and read the `torchci` folder.
+
+### Example Queries
+
+Within the pytorch/pytorch repo on main, list the top most failing workflow jobs in the last 2 weeks:
+```
+.claude/skills/ci-metrics/gcx-wrapper.sh datasources clickhouse query "
+  SELECT name, count(DISTINCT id) AS failures
+  FROM default.workflow_job
+  WHERE conclusion = 'failure'
+    AND completed_at >= now() - INTERVAL 2 WEEK
+    AND repository_full_name = 'pytorch/pytorch'
+    AND head_branch = 'main'
+  GROUP BY name ORDER BY failures DESC LIMIT 10"
+```
+
+For a test file, how many times was it run in the last week? How many times did it pass or fail?
+```
+.claude/skills/ci-metrics/gcx-wrapper.sh datasources clickhouse query "
+  SELECT
+    file,
+    classname,
+    name,
+    count() AS runs,
+    countIf(failure_count = 0 AND error_count = 0 AND skipped_count = 0) AS successful,
+    countIf(failure_count > 0 OR error_count > 0) AS fails,
+    countIf(skipped_count > 0) AS skipped
+  FROM tests.all_test_runs
+  WHERE time_inserted >= now() - INTERVAL 7 DAY
+    AND file = 'lazy/test_ts_opinfo.py'
+  GROUP BY file, classname, name
+  ORDER BY runs DESC"
+```
+
+## CI Infrastructure
+
+CI infrastructure metrics are stored in `grafanacloud-pytorchci-prom`. To get a better understanding of the data, clone these repositories in a temporary directory:
+  * https://github.com/pytorch/ci-infra - In `/osdc` contains the code for OSDC, the infra running PyTorch's CI. Read it to understand how metrics are exported and what metrics are available. Read the docs in /osdc/docs to understand the scope and project setup.
+  * https://github.com/jeanschmidt/actions-runner-controller - To understand how actions-runner-controller exposes data.
+
+### Example Queries
+
+Which runner types have the deepest queue right now (jobs assigned but not yet running)?
+```
+.claude/skills/ci-metrics/gcx-wrapper.sh datasources prometheus query -d grafanacloud-prom 'topk(10, clamp_min(sum by (name) (gha_assigned_jobs) - sum by (name) (gha_running_jobs), 0))'
+```
+
+How many jobs were running per cluster over the last 6 hours, sampled every 30 minutes? Use `--since`/`--step` (or `--from`/`--to`) for a range query:
+```
+.claude/skills/ci-metrics/gcx-wrapper.sh datasources prometheus query -d grafanacloud-prom 'sum by (cluster) (gha_running_jobs)' --since 6h --step 30m
+```

--- a/.claude/skills/ci-metrics/SKILL.md
+++ b/.claude/skills/ci-metrics/SKILL.md
@@ -10,11 +10,10 @@ PyTorch CI and infrastructure metrics are exposed through Grafana. Use [.claude/
 ## Requirements
 
 The wrapper needs these tools on PATH:
-  * `go` - runs the `gcx` CLI.
   * `gh` - fetches the Grafana token and must be authenticated; if not, run `gh auth login --hostname github.com --git-protocol ssh --web`.
-  * `curl` - fetches the token from HUD.
+  * `curl` - downloads `gcx` and fetches the token from HUD.
 
-On first use the wrapper authenticates automatically. If a tool is missing or `gh` is not authenticated, it exits with an error describing what to fix.
+On first use the wrapper downloads a pinned, checksum-verified `gcx` binary into a private cache (`~/.cache/pytorch-ci-metrics/`) and authenticates automatically. Nothing is installed on your PATH. If a tool is missing or `gh` is not authenticated, it exits with an error describing what to fix.
 
 ## Datasources
 

--- a/.claude/skills/ci-metrics/gcx-wrapper.sh
+++ b/.claude/skills/ci-metrics/gcx-wrapper.sh
@@ -4,16 +4,42 @@ set -euo pipefail
 
 export GCX_SERVER="${GCX_SERVER:-https://pytorchci.grafana.net}"
 export GCX_CONTEXT="${GCX_CONTEXT:-pytorchci}"
-export GCX_NO_UPDATE_NOTIFIER="${GCX_NO_UPDATE_NOTIFIER:-1}"
-GCX_CMD=(go run "${GCX_MODULE:-github.com/grafana/gcx/cmd/gcx@latest}")
 
-if ! command -v go >/dev/null 2>&1; then
-  echo "error: go is needed to run gcx." >&2
+# Cache a pinned, prebuilt gcx binary in a private directory and invoke it by
+# absolute path, so nothing lands on the user's PATH. gcx's installer verifies
+# the download's SHA-256 checksum.
+GCX_VERSION="${GCX_VERSION:-0.4.3}"
+GCX_CACHE="${GCX_CACHE:-${XDG_CACHE_HOME:-$HOME/.cache}/pytorch-ci-metrics}"
+GCX_BIN="${GCX_CACHE}/gcx-${GCX_VERSION}"
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "error: curl is needed to download gcx and fetch its token." >&2
   exit 1
 fi
 
+_ensure_gcx() {
+  [[ -x "${GCX_BIN}" ]] && return 0
+
+  echo "Fetching gcx ${GCX_VERSION} to ${GCX_BIN}..." >&2
+  mkdir -p "${GCX_CACHE}"
+  local tmp
+  tmp="$(mktemp -d "${GCX_CACHE}/install.XXXXXX")"
+  local installer="https://raw.githubusercontent.com/grafana/gcx/v${GCX_VERSION}/scripts/install.sh"
+  if ! curl -fsSL "${installer}" | INSTALL_DIR="${tmp}" VERSION="${GCX_VERSION}" sh >/dev/null; then
+    rm -rf "${tmp}"
+    echo "error: failed to install gcx ${GCX_VERSION}" >&2
+    return 1
+  fi
+  if ! mv "${tmp}/gcx" "${GCX_BIN}"; then
+    rm -rf "${tmp}"
+    echo "error: gcx installer did not produce a binary" >&2
+    return 1
+  fi
+  rm -rf "${tmp}"
+}
+
 _run_gcx() {
-  "${GCX_CMD[@]}" "$@"
+  "${GCX_BIN}" "$@"
 }
 
 _login_gcx() {
@@ -21,11 +47,6 @@ _login_gcx() {
 
   if ! command -v gh >/dev/null 2>&1; then
     echo "error: gh CLI is needed to fetch the gcx token"
-    return 1
-  fi
-
-  if ! command -v curl >/dev/null 2>&1; then
-    echo "error: curl is needed to fetch the gcx token"
     return 1
   fi
 
@@ -55,6 +76,10 @@ _login_gcx() {
   fi
 }
 
+if ! _ensure_gcx; then
+  exit 1
+fi
+
 if ! _run_gcx --no-color api --context "${GCX_CONTEXT}" /api/health >/dev/null 2>&1; then
   if ! login_error="$(_login_gcx)"; then
     echo "${login_error}" >&2
@@ -64,4 +89,4 @@ fi
 
 _run_gcx config use-context "${GCX_CONTEXT}" >/dev/null 2>&1 || true
 
-exec "${GCX_CMD[@]}" "$@"
+exec "${GCX_BIN}" "$@"

--- a/.claude/skills/ci-metrics/gcx-wrapper.sh
+++ b/.claude/skills/ci-metrics/gcx-wrapper.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+export GCX_SERVER="${GCX_SERVER:-https://pytorchci.grafana.net}"
+export GCX_CONTEXT="${GCX_CONTEXT:-pytorchci}"
+export GCX_NO_UPDATE_NOTIFIER="${GCX_NO_UPDATE_NOTIFIER:-1}"
+GCX_CMD=(go run "${GCX_MODULE:-github.com/grafana/gcx/cmd/gcx@latest}")
+
+if ! command -v go >/dev/null 2>&1; then
+  echo "error: go is needed to run gcx." >&2
+  exit 1
+fi
+
+_run_gcx() {
+  "${GCX_CMD[@]}" "$@"
+}
+
+_login_gcx() {
+  echo "Authenticating Grafana..." >&2
+
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "error: gh CLI is needed to fetch the gcx token"
+    return 1
+  fi
+
+  if ! command -v curl >/dev/null 2>&1; then
+    echo "error: curl is needed to fetch the gcx token"
+    return 1
+  fi
+
+  if ! gh auth status >/dev/null 2>&1; then
+    echo "error: gh is not authorized. Run 'gh auth login --hostname github.com --git-protocol ssh --web' and retry."
+    return 1
+  fi
+
+  local gh_token
+  if ! gh_token="$(gh auth token 2>/dev/null)"; then
+    echo "error: failed to read gh auth token"
+    return 1
+  fi
+
+  local gcx_token
+  if ! gcx_token="$(curl -fsSL -H "Authorization: Bearer ${gh_token}" "https://hud.pytorch.org/api/gcx-token?token_name=$HOSTNAME" 2>&1)"; then
+    echo "error: failed to fetch gcx token from HUD: ${gcx_token}"
+    return 1
+  fi
+
+  if ! _run_gcx login "${GCX_CONTEXT}" \
+    --server "${GCX_SERVER}" \
+    --yes \
+    --token "${gcx_token}" >/dev/null 2>&1; then
+    echo "error: gcx login failed for ${GCX_CONTEXT}"
+    return 1
+  fi
+}
+
+if ! _run_gcx --no-color api --context "${GCX_CONTEXT}" /api/health >/dev/null 2>&1; then
+  if ! login_error="$(_login_gcx)"; then
+    echo "${login_error}" >&2
+    exit 1
+  fi
+fi
+
+_run_gcx config use-context "${GCX_CONTEXT}" >/dev/null 2>&1 || true
+
+exec "${GCX_CMD[@]}" "$@"


### PR DESCRIPTION
TSIA. This is just the initial skill, as we use this more, we can add more example queries to help the agent have a better starting point. For now, the agent is relatively good at discovering and making sense of the data.

# Test Plan

Test some common questions in Claude.

### What tests are failing the most this week?

```
● Two consistent signals now. Here's what's failing the most this week (rolling 7 days, across all of CI):

  Top offenders — broad failures (affecting the most distinct CI runs)

  These four dominate both by raw failure count and by breadth (hundreds of separate workflows), so they're the real problems:

  ┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┬───────────┬───────┐
  │                                                                 Test                                                                 │ Workflows │ Fails │
  ├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼───────────┼───────┤
  │ inductor/test_aot_inductor.py::AOTInductorLoggingTest::test_shape_env_reuse                                                          │ 694       │ 2,144 │
  ├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼───────────┼───────┤
  │ …AOTInductorLoggingTest::test_shape_env_reuse_zero_consts_use_consts_asm_false                                                       │ 643       │ 2,004 │
  ├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼───────────┼───────┤
  │ inductor/test_aot_inductor.py::AOTInductorTestDualWrapper::test_upper_bound_i64_cuda                                                 │ 597       │ 598   │
  ├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼───────────┼───────┤
  │ inductor/test_torchinductor_opinfo_properties.py::…::test_eager_equivalence_nn_functional_gelu_backend_inductor_default_cuda_float32 │ 569       │ 732   │
  └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┴───────────┴───────┘

  Then a steep drop to test_nv_universal_gemm.py GEMM tests (~84–150 workflows each) and distributed/tensor/test_dtensor_ops.py multinomial.

  High raw count but concentrated (a few broken configs, not broad)

  These rack up big counts because one job re-runs them ~100× and they fail every time — isolated to ~10–13 workflows, so much lower priority:

  - profiler/test_profiler.py::TestProfilerCUDA::test_cupti_monitor_* — 6 tests, 1,000 fails each, only ~10 workflows (a broken CUPTI/CUDA config)
  - test_cuda.py::TestCudaAllocator::test_memory_snapshot — 859 fails / 13 workflows
  - test_overrides.py::…::test_redispatch_nn_functional_linear_cross_entropy_cuda_float16 — 733 fails / 13 workflows

  Caveats worth knowing

  - This mixes PR and trunk runs — the tests table has no branch column. A test failing across ~700 distinct workflows is likely broad flakiness hitting many PRs (or a real
  regression PRs inherit) rather than a hard-red trunk, especially since the top two show a rerun on every failure (auto-retry = classic flaky signature).
  - "Failing the most" = raw failure count by default; I added the workflow-breadth cut because raw counts alone are dominated by re-run-heavy configs.

  Want me to drill in on any of these? Good next steps: filter to trunk/main only (join through workflow_job to separate real breakages from PR-author bugs), or pull the
  failure messages for the top AOTInductor test to see if it's one root cause.
  ```
  
  ### What is the queue time for H100 tests?
  
  ```
  ● H100 test queue times (pytorch/pytorch, last 7 days)

  Measured as per-job wait between created_at and started_at in workflow_job. Queue times are heavily skewed, so percentiles are more meaningful than the mean:

  ┌─────────────────────────────────────────────┬──────┬─────────┬─────────┬───────┬─────────┬────────┐
  │            Runner (H100 variant)            │ Jobs │   p50   │   p90   │  p99  │  mean   │  max   │
  ├─────────────────────────────────────────────┼──────┼─────────┼─────────┼───────┼─────────┼────────┤
  │ mt-l-x86iamx-22-225-h100 (1× H100, primary) │ 993  │ 1.5 min │ 25 min  │ 2.0 h │ 8 min   │ 3.6 h  │
  ├─────────────────────────────────────────────┼──────┼─────────┼─────────┼───────┼─────────┼────────┤
  │ mt-l-x86iamx-88-900-h100-4 (4× H100)        │ 43   │ 1.5 min │ 4.6 min │ 1.1 h │ 4.5 min │ 1.7 h  │
  ├─────────────────────────────────────────────┼──────┼─────────┼─────────┼───────┼─────────┼────────┤
  │ mt-l-bx86iamx-176-1800-h100-8 (8× H100)     │ 9    │ 4.3 min │ 29 min  │ —     │ 13 min  │ 63 min │
  └─────────────────────────────────────────────┴──────┴─────────┴─────────┴───────┴─────────┴────────┘

  Bottom line: For the main single-H100 runner, half of jobs start within ~1.5 min, 90% within ~25 min, but the tail is long (p99 ~2 h). The multi-GPU runners have too few
  jobs (43 and 9) to read much into their tails.

  Two things worth flagging:

  - linux.aws.h100 is no longer active. It had zero completed jobs in the last 7 days and stopped reporting queue data on 2026-06-27. H100 CI has migrated to the mt-l-*-h100
  runners. If you were asking about linux.aws.h100 specifically, that's why it looks quiet.
  - Backlog vs. per-job wait differ a lot. The official half-hour snapshot metric (misc.oss_ci_queue_time_histogram) shows an average in-queue wait of ~3.3 h with peaks near
  11 h for the primary runner. That metric samples jobs still waiting at each 30-min mark, so it over-weights the slow tail and reflects backlog depth during congestion — not
  what a typical job experiences. The per-job percentiles above are the better answer to "how long does an H100 test wait."

  Want me to break this down by time-of-day, plot the trend over the last few weeks, or split by specific job/workflow name?
  ```