### PR TITLE
[ROCm][inductor] Enable scaled grouped GEMM Triton lowering

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -80,6 +80,7 @@ from torch.testing._internal.common_cuda import (
     _get_torch_cuda_version,
     IS_SM90,
     PLATFORM_SUPPORTS_FLASH_ATTENTION,
+    PLATFORM_SUPPORTS_FP8,
     PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
     SM100OrLater,
     SM80OrLater,
@@ -89,6 +90,7 @@ from torch.testing._internal.common_cuda import (
     with_tf32_off,
 )
 from torch.testing._internal.common_device_type import (
+    e4m3_type,
     expectedFailureXPU,
     largeTensorTest,
 )
@@ -20505,7 +20507,10 @@ if RUN_GPU:
                 "'XBLOCK': 'constexpr'"
             ).run(code[0])
 
-        @unittest.skipIf(TEST_WITH_ROCM or not IS_SM90, "no scaled_grouped_mm support")
+        @unittest.skipIf(
+            not (IS_SM90 or (TEST_WITH_ROCM and PLATFORM_SUPPORTS_FP8)),
+            "no scaled_grouped_mm support",
+        )
         def test_respect_scaled_grouped_mm_layout_tag(self):
             # scaled_grouped_mm needs `mat2` to be column-major
             M, K, N = 128, 64, 32  # K and N must be divisible by 16
@@ -20540,11 +20545,11 @@ if RUN_GPU:
             def fn():
                 A_scales = torch.ones(M, dtype=torch.float32, device=GPU_TYPE)
                 A_scaled = A.to(torch.float32) * A_scales.unsqueeze(-1)
-                A_fp8_row_major = A_scaled.to(torch.float8_e4m3fn)
+                A_fp8_row_major = A_scaled.to(e4m3_type)
 
                 B_t_scales = torch.ones(E, N, dtype=torch.float32, device=GPU_TYPE)
                 B_t_scaled = B_t.to(torch.float32) * B_t_scales.unsqueeze(1)
-                B_t_fp8_col_major = B_t_scaled.to(torch.float8_e4m3fn)
+                B_t_fp8_col_major = B_t_scaled.to(e4m3_type)
 
                 A_scales_reciprocal = A_scales.reciprocal()
                 B_t_scales_reciprocal = B_t_scales.reciprocal()

--- a/torch/_inductor/kernel/mm_grouped.py
+++ b/torch/_inductor/kernel/mm_grouped.py
@@ -153,15 +153,27 @@ def has_grouped_mm_triton_support() -> bool:
     return torch.cuda.get_device_capability() >= (9, 0)
 
 
+def _rocm_gcn_arch() -> str:
+    return torch.cuda.get_device_properties(
+        torch.cuda.current_device()
+    ).gcnArchName.split(":", 1)[0]
+
+
 def has_rocm_fp8_hardware_support() -> bool:
     if not torch.version.hip:
         return False
-    arch = torch.cuda.get_device_properties(
-        torch.cuda.current_device()
-    ).gcnArchName.split(":", 1)[0]
-    # Scaled grouped GEMM uses FP8 inputs. On ROCm, hardware FP8 matrix
-    # support starts with CDNA3/CDNA4 and RDNA4.
-    return arch.startswith(("gfx94", "gfx95", "gfx12"))
+
+    # Keep this in sync with torch.testing._internal.common_cuda.PLATFORM_SUPPORTS_FP8;
+    # this is the production-side equivalent used to gate Triton FP8 lowering.
+    arch = _rocm_gcn_arch()
+    rocm_version = tuple(int(v) for v in torch.version.hip.split(".")[:2])
+    if arch.startswith("gfx94"):
+        return True
+    if arch.startswith("gfx120") and rocm_version >= (6, 3):
+        return True
+    if arch.startswith("gfx95") and rocm_version >= (6, 5):
+        return True
+    return False
 
 
 def has_scaled_grouped_mm_triton_support(mat_a: TensorBox, mat_b: TensorBox) -> bool:
@@ -170,12 +182,12 @@ def has_scaled_grouped_mm_triton_support(mat_a: TensorBox, mat_b: TensorBox) -> 
     if not has_rocm_fp8_hardware_support():
         return False
 
-    arch = torch.cuda.get_device_properties(
-        torch.cuda.current_device()
-    ).gcnArchName.split(":", 1)[0]
+    arch = _rocm_gcn_arch()
     # Match ATen's ROCm rowwise scaled grouped GEMM contract: gfx94 uses the
     # FNUZ FP8 encoding, while newer FP8-capable arches use OCP FP8.
-    expected_dtype = torch.float8_e4m3fnuz if arch.startswith("gfx94") else torch.float8_e4m3fn
+    expected_dtype = (
+        torch.float8_e4m3fnuz if arch.startswith("gfx94") else torch.float8_e4m3fn
+    )
     return mat_a.get_dtype() == expected_dtype and mat_b.get_dtype() == expected_dtype
 
 

--- a/torch/_inductor/kernel/mm_grouped.py
+++ b/torch/_inductor/kernel/mm_grouped.py
@@ -153,6 +153,32 @@ def has_grouped_mm_triton_support() -> bool:
     return torch.cuda.get_device_capability() >= (9, 0)
 
 
+def has_rocm_fp8_hardware_support() -> bool:
+    if not torch.version.hip:
+        return False
+    arch = torch.cuda.get_device_properties(
+        torch.cuda.current_device()
+    ).gcnArchName.split(":", 1)[0]
+    # Scaled grouped GEMM uses FP8 inputs. On ROCm, hardware FP8 matrix
+    # support starts with CDNA3/CDNA4 and RDNA4.
+    return arch.startswith(("gfx94", "gfx95", "gfx12"))
+
+
+def has_scaled_grouped_mm_triton_support(mat_a: TensorBox, mat_b: TensorBox) -> bool:
+    if not torch.version.hip:
+        return True
+    if not has_rocm_fp8_hardware_support():
+        return False
+
+    arch = torch.cuda.get_device_properties(
+        torch.cuda.current_device()
+    ).gcnArchName.split(":", 1)[0]
+    # Match ATen's ROCm rowwise scaled grouped GEMM contract: gfx94 uses the
+    # FNUZ FP8 encoding, while newer FP8-capable arches use OCP FP8.
+    expected_dtype = torch.float8_e4m3fnuz if arch.startswith("gfx94") else torch.float8_e4m3fn
+    return mat_a.get_dtype() == expected_dtype and mat_b.get_dtype() == expected_dtype
+
+
 def grouped_mm_args(
     mat1: TensorBox,
     mat2: TensorBox,
@@ -387,13 +413,14 @@ def _tuned_grouped_mm_common(
             k = V.graph.sizevars.check_equals(k1, k2)
             a_is_2d, b_is_2d = False, False
 
+    scaled = scale_a is not None
+
     if (
         is_nonzero
         and use_triton_template(layout)
         and can_use_triton_kernel(mat_a, mat_b, offs, bias, scale_result)
+        and (not scaled or has_scaled_grouped_mm_triton_support(mat_a, mat_b))
     ):
-        scaled = scale_a is not None
-
         a_is_k_major = mat_a.get_stride()[-1] == 1
         b_is_k_major = mat_b.get_stride()[-2] == 1
 


### PR DESCRIPTION
## Summary
- Build on the ROCm grouped GEMM Triton lowering change so legacy `aten._scaled_grouped_mm` can use the shared scaled grouped Triton template on ROCm.
- Gate ROCm scaled grouped GEMM Triton selection to FP8-capable hardware and the expected FP8 encoding (`fnuz` on gfx94, OCP FP8 on newer FP8-capable arches).
- Enable the existing scaled grouped GEMM Inductor layout test on ROCm FP8-capable platforms and use the platform-specific `e4m3_type` test helper.

Made with [Cursor](https://cursor.com)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben