### PR TITLE
[CUDA][CuteDSL] Use unique values for cutedsl topk in `common_methods_invocations.py`

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -5428,7 +5428,10 @@ def sample_inputs_cutedsl_topk(op_info, device, dtype, requires_grad, **kwargs):
         _REGISTER_N_RANGE,
     )
 
-    make_arg = partial(make_tensor, device=device, dtype=dtype, requires_grad=False)
+    def make_arg(shape):
+        # Generic tests compare indices exactly; tie behavior has dedicated tests.
+        values = torch.randperm(math.prod(shape), dtype=torch.int64, device=device)
+        return values.reshape(shape).to(dtype)
 
     # M=256 is >= typical GPU SM count so the cond's SM-wave gate passes.
     for K in (64, 128, 256, 512, 1024):


### PR DESCRIPTION
Otherwise we get spurious failures due to divergence vs. reference on equal values---aligns with existing conventions for topk testing and other tests handle ties.

Authored with codex

cc @ptrblck @msaroufim @tinglvv @nWEIdia @mruberry