### PR TITLE
Fix type confusion in Stream comparison against non-Stream objects

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6725,6 +6725,24 @@ class TestTorch(TestCase):
     def test_dir(self):
         dir(torch)
 
+    def test_stream_compare_with_non_stream(self):
+        # Comparing a Stream with a non-Stream object used to reinterpret_cast the
+        # other object to THPStream* and read Stream fields out of unrelated memory.
+        # It must instead compare unequal without crashing. See issue #188033.
+        s = torch.Stream(device='cpu')
+        same = torch.Stream(
+            stream_id=s.stream_id,
+            device_index=s.device_index,
+            device_type=s.device_type,
+        )
+        for other in (5, 'x', None, [1, 2], object()):
+            self.assertFalse(s == other)
+            self.assertTrue(s != other)
+        self.assertTrue(s == same)
+        self.assertFalse(s != same)
+        # ordering against a non-Stream is undefined, not silently False
+        self.assertRaises(TypeError, lambda: s < 5)
+
     def test_wildcard_import(self):
         exec('from torch import *')
 

--- a/torch/csrc/Stream.cpp
+++ b/torch/csrc/Stream.cpp
@@ -435,8 +435,22 @@ static PyObject* THPStream_richcompare(
     PyObject* other,
     int op) {
   PyObject* result = nullptr;
-  if (Py_IsNone(other)) {
-    result = Py_False;
+  if (!THPStream_Check(other)) {
+    // `other` is None or any non-Stream object. Only (in)equality is defined,
+    // and a Stream never equals a non-Stream. Handling this here also avoids
+    // reinterpret_cast-ing an unrelated object to THPStream* below, which would
+    // read Stream fields out of unrelated memory.
+    switch (op) {
+      case Py_EQ:
+        result = Py_False;
+        break;
+      case Py_NE:
+        result = Py_True;
+        break;
+      default:
+        result = Py_NotImplemented;
+        break;
+    }
   } else {
     switch (op) {
       case Py_EQ:


### PR DESCRIPTION
Fixes #188033

### Root cause
`THPStream_richcompare` (`torch/csrc/Stream.cpp`) only special-cased `None` and otherwise did `reinterpret_cast<THPStream*>(other)` unconditionally, then read `stream_id` / `device_index` / `device_type` off it. When `other` is any non-Stream object (e.g. `stream == 5`), those reads land at `THPStream` field offsets inside an unrelated Python object — garbage results and a potential out-of-bounds read.

### Fix
Gate the cast on `THPStream_Check(other)`. A `Stream` compared with a non-Stream object (including `None`) is now unequal for `Py_EQ`/`Py_NE` without touching the operand's memory; ordering comparisons return `Py_NotImplemented` so Python raises `TypeError` instead of silently returning `False`. As a side effect this also fixes `stream != None` previously returning `False`.

### Test Plan
```
python -m pytest test/test_torch.py -k test_stream_compare_with_non_stream -q
```
Added `test_stream_compare_with_non_stream` covering equality/inequality against `int`, `str`, `None`, `list`, and a bare `object()`, equality between two equal streams, and that ordering against a non-Stream raises `TypeError`.
