### PR TITLE
Let packanlayzer handle lane uniform masks

### DIFF
--- a/test/inductor/test_interval_mask_packing.py
+++ b/test/inductor/test_interval_mask_packing.py
@@ -32,6 +32,14 @@ class TestIntervalMaskPacking(InductorTestCase):
                 return kv_idx + lane in (q_idx, q_idx + 2)
             case "block_equality":
                 return q_idx // 16 == (kv_idx + lane) // 16
+            case "row_bounded_causal":
+                return q_idx >= kv_idx + lane and q_idx < 100
+            case "not_causal":
+                return not q_idx >= kv_idx + lane
+            case "ne_diagonal":
+                return kv_idx + lane != q_idx
+            case "lane_uniform_eq":
+                return q_idx == 16
             case _:
                 raise AssertionError(case_name)
 
@@ -67,6 +75,10 @@ class TestIntervalMaskPacking(InductorTestCase):
             "sliding_window",
             "disjoint_or",
             "block_equality",
+            "row_bounded_causal",
+            "not_causal",
+            "ne_diagonal",
+            "lane_uniform_eq",
             "batch_dependent",
         ],
     )
@@ -126,6 +138,23 @@ class TestIntervalMaskPacking(InductorTestCase):
                 )
             case "batch_dependent":
                 output = graph.call_function(torch.ops.aten.ge.Tensor, (b, kv_idx))
+            case "row_bounded_causal":
+                row_bound = graph.call_function(
+                    torch.ops.aten.lt.Scalar, (q_idx, 100)
+                )
+                output = graph.call_function(
+                    torch.ops.aten.bitwise_and.Tensor, (causal, row_bound)
+                )
+            case "not_causal":
+                output = graph.call_function(
+                    torch.ops.aten.logical_not.default, (causal,)
+                )
+            case "ne_diagonal":
+                output = graph.call_function(
+                    torch.ops.aten.ne.Tensor, (kv_idx, q_idx)
+                )
+            case "lane_uniform_eq":
+                output = graph.call_function(torch.ops.aten.eq.Scalar, (q_idx, 16))
             case _:
                 raise AssertionError(case_name)
         graph.output(output)
@@ -346,6 +375,37 @@ class TestIntervalMaskPacking(InductorTestCase):
         self.assertIn("min(", intervals[0].render_upper())
         self.assertIn("q_idx[0]", intervals[0].render_upper())
         self.assertIn("cutlass.Int32(1)", intervals[0].render_upper())
+
+    def test_packed_mask_interval_selector_padding_mask(self):
+        """Regression for attention-gym #208: BERT-style padding masks must pack.
+
+        (q_idx < seq_lens[b]) & (kv_idx < seq_lens[b]) mixes a lane-affine kv bound
+        with a lane-uniform q bound; the lane-uniform conjunct used to reject the
+        whole mask into the per-lane fallback path.
+        """
+        graph = torch.fx.Graph()
+        b = graph.placeholder("b")
+        graph.placeholder("h")
+        q_idx = graph.placeholder("q_idx")
+        kv_idx = graph.placeholder("kv_idx")
+        seq_lens = graph.placeholder("seq_lens")
+        self._set_node_dtype(seq_lens, torch.int64, (8,))
+        length = graph.call_function(torch.ops.aten.index.Tensor, (seq_lens, [b]))
+        self._set_node_dtype(length, torch.int64)
+        q_ok = graph.call_function(torch.ops.aten.lt.Tensor, (q_idx, length))
+        kv_ok = graph.call_function(torch.ops.aten.lt.Tensor, (kv_idx, length))
+        graph.output(
+            graph.call_function(torch.ops.aten.bitwise_and.Tensor, (q_ok, kv_ok))
+        )
+
+        with V.set_graph_handler(MockGraphHandler()):
+            intervals = select_packed_mask_intervals(torch.fx.GraphModule({}, graph))
+
+        self.assertIsNotNone(intervals)
+        self.assertEqual(len(intervals), 1)
+        self.assertIn("min(", intervals[0].render_upper())
+        self.assertIn("aux_tensors[0]", intervals[0].render_upper())
+        self.assertIn("cutlass.Int32(32)", intervals[0].render_upper())
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_interval_mask_packing.py
+++ b/test/inductor/test_interval_mask_packing.py
@@ -139,9 +139,7 @@ class TestIntervalMaskPacking(InductorTestCase):
             case "batch_dependent":
                 output = graph.call_function(torch.ops.aten.ge.Tensor, (b, kv_idx))
             case "row_bounded_causal":
-                row_bound = graph.call_function(
-                    torch.ops.aten.lt.Scalar, (q_idx, 100)
-                )
+                row_bound = graph.call_function(torch.ops.aten.lt.Scalar, (q_idx, 100))
                 output = graph.call_function(
                     torch.ops.aten.bitwise_and.Tensor, (causal, row_bound)
                 )
@@ -150,9 +148,7 @@ class TestIntervalMaskPacking(InductorTestCase):
                     torch.ops.aten.logical_not.default, (causal,)
                 )
             case "ne_diagonal":
-                output = graph.call_function(
-                    torch.ops.aten.ne.Tensor, (kv_idx, q_idx)
-                )
+                output = graph.call_function(torch.ops.aten.ne.Tensor, (kv_idx, q_idx))
             case "lane_uniform_eq":
                 output = graph.call_function(torch.ops.aten.eq.Scalar, (q_idx, 16))
             case _:

--- a/torch/_inductor/kernel/flex/interval_mask_packing.py
+++ b/torch/_inductor/kernel/flex/interval_mask_packing.py
@@ -30,6 +30,9 @@ from ...virtualized import NullHandler, V
 from .aux_vectorization import fx_aux_index_to_sympy
 
 
+perf_hint_log = torch._logging.getArtifactLogger(__name__, "perf_hints")
+
+
 # Fall back to scalar mask lowering before interval expansion makes generated CuTe too large.
 MAX_PACKED_MASK_INTERVALS_FOR_CODE_SIZE = 8
 LANE_UNIFORM_BINARY_OPS: Mapping[object, str] = {
@@ -287,6 +290,19 @@ class PackedMaskAnalyzer:
                 )
             case torch.ops.aten.eq.Tensor | torch.ops.aten.eq.Scalar:
                 return self.equality_to_intervals(node.args[0], node.args[1])
+            case torch.ops.aten.ne.Tensor | torch.ops.aten.ne.Scalar:
+                intervals = self.equality_to_intervals(node.args[0], node.args[1])
+                if intervals is None:
+                    return None
+                return self.complement_intervals(intervals)
+            case torch.ops.aten.logical_not.default | torch.ops.aten.bitwise_not.default:
+                child = node.args[0]
+                if not isinstance(child, torch.fx.Node):
+                    return None
+                intervals = self.node_to_intervals(child)
+                if intervals is None:
+                    return None
+                return self.complement_intervals(intervals)
             case _:
                 return None
 
@@ -349,6 +365,13 @@ class PackedMaskAnalyzer:
         if affine is None:
             return None
         lane_coeff, rest = affine
+        if lane_coeff == 0:
+            # Lane-uniform predicate (e.g. q_idx < seq_lens[b]): keep either all 32
+            # lanes or none. Encode as an upper bound of 32 * (0-or-positive) that the
+            # kernel's keep-mask rendering already clamps to [0, 32].
+            keep = -rest if strict else 1 - rest
+            upper = V.graph.sizevars.simplify(sympy.Integer(32) * keep)
+            return self.interval_if_renderable(sympy.Integer(0), upper)
         if lane_coeff == 1:
             upper = V.graph.sizevars.simplify(-rest if strict else -rest + 1)
             return self.interval_if_renderable(sympy.Integer(0), upper)
@@ -370,6 +393,15 @@ class PackedMaskAnalyzer:
         if affine is None:
             return None
         lane_coeff, rest = affine
+        if lane_coeff == 0:
+            # Lane-uniform equality (e.g. head_type[h] == 0): keep either all 32
+            # lanes or none. Both operands of Min are >= 32 iff rest == 0; the
+            # kernel's keep-mask rendering clamps the bound to [0, 32].
+            scale = sympy.Integer(32)
+            upper = V.graph.sizevars.simplify(
+                Min(scale * (1 - rest), scale * (1 + rest))
+            )
+            return self.interval_if_renderable(sympy.Integer(0), upper)
         if lane_coeff in (1, -1):
             lane_value = -rest if lane_coeff == 1 else rest
             lower = V.graph.sizevars.simplify(lane_value)
@@ -411,6 +443,26 @@ class PackedMaskAnalyzer:
         ):
             return (PackedMaskInterval(lower, upper),)
         return None
+
+    def complement_intervals(self, intervals: IntervalSet) -> MaybeIntervalSet:
+        """Complement a keep-set within the 32-lane window via De Morgan.
+
+        The complement of a union of intervals is the intersection of each
+        interval's two complement pieces, which stays interval-representable.
+        Interval bounds may be symbolic, so this composes existing renderable
+        bounds instead of sorting; merge_intersection caps the blowup.
+        """
+        result: IntervalSet = (PackedMaskInterval.full(),)
+        for interval in intervals:
+            pieces = (
+                PackedMaskInterval(sympy.Integer(0), interval.lower_lane),
+                PackedMaskInterval(interval.upper_lane_exclusive, sympy.Integer(32)),
+            )
+            merged = self.merge_intersection(result, pieces)
+            if merged is None:
+                return None
+            result = merged
+        return result
 
     def merge_intersection(
         self,
@@ -639,6 +691,13 @@ def select_packed_mask_intervals(
     )
     intervals = analyzer.node_to_intervals(output_val)
     if intervals is None:
+        perf_hint_log.info(
+            "flex FLASH: mask_mod could not be lowered to packed 32-lane intervals; "
+            "partial blocks will evaluate the mask per lane, which can be much "
+            "slower. Prefer comparisons of q_idx/kv_idx against lane-uniform bounds "
+            "(e.g. seq_lens[b]) over per-token gathers. mask graph:\n%s",
+            graph,
+        )
         return None
     if len(intervals) == 1 and intervals[0].is_full():
         return None

--- a/torch/_inductor/kernel/flex/interval_mask_packing.py
+++ b/torch/_inductor/kernel/flex/interval_mask_packing.py
@@ -292,9 +292,9 @@ class PackedMaskAnalyzer:
                 return self.equality_to_intervals(node.args[0], node.args[1])
             case torch.ops.aten.ne.Tensor | torch.ops.aten.ne.Scalar:
                 intervals = self.equality_to_intervals(node.args[0], node.args[1])
-                if intervals is None:
-                    return None
-                return self.complement_intervals(intervals)
+                return (
+                    None if intervals is None else self.complement_intervals(intervals)
+                )
             case (
                 torch.ops.aten.logical_not.default | torch.ops.aten.bitwise_not.default
             ):
@@ -302,9 +302,9 @@ class PackedMaskAnalyzer:
                 if not isinstance(child, torch.fx.Node):
                     return None
                 intervals = self.node_to_intervals(child)
-                if intervals is None:
-                    return None
-                return self.complement_intervals(intervals)
+                return (
+                    None if intervals is None else self.complement_intervals(intervals)
+                )
             case _:
                 return None
 

--- a/torch/_inductor/kernel/flex/interval_mask_packing.py
+++ b/torch/_inductor/kernel/flex/interval_mask_packing.py
@@ -361,31 +361,67 @@ class PackedMaskAnalyzer:
         *,
         strict: bool,
     ) -> MaybeIntervalSet:
-        """Convert a lane-affine comparison into one packed keep interval."""
+        """Convert ``lhs_expr < rhs_expr`` or ``lhs_expr <= rhs_expr`` to an interval.
+
+        The caller normalizes ``>`` and ``>=`` by swapping operands, so this method
+        only has to lower ``lhs_expr - rhs_expr < 0`` when ``strict`` is true and
+        ``lhs_expr - rhs_expr <= 0`` otherwise. The difference decomposes as
+        ``lane_coeff * mask_lane + rest``, and each unit coefficient maps to a mask
+        shape:
+
+        - ``1``: kv on the small side, e.g. ``kv_idx < q_idx`` (causal-style) ->
+          prefix interval ``[0, upper)``.
+        - ``-1``: kv on the large side, e.g. ``start[b] <= kv_idx`` (window or
+          document starts) -> suffix interval ``[lower, 32)``.
+        - ``0``: no kv dependence, e.g. ``q_idx < seq_lens[b]`` (padding or other
+          row/batch/head bounds) -> the whole window is kept or dropped. Truth is
+          encoded as the upper bound ``32 * keep`` with ``keep`` positive iff the
+          predicate holds; keep-mask rendering clamps bounds to ``[0, 32]``, so any
+          positive multiple of 32 keeps all lanes and any non-positive value keeps
+          none.
+
+        Other coefficients (e.g. ``2 * kv_idx < q_idx``, dilated/strided patterns)
+        describe non-interval lane sets and fall back to per-lane evaluation.
+        """
         diff = V.graph.sizevars.simplify(lhs_expr - rhs_expr)
         affine = decompose_affine_lane_expr(diff, self.lane_symbol)
         if affine is None:
             return None
         lane_coeff, rest = affine
-        if lane_coeff == 0:
-            # Lane-uniform predicate (e.g. q_idx < seq_lens[b]): keep either all 32
-            # lanes or none. Encode as an upper bound of 32 * (0-or-positive) that the
-            # kernel's keep-mask rendering already clamps to [0, 32].
-            keep = -rest if strict else 1 - rest
-            upper = V.graph.sizevars.simplify(sympy.Integer(32) * keep)
-            return self.interval_if_renderable(sympy.Integer(0), upper)
-        if lane_coeff == 1:
-            upper = V.graph.sizevars.simplify(-rest if strict else -rest + 1)
-            return self.interval_if_renderable(sympy.Integer(0), upper)
-        if lane_coeff == -1:
-            lower = V.graph.sizevars.simplify(rest + 1 if strict else rest)
-            return self.interval_if_renderable(lower, sympy.Integer(32))
-        return None
+        match lane_coeff:
+            case 0:
+                keep = -rest if strict else 1 - rest
+                upper = V.graph.sizevars.simplify(sympy.Integer(32) * keep)
+                return self.interval_if_renderable(sympy.Integer(0), upper)
+            case 1:
+                upper = V.graph.sizevars.simplify(-rest if strict else -rest + 1)
+                return self.interval_if_renderable(sympy.Integer(0), upper)
+            case -1:
+                lower = V.graph.sizevars.simplify(rest + 1 if strict else rest)
+                return self.interval_if_renderable(lower, sympy.Integer(32))
+            case _:
+                return None
 
     def lane_equality_to_intervals(
         self, lhs_expr: sympy.Expr, rhs_expr: sympy.Expr
     ) -> MaybeIntervalSet:
-        """Convert a lane-affine equality into singleton keep intervals."""
+        """Convert ``lhs_expr == rhs_expr`` to packed keep intervals.
+
+        Matching ``FloorDiv`` expressions can describe a contiguous block, e.g.
+        ``q_idx // B == kv_idx // B``, and are handled before the generic
+        lane-affine path. Otherwise the difference decomposes as
+        ``lane_coeff * mask_lane + rest``:
+
+        - ``1`` or ``-1``: exactly one lane can satisfy the equality, e.g.
+          ``kv_idx == q_idx + c`` -> singleton interval ``[v, v + 1)``.
+        - ``0``: no kv dependence, e.g. ``head_type[h] == 0`` -> the whole window
+          is kept or dropped. ``Min(32 * (1 - rest), 32 * (1 + rest))`` is >= 32
+          iff ``rest == 0`` and non-positive otherwise, reusing the clamped
+          all-or-none upper-bound encoding from the comparison case.
+
+        Other coefficients are rejected rather than emitting strided or
+        divisibility-dependent masks.
+        """
         if isinstance(lhs_expr, FloorDiv) and isinstance(rhs_expr, FloorDiv):
             intervals = self._floor_div_equality_to_intervals(lhs_expr, rhs_expr)
             if intervals is not None:
@@ -395,21 +431,20 @@ class PackedMaskAnalyzer:
         if affine is None:
             return None
         lane_coeff, rest = affine
-        if lane_coeff == 0:
-            # Lane-uniform equality (e.g. head_type[h] == 0): keep either all 32
-            # lanes or none. Both operands of Min are >= 32 iff rest == 0; the
-            # kernel's keep-mask rendering clamps the bound to [0, 32].
-            scale = sympy.Integer(32)
-            upper = V.graph.sizevars.simplify(
-                Min(scale * (1 - rest), scale * (1 + rest))
-            )
-            return self.interval_if_renderable(sympy.Integer(0), upper)
-        if lane_coeff in (1, -1):
-            lane_value = -rest if lane_coeff == 1 else rest
-            lower = V.graph.sizevars.simplify(lane_value)
-            upper = V.graph.sizevars.simplify(lane_value + 1)
-            return self.interval_if_renderable(lower, upper)
-        return None
+        match lane_coeff:
+            case 0:
+                scale = sympy.Integer(32)
+                upper = V.graph.sizevars.simplify(
+                    Min(scale * (1 - rest), scale * (1 + rest))
+                )
+                return self.interval_if_renderable(sympy.Integer(0), upper)
+            case 1 | -1:
+                lane_value = -rest if lane_coeff == 1 else rest
+                lower = V.graph.sizevars.simplify(lane_value)
+                upper = V.graph.sizevars.simplify(lane_value + 1)
+                return self.interval_if_renderable(lower, upper)
+            case _:
+                return None
 
     def _floor_div_equality_to_intervals(
         self, lhs_expr: FloorDiv, rhs_expr: FloorDiv

--- a/torch/_inductor/kernel/flex/interval_mask_packing.py
+++ b/torch/_inductor/kernel/flex/interval_mask_packing.py
@@ -295,7 +295,9 @@ class PackedMaskAnalyzer:
                 if intervals is None:
                     return None
                 return self.complement_intervals(intervals)
-            case torch.ops.aten.logical_not.default | torch.ops.aten.bitwise_not.default:
+            case (
+                torch.ops.aten.logical_not.default | torch.ops.aten.bitwise_not.default
+            ):
                 child = node.args[0]
                 if not isinstance(child, torch.fx.Node):
                     return None


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #188929


# Summary

This was found while looking at : https://github.com/meta-pytorch/attention-gym/issues/208

Our pack analyzer basically didn't have good analzysis when a predicate is lane uniform e.g. `q_idx < seq_lens[b]`
There are no lanes -> e.g. no kv_indices so the stride coeff is 0 == so completely lane unfiorm previously that would fall through. 

The De-Morgan flip was from fable although yes I know this rule ;) 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Chillee @yanboliang @BoyuanFeng @liangel-02 @howardzhang-cv