### PR TITLE
Fix #166722

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -2402,6 +2402,40 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         torch.accelerator.empty_cache()
 
     @supported_platform
+    @skip_on_cpu
+    @dtypes(*device_configs["cuda"].dtypes_fast)
+    @dtypesIfCUDA(*device_configs["cuda"].dtypes_fast)
+    @dtypesIfXPU(*device_configs["xpu"].dtypes_fast)
+    @common_utils.parametrize("compiled", [False, True])
+    def test_unused_captured_score_mod_grad(self, device, dtype, compiled):
+        """Unused captured grad slots should propagate None through backward."""
+        B_local, H_local, S_local, D_local = 1, 4, 16, 64
+        make_input = functools.partial(
+            torch.randn,
+            (B_local, H_local, S_local, D_local),
+            device=device,
+            dtype=dtype,
+            requires_grad=True,
+        )
+        q, k, v = make_input(), make_input(), make_input()
+        unused = torch.zeros(
+            (H_local, 2), device=device, dtype=dtype, requires_grad=True
+        )
+
+        def score_mod(score, b, h, q_idx, kv_idx):
+            _ = unused[h]
+            return score
+
+        attention = torch.compile(flex_attention) if compiled else flex_attention
+        attention(q, k, v, score_mod=score_mod).sum().backward()
+
+        self.assertIsNotNone(q.grad)
+        self.assertIsNotNone(k.grad)
+        self.assertIsNotNone(v.grad)
+        self.assertIsNone(unused.grad)
+        torch._dynamo.reset()
+
+    @supported_platform
     @dtypes(*device_configs["cpu"].dtypes_fast)
     @dtypesIfCUDA(*device_configs["cuda"].dtypes_fast)
     @dtypesIfXPU(*device_configs["xpu"].dtypes_fast)

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -2403,6 +2403,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
 
     @supported_platform
     @skip_on_cpu
+    @skip_on_mps
     @dtypes(*device_configs["cuda"].dtypes_fast)
     @dtypesIfCUDA(*device_configs["cuda"].dtypes_fast)
     @dtypesIfXPU(*device_configs["xpu"].dtypes_fast)

--- a/torch/_higher_order_ops/flex_attention.py
+++ b/torch/_higher_order_ops/flex_attention.py
@@ -1016,20 +1016,9 @@ def sdpa_dense_backward(
     actual_grad_value = value.new_empty((Bq, Hkv, seq_len_kv, v_head_dim))
     actual_grad_value = _permute_strides(actual_grad_value, value.stride())
 
-    def _maybe_new_buffer(
-        buffer: torch.Tensor | torch.SymInt | int,
-    ) -> torch.Tensor | torch.SymInt | int | None:
-        if isinstance(buffer, torch.Tensor):
-            return (
-                torch.empty_like(buffer, memory_format=torch.contiguous_format)
-                if buffer.requires_grad
-                else None
-            )
-        return buffer
-
-    actual_grad_score_mod_captured = [
-        _maybe_new_buffer(buffer) for buffer in score_mod_other_buffers
-    ]
+    actual_grad_score_mod_captured = _new_captured_grad_buffers(
+        score_mod_other_buffers, joint_graph
+    )
 
     Bq, Bkv = query.size(0), key.size(0)
     if not ((Bq == Bkv) or (Bq > 1 and Bkv == 1)):
@@ -1146,18 +1135,69 @@ def sdpa_dense_backward(
         actual_grad_key = torch.sum(actual_grad_key, 0, keepdim=True)
         actual_grad_value = torch.sum(actual_grad_value, 0, keepdim=True)
 
-    score_mod_other_buffer_grads = [
-        actual_grad.copy_(grad) if isinstance(actual_grad, torch.Tensor) else None
-        for actual_grad, grad in zip(
-            actual_grad_score_mod_captured, grad_score_mod_captured
-        )
-    ]
+    score_mod_other_buffer_grads = []
+    for actual_grad, grad in zip(
+        actual_grad_score_mod_captured, grad_score_mod_captured
+    ):
+        if not isinstance(grad, torch.Tensor):
+            score_mod_other_buffer_grads.append(None)
+            continue
+        if actual_grad is None:
+            raise AssertionError("Expected a captured grad buffer for a tensor grad")
+        score_mod_other_buffer_grads.append(actual_grad.copy_(grad))
 
     return (
         actual_grad_query,
         actual_grad_key,
         actual_grad_value,
         tuple(score_mod_other_buffer_grads),
+    )
+
+
+def _captured_grad_buffer_mask(
+    joint_graph: Callable | GraphModule, num_captures: int
+) -> tuple[bool, ...]:
+    """Return which score_mod captures need concrete grad buffers.
+
+    A capture can require grad but still be dead in score_mod, for example when
+    the function reads a closed-over tensor but returns the original score. AOT
+    represents that as a None grad in the joint graph, and that None must stay a
+    None instead of being copied into a materialized buffer.
+
+    Conversely, this is independent of the saved capture's requires_grad flag:
+    compiled backward may save an intermediate whose grad is needed to propagate
+    to earlier user inputs.
+    """
+    if not isinstance(joint_graph, GraphModule):
+        # The @register_fake path for direct flex_attention_backward HOP calls
+        # can see callable subgraphs before make_fx materializes them. In that
+        # metadata-only phase, no capture is provably dead.
+        return (True,) * num_captures
+
+    output_node = next(node for node in joint_graph.graph.nodes if node.op == "output")
+    score_mod_arg_grads = 5
+    captured_grad_outputs = output_node.args[0][score_mod_arg_grads:]
+    if len(captured_grad_outputs) != num_captures:
+        raise AssertionError(
+            f"Expected {num_captures} captured grad outputs, "
+            f"got {len(captured_grad_outputs)}"
+        )
+    return tuple(grad is not None for grad in captured_grad_outputs)
+
+
+def _new_captured_grad_buffers(
+    score_mod_other_buffers: tuple, joint_graph: Callable | GraphModule
+) -> tuple[torch.Tensor | None, ...]:
+    """Allocate only the captured grad buffers that the joint graph can produce."""
+    needs_grad_buffer = _captured_grad_buffer_mask(
+        joint_graph, len(score_mod_other_buffers)
+    )
+    # The lowering returns captured grads as contiguous buffers, so match that here.
+    return tuple(
+        torch.empty_like(buffer, memory_format=torch.contiguous_format)
+        if isinstance(buffer, torch.Tensor) and needs_buffer
+        else None
+        for buffer, needs_buffer in zip(score_mod_other_buffers, needs_grad_buffer)
     )
 
 
@@ -1181,23 +1221,6 @@ def trace_flex_attention_backward(
     """We already have the forward graph and joint graph from the forward pass, so we create a proxy attach both graphs"""
     from torch._dynamo._trace_wrapped_higher_order_op import TransformGetItemToIndex
 
-    example_out = flex_attention_backward(
-        query,
-        key,
-        value,
-        out,
-        logsumexp,
-        grad_out,
-        grad_logsumexp,
-        fw_graph,
-        joint_graph,
-        block_mask,
-        scale,
-        kernel_options,
-        score_mod_other_buffers,
-        mask_mod_other_buffers,
-    )
-
     requires_grad = any(pytree.tree_map(lambda x: x.requires_grad, (query, key)))
     fw_example_vals = [query.new_zeros((), requires_grad=requires_grad)] + [
         query.new_zeros((), dtype=torch.int) for _ in range(4)
@@ -1216,11 +1239,28 @@ def trace_flex_attention_backward(
         mask_graph = _maybe_reenter_make_fx(mask_graph)(
             *mask_example_vals, *mask_mod_other_buffers
         )
+    block_mask = block_mask[:-1] + (mask_graph,)
+    example_out = flex_attention_backward(
+        query,
+        key,
+        value,
+        out,
+        logsumexp,
+        grad_out,
+        grad_logsumexp,
+        fw_graph,
+        joint_graph,
+        block_mask,
+        scale,
+        kernel_options,
+        score_mod_other_buffers,
+        mask_mod_other_buffers,
+    )
+
     if not isinstance(proxy_mode.tracer, torch.fx.Tracer):
         raise AssertionError(
             f"expected proxy_mode.tracer to be torch.fx.Tracer, got {type(proxy_mode.tracer)}"
         )
-    block_mask = block_mask[:-1] + (mask_graph,)
 
     qualname = proxy_mode.tracer.get_fresh_qualname("fw_graph")
     proxy_mode.tracer.root.register_module(qualname, fw_graph)  # type: ignore[arg-type]
@@ -1457,14 +1497,9 @@ def flex_attention_backward_fake_tensor_mode(
 
     grad_query = query.new_empty(query.shape)
     grad_query = _permute_strides(grad_query, query.stride())
-    # zeros_and_scatter creates a contiguous zeros tensor -> contiguous_format
-    grad_score_mod_captured = tuple(
-        (
-            torch.empty_like(buffer, memory_format=torch.contiguous_format)
-            if isinstance(buffer, torch.Tensor)
-            else None
-        )
-        for buffer in score_mod_other_buffers
+
+    grad_score_mod_captured = _new_captured_grad_buffers(
+        score_mod_other_buffers, joint_graph
     )
 
     broadcasted_grad_key = key.new_empty((Bq, Hkv, seq_len_kv, qk_head_dim))


### PR DESCRIPTION
## Human Note
 I think that this is pretty edge casey but simple enough to fix. basically when you close over a input that requreis grad but is not yet used we still think we need to roduce gards for this closure. But in fact we do not since it is essnetially just waiting to get dce'd. I though about trying to dce as early as posssible and worked on this but it ended up being way larger blast radius. I think this is fine pretty self contained and handles an edge case in a decently simple way. Calling bwd direclty has lil more code needed to maek sure thi sstill works but ring attention impl is still good

## Agent Report
# PyTorch Issue #166722 Report

## Summary

FlexAttention backward failed when `score_mod` captured a `requires_grad=True` tensor, indexed it, but did not use that indexed value in the returned score. The AOT joint graph correctly produced `None` for the unused captured tensor gradient, but the eager fallback and compiled metadata paths did not consistently preserve that `None`.

## Root cause

`torch/_higher_order_ops/flex_attention.py::sdpa_dense_backward` preallocates `actual_grad_score_mod_captured` entries for captured `score_mod` tensors that require grad. Later, it blindly ran `actual_grad.copy_(grad)` whenever the preallocated slot was a tensor. For an unused capture such as `self.weight[h]; return score`, AOT autograd returns `grad is None`, following normal autograd semantics for unused differentiable inputs. The unconditional copy caused:

```text
TypeError: copy_(): argument 'other' (position 1) must be Tensor, not NoneType
```

After fixing that eager path, `torch.compile` exposed the same semantic mismatch in metadata: the proxy/fake output for `flex_attention_backward` still described the unused captured grad as a tensor, while the joint graph and Inductor lowering returned `None`. Inductor then tried to treat the runtime `None` as a tensor and failed with `AttributeError: 'NoneType' object has no attribute 'get_size'`.

## Fix

The eager fallback now uses the joint graph to allocate captured-grad destination slots only for captures whose gradient output can be a tensor. The copy-back path treats a non-Tensor produced grad as `None` and asserts that tensor grads have a destination buffer before copying. If AOT returns `None`, FlexAttention propagates `None` for that captured input's gradient instead of materializing or copying a gradient.

The same shared helpers normalize the joint graph's captured-gradient outputs and allocate captured-grad buffers for eager, proxy tracing, and fake tensor mode. This keeps unused captured-grad slots represented as `None` in compiled metadata, matching the real lowering/runtime result. The allocation is based on the joint graph output rather than the saved buffer's `requires_grad`, since compiled backward can need a captured intermediate's gradient to propagate to its producer even when the saved tensor itself does not carry `requires_grad=True`. In proxy tracing, the joint graph is materialized before computing the example output so the metadata is generated from the final graph rather than patched afterward.

I also added `TestFlexAttention.test_unused_captured_score_mod_grad`, which exercises both uncompiled and compiled `flex_attention` with a captured `requires_grad=True` tensor that is indexed in `score_mod` but unused in the returned score. The test verifies that Q/K/V receive gradients and the unused captured tensor's gradient remains `None`.

## Repro

The checked-in `repro.py` uses `device = None`, which now hits the current checkout's explicit CPU limitation (`FlexAttention does not support backward on CPU`) before reaching the reported bug. The CUDA version below reproduced the eager issue before the fix. I also checked the same module under `torch.compile`; after the eager-only fix it failed in Inductor metadata/lowering, and after the final fix both modes complete.

<details>
<summary>Repro Script</summary>

```python
import torch
from torch import nn
from torch.nn.attention import flex_attention


class MhaBugRepro(nn.Module):
    def __init__(self, num_heads: int):
        super().__init__()
        self.weight = nn.Parameter(torch.zeros(num_heads, 2))

    def forward(self, q, k, v):
        def score_mod(score, b, h, q_idx, kv_idx):
            _ = self.weight[h]
            return score

        return flex_attention.flex_attention(q, k, v, score_mod=score_mod)


device = "cuda"
for compiled in [False, True]:
    torch._dynamo.reset()
    repro = MhaBugRepro(num_heads=8).to(device)
    if compiled:
        repro = torch.compile(repro)
    q = torch.randn(1, 8, 10, 128, requires_grad=True, device=device)
    k = torch.randn(1, 8, 10, 128, device=device)
    v = torch.randn(1, 8, 10, 128, device=device)
    loss = repro(q, k, v).sum()
    loss.backward()
    weight = repro._orig_mod.weight if compiled else repro.weight
    print("compiled" if compiled else "eager", "ok", q.grad.shape, weight.grad)
```

Output after the fix:

```text
/home/drisspg/.ptq_workspace/jobs/20260701-pytorch-166722/pytorch/torch/nn/attention/flex_attention.py:2565: UserWarning: flex_attention called without torch.compile() - this will use an unfused implementation that materializes the full scores matrix instead of generating a fused kernel.

SOLUTION: Use torch.compile(flex_attention)(...)

If you want to debug your score_mod/mask_mod, you can set:
torch.nn.attention.flex_attention._FLEX_ATTENTION_DISABLE_COMPILE_DEBUG = True

This will allow you to use print statements or breakpoints. Note: This doesn't work with the backwards pass and may produce incorrect results.
  _warn_once(
eager ok torch.Size([1, 8, 10, 128]) None
compiled ok torch.Size([1, 8, 10, 128]) None
```

</details>

## Test results

Behavioral tests:

```text
cd pytorch && ~/.ptq_workspace/jobs/20260701-pytorch-166722/.venv/bin/python test/inductor/test_flex_attention.py TestFlexAttentionCUDA.test_direct_backward_supports_symint_score_mod_buffers_cuda TestLearnableBiasesCUDA.test_backprop_error_case_cuda
Ran 2 tests in 7.062s
OK

cd pytorch && ~/.ptq_workspace/jobs/20260701-pytorch-166722/.venv/bin/python test/inductor/test_flex_attention.py -k test_unused_captured_score_mod_grad
Ran 2 tests in 5.801s
OK

cd pytorch && ~/.ptq_workspace/jobs/20260701-pytorch-166722/.venv/bin/python test/inductor/test_flex_attention.py -k test_captured_scalar_grad
Ran 1 test in 16.183s
OK
```

Broader suite signal:

```text
cd pytorch && ~/.ptq_workspace/jobs/20260701-pytorch-166722/.venv/bin/python -m pytest test/inductor/test_flex_attention.py -n 32 -q
667 passed, 24 skipped, 1 xfailed, 2 subtests passed in 292.50s (0:04:52)
```

Before `pytest-xdist` was installed, `pytest` rejected `-n`; I also ran the full file serially and it produced no failures before a 3600s timeout. The first xdist run after installation exposed `TestLearnableBiasesCUDA.test_backprop_error_case_cuda` with `y.grad is None`; that was fixed by allocating captured-grad buffers from the joint graph output rather than `buffer.requires_grad`, and the final xdist full-file run above passed.

Ring attention direct-backward smoke:

```text
cd pytorch && ~/.ptq_workspace/jobs/20260701-pytorch-166722/.venv/bin/torchrun --standalone --nproc_per_node=2 ../agent_space/ring_attention.py --seq-len 256 --dtype float32 --backend TRITON
[rank 0] local forward shard matches reference
[rank 1] local forward shard matches reference
[rank 0] gathered forward matches reference
[rank 0] local dq, dk, and dv match reference
[rank 1] local dq, dk, and dv match reference
[rank 0] gathered outputs and gradients match the single-process reference
```

I also ran the same copied ring-attention script with default/AUTO and `--no-validate`; forward and backward completed on both ranks. The default/AUTO validated run produced large gradient mismatches, and FLASH bf16 hit separate CuTe block-sparse block-size constraints, so the passing direct-backward validation signal is the explicit TRITON run above.

Prerequisite checks:

```text
cd pytorch && spin quickfix
ok No lint issues.

cd pytorch && spin quicklint
ok No lint issues.
```

I also attempted full `spin fixlint`; it failed on unrelated pre-existing shellcheck issues in `.ci/pytorch/test.sh` and `.ci/pytorch/common.sh`, not on the changed Python files.


Fixes #166722


<details>
<summary>Repro Script</summary>

```python
import torch
from torch import nn
from torch.nn.attention import flex_attention

class MhaBugRepro(nn.Module):
    def __init__(self, num_heads: int):
        super().__init__()
        self.weight = nn.Parameter(torch.zeros(num_heads, 2))

    def forward(self, q, k, v):
        def score_mod(score, b, h, q_idx, kv_idx):
            foo = self.weight[h] # THIS LINE CAUSES IT TO BREAK
            return score

        return flex_attention.flex_attention(
            q, k, v,
            score_mod=score_mod,
        )

# Same behaviour on CPU and GPU
device = None
repro = MhaBugRepro(num_heads=8).to(device)
loss = repro(torch.randn(1, 8, 10, 128, requires_grad=True).to(device), torch.randn(1, 8, 10, 128).to(device), torch.randn(1, 8, 10, 128).to(device)).sum()
loss.backward()
```

</details>


<details>
<summary>Agent Worklog</summary>

## Run 1

### Primed and reproduced on GPU
Read the PTQ context, issue prompt, existing worklog, and repo AGENTS instructions. The provided `repro.py` hits a CPU `NotImplementedError` because FlexAttention backward is unsupported on CPU in this checkout. Running the same repro on CUDA (`NVIDIA GB200`, torch `2.14.0a0+gita7dae7f`) reproduces the reported failure at backward with `TypeError: copy_(): argument 'other' (position 1) must be Tensor, not NoneType` in `torch/_higher_order_ops/flex_attention.py:1150`.

### Fixed unused captured score_mod grads
Traced the eager failure to `sdpa_dense_backward`: it allocates an output gradient buffer for captured `score_mod` tensors with `requires_grad=True`, but the AOT joint graph legitimately returns `None` when the captured tensor is referenced and not used in the returned score. Updated the copy-back path to return `None` for non-Tensor grads instead of calling `copy_(None)`.

### Fixed compiled metadata for unused captured grads
Checked `torch.compile` after the eager fix and found a related Inductor backward failure: `AttributeError: 'NoneType' object has no attribute 'get_size'`. The compiled path's proxy/fake metadata still claimed the unused captured grad was a tensor even though the joint graph and lowering returned `None`. Added a helper that reads the joint graph outputs corresponding to `score_mod` captures, then uses it in proxy tracing and fake tensor mode so `None` captured-grad slots stay `None` in metadata. Expanded `test_unused_captured_score_mod_grad` to run both uncompiled and compiled `flex_attention`.

### Simplified final patch and validated
CUDA issue repro now completes backward in both eager/uncompiled and `torch.compile` modes and leaves `weight.grad` as `None`, as expected for an unused parameter. Refined the eager allocation so captured-grad destination buffers are also `None` when the joint graph reports an unused captured grad, then simplified the patch to share captured-grad output normalization and buffer allocation across eager/proxy/fake paths. Targeted tests pass: `test_unused_captured_score_mod_grad` (2 parameterized cases) and `test_captured_scalar_grad`. `spin quickfix` and `spin quicklint` pass on changed files. Full `spin fixlint` was attempted earlier and fails on pre-existing unrelated shellcheck issues in `.ci/pytorch/*.sh`.

### Full FlexAttention file signal
Tried to run the full file with pytest-xdist via `python -m pytest test/inductor/test_flex_attention.py -n 15 -q`, but this job venv did not initially have xdist enabled (`pytest: error: unrecognized arguments: -n`). Ran the full `test/inductor/test_flex_attention.py` file serially with the repo test runner instead; it produced no failures before the 3600s timeout and no leftover test processes remained afterward.

After `pytest-xdist` was installed, ran `python -m pytest test/inductor/test_flex_attention.py -n 32 -q`. The first xdist run failed `TestLearnableBiasesCUDA.test_backprop_error_case_cuda` with `y.grad is None`, showing that captured-grad destination buffers must be allocated whenever the joint graph produces a captured grad, not only when the saved captured tensor has `requires_grad=True`. Removed that stale `requires_grad` condition.

Also checked whether the callable-joint-graph fallback was actually needed. Removing it broke direct compiled backward/fake-mode paths where proxy/fake tracing sees a callable joint graph before `make_fx` materializes it, so the fallback is real. To avoid patching metadata after the fact, reordered `trace_flex_attention_backward` to materialize `fw_graph`, `joint_graph`, and `mask_graph` first, then compute `example_out` once using those final graphs. Reran direct-backward tests, targeted regressions, lint, and the full xdist file. Final full-file result after the reorder: `667 passed, 24 skipped, 1 xfailed, 2 subtests passed in 292.50s`.

### Ring attention direct-backward smoke
Copied the provided ring attention example into `agent_space/ring_attention.py` and ran it with two local GB200 ranks. The explicit TRITON backend validated forward and direct-backward gradients against the single-process reference: `torchrun --standalone --nproc_per_node=2 ../agent_space/ring_attention.py --seq-len 256 --dtype float32 --backend TRITON` printed local/gathered forward and gradient matches. The default/AUTO backend completed forward and backward with `--no-validate`, showing the direct backward path compiles and runs, but its validated run had large gradient mismatches; that appears to be backend/LSE-conversion behavior in the example rather than a captured-grad metadata crash. FLASH bf16 runs hit separate CuTe block-sparse block-size constraints before validation.

</details>

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Chillee @yanboliang @BoyuanFeng @liangel-02 @howardzhang-cv