### PR TITLE
Raise a clear error when linalg.eigh/svd workspace exceeds 32-bit LAPACK limit

### DIFF
--- a/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
@@ -203,6 +203,17 @@ template <typename T>
 inline
 std::enable_if_t<std::is_floating_point_v<T>, int> lapack_work_to_int(const T val) {
     const auto next_after = std::nextafter(val, std::numeric_limits<T>::infinity());
+    // The LAPACK interface used here indexes workspace with a 32-bit int, so a
+    // required workspace above INT_MAX cannot be represented and would overflow
+    // when cast below. This happens for large matrices (e.g. eigh/svd on inputs
+    // with a dimension in the tens of thousands). Fail with an actionable error
+    // rather than silently overflowing into a bogus (often negative) size.
+    TORCH_CHECK(next_after <= static_cast<T>(std::numeric_limits<int>::max()),
+        "The matrix is too large for the current LAPACK backend: it requires a ",
+        "workspace of size ", next_after, ", which exceeds the maximum ",
+        std::numeric_limits<int>::max(), " supported by the 32-bit LAPACK ",
+        "interface. Consider processing the input in smaller chunks or building ",
+        "PyTorch against a 64-bit integer (ILP64) LAPACK.");
     return std::max<int>(1, std::ceil(next_after));
 }
 template <typename T>

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1038,6 +1038,21 @@ class TestLinalg(TestCase):
             with self.assertRaisesRegex(RuntimeError, "tensors to be on the same device"):
                 torch.linalg.eigh(a, out=(out_w, out_v))
 
+    @onlyCPU
+    @skipCPUIfNoLapack
+    @largeTensorTest("10GB", device="cpu")
+    @dtypes(torch.float32)
+    def test_eigh_lwork_int_overflow(self, device, dtype):
+        # The CPU LAPACK interface indexes the workspace with a 32-bit int. For a
+        # large enough matrix the required workspace (~2 * n**2 for syevd with
+        # eigenvectors) exceeds INT_MAX and used to silently overflow into a bogus
+        # size. It must instead raise an actionable error. See issue #92141.
+        # n is chosen so that 2 * n**2 > INT_MAX while the input still fits in RAM.
+        n = 33000
+        a = torch.eye(n, device=device, dtype=dtype)
+        with self.assertRaisesRegex(RuntimeError, "too large for the current LAPACK backend"):
+            torch.linalg.eigh(a)
+
     @skipCPUIfNoLapack
     @dtypes(torch.float, torch.double)
     def test_eigh_svd_illcondition_matrix_input_should_not_crash(self, device, dtype):


### PR DESCRIPTION
Fixes #92141

### Root cause
The CPU LAPACK path indexes its workspace with a 32-bit `int`. LAPACK returns the optimal workspace size from its query call as a floating point value, which `lapack_work_to_int()` rounds and casts to `int`. For a large matrix the required workspace can exceed `INT_MAX` — for `syevd` with eigenvectors it is `~2 * n**2`, so it overflows once `n` reaches the low tens of thousands (e.g. `torch.linalg.eigh` on a `53000 x 53000` matrix from the issue). The cast wrapped to a bogus, often negative, size and the subsequent allocation / LAPACK call failed with an opaque error.

### Fix
`lapack_work_to_int()` is the single choke point every CPU LAPACK routine funnels its workspace size through (`eigh`, `svd`, `qr`, `lstsq`, ...), so the guard is added there. When the queried size exceeds `INT_MAX` it now raises a clear `TORCH_CHECK` naming the required and maximum sizes and suggesting the input be processed in chunks or PyTorch be built against a 64-bit-integer (ILP64) LAPACK.

The overflow is specific to the CPU LAPACK backend; the CUDA path uses cuSOLVER and is unaffected, so the added regression test is CPU-only and memory-gated (`@largeTensorTest`).

### Test Plan
```
python -m pytest test/test_linalg.py -k test_eigh_lwork_int_overflow -q
python -m pytest test/test_linalg.py -k test_eigh_errors_and_warnings -q
```
Manually confirmed `torch.linalg.eigh` on a `33000 x 33000` float32 matrix now raises:
```
The matrix is too large for the current LAPACK backend: it requires a workspace of size
2.1782e+09, which exceeds the maximum 2147483647 supported by the 32-bit LAPACK interface.
Consider processing the input in smaller chunks or building PyTorch against a 64-bit
integer (ILP64) LAPACK.
```
and that `eigh`/`eigvalsh`/`svd`/`qr` remain numerically correct on ordinary sizes for float32/float64/complex64/complex128.

