### PR TITLE
[Dynamo] Fix scheduler option in tvm backend partials

### DIFF
--- a/test/dynamo/test_backends.py
+++ b/test/dynamo/test_backends.py
@@ -1,4 +1,5 @@
 # Owner(s): ["module: dynamo"]
+import sys
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -162,6 +163,16 @@ class TestOptimizations(torch._dynamo.test_case.TestCase):
         self._check_backend_works("tvm", device)
         self._check_backend_works("tvm", device, options={"scheduler": None})
         self._check_backend_works("tvm", device, options={"opt_level": 0})
+
+    def test_tvm_scheduler_backends(self, device):
+        from torch._dynamo.backends.tvm import tvm_auto_scheduler, tvm_meta_schedule
+
+        gm = torch.fx.symbolic_trace(lambda x: x + 1)
+        for backend in (tvm_meta_schedule, tvm_auto_scheduler):
+            # blocking the tvm import keeps this fast and deterministic;
+            # reaching ImportError proves the partial's kwargs are valid
+            with patch.dict(sys.modules, {"tvm": None}):
+                self.assertRaises(ImportError, backend, gm, [torch.randn(2)])
 
     @onlyHPU
     def test_intel_gaudi_backend(self, device):

--- a/torch/_dynamo/backends/tvm.py
+++ b/torch/_dynamo/backends/tvm.py
@@ -182,8 +182,12 @@ def tvm(
     return exec_tvm
 
 
-tvm_meta_schedule = functools.partial(tvm, scheduler="meta_schedule")
-tvm_auto_scheduler = functools.partial(tvm, scheduler="auto_scheduler")
+tvm_meta_schedule = functools.partial(
+    tvm, options=MappingProxyType({"scheduler": "meta_schedule"})
+)
+tvm_auto_scheduler = functools.partial(
+    tvm, options=MappingProxyType({"scheduler": "auto_scheduler"})
+)
 
 
 def has_tvm() -> bool:


### PR DESCRIPTION
## Related Isue

closes #188809

## Why

`tvm_meta_schedule` and `tvm_auto_scheduler` raised `TypeError` on every call because they passed a scheduler kwarg that `tvm()` does not accept.

## How

- Pass the scheduler through `options=MappingProxyType({"scheduler": ...})` in both partials
- Add `test_tvm_scheduler_backends` verifying both backends are callable

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98