### PR TITLE
Fix torch.pow docstring: scalar params are Number, not float

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -8673,7 +8673,7 @@ and :attr:`exponent` must be :ref:`broadcastable <broadcasting-semantics>`.
 
 Args:
     {input}
-    exponent (Number or Tensor): the exponent value
+    exponent (Number or complex or Tensor): the exponent value
 
 Keyword args:
     {out}
@@ -8707,7 +8707,7 @@ The operation applied is:
     \text{{out}}_i = \text{{self}} ^ {{\text{{exponent}}_i}}
 
 Args:
-    self (Number): the scalar base value for the power operation
+    self (Number or complex): the scalar base value for the power operation
     exponent (Tensor): the exponent tensor
 
 Keyword args:

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -8654,7 +8654,7 @@ pow(input, exponent, *, out=None) -> Tensor
 Takes the power of each element in :attr:`input` with :attr:`exponent` and
 returns a tensor with the result.
 
-:attr:`exponent` can be either a single ``float`` number or a `Tensor`
+:attr:`exponent` can be either a single number or a `Tensor`
 with the same number of elements as :attr:`input`.
 
 When :attr:`exponent` is a scalar value, the operation applied is:
@@ -8673,7 +8673,7 @@ and :attr:`exponent` must be :ref:`broadcastable <broadcasting-semantics>`.
 
 Args:
     {input}
-    exponent (float or tensor): the exponent value
+    exponent (Number or Tensor): the exponent value
 
 Keyword args:
     {out}
@@ -8698,7 +8698,7 @@ Example::
 .. function:: pow(self, exponent, *, out=None) -> Tensor
    :noindex:
 
-:attr:`self` is a scalar ``float`` value, and :attr:`exponent` is a tensor.
+:attr:`self` is a scalar value, and :attr:`exponent` is a tensor.
 The returned tensor :attr:`out` is of the same shape as :attr:`exponent`
 
 The operation applied is:
@@ -8707,7 +8707,7 @@ The operation applied is:
     \text{{out}}_i = \text{{self}} ^ {{\text{{exponent}}_i}}
 
 Args:
-    self (float): the scalar base value for the power operation
+    self (Number): the scalar base value for the power operation
     exponent (Tensor): the exponent tensor
 
 Keyword args:


### PR DESCRIPTION
The `torch.pow` docstring types both scalar parameters as `float`, but they accept any `Number`:

- `pow(input, exponent)`: the `exponent` Args entry reads `exponent (float or tensor)`, but the ATen schema is `pow.Tensor_Scalar(Tensor self, Scalar exponent)`, so a scalar `exponent` is a `Scalar` (any Number). The docstring's own example passes an int: `torch.pow(a, 2)`.
- `pow(self, exponent)`: the `self` Args entry reads `self (float)`, but the ATen schema is `pow.Scalar(Scalar self, Tensor exponent)`, so the scalar base is a `Scalar` (any Number). The docstring's own example passes an int base: `base = 2` then `torch.pow(base, exp)`.

This mirrors the recently corrected `linspace`/`logspace` docstrings (#188378), where `start`/`end` were similarly documented as `float` instead of `Number`. `Number` is the established house style in this file for scalar parameters (`arange`, `clamp`, `addcmul`'s `value`, etc.).

The change is docs-only: it updates the two Args entries and the two matching prose sentences so the documented types match the schema and the file's convention. No behavior change.
