### PR TITLE
[NVGEMM] Support `cutlass.operators`

### DIFF
--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -101,7 +101,6 @@ ignore-missing-imports = [
     "usort.*",
     "cutlass.*",
     "cutlass_library.*",
-    "cutlass_api.*",
     "deeplearning.*",
     "einops.*",
     "libfb.*",

--- a/test/inductor/test_async_compile.py
+++ b/test/inductor/test_async_compile.py
@@ -1340,7 +1340,7 @@ class TestCuteDSLSubprocessCompile(TestCase):
 
     @unittest.skipIf(
         not ensure_nv_universal_gemm_available(),
-        "NVIDIA Universal GEMM (cutlass_api) library not available",
+        "NVIDIA Universal GEMM (cutlass.operators) library not available",
     )
     def test_nv_universal_gemm_subprocess_precompile_skips_bad_fork(self):
         """NV Universal GEMM precompile skips compile in bad-fork workers."""

--- a/test/inductor/test_nv_universal_gemm.py
+++ b/test/inductor/test_nv_universal_gemm.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: inductor"]
 
 
+import types
 import unittest
 from unittest import mock
 from unittest.mock import MagicMock, patch
@@ -92,10 +93,66 @@ def _nvgemm_config(**overrides):
     return cfg
 
 
-# TODO(nikhilap): Remove Blackwell restriction once cutlass_api includes H100 kernels
+def _missing_module(name):
+    err = ModuleNotFoundError(f"No module named {name!r}")
+    err.name = name
+    return err
+
+
+class TestCutlassOperatorsAdapter(TestCase):
+    def test_prefers_cutlass_operators(self):
+        from torch._inductor.codegen.nv_universal_gemm import cutlass_ops
+
+        operators = types.ModuleType("cutlass.operators")
+        legacy = types.ModuleType("cutlass_api")
+
+        def fake_import(name):
+            if name == "cutlass.operators":
+                return operators
+            if name == "cutlass_api":
+                return legacy
+            raise _missing_module(name)
+
+        with patch.object(cutlass_ops.importlib, "import_module", fake_import):
+            self.assertIs(cutlass_ops.get_operator_api(), operators)
+
+    def test_falls_back_to_cutlass_api(self):
+        from torch._inductor.codegen.nv_universal_gemm import cutlass_ops
+
+        legacy = types.ModuleType("cutlass_api")
+
+        def fake_import(name):
+            if name == "cutlass.operators":
+                raise _missing_module(name)
+            if name == "cutlass_api":
+                return legacy
+            raise _missing_module(name)
+
+        with patch.object(cutlass_ops.importlib, "import_module", fake_import):
+            self.assertIs(cutlass_ops.get_operator_api(), legacy)
+
+    def test_submodule_uses_selected_api(self):
+        from torch._inductor.codegen.nv_universal_gemm import cutlass_ops
+
+        operators = types.ModuleType("cutlass.operators")
+        arguments = types.ModuleType("cutlass.operators.arguments")
+
+        def fake_import(name):
+            if name == "cutlass.operators":
+                return operators
+            if name == "cutlass.operators.arguments":
+                return arguments
+            raise _missing_module(name)
+
+        with patch.object(cutlass_ops.importlib, "import_module", fake_import):
+            self.assertIs(cutlass_ops.get_arguments_module(), arguments)
+
+
+# TODO(nikhilap): Remove Blackwell restriction once `cutlass.operators` or
+# legacy `cutlass_api` include H100 kernels.
 @unittest.skipIf(
     not (ensure_nv_universal_gemm_available() and is_datacenter_blackwell_arch()),
-    "NVIDIA Universal GEMM (cutlass_api) library not available or not on Blackwell",
+    "NVIDIA Universal GEMM operator API not available or not on Blackwell",
 )
 @instantiate_parametrized_tests
 class TestNVUniversalGemm(TestCase):
@@ -140,7 +197,8 @@ class TestNVUniversalGemm(TestCase):
     def test_unaligned_base_pointer_rejected(self):
         """Test that matmul with unaligned base pointer is rejected.
 
-        cutlass_api requires 16-byte aligned base pointers. Since alignment
+        The CUTLASS operator API (`cutlass.operators` or legacy `cutlass_api`)
+        requires 16-byte aligned base pointers. Since alignment
         can't be checked at compile time (FakeTensors don't have real pointers),
         Inductor must guard against unaligned buffers.
         """
@@ -195,7 +253,8 @@ class TestNVUniversalGemm(TestCase):
     def test_workspace_allocation(self):
         """Test that workspace allocation works correctly.
 
-        Since no current CUTLASS kernels require a workspace, we mock the
+        Since no current `cutlass.operators` or legacy `cutlass_api` kernels
+        require a workspace, we mock the
         kernel.get_workspace_size method to return a non-zero value.
         """
         m, n, k = 512, 512, 512
@@ -211,13 +270,15 @@ class TestNVUniversalGemm(TestCase):
 
         torch._dynamo.reset()
 
-        import cutlass_api
+        from torch._inductor.codegen.nv_universal_gemm.cutlass_ops import (
+            get_operator_api,
+        )
 
         def patched_get_workspace_size(self, args):
             return 1024
 
         with patch.object(
-            cutlass_api.Kernel,
+            get_operator_api().Kernel,
             "get_workspace_size",
             patched_get_workspace_size,
         ):
@@ -601,7 +662,8 @@ class TestNVUniversalGemmHeuristics(TestCase):
         and is_datacenter_blackwell_arch()
         and ensure_nvmatmul_heuristics_available()
     ),
-    "Requires cutlass_api, nvMatmulHeuristics, and Blackwell GPU",
+    "Requires CUTLASS operator API (`cutlass.operators` or legacy "
+    "`cutlass_api`), nvMatmulHeuristics, and Blackwell GPU",
 )
 class TestNVUniversalGemmHeuristicsIntegration(TestCase):
     """Integration tests for nvMatmulHeuristics with real library calls."""
@@ -663,7 +725,7 @@ class TestNVUniversalGemmHeuristicsIntegration(TestCase):
 
 @unittest.skipIf(
     not (ensure_nv_universal_gemm_available() and is_datacenter_blackwell_arch()),
-    "NVIDIA Universal GEMM (cutlass_api) library not available or not on Blackwell",
+    "NVIDIA Universal GEMM operator API not available or not on Blackwell",
 )
 class TestNVUniversalGemmDynamicShapes(TestCase):
     """Test cases for NVIDIA Universal GEMM with dynamic shapes."""
@@ -726,7 +788,7 @@ class TestNVUniversalGemmDynamicShapes(TestCase):
 
 @unittest.skipIf(
     not (ensure_nv_universal_gemm_available() and is_datacenter_blackwell_arch()),
-    "NVIDIA Universal GEMM (cutlass_api) library not available or not on Blackwell",
+    "NVIDIA Universal GEMM operator API not available or not on Blackwell",
 )
 @instantiate_parametrized_tests
 class TestNVUniversalGemmEpilogueFusion(TestCase):
@@ -913,16 +975,19 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
         if efc_kernel is None:
             self.skipTest("No matching EFC kernel found in cache")
 
-        import cutlass_api
-        from cutlass_api.artifact import CompiledArtifact
+        from torch._inductor.codegen.nv_universal_gemm.cutlass_ops import (
+            get_arguments_module,
+            get_artifact_module,
+        )
+
+        CompiledArtifact = get_artifact_module().CompiledArtifact
+        GemmArguments = get_arguments_module().GemmArguments
 
         a = torch.randn(self.M, self.K, device="cuda", dtype=torch.bfloat16)
         b = torch.randn(self.K, self.N, device="cuda", dtype=torch.bfloat16)
         out = torch.empty(self.M, self.N, device="cuda", dtype=torch.bfloat16)
 
-        args = cutlass_api.arguments.GemmArguments(
-            a, b, out, accumulator_type=torch.float32
-        )
+        args = GemmArguments(a, b, out, accumulator_type=torch.float32)
         artifact = efc_kernel.compile(args)
 
         # Unwrap, serialize, reload, rewrap
@@ -943,9 +1008,7 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
 
         # Run with reloaded artifact and verify correctness
         out2 = torch.empty(self.M, self.N, device="cuda", dtype=torch.bfloat16)
-        args2 = cutlass_api.arguments.GemmArguments(
-            a, b, out2, accumulator_type=torch.float32
-        )
+        args2 = GemmArguments(a, b, out2, accumulator_type=torch.float32)
         efc_kernel.run(
             args2,
             reloaded_artifact,
@@ -969,10 +1032,11 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
         catch the regression we intercept _benchmark_nvgemm_module to record
         every (ms, path) it returns and assert at least one finite-ms result —
         i.e., at least one EFC choice with workspace did get benchmarked."""
-        import cutlass_api
-
         from torch._inductor.codegen.cuda_combined_scheduling import (
             CUDACombinedScheduling,
+        )
+        from torch._inductor.codegen.nv_universal_gemm.cutlass_ops import (
+            get_operator_api,
         )
 
         a = torch.randn(self.M, self.K, device="cuda", dtype=torch.bfloat16)
@@ -992,7 +1056,9 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
         torch._dynamo.reset()
         with (
             patch.object(
-                cutlass_api.Kernel, "get_workspace_size", lambda self, args: 4096
+                get_operator_api().Kernel,
+                "get_workspace_size",
+                lambda self, args: 4096,
             ),
             mock.patch.object(
                 CUDACombinedScheduling, "_benchmark_nvgemm_module", capturing_bench

--- a/test/inductor/test_nv_universal_gemm.py
+++ b/test/inductor/test_nv_universal_gemm.py
@@ -147,6 +147,77 @@ class TestCutlassOperatorsAdapter(TestCase):
         with patch.object(cutlass_ops.importlib, "import_module", fake_import):
             self.assertIs(cutlass_ops.get_arguments_module(), arguments)
 
+    def test_falls_back_when_canonical_import_broken(self):
+        from torch._inductor.codegen.nv_universal_gemm import cutlass_ops
+
+        legacy = types.ModuleType("cutlass_api")
+
+        def fake_import(name):
+            if name == "cutlass.operators":
+                raise _missing_module("networkx")
+            if name == "cutlass_api":
+                return legacy
+            raise _missing_module(name)
+
+        with patch.object(cutlass_ops.importlib, "import_module", fake_import):
+            self.assertIs(cutlass_ops.get_operator_api(), legacy)
+
+    def test_falls_back_when_canonical_raises_bare_import_error(self):
+        from torch._inductor.codegen.nv_universal_gemm import cutlass_ops
+
+        legacy = types.ModuleType("cutlass_api")
+
+        def fake_import(name):
+            if name == "cutlass.operators":
+                raise ImportError("cannot import name 'GemmArguments'")
+            if name == "cutlass_api":
+                return legacy
+            raise _missing_module(name)
+
+        with patch.object(cutlass_ops.importlib, "import_module", fake_import):
+            self.assertIs(cutlass_ops.get_operator_api(), legacy)
+
+    def test_raises_canonical_error_when_both_unavailable(self):
+        from torch._inductor.codegen.nv_universal_gemm import cutlass_ops
+
+        def fake_import(name):
+            if name == "cutlass.operators":
+                raise _missing_module("cutlass")
+            raise _missing_module(name)
+
+        with patch.object(cutlass_ops.importlib, "import_module", fake_import):
+            with self.assertRaises(ModuleNotFoundError) as cm:
+                cutlass_ops.get_operator_api()
+        self.assertEqual(cm.exception.name, "cutlass")
+
+    def test_target_sm_cc(self):
+        from torch._inductor.codegen.nv_universal_gemm import cutlass_ops
+
+        self.assertIsNone(cutlass_ops._target_sm_cc(None))
+        self.assertEqual(cutlass_ops._target_sm_cc(types.SimpleNamespace(cc=90)), 90)
+        self.assertEqual(cutlass_ops._target_sm_cc("sm100"), 100)
+        self.assertIsNone(cutlass_ops._target_sm_cc("blackwell"))
+
+    def test_metadata_min_cc(self):
+        from torch._inductor.codegen.nv_universal_gemm import cutlass_ops
+
+        with_targets = types.SimpleNamespace(
+            supported_targets=[
+                types.SimpleNamespace(cc=100),
+                types.SimpleNamespace(cc=90),
+            ]
+        )
+        self.assertEqual(cutlass_ops._metadata_min_cc(with_targets), 90)
+
+        via_class = types.SimpleNamespace(
+            supported_targets=[],
+            operator_class=types.SimpleNamespace(designed_for_min_cc=80),
+        )
+        self.assertEqual(cutlass_ops._metadata_min_cc(via_class), 80)
+
+        empty = types.SimpleNamespace(supported_targets=None, operator_class=None)
+        self.assertEqual(cutlass_ops._metadata_min_cc(empty), 0)
+
 
 # TODO(nikhilap): Remove Blackwell restriction once `cutlass.operators` or
 # legacy `cutlass_api` include H100 kernels.

--- a/test/inductor/test_nv_universal_gemm.py
+++ b/test/inductor/test_nv_universal_gemm.py
@@ -1023,6 +1023,9 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
         unwraps the inner JIT function for serialization and rewraps it on
         reload. This test compiles an EFC kernel, round-trips through disk
         cache, and verifies the reloaded artifact produces correct results."""
+        from torch._inductor.codegen.nv_universal_gemm.cutlass_ops import (
+            get_provider_submodule,
+        )
         from torch._inductor.codegen.nv_universal_gemm.kernel_cache import (
             _get_kernel_cache,
         )
@@ -1031,6 +1034,14 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
             _unwrap_efc_compiled_obj,
         )
         from torch._inductor.runtime.cutedsl_cache import disk_cache_get, disk_cache_set
+
+        if not hasattr(
+            get_provider_submodule("cutedsl.gemm.sm100_static_persistent_efc"),
+            "KernelOperand",
+        ):
+            self.skipTest(
+                "EFC disk-cache rewrap is only supported with legacy cutlass_api"
+            )
 
         cache = _get_kernel_cache()
         efc_kernel = None
@@ -1109,6 +1120,11 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
         from torch._inductor.codegen.nv_universal_gemm.cutlass_ops import (
             get_operator_api,
         )
+
+        if not hasattr(get_operator_api(), "Kernel"):
+            self.skipTest(
+                "workspace patch target `Kernel` is only exposed by legacy cutlass_api"
+            )
 
         a = torch.randn(self.M, self.K, device="cuda", dtype=torch.bfloat16)
         b = torch.randn(self.K, self.N, device="cuda", dtype=torch.bfloat16)

--- a/test/inductor/test_nv_universal_gemm.py
+++ b/test/inductor/test_nv_universal_gemm.py
@@ -100,95 +100,129 @@ def _missing_module(name):
 
 
 class TestCutlassOperatorsAdapter(TestCase):
-    def test_prefers_cutlass_operators(self):
+    def test_imports_cutlass_operators(self):
         from torch._inductor.codegen.nv_universal_gemm import cutlass_ops
 
         operators = types.ModuleType("cutlass.operators")
-        legacy = types.ModuleType("cutlass_api")
+        imports = []
 
         def fake_import(name):
+            imports.append(name)
             if name == "cutlass.operators":
                 return operators
-            if name == "cutlass_api":
-                return legacy
             raise _missing_module(name)
 
         with patch.object(cutlass_ops.importlib, "import_module", fake_import):
             self.assertIs(cutlass_ops.get_operator_api(), operators)
+        self.assertEqual(imports, ["cutlass.operators"])
 
-    def test_falls_back_to_cutlass_api(self):
-        from torch._inductor.codegen.nv_universal_gemm import cutlass_ops
-
-        legacy = types.ModuleType("cutlass_api")
-
-        def fake_import(name):
-            if name == "cutlass.operators":
-                raise _missing_module(name)
-            if name == "cutlass_api":
-                return legacy
-            raise _missing_module(name)
-
-        with patch.object(cutlass_ops.importlib, "import_module", fake_import):
-            self.assertIs(cutlass_ops.get_operator_api(), legacy)
-
-    def test_submodule_uses_selected_api(self):
+    def test_submodule_uses_cutlass_operators(self):
         from torch._inductor.codegen.nv_universal_gemm import cutlass_ops
 
         operators = types.ModuleType("cutlass.operators")
-        arguments = types.ModuleType("cutlass.operators.arguments")
+        status = types.ModuleType("cutlass.operators.status")
 
         def fake_import(name):
             if name == "cutlass.operators":
                 return operators
-            if name == "cutlass.operators.arguments":
-                return arguments
+            if name == "cutlass.operators.status":
+                return status
             raise _missing_module(name)
 
         with patch.object(cutlass_ops.importlib, "import_module", fake_import):
-            self.assertIs(cutlass_ops.get_arguments_module(), arguments)
+            self.assertIs(cutlass_ops.get_status_module(), status)
 
-    def test_falls_back_when_canonical_import_broken(self):
+    def test_import_error_is_not_masked(self):
         from torch._inductor.codegen.nv_universal_gemm import cutlass_ops
 
-        legacy = types.ModuleType("cutlass_api")
+        error = _missing_module("networkx")
 
         def fake_import(name):
-            if name == "cutlass.operators":
-                raise _missing_module("networkx")
-            if name == "cutlass_api":
-                return legacy
-            raise _missing_module(name)
-
-        with patch.object(cutlass_ops.importlib, "import_module", fake_import):
-            self.assertIs(cutlass_ops.get_operator_api(), legacy)
-
-    def test_falls_back_when_canonical_raises_bare_import_error(self):
-        from torch._inductor.codegen.nv_universal_gemm import cutlass_ops
-
-        legacy = types.ModuleType("cutlass_api")
-
-        def fake_import(name):
-            if name == "cutlass.operators":
-                raise ImportError("cannot import name 'GemmArguments'")
-            if name == "cutlass_api":
-                return legacy
-            raise _missing_module(name)
-
-        with patch.object(cutlass_ops.importlib, "import_module", fake_import):
-            self.assertIs(cutlass_ops.get_operator_api(), legacy)
-
-    def test_raises_canonical_error_when_both_unavailable(self):
-        from torch._inductor.codegen.nv_universal_gemm import cutlass_ops
-
-        def fake_import(name):
-            if name == "cutlass.operators":
-                raise _missing_module("cutlass")
-            raise _missing_module(name)
+            self.assertEqual(name, "cutlass.operators")
+            raise error
 
         with patch.object(cutlass_ops.importlib, "import_module", fake_import):
             with self.assertRaises(ModuleNotFoundError) as cm:
                 cutlass_ops.get_operator_api()
-        self.assertEqual(cm.exception.name, "cutlass")
+        self.assertIs(cm.exception, error)
+
+    def test_workspace_size_bytes(self):
+        from torch._inductor.codegen.nv_universal_gemm import cutlass_ops
+
+        requirement = types.SimpleNamespace(size_bytes=4096)
+        kernel = types.SimpleNamespace(get_workspace_size=lambda _: requirement)
+
+        self.assertEqual(cutlass_ops.get_workspace_size(kernel, object()), 4096)
+
+    def test_disk_cache_reuses_non_efc_artifact(self):
+        from torch._inductor.codegen.nv_universal_gemm.nv_universal_gemm_kernel import (
+            _use_disk_cached_compiled_obj,
+        )
+
+        compiled_obj = object()
+
+        self.assertIs(
+            _use_disk_cached_compiled_obj(compiled_obj, types.SimpleNamespace()),
+            compiled_obj,
+        )
+
+    def test_disk_cache_recompiles_efc_kernel(self):
+        from torch._inductor.codegen.nv_universal_gemm.nv_universal_gemm_kernel import (
+            _use_disk_cached_compiled_obj,
+        )
+
+        kernel = types.SimpleNamespace(impl=types.SimpleNamespace(efc=object()))
+        self.assertIsNone(_use_disk_cached_compiled_obj(object(), kernel))
+
+    def test_nvgemm_run_uses_cached_operator(self):
+        from torch._inductor.codegen.nv_universal_gemm import (
+            nv_universal_gemm_kernel as nvgemm_kernel,
+        )
+
+        tensor = types.SimpleNamespace(
+            shape=(1,),
+            stride=lambda: (1,),
+            dtype=torch.float32,
+            device=types.SimpleNamespace(index=0),
+        )
+        input_tensors = (tensor, tensor)
+        cache_key = nvgemm_kernel._create_gemm_cache_key(input_tensors, tensor)
+        kernel = MagicMock()
+        artifact = types.SimpleNamespace(operator_obj=kernel)
+        compiled_cache = {(cache_key, 0): artifact}
+        args = object()
+
+        with (
+            patch.object(
+                nvgemm_kernel,
+                "get_artifact_module",
+                return_value=types.SimpleNamespace(CompiledArtifact=object),
+            ),
+            patch.object(
+                nvgemm_kernel,
+                "_create_gemm_arguments",
+                return_value=args,
+            ),
+        ):
+            nvgemm_kernel._nvgemm_run(
+                "GEMM",
+                "unused",
+                input_tensors,
+                tensor,
+                torch.float32,
+                compiled_cache,
+                {},
+                "unused",
+                (),
+            )
+
+        kernel.run.assert_called_once_with(
+            args,
+            artifact,
+            stream=None,
+            workspace=None,
+            assume_supported_args=True,
+        )
 
     def test_target_sm_cc(self):
         from torch._inductor.codegen.nv_universal_gemm import cutlass_ops
@@ -219,8 +253,7 @@ class TestCutlassOperatorsAdapter(TestCase):
         self.assertEqual(cutlass_ops._metadata_min_cc(empty), 0)
 
 
-# TODO(nikhilap): Remove Blackwell restriction once `cutlass.operators` or
-# legacy `cutlass_api` include H100 kernels.
+# TODO(nikhilap): Remove Blackwell restriction once `cutlass.operators` includes H100 kernels.
 @unittest.skipIf(
     not (ensure_nv_universal_gemm_available() and is_datacenter_blackwell_arch()),
     "NVIDIA Universal GEMM operator API not available or not on Blackwell",
@@ -268,7 +301,7 @@ class TestNVUniversalGemm(TestCase):
     def test_unaligned_base_pointer_rejected(self):
         """Test that matmul with unaligned base pointer is rejected.
 
-        The CUTLASS operator API (`cutlass.operators` or legacy `cutlass_api`)
+        The CUTLASS operator API (`cutlass.operators`)
         requires 16-byte aligned base pointers. Since alignment
         can't be checked at compile time (FakeTensors don't have real pointers),
         Inductor must guard against unaligned buffers.
@@ -324,9 +357,8 @@ class TestNVUniversalGemm(TestCase):
     def test_workspace_allocation(self):
         """Test that workspace allocation works correctly.
 
-        Since no current `cutlass.operators` or legacy `cutlass_api` kernels
-        require a workspace, we mock the
-        kernel.get_workspace_size method to return a non-zero value.
+        Since no current `cutlass.operators` kernels require a workspace, we
+        mock the adapter to return a non-zero value.
         """
         m, n, k = 512, 512, 512
         dtype = torch.bfloat16
@@ -341,24 +373,19 @@ class TestNVUniversalGemm(TestCase):
 
         torch._dynamo.reset()
 
-        from torch._inductor.codegen.nv_universal_gemm.cutlass_ops import (
-            get_operator_api,
+        from torch._inductor.codegen.nv_universal_gemm import (
+            nv_universal_gemm as nvgemm,
         )
 
-        def patched_get_workspace_size(self, args):
-            return 1024
-
-        with patch.object(
-            get_operator_api().Kernel,
-            "get_workspace_size",
-            patched_get_workspace_size,
+        with (
+            patch.object(nvgemm, "get_workspace_size", return_value=1024),
+            config.patch(_nvgemm_config()),
         ):
-            with config.patch(_nvgemm_config()):
-                result, (code,) = run_and_get_code(
-                    torch.compile(matmul),
-                    a,
-                    b,
-                )
+            result, (code,) = run_and_get_code(
+                torch.compile(matmul),
+                a,
+                b,
+            )
 
         self.assertIn("workspace=workspace", code)
         torch.testing.assert_close(result, expected)
@@ -733,8 +760,7 @@ class TestNVUniversalGemmHeuristics(TestCase):
         and is_datacenter_blackwell_arch()
         and ensure_nvmatmul_heuristics_available()
     ),
-    "Requires CUTLASS operator API (`cutlass.operators` or legacy "
-    "`cutlass_api`), nvMatmulHeuristics, and Blackwell GPU",
+    "Requires `cutlass.operators`, nvMatmulHeuristics, and Blackwell GPU",
 )
 class TestNVUniversalGemmHeuristicsIntegration(TestCase):
     """Integration tests for nvMatmulHeuristics with real library calls."""
@@ -1015,93 +1041,6 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
         torch.testing.assert_close(result, fn(a, b, bias), atol=1e-2, rtol=1e-2)
         self.assertTrue(epilogue_fused, "bias+relu was NOT fused into epilogue")
 
-    def test_efc_disk_cache_round_trip(self):
-        """Verify that EFC kernel compiled artifacts can be serialized to disk
-        and reloaded correctly.
-
-        EFC kernels produce a closure-wrapped compiled_obj. The disk cache
-        unwraps the inner JIT function for serialization and rewraps it on
-        reload. This test compiles an EFC kernel, round-trips through disk
-        cache, and verifies the reloaded artifact produces correct results."""
-        from torch._inductor.codegen.nv_universal_gemm.cutlass_ops import (
-            get_provider_submodule,
-        )
-        from torch._inductor.codegen.nv_universal_gemm.kernel_cache import (
-            _get_kernel_cache,
-        )
-        from torch._inductor.codegen.nv_universal_gemm.nv_universal_gemm_kernel import (
-            _rewrap_efc_compiled_obj,
-            _unwrap_efc_compiled_obj,
-        )
-        from torch._inductor.runtime.cutedsl_cache import disk_cache_get, disk_cache_set
-
-        if not hasattr(
-            get_provider_submodule("cutedsl.gemm.sm100_static_persistent_efc"),
-            "KernelOperand",
-        ):
-            self.skipTest(
-                "EFC disk-cache rewrap is only supported with legacy cutlass_api"
-            )
-
-        cache = _get_kernel_cache()
-        efc_kernel = None
-        for name, k in cache.items():
-            if (
-                "EFC" in name
-                and "ABFloat16" in name
-                and "outBFloat16" in name
-                and "ttt" in name
-            ):
-                efc_kernel = k
-                break
-        if efc_kernel is None:
-            self.skipTest("No matching EFC kernel found in cache")
-
-        from torch._inductor.codegen.nv_universal_gemm.cutlass_ops import (
-            get_arguments_module,
-            get_artifact_module,
-        )
-
-        CompiledArtifact = get_artifact_module().CompiledArtifact
-        GemmArguments = get_arguments_module().GemmArguments
-
-        a = torch.randn(self.M, self.K, device="cuda", dtype=torch.bfloat16)
-        b = torch.randn(self.K, self.N, device="cuda", dtype=torch.bfloat16)
-        out = torch.empty(self.M, self.N, device="cuda", dtype=torch.bfloat16)
-
-        args = GemmArguments(a, b, out, accumulator_type=torch.float32)
-        artifact = efc_kernel.compile(args)
-
-        # Unwrap, serialize, reload, rewrap
-        inner = _unwrap_efc_compiled_obj(artifact.compiled_obj)
-        self.assertNotEqual(
-            type(inner).__name__,
-            "function",
-            "unwrap should extract the JIT function, not the closure",
-        )
-
-        test_cache: dict = {}
-        disk_cache_set(test_cache, "/tmp/test_efc_rt.py", ("efc",), ("key",), inner, 0)
-        loaded = disk_cache_get({}, "/tmp/test_efc_rt.py", ("efc",), ("key",), 0)
-        self.assertIsNotNone(loaded, "disk_cache_get returned None")
-
-        rewrapped = _rewrap_efc_compiled_obj(loaded, efc_kernel)
-        reloaded_artifact = CompiledArtifact(rewrapped, efc_kernel)
-
-        # Run with reloaded artifact and verify correctness
-        out2 = torch.empty(self.M, self.N, device="cuda", dtype=torch.bfloat16)
-        args2 = GemmArguments(a, b, out2, accumulator_type=torch.float32)
-        efc_kernel.run(
-            args2,
-            reloaded_artifact,
-            stream=torch.cuda.current_stream(),
-            workspace=None,
-            assume_supported_args=True,
-        )
-        torch.cuda.synchronize()
-        expected = a.float() @ b.float()
-        torch.testing.assert_close(out2.float(), expected, atol=1e-2, rtol=1e-2)
-
     def test_workspace_runtime_integration(self):
         """End-to-end: mock the chosen kernel's workspace_size to non-zero and
         actually let benchmark_codegened_module run, exercising the runtime
@@ -1117,14 +1056,9 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
         from torch._inductor.codegen.cuda_combined_scheduling import (
             CUDACombinedScheduling,
         )
-        from torch._inductor.codegen.nv_universal_gemm.cutlass_ops import (
-            get_operator_api,
+        from torch._inductor.codegen.nv_universal_gemm import (
+            nv_universal_gemm as nvgemm,
         )
-
-        if not hasattr(get_operator_api(), "Kernel"):
-            self.skipTest(
-                "workspace patch target `Kernel` is only exposed by legacy cutlass_api"
-            )
 
         a = torch.randn(self.M, self.K, device="cuda", dtype=torch.bfloat16)
         b = torch.randn(self.K, self.N, device="cuda", dtype=torch.bfloat16)
@@ -1142,11 +1076,7 @@ class TestNVUniversalGemmEpilogueFusion(TestCase):
 
         torch._dynamo.reset()
         with (
-            patch.object(
-                get_operator_api().Kernel,
-                "get_workspace_size",
-                lambda self, args: 4096,
-            ),
+            patch.object(nvgemm, "get_workspace_size", return_value=4096),
             mock.patch.object(
                 CUDACombinedScheduling, "_benchmark_nvgemm_module", capturing_bench
             ),

--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -13,6 +13,9 @@ from sympy import I, Max, Min, Symbol, sympify
 import torch
 from torch._dynamo.testing import AotEagerAndRecordGraphs
 from torch._dynamo.utils import detect_fake_mode
+from torch._inductor.codegen.nv_universal_gemm.cutlass_ops import (
+    is_available as is_nv_universal_gemm_operator_available,
+)
 from torch._inductor.compile_fx import _get_subgraph_names
 from torch._inductor.fx_utils import (
     _is_fake_tensor_same,
@@ -384,22 +387,25 @@ class TestFP4Support(TestCase):
     """Tests for FP4 (float4_e2m1fn_x2) infrastructure support."""
 
     @unittest.skipIf(
-        not torch.cuda.is_available()
-        or importlib.util.find_spec("cutlass_api") is None,
-        "requires CUDA and cutlass_api",
+        not torch.cuda.is_available() or not is_nv_universal_gemm_operator_available(),
+        "requires CUDA and CUTLASS operator API "
+        "(`cutlass.operators` or legacy `cutlass_api`)",
     )
     def test_ensure_fp4_dtype_registered(self):
-        """_ensure_fp4_dtype_registered should patch cutlass_api for FP4."""
+        """Patch `cutlass.operators` or legacy `cutlass_api` for FP4."""
+        from torch._inductor.codegen.nv_universal_gemm.cutlass_ops import (
+            get_dtype_utils_module,
+        )
         from torch._inductor.utils import _ensure_fp4_dtype_registered
 
         _ensure_fp4_dtype_registered()
         import cutlass
-        import cutlass_api.utils
 
-        result = cutlass_api.utils.cutlass_type_from_torch_type(torch.float4_e2m1fn_x2)
+        utils = get_dtype_utils_module()
+        result = utils.cutlass_type_from_torch_type(torch.float4_e2m1fn_x2)
         self.assertEqual(result, cutlass.Float4E2M1FN)
 
-        result_fp32 = cutlass_api.utils.cutlass_type_from_torch_type(torch.float32)
+        result_fp32 = utils.cutlass_type_from_torch_type(torch.float32)
         self.assertEqual(result_fp32, cutlass.Float32)
 
     def test_rand_strided_fp4(self):

--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -388,11 +388,10 @@ class TestFP4Support(TestCase):
 
     @unittest.skipIf(
         not torch.cuda.is_available() or not is_nv_universal_gemm_operator_available(),
-        "requires CUDA and CUTLASS operator API "
-        "(`cutlass.operators` or legacy `cutlass_api`)",
+        "requires CUDA and CUTLASS operator API (`cutlass.operators`)",
     )
     def test_ensure_fp4_dtype_registered(self):
-        """Patch `cutlass.operators` or legacy `cutlass_api` for FP4."""
+        """Patch `cutlass.operators` for FP4."""
         from torch._inductor.codegen.nv_universal_gemm.cutlass_ops import (
             get_dtype_utils_module,
         )

--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -1,7 +1,6 @@
 # Owner(s): ["module: inductor"]
 
 import builtins
-import importlib.util
 import tempfile
 import unittest
 from collections.abc import Callable, Iterator

--- a/test/test_public_bindings.py
+++ b/test/test_public_bindings.py
@@ -363,8 +363,8 @@ class TestPublicBindings(TestCase):
             "torch._inductor.codegen.cpp_template_kernel",
             "torch._inductor.kernel.vendored_templates.cutedsl.kernels.cutedsl_grouped_gemm",  # depends on cutlass
             "torch._inductor.kernel.vendored_templates.cutedsl.dense_blockscaled_gemm_persistent",  # depends on cutlass
-            "torch._inductor.kernel.vendored_templates.cutedsl.wrappers",  # depends on cutlass_api
-            "torch._inductor.kernel.vendored_templates.cutedsl.wrappers.dense_blockscaled_gemm_kernel",  # depends on cutlass_api
+            "torch._inductor.kernel.vendored_templates.cutedsl.wrappers",  # depends on cutlass
+            "torch._inductor.kernel.vendored_templates.cutedsl.wrappers.dense_blockscaled_gemm_kernel",  # depends on cutlass
             "torch._inductor.runtime.triton_helpers",
             "torch.ao.pruning._experimental.data_sparsifier.lightning.callbacks.data_sparsity",
             "torch.backends._coreml.preprocess",

--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -747,7 +747,8 @@ class AsyncCompile:
                 real CuTe DSL compilation in the subprocess worker.
 
         Note:
-            NVIDIA Universal GEMM kernels are Python code that calls the cutlass_api library.
+            NVIDIA Universal GEMM kernels are Python code that calls the
+            cutlass.operators library.
             We use the PyCodeCache to write the source code to a file and load it.
         """
         from torch._inductor.codegen.nv_universal_gemm.nv_universal_gemm_kernel import (

--- a/torch/_inductor/codegen/nv_universal_gemm/cutlass_ops.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/cutlass_ops.py
@@ -15,13 +15,23 @@ _proxy_cache: dict[str, ModuleType] = {}
 
 
 def get_operator_api() -> ModuleType:
-    """Return `cutlass.operators`, falling back to legacy `cutlass_api`."""
+    """Return `cutlass.operators`, falling back to legacy `cutlass_api`.
+
+    Any ImportError from the canonical namespace (absent, a missing transitive
+    dependency, or a broken import) falls back to legacy `cutlass_api` when it is
+    importable. This mirrors the ImportError boundary used by is_available(), so
+    a present-but-broken canonical install does not silently disable NVGEMM when
+    a working legacy `cutlass_api` exists. If legacy is also unavailable, the
+    original canonical error is raised so the broken install is not masked by a
+    bare "cutlass_api not found".
+    """
     try:
         return importlib.import_module(_CANONICAL_API)
-    except ModuleNotFoundError as e:
-        if e.name not in ("cutlass", _CANONICAL_API):
-            raise
-    return importlib.import_module(_LEGACY_API)
+    except ImportError as canonical_err:
+        try:
+            return importlib.import_module(_LEGACY_API)
+        except ImportError:
+            raise canonical_err from None
 
 
 def _is_canonical_api(api: ModuleType | None = None) -> bool:
@@ -88,6 +98,13 @@ def _metadata_min_cc(metadata: Any) -> int:
 
 
 def get_arguments_module() -> ModuleType:
+    """Return the arguments module with legacy-style operand properties.
+
+    For the canonical API this adds legacy properties (element_type/shape/stride
+    and scaled-operand aliases) directly onto the real `DenseTensor`/
+    `ScaledOperand` classes in place, so the mutation is process-global rather
+    than confined to the returned proxy. Each property is only added when absent.
+    """
     arguments = _get_submodule("arguments")
     if not _is_canonical_api() or not hasattr(arguments, "ScaledOperand"):
         return arguments
@@ -457,7 +474,12 @@ def get_kernels() -> Any:
 
 
 def ensure_fp4_dtype_registered() -> None:
-    """Patch `cutlass.operators` or legacy `cutlass_api` for FP4."""
+    """Patch `cutlass.operators` or legacy `cutlass_api` for FP4.
+
+    Patches the lookup in place on the real dtype module in addition to the
+    adapter proxy so cutlass-internal callers (not just code going through the
+    proxy) pick up the FP4 mapping, matching the legacy in-place patch.
+    """
     import torch
 
     utils = get_dtype_utils_module()
@@ -466,11 +488,22 @@ def ensure_fp4_dtype_registered() -> None:
     except KeyError:
         import cutlass
 
-        orig = utils.cutlass_type_from_torch_type
+        def make_patched(orig):
+            def patched(dtype):
+                if dtype == torch.float4_e2m1fn_x2:
+                    return cutlass.Float4E2M1FN
+                return orig(dtype)
 
-        def patched(dtype):
-            if dtype == torch.float4_e2m1fn_x2:
-                return cutlass.Float4E2M1FN
-            return orig(dtype)
+            return patched
 
-        _set_module_attr(utils, "cutlass_type_from_torch_type", patched)
+        modules = [utils]
+        real_dtype = getattr(utils, "dtype", None)
+        if (
+            real_dtype is not None
+            and real_dtype is not utils
+            and hasattr(real_dtype, "cutlass_type_from_torch_type")
+        ):
+            modules.append(real_dtype)
+        for module in modules:
+            orig = _get_module_attr(module, "cutlass_type_from_torch_type")
+            _set_module_attr(module, "cutlass_type_from_torch_type", make_patched(orig))

--- a/torch/_inductor/codegen/nv_universal_gemm/cutlass_ops.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/cutlass_ops.py
@@ -1,0 +1,476 @@
+# mypy: allow-untyped-defs
+"""Import adapter for `cutlass.operators` and legacy `cutlass_api`."""
+
+from __future__ import annotations
+
+import importlib
+from types import ModuleType
+from typing import Any
+
+
+_CANONICAL_API = "cutlass.operators"
+_LEGACY_API = "cutlass_api"
+
+_proxy_cache: dict[str, ModuleType] = {}
+
+
+def get_operator_api() -> ModuleType:
+    """Return `cutlass.operators`, falling back to legacy `cutlass_api`."""
+    try:
+        return importlib.import_module(_CANONICAL_API)
+    except ModuleNotFoundError as e:
+        if e.name not in ("cutlass", _CANONICAL_API):
+            raise
+    return importlib.import_module(_LEGACY_API)
+
+
+def _is_canonical_api(api: ModuleType | None = None) -> bool:
+    api = api or get_operator_api()
+    return api.__name__ == _CANONICAL_API
+
+
+def is_available() -> bool:
+    try:
+        get_operator_api()
+    except ImportError:
+        return False
+    return True
+
+
+def _get_submodule(name: str) -> ModuleType:
+    api = get_operator_api()
+    module_name = f"{api.__name__}.{name}"
+    try:
+        return importlib.import_module(module_name)
+    except ModuleNotFoundError as e:
+        if e.name == module_name and hasattr(api, name):
+            return getattr(api, name)
+        raise
+
+
+def _copy_module_proxy(cache_key: str, module: ModuleType) -> ModuleType:
+    proxy = _proxy_cache.get(cache_key)
+    if proxy is None:
+        proxy = ModuleType(module.__name__)
+        proxy.__dict__.update(module.__dict__)
+        _proxy_cache[cache_key] = proxy
+    return proxy
+
+
+def _set_module_attr(module: ModuleType, name: str, value: Any) -> None:
+    setattr(module, name, value)
+
+
+def _get_module_attr(module: ModuleType, name: str) -> Any:
+    return getattr(module, name)
+
+
+def _target_sm_cc(target_sm: Any) -> int | None:
+    if target_sm is None:
+        return None
+    cc = getattr(target_sm, "cc", None)
+    if cc is not None:
+        return int(cc)
+    digits = "".join(ch for ch in str(target_sm) if ch.isdigit())
+    if not digits:
+        return None
+    return int(digits)
+
+
+def _metadata_min_cc(metadata: Any) -> int:
+    targets = getattr(metadata, "supported_targets", None)
+    target_ccs = [_target_sm_cc(target) for target in targets or ()]
+    target_ccs = [cc for cc in target_ccs if cc is not None]
+    if target_ccs:
+        return min(target_ccs)
+    operator_class = getattr(metadata, "operator_class", None)
+    return int(getattr(operator_class, "designed_for_min_cc", 0))
+
+
+def get_arguments_module() -> ModuleType:
+    arguments = _get_submodule("arguments")
+    if not _is_canonical_api() or not hasattr(arguments, "ScaledOperand"):
+        return arguments
+
+    proxy = _copy_module_proxy("canonical_arguments", arguments)
+    DenseTensor = arguments.DenseTensor
+    ScaledOperand = arguments.ScaledOperand
+
+    def dense_element_type(self):
+        dtype = self.tensor.dtype
+        try:
+            return get_dtype_utils_module().cutlass_type_from_torch_type(dtype)
+        except KeyError:
+            return dtype
+
+    def dense_shape(self):
+        return self.tensor.shape
+
+    def dense_stride(self):
+        stride = self.tensor.stride
+        return stride() if callable(stride) else stride
+
+    def scaled_base(self):
+        return self.quantized
+
+    def scaled_attr(name):
+        def getter(self):
+            return getattr(self.quantized, name)
+
+        return getter
+
+    for cls, attr, getter in (
+        (DenseTensor, "element_type", dense_element_type),
+        (DenseTensor, "shape", dense_shape),
+        (DenseTensor, "stride", dense_stride),
+        (ScaledOperand, "base", scaled_base),
+        (ScaledOperand, "tensor", scaled_attr("tensor")),
+        (ScaledOperand, "element_type", scaled_attr("element_type")),
+        (ScaledOperand, "shape", scaled_attr("shape")),
+        (ScaledOperand, "stride", scaled_attr("stride")),
+    ):
+        if not hasattr(cls, attr):
+            setattr(cls, attr, property(getter))
+
+    if not hasattr(proxy, "ScaledTensor"):
+
+        class ScaledTensor(ScaledOperand):
+            pass
+
+        ScaledTensor.__module__ = arguments.__name__
+        _set_module_attr(proxy, "ScaledTensor", ScaledTensor)
+    return proxy
+
+
+def get_artifact_module() -> ModuleType:
+    artifact = _get_submodule("artifact")
+    if not _is_canonical_api():
+        return artifact
+
+    proxy = _copy_module_proxy("canonical_artifact", artifact)
+    if getattr(proxy.CompiledArtifact, "_torchinductor_legacy_ctor", False):
+        return proxy
+
+    from cutlass.operators.arch import TargetSm
+
+    class CompiledArtifact(artifact.CompiledArtifact):
+        def __init__(self, compiled_obj, operator_obj, compiled_for=None):
+            if isinstance(compiled_obj, artifact.CompiledArtifact):
+                compiled_for = compiled_for or compiled_obj.compiled_for
+                compiled_obj = compiled_obj.compiled_obj
+            if compiled_for is None:
+                metadata = getattr(operator_obj, "metadata", None)
+                compiled_for = TargetSm.ensure(str(_metadata_min_cc(metadata)))
+            super().__init__(compiled_obj, operator_obj, compiled_for)
+
+    CompiledArtifact.__module__ = artifact.__name__
+    CompiledArtifact._torchinductor_legacy_ctor = True
+    _set_module_attr(proxy, "CompiledArtifact", CompiledArtifact)
+    return proxy
+
+
+def get_library_module() -> ModuleType:
+    if not _is_canonical_api():
+        return _get_submodule("library")
+
+    arguments = get_arguments_module()
+    proxy = _proxy_cache.get("canonical_library")
+    if proxy is None:
+        proxy = ModuleType(f"{_CANONICAL_API}.library")
+        _set_module_attr(proxy, "ScaleMode", _get_module_attr(arguments, "ScaleMode"))
+        _set_module_attr(
+            proxy, "ScaleSwizzleMode", _get_module_attr(arguments, "ScaleSwizzleMode")
+        )
+        _proxy_cache["canonical_library"] = proxy
+    return proxy
+
+
+def get_metadata_module() -> ModuleType:
+    """Return operator metadata with legacy NVGEMM aliases when needed."""
+    metadata = _get_submodule("metadata")
+    if not _is_canonical_api() or hasattr(metadata, "KernelMetadata"):
+        return metadata
+
+    proxy = _copy_module_proxy("canonical_metadata", metadata)
+    if hasattr(proxy, "KernelMetadata"):
+        return proxy
+
+    from cutlass.operators.arch import TargetSm
+    from cutlass.operators.mma import BlackwellTcgen05Mma
+
+    class DenseTensorAttributes(metadata.DenseTensorConstraints):
+        pass
+
+    class ScaledTensorAttributes(metadata.ScaledOperandConstraints):
+        def __init__(self, base, scale, mode, swizzle):
+            super().__init__(
+                quantized=base,
+                scale=scale,
+                mode=mode,
+                swizzle=swizzle,
+            )
+
+        @property
+        def base(self):
+            return self.quantized
+
+    class Sm100DesignMetadata(metadata.Sm100DesignMetadata):
+        def __init__(
+            self,
+            tile_shape,
+            cluster_shape,
+            use_2cta_mma,
+            use_tma_store,
+            tile_scheduler=None,
+            fallback_cluster_shape=None,
+            *,
+            mma_instruction_type=None,
+            num_smem_stages=None,
+        ):
+            super().__init__(
+                use_2cta_mma=use_2cta_mma,
+                use_tma_store=use_tma_store,
+                tile_scheduler=tile_scheduler,
+                fallback_cluster_shape=fallback_cluster_shape,
+                mma_instruction_type=mma_instruction_type or BlackwellTcgen05Mma,
+                tile_shape=tile_shape,
+                cluster_shape=cluster_shape,
+                num_smem_stages=num_smem_stages,
+            )
+
+    class KernelMetadata(metadata.OperatorMetadata):
+        def __init__(
+            self,
+            *,
+            operands,
+            design,
+            kernel_name,
+            kernel_class,
+            min_cc,
+            epilogue=None,
+            supported_targets=None,
+        ):
+            if supported_targets is None:
+                supported_targets = [TargetSm.ensure(str(min_cc))]
+            super().__init__(
+                operator_name=kernel_name,
+                operator_class=kernel_class,
+                supported_targets=supported_targets,
+                operands=operands,
+                design=design,
+                epilogue=epilogue,
+            )
+            self.kernel_name = kernel_name
+            self.kernel_class = kernel_class
+            self.min_cc = min_cc
+
+    for cls in (
+        DenseTensorAttributes,
+        ScaledTensorAttributes,
+        Sm100DesignMetadata,
+        KernelMetadata,
+    ):
+        cls.__module__ = metadata.__name__
+
+    _set_module_attr(proxy, "DenseTensorAttributes", DenseTensorAttributes)
+    _set_module_attr(proxy, "ScaledTensorAttributes", ScaledTensorAttributes)
+    _set_module_attr(proxy, "Sm100DesignMetadata", Sm100DesignMetadata)
+    _set_module_attr(proxy, "KernelMetadata", KernelMetadata)
+    return proxy
+
+
+def get_status_module() -> ModuleType:
+    return _get_submodule("status")
+
+
+def get_utils_module() -> ModuleType:
+    utils = _get_submodule("utils")
+    if not _is_canonical_api():
+        return utils
+
+    proxy = _copy_module_proxy("canonical_utils", utils)
+    if not hasattr(proxy, "strides_to_layout_string"):
+        _set_module_attr(
+            proxy,
+            "strides_to_layout_string",
+            importlib.import_module(
+                f"{utils.__name__}.tensor"
+            ).strides_to_layout_string,
+        )
+    if not hasattr(proxy, "to_cuda_stream"):
+        _set_module_attr(
+            proxy,
+            "to_cuda_stream",
+            importlib.import_module(f"{utils.__name__}.device").to_cuda_stream,
+        )
+    if not hasattr(proxy, "tuple_to_string"):
+        _set_module_attr(
+            proxy,
+            "tuple_to_string",
+            importlib.import_module(f"{utils.__name__}.common").tuple_to_string,
+        )
+    if not hasattr(proxy, "cutlass_type_from_torch_type"):
+        dtype = importlib.import_module(f"{utils.__name__}.dtype")
+        _set_module_attr(
+            proxy, "cutlass_type_from_torch_type", dtype.cutlass_type_from_torch_type
+        )
+        _set_module_attr(proxy, "dtype", dtype)
+    return proxy
+
+
+def get_dtype_utils_module() -> ModuleType:
+    utils = get_utils_module()
+    if hasattr(utils, "cutlass_type_from_torch_type"):
+        return utils
+    if hasattr(utils, "dtype"):
+        return utils.dtype
+    return _get_submodule("utils.dtype")
+
+
+def _canonical_cutedsl_kernel_module() -> ModuleType:
+    proxy = _proxy_cache.get("canonical_cutedsl_kernel")
+    if proxy is not None:
+        return proxy
+
+    from cutlass.operators.providers.cutedsl.operator import CuteDslOperator
+
+    arguments = get_arguments_module()
+
+    class CuteDslKernel(CuteDslOperator):
+        supported_args_type = _get_module_attr(arguments, "GemmArguments")
+        designed_for_min_cc = 100
+
+        def __init_subclass__(cls, **kwargs):
+            pass
+
+        def _compile(self, args, target_sm=None):
+            cc = _target_sm_cc(target_sm)
+            return self.compile(args, cc=cc)
+
+        def _run(self, args, compiled_artifact, stream, workspace=None):
+            raise NotImplementedError
+
+        @classmethod
+        def generate_operators(
+            cls,
+            metadata_filter=None,
+            epilogue_args=None,
+            target_sm=None,
+            args=None,
+        ):
+            cc = _target_sm_cc(target_sm)
+            return cls.generate_kernels(
+                metadata_filter,
+                epilogue_args=epilogue_args,
+                cc=cc,
+            )
+
+        @classmethod
+        def _generate_operators(
+            cls,
+            metadata_filter,
+            epilogue_args=None,
+            target_sm=None,
+            args=None,
+        ):
+            return cls.generate_operators(
+                metadata_filter,
+                epilogue_args=epilogue_args,
+                target_sm=target_sm,
+                args=args,
+            )
+
+    CuteDslKernel.__module__ = f"{_CANONICAL_API}.providers.cutedsl.kernel"
+    proxy = ModuleType(CuteDslKernel.__module__)
+    _set_module_attr(proxy, "CuteDslKernel", CuteDslKernel)
+    _proxy_cache["canonical_cutedsl_kernel"] = proxy
+    return proxy
+
+
+def get_provider_submodule(name: str) -> ModuleType:
+    if not _is_canonical_api():
+        return _get_submodule(f"providers.{name}")
+    if name == "cutedsl.kernel":
+        return _canonical_cutedsl_kernel_module()
+    if name == "cutedsl.utils":
+        return importlib.import_module(
+            f"{_CANONICAL_API}.providers.cutedsl.integration_utils.mma"
+        )
+    return _get_submodule(f"providers.{name}")
+
+
+def _canonical_provider_module_name(name: str) -> str:
+    mapping = {
+        "cutedsl.utils": f"{_CANONICAL_API}.providers.cutedsl.integration_utils.mma",
+        "cutedsl.gemm.sm100_static_persistent": f"{_CANONICAL_API}.providers.cutedsl.gemm.sm100_persistent",
+    }
+    return mapping.get(name, f"{_CANONICAL_API}.providers.{name}")
+
+
+def provider_module_names(names: list[str]) -> list[str]:
+    api = get_operator_api()
+    if api.__name__ == _CANONICAL_API:
+        return [_canonical_provider_module_name(name) for name in names]
+    return [f"{api.__name__}.providers.{name}" for name in names]
+
+
+def _ensure_legacy_workspace_size(kernel: Any) -> None:
+    if getattr(kernel, "_torchinductor_workspace_size_compat", False):
+        return
+
+    get_workspace_size = kernel.get_workspace_size
+
+    def legacy_get_workspace_size(args):
+        workspace_size = get_workspace_size(args)
+        return getattr(workspace_size, "size_bytes", workspace_size)
+
+    kernel.get_workspace_size = legacy_get_workspace_size
+    kernel._torchinductor_workspace_size_compat = True
+
+
+def _ensure_legacy_kernel_metadata(kernel: Any) -> Any:
+    metadata = kernel.metadata
+    if not all(
+        hasattr(metadata, attr) for attr in ("kernel_name", "kernel_class", "min_cc")
+    ):
+        metadata_module = get_metadata_module()
+        metadata = metadata_module.KernelMetadata(
+            operands=metadata.operands,
+            design=metadata.design,
+            kernel_name=metadata.operator_name,
+            kernel_class=metadata.operator_class,
+            min_cc=_metadata_min_cc(metadata),
+            epilogue=metadata.epilogue,
+            supported_targets=metadata.supported_targets,
+        )
+        kernel._metadata = metadata
+
+    _ensure_legacy_workspace_size(kernel)
+    return kernel
+
+
+def get_kernels() -> Any:
+    api = get_operator_api()
+    if hasattr(api, "get_kernels"):
+        return api.get_kernels()
+    return [_ensure_legacy_kernel_metadata(kernel) for kernel in api.get_operators()]
+
+
+def ensure_fp4_dtype_registered() -> None:
+    """Patch `cutlass.operators` or legacy `cutlass_api` for FP4."""
+    import torch
+
+    utils = get_dtype_utils_module()
+    try:
+        utils.cutlass_type_from_torch_type(torch.float4_e2m1fn_x2)
+    except KeyError:
+        import cutlass
+
+        orig = utils.cutlass_type_from_torch_type
+
+        def patched(dtype):
+            if dtype == torch.float4_e2m1fn_x2:
+                return cutlass.Float4E2M1FN
+            return orig(dtype)
+
+        _set_module_attr(utils, "cutlass_type_from_torch_type", patched)

--- a/torch/_inductor/codegen/nv_universal_gemm/cutlass_ops.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/cutlass_ops.py
@@ -1,42 +1,29 @@
 # mypy: allow-untyped-defs
-"""Import adapter for `cutlass.operators` and legacy `cutlass_api`."""
+"""Compatibility helpers for `cutlass.operators`."""
 
 from __future__ import annotations
 
 import importlib
 from types import ModuleType
-from typing import Any
+from typing import Any, cast
 
 
-_CANONICAL_API = "cutlass.operators"
-_LEGACY_API = "cutlass_api"
+_OPERATOR_API = "cutlass.operators"
 
 _proxy_cache: dict[str, ModuleType] = {}
 
 
+def _get_module_attr(module: ModuleType, name: str) -> Any:
+    return getattr(module, name)
+
+
+def _set_module_attr(module: ModuleType, name: str, value: Any) -> None:
+    setattr(module, name, value)
+
+
 def get_operator_api() -> ModuleType:
-    """Return `cutlass.operators`, falling back to legacy `cutlass_api`.
-
-    Any ImportError from the canonical namespace (absent, a missing transitive
-    dependency, or a broken import) falls back to legacy `cutlass_api` when it is
-    importable. This mirrors the ImportError boundary used by is_available(), so
-    a present-but-broken canonical install does not silently disable NVGEMM when
-    a working legacy `cutlass_api` exists. If legacy is also unavailable, the
-    original canonical error is raised so the broken install is not masked by a
-    bare "cutlass_api not found".
-    """
-    try:
-        return importlib.import_module(_CANONICAL_API)
-    except ImportError as canonical_err:
-        try:
-            return importlib.import_module(_LEGACY_API)
-        except ImportError:
-            raise canonical_err from None
-
-
-def _is_canonical_api(api: ModuleType | None = None) -> bool:
-    api = api or get_operator_api()
-    return api.__name__ == _CANONICAL_API
+    """Return the `cutlass.operators` module."""
+    return importlib.import_module(_OPERATOR_API)
 
 
 def is_available() -> bool:
@@ -67,14 +54,6 @@ def _copy_module_proxy(cache_key: str, module: ModuleType) -> ModuleType:
     return proxy
 
 
-def _set_module_attr(module: ModuleType, name: str, value: Any) -> None:
-    setattr(module, name, value)
-
-
-def _get_module_attr(module: ModuleType, name: str) -> Any:
-    return getattr(module, name)
-
-
 def _target_sm_cc(target_sm: Any) -> int | None:
     if target_sm is None:
         return None
@@ -98,17 +77,14 @@ def _metadata_min_cc(metadata: Any) -> int:
 
 
 def get_arguments_module() -> ModuleType:
-    """Return the arguments module with legacy-style operand properties.
+    """Return the arguments module with NVGEMM-compatible operand properties.
 
-    For the canonical API this adds legacy properties (element_type/shape/stride
-    and scaled-operand aliases) directly onto the real `DenseTensor`/
-    `ScaledOperand` classes in place, so the mutation is process-global rather
-    than confined to the returned proxy. Each property is only added when absent.
+    This adds element_type/shape/stride properties and scaled-operand aliases
+    directly onto the real `DenseTensor`/`ScaledOperand` classes in place, so
+    the mutation is process-global rather than confined to the returned proxy.
+    Each property is only added when absent.
     """
     arguments = _get_submodule("arguments")
-    if not _is_canonical_api() or not hasattr(arguments, "ScaledOperand"):
-        return arguments
-
     proxy = _copy_module_proxy("canonical_arguments", arguments)
     DenseTensor = arguments.DenseTensor
     ScaledOperand = arguments.ScaledOperand
@@ -161,11 +137,8 @@ def get_arguments_module() -> ModuleType:
 
 def get_artifact_module() -> ModuleType:
     artifact = _get_submodule("artifact")
-    if not _is_canonical_api():
-        return artifact
-
     proxy = _copy_module_proxy("canonical_artifact", artifact)
-    if getattr(proxy.CompiledArtifact, "_torchinductor_legacy_ctor", False):
+    if getattr(proxy.CompiledArtifact, "_torchinductor_compat_ctor", False):
         return proxy
 
     from cutlass.operators.arch import TargetSm
@@ -181,31 +154,26 @@ def get_artifact_module() -> ModuleType:
             super().__init__(compiled_obj, operator_obj, compiled_for)
 
     CompiledArtifact.__module__ = artifact.__name__
-    CompiledArtifact._torchinductor_legacy_ctor = True
+    CompiledArtifact._torchinductor_compat_ctor = True
     _set_module_attr(proxy, "CompiledArtifact", CompiledArtifact)
     return proxy
 
 
 def get_library_module() -> ModuleType:
-    if not _is_canonical_api():
-        return _get_submodule("library")
-
-    arguments = get_arguments_module()
     proxy = _proxy_cache.get("canonical_library")
     if proxy is None:
-        proxy = ModuleType(f"{_CANONICAL_API}.library")
-        _set_module_attr(proxy, "ScaleMode", _get_module_attr(arguments, "ScaleMode"))
-        _set_module_attr(
-            proxy, "ScaleSwizzleMode", _get_module_attr(arguments, "ScaleSwizzleMode")
-        )
+        arguments = get_arguments_module()
+        proxy = ModuleType(f"{_OPERATOR_API}.library")
+        _set_module_attr(proxy, "ScaleMode", arguments.ScaleMode)
+        _set_module_attr(proxy, "ScaleSwizzleMode", arguments.ScaleSwizzleMode)
         _proxy_cache["canonical_library"] = proxy
     return proxy
 
 
 def get_metadata_module() -> ModuleType:
-    """Return operator metadata with legacy NVGEMM aliases when needed."""
+    """Return operator metadata with NVGEMM compatibility aliases."""
     metadata = _get_submodule("metadata")
-    if not _is_canonical_api() or hasattr(metadata, "KernelMetadata"):
+    if hasattr(metadata, "KernelMetadata"):
         return metadata
 
     proxy = _copy_module_proxy("canonical_metadata", metadata)
@@ -302,9 +270,6 @@ def get_status_module() -> ModuleType:
 
 def get_utils_module() -> ModuleType:
     utils = _get_submodule("utils")
-    if not _is_canonical_api():
-        return utils
-
     proxy = _copy_module_proxy("canonical_utils", utils)
     if not hasattr(proxy, "strides_to_layout_string"):
         _set_module_attr(
@@ -344,8 +309,8 @@ def get_dtype_utils_module() -> ModuleType:
     return _get_submodule("utils.dtype")
 
 
-def _canonical_cutedsl_kernel_module() -> ModuleType:
-    proxy = _proxy_cache.get("canonical_cutedsl_kernel")
+def _cutedsl_kernel_module() -> ModuleType:
+    proxy = _proxy_cache.get("cutedsl_kernel")
     if proxy is not None:
         return proxy
 
@@ -354,7 +319,7 @@ def _canonical_cutedsl_kernel_module() -> ModuleType:
     arguments = get_arguments_module()
 
     class CuteDslKernel(CuteDslOperator):
-        supported_args_type = _get_module_attr(arguments, "GemmArguments")
+        supported_args_type = arguments.GemmArguments
         designed_for_min_cc = 100
 
         def __init_subclass__(cls, **kwargs):
@@ -397,55 +362,43 @@ def _canonical_cutedsl_kernel_module() -> ModuleType:
                 args=args,
             )
 
-    CuteDslKernel.__module__ = f"{_CANONICAL_API}.providers.cutedsl.kernel"
+    CuteDslKernel.__module__ = f"{_OPERATOR_API}.providers.cutedsl.kernel"
     proxy = ModuleType(CuteDslKernel.__module__)
     _set_module_attr(proxy, "CuteDslKernel", CuteDslKernel)
-    _proxy_cache["canonical_cutedsl_kernel"] = proxy
+    _proxy_cache["cutedsl_kernel"] = proxy
     return proxy
 
 
 def get_provider_submodule(name: str) -> ModuleType:
-    if not _is_canonical_api():
-        return _get_submodule(f"providers.{name}")
     if name == "cutedsl.kernel":
-        return _canonical_cutedsl_kernel_module()
+        return _cutedsl_kernel_module()
     if name == "cutedsl.utils":
         return importlib.import_module(
-            f"{_CANONICAL_API}.providers.cutedsl.integration_utils.mma"
+            f"{_OPERATOR_API}.providers.cutedsl.integration_utils.mma"
         )
     return _get_submodule(f"providers.{name}")
 
 
-def _canonical_provider_module_name(name: str) -> str:
-    mapping = {
-        "cutedsl.utils": f"{_CANONICAL_API}.providers.cutedsl.integration_utils.mma",
-        "cutedsl.gemm.sm100_static_persistent": f"{_CANONICAL_API}.providers.cutedsl.gemm.sm100_persistent",
-    }
-    return mapping.get(name, f"{_CANONICAL_API}.providers.{name}")
+def _provider_module_name(name: str) -> str:
+    provider_root = f"{_OPERATOR_API}.providers"
+    if name == "cutedsl.utils":
+        return f"{provider_root}.cutedsl.integration_utils.mma"
+    if name == "cutedsl.gemm.sm100_static_persistent":
+        return f"{provider_root}.cutedsl.gemm.sm100_persistent"
+    return f"{provider_root}.{name}"
 
 
 def provider_module_names(names: list[str]) -> list[str]:
-    api = get_operator_api()
-    if api.__name__ == _CANONICAL_API:
-        return [_canonical_provider_module_name(name) for name in names]
-    return [f"{api.__name__}.providers.{name}" for name in names]
+    return [_provider_module_name(name) for name in names]
 
 
-def _ensure_legacy_workspace_size(kernel: Any) -> None:
-    if getattr(kernel, "_torchinductor_workspace_size_compat", False):
-        return
-
-    get_workspace_size = kernel.get_workspace_size
-
-    def legacy_get_workspace_size(args):
-        workspace_size = get_workspace_size(args)
-        return getattr(workspace_size, "size_bytes", workspace_size)
-
-    kernel.get_workspace_size = legacy_get_workspace_size
-    kernel._torchinductor_workspace_size_compat = True
+def get_workspace_size(kernel: Any, args: Any) -> int:
+    """Return a workspace allocation size in bytes."""
+    requirement = kernel.get_workspace_size(args)
+    return cast(int, getattr(requirement, "size_bytes", requirement))
 
 
-def _ensure_legacy_kernel_metadata(kernel: Any) -> Any:
+def _ensure_kernel_metadata(kernel: Any) -> Any:
     metadata = kernel.metadata
     if not all(
         hasattr(metadata, attr) for attr in ("kernel_name", "kernel_class", "min_cc")
@@ -462,23 +415,20 @@ def _ensure_legacy_kernel_metadata(kernel: Any) -> Any:
         )
         kernel._metadata = metadata
 
-    _ensure_legacy_workspace_size(kernel)
     return kernel
 
 
 def get_kernels() -> Any:
     api = get_operator_api()
-    if hasattr(api, "get_kernels"):
-        return api.get_kernels()
-    return [_ensure_legacy_kernel_metadata(kernel) for kernel in api.get_operators()]
+    return [_ensure_kernel_metadata(kernel) for kernel in api.get_operators()]
 
 
 def ensure_fp4_dtype_registered() -> None:
-    """Patch `cutlass.operators` or legacy `cutlass_api` for FP4.
+    """Patch `cutlass.operators` for FP4.
 
     Patches the lookup in place on the real dtype module in addition to the
     adapter proxy so cutlass-internal callers (not just code going through the
-    proxy) pick up the FP4 mapping, matching the legacy in-place patch.
+    proxy) pick up the FP4 mapping.
     """
     import torch
 

--- a/torch/_inductor/codegen/nv_universal_gemm/kernel_cache.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/kernel_cache.py
@@ -3,11 +3,11 @@
 Global kernel cache for NVIDIA Universal GEMM.
 
 This module provides a lazy-initialized cache for CUTLASS operator API
-(`cutlass.operators` or legacy `cutlass_api`) kernels,
+(`cutlass.operators`) kernels,
 avoiding expensive manifest scans on every kernel lookup.
 
 The first call to get_kernel_by_name() loads all kernels from
-`cutlass.operators` or legacy `cutlass_api`
+`cutlass.operators`
 (~10 seconds) and builds a name->kernel dict. Subsequent calls use the
 dict for O(1) lookup (~0.1 μs).
 """
@@ -124,7 +124,7 @@ def partition_compatible_kernels(
 
 
 def get_kernel_by_name(kernel_name: str) -> Any:
-    """Get a `cutlass.operators` or legacy `cutlass_api` kernel by name."""
+    """Get a `cutlass.operators` kernel by name."""
     return _get_kernel_cache().get(kernel_name)
 
 

--- a/torch/_inductor/codegen/nv_universal_gemm/kernel_cache.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/kernel_cache.py
@@ -2,10 +2,12 @@
 """
 Global kernel cache for NVIDIA Universal GEMM.
 
-This module provides a lazy-initialized cache for cutlass_api kernels,
+This module provides a lazy-initialized cache for CUTLASS operator API
+(`cutlass.operators` or legacy `cutlass_api`) kernels,
 avoiding expensive manifest scans on every kernel lookup.
 
-The first call to get_kernel_by_name() loads all kernels from cutlass_api
+The first call to get_kernel_by_name() loads all kernels from
+`cutlass.operators` or legacy `cutlass_api`
 (~10 seconds) and builds a name->kernel dict. Subsequent calls use the
 dict for O(1) lookup (~0.1 μs).
 """
@@ -55,7 +57,7 @@ _kernel_by_name_cache: dict[str, Any] | None = None
 
 def _build_kernel_cache() -> dict[str, Any]:
     """Build the kernel name -> kernel object cache."""
-    import cutlass_api
+    from torch._inductor.codegen.nv_universal_gemm.cutlass_ops import get_kernels
 
     log.debug("Building NVGEMM kernel cache (this may take a few seconds)...")
 
@@ -66,7 +68,7 @@ def _build_kernel_cache() -> dict[str, Any]:
     except ImportError:
         log.debug("Vendored kernel wrappers not available")
 
-    all_kernels = cutlass_api.get_kernels()
+    all_kernels = get_kernels()
     cache = {k.metadata.kernel_name: k for k in all_kernels}
     log.debug("NVGEMM kernel cache built: %d kernels", len(cache))
     return cache
@@ -122,7 +124,7 @@ def partition_compatible_kernels(
 
 
 def get_kernel_by_name(kernel_name: str) -> Any:
-    """Get a cutlass_api kernel by name using the global cache."""
+    """Get a `cutlass.operators` or legacy `cutlass_api` kernel by name."""
     return _get_kernel_cache().get(kernel_name)
 
 
@@ -184,7 +186,13 @@ def get_efc_kernel_with_epilogue(
             log.debug("Base EFC kernel not found: %s", efc_kernel_name)
             return None
 
-        from cutlass_api.metadata import EpilogueMetadata, KernelMetadata
+        from torch._inductor.codegen.nv_universal_gemm.cutlass_ops import (
+            get_metadata_module,
+        )
+
+        metadata_module = get_metadata_module()
+        EpilogueMetadata = metadata_module.EpilogueMetadata
+        KernelMetadata = metadata_module.KernelMetadata
 
         epilogue_metadata = EpilogueMetadata.from_args(epilogue_args)
 

--- a/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm.py
@@ -2,8 +2,8 @@
 """
 NVIDIA Universal GEMM (NVGEMM) backend for PyTorch Inductor.
 
-This module integrates with the CUTLASS operator API (`cutlass.operators` or
-legacy `cutlass_api`) to enable high-performance GEMM kernels for NVIDIA GPUs.
+This module integrates with `cutlass.operators` to enable high-performance
+GEMM kernels for NVIDIA GPUs.
 """
 
 import itertools
@@ -19,14 +19,14 @@ from torch._inductor.autotune_process import (
     TensorMeta,
 )
 from torch._inductor.codegen.cuda.cuda_env import get_cuda_arch
+from torch._inductor.codegen.nv_universal_gemm.cutlass_ops import get_workspace_size
 from torch._inductor.codegen.nv_universal_gemm.nv_universal_gemm_kernel import (
     _compile_nvgemm,
     _create_gemm_arguments,
     _create_gemm_cache_key,
     _get_scaled_gemm_modes,
     _make_disk_config_key,
-    _rewrap_efc_compiled_obj,
-    _unwrap_efc_compiled_obj,
+    _use_disk_cached_compiled_obj,
 )
 from torch._inductor.heuristics.template.nv_universal_gemm import get_nvgemm_heuristics
 from torch._inductor.ir import Buffer, ChoiceCaller, Layout, TensorBox
@@ -67,7 +67,7 @@ class NVUniversalGemmBenchmarkRequest(GPUDeviceBenchmarkMixin, BenchmarkRequest)
         kernel_name: str,
         input_tensor_meta: TensorMeta | list[TensorMeta],
         output_tensor_meta: TensorMeta | list[TensorMeta],
-        kernel,  # `cutlass.operators` or legacy `cutlass_api` kernel object
+        kernel,  # `cutlass.operators` kernel object
         accumulator_type: torch.dtype,
         variant: GemmVariant,
         workspace_size: int = 0,
@@ -171,7 +171,7 @@ class NVUniversalGemmBenchmarkRequest(GPUDeviceBenchmarkMixin, BenchmarkRequest)
                 dev_idx,
             )
             if compiled_fn is not None:
-                compiled_fn = _rewrap_efc_compiled_obj(compiled_fn, kernel)
+                compiled_fn = _use_disk_cached_compiled_obj(compiled_fn, kernel)
             if compiled_fn is not None:
                 return CompiledArtifact(compiled_fn, kernel)
             return None
@@ -187,7 +187,7 @@ class NVUniversalGemmBenchmarkRequest(GPUDeviceBenchmarkMixin, BenchmarkRequest)
         )
 
         if was_compiled:
-            obj = _unwrap_efc_compiled_obj(artifact.compiled_obj)
+            obj = artifact.compiled_obj
             disk_cache_set(
                 self._disk_fn_cache,
                 kernel_name,
@@ -233,7 +233,7 @@ class NVUniversalGemmCaller(ChoiceCaller):
     """
     ChoiceCaller for NVIDIA Universal GEMM kernels.
 
-    Wraps a `cutlass.operators` or legacy `cutlass_api` kernel and integrates
+    Wraps a `cutlass.operators` kernel and integrates
     with Inductor's autotuning.
     """
 
@@ -244,7 +244,7 @@ class NVUniversalGemmCaller(ChoiceCaller):
         name: str,
         input_nodes: list[Buffer],
         layout: Layout,
-        kernel,  # `cutlass.operators` or legacy `cutlass_api` kernel object
+        kernel,  # `cutlass.operators` kernel object
         accumulator_type: torch.dtype,
         variant: GemmVariant,
         workspace_size: int = 0,
@@ -429,7 +429,7 @@ def _create_dummy_tensor_from_layout(
 
     Uses Layout.get_example() which creates FakeTensors within V.fake_mode,
     avoiding real CUDA memory allocation. The CUTLASS operator API
-    (`cutlass.operators` or legacy `cutlass_api`) only needs shape/stride/dtype
+    (`cutlass.operators`) only needs shape/stride/dtype
     metadata for its supports() checks.
     """
     try:
@@ -452,14 +452,13 @@ def _include_efc_kernels_only(metadata) -> bool:
     """Filter to include only EFC (Epilogue Fusion Compatible) kernels.
 
     Excludes tile_M=64 EFC kernels: the CUTLASS operator API
-    (`cutlass.operators` or legacy `cutlass_api`) has a broadcast bug in the
+    (`cutlass.operators`) has a broadcast bug in the
     epilogue thread operation for aux-tensor inputs with tile_M=64, and we
     don't yet know at autotune time whether fusion will consume aux tensors.
     Non-EFC kernels still cover tile_M=64, so plain GEMM autotune is unaffected.
 
     Strictly requires the kernel name to encode tile dims; if `cutlass.operators`
-    or legacy `cutlass_api` ever
-    changes the naming scheme, this raises rather than silently letting the
+    ever changes the naming scheme, this raises rather than silently letting the
     broken tile_M=64 kernels through.
     """
     if "EFC" not in metadata.kernel_class.__name__:
@@ -515,7 +514,7 @@ def _add_nv_gemm_choices_impl(
         partition_compatible_kernels,
     )
 
-    # Create dummy tensors for `cutlass.operators` or legacy `cutlass_api`
+    # Create dummy tensors for `cutlass.operators`
     # supports() checks.
     # Pass node dtype to handle FP4 ReinterpretView (uint8 storage viewed as float4_e2m1fn_x2).
     dummy_tensors = [
@@ -573,7 +572,7 @@ def _add_nv_gemm_choices_impl(
         if _exclude_efc_kernels(metadata):
             return 0  # non-efc bucket
         # NOTE: tile_M < 128 EFC kernels are dropped due to a
-        # `cutlass.operators` or legacy `cutlass_api` broadcast bug.
+        # `cutlass.operators` broadcast bug.
         # broadcast bug. Tracking: https://github.com/pytorch/pytorch/issues/181901
         return -1
 
@@ -610,7 +609,7 @@ def _add_nv_gemm_choices_impl(
     num_added = 0
     for kernel, supports_epilogue_fusion in all_kernels:
         name = f"{variant.op_name}_{next(NVUniversalGemmCaller.index_counter)}"
-        workspace_size = kernel.get_workspace_size(args)
+        workspace_size = get_workspace_size(kernel, args)
         try:
             caller = NVUniversalGemmCaller(
                 name=name,
@@ -629,8 +628,7 @@ def _add_nv_gemm_choices_impl(
             choices.append(caller)
             num_added += 1
         except Exception:
-            # Broad: caller construction touches `cutlass.operators` or legacy
-            # `cutlass_api` / fake-mode tensors
+            # Broad: caller construction touches `cutlass.operators` and fake-mode tensors,
             # which can raise types other than RuntimeError/ValueError. A single
             # bad choice should never abort the rest of autotune choice population.
             log.debug("Failed to create %s choice", variant.op_name, exc_info=True)
@@ -651,7 +649,7 @@ def add_nv_universal_gemm_choices(
     """
     if not ensure_nv_universal_gemm_available():
         log.debug(
-            "CUTLASS operator API (`cutlass.operators` or legacy `cutlass_api`) "
+            "CUTLASS operator API (`cutlass.operators`) "
             "not available, skipping NVIDIA Universal GEMM choices"
         )
         return
@@ -685,7 +683,7 @@ def add_nv_universal_grouped_gemm_choices(
     """
     if not ensure_nv_universal_gemm_available():
         log.debug(
-            "CUTLASS operator API (`cutlass.operators` or legacy `cutlass_api`) "
+            "CUTLASS operator API (`cutlass.operators`) "
             "not available, skipping NVIDIA Universal Grouped GEMM choices"
         )
         return

--- a/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm.py
@@ -2,8 +2,8 @@
 """
 NVIDIA Universal GEMM (NVGEMM) backend for PyTorch Inductor.
 
-This module provides integration with the cutlass_api library to enable
-high-performance GEMM kernels for NVIDIA GPUs.
+This module integrates with the CUTLASS operator API (`cutlass.operators` or
+legacy `cutlass_api`) to enable high-performance GEMM kernels for NVIDIA GPUs.
 """
 
 import itertools
@@ -67,7 +67,7 @@ class NVUniversalGemmBenchmarkRequest(GPUDeviceBenchmarkMixin, BenchmarkRequest)
         kernel_name: str,
         input_tensor_meta: TensorMeta | list[TensorMeta],
         output_tensor_meta: TensorMeta | list[TensorMeta],
-        kernel,  # cutlass_api.Kernel object
+        kernel,  # `cutlass.operators` or legacy `cutlass_api` kernel object
         accumulator_type: torch.dtype,
         variant: GemmVariant,
         workspace_size: int = 0,
@@ -122,12 +122,15 @@ class NVUniversalGemmBenchmarkRequest(GPUDeviceBenchmarkMixin, BenchmarkRequest)
 
     def make_run_fn(self, *input_tensors: torch.Tensor, out: torch.Tensor):
         """Create a function to run the NVIDIA Universal GEMM kernel."""
-        from cutlass_api.artifact import CompiledArtifact
-
+        from torch._inductor.codegen.nv_universal_gemm.cutlass_ops import (
+            get_artifact_module,
+        )
         from torch._inductor.runtime.cutedsl_cache import disk_cache_get, disk_cache_set
         from torch._inductor.utils import _ensure_fp4_dtype_registered
 
         _ensure_fp4_dtype_registered()
+
+        CompiledArtifact = get_artifact_module().CompiledArtifact
 
         helper_kwargs: dict[str, Any] = {}
         if self.variant == GemmVariant.SCALED_GEMM:
@@ -230,7 +233,8 @@ class NVUniversalGemmCaller(ChoiceCaller):
     """
     ChoiceCaller for NVIDIA Universal GEMM kernels.
 
-    Wraps a cutlass_api kernel and integrates with Inductor's autotuning.
+    Wraps a `cutlass.operators` or legacy `cutlass_api` kernel and integrates
+    with Inductor's autotuning.
     """
 
     index_counter = itertools.count()
@@ -240,7 +244,7 @@ class NVUniversalGemmCaller(ChoiceCaller):
         name: str,
         input_nodes: list[Buffer],
         layout: Layout,
-        kernel,  # cutlass_api.Kernel object
+        kernel,  # `cutlass.operators` or legacy `cutlass_api` kernel object
         accumulator_type: torch.dtype,
         variant: GemmVariant,
         workspace_size: int = 0,
@@ -424,7 +428,8 @@ def _create_dummy_tensor_from_layout(
     Create a FakeTensor from a Layout for kernel filtering.
 
     Uses Layout.get_example() which creates FakeTensors within V.fake_mode,
-    avoiding real CUDA memory allocation. cutlass_api only needs shape/stride/dtype
+    avoiding real CUDA memory allocation. The CUTLASS operator API
+    (`cutlass.operators` or legacy `cutlass_api`) only needs shape/stride/dtype
     metadata for its supports() checks.
     """
     try:
@@ -446,12 +451,14 @@ _TILE_RE = re.compile(r"tile(\d+)x\d+x\d+")
 def _include_efc_kernels_only(metadata) -> bool:
     """Filter to include only EFC (Epilogue Fusion Compatible) kernels.
 
-    Excludes tile_M=64 EFC kernels: cutlass_api has a broadcast bug in the
+    Excludes tile_M=64 EFC kernels: the CUTLASS operator API
+    (`cutlass.operators` or legacy `cutlass_api`) has a broadcast bug in the
     epilogue thread operation for aux-tensor inputs with tile_M=64, and we
     don't yet know at autotune time whether fusion will consume aux tensors.
     Non-EFC kernels still cover tile_M=64, so plain GEMM autotune is unaffected.
 
-    Strictly requires the kernel name to encode tile dims; if cutlass_api ever
+    Strictly requires the kernel name to encode tile dims; if `cutlass.operators`
+    or legacy `cutlass_api` ever
     changes the naming scheme, this raises rather than silently letting the
     broken tile_M=64 kernels through.
     """
@@ -508,7 +515,8 @@ def _add_nv_gemm_choices_impl(
         partition_compatible_kernels,
     )
 
-    # Create dummy tensors for cutlass_api's supports() checks.
+    # Create dummy tensors for `cutlass.operators` or legacy `cutlass_api`
+    # supports() checks.
     # Pass node dtype to handle FP4 ReinterpretView (uint8 storage viewed as float4_e2m1fn_x2).
     dummy_tensors = [
         _create_dummy_tensor_from_layout(
@@ -564,7 +572,8 @@ def _add_nv_gemm_choices_impl(
             return 1  # efc bucket (with tile_M >= 128)
         if _exclude_efc_kernels(metadata):
             return 0  # non-efc bucket
-        # NOTE: tile_M < 128 EFC kernels are dropped due to a cutlass_api
+        # NOTE: tile_M < 128 EFC kernels are dropped due to a
+        # `cutlass.operators` or legacy `cutlass_api` broadcast bug.
         # broadcast bug. Tracking: https://github.com/pytorch/pytorch/issues/181901
         return -1
 
@@ -620,7 +629,8 @@ def _add_nv_gemm_choices_impl(
             choices.append(caller)
             num_added += 1
         except Exception:
-            # Broad: caller construction touches cutlass_api / fake-mode tensors
+            # Broad: caller construction touches `cutlass.operators` or legacy
+            # `cutlass_api` / fake-mode tensors
             # which can raise types other than RuntimeError/ValueError. A single
             # bad choice should never abort the rest of autotune choice population.
             log.debug("Failed to create %s choice", variant.op_name, exc_info=True)
@@ -640,7 +650,10 @@ def add_nv_universal_gemm_choices(
     Thin wrapper around _add_nv_gemm_choices_impl for regular GEMM.
     """
     if not ensure_nv_universal_gemm_available():
-        log.debug("cutlass_api not available, skipping NVIDIA Universal GEMM choices")
+        log.debug(
+            "CUTLASS operator API (`cutlass.operators` or legacy `cutlass_api`) "
+            "not available, skipping NVIDIA Universal GEMM choices"
+        )
         return
 
     _add_nv_gemm_choices_impl(
@@ -672,7 +685,8 @@ def add_nv_universal_grouped_gemm_choices(
     """
     if not ensure_nv_universal_gemm_available():
         log.debug(
-            "cutlass_api not available, skipping NVIDIA Universal Grouped GEMM choices"
+            "CUTLASS operator API (`cutlass.operators` or legacy `cutlass_api`) "
+            "not available, skipping NVIDIA Universal Grouped GEMM choices"
         )
         return
 

--- a/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_kernel.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_kernel.py
@@ -2,8 +2,7 @@
 """
 NVIDIA Universal GEMM kernel code generation.
 
-This module generates Python code that calls `cutlass.operators` or legacy
-`cutlass_api` kernels to execute GEMM operations.
+This module generates Python code that calls `cutlass.operators` kernels.
 The runtime helpers (_nvgemm_run, _nvgemm_precompile, etc.) are imported by the
 generated wrapper at runtime, keeping the generated code thin.
 """
@@ -278,7 +277,7 @@ def _worker_nvgemm_autotuning_precompile(
         )
 
         if was_compiled:
-            obj = _unwrap_efc_compiled_obj(artifact.compiled_obj)
+            obj = artifact.compiled_obj
             disk_cache_set(
                 disk_fn_cache,
                 kernel_name,
@@ -411,79 +410,11 @@ def _create_gemm_cache_key(
     return cache_key
 
 
-def _unwrap_efc_compiled_obj(compiled_obj):
-    """Extract the inner JIT function from an EFC closure for disk serialization."""
-    if hasattr(compiled_obj, "__closure__") and compiled_obj.__closure__:
-        inner = compiled_obj.__closure__[0].cell_contents
-        if hasattr(inner, "export_to_c"):
-            return inner
-    return compiled_obj
-
-
-def _init_efc_jit(kernel, epilogue_args):
-    """Lightweight EFC JIT init from epilogue args, without a full kernel.compile().
-
-    EFC.compile() calls analyze_epilogue_with_arguments() then creates the JIT
-    object. We replicate just those two steps so that disk-cached artifacts can
-    be rewrapped without recompiling the CuTe DSL kernel.
-    """
-    EFC = get_provider_submodule("cutedsl.evt.common_efc").EFC
-    TensorWrapper = get_provider_submodule(
-        "cutedsl.gemm.sm100_static_persistent_efc"
-    ).TensorWrapper
-
-    efc = kernel.impl.efc
-    params = [
-        e.compile_time_tensor if isinstance(e, TensorWrapper) else e
-        for e in epilogue_args.parameters
-    ]
-    efc.analyze_epilogue_with_arguments(params)
-    efc.jit = EFC.JIT(efc, efc.epilogue_parameter_names)
-
-
-def _rewrap_efc_compiled_obj(compiled_fn, kernel, epilogue_args=None):
-    """Reconstruct the EFC wrapped_launch closure from a loaded JIT function.
-
-    When epilogue_args is provided and efc.jit is missing, performs a
-    lightweight initialization (analyze + JIT creation) so that
-    disk-cached EFC artifacts can be reused without a full recompile.
-    Falls back to returning None (triggering recompile) only when
-    epilogue_args is not available.
-    """
-    if not hasattr(kernel, "impl") or not hasattr(kernel.impl, "efc"):
-        return compiled_fn
-
-    efc_module = get_provider_submodule("cutedsl.gemm.sm100_static_persistent_efc")
-    # The legacy `cutlass_api` disk-cache rewrap depends on KernelOperand and a
-    # packed-argument JIT entry point. Canonical `cutlass.operators` has no
-    # KernelOperand and its EFC compiled function takes tensors directly, so the
-    # legacy closure does not apply; signal recompile instead of reloading.
-    if not hasattr(efc_module, "KernelOperand"):
+def _use_disk_cached_compiled_obj(compiled_obj, kernel):
+    """Return a reusable cached object, or None when the kernel must recompile."""
+    if hasattr(kernel, "impl") and hasattr(kernel.impl, "efc"):
         return None
-    KernelOperand = efc_module.KernelOperand
-    TensorWrapper = efc_module.TensorWrapper
-
-    if not hasattr(kernel.impl.efc, "jit"):
-        if epilogue_args is not None:
-            _init_efc_jit(kernel, epilogue_args)
-        else:
-            return None
-
-    def wrapped_launch(a_tensor, b_tensor, stream, *supplemental_args):
-        runtime_args = [
-            e.runtime_tensor
-            if isinstance(e, TensorWrapper)
-            else (e.tensor.runtime_tensor if isinstance(e, KernelOperand) else e)
-            for e in supplemental_args
-        ]
-        return compiled_fn(
-            a_tensor,
-            b_tensor,
-            stream,
-            kernel.impl.efc.jit.pack_arguments(*runtime_args),
-        )
-
-    return wrapped_launch
+    return compiled_obj
 
 
 def _nvgemm_run(
@@ -528,7 +459,7 @@ def _nvgemm_run(
             epilogue=epilogue_args,
             **(variant_kwargs or {}),
         )
-        kernel = artifact.kernel_obj
+        kernel = artifact.operator_obj
     else:
 
         def disk_fallback(kernel):
@@ -540,11 +471,7 @@ def _nvgemm_run(
                 dev_idx,
             )
             if compiled_fn is not None:
-                compiled_fn = _rewrap_efc_compiled_obj(
-                    compiled_fn,
-                    kernel,
-                    epilogue_args=epilogue_args,
-                )
+                compiled_fn = _use_disk_cached_compiled_obj(compiled_fn, kernel)
             if compiled_fn is not None:
                 return CompiledArtifact(compiled_fn, kernel)
             return None
@@ -567,7 +494,7 @@ def _nvgemm_run(
                 module_path,
                 disk_config_key,
                 cache_key,
-                _unwrap_efc_compiled_obj(artifact.compiled_obj),
+                artifact.compiled_obj,
                 dev_idx,
             )
 
@@ -611,8 +538,8 @@ def _nvgemm_precompile(
 ):
     """Precompile an NVGEMM kernel in a subprocess for parallel compilation.
 
-    Precompiles only the base (non-EFC) kernel. EFC kernels produce
-    closure-wrapped artifacts that can't be serialized to disk cache.
+    Precompiles only the base (non-EFC) kernel. EFC compiled artifacts cannot
+    currently be reused from the disk cache.
     """
     import torch
     from torch._inductor.runtime.cutedsl_cache import disk_cache_set
@@ -621,8 +548,8 @@ def _nvgemm_precompile(
     if max_active_clusters is None:
         return
 
-    # cutlass_api queries device occupancy while compiling. In async-compile
-    # workers forked from a CUDA-initialized parent, skip precompile.
+    # CUTLASS queries device occupancy while compiling. Skip precompile in an
+    # async-compile worker forked from a CUDA-initialized parent.
     if torch.cuda._is_in_bad_fork():
         return
 

--- a/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_kernel.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_kernel.py
@@ -2,7 +2,8 @@
 """
 NVIDIA Universal GEMM kernel code generation.
 
-This module generates Python code that calls cutlass_api to execute GEMM operations.
+This module generates Python code that calls `cutlass.operators` or legacy
+`cutlass_api` kernels to execute GEMM operations.
 The runtime helpers (_nvgemm_run, _nvgemm_precompile, etc.) are imported by the
 generated wrapper at runtime, keeping the generated code thin.
 """
@@ -22,6 +23,13 @@ from torch._inductor.codegen.common import (
 )
 from torch._inductor.codegen.cutedsl.cutedsl_op_overrides import CuteDSLOpOverrides
 from torch._inductor.codegen.cutlass.python_evt import _ACCUMULATOR_ARG_NAME
+from torch._inductor.codegen.nv_universal_gemm.cutlass_ops import (
+    get_arguments_module,
+    get_artifact_module,
+    get_provider_submodule,
+    get_utils_module,
+    provider_module_names,
+)
 from torch._inductor.codegen.nv_universal_gemm.nv_universal_gemm_utils import (
     to_cutlass_scale_mode,
 )
@@ -138,7 +146,7 @@ class CUDAContextMetadata:
 
     @staticmethod
     def from_kernel(kernel, device) -> CUDAContextMetadata:
-        """Build from a cutlass_api Kernel and torch device in the main process."""
+        """Build from a CUTLASS operator kernel and torch device in the main process."""
         import torch
 
         mac = None
@@ -147,7 +155,9 @@ class CUDAContextMetadata:
                 getattr(kernel, "impl", None), "cluster_shape_mn", None
             )
             if cluster_shape is not None:
-                from cutlass_api.providers.cutedsl.utils import get_max_active_clusters
+                get_max_active_clusters = get_provider_submodule(
+                    "cutedsl.utils"
+                ).get_max_active_clusters
 
                 mac = get_max_active_clusters(cluster_shape)
         except Exception:
@@ -168,7 +178,7 @@ def _patch_max_active_clusters(max_active_clusters):
     def mac_fn(*a, **kw):
         return max_active_clusters
 
-    for mod_name in _MAX_ACTIVE_CLUSTERS_MODULES:
+    for mod_name in provider_module_names(_MAX_ACTIVE_CLUSTERS_MODULE_NAMES):
         try:
             m = importlib.import_module(mod_name)
         except ImportError:
@@ -317,7 +327,7 @@ def _create_gemm_arguments(
     swizzle_mode_b: Any | None = None,
     epilogue: Any | None = None,
 ):
-    import cutlass_api
+    arguments = get_arguments_module()
 
     if epilogue is not None and variant_name != "GEMM":
         raise NotImplementedError(
@@ -327,7 +337,7 @@ def _create_gemm_arguments(
     match variant_name:
         case "GROUPED_GEMM":
             a, b, offsets = input_tensors
-            return cutlass_api.arguments.GroupedGemmArguments(
+            return arguments.GroupedGemmArguments(
                 a,
                 b,
                 out,
@@ -336,12 +346,10 @@ def _create_gemm_arguments(
             )
 
         case "SCALED_GEMM":
-            from cutlass_api.arguments import ScaledTensor
-
             a, b, scale_a, scale_b = input_tensors
-            scaled_a = ScaledTensor(a, scale_a, scale_mode_a, swizzle_mode_a)
-            scaled_b = ScaledTensor(b, scale_b, scale_mode_b, swizzle_mode_b)
-            return cutlass_api.arguments.GemmArguments(
+            scaled_a = arguments.ScaledTensor(a, scale_a, scale_mode_a, swizzle_mode_a)
+            scaled_b = arguments.ScaledTensor(b, scale_b, scale_mode_b, swizzle_mode_b)
+            return arguments.GemmArguments(
                 scaled_a,
                 scaled_b,
                 out,
@@ -353,7 +361,7 @@ def _create_gemm_arguments(
             kwargs: dict[str, Any] = {"accumulator_type": accumulator_type}
             if epilogue is not None:
                 kwargs["epilogue"] = epilogue
-            return cutlass_api.arguments.GemmArguments(a, b, out, **kwargs)
+            return arguments.GemmArguments(a, b, out, **kwargs)
 
         case _:
             raise NotImplementedError(f"Unsupported NVGEMM variant: {variant_name}")
@@ -420,8 +428,8 @@ def _init_efc_jit(kernel, epilogue_args):
     object. We replicate just those two steps so that disk-cached artifacts can
     be rewrapped without recompiling the CuTe DSL kernel.
     """
-    from cutlass_api.providers.cutedsl.evt.common_efc import EFC
-    from cutlass_api.utils import TensorWrapper
+    EFC = get_provider_submodule("cutedsl.evt.common_efc").EFC
+    TensorWrapper = get_utils_module().TensorWrapper
 
     efc = kernel.impl.efc
     params = [
@@ -449,10 +457,9 @@ def _rewrap_efc_compiled_obj(compiled_fn, kernel, epilogue_args=None):
         else:
             return None
 
-    from cutlass_api.providers.cutedsl.gemm.sm100_static_persistent_efc import (
-        KernelOperand,
-        TensorWrapper,
-    )
+    efc_module = get_provider_submodule("cutedsl.gemm.sm100_static_persistent_efc")
+    KernelOperand = efc_module.KernelOperand
+    TensorWrapper = efc_module.TensorWrapper
 
     def wrapped_launch(a_tensor, b_tensor, stream, *supplemental_args):
         runtime_args = [
@@ -490,9 +497,9 @@ def _nvgemm_run(
     has_epilogue: bool = False,
     aux_tensors: tuple = (),
 ):
-    from cutlass_api.artifact import CompiledArtifact
-
     from torch._inductor.runtime.cutedsl_cache import disk_cache_get, disk_cache_set
+
+    CompiledArtifact = get_artifact_module().CompiledArtifact
 
     cache_key = _create_gemm_cache_key(
         input_tensors,
@@ -567,12 +574,12 @@ def _nvgemm_run(
     )
 
 
-_MAX_ACTIVE_CLUSTERS_MODULES = [
-    "cutlass_api.providers.cutedsl.utils",
-    "cutlass_api.providers.cutedsl.gemm.sm100_static_persistent",
-    "cutlass_api.providers.cutedsl.gemm.sm100_static_persistent_efc",
-    "cutlass_api.providers.cutedsl.gemm.sm100_dense_blockscaled_static_persistent",
-    "cutlass_api.providers.cutedsl.gemm.sm100_contiguous_offset_2d3d_dense_gemm",
+_MAX_ACTIVE_CLUSTERS_MODULE_NAMES = [
+    "cutedsl.utils",
+    "cutedsl.gemm.sm100_static_persistent",
+    "cutedsl.gemm.sm100_static_persistent_efc",
+    "cutedsl.gemm.sm100_dense_blockscaled_static_persistent",
+    "cutedsl.gemm.sm100_contiguous_offset_2d3d_dense_gemm",
 ]
 
 
@@ -746,7 +753,7 @@ class NVUniversalGemmKernel(Kernel):
 
         # Build variant_kwargs dict expression for SCALED_GEMM
         variant_kwargs_expr = "None"
-        variant_extra_imports = ""
+        needs_library_import = False
         if self.variant.name == "SCALED_GEMM":
             sma, swza, smb, swzb = _get_scaled_gemm_modes(
                 self.scale_type_a,
@@ -754,9 +761,7 @@ class NVUniversalGemmKernel(Kernel):
                 self.scale_type_b,
                 self.swizzle_type_b,
             )
-            variant_extra_imports = (
-                "from cutlass_api.library import ScaleMode, ScaleSwizzleMode"
-            )
+            needs_library_import = True
             variant_kwargs_expr = (
                 "{"
                 f'"scale_mode_a": ScaleMode.{sma.name}, '
@@ -778,15 +783,26 @@ class NVUniversalGemmKernel(Kernel):
             code.writeline("_nvgemm_run,")
             code.writeline("_nvgemm_precompile,")
         code.writeline(")")
-        code.writeline("from torch._inductor.utils import _ensure_fp4_dtype_registered")
-        code.writeline("_ensure_fp4_dtype_registered()")
-        if variant_extra_imports:
-            code.writeline(variant_extra_imports)
+        code.writeline(
+            "from torch._inductor.codegen.nv_universal_gemm.cutlass_ops import ("
+        )
+        with code.indent():
+            code.writeline("ensure_fp4_dtype_registered,")
+            if needs_library_import:
+                code.writeline("get_library_module,")
+            if has_epilogue:
+                code.writeline("get_arguments_module,")
+        code.writeline(")")
+        code.writeline("ensure_fp4_dtype_registered()")
+        if needs_library_import:
+            code.writeline("_cutlass_library = get_library_module()")
+            code.writeline("ScaleMode = _cutlass_library.ScaleMode")
+            code.writeline("ScaleSwizzleMode = _cutlass_library.ScaleSwizzleMode")
         if has_epilogue:
-            code.writeline("from cutlass_api.arguments import EpilogueArguments")
+            code.writeline("EpilogueArguments = get_arguments_module().EpilogueArguments")
         code.writeline("")
 
-        # -- Epilogue function definition (must be module-level for cutlass_api) --
+        # -- Epilogue function definition (must be module-level for CUTLASS) --
         epilogue_fn_code = self.epilogue_fn_code
         if has_epilogue and epilogue_fn_code is not None:
             code.splice(epilogue_fn_code, strip=True)

--- a/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_kernel.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_kernel.py
@@ -27,7 +27,6 @@ from torch._inductor.codegen.nv_universal_gemm.cutlass_ops import (
     get_arguments_module,
     get_artifact_module,
     get_provider_submodule,
-    get_utils_module,
     provider_module_names,
 )
 from torch._inductor.codegen.nv_universal_gemm.nv_universal_gemm_utils import (
@@ -429,7 +428,9 @@ def _init_efc_jit(kernel, epilogue_args):
     be rewrapped without recompiling the CuTe DSL kernel.
     """
     EFC = get_provider_submodule("cutedsl.evt.common_efc").EFC
-    TensorWrapper = get_utils_module().TensorWrapper
+    TensorWrapper = get_provider_submodule(
+        "cutedsl.gemm.sm100_static_persistent_efc"
+    ).TensorWrapper
 
     efc = kernel.impl.efc
     params = [
@@ -451,15 +452,22 @@ def _rewrap_efc_compiled_obj(compiled_fn, kernel, epilogue_args=None):
     """
     if not hasattr(kernel, "impl") or not hasattr(kernel.impl, "efc"):
         return compiled_fn
+
+    efc_module = get_provider_submodule("cutedsl.gemm.sm100_static_persistent_efc")
+    # The legacy `cutlass_api` disk-cache rewrap depends on KernelOperand and a
+    # packed-argument JIT entry point. Canonical `cutlass.operators` has no
+    # KernelOperand and its EFC compiled function takes tensors directly, so the
+    # legacy closure does not apply; signal recompile instead of reloading.
+    if not hasattr(efc_module, "KernelOperand"):
+        return None
+    KernelOperand = efc_module.KernelOperand
+    TensorWrapper = efc_module.TensorWrapper
+
     if not hasattr(kernel.impl.efc, "jit"):
         if epilogue_args is not None:
             _init_efc_jit(kernel, epilogue_args)
         else:
             return None
-
-    efc_module = get_provider_submodule("cutedsl.gemm.sm100_static_persistent_efc")
-    KernelOperand = efc_module.KernelOperand
-    TensorWrapper = efc_module.TensorWrapper
 
     def wrapped_launch(a_tensor, b_tensor, stream, *supplemental_args):
         runtime_args = [
@@ -799,7 +807,9 @@ class NVUniversalGemmKernel(Kernel):
             code.writeline("ScaleMode = _cutlass_library.ScaleMode")
             code.writeline("ScaleSwizzleMode = _cutlass_library.ScaleSwizzleMode")
         if has_epilogue:
-            code.writeline("EpilogueArguments = get_arguments_module().EpilogueArguments")
+            code.writeline(
+                "EpilogueArguments = get_arguments_module().EpilogueArguments"
+            )
         code.writeline("")
 
         # -- Epilogue function definition (must be module-level for CUTLASS) --

--- a/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_scheduling.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_scheduling.py
@@ -589,10 +589,13 @@ class NVUniversalGemmScheduling(BaseScheduling):
 
                 k = get_kernel_by_name(kernel_name)
                 if k is not None and hasattr(k, "impl"):
-                    from cutlass_api.providers.cutedsl.utils import (
-                        get_max_active_clusters,
+                    from torch._inductor.codegen.nv_universal_gemm.cutlass_ops import (
+                        get_provider_submodule,
                     )
 
+                    get_max_active_clusters = get_provider_submodule(
+                        "cutedsl.utils"
+                    ).get_max_active_clusters
                     max_active_clusters = get_max_active_clusters(
                         k.impl.cluster_shape_mn
                     )

--- a/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_utils.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_utils.py
@@ -19,13 +19,11 @@ def to_cutlass_scale_mode(
         swizzle_type: SwizzleType from torch.nn.functional
 
     Returns:
-        Tuple of (ScaleMode, ScaleSwizzleMode) from `cutlass.operators` or
-        legacy `cutlass_api`,
+        Tuple of (ScaleMode, ScaleSwizzleMode) from `cutlass.operators`,
         or (None, None) if the types are not supported.
 
-    The returned enum objects can be used directly with `cutlass.operators` or
-    legacy `cutlass_api`, or their
-    .name attribute can be used for codegen (e.g., scale_mode.name -> "Blockwise1x32").
+    The returned enum objects can be used directly with `cutlass.operators`.
+    Their .name attribute can be used for codegen.
 
     NOTE:
         Currently on Blackwell (SM100), NVGEMM only supports MXFP8 scaling modes.

--- a/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_utils.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_utils.py
@@ -12,24 +12,30 @@ def to_cutlass_scale_mode(
     scale_type: Any, swizzle_type: Any
 ) -> tuple[Any | None, Any | None]:
     """
-    Map PyTorch ScalingType/SwizzleType to cutlass_api ScaleMode/ScaleSwizzleMode.
+    Map PyTorch ScalingType/SwizzleType to CUTLASS ScaleMode/ScaleSwizzleMode.
 
     Args:
         scale_type: ScalingType from torch.nn.functional
         swizzle_type: SwizzleType from torch.nn.functional
 
     Returns:
-        Tuple of (ScaleMode, ScaleSwizzleMode) from cutlass_api.library,
+        Tuple of (ScaleMode, ScaleSwizzleMode) from `cutlass.operators` or
+        legacy `cutlass_api`,
         or (None, None) if the types are not supported.
 
-    The returned enum objects can be used directly with cutlass_api, or their
+    The returned enum objects can be used directly with `cutlass.operators` or
+    legacy `cutlass_api`, or their
     .name attribute can be used for codegen (e.g., scale_mode.name -> "Blockwise1x32").
 
     NOTE:
         Currently on Blackwell (SM100), NVGEMM only supports MXFP8 scaling modes.
         Update this mapping when additional scaling modes are added.
     """
-    from cutlass_api.library import ScaleMode, ScaleSwizzleMode
+    from torch._inductor.codegen.nv_universal_gemm.cutlass_ops import get_library_module
+
+    library = get_library_module()
+    ScaleMode = library.ScaleMode
+    ScaleSwizzleMode = library.ScaleSwizzleMode
 
     scale_mode_map = {
         ScalingType.BlockWise1x32: ScaleMode.Blockwise1x32,

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -641,7 +641,7 @@ multi_kernel_hints: list[int] = []
 # Triton: Triton templates defined in torch inductor (AMD and NVidia GPUs).
 # CUTLASS: Cutlass templates and kernels (NVidia GPUs only).
 # CUTEDSL: CuteDSL templates for Blackwell GPUs (NVidia SM100-SM109 only).
-# NVGEMM: NVIDIA Universal GEMM via cutlass_api (NVidia GPUs only).
+# NVGEMM: NVIDIA Universal GEMM via cutlass.operators (NVidia GPUs only).
 # CK: Composable Kernel templates and kernels (AMD Instinct GPUs only).
 # CKTILE: Composable Kernel templates and kernels, new API (AMD Instinct GPUs only).
 # CPP: CPP templates and kernels for CPU.

--- a/torch/_inductor/heuristics/template/nv_universal_gemm.py
+++ b/torch/_inductor/heuristics/template/nv_universal_gemm.py
@@ -25,7 +25,8 @@ autotuning_log = getArtifactLogger(__name__, "autotuning")
 
 # Type alias for kernel config key tuple.
 # Currently matches on (tile_m, tile_n, cluster_m, cluster_n).
-# tile_k excluded because nvMatmulHeuristics and cutlass_api use it to mean different things.
+# tile_k excluded because nvMatmulHeuristics and cutlass.operators use it to
+# mean different things.
 # TODO(nikhilap): Extend config key for stages/split_k https://github.com/pytorch/pytorch/issues/177578
 ConfigKey = tuple[int, int, int, int]
 
@@ -53,7 +54,7 @@ def _make_config_key_from_heuristic(cfg: HeuristicConfig) -> ConfigKey:
 
 
 def _make_config_key_from_kernel_design(design) -> ConfigKey | None:
-    """Build config key from cutlass_api kernel metadata.design."""
+    """Build config key from cutlass.operators kernel metadata.design."""
     if (
         hasattr(design, "tile_shape")
         and len(design.tile_shape) >= 2
@@ -109,7 +110,7 @@ class NVUniversalGemmHeuristics(GemmMaxAutotuneTemplateConfigHeuristics):
         returns the first `count` kernels without heuristic ranking.
 
         Args:
-            kernels: List of cutlass_api.Kernel objects
+            kernels: List of `cutlass.operators` operator objects
             inputs: MMKernelInputs with matrix shapes, dtypes, and strides
             count: Maximum number of kernels to return
             accumulator_type: Accumulator dtype
@@ -270,7 +271,7 @@ class NVUniversalGemmHeuristics(GemmMaxAutotuneTemplateConfigHeuristics):
     ):
         """
         Create callback for nvMatmulHeuristics that only accepts configurations
-        matching the available cutlass_api kernel tile/cluster shapes.
+        matching the available cutlass.operators kernel tile/cluster shapes.
         """
 
         def validity_check(kernel_config_ptr, problem_ptr):
@@ -298,7 +299,7 @@ class NVUniversalGemmHeuristics(GemmMaxAutotuneTemplateConfigHeuristics):
         """
         Get kernel configurations recommended by nvMatmulHeuristics.
 
-        Uses validity callback to filter to cutlass_api-compatible configs.
+        Uses validity callback to filter to cutlass.operators-compatible configs.
         """
         import nvMatmulHeuristics
 

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -6451,7 +6451,7 @@ class NVUniversalGemmBuffer(TemplateBuffer):
     Buffer for NVIDIA Universal GEMM kernels.
 
     Unlike CuteDSL templates which use Jinja templates, this generates
-    simpler Python code that directly calls the cutlass_api library.
+    simpler Python code that directly calls the cutlass.operators library.
     """
 
     def __init__(

--- a/torch/_inductor/kernel/vendored_templates/cutedsl/wrappers/dense_blockscaled_gemm_kernel.py
+++ b/torch/_inductor/kernel/vendored_templates/cutedsl/wrappers/dense_blockscaled_gemm_kernel.py
@@ -6,21 +6,39 @@ import itertools
 import logging
 from collections.abc import Callable, Generator  # noqa: TC003
 
-import cutlass_api
-from cutlass_api.arguments import GemmArguments  # noqa: TC002
-from cutlass_api.artifact import CompiledArtifact
-from cutlass_api.library import ScaleMode, ScaleSwizzleMode
-from cutlass_api.metadata import (
-    DenseTensorAttributes,
-    GemmOperandsMetadata,
-    KernelMetadata,
-    ScaledTensorAttributes,
-    Sm100DesignMetadata,
+from torch._inductor.codegen.nv_universal_gemm.cutlass_ops import (
+    get_arguments_module,
+    get_artifact_module,
+    get_library_module,
+    get_metadata_module,
+    get_provider_submodule,
+    get_status_module,
+    get_utils_module,
 )
-from cutlass_api.providers.cutedsl.kernel import CuteDslKernel
-from cutlass_api.providers.cutedsl.utils import get_max_active_clusters
-from cutlass_api.status import Status
-from cutlass_api.utils import strides_to_layout_string, to_cuda_stream, tuple_to_string
+
+
+arguments = get_arguments_module()
+GemmArguments = arguments.GemmArguments
+CompiledArtifact = get_artifact_module().CompiledArtifact
+library = get_library_module()
+ScaleMode = library.ScaleMode
+ScaleSwizzleMode = library.ScaleSwizzleMode
+metadata = get_metadata_module()
+DenseTensorAttributes = metadata.DenseTensorAttributes
+GemmOperandsMetadata = metadata.GemmOperandsMetadata
+KernelMetadata = metadata.KernelMetadata
+ScaledTensorAttributes = metadata.ScaledTensorAttributes
+Sm100DesignMetadata = metadata.Sm100DesignMetadata
+cutedsl_provider = get_provider_submodule("cutedsl")
+CuteDslKernel = get_provider_submodule("cutedsl.kernel").CuteDslKernel
+get_max_active_clusters = get_provider_submodule(
+    "cutedsl.utils"
+).get_max_active_clusters
+Status = get_status_module().Status
+utils = get_utils_module()
+strides_to_layout_string = utils.strides_to_layout_string
+to_cuda_stream = utils.to_cuda_stream
+tuple_to_string = utils.tuple_to_string
 
 
 log = logging.getLogger(__name__)
@@ -126,7 +144,7 @@ class VendoredDenseBlockScaledGemmKernel(CuteDslKernel):
     def get_workspace_size(self, args: GemmArguments) -> int:
         return 0
 
-    def _supports(self, args: GemmArguments) -> Status:
+    def _supports(self, args: GemmArguments, target_sm: object = None) -> Status:
         from torch._inductor.codegen.nv_universal_gemm.nv_universal_gemm_utils import (
             cutlass_dtype_to_torch,
         )
@@ -458,6 +476,4 @@ class VendoredDenseBlockScaledGemmKernel(CuteDslKernel):
 
 # Only register if kernel implementation is available
 if BlockScaledGemmKernelImpl is not None:
-    cutlass_api.providers.cutedsl.CuTeDSLProvider.register(
-        VendoredDenseBlockScaledGemmKernel
-    )
+    cutedsl_provider.CuTeDSLProvider.register(VendoredDenseBlockScaledGemmKernel)

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -5885,7 +5885,7 @@ class Scheduler:
 
                         is_nvgemm_choice = isinstance(choice, NVUniversalGemmCaller)
                         if is_nvgemm_choice and fusible_choice:
-                            # NVGEMM register allocations are fixed by cutlass_api;
+                            # NVGEMM register allocations are fixed by cutlass.operators;
                             # Triton's n_regs/n_spills heuristic doesn't apply.
                             ms_fused_choice = choice
                             break

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2352,9 +2352,8 @@ def ensure_cute_available() -> bool:
 def ensure_nv_universal_gemm_available() -> bool:
     """Check if the NVGEMM operator API is importable; cache the result.
 
-    This accepts public `cutlass.operators` or legacy `cutlass_api`. Call
-    ensure_nv_universal_gemm_available.cache_clear() after installing either
-    operator package in the same interpreter to retry the import.
+    Call ensure_nv_universal_gemm_available.cache_clear() after installing
+    `cutlass.operators` in the same interpreter to retry the import.
     """
     from torch._inductor.codegen.nv_universal_gemm.cutlass_ops import is_available
 
@@ -2365,7 +2364,7 @@ def ensure_nv_universal_gemm_available() -> bool:
 
 
 def _ensure_fp4_dtype_registered():
-    """Patch `cutlass.operators` or legacy `cutlass_api` for FP4."""
+    """Patch `cutlass.operators` for FP4."""
     from torch._inductor.codegen.nv_universal_gemm.cutlass_ops import (
         ensure_fp4_dtype_registered,
     )
@@ -2502,7 +2501,7 @@ def use_nv_universal_gemm_template(
 
     Required conditions:
         1. NVGEMM backend is enabled
-        2. CUTLASS operator API (`cutlass.operators` or legacy `cutlass_api`) is available
+        2. CUTLASS operator API (`cutlass.operators`) is available
         3. We are on a NVIDIA GPU
         4. Max autotune or max autotune gemm is enabled
         5. Not in AOT Inductor mode (requires runtime JIT compilation)
@@ -2511,8 +2510,7 @@ def use_nv_universal_gemm_template(
 
     Note:
         - Shape and stride constraints are handled internally by
-          the adapter loads kernels from `cutlass.operators` or legacy
-          `cutlass_api` and filters incompatible kernels.
+          `cutlass.operators`, which filters incompatible kernels.
         - GroupedGemm currently only supports TN layout (column-major B).
           Any other layout will act as a noop and fall back to ATen.
         - Dynamic shapes are supported as long as they have hints
@@ -2540,7 +2538,7 @@ def use_nv_universal_gemm_template(
     if not (config.max_autotune or config.max_autotune_gemm):
         return False
 
-    # The CUTLASS operator API (`cutlass.operators` or legacy `cutlass_api`)
+    # The CUTLASS operator API (`cutlass.operators`)
     # can't handle unbacked symbols because it needs to evaluate
     # shape constraints (e.g., stride divisibility by 8, N/K divisibility by 16).
     # Unbacked symbols have no hint values, causing GuardOnDataDependentSymNode errors.
@@ -2551,7 +2549,7 @@ def use_nv_universal_gemm_template(
         return False
 
     # Base pointer must be 16-byte aligned. The CUTLASS operator API
-    # (`cutlass.operators` or legacy `cutlass_api`) can't check this at
+    # (`cutlass.operators`) can't check this at
     # compile time because it only sees FakeTensors without real data pointers.
     tensors_to_check = [mat_a, mat_b]
     if offs is not None:

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2350,42 +2350,27 @@ def ensure_cute_available() -> bool:
 
 @functools.lru_cache(maxsize=1)
 def ensure_nv_universal_gemm_available() -> bool:
-    """Check if NVIDIA Universal GEMM (cutlass_api) is importable; cache the result for reuse.
+    """Check if the NVGEMM operator API is importable; cache the result.
 
-    Call ensure_nv_universal_gemm_available.cache_clear() after installing cutlass_api
-    in the same interpreter to retry the import.
+    This accepts public `cutlass.operators` or legacy `cutlass_api`. Call
+    ensure_nv_universal_gemm_available.cache_clear() after installing either
+    operator package in the same interpreter to retry the import.
     """
-    try:
-        available = importlib.util.find_spec("cutlass_api") is not None
-    except ImportError:
-        return False
-    if available:
+    from torch._inductor.codegen.nv_universal_gemm.cutlass_ops import is_available
+
+    if is_available():
         _ensure_fp4_dtype_registered()
-    return available
+        return True
+    return False
 
 
 def _ensure_fp4_dtype_registered():
-    """Patch cutlass_api to handle torch.float4_e2m1fn_x2 -> cutlass.Float4E2M1FN.
+    """Patch `cutlass.operators` or legacy `cutlass_api` for FP4."""
+    from torch._inductor.codegen.nv_universal_gemm.cutlass_ops import (
+        ensure_fp4_dtype_registered,
+    )
 
-    NOTE: cutlass_api doesn't natively map this dtype. We patch the lookup function
-    in-place so all callers (including TensorWrapper) pick up the change.
-    Remove once cutlass_api adds native FP4 support.
-    """
-    import cutlass_api.utils
-
-    try:
-        cutlass_api.utils.cutlass_type_from_torch_type(torch.float4_e2m1fn_x2)
-    except (KeyError, AttributeError):
-        import cutlass
-
-        _orig = cutlass_api.utils.cutlass_type_from_torch_type
-
-        def _patched(dtype):
-            if dtype == torch.float4_e2m1fn_x2:
-                return cutlass.Float4E2M1FN
-            return _orig(dtype)
-
-        cutlass_api.utils.cutlass_type_from_torch_type = _patched
+    ensure_fp4_dtype_registered()
 
 
 @functools.lru_cache(maxsize=1)
@@ -2517,7 +2502,7 @@ def use_nv_universal_gemm_template(
 
     Required conditions:
         1. NVGEMM backend is enabled
-        2. cutlass_api is available
+        2. CUTLASS operator API (`cutlass.operators` or legacy `cutlass_api`) is available
         3. We are on a NVIDIA GPU
         4. Max autotune or max autotune gemm is enabled
         5. Not in AOT Inductor mode (requires runtime JIT compilation)
@@ -2526,7 +2511,8 @@ def use_nv_universal_gemm_template(
 
     Note:
         - Shape and stride constraints are handled internally by
-          cutlass_api.get_kernels() which filters incompatible kernels.
+          the adapter loads kernels from `cutlass.operators` or legacy
+          `cutlass_api` and filters incompatible kernels.
         - GroupedGemm currently only supports TN layout (column-major B).
           Any other layout will act as a noop and fall back to ATen.
         - Dynamic shapes are supported as long as they have hints
@@ -2554,7 +2540,8 @@ def use_nv_universal_gemm_template(
     if not (config.max_autotune or config.max_autotune_gemm):
         return False
 
-    # cutlass_api can't handle unbacked symbols because it needs to evaluate
+    # The CUTLASS operator API (`cutlass.operators` or legacy `cutlass_api`)
+    # can't handle unbacked symbols because it needs to evaluate
     # shape constraints (e.g., stride divisibility by 8, N/K divisibility by 16).
     # Unbacked symbols have no hint values, causing GuardOnDataDependentSymNode errors.
     dims_to_check = [m, n, k]
@@ -2563,7 +2550,8 @@ def use_nv_universal_gemm_template(
     if any(has_free_unbacked_symbols(dim) for dim in dims_to_check):
         return False
 
-    # Base pointer must be 16-byte aligned. cutlass_api can't check this at
+    # Base pointer must be 16-byte aligned. The CUTLASS operator API
+    # (`cutlass.operators` or legacy `cutlass_api`) can't check this at
     # compile time because it only sees FakeTensors without real data pointers.
     tensors_to_check = [mat_a, mat_b]
     if offs is not None:


### PR DESCRIPTION
This PR updates NVGEMM so that it uses `cutlass.operators`.

Authored with Claude Opus 4.8 through Cursor.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo