### PR TITLE
Fix OOB write in repeat_interleave with output_size and negative repeats (#188938)

### DIFF
--- a/aten/src/ATen/native/Repeat.cpp
+++ b/aten/src/ATen/native/Repeat.cpp
@@ -28,8 +28,15 @@ static void compute_cpu(
     for (const auto i : c10::irange(i_begin, i_end)) {
       int64_t end = cumsum_ptr[i];
       index_t size = repeat_ptr[i];
-      TORCH_CHECK((size >= 0), "repeats can not be negative");
       int64_t start = end - size;
+      // A negative repeat makes the cumsum non-monotonic, so even a
+      // non-negative element can yield start < 0 or end > result_size and write
+      // out of bounds. When output_size is given this per-element check is the
+      // only guard against negative repeats, so validate the write range before
+      // touching result_ptr.
+      TORCH_CHECK(
+          size >= 0 && start >= 0 && end <= result_size,
+          "repeats can not be negative");
       for (const auto j : c10::irange(start, end)) {
         result_ptr[j] = i;
       }

--- a/aten/src/ATen/native/cuda/Repeat.cu
+++ b/aten/src/ATen/native/cuda/Repeat.cu
@@ -30,8 +30,10 @@ __global__ static void compute_cuda_kernel(
   for (int64_t i = warp_id; i < size; i += stride) {
     int64_t end = cumsum_ptr[i];
     index_t repeat = repeat_ptr[i];
-    CUDA_KERNEL_ASSERT(repeat >= 0);
     int64_t start = end - repeat;
+    // A negative repeat makes the cumsum non-monotonic, so even a non-negative
+    // element can yield start < 0 or end > result_size and write out of bounds.
+    CUDA_KERNEL_ASSERT(repeat >= 0 && start >= 0 && end <= result_size);
     for (int64_t j = start + tid_in_warp; j < end; j += C10_WARP_SIZE) {
       result_ptr[j] = i;
     }

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -1279,6 +1279,22 @@ class TestTensorCreation(TestCase):
         with self.assertRaises(RuntimeError):
             torch.repeat_interleave(torch.tensor([1, 2, -1, 3, 4], device=device))
 
+        # Negative repeats must be rejected even when output_size is passed,
+        # otherwise the CPU kernel can write out of bounds: the corrupted cumsum
+        # makes a later non-negative element produce start < 0, and in a
+        # multi-threaded run that OOB write races ahead of the sibling thread's
+        # check. See https://github.com/pytorch/pytorch/issues/188938
+        # On CUDA the kernel rejects these inputs via a device-side assert,
+        # which cannot be caught cleanly and poisons the context, so this is
+        # validated on CPU only.
+        if torch.device(device).type == "cpu":
+            with self.assertRaisesRegex(RuntimeError, "repeats can not be negative"):
+                torch.repeat_interleave(
+                    torch.tensor([-1, -1, 2], device=device), output_size=0)
+            with self.assertRaisesRegex(RuntimeError, "repeats can not be negative"):
+                torch.repeat_interleave(
+                    torch.tensor([5, -2, 1], device=device), output_size=4)
+
         y = torch.tensor([[1, 2], [3, 4]], device=device)
 
         y1_v1 = torch.repeat_interleave(y, 2)


### PR DESCRIPTION
Fixes #188938

## Summary

`torch.repeat_interleave(repeats, output_size=...)` can perform an out-of-bounds write on CPU (ASan `SEGV`, reproducible with multiple threads) when `repeats` contains negative values, instead of deterministically raising `RuntimeError: repeats can not be negative`.

### Root cause

`repeat_interleave_common` (`aten/src/ATen/native/Repeat.h`) only runs the `(repeats >= 0).all()` validation on the branch where `output_size` is **not** provided. When `output_size` is given, that check is intentionally skipped to avoid a host-device sync (#58417), so the compute kernel is the only remaining guard.

Both kernels do check `repeat >= 0` per element, but that is insufficient: a negative repeat makes the running `cumsum` non-monotonic, so a **later non-negative** element computes

```
start = cumsum[i] - repeat[i]
```

that is negative (or an `end` that exceeds `result_size`) and writes outside the output buffer. Under multiple threads that non-negative element can execute the OOB write before the sibling thread's `repeat >= 0` check throws — the exact race in the report:

```python
repeats = torch.tensor([-1, -1, 2], dtype=torch.int64)  # cumsum = [-1, -2, 0]
torch.repeat_interleave(repeats, output_size=0)          # element 2 writes result_ptr[-2]
```

### Fix

Validate the actual write range in both the CPU (`Repeat.cpp`) and CUDA (`Repeat.cu`) kernels before touching the output buffer:

```
size >= 0 && start >= 0 && end <= result_size
```

This makes the kernels memory-safe regardless of `output_size` and still surfaces the expected `RuntimeError: repeats can not be negative`. It keeps the guard in the kernel rather than unconditionally restoring the host-side `(repeats >= 0).all().item()` check, so the sync-free `output_size` fast path that `torch.compile` / dynamic shapes depend on is preserved.

## Test plan

Added regression cases to `test_repeat_interleave` covering the `output_size` path with negative repeats — both the `start < 0` and the `end > result_size` overflow:

```
python test/test_tensor_creation_ops.py -k test_repeat_interleave
```

I also modeled the CPU kernel loop in Python to confirm the guard rejects every negative-repeat input that previously wrote out of bounds while leaving all valid all-non-negative inputs byte-for-byte unchanged.

> Note: authored with the assistance of an AI coding assistant. A local PyTorch build was not run in my environment, so on-device numerics rely on the CI run of the test above.

cc @albanD @malfet