### PR TITLE
 Fix ComplexTensor mul_ in-place semantics and ne with real lhs

### DIFF
--- a/test/complex_tensor/test_complex_tensor.py
+++ b/test/complex_tensor/test_complex_tensor.py
@@ -157,6 +157,28 @@ class TestComplexTensor(TestCase):
         self.assertEqual(c.imag, torch.tensor([7, 8], dtype=torch.float32))
         self.assertEqual(c, torch.tensor([5 + 7j, 6 + 8j], dtype=torch.complex64))
 
+    def test_mul_inplace_complex(self):
+        from torch._subclasses.complex_tensor import ComplexTensor
+
+        a = torch.tensor([1 + 2j, 3 + 4j], dtype=torch.complex64)
+        b = torch.tensor([7 - 8j, -9 + 1j], dtype=torch.complex64)
+        expected = a * b
+
+        xa = ComplexTensor.from_interleaved(a)
+        result = xa.mul_(ComplexTensor.from_interleaved(b))
+
+        self.assertIs(result, xa)
+        self.assertEqual(xa.as_interleaved(), expected)
+
+    def test_ne_real_operand(self):
+        from torch._subclasses.complex_tensor import ComplexTensor
+
+        r = torch.tensor([1.0, 3.0, 5.0])
+        c = torch.tensor([1 + 2j, 3 + 0j, 0 + 4j], dtype=torch.complex64)
+        xc = ComplexTensor.from_interleaved(c)
+
+        self.assertEqual(torch.ne(r, xc), torch.ne(r, c))
+
 
 @unMarkDynamoStrictTest
 class TestComplexBwdGradients(TestCase):

--- a/torch/_subclasses/complex_tensor/_ops/aten.py
+++ b/torch/_subclasses/complex_tensor/_ops/aten.py
@@ -141,7 +141,7 @@ del simple_op
 
 # some binary ops which we can stamp out
 mul_impl = register_binary_nonlinear(aten.mul)
-mul__impl = register_binary_nonlinear(aten.mul_)
+mul__impl = register_binary_linear_inplace(aten.mul_, mul_impl)
 mm_impl = register_binary_nonlinear(aten.mm)
 dot_impl = register_binary_nonlinear(aten.dot)
 bmm_impl = register_binary_nonlinear(aten.bmm)
@@ -443,7 +443,7 @@ def eq_impl(
 def ne_impl(
     self: ComplexTensor, rhs: ComplexTensor, *args: Any, **kwargs: Any
 ) -> torch.Tensor:
-    a_r, a_i = split_complex_tensor(self)
+    a_r, a_i = split_complex_arg(self)
     b_r, b_i = split_complex_arg(rhs)
     return torch.ne(a_r, b_r, *args, **kwargs) | torch.ne(a_i, b_i, *args, **kwargs)
 


### PR DESCRIPTION
Fix mul_ and ne bugs in ComplexTensor

Fixes two independent bugs in `torch/_subclasses/complex_tensor/_ops/aten.py`.

**`mul_`:** was registered via `register_binary_nonlinear(aten.mul_)`, which applies the op directly to split real/imag components. The in-place`aten.mul_` mutated the `a_r` view before it was reused for the imag term, corrupting the result, and returned a new ComplexTensor instead of `lhs` (so `x.mul_(y) is x` was false). Now registered via `register_binary_linear_inplace(aten.mul_, mul_impl)`, which computes the product functionally then does `lhs.copy_(result)` and returns `lhs`.

**`ne`:** `ne_impl` used `split_complex_tensor(self)`, which reads `.re`/`.im` attributes that only exist on a ComplexTensor, breaking `torch.ne(real, complex)`. Switched to `split_complex_arg(self)` to handle real tensors and numbers (imag treated as zero), matching `eq_impl`.

## Test Plan

Added two regression tests in `test/complex_tensor/test_complex_tensor.py`:
- `test_mul_inplace_complex`: `mul_` returns the same object and equals the out-of-place product.
- `test_ne_real_operand`: `torch.ne` with a real left operand matches native complex `ne`.


cc @ezyang @anjali411 @dylanbespalko @mruberry @nikitaved @amjames