### PR TITLE
Fix non-deterministic node ordering in get_source_partitions()

### DIFF
--- a/test/fx/test_source_matcher_utils.py
+++ b/test/fx/test_source_matcher_utils.py
@@ -24,6 +24,10 @@ from torch.testing._internal.common_utils import (
 from torch.testing._internal.jit_utils import JitTestCase
 
 
+def _get_node_names(nodes: list[torch.fx.Node]) -> list[str]:
+    return [n.name for n in nodes]
+
+
 class TestSourceMatcher(JitTestCase):
     @unittest.skipIf(not is_dynamo_supported(), "Dynamo not supported")
     def test_module_partitioner_linear_relu_linear(self):
@@ -529,6 +533,63 @@ class TestSourceMatcher(JitTestCase):
                 module_partitions[torch.nn.ReLU][0],
             )
         )
+
+    @unittest.skipIf(not is_dynamo_supported(), "Dynamo not supported")
+    def test_get_source_partitions_deterministic_ordering(self):
+        """
+        Verifies that get_source_partitions() returns input_nodes, output_nodes,
+        and params in deterministic order (sorted by graph position).
+        """
+        # Create a model where a single linear takes input from multiple sources
+        # and produces outputs consumed by multiple downstream nodes.
+        # This ensures multiple input_nodes, output_nodes, and params per partition.
+        class M(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear1 = torch.nn.Linear(3, 3)
+                self.linear2 = torch.nn.Linear(3, 3)
+                self.linear3 = torch.nn.Linear(3, 3)
+
+            def forward(self, x):
+                a = self.linear1(x)
+                b = self.linear2(x)
+                # linear3 takes both a and b as inputs, so both are input_nodes
+                c = self.linear3(a + b)
+                return c
+
+        inputs = (torch.randn(3, 3),)
+        gm, _ = torch._dynamo.export(M(), aten_graph=True)(*inputs)
+        gm.graph.eliminate_dead_code()
+
+        partitions = get_source_partitions(gm.graph, [torch.nn.Linear])
+
+        # Build a position map to verify nodes are sorted by graph order
+        node_positions = {n: i for i, n in enumerate(gm.graph.nodes)}
+
+        for partition in partitions[torch.nn.Linear]:
+            # Verify input_nodes are sorted by graph position
+            input_positions = [node_positions[n] for n in partition.input_nodes]
+            self.assertEqual(
+                input_positions,
+                sorted(input_positions),
+                f"input_nodes not in graph order: {_get_node_names(partition.input_nodes)}",
+            )
+
+            # Verify output_nodes are sorted by graph position
+            output_positions = [node_positions[n] for n in partition.output_nodes]
+            self.assertEqual(
+                output_positions,
+                sorted(output_positions),
+                f"output_nodes not in graph order: {_get_node_names(partition.output_nodes)}",
+            )
+
+            # Verify params are sorted by graph position
+            params_positions = [node_positions[n] for n in partition.params]
+            self.assertEqual(
+                params_positions,
+                sorted(params_positions),
+                f"params not in graph order: {_get_node_names(partition.params)}",
+            )
 
 
 instantiate_parametrized_tests(TestSourceMatcher)

--- a/test/fx/test_source_matcher_utils.py
+++ b/test/fx/test_source_matcher_utils.py
@@ -540,6 +540,7 @@ class TestSourceMatcher(JitTestCase):
         Verifies that get_source_partitions() returns input_nodes, output_nodes,
         and params in deterministic order (sorted by graph position).
         """
+
         # Create a model where a single linear takes input from multiple sources
         # and produces outputs consumed by multiple downstream nodes.
         # This ensures multiple input_nodes, output_nodes, and params per partition.

--- a/torch/fx/passes/utils/source_matcher_utils.py
+++ b/torch/fx/passes/utils/source_matcher_utils.py
@@ -127,12 +127,6 @@ def get_source_partitions(
             if source_fn[1] in wanted_sources:
                 add_to_partition(source_fn[1], source_fn[0], node)
 
-    # Build once, reuse across all partitions to avoid O(N*P) cost.
-    node_positions = {node: i for i, node in enumerate(graph.nodes)}
-
-    def sort_key(n: Node) -> int:
-        return node_positions.get(n, len(node_positions))
-
     def make_partition(nodes: list[Node], module_type: type) -> SourcePartition:
         input_nodes = set()
         output_nodes = set()
@@ -154,9 +148,9 @@ def get_source_partitions(
         return SourcePartition(
             nodes,
             module_type,
-            sorted(input_nodes, key=sort_key),
-            sorted(output_nodes, key=sort_key),
-            sorted(params, key=sort_key),  # type: ignore[arg-type]
+            sorted(input_nodes),
+            sorted(output_nodes),
+            sorted(params),  # type: ignore[arg-type]
         )
 
     ret: dict[type[Any], list[SourcePartition]] = {}

--- a/torch/fx/passes/utils/source_matcher_utils.py
+++ b/torch/fx/passes/utils/source_matcher_utils.py
@@ -127,6 +127,12 @@ def get_source_partitions(
             if source_fn[1] in wanted_sources:
                 add_to_partition(source_fn[1], source_fn[0], node)
 
+    # Build once, reuse across all partitions to avoid O(N*P) cost.
+    node_positions = {node: i for i, node in enumerate(graph.nodes)}
+
+    def sort_key(n: Node) -> int:
+        return node_positions.get(n, len(node_positions))
+
     def make_partition(nodes: list[Node], module_type: type) -> SourcePartition:
         input_nodes = set()
         output_nodes = set()
@@ -144,13 +150,6 @@ def get_source_partitions(
             for user in node.users:
                 if user not in nodes:
                     output_nodes.add(node)
-
-        # Sort nodes by their position in the graph for deterministic ordering.
-        # Sets are non-deterministic across runs due to hash randomization.
-        node_positions = {node: i for i, node in enumerate(graph.nodes)}
-
-        def sort_key(n: Node) -> int:
-            return node_positions.get(n, len(node_positions))
 
         return SourcePartition(
             nodes,

--- a/torch/fx/passes/utils/source_matcher_utils.py
+++ b/torch/fx/passes/utils/source_matcher_utils.py
@@ -145,12 +145,19 @@ def get_source_partitions(
                 if user not in nodes:
                     output_nodes.add(node)
 
+        # Sort nodes by their position in the graph for deterministic ordering.
+        # Sets are non-deterministic across runs due to hash randomization.
+        node_positions = {node: i for i, node in enumerate(graph.nodes)}
+
+        def sort_key(n: Node) -> int:
+            return node_positions.get(n, len(node_positions))
+
         return SourcePartition(
             nodes,
             module_type,
-            list(input_nodes),
-            list(output_nodes),
-            list(params),  # type: ignore[arg-type]
+            sorted(input_nodes, key=sort_key),
+            sorted(output_nodes, key=sort_key),
+            sorted(params, key=sort_key),  # type: ignore[arg-type]
         )
 
     ret: dict[type[Any], list[SourcePartition]] = {}


### PR DESCRIPTION
Fixes #147170

## Summary

`get_source_partitions()` in `torch/fx/passes/utils/source_matcher_utils.py` could return `input_nodes`, `output_nodes`, and `params` in non-deterministic order across runs due to the use of Python `set()` which has non-deterministic iteration order due to hash randomization (`PYTHONHASHSEED`).

## Root Cause

In the `make_partition` helper function, `input_nodes`, `output_nodes`, and `params` were collected using `set()` and then converted to `list()`:

```python
input_nodes = set()
...
return SourcePartition(
    nodes,
    module_type,
    list(input_nodes),
    list(output_nodes),
    list(params),
)
```

Since Python sets have non-deterministic iteration order across processes/runs, the same input graph could produce different orderings of `input_nodes` on different invocations. This caused issues for downstream consumers like quantization backends that rely on stable indexing (e.g. `input_nodes[0]` vs `input_nodes[1]`).

## Fix

Sort the collected nodes by their position in the graph before returning, ensuring deterministic, graph-order-based ordering:

```python
node_positions = {node: i for i, node in enumerate(graph.nodes)}
def sort_key(n: Node) -> int:
    return node_positions.get(n, len(node_positions))

return SourcePartition(
    nodes,
    module_type,
    sorted(input_nodes, key=sort_key),
    sorted(output_nodes, key=sort_key),
    sorted(params, key=sort_key),
)
```
