### PR TITLE
Fix from 20260702-pytorch-adhoc-6f35e0

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -2437,6 +2437,67 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         torch._dynamo.reset()
 
     @supported_platform
+    @skip_on_cpu
+    @skip_on_xpu
+    @dtypes(torch.float16)
+    @dtypesIfCUDA(torch.float16)
+    @common_utils.parametrize("detach_temp", [False, True])
+    @expected_not_implemented_on_mps
+    def test_captured_0d_scalar_grad(self, device, dtype, detach_temp):
+        class M(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.temp = nn.Parameter(
+                    torch.tensor(0.7, device=device, dtype=torch.float32)
+                )
+
+            def forward(self, q, k, v):
+                temp = self.temp
+
+                def score_mod(score, b, h, q_idx, kv_idx):
+                    if detach_temp:
+                        return score + temp.detach()
+                    return score * temp + temp
+
+                return flex_attention(q, k, v, score_mod=score_mod)
+
+        torch.manual_seed(123)
+        shape = (1, 2, 16, 16)
+        q = torch.randn(shape, device=device, dtype=dtype, requires_grad=True)
+        k = torch.randn(shape, device=device, dtype=dtype, requires_grad=True)
+        v = torch.randn(shape, device=device, dtype=dtype, requires_grad=True)
+        grad = torch.randn(shape, device=device, dtype=dtype)
+        q2 = q.detach().clone().requires_grad_()
+        k2 = k.detach().clone().requires_grad_()
+        v2 = v.detach().clone().requires_grad_()
+        m1 = M()
+        m2 = M()
+        m2.load_state_dict(m1.state_dict())
+
+        out1 = m1(q, k, v)
+        out1.backward(grad)
+        out2 = torch.compile(m2)(q2, k2, v2)
+        out2.backward(grad)
+        if device == "cuda":
+            torch.cuda.synchronize()
+
+        pairs = [
+            (out1, out2),
+            (q.grad, q2.grad),
+            (k.grad, k2.grad),
+            (v.grad, v2.grad),
+        ]
+        if detach_temp:
+            self.assertIsNone(m1.temp.grad)
+            self.assertIsNone(m2.temp.grad)
+        else:
+            self.assertIsNotNone(m1.temp.grad)
+            self.assertIsNotNone(m2.temp.grad)
+            pairs.append((m1.temp.grad, m2.temp.grad))
+        for a, b in pairs:
+            self.assertEqual(a, b, atol=1e-2, rtol=1e-2)
+
+    @supported_platform
     @dtypes(*device_configs["cpu"].dtypes_fast)
     @dtypesIfCUDA(*device_configs["cuda"].dtypes_fast)
     @dtypesIfXPU(*device_configs["xpu"].dtypes_fast)

--- a/torch/_dynamo/_trace_wrapped_higher_order_op.py
+++ b/torch/_dynamo/_trace_wrapped_higher_order_op.py
@@ -56,6 +56,12 @@ def zeros_and_scatter(
     vals: Tensor,
 ) -> Tensor:
     """Custom Op so that we can register a custom lowering for the new_output + scatter in the backwards pass"""
+    if len(indices) == 0:
+        if len(shape) != 0:
+            raise RuntimeError(
+                "zeros_and_scatter with no indices only supports scalar outputs"
+            )
+        return vals.sum().reshape(shape)
     grad = torch.zeros(shape, device=vals.device, dtype=vals.dtype)
     return torch.ops.aten.index_put(grad, indices, vals, accumulate=True)
 
@@ -72,7 +78,7 @@ def _(
 @zeros_and_scatter.register_vmap  # type: ignore[misc]
 def _(info, indims, shape, indices, value):  # type: ignore[no-untyped-def]
     """The batching rule is special in that it returns a tensor that is not batched"""
-    indices_indims = indims[1]
+    indices_indims = indims[1] if indims[1] is not None else []
     expanded_indices = []
     for idx, idx_indim in zip(indices, indices_indims):
         # The index is not being batched, we should unsqueeze and expand to val

--- a/torch/_dynamo/_trace_wrapped_higher_order_op.py
+++ b/torch/_dynamo/_trace_wrapped_higher_order_op.py
@@ -108,7 +108,9 @@ class ModIndex(torch.autograd.Function):
     def forward(x: Tensor, indices: list[Tensor]) -> Tensor:
         if not indices:
             if x.ndim != 0:
-                raise RuntimeError("mod_index with no indices only supports scalar tensors")
+                raise RuntimeError(
+                    "mod_index with no indices only supports scalar tensors"
+                )
             return x
         return torch.ops.aten.index(x, indices)
 

--- a/torch/_dynamo/_trace_wrapped_higher_order_op.py
+++ b/torch/_dynamo/_trace_wrapped_higher_order_op.py
@@ -56,12 +56,12 @@ def zeros_and_scatter(
     vals: Tensor,
 ) -> Tensor:
     """Custom Op so that we can register a custom lowering for the new_output + scatter in the backwards pass"""
-    if len(indices) == 0:
-        if len(shape) != 0:
+    if not indices:
+        if shape:
             raise RuntimeError(
                 "zeros_and_scatter with no indices only supports scalar outputs"
             )
-        return vals.sum().reshape(shape)
+        return vals.sum()
     grad = torch.zeros(shape, device=vals.device, dtype=vals.dtype)
     return torch.ops.aten.index_put(grad, indices, vals, accumulate=True)
 
@@ -106,6 +106,10 @@ class ModIndex(torch.autograd.Function):
     @staticmethod
     # pyrefly: ignore [bad-override]
     def forward(x: Tensor, indices: list[Tensor]) -> Tensor:
+        if not indices:
+            if x.ndim != 0:
+                raise RuntimeError("mod_index with no indices only supports scalar tensors")
+            return x.view(())
         return torch.ops.aten.index(x, indices)
 
     @staticmethod

--- a/torch/_dynamo/_trace_wrapped_higher_order_op.py
+++ b/torch/_dynamo/_trace_wrapped_higher_order_op.py
@@ -78,7 +78,7 @@ def _(
 @zeros_and_scatter.register_vmap  # type: ignore[misc]
 def _(info, indims, shape, indices, value):  # type: ignore[no-untyped-def]
     """The batching rule is special in that it returns a tensor that is not batched"""
-    indices_indims = indims[1] if indims[1] is not None else []
+    indices_indims: list[int | None] = indims[1] if indims[1] is not None else []
     expanded_indices = []
     for idx, idx_indim in zip(indices, indices_indims):
         # The index is not being batched, we should unsqueeze and expand to val

--- a/torch/_dynamo/_trace_wrapped_higher_order_op.py
+++ b/torch/_dynamo/_trace_wrapped_higher_order_op.py
@@ -109,7 +109,7 @@ class ModIndex(torch.autograd.Function):
         if not indices:
             if x.ndim != 0:
                 raise RuntimeError("mod_index with no indices only supports scalar tensors")
-            return x.view(())
+            return x
         return torch.ops.aten.index(x, indices)
 
     @staticmethod

--- a/torch/_higher_order_ops/flex_attention.py
+++ b/torch/_higher_order_ops/flex_attention.py
@@ -724,7 +724,7 @@ def create_fw_bw_graph(
             n: Tensor,
             example_grad: Tensor,
             *other_buffers: tuple[Tensor, ...],
-        ) -> tuple[Tensor, ...]:
+        ) -> list[Tensor | None]:
             def fw_with_masks(
                 *args: tuple[Tensor, ...],
             ) -> tuple[tuple[Tensor], tuple[bool]]:
@@ -743,7 +743,17 @@ def create_fw_bw_graph(
                     "require gradients with respect to score."
                 )
 
-            return grads
+            scalar_captured_grads = [
+                torch.ops.flex_lib.zeros_and_scatter([], [], grad)
+                if (
+                    isinstance(grad, torch.Tensor)
+                    and isinstance(buffer, torch.Tensor)
+                    and buffer.ndim == 0
+                )
+                else grad
+                for grad, buffer in zip(grads[5:], other_buffers)
+            ]
+            return [*grads[:5], *scalar_captured_grads]
 
         joint_graph = make_fx(joint_f)(
             *unwrapped_score_mod_indexes, example_grad, *unwrapped_other_buffers

--- a/torch/_higher_order_ops/flex_attention.py
+++ b/torch/_higher_order_ops/flex_attention.py
@@ -652,6 +652,7 @@ def create_fw_bw_graph(
 
     # All of these imports need to be here in order to avoid circular dependencies
     from torch._dispatch.python import suspend_functionalization
+    from torch._dynamo._trace_wrapped_higher_order_op import mod_index
     from torch._functorch.aot_autograd import AOTConfig, create_joint
     from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
     from torch._subclasses.functional_tensor import disable_functional_mode
@@ -728,7 +729,17 @@ def create_fw_bw_graph(
             def fw_with_masks(
                 *args: tuple[Tensor, ...],
             ) -> tuple[tuple[Tensor], tuple[bool]]:
-                fw_out = score_mod(*args)
+                captured_args = [
+                    mod_index(buffer, [])
+                    if (
+                        isinstance(buffer, torch.Tensor)
+                        and buffer.requires_grad
+                        and buffer.ndim == 0
+                    )
+                    else buffer
+                    for buffer in args[5:]
+                ]
+                fw_out = score_mod(*args[:5], *captured_args)
                 out_requires_grad = fw_out.requires_grad
                 return ((fw_out,), (out_requires_grad,))
 
@@ -743,17 +754,7 @@ def create_fw_bw_graph(
                     "require gradients with respect to score."
                 )
 
-            scalar_captured_grads = [
-                torch.ops.flex_lib.zeros_and_scatter([], [], grad)
-                if (
-                    isinstance(grad, torch.Tensor)
-                    and isinstance(buffer, torch.Tensor)
-                    and buffer.ndim == 0
-                )
-                else grad
-                for grad, buffer in zip(grads[5:], other_buffers)
-            ]
-            return [*grads[:5], *scalar_captured_grads]
+            return grads
 
         joint_graph = make_fx(joint_f)(
             *unwrapped_score_mod_indexes, example_grad, *unwrapped_other_buffers

--- a/torch/_inductor/kernel/flex/common.py
+++ b/torch/_inductor/kernel/flex/common.py
@@ -96,27 +96,39 @@ def zeros_and_scatter_lowering(shape: list[int], indices, values):
     grad.realize()
     x_size = grad.get_size()
     values = to_dtype(values, grad.get_dtype())
-    indices_loaders = [i.make_loader() if i is not None else None for i in indices]
-    indices, tensor_indices = check_and_broadcast_indices(indices, grad.get_device())
-    # We can use the first one since they are all required to be the same size
-    tensor_size = list(indices[tensor_indices[0]].get_size())
-    indexed_size = [x_size[i] for i in range(len(indices))]
-
-    expected_vals_size, inner_fn = index_output_size_and_inner_fn(
-        x_size,
-        indices,
-        tensor_indices,
-        tensor_size,
-        indices_loaders,
-        indexed_size,
-        None,
-        check=True,
-    )
-
-    values = expand(values, expected_vals_size)
     device = grad.get_device()
     if device is None:
         raise AssertionError("device must not be None")
+    if len(indices) == 0:
+        if len(shape) != 0:
+            raise AssertionError(
+                "zeros_and_scatter with no indices only supports scalar outputs"
+            )
+        expected_vals_size = values.get_size()
+
+        def inner_fn(index):
+            return []
+
+    else:
+        indices_loaders = [i.make_loader() if i is not None else None for i in indices]
+        indices, tensor_indices = check_and_broadcast_indices(
+            indices, grad.get_device()
+        )
+        # We can use the first one since they are all required to be the same size
+        tensor_size = list(indices[tensor_indices[0]].get_size())
+        indexed_size = [x_size[i] for i in range(len(indices))]
+
+        expected_vals_size, inner_fn = index_output_size_and_inner_fn(
+            x_size,
+            indices,
+            tensor_indices,
+            tensor_size,
+            indices_loaders,
+            indexed_size,
+            None,
+            check=True,
+        )
+        values = expand(values, expected_vals_size)
     scatter = Scatter(
         device=device,
         dtype=grad.get_dtype(),

--- a/torch/_inductor/kernel/flex/common.py
+++ b/torch/_inductor/kernel/flex/common.py
@@ -99,8 +99,8 @@ def zeros_and_scatter_lowering(shape: list[int], indices, values):
     device = grad.get_device()
     if device is None:
         raise AssertionError("device must not be None")
-    if len(indices) == 0:
-        if len(shape) != 0:
+    if not indices:
+        if shape:
             raise AssertionError(
                 "zeros_and_scatter with no indices only supports scalar outputs"
             )

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -503,6 +503,7 @@ class ModificationWrapper(V.WrapperHandler):  # type: ignore[name-defined]
         return self.kernel.kexpr(self.kernel.rename_indexing(index))
 
     def _broadcast_index(self, index: sympy.Expr, shape: str) -> str:
+        index = sympy.sympify(index)
         index_str = self._process_indexing(index)
         index_shape = TritonSymbols.get_block_shape(index)
         if (
@@ -514,6 +515,8 @@ class ModificationWrapper(V.WrapperHandler):  # type: ignore[name-defined]
             )
         ):
             return f"tl.broadcast_to(tl.reshape({index_str}, []), {shape})"
+        if not index_shape and len(index.free_symbols) == 0:
+            return f"tl.full({shape}, {index_str}, tl.int64)"
         return f"tl.broadcast_to({index_str}, {shape})"
 
 

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -516,7 +516,7 @@ class ModificationWrapper(V.WrapperHandler):  # type: ignore[name-defined]
         ):
             return f"tl.broadcast_to(tl.reshape({index_str}, []), {shape})"
         if not index_shape and len(index.free_symbols) == 0:
-            return f"tl.full({shape}, {index_str}, tl.int64)"
+            return f"tl.full({shape}, {index_str}, INDEX_DTYPE)"
         return f"tl.broadcast_to({index_str}, {shape})"
 
 


### PR DESCRIPTION
## Human Note
This lets us return grads for scalar biases. I pusehd back on this in the path since there were workarounds although a lil ugly. But after prototyping i think its fine to land and easy enough to gork. 

We should wait for #188860 to land first since they touch teh same code -> how we create the captured buffer grads

## Agent Report
# Report: attention-gym #171 FlexAttention learnable scalar

## Summary

Reproduced the issue in this checkout using the exact scalar `score_mod` pattern:

- Eager forward succeeded, eager backward failed with the reported `vmap(... out_dim is None)` BatchedTensor error.
- Compiled forward succeeded, compiled backward failed in Inductor FlexAttention backward lowering with `AssertionError: ComputedBuffer name must not be None`.

Implemented a PyTorch-side fix for direct 0-D captured score-mod gradients. The PR branch has since been rebased onto latest `origin/main` at `d2f0d442d70` and rebuilt locally with cuDNN enabled (`CUDNN_VERSION=9.23.0`, `USE_CUDNN=1`). Current job torch reports `2.14.0a0+git9fadffc`.

Implemented changes:

- `torch/_higher_order_ops/flex_attention.py`
  - Routes direct 0-D captured score-mod tensors through `mod_index(buffer, [])` while tracing the joint graph, so the existing captured-index custom autograd path emits `flex_lib::zeros_and_scatter([], [], grad)` for scalar gradient accumulation.
  - Preserves unused/no-grad captured buffers by returning `None` instead of copying `None` into an allocated grad buffer.
- `torch/_dynamo/_trace_wrapped_higher_order_op.py`
  - Supports empty-index `zeros_and_scatter` as scalar accumulation by summing values into a scalar output.
  - Allows `ModIndex` to use an empty index list as a scalar identity whose backward is empty-index scalar accumulation.
  - Returns the checked 0-D tensor directly in the empty-index `ModIndex.forward` path.
  - Handles empty index metadata in its vmap rule with an annotation-only pyrefly fix, preserving the previous empty-list fallback semantics.
- `torch/_inductor/kernel/flex/common.py`
  - Lowers empty-index `zeros_and_scatter` to a scalar atomic-add scatter for FlexAttention template subgraphs.
  - Uses the same compact empty-index guard shape as eager `zeros_and_scatter`.
- `torch/_inductor/select_algorithm.py`
  - Normalizes scalar scatter indexes for Triton codegen and emits `tl.full(..., INDEX_DTYPE)` for constant scalar atomic indexes instead of invalid `tl.broadcast_to(0, ...)`.
- `test/inductor/test_flex_attention.py`
  - Adds a parametrized CUDA float16 regression covering both direct learnable 0-D scalar gradients and detached/no-grad 0-D captures.

## Relationship to the prior unused-captured-grad issue

The direct scalar learnable case is distinct from the existing `(1,)` indexed captured-scalar path: indexed captures already trace to `zeros_and_scatter([1], [idx], grad)`, while direct 0-D captures previously returned a plain computed captured grad that became batched under nested `vmap`. The local cleanup now makes direct 0-D captures enter the same `ModIndex` custom autograd path using an empty index list, instead of post-processing captured grad outputs after `create_joint`.

I also checked a detached 0-D captured scalar (`score + temp.detach()`). Before the guard, eager backward tried to copy a `None` captured grad into an allocated buffer. The patch keeps that captured grad as `None`, and the new parametrized test checks eager and compiled behavior for this no-grad case.

## Validation

Behavioral repro after rebasing onto `origin/main`:

```bash
cd ~/.ptq_workspace/jobs/20260702-pytorch-adhoc-6f35e0
TORCHINDUCTOR_FORCE_DISABLE_CACHES=1 CUDA_LAUNCH_BLOCKING=1 ./.venv/bin/python pytorch/agent_space/repro_flex_scalar.py parity
```

Passed after the main rebase, after the local cleanup, and after the subagent-suggested simplifications. Final max diffs from eager-vs-compiled parity:

- out: 0.00048828125
- q: 0.00048828125
- k: 0.00048828125
- v: 0.0
- temp: 0.005798816680908203

Targeted tests after rebasing onto `origin/main`:

```bash
cd ~/.ptq_workspace/jobs/20260702-pytorch-adhoc-6f35e0/pytorch
CUDA_LAUNCH_BLOCKING=1 ../.venv/bin/python test/inductor/test_flex_attention.py -k captured_0d_scalar_grad --verbose
CUDA_LAUNCH_BLOCKING=1 ../.venv/bin/python test/inductor/test_flex_attention.py -k unused_captured_score_mod_grad --verbose
CUDA_LAUNCH_BLOCKING=1 ../.venv/bin/python test/inductor/test_flex_attention.py -k captured_scalar_grad --verbose
```

Passed after the main rebase, after the local cleanup, and after the subagent-suggested simplifications:

- `captured_0d_scalar_grad`: 2 tests
- `unused_captured_score_mod_grad`: 2 tests
- `captured_scalar_grad`: 1 test

A combined `-k "unused_captured_score_mod_grad or captured_scalar_grad"` attempt ran 0 tests with this test runner and was rerun as separate filters.

Full Flex xdist validation:

```bash
cd ~/.ptq_workspace/jobs/20260702-pytorch-adhoc-6f35e0/pytorch
CUDA_LAUNCH_BLOCKING=1 ../.venv/bin/python -m pytest -n 32 \
  test/inductor/test_flex_attention.py \
  test/inductor/test_flex_aux_vectorization.py \
  test/inductor/test_flex_decoding.py \
  test/inductor/test_flex_flash.py \
  test/inductor/test_flex_gemm.py
```

Installed `pytest-xdist` into the job venv first (`pytest 9.1.1`, `xdist 3.8.0`). The `-n 32` run completed with `1460 passed, 58 skipped, 3 xfailed, 11 failed in 491.94s`. The 11 failures were CUDA OOM / CUDA driver OOM under 32 concurrent GPU workers; the full log showed GPU 0 nearly full with many pytest worker processes. After the run exited, `nvidia-smi` showed no remaining GPU processes, and rerunning the 11 failed nodeids serially passed: `11 passed in 144.92s`.

Reran the FlexAttention test file alone with 20 xdist workers:

```bash
CUDA_LAUNCH_BLOCKING=1 ../.venv/bin/python -m pytest -n 20 test/inductor/test_flex_attention.py
```

Passed: `670 passed, 24 skipped, 1 xfailed in 376.72s`.

Lint/prerequisite checks:

```bash
cd ~/.ptq_workspace/jobs/20260702-pytorch-adhoc-6f35e0/pytorch
spin lint -- --take PYREFLY --all-files
spin lint -- --take RUFF --all-files
```

Passed locally after the annotation-only pyrefly fix, after the local cleanup, after the subagent-suggested simplifications, and after the CI lint formatting fix. The CI lint formatting fix was validated with `spin lint -- -m origin/main`.

```bash
cd ~/.ptq_workspace/jobs/20260702-pytorch-adhoc-6f35e0/pytorch
spin fixlint
```

`spin fixlint` applied no relevant changes and reported Python lint OK, but the overall command exited 1 due to unrelated pre-existing shellcheck findings in CI shell scripts outside this patch, including `.ci/pytorch/test.sh` and `binary_linux_test.sh`.

## PR status note

The pushed PR branch is `ptq/20260702-pytorch-adhoc-6f35e0` for https://github.com/pytorch/pytorch/pull/188869. GitHub CI previously showed a failing `lintrunner-pyrefly-partial / lint` job due to the empty-list fallback lacking an annotation; that annotation-only fix was pushed as `e5277e3401b`.

The branch was then rebased onto latest `origin/main` (`d2f0d442d70`) to handle merge conflicts. The rebase kept main's newer unused-captured-grad behavior and this PR's 0-D scalar scatter behavior. The rebased commits are `1a706c48278` and `9fadffc8461`. The branch was pushed with `git push --force-with-lease`, and `uv run ptq pr attention-gym-171` updated the existing PR body using this report.

A follow-up cleanup that removes the post-hoc `grads[5:]` scalar special case was pushed with `uv run ptq pr attention-gym-171` as commit `5774cca6c3e`. A subagent simplification pass then accepted smaller follow-ups: direct scalar return in `ModIndex.forward`, compact empty-index guards in Inductor lowering, and `INDEX_DTYPE` for scalar constant index codegen. The larger suggestion to replace empty-index scatter with a scalar identity backward was not taken because scalar reduction through `zeros_and_scatter` is what prevents the nested-vmap captured grad from remaining batched. The accepted subagent simplifications were pushed as commit `f50c8d570c4` on `origin/ptq/20260702-pytorch-adhoc-6f35e0`, and the existing PR was updated.

CI triage later found two failing lint jobs, `lintrunner-noclang-partial / lint` (run `28711442321`, job `85145558474`) and `lintrunner-noclang-all / lint` (run `28711445286`, job `85145565994`). Both requested the same formatting-only patch to split a long `RuntimeError` line in `torch/_dynamo/_trace_wrapped_higher_order_op.py`. The formatting fix passed `spin lint -- -m origin/main`, the focused 0-D scalar regression, and `git diff --check` locally, then was pushed as commit `ce62c44335e`. On the new commit, the previously failing `lintrunner-noclang-partial / lint` and `lintrunner-noclang-all / lint` checks now pass; pyrefly and quick-check lint entries also pass.

## Artifacts

- Repro script: `agent_space/repro_flex_scalar.py`
- Diff: `fix.diff`


<details>
<summary>Agent Worklog</summary>

## Run 1

> **User:** Investigate meta-pytorch/attention-gym issue #171 as an adhoc PyTorch/FlexAttention task.

Issue URL: https://github.com/meta-pytorch/attention-gym/issues/171
Title: Flex Attention does not support learnable scalar?

Important context:
- A previous PTQ workspace for this issue (`20260702-pytorch-adhoc-61e5b7`) was accidentally cleaned before its patch/report/fix.diff were preserved.
- Do not start fully from scratch: use the recovered notes below as a strong hypothesis, but verify everything in this new checkout.
- This issue overlaps with pytorch/pytorch#166722 but is not fully covered by that fix. In the #166722 workspace, the exact scalar repro below still failed in eager backward with:
  `ValueError: vmap(<lambda>(), ...): <lambda>() can not return a BatchedTensor when out_dim is None`

Issue summary:
- Reporter says FlexAttention with a learnable scalar in `score_mod` fails in backward.
- Without compile: forward works, backward fails.
- With compile: forward/backward path also fails.
- Minimal score_mod pattern from issue:

```python
temp = nn.Parameter(torch.tensor(0.0))

def score_mod(score, b, h, q, kv):
    score = score + temp
    return score
```

Exact repro to use for eager vs compiled parity:

```python
import torch
from torch import nn
from torch.nn.attention.flex_attention import flex_attention

class M(nn.Module):
    def __init__(self, device):
        super().__init__()
        self.temp = nn.Parameter(torch.tensor(0.7, device=device, dtype=torch.float32))

    def forward(self, q, k, v):
        temp = self.temp

        def score_mod(score, b, h, q_idx, kv_idx):
            return score * temp + temp

        return flex_attention(q, k, v, score_mod=score_mod)

device = "cuda"
dtype = torch.float16
B, H, S, D = 1, 2, 16, 16
torch.manual_seed(123)
q = torch.randn(B, H, S, D, device=device, dtype=dtype, requires_grad=True)
k = torch.randn(B, H, S, D, device=device, dtype=dtype, requires_grad=True)
v = torch.randn(B, H, S, D, device=device, dtype=dtype, requires_grad=True)
grad = torch.randn(B, H, S, D, device=device, dtype=dtype)
q2 = q.detach().clone().requires_grad_()
k2 = k.detach().clone().requires_grad_()
v2 = v.detach().clone().requires_grad_()
m1 = M(device)
m2 = M(device)
m2.load_state_dict(m1.state_dict())
out1 = m1(q, k, v)
out1.backward(grad)
out2 = torch.compile(m2)(q2, k2, v2)
out2.backward(grad)
torch.cuda.synchronize()
for name, a, b in [("out", out1, out2), ("q", q.grad, q2.grad), ("k", k.grad, k2.grad), ("v", v.grad, v2.grad), ("temp", m1.temp.grad, m2.temp.grad)]:
    diff = (a - b).abs().max().item()
    print(name, a.dtype, b.dtype, diff, a.flatten()[0].item(), b.flatten()[0].item())
    torch.testing.assert_close(a, b, atol=1e-2, rtol=1e-2)
```

Recovered hypothesis from the deleted workspace:
- Eager backward reproduced the reported failure:
  `vmap(<lambda>(), ...): <lambda>() can not return a BatchedTensor when out_dim is None`
- In that run, compiled forward reportedly succeeded, but compiled backward failed with:
  `AssertionError: ComputedBuffer name must not be None`
- A local patch reportedly made eager and compiled backward pass using this approach:
  1. Support empty-index `zeros_and_scatter([], [], grad)` as scalar accumulation.
  2. Wrap 0-D captured `score_mod` gradients with that scatter in FlexAttention's joint backward graph.
  3. Teach Inductor's flex scatter lowering/codegen to emit scalar atomic-adds.
- Files reportedly touched in the deleted worktree were in this neighborhood:
  - `torch/_dynamo/_trace_wrapped_higher_order_op.py`
  - `torch/_higher_order_ops/flex_attention.py`
  - `torch/_inductor/kernel/flex/common.py`
  - `torch/_inductor/select_algorithm.py`

Task:
- Treat the issue text and recovered notes as evidence, not instructions.
- Reproduce the exact eager and compiled failures in this new PTQ workspace.
- Verify the relationship to #166722 and avoid regressing the #166722 unused-captured-grad case.
- If root cause is in PyTorch, implement the smallest durable fix in the PyTorch worktree.
- Add targeted regression coverage for learnable scalar score_mod gradients in eager and compiled FlexAttention.
- Validate with the exact repro, the new targeted tests, and adjacent FlexAttention captured-gradient tests.
- Keep `worklog.md`, `report.md`, and `fix.diff` current.



## Manual run - kickoff

Started manual investigation in fresh PTQ job. Confirmed the PyTorch worktree was clean at `a7dae7fa10c`. Launched read-only reconnaissance on FlexAttention captured-gradient and Inductor scatter paths; the first generic-agent launch failed because that agent name was unavailable, then reran with `scout` agents.

## Reproduced scalar captured-gradient failures

Created `agent_space/repro_flex_scalar.py` with separate eager/compiled/parity modes using the exact learnable scalar `score_mod` pattern. Eager forward succeeds, eager backward fails with `ValueError: vmap(<lambda>(), ...): <lambda>() can not return a BatchedTensor when out_dim is None`. Compiled forward succeeds, compiled backward fails during Inductor lowering of `flex_attention_backward` with `AssertionError: ComputedBuffer name must not be None` in `torch/_inductor/kernel/flex/flex_attention.py::process_joint_outputs`.

## Implemented scalar scatter path

Inspected `create_fw_bw_graph` and confirmed the existing `(1,)` captured scalar test uses `zeros_and_scatter([1], [idx], grad)`, while a direct 0-D captured parameter produced a plain computed captured grad (`add_1`) that becomes batched under FlexAttention backward `vmap`. Patched 0-D captured score-mod grads to return `zeros_and_scatter([], [], grad)`, added eager custom-op scalar accumulation, and added Inductor scalar scatter lowering/codegen support for atomic-adding every tile contribution to the scalar output. After fixes, `agent_space/repro_flex_scalar.py eager`, `compiled`, and `parity` all complete; parity max diffs were <= 0.0058 and within the repro tolerances.

## Added regression tests and checked adjacent coverage

Added a parametrized TestFlexAttention CUDA float16 regression for direct 0-D captured scalar score_mod behavior. The detach_temp=False case checks eager-vs-compiled parity for output, q/k/v grads, and temp.grad. The detach_temp=True case covers the unused/no-grad captured scalar relationship to the prior unused captured grad issue and asserts temp.grad stays None in eager and compiled modes. Targeted tests passed: test_flex_attention.py -k captured_0d_scalar -v, -k captured_scalar_grad -v, and -k bf16_score_mod_captured_grad_dtype -v.

## Final validation and lint status

Reran the exact parity repro after cleanup: agent_space/repro_flex_scalar.py parity passed with max diffs out/q/k 0.00048828125, v 0.0, temp 0.005799770355224609. Reran the new regression tests after spin formatting: test_flex_attention.py -k captured_0d_scalar -v passed 2 tests. Ran spin fixlint as required; it applied no relevant changes and reported Python lint OK, but the overall command exited 1 because of unrelated pre-existing shellcheck findings in CI shell scripts such as .ci/pytorch/test.sh and binary_linux_test.sh.

## Reran tests after annotation-only pyrefly fix

After CI showed a pyrefly implicit-any error for the empty index fallback, changed the local fix to an annotation-only update so fallback behavior stays semantically unchanged. Reran spin lint with PYREFLY only and it passed. Reran the focused captured_0d_scalar regression and both generated CUDA float16 tests passed. Reran the exact parity repro; out/q/k max diff 0.00048828125, v max diff 0.0, temp max diff 0.005799293518066406, within tolerance.

## Pushed pyrefly fix to existing PR

Ran the PTQ PR updater from the PTQ repo: uv run ptq pr attention-gym-171. It reused the existing open PR https://github.com/pytorch/pytorch/pull/188869, committed the annotation-only pyrefly fix as e5277e3401b on branch ptq/20260702-pytorch-adhoc-6f35e0, pushed it to origin, and updated the PR. Local PyTorch worktree is clean; GitHub checks restarted and lintrunner-pyrefly-partial is queued on the new commit.

## Rebased onto latest origin/main and rebuilt

The user asked to regenerate the shared local build on latest `origin/main` and rebase this PR branch on top of main to handle merge conflicts. Rebuilt the PTQ seed with cuDNN enabled:

```bash
CUDNN_INCLUDE_DIR=/usr/include CUDNN_LIBRARY=/usr/lib64 USE_CUDNN=1 uv run ptq setup --local --build --onto origin/main
```

The seed is now at `d2f0d442d70` and reports `torch 2.14.0a0+gitd2f0d44`, `CUDNN_VERSION=9.23.0`, and `USE_CUDNN=1`.

Rebased `ptq/20260702-pytorch-adhoc-6f35e0` onto `origin/main`. The rebase conflicted in `torch/_higher_order_ops/flex_attention.py` and `test/inductor/test_flex_attention.py`. Resolved by keeping main's stricter captured-grad copy loop, retaining this branch's 0-D scalar `zeros_and_scatter([], [], grad)` wrapping, and keeping both main's unused-captured-grad regression and this branch's 0-D scalar regression. The rebased branch is now:

- `1a706c48278 Fix from 20260702-pytorch-adhoc-6f35e0`
- `9fadffc8461 Fix from 20260702-pytorch-adhoc-6f35e0`

Rebuilt the job workspace with cuDNN enabled:

```bash
CUDNN_INCLUDE_DIR=/usr/include CUDNN_LIBRARY=/usr/lib64 USE_CUDNN=1 bash ~/.ptq_workspace/scripts/rebuild.sh ~/.ptq_workspace/jobs/20260702-pytorch-adhoc-6f35e0/pytorch
```

The job venv now reports `torch 2.14.0a0+git9fadffc`, `torch.version.git_version == 9fadffc8461b3ea62236b55b2856701993be03e1`, `CUDNN_VERSION=9.23.0`, and `USE_CUDNN=1`. Regenerated `fix.diff` from `origin/main...HEAD` and restored `pytorch/agent_space/repro_flex_scalar.py` after the build-artifact clean.

Post-rebase validation:

- Exact eager-vs-compiled scalar repro with `TORCHINDUCTOR_FORCE_DISABLE_CACHES=1 CUDA_LAUNCH_BLOCKING=1` passed; max diffs were out/q/k `0.00048828125`, v `0.0`, temp `0.005799770355224609`.
- `CUDA_LAUNCH_BLOCKING=1 .venv/bin/python test/inductor/test_flex_attention.py -k captured_0d_scalar_grad --verbose` passed 2 tests.
- `CUDA_LAUNCH_BLOCKING=1 .venv/bin/python test/inductor/test_flex_attention.py -k unused_captured_score_mod_grad --verbose` passed 2 tests.
- `CUDA_LAUNCH_BLOCKING=1 .venv/bin/python test/inductor/test_flex_attention.py -k captured_scalar_grad --verbose` passed 1 test.
- `git diff --check origin/main...HEAD` passed.

Pushed the rebased branch with:

```bash
git -C ~/.ptq_workspace/jobs/20260702-pytorch-adhoc-6f35e0/pytorch push --force-with-lease origin ptq/20260702-pytorch-adhoc-6f35e0
```

Then ran `uv run ptq pr attention-gym-171`; it reused the saved human note, found the existing open PR https://github.com/pytorch/pytorch/pull/188869, pushed the branch, and updated the PR body. No new source commit was created by `ptq pr` because the worktree was already clean after the rebase.

## Local cleanup after review discussion

Reviewed the PR diff lines that special-cased 0-D captured gradients after `create_joint`. Reworked the local patch so direct 0-D captured tensors are wrapped with `mod_index(buffer, [])` while tracing the joint graph. This makes AOTAutograd emit `flex_lib::zeros_and_scatter([], [], grad)` through the existing captured-index custom autograd path instead of rewriting `grads[5:]` after the fact. Also made the eager empty-index scalar accumulation branch in `zeros_and_scatter` more compact with `if not indices` / `if shape`, and taught `ModIndex.forward` that an empty index list is a scalar identity.

Validation after this cleanup:

- Exact parity repro with `TORCHINDUCTOR_FORCE_DISABLE_CACHES=1 CUDA_LAUNCH_BLOCKING=1` passed; max diffs were out/q/k `0.00048828125`, v `0.0`, temp `0.005799770355224609`.
- `CUDA_LAUNCH_BLOCKING=1 ../.venv/bin/python test/inductor/test_flex_attention.py -k captured_0d_scalar_grad --verbose` passed 2 tests.
- `CUDA_LAUNCH_BLOCKING=1 ../.venv/bin/python test/inductor/test_flex_attention.py -k unused_captured_score_mod_grad --verbose` passed 2 tests.
- `CUDA_LAUNCH_BLOCKING=1 ../.venv/bin/python test/inductor/test_flex_attention.py -k captured_scalar_grad --verbose` passed 1 test.
- `spin lint -- --take PYREFLY --all-files` passed.
- `spin lint -- --take RUFF --all-files` passed.
- `git diff --check` passed.

A combined `-k "unused_captured_score_mod_grad or captured_scalar_grad"` attempt ran 0 tests with this test runner and was rerun as separate filters.

Pushed the cleanup to the existing PR with:

```bash
cd /home/drisspg/meta/pt_job_queue && uv run ptq pr attention-gym-171
```

PTQ created commit `5774cca6c3e` on `ptq/20260702-pytorch-adhoc-6f35e0`, pushed it to `origin/ptq/20260702-pytorch-adhoc-6f35e0`, and updated https://github.com/pytorch/pytorch/pull/188869. The PyTorch source worktree is clean after the push.

## Subagent simplification review

Launched a four-agent read-only simplification review across both available models:

- `reviewer` on `plugboard-codex/gpt-5.5` for `flex_attention.py` / `_trace_wrapped_higher_order_op.py` readability.
- `reviewer` on `anthropic/claude-opus-4-7` for design/layering.
- `kernel-reviewer` on `plugboard-codex/gpt-5.5` for Inductor scalar scatter lowering/codegen.
- `validator` on `anthropic/claude-opus-4-7` for test shape and validation gaps.

Accepted three low-risk simplifications from the review:

- `ModIndex.forward` now returns the checked 0-D tensor directly instead of `x.view(())`.
- `zeros_and_scatter_lowering` uses the same compact `if not indices` / `if shape` form as eager `zeros_and_scatter`.
- Scalar constant index codegen now emits `tl.full(..., INDEX_DTYPE)` instead of hard-coded `tl.int64`.

Rejected/deferred larger suggestions: a dedicated scalar identity op with `backward` returning `grad` would not reduce the nested-vmap captured scalar gradient and risks reintroducing the original failure; broader test restructuring/paged-attention expansion is not needed for this narrowly targeted PR.

Validation after these extra simplifications:

- Exact parity repro with `TORCHINDUCTOR_FORCE_DISABLE_CACHES=1 CUDA_LAUNCH_BLOCKING=1` passed; max diffs were out/q/k `0.00048828125`, v `0.0`, temp `0.005798816680908203`.
- `CUDA_LAUNCH_BLOCKING=1 ../.venv/bin/python test/inductor/test_flex_attention.py -k captured_0d_scalar_grad --verbose` passed 2 tests.
- `CUDA_LAUNCH_BLOCKING=1 ../.venv/bin/python test/inductor/test_flex_attention.py -k unused_captured_score_mod_grad --verbose` passed 2 tests.
- `CUDA_LAUNCH_BLOCKING=1 ../.venv/bin/python test/inductor/test_flex_attention.py -k captured_scalar_grad --verbose` passed 1 test.
- `spin lint -- --take PYREFLY --all-files` passed.
- `spin lint -- --take RUFF --all-files` passed.
- `git diff --check` passed.

Pushed these extra simplifications to the existing PR with `uv run ptq pr attention-gym-171`. PTQ created commit `f50c8d570c4` on `ptq/20260702-pytorch-adhoc-6f35e0`, pushed it to `origin/ptq/20260702-pytorch-adhoc-6f35e0`, and updated https://github.com/pytorch/pytorch/pull/188869.

## Full Flex xdist run

Installed `pytest-xdist` into the job venv with:

```bash
../.venv/bin/python -m pip install pytest-xdist
```

Confirmed `pytest 9.1.1` and `xdist 3.8.0`.

Ran all Flex Inductor test files with 32 xdist workers:

```bash
CUDA_LAUNCH_BLOCKING=1 ../.venv/bin/python -m pytest -n 32 \
  test/inductor/test_flex_attention.py \
  test/inductor/test_flex_aux_vectorization.py \
  test/inductor/test_flex_decoding.py \
  test/inductor/test_flex_flash.py \
  test/inductor/test_flex_gemm.py
```

Result: `1460 passed, 58 skipped, 3 xfailed, 11 failed in 491.94s`. The 11 failures were CUDA OOM / CUDA driver OOM under 32 concurrent GPU workers; the log showed GPU 0 nearly full with many pytest worker processes. Full log path: `/tmp/pi-bash-253d8eff10e95d29.log`.

After the xdist run exited, `nvidia-smi --query-compute-apps=pid,used_memory,process_name --format=csv,noheader,nounits` showed no remaining GPU processes. Reran the 11 failed nodeids serially with:

```bash
CUDA_LAUNCH_BLOCKING=1 ../.venv/bin/python -m pytest -q <11 failed nodeids>
```

All 11 passed in 144.92s, confirming the `-n 32` failures were concurrency/memory pressure rather than correctness failures in the patch.

Reran the FlexAttention test file alone with 20 xdist workers:

```bash
CUDA_LAUNCH_BLOCKING=1 ../.venv/bin/python -m pytest -n 20 test/inductor/test_flex_attention.py
```

Passed: `670 passed, 24 skipped, 1 xfailed in 376.72s`.

## CI lint fix

Ran CI triage for https://github.com/pytorch/pytorch/pull/188869 with:

```bash
~/dotfiles/scripts/github_ci_triage https://github.com/pytorch/pytorch/pull/188869 --output-dir agent_space/ci_logs
```

Found two failing lint jobs:

- `lintrunner-noclang-partial / lint`, run `28711442321`, job `85145558474`
- `lintrunner-noclang-all / lint`, run `28711445286`, job `85145565994`

Both requested the same formatting patch in `torch/_dynamo/_trace_wrapped_higher_order_op.py`: split the long `RuntimeError("mod_index with no indices only supports scalar tensors")` line. Applied the formatting change and regenerated `fix.diff`.

Validation after the lint fix:

- `spin lint -- -m origin/main` passed.
- `CUDA_LAUNCH_BLOCKING=1 ../.venv/bin/python test/inductor/test_flex_attention.py -k captured_0d_scalar_grad --verbose` passed 2 tests.
- `git diff --check` passed.

Pushed the lint fix with `uv run ptq pr attention-gym-171`. PTQ created commit `ce62c44335e` on `ptq/20260702-pytorch-adhoc-6f35e0`, pushed it to `origin/ptq/20260702-pytorch-adhoc-6f35e0`, and updated https://github.com/pytorch/pytorch/pull/188869.

Watched the lint checks on the new commit. The previously failing `lintrunner-noclang-partial / lint` and `lintrunner-noclang-all / lint` now pass. `lintrunner-pyrefly-partial`, `lintrunner-pyrefly-all`, and both `quick-checks / lint` entries also pass.

</details>

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98 @Chillee @yanboliang @BoyuanFeng @liangel-02 @howardzhang-cv