### PR TITLE
[inductor] Accept `implicit` kwarg in `expand` lowering (#188758)

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4487,6 +4487,17 @@ for dtype in (torch.int32, torch.int64):
 
         self.common(fn, (torch.randn(2, 1, 2),))
 
+    def test_expand_implicit_kwarg(self):
+        # aten::expand's schema is `expand(Tensor self, SymInt[] size, *, bool
+        # implicit=False)`. Autograd emits calls with `implicit=False` (e.g.
+        # from mean_backward and broadcast backward). The Inductor lowering
+        # must accept the kwarg or such graphs fail with
+        # `TypeError: expand() got an unexpected keyword argument 'implicit'`.
+        def fn(a):
+            return torch.ops.aten.expand.default(a, [3, 4], implicit=False) + 1
+
+        self.common(fn, (torch.randn(1, 4),))
+
     def test_squeeze1(self):
         def fn(a):
             return ((a + 1).squeeze() + 2, a.squeeze() + 2)

--- a/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
@@ -155,6 +155,7 @@ test_failures = {
         ("cpu",)
     ),
     "test_expand_dynamic_shapes": TestFailure(("cpu",)),
+    "test_expand_implicit_kwarg_dynamic_shapes": TestFailure(("cpu",)),
     "test_full_boolean_dynamic_shapes": TestFailure(("cpu",)),
     "test_glu_dynamic_shapes": TestFailure(("cpu",)),
     "test_isinf2_dynamic_shapes": TestFailure(("cpu",)),

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1380,7 +1380,12 @@ def trunc(x):
 
 
 @register_lowering(aten.expand, type_promotion_kind=None)
-def expand(x, sizes):
+def expand(x, sizes, *, implicit=False):
+    # `implicit` is autograd-internal metadata (see aten::expand schema); it
+    # does not affect the produced tensor, so the lowering ignores it. Without
+    # this kwarg the lowering rejects graphs produced by dynamo autograd where
+    # aten.expand.default is emitted with implicit=False.
+    del implicit
     (x,) = promote_constants([x])
     if isinstance(x, ir.BaseConstant):
         return ExpandView.create(x, tuple(sizes))


### PR DESCRIPTION
Summary:

The Inductor lowering for `aten.expand.default` at `torch/_inductor/lowering.py` was declared as `def expand(x, sizes):`, missing the `implicit` kwarg from the aten schema `aten::expand(Tensor(a) self, SymInt[] size, *, bool implicit=False)`.

Autograd emits `aten.expand.default(..., implicit=False)` internally — for example, from `mean_backward` and broadcast-backward paths. When dynamo captures such a graph and hands it to Inductor, the `register_lowering` wrapper forwards kwargs unchanged to the lowering, and `expand()` raises `TypeError: expand() got an unexpected keyword argument 'implicit'`. Every backward compile that flows through an autograd-generated expand fails with this error.

`implicit` is autograd-internal metadata (per aten's docs, "an internal flag used by PyTorch's autograd machinery") that does not affect the produced tensor. This diff makes the lowering accept and discard the kwarg. No output semantics change.

Test Plan:
Added a regression test `test_expand_implicit_kwarg` in `caffe2/test/inductor/test_torchinductor.py` that calls `torch.ops.aten.expand.default(x, sizes, implicit=False)` inside a compiled fn — mirrors what autograd emits.

```
$ buck2 test mode/opt //caffe2/test/inductor:test_inductor -- test_expand_implicit_kwarg
Tests finished: Pass 1. Fail 0.
```

Also verified end-to-end with an out-of-tree MTIA backward-compile harness — a suite of 7 minimal backward tests (`mean(a).backward()`, `mean(a * b).backward()`, `mean(a * b.unsqueeze(-1)).backward()`, `mean(a * b.expand(...)).backward()`, etc.) all failed pre-fix with the `implicit` `TypeError` and all pass post-fix.

Authored with AI assistant (Claude Code).

Reviewed By: jansel

Differential Revision: D110394927




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo