### PR TITLE
[Accelerator] Add torch.acclerator.device_of

### DIFF
--- a/docs/source/accelerator.md
+++ b/docs/source/accelerator.md
@@ -54,6 +54,7 @@ per-backend modules, the following APIs are delegated to each backend:
     current_stream
     synchronize
     device_index
+    device_of
 ```
 
 ## Graphs

--- a/test/test_accelerator.py
+++ b/test/test_accelerator.py
@@ -94,6 +94,40 @@ class TestAccelerator(TestCase):
             self.assertEqual(torch.accelerator.current_device_index(), 0)
         self.assertEqual(torch.accelerator.current_device_index(), prev_device)
 
+    def test_device_of_context_manager(self):
+        prev_device = torch.accelerator.current_device_index()
+        # CPU tensor is a no-op
+        cpu_x = torch.randn(10, device="cpu")
+        with torch.accelerator.device_of(cpu_x):
+            self.assertEqual(torch.accelerator.current_device_index(), prev_device)
+        self.assertEqual(torch.accelerator.current_device_index(), prev_device)
+        # Accelerator tensor switches to its index
+        acc = torch.accelerator.current_accelerator()
+        x = torch.randn(10, device=acc)
+        with torch.accelerator.device_of(x):
+            self.assertEqual(
+                torch.accelerator.current_device_index(), x.get_device()
+            )
+        self.assertEqual(torch.accelerator.current_device_index(), prev_device)
+        # Storage is also accepted
+        s = x.untyped_storage()
+        with torch.accelerator.device_of(s):
+            self.assertEqual(
+                torch.accelerator.current_device_index(), s.get_device()
+            )
+        self.assertEqual(torch.accelerator.current_device_index(), prev_device)
+
+    @unittest.skipIf(not TEST_MULTIACCELERATOR, "only one accelerator detected")
+    def test_device_of_multi_device(self):
+        src_device = 0
+        dst_device = 1
+        torch.accelerator.set_device_index(src_device)
+        acc = torch.accelerator.current_accelerator()
+        x = torch.randn(10, device=torch.device(acc.type, dst_device))
+        with torch.accelerator.device_of(x):
+            self.assertEqual(torch.accelerator.current_device_index(), dst_device)
+        self.assertEqual(torch.accelerator.current_device_index(), src_device)
+
     def test_device_index_fullgraph(self):
         def fn(x):
             with torch.accelerator.device_index(x.device.index):

--- a/torch/accelerator/__init__.py
+++ b/torch/accelerator/__init__.py
@@ -34,6 +34,7 @@ __all__ = [
     "current_stream",
     "device_count",
     "device_index",
+    "device_of",
     "empty_cache",
     "empty_host_cache",
     "get_memory_info",
@@ -306,3 +307,31 @@ class device_index:
     def __exit__(self, *exc_info: object) -> None:
         if self.idx is not None:
             torch._C._accelerator_maybeExchangeDevice(self.prev_idx)
+
+
+class device_of(device_index):
+    r"""Context-manager that changes the current device to that of given object.
+
+    You can use both tensors and storages as arguments. If a given object is
+    not allocated on the current :ref:`accelerator<accelerators>`, this is a no-op.
+
+    Args:
+        obj (Tensor or Storage): object allocated on the selected device.
+
+    Examples:
+
+        >>> # xdoctest: +REQUIRES(env:TORCH_DOCTEST_CUDA)
+        >>> x = torch.randn(10, device="cuda:1")
+        >>> with torch.accelerator.device_of(x):
+        ...     # Code here runs with device 1 as the current accelerator device
+        ...     y = torch.randn(10, device="cuda")
+    """
+
+    def __init__(self, obj) -> None:
+        acc = current_accelerator()
+        idx = (
+            obj.get_device()
+            if (acc is not None and obj.device.type == acc.type)
+            else -1
+        )
+        super().__init__(idx if idx >= 0 else None)


### PR DESCRIPTION
## Summary

  This PR adds `torch.accelerator.device_of`, a generic accelerator context manager that temporarily switches the current accelerator device to the device of a given tensor or
  storage.

  The new API mirrors the behavior of backend-specific helpers such as `torch.cuda.device_of`, while working through the unified `torch.accelerator` abstraction. If the
  provided object is not allocated on the current accelerator type, the context manager is a no-op. On exit, it restores the previous accelerator device index.

  This PR also adds `device_of` to the accelerator docs autosummary and covers tensor, storage, CPU no-op, and multi-device behavior in `test/test_accelerator.py`.

## Test Plan

  ```bash
  python test/test_accelerator.py -k device_of
  ```
## BC-breaking?

  No.

cc @albanD @guangyey @EikanWang @fffrog
