### PR TITLE
Guard user stream compile tests with xfailIfNoAcceleratorTriton

### DIFF
--- a/test/inductor/test_reorder_for_locality_in_training.py
+++ b/test/inductor/test_reorder_for_locality_in_training.py
@@ -13,7 +13,11 @@ import torch._dynamo
 import torch._inductor.config as inductor_config
 from torch._inductor.fx_passes import post_grad
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    run_tests,
+    TestCase,
+    xfailIfNoAcceleratorTriton,
+)
 
 
 def _flag_in_subprocess(env_value):
@@ -120,6 +124,7 @@ class TestReorderForLocalityInTrainingEnv(TestCase):
 
 
 class TestReorderForLocalityInTraining(TestCase):
+    @xfailIfNoAcceleratorTriton
     def test_training_flag_reorders_and_preserves_semantics(self, device):
         p_off, g_off, rec_off = _train_once(device, flag_on=False)
         p_on, g_on, rec_on = _train_once(device, flag_on=True)
@@ -144,6 +149,7 @@ class TestReorderForLocalityInTraining(TestCase):
             "flag on must reorder at least one node on the training graph",
         )
 
+    @xfailIfNoAcceleratorTriton
     def test_training_flag_noop_when_reorder_off(self, device):
         # The training flag is gated by reorder_for_locality: enabling it while
         # reorder_for_locality is off must not run the pass on a training graph.

--- a/test/inductor/test_user_streams.py
+++ b/test/inductor/test_user_streams.py
@@ -301,6 +301,7 @@ with torch.xpu._DeviceGuard(0):
         self.assertTrue(make_line(0).setup_stream_cache)
 
     @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @xfailIfNoAcceleratorTriton
     def test_generated_code_uses_get_stream_by_index(self):
         """Generated inductor code should use _get_stream_by_index."""
         from torch._inductor.utils import run_and_get_code
@@ -2657,6 +2658,7 @@ instantiate_parametrized_tests(TestStreamCudagraphInteraction)
 
 @unittest.skipIf(not TEST_CUDA, "requires CUDA")
 class TestStreamExternalObjectRestore(InductorTestCase):
+    @xfailIfNoAcceleratorTriton
     def test_restore_external_objects_before_backward(self):
         """Forward snapshots external object registry, backward restores it."""
         from torch._dynamo.graph_bytecode_inputs import store_user_object_weakrefs


### PR DESCRIPTION
### Summary
This PR adds `@xfailIfNoAcceleratorTriton` at the test method level for inductor tests so `torch.compile` xfails instead of failing in environments without Triton

test/inductor/test_user_streams.py

- `TestStreamCodegen.test_generated_code_uses_get_stream_by_index`
- `TestStreamExternalObjectRestore.test_restore_external_objects_before_backward`

test/inductor/test_reorder_for_locality_in_training.py

- `TestReorderForLocalityInTraining.test_training_flag_reorders_and_preserves_semantics`
- `TestReorderForLocalityInTraining.test_training_flag_noop_when_reorder_off`

On environments with Triton, all tests run normally.

### Test plan
`python -m pytest .\pytorch\test\inductor\test_user_streams.py`
`python -m pytest .\pytorch\test\inductor\test_reorder_for_locality_in_training.py`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo