### PR TITLE
[dynamo, nested graph breaks] fix exhausted generator reconstruction

### DIFF
--- a/test/dynamo/test_nested_graph_breaks.py
+++ b/test/dynamo/test_nested_graph_breaks.py
@@ -1606,6 +1606,65 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         inp = torch.randn(3)
         self.assertEqual(fn(inp), inp + 1)
 
+    def test_exhausted_generator_across_graph_break(self):
+        """Reconstruct an exhausted generator after a graph break.
+
+        Regression test: LocalGeneratorObjectVariable.reconstruct() crashed
+        with AttributeError on 'remaining_items' when the generator was
+        exhausted, because the field was only set inside a conditional.
+        The generator must be fully consumed (exhausted) and still in locals
+        when a graph break occurs inside a nested inlined function -- the NGB
+        stack reconstruction includes outer locals, so the exhausted generator
+        gets reconstruct()'d.
+        """
+        cnts = torch._dynamo.testing.CompileCounter()
+
+        def my_generator(n):
+            for i in range(n):  # noqa: UP028
+                yield i
+
+        def inner(x, val):
+            torch._dynamo.graph_break()
+            return x + val
+
+        @torch.compile(backend=cnts)
+        def fn(x):
+            gen = my_generator(3)
+            total = 0
+            for val in gen:
+                total += val
+            result = inner(x, total)
+            # Reference gen after the graph break to keep it live in locals
+            # during NGB stack reconstruction.
+            type(gen)
+            return result
+
+        inp = torch.tensor(10.0)
+        result = fn(inp)
+        self.assertEqual(result, inp + 3)
+
+    def test_generator_star_unpack_with_graph_break(self):
+        """Generator unpacked as *args must survive two-pass codegen.
+
+        reconstruct() is called twice during compile_subgraph (pass1 for use
+        counting, pass2 for actual codegen). The remaining items from the
+        generator must be cached so the second call doesn't see an empty
+        generator. CALL_FUNCTION_EX with *generator + **kwargs triggers a
+        graph break, putting the unconsumed generator on the stack.
+        """
+
+        def my_generator(n):
+            for i in range(n):
+                yield i + 1
+
+        @torch.compile(backend="eager")
+        def fn():
+            shape = my_generator(2)
+            return torch.randn(*shape, requires_grad=True)
+
+        result = fn()
+        self.assertEqual(result.shape, torch.Size([1, 2]))
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -1149,6 +1149,7 @@ class LocalGeneratorObjectVariable(VariableTracker):
         self.code = code
         self.f_globals = f_globals
         self.inline_tracer = inline_tracer
+        self.remaining_items: list[VariableTracker] | None = None
 
     def get_code(self) -> types.CodeType:
         return self.code
@@ -1186,9 +1187,12 @@ class LocalGeneratorObjectVariable(VariableTracker):
         temp = temporarely_allow_writes_to_output_graph(tx)
 
         with save, disallow, temp:
-            tracer = self.inline_tracer
-            if not tracer.generator_exhausted:
-                self.remaining_items = unpack_iterable(tx, self)  # type: ignore[bad-argument-type]
+            if self.remaining_items is None:
+                tracer = self.inline_tracer
+                if not tracer.generator_exhausted:
+                    self.remaining_items = unpack_iterable(tx, self)  # type: ignore[bad-argument-type]
+                else:
+                    self.remaining_items = []
             variables.ListIteratorVariable(self.remaining_items).reconstruct(codegen)
 
     def get_globals(self) -> dict[str, Any]:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #171826
* #163503
* #185524
* #188173
* #186100
* #186657
* __->__ #188738
* #188596
* #188622

`LocalGeneratorObjectVariable.reconstruct()` crashed with `AttributeError:
'remaining_items'` when the generator was exhausted. The bug: `remaining_items`
was stored as `self.remaining_items` only inside an `if not
tracer.generator_exhausted` branch, but unconditionally accessed on the next
line. When the generator was exhausted, the attribute was never set.

The fix initializes `remaining_items` to `None` in `__init__` and lazily
populates it on the first `reconstruct()` call. This is necessary because
`reconstruct()` is called twice (two codegen passes in `compile_subgraph`), so
the result must be cached -- `unpack_iterable` exhausts the generator on the
first call. When the generator was already exhausted before reconstruction, an
empty list is cached instead.

This manifests in two scenarios:
1. A generator (e.g. `itertools.islice`) is fully consumed and still alive in
   locals when a nested graph break occurs in a subsequently inlined function --
   the NGB stack reconstruction includes outer locals.
2. A generator used as `*args` in a `CALL_FUNCTION_EX` (e.g.
   `torch.randn(*(gen), requires_grad=True)`) -- the instruction itself causes
   a graph break while the unconsumed generator is on the operand stack.

Test Plan:
Added two regression tests to `test/dynamo/test_nested_graph_breaks.py`:
- `test_exhausted_generator_across_graph_break`: exhausts a generator in a for
  loop, then triggers a graph break in an inlined function while the generator
  is still live in locals.
- `test_generator_star_unpack_with_graph_break`: uses a generator as `*args`
  with kwargs, triggering a `CALL_FUNCTION_EX` graph break while the unconsumed
  generator is on the stack.

```
python test/dynamo/test_nested_graph_breaks.py -k test_exhausted_generator -k test_generator_star_unpack
PYTORCH_TEST_WITH_DYNAMO=1 python test/test_spectral_ops.py TestFFTCPU.test_fftn_round_trip_cpu_float32
PYTORCH_TEST_WITH_DYNAMO=1 python test/test_nestedtensor.py TestNestedTensorSubclassCPU.test_as_nested_tensor_from_tensor_dim_1_layout_jagged_requires_grad_True_contiguous_False_cpu_float16
```

Co-authored-by: Claude <noreply@anthropic.com>