### PR TITLE
Upgrade submodule oneDNN to v3.12.3

### DIFF
--- a/cmake/Modules/FindMKLDNN.cmake
+++ b/cmake/Modules/FindMKLDNN.cmake
@@ -56,7 +56,7 @@ IF(NOT MKLDNN_FOUND)
     endif()
     ExternalProject_Add(xpu_mkldnn_proj
       GIT_REPOSITORY https://github.com/uxlfoundation/oneDNN
-      GIT_TAG v3.12
+      GIT_TAG v3.12.2
       PREFIX ${XPU_MKLDNN_DIR_PREFIX}
       BUILD_IN_SOURCE 0
       CMAKE_ARGS  -DCMAKE_C_COMPILER=${DNNL_C_COMPILER}

--- a/cmake/Modules/FindMKLDNN.cmake
+++ b/cmake/Modules/FindMKLDNN.cmake
@@ -56,7 +56,7 @@ IF(NOT MKLDNN_FOUND)
     endif()
     ExternalProject_Add(xpu_mkldnn_proj
       GIT_REPOSITORY https://github.com/uxlfoundation/oneDNN
-      GIT_TAG v3.12.2
+      GIT_TAG rls-v3.12
       PREFIX ${XPU_MKLDNN_DIR_PREFIX}
       BUILD_IN_SOURCE 0
       CMAKE_ARGS  -DCMAKE_C_COMPILER=${DNNL_C_COMPILER}

--- a/cmake/Modules/FindMKLDNN.cmake
+++ b/cmake/Modules/FindMKLDNN.cmake
@@ -56,7 +56,7 @@ IF(NOT MKLDNN_FOUND)
     endif()
     ExternalProject_Add(xpu_mkldnn_proj
       GIT_REPOSITORY https://github.com/uxlfoundation/oneDNN
-      GIT_TAG rls-v3.12
+      GIT_TAG v3.12.3
       PREFIX ${XPU_MKLDNN_DIR_PREFIX}
       BUILD_IN_SOURCE 0
       CMAKE_ARGS  -DCMAKE_C_COMPILER=${DNNL_C_COMPILER}


### PR DESCRIPTION
This PR is to upgrade oneDNN from v3.12 to v3.12.2.   This upgrade mainly aims at supporting SYCL Graph for OneDNN XPU primitives.

# Improvements
- Enabled SYCL Graph record/replay mode support on Intel GPUs
- Fixed some correctness and performance issues on x64 and RV64 CPUs.


## Validation results on Xeon CPU
1. Dynamo benchmarks

The test results are based on the 3 dynamo benchmark suites with three data types.

| Precision | Shape | Wrapper | Thread | Eager Ratio (3.12.2/3.12) | Inductor Ratio (3.12.2/3.12) |
| -- | -- | -- | -- | -- | -- |
| FP32 | Static | cpp | Multiple | 1.0094 | 1.0116 |
| FP32 | Static | cpp | Single | 1.0139 | 1.0183 |
| AMP_BF16 | Static | cpp | Multiple | 1.0037 | 1.0035 |
| AMP_BF16 | Static | cpp | Single | 0.9954 | 0.9926 |
| AMP_FP16 | Static | cpp | Multiple | 1.0058 | 0.9991 |
| AMP_FP16 | Static | cpp | Single | 0.9984 | 0.9980 |

## Validation results on Intel B60

Shows **NO verified blocker** attributable to the oneDNN v3.12.2 upgrade.

| Area | Total | v3.12.2 / v3.12 | Verdict |
| --- | ---: | --- | --- |
| UT | 296K | **1.00x** pass rate | No verified regressions |
| Accuracy | 1995 | **1.00x** pass rate | No verified regressions |
| Performance | 1995 | **1.0015x** inductor / **1.0017x** eager | No verified sustained drops |

Note: All data are based on release/2.13

UT scope owned by https://github.com/intel/torch-xpu-ops
Dynamo benchmark scope
- huggingface (~ 46 models), timm_models (~ 61 models), torchbench (~77 train, ~99 inf)
- float32, float16, bfloat16, amp fp16, amp bf16
- inference, training


## Validation results on AArch64

See below for a breakdown of Arm Neoverse-V1 performance for a set of NLP, Torchbench, and Dynamo model configurations. Considering this is a patch release, the performance is similar to `v3.12.0` . 

 **Arm Neoverse-V1 - Dynamo - 16 Threads:**  

Suite | Compiler | Data Type | Shape | Throughput Geomean (lower is better)
-- | -- | -- | -- | --
huggingface | eager | bf16_amp | dynamic | 1.00
huggingface | eager | bf16_amp | static | 1.01
huggingface | eager | fp32 | dynamic | 1.00
huggingface | eager | fp32 | static | 1.00
huggingface | inductor | fp32 | dynamic | 1.00
huggingface | inductor | fp32 | static | 1.00
timm | eager | bf16_amp | dynamic | 1.00
timm | eager | bf16_amp | static | 1.01
timm | eager | fp32 | dynamic | 1.00
timm | eager | fp32 | static | 1.00
timm | inductor | bf16_amp | dynamic | 1.00
timm | inductor | fp32 | dynamic | 1.00
timm | inductor | fp32 | static | 1.01
torchbench | inductor | fp32 | dynamic | 0.99
torchbench | inductor | fp32 | static | 0.99

 **Arm Neoverse-V1 - Torchbench - 16 Threads:**  

Mode | Precision | Latency Geomean (lower is better)
-- | -- | --
eager | bf16_amp | 1.00
eager | fp32 | 1.00
eager | fx_int8 | 1.00
torchscript | bf16_amp | 0.98
torchscript | fp32 | 1.00

 **Arm Neoverse-V1 - NLP - 16 Threads:**  

| latency geomean (lower is better) |
| -------------------------------- |
|0.99                      |





cc @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10 @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal