### PR TITLE
[MPS] Add solo large-tensor allocator

### DIFF
--- a/aten/src/ATen/mps/MPSAllocator.h
+++ b/aten/src/ATen/mps/MPSAllocator.h
@@ -9,7 +9,6 @@
 #include <c10/util/flat_hash_map.h>
 #include <mach/vm_page_size.h>
 #include <cstdio>
-#include <atomic>
 #include <mutex>
 #include <set>
 #include <unordered_map>
@@ -439,9 +438,13 @@ class MPSHeapAllocatorImpl {
   // Solo allocator: direct per-buffer MTLBuffer for large tensors; bypasses MTLHeap
   // sub-allocation. Threshold comes from the shared accelerator config
   // (mps_large_alloc_threshold_mb, read via MPSAllocatorConfig on the alloc path).
+  // All access is under m_mutex (alloc/free/emptyCache paths all hold it).
   // Per-size free list: size_bytes -> retained id<MTLBuffer> (as void* to avoid ObjC ARC in header)
-  std::mutex m_solo_mutex;
   std::unordered_multimap<size_t, void*> m_solo_cache;
+  // Freed solo buffers still referenced by an in-flight command buffer, parked
+  // here until freeInactiveBuffers() reclaims them to m_solo_cache (mirrors the
+  // heap pool's buffers_pending_free).
+  std::unordered_set<BufferBlock*> m_solo_pending_free;
   // default MPS stream
   MPSStream* m_stream;
   // we hold a reference to MPSEventPool so it could get destroyed after MPSAllocator

--- a/aten/src/ATen/mps/MPSAllocator.h
+++ b/aten/src/ATen/mps/MPSAllocator.h
@@ -30,9 +30,17 @@ static const size_t kMaxScalarAlloc = (sizeof(int64_t)); // largest "scalar" all
 
 enum class HeapTier { SMALL, LARGE, XLARGE, OVERSIZE };
 
-inline HeapTier getHeapTier(size_t size, bool has_memory_pressure) {
+// oversize_threshold_bytes, when nonzero, lowers the OVERSIZE cutoff below the
+// default kXLargeHeap/2 (see MPSAllocatorConfig::large_alloc_threshold_bytes()):
+// large-but-sub-512MB tensors that would otherwise share a 1 GiB XLARGE heap
+// instead get their own right-sized, non-split heap. Checked right after the
+// SMALL cutoff (not after kMinLargeAlloc) so a threshold below 10 MB still
+// takes effect instead of being silently absorbed into the LARGE tier.
+inline HeapTier getHeapTier(size_t size, bool has_memory_pressure, size_t oversize_threshold_bytes = 0) {
   if (size <= kMaxSmallAlloc) {
     return HeapTier::SMALL;
+  } else if (oversize_threshold_bytes > 0 && size >= oversize_threshold_bytes) {
+    return HeapTier::OVERSIZE;
   } else if (size < kMinLargeAlloc) {
     return HeapTier::LARGE;
   } else if (size < kXLargeHeap / 2 && !has_memory_pressure) {
@@ -77,10 +85,6 @@ struct BufferBlock {
   std::vector<int64_t> shape;
   bool in_use = false;
   HeapBlock* heap;
-  // For heap-less "solo" buffers, records the usage flags that a heap-backed
-  // buffer would carry on its pool, so shared-buffer queries can treat a shared
-  // solo buffer as shared. Unused (0) for heap-backed buffers.
-  uint32_t usage = 0;
   id_t buf_id = 0;
   uint32_t use_count = 0;
   // counter to assign unique ids to buffer blocks
@@ -134,6 +138,10 @@ struct AllocParams {
   // true if we exceed the low watermark limit. In this case
   // we apply strategies to relieve the pressure before allocation.
   bool has_memory_pressure = false;
+  // mirrors MPSAllocatorConfig::large_alloc_threshold_bytes(); threaded through
+  // here so the static HeapBlock::createHeapBlock() (no access to the .mm-local
+  // config singleton) can lower the OVERSIZE cutoff the same way getHeapTier does.
+  size_t oversize_threshold_bytes = 0;
 };
 
 struct HeapBlock {
@@ -182,7 +190,7 @@ struct HeapBlock {
     const size_t size = params.size();
     MTLHeapDescriptor* d = [MTLHeapDescriptor new];
     if (d) {
-      switch (getHeapTier(size, params.has_memory_pressure)) {
+      switch (getHeapTier(size, params.has_memory_pressure, params.oversize_threshold_bytes)) {
         case HeapTier::SMALL:
           d.size = kSmallHeap;
           break;
@@ -435,16 +443,6 @@ class MPSHeapAllocatorImpl {
   size_t m_low_watermark_limit;
   // use "PYTORCH_DEBUG_MPS_ALLOCATOR" env-var to set debug verbosity
   uint32_t m_debug_verbosity;
-  // Solo allocator: direct per-buffer MTLBuffer for large tensors; bypasses MTLHeap
-  // sub-allocation. Threshold comes from the shared accelerator config
-  // (mps_large_alloc_threshold_mb, read via MPSAllocatorConfig on the alloc path).
-  // All access is under m_mutex (alloc/free/emptyCache paths all hold it).
-  // Per-size free list: size_bytes -> retained id<MTLBuffer> (as void* to avoid ObjC ARC in header)
-  std::unordered_multimap<size_t, void*> m_solo_cache;
-  // Freed solo buffers still referenced by an in-flight command buffer, parked
-  // here until freeInactiveBuffers() reclaims them to m_solo_cache (mirrors the
-  // heap pool's buffers_pending_free).
-  std::unordered_set<BufferBlock*> m_solo_pending_free;
   // default MPS stream
   MPSStream* m_stream;
   // we hold a reference to MPSEventPool so it could get destroyed after MPSAllocator
@@ -464,8 +462,6 @@ class MPSHeapAllocatorImpl {
   // waits for buffers parked in-flight in the pool's pending-free list to finish
   // on the GPU and returns them to the pool; returns true if any were reclaimed
   bool wait_for_pending_free_buffers(BufferPool& pool);
-  // release all cached (freed) solo buffers back to the driver
-  void release_cached_solo_buffers();
   // release fully free heaps to reclaim GPU memory if memory pressure is high
   void garbage_collect_cached_buffers(AllocParams& params);
   // places a buffer on the block's range, or releases the one placed on it

--- a/aten/src/ATen/mps/MPSAllocator.h
+++ b/aten/src/ATen/mps/MPSAllocator.h
@@ -9,8 +9,10 @@
 #include <c10/util/flat_hash_map.h>
 #include <mach/vm_page_size.h>
 #include <cstdio>
+#include <atomic>
 #include <mutex>
 #include <set>
+#include <unordered_map>
 #include <unordered_set>
 
 // this implementation is based on CUDACachingAllocator.
@@ -76,6 +78,10 @@ struct BufferBlock {
   std::vector<int64_t> shape;
   bool in_use = false;
   HeapBlock* heap;
+  // For heap-less "solo" buffers, records the usage flags that a heap-backed
+  // buffer would carry on its pool, so shared-buffer queries can treat a shared
+  // solo buffer as shared. Unused (0) for heap-backed buffers.
+  uint32_t usage = 0;
   id_t buf_id = 0;
   uint32_t use_count = 0;
   // counter to assign unique ids to buffer blocks
@@ -430,6 +436,12 @@ class MPSHeapAllocatorImpl {
   size_t m_low_watermark_limit;
   // use "PYTORCH_DEBUG_MPS_ALLOCATOR" env-var to set debug verbosity
   uint32_t m_debug_verbosity;
+  // Solo allocator: direct per-buffer MTLBuffer for large tensors; bypasses MTLHeap
+  // sub-allocation. Threshold comes from the shared accelerator config
+  // (mps_large_alloc_threshold_mb, read via MPSAllocatorConfig on the alloc path).
+  // Per-size free list: size_bytes -> retained id<MTLBuffer> (as void* to avoid ObjC ARC in header)
+  std::mutex m_solo_mutex;
+  std::unordered_multimap<size_t, void*> m_solo_cache;
   // default MPS stream
   MPSStream* m_stream;
   // we hold a reference to MPSEventPool so it could get destroyed after MPSAllocator
@@ -449,6 +461,8 @@ class MPSHeapAllocatorImpl {
   // waits for buffers parked in-flight in the pool's pending-free list to finish
   // on the GPU and returns them to the pool; returns true if any were reclaimed
   bool wait_for_pending_free_buffers(BufferPool& pool);
+  // release all cached (freed) solo buffers back to the driver
+  void release_cached_solo_buffers();
   // release fully free heaps to reclaim GPU memory if memory pressure is high
   void garbage_collect_cached_buffers(AllocParams& params);
   // places a buffer on the block's range, or releases the one placed on it

--- a/aten/src/ATen/mps/MPSAllocator.h
+++ b/aten/src/ATen/mps/MPSAllocator.h
@@ -9,7 +9,6 @@
 #include <c10/util/flat_hash_map.h>
 #include <mach/vm_page_size.h>
 #include <cstdio>
-#include <atomic>
 #include <mutex>
 #include <set>
 #include <unordered_map>
@@ -426,9 +425,13 @@ class MPSHeapAllocatorImpl {
   // Solo allocator: direct per-buffer MTLBuffer for large tensors; bypasses MTLHeap
   // sub-allocation. Threshold comes from the shared accelerator config
   // (mps_large_alloc_threshold_mb, read via MPSAllocatorConfig on the alloc path).
+  // All access is under m_mutex (alloc/free/emptyCache paths all hold it).
   // Per-size free list: size_bytes -> retained id<MTLBuffer> (as void* to avoid ObjC ARC in header)
-  std::mutex m_solo_mutex;
   std::unordered_multimap<size_t, void*> m_solo_cache;
+  // Freed solo buffers still referenced by an in-flight command buffer, parked
+  // here until freeInactiveBuffers() reclaims them to m_solo_cache (mirrors the
+  // heap pool's buffers_pending_free).
+  std::unordered_set<BufferBlock*> m_solo_pending_free;
   // default MPS stream
   MPSStream* m_stream;
   // we hold a reference to MPSEventPool so it could get destroyed after MPSAllocator

--- a/aten/src/ATen/mps/MPSAllocator.h
+++ b/aten/src/ATen/mps/MPSAllocator.h
@@ -30,9 +30,17 @@ static const size_t kMaxScalarAlloc = (sizeof(int64_t)); // largest "scalar" all
 
 enum class HeapTier { SMALL, LARGE, XLARGE, OVERSIZE };
 
-inline HeapTier getHeapTier(size_t size, bool has_memory_pressure) {
+// oversize_threshold_bytes, when nonzero, lowers the OVERSIZE cutoff below the
+// default kXLargeHeap/2 (see MPSAllocatorConfig::large_alloc_threshold_bytes()):
+// large-but-sub-512MB tensors that would otherwise share a 1 GiB XLARGE heap
+// instead get their own right-sized, non-split heap. Checked right after the
+// SMALL cutoff (not after kMinLargeAlloc) so a threshold below 10 MB still
+// takes effect instead of being silently absorbed into the LARGE tier.
+inline HeapTier getHeapTier(size_t size, bool has_memory_pressure, size_t oversize_threshold_bytes = 0) {
   if (size <= kMaxSmallAlloc) {
     return HeapTier::SMALL;
+  } else if (oversize_threshold_bytes > 0 && size >= oversize_threshold_bytes) {
+    return HeapTier::OVERSIZE;
   } else if (size < kMinLargeAlloc) {
     return HeapTier::LARGE;
   } else if (size < kXLargeHeap / 2 && !has_memory_pressure) {
@@ -77,10 +85,6 @@ struct BufferBlock {
   std::vector<int64_t> shape;
   bool in_use = false;
   HeapBlock* heap;
-  // For heap-less "solo" buffers, records the usage flags that a heap-backed
-  // buffer would carry on its pool, so shared-buffer queries can treat a shared
-  // solo buffer as shared. Unused (0) for heap-backed buffers.
-  uint32_t usage = 0;
   id_t buf_id = 0;
   uint32_t use_count = 0;
   // counter to assign unique ids to buffer blocks
@@ -127,6 +131,10 @@ struct AllocParams {
   // true if we exceed the low watermark limit. In this case
   // we apply strategies to relieve the pressure before allocation.
   bool has_memory_pressure = false;
+  // mirrors MPSAllocatorConfig::large_alloc_threshold_bytes(); threaded through
+  // here so the static HeapBlock::createHeapBlock() (no access to the .mm-local
+  // config singleton) can lower the OVERSIZE cutoff the same way getHeapTier does.
+  size_t oversize_threshold_bytes = 0;
 };
 
 struct HeapBlock {
@@ -175,7 +183,7 @@ struct HeapBlock {
     const size_t size = params.size();
     MTLHeapDescriptor* d = [MTLHeapDescriptor new];
     if (d) {
-      switch (getHeapTier(size, params.has_memory_pressure)) {
+      switch (getHeapTier(size, params.has_memory_pressure, params.oversize_threshold_bytes)) {
         case HeapTier::SMALL:
           d.size = kSmallHeap;
           break;
@@ -422,16 +430,6 @@ class MPSHeapAllocatorImpl {
   size_t m_low_watermark_limit;
   // use "PYTORCH_DEBUG_MPS_ALLOCATOR" env-var to set debug verbosity
   uint32_t m_debug_verbosity;
-  // Solo allocator: direct per-buffer MTLBuffer for large tensors; bypasses MTLHeap
-  // sub-allocation. Threshold comes from the shared accelerator config
-  // (mps_large_alloc_threshold_mb, read via MPSAllocatorConfig on the alloc path).
-  // All access is under m_mutex (alloc/free/emptyCache paths all hold it).
-  // Per-size free list: size_bytes -> retained id<MTLBuffer> (as void* to avoid ObjC ARC in header)
-  std::unordered_multimap<size_t, void*> m_solo_cache;
-  // Freed solo buffers still referenced by an in-flight command buffer, parked
-  // here until freeInactiveBuffers() reclaims them to m_solo_cache (mirrors the
-  // heap pool's buffers_pending_free).
-  std::unordered_set<BufferBlock*> m_solo_pending_free;
   // default MPS stream
   MPSStream* m_stream;
   // we hold a reference to MPSEventPool so it could get destroyed after MPSAllocator
@@ -451,8 +449,6 @@ class MPSHeapAllocatorImpl {
   // waits for buffers parked in-flight in the pool's pending-free list to finish
   // on the GPU and returns them to the pool; returns true if any were reclaimed
   bool wait_for_pending_free_buffers(BufferPool& pool);
-  // release all cached (freed) solo buffers back to the driver
-  void release_cached_solo_buffers();
   // release fully free heaps to reclaim GPU memory if memory pressure is high
   void garbage_collect_cached_buffers(AllocParams& params);
   // places a buffer on the block's range, or releases the one placed on it

--- a/aten/src/ATen/mps/MPSAllocator.h
+++ b/aten/src/ATen/mps/MPSAllocator.h
@@ -9,8 +9,10 @@
 #include <c10/util/flat_hash_map.h>
 #include <mach/vm_page_size.h>
 #include <cstdio>
+#include <atomic>
 #include <mutex>
 #include <set>
+#include <unordered_map>
 #include <unordered_set>
 
 // this implementation is based on CUDACachingAllocator.
@@ -76,6 +78,10 @@ struct BufferBlock {
   std::vector<int64_t> shape;
   bool in_use = false;
   HeapBlock* heap;
+  // For heap-less "solo" buffers, records the usage flags that a heap-backed
+  // buffer would carry on its pool, so shared-buffer queries can treat a shared
+  // solo buffer as shared. Unused (0) for heap-backed buffers.
+  uint32_t usage = 0;
   id_t buf_id = 0;
   uint32_t use_count = 0;
   // counter to assign unique ids to buffer blocks
@@ -417,6 +423,12 @@ class MPSHeapAllocatorImpl {
   size_t m_low_watermark_limit;
   // use "PYTORCH_DEBUG_MPS_ALLOCATOR" env-var to set debug verbosity
   uint32_t m_debug_verbosity;
+  // Solo allocator: direct per-buffer MTLBuffer for large tensors; bypasses MTLHeap
+  // sub-allocation. Threshold comes from the shared accelerator config
+  // (mps_large_alloc_threshold_mb, read via MPSAllocatorConfig on the alloc path).
+  // Per-size free list: size_bytes -> retained id<MTLBuffer> (as void* to avoid ObjC ARC in header)
+  std::mutex m_solo_mutex;
+  std::unordered_multimap<size_t, void*> m_solo_cache;
   // default MPS stream
   MPSStream* m_stream;
   // we hold a reference to MPSEventPool so it could get destroyed after MPSAllocator
@@ -436,6 +448,8 @@ class MPSHeapAllocatorImpl {
   // waits for buffers parked in-flight in the pool's pending-free list to finish
   // on the GPU and returns them to the pool; returns true if any were reclaimed
   bool wait_for_pending_free_buffers(BufferPool& pool);
+  // release all cached (freed) solo buffers back to the driver
+  void release_cached_solo_buffers();
   // release fully free heaps to reclaim GPU memory if memory pressure is high
   void garbage_collect_cached_buffers(AllocParams& params);
   // places a buffer on the block's range, or releases the one placed on it

--- a/aten/src/ATen/mps/MPSAllocator.mm
+++ b/aten/src/ATen/mps/MPSAllocator.mm
@@ -30,9 +30,10 @@ static std::atomic<bool> s_mps_allocator_initialized{false};
 // MPS-specific allocator settings, parsed from the shared accelerator config
 // (PYTORCH_ALLOC_CONF, or torch._C._accelerator_setAllocatorSettings), the same
 // way CUDAAllocatorConfig registers a device parser hook. The only MPS key is
-// `mps_large_alloc_threshold_mb`: tensors at or above this size get a dedicated
-// MTLBuffer (the "solo" path) instead of MTLHeap sub-allocation. 0 (the default)
-// disables it.
+// `mps_large_alloc_threshold_mb`: tensors at or above this size get their own
+// right-sized, non-split OVERSIZE heap (see HeapAllocator::getHeapTier) instead
+// of sharing a 1 GiB XLARGE heap. 0 (the default) leaves the XLARGE/OVERSIZE
+// boundary at its built-in kXLargeHeap/2 cutoff.
 class MPSAllocatorConfig {
  public:
   static MPSAllocatorConfig& instance() {
@@ -52,21 +53,21 @@ class MPSAllocatorConfig {
     return keys;
   }
 
-  size_t solo_threshold_bytes() const {
-    return m_solo_threshold_bytes.load();
+  size_t large_alloc_threshold_bytes() const {
+    return m_large_alloc_threshold_bytes.load();
   }
 
   void parseArgs(const std::string& env) {
     // Reset to the default (disabled) if the key is not present, matching the
     // shared AcceleratorAllocatorConfig::parseArgs convention: each settings
     // string is a full spec, so omitting the key reverts to default.
-    m_solo_threshold_bytes.store(0);
+    m_large_alloc_threshold_bytes.store(0);
     c10::CachingAllocator::ConfigTokenizer tokenizer(env);
     for (size_t i = 0; i < tokenizer.size(); i++) {
       const auto& key = tokenizer[i];
       if (key == "mps_large_alloc_threshold_mb") {
         tokenizer.checkToken(++i, ":");
-        m_solo_threshold_bytes.store(tokenizer.toSizeT(++i) * 1024ull * 1024ull);
+        m_large_alloc_threshold_bytes.store(tokenizer.toSizeT(++i) * 1024ull * 1024ull);
       } else {
         const auto& shared_keys = c10::CachingAllocator::AcceleratorAllocatorConfig::getKeys();
         TORCH_CHECK(
@@ -81,7 +82,7 @@ class MPSAllocatorConfig {
 
  private:
   MPSAllocatorConfig() = default;
-  std::atomic<size_t> m_solo_threshold_bytes{0};
+  std::atomic<size_t> m_large_alloc_threshold_bytes{0};
 };
 
 REGISTER_ALLOCATOR_CONFIG_PARSE_HOOK(MPSAllocatorConfig)
@@ -160,8 +161,10 @@ size_t MPSHeapAllocatorImpl::get_allocation_size(size_t size, uint32_t usage) co
   // Keep the request in its original heap-size class (see getHeapTier): never let
   // rounding cross into a larger class, which would reserve a much larger backing
   // heap, nor push it past Metal's per-buffer limit.
+  const size_t oversize_threshold_bytes = MPSAllocatorConfig::instance().large_alloc_threshold_bytes();
   if (bucketed >= m_max_buffer_size ||
-      getHeapTier(bucketed, /*has_memory_pressure=*/false) != getHeapTier(aligned, /*has_memory_pressure=*/false)) {
+      getHeapTier(bucketed, /*has_memory_pressure=*/false, oversize_threshold_bytes) !=
+          getHeapTier(aligned, /*has_memory_pressure=*/false, oversize_threshold_bytes)) {
     return aligned;
   }
   return bucketed;
@@ -475,88 +478,17 @@ size_t MPSHeapAllocatorImpl::release_free_heaps(BufferPool& pool, size_t target_
 BufferBlock* MPSHeapAllocatorImpl::alloc_buffer_block(size_t size, uint32_t usage, bool allow_in_flight_reuse) {
   TORCH_CHECK(size < m_max_buffer_size, "Invalid buffer size: ", format_size(size));
 
-  // Solo allocator: bypass the heap for large tensors. Sizes are bucketed the
-  // same way as the heap path (get_allocation_size) so a slowly growing
-  // allocation reuses the previous buffer, and the free list is keyed on that
-  // bucketed size.
-  const size_t solo_threshold = MPSAllocatorConfig::instance().solo_threshold_bytes();
-  if (solo_threshold > 0 && size >= solo_threshold) {
-    const size_t alloc_size = get_allocation_size(size, usage);
-    id<MTLBuffer> buf = nil;
-    {
-      auto it = m_solo_cache.find(alloc_size);
-      if (it != m_solo_cache.end()) {
-        buf = (id<MTLBuffer>)it->second;
-        m_solo_cache.erase(it);
-      }
-    }
-    if (!buf) {
-      // Solo buffers must be hazard-tracked: a freed one is recycled directly to
-      // a new allocation, and without tracking Metal will not order a new use
-      // against a still-in-flight prior use of the same buffer (data corruption).
-      const MTLResourceOptions options = HeapBlock::getOptions(usage | UsageFlags::HAZARD);
-      // Honor the high-watermark limit and, on failure, free cached memory and
-      // retry, mirroring the heap path so solo allocations raise the same OOM
-      // error instead of silently returning a null buffer.
-      auto within_limit = [&]() {
-        return m_max_total_allowed_size == std::numeric_limits<size_t>::max() ||
-            current_allocated_size() + alloc_size <= m_max_total_allowed_size;
-      };
-      if (within_limit()) {
-        buf = [m_device newBufferWithLength:alloc_size options:options];
-      }
-      if (!buf) {
-        // release_cached_buffers() syncs the GPU (COMMIT_AND_WAIT), so draining
-        // the solo free list afterwards is safe.
-        release_cached_buffers();
-        release_cached_solo_buffers();
-        if (within_limit()) {
-          buf = [m_device newBufferWithLength:alloc_size options:options];
-        }
-      }
-      if (!buf) {
-        if (m_high_watermark_ratio > 0.0) {
-          TORCH_CHECK(
-              false,
-              "MPS backend out of memory (MPS allocated: ",
-              format_size(m_total_allocated_memory.current),
-              ", other allocations: ",
-              format_size(current_allocated_size() - m_total_allocated_memory.current),
-              ", max allowed: ",
-              format_size(m_max_total_allowed_size),
-              "). Tried to allocate ",
-              format_size(alloc_size),
-              " as a solo buffer. Use PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0 to disable upper limit for memory allocations (may cause system failure).");
-        } else {
-          TORCH_CHECK(false,
-                      "MPS backend out of memory (MPS allocated: ",
-                      format_size(m_total_allocated_memory.current),
-                      ", other allocations: ",
-                      format_size(current_allocated_size() - m_total_allocated_memory.current),
-                      "). Tried to allocate ",
-                      format_size(alloc_size),
-                      " as a solo buffer.");
-        }
-      }
-      m_total_allocated_memory.increase(alloc_size);
-    }
-    BufferBlock* buffer_block = new BufferBlock(alloc_size, /*offset=*/0, /*heap=*/nullptr);
-    buffer_block->buffer = buf;
-    buffer_block->requested_size = size;
-    buffer_block->usage = usage;
-    m_allocated_buffers[buffer_block->buffer] = buffer_block;
-    buffer_block->in_use = true;
-    buffer_block->use_count++;
-    m_current_allocated_memory.increase(alloc_size);
-    return buffer_block;
-  }
-
   size_t alloc_size = get_allocation_size(size, usage);
   auto& pool = get_pool(size, alloc_size, usage);
   AllocParams params(alloc_size, size, &pool, allow_in_flight_reuse);
   // we care about memory pressure if only we're allocating large buffers when the
   // low watermark limit has been reached
   params.has_memory_pressure = !(pool.usage & UsageFlags::SMALL) && getLowWatermarkValue() <= 0;
+  // Lowers the OVERSIZE cutoff (see HeapAllocator::getHeapTier) so a large-but-
+  // sub-512MB tensor gets a dedicated, non-split heap instead of sharing a 1 GiB
+  // XLARGE heap with everything else in that size class. 0 (the default) keeps
+  // the built-in kXLargeHeap/2 cutoff.
+  params.oversize_threshold_bytes = MPSAllocatorConfig::instance().large_alloc_threshold_bytes();
 
   // first, try to get a block from the existing pool.
   bool block_found = get_free_buffer(params);
@@ -734,15 +666,11 @@ id<MTLBuffer> MPSHeapAllocatorImpl::malloc_host(size_t size, uint32_t usage) {
   return buffer_block ? buffer_block->buffer : nullptr;
 }
 
-// A heap-less "solo" buffer records its usage flags on the block itself; heap-
-// backed buffers carry them on their pool. Both let shared-buffer queries treat
-// a shared solo buffer (unified memory) as shared.
 static bool block_is_shared(const BufferBlock* buffer_block) {
   if (!buffer_block) {
     return false;
   }
-  const uint32_t usage = buffer_block->heap ? buffer_block->heap->pool->usage : buffer_block->usage;
-  return usage & UsageFlags::SHARED;
+  return buffer_block->heap->pool->usage & UsageFlags::SHARED;
 }
 
 bool MPSHeapAllocatorImpl::isSharedBuffer(const void* ptr) {
@@ -935,23 +863,6 @@ void MPSHeapAllocatorImpl::free(void* ptr) {
 
     buffer_block = get_allocated_buffer_block(ptr);
     TORCH_INTERNAL_ASSERT(buffer_block);
-    // Solo buffer: return to per-size free list instead of heap pool.
-    if (buffer_block->heap == nullptr) {
-      m_allocated_buffers.erase(ptr);
-      m_current_allocated_memory.decrease(buffer_block->size);
-      // A solo buffer marked by recordEvents and still referenced by an in-flight
-      // command buffer must not be recycled yet: handing it to a new allocation
-      // could let the CPU overwrite it before the GPU is done. Park it;
-      // freeInactiveBuffers() returns it to the free list once its command buffer
-      // completes. Same rule as the heap path below.
-      if (buffer_block->event && buffer_block->retainCount() > 1) {
-        m_solo_pending_free.insert(buffer_block);
-      } else {
-        m_solo_cache.insert({buffer_block->size, (void*)buffer_block->buffer});
-        delete buffer_block;
-      }
-      return;
-    }
     BufferPool& pool = *buffer_block->heap->pool;
     if (!(pool.usage & UsageFlags::SCALAR)) {
       // A buffer marked by recordEvents (used by the GPU in a context where a
@@ -994,48 +905,11 @@ void MPSHeapAllocatorImpl::freeInactiveBuffers() {
       }
     }
   }
-  // Reclaim parked solo buffers whose command buffer has completed: return them
-  // to the per-size free list for reuse.
-  for (auto it = m_solo_pending_free.begin(), last = m_solo_pending_free.end(); it != last;) {
-    BufferBlock* buffer_block = *it;
-    if (buffer_block->retainCount() <= 1) {
-      m_solo_cache.insert({buffer_block->size, (void*)buffer_block->buffer});
-      it = m_solo_pending_free.erase(it);
-      delete buffer_block;
-    } else {
-      ++it;
-    }
-  }
-}
-
-void MPSHeapAllocatorImpl::release_cached_solo_buffers() {
-  // Callers (emptyCache, the alloc retry) run this after release_cached_buffers()
-  // has done a COMMIT_AND_WAIT, so the GPU is idle and parked buffers are safe to
-  // release too.
-  for (BufferBlock* buffer_block : m_solo_pending_free) {
-    m_total_allocated_memory.decrease(buffer_block->size);
-    id<MTLBuffer> buf = buffer_block->buffer;
-    [buf setPurgeableState:MTLPurgeableStateEmpty];
-    [buf release];
-    delete buffer_block;
-  }
-  m_solo_pending_free.clear();
-  for (auto& [sz, raw] : m_solo_cache) {
-    m_total_allocated_memory.decrease(sz);
-    id<MTLBuffer> buf = (id<MTLBuffer>)raw;
-    [buf setPurgeableState:MTLPurgeableStateEmpty];
-    [buf release];
-  }
-  m_solo_cache.clear();
 }
 
 void MPSHeapAllocatorImpl::emptyCache() {
   std::lock_guard<std::recursive_mutex> lock(m_mutex);
-  // Release heap pools first; the solo drain runs after the GPU is idle
-  // (release_cached_buffers does COMMIT_AND_WAIT) so Metal retainCounts have
-  // settled before we call [buf release].
   release_cached_buffers();
-  release_cached_solo_buffers();
 }
 
 ssize_t MPSHeapAllocatorImpl::getLowWatermarkValue() {

--- a/aten/src/ATen/mps/MPSAllocator.mm
+++ b/aten/src/ATen/mps/MPSAllocator.mm
@@ -4,6 +4,7 @@
 #include <ATen/EmptyTensor.h>
 #include <ATen/mps/MPSAllocator.h>
 #include <c10/core/Allocator.h>
+#include <c10/core/AllocatorConfig.h>
 #include <c10/core/Storage.h>
 #include <c10/util/Logging.h>
 #include <c10/util/env.h>
@@ -25,6 +26,65 @@ uint64_t HeapBlock::heap_counter = 0;
 // actually in use). Lets the registered c10 allocator report readiness via
 // DeviceAllocator::initialized() without forcing Metal initialization.
 static std::atomic<bool> s_mps_allocator_initialized{false};
+
+// MPS-specific allocator settings, parsed from the shared accelerator config
+// (PYTORCH_ALLOC_CONF, or torch._C._accelerator_setAllocatorSettings), the same
+// way CUDAAllocatorConfig registers a device parser hook. The only MPS key is
+// `mps_large_alloc_threshold_mb`: tensors at or above this size get a dedicated
+// MTLBuffer (the "solo" path) instead of MTLHeap sub-allocation. 0 (the default)
+// disables it.
+class MPSAllocatorConfig {
+ public:
+  static MPSAllocatorConfig& instance() {
+    static MPSAllocatorConfig* s_instance = ([]() {
+      auto* inst = new MPSAllocatorConfig();
+      auto env = c10::utils::get_env("PYTORCH_ALLOC_CONF");
+      if (env.has_value()) {
+        inst->parseArgs(env.value());
+      }
+      return inst;
+    })();
+    return *s_instance;
+  }
+
+  static const std::unordered_set<std::string>& getKeys() {
+    static std::unordered_set<std::string> keys{"mps_large_alloc_threshold_mb"};
+    return keys;
+  }
+
+  size_t solo_threshold_bytes() const {
+    return m_solo_threshold_bytes.load();
+  }
+
+  void parseArgs(const std::string& env) {
+    // Reset to the default (disabled) if the key is not present, matching the
+    // shared AcceleratorAllocatorConfig::parseArgs convention: each settings
+    // string is a full spec, so omitting the key reverts to default.
+    m_solo_threshold_bytes.store(0);
+    c10::CachingAllocator::ConfigTokenizer tokenizer(env);
+    for (size_t i = 0; i < tokenizer.size(); i++) {
+      const auto& key = tokenizer[i];
+      if (key == "mps_large_alloc_threshold_mb") {
+        tokenizer.checkToken(++i, ":");
+        m_solo_threshold_bytes.store(tokenizer.toSizeT(++i) * 1024ull * 1024ull);
+      } else {
+        const auto& shared_keys = c10::CachingAllocator::AcceleratorAllocatorConfig::getKeys();
+        TORCH_CHECK(
+            shared_keys.find(key) != shared_keys.end(), "Unrecognized key '", key, "' in MPS allocator config.");
+        i = tokenizer.skipKey(i);
+      }
+      if (i + 1 < tokenizer.size()) {
+        tokenizer.checkToken(++i, ",");
+      }
+    }
+  }
+
+ private:
+  MPSAllocatorConfig() = default;
+  std::atomic<size_t> m_solo_threshold_bytes{0};
+};
+
+REGISTER_ALLOCATOR_CONFIG_PARSE_HOOK(MPSAllocatorConfig)
 
 void MPSHeapAllocatorImpl::init_allocator() {
   TORCH_CHECK(m_device.hasUnifiedMemory, "MPS backend is only supported on devices with unified memory");
@@ -415,6 +475,80 @@ size_t MPSHeapAllocatorImpl::release_free_heaps(BufferPool& pool, size_t target_
 BufferBlock* MPSHeapAllocatorImpl::alloc_buffer_block(size_t size, uint32_t usage, bool allow_in_flight_reuse) {
   TORCH_CHECK(size < m_max_buffer_size, "Invalid buffer size: ", format_size(size));
 
+  // Solo allocator: bypass the heap for large tensors. Sizes are bucketed the
+  // same way as the heap path (get_allocation_size) so a slowly growing
+  // allocation reuses the previous buffer, and the free list is keyed on that
+  // bucketed size.
+  const size_t solo_threshold = MPSAllocatorConfig::instance().solo_threshold_bytes();
+  if (solo_threshold > 0 && size >= solo_threshold) {
+    const size_t alloc_size = get_allocation_size(size, usage);
+    id<MTLBuffer> buf = nil;
+    {
+      std::lock_guard<std::mutex> solo_lock(m_solo_mutex);
+      auto it = m_solo_cache.find(alloc_size);
+      if (it != m_solo_cache.end()) {
+        buf = (id<MTLBuffer>)it->second;
+        m_solo_cache.erase(it);
+      }
+    }
+    if (!buf) {
+      const MTLResourceOptions options = HeapBlock::getOptions(usage);
+      // Honor the high-watermark limit and, on failure, free cached memory and
+      // retry, mirroring the heap path so solo allocations raise the same OOM
+      // error instead of silently returning a null buffer.
+      auto within_limit = [&]() {
+        return m_max_total_allowed_size == std::numeric_limits<size_t>::max() ||
+            current_allocated_size() + alloc_size <= m_max_total_allowed_size;
+      };
+      if (within_limit()) {
+        buf = [m_device newBufferWithLength:alloc_size options:options];
+      }
+      if (!buf) {
+        // release_cached_buffers() syncs the GPU (COMMIT_AND_WAIT), so draining
+        // the solo free list afterwards is safe.
+        release_cached_buffers();
+        release_cached_solo_buffers();
+        if (within_limit()) {
+          buf = [m_device newBufferWithLength:alloc_size options:options];
+        }
+      }
+      if (!buf) {
+        if (m_high_watermark_ratio > 0.0) {
+          TORCH_CHECK(
+              false,
+              "MPS backend out of memory (MPS allocated: ",
+              format_size(m_total_allocated_memory.current),
+              ", other allocations: ",
+              format_size(current_allocated_size() - m_total_allocated_memory.current),
+              ", max allowed: ",
+              format_size(m_max_total_allowed_size),
+              "). Tried to allocate ",
+              format_size(alloc_size),
+              " as a solo buffer. Use PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0 to disable upper limit for memory allocations (may cause system failure).");
+        } else {
+          TORCH_CHECK(false,
+                      "MPS backend out of memory (MPS allocated: ",
+                      format_size(m_total_allocated_memory.current),
+                      ", other allocations: ",
+                      format_size(current_allocated_size() - m_total_allocated_memory.current),
+                      "). Tried to allocate ",
+                      format_size(alloc_size),
+                      " as a solo buffer.");
+        }
+      }
+      m_total_allocated_memory.increase(alloc_size);
+    }
+    BufferBlock* buffer_block = new BufferBlock(alloc_size, /*offset=*/0, /*heap=*/nullptr);
+    buffer_block->buffer = buf;
+    buffer_block->requested_size = size;
+    buffer_block->usage = usage;
+    m_allocated_buffers[buffer_block->buffer] = buffer_block;
+    buffer_block->in_use = true;
+    buffer_block->use_count++;
+    m_current_allocated_memory.increase(alloc_size);
+    return buffer_block;
+  }
+
   size_t alloc_size = get_allocation_size(size, usage);
   auto& pool = get_pool(size, alloc_size, usage);
   AllocParams params(alloc_size, size, &pool, allow_in_flight_reuse);
@@ -598,12 +732,23 @@ id<MTLBuffer> MPSHeapAllocatorImpl::malloc_host(size_t size, uint32_t usage) {
   return buffer_block ? buffer_block->buffer : nullptr;
 }
 
+// A heap-less "solo" buffer records its usage flags on the block itself; heap-
+// backed buffers carry them on their pool. Both let shared-buffer queries treat
+// a shared solo buffer (unified memory) as shared.
+static bool block_is_shared(const BufferBlock* buffer_block) {
+  if (!buffer_block) {
+    return false;
+  }
+  const uint32_t usage = buffer_block->heap ? buffer_block->heap->pool->usage : buffer_block->usage;
+  return usage & UsageFlags::SHARED;
+}
+
 bool MPSHeapAllocatorImpl::isSharedBuffer(const void* ptr) {
   std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
   BufferBlock* buffer_block = get_allocated_buffer_block(ptr);
   // it's OK for the buffer_block to not exist yet
-  return buffer_block && (buffer_block->heap->pool->usage & UsageFlags::SHARED);
+  return block_is_shared(buffer_block);
 }
 
 id<MTLBuffer> MPSHeapAllocatorImpl::allocScalarBufferWithValue(void* value, size_t size) {
@@ -629,7 +774,7 @@ std::pair<const void*, uint32_t> MPSHeapAllocatorImpl::getSharedBufferPtr(const 
 
   BufferBlock* buffer_block = get_allocated_buffer_block(ptr);
   // return if buffer was not allocated on MPSAllocator or isn't a Shared buffer
-  if (!buffer_block || !(buffer_block->heap->pool->usage & UsageFlags::SHARED)) {
+  if (!buffer_block || !block_is_shared(buffer_block)) {
     return {nullptr, 0};
   }
   if (!buffer_block->cpu_ptr) {
@@ -656,7 +801,7 @@ c10::Storage MPSHeapAllocatorImpl::getHostAliasStorage(const c10::Storage& mps_s
   std::lock_guard<std::recursive_mutex> lock(m_mutex);
   BufferBlock* buffer_block = get_allocated_buffer_block(mps_storage.data());
   TORCH_CHECK(buffer_block, "getHostAliasStorage: storage was not allocated by the MPSAllocator");
-  TORCH_CHECK(buffer_block->heap->pool->usage & UsageFlags::SHARED,
+  TORCH_CHECK(block_is_shared(buffer_block),
               "getHostAliasStorage: storage is not backed by a shared (unified) MTLBuffer");
 
   if (!buffer_block->cpu_ptr) {
@@ -682,7 +827,7 @@ bool MPSHeapAllocatorImpl::recordEvents(c10::ArrayRef<const void*> buffers) {
   for (const auto& buffer : buffers) {
     BufferBlock* buffer_block = get_allocated_buffer_block(buffer);
     // return if buffer was not allocated on MPSAllocator or isn't a Shared buffer
-    if (buffer_block && (buffer_block->heap->pool->usage & UsageFlags::SHARED)) {
+    if (block_is_shared(buffer_block)) {
       if (!buffer_block->event) {
         buffer_block->event = m_event_pool->acquireEvent(false, nullptr);
         TORCH_INTERNAL_ASSERT_DEBUG_ONLY(buffer_block->event);
@@ -702,8 +847,7 @@ bool MPSHeapAllocatorImpl::waitForEvents(c10::ArrayRef<const void*> buffers) {
       BufferBlock* buffer_block = get_allocated_buffer_block(buffer);
       // wait on event if "shared" buffer was allocated on MPSAllocator and
       // or actually needs waiting (based on retainCount)
-      if (buffer_block && (buffer_block->heap->pool->usage & UsageFlags::SHARED) && buffer_block->retainCount() > 1 &&
-          buffer_block->event) {
+      if (block_is_shared(buffer_block) && buffer_block->retainCount() > 1 && buffer_block->event) {
         buffer_blocks.push_back(buffer_block);
       }
     }
@@ -789,6 +933,16 @@ void MPSHeapAllocatorImpl::free(void* ptr) {
 
     buffer_block = get_allocated_buffer_block(ptr);
     TORCH_INTERNAL_ASSERT(buffer_block);
+    // Solo buffer: return to per-size free list instead of heap pool.
+    if (buffer_block->heap == nullptr) {
+      m_allocated_buffers.erase(ptr);
+      m_current_allocated_memory.decrease(buffer_block->size);
+      void* raw = (void*)buffer_block->buffer;
+      std::lock_guard<std::mutex> solo_lock(m_solo_mutex);
+      m_solo_cache.insert({buffer_block->size, raw});
+      delete buffer_block;
+      return;
+    }
     BufferPool& pool = *buffer_block->heap->pool;
     if (!(pool.usage & UsageFlags::SCALAR)) {
       // A buffer marked by recordEvents (used by the GPU in a context where a
@@ -833,9 +987,24 @@ void MPSHeapAllocatorImpl::freeInactiveBuffers() {
   }
 }
 
+void MPSHeapAllocatorImpl::release_cached_solo_buffers() {
+  std::lock_guard<std::mutex> solo_lock(m_solo_mutex);
+  for (auto& [sz, raw] : m_solo_cache) {
+    m_total_allocated_memory.decrease(sz);
+    id<MTLBuffer> buf = (id<MTLBuffer>)raw;
+    [buf setPurgeableState:MTLPurgeableStateEmpty];
+    [buf release];
+  }
+  m_solo_cache.clear();
+}
+
 void MPSHeapAllocatorImpl::emptyCache() {
   std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  // Release heap pools first; the solo drain runs after the GPU is idle
+  // (release_cached_buffers does COMMIT_AND_WAIT) so Metal retainCounts have
+  // settled before we call [buf release].
   release_cached_buffers();
+  release_cached_solo_buffers();
 }
 
 ssize_t MPSHeapAllocatorImpl::getLowWatermarkValue() {

--- a/aten/src/ATen/mps/MPSAllocator.mm
+++ b/aten/src/ATen/mps/MPSAllocator.mm
@@ -484,7 +484,6 @@ BufferBlock* MPSHeapAllocatorImpl::alloc_buffer_block(size_t size, uint32_t usag
     const size_t alloc_size = get_allocation_size(size, usage);
     id<MTLBuffer> buf = nil;
     {
-      std::lock_guard<std::mutex> solo_lock(m_solo_mutex);
       auto it = m_solo_cache.find(alloc_size);
       if (it != m_solo_cache.end()) {
         buf = (id<MTLBuffer>)it->second;
@@ -492,7 +491,10 @@ BufferBlock* MPSHeapAllocatorImpl::alloc_buffer_block(size_t size, uint32_t usag
       }
     }
     if (!buf) {
-      const MTLResourceOptions options = HeapBlock::getOptions(usage);
+      // Solo buffers must be hazard-tracked: a freed one is recycled directly to
+      // a new allocation, and without tracking Metal will not order a new use
+      // against a still-in-flight prior use of the same buffer (data corruption).
+      const MTLResourceOptions options = HeapBlock::getOptions(usage | UsageFlags::HAZARD);
       // Honor the high-watermark limit and, on failure, free cached memory and
       // retry, mirroring the heap path so solo allocations raise the same OOM
       // error instead of silently returning a null buffer.
@@ -937,10 +939,17 @@ void MPSHeapAllocatorImpl::free(void* ptr) {
     if (buffer_block->heap == nullptr) {
       m_allocated_buffers.erase(ptr);
       m_current_allocated_memory.decrease(buffer_block->size);
-      void* raw = (void*)buffer_block->buffer;
-      std::lock_guard<std::mutex> solo_lock(m_solo_mutex);
-      m_solo_cache.insert({buffer_block->size, raw});
-      delete buffer_block;
+      // A solo buffer marked by recordEvents and still referenced by an in-flight
+      // command buffer must not be recycled yet: handing it to a new allocation
+      // could let the CPU overwrite it before the GPU is done. Park it;
+      // freeInactiveBuffers() returns it to the free list once its command buffer
+      // completes. Same rule as the heap path below.
+      if (buffer_block->event && buffer_block->retainCount() > 1) {
+        m_solo_pending_free.insert(buffer_block);
+      } else {
+        m_solo_cache.insert({buffer_block->size, (void*)buffer_block->buffer});
+        delete buffer_block;
+      }
       return;
     }
     BufferPool& pool = *buffer_block->heap->pool;
@@ -985,10 +994,32 @@ void MPSHeapAllocatorImpl::freeInactiveBuffers() {
       }
     }
   }
+  // Reclaim parked solo buffers whose command buffer has completed: return them
+  // to the per-size free list for reuse.
+  for (auto it = m_solo_pending_free.begin(), last = m_solo_pending_free.end(); it != last;) {
+    BufferBlock* buffer_block = *it;
+    if (buffer_block->retainCount() <= 1) {
+      m_solo_cache.insert({buffer_block->size, (void*)buffer_block->buffer});
+      it = m_solo_pending_free.erase(it);
+      delete buffer_block;
+    } else {
+      ++it;
+    }
+  }
 }
 
 void MPSHeapAllocatorImpl::release_cached_solo_buffers() {
-  std::lock_guard<std::mutex> solo_lock(m_solo_mutex);
+  // Callers (emptyCache, the alloc retry) run this after release_cached_buffers()
+  // has done a COMMIT_AND_WAIT, so the GPU is idle and parked buffers are safe to
+  // release too.
+  for (BufferBlock* buffer_block : m_solo_pending_free) {
+    m_total_allocated_memory.decrease(buffer_block->size);
+    id<MTLBuffer> buf = buffer_block->buffer;
+    [buf setPurgeableState:MTLPurgeableStateEmpty];
+    [buf release];
+    delete buffer_block;
+  }
+  m_solo_pending_free.clear();
   for (auto& [sz, raw] : m_solo_cache) {
     m_total_allocated_memory.decrease(sz);
     id<MTLBuffer> buf = (id<MTLBuffer>)raw;

--- a/aten/src/ATen/mps/MPSAllocator.mm
+++ b/aten/src/ATen/mps/MPSAllocator.mm
@@ -30,9 +30,10 @@ static std::atomic<bool> s_mps_allocator_initialized{false};
 // MPS-specific allocator settings, parsed from the shared accelerator config
 // (PYTORCH_ALLOC_CONF, or torch._C._accelerator_setAllocatorSettings), the same
 // way CUDAAllocatorConfig registers a device parser hook. The only MPS key is
-// `mps_large_alloc_threshold_mb`: tensors at or above this size get a dedicated
-// MTLBuffer (the "solo" path) instead of MTLHeap sub-allocation. 0 (the default)
-// disables it.
+// `mps_large_alloc_threshold_mb`: tensors at or above this size get their own
+// right-sized, non-split OVERSIZE heap (see HeapAllocator::getHeapTier) instead
+// of sharing a 1 GiB XLARGE heap. 0 (the default) leaves the XLARGE/OVERSIZE
+// boundary at its built-in kXLargeHeap/2 cutoff.
 class MPSAllocatorConfig {
  public:
   static MPSAllocatorConfig& instance() {
@@ -52,21 +53,21 @@ class MPSAllocatorConfig {
     return keys;
   }
 
-  size_t solo_threshold_bytes() const {
-    return m_solo_threshold_bytes.load();
+  size_t large_alloc_threshold_bytes() const {
+    return m_large_alloc_threshold_bytes.load();
   }
 
   void parseArgs(const std::string& env) {
     // Reset to the default (disabled) if the key is not present, matching the
     // shared AcceleratorAllocatorConfig::parseArgs convention: each settings
     // string is a full spec, so omitting the key reverts to default.
-    m_solo_threshold_bytes.store(0);
+    m_large_alloc_threshold_bytes.store(0);
     c10::CachingAllocator::ConfigTokenizer tokenizer(env);
     for (size_t i = 0; i < tokenizer.size(); i++) {
       const auto& key = tokenizer[i];
       if (key == "mps_large_alloc_threshold_mb") {
         tokenizer.checkToken(++i, ":");
-        m_solo_threshold_bytes.store(tokenizer.toSizeT(++i) * 1024ull * 1024ull);
+        m_large_alloc_threshold_bytes.store(tokenizer.toSizeT(++i) * 1024ull * 1024ull);
       } else {
         const auto& shared_keys = c10::CachingAllocator::AcceleratorAllocatorConfig::getKeys();
         TORCH_CHECK(
@@ -81,7 +82,7 @@ class MPSAllocatorConfig {
 
  private:
   MPSAllocatorConfig() = default;
-  std::atomic<size_t> m_solo_threshold_bytes{0};
+  std::atomic<size_t> m_large_alloc_threshold_bytes{0};
 };
 
 REGISTER_ALLOCATOR_CONFIG_PARSE_HOOK(MPSAllocatorConfig)
@@ -160,8 +161,10 @@ size_t MPSHeapAllocatorImpl::get_allocation_size(size_t size, uint32_t usage) co
   // Keep the request in its original heap-size class (see getHeapTier): never let
   // rounding cross into a larger class, which would reserve a much larger backing
   // heap, nor push it past Metal's per-buffer limit.
+  const size_t oversize_threshold_bytes = MPSAllocatorConfig::instance().large_alloc_threshold_bytes();
   if (bucketed >= m_max_buffer_size ||
-      getHeapTier(bucketed, /*has_memory_pressure=*/false) != getHeapTier(aligned, /*has_memory_pressure=*/false)) {
+      getHeapTier(bucketed, /*has_memory_pressure=*/false, oversize_threshold_bytes) !=
+          getHeapTier(aligned, /*has_memory_pressure=*/false, oversize_threshold_bytes)) {
     return aligned;
   }
   return bucketed;
@@ -472,88 +475,17 @@ size_t MPSHeapAllocatorImpl::release_free_heaps(BufferPool& pool, size_t target_
 BufferBlock* MPSHeapAllocatorImpl::alloc_buffer_block(size_t size, uint32_t usage) {
   TORCH_CHECK(size < m_max_buffer_size, "Invalid buffer size: ", format_size(size));
 
-  // Solo allocator: bypass the heap for large tensors. Sizes are bucketed the
-  // same way as the heap path (get_allocation_size) so a slowly growing
-  // allocation reuses the previous buffer, and the free list is keyed on that
-  // bucketed size.
-  const size_t solo_threshold = MPSAllocatorConfig::instance().solo_threshold_bytes();
-  if (solo_threshold > 0 && size >= solo_threshold) {
-    const size_t alloc_size = get_allocation_size(size, usage);
-    id<MTLBuffer> buf = nil;
-    {
-      auto it = m_solo_cache.find(alloc_size);
-      if (it != m_solo_cache.end()) {
-        buf = (id<MTLBuffer>)it->second;
-        m_solo_cache.erase(it);
-      }
-    }
-    if (!buf) {
-      // Solo buffers must be hazard-tracked: a freed one is recycled directly to
-      // a new allocation, and without tracking Metal will not order a new use
-      // against a still-in-flight prior use of the same buffer (data corruption).
-      const MTLResourceOptions options = HeapBlock::getOptions(usage | UsageFlags::HAZARD);
-      // Honor the high-watermark limit and, on failure, free cached memory and
-      // retry, mirroring the heap path so solo allocations raise the same OOM
-      // error instead of silently returning a null buffer.
-      auto within_limit = [&]() {
-        return m_max_total_allowed_size == std::numeric_limits<size_t>::max() ||
-            current_allocated_size() + alloc_size <= m_max_total_allowed_size;
-      };
-      if (within_limit()) {
-        buf = [m_device newBufferWithLength:alloc_size options:options];
-      }
-      if (!buf) {
-        // release_cached_buffers() syncs the GPU (COMMIT_AND_WAIT), so draining
-        // the solo free list afterwards is safe.
-        release_cached_buffers();
-        release_cached_solo_buffers();
-        if (within_limit()) {
-          buf = [m_device newBufferWithLength:alloc_size options:options];
-        }
-      }
-      if (!buf) {
-        if (m_high_watermark_ratio > 0.0) {
-          TORCH_CHECK(
-              false,
-              "MPS backend out of memory (MPS allocated: ",
-              format_size(m_total_allocated_memory.current),
-              ", other allocations: ",
-              format_size(current_allocated_size() - m_total_allocated_memory.current),
-              ", max allowed: ",
-              format_size(m_max_total_allowed_size),
-              "). Tried to allocate ",
-              format_size(alloc_size),
-              " as a solo buffer. Use PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0 to disable upper limit for memory allocations (may cause system failure).");
-        } else {
-          TORCH_CHECK(false,
-                      "MPS backend out of memory (MPS allocated: ",
-                      format_size(m_total_allocated_memory.current),
-                      ", other allocations: ",
-                      format_size(current_allocated_size() - m_total_allocated_memory.current),
-                      "). Tried to allocate ",
-                      format_size(alloc_size),
-                      " as a solo buffer.");
-        }
-      }
-      m_total_allocated_memory.increase(alloc_size);
-    }
-    BufferBlock* buffer_block = new BufferBlock(alloc_size, /*offset=*/0, /*heap=*/nullptr);
-    buffer_block->buffer = buf;
-    buffer_block->requested_size = size;
-    buffer_block->usage = usage;
-    m_allocated_buffers[buffer_block->buffer] = buffer_block;
-    buffer_block->in_use = true;
-    buffer_block->use_count++;
-    m_current_allocated_memory.increase(alloc_size);
-    return buffer_block;
-  }
-
   size_t alloc_size = get_allocation_size(size, usage);
   auto& pool = get_pool(size, alloc_size, usage);
   AllocParams params(alloc_size, size, &pool);
   // we care about memory pressure if only we're allocating large buffers when the
   // low watermark limit has been reached
   params.has_memory_pressure = !(pool.usage & UsageFlags::SMALL) && getLowWatermarkValue() <= 0;
+  // Lowers the OVERSIZE cutoff (see HeapAllocator::getHeapTier) so a large-but-
+  // sub-512MB tensor gets a dedicated, non-split heap instead of sharing a 1 GiB
+  // XLARGE heap with everything else in that size class. 0 (the default) keeps
+  // the built-in kXLargeHeap/2 cutoff.
+  params.oversize_threshold_bytes = MPSAllocatorConfig::instance().large_alloc_threshold_bytes();
 
   // first, try to get a block from the existing pool.
   bool block_found = get_free_buffer(params);
@@ -723,15 +655,11 @@ id<MTLBuffer> MPSHeapAllocatorImpl::malloc(size_t size, uint32_t usage) {
   return buffer_block ? buffer_block->buffer : nullptr;
 }
 
-// A heap-less "solo" buffer records its usage flags on the block itself; heap-
-// backed buffers carry them on their pool. Both let shared-buffer queries treat
-// a shared solo buffer (unified memory) as shared.
 static bool block_is_shared(const BufferBlock* buffer_block) {
   if (!buffer_block) {
     return false;
   }
-  const uint32_t usage = buffer_block->heap ? buffer_block->heap->pool->usage : buffer_block->usage;
-  return usage & UsageFlags::SHARED;
+  return buffer_block->heap->pool->usage & UsageFlags::SHARED;
 }
 
 bool MPSHeapAllocatorImpl::isSharedBuffer(const void* ptr) {
@@ -924,23 +852,6 @@ void MPSHeapAllocatorImpl::free(void* ptr) {
 
     buffer_block = get_allocated_buffer_block(ptr);
     TORCH_INTERNAL_ASSERT(buffer_block);
-    // Solo buffer: return to per-size free list instead of heap pool.
-    if (buffer_block->heap == nullptr) {
-      m_allocated_buffers.erase(ptr);
-      m_current_allocated_memory.decrease(buffer_block->size);
-      // A solo buffer marked by recordEvents and still referenced by an in-flight
-      // command buffer must not be recycled yet: handing it to a new allocation
-      // could let the CPU overwrite it before the GPU is done. Park it;
-      // freeInactiveBuffers() returns it to the free list once its command buffer
-      // completes. Same rule as the heap path below.
-      if (buffer_block->event && buffer_block->retainCount() > 1) {
-        m_solo_pending_free.insert(buffer_block);
-      } else {
-        m_solo_cache.insert({buffer_block->size, (void*)buffer_block->buffer});
-        delete buffer_block;
-      }
-      return;
-    }
     BufferPool& pool = *buffer_block->heap->pool;
     if (!(pool.usage & UsageFlags::SCALAR)) {
       // A buffer marked by recordEvents (used by the GPU in a context where a
@@ -983,48 +894,11 @@ void MPSHeapAllocatorImpl::freeInactiveBuffers() {
       }
     }
   }
-  // Reclaim parked solo buffers whose command buffer has completed: return them
-  // to the per-size free list for reuse.
-  for (auto it = m_solo_pending_free.begin(), last = m_solo_pending_free.end(); it != last;) {
-    BufferBlock* buffer_block = *it;
-    if (buffer_block->retainCount() <= 1) {
-      m_solo_cache.insert({buffer_block->size, (void*)buffer_block->buffer});
-      it = m_solo_pending_free.erase(it);
-      delete buffer_block;
-    } else {
-      ++it;
-    }
-  }
-}
-
-void MPSHeapAllocatorImpl::release_cached_solo_buffers() {
-  // Callers (emptyCache, the alloc retry) run this after release_cached_buffers()
-  // has done a COMMIT_AND_WAIT, so the GPU is idle and parked buffers are safe to
-  // release too.
-  for (BufferBlock* buffer_block : m_solo_pending_free) {
-    m_total_allocated_memory.decrease(buffer_block->size);
-    id<MTLBuffer> buf = buffer_block->buffer;
-    [buf setPurgeableState:MTLPurgeableStateEmpty];
-    [buf release];
-    delete buffer_block;
-  }
-  m_solo_pending_free.clear();
-  for (auto& [sz, raw] : m_solo_cache) {
-    m_total_allocated_memory.decrease(sz);
-    id<MTLBuffer> buf = (id<MTLBuffer>)raw;
-    [buf setPurgeableState:MTLPurgeableStateEmpty];
-    [buf release];
-  }
-  m_solo_cache.clear();
 }
 
 void MPSHeapAllocatorImpl::emptyCache() {
   std::lock_guard<std::recursive_mutex> lock(m_mutex);
-  // Release heap pools first; the solo drain runs after the GPU is idle
-  // (release_cached_buffers does COMMIT_AND_WAIT) so Metal retainCounts have
-  // settled before we call [buf release].
   release_cached_buffers();
-  release_cached_solo_buffers();
 }
 
 ssize_t MPSHeapAllocatorImpl::getLowWatermarkValue() {

--- a/aten/src/ATen/mps/MPSAllocator.mm
+++ b/aten/src/ATen/mps/MPSAllocator.mm
@@ -4,6 +4,7 @@
 #include <ATen/EmptyTensor.h>
 #include <ATen/mps/MPSAllocator.h>
 #include <c10/core/Allocator.h>
+#include <c10/core/AllocatorConfig.h>
 #include <c10/core/Storage.h>
 #include <c10/util/Logging.h>
 #include <c10/util/env.h>
@@ -25,6 +26,65 @@ uint64_t HeapBlock::heap_counter = 0;
 // actually in use). Lets the registered c10 allocator report readiness via
 // DeviceAllocator::initialized() without forcing Metal initialization.
 static std::atomic<bool> s_mps_allocator_initialized{false};
+
+// MPS-specific allocator settings, parsed from the shared accelerator config
+// (PYTORCH_ALLOC_CONF, or torch._C._accelerator_setAllocatorSettings), the same
+// way CUDAAllocatorConfig registers a device parser hook. The only MPS key is
+// `mps_large_alloc_threshold_mb`: tensors at or above this size get a dedicated
+// MTLBuffer (the "solo" path) instead of MTLHeap sub-allocation. 0 (the default)
+// disables it.
+class MPSAllocatorConfig {
+ public:
+  static MPSAllocatorConfig& instance() {
+    static MPSAllocatorConfig* s_instance = ([]() {
+      auto* inst = new MPSAllocatorConfig();
+      auto env = c10::utils::get_env("PYTORCH_ALLOC_CONF");
+      if (env.has_value()) {
+        inst->parseArgs(env.value());
+      }
+      return inst;
+    })();
+    return *s_instance;
+  }
+
+  static const std::unordered_set<std::string>& getKeys() {
+    static std::unordered_set<std::string> keys{"mps_large_alloc_threshold_mb"};
+    return keys;
+  }
+
+  size_t solo_threshold_bytes() const {
+    return m_solo_threshold_bytes.load();
+  }
+
+  void parseArgs(const std::string& env) {
+    // Reset to the default (disabled) if the key is not present, matching the
+    // shared AcceleratorAllocatorConfig::parseArgs convention: each settings
+    // string is a full spec, so omitting the key reverts to default.
+    m_solo_threshold_bytes.store(0);
+    c10::CachingAllocator::ConfigTokenizer tokenizer(env);
+    for (size_t i = 0; i < tokenizer.size(); i++) {
+      const auto& key = tokenizer[i];
+      if (key == "mps_large_alloc_threshold_mb") {
+        tokenizer.checkToken(++i, ":");
+        m_solo_threshold_bytes.store(tokenizer.toSizeT(++i) * 1024ull * 1024ull);
+      } else {
+        const auto& shared_keys = c10::CachingAllocator::AcceleratorAllocatorConfig::getKeys();
+        TORCH_CHECK(
+            shared_keys.find(key) != shared_keys.end(), "Unrecognized key '", key, "' in MPS allocator config.");
+        i = tokenizer.skipKey(i);
+      }
+      if (i + 1 < tokenizer.size()) {
+        tokenizer.checkToken(++i, ",");
+      }
+    }
+  }
+
+ private:
+  MPSAllocatorConfig() = default;
+  std::atomic<size_t> m_solo_threshold_bytes{0};
+};
+
+REGISTER_ALLOCATOR_CONFIG_PARSE_HOOK(MPSAllocatorConfig)
 
 void MPSHeapAllocatorImpl::init_allocator() {
   TORCH_CHECK(m_device.hasUnifiedMemory, "MPS backend is only supported on devices with unified memory");
@@ -412,6 +472,80 @@ size_t MPSHeapAllocatorImpl::release_free_heaps(BufferPool& pool, size_t target_
 BufferBlock* MPSHeapAllocatorImpl::alloc_buffer_block(size_t size, uint32_t usage) {
   TORCH_CHECK(size < m_max_buffer_size, "Invalid buffer size: ", format_size(size));
 
+  // Solo allocator: bypass the heap for large tensors. Sizes are bucketed the
+  // same way as the heap path (get_allocation_size) so a slowly growing
+  // allocation reuses the previous buffer, and the free list is keyed on that
+  // bucketed size.
+  const size_t solo_threshold = MPSAllocatorConfig::instance().solo_threshold_bytes();
+  if (solo_threshold > 0 && size >= solo_threshold) {
+    const size_t alloc_size = get_allocation_size(size, usage);
+    id<MTLBuffer> buf = nil;
+    {
+      std::lock_guard<std::mutex> solo_lock(m_solo_mutex);
+      auto it = m_solo_cache.find(alloc_size);
+      if (it != m_solo_cache.end()) {
+        buf = (id<MTLBuffer>)it->second;
+        m_solo_cache.erase(it);
+      }
+    }
+    if (!buf) {
+      const MTLResourceOptions options = HeapBlock::getOptions(usage);
+      // Honor the high-watermark limit and, on failure, free cached memory and
+      // retry, mirroring the heap path so solo allocations raise the same OOM
+      // error instead of silently returning a null buffer.
+      auto within_limit = [&]() {
+        return m_max_total_allowed_size == std::numeric_limits<size_t>::max() ||
+            current_allocated_size() + alloc_size <= m_max_total_allowed_size;
+      };
+      if (within_limit()) {
+        buf = [m_device newBufferWithLength:alloc_size options:options];
+      }
+      if (!buf) {
+        // release_cached_buffers() syncs the GPU (COMMIT_AND_WAIT), so draining
+        // the solo free list afterwards is safe.
+        release_cached_buffers();
+        release_cached_solo_buffers();
+        if (within_limit()) {
+          buf = [m_device newBufferWithLength:alloc_size options:options];
+        }
+      }
+      if (!buf) {
+        if (m_high_watermark_ratio > 0.0) {
+          TORCH_CHECK(
+              false,
+              "MPS backend out of memory (MPS allocated: ",
+              format_size(m_total_allocated_memory.current),
+              ", other allocations: ",
+              format_size(current_allocated_size() - m_total_allocated_memory.current),
+              ", max allowed: ",
+              format_size(m_max_total_allowed_size),
+              "). Tried to allocate ",
+              format_size(alloc_size),
+              " as a solo buffer. Use PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0 to disable upper limit for memory allocations (may cause system failure).");
+        } else {
+          TORCH_CHECK(false,
+                      "MPS backend out of memory (MPS allocated: ",
+                      format_size(m_total_allocated_memory.current),
+                      ", other allocations: ",
+                      format_size(current_allocated_size() - m_total_allocated_memory.current),
+                      "). Tried to allocate ",
+                      format_size(alloc_size),
+                      " as a solo buffer.");
+        }
+      }
+      m_total_allocated_memory.increase(alloc_size);
+    }
+    BufferBlock* buffer_block = new BufferBlock(alloc_size, /*offset=*/0, /*heap=*/nullptr);
+    buffer_block->buffer = buf;
+    buffer_block->requested_size = size;
+    buffer_block->usage = usage;
+    m_allocated_buffers[buffer_block->buffer] = buffer_block;
+    buffer_block->in_use = true;
+    buffer_block->use_count++;
+    m_current_allocated_memory.increase(alloc_size);
+    return buffer_block;
+  }
+
   size_t alloc_size = get_allocation_size(size, usage);
   auto& pool = get_pool(size, alloc_size, usage);
   AllocParams params(alloc_size, size, &pool);
@@ -587,12 +721,23 @@ id<MTLBuffer> MPSHeapAllocatorImpl::malloc(size_t size, uint32_t usage) {
   return buffer_block ? buffer_block->buffer : nullptr;
 }
 
+// A heap-less "solo" buffer records its usage flags on the block itself; heap-
+// backed buffers carry them on their pool. Both let shared-buffer queries treat
+// a shared solo buffer (unified memory) as shared.
+static bool block_is_shared(const BufferBlock* buffer_block) {
+  if (!buffer_block) {
+    return false;
+  }
+  const uint32_t usage = buffer_block->heap ? buffer_block->heap->pool->usage : buffer_block->usage;
+  return usage & UsageFlags::SHARED;
+}
+
 bool MPSHeapAllocatorImpl::isSharedBuffer(const void* ptr) {
   std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
   BufferBlock* buffer_block = get_allocated_buffer_block(ptr);
   // it's OK for the buffer_block to not exist yet
-  return buffer_block && (buffer_block->heap->pool->usage & UsageFlags::SHARED);
+  return block_is_shared(buffer_block);
 }
 
 id<MTLBuffer> MPSHeapAllocatorImpl::allocScalarBufferWithValue(void* value, size_t size) {
@@ -618,7 +763,7 @@ std::pair<const void*, uint32_t> MPSHeapAllocatorImpl::getSharedBufferPtr(const 
 
   BufferBlock* buffer_block = get_allocated_buffer_block(ptr);
   // return if buffer was not allocated on MPSAllocator or isn't a Shared buffer
-  if (!buffer_block || !(buffer_block->heap->pool->usage & UsageFlags::SHARED)) {
+  if (!buffer_block || !block_is_shared(buffer_block)) {
     return {nullptr, 0};
   }
   if (!buffer_block->cpu_ptr) {
@@ -645,7 +790,7 @@ c10::Storage MPSHeapAllocatorImpl::getHostAliasStorage(const c10::Storage& mps_s
   std::lock_guard<std::recursive_mutex> lock(m_mutex);
   BufferBlock* buffer_block = get_allocated_buffer_block(mps_storage.data());
   TORCH_CHECK(buffer_block, "getHostAliasStorage: storage was not allocated by the MPSAllocator");
-  TORCH_CHECK(buffer_block->heap->pool->usage & UsageFlags::SHARED,
+  TORCH_CHECK(block_is_shared(buffer_block),
               "getHostAliasStorage: storage is not backed by a shared (unified) MTLBuffer");
 
   if (!buffer_block->cpu_ptr) {
@@ -671,7 +816,7 @@ bool MPSHeapAllocatorImpl::recordEvents(c10::ArrayRef<const void*> buffers) {
   for (const auto& buffer : buffers) {
     BufferBlock* buffer_block = get_allocated_buffer_block(buffer);
     // return if buffer was not allocated on MPSAllocator or isn't a Shared buffer
-    if (buffer_block && (buffer_block->heap->pool->usage & UsageFlags::SHARED)) {
+    if (block_is_shared(buffer_block)) {
       if (!buffer_block->event) {
         buffer_block->event = m_event_pool->acquireEvent(false, nullptr);
         TORCH_INTERNAL_ASSERT_DEBUG_ONLY(buffer_block->event);
@@ -691,8 +836,7 @@ bool MPSHeapAllocatorImpl::waitForEvents(c10::ArrayRef<const void*> buffers) {
       BufferBlock* buffer_block = get_allocated_buffer_block(buffer);
       // wait on event if "shared" buffer was allocated on MPSAllocator and
       // or actually needs waiting (based on retainCount)
-      if (buffer_block && (buffer_block->heap->pool->usage & UsageFlags::SHARED) && buffer_block->retainCount() > 1 &&
-          buffer_block->event) {
+      if (block_is_shared(buffer_block) && buffer_block->retainCount() > 1 && buffer_block->event) {
         buffer_blocks.push_back(buffer_block);
       }
     }
@@ -778,6 +922,16 @@ void MPSHeapAllocatorImpl::free(void* ptr) {
 
     buffer_block = get_allocated_buffer_block(ptr);
     TORCH_INTERNAL_ASSERT(buffer_block);
+    // Solo buffer: return to per-size free list instead of heap pool.
+    if (buffer_block->heap == nullptr) {
+      m_allocated_buffers.erase(ptr);
+      m_current_allocated_memory.decrease(buffer_block->size);
+      void* raw = (void*)buffer_block->buffer;
+      std::lock_guard<std::mutex> solo_lock(m_solo_mutex);
+      m_solo_cache.insert({buffer_block->size, raw});
+      delete buffer_block;
+      return;
+    }
     BufferPool& pool = *buffer_block->heap->pool;
     if (!(pool.usage & UsageFlags::SCALAR)) {
       // A buffer marked by recordEvents (used by the GPU in a context where a
@@ -822,9 +976,24 @@ void MPSHeapAllocatorImpl::freeInactiveBuffers() {
   }
 }
 
+void MPSHeapAllocatorImpl::release_cached_solo_buffers() {
+  std::lock_guard<std::mutex> solo_lock(m_solo_mutex);
+  for (auto& [sz, raw] : m_solo_cache) {
+    m_total_allocated_memory.decrease(sz);
+    id<MTLBuffer> buf = (id<MTLBuffer>)raw;
+    [buf setPurgeableState:MTLPurgeableStateEmpty];
+    [buf release];
+  }
+  m_solo_cache.clear();
+}
+
 void MPSHeapAllocatorImpl::emptyCache() {
   std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  // Release heap pools first; the solo drain runs after the GPU is idle
+  // (release_cached_buffers does COMMIT_AND_WAIT) so Metal retainCounts have
+  // settled before we call [buf release].
   release_cached_buffers();
+  release_cached_solo_buffers();
 }
 
 ssize_t MPSHeapAllocatorImpl::getLowWatermarkValue() {

--- a/aten/src/ATen/mps/MPSAllocator.mm
+++ b/aten/src/ATen/mps/MPSAllocator.mm
@@ -481,7 +481,6 @@ BufferBlock* MPSHeapAllocatorImpl::alloc_buffer_block(size_t size, uint32_t usag
     const size_t alloc_size = get_allocation_size(size, usage);
     id<MTLBuffer> buf = nil;
     {
-      std::lock_guard<std::mutex> solo_lock(m_solo_mutex);
       auto it = m_solo_cache.find(alloc_size);
       if (it != m_solo_cache.end()) {
         buf = (id<MTLBuffer>)it->second;
@@ -489,7 +488,10 @@ BufferBlock* MPSHeapAllocatorImpl::alloc_buffer_block(size_t size, uint32_t usag
       }
     }
     if (!buf) {
-      const MTLResourceOptions options = HeapBlock::getOptions(usage);
+      // Solo buffers must be hazard-tracked: a freed one is recycled directly to
+      // a new allocation, and without tracking Metal will not order a new use
+      // against a still-in-flight prior use of the same buffer (data corruption).
+      const MTLResourceOptions options = HeapBlock::getOptions(usage | UsageFlags::HAZARD);
       // Honor the high-watermark limit and, on failure, free cached memory and
       // retry, mirroring the heap path so solo allocations raise the same OOM
       // error instead of silently returning a null buffer.
@@ -926,10 +928,17 @@ void MPSHeapAllocatorImpl::free(void* ptr) {
     if (buffer_block->heap == nullptr) {
       m_allocated_buffers.erase(ptr);
       m_current_allocated_memory.decrease(buffer_block->size);
-      void* raw = (void*)buffer_block->buffer;
-      std::lock_guard<std::mutex> solo_lock(m_solo_mutex);
-      m_solo_cache.insert({buffer_block->size, raw});
-      delete buffer_block;
+      // A solo buffer marked by recordEvents and still referenced by an in-flight
+      // command buffer must not be recycled yet: handing it to a new allocation
+      // could let the CPU overwrite it before the GPU is done. Park it;
+      // freeInactiveBuffers() returns it to the free list once its command buffer
+      // completes. Same rule as the heap path below.
+      if (buffer_block->event && buffer_block->retainCount() > 1) {
+        m_solo_pending_free.insert(buffer_block);
+      } else {
+        m_solo_cache.insert({buffer_block->size, (void*)buffer_block->buffer});
+        delete buffer_block;
+      }
       return;
     }
     BufferPool& pool = *buffer_block->heap->pool;
@@ -974,10 +983,32 @@ void MPSHeapAllocatorImpl::freeInactiveBuffers() {
       }
     }
   }
+  // Reclaim parked solo buffers whose command buffer has completed: return them
+  // to the per-size free list for reuse.
+  for (auto it = m_solo_pending_free.begin(), last = m_solo_pending_free.end(); it != last;) {
+    BufferBlock* buffer_block = *it;
+    if (buffer_block->retainCount() <= 1) {
+      m_solo_cache.insert({buffer_block->size, (void*)buffer_block->buffer});
+      it = m_solo_pending_free.erase(it);
+      delete buffer_block;
+    } else {
+      ++it;
+    }
+  }
 }
 
 void MPSHeapAllocatorImpl::release_cached_solo_buffers() {
-  std::lock_guard<std::mutex> solo_lock(m_solo_mutex);
+  // Callers (emptyCache, the alloc retry) run this after release_cached_buffers()
+  // has done a COMMIT_AND_WAIT, so the GPU is idle and parked buffers are safe to
+  // release too.
+  for (BufferBlock* buffer_block : m_solo_pending_free) {
+    m_total_allocated_memory.decrease(buffer_block->size);
+    id<MTLBuffer> buf = buffer_block->buffer;
+    [buf setPurgeableState:MTLPurgeableStateEmpty];
+    [buf release];
+    delete buffer_block;
+  }
+  m_solo_pending_free.clear();
   for (auto& [sz, raw] : m_solo_cache) {
     m_total_allocated_memory.decrease(sz);
     id<MTLBuffer> buf = (id<MTLBuffer>)raw;

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9695,6 +9695,115 @@ class TestMPS(TestCaseMPS):
         print(f"Recommended Max Memory : {max_memory / 1024 ** 3} GB")
         self.assertGreater(max_memory, 0)
 
+    def _reset_solo_allocator(self):
+        torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:0")
+        torch.mps.empty_cache()
+        self.addCleanup(torch._C._accelerator_setAllocatorSettings, "mps_large_alloc_threshold_mb:0")
+        self.addCleanup(torch.mps.empty_cache)
+
+    def test_enable_reduces_pool_growth(self):
+        """Solo allocation should not trigger a 1 GB heap block."""
+        self._reset_solo_allocator()
+        baseline = torch.mps.driver_allocated_memory()
+
+        torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:10")
+        t = torch.zeros(50 * 1024 * 1024 // 4, device='mps')  # 50 MB
+        grow = torch.mps.driver_allocated_memory() - baseline
+
+        self.assertLess(grow, 200 * 1024 * 1024,
+            f"Expected < 200 MB pool growth, got {grow / 1024**2:.0f} MB")
+        del t
+
+    def test_reuse_on_same_size(self):
+        """Freed solo buffer should be recycled on next same-size request."""
+        self._reset_solo_allocator()
+        torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:10")
+        SIZE = 30 * 1024 * 1024 // 4  # 30 MB
+
+        t1 = torch.zeros(SIZE, device='mps')
+        del t1
+        gc.collect()
+
+        pool_after_free = torch.mps.driver_allocated_memory()
+        t2 = torch.zeros(SIZE, device='mps')
+        pool_after_reuse = torch.mps.driver_allocated_memory()
+
+        self.assertLess(abs(pool_after_reuse - pool_after_free), 10 * 1024 * 1024,
+            "Same-size second allocation should reuse cached solo buffer")
+        del t2
+
+    def test_empty_cache_releases_solo_buffers(self):
+        """empty_cache() should drain the solo free list."""
+        self._reset_solo_allocator()
+        torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:10")
+        torch.mps.empty_cache()
+        baseline = torch.mps.driver_allocated_memory()
+
+        t = torch.zeros(50 * 1024 * 1024 // 4, device='mps')
+        del t
+        gc.collect()
+        torch.mps.empty_cache()
+
+        after = torch.mps.driver_allocated_memory()
+        self.assertAlmostEqual(after, baseline, delta=10 * 1024 * 1024,
+            msg="Pool should return to baseline after empty_cache")
+
+    def test_tensor_is_functional(self):
+        """Solo-allocated tensor should work with all standard ops."""
+        self._reset_solo_allocator()
+        torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:10")
+        N = 30 * 1024 * 1024 // 4
+        t = torch.zeros(N, device='mps')
+        self.assertEqual(t.device.type, 'mps')
+        self.assertEqual(t.sum().item(), 0.0)
+
+        t.fill_(1.0)
+        self.assertAlmostEqual(t.sum().item(), float(N), delta=1.0)
+
+        t2 = torch.ones(N, device='mps', requires_grad=True)
+        loss = (t2 * 2).sum()
+        loss.backward()
+        self.assertAlmostEqual(t2.grad.sum().item(), float(N) * 2, delta=1.0)
+
+    def test_solo_respects_memory_limit(self):
+        """Solo allocation honors the high-watermark limit and raises a clean OOM
+        RuntimeError instead of returning a null buffer."""
+        self._reset_solo_allocator()
+        torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:10")
+        self.addCleanup(torch.mps.set_per_process_memory_fraction, 0.0)
+        torch.mps.set_per_process_memory_fraction(0.001)
+        # 10x the limit, and well above the 10 MB solo threshold, so the request
+        # exceeds the watermark regardless of device memory size.
+        n = int(0.01 * torch.mps.recommended_max_memory() / 4)
+        with self.assertRaisesRegex(RuntimeError, "out of memory"):
+            torch.zeros(n, device='mps')
+
+    def test_solo_buffer_is_shared(self):
+        """Solo large buffers are still unified/shared, so shared-buffer paths
+        (non_blocking host copies) work as on the heap path."""
+        self._reset_solo_allocator()
+        torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:10")
+        n = 30 * 1024 * 1024 // 4  # 30 MB, above the threshold
+        src = torch.arange(n, dtype=torch.float32)
+        d = src.to('mps', non_blocking=True)
+        back = d.to('cpu', non_blocking=True)
+        torch.mps.synchronize()
+        self.assertEqual(back, src)
+
+    def test_heap_mode_restored(self):
+        """Setting the threshold to 0 should revert to default 1 GB heap behaviour."""
+        self._reset_solo_allocator()
+        torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:10")
+        torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:0")
+        torch.mps.empty_cache()
+        baseline = torch.mps.driver_allocated_memory()
+
+        t = torch.zeros(50 * 1024 * 1024 // 4, device='mps')  # 50 MB -> 1 GB heap
+        grow = torch.mps.driver_allocated_memory() - baseline
+        del t
+        self.assertGreater(grow, 900 * 1024 * 1024,
+            "heap mode should still use 1 GB block for large allocation")
+
     def test_host_alias_storage(self):
         n = 1024
         dtype = torch.float32
@@ -17217,6 +17326,7 @@ class TestCommon(TestCase):
             mps_tensor = ones(device)
             cpu_tensor = ones("cpu")
             self.assertEqual(mps_tensor.cpu(), cpu_tensor)
+
 
 class TestMetalLibrary(TestCaseMPS):
     def test_metal_arange(self):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9695,15 +9695,15 @@ class TestMPS(TestCaseMPS):
         print(f"Recommended Max Memory : {max_memory / 1024 ** 3} GB")
         self.assertGreater(max_memory, 0)
 
-    def _reset_solo_allocator(self):
+    def _reset_large_alloc_threshold(self):
         torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:0")
         torch.mps.empty_cache()
         self.addCleanup(torch._C._accelerator_setAllocatorSettings, "mps_large_alloc_threshold_mb:0")
         self.addCleanup(torch.mps.empty_cache)
 
     def test_enable_reduces_pool_growth(self):
-        """Solo allocation should not trigger a 1 GB heap block."""
-        self._reset_solo_allocator()
+        """Lowering the OVERSIZE threshold should not trigger a 1 GB heap block."""
+        self._reset_large_alloc_threshold()
         baseline = torch.mps.driver_allocated_memory()
 
         torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:10")
@@ -9715,8 +9715,8 @@ class TestMPS(TestCaseMPS):
         del t
 
     def test_reuse_on_same_size(self):
-        """Freed solo buffer should be recycled on next same-size request."""
-        self._reset_solo_allocator()
+        """A freed OVERSIZE-tier buffer should be recycled on the next same-size request."""
+        self._reset_large_alloc_threshold()
         torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:10")
         SIZE = 30 * 1024 * 1024 // 4  # 30 MB
 
@@ -9729,12 +9729,12 @@ class TestMPS(TestCaseMPS):
         pool_after_reuse = torch.mps.driver_allocated_memory()
 
         self.assertLess(abs(pool_after_reuse - pool_after_free), 10 * 1024 * 1024,
-            "Same-size second allocation should reuse cached solo buffer")
+            "Same-size second allocation should reuse the cached OVERSIZE-tier heap")
         del t2
 
-    def test_empty_cache_releases_solo_buffers(self):
-        """empty_cache() should drain the solo free list."""
-        self._reset_solo_allocator()
+    def test_empty_cache_releases_oversize_buffers(self):
+        """empty_cache() should release OVERSIZE-tier heaps like any other tier."""
+        self._reset_large_alloc_threshold()
         torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:10")
         torch.mps.empty_cache()
         baseline = torch.mps.driver_allocated_memory()
@@ -9749,8 +9749,8 @@ class TestMPS(TestCaseMPS):
             msg="Pool should return to baseline after empty_cache")
 
     def test_tensor_is_functional(self):
-        """Solo-allocated tensor should work with all standard ops."""
-        self._reset_solo_allocator()
+        """An OVERSIZE-tier tensor should work with all standard ops."""
+        self._reset_large_alloc_threshold()
         torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:10")
         N = 30 * 1024 * 1024 // 4
         t = torch.zeros(N, device='mps')
@@ -9765,23 +9765,23 @@ class TestMPS(TestCaseMPS):
         loss.backward()
         self.assertAlmostEqual(t2.grad.sum().item(), float(N) * 2, delta=1.0)
 
-    def test_solo_respects_memory_limit(self):
-        """Solo allocation honors the high-watermark limit and raises a clean OOM
-        RuntimeError instead of returning a null buffer."""
-        self._reset_solo_allocator()
+    def test_oversize_threshold_respects_memory_limit(self):
+        """Lowering the OVERSIZE threshold still honors the high-watermark limit
+        and raises a clean OOM RuntimeError instead of returning a null buffer."""
+        self._reset_large_alloc_threshold()
         torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:10")
         self.addCleanup(torch.mps.set_per_process_memory_fraction, 0.0)
         torch.mps.set_per_process_memory_fraction(0.001)
-        # 10x the limit, and well above the 10 MB solo threshold, so the request
+        # 10x the limit, and well above the 10 MB threshold, so the request
         # exceeds the watermark regardless of device memory size.
         n = int(0.01 * torch.mps.recommended_max_memory() / 4)
         with self.assertRaisesRegex(RuntimeError, "out of memory"):
             torch.zeros(n, device='mps')
 
-    def test_solo_buffer_is_shared(self):
-        """Solo large buffers are still unified/shared, so shared-buffer paths
-        (non_blocking host copies) work as on the heap path."""
-        self._reset_solo_allocator()
+    def test_oversize_threshold_buffer_is_shared(self):
+        """OVERSIZE-tier buffers are still unified/shared, so shared-buffer paths
+        (non_blocking host copies) work the same as any other tier."""
+        self._reset_large_alloc_threshold()
         torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:10")
         n = 30 * 1024 * 1024 // 4  # 30 MB, above the threshold
         src = torch.arange(n, dtype=torch.float32)
@@ -9790,16 +9790,17 @@ class TestMPS(TestCaseMPS):
         torch.mps.synchronize()
         self.assertEqual(back, src)
 
-    def test_solo_no_corruption_on_reuse(self):
-        """A recycled solo buffer must not corrupt data still referenced by an
-        in-flight command buffer: solo buffers are hazard-tracked, and one still
-        used by a pending copy is parked (not recycled) until its GPU work ends."""
-        self._reset_solo_allocator()
+    def test_oversize_threshold_no_corruption_on_reuse(self):
+        """Lowering the OVERSIZE threshold must not weaken the tier's existing
+        safety guarantees: a recycled heap is hazard-tracked like every other
+        tier, and one still referenced by an in-flight command buffer is parked
+        (not recycled) until its GPU work ends."""
+        self._reset_large_alloc_threshold()
         torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:10")
         N = 30 * 1024 * 1024 // 4  # 30 MB, above the threshold
 
         # (a) hazard tracking: queue a device->host copy behind GPU work, free the
-        # source, force a same-size solo reuse; the copied data must stay intact.
+        # source, force a same-size reuse; the copied data must stay intact.
         a = torch.empty(N, device="mps").fill_(1.0)
         junk = torch.randn(4096, 4096, device="mps")
         for _ in range(60):
@@ -9823,12 +9824,37 @@ class TestMPS(TestCaseMPS):
         q = torch.empty(N, pin_memory=True)
         q.fill_(2.0)
         torch.mps.synchronize()
-        self.assertEqual(int((d != 1.0).sum().item()), 0, "recycled in-flight solo buffer was overwritten")
+        self.assertEqual(int((d != 1.0).sum().item()), 0, "recycled in-flight buffer was overwritten")
         del d, q, junk
+
+    def test_oversize_alloc_recovers_reclaimable_memory_without_empty_cache(self):
+        """A heap-tier allocation must succeed by draining freed OVERSIZE-tier
+        heaps through the normal OOM-recovery cascade, without the caller having
+        to call empty_cache() explicitly. (Regression test: the deleted "solo"
+        path had its own free list, invisible to this cascade, so a heap
+        allocation could spuriously OOM while trivially reclaimable memory sat
+        in that separate cache.)"""
+        self._reset_large_alloc_threshold()
+        self.addCleanup(torch.mps.set_per_process_memory_fraction, 0.0)
+        torch.mps.set_per_process_memory_fraction(0.5)
+        rec = torch.mps.recommended_max_memory()
+        n = int(0.3 * rec / 4)
+
+        torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:10")
+        a = torch.empty(n, device="mps")
+        del a
+        gc.collect()
+        torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:0")
+
+        # Same-size heap-tier allocation must succeed without an intervening
+        # empty_cache(): the freed OVERSIZE heap from above must already be
+        # visible to the normal alloc_heap()/release_free_heaps() cascade.
+        b = torch.empty(n, device="mps")
+        del b
 
     def test_heap_mode_restored(self):
         """Setting the threshold to 0 should revert to default 1 GB heap behaviour."""
-        self._reset_solo_allocator()
+        self._reset_large_alloc_threshold()
         torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:10")
         torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:0")
         torch.mps.empty_cache()

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9790,6 +9790,42 @@ class TestMPS(TestCaseMPS):
         torch.mps.synchronize()
         self.assertEqual(back, src)
 
+    def test_solo_no_corruption_on_reuse(self):
+        """A recycled solo buffer must not corrupt data still referenced by an
+        in-flight command buffer: solo buffers are hazard-tracked, and one still
+        used by a pending copy is parked (not recycled) until its GPU work ends."""
+        self._reset_solo_allocator()
+        torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:10")
+        N = 30 * 1024 * 1024 // 4  # 30 MB, above the threshold
+
+        # (a) hazard tracking: queue a device->host copy behind GPU work, free the
+        # source, force a same-size solo reuse; the copied data must stay intact.
+        a = torch.empty(N, device="mps").fill_(1.0)
+        junk = torch.randn(4096, 4096, device="mps")
+        for _ in range(60):
+            junk = junk @ junk
+        back = torch.empty(N, pin_memory=True)
+        back.copy_(a, non_blocking=True)
+        del a
+        b = torch.full((N,), 2.0).to("mps")  # same size -> candidate for reuse
+        torch.mps.synchronize()
+        self.assertEqual(int((back != 1.0).sum()), 0, "hazard-tracked reuse corrupted an in-flight copy")
+        del b, junk
+
+        # (b) pending-free: a pinned buffer read by an in-flight blit must not be
+        # handed to a new allocation and CPU-overwritten before the GPU is done.
+        p = torch.empty(N, pin_memory=True).fill_(1.0)
+        junk = torch.randn(4096, 4096, device="mps")
+        for _ in range(60):
+            junk = junk @ junk
+        d = p.to("mps", non_blocking=True)
+        del p
+        q = torch.empty(N, pin_memory=True)
+        q.fill_(2.0)
+        torch.mps.synchronize()
+        self.assertEqual(int((d != 1.0).sum().item()), 0, "recycled in-flight solo buffer was overwritten")
+        del d, q, junk
+
     def test_heap_mode_restored(self):
         """Setting the threshold to 0 should revert to default 1 GB heap behaviour."""
         self._reset_solo_allocator()

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9549,6 +9549,115 @@ class TestMPS(TestCaseMPS):
         print(f"Recommended Max Memory : {max_memory / 1024 ** 3} GB")
         self.assertGreater(max_memory, 0)
 
+    def _reset_solo_allocator(self):
+        torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:0")
+        torch.mps.empty_cache()
+        self.addCleanup(torch._C._accelerator_setAllocatorSettings, "mps_large_alloc_threshold_mb:0")
+        self.addCleanup(torch.mps.empty_cache)
+
+    def test_enable_reduces_pool_growth(self):
+        """Solo allocation should not trigger a 1 GB heap block."""
+        self._reset_solo_allocator()
+        baseline = torch.mps.driver_allocated_memory()
+
+        torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:10")
+        t = torch.zeros(50 * 1024 * 1024 // 4, device='mps')  # 50 MB
+        grow = torch.mps.driver_allocated_memory() - baseline
+
+        self.assertLess(grow, 200 * 1024 * 1024,
+            f"Expected < 200 MB pool growth, got {grow / 1024**2:.0f} MB")
+        del t
+
+    def test_reuse_on_same_size(self):
+        """Freed solo buffer should be recycled on next same-size request."""
+        self._reset_solo_allocator()
+        torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:10")
+        SIZE = 30 * 1024 * 1024 // 4  # 30 MB
+
+        t1 = torch.zeros(SIZE, device='mps')
+        del t1
+        gc.collect()
+
+        pool_after_free = torch.mps.driver_allocated_memory()
+        t2 = torch.zeros(SIZE, device='mps')
+        pool_after_reuse = torch.mps.driver_allocated_memory()
+
+        self.assertLess(abs(pool_after_reuse - pool_after_free), 10 * 1024 * 1024,
+            "Same-size second allocation should reuse cached solo buffer")
+        del t2
+
+    def test_empty_cache_releases_solo_buffers(self):
+        """empty_cache() should drain the solo free list."""
+        self._reset_solo_allocator()
+        torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:10")
+        torch.mps.empty_cache()
+        baseline = torch.mps.driver_allocated_memory()
+
+        t = torch.zeros(50 * 1024 * 1024 // 4, device='mps')
+        del t
+        gc.collect()
+        torch.mps.empty_cache()
+
+        after = torch.mps.driver_allocated_memory()
+        self.assertAlmostEqual(after, baseline, delta=10 * 1024 * 1024,
+            msg="Pool should return to baseline after empty_cache")
+
+    def test_tensor_is_functional(self):
+        """Solo-allocated tensor should work with all standard ops."""
+        self._reset_solo_allocator()
+        torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:10")
+        N = 30 * 1024 * 1024 // 4
+        t = torch.zeros(N, device='mps')
+        self.assertEqual(t.device.type, 'mps')
+        self.assertEqual(t.sum().item(), 0.0)
+
+        t.fill_(1.0)
+        self.assertAlmostEqual(t.sum().item(), float(N), delta=1.0)
+
+        t2 = torch.ones(N, device='mps', requires_grad=True)
+        loss = (t2 * 2).sum()
+        loss.backward()
+        self.assertAlmostEqual(t2.grad.sum().item(), float(N) * 2, delta=1.0)
+
+    def test_solo_respects_memory_limit(self):
+        """Solo allocation honors the high-watermark limit and raises a clean OOM
+        RuntimeError instead of returning a null buffer."""
+        self._reset_solo_allocator()
+        torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:10")
+        self.addCleanup(torch.mps.set_per_process_memory_fraction, 0.0)
+        torch.mps.set_per_process_memory_fraction(0.001)
+        # 10x the limit, and well above the 10 MB solo threshold, so the request
+        # exceeds the watermark regardless of device memory size.
+        n = int(0.01 * torch.mps.recommended_max_memory() / 4)
+        with self.assertRaisesRegex(RuntimeError, "out of memory"):
+            torch.zeros(n, device='mps')
+
+    def test_solo_buffer_is_shared(self):
+        """Solo large buffers are still unified/shared, so shared-buffer paths
+        (non_blocking host copies) work as on the heap path."""
+        self._reset_solo_allocator()
+        torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:10")
+        n = 30 * 1024 * 1024 // 4  # 30 MB, above the threshold
+        src = torch.arange(n, dtype=torch.float32)
+        d = src.to('mps', non_blocking=True)
+        back = d.to('cpu', non_blocking=True)
+        torch.mps.synchronize()
+        self.assertEqual(back, src)
+
+    def test_heap_mode_restored(self):
+        """Setting the threshold to 0 should revert to default 1 GB heap behaviour."""
+        self._reset_solo_allocator()
+        torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:10")
+        torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:0")
+        torch.mps.empty_cache()
+        baseline = torch.mps.driver_allocated_memory()
+
+        t = torch.zeros(50 * 1024 * 1024 // 4, device='mps')  # 50 MB -> 1 GB heap
+        grow = torch.mps.driver_allocated_memory() - baseline
+        del t
+        self.assertGreater(grow, 900 * 1024 * 1024,
+            "heap mode should still use 1 GB block for large allocation")
+
     def test_host_alias_storage(self):
         n = 1024
         dtype = torch.float32
@@ -16792,6 +16901,7 @@ class TestCommon(TestCase):
             mps_tensor = ones(device)
             cpu_tensor = ones("cpu")
             self.assertEqual(mps_tensor.cpu(), cpu_tensor)
+
 
 class TestMetalLibrary(TestCaseMPS):
     def test_metal_arange(self):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9644,6 +9644,42 @@ class TestMPS(TestCaseMPS):
         torch.mps.synchronize()
         self.assertEqual(back, src)
 
+    def test_solo_no_corruption_on_reuse(self):
+        """A recycled solo buffer must not corrupt data still referenced by an
+        in-flight command buffer: solo buffers are hazard-tracked, and one still
+        used by a pending copy is parked (not recycled) until its GPU work ends."""
+        self._reset_solo_allocator()
+        torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:10")
+        N = 30 * 1024 * 1024 // 4  # 30 MB, above the threshold
+
+        # (a) hazard tracking: queue a device->host copy behind GPU work, free the
+        # source, force a same-size solo reuse; the copied data must stay intact.
+        a = torch.empty(N, device="mps").fill_(1.0)
+        junk = torch.randn(4096, 4096, device="mps")
+        for _ in range(60):
+            junk = junk @ junk
+        back = torch.empty(N, pin_memory=True)
+        back.copy_(a, non_blocking=True)
+        del a
+        b = torch.full((N,), 2.0).to("mps")  # same size -> candidate for reuse
+        torch.mps.synchronize()
+        self.assertEqual(int((back != 1.0).sum()), 0, "hazard-tracked reuse corrupted an in-flight copy")
+        del b, junk
+
+        # (b) pending-free: a pinned buffer read by an in-flight blit must not be
+        # handed to a new allocation and CPU-overwritten before the GPU is done.
+        p = torch.empty(N, pin_memory=True).fill_(1.0)
+        junk = torch.randn(4096, 4096, device="mps")
+        for _ in range(60):
+            junk = junk @ junk
+        d = p.to("mps", non_blocking=True)
+        del p
+        q = torch.empty(N, pin_memory=True)
+        q.fill_(2.0)
+        torch.mps.synchronize()
+        self.assertEqual(int((d != 1.0).sum().item()), 0, "recycled in-flight solo buffer was overwritten")
+        del d, q, junk
+
     def test_heap_mode_restored(self):
         """Setting the threshold to 0 should revert to default 1 GB heap behaviour."""
         self._reset_solo_allocator()

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9549,15 +9549,15 @@ class TestMPS(TestCaseMPS):
         print(f"Recommended Max Memory : {max_memory / 1024 ** 3} GB")
         self.assertGreater(max_memory, 0)
 
-    def _reset_solo_allocator(self):
+    def _reset_large_alloc_threshold(self):
         torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:0")
         torch.mps.empty_cache()
         self.addCleanup(torch._C._accelerator_setAllocatorSettings, "mps_large_alloc_threshold_mb:0")
         self.addCleanup(torch.mps.empty_cache)
 
     def test_enable_reduces_pool_growth(self):
-        """Solo allocation should not trigger a 1 GB heap block."""
-        self._reset_solo_allocator()
+        """Lowering the OVERSIZE threshold should not trigger a 1 GB heap block."""
+        self._reset_large_alloc_threshold()
         baseline = torch.mps.driver_allocated_memory()
 
         torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:10")
@@ -9569,8 +9569,8 @@ class TestMPS(TestCaseMPS):
         del t
 
     def test_reuse_on_same_size(self):
-        """Freed solo buffer should be recycled on next same-size request."""
-        self._reset_solo_allocator()
+        """A freed OVERSIZE-tier buffer should be recycled on the next same-size request."""
+        self._reset_large_alloc_threshold()
         torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:10")
         SIZE = 30 * 1024 * 1024 // 4  # 30 MB
 
@@ -9583,12 +9583,12 @@ class TestMPS(TestCaseMPS):
         pool_after_reuse = torch.mps.driver_allocated_memory()
 
         self.assertLess(abs(pool_after_reuse - pool_after_free), 10 * 1024 * 1024,
-            "Same-size second allocation should reuse cached solo buffer")
+            "Same-size second allocation should reuse the cached OVERSIZE-tier heap")
         del t2
 
-    def test_empty_cache_releases_solo_buffers(self):
-        """empty_cache() should drain the solo free list."""
-        self._reset_solo_allocator()
+    def test_empty_cache_releases_oversize_buffers(self):
+        """empty_cache() should release OVERSIZE-tier heaps like any other tier."""
+        self._reset_large_alloc_threshold()
         torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:10")
         torch.mps.empty_cache()
         baseline = torch.mps.driver_allocated_memory()
@@ -9603,8 +9603,8 @@ class TestMPS(TestCaseMPS):
             msg="Pool should return to baseline after empty_cache")
 
     def test_tensor_is_functional(self):
-        """Solo-allocated tensor should work with all standard ops."""
-        self._reset_solo_allocator()
+        """An OVERSIZE-tier tensor should work with all standard ops."""
+        self._reset_large_alloc_threshold()
         torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:10")
         N = 30 * 1024 * 1024 // 4
         t = torch.zeros(N, device='mps')
@@ -9619,23 +9619,23 @@ class TestMPS(TestCaseMPS):
         loss.backward()
         self.assertAlmostEqual(t2.grad.sum().item(), float(N) * 2, delta=1.0)
 
-    def test_solo_respects_memory_limit(self):
-        """Solo allocation honors the high-watermark limit and raises a clean OOM
-        RuntimeError instead of returning a null buffer."""
-        self._reset_solo_allocator()
+    def test_oversize_threshold_respects_memory_limit(self):
+        """Lowering the OVERSIZE threshold still honors the high-watermark limit
+        and raises a clean OOM RuntimeError instead of returning a null buffer."""
+        self._reset_large_alloc_threshold()
         torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:10")
         self.addCleanup(torch.mps.set_per_process_memory_fraction, 0.0)
         torch.mps.set_per_process_memory_fraction(0.001)
-        # 10x the limit, and well above the 10 MB solo threshold, so the request
+        # 10x the limit, and well above the 10 MB threshold, so the request
         # exceeds the watermark regardless of device memory size.
         n = int(0.01 * torch.mps.recommended_max_memory() / 4)
         with self.assertRaisesRegex(RuntimeError, "out of memory"):
             torch.zeros(n, device='mps')
 
-    def test_solo_buffer_is_shared(self):
-        """Solo large buffers are still unified/shared, so shared-buffer paths
-        (non_blocking host copies) work as on the heap path."""
-        self._reset_solo_allocator()
+    def test_oversize_threshold_buffer_is_shared(self):
+        """OVERSIZE-tier buffers are still unified/shared, so shared-buffer paths
+        (non_blocking host copies) work the same as any other tier."""
+        self._reset_large_alloc_threshold()
         torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:10")
         n = 30 * 1024 * 1024 // 4  # 30 MB, above the threshold
         src = torch.arange(n, dtype=torch.float32)
@@ -9644,16 +9644,17 @@ class TestMPS(TestCaseMPS):
         torch.mps.synchronize()
         self.assertEqual(back, src)
 
-    def test_solo_no_corruption_on_reuse(self):
-        """A recycled solo buffer must not corrupt data still referenced by an
-        in-flight command buffer: solo buffers are hazard-tracked, and one still
-        used by a pending copy is parked (not recycled) until its GPU work ends."""
-        self._reset_solo_allocator()
+    def test_oversize_threshold_no_corruption_on_reuse(self):
+        """Lowering the OVERSIZE threshold must not weaken the tier's existing
+        safety guarantees: a recycled heap is hazard-tracked like every other
+        tier, and one still referenced by an in-flight command buffer is parked
+        (not recycled) until its GPU work ends."""
+        self._reset_large_alloc_threshold()
         torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:10")
         N = 30 * 1024 * 1024 // 4  # 30 MB, above the threshold
 
         # (a) hazard tracking: queue a device->host copy behind GPU work, free the
-        # source, force a same-size solo reuse; the copied data must stay intact.
+        # source, force a same-size reuse; the copied data must stay intact.
         a = torch.empty(N, device="mps").fill_(1.0)
         junk = torch.randn(4096, 4096, device="mps")
         for _ in range(60):
@@ -9677,12 +9678,37 @@ class TestMPS(TestCaseMPS):
         q = torch.empty(N, pin_memory=True)
         q.fill_(2.0)
         torch.mps.synchronize()
-        self.assertEqual(int((d != 1.0).sum().item()), 0, "recycled in-flight solo buffer was overwritten")
+        self.assertEqual(int((d != 1.0).sum().item()), 0, "recycled in-flight buffer was overwritten")
         del d, q, junk
+
+    def test_oversize_alloc_recovers_reclaimable_memory_without_empty_cache(self):
+        """A heap-tier allocation must succeed by draining freed OVERSIZE-tier
+        heaps through the normal OOM-recovery cascade, without the caller having
+        to call empty_cache() explicitly. (Regression test: the deleted "solo"
+        path had its own free list, invisible to this cascade, so a heap
+        allocation could spuriously OOM while trivially reclaimable memory sat
+        in that separate cache.)"""
+        self._reset_large_alloc_threshold()
+        self.addCleanup(torch.mps.set_per_process_memory_fraction, 0.0)
+        torch.mps.set_per_process_memory_fraction(0.5)
+        rec = torch.mps.recommended_max_memory()
+        n = int(0.3 * rec / 4)
+
+        torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:10")
+        a = torch.empty(n, device="mps")
+        del a
+        gc.collect()
+        torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:0")
+
+        # Same-size heap-tier allocation must succeed without an intervening
+        # empty_cache(): the freed OVERSIZE heap from above must already be
+        # visible to the normal alloc_heap()/release_free_heaps() cascade.
+        b = torch.empty(n, device="mps")
+        del b
 
     def test_heap_mode_restored(self):
         """Setting the threshold to 0 should revert to default 1 GB heap behaviour."""
-        self._reset_solo_allocator()
+        self._reset_large_alloc_threshold()
         torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:10")
         torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:0")
         torch.mps.empty_cache()


### PR DESCRIPTION
## Description

Adds an opt-in "solo" allocation path in `MPSHeapAllocatorImpl`: tensors at or
above a configurable threshold get a dedicated `MTLBuffer` instead of `MTLHeap`
sub-allocation, avoiding the 1 GB heap block grown for large single-tensor
allocations. Freed solo buffers are cached per size for reuse and released on
`empty_cache()`.

Configured through the shared `AcceleratorAllocatorConfig` (as CUDA/XPU do), via
the `mps_large_alloc_threshold_mb` key:

    torch._C._accelerator_setAllocatorSettings("mps_large_alloc_threshold_mb:256")

or the `PYTORCH_ALLOC_CONF` env var. 0 (the default) uses the heap path.

The solo path respects the high-watermark limit and raises the same OOM error as
the heap path, buckets sizes so a slowly growing allocation reuses its buffer,
and reports as shared (unified) memory so `is_pinned` / zero-copy still work.

### Test Plan
```
python test/test_mps.py -v \
  TestMPS.test_enable_reduces_pool_growth \
  TestMPS.test_reuse_on_same_size \
  TestMPS.test_empty_cache_releases_solo_buffers \
  TestMPS.test_tensor_is_functional \
  TestMPS.test_heap_mode_restored \
  TestMPS.test_solo_respects_memory_limit \
  TestMPS.test_solo_buffer_is_shared \
  TestMPS.test_host_alias_storage
```
All 8 pass.

By @jasonfielder.
