### PR TITLE
[profiler][cupti] PM sampling engine

### DIFF
--- a/test/profiler/test_cupti_pm_sampling.py
+++ b/test/profiler/test_cupti_pm_sampling.py
@@ -1,0 +1,223 @@
+# Owner(s): ["oncall: profiler"]
+"""Tests for CUPTI PM sampling (``torch.profiler._cupti.pm_sampling``).
+
+Covers the PmSampler sizing (decode-image = process-wide look-back / interval, capped), metric
+selection + non-empty enforcement, and discovery -- exercised through real CUPTI PM sampling
+(needs a perfmon-capable GPU; the tests skip otherwise).
+"""
+
+import time
+import unittest
+
+import torch
+from torch.profiler._cupti.pm_sampling import (
+    _DEFAULT_WINDOW_NS,
+    _MAX_SAMPLES_CAP,
+    _SAMPLING_INTERVAL_NS,
+    PmSampler,
+    supported_metrics,
+)
+from torch.testing._internal.common_utils import run_tests, TEST_WITH_ROCM, TestCase
+from torch.utils._import_utils import _check_module_exists
+
+
+# Metrics are per-consumer (PmSampler.add_consumer), with no built-in default, so tests pass an
+# explicit set (single-pass on the default 4-counter chips).
+_TEST_METRICS = (
+    "sm__cycles_active.avg.pct_of_peak_sustained_elapsed",
+    "gpu__dram_throughput.avg.pct_of_peak_sustained_elapsed",
+    "nvlrx__bytes.avg.pct_of_peak_sustained_elapsed",
+    "nvltx__bytes.avg.pct_of_peak_sustained_elapsed",
+)
+
+
+TEST_CUDA = torch.cuda.is_available()
+# cupti-python is pip-installable on ROCm hosts too, but CUPTI itself is a no-op there.
+TEST_CUPTI_PYTHON = _check_module_exists("cupti") and not TEST_WITH_ROCM
+
+
+def _cupti_version() -> int:
+    if not TEST_CUPTI_PYTHON:
+        return 0
+    try:
+        from torch.profiler._cupti.cupti_python import pylibcupti
+
+        return pylibcupti().get_version()
+    except Exception:
+        return 0
+
+
+# PM sampling goes through the CUPTI profiler API; gate it at the same >= 13.3 as the monitor.
+TEST_CUPTI_V13_3 = TEST_CUPTI_PYTHON and _cupti_version() >= 130300
+
+
+def _pm_sampling_available() -> bool:
+    # Needs CUDA, libcupti >= 13.3, and the cupti.pm_sampling module. Whether the HW can actually
+    # engage (perfmon access) is only known at start(), so tests still skip at runtime when no
+    # session comes up.
+    if not (TEST_CUDA and TEST_CUPTI_V13_3):
+        return False
+    from torch.profiler._cupti.pm_sampling import is_available
+
+    return is_available()
+
+
+TEST_CUPTI_PM_SAMPLING = _pm_sampling_available()
+
+
+@unittest.skipIf(
+    not TEST_CUPTI_PM_SAMPLING, "requires cupti pm_sampling + a capable CUDA GPU"
+)
+class TestPmSamplingWindowSizing(TestCase):
+    """PM-sampling window sizing exercised through real CUPTI PM sampling: a PmSampler configured
+    with a window + interval samples live GPU work, and the decoded frames confirm the sizing --
+    max_samples = window // interval flows through configure()/decode(), each frame carries a column
+    per metric, HW timestamps are monotonic, and the decoded span stays within the requested window.
+    Skips at runtime when PM sampling cannot engage on the host (needs perfmon-capable HW)."""
+
+    def _run_gpu_work(self, seconds: float = 0.2) -> None:
+        a = torch.randn(512, 512, device="cuda")
+        deadline = time.time() + seconds
+        while time.time() < deadline:
+            a = torch.relu(a @ a)
+        torch.cuda.synchronize()
+
+    def _collect(self, metrics=_TEST_METRICS) -> tuple[PmSampler, list]:
+        # Real session: the first add_consumer enables PM sampling on the current device via CUPTI,
+        # we drive some GPU work, and poll() decodes the ring into `frames` (raw HW-ns timestamps).
+        frames: list = []
+        sampler = PmSampler.for_device(torch.cuda.current_device())
+        handle = sampler.add_consumer(list(metrics), frames.append)
+        self.addCleanup(sampler.remove_consumer, handle)
+        if sampler._col is None:
+            self.skipTest("PM sampling could not start on this GPU")
+        self._run_gpu_work()
+        sampler.poll()
+        return sampler, frames
+
+    def test_max_samples_from_process_config(self):
+        # max_samples = look-back / interval (process-wide env), clamped to the cap; accepted by a
+        # real configure()/decode() (start sizes the ring from it via get_counter_data_size).
+        sampler, _ = self._collect()
+        expected = min(_DEFAULT_WINDOW_NS // _SAMPLING_INTERVAL_NS, _MAX_SAMPLES_CAP)
+        self.assertEqual(sampler._max_samples, expected)
+
+    def test_empty_metrics_rejected(self):
+        # A consumer must bring a non-empty metric set; add_consumer rejects an empty one.
+        sampler = PmSampler.for_device(torch.cuda.current_device())
+        with self.assertRaises(ValueError):
+            sampler.add_consumer((), lambda frame: None)
+        self.assertIsNone(sampler._col)
+
+    def test_multipass_metrics_rejected(self):
+        # PM sampling is single-pass only; a metric that needs multiple passes (sm__throughput.*
+        # needs ~8) is rejected by add_consumer -> ValueError, no session, running state untouched.
+        sampler = PmSampler.for_device(torch.cuda.current_device())
+        with self.assertRaises(ValueError) as cm:
+            sampler.add_consumer(
+                ["sm__throughput.avg.pct_of_peak_sustained_elapsed"],
+                lambda frame: None,
+            )
+        self.assertIn("pass", str(cm.exception).lower())
+        self.assertIsNone(sampler._col)
+
+    def test_suggested_poll_interval_under_ring_span(self):
+        # The recommended poll cadence drains a little before the ring fills (one window span minus a
+        # buffer), so periodic polls are productive without hitting the decode overflow cap.
+        sampler = PmSampler.for_device(torch.cuda.current_device())
+        span = sampler._max_samples * sampler._sampling_interval_ns
+        self.assertGreater(sampler.suggested_poll_interval_ns, 0)
+        self.assertLess(sampler.suggested_poll_interval_ns, span)
+
+    def test_decoded_frames_have_per_metric_columns(self):
+        # Each sampled metric is a value column keyed by its metric name (self-describing frame).
+        _, frames = self._collect()
+        if not frames:
+            self.skipTest("no PM samples produced on this GPU")
+        for f in frames:
+            self.assertIn("start_ns", f)
+            self.assertIn("device_id", f)
+            for name in _TEST_METRICS:
+                self.assertIn(name, f)
+
+    def test_decoded_span_within_lookback(self):
+        import numpy as np
+
+        _, frames = self._collect()
+        ts = (
+            np.concatenate([f["start_ns"] for f in frames])
+            if frames
+            else np.empty(0, dtype=np.int64)
+        )
+        if ts.size == 0:
+            self.skipTest("no PM samples produced on this GPU")
+        self.assertTrue((np.diff(np.sort(ts)) >= 0).all())  # monotonic HW timestamps
+        self.assertLessEqual(int(ts.max() - ts.min()), _DEFAULT_WINDOW_NS)
+
+    def test_select_metrics_by_name(self):
+        # A caller passes metric name strings; each selected metric becomes its own frame column.
+        chosen = list(_TEST_METRICS[:2])
+        sampler, frames = self._collect(metrics=chosen)
+        self.assertEqual(sampler._metric_names, chosen)
+        if not frames:
+            self.skipTest("no PM samples produced on this GPU")
+        for f in frames:
+            for name in chosen:
+                self.assertIn(name, f)
+            self.assertNotIn(_TEST_METRICS[2], f)  # unselected
+
+    def test_supported_metrics_lists_chip_counters(self):
+        metrics = supported_metrics()
+        if not metrics:
+            self.skipTest("profiler host could not enumerate metrics on this chip")
+        self.assertTrue(all(isinstance(m, str) for m in metrics))
+        base = {m.split(".", 1)[0] for m in metrics}
+        self.assertIn(
+            "sm__cycles_active", base
+        )  # our default SM counter is in the menu
+
+    def test_unknown_metric_warns(self):
+        # A metric the chip does not report is warned about (not silently accepted).
+        supported = supported_metrics()
+        if not supported:
+            self.skipTest("profiler host could not enumerate metrics on this chip")
+        sampler = PmSampler.for_device(torch.cuda.current_device())
+        with self.assertLogs(
+            "torch.profiler._cupti.pm_sampling", level="WARNING"
+        ) as cm:
+            handle = sampler.add_consumer(
+                ["not__a_real_metric.avg"], lambda frame: None
+            )
+            self.addCleanup(sampler.remove_consumer, handle)
+        self.assertTrue(any("not reported by this chip" in m for m in cm.output))
+
+    def test_multiple_consumers_share_session(self):
+        # Two consumers on one device share the single session: it samples the union of their
+        # metrics, and each consumer's frames carry only its own metric columns.
+        a_metrics, b_metrics = [_TEST_METRICS[0]], list(_TEST_METRICS[1:3])
+        a_frames: list = []
+        b_frames: list = []
+        sampler = PmSampler.for_device(torch.cuda.current_device())
+        a = sampler.add_consumer(a_metrics, a_frames.append)
+        self.addCleanup(sampler.remove_consumer, a)
+        b = sampler.add_consumer(b_metrics, b_frames.append)
+        self.addCleanup(sampler.remove_consumer, b)
+        if sampler._col is None:
+            self.skipTest("PM sampling could not start on this GPU")
+        # The session samples the union (dedup, order-preserving).
+        self.assertEqual(sampler._metric_names, a_metrics + b_metrics)
+        self._run_gpu_work()
+        sampler.poll()
+        if not a_frames or not b_frames:
+            self.skipTest("no PM samples produced on this GPU")
+        for f in a_frames:  # only consumer A's metric
+            self.assertIn(a_metrics[0], f)
+            self.assertNotIn(b_metrics[0], f)
+        for f in b_frames:  # only consumer B's metrics
+            for name in b_metrics:
+                self.assertIn(name, f)
+            self.assertNotIn(a_metrics[0], f)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/profiler/_cupti/pm_sampling.py
+++ b/torch/profiler/_cupti/pm_sampling.py
@@ -1,0 +1,477 @@
+# mypy: allow-untyped-defs
+"""CUPTI PM-sampling: continuous GPU performance-monitor sampling (SM-active %, DRAM-throughput
+%) that runs concurrently with the activity monitor.
+
+PM sampling reads dedicated on-chip performance-monitor units, so it has negligible GPU-side cost
+and coexists with the activity subscriber, but it locks the GPU clocks while active (which can
+shift absolute kernel durations) -- so it is opt-in via custom_profiler_config
+{"enable_pm_sampling": true}, not always-on like the environment counters.
+
+The HW units sample autonomously into a device-side ring (KEEP_LATEST) between start and decode,
+so there is no background thread: the first consumer opens the session and the ring is drained by
+:meth:`~PmSampler.poll` (and a final tail-drain when the last consumer leaves) -- crucially
+*before* disabling, since a wrapped ring is only decodable while sampling is active. A window that
+fits the ring yields all its samples; one that exceeds it keeps the most recent (the trace's tail)
+rather than erroring. ``decode`` drains the whole ring in one call and caps at its ``max_samples``
+(a second call does not resume), so the host image is sized above the ring's sample capacity.
+Samples are HW-timestamped in the CUPTI clock domain (raw); converting them to trace time is the
+consumer's job (the sampler has no clock dependency), and doing so against the base the monitor's
+record timestamps use aligns them with the activity records; they surface as GPU counter tracks
+(siblings of the environment counters).
+
+There is one :class:`PmSampler` per CUDA device -- a per-device singleton (see
+:meth:`~PmSampler.for_device`), a single collector per device. Lifecycle follows NVIDIA's
+cupti-python PM sampling sample: ``enable`` -> ``configure`` -> ``start`` -> drain -> ``stop`` ->
+``disable``, where ``disable`` deinitializes the process-global CUPTI profiler. That deinit is
+*not* refcounted, so the per-device singleton matters: it keeps init/deinit balanced one-per-cycle
+(two concurrent collectors each disabling would double-deinit and segfault -- why we sample only
+the one device we profile)."""
+
+from __future__ import annotations
+
+import functools
+import logging
+import os
+import threading
+from typing import Any, TYPE_CHECKING
+
+import numpy as np
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
+
+logger = logging.getLogger(__name__)
+
+# Interval + look-back are configured process-wide via env read at import (set them before importing
+# torch); metrics are NOT -- each consumer brings its own via add_consumer(). The HW sampling
+# interval (GPU_TIME_INTERVAL units = ns); TORCH_CUPTI_PM_SAMPLING_INTERVAL_MS, default 1 ms.
+_SAMPLING_INTERVAL_NS = int(
+    float(os.environ.get("TORCH_CUPTI_PM_SAMPLING_INTERVAL_MS", 1)) * 1_000_000
+)
+# Retained look-back window: the sampler is sized (max_samples + ring) to cover this much wall-clock
+# at the interval. Kept modest because the host counter-data image is ~18 KiB/sample (see
+# _counter_data_size), so a decode of window/interval samples allocates that many.
+# TORCH_CUPTI_PM_SAMPLING_LOOKBACK_MS, default 10 s.
+_DEFAULT_WINDOW_NS = int(
+    float(os.environ.get("TORCH_CUPTI_PM_SAMPLING_LOOKBACK_MS", 10_000)) * 1_000_000
+)
+# Ceiling on max_samples (decode image + ring) so an extreme look-back/interval can't allocate an
+# unbounded image; cap it and warn that the retained window is truncated. ~16k samples ~= 300 MB
+# for 4 metrics.
+_MAX_SAMPLES_CAP = 16384
+
+
+def is_available() -> bool:
+    try:
+        import cupti.pm_sampling  # noqa: F401  # pyrefly: ignore[missing-import]
+    except Exception:
+        return False
+    return True
+
+
+def _counter_data_size(
+    pm_sampling_object: int, metrics: list[str], max_samples: int
+) -> int:
+    """Exact byte size of the counter-data image that holds ``max_samples`` samples for ``metrics``
+    (CUPTI's ``pm_sampling_get_counter_data_size``). Used to size the HW ring to the target window
+    -- no per-sample byte estimate -- and it's the same size ``decode`` allocates for its image."""
+    from cupti import cupti as c  # pyrefly: ignore[missing-import]
+    from cupti.pm_sampling import metrics_to_c_array  # pyrefly: ignore[missing-import]
+
+    _, metric_names_ptr = metrics_to_c_array(metrics)
+    p = c.PmSampling_GetCounterDataSize_Params()
+    p.struct_size = c.PM_SAMPLING_GET_COUNTER_DATA_SIZE_PARAMS_STRUCT_SIZE
+    p.p_pm_sampling_object = pm_sampling_object
+    p.p_metric_names = metric_names_ptr
+    p.num_metrics = len(metrics)
+    p.max_samples = max_samples
+    c.pm_sampling_get_counter_data_size(p.ptr)
+    return p.counter_data_size
+
+
+def _device_chip_name(device: int) -> str:
+    """The CUPTI chip name (e.g. 'GB100') for a CUDA device index -- the key the profiler-host
+    metric queries use."""
+    from cupti import cupti as c  # pyrefly: ignore[missing-import]
+
+    p = c.Device_GetChipName_Params()
+    p.struct_size = c.DEVICE_GET_CHIP_NAME_PARAMS_STRUCT_SIZE
+    p.device_index = device
+    c.device_get_chip_name(p.ptr)
+    return p.p_chip_name
+
+
+@functools.cache
+def supported_metrics(*, with_sub_metrics: bool = False) -> frozenset[str]:
+    """The PM-counter metric names CUPTI reports for the current CUDA device's chip -- the menu to
+    pick ``add_consumer(metrics=...)`` metrics from. The chip name is resolved from the device via
+    CUPTI (:func:`_device_chip_name`). ``with_sub_metrics`` expands each base metric to its
+    rollup/suffix forms (e.g. ``sm__cycles_active.avg.pct_of_peak_sustained_elapsed``, the
+    fully-qualified names ``configure`` accepts); otherwise the base names. Memoized (the
+    profiler-host query is expensive and the chip is constant for a process); returns a frozenset,
+    empty if PM sampling or the profiler host is unavailable. NOTE: not every returned metric is
+    single-pass and a chosen set must all fit in one PM-sampling pass -- CUPTI validates that when a
+    consumer is added."""
+    if not is_available():
+        return frozenset()
+    try:
+        from cupti import profiler_host as ph  # pyrefly: ignore[missing-import]
+        from cupti.cupti import (  # pyrefly: ignore[missing-import]
+            MetricType,
+            ProfilerType,
+        )
+    except Exception:
+        return frozenset()
+    try:
+        import torch
+
+        chip_name = _device_chip_name(torch.cuda.current_device())
+    except Exception as e:
+        logger.warning("PM sampling could not resolve the chip name: %s", e)
+        return frozenset()
+    # PM_SAMPLING is the relevant type; fall back to RANGE_PROFILER (same base-metric DB) if its
+    # host cannot initialize without a single-pass set name on this CUPTI version.
+    for profiler_type in (ProfilerType.PM_SAMPLING, ProfilerType.RANGE_PROFILER):
+        try:
+            host = ph.ProfilerHost(chip_name, profiler_type)
+            host.initialize()
+        except Exception:
+            continue
+        try:
+            names: set[str] = set()
+            for mt in (MetricType.COUNTER, MetricType.RATIO, MetricType.THROUGHPUT):
+                for base in host.get_base_metrics(mt):
+                    names.update(
+                        host.get_sub_metrics(base, mt) if with_sub_metrics else (base,)
+                    )
+            return frozenset(names)
+        except Exception as e:
+            logger.warning("PM sampling metric enumeration failed: %s", e)
+            return frozenset()
+        finally:
+            host.deinitialize()
+    logger.warning(
+        "PM sampling profiler host could not initialize for chip %s", chip_name
+    )
+    return frozenset()
+
+
+class _Consumer:
+    """A registered PM-sampling consumer: the metric names it wants and the sink its frames go to.
+    Returned by :meth:`PmSampler.add_consumer` as the opaque handle for
+    :meth:`PmSampler.remove_consumer`."""
+
+    __slots__ = ("metrics", "sink")
+
+    def __init__(
+        self, metrics: list[str], sink: Callable[[dict[str, Any]], None]
+    ) -> None:
+        self.metrics = metrics
+        self.sink = sink
+
+
+class PmSampler:
+    """The single PM-sampling session on one CUDA device -- a per-device singleton (see
+    :meth:`for_device`). Only one PM session per device is possible, and the shared CUPTI profiler's
+    init/deinit is not refcounted (two concurrent collectors each disabling would double-deinit and
+    segfault), so all users of a device share this one object.
+
+    Consumers register with :meth:`add_consumer` (the metrics they want + a sink) and unregister
+    with :meth:`remove_consumer`. The session samples the *union* of all consumers' metrics and
+    hands each consumer a frame sliced to just its own metrics. Frames carry RAW CUPTI-clock-ns
+    timestamps in ``start_ns`` -- converting to trace/epoch time is the consumer's job, so the
+    sampler has no clock dependency.
+
+    The HW units sample autonomously into a device-side ring (KEEP_LATEST), so there is no
+    background thread: the first consumer starts the session, a caller drains the ring with
+    :meth:`poll` on its own cadence, and removing the last consumer drains the tail and disables.
+    Add/remove reconfigure the live session to the new metric union; a union that cannot be
+    collected in one PM-sampling pass is rejected (:meth:`add_consumer` raises), leaving the running
+    session untouched."""
+
+    # One sampler per CUDA device index; get via for_device(), don't construct directly.
+    _instances: dict[int, PmSampler] = {}
+    _instances_lock = threading.Lock()
+
+    @classmethod
+    def for_device(cls, device: int | None = None) -> PmSampler:
+        """The singleton PM sampler for a CUDA device (default the current device)."""
+        import torch
+
+        if device is None:
+            device = torch.cuda.current_device()
+        with cls._instances_lock:
+            inst = cls._instances.get(device)
+            if inst is None:
+                inst = cls(device)
+                cls._instances[device] = inst
+            return inst
+
+    def __init__(self, device: int) -> None:
+        # Prefer for_device(); direct construction bypasses the per-device singleton.
+        self._device = device
+        # Interval + look-back are process-wide (env); the HW sampling interval in ns:
+        self._sampling_interval_ns = _SAMPLING_INTERVAL_NS
+        # max_samples (decode image + ring capacity) = look-back / interval, clamped to
+        # _MAX_SAMPLES_CAP so an extreme env config can't allocate an unbounded image; a decode that
+        # finds more in the ring caps and drops the newest, and _start() sizes the ring to hold this
+        # many (see _counter_data_size). The retained window is truncated when clamped.
+        requested = max(1, _DEFAULT_WINDOW_NS // _SAMPLING_INTERVAL_NS)
+        self._max_samples = min(requested, _MAX_SAMPLES_CAP)
+        if requested > _MAX_SAMPLES_CAP:
+            logger.warning(
+                "PM sampling look-back (%d ns @ %d ns = %d samples) exceeds the %d-sample cap; "
+                "retained window truncated to ~%d ns.",
+                _DEFAULT_WINDOW_NS,
+                _SAMPLING_INTERVAL_NS,
+                requested,
+                _MAX_SAMPLES_CAP,
+                _MAX_SAMPLES_CAP * _SAMPLING_INTERVAL_NS,
+            )
+        # Registered consumers and the metric union currently sampled (empty until the first add).
+        self._consumers: list[_Consumer] = []
+        self._metric_names: list[str] = []
+        self._col: Any = None
+        # Guards the consumer list + collector ops (add/remove/poll may race across threads); an
+        # RLock since remove_consumer drains (which the lock also guards) before reconfiguring.
+        self._lock = threading.RLock()
+
+    def add_consumer(
+        self, metrics: Iterable[str], sink: Callable[[dict[str, Any]], None]
+    ) -> _Consumer:
+        """Register a consumer wanting ``metrics``, delivered to ``sink`` as raw-timestamp frames;
+        returns a handle for :meth:`remove_consumer`. Starts the session (first consumer) or
+        reconfigures it to the new metric union. Raises ValueError if ``metrics`` is empty or the
+        resulting union needs more than one PM-sampling pass (the running session is left intact)."""
+        metrics = list(metrics)
+        if not metrics:
+            raise ValueError("PM sampling requires a non-empty metric set")
+        consumer = _Consumer(metrics, sink)
+        with self._lock:
+            # Validate the candidate union BEFORE committing, so a multi-pass add fails cleanly
+            # without disturbing the running session.
+            self._check_single_pass(self._union_of([*self._consumers, consumer]))
+            # Flush ring samples (collected under the old metric union) to the EXISTING consumers
+            # before the resize; done here, pre-append, so the drain's column set matches the old
+            # union (the new consumer's metrics aren't sampled yet).
+            self._drain()
+            self._consumers.append(consumer)
+            self._reconfigure()
+        return consumer
+
+    def remove_consumer(self, consumer: _Consumer) -> None:
+        """Unregister a consumer. Drains pending samples to the current consumers (including the one
+        leaving) first, then reconfigures to the smaller union -- or tears the session down when the
+        last consumer leaves. Idempotent."""
+        with self._lock:
+            if consumer not in self._consumers:
+                return
+            self._drain()  # deliver in-flight samples to the leaver before it goes
+            self._consumers.remove(consumer)
+            self._reconfigure()
+
+    @staticmethod
+    def _union_of(consumers: list[_Consumer]) -> list[str]:
+        seen: set[str] = set()
+        union: list[str] = []
+        for c in consumers:
+            for m in c.metrics:
+                if m not in seen:
+                    seen.add(m)
+                    union.append(m)
+        return union
+
+    def _reconfigure(self) -> None:
+        # Bring the live session in line with the consumers' metric union (caller holds _lock): tear
+        # it down when no consumers remain, else (re)build it whenever the union changed. A changed
+        # union rebuilds with a clean enable/configure/start rather than an in-place
+        # stop/configure/start -- decode after an in-place reconfigure errors on some CUPTI versions,
+        # and union changes are rare (an observer joining/leaving). Callers drain the old ring first,
+        # so no samples are lost across the rebuild.
+        desired = self._union_of(self._consumers)
+        if not desired:
+            self._teardown()
+        elif desired != self._metric_names:
+            self._teardown()
+            self._metric_names = desired
+            self._start()
+
+    @property
+    def suggested_poll_interval_ns(self) -> int:
+        """Recommended cadence for periodic :meth:`poll`. The KEEP_LATEST ring holds max_samples
+        (~one look-back window) and each decode re-reads the whole ring, so polling much more often
+        just re-decodes the same samples, while polling slower than the ring fills drops the samples
+        between polls. Drain a little before the ring is full -- one window span minus a small buffer
+        -- so each decode is productive without hitting the overflow cap; the final drain at teardown
+        still catches the tail."""
+        span = self._max_samples * self._sampling_interval_ns
+        return max(self._sampling_interval_ns, span * 9 // 10)
+
+    def poll(self) -> None:
+        """Drain the ring into the consumers' sinks without disabling -- continuous flight-recorder
+        decode; a caller polls on its own cadence (see :attr:`suggested_poll_interval_ns`). Safe to
+        call repeatedly while sampling (the KEEP_LATEST ring is decodable while active). No-op until
+        a consumer starts the session."""
+        with self._lock:
+            if self._col is None:
+                return
+            try:
+                self._drain()
+            except Exception:
+                logger.exception("PM sampling poll decode error")
+
+    def _start(self) -> None:
+        # Enable + configure + start the collector for self._metric_names (the union). enable()
+        # initializes the process-global CUPTI profiler; _teardown() disables it. A failure tears the
+        # partial enable down so a later retry is clean. Caller holds _lock.
+        if self._col is not None or not is_available() or not self._metric_names:
+            return
+        try:
+            from cupti import pm_sampling as pm  # pyrefly: ignore[missing-import]
+
+            self._warn_unsupported()
+            self._col = pm.Collector(device_index=self._device)
+            self._col.enable()
+            # Size the ring to hold the window's samples: the counter-data-image bytes for
+            # max_samples (exact, via CUPTI) is >= the device records for the same count, so the ring
+            # never wraps before the window is full.
+            self._col.configure(
+                metrics=self._metric_names,
+                hardware_buffer_size=_counter_data_size(
+                    self._col._pm_sampling_object, self._metric_names, self._max_samples
+                ),
+                sampling_interval=self._sampling_interval_ns,
+                trigger_mode=pm.TriggerMode.GPU_TIME_INTERVAL,
+                # KEEP_LATEST = ring buffer: an over-capacity window keeps the most recent samples
+                # (the trace's tail) instead of erroring. Requires decoding before disabling.
+                hw_buffer_append_mode=pm.HardwareBuffer_AppendMode.KEEP_LATEST,
+            )
+            self._col.start()
+        except Exception as e:
+            logger.warning("PM sampling could not start: %s", e)
+            self._teardown()
+
+    def _teardown(self) -> None:
+        # Canonical teardown: stop sampling, then Collector.disable() frees this session's PM object
+        # and deinitializes the process-global CUPTI profiler (NVIDIA's cupti-python sample pattern).
+        # Safe because there is one collector per device -- one balanced init/deinit per cycle. A
+        # wrapped KEEP_LATEST ring must already be drained (callers drain first). Caller holds _lock.
+        col, self._col = self._col, None
+        self._metric_names = []
+        if col is None:
+            return
+        try:
+            col.stop()
+        except Exception:
+            logger.exception("PM sampling stop error")
+        try:
+            col.disable()
+        except Exception:
+            logger.exception("PM sampling disable error")
+
+    def _warn_unsupported(self) -> None:
+        # Warn (don't fail) for any sampled metric the chip does not report; enable/configure is the
+        # real gate. supported_metrics() may be empty (host query unavailable) -> skip. Compared by
+        # base name (before the first '.') so a rollup/suffix doesn't cause a false warning.
+        try:
+            supported = supported_metrics()
+        except Exception:
+            return
+        if not supported:
+            return
+        known = {s.split(".", 1)[0] for s in supported}
+        unknown = [m for m in self._metric_names if m.split(".", 1)[0] not in known]
+        if unknown:
+            logger.warning(
+                "PM sampling: metric(s) not reported by this chip, may fail to enable: %s",
+                ", ".join(unknown),
+            )
+
+    def _check_single_pass(self, metrics: list[str]) -> None:
+        """Raise ValueError if ``metrics`` can't be collected in one PM-sampling pass (PM sampling is
+        single-pass only). Uses the profiler host to build the config image and count passes.
+        Best-effort: if the host can't compute passes here, return and let configure() reject a
+        multi-pass set (with a generic error)."""
+        try:
+            from cupti import profiler_host as ph  # pyrefly: ignore[missing-import]
+            from cupti.cupti import ProfilerType  # pyrefly: ignore[missing-import]
+
+            host = ph.ProfilerHost(
+                _device_chip_name(self._device), ProfilerType.PM_SAMPLING
+            )
+            host.initialize()
+            try:
+                passes = ph.get_num_of_passes(host.create_config_image(metrics=metrics))
+            finally:
+                host.deinitialize()
+        except Exception:
+            return  # can't determine passes here; configure() still enforces single-pass
+        if passes > 1:
+            raise ValueError(
+                f"PM sampling requires all metrics in a single pass, but the requested set needs "
+                f"{passes} passes: {metrics}. Reduce it to a single-pass set (see "
+                f"supported_metrics())."
+            )
+
+    def _drain(self) -> None:
+        # A single decode drains the whole ring (see module docstring). With KEEP_LATEST a wrapped
+        # ring just yields its most-recent samples, so no overflow error; the MemoryError guard is a
+        # defensive backstop only. Caller holds _lock.
+        col = self._col
+        if col is None:
+            return
+        try:
+            cd = col.decode(max_samples=self._max_samples)
+        except MemoryError:
+            logger.warning(
+                "PM sampling HW buffer overflow during decode; samples dropped."
+            )
+            return
+        except Exception:
+            # A transient decode failure (e.g. right after a rebuild, before samples exist) must not
+            # propagate through poll()/remove_consumer -- skip this drain, the next one recovers.
+            logger.exception("PM sampling decode error")
+            return
+        n = cd.num_completed_samples
+        if not n:
+            return
+        if n >= self._max_samples:
+            # The image filled before the buffer drained; the newest samples past the cap were
+            # dropped. Sized not to happen for a window that fit the buffer, so this is a backstop.
+            logger.warning(
+                "PM sampling decoded the maximum %d samples; some were dropped.",
+                self._max_samples,
+            )
+        # One pass over the decoded ring: CounterData iterates exactly num_completed_samples and
+        # evaluates each sample's metrics host-side on access (the decode cost). Stamp at the
+        # sample's interval START: the value is the average over [start, end] (~1 ms), and the viewer
+        # draws a counter as a step from each sample's ts to the next -- so start makes the step span
+        # exactly its measurement window, lining the high-counter region up with the activity span
+        # (end would lag a full interval; midpoint would offset the edges).
+        ts = np.empty(n, dtype=np.int64)
+        vals = np.empty((n, len(self._metric_names)), dtype=np.float64)
+        for i, s in enumerate(cd):
+            ts[i] = s.start_timestamp
+            vals[i] = s.metric_values
+        # Drop samples with a bogus start timestamp: the first sample of a session has an unset
+        # interval-start -- 0, or a stale small value from a different clock domain (observed
+        # ~7.5e13 vs the real ~1.78e18). Real samples all fall within the look-back of the newest,
+        # so keep only ts in (max - look-back, max]; this also drops any stale pre-wrap remnant.
+        keep = ts > 0
+        if keep.any():
+            keep &= ts >= int(ts[keep].max()) - _DEFAULT_WINDOW_NS
+        if not keep.any():
+            return
+        ts = ts[keep]
+        vals = vals[keep]
+        device_col = np.full(len(ts), self._device, dtype=np.int64)
+        col_index = {m: j for j, m in enumerate(self._metric_names)}
+        # Frames share the ts/value arrays across consumers (read-only): a consumer that transforms
+        # a column (e.g. converts start_ns) must produce a new array, not mutate in place.
+        for consumer in self._consumers:
+            frame: dict[str, Any] = {"start_ns": ts, "device_id": device_col}
+            for m in consumer.metrics:
+                frame[m] = vals[:, col_index[m]]
+            consumer.sink(frame)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

Add the standalone CUPTI PM-sampling engine (PmSampler): continuous sampling of the
on-chip GPU performance-monitor units -- e.g. SM-active % (sm__cycles_active),
DRAM-throughput % (gpu__dram_throughput), NVLink RX/TX % -- concurrently with the
activity monitor. PM sampling reads dedicated HW units, so it has negligible GPU-side
cost, but it locks the GPU clocks while active (which can shift absolute kernel
durations), so it is opt-in.

There is one PmSampler per CUDA device -- a per-device singleton (PmSampler.for_device),
since only one PM session per device is possible and the shared CUPTI profiler's
init/deinit is not refcounted (two concurrent collectors each disabling would
double-deinit and segfault, verified on current CUPTI). Users register as consumers:
add_consumer(metrics, sink) returns a handle, remove_consumer(handle) drops it. The
session samples the union of all consumers' metrics and hands each consumer a frame
sliced to just its own metrics; the first consumer starts the session and the last one
tears it down. Lifecycle follows NVIDIA's cupti-python sample: enable -> configure ->
start -> drain -> stop -> disable. A metric union that cannot be collected in one PM pass
is rejected at add_consumer (PM sampling is single-pass), leaving any running session
untouched; a union change rebuilds the session (clean enable/configure/start) rather than
reconfiguring in place, since decode after an in-place stop/configure/start errors on some
CUPTI versions.

The HW units sample autonomously into a device-side ring (KEEP_LATEST), so there is no
background thread: poll() drains the ring without disabling (safe to call repeatedly while
sampling) and the final tail drain happens when the last consumer leaves -- before
disabling, since a wrapped ring is only decodable while active. Each decode re-reads the
whole ring, so suggested_poll_interval_ns recommends a cadence of one ring span minus a
small buffer (drain just before it fills). Interval + look-back are process-wide env
(TORCH_CUPTI_PM_SAMPLING_INTERVAL_MS default 1, TORCH_CUPTI_PM_SAMPLING_LOOKBACK_MS
default 10000) and size the ring exactly via CUPTI's pm_sampling_get_counter_data_size (no
per-sample byte estimate); metrics are NOT env -- each consumer brings its own.

Decoded samples are HW-timestamped in the CUPTI clock domain and delivered raw (start_ns /
device_id / one column per metric name) -- converting to trace/epoch time is the consumer's
job, so the engine has no clock dependency. The first sample of a session has a bogus
(uninitialized, nonzero) start timestamp, so samples outside the look-back of the newest
are dropped. The engine is thus usable on its own, independent of the profiler backend;
wiring it into the cupti_monitor backend lands in a follow-up.

Test Plan:
Real CUPTI PM sampling (needs a perfmon-capable GPU + cupti.pm_sampling; the tests skip
otherwise):

```
python test/profiler/test_cupti_pm_sampling.py
```

Validated on a GB200 (GB100 chip) -- all 10 tests pass with PM sampling actually engaged:
frames carry a column per metric, HW timestamps are monotonic and within the look-back,
max_samples matches look-back / interval, metric selection works, two consumers share one
session (sampling their union, each sliced to its own metrics), supported_metrics returns
the chip's counters, an unknown metric warns, an empty metric set and a multi-pass set
(sm__throughput.*, ~8 passes) are rejected, and the suggested poll interval stays under the
ring span.

Authored with the assistance of an AI coding assistant.