### PR TITLE
[xpu][fix]Fix bmm_outer_product override to support XPU tensors

### DIFF
--- a/torch/_native/ops/bmm_outer_product/triton_impl.py
+++ b/torch/_native/ops/bmm_outer_product/triton_impl.py
@@ -23,12 +23,19 @@ def _bmm_outer_product_impl(
 ) -> torch.Tensor:
     from .triton_kernels import bmm_outer_product
 
-    device = a.get_device()
-    if device == torch.cuda.current_device():
+    device = a.device
+    if device.type == "cuda":
+        if device.index == torch.cuda.current_device():
+            return bmm_outer_product(a, b)
+        with torch.cuda.device(device):
+            return bmm_outer_product(a, b)
+    else:
+        # XPU or other device types
         return bmm_outer_product(a, b)
 
-    with torch.cuda.device(device):
-        return bmm_outer_product(a, b)
+
+def _is_gpu_tensor(t: torch.Tensor) -> bool:
+    return t.is_cuda or t.is_xpu
 
 
 def _bmm_outer_product_cond(
@@ -40,7 +47,7 @@ def _bmm_outer_product_cond(
     # a and b are read-only here: the kernel wraps them in ConstTensorWrapper and
     # reads through const_data_ptr(), so copy-on-write inputs are not
     # materialized and need not be excluded.
-    if a.is_cuda and b.is_cuda and a.device == b.device and _is_outer_product(a, b):
+    if _is_gpu_tensor(a) and _is_gpu_tensor(b) and a.device == b.device and _is_outer_product(a, b):
         return True
     return False
 

--- a/torch/_native/ops/bmm_outer_product/triton_impl.py
+++ b/torch/_native/ops/bmm_outer_product/triton_impl.py
@@ -27,8 +27,9 @@ def _bmm_outer_product_impl(
         return bmm_outer_product(a, b)
 
 
-def _is_gpu_tensor(t: torch.Tensor) -> bool:
-    return t.is_cuda or t.is_xpu
+def _is_acc_tensor(t: torch.Tensor) -> bool:
+    acc = torch.accelerator.current_accelerator()
+    return acc is not None and acc.type == t.device.type
 
 
 def _bmm_outer_product_cond(

--- a/torch/_native/ops/bmm_outer_product/triton_impl.py
+++ b/torch/_native/ops/bmm_outer_product/triton_impl.py
@@ -23,14 +23,7 @@ def _bmm_outer_product_impl(
 ) -> torch.Tensor:
     from .triton_kernels import bmm_outer_product
 
-    device = a.device
-    if device.type == "cuda":
-        if device.index == torch.cuda.current_device():
-            return bmm_outer_product(a, b)
-        with torch.cuda.device(device):
-            return bmm_outer_product(a, b)
-    else:
-        # XPU or other device types
+    with torch.accelerator.device_index(a.get_device()):
         return bmm_outer_product(a, b)
 
 

--- a/torch/_native/ops/bmm_outer_product/triton_impl.py
+++ b/torch/_native/ops/bmm_outer_product/triton_impl.py
@@ -41,7 +41,7 @@ def _bmm_outer_product_cond(
     # a and b are read-only here: the kernel wraps them in ConstTensorWrapper and
     # reads through const_data_ptr(), so copy-on-write inputs are not
     # materialized and need not be excluded.
-    if _is_gpu_tensor(a) and _is_gpu_tensor(b) and a.device == b.device and _is_outer_product(a, b):
+    if _is_acc_tensor(a) and a.device == b.device and _is_outer_product(a, b):
         return True
     return False
 


### PR DESCRIPTION
Fixes [#188773](https://github.com/pytorch/pytorch/issues/188773)

The `_bmm_outer_product_cond` function only checked `a.is_cuda and b.is_cuda`,
which returns `False` for XPU tensors. This caused the triton override to never
fire on XPU, making `test_cow_inputs_accepted_by_override` fail.

Changes:
- Add `_is_gpu_tensor()` helper that checks both `is_cuda` and `is_xpu`
- Use it in `_bmm_outer_product_cond` so the override activates for XPU tensors
- Update `_bmm_outer_product_impl` to handle XPU devices that don't need the
  CUDA device-switching logic