### PR TITLE
Update dynamic_inductor_huggingface graph-break baselines

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_inductor_huggingface_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_inductor_huggingface_training.csv
@@ -10,7 +10,7 @@ AllenaiLongformerBase,pass,9
 
 
 
-BartForCausalLM,pass,6
+BartForCausalLM,pass,7
 
 
 
@@ -50,11 +50,11 @@ LayoutLMForMaskedLM,pass,5
 
 
 
-M2M100ForConditionalGeneration,pass,11
+M2M100ForConditionalGeneration,pass,4
 
 
 
-MBartForCausalLM,pass,6
+MBartForCausalLM,pass,7
 
 
 
@@ -70,7 +70,7 @@ MobileBertForMaskedLM,pass,3
 
 
 
-OPTForCausalLM,pass,8
+OPTForCausalLM,pass,7
 
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #188743

The periodic dynamic_inductor_huggingface benchmark started failing the
graph-break check. Sync the expected baselines to the current counts:

- BartForCausalLM: 6 -> 7 (new graph break)
- MBartForCausalLM: 6 -> 7 (new graph break)
- M2M100ForConditionalGeneration: 11 -> 4 (improved)
- OPTForCausalLM: 8 -> 7 (improved)

Counts taken from the failing periodic run (pytorch commit 909e76cadf21).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98