### PR TITLE
[inductor][NVGEMM] Use string literals for CuTeDSL fence_proxy API

### DIFF
--- a/torch/_inductor/kernel/vendored_templates/cutedsl/dense_blockscaled_gemm_persistent.py
+++ b/torch/_inductor/kernel/vendored_templates/cutedsl/dense_blockscaled_gemm_persistent.py
@@ -1503,8 +1503,8 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                     )
                     # Fence and barrier to make sure shared memory store is visible to TMA store
                     cute.arch.fence_proxy(
-                        cute.arch.ProxyKind.async_shared,
-                        space=cute.arch.SharedSpace.shared_cta,
+                        "async.shared",
+                        space="cta",
                     )
                     self.epilog_sync_barrier.arrive_and_wait()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #188646
* __->__ #188865
* #188303

The `fence_proxy()` API changed to accept string literals instead of
enum members (`ProxyKind.async_shared` -> `"async.shared"`,
`SharedSpace.shared_cta` -> `"cta"`). The enum-based API was deprecated
and then removed in newer `nvidia_cutlass_dsl` versions, causing
`AttributeError: module 'cutlass.cute.arch' has no attribute
'ProxyKind'` on CI.

Root cause: the vendored `dense_blockscaled_gemm_persistent.py` used
the old enum API.

Test Plan:

Verified the fix locally by running the previously-failing test:

```bash
python test/inductor/test_nv_universal_gemm.py \
    TestNVUniversalGemm.test_bmm_non_standard_batch_stride_bfloat16

python test/inductor/test_nv_universal_gemm.py \
    TestNVUniversalGemm.test_bmm_non_standard_batch_stride_float16
```

Both pass. The failure could not be reproduced locally because the local
`nvidia_cutlass_dsl` still has the deprecated enum (with warnings), but
CI's version has it removed.

Co-authored-by: Claude AI (claude-code)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo