### PR TITLE
[dynamo] Report concrete set type in SetVariable.call_obj_hasattr

### DIFF
--- a/test/dynamo/test_sets.py
+++ b/test/dynamo/test_sets.py
@@ -22,6 +22,17 @@ class FrozenstSubclass(frozenset):
     pass
 
 
+class BadCmp:
+    # Elements collide on hash (so __eq__ runs during set insertion/lookup),
+    # and __eq__ raises so the error must propagate.  Mirrors CPython
+    # test_set.py BadCmp.
+    def __hash__(self):
+        return 1
+
+    def __eq__(self, other):
+        raise RuntimeError
+
+
 class _BaseSetTests(torch._dynamo.test_case.TestCase):
     def setUp(self):
         self.old = torch._dynamo.config.enable_trace_unittest
@@ -379,6 +390,20 @@ class _FrozensetBase:
         self.assertEqual(p ^ p, self.thetype())
         self.assertEqual(p ^ q, self.thetype("acef"))
         self.assertEqual(self.thetype.__xor__(p, q), set("acef"))
+
+    @make_dynamo_test
+    def test_badcmp(self):
+        # A comparison error during insertion/lookup must propagate as the
+        # user exception.  For frozenset types hasattr(s, "add") is False, so
+        # the mutating block is skipped (regression: exact frozenset used to
+        # report hasattr(set, "add")).  Mirrors CPython test_set.py test_badcmp.
+        s = self.thetype([BadCmp()])
+        self.assertRaises(RuntimeError, self.thetype, [BadCmp(), BadCmp()])
+        self.assertRaises(RuntimeError, s.__contains__, BadCmp())
+        if hasattr(s, "add"):
+            self.assertRaises(RuntimeError, s.add, BadCmp())
+            self.assertRaises(RuntimeError, s.discard, BadCmp())
+            self.assertRaises(RuntimeError, s.remove, BadCmp())
 
     @make_dynamo_test
     def test_cmp_eq(self):

--- a/torch/_dynamo/variables/sets.py
+++ b/torch/_dynamo/variables/sets.py
@@ -224,7 +224,7 @@ class SetVariable(VariableTracker):
     def call_obj_hasattr(
         self, tx: "InstructionTranslatorBase", name: str
     ) -> ConstantVariable:
-        return VariableTracker.build(tx, hasattr(set, name))
+        return VariableTracker.build(tx, hasattr(self.python_type(), name))
 
     def install_set_contains_guard(
         self, tx: "InstructionTranslatorBase", args: list[VariableTracker]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #188908

SetVariable.call_obj_hasattr answered hasattr(obj, name) against the fixed
`set` type, so for an exact frozenset it wrongly reported hasattr(s, "add")
== True. test_set TestFrozenSet.test_badcmp guards its mutating block with
`if hasattr(s, 'add'):`; under the bug that block ran on a frozenset and hit
"Illegal call_method add on a frozenset" (InternalTorchDynamoError).

Use self.python_type() so hasattr reflects the concrete type: frozenset (no
`add`), set (has `add`), OrderedSet, and dict_keys views. This also fixes a
latent bug where a dict_keys view wrongly reported set-mutator attributes.
The badcmp exception-propagation path (a user __eq__ that raises) is unchanged
-- it already propagates via the richcompare machinery, which is why the
non-frozenset badcmp variants already passed.

Removes the CPython313 test_set TestFrozenSet.test_badcmp expected-failure
sentinel. The two test_hash_effectiveness sentinels remain: they are
@skipIfTorchDynamo("slow"), not object-protocol gaps.

Test Plan:

```
CUDA_VISIBLE_DEVICES= PYTORCH_TESTING_DEVICE_ONLY_FOR=cpu PYTORCH_TEST_WITH_DYNAMO=1 \
  python test/cpython/v3_13/test_set.py TestFrozenSet.test_badcmp TestSet.test_badcmp \
  TestSetSubclass.test_badcmp TestFrozenSetSubclass.test_badcmp
python test/dynamo/test_sets.py -k badcmp
CUDA_VISIBLE_DEVICES= PYTORCH_TESTING_DEVICE_ONLY_FOR=cpu PYTORCH_TEST_WITH_DYNAMO=1 \
  python test/cpython/v3_13/test_set.py
```

All pass (full test_set.py: 623 OK/178 skipped, no XPASS; test_sets.py badcmp: 5 OK).

This change was authored with the help of an AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98