### PR TITLE
Add Scalar(long long) constructor guard for NetBSD and other LP64 BSDs

### DIFF
--- a/c10/core/Scalar.h
+++ b/c10/core/Scalar.h
@@ -71,10 +71,11 @@ class C10_API Scalar {
       "int64_t is the same as long long on Windows");
   Scalar(long vv) : Scalar(vv, true) {}
 #endif
-#if defined(__linux__) && !defined(__ANDROID__)
+#if (defined(__linux__) && !defined(__ANDROID__)) || defined(__NetBSD__) || \
+    defined(__FreeBSD__) || defined(__OpenBSD__)
   static_assert(
       sizeof(void*) != 8 || std::is_same_v<long, int64_t>,
-      "int64_t is the same as long on 64 bit Linux");
+      "int64_t is the same as long on 64 bit Linux and BSDs");
 #if LONG_MAX != INT_MAX
   Scalar(long long vv) : Scalar(vv, true) {}
 #endif /* not 32-bit system */


### PR DESCRIPTION
Extends the LP64 `Scalar(long long)` constructor guard in `c10/core/Scalar.h` from Linux-only to NetBSD, FreeBSD, and OpenBSD, where `int64_t` is also `long` on 64-bit (see the issue for the failing build). The existing `static_assert` is generalized with the platforms, so a wrong-model platform still fails loudly at compile time.


Fixes #188911