### PR TITLE
Add RISC-V CPU pause hint to cpu_atomic_add_float spin loop

### DIFF
--- a/aten/src/ATen/native/cpu/AtomicAddFloat.h
+++ b/aten/src/ATen/native/cpu/AtomicAddFloat.h
@@ -19,8 +19,13 @@ static inline void cpu_atomic_add_float(float* dst, float fvalue)
   float old_value = atomic_dst.load();
   float new_value = old_value + fvalue;
   while (!atomic_dst.compare_exchange_weak(old_value, new_value)) {
-#ifdef __aarch64__
+#if defined(__aarch64__)
     __asm__ __volatile__("yield;" : : : "memory");
+#elif defined(__riscv)
+    // Zihintpause `pause` spin-loop hint, emitted as its raw encoding so it
+    // assembles regardless of -march (it is a no-op HINT on cores lacking the
+    // extension).
+    __asm__ __volatile__(".insn i 0x0F, 0, x0, x0, 0x010" : : : "memory");
 #else
     _mm_pause();
 #endif


### PR DESCRIPTION
## Summary

`cpu_atomic_add_float` retries a `compare_exchange_weak` in a busy loop and emits an architecture-specific CPU relax hint between attempts — `yield` on aarch64, `_mm_pause()` on x86. On RISC-V neither branch applied: `__aarch64__` is undefined, so the loop fell through to `_mm_pause()`, which this header defines as an **empty macro** for non-x86/arm targets. The result on RISC-V was an unbounded busy-wait with no pipeline back-off, wasting issue slots and power under contention.

This adds the RISC-V `pause` hint (Zihintpause) between retries, mirroring the existing aarch64 and x86 branches.

## Details

The hint is written as its raw instruction encoding via `.insn` so it assembles on any toolchain regardless of `-march`. `pause` is a HINT in the FENCE encoding space and executes as a no-op on cores that do not implement the extension, so it is always safe — no `-march` bump or runtime guard needed.

**Alternative considered:** `.option arch, +zihintpause` + `pause`. More readable, but depends on assembler support for `.option arch` (binutils 2.38+). The raw `.insn` form has no such dependency and matches the minimal inline-asm style already used for the aarch64 branch.

## Test plan

```
# RISC-V branch compiles with no zihintpause in -march:
clang --target=riscv64-unknown-elf -march=rv64gc -c harness.c

# the .insn encodes to exactly `pause` (0x0100000F):
echo '.insn i 0x0F, 0, x0, x0, 0x010' \
  | llvm-mc --triple=riscv64 --filetype=obj -o pause.o
llvm-objdump -d --mattr=+zihintpause pause.o    # => 0100000f  pause

# existing aarch64 (yield) and default (_mm_pause) paths still compile
# and run (verified natively on an aarch64 host):
clang harness.c -o t && ./t                     # rc=0
```

Part of the RISC-V enablement effort #180975 (Phase 1.3: RISC-V CI / arch enablement).


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01