### PR TITLE
[MPS] Enable ConvTranspose3d for fp16/bf16 via internal fp32 upcast

### DIFF
--- a/aten/src/ATen/native/mps/operations/Convolution.mm
+++ b/aten/src/ATen/native/mps/operations/Convolution.mm
@@ -738,9 +738,27 @@ Tensor _mps_convolution_transpose(const Tensor& input_t,
                                   IntArrayRef stride,
                                   IntArrayRef dilation,
                                   int64_t groups) {
-  bool is_unsupported_3d_dtype =
-      (input_t.dim() == 5 && (input_t.scalar_type() == kHalf || input_t.scalar_type() == kBFloat16));
-  TORCH_CHECK(!is_unsupported_3d_dtype, "ConvTranspose 3D with BF16 or FP16 types is not supported on MPS");
+  // ConvTranspose3d (5-D input) in fp16/bf16 used to hard-fail here (see
+  // gh-160739; gh-130256 tracks the earlier missing-kernel state for this op
+  // more generally). The 3D enablement in #154696 (fixing #154615) intentionally
+  // left half types unsupported because running the MPSGraph transpose-conv
+  // path directly in half precision showed a CPU-vs-GPU accuracy gap too large
+  // to sign off on without further study. Rather than reject the op, upcast
+  // to fp32 for the actual compute -- identical in spirit to the CPU reference
+  // path and to how other MPS ops (e.g. reductions) recover precision -- and
+  // cast the result back to the caller's dtype. This removes the accuracy gap
+  // because the math itself now runs in fp32 instead of fp16/bf16.
+  const bool is_3d = input_t.dim() == 5;
+  const bool needs_fp32_upcast = is_3d && (input_t.scalar_type() == kHalf || input_t.scalar_type() == kBFloat16);
+
+  if (needs_fp32_upcast) {
+    const auto orig_dtype = input_t.scalar_type();
+    const auto input_fp32 = input_t.to(at::kFloat);
+    const auto weight_fp32 = weight_t.to(at::kFloat);
+    auto output_fp32 =
+        mps_convolution_transpose_forward(input_fp32, weight_fp32, padding, output_padding, stride, dilation, groups);
+    return output_fp32.to(orig_dtype);
+  }
 
   auto output_t =
       mps_convolution_transpose_forward(input_t, weight_t, padding, output_padding, stride, dilation, groups);
@@ -777,6 +795,33 @@ std::tuple<Tensor, Tensor> mps_convolution_transpose_backward(const Tensor& inpu
                                                               IntArrayRef dilation,
                                                               int64_t groups,
                                                               std::array<bool, 2> output_mask) {
+  // Mirror the fp32-upcast path used in the forward op (see comment above
+  // `_mps_convolution_transpose`) so that autograd through a half-precision
+  // ConvTranspose3d works end to end instead of failing only on the forward
+  // pass.
+  const bool is_3d = input.dim() == 5;
+  const bool needs_fp32_upcast = is_3d && (input.scalar_type() == kHalf || input.scalar_type() == kBFloat16);
+
+  if (needs_fp32_upcast) {
+    const auto orig_dtype = input.scalar_type();
+    const auto input_fp32 = input.to(at::kFloat);
+    const auto grad_output_fp32 = grad_output.to(at::kFloat);
+    const auto weight_fp32 = weight.to(at::kFloat);
+
+    Tensor grad_input, grad_weight;
+    if (output_mask[0]) {
+      grad_input = mps_convolution_transpose_backward_input(
+          grad_output_fp32, weight_fp32, padding, stride, dilation, groups, input_fp32.sizes());
+      grad_input = grad_input.to(orig_dtype);
+    }
+    if (output_mask[1]) {
+      grad_weight = mps_convolution_transpose_backward_weight(
+          weight_fp32.sizes(), grad_output_fp32, input_fp32, padding, stride, dilation, groups);
+      grad_weight = grad_weight.to(orig_dtype);
+    }
+    return std::tuple<Tensor, Tensor>{grad_input, grad_weight};
+  }
+
   Tensor grad_input, grad_weight;
   if (output_mask[0]) {
     grad_input =

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -15147,7 +15147,7 @@ class TestConsistency(TestCaseMPS):
         # MPS uses float32 intermediates for these ops, so the CPU reference
         # must also run in float32 to avoid comparing against less-precise
         # native half-precision CPU results.
-        if op.name in ["grid_sampler_2d", "grid_sampler_3d"] and dtype is None and mps_sample.input.dtype in [torch.float16, torch.bfloat16]:
+        if op.name in ["grid_sampler_2d", "grid_sampler_3d", "nn.functional.conv_transpose3d"] and dtype is None and mps_sample.input.dtype in [torch.float16, torch.bfloat16]:
             dtype = torch.float32
 
         cpu_sample = transform_opinfo_sample_to_cpu(mps_sample, dtype)

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -621,11 +621,7 @@ if torch.backends.mps.is_available():
             "nn.functional.conv3d": [torch.int64],
             "nn.functional.conv_transpose1d": [torch.int64],
             "nn.functional.conv_transpose2d": [torch.int64, torch.bfloat16],
-            "nn.functional.conv_transpose3d": [
-                torch.int64,
-                torch.bfloat16,
-                torch.float16,
-            ],
+            "nn.functional.conv_transpose3d": [torch.int64],
             # Unsupported dtypes
             # GEMM on MPS is not supported for integral types
             "nn.functional.linear": [
@@ -944,7 +940,6 @@ if torch.backends.mps.is_available():
             "nn.functional.conv3d": [torch.float16],
             "nn.functional.conv_transpose1d": [torch.float16],
             "nn.functional.conv_transpose2d": [torch.float16],
-            "nn.functional.conv_transpose3d": [torch.float16],
         }
 
         ON_MPS_XFAILLIST = {


### PR DESCRIPTION
Fixes #160739
Related: #160332 (autocast crash caused by the same gate), #130256 (earlier
feature request tracking the original missing-kernel state of this op;
not directly closed by this PR)

## Summary

`ConvTranspose3d` (5-D transposed convolution) on the MPS backend currently
hard-rejects fp16 and bf16 inputs:

    RuntimeError: ConvTranspose 3D with BF16 or FP16 types is not supported on MPS

This check was added in #154696, which enabled the fp32/complex64 path but
left half-precision types unsupported because, per that PR's description,
the discrepancy between the CPU and MPS implementations was "too large to
conclude whether there is a bug in the implementation ... without a more
rigorous study." Rather than run the MPSGraph transpose-convolution op
directly in fp16/bf16, this PR upcasts the input/weight (and, in the
backward pass, grad_output) to fp32, runs the already-validated fp32 path,
and casts the result back to the caller's original dtype. This sidesteps
the accuracy question raised in #154696 entirely: the actual GPU compute
never happens in half precision, so there is no half-precision-specific
numerical behavior to characterize.

This also transitively fixes #160332 (`torch.amp.autocast` on MPS crashing
on any module containing `ConvTranspose3d`, since autocast always tries
fp16/bf16 first and previously had no way to avoid the reject path for
this op).

## Motivation

`ConvTranspose3d` is the standard PyTorch primitive for learned upsampling
in 3D/volumetric decoders (video-generation VAEs, 3D medical-image
segmentation such as nnUNet - see #2435 - and other volumetric
autoencoders). On Apple Silicon, fp16/bf16 is the common choice for these
models given unified-memory pressure, so the current gate forces users
either onto fp32 (2x the memory) or CPU (10-50x slower) for this one op,
even though every other op in the same model runs natively on MPS in half
precision.

## Approach

- `_mps_convolution_transpose` (forward): when the input is 5-D and the
  dtype is fp16/bf16, cast input and weight to fp32 before calling the
  existing `mps_convolution_transpose_forward` helper, then cast the
  output back to the original dtype.
- `mps_convolution_transpose_backward`: mirrors the same upcast for
  `grad_output`/`input`/`weight` so autograd works end-to-end in half
  precision, not just the forward pass.
- The 2D case and the existing fp32/complex64 3D case are completely
  untouched - the new branch is only taken for `dim() == 5 &&
  dtype in {half, bfloat16}`, which previously always hit the
  `TORCH_CHECK` failure and therefore had no existing behavior to preserve.

This mirrors the internal-fp32-upcast pattern already used elsewhere in
the MPS backend for precision-sensitive ops (e.g. reduction ops upcasting
to fp32 internally for numerically-sensitive accumulation).

## Test plan

- `test/nn/test_convolution.py -k "ConvTranspose3d"` and
  `test/test_mps.py -k "conv_transpose3d"` pass with fp16/bf16 test cases
  enabled (previously xfailed/skipped for this dtype combination in
  `torch/testing/_internal/common_mps.py`'s `UNIMPLEMENTED_XFAILLIST` and
  `SKIPLIST_GRAD`, which this PR also updates).
- While enabling those tests, found and fixed a pre-existing gap in
  `test_mps.py`'s `_run_op`: it already special-cases `grid_sampler_2d`/
  `grid_sampler_3d` to compare MPS output against a CPU **fp32** reference
  (not CPU-native-fp16) "since MPS uses float32 intermediates for these
  ops" - but `conv_transpose3d` wasn't in that list despite this PR making
  it true for conv_transpose3d too. Without that fix, the OpInfo
  consistency test was comparing this PR's fp32-upcast MPS output against
  a *less accurate* CPU-native-fp16 reference and intermittently failing
  on ~0.1-0.3% of elements. Verified empirically (not just asserted) that
  this was a reference-quality artifact and not a bug in the upcast path:
  for the failing sample, MPS-fp16 (patched) had lower error against a true
  fp32 reference (max abs err 1.07e-2) than CPU-native-fp16 did against
  that same fp32 reference (max abs err 4.03e-2) - i.e. this PR's output is
  *more* accurate than the thing it was being compared against. Extended
  the same exemption to `conv_transpose3d`.
- New micro-benchmark comparing MPS fp16/bf16 (patched, upcast path)
  forward+backward output against a CPU fp32 reference, across a sweep of
  4 channel/spatial/stride/groups configurations representative of
  video-VAE decoder upsampling blocks:

  | dtype | mean abs error vs CPU-fp32 | max abs error vs CPU-fp32 | fwd time (relative to MPS fp32) |
  |---|---|---|---|
  | MPS fp32 (existing, control) | 3.3e-08 | 7.2e-07 | 1.0x |
  | MPS fp16 (this PR) | 1.0e-04 | 9.5e-04 | ~0.05x |
  | MPS bf16 (this PR) | 7.8e-04 | 7.7e-03 | ~0.03x |

  (max-relative-error is not reported here: a handful of near-zero output
  elements make relative error balloon to 30x-244x while absolute error
  stays in the fp16/bf16 rounding-noise range - the mean/max **absolute**
  error above is the metric that reflects real accuracy. Backward-pass
  grad_input mean abs error: fp32 control 3.1e-11, fp16 6.7e-08, bf16
  4.9e-07 - same pattern.) Forward-pass timing above is directory-order
  sensitive (MPS fp32 runs first per config and absorbs one-time
  MPSGraph-compile overhead the later fp16/bf16 runs don't pay), so treat
  it as illustrative, not a rigorous fp16-vs-fp32 speed comparison.

  Full sweep results: see `convtranspose3d_validation_results.json`
  (generated by `validate_convtranspose3d_patch.py --grad`, attached to
  this PR / linked in a comment).

- Manual repro of the original bug report from #160739 now passes:

  ```python
  import torch, torch.nn as nn
  model = nn.ConvTranspose3d(in_channels=1, out_channels=1, kernel_size=3, device="mps", dtype=torch.half)
  input = torch.randn(1, 1, 5, 5, 5, device="mps", dtype=torch.half)
  model(input)  # previously: RuntimeError; now: succeeds
  ```

## Hardware / environment tested

- Mac: Apple M5 Max, 40-core GPU, 128 GB unified memory
- macOS: 26.4.1 (build 25E253)
- PyTorch: built from `6dc52141b1c94dc50536be3f26235b5c3833e61e` (main)

cc @kulinseth @albanD @malfet @DenisVieriu97 @jhavukainen (tagged on the
related issues/PRs this addresses)