### PR TITLE
Fix torch.arange dtype note: stop should be step

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -9387,7 +9387,7 @@ Args:
 Keyword args:
     {out}
     {dtype} If `dtype` is not given, infer the data type from the other input
-        arguments. If any of `start`, `end`, or `stop` are floating-point, the
+        arguments. If any of `start`, `end`, or `step` are floating-point, the
         `dtype` is inferred to be the default dtype, see
         :meth:`~torch.get_default_dtype`. Otherwise, the `dtype` is inferred to
         be `torch.int64`.


### PR DESCRIPTION
The dtype-inference note in the `torch.arange` docstring says:

> If any of `start`, `end`, or `stop` are floating-point, the `dtype` is inferred to be the default dtype

`torch.arange` has no `stop` argument: its parameters are `start`, `end`, and `step`, as the signature and the Args section directly above the note state. The third parameter that participates in dtype inference is `step`; the docstring's own example shows it (`torch.arange(1, 2.5, 0.5)` returns a floating-point tensor because `step=0.5` is floating-point).

One-word docs-only fix: `stop` -> `step`. Rendered at https://docs.pytorch.org/docs/stable/generated/torch.arange.html
