### PR TITLE
Fix multinomial without replacement silently sampling zero-probability categories

### DIFF
--- a/aten/src/ATen/native/Distributions.cpp
+++ b/aten/src/ATen/native/Distributions.cpp
@@ -604,6 +604,17 @@ Tensor& multinomial_out(const Tensor& self,
     }
     at::_assert_async(~zero_prob_condition, "invalid multinomial distribution (sum of probabilities <= 0)");
 
+    if (!with_replacement) {
+      at::Tensor not_enough_nonzero;
+      if (self.dim() == 1) {
+        not_enough_nonzero = (self > 0).sum() < n_sample;
+      } else {
+        not_enough_nonzero = ((self > 0).sum(1) < n_sample).any();
+      }
+      at::_assert_async(~not_enough_nonzero,
+          "cannot sample n_sample > number of categories with nonzero probability without replacement");
+    }
+
     // The algorithm is from gumbel softmax.
     // s = argmax( logp - log(-log(eps)) ) where eps ~ U(0, 1)
     // Here we can apply exp to the formula which will not affect result of

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -5235,6 +5235,21 @@ class TestTorchDeviceType(TestCase):
         self.assertEqual(sample_indices.dim(), 2, msg="wrong number of dimensions")
         self.assertEqual(sample_indices.size(1), n_sample, msg="wrong number of samples")
 
+    @dtypes(torch.float, torch.double)
+    def test_multinomial_without_replacement_zero_prob(self, device, dtype):
+        # https://github.com/pytorch/pytorch/issues/125388
+        weights = torch.tensor([0, 10, 3, 0], dtype=dtype, device=device)
+        # n_sample == number of nonzero categories is fine and never draws a zero-prob index
+        idx = torch.multinomial(weights, 2, replacement=False)
+        self.assertFalse((weights[idx] == 0).any(), msg="sampled an index with zero probability")
+        # drawing more than the nonzero categories must raise instead of returning zero-prob indices
+        if self.device_type == "cpu":
+            with self.assertRaisesRegex(RuntimeError, "nonzero"):
+                torch.multinomial(weights, 3, replacement=False)
+            batched = torch.tensor([[1, 1, 1, 1], [0, 5, 5, 0]], dtype=dtype, device=device)
+            with self.assertRaisesRegex(RuntimeError, "nonzero"):
+                torch.multinomial(batched, 3, replacement=False)
+
     # FIXME: move to test distributions
     @onlyCUDA
     @dtypes(torch.float, torch.double, torch.half)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2012,8 +2012,12 @@ def sample_inputs_multinomial(self, device, dtype, requires_grad, **kwargs):
     ]
 
     for shape, num_samples, kwargs in cases:
+        # Use low=1 so no weight rounds to exactly 0 in low-precision dtypes
+        # (e.g. bfloat16). The replacement=False cases draw num_samples equal to
+        # the category count, so any zero-probability category would make the
+        # draw impossible without replacement.
         t = make_tensor(shape, dtype=dtype, device=device,
-                        low=0, high=None,
+                        low=1, high=None,
                         requires_grad=requires_grad)
         yield SampleInput(t, num_samples, **kwargs)
 


### PR DESCRIPTION
Fixes #125388

`torch.multinomial(input, n_sample, replacement=False)` can return categories
whose probability is zero.

## Root cause
The without-replacement path samples via Gumbel top-k
(`aten/src/ATen/native/Distributions.cpp`): it computes `q = input / Exponential(1)`
and takes `topk(q, n_sample)`. A zero-weight category gets key `q = 0` while
every nonzero category gets a strictly positive key, so once `n_sample` exceeds
the number of categories with nonzero probability, `topk` is forced to return
zero-probability indices. The only guard checks `n_sample <= input.size(-1)`
(the total number of categories), not the number of nonzero categories, so:

```python
>>> torch.multinomial(torch.tensor([0., 10., 3., 0.]), 4, replacement=False)
tensor([1, 2, 0, 3])   # indices 0 and 3 have zero weight
```

The documented behavior is to raise here.

## Fix
In `multinomial_out`, when sampling without replacement, assert that every
distribution has at least `n_sample` categories with nonzero probability. This
reuses the `at::_assert_async` mechanism already used for the adjacent
zero-probability check (#134818), so it adds no host synchronization, and one
host-level check covers CPU, CUDA and MPS since all without-replacement
sampling flows through this path.

## Test plan
Built CPU-only from source and ran:

```
python -m pytest test/test_torch.py -k "multinomial and cpu" -q
# 11 passed, 6 skipped
```

The added regression test `test_multinomial_without_replacement_zero_prob`
fails without the fix (`RuntimeError not raised`) and passes with it.
