### PR TITLE
[dynamo] Allow raw unbacked SymInts in strict mode (FlexAttention BlockMask) (#187547)

### DIFF
--- a/test/dynamo/test_dynamic_spec.py
+++ b/test/dynamo/test_dynamic_spec.py
@@ -569,19 +569,31 @@ class TestShapeVarCompile(TestCase):
             with torch.compiler._non_strict_tracing_context():
                 compiled(n)
 
-    def test_raw_unbacked_symint_input_graph_breaks_outside_non_strict(self):
+    def test_raw_unbacked_symint_compiles(self):
+        # Regression test for GH#187547: a raw scalar unbacked SymInt reaching
+        # Dynamo (e.g. BlockMask.seq_lengths in flex_attention) used to
+        # trigger "Attempted to wrap unbacked SymInt".  After lifting the
+        # _is_non_strict_tracing() gate in VariableBuilder._wrap, raw
+        # unbacked SymInts are transferred into Dynamo's ShapeEnv, matching
+        # non-strict behavior.
+        from torch._subclasses.fake_tensor import FakeTensorMode
         from torch.fx.experimental.symbolic_shapes import ShapeEnv
 
+        @torch.compile(backend="eager", fullgraph=True)
         def fn(n):
-            return torch.ones((n,))
+            return n + 1
 
-        compiled = torch.compile(fn, backend="eager", fullgraph=True)
-        n = ShapeEnv().create_unbacked_symint()
-        with self.assertRaisesRegex(
-            torch._dynamo.exc.Unsupported,
-            "Attempted to wrap unbacked SymInt",
-        ):
-            compiled(n)
+        # Foreign ShapeEnv path (fresh ShapeEnv not yet seen by Dynamo).
+        n_foreign = ShapeEnv().create_unbacked_symint()
+        out_foreign = fn(n_foreign)
+        self.assertIsInstance(out_foreign, torch.SymInt)
+
+        # Same ShapeEnv path (as used by FlexAttention under FakeTensorMode).
+        shape_env = ShapeEnv()
+        n_same = shape_env.create_unbacked_symint()
+        with FakeTensorMode(shape_env=shape_env, allow_non_fake_inputs=True):
+            out_same = fn(n_same)
+        self.assertIsInstance(out_same, torch.SymInt)
 
     def test_none_entry_is_static(self):
         """A ``None`` entry is implicit static.

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -7412,6 +7412,36 @@ def forward(self, L_x_ : torch.Tensor, s77 : torch.SymInt, s27 : torch.SymInt):
 
         self.assertEqual(out.shape, (1, 1, seq, 8))
 
+    def test_flex_attention_unbacked_seq_lengths_raw_symint(self):
+        # https://github.com/pytorch/pytorch/issues/187547
+        # Raw unbacked SymInts used as BlockMask.seq_lengths should compile
+        # under strict torch.compile without graph breaks, sharing the
+        # symbolic dimension with q/k/v sizes.
+        from torch._subclasses.fake_tensor import FakeTensorMode
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        shape_env = ShapeEnv()
+        seq = shape_env.create_unbacked_symint()
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def model(q, k, v, block_mask):
+            return flex_attention(q, k, v, block_mask=block_mask)
+
+        with FakeTensorMode(shape_env=shape_env, allow_non_fake_inputs=True):
+            q = torch.empty((1, 1, seq, 8), device="cpu")
+            k = torch.empty((1, 1, seq, 8), device="cpu")
+            v = torch.empty((1, 1, seq, 8), device="cpu")
+            kv_num_blocks = torch.ones((1, 1, 1), dtype=torch.int32)
+            kv_indices = torch.zeros((1, 1, 1, 1), dtype=torch.int32)
+            block_mask = BlockMask.from_kv_blocks(
+                kv_num_blocks,
+                kv_indices,
+                BLOCK_SIZE=128,
+                seq_lengths=(seq, seq),
+            )
+            out = model(q, k, v, block_mask)
+        self.assertEqual(out.shape, (1, 1, seq, 8))
+
     # https://github.com/pytorch/pytorch/issues/164990
     def test_guard_same_frame_fail_message(self):
         import torch._dynamo.guards as g

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1673,16 +1673,16 @@ class VariableBuilder:
                     new_symint = self.tx.output.shape_env.create_unbacked_symint()
                 else:
                     shape_env = self.tx.output.shape_env
-                    if not torch.compiler._is_non_strict_tracing():
-                        # TODO: Need to enable this for Dynamo after broader
-                        # verification. See
-                        # test_raw_unbacked_symint_input_graph_breaks_outside_non_strict.
-                        unimplemented(
-                            gb_type="Attempted to wrap unbacked SymInt",
-                            context="",
-                            explanation="Unbacked SymInt input is not supported yet.",
-                            hints=[*graph_break_hints.SUPPORTABLE],
-                        )
+                    # A raw unbacked SymInt may reach Dynamo from a foreign
+                    # ShapeEnv (e.g. BlockMask.seq_lengths sharing the
+                    # unbacked token dimension with q/k/v in FlexAttention,
+                    # see GH#187547).  Transfer it into the local ShapeEnv so
+                    # that provenance with tensor dims is preserved via the
+                    # foreign-symbol cache.  Skip the same-frame guard
+                    # sanity check (same as non-strict tracing): raw
+                    # unbacked SymInts have no concrete value to evaluate
+                    # guards against at compile time.
+                    self.tx.output.skip_guards_check = True
                     if value.node.shape_env is shape_env:
                         # SymInt already belongs to this ShapeEnv; no
                         # transfer needed, reuse it directly.


### PR DESCRIPTION
Fixes #187547

`VariableBuilder._wrap` had an explicit gate requiring `_is_non_strict_tracing()` that blocked raw unbacked SymInts in strict Dynamo, even though the underlying `ShapeEnv._transfer_foreign_expr_as_unbacked` machinery already supported them. This broke FlexAttention `BlockMask` with raw unbacked seq_lengths under `torch.compile(fullgraph=True)`.

Changes:
- Remove the non-strict gate.
- Set `self.tx.output.skip_guards_check = True` during raw unbacked SymInt transfer to bypass the same-frame guard self-check in strict mode (guards are still installed and enforced at runtime, matching non-strict behavior).

Tests:
- `test_raw_unbacked_symint_compiles` covers both foreign-ShapeEnv and same-ShapeEnv (FakeTensorMode/FlexAttention) paths, replacing the old `test_raw_unbacked_symint_input_graph_breaks_outside_non_strict` which asserted the old graph break.
- Direct FlexAttention BlockMask regression test in `test/dynamo/test_repros.py`.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98