### PR TITLE
Ensure correct sign of input for test_laplace in test_distributions.py

### DIFF
--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -3516,7 +3516,7 @@ class TestDistributions(DistributionsTestCase):
         loc = torch.randn(5, 5, requires_grad=True)
         scale = torch.randn(5, 5).abs().requires_grad_()
         loc_1d = torch.randn(1, requires_grad=True)
-        scale_1d = torch.randn(1, requires_grad=True)
+        scale_1d = torch.randn(1).abs().requires_grad_()
         loc_delta = torch.tensor([1.0, 0.0])
         scale_delta = torch.tensor([1e-5, 1e-5])
         self.assertEqual(Laplace(loc, scale).sample().size(), (5, 5))


### PR DESCRIPTION
Previously scale_1D input tensor was unconstrained, and could contain negative values, which led to invalid behaviour,

Partially fixes: https://github.com/intel/torch-xpu-ops/issues/4021