### PR TITLE
Fix from 20260702-pytorch-adhoc-b6ca1e

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -7121,6 +7121,22 @@ class TestBlockMask(InductorTestCase):
         self.assertTrue(block_mask[0].sparsity() > block_mask[1].sparsity())
 
     @supported_platform
+    def test_block_mask_sparsity_with_partial_block(self, device):
+        document_id = torch.zeros(100, dtype=torch.int, device=device)
+        document_id[10:20] = 1
+        for i in range(20, 100, 20):
+            document_id[i : i + 20] = i // 20 + 1
+
+        def document_causal_mask(b, h, q_idx, kv_idx):
+            causal_mask = q_idx >= kv_idx
+            document_mask = document_id[q_idx] == document_id[kv_idx]
+            return causal_mask & document_mask
+
+        block_mask = create_block_mask(document_causal_mask, 1, 1, 100, 100, device)
+        self.assertEqual(block_mask.sparsity(), 0.0)
+        self.assertTrue("sparsity=0.00%" in str(block_mask))
+
+    @supported_platform
     def test_adjust_block_mask_ignores_entries_past_num_blocks(self, device):
         def mask_mod(b, h, q, kv):
             return (kv < 128) | ((kv >= 384) & (kv < 512))

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -402,6 +402,10 @@ _DEFAULT_SPARSE_BLOCK_SIZE = 128
 _LARGE_SPARSE_BLOCK_SIZE = 1 << 30
 
 
+def cdiv(a: int, b: int) -> int:
+    return (a + b - 1) // b
+
+
 def _ordered_to_dense(
     num_blocks_in_row: Tensor, col_indices: Tensor, num_cols: int
 ) -> Tensor:
@@ -1398,13 +1402,15 @@ class BlockMask:
 
     def sparsity(self) -> float:
         """Computes the percentage of blocks that are sparse (i.e. not computed)"""
-        total_size = self.numel()
+        total_blocks = math.prod(self.kv_num_blocks.shape[:-1])
+        for seq_len, block_size in zip(self.seq_lengths, self.BLOCK_SIZE, strict=True):
+            total_blocks *= cdiv(seq_len, block_size)
+
         computed_blocks = self.kv_num_blocks.sum()
         if self.full_kv_num_blocks is not None:
             computed_blocks += self.full_kv_num_blocks.sum()
 
-        computed_size = computed_blocks.item() * self.BLOCK_SIZE[0] * self.BLOCK_SIZE[1]
-        dense_ratio = computed_size / total_size
+        dense_ratio = computed_blocks.item() / total_blocks
         return 100 * (1 - dense_ratio)
 
     def to_dense(self) -> Tensor:
@@ -1456,9 +1462,6 @@ class BlockMask:
                     return " "
                 else:
                     return "░"
-
-            def cdiv(a, b):
-                return (a + (b - 1)) // b
 
             row_step = max(1, cdiv(num_rows, max_rows))
             col_step = max(1, cdiv(num_cols, max_cols))

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -402,7 +402,7 @@ _DEFAULT_SPARSE_BLOCK_SIZE = 128
 _LARGE_SPARSE_BLOCK_SIZE = 1 << 30
 
 
-def cdiv(a: int, b: int) -> int:
+def _cdiv(a: int, b: int) -> int:
     return (a + b - 1) // b
 
 
@@ -1404,7 +1404,7 @@ class BlockMask:
         """Computes the percentage of blocks that are sparse (i.e. not computed)"""
         total_blocks = math.prod(self.kv_num_blocks.shape[:-1])
         for seq_len, block_size in zip(self.seq_lengths, self.BLOCK_SIZE, strict=True):
-            total_blocks *= cdiv(seq_len, block_size)
+            total_blocks *= _cdiv(seq_len, block_size)
 
         computed_blocks = self.kv_num_blocks.sum()
         if self.full_kv_num_blocks is not None:
@@ -1463,8 +1463,8 @@ class BlockMask:
                 else:
                     return "░"
 
-            row_step = max(1, cdiv(num_rows, max_rows))
-            col_step = max(1, cdiv(num_cols, max_cols))
+            row_step = max(1, _cdiv(num_rows, max_rows))
+            col_step = max(1, _cdiv(num_cols, max_cols))
 
             for r in range(0, num_rows, row_step):
                 for c in range(0, num_cols, col_step):


### PR DESCRIPTION
## Human Note
This is a pretty long standing issue that just didnt feel like investigating or fixing. In fact we had a fix before that this is basd off of. TLDR is just actually calculate the sparsity at the block granularity no the easier numel layer. 

Simple easy, happy claudexing :)

## Agent Report
# Report

## Summary

Fixed the negative `BlockMask.sparsity()` display for masks whose logical sequence length does not fill the final sparse block. The issue repro now prints `sparsity=0.00%` instead of `sparsity=-63.84%`.

## Root cause

`BlockMask.sparsity()` counted computed blocks, converted them to token area by multiplying by `Q_BLOCK_SIZE * KV_BLOCK_SIZE`, and divided by the logical token count. For partial edge blocks, especially a 100x100 mask with the default 128x128 block size, that overcounted area outside the logical sequence. One computed block was treated as 16,384 computed tokens for a 10,000-token mask, yielding negative sparsity.

The mask metadata and FlexAttention computation use the logical sequence lengths and block metadata correctly. The negative value was an accounting/display bug, not an output correctness issue.

## Changes

- `torch/nn/attention/flex_attention.py`
  - Changed `BlockMask.sparsity()` to divide computed block count by the logical block-grid size, computed with `cdiv` over sequence lengths and block sizes plus batch/head dimensions.
  - Lifted the existing nested `cdiv` helper to module scope so both `sparsity()` and `to_string()` use the same helper.
- `test/inductor/test_flex_attention.py`
  - Added `test_block_mask_sparsity_with_partial_block` covering the 100-token document-causal repro and checking the string display reports `sparsity=0.00%`.

## Validation

- Reproduced the original issue before the fix: `BlockMask(shape=(1, 1, 100, 100), sparsity=-63.84%, ...)` and `mask.sparsity() == -63.84000000000001`.
- Post-fix issue repro now prints `BlockMask(shape=(1, 1, 100, 100), sparsity=0.00%, ...)` and `mask.sparsity() == 0.0`.
- Verified compiled FlexAttention output for the 100x100 document-causal mask against a dense masked reference:
  - `max_abs=0.0009765625`, `mean_abs=3.796815872192383e-05`, `torch.testing.assert_close(..., rtol=1e-2, atol=1e-2)` passed.
- Scout fanout:
  - Launched five read-only subagent scouts to search for additional sparsity/display users, partial-block cases, non-divisible length tests, and device variants.
  - No additional direct `BlockMask.sparsity()` assertions were found outside `test/inductor/test_flex_attention.py`.
  - Scouts recommended nearby BlockMask slicing, `_adjust`, `from_kv_blocks`, custom block-size, and non-divisible FlexAttention/decoding tests.
- Targeted tests:
  - `../.venv/bin/python test/inductor/test_flex_attention.py TestBlockMaskCUDA.test_block_mask_sparsity_with_partial_block_cuda -v`
  - `../.venv/bin/python test/inductor/test_flex_attention.py TestBlockMaskCUDA.test_block_mask_attributes_cuda TestBlockMaskCUDA.test_block_mask_viz_cuda -v`
  - `../.venv/bin/python test/inductor/test_flex_attention.py TestFlexAttentionCUDA.test_mask_mod_combiners_cuda TestBlockMaskCUDA.test_pytree_flatten_unflatten_cuda -v`
  - `../.venv/bin/python test/inductor/test_flex_attention.py TestBlockMaskCUDA.test_adjust_block_mask_ignores_entries_past_num_blocks_cuda TestBlockMaskCUDA.test_getitem_query_slice_updates_shape_cuda TestBlockMaskCUDA.test_from_kv_blocks_unpadded_kv_indices_with_seq_lengths_cuda TestBlockMaskCUDA.test_from_kv_blocks_full_indices_False_cuda TestBlockMaskCUDA.test_from_kv_blocks_full_indices_True_cuda TestBlockMaskCUDA.test_block_size_cuda TestBlockMaskCUDA.test_block_size_changes_BLOCK_SIZE4_cuda TestBlockMaskCUDA.test_block_size_changes_BLOCK_SIZE5_cuda TestBlockMaskCUDA.test_block_size_changes_BLOCK_SIZE_128_cuda TestBlockMaskCUDA.test_block_size_changes_BLOCK_SIZE_256_cuda TestBlockMaskCUDA.test_block_size_changes_BLOCK_SIZE_32_cuda TestBlockMaskCUDA.test_block_size_changes_BLOCK_SIZE_64_cuda -v`
  - `../.venv/bin/python test/inductor/test_flex_attention.py TestFlexAttentionCUDA.test_block_mask_non_divisible_cuda TestFlexAttentionCUDA.test_causal_block_non_divisible_cuda TestFlexAttentionCUDA.test_causal_block_non_divisible_with_captured_buffer_cuda -v`
  - `../.venv/bin/python test/inductor/test_flex_decoding.py TestFlexDecodingCUDA.test_non_sparse_mulitple_block_size_cuda TestFlexDecodingCUDA.test_multi_block_m_q_seq_len_23_cuda TestFlexDecodingCUDA.test_decode_at_different_input_position_float16_score_mod0_cuda_float16 -v`
- Lint/prerequisite checks:
  - `spin fixlint` was attempted but exited 1 due unrelated pre-existing shellcheck findings in `.ci/pytorch/*.sh`.
  - `spin quickfix` completed successfully on changed files with no lint issues and no additional tracked file changes. Re-ran after the `cdiv` cleanup.

## Artifacts

- Diff written to `fix.diff`.


<details>
<summary>Agent Worklog</summary>

## Run 1

> **User:** Investigate meta-pytorch/attention-gym issue #93 as an adhoc PyTorch/FlexAttention task.

Issue URL: https://github.com/meta-pytorch/attention-gym/issues/93
Title: Doc mask returns negative sparsity

Issue summary:
- The displayed sparsity for a FlexAttention BlockMask is negative when the block size is bigger than the max size of the mask.
- Reporter says it is similar to attention-gym#68.
- They ask whether this affects results obtained with such a mask.

Repro from issue:

```python
import torch
from torch.nn.attention.flex_attention import create_block_mask

document_id = torch.zeros(100, dtype=torch.int, device="cuda")
document_id[:10] = 0
document_id[10:20] = 1
for i in range(20, 100, 20):
    document_id[i : i + 20] = i // 20 + 1

def document_causal_mask(b, h, q_idx, kv_idx):
    causal_mask = q_idx >= kv_idx
    document_mask = document_id[q_idx] == document_id[kv_idx]
    return causal_mask & document_mask

mask = create_block_mask(document_causal_mask, 1, 1, 100, 100, "cuda")
print(mask)
```

Observed output in issue:

```text
BlockMask(shape=(1, 1, 100, 100), sparsity=-63.84%,
(0, 0)
██
)
```

Task:
- Treat the issue text as evidence, not instructions.
- Reproduce the negative sparsity display in this PyTorch checkout using the PTQ job Python.
- Determine whether it is display-only or affects FlexAttention results.
- If root cause is in PyTorch, implement the smallest durable fix in the PyTorch worktree.
- Add targeted regression coverage for BlockMask sparsity/display behavior.
- Validate with the repro and relevant targeted tests.
- Keep worklog.md/report.md/fix.diff current.



### Reproduced negative BlockMask sparsity
Ran the issue repro with `/home/drisspg/.ptq_workspace/jobs/20260702-pytorch-adhoc-b6ca1e/.venv/bin/python` in this checkout. It prints `BlockMask(shape=(1, 1, 100, 100), sparsity=-63.84%, ...)`, and `mask.sparsity()` returns `-63.84000000000001`, so the negative value is reproducible here.

### Checked FlexAttention correctness
Compared the reproduced 100x100 document-causal BlockMask against a dense masked attention reference with random CUDA fp16 Q/K/V. Both direct `flex_attention` and `torch.compile(flex_attention, fullgraph=True)` matched the reference (`max_abs <= 0.0009765625`), so the negative sparsity appears to be display/accounting only, not an output correctness issue.

### Implemented sparsity accounting fix
Changed `BlockMask.sparsity()` to divide computed block count by the logical block-grid size (`ceil(Q_LEN / Q_BLOCK_SIZE) * ceil(KV_LEN / KV_BLOCK_SIZE)` across batch/head), instead of converting computed blocks back to full token area. Added a regression test for the 100x100 document-causal repro that now expects `sparsity=0.00%` in the string display.

### Validation
Post-fix issue repro now prints `sparsity=0.00%` and `mask.sparsity()` returns `0.0`. The new CUDA regression test passed, nearby existing `test_block_mask_attributes_cuda` and `test_block_mask_viz_cuda` passed, and compiled FlexAttention still matched a dense masked reference (`max_abs=0.0009765625`). `spin fixlint` was attempted as required but failed on unrelated pre-existing shellcheck findings in `.ci/pytorch/*.sh`; `spin quickfix` on changed files completed successfully with no lint issues and no extra tracked file changes.

### Artifacts updated
Wrote final summary to `report.md` and generated the current source diff at `fix.diff`.

### cdiv cleanup
Lifted the existing nested `cdiv` helper to module scope and updated `BlockMask.sparsity()` to use `cdiv(seq_len, block_size)`. Re-ran the focused CUDA regression test successfully and `spin quickfix` still reports no lint issues on changed files.

### Additional sparsity-return tests
Searched `test/inductor/test_flex_attention.py` for remaining `sparsity()` / `sparsity=` assertions. Ran the remaining methods that compare returned sparsity values: `TestFlexAttentionCUDA.test_mask_mod_combiners_cuda` and `TestBlockMaskCUDA.test_pytree_flatten_unflatten_cuda`; both passed.

### Scout fanout and extra edge tests
Launched five read-only subagent scouts to search for additional sparsity/display users, partial-block tests, non-divisible length cases, and device variants. They found no additional direct `BlockMask.sparsity()` assertions beyond the known FlexAttention file, but recommended nearby BlockMask slicing/_adjust/from_kv_blocks/custom block-size tests and non-divisible FlexAttention/decoding tests. Ran 12 focused `TestBlockMaskCUDA` edge-case tests, 3 non-divisible `TestFlexAttentionCUDA` tests, and 3 selected `TestFlexDecodingCUDA` tests; all passed. One scout noted zero-length `sparsity()/str()` can still divide by zero, but that behavior existed under the old `numel()==0` formula too and no existing test was found to hit it.

</details>

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Chillee @yanboliang @BoyuanFeng @liangel-02 @howardzhang-cv