### PR TITLE
[Dynamo] Hoist static input info out of tvm exec loop

### DIFF
--- a/torch/_dynamo/backends/tvm.py
+++ b/torch/_dynamo/backends/tvm.py
@@ -157,10 +157,12 @@ def tvm(
             return tvm.nd.array(torch_tensor.cpu().numpy())
         return tvm.nd.from_dlpack(torch_tensor)
 
+    # input info is fixed at compile time, so query it once instead of per call
+    shape_info, _ = m.get_input_info()
+    active_inputs = set(shape_info.keys())
+
     def exec_tvm(*i_args: torch.Tensor) -> list[torch.Tensor]:
         args = [a.contiguous() for a in i_args]
-        shape_info, _ = m.get_input_info()
-        active_inputs = set(shape_info.keys())
         for idx, arg in enumerate(args, 0):
             if arg.dim() != 0:
                 if arg.requires_grad:


### PR DESCRIPTION
## Why

`exec_tvm` re-queries `m.get_input_info()` through TVM FFI on every forward call, but the runtime module's input info is fixed at compile time. This also re-emits the "input skipped" warning on every call.

## How

- Query `get_input_info()` once when building `exec_tvm` instead of per call

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98