### PR TITLE
[MPS] Leak MetalShaderLibrary bundled singleton to avoid exit-time destructor crashes

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -1669,8 +1669,12 @@ void MetalShaderLibrary::exec_ternary_kernel(TensorIteratorBase& iter, const std
 }
 
 MetalShaderLibrary& MetalShaderLibrary::getBundledLibrary() {
-  static BundledShaderLibrary l;
-  return l;
+  // Heap-allocate and intentionally leak: the singleton lives for the whole
+  // process, and its destructor cannot safely release Metal objects during
+  // __cxa_finalize on builds where the Metal runtime has already been torn
+  // down. See https://github.com/pytorch/pytorch/issues/188812.
+  static BundledShaderLibrary* l = new BundledShaderLibrary();
+  return *l;
 }
 
 // DynamicMetalShaderLibrary implementation

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -1642,8 +1642,12 @@ void MetalShaderLibrary::exec_ternary_kernel(TensorIteratorBase& iter, const std
 }
 
 MetalShaderLibrary& MetalShaderLibrary::getBundledLibrary() {
-  static BundledShaderLibrary l;
-  return l;
+  // Heap-allocate and intentionally leak: the singleton lives for the whole
+  // process, and its destructor cannot safely release Metal objects during
+  // __cxa_finalize on builds where the Metal runtime has already been torn
+  // down. See https://github.com/pytorch/pytorch/issues/188812.
+  static BundledShaderLibrary* l = new BundledShaderLibrary();
+  return *l;
 }
 
 // DynamicMetalShaderLibrary implementation

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -854,6 +854,33 @@ class TestAvgPool(TestCaseMPS):
 
 
 class TestMPS(TestCaseMPS):
+    def test_metalshaderlibrary_destructor_clean_exit(self):
+        # Regression for MetalShaderLibrary destructor crashes on macOS 15+
+        # where the Metal runtime tears down before __cxa_finalize fires,
+        # making ObjC messages to Metal objects during static destruction
+        # unsafe. The fix nulls every ObjC member pointer in the destructor
+        # before implicit member destructors run, so each one calls
+        # objc_release(nil) -- a guaranteed no-op even after Metal is gone.
+        # Without the fix, the test subprocess crashes during interpreter
+        # shutdown with a non-zero return code (SIGSEGV).
+        snippet = """
+import torch
+# Touch enough of the MPS kernel-library surface that MetalShaderLibrary
+# instances get instantiated and registered with the bundled-library global.
+x = torch.randn(8, device='mps')
+_ = x.relu()
+_ = x + 1.5
+torch.mps.synchronize()
+"""
+        proc = subprocess.run([sys.executable, "-c", snippet],
+                              capture_output=True, text=True, timeout=60)
+        self.assertEqual(
+            proc.returncode, 0,
+            f"Interpreter exit was unclean (returncode={proc.returncode}). "
+            f"Likely MetalShaderLibrary destructor regression.\n"
+            f"stderr tail:\n{proc.stderr[-1000:]}",
+        )
+
     def ulpAssertAllClose(self, output, reference, n_ulps):
         """
         Wrapper for element-wise tolerances with known

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -855,21 +855,22 @@ class TestAvgPool(TestCaseMPS):
 
 class TestMPS(TestCaseMPS):
     def test_metalshaderlibrary_destructor_clean_exit(self):
-        # Regression for MetalShaderLibrary destructor crashes on macOS 15+
-        # where the Metal runtime tears down before __cxa_finalize fires,
-        # making ObjC messages to Metal objects during static destruction
-        # unsafe. The fix nulls every ObjC member pointer in the destructor
-        # before implicit member destructors run, so each one calls
-        # objc_release(nil) -- a guaranteed no-op even after Metal is gone.
+        # Regression for MetalShaderLibrary destructor crashes at process
+        # exit. On builds where the Metal runtime is finalized before
+        # libtorch_cpu (depends on dylib finalize order, not OS version),
+        # ObjC messages to Metal objects during static destruction are
+        # unsafe. The fix heap-allocates the bundled-library singleton and
+        # never frees it, so its destructor (which releases every cached
+        # MTLComputePipelineState/MTLFunction) never runs at process exit.
         # Without the fix, the test subprocess crashes during interpreter
         # shutdown with a non-zero return code (SIGSEGV).
         snippet = """
 import torch
-# Touch enough of the MPS kernel-library surface that MetalShaderLibrary
-# instances get instantiated and registered with the bundled-library global.
+# Touch the MPS kernel-library surface so the bundled MetalShaderLibrary
+# compiles and caches at least one pipeline state, giving its destructor
+# Metal objects to release at exit.
 x = torch.randn(8, device='mps')
 _ = x.relu()
-_ = x + 1.5
 torch.mps.synchronize()
 """
         proc = subprocess.run([sys.executable, "-c", snippet],

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -878,6 +878,33 @@ class TestAvgPool(TestCaseMPS):
 
 
 class TestMPS(TestCaseMPS):
+    def test_metalshaderlibrary_destructor_clean_exit(self):
+        # Regression for MetalShaderLibrary destructor crashes on macOS 15+
+        # where the Metal runtime tears down before __cxa_finalize fires,
+        # making ObjC messages to Metal objects during static destruction
+        # unsafe. The fix nulls every ObjC member pointer in the destructor
+        # before implicit member destructors run, so each one calls
+        # objc_release(nil) -- a guaranteed no-op even after Metal is gone.
+        # Without the fix, the test subprocess crashes during interpreter
+        # shutdown with a non-zero return code (SIGSEGV).
+        snippet = """
+import torch
+# Touch enough of the MPS kernel-library surface that MetalShaderLibrary
+# instances get instantiated and registered with the bundled-library global.
+x = torch.randn(8, device='mps')
+_ = x.relu()
+_ = x + 1.5
+torch.mps.synchronize()
+"""
+        proc = subprocess.run([sys.executable, "-c", snippet],
+                              capture_output=True, text=True, timeout=60)
+        self.assertEqual(
+            proc.returncode, 0,
+            f"Interpreter exit was unclean (returncode={proc.returncode}). "
+            f"Likely MetalShaderLibrary destructor regression.\n"
+            f"stderr tail:\n{proc.stderr[-1000:]}",
+        )
+
     def ulpAssertAllClose(self, output, reference, n_ulps):
         """
         Wrapper for element-wise tolerances with known

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -879,21 +879,22 @@ class TestAvgPool(TestCaseMPS):
 
 class TestMPS(TestCaseMPS):
     def test_metalshaderlibrary_destructor_clean_exit(self):
-        # Regression for MetalShaderLibrary destructor crashes on macOS 15+
-        # where the Metal runtime tears down before __cxa_finalize fires,
-        # making ObjC messages to Metal objects during static destruction
-        # unsafe. The fix nulls every ObjC member pointer in the destructor
-        # before implicit member destructors run, so each one calls
-        # objc_release(nil) -- a guaranteed no-op even after Metal is gone.
+        # Regression for MetalShaderLibrary destructor crashes at process
+        # exit. On builds where the Metal runtime is finalized before
+        # libtorch_cpu (depends on dylib finalize order, not OS version),
+        # ObjC messages to Metal objects during static destruction are
+        # unsafe. The fix heap-allocates the bundled-library singleton and
+        # never frees it, so its destructor (which releases every cached
+        # MTLComputePipelineState/MTLFunction) never runs at process exit.
         # Without the fix, the test subprocess crashes during interpreter
         # shutdown with a non-zero return code (SIGSEGV).
         snippet = """
 import torch
-# Touch enough of the MPS kernel-library surface that MetalShaderLibrary
-# instances get instantiated and registered with the bundled-library global.
+# Touch the MPS kernel-library surface so the bundled MetalShaderLibrary
+# compiles and caches at least one pipeline state, giving its destructor
+# Metal objects to release at exit.
 x = torch.randn(8, device='mps')
 _ = x.relu()
-_ = x + 1.5
 torch.mps.synchronize()
 """
         proc = subprocess.run([sys.executable, "-c", snippet],


### PR DESCRIPTION
Fixes #188812.

`MetalShaderLibrary::getBundledLibrary()` used to return a function-local `static BundledShaderLibrary`, so its destructor ran during `__cxa_finalize`. On some builds the Metal runtime is already gone at that point, and the destructor's `[cpl release]` / `[func release]` calls fault, aborting an otherwise clean process exit.

Heap-allocate the singleton and never delete it. The library lives for the whole process, so its destructor never needs to run; the OS reclaims all GPU resources on exit anyway.

## Test Plan

`python test/test_mps.py TestMPS.test_metalshaderlibrary_destructor_clean_exit`

Passes on macOS; the test subprocess exits with returncode 0.