### PR TITLE
[native] Move scatter-add N-dim to dynamic

### DIFF
--- a/test/test_scatter_gather_ops.py
+++ b/test/test_scatter_gather_ops.py
@@ -927,6 +927,45 @@ class TestScatterAddOverrideCorrectness(TestCase):
         tol = _override_tol(dtype)
         self.assertEqual(got, ref, atol=tol, rtol=tol)
 
+    @parametrize("path", ["tma", "vec"])
+    def test_inner_dim_change_no_recompile(self, path):
+        # The kernels take the slice extent N as a runtime arg, so a single
+        # compile must serve every inner-dim size. Call the kernel host entry
+        # at several N and assert the compile cache runs exactly one real
+        # compile (misses advances once, then only hits). We drive the host
+        # entry directly rather than through torch.scatter_add: TMA is
+        # registered first and strictly narrower, so on sm_90+ it would win
+        # every contiguous shape and the vec cache would never move.
+        from torch._native.ops.scatter_add import tma_kernel, vec_scatter_kernel
+        if path == "tma":
+            if not SM90OrLater:
+                self.skipTest("TMA path requires sm_90+")
+            compile_fn = tma_kernel._compile_tma_scatter
+            run = tma_kernel.tma_scatter_add_into
+        else:
+            compile_fn = vec_scatter_kernel._compile_vec_scatter
+            run = vec_scatter_kernel.vec_scatter_add_into
+
+        torch.manual_seed(0)
+        # Same dtype and contiguity across all sizes so only N varies.
+        Ns = [128, 256, 512, 1024, 2048]
+        compile_fn.cache_clear()
+        for N in Ns:
+            self_t, _, src, idx_1d = _make_override_triple(200, 100, (N,))
+            out = self_t.clone()
+            run(out, idx_1d, src)
+            self.assertEqual(out, _naive_scatter_add(self_t, idx_1d, src),
+                             atol=1e-4, rtol=1e-4)
+            misses = compile_fn.cache_info().misses
+            # Every N after the first must be served from cache: misses
+            # tops out at 1 (0 if the .o was already warm on disk). If N
+            # were still in the key, misses would climb with each size.
+            self.assertLessEqual(misses, 1, msg=f"recompiled at N={N}")
+        # The decisive invariant, independent of on-disk cache state: one
+        # in-memory entry serves every N. If N were in the key there'd be
+        # len(Ns) entries.
+        self.assertEqual(compile_fn.cache_info().currsize, 1)
+
     @parametrize("variant", ["functional", "out", "inplace"])
     def test_op_variants(self, variant):
         torch.manual_seed(0)

--- a/torch/_native/ops/scatter_add/tma_kernel.py
+++ b/torch/_native/ops/scatter_add/tma_kernel.py
@@ -56,7 +56,7 @@ import cutlass.cute as cute
 import cutlass.cute.nvgpu.cpasync as cpasync
 import cutlass.cute.testing as cute_testing
 import cutlass.pipeline as pipeline
-from cutlass import BFloat16, const_expr, Float16, Float32, Int32, Int64
+from cutlass import BFloat16, Float16, Float32, Int32, Int64
 
 import torch
 from torch._native.instrumentation import instrumented_cutedsl_cache
@@ -96,36 +96,30 @@ def _reduce_op_for(dtype):
     raise ValueError(f"unsupported dtype: {dtype}")
 
 
-def _make_kernel(
-    dtype, elem_bytes: int, N: int, chunk_elems: int, reduce_op, contig: bool
-):
-    """Build a dtype-specialized kernel closure. dtype/elem_bytes/N
-    /chunk_elems/contig are Python-time constants that the preprocessor
-    folds at cute.compile time.
+def _make_kernel(dtype, elem_bytes: int, chunk_elems: int, reduce_op):
+    """Build a dtype-specialized kernel closure. dtype/elem_bytes
+    /chunk_elems are Python-time constants that the preprocessor folds
+    at cute.compile time; ``N`` and ``num_chunks`` are runtime args so
+    one compile serves every row length.
 
-    ``chunk_elems`` is baked in at compile time. The TMA descriptor
-    built in ``_launch`` (via ``make_tiled_tma_atom`` on the source
-    tensor) enables OOB-clamp-to-zero for reads past column ``N``; the
-    reduce side then writes only the actual valid byte count, so
-    partial final chunks are handled natively.
+    ``chunk_elems`` is baked in at compile time (it is the static TMA
+    box dim). The TMA descriptor built in ``_launch`` (via
+    ``make_tiled_tma_atom`` on the source tensor) enables
+    OOB-clamp-to-zero for reads past column ``N``; the reduce side then
+    writes only the actual valid byte count, so partial final chunks --
+    and rows shorter than a full box -- are handled natively.
 
     One CTA = one warp. The single driver thread (tidx == 0) serves as
     both producer (issues the TMA load) and consumer (issues the
     bulk-reduce). Both CooperativeGroups are ``Agent.Thread, size=1``
     so the mbarrier arrive counts match the single-threaded flow.
 
-    ``contig`` gates a fast path on the reduce side: when True, the
-    output row stride is D at compile time, avoiding a runtime stride
-    multiply. When False the kernel takes a runtime
-    ``out_row_stride`` arg so outer-strided outputs (e.g. slices) work.
-    The TMA load always goes through the descriptor and doesn't use
-    ``contig``.
+    The reduce side always uses the runtime ``out_row_stride`` arg so
+    outer-strided outputs (e.g. slices) work; the contiguous case just
+    passes ``out.stride(0) == N`` in as that value.
     """
 
     chunk_bytes = chunk_elems * elem_bytes
-    # Compile-time derived values. num_chunks covers row_bytes with
-    # partial final chunk handled by TMA OOB clamp.
-    num_chunks = (N + chunk_elems - 1) // chunk_elems
 
     # 2-stage pipeline buffer is laid out column-major; stage i starts
     # at offset i * stage_stride_elems * elem_bytes, so the stride must
@@ -141,6 +135,8 @@ def _make_kernel(
         tma_tensor_src: cute.Tensor,  # TMA-view of mSrc
         mIndex: cute.Tensor,
         mOut: cute.Tensor,
+        N: Int32,
+        num_chunks: Int32,
         chunks_per_cta: Int32,
         out_row_stride: Int64,
     ):
@@ -158,14 +154,10 @@ def _make_kernel(
         # the whole D.
         chunk_start = bidy * chunks_per_cta
         chunk_end = chunk_start + chunks_per_cta
-        if chunk_end > Int32(num_chunks):
-            chunk_end = Int32(num_chunks)
+        if chunk_end > num_chunks:
+            chunk_end = num_chunks
 
-        # Reduce-side out-row stride: compile-time N (contig) or runtime.
-        if const_expr(contig):
-            out_rs = Int64(N)
-        else:
-            out_rs = out_row_stride
+        out_rs = out_row_stride
 
         smem = cutlass.utils.SmemAllocator()
         sBuf = smem.allocate_tensor(
@@ -251,7 +243,7 @@ def _make_kernel(
                         # OOB-clamped the tail to 0 in smem, we reduce
                         # only the valid bytes.
                         off = prev_chunk_idx * Int32(chunk_elems)
-                        cur_elems = Int32(N) - off
+                        cur_elems = N - off
                         if cur_elems > Int32(chunk_elems):
                             cur_elems = Int32(chunk_elems)
                         cur_bytes = cur_elems * Int32(elem_bytes)
@@ -279,7 +271,7 @@ def _make_kernel(
                 cbuf_ptr = sBuf[None, consumer_state.index].iterator
 
                 off = prev_chunk_idx * Int32(chunk_elems)
-                cur_elems = Int32(N) - off
+                cur_elems = N - off
                 if cur_elems > Int32(chunk_elems):
                     cur_elems = Int32(chunk_elems)
                 cur_bytes = cur_elems * Int32(elem_bytes)
@@ -297,14 +289,18 @@ def _make_kernel(
         mIndex: cute.Tensor,
         mOut: cute.Tensor,
         stream: cuda.CUstream,
+        N: Int32,
+        num_chunks: Int32,
         chunks_per_cta: Int32,
         grid_x: Int32,
         grid_y: Int32,
         out_row_stride: Int64,
     ):
-        # Build the tile-mode TMA descriptor. Shape (M_src, N) comes
-        # from mSrc; TMA clamps OOB column reads to 0, so rows with
-        # ``N % chunk_elems != 0`` are handled natively on the load.
+        # Build the tile-mode TMA descriptor over the (M_src, N) source.
+        # Both global dims are dynamic; the ``(1, chunk_elems)`` box is
+        # static. TMA clamps OOB column reads to 0, so rows shorter than
+        # a full box and rows with ``N % chunk_elems != 0`` are handled
+        # natively on the load.
         tma_atom, tma_tensor_src = cpasync.make_tiled_tma_atom(
             cpasync.CopyBulkTensorTileG2SOp(),
             mSrc,
@@ -316,6 +312,8 @@ def _make_kernel(
             tma_tensor_src,
             mIndex,
             mOut,
+            N,
+            num_chunks,
             chunks_per_cta,
             out_row_stride,
         ).launch(
@@ -327,39 +325,39 @@ def _make_kernel(
     return _launch
 
 
-def _chunk_elems_for(torch_dtype: torch.dtype, N: int) -> int:
-    """Compile-time ``chunk_elems``: whole row if it fits in
-    ``_MAX_CHUNK_BYTES``, else ``_MAX_CHUNK_BYTES // elem_bytes``.
-    Rounded down to a multiple of ``16 / elem_bytes`` so the final
-    partial chunk (if any) still satisfies the 16-byte reduce
-    alignment."""
-    elem_bytes = torch_dtype.itemsize
-    row_bytes = N * elem_bytes
-    chunk_bytes = min(row_bytes, _MAX_CHUNK_BYTES)
-    # Ensure chunk_bytes itself is 16-aligned (true for 512, true for
-    # any small row since cond requires row_bytes % 16 == 0).
-    return chunk_bytes // elem_bytes
+def _chunk_elems_for(torch_dtype: torch.dtype) -> int:
+    """Compile-time ``chunk_elems`` (the static TMA box dim): always
+    ``_MAX_CHUNK_BYTES // elem_bytes``. Since ``N`` is now a runtime arg
+    the box can't shrink to fit small rows -- instead a short row loads
+    one box and the TMA descriptor OOB-clamps the tail to 0, and the
+    reduce writes only ``min(chunk_elems, N)`` valid elements. 512 B is
+    a multiple of 16 for every supported dtype, so the box always meets
+    the reduce's 16-byte alignment."""
+    return _MAX_CHUNK_BYTES // torch_dtype.itemsize
 
 
 @instrumented_cutedsl_cache(
     "aten::scatter_add",
-    key_fn=lambda torch_dtype, N, contig: f"tma {torch_dtype} N={N} contig={contig}",
+    key_fn=lambda torch_dtype: f"tma {torch_dtype}",
 )
-def _compile_tma_scatter(torch_dtype: torch.dtype, N: int, contig: bool):
+def _compile_tma_scatter(torch_dtype: torch.dtype):
+    # N and num_chunks are runtime args, so one compile per dtype serves
+    # every row length. chunk_elems (the static TMA box) depends only on
+    # the dtype's element size.
     dtype = _TORCH_TO_CUTE[torch_dtype]
     elem_bytes = dtype.width // 8
-    chunk_elems = _chunk_elems_for(torch_dtype, N)
+    chunk_elems = _chunk_elems_for(torch_dtype)
     reduce_op = _reduce_op_for(dtype)
-    launcher = _make_kernel(dtype, elem_bytes, N, chunk_elems, reduce_op, contig)
+    launcher = _make_kernel(dtype, elem_bytes, chunk_elems, reduce_op)
 
     mSrc_fake = cute.runtime.make_fake_tensor(
-        dtype, (cute.sym_int(), N), stride=(cute.sym_int64(), 1)
+        dtype, (cute.sym_int(), cute.sym_int()), stride=(cute.sym_int64(), 1)
     )
     # Index is guaranteed contiguous by _flatten_for_expanded_1d; fix
     # stride=1 so `mIndex[i]` doesn't emit a runtime stride multiply.
     mIndex_fake = cute.runtime.make_fake_tensor(Int64, (cute.sym_int(),), stride=(1,))
     mOut_fake = cute.runtime.make_fake_tensor(
-        dtype, (cute.sym_int(), N), stride=(cute.sym_int64(), 1)
+        dtype, (cute.sym_int(), cute.sym_int()), stride=(cute.sym_int64(), 1)
     )
     return cute.compile(
         launcher,
@@ -367,6 +365,8 @@ def _compile_tma_scatter(torch_dtype: torch.dtype, N: int, contig: bool):
         mIndex_fake,
         mOut_fake,
         cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
+        Int32(0),  # N
+        Int32(0),  # num_chunks
         Int32(0),  # chunks_per_cta
         Int32(0),  # grid_x
         Int32(0),  # grid_y
@@ -442,16 +442,18 @@ def tma_scatter_add_into(
     multiple of 16; the host cond enforces this.
     """
     M, N = src.shape
-    chunk_elems = _chunk_elems_for(src.dtype, N)
-    contig = src.stride(0) == N and out.stride(0) == N
-    compiled = _compile_tma_scatter(src.dtype, N, contig)
+    chunk_elems = _chunk_elems_for(src.dtype)
+    compiled = _compile_tma_scatter(src.dtype)
     sm = torch.cuda.get_device_properties(out.device).multi_processor_count
 
     grid_x, grid_y, chunks_per_cta = _plan_grid(M, N, chunk_elems, sm)
+    num_chunks = (N + chunk_elems - 1) // chunk_elems
     compiled(
         src,
         index_1d,
         out,
+        N,
+        num_chunks,
         chunks_per_cta,
         grid_x,
         grid_y,

--- a/torch/_native/ops/scatter_add/vec_scatter_kernel.py
+++ b/torch/_native/ops/scatter_add/vec_scatter_kernel.py
@@ -192,22 +192,26 @@ def _make_kernel(dtype, elem_bytes: int, vec_elems: int, contig: bool):
 
 @instrumented_cutedsl_cache(
     "aten::scatter_add",
-    key_fn=lambda torch_dtype, N, contig: f"vec {torch_dtype} N={N} contig={contig}",
+    key_fn=lambda torch_dtype, contig: f"vec {torch_dtype} contig={contig}",
 )
-def _compile_vec_scatter(torch_dtype: torch.dtype, N: int, contig: bool):
+def _compile_vec_scatter(torch_dtype: torch.dtype, contig: bool):
+    # N is a runtime arg (``D``), never a compile-time constant here: the
+    # kernel loops ``while off < D`` and loads fixed ``vec_elems`` chunks off
+    # a raw iterator, so the inner dim can stay symbolic. One compile per
+    # (dtype, contig) serves every N.
     dtype = _TORCH_TO_CUTE[torch_dtype]
     elem_bytes = dtype.width // 8
     vec_elems = _VEC_BYTES // elem_bytes
     launcher = _make_kernel(dtype, elem_bytes, vec_elems, contig)
 
     mSrc_fake = cute.runtime.make_fake_tensor(
-        dtype, (cute.sym_int(), N), stride=(cute.sym_int64(), 1)
+        dtype, (cute.sym_int(), cute.sym_int()), stride=(cute.sym_int64(), 1)
     )
     # Index is contiguous (see _flatten_for_expanded_1d); fix stride=1
     # so `mIndex[i]` doesn't emit a runtime stride multiply.
     mIndex_fake = cute.runtime.make_fake_tensor(Int64, (cute.sym_int(),), stride=(1,))
     mOut_fake = cute.runtime.make_fake_tensor(
-        dtype, (cute.sym_int(), N), stride=(cute.sym_int64(), 1)
+        dtype, (cute.sym_int(), cute.sym_int()), stride=(cute.sym_int64(), 1)
     )
     return cute.compile(
         launcher,
@@ -248,7 +252,7 @@ def vec_scatter_add_into(
     """
     M, N = src.shape
     contig = src.stride(0) == N and out.stride(0) == N
-    compiled = _compile_vec_scatter(src.dtype, N, contig)
+    compiled = _compile_vec_scatter(src.dtype, contig)
     sm = torch.cuda.get_device_properties(out.device).multi_processor_count
     grid = min((M + _WARPS_PER_BLOCK - 1) // _WARPS_PER_BLOCK, sm * 8)
     compiled(src, index_1d, out, M, N, grid, src.stride(0), out.stride(0))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #188820

For input [M, N], the scatter_add override keyed the compile cache on N,
causing a recompile for many applications. Move N to dynamic, allowing a
single compile for all sizes. (Note: dtype and contig/non-contig changes
still recompile.)

Test Plan:

    python3 -m pytest test/test_scatter_gather_ops.py \
        -k "test_scatter_add_large or test_scatter_expanded_index"

Authored with assistance from Claude.