### PR TITLE
[NCCL] try to remove the redundant copy in functional collectives

### DIFF
--- a/torch/csrc/distributed/c10d/Backend.hpp
+++ b/torch/csrc/distributed/c10d/Backend.hpp
@@ -85,6 +85,13 @@ class TORCH_API Backend : public torch::CustomClassHolder {
     return false;
   }
 
+  // Returns true if the backend can execute allreduce/broadcast with a
+  // distinct output tensor (via _allreduce_oop/_broadcast_oop) instead of
+  // requiring the caller to alias input and output storage.
+  virtual bool supportsOutOfPlaceCollectives() const {
+    return false;
+  }
+
   // Shrink the backend by excluding specified ranks. Backends that support
   // communicator shrinking should override this and return a new backend
   // instance representing the shrunken group. Backends may use opts_override
@@ -144,12 +151,38 @@ class TORCH_API Backend : public torch::CustomClassHolder {
         c10::str("Backend ", getBackendName(), " does not support broadcast"));
   }
 
+  // Out-of-place broadcast: outputBuffer receives the root's inputBuffer
+  // without requiring them to alias the same storage. Only supported when
+  // supportsOutOfPlaceCollectives() is true.
+  virtual c10::intrusive_ptr<Work> _broadcast_oop(
+      at::Tensor& /* outputBuffer */,
+      at::Tensor& /* inputBuffer */,
+      const BroadcastOptions& /* opts */ = BroadcastOptions()) {
+    TORCH_CHECK(
+        false,
+        c10::str(
+            "Backend ", getBackendName(), " does not support _broadcast_oop"));
+  }
+
   virtual c10::intrusive_ptr<Work> allreduce(
       std::vector<at::Tensor>& /* tensors */,
       const AllreduceOptions& /* opts */ = AllreduceOptions()) {
     TORCH_CHECK(
         false,
         c10::str("Backend ", getBackendName(), " does not support allreduce"));
+  }
+
+  // Out-of-place allreduce: outputBuffer receives the reduction of
+  // inputBuffer across all ranks without requiring them to alias the same
+  // storage. Only supported when supportsOutOfPlaceCollectives() is true.
+  virtual c10::intrusive_ptr<Work> _allreduce_oop(
+      at::Tensor& /* outputBuffer */,
+      at::Tensor& /* inputBuffer */,
+      const AllreduceOptions& /* opts */ = AllreduceOptions()) {
+    TORCH_CHECK(
+        false,
+        c10::str(
+            "Backend ", getBackendName(), " does not support _allreduce_oop"));
   }
 
   virtual c10::intrusive_ptr<Work> allreduce_sparse(

--- a/torch/csrc/distributed/c10d/Functional.cpp
+++ b/torch/csrc/distributed/c10d/Functional.cpp
@@ -94,6 +94,25 @@ at::Tensor all_reduce(
         " does not support complex tensors");
   }
   auto input_real = input.is_complex() ? at::view_as_real(input) : input;
+  auto group = c10d::resolve_process_group(group_name);
+  auto backend = group->getBackend(input_real.device().type());
+  if (backend->supportsOutOfPlaceCollectives()) {
+    // Avoid the redundant device-to-device copy that clone() + in-place
+    // allreduce would otherwise incur: NCCL's allreduce already supports
+    // distinct send/recv buffers, so we can write the result straight into a
+    // freshly allocated output tensor.
+    auto input_contig = input_real.contiguous();
+    auto output = at::empty(
+        input_contig.sizes(),
+        at::TensorOptions()
+            .dtype(input_contig.dtype())
+            .device(input_contig.device()));
+    c10d::AllreduceOptions opts;
+    opts.reduceOp = to_reduce_op(reduce_op);
+    auto work = group->_allreduce_oop(output, input_contig, opts);
+    c10d::register_work(output, work);
+    return input.is_complex() ? at::view_as_complex(output) : output;
+  }
   auto output = input_real.clone(at::MemoryFormat::Contiguous);
   auto output_ret =
       all_reduce_(output, std::move(reduce_op), std::move(group_name));
@@ -318,6 +337,25 @@ at::Tensor broadcast(
     const at::Tensor& input,
     int64_t src,
     std::string group_name) {
+  auto input_real = input.is_complex() ? at::view_as_real(input) : input;
+  auto group = c10d::resolve_process_group(group_name);
+  auto backend = group->getBackend(input_real.device().type());
+  if (backend->supportsOutOfPlaceCollectives()) {
+    // Avoid the redundant device-to-device copy that clone() + in-place
+    // broadcast would otherwise incur; see all_reduce() above for the same
+    // rationale.
+    auto input_contig = input_real.contiguous();
+    auto output = at::empty(
+        input_contig.sizes(),
+        at::TensorOptions()
+            .dtype(input_contig.dtype())
+            .device(input_contig.device()));
+    c10d::BroadcastOptions opts;
+    opts.rootRank = src;
+    auto work = group->_broadcast_oop(output, input_contig, opts);
+    c10d::register_work(output, work);
+    return input.is_complex() ? at::view_as_complex(output) : output;
+  }
   auto output = input.clone(at::MemoryFormat::Contiguous);
   return broadcast_(output, src, std::move(group_name));
 }

--- a/torch/csrc/distributed/c10d/Ops.cpp
+++ b/torch/csrc/distributed/c10d/Ops.cpp
@@ -22,7 +22,11 @@ TORCH_LIBRARY(c10d, m) {
   m.def(
       "broadcast_(Tensor[] tensors, __torch__.torch.classes.c10d.ProcessGroup process_group, int root_rank, int root_tensor, bool async_op=True, int timeout=-1) -> (Tensor[], __torch__.torch.classes.c10d.Work)");
   m.def(
+      "_broadcast_oop_(Tensor output_tensor, Tensor input_tensor, __torch__.torch.classes.c10d.ProcessGroup process_group, int root_rank, int root_tensor, bool async_op=True, int timeout=-1) -> (Tensor, __torch__.torch.classes.c10d.Work)");
+  m.def(
       "allreduce_(Tensor[] tensors, __torch__.torch.classes.c10d.ProcessGroup process_group, __torch__.torch.classes.c10d.ReduceOp reduce_op, Tensor? sparse_indices, bool async_op=True, int timeout=-1) -> (Tensor[], __torch__.torch.classes.c10d.Work)");
+  m.def(
+      "_allreduce_oop_(Tensor output_tensor, Tensor input_tensor, __torch__.torch.classes.c10d.ProcessGroup process_group, __torch__.torch.classes.c10d.ReduceOp reduce_op, bool async_op=True, int timeout=-1) -> (Tensor, __torch__.torch.classes.c10d.Work)");
   m.def(
       "allreduce_coalesced_(Tensor[] tensors, __torch__.torch.classes.c10d.ProcessGroup process_group, __torch__.torch.classes.c10d.ReduceOp reduce_op, bool async_op=True, int timeout=-1) -> __torch__.torch.classes.c10d.Work");
   m.def(
@@ -165,6 +169,32 @@ IMPL_BROADCAST(CPU)
 IMPL_BROADCAST(CUDA)
 IMPL_BROADCAST(PrivateUse1)
 
+#define IMPL__BROADCAST_OOP(DEV)                                         \
+  std::tuple<at::Tensor, c10::intrusive_ptr<Work>> _broadcast_oop_##DEV( \
+      at::Tensor& output_tensor,                                          \
+      at::Tensor& input_tensor,                                           \
+      const c10::intrusive_ptr<ProcessGroup>& process_group,              \
+      int64_t root_rank,                                                  \
+      int64_t root_tensor,                                                \
+      bool asyncOp,                                                       \
+      int64_t timeout) {                                                  \
+    auto work = process_group->getBackend(c10::DeviceType::DEV)           \
+                    ->_broadcast_oop(                                    \
+                        output_tensor,                                    \
+                        input_tensor,                                     \
+                        BroadcastOptions{                                 \
+                            root_rank,                                    \
+                            root_tensor,                                  \
+                            std::chrono::milliseconds(timeout),           \
+                            asyncOp});                                    \
+    return std::tuple<at::Tensor, c10::intrusive_ptr<Work>>(              \
+        output_tensor, work);                                             \
+  }
+
+IMPL__BROADCAST_OOP(CPU)
+IMPL__BROADCAST_OOP(CUDA)
+IMPL__BROADCAST_OOP(PrivateUse1)
+
 // Return input tensors as output tensors to make inplace allreduce look like
 // a functional API, so that make_fx can correctly build the dependencies in
 // the graph later.
@@ -192,6 +222,30 @@ IMPL_BROADCAST(PrivateUse1)
 IMPL_ALLREDUCE(CPU)
 IMPL_ALLREDUCE(CUDA)
 IMPL_ALLREDUCE(PrivateUse1)
+
+#define IMPL__ALLREDUCE_OOP(DEV)                                         \
+  std::tuple<at::Tensor, c10::intrusive_ptr<Work>> _allreduce_oop_##DEV( \
+      at::Tensor& output_tensor,                                          \
+      at::Tensor& input_tensor,                                           \
+      const c10::intrusive_ptr<ProcessGroup>& process_group,              \
+      const c10::intrusive_ptr<ReduceOp>& reduce_op,                      \
+      bool asyncOp,                                                       \
+      int64_t timeout) {                                                  \
+    auto work = process_group->getBackend(c10::DeviceType::DEV)           \
+                    ->_allreduce_oop(                                    \
+                        output_tensor,                                    \
+                        input_tensor,                                     \
+                        AllreduceOptions{                                 \
+                            *reduce_op.get(),                             \
+                            std::chrono::milliseconds(timeout),           \
+                            asyncOp});                                    \
+    return std::tuple<at::Tensor, c10::intrusive_ptr<Work>>(              \
+        output_tensor, work);                                             \
+  }
+
+IMPL__ALLREDUCE_OOP(CPU)
+IMPL__ALLREDUCE_OOP(CUDA)
+IMPL__ALLREDUCE_OOP(PrivateUse1)
 
 #define IMPL_ALLREDUCE_COALESCED(DEV)                             \
   c10::intrusive_ptr<Work> allreduce_coalesced_##DEV(             \
@@ -548,7 +602,9 @@ REGISTER_C10D_OP(recv_)
 REGISTER_C10D_OP(recv_any_source_)
 REGISTER_C10D_OP(reduce_)
 REGISTER_C10D_OP(broadcast_)
+REGISTER_C10D_OP(_broadcast_oop_)
 REGISTER_C10D_OP(allreduce_)
+REGISTER_C10D_OP(_allreduce_oop_)
 REGISTER_C10D_OP(allreduce_coalesced_)
 REGISTER_C10D_OP(allgather_)
 REGISTER_C10D_OP(_allgather_base_)

--- a/torch/csrc/distributed/c10d/ProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.hpp
@@ -236,6 +236,38 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
     return work;
   }
 
+  // Out-of-place broadcast; see Backend::_broadcast_oop.
+  virtual c10::intrusive_ptr<Work> _broadcast_oop(
+      at::Tensor& outputBuffer,
+      at::Tensor& inputBuffer,
+      const BroadcastOptions& opts = BroadcastOptions()) {
+    static auto op =
+        c10::Dispatcher::singleton()
+            .findSchemaOrThrow("c10d::_broadcast_oop_", "")
+            .typed<std::tuple<at::Tensor, c10::intrusive_ptr<Work>>(
+                at::Tensor&,
+                at::Tensor&,
+                const c10::intrusive_ptr<::c10d::ProcessGroup>&,
+                int64_t,
+                int64_t,
+                bool,
+                int64_t)>();
+
+    auto work = std::get<1>(op.call(
+        outputBuffer,
+        inputBuffer,
+        c10::intrusive_ptr<ProcessGroup>::unsafe_reclaim_from_nonowning(this),
+        opts.rootRank,
+        opts.rootTensor,
+        opts.asyncOp,
+        opts.timeout.count()));
+
+    if (c10d::allow_inflight_collective_as_graph_input()) {
+      c10d::register_work(outputBuffer, work);
+    }
+    return work;
+  }
+
   virtual c10::intrusive_ptr<Work> allreduce(
       std::vector<at::Tensor>& tensors,
       const AllreduceOptions& opts = AllreduceOptions()) {
@@ -263,6 +295,36 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
       for (const auto& tensor : tensors) {
         c10d::register_work(tensor, work);
       }
+    }
+    return work;
+  }
+
+  // Out-of-place allreduce; see Backend::_allreduce_oop.
+  virtual c10::intrusive_ptr<Work> _allreduce_oop(
+      at::Tensor& outputBuffer,
+      at::Tensor& inputBuffer,
+      const AllreduceOptions& opts = AllreduceOptions()) {
+    static auto op =
+        c10::Dispatcher::singleton()
+            .findSchemaOrThrow("c10d::_allreduce_oop_", "")
+            .typed<std::tuple<at::Tensor, c10::intrusive_ptr<Work>>(
+                at::Tensor&,
+                at::Tensor&,
+                const c10::intrusive_ptr<::c10d::ProcessGroup>&,
+                const c10::intrusive_ptr<::c10d::ReduceOp>&,
+                bool,
+                int64_t)>();
+
+    auto work = std::get<1>(op.call(
+        outputBuffer,
+        inputBuffer,
+        c10::intrusive_ptr<ProcessGroup>::unsafe_reclaim_from_nonowning(this),
+        c10::make_intrusive<ReduceOp>(opts.reduceOp),
+        opts.asyncOp,
+        opts.timeout.count()));
+
+    if (c10d::allow_inflight_collective_as_graph_input()) {
+      c10d::register_work(outputBuffer, work);
     }
     return work;
   }

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -4525,6 +4525,70 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::allreduce(
   return allreduce_impl(tensor, "nccl:all_reduce", opts);
 }
 
+// _allreduce_oop adds an out-of-place allreduce in PGNCCL: output_tensor
+// receives the reduction of input_tensor without requiring the caller to
+// alias their storage, avoiding the extra copy that in-place allreduce
+// forces on callers that want a fresh output tensor.
+c10::intrusive_ptr<Work> ProcessGroupNCCL::_allreduce_oop(
+    at::Tensor& output_tensor,
+    at::Tensor& input_tensor,
+    const AllreduceOptions& opts) {
+  check_gpu_single_tensor(input_tensor);
+  check_gpu_single_tensor(output_tensor);
+
+  if (input_tensor.numel() != output_tensor.numel()) {
+    C10_THROW_ERROR(
+        ValueError,
+        "Tensor input and output of _allreduce_oop must have the same number of elements ");
+  }
+  TORCH_CHECK(
+      !isUnsupportedFloat8(input_tensor.scalar_type()),
+      "Unsupported Float8 type for NCCL reduction");
+
+  RECORD_PARAM_COMMS_DATA(
+      std::make_tuple(
+          static_cast<int64_t>(seqCollective_) + 1,
+          false), // seq + 1 to match collective
+      std::make_tuple(pg_uid_, pg_desc_), // PG name tuple
+      input_tensor, // inputTensors
+      output_tensor, // outputTensors
+      rank_, // rank
+      "_allreduce_oop", // collective name
+      input_tensor.numel(), // inNelems
+      output_tensor.numel(), // outNelems
+      output_tensor.scalar_type(), // dType
+      std::vector<int64_t>(), // inSplitSizes
+      std::vector<int64_t>(), // outSplitSizes
+      globalRankStart_, // globalRankStart_
+      globalRankStride_, // globalRankStride_
+      this->getSize()); // worldSize
+
+  // avoidRecordStreams_ note: collective() will stash input_tensor and
+  // output_tensor.
+  return collective(
+      input_tensor,
+      output_tensor,
+      [&](at::Tensor& input,
+          at::Tensor& output,
+          ncclComm_t comm,
+          at::cuda::CUDAStream& stream) {
+        auto ncclDataType = getNcclDataType(input.scalar_type());
+        auto ncclReduceOp =
+            getNcclReduceOp(opts.reduceOp, input, ncclDataType, comm);
+        return ncclAllReduce(
+            input.data_ptr(),
+            output.data_ptr(),
+            input.numel(),
+            ncclDataType,
+            ncclReduceOp,
+            comm,
+            stream.stream());
+      },
+      OpType::ALLREDUCE,
+      opts.asyncOp,
+      "nccl:_allreduce_oop");
+}
+
 c10::intrusive_ptr<Work> ProcessGroupNCCL::allreduce_coalesced(
     std::vector<at::Tensor>& tensors,
     const AllreduceCoalescedOptions& opts) {

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -824,6 +824,10 @@ class TORCH_API ProcessGroupNCCL : public Backend {
 #endif
   }
 
+  bool supportsOutOfPlaceCollectives() const override {
+    return true;
+  }
+
   void setTimeout(std::chrono::milliseconds timeout) override {
     options_->timeout = timeout;
   }
@@ -846,7 +850,7 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   c10::intrusive_ptr<Work> _broadcast_oop(
       at::Tensor& outputTensors,
       at::Tensor& inputTensors,
-      const BroadcastOptions& opts = BroadcastOptions());
+      const BroadcastOptions& opts = BroadcastOptions()) override;
 
   c10::intrusive_ptr<Work> allreduce_sparse(
       std::vector<at::Tensor>& tensors,
@@ -854,6 +858,11 @@ class TORCH_API ProcessGroupNCCL : public Backend {
 
   c10::intrusive_ptr<Work> allreduce(
       std::vector<at::Tensor>& tensors,
+      const AllreduceOptions& opts = AllreduceOptions()) override;
+
+  c10::intrusive_ptr<Work> _allreduce_oop(
+      at::Tensor& outputTensor,
+      at::Tensor& inputTensor,
       const AllreduceOptions& opts = AllreduceOptions()) override;
 
   c10::intrusive_ptr<Work> allreduce_coalesced(

--- a/torch/distributed/flight_recorder/components/types.py
+++ b/torch/distributed/flight_recorder/components/types.py
@@ -210,6 +210,7 @@ COLLECTIVES = {
     "_reduce_oop",
     "all_gather",
     "all_reduce",
+    "_allreduce_oop",
     "_all_gather_base",
     "all_gather_into_tensor_coalesced",
     "reduce_scatter",


### PR DESCRIPTION
Hi, I am a fan of the DTensor API which uses functional collectives.
However, there is redundant copies in the all_reduce and broadcast when not using compile.
The NCCL interface already supports out of place APIs.
Can someone take a look at this PR?

The idea is to allocate output = torch.empty(...) rather than output = input.clone()

Note: I am not very familiar with NCCL and this PR is generated by Opus