### PR TITLE
Add ROCm Docker release images

### DIFF
--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -37,10 +37,10 @@ CUDA_ARCHES_CUDNN_VERSION = {
     "13.2": "9",
 }
 
-ROCM_ARCHES = ["7.1", "7.2"]
+ROCM_ARCHES = ["7.2", "7.14"]
 ROCM_ARCHES_FULL_VERSION = {
-    "7.1": "7.1.1",
     "7.2": "7.2.3",
+    "7.14": "7.14.0",
 }
 
 XPU_ARCHES = ["xpu"]

--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -38,6 +38,10 @@ CUDA_ARCHES_CUDNN_VERSION = {
 }
 
 ROCM_ARCHES = ["7.1", "7.2"]
+ROCM_ARCHES_FULL_VERSION = {
+    "7.1": "7.1.1",
+    "7.2": "7.2.3",
+}
 
 XPU_ARCHES = ["xpu"]
 

--- a/.github/scripts/generate_docker_release_matrix.py
+++ b/.github/scripts/generate_docker_release_matrix.py
@@ -1,26 +1,23 @@
 #!/usr/bin/env python3
-
 """Generates a matrix for docker releases through github actions
-
-Will output a condensed version of the matrix. Will include fllowing:
+Will output a condensed version of the matrix. Will include following:
     * CUDA version short
     * CUDA full version
     * CUDNN version short
     * Image type either runtime or devel
     * Platform linux/arm64,linux/amd64
-
+    * ROCm version short
+    * ROCm full version
 """
-
 import json
-
 import generate_binary_build_matrix
-
 
 DOCKER_IMAGE_TYPES = ["runtime", "devel"]
 
 
 def generate_docker_matrix() -> dict[str, list[dict[str, str]]]:
     ret: list[dict[str, str]] = []
+
     # CUDA amd64 Docker images are available as both runtime and devel while
     # CPU arm64 image is only available as runtime.
     for cuda, version in generate_binary_build_matrix.CUDA_ARCHES_FULL_VERSION.items():
@@ -34,8 +31,26 @@ def generate_docker_matrix() -> dict[str, list[dict[str, str]]]:
                     ],
                     "image_type": image,
                     "platform": "linux/amd64",
+                    "rocm": "",
+                    "rocm_full_version": "",
                 }
             )
+
+    # ROCm amd64 Docker images, runtime and devel
+    for rocm, version in generate_binary_build_matrix.ROCM_ARCHES_FULL_VERSION.items():
+        for image in DOCKER_IMAGE_TYPES:
+            ret.append(
+                {
+                    "cuda": "",
+                    "cuda_full_version": "",
+                    "cudnn_version": "",
+                    "image_type": image,
+                    "platform": "linux/amd64",
+                    "rocm": rocm,
+                    "rocm_full_version": version,
+                }
+            )
+
     ret.append(
         {
             "cuda": "cpu",
@@ -43,9 +58,10 @@ def generate_docker_matrix() -> dict[str, list[dict[str, str]]]:
             "cudnn_version": "",
             "image_type": "runtime",
             "platform": "linux/arm64",
+            "rocm": "",
+            "rocm_full_version": "",
         }
     )
-
     return {"include": ret}
 
 

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -82,6 +82,8 @@ jobs:
       CUDA_VERSION: ${{ matrix.cuda_full_version }}
       CUDA_VERSION_SHORT: ${{ matrix.cuda }}
       CUDNN_VERSION: ${{ matrix.cudnn_version }}
+      ROCM_VERSION: ${{ matrix.rocm_full_version }}
+      ROCM_VERSION_SHORT: ${{ matrix.rocm }}
     steps:
       - name: Setup SSH (Click me for login details)
         uses: pytorch/test-infra/.github/actions/setup-ssh@main

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN git submodule update --init --recursive
 FROM python-deps as pytorch-installs
 ARG CUDA_PATH=cu121
 ARG INSTALL_CHANNEL=whl/nightly
+ARG ROCM_VERSION=
 # Automatically set by buildx
 ARG TARGETPLATFORM
 
@@ -49,7 +50,10 @@ ARG TARGETPLATFORM
 RUN case ${TARGETPLATFORM} in \
          "linux/arm64")  pip3 install --extra-index-url https://download.pytorch.org/whl/cpu/ torch torchvision torchaudio ;; \
          *) \
-             if [ "${CUDA_PATH}" = "cu132" ]; then \
+             if [ -n "${ROCM_VERSION}" ]; then \
+                 ROCM_PATH="rocm$(echo ${ROCM_VERSION} | cut -d'.' -f1,2)"; \
+                 pip3 install --index-url https://download.pytorch.org/${INSTALL_CHANNEL}/${ROCM_PATH}/ torch torchvision torchaudio; \
+             elif [ "${CUDA_PATH}" = "cu132" ]; then \
                  pip3 install --index-url https://download.pytorch.org/${INSTALL_CHANNEL}/${CUDA_PATH}/ torch torchvision; \
              else \
                  pip3 install --index-url https://download.pytorch.org/${INSTALL_CHANNEL}/${CUDA_PATH}/ torch torchvision torchaudio; \
@@ -86,10 +90,12 @@ RUN if test -n "${CUDA_VERSION}" -a "${TARGETPLATFORM}" != "linux/arm64"; then \
         DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gcc && \
         rm -rf /var/lib/apt/lists/*; \
     fi
-ENV NVIDIA_VISIBLE_DEVICES all
-ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+ARG ROCM_VERSION=
+ENV NVIDIA_VISIBLE_DEVICES ${ROCM_VERSION:+}${ROCM_VERSION:-all}
+ENV NVIDIA_DRIVER_CAPABILITIES ${ROCM_VERSION:+}${ROCM_VERSION:-compute,utility}
 ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
 ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:$PATH
+ENV ROCM_VERSION ${ROCM_VERSION}
 ENV PYTORCH_VERSION ${PYTORCH_VERSION}
 WORKDIR /workspace
 
@@ -99,7 +105,7 @@ ARG BUILD_TYPE
 
 # Install CUDA toolkit for devel images
 # Only runs when building devel-image target (BUILD_TYPE != official)
-RUN if [ "${BUILD_TYPE}" = "dev" ] && [ -n "${CUDA_VERSION}" ]; then \
+RUN if [ "${BUILD_TYPE}" = "dev" ] && [ -n "${CUDA_VERSION}" ] && [ -z "${ROCM_VERSION}" ]; then \
     apt-get update && apt-get install -y --no-install-recommends \
         wget gnupg2 ca-certificates && \
     # Add NVIDIA repository

--- a/README.md
+++ b/README.md
@@ -410,6 +410,16 @@ You can also pull a pre-built docker image from Docker Hub and run with docker v
 docker run --gpus all --rm -ti --ipc=host pytorch/pytorch:latest
 ```
 
+**ROCm (AMD GPUs):**
+```bash
+docker run --device=/dev/kfd --device=/dev/dri --rm -ti --ipc=host pytorch/pytorch:-rocm-runtime
+```
+
+For example:
+```bash
+docker run --device=/dev/kfd --device=/dev/dri --rm -ti --ipc=host pytorch/pytorch:2.13.0-rocm7.2-runtime
+```
+
 Please note that PyTorch uses shared memory to share data between processes, so if torch multiprocessing is used (e.g.
 for multithreaded data loaders) the default shared memory segment size that container runs with is not enough, and you
 should increase shared memory size either with `--ipc=host` or `--shm-size` command line options to `nvidia-docker run`.
@@ -419,6 +429,11 @@ should increase shared memory size either with `--ipc=host` or `--shm-size` comm
 **NOTE:** Must be built with a Docker version >= 23.0
 
 The Dockerfile is supplied to build images with CUDA 12.1 support and cuDNN v9.
+To build a ROCm image, pass `ROCM_VERSION` and `ROCM_VERSION_SHORT`:
+```bash
+make -f docker.Makefile runtime-image ROCM_VERSION=7.2.3 ROCM_VERSION_SHORT=7.2
+# images are tagged as docker.io/${your_docker_username}/pytorch:<version>-rocm7.2-runtime
+```
 You can pass `PYTHON_VERSION=x.y` make variable to specify which Python version is to be used by Miniconda, or leave it
 unset to use the default, as the Dockerfile uses system Python.
 

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -11,8 +11,15 @@ endif
 CUDA_VERSION_SHORT       ?= 12.1
 CUDA_VERSION             ?= 12.1.1
 CUDNN_VERSION            ?= 9
+ROCM_VERSION             ?=
+ROCM_VERSION_SHORT       ?=
 BASE_RUNTIME              = ubuntu:24.04
 BASE_DEVEL                = ubuntu:24.04
+# ROCm base images
+ifneq ("$(ROCM_VERSION)","")
+BASE_RUNTIME              = rocm/dev-ubuntu-24.04:$(ROCM_VERSION)-complete
+BASE_DEVEL                = rocm/dev-ubuntu-24.04:$(ROCM_VERSION)-complete
+endif
 CMAKE_VARS               ?=
 
 # The conda channel to use to install cudatoolkit
@@ -41,7 +48,8 @@ BUILD_ARGS                = --build-arg BASE_IMAGE=$(BASE_IMAGE) \
 							--build-arg INSTALL_CHANNEL=$(INSTALL_CHANNEL) \
 							--build-arg TRITON_VERSION=$(TRITON_VERSION) \
 							--build-arg BUILD_TYPE=$(BUILD_TYPE) \
-							--build-arg CMAKE_VARS="$(CMAKE_VARS)"
+							--build-arg CMAKE_VARS="$(CMAKE_VARS)" \
+							--build-arg ROCM_VERSION=$(ROCM_VERSION)
 EXTRA_DOCKER_BUILD_FLAGS ?=
 
 BUILD                    ?= build
@@ -118,6 +126,24 @@ runtime-push: BASE_IMAGE := $(BASE_RUNTIME)
 runtime-push: DOCKER_TAG := $(PYTORCH_VERSION)-cuda$(CUDA_VERSION_SHORT)-cudnn$(CUDNN_VERSION)-runtime
 runtime-push:
 	$(DOCKER_PUSH)
+
+endif
+
+ifneq ("$(ROCM_VERSION)","")
+
+.PHONY: runtime-image
+runtime-image: BASE_IMAGE := $(BASE_RUNTIME)
+runtime-image: BUILD_TYPE := official
+runtime-image: DOCKER_TAG := $(PYTORCH_VERSION)-rocm$(ROCM_VERSION_SHORT)-runtime
+runtime-image:
+        $(DOCKER_BUILD)
+
+.PHONY: devel-image
+devel-image: BASE_IMAGE := $(BASE_DEVEL)
+devel-image: BUILD_TYPE := dev
+devel-image: DOCKER_TAG := $(PYTORCH_VERSION)-rocm$(ROCM_VERSION_SHORT)-devel
+devel-image:
+        $(DOCKER_BUILD)
 
 endif
 


### PR DESCRIPTION
Implements the changes proposed in #188319.

## Changes
- `generate_binary_build_matrix.py`: add `ROCM_ARCHES_FULL_VERSION` mapping (7.1→7.1.1, 7.2→7.2.3)
- `generate_docker_release_matrix.py`: add ROCm matrix rows alongside existing CUDA rows
- `docker-release.yml`: pass `ROCM_VERSION` and `ROCM_VERSION_SHORT` env vars to build job
- `docker.Makefile`: add ROCm base image selection and rocm-tagged build targets
- `Dockerfile`: add ROCm wheel install path, skip CUDA toolkit for ROCm devel images

## Not included (separate follow-ups per RFC scope)
- `README.md` docs
- `pytorch/test-infra` validate-docker-images.yml ROCm checks

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang