### PR TITLE
[Dynamo] Support relax frontend in tvm backend

### DIFF
--- a/test/dynamo/test_backends.py
+++ b/test/dynamo/test_backends.py
@@ -174,6 +174,37 @@ class TestOptimizations(torch._dynamo.test_case.TestCase):
             with patch.dict(sys.modules, {"tvm": None}):
                 self.assertRaises(ImportError, backend, gm, [torch.randn(2)])
 
+    def test_tvm_dispatches_relay_or_relax(self, device):
+        import torch._dynamo.backends.tvm as tvm_backend
+
+        gm = torch.fx.symbolic_trace(lambda x: x + 1)
+        sentinel = object()
+
+        def find_spec(present):
+            return lambda name: MagicMock() if name == present else None
+
+        with (
+            patch.dict(sys.modules, {"tvm": MagicMock()}),
+            patch.object(
+                tvm_backend, "_tvm_relay_compile", return_value=sentinel
+            ) as relay,
+            patch.object(
+                tvm_backend, "_tvm_relax_compile", return_value=sentinel
+            ) as relax,
+        ):
+            with patch("importlib.util.find_spec", side_effect=find_spec("tvm.relay")):
+                self.assertIs(tvm_backend.tvm(gm, [torch.randn(2)]), sentinel)
+            relay.assert_called_once()
+            relax.assert_not_called()
+
+            with patch(
+                "importlib.util.find_spec",
+                side_effect=find_spec("tvm.relax.frontend.torch"),
+            ):
+                self.assertIs(tvm_backend.tvm(gm, [torch.randn(2)]), sentinel)
+            relax.assert_called_once()
+            relay.assert_called_once()
+
     @onlyHPU
     def test_intel_gaudi_backend(self, device):
         self._check_backend_works("hpu_backend", device)

--- a/torch/_dynamo/backends/tvm.py
+++ b/torch/_dynamo/backends/tvm.py
@@ -51,17 +51,51 @@ def tvm(
 ) -> Callable[..., Any]:
     if options is None:
         options = MappingProxyType({"scheduler": None, "trials": 20000, "opt_level": 3})
-    if options is None:
-        raise AssertionError("options must not be None")
     try:
-        import tvm  # type: ignore[import]
-        from tvm import relay  # type: ignore[import]
-        from tvm.contrib import graph_executor  # type: ignore[import]
+        import tvm  # type: ignore[import]  # noqa: F401
     except ImportError as e:
         raise ImportError(
             "Please install apache-tvm to use the tvm backend. "
             "See https://tvm.apache.org/docs/install/index.html for instructions."
         ) from e
+
+    # relay was removed in TVM 0.20; newer pip wheels only ship the relax
+    # frontend, so dispatch on whichever API the installed TVM provides.
+    if importlib.util.find_spec("tvm.relay") is not None:
+        return _tvm_relay_compile(gm, example_inputs, options)
+    if importlib.util.find_spec("tvm.relax.frontend.torch") is not None:
+        return _tvm_relax_compile(gm, example_inputs, options)
+    raise ImportError(
+        "The installed apache-tvm provides neither the legacy relay frontend nor "
+        "the relax torch frontend, so the tvm backend cannot compile this graph."
+    )
+
+
+def _tvm_relax_compile(
+    gm: fx.GraphModule,
+    example_inputs: list[torch.Tensor],
+    options: MappingProxyType[str, Any],
+) -> Callable[..., Any]:
+    from tvm.relax.frontend.torch import relax_dynamo  # type: ignore[import]
+
+    scheduler = options.get("scheduler", None) or os.environ.get("TVM_SCHEDULER", None)
+    if scheduler in ("auto_scheduler", "meta_schedule"):
+        log.warning(
+            "scheduler=%s has no equivalent in the relax TVM backend; "
+            "falling back to the default relax pipeline.",
+            scheduler,
+        )
+    return relax_dynamo()(gm, example_inputs)
+
+
+def _tvm_relay_compile(
+    gm: fx.GraphModule,
+    example_inputs: list[torch.Tensor],
+    options: MappingProxyType[str, Any],
+) -> Callable[..., Any]:
+    import tvm  # type: ignore[import]
+    from tvm import relay  # type: ignore[import]
+    from tvm.contrib import graph_executor  # type: ignore[import]
 
     jit_mod = torch.jit.trace(gm, example_inputs)
     device = device_from_inputs(example_inputs)


### PR DESCRIPTION
## Related Isue

closes #188866

## Why

The tvm backend depends on `tvm.relay` and `tvm.contrib.graph_executor`, removed upstream in TVM 0.20, so every pip-installable TVM (`apache-tvm==0.25.*`) fails at import with `ImportError: cannot import name 'relay' from 'tvm'`.

## How

- Dispatch on the installed TVM API: use the legacy relay path when `tvm.relay` exists, otherwise delegate to TVM's own `tvm.relax.frontend.torch.relax_dynamo` backend
- Warn and fall back to the default relax pipeline for `meta_schedule`/`auto_scheduler`, which have no relax equivalent
- Add `test_tvm_dispatches_relay_or_relax` verifying both dispatch paths

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98