### PR TITLE
torch.unravel_index: raise clear ValueError when shape has a zero-size dimension

### DIFF
--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -1611,6 +1611,11 @@ class TestIndexing(TestCase):
         ):
             torch.unravel_index(torch.tensor(0, device=device), (2, -3))
 
+        with self.assertRaisesRegex(
+            ValueError, r"'indices' is non-empty, but 'shape' .* has a zero-size dimension"
+        ):
+            torch.unravel_index(torch.tensor(0, device=device), (2, 0, 3))
+
     def test_invalid_index(self, device):
         x = torch.arange(0, 16, device=device).view(4, 4)
         self.assertRaisesRegex(TypeError, "slice indices", lambda: x["0":"1"])

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -2040,6 +2040,11 @@ def _unravel_index(indices: Tensor, shape: int | Sequence[int]) -> Tensor:
         lambda: f"'shape' cannot have negative values, but got {tuple(shape)}",
     )
 
+    torch._check_value(
+        indices.numel() == 0 or 0 not in shape,
+        lambda: f"'indices' is non-empty, but 'shape' {tuple(shape)} has a zero-size dimension",
+    )
+
     coefs = list(
         reversed(
             list(


### PR DESCRIPTION
Fixes #188926.

## Summary

`torch.unravel_index` crashes with a cryptic `RuntimeError: ZeroDivisionError` when `shape` contains a zero-size dimension and `indices` is non-empty. This happens because `itertools.accumulate(..., operator.mul)` over the shape produces a `0` in `coefs`, and the subsequent `floor_divide`/`%` operations divide by it.

The fix adds a `torch._check_value` guard in `_unravel_index` before the coefs computation. If `indices` is non-empty and any dimension of `shape` is zero, a `ValueError` is raised with a clear message. The `indices.numel() == 0` short-circuit preserves the valid case where empty indices are passed alongside a zero-size shape (the downstream math safely produces empty output tensors in that case).

An alternative would have been to special-case zero-shape and always return empty tensors, but that would silently accept out-of-bounds indices — every index is out of bounds when `prod(shape) == 0` — which is inconsistent with how NumPy handles this.

## Test plan

Added a case to `test_unravel_index_errors` in `test/test_indexing.py`:

```python
with self.assertRaisesRegex(
    ValueError, r"'indices' is non-empty, but 'shape' .* has a zero-size dimension"
):
    torch.unravel_index(torch.tensor(0, device=device), (2, 0, 3))
```

```
python test/test_indexing.py -k test_unravel_index_errors
```