### PR TITLE
[Dynamo] Use find_spec to check tvm availability

### DIFF
--- a/torch/_dynamo/backends/tvm.py
+++ b/torch/_dynamo/backends/tvm.py
@@ -21,7 +21,7 @@ The backend can be used with torch.compile():
 """
 
 import functools
-import importlib
+import importlib.util
 import logging
 import os
 import sys
@@ -191,11 +191,8 @@ tvm_auto_scheduler = functools.partial(
 
 
 def has_tvm() -> bool:
-    try:
-        importlib.import_module("tvm")
-        return True
-    except ImportError:
-        return False
+    # avoid the heavy tvm import just to check availability
+    return importlib.util.find_spec("tvm") is not None
 
 
 @functools.cache


### PR DESCRIPTION
## Why

`has_tvm()` fully imports tvm (heavy: FFI bindings, runtime) just to return a bool. It runs at test collection time via `skipIf` in `test/dynamo/test_backends.py`.

## How

- Check `importlib.util.find_spec("tvm")` instead of importing the module

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98