### PR TITLE
[AOTI] Support PDL launch attributes via `cuLaunchKernelEx` in CUDA wrappers

### DIFF
--- a/test/inductor/test_cpp_wrapper_hipify.py
+++ b/test/inductor/test_cpp_wrapper_hipify.py
@@ -40,8 +40,9 @@ class TestCppWrapperHipify(TestCase):
 
     def test_hipify_aoti_driver_header(self) -> None:
         cuda_codegen = get_device_op_overrides("cuda")
-        with mock.patch.object(torch.version, "hip", "test-hip"), mock.patch.object(
-            torch.cuda, "is_available", return_value=False
+        with (
+            mock.patch.object(torch.version, "hip", "test-hip"),
+            mock.patch.object(torch.cuda, "is_available", return_value=False),
         ):
             header = cuda_codegen.kernel_driver()
 

--- a/test/inductor/test_cpp_wrapper_hipify.py
+++ b/test/inductor/test_cpp_wrapper_hipify.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: inductor"]
-import torch
 from unittest import mock
+
+import torch
 from torch._inductor.codegen.aoti_hipify_utils import maybe_hipify_code_wrapper
 from torch._inductor.codegen.common import get_device_op_overrides
 from torch._inductor.test_case import run_tests, TestCase

--- a/test/inductor/test_cpp_wrapper_hipify.py
+++ b/test/inductor/test_cpp_wrapper_hipify.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: inductor"]
 import torch
+from unittest import mock
 from torch._inductor.codegen.aoti_hipify_utils import maybe_hipify_code_wrapper
 from torch._inductor.codegen.common import get_device_op_overrides
 from torch._inductor.test_case import run_tests, TestCase
@@ -38,98 +39,22 @@ class TestCppWrapperHipify(TestCase):
 
     def test_hipify_aoti_driver_header(self) -> None:
         cuda_codegen = get_device_op_overrides("cuda")
-        header = cuda_codegen.kernel_driver()
-        expected = """
-            #define CUDA_DRIVER_CHECK(EXPR)                    \\
-            do {                                               \\
-                hipError_t code = EXPR;                          \\
-                const char *msg;                               \\
-                hipError_t code_get_error = hipDrvGetErrorString(code, &msg); \\
-                if (code_get_error != hipSuccess) {          \\
-                    throw std::runtime_error(                  \\
-                        std::string("CUDA driver error: ") +   \\
-                        std::string("invalid error code!"));   \\
-                }                                              \\
-                if (code != hipSuccess) {                    \\
-                    throw std::runtime_error(                  \\
-                        std::string("CUDA driver error: ") +   \\
-                        std::string(msg));                     \\
-                }                                              \\
-            } while (0);
+        with mock.patch.object(torch.version, "hip", "test-hip"), mock.patch.object(
+            torch.cuda, "is_available", return_value=False
+        ):
+            header = cuda_codegen.kernel_driver()
 
-            static inline hipFunction_t loadKernel(
-                    std::string filePath,
-                    const std::string &funcName,
-                    uint32_t sharedMemBytes,
-                    const std::optional<std::string> &cubinDir = std::nullopt,
-                    std::vector<hipModule_t>* loaded_modules = nullptr) {
-                if (cubinDir) {
-                    std::filesystem::path p1{*cubinDir};
-                    std::filesystem::path p2{filePath};
-                    filePath = (p1 / p2.filename()).string();
-                }
+        self.assertIn("hipModuleLaunchKernel", header)
+        self.assertIn("bool launch_pdl = false", header)
+        self.assertNotIn("CUlaunchAttribute", header)
+        self.assertNotIn("CUlaunchConfig", header)
+        self.assertNotIn("cuLaunchKernelEx", header)
 
-                hipModule_t mod;
-                hipFunction_t func;
-                CUDA_DRIVER_CHECK(hipModuleLoad(&mod, filePath.c_str()));
-                if (loaded_modules) {
-                    loaded_modules->push_back(mod);
-                }
-                CUDA_DRIVER_CHECK(hipModuleGetFunction(&func, mod, funcName.c_str()));
-                if (sharedMemBytes > 0) {
-                    CUDA_DRIVER_CHECK(hipFuncSetAttribute(
-                        func,
-                        hipFuncAttributeMaxDynamicSharedMemorySize,
-                        sharedMemBytes
-                    ))
-                }
-                return func;
-            }
-
-            static inline hipFunction_t loadKernel(
-                    const void* start,
-                    const std::string &funcName,
-                    uint32_t sharedMemBytes,
-                    std::vector<hipModule_t>* loaded_modules = nullptr) {
-                hipModule_t mod;
-                hipFunction_t func;
-                CUDA_DRIVER_CHECK(hipModuleLoadData(&mod, start));
-                if (loaded_modules) {
-                    loaded_modules->push_back(mod);
-                }
-                CUDA_DRIVER_CHECK(hipModuleGetFunction(&func, mod, funcName.c_str()));
-                if (sharedMemBytes > 0) {
-                    CUDA_DRIVER_CHECK(hipFuncSetAttribute(
-                        func,
-                        hipFuncAttributeMaxDynamicSharedMemorySize,
-                        sharedMemBytes
-                    ))
-                }
-                return func;
-            }
-
-            static inline void launchKernel(
-                    hipFunction_t func,
-                    uint32_t gridX,
-                    uint32_t gridY,
-                    uint32_t gridZ,
-                    uint32_t numWarps,
-                    uint32_t sharedMemBytes,
-                    void* args[],
-                    hipStream_t stream) {
-                CUDA_DRIVER_CHECK(hipModuleLaunchKernel(
-                    func, gridX, gridY, gridZ, 32*numWarps, 1, 1, sharedMemBytes, stream, args, nullptr
-                ));
-            }
-        """
-        if torch.version.hip is not None:
-            # Adjusting the warp size to GPU supported wavefront size on AMD GPU
-            prop = torch.cuda.get_device_properties(torch.cuda.current_device())
-            expected = expected.replace(
-                "32*numWarps", str(prop.warp_size) + "*numWarps"
-            )
         result = maybe_hipify_code_wrapper(header, True)
-        self.assertEqual(result.rstrip(), expected.rstrip())
+        self.assertIn("hipModuleLaunchKernel", result)
+        self.assertNotIn("CUlaunchAttribute", result)
+        self.assertNotIn("CUlaunchConfig", result)
+        self.assertNotIn("cuLaunchKernelEx", result)
 
     def test_hipify_cross_platform(self) -> None:
         if len(TEST_CODES) != len(HIP_CODES):

--- a/test/inductor/test_cpp_wrapper_hipify.py
+++ b/test/inductor/test_cpp_wrapper_hipify.py
@@ -46,6 +46,7 @@ class TestCppWrapperHipify(TestCase):
 
         self.assertIn("hipModuleLaunchKernel", header)
         self.assertIn("bool launch_pdl = false", header)
+        self.assertIn("PDL launch is not supported on HIP", header)
         self.assertNotIn("CUlaunchAttribute", header)
         self.assertNotIn("CUlaunchConfig", header)
         self.assertNotIn("cuLaunchKernelEx", header)

--- a/test/inductor/test_gpu_cpp_wrapper.py
+++ b/test/inductor/test_gpu_cpp_wrapper.py
@@ -343,6 +343,7 @@ class TestGpuWrapper(InductorTestCase):
         )
         self.assertIn("programmaticStreamSerializationAllowed = 1", kernel_driver)
         self.assertIn("cuLaunchKernelEx(&launch_config", kernel_driver)
+        self.assertNotIn("cuLaunchKernel(", kernel_driver)
 
     def test_triton_wrapper_passes_pdl_launch_flag(self):
         if GPU_TYPE != "cuda" or torch.version.hip:

--- a/test/inductor/test_gpu_cpp_wrapper.py
+++ b/test/inductor/test_gpu_cpp_wrapper.py
@@ -19,7 +19,7 @@ from torch._inductor.codegen.cpp_wrapper_gpu import (
 )
 from torch._inductor.codegen.cuda.device_op_overrides import CUDADeviceOpOverrides
 from torch._inductor.test_case import TestCase as InductorTestCase
-from torch._inductor.utils import IndentedBuffer
+from torch._inductor.utils import DualIndentedBuffer, IndentedBuffer
 from torch._inductor.virtualized import V
 from torch.testing._internal.common_utils import (
     find_library_location,
@@ -330,6 +330,110 @@ class TestGpuWrapper(InductorTestCase):
         self.assertEqual(scratch_var, "global_scratch_scratch_0")
         self.assertIn(
             "static_cast<int64_t>(256) * grid_0 * grid_1 * grid_2", scratch_def[0]
+        )
+
+    def test_cuda_launch_kernel_supports_pdl(self):
+        if GPU_TYPE != "cuda" or torch.version.hip:
+            self.skipTest("CUDA-only codegen test")
+
+        kernel_driver = CUDADeviceOpOverrides().kernel_driver()
+        self.assertIn("bool launch_pdl = false", kernel_driver)
+        self.assertIn(
+            "CU_LAUNCH_ATTRIBUTE_PROGRAMMATIC_STREAM_SERIALIZATION", kernel_driver
+        )
+        self.assertIn("programmaticStreamSerializationAllowed = 1", kernel_driver)
+        self.assertIn("cuLaunchKernelEx(&launch_config", kernel_driver)
+
+    def test_triton_wrapper_passes_pdl_launch_flag(self):
+        if GPU_TYPE != "cuda" or torch.version.hip:
+            self.skipTest("CUDA-only codegen test")
+
+        class FakeWrapper:
+            device = "cuda"
+
+            def generate_args_decl(
+                self,
+                prefix,
+                call_args,
+                arg_types,
+                arg_signatures,
+                is_triton_kernel=True,
+                scratch_spaces=None,
+            ):
+                return ""
+
+        prefix = IndentedBuffer()
+        params = {
+            "triton_meta": {
+                "signature": {"x": "*fp32"},
+                "constants": {},
+                "launch_pdl": True,
+            },
+            "def_args": ["x"],
+            "call_args": ["x"],
+            "num_warps": 4,
+            "shared_mem": 0,
+        }
+
+        DeferredTritonCallWrapper(
+            wrapper_name="wrapper",
+            kernel_name="kernel",
+            kernel_name_to_body={},
+            arg_types=[torch.float32],
+        ).generate_launch_kernel(prefix, FakeWrapper(), "kernel_var", params)
+
+        self.assertIn(
+            "launchKernel(kernel_var, grid_0, grid_1, grid_2, 4, 0, kernel_args_, stream_, true);",
+            prefix.getvalue(),
+        )
+
+    @config.patch({"cpp.enable_kernel_profile": True})
+    def test_lazy_triton_wrapper_profile_passes_pdl_launch_flag(self):
+        if GPU_TYPE != "cuda" or torch.version.hip:
+            self.skipTest("CUDA-only codegen test")
+
+        class FakeDeviceCodegen:
+            def cpp_device_ptr(self):
+                return "void*"
+
+        class FakeWrapper:
+            device = "cuda"
+            device_codegen = FakeDeviceCodegen()
+
+            def codegen_dtype(self, dtype):
+                return "at::ScalarType::Byte"
+
+            def codegen_device(self, device):
+                return "aoti_torch_device_type_cuda(), device_idx_"
+
+            def generate_args_decl(
+                self,
+                prefix,
+                call_args,
+                arg_types,
+                arg_signatures,
+                is_triton_kernel=True,
+                scratch_spaces=None,
+            ):
+                return ""
+
+        prefix = DualIndentedBuffer()
+        wrapper = FakeWrapper()
+        DeferredTritonCallWrapper(
+            wrapper_name="wrapper",
+            kernel_name="kernel",
+            kernel_name_to_body={},
+            arg_types=[torch.float32],
+            triton_meta={
+                "signature": {"x": "*fp32"},
+                "constants": {},
+                "launch_pdl": True,
+            },
+        )._generate_lazy_launch(prefix, wrapper, ["x"], ["x"])
+
+        self.assertIn(
+            "launchKernel(kernels_.kernel, grid_0, grid_1, grid_2, kernel_result.num_warps, kernel_result.shared_mem, kernel_args_, stream_, true);",
+            prefix.aot.getvalue(),
         )
 
     @skipIfXpu(msg="tests CUDA/ROCm CUDADeviceOpOverrides codegen")

--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -607,6 +607,9 @@ class DeferredTritonCallWrapper:
             f" {kernel_name}_result.shared_mem,"
             f" kernel_args_, stream_"
         )
+        launch_pdl = str((self.triton_meta or {}).get("launch_pdl", False)).lower()
+        if wrapper.device == "cuda":
+            common_launch_args = f"{common_launch_args}, {launch_pdl}"
         # stream_ comes from the generated wrapper signature on both JIT and
         # AOTI sides.
         launch_kernel_args = [
@@ -616,7 +619,6 @@ class DeferredTritonCallWrapper:
             f"{kernel_name}_result.num_warps",
             f"{kernel_name}_result.shared_mem",
         ]
-
         # kernel_args_ is consumed by both JIT and AOT launchKernel calls.
         prefix.writeline(f"void* kernel_args_[] = {{{call_args_str}}};")
         enable_kernel_profile = config.cpp.enable_kernel_profile and sys.platform in [
@@ -639,6 +641,7 @@ class DeferredTritonCallWrapper:
                     *launch_kernel_args,
                     "kernel_args_",
                     "stream_",
+                    *([launch_pdl] if wrapper.device == "cuda" else []),
                 ],
                 num_warps=f"{kernel_name}_result.num_warps",
                 shared_mem=f"{kernel_name}_result.shared_mem",
@@ -907,6 +910,9 @@ class DeferredTritonCallWrapper:
             "kernel_args_",
             "stream_",
         ]
+        if wrapper.device == "cuda":
+            launch_pdl = str(triton_meta.get("launch_pdl", False)).lower()
+            launch_kernel_args.append(launch_pdl)
 
         enable_kernel_profile = config.cpp.enable_kernel_profile and sys.platform in [
             "linux",

--- a/torch/_inductor/codegen/cuda/device_op_overrides.py
+++ b/torch/_inductor/codegen/cuda/device_op_overrides.py
@@ -65,21 +65,21 @@ class CUDADeviceOpOverrides(DeviceOpOverrides):
             else:
                 warp_size = 32
             source_codes = """
-            #define CUDA_DRIVER_CHECK(EXPR)                    \
-            do {                                               \
-                hipError_t code = EXPR;                        \
-                const char *msg;                               \
-                hipError_t code_get_error = hipDrvGetErrorString(code, &msg); \
-                if (code_get_error != hipSuccess) {            \
-                    throw std::runtime_error(                  \
-                        std::string("CUDA driver error: ") +   \
-                        std::string("invalid error code!"));   \
-                }                                              \
-                if (code != hipSuccess) {                      \
-                    throw std::runtime_error(                  \
-                        std::string("CUDA driver error: ") +   \
-                        std::string(msg));                     \
-                }                                              \
+            #define CUDA_DRIVER_CHECK(EXPR)                    \\
+            do {                                               \\
+                hipError_t code = EXPR;                        \\
+                const char *msg;                               \\
+                hipError_t code_get_error = hipDrvGetErrorString(code, &msg); \\
+                if (code_get_error != hipSuccess) {            \\
+                    throw std::runtime_error(                  \\
+                        std::string("CUDA driver error: ") +   \\
+                        std::string("invalid error code!"));   \\
+                }                                              \\
+                if (code != hipSuccess) {                      \\
+                    throw std::runtime_error(                  \\
+                        std::string("CUDA driver error: ") +   \\
+                        std::string(msg));                     \\
+                }                                              \\
             } while (0);
 
             static inline hipFunction_t loadKernel(

--- a/torch/_inductor/codegen/cuda/device_op_overrides.py
+++ b/torch/_inductor/codegen/cuda/device_op_overrides.py
@@ -58,6 +58,101 @@ class CUDADeviceOpOverrides(DeviceOpOverrides):
         embedded in AOTI-generated wrapper code."""
         # NVIDIA devices have a warp size of 32, while AMD devices can have a
         # warp size of 32 or 64 depending on the architecture.
+        if torch.version.hip is not None:
+            if torch.cuda.is_available():
+                device = torch.device("cuda", torch.cuda.current_device())
+                warp_size = get_warp_size(device)
+            else:
+                warp_size = 32
+            source_codes = """
+            #define CUDA_DRIVER_CHECK(EXPR)                    \
+            do {                                               \
+                hipError_t code = EXPR;                        \
+                const char *msg;                               \
+                hipError_t code_get_error = hipDrvGetErrorString(code, &msg); \
+                if (code_get_error != hipSuccess) {            \
+                    throw std::runtime_error(                  \
+                        std::string("CUDA driver error: ") +   \
+                        std::string("invalid error code!"));   \
+                }                                              \
+                if (code != hipSuccess) {                      \
+                    throw std::runtime_error(                  \
+                        std::string("CUDA driver error: ") +   \
+                        std::string(msg));                     \
+                }                                              \
+            } while (0);
+
+            static inline hipFunction_t loadKernel(
+                    std::string filePath,
+                    const std::string &funcName,
+                    uint32_t sharedMemBytes,
+                    const std::optional<std::string> &cubinDir = std::nullopt,
+                    std::vector<hipModule_t>* loaded_modules = nullptr) {
+                if (cubinDir) {
+                    std::filesystem::path p1{*cubinDir};
+                    std::filesystem::path p2{filePath};
+                    filePath = (p1 / p2.filename()).string();
+                }
+
+                hipModule_t mod;
+                hipFunction_t func;
+                CUDA_DRIVER_CHECK(hipModuleLoad(&mod, filePath.c_str()));
+                if (loaded_modules) {
+                    loaded_modules->push_back(mod);
+                }
+                CUDA_DRIVER_CHECK(hipModuleGetFunction(&func, mod, funcName.c_str()));
+                if (sharedMemBytes > 0) {
+                    CUDA_DRIVER_CHECK(hipFuncSetAttribute(
+                        func,
+                        hipFuncAttributeMaxDynamicSharedMemorySize,
+                        sharedMemBytes
+                    ))
+                }
+                return func;
+            }
+
+            static inline hipFunction_t loadKernel(
+                    const void* start,
+                    const std::string &funcName,
+                    uint32_t sharedMemBytes,
+                    std::vector<hipModule_t>* loaded_modules = nullptr) {
+                hipModule_t mod;
+                hipFunction_t func;
+                CUDA_DRIVER_CHECK(hipModuleLoadData(&mod, start));
+                if (loaded_modules) {
+                    loaded_modules->push_back(mod);
+                }
+                CUDA_DRIVER_CHECK(hipModuleGetFunction(&func, mod, funcName.c_str()));
+                if (sharedMemBytes > 0) {
+                    CUDA_DRIVER_CHECK(hipFuncSetAttribute(
+                        func,
+                        hipFuncAttributeMaxDynamicSharedMemorySize,
+                        sharedMemBytes
+                    ))
+                }
+                return func;
+            }
+
+            static inline void launchKernel(
+                    hipFunction_t func,
+                    uint32_t gridX,
+                    uint32_t gridY,
+                    uint32_t gridZ,
+                    uint32_t numWarps,
+                    uint32_t sharedMemBytes,
+                    void* args[],
+                    hipStream_t stream,
+                    bool launch_pdl = false) {
+                if (launch_pdl) {
+                    throw std::runtime_error("PDL launch is not supported on HIP");
+                }
+                CUDA_DRIVER_CHECK(hipModuleLaunchKernel(
+                    func, gridX, gridY, gridZ, __WARP_SIZE__*numWarps, 1, 1, sharedMemBytes, stream, args, nullptr
+                ));
+            }
+        """
+            return source_codes.replace("__WARP_SIZE__", str(warp_size))
+
         source_codes = """
             #define CUDA_DRIVER_CHECK(EXPR)                    \\
             do {                                               \\
@@ -151,12 +246,7 @@ class CUDADeviceOpOverrides(DeviceOpOverrides):
                 CUDA_DRIVER_CHECK(cuLaunchKernelEx(&launch_config, func, args, nullptr));
             }
         """
-        if torch.version.hip is not None and torch.cuda.is_available():
-            device = torch.device("cuda", torch.cuda.current_device())
-            warp_size = get_warp_size(device)
-        else:
-            warp_size = 32
-        return source_codes.replace("__WARP_SIZE__", str(warp_size))
+        return source_codes.replace("__WARP_SIZE__", "32")
 
     def tma_descriptor_helpers(self) -> str:
         """

--- a/torch/_inductor/codegen/cuda/device_op_overrides.py
+++ b/torch/_inductor/codegen/cuda/device_op_overrides.py
@@ -135,7 +135,23 @@ class CUDADeviceOpOverrides(DeviceOpOverrides):
                     uint32_t numWarps,
                     uint32_t sharedMemBytes,
                     void* args[],
-                    cudaStream_t stream) {
+                    cudaStream_t stream,
+                    bool launch_pdl = false) {
+                if (launch_pdl) {
+                    #if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 12000
+                    CUlaunchAttribute launch_attribute[1];
+                    launch_attribute[0].id = CU_LAUNCH_ATTRIBUTE_PROGRAMMATIC_STREAM_SERIALIZATION;
+                    launch_attribute[0].value.programmaticStreamSerializationAllowed = 1;
+                    CUlaunchConfig launch_config = {
+                        gridX, gridY, gridZ, __WARP_SIZE__*numWarps, 1, 1,
+                        sharedMemBytes, stream, launch_attribute, 1
+                    };
+                    CUDA_DRIVER_CHECK(cuLaunchKernelEx(&launch_config, func, args, nullptr));
+                    #else
+                    throw std::runtime_error("PDL launch requires CUDA 12.0 or newer");
+                    #endif
+                    return;
+                }
                 CUDA_DRIVER_CHECK(cuLaunchKernel(
                     func, gridX, gridY, gridZ, __WARP_SIZE__*numWarps, 1, 1, sharedMemBytes, stream, args, nullptr
                 ));

--- a/torch/_inductor/codegen/cuda/device_op_overrides.py
+++ b/torch/_inductor/codegen/cuda/device_op_overrides.py
@@ -137,24 +137,18 @@ class CUDADeviceOpOverrides(DeviceOpOverrides):
                     void* args[],
                     cudaStream_t stream,
                     bool launch_pdl = false) {
+                CUlaunchAttribute launch_attribute[1];
+                uint32_t num_attrs = 0;
                 if (launch_pdl) {
-                    #if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 12000
-                    CUlaunchAttribute launch_attribute[1];
                     launch_attribute[0].id = CU_LAUNCH_ATTRIBUTE_PROGRAMMATIC_STREAM_SERIALIZATION;
                     launch_attribute[0].value.programmaticStreamSerializationAllowed = 1;
-                    CUlaunchConfig launch_config = {
-                        gridX, gridY, gridZ, __WARP_SIZE__*numWarps, 1, 1,
-                        sharedMemBytes, stream, launch_attribute, 1
-                    };
-                    CUDA_DRIVER_CHECK(cuLaunchKernelEx(&launch_config, func, args, nullptr));
-                    #else
-                    throw std::runtime_error("PDL launch requires CUDA 12.0 or newer");
-                    #endif
-                    return;
+                    num_attrs = 1;
                 }
-                CUDA_DRIVER_CHECK(cuLaunchKernel(
-                    func, gridX, gridY, gridZ, __WARP_SIZE__*numWarps, 1, 1, sharedMemBytes, stream, args, nullptr
-                ));
+                CUlaunchConfig launch_config = {
+                    gridX, gridY, gridZ, __WARP_SIZE__*numWarps, 1, 1,
+                    sharedMemBytes, stream, launch_pdl ? launch_attribute : nullptr, num_attrs
+                };
+                CUDA_DRIVER_CHECK(cuLaunchKernelEx(&launch_config, func, args, nullptr));
             }
         """
         if torch.version.hip is not None and torch.cuda.is_available():


### PR DESCRIPTION
## Summary
Enable programmatic dependent launch (PDL) for AOTI CUDA wrappers by
switching kernel launches from `cuLaunchKernel` to `cuLaunchKernelEx` /
`CUlaunchConfig`, which can carry
`CU_LAUNCH_ATTRIBUTE_PROGRAMMATIC_STREAM_SERIALIZATION`. PDL codegen
stays CUDA-only and SM90+.

### Cost: forked HIP/ROCm codegen
PDL is CUDA/SM90+ only, so ROCm was never a target for the feature. The
cost is instead in how the launch helper is generated: the shared CUDA
`kernel_driver()` template was previously hipified into the HIP helper
automatically. Moving to `cuLaunchKernelEx` / `CUlaunchConfig` (required
to pass the PDL launch attribute) has no hipify mapping, so the HIP path
can no longer be auto-translated. As a result the HIP host helper is now
hand-forked -- staying on `hipModuleLaunchKernel` and rejecting
`launch_pdl` -- duplicating the `loadKernel`/`launchKernel` code even
though ROCm gains nothing from PDL.

Authored with CodeX GPT 5.5

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo