### PR TITLE
Fix assert_close to support comparisons involving Python and NumPy scalars

### DIFF
--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -981,6 +981,22 @@ class TestAssertClose(TestCase):
             torch.testing.assert_close(torch.ones(()), np.float64(1.0), check_dtype=False)
             torch.testing.assert_close(torch.tensor(1.0, dtype=torch.float64), np.float64(1.0))
 
+            # 0-d numpy.ndarray vs Tensor (eager and compiled)
+            torch.testing.assert_close(torch.ones(()), np.array(1.0), check_dtype=False)
+            torch.testing.assert_close(torch.tensor(1.0, dtype=torch.float64), np.array(1.0))
+
+            @torch.compile(backend="aot_eager")
+            def compiled_assert_close(x, y):
+                torch.testing.assert_close(x, y, check_dtype=False)
+
+            compiled_assert_close(torch.ones(()), np.array(1.0))
+
+            # Non-scalar numpy.ndarray (1-d or 2-d) still raises TypeError
+            with self.assertRaises(TypeError):
+                torch.testing.assert_close(torch.ones(2), np.array([1.0, 1.0]))
+            with self.assertRaises(TypeError):
+                torch.testing.assert_close(torch.ones((2, 2)), np.array([[1.0, 1.0], [1.0, 1.0]]))
+
         # CUDA tensor vs Python scalar (if CUDA is available)
         if torch.cuda.is_available():
             torch.testing.assert_close(torch.ones((), device="cuda"), 1, check_dtype=False)

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -22,7 +22,7 @@ from torch.testing import make_tensor
 from torch.testing._internal.common_utils import (
     IS_FBCODE, IS_JETSON, IS_MACOS, IS_SANDCASTLE, IS_WINDOWS, TestCase, run_tests, slowTest,
     parametrize, reparametrize, subtest, instantiate_parametrized_tests, dtype_name,
-    TEST_WITH_ROCM, decorateIf, skipIfXpu
+    TEST_WITH_ROCM, decorateIf, skipIfXpu, TEST_NUMPY
 )
 from torch.testing._internal.common_device_type import \
     (PYTORCH_TESTING_DEVICE_EXCEPT_FOR_KEY, PYTORCH_TESTING_DEVICE_ONLY_FOR_KEY, dtypes,
@@ -969,7 +969,30 @@ class TestAssertClose(TestCase):
         with self.assertRaisesRegex(RuntimeError, "unexpected exception"):
             torch.testing.assert_close(actual, expected)
 
+    def test_tensor_vs_scalar(self):
+        # CPU tensor vs Python scalar
+        torch.testing.assert_close(torch.ones(()), 1, check_dtype=False)
+        torch.testing.assert_close(torch.tensor(1, dtype=torch.int64), 1)
+        torch.testing.assert_close(torch.ones(()), 1.0, check_dtype=False)
 
+        # NumPy scalar vs Tensor
+        if TEST_NUMPY:
+            import numpy as np
+            torch.testing.assert_close(torch.ones(()), np.float64(1.0), check_dtype=False)
+            torch.testing.assert_close(torch.tensor(1.0, dtype=torch.float64), np.float64(1.0))
+
+        # CUDA tensor vs Python scalar (if CUDA is available)
+        if torch.cuda.is_available():
+            torch.testing.assert_close(torch.ones((), device="cuda"), 1, check_dtype=False)
+            torch.testing.assert_close(torch.ones((), device="cuda"), 1.0, check_dtype=False)
+
+        # Ensure unsupported types (e.g., list, numpy.ndarray) still raise the expected TypeError.
+        with self.assertRaises(TypeError):
+            torch.testing.assert_close(torch.arange(3), [0, 1, 2])
+        if TEST_NUMPY:
+            import numpy as np
+            with self.assertRaises(TypeError):
+                torch.testing.assert_close(torch.ones(2), np.ones(2))
 
 
 class TestAssertCloseMultiDevice(TestCase):

--- a/torch/testing/_comparison.py
+++ b/torch/testing/_comparison.py
@@ -729,10 +729,14 @@ class TensorLikePair(Pair):
         self, actual: Any, expected: Any, *, id: tuple[Any, ...], allow_subclasses: bool
     ) -> tuple[torch.Tensor, torch.Tensor]:
         is_actual_scalar = isinstance(actual, (bool, int, float, complex)) or (
-            np is not None and isinstance(actual, np.generic)
+            np is not None and (
+                isinstance(actual, np.generic) or (isinstance(actual, np.ndarray) and actual.ndim == 0)
+            )
         )
         is_expected_scalar = isinstance(expected, (bool, int, float, complex)) or (
-            np is not None and isinstance(expected, np.generic)
+            np is not None and (
+                isinstance(expected, np.generic) or (isinstance(expected, np.ndarray) and expected.ndim == 0)
+            )
         )
 
         if not (is_actual_scalar or is_expected_scalar):

--- a/torch/testing/_comparison.py
+++ b/torch/testing/_comparison.py
@@ -729,10 +729,10 @@ class TensorLikePair(Pair):
         self, actual: Any, expected: Any, *, id: tuple[Any, ...], allow_subclasses: bool
     ) -> tuple[torch.Tensor, torch.Tensor]:
         is_actual_scalar = isinstance(actual, (bool, int, float, complex)) or (
-            HAS_NUMPY and isinstance(actual, np.generic)
+            np is not None and isinstance(actual, np.generic)
         )
         is_expected_scalar = isinstance(expected, (bool, int, float, complex)) or (
-            HAS_NUMPY and isinstance(expected, np.generic)
+            np is not None and isinstance(expected, np.generic)
         )
 
         if not (is_actual_scalar or is_expected_scalar):
@@ -758,7 +758,9 @@ class TensorLikePair(Pair):
             self._check_supported(tensor, id=id)
         return actual, expected
 
-    def _to_tensor(self, tensor_like: Any, *, device: torch.device | None = None) -> torch.Tensor:
+    def _to_tensor(
+        self, tensor_like: Any, *, device: torch.device | None = None
+    ) -> torch.Tensor:
         if isinstance(tensor_like, torch.Tensor):
             return tensor_like
 

--- a/torch/testing/_comparison.py
+++ b/torch/testing/_comparison.py
@@ -728,26 +728,42 @@ class TensorLikePair(Pair):
     def _process_inputs(
         self, actual: Any, expected: Any, *, id: tuple[Any, ...], allow_subclasses: bool
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        directly_related = isinstance(actual, type(expected)) or isinstance(
-            expected, type(actual)
+        is_actual_scalar = isinstance(actual, (bool, int, float, complex)) or (
+            HAS_NUMPY and isinstance(actual, np.generic)
         )
-        if not directly_related:
-            self._inputs_not_supported()
+        is_expected_scalar = isinstance(expected, (bool, int, float, complex)) or (
+            HAS_NUMPY and isinstance(expected, np.generic)
+        )
 
-        if not allow_subclasses and type(actual) is not type(expected):
-            self._inputs_not_supported()
+        if not (is_actual_scalar or is_expected_scalar):
+            directly_related = isinstance(actual, type(expected)) or isinstance(
+                expected, type(actual)
+            )
+            if not directly_related:
+                self._inputs_not_supported()
 
-        actual, expected = (self._to_tensor(input) for input in (actual, expected))
+            if not allow_subclasses and type(actual) is not type(expected):
+                self._inputs_not_supported()
+
+        device = None
+        if isinstance(actual, torch.Tensor):
+            device = actual.device
+        elif isinstance(expected, torch.Tensor):
+            device = expected.device
+
+        actual, expected = (
+            self._to_tensor(input, device=device) for input in (actual, expected)
+        )
         for tensor in (actual, expected):
             self._check_supported(tensor, id=id)
         return actual, expected
 
-    def _to_tensor(self, tensor_like: Any) -> torch.Tensor:
+    def _to_tensor(self, tensor_like: Any, *, device: torch.device | None = None) -> torch.Tensor:
         if isinstance(tensor_like, torch.Tensor):
             return tensor_like
 
         try:
-            return torch.as_tensor(tensor_like)
+            return torch.as_tensor(tensor_like, device=device)
         except Exception:
             self._inputs_not_supported()
 


### PR DESCRIPTION
### Description
This PR resolves issue #161863 where `torch.testing.assert_close` would raise a `TypeError` (no comparison pair was able to handle inputs) when comparing a `torch.Tensor` to a Python scalar (`int`, `float`, `complex`, `bool`) or a NumPy scalar (`np.generic`).

### Implementation Details
- Modified `TensorLikePair._process_inputs` to identify if either input is a Python or NumPy scalar. If so, we bypass the strict `directly_related` subclass and type matching checks.
- Bypassed spurious device mismatch errors by dynamically identifying the target device of the `torch.Tensor` operand and initializing the scalar directly on that device via `torch.as_tensor(tensor_like, device=device)` during conversion. 
- This device-coercion approach is extremely clean and eliminates the need for keeping temporary instance variables or modifying attribute matching methods in `TensorLikePair`.
- Preserves expected behavior of `check_dtype=True`, which will still correctly raise an `AssertionError` for mismatched dtypes (e.g., `float32` vs `float64`), as documented.

### Link to Issue
Fixes #161863

### Test Plan
1. Added regression tests in `test/test_testing.py` covering CPU tensor vs scalar, CUDA tensor vs scalar, NumPy scalar vs tensor, and type checks.
2. Ran regression test:
   ```bash
   python test/test_testing.py -k test_tensor_vs_scalar

cc @mruberry @rgommers