### PR TITLE
[DataLoader] Clean up stale Py2 comments and pickle-error warning

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -2074,7 +2074,9 @@ except RuntimeError as e:
         dataloader = self._get_data_loader(
             dataset, batch_size=2, num_workers=2, worker_init_fn=local_init_fn
         )
-        with self.assertWarnsRegex(UserWarning, "Got pickle error when"):
+        with self.assertWarnsRegex(
+            UserWarning, "Failed to pickle worker Process arguments"
+        ):
             with self.assertRaises(Exception):
                 next(iter(dataloader))
 

--- a/torch/utils/data/_utils/__init__.py
+++ b/torch/utils/data/_utils/__init__.py
@@ -1,9 +1,8 @@
 r"""Utility classes & functions for data loading. Code in this folder is mostly used by ../dataloader.py.
 
-A lot of multiprocessing is used in data loading, which only supports running
-functions defined in global environment (py2 can't serialize static methods).
-Therefore, for code tidiness we put these functions into different files in this
-folder.
+Data loading uses multiprocessing. Under the 'spawn'/'forkserver' start methods,
+worker functions must be at module scope to be pickled by qualified name, so we
+split them across the files in this folder.
 """
 
 import atexit

--- a/torch/utils/data/_utils/pin_memory.py
+++ b/torch/utils/data/_utils/pin_memory.py
@@ -1,8 +1,8 @@
 # mypy: allow-untyped-defs
 r"""Contains definitions of the methods used by the _BaseDataLoaderIter to put fetched tensors into pinned memory.
 
-These **need** to be in global scope since Py2 doesn't support serializing
-static methods.
+These **need** to be at module scope so 'spawn'/'forkserver' can pickle them by
+qualified name.
 """
 
 import collections

--- a/torch/utils/data/_utils/worker.py
+++ b/torch/utils/data/_utils/worker.py
@@ -1,8 +1,8 @@
 # mypy: allow-untyped-defs
 r"""Contains definitions of the methods used by the _BaseDataLoaderIter workers.
 
-These **need** to be in global scope since Py2 doesn't support serializing
-static methods.
+These **need** to be at module scope so 'spawn'/'forkserver' can pickle them by
+qualified name.
 """
 
 from __future__ import annotations
@@ -125,19 +125,17 @@ def get_worker_info() -> WorkerInfo | None:
     return _worker_info
 
 
-r"""Dummy class used to signal the end of an IterableDataset"""
-
-
 @dataclass(frozen=True)
 class _IterableDatasetStopIteration:
+    r"""Sentinel sent from an IterableDataset worker to signal it is exhausted."""
+
     worker_id: int
-
-
-r"""Dummy class used to resume the fetching when worker reuse is enabled"""
 
 
 @dataclass(frozen=True)
 class _ResumeIteration:
+    r"""Control message telling reused workers to resume fetching with a new seed."""
+
     seed: int | None = None
 
 

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -1176,11 +1176,9 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
                 w.start()
             except (TypeError, AttributeError, PicklingError):
                 warnings.warn(
-                    "Got pickle error when attempting to start a worker Process. "
-                    "This might be because the worker Process arguments are not picklable. "
-                    "Python 3.14+ changed the multiprocessing start method in non-Mac POSIX platforms "
-                    "to 'forkserver', which requires the worker Process arguments to be picklable. "
-                    "You can also try multiprocessing.set_start_method('fork').",
+                    "Failed to pickle worker Process arguments, as required by the "
+                    "'spawn' and 'forkserver' start methods. Ensure dataset, "
+                    "collate_fn and worker_init_fn are not lambdas or closures.",
                     stacklevel=2,
                 )
                 raise


### PR DESCRIPTION
This PR contains the following changes:
- Replace the obsolete "Py2 can't serialize static methods" rationale (min Python is 3.10) with the real reason: spawn/forkserver pickle worker callables by qualified name.
- Move two `_IterableDatasetStopIteration`/`_ResumeIteration` docstrings inside their classes (they were module-level string statements attached to nothing) and reword to describe what they are.
- The pickle-error warning suggested `set_start_method('fork')`, which doesn't exist on Windows and undoes the safer 3.14 forkserver default; replace with an actionable message about making worker args picklable.


Authored with the assistance of an AI agent.