### PR TITLE
fix: validate tensor lengths against cu_seqlens in varlen_attn to prevent NaN gradients (fixes #176793)

### DIFF
--- a/torch/nn/attention/varlen.py
+++ b/torch/nn/attention/varlen.py
@@ -323,6 +323,25 @@ def varlen_attn(
             f"but got Hq={num_heads_q} and Hkv={num_heads_k}. "
             f"Try setting enable_gqa=True for GQA."
         )
+
+    # Validate tensor lengths match cu_seqlens (fixes #176793)
+    # When query/key tensors are longer than cu_seqlens, backward produces NaN
+    total_q = cu_seq_q[-1].item()
+    if query.size(0) > total_q:
+        raise ValueError(
+            f"query has {query.size(0)} tokens but cu_seq_q[-1] = {total_q}. "
+            f"query length must not exceed cu_seq_q[-1]. "
+            f"See https://github.com/pytorch/pytorch/issues/176793."
+        )
+    if cu_seq_k is not None:
+        total_k = cu_seq_k[-1].item()
+        if key.size(0) > total_k:
+            raise ValueError(
+                f"key has {key.size(0)} tokens but cu_seq_k[-1] = {total_k}. "
+                f"key length must not exceed cu_seq_k[-1]. "
+                f"See https://github.com/pytorch/pytorch/issues/176793."
+            )
+
     if enable_gqa and num_heads_q % num_heads_k != 0:
         raise ValueError(
             f"Expect number of query heads to be a multiple of kv heads for GQA "


### PR DESCRIPTION
Fixes #176793

## Problem
When padding tokens are added to query/key tensors beyond what \cu_seqlens[-1]\ defines, \arlen_attn()\ completes forward pass without errors but produces NaN gradients in backward. This is a **silent correctness bug** — users get NaN gradients with no error message.

The extra tokens are outside the attention computation but still participate in the autograd graph, causing undefined gradients that propagate through the entire model.

## Fix
Add input validation that raises \ValueError\ with a clear message when:
- \query.size(0) > cu_seq_q[-1]\
- \key.size(0) > cu_seq_k[-1]\

This converts a silent NaN corruption into an explicit, actionable error.

## Reproduction (before fix)
\\\python
cu_seqlens = torch.tensor([0, 144, 432, 944], dtype=torch.int32, device='cuda')
x = torch.randn(946, 1024, device='cuda', requires_grad=True)  # 2 extra tokens
q, k, v = x.chunk(3, dim=-1)
loss = varlen_attn(q, k, v, cu_seqlens, cu_seqlens, 512, 512).sum()
loss.backward()  # NaN in gradients!
\\\

After fix: raises \ValueError\ with clear message pointing to #176793.

## Detection
Detected via [NeuralDBG](https://github.com/LambdaSection/NeuralDBG) — causal diagnostic engine for PyTorch training. The NaN was traced through the gradient health transition system back to \arlen_attn\.

cc @cpuhrsch @drisspg @mikaylagawarecki