### PR TITLE
[dynamo] Let an uncaught unittest.SkipTest skip the frame, not graph-break

### DIFF
--- a/test/dynamo/test_unittest.py
+++ b/test/dynamo/test_unittest.py
@@ -26,6 +26,17 @@ class TestUnittest(torch._dynamo.test_case.TestCase):
             z = 1
         self.assertEqual(z, 1)
 
+    def test_uncaught_SkipTest_propagates(self):
+        # An unhandled unittest.SkipTest at the top of a compiled frame is
+        # test-runner control flow: it must propagate as a real SkipTest (so
+        # the test is reported skipped) instead of a hard graph break.
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(x):
+            raise unittest.SkipTest("skip me")
+
+        with self.assertRaises(unittest.SkipTest):
+            fn(torch.randn(3))
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -45,6 +45,7 @@ import threading
 import time
 import traceback
 import types
+import unittest
 import weakref
 from collections import defaultdict, deque
 from typing import Any, cast, NoReturn, TYPE_CHECKING, TypeAlias, TypeVar
@@ -2749,6 +2750,15 @@ class InstructionTranslatorBase(
                 raise AssertionError(
                     "expected isinstance(raised_exception, dynamo_exc) to be true"
                 )  # sanity check
+            # unittest.SkipTest is test-runner control flow, not a real error:
+            # skip the frame and let eager re-raise the actual SkipTest so the
+            # test is reported as skipped rather than a hard graph break. This
+            # matches eager, where the same raise skips the test.
+            if issubclass(curr_exc.python_type(), unittest.SkipTest):
+                raise exc.SkipFrame(
+                    f"Skipping frame: {curr_exc.python_type().__name__} raised "
+                    "at the top level of the compiled function."
+                )
             unimplemented(
                 gb_type="Observed exception",
                 context=f"raised exception {curr_exc.debug_repr()}",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #188919

test_small_stability is @slowTest; with PYTORCH_TEST_WITH_SLOW unset the
slowTest wrapper does `raise unittest.SkipTest(...)` at the top of the
compiled frame. Dynamo found no handler and routed the observed exception
through bubble_exception_to_interpreter -> unimplemented("Observed
exception"), a hard Unsupported error under nopython. The test body itself
traces and passes (verified with slow enabled); only the skip machinery broke.

A unittest.SkipTest is test-runner control flow, not a tracing failure -- in
eager it simply skips the test. When such an exception reaches the top of a
compiled frame unhandled, raise exc.SkipFrame so the frame is re-run in eager
and the real SkipTest propagates, matching eager. This is scoped strictly to
SkipTest subclasses, so genuine uncaught exceptions still surface as
Unsupported under nopython. Core Dynamo already couples to unittest elsewhere
(trace_rules.py skip decisions, eval_frame.py), so the module-level import
adds no new dependency; SkipFrame here reuses the same empty-graph eager
fallback the "No ops traced" path already uses.

Removes the CPython313 test_sort TestBase.test_small_stability
expected-failure sentinel; it now reports skipped (not passed), like eager.

Test Plan:

```
CUDA_VISIBLE_DEVICES= PYTORCH_TESTING_DEVICE_ONLY_FOR=cpu PYTORCH_TEST_WITH_DYNAMO=1 \
  python test/cpython/v3_13/test_sort.py TestBase.test_small_stability
python test/dynamo/test_unittest.py
CUDA_VISIBLE_DEVICES= PYTORCH_TESTING_DEVICE_ONLY_FOR=cpu PYTORCH_TEST_WITH_DYNAMO=1 \
  python test/cpython/v3_13/test_sort.py
```

test_small_stability reports OK (skipped=1); full test_sort.py 21 OK/10
skipped; test_unittest.py 2 OK. A top-level uncaught non-SkipTest exception
still raises Unsupported under fullgraph (verified).

This change was authored with the help of an AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98