### PR TITLE
Mark detectron2_maskrcnn r_101_fpn/r_50_c4 fail_accuracy (cpu_inductor_amp_freezing)

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/cpu_inductor_amp_freezing_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/cpu_inductor_amp_freezing_torchbench_inference.csv
@@ -82,11 +82,11 @@ detectron2_maskrcnn_r_101_c4,fail_accuracy,57
 
 
 
-detectron2_maskrcnn_r_101_fpn,pass,63
+detectron2_maskrcnn_r_101_fpn,fail_accuracy,63
 
 
 
-detectron2_maskrcnn_r_50_c4,pass,57
+detectron2_maskrcnn_r_50_c4,fail_accuracy,57
 
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #188746

detectron2_maskrcnn_r_101_fpn and detectron2_maskrcnn_r_50_c4 have been
failing the accuracy check on the periodic cpu_inductor_amp_freezing
torchbench benchmark for weeks (tiny CPU-inductor-freezing numeric diffs in
the mask logits that exceed even the IoU-based bool-mask tolerance added in
#186441). Their sibling variants r_101_c4 and r_50_fpn are already recorded
as fail_accuracy; update the expected baseline for these two to match so the
job stops being blocked.

Tracked in #188514.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98