### PR TITLE
Add RISC-V approximate fast path to getApproximateTime

### DIFF
--- a/c10/util/ApproximateClock.h
+++ b/c10/util/ApproximateClock.h
@@ -31,6 +31,9 @@
 #endif
 #elif defined(__aarch64__) && !defined(__CUDACC__) && !defined(__HIPCC__)
 #define C10_ARMTSC
+#elif defined(__riscv) && (__riscv_xlen == 64) && !defined(__CUDACC__) && \
+    !defined(__HIPCC__)
+#define C10_RISCVTSC
 #endif
 
 namespace c10 {
@@ -80,6 +83,16 @@ inline uint64_t getArmApproximateTime() {
 }
 #endif
 
+#if defined(C10_RISCVTSC)
+inline uint64_t getRiscvApproximateTime() {
+  uint64_t val;
+  // rdtime reads the constant-frequency `time` CSR (user-readable on Linux,
+  // as cntvct_el0 is on aarch64).
+  __asm__ __volatile__("rdtime %0" : "=r"(val));
+  return val;
+}
+#endif
+
 // We often do not need to capture true wall times. If a fast mechanism such
 // as TSC is available we can use that instead and convert back to epoch time
 // during post processing. This greatly reduce the clock's contribution to
@@ -93,6 +106,8 @@ inline auto getApproximateTime() {
   return static_cast<uint64_t>(__rdtsc());
 #elif defined(C10_ARMTSC)
   return getArmApproximateTime();
+#elif defined(C10_RISCVTSC)
+  return getRiscvApproximateTime();
 #else
   return getTime();
 #endif


### PR DESCRIPTION
## Summary

`getApproximateTime()` returns a cheap monotonic counter that the profiler calibrates against wall-clock time, avoiding a `clock_gettime` syscall on every timestamp. It uses `__rdtsc` on x86 and `cntvct_el0` on aarch64, but had **no RISC-V branch** — so on RISC-V every timestamp fell back to the `getTime()` syscall path, the slow path this mechanism exists to avoid.

This adds a RISC-V (rv64) fast path that reads the `time` CSR via `rdtime`, mirroring the aarch64 `cntvct_el0` path from #178639.

## Details

`rdtime` is a constant-frequency counter and is user-readable on Linux — the same assumption the aarch64 path already makes for `cntvct_el0`. The branch is gated on `__riscv_xlen == 64` because on RV32 `rdtime` returns only the low 32 bits, so RV32 correctly keeps the `getTime()` fallback.

**Alternative considered:** `rdcycle`. It counts core cycles, which vary with frequency scaling and are commonly privileged (trap) in user mode, so it is unsuitable for a wall-time approximation; `rdtime` is the right counter.

## Test plan

```
# riscv64 emits the rdtime fast path:
clang --target=riscv64-unknown-elf -march=rv64gc -ffreestanding -O2 -c harness.c
llvm-objdump -d harness.o        # getApproximateTime: c0102573  rdtime a0

# rv32 correctly keeps the syscall fallback (no rdtime, calls getTime):
clang --target=riscv32-unknown-elf -march=rv32gc -ffreestanding -O2 -c harness.c
llvm-objdump -dr harness.o       # no rdtime; R_RISCV_CALL_PLT getTime

# existing aarch64 path still compiles and runs (verified natively):
clang harness.c -o t && ./t      # rc=0
```

Part of the RISC-V enablement effort #180975 (Phase 1.3).

cc @scotts (author of the aarch64 fast path in #178639, which this mirrors) @ryanzhang22
