### PR TITLE
[xpu][fix] Enable test_fallback_kernel_with_symexpr_output on XPU with correct head_dim

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -2532,7 +2532,9 @@ class AOTInductorTestsTemplate:
                 return res[0]
 
         m = Module().to(device=self.device)
-        tensor_shape = (4, 32, 4, 4)
+        # Use head_dim = q.shape[1] // 2 = 64, which is supported by both CUDA
+        # and XPU flash attention (XPU supports: 64, 96, 128, 192).
+        tensor_shape = (4, 128, 4, 4)
         inputs = (
             torch.randn(tensor_shape, dtype=torch.float16, device=self.device),
             torch.randn(tensor_shape, dtype=torch.float16, device=self.device),


### PR DESCRIPTION
## Motivation

`test_fallback_kernel_with_symexpr_output` was disabled on XPU via `@skipIfXpu` because it used `tensor_shape=(4,32,4,4)`, giving `head_dim=32//2=16` after reshape. The XPU sycltla flash attention kernel only supports specific head_dim values and crashes for unsupported ones.

Fixes #188131 (`DISABLED test_fallback_kernel_with_symexpr_output_xpu`).

## Solution

Change `tensor_shape` to `(4,128,4,4)` so `head_dim=64`, which is supported on both CUDA and XPU. The symexpr property is preserved: `q.shape[2]*q.shape[3]` remains a dynamic product (`s2*s3`).

## Test plan

```
python test/inductor/test_aot_inductor.py -k fallback_kernel
# 1 passed, 2 skipped (CPU/MPS platform skips)

python test/test_transformers.py TestSDPAXPU
# 8/8 passed

python test/dynamo/test_sdpa.py
# 6/6 passed
```

Note: This PR was authored with AI assistance (GitHub Copilot / Claude).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo