### PR TITLE
[Decomp] Fix multi_margin_loss to use 1D indexing for weight

### DIFF
--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -5704,13 +5704,16 @@ def multi_margin_loss(
             weight.ndim == 1 and weight.numel() == dim,  # type: ignore[union-attr]
             lambda: f"inconsistent weight size, expected {dim} but got {weight.shape}",  # type: ignore[union-attr]
         )
+    # Keep 1D target for weight indexing
+    target_1d = target
     target = target.unsqueeze(1)
     u = torch.gather(input, dim=1, index=target)
     z = margin - u + input
     z = z.clamp_min(0)
     z = z if p == 1 else z * z
     if weight is not None:
-        z = z * weight[target]
+        # Use 1D indexing to avoid issues with advanced indexing in inductor
+        z = z * weight[target_1d].unsqueeze(1)
     idx = torch.arange(dim, device=input.device)
     z = torch.where(idx != target, z, 0)
     if reduction == Reduction.MEAN.value:


### PR DESCRIPTION
## Summary

Fixes #178992 by changing the `multi_margin_loss` decomposition to use 1D indexing instead of 2D advanced indexing for the weight tensor. This resolves inductor lowering issues on XPU backend.

## Root Cause

The decomposition was performing 2D advanced indexing:
```python
target = target.unsqueeze(1)  # [batch] -> [batch, 1]
...
z = z * weight[target]  # weight is [dim], target is [batch, 1]
```

When `target` is 2D (`[batch, 1]`), the advanced indexing `weight[target]` uses a 2D index tensor, which doesn't lower correctly in inductor for XPU backend.

## Solution

Keep the original 1D target and use explicit unsqueeze:
```python
target_1d = target  # [batch]
target = target.unsqueeze(1)  # [batch, 1] for gather
...
z = z * weight[target_1d].unsqueeze(1)  # 1D indexing + explicit unsqueeze
```

This approach:
- Uses simple 1D indexing which inductor can lower correctly
- Matches how native CUDA/XPU kernels work (scalar indexing)
- Produces identical numerical results
- Is easier for compiler optimization

## Testing

**Manual Analysis**: 
- Verified the shapes are mathematically equivalent:
  - Old: `weight[[batch, 1]]` → `[batch, 1]`
  - New: `weight[[batch]].unsqueeze(1)` → `[batch, 1]`
- Compared against native CUDA/XPU kernel implementations

**Local Validation Note**:
Could not run test locally due to environment constraints (missing MKL libs). However, the fix is a straightforward refactoring of indexing operations with no algorithmic changes.

**Expected CI Result**:
`test_comprehensive_nn_functional_multi_margin_loss_xpu_float32` should now pass.

## Files Changed

- `torch/_decomp/decompositions.py`: Modified `multi_margin_loss` function (lines 5707-5716)

## Additional Context

Native kernels (CUDA, XPU) use scalar indexing in loops:
```cpp
if (weights) {
    h *= weights[target_k];  // scalar index, not tensor
}
```

This fix brings the decomposition closer to how native implementations work.

cc @mruberry @chauhang @penguinwu @voznesenskym @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @aakhundov @coconutruben @jataylo @gujinghui @fengyuan14 @guangyey

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>