### PR TITLE
[CI] Benchmark TorchInductor perf against 2.12.1 release

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1105,6 +1105,19 @@ test_dynamo_benchmark() {
   local shard_id="$1"
   shift
 
+  ### Perf benchmark 2.12.1, need to reinstall detectron2 to avoid crashing when importing it
+  pip_uninstall torch torchvision torchaudio torchrec fbgemm-gpu triton pytorch-triton detectron2
+  pip_install torch==2.12.1 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu130
+  # Rebuild torchrec and fbgemm_gpu against the installed torch release
+  if [[ "${TEST_CONFIG}" == *torchbench* ]] && [[ "${TEST_CONFIG}" != *cpu* ]]; then
+    rm -rf dist/torchrec
+    rm -rf dist/fbgemm_gpu
+    install_torchrec_and_fbgemm
+  fi
+  # Same pinned commit as used in TorchBench (no ci)
+  pip_install git+https://github.com/facebookresearch/detectron2.git@0df2d73d0013db7de629602c23cc120219b4f2b8 --no-build-isolation
+  pip freeze
+
   # Exclude torchrec_dlrm for CUDA 13 as FBGEMM is not compatible
   local extra_args=()
   if [[ "$BUILD_ENVIRONMENT" == *cuda13* ]]; then


### PR DESCRIPTION
Temporary test PR to drive the TorchInductor perf benchmark against the **2.12.1** stable release, as part of the release validation checklist. **Not meant to be merged.**

### What this does
In `test_dynamo_benchmark()` (`.ci/pytorch/test.sh`), before running the benchmark:
- Uninstall the torch stack built into the inductor-benchmarks Docker image and reinstall `torch==2.12.1` (+ matching torchvision/torchaudio) from the **stable cu130** channel, matching the `linux-jammy-cuda13.0` build environment used by `inductor-perf-test-nightly-h100`.
- Rebuild `torchrec` and `fbgemm_gpu` from source against the installed release for the torchbench suite.
- Reinstall the TorchBench-pinned `detectron2` so it can be imported without crashing.

Follows the same pattern as the 2.11 RC benchmark PR (#175777). The CUDA 13.0 upgrade for the inductor workflow is already on `main`, so no workflow/infra changes are needed here.

### Test plan
Run the `inductor-perf-test-nightly-h100` workflow against `refs/pull/PR_NUMBER/head`, covering `inductor_default`, `inductor_dynamic_shapes`, and `inductor_cudagraphs` on both training and inference, then compare pass rate and speedup/compilation/memory against the baseline on the [PT2 dashboard](https://hud.pytorch.org/benchmark/compilers_regression).

_This PR was authored with the assistance of Claude Code._