### PR TITLE
Parametrize override_cudagraphs annotation graph-break tests

### DIFF
--- a/test/dynamo/test_decorators.py
+++ b/test/dynamo/test_decorators.py
@@ -15,6 +15,7 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     IS_LINUX,
     IS_MACOS,
+    parametrize,
     skipIfWindows,
     TEST_WITH_ASAN,
 )
@@ -2519,87 +2520,50 @@ Detected recompile when torch.compile stance is 'fail_on_recompile'. filename: '
         ):
             compiled(torch.randn(4))
 
-    def test_override_cudagraphs_annotation_nested_graph_break(self):
+    @parametrize("use_decorator", [False, True])
+    @parametrize("fwd,bwd", [(True, False), (False, False)])
+    def test_override_cudagraphs_annotation_graph_break(self, use_decorator, fwd, bwd):
         # override_cudagraphs must propagate its annotation onto every compiled
-        # subgraph even when the graph break happens inside a nested callee
-        # that is compiled as a separate frame (it cannot be inlined). This is a
-        # device-independent check on gm.meta, so it does not require CUDA.
+        # subgraph even when the graph break happens inside a callee compiled as
+        # a separate frame (it cannot be inlined). The override is established
+        # either by a context manager in the caller or by decorating the callee;
+        # both must seed every segment, for enable (fwd=True) and disable
+        # (fwd=False) alike. Device-independent check on gm.meta (no CUDA).
         annotations = []
 
         def backend(gm, example_inputs):
             annotations.append(gm.meta.get("cudagraph_annotation"))
             return gm.forward
 
-        def callee(x):
-            y = x + 1
-            torch._dynamo.graph_break()
-            return y * 2
+        if use_decorator:
 
-        def ctx_mgr(x):
-            with torch._dynamo.override_cudagraphs(fwd=True, bwd=False):
+            @torch._dynamo.override_cudagraphs(fwd=fwd, bwd=bwd)
+            def callee(x):
+                y = x + 1
+                torch._dynamo.graph_break()
+                return y * 2
+
+            def model(x):
                 return callee(x)
 
+        else:
+
+            def callee(x):
+                y = x + 1
+                torch._dynamo.graph_break()
+                return y * 2
+
+            def model(x):
+                with torch._dynamo.override_cudagraphs(fwd=fwd, bwd=bwd):
+                    return callee(x)
+
         torch._dynamo.reset()
-        torch.compile(ctx_mgr, backend=backend)(torch.randn(4))
+        torch.compile(model, backend=backend)(torch.randn(4))
         # Both segments of the callee (before and after the break) carry it.
         self.assertEqual(len(annotations), 2)
         for ann in annotations:
             self.assertIsNotNone(ann)
-            self.assertEqual((ann.fwd, ann.bwd), (True, False))
-
-    def test_override_cudagraphs_annotation_decorator_graph_break(self):
-        # Decorator form: a decorated function whose body contains a graph break
-        # is split into multiple compiled segments. Every segment must carry the
-        # annotation, even though the decorator's `with` lives in the wrapper
-        # frame and the body is compiled as a separate frame. Device-independent
-        # check on gm.meta, so it does not require CUDA.
-        annotations = []
-
-        def backend(gm, example_inputs):
-            annotations.append(gm.meta.get("cudagraph_annotation"))
-            return gm.forward
-
-        @torch._dynamo.override_cudagraphs(fwd=True, bwd=False)
-        def inner(x):
-            y = x + 1
-            torch._dynamo.graph_break()
-            return y * 2
-
-        def model(x):
-            return inner(x)
-
-        torch._dynamo.reset()
-        torch.compile(model, backend=backend)(torch.randn(4))
-        self.assertEqual(len(annotations), 2)
-        for ann in annotations:
-            self.assertIsNotNone(ann)
-            self.assertEqual((ann.fwd, ann.bwd), (True, False))
-
-    def test_override_cudagraphs_annotation_disable_graph_break(self):
-        # The disable case (fwd=False) flows through the same separate-frame
-        # seeding path and must also propagate across a graph break in a
-        # separately-compiled callee. Device-independent check on gm.meta.
-        annotations = []
-
-        def backend(gm, example_inputs):
-            annotations.append(gm.meta.get("cudagraph_annotation"))
-            return gm.forward
-
-        def callee(x):
-            y = x + 1
-            torch._dynamo.graph_break()
-            return y * 2
-
-        def model(x):
-            with torch._dynamo.override_cudagraphs(fwd=False, bwd=False):
-                return callee(x)
-
-        torch._dynamo.reset()
-        torch.compile(model, backend=backend)(torch.randn(4))
-        self.assertEqual(len(annotations), 2)
-        for ann in annotations:
-            self.assertIsNotNone(ann)
-            self.assertEqual((ann.fwd, ann.bwd), (False, False))
+            self.assertEqual((ann.fwd, ann.bwd), (fwd, bwd))
 
     def test_override_cudagraphs_annotation_nested_overrides_graph_break(self):
         # Nested overrides: the innermost (most recently entered) override wins


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

Follow-up to #188610. Collapse the three near-identical device-independent
override_cudagraphs annotation tests (nested_graph_break, decorator_graph_break,
disable_graph_break) into a single test parametrized over the establishing form
(context manager vs decorator) and the (fwd, bwd) override values. This removes
duplicated scaffolding and additionally covers the previously-untested
decorator + disable combination.

Test Plan:

```
python test/dynamo/test_decorators.py -k test_override_cudagraphs_annotation
```

All 6 tests pass (4 parametrized variants plus the two explicit tests kept for
nested overrides and the not-guarded sticky behavior).

This change was authored with the assistance of Claude Code.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98