### PR TITLE
Fix Windows target determination for POSIX changed-file paths

### DIFF
--- a/test/test_determination.py
+++ b/test/test_determination.py
@@ -4,8 +4,9 @@ import os
 
 import run_test
 
-from torch.testing._internal.common_utils import run_tests, TestCase
 from tools.testing.modulefinder_determinator import test_impact_of_file
+
+from torch.testing._internal.common_utils import run_tests, TestCase
 
 
 class DummyOptions:

--- a/test/test_determination.py
+++ b/test/test_determination.py
@@ -5,6 +5,7 @@ import os
 import run_test
 
 from torch.testing._internal.common_utils import run_tests, TestCase
+from tools.testing.modulefinder_determinator import test_impact_of_file
 
 
 class DummyOptions:
@@ -46,6 +47,42 @@ class DeterminationTest(TestCase):
     def test_config_change_only(self):
         """CI configs trigger all tests"""
         self.assertEqual(self.determined_tests([".ci/pytorch/test.sh"]), self.TESTS)
+
+    def test_classifies_git_style_paths(self):
+        """Git-style paths use / even on Windows"""
+        self.assertEqual(test_impact_of_file("torch/nn/modules/linear.py"), "TORCH")
+        self.assertEqual(test_impact_of_file("test/test_jit.py"), "TEST")
+        self.assertEqual(test_impact_of_file("caffe2/python/core.py"), "CAFFE2")
+        self.assertEqual(test_impact_of_file(".ci/pytorch/test.sh"), "CI")
+
+    def test_classifies_windows_style_paths(self):
+        """Windows-style paths are still accepted"""
+        self.assertEqual(test_impact_of_file(r"torch\nn\modules\linear.py"), "TORCH")
+        self.assertEqual(test_impact_of_file(r"test\test_jit.py"), "TEST")
+        self.assertEqual(test_impact_of_file(r"caffe2\python\core.py"), "CAFFE2")
+        self.assertEqual(test_impact_of_file(r".ci\pytorch\test.sh"), "CI")
+
+    def test_should_run_test_handles_git_style_paths(self):
+        """should_run_test handles raw Git-style changed-file paths"""
+        self.assertTrue(
+            run_test.should_run_test(
+                run_test.TARGET_DET_LIST,
+                "test_determination",
+                ["torch/utils/cpp_extension.py"],
+                DummyOptions(),
+            )
+        )
+
+    def test_should_run_test_handles_windows_style_paths(self):
+        """should_run_test still handles Windows-style changed-file paths"""
+        self.assertTrue(
+            run_test.should_run_test(
+                run_test.TARGET_DET_LIST,
+                "test_determination",
+                [r"torch\utils\cpp_extension.py"],
+                DummyOptions(),
+            )
+        )
 
     def test_run_test(self):
         """run_test.py is imported by determination tests"""

--- a/tools/testing/modulefinder_determinator.py
+++ b/tools/testing/modulefinder_determinator.py
@@ -87,7 +87,7 @@ def should_run_test(
             log_test_reason(file_type, touched_file, test, options)
             return True
         elif file_type in ["TORCH", "CAFFE2", "TEST"]:
-            parts = os.path.splitext(touched_file)[0].split(os.sep)
+            parts = _split_path(os.path.splitext(touched_file)[0])
             touched_module = ".".join(parts)
             # test/ path does not have a "test." namespace
             if touched_module.startswith("test."):
@@ -116,7 +116,7 @@ def test_impact_of_file(filename: str) -> str:
         NONE - known to have no effect on test outcome
         CI - CI configuration files
     """
-    parts = filename.split(os.sep)
+    parts = _split_path(filename)
     if parts[0] in [".jenkins", ".ci"]:
         return "CI"
     if parts[0] in ["docs", "scripts", "CODEOWNERS", "README.md"]:
@@ -132,6 +132,10 @@ def test_impact_of_file(filename: str) -> str:
             return "TEST"
 
     return "UNKNOWN"
+
+
+def _split_path(filename: str) -> list[str]:
+    return filename.replace("\\", "/").split("/")
 
 
 def log_test_reason(file_type: str, filename: str, test: str, options: Any) -> None:


### PR DESCRIPTION
`tools/testing/modulefinder_determinator.py` interprets changed-file paths when deciding whether slow tests need to run. Git and GitHub report changed files as repository-relative POSIX-style paths such as `torch/utils/cpp_extension.py`, even when the target determination code runs on Windows.

Before this change, modulefinder target determination split those paths with `os.sep`. On Windows, `os.sep` is `\`, so a Git-style path containing `/` stayed as one component and could be classified as `UNKNOWN` instead of `TORCH`, `TEST`, `CAFFE2`, or `CI`. `UNKNOWN` files conservatively trigger tests more broadly, so Windows runs could lose a useful target-determination signal and run more tests than necessary.

Fixes #188960