### PR TITLE
Fix index_reduce_ docstring: index indexes into self, not source

### DIFF
--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -2512,7 +2512,7 @@ Note:
 
 Args:
     dim (int): dimension along which to index
-    index (Tensor): indices of ``source`` to select from,
+    index (Tensor): indices of :attr:`self` to accumulate into,
         should have dtype either `torch.int64` or `torch.int32`
     source (FloatTensor): the tensor containing values to accumulate
     reduce (str): the reduction operation to apply


### PR DESCRIPTION
### Summary

The `Args` entry for `index` in `Tensor.index_reduce_` reads:

```
index (Tensor): indices of ``source`` to select from,
```

That wording is copied from `index_select`-style ops and is wrong for `index_reduce_`. Like `index_add_` and `index_copy_`, `index_reduce_` consumes `source` sequentially, and `index` gives the positions in `self` to accumulate into. The docstring's own body says so:

> if `dim == 0`, `index[i] == j`, ... then the `i`-th row of `source` is multiplied by the `j`-th row of `self`

and the formula it shows is `self[index[i], :, :] *= src[i, :, :]`, i.e. `index[i]` is a position in `self`, not an index into `source`.

### Fix

Change the description to `indices of :attr:\`self\` to accumulate into,`. This matches the sibling operators and the function's own explanation. Docstring-only, `+1/-1`.

This is the `index_reduce_` counterpart of the same copy-paste error in `index_add_` that PR #180783 (for issue #180119) is fixing; that PR touches only the `index_add_` hunk and not `index_reduce_`.
