### PR TITLE
Fix typos in comments and docstrings across ao, distributed, masked, nn, and sparse modules

### DIFF
--- a/torch/ao/pruning/_experimental/data_sparsifier/lightning/callbacks/data_sparsity.py
+++ b/torch/ao/pruning/_experimental/data_sparsifier/lightning/callbacks/data_sparsity.py
@@ -39,7 +39,7 @@ class PostTrainingDataSparsity(pl.callbacks.Callback):
     Hooks implemented:
         on_fit_end()
             1. copies the model and attaches it to the sparsifier
-            2. sparsier step() is called
+            2. sparsifier step() is called
             3. squashes the mask()
     """
 

--- a/torch/ao/pruning/_experimental/pruner/FPGM_pruner.py
+++ b/torch/ao/pruning/_experimental/pruner/FPGM_pruner.py
@@ -51,7 +51,7 @@ class FPGMPruner(BaseStructuredSparsifier):
         Args:
             t (torch.Tensor): tensor representing the parameter to prune
         Returns:
-            distance (torch.Tensor): distance computed across filtters
+            distance (torch.Tensor): distance computed across filters
         """
         dim = 0  # prune filter (row)
 

--- a/torch/ao/quantization/fx/_equalize.py
+++ b/torch/ao/quantization/fx/_equalize.py
@@ -805,7 +805,7 @@ def convert_eq_obs(
     modified.
 
     Having the equalization observer before the quantization observer would also
-    cause some inconsistences between the ordering of the quantization and
+    cause some inconsistencies between the ordering of the quantization and
     equalization observers.
     For example, a single linear layer would look like:
         x -> InpEqObs1 -> InpQuantObs1 -> linear1 -> OutQuantObs1

--- a/torch/ao/quantization/fx/_lower_to_native_backend.py
+++ b/torch/ao/quantization/fx/_lower_to_native_backend.py
@@ -442,7 +442,7 @@ def _load_packed_weight(
             setattr(self, attr_name, state_dict[attr_name])
             attrs_to_pop.append(attr_name)
 
-    # pop the packed param attributesn
+    # pop the packed param attributes
     for attr_name in attrs_to_pop:
         state_dict.pop(attr_name)
 

--- a/torch/ao/quantization/fx/_model_report/model_report.py
+++ b/torch/ao/quantization/fx/_model_report/model_report.py
@@ -363,7 +363,7 @@ class ModelReport:
         dict_a_keys: set = set(info_dict_a.keys())
         dict_b_keys: set = set(info_dict_b.keys())
 
-        # get the insersection keys and check if same value for both dicts
+        # get the intersection keys and check if same value for both dicts
         intersecting_keys: set = dict_a_keys.intersection(dict_b_keys)
 
         for key in intersecting_keys:

--- a/torch/ao/quantization/fx/graph_module.py
+++ b/torch/ao/quantization/fx/graph_module.py
@@ -181,7 +181,7 @@ class QuantizedGraphModule(GraphModule):
                 setattr(self, attr_name, state_dict[attr_name])
                 attrs_to_pop.append(attr_name)
 
-        # pop the packed param attributesn
+        # pop the packed param attributes
         for attr_name in attrs_to_pop:
             state_dict.pop(attr_name)
 

--- a/torch/ao/quantization/observer.py
+++ b/torch/ao/quantization/observer.py
@@ -1061,7 +1061,7 @@ class HistogramObserver(UniformQuantizationObserverBase):
         self, delta_begin: torch.Tensor, delta_end: torch.Tensor, density: torch.Tensor
     ) -> torch.Tensor:
         r"""
-        Compute the norm of the values uniformaly distributed between
+        Compute the norm of the values uniformly distributed between
         delta_begin and delta_end.
         Currently only L2 norm is supported.
 

--- a/torch/distributed/launcher/api.py
+++ b/torch/distributed/launcher/api.py
@@ -204,7 +204,7 @@ def _get_entrypoint_name(entrypoint: Callable | str | None, args: list[Any]) -> 
     1. If entrypoint is a function, use ``entrypoint.__qualname__``.
     2. If entrypoint is a string, check its value:
         2.1 if entrypoint equals to ``sys.executable`` (like "python"), use the first element from ``args``
-            which does not start with hifen letter (for example, "-u" will be skipped).
+            which does not start with hyphen letter (for example, "-u" will be skipped).
         2.2 otherwise, use ``entrypoint`` value.
     3. Otherwise, return empty string.
     """

--- a/torch/masked/_ops.py
+++ b/torch/masked/_ops.py
@@ -397,7 +397,7 @@ Example::
         for k, v in template_data.items()
     )
 
-    # Apply docstring templates to function doctring:
+    # Apply docstring templates to function docstring:
     if func.__doc__ is None:
         doc_template = "\n\n".join([f"{{{op_kind}_{sec}}}" for sec in doc_sections])
     else:

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5388,7 +5388,7 @@ def upsample_nearest(input, size=None, scale_factor=None):  # noqa: F811
 
     Args:
         input (Tensor): input
-        size (int or Tuple[int, int] or Tuple[int, int, int]): output spatia
+        size (int or Tuple[int, int] or Tuple[int, int, int]): output spatial
             size.
         scale_factor (int): multiplier for spatial size. Has to be an integer.
 

--- a/torch/sparse/_semi_structured_ops.py
+++ b/torch/sparse/_semi_structured_ops.py
@@ -219,7 +219,7 @@ def semi_sparse_scaled_mm(func, types, args=(), kwargs=None) -> torch.Tensor:
         )
 
     # cuSPARSELt lacks the A and B operand scaling support, so instead we use alpha to scale the result.
-    # Note that this limits us to per-tensor scalig only.
+    # Note that this limits us to per-tensor scaling only.
     sparse_result = torch._cslt_sparse_mm(
         A.packed,
         B,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #188814

No functional changes; corrects misspellings such as "sparsier", "filtters", "inconsistences", "attributesn", "insersection", "uniformaly", "hifen", "doctring", "spatia", and "scalig" in documentation and inline comments.

Authored with the assistance of an AI agent.