### PR TITLE
Bump third_party/protobuf to v21.12 (last Abseil-free release)

### DIFF
--- a/cmake/ProtoBufPatch.cmake
+++ b/cmake/ProtoBufPatch.cmake
@@ -28,6 +28,17 @@ if(NOT SYSTEM_PROTOBUF)
     content
     "${content}")
 
+  # Stripping PROTOBUF_CONSTEXPR above makes the ConstantInitialized
+  # constructors non-constexpr, so the default-instance globals can no longer
+  # be constinit. Drop PROTOBUF_CONSTINIT (protobuf 3.21+) so they fall back to
+  # dynamic initialization instead of failing to compile.
+  string(
+    REPLACE
+    "PROTOBUF_CONSTINIT"
+    ""
+    content
+    "${content}")
+
   # https://github.com/protocolbuffers/protobuf/commit/0400cca3236de1ca303af38bf81eab332d042b7c
   # changes PROTOBUF_CONSTEXPR to constexpr, which breaks windows
   # build.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #188927

Update the bundled protobuf submodule from ancient v3.13 (released Oct 2020) to last Abseil-free v21.12 (released Dec 2022). Abseil has no stable ABI and carries its own process-global state, so embedding it into libtorch_cpu would create ODR/visibility hazards with any other Abseil/protobuf already loaded in the process (TensorFlow, gRPC, system protobuf).

Root cause of the one required patch change: protobuf 3.21 emits PROTOBUF_CONSTINIT (constinit) on the generated *_default_instance_ globals. ProtoBufPatch.cmake strips PROTOBUF_CONSTEXPR from the ConstantInitialized constructors (a long-standing Windows workaround), which makes them non-constexpr; constinit then requires a constant initializer it can no longer get, so every ONNX .pb.cc failed to compile with "variable does not have a constant initializer". The fix strips PROTOBUF_CONSTINIT alongside PROTOBUF_CONSTEXPR so those globals fall back to dynamic initialization. proto_wrap.cc is unchanged, since GetEmptyStringAlreadyInited still exists in 21.x.

As a side benefit, the 3.21 code generator no longer emits the C++20-deprecated ATOMIC_VAR_INIT macro into the generated ONNX *.pb.cc

TODO: the only remaining C++ protobuf consumer is the legacy TorchScript ONNX exporter, which merely serializes onnx::ModelProto. Once ONNX proto generation is moved to Python (the torch.export/onnxscript exporter already works this way) or the legacy exporter is dropped entirely, libtorch stops needing protobuf and the bundled submodule, ProtoBufPatch.cmake, and proto_wrap.cc can all be removed -- which is also the only way to converge onto ONNX's own protobuf pin (4.25/v29.x) without vendoring Abseil.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>