### PR TITLE
[JIT] Reject bare `list`/`tuple` value annotations

### DIFF
--- a/test/jit/test_list_dict.py
+++ b/test/jit/test_list_dict.py
@@ -57,6 +57,26 @@ class TestList(JitTestCase):
         self.checkScript(ternary_predicate, ([1, 2, 3],))
         self.checkScript(ternary_predicate, ([],))
 
+    def test_bare_container_annotation(self):
+        err = r"Attempted to use list without a contained type"
+
+        with self.assertRaisesRegex(RuntimeError, err):
+
+            @torch.jit.script
+            def bare_list_empty():
+                x: list = []
+                return x
+
+        # `isinstance` against a bare container is still valid (it is a
+        # type-erased runtime check, not a value's element type).
+        @torch.jit.script
+        def uses_isinstance(x: List[int]):
+            if isinstance(x, list):
+                return len(x)
+            return 0
+
+        self.assertEqual(uses_isinstance([1, 2, 3]), 3)
+
     def test_in_check(self):
         def int_in(x: List[int]) -> bool:
             return 2 in x

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -3104,6 +3104,28 @@ struct to_ir {
     }
   }
 
+  // Parse a value's declared type annotation. Bare `list`/`tuple` resolve to
+  // the type-erased AnyListType/AnyTupleType, which are only meaningful as
+  // `isinstance` targets, not as a value's element type. Reject them here (as
+  // is already done for `typing.List`/`typing.Tuple`) instead of letting them
+  // flow into the emitters, where they crash or produce confusing errors.
+  TypePtr parseTypeHintFromExpr(const Expr& type_expr) {
+    auto type = typeParser_.parseTypeFromExpr(type_expr);
+    const char* container = nullptr;
+    if (type->kind() == AnyListType::Kind) {
+      container = "list";
+    } else if (type->kind() == AnyTupleType::Kind) {
+      container = "tuple";
+    }
+    if (container) {
+      throw(
+          ErrorReport(type_expr)
+          << "Attempted to use " << container << " without a contained type. "
+          << "Please add a contained type, e.g. " << container << "[int]");
+    }
+    return type;
+  }
+
   void emitSingleAssignment(const Assign& stmt) {
     if (!stmt.rhs().present()) {
       throw(
@@ -3116,7 +3138,7 @@ struct to_ir {
         auto v = Var(stmt.lhs());
         TypePtr type = nullptr;
         if (stmt.type().present()) {
-          type = typeParser_.parseTypeFromExpr(stmt.type().get());
+          type = parseTypeHintFromExpr(stmt.type().get());
         }
         auto rhs_sugared_val = emitSugaredExpr(rhs, 1, type);
         // START BC HACK
@@ -3178,7 +3200,7 @@ struct to_ir {
 
     TypePtr type_hint = nullptr;
     if (stmt.type().present()) {
-      type_hint = typeParser_.parseTypeFromExpr(stmt.type().get());
+      type_hint = parseTypeHintFromExpr(stmt.type().get());
     }
     const auto lhs = Select(stmt.lhs());
     auto lhsObject = emitSugaredExpr(lhs.value(), 1);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #188779

Parse value type annotations in the assignment paths through `parseTypeHintFromExpr` helper that rejects a top-level `AnyListType`/ `AnyTupleType` with the same "Attempted to use list without a contained type" error that `typing.List` produces.

Fixes https://github.com/pytorch/pytorch/issues/149623

This change was authored with the assistance of Claude Code.