### PR TITLE
 print_sccache_stats: warn if sccache optional, fail if expected

### DIFF
--- a/.ci/pytorch/common_utils.sh
+++ b/.ci/pytorch/common_utils.sh
@@ -382,8 +382,19 @@ function install_cutlass_api() {
 }
 
 function print_sccache_stats() {
-  if ! which sccache &> /dev/null; then echo "sccache not installed, skipping stats"; return; fi
   echo 'PyTorch Build Statistics'
+  if ! which sccache &> /dev/null; then
+    if [[ -n "${SCCACHE_BUCKET:-}" ]]; then
+      # sccache was configured for this build (SCCACHE_BUCKET is set) but the
+      # binary is missing: that's a real misconfiguration, not an optional tool
+      # being absent, so fail the build (callers run under `set -e`).
+      echo "::error::sccache was expected (SCCACHE_BUCKET is set) but the sccache binary was not found; failing the build."
+      return 1
+    fi
+    # sccache genuinely not in use here: warn (#188060) but don't fail the build.
+    echo "::warning::sccache not found, skipping build statistics. If this build was expected to use sccache, check its installation/configuration."
+    return
+  fi
   sccache --show-stats
 
   if [[ -n "${OUR_GITHUB_JOB_ID}" ]]; then

--- a/.ci/pytorch/macos-build.sh
+++ b/.ci/pytorch/macos-build.sh
@@ -50,9 +50,8 @@ else
   # that building with USE_DISTRIBUTED=0 works at all. See https://github.com/pytorch/pytorch/issues/86448
   USE_DISTRIBUTED=0 USE_OPENMP=1 WERROR=1 BUILD_TEST=OFF USE_PYTORCH_METAL=1 python -m build --wheel --no-isolation
 fi
-if which sccache > /dev/null; then
-  print_sccache_stats
-fi
+# print_sccache_stats self-guards (and warns) when sccache is absent.
+print_sccache_stats
 
 python tools/stats/export_test_times.py
 


### PR DESCRIPTION
## Summary

Follow-up to #188061 / #188060, addressing @malfet's [review comment](https://github.com/pytorch/pytorch/pull/188061#issuecomment-4878194773).

#188061 stopped `print_sccache_stats()` from failing a successful build when sccache is missing, but it does so by **silently** returning. As malfet noted, that makes it *"much harder to detect when sccache should be there, but it's not installed"* — on Linux CI (everything except s390x/riscv64) sccache is expected, so a broken install would otherwise yield a green build with no signal.

### Change
When sccache is absent, `print_sccache_stats()` now branches on whether sccache was actually **expected** for this build, using `SCCACHE_BUCKET` — the same signal `common-build.sh` already uses to gate sccache setup:

- **`SCCACHE_BUCKET` set** (sccache was configured, so a missing binary is a real misconfiguration): emit a GitHub Actions `::error::` annotation and `return 1`, failing the build. Callers run under `set -e`, so on Linux `build.sh` this turns the job red instead of shipping a silently-uncached build.
- **`SCCACHE_BUCKET` unset** (sccache legitimately not in use): emit a `::warning::` and continue. The build stays green (preserving the #188060 fix), but the condition is still loud and greppable.

`macos-build.sh`: drop the now-redundant `if which sccache` wrapper around the call, since the function self-guards — making behavior uniform across platforms. (macOS scripts don't run under `set -e` and the macOS call site was already guarded, so the new error path is a no-op there.)

### Why key on `SCCACHE_BUCKET` instead of a new flag
There is no existing `SKIP_SCCACHE` / `NO_SCCACHE` opt-out. The closest env var, `SKIP_SCCACHE_INITIALIZATION`, means something different (skip *starting the server* on self-hosted runners — sccache is still expected). `SCCACHE_BUCKET` is the real "sccache is configured" gate: `common-build.sh` explicitly `unset`s it when empty, so its presence is a reliable "sccache expected" signal that needs no new configuration.

### Why this over silent-skip or unconditional hard-fail
- **Silent-skip** hides misconfiguration (malfet's point).
- **Unconditional hard-fail** regresses #188060 — builds that legitimately don't use sccache would fail at the very end.
- **Context-dependent** (this PR): fail only when sccache was expected, warn otherwise. Non-fatal where sccache is optional, loud-and-fatal where it's required.

Note: sccache setup + the stats-on-exit `sccache_epilogue` trap in `common-build.sh` are already gated on `which sccache`; this only changes the explicit `print_sccache_stats()` call path.

## How the annotations surface on the job

`echo "::warning::<msg>"` / `echo "::error::<msg>"` are GitHub Actions workflow commands. When the step prints one, the runner turns it into an annotation:

- **Job log** — appears in the raw step log (rendered highlighted, not plain text).
- **Job summary page** — shown as a yellow ⚠️ (warning) or red ❌ (error) box at the top of the run/job.
- **PR "Checks" tab / merge box** — propagates to the job's check run, visible without opening the full log.

Key difference: `::warning::` does **not** change the step exit code — the build stays green. Failing the build in the "expected" case comes from the `return 1` under `set -e`, **not** from the `::error::` line itself (the annotation is purely cosmetic/surfacing). The `::error::` is emitted alongside `return 1` so the failure is both fatal and clearly annotated.

Notes:
- We don't set `file=`/`line=` params, so it's a general job-level annotation (appropriate — it's a build-environment condition, not a source location).
- The annotation rendering only happens under GitHub Actions. If these scripts ever run elsewhere, the line just prints literally as text — still visible/greppable in logs.
