### PR TITLE
[c++20] Simplify waiting using std::latch in ParallelNative.cpp (#188981)

### DIFF
--- a/aten/src/ATen/ParallelNative.cpp
+++ b/aten/src/ATen/ParallelNative.cpp
@@ -12,6 +12,8 @@
 #endif // C10_MOBILE
 
 #include <atomic>
+#include <latch>
+#include <memory>
 #include <utility>
 
 #ifdef _OPENMP
@@ -152,16 +154,20 @@ void invoke_parallel(
   std::tie(num_tasks, chunk_size) =
       internal::calc_num_tasks_and_chunk_size(begin, end, grain_size);
 
-  struct {
+  struct State {
     std::atomic_flag err_flag = ATOMIC_FLAG_INIT;
     std::exception_ptr eptr;
-    std::mutex mutex;
-    std::atomic_size_t remaining{0};
-    std::condition_variable cv;
-  } state;
+    std::latch latch;
+    explicit State(size_t n) : latch(static_cast<ptrdiff_t>(n)) {}
+  };
+  // shared_ptr so the latch outlives every worker's count_down(): a worker's
+  // pool job holds a reference until after it returns from count_down(), so
+  // the last reference (and thus destruction) can never race the notify. A
+  // stack-local latch is a use-after-free -- the coordinator's wait() can
+  // return and unwind this frame while a worker is still touching the latch.
+  auto state = std::make_shared<State>(num_tasks);
 
-  auto task = [f, &state, begin, end, chunk_size]
-      (size_t task_id) {
+  auto task = [state, f, begin, end, chunk_size](size_t task_id) {
     int64_t local_start = static_cast<int64_t>(begin + task_id * chunk_size);
     if (local_start < end) {
       int64_t local_end = std::min(end, static_cast<int64_t>(chunk_size + local_start));
@@ -169,30 +175,19 @@ void invoke_parallel(
         ParallelRegionGuard guard(static_cast<int>(task_id));
         f(local_start, local_end);
       } catch (...) {
-        if (!state.err_flag.test_and_set()) {
-          state.eptr = std::current_exception();
+        if (!state->err_flag.test_and_set()) {
+          state->eptr = std::current_exception();
         }
       }
     }
-    {
-      std::unique_lock<std::mutex> lk(state.mutex);
-      if (--state.remaining == 0) {
-        state.cv.notify_one();
-      }
-    }
+    state->latch.count_down();
   };
-  state.remaining = num_tasks;
   _run_with_pool(std::move(task), num_tasks);
 
   // Wait for all tasks to finish.
-  {
-    std::unique_lock<std::mutex> lk(state.mutex);
-    if (state.remaining != 0) {
-      state.cv.wait(lk);
-    }
-  }
-  if (state.eptr) {
-    std::rethrow_exception(state.eptr);
+  state->latch.wait();
+  if (state->eptr) {
+    std::rethrow_exception(state->eptr);
   }
 }
 

--- a/aten/src/ATen/test/test_parallel.cpp
+++ b/aten/src/ATen/test/test_parallel.cpp
@@ -5,7 +5,9 @@
 #include <ATen/Parallel.h>
 #include <ATen/ParallelFuture.h>
 
+#include <atomic>
 #include <iostream>
+#include <memory>
 // NOLINTNEXTLINE(modernize-deprecated-headers)
 #include <string.h>
 #include <sstream>
@@ -105,6 +107,34 @@ TEST(TestParallel, Exceptions) {
       throw std::runtime_error("exception");
     }),
     std::runtime_error);
+}
+
+// Regression test for the std::latch use-after-free that was introduced into
+// at::internal::invoke_parallel(): the coordinator's wait() could return and
+// unwind the frame holding the synchronization object while a pool worker was
+// still inside its final count_down(), touching freed memory. We stress
+// parallel_for with grain_size 1 so every call spins up several pool tasks and
+// a pool thread is frequently the last to finish. On a build with the bug this
+// deterministically trips TSan (data race) / ASan (heap-use-after-free); the
+// exact-visit checks additionally guard the wait/dispatch correctness in every
+// build.
+TEST(TestParallel, InvokeParallelNoUseAfterFree) {
+  NumThreadsGuard guard(4);
+  constexpr int64_t kSize = 2048;
+  for (int iter = 0; iter < 2000; ++iter) {
+    auto visited = std::make_unique<std::atomic<int>[]>(kSize);
+    for (int64_t i = 0; i < kSize; ++i) {
+      visited[i].store(0, std::memory_order_relaxed);
+    }
+    at::parallel_for(0, kSize, 1, [&](int64_t begin, int64_t end) {
+      for (int64_t i = begin; i < end; ++i) {
+        visited[i].fetch_add(1, std::memory_order_relaxed);
+      }
+    });
+    for (int64_t i = 0; i < kSize; ++i) {
+      ASSERT_EQ(visited[i].load(std::memory_order_relaxed), 1);
+    }
+  }
 }
 
 TEST(TestParallel, IntraOpLaunchFuture) {


### PR DESCRIPTION
Summary:

[c++20] Simplify waiting using `std::latch` in `ParallelNative.cpp`

Replaces the atomic + mutex + condvar `state` struct in `ParallelNative.cpp` with a single `std::latch`, which is cleaner and removes ~20 lines of boilerplate. Originally landed as D108538999 and reverted due to an iOS build failure (`'count_down' is unavailable: introduced in iOS 14.0 simulator`); the prerequisite iOS deployment-target fix has been separated into D110545168 (parent of this diff).

The `std::latch` change:
- Lifts `err_flag` and `eptr` out of the anonymous struct into plain local variables
- Replaces the mutex + condvar + `remaining` counter with `latch.count_down()` / `latch.wait()`
- Switches the task lambda capture from explicit `[f, &state, ...]` to `[&, f, ...]`

Reviewed By: NSProgrammer

Differential Revision: D109888039

@diff-train-skip-merge 
