### PR TITLE
[BE] Replace deprecated `wstring_convert`

### DIFF
--- a/c10/util/StringUtil.cpp
+++ b/c10/util/StringUtil.cpp
@@ -1,11 +1,9 @@
 #include <c10/util/StringUtil.h>
 
+#include <cstdint>
 #include <string>
 
-#ifndef _WIN32
-#include <codecvt>
-#include <locale>
-#else
+#ifdef _WIN32
 #include <c10/util/Unicode.h>
 #endif
 
@@ -43,16 +41,54 @@ static std::ostream& _strFromWide(
 
 #ifndef _WIN32
 
-C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wdeprecated-declarations")
-// TODO (huydhn) https://en.cppreference.com/w/cpp/header/codecvt has been
-// deprecated in C++17 but there is no alternative yet, so I just ack it
+// Decodes one code point from a UTF-16 sequence (one code unit per wchar_t,
+// matching the old std::codecvt_utf8_utf16 behavior), advancing `it` past the
+// consumed code unit(s) and combining a surrogate pair when present.
+static uint32_t decode_utf16_char(
+    std::wstring::const_iterator& it,
+    std::wstring::const_iterator end) {
+  uint32_t cp = static_cast<char16_t>(*it++);
+  if (cp >= 0xD800 && cp <= 0xDBFF && it != end) {
+    const char16_t low = static_cast<char16_t>(*it);
+    if (low >= 0xDC00 && low <= 0xDFFF) {
+      cp = 0x10000 + ((cp - 0xD800) << 10) + (low - 0xDC00);
+      ++it;
+    }
+  }
+  return cp;
+}
+
+// Appends the UTF-8 encoding of a single code point to `out`.
+static void encode_utf8_char(std::string& out, uint32_t cp) {
+  if (cp < 0x80) {
+    out.push_back(static_cast<char>(cp));
+  } else if (cp < 0x800) {
+    out.push_back(static_cast<char>(0xC0 | (cp >> 6)));
+    out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+  } else if (cp < 0x10000) {
+    out.push_back(static_cast<char>(0xE0 | (cp >> 12)));
+    out.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
+    out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+  } else {
+    out.push_back(static_cast<char>(0xF0 | (cp >> 18)));
+    out.push_back(static_cast<char>(0x80 | ((cp >> 12) & 0x3F)));
+    out.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
+    out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+  }
+}
+
 static std::ostream& _strFromWide(
     std::ostream& ss,
     const std::wstring& wString) {
-  std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-  return _str(ss, converter.to_bytes(wString));
+  std::string result;
+  result.reserve(wString.size());
+  auto it = wString.begin();
+  const auto end = wString.end();
+  while (it != end) {
+    encode_utf8_char(result, decode_utf16_char(it, end));
+  }
+  return _str(ss, result);
 }
-C10_DIAGNOSTIC_POP()
 
 #else // #ifndef _WIN32
 // The WIN32 implementation of wstring_convert leaks memory; see

--- a/c10/util/StringUtil.cpp
+++ b/c10/util/StringUtil.cpp
@@ -1,6 +1,7 @@
 #include <c10/util/StringUtil.h>
 
 #include <cstdint>
+#include <stdexcept>
 #include <string>
 
 #ifdef _WIN32
@@ -41,25 +42,37 @@ static std::ostream& _strFromWide(
 
 #ifndef _WIN32
 
-// Decodes one code point from a UTF-16 sequence (one code unit per wchar_t,
-// matching the old std::codecvt_utf8_utf16 behavior), advancing `it` past the
-// consumed code unit(s) and combining a surrogate pair when present.
+// Decodes one code point from a UTF-16 sequence, advancing `it` past the
+// consumed code unit(s) and combining a surrogate pair when present. Each
+// wchar_t is treated as a single UTF-16 code unit: on platforms where wchar_t
+// is 32-bit, values above 0xFFFF are truncated to 16 bits, matching the old
+// std::codecvt_utf8_utf16 behavior this replaced. An unpaired surrogate is
+// malformed UTF-16 and throws, as the old codecvt path did.
 static uint32_t decode_utf16_char(
     std::wstring::const_iterator& it,
     std::wstring::const_iterator end) {
-  uint32_t cp = static_cast<char16_t>(*it++);
-  if (cp >= 0xD800 && cp <= 0xDBFF && it != end) {
-    const char16_t low = static_cast<char16_t>(*it);
-    if (low >= 0xDC00 && low <= 0xDFFF) {
-      cp = 0x10000 + ((cp - 0xD800) << 10) + (low - 0xDC00);
-      ++it;
-    }
+  const char16_t high = static_cast<char16_t>(*it++);
+  if (high < 0xD800 || high > 0xDFFF) {
+    return high;
   }
-  return cp;
+  if (high > 0xDBFF) {
+    throw std::range_error("invalid UTF-16: unpaired low surrogate");
+  }
+  if (it == end) {
+    throw std::range_error("invalid UTF-16: truncated surrogate pair");
+  }
+  const char16_t low = static_cast<char16_t>(*it++);
+  if (low < 0xDC00 || low > 0xDFFF) {
+    throw std::range_error("invalid UTF-16: unpaired high surrogate");
+  }
+  return 0x10000 + ((static_cast<uint32_t>(high) - 0xD800) << 10) +
+      (static_cast<uint32_t>(low) - 0xDC00);
 }
 
-// Appends the UTF-8 encoding of a single code point to `out`. Code points
-// outside the Unicode range are emitted as U+FFFD (replacement character).
+// Appends the UTF-8 encoding of a single code point to `out`. decode_utf16_char
+// truncates each code unit to 16 bits and caps surrogate pairs at U+10FFFF, so
+// cp can never exceed U+10FFFF here; the clamp below is purely defensive and in
+// practice never fires.
 static void encode_utf8_char(std::string& out, uint32_t cp) {
   if (cp > 0x10FFFF) {
     cp = 0xFFFD;

--- a/c10/util/StringUtil.cpp
+++ b/c10/util/StringUtil.cpp
@@ -58,22 +58,23 @@ static uint32_t decode_utf16_char(
   return cp;
 }
 
-// Appends the UTF-8 encoding of a single code point to `out`.
+// Appends the UTF-8 encoding of a single code point to `out`. Code points
+// outside the Unicode range are emitted as U+FFFD (replacement character).
 static void encode_utf8_char(std::string& out, uint32_t cp) {
+  if (cp > 0x10FFFF) {
+    cp = 0xFFFD;
+  }
   if (cp < 0x80) {
     out.push_back(static_cast<char>(cp));
-  } else if (cp < 0x800) {
-    out.push_back(static_cast<char>(0xC0 | (cp >> 6)));
-    out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
-  } else if (cp < 0x10000) {
-    out.push_back(static_cast<char>(0xE0 | (cp >> 12)));
-    out.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
-    out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
-  } else {
-    out.push_back(static_cast<char>(0xF0 | (cp >> 18)));
-    out.push_back(static_cast<char>(0x80 | ((cp >> 12) & 0x3F)));
-    out.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
-    out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+    return;
+  }
+  // Number of continuation bytes; the leading byte has `trailing + 1` high
+  // bits set (0xC0, 0xE0, 0xF0 for 1, 2, 3 continuation bytes).
+  int trailing = cp < 0x800 ? 1 : (cp < 0x10000 ? 2 : 3);
+  const uint32_t lead_mask = (0xFF << (7 - trailing)) & 0xFF;
+  out.push_back(static_cast<char>(lead_mask | (cp >> (6 * trailing))));
+  for (int shift = 6 * (trailing - 1); shift >= 0; shift -= 6) {
+    out.push_back(static_cast<char>(0x80 | ((cp >> shift) & 0x3F)));
   }
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #188910
* __->__ #188904

With hand-rolled UTF-16 to UTF-8 converter, which is trivial loop of `decode_utf16`/`encode_utf8` rather than adding more and more deprecation suppressions, and error out of utf16 string is malformed (same as `wstring_convert` does on MacOS-26)

TODO: Figure out if this helper function at all makes sense outside of Windows platform, where it used to convert UTF-16 WIN32 error messages back into utf-8

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>