### PR TITLE
[ATen] Add reduction tag to missing base reduction ops

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3971,9 +3971,11 @@
 - func: nanmean(Tensor self, int[1]? dim=None, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor
   device_check: NoCheck   # Composite
   variants: function, method
+  tags: reduction
 
 - func: nanmean.out(Tensor self, int[1]? dim=None, bool keepdim=False, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # Composite
+  tags: reduction
 
 - func: median(Tensor self) -> Tensor
   variants: function, method
@@ -3983,11 +3985,13 @@
     MPS: median_mps
     XPU: median_xpu
   autogen: median.out
+  tags: reduction
 
 - func: median.dim(Tensor self, int dim, bool keepdim=False) -> (Tensor values, Tensor indices)
   variants: function, method
   dispatch:
     CompositeExplicitAutograd: median
+  tags: reduction
 
 - func: median.dim_values(Tensor self, int dim, bool keepdim=False, *, Tensor(a!) values, Tensor(b!) indices) -> (Tensor(a!) values, Tensor(b!) indices)
   dispatch:
@@ -3995,6 +3999,7 @@
     CUDA: median_out_cuda
     MPS: median_out_mps
     XPU: median_out_xpu
+  tags: reduction
 
 - func: nanmedian(Tensor self) -> Tensor
   variants: function, method
@@ -4004,11 +4009,13 @@
     MPS: nanmedian_mps
     XPU: nanmedian_xpu
   autogen: nanmedian.out
+  tags: reduction
 
 - func: nanmedian.dim(Tensor self, int dim, bool keepdim=False) -> (Tensor values, Tensor indices)
   variants: function, method
   dispatch:
     CompositeExplicitAutograd: nanmedian
+  tags: reduction
 
 - func: nanmedian.dim_values(Tensor self, int dim, bool keepdim=False, *, Tensor(a!) values, Tensor(b!) indices) -> (Tensor(a!) values, Tensor(b!) indices)
   dispatch:
@@ -4016,6 +4023,7 @@
     CUDA: nanmedian_out_cuda
     MPS: nanmedian_out_mps
     XPU: nanmedian_out_xpu
+  tags: reduction
 
 - func: min.dim(Tensor self, int dim, bool keepdim=False) -> (Tensor values, Tensor indices)
   device_check: NoCheck   # TensorIterator
@@ -4240,10 +4248,12 @@
   variants: function, method
   dispatch:
     CPU, CUDA, XPU: mode
+  tags: reduction
 
 - func: mode.values(Tensor self, int dim=-1, bool keepdim=False, *, Tensor(a!) values, Tensor(b!) indices) -> (Tensor(a!) values, Tensor(b!) indices)
   dispatch:
     CompositeExplicitAutograd: mode_out
+  tags: reduction
 
 - func: mul.Tensor(Tensor self, Tensor other) -> Tensor
   device_check: NoCheck   # TensorIterator
@@ -8892,6 +8902,7 @@
     MPS: trace_mps
     XPU: trace_xpu
   autogen: trace.out
+  tags: reduction
 
 - func: trace_backward(Tensor grad, SymInt[] sizes) -> Tensor
   variants: function
@@ -9714,6 +9725,7 @@
   dispatch:
     CompositeExplicitAutograd: dist
   autogen: dist.out
+  tags: reduction
 
 - func: atan2.out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
@@ -13888,9 +13900,11 @@
 - func: special_logsumexp(Tensor self, int[1] dim, bool keepdim=False) -> Tensor
   python_module: special
   variants: function
+  tags: reduction
 
 - func: special_logsumexp.out(Tensor self, int[1] dim, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
   python_module: special
+  tags: reduction
 
 - func: special_expit(Tensor self) -> Tensor
   python_module: special


### PR DESCRIPTION
Fixes #129020 (partial)

Follow-up to #165155. Extends the `reduction` tag to base reduction operators
that were not addressed in the original PR. Each newly tagged op is directly
analogous to a currently tagged reduction, so this is a mechanical extension
of the existing tag definition — no new semantics.

### Newly tagged ops

| Op | Rationale |
| --- | --- |
| `nanmean`, `nanmean.out` | mirrors `mean.*` (already tagged) |
| `median`, `median.dim`, `median.dim_values` | dim reduction, mirrors `min.dim`/`max.dim` |
| `nanmedian`, `nanmedian.dim`, `nanmedian.dim_values` | mirror of `median.*` |
| `mode`, `mode.values` | dim reduction returning `(values, indices)` like `min.dim` |
| `trace` | sum over the diagonal — reduces 2D tensor to a scalar |
| `dist` | `norm(a - b)` — reduces to a scalar |
| `special_logsumexp`, `special_logsumexp.out` | identical to `logsumexp.*`, just in `torch.special` |

All 14 additions are `+  tags: reduction` on an existing YAML block; no
existing tags are modified.

### Scope

Intentionally excluded from this PR to keep it focused:
- `quantile` / `nanquantile` — multiple `q`-scalar vs `q`-tensor overloads
- `linalg_norm` / `linalg_matrix_norm` / `frobenius_norm` / `nuclear_norm`
- Private / foreach / sparse variants

Those can be follow-up PRs once this lands.

### Context

Per @eellison on #169944:
> The reduction tag has already been added. if there are any missing ops,
> please submit a pr to add them.

cc @eellison

### Test plan

Only `aten/src/ATen/native/native_functions.yaml` is modified.
- No existing test enforces or blocks these additions:
  - `test_ops.py::test_reduction_tag_coverage` verifies stub-registered
    reductions in `ReduceOps.cpp` / `ReduceAllOps.h` are tagged; the ops
    added here are not stub-registered and are unaffected.
  - `test_ops.py::test_reduction_ops_reduce` iterates OpInfo samples of
    tagged ops and checks `numel` is divided by the reduction factor when a
    `dim` kwarg is present. Ops added here that return `(values, indices)`
    (median.dim, nanmedian.dim, mode) are skipped by the
    `isinstance(result, torch.Tensor)` guard, and the tensor-returning
    additions (nanmean, special_logsumexp) reduce the requested dim exactly
    like their currently-tagged counterparts.
- Existing users of `torch.Tag.reduction` (inductor's `cat` lowering and
  `decomp_comms.py`) use the tag as an inclusion filter, so more tagged
  ops means strictly more optimizations, no behavior regressions.