### PR TITLE
Fix `torch.asarray` to preserve an input's device when a default device is set

### DIFF
--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -4525,25 +4525,55 @@ class TestAsArray(TestCase):
         self.assertEqual(tensor.dtype, torch.int32)
 
     def test_default_device(self, device):
-        original = torch.arange(5)
+        # A pure Python scalar or sequence adopts the default device.
+        with torch.device(device):
+            self.assertEqual(torch.asarray(3).device, torch.device(device))
+            self.assertEqual(torch.asarray([1, 2, 3]).device, torch.device(device))
 
+        # A device-bearing input (tensor, numpy array, buffer) keeps its own
+        # device even when a default device is set.
+        # See https://github.com/pytorch/pytorch/issues/150199.
+        original = torch.arange(5)  # on CPU
         examples: list[tuple[Any, dict]] = [
-            (3, {}),
             (original, {}),
             (to_numpy(original), {}),
             (to_memview(original), {"dtype": original.dtype}),
         ]
-
         for data, kwargs in examples:
             with torch.device(device):
                 tensor = torch.asarray(data, **kwargs)
-                self.assertEqual(tensor.device, torch.device(device))
+                self.assertEqual(tensor.device.type, "cpu")
+                self.assertEqual(data, tensor)
 
-                # Check the contents of the tensor.
-                if isinstance(data, int):
-                    self.assertEqual(data, tensor.item())
-                else:
-                    self.assertEqual(data, tensor)
+    def test_asarray_set_default_device_preserves_input_device(self, device):
+        # gh-150199: with a default device set, asarray must preserve a
+        # device-bearing input's device; only pure Python scalars and sequences
+        # use the default device.
+        other = get_another_device(device)
+        if other is None:
+            self.skipTest("requires a second device")
+
+        other_tensor = torch.ones(3, device=other)
+        cpu_numpy = np.ones(3, dtype=np.float32)
+        try:
+            torch.set_default_device(device)
+            # device-bearing inputs keep their own device
+            self.assertEqual(
+                torch.asarray(other_tensor).device.type, torch.device(other).type
+            )
+            self.assertEqual(torch.asarray(cpu_numpy).device.type, "cpu")
+            # pure Python scalar/sequence uses the default device
+            self.assertEqual(torch.asarray(5.0).device.type, torch.device(device).type)
+            self.assertEqual(
+                torch.asarray([1.0, 2.0]).device.type, torch.device(device).type
+            )
+            # an explicit device always wins
+            self.assertEqual(
+                torch.asarray(other_tensor, device=device).device.type,
+                torch.device(device).type,
+            )
+        finally:
+            torch.set_default_device(None)
 
     @onlyAccelerator
     def test_device_without_index(self, device):

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -4490,25 +4490,55 @@ class TestAsArray(TestCase):
         self.assertEqual(tensor.dtype, torch.int32)
 
     def test_default_device(self, device):
-        original = torch.arange(5)
+        # A pure Python scalar or sequence adopts the default device.
+        with torch.device(device):
+            self.assertEqual(torch.asarray(3).device, torch.device(device))
+            self.assertEqual(torch.asarray([1, 2, 3]).device, torch.device(device))
 
+        # A device-bearing input (tensor, numpy array, buffer) keeps its own
+        # device even when a default device is set.
+        # See https://github.com/pytorch/pytorch/issues/150199.
+        original = torch.arange(5)  # on CPU
         examples: list[tuple[Any, dict]] = [
-            (3, {}),
             (original, {}),
             (to_numpy(original), {}),
             (to_memview(original), {"dtype": original.dtype}),
         ]
-
         for data, kwargs in examples:
             with torch.device(device):
                 tensor = torch.asarray(data, **kwargs)
-                self.assertEqual(tensor.device, torch.device(device))
+                self.assertEqual(tensor.device.type, "cpu")
+                self.assertEqual(data, tensor)
 
-                # Check the contents of the tensor.
-                if isinstance(data, int):
-                    self.assertEqual(data, tensor.item())
-                else:
-                    self.assertEqual(data, tensor)
+    def test_asarray_set_default_device_preserves_input_device(self, device):
+        # gh-150199: with a default device set, asarray must preserve a
+        # device-bearing input's device; only pure Python scalars and sequences
+        # use the default device.
+        other = get_another_device(device)
+        if other is None:
+            self.skipTest("requires a second device")
+
+        other_tensor = torch.ones(3, device=other)
+        cpu_numpy = np.ones(3, dtype=np.float32)
+        try:
+            torch.set_default_device(device)
+            # device-bearing inputs keep their own device
+            self.assertEqual(
+                torch.asarray(other_tensor).device.type, torch.device(other).type
+            )
+            self.assertEqual(torch.asarray(cpu_numpy).device.type, "cpu")
+            # pure Python scalar/sequence uses the default device
+            self.assertEqual(torch.asarray(5.0).device.type, torch.device(device).type)
+            self.assertEqual(
+                torch.asarray([1.0, 2.0]).device.type, torch.device(device).type
+            )
+            # an explicit device always wins
+            self.assertEqual(
+                torch.asarray(other_tensor, device=device).device.type,
+                torch.device(device).type,
+            )
+        finally:
+            torch.set_default_device(None)
 
     @onlyAccelerator
     def test_device_without_index(self, device):

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1311,7 +1311,8 @@ Keyword args:
            error is thrown if it cannot.
     device (:class:`torch.device`, optional): the device of the returned tensor.
            Default: ``None``, which causes the device of :attr:`obj` to be used. Or, if
-           :attr:`obj` is a Python sequence, the current default device will be used.
+           :attr:`obj` is a Python scalar or sequence, the current default device will
+           be used.
     requires_grad (bool, optional): whether the returned tensor requires grad.
            Default: ``None``, which causes requires_grad for the returned tensor to be
            inferred from :attr:`obj`. If ``True``, then the returned tensor will require

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1287,6 +1287,13 @@ When :attr:`obj` is none of the above but a scalar, or a sequence of scalars the
 returned tensor will, by default, infer its datatype from the scalar values, be on the
 current default device, and not share its memory.
 
+.. versionchanged:: 2.14
+   When a default device is set (via :func:`torch.set_default_device` or a
+   ``with torch.device(...):`` block) and :attr:`device` is not given, the device of a
+   device-bearing :attr:`obj` (a tensor, NumPy array, DLPack producer, or buffer) is now
+   preserved instead of being overridden by the default device. The default device still
+   applies to Python scalars and sequences.
+
 .. seealso::
 
     :func:`torch.tensor` creates a tensor that always copies the data from the input object.

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1433,6 +1433,13 @@ When :attr:`obj` is none of the above but a scalar, or a sequence of scalars the
 returned tensor will, by default, infer its datatype from the scalar values, be on the
 current default device, and not share its memory.
 
+.. versionchanged:: 2.14
+   When a default device is set (via :func:`torch.set_default_device` or a
+   ``with torch.device(...):`` block) and :attr:`device` is not given, the device of a
+   device-bearing :attr:`obj` (a tensor, NumPy array, DLPack producer, or buffer) is now
+   preserved instead of being overridden by the default device. The default device still
+   applies to Python scalars and sequences.
+
 .. seealso::
 
     :func:`torch.tensor` creates a tensor that always copies the data from the input object.

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1457,7 +1457,8 @@ Keyword args:
            error is thrown if it cannot.
     device (:class:`torch.device`, optional): the device of the returned tensor.
            Default: ``None``, which causes the device of :attr:`obj` to be used. Or, if
-           :attr:`obj` is a Python sequence, the current default device will be used.
+           :attr:`obj` is a Python scalar or sequence, the current default device will
+           be used.
     requires_grad (bool, optional): whether the returned tensor requires grad.
            Default: ``None``, which causes requires_grad for the returned tensor to be
            inferred from :attr:`obj`. If ``True``, then the returned tensor will require

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1433,7 +1433,7 @@ When :attr:`obj` is none of the above but a scalar, or a sequence of scalars the
 returned tensor will, by default, infer its datatype from the scalar values, be on the
 current default device, and not share its memory.
 
-.. versionchanged:: 2.14
+.. versionchanged:: 2.15
    When a default device is set (via :func:`torch.set_default_device` or a
    ``with torch.device(...):`` block) and :attr:`device` is not given, the device of a
    device-bearing :attr:`obj` (a tensor, NumPy array, DLPack producer, or buffer) is now

--- a/torch/utils/_device.py
+++ b/torch/utils/_device.py
@@ -1,5 +1,6 @@
 # mypy: allow-untyped-defs
 import functools
+import sys
 
 import torch
 from torch._C import _len_torch_function_stack
@@ -64,6 +65,29 @@ def _device_constructors():
     }
 
 
+def _asarray_input_has_device(obj) -> bool:
+    """Whether a ``torch.asarray`` input already carries its own device.
+
+    ``torch.asarray`` preserves the device of a device-bearing input (a tensor,
+    numpy array/scalar, DLPack producer, or buffer-protocol object); only pure
+    Python scalars and sequences fall back to the default device. This mirrors
+    ``torch.asarray``'s own input dispatch so that a set default device does not
+    override an input's device. See https://github.com/pytorch/pytorch/issues/150199.
+    """
+    if isinstance(obj, torch.Tensor):
+        return True
+    if hasattr(obj, "__dlpack__"):
+        return True
+    numpy = sys.modules.get("numpy")
+    if numpy is not None and isinstance(obj, (numpy.ndarray, numpy.generic)):
+        return True
+    try:
+        memoryview(obj)
+    except TypeError:
+        return False
+    return True
+
+
 # NB: This is directly called from C++ in torch/csrc/Device.cpp
 class DeviceContext(TorchFunctionMode):
     def __init__(self, device) -> None:
@@ -118,6 +142,10 @@ class DeviceContext(TorchFunctionMode):
     def __torch_function__(self, func, types, args=(), kwargs=None):
         kwargs = kwargs or {}
         if func in _device_constructors() and kwargs.get("device") is None:
+            if func is torch.asarray:
+                obj = args[0] if args else kwargs.get("obj")
+                if _asarray_input_has_device(obj):
+                    return func(*args, **kwargs)
             kwargs["device"] = self.device
         return func(*args, **kwargs)
 


### PR DESCRIPTION
Fixes #150199

`torch.asarray` preserves input's device when a default device is set except for Python scalars and sequences.

`_asarray_input_has_device` helper checks whether the input already carries its own device and if `true` then `DeviceContext` does not override it.