### PR TITLE
Stop LoggingTensor logger from propagating to formatting handlers

### DIFF
--- a/torch/testing/_internal/logging_tensor.py
+++ b/torch/testing/_internal/logging_tensor.py
@@ -13,6 +13,13 @@ import functools
 from torch._C._profiler import gather_traceback, symbolize_tracebacks
 
 logger = logging.getLogger("LoggingTensor")
+# Records are logged with (args, kwargs, rs) as positional %-args on a message
+# that has no % placeholders; only the dedicated LoggingTensorHandler (which
+# reads record.args directly) can render them. If the record propagates to any
+# other handler (e.g. a root/pytest handler at INFO), record.getMessage() does
+# `msg % (args, kwargs, rs)` and raises "not all arguments converted during
+# string formatting". Don't propagate so only our handler ever sees these.
+logger.propagate = False
 
 # How the chain of calls works for LoggingTensor:
 # 1. Call torch.sin


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189029

LoggingTensor/LoggingTensorMode log via
`logger.info(f"{op}", args, kwargs, rs)`, stuffing (args, kwargs, rs) in as
printf %-format args on a message with no % placeholders. Only the dedicated
LoggingTensorHandler can render these (it reads record.args directly and never
calls record.getMessage()).

If the "LoggingTensor" logger propagates to any other handler at INFO (e.g. a
root/pytest log handler present on some runners such as windows-arm64), that
handler calls record.getMessage() -> `op % (args, kwargs, rs)` ->
"TypeError: not all arguments converted during string formatting", which fails
tests like test_autograd.py::TestAutogradFunctional::test_vjp_scalar_logging_tensor
that exercise the dispatch logging outside capture_logs.

Set logger.propagate = False so these records only ever reach our handler.
capture_logs already sets this locally; making it the module default closes the
gap for uncaptured code paths. Safe because LoggingTensor logs are only consumed
via capture_logs, not root propagation.