### PR TITLE
[inductor][XPU] Fix AMP autocast round-trip fp16 accuracy (#188261)

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -869,8 +869,8 @@ class TestPatternMatcher(TestCase):
     @parametrize(
         "input_dtype, intermediate_dtype, emulate_precision_casts, expected_calls",
         [
-            (torch.float32, torch.float16, False, 2),
-            (torch.float32, torch.bfloat16, False, 2),
+            (torch.float32, torch.float16, False, 1),
+            (torch.float32, torch.bfloat16, False, 1),
             (torch.float32, torch.float64, False, 1),
             (torch.float32, torch.float16, True, 2),
             (torch.float16, torch.float32, True, 1),
@@ -900,6 +900,22 @@ class TestPatternMatcher(TestCase):
         gm = make_fx(fn_int)(x)
         self.assertEqual(count_calls(gm.graph), 2)
         joint_graph.joint_graph_passes(gm)
+        self.assertEqual(count_calls(gm.graph), 2)
+
+    @parametrize("emulate_precision_casts", [False, True])
+    def test_pointless_convert_preserves_non_roundtrip_narrow_intermediate(
+        self, emulate_precision_casts
+    ):
+        def fn(x):
+            x = torch.ops.prims.convert_element_type.default(x, torch.float16)
+            x = torch.ops.prims.convert_element_type.default(x, torch.float32)
+            return x
+
+        x = torch.randn(8, device=GPU_TYPE, dtype=torch.float64)
+        gm = make_fx(fn)(x)
+        self.assertEqual(count_calls(gm.graph), 2)
+        with inductor_config.patch(emulate_precision_casts=emulate_precision_casts):
+            joint_graph.joint_graph_passes(gm)
         self.assertEqual(count_calls(gm.graph), 2)
 
     # Constant folding was explicitly turned off due to issue #108388

--- a/torch/_inductor/fx_passes/joint_graph.py
+++ b/torch/_inductor/fx_passes/joint_graph.py
@@ -849,12 +849,14 @@ def pointless_convert(match: Match, arg, dtype1: torch.dtype, dtype2: torch.dtyp
         return
 
     if arg_val.dtype in allowed and dtype1 in allowed and dtype2 in allowed:
-        # A narrower intermediate can be worth materializing before upcasting.
-        if dtype1.itemsize < dtype2.itemsize:
-            return
         if config.emulate_precision_casts and not _is_lossless_fp_widening_cast(
             arg_val.dtype, dtype1
         ):
+            return
+        # Preserve narrow intermediates when the final dtype is not restoring
+        # the original dtype. AMP round trips like fp32 -> fp16 -> fp32 should
+        # collapse when precision emulation is disabled.
+        if dtype1.itemsize < dtype2.itemsize and dtype2 != arg_val.dtype:
             return
         repl = graph.call_function(
             torch.ops.prims.convert_element_type.default, (arg, dtype2)


### PR DESCRIPTION
Fixes #188261

Collapse redundant AMP autocast dtype round-trip conversions in the Inductor joint graph FX pass to prevent fp16 accuracy loss on XPU. When an operator's input and output are both in fp16 after autocast, the intermediate cast through fp32 is unnecessary and introduces precision loss.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo