### PR TITLE
Document pack_hook reference-cycle caveat for saved tensor hooks

### DIFF
--- a/docs/source/autograd.md
+++ b/docs/source/autograd.md
@@ -409,7 +409,9 @@ You can also define how these saved tensors should be packed / unpacked using ho
 A common application is to trade compute for memory by saving those intermediary results
 to disk or to CPU instead of leaving them on the GPU. This is especially useful if you
 notice your model fits on GPU during evaluation, but not training.
-Also see {ref}`saved-tensors-hooks-doc`.
+When writing a ``pack_hook`` that keeps its input tensor, call ``.detach()`` on it first
+to avoid a reference cycle when the saved tensor is a graph output; see
+{ref}`saved-tensors-hooks-doc` for details.
 
 ```{eval-rst}
 .. autoclass:: torch.autograd.graph.saved_tensors_hooks

--- a/docs/source/notes/autograd.md
+++ b/docs/source/notes/autograd.md
@@ -821,6 +821,29 @@ Alternatively, you can use the context-manager
 hooks which will be applied to *all* saved tensors that are created in
 that context.
 
+```{note}
+ With this context manager the input to ``pack_hook`` is a live tensor that
+ still carries its ``grad_fn`` (unlike per-tensor
+ {meth}`~torch.autograd.SavedTensor.register_hooks` above, which receives an
+ already-detached tensor). If you keep that live tensor in the object you
+ return and the saved tensor is a graph output, you form a reference cycle: the
+ output's ``grad_fn`` owns the saved tensor, which then owns a tensor referring
+ back to that same ``grad_fn``. This does not produce wrong results. Running
+ backward with ``retain_graph=False`` releases the saved tensor and breaks the
+ cycle, so memory is freed as usual; but if you build the graph without ever
+ running backward -- or use ``retain_graph=True`` -- the cycle keeps the tensor
+ alive, and because PyTorch does not expose the autograd graph to Python's
+ cyclic garbage collector (pytorch/pytorch#7343) it cannot be reclaimed even by
+ an explicit ``gc.collect()``. Calling ``.detach()`` on the input before
+ keeping it breaks the cycle, which is why the examples below do so. Detaching
+ is lossless: as noted above, PyTorch stashes the autograd metadata separately
+ and restores ``grad_fn`` on unpack, so gradients are unaffected. Hooks that
+ instead return a freshly computed tensor are unaffected -- pack hooks run with
+ gradient tracking disabled, so a tensor computed inside the hook (for example
+ moving a CUDA tensor to CPU) carries no ``grad_fn``, and the original input is
+ not retained.
+```
+
 Example:
 
 ```python


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189025

The saved-tensors-hooks docs show pack hooks calling `.detach()` on their
input but never explain why. Add a note to the "Registering default hooks
for saved tensors" section spelling out the reason and its precise semantics.

With the `saved_tensors_hooks` context manager, `pack_hook` receives a live
tensor that still carries its `grad_fn` (unlike per-tensor `register_hooks`,
which receives an already-detached tensor). Retaining that tensor when the
saved tensor is a graph output forms a reference cycle: the output's `grad_fn`
owns the SavedVariable, which would then own a tensor referring back to that
same `grad_fn`. This is exactly the cycle PyTorch's internals avoid by storing
`tensor_data()` for saved outputs (see the comment in saved_variable.cpp).

The note also corrects a subtle point about reclamation: the cycle does not
leak under a normal `backward()` (retain_graph=False releases the saved tensor
and breaks the cycle), but it is unreclaimable -- even by an explicit
gc.collect() -- when the graph is built without running backward or with
retain_graph=True, because PyTorch's tensor traverse deliberately does not walk
the autograd graph (pytorch/pytorch#7343). Detaching is lossless: autograd
stashes the grad_fn separately in save_metadata and restores it on unpack, so
first- and higher-order gradients are unaffected. Offload-style hooks that
return a freshly computed tensor are unaffected because pack hooks run with
gradient tracking disabled.

Also adds a one-line pointer from the `torch.autograd` API reference.

Test Plan: docs-only change; verified with lintrunner:

```
lintrunner -a docs/source/autograd.md docs/source/notes/autograd.md
```

Authored-with: Claude (Anthropic AI assistant)