### PR TITLE
Bypass dispatch cache for `as_strided`

### DIFF
--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -3443,6 +3443,20 @@ class FakeTensorDispatchCache(TestCase):
                 extract_tensor_metadata(res2),
             )
 
+    def test_cache_bypass_prims_as_strided(self):
+        x = torch.empty(0, 8)
+        y = torch.empty(0, 8)
+        mode = FakeTensorMode(shape_env=ShapeEnv())
+        x = mode.from_tensor(x, static_shapes=True)
+        y = mode.from_tensor(y, static_shapes=True)
+
+        with mode:
+            FakeTensorMode.cache_clear()
+            prims.as_strided(x, (0, 8), (8, 1), 0)
+            prims.as_strided(y, (0, 8), (8, 1), 0)
+
+            self.assertBypasses("prims.as_strided", 2)
+
     def test_cache_bypass(self):
         """
         Test that cache bypass counters are updated correctly.

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -1908,6 +1908,9 @@ class FakeTensorMode(TorchDispatchMode):
         if func is aten._unsafe_view.default:
             raise _BypassDispatchCache("unsafe view")
 
+        if func is torch.ops.prims.as_strided.default:
+            raise _BypassDispatchCache("prims.as_strided")
+
         if func in self.lift_fns:
             raise _BypassDispatchCache("lift")
 


### PR DESCRIPTION
otherwise seems to cause failures in e.g.,

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_device_type.py", line 1364, in test_wrapper
    return test(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_device_type.py", line 1661, in only_fn
    return fn(slf, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/pytorch/test/test_ops.py", line 2997, in test_fake_crossref_backward_amp
    self._test_fake_crossref_helper(device, dtype, op, torch.cuda.amp.autocast)
  File "/opt/pytorch/pytorch/test/test_ops.py", line 2977, in _test_fake_crossref_helper
    composite_compliance.compute_expected_grads(
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/composite_compliance.py", line 434, in compute_expected_grads
    results = gradcheck_wrapper(op, *args, **kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/opinfo/core.py", line 847, in <lambda>
    gradcheck_wrapper: Callable = lambda op, *args, **kwargs: op(*args, **kwargs)
                                                              ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_compile.py", line 54, in inner
    return disable_fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/eval_frame.py", line 1446, in _fn
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_subclasses/fake_utils.py", line 295, in __torch_dispatch__
    _check_alias_info(
  File "/usr/local/lib/python3.12/dist-packages/torch/_subclasses/fake_utils.py", line 68, in _check_alias_info
    raise MetadataMismatchError(
torch._subclasses.fake_tensor.MetadataMismatchError: When comparing the output of aten.view.default on FakeTensor and concrete Tensors, found mismatch in outputs_alias_inputs check False != True

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/lib/python3.12/unittest/case.py", line 58, in testPartExecutor
    yield
  File "/usr/lib/python3.12/unittest/case.py", line 634, in run
    self._callTestMethod(testMethod)
  File "/usr/lib/python3.12/unittest/case.py", line 589, in _callTestMethod
    if method() is not None:
       ^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_utils.py", line 3553, in wrapper
    method(*args, **kwargs)
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_utils.py", line 3553, in wrapper
    method(*args, **kwargs)
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_device_type.py", line 551, in instantiated_test
    result = test(self, **param_kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_utils.py", line 1934, in wrapper
    fn(*args, **kwargs)
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_device_type.py", line 1376, in test_wrapper
    raise e_tracked from e
Exception: When comparing the output of aten.view.default on FakeTensor and concrete Tensors, found mismatch in outputs_alias_inputs check False != True

Caused by sample input at index 5: SampleInput(input=Tensor[size=(0, 8), device="cuda:0", dtype=torch.float32], args=TensorList[Tensor[size=(0, 8), device="cuda:0", dtype=torch.float32], Tensor[size=(8, 8, 8), device="cuda:0", dtype=torch.float32], Tensor[size=(8,), device="cuda:0", dtype=torch.float32]], kwargs={}, broadcasts_input=False, name='')

To execute this test, run the following from the base repo dir:
    PYTORCH_OPINFO_SAMPLE_INPUT_INDEX=5 python test/test_ops.py TestFakeTensorCUDA.test_fake_crossref_backward_amp_nn_functional_bilinear_cuda_float32
    ```
    
    authored with codex

cc @ptrblck @msaroufim @tinglvv @nWEIdia @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo