### PR TITLE
vllm-benchmark: migrate set-parameters + build jobs to OSDC

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -86,6 +86,8 @@ self-hosted-runner:
     - linux.google.tpuv7x.4
     # OSDC ARC (multi-tenant) runners
     - mt-l-x86iavx512-2-4
+    - mt-l-x86iavx512-94-768
+    - mt-l-x86iamx-8-16
     - mt-rel-l-x86iavx512-8-64
     - mt-rel-l-arm64g4-16-62
     - mt-l-x86iamx-22-225-h100

--- a/.github/workflows/_vllm-build.yml
+++ b/.github/workflows/_vllm-build.yml
@@ -31,6 +31,9 @@ on:
 jobs:
   build:
     runs-on: ${{ inputs.runner }}
+    permissions:
+      id-token: write
+      contents: read
     container:
       image: ${{ inputs.docker_image }}
       options: --ipc=host --tty
@@ -49,6 +52,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y git zip
 
+      - name: Fix workspace permissions
+        shell: bash
+        run: |
+          sudo chmod -R 777 "$GITHUB_WORKSPACE"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Checkout PyTorch
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -62,10 +71,20 @@ jobs:
           VLLM_PINNED_COMMIT=$(cat .github/ci_commit_pins/vllm.txt)
           echo "commit=${VLLM_PINNED_COMMIT}" >> "${GITHUB_OUTPUT}"
 
+      - name: Configure AWS credentials
+        id: aws-creds
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/arc
+          aws-region: us-east-1
+          role-duration-seconds: 18000
+
       - name: Build PyTorch
         shell: bash
         env:
           BUILD_ADDITIONAL_PACKAGES: 'vision audio torchao'
+          SCCACHE_S3_NO_CREDENTIALS: ${{ steps.aws-creds.outcome != 'success' && 'true' || 'false' }}
         run: |
           set -eux
           bash .ci/pytorch/build.sh
@@ -115,11 +134,9 @@ jobs:
         run: |
           zip -1 -r artifacts.zip dist/
 
-      - name: Store the build artifacts on S3
-        uses: seemethere/upload-artifact-s3@baba72d0712b404f646cebe0730933554ebce96a # v5.1.0
+      - name: Store the build artifacts
+        uses: pytorch/pytorch/.github/actions/upload-build-artifacts@main
         with:
           name: ${{ inputs.build_environment }}
-          retention-days: 14
-          if-no-files-found: error
-          path: artifacts.zip
           s3-bucket: gha-artifacts
+          use-gha: ${{ steps.aws-creds.outcome != 'success' }}

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -50,9 +50,6 @@ jobs:
   set-parameters:
     if: ${{ !github.event.pull_request.head.repo.fork && github.repository_owner == 'pytorch' }}
     runs-on: mt-l-x86iamx-8-16
-    # OSDC ARC forbids container-less jobs; the actions-runner image is a
-    # lightweight base (its uid matches the runner hook, so no workspace-perm fix
-    # is needed — unlike the CI-image build job).
     container:
       image: ghcr.io/actions/actions-runner:latest
     outputs:
@@ -97,9 +94,6 @@ jobs:
           ref: ${{ inputs.pytorch_commit || inputs.pytorch_branch }}
           show-progress: false
 
-      # The vLLM ci-image is prebuilt by docker-builds.yml; construct its ECR path
-      # inline from the .ci/docker tree hash. calculate-docker-image needs a docker
-      # daemon, which OSDC runners don't have.
       - name: Compute docker image
         id: calculate-docker-image
         working-directory: pytorch/pytorch

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -49,13 +49,19 @@ concurrency:
 jobs:
   set-parameters:
     if: ${{ !github.event.pull_request.head.repo.fork && github.repository_owner == 'pytorch' }}
-    runs-on: linux.c7i.2xlarge
+    runs-on: mt-l-x86iamx-8-16
     outputs:
       benchmark_matrix: ${{ steps.set-parameters.outputs.benchmark_matrix }}
       docker_image: ${{ steps.calculate-docker-image.outputs.docker-image }}
       torch_cuda_arch_list: '8.0 8.9 9.0 10.0 12.0'
       build_environment: linux-jammy-cuda13.0-py3.12-gcc11
     steps:
+      - name: Fix workspace permissions
+        shell: bash
+        run: |
+          sudo chmod -R 777 "$GITHUB_WORKSPACE"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - uses: pytorch/test-infra/.github/actions/setup-uv@main
         with:
           python-version: "3.12"
@@ -92,20 +98,29 @@ jobs:
           ref: ${{ inputs.pytorch_commit || inputs.pytorch_branch }}
           show-progress: false
 
-      - name: Calculate docker image
+      # The vLLM ci-image is prebuilt by docker-builds.yml; construct its ECR path
+      # inline from the .ci/docker tree hash. calculate-docker-image needs a docker
+      # daemon, which OSDC runners don't have.
+      - name: Compute docker image
         id: calculate-docker-image
-        uses: pytorch/test-infra/.github/actions/calculate-docker-image@main
-        with:
-          working-directory: pytorch/pytorch
-          docker-image-name: ci-image:pytorch-linux-jammy-cuda13.0-cudnn9-py3.12-gcc11-vllm
+        working-directory: pytorch/pytorch
+        shell: bash
+        run: |
+          set -eux
+          DOCKER_TAG=$(git rev-parse HEAD:.ci/docker)
+          IMAGE="308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/ci-image:pytorch-linux-jammy-cuda13.0-cudnn9-py3.12-gcc11-vllm-${DOCKER_TAG}"
+          echo "docker-image=${IMAGE}" >> "${GITHUB_OUTPUT}"
 
   build:
     name: Build PyTorch and vLLM
     needs:
       - set-parameters
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/_vllm-build.yml
     with:
-      runner: linux.24xlarge.memory
+      runner: mt-l-x86iavx512-94-768
       docker_image: ${{ needs.set-parameters.outputs.docker_image }}
       build_environment: ${{ needs.set-parameters.outputs.build_environment }}
       pytorch_branch: ${{ inputs.pytorch_branch }}

--- a/.github/workflows/vllm-benchmark.yml
+++ b/.github/workflows/vllm-benchmark.yml
@@ -50,18 +50,17 @@ jobs:
   set-parameters:
     if: ${{ !github.event.pull_request.head.repo.fork && github.repository_owner == 'pytorch' }}
     runs-on: mt-l-x86iamx-8-16
+    # OSDC ARC forbids container-less jobs; the actions-runner image is a
+    # lightweight base (its uid matches the runner hook, so no workspace-perm fix
+    # is needed — unlike the CI-image build job).
+    container:
+      image: ghcr.io/actions/actions-runner:latest
     outputs:
       benchmark_matrix: ${{ steps.set-parameters.outputs.benchmark_matrix }}
       docker_image: ${{ steps.calculate-docker-image.outputs.docker-image }}
       torch_cuda_arch_list: '8.0 8.9 9.0 10.0 12.0'
       build_environment: linux-jammy-cuda13.0-py3.12-gcc11
     steps:
-      - name: Fix workspace permissions
-        shell: bash
-        run: |
-          sudo chmod -R 777 "$GITHUB_WORKSPACE"
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
       - uses: pytorch/test-infra/.github/actions/setup-uv@main
         with:
           python-version: "3.12"


### PR DESCRIPTION
Migrate the last two EC2 jobs of the vLLM benchmark workflow onto OSDC ARC runners (the `benchmarks` job is already on OSDC).

- **set-parameters** (`linux.c7i.2xlarge` → `mt-l-x86iamx-8-16`): add the workspace-permission fix, and replace `calculate-docker-image` — which needs a docker daemon that OSDC pods don't have — with inline ECR-path construction from the `.ci/docker` tree hash. Safe because the vLLM ci-image is prebuilt by `docker-builds.yml`.
- **build** (`linux.24xlarge.memory` → `mt-l-x86iavx512-94-768`, the `arc.yaml` mapping): add `id-token` permission + `role/arc` OIDC, the workspace-permission fix, `SCCACHE_S3_NO_CREDENTIALS` from the creds-step outcome, and switch artifact upload to `upload-build-artifacts@main` (S3 with GHA fallback). Artifacts still land in `gha-artifacts` under the same `build_environment` name the `benchmarks` job downloads.

### Testing

https://github.com/pytorch/pytorch/actions/runs/28686628772
