### PR TITLE
Fix typos in ONNX exporter comments

### DIFF
--- a/torch/onnx/_internal/exporter/_torchlib/_tensor_typing.py
+++ b/torch/onnx/_internal/exporter/_torchlib/_tensor_typing.py
@@ -21,7 +21,7 @@ from onnxscript import (
 )
 
 
-# NOTE: We do not care about unsigned types beyond UINT8 because PyTorch does not us them.
+# NOTE: We do not care about unsigned types beyond UINT8 because PyTorch does not use them.
 # More detail can be found: https://pytorch.org/docs/stable/tensors.html
 
 TensorType = Union[  # noqa: UP007

--- a/torch/onnx/ops/_symbolic_impl.py
+++ b/torch/onnx/ops/_symbolic_impl.py
@@ -6,7 +6,7 @@ arbitrary ONNX operators.
 The operators are called "symbolic" because they don't do any actual computation
 but instead serve as placeholders in the computation graph.
 
-Each implementation contains two parts: A "real" implementation that produce all
+Each implementation contains two parts: A "real" implementation that produces all
 zeros based on the input shape and dtype, and a "fake" implementation that does more
 or less the same thing but is required by the `torch.library.custom_op` interface.
 """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #188817

Correct "us"->"use" and "produce"->"produces" in docstrings/comments for the ONNX torchlib tensor typing and symbolic op implementations.