### PR TITLE
[native] Fix bmm_outer_product override on XPU (accept XPU tensors in cond)

### DIFF
--- a/torch/_native/ops/bmm_outer_product/triton_impl.py
+++ b/torch/_native/ops/bmm_outer_product/triton_impl.py
@@ -23,11 +23,12 @@ def _bmm_outer_product_impl(
 ) -> torch.Tensor:
     from .triton_kernels import bmm_outer_product
 
+    device_module = torch.get_device_module(a.device)
     device = a.get_device()
-    if device == torch.cuda.current_device():
+    if device == device_module.current_device():
         return bmm_outer_product(a, b)
 
-    with torch.cuda.device(device):
+    with device_module.device(device):
         return bmm_outer_product(a, b)
 
 
@@ -40,7 +41,8 @@ def _bmm_outer_product_cond(
     # a and b are read-only here: the kernel wraps them in ConstTensorWrapper and
     # reads through const_data_ptr(), so copy-on-write inputs are not
     # materialized and need not be excluded.
-    if a.is_cuda and b.is_cuda and a.device == b.device and _is_outer_product(a, b):
+    same_accelerator = a.device == b.device and a.device.type in ("cuda", "xpu")
+    if same_accelerator and _is_outer_product(a, b):
         return True
     return False
 


### PR DESCRIPTION
Fixes #188803

`_bmm_outer_product_cond` gated on `a.is_cuda and b.is_cuda`, but the op is also
registered for the `XPU` dispatch key, so on XPU (`is_cuda == False`) the cond
always returned `False` and the registration was dead. This fixes it to accept
`device.type in ("cuda", "xpu")`, and routes `_bmm_outer_product_impl` (which
also hardcoded `torch.cuda.current_device()`) through
`torch.get_device_module(a.device)`. 

### Test Plan

```
python test/test_bmm_outer_product.py -v
```

On an Intel XPU: 13 passed, 2 skipped (previously
`test_cow_inputs_accepted_by_override` failed with `AssertionError: False is not
true`). Reverting only the cond reproduces the failure. Please run the same on
CUDA to confirm no regression.