### PR TITLE
[DOC] Fix math formula for `nn.MaxPool1d` output size calculation

### DIFF
--- a/torch/nn/modules/pooling.py
+++ b/torch/nn/modules/pooling.py
@@ -117,8 +117,8 @@ class MaxPool1d(_MaxPoolNd):
           where ``ceil_mode = True``
 
           .. math::
-              L_{out} = \left\lceil \frac{L_{in} + 2 \times \text{padding} - \text{dilation}
-                    \times (\text{kernel\_size} - 1) - 1 + (stride - 1)}{\text{stride}}\right\rceil + 1
+              L_{out} = \left\lfloor \frac{L_{in} + 2 \times \text{padding} - \text{dilation}
+                    \times (\text{kernel\_size} - 1) - 1 + (\text{stride} - 1)}{\text{stride}}\right\rfloor + 1
 
         - Ensure that the last pooling starts inside the image, make :math:`L_{out} = L_{out} - 1`
           when :math:`(L_{out} - 1) * \text{stride} >= L_{in} + \text{padding}`.


### PR DESCRIPTION
The output-size formula for `nn.MaxPool1d` when `ceil_mode=True` is incorrect in the [PyTorch documentation](https://docs.pytorch.org/docs/2.12/generated/torch.nn.MaxPool1d.html):

<img width="1542" height="182" alt="image" src="https://github.com/user-attachments/assets/affc0ae1-f0ab-4cd3-aa35-0986afb76520" />

The correct one should be:

<img width="2281" height="243" alt="image" src="https://github.com/user-attachments/assets/31a05381-68f3-42b6-9d2b-cdf001360f78" />