### PR TITLE
[inductor] Fix autotuning HBM leak from retained config exception (#188907)

### DIFF
--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -1520,6 +1520,74 @@ class TestWarpSizeUnification(TestCase):
         self.assertEqual(cfg64.kwargs["XBLOCK"], 2 * cfg32.kwargs["XBLOCK"])
 
 
+class TestMakeLaunchersMemory(TestCase):
+    def test_failed_config_exception_not_retained(self):
+        """Regression (D107597017 / PR #184285): CachingAutotuner._make_launchers
+        must not retain the failed-config build exception past its return. That
+        exception's traceback pins its frame chain -- and via those frames' f_back
+        the benchmarking callers up to do_bench, whose 256MB Triton L2-flush buffer
+        then leaks one-per-autotuned-kernel until cyclic GC (which never runs under
+        gc.disable(), as APS training does). Pure reference-cycle check, no GPU: a
+        sentinel standing in for the L2 buffer, held only by a frame that calls
+        _make_launchers, must be freed by refcount once _make_launchers returns.
+        """
+        import contextlib
+        import gc
+        import types
+        import weakref
+
+        class _Result:
+            config = types.SimpleNamespace(num_stages=1, kwargs={})
+
+        results = [_Result(), _Result()]
+
+        def fake_make_launcher(result):
+            # First config builds; the last fails, returning a live exception whose
+            # traceback references this call stack -- as the real _make_launcher does
+            # for OutOfResources / OutOfMemoryError.
+            if result is results[0]:
+                return object(), None
+            try:
+                raise RuntimeError("out of resource (test)")
+            except RuntimeError as e:
+                return None, e
+
+        fake_self = types.SimpleNamespace(
+            launchers=[],
+            compile_results=results,
+            triton_meta={"device": 0},
+            inductor_meta={},
+            get_device_interface=lambda: None,
+            _make_launcher=fake_make_launcher,
+        )
+
+        class _Sentinel:
+            pass
+
+        def run():
+            l2_buffer = _Sentinel()  # stands in for do_bench's L2-flush buffer
+            ref = weakref.ref(l2_buffer)
+            with patch(
+                "torch._dynamo.device_interface.DeviceGuard",
+                lambda *args, **kwargs: contextlib.nullcontext(),
+            ):
+                CachingAutotuner._make_launchers(fake_self)
+            return ref
+
+        gc.disable()
+        try:
+            ref = run()
+            self.assertIsNone(
+                ref(),
+                "_make_launchers retained the failed-config exception; its traceback "
+                "pins caller frames (do_bench's L2-flush buffer) until cyclic GC.",
+            )
+        finally:
+            gc.enable()
+
+        self.assertEqual(len(fake_self.launchers), 1)
+
+
 if __name__ == "__main__":
     if IS_LINUX and HAS_GPU:
         run_tests()

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1014,28 +1014,37 @@ class CachingAutotuner(KernelInterface):
         device_interface = self.get_device_interface()
         launchers = []
         exc = None
-        # DeviceGuard ensures each launcher's binary loads onto the right device.
-        with DeviceGuard(device_interface, cast(int, self.triton_meta["device"])):
-            for result in self.compile_results:
-                launcher, exc = self._make_launcher(result)
-                if launcher is not None:
-                    launchers.append(launcher)
-            if len(launchers) == 0:
-                result = self.compile_results[-1]
-                config = result.config
-                if (
-                    isinstance(exc, (OutOfResources, torch.cuda.OutOfMemoryError))
-                    and (
-                        config.num_stages > 1 or config.kwargs.get("NUM_STAGES", 1) > 1
+        try:
+            # DeviceGuard ensures each launcher's binary loads onto the right device.
+            with DeviceGuard(device_interface, cast(int, self.triton_meta["device"])):
+                for result in self.compile_results:
+                    launcher, exc = self._make_launcher(result)
+                    if launcher is not None:
+                        launchers.append(launcher)
+                if len(launchers) == 0:
+                    result = self.compile_results[-1]
+                    config = result.config
+                    if (
+                        isinstance(exc, (OutOfResources, torch.cuda.OutOfMemoryError))
+                        and (
+                            config.num_stages > 1
+                            or config.kwargs.get("NUM_STAGES", 1) > 1
+                        )
+                        and self.inductor_meta.get("dynamic_disable_pipelining", True)
+                    ):
+                        self.launchers = [self.compile_by_disabling_pipelining(config)]
+                        return
+                    raise RuntimeError(
+                        f"No valid triton configs. {type(exc).__name__}: {exc}"
                     )
-                    and self.inductor_meta.get("dynamic_disable_pipelining", True)
-                ):
-                    self.launchers = [self.compile_by_disabling_pipelining(config)]
-                    return
-                raise RuntimeError(
-                    f"No valid triton configs. {type(exc).__name__}: {exc}"
-                )
-        self.launchers = launchers
+            self.launchers = launchers
+        finally:
+            # Drop the retained failed-config exception. Holding it keeps its traceback
+            # (and thus the whole benchmarking frame chain up to do_bench via f_back)
+            # alive; do_bench's 256MB L2-flush buffer would then leak one-per-autotuned
+            # kernel until cyclic GC runs -- which never happens under gc.disable(). We
+            # only needed exc's type/message above.
+            exc = None
 
     def _prune_compile_results_to_launcher(self, launcher: LauncherType) -> None:
         if not self.compile_results:


### PR DESCRIPTION
Summary:

During GEMM template autotuning, CachingAutotuner._make_launchers keeps the last
failed config's build exception in a local (`exc`). That exception's
__traceback__ retains its frame chain and, via those frames' f_back, the
benchmarking callers up to Triton's do_bench -- whose 256MB L2-cache-flush buffer
is then pinned. exc <-> traceback <-> frame is a reference cycle only cyclic GC
can reclaim, so when the caller has disabled cyclic GC (as APS training loops do)
one 256MB buffer leaks per autotuned kernel whose last-tried config fails
(routine in max-autotune: large BLOCK configs exceed shared memory ->
OutOfResources). On a 128xGB300 APS job this accumulated to ~44GB of transient
HBM, ~63% of an 87GB peak high-water-mark.

Fix: drop the retained exception in a `finally` in _make_launchers (it is only
used for its type/message). This breaks the cycle so the buffer frees by refcount
without needing cyclic GC, and also releases the f_back chain up to do_bench.
Regression from D107597017 (PR #184285); preserves that change's
module-exhaustion fix.

Authored with Claude.

Test Plan:
Unit test (fails before this change, passes after):
  buck test fbcode//caffe2/test/inductor:triton_heuristics -- \
    TestMakeLaunchersMemory.test_failed_config_exception_not_retained

Repro: 24 distinct-shaped GEMMs, TritonBenchmarker, cold cache, gc.disable(),
on the job's package revision. Peak co-resident 256MB L2-flush buffers
(get_empty_cache_for_benchmark) 144 -> 1; peak allocated during autotuning
36.84GB -> 0.63GB. Identical benchmarking otherwise (582 do_bench allocs).

Reviewed By: williamwen42

Differential Revision: D110557608




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo