### PR TITLE
include activation epilogue in GemmAndBiasParams::Signature()

### DIFF
--- a/aten/src/ATen/cuda/tunable/GemmCommon.h
+++ b/aten/src/ATen/cuda/tunable/GemmCommon.h
@@ -393,7 +393,8 @@ struct GemmAndBiasParams : OpParams {
   }
 
   std::string Signature() const override {
-    return fmt::sprintf("%c%c_%ld_%ld_%ld_ld_%ld_%ld_%ld", transa, transb, m, n, k, lda, ldb, ldc);
+    std::string activation_str = to_string_epilogue(activation);
+    return fmt::sprintf("%c%c_%ld_%ld_%ld_ld_%ld_%ld_%ld_%s", transa, transb, m, n, k, lda, ldb, ldc, activation_str);
   }
 
   size_t GetSizeA() const {

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -10882,6 +10882,43 @@ class TestLinalgCudaOnly(TestCase):
             torch.cuda.tunable.set_max_tuning_iterations(1)
             self._test_addmm_impl(torch._addmm_activation, "relu", device, dtype)
 
+    @skipCUDAIfNotRocm
+    @dtypes(torch.bfloat16)
+    def test_addmm_activation_signature_tunableop(self, device, dtype):
+        # Verify that use_gelu=False and use_gelu=True produce distinct
+        # TunableOp CSV keys, confirming that activation is included in
+        # GemmAndBiasParams::Signature().
+        with self._tunableop_ctx():
+
+            M, K, N = 4, 64, 128
+            x   = torch.randn(M, K, dtype=dtype, device=device)
+            W   = torch.randn(N, K, dtype=dtype, device=device)
+            b   = torch.zeros(N,    dtype=dtype, device=device)
+            W_t = W.t().contiguous()
+
+            ref_num_results = len(torch.cuda.tunable.get_results())
+
+            torch._addmm_activation(b, x, W_t, beta=1, alpha=1, use_gelu=False)
+            torch._addmm_activation(b, x, W_t, beta=1, alpha=1, use_gelu=True)
+
+            results = torch.cuda.tunable.get_results()
+
+            # There must be 2 new results -- one per activation type.
+            # If 0: _addmm_activation is not going through TunableOp on this platform.
+            # If 1: use_gelu=False and use_gelu=True are sharing the same CSV key (fix missing).
+            self.assertEqual(
+                len(results) - ref_num_results, 2,
+                "Expected distinct CSV keys for use_gelu=False and use_gelu=True"
+            )
+
+            # Each activation type must have its own key.
+            # Verify the 2 new param signatures are distinct.
+            new_results = results[ref_num_results:]
+            param_sigs  = [r[1] for r in new_results]
+            self.assertEqual(len(set(param_sigs)), 2,
+                             f"use_gelu=False and use_gelu=True must not share the same CSV key, "
+                             f"got: {param_sigs}")
+
     @onlyCUDA
     @setLinalgBackendsToDefaultFinally
     def test_preferred_linalg_library(self):

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -10891,9 +10891,9 @@ class TestLinalgCudaOnly(TestCase):
         with self._tunableop_ctx():
 
             M, K, N = 4, 64, 128
-            x   = torch.randn(M, K, dtype=dtype, device=device)
-            W   = torch.randn(N, K, dtype=dtype, device=device)
-            b   = torch.zeros(N,    dtype=dtype, device=device)
+            x = torch.randn(M, K, dtype=dtype, device=device)
+            W = torch.randn(N, K, dtype=dtype, device=device)
+            b = torch.zeros(N, dtype=dtype, device=device)
             W_t = W.t().contiguous()
 
             ref_num_results = len(torch.cuda.tunable.get_results())
@@ -10914,7 +10914,7 @@ class TestLinalgCudaOnly(TestCase):
             # Each activation type must have its own key.
             # Verify the 2 new param signatures are distinct.
             new_results = results[ref_num_results:]
-            param_sigs  = [r[1] for r in new_results]
+            param_sigs = [r[1] for r in new_results]
             self.assertEqual(len(set(param_sigs)), 2,
                              f"use_gelu=False and use_gelu=True must not share the same CSV key, "
                              f"got: {param_sigs}")


### PR DESCRIPTION
### Issue Description

This issue can be triggered by `torch._addmm_activation()` when called with different `use_gelu` values on the same tensor shape.

`GemmAndBiasParams` defines two signature methods:
-  `BLASSignature()` — includes activation
-  `Signature()`     — omits activation

Because `GemmAndBiasParams::Signature()` omits activation, calls with different epilogue types (e.g. use_gelu=True vs use_gelu=False) map to the same CSV key.

On ROCm, TunableOp may store a specific `Gemm_Hipblaslt_XXX` kernel in the CSV. When a key collision occurs:

  1. A kernel is tuned and selected using `use_gelu=False`
  2. A subsequent `use_gelu=True` call hits the same CSV key and gets the same kernel
  3. `HipblasltGemmOp::Call()` attempts to run that kernel with GELU epilogue
  4. If `matmulIsAlgoSupported()` fails for the replayed kernel with GELU epilogue, Call() returns FAIL silently, leaving the output buffer in an undefined state


On CUDA, `CublasltMatmulOp::Call()` rebuilds the matmul problem from params on every invocation (GemmCublaslt.h), so params->activation is correctly reflected in the matmul problem regardless of which CSV entry is matched. The fix is still applied for consistency.

### Solution Description

This commit append the activation epilogue string to `GemmAndBiasParams::Signature()` so that each (shape, activation) combination has a distinct CSV key, consistent with `GemmAndBiasParams::BLASSignature()`.

### Note
Existing TunableOp CSV files are invalidated by this change. Delete and re-tune to regenerate correct entries.