### PR TITLE
 [inductor] Fix bool minimum/maximum crash in index propagation (#188862) (#188862)

### DIFF
--- a/test/inductor/test_indexing.py
+++ b/test/inductor/test_indexing.py
@@ -501,6 +501,23 @@ class TestIndexingSimplification(InductorTestCase):
         out_compiled = compiled_foo(arg0, arg1, arg2, arg3, arg4, sentinel)
         out_compiled.sum().backward()
 
+    @unittest.skipUnless(HAS_CPU, "requires CPU")
+    def test_bool_minimum_maximum_index_propagation(self):
+        def foo(x):
+            thresh = torch.nn.functional.threshold(x, 6.08522335982976, -0.05932757)
+            eq = torch.eq(thresh, x)
+            empty = torch.empty_like(eq)
+            return torch.minimum(empty, empty), torch.maximum(empty, empty)
+
+        x = torch.randn([32], dtype=torch.float64)
+        compiled_foo = torch.compile(foo, backend="inductor")
+        with torch.no_grad():
+            out_min, out_max = compiled_foo(x)
+        self.assertEqual(out_min.dtype, torch.bool)
+        self.assertEqual(out_max.dtype, torch.bool)
+        self.assertEqual(out_min.shape, x.shape)
+        self.assertEqual(out_max.shape, x.shape)
+
 
 class ExprPrinterTests(InductorTestCase):
     def test_print_pow(self):

--- a/test/test_sympy_utils.py
+++ b/test/test_sympy_utils.py
@@ -367,6 +367,42 @@ class TestValueRanges(TestCase):
                 else:
                     self.assertEqual(len(unique), 2)
 
+    def test_bool_minimum_maximum(self):
+        vals = [sympy.false, sympy.true]
+        for fn in ("minimum", "maximum"):
+            for a, b in itertools.product(generate_range(vals), repeat=2):
+                with self.subTest(fn=fn, a=a, b=b):
+                    ref_r = getattr(ValueRangeAnalysis, fn)(a, b)
+                    self.assertTrue(ref_r.is_bool)
+                    unique = set()
+                    for a0, b0 in itertools.product(vals, repeat=2):
+                        if a0 not in a or b0 not in b:
+                            continue
+                        if fn == "minimum":
+                            expected = bool(a0) and bool(b0)
+                        else:
+                            expected = bool(a0) or bool(b0)
+                        r = sympy.true if expected else sympy.false
+                        self.assertIn(r, ref_r)
+                        unique.add(r)
+                    if ref_r.lower == ref_r.upper:
+                        self.assertEqual(len(unique), 1)
+                    else:
+                        self.assertEqual(len(unique), 2)
+
+    def test_bool_minimum_maximum_mixed_raises(self):
+        # min/max require both operands to be boolean or both non-boolean;
+        # a mixed boolean/non-boolean pair must raise.
+        bool_range = ValueRanges(sympy.false, sympy.true)
+        int_range = ValueRanges(sympy.Integer(0), sympy.Integer(4))
+        for fn in ("minimum", "maximum"):
+            for a, b in ((bool_range, int_range), (int_range, bool_range)):
+                with self.subTest(fn=fn, a=a, b=b):
+                    with self.assertRaisesRegex(
+                        AssertionError, "operands must both be boolean"
+                    ):
+                        getattr(ValueRangeAnalysis, fn)(a, b)
+
     @parametrize("fn", UNARY_OPS)
     def test_unary_ref_range(self, fn):
         # TODO: bring back sympy.oo testing for float unary fns

--- a/torch/_inductor/index_propagation.py
+++ b/torch/_inductor/index_propagation.py
@@ -175,11 +175,15 @@ class SymPyOps:
     @staticmethod
     def minimum(x: TypedExpr, y: TypedExpr) -> TypedExpr:
         result_type = torch.promote_types(x.dtype, y.dtype)
+        if result_type == torch.bool:
+            return NotImplemented
         return TypedExpr(Min(x.expr, y.expr), result_type)
 
     @staticmethod
     def maximum(x: TypedExpr, y: TypedExpr) -> TypedExpr:
         result_type = torch.promote_types(x.dtype, y.dtype)
+        if result_type == torch.bool:
+            return NotImplemented
         return TypedExpr(Max(x.expr, y.expr), result_type)
 
 

--- a/torch/utils/_sympy/value_ranges.py
+++ b/torch/utils/_sympy/value_ranges.py
@@ -911,10 +911,24 @@ class SymPyValueRangeAnalysis:
 
     @classmethod
     def minimum(cls, a, b):
+        a, b = ValueRanges.wrap(a), ValueRanges.wrap(b)
+        if a.is_bool != b.is_bool:
+            raise AssertionError(
+                "operands must both be boolean ValueRanges or both non-boolean"
+            )
+        if a.is_bool:
+            return cls.and_(a, b)
         return cls.min_or_max(a, b, sympy.Min)
 
     @classmethod
     def maximum(cls, a, b):
+        a, b = ValueRanges.wrap(a), ValueRanges.wrap(b)
+        if a.is_bool != b.is_bool:
+            raise AssertionError(
+                "operands must both be boolean ValueRanges or both non-boolean"
+            )
+        if a.is_bool:
+            return cls.or_(a, b)
         return cls.min_or_max(a, b, sympy.Max)
 
     @staticmethod


### PR DESCRIPTION
Summary:
**Context**
`torch.minimum`/`torch.maximum` on boolean tensors crash under `torch.compile(backend="inductor")` with `ValueError: The argument 'False' is not comparable.`, while eager mode works. Reported in https://github.com/pytorch/pytorch/issues/188230 (repro: threshold -> torch.eq -> torch.empty_like -> torch.minimum). The root cause is that inductor feeds boolean sympy values into `Min`/`Max`, which sympy rejects because booleans are not orderable. Two independent call sites are involved: (1) index propagation builds a symbolic `Min`/`Max` over the operand expressions, and (2) value-range/bounds analysis calls `sympy.Min`/`sympy.Max` on boolean ranges. The second site stays masked behind the first until the first is fixed.

**This diff**
Guards both call sites against boolean operands, mirroring the existing pattern in each file:
- `torch/_inductor/index_propagation.py`: `SymPyOps.minimum`/`maximum` return `NotImplemented` when the promoted result type is `torch.bool`, so index propagation falls back to the regular ops handler (same convention as the existing `floordiv`/`mod`/`remainder` guards).
- `torch/utils/_sympy/value_ranges.py`: `SymPyValueRangeAnalysis.minimum`/`maximum` delegate to `and_`/`or_` when either operand `is_bool` (boolean min == logical-and, max == logical-or), matching the existing `bitwise_and`/`bitwise_or` handling.
Adds regression tests covering both paths.
---
> Generated by [RACER](https://www.internalfb.com/wiki/RACER_(Risk-Aware_Code_Editing_and_Refactoring)/), powered by [Claude Code](https://www.internalfb.com/wiki/Confucius/Analect/Dev/Assistant/Claude_Code/)
Trajectory: https://www.internalfb.com/devai/trajectory/bf5af293-80ae-4234-b210-57b792e46163
Inspector: https://www.internalfb.com/intern/devai/devmate/inspector/bf5af293-80ae-4234-b210-57b792e46163
Agent Home: https://www.internalfb.com/agent-home?session_id=bf5af293-80ae-4234-b210-57b792e46163


Test Plan:
buck2 test fbcode//caffe2/test/inductor:indexing
  -> Pass 66. Fail 0. Skip 3.  (incl. new test_bool_minimum_maximum_index_propagation)

buck2 test fbcode//caffe2/test:sympy_utils
  -> Pass 231. Fail 0. Skip 1 (Z3 not installed).  (incl. new test_bool_minimum_maximum)
  (test_sympy_utils.py has no standing fbcode target; runs in PyTorch OSS CI via `python test/...`)

arc lint on all 4 changed files -> ok No lint issues.

Without the fix, the new inductor test fails with the exact `ValueError: The argument 'False' is not comparable.`





cc jgong5 mingfeima XiaobingSuper sanchitintel ashokei jingxu10 aditew01 voznesenskym penguinwu EikanWang Guobing-Chen zhuhaozhe blzheng wenzhe-nrv jiayisunx ipiszy kadeng muchulee8 amjames chauhang aakhundov coconutruben jataylo

Reviewed By: williamwen42

Differential Revision: D110519151

Pulled By: tanpuresiddhant




cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo