### PR TITLE
[HOP] Moved branch clamping to user surface for switch

### DIFF
--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -6125,10 +6125,11 @@ class TestControlFlowTraced(TestCase):
 def forward(self, L_inp_x_ : torch.Tensor, L_idx_ : torch.Tensor):
     l_inp_x_ = L_inp_x_
     l_idx_ = L_idx_
+    index = l_idx_.clamp(0, 2);  l_idx_ = None
     switch_branch0_0 = self.switch_branch0_0
     switch_branch1_0 = self.switch_branch1_0
     switch_branch2_0 = self.switch_branch2_0
-    switch = torch.ops.higher_order.switch(l_idx_, [switch_branch0_0, switch_branch1_0, switch_branch2_0], (l_inp_x_,));  l_idx_ = switch_branch0_0 = switch_branch1_0 = switch_branch2_0 = l_inp_x_ = None
+    switch = torch.ops.higher_order.switch(index, [switch_branch0_0, switch_branch1_0, switch_branch2_0], (l_inp_x_,));  index = switch_branch0_0 = switch_branch1_0 = switch_branch2_0 = l_inp_x_ = None
     getitem = switch[0];  switch = None
     return (getitem,)""",
         )
@@ -6197,10 +6198,11 @@ def forward(self, L_inp_x_ : torch.Tensor, L_idx_ : torch.Tensor, L_branch0_clos
     l_branch0_closure_0_cell_contents = L_branch0_closure_0_cell_contents
     l_branch1_closure_0_cell_contents = L_branch1_closure_0_cell_contents
     l_branch2_closure_0_cell_contents = L_branch2_closure_0_cell_contents
+    index = l_idx_.clamp(0, 2);  l_idx_ = None
     switch_branch0_0 = self.switch_branch0_0
     switch_branch1_0 = self.switch_branch1_0
     switch_branch2_0 = self.switch_branch2_0
-    switch = torch.ops.higher_order.switch(l_idx_, [switch_branch0_0, switch_branch1_0, switch_branch2_0], (l_inp_x_, l_branch0_closure_0_cell_contents, l_branch1_closure_0_cell_contents, l_branch2_closure_0_cell_contents));  l_idx_ = switch_branch0_0 = switch_branch1_0 = switch_branch2_0 = l_inp_x_ = l_branch0_closure_0_cell_contents = l_branch1_closure_0_cell_contents = l_branch2_closure_0_cell_contents = None
+    switch = torch.ops.higher_order.switch(index, [switch_branch0_0, switch_branch1_0, switch_branch2_0], (l_inp_x_, l_branch0_closure_0_cell_contents, l_branch1_closure_0_cell_contents, l_branch2_closure_0_cell_contents));  index = switch_branch0_0 = switch_branch1_0 = switch_branch2_0 = l_inp_x_ = l_branch0_closure_0_cell_contents = l_branch1_closure_0_cell_contents = l_branch2_closure_0_cell_contents = None
     getitem = switch[0];  switch = None
     return (getitem,)""",
         )
@@ -6366,9 +6368,10 @@ def forward(self, L_inp_x_ : torch.Tensor, L_idx_ : torch.Tensor, L_linear0_para
     l_linear0_parameters_bias_ = L_linear0_parameters_bias_
     l_linear1_parameters_weight_ = L_linear1_parameters_weight_
     l_linear1_parameters_bias_ = L_linear1_parameters_bias_
+    index = l_idx_.clamp(0, 1);  l_idx_ = None
     switch_branch0_0 = self.switch_branch0_0
     switch_branch1_0 = self.switch_branch1_0
-    switch = torch.ops.higher_order.switch(l_idx_, [switch_branch0_0, switch_branch1_0], (l_inp_x_, l_linear0_parameters_bias_, l_linear0_parameters_weight_, l_linear1_parameters_bias_, l_linear1_parameters_weight_));  l_idx_ = switch_branch0_0 = switch_branch1_0 = l_inp_x_ = l_linear0_parameters_bias_ = l_linear0_parameters_weight_ = l_linear1_parameters_bias_ = l_linear1_parameters_weight_ = None
+    switch = torch.ops.higher_order.switch(index, [switch_branch0_0, switch_branch1_0], (l_inp_x_, l_linear0_parameters_bias_, l_linear0_parameters_weight_, l_linear1_parameters_bias_, l_linear1_parameters_weight_));  index = switch_branch0_0 = switch_branch1_0 = l_inp_x_ = l_linear0_parameters_bias_ = l_linear0_parameters_weight_ = l_linear1_parameters_bias_ = l_linear1_parameters_weight_ = None
     getitem = switch[0];  switch = None
     return (getitem,)""",
         )

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -1849,6 +1849,7 @@ def forward(self, pred_1, x_1):
         # Clamped above-range index picks branch N-1.
         self.assertEqual(f_huge(x), branch2(x))
 
+    @skipIfTorchDynamo("mark_dynamic cannot be traced under dynamo_wrapped")
     def test_switch_symint_index_clamped(self):
         def branch0(inp_x):
             return inp_x.sin()

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -1849,6 +1849,36 @@ def forward(self, pred_1, x_1):
         # Clamped above-range index picks branch N-1.
         self.assertEqual(f_huge(x), branch2(x))
 
+    def test_switch_symint_index_clamped(self):
+        def branch0(inp_x):
+            return inp_x.sin()
+
+        def branch1(inp_x):
+            return inp_x.cos()
+
+        def branch2(inp_x):
+            return inp_x.abs()
+
+        branches = (branch0, branch1, branch2)
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def f(idx_carrier, inp_x):
+            idx = idx_carrier.shape[0] - 5
+            return switch(idx, branches, (inp_x,))
+
+        x = torch.randn(4)
+
+        # shape[0] - 5 is negative -> clamps to branch0.
+        idx_carrier = torch.zeros(2)
+        torch._dynamo.mark_dynamic(idx_carrier, 0)
+        self.assertEqual(f(idx_carrier, x), branch0(x))
+
+        # shape[0] - 5 == 3 (above range) -> clamps to branch2.
+        torch._dynamo.reset()
+        idx_carrier = torch.zeros(8)
+        torch._dynamo.mark_dynamic(idx_carrier, 0)
+        self.assertEqual(f(idx_carrier, x), branch2(x))
+
     def test_switch_nn_module_branches(self):
         # Each branch is a different nn.Module whose parameters are
         # captured as free variables. Dynamo must lift the parameters of

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -2639,8 +2639,11 @@ class SwitchHigherOrderVariable(TorchHigherOrderOperatorVariable):
             )
             idx = index.as_python_constant()
             branch_fns = branches.unpack_var_sequence(tx)
-            clamped = min(max(0, idx), len(branch_fns) - 1)
-            return branch_fns[clamped].call_function(
+            if not 0 <= idx < len(branch_fns):
+                raise AssertionError(
+                    f"switch index {idx} out of range for {len(branch_fns)} branches"
+                )
+            return branch_fns[idx].call_function(
                 tx, operands.unpack_var_sequence(tx), {}
             )
 

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -2607,6 +2607,8 @@ class SwitchHigherOrderVariable(TorchHigherOrderOperatorVariable):
         args: Sequence[VariableTracker],
         kwargs: dict[str, VariableTracker],
     ) -> VariableTracker:
+        from torch._higher_order_ops.switch import _get_branch
+
         from . import ListVariable
 
         args, kwargs = LazyVariableTracker.realize_all((args, kwargs))
@@ -2639,11 +2641,7 @@ class SwitchHigherOrderVariable(TorchHigherOrderOperatorVariable):
             )
             idx = index.as_python_constant()
             branch_fns = branches.unpack_var_sequence(tx)
-            if not 0 <= idx < len(branch_fns):
-                raise AssertionError(
-                    f"switch index {idx} out of range for {len(branch_fns)} branches"
-                )
-            return branch_fns[idx].call_function(
+            return _get_branch(branch_fns, idx).call_function(
                 tx, operands.unpack_var_sequence(tx), {}
             )
 

--- a/torch/_higher_order_ops/switch.py
+++ b/torch/_higher_order_ops/switch.py
@@ -95,6 +95,14 @@ def wrap_branch_fn_flat(*args, branch_fn, spec_operands):
     return branch_fn(*operands)
 
 
+def _get_branch(branches, idx):
+    if not 0 <= idx < len(branches):
+        raise AssertionError(
+            f"switch index {idx} out of range for {len(branches)} branches"
+        )
+    return branches[idx]
+
+
 @exposed_in("torch")
 def switch(
     index: int | torch.SymInt | torch.Tensor,
@@ -189,7 +197,7 @@ def switch(
     elif isinstance(index, torch.SymInt):
         index = torch.sym_max(0, torch.sym_min(index, num_branches - 1))
     elif isinstance(index, int):
-        index = min(max(0, index), num_branches - 1)
+        index = max(0, min(index, num_branches - 1))
 
     # Constant index shortcut for eager mode.
     if not torch.compiler.is_dynamo_compiling() and isinstance(index, int):
@@ -203,7 +211,7 @@ def switch(
                 stacklevel=2,
             )
 
-        return wrapped_branches[index](*leaves_operands)
+        return _get_branch(wrapped_branches, index)(*leaves_operands)
 
     # Use _maybe_compile_and_run_fn pattern from scan/associative_scan
     def run_switch(index, wrapped_branches, leaves_operands):
@@ -267,13 +275,7 @@ def switch_op_dense(index, branches, operands):
     if mode is not None:
         raise AssertionError("Mode should never be enabled for CPU/CUDA key")
     idx: int = int(index.item()) if isinstance(index, torch.Tensor) else int(index)
-    # torch.switch is the only supported entry point and clamps index into range;
-    # a direct HOP invocation with an out-of-range index is a caller error.
-    if not 0 <= idx < len(branches):
-        raise AssertionError(
-            f"switch index {idx} out of range for {len(branches)} branches"
-        )
-    return branches[idx](*operands)
+    return _get_branch(branches, idx)(*operands)
 
 
 @switch_op.py_autograd_impl

--- a/torch/_higher_order_ops/switch.py
+++ b/torch/_higher_order_ops/switch.py
@@ -97,7 +97,7 @@ def wrap_branch_fn_flat(*args, branch_fn, spec_operands):
 
 @exposed_in("torch")
 def switch(
-    index: int | torch.Tensor,
+    index: int | torch.SymInt | torch.Tensor,
     branches: tuple[Callable, ...] | list[Callable],
     operands: tuple | list = (),
 ) -> Any:
@@ -179,8 +179,17 @@ def switch(
     )
 
     # Early shortcut: single-branch switch degenerates to a plain call
-    if len(wrapped_branches) == 1:
+    num_branches = len(wrapped_branches)
+    if num_branches == 1:
         return wrapped_branches[0](*leaves_operands)
+
+    # Clamp out-of-range indices to [0, len(branches) - 1]
+    if isinstance(index, torch.Tensor):
+        index = index.clamp(0, num_branches - 1)
+    elif isinstance(index, torch.SymInt):
+        index = torch.sym_max(0, torch.sym_min(index, num_branches - 1))
+    elif isinstance(index, int):
+        index = min(max(0, index), num_branches - 1)
 
     # Constant index shortcut for eager mode.
     if not torch.compiler.is_dynamo_compiling() and isinstance(index, int):
@@ -194,9 +203,7 @@ def switch(
                 stacklevel=2,
             )
 
-        # Clamp out-of-range indices rather than raising for consistency with compiled behavior.
-        clamped_index = min(max(0, index), len(wrapped_branches) - 1)
-        return wrapped_branches[clamped_index](*leaves_operands)
+        return wrapped_branches[index](*leaves_operands)
 
     # Use _maybe_compile_and_run_fn pattern from scan/associative_scan
     def run_switch(index, wrapped_branches, leaves_operands):
@@ -260,9 +267,8 @@ def switch_op_dense(index, branches, operands):
     if mode is not None:
         raise AssertionError("Mode should never be enabled for CPU/CUDA key")
     idx: int = int(index.item()) if isinstance(index, torch.Tensor) else int(index)
-    # Clamp out-of-range indices rather than raising for consistency with compiled behavior.
-    clamped_idx = min(max(0, idx), len(branches) - 1)
-    return branches[clamped_idx](*operands)
+    # index has already been clamped to [0, len(branches) - 1] by torch.switch.
+    return branches[idx](*operands)
 
 
 @switch_op.py_autograd_impl

--- a/torch/_higher_order_ops/switch.py
+++ b/torch/_higher_order_ops/switch.py
@@ -267,7 +267,12 @@ def switch_op_dense(index, branches, operands):
     if mode is not None:
         raise AssertionError("Mode should never be enabled for CPU/CUDA key")
     idx: int = int(index.item()) if isinstance(index, torch.Tensor) else int(index)
-    # index has already been clamped to [0, len(branches) - 1] by torch.switch.
+    # torch.switch is the only supported entry point and clamps index into range;
+    # a direct HOP invocation with an out-of-range index is a caller error.
+    if not 0 <= idx < len(branches):
+        raise AssertionError(
+            f"switch index {idx} out of range for {len(branches)} branches"
+        )
     return branches[idx](*operands)
 
 


### PR DESCRIPTION
This PR moves the clamping of the branch index into the user-facing switch(...) call. This has be advantage that it can be handled in a central place and no plumbing into the dense implementation or Inductor is required.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @ydwu4 