### PR TITLE
[XPU] Skip nn.functional.multi_margin_loss float32 test in inductor opinfo

### DIFF
--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -239,6 +239,8 @@ inductor_skips["xpu"] = {
 inductor_skips["xpu"]["lu"] = {f32}
 inductor_skips["xpu"]["nn.functional.linear"] = {f16}
 inductor_skips["xpu"]["masked.cumprod"] = {f16}
+# pytorch/pytorch: #178992
+inductor_skips["xpu"]["nn.functional.multi_margin_loss"] = {f32}
 
 inductor_expected_failures_single_sample = defaultdict(dict)
 


### PR DESCRIPTION
## Summary
Adds skip for `test_comprehensive_nn_functional_multi_margin_loss_xpu_float32` which is failing on XPU platform.

## Details
The test is disabled due to failures in the inductor path for this operator on XPU with float32 dtype. The operator itself works correctly but has issues when run through the inductor compiler.

This PR adds the operator to `inductor_skips["xpu"]` to prevent test failures while the underlying issue is investigated and fixed.

## Testing
- Verified the skip is properly added to the test configuration
- Test will no longer run on XPU platform, preventing CI failures

Fixes #178992

cc @mruberry @chauhang @penguinwu @voznesenskym @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @aakhundov @coconutruben @jataylo @gujinghui @fengyuan14 @guangyey

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>