### PR TITLE
Add torch.utils.checkpoint.register_determinism_check

### DIFF
--- a/docs/source/checkpoint.md
+++ b/docs/source/checkpoint.md
@@ -42,4 +42,5 @@ output compared to non-checkpointed passes is never guaranteed.
 .. autoclass:: GraphExecGroup
 .. autofunction:: set_checkpoint_early_stop
 .. autofunction:: set_device_states
+.. autofunction:: register_determinism_check
 ```

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -45,10 +45,12 @@ from torch.utils._traceback import (
     report_compile_source_on_error,
 )
 from torch.utils.checkpoint import (
+    _allowed_determinism_checks_to_fns,
     _infer_device_type,
     checkpoint,
     checkpoint_sequential,
     get_device_states,
+    register_determinism_check,
 )
 from torch.utils.data import DataLoader
 
@@ -1133,6 +1135,73 @@ class TestDeviceLazyInit(TestCase):
 instantiate_device_type_tests(
     TestDeviceLazyInit, globals(), except_for=["cpu"], allow_xpu=True
 )
+
+
+class TestRegisterDeterminismCheck(TestCase):
+    def _register(self, name, metadata_fn):
+        register_determinism_check(name, metadata_fn)
+        self.addCleanup(_allowed_determinism_checks_to_fns.pop, name, None)
+
+    def test_custom_check_is_used_by_checkpoint(self):
+        calls = []
+
+        def metadata_fn(x):
+            calls.append(x.shape)
+            return {"shape": x.shape, "dtype": x.dtype}
+
+        def fn(x):
+            return torch.sigmoid(x.exp())
+
+        self._register("test_shape_dtype", metadata_fn)
+        a = torch.randn(3, requires_grad=True)
+        out = checkpoint(
+            fn, a, use_reentrant=False, determinism_check="test_shape_dtype"
+        )
+        self.assertTrue(len(calls) > 0)
+        out.sum().backward()
+        self.assertEqual(a.grad.shape, a.shape)
+
+    def test_custom_check_detects_mismatch(self):
+        counter = [0]
+
+        def metadata_fn(x):
+            # Returns different metadata on forward vs. recompute
+            counter[0] += 1
+            return counter[0]
+
+        def fn(x):
+            return torch.sigmoid(x.exp())
+
+        self._register("test_always_mismatch", metadata_fn)
+        a = torch.randn(3, requires_grad=True)
+        out = checkpoint(
+            fn, a, use_reentrant=False, determinism_check="test_always_mismatch"
+        )
+        with self.assertRaisesRegex(
+            torch.utils.checkpoint.CheckpointError,
+            "Recomputed values for the following tensors have different",
+        ):
+            out.sum().backward()
+
+    def test_register_existing_name_raises(self):
+        with self.assertRaisesRegex(ValueError, "already registered"):
+            register_determinism_check("default", lambda x: x.shape)
+        self._register("test_dupe", lambda x: x.shape)
+        with self.assertRaisesRegex(ValueError, "already registered"):
+            register_determinism_check("test_dupe", lambda x: x.shape)
+
+    def test_register_non_callable_raises(self):
+        with self.assertRaisesRegex(TypeError, "must be callable"):
+            register_determinism_check("test_non_callable", "not a function")  # type: ignore[arg-type]
+
+    def test_unknown_check_error_lists_registered_names(self):
+        def fn(x):
+            return x.sin()
+
+        self._register("test_listed", lambda x: x.shape)
+        a = torch.randn(3, requires_grad=True)
+        with self.assertRaisesRegex(ValueError, "test_listed"):
+            checkpoint(fn, a, use_reentrant=False, determinism_check="not_a_check")
 
 
 if __name__ == "__main__":

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -39,6 +39,7 @@ __all__ = [
     "create_selective_checkpoint_contexts",
     "SAC_IGNORED_OPS",
     "GraphExecGroup",
+    "register_determinism_check",
 ]
 
 _DEFAULT_DETERMINISM_MODE = "default"
@@ -466,9 +467,9 @@ def checkpoint(
             check to perform. By default it is set to ``"default"`` which
             compares the shapes, dtypes, and devices of the recomputed tensors
             against those the saved tensors. To turn off this check, specify
-            ``"none"``. Currently these are the only two supported values.
-            Please open an issue if you would like to see more determinism
-            checks. This argument is only supported if ``use_reentrant=False``,
+            ``"none"``. Custom checks can be added with
+            :func:`~torch.utils.checkpoint.register_determinism_check`.
+            This argument is only supported if ``use_reentrant=False``,
             if ``use_reentrant=True``, the determinism check is always disabled.
         debug(bool, optional): If ``True``, error messages will also include
             a trace of the operators ran during the original forward computation
@@ -1080,6 +1081,48 @@ _allowed_determinism_checks_to_fns: Dict[str, Callable[[torch.Tensor], Any]] = {
     "none": lambda _: None,
 }
 
+
+def register_determinism_check(
+    name: str, metadata_fn: Callable[[torch.Tensor], Any]
+) -> None:
+    r"""Registers a custom determinism check for use with checkpoint.
+
+    When ``determinism_check=name`` is passed to
+    :func:`~torch.utils.checkpoint.checkpoint` with ``use_reentrant=False``,
+    ``metadata_fn`` is applied to every tensor saved for backward during the
+    original forward pass and again during recomputation. If the two results
+    compare unequal for any tensor, a :class:`CheckpointError` is raised.
+
+    Args:
+        name (str): the value to pass as ``determinism_check`` to select this
+            check. Registering an existing name, including the built-in names
+            ``"default"`` and ``"none"``, raises a :class:`ValueError`.
+        metadata_fn (Callable): a callable that takes a :class:`torch.Tensor`
+            and returns metadata that supports ``==`` comparison, e.g. a dict
+            of tensor properties.
+
+    Example:
+        >>> # xdoctest: +SKIP
+        >>> def check_with_strides(x):
+        ...     return {
+        ...         "shape": x.shape,
+        ...         "dtype": x.dtype,
+        ...         "device": x.device,
+        ...         "stride": x.stride(),
+        ...     }
+        >>> torch.utils.checkpoint.register_determinism_check(
+        ...     "default_and_strides", check_with_strides
+        ... )
+        >>> out = checkpoint(
+        ...     fn, x, use_reentrant=False, determinism_check="default_and_strides"
+        ... )
+    """
+    if not callable(metadata_fn):
+        raise TypeError(f"metadata_fn must be callable, got {type(metadata_fn)}")
+    if name in _allowed_determinism_checks_to_fns:
+        raise ValueError(f"Determinism check '{name}' is already registered")
+    _allowed_determinism_checks_to_fns[name] = metadata_fn
+
 # See Rule 5
 class _StopRecomputationError(Exception):
     pass
@@ -1583,9 +1626,8 @@ def _checkpoint_without_reentrant_generator(
             check to perform. By default it is set to ``"default"`` which
             compares the shapes, dtypes, and devices of the recomputed tensors
             against those the saved tensors. To turn off this check, specify
-            ``"none"``. Currently these are the only two supported values.
-            Please open an issue if you would like to see more determinism
-            checks.
+            ``"none"``. Custom checks can be added with
+            :func:`~torch.utils.checkpoint.register_determinism_check`.
         debug(bool, optional): If ``True``, error messages will also include
             a trace of the operators ran during the original forward computation
             as well as the recomputation.


### PR DESCRIPTION
Fixes #162980

## Summary

The `determinism_check` argument of `torch.utils.checkpoint.checkpoint` looks up its metadata function in the module-private dict `_allowed_determinism_checks_to_fns`, so users who want a custom check (e.g. one that also compares strides, or ignores devices) have to monkey-patch the dict. As @soulitzer said in the issue: "We'd accept a PR to add this."

This adds a public `register_determinism_check(name, metadata_fn)`:

- validates `metadata_fn` is callable and `name` isn't already registered (including the built-ins `"default"` and `"none"`),
- documents the contract (applied to every saved tensor on forward and recompute; results compared with `==`; mismatch raises `CheckpointError`),
- exports it in `__all__` and the `torch.utils.checkpoint` docs page, and updates the two `determinism_check` docstrings that said "these are the only two supported values".

**API scope note:** I deliberately kept the surface minimal (register only, no unregister/list) — the unknown-name error message already lists registered names dynamically, and unregistering has no clear use outside tests. Happy to extend if reviewers prefer the fuller trio.

## Test Plan

New `TestRegisterDeterminismCheck` in `test/test_utils.py`:

- registered check is actually invoked by `checkpoint(..., use_reentrant=False, determinism_check=<name>)` and gradients flow,
- a check returning different metadata between forward and recompute raises `CheckpointError` ("Recomputed values ... have different metadata"),
- duplicate / built-in names raise `ValueError`; non-callable raises `TypeError`,
- unknown `determinism_check` error message lists registered names.

```
$ python -m pytest test/test_utils.py::TestRegisterDeterminismCheck -v
5 passed
$ python -m pytest test/test_utils.py::TestCheckpoint -q
13 passed, 10 subtests passed
```

Verified on macOS (CPU) against a nightly wheel with the same patch applied.

Authored with the assistance of an AI assistant (Claude Code).

cc @soulitzer