### PR TITLE
[dynamic shapes] Preserve algebraic relationships in foreign unbacked SymInt transfer (#188723)

### DIFF
--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -6800,6 +6800,12 @@ class TestTransferSymbolsFromForeignShapeEnv(TestCase):
         # All free symbols are owned by local_env.
         for sym in result_expr.free_symbols:
             self.assertTrue(local_env.is_unbacked_symint(sym))
+        # Do not partially seed resolvable leaves when the whole expression
+        # requires the opaque fallback.
+        self.assertNotIn(
+            (id(foreign_env), u0.node.expr),
+            local_env.foreign_unbacked_symbol_cache,
+        )
 
     def test_transfer_is_self_short_circuit(self):
         """When the SymInt already belongs to this ShapeEnv,
@@ -7008,7 +7014,8 @@ class TestTransferSymbolsFromForeignShapeEnv(TestCase):
         self.assertIn(new_sizes[1].node.expr, local_env.size_like)
         self.assertIn(new_sizes[2].node.expr, local_env.size_like)
         self.assertEqual(
-            local_env.var_to_range[new_sizes[1].node.expr].lower, 0,
+            local_env.var_to_range[new_sizes[1].node.expr].lower,
+            0,
         )
 
     @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -6845,8 +6845,12 @@ class TestTransferSymbolsFromForeignShapeEnv(TestCase):
         self.assertIn(raw, local_env.size_like)
 
     def test_foreign_unbacked_transfer_preserves_derived_tensor_expr(self):
-        """Derived tensor dims are minted as opaque symbols; raw SymInt with
-        the same expression reuses that symbol via the (env, expr) cache."""
+        """Derived tensor dims (e.g. u0 // 2) encountered before their base
+        unbacked symbol are resolved by seeding the base symbol first; the
+        composite is then a derived expression (not an opaque fresh symbol),
+        and its raw-SymInt counterpart shares the transferred base symbol."""
+        import sympy
+
         foreign_env = ShapeEnv()
         global_tokens = foreign_env.create_unbacked_symint()
         hidden = foreign_env.create_unbacked_symint()
@@ -6867,11 +6871,16 @@ class TestTransferSymbolsFromForeignShapeEnv(TestCase):
 
         self.assertEqual(raw_derived_tokens.node.expr, new_sizes[0].node.expr)
         self.assertEqual(new_strides[0].node.expr, new_sizes[1].node.expr)
-        self.assertEqual(len(raw_derived_tokens.node.expr.free_symbols), 1)
-        derived_token_sym = next(iter(raw_derived_tokens.node.expr.free_symbols))
-        # `derived_tokens` (= global_tokens // 2) is minted as one fresh
-        # opaque symbol; its hint is the foreign expression's hint (64 // 2).
-        self.assertEqual(local_env.var_to_hint_override[derived_token_sym], 32)
+        # The transferred expression is derived (floor division of a fresh
+        # local unbacked symbol by 2), not a single opaque symbol.
+        self.assertFalse(isinstance(new_sizes[0].node.expr, sympy.Symbol))
+        self.assertEqual(len(new_sizes[0].node.expr.free_symbols), 1)
+        derived_token_sym = next(iter(new_sizes[0].node.expr.free_symbols))
+        # The base symbol (transferred global_tokens) retains its foreign
+        # hint override (64); the derived expression simplifies to
+        # floor(derived_token_sym / 2) rather than being collapsed to a
+        # single opaque symbol with a precomputed 64//2 hint.
+        self.assertEqual(local_env.var_to_hint_override[derived_token_sym], 64)
         self.assertEqual(local_env.var_to_hint_override[new_sizes[1].node.expr], 128)
 
     def test_foreign_unbacked_transfer_preserves_shared_token_grid(self):
@@ -6930,6 +6939,76 @@ class TestTransferSymbolsFromForeignShapeEnv(TestCase):
         self.assertEqual(
             raw_seq_plus_hidden.node.expr,
             token_grid_sizes[1].node.expr + derived_sizes[2].node.expr,
+        )
+
+    def test_composite_unbacked_transferred_before_leaves_preserves_relation(self):
+        """Regression test for gh-188723: when a composite unbacked expression
+        (u0 + u1) appears in the size tuple before its base symbols (u0, u1),
+        the transfer must preserve the algebraic relationship rather than
+        collapsing the composite to a single opaque symbol.
+
+        Previously the transfer minted one fresh unbacked symbol per foreign
+        expression in encounter order, so u0+u1 got minted as a single opaque
+        u_local0 before u0 and u1 were ever seen, losing the fact that
+        new_sizes[0] == new_sizes[1] + new_sizes[2]."""
+        import sympy
+
+        foreign_env = ShapeEnv()
+        u0 = foreign_env.create_unbacked_symint()
+        u1 = foreign_env.create_unbacked_symint()
+
+        local_env = ShapeEnv()
+        # Composite (u0 + u1) is listed BEFORE its base symbols u0, u1.
+        new_sizes, _, _ = local_env.transfer_symbols_from_foreign_shape_env(
+            (u0 + u1, u0, u1),
+            (1, 1, 1),
+            0,
+            source=self._make_source("regression_188723"),
+        )
+        # Algebraic relationship must be preserved.
+        self.assertEqual(
+            sympy.simplify(
+                new_sizes[0].node.expr
+                - (new_sizes[1].node.expr + new_sizes[2].node.expr)
+            ),
+            0,
+            f"Expected new_sizes[0] == new_sizes[1] + new_sizes[2], but got "
+            f"{new_sizes[0].node.expr} vs {new_sizes[1].node.expr} + "
+            f"{new_sizes[2].node.expr}",
+        )
+        # The composite dim should be a derived expression (u + v), not an
+        # opaque leaf symbol that hides the relationship.
+        self.assertFalse(
+            isinstance(new_sizes[0].node.expr, sympy.Symbol),
+            f"Composite size {new_sizes[0].node.expr} should be a derived "
+            f"expression, not an opaque symbol",
+        )
+        # Base dims should be leaf symbols.
+        self.assertIsInstance(new_sizes[1].node.expr, sympy.Symbol)
+        self.assertIsInstance(new_sizes[2].node.expr, sympy.Symbol)
+        # Transferring the same foreign SymInts again (raw-SymInt path) must
+        # reuse the same local symbols / derived expression.
+        raw_sum = self._transfer_symint(
+            local_env, u0 + u1, source=self._make_source("raw_sum_188723")
+        )
+        self.assertEqual(raw_sum.node.expr, new_sizes[0].node.expr)
+        raw_u0 = self._transfer_symint(
+            local_env, u0, source=self._make_source("raw_u0_188723")
+        )
+        self.assertEqual(raw_u0.node.expr, new_sizes[1].node.expr)
+        raw_u1 = self._transfer_symint(
+            local_env, u1, source=self._make_source("raw_u1_188723")
+        )
+        self.assertEqual(raw_u1.node.expr, new_sizes[2].node.expr)
+        # Base symbols must be unbacked and size_like (non-negative) even
+        # though they were seeded from a composite dim before being seen
+        # individually.
+        self.assertTrue(local_env.is_unbacked_symint(new_sizes[1].node.expr))
+        self.assertTrue(local_env.is_unbacked_symint(new_sizes[2].node.expr))
+        self.assertIn(new_sizes[1].node.expr, local_env.size_like)
+        self.assertIn(new_sizes[2].node.expr, local_env.size_like)
+        self.assertEqual(
+            local_env.var_to_range[new_sizes[1].node.expr].lower, 0,
         )
 
     @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -7018,6 +7018,44 @@ class TestTransferSymbolsFromForeignShapeEnv(TestCase):
             0,
         )
 
+    def test_same_named_symbols_from_distinct_foreign_envs_do_not_alias(self):
+        foreign_env1 = ShapeEnv()
+        foreign_u0 = foreign_env1.create_unbacked_symint()
+        foreign_u1 = foreign_env1.create_unbacked_symint()
+        foreign_env2 = ShapeEnv()
+        other_foreign_u0 = foreign_env2.create_unbacked_symint()
+        other_foreign_u1 = foreign_env2.create_unbacked_symint()
+        self.assertEqual(foreign_u0.node.expr.name, other_foreign_u0.node.expr.name)
+        self.assertEqual(foreign_u1.node.expr.name, other_foreign_u1.node.expr.name)
+
+        local_env = ShapeEnv()
+        transferred1, _, _ = local_env.transfer_symbols_from_foreign_shape_env(
+            (foreign_u0 + foreign_u1, foreign_u0, foreign_u1),
+            (1, 1, 1),
+            0,
+            source=self._make_source("foreign_env1"),
+        )
+        transferred2, _, _ = local_env.transfer_symbols_from_foreign_shape_env(
+            (other_foreign_u0 + other_foreign_u1, other_foreign_u0, other_foreign_u1),
+            (1, 1, 1),
+            0,
+            source=self._make_source("foreign_env2"),
+        )
+
+        self.assertEqual(
+            transferred1[0].node.expr,
+            transferred1[1].node.expr + transferred1[2].node.expr,
+        )
+        self.assertEqual(
+            transferred2[0].node.expr,
+            transferred2[1].node.expr + transferred2[2].node.expr,
+        )
+        self.assertTrue(
+            transferred1[0].node.expr.free_symbols.isdisjoint(
+                transferred2[0].node.expr.free_symbols
+            )
+        )
+
     @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
     def test_flex_attention_foreign_fake_e2e(self):
         """E2E test: trace flex_attention with BlockMask containing unbacked dims

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -6800,6 +6800,12 @@ class TestTransferSymbolsFromForeignShapeEnv(TestCase):
         # All free symbols are owned by local_env.
         for sym in result_expr.free_symbols:
             self.assertTrue(local_env.is_unbacked_symint(sym))
+        # Do not partially seed resolvable leaves when the whole expression
+        # requires the opaque fallback.
+        self.assertNotIn(
+            (id(foreign_env), u0.node.expr),
+            local_env.foreign_unbacked_symbol_cache,
+        )
 
     def test_transfer_is_self_short_circuit(self):
         """When the SymInt already belongs to this ShapeEnv,
@@ -6845,8 +6851,10 @@ class TestTransferSymbolsFromForeignShapeEnv(TestCase):
         self.assertIn(raw, local_env.size_like)
 
     def test_foreign_unbacked_transfer_preserves_derived_tensor_expr(self):
-        """Derived tensor dims are minted as opaque symbols; raw SymInt with
-        the same expression reuses that symbol via the (env, expr) cache."""
+        """Derived tensor dims (e.g. u0 // 2) encountered before their base
+        unbacked symbol are resolved by seeding the base symbol first; the
+        composite is then a derived expression (not an opaque fresh symbol),
+        and its raw-SymInt counterpart shares the transferred base symbol."""
         foreign_env = ShapeEnv()
         global_tokens = foreign_env.create_unbacked_symint()
         hidden = foreign_env.create_unbacked_symint()
@@ -6867,11 +6875,16 @@ class TestTransferSymbolsFromForeignShapeEnv(TestCase):
 
         self.assertEqual(raw_derived_tokens.node.expr, new_sizes[0].node.expr)
         self.assertEqual(new_strides[0].node.expr, new_sizes[1].node.expr)
-        self.assertEqual(len(raw_derived_tokens.node.expr.free_symbols), 1)
-        derived_token_sym = next(iter(raw_derived_tokens.node.expr.free_symbols))
-        # `derived_tokens` (= global_tokens // 2) is minted as one fresh
-        # opaque symbol; its hint is the foreign expression's hint (64 // 2).
-        self.assertEqual(local_env.var_to_hint_override[derived_token_sym], 32)
+        # The transferred expression is derived (floor division of a fresh
+        # local unbacked symbol by 2), not a single opaque symbol.
+        self.assertFalse(isinstance(new_sizes[0].node.expr, sympy.Symbol))
+        self.assertEqual(len(new_sizes[0].node.expr.free_symbols), 1)
+        derived_token_sym = next(iter(new_sizes[0].node.expr.free_symbols))
+        # The base symbol (transferred global_tokens) retains its foreign
+        # hint override (64); the derived expression simplifies to
+        # floor(derived_token_sym / 2) rather than being collapsed to a
+        # single opaque symbol with a precomputed 64//2 hint.
+        self.assertEqual(local_env.var_to_hint_override[derived_token_sym], 64)
         self.assertEqual(local_env.var_to_hint_override[new_sizes[1].node.expr], 128)
 
     def test_foreign_unbacked_transfer_preserves_shared_token_grid(self):
@@ -6931,6 +6944,79 @@ class TestTransferSymbolsFromForeignShapeEnv(TestCase):
             raw_seq_plus_hidden.node.expr,
             token_grid_sizes[1].node.expr + derived_sizes[2].node.expr,
         )
+
+    def test_composite_unbacked_transferred_before_leaves_preserves_relation(self):
+        foreign_env = ShapeEnv()
+        u0 = foreign_env.create_unbacked_symint()
+        u1 = foreign_env.create_unbacked_symint()
+
+        local_env = ShapeEnv()
+        new_sizes, _, _ = local_env.transfer_symbols_from_foreign_shape_env(
+            (u0 + u1, u0, u1),
+            (1, 1, 1),
+            0,
+            source=self._make_source("regression_188723"),
+        )
+        self.assertEqual(
+            new_sizes[0].node.expr,
+            new_sizes[1].node.expr + new_sizes[2].node.expr,
+        )
+        self.assertNotIsInstance(new_sizes[0].node.expr, sympy.Symbol)
+        self.assertIsInstance(new_sizes[1].node.expr, sympy.Symbol)
+        self.assertIsInstance(new_sizes[2].node.expr, sympy.Symbol)
+
+        raw_sum = self._transfer_symint(
+            local_env, u0 + u1, source=self._make_source("raw_sum_188723")
+        )
+        self.assertEqual(raw_sum.node.expr, new_sizes[0].node.expr)
+        raw_u0 = self._transfer_symint(
+            local_env, u0, source=self._make_source("raw_u0_188723")
+        )
+        self.assertEqual(raw_u0.node.expr, new_sizes[1].node.expr)
+        raw_u1 = self._transfer_symint(
+            local_env, u1, source=self._make_source("raw_u1_188723")
+        )
+        self.assertEqual(raw_u1.node.expr, new_sizes[2].node.expr)
+
+    def test_composite_size_does_not_constrain_individual_leaves(self):
+        foreign_env = ShapeEnv()
+        u0 = foreign_env.create_unbacked_symint()
+        u1 = foreign_env.create_unbacked_symint()
+
+        local_env = ShapeEnv()
+        new_sizes, _, _ = local_env.transfer_symbols_from_foreign_shape_env(
+            (u0 - u1,),
+            (1,),
+            0,
+            source=self._make_source("composite_size"),
+        )
+
+        self.assertEqual(len(new_sizes[0].node.expr.free_symbols), 2)
+        for sym in new_sizes[0].node.expr.free_symbols:
+            self.assertNotIn(sym, local_env.size_like)
+
+    def test_same_named_symbols_from_distinct_live_foreign_envs(self):
+        foreign_env1 = ShapeEnv()
+        foreign_u0 = foreign_env1.create_unbacked_symint()
+        foreign_env2 = ShapeEnv()
+        other_foreign_u0 = foreign_env2.create_unbacked_symint()
+        self.assertEqual(foreign_u0.node.expr.name, other_foreign_u0.node.expr.name)
+
+        local_env = ShapeEnv()
+        transferred1, _, _ = local_env.transfer_symbols_from_foreign_shape_env(
+            (foreign_u0,),
+            (1,),
+            0,
+            source=self._make_source("foreign_env1"),
+        )
+        transferred2, _, _ = local_env.transfer_symbols_from_foreign_shape_env(
+            (other_foreign_u0,),
+            (1,),
+            0,
+            source=self._make_source("foreign_env2"),
+        )
+
+        self.assertNotEqual(transferred1[0].node.expr, transferred2[0].node.expr)
 
     @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
     def test_flex_attention_foreign_fake_e2e(self):

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -4874,20 +4874,10 @@ class ShapeEnv:
     ) -> sympy.Expr:
         """Transfer a foreign SymInt expression into this ShapeEnv.
 
-        Algorithm (used uniformly for tensor sizes, strides, storage offsets,
-        and raw SymInt inputs):
-        1. Replace any foreign symbols in ``value.expr`` that are already in
-           the per-symbol cache (cache-only; no minting yet).
-        2. If every free symbol got replaced, return the resulting (possibly
-           derived) expression as-is.
-        3. Otherwise, for each unresolved foreign free symbol that is itself
-           a base unbacked sympy.Symbol in the source env, mint a fresh local
-           unbacked symbol and cache it one-to-one (pre-seeding).  Then
-           re-run substitution and return the derived structural expression
-           if all free symbols now resolve.
-        4. Fall back to minting ONE fresh local unbacked symbol for the whole
-           foreign expression (preserves pre-fix behavior for edge cases
-           involving backed or otherwise unclassifiable symbols)."""
+        Resolve each free symbol from the per-symbol cache or by minting a
+        fresh local unbacked symbol, then rebuild the expression once.  If any
+        free symbol cannot be resolved this way, preserve the old behavior of
+        minting one opaque symbol for the whole expression."""
         src_shape_env = value.node.shape_env
         if src_shape_env is self:
             # SymInt already belongs to this ShapeEnv; nothing to transfer.
@@ -4901,25 +4891,49 @@ class ShapeEnv:
                 f"to a foreign ShapeEnv, got {value!r} with shape_env=None"
             )
         expr = value.node.expr
+        env_id = id(src_shape_env)
+        foreign_symbols = sorted(expr.free_symbols, key=lambda s: s.name)
+        cache = self.foreign_unbacked_symbol_cache
 
-        # Step 1: cache-only replacement.
-        cache_map = {
-            sym: self.foreign_unbacked_symbol_cache[(id(src_shape_env), sym)]
-            for sym in expr.free_symbols
-            if (id(src_shape_env), sym) in self.foreign_unbacked_symbol_cache
-        }
-        new_expr = expr.xreplace(cache_map) if cache_map else expr
+        can_transfer_structurally = all(
+            (env_id, sym) in cache or src_shape_env.is_unbacked_symint(sym)
+            for sym in foreign_symbols
+        )
+        if can_transfer_structurally:
+            from torch._dynamo.source import EphemeralSource
 
-        # Step 2: all symbols resolved from cache; use the derived expression.
-        if not (new_expr.free_symbols - set(cache_map.values())):
+            hint_sources = (
+                src_shape_env.backed_var_to_val.keys()
+                | src_shape_env.var_to_hint_override.keys()
+            )
+            replacements = {}
+            for foreign_sym in foreign_symbols:
+                key = (env_id, foreign_sym)
+                local_sym = cache.get(key)
+                if local_sym is None:
+                    leaf_source = EphemeralSource(f"foreign_leaf:{foreign_sym.name}")
+                    with self.ignore_fresh_unbacked_symbols():
+                        local_symint = self.create_unbacked_symint(leaf_source)
+                    local_sym = local_symint.node.expr
+                    cache[key] = local_sym
+                    optimization_hint = (
+                        src_shape_env.optimization_hint(foreign_sym)
+                        if foreign_sym in hint_sources
+                        else None
+                    )
+                    self._register_unbacked_symbol_as_input(
+                        local_sym,
+                        source=leaf_source,
+                        value_range=src_shape_env.bound_sympy(foreign_sym),
+                        optimization_hint=optimization_hint,
+                    )
+                replacements[foreign_sym] = local_sym
+
+            new_expr = expr.xreplace(replacements)
             if is_size:
                 if isinstance(new_expr, sympy.Symbol):
                     self._constrain_range_for_size(new_expr)
                 else:
-                    # Derived expr (e.g. u0+u1): mark every base unbacked
-                    # symbol as size-like (non-negative) so components are
-                    # properly ranged, then constrain the whole sum via a
-                    # deferred runtime assert.
                     for s in new_expr.free_symbols:
                         if isinstance(s, sympy.Symbol) and self.is_unbacked_symint(s):
                             self._constrain_range_for_size(s)
@@ -4928,80 +4942,13 @@ class ShapeEnv:
                     )
             return new_expr
 
-        # Step 3: some free foreign symbols are not yet in the cache.
-        # Before minting an opaque symbol for the whole expression, seed the
-        # cache with fresh local unbacked symbols for every unresolved leaf
-        # (sympy.Symbol) foreign free symbol.  This preserves algebraic
-        # structure: a composite like u0+u1 encountered before u0/u1 will
-        # resolve to local_u0 + local_u1 instead of a single opaque symbol.
-        from torch._dynamo.source import EphemeralSource
-
-        hint_sources = (
-            src_shape_env.backed_var_to_val.keys()
-            | src_shape_env.var_to_hint_override.keys()
-        )
-        unresolved = [
-            s for s in expr.free_symbols
-            if isinstance(s, sympy.Symbol)
-            and (id(src_shape_env), s) not in self.foreign_unbacked_symbol_cache
-            and src_shape_env.is_unbacked_symint(s)
-        ]
-        # Sort for determinism (free_symbols is a set).
-        unresolved.sort(key=lambda s: s.name)
-        for fsym in unresolved:
-            f_key = (id(src_shape_env), fsym)
-            if f_key in self.foreign_unbacked_symbol_cache:
-                continue
-            leaf_source = EphemeralSource(f"foreign_leaf:{fsym.name}")
-            with self.ignore_fresh_unbacked_symbols():
-                leaf_symint = self.create_unbacked_symint(leaf_source)
-            leaf_cached = leaf_symint.node.expr
-            self.foreign_unbacked_symbol_cache[f_key] = leaf_cached
-            leaf_opt_hint = (
-                src_shape_env.optimization_hint(fsym)
-                if not fsym.free_symbols - hint_sources
-                else None
-            )
-            self._register_unbacked_symbol_as_input(
-                leaf_cached,
-                source=leaf_source,
-                value_range=src_shape_env.bound_sympy(fsym),
-                optimization_hint=leaf_opt_hint,
-            )
-            if is_size:
-                self._constrain_range_for_size(leaf_cached)
-
-        # Re-run substitution after seeding leaves.
-        cache_map2 = {
-            sym: self.foreign_unbacked_symbol_cache[(id(src_shape_env), sym)]
-            for sym in expr.free_symbols
-            if (id(src_shape_env), sym) in self.foreign_unbacked_symbol_cache
-        }
-        new_expr2 = expr.xreplace(cache_map2) if cache_map2 else expr
-        if not (new_expr2.free_symbols - set(cache_map2.values())):
-            if is_size:
-                if isinstance(new_expr2, sympy.Symbol):
-                    self._constrain_range_for_size(new_expr2)
-                else:
-                    for s in new_expr2.free_symbols:
-                        if isinstance(s, sympy.Symbol) and self.is_unbacked_symint(s):
-                            self._constrain_range_for_size(s)
-                    torch._check(
-                        self.create_symintnode(new_expr2, hint=None, source=source) >= 0
-                    )
-            return new_expr2
-
-        # Step 4: still could not resolve every free symbol (e.g. expr
-        # contains a foreign symbol we don't know how to classify).  Mint one
-        # fresh opaque local symbol for the whole foreign expression as a
-        # fallback, preserving pre-fix behavior for edge cases.
-        expr_key = (id(src_shape_env), expr)
-        cached = self.foreign_unbacked_symbol_cache.get(expr_key)
+        expr_key = (env_id, expr)
+        cached = cache.get(expr_key)
         if cached is None:
             with self.ignore_fresh_unbacked_symbols():
                 new_symint = self.create_unbacked_symint(source)
             cached = new_symint.node.expr
-            self.foreign_unbacked_symbol_cache[expr_key] = cached
+            cache[expr_key] = cached
             # Only carry the foreign optimization hint forward when every
             # free symbol in expr has an explicit backed value or hint
             # override; otherwise optimization_hint would return a generic

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -4892,8 +4892,14 @@ class ShapeEnv:
             )
         expr = value.node.expr
         env_id = id(src_shape_env)
+        # free_symbols are the leaves that need local replacements; no recursion
+        # into the expression is necessary.
         foreign_symbols = sorted(expr.free_symbols, key=lambda s: s.name)
         cache = self.foreign_unbacked_symbol_cache
+        hint_sources = (
+            src_shape_env.backed_var_to_val.keys()
+            | src_shape_env.var_to_hint_override.keys()
+        )
 
         can_transfer_structurally = all(
             (env_id, sym) in cache or src_shape_env.is_unbacked_symint(sym)
@@ -4902,10 +4908,6 @@ class ShapeEnv:
         if can_transfer_structurally:
             from torch._dynamo.source import EphemeralSource
 
-            hint_sources = (
-                src_shape_env.backed_var_to_val.keys()
-                | src_shape_env.var_to_hint_override.keys()
-            )
             replacements = {}
             for foreign_sym in foreign_symbols:
                 key = (env_id, foreign_sym)
@@ -4954,10 +4956,6 @@ class ShapeEnv:
             # override; otherwise optimization_hint would return a generic
             # heuristic fallback that shouldn't be recorded as user
             # provenance.
-            hint_sources = (
-                src_shape_env.backed_var_to_val.keys()
-                | src_shape_env.var_to_hint_override.keys()
-            )
             optimization_hint = (
                 src_shape_env.optimization_hint(expr)
                 if not expr.free_symbols - hint_sources

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -4880,18 +4880,14 @@ class ShapeEnv:
            the per-symbol cache (cache-only; no minting yet).
         2. If every free symbol got replaced, return the resulting (possibly
            derived) expression as-is.
-        3. Otherwise mint ONE fresh local unbacked symbol for the whole
-           foreign expression, attach the caller's ``source`` to it, register
-           its value range / hint from the foreign env, and cache
-           ``(foreign_env, foreign_expr) -> new_symbol`` so a future call
-           with the same expression reuses the symbol.
-
-        Note: this loses fine-grained relationships when a derived expression
-        is minted before its base symbols are seen individually (e.g. minting
-        a symbol for ``u0 + u1`` before any tensor dim carries ``u0`` or
-        ``u1`` alone; later occurrences of those bare symbols cannot share
-        with the minted derived symbol).  This is consistent with the
-        pre-refactor behavior."""
+        3. Otherwise, for each unresolved foreign free symbol that is itself
+           a base unbacked sympy.Symbol in the source env, mint a fresh local
+           unbacked symbol and cache it one-to-one (pre-seeding).  Then
+           re-run substitution and return the derived structural expression
+           if all free symbols now resolve.
+        4. Fall back to minting ONE fresh local unbacked symbol for the whole
+           foreign expression (preserves pre-fix behavior for edge cases
+           involving backed or otherwise unclassifiable symbols)."""
         src_shape_env = value.node.shape_env
         if src_shape_env is self:
             # SymInt already belongs to this ShapeEnv; nothing to transfer.
@@ -4920,19 +4916,85 @@ class ShapeEnv:
                 if isinstance(new_expr, sympy.Symbol):
                     self._constrain_range_for_size(new_expr)
                 else:
-                    # Derived expr (e.g. u0+u1): constrain the whole sum to be
-                    # a valid size via a deferred runtime assert, not each
-                    # individual base symbol.
+                    # Derived expr (e.g. u0+u1): mark every base unbacked
+                    # symbol as size-like (non-negative) so components are
+                    # properly ranged, then constrain the whole sum via a
+                    # deferred runtime assert.
+                    for s in new_expr.free_symbols:
+                        if isinstance(s, sympy.Symbol) and self.is_unbacked_symint(s):
+                            self._constrain_range_for_size(s)
                     torch._check(
                         self.create_symintnode(new_expr, hint=None, source=source) >= 0
                     )
             return new_expr
 
-        # Step 3: at least one symbol could not be resolved.  Mint one fresh
-        # symbol for the whole foreign expression and cache by expression.
-        # TODO we can do better here: we lose all structural info about the
-        # foreign expression (e.g. that it was u0 + u1) by collapsing it to a
-        # single opaque local symbol.
+        # Step 3: some free foreign symbols are not yet in the cache.
+        # Before minting an opaque symbol for the whole expression, seed the
+        # cache with fresh local unbacked symbols for every unresolved leaf
+        # (sympy.Symbol) foreign free symbol.  This preserves algebraic
+        # structure: a composite like u0+u1 encountered before u0/u1 will
+        # resolve to local_u0 + local_u1 instead of a single opaque symbol.
+        from torch._dynamo.source import EphemeralSource
+
+        hint_sources = (
+            src_shape_env.backed_var_to_val.keys()
+            | src_shape_env.var_to_hint_override.keys()
+        )
+        unresolved = [
+            s for s in expr.free_symbols
+            if isinstance(s, sympy.Symbol)
+            and (id(src_shape_env), s) not in self.foreign_unbacked_symbol_cache
+            and src_shape_env.is_unbacked_symint(s)
+        ]
+        # Sort for determinism (free_symbols is a set).
+        unresolved.sort(key=lambda s: s.name)
+        for fsym in unresolved:
+            f_key = (id(src_shape_env), fsym)
+            if f_key in self.foreign_unbacked_symbol_cache:
+                continue
+            leaf_source = EphemeralSource(f"foreign_leaf:{fsym.name}")
+            with self.ignore_fresh_unbacked_symbols():
+                leaf_symint = self.create_unbacked_symint(leaf_source)
+            leaf_cached = leaf_symint.node.expr
+            self.foreign_unbacked_symbol_cache[f_key] = leaf_cached
+            leaf_opt_hint = (
+                src_shape_env.optimization_hint(fsym)
+                if not fsym.free_symbols - hint_sources
+                else None
+            )
+            self._register_unbacked_symbol_as_input(
+                leaf_cached,
+                source=leaf_source,
+                value_range=src_shape_env.bound_sympy(fsym),
+                optimization_hint=leaf_opt_hint,
+            )
+            if is_size:
+                self._constrain_range_for_size(leaf_cached)
+
+        # Re-run substitution after seeding leaves.
+        cache_map2 = {
+            sym: self.foreign_unbacked_symbol_cache[(id(src_shape_env), sym)]
+            for sym in expr.free_symbols
+            if (id(src_shape_env), sym) in self.foreign_unbacked_symbol_cache
+        }
+        new_expr2 = expr.xreplace(cache_map2) if cache_map2 else expr
+        if not (new_expr2.free_symbols - set(cache_map2.values())):
+            if is_size:
+                if isinstance(new_expr2, sympy.Symbol):
+                    self._constrain_range_for_size(new_expr2)
+                else:
+                    for s in new_expr2.free_symbols:
+                        if isinstance(s, sympy.Symbol) and self.is_unbacked_symint(s):
+                            self._constrain_range_for_size(s)
+                    torch._check(
+                        self.create_symintnode(new_expr2, hint=None, source=source) >= 0
+                    )
+            return new_expr2
+
+        # Step 4: still could not resolve every free symbol (e.g. expr
+        # contains a foreign symbol we don't know how to classify).  Mint one
+        # fresh opaque local symbol for the whole foreign expression as a
+        # fallback, preserving pre-fix behavior for edge cases.
         expr_key = (id(src_shape_env), expr)
         cached = self.foreign_unbacked_symbol_cache.get(expr_key)
         if cached is None:

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -4913,7 +4913,9 @@ class ShapeEnv:
                 key = (env_id, foreign_sym)
                 local_sym = cache.get(key)
                 if local_sym is None:
-                    leaf_source = EphemeralSource(f"foreign_leaf:{foreign_sym.name}")
+                    leaf_source = EphemeralSource(
+                        f"foreign_leaf:{env_id}:{foreign_sym.name}"
+                    )
                     with self.ignore_fresh_unbacked_symbols():
                         local_symint = self.create_unbacked_symint(leaf_source)
                     local_sym = local_symint.node.expr

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -4874,24 +4874,10 @@ class ShapeEnv:
     ) -> sympy.Expr:
         """Transfer a foreign SymInt expression into this ShapeEnv.
 
-        Algorithm (used uniformly for tensor sizes, strides, storage offsets,
-        and raw SymInt inputs):
-        1. Replace any foreign symbols in ``value.expr`` that are already in
-           the per-symbol cache (cache-only; no minting yet).
-        2. If every free symbol got replaced, return the resulting (possibly
-           derived) expression as-is.
-        3. Otherwise mint ONE fresh local unbacked symbol for the whole
-           foreign expression, attach the caller's ``source`` to it, register
-           its value range / hint from the foreign env, and cache
-           ``(foreign_env, foreign_expr) -> new_symbol`` so a future call
-           with the same expression reuses the symbol.
-
-        Note: this loses fine-grained relationships when a derived expression
-        is minted before its base symbols are seen individually (e.g. minting
-        a symbol for ``u0 + u1`` before any tensor dim carries ``u0`` or
-        ``u1`` alone; later occurrences of those bare symbols cannot share
-        with the minted derived symbol).  This is consistent with the
-        pre-refactor behavior."""
+        Resolve each free symbol from the per-symbol cache or by minting a
+        fresh local unbacked symbol, then rebuild the expression once.  If any
+        free symbol cannot be resolved this way, preserve the old behavior of
+        minting one opaque symbol for the whole expression."""
         src_shape_env = value.node.shape_env
         if src_shape_env is self:
             # SymInt already belongs to this ShapeEnv; nothing to transfer.
@@ -4905,50 +4891,70 @@ class ShapeEnv:
                 f"to a foreign ShapeEnv, got {value!r} with shape_env=None"
             )
         expr = value.node.expr
+        env_id = id(src_shape_env)
+        # free_symbols are the leaves that need local replacements; no recursion
+        # into the expression is necessary.
+        foreign_symbols = sorted(expr.free_symbols, key=lambda s: s.name)
+        cache = self.foreign_unbacked_symbol_cache
+        hint_sources = (
+            src_shape_env.backed_var_to_val.keys()
+            | src_shape_env.var_to_hint_override.keys()
+        )
 
-        # Step 1: cache-only replacement.
-        cache_map = {
-            sym: self.foreign_unbacked_symbol_cache[(id(src_shape_env), sym)]
-            for sym in expr.free_symbols
-            if (id(src_shape_env), sym) in self.foreign_unbacked_symbol_cache
-        }
-        new_expr = expr.xreplace(cache_map) if cache_map else expr
+        can_transfer_structurally = all(
+            (env_id, sym) in cache or src_shape_env.is_unbacked_symint(sym)
+            for sym in foreign_symbols
+        )
+        if can_transfer_structurally:
+            from torch._dynamo.source import EphemeralSource
 
-        # Step 2: all symbols resolved from cache; use the derived expression.
-        if not (new_expr.free_symbols - set(cache_map.values())):
+            replacements = {}
+            for foreign_sym in foreign_symbols:
+                key = (env_id, foreign_sym)
+                local_sym = cache.get(key)
+                if local_sym is None:
+                    leaf_source = EphemeralSource(
+                        f"foreign_leaf:{self.unbacked_symint_counter}"
+                    )
+                    with self.ignore_fresh_unbacked_symbols():
+                        local_symint = self.create_unbacked_symint(leaf_source)
+                    local_sym = local_symint.node.expr
+                    cache[key] = local_sym
+                    optimization_hint = (
+                        src_shape_env.optimization_hint(foreign_sym)
+                        if foreign_sym in hint_sources
+                        else None
+                    )
+                    self._register_unbacked_symbol_as_input(
+                        local_sym,
+                        source=leaf_source,
+                        value_range=src_shape_env.bound_sympy(foreign_sym),
+                        optimization_hint=optimization_hint,
+                    )
+                replacements[foreign_sym] = local_sym
+
+            new_expr = expr.xreplace(replacements)
             if is_size:
                 if isinstance(new_expr, sympy.Symbol):
                     self._constrain_range_for_size(new_expr)
                 else:
-                    # Derived expr (e.g. u0+u1): constrain the whole sum to be
-                    # a valid size via a deferred runtime assert, not each
-                    # individual base symbol.
                     torch._check(
                         self.create_symintnode(new_expr, hint=None, source=source) >= 0
                     )
             return new_expr
 
-        # Step 3: at least one symbol could not be resolved.  Mint one fresh
-        # symbol for the whole foreign expression and cache by expression.
-        # TODO we can do better here: we lose all structural info about the
-        # foreign expression (e.g. that it was u0 + u1) by collapsing it to a
-        # single opaque local symbol.
-        expr_key = (id(src_shape_env), expr)
-        cached = self.foreign_unbacked_symbol_cache.get(expr_key)
+        expr_key = (env_id, expr)
+        cached = cache.get(expr_key)
         if cached is None:
             with self.ignore_fresh_unbacked_symbols():
                 new_symint = self.create_unbacked_symint(source)
             cached = new_symint.node.expr
-            self.foreign_unbacked_symbol_cache[expr_key] = cached
+            cache[expr_key] = cached
             # Only carry the foreign optimization hint forward when every
             # free symbol in expr has an explicit backed value or hint
             # override; otherwise optimization_hint would return a generic
             # heuristic fallback that shouldn't be recorded as user
             # provenance.
-            hint_sources = (
-                src_shape_env.backed_var_to_val.keys()
-                | src_shape_env.var_to_hint_override.keys()
-            )
             optimization_hint = (
                 src_shape_env.optimization_hint(expr)
                 if not expr.free_symbols - hint_sources


### PR DESCRIPTION
Fixes #188723

`ShapeEnv._transfer_foreign_expr_as_unbacked` had an order-dependent bug: when a composite foreign expression such as `u0 + u1` was transferred before its base unbacked symbols, the algorithm collapsed the composite to one opaque local symbol and lost the algebraic relationship.

This PR now contains only the core expression-preservation fix. It preflights every free symbol, mints leaf mappings only when the complete expression is structurally transferable, and rebuilds the expression with one `xreplace`. Unclassifiable expressions still use the opaque fallback without partially seeding the cache. Hint copying and existing fallback behavior are preserved.

For tensor sizes, only the complete composite expression is constrained nonnegative; an individual leaf becomes `size_like` only when it independently appears as a size. Durable foreign `ShapeEnv` identity is handled separately in #190686.

Test Plan:

```
PYTHONPATH=/tmp/pytorch-core-archive-882cc6 python test/test_dynamic_shapes.py TestTransferSymbolsFromForeignShapeEnv
```

```
PATH=/root/.local/bin:$PATH /usr/local/bin/lintrunner -a -r HEAD --take FLAKE8,PYFMT,RUFF,NEWLINE,SPACES,TABS --output oneline
```

This change was authored with assistance from Codex.