### PR TITLE
Strip +PTX from CUDA arch list on release/RC builds (in build_env_setup.py)

### DIFF
--- a/.ci/manywheel/build_env_setup.py
+++ b/.ci/manywheel/build_env_setup.py
@@ -84,14 +84,35 @@ TORCH_CUDA_ARCH_LIST_TABLE: dict[str, dict[str, set[int]]] = {
     },
 }
 
-# Architectures we additionally emit PTX for (forward-compat for newer GPUs).
+# Architectures we additionally emit PTX for on nightly/dev builds
+# (forward-compat for newer GPUs). Release/RC wheels ship SASS-only to keep
+# libtorch_cuda.so size down; see _ptx_arches().
 _PTX_ARCHES: set[int] = {120}
+
+
+def _is_release_build() -> bool:
+    """True for release / RC binary builds (vs nightly / dev builds).
+
+    Binary builds off a git tag (releases and RCs, e.g. v2.13.0 / v2.13.0-rc1)
+    get a ``PYTORCH_BUILD_VERSION`` with no ``.dev<date>`` suffix, while
+    nightlies do -- see .ci/pytorch/binary_populate_env.sh, which relies on the
+    same ``dev`` check for Triton pinning. A missing/empty version (local or
+    non-binary builds) is treated as non-release, so PTX is kept.
+    """
+    version = os.environ.get("PYTORCH_BUILD_VERSION", "")
+    return bool(version) and "dev" not in version
+
+
+def _ptx_arches() -> set[int]:
+    """PTX arches for this build: empty on release/RC, forward-compat set otherwise."""
+    return set() if _is_release_build() else _PTX_ARCHES
 
 
 def torch_cuda_arch_list(cuda_version: str, arch: str) -> str:
     """Format TORCH_CUDA_ARCH_LIST for the wheel build (";"-separated).
 
-    Returns e.g. "8.0;9.0;10.0;11.0;12.0+PTX" for cuda 13.x aarch64.
+    Returns e.g. "8.0;9.0;10.0;11.0;12.0+PTX" for cuda 13.x aarch64 on
+    nightly builds; release/RC builds omit the +PTX suffix (see _ptx_arches()).
 
     CUDA 13.x dropped sm_50/60/70, so we must NOT leave this empty --
     CMake's defaults still include compute_50 which nvcc 13 rejects with
@@ -102,8 +123,9 @@ def torch_cuda_arch_list(cuda_version: str, arch: str) -> str:
     archs = TORCH_CUDA_ARCH_LIST_TABLE[cuda_version].get(arch)
     if not archs:
         raise SystemExit(f"no TORCH_CUDA_ARCH_LIST for cuda {cuda_version} on {arch}")
+    ptx_arches = _ptx_arches()
     return ";".join(
-        f"{cc // 10}.{cc % 10}" + ("+PTX" if cc in _PTX_ARCHES else "")
+        f"{cc // 10}.{cc % 10}" + ("+PTX" if cc in ptx_arches else "")
         for cc in sorted(archs)
     )
 

--- a/scripts/release/apply-release-changes.sh
+++ b/scripts/release/apply-release-changes.sh
@@ -44,9 +44,12 @@ echo "XLA Changes"
 sed -i -e s#--quiet#-b\ r"${RELEASE_VERSION}"# .ci/pytorch/common_utils.sh
 sed -i -e s#.*#r"${RELEASE_VERSION}"# .github/ci_commit_pins/xla.txt
 
-# Strip +PTX from CUDA arch lists in release builds
+# Strip +PTX from CUDA arch lists in release builds. main keeps +PTX for
+# forward-compat on nightlies; releases ship SASS-only to keep wheel size down.
+# The arch list moved from build_cuda.sh into build_env_setup.py, where the
+# "+PTX" suffix is driven by the _PTX_ARCHES set, so empty that set.
 echo "Stripping +PTX from CUDA arch lists"
-sed -i 's/+PTX//' .ci/manywheel/build_cuda.sh
+sed -i 's/^_PTX_ARCHES: set\[int\] = .*/_PTX_ARCHES: set[int] = set()/' .ci/manywheel/build_env_setup.py
 
 # Regenerate templates
 export RELEASE_VERSION_TAG=${RELEASE_VERSION}

--- a/scripts/release/apply-release-changes.sh
+++ b/scripts/release/apply-release-changes.sh
@@ -44,13 +44,6 @@ echo "XLA Changes"
 sed -i -e s#--quiet#-b\ r"${RELEASE_VERSION}"# .ci/pytorch/common_utils.sh
 sed -i -e s#.*#r"${RELEASE_VERSION}"# .github/ci_commit_pins/xla.txt
 
-# Strip +PTX from CUDA arch lists in release builds. main keeps +PTX for
-# forward-compat on nightlies; releases ship SASS-only to keep wheel size down.
-# The arch list moved from build_cuda.sh into build_env_setup.py, where the
-# "+PTX" suffix is driven by the _PTX_ARCHES set, so empty that set.
-echo "Stripping +PTX from CUDA arch lists"
-sed -i 's/^_PTX_ARCHES: set\[int\] = .*/_PTX_ARCHES: set[int] = set()/' .ci/manywheel/build_env_setup.py
-
 # Regenerate templates
 export RELEASE_VERSION_TAG=${RELEASE_VERSION}
 ./.github/regenerate.sh


### PR DESCRIPTION
## Summary

Restore the pre-2.13 behavior where **release/RC** CUDA wheels ship **without `+PTX`**, while nightlies keep it for forward-compat.

### Background
`libtorch_cuda.so` grew ~80-90 MB from 2.12.1 to 2.13.0 (cu130): 2.13 started emitting `12.0+PTX` (sm_120 PTX) in the release wheels. The SASS arch set is unchanged; the growth is the embedded compute_120 PTX.

The branch-cut script `scripts/release/apply-release-changes.sh` was *supposed* to strip `+PTX` for releases, but it edited `.ci/manywheel/build_cuda.sh` — which was refactored into `.ci/manywheel/build_env_setup.py`. The `sed` silently became a no-op, so 2.13.0 shipped with `+PTX`.

### Fix
Detect release/RC builds in Python instead of relying on a branch-cut `sed`:

- `build_env_setup.py`: add `_is_release_build()` (true when `PYTORCH_BUILD_VERSION` is set and has no `.dev` suffix — i.e. tagged release/RC builds, per `binary_populate_env.sh`) and `_ptx_arches()`; emit `+PTX` only for nightly/dev builds.
- `apply-release-changes.sh`: drop the now-redundant/broken `+PTX` `sed`.

### Behavior (cuda 13.0, x86_64)
| Build | `PYTORCH_BUILD_VERSION` | arch list |
|---|---|---|
| nightly | `2.13.0.dev...+cu130` | `7.5;8.0;8.6;9.0;10.0;12.0+PTX` |
| RC / release | `2.13.0+cu130` | `7.5;8.0;8.6;9.0;10.0;12.0` |
| local / unset | `''` | `...;12.0+PTX` (safe default) |

This is drift-proof: the logic lives next to the arch table it depends on, keyed off a signal the repo already uses.

*Authored with AI assistance.*