### PR TITLE
[cpu] Address clang-tidy warnings in vec(256/512)_int.h

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256_int.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_int.h
@@ -8,14 +8,15 @@
 #include <c10/macros/Macros.h>
 #include <c10/util/irange.h>
 
-namespace at::vec {
-inline namespace CPU_CAPABILITY {
+namespace at::vec::inline CPU_CAPABILITY {
 
 #ifdef CPU_CAPABILITY_AVX2
 
+#include <array>
+
 struct Vectorizedi {
  protected:
-  __m256i values;
+  __m256i values{_mm256_setzero_si256()};
 
   static inline __m256i invert(const __m256i& v) {
     const auto ones = _mm256_set1_epi64x(-1);
@@ -23,9 +24,7 @@ struct Vectorizedi {
   }
 
  public:
-  Vectorizedi() {
-    values = _mm256_setzero_si256();
-  }
+  Vectorizedi() = default;
   Vectorizedi(__m256i v) : values(v) {}
   operator __m256i() const {
     return values;
@@ -55,21 +54,15 @@ class Vectorized<int64_t> : public Vectorizedi {
     return 4;
   }
   using Vectorizedi::Vectorizedi;
-  Vectorized() {
-    values = _mm256_setzero_si256();
-  }
-  Vectorized(int64_t v) {
-    values = _mm256_set1_epi64x(v);
-  }
-  Vectorized(int64_t val1, int64_t val2, int64_t val3, int64_t val4) {
-    values = _mm256_setr_epi64x(val1, val2, val3, val4);
-  }
+  Vectorized(int64_t v) : Vectorizedi{_mm256_set1_epi64x(v)} {}
+  Vectorized(int64_t val1, int64_t val2, int64_t val3, int64_t val4)
+      : Vectorizedi{_mm256_setr_epi64x(val1, val2, val3, val4)} {}
   template <int64_t mask>
   static Vectorized<int64_t> blend(
       Vectorized<int64_t> a,
       Vectorized<int64_t> b) {
-    __at_align__ int64_t tmp_values[size()];
-    a.store(tmp_values);
+    __at_align__ std::array<int64_t, size()> tmp_values{};
+    a.store(tmp_values.data());
     if (mask & 0x01)
       tmp_values[0] = _mm256_extract_epi64(b.values, 0);
     if (mask & 0x02)
@@ -78,7 +71,7 @@ class Vectorized<int64_t> : public Vectorizedi {
       tmp_values[2] = _mm256_extract_epi64(b.values, 2);
     if (mask & 0x08)
       tmp_values[3] = _mm256_extract_epi64(b.values, 3);
-    return loadu(tmp_values);
+    return loadu(tmp_values.data());
   }
   static Vectorized<int64_t> blendv(
       const Vectorized<int64_t>& a,
@@ -106,21 +99,21 @@ class Vectorized<int64_t> : public Vectorizedi {
         return blend<3>(a, b);
       case 3:
         return blend<7>(a, b);
+      default:
+        return b;
     }
-    return b;
   }
   static Vectorized<int64_t> loadu(const void* ptr) {
     return _mm256_loadu_si256(reinterpret_cast<const __m256i*>(ptr));
   }
   static Vectorized<int64_t> loadu(const void* ptr, int64_t count) {
-    __at_align__ int64_t tmp_values[size()];
-    // Fill tail with 1; loop for GCC 11 auto-vec.
-    for (const auto i : c10::irange(size())) {
-      tmp_values[i] = 1;
-    }
+    __at_align__ std::array<int64_t, size()> tmp_values{};
+    tmp_values.fill(1);
     std::memcpy(
-        tmp_values, ptr, std::min<int64_t>(count, size()) * sizeof(int64_t));
-    return loadu(tmp_values);
+        tmp_values.data(),
+        ptr,
+        std::min<int64_t>(count, size()) * sizeof(int64_t));
+    return loadu(tmp_values.data());
   }
   void store(void* ptr, int count = size()) const {
     if (count == size()) {
@@ -128,10 +121,13 @@ class Vectorized<int64_t> : public Vectorizedi {
       // https://software.intel.com/content/www/us/en/develop/documentation/cpp-compiler-developer-guide-and-reference/top/compiler-reference/intrinsics/intrinsics-for-intel-advanced-vector-extensions/intrinsics-for-load-and-store-operations-1/mm256-storeu-si256.html
       _mm256_storeu_si256(reinterpret_cast<__m256i*>(ptr), values);
     } else if (count > 0) {
-      __at_align__ int64_t tmp_values[size()];
-      _mm256_storeu_si256(reinterpret_cast<__m256i*>(tmp_values), values);
+      __at_align__ std::array<int64_t, size()> tmp_values{};
+      _mm256_storeu_si256(
+          reinterpret_cast<__m256i*>(tmp_values.data()), values);
       std::memcpy(
-          ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(int64_t));
+          ptr,
+          tmp_values.data(),
+          std::min<int64_t>(count, size()) * sizeof(int64_t));
     }
   }
   const int64_t& operator[](int idx) const = delete;
@@ -255,21 +251,21 @@ class Vectorized<int32_t> : public Vectorizedi {
         return blend<63>(a, b);
       case 7:
         return blend<127>(a, b);
+      default:
+        return b;
     }
-    return b;
   }
   static Vectorized<int32_t> loadu(const void* ptr) {
     return _mm256_loadu_si256(reinterpret_cast<const __m256i*>(ptr));
   }
   static Vectorized<int32_t> loadu(const void* ptr, int32_t count) {
-    __at_align__ int32_t tmp_values[size()];
-    // Fill tail with 1; loop for GCC 11 auto-vec.
-    for (const auto i : c10::irange(size())) {
-      tmp_values[i] = 1;
-    }
+    __at_align__ std::array<int32_t, size()> tmp_values{};
+    tmp_values.fill(1);
     std::memcpy(
-        tmp_values, ptr, std::min<int64_t>(count, size()) * sizeof(int32_t));
-    return loadu(tmp_values);
+        tmp_values.data(),
+        ptr,
+        std::min<int64_t>(count, size()) * sizeof(int32_t));
+    return loadu(tmp_values.data());
   }
   void store(void* ptr, int count = size()) const {
     if (count == size()) {
@@ -277,10 +273,13 @@ class Vectorized<int32_t> : public Vectorizedi {
       // https://software.intel.com/content/www/us/en/develop/documentation/cpp-compiler-developer-guide-and-reference/top/compiler-reference/intrinsics/intrinsics-for-intel-advanced-vector-extensions/intrinsics-for-load-and-store-operations-1/mm256-storeu-si256.html
       _mm256_storeu_si256(reinterpret_cast<__m256i*>(ptr), values);
     } else if (count > 0) {
-      __at_align__ int32_t tmp_values[size()];
-      _mm256_storeu_si256(reinterpret_cast<__m256i*>(tmp_values), values);
+      __at_align__ std::array<int32_t, size()> tmp_values{};
+      _mm256_storeu_si256(
+          reinterpret_cast<__m256i*>(tmp_values.data()), values);
       std::memcpy(
-          ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(int32_t));
+          ptr,
+          tmp_values.data(),
+          std::min<int64_t>(count, size()) * sizeof(int32_t));
     }
   }
   const int32_t& operator[](int idx) const = delete;
@@ -354,12 +353,12 @@ class Vectorized<int32_t> : public Vectorizedi {
 
 template <>
 inline void convert(const int32_t* src, float* dst, int64_t n) {
-  int64_t i;
+  int64_t i{0};
   // int32_t and float have same size
 #ifndef _MSC_VER
 #pragma unroll
 #endif
-  for (i = 0; i <= (n - Vectorized<int32_t>::size());
+  for (; i <= (n - Vectorized<int32_t>::size());
        i += Vectorized<int32_t>::size()) {
     auto input_vec =
         _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + i));
@@ -376,12 +375,12 @@ inline void convert(const int32_t* src, float* dst, int64_t n) {
 
 template <>
 inline void convert(const int32_t* src, double* dst, int64_t n) {
-  int64_t i;
+  int64_t i{0};
   // int32_t has half the size of double
 #ifndef _MSC_VER
 #pragma unroll
 #endif
-  for (i = 0; i <= (n - Vectorized<double>::size());
+  for (; i <= (n - Vectorized<double>::size());
        i += Vectorized<double>::size()) {
     auto input_128_vec =
         _mm_loadu_si128(reinterpret_cast<const __m128i*>(src + i));
@@ -453,8 +452,8 @@ class Vectorized<int16_t> : public Vectorizedi {
   static Vectorized<int16_t> blend(
       Vectorized<int16_t> a,
       Vectorized<int16_t> b) {
-    __at_align__ int16_t tmp_values[size()];
-    a.store(tmp_values);
+    __at_align__ std::array<int16_t, size()> tmp_values{};
+    a.store(tmp_values.data());
     if (mask & 0x01)
       tmp_values[0] = _mm256_extract_epi16(b.values, 0);
     if (mask & 0x02)
@@ -487,7 +486,7 @@ class Vectorized<int16_t> : public Vectorizedi {
       tmp_values[14] = _mm256_extract_epi16(b.values, 14);
     if (mask & 0x8000)
       tmp_values[15] = _mm256_extract_epi16(b.values, 15);
-    return loadu(tmp_values);
+    return loadu(tmp_values.data());
   }
   static Vectorized<int16_t> blendv(
       const Vectorized<int16_t>& a,
@@ -554,21 +553,21 @@ class Vectorized<int16_t> : public Vectorizedi {
         return blend<16383>(a, b);
       case 15:
         return blend<32767>(a, b);
+      default:
+        return b;
     }
-    return b;
   }
   static Vectorized<int16_t> loadu(const void* ptr) {
     return _mm256_loadu_si256(reinterpret_cast<const __m256i*>(ptr));
   }
   static Vectorized<int16_t> loadu(const void* ptr, int16_t count) {
-    __at_align__ int16_t tmp_values[size()];
-    // Fill tail with 1; loop for GCC 11 auto-vec.
-    for (const auto i : c10::irange(size())) {
-      tmp_values[i] = 1;
-    }
+    __at_align__ std::array<int16_t, size()> tmp_values{};
+    tmp_values.fill(1);
     std::memcpy(
-        tmp_values, ptr, std::min<int64_t>(count, size()) * sizeof(int16_t));
-    return loadu(tmp_values);
+        tmp_values.data(),
+        ptr,
+        std::min<int64_t>(count, size()) * sizeof(int16_t));
+    return loadu(tmp_values.data());
   }
   void store(void* ptr, int count = size()) const {
     if (count == size()) {
@@ -576,10 +575,13 @@ class Vectorized<int16_t> : public Vectorizedi {
       // https://software.intel.com/content/www/us/en/develop/documentation/cpp-compiler-developer-guide-and-reference/top/compiler-reference/intrinsics/intrinsics-for-intel-advanced-vector-extensions/intrinsics-for-load-and-store-operations-1/mm256-storeu-si256.html
       _mm256_storeu_si256(reinterpret_cast<__m256i*>(ptr), values);
     } else if (count > 0) {
-      __at_align__ int16_t tmp_values[size()];
-      _mm256_storeu_si256(reinterpret_cast<__m256i*>(tmp_values), values);
+      __at_align__ std::array<int16_t, size()> tmp_values{};
+      _mm256_storeu_si256(
+          reinterpret_cast<__m256i*>(tmp_values.data()), values);
       std::memcpy(
-          ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(int16_t));
+          ptr,
+          tmp_values.data(),
+          std::min<int64_t>(count, size()) * sizeof(int16_t));
     }
   }
   const int16_t& operator[](int idx) const = delete;
@@ -712,8 +714,8 @@ class Vectorized8 : public Vectorizedi {
   }
   template <int64_t mask>
   static Vectorized<T> blend(Vectorized<T> a, Vectorized<T> b) {
-    __at_align__ T tmp_values[size()];
-    a.store(tmp_values);
+    __at_align__ std::array<T, size()> tmp_values{};
+    a.store(tmp_values.data());
     if (mask & 0x01)
       tmp_values[0] = _mm256_extract_epi8(b.values, 0);
     if (mask & 0x02)
@@ -778,7 +780,7 @@ class Vectorized8 : public Vectorizedi {
       tmp_values[30] = _mm256_extract_epi8(b.values, 30);
     if (mask & 0x80000000)
       tmp_values[31] = _mm256_extract_epi8(b.values, 31);
-    return loadu(tmp_values);
+    return loadu(tmp_values.data());
   }
   static Vectorized<T> blendv(
       const Vectorized<T>& a,
@@ -890,8 +892,9 @@ class Vectorized8 : public Vectorizedi {
         return blend<0x3FFFFFFF>(a, b);
       case 31:
         return blend<0x7FFFFFFF>(a, b);
+      default:
+        return b;
     }
-    return b;
   }
   static Vectorized<T> loadu(const void* ptr) {
     return _mm256_loadu_si256(reinterpret_cast<const __m256i*>(ptr));
@@ -908,13 +911,11 @@ class Vectorized8 : public Vectorizedi {
     return _mm256_castsi128_si256(input_128);
   }
   static Vectorized<T> loadu(const void* ptr, T count) {
-    __at_align__ T tmp_values[size()];
-    // Fill tail with 1; loop for GCC 11 auto-vec.
-    for (const auto i : c10::irange(size())) {
-      tmp_values[i] = 1;
-    }
-    std::memcpy(tmp_values, ptr, std::min<int64_t>(count, size()) * sizeof(T));
-    return loadu(tmp_values);
+    __at_align__ std::array<T, size()> tmp_values{};
+    tmp_values.fill(1);
+    std::memcpy(
+        tmp_values.data(), ptr, std::min<int64_t>(count, size()) * sizeof(T));
+    return loadu(tmp_values.data());
   }
   void store(void* ptr, int count = size()) const {
     if (count == size()) {
@@ -927,10 +928,13 @@ class Vectorized8 : public Vectorizedi {
         _mm_storel_epi64(
             reinterpret_cast<__m128i*>(ptr), _mm256_castsi256_si128(values));
       } else {
-        __at_align__ T tmp_values[size()];
-        _mm256_storeu_si256(reinterpret_cast<__m256i*>(tmp_values), values);
+        __at_align__ std::array<T, size()> tmp_values{};
+        _mm256_storeu_si256(
+            reinterpret_cast<__m256i*>(tmp_values.data()), values);
         std::memcpy(
-            ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(T));
+            ptr,
+            tmp_values.data(),
+            std::min<int64_t>(count, size()) * sizeof(T));
       }
     }
   }
@@ -1211,24 +1215,20 @@ Vectorized<T> inline int_elementwise_binary_256(
     const Vectorized<T>& a,
     const Vectorized<T>& b,
     Op op) {
-  T values_a[Vectorized<T>::size()];
-  T values_b[Vectorized<T>::size()];
-  a.store(values_a);
-  b.store(values_b);
+  std::array<T, Vectorized<T>::size()> values_a{};
+  std::array<T, Vectorized<T>::size()> values_b{};
+  a.store(values_a.data());
+  b.store(values_b.data());
   for (int i = 0; i != Vectorized<T>::size(); i++) {
     values_a[i] = op(values_a[i], values_b[i]);
   }
-  return Vectorized<T>::loadu(values_a);
+  return Vectorized<T>::loadu(values_a.data());
 }
 
 template <>
 Vectorized<int8_t> inline operator*(
     const Vectorized<int8_t>& a,
     const Vectorized<int8_t>& b) {
-  // We don't have an instruction for multiplying int8_t
-#ifndef CPU_CAPABILITY_AVX2
-  return int_elementwise_binary_256(a, b, std::multiplies<int8_t>());
-#else
   __m256i mask00FF = _mm256_set1_epi16(0x00FF);
   __m256i a_lo = _mm256_srai_epi16(_mm256_slli_epi16(a, 8), 8);
   __m256i b_lo = _mm256_srai_epi16(_mm256_slli_epi16(b, 8), 8);
@@ -1238,7 +1238,6 @@ Vectorized<int8_t> inline operator*(
   __m256i res_hi = _mm256_slli_epi16(_mm256_mullo_epi16(a_hi, b_hi), 8);
   __m256i res = _mm256_or_si256(res_hi, res_lo);
   return res;
-#endif
 }
 
 template <>
@@ -1246,9 +1245,6 @@ Vectorized<uint8_t> inline operator*(
     const Vectorized<uint8_t>& a,
     const Vectorized<uint8_t>& b) {
   // We don't have an instruction for multiplying uint8_t
-#ifndef CPU_CAPABILITY_AVX2
-  return int_elementwise_binary_256(a, b, std::multiplies<uint8_t>());
-#else
   __m256i mask00FF = _mm256_set1_epi16(0x00FF);
   __m256i a_lo = _mm256_and_si256(a, mask00FF);
   __m256i b_lo = _mm256_and_si256(b, mask00FF);
@@ -1258,21 +1254,14 @@ Vectorized<uint8_t> inline operator*(
   __m256i res_hi = _mm256_slli_epi16(_mm256_mullo_epi16(a_hi, b_hi), 8);
   __m256i res = _mm256_or_si256(res_hi, res_lo);
   return res;
-#endif
 }
 
 template <>
 Vectorized<int64_t> inline minimum(
     const Vectorized<int64_t>& a,
     const Vectorized<int64_t>& b) {
-#ifndef CPU_CAPABILITY_AVX2
-  return emulate(a, b, [](int64_t a_point, int64_t b_point) {
-    return std::min(a_point, b_point);
-  });
-#else
   __m256i cmp = _mm256_cmpgt_epi64(a, b);
   return _mm256_blendv_epi8(a, b, cmp);
-#endif
 }
 
 template <>
@@ -1307,14 +1296,8 @@ template <>
 Vectorized<int64_t> inline maximum(
     const Vectorized<int64_t>& a,
     const Vectorized<int64_t>& b) {
-#ifndef CPU_CAPABILITY_AVX2
-  return emulate(a, b, [](int64_t a_point, int64_t b_point) {
-    return std::max(a_point, b_point);
-  });
-#else
   __m256i cmp = _mm256_cmpgt_epi64(a, b);
   return _mm256_blendv_epi8(b, a, cmp);
-#endif
 }
 
 template <>
@@ -1350,17 +1333,7 @@ Vectorized<int64_t> inline clamp(
     const Vectorized<int64_t>& a,
     const Vectorized<int64_t>& min_val,
     const Vectorized<int64_t>& max_val) {
-#ifndef CPU_CAPABILITY_AVX2
-  return emulate(
-      a,
-      min_val,
-      max_val,
-      [](int64_t a_point, int64_t min_point, int64_t max_point) {
-        return std::min(max_point, std::max(a_point, min_point));
-      });
-#else
   return minimum(maximum(a, min_val), max_val);
-#endif
 }
 
 template <>
@@ -1399,13 +1372,7 @@ template <>
 Vectorized<int64_t> inline clamp_max(
     const Vectorized<int64_t>& a,
     const Vectorized<int64_t>& max_val) {
-#ifndef CPU_CAPABILITY_AVX2
-  return emulate(a, max_val, [](int64_t a_point, int64_t max_point) {
-    return std::min(max_point, a_point);
-  });
-#else
   return minimum(max_val, a);
-#endif
 }
 
 template <>
@@ -1440,13 +1407,7 @@ template <>
 Vectorized<int64_t> inline clamp_min(
     const Vectorized<int64_t>& a,
     const Vectorized<int64_t>& min_val) {
-#ifndef CPU_CAPABILITY_AVX2
-  return emulate(a, min_val, [](int64_t a_point, int64_t min_point) {
-    return std::max(min_point, a_point);
-  });
-#else
   return maximum(min_val, a);
-#endif
 }
 
 template <>
@@ -1494,7 +1455,7 @@ std::
     return _mm256_cvtepi8_epi32(
         _mm_loadl_epi64(reinterpret_cast<const __m128i*>(ptr)));
   } else {
-    auto a = Vectorized<int8_t>::loadu(ptr, count);
+    auto a = Vectorized<int8_t>::loadu(ptr, static_cast<int8_t>(count));
     return _mm256_cvtepi8_epi32(_mm256_castsi256_si128(a));
   }
 }
@@ -1517,62 +1478,58 @@ template <>
 Vectorized<int64_t> inline operator/(
     const Vectorized<int64_t>& a,
     const Vectorized<int64_t>& b) {
-  return int_elementwise_binary_256(a, b, std::divides<int64_t>());
+  return int_elementwise_binary_256(a, b, std::divides<>());
 }
 template <>
 Vectorized<int32_t> inline operator/(
     const Vectorized<int32_t>& a,
     const Vectorized<int32_t>& b) {
-  return int_elementwise_binary_256(a, b, std::divides<int32_t>());
+  return int_elementwise_binary_256(a, b, std::divides<>());
 }
 template <>
 Vectorized<int16_t> inline operator/(
     const Vectorized<int16_t>& a,
     const Vectorized<int16_t>& b) {
-  return int_elementwise_binary_256(a, b, std::divides<int16_t>());
+  return int_elementwise_binary_256(a, b, std::divides<>());
 }
 template <>
 Vectorized<int8_t> inline operator/(
     const Vectorized<int8_t>& a,
     const Vectorized<int8_t>& b) {
-  return int_elementwise_binary_256(a, b, std::divides<int8_t>());
+  return int_elementwise_binary_256(a, b, std::divides<>());
 }
 template <>
 Vectorized<uint8_t> inline operator/(
     const Vectorized<uint8_t>& a,
     const Vectorized<uint8_t>& b) {
-  return int_elementwise_binary_256(a, b, std::divides<uint8_t>());
+  return int_elementwise_binary_256(a, b, std::divides<>());
 }
 
 template <
     class T,
-    typename std::enable_if_t<
-        std::is_base_of<Vectorizedi, Vectorized<T>>::value,
-        int> = 0>
+    typename std::
+        enable_if_t<std::is_base_of_v<Vectorizedi, Vectorized<T>>, int> = 0>
 inline Vectorized<T> operator&(const Vectorized<T>& a, const Vectorized<T>& b) {
   return _mm256_and_si256(a, b);
 }
 template <
     class T,
-    typename std::enable_if_t<
-        std::is_base_of<Vectorizedi, Vectorized<T>>::value,
-        int> = 0>
+    typename std::
+        enable_if_t<std::is_base_of_v<Vectorizedi, Vectorized<T>>, int> = 0>
 inline Vectorized<T> operator|(const Vectorized<T>& a, const Vectorized<T>& b) {
   return _mm256_or_si256(a, b);
 }
 template <
     class T,
-    typename std::enable_if_t<
-        std::is_base_of<Vectorizedi, Vectorized<T>>::value,
-        int> = 0>
+    typename std::
+        enable_if_t<std::is_base_of_v<Vectorizedi, Vectorized<T>>, int> = 0>
 inline Vectorized<T> operator^(const Vectorized<T>& a, const Vectorized<T>& b) {
   return _mm256_xor_si256(a, b);
 }
 template <
     class T,
-    typename std::enable_if_t<
-        std::is_base_of<Vectorizedi, Vectorized<T>>::value,
-        int> = 0>
+    typename std::
+        enable_if_t<std::is_base_of_v<Vectorizedi, Vectorized<T>>, int> = 0>
 inline Vectorized<T> operator~(const Vectorized<T>& a) {
   return _mm256_xor_si256(a, _mm256_set1_epi32(-1));
 }
@@ -1727,6 +1684,8 @@ inline Vectorized<uint8_t> Vectorized<uint8_t>::le(
   return (*this <= other) & Vectorized<uint8_t>(1);
 }
 
+constexpr int8_t top_bit_set{-128}; // 0x80
+
 template <bool left_shift>
 Vectorized<int16_t> inline shift_256_16(
     const Vectorized<int16_t>& a,
@@ -1742,67 +1701,67 @@ Vectorized<int16_t> inline shift_256_16(
   __m256i ctl_0_1 = _mm256_set_epi8(
       29,
       28,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
       25,
       24,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
       21,
       20,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
       17,
       16,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
       13,
       12,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
       9,
       8,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
       5,
       4,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
       1,
       0,
-      0x80,
-      0x80);
+      top_bit_set,
+      top_bit_set);
   __m256i ctl_1_0 = _mm256_set_epi8(
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
       31,
       30,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
       27,
       26,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
       23,
       22,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
       19,
       18,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
       15,
       14,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
       11,
       10,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
       7,
       6,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
       3,
       2);
 
@@ -1813,7 +1772,7 @@ Vectorized<int16_t> inline shift_256_16(
   // element with the same index in output pair, while the other
   // element in output pair will be set to all 0s.
   __m256i keep_0 = _mm256_set1_epi32(0xFFFF);
-  __m256i keep_1 = _mm256_set1_epi32(0xFFFF0000);
+  __m256i keep_1 = _mm256_set1_epi32(-0x00010000); // 0xFFFF0000
 
   // Take each 16-bit element with idx%2==0 from input array to be
   // shifted and extend it to 32 bits so that 0s are added to the
@@ -1877,268 +1836,268 @@ Vectorized<T> inline shift_256_8(
   // set to all 0s.
   __m256i ctl_0_3 = _mm256_set_epi8(
       28,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       24,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       20,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       16,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       12,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       8,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       4,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       0,
-      0x80,
-      0x80,
-      0x80);
+      top_bit_set,
+      top_bit_set,
+      top_bit_set);
   __m256i ctl_1_0 = _mm256_set_epi8(
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       29,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       25,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       21,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       17,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       13,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       9,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       5,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       1);
   __m256i ctl_1_3 = _mm256_set_epi8(
       29,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       25,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       21,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       17,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       13,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       9,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       5,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       1,
-      0x80,
-      0x80,
-      0x80);
+      top_bit_set,
+      top_bit_set,
+      top_bit_set);
   __m256i ctl_2_0 = _mm256_set_epi8(
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       30,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       26,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       22,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       18,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       14,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       10,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       6,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       2);
   __m256i ctl_2_3 = _mm256_set_epi8(
       30,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       26,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       22,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       18,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       14,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       10,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       6,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       2,
-      0x80,
-      0x80,
-      0x80);
+      top_bit_set,
+      top_bit_set,
+      top_bit_set);
   __m256i ctl_3_0 = _mm256_set_epi8(
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       31,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       27,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       23,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       19,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       15,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       11,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       7,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       3);
   __m256i ctl_3_1 = _mm256_set_epi8(
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
       31,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       27,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       23,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       19,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       15,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       11,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       7,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       3,
-      0x80);
+      top_bit_set);
   __m256i ctl_3_2 = _mm256_set_epi8(
-      0x80,
+      top_bit_set,
       31,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       27,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       23,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       19,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       15,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       11,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       7,
-      0x80,
-      0x80,
-      0x80,
+      top_bit_set,
+      top_bit_set,
+      top_bit_set,
       3,
-      0x80,
-      0x80);
+      top_bit_set,
+      top_bit_set);
 
   // Masks for bitwise and operation, treating 256 bits as an array of
   // 8-bit elements, and considering them in quadruples of neighboring
@@ -2147,7 +2106,7 @@ Vectorized<T> inline shift_256_8(
   // into element with the same index in output quadruple, while the
   // other elements in output quadruple will be set to all 0s.
   __m256i keep_0 = _mm256_set1_epi32(0xFF);
-  __m256i keep_3 = _mm256_set1_epi32(0xFF000000);
+  __m256i keep_3 = _mm256_set1_epi32(-0x01000000); // 0xFF000000
 
   // Take each 8-bit element with idx%4==0 from input array to be
   // shifted and extend it to 32 bits so that 0s are added to the
@@ -2313,5 +2272,4 @@ Vectorized<uint8_t> inline operator>>(
 
 #endif
 
-} // namespace CPU_CAPABILITY
-} // namespace at::vec
+} // namespace at::vec::inline CPU_CAPABILITY

--- a/aten/src/ATen/cpu/vec/vec512/vec512_int.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_int.h
@@ -8,14 +8,15 @@
 #include <c10/macros/Macros.h>
 #include <c10/util/irange.h>
 
-namespace at::vec {
-inline namespace CPU_CAPABILITY {
+namespace at::vec::inline CPU_CAPABILITY {
 
 #ifdef CPU_CAPABILITY_AVX512
 
+#include <array>
+
 struct Vectorizedi {
  protected:
-  __m512i values;
+  __m512i values{_mm512_setzero_si512()};
   static constexpr __m512i zero_vector{0, 0, 0, 0, 0, 0, 0, 0};
   static inline __m512i invert(const __m512i& v) {
     const auto ones = _mm512_set1_epi64(-1);
@@ -53,12 +54,7 @@ class Vectorized<int64_t> : public Vectorizedi {
     return 8;
   }
   using Vectorizedi::Vectorizedi;
-  Vectorized() {
-    values = _mm512_setzero_si512();
-  }
-  Vectorized(int64_t v) {
-    values = _mm512_set1_epi64(v);
-  }
+  Vectorized(int64_t v) : Vectorizedi{_mm512_set1_epi64(v)} {}
   Vectorized(
       int64_t val1,
       int64_t val2,
@@ -67,9 +63,16 @@ class Vectorized<int64_t> : public Vectorizedi {
       int64_t val5,
       int64_t val6,
       int64_t val7,
-      int64_t val8) {
-    values = _mm512_setr_epi64(val1, val2, val3, val4, val5, val6, val7, val8);
-  }
+      int64_t val8)
+      : Vectorizedi{_mm512_setr_epi64(
+            val1,
+            val2,
+            val3,
+            val4,
+            val5,
+            val6,
+            val7,
+            val8)} {}
   template <int64_t mask>
   static Vectorized<int64_t> blend(
       Vectorized<int64_t> a,
@@ -80,7 +83,7 @@ class Vectorized<int64_t> : public Vectorizedi {
       const Vectorized<int64_t>& a,
       const Vectorized<int64_t>& b,
       const Vectorized<int64_t>& mask) {
-    auto msb_one = _mm512_set1_epi64(0xFFFFFFFFFFFFFFFF);
+    auto msb_one = _mm512_set1_epi64(-1);
     auto mask_ = _mm512_cmp_epi64_mask(mask, msb_one, _MM_CMPINT_EQ);
     return _mm512_mask_blend_epi64(mask_, a.values, b.values);
   }
@@ -119,8 +122,9 @@ class Vectorized<int64_t> : public Vectorizedi {
         return blend<63>(a, b);
       case 7:
         return blend<127>(a, b);
+      default:
+        return b;
     }
-    return b;
   }
   static Vectorized<int64_t> loadu(const void* ptr) {
     return _mm512_loadu_si512(reinterpret_cast<const __m512i*>(ptr));
@@ -148,8 +152,7 @@ class Vectorized<int64_t> : public Vectorizedi {
   int64_t& operator[](int idx) = delete;
   Vectorized<int64_t> abs() const {
     auto is_larger_mask = _mm512_cmpgt_epi64_mask(zero_vector, values);
-    auto is_larger =
-        _mm512_mask_set1_epi64(zero_vector, is_larger_mask, 0xFFFFFFFFFFFFFFFF);
+    auto is_larger = _mm512_mask_set1_epi64(zero_vector, is_larger_mask, -1);
     auto inverse = _mm512_xor_si512(values, is_larger);
     return _mm512_sub_epi64(inverse, is_larger);
   }
@@ -165,27 +168,27 @@ class Vectorized<int64_t> : public Vectorizedi {
   Vectorized<int64_t> neg() const;
   Vectorized<int64_t> operator==(const Vectorized<int64_t>& other) const {
     auto mask = _mm512_cmpeq_epi64_mask(values, other.values);
-    return _mm512_mask_set1_epi64(zero_vector, mask, 0xFFFFFFFFFFFFFFFF);
+    return _mm512_mask_set1_epi64(zero_vector, mask, -1);
   }
   Vectorized<int64_t> operator!=(const Vectorized<int64_t>& other) const {
     auto mask = _mm512_cmpneq_epi64_mask(values, other.values);
-    return _mm512_mask_set1_epi64(zero_vector, mask, 0xFFFFFFFFFFFFFFFF);
+    return _mm512_mask_set1_epi64(zero_vector, mask, -1);
   }
   Vectorized<int64_t> operator<(const Vectorized<int64_t>& other) const {
     auto mask = _mm512_cmplt_epi64_mask(values, other.values);
-    return _mm512_mask_set1_epi64(zero_vector, mask, 0xFFFFFFFFFFFFFFFF);
+    return _mm512_mask_set1_epi64(zero_vector, mask, -1);
   }
   Vectorized<int64_t> operator<=(const Vectorized<int64_t>& other) const {
     auto mask = _mm512_cmple_epi64_mask(values, other.values);
-    return _mm512_mask_set1_epi64(zero_vector, mask, 0xFFFFFFFFFFFFFFFF);
+    return _mm512_mask_set1_epi64(zero_vector, mask, -1);
   }
   Vectorized<int64_t> operator>(const Vectorized<int64_t>& other) const {
     auto mask = _mm512_cmpgt_epi64_mask(values, other.values);
-    return _mm512_mask_set1_epi64(zero_vector, mask, 0xFFFFFFFFFFFFFFFF);
+    return _mm512_mask_set1_epi64(zero_vector, mask, -1);
   }
   Vectorized<int64_t> operator>=(const Vectorized<int64_t>& other) const {
     auto mask = _mm512_cmpge_epi64_mask(values, other.values);
-    return _mm512_mask_set1_epi64(zero_vector, mask, 0xFFFFFFFFFFFFFFFF);
+    return _mm512_mask_set1_epi64(zero_vector, mask, -1);
   }
 
   Vectorized<int64_t> eq(const Vectorized<int64_t>& other) const;
@@ -259,7 +262,7 @@ class Vectorized<int32_t> : public Vectorizedi {
       const Vectorized<int32_t>& a,
       const Vectorized<int32_t>& b,
       const Vectorized<int32_t>& mask) {
-    auto msb_one = _mm512_set1_epi32(0xFFFFFFFF);
+    auto msb_one = _mm512_set1_epi32(-1);
     auto mask_ = _mm512_cmp_epi32_mask(mask, msb_one, _MM_CMPINT_EQ);
     return _mm512_mask_blend_epi32(mask_, a.values, b.values);
   }
@@ -322,8 +325,9 @@ class Vectorized<int32_t> : public Vectorizedi {
         return blend<16383>(a, b);
       case 15:
         return blend<32767>(a, b);
+      default:
+        return b;
     }
-    return b;
   }
   static Vectorized<int32_t> loadu(const void* ptr) {
     return _mm512_loadu_si512(reinterpret_cast<const __m512i*>(ptr));
@@ -370,27 +374,27 @@ class Vectorized<int32_t> : public Vectorizedi {
   }
   Vectorized<int32_t> operator==(const Vectorized<int32_t>& other) const {
     auto mask = _mm512_cmpeq_epi32_mask(values, other.values);
-    return _mm512_mask_set1_epi32(zero_vector, mask, 0xFFFFFFFF);
+    return _mm512_mask_set1_epi32(zero_vector, mask, -1);
   }
   Vectorized<int32_t> operator!=(const Vectorized<int32_t>& other) const {
     auto mask = _mm512_cmpneq_epi32_mask(values, other.values);
-    return _mm512_mask_set1_epi32(zero_vector, mask, 0xFFFFFFFF);
+    return _mm512_mask_set1_epi32(zero_vector, mask, -1);
   }
   Vectorized<int32_t> operator<(const Vectorized<int32_t>& other) const {
     auto mask = _mm512_cmplt_epi32_mask(values, other.values);
-    return _mm512_mask_set1_epi32(zero_vector, mask, 0xFFFFFFFF);
+    return _mm512_mask_set1_epi32(zero_vector, mask, -1);
   }
   Vectorized<int32_t> operator<=(const Vectorized<int32_t>& other) const {
     auto mask = _mm512_cmple_epi32_mask(values, other.values);
-    return _mm512_mask_set1_epi32(zero_vector, mask, 0xFFFFFFFF);
+    return _mm512_mask_set1_epi32(zero_vector, mask, -1);
   }
   Vectorized<int32_t> operator>(const Vectorized<int32_t>& other) const {
     auto mask = _mm512_cmpgt_epi32_mask(values, other.values);
-    return _mm512_mask_set1_epi32(zero_vector, mask, 0xFFFFFFFF);
+    return _mm512_mask_set1_epi32(zero_vector, mask, -1);
   }
   Vectorized<int32_t> operator>=(const Vectorized<int32_t>& other) const {
     auto mask = _mm512_cmpge_epi32_mask(values, other.values);
-    return _mm512_mask_set1_epi32(zero_vector, mask, 0xFFFFFFFF);
+    return _mm512_mask_set1_epi32(zero_vector, mask, -1);
   }
   Vectorized<int32_t> eq(const Vectorized<int32_t>& other) const;
   Vectorized<int32_t> ne(const Vectorized<int32_t>& other) const;
@@ -402,12 +406,12 @@ class Vectorized<int32_t> : public Vectorizedi {
 
 template <>
 inline void convert(const int32_t* src, float* dst, int64_t n) {
-  int64_t i;
+  int64_t i{0};
   // int32_t and float have same size
 #ifndef _MSC_VER
 #pragma unroll
 #endif
-  for (i = 0; i <= (n - Vectorized<int32_t>::size());
+  for (; i <= (n - Vectorized<int32_t>::size());
        i += Vectorized<int32_t>::size()) {
     auto input_vec =
         _mm512_loadu_si512(reinterpret_cast<const __m512i*>(src + i));
@@ -424,12 +428,12 @@ inline void convert(const int32_t* src, float* dst, int64_t n) {
 
 template <>
 inline void convert(const int32_t* src, double* dst, int64_t n) {
-  int64_t i;
+  int64_t i{0};
   // int32_t has half the size of double
 #ifndef _MSC_VER
 #pragma unroll
 #endif
-  for (i = 0; i <= (n - Vectorized<double>::size());
+  for (; i <= (n - Vectorized<double>::size());
        i += Vectorized<double>::size()) {
     auto input_256_vec =
         _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + i));
@@ -540,7 +544,7 @@ class Vectorized<int16_t> : public Vectorizedi {
       const Vectorized<int16_t>& a,
       const Vectorized<int16_t>& b,
       const Vectorized<int16_t>& mask) {
-    auto msb_one = _mm512_set1_epi16(0xFFFF);
+    auto msb_one = _mm512_set1_epi16(-1);
     auto mask_ = _mm512_cmp_epi16_mask(mask, msb_one, _MM_CMPINT_EQ);
     return _mm512_mask_blend_epi16(mask_, a.values, b.values);
   }
@@ -651,8 +655,9 @@ class Vectorized<int16_t> : public Vectorizedi {
         return blend<0x3FFFFFFF>(a, b);
       case 31:
         return blend<0x7FFFFFFF>(a, b);
+      default:
+        return b;
     }
-    return b;
   }
   static Vectorized<int16_t> loadu(const void* ptr) {
     return _mm512_loadu_si512(reinterpret_cast<const __m512i*>(ptr));
@@ -693,27 +698,27 @@ class Vectorized<int16_t> : public Vectorizedi {
   Vectorized<int16_t> neg() const;
   Vectorized<int16_t> operator==(const Vectorized<int16_t>& other) const {
     auto mask = _mm512_cmpeq_epi16_mask(values, other.values);
-    return _mm512_mask_set1_epi16(zero_vector, mask, 0xFFFF);
+    return _mm512_mask_set1_epi16(zero_vector, mask, -1);
   }
   Vectorized<int16_t> operator!=(const Vectorized<int16_t>& other) const {
     auto mask = _mm512_cmpneq_epi16_mask(values, other.values);
-    return _mm512_mask_set1_epi16(zero_vector, mask, 0xFFFF);
+    return _mm512_mask_set1_epi16(zero_vector, mask, -1);
   }
   Vectorized<int16_t> operator<(const Vectorized<int16_t>& other) const {
     auto mask = _mm512_cmplt_epi16_mask(values, other.values);
-    return _mm512_mask_set1_epi16(zero_vector, mask, 0xFFFF);
+    return _mm512_mask_set1_epi16(zero_vector, mask, -1);
   }
   Vectorized<int16_t> operator<=(const Vectorized<int16_t>& other) const {
     auto mask = _mm512_cmple_epi16_mask(values, other.values);
-    return _mm512_mask_set1_epi16(zero_vector, mask, 0xFFFF);
+    return _mm512_mask_set1_epi16(zero_vector, mask, -1);
   }
   Vectorized<int16_t> operator>(const Vectorized<int16_t>& other) const {
     auto mask = _mm512_cmpgt_epi16_mask(values, other.values);
-    return _mm512_mask_set1_epi16(zero_vector, mask, 0xFFFF);
+    return _mm512_mask_set1_epi16(zero_vector, mask, -1);
   }
   Vectorized<int16_t> operator>=(const Vectorized<int16_t>& other) const {
     auto mask = _mm512_cmpge_epi16_mask(values, other.values);
-    return _mm512_mask_set1_epi16(zero_vector, mask, 0xFFFF);
+    return _mm512_mask_set1_epi16(zero_vector, mask, -1);
   }
 
   Vectorized<int16_t> eq(const Vectorized<int16_t>& other) const;
@@ -1149,7 +1154,7 @@ class Vectorized<int8_t> : public Vectorized8<int8_t> {
       const Vectorized<int8_t>& a,
       const Vectorized<int8_t>& b,
       const Vectorized<int8_t>& mask) {
-    auto msb_one = _mm512_set1_epi8(0xFF);
+    auto msb_one = _mm512_set1_epi8(-1);
     auto mask_ = _mm512_cmp_epi8_mask(mask, msb_one, _MM_CMPINT_EQ);
     return _mm512_mask_blend_epi8(mask_, a.values, b.values);
   }
@@ -1162,19 +1167,19 @@ class Vectorized<int8_t> : public Vectorized8<int8_t> {
 
   Vectorized<int8_t> operator==(const Vectorized<int8_t>& other) const {
     auto mask = _mm512_cmpeq_epi8_mask(values, other.values);
-    return _mm512_mask_set1_epi8(zero_vector, mask, 0xFF);
+    return _mm512_mask_set1_epi8(zero_vector, mask, -1);
   }
   Vectorized<int8_t> operator!=(const Vectorized<int8_t>& other) const {
     auto mask = _mm512_cmpneq_epi8_mask(values, other.values);
-    return _mm512_mask_set1_epi8(zero_vector, mask, 0xFF);
+    return _mm512_mask_set1_epi8(zero_vector, mask, -1);
   }
   Vectorized<int8_t> operator<(const Vectorized<int8_t>& other) const {
     auto mask = _mm512_cmplt_epi8_mask(values, other.values);
-    return _mm512_mask_set1_epi8(zero_vector, mask, 0xFF);
+    return _mm512_mask_set1_epi8(zero_vector, mask, -1);
   }
   Vectorized<int8_t> operator<=(const Vectorized<int8_t>& other) const {
     auto mask = _mm512_cmple_epi8_mask(values, other.values);
-    return _mm512_mask_set1_epi8(zero_vector, mask, 0xFF);
+    return _mm512_mask_set1_epi8(zero_vector, mask, -1);
   }
   Vectorized<int8_t> operator>(const Vectorized<int8_t>& other) const {
     return other < *this;
@@ -1203,7 +1208,7 @@ class Vectorized<uint8_t> : public Vectorized8<uint8_t> {
       const Vectorized<uint8_t>& a,
       const Vectorized<uint8_t>& b,
       const Vectorized<uint8_t>& mask) {
-    auto msb_one = _mm512_set1_epi8(0xFF);
+    auto msb_one = _mm512_set1_epi8(-1);
     auto mask_ = _mm512_cmp_epu8_mask(mask, msb_one, _MM_CMPINT_EQ);
     return _mm512_mask_blend_epi8(mask_, a.values, b.values);
   }
@@ -1216,19 +1221,19 @@ class Vectorized<uint8_t> : public Vectorized8<uint8_t> {
 
   Vectorized<uint8_t> operator==(const Vectorized<uint8_t>& other) const {
     auto mask = _mm512_cmpeq_epu8_mask(values, other.values);
-    return _mm512_mask_set1_epi8(zero_vector, mask, 0xFF);
+    return _mm512_mask_set1_epi8(zero_vector, mask, -1);
   }
   Vectorized<uint8_t> operator!=(const Vectorized<uint8_t>& other) const {
     auto mask = _mm512_cmpneq_epu8_mask(values, other.values);
-    return _mm512_mask_set1_epi8(zero_vector, mask, 0xFF);
+    return _mm512_mask_set1_epi8(zero_vector, mask, -1);
   }
   Vectorized<uint8_t> operator<(const Vectorized<uint8_t>& other) const {
     auto mask = _mm512_cmplt_epu8_mask(values, other.values);
-    return _mm512_mask_set1_epi8(zero_vector, mask, 0xFF);
+    return _mm512_mask_set1_epi8(zero_vector, mask, -1);
   }
   Vectorized<uint8_t> operator<=(const Vectorized<uint8_t>& other) const {
     auto mask = _mm512_cmple_epu8_mask(values, other.values);
-    return _mm512_mask_set1_epi8(zero_vector, mask, 0xFF);
+    return _mm512_mask_set1_epi8(zero_vector, mask, -1);
   }
   Vectorized<uint8_t> operator>(const Vectorized<uint8_t>& other) const {
     return other < *this;
@@ -1362,14 +1367,14 @@ Vectorized<T> inline int_elementwise_binary_512(
     const Vectorized<T>& a,
     const Vectorized<T>& b,
     Op op) {
-  T values_a[Vectorized<T>::size()];
-  T values_b[Vectorized<T>::size()];
-  a.store(values_a);
-  b.store(values_b);
+  std::array<T, Vectorized<T>::size()> values_a{};
+  std::array<T, Vectorized<T>::size()> values_b{};
+  a.store(values_a.data());
+  b.store(values_b.data());
   for (int i = 0; i != Vectorized<T>::size(); i++) {
     values_a[i] = op(values_a[i], values_b[i]);
   }
-  return Vectorized<T>::loadu(values_a);
+  return Vectorized<T>::loadu(values_a.data());
 }
 
 template <>
@@ -1377,9 +1382,6 @@ Vectorized<int8_t> inline operator*(
     const Vectorized<int8_t>& a,
     const Vectorized<int8_t>& b) {
   // We don't have an instruction for multiplying int8_t
-#ifndef CPU_CAPABILITY_AVX512
-  return int_elementwise_binary_512(a, b, std::multiplies<int8_t>());
-#else
   __m512i mask00FF = _mm512_set1_epi16(0x00FF);
   __m512i a_lo = _mm512_srai_epi16(_mm512_slli_epi16(a, 8), 8);
   __m512i b_lo = _mm512_srai_epi16(_mm512_slli_epi16(b, 8), 8);
@@ -1389,7 +1391,6 @@ Vectorized<int8_t> inline operator*(
   __m512i res_hi = _mm512_slli_epi16(_mm512_mullo_epi16(a_hi, b_hi), 8);
   __m512i res = _mm512_or_si512(res_hi, res_lo);
   return res;
-#endif
 }
 
 template <>
@@ -1397,9 +1398,6 @@ Vectorized<uint8_t> inline operator*(
     const Vectorized<uint8_t>& a,
     const Vectorized<uint8_t>& b) {
   // We don't have an instruction for multiplying uint8_t
-#ifndef CPU_CAPABILITY_AVX512
-  return int_elementwise_binary_512(a, b, std::multiplies<uint8_t>());
-#else
   __m512i mask00FF = _mm512_set1_epi16(0x00FF);
   __m512i a_lo = _mm512_and_si512(a, mask00FF);
   __m512i b_lo = _mm512_and_si512(b, mask00FF);
@@ -1409,7 +1407,6 @@ Vectorized<uint8_t> inline operator*(
   __m512i res_hi = _mm512_slli_epi16(_mm512_mullo_epi16(a_hi, b_hi), 8);
   __m512i res = _mm512_or_si512(res_hi, res_lo);
   return res;
-#endif
 }
 
 template <>
@@ -1609,7 +1606,7 @@ std::
     return _mm512_cvtepi8_epi32(
         _mm_loadu_si128(reinterpret_cast<const __m128i*>(ptr)));
   } else {
-    auto a = Vectorized<int8_t>::loadu(ptr, count);
+    auto a = Vectorized<int8_t>::loadu(ptr, static_cast<int8_t>(count));
     return _mm512_cvtepi8_epi32(_mm512_castsi512_si128(a));
   }
 }
@@ -1632,62 +1629,58 @@ template <>
 Vectorized<int64_t> inline operator/(
     const Vectorized<int64_t>& a,
     const Vectorized<int64_t>& b) {
-  return int_elementwise_binary_512(a, b, std::divides<int64_t>());
+  return int_elementwise_binary_512(a, b, std::divides<>());
 }
 template <>
 Vectorized<int32_t> inline operator/(
     const Vectorized<int32_t>& a,
     const Vectorized<int32_t>& b) {
-  return int_elementwise_binary_512(a, b, std::divides<int32_t>());
+  return int_elementwise_binary_512(a, b, std::divides<>());
 }
 template <>
 Vectorized<int16_t> inline operator/(
     const Vectorized<int16_t>& a,
     const Vectorized<int16_t>& b) {
-  return int_elementwise_binary_512(a, b, std::divides<int16_t>());
+  return int_elementwise_binary_512(a, b, std::divides<>());
 }
 template <>
 Vectorized<int8_t> inline operator/(
     const Vectorized<int8_t>& a,
     const Vectorized<int8_t>& b) {
-  return int_elementwise_binary_512(a, b, std::divides<int8_t>());
+  return int_elementwise_binary_512(a, b, std::divides<>());
 }
 template <>
 Vectorized<uint8_t> inline operator/(
     const Vectorized<uint8_t>& a,
     const Vectorized<uint8_t>& b) {
-  return int_elementwise_binary_512(a, b, std::divides<uint8_t>());
+  return int_elementwise_binary_512(a, b, std::divides<>());
 }
 
 template <
     class T,
-    typename std::enable_if_t<
-        std::is_base_of<Vectorizedi, Vectorized<T>>::value,
-        int> = 0>
+    typename std::
+        enable_if_t<std::is_base_of_v<Vectorizedi, Vectorized<T>>, int> = 0>
 inline Vectorized<T> operator&(const Vectorized<T>& a, const Vectorized<T>& b) {
   return _mm512_and_si512(a, b);
 }
 template <
     class T,
-    typename std::enable_if_t<
-        std::is_base_of<Vectorizedi, Vectorized<T>>::value,
-        int> = 0>
+    typename std::
+        enable_if_t<std::is_base_of_v<Vectorizedi, Vectorized<T>>, int> = 0>
 inline Vectorized<T> operator|(const Vectorized<T>& a, const Vectorized<T>& b) {
   return _mm512_or_si512(a, b);
 }
 template <
     class T,
-    typename std::enable_if_t<
-        std::is_base_of<Vectorizedi, Vectorized<T>>::value,
-        int> = 0>
+    typename std::
+        enable_if_t<std::is_base_of_v<Vectorizedi, Vectorized<T>>, int> = 0>
 inline Vectorized<T> operator^(const Vectorized<T>& a, const Vectorized<T>& b) {
   return _mm512_xor_si512(a, b);
 }
 template <
     class T,
-    typename std::enable_if_t<
-        std::is_base_of<Vectorizedi, Vectorized<T>>::value,
-        int> = 0>
+    typename std::
+        enable_if_t<std::is_base_of_v<Vectorizedi, Vectorized<T>>, int> = 0>
 inline Vectorized<T> operator~(const Vectorized<T>& a) {
   return _mm512_xor_si512(a, _mm512_set1_epi32(-1));
 }
@@ -1851,6 +1844,8 @@ template <
 Vectorized<T> inline shift_512_8(
     const Vectorized<T>& a,
     const Vectorized<T>& b) {
+  constexpr int8_t top_bit_set{-128}; // 0x80
+
   // No vector instruction for shifting int8_t/uint8_t, so emulating
   // it instead.
 
@@ -1862,133 +1857,133 @@ Vectorized<T> inline shift_512_8(
   // with index M in output pair will be set to all 0s.
   __m512i ctl_0_1 = _mm512_set_epi8(
       62,
-      0x80,
+      top_bit_set,
       60,
-      0x80,
+      top_bit_set,
       58,
-      0x80,
+      top_bit_set,
       56,
-      0x80,
+      top_bit_set,
       54,
-      0x80,
+      top_bit_set,
       52,
-      0x80,
+      top_bit_set,
       50,
-      0x80,
+      top_bit_set,
       48,
-      0x80,
+      top_bit_set,
       46,
-      0x80,
+      top_bit_set,
       44,
-      0x80,
+      top_bit_set,
       42,
-      0x80,
+      top_bit_set,
       40,
-      0x80,
+      top_bit_set,
       38,
-      0x80,
+      top_bit_set,
       36,
-      0x80,
+      top_bit_set,
       34,
-      0x80,
+      top_bit_set,
       32,
-      0x80,
+      top_bit_set,
       30,
-      0x80,
+      top_bit_set,
       28,
-      0x80,
+      top_bit_set,
       26,
-      0x80,
+      top_bit_set,
       24,
-      0x80,
+      top_bit_set,
       22,
-      0x80,
+      top_bit_set,
       20,
-      0x80,
+      top_bit_set,
       18,
-      0x80,
+      top_bit_set,
       16,
-      0x80,
+      top_bit_set,
       14,
-      0x80,
+      top_bit_set,
       12,
-      0x80,
+      top_bit_set,
       10,
-      0x80,
+      top_bit_set,
       8,
-      0x80,
+      top_bit_set,
       6,
-      0x80,
+      top_bit_set,
       4,
-      0x80,
+      top_bit_set,
       2,
-      0x80,
+      top_bit_set,
       0,
-      0x80);
+      top_bit_set);
   __m512i ctl_1_0 = _mm512_set_epi8(
-      0x80,
+      top_bit_set,
       63,
-      0x80,
+      top_bit_set,
       61,
-      0x80,
+      top_bit_set,
       59,
-      0x80,
+      top_bit_set,
       57,
-      0x80,
+      top_bit_set,
       55,
-      0x80,
+      top_bit_set,
       53,
-      0x80,
+      top_bit_set,
       51,
-      0x80,
+      top_bit_set,
       49,
-      0x80,
+      top_bit_set,
       47,
-      0x80,
+      top_bit_set,
       45,
-      0x80,
+      top_bit_set,
       43,
-      0x80,
+      top_bit_set,
       41,
-      0x80,
+      top_bit_set,
       39,
-      0x80,
+      top_bit_set,
       37,
-      0x80,
+      top_bit_set,
       35,
-      0x80,
+      top_bit_set,
       33,
-      0x80,
+      top_bit_set,
       31,
-      0x80,
+      top_bit_set,
       29,
-      0x80,
+      top_bit_set,
       27,
-      0x80,
+      top_bit_set,
       25,
-      0x80,
+      top_bit_set,
       23,
-      0x80,
+      top_bit_set,
       21,
-      0x80,
+      top_bit_set,
       19,
-      0x80,
+      top_bit_set,
       17,
-      0x80,
+      top_bit_set,
       15,
-      0x80,
+      top_bit_set,
       13,
-      0x80,
+      top_bit_set,
       11,
-      0x80,
+      top_bit_set,
       9,
-      0x80,
+      top_bit_set,
       7,
-      0x80,
+      top_bit_set,
       5,
-      0x80,
+      top_bit_set,
       3,
-      0x80,
+      top_bit_set,
       1);
 
   // Masks for bitwise and operation, treating 512 bits as an array of
@@ -1998,7 +1993,7 @@ Vectorized<T> inline shift_512_8(
   // element with the same index in output pair, while the other
   // element in output pair will be set to all 0s.
   __m512i keep_0 = _mm512_set1_epi16(0xFF);
-  __m512i keep_1 = _mm512_set1_epi16(0xFF00);
+  __m512i keep_1 = _mm512_set1_epi16(-0x0100); // 0xFF00
 
   // Take each 8-bit element with idx%2==0 from input array to be
   // shifted and extend it to 16 bits so that 0s are added to the
@@ -2117,5 +2112,4 @@ Vectorized<uint8_t> inline operator>>(
 
 #endif
 
-} // namespace CPU_CAPABILITY
-} // namespace at::vec
+} // namespace at::vec::inline CPU_CAPABILITY


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Pull-Request: https://github.com/pytorch/pytorch/pull/188311

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01