### PR TITLE
test-osdc: use a writable HF_DATASETS_CACHE

### DIFF
--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -814,6 +814,12 @@ jobs:
             export HF_DATASETS_OFFLINE=0
           fi
 
+          # The datasets library writes its arrow build + lock files even in offline
+          # mode and even for local datasets (e.g. torchtitan's c4_test), so keep its
+          # cache off the read-only /mnt/hf_cache mount.
+          export HF_DATASETS_CACHE="${RUNNER_TEMP}/hf_datasets"
+          mkdir -p "${HF_DATASETS_CACHE}"
+
           # shellcheck disable=SC2046
           python3 -m pip install $(echo dist/*.whl)[opt-einsum]
           ${TEST_COMMAND}


### PR DESCRIPTION
On OSDC the runner hook sets `HF_HOME=/mnt/hf_cache` (the read-only shared mount), so the `datasets` library's default cache (`$HF_HOME/datasets`) is read-only. It writes its arrow build + lock files there even in offline mode and even for local datasets (e.g. torchtitan's `c4_test` from `tests/assets/c4_test`), so `os.makedirs('/mnt/hf_cache/datasets')` fails with `OSError: [Errno 30] Read-only file system` and the job dies before training.

Point `HF_DATASETS_CACHE` at a writable `${RUNNER_TEMP}/hf_datasets` in the test-osdc run block. The model cache (`HF_CACHE`/`hub`) stays read-only. Fixes the torchtitan OSDC jobs; covers any `datasets`-using test on OSDC.
