### PR TITLE
[dynamo] Guard os.environ reads with an ambient env-var guard

### DIFF
--- a/test/dynamo/test_environ.py
+++ b/test/dynamo/test_environ.py
@@ -1,0 +1,167 @@
+# Owner(s): ["module: dynamo"]
+
+import os
+from contextlib import contextmanager
+
+import torch
+import torch._dynamo.test_case
+import torch._dynamo.testing
+
+
+@contextmanager
+def env_var(key, value):
+    old = os.environ.get(key)
+    try:
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+        yield
+    finally:
+        if old is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = old
+
+
+class EnvironTests(torch._dynamo.test_case.TestCase):
+    def _check_recompiles_on_change(self, fn, key):
+        cnt = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch.compile(fn, backend=cnt, fullgraph=True)
+        x = torch.ones(4)
+        with env_var(key, "1"):
+            self.assertEqual(opt_fn(x), x + 1)
+            self.assertEqual(opt_fn(x), x + 1)
+            self.assertEqual(cnt.frame_count, 1)
+        with env_var(key, "0"):
+            self.assertEqual(opt_fn(x), x - 1)
+            self.assertEqual(cnt.frame_count, 2)
+        with env_var(key, "1"):
+            self.assertEqual(opt_fn(x), x + 1)
+
+    def test_getenv(self):
+        def fn(x):
+            if int(os.getenv("TEST_DYNAMO_ENV_A", "0")):
+                return x + 1
+            return x - 1
+
+        self._check_recompiles_on_change(fn, "TEST_DYNAMO_ENV_A")
+
+    def test_environ_get(self):
+        def fn(x):
+            if int(os.environ.get("TEST_DYNAMO_ENV_B", "0")):
+                return x + 1
+            return x - 1
+
+        self._check_recompiles_on_change(fn, "TEST_DYNAMO_ENV_B")
+
+    def test_environ_getitem(self):
+        def fn(x):
+            if int(os.environ["TEST_DYNAMO_ENV_C"]):
+                return x + 1
+            return x - 1
+
+        self._check_recompiles_on_change(fn, "TEST_DYNAMO_ENV_C")
+
+    def test_environ_contains(self):
+        def fn(x):
+            if "TEST_DYNAMO_ENV_D" in os.environ:
+                return x + 1
+            return x - 1
+
+        cnt = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch.compile(fn, backend=cnt, fullgraph=True)
+        x = torch.ones(4)
+        with env_var("TEST_DYNAMO_ENV_D", None):
+            self.assertEqual(opt_fn(x), x - 1)
+            self.assertEqual(cnt.frame_count, 1)
+        with env_var("TEST_DYNAMO_ENV_D", "anything"):
+            self.assertEqual(opt_fn(x), x + 1)
+            self.assertEqual(cnt.frame_count, 2)
+
+    def test_getenv_missing_then_set(self):
+        def fn(x):
+            return x + int(os.getenv("TEST_DYNAMO_ENV_E", "0"))
+
+        cnt = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch.compile(fn, backend=cnt, fullgraph=True)
+        x = torch.ones(4)
+        with env_var("TEST_DYNAMO_ENV_E", None):
+            self.assertEqual(opt_fn(x), x)
+            self.assertEqual(cnt.frame_count, 1)
+        with env_var("TEST_DYNAMO_ENV_E", "3"):
+            self.assertEqual(opt_fn(x), x + 3)
+            self.assertEqual(cnt.frame_count, 2)
+
+    def test_getenv_no_default(self):
+        def fn(x):
+            if os.getenv("TEST_DYNAMO_ENV_F") is None:
+                return x - 1
+            return x + 1
+
+        cnt = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch.compile(fn, backend=cnt, fullgraph=True)
+        x = torch.ones(4)
+        with env_var("TEST_DYNAMO_ENV_F", None):
+            self.assertEqual(opt_fn(x), x - 1)
+        with env_var("TEST_DYNAMO_ENV_F", "1"):
+            self.assertEqual(opt_fn(x), x + 1)
+            self.assertEqual(cnt.frame_count, 2)
+
+    def test_environ_get_non_str_default(self):
+        def fn(x):
+            return x + int(os.environ.get("TEST_DYNAMO_ENV_G", 2))
+
+        cnt = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch.compile(fn, backend=cnt, fullgraph=True)
+        x = torch.ones(4)
+        with env_var("TEST_DYNAMO_ENV_G", None):
+            self.assertEqual(opt_fn(x), x + 2)
+        with env_var("TEST_DYNAMO_ENV_G", "1"):
+            self.assertEqual(opt_fn(x), x + 1)
+            self.assertEqual(cnt.frame_count, 2)
+
+    def test_env_change_during_compile(self):
+        # The backend compiler runs between tracing and guard construction
+        # and may itself set env vars (inductor does). ENV_MATCH compares
+        # against the trace-time snapshot carried by EnvVarSource, so a
+        # mid-compile mutation of a guarded variable fails the same-frame
+        # guard sanity check loudly instead of revalidating a stale graph
+        # forever (which is what re-reading os.environ at guard-construction
+        # time used to do).
+        def fn(x):
+            if int(os.getenv("TEST_DYNAMO_ENV_I", "0")):
+                return x + 1
+            return x - 1
+
+        def mutating_backend(gm, example_inputs):
+            os.environ["TEST_DYNAMO_ENV_I"] = "1"
+            return gm.forward
+
+        opt_fn = torch.compile(fn, backend=mutating_backend, fullgraph=True)
+        x = torch.ones(4)
+        with env_var("TEST_DYNAMO_ENV_I", None):
+            with self.assertRaisesRegex(
+                AssertionError, "Guard failed on the same frame"
+            ):
+                opt_fn(x)
+
+    def test_environ_getitem_missing_raises(self):
+        def fn(x):
+            return x + int(os.environ["TEST_DYNAMO_ENV_H"])
+
+        # Not fullgraph: an exception escaping the compiled region is a graph
+        # break by design, same as for a plain dict.
+        opt_fn = torch.compile(fn, backend="eager")
+        x = torch.ones(4)
+        with env_var("TEST_DYNAMO_ENV_H", None):
+            with self.assertRaises(KeyError):
+                opt_fn(x)
+        with env_var("TEST_DYNAMO_ENV_H", "2"):
+            self.assertEqual(opt_fn(x), x + 2)
+
+
+if __name__ == "__main__":
+    from torch._dynamo.test_case import run_tests
+
+    run_tests()

--- a/test/dynamo/test_environ.py
+++ b/test/dynamo/test_environ.py
@@ -78,6 +78,11 @@ class EnvironTests(torch._dynamo.test_case.TestCase):
         with env_var("TEST_DYNAMO_ENV_D", "anything"):
             self.assertEqual(opt_fn(x), x + 1)
             self.assertEqual(cnt.frame_count, 2)
+        # ENV_CONTAINS guards on presence only: changing the value of a set
+        # variable does not recompile a graph that only tested membership.
+        with env_var("TEST_DYNAMO_ENV_D", "something_else"):
+            self.assertEqual(opt_fn(x), x + 1)
+            self.assertEqual(cnt.frame_count, 2)
 
     def test_getenv_missing_then_set(self):
         def fn(x):

--- a/test/dynamo/test_environ.py
+++ b/test/dynamo/test_environ.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 import torch
 import torch._dynamo.test_case
 import torch._dynamo.testing
+from torch.testing._internal.logging_utils import logs_to_string
 
 
 @contextmanager
@@ -62,6 +63,32 @@ class EnvironTests(torch._dynamo.test_case.TestCase):
             return x - 1
 
         self._check_recompiles_on_change(fn, "TEST_DYNAMO_ENV_C")
+
+    def _guard_log(self, fn, key, value):
+        log_stream, ctx = logs_to_string("torch._dynamo.guards", "guards")
+        with env_var(key, value), ctx():
+            opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+            opt_fn(torch.ones(4))
+        return log_stream.getvalue()
+
+    def test_environ_read_guards_are_ambient(self):
+        # Pin the guard, not the recompile: the old environ._data path also
+        # recompiles, so a frame-count test cannot tell the two apart. Each of
+        # the three read paths needs its own hook (subscript in particular
+        # dispatches through mp_subscript, which never reaches call_method).
+        def getitem_fn(x):
+            return x + int(os.environ["TEST_DYNAMO_ENV_J"])
+
+        def getenv_fn(x):
+            return x + int(os.getenv("TEST_DYNAMO_ENV_J", "0"))
+
+        def get_fn(x):
+            return x + int(os.environ.get("TEST_DYNAMO_ENV_J", "0"))
+
+        for fn in (getitem_fn, getenv_fn, get_fn):
+            guard_log = self._guard_log(fn, "TEST_DYNAMO_ENV_J", "1")
+            self.assertIn("environ.get('TEST_DYNAMO_ENV_J')", guard_log)
+            self.assertNotIn("environ._data", guard_log)
 
     def test_environ_contains(self):
         def fn(x):

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -136,6 +136,7 @@ from .source import (
     DictGetItemSource,
     DictSubclassGetItemSource,
     DynamicScalarSource,
+    EnvVarSource,
     FlattenScriptObjectSource,
     FloatTensorSource,
     FSDPNNModuleSource,
@@ -2590,6 +2591,7 @@ class GuardBuilder(GuardBuilderBase):
     @skip_guard_check_spec
     def ENV_MATCH(self, guard: Guard) -> None:
         source = guard.originating_source
+        assert isinstance(source, EnvVarSource)
         key = source.key
         value = source.value
         code = f"{source.name} == {value!r}"

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -29,6 +29,7 @@ import io
 import itertools
 import logging
 import math
+import os
 import pickle
 import sys
 import textwrap
@@ -2577,6 +2578,31 @@ class GuardBuilder(GuardBuilderBase):
 
         self.guard_manager.root.add_lambda_guard(
             fn, get_verbose_code_parts(code, guard), guard.user_stack
+        )
+
+    # Ambient environment-variable guard - not source-specific, checked
+    # separately at runtime. Installed when a read of os.environ (os.getenv,
+    # os.environ.get, subscript, "in") is baked into the graph as a constant;
+    # recompiles if the variable's value changes. The expected value is the
+    # trace-time snapshot carried by EnvVarSource - do not re-read os.environ
+    # here: guards are built after the backend compiler runs (which can set
+    # env vars) and re-run from serialized state on precompile load.
+    @skip_guard_check_spec
+    def ENV_MATCH(self, guard: Guard) -> None:
+        source = guard.originating_source
+        key = source.key
+        value = source.value
+        code = f"{source.name} == {value!r}"
+        if code in self.already_added_code_parts:
+            return
+        self.already_added_code_parts.add(code)
+        self._set_guard_export_info(guard, [code])
+
+        def fn(x: Any) -> bool:
+            return os.environ.get(key) == value
+
+        self.guard_manager.root.add_lambda_guard(
+            fn, get_verbose_code_parts([code], guard), guard.user_stack
         )
 
     # Global state guard — not source-specific, checked separately at runtime.

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -2591,7 +2591,8 @@ class GuardBuilder(GuardBuilderBase):
     @skip_guard_check_spec
     def ENV_MATCH(self, guard: Guard) -> None:
         source = guard.originating_source
-        assert isinstance(source, EnvVarSource)
+        if not isinstance(source, EnvVarSource):
+            raise AssertionError(f"ENV_MATCH expects EnvVarSource, got {type(source)}")
         key = source.key
         value = source.value
         code = f"{source.name} == {value!r}"
@@ -2602,6 +2603,34 @@ class GuardBuilder(GuardBuilderBase):
 
         def fn(x: Any) -> bool:
             return os.environ.get(key) == value
+
+        self.guard_manager.root.add_lambda_guard(
+            fn, get_verbose_code_parts([code], guard), guard.user_stack
+        )
+
+    # Weaker sibling of ENV_MATCH for ``key in os.environ``: guards only on the
+    # variable's presence, not its value, so changing the value of a variable
+    # that is already set does not recompile a graph that only tested
+    # membership. Like ENV_MATCH, the presence is taken from the trace-time
+    # snapshot carried by EnvVarSource (value is None iff unset) - do not
+    # re-read os.environ here.
+    @skip_guard_check_spec
+    def ENV_CONTAINS(self, guard: Guard) -> None:
+        source = guard.originating_source
+        if not isinstance(source, EnvVarSource):
+            raise AssertionError(
+                f"ENV_CONTAINS expects EnvVarSource, got {type(source)}"
+            )
+        key = source.key
+        present = source.value is not None
+        code = f"({source.name} is not None) == {present!r}"
+        if code in self.already_added_code_parts:
+            return
+        self.already_added_code_parts.add(code)
+        self._set_guard_export_info(guard, [code])
+
+        def fn(x: Any) -> bool:
+            return (os.environ.get(key) is not None) == present
 
         self.guard_manager.root.add_lambda_guard(
             fn, get_verbose_code_parts([code], guard), guard.user_stack

--- a/torch/_dynamo/source.py
+++ b/torch/_dynamo/source.py
@@ -1094,6 +1094,32 @@ class GlobalStateSource(Source):
 
 
 @dataclass_with_cached_hash(frozen=True)
+class EnvVarSource(Source):
+    """Ambient source for a process environment variable read (``os.getenv``,
+    ``os.environ.get``, subscript or ``in`` on ``os.environ``). ``value`` is
+    the variable's value observed at trace time (None if unset), which is
+    baked into the graph as a constant and guarded by
+    ``GuardBuilder.ENV_MATCH`` so that a change to the variable at runtime
+    triggers a recompile. Carrying the traced value here (instead of
+    re-reading os.environ when guards are built) keeps the guard in sync with
+    the graph even if the environment mutates during backend compilation, and
+    keeps it correct across guard serialization. The name uses ``__import__``
+    so it stays eval-able in scopes that don't have ``os`` imported (e.g.
+    guard export)."""
+
+    key: str = ""
+    value: str | None = None
+
+    @functools.cached_property
+    def _name_template(self) -> str:
+        return f"__import__('os').environ.get({self.key!r})"
+
+    @property
+    def guard_source(self) -> GuardSource:
+        return GuardSource.GLOBAL
+
+
+@dataclass_with_cached_hash(frozen=True)
 class ImportSource(Source):
     """Points to an imported module - used instead of GlobalSource
     in case the user has overridden the module name in their local namespace"""

--- a/torch/_dynamo/source.py
+++ b/torch/_dynamo/source.py
@@ -1099,7 +1099,8 @@ class EnvVarSource(Source):
     ``os.environ.get``, subscript or ``in`` on ``os.environ``). ``value`` is
     the variable's value observed at trace time (None if unset), which is
     baked into the graph as a constant and guarded by
-    ``GuardBuilder.ENV_MATCH`` so that a change to the variable at runtime
+    ``GuardBuilder.ENV_MATCH`` (value reads) or ``GuardBuilder.ENV_CONTAINS``
+    (presence only, for ``in``) so that a change to the variable at runtime
     triggers a recompile. Carrying the traced value here (instead of
     re-reading os.environ when guards are built) keeps the guard in sync with
     the graph even if the environment mutates during backend compilation, and
@@ -1107,8 +1108,8 @@ class EnvVarSource(Source):
     so it stays eval-able in scopes that don't have ``os`` imported (e.g.
     guard export)."""
 
-    key: str = ""
-    value: str | None = None
+    key: str
+    value: str | None
 
     @functools.cached_property
     def _name_template(self) -> str:

--- a/torch/_dynamo/variables/__init__.py
+++ b/torch/_dynamo/variables/__init__.py
@@ -183,6 +183,7 @@ from .tensor import (
 from .torch import TorchCtxManagerClassVariable, TorchInGraphFunctionVariable
 from .user_defined import (
     DefaultDictVariable,
+    EnvironVariable,
     FrozenDataClassVariable,
     InspectVariable,
     MutableMappingVariable,
@@ -230,6 +231,7 @@ __all__ = [
     "DictBuiltinVariable",
     "DictKeySetVariable",
     "DynamoConfigPatchVariable",
+    "EnvironVariable",
     "ErrorOnGraphBreakVariable",
     "FakeItemVariable",
     "get_device_context_manager",

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -314,6 +314,7 @@ from .torch_function import (
 )
 from .user_defined import (
     DefaultDictVariable,
+    EnvironVariable,
     FrozenDataClassVariable,
     InspectVariable,
     IntWrapperVariable,
@@ -2225,7 +2226,10 @@ class VariableBuilder:
             return self.tx.output.side_effects.track_object_existing(value, result)
         elif issubclass(type(value), MutableMapping):
             self.install_guards(GuardBuilder.TYPE_MATCH)
-            result = MutableMappingVariable(value, source=self.source)
+            if EnvironVariable.is_matching_object(value):
+                result = EnvironVariable(value, source=self.source)
+            else:
+                result = MutableMappingVariable(value, source=self.source)
             return self.tx.output.side_effects.track_object_existing(value, result)
         elif is_frozen_dataclass(value):
             self.install_guards(GuardBuilder.TYPE_MATCH)

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -5595,10 +5595,13 @@ class EnvironVariable(MutableMappingVariable):
     """Handles the ``os.environ`` singleton.
 
     Reads with constant string keys (``get``, ``__getitem__``,
-    ``__contains__``) are constant-folded at trace time and guarded by the
-    ambient ``GuardBuilder.ENV_MATCH`` guard (via ``EnvVarSource``) so that a
-    runtime change to the variable triggers a recompile. Reads funnel through
-    three hooks: subscript via ``mp_subscript_impl``, ``in`` via
+    ``__contains__``) are constant-folded at trace time and guarded via an
+    ambient ``EnvVarSource`` guard so that a runtime change to the variable
+    triggers a recompile: value reads install ``GuardBuilder.ENV_MATCH``
+    (guards on the value), while ``in`` installs the weaker
+    ``GuardBuilder.ENV_CONTAINS`` (guards only on presence, so changing the
+    value of a set variable does not recompile a membership test). Reads
+    funnel through three hooks: subscript via ``mp_subscript_impl``, ``in`` via
     ``sq_contains``, and ``environ.get``/``environ.__getitem__`` attribute
     calls (including ``os.getenv``, which inlines ``environ.get``) via
     ``getattro_impl``.
@@ -5643,14 +5646,16 @@ class EnvironVariable(MutableMappingVariable):
         self, tx: "InstructionTranslatorBase", name: str
     ) -> VariableTracker:
         if name in ("get", "__getitem__"):
-            return variables.LambdaVariable(
-                lambda *args, **kwargs: self.call_method(tx, name, list(args), kwargs)
-            )
+            return variables.CallMethodVariable(self, name)
         return super().getattro_impl(tx, name)
 
     def mp_subscript_impl(
         self, tx: "InstructionTranslatorBase", key: VariableTracker
     ) -> VariableTracker:
+        # Load-bearing: without this, os.environ["X"] falls back to inlining
+        # os._Environ.__getitem__, whose self._data read takes the sourced-dict
+        # guard path this class exists to avoid. Routing through call_method
+        # guards it via the ambient ENV_MATCH like the other reads.
         return self.call_method(tx, "__getitem__", [key], {})
 
     def sq_contains(
@@ -5661,7 +5666,9 @@ class EnvironVariable(MutableMappingVariable):
         if item.is_python_constant() and isinstance(item.as_python_constant(), str):
             key = item.as_python_constant()
             value = os.environ.get(key)
-            install_guard(EnvVarSource(key, value).make_guard(GuardBuilder.ENV_MATCH))
+            install_guard(
+                EnvVarSource(key, value).make_guard(GuardBuilder.ENV_CONTAINS)
+            )
             return ConstantVariable.create(value is not None)
         return super().sq_contains(tx, item)
 

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -29,6 +29,7 @@ import dataclasses
 import enum
 import functools
 import inspect
+import os
 import random
 import sys
 import threading
@@ -65,6 +66,7 @@ from ..source import (
     AttrSource,
     CallFunctionNoArgsSource,
     DictGetItemSource,
+    EnvVarSource,
     EphemeralSource,
     GetItemSource,
     RandomValueSource,
@@ -5587,6 +5589,81 @@ class MutableMappingVariable(UserDefinedObjectVariable):
         if self._maybe_get_baseclass_method("__len__") in dict_methods:
             return VariableTracker.build(tx, len(self.value))  # type: ignore[bad-argument-type]
         return super().mp_length(tx)
+
+
+class EnvironVariable(MutableMappingVariable):
+    """Handles the ``os.environ`` singleton.
+
+    Reads with constant string keys (``get``, ``__getitem__``,
+    ``__contains__``) are constant-folded at trace time and guarded by the
+    ambient ``GuardBuilder.ENV_MATCH`` guard (via ``EnvVarSource``) so that a
+    runtime change to the variable triggers a recompile. Reads funnel through
+    three hooks: subscript via ``mp_subscript_impl``, ``in`` via
+    ``sq_contains``, and ``environ.get``/``environ.__getitem__`` attribute
+    calls (including ``os.getenv``, which inlines ``environ.get``) via
+    ``getattro_impl``.
+
+    Anything else (mutation, iteration, non-constant keys) falls back to
+    regular ``MutableMappingVariable`` tracing of ``os._Environ``.
+    """
+
+    @staticmethod
+    def is_matching_object(obj: object) -> bool:
+        return obj is os.environ
+
+    def call_method(
+        self,
+        tx: "InstructionTranslatorBase",
+        name: str,
+        args: list[Any],
+        kwargs: dict[str, Any],
+    ) -> VariableTracker:
+        from .constant import ConstantVariable
+
+        if (
+            name in ("get", "__getitem__")
+            and not kwargs
+            and (len(args) == 1 or (name == "get" and len(args) == 2))
+            and args[0].is_python_constant()
+            and isinstance(args[0].as_python_constant(), str)
+        ):
+            key = args[0].as_python_constant()
+            value = os.environ.get(key)
+            install_guard(EnvVarSource(key, value).make_guard(GuardBuilder.ENV_MATCH))
+            if value is not None:
+                return ConstantVariable.create(value)
+            if name == "get":
+                return args[1] if len(args) == 2 else ConstantVariable.create(None)
+            # Missing key: the guard installed above forces a recompile if the
+            # variable appears later; for now raise like ``dict.__getitem__``.
+            raise_observed_exception(KeyError, tx, args=[key])
+        return super().call_method(tx, name, args, kwargs)
+
+    def getattro_impl(
+        self, tx: "InstructionTranslatorBase", name: str
+    ) -> VariableTracker:
+        if name in ("get", "__getitem__"):
+            return variables.LambdaVariable(
+                lambda *args, **kwargs: self.call_method(tx, name, list(args), kwargs)
+            )
+        return super().getattro_impl(tx, name)
+
+    def mp_subscript_impl(
+        self, tx: "InstructionTranslatorBase", key: VariableTracker
+    ) -> VariableTracker:
+        return self.call_method(tx, "__getitem__", [key], {})
+
+    def sq_contains(
+        self, tx: "InstructionTranslatorBase", item: VariableTracker
+    ) -> VariableTracker:
+        from .constant import ConstantVariable
+
+        if item.is_python_constant() and isinstance(item.as_python_constant(), str):
+            key = item.as_python_constant()
+            value = os.environ.get(key)
+            install_guard(EnvVarSource(key, value).make_guard(GuardBuilder.ENV_MATCH))
+            return ConstantVariable.create(value is not None)
+        return super().sq_contains(tx, item)
 
 
 class RandomVariable(UserDefinedObjectVariable):


### PR DESCRIPTION
## Problem

`os.getenv` results are baked into compiled graphs as constants **with no guard**. This compiles under `fullgraph=True` and then never recompiles when the variable changes, silently returning stale results:

```python
os.environ["FLAG"] = "1"

@torch.compile(fullgraph=True)
def f(x):
    if int(os.getenv("FLAG", "0")):
        return x + 1
    return x - 1

f(x)                       # x + 1, compiles once
os.environ["FLAG"] = "0"
f(x)                       # still returns x + 1 forever, no recompile
```

## Root cause

Dynamo inlines `os.getenv -> environ.get -> _Environ.__getitem__`, and that inlining *does* produce value guards (per-key `EQUALS_MATCH` on `environ._data`). But [`InliningInstructionTranslator.get_globals_source_and_value`](https://github.com/pytorch/pytorch/blob/885cf52c2b7a1195abaa954bf786b9f5cfedfa60/torch/_dynamo/symbolic_convert.py#L6232-L6262) wraps globals of inlined stdlib functions in [`SkipGuardSource`](https://github.com/pytorch/pytorch/blob/885cf52c2b7a1195abaa954bf786b9f5cfedfa60/torch/_dynamo/source.py#L513) ("users don't inplace mutate a stdlib attribute"), and `os.getenv` reads `environ` as a global of the stdlib `os` module - so every guard derived from that access path is dropped. `os.environ` is the counterexample to the skip's assumption: the attribute is never rebound, but its *contents* mutate at runtime.

Direct reads like `os.environ.get("FLAG")` in user code were unaffected (their guards derive from the user frame), which made the `os.getenv` hole easy to miss.

## Fix

Represent `os.environ` with a dedicated [`EnvironVariable`](https://github.com/pggPL/pytorch/blob/cc88b32addd9fe722a0774bc696fb722df55c844/torch/_dynamo/variables/user_defined.py#L5594-L5668) (a [`MutableMappingVariable`](https://github.com/pytorch/pytorch/blob/885cf52c2b7a1195abaa954bf786b9f5cfedfa60/torch/_dynamo/variables/user_defined.py#L5533) subclass, selected when [`VariableBuilder` wraps the `os.environ` singleton](https://github.com/pggPL/pytorch/blob/cc88b32addd9fe722a0774bc696fb722df55c844/torch/_dynamo/variables/builder.py#L2227-L2233)). Reads with constant string keys are constant-folded at trace time and protected by a new ambient guard [`GuardBuilder.ENV_MATCH`](https://github.com/pggPL/pytorch/blob/cc88b32addd9fe722a0774bc696fb722df55c844/torch/_dynamo/guards.py#L2583-L2606) (via [`EnvVarSource`](https://github.com/pggPL/pytorch/blob/cc88b32addd9fe722a0774bc696fb722df55c844/torch/_dynamo/source.py#L1096-L1115)) - a root-level lambda that compares `os.environ.get(key)` on entry against the trace-time snapshot carried by `EnvVarSource`, mirroring the other ambient/global-state guards. Because the guard hangs off a fresh `EnvVarSource` rather than the access path, `SkipGuardSource` cannot drop it.

Reads funnel through three hooks: `mp_subscript_impl` (subscript), `sq_contains` (`in`), and `getattro_impl` for `get`/`__getitem__` attribute calls - which covers both `os.environ.get` and `os.getenv` (both bottom out in `Mapping.get` / the [`mapping_get` polyfill](https://github.com/pytorch/pytorch/blob/885cf52c2b7a1195abaa954bf786b9f5cfedfa60/torch/_dynamo/polyfills/__init__.py#L359-L363) calling `obj.__getitem__`). Mutation, iteration and non-constant keys fall back to regular `MutableMapping` tracing.

Guards before (only for the paths that worked at all, i.e. direct `os.environ.get`):

```
+- GuardManager: source=G['os'].environ._data ... EQUALS_MATCH: G['os'].environ._data[b'FLAG'] == b'1'
+- ... ID_MATCH on encodekey.__code__, decodevalue.__code__, EQUALS_MATCH on closure 'utf-8', ...
```

Guards after (all read paths, including `os.getenv`):

```
+- LAMBDA_GUARD: __import__('os').environ.get('FLAG', None) == '1'
```

## Test plan

New [`test/dynamo/test_environ.py`](https://github.com/pggPL/pytorch/blob/cc88b32addd9fe722a0774bc696fb722df55c844/test/dynamo/test_environ.py) covers every read path, recompilation on change/appear/unset, non-str defaults, and `KeyError` on missing subscript:

```
python test/dynamo/test_environ.py
```

Regression suites run against this patch (torch nightly 2.14.0.dev20260705+cpu): `pytest test/dynamo/test_dicts.py` (320 passed / 1 xfailed) and `pytest test/dynamo/test_functions.py test/dynamo/test_len_protocol.py test/dynamo/test_tp_slots.py test/dynamo/test_misc.py -k "mapping or environ or getenv or Mapping"` (31 passed).

This PR was authored with the assistance of an AI coding tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98
