### PR TITLE
[dynamo] Preserve Event/Stream subclass identity across graph breaks (#188536)

### DIFF
--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -2505,6 +2505,79 @@ class <lambda>(torch.nn.Module):
         self.assertNotIn(getitem_out, set(graph.nodes))
         self.assertIn(new_gi, add_node.all_input_nodes)
 
+    def test_event_stream_subclass_preserved_across_graph_break(self):
+        """Regression test for GitHub issue #188536: when a user subclasses
+        torch.Stream or torch.Event, constructs an instance inside a
+        torch.compile region, and hits a graph break between construction
+        and subsequent use, Dynamo must reconstruct the object with the
+        user subclass rather than demoting it to the base torch._C.Stream /
+        torch._C.Event.
+
+        The bug manifests when the resumed trace inspects the type of the
+        reconstructed object: before the fix, ``isinstance(ev, MyEvent)``
+        returned False and ``type(ev)`` was ``torch.Event`` because the
+        reconstruction path hard-coded the base class.
+
+        The bug is purely in Python-level reconstruction, so it reproduces
+        on CPU; we do not exercise record()/wait() because those require a
+        real accelerator stream stack.
+        """
+
+        class MyEvent(torch.Event):
+            pass
+
+        class MyStream(torch.Stream):
+            pass
+
+        # Event subclass: isinstance check must hold across graph break.
+        @torch.compile(backend="eager")
+        def fn_event(x):
+            ev = MyEvent()
+            torch._dynamo.graph_break()
+            return x + 1, isinstance(ev, MyEvent), type(ev).__name__
+
+        y, ok, name = fn_event(torch.ones(3))
+        self.assertEqual(y, torch.tensor([2.0, 2.0, 2.0]))
+        self.assertTrue(ok, f"isinstance(ev, MyEvent) was False; type(ev)={name}")
+        self.assertEqual(name, "MyEvent")
+
+        # Stream subclass: isinstance check must hold across graph break.
+        @torch.compile(backend="eager")
+        def fn_stream(x):
+            s = MyStream()
+            torch._dynamo.graph_break()
+            return x + 1, isinstance(s, MyStream), type(s).__name__
+
+        y, ok, name = fn_stream(torch.ones(3))
+        self.assertEqual(y, torch.tensor([2.0, 2.0, 2.0]))
+        self.assertTrue(ok, f"isinstance(s, MyStream) was False; type(s)={name}")
+        self.assertEqual(name, "MyStream")
+
+        # Multiple instances must each retain their subclass, and identity
+        # must be preserved across the graph break.
+        @torch.compile(backend="eager")
+        def fn_multi(x):
+            e1 = MyEvent()
+            e2 = MyEvent()
+            s = MyStream()
+            torch._dynamo.graph_break()
+            return (
+                x + 1,
+                isinstance(e1, MyEvent),
+                isinstance(e2, MyEvent),
+                isinstance(s, MyStream),
+                type(e1).__name__,
+                e1 is not e2,
+            )
+
+        y, ok1, ok2, oks, n1, ne = fn_multi(torch.ones(3))
+        self.assertEqual(y, torch.tensor([2.0, 2.0, 2.0]))
+        self.assertTrue(ok1)
+        self.assertTrue(ok2)
+        self.assertTrue(oks)
+        self.assertEqual(n1, "MyEvent")
+        self.assertTrue(ne)
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -5609,12 +5609,16 @@ def _extract_tensor_dict(t: torch.Tensor) -> dict[str, Any]:
     return tensor_dict
 
 
-def build_stream(args: tuple[Any], kwargs: dict[Any, Any]) -> torch.Stream:
-    return torch._C.Stream(*args, **kwargs)
+def build_stream(
+    stream_cls: type, args: tuple[Any], kwargs: dict[Any, Any]
+) -> torch.Stream:
+    return stream_cls(*args, **kwargs)
 
 
-def build_event(args: tuple[Any], kwargs: dict[Any, Any]) -> torch.Event:
-    return torch._C.Event(*args, **kwargs)
+def build_event(
+    event_cls: type, args: tuple[Any], kwargs: dict[Any, Any]
+) -> torch.Event:
+    return event_cls(*args, **kwargs)
 
 
 class CompileTimeInstructionCounter:

--- a/torch/_dynamo/variables/streams.py
+++ b/torch/_dynamo/variables/streams.py
@@ -40,7 +40,7 @@ def new_event(*args: Any, **kwargs: Any) -> int:
     return register_graph_created_object(
         event,
         EventVariable.make_construct_in_graph_event_fn(
-            TupleVariable([]), ConstDictVariable({})
+            torch.Event, TupleVariable([]), ConstDictVariable({})
         ),
     )
 
@@ -50,7 +50,7 @@ def new_stream(*args: tuple[Any], **kwargs: Any) -> int:
     return register_graph_created_object(
         stream,
         StreamVariable.make_construct_in_graph_stream_fn(
-            TupleVariable([]), ConstDictVariable({})
+            torch.Stream, TupleVariable([]), ConstDictVariable({})
         ),
     )
 
@@ -400,7 +400,7 @@ class StreamVariable(StreamContextVariable):
         super().__init__(None, **kwargs)
 
     def python_type(self) -> type:
-        return self._cpython_type
+        return type(self.value)
 
     def getattro_impl(
         self, tx: "InstructionTranslatorBase", name: str
@@ -488,7 +488,7 @@ class StreamVariable(StreamContextVariable):
                 event_index = register_graph_created_object(
                     event,
                     EventVariable.make_construct_in_graph_event_fn(
-                        TupleVariable([]), ConstDictVariable({})
+                        type(event), TupleVariable([]), ConstDictVariable({})
                     ),
                 )
             tx.output.create_proxy(
@@ -561,7 +561,9 @@ class StreamVariable(StreamContextVariable):
 
     @staticmethod
     def make_construct_in_graph_stream_fn(
-        args: TupleVariable, kwargs: ConstDictVariable
+        stream_cls: type,
+        args: TupleVariable,
+        kwargs: ConstDictVariable,
     ) -> Callable[[int, "PyCodegen"], None]:
         def fn(index: int, codegen: "PyCodegen") -> None:
             codegen.add_push_null(
@@ -575,9 +577,14 @@ class StreamVariable(StreamContextVariable):
                     torch._dynamo.utils.__name__, "build_stream"
                 )
             )
+            # Load the stream class (preserves subclass identity across graph breaks)
+            cls_name = codegen.tx.output.install_global_by_id(
+                "_stream_cls", stream_cls
+            )
+            codegen.append_output(codegen.create_load_global(cls_name, add=True))
             codegen(args)
             codegen(kwargs)
-            codegen.extend_output(create_call_function(2, False))
+            codegen.extend_output(create_call_function(3, False))
             codegen.extend_output(create_call_function(1, False))
 
         return fn
@@ -633,7 +640,7 @@ class EventVariable(VariableTracker):
         return object_richcompare(self, tx, other, op)
 
     def python_type(self) -> type:
-        return torch.Event
+        return type(self.value)
 
     def get_real_python_backed_value(self) -> object:
         return self.value
@@ -733,7 +740,9 @@ class EventVariable(VariableTracker):
 
     @staticmethod
     def make_construct_in_graph_event_fn(
-        args: TupleVariable, kwargs: ConstDictVariable
+        event_cls: type,
+        args: TupleVariable,
+        kwargs: ConstDictVariable,
     ) -> Callable[[int, "PyCodegen"], None]:
         def fn(index: int, codegen: "PyCodegen") -> None:
             codegen.add_push_null(
@@ -747,9 +756,14 @@ class EventVariable(VariableTracker):
                     torch._dynamo.utils.__name__, "build_event"
                 )
             )
+            # Load the event class (preserves subclass identity across graph breaks)
+            cls_name = codegen.tx.output.install_global_by_id(
+                "_event_cls", event_cls
+            )
+            codegen.append_output(codegen.create_load_global(cls_name, add=True))
             codegen(args)
             codegen(kwargs)
-            codegen.extend_output(create_call_function(2, False))
+            codegen.extend_output(create_call_function(3, False))
             codegen.extend_output(create_call_function(1, False))
 
         return fn

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -1450,7 +1450,7 @@ class UserDefinedClassVariable(UserDefinedVariable):
                 ind = register_graph_created_object(
                     stream,
                     StreamVariable.make_construct_in_graph_stream_fn(
-                        var_args, var_kwargs
+                        self.value, var_args, var_kwargs
                     ),
                 )
                 tensor_variable = wrap_fx_proxy(
@@ -1477,7 +1477,7 @@ class UserDefinedClassVariable(UserDefinedVariable):
                 ind = register_graph_created_object(
                     event,
                     EventVariable.make_construct_in_graph_event_fn(
-                        var_args, var_kwargs
+                        self.value, var_args, var_kwargs
                     ),
                 )
                 tensor_variable = wrap_fx_proxy(


### PR DESCRIPTION
Fixes #188536

When a user subclasses `torch.Event` or `torch.Stream`, Dynamo's graph break path lost the subclass identity because `build_event`/`build_stream` helpers always constructed the base `torch._C.Event`/`torch._C.Stream` types. This caused `record()` and `wait()` to operate on different objects across graph breaks.

Changes:
- `torch/_dynamo/utils.py`: `build_event` and `build_stream` now accept a class parameter and construct the user subclass when appropriate.
- `torch/_dynamo/variables/streams.py`: stream/event construction in graph codegen loads the user class via `install_global_by_id` and passes it to the helper; `record_event` paths use `type(event)`.
- `torch/_dynamo/variables/user_defined.py`: user-defined Stream/Event subclass construction forwards `self.value`.

Tests added in `test/dynamo/test_streams.py`.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98