### PR TITLE
[dynamo] Add ReproOptions Protocol for repro CLI option Namespaces

### DIFF
--- a/torch/_dynamo/repro/__init__.py
+++ b/torch/_dynamo/repro/__init__.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class ReproOptions(Protocol):
+    """
+    Read-only view of the argparse Namespace threaded through the repro_*
+    entrypoints in after_aot.py and after_dynamo.py.
+
+    argparse populates the Namespace dynamically, so a Protocol (rather than a
+    concrete class) is the pragmatic fit: it documents the attributes those
+    functions actually read without asserting how the Namespace is built. Not
+    every attribute is populated for every subcommand -- e.g. after_dynamo
+    never sets tracing_mode -- but each repro_* function only reads the subset
+    that its own subparser defines.
+    """
+
+    # Shared across the after_aot and after_dynamo subparsers.
+    command: str
+    accuracy: str
+    save_dir: str | None
+
+    # after_aot-only attributes.
+    tracing_mode: str | None
+    check_str: str | None
+    isolate: bool
+    offload_to_disk: bool
+    skip_saving_eager_intermediates: bool
+    skip_sanity: bool
+    max_granularity: int | None
+    stable_hash: bool
+    skip_saving_inductor_intermediates: bool
+    skip_saving_float64_intermediates: bool
+    skip_check_deterministic: bool
+
+    # after_dynamo-only attributes.
+    backend: str | None
+    autocast: bool
+    only_fwd: bool

--- a/torch/_dynamo/repro/after_aot.py
+++ b/torch/_dynamo/repro/after_aot.py
@@ -139,6 +139,8 @@ if TYPE_CHECKING:
     from torch._inductor.output_code import OutputCode
     from torch._inductor.utils import InputType
 
+    from . import ReproOptions
+
 
 log = logging.getLogger(__name__)
 
@@ -1137,7 +1139,7 @@ def _build_symbolic_wrapper(
 
 
 def repro_common(
-    options: Any, mod: nn.Module, load_args: Any
+    options: ReproOptions, mod: nn.Module, load_args: Any
 ) -> tuple[torch.fx.GraphModule, list[Any]]:
     # Invariant for graphs we generate with the repro script
     if any(mod.named_parameters()):
@@ -1180,7 +1182,7 @@ def repro_common(
     # _build_symbolic_wrapper to reconstruct algebraic relationships between
     # free and derived symints, but the arg reordering is fragile across
     # different graph structures so we skip it for now.
-    mod = make_fx(mod, tracing_mode=options.tracing_mode)(*args)
+    mod = make_fx(mod, tracing_mode=options.tracing_mode)(*args)  # type: ignore[arg-type]
 
     # pyrefly: ignore [bad-assignment]
     torch._inductor.config.generate_intermediate_hooks = True
@@ -1228,7 +1230,7 @@ ACCURACY_FAILS: dict[str, Callable[[torch.fx.GraphModule, Any], bool]] = {
 }
 
 
-def repro_minifier_query(options: Any, mod: nn.Module, load_args: Any) -> None:
+def repro_minifier_query(options: ReproOptions, mod: nn.Module, load_args: Any) -> None:
     mod, args = repro_common(options, mod, load_args)
     fail_fn = functools.partial(
         ACCURACY_FAILS[options.accuracy],
@@ -1240,7 +1242,7 @@ def repro_minifier_query(options: Any, mod: nn.Module, load_args: Any) -> None:
         sys.exit(0)
 
 
-def repro_minify(options: Any, mod: nn.Module, load_args: Any) -> None:
+def repro_minify(options: ReproOptions, mod: nn.Module, load_args: Any) -> None:
     from functorch.compile import minifier
 
     mod, args = repro_common(options, mod, load_args)
@@ -1278,7 +1280,7 @@ def repro_minify(options: Any, mod: nn.Module, load_args: Any) -> None:
         )
 
 
-def repro_analyze(options: Any, mod: nn.Module, load_args: Any) -> None:
+def repro_analyze(options: ReproOptions, mod: nn.Module, load_args: Any) -> None:
     from torch._inductor.compile_fx import compile_fx_inner
     from torch._inductor.hooks import intermediate_hook
 
@@ -1304,10 +1306,15 @@ def repro_analyze(options: Any, mod: nn.Module, load_args: Any) -> None:
             writer.write_tensor(os.path.join("inductor", name), val)
         pbar.update(1)  # type: ignore[has-type]
 
+    # analyze stores and re-reads intermediates on disk, so a save_dir is
+    # required; --no-save-dir (save_dir=None) is invalid for this subcommand.
+    save_dir = options.save_dir
+    if save_dir is None:
+        raise RuntimeError("analyze requires a save_dir; do not pass --no-save-dir")
     writer = torch.utils._content_store.ContentStoreWriter(
-        options.save_dir, stable_hash=options.stable_hash
+        save_dir, stable_hash=options.stable_hash
     )
-    reader = torch.utils._content_store.ContentStoreReader(options.save_dir)
+    reader = torch.utils._content_store.ContentStoreReader(save_dir)
 
     new_args = clone_inputs(args)
     with (
@@ -1427,13 +1434,13 @@ def repro_analyze(options: Any, mod: nn.Module, load_args: Any) -> None:
 
 
 def repro_get_args(
-    options: Any, mod: nn.Module, load_args: Any
+    options: ReproOptions, mod: nn.Module, load_args: Any
 ) -> tuple[torch.fx.GraphModule, list[Any]]:
     mod, args = repro_common(options, mod, load_args)
     return mod, args
 
 
-def repro_run(options: Any, mod: nn.Module, load_args: Any) -> None:
+def repro_run(options: ReproOptions, mod: nn.Module, load_args: Any) -> None:
     from torch._inductor.compile_fx import compile_fx_inner
 
     mod, args = repro_common(options, mod, load_args)
@@ -1683,7 +1690,7 @@ divergences--you just might not end up with a useful repro in the end.""",
     if len(sys.argv) <= 1:
         args = [command, *sys.argv[1:]]
 
-    options = parser.parse_args(args)
+    options = typing.cast("ReproOptions", parser.parse_args(args))
     COMMAND_FNS = {
         "minify": repro_minify,
         "analyze": repro_analyze,

--- a/torch/_dynamo/repro/after_dynamo.py
+++ b/torch/_dynamo/repro/after_dynamo.py
@@ -54,6 +54,7 @@ from .. import config
 from ..backends.registry import CompilerFn, lookup_backend, register_debug_backend
 from ..debug_utils import clone_inputs_retaining_gradness
 from ..types import CompilerConfigProvider
+from . import ReproOptions
 
 
 log = logging.getLogger(__name__)
@@ -431,7 +432,9 @@ def backend_fails(
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 
 
-def run_load_args(options: Any, mod: torch.nn.Module, load_args: Any) -> list[Any]:
+def run_load_args(
+    options: ReproOptions, mod: torch.nn.Module, load_args: Any
+) -> list[Any]:
     if not hasattr(load_args, "_version"):
         log.warning(
             "load_args does not have a _version attribute, please file a bug to PyTorch "
@@ -457,7 +460,7 @@ def run_load_args(options: Any, mod: torch.nn.Module, load_args: Any) -> list[An
     return args
 
 
-def repro_minify(options: Any, mod: torch.nn.Module, load_args: Any) -> None:
+def repro_minify(options: ReproOptions, mod: torch.nn.Module, load_args: Any) -> None:
     # Setup debug minifier compiler
     if not options.accuracy:
         compiler_fn = lookup_backend("dynamo_minifier_backend")
@@ -491,7 +494,7 @@ def repro_minify(options: Any, mod: torch.nn.Module, load_args: Any) -> None:
         opt_mod(*args)
 
 
-def repro_run(options: Any, mod: torch.nn.Module, load_args: Any) -> None:
+def repro_run(options: ReproOptions, mod: torch.nn.Module, load_args: Any) -> None:
     opt_mod = torch._dynamo.optimize(options.backend)(mod)
 
     if options.accuracy != "":
@@ -660,7 +663,7 @@ default settings on this script:
     if len(sys.argv) <= 1:
         args = [command, *sys.argv[1:]]
 
-    options = parser.parse_args(args)
+    options = cast(ReproOptions, parser.parse_args(args))
     COMMAND_FNS = {
         "minify": repro_minify,
         "run": repro_run,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* (to be filled)

The argparse Namespace produced by run_repro is threaded through the repro_*
entrypoints in repro/after_aot.py and repro/after_dynamo.py as `options: Any`.
argparse populates the Namespace dynamically, so there is no concrete class to
name; this replaces `Any` with a shared ReproOptions Protocol that documents the
full attribute surface those functions actually read (save_dir, tracing_mode,
accuracy, check_str, isolate, offload_to_disk, the skip_* flags,
max_granularity, command, stable_hash for after_aot, plus backend, autocast,
only_fwd for after_dynamo). The Protocol lives in the repro package __init__ so
both modules share one definition.

Tightening the type surfaced two things that are handled here rather than
suppressed blindly:

- run_repro parses into an argparse.Namespace, which pyrefly does not treat as
  structurally satisfying the Protocol (its __getattr__ cannot be checked for
  override compatibility), so the parsed value is cast to ReproOptions at the
  single dispatch site in each module.

- repro_analyze fed options.save_dir (now str | None) into ContentStoreWriter/
  Reader, which require str. save_dir is only None under --no-save-dir, which
  was always broken for analyze since it stores and re-reads intermediates on
  disk, so this adds a fail-fast guard instead of a suppression. The one
  remaining suppression is make_fx's tracing_mode: a runtime-valid mode string
  that is only typed str | None here versus make_fx's Literal.

Test Plan:

Type-checking and lint are the relevant verification for an annotation-only
change; the modified files are clean:

```
lintrunner --take PYFMT,RUFF,PYREFLY,CODESPELL,FLAKE8 \
  torch/_dynamo/repro/__init__.py \
  torch/_dynamo/repro/after_aot.py \
  torch/_dynamo/repro/after_dynamo.py
```

This PR was authored with the assistance of an AI coding assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98