### PR TITLE
Enable cpp_wrapper for mixed order reduction

### DIFF
--- a/test/inductor/test_gpu_cpp_wrapper.py
+++ b/test/inductor/test_gpu_cpp_wrapper.py
@@ -217,6 +217,33 @@ class TestGpuWrapper(InductorTestCase):
             _, code = test_torchinductor.run_and_get_cpp_code(compiled, x, 3)
         self.assertIn("torch.tensor(arg, device='cpu')", code)
 
+    def test_cpp_wrapper_mix_order_reduction(self):
+        if not RUN_GPU:
+            self.skipTest("GPU not available")
+        from torch._dynamo.utils import same
+        from torch._inductor import metrics
+        from torch._inductor.utils import fresh_cache
+
+        def f(x):
+            return x.sum(dim=-1), x.sum(dim=0)
+
+        x = torch.randn(32768, 768, device=self.device)
+        metrics.reset()
+        with (
+            fresh_cache(),
+            config.patch(
+                {
+                    "cpp_wrapper": True,
+                    "triton.mix_order_reduction": True,
+                    "triton.cooperative_reductions": False,
+                }
+            ),
+        ):
+            result = torch.compile(f)(x)
+
+        self.assertTrue(same(f(x), result, tol=1e-2))
+        self.assertTrue(metrics.codegen_mix_order_reduction)
+
     @config.patch(implicit_fallbacks=True)
     def test_fbcode_custom_op_fallback_python_arg_helpers(self):
         if not RUN_GPU:

--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -406,9 +406,11 @@ class DeferredTritonCallWrapper:
         tma_tensor_args = self.tma_tensor_args
         num_tma_tensor_args = len(tma_tensor_args)
 
-        # Matches internal config params like XBLOCK, RSPLIT_SIZE, and their
-        # per-subkernel variants like XBLOCK_0, YBLOCK_1.
-        internal_config_re = re.compile(r"(?:BLOCK|RSPLIT_SIZE|RSPLIT)(?:_\d+)?$")
+        # Matches internal config params like XBLOCK, RSPLIT_SIZE, NUM_STAGES,
+        # and their per-subkernel variants like XBLOCK_0, YBLOCK_1.
+        internal_config_re = re.compile(
+            r"(?:BLOCK|RSPLIT_SIZE|RSPLIT|NUM_STAGES)(?:_\d+)?$"
+        )
         # Declared constexpr params (tl.constexpr in kernel signature) are excluded
         # from arg_types for user-defined kernels, while value-based constexpr params
         # (e.g. numel=1, arg=None) are still in arg_types.

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -2398,6 +2398,115 @@ class SIMDScheduling(BaseScheduling):
     ) -> tuple[float, str]:
         raise NotImplementedError
 
+    def _codegen_mix_order_workspace_reduction(
+        self,
+        kernel,
+        ws_name,
+        idx,
+        partial_accum,
+        numel,
+        rnumel,
+        split_size,
+    ):
+        """Codegen the mix-order outer reduction over the workspace as a kernel.
+
+        The python wrapper emits this reduction as raw tensor ops (``ws[...].view(...).sum(dim=0)``)
+        which cpp_wrapper backend cannot compile. Express the reduction as IR over a view of
+        the workspace and graft it onto the original output buffer so it goes through the regular
+        Triton kernel codegen that cpp_wrapper already supports.
+        """
+        from .. import lowering
+
+        buffer_name = partial_accum.buffer_name
+        buffer = V.graph.get_buffer(buffer_name)
+        if not isinstance(buffer, ir.ComputedBuffer):
+            raise AssertionError(
+                f"mix-order outer reduction expected a ComputedBuffer for {buffer_name}, got {type(buffer).__name__}"
+            )
+
+        device = buffer.get_device()
+        if device is None:
+            raise AssertionError("expected output buffer to have a device")
+        buffer_dtype = buffer.get_dtype()
+        final_shape = list(buffer.get_layout().size)
+
+        nsplit = (numel + split_size - 1) // split_size
+        total_numel = len(kernel.saved_partial_accumulate) * nsplit * rnumel
+
+        # Expose the workspace (always torch.float) as a readable input buffer
+        # so the reduction IR can load from it.
+        if ws_name not in V.graph.name_to_buffer:
+            V.graph.name_to_buffer[ws_name] = ir.InputBuffer(
+                name=ws_name, layout=ir.FixedLayout(device, torch.float, [total_numel])
+            )
+        ws_buf = V.graph.name_to_buffer[ws_name]
+        # Register the workspace with the scheduler too so codegen helpers.
+        # (e.g. buffer-layout/alignment lookups) can resolve it.
+        if self.scheduler is not None and ws_name not in self.scheduler.name_to_buf:
+            self.scheduler.name_to_buf[ws_name] = scheduler.SchedulerBuffer(
+                scheduler=self.scheduler, node=ws_buf, defining_op=None
+            )
+
+        view_size = [nsplit, *final_shape]
+        view = ir.TensorBox(
+            ir.ReinterpretView(
+                data=ws_buf,
+                layout=ir.FixedLayout(
+                    device,
+                    torch.float,
+                    view_size,
+                    ir.FlexibleLayout.contiguous_strides(view_size),
+                    idx * nsplit * rnumel,
+                ),
+            )
+        )
+
+        reduction_type = partial_accum.reduction_type
+        kwargs = lowering._make_reduction_inner(
+            view,
+            axis=[0],
+            keepdims=False,
+            dtype=None,
+            override_return_dtype=buffer_dtype,
+            reduction_type=reduction_type,
+        )
+        # Build a single (non-split) reduction directly. Reduction.create
+        # would apply the split-reduction heuristic and emit an extra
+        # intermediate buffer that is not wired into codegen here.
+        loops = ir.Reduction(
+            device=kwargs["device"],
+            dtype=kwargs["dst_dtype"],
+            inner_fn=kwargs["inner_fn"],
+            ranges=kwargs["ranges"],
+            reduction_ranges=kwargs["reduction_ranges"],
+            reduction_type=reduction_type,
+            src_dtype=kwargs["src_dtype"],
+            reduction_hint=ir.ReductionHint.DEFAULT,
+        )
+
+        # Graft the workspace reduction onto the original output buffer so it
+        # keeps its name, layout and origins; downstream consumers are unchanged.
+        buffer.data = loops
+        buffer._split_size = None
+        # The buffer cached its LoopBody/read-writes during scheduelr init
+        # (reading the now-replaced inputs); invalidate so codegen uses the
+        # new workspace reduction body.
+        ir.ComputedBuffer.get_default_sizes_body.clear_cache(buffer)
+        if self.scheduler is None:
+            raise AssertionError("expected self.scheduler to be set")
+        # buffer's op was marked removed for the mix-order fusion (the python
+        # wrapper materializes it via tenosr ops). Temporarily un-remove it so
+        # our replacement kernel skipping the original (stale) node.
+        op_name = buffer.get_operation_name()
+        was_removed = op_name in self.scheduler.removed_ops
+        self.scheduler.removed_ops.discard(op_name)
+        snode = self.scheduler.create_scheduler_node(buffer)
+        if not isinstance(snode, scheduler.SchedulerNode):
+            raise AssertionError(f"expected SchedulerNode, got {type(snode).__name__}")
+        self.codegen_node(snode)
+        if was_removed:
+            self.scheduler.removed_ops.add(op_name)
+
     def _codegen_mix_order_reduction(self, node1, node2):
         numel, rnumel = scheduler.MixOrderReduction.get_numel_rnumel(node1)
 
@@ -2511,7 +2620,7 @@ class SIMDScheduling(BaseScheduling):
                 if node.get_outputs()[0].node.get_name() not in rename:
                     node.mark_run()
 
-        V.graph.wrapper_code.make_comment("# Call mix order reduction kernel")
+        V.graph.wrapper_code.make_comment(f"{V.graph.wrapper_code.comment} Call mix order reduction kernel")
         self.codegen_comment(node_schedule, None)
         # workspace args is still needed after the call
         kernel.call_kernel(kernel.kernel_name, deallocate_ws=False)
@@ -2530,6 +2639,13 @@ class SIMDScheduling(BaseScheduling):
         )
         for idx, partial_accum in enumerate(kernel.saved_partial_accumulate):
             buffer_name = partial_accum.buffer_name
+
+            if V.graph.cpp_wrapper:
+                # The python wrapper emits the outer reduction as raw tensor
+                # ops (ws[...].view(...).sum(dim=0)), which cpp_wrapper cannot
+                # compile. Route it through normal kernel codegen instead.
+                self._codegen_mix_order_workspace_reduction(kernel, ws_name, idx, partial_accum, numel, rnumel, split_size)
+                continue
 
             stride_str = f"({nsplit}) * ({rnumel})"
             start = f"{idx} * {stride_str}"

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -348,10 +348,6 @@ class MixOrderReduction:
         if not config.triton.mix_order_reduction:
             return False
 
-        # TODO: Mix order reduction is not supported with cpp_wrapper yet
-        if V.graph.cpp_wrapper:
-            return False
-
         if not _is_gpu_triton_backend(node1, node2):
             return False
         if not node1.is_reduction() or not node2.is_reduction():


### PR DESCRIPTION
Enable `tirton.mix_order_reduction` when `cpp_wrapper=True` on CUDA.

1. **Kernel signature / arg filtering.** The mix-order fused kernel carries a `NUM_STAGES` `tl.constexpr` that `CppWrapper.Gpu._resolve_lazy_arg_names` did not filter (its `internal_config_re` only matched `BLOCK`/`RSPLIT`), causing an arg-count mismatch at wrapper generation time.
    2. Extend the regex to include `NUM_STAGES`
2. **Workspace outer reduction codegen.** The outer reduction over the workspace cannot be emitted as Python tensor ops under cpp_wrapper.
    3. When `V.graph.cpp_wrapper`, re-express the reduction as Inductor IR (`ir.Reduction` over an `ir.ReinterpretView` of the workspace buffer) and graft it onto the original output `ComputedBuffer`, so it flows through the normal Triton kernel codegen path cpp_wrapper already supports. Also use `V.graph.wrapper_code.comment` for the mix-order comment so it is `//` under cpp_wrapper instead of `#`.

Authored with Claude Opus 4.8 via Cursor.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo