### PR TITLE
Refactor tensor.py for device context and cleanup

### DIFF
--- a/torch/autograd/_functions/tensor.py
+++ b/torch/autograd/_functions/tensor.py
@@ -30,8 +30,8 @@ class Type(Function):
         if ctx.input_device == -1:
             return grad_output.type(ctx.input_type), None
         else:
-            # Using the exact device ID with torch.cuda.device context manager
-            with torch.cuda.device(ctx.input_device):
+            # Use torch.accelerator for cross-device compatibility
+            with torch.accelerator.device_index(ctx.input_device):
                 return grad_output.type(ctx.input_type), None
 
 
@@ -46,11 +46,17 @@ class Resize(Function):
             raise RuntimeError(
                 f"requested resize to {'x'.join(map(str, sizes))} ({ctx.numel} elements in total), "
                 f"but the given tensor has a size of {'x'.join(map(str, tensor.size()))} ({tensor.numel()} elements). "
-                f"autograd's resize can only change the shape of a given tensor, while preserving the number of elements."
+                f"autograd's resize can only change the shape of a given tensor, "
+                f"while preserving the number of elements."
             )
         ctx.input_sizes = tensor.size()
-
-        # Optimized to bypass old redundant memory allocation checks
+        
+        # Handle different tensor types appropriately
+        if tensor.is_quantized:
+            # Quantized tensors require explicit copy for memory layout preservation
+            tensor = tensor.copy_()
+        
+        # Ensure contiguity before view (safe for all tensor types)
         return tensor.contiguous().view(*sizes)
 
     @staticmethod

--- a/torch/autograd/_functions/tensor.py
+++ b/torch/autograd/_functions/tensor.py
@@ -8,6 +8,9 @@ import torch._utils
 from torch.autograd.function import Function
 
 
+__all__ = ["Type", "Resize"]
+
+
 class Type(Function):
     @staticmethod
     @deprecated(
@@ -15,24 +18,27 @@ class Type(Function):
         "please use `torch.tensor.to(dtype=dtype)` instead.",
         category=FutureWarning,
     )
+    # pyrefly: ignore [bad-override]
     def forward(ctx, i, dest_type):
         ctx.input_type = type(i)
         ctx.input_device = -1 if not i.is_cuda else i.get_device()
         return i.type(dest_type)
 
     @staticmethod
+    # pyrefly: ignore [bad-override]
     def backward(ctx, grad_output):
         if ctx.input_device == -1:
             return grad_output.type(ctx.input_type), None
         else:
-            # FIX: Changed device_index to device context manager
-            with torch.accelerator.device(ctx.input_device):
+            # Using torch.cuda.device to comply with module attributes and pass linter
+            with torch.cuda.device(ctx.input_device):
                 return grad_output.type(ctx.input_type), None
 
 
 # TODO: deprecate this
 class Resize(Function):
     @staticmethod
+    # pyrefly: ignore [bad-override]
     def forward(ctx, tensor, sizes):
         ctx.sizes = sizes
         ctx.numel = reduce(operator.mul, sizes, 1)
@@ -42,12 +48,13 @@ class Resize(Function):
                 f"but the given tensor has a size of {'x'.join(map(str, tensor.size()))} ({tensor.numel()} elements). "
                 f"autograd's resize can only change the shape of a given tensor, while preserving the number of elements."
             )
-        
         ctx.input_sizes = tensor.size()
-        # FIX: Cleaned up redundant copy_ and obsolete tensor.new() branching
+        
+        # Optimized to a high-performance, zero-copy layout view
         return tensor.contiguous().view(*sizes)
 
     @staticmethod
+    # pyrefly: ignore [bad-override]
     def backward(ctx, grad_output):
         if grad_output.numel() != ctx.numel:
             raise AssertionError(

--- a/torch/autograd/_functions/tensor.py
+++ b/torch/autograd/_functions/tensor.py
@@ -30,7 +30,7 @@ class Type(Function):
         if ctx.input_device == -1:
             return grad_output.type(ctx.input_type), None
         else:
-            # Using torch.cuda.device to comply with module attributes and pass linter
+            # Using the exact device ID with torch.cuda.device context manager
             with torch.cuda.device(ctx.input_device):
                 return grad_output.type(ctx.input_type), None
 
@@ -49,8 +49,8 @@ class Resize(Function):
                 f"autograd's resize can only change the shape of a given tensor, while preserving the number of elements."
             )
         ctx.input_sizes = tensor.size()
-        
-        # Optimized to a high-performance, zero-copy layout view
+
+        # Optimized to bypass old redundant memory allocation checks
         return tensor.contiguous().view(*sizes)
 
     @staticmethod

--- a/torch/autograd/_functions/tensor.py
+++ b/torch/autograd/_functions/tensor.py
@@ -15,55 +15,39 @@ class Type(Function):
         "please use `torch.tensor.to(dtype=dtype)` instead.",
         category=FutureWarning,
     )
-    # pyrefly: ignore [bad-override]
     def forward(ctx, i, dest_type):
         ctx.input_type = type(i)
         ctx.input_device = -1 if not i.is_cuda else i.get_device()
         return i.type(dest_type)
 
     @staticmethod
-    # pyrefly: ignore [bad-override]
     def backward(ctx, grad_output):
         if ctx.input_device == -1:
             return grad_output.type(ctx.input_type), None
         else:
-            with torch.accelerator.device_index(ctx.input_device):
+            # FIX: Changed device_index to device context manager
+            with torch.accelerator.device(ctx.input_device):
                 return grad_output.type(ctx.input_type), None
 
 
 # TODO: deprecate this
 class Resize(Function):
     @staticmethod
-    # pyrefly: ignore [bad-override]
     def forward(ctx, tensor, sizes):
         ctx.sizes = sizes
         ctx.numel = reduce(operator.mul, sizes, 1)
         if tensor.numel() != ctx.numel:
             raise RuntimeError(
-                (
-                    "requested resize to {} ({} elements in total), "
-                    "but the given tensor has a size of {} ({} elements). "
-                    "autograd's resize can only change the shape of a given "
-                    "tensor, while preserving the number of elements. "
-                ).format(
-                    "x".join(map(str, sizes)),
-                    ctx.numel,
-                    "x".join(map(str, tensor.size())),
-                    tensor.numel(),
-                )
+                f"requested resize to {'x'.join(map(str, sizes))} ({ctx.numel} elements in total), "
+                f"but the given tensor has a size of {'x'.join(map(str, tensor.size()))} ({tensor.numel()} elements). "
+                f"autograd's resize can only change the shape of a given tensor, while preserving the number of elements."
             )
+        
         ctx.input_sizes = tensor.size()
-        if tensor.is_quantized:
-            tensor.copy_(tensor)
-            return tensor.contiguous().view(*sizes)
-        if tensor.is_contiguous():
-            result = tensor.new(tensor).contiguous().view(*sizes)
-            return result
-        else:
-            return tensor.contiguous().view(*sizes)
+        # FIX: Cleaned up redundant copy_ and obsolete tensor.new() branching
+        return tensor.contiguous().view(*sizes)
 
     @staticmethod
-    # pyrefly: ignore [bad-override]
     def backward(ctx, grad_output):
         if grad_output.numel() != ctx.numel:
             raise AssertionError(

--- a/torch/autograd/_functions/tensor.py
+++ b/torch/autograd/_functions/tensor.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 import operator
 from functools import reduce
+
 from typing_extensions import deprecated
 
 import torch
@@ -50,14 +51,15 @@ class Resize(Function):
                 f"while preserving the number of elements."
             )
         ctx.input_sizes = tensor.size()
-        
-        # Handle different tensor types appropriately
+
         if tensor.is_quantized:
-            # Quantized tensors require explicit copy for memory layout preservation
-            tensor = tensor.copy_()
-        
-        # Ensure contiguity before view (safe for all tensor types)
-        return tensor.contiguous().view(*sizes)
+            tensor.copy_(tensor)
+            return tensor.contiguous().view(*sizes)
+        if tensor.is_contiguous():
+            result = tensor.new(tensor).contiguous().view(*sizes)
+            return result
+        else:
+            return tensor.contiguous().view(*sizes)
 
     @staticmethod
     # pyrefly: ignore [bad-override]


### PR DESCRIPTION
# Refactor tensor.py for device context and cleanup (fixed)

**File changed:** `torch/autograd/_functions/tensor.py`
## Summary

Carries forward the safe, cosmetic improvements drops the
part of this PR that introduced a runtime bug and a behavior regression in
`Resize.forward`.

## Changes included

1. **Add module exports**
   `__all__ = ["Type", "Resize"]` — makes the public API of this module
   explicit.

2. **Clarifying comment on `Type.backward`**
   Documents that `torch.accelerator.device_index` is used for cross-device
   compatibility. No behavior change.

3. **Modernize the `Resize.forward` error message**
   Replaced `.format()`-based string formatting with an equivalent f-string.
   No behavior change, purely stylistic.

## Changes intentionally *not* carried forward

This **PR previously** also collapsed the `Resize.forward` tensor-handling logic
(the `is_quantized` / `is_contiguous` branches) into a single unified
return statement. That change is **not** included here because it:

- Called `tensor.copy_()` with no arguments. `Tensor.copy_()` requires a
  source tensor (`copy_(src)`); calling it with zero arguments raises
  `TypeError` at runtime. This path would break every quantized tensor
  resize.
- Removed the `tensor.new(tensor)` allocation in the contiguous-tensor
  branch. `.contiguous()` on an already-contiguous tensor is a no-op and
  returns the *same* tensor, so removing this allocation makes the
  contiguous-tensor output alias the input's storage instead of returning
  an independent tensor as the original code guaranteed. This is a
  correctness regression for an autograd `Function.forward`.

fix: #188810