### PR TITLE
cudagraph_trees: honor mark_static_address outputs

### DIFF
--- a/docs/source/logging.md
+++ b/docs/source/logging.md
@@ -105,7 +105,7 @@ Internal test-only artifacts are omitted.
   default.
 * `cudagraphs`: Logs information from wrapping Inductor generated code with
   CUDA graphs.
-* `cudagraph_static_inputs`: Logs static input handling in Dynamo, AOT, and
+* `cudagraph_static_addrs`: Logs static input handling in Dynamo, AOT, and
   CUDA graphs. Off by default.
 * `ddp_graphs`: Prints individual graphs generated when DDPOptimizer splits
   graphs to trigger communication early.

--- a/test/dynamo/test_logging.py
+++ b/test/dynamo/test_logging.py
@@ -1327,8 +1327,8 @@ TRACE FX call mul from test_logging.py:N in fn (LoggingTests.test_trace_call_pre
             """+- GLOBAL_STATE: ___check_global_state() against {"allow_bf16_reduce": "#","allow_fp16_reduce": "#","allow_tf32": "#","autocast_state":{"cached_enabled": "#","dtype": "#","enabled": "#"},"default_dtype": "#","deterministic_algorithms": "#","deterministic_algorithms_warn_only": "#","grad_mode": "#","num_threads": "#","torch_function": "#","torch_function_all_disabled": "#"}""",
         )
 
-    @make_logging_test(cudagraph_static_inputs=True)
-    def test_cudagraph_static_inputs(self, records):
+    @make_logging_test(cudagraph_static_addrs=True)
+    def test_cudagraph_static_addrs(self, records):
         @torch.compile(mode="reduce-overhead")
         def fn(x):
             return x + 1
@@ -1614,7 +1614,7 @@ exclusions = {
     "sym_node",
     "export",
     "trace_shape_events",
-    "cudagraph_static_inputs",
+    "cudagraph_static_addrs",
     "benchmarking",
     "loop_ordering",
     "loop_tiling",

--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -2939,7 +2939,7 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
             self.assertGreater(len(input_nodes), 0)
             for input_node in input_nodes:
                 self.assertEqual(
-                    input_node.meta["tensor_dict"]["_dynamo_static_input_type"],
+                    input_node.meta["tensor_dict"]["_dynamo_static_type"],
                     "unguarded",
                 )
 
@@ -2984,7 +2984,7 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
             self.assertGreater(len(input_nodes), 0)
             for input_node in input_nodes:
                 self.assertEqual(
-                    input_node.meta["tensor_dict"]["_dynamo_static_input_type"],
+                    input_node.meta["tensor_dict"]["_dynamo_static_type"],
                     "unguarded",
                 )
 

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -1886,6 +1886,75 @@ if HAS_CUDA_AND_TRITON:
             self.assertEqual(node.cached_tensor_outputs, [None])
             self.assertEqual(node.unaliased_in_all_paths, [False])
 
+        def test_static_address_output_classified_as_static(self):
+            # Outputs marked as a static address should have that state
+            # propagate through the compiler.
+            pool = torch.cuda.MemPool()
+            with torch.cuda.use_mem_pool(pool):
+                static_out = torch.zeros(20, 20, device="cuda")
+            torch._dynamo.mark_static_address(static_out)
+
+            def foo(args):
+                x = args[0]
+                args.clear()
+                static_out.copy_(x + 1)
+                return (static_out,)
+
+            foo_cg = self.cudagraphify_impl(
+                foo, [torch.zeros(20, 20, device="cuda")], ()
+            )
+            for gen in range(3):
+                inp = torch.full((20, 20), float(gen), device="cuda")
+                self.assertEqual(foo_cg([inp])[0], inp + 1)
+
+            # internal state: the marked output is classified static and kept
+            # out of the pool-managed output set (so it is never poisoned).
+            node = self.curr_node()
+            self.assertIs(node.static_output_tensors[0], static_out)
+            self.assertIsNone(node.outputs_weakrefs[0])
+            self.assertTrue(
+                torch._inductor.cudagraph_trees._is_marked_static_address(static_out)
+            )
+
+        def test_unmarked_out_of_pool_output_still_rejected(self):
+            # After support for mark_static_address on outputs was added, we
+            # need to be sure that dynamic addresses from another pool still
+            # appropriately raise errors.
+            pool = torch.cuda.MemPool()
+            with torch.cuda.use_mem_pool(pool):
+                out_buf = torch.zeros(20, 20, device="cuda")
+
+            def foo(args):
+                x = args[0]
+                args.clear()
+                out_buf.copy_(x + 1)
+                return (out_buf,)
+
+            foo_cg = self.cudagraphify_impl(
+                foo, [torch.zeros(20, 20, device="cuda")], ()
+            )
+            with self.assertRaisesRegex(RuntimeError, "not allocated in pool"):
+                for gen in range(3):
+                    foo_cg([torch.full((20, 20), float(gen), device="cuda")])
+
+        def test_static_address_output_reduce_overhead(self):
+            # mark_static_address can be used on outputs as well, which lets
+            # users pre-allocate outputs via a custom memory pool (for
+            # example).
+            pool = torch.cuda.MemPool()
+            with torch.cuda.use_mem_pool(pool):
+                out = torch.zeros(64, device="cuda")
+            torch._dynamo.mark_static_address(out)
+
+            @torch.compile(mode="reduce-overhead", fullgraph=True)
+            def f(x):
+                out.copy_(x + 1)
+                return out
+
+            for i in range(4):
+                x = torch.full((64,), float(i), device="cuda")
+                self.assertEqual(f(x), x + 1)
+
         def test_warmup_stream_sync(self):
             def foo(args):
                 x = args[0]

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -1368,19 +1368,19 @@ def mark_static(t: Any, index: int | list[Any] | tuple[Any] | None = None) -> No
 @forbid_in_graph
 def mark_static_address(t: Any, guard: bool = False) -> None:
     """
-    Marks an input tensor whose address should be treated as constant across calls to the
-    same dynamo-compiled function. This indicates to cudagraphs that an extra allocation
-    is not needed for this input. The data_ptr will be guarded if guard=True, and cause a full
-    recompile if the data_ptr changes. Note: If this address changes, cudagraphs will re-record
-    if guard=False.
+    Marks a tensor whose address should be treated as constant across calls to
+    the same dynamo-compiled function. This indicates to cudagraphs that an
+    extra allocation is not needed for the tensor. The data_ptr will be guarded
+    if guard=True, and cause a full recompile if the data_ptr changes. Note: If
+    this address changes, cudagraphs will re-record if guard=False.
     """
     if not isinstance(t, torch.Tensor):
         raise TypeError(f"mark_static_address expects a tensor but received {type(t)}")
 
     if guard:
-        t._dynamo_static_input_type = "guarded"  # type: ignore[attr-defined]
+        t._dynamo_static_type = "guarded"  # type: ignore[attr-defined]
     else:
-        t._dynamo_static_input_type = "unguarded"  # type: ignore[attr-defined]
+        t._dynamo_static_type = "unguarded"  # type: ignore[attr-defined]
 
 
 def _patch_einops_symint_compat(einops_mod: Any) -> None:

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -5205,12 +5205,12 @@ def get_instruction_source_311(code: types.CodeType, inst: Instruction) -> str:
 
 # The two flavors of mark_static_address: "guarded" recompiles when the data_ptr
 # changes, "unguarded" re-records cudagraphs instead. Set in decorators.py.
-StaticInputType = Literal["guarded", "unguarded"]
+StaticType = Literal["guarded", "unguarded"]
 
 
-def get_static_address_type(t: Any) -> StaticInputType | None:
+def get_static_address_type(t: Any) -> StaticType | None:
     if isinstance(t, torch.Tensor):
-        return getattr(t, "_dynamo_static_input_type", None)
+        return getattr(t, "_dynamo_static_type", None)
 
     return None
 
@@ -5586,7 +5586,7 @@ def call_storage_offset(x: Any) -> int:
 # To avoid ref cycles, it's important that no tensors are present here, so leave those out.
 def _extract_tensor_dict(t: torch.Tensor) -> dict[str, Any]:
     KEYS_TO_COPY = [
-        "_dynamo_static_input_type",
+        "_dynamo_static_type",
         "tag",
     ]
 

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -344,9 +344,7 @@ if TYPE_CHECKING:
 
 
 log = logging.getLogger(__name__)
-static_inputs_log = torch._logging.getArtifactLogger(
-    __name__, "cudagraph_static_inputs"
-)
+static_addrs_log = torch._logging.getArtifactLogger(__name__, "cudagraph_static_addrs")
 symbolic_shape_log = logging.getLogger("torch.fx.experimental.symbolic_shapes")
 from typing import TypeVar
 
@@ -2477,7 +2475,7 @@ class VariableBuilder:
     def mark_static_input(self, value: torch.Tensor, guard: bool) -> None:
         from ..decorators import mark_static_address
 
-        static_inputs_log.debug(
+        static_addrs_log.debug(
             "Marking static input %s, id: %s)", self.source.name, id(value)
         )
         mark_static_address(value, guard=guard)
@@ -2487,9 +2485,9 @@ class VariableBuilder:
         if value in self.tx.output.side_effects:
             var = self.tx.output.side_effects[value]
             # type: ignore[attr-defined]
-            var.proxy.node.meta["tensor_dict"]["_dynamo_static_input_type"] = (
+            var.proxy.node.meta["tensor_dict"]["_dynamo_static_type"] = (
                 # type: ignore[attr-defined]
-                value._dynamo_static_input_type
+                value._dynamo_static_type
             )
 
     def wrap_module(self, value: torch.nn.Module) -> VariableTracker:

--- a/torch/_functorch/_aot_autograd/collect_metadata_analysis.py
+++ b/torch/_functorch/_aot_autograd/collect_metadata_analysis.py
@@ -69,7 +69,7 @@ if TYPE_CHECKING:
 zip = strict_zip
 
 log = logging.getLogger(__name__)
-static_input_logger = getArtifactLogger("torch._dynamo", "cudagraph_static_inputs")
+static_addr_logger = getArtifactLogger("torch._dynamo", "cudagraph_static_addrs")
 
 
 # Note [Tangents memory format]
@@ -818,7 +818,7 @@ from a multi-output view call"
                 if (isinstance(arg, torch.nn.Parameter) or i in passed_indices)
             ]
 
-        static_input_logger.debug(
+        static_addr_logger.debug(
             "static input indices metadata analysis: %s", static_input_indices
         )
 

--- a/torch/_functorch/_aot_autograd/frontend_utils.py
+++ b/torch/_functorch/_aot_autograd/frontend_utils.py
@@ -26,9 +26,7 @@ if TYPE_CHECKING:
     from torch.distributed._functional_collectives import AsyncCollectiveTensor
 
 
-static_inputs_log = torch._logging.getArtifactLogger(
-    __name__, "cudagraph_static_inputs"
-)
+static_addr_log = torch._logging.getArtifactLogger(__name__, "cudagraph_static_addrs")
 
 
 def process_inputs(
@@ -316,14 +314,14 @@ def _try_get_metadata_from_dynamo(
         actual_pos = pos + len(param_keys)
 
         if "tensor_dict" in node.meta and node.meta["tensor_dict"].get(
-            "_dynamo_static_input_type", None
+            "_dynamo_static_type", None
         ):
-            static_inputs_log.debug(
+            static_addr_log.debug(
                 "Adding static input pos %s for source %s", actual_pos, source_name
             )
             static_input_indices.append(actual_pos)
         else:
-            static_inputs_log.debug(
+            static_addr_log.debug(
                 "Non-static input pos %s for source %s", actual_pos, source_name
             )
 

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -241,9 +241,7 @@ log = logging.getLogger(__name__)
 perf_hint_log = torch._logging.getArtifactLogger(__name__, "perf_hints")
 pre_grad_graphs_log = torch._logging.getArtifactLogger(__name__, "pre_grad_graphs")
 post_grad_graphs_log = torch._logging.getArtifactLogger(__name__, "post_grad_graphs")
-static_inputs_log = torch._logging.getArtifactLogger(
-    __name__, "cudagraph_static_inputs"
-)
+static_addr_log = torch._logging.getArtifactLogger(__name__, "cudagraph_static_addrs")
 inductor_metrics_log = torch._logging.getArtifactLogger(__name__, "inductor_metrics")
 
 
@@ -912,7 +910,7 @@ def _compile_fx_inner(
         return make_boxed_func(gm.forward)
 
     static_input_idxs: Sequence[int] = graph_kwargs.setdefault("static_input_idxs", ())
-    static_inputs_log.debug("static input idxs compile_fx_inner: %s", static_input_idxs)
+    static_addr_log.debug("static input idxs compile_fx_inner: %s", static_input_idxs)
     inputs_to_check = get_input_idxs_to_check(example_inputs, static_input_idxs)
 
     if not isinstance(next(iter(reversed(gm.graph.nodes))).args[0], (tuple, list)):

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -680,6 +680,22 @@ def map_to_ref(t: Tensor | None) -> StorageWeakRefWrapper | None:
     return StorageWeakRefWrapper(t)
 
 
+def _is_marked_static_address(t: Any) -> bool:
+    """True if ``t`` was marked with ``torch._dynamo.mark_static_address``.
+
+    Such a tensor's address is constant across calls and externally managed
+    (e.g. a parameter, or a persistent buffer a compiled wrapper allocates in
+    its header).  When one appears as a cudagraph input/output it lives outside
+    the private pool, so cudagraph_trees must treat it as a static tensor --
+    skip the pool-membership check and never deallocate/poison it across steps
+    -- rather than flag it as a leaked pool allocation.
+    """
+    return (
+        isinstance(t, torch.Tensor)
+        and getattr(t, "_dynamo_static_type", None) is not None
+    )
+
+
 # A path index of (depth, offset) indices into a graph that is `depth`` number of nodes from the root
 # at graph output offset
 PathOutputIndex = tuple[int, int]
@@ -812,6 +828,9 @@ class CUDAWarmupNode:
                 and o.is_cuda
                 and o.untyped_storage()._cdata not in non_cudagraph_inps_storage_ptrs
                 and o.untyped_storage().data_ptr() != 0
+                # mark_static_address'd outputs are externally managed and live
+                # outside the pool; don't track/lifetime-manage them
+                and not _is_marked_static_address(o)
             )
 
         self.outputs_weakrefs.extend(
@@ -1521,7 +1540,13 @@ class CUDAGraphNode:
             # also treat empty storages as static outputs because we do not need to manage their lifetime
             # and they should not participate in checkpointing
             is_empty_storage = o.untyped_storage().data_ptr() == 0
-            if (ref and ref() is not None) or is_empty_storage:
+            # a mark_static_address'd output is externally managed (lives outside
+            # the private pool); treat it as a static output like the above
+            if (
+                (ref and ref() is not None)
+                or is_empty_storage
+                or _is_marked_static_address(o)
+            ):
                 self.output_storage_alias.append(None)
                 self.static_output_tensors[i] = o
                 continue

--- a/torch/_inductor/cudagraph_utils.py
+++ b/torch/_inductor/cudagraph_utils.py
@@ -25,9 +25,7 @@ _OC = TypeVar("_OC", bound="OutputCode")
 
 
 cudagraphs_log = torch._logging.getArtifactLogger(__name__, "cudagraphs")
-static_inputs_log = torch._logging.getArtifactLogger(
-    __name__, "cudagraph_static_inputs"
-)
+static_addr_log = torch._logging.getArtifactLogger(__name__, "cudagraph_static_addrs")
 
 
 OutputType = list[int | torch.Tensor | None]
@@ -321,10 +319,10 @@ def check_for_mutation(
     else:
         mutation_indices = func.mutated_input_idxs
 
-    static_inputs_log.debug(
+    static_addr_log.debug(
         "check mutation static input indices: %s", func.static_input_idxs
     )
-    static_inputs_log.debug("check mutation indices: %s", mutation_indices)
+    static_addr_log.debug("check mutation indices: %s", mutation_indices)
 
     return (
         get_mutation_stack_trace(func.placeholders, mutation_indices)

--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -255,7 +255,7 @@ def set_logs(
     sym_node: bool = False,
     compiled_autograd: bool = False,
     compiled_autograd_verbose: bool = False,
-    cudagraph_static_inputs: bool = False,
+    cudagraph_static_addrs: bool = False,
     benchmarking: bool = False,
     autotuning: bool = False,
     autotuning_inputs: bool = False,
@@ -454,8 +454,8 @@ def set_logs(
             needs to be set. This can be done by providing the fully-qualified module
             name as the key, with the log level as the value. Default: ``None``
 
-        cudagraph_static_inputs (:class:`bool`):
-            Whether to emit debug info for cudagraph static input detection. Default: ``False``
+        cudagraph_static_addrs (:class:`bool`):
+            Whether to emit debug info for cudagraph static tensor detection. Default: ``False``
 
         autotuning (:class:`bool`):
             Autotuning choice logs, such as kernel source, perf, and tuning parameters. Default: ``False``
@@ -591,7 +591,7 @@ def set_logs(
         cudagraphs=cudagraphs,
         compiled_autograd=compiled_autograd,
         compiled_autograd_verbose=compiled_autograd_verbose,
-        cudagraph_static_inputs=cudagraph_static_inputs,
+        cudagraph_static_addrs=cudagraph_static_addrs,
         benchmarking=benchmarking,
         autotuning=autotuning,
         autotuning_inputs=autotuning_inputs,

--- a/torch/_logging/_registrations.py
+++ b/torch/_logging/_registrations.py
@@ -232,7 +232,7 @@ register_artifact(
     off_by_default=True,
 )
 register_artifact(
-    "cudagraph_static_inputs",
+    "cudagraph_static_addrs",
     "Logs static inputs handling in dynamo, AOT, and cudagraphs",
     off_by_default=True,
 )


### PR DESCRIPTION
cudagraph_trees classifies each storage that is live at the end of capture as either a private-pool allocation or a known static input. An output whose storage was flagged via torch._dynamo.mark_static_address was neither, so check_memory_pool reported it as "not allocated in pool but should be", and (with the slow-path asserts off) the pool manager poisoned/freed it across steps ("accessing tensor output of CUDAGraphs that has been overwritten by a subsequent run").

mark_static_address marks a tensor's address as constant/externally- managed; this honors that on outputs too. An output carrying _dynamo_static_input_type (renamed to just _dynamo_static_type) is now treated as a static output: excluded from the warmup live-storage set (add_ref) and classified as a static output at record time (_add_first_outputs), so it skips the pool-membership check and per-step deallocation -- exactly as an output aliasing a persistent static input already does.

Authored with Claude.

Note to reviewers: the core of this is the changes to `torch/_inductor/cudagraph_trees.py`. The other changes are cosmetic: it made sense to rename `_dynamo_static_input_type` to just `_dynamo_static_type` given that it's no longer limited to just inputs, and then other renames cascaded from there. Happy to remove the cosmetic aspects.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98