### PR TITLE
Register DTensorSpec as an opaque reference type for torch.export

### DIFF
--- a/test/distributed/tensor/test_dtensor_export.py
+++ b/test/distributed/tensor/test_dtensor_export.py
@@ -12,7 +12,6 @@ from torch._guards import tracing, TracingContext
 from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.tensor import distribute_tensor, Partial, Replicate, Shard
 from torch.distributed.tensor._api import DTensor
-from torch.distributed.tensor._dtensor_spec import DTensorSpec
 from torch.distributed.tensor.parallel import (
     ColwiseParallel,
     parallelize_module,
@@ -124,20 +123,15 @@ class FlexAttentionModel(torch.nn.Module):
 def strict_export_and_aot_export_joint_with_descriptors(model, args, kwargs=None):
     if kwargs is None:
         kwargs = {}
-    # needed for strict export; must be cleaned up to avoid polluting global state
-    torch.utils._pytree.register_constant(DTensorSpec)
-    try:
-        # install_free_tensors is required for dynamo to work
-        with torch._dynamo.config.patch(install_free_tensors=True):
-            with torch._export.utils._disable_aten_to_metadata_assertions():
-                ep = torch.export.export(model, args, kwargs, strict=True)
+    # install_free_tensors is required for dynamo to work
+    with torch._dynamo.config.patch(install_free_tensors=True):
+        with torch._export.utils._disable_aten_to_metadata_assertions():
+            ep = torch.export.export(model, args, kwargs, strict=True)
 
-        # joint_gm produced here is missing the backward region, due to incompatiblility
-        # between ep.module() and aot_export_joint_with_descriptors.
-        # Keeping this here to show the issue.
-        return aot_export_joint_with_descriptors_alone(ep.module(), args, kwargs)
-    finally:
-        torch.utils._pytree._deregister_pytree_node(DTensorSpec)
+    # joint_gm produced here is missing the backward region, due to incompatiblility
+    # between ep.module() and aot_export_joint_with_descriptors.
+    # Keeping this here to show the issue.
+    return aot_export_joint_with_descriptors_alone(ep.module(), args, kwargs)
 
 
 def graph_capture_and_aot_export_joint_with_descriptors_v2(model, args, kwargs=None):

--- a/torch/distributed/tensor/_dtensor_spec.py
+++ b/torch/distributed/tensor/_dtensor_spec.py
@@ -75,11 +75,6 @@ class TensorMeta(NamedTuple):
 
 
 # used internally to propagate the placements.
-# DTensorSpec uses OpaqueBaseMeta so it can be registered as an opaque reference
-# type (see _register_dtensor_spec_opaque_type below), letting torch.export
-# capture it as a graph input when it appears as a non-tensor argument (e.g. to
-# the DTensor constructor). It must remain a pytree leaf, which opaque
-# registration preserves.
 @dataclass
 class DTensorSpec(metaclass=OpaqueBaseMeta):
     mesh: DeviceMesh
@@ -774,12 +769,7 @@ class DTensorSpec(metaclass=OpaqueBaseMeta):
 
 # Register DTensorSpec as an opaque reference type so torch.export can capture it
 # as a graph input when it shows up as a non-tensor argument (e.g. to the DTensor
-# constructor). This is done here, after the class definition, rather than in
-# device_mesh._register_distributed_opaque_types() to avoid a circular import:
-# that function runs while this module is still being imported (via
-# placement_types -> _collective_utils), before DTensorSpec exists. By this point
-# DeviceMesh has already been registered through the same import chain, which
-# satisfies the "register the mesh before the spec that holds it" ordering.
+# constructor).
 def _register_dtensor_spec_opaque_type() -> None:
     from torch._library.opaque_object import MemberType, register_opaque_type
 

--- a/torch/distributed/tensor/_dtensor_spec.py
+++ b/torch/distributed/tensor/_dtensor_spec.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Any, cast, NamedTuple
 
 import torch
+from torch._opaque_base import OpaqueBaseMeta
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor.placement_types import (
     _is_shard_like,
@@ -73,9 +74,14 @@ class TensorMeta(NamedTuple):
     dtype: torch.dtype
 
 
-# used internally to propagate the placements
+# used internally to propagate the placements.
+# DTensorSpec uses OpaqueBaseMeta so it can be registered as an opaque reference
+# type (see _register_dtensor_spec_opaque_type below), letting torch.export
+# capture it as a graph input when it appears as a non-tensor argument (e.g. to
+# the DTensor constructor). It must remain a pytree leaf, which opaque
+# registration preserves.
 @dataclass
-class DTensorSpec:
+class DTensorSpec(metaclass=OpaqueBaseMeta):
     mesh: DeviceMesh
     placements: tuple[Placement, ...]
 
@@ -764,3 +770,42 @@ class DTensorSpec:
             tensor_meta=tensor_meta,
             use_strided_shard_as_shard_order=self.use_strided_shard_as_shard_order,
         )
+
+
+# Register DTensorSpec as an opaque reference type so torch.export can capture it
+# as a graph input when it shows up as a non-tensor argument (e.g. to the DTensor
+# constructor). This is done here, after the class definition, rather than in
+# device_mesh._register_distributed_opaque_types() to avoid a circular import:
+# that function runs while this module is still being imported (via
+# placement_types -> _collective_utils), before DTensorSpec exists. By this point
+# DeviceMesh has already been registered through the same import chain, which
+# satisfies the "register the mesh before the spec that holds it" ordering.
+def _register_dtensor_spec_opaque_type() -> None:
+    from torch._library.opaque_object import MemberType, register_opaque_type
+
+    register_opaque_type(
+        DTensorSpec,
+        typ="reference",
+        guard_fn=lambda obj: [
+            obj.mesh,
+            obj.placements,
+            obj.shard_order,
+            obj.tensor_meta,
+        ],
+        members={
+            "mesh": MemberType.USE_REAL,
+            "placements": MemberType.USE_REAL,
+            "tensor_meta": MemberType.USE_REAL,
+            "shard_order": MemberType.USE_REAL,
+            "use_strided_shard_as_shard_order": MemberType.USE_REAL,
+            "device_mesh": MemberType.USE_REAL,
+            "sums": MemberType.USE_REAL,
+            "is_replicated": MemberType.USE_REAL,
+            "is_sharded": MemberType.USE_REAL,
+            "__eq__": MemberType.USE_REAL,
+            "__hash__": MemberType.USE_REAL,
+        },
+    )
+
+
+_register_dtensor_spec_opaque_type()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #188853
 
Fixes https://github.com/pytorch/pytorch/issues/175467