### PR TITLE
Fix system Eigen 5.0.x detection in CMake

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -811,11 +811,12 @@ endif()
 set(EIGEN_MPL2_ONLY 1)
 if(USE_SYSTEM_EIGEN_INSTALL)
   find_package(Eigen3)
-  if(EIGEN3_FOUND)
-    message(STATUS "Found system Eigen at " ${EIGEN3_INCLUDE_DIR})
+  if(Eigen3_FOUND)
+    get_target_property(EIGEN3_INCLUDE_DIR Eigen3::Eigen INTERFACE_INCLUDE_DIRECTORIES)
+    message(STATUS "Found system Eigen ${Eigen3_VERSION} at ${EIGEN3_INCLUDE_DIR}")
   else()
     message(STATUS "Did not find system Eigen. Using third party subdirectory.")
-    execute_process(COMMAND ${Python_EXECUTABLE} ../tools/optional_modules.py checkout_eigen
+    execute_process(COMMAND ${Python_EXECUTABLE} ../tools/optional_submodules.py checkout_eigen
                     WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR})
 
     set(EIGEN3_INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/../third_party/eigen)


### PR DESCRIPTION
Fix system Eigen 5.0.x detection in CMake

Eigen 5.0's installed Eigen3Config.cmake only defines the Eigen3::Eigen target; it no longer sets the legacy EIGEN3_FOUND / EIGEN3_INCLUDE_DIR variables that Eigen 3.4 provided. find_package(Eigen3) sets the case-sensitive Eigen3_FOUND, so the old if(EIGEN3_FOUND) check never fired with system Eigen 5.0.x: builds with USE_SYSTEM_EIGEN_INSTALL=ON silently fell through to the bundled-Eigen fallback. Switch the check to Eigen3_FOUND and read the include directory from the target's INTERFACE_INCLUDE_DIRECTORIES.

The bundled-Eigen fallback in the same block invoked tools/optional_modules.py, which does not exist. The script is tools/optional_submodules.py (checkout_eigen was added there in #155955, but the cmake reference was never updated). Because execute_process did not check its result, the failure was silent and the fallback never actually checked out the pinned Eigen. Corrected the path so the fallback works.

Revives #172980 by @heylinn, approved by @malfet and closed only because of an unsigned CLA; credit for the detection fix goes to her.

Test Plan:

Installed Eigen 5.0.1 into a local prefix (WSL Ubuntu, gcc 15, CMake 3.31):

```
curl -sSLO https://gitlab.com/libeigen/eigen/-/archive/5.0.1/eigen-5.0.1.tar.gz
tar xzf eigen-5.0.1.tar.gz
cmake -S eigen-5.0.1 -B eigen-build -DCMAKE_INSTALL_PREFIX=$HOME/eigen-install -DEIGEN_BUILD_TESTING=OFF -DEIGEN_BUILD_DOC=OFF
cmake --install eigen-build
```

Configure with system Eigen (previously fell back to bundled):

```
cmake -S pytorch -B build-system -G Ninja -DCMAKE_PREFIX_PATH=$HOME/eigen-install -DUSE_SYSTEM_EIGEN_INSTALL=ON -DBLAS=Eigen -DBUILD_PYTHON=OFF -DBUILD_TEST=OFF -DUSE_CUDA=OFF -DUSE_DISTRIBUTED=OFF -DUSE_MKLDNN=OFF -DUSE_FBGEMM=OFF -DUSE_XNNPACK=OFF -DUSE_PYTORCH_QNNPACK=OFF -DUSE_KINETO=OFF -DUSE_NNPACK=OFF -DUSE_NUMPY=OFF -DUSE_OPENMP=OFF
```

now prints "-- Found system Eigen 5.0.1 at
$HOME/eigen-install/include/eigen3" and completes ("Configuring done", "Generating done"). The default configure (same flags minus CMAKE_PREFIX_PATH and USE_SYSTEM_EIGEN_INSTALL) still prints "-- Using third party subdirectory Eigen." and completes, so the bundled path is unchanged. Also verified the fallback script reference directly: `python3 tools/optional_modules.py checkout_eigen` fails with "No such file or directory" while `python3 tools/optional_submodules.py checkout_eigen` runs and no-ops when third_party/eigen is present.

Fixes #172949