### PR TITLE
Fix inconsistent accelerator guard in checkpoint staging test

### DIFF
--- a/test/distributed/checkpoint/_experimental/test_staging.py
+++ b/test/distributed/checkpoint/_experimental/test_staging.py
@@ -107,7 +107,7 @@ class TestDefaultStager(TestCase):
             ),
         ]
 
-        if torch.cuda.is_available():
+        if torch.accelerator.is_available():
             # Only async staging
             test_cases.append(
                 CheckpointStagerConfig(


### PR DESCRIPTION
Fixes #188790

### Summary

In `test/distributed/checkpoint/_experimental/test_staging.py`, the block that appends the async-staging and non-blocking-copy test cases was guarded by `torch.cuda.is_available()`, while the config values constructed inside that same block already use the backend-generic `torch.accelerator.is_available()`.

Because of the hardcoded CUDA guard, those two cases were skipped on non-CUDA accelerators (XPU/HPU/MTIA) even though the staging code they exercise is accelerator-generic. This changes the guard to `torch.accelerator.is_available()` so it is consistent with the block body and the cases run on any available accelerator. This matches the fix suggested by the maintainer in the issue.

### Test Plan

The change swaps a single method name on an existing call and adds no imports (`torch.accelerator` is already used in this file). Verified the file still compiles:

```
python -m py_compile test/distributed/checkpoint/_experimental/test_staging.py
```

The distributed staging suite requires a built PyTorch and an available accelerator, exercised by CI:

```
python test/distributed/checkpoint/_experimental/test_staging.py
```

> This PR was authored with the assistance of an AI coding agent (Claude Code).
