### PR TITLE
[FlexAttention] Fix int64/int32 index dtype mismatches in CuTeDSL score_mod codegen

### DIFF
--- a/test/inductor/test_flex_flash.py
+++ b/test/inductor/test_flex_flash.py
@@ -909,6 +909,18 @@ GQA_MQA_BLOCK_MASK_CASES = [
 class TestFlexFlash(InductorTestCase):
     # `FlashAttentionForwardSm120` does not have `apply_score_mod`.
     @xfailIfSM120OrLater
+    def test_captured_table_int64_index(self):
+        """Widening index casts must not break index-fragment materialization (#188871)."""
+        seq_len = 512
+        tbl = torch.randn(seq_len, device="cuda")
+
+        def score_mod(score, _b, _h, _q, kv_idx):
+            return score + tbl[kv_idx.to(torch.int64)]
+
+        q, k, v = create_test_tensors(seq_len=seq_len, device="cuda")
+        flash_vs_triton(q, k, v, score_mod=score_mod)
+
+    @xfailIfSM120OrLater
     @dtypes(torch.float16, torch.bfloat16)
     @parametrize("case", SCORE_MOD_CASES, name_fn=score_case_name)
     def test_flash_attention_score_mod_cases(self, device, dtype, case):
@@ -2443,6 +2455,24 @@ class TestFlexFlashDynamicShapes(InductorTestCase):
             return score + (kv_idx - q_idx) * slopes[h]
 
         self._run_dynamic_test(seq_lens=[128, 256, 512], score_mod=alibi_score_mod)
+
+    @xfailIfSM120OrLater
+    def test_dynamic_captured_table_negative_index_wrap(self):
+        """Rel-pos table gather with a shape-dependent offset (#188871).
+
+        Once shapes go dynamic, the table length and offset are rendered as Int64
+        aux scalars; the emitted negative-index wrap must cast them to the Int32
+        index dtype or cute.where rejects the mixed operands.
+        """
+        for seq_len in [512, 1024]:
+            tbl = torch.randn(2 * seq_len, device="cuda")
+            offset = seq_len - 1
+
+            def score_mod(score, _b, _h, q_idx, kv_idx):
+                return score + tbl[q_idx - kv_idx + offset]
+
+            q, k, v = create_test_tensors(seq_len=seq_len, device="cuda")
+            flash_vs_triton(q, k, v, score_mod=score_mod, dynamic=True)
 
     @xfailIfSM120OrLater
     def test_dynamic_seq_len_with_block_mask(self):

--- a/test/inductor/test_flex_flash.py
+++ b/test/inductor/test_flex_flash.py
@@ -909,6 +909,25 @@ GQA_MQA_BLOCK_MASK_CASES = [
 class TestFlexFlash(InductorTestCase):
     # `FlashAttentionForwardSm120` does not have `apply_score_mod`.
     @xfailIfSM120OrLater
+    def test_vectorized_group_per_lane_gather(self):
+        """Per-lane gather + lane-uniform load in one vec group (#188871).
+
+        The uniform scale load enables score_mod vectorization; the rel-pos
+        gather's wrapped index must still classify per-lane, not lane-uniform
+        (which silently broadcast lane 0's bias across the group).
+        """
+        seq_len = 512
+        rel_bias = torch.randn(2 * seq_len, device="cuda")
+        head_scale = torch.randn(4, device="cuda")
+        offset = seq_len - 1
+
+        def score_mod(score, _b, h, q_idx, kv_idx):
+            return score + rel_bias[q_idx - kv_idx + offset] * head_scale[h]
+
+        q, k, v = create_test_tensors(seq_len=seq_len, device="cuda")
+        flash_vs_triton(q, k, v, score_mod=score_mod)
+
+    @xfailIfSM120OrLater
     def test_captured_table_int64_index(self):
         """Widening index casts must not break index-fragment materialization (#188871)."""
         seq_len = 512

--- a/test/inductor/test_flex_flash.py
+++ b/test/inductor/test_flex_flash.py
@@ -928,6 +928,47 @@ class TestFlexFlash(InductorTestCase):
         flash_vs_triton(q, k, v, score_mod=score_mod)
 
     @xfailIfSM120OrLater
+    def test_vectorized_group_untraceable_index_op(self):
+        """Nonlinear index ops (abs/clamp/min/max) must keep per-lane index
+        semantics under vectorization — whether traced to sympy or treated as
+        opaque, never classified lane-uniform (#188878)."""
+        seq_len = 512
+        tbl = torch.randn(2 * seq_len, device="cuda")
+        head_scale = torch.randn(4, device="cuda")
+
+        index_fns = {
+            "abs": lambda q_idx, kv_idx: (q_idx - kv_idx).abs(),
+            "clamp": lambda q_idx, kv_idx: (q_idx - kv_idx).clamp(0, seq_len - 1),
+            "minimum": lambda q_idx, kv_idx: torch.minimum(q_idx, kv_idx),
+            "maximum": lambda q_idx, kv_idx: torch.maximum(
+                kv_idx - q_idx, torch.zeros_like(kv_idx)
+            ),
+        }
+        for name, index_fn in index_fns.items():
+            with self.subTest(index_fn=name):
+
+                def score_mod(score, _b, h, q_idx, kv_idx):
+                    return score + tbl[index_fn(q_idx, kv_idx)] * head_scale[h]
+
+                q, k, v = create_test_tensors(seq_len=seq_len, device="cuda")
+                flash_vs_triton(q, k, v, score_mod=score_mod)
+
+    @xfailIfSM120OrLater
+    def test_chained_kv_gather(self):
+        """Document-style chained gather: the contiguous inner load promotes
+        vectorization and the outer loaded-value index is opaque; it must stay
+        a per-lane gather (#188878)."""
+        seq_len = 512
+        doc_bias = torch.randn(8, device="cuda")
+        doc_id = torch.arange(seq_len, device="cuda") % 8
+
+        def score_mod(score, _b, _h, _q, kv_idx):
+            return score + doc_bias[doc_id[kv_idx]]
+
+        q, k, v = create_test_tensors(seq_len=seq_len, device="cuda")
+        flash_vs_triton(q, k, v, score_mod=score_mod)
+
+    @xfailIfSM120OrLater
     def test_captured_table_int64_index(self):
         """Widening index casts must not break index-fragment materialization (#188871)."""
         seq_len = 512

--- a/torch/_inductor/codegen/cutedsl/_cutedsl_utils.py
+++ b/torch/_inductor/codegen/cutedsl/_cutedsl_utils.py
@@ -1,5 +1,6 @@
 # mypy: disable-error-code=import-not-found
 # pyrefly: ignore [import-error, missing-import]
+import cutlass
 import cutlass.cute as cute
 
 
@@ -18,7 +19,14 @@ def ssa_to_indexable(ssa_value: cute.TensorSSA, dtype: str) -> cute.Numeric:
 
 @cute.jit  # type: ignore[misc]
 def ssa_to_fragment(ssa_value: cute.TensorSSA, dtype: str) -> cute.Tensor:
-    """Materialize an SSA vector into a register fragment."""
+    """Materialize an SSA vector into a register fragment.
+
+    Casts to the fragment dtype when the SSA dtype differs (e.g. an int64 index
+    expression materialized into an int32 index fragment), since fragment
+    stores require matching element types.
+    """
+    if cutlass.const_expr(ssa_value.dtype != dtype):
+        ssa_value = ssa_value.to(dtype)
     frag = cute.make_rmem_tensor(ssa_value.shape, dtype)
     frag.store(ssa_value)
     return frag

--- a/torch/_inductor/codegen/cutedsl/cutedsl_kernel.py
+++ b/torch/_inductor/codegen/cutedsl/cutedsl_kernel.py
@@ -123,6 +123,26 @@ class CuteDSLIndexFragment:
     contiguous_width: int | None = None
 
 
+@dataclasses.dataclass(frozen=True)
+class IndexSymbolInfo:
+    """What lane analysis may assume about a generated index symbol.
+
+    expr: Recovered semantic index expression, or None when the value's
+        semantics are unknown (loaded from a captured tensor, or produced by
+        ops outside the traced index algebra). Unknown semantics force a
+        per-lane gather: assuming lane-uniform would broadcast lane 0's load
+        across the vectorized group (#188878).
+    contiguous_ok: False when the value passed through a negative-index wrap
+        (idx + size for negative lanes only). Uniform lanes all wrap
+        identically, so lane-uniformity survives, but a contiguous window
+        straddling 0 jumps from size-1 back to 0 and we can't prove a window
+        avoids 0.
+    """
+
+    expr: sympy.Expr | None
+    contiguous_ok: bool = True
+
+
 @dataclasses.dataclass
 class CuteDSLSubgraphInfo:
     """Minimal subgraph info for CuteDSL kernels."""
@@ -626,20 +646,9 @@ class ModificationWrapperCuteDSL(V.WrapperHandler):  # type: ignore[name-defined
         self.mask = mask
         # Track tensor buffers that get added during modification processing
         self.tensor_buffers: list[str] = []
-        # Maps generated CSE names back to their original index expressions so
-        # vector-load analysis can reason about the source indexing semantics.
-        self._semantic_index_replacements: dict[sympy.Symbol, sympy.Expr] = {}
-        # Symbols whose value passed through a negative-index wrap (idx + size
-        # for negative lanes only). Uniform lanes all wrap identically, so
-        # lane-uniformity survives, but a contiguous window straddling 0 jumps
-        # from size-1 back to 0. We can't prove a window avoids 0, so tainted
-        # symbols may classify as lane-uniform but never as contiguous.
-        self._wrap_tainted_symbols: OrderedSet[sympy.Symbol] = OrderedSet()
-        # Symbols for computed index values with unrecoverable semantics
-        # (values loaded from captured tensors, ops outside the traced index
-        # algebra -> wed dont know what to do). Their lane behavior is unknown,
-        # so they must never classify as lane-uniform or contiguous.
-        self._opaque_index_symbols: OrderedSet[sympy.Symbol] = OrderedSet()
+        # Maps generated CSE names to their semantic provenance so vector-load
+        # analysis can reason about the source indexing semantics.
+        self._index_symbol_info: dict[sympy.Symbol, IndexSymbolInfo] = {}
 
     def _get_input_dtype(self, name: str) -> torch.dtype:
         """Get the dtype for an input from the kernel's named_input_nodes."""
@@ -941,8 +950,7 @@ class ModificationWrapperCuteDSL(V.WrapperHandler):  # type: ignore[name-defined
 
         expr = self.kernel.rename_indexing(expr)
         is_lane_uniform, is_contiguous, contiguous_width = self._analyze_index_fragment(
-            self._semantic_index_expr(expr),
-            wrap_tainted=bool(expr.free_symbols & self._wrap_tainted_symbols),
+            expr
         )
         result = self.kernel.cse.newvar(dtype=torch_dtype)
         self.kernel.body.writeline(
@@ -957,16 +965,26 @@ class ModificationWrapperCuteDSL(V.WrapperHandler):  # type: ignore[name-defined
         )
 
     def _analyze_index_fragment(
-        self, semantic_expr: sympy.Expr, wrap_tainted: bool = False
+        self, expr: sympy.Expr
     ) -> tuple[bool, bool, int | None]:
         if self.vector_load_config is None:
             return False, False, None
         if self.vector_load_config.vec_size <= 1:
             return True, False, None
 
+        contiguous_ok = True
+        for sym in expr.free_symbols:
+            info = self._index_symbol_info.get(sym)
+            if info is not None:
+                if info.expr is None:
+                    # If we dont know the semantics of the index, we cannot determine lane behavior.
+                    # So we default to safe/pessimistic behavior: per-lane gather, no uniformity, no contiguity.
+                    return False, False, None
+                contiguous_ok &= info.contiguous_ok
+
+        semantic_expr = self._semantic_index_expr(expr)
         if self._has_unresolved_index_symbols(semantic_expr):
-            # If we dont know the semantics of the index, we cannot determine lane behavior.
-            # So we default to safe/pessimistic behavior: per-lane gather, no uniformity, no contiguity.
+            # ditto -> we dont know so choose safe/pessimistic behavior
             return False, False, None
 
         lane_info = classify_lane_expr(
@@ -975,14 +993,10 @@ class ModificationWrapperCuteDSL(V.WrapperHandler):  # type: ignore[name-defined
             max_width=self.vector_load_config.vec_size,
             uniform_symbols=self._lane_uniform_symbols(),
         )
-        if wrap_tainted:
-            # The wrap remaps negative lanes individually, so contiguity of the
-            # pre-wrap expression does not survive; uniformity does.
-            return lane_info.is_uniform, False, None
         return (
             lane_info.is_uniform,
-            lane_info.is_contiguous,
-            lane_info.contiguous_width,
+            lane_info.is_contiguous and contiguous_ok,
+            lane_info.contiguous_width if contiguous_ok else None,
         )
 
     def _has_unresolved_index_symbols(self, semantic_expr: sympy.Expr) -> bool:
@@ -993,11 +1007,8 @@ class ModificationWrapperCuteDSL(V.WrapperHandler):  # type: ignore[name-defined
         lane 0's gather when the symbol is actually per-lane runtime data
         (#188878). Recovered semantics substitute away generated CSE names, so
         a surviving symbol in the reserved ``tmpN`` namespace means recovery
-        failed and the load must stay a per-lane gather. Covers both
-        explicitly tracked opaque symbols and that reserved-name fallback.
+        failed and the load must stay a per-lane gather.
         """
-        if semantic_expr.free_symbols & self._opaque_index_symbols:
-            return True
         prefix = self.kernel.cse.name_prefix
         lane_var = self.vector_load_config.index if self.vector_load_config else None
         return any(
@@ -1029,9 +1040,11 @@ class ModificationWrapperCuteDSL(V.WrapperHandler):  # type: ignore[name-defined
 
     def _semantic_index_expr(self, expr: sympy.Expr) -> sympy.Expr:
         """Recover the original index meaning from generated CSE names."""
-        replacements: dict[sympy.Symbol, sympy.Expr] = dict(
-            self._semantic_index_replacements
-        )
+        replacements: dict[sympy.Symbol, sympy.Expr] = {
+            symbol: info.expr
+            for symbol, info in self._index_symbol_info.items()
+            if info.expr is not None
+        }
         for var in self.kernel.cse._cache.values():
             if isinstance(var, CuteDSLCSEVariable) and var.index_expr is not None:
                 replacements[sympy_index_symbol(var.name)] = var.index_expr
@@ -1077,10 +1090,11 @@ class ModificationWrapperCuteDSL(V.WrapperHandler):  # type: ignore[name-defined
             )
             symbol = sympy_index_symbol(str(wrapped))
             # Preserve the pre-wrap semantics so lane analysis sees the true
-            # lane structure instead of an unknown (default lane-uniform)
-            # symbol, which broadcast lane 0's gather to the whole group.
-            self._semantic_index_replacements[symbol] = index_var.index_expr
-            self._wrap_tainted_symbols.add(symbol)
+            # lane structure; the wrap remaps negative lanes individually, so
+            # contiguity of the pre-wrap expression does not survive it.
+            self._index_symbol_info[symbol] = IndexSymbolInfo(
+                index_var.index_expr, contiguous_ok=False
+            )
             return symbol
         source_name = None
         for expr, var in self.kernel.cse._cache.items():
@@ -1088,14 +1102,10 @@ class ModificationWrapperCuteDSL(V.WrapperHandler):  # type: ignore[name-defined
                 source_name = expr if isinstance(expr, str) else None
                 break
         symbol = sympy_index_symbol(source_name or str(index_var))
-        if (
-            isinstance(index_var, CuteDSLCSEVariable)
-            and index_var.index_expr is not None
-        ):
-            self._semantic_index_replacements[symbol] = index_var.index_expr
-        else:
-            # Fall through | we dont know the semantics of this index
-            self._opaque_index_symbols.add(symbol)
+        index_expr = (
+            index_var.index_expr if isinstance(index_var, CuteDSLCSEVariable) else None
+        )
+        self._index_symbol_info[symbol] = IndexSymbolInfo(index_expr)
         return symbol
 
     # pyrefly: ignore [bad-override]

--- a/torch/_inductor/codegen/cutedsl/cutedsl_kernel.py
+++ b/torch/_inductor/codegen/cutedsl/cutedsl_kernel.py
@@ -629,10 +629,17 @@ class ModificationWrapperCuteDSL(V.WrapperHandler):  # type: ignore[name-defined
         # Maps generated CSE names back to their original index expressions so
         # vector-load analysis can reason about the source indexing semantics.
         self._semantic_index_replacements: dict[sympy.Symbol, sympy.Expr] = {}
-        # Symbols whose value passed through a negative-index wrap. The wrap can
-        # remap individual lanes (idx + size for negatives only), so these may
-        # classify as lane-uniform but never as contiguous.
+        # Symbols whose value passed through a negative-index wrap (idx + size
+        # for negative lanes only). Uniform lanes all wrap identically, so
+        # lane-uniformity survives, but a contiguous window straddling 0 jumps
+        # from size-1 back to 0. We can't prove a window avoids 0, so tainted
+        # symbols may classify as lane-uniform but never as contiguous.
         self._wrap_tainted_symbols: OrderedSet[sympy.Symbol] = OrderedSet()
+        # Symbols for computed index values with unrecoverable semantics
+        # (values loaded from captured tensors, ops outside the traced index
+        # algebra -> wed dont know what to do). Their lane behavior is unknown,
+        # so they must never classify as lane-uniform or contiguous.
+        self._opaque_index_symbols: OrderedSet[sympy.Symbol] = OrderedSet()
 
     def _get_input_dtype(self, name: str) -> torch.dtype:
         """Get the dtype for an input from the kernel's named_input_nodes."""
@@ -933,13 +940,6 @@ class ModificationWrapperCuteDSL(V.WrapperHandler):  # type: ignore[name-defined
             )
 
         expr = self.kernel.rename_indexing(expr)
-        static_expr = self._static_integer_expr(expr)
-        if static_expr is not None:
-            return CuteDSLIndexFragment(
-                self.kernel.kexpr(self._wrap_static_index(static_expr, dim_size)),
-                is_static_int=True,
-            )
-
         is_lane_uniform, is_contiguous, contiguous_width = self._analyze_index_fragment(
             self._semantic_index_expr(expr),
             wrap_tainted=bool(expr.free_symbols & self._wrap_tainted_symbols),
@@ -964,6 +964,11 @@ class ModificationWrapperCuteDSL(V.WrapperHandler):  # type: ignore[name-defined
         if self.vector_load_config.vec_size <= 1:
             return True, False, None
 
+        if self._has_unresolved_index_symbols(semantic_expr):
+            # If we dont know the semantics of the index, we cannot determine lane behavior.
+            # So we default to safe/pessimistic behavior: per-lane gather, no uniformity, no contiguity.
+            return False, False, None
+
         lane_info = classify_lane_expr(
             semantic_expr,
             self.vector_load_config.index,
@@ -978,6 +983,28 @@ class ModificationWrapperCuteDSL(V.WrapperHandler):  # type: ignore[name-defined
             lane_info.is_uniform,
             lane_info.is_contiguous,
             lane_info.contiguous_width,
+        )
+
+    def _has_unresolved_index_symbols(self, semantic_expr: sympy.Expr) -> bool:
+        """Return whether the expression references opaque computed indices.
+
+        Lane analysis treats unknown non-lane symbols as lane-uniform scalars,
+        which is correct for sizes and fixed inputs but silently broadcasts
+        lane 0's gather when the symbol is actually per-lane runtime data
+        (#188878). Recovered semantics substitute away generated CSE names, so
+        a surviving symbol in the reserved ``tmpN`` namespace means recovery
+        failed and the load must stay a per-lane gather. Covers both
+        explicitly tracked opaque symbols and that reserved-name fallback.
+        """
+        if semantic_expr.free_symbols & self._opaque_index_symbols:
+            return True
+        prefix = self.kernel.cse.name_prefix
+        lane_var = self.vector_load_config.index if self.vector_load_config else None
+        return any(
+            sym is not lane_var
+            and sym.name.startswith(prefix)
+            and sym.name[len(prefix) :].isdigit()
+            for sym in semantic_expr.free_symbols
         )
 
     @staticmethod
@@ -1066,6 +1093,9 @@ class ModificationWrapperCuteDSL(V.WrapperHandler):  # type: ignore[name-defined
             and index_var.index_expr is not None
         ):
             self._semantic_index_replacements[symbol] = index_var.index_expr
+        else:
+            # Fall through | we dont know the semantics of this index
+            self._opaque_index_symbols.add(symbol)
         return symbol
 
     # pyrefly: ignore [bad-override]

--- a/torch/_inductor/codegen/cutedsl/cutedsl_kernel.py
+++ b/torch/_inductor/codegen/cutedsl/cutedsl_kernel.py
@@ -629,6 +629,10 @@ class ModificationWrapperCuteDSL(V.WrapperHandler):  # type: ignore[name-defined
         # Maps generated CSE names back to their original index expressions so
         # vector-load analysis can reason about the source indexing semantics.
         self._semantic_index_replacements: dict[sympy.Symbol, sympy.Expr] = {}
+        # Symbols whose value passed through a negative-index wrap. The wrap can
+        # remap individual lanes (idx + size for negatives only), so these may
+        # classify as lane-uniform but never as contiguous.
+        self._wrap_tainted_symbols: OrderedSet[sympy.Symbol] = OrderedSet()
 
     def _get_input_dtype(self, name: str) -> torch.dtype:
         """Get the dtype for an input from the kernel's named_input_nodes."""
@@ -891,13 +895,22 @@ class ModificationWrapperCuteDSL(V.WrapperHandler):  # type: ignore[name-defined
     def _emit_per_lane_gather_load(
         self, var: str, idx_vars: list[CuteDSLIndexFragment], val_frag: str
     ) -> None:
-        """Emit scalar per-lane loads for non-contiguous gather indices."""
+        """Emit scalar per-lane loads for non-contiguous gather indices.
+
+        Lane-uniform index fragments hold a single element, so they are indexed
+        at [0] rather than [load_idx] (which would read out of bounds and
+        silently corrupt the gathered rows).
+        """
         self.kernel.body.writeline(
             f"for load_idx in cutlass.range(cute.size({val_frag}.shape), unroll_full=True):"
         )
         with self.kernel.body.indent():
             load_indices = [
-                idx.code if idx.is_static_int else f"{idx.code}[load_idx]"
+                idx.code
+                if idx.is_static_int
+                else f"{idx.code}[0]"
+                if idx.is_lane_uniform
+                else f"{idx.code}[load_idx]"
                 for idx in idx_vars
             ]
             self.kernel.body.writeline(
@@ -928,7 +941,8 @@ class ModificationWrapperCuteDSL(V.WrapperHandler):  # type: ignore[name-defined
             )
 
         is_lane_uniform, is_contiguous, contiguous_width = self._analyze_index_fragment(
-            self._semantic_index_expr(expr)
+            self._semantic_index_expr(expr),
+            wrap_tainted=bool(expr.free_symbols & self._wrap_tainted_symbols),
         )
         result = self.kernel.cse.newvar(dtype=torch_dtype)
         self.kernel.body.writeline(
@@ -943,7 +957,7 @@ class ModificationWrapperCuteDSL(V.WrapperHandler):  # type: ignore[name-defined
         )
 
     def _analyze_index_fragment(
-        self, semantic_expr: sympy.Expr
+        self, semantic_expr: sympy.Expr, wrap_tainted: bool = False
     ) -> tuple[bool, bool, int | None]:
         if self.vector_load_config is None:
             return False, False, None
@@ -956,6 +970,10 @@ class ModificationWrapperCuteDSL(V.WrapperHandler):  # type: ignore[name-defined
             max_width=self.vector_load_config.vec_size,
             uniform_symbols=self._lane_uniform_symbols(),
         )
+        if wrap_tainted:
+            # The wrap remaps negative lanes individually, so contiguity of the
+            # pre-wrap expression does not survive; uniformity does.
+            return lane_info.is_uniform, False, None
         return (
             lane_info.is_uniform,
             lane_info.is_contiguous,
@@ -1030,7 +1048,13 @@ class ModificationWrapperCuteDSL(V.WrapperHandler):  # type: ignore[name-defined
                 f"{wrapped} = cute.where("
                 f"{index_var} < 0, {index_var} + {size_expr}, {index_var})"
             )
-            return sympy_index_symbol(str(wrapped))
+            symbol = sympy_index_symbol(str(wrapped))
+            # Preserve the pre-wrap semantics so lane analysis sees the true
+            # lane structure instead of an unknown (default lane-uniform)
+            # symbol, which broadcast lane 0's gather to the whole group.
+            self._semantic_index_replacements[symbol] = index_var.index_expr
+            self._wrap_tainted_symbols.add(symbol)
+            return symbol
         source_name = None
         for expr, var in self.kernel.cse._cache.items():
             if var is index_var:

--- a/torch/_inductor/codegen/cutedsl/cutedsl_kernel.py
+++ b/torch/_inductor/codegen/cutedsl/cutedsl_kernel.py
@@ -657,6 +657,10 @@ class ModificationWrapperCuteDSL(V.WrapperHandler):  # type: ignore[name-defined
             dim_sizes = buffer.get_size()
             if len(dim_sizes) == 0:
                 dim_indices = ()
+            # Per-dimension indices into captured buffers are bounded by dim
+            # sizes (not flattened offsets), so Int32 is safe whatever index
+            # dtype the consuming kernel passes in; wider index expressions are
+            # narrowed at fragment materialization.
             idx_vars = [
                 self._emit_index_fragment(
                     dim_index, dim_size, "cutlass.Int32", torch.int32
@@ -1016,7 +1020,12 @@ class ModificationWrapperCuteDSL(V.WrapperHandler):  # type: ignore[name-defined
             and not V.graph.sizevars.statically_known_geq(index_var.index_expr, 0)
         ):
             wrapped = self.kernel.cse.newvar(dtype=index_var.dtype)
-            size_expr = self.kernel.kexpr(size)
+            # Dynamic sizes render as Int64 aux_scalars; cast to the index dtype so
+            # both cute.where branches agree (per-dim size, so narrowing is safe).
+            index_cute_dtype = CuteDSLOpOverrides.TORCH_TO_CUTE_DTYPE.get(
+                index_var.dtype, "cutlass.Int32"
+            )
+            size_expr = f"{index_cute_dtype}({self.kernel.kexpr(size)})"
             self.kernel.body.writeline(
                 f"{wrapped} = cute.where("
                 f"{index_var} < 0, {index_var} + {size_expr}, {index_var})"

--- a/torch/_inductor/codegen/cutedsl/cutedsl_op_overrides.py
+++ b/torch/_inductor/codegen/cutedsl/cutedsl_op_overrides.py
@@ -14,6 +14,7 @@ import torch
 from torch._inductor.codegen.common import CSEVariable, OpOverrides
 from torch._inductor.utils import get_bounds_index_expr
 from torch._inductor.virtualized import OpsValue, V
+from torch.utils._sympy.functions import Max, Min
 from torch.utils._sympy.value_ranges import ValueRanges
 
 
@@ -268,13 +269,17 @@ class CuteDSLOpOverrides(OpOverrides):
         return f"{cute_type}({expr})"
 
     @staticmethod
-    def _apply_unary_op(x: CuteDSLArg, op_format: str) -> CuteDSLArg:
+    def _apply_unary_op(
+        x: CuteDSLArg, op_format: str, index_expr_fn=None
+    ) -> CuteDSLArg:
         """
         Apply a unary operation, returning CSEVariable if input is a tensor.
 
         Args:
             x: Input operand (CSEVariable for tensors, str for scalars, or OpsValue wrapper)
             op_format: Format string with {x} placeholder for the operation
+            index_expr_fn: Optional sympy builder to propagate index semantics
+                through the op for lane analysis
 
         Returns:
             CSEVariable if input is a tensor, otherwise string
@@ -289,6 +294,10 @@ class CuteDSLOpOverrides(OpOverrides):
                 dtype=cse_var.dtype,
                 shape=cse_var.shape,
             )
+            if index_expr_fn is not None and isinstance(result, CuteDSLCSEVariable):
+                x_expr = CuteDSLOpOverrides._index_expr(x)
+                if x_expr is not None:
+                    result.index_expr = V.graph.sizevars.simplify(index_expr_fn(x_expr))
             if CuteDSLOpOverrides._is_scalar_expr(x):
                 result.is_scalar_expr = True
             return result
@@ -488,11 +497,15 @@ class CuteDSLOpOverrides(OpOverrides):
 
     @staticmethod
     def _minmax(a: CuteDSLArg, b: CuteDSLArg, *, op: str) -> CuteDSLArg:
+        index_expr_fn = Max if op == ">" else Min
         if CuteDSLOpOverrides._is_tensor_like(a) or CuteDSLOpOverrides._is_tensor_like(
             b
         ):
             return CuteDSLOpOverrides._apply_binary_op(
-                a, b, f"cute.where(({{a}}) {op} ({{b}}), {{a}}, {{b}})"
+                a,
+                b,
+                f"cute.where(({{a}}) {op} ({{b}}), {{a}}, {{b}})",
+                index_expr_fn,
             )
 
         lhs = CuteDSLOpOverrides._as_expr(a)
@@ -513,6 +526,13 @@ class CuteDSLOpOverrides(OpOverrides):
             bounds=bounds,
             dtype=dtype if dtype is not None else torch.int32,
         )
+        if isinstance(result, CuteDSLCSEVariable):
+            a_expr = CuteDSLOpOverrides._index_expr(a)
+            b_expr = CuteDSLOpOverrides._index_expr(b)
+            if a_expr is not None and b_expr is not None:
+                result.index_expr = V.graph.sizevars.simplify(
+                    index_expr_fn(a_expr, b_expr)
+                )
         result.is_scalar_expr = True
         return result
 
@@ -611,17 +631,24 @@ class CuteDSLOpOverrides(OpOverrides):
             return CuteDSLOpOverrides._apply_unary_op(
                 x,
                 f"cute.TensorSSA({abs_op}({{x}}), {{x}}.shape, {{x}}.dtype)",
+                index_expr_fn=sympy.Abs,
             )
-        return CuteDSLOpOverrides._apply_unary_op(x, f"{abs_op}({{x}})")
+        return CuteDSLOpOverrides._apply_unary_op(
+            x, f"{abs_op}({{x}})", index_expr_fn=sympy.Abs
+        )
 
     @staticmethod
     def neg(x: CuteDSLArg) -> CuteDSLArg:
         """Negation for both TensorSSA and scalar-like expressions."""
         if CuteDSLOpOverrides._is_tensor_like(x):
             return CuteDSLOpOverrides._apply_unary_op(
-                x, "cute.TensorSSA(-{x}, {x}.shape, {x}.dtype)"
+                x,
+                "cute.TensorSSA(-{x}, {x}.shape, {x}.dtype)",
+                index_expr_fn=lambda expr: -expr,
             )
-        return CuteDSLOpOverrides._apply_unary_op(x, "(-{x})")
+        return CuteDSLOpOverrides._apply_unary_op(
+            x, "(-{x})", index_expr_fn=lambda expr: -expr
+        )
 
     @staticmethod
     def to_dtype(
@@ -654,6 +681,12 @@ class CuteDSLOpOverrides(OpOverrides):
             )
             if CuteDSLOpOverrides._is_scalar_expr(x):
                 result.is_scalar_expr = True
+            if (
+                dtype in (torch.int32, torch.int64)
+                and isinstance(result, CuteDSLCSEVariable)
+                and isinstance(x, CuteDSLCSEVariable)
+            ):
+                result.index_expr = x.index_expr
             return result
 
         return f"{x}.to({cute_type})"

--- a/torch/_inductor/kernel/flex/aux_vectorization.py
+++ b/torch/_inductor/kernel/flex/aux_vectorization.py
@@ -9,7 +9,7 @@ import sympy
 
 import torch
 from torch.fx import GraphModule
-from torch.utils._sympy.functions import FloorDiv, ModularIndexing
+from torch.utils._sympy.functions import FloorDiv, Max, Min, ModularIndexing
 
 from ...codegen.cutedsl.lane_analysis import classify_lane_expr
 from ...ir import TensorBox
@@ -367,6 +367,29 @@ def fx_aux_index_to_sympy(
 
     args = index.args
     target = index.target
+    match target:
+        case torch.ops.aten.abs.default:
+            operand = fx_aux_index_to_sympy(args[0], index_symbols, node_to_sympy)
+            return None if operand is None else sympy.Abs(operand)
+        case torch.ops.aten.neg.default:
+            operand = fx_aux_index_to_sympy(args[0], index_symbols, node_to_sympy)
+            return None if operand is None else -operand
+        case torch.ops.aten.clamp.default:
+            operand = fx_aux_index_to_sympy(args[0], index_symbols, node_to_sympy)
+            if operand is None:
+                return None
+            lo = args[1] if len(args) > 1 else index.kwargs.get("min")
+            hi = args[2] if len(args) > 2 else index.kwargs.get("max")
+            for bound, combine in ((lo, Max), (hi, Min)):
+                if bound is not None:
+                    bound_expr = fx_aux_index_to_sympy(
+                        bound, index_symbols, node_to_sympy
+                    )
+                    if bound_expr is None:
+                        return None
+                    operand = combine(operand, bound_expr)
+            return operand
+
     if len(args) < 2:
         return None
     lhs = fx_aux_index_to_sympy(args[0], index_symbols, node_to_sympy)
@@ -380,6 +403,10 @@ def fx_aux_index_to_sympy(
             return V.graph.sizevars.simplify(lhs - rhs)
         case torch.ops.aten.mul.Tensor | torch.ops.aten.mul.Scalar:
             return V.graph.sizevars.simplify(lhs * rhs)
+        case torch.ops.aten.minimum.default:
+            return Min(lhs, rhs)
+        case torch.ops.aten.maximum.default:
+            return Max(lhs, rhs)
         case torch.ops.aten.remainder.Tensor | torch.ops.aten.remainder.Scalar:
             return ModularIndexing(lhs, 1, rhs)
         case torch.ops.aten.div.Tensor_mode if (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #188876

ME:
Fixes a bug I found when making some new additions to attention gym. This is basically pretty new cause of the aux_scalar code that was added recently. So this wasnt supported before and we baiscally cast down to align dtypes for where.


UPDATE also found a big with our lane uniform anlaysis with aux_scalars that made is assume we were braodcastable e.g. lane unfiform. We have since fixed this in this pr since it is a small tweak


### Agent notes
Fixes two dtype bugs in the FLASH backend's captured-buffer index codegen
(#188871):

1. Negative-index wrap under dynamic shapes: dynamic table sizes render as
   Int64 aux_scalars, so the emitted
   cute.where(idx < 0, idx + size, idx) mixed an Int64 sum with an Int32
   index and CuTeDSL rejected the operands. Cast the size operand to the
   index dtype at the point of use.

2. Widening index casts: an int64 index expression (e.g.
   tbl[kv_idx.to(torch.int64)]) was stored unconverted into the int32 index
   fragment, failing with 'Type mismatch, store Int64 to Tensor with element
   type Int32'. ssa_to_fragment now casts to the fragment dtype (const_expr
   branch, no dynamic control flow).

Both regression tests fail before this change and pass after; verified
against fp32 flex references via flash_vs_triton. No regressions in
test/inductor/test_flex_flash.py (246 passed) or
test_flex_aux_vectorization.py (17 passed) on B200.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Chillee @yanboliang @BoyuanFeng @liangel-02 @howardzhang-cv