### PR TITLE
Fix MKL VML first-call dispatch race producing silent low-precision results

### DIFF
--- a/aten/src/ATen/cpu/vml.h
+++ b/aten/src/ATen/cpu/vml.h
@@ -5,6 +5,7 @@
 #include <ATen/OpMathType.h>
 #include <ATen/cpu/vec/functional.h>
 #include <ATen/cpu/vec/vec.h>
+#include <c10/util/CallOnce.h>
 #include <c10/util/complex.h>
 
 // This header implements various unary operations using a MKL VML style
@@ -105,10 +106,33 @@ IMPLEMENT_VML(lgamma)
 static_assert(
     std::is_same_v<MKL_INT, int32_t> || std::is_same_v<MKL_INT, int64_t>,
     "MKL_INT is assumed to be int32_t or int64_t");
+
+// MKL VML resolves each function's (ISA, accuracy) kernel dispatch lazily on
+// its first call. If that first call runs concurrently on several intra-op
+// worker threads (these functions are called per-chunk from parallel_for), a
+// thread can transiently execute a mismatched kernel and silently return
+// low-precision results for its whole chunk (observed on oneMKL 2024.2: AVX2
+// EP kernel served despite VML_HA requested, on AVX512 hardware). A
+// serialized warm-up call resolves the dispatch before any concurrent use.
+#define IMPLEMENT_VML_MKL_WARMUP(mklop, type, mkltype)                  \
+  {                                                                     \
+    static c10::once_flag vml_dispatch_resolved;                        \
+    c10::call_once(vml_dispatch_resolved, []() {                        \
+      type warmup_in = static_cast<type>(0.5);                          \
+      type warmup_out = static_cast<type>(0);                           \
+      vm##mkltype##mklop(                                               \
+          1,                                                            \
+          &warmup_in,                                                   \
+          &warmup_out,                                                  \
+          VML_HA | VML_FTZDAZ_OFF | VML_ERRMODE_IGNORE);                \
+    });                                                                 \
+  }
+
 #define IMPLEMENT_VML_MKL_STUB(op, mklop, type, mkltype)                \
   template <>                                                           \
   inline void v##op(type * out, const type * in, int64_t size) {        \
     auto constexpr max_mkl_ind = std::numeric_limits<MKL_INT>::max();   \
+    IMPLEMENT_VML_MKL_WARMUP(mklop, type, mkltype)                      \
     if (size <= static_cast<int64_t>(max_mkl_ind)) {                    \
       vm##mkltype##mklop(                                               \
           size, in, out, VML_HA | VML_FTZDAZ_OFF | VML_ERRMODE_IGNORE); \

--- a/aten/src/ATen/cpu/vml.h
+++ b/aten/src/ATen/cpu/vml.h
@@ -114,6 +114,9 @@ static_assert(
 // low-precision results for its whole chunk (observed on oneMKL 2024.2: AVX2
 // EP kernel served despite VML_HA requested, on AVX512 hardware). A
 // serialized warm-up call resolves the dispatch before any concurrent use.
+// Reproduces on oneMKL 2024.2.0 through 2024.2.2; not reproducible on
+// >= 2025.0, so this can be dropped once the minimum supported oneMKL moves
+// past 2024.2.x. See https://github.com/pytorch/pytorch/issues/188792.
 #define IMPLEMENT_VML_MKL_WARMUP(mklop, type, mkltype)                  \
   {                                                                     \
     static c10::once_flag vml_dispatch_resolved;                        \


### PR DESCRIPTION
## Issue

Fixes #188792

## Summary

oneMKL resolves each VML function's kernel dispatch lazily on first call; concurrent first calls from intra-op worker threads can transiently execute the low-accuracy AVX2 EP kernel for one thread's chunk despite `VML_HA` being requested (bit-exact evidence and repro in #188792). This adds a `c10::call_once` 1-element warm-up per VML function and precision so dispatch resolves before any concurrent use. Steady-state outputs are bitwise unchanged; steady-state cost is one atomic load per call. The race reproduces on oneMKL 2024.2.0-2024.2.2 (2024.2.0 is the current CI/wheel pin) and stops reproducing at oneMKL >= 2025.0 (version matrix in #188792); bumping the MKL pin is an alternative fix, while this warm-up protects any build linked against an affected version.

## Checklist

- [x] Passes lint (`spin fixlint`)
- [ ] Added/updated tests -- the race needs a multi-process spawn storm and is not deterministically triggerable in CI; A/B storm results are in #188792 (unpatched 216/4,160 corrupted first-calls on a static-MKL build, patched 0/5,200)
- [ ] Updated documentation (if applicable) -- N/A
- [x] Included benchmark results (for PRs impacting perf) -- min-of-7 sqrt latency A/B on the same box and oneMKL shows no regression (patched equal or faster at all sizes tested from 8 to 393k elements at 1 and 4 threads; steady-state cost is one atomic load)

## BC-breaking?

No.

Authored with the help of an AI assistant.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01
