### PR TITLE
[FlexAttention] Fix CuTeDSL score_mod index codegen: dtype mismatches and wrapped-gather lane misclassification

### DIFF
--- a/test/inductor/test_flex_flash.py
+++ b/test/inductor/test_flex_flash.py
@@ -909,6 +909,37 @@ GQA_MQA_BLOCK_MASK_CASES = [
 class TestFlexFlash(InductorTestCase):
     # `FlashAttentionForwardSm120` does not have `apply_score_mod`.
     @xfailIfSM120OrLater
+    def test_vectorized_group_per_lane_gather(self):
+        """Per-lane gather + lane-uniform load in one vec group (#188871).
+
+        The uniform scale load enables score_mod vectorization; the rel-pos
+        gather's wrapped index must still classify per-lane, not lane-uniform
+        (which silently broadcast lane 0's bias across the group).
+        """
+        seq_len = 512
+        rel_bias = torch.randn(2 * seq_len, device="cuda")
+        head_scale = torch.randn(4, device="cuda")
+        offset = seq_len - 1
+
+        def score_mod(score, _b, h, q_idx, kv_idx):
+            return score + rel_bias[q_idx - kv_idx + offset] * head_scale[h]
+
+        q, k, v = create_test_tensors(seq_len=seq_len, device="cuda")
+        flash_vs_triton(q, k, v, score_mod=score_mod)
+
+    @xfailIfSM120OrLater
+    def test_captured_table_int64_index(self):
+        """Widening index casts must not break index-fragment materialization (#188871)."""
+        seq_len = 512
+        tbl = torch.randn(seq_len, device="cuda")
+
+        def score_mod(score, _b, _h, _q, kv_idx):
+            return score + tbl[kv_idx.to(torch.int64)]
+
+        q, k, v = create_test_tensors(seq_len=seq_len, device="cuda")
+        flash_vs_triton(q, k, v, score_mod=score_mod)
+
+    @xfailIfSM120OrLater
     @dtypes(torch.float16, torch.bfloat16)
     @parametrize("case", SCORE_MOD_CASES, name_fn=score_case_name)
     def test_flash_attention_score_mod_cases(self, device, dtype, case):
@@ -2443,6 +2474,24 @@ class TestFlexFlashDynamicShapes(InductorTestCase):
             return score + (kv_idx - q_idx) * slopes[h]
 
         self._run_dynamic_test(seq_lens=[128, 256, 512], score_mod=alibi_score_mod)
+
+    @xfailIfSM120OrLater
+    def test_dynamic_captured_table_negative_index_wrap(self):
+        """Rel-pos table gather with a shape-dependent offset (#188871).
+
+        Once shapes go dynamic, the table length and offset are rendered as Int64
+        aux scalars; the emitted negative-index wrap must cast them to the Int32
+        index dtype or cute.where rejects the mixed operands.
+        """
+        for seq_len in [512, 1024]:
+            tbl = torch.randn(2 * seq_len, device="cuda")
+            offset = seq_len - 1
+
+            def score_mod(score, _b, _h, q_idx, kv_idx):
+                return score + tbl[q_idx - kv_idx + offset]
+
+            q, k, v = create_test_tensors(seq_len=seq_len, device="cuda")
+            flash_vs_triton(q, k, v, score_mod=score_mod, dynamic=True)
 
     @xfailIfSM120OrLater
     def test_dynamic_seq_len_with_block_mask(self):

--- a/torch/_inductor/codegen/cutedsl/_cutedsl_utils.py
+++ b/torch/_inductor/codegen/cutedsl/_cutedsl_utils.py
@@ -1,5 +1,6 @@
 # mypy: disable-error-code=import-not-found
 # pyrefly: ignore [import-error, missing-import]
+import cutlass
 import cutlass.cute as cute
 
 
@@ -18,7 +19,14 @@ def ssa_to_indexable(ssa_value: cute.TensorSSA, dtype: str) -> cute.Numeric:
 
 @cute.jit  # type: ignore[misc]
 def ssa_to_fragment(ssa_value: cute.TensorSSA, dtype: str) -> cute.Tensor:
-    """Materialize an SSA vector into a register fragment."""
+    """Materialize an SSA vector into a register fragment.
+
+    Casts to the fragment dtype when the SSA dtype differs (e.g. an int64 index
+    expression materialized into an int32 index fragment), since fragment
+    stores require matching element types.
+    """
+    if cutlass.const_expr(ssa_value.dtype != dtype):
+        ssa_value = ssa_value.to(dtype)
     frag = cute.make_rmem_tensor(ssa_value.shape, dtype)
     frag.store(ssa_value)
     return frag

--- a/torch/_inductor/codegen/cutedsl/cutedsl_kernel.py
+++ b/torch/_inductor/codegen/cutedsl/cutedsl_kernel.py
@@ -629,6 +629,10 @@ class ModificationWrapperCuteDSL(V.WrapperHandler):  # type: ignore[name-defined
         # Maps generated CSE names back to their original index expressions so
         # vector-load analysis can reason about the source indexing semantics.
         self._semantic_index_replacements: dict[sympy.Symbol, sympy.Expr] = {}
+        # Symbols whose value passed through a negative-index wrap. The wrap can
+        # remap individual lanes (idx + size for negatives only), so these may
+        # classify as lane-uniform but never as contiguous.
+        self._wrap_tainted_symbols: OrderedSet[sympy.Symbol] = OrderedSet()
 
     def _get_input_dtype(self, name: str) -> torch.dtype:
         """Get the dtype for an input from the kernel's named_input_nodes."""
@@ -657,6 +661,10 @@ class ModificationWrapperCuteDSL(V.WrapperHandler):  # type: ignore[name-defined
             dim_sizes = buffer.get_size()
             if len(dim_sizes) == 0:
                 dim_indices = ()
+            # Per-dimension indices into captured buffers are bounded by dim
+            # sizes (not flattened offsets), so Int32 is safe whatever index
+            # dtype the consuming kernel passes in; wider index expressions are
+            # narrowed at fragment materialization.
             idx_vars = [
                 self._emit_index_fragment(
                     dim_index, dim_size, "cutlass.Int32", torch.int32
@@ -887,13 +895,22 @@ class ModificationWrapperCuteDSL(V.WrapperHandler):  # type: ignore[name-defined
     def _emit_per_lane_gather_load(
         self, var: str, idx_vars: list[CuteDSLIndexFragment], val_frag: str
     ) -> None:
-        """Emit scalar per-lane loads for non-contiguous gather indices."""
+        """Emit scalar per-lane loads for non-contiguous gather indices.
+
+        Lane-uniform index fragments hold a single element, so they are indexed
+        at [0] rather than [load_idx] (which would read out of bounds and
+        silently corrupt the gathered rows).
+        """
         self.kernel.body.writeline(
             f"for load_idx in cutlass.range(cute.size({val_frag}.shape), unroll_full=True):"
         )
         with self.kernel.body.indent():
             load_indices = [
-                idx.code if idx.is_static_int else f"{idx.code}[load_idx]"
+                idx.code
+                if idx.is_static_int
+                else f"{idx.code}[0]"
+                if idx.is_lane_uniform
+                else f"{idx.code}[load_idx]"
                 for idx in idx_vars
             ]
             self.kernel.body.writeline(
@@ -924,7 +941,8 @@ class ModificationWrapperCuteDSL(V.WrapperHandler):  # type: ignore[name-defined
             )
 
         is_lane_uniform, is_contiguous, contiguous_width = self._analyze_index_fragment(
-            self._semantic_index_expr(expr)
+            self._semantic_index_expr(expr),
+            wrap_tainted=bool(expr.free_symbols & self._wrap_tainted_symbols),
         )
         result = self.kernel.cse.newvar(dtype=torch_dtype)
         self.kernel.body.writeline(
@@ -939,7 +957,7 @@ class ModificationWrapperCuteDSL(V.WrapperHandler):  # type: ignore[name-defined
         )
 
     def _analyze_index_fragment(
-        self, semantic_expr: sympy.Expr
+        self, semantic_expr: sympy.Expr, wrap_tainted: bool = False
     ) -> tuple[bool, bool, int | None]:
         if self.vector_load_config is None:
             return False, False, None
@@ -952,6 +970,10 @@ class ModificationWrapperCuteDSL(V.WrapperHandler):  # type: ignore[name-defined
             max_width=self.vector_load_config.vec_size,
             uniform_symbols=self._lane_uniform_symbols(),
         )
+        if wrap_tainted:
+            # The wrap remaps negative lanes individually, so contiguity of the
+            # pre-wrap expression does not survive; uniformity does.
+            return lane_info.is_uniform, False, None
         return (
             lane_info.is_uniform,
             lane_info.is_contiguous,
@@ -1016,12 +1038,23 @@ class ModificationWrapperCuteDSL(V.WrapperHandler):  # type: ignore[name-defined
             and not V.graph.sizevars.statically_known_geq(index_var.index_expr, 0)
         ):
             wrapped = self.kernel.cse.newvar(dtype=index_var.dtype)
-            size_expr = self.kernel.kexpr(size)
+            # Dynamic sizes render as Int64 aux_scalars; cast to the index dtype so
+            # both cute.where branches agree (per-dim size, so narrowing is safe).
+            index_cute_dtype = CuteDSLOpOverrides.TORCH_TO_CUTE_DTYPE.get(
+                index_var.dtype, "cutlass.Int32"
+            )
+            size_expr = f"{index_cute_dtype}({self.kernel.kexpr(size)})"
             self.kernel.body.writeline(
                 f"{wrapped} = cute.where("
                 f"{index_var} < 0, {index_var} + {size_expr}, {index_var})"
             )
-            return sympy_index_symbol(str(wrapped))
+            symbol = sympy_index_symbol(str(wrapped))
+            # Preserve the pre-wrap semantics so lane analysis sees the true
+            # lane structure instead of an unknown (default lane-uniform)
+            # symbol, which broadcast lane 0's gather to the whole group.
+            self._semantic_index_replacements[symbol] = index_var.index_expr
+            self._wrap_tainted_symbols.add(symbol)
+            return symbol
         source_name = None
         for expr, var in self.kernel.cse._cache.items():
             if var is index_var:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #188879

Three fixes in the FLASH backend's captured-buffer index codegen:

1. Negative-index wrap under dynamic shapes: dynamic table sizes render as
   Int64 aux_scalars, so the emitted cute.where(idx < 0, idx + size, idx)
   mixed an Int64 sum with an Int32 index and CuTeDSL rejected the operands.
   Cast the size operand to the index dtype at the point of use (#188871).

2. Widening index casts: an int64 index expression (e.g.
   tbl[kv_idx.to(torch.int64)]) was stored unconverted into the int32 index
   fragment, failing with 'Type mismatch, store Int64 to Tensor with element
   type Int32'. ssa_to_fragment now casts to the fragment dtype (#188871).

3. Silent wrong results: the wrap path returned its CSE symbol without
   registering the semantic index expression, so lane analysis classified the
   per-lane gather as lane-uniform and broadcast lane 0's load across the
   vectorized group (7/8 elements wrong) for mods like
   score + rel_bias[q_idx - kv_idx + offset] * head_scale[h].
   Register the pre-wrap semantics and track wrap-tainted symbols: they keep
   per-lane classification but never classify contiguous, since the wrap
   remaps negative lanes individually. Per-lane gather loops index
   lane-uniform fragments at [0] (#188878).

All three regression tests fail before their fix and pass after; verified
against fp32 flex references via flash_vs_triton. No regressions in
test/inductor/test_flex_flash.py + test_flex_aux_vectorization.py
(266 passed) on B200.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo