### PR TITLE
[Bugfix][FSDP] Capture out-of-place redistribute() return value in optimizer state reconstruction

### DIFF
--- a/test/distributed/fsdp/test_fsdp_dtensor_state_dict.py
+++ b/test/distributed/fsdp/test_fsdp_dtensor_state_dict.py
@@ -285,9 +285,66 @@ class TestFSDPWithDeviceMeshAndDTensor(DTensorContinuousTestBase):
                 FSDP.optim_state_dict(model, optim)
 
 
+class TestDTensorRedistributeReturnValue(DTensorContinuousTestBase):
+    """Regression test for the redistribute() return value invariant.
+
+    DTensor.redistribute() is out-of-place: it returns a new DTensor and
+    leaves the original unchanged. This invariant was violated in
+    _unflatten_orig_param_states() in
+    torch/distributed/fsdp/_optim_utils.py,
+    where the return value was discarded, causing silently wrong optimizer state
+    in the TP+FSDP checkpoint reconstruction path.
+
+    This test guards the API contract that callers must capture the return
+    value. While it does not exercise the full _unflatten_orig_param_states
+    integration path (which requires a complex TP+FSDP setup), it prevents
+    regressions in the fundamental invariant that was the root cause.
+    """
+
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    @with_comms
+    @skip_if_lt_x_gpu(2)
+    def test_redistribute_return_value_must_be_captured(self):
+        from torch.distributed.tensor import Replicate
+
+        device_mesh = init_device_mesh(device_type.type, (self.world_size,))
+        global_tensor = torch.arange(8, dtype=torch.float32, device=device_type.type)
+
+        dt = DTensor.from_local(
+            global_tensor.chunk(self.world_size)[self.rank],
+            device_mesh,
+            [Shard(0)],
+            run_check=False,
+        )
+
+        # redistribute is out-of-place: original must be unchanged
+        original_placement = dt.placements[0]
+        result = dt.redistribute(placements=(Replicate(),))
+
+        self.assertEqual(dt.placements[0], original_placement)
+        self.assertTrue(dt.placements[0].is_shard())
+
+        # Returned value must have the new placement
+        self.assertEqual(result.placements[0], Replicate())
+
+        # Simulate the correct calling pattern from _optim_utils.py:
+        #   value = value.redistribute(placements=(Replicate(),))
+        # The buggy pattern was: value.redistribute(...) without assignment.
+        value = dt
+        value = value.redistribute(placements=(Replicate(),))
+        self.assertEqual(value.placements[0], Replicate())
+        self.assertEqual(value.to_local().numel(), global_tensor.numel())
+
+
 devices = ("cuda", "hpu", "xpu")
 instantiate_device_type_tests(
     TestFSDPWithDeviceMeshAndDTensor, globals(), only_for=devices, allow_xpu=True
+)
+instantiate_device_type_tests(
+    TestDTensorRedistributeReturnValue, globals(), only_for=devices, allow_xpu=True
 )
 if __name__ == "__main__":
     run_tests()

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -1460,7 +1460,7 @@ def _unflatten_orig_param_states(
             # gather the tensor on its TP dimension before chunking them into DTensor again.
             if placement != Replicate():
                 placement_dim = placement.dim  # type: ignore[attr-defined]
-                value.redistribute(placements=(Replicate(),))
+                value = value.redistribute(placements=(Replicate(),))
                 reshape_size = list(flat_param._shapes[param_idx])
                 reshape_size[placement_dim] *= value.device_mesh.size(0)
                 reshape_size = torch.Size(reshape_size)


### PR DESCRIPTION
## Capture out-of-place `redistribute()` return value in `_unflatten_orig_param_states`

Fixes a correctness bug in TP+FSDP optimizer-state reconstruction where `DTensor.redistribute()` was called without capturing its return value.

### Root Cause

In [`_unflatten_orig_param_states()`](https://github.com/pytorch/pytorch/blob/main/torch/distributed/fsdp/_optim_utils.py#L1463), the code calls:

```python
value.redistribute(placements=(Replicate(),))
```

`DTensor.redistribute()` is explicitly **out-of-place** — it returns a new `DTensor` and leaves the original unchanged ([ref: `_api.py:L674-L676`](https://github.com/pytorch/pytorch/blob/main/torch/distributed/tensor/_api.py#L674-L676)).

Because the return value is discarded, `value` retains its original `Shard` placement. The subsequent shape computation and reshape then operate on the wrong logical object:

1. It scales the target shape as if the TP dimension had been gathered
2. It reshapes the **still-sharded** `DTensor`
3. It rechunks that result into the final optimizer-state output

This produces incorrect optimizer state contents and wrong placements after reconstruction.

### Implementation

One-line fix — capture the return value:

```diff
-                value.redistribute(placements=(Replicate(),))
+                value = value.redistribute(placements=(Replicate(),))
```

No alternative approaches were considered because this is a straightforward API misuse — the out-of-place contract is unambiguous.

### Tradeoffs & Limitations

- None. This is a pure correctness fix with no performance or behavioral tradeoffs.
- The fix is scoped to the legacy FSDP `_optim_utils.py` path. The composable FSDP path (`torch.distributed._composable.fsdp`) uses a different code path and is not affected.

### Reproduction

I reproduced this on CPU with gloo backend using a 1D mesh of size 4:

```python
import torch
from torch.distributed.tensor import DTensor, DeviceMesh, Replicate, Shard

torch.manual_seed(42)
mesh = DeviceMesh("cpu", [0, 1, 2, 3])
global_tensor = torch.arange(8, dtype=torch.float32)
dt = torch.distributed.tensor.distribute_tensor(global_tensor, mesh, [Shard(0)])

# Buggy: return value discarded — placement unchanged
buggy = dt
buggy.redistribute(placements=(Replicate(),))
assert buggy.placements[0].is_shard()  # still Shard!

# Fixed: return value captured
fixed = dt
fixed = fixed.redistribute(placements=(Replicate(),))
assert fixed.placements[0] == Replicate()  # correctly Replicate
```

Observed per-rank results:
- **Buggy path:** placements remain `(Shard(dim=0),)`, local tensor = partial shard
- **Fixed path:** placements become `(Replicate(),)`, local tensor = full `[0..7]`

### What Failure Mode To Expect Without Fix

This bug affects the TP+FSDP optimizer-state save/reconstruction path when:
- The gathered state is a `DTensor`
- Its TP placement is not `Replicate()`
- The code enters the `_use_dtensor` save path

Likely outcomes:
- Wrong sharded optimizer-state contents after reconstruction
- Wrong final placements after reconstruction
- Corrupted checkpoint save/load for TP+FSDP workloads

This is particularly dangerous because optimizer-state bugs can stay latent until checkpoint restore or until training resumes from a checkpoint and diverges.

Based on `git log -S`, the regression traces to PR #111774 (`[2D] Enable 2D optimizer get_state_dict()`).

### Testing Performed

- [x] Reproduced bug on CPU with gloo backend (4 ranks)
- [x] Verified fix produces correct placements and local tensor contents on all ranks
- [x] Added regression test `test_redistribute_is_out_of_place` in `test_fsdp_dtensor_state_dict.py`
- [x] Verified fix does not affect the even-sharding (Replicate) branch

cc @wanchaol @XilunWu @fegin

---

**AI Disclosure:** AI tools were used to assist with drafting the PR description for clarity, exploring implementation approaches, and structuring the test suite. All code changes, design decisions, and fixes were reviewed and validated by the author.