### PR TITLE
Attribute pinned failure-streak starts to their commit/PR in HUD tool

### DIFF
--- a/scripts/hud/analyze_failing_jobs.py
+++ b/scripts/hud/analyze_failing_jobs.py
@@ -124,7 +124,10 @@ def group_failures(jobs: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]
 
 
 def summarize_job(
-    name: str, statuses: list[dict[str, Any]], oldest_sha: str | None
+    name: str,
+    statuses: list[dict[str, Any]],
+    oldest_sha: str | None,
+    commit_meta: dict[str, dict[str, Any]],
 ) -> dict[str, Any]:
     real = [j for j in statuses if not is_skipped(j)]
     streak = current_failure_streak(statuses)
@@ -135,25 +138,36 @@ def summarize_job(
         reverse=True,
     )
     latest_real = real[0] if real else None
+    failing_since_sha = streak[-1].get("sha") if streak else None
+    # Clipped means the true start may predate the window, so more --commits
+    # could help. That needs two things: (A) every completed run in the
+    # window is a failure, so nothing pins the start (len(streak) == len(real)),
+    # and (B) the job still has data at the oldest fetched commit, so older
+    # data plausibly exists. (B) uses the oldest cell, not the oldest failure,
+    # to tolerate no-data gaps at the window edge. A job that simply stopped
+    # running earlier fails (B) and is not clipped.
+    clipped = (
+        bool(streak)
+        and len(streak) == len(real)
+        and bool(statuses)
+        and statuses[-1].get("sha") == oldest_sha
+    )
+    # When the start is pinned (not clipped), surface the suspected culprit: the
+    # commit/PR the streak began at. Left blank when clipped -- we don't know it.
+    meta = commit_meta.get(failing_since_sha) if not clipped else None
+    pr_num = meta.get("prNum") if meta else None
     return {
         "job_name": name,
         "current_conclusion": latest_real.get("conclusion") if latest_real else None,
         "total_runs": len(real),
         "current_streak": len(streak),
-        "failing_since_sha": streak[-1].get("sha") if streak else None,
-        # Clipped means the true start may predate the window, so more --commits
-        # could help. That needs two things: (A) every completed run in the
-        # window is a failure, so nothing pins the start (len(streak) == len(real)),
-        # and (B) the job still has data at the oldest fetched commit, so older
-        # data plausibly exists. (B) uses the oldest cell, not the oldest failure,
-        # to tolerate no-data gaps at the window edge. A job that simply stopped
-        # running earlier fails (B) and is not clipped.
-        "failing_since_clipped": (
-            bool(streak)
-            and len(streak) == len(real)
-            and bool(statuses)
-            and statuses[-1].get("sha") == oldest_sha
+        "failing_since_sha": failing_since_sha,
+        "failing_since_clipped": clipped,
+        "failing_since_date": (meta.get("time") or "")[:10] if meta else "",
+        "failing_since_pr_url": (
+            f"https://github.com/pytorch/pytorch/pull/{pr_num}" if pr_num else ""
         ),
+        "failing_since_pr_title": (meta.get("commitTitle") or "") if meta else "",
         "distinct_failures": distinct,
     }
 
@@ -172,6 +186,11 @@ def collect_stats(
     oldest_sha = next(
         (grid[-1].get("sha") for _, grid in reversed(pages) if grid), None
     )
+    # Per-commit metadata (time, PR number, title) to attribute a pinned streak
+    # start to its commit/PR.
+    commit_meta = {
+        row["sha"]: row for _, grid in pages for row in grid if row.get("sha")
+    }
     stats = []
     for name, statuses in transpose_grid(pages).items():
         if pattern and not pattern.match(name):
@@ -180,7 +199,7 @@ def collect_stats(
         # so its "streak" is ancient history, not a current failure.
         if not statuses or statuses[0].get("sha") != newest_sha:
             continue
-        summary = summarize_job(name, statuses, oldest_sha)
+        summary = summarize_job(name, statuses, oldest_sha, commit_meta)
         if summary["current_streak"] < min_streak:
             continue
         stats.append(summary)
@@ -248,6 +267,9 @@ def print_report(stats: list[dict[str, Any]], ref: str) -> None:
                 print(
                     "        (or earlier; failing throughout window, rerun with more --commits)"
                 )
+            elif s["failing_since_pr_url"]:
+                print(f"        {s['failing_since_date']} {s['failing_since_pr_url']}")
+                print(f"        {s['failing_since_pr_title']}")
         for failure in s["distinct_failures"]:
             capture = failure["capture"]
             if len(capture) > 100:
@@ -269,6 +291,9 @@ def write_csv(stats: list[dict[str, Any]]) -> None:
             "current_streak",
             "failing_since_sha",
             "failing_since_clipped",
+            "failing_since_date",
+            "failing_since_pr_url",
+            "failing_since_pr_title",
             "distinct_failures",
         ]
     )
@@ -284,6 +309,9 @@ def write_csv(stats: list[dict[str, Any]]) -> None:
                 s["current_streak"],
                 s["failing_since_sha"],
                 s["failing_since_clipped"],
+                s["failing_since_date"],
+                s["failing_since_pr_url"],
+                s["failing_since_pr_title"],
                 failures,
             ]
         )

--- a/scripts/hud/analyze_failing_jobs.py
+++ b/scripts/hud/analyze_failing_jobs.py
@@ -127,7 +127,7 @@ def summarize_job(
     name: str,
     statuses: list[dict[str, Any]],
     oldest_sha: str | None,
-    commit_meta: dict[str, dict[str, Any]],
+    commit_meta: dict[str, dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     real = [j for j in statuses if not is_skipped(j)]
     streak = current_failure_streak(statuses)
@@ -154,7 +154,7 @@ def summarize_job(
     )
     # When the start is pinned (not clipped), surface the suspected culprit: the
     # commit/PR the streak began at. Left blank when clipped -- we don't know it.
-    meta = commit_meta.get(failing_since_sha) if not clipped else None
+    meta = commit_meta.get(failing_since_sha) if (commit_meta and not clipped) else None
     pr_num = meta.get("prNum") if meta else None
     return {
         "job_name": name,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #188842

When a job's failure streak start is pinned within the window (not clipped),
surface the suspected culprit: the commit/PR the streak began at. The HUD
already returns per-commit time, PR number, and title in each row, so no extra
API calls are needed -- build a sha->commit map from the pages already fetched
and resolve the failing-since commit.

The text report prints the date, PR URL, and title under "failing since"; the
CSV gains failing_since_date, failing_since_pr_url, and failing_since_pr_title
columns. These are populated only when the start is pinned; clipped streaks
(true start unknown, possibly older than the window) leave them blank.

Test Plan:

    HUD_INTERNAL_BOT_TOKEN=<token> python scripts/hud/analyze_failing_jobs.py --commits 500 --csv > out.csv

Confirmed pinned rows carry the culprit PR date/url/title (e.g. #188107, dated
2026-06-28) while clipped rows leave those columns blank.

    lintrunner scripts/hud/analyze_failing_jobs.py

Authored with Claude.