### PR TITLE
[MPS] add matrix exp on MPS

### DIFF
--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -2305,11 +2305,12 @@ void _fill_matrix_powers(Tensor& buffer, const Tensor& a, int num_matrices) {
   }
 }
 
-inline Tensor _move_memory_if_cuda_input(
+inline Tensor _move_memory_if_cuda_or_mps_input(
   const Tensor& mem,
   const Tensor& in
 ) {
-  return (in.device().type() == at::kCUDA)
+  const auto device_type = in.device().type();
+  return (device_type == at::kCUDA || device_type == at::kMPS)
     ? mem.to(at::device_of(in).value())
     : mem;
 }
@@ -2329,7 +2330,7 @@ inline Tensor _blob_to_Tensor(
   // be used in _compute_linear_combination
   auto tensor = at::from_blob((void*)blob.begin(), blob.size(),
     c10::toRealValueType(in.scalar_type())).unsqueeze(0);
-  return _move_memory_if_cuda_input(tensor, in);
+  return _move_memory_if_cuda_or_mps_input(tensor, in);
 }
 
 template <typename scalar_t>
@@ -2478,7 +2479,7 @@ Tensor compute_T12(const Tensor& A) {
     {num_prods, 1},
     c10::toRealValueType(A.scalar_type())
   );
-  bs = _move_memory_if_cuda_input(bs, A);
+  bs = _move_memory_if_cuda_or_mps_input(bs, A);
 
   auto As = _allocate_buffer(A, num_prods);
   _fill_matrix_powers(As, A, num_prods);
@@ -2550,7 +2551,7 @@ Tensor compute_T18(const Tensor& A) {
     {num_prods, 1},
     c10::toRealValueType(A.scalar_type())
   );
-  bs = _move_memory_if_cuda_input(bs, A);
+  bs = _move_memory_if_cuda_or_mps_input(bs, A);
 
   auto As = _allocate_buffer(A, num_prods);
   _fill_matrix_powers(As, A, num_prods);
@@ -2664,10 +2665,11 @@ Tensor mexp_impl(
                              at::MemoryFormat::Contiguous);
     // `norm_cpu` is used to decide which Tensors require which approximation
     // based on their norm. This decision takes place on CPU.
-    // It requires moving data back and forth between devices when `a` is on CUDA,
-    // but at the cost of only one single CPU-CUDA synchronization (instead of 6),
-    // and better performance overall (benchmarked).
-    const auto norm_cpu = (a.device().type() == at::kCUDA)
+    // It requires moving data back and forth between devices when `a` is on an
+    // accelerator (CUDA/MPS), but at the cost of only one single synchronization
+    // (instead of 6), and better performance overall (benchmarked).
+    const auto device_type = a.device().type();
+    const auto norm_cpu = (device_type == at::kCUDA || device_type == at::kMPS)
       ? norm.to(at::kCPU) : norm;
 
     constexpr std::array<
@@ -2687,7 +2689,7 @@ Tensor mexp_impl(
       ).nonzero().squeeze(-1);
 
       if (idx_curr_norm_interval.numel()) {
-        auto idx_to_device = _move_memory_if_cuda_input(
+        auto idx_to_device = _move_memory_if_cuda_or_mps_input(
           idx_curr_norm_interval, a
         );
         auto sub_a = at::index_select(a, 0, idx_to_device);
@@ -2700,7 +2702,7 @@ Tensor mexp_impl(
       .nonzero().squeeze(-1);
 
     if (idx_large_norm.numel()) {
-      auto idx_to_device = _move_memory_if_cuda_input(
+      auto idx_to_device = _move_memory_if_cuda_or_mps_input(
         idx_large_norm, a
       );
       auto a_large_norm = at::index_select(a, 0, idx_to_device);

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -2792,6 +2792,13 @@ Tensor linalg_matrix_exp(const Tensor& a) {
   squareCheckInputs(a, "linalg.matrix_exp");
   checkFloatingOrComplex(a, "linalg.matrix_exp");
 
+  // MPSGraph complex matmul is numerically unreliable before macOS 15, which
+  // breaks the scale-and-square recurrence this op relies on.
+  TORCH_CHECK(
+      a.device().type() != at::kMPS ||
+          at::detail::getMPSHooks().isOnMacOSorNewer(15, 0),
+      "linalg.matrix_exp on MPS requires macOS 15.0 or newer");
+
   NoTF32Guard disable_tf32;
 
   // Trivial cases

--- a/aten/src/ATen/native/mps/kernels/FunctionOfAMatrixUtils.metal
+++ b/aten/src/ATen/native/mps/kernels/FunctionOfAMatrixUtils.metal
@@ -1,0 +1,55 @@
+#include <c10/metal/indexing.h>
+#include <metal_stdlib>
+
+using namespace metal;
+using namespace c10::metal;
+
+template <typename T, typename C, typename IdxT>
+kernel void compute_linear_combination(
+    device void* out_ptr [[buffer(0)]],
+    constant void* in_ptr [[buffer(1)]],
+    constant void* coeff_ptr [[buffer(2)]],
+    constant long* sizes [[buffer(3)]],
+    constant long* out_strides [[buffer(4)]],
+    constant long* in_strides [[buffer(5)]],
+    constant long* coeff_strides [[buffer(6)]],
+    constant vec<IdxT, 4>& params [[buffer(7)]],
+    uint tid [[thread_position_in_grid]]) {
+  const auto ndim = uint(params.w);
+  IdxT pos[max_ndim];
+  pos_from_thread_index(IdxT(tid), pos, sizes, ndim);
+  const auto out_off = offset_from_coord(pos, out_strides, ndim);
+  const auto in_off = offset_from_coord(pos, in_strides, ndim);
+  const auto coeff_off = offset_from_coord(pos, coeff_strides, ndim);
+  T acc = T(0);
+  for (IdxT i = 0; i < params.z; ++i) {
+    const auto a =
+        val_at_offs<T>(in_ptr, in_off + i * params.x * IdxT(sizeof(T)));
+    const auto b =
+        val_at_offs<C>(coeff_ptr, coeff_off + i * params.y * IdxT(sizeof(C)));
+    acc += a * b;
+  }
+  ref_at_offs<T>(out_ptr, out_off) += acc;
+}
+
+#define INSTANTIATE_CLC(T, C, IDX, SUF)                                   \
+  template[[host_name("compute_linear_combination_" #T SUF)]] kernel void \
+  compute_linear_combination<T, C, IDX>(                                  \
+      device void* out_ptr [[buffer(0)]],                                 \
+      constant void* in_ptr [[buffer(1)]],                                \
+      constant void* coeff_ptr [[buffer(2)]],                             \
+      constant long* sizes [[buffer(3)]],                                 \
+      constant long* out_strides [[buffer(4)]],                           \
+      constant long* in_strides [[buffer(5)]],                            \
+      constant long* coeff_strides [[buffer(6)]],                         \
+      constant vec<IDX, 4>& params [[buffer(7)]],                         \
+      uint tid [[thread_position_in_grid]]);
+
+#define INSTANTIATE_CLC_ALL(T, C)    \
+  INSTANTIATE_CLC(T, C, int, "_u32") \
+  INSTANTIATE_CLC(T, C, long, "_u64")
+
+INSTANTIATE_CLC_ALL(float, float);
+INSTANTIATE_CLC_ALL(half, half);
+INSTANTIATE_CLC_ALL(bfloat, bfloat);
+INSTANTIATE_CLC_ALL(float2, float);

--- a/aten/src/ATen/native/mps/operations/FunctionOfAMatrixUtils.mm
+++ b/aten/src/ATen/native/mps/operations/FunctionOfAMatrixUtils.mm
@@ -37,7 +37,11 @@ static void _compute_linear_combination_mps_kernel(TensorIterator& iter,
   if (iter.numel() == 0) {
     return;
   }
-  TORCH_CHECK(iter.dtype() != at::kDouble, "float64 is not supported on MPS");
+  const auto dtype = iter.dtype();
+  TORCH_CHECK_TYPE(supportedFloatingType(dtype) || dtype == kComplexFloat,
+                   "_compute_linear_combination: unsupported dtype ",
+                   dtype,
+                   " on MPS, expected float32, float16, bfloat16 or complex64");
 
   // uint thread ids cap one dispatch at UINT32_MAX threads; split so numel (and
   // every operand's base offset) fits 32 bits.
@@ -54,7 +58,7 @@ static void _compute_linear_combination_mps_kernel(TensorIterator& iter,
   const bool use32 = clc_max_byte_offset(iter, 1, in_stride, num_summations) <= kMax &&
       clc_max_byte_offset(iter, 2, coeff_stride, num_summations) <= kMax;
 
-  const auto type_str = scalarToMetalTypeString(iter.dtype());
+  const auto type_str = scalarToMetalTypeString(dtype);
   const auto ndim = static_cast<uint32_t>(iter.ndim());
   auto pso = lib.getPipelineStateForFunc("compute_linear_combination_" + type_str + std::string(mtlIdxSuffix(use32)));
   dispatch_sync_with_rethrow(getCurrentMPSStream()->queue(), ^() {

--- a/aten/src/ATen/native/mps/operations/FunctionOfAMatrixUtils.mm
+++ b/aten/src/ATen/native/mps/operations/FunctionOfAMatrixUtils.mm
@@ -1,0 +1,75 @@
+#include <ATen/native/FunctionOfAMatrixUtils.h>
+#include <ATen/native/TensorIterator.h>
+#include <ATen/native/mps/OperationUtils.h>
+#include <c10/util/irange.h>
+
+#include <array>
+#include <cstdlib>
+#include <limits>
+
+namespace at::native {
+#ifndef PYTORCH_JIT_COMPILE_SHADERS
+static auto& lib = mps::MetalShaderLibrary::getBundledLibrary();
+#else
+#include <ATen/native/mps/FunctionOfAMatrixUtils_metallib.h>
+#endif
+
+// Largest byte offset the kernel dereferences for operand `arg`, including the
+// manually walked summation dim. That dim is collapsed out of the iterator (a
+// size-1 broadcast), so can_use_32bit_indexing() does not account for its
+// i*stride reach; a summation stride > INT32_MAX must still force 64-bit math.
+static int64_t clc_max_byte_offset(const TensorIteratorBase& iter,
+                                   int arg,
+                                   int64_t sum_stride,
+                                   int64_t num_summations) {
+  int64_t off = 0;
+  for (const auto d : c10::irange(iter.ndim())) {
+    off += (iter.shape()[d] - 1) * std::abs(iter.strides(arg)[d]);
+  }
+  return off + (num_summations - 1) * std::abs(sum_stride) * iter.element_size(arg);
+}
+
+static void _compute_linear_combination_mps_kernel(TensorIterator& iter,
+                                                   int64_t in_stride,
+                                                   int64_t coeff_stride,
+                                                   int64_t num_summations) {
+  using namespace mps;
+  if (iter.numel() == 0) {
+    return;
+  }
+  TORCH_CHECK(iter.dtype() != at::kDouble, "float64 is not supported on MPS");
+
+  // uint thread ids cap one dispatch at UINT32_MAX threads; split so numel (and
+  // every operand's base offset) fits 32 bits.
+  if (!iter.can_use_32bit_indexing()) {
+    for (auto& sub_iter : iter.with_32bit_indexing()) {
+      _compute_linear_combination_mps_kernel(sub_iter, in_stride, coeff_stride, num_summations);
+    }
+    return;
+  }
+
+  // Base offsets fit int32 now; widen to 64-bit only when the summation reach
+  // pushes an input/coeff operand past it (out has no summation reach).
+  const int64_t kMax = std::numeric_limits<int32_t>::max();
+  const bool use32 = clc_max_byte_offset(iter, 1, in_stride, num_summations) <= kMax &&
+      clc_max_byte_offset(iter, 2, coeff_stride, num_summations) <= kMax;
+
+  const auto type_str = scalarToMetalTypeString(iter.dtype());
+  const auto ndim = static_cast<uint32_t>(iter.ndim());
+  auto pso = lib.getPipelineStateForFunc("compute_linear_combination_" + type_str + std::string(mtlIdxSuffix(use32)));
+  dispatch_sync_with_rethrow(getCurrentMPSStream()->queue(), ^() {
+    auto computeEncoder = getCurrentMPSStream()->commandEncoder();
+    [computeEncoder setComputePipelineState:pso];
+    bind_iter_tensors(computeEncoder, iter);
+    mtlDispatchByIndexWidth<int32_t, int64_t>(use32, [&](auto idx_tag) {
+      using idx_t = typename decltype(idx_tag)::type;
+      std::array<idx_t, 4> params{idx_t(in_stride), idx_t(coeff_stride), idx_t(num_summations), idx_t(ndim)};
+      mtl_setArgs<3>(computeEncoder, iter.shape(), iter.strides(0), iter.strides(1), iter.strides(2), params);
+    });
+    mtl_dispatch1DJob(computeEncoder, pso, static_cast<uint32_t>(iter.numel()));
+  });
+}
+
+REGISTER_MPS_DISPATCH(_compute_linear_combination_stub, &_compute_linear_combination_mps_kernel)
+
+} // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3840,11 +3840,11 @@
 
 - func: _compute_linear_combination(Tensor input, Tensor coefficients) -> Tensor
   dispatch:
-    CPU, CUDA, XPU: _compute_linear_combination
+    CPU, CUDA, XPU, MPS: _compute_linear_combination
 
 - func: _compute_linear_combination.out(Tensor input, Tensor coefficients, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
-    CPU, CUDA, XPU: _compute_linear_combination_out
+    CPU, CUDA, XPU, MPS: _compute_linear_combination_out
 
 - func: max.dim(Tensor self, int dim, bool keepdim=False) -> (Tensor values, Tensor indices)
   device_check: NoCheck   # TensorIterator
@@ -14391,7 +14391,7 @@
   python_module: linalg
   variants: function
   dispatch:
-    CPU, CUDA: linalg_matrix_exp
+    CPU, CUDA, MPS: linalg_matrix_exp
   autogen: linalg_matrix_exp.out
 
 - func: linalg_matrix_sqrth(Tensor self) -> Tensor

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -11319,6 +11319,34 @@ class TestLinalgMPS(TestCaseMPS):
             torch._compute_linear_combination(xm, cm, out=actual)
         self.assertEqual(actual.cpu(), expected, atol=tol[0], rtol=tol[1])
 
+    @unittest.skipIf(MACOS_VERSION < 15.0, "matrix_exp on MPS requires macOS 15+")
+    @dtypes(torch.float32, torch.complex64)
+    def test_matrix_exp_invariants(self, device, dtype):
+        # Reference-free identities catch systematic MPS bias an MPS-vs-CPU compare misses.
+        torch.manual_seed(0)
+        expm = torch.linalg.matrix_exp
+
+        for n, batch in [(8, ()), (16, ()), (32, (4,))]:
+            eye = torch.eye(n, dtype=dtype, device=device).expand(*batch, n, n)
+
+            zero = torch.zeros(*batch, n, n, dtype=dtype, device=device)
+            self.assertEqual(expm(zero), eye, atol=2e-4, rtol=2e-4)
+
+            # exp(skew-Hermitian) is unitary, and the norm sweep hits every branch
+            # plus the squaring path.
+            for scale in (1e-2, 1.0, 5.0):
+                a = torch.randn(*batch, n, n, dtype=dtype, device=device)
+                q = expm((a - a.mH) * scale)
+                self.assertEqual(torch.matmul(q, q.mH), eye, atol=2e-4, rtol=2e-4)
+
+            # det(exp(A)) == exp(tr(A)); a scalar check over the full matmul path.
+            # linalg.det has no complex MPS support, so the identity is evaluated on
+            # CPU over the MPS matrix_exp result.
+            a = torch.randn(*batch, n, n, dtype=dtype, device=device) / n
+            lhs = torch.linalg.det(expm(a).cpu())
+            rhs = torch.exp(torch.diagonal(a.cpu(), dim1=-2, dim2=-1).sum(-1))
+            self.assertEqual(lhs, rhs, atol=1e-3, rtol=1e-3)
+
     def test_matrix_rank(self, device="mps", dtype=torch.float32):
         matrix_rank = torch.linalg.matrix_rank
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -11292,6 +11292,33 @@ class TestLinalgMPS(TestCaseMPS):
         self.assertEqual(mps.rank.cpu(), cpu.rank)
         self.assertEqual(mps.singular_values.cpu(), cpu.singular_values)
 
+    @dtypes(torch.float32, torch.complex64, torch.float16, torch.bfloat16)
+    @parametrize("out", ["none", "zeros", "ones"])
+    @parametrize("m, n, data, noncontig", [
+        (1, 3, (2, 2), False),
+        (2, 6, (256, 256), False),
+        (3, 4, (7, 7, 7), False),
+        (6, 5, (512, 512), False),
+        (5, 3, (128, 128), True),
+    ])
+    def test_compute_linear_combination(self, device, dtype, m, n, data, noncontig, out):
+        torch.manual_seed(0)
+        coeff_dtype = torch.float32 if dtype.is_complex else dtype  # coeffs are real
+        tol = {torch.float16: (2e-2, 2e-2), torch.bfloat16: (5e-2, 5e-2)}.get(dtype, (1e-4, 1e-4))
+        coeffs = torch.rand(m, n, dtype=coeff_dtype)
+        x = torch.randn(n, *data, 2, dtype=dtype)[..., 1] if noncontig else torch.randn(n, *data, dtype=dtype)
+        xm, cm = x.to(device), coeffs.to(device)
+        if out == "none":
+            expected = torch._compute_linear_combination(x, coeffs)
+            actual = torch._compute_linear_combination(xm, cm)
+        else:
+            init = torch.zeros if out == "zeros" else torch.ones
+            expected = init(m, *data, dtype=dtype)
+            actual = init(m, *data, device=device, dtype=dtype)
+            torch._compute_linear_combination(x, coeffs, out=expected)
+            torch._compute_linear_combination(xm, cm, out=actual)
+        self.assertEqual(actual.cpu(), expected, atol=tol[0], rtol=tol[1])
+
     def test_matrix_rank(self, device="mps", dtype=torch.float32):
         matrix_rank = torch.linalg.matrix_rank
 
@@ -15037,6 +15064,10 @@ class TestConsistency(TestCaseMPS):
         'nn.functional.conv_transpose3d',
         'matmul', '__rmatmul__',
         'linalg.multi_dot',
+        # matrix_exp is Taylor + scale-and-square, i.e. repeated matmuls, so MPS
+        # and CPU diverge by ~1e-5 like the rest of this list; complex64 outputs
+        # of magnitude e^||A|| also need rtol rather than a tight atol.
+        'matrix_exp',
         'addbmm',
         # Accumulates sigmoid + log + weighted sum rounding; CPU and MPS
         # end up within ~3e-5 of fp64 but differ from each other by more

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -15383,8 +15383,6 @@ op_db: list[OpInfo] = [
                # mexp does not support bf16 and fp16
                DecorateInfo(unittest.skip('Skipped!'), 'TestInductorOpInfo', 'test_comprehensive',
                             dtypes=[torch.half], device_type="cpu"),
-               # The operator 'aten::linalg_matrix_exp' is not currently implemented for the MPS device
-               DecorateInfo(unittest.expectedFailure, 'TestCommon', device_type='mps'),
            ),
            supports_out=False,
            ),

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -126,6 +126,7 @@ if torch.backends.mps.is_available():
             "masked_fill",
             "masked_scatter",
             "masked_select",
+            "matrix_exp",
             "meshgridlist_of_tensors",
             "meshgridvariadic_tensors",
             "movedim",
@@ -371,7 +372,6 @@ if torch.backends.mps.is_available():
             "linalg.ldl_solve": None,
             "linalg.matrix_sqrth": None,
             "linalg.polar": None,
-            "matrix_exp": None,
             "max_pool2d_with_indices_backward": [
                 torch.int8,
                 torch.int16,

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -355,9 +355,10 @@ if torch.backends.mps.is_available():
         }
 
         MACOS_BEFORE_15_0_XFAILLIST = {
-            # matrix_exp chains complex matmuls; MPSGraph complex matmul is
-            # numerically unreliable before macOS 15 (NaN/inf via scale-square).
-            "matrix_exp": [torch.complex64],
+            # matrix_exp is disabled on MPS before macOS 15 (TORCH_CHECK): MPSGraph
+            # complex matmul is numerically unreliable there and breaks the
+            # scale-and-square recurrence, so the op raises for every dtype.
+            "matrix_exp": None,
         }
 
         # Those ops are not expected to work
@@ -972,11 +973,9 @@ if torch.backends.mps.is_available():
         }
 
         MACOS_BEFORE_15_0_XFAILLIST_GRAD = {
-            # matrix_exp backward exponentiates a 2n x 2n augmented matrix, so it
-            # leans even harder on MPSGraph matmul than the forward; before macOS
-            # 15 that matmul is unreliable enough to make the fp32 grad diverge
-            # wildly from CPU (the forward leg still matches, hence grad-only).
-            "matrix_exp": [torch.float32],
+            # matrix_exp is disabled on MPS before macOS 15 (TORCH_CHECK), so the
+            # forward leg of the grad test raises for every dtype.
+            "matrix_exp": None,
         }
 
         def addDecorator(op: OpInfo, d: DecorateInfo) -> None:

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -971,6 +971,14 @@ if torch.backends.mps.is_available():
             "nn.functional.conv3d": [torch.float32],
         }
 
+        MACOS_BEFORE_15_0_XFAILLIST_GRAD = {
+            # matrix_exp backward exponentiates a 2n x 2n augmented matrix, so it
+            # leans even harder on MPSGraph matmul than the forward; before macOS
+            # 15 that matmul is unreliable enough to make the fp32 grad diverge
+            # wildly from CPU (the forward leg still matches, hence grad-only).
+            "matrix_exp": [torch.float32],
+        }
+
         def addDecorator(op: OpInfo, d: DecorateInfo) -> None:
             op.decorators = op.decorators + (d,)
 
@@ -980,6 +988,15 @@ if torch.backends.mps.is_available():
                 addDecorator(
                     op,
                     DecorateInfo(unittest.expectedFailure, dtypes=XFAILLIST_GRAD[key]),
+                )
+
+            if key in MACOS_BEFORE_15_0_XFAILLIST_GRAD and MACOS_VERSION < 15.0:
+                addDecorator(
+                    op,
+                    DecorateInfo(
+                        unittest.expectedFailure,
+                        dtypes=MACOS_BEFORE_15_0_XFAILLIST_GRAD[key],
+                    ),
                 )
 
             if key in SKIPLIST_GRAD:

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -354,6 +354,12 @@ if torch.backends.mps.is_available():
             "fft.hfft2": [torch.complex64],
         }
 
+        MACOS_BEFORE_15_0_XFAILLIST = {
+            # matrix_exp chains complex matmuls; MPSGraph complex matmul is
+            # numerically unreliable before macOS 15 (NaN/inf via scale-square).
+            "matrix_exp": [torch.complex64],
+        }
+
         # Those ops are not expected to work
         UNIMPLEMENTED_XFAILLIST: dict[str, list | None] = {
             # Failures due to lack of op implementation on MPS backend
@@ -836,6 +842,19 @@ if torch.backends.mps.is_available():
                     DecorateInfo(
                         unittest.expectedFailure,
                         dtypes=MACOS_BEFORE_14_4_XFAILLIST[key],
+                    ),
+                )
+
+            if (
+                key in MACOS_BEFORE_15_0_XFAILLIST
+                and key not in xfail_exclusion
+                and (MACOS_VERSION < 15.0)
+            ):
+                addDecorator(
+                    op,
+                    DecorateInfo(
+                        unittest.expectedFailure,
+                        dtypes=MACOS_BEFORE_15_0_XFAILLIST[key],
                     ),
                 )
 


### PR DESCRIPTION
Add matrix_exp on MPS. Perf measured on few shapes since larger means cpu gets much slower:

## float32

| Matrix | CPU (us) | MPS (us) | Speedup |
|---:|---:|---:|---:|
| 256x256 | 632.8 | 1464.7 | 0.43x |
| 512x512 | 2237.5 | 1967.5 | 1.14x |
| 1024x1024 | 13315.9 | 5675.8 | 2.35x |

## complex64

| Matrix | CPU (us) | MPS (us) | Speedup |
|---:|---:|---:|---:|
| 256x256 | 1882.4 | 1711.1 | 1.10x |
| 512x512 | 8821.6 | 3379.3 | 2.61x |
| 1024x1024 | 61302.4 | 17479.7 | 3.51x |