### PR TITLE
[inductor] Fix bf16 matmul accumulation precision in Triton templates (#188492)

### DIFF
--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1766,7 +1766,7 @@ class TritonOverrides(OpOverrides):
             shape=(RBLOCK, XBLOCK),
         )
 
-        if torch.backends.cuda.matmul.fp32_precision == "tf32":
+        if a.dtype == torch.float32 and torch.backends.cuda.matmul.fp32_precision == "tf32":
             input_precision = "tf32"
         else:
             input_precision = "ieee"

--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -110,7 +110,7 @@ LOOP_BODY_2D = """
         )
         mask_w = (idx_x_c[:, None] < GROUP_IN_C) & (idx_y_c[None, :] < GROUP_OUT_C)
         matrix_w = tl.load(w_ptrs, mask=mask_w, other=0.0)
-        acc += tl.dot(matrix_x, matrix_w, allow_tf32=ALLOW_TF32)
+        acc += tl.dot(matrix_x, matrix_w, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE)
 """
 
 """
@@ -239,7 +239,7 @@ LOOP_BODY_3D = """
         )
         mask_w = (idx_x_c[:, None] < GROUP_IN_C) & (idx_y_c[None, :] < GROUP_OUT_C)
         matrix_w = tl.load(w_ptrs, mask=mask_w, other=0.0)
-        acc += tl.dot(matrix_x, matrix_w, allow_tf32=ALLOW_TF32)
+        acc += tl.dot(matrix_x, matrix_w, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE)
 """
 
 conv3d_template = TritonTemplate(
@@ -681,7 +681,7 @@ def convolution(
                     # TODO(jansel): try unroll for bigger kernels once fixed:
                     #               https://github.com/triton-lang/triton/issues/1254
                     UNROLL=unroll,
-                    ALLOW_TF32=torch.backends.cudnn.fp32_precision == "tf32",
+                    ALLOW_TF32=x.get_dtype() == torch.float32 and torch.backends.cudnn.fp32_precision == "tf32",
                     num_stages=cfg.num_stages,
                     num_warps=num_warps,
                     **cfg.kwargs,
@@ -704,7 +704,7 @@ def convolution(
                     # TODO(jansel): try unroll for bigger kernels once fixed:
                     #               https://github.com/triton-lang/triton/issues/1254
                     UNROLL=unroll,
-                    ALLOW_TF32=torch.backends.cudnn.fp32_precision == "tf32",
+                    ALLOW_TF32=x.get_dtype() == torch.float32 and torch.backends.cudnn.fp32_precision == "tf32",
                     num_stages=cfg.num_stages,
                     num_warps=num_warps,
                     **cfg.kwargs,
@@ -739,7 +739,7 @@ def convolution(
                 DILATION_H=dilation[0],
                 DILATION_W=dilation[1],
                 GROUPS=groups,
-                ALLOW_TF32=torch.backends.cudnn.fp32_precision == "tf32",
+                ALLOW_TF32=x.get_dtype() == torch.float32 and torch.backends.cudnn.fp32_precision == "tf32",
                 num_stages=cfg.num_stages,
                 num_warps=cfg.num_warps,
                 **cfg.kwargs,
@@ -1127,7 +1127,7 @@ def convolution_backward_lowering(
                         DILATION_H=dilation[0],
                         DILATION_W=dilation[1],
                         GROUPS=groups,
-                        ALLOW_TF32=torch.backends.cudnn.allow_tf32,
+                        ALLOW_TF32=input.get_dtype() == torch.float32 and torch.backends.cudnn.allow_tf32,
                         num_stages=cfg.num_stages,
                         num_warps=cfg.num_warps,
                         **cfg.kwargs,
@@ -1183,7 +1183,7 @@ def convolution_backward_lowering(
                         DILATION_H=dilation[0],
                         DILATION_W=dilation[1],
                         GROUPS=groups,
-                        ALLOW_TF32=torch.backends.cudnn.allow_tf32,
+                        ALLOW_TF32=input.get_dtype() == torch.float32 and torch.backends.cudnn.allow_tf32,
                         num_stages=cfg.num_stages,
                         num_warps=cfg.num_warps,
                         **cfg.kwargs,

--- a/torch/_inductor/kernel/mm_plus_mm.py
+++ b/torch/_inductor/kernel/mm_plus_mm.py
@@ -96,7 +96,7 @@ mm_plus_mm_template = TritonTemplate(
         else:
             a = tl.load(A, mask=rk[None, :] < k1, other=0.)
             b = tl.load(B, mask=rk[:, None] < k1, other=0.)
-        acc += tl.dot(a, b, allow_tf32=ALLOW_TF32)
+        acc += tl.dot(a, b, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE)
         A += BLOCK_K * stride_ak
         B += BLOCK_K * stride_bk
 
@@ -109,7 +109,7 @@ mm_plus_mm_template = TritonTemplate(
         else:
             c = tl.load(C, mask=rk[None, :] < k2, other=0.)
             d = tl.load(D, mask=rk[:, None] < k2, other=0.)
-        acc += tl.dot(c, d, allow_tf32=ALLOW_TF32)
+        acc += tl.dot(c, d, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE)
         C += BLOCK_K * stride_ck
         D += BLOCK_K * stride_dk
 

--- a/torch/_inductor/kernel/templates/triton_blackwell_ws_persistent_device_tma_mm.py.jinja
+++ b/torch/_inductor/kernel/templates/triton_blackwell_ws_persistent_device_tma_mm.py.jinja
@@ -65,6 +65,7 @@
                 a if A_ROW_MAJOR else a.T,
                 b if B_ROW_MAJOR else b.T,
                 allow_tf32=ALLOW_TF32,
+                out_dtype=ACC_TYPE,
             )
 
         tile_id_c += NUM_SMS

--- a/torch/_inductor/kernel/templates/triton_bmm.py.jinja
+++ b/torch/_inductor/kernel/templates/triton_bmm.py.jinja
@@ -55,7 +55,7 @@
         else:
             a = tl.load(A, mask=rk[None, :] < k, other=0.)
             b = tl.load(B, mask=rk[:, None] < k, other=0.)
-        acc += tl.dot(a, b, allow_tf32=ALLOW_TF32)
+        acc += tl.dot(a, b, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE)
         A += BLOCK_K * stride_ak
         B += BLOCK_K * stride_bk
 

--- a/torch/_inductor/kernel/templates/triton_conv2d_bwd_input.py.jinja
+++ b/torch/_inductor/kernel/templates/triton_conv2d_bwd_input.py.jinja
@@ -49,7 +49,7 @@
         mat_w = tl.load(w_ptrs, mask=mask_w, other=0.0)
 
         # (M,K) @ (K,N) = (M,N)
-        acc += tl.dot(mat_dy, mat_w, allow_tf32=ALLOW_TF32)
+        acc += tl.dot(mat_dy, mat_w, allow_tf32=ALLOW_TF32, out_dtype=tl.float32)
 {%- endmacro %}
 
 {{def_kernel("dY", "W")}}

--- a/torch/_inductor/kernel/templates/triton_conv2d_bwd_weight.py.jinja
+++ b/torch/_inductor/kernel/templates/triton_conv2d_bwd_weight.py.jinja
@@ -44,7 +44,7 @@
         )
         matrix_dy = tl.load(dy_ptrs, mask=mask_dy, other=0.0)
 
-        acc += tl.dot(matrix_x, matrix_dy, allow_tf32=ALLOW_TF32)
+        acc += tl.dot(matrix_x, matrix_dy, allow_tf32=ALLOW_TF32, out_dtype=tl.float32)
 {%- endmacro %}
 
 {{def_kernel("X", "dY")}}

--- a/torch/_inductor/kernel/templates/triton_persistent_tma_mm.py.jinja
+++ b/torch/_inductor/kernel/templates/triton_persistent_tma_mm.py.jinja
@@ -102,12 +102,14 @@
                     b if B_ROW_MAJOR else b.T,
                     acc,
                     allow_tf32=ALLOW_TF32,
+                    out_dtype=ACC_TYPE,
                     )
             else:
                 acc += tl.dot(
                     a if A_ROW_MAJOR else a.T,
                     b if B_ROW_MAJOR else b.T,
                     allow_tf32=ALLOW_TF32,
+                out_dtype=ACC_TYPE,
                 )
 
         # rematerialize rm and rn to save registers

--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -2146,11 +2146,18 @@ class MMTemplateConfigMixin(GemmMaxAutotuneTemplateConfigHeuristics):
         elif device_type == "cuda":
             # allow_tf32 alignment heuristics based on reverse engineering
             # H100 CUDA 12.8 behavior
+            # TF32 only applies to float32 matmuls; for bf16/fp16 inputs keep it off
+            # to avoid reduced-precision wgmma miscompiles on Hopper with Triton 3.8
+            # SLP vectorizer (gh-188492).
+            inp_dtype = kernel_inputs.mat1mat2()[0].get_dtype()
+            is_fp32_input = inp_dtype == torch.float32
             size_threshold = V.graph.sizevars.statically_known_true(
                 sympy.And(sympy.Ge(m, 16), sympy.Ge(Min(n, k), 512))
             )
             allow_tf32 = (
-                torch.backends.cuda.matmul.fp32_precision == "tf32" and size_threshold
+                is_fp32_input
+                and torch.backends.cuda.matmul.fp32_precision == "tf32"
+                and size_threshold
             )
         else:
             allow_tf32 = False


### PR DESCRIPTION
Fixes #188492

Under Triton 3.8 on Hopper (SM90), bf16 Swin-Transformer and similar bf16 workloads compiled with `torch.compile(mode="max-autotune")` showed significant accuracy degradation. Root cause:

1. Multiple Triton MM/conv/BMM templates called `tl.dot(a, b, allow_tf32=ALLOW_TF32)` without an explicit `out_dtype`. When ALLOW_TF32 was True (default for sizeable matmuls on CUDA), the generated wgmma accumulated in bf16 instead of fp32, losing precision on Hopper.
2. The `allow_tf32` flag was being propagated to bf16/fp16 paths where it shouldn't influence accumulation precision.

Changes:
- Pass `out_dtype=ACC_TYPE` (fp32) to all affected `tl.dot` calls: `triton_persistent_tma_mm`, `triton_blackwell_ws_persistent_device_tma_mm`, `triton_bmm`, `triton_conv2d_bwd_{input,weight}`, `mm_plus_mm`, and the `conv.py` LOOP_BODY macros.
- Gate ALLOW_TF32 on `input_dtype == torch.float32` in:
  - `torch/_inductor/codegen/triton.py` (`input_precision = "tf32"`),
  - `torch/_inductor/kernel/conv.py`,
  - `torch/_inductor/template_heuristics/triton.py` (MMTemplateConfigMixin allow_tf32 heuristic).

This ensures bf16/fp16 matmuls always accumulate in fp32 regardless of the TF32 setting, matching eager cuBLAS behavior.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo