### PR TITLE
[MPS] Add `@serialTest` to `test_group_norm_backward_large_input`

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -15614,6 +15614,7 @@ class TestConsistency(TestCaseMPS):
     # because 64-bit indexing is supported. But if 64-bit is turned off, the
     # test fails.
     @unittest.skipIf(torch._C._mps_maxBufferLength() < int(8.1 * 1024**3), "Need >8 GB buffer")
+    @serialTest()
     @parametrize("dtype", [torch.float16, torch.bfloat16])
     @parametrize("trigger_32bit_overflow", [False, True])
     def test_group_norm_backward_large_input(self, device, dtype, trigger_32bit_overflow):


### PR DESCRIPTION
Fixes #186867
Fixes #186866
Fixes #186605
Fixes #186604