### PR TITLE
Reapply "Avoid redundant scalar-to-tensor conversion in `real`/`imag`setters on complex tensors (#188603)

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2055,10 +2055,15 @@ class TestTorchDeviceType(TestCase):
             else:
                 return 2 * x
 
+        def _set_real_imag(tensor, real, imag):
+            tensor.real = real
+            tensor.imag = imag
+
         # prepare inputs for subsequent ops
         size = 4
         x = torch.rand(size, device=device)
         y = torch.rand((), device=device)
+        z = torch.randn(size, device=device, dtype=torch.complex64)
         ind = torch.randint(size, (3,), device=device)
         ind_cpu = ind.cpu()
         repeats = torch.full((1,), 2, device=device)
@@ -2069,6 +2074,7 @@ class TestTorchDeviceType(TestCase):
                           lambda: _ind_put_fn(x, ind, y),
                           lambda: _ind_put_fn(x, 0, 5.),
                           lambda: _ind_put_fn(x, slice(0, 1), 5.),
+                          lambda: _set_real_imag(z, 3., 5.),
                           lambda: _ind_get_fn(x, mask_cpu),
                           lambda: _ind_get_fn(x, ind),
                           lambda: torch.nn.functional.one_hot(ind, num_classes=size),

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2174,10 +2174,15 @@ class TestTorchDeviceType(TestCase):
             else:
                 return 2 * x
 
+        def _set_real_imag(tensor, real, imag):
+            tensor.real = real
+            tensor.imag = imag
+
         # prepare inputs for subsequent ops
         size = 4
         x = torch.rand(size, device=device)
         y = torch.rand((), device=device)
+        z = torch.randn(size, device=device, dtype=torch.complex64)
         ind = torch.randint(size, (3,), device=device)
         ind_cpu = ind.cpu()
         repeats = torch.full((1,), 2, device=device)
@@ -2189,6 +2194,7 @@ class TestTorchDeviceType(TestCase):
                           lambda: _ind_put_fn(x, ind, 1.),
                           lambda: _ind_put_fn(x, 0, 5.),
                           lambda: _ind_put_fn(x, slice(0, 1), 5.),
+                          lambda: _set_real_imag(z, 3., 5.),
                           lambda: _ind_get_fn(x, mask_cpu),
                           lambda: _ind_get_fn(x, ind),
                           lambda: torch.nn.functional.one_hot(ind, num_classes=size),

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -3347,29 +3347,35 @@ static PyObject* THPVariable_get_itemsize(THPVariable* self, void* unused) {
   END_HANDLE_TH_ERRORS
 }
 
+static inline int copy_value_(const Tensor& self, PyObject* value) {
+  if (THPVariable_Check(value)) {
+    auto value_ = THPVariable_Unpack(value);
+    {
+      pybind11::gil_scoped_release no_gil;
+      self.copy_(value_);
+      return 0;
+    }
+  } else {
+    auto scalar = valueToScalar(self.options(), value);
+    {
+      pybind11::gil_scoped_release no_gil;
+      self.fill_(scalar);
+      return 0;
+    }
+  }
+}
+
 static int THPVariable_set_real(PyObject* self, PyObject* real, void* unused) {
   HANDLE_TH_ERRORS
   auto& self_ = THPVariable_Unpack(self);
-  auto self_real = at::real(self_);
-  auto real_ = valueToTensor(self_real.options(), real, self_real.device());
-  {
-    pybind11::gil_scoped_release no_gil;
-    self_real.copy_(real_);
-    return 0;
-  }
+  return copy_value_(at::real(self_), real);
   END_HANDLE_TH_ERRORS_RET(-1)
 }
 
 static int THPVariable_set_imag(PyObject* self, PyObject* imag, void* unused) {
   HANDLE_TH_ERRORS
   auto& self_ = THPVariable_Unpack(self);
-  auto self_imag = at::imag(self_);
-  auto imag_ = valueToTensor(self_imag.options(), imag, self_imag.device());
-  {
-    pybind11::gil_scoped_release no_gil;
-    self_imag.copy_(imag_);
-    return 0;
-  }
+  return copy_value_(at::imag(self_), imag);
   END_HANDLE_TH_ERRORS_RET(-1)
 }
 

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -141,9 +141,7 @@ static Variable sequenceToVariable(c10::TensorOptions options, PyObject* seq) {
       options, kLong, std::nullopt, seq);
 }
 
-static inline Scalar valueToScalar(
-    c10::TensorOptions options,
-    PyObject* value) {
+inline Scalar valueToScalar(c10::TensorOptions options, PyObject* value) {
   Scalar scalar;
   if (THPUtils_checkLong(value) || PyBool_Check(value)) {
     scalar = Scalar(THPUtils_unpackLong(value));
@@ -168,31 +166,13 @@ static inline Scalar valueToScalar(
   return scalar;
 }
 
-Variable valueToTensor(
-    c10::TensorOptions options,
-    PyObject* value,
-    const at::Device& device) {
-  if (THPVariable_Check(value)) {
-    return THPVariable_Unpack(value);
-  }
-  auto scalar = valueToScalar(options, value);
-  // lift_fresh is supposed to be used in situations where you are guaranteed to
-  // get a plain Tensor which is not true for cpu device but not for non cpu
-  // device
-  at::AutoDispatchBelowADInplaceOrView guard; // TODO: remove
-  at::tracer::impl::NoTracerDispatchMode tracer_guard;
-  if (device == at::kCPU && !scalar.isSymbolic()) {
-    return at::lift_fresh(
-        at::indexing::scalarToTensor(scalar, options, device));
-  } else {
-    return at::indexing::scalarToTensor(scalar, options, device);
-  }
-}
-
 static inline Tensor asTensor(const Tensor& value, const Tensor& target) {
   return value;
 }
 static inline Tensor asTensor(const Scalar& value, const Tensor& self) {
+  // lift_fresh is supposed to be used in situations where you are guaranteed to
+  // get a plain Tensor which is not true for cpu device but not for non cpu
+  // device
   at::AutoDispatchBelowADInplaceOrView guard;
   at::tracer::impl::NoTracerDispatchMode tracer_guard;
   Tensor tensor = at::indexing::asTensor(value, self);

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -135,9 +135,7 @@ static Variable sequenceToVariable(c10::TensorOptions options, PyObject* seq) {
       options, kLong, std::nullopt, seq);
 }
 
-static inline Scalar valueToScalar(
-    c10::TensorOptions options,
-    PyObject* value) {
+inline Scalar valueToScalar(c10::TensorOptions options, PyObject* value) {
   Scalar scalar;
   if (THPUtils_checkLong(value) || PyBool_Check(value)) {
     // uint64 values above INT64_MAX must not go through signed long long unpack
@@ -169,31 +167,13 @@ static inline Scalar valueToScalar(
   return scalar;
 }
 
-Variable valueToTensor(
-    c10::TensorOptions options,
-    PyObject* value,
-    const at::Device& device) {
-  if (THPVariable_Check(value)) {
-    return THPVariable_Unpack(value);
-  }
-  auto scalar = valueToScalar(options, value);
-  // lift_fresh is supposed to be used in situations where you are guaranteed to
-  // get a plain Tensor which is not true for cpu device but not for non cpu
-  // device
-  at::AutoDispatchBelowADInplaceOrView guard; // TODO: remove
-  at::tracer::impl::NoTracerDispatchMode tracer_guard;
-  if (device == at::kCPU && !scalar.isSymbolic()) {
-    return at::lift_fresh(
-        at::indexing::scalarToTensor(scalar, options, device));
-  } else {
-    return at::indexing::scalarToTensor(scalar, options, device);
-  }
-}
-
 static inline Tensor asTensor(const Tensor& value, const Tensor& target) {
   return value;
 }
 static inline Tensor asTensor(const Scalar& value, const Tensor& self) {
+  // lift_fresh is supposed to be used in situations where you are guaranteed to
+  // get a plain Tensor which is not true for cpu device but not for non cpu
+  // device
   at::AutoDispatchBelowADInplaceOrView guard;
   at::tracer::impl::NoTracerDispatchMode tracer_guard;
   Tensor tensor = at::indexing::asTensor(value, self);

--- a/torch/csrc/autograd/python_variable_indexing.h
+++ b/torch/csrc/autograd/python_variable_indexing.h
@@ -91,9 +91,6 @@ Py_ssize_t THPVariable_length(PyObject* self);
 PyObject* THPVariable_getitem(PyObject* self, PyObject* index);
 int THPVariable_setitem(PyObject* self, PyObject* index, PyObject* value);
 
-Variable valueToTensor(
-    c10::TensorOptions options,
-    PyObject* value,
-    const at::Device& device);
+at::Scalar valueToScalar(c10::TensorOptions options, PyObject* value);
 
 } // namespace torch::autograd

--- a/torch/csrc/autograd/python_variable_indexing.h
+++ b/torch/csrc/autograd/python_variable_indexing.h
@@ -83,9 +83,6 @@ Py_ssize_t THPVariable_length(PyObject* self);
 PyObject* THPVariable_getitem(PyObject* self, PyObject* index);
 int THPVariable_setitem(PyObject* self, PyObject* index, PyObject* value);
 
-Variable valueToTensor(
-    c10::TensorOptions options,
-    PyObject* value,
-    const at::Device& device);
+at::Scalar valueToScalar(c10::TensorOptions options, PyObject* value);
 
 } // namespace torch::autograd


### PR DESCRIPTION
This reapplies #188603 which has been reverted due to Meta internal CI failures.

@ngimel let me know which CI failure caused the revert and I can work on a fix.

This reverts commit bfd16513e6ffaabbdc4b9c53414b89e68f982e01.