### PR TITLE
[inductor] Add TritonMeta TypedDict for the Triton-launch metadata bag

### DIFF
--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -72,6 +72,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
     from ..graph import GraphLowering
+    from ..runtime.hints import TritonMeta
 
     # At most, the list nesting can go one layer deep.
     _OUTPUT_ARGS_TYPE = list[str | None | list[str | None]]
@@ -106,7 +107,7 @@ class DeferredCpuTritonCallWrapper:
     wrapper_name: str
     kernel_name: str
     arg_types: list[Any]
-    triton_meta: dict[str, Any] | None = None
+    triton_meta: TritonMeta | None = None
     inductor_meta: dict[str, Any] | None = None
 
     def _get_cpp_param_type(self, name: str, arg_type: Any) -> str:
@@ -432,7 +433,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
         arg_types=None,
         raw_keys=None,
         raw_args=None,
-        triton_meta=None,
+        triton_meta: TritonMeta | None = None,
         inductor_meta=None,
         graph_name="",
         original_fxnode_name=None,

--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -28,6 +28,7 @@ from ..runtime.hints import (
     TRITON_DEFAULT_BLOCK_SIZES,
     TRITON_DEFAULT_RSPLIT,
     TRITON_DEFAULT_RSPLIT_SIZE,
+    TritonMeta,
 )
 from ..utils import (
     cache_on_self,
@@ -235,7 +236,7 @@ class DeferredTritonCallWrapper:
     kernel_name: str
     kernel_name_to_body: dict[str, str]
     arg_types: list[Any]
-    triton_meta: dict[str, Any] | None = None
+    triton_meta: TritonMeta | None = None
     inductor_meta: dict[str, Any] | None = None
     tma_tensor_args: dict[str, str] = dataclasses.field(default_factory=dict)
 
@@ -1505,7 +1506,7 @@ static inline void ensure_triton_kernel_compiles_started() {{
         arg_types=None,
         raw_keys=None,
         raw_args=None,
-        triton_meta=None,
+        triton_meta: TritonMeta | None = None,
         inductor_meta=None,
         graph_name="",
         original_fxnode_name=None,

--- a/torch/_inductor/codegen/cpp_wrapper_mps.py
+++ b/torch/_inductor/codegen/cpp_wrapper_mps.py
@@ -6,6 +6,7 @@ import torch
 from torch.utils._ordered_set import OrderedSet
 
 from ..ir import GraphPartitionSignature
+from ..runtime.hints import TritonMeta
 from ..virtualized import V
 from .cpp_wrapper_cpu import CppWrapperCpu
 from .cpp_wrapper_gpu import CppWrapperGpu
@@ -41,7 +42,7 @@ class CppWrapperMps(CppWrapperGpu):
         arg_types: tuple[Any, ...] | None = None,
         raw_keys: tuple[Any, ...] | None = None,
         raw_args: tuple[Any, ...] | None = None,
-        triton_meta: dict[str, Any] | None = None,
+        triton_meta: TritonMeta | None = None,
         inductor_meta: dict[str, Any] | None = None,
         graph_name: str = "",
         original_fxnode_name: str | None = None,

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -59,6 +59,7 @@ from ..runtime.hints import (
     ReductionHint,
     TRITON_MAX_BLOCK,
     TRITON_MAX_RSPLIT,
+    TritonMeta,
 )
 from ..runtime.runtime_utils import get_max_y_grid, next_power_of_2
 from ..scheduler import (
@@ -3213,7 +3214,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
         # A set of autotuning hints to pass as part of triton_meta
         self.autotune_hints = OrderedSet[AutotuneHint]()
-        self.triton_meta: dict[str, Any] | None = None
+        self.triton_meta: TritonMeta | None = None
 
         if self.inside_reduction:
             self.codegen_reduction_numels(self.body)
@@ -6323,7 +6324,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         return imports.getvalue()
 
     @classmethod
-    def triton_meta_common(cls):
+    def triton_meta_common(cls) -> TritonMeta:
         return {
             "enable_fp_fusion": not config.emulate_precision_casts,
             "launch_pdl": cls._enable_pdl_codegen(),
@@ -6597,16 +6598,21 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         triton_meta_signature = signature_to_meta(
             signature, size_dtype=self.index_dtype, argdefs=argdefs
         )
-        triton_meta: dict[str, Any] = {
-            "signature": triton_meta_signature,
-            "device": DeviceProperties.create(V.graph.get_current_device_or_throw()),
-            "constants": {},
-            "native_matmul": (
-                torch._inductor.config.triton.native_matmul
-                and ("tl.dot" in str(self.body) or "tl.dot" in str(self.compute))
-            ),
-            **self.triton_meta_common(),
-        }
+        triton_meta: TritonMeta = cast(
+            TritonMeta,
+            {
+                "signature": triton_meta_signature,
+                "device": DeviceProperties.create(
+                    V.graph.get_current_device_or_throw()
+                ),
+                "constants": {},
+                "native_matmul": (
+                    torch._inductor.config.triton.native_matmul
+                    and ("tl.dot" in str(self.body) or "tl.dot" in str(self.compute))
+                ),
+                **self.triton_meta_common(),
+            },
+        )
 
         if self.cooperative_reduction:
             # Cooperative reductions rely on multi-block synchronization that

--- a/torch/_inductor/codegen/triton_combo_kernel.py
+++ b/torch/_inductor/codegen/triton_combo_kernel.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 from torch.utils._ordered_set import OrderedSet
 
 from .. import config, metrics
-from ..runtime.hints import DeviceProperties
+from ..runtime.hints import DeviceProperties, TritonMeta
 from ..runtime.runtime_utils import next_power_of_2
 from ..runtime.triton_heuristics import (
     RoundRobinComboKernelGrid,
@@ -751,16 +751,21 @@ class ComboKernel(Kernel):
         for i, sub in enumerate(self.sub_kernels):
             self.min_x_blocks_sub_kernel(sub, i)
         self.select_dispatch_strategy()
-        triton_meta: dict[str, Any] = {
-            "signature": signature_to_meta(
-                signature, size_dtype=size_dtype, argdefs=argdefs
-            ),
-            "device": DeviceProperties.create(V.graph.get_current_device_or_throw()),
-            "constants": {},
-            # Inherit enable_fp_fusion, launch_pdl, disable_ftz so combo kernels
-            # compile with the same Triton options as standalone kernels.
-            **TritonKernel.triton_meta_common(),
-        }
+        triton_meta: TritonMeta = cast(
+            TritonMeta,
+            {
+                "signature": signature_to_meta(
+                    signature, size_dtype=size_dtype, argdefs=argdefs
+                ),
+                "device": DeviceProperties.create(
+                    V.graph.get_current_device_or_throw()
+                ),
+                "constants": {},
+                # Inherit enable_fp_fusion, launch_pdl, disable_ftz so combo kernels
+                # compile with the same Triton options as standalone kernels.
+                **TritonKernel.triton_meta_common(),
+            },
+        )
 
         for arg_num in equal_1_arg_indices(signature):
             triton_meta["constants"][signature[arg_num].name] = 1  # type: ignore[index,union-attr]

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -49,7 +49,7 @@ from .. import async_compile, config, debug as inductor_debug, ir
 from ..codecache import output_code_log
 from ..ir import IRNode, ReinterpretView
 from ..runtime import triton_heuristics
-from ..runtime.hints import DeviceProperties
+from ..runtime.hints import DeviceProperties, TritonMeta
 from ..stream_constants import DEFAULT_STREAM, DEFAULT_STREAM_IDX, STREAM_NAME_TEMPLATE
 from ..stream_utils import get_raw_stream_name, get_stream_name
 from ..utils import (
@@ -750,7 +750,7 @@ class KernelCallLine(WrapperLine):
     raw_args: tuple[Any, ...]
     arg_types: list[str]
     triton: bool
-    triton_meta: dict[str, Any]
+    triton_meta: TritonMeta
     inductor_meta: dict[str, Any] | None
     device: torch.device
     graph_name: str
@@ -3214,7 +3214,7 @@ class PythonWrapperCodegen(CodeGen):
         )
         device = V.graph.get_current_device_or_throw()
         device_props = DeviceProperties.create(device)
-        triton_meta: dict[str, Any] = {
+        triton_meta: TritonMeta = {
             "signature": triton_signature,
             "device": device_props,
             # Triton compiler includes equal_to_1 args into constants even
@@ -3643,7 +3643,7 @@ class PythonWrapperCodegen(CodeGen):
         arg_types=None,
         raw_keys=None,
         raw_args=None,
-        triton_meta=None,
+        triton_meta: TritonMeta | None = None,
         inductor_meta=None,
         original_fxnode_name=None,
     ):
@@ -3699,7 +3699,7 @@ class PythonWrapperCodegen(CodeGen):
         arg_types=None,
         raw_keys=None,
         raw_args=None,
-        triton_meta=None,
+        triton_meta: TritonMeta | None = None,
         inductor_meta=None,
         graph_name="",
         original_fxnode_name=None,

--- a/torch/_inductor/runtime/hints.py
+++ b/torch/_inductor/runtime/hints.py
@@ -234,6 +234,36 @@ def get_warp_size(device) -> int:
     return DeviceProperties.create(device).warp_size_or_default
 
 
+class TritonMeta(typing.TypedDict, total=False):
+    """Metadata bag threaded from Triton codegen into the runtime launcher.
+
+    total=False because the key set is populated incrementally across codegen
+    (signature/device/constants/configs first, then backend/ROCm/tlx extras)
+    and the whole bag is forwarded verbatim to external Triton APIs, which
+    tolerate and ignore keys they do not recognize. `device` is typed as the
+    codegen-time DeviceProperties; CachingAutotuner rewrites it to the integer
+    device index before reaching Triton, and the runtime read sites that expect
+    that int narrow it with an explicit cast.
+    """
+
+    signature: dict[str, typing.Any]
+    device: DeviceProperties
+    device_type: str
+    constants: dict[str, typing.Any]
+    configs: list[typing.Any]
+    native_matmul: bool
+    launch_cooperative_grid: bool
+    enable_fp_fusion: bool
+    launch_pdl: bool
+    disable_ftz: bool
+    matrix_instr_nonkdim: int
+    waves_per_eu: int
+    kpack: int
+    restore_value: tuple[str, ...]
+    reset_to_zero: tuple[str, ...]
+    backend_options: dict[str, typing.Any]
+
+
 class HalideInputSpec(typing.NamedTuple):
     ctype: str
     name: str

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -21,6 +21,7 @@ import time
 from collections import namedtuple
 from typing import (
     Any,
+    cast,
     Final,
     Generic,
     get_args,
@@ -62,6 +63,7 @@ from .hints import (
     TRITON_MAX_BLOCK,
     TRITON_MAX_RSPLIT,
     TRITON_MAX_TENSOR_NUMEL,
+    TritonMeta,
 )
 from .runtime_utils import (
     cache_dir,
@@ -453,7 +455,7 @@ class CachingAutotuner(KernelInterface):
     def __init__(
         self,
         fn,
-        triton_meta,  # passed directly to triton
+        triton_meta: TritonMeta,  # passed directly to triton
         configs,
         save_cache_hook,
         mutated_arg_names: list[str],  # see [Note: clone mutated buffers]
@@ -476,11 +478,14 @@ class CachingAutotuner(KernelInterface):
 
         self.fn = fn
         self.device_props: DeviceProperties = triton_meta["device"]
-        self.triton_meta = {
-            **triton_meta,
-            "device": self.device_props.index,
-            "device_type": self.device_props.type,
-        }
+        self.triton_meta: TritonMeta = cast(
+            TritonMeta,
+            {
+                **triton_meta,
+                "device": self.device_props.index,
+                "device_type": self.device_props.type,
+            },
+        )
         self.inductor_meta = {} if inductor_meta is None else inductor_meta
         # Add device properties to inductor_meta for use by coordinate descent tuner
         self.inductor_meta["warp_size"] = self.device_props.warp_size
@@ -518,7 +523,7 @@ class CachingAutotuner(KernelInterface):
         self.benchmark_failure_reasons: dict[Any, BenchmarkFailureReason] = {}
         if os.getenv("TRITON_CACHE_DIR") is None:
             os.environ["TRITON_CACHE_DIR"] = triton_cache_dir(
-                self.triton_meta.get("device", 0)
+                cast(int, self.triton_meta.get("device", 0))
             )
         log.debug("Triton cache dir: %s", os.environ["TRITON_CACHE_DIR"])
 
@@ -701,7 +706,7 @@ class CachingAutotuner(KernelInterface):
             for result in self.compile_results:
                 TritonBundler.put(
                     triton_hash_to_path_key(result.kernel.hash),  # type: ignore[attr-defined]
-                    self.triton_meta.get("device", 0),
+                    cast(int, self.triton_meta.get("device", 0)),
                 )
             return
         if self.launchers:
@@ -973,7 +978,7 @@ class CachingAutotuner(KernelInterface):
         launchers = []
         exc = None
         # DeviceGuard ensures each launcher's binary loads onto the right device.
-        with DeviceGuard(device_interface, self.triton_meta["device"]):
+        with DeviceGuard(device_interface, cast(int, self.triton_meta["device"])):
             for result in self.compile_results:
                 launcher, exc = self._make_launcher(result)
                 if launcher is not None:
@@ -1118,7 +1123,9 @@ class CachingAutotuner(KernelInterface):
         of the triton signature are passed in as options to triton.compile
         instead
         """
-        compile_meta = copy.deepcopy(self.triton_meta)
+        compile_meta: dict[str, Any] = cast(
+            dict[str, Any], copy.deepcopy(self.triton_meta)
+        )
         compile_meta["num_warps"] = cfg.num_warps
         compile_meta["num_stages"] = cfg.num_stages
 
@@ -1308,7 +1315,8 @@ class CachingAutotuner(KernelInterface):
                 log.exception("jit_post_compile_hook failed")
 
         TritonBundler.put(
-            triton_hash_to_path_key(binary.hash), self.triton_meta.get("device", 0)
+            triton_hash_to_path_key(binary.hash),
+            cast(int, self.triton_meta.get("device", 0)),
         )
         # If the binary has a cubin file to directly launch, save it on the binary
         static_launcher = StaticTritonCompileResult.can_statically_launch(
@@ -2007,7 +2015,7 @@ class CachingAutotuner(KernelInterface):
         # for scratch space scaling, but is not used in the actual kernel launch.
         schema = getattr(binary, "launch_metadata_schema", None)
         if schema is not None and inductor_config.use_launch_metadata_schema:
-            params = {
+            params: dict[str, Any] = {
                 "mangled_name": schema["entry_name"],
                 "num_warps": schema["num_warps"],
                 "shared_mem": schema["shared_mem"],
@@ -2023,7 +2031,7 @@ class CachingAutotuner(KernelInterface):
             }
         else:
             # Fallback: hasattr probing for older Triton versions
-            params = {
+            params: dict[str, Any] = {
                 "mangled_name": (
                     binary.metadata.name
                     if hasattr(binary.metadata, "name")
@@ -2727,7 +2735,7 @@ class StaticTritonCompileResult(CompileResult[_T]):
     def can_statically_launch(
         kernel: CompiledKernel,
         inductor_meta: dict[str, Any],
-        triton_meta: dict[str, Any],
+        triton_meta: TritonMeta,
         heuristic_type: HeuristicType,
     ) -> _KernelType | None:
         if not torch._inductor.config.use_static_triton_launcher:
@@ -2770,7 +2778,7 @@ class StaticTritonCompileResult(CompileResult[_T]):
                 triton_meta.get("device_type"), ".cubin"
             )
             cubin_location = os.path.join(
-                triton_cache_dir(triton_meta.get("device", 0)),
+                triton_cache_dir(cast(int, triton_meta.get("device", 0))),
                 triton_hash_to_path_key(kernel.hash),
                 f"{kernel.src.fn.__name__}{binary_ext}",
             )
@@ -3275,7 +3283,7 @@ def hash_configs(configs: list[Config]):
 def cached_autotune(
     size_hints: list[int] | None,
     configs: list[Config],
-    triton_meta,
+    triton_meta: TritonMeta,
     heuristic_type,
     filename=None,
     inductor_meta=None,
@@ -3863,7 +3871,7 @@ def _update_combo_kernel_kwargs(
 def _handle_combo_kernel_per_subkernel_blocks(
     size_hints: dict[str, int],
     inductor_meta: dict[str, Any],
-    triton_meta: dict[str, Any],
+    triton_meta: TritonMeta,
     filename: str | None = None,
     reduction_hint: bool = False,
     tile_hint: Any = None,
@@ -4143,7 +4151,7 @@ def _maybe_filter_configs_for_tma_restrictions(inductor_meta, configs: list[Conf
 
 def pointwise(
     size_hints,
-    triton_meta,
+    triton_meta: TritonMeta,
     tile_hint=None,
     filename=None,
     min_elem_per_thread=0,
@@ -4402,7 +4410,7 @@ def _reduction_configs(
     *,
     size_hints: dict[str, int],
     inductor_meta: dict[str, Any],
-    triton_meta: dict[str, Any],
+    triton_meta: TritonMeta,
     num_dynamic=0,
 ) -> list[Config]:
     reduction_hint = inductor_meta.get("reduction_hint")
@@ -4833,7 +4841,7 @@ def filter_reduction_configs_for_determinism(
 def reduction(
     size_hints,
     reduction_hint=False,
-    triton_meta=None,
+    triton_meta: TritonMeta | None = None,
     filename=None,
     inductor_meta=None,
     return_configs=False,
@@ -4843,6 +4851,9 @@ def reduction(
     inductor_meta["reduction_hint"] = reduction_hint
     if inductor_meta.get("no_x_dim"):
         size_hints["x"] = 1
+
+    if triton_meta is None:
+        raise AssertionError("triton_meta must not be None")
 
     configs = _handle_combo_kernel_per_subkernel_blocks(
         size_hints,
@@ -4895,7 +4906,7 @@ def reduction(
 def cooperative_reduction(
     size_hints,
     reduction_hint,
-    triton_meta,
+    triton_meta: TritonMeta,
     filename,
     inductor_meta,
 ):
@@ -4951,7 +4962,7 @@ def _persistent_reduction_configs(
     size_hints,
     reduction_hint=False,
     inductor_meta=None,
-    triton_meta=None,
+    triton_meta: TritonMeta | None = None,
 ):
     inductor_meta = {} if inductor_meta is None else inductor_meta
     # Under deterministic mode, canonicalize the batch-dim hint so the
@@ -5102,7 +5113,7 @@ def _persistent_reduction_configs(
 def persistent_reduction(
     size_hints,
     reduction_hint=False,
-    triton_meta=None,
+    triton_meta: TritonMeta | None = None,
     filename=None,
     inductor_meta=None,
     return_configs=False,
@@ -5112,6 +5123,9 @@ def persistent_reduction(
     inductor_meta["reduction_hint"] = reduction_hint
     if inductor_meta.get("no_x_dim"):
         size_hints["x"] = 1
+
+    if triton_meta is None:
+        raise AssertionError("triton_meta must not be None")
 
     configs = _handle_combo_kernel_per_subkernel_blocks(
         size_hints,
@@ -5222,7 +5236,7 @@ def persistent_reduction(
 def split_scan(
     size_hints,
     reduction_hint=False,
-    triton_meta=None,
+    triton_meta: TritonMeta | None = None,
     filename=None,
     inductor_meta=None,
 ):
@@ -5263,7 +5277,7 @@ def split_scan(
 def template(
     num_stages,
     num_warps,
-    triton_meta,
+    triton_meta: TritonMeta,
     num_consumer_groups=0,
     num_buffers_warp_spec=0,
     filename=None,
@@ -5340,7 +5354,7 @@ def config_from_dict(config: dict[str, Any]) -> Config:
     return Config(config, **_pop_config_kwargs(config))
 
 
-def fixed_config(config, filename, triton_meta, inductor_meta):
+def fixed_config(config, filename, triton_meta: TritonMeta, inductor_meta):
     """
     Used when the configuration is already decided at compile time
     """
@@ -5356,7 +5370,11 @@ def fixed_config(config, filename, triton_meta, inductor_meta):
 
 
 def user_autotune(
-    configs, triton_meta, filename=None, inductor_meta=None, custom_kernel=False
+    configs,
+    triton_meta: TritonMeta,
+    filename=None,
+    inductor_meta=None,
+    custom_kernel=False,
 ):
     """
     Compile a user defined triton kernel
@@ -5376,7 +5394,7 @@ def user_autotune(
     )
 
 
-def foreach(triton_meta, filename=None, inductor_meta=None):
+def foreach(triton_meta: TritonMeta, filename=None, inductor_meta=None):
     """
     Compile a triton foreach kernel
     """

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -77,7 +77,7 @@ from .exc import CUDACompileError
 from .fx_utils import count_flops_fx
 from .ir import ChoiceCaller, PrimitiveInfoType
 from .ops_handler import StoreMode
-from .runtime.hints import DeviceProperties
+from .runtime.hints import DeviceProperties, TritonMeta
 from .runtime.triton_compat import HAS_WARP_SPEC
 from .runtime.triton_heuristics import FixedGrid
 from .utils import (
@@ -555,7 +555,7 @@ class TritonTemplateKernel(TritonKernel):
         workspace_arg: WorkspaceArg | None = None,
         prologue_loads_all_inputs=False,
         hint_override: int | None = None,
-        triton_meta: dict[str, object] | None = None,
+        triton_meta: TritonMeta | None = None,
         always_freeze_layout: bool = False,
         index_dtype_override: str | None = None,
     ) -> None:
@@ -630,7 +630,7 @@ class TritonTemplateKernel(TritonKernel):
         # pyrefly: ignore [invalid-type-var]
         self.epilogue_fn = epilogue_fn
         self.render_hooks = {}  # type: ignore[var-annotated]
-        self.triton_meta: dict[str, object] | None = triton_meta
+        self.triton_meta: TritonMeta | None = triton_meta
         self._index_dtype_override = index_dtype_override
         # For Templated Attention this can be a list of ir.Subgraph
         self.subgraphs: list[ir.ComputedBuffer] | None = subgraphs
@@ -887,7 +887,7 @@ class TritonTemplateKernel(TritonKernel):
             return "@triton.jit"
 
         argdefs, _, signature, _ = self.args.python_argdefs()
-        triton_meta: dict[str, Any] = {
+        triton_meta: TritonMeta = {
             "signature": signature_to_meta(
                 signature,
                 size_dtype=self.index_dtype,
@@ -910,9 +910,11 @@ class TritonTemplateKernel(TritonKernel):
         if kpack:
             triton_meta["kpack"] = kpack
 
+        # tlx options carry dynamic string keys outside the TritonMeta schema.
+        triton_meta_extra = cast(dict[str, Any], triton_meta)
         for k in tlx_only_cuda_options():
             if v := self.meta.get(k, None):
-                triton_meta[k] = v
+                triton_meta_extra[k] = v
 
         if self.triton_meta is None:
             self.triton_meta = triton_meta
@@ -946,12 +948,14 @@ class TritonTemplateKernel(TritonKernel):
             num_buffers_warp_spec={self.num_buffers_warp_spec},
         """
 
+        # tlx options carry dynamic string keys outside the TritonMeta schema.
+        triton_meta_extra = cast(dict[str, Any], self.triton_meta)
         for k in tlx_only_cuda_options():
             if v := self.meta.get(k, None):
                 template_args += f"""
                     {k}={v},
                 """
-                self.triton_meta[k] = v
+                triton_meta_extra[k] = v
 
         return f"""
             @triton_heuristics.template(
@@ -2576,7 +2580,7 @@ class GeneratedCodeCache:
         num_buffers_warp_spec: int,
         kwargs: dict[str, Any],
         hint_override: int | None = None,
-        triton_meta: dict[str, Any] | None = None,
+        triton_meta: TritonMeta | None = None,
     ) -> str | None:
         def layout_key(layout: ir.Layout) -> str:
             if isinstance(layout, ir.FlexibleLayout):
@@ -2755,7 +2759,7 @@ class TritonTemplate(KernelTemplate):
         tma_store: bool = False,
         tma_load_for_template_epilogue: bool = False,
         transpose_discontiguous_tensor_descriptors_override: bool | None = None,
-        triton_meta: dict[str, Any] | None = None,
+        triton_meta: TritonMeta | None = None,
     ) -> GenerateAndLoadResult | None:
         """Generate the python code and load it into the current process"""
         caching_enabled = (
@@ -2976,7 +2980,7 @@ class TritonTemplate(KernelTemplate):
         tma_store: bool = False,
         tma_load_for_template_epilogue: bool = False,
         transpose_discontiguous_tensor_descriptors_override: bool | None = None,
-        triton_meta: dict[str, Any] | None = None,
+        triton_meta: TritonMeta | None = None,
         **kwargs,
     ):
         """This function generates a TritonTemplateCaller


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* (to be filled)

The `triton_meta` bag that Inductor threads from Triton codegen into the
runtime launcher was typed as `dict[str, Any]` everywhere, which gave no
static guarantees about its keys and hid the fact that its shape is fixed.
This replaces those annotations with a `TritonMeta` TypedDict.

`TritonMeta` is defined `total=False` because the bag is populated
incrementally across codegen (signature/device/constants/configs first,
then backend/ROCm/tlx extras) and is forwarded verbatim to external Triton
APIs, which tolerate and ignore unrecognized keys.

Two lifecycle subtleties are worth calling out for review:

- `device` is typed as the codegen-time `DeviceProperties`. `CachingAutotuner`
  rewrites it to the integer device index before the bag reaches Triton, so
  the handful of runtime read sites that consume the int narrow it with an
  explicit `cast(int, ...)`. Typing `device` as the codegen shape (rather
  than a `DeviceProperties | int` union) keeps the common codegen accesses
  cast-free and confines the casts to the ~5 runtime consumption sites.
- The tlx-only options carry dynamic string keys outside the schema, so those
  assignment loops go through a `cast(dict[str, Any], ...)` view. The
  `_create_compile_meta` deepcopy is likewise cast to a plain dict since it
  augments the bag with many non-schema compile keys.

Suggested review order: `runtime/hints.py` (the definition) first, then the
producers (`codegen/triton.py`, `select_algorithm.py`, `codegen/wrapper.py`,
`codegen/triton_combo_kernel.py`), then the threading/consumer sites in
`runtime/triton_heuristics.py` and the `codegen/cpp_wrapper_*.py` wrappers.

This PR was authored with the assistance of an AI coding tool.

Test Plan:

Type-checked the changed files with pyrefly and confirmed no new errors
(the pre-existing count went from 262 to 259):

```
pyrefly check \
  torch/_inductor/runtime/hints.py \
  torch/_inductor/runtime/triton_heuristics.py \
  torch/_inductor/select_algorithm.py \
  torch/_inductor/codegen/triton.py \
  torch/_inductor/codegen/wrapper.py \
  torch/_inductor/codegen/cpp_wrapper_cpu.py \
  torch/_inductor/codegen/cpp_wrapper_gpu.py \
  torch/_inductor/codegen/cpp_wrapper_mps.py \
  torch/_inductor/codegen/triton_combo_kernel.py
```

Ran the linters clean:

```
lintrunner --take PYFMT,RUFF,PYREFLY,CODESPELL,FLAKE8 -a <changed files>
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo