### PR TITLE
[Bugfix][DTensor] Fix wrong shard offsets for uneven DTensor shards in TP-FSDP metadata

### DIFF
--- a/test/distributed/tensor/parallel/test_tp_fsdp_shard_metadata.py
+++ b/test/distributed/tensor/parallel/test_tp_fsdp_shard_metadata.py
@@ -1,0 +1,131 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates
+# Owner(s): ["oncall: distributed"]
+
+import torch
+import torch.distributed as dist
+import torch.distributed.fsdp  # noqa: F401 -- must init before fsdp submodule
+from torch.distributed._shard.sharded_tensor import ShardedTensor
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.tensor import distribute_tensor, Replicate, Shard
+from torch.distributed.tensor.parallel.fsdp import _chunk_tensor, _get_box_for
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+)
+from torch.testing._internal.distributed._tensor.common_dtensor import (
+    DTensorTestBase,
+    with_comms,
+)
+
+
+class TestGetBoxForUnevenShards(DTensorTestBase):
+    """_get_box_for must follow torch.chunk (ceil-division) semantics.
+
+    Per-rank shard offsets and sizes must match DTensor's internal Shard
+    placement, which uses torch.chunk. This test suite verifies correctness
+    for various global sizes and world sizes.
+    """
+
+    @property
+    def world_size(self) -> int:
+        return 3
+
+    @with_comms
+    @parametrize(
+        "global_size,expected_offsets,expected_sizes",
+        [
+            # uneven: 5 / 3 -> [2, 2, 1]
+            (5, [0, 2, 4], [2, 2, 1]),
+            # ceil vs floor diverge: 7 / 3 -> [3, 3, 1] (ceil), not [3, 2, 2]
+            (7, [0, 3, 6], [3, 3, 1]),
+            # ceil vs floor diverge: 10 / 3 -> [4, 4, 2] (ceil), not [4, 3, 3]
+            (10, [0, 4, 8], [4, 4, 2]),
+            # even (regression): 6 / 3 -> [2, 2, 2]
+            (6, [0, 2, 4], [2, 2, 2]),
+            # global < world: 1 / 3 -> [1, 0, 0]
+            (1, [0, 1, 1], [1, 0, 0]),
+        ],
+    )
+    def test_get_box_for_shard_offsets(
+        self, global_size, expected_offsets, expected_sizes
+    ):
+        mesh = init_device_mesh("cpu", (self.world_size,))
+        dt = distribute_tensor(
+            torch.arange(global_size, dtype=torch.float32), mesh, [Shard(0)]
+        )
+
+        for idx in range(self.world_size):
+            offsets, sizes = _get_box_for(dt, idx)
+            self.assertEqual(offsets[0], expected_offsets[idx])
+            self.assertEqual(sizes[0], expected_sizes[idx])
+
+    @with_comms
+    def test_get_box_for_replicated_placement(self):
+        """Non-shard placement: offsets are zero, sizes are the full global size."""
+        mesh = init_device_mesh("cpu", (self.world_size,))
+        dt = distribute_tensor(
+            torch.arange(5, dtype=torch.float32), mesh, [Replicate()]
+        )
+
+        for idx in range(self.world_size):
+            offsets, sizes = _get_box_for(dt, idx)
+            self.assertEqual(offsets[0], 0)
+            self.assertEqual(sizes[0], 5)
+
+    @with_comms
+    def test_get_box_for_multidim_non_zero_shard_dim(self):
+        """2D tensor sharded on dim=1: dim 0 unchanged, dim 1 chunked."""
+        mesh = init_device_mesh("cpu", (self.world_size,))
+
+        # Shape (4, 7), sharded on dim=1 -> torch.chunk(7, 3) -> [3, 3, 1]
+        t = torch.randn(4, 7)
+        dt = distribute_tensor(t, mesh, [Shard(1)])
+
+        expected_offsets_dim1 = [0, 3, 6]
+        expected_sizes_dim1 = [3, 3, 1]
+
+        for idx in range(self.world_size):
+            offsets, sizes = _get_box_for(dt, idx)
+            # dim 0 is not sharded
+            self.assertEqual(offsets[0], 0)
+            self.assertEqual(sizes[0], 4)
+            # dim 1 is sharded
+            self.assertEqual(offsets[1], expected_offsets_dim1[idx])
+            self.assertEqual(sizes[1], expected_sizes_dim1[idx])
+
+    @with_comms
+    def test_get_box_for_matches_local_tensor_size(self):
+        """_get_box_for(dt, rank) shard size must match dt._local_tensor.size().
+
+        This cross-checks the computed metadata against the actual DTensor
+        local data, independent of the chunk formula.
+        """
+        mesh = init_device_mesh("cpu", (self.world_size,))
+        dt = distribute_tensor(torch.arange(7, dtype=torch.float32), mesh, [Shard(0)])
+
+        _, sizes = _get_box_for(dt, self.rank)
+        self.assertEqual(sizes, dt._local_tensor.size())
+
+    @with_comms
+    def test_chunk_tensor_uneven_shard_no_overlap_error(self):
+        """_chunk_tensor must not raise ValueError for uneven DTensor shards.
+
+        Before the fix, floor-division offsets produced overlapping
+        ShardMetadata, causing validate_non_overlapping_shards_metadata
+        to raise ValueError from
+        ShardedTensor._init_from_local_shards_and_global_metadata.
+        """
+        mesh = init_device_mesh("cpu", (self.world_size,))
+        dt = distribute_tensor(torch.arange(7, dtype=torch.float32), mesh, [Shard(0)])
+        pg = dist.group.WORLD
+
+        # This must not raise ValueError: Shards ... overlap
+        st = _chunk_tensor(dt, self.rank, self.world_size, 1, pg)
+        self.assertIsInstance(st, ShardedTensor)
+
+
+instantiate_parametrized_tests(TestGetBoxForUnevenShards)
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/distributed/tensor/parallel/fsdp.py
+++ b/torch/distributed/tensor/parallel/fsdp.py
@@ -28,27 +28,34 @@ from torch.distributed.tensor.parallel._data_parallel_utils import (
 __all__ = ["DTensorExtensions"]
 
 
-def _get_box(tensor: DTensor) -> tuple[torch.Size, torch.Size]:
+def _get_box_for(tensor: DTensor, idx: int) -> tuple[torch.Size, torch.Size]:
     device_mesh = tensor.device_mesh
     if device_mesh.ndim != 1:
         raise AssertionError("Only 1D DeviceMeshes currently handled")
 
     placement = tensor.placements[0]
     offsets = [0] * len(tensor.size())
-    num_chunks = device_mesh.size(mesh_dim=0)
+    shard_sizes = list(tensor.size())
 
     # NOTE: is_shard() does not match _StridedShard; see _is_shard_like().
-    if tensor.placements[0].is_shard():
+    # The non-is_shard() fallback returns the full global size, which is
+    # correct for Replicate/Partial but would be wrong for _StridedShard.
+    # This is safe today because _get_box_for requires a 1-D mesh (above)
+    # and _StridedShard is only constructed for 2D+ redistribution.
+    if placement.is_shard():
         shard_dim = cast(DShard, placement).dim
-        chunk_size = tensor.size(shard_dim) // num_chunks
-        offsets[shard_dim] = chunk_size
+        full_dim_size = tensor.size(shard_dim)
+        num_chunks = device_mesh.size(mesh_dim=0)
+        # Use Shard.local_shard_size_and_offset which computes sizes and
+        # offsets using torch.chunk (ceil-division) semantics -- the same
+        # logic DTensor uses internally for Shard placement.
+        shard_size, shard_offset = DShard.local_shard_size_and_offset(
+            full_dim_size, num_chunks, idx
+        )
+        offsets[shard_dim] = shard_offset
+        shard_sizes[shard_dim] = shard_size
 
-    return (torch.Size(offsets), tensor._local_tensor.size())
-
-
-def _get_box_for(tensor: DTensor, idx: int) -> tuple[torch.Size, torch.Size]:
-    offsets, size = _get_box(tensor)
-    return (torch.Size([val * idx for val in offsets]), size)
+    return (torch.Size(offsets), torch.Size(shard_sizes))
 
 
 def _get_local_box(tensor: DTensor) -> tuple[torch.Size, torch.Size]:


### PR DESCRIPTION
## Fix wrong shard offsets for uneven DTensor shards in `_get_box_for`

Fixes a correctness bug in TP-FSDP shard metadata generation where `ShardMetadata` offsets are computed incorrectly for DTensors whose shard dimension is not evenly divisible by the mesh size.

### Root Cause

In the original `_get_box()`/`_get_box_for()`, shard offsets were computed using floor division:

```python
chunk_size = tensor.size(shard_dim) // num_chunks
offsets[shard_dim] = chunk_size * idx
```

DTensor's `Shard` placement uses `torch.chunk` (ceil-division) semantics, so the actual shard layout differs from what this code computes.

**Example:** `global_size=7, world_size=3`:
- Actual shard sizes (`torch.chunk`, ceil): `[3, 3, 1]`, offsets: `[0, 3, 6]`
- Buggy offsets (floor division): `[0, 2, 4]` with sizes `[3, 3, 3]`

### Failure Mode

The floor-division offsets produce **overlapping** `ShardMetadata` intervals. When `_chunk_tensor` passes these to `ShardedTensor._init_from_local_shards_and_global_metadata`, the call to `validate_non_overlapping_shards_metadata` (`torch/distributed/_shard/sharding_spec/_internals.py:138`) raises:

```
ValueError: Shards ... overlap
```

This blocks any TP+FSDP code path that goes through `_chunk_tensor` with an unevenly-sharded DTensor.

### Implementation

Merged `_get_box` and `_get_box_for` into a single `_get_box_for(tensor, idx)` that delegates to `Shard.local_shard_size_and_offset`:

```python
shard_size, shard_offset = DShard.local_shard_size_and_offset(
    full_dim_size, num_chunks, idx
)
```

This approach:
- **Guarantees correctness** by using the exact same code path DTensor uses internally
- **Reduces code** from ~20 lines of custom math to ~5 lines of delegation
- **Eliminates maintenance risk** of chunking semantics drifting apart

### Backward Compatibility

The non-`is_shard()` fallback now returns the full global size (previously returned `tensor._local_tensor.size()`). For `Replicate`/`Partial` placements these are equal. For `_StridedShard` they would differ, but this is unreachable today because `_get_box_for` requires a 1-D mesh and `_StridedShard` is only constructed for 2D+ redistribution. A comment documents this invariant.

### Testing

- `@parametrize`d unit test covering 5 global sizes (uneven, ceil-divergent, even, edge case)
- Replicated placement test (offsets zero, full global size)
- Multi-dim tensor with non-zero shard dim
- Cross-check: `_get_box_for(dt, rank)[1] == dt._local_tensor.size()`
- **End-to-end regression test**: drives `_chunk_tensor` on an unevenly-sharded DTensor and asserts `ShardedTensor` construction does not raise `ValueError`

cc @wanchaol @XilunWu @fegin

**AI Disclosure:** AI tools were used to assist with drafting the PR description for clarity, exploring implementation approaches, and structuring the test suite. All code changes, design decisions, and fixes were reviewed and validated by the author.