### PR TITLE
[release/2.13] Strip +PTX from CUDA arch list on release/RC builds (#188914)

### DIFF
--- a/.ci/manywheel/build_env_setup.py
+++ b/.ci/manywheel/build_env_setup.py
@@ -88,14 +88,35 @@ TORCH_CUDA_ARCH_LIST_TABLE: dict[str, dict[str, set[int]]] = {
     },
 }
 
-# Architectures we additionally emit PTX for (forward-compat for newer GPUs).
+# Architectures we additionally emit PTX for on nightly/dev builds
+# (forward-compat for newer GPUs). Release/RC wheels ship SASS-only to keep
+# libtorch_cuda.so size down; see _ptx_arches().
 _PTX_ARCHES: set[int] = {120}
+
+
+def _is_release_build() -> bool:
+    """True for release / RC binary builds (vs nightly / dev builds).
+
+    Binary builds off a git tag (releases and RCs, e.g. v2.13.0 / v2.13.0-rc1)
+    get a ``PYTORCH_BUILD_VERSION`` with no ``.dev<date>`` suffix, while
+    nightlies do -- see .ci/pytorch/binary_populate_env.sh, which relies on the
+    same ``dev`` check for Triton pinning. A missing/empty version (local or
+    non-binary builds) is treated as non-release, so PTX is kept.
+    """
+    version = os.environ.get("PYTORCH_BUILD_VERSION", "")
+    return bool(version) and "dev" not in version
+
+
+def _ptx_arches() -> set[int]:
+    """PTX arches for this build: empty on release/RC, forward-compat set otherwise."""
+    return set() if _is_release_build() else _PTX_ARCHES
 
 
 def torch_cuda_arch_list(cuda_version: str, arch: str) -> str:
     """Format TORCH_CUDA_ARCH_LIST for the wheel build (";"-separated).
 
-    Returns e.g. "8.0;9.0;10.0;11.0;12.0+PTX" for cuda 13.x aarch64.
+    Returns e.g. "8.0;9.0;10.0;11.0;12.0+PTX" for cuda 13.x aarch64 on
+    nightly builds; release/RC builds omit the +PTX suffix (see _ptx_arches()).
 
     CUDA 13.x dropped sm_50/60/70, so we must NOT leave this empty --
     CMake's defaults still include compute_50 which nvcc 13 rejects with
@@ -106,8 +127,9 @@ def torch_cuda_arch_list(cuda_version: str, arch: str) -> str:
     archs = TORCH_CUDA_ARCH_LIST_TABLE[cuda_version].get(arch)
     if not archs:
         raise SystemExit(f"no TORCH_CUDA_ARCH_LIST for cuda {cuda_version} on {arch}")
+    ptx_arches = _ptx_arches()
     return ";".join(
-        f"{cc // 10}.{cc % 10}" + ("+PTX" if cc in _PTX_ARCHES else "")
+        f"{cc // 10}.{cc % 10}" + ("+PTX" if cc in ptx_arches else "")
         for cc in sorted(archs)
     )
 

--- a/scripts/release/apply-release-changes.sh
+++ b/scripts/release/apply-release-changes.sh
@@ -44,10 +44,6 @@ echo "XLA Changes"
 sed -i -e s#--quiet#-b\ r"${RELEASE_VERSION}"# .ci/pytorch/common_utils.sh
 sed -i -e s#.*#r"${RELEASE_VERSION}"# .github/ci_commit_pins/xla.txt
 
-# Strip +PTX from CUDA arch lists in release builds
-echo "Stripping +PTX from CUDA arch lists"
-sed -i 's/+PTX//' .ci/manywheel/build_cuda.sh
-
 # Regenerate templates
 export RELEASE_VERSION_TAG=${RELEASE_VERSION}
 ./.github/regenerate.sh


### PR DESCRIPTION
Cherry-pick of #188914 onto `release/2.13`.

## Summary
Restore the pre-2.13 behavior where **release/RC** CUDA wheels ship **without `+PTX`**, while nightlies keep it for forward-compat. 2.13.0 (cu130) shipped `12.0+PTX` in release wheels, growing `libtorch_cuda.so` by ~80-90 MB.

The branch-cut `sed` in `apply-release-changes.sh` that used to strip `+PTX` became a silent no-op after the manywheel build env was refactored from `build_cuda.sh` into `build_env_setup.py`. This detects release/RC builds in Python instead (`_is_release_build()` keys off `PYTORCH_BUILD_VERSION` having no `.dev` suffix), and drops the dead `sed`.

### Behavior (cuda 13.0)
| Build | `PYTORCH_BUILD_VERSION` | arch list |
|---|---|---|
| nightly | `2.13.0.dev...+cu130` | `...;12.0+PTX` |
| RC / release | `2.13.0+cu130` | `...;12.0` (no +PTX) |
| local / unset | `''` | `...;12.0+PTX` (safe default) |

Original PR: #188914
(cherry picked from commit 089472d4523125834f435df46a346e330ea212e4)

*Authored with AI assistance.*