### PR TITLE
[dynamo] Model list subclass __new__/__init__ arg handling to match CPython

### DIFF
--- a/test/dynamo/test_sequence_ops.py
+++ b/test/dynamo/test_sequence_ops.py
@@ -1121,6 +1121,83 @@ class TestRangeDynamicBounds(torch._dynamo.test_case.TestCase):
         self.assertEqual(fn(), [0, 1, 2, 3, 4])
 
 
+class TestListSubclassConstruction(torch._dynamo.test_case.TestCase):
+    # list subclass construction via list.__new__/list.__init__ mirrors CPython:
+    # list.__new__ ignores extra args/kwargs; list.__init__ tolerates (ignores)
+    # keyword args only when the type overrides __new__ (Argument Clinic guard).
+
+    def test_subclass_plain(self):
+        class subclass(list):
+            pass
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn():
+            u = subclass([1, 2])
+            return type(u) is subclass, list(u)
+
+        self.assertEqual(fn(), (True, [1, 2]))
+
+    def test_subclass_plain_kwarg_raises(self):
+        class subclass(list):
+            pass
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn():
+            try:
+                subclass(sequence=())
+                return "no_error"
+            except TypeError:
+                return "type_error"
+
+        self.assertEqual(fn(), "type_error")
+
+    def test_subclass_with_init(self):
+        class subclass_with_init(list):
+            def __init__(self, seq, newarg=None):
+                super().__init__(seq)
+                self.newarg = newarg
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn():
+            u = subclass_with_init([1, 2], newarg=3)
+            return type(u) is subclass_with_init, list(u), u.newarg
+
+        self.assertEqual(fn(), (True, [1, 2], 3))
+
+    def test_subclass_with_new(self):
+        class subclass_with_new(list):
+            def __new__(cls, seq, newarg=None):
+                self = super().__new__(cls, seq)
+                self.newarg = newarg
+                return self
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn():
+            u = subclass_with_new([1, 2], newarg=3)
+            return type(u) is subclass_with_new, list(u), u.newarg
+
+        self.assertEqual(fn(), (True, [1, 2], 3))
+
+    def test_plain_list_kwarg_raises(self):
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn():
+            seq = [1]
+            try:
+                list(seq, other=2)
+                return "no_error"
+            except TypeError:
+                return "type_error"
+
+        self.assertEqual(fn(), "type_error")
+
+    def test_new_ignores_multiple_extra_args(self):
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn():
+            return list.__new__(list, 1, 2, 3)
+
+        self.assertEqual(fn(), [])
+
+
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests
 

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -3530,14 +3530,20 @@ class ListBuiltinVariable(BaseBuiltinVariable):
         kwargs: dict[str, VariableTracker],
     ) -> VariableTracker:
         if name == "__new__":
-            if len(args) == 1 and not kwargs:
+            if args:
+                # list.__new__ (tp_new) ignores extra args and kwargs - only
+                # the first arg (the type) matters, so a list subclass with a
+                # custom __new__ calling super().__new__(cls, seq) yields an
+                # empty instance.  Pass init_args=[] so reconstruction emits
+                # base_cls.__new__(cls) without extras.
+                # https://github.com/python/cpython/blob/v3.13.0/Objects/listobject.c#L1289-L1300
                 list_vt = ListVariable([], mutation_type=ValueMutationNew())
                 if isinstance(args[0], ListBuiltinVariable):
                     return list_vt
                 return tx.output.side_effects.track_new_user_defined_object(
                     self,
                     args[0],
-                    args[1:],
+                    [],
                     tx=tx,
                 )
 

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -5196,6 +5196,27 @@ class UserDefinedListVariable(UserDefinedObjectVariable):
         if self._base_vt is None:
             raise AssertionError("_base_vt must not be None after initialization")
 
+    def call_method(
+        self,
+        tx: "InstructionTranslatorBase",
+        name: str,
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
+        # CPython's list.__init__ (Argument Clinic) enforces the no-keyword-args
+        # check only when the type does not override __new__ (tp_new). A list
+        # subclass with a custom __new__ tolerates and ignores keyword args; the
+        # positional count is still validated by the base __init__.
+        # https://github.com/python/cpython/blob/v3.13.0/Objects/clinic/listobject.c.h
+        if (
+            name == "__init__"
+            and kwargs
+            and self._maybe_get_baseclass_method(name) is list.__init__
+            and type(self.value).__new__ is not list.__new__
+        ):
+            kwargs = {}
+        return super().call_method(tx, name, args, kwargs)
+
 
 class UserDefinedDequeVariable(UserDefinedObjectVariable):
     """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

Root cause: CPython's list.__new__ (tp_new = PyType_GenericNew) ignores all
args and kwargs, so super().__new__(cls, seq) just returns an empty instance.
Its list.__init__ (Argument Clinic) rejects keyword arguments only when the
type does not override __new__ (Py_TYPE(self)->tp_new == PyList_Type.tp_new);
a subclass with a custom __new__ tolerates and ignores keyword args. Dynamo
modeled neither behavior, so a local list subclass overriding __new__ and
constructed with a keyword arg failed twice: an "Unsupported method call" on
__new__ (extra args), then a spurious kwargs TypeError from the inherited
list.__init__ (tp_init).

Fix: ListBuiltinVariable.__new__ now ignores extra args/kwargs, passing
init_args=[] so reconstruction emits base_cls.__new__(cls) without extras.
UserDefinedListVariable.call_method drops kwargs before the inherited
list.__init__ only when the subclass overrides __new__, so a plain subclass
or plain list still rejects keyword args and the positional-count validation
still runs.

Removes the test_list ListTest.test_keywords_in_subclass expected-failure
sentinel.

Test Plan:

```
CUDA_VISIBLE_DEVICES= PYTORCH_TESTING_DEVICE_ONLY_FOR=cpu PYTORCH_TEST_WITH_DYNAMO=1 \
    python test/cpython/v3_13/test_list.py ListTest.test_keywords_in_subclass
python test/dynamo/test_sequence_ops.py -k TestListSubclassConstruction
python test/dynamo/test_sequence_ops.py
```

All pass (156 tests in the full suite, 1 pre-existing expected failure).

This PR was authored with the assistance of an AI coding assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98