### PR TITLE
Fix matrix-vector linear fallback crashes with 1D weight and bias

### DIFF
--- a/aten/src/ATen/native/Linear.cpp
+++ b/aten/src/ATen/native/Linear.cpp
@@ -103,13 +103,14 @@ Tensor linear(const Tensor& input, const Tensor& weight, const std::optional<Ten
     return xnnpack::linear(input, weight, *bias);
   }
 #endif
-  if (input_dim == 2 && bias->defined()) {
+  if (input_dim == 2 && weight_dim == 2 && bias->defined()) {
     // Fused op is marginally faster.
     return at::addmm(*bias, input, weight.t());
   }
 
   const auto is_bias_likely_fusable = (
       bias->defined() &&
+      weight_dim == 2 &&
       // cuBLASLt: will fuse in the epilogue without copies
       // when input/weight/bias are all strided.
       // When weight is not strided, bias will not be fused,
@@ -149,7 +150,8 @@ Tensor& linear_out(const Tensor& input, const Tensor& weight, const std::optiona
               ? c10::MaybeOwned<Tensor>::borrowed(*bias_opt)
               : c10::MaybeOwned<Tensor>::owned(std::in_place);
 
-  if (input.dim() == 2 && bias->defined()) {
+  const auto weight_dim = weight.dim();
+  if (input.dim() == 2 && weight_dim == 2 && bias->defined()) {
     // Fused op is marginally faster.
     return at::addmm_out(output, *bias, input, weight.t());
   }

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -6736,6 +6736,16 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         with self.assertRaisesRegex(RuntimeError, ".*both arguments.*1D.*"):
             m(inp)
 
+    def test_linear_1d_weight_bias(self):
+        # Verifies that F.linear with a 2D input, 1D weight, and 1D bias works
+        # and correctly bypasses the addmm fast-path (which expects a 2D weight)
+        input = torch.randn(2, 3)
+        weight = torch.randn(3)
+        bias = torch.randn(1)
+        res = torch.nn.functional.linear(input, weight, bias)
+        expected = torch.matmul(input, weight) + bias
+        self.assertEqual(res, expected)
+
     @tf32_on_and_off(0.005)
     @parametrize_test('device', ['cpu'] + (['cuda'] if TEST_CUDA else []))
     @parametrize_test('bias', [

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -4845,11 +4845,6 @@ def sample_inputs_linear(self, device, dtype, requires_grad, **kwargs):
     yield SampleInput(create_tensor(2, 1, 2, 1, 2), create_tensor(4, 2))
     yield SampleInput(create_tensor(2, 1, 2, 1, 2), create_tensor(4, 2), create_tensor(4))
 
-    # 1D weight and bias, checks correct fallback path when input is 2D and bias is defined
-    yield SampleInput(create_tensor(2, 3), create_tensor(3), create_tensor(1))
-
-
-
 def sample_inputs_bilinear(self, device, dtype, requires_grad, **kwargs):
     features_options = [[3, 4, 5], [8, 8, 8]]
     batch_options: list[list[int]] = [

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -4845,6 +4845,11 @@ def sample_inputs_linear(self, device, dtype, requires_grad, **kwargs):
     yield SampleInput(create_tensor(2, 1, 2, 1, 2), create_tensor(4, 2))
     yield SampleInput(create_tensor(2, 1, 2, 1, 2), create_tensor(4, 2), create_tensor(4))
 
+    # 1D weight and bias, checks correct fallback path when input is 2D and bias is defined
+    yield SampleInput(create_tensor(2, 3), create_tensor(3), create_tensor(1))
+
+
+
 def sample_inputs_bilinear(self, device, dtype, requires_grad, **kwargs):
     features_options = [[3, 4, 5], [8, 8, 8]]
     batch_options: list[list[int]] = [


### PR DESCRIPTION
When F.linear (or linear_out) is called with a 2D input, 1D weight, and a defined bias, PyTorch incorrectly routes the execution to fused addmm paths. Since addmm and addmm_out expect a 2D weight matrix as their second input, invoking them with a 1D weight tensor results in a crash (e.g., RuntimeError: mat2 must be a matrix, got 1-D tensor).

This fix adds explicit weight_dim == 2 checks inside the is_bias_likely_fusable check and the linear_out fast-path condition. This ensures that any 1D weight is correctly routed to the standard fallback path utilizing at::matmul (which natively handles 1D weights).

Test Plan:
We added a dedicated unit test test_linear_1d_weight_bias to test_nn.py and a corresponding sample input to the linear OpInfo configuration. The tests were run and passed successfully:
```bash
.venv/bin/python test/test_nn.py -k test_linear_1d_weight_bias
.venv/bin/python test/test_ops.py -k "nn_functional_linear"
```

fixes: #188891

This PR was authored with the help of an AI assistant.