### PR TITLE
[inductor] Rewind block_ptr across outer loop in nested reductions (#188771)

### DIFF
--- a/.github/actions/checkout-pytorch/action.yml
+++ b/.github/actions/checkout-pytorch/action.yml
@@ -108,10 +108,10 @@ runs:
         echo "${GITHUB_WORKSPACE}"
         if [ -z "${NO_SUDO}" ]; then
           retry sudo rm -rf "${GITHUB_WORKSPACE}"
+          mkdir "${GITHUB_WORKSPACE}"
         else
-          retry rm -rf "${GITHUB_WORKSPACE}"
+          retry find "${GITHUB_WORKSPACE}" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
         fi
-        mkdir "${GITHUB_WORKSPACE}"
 
     - name: Checkout PyTorch (try again)
       uses: pytorch/test-infra/.github/actions/checkout@main

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4556,6 +4556,35 @@ for dtype in (torch.int32, torch.int64):
 
         self.common(fn, (torch.randn(1, 4),))
 
+    def test_nested_reduction_broadcast_outer_product(self):
+        # Regression: for a fused broadcast+reduce whose broadcast
+        # materializes [N, N] from [N] and [N, 1], the codegen used to emit
+        # nested reduction loops that advanced a block_ptr through the entire
+        # inner loop without rewinding it at outer-loop suffix. Any backend
+        # that lowers the loops to iter-arg-threaded control flow (e.g.
+        # `scf.for` on Triton-MTIA) would then load out-of-bounds on outer
+        # iterations >= 1 and silently drop most of the reduction. This test
+        # verifies numerical correctness for the outer-product-broadcast +
+        # sum/mean pattern at a size large enough to exercise multi-tile
+        # reduction paths.
+        def fn(a, b):
+            return (a * b).sum(), torch.mean(a * b)
+
+        # Non-zero mean so a truncated reduction cannot hide behind noise.
+        # rtol is relaxed from the float32 default because summing N^2=1M
+        # elements accumulates float32 rounding (~1e-5 relative), while the
+        # bug this catches causes a >90% error, so the looser bound still
+        # detects any regression.
+        self.common(
+            fn,
+            (
+                torch.randn(1024) + 3.0,
+                (torch.randn(1024) + 3.0).view(-1, 1),
+            ),
+            rtol=2e-4,
+            atol=1e-5,
+        )
+
     def test_squeeze1(self):
         def fn(a):
             return ((a + 1).squeeze() + 2, a.squeeze() + 2)

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -4162,17 +4162,18 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                     self.block_ptr_to_buffer[block_descriptor] = name
 
                     # Generate block pointer advancements, for later use.
+                    # We record the entry for every level, even when the
+                    # per-level offset is zero. The outer-loop suffix computes
+                    # a rewind as `outer_step - inner_step * inner_num_iter`;
+                    # if a pointer's outer entry is absent, no rewind is
+                    # emitted and its SSA value (in scf.for-based backends
+                    # such as Triton-MTIA) retains the accumulated inner
+                    # advances across outer iterations, silently loading
+                    # out-of-bounds. The emit site below drops pure no-op
+                    # advances so this does not add codegen noise for
+                    # pointers that are truly constant across all levels.
                     for symt in TritonSymbols.reduction_types:
                         advance_offsets = indexing.advance_roffset(symt)
-
-                        # Ignore identity advancements.
-                        if all(
-                            V.graph.sizevars.statically_known_equals(
-                                offset, sympy.Integer(0)
-                            )
-                            for offset in advance_offsets
-                        ):
-                            continue
 
                         advancements = self.pointer_advancements[symt]
                         if block_descriptor in advancements:
@@ -6260,8 +6261,6 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                             prev_advancements = self.pointer_advancements[
                                 prev_tree.symt
                             ]
-                            # block_ptr may not exist in the inner loop's advancements
-                            # if its advancement was identity (zero) and was skipped
                             if block_ptr in prev_advancements:
                                 prev_advancement = prev_advancements[block_ptr]
                                 prev_block = TritonSymbols.get_block_size(prev_tree)
@@ -6270,6 +6269,17 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                                     cur - prev * prev_num_iter
                                     for cur, prev in zip(advancement, prev_advancement)
                                 ]
+
+                        # Drop pure no-op advances to avoid emitting
+                        # `tl.advance(ptr, [0, 0, ...])` for pointers that
+                        # are constant across every level.
+                        if all(
+                            V.graph.sizevars.statically_known_equals(
+                                offset, sympy.Integer(0)
+                            )
+                            for offset in advancement
+                        ):
+                            continue
 
                         self.body.writeline(
                             DeferredLine(


### PR DESCRIPTION
Summary:

For a fused broadcast + reduction (e.g. `mean(a * b)` where `a:[N]` and `b:[N, 1]` broadcast to `[N, N]`), Inductor's Triton codegen emits nested `for` loops over the two reduction axes. Block pointers are threaded through the loops and advanced with `tl.advance` at the suffix of each level.

The bookkeeping in `TritonKernel` recorded a pointer's per-level advancement only when that advancement was non-zero (`triton.py` around L3999-4005 skipped identity offsets). For a pointer that is constant along the outer axis but stepped along the inner axis, this meant no entry was recorded for the outer axis, so no `tl.advance` was emitted at the outer-loop suffix. On backends that lower the Python `for` to `scf.for` with the block pointer as an iter-arg (e.g. Triton-MTIA), the SSA value yielded at the end of the outer iteration was the pointer already stepped through all inner iterations. Subsequent outer iterations would then load out-of-bounds, silently returning padding (zero) and dropping most of the reduction. For a `6144x6144` case with `R0_BLOCK=R1_BLOCK=32` the observed result was `1/192` of the true value.

**The bug is generic, not MTIA-specific.** Triton lowers every backend's Python for-loop to `scf.for`, and any variable reassigned inside the loop (like `block_ptr = tl.advance(block_ptr, ...)`) becomes an iter-arg carried across iterations. CUDA Triton is mechanically susceptible to the same OOB-load pattern. That the bug hasn't surfaced on CUDA before is likely a combination of (1) MTIA's autotuner floors `R0_BLOCK` at 32 whereas CUDA typically picks a much larger tile, so on CUDA the "iteration 0 only" truncation drops a much smaller fraction of the reduction and is easy to attribute to BF16 accumulation noise; (2) Inductor's scheduler more often avoids nested-reduction codepaths on CUDA for broadcast-heavy shapes; and (3) most CUDA tests use zero-mean inputs where a truncated outer-product reduction is close to zero anyway. Landing this as an upstream Inductor fix rather than an MTIA-only workaround.

The fix records every pointer at every reduction level, including zero offsets, so the existing outer-suffix subtraction `outer_step - inner_step * inner_num_iter` can compute the correct rewind (e.g. `0 - 32*192 = -6144`). To keep the emitted kernel body clean, the emit site now drops `tl.advance(ptr, [0, ...])` lines whose final advancement collapses to zero. Backends that keep the block pointer as a Python-local rebound each iteration are unaffected; backends that thread it through SSA iter-args now see the rewind they need.

Test Plan:
Added a regression test `test_nested_reduction_broadcast_outer_product` in `caffe2/test/inductor/test_torchinductor.py` that exercises `(a * b).sum()` and `torch.mean(a * b)` on `[N]` and `[N, 1]` inputs at `N=1024`, using non-zero-mean inputs so a truncated reduction cannot hide behind BF16 noise.

```
$ buck2 test mode/opt //caffe2/test/inductor:test_inductor -- test_nested_reduction_broadcast_outer_product
```

Also verified out-of-tree on MTIA-Triton with a shifted-mean bcast harness (`randn + 3.0` at `N=6144`):

| Case | Pre-fix `mtia_err / cpu_bf16_err` | Post-fix ratio |
| --- | --- | --- |
| `sum([N] * [N,1])` | 689x wrong | 1.0 (matches) |
| `mean([N] * [N,1], shift=10)` | 436x wrong | 1.0 (matches) |
| `mean([N,22] * [N,1])` (production LAMP shape) | 1.0 (unaffected) | 1.0 (unaffected) |

Confirmed the generated Triton IR after the fix contains the missing outer-loop rewind: `tt.advance %8#1, [-6144]`.

Authored with AI assistant (Claude Code).

Differential Revision: D110408213




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo