### PR TITLE
[CI] Update sccache to 0.16.0

### DIFF
--- a/.ci/docker/common/install_cache.sh
+++ b/.ci/docker/common/install_cache.sh
@@ -8,10 +8,8 @@ install_ubuntu() {
   echo "Installing rust"
   curl https://sh.rustup.rs -sSf | sh -s -- -y
   echo "Checking out sccache repo"
-  git clone https://github.com/mozilla/sccache -b v0.13.0
+  git clone https://github.com/mozilla/sccache -b v0.16.0
   cd sccache
-  echo "Patch dist build on aarch64"
-  sed -i '/all(target_os = "linux", target_arch = "x86_64"),/{ p; s/x86_64/aarch64/; }' src/bin/sccache-dist/main.rs
   echo "Building sccache"
   . "$HOME/.cargo/env" && cargo build --release --features="dist-client dist-server"
   cp target/release/sccache /opt/cache/bin


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #188924

And undo aarch64 dist build caches, as https://github.com/mozilla/sccache/pull/2668 has finally merged