### PR TITLE
Fix scatter/scatter_add/scatter_reduce src gradient when index is sma…

### DIFF
--- a/test/test_scatter_gather_ops.py
+++ b/test/test_scatter_gather_ops.py
@@ -8,7 +8,7 @@ import torch
 
 from torch.testing import make_tensor
 from torch.testing._internal.common_utils import \
-    (instantiate_parametrized_tests, parametrize, run_tests, skipIfNoCuteDSL,
+    (gradcheck, instantiate_parametrized_tests, parametrize, run_tests, skipIfNoCuteDSL,
      subtest, TestCase, DeterministicGuard, TEST_CUDA, TEST_WITH_ROCM, serialTest)
 from torch.testing._internal.common_device_type import \
     (instantiate_device_type_tests, onlyCPU, onlyAccelerator, dtypes, dtypesIfCUDA,
@@ -508,6 +508,74 @@ class TestScatterGather(TestCase):
                 res = inp.clone().scatter_add_(d, idx, src)
             self.assertEqual(res, ref)
 
+    @dtypes(torch.double)
+    def test_scatter_grads_index_smaller_than_src(self, device, dtype):
+        # Regression test for https://github.com/pytorch/pytorch/issues/94336
+        # The scatter family allows index.size(d) <= src.size(d) and an empty
+        # index of any dimensionality: only the src region covered by index
+        # participates in the output, so the remaining src elements must get
+        # zero gradient. The src gradient used to be index-shaped instead:
+        # backward errored for scatter/scatter_add/scatter_reduce(sum/mean)
+        # and was silently wrong for scatter_reduce(prod/amax/amin).
+        ops = [("scatter", None, None), ("scatter_add", None, None)]
+        ops += [("scatter_reduce", r, inc)
+                for r in ("sum", "prod", "mean", "amax", "amin")
+                for inc in (True, False)]
+
+        def apply_op(op, reduce, include_self, inp, idx, src):
+            if op == "scatter_reduce":
+                return torch.scatter_reduce(inp, 0, idx, src, reduce=reduce, include_self=include_self)
+            return getattr(torch, op)(inp, 0, idx, src)
+
+        # distinct, well-separated, nonzero values keep prod/amax/amin
+        # gradients well-defined and gradcheck stable
+        inp2 = torch.tensor([[8., -12., 3.], [-5., 10., -2.]], device=device, dtype=dtype)
+        src2 = torch.tensor([[6., -9., 14.], [-15., 4., -7.]], device=device, dtype=dtype)
+        inp1 = torch.tensor([8., -12., 3.], device=device, dtype=dtype)
+        src1 = torch.tensor([6., -9., 14.], device=device, dtype=dtype)
+        src0 = torch.tensor(6., device=device, dtype=dtype)
+        cases = ((inp2, src2, torch.empty(0, dtype=torch.long, device=device)),
+                 (inp2, src2, torch.empty(0, 3, dtype=torch.long, device=device)),
+                 (inp2, src2, torch.tensor([[0, 1]], device=device)),
+                 (inp2, src2, torch.tensor([[1], [0]], device=device)),
+                 # legacy rank mismatches: missing index dims act as size 1
+                 (inp1, src1, torch.tensor(1, device=device)),
+                 (inp1, src0, torch.tensor([1], device=device)))
+
+        for op, reduce, include_self in ops:
+            for inp_vals, src_vals, idx in cases:
+                msg = f"{op} reduce={reduce} include_self={include_self} index_shape={tuple(idx.shape)}"
+                inp = inp_vals.clone().requires_grad_()
+                src = src_vals.clone().requires_grad_()
+                out = apply_op(op, reduce, include_self, inp, idx, src)
+                grad_out = torch.arange(1., out.numel() + 1, device=device, dtype=dtype).view_as(out)
+                out.backward(grad_out)
+                if idx.numel() == 0:
+                    self.assertEqual(out, inp_vals, msg=msg)
+                    self.assertEqual(inp.grad, grad_out, msg=msg)
+                    self.assertEqual(src.grad, torch.zeros_like(src_vals), msg=msg)
+                else:
+                    # reference: the same op with index reshaped to its
+                    # effective sizes and src pre-narrowed to match, which
+                    # takes the equal-shape path
+                    eff = [idx.size(d) if d < idx.dim() else 1 for d in range(src_vals.dim())]
+                    domain = tuple(slice(s) for s in eff)
+                    inp_ref = inp_vals.clone().requires_grad_()
+                    src_ref = src_vals[domain].clone().requires_grad_()
+                    out_ref = apply_op(op, reduce, include_self, inp_ref, idx.reshape(eff), src_ref)
+                    self.assertEqual(out, out_ref, msg=msg)
+                    out_ref.backward(grad_out)
+                    expected_src_grad = torch.zeros_like(src_vals)
+                    expected_src_grad[domain] = src_ref.grad
+                    self.assertEqual(src.grad, expected_src_grad, msg=msg)
+                    self.assertEqual(inp.grad, inp_ref.grad, msg=msg)
+
+                # forward-mode AD with an empty or non-broadcastable smaller
+                # index used to fail as well (scatter_reduce prod has no jvp)
+                forward_ad = not (op == "scatter_reduce" and reduce == "prod")
+                gradcheck(lambda inp, src, idx=idx: apply_op(op, reduce, include_self, inp, idx, src),
+                          (inp_vals.clone().requires_grad_(), src_vals.clone().requires_grad_()),
+                          check_forward_ad=forward_ad)
 
     @onlyCPU
     @dtypes(torch.float32, torch.float64, torch.bfloat16)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1504,7 +1504,7 @@
 - name: scatter.src(Tensor self, int dim, Tensor index, Tensor src) -> Tensor
   self: grad.scatter(dim, index, 0)
   index: non_differentiable
-  src: grad.gather(dim, index)
+  src: scatter_src_backward(grad, dim, index, src.sym_sizes())
   result: self_t.scatter(dim, index, src_t)
 
 - name: scatter.value(Tensor self, int dim, Tensor index, Scalar value) -> Tensor
@@ -1515,7 +1515,7 @@
 - name: scatter_add(Tensor self, int dim, Tensor index, Tensor src) -> Tensor
   self: grad
   index: non_differentiable
-  src: grad.gather(dim, index)
+  src: scatter_src_backward(grad, dim, index, src.sym_sizes())
   result: scatter_add(self_t, dim, index, src_t)
 
 - name: select.int(Tensor(a) self, int dim, SymInt index) -> Tensor(a)

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -7420,6 +7420,54 @@ std::tuple<Tensor, Tensor> _cudnn_convolution_backward(
       std::move(std::get<0>(grad_inputs)), std::move(std::get<1>(grad_inputs)));
 }
 
+// The scatter family allows index.size(d) <= src.size(d) for all d, an empty
+// index of any shape, and legacy rank-mismatched 0-dim/1-dim combinations
+// where missing index dims act as size 1: only the leading src region covered
+// by index participates in the output, so the gradient outside it is zero.
+static Tensor narrow_to_index_domain(Tensor t, const Tensor& index) {
+  for (const auto d : c10::irange(t.dim())) {
+    const auto len = d < index.dim() ? index.sym_size(d) : c10::SymInt(1);
+    t = t.narrow_symint(d, 0, len);
+  }
+  return t;
+}
+
+static Tensor embed_index_domain_grad(
+    const Tensor& grad_at_index,
+    const Tensor& index,
+    c10::SymIntArrayRef src_sizes) {
+  if (index.sym_numel() == 0) {
+    return at::zeros_symint(src_sizes, grad_at_index.options());
+  }
+  const auto src_rank = static_cast<int64_t>(src_sizes.size());
+  std::vector<c10::SymInt> domain_sizes;
+  domain_sizes.reserve(src_rank);
+  for (const auto d : c10::irange(src_rank)) {
+    domain_sizes.push_back(
+        d < index.dim() ? index.sym_size(d) : c10::SymInt(1));
+  }
+  // pad lists (before, after) pairs from the last dim backwards
+  std::vector<c10::SymInt> pad;
+  pad.reserve(2 * src_rank);
+  for (auto d = src_rank - 1; d >= 0; --d) {
+    pad.emplace_back(0);
+    pad.push_back(src_sizes[d] - domain_sizes[d]);
+  }
+  return at::constant_pad_nd_symint(
+      grad_at_index.reshape_symint(domain_sizes), pad, 0);
+}
+
+Tensor scatter_src_backward(
+    const Tensor& grad,
+    int64_t dim,
+    const Tensor& index,
+    c10::SymIntArrayRef src_sizes) {
+  if (index.sym_sizes().equals(src_sizes)) {
+    return grad.gather(dim, index);
+  }
+  return embed_index_domain_grad(grad.gather(dim, index), index, src_sizes);
+}
+
 Tensor scatter_reduce_jvp(
     const Tensor& self_p,
     const Tensor& self_t,
@@ -7430,6 +7478,10 @@ Tensor scatter_reduce_jvp(
     std::string_view reduce,
     bool include_self,
     const Tensor& result) {
+  if (index.sym_numel() == 0) {
+    // The output equals self: no src element participates in the reduction
+    return self_t.clone();
+  }
   if (reduce == "sum" || reduce == "mean") {
     // The function is linear
     return at::scatter_reduce(self_t, dim, index, src_t, reduce, include_self);
@@ -7437,10 +7489,18 @@ Tensor scatter_reduce_jvp(
     //  return at::where(mask, dx, 0.).sum(dim, keepdim) / mask.sum(dim,
     //  keepdim);
   } else if (reduce == "amin" || reduce == "amax") {
+    auto src_p_in = src_p;
+    auto src_t_in = src_t;
+    if (!index.sym_sizes().equals(src_p.sym_sizes())) {
+      src_p_in = narrow_to_index_domain(src_p_in, index)
+                     .reshape_symint(index.sym_sizes());
+      src_t_in = narrow_to_index_domain(src_t_in, index)
+                     .reshape_symint(index.sym_sizes());
+    }
     auto gather_result = at::gather(result, dim, index);
     auto mask_self = self_p == result;
-    auto mask_src = src_p == gather_result;
-    auto masked_src_t = at::where(mask_src, src_t, 0.);
+    auto mask_src = src_p_in == gather_result;
+    auto masked_src_t = at::where(mask_src, src_t_in, 0.);
     auto div =
         mask_self.to(self_t.dtype())
             .scatter_reduce(
@@ -7473,6 +7533,20 @@ std::tuple<Tensor, Tensor> scatter_reduce_backward(
     return std::make_tuple(std::move(grad_self), std::move(grad_src));
   }
 
+  if (index.sym_numel() == 0) {
+    // The output equals self: no src element participates in the reduction
+    grad_self = grad;
+    grad_src = at::zeros_symint(src.sym_sizes(), grad.options());
+    return std::make_tuple(std::move(grad_self), std::move(grad_src));
+  }
+
+  // Only the src region covered by index participates in the output; compute
+  // index-shaped src gradients and embed them into src-shaped zeros at the end
+  const bool index_shape_mismatch = !index.sym_sizes().equals(src.sym_sizes());
+  Tensor src_in = index_shape_mismatch
+      ? narrow_to_index_domain(src, index).reshape_symint(index.sym_sizes())
+      : src;
+
   if (reduce == "sum") {
     grad_self = grad;
     grad_src = grad.gather(dim, index);
@@ -7480,9 +7554,9 @@ std::tuple<Tensor, Tensor> scatter_reduce_backward(
     // Explicitly compute exclusive prod for elements in self/src that are 0
     Tensor masked_self = self.masked_fill(self == 0, 1);
     Tensor masked_self_result =
-        masked_self.scatter_reduce(dim, index, src, reduce, include_self);
+        masked_self.scatter_reduce(dim, index, src_in, reduce, include_self);
     grad_self = grad * masked_self_result / masked_self;
-    Tensor src_zero = src == 0;
+    Tensor src_zero = src_in == 0;
     Tensor src_num_zeros =
         zeros_like(self)
             .scatter_add(dim, index, src_zero.to(self.dtype()))
@@ -7491,13 +7565,13 @@ std::tuple<Tensor, Tensor> scatter_reduce_backward(
     // For src positions with src_single_zero, grad * result.gather(dim,index) /
     // src.masked_fill(src_zero, 1) would incorrectly propagate zeros as the
     // gradient
-    Tensor masked_src = src.masked_fill(src_single_zero, 1);
+    Tensor masked_src = src_in.masked_fill(src_single_zero, 1);
     Tensor masked_src_result =
         self.scatter_reduce(dim, index, masked_src, reduce, include_self);
     Tensor grad_src1 = where(
         src_single_zero,
         (grad * masked_src_result).gather(dim, index),
-        (grad * result).gather(dim, index) / src.masked_fill(src_zero, 1));
+        (grad * result).gather(dim, index) / src_in.masked_fill(src_zero, 1));
     // GradMode::is_enabled() - adding the autograd Node is a no-op if autograd
     // is disabled; this also avoids having the item() call in the usual case.
     if (GradMode::is_enabled() && (src_num_zeros > 1).any().item<bool>()) {
@@ -7511,7 +7585,7 @@ std::tuple<Tensor, Tensor> scatter_reduce_backward(
     }
   } else if (reduce == "mean") {
     Tensor N = include_self ? ones_like(grad) : zeros_like(grad);
-    N = N.scatter_add(dim, index, ones_like(src));
+    N = N.scatter_add(dim, index, ones_like(src_in));
     N.masked_fill_(N == 0, 1);
     grad_self = grad / N;
     Tensor N_src = N.gather(dim, index);
@@ -7520,12 +7594,12 @@ std::tuple<Tensor, Tensor> scatter_reduce_backward(
     // Evenly distribute gradient when there are multiple max/mins
     Tensor value = result.gather(dim, index);
     Tensor self_is_result = (self == result).to(self.scalar_type());
-    Tensor src_is_result = (src == value).to(self.scalar_type());
+    Tensor src_is_result = (src_in == value).to(self.scalar_type());
     Tensor N_to_distribute =
         self_is_result.scatter_add(dim, index, src_is_result);
     Tensor grad_distributed = grad / N_to_distribute;
     grad_self = (self == result) * grad_distributed;
-    grad_src = (src == value) * grad_distributed.gather(dim, index);
+    grad_src = (src_in == value) * grad_distributed.gather(dim, index);
   } else {
     TORCH_CHECK(
         false,
@@ -7536,6 +7610,10 @@ std::tuple<Tensor, Tensor> scatter_reduce_backward(
 
   if (!include_self) {
     grad_self = grad_self.scatter(dim, index, 0);
+  }
+
+  if (index_shape_mismatch) {
+    grad_src = embed_index_domain_grad(grad_src, index, src.sym_sizes());
   }
 
   return std::make_tuple(std::move(grad_self), std::move(grad_src));

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -7440,14 +7440,14 @@ static Tensor embed_index_domain_grad(
     return at::zeros_symint(src_sizes, grad_at_index.options());
   }
   const auto src_rank = static_cast<int64_t>(src_sizes.size());
-  std::vector<c10::SymInt> domain_sizes;
+  at::SymDimVector domain_sizes;
   domain_sizes.reserve(src_rank);
   for (const auto d : c10::irange(src_rank)) {
     domain_sizes.push_back(
         d < index.dim() ? index.sym_size(d) : c10::SymInt(1));
   }
   // pad lists (before, after) pairs from the last dim backwards
-  std::vector<c10::SymInt> pad;
+  at::SymDimVector pad;
   pad.reserve(2 * src_rank);
   for (auto d = src_rank - 1; d >= 0; --d) {
     pad.emplace_back(0);

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -7426,8 +7426,8 @@ std::tuple<Tensor, Tensor> _cudnn_convolution_backward(
 // by index participates in the output, so the gradient outside it is zero.
 static Tensor narrow_to_index_domain(Tensor t, const Tensor& index) {
   for (const auto d : c10::irange(t.dim())) {
-    const auto len = d < index.dim() ? index.sym_size(d) : c10::SymInt(1);
-    t = t.narrow_symint(d, 0, len);
+    t = t.narrow_symint(
+        d, 0, d < index.dim() ? index.sym_size(d) : c10::SymInt(1));
   }
   return t;
 }

--- a/torch/csrc/autograd/FunctionsManual.h
+++ b/torch/csrc/autograd/FunctionsManual.h
@@ -1132,6 +1132,12 @@ std::tuple<Tensor, Tensor> _cudnn_convolution_backward(
     c10::SymInt groups,
     ::std::array<bool, 2> output_mask);
 
+Tensor scatter_src_backward(
+    const Tensor& grad,
+    int64_t dim,
+    const Tensor& index,
+    c10::SymIntArrayRef src_sizes);
+
 Tensor scatter_reduce_jvp(
     const Tensor& self_p,
     const Tensor& self_t,


### PR DESCRIPTION
## Issue

Fixes #94336
Fixes #27614

## Summary

The scatter family accepts an `index` smaller than `src` (`index.size(d) <= src.size(d)`, an empty index of any dimensionality, and legacy rank-mismatched 0-dim/1-dim combinations where missing index dims act as size 1); only the src region covered by index participates in the output.

Root cause: the reverse-mode formulas compute the src gradient as `grad.gather(dim, index)`, which has index's shape instead of src's. Backward errors with "invalid gradient" for `scatter`, `scatter_add` and `scatter_reduce(sum|mean)`, and silently returns wrong gradients for `scatter_reduce(prod|amax|amin)`, where index-shaped intermediates broadcast against src-shaped masks. Forward AD of `scatter_reduce(amax|amin)` hits the same broadcast problem.

Fix: compute the index-shaped src gradient against the covered src slice (`narrow` + `reshape` to index's shape) and embed it at the leading corner of a src-shaped zero gradient with `constant_pad_nd` (out-of-place, so vmap-over-backward keeps working). When index and src shapes match, the path is the previous `grad.gather(dim, index)`, unchanged. An empty index early-returns: the output equals `self`, so the src gradient is zero and the jvp is `self_t`.

## Test Plan

Added a device-generic regression test covering `scatter`/`scatter_add`/`scatter_reduce` (all reduce modes, both `include_self` values) with empty 1-D/2-D, smaller non-empty, and legacy rank-mismatched indices. It checks analytic gradients against a reference run with index reshaped to its effective sizes and src pre-narrowed to match (the always-correct equal-shape path) and runs `gradcheck` with forward AD.

```
python test/test_scatter_gather_ops.py -k test_scatter_grads_index_smaller_than_src
python test/test_scatter_gather_ops.py
python test/test_autograd.py -k scatter
python test/test_ops_gradients.py -k scatter
python test/test_ops_fwd_gradients.py -k scatter
python test/test_ops.py -k scatter TestCommonCPU
lintrunner tools/autograd/derivatives.yaml torch/csrc/autograd/FunctionsManual.cpp torch/csrc/autograd/FunctionsManual.h test/test_scatter_gather_ops.py
```

All pass on CPU (macOS arm64, Python 3.13). Also verified `torch.compile(dynamic=True)` backward matches eager for empty, smaller and equal-shape indices, and `gradgradcheck` for double backward.

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No. Cases that previously errored now compute correct gradients; the equal-shape path is unchanged.
