### PR TITLE
[ROCm] nativert: query warp size for Triton kernel launch

### DIFF
--- a/torch/nativert/executor/triton/CudaTritonKernelManager.cpp
+++ b/torch/nativert/executor/triton/CudaTritonKernelManager.cpp
@@ -1,5 +1,6 @@
 #include <torch/nativert/executor/triton/TritonKernelManager.h>
 
+#include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/Exceptions.h>
 #include <ATen/cuda/nvrtc_stub/ATenNVRTC.h>
 #include <c10/cuda/CUDAStream.h>
@@ -156,7 +157,9 @@ void CudaTritonKernelManager::launch(
     const LaunchParams& launch_params,
     void** args /* { ...inputs, output }*/) {
   const auto& cuda_params = static_cast<const CudaLaunchParams&>(launch_params);
-  const constexpr int kThreadsPerWarp = 2 << 4;
+  // HIP wavefront size is 64 on most AMD GPUs vs 32 on NVIDIA; query it so
+  // blockDim.x = warp_size * num_warps matches the compiled Triton kernel.
+  const int kThreadsPerWarp = at::cuda::warp_size();
 
   auto kernel_fn = load();
   TORCH_CHECK(


### PR DESCRIPTION
Hardcoded `kThreadsPerWarp = 32` in `CudaTritonKernelManager::launch` is NVIDIA-only. AMD wavefronts are 64 wide, so HIP Triton kernels launched with `32 * num_warps` threads got half a block and mismatched the compiled kernel.

Query `at::cuda::warp_size()` instead, matching inductor's `static_launcher` which reads `hipDeviceAttributeWarpSize`.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang