### PR TITLE
[MPS] Fix baddbmm for empty inputs

### DIFF
--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -800,6 +800,10 @@ static Tensor& addbmm_or_baddbmm_out_mps_impl(const Tensor& input,
       result.zero_();
       return result;
     }
+  } else if (result.numel() == 0) {
+    // Empty baddbmm output (e.g. a zero-sized batch dim): nothing to compute,
+    // avoid feeding empty buffers to the MPSGraph / Metal kernel paths.
+    return result;
   }
 
   // Use Metal kernels for integer and complex types

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -1436,6 +1436,7 @@ def sample_inputs_baddbmm(op_info, device, dtype, requires_grad, **kwargs):
                   ((1,), (S, S, S), (S, S, M), 0.6, 0.2, True),
                   ((), (S, S, S), (S, S, M), 1, 1, True),
                   ((), (S, S, S), (S, S, M), 0.6, 0.2, True),
+                  ((), (0, S, S), (0, S, M), 1, 1, True),  # empty batch, see #188765
                   ]
     make_arg = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad, low=None, high=None)
     for (input_shape, batch1_shape, batch2_shape, alpha, beta, broadcasts_input) in test_cases:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #188808

Exit early if result is empty rather than building MPSGraph that will fail with "Placeholder tensor is empty!" assert
Extend OpInfo coverage to empty tensors

Fixes https://github.com/pytorch/pytorch/issues/188765

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>