### PR TITLE
Reorder condition to handle empty tensor the same for file_system & file_descriptor

### DIFF
--- a/torch/multiprocessing/reductions.py
+++ b/torch/multiprocessing/reductions.py
@@ -598,6 +598,10 @@ def reduce_storage(storage):
         raise RuntimeError(
             "Cannot pickle meta storage; try pickling a meta tensor instead"
         )
+    elif storage.size() == 0:
+        # This is special cased because Empty tensors
+        # (with size 0) cannot be mmapped.
+        return (rebuild_storage_empty, (type(storage),))
     elif get_sharing_strategy() == "file_system":
         metadata = storage._share_filename_cpu_()
         cache_key = metadata[1]
@@ -605,10 +609,6 @@ def reduce_storage(storage):
         if isinstance(storage, torch.TypedStorage):
             metadata += (storage.dtype,)
         storage._shared_incref()
-    elif storage.size() == 0:
-        # This is special cased because Empty tensors
-        # (with size 0) cannot be mmapped.
-        return (rebuild_storage_empty, (type(storage),))
     else:
         fd, size = storage._share_fd_cpu_()
         df = multiprocessing.reduction.DupFd(fd)


### PR DESCRIPTION
For XPU devices, empty tensor is handled differently depends of the _sharing_strategy. For file_system test fails but for file_descriptor passed. Changing conditions order will cause that both cases will work the same for empty tensor.  XPU Windows issue: https://github.com/intel/torch-xpu-ops/issues/4068