### PR TITLE
Pin ubuntu-latest GHA runners to ubuntu-24.04

### DIFF
--- a/.github/workflows/_binary-upload-flash-attention-wheel.yml
+++ b/.github/workflows/_binary-upload-flash-attention-wheel.yml
@@ -17,7 +17,7 @@ jobs:
   upload-wheel-linux:
     name: "Upload FA3 ${{ matrix.build_cuda_short }} ${{ matrix.arch }}"
     if: ${{ inputs.linux_run_id != '' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -74,7 +74,7 @@ jobs:
   upload-wheel-windows:
     name: "Upload FA3 ${{ matrix.build_cuda_short }} windows_amd64"
     if: ${{ inputs.windows_run_id != '' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -418,7 +418,7 @@ jobs:
   memory-viz-tests:
     # Tests for torch memory visualizer
     # tag shangdiy for any issue with this test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/_get-changed-files.yml
+++ b/.github/workflows/_get-changed-files.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   get-changed-files:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       changed-files: ${{ steps.get-files.outputs.changed-files }}
 

--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -71,7 +71,7 @@ jobs:
   runner-determinator:
     # Don't run on forked repos
     if: github.repository_owner == 'pytorch'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       label-type: ${{ steps.set-condition.outputs.label-type }}
       runner-config: ${{ steps.set-runner-info.outputs.runner-config }}

--- a/.github/workflows/assigntome-docathon.yml
+++ b/.github/workflows/assigntome-docathon.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   assign:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       issues: write
     steps:

--- a/.github/workflows/auto_request_review.yml
+++ b/.github/workflows/auto_request_review.yml
@@ -12,7 +12,7 @@ jobs:
       contents: read
       pull-requests: write
     name: Auto Request Review
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Request review based on files changes and/or groups the author belongs to
         # v0.7.0

--- a/.github/workflows/build-vllm-wheel.yml
+++ b/.github/workflows/build-vllm-wheel.yml
@@ -160,7 +160,7 @@ jobs:
     name: "Upload ${{ matrix.device }} vLLM wheel on ${{ matrix.platform }}"
     needs:
       - build-wheel
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/check_mergeability_ghstack.yml
+++ b/.github/workflows/check_mergeability_ghstack.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   ghstack-mergeability-check:
     if: github.repository_owner == 'pytorch'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   cherry-pick:
     name: cherry-pick-pr-${{ github.event.client_payload.pr_num }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: cherry-pick-bot
     env:
         GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/claude-autorevert-advisor.yml
+++ b/.github/workflows/claude-autorevert-advisor.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   analyze:
     if: github.repository == 'pytorch/pytorch'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     environment: bedrock
     permissions:

--- a/.github/workflows/claude-distributed-triage-cron.yml
+++ b/.github/workflows/claude-distributed-triage-cron.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   sweep:
     if: github.repository == 'pytorch/pytorch'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     environment: bedrock
     permissions:

--- a/.github/workflows/claude-distributed-triage.yml
+++ b/.github/workflows/claude-distributed-triage.yml
@@ -18,7 +18,7 @@ jobs:
       github.repository == 'pytorch/pytorch' &&
       (github.event_name == 'workflow_dispatch' ||
        github.event.workflow_run.conclusion == 'success')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     environment: bedrock
     permissions:

--- a/.github/workflows/claude-issue-triage-run.yml
+++ b/.github/workflows/claude-issue-triage-run.yml
@@ -12,7 +12,7 @@ jobs:
       github.repository == 'pytorch/pytorch' &&
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow.path == '.github/workflows/claude-issue-triage.yml'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     environment: bedrock
     permissions:

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   capture-issue:
     if: github.repository == 'pytorch/pytorch'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 2
     permissions:
       contents: read

--- a/.github/workflows/close-nonexistent-disable-issues.yml
+++ b/.github/workflows/close-nonexistent-disable-issues.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       issues: write
     if: github.repository_owner == 'pytorch'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -20,7 +20,7 @@ jobs:
   release:
     if: ${{ github.repository == 'pytorch/pytorch' }}
     name: Create Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # https://github.com/softprops/action-gh-release?tab=readme-ov-file#permissions
     permissions:
       contents: write
@@ -112,7 +112,7 @@ jobs:
 
   upload_source_code_to_s3:
     if: ${{ github.repository == 'pytorch/pytorch' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && contains(github.ref, 'rc') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: sourcecode-upload
     name: Upload source code to S3 for release tags
     permissions:

--- a/.github/workflows/delete_old_branches.yml
+++ b/.github/workflows/delete_old_branches.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   delete:
     if: ${{ github.repository == 'pytorch/pytorch' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/docathon-sync-label.yml
+++ b/.github/workflows/docathon-sync-label.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   check-labels:
     if: github.repository_owner == 'pytorch'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/docker-cache-rocm.yml
+++ b/.github/workflows/docker-cache-rocm.yml
@@ -31,7 +31,7 @@ jobs:
   download-docker-builds-artifacts:
     if: github.repository_owner == 'pytorch'
     name: download-docker-builds-artifacts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       pytorch-linux-jammy-rocm-n-py3: ${{ steps.process-artifacts.outputs.pytorch-linux-jammy-rocm-n-py3 }}
       pytorch-linux-noble-rocm-n-py3: ${{ steps.process-artifacts.outputs.pytorch-linux-noble-rocm-n-py3 }}

--- a/.github/workflows/job-filter.yml
+++ b/.github/workflows/job-filter.yml
@@ -37,7 +37,7 @@ on:
 
 jobs:
   compute:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       jobs: ${{ steps.set.outputs.jobs }}
     steps:

--- a/.github/workflows/lint-bc.yml
+++ b/.github/workflows/lint-bc.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   bc_linter:
     if: github.repository_owner == 'pytorch'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Run BC Lint Action
         uses: pytorch/test-infra/.github/actions/bc-lint@main

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -80,7 +80,7 @@ jobs:
 
   update-metamates-rule:
     if: github.repository_owner == 'pytorch' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: update-commit-hash
     steps:
       - name: Checkout repo
@@ -132,7 +132,7 @@ jobs:
           fi
 
   update-commit-hashes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: update-commit-hash
     strategy:
       fail-fast: false

--- a/.github/workflows/operator_microbenchmark_compare.yml
+++ b/.github/workflows/operator_microbenchmark_compare.yml
@@ -155,7 +155,7 @@ jobs:
         needs.test-rocm.result == 'success'
       )
     needs: [test-cuda, test-b200, test-rocm]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       OPERATOR: ${{ inputs.operator }}

--- a/.github/workflows/quack-vendor-reproducibility.yml
+++ b/.github/workflows/quack-vendor-reproducibility.yml
@@ -43,7 +43,7 @@ jobs:
   reproduce:
     if: github.repository_owner == 'pytorch'
     name: re-vendor and diff
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout pytorch
         uses: actions/checkout@v4

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -15,7 +15,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecards analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   stale:
     if: ${{ github.repository == 'pytorch/pytorch' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/tools-unit-tests.yml
+++ b/.github/workflows/tools-unit-tests.yml
@@ -23,7 +23,7 @@ jobs:
       contents: read
       pull-requests: write
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout pytorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
@@ -50,7 +50,7 @@ jobs:
       contents: read
       pull-requests: write
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout pytorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main

--- a/.github/workflows/torchtitan.yml
+++ b/.github/workflows/torchtitan.yml
@@ -35,7 +35,7 @@ jobs:
   # (CUDA_STABLE) so the build/test environment tracks it without hardcoding.
   get-cuda-version:
     name: get-cuda-version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.repository_owner == 'pytorch'
     outputs:
       stable-cuda: ${{ steps.get.outputs.stable-cuda }}

--- a/.github/workflows/trunk-tagging.yml
+++ b/.github/workflows/trunk-tagging.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   tag-trunk-commit:
     name: Tag trunk commit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.repository_owner == 'pytorch'
 
     steps:

--- a/.github/workflows/unstable-periodic.yml
+++ b/.github/workflows/unstable-periodic.yml
@@ -20,7 +20,7 @@ jobs:
   # There must be at least one job here to satisfy GitHub action workflow syntax
   introduction:
     if: github.repository_owner == 'pytorch'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     continue-on-error: true
     steps:
       - name: Introduce PyTorch unstable (periodic) workflow

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -21,7 +21,7 @@ jobs:
   # There must be at least one job here to satisfy GitHub action workflow syntax
   introduction:
     if: github.repository_owner == 'pytorch'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     continue-on-error: true
     steps:
       - name: Introduce PyTorch unstable workflow

--- a/.github/workflows/upload-test-stats.yml
+++ b/.github/workflows/upload-test-stats.yml
@@ -39,7 +39,7 @@ jobs:
   # solution adapted from https://github.com/community/community/discussions/21090#discussioncomment-3226271
   get_workflow_conclusion:
     if: github.repository_owner == 'pytorch'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       conclusion: ${{ fromJson(steps.get_conclusion.outputs.data).conclusion }}
     steps:
@@ -135,7 +135,7 @@ jobs:
 
   check-api-rate:
     if: ${{ always() && github.repository_owner == 'pytorch' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     continue-on-error: true
     steps:
       - name: Get our GITHUB_TOKEN API limit usage

--- a/.github/workflows/upload-torch-dynamo-perf-stats.yml
+++ b/.github/workflows/upload-torch-dynamo-perf-stats.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   get-conclusion:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       conclusion: ${{ fromJson(steps.get-conclusion.outputs.data).conclusion }}
     steps:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -14,7 +14,7 @@ permissions: read-all
 jobs:
   update-commit-hash:
     if: github.repository_owner == 'pytorch'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: update-commit-hash
     steps:
       - name: Checkout repo
@@ -34,7 +34,7 @@ jobs:
 
   update-slow-tests:
     if: github.repository_owner == 'pytorch'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: update-commit-hash
     steps:
       - name: Checkout repo


### PR DESCRIPTION
## Summary
Replace the floating `ubuntu-latest` GitHub Actions runner label with the explicit `ubuntu-24.04` image across all workflows.

`ubuntu-latest` currently resolves to `ubuntu-24.04`, so this is behavior-preserving today, but pinning avoids surprise breakage / toolchain churn whenever GitHub advances the `ubuntu-latest` alias to a newer image (as happened on the 20.04->22.04 and 22.04->24.04 transitions).

## Details
- 40 occurrences across 34 workflow files, all the exact `ubuntu-latest` label in `runs-on:` (no self-hosted `ubuntu-latest-*` variants), so this is a mechanical 1:1 substitution.
- No other YAML changed.

## Test Plan
```
grep -rn "ubuntu-latest" .github/    # 0 results after the change
```

*Authored with AI assistance.*