### PR TITLE
[docs] document __torch_function__ behavior during autograd hooks

### DIFF
--- a/docs/source/notes/extending.md
+++ b/docs/source/notes/extending.md
@@ -945,6 +945,35 @@ as was the case before version 1.7.0. Failing to do this may cause ``func``
 to recurse back into ``__torch_function__`` and therefore cause infinite
 recursion.
 
+When you call ``backward()`` on a tensor subclass, PyTorch temporarily disables
+subclass ``__torch_function__`` dispatch for the entire backward pass. Autograd
+hooks (for example, ``register_post_accumulate_grad_hook`` and ``register_hook``) run during that pass, so
+PyTorch operations inside those hooks do not dispatch to your subclass's
+``__torch_function__``.
+
+This happens because subclass dispatch uses
+``torch._C.DisableTorchFunctionSubclass()`` inside
+``Tensor.__torch_function__`` when you call ``super().__torch_function__()``.
+Since ``backward()`` runs synchronously inside that context, hooks inherit the
+disabled state.
+
+If you need subclass dispatch inside a hook, re-enable it locally with
+``torch._C._EnableTorchFunction()``:
+
+```{code-block} python
+:dedent: 2
+
+  def post_accum_hook(param):
+      with torch._C._EnableTorchFunction():
+          param + MyTensor(torch.ones_like(param))
+
+```
+
+Tensor-like objects (separate wrapper classes that are not ``Tensor`` subclasses)
+behave differently: their ``__torch_function__`` is still called inside hooks
+because they do not go through ``super().__torch_function__()`` during
+``backward()``.
+
 ### Extending {mod}`torch` with a {class}`Tensor` wrapper type
 
 Another useful case is a type that wraps a {class}`Tensor`, either as an


### PR DESCRIPTION
Document that subclass `__torch_function__` dispatch is disabled during backward autograd hooks, and show how to re-enable it when needed.

Fixes #167223

### Problem

Tensor subclass authors expect `__torch_function__` to run consistently whenever they call PyTorch ops, including inside autograd hooks. In practice, hooks registered on subclass tensors do not trigger subclass dispatch because `backward()` runs inside `DisableTorchFunctionSubclass()` via `super().__torch_function__()`. Tensor-like wrapper types behave differently, which is confusing without documentation.

### Solution

Add a short note to `docs/source/notes/extending.md` under **Subclassing torch.Tensor** that explains:

- subclass dispatch is off for the whole backward pass
- autograd hooks inherit that disabled state
- users can wrap hook code in `torch._C._EnableTorchFunction()` to opt back in
- tensor-like wrappers are unaffected because they do not use `super().__torch_function__()` during backward

### Test plan

Docs-only change. No runtime tests required.

<sub>Authored with an AI assistant.</sub>
