### PR TITLE
[dynamo, nested graph breaks] add _create_sub_mesh skip rule and use UNSUPPORTED_SERIALIZATION_GUARD_TYPES

### DIFF
--- a/test/dynamo/test_guard_serialization.py
+++ b/test/dynamo/test_guard_serialization.py
@@ -1543,13 +1543,15 @@ class TestGuardSerialization(TestGuardSerializationBase):
             def foo(ddp, x):
                 return ddp(x)
 
+            unsupported = frozenset(
+                torch._dynamo.guards.CheckFunctionManager.UNSUPPORTED_SERIALIZATION_GUARD_TYPES
+            )
             x = torch.randn(10)
             package = CompilePackage(foo)
             torch._dynamo.optimize(
                 package=package,
                 guard_filter_fn=lambda gs: [
-                    x.guard_type not in ("CLOSURE_MATCH", "ID_MATCH", "CLASS_MATCH")
-                    for x in gs
+                    x.guard_type not in unsupported for x in gs
                 ],
             )(foo)(ddp_model, x)
             self.assertEqual(len(package._codes[foo.__code__].guarded_codes), 1)

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -177,6 +177,7 @@ manual_torch_name_rule_map: dict[
     "torch.distributed.get_world_size": TorchInGraphFunctionVariable,
     "torch.distributed.tensor._api.DTensor#from_local": TorchInGraphFunctionVariable,
     "torch.distributed.device_mesh.DeviceMesh#__init__": SkipFunctionVariable,
+    "torch/distributed/device_mesh.py#_create_sub_mesh": SkipFunctionVariable,
     "torch.distributed.distributed_c10d._get_group_size_by_name": TorchInGraphFunctionVariable,
     "torch.distributed.distributed_c10d._resolve_group_name_by_ranks_and_tag": TorchInGraphFunctionVariable,
     "torch.distributed.distributed_c10d._get_group_tag": TorchInGraphFunctionVariable,

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -846,18 +846,17 @@ else:
             with torch._dynamo.disable_nested_graph_breaks():
                 root_mesh = self._get_root_mesh()
                 slice_dim_group_name = []
+                dim_names = not_none(self._mesh_dim_names)
                 if len(self._dim_group_names) > 0:
-                    if len(self._dim_group_names) != len(not_none(self._mesh_dim_names)):
+                    if len(self._dim_group_names) != len(dim_names):
                         raise AssertionError(
                             "The number of dim_group_names and mesh_dim_names "
                             "should have the same length if the rank is in the mesh."
                         )
                     for name in submesh_dim_names:
-                        if name in not_none(self._mesh_dim_names):
+                        if name in dim_names:
                             slice_dim_group_name.append(
-                                self._dim_group_names[
-                                    not_none(self._mesh_dim_names).index(name)
-                                ]
+                                self._dim_group_names[dim_names.index(name)]
                             )
                         else:
                             # If device_mesh is not root_mesh, we already throw error in _get_slice_mesh_layout

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -843,41 +843,42 @@ else:
             layout: _MeshLayout,
             submesh_dim_names: tuple[str, ...],
         ) -> "DeviceMesh":
-            root_mesh = self._get_root_mesh()
-            slice_dim_group_name = []
-            if len(self._dim_group_names) > 0:
-                if len(self._dim_group_names) != len(not_none(self._mesh_dim_names)):
-                    raise AssertionError(
-                        "The number of dim_group_names and mesh_dim_names "
-                        "should have the same length if the rank is in the mesh."
-                    )
-                for name in submesh_dim_names:
-                    if name in not_none(self._mesh_dim_names):
-                        slice_dim_group_name.append(
-                            self._dim_group_names[
-                                not_none(self._mesh_dim_names).index(name)
-                            ]
+            with torch._dynamo.disable_nested_graph_breaks():
+                root_mesh = self._get_root_mesh()
+                slice_dim_group_name = []
+                if len(self._dim_group_names) > 0:
+                    if len(self._dim_group_names) != len(not_none(self._mesh_dim_names)):
+                        raise AssertionError(
+                            "The number of dim_group_names and mesh_dim_names "
+                            "should have the same length if the rank is in the mesh."
                         )
-                    else:
-                        # If device_mesh is not root_mesh, we already throw error in _get_slice_mesh_layout
-                        # Since we will deprecate the slicing of flattened dim_name from root mesh soon,
-                        # we don't want to optimize the code furthermore.
-                        flatten_mesh = self._flatten_mapping[name]
-                        slice_dim_group_name.append(
-                            flatten_mesh._dim_group_names[
-                                not_none(flatten_mesh._mesh_dim_names).index(name)
-                            ]
-                        )
-            res_submesh = DeviceMesh(
-                self._device_type,
-                _layout=layout,
-                _rank_map=root_mesh._rank_map,
-                mesh_dim_names=submesh_dim_names,
-                _root_mesh=root_mesh,
-                _init_backend=False,
-            )
-            res_submesh._dim_group_names = slice_dim_group_name
-            return res_submesh
+                    for name in submesh_dim_names:
+                        if name in not_none(self._mesh_dim_names):
+                            slice_dim_group_name.append(
+                                self._dim_group_names[
+                                    not_none(self._mesh_dim_names).index(name)
+                                ]
+                            )
+                        else:
+                            # If device_mesh is not root_mesh, we already throw error in _get_slice_mesh_layout
+                            # Since we will deprecate the slicing of flattened dim_name from root mesh soon,
+                            # we don't want to optimize the code furthermore.
+                            flatten_mesh = self._flatten_mapping[name]
+                            slice_dim_group_name.append(
+                                flatten_mesh._dim_group_names[
+                                    not_none(flatten_mesh._mesh_dim_names).index(name)
+                                ]
+                            )
+                res_submesh = DeviceMesh(
+                    self._device_type,
+                    _layout=layout,
+                    _rank_map=root_mesh._rank_map,
+                    mesh_dim_names=submesh_dim_names,
+                    _root_mesh=root_mesh,
+                    _init_backend=False,
+                )
+                res_submesh._dim_group_names = slice_dim_group_name
+                return res_submesh
 
         def _create_flatten_mesh(
             self,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #171826
* #163503
* #185524
* #188173
* #186100
* #186657
* __->__ #188861

Add a skip rule for `_create_sub_mesh` in trace_rules.py so dynamo skips it
as a top-level frame (the DeviceMesh constructor always graph breaks). Wrap
`_create_sub_mesh`'s body in `disable_nested_graph_breaks()` so any graph
breaks inside fall back to regular breaks instead of NGB.

Also update `test_ddp_module` to use
`CheckFunctionManager.UNSUPPORTED_SERIALIZATION_GUARD_TYPES` instead of a
hardcoded tuple, so the guard filter stays in sync as new unsupported guard
types are added.

These changes were originally in PR #177934 which was never relanded.

Test Plan:

```
python test/dynamo/test_guard_serialization.py TestGuardSerialization.test_ddp_module
```

Co-authored-by: AI Assistant

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98