### PR TITLE
Mark maml_omniglot pass on rocm dynamic_inductor_torchbench training baseline

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamic_inductor_torchbench_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamic_inductor_torchbench_training.csv
@@ -82,7 +82,7 @@ llava,eager_fail_to_run,0
 
 
 
-maml_omniglot,fail_accuracy,7
+maml_omniglot,pass,7
 
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #188754

maml_omniglot now passes accuracy on the ROCm (gfx950) dynamic_inductor_torchbench
training benchmark, but the baseline still expects fail_accuracy, so the periodic
job fails with "IMPROVED: accuracy=pass, expected=fail_accuracy". Update the
expected status to pass. This rocm/ training CSV is only consumed by that job.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @azahed98