### PR TITLE
[ONNX] Clarify that output_names labels outputs but does not reorder them

### DIFF
--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -128,6 +128,9 @@ def export(
         verbose: Whether to enable verbose logging.
         input_names: names to assign to the input nodes of the graph, in order.
         output_names: names to assign to the output nodes of the graph, in order.
+            These are labels only and do not affect the order of outputs. If the model
+            returns a dictionary, outputs are flattened in the dictionary's iteration
+            order regardless of the names specified here.
         opset_version: The version of the
             `default (ai.onnx) opset <https://github.com/onnx/onnx/blob/master/docs/Operators.md>`_
             to target. You should set ``opset_version`` according to the supported opset versions

--- a/torch/onnx/_internal/torchscript_exporter/utils.py
+++ b/torch/onnx/_internal/torchscript_exporter/utils.py
@@ -323,7 +323,10 @@ def export(
         input_names (list of str, default empty list): names to assign to the
             input nodes of the graph, in order.
         output_names (list of str, default empty list): names to assign to the
-            output nodes of the graph, in order.
+            output nodes of the graph, in order. These are labels only and do not
+            affect the order of outputs. If the model returns a dictionary, outputs
+            are flattened in the dictionary's iteration order regardless of the
+            names specified here.
         operator_export_type (enum, default OperatorExportTypes.ONNX):
 
             .. warning::


### PR DESCRIPTION
Fixes #165758

## Summary

Users passing `output_names` to `torch.onnx.export` often expect it to select or reorder model outputs by name. It does not: the exporter flattens the model outputs (for a dict return, in the dict's iteration order) and applies the given names positionally, so a mismatched ordering silently mislabels outputs. As @justinchuby noted in the issue:

> The output_names argument specifies a renaming behavior rather than a selection. We should make it clear in the documentation.

This PR clarifies the `output_names` documentation in both the new exporter entry point (`torch/onnx/__init__.py`) and the torchscript exporter (`torch/onnx/_internal/torchscript_exporter/utils.py`) to state that the names are labels only and do not affect output order.

This revives #175796, which was approved by @justinchuby but closed by the stale bot when the author went inactive. Credit to @JStoschek for the original wording.

## Test Plan

Docs-only change; verified the edited files still parse:

```
python3 -m py_compile torch/onnx/__init__.py torch/onnx/_internal/torchscript_exporter/utils.py
```

Authored with the assistance of an AI assistant (Claude Code).

cc @justinchuby