### PR TITLE
[dynamo] fix lazy module initialization with symbolic shapes

### DIFF
--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -21,7 +21,7 @@ import torch.nn.functional as F
 from torch._dynamo.debug_utils import same_two_models
 from torch._dynamo.eval_frame import unsupported
 from torch._dynamo.mutation_guard import GenerationTracker
-from torch._dynamo.testing import expectedFailureDynamic, same
+from torch._dynamo.testing import same
 from torch._dynamo.utils import ifdynstaticdefault
 from torch._dynamo.variables.torch_function import TensorWithTFOverrideVariable
 from torch.nn.modules.lazy import LazyModuleMixin
@@ -1511,8 +1511,6 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(cnt.op_count, 1)
         self.assertTrue(torch._dynamo.testing.same(out1, out2))
 
-    # RuntimeError: SymIntArrayRef expected to contain only concrete integers
-    @expectedFailureDynamic
     def test_lazy_module1(self):
         input_shape = (16, 3, 6, 7, 8)
 
@@ -1581,8 +1579,6 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
         )
         self.assertEqual(cnt.frame_count, 1, "No guards should have triggered.")
 
-    # RuntimeError: SymIntArrayRef expected to contain only concrete integers
-    @expectedFailureDynamic
     def test_lazy_module2(self):
         # Test FX graph 'call_module' works well if argument is lazy module
         m = LazyMLP()
@@ -1594,8 +1590,6 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
         ref = m(x)
         self.assertTrue(torch.allclose(ref, res))
 
-    # RuntimeError: SymIntArrayRef expected to contain only concrete integers
-    @expectedFailureDynamic
     def test_lazy_module4(self):
         m = LazyMLP()
         x = torch.rand([10, 10])
@@ -1612,8 +1606,6 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
         except RuntimeError:
             self.assertIn("must have same reduction dim", traceback.format_exc())
 
-    # RuntimeError: SymIntArrayRef expected to contain only concrete integers
-    @expectedFailureDynamic
     def test_lazy_module5(self):
         # Test lazy module works well with list/tuple input
         m = LazyModuleWithListInput()
@@ -1623,8 +1615,6 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
         ref = m(x)
         self.assertTrue(torch.allclose(ref, res))
 
-    # RuntimeError: SymIntArrayRef expected to contain only concrete integers
-    @expectedFailureDynamic
     def test_lazy_module6(self):
         # Test new lazy submodule in lazy module's initialize_parameters
         m = LazyModuleWithLazySubmodule()
@@ -1634,8 +1624,6 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
         ref = m(x)
         self.assertTrue(torch.allclose(ref, res))
 
-    # RuntimeError: SymIntArrayRef expected to contain only concrete integers
-    @expectedFailureDynamic
     def test_lazy_module7(self):
         # Test lazy module works well with namedtuple/dict input
         m = LazyModuleWithNamedTupleInput()
@@ -1691,8 +1679,6 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
         with self.assertRaises(AttributeError):
             exp_res = opt_m(x, y)
 
-    # RuntimeError: SymIntArrayRef expected to contain only concrete integers
-    @expectedFailureDynamic
     def test_lazy_module_speculation_log_divergence(self):
         class ModWithOneLazyLinear(torch.nn.Module):
             def __init__(self) -> None:
@@ -1729,6 +1715,22 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
         expect_res = mod(x)
         self.assertTrue(torch.allclose(expect_res, actual_res))
         self.assertEqual(cnt.frame_count, 1)
+
+    def test_lazy_module_symbolic_shapes(self):
+        # Regression test: lazy module initialization must handle symbolic
+        # shapes from dynamic inputs without hitting "SymIntArrayRef expected
+        # to contain only concrete integers".
+        m = torch.nn.LazyBatchNorm1d()
+
+        @torch.compile(backend="eager", dynamic=True)
+        def fn(x):
+            return m(x)
+
+        x = torch.randn(16, 3, 6)
+        result = fn(x)
+        self.assertEqual(result.shape, x.shape)
+        self.assertIsInstance(m, torch.nn.BatchNorm1d)
+        self.assertEqual(m.num_features, 3)
 
     def test_call_fn_with_non_const_inputs_safe(self):
         class ModuleSpecialFwd(torch.nn.Module):
@@ -1816,7 +1818,6 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
 
 
 class NNModuleTestsDevice(torch._dynamo.test_case.TestCase):
-    @expectedFailureDynamic
     @skipIfHpu
     def test_lazy_module3(self, device):
         m = LazyMLP()

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -107,7 +107,21 @@ def initialize_lazy_module(
             elif isinstance(x, (list, tuple, set)):
                 return type(x)(convert_to_fake(elem) for elem in x)
             elif isinstance(x, torch.fx.Proxy):
-                return get_fake_value(x.node, tx)
+                fake = get_fake_value(x.node, tx)
+                if isinstance(fake, torch.Tensor) and any(
+                    isinstance(s, torch.SymInt) for s in fake.shape
+                ):
+                    # _infer_parameters runs real ops on the module, so
+                    # symbolic shapes must be concretized to their hints.
+                    shape = [
+                        s.node.hint if isinstance(s, torch.SymInt) else s
+                        for s in fake.shape
+                    ]
+                    assert all(isinstance(s, int) for s in shape), shape  # noqa: S101
+                    return torch.empty(  # pyrefly: ignore[no-matching-overload]
+                        shape, dtype=fake.dtype, device=fake.device
+                    )
+                return fake
             else:
                 return x
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #171826
* #163503
* #185524
* #188173
* #186100
* #186657
* #188622
* #188596
* #188752
* __->__ #188751

`initialize_lazy_module` converts proxy args to fake tensors to call
`_infer_parameters` on the real module. In resume functions (after a graph
break), fake tensors can have symbolic shapes. When `_infer_parameters` reads
`input.shape[1]` to get `num_features` and passes it to
`UninitializedParameter.materialize()`, the SymInt reaches `torch.empty` in
C++ which rejects non-concrete integers.

The fix concretizes symbolic shapes to their concrete hints before passing
fake tensors to `_infer_parameters`, since that function runs real ops on the
module outside of tracing.

This was surfaced by `TestLazyModules.test_lazy_batchnorm_with_dict_input`
failing under `PYTORCH_TEST_WITH_DYNAMO=1` with `nested_graph_breaks=False`.

Authored with the help of an AI assistant.

Test Plan:

```
PYTORCH_TEST_WITH_DYNAMO=1 python -c "
import torch._dynamo.config; torch._dynamo.config.nested_graph_breaks = False
import sys, os; sys.path.insert(0, os.path.join(os.getcwd(), 'test'))
from nn.test_lazy_modules import TestLazyModules
import unittest
suite = unittest.TestSuite()
for t in ['test_lazy_batchnorm1d', 'test_lazy_batchnorm2d', 'test_lazy_batchnorm3d',
          'test_lazy_batchnorm_with_dict_input', 'test_lazy_conv1d', 'test_lazy_conv2d', 'test_lazy_conv3d']:
    suite.addTest(unittest.TestLoader().loadTestsFromName(t, TestLazyModules))
unittest.TextTestRunner(verbosity=2).run(suite)
"
```