### PR TITLE
[SymmMem] Place the signal pad at the front of symmetric memory allocations

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
@@ -405,18 +405,18 @@ void* CUDASymmetricMemoryAllocator::alloc(
   TORCH_CHECK(
       false, "CUDASymmetricMemory requires PYTORCH_C10_DRIVER_API_SUPPORTED");
 #endif
-  void* ptr = nullptr;
-  map_block(&ptr, handle, block_size, device_idx);
+  void* alloc_base = nullptr;
+  map_block(&alloc_base, handle, block_size, device_idx);
 
   // Zero the whole block; this initializes the signal pad (at the front) for
   // the CAS-based barrier() protocol.
-  AT_CUDA_CHECK(cudaMemset(ptr, 0, block_size));
+  AT_CUDA_CHECK(cudaMemset(alloc_base, 0, block_size));
 
   // Hand back the data buffer pointer; the signal pad stays hidden in front.
-  void* buffer_ptr = static_cast<char*>(ptr) + buffer_offset;
+  void* buffer_ptr = static_cast<char*>(alloc_base) + buffer_offset;
 
-  auto alloc_ref =
-      c10::make_intrusive<AllocationRef>(ptr, handle, block_size, device_idx);
+  auto alloc_ref = c10::make_intrusive<AllocationRef>(
+      alloc_base, handle, block_size, device_idx);
   auto block = c10::make_intrusive<Block>(
       std::move(alloc_ref),
       device_idx,

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
@@ -328,13 +328,13 @@ Block::Block(
     int device_idx,
     size_t block_size,
     size_t buffer_size,
-    size_t signal_pad_offset,
+    size_t buffer_offset,
     const std::optional<std::string>& group_name)
     : alloc_ref(std::move(alloc_ref)),
       device_idx(device_idx),
       block_size(block_size),
       buffer_size(buffer_size),
-      signal_pad_offset(signal_pad_offset),
+      buffer_offset(buffer_offset),
       default_group_name(std::move(group_name)) {}
 
 namespace {
@@ -346,8 +346,12 @@ void* CUDASymmetricMemoryAllocator::alloc(
     size_t size,
     int device_idx,
     const std::optional<std::string>& group_name) {
-  size_t signal_pad_offset = at::round_up(size, 16UL);
-  size_t block_size = signal_pad_offset + get_signal_pad_size();
+  // Layout: signal pad first at [0, signal_pad_size), then the data buffer at
+  // buffer_offset = signal_pad_size. The signal pad size is already 16-aligned,
+  // so the data buffer is aligned without extra padding; round up the data
+  // size instead.
+  size_t buffer_offset = get_signal_pad_size();
+  size_t block_size = buffer_offset + at::round_up(size, 16UL);
   c10::cuda::CUDAGuard guard(device_idx);
   device_idx = static_cast<int>(guard.current_device().index());
 #if !defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
@@ -404,7 +408,12 @@ void* CUDASymmetricMemoryAllocator::alloc(
   void* ptr = nullptr;
   map_block(&ptr, handle, block_size, device_idx);
 
+  // Zero the whole block; this initializes the signal pad (at the front) for
+  // the CAS-based barrier() protocol.
   AT_CUDA_CHECK(cudaMemset(ptr, 0, block_size));
+
+  // Hand back the data buffer pointer; the signal pad stays hidden in front.
+  void* buffer_ptr = static_cast<char*>(ptr) + buffer_offset;
 
   auto alloc_ref =
       c10::make_intrusive<AllocationRef>(ptr, handle, block_size, device_idx);
@@ -413,13 +422,14 @@ void* CUDASymmetricMemoryAllocator::alloc(
       device_idx,
       block_size,
       size,
-      signal_pad_offset,
+      buffer_offset,
       group_name);
   {
     std::unique_lock lock(mutex_);
-    ptr_to_block_.emplace(ptr, std::move(block));
+    // Key by the data pointer we return (that's what free()/rendezvous see).
+    ptr_to_block_.emplace(buffer_ptr, std::move(block));
   }
-  return ptr;
+  return buffer_ptr;
 }
 
 void CUDASymmetricMemoryAllocator::free(void* ptr) {
@@ -441,7 +451,7 @@ struct RendezvousRequest {
   int pid;
   size_t block_size;
   size_t buffer_size;
-  size_t signal_pad_offset;
+  size_t buffer_offset;
   bool has_multicast_support;
   int clique_id;
   char hostname[HOST_NAME_MAX + 1];
@@ -487,7 +497,7 @@ void validate_rendezvous_requests(
   for (int r = 1; r < world_size; ++r) {
     TORCH_CHECK(reqs[r].block_size == reqs[0].block_size);
     TORCH_CHECK(reqs[r].buffer_size == reqs[0].buffer_size);
-    TORCH_CHECK(reqs[r].signal_pad_offset == reqs[0].signal_pad_offset);
+    TORCH_CHECK(reqs[r].buffer_offset == reqs[0].buffer_offset);
   }
 }
 
@@ -657,7 +667,6 @@ check_all:
 namespace {
 template <bool use_fabric_handle>
 c10::intrusive_ptr<CUDAPeerAllocInfo> make_peer_alloc_info(
-    void* ptr,
     c10::intrusive_ptr<Block> block,
     const std::string& group_name) {
 #if defined(USE_ROCM)
@@ -713,7 +722,7 @@ c10::intrusive_ptr<CUDAPeerAllocInfo> make_peer_alloc_info(
       .pid = getpid(),
       .block_size = block->block_size,
       .buffer_size = block->buffer_size,
-      .signal_pad_offset = block->signal_pad_offset,
+      .buffer_offset = block->buffer_offset,
       .has_multicast_support = device_has_multicast_support(block->device_idx),
       .clique_id = at::cuda::get_fabric_clique_id(block->device_idx)};
 
@@ -750,9 +759,14 @@ c10::intrusive_ptr<CUDAPeerAllocInfo> make_peer_alloc_info(
 
   for (int r = 0; r < world_size; ++r) {
     if (r == rank) {
+      // Derive both pointers from the allocation base (not the rendezvous
+      // ptr, which may be an interior MemPool pointer): this pai is shared by
+      // every handle on the allocation, and per-handle offsets are applied
+      // separately.
       handles[r] = block->alloc_ref->handle;
-      buffers[r] = ptr;
-      signal_pads[r] = (void*)((uintptr_t)ptr + block->signal_pad_offset);
+      signal_pads[r] = block->alloc_ref->ptr;
+      buffers[r] =
+          (void*)((uintptr_t)block->alloc_ref->ptr + block->buffer_offset);
       continue;
     }
     // This api imports a GPU memory allocation that was previously exported as
@@ -788,8 +802,12 @@ c10::intrusive_ptr<CUDAPeerAllocInfo> make_peer_alloc_info(
     TORCH_CHECK(
         false, "CUDASymmetricMemory requires PYTORCH_C10_DRIVER_API_SUPPORTED");
 #endif
-    map_block(&buffers[r], handles[r], block->block_size, block->device_idx);
-    signal_pads[r] = (void*)((uintptr_t)buffers[r] + block->signal_pad_offset);
+    // map_block returns the mapped base (== signal pad base); the data buffer
+    // follows at buffer_offset.
+    void* base = nullptr;
+    map_block(&base, handles[r], block->block_size, block->device_idx);
+    signal_pads[r] = base;
+    buffers[r] = (void*)((uintptr_t)base + block->buffer_offset);
     if constexpr (!use_fabric_handle) {
       close(imported_handles[r]);
     }
@@ -822,16 +840,24 @@ c10::intrusive_ptr<CUDAPeerAllocInfo> make_peer_alloc_info(
       alloc_refs.emplace_back(block->alloc_ref);
       continue;
     }
+    // signal_pads[r] holds peer r's mapped base (== signal pad base), which is
+    // the address AllocationRef must unmap.
     alloc_refs.push_back(c10::make_intrusive<AllocationRef>(
-        buffers[r], handles[r], block->block_size, block->device_idx));
+        signal_pads[r], handles[r], block->block_size, block->device_idx));
   }
+
+  // The multicast mapping mirrors the block layout, so the data buffer lives at
+  // buffer_offset within it; get_multicast_ptr() adds the per-handle offset.
+  void* mc_buffer_addr = mc_addr != nullptr
+      ? (void*)((uintptr_t)mc_addr + block->buffer_offset)
+      : nullptr;
 
   auto pai = c10::make_intrusive<CUDAPeerAllocInfo>(
       std::move(alloc_refs),
       std::move(buffers),
       std::move(signal_pads),
       mc_handle,
-      mc_addr,
+      mc_buffer_addr,
       block->buffer_size,
       block->device_idx,
       rank,
@@ -883,8 +909,8 @@ c10::intrusive_ptr<SymmetricMemory> CUDASymmetricMemoryAllocator::rendezvous(
     bool use_fabric =
         handle_type_ == Expandable_Segments_Handle_Type::FABRIC_HANDLE;
     // PeerAllocInfo captures this block's rendezvous info
-    auto pai = use_fabric ? make_peer_alloc_info<true>(ptr, block, group_name_)
-                          : make_peer_alloc_info<false>(ptr, block, group_name_);
+    auto pai = use_fabric ? make_peer_alloc_info<true>(block, group_name_)
+                          : make_peer_alloc_info<false>(block, group_name_);
     // Cache it with the group name
     it = block->symm_mems.emplace(group_name_, pai).first;
   }
@@ -927,10 +953,12 @@ c10::intrusive_ptr<Block> CUDASymmetricMemoryAllocator::find_block_covering(void
                                 auto& block = pair.second;
                                 auto& allocation = block->alloc_ref;
                                 auto ptr_int = reinterpret_cast<uintptr_t>(ptr);
-                                auto base_ptr = reinterpret_cast<uintptr_t>(allocation->ptr);
+                                // The data buffer starts buffer_offset bytes
+                                // into the allocation (past the signal pad).
+                                auto data_base = reinterpret_cast<uintptr_t>(allocation->ptr) + block->buffer_offset;
                                 // Modify offset so that it is returned
-                                offset = ptr_int - base_ptr;
-                                return ptr_int >= base_ptr && offset < block->buffer_size; });
+                                offset = ptr_int - data_base;
+                                return ptr_int >= data_base && offset < block->buffer_size; });
 
   if (alloc_it == ptr_to_block_.end()) {
     return nullptr;

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
@@ -408,11 +408,18 @@ void* CUDASymmetricMemoryAllocator::alloc(
   void* alloc_base = nullptr;
   map_block(&alloc_base, handle, block_size, device_idx);
 
-  // Zero the whole block; this initializes the signal pad (at the front) for
-  // the CAS-based barrier() protocol.
-  AT_CUDA_CHECK(cudaMemset(alloc_base, 0, block_size));
+  // Zero the signal pad (at the front, [0, buffer_offset)) to initialize it for
+  // the CAS-based barrier() protocol; the data buffer that follows does not need
+  // zeroing. This matches the NCCL/NVSHMEM backends, which also only clear the
+  // signal pad. Memsetting the whole (granularity-rounded) block instead fails
+  // with "invalid argument" on some devices (e.g. B200 / CUDA 13).
+  AT_CUDA_CHECK(cudaMemset(alloc_base, 0, buffer_offset));
 
-  // Hand back the data buffer pointer; the signal pad stays hidden in front.
+  // Hand back the data buffer pointer, not alloc_base; the signal pad stays
+  // hidden in front. Returning the data ptr (rather than the alloc ptr) is safe
+  // for free(): the whole block is owned by the AllocationRef held in the Block,
+  // so free() only needs the data ptr to find and drop the Block; the block
+  // (and thus alloc_base) is released internally by ~AllocationRef.
   void* buffer_ptr = static_cast<char*>(alloc_base) + buffer_offset;
 
   auto alloc_ref = c10::make_intrusive<AllocationRef>(
@@ -756,6 +763,9 @@ c10::intrusive_ptr<CUDAPeerAllocInfo> make_peer_alloc_info(
   std::vector<HandleType> handles(world_size);
   std::vector<void*> buffers(world_size, nullptr);
   std::vector<void*> signal_pads(world_size, nullptr);
+  // Mapped base (== signal pad base) per rank; kept separately so AllocationRef
+  // gets an explicit base to unmap rather than relying on signal_pads[r].
+  std::vector<void*> bases(world_size, nullptr);
 
   for (int r = 0; r < world_size; ++r) {
     if (r == rank) {
@@ -764,6 +774,7 @@ c10::intrusive_ptr<CUDAPeerAllocInfo> make_peer_alloc_info(
       // every handle on the allocation, and per-handle offsets are applied
       // separately.
       handles[r] = block->alloc_ref->handle;
+      bases[r] = block->alloc_ref->ptr;
       signal_pads[r] = block->alloc_ref->ptr;
       buffers[r] =
           (void*)((uintptr_t)block->alloc_ref->ptr + block->buffer_offset);
@@ -806,6 +817,7 @@ c10::intrusive_ptr<CUDAPeerAllocInfo> make_peer_alloc_info(
     // follows at buffer_offset.
     void* base = nullptr;
     map_block(&base, handles[r], block->block_size, block->device_idx);
+    bases[r] = base;
     signal_pads[r] = base;
     buffers[r] = (void*)((uintptr_t)base + block->buffer_offset);
     if constexpr (!use_fabric_handle) {
@@ -840,10 +852,9 @@ c10::intrusive_ptr<CUDAPeerAllocInfo> make_peer_alloc_info(
       alloc_refs.emplace_back(block->alloc_ref);
       continue;
     }
-    // signal_pads[r] holds peer r's mapped base (== signal pad base), which is
-    // the address AllocationRef must unmap.
+    // bases[r] is peer r's mapped base, i.e. the address AllocationRef unmaps.
     alloc_refs.push_back(c10::make_intrusive<AllocationRef>(
-        signal_pads[r], handles[r], block->block_size, block->device_idx));
+        bases[r], handles[r], block->block_size, block->device_idx));
   }
 
   // The multicast mapping mirrors the block layout, so the data buffer lives at

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.hpp
@@ -113,8 +113,8 @@ struct Block : public c10::intrusive_ptr_target {
   int device_idx;
   size_t block_size;
   size_t buffer_size;
-  // Offset of the data buffer from the allocation base. The signal pad sits at
-  // [0, buffer_offset) and the data buffer at [buffer_offset, ...).
+  // Byte offset from the allocation base (alloc_ref->ptr) to the start of the
+  // user buffer; the signal pad occupies [0, buffer_offset).
   size_t buffer_offset;
   std::optional<std::string> default_group_name;
   std::map<std::string, c10::intrusive_ptr<CUDAPeerAllocInfo>> symm_mems;

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.hpp
@@ -113,7 +113,9 @@ struct Block : public c10::intrusive_ptr_target {
   int device_idx;
   size_t block_size;
   size_t buffer_size;
-  size_t signal_pad_offset;
+  // Offset of the data buffer from the allocation base. The signal pad sits at
+  // [0, buffer_offset) and the data buffer at [buffer_offset, ...).
+  size_t buffer_offset;
   std::optional<std::string> default_group_name;
   std::map<std::string, c10::intrusive_ptr<CUDAPeerAllocInfo>> symm_mems;
 
@@ -122,7 +124,7 @@ struct Block : public c10::intrusive_ptr_target {
       int device_idx,
       size_t block_size,
       size_t buffer_size,
-      size_t signal_pad_offset,
+      size_t buffer_offset,
       const std::optional<std::string>& group_name);
 };
 

--- a/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
@@ -37,14 +37,14 @@ struct NCCLAllocation {
   // Combined ncclMemAlloc region. Layout (signal pad first):
   //   [0, buffer_offset)                            - signal pad
   //   [buffer_offset, buffer_offset + buffer_size)  - user data buffer
-  // buffer_offset equals the signal pad size (already 16-aligned). `ptr` is the
-  // ncclMemAlloc base (== signal pad base); alloc() hands back
-  // `ptr + buffer_offset` (the data buffer).
-  void* ptr;
+  // buffer_offset equals the signal pad size (already 16-aligned). alloc_base is
+  // the ncclMemAlloc base (== signal pad base); alloc() hands back
+  // `alloc_base + buffer_offset` (the data buffer).
+  void* alloc_base;
   // Size of the user-visible data buffer in bytes, as requested by alloc().
   size_t buffer_size;
-  // Offset of the data buffer from `ptr`; the signal pad occupies
-  // [0, buffer_offset).
+  // Byte offset from alloc_base to the start of the user buffer; the signal pad
+  // occupies [0, buffer_offset).
   size_t buffer_offset;
   int device_idx;
   std::mutex mutex;
@@ -53,11 +53,11 @@ struct NCCLAllocation {
       peer_alloc_infos_;
 
   NCCLAllocation(
-      void* ptr,
+      void* alloc_base,
       size_t buffer_size,
       size_t buffer_offset,
       int device_idx)
-      : ptr(ptr),
+      : alloc_base(alloc_base),
         buffer_size(buffer_size),
         buffer_offset(buffer_offset),
         device_idx(device_idx) {}
@@ -69,7 +69,7 @@ struct NCCLAllocation {
     }
     c10::cuda::CUDAGuard guard(device_idx);
     // Single free for the combined buffer + signal pad region.
-    ncclResult_t res = ncclMemFree(ptr);
+    ncclResult_t res = ncclMemFree(alloc_base);
     if (res != ncclSuccess) {
         LOG(WARNING) << "ncclMemFree failed in NCCLAllocation dtor: "
                       << ncclGetErrorString(res);
@@ -94,8 +94,8 @@ bool pointer_in_allocation(void* ptr, const NCCLAllocation& allocation) {
   auto ptr_int = reinterpret_cast<uintptr_t>(ptr);
   // The data buffer starts `buffer_offset` bytes into the allocation (past the
   // signal pad); only data-region pointers belong to this allocation.
-  auto data_base =
-      reinterpret_cast<uintptr_t>(allocation.ptr) + allocation.buffer_offset;
+  auto data_base = reinterpret_cast<uintptr_t>(allocation.alloc_base) +
+      allocation.buffer_offset;
   return ptr_int >= data_base && ptr_int < data_base + allocation.buffer_size;
 }
 
@@ -138,6 +138,8 @@ NCCLAllocMap::iterator find_allocation_covering(
       return alloc_it;
     }
   }
+#else
+  // No driver API support here, so fall through to the linear scan below.
 #endif
   return find_allocation_covering_linear(ptr, allocations);
 }
@@ -211,10 +213,10 @@ class NCCLPeerAllocInfo : public c10::intrusive_ptr_target {
     const size_t aligned_buffer_size = at::round_up(buffer_size_, 16UL);
     const size_t total_size = buffer_offset_ + aligned_buffer_size;
     C10D_NCCL_CHECK(
-      ncclCommWindowRegister(comm_, allocation->ptr, total_size, &combined_win_, NCCL_WIN_COLL_SYMMETRIC),
+      ncclCommWindowRegister(comm_, allocation->alloc_base, total_size, &combined_win_, NCCL_WIN_COLL_SYMMETRIC),
       c10::str(
           "Failed to window register segment with ptr ",
-          allocation->ptr,
+          allocation->alloc_base,
           ", size ",
           total_size,
           " on rank ",
@@ -325,8 +327,8 @@ class NCCLPeerAllocInfo : public c10::intrusive_ptr_target {
 
  private:
   size_t buffer_size_;
-  // Offset of the data buffer from the allocation base; the signal pad sits at
-  // [0, buffer_offset_) and the data buffer at [buffer_offset_, ...).
+  // Byte offset from the allocation base to the start of the user buffer; the
+  // signal pad occupies [0, buffer_offset_).
   size_t buffer_offset_;
   int device_idx_;
   int rank_;
@@ -517,20 +519,21 @@ class NCCLSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
     const size_t buffer_offset = get_signal_pad_size();
     const size_t aligned_buffer_size = at::round_up(size, 16UL);
     const size_t total_size = buffer_offset + aligned_buffer_size;
-    void* ptr;
-    C10D_NCCL_CHECK(ncclMemAlloc(&ptr, total_size), "ncclMemAlloc");
+    void* alloc_base;
+    C10D_NCCL_CHECK(ncclMemAlloc(&alloc_base, total_size), "ncclMemAlloc");
     // ncclMemAlloc does not zero memory. Zero the signal pad (the first
     // buffer_offset bytes) so the CAS-based barrier() protocol starts from a
     // known all-zero state on first use.
-    C10_CUDA_CHECK(cudaMemset(ptr, 0, buffer_offset));
+    C10_CUDA_CHECK(cudaMemset(alloc_base, 0, buffer_offset));
     // Hand back the data buffer pointer; the signal pad stays hidden in front.
-    void* buffer_ptr = static_cast<char*>(ptr) + buffer_offset;
+    void* buffer_ptr = static_cast<char*>(alloc_base) + buffer_offset;
     {
       std::lock_guard<std::mutex> lock(mutex_);
       // Key by the data pointer we return (that's what `free()` receives).
       allocations_.emplace(
           buffer_ptr,
-          std::make_unique<NCCLAllocation>(ptr, size, buffer_offset, device_idx));
+          std::make_unique<NCCLAllocation>(
+              alloc_base, size, buffer_offset, device_idx));
     }
     return buffer_ptr;
   }
@@ -595,8 +598,9 @@ class NCCLSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
       pai = c10::make_intrusive<NCCLPeerAllocInfo>(allocation, *group_name);
     }
     // Offset is relative to the data buffer base (past the signal pad).
-    const uintptr_t data_base =
-        reinterpret_cast<uintptr_t>(allocation->ptr) + allocation->buffer_offset;
+    const uintptr_t data_base = reinterpret_cast<uintptr_t>(
+                                    allocation->alloc_base) +
+        allocation->buffer_offset;
     size_t offset = reinterpret_cast<uintptr_t>(ptr) - data_base;
     // Create the SymmetricMemory handle.
     auto symm_mem = c10::make_intrusive<NCCLSymmetricMemory>(pai, offset);

--- a/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
@@ -94,9 +94,9 @@ bool pointer_in_allocation(void* ptr, const NCCLAllocation& allocation) {
   auto ptr_int = reinterpret_cast<uintptr_t>(ptr);
   // The data buffer starts `buffer_offset` bytes into the allocation (past the
   // signal pad); only data-region pointers belong to this allocation.
-  auto data_base = reinterpret_cast<uintptr_t>(allocation.alloc_base) +
+  auto buffer_ptr = reinterpret_cast<uintptr_t>(allocation.alloc_base) +
       allocation.buffer_offset;
-  return ptr_int >= data_base && ptr_int < data_base + allocation.buffer_size;
+  return ptr_int >= buffer_ptr && ptr_int < buffer_ptr + allocation.buffer_size;
 }
 
 NCCLAllocMap::iterator find_allocation_covering_linear(
@@ -113,27 +113,19 @@ NCCLAllocMap::iterator find_allocation_covering_linear(
 NCCLAllocMap::iterator find_allocation_covering(
     void* ptr,
     NCCLAllocMap& allocations) {
-  // Fast path: `allocations` is keyed by the data pointer returned from
-  // alloc(), so a whole-buffer tensor matches exactly.
   auto alloc_it = allocations.find(ptr);
   if (alloc_it != allocations.end()) {
     return alloc_it;
   }
 #if !defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
-  // Interior pointer (e.g. a MemPool sub-allocation): recover the ncclMemAlloc
-  // base via the driver, add the signal-pad offset to reconstruct the data
-  // pointer used as the map key, and look it up directly -- O(1) instead of a
-  // linear scan. buffer_offset equals the signal pad size; if that was
-  // reconfigured between allocations this lookup misses and the linear scan
-  // below covers it.
   auto driver_api = c10::cuda::DriverAPI::get();
   CUdeviceptr base_ptr = 0;
   if (driver_api->cuMemGetAddressRange_(
           &base_ptr, nullptr, reinterpret_cast<CUdeviceptr>(ptr)) ==
       CUDA_SUCCESS) {
-    auto data_ptr = reinterpret_cast<void*>(
+    auto buffer_ptr = reinterpret_cast<void*>(
         static_cast<uintptr_t>(base_ptr) + get_signal_pad_size());
-    alloc_it = allocations.find(data_ptr);
+    alloc_it = allocations.find(buffer_ptr);
     if (alloc_it != allocations.end()) {
       return alloc_it;
     }
@@ -598,10 +590,10 @@ class NCCLSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
       pai = c10::make_intrusive<NCCLPeerAllocInfo>(allocation, *group_name);
     }
     // Offset is relative to the data buffer base (past the signal pad).
-    const uintptr_t data_base = reinterpret_cast<uintptr_t>(
-                                    allocation->alloc_base) +
+    const uintptr_t buffer_ptr =
+        reinterpret_cast<uintptr_t>(allocation->alloc_base) +
         allocation->buffer_offset;
-    size_t offset = reinterpret_cast<uintptr_t>(ptr) - data_base;
+    size_t offset = reinterpret_cast<uintptr_t>(ptr) - buffer_ptr;
     // Create the SymmetricMemory handle.
     auto symm_mem = c10::make_intrusive<NCCLSymmetricMemory>(pai, offset);
     {
@@ -619,7 +611,7 @@ class NCCLSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
       // There is no more use of `key`; we can move it into the per-allocation
       // key set to avoid an extra copy. Key by the data pointer (the value
       // returned by alloc()), matching the lookup done in free().
-      symm_mem_keys_by_alloc_[reinterpret_cast<void*>(data_base)].insert(
+      symm_mem_keys_by_alloc_[reinterpret_cast<void*>(buffer_ptr)].insert(
           std::move(key));
     }
     return symm_mem;

--- a/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
@@ -34,16 +34,18 @@ namespace symmetric_memory {
 static StoreExchange storeExchange = StoreExchange("NCCLAllocation");
 
 struct NCCLAllocation {
-  // Combined ncclMemAlloc region. Layout:
-  //   [0, buffer_size)                                          - user data buffer
-  //   [round_up(buffer_size, 16), round_up(buffer_size, 16) + signal_pad_size)
-  //                                                             - signal pad
-  // Total allocation size is round_up(buffer_size, 16) + signal_pad_size.
+  // Combined ncclMemAlloc region. Layout (signal pad first):
+  //   [0, buffer_offset)                            - signal pad
+  //   [buffer_offset, buffer_offset + buffer_size)  - user data buffer
+  // buffer_offset equals the signal pad size (already 16-aligned). `ptr` is the
+  // ncclMemAlloc base (== signal pad base); alloc() hands back
+  // `ptr + buffer_offset` (the data buffer).
   void* ptr;
-  // Size of the user-visible data buffer in bytes, as requested by the
-  // caller of `alloc()`.
+  // Size of the user-visible data buffer in bytes, as requested by alloc().
   size_t buffer_size;
-  size_t signal_pad_size;
+  // Offset of the data buffer from `ptr`; the signal pad occupies
+  // [0, buffer_offset).
+  size_t buffer_offset;
   int device_idx;
   std::mutex mutex;
   // Map of group name to peer alloc info
@@ -53,11 +55,11 @@ struct NCCLAllocation {
   NCCLAllocation(
       void* ptr,
       size_t buffer_size,
-      size_t signal_pad_size,
+      size_t buffer_offset,
       int device_idx)
       : ptr(ptr),
         buffer_size(buffer_size),
-        signal_pad_size(signal_pad_size),
+        buffer_offset(buffer_offset),
         device_idx(device_idx) {}
 
   ~NCCLAllocation() {
@@ -90,8 +92,11 @@ using NCCLSymmMemKeysByAlloc =
 
 bool pointer_in_allocation(void* ptr, const NCCLAllocation& allocation) {
   auto ptr_int = reinterpret_cast<uintptr_t>(ptr);
-  auto base_ptr = reinterpret_cast<uintptr_t>(allocation.ptr);
-  return ptr_int >= base_ptr && ptr_int < base_ptr + allocation.buffer_size;
+  // The data buffer starts `buffer_offset` bytes into the allocation (past the
+  // signal pad); only data-region pointers belong to this allocation.
+  auto data_base =
+      reinterpret_cast<uintptr_t>(allocation.ptr) + allocation.buffer_offset;
+  return ptr_int >= data_base && ptr_int < data_base + allocation.buffer_size;
 }
 
 NCCLAllocMap::iterator find_allocation_covering_linear(
@@ -108,27 +113,31 @@ NCCLAllocMap::iterator find_allocation_covering_linear(
 NCCLAllocMap::iterator find_allocation_covering(
     void* ptr,
     NCCLAllocMap& allocations) {
+  // Fast path: `allocations` is keyed by the data pointer returned from
+  // alloc(), so a whole-buffer tensor matches exactly.
   auto alloc_it = allocations.find(ptr);
   if (alloc_it != allocations.end()) {
     return alloc_it;
   }
 #if !defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
+  // Interior pointer (e.g. a MemPool sub-allocation): recover the ncclMemAlloc
+  // base via the driver, add the signal-pad offset to reconstruct the data
+  // pointer used as the map key, and look it up directly -- O(1) instead of a
+  // linear scan. buffer_offset equals the signal pad size; if that was
+  // reconfigured between allocations this lookup misses and the linear scan
+  // below covers it.
   auto driver_api = c10::cuda::DriverAPI::get();
   CUdeviceptr base_ptr = 0;
-  // Recover the CUDA allocation base for interior pointers before falling
-  // back to the linear scan below when the direct lookup cannot help.
-  auto status = driver_api->cuMemGetAddressRange_(
-      &base_ptr,
-      nullptr,
-      reinterpret_cast<CUdeviceptr>(ptr));
-  if (status == CUDA_SUCCESS) {
-    alloc_it = allocations.find(reinterpret_cast<void*>(base_ptr));
+  if (driver_api->cuMemGetAddressRange_(
+          &base_ptr, nullptr, reinterpret_cast<CUdeviceptr>(ptr)) ==
+      CUDA_SUCCESS) {
+    auto data_ptr = reinterpret_cast<void*>(
+        static_cast<uintptr_t>(base_ptr) + get_signal_pad_size());
+    alloc_it = allocations.find(data_ptr);
     if (alloc_it != allocations.end()) {
       return alloc_it;
     }
   }
-#else
-  // No driver API support here, so fall through to the linear scan below.
 #endif
   return find_allocation_covering_linear(ptr, allocations);
 }
@@ -139,24 +148,23 @@ NCCLAllocMap::iterator find_allocation_covering(
 #if NCCL_VERSION_CODE < NCCL_VERSION(2, 29, 0)
 #ifdef NCCL_HAS_SYMMEM_DEVICE_SUPPORT
 // Fill both peer pointer arrays in a single kernel launch. For each peer,
-// the buffer pointer comes from NCCL and the signal pad pointer is derived
-// as `buffer + round_up(buffer_size, 16)`, mirroring the host-side layout.
+// NCCL returns the window base (== signal pad base); the data buffer pointer
+// is derived as `base + buffer_offset`, mirroring the host-side layout.
 static __global__ void build_ptr_dev(
   ncclWindow_t  handle,
-  size_t  buffer_size,    // user buffer size; the kernel rounds it up to 16
+  size_t  buffer_offset,  // data buffer offset; signal pad occupies [0, buffer_offset)
   void**  buffers,        // out: peer buffer pointers
   void**  signal_pads,    // out: peer signal pad pointers
   int  world_size)
 {
-  const size_t aligned_buffer_size = (buffer_size + 15UL) & ~15UL;
   int tid = blockIdx.x * blockDim.x + threadIdx.x;
   int stride = blockDim.x * gridDim.x;
   for (int peer = tid; peer < world_size; peer += stride) {
       void* buf = ncclGetLsaPointer(handle, 0, peer);
-      buffers[peer] = buf;
-      signal_pads[peer] = buf == nullptr
+      signal_pads[peer] = buf;
+      buffers[peer] = buf == nullptr
           ? nullptr
-          : static_cast<char*>(buf) + aligned_buffer_size;
+          : static_cast<char*>(buf) + buffer_offset;
   }
 }
 #endif // NCCL_HAS_SYMMEM_DEVICE_SUPPORT
@@ -168,6 +176,7 @@ class NCCLPeerAllocInfo : public c10::intrusive_ptr_target {
       NCCLAllocation* allocation,
       std::string group_name)
       : buffer_size_(allocation->buffer_size),
+        buffer_offset_(allocation->buffer_offset),
         device_idx_(allocation->device_idx),
         group_name_(std::move(group_name))
   {
@@ -192,16 +201,15 @@ class NCCLPeerAllocInfo : public c10::intrusive_ptr_target {
         "been eagerly initialized by filling `device_id` in the "
         "`init_process_group` call.");
 
-    // Register a single window over the combined buffer + signal pad region.
-    // Layout inside the registration:
-    //   [0, aligned_buffer_size)            - user data buffer
-    //   [aligned_buffer_size, total_size)   - signal pad
+    // Register a single window over the combined signal pad + buffer region.
+    // Layout inside the registration (signal pad first):
+    //   [0, signal_pad_size)                          - signal pad
+    //   [buffer_offset_, buffer_offset_ + buffer)     - user data buffer
     // The single registration sidesteps NCCL's window-alignment requirement
-    // for the signal-pad sub-region: only the base pointer (returned by
+    // for the data sub-region: only the base pointer (returned by
     // ncclMemAlloc, already granularity-aligned) is registered.
     const size_t aligned_buffer_size = at::round_up(buffer_size_, 16UL);
-    const size_t signal_pad_size = allocation->signal_pad_size;
-    const size_t total_size = aligned_buffer_size + signal_pad_size;
+    const size_t total_size = buffer_offset_ + aligned_buffer_size;
     C10D_NCCL_CHECK(
       ncclCommWindowRegister(comm_, allocation->ptr, total_size, &combined_win_, NCCL_WIN_COLL_SYMMETRIC),
       c10::str(
@@ -211,7 +219,6 @@ class NCCLPeerAllocInfo : public c10::intrusive_ptr_target {
           total_size,
           " on rank ",
           rank_));
-    signal_pad_ptr_ = static_cast<char*>(allocation->ptr) + aligned_buffer_size;
 
 #ifdef NCCL_HAS_SYMMEM_DEVICE_SUPPORT
     // (Host comm is already published into NCCLDevCommManager by the
@@ -233,7 +240,7 @@ class NCCLPeerAllocInfo : public c10::intrusive_ptr_target {
     int threads = std::min(128, world_size_);
     auto stream = at::cuda::getCurrentCUDAStream();
     build_ptr_dev<<<1, threads, 0, stream>>>(
-        combined_win_, buffer_size_, buffers_dev_, signal_pads_dev_, world_size_);
+        combined_win_, buffer_offset_, buffers_dev_, signal_pads_dev_, world_size_);
     C10_CUDA_KERNEL_LAUNCH_CHECK();
     C10_CUDA_CHECK(cudaStreamSynchronize(stream));
     C10_CUDA_CHECK(cudaMemcpy(
@@ -248,28 +255,27 @@ class NCCLPeerAllocInfo : public c10::intrusive_ptr_target {
       cudaMemcpyDeviceToHost));
 #else
   // Starting from NCCL 2.29, we can use host-side APIs to get peer pointers.
+  // ncclGetPeerDevicePointer returns each peer's window base, which is the
+  // signal pad base (the signal pad is at the front of the window).
   for (int i = 0; i < world_size_; i++) {
     // If peer is not accessible within LSA domain, `ncclGetPeerDevicePointer`
     // returns nullptr.
     C10D_NCCL_CHECK(
-      ncclGetPeerDevicePointer(combined_win_, 0, i, &buffers_[i]),
+      ncclGetPeerDevicePointer(combined_win_, 0, i, &signal_pads_[i]),
       "ncclGetPeerDevicePointer failed");
   }
-  // Copy the peer buffer pointers to the device-side buffers array.
+  // Derive each peer's data buffer pointer from its window base; all ranks
+  // share the same buffer_offset_ so we don't need to ask NCCL separately.
+  for (int i = 0; i < world_size_; i++) {
+    buffers_[i] = signal_pads_[i] == nullptr
+        ? nullptr
+        : static_cast<char*>(signal_pads_[i]) + buffer_offset_;
+  }
   C10_CUDA_CHECK(cudaMemcpy(
     buffers_dev_,  // dst (device)
     buffers_.data(),  // src (host)
     arr_size,
     cudaMemcpyHostToDevice));
-
-  // Derive each peer's signal pad pointer from its buffer pointer; all
-  // ranks share the same aligned_buffer_size so we don't need to ask NCCL
-  // for the signal pad pointers separately.
-  for (int i = 0; i < world_size_; i++) {
-    signal_pads_[i] = buffers_[i] == nullptr
-        ? nullptr
-        : static_cast<char*>(buffers_[i]) + aligned_buffer_size;
-  }
   C10_CUDA_CHECK(cudaMemcpy(
       signal_pads_dev_,  // dst (device)
       signal_pads_.data(),  // src (host)
@@ -281,8 +287,11 @@ class NCCLPeerAllocInfo : public c10::intrusive_ptr_target {
   void* mc_addr = nullptr;
   // Skip CHECK on purpose to improve fault tolerance since some machine's
   // Fabric Manager may be in bad NVLink Sharp state.
-  if (ncclGetLsaMultimemDevicePointer(combined_win_, 0, &mc_addr) == ncclSuccess) {
-    mc_addr_ = mc_addr;
+  if (ncclGetLsaMultimemDevicePointer(combined_win_, 0, &mc_addr) == ncclSuccess &&
+      mc_addr != nullptr) {
+    // Point at the data buffer within the multicast mapping (data follows the
+    // signal pad).
+    mc_addr_ = static_cast<char*>(mc_addr) + buffer_offset_;
   }
 #endif // NCCL_VERSION_CODE < NCCL_VERSION(2, 29, 0)
 #endif // NCCL_HAS_SYMMEM_DEVICE_SUPPORT
@@ -306,8 +315,6 @@ class NCCLPeerAllocInfo : public c10::intrusive_ptr_target {
                      << ncclGetErrorString(res);
       }
     }
-    // signal_pad_ptr_ is part of the owning NCCLAllocation's combined
-    // ncclMemAlloc region; freeing the buffer there releases it too.
     if (buffers_dev_ != nullptr) {
       c10::cuda::CUDACachingAllocator::raw_delete(buffers_dev_);
     }
@@ -318,6 +325,9 @@ class NCCLPeerAllocInfo : public c10::intrusive_ptr_target {
 
  private:
   size_t buffer_size_;
+  // Offset of the data buffer from the allocation base; the signal pad sits at
+  // [0, buffer_offset_) and the data buffer at [buffer_offset_, ...).
+  size_t buffer_offset_;
   int device_idx_;
   int rank_;
   int world_size_;
@@ -328,8 +338,7 @@ class NCCLPeerAllocInfo : public c10::intrusive_ptr_target {
   std::string group_name_;
   // Single NCCL window covering both the user data buffer and the signal pad.
   ncclWindow_t combined_win_{nullptr};
-  void* signal_pad_ptr_{nullptr};
-  // Multicast address
+  // Multicast address (data buffer base within the multicast mapping)
   void* mc_addr_{nullptr};
   ncclComm_t comm_{nullptr};
   friend class NCCLSymmetricMemory;
@@ -476,6 +485,12 @@ size_t NCCLSymmetricMemory::get_offset() {
   return offset_;
 }
 
+size_t NCCLSymmetricMemory::get_window_offset() {
+  // The NCCL window starts at the signal pad; this handle's data lives
+  // buffer_offset_ bytes further in, plus its own offset within the buffer.
+  return pai_->buffer_offset_ + offset_;
+}
+
 std::string NCCLSymmetricMemory::get_group_name() {
   return pai_->group_name_;
 }
@@ -492,29 +507,32 @@ class NCCLSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
         "must not be called with a group_name");
 
     c10::cuda::CUDAGuard guard(device_idx);
-    // Allocate buffer + signal pad together in a single ncclMemAlloc call.
-    // Buffer occupies [0, size); signal pad starts at round_up(size, 16).
-    // A single window is registered over the whole region at rendezvous
-    // time, so only the base pointer (already granularity-aligned by
+    // Allocate signal pad + buffer together in a single ncclMemAlloc call.
+    // Layout: signal pad in [0, buffer_offset), data buffer after it.
+    // buffer_offset is the signal pad size, which is already 16-aligned, so the
+    // data buffer is aligned without extra padding; the data size is rounded up
+    // instead. A single window is registered over the whole region at
+    // rendezvous time, so only the base pointer (already granularity-aligned by
     // ncclMemAlloc) needs to satisfy NCCL's window-alignment requirement.
+    const size_t buffer_offset = get_signal_pad_size();
     const size_t aligned_buffer_size = at::round_up(size, 16UL);
-    const size_t signal_pad_size = get_signal_pad_size();
-    const size_t total_size = aligned_buffer_size + signal_pad_size;
+    const size_t total_size = buffer_offset + aligned_buffer_size;
     void* ptr;
     C10D_NCCL_CHECK(ncclMemAlloc(&ptr, total_size), "ncclMemAlloc");
-    // ncclMemAlloc does not zero memory. Zero the signal pad so the CAS-based
-    // barrier() protocol starts from a known (all-zero) state on first use
-    // (CUDASymmetricMemory zeroes its whole allocation for the same reason).
-    C10_CUDA_CHECK(cudaMemset(
-        static_cast<char*>(ptr) + aligned_buffer_size, 0, signal_pad_size));
+    // ncclMemAlloc does not zero memory. Zero the signal pad (the first
+    // buffer_offset bytes) so the CAS-based barrier() protocol starts from a
+    // known all-zero state on first use.
+    C10_CUDA_CHECK(cudaMemset(ptr, 0, buffer_offset));
+    // Hand back the data buffer pointer; the signal pad stays hidden in front.
+    void* buffer_ptr = static_cast<char*>(ptr) + buffer_offset;
     {
       std::lock_guard<std::mutex> lock(mutex_);
+      // Key by the data pointer we return (that's what `free()` receives).
       allocations_.emplace(
-          ptr,
-          std::make_unique<NCCLAllocation>(
-              ptr, size, signal_pad_size, device_idx));
+          buffer_ptr,
+          std::make_unique<NCCLAllocation>(ptr, size, buffer_offset, device_idx));
     }
-    return ptr;
+    return buffer_ptr;
   }
 
   void free(void* ptr) override {
@@ -576,9 +594,10 @@ class NCCLSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
     if (!pai) {
       pai = c10::make_intrusive<NCCLPeerAllocInfo>(allocation, *group_name);
     }
-    size_t offset =
-        reinterpret_cast<uintptr_t>(ptr) -
-        reinterpret_cast<uintptr_t>(allocation->ptr);
+    // Offset is relative to the data buffer base (past the signal pad).
+    const uintptr_t data_base =
+        reinterpret_cast<uintptr_t>(allocation->ptr) + allocation->buffer_offset;
+    size_t offset = reinterpret_cast<uintptr_t>(ptr) - data_base;
     // Create the SymmetricMemory handle.
     auto symm_mem = c10::make_intrusive<NCCLSymmetricMemory>(pai, offset);
     {
@@ -594,8 +613,10 @@ class NCCLSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
         return it->second;
       }
       // There is no more use of `key`; we can move it into the per-allocation
-      // key set to avoid an extra copy.
-      symm_mem_keys_by_alloc_[allocation->ptr].insert(std::move(key));
+      // key set to avoid an extra copy. Key by the data pointer (the value
+      // returned by alloc()), matching the lookup done in free().
+      symm_mem_keys_by_alloc_[reinterpret_cast<void*>(data_base)].insert(
+          std::move(key));
     }
     return symm_mem;
   }

--- a/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
@@ -517,7 +517,11 @@ class NCCLSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
     // buffer_offset bytes) so the CAS-based barrier() protocol starts from a
     // known all-zero state on first use.
     C10_CUDA_CHECK(cudaMemset(alloc_base, 0, buffer_offset));
-    // Hand back the data buffer pointer; the signal pad stays hidden in front.
+    // Hand back the data buffer pointer, not alloc_base; the signal pad stays
+    // hidden in front. Returning the data ptr is safe for free(): the whole
+    // block is owned by the NCCLAllocation keyed below, which ncclMemFree's
+    // alloc_base in its destructor, so free() only needs the data ptr to drop
+    // the allocation entry.
     void* buffer_ptr = static_cast<char*>(alloc_base) + buffer_offset;
     {
       std::lock_guard<std::mutex> lock(mutex_);

--- a/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.hpp
@@ -47,6 +47,10 @@ class NCCLSymmetricMemory : public SymmetricMemory {
 
   size_t get_offset() override;
 
+  // Byte offset of this handle's data within the NCCL window. The window
+  // starts at the signal pad, so this is buffer_offset + get_offset().
+  size_t get_window_offset();
+
  private:
   c10::intrusive_ptr<NCCLPeerAllocInfo> pai_;
   size_t offset_;

--- a/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cpp
@@ -418,27 +418,6 @@ class NVSHMEMSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
 
   void free(void* ptr) override {
     std::lock_guard<std::mutex> lock(mutex_);
-    auto it = allocations_.find(ptr);
-    if (it != allocations_.end()) {
-      // Purge cached rendezvous handles that point into this allocation's data
-      // range. nvshmem_free can hand this address back to a later allocation of
-      // a different size; without this, rendezvous() would return a stale
-      // handle (wrong buffer_size/offset) from symm_mems_, keyed by an address
-      // that now belongs to the new allocation.
-      const auto lo = reinterpret_cast<uintptr_t>(it->second->alloc_base) +
-          it->second->buffer_offset;
-      const auto hi = lo + it->second->buffer_size;
-      std::vector<SymmMemKey> stale;
-      for (const auto& kv : symm_mems_) {
-        auto k = reinterpret_cast<uintptr_t>(kv.first.first);
-        if (k >= lo && k < hi) {
-          stale.push_back(kv.first);
-        }
-      }
-      for (auto& key : stale) {
-        symm_mems_.erase(key);
-      }
-    }
     allocations_.erase(ptr);
   };
 
@@ -470,10 +449,11 @@ class NVSHMEMSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
         allocations_.begin(), allocations_.end(), [&](const auto& pair) {
           auto& allocation = pair.second;
           auto ptr_int = reinterpret_cast<uintptr_t>(ptr);
-          auto data_base = reinterpret_cast<uintptr_t>(allocation->alloc_base) +
+          auto buffer_ptr =
+              reinterpret_cast<uintptr_t>(allocation->alloc_base) +
               allocation->buffer_offset;
-          return ptr_int >= data_base &&
-              ptr_int < data_base + allocation->buffer_size;
+          return ptr_int >= buffer_ptr &&
+              ptr_int < buffer_ptr + allocation->buffer_size;
         });
     TORCH_CHECK(
         alloc_it != allocations_.end(),
@@ -483,11 +463,11 @@ class NVSHMEMSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
     auto& allocation = alloc_it->second;
     // Data buffer base (the pointer alloc() returned). Offsets are relative to
     // it, and it is the key used to cache this allocation's base rendezvous.
-    void* data_base =
+    void* buffer_ptr =
         static_cast<char*>(allocation->alloc_base) + allocation->buffer_offset;
 
     // Search again using the data buffer base ptr (the caching key)
-    auto it = symm_mems_.find(SymmMemKey{data_base, *group_name});
+    auto it = symm_mems_.find(SymmMemKey{buffer_ptr, *group_name});
     c10::intrusive_ptr<NVSHMEMSymmetricMemory> symm_mem;
     if (it != symm_mems_.end()) {
       // Base allocation has been rendezvoused
@@ -499,20 +479,20 @@ class NVSHMEMSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
     }
 
     // Cache rendezvous using the data buffer base address as key
-    symm_mems_[SymmMemKey{data_base, *group_name}] = symm_mem;
+    symm_mems_[SymmMemKey{buffer_ptr, *group_name}] = symm_mem;
 
     // TODO: change the `ptr` below to `tensor.data_ptr()` when adding support
     // for user slice/view operations. For MemPool support,
     // `tensor.storage().data_ptr()` is fine (today's `ptr`).
 
     // If the tensor's ptr happens to be the data buffer base
-    if (ptr == data_base) {
+    if (ptr == buffer_ptr) {
       return symm_mem;
     } else {
       // Return a copy of the SymmetricMemory with an offset. This is a
       // "shallow" copy adjusting the offset field in the handle.
       return c10::make_intrusive<NVSHMEMSymmetricMemory>(
-          *symm_mem, (uintptr_t)ptr - (uintptr_t)data_base);
+          *symm_mem, (uintptr_t)ptr - (uintptr_t)buffer_ptr);
     }
   };
 
@@ -525,11 +505,11 @@ class NVSHMEMSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
     auto alloc_it = std::find_if(
         allocations_.begin(), allocations_.end(), [&](const auto& pair) {
           auto ptr_int = reinterpret_cast<uintptr_t>(ptr);
-          auto data_base =
+          auto buffer_ptr =
               reinterpret_cast<uintptr_t>(pair.second->alloc_base) +
               pair.second->buffer_offset;
-          return ptr_int >= data_base &&
-              ptr_int < data_base + pair.second->buffer_size;
+          return ptr_int >= buffer_ptr &&
+              ptr_int < buffer_ptr + pair.second->buffer_size;
         });
     return alloc_it != allocations_.end();
   }

--- a/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cpp
@@ -36,19 +36,19 @@ struct NVSHMEMAllocation {
   // Layout (signal pad first):
   //   [0, signal_pad_size)                          - signal pad
   //   [buffer_offset, buffer_offset + buffer_size)  - user data buffer
-  // `ptr` is the nvshmem_malloc base (== signal pad base); alloc() hands back
-  // `ptr + buffer_offset` (the data buffer).
-  void* ptr;
+  // alloc_base is the nvshmem_malloc base (== signal pad base); alloc() hands
+  // back `alloc_base + buffer_offset` (the data buffer).
+  void* alloc_base;
   size_t buffer_size;
   size_t buffer_offset;
   int device_idx;
 
   NVSHMEMAllocation(
-      void* ptr,
+      void* alloc_base,
       size_t buffer_size,
       size_t buffer_offset,
       int device_idx)
-      : ptr(ptr),
+      : alloc_base(alloc_base),
         buffer_size(buffer_size),
         buffer_offset(buffer_offset),
         device_idx(device_idx) {}
@@ -65,7 +65,7 @@ struct NVSHMEMAllocation {
       return;
     }
     c10::cuda::CUDAGuard guard(device_idx);
-    nvshmem_free(ptr); // nvshmem_free has no return value
+    nvshmem_free(alloc_base); // nvshmem_free has no return value
   }
 };
 
@@ -86,8 +86,10 @@ class NVSHMEMPeerAllocInfo : public c10::intrusive_ptr_target {
   NVSHMEMPeerAllocInfo(
       NVSHMEMAllocation* allocation,
       const std::string& group_name)
-      : base_ptr_(allocation->ptr), buffer_size_(allocation->buffer_size) {
-    // Offset of the data buffer from base_ptr_; only needed during setup below.
+      : base_ptr_(allocation->alloc_base),
+        buffer_size_(allocation->buffer_size) {
+    // Byte offset from base_ptr_ to the start of the user buffer; only needed
+    // during setup below.
     const size_t buffer_offset = allocation->buffer_offset;
     // For logging only
     static int exchanged_n_times = 0;
@@ -398,18 +400,18 @@ class NVSHMEMSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
     const size_t signal_pad_size = get_signal_pad_size();
     const size_t buffer_offset = signal_pad_size;
     const size_t total_size = buffer_offset + at::round_up(size, 16UL);
-    auto ptr = nvshmem_malloc(total_size);
-    TORCH_CHECK(ptr != nullptr, "nvshmem_malloc failed");
+    auto alloc_base = nvshmem_malloc(total_size);
+    TORCH_CHECK(alloc_base != nullptr, "nvshmem_malloc failed");
     // Zero the signal pad (at the front) for the signaling protocol.
-    AT_CUDA_CHECK(cudaMemset(ptr, 0, signal_pad_size));
+    AT_CUDA_CHECK(cudaMemset(alloc_base, 0, signal_pad_size));
     // Hand back the data buffer pointer; the signal pad stays hidden in front.
-    void* buffer_ptr = static_cast<char*>(ptr) + buffer_offset;
+    void* buffer_ptr = static_cast<char*>(alloc_base) + buffer_offset;
     {
       std::lock_guard<std::mutex> lock(mutex_);
       allocations_.try_emplace(
           buffer_ptr,
           std::make_unique<NVSHMEMAllocation>(
-              ptr, size, buffer_offset, device_idx));
+              alloc_base, size, buffer_offset, device_idx));
     }
     return buffer_ptr;
   }
@@ -423,7 +425,7 @@ class NVSHMEMSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
       // a different size; without this, rendezvous() would return a stale
       // handle (wrong buffer_size/offset) from symm_mems_, keyed by an address
       // that now belongs to the new allocation.
-      const auto lo = reinterpret_cast<uintptr_t>(it->second->ptr) +
+      const auto lo = reinterpret_cast<uintptr_t>(it->second->alloc_base) +
           it->second->buffer_offset;
       const auto hi = lo + it->second->buffer_size;
       std::vector<SymmMemKey> stale;
@@ -468,7 +470,7 @@ class NVSHMEMSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
         allocations_.begin(), allocations_.end(), [&](const auto& pair) {
           auto& allocation = pair.second;
           auto ptr_int = reinterpret_cast<uintptr_t>(ptr);
-          auto data_base = reinterpret_cast<uintptr_t>(allocation->ptr) +
+          auto data_base = reinterpret_cast<uintptr_t>(allocation->alloc_base) +
               allocation->buffer_offset;
           return ptr_int >= data_base &&
               ptr_int < data_base + allocation->buffer_size;
@@ -482,7 +484,7 @@ class NVSHMEMSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
     // Data buffer base (the pointer alloc() returned). Offsets are relative to
     // it, and it is the key used to cache this allocation's base rendezvous.
     void* data_base =
-        static_cast<char*>(allocation->ptr) + allocation->buffer_offset;
+        static_cast<char*>(allocation->alloc_base) + allocation->buffer_offset;
 
     // Search again using the data buffer base ptr (the caching key)
     auto it = symm_mems_.find(SymmMemKey{data_base, *group_name});
@@ -523,7 +525,8 @@ class NVSHMEMSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
     auto alloc_it = std::find_if(
         allocations_.begin(), allocations_.end(), [&](const auto& pair) {
           auto ptr_int = reinterpret_cast<uintptr_t>(ptr);
-          auto data_base = reinterpret_cast<uintptr_t>(pair.second->ptr) +
+          auto data_base =
+              reinterpret_cast<uintptr_t>(pair.second->alloc_base) +
               pair.second->buffer_offset;
           return ptr_int >= data_base &&
               ptr_int < data_base + pair.second->buffer_size;

--- a/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cpp
@@ -33,12 +33,25 @@ namespace symmetric_memory {
 static StoreExchange storeExchange = StoreExchange("NVSHMEMSymmetricMemory");
 
 struct NVSHMEMAllocation {
+  // Layout (signal pad first):
+  //   [0, signal_pad_size)                          - signal pad
+  //   [buffer_offset, buffer_offset + buffer_size)  - user data buffer
+  // `ptr` is the nvshmem_malloc base (== signal pad base); alloc() hands back
+  // `ptr + buffer_offset` (the data buffer).
   void* ptr;
   size_t buffer_size;
+  size_t buffer_offset;
   int device_idx;
 
-  NVSHMEMAllocation(void* ptr, size_t buffer_size, int device_idx)
-      : ptr(ptr), buffer_size(buffer_size), device_idx(device_idx) {}
+  NVSHMEMAllocation(
+      void* ptr,
+      size_t buffer_size,
+      size_t buffer_offset,
+      int device_idx)
+      : ptr(ptr),
+        buffer_size(buffer_size),
+        buffer_offset(buffer_offset),
+        device_idx(device_idx) {}
 
   // Delete copy and move operations to prevent double-free
   NVSHMEMAllocation(const NVSHMEMAllocation&) = delete;
@@ -74,6 +87,8 @@ class NVSHMEMPeerAllocInfo : public c10::intrusive_ptr_target {
       NVSHMEMAllocation* allocation,
       const std::string& group_name)
       : base_ptr_(allocation->ptr), buffer_size_(allocation->buffer_size) {
+    // Offset of the data buffer from base_ptr_; only needed during setup below.
+    const size_t buffer_offset = allocation->buffer_offset;
     // For logging only
     static int exchanged_n_times = 0;
     c10::cuda::CUDAGuard guard(allocation->device_idx);
@@ -115,25 +130,20 @@ class NVSHMEMPeerAllocInfo : public c10::intrusive_ptr_target {
     }
     auto& rank_to_global_rank = it->second;
 
+    // The signal pad shares the allocation with the data buffer: each peer's
+    // allocation base is its signal pad base, and its data buffer follows at
+    // buffer_offset. The signal pad is zeroed once in alloc().
     world_within_cuda_p2p_ = true;
     for (int r = 0; r < world_size_; ++r) {
-      auto peer_ptr = nvshmem_ptr(base_ptr_, rank_to_global_rank[r]);
-      buffers_.push_back(peer_ptr);
+      auto peer_base = nvshmem_ptr(base_ptr_, rank_to_global_rank[r]);
       // If a peer is over network, `nvshmem_ptr` returns null
-      if (peer_ptr == nullptr) {
+      if (peer_base == nullptr) {
         world_within_cuda_p2p_ = false;
       }
-    }
-
-    // TODO: use the same allocation for signal pad
-    const size_t signal_pad_size = get_signal_pad_size();
-    void* signal_pad_ptr = nvshmem_malloc(signal_pad_size);
-    TORCH_CHECK(signal_pad_ptr != nullptr, "nvshmem_malloc failed");
-    AT_CUDA_CHECK(cudaMemset(signal_pad_ptr, 0, signal_pad_size));
-
-    for (int r = 0; r < world_size_; ++r) {
-      signal_pads_.push_back(
-          nvshmem_ptr(signal_pad_ptr, rank_to_global_rank[r]));
+      signal_pads_.push_back(peer_base);
+      buffers_.push_back(
+          peer_base == nullptr ? nullptr
+                               : static_cast<char*>(peer_base) + buffer_offset);
     }
 
     const size_t arr_size = sizeof(void*) * world_size_;
@@ -157,6 +167,11 @@ class NVSHMEMPeerAllocInfo : public c10::intrusive_ptr_target {
     auto& team_manager = c10d::nvshmem_extension::TeamManager::get(device);
     auto team = team_manager.get_team(group_name, rank_to_global_rank);
     mc_addr_ = nvshmemx_mc_ptr(team, base_ptr_);
+    // Point at the data buffer within the multicast mapping (data follows the
+    // signal pad).
+    if (mc_addr_ != nullptr) {
+      mc_addr_ = static_cast<char*>(mc_addr_) + buffer_offset;
+    }
 #endif
   }
 
@@ -377,19 +392,51 @@ class NVSHMEMSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
     initialize_nvshmem_with_store(
         group->getStore(), group->getRank(), group->getSize(), device_idx);
 
-    auto ptr = nvshmem_malloc(size);
-    // If size is 0 (which is legal allocation request) we shouldn't error out
-    TORCH_CHECK(ptr != nullptr || size == 0, "nvshmem_malloc failed");
+    // Signal pad first at [0, signal_pad_size), data buffer at buffer_offset =
+    // signal_pad_size. The signal pad size is already 16-aligned, so the data
+    // buffer is aligned without extra padding; round up the data size instead.
+    const size_t signal_pad_size = get_signal_pad_size();
+    const size_t buffer_offset = signal_pad_size;
+    const size_t total_size = buffer_offset + at::round_up(size, 16UL);
+    auto ptr = nvshmem_malloc(total_size);
+    TORCH_CHECK(ptr != nullptr, "nvshmem_malloc failed");
+    // Zero the signal pad (at the front) for the signaling protocol.
+    AT_CUDA_CHECK(cudaMemset(ptr, 0, signal_pad_size));
+    // Hand back the data buffer pointer; the signal pad stays hidden in front.
+    void* buffer_ptr = static_cast<char*>(ptr) + buffer_offset;
     {
       std::lock_guard<std::mutex> lock(mutex_);
       allocations_.try_emplace(
-          ptr, std::make_unique<NVSHMEMAllocation>(ptr, size, device_idx));
+          buffer_ptr,
+          std::make_unique<NVSHMEMAllocation>(
+              ptr, size, buffer_offset, device_idx));
     }
-    return ptr;
+    return buffer_ptr;
   }
 
   void free(void* ptr) override {
     std::lock_guard<std::mutex> lock(mutex_);
+    auto it = allocations_.find(ptr);
+    if (it != allocations_.end()) {
+      // Purge cached rendezvous handles that point into this allocation's data
+      // range. nvshmem_free can hand this address back to a later allocation of
+      // a different size; without this, rendezvous() would return a stale
+      // handle (wrong buffer_size/offset) from symm_mems_, keyed by an address
+      // that now belongs to the new allocation.
+      const auto lo = reinterpret_cast<uintptr_t>(it->second->ptr) +
+          it->second->buffer_offset;
+      const auto hi = lo + it->second->buffer_size;
+      std::vector<SymmMemKey> stale;
+      for (const auto& kv : symm_mems_) {
+        auto k = reinterpret_cast<uintptr_t>(kv.first.first);
+        if (k >= lo && k < hi) {
+          stale.push_back(kv.first);
+        }
+      }
+      for (auto& key : stale) {
+        symm_mems_.erase(key);
+      }
+    }
     allocations_.erase(ptr);
   };
 
@@ -421,9 +468,10 @@ class NVSHMEMSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
         allocations_.begin(), allocations_.end(), [&](const auto& pair) {
           auto& allocation = pair.second;
           auto ptr_int = reinterpret_cast<uintptr_t>(ptr);
-          auto base_ptr = reinterpret_cast<uintptr_t>(allocation->ptr);
-          return ptr_int >= base_ptr &&
-              ptr_int < base_ptr + allocation->buffer_size;
+          auto data_base = reinterpret_cast<uintptr_t>(allocation->ptr) +
+              allocation->buffer_offset;
+          return ptr_int >= data_base &&
+              ptr_int < data_base + allocation->buffer_size;
         });
     TORCH_CHECK(
         alloc_it != allocations_.end(),
@@ -431,10 +479,13 @@ class NVSHMEMSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
         "is the tensor allocated from SymmetricMemory?");
 
     auto& allocation = alloc_it->second;
+    // Data buffer base (the pointer alloc() returned). Offsets are relative to
+    // it, and it is the key used to cache this allocation's base rendezvous.
+    void* data_base =
+        static_cast<char*>(allocation->ptr) + allocation->buffer_offset;
 
-    // Search again using allocation base ptr (which is the key we use for
-    // caching, see below)
-    auto it = symm_mems_.find(SymmMemKey{allocation->ptr, *group_name});
+    // Search again using the data buffer base ptr (the caching key)
+    auto it = symm_mems_.find(SymmMemKey{data_base, *group_name});
     c10::intrusive_ptr<NVSHMEMSymmetricMemory> symm_mem;
     if (it != symm_mems_.end()) {
       // Base allocation has been rendezvoused
@@ -445,21 +496,21 @@ class NVSHMEMSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
           allocation.get(), *group_name);
     }
 
-    // Cache rendezvous using allocation's base address as key
-    symm_mems_[SymmMemKey{allocation->ptr, *group_name}] = symm_mem;
+    // Cache rendezvous using the data buffer base address as key
+    symm_mems_[SymmMemKey{data_base, *group_name}] = symm_mem;
 
     // TODO: change the `ptr` below to `tensor.data_ptr()` when adding support
     // for user slice/view operations. For MemPool support,
     // `tensor.storage().data_ptr()` is fine (today's `ptr`).
 
-    // If the tensor's ptr happen to be the same as allocation ptr
-    if (ptr == allocation->ptr) {
+    // If the tensor's ptr happens to be the data buffer base
+    if (ptr == data_base) {
       return symm_mem;
     } else {
       // Return a copy of the SymmetricMemory with an offset. This is a
       // "shallow" copy adjusting the offset field in the handle.
       return c10::make_intrusive<NVSHMEMSymmetricMemory>(
-          *symm_mem, (uintptr_t)ptr - (uintptr_t)allocation->ptr);
+          *symm_mem, (uintptr_t)ptr - (uintptr_t)data_base);
     }
   };
 
@@ -472,9 +523,10 @@ class NVSHMEMSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
     auto alloc_it = std::find_if(
         allocations_.begin(), allocations_.end(), [&](const auto& pair) {
           auto ptr_int = reinterpret_cast<uintptr_t>(ptr);
-          auto base_ptr = reinterpret_cast<uintptr_t>(pair.second->ptr);
-          return ptr_int >= base_ptr &&
-              ptr_int < base_ptr + pair.second->buffer_size;
+          auto data_base = reinterpret_cast<uintptr_t>(pair.second->ptr) +
+              pair.second->buffer_offset;
+          return ptr_int >= data_base &&
+              ptr_int < data_base + pair.second->buffer_size;
         });
     return alloc_it != allocations_.end();
   }

--- a/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cpp
@@ -404,7 +404,11 @@ class NVSHMEMSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
     TORCH_CHECK(alloc_base != nullptr, "nvshmem_malloc failed");
     // Zero the signal pad (at the front) for the signaling protocol.
     AT_CUDA_CHECK(cudaMemset(alloc_base, 0, signal_pad_size));
-    // Hand back the data buffer pointer; the signal pad stays hidden in front.
+    // Hand back the data buffer pointer, not alloc_base; the signal pad stays
+    // hidden in front. Returning the data ptr is safe for free(): the whole
+    // block is owned by the NVSHMEMAllocation keyed below, which nvshmem_free's
+    // alloc_base in its destructor, so free() only needs the data ptr to drop
+    // the allocation entry.
     void* buffer_ptr = static_cast<char*>(alloc_base) + buffer_offset;
     {
       std::lock_guard<std::mutex> lock(mutex_);

--- a/torch/csrc/distributed/c10d/symm_mem/nccl_extension.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/nccl_extension.cu
@@ -371,7 +371,7 @@ void nccl_put_signal(at::Tensor& tensor, const c10::intrusive_ptr<SymmetricMemor
   auto nccl_hdl = dynamic_cast<NCCLSymmetricMemory*>(hdl.get());
   auto window = nccl_hdl->get_window();
   TORCH_CHECK(window != nullptr, "window is nullptr");
-  auto offset = nccl_hdl->get_offset();
+  auto offset = nccl_hdl->get_window_offset();
   auto byte_size = tensor.numel() * tensor.element_size();
 
   // Get the NCCL communicator

--- a/torch/csrc/distributed/c10d/symm_mem/ops/nccl_reduce_scatter_offset.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/ops/nccl_reduce_scatter_offset.cu
@@ -320,7 +320,7 @@ void nccl_reduce_scatter_offset(
   const int fixed_dim_size = static_cast<int>(col_sharded ? input.size(0) : input.size(1));
   const int unroll = 4 * 16 / static_cast<int>(input.element_size());
   const int elems_per_cta = RS_THREADS_PER_CTA * unroll;
-  const size_t window_base_offset = nccl_hdl->get_offset();
+  const size_t window_base_offset = nccl_hdl->get_window_offset();
 
   // Build the per-slot info struct.
   // For dim=1: byte_offsets encodes the column-block start within the window.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #188741


We place the signal pad at the front of symmetric memory allocations in this PR. The purpose is to unify the memory layout across all three symmetric-memory backends (CUDA, NCCL, NVSHMEM) to [signal pad | data buffer] — the signal pad lives at the front of every allocation, at a fixed buffer_offset (= the signal-pad size, already 16-aligned), and alloc() hands back the interior data pointer (alloc_base + buffer_offset) while the pad stays hidden in front. This gives a single consistent convention and lets the pad be initialized independently of the (potentially large) user data buffer.

Detailed changes:
CUDA backend
- Move the signal pad from the end to the front of the block; return the data pointer, keep the pad hidden.
- Only zero the signal pad, not the whole block. The old code memset the entire granularity-rounded allocation, so a large data buffer paid a large, pointless zeroing cost on every alloc() — only the pad needs initializing for the CAS-based barrier() protocol.
- Bookkeeping stays keyed on the returned data pointer; free() still drops the whole block via the owning AllocationRef. Rendezvous derives each peer's mapped base explicitly (rather than reusing the signal-pad pointer as the unmap address).

NCCL backend
- Adopt the same pad-first layout, and explicitly zero the signal pad after ncclMemAlloc (which does not zero memory). This is required for MemPool correctness: when a buffer is recycled from the pool, its bytes are stale, so without this the reused allocation's signal pad would be polluted and the barrier/signaling protocol would misbehave.

NVSHMEM backend
- Consolidate the signal pad into the data allocation (previously a separate nvshmem_malloc), matching the other two backends: one allocation laid out pad-first, pad zeroed once in alloc(), peer signal pads / buffers / multicast address all derived from the shared base + buffer_offset.