### PR TITLE
[CD][ARM][CUDA] Enable multi-arch official Docker release images

### DIFF
--- a/.github/scripts/generate_docker_release_matrix.py
+++ b/.github/scripts/generate_docker_release_matrix.py
@@ -21,8 +21,8 @@ DOCKER_IMAGE_TYPES = ["runtime", "devel"]
 
 def generate_docker_matrix() -> dict[str, list[dict[str, str]]]:
     ret: list[dict[str, str]] = []
-    # CUDA amd64 Docker images are available as both runtime and devel while
-    # CPU arm64 image is only available as runtime.
+    # CUDA Docker images are available on amd64 and arm64 as both runtime and
+    # devel while CPU arm64 image is only available as runtime.
     for cuda, version in generate_binary_build_matrix.CUDA_ARCHES_FULL_VERSION.items():
         for image in DOCKER_IMAGE_TYPES:
             ret.append(
@@ -33,7 +33,7 @@ def generate_docker_matrix() -> dict[str, list[dict[str, str]]]:
                         cuda
                     ],
                     "image_type": image,
-                    "platform": "linux/amd64",
+                    "platform": "linux/amd64,linux/arm64",
                 }
             )
     ret.append(

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -146,11 +146,11 @@ jobs:
         run: |
           make -f docker.Makefile "${BUILD_IMAGE_TYPE}-image"
       - name: Push nightly tags
-        if: ${{ github.event.ref == 'refs/heads/nightly' && matrix.image_type == 'runtime' && matrix.platform == 'linux/amd64' }}
+        if: ${{ github.event.ref == 'refs/heads/nightly' && matrix.image_type == 'runtime' && matrix.cuda != 'cpu' }}
         run: |
           PYTORCH_DOCKER_TAG="${PYTORCH_VERSION}-cuda${CUDA_VERSION_SHORT}-cudnn${CUDNN_VERSION}-runtime"
           CUDA_SUFFIX="-cu${CUDA_VERSION}"
-          PYTORCH_NIGHTLY_COMMIT=$(docker run ghcr.io/pytorch/pytorch-nightly:"${PYTORCH_DOCKER_TAG}" \
+          PYTORCH_NIGHTLY_COMMIT=$(docker run --platform linux/amd64 ghcr.io/pytorch/pytorch-nightly:"${PYTORCH_DOCKER_TAG}" \
                                           python -c 'import torch; print(torch.version.git_version[:7],end="")')
 
           docker tag ghcr.io/pytorch/pytorch-nightly:"${PYTORCH_DOCKER_TAG}" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,21 +41,16 @@ RUN git submodule update --init --recursive
 FROM python-deps as pytorch-installs
 ARG CUDA_PATH=cu121
 ARG INSTALL_CHANNEL=whl/nightly
-# Automatically set by buildx
-ARG TARGETPLATFORM
 
 # torchaudio does not publish wheels against the CUDA 13.2 index yet,
 # so skip it when CUDA_PATH=cu132 to keep this Dockerfile building.
-RUN case ${TARGETPLATFORM} in \
-         "linux/arm64")  pip3 install --extra-index-url https://download.pytorch.org/whl/cpu/ torch torchvision torchaudio ;; \
-         *) \
-             if [ "${CUDA_PATH}" = "cu132" ]; then \
-                 pip3 install --index-url https://download.pytorch.org/${INSTALL_CHANNEL}/${CUDA_PATH}/ torch torchvision; \
-             else \
-                 pip3 install --index-url https://download.pytorch.org/${INSTALL_CHANNEL}/${CUDA_PATH}/ torch torchvision torchaudio; \
-             fi \
-             ;; \
-    esac
+RUN if [ "${CUDA_PATH}" = "cpu" ]; then \
+        pip3 install --extra-index-url https://download.pytorch.org/whl/cpu/ torch torchvision torchaudio; \
+    elif [ "${CUDA_PATH}" = "cu132" ]; then \
+        pip3 install --index-url https://download.pytorch.org/${INSTALL_CHANNEL}/${CUDA_PATH}/ torch torchvision; \
+    else \
+        pip3 install --index-url https://download.pytorch.org/${INSTALL_CHANNEL}/${CUDA_PATH}/ torch torchvision torchaudio; \
+    fi
 RUN pip3 install torchelastic
 RUN IS_CUDA=$(python3 -c 'import torch ; print(torch.cuda._is_compiled())'); \
     echo "Is torch compiled with cuda: ${IS_CUDA}"; \
@@ -66,7 +61,6 @@ RUN IS_CUDA=$(python3 -c 'import torch ; print(torch.cuda._is_compiled())'); \
 FROM ${BASE_IMAGE} as official
 ARG PYTORCH_VERSION
 ARG TRITON_VERSION
-ARG TARGETPLATFORM
 ARG CUDA_VERSION
 LABEL com.nvidia.volumes.needed="nvidia_driver"
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -81,7 +75,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
 # Copy Python packages from pytorch-installs stage
 COPY --from=pytorch-installs /usr/local/lib/python3.12 /usr/local/lib/python3.12
 COPY --from=pytorch-installs /usr/local/bin /usr/local/bin
-RUN if test -n "${CUDA_VERSION}" -a "${TARGETPLATFORM}" != "linux/arm64"; then \
+RUN if test -n "${CUDA_VERSION}"; then \
         apt-get update -qq && \
         DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gcc && \
         rm -rf /var/lib/apt/lists/*; \


### PR DESCRIPTION
Issue
Fixes https://github.com/pytorch/pytorch/issues/168168

Summary
The official docker release workflow was building CUDA images only for linux/amd64, which is why tags like pytorch/pytorch:<ver>-cuda*-cudnn*-{runtime,devel} resolved to x86 only.

This PR makes official CUDA docker releases multi-arch by:

generating CUDA matrix entries with platform: linux/amd64,linux/arm64
updating Dockerfile wheel-install logic to select CPU vs CUDA index from CUDA_PATH (instead of TARGETPLATFORM), so arm64 CUDA builds install CUDA wheels
removing the arm64 exclusion from CUDA image gcc install
updating nightly tag push condition to run for CUDA runtime images (matrix.cuda != 'cpu') and using docker run --platform linux/amd64 to consistently extract the nightly commit tag

Authored with AI assistance.,