### PR TITLE
[MPS] Reject complex logaddexp2 inputs before Metal dispatch

### DIFF
--- a/aten/src/ATen/native/mps/operations/BinaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryKernel.mm
@@ -106,6 +106,8 @@ static void logaddexp_mps_kernel(TensorIteratorBase& iter) {
 }
 
 static void logaddexp2_mps_kernel(TensorIteratorBase& iter) {
+  TORCH_CHECK_NOT_IMPLEMENTED(
+      !c10::isComplexType(iter.common_dtype()), "\"logaddexp2_mps\" not implemented for '", iter.common_dtype(), "'");
   lib.exec_binary_kernel(iter, "logaddexp2");
 }
 

--- a/aten/src/ATen/native/mps/operations/BinaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryKernel.mm
@@ -107,7 +107,7 @@ static void logaddexp_mps_kernel(TensorIteratorBase& iter) {
 
 static void logaddexp2_mps_kernel(TensorIteratorBase& iter) {
   TORCH_CHECK_NOT_IMPLEMENTED(
-      !c10::isComplexType(iter.common_dtype()), "\"logaddexp2_mps\" not implemented for '", iter.common_dtype(), "'");
+      c10::isFloatingType(iter.common_dtype()), "\"logaddexp2_mps\" not implemented for '", iter.common_dtype(), "'");
   lib.exec_binary_kernel(iter, "logaddexp2");
 }
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -7292,13 +7292,6 @@ class TestMPS(TestCaseMPS):
 
         helper((2, 8, 4, 5))
 
-    def test_logaddexp2_complex_unsupported(self):
-        a = torch.randn((3, 1), dtype=torch.complex64, device="mps")
-        b = torch.randn((1, 4), dtype=torch.complex64, device="mps")
-
-        with self.assertRaisesRegex(NotImplementedError, "logaddexp2_mps.*ComplexFloat"):
-            torch.logaddexp2(a, b)
-
     def test_logsumexp(self):
         def helper(shape):
             cpu_x = torch.randn(shape, device='cpu', dtype=torch.float, requires_grad=False)

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -7292,6 +7292,13 @@ class TestMPS(TestCaseMPS):
 
         helper((2, 8, 4, 5))
 
+    def test_logaddexp2_complex_unsupported(self):
+        a = torch.randn((3, 1), dtype=torch.complex64, device="mps")
+        b = torch.randn((1, 4), dtype=torch.complex64, device="mps")
+
+        with self.assertRaisesRegex(NotImplementedError, "logaddexp2_mps.*ComplexFloat"):
+            torch.logaddexp2(a, b)
+
     def test_logsumexp(self):
         def helper(shape):
             cpu_x = torch.randn(shape, device='cpu', dtype=torch.float, requires_grad=False)


### PR DESCRIPTION
Fixes #188386

`torch.logaddexp2` on MPS is implemented only for real floating dtypes, but complex inputs could reach the generic Metal binary kernel path. That routed `complex64` storage to a `float2` specialization and failed while creating the Metal function state, producing an opaque internal error.

This adds a dispatch-boundary guard for complex common dtypes in the MPS `logaddexp2` kernel and adds a regression test covering broadcast `complex64` inputs.

Test Plan:
```
env CMAKE_OSX_ARCHITECTURES=arm64 ARCHFLAGS=-arch\ arm64 USE_FBGEMM=0 USE_MKLDNN=0 arch -arm64 pip install -e . -v --no-build-isolation
arch -arm64 python -c "import torch, platform; print(torch.__version__); print(platform.machine()); print('mps built', torch.backends.mps.is_built()); print('mps available', torch.backends.mps.is_available())"
arch -arm64 python -m py_compile test/test_mps.py
git diff --check
spin quicklint
uvx --python 3.10 lintrunner@0.12.7 -a
```

The focused MPS runtime test could not be executed in this tool shell because `torch.backends.mps.is_available()` returned `False`, although the local build has MPS enabled. Command for a normal Apple Silicon terminal:
```
arch -arm64 python test/test_mps.py TestMPS.test_logaddexp2_complex_unsupported
```