### PR TITLE
MSVC compiler flag change for JIT cpp extensions on Windows

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -619,6 +619,12 @@ def get_compiler_abi_compatibility_and_version(compiler) -> tuple[bool, TorchVer
     return (False, TorchVersion('.'.join(numeric_version)))
 
 
+def _cuda13_nvcc_preprocessor_flags() -> list[str]:
+    if torch.version.cuda is not None and Version(torch.version.cuda) >= Version('13.0'):
+        return ['-Xcompiler', '/Zc:preprocessor']
+    return []
+
+
 def _check_cuda_version(compiler_name: str, compiler_version: TorchVersion) -> None:
     if not CUDA_HOME:
         raise RuntimeError(CUDA_NOT_FOUND_MESSAGE)
@@ -1119,6 +1125,7 @@ class BuildExtension(_LazyBuildExt):
                                 cflags = ['-Xcudafe', '--diag_suppress=' + ignore_warning] + cflags
                         for flag in COMMON_MSVC_FLAGS:
                             cflags = ['-Xcompiler', flag] + cflags
+                        cflags = _cuda13_nvcc_preprocessor_flags() + cflags
                         cmd = _wrap_compiler([nvcc, '-c', src, '-o', obj] + include_list + cflags)
                     else:
                         if isinstance(self.cflags, dict):
@@ -1203,7 +1210,7 @@ class BuildExtension(_LazyBuildExt):
             cuda_post_cflags = None
             cuda_cflags = None
             if with_cuda:
-                cuda_cflags = ['-std=c++20']
+                cuda_cflags = ['-std=c++20'] + _cuda13_nvcc_preprocessor_flags()
                 for common_cflag in common_cflags:
                     cuda_cflags.append('-Xcompiler')
                     cuda_cflags.append(common_cflag)
@@ -3006,6 +3013,7 @@ def _write_ninja_file_to_build_library(path,
         if IS_WINDOWS:
             for flag in COMMON_MSVC_FLAGS:
                 cuda_flags = ['-Xcompiler', flag] + cuda_flags
+            cuda_flags = _cuda13_nvcc_preprocessor_flags() + cuda_flags
             for ignore_warning in MSVC_IGNORE_CUDAFE_WARNINGS:
                 cuda_flags = ['-Xcudafe', '--diag_suppress=' + ignore_warning] + cuda_flags
             cuda_flags = cuda_flags + ['-std=c++20']


### PR DESCRIPTION
### Summary

Fix Windows JIT C++ extension builds with CUDA 13+ by passing MSVC's standard-conforming preprocessor flag `Zc:preprocessor` through `torch.utils.cpp_extension`.

CUDA 13.x ships CCCL headers that `#error` when `cl.exe` uses MSVC's legacy (traditional) preprocessor. PyTorch's main build already sets this flag in CMake, but `COMMON_MSVC_FLAGS` in `cpp_extension.py` did not, so `torch.utils.cpp_extension.load()` failed when compiling `.cu` files (e.g. `test_jit_cuda_extension` on Blackwell + CUDA 13.2).

### Error message
`C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.2\bin/../include/cccl\cuda/std/__cccl/preprocessor.h(23): fatal error C1189: #error:  MSVC/cl.exe with traditional preprocessor is used. This may lead to unexpected compilation errors. Please switch to the standard conforming preprocessor by passing /Zc:preprocessor to cl.exe. You can define CCCL_IGNORE_MSVC_TRADITIONAL_PREPROCESSOR_WARNING to suppress this warning.
cuda_extension.cu`

### Test plan
- `python -m pytest test/test_cpp_extensions_jit.py -k test_jit_cuda_extension -vv` (Windows, CUDA 13+)

Fixes #197574
