### PR TITLE
Fix C2872 'std' ambiguous symbol when nvcc compiles compiled_autograd.h on Windows extension builds

### DIFF
--- a/torch/csrc/dynamo/compiled_autograd.h
+++ b/torch/csrc/dynamo/compiled_autograd.h
@@ -1142,8 +1142,6 @@ struct IValuePacker {
       return at::SymBoolType::get();
     } else if constexpr (::std::is_same_v<T, c10::Layout>) {
       return at::LayoutType::get();
-    } else if constexpr (::std::is_same_v<T, ::std::string>) {
-      return at::StringType::get();
     } else if constexpr (::std::is_same_v<T, at::Device>) {
       return at::DeviceObjType::get();
     } else if constexpr (::std::is_same_v<T, at::Scalar>) {
@@ -1166,6 +1164,26 @@ struct IValuePacker {
       return at::NoneType::get();
     }
 #endif
+  }
+};
+
+// NB: This is a full specialization rather than a branch in the primary
+// template's packed_type() if-constexpr chain: the (fully-qualified)
+// ::std::is_same_v<T, ::std::string> comparison in that chain triggers
+// "error C2872: 'std': ambiguous symbol" when the header is compiled by
+// nvcc/hipcc on Windows in downstream extension builds, which do not define
+// USE_CUDA/USE_ROCM and therefore do not take the carve-out above.
+// See https://github.com/pytorch/pytorch/issues/148317.
+template <>
+struct IValuePacker<std::string> {
+  static at::IValue pack(const std::string& t) {
+    return t;
+  }
+  static std::string unpack(const at::IValue& t) {
+    return t.to<std::string>();
+  }
+  static at::TypePtr packed_type() {
+    return at::StringType::get();
   }
 };
 


### PR DESCRIPTION
Fixes #148317
Fixes #173232

## Problem

Any Windows CUDA extension build that includes `torch/extension.h` (SageAttention-style builds via `torch.utils.cpp_extension`) fails to compile under nvcc with:

```
torch/csrc/dynamo/compiled_autograd.h(1143): error C2872: 'std': ambiguous symbol
C:\...\MSVC\14.42.34433\include\valarray(20): note: could be 'std'
note: while compiling class template member function
      'c10::TypePtr torch::dynamo::autograd::IValuePacker<__int64>::packed_type(void)'
```

The include chain is `torch/extension.h` -> `torch/csrc/autograd/custom_function.h` -> `torch/csrc/dynamo/compiled_autograd.h`, so every downstream Windows CUDA extension compiles this header under nvcc.

## Root cause

`IValuePacker<T>::packed_type()` has a Windows carve-out, but it is gated on:

```cpp
#if defined(_WIN32) && (defined(USE_CUDA) || defined(USE_ROCM))
```

`USE_CUDA` / `USE_ROCM` are libtorch build-config macros that downstream extension builds never define, so the carve-out cannot fire for them. Measured with a macro probe compiled under the same nvcc flags as the failing build (both compilation passes):

| macro | device pass | host pass |
|---|---|---|
| `_WIN32` | defined | defined |
| `__CUDACC__` | defined | defined |
| `USE_CUDA` | undefined | undefined |
| `USE_ROCM` | undefined | undefined |

The if-constexpr chain therefore compiles under nvcc, and the `::std::is_same_v<T, ::std::string>` branch is the only branch in the chain whose right-hand type lives in namespace `std`. MSVC reports C2872 there for every instantiation of the chain (note the error above fires while instantiating `IValuePacker<__int64>`, not a string type). This matches the observation in #173232 that altering that exact line unblocks the build; note the line is already fully `::std::`-qualified on main, so further qualification does not help. Downstream projects have been working around this by manually passing `-DUSE_CUDA` to their extension builds to force the carve-out.

## Fix

Move string handling out of the if-constexpr chain into an explicit `IValuePacker<std::string>` specialization, mirroring the existing `size_t` and `std::vector<at::SymInt>` specializations, and drop the poisoned branch. Semantically identical on all platforms: strings still pack via the implicit `at::IValue` conversion and `packed_type()` still returns `at::StringType::get()`. Existing compiled-autograd tests exercise the same packing paths on Linux.

Why this fixes the build: `packed_type()` in the primary template is instantiated for every packed type (the reported error fires while instantiating `IValuePacker<int64_t>`, not a string type), so the `::std::string` branch poisons every instantiation of the chain. A specialization's member bodies are only compiled when `IValuePacker<std::string>` is actually odr-used, which a plain `#include <torch/extension.h>` never does, so the poisoned construct is removed from the always-instantiated path entirely. Corollary for future readers: avoid reintroducing `std::`-typed branches into the primary chain.

Considered and rejected:
- Extending the guard with `|| defined(__CUDACC__)` also fixes the build (verified), but it routes extension TUs into the `TORCH_CHECK_NOT_IMPLEMENTED` carve-out (masking capability rather than fixing the construct) and is macro-dependent.
- Deleting the trailing nice-error else-branch (discussed in #173232) does not address this error; C2872 fires on the functional string branch, not the diagnostic one.

## Verification (on a failing configuration)

Windows 11, MSVC 14.42.34433 (cl 19.42.34444), CUDA 13.0 (nvcc V13.0.88), torch 2.11.0+cu128, Python 3.13. Minimal extension: a `.cu` containing only `#include <torch/extension.h>` plus a trivial kernel, built via `torch.utils.cpp_extension.load()` with stock flags.

- Before this change: fails with the C2872 error above (100% reproducible, vanilla flags).
- After applying exactly this patch to the installed header and re-running the identical build: compiles and links clean.
- Header edits verified byte-equivalent to this diff; the patch region is identical between the 2.11 release headers and current main.

cc @malfet @zklaus @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @xmfan @aditvenk @zou3519
