### PR TITLE
Fix integer overflow / OOB read in col2im (fold) with near-INT64_MAX params (#188959)

### DIFF
--- a/aten/src/ATen/native/im2col_shape_check.h
+++ b/aten/src/ATen/native/im2col_shape_check.h
@@ -13,9 +13,30 @@ inline int64_t sliding_window_count(
     int64_t dilation,
     int64_t kernel,
     int64_t stride) {
-  return div_rtn<int64_t>(
-             input_size + 2 * pad - (dilation * (kernel - 1) + 1), stride) +
-      1;
+  // Compute (input_size + 2 * pad - (dilation * (kernel - 1) + 1)) / stride + 1
+  // with overflow checks. Near-INT64_MAX pad/dilation/kernel values would
+  // otherwise silently wrap and yield a bogus (but shape-check-passing) block
+  // count, leading to out-of-bounds accesses in the im2col/col2im kernels.
+  int64_t kernel_extent = 0;
+  int64_t two_pad = 0;
+  int64_t padded_size = 0;
+  TORCH_CHECK(
+      !c10::mul_overflows(dilation, kernel - 1, &kernel_extent) &&
+          !c10::add_overflows(
+              kernel_extent, static_cast<int64_t>(1), &kernel_extent) &&
+          !c10::mul_overflows(pad, static_cast<int64_t>(2), &two_pad) &&
+          !c10::add_overflows(input_size, two_pad, &padded_size),
+      "The combination of input_size=",
+      input_size,
+      ", pad=",
+      pad,
+      ", dilation=",
+      dilation,
+      ", and kernel=",
+      kernel,
+      " overflows in the sliding-window size computation");
+  // padded_size >= 0 and kernel_extent >= 1, so this subtraction cannot overflow.
+  return div_rtn<int64_t>(padded_size - kernel_extent, stride) + 1;
 }
 
 inline void col2im_shape_check(
@@ -94,7 +115,18 @@ inline void col2im_shape_check(
   int64_t n_blocks_width = sliding_window_count(
       output_width, pad_width, dilation_width, kernel_width, stride_width);
 
-  if (input_length != (n_blocks_height * n_blocks_width)) {
+  int64_t n_blocks = 0;
+  TORCH_CHECK(
+      !c10::mul_overflows(n_blocks_height, n_blocks_width, &n_blocks),
+      "Given output_size=(", output_height, ", ", output_width, "), ",
+      "kernel_size=(", kernel_height, ", ", kernel_width, "), ",
+      "dilation=(", dilation_height, ", ", dilation_width, "), ",
+      "padding=(", pad_height, ", ", pad_width, "), ",
+      "stride=(", stride_height, ", ", stride_width, "), ",
+      "the number of sliding blocks (", n_blocks_height, " * ", n_blocks_width,
+      ") overflows int64.");
+
+  if (input_length != n_blocks) {
     TORCH_CHECK(false,
         "Given output_size=(",
         output_height,
@@ -122,7 +154,7 @@ inline void col2im_shape_check(
         " * ",
         n_blocks_width,
         " = ",
-        (n_blocks_height * n_blocks_width),
+        n_blocks,
         ", but got input.size(2)=",
         input_length,
         ".");

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -6890,6 +6890,29 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         with self.assertRaisesRegex(RuntimeError, r"calculated shape of the array of sliding blocks as"):
             fold(torch.randn(1, 12, 12))
 
+        # Near-INT64_MAX padding/stride must be rejected instead of overflowing
+        # the sliding-window index math and reading out of bounds.
+        # See https://github.com/pytorch/pytorch/issues/188959
+        with self.assertRaisesRegex(RuntimeError, r"overflows in the sliding-window size computation"):
+            F.fold(
+                torch.zeros(1, 1, 1),
+                output_size=(100, 100),
+                kernel_size=(1, 1),
+                dilation=(100, 100),
+                padding=(2**63 - 2, 2**63 - 2),
+                stride=(2**63 - 1, 2**63 - 1),
+            )
+
+        # Padding large enough that the per-dimension block counts fit in int64
+        # but their product does not.
+        with self.assertRaisesRegex(RuntimeError, r"number of sliding blocks .* overflows int64"):
+            F.fold(
+                torch.zeros(1, 1, 1),
+                output_size=(100, 100),
+                kernel_size=(1, 1),
+                padding=(2**40, 2**40),
+            )
+
     def test_softmin(self):
         x = torch.randn(2, 16)
         self.assertEqual(F.softmin(x, 1), F.softmax(-x, 1))


### PR DESCRIPTION
Fixes #188959

## Summary

`torch.nn.functional.fold` (col2im) with near-`INT64_MAX` padding/stride triggers an integer overflow that bypasses the shape check and causes an out-of-bounds read in the CUDA `col2im_batched_kernel` (compute-sanitizer: *"Invalid `__global__` read of size 4 bytes"*).

### Root cause

[`sliding_window_count`](https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/im2col_shape_check.h) computes

```
(input_size + 2 * pad - (dilation * (kernel - 1) + 1)) / stride + 1
```

with plain int64 arithmetic. For `pad = 2**63 - 2` the `2 * pad` term overflows and wraps to a small value, so the function returns a bogus block count (`1`) that matches the input's block dimension. `col2im_shape_check` then passes, and the kernel runs with the absurd `pad`/`stride`, computing wrapped (negative) coordinates such as `w_im = index % width + pad_width` that index far outside `data_col`.

Repro from the issue:

```python
import torch
torch.cuda.init()
x = torch.zeros(1, 1, 1, device='cuda')
torch.nn.functional.fold(
    x, output_size=(100, 100), kernel_size=(1, 1), dilation=(100, 100),
    padding=(2**63 - 2, 2**63 - 2), stride=(2**63 - 1, 2**63 - 1),
)
torch.cuda.synchronize()
```

### Fix

- Make `sliding_window_count` overflow-checked with `c10::mul_overflows` / `c10::add_overflows` (the same helpers `col2im_shape_check` already uses for the kernel-size product), raising a clear error instead of wrapping. Shared by fold/unfold on CPU and CUDA; results are unchanged for valid inputs.
- Additionally guard the `n_blocks_height * n_blocks_width` product in `col2im_shape_check`. Once `sliding_window_count` no longer wraps, a moderately large pad (e.g. `2**40`) produces per-dimension counts that each fit in int64 but whose product does not, re-opening the same class of OOB.

## Test plan

Added two cases to `test_fold_invalid_arg` (a CPU test — the overflow is caught in the shared shape check before any kernel launches, so no GPU is required): the reported near-`INT64_MAX` repro, and the product-overflow case.

```
python test/test_nn.py -k test_fold_invalid_arg
```

I also modeled `sliding_window_count` in Python with int64 wraparound semantics to confirm the fixed version rejects the overflowing repro and returns identical block counts to the original across 200k valid parameter combinations.

> Note: authored with the assistance of an AI coding assistant. A local build was not run in my environment (no CUDA / multi-hour build), so the on-device kernel behavior relies on the CI run of the test above.

cc @malfet @ngimel