### PR TITLE
[dynamo] Add Protocols and precise types for fixed-interface Any objects

### DIFF
--- a/torch/_dynamo/compiled_autograd.py
+++ b/torch/_dynamo/compiled_autograd.py
@@ -21,7 +21,7 @@ import operator
 import time
 from collections import Counter, defaultdict
 from collections.abc import Callable, Generator, Sequence
-from typing import Any, Literal, TYPE_CHECKING
+from typing import Any, cast, Literal, Protocol, TYPE_CHECKING
 
 import torch
 import torch.utils._pytree as pytree
@@ -67,6 +67,7 @@ from torch.utils._traceback import CapturedTraceback
 
 
 if TYPE_CHECKING:
+    from torch._functorch._aot_autograd.schemas import SubclassMeta, ViewAndMutationMeta
     from torch.fx.proxy import Proxy
 
 
@@ -107,11 +108,27 @@ def maybe_clone(x: torch.Tensor | None) -> torch.Tensor | None:
     return x
 
 
-def extract_bw_module(CompiledFunction: Any) -> Callable[..., Any]:
+class _AOTCompiledFunction(Protocol):
+    """Structural type for the AOTAutograd autograd.Function subclass that
+    compiled autograd retraces. The concrete class is generated locally inside
+    AOTAutograd, so we describe only the private attributes consumed here.
+    """
+
+    _lazy_backward_info: (
+        AutogradLazyBackwardCompileInfo | CachedAutogradLazyBackwardCompileInfo | None
+    )
+    metadata: "ViewAndMutationMeta"
+    maybe_subclass_metadata: "SubclassMeta | None"
+    _aot_id: int
+    _bw_prologue_fn: Callable[..., Any]
+    _bw_epilogue_fn: Callable[..., Any]
+
+
+def extract_bw_module(CompiledFunction: _AOTCompiledFunction) -> GraphModule:
     if isinstance(
         CompiledFunction._lazy_backward_info, AutogradLazyBackwardCompileInfo
     ):
-        return CompiledFunction._lazy_backward_info.bw_module
+        return cast(GraphModule, CompiledFunction._lazy_backward_info.bw_module)
     elif isinstance(
         CompiledFunction._lazy_backward_info, CachedAutogradLazyBackwardCompileInfo
     ):
@@ -480,8 +497,8 @@ class AutogradCompilerInstance:
         pinputs: Sequence[Any],
         psaved_tensors: Sequence[torch.Tensor],
         saved_tensors: Sequence[torch.Tensor],
-        pctx: Any,
-        ctx: Any,
+        pctx: "Proxy",
+        ctx: torch.autograd.function.BackwardCFunction,
         maybe_backward_state_idx: int | None,
         opaque_object_indices: list[int],
     ) -> Sequence[Any]:
@@ -496,7 +513,10 @@ class AutogradCompilerInstance:
         # If Dynamo graph capture were better, then we could add a node for the prologue
         # into the CA graph and have Dynamo trace into it.
 
-        psymints = [self.to_proxy(e) for e in ctx._get_compiled_autograd_symints()]
+        psymints = [
+            self.to_proxy(e)
+            for e in ctx._get_compiled_autograd_symints()  # type: ignore[attr-defined]
+        ]
 
         popaque_objects = [
             self.hooks_proxy[idx]  # type: ignore[index]
@@ -504,7 +524,7 @@ class AutogradCompilerInstance:
         ]
 
         # NOTE: we should only close over constants
-        CompiledFunction = ctx._forward_cls
+        CompiledFunction: _AOTCompiledFunction = ctx._forward_cls  # type: ignore[attr-defined]
         bw_module = extract_bw_module(CompiledFunction)
         metadata = CompiledFunction.metadata
         maybe_subclass_metadata = CompiledFunction.maybe_subclass_metadata
@@ -565,15 +585,15 @@ class AutogradCompilerInstance:
 
             # set up the proxy inputs to bw_module
             # the calling convention is: [*symints, *args (primals and tangents), backward_state]
-            num_args = num_inputs(bw_module.graph)  # type: ignore[attr-defined]
+            num_args = num_inputs(bw_module.graph)
             pall_args = [
                 pgrads[i] for i in range(num_args - int(pbackward_state is not None))
             ]
             # replace the symints with our symints
-            symints = ctx._get_compiled_autograd_symints()
-            if len(symints) != len(ctx.symints):
+            symints = ctx._get_compiled_autograd_symints()  # type: ignore[attr-defined]
+            if len(symints) != len(ctx.symints):  # type: ignore[attr-defined]
                 raise AssertionError(
-                    f"symints length mismatch: {len(symints)} vs {len(ctx.symints)}"
+                    f"symints length mismatch: {len(symints)} vs {len(ctx.symints)}"  # type: ignore[attr-defined]
                 )
             psymints = [self.to_proxy(e) for e in symints]
             pall_args[: len(symints)] = psymints
@@ -599,7 +619,7 @@ class AutogradCompilerInstance:
                 # make it both informative and unique
                 return f"aot{deduped_aot_id}_{node_name}"
 
-            for node in bw_module.graph.nodes:  # type: ignore[attr-defined]
+            for node in bw_module.graph.nodes:
                 if node.op == "placeholder":
                     ph = pall_args[args_idx].node
                     ph.name = make_unique(node.name)

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -8,7 +8,7 @@ import weakref
 from collections.abc import Callable
 from dataclasses import dataclass
 from types import TracebackType
-from typing import Any, overload, TYPE_CHECKING, TypeVar
+from typing import Any, overload, Protocol, TYPE_CHECKING, TypeVar
 from typing_extensions import ParamSpec
 
 import torch
@@ -1483,10 +1483,25 @@ def _allow_in_graph_einops() -> None:
 trace_rules.add_module_init_func("einops", _allow_in_graph_einops)
 
 
+class _ConfigPatchProtocol(Protocol):
+    """The config.patch() context manager object wrapped by DynamoConfigPatchProxy."""
+
+    changes: dict[str, Any]
+
+    def __enter__(self) -> None: ...
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None: ...
+
+
 # Proxy class for torch._dynamo.config patching - so dynamo can identify context managers/decorators
 # created by patch_dynamo_config, compared to ones created by a raw torch._dynamo.config.patch.
 class DynamoConfigPatchProxy:
-    def __init__(self, config_patch: Any) -> None:
+    def __init__(self, config_patch: _ConfigPatchProtocol) -> None:
         self.config_patch = config_patch
 
     @property

--- a/torch/_dynamo/functional_export.py
+++ b/torch/_dynamo/functional_export.py
@@ -21,7 +21,7 @@ from torch._dynamo.exc import UserErrorType
 from torch._dynamo.source import GetItemSource
 from torch._dynamo.utils import dynamo_timed, get_metrics_context
 from torch._export.utils import _compiling_state_context
-from torch._guards import detect_fake_mode, TracingContext
+from torch._guards import detect_fake_mode, Source, TracingContext
 from torch.export.dynamic_shapes import _RelaxedConstraint, Constraint
 from torch.fx.experimental.symbolic_shapes import (
     ConstraintViolationError,
@@ -259,8 +259,8 @@ class DynamoGraphTransformer(torch.fx.Transformer):
         flat_args_dynamic_dims: list[set[int]],
         graph_input_order: dict[int, int],
         graph_output_map: dict[int, OutputReturnInfo],
-        fake_mode: Any | None = None,
-        graph_inputs: dict[int, Any] | None = None,
+        fake_mode: FakeTensorMode | None = None,
+        graph_inputs: dict[int, Source | None] | None = None,
     ) -> None:
         super().__init__(module)
 
@@ -753,10 +753,8 @@ class _DynamoBytecodeCodeGen(torch.fx.graph.CodeGen):
     def __init__(
         self,
         orig_arg_names: list[str],
-        # pyrefly: ignore [implicit-any]
-        dynamo_bytecode_flatten: Callable,
-        # pyrefly: ignore [implicit-any]
-        dynamo_bytecode_unflatten: Callable,
+        dynamo_bytecode_flatten: DynamoBytecodeFlatten,
+        dynamo_bytecode_unflatten: DynamoBytecodeUnflatten,
     ) -> None:
         super().__init__()
         self.orig_arg_names = orig_arg_names
@@ -783,6 +781,8 @@ class _DynamoBytecodeCodeGen(torch.fx.graph.CodeGen):
         return results
 
     def process_outputs(self, outputs: Any) -> Any:
+        if self._inputs is None:
+            raise AssertionError("process_outputs called before process_inputs")
         results = self.dynamo_bytecode_unflatten(outputs, self._inputs)
         if self.wrap_tuple:
             results = (results,)

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -199,6 +199,9 @@ from .utils import (
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    GuardCheckGetMetadataFn = Callable[[Guard, Any], Any]
+    GuardCheckEvalFn = Callable[[Any, Any], bool]
+
 
 guard_manager_testing_hook_fn: Callable[[Any, Any, Any], Any] | None = None
 _COUNT_ITERATOR_TYPE = type(itertools.count())
@@ -1063,8 +1066,8 @@ class GuardCheckSpec(NamedTuple):
         time using a fresh value and the previously saved metadata.
     """
 
-    get_metadata_fn: Any
-    eval_fn: Any
+    get_metadata_fn: GuardCheckGetMetadataFn
+    eval_fn: GuardCheckEvalFn
 
 
 SKIP_GUARD = object()
@@ -1182,9 +1185,17 @@ def _constant_subclass_base_value(value: Any) -> Any:
     raise TypeError(f"Not a constant subclass: {type(value)}")
 
 
+def _guard_create_fn_keyword(guard: Guard, name: str) -> Any:
+    """Read a keyword bound into a guard's create_fn functools.partial."""
+    create_fn = guard.create_fn
+    if not isinstance(create_fn, functools.partial):
+        raise TypeError(f"Guard create_fn is not a functools.partial: {create_fn}")
+    return create_fn.keywords[name]
+
+
 def register_guard_check_spec(
-    get_metadata_fn,
-    eval_fn,
+    get_metadata_fn: GuardCheckGetMetadataFn,
+    eval_fn: GuardCheckEvalFn,
 ):
     """Attach a GuardCheckSpec to a guard method for auto-dispatch."""
     handler = GuardCheckSpec(get_metadata_fn=get_metadata_fn, eval_fn=eval_fn)
@@ -2147,8 +2158,8 @@ class GuardBuilder(GuardBuilderBase):
 
     @register_guard_check_spec(
         get_metadata_fn=lambda guard, value: (
-            guard.create_fn.keywords["attr"],
-            hasattr(value, guard.create_fn.keywords["attr"]),
+            _guard_create_fn_keyword(guard, "attr"),
+            hasattr(value, _guard_create_fn_keyword(guard, "attr")),
         ),
         eval_fn=lambda value, metadata: hasattr(value, metadata[0]) == metadata[1],
     )
@@ -2209,11 +2220,11 @@ class GuardBuilder(GuardBuilderBase):
         self.already_added_code_parts.add(code)
 
     @register_guard_check_spec(
-        get_metadata_fn=lambda guard, value: guard.create_fn.keywords["attr"],
+        get_metadata_fn=lambda guard, value: _guard_create_fn_keyword(guard, "attr"),
         eval_fn=lambda value, metadata: metadata not in value.__dict__,
     )
     def NOT_PRESENT_IN_GENERIC_DICT(
-        self, guard: Guard, attr: Any | None = None
+        self, guard: Guard, attr: str | None = None
     ) -> None:
         if attr is None:
             raise AssertionError(
@@ -2328,7 +2339,7 @@ class GuardBuilder(GuardBuilderBase):
         )
 
     @register_guard_check_spec(
-        get_metadata_fn=lambda guard, value: guard.create_fn.keywords["key"],
+        get_metadata_fn=lambda guard, value: _guard_create_fn_keyword(guard, "key"),
         eval_fn=lambda value, metadata: metadata in value,
     )
     def DICT_CONTAINS(self, guard: Guard, key: str) -> None:
@@ -2348,7 +2359,7 @@ class GuardBuilder(GuardBuilderBase):
         self.already_added_code_parts.add(code)
 
     @register_guard_check_spec(
-        get_metadata_fn=lambda guard, value: guard.create_fn.keywords["key"],
+        get_metadata_fn=lambda guard, value: _guard_create_fn_keyword(guard, "key"),
         eval_fn=lambda value, metadata: metadata not in value,
     )
     def DICT_NOT_CONTAINS(self, guard: Guard, key: str) -> None:
@@ -2368,7 +2379,7 @@ class GuardBuilder(GuardBuilderBase):
         self.already_added_code_parts.add(code)
 
     @register_guard_check_spec(
-        get_metadata_fn=lambda guard, value: guard.create_fn.keywords["key"],
+        get_metadata_fn=lambda guard, value: _guard_create_fn_keyword(guard, "key"),
         eval_fn=lambda value, metadata: metadata in value,
     )
     def SET_CONTAINS(self, guard: Guard, key: Any) -> None:
@@ -2390,7 +2401,7 @@ class GuardBuilder(GuardBuilderBase):
         self.already_added_code_parts.add(code)
 
     @register_guard_check_spec(
-        get_metadata_fn=lambda guard, value: guard.create_fn.keywords["key"],
+        get_metadata_fn=lambda guard, value: _guard_create_fn_keyword(guard, "key"),
         eval_fn=lambda value, metadata: metadata not in value,
     )
     def SET_NOT_CONTAINS(self, guard: Guard, key: Any) -> None:
@@ -5267,8 +5278,7 @@ def get_guard_fail_reason_helper(
     guard_manager: GuardManagerWrapper,
     f_locals: dict[str, object],
     compile_id: CompileId | None,
-    # pyrefly: ignore [implicit-any]
-    backend: Callable | None,
+    backend: Callable[..., object] | None,
 ) -> str:
     """
     Return the reason why `guard_manager` failed.
@@ -5381,8 +5391,7 @@ def get_guard_fail_reason(
     code: types.CodeType,
     f_locals: dict[str, object],
     compile_id: CompileId,
-    # pyrefly: ignore [implicit-any]
-    backend: Callable,
+    backend: Callable[..., object],
     skip_logging: bool = False,
 ) -> str:
     if isinstance(guard_manager, DeletedGuardManagerWrapper):
@@ -5410,8 +5419,7 @@ def get_guard_fail_reason(
 def get_and_maybe_log_recompilation_reasons(
     cache_entries: list[CacheEntry],
     frame: DynamoFrameType,
-    # pyrefly: ignore [implicit-any]
-    backend: Callable,
+    backend: Callable[..., object],
     skip_logging: bool = False,
 ) -> list[str]:
     """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* (to be filled)

Replaces `Any` annotations with precise types wherever a value is only ever
accessed through a small, fixed interface. Where the concrete producer type is
unnameable (locally-defined classes) a Protocol documents the consumed surface;
elsewhere existing concrete types are used directly.

Suggested review order:

- guards.py: give `GuardCheckSpec.get_metadata_fn`/`eval_fn` and the
  `register_guard_check_spec` factory precise `Callable` aliases matching the
  signatures documented on the class; type the three `backend` parameters to
  match `describe_backend` (dropping the `implicit-any` suppressions); tighten
  `NOT_PRESENT_IN_GENERIC_DICT`'s `attr` to `str | None`. A small
  `_guard_create_fn_keyword` helper reads the functools.partial keyword the
  registration lambdas need so they type-check against the new aliases.
- decorators.py: `DynamoConfigPatchProxy.config_patch` gets a small Protocol
  (`changes`, `__enter__`, `__exit__`) since `config.patch()` returns a
  locally-defined context manager class.
- compiled_autograd.py: introduce `_AOTCompiledFunction` Protocol for the
  AOTAutograd-generated autograd.Function that compiled autograd retraces;
  tighten `extract_bw_module` to return `torch.fx.GraphModule` (removing two
  now-unnecessary attr-defined suppressions on `bw_module.graph`); type
  `proxy_call_aot_backward`'s `ctx`/`pctx`.
- functional_export.py: `DynamoGraphTransformer` gets `fake_mode:
  FakeTensorMode | None` and `graph_inputs: dict[int, Source | None] | None`
  (the `| None` value matches the `graph_input_idx_to_local_source` producer);
  the bytecode codegen takes concrete
  `DynamoBytecodeFlatten`/`DynamoBytecodeUnflatten` instead of bare `Callable`.

All changes are type-only except two fail-fast guards on already-impossible
paths (a non-partial `create_fn`, and `process_outputs` before `process_inputs`)
and a no-op `cast`.

Test Plan:

Type-checking and lint are the relevant verification for an annotation-only
change; the modified files are clean:

```
lintrunner --take PYFMT,RUFF,PYREFLY,CODESPELL,FLAKE8 \
  torch/_dynamo/guards.py \
  torch/_dynamo/decorators.py \
  torch/_dynamo/compiled_autograd.py \
  torch/_dynamo/functional_export.py
```

This PR was authored with the assistance of an AI coding assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @xmfan @aditvenk