### PR TITLE
[#4068] Handle reduce storage for XPU

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -629,6 +629,7 @@ coverage_ignore_functions = [
     "init_reductions",
     "rebuild_cuda_tensor",
     "rebuild_meta_tensor",
+    "rebuild_xpu_tensor",
     "rebuild_event",
     "rebuild_nested_tensor",
     "rebuild_sparse_coo_tensor",

--- a/torch/multiprocessing/reductions.py
+++ b/torch/multiprocessing/reductions.py
@@ -150,6 +150,37 @@ def rebuild_meta_tensor(
     return t
 
 
+def rebuild_xpu_tensor(
+    tensor_cls,
+    tensor_size,
+    tensor_stride,
+    tensor_offset,
+    dtype,
+    storage_device,
+    storage_size_bytes,
+    requires_grad,
+):
+    untyped_storage = torch.UntypedStorage(storage_size_bytes, device=storage_device)
+
+    typed_storage = torch.TypedStorage(
+        wrap_storage=untyped_storage, dtype=dtype, _internal=True
+    )
+
+    t = torch._utils._rebuild_tensor(
+        typed_storage,
+        tensor_offset,
+        tensor_size,
+        tensor_stride,
+    )
+
+    if tensor_cls == torch.nn.parameter.Parameter:
+        t = torch.nn.parameter.Parameter(t, requires_grad=requires_grad)
+    else:
+        t.requires_grad = requires_grad
+
+    return t
+
+
 def rebuild_cuda_tensor(
     tensor_cls,
     tensor_size,
@@ -386,6 +417,24 @@ def reduce_tensor(tensor):
                 tensor.requires_grad,
             ),
         )
+    elif storage._untyped_storage.device.type == "xpu":
+        if tensor.numel() != 0:
+            raise RuntimeError(
+                "Multiprocessing of non-empty XPU tensors is not supported"
+            )
+        return (
+            rebuild_xpu_tensor,
+            (
+                type(tensor),
+                tensor.size(),
+                tensor.stride(),
+                tensor.storage_offset(),
+                tensor.dtype,
+                storage._untyped_storage.device,
+                tensor.untyped_storage().nbytes(),
+                tensor.requires_grad,
+            ),
+        )
 
     # _backward_hooks purposely omitted here, see Note [Don't serialize hooks]
     metadata = (
@@ -597,6 +646,10 @@ def reduce_storage(storage):
     elif storage.device.type == "meta":
         raise RuntimeError(
             "Cannot pickle meta storage; try pickling a meta tensor instead"
+        )
+    elif storage.device.type == "xpu":
+        raise RuntimeError(
+            "Cannot pickle XPU storage; try pickling an XPU tensor instead"
         )
     elif get_sharing_strategy() == "file_system":
         metadata = storage._share_filename_cpu_()


### PR DESCRIPTION
PR address xpu issue: https://github.com/intel/torch-xpu-ops/issues/4068. On Windows _test_empty_tensor_sharing_xpu test FAILED but on Linux due to how condition is created zero element was checked first and test PASSED. In both cases xpu empty tensor sharing was handled incorrectly. This change fix this problem and add xpu sharing empty tensor handling the same way CUDA handles it.