### PR TITLE
Fix LoggingTensor logging TypeError under log capture

### DIFF
--- a/torch/testing/_internal/logging_tensor.py
+++ b/torch/testing/_internal/logging_tensor.py
@@ -13,6 +13,13 @@ import functools
 from torch._C._profiler import gather_traceback, symbolize_tracebacks
 
 logger = logging.getLogger("LoggingTensor")
+# Records are logged with (args, kwargs, rs) as positional %-args on a message
+# that has no % placeholders; only the dedicated LoggingTensorHandler (which
+# reads record.args directly) can render them. If the record propagates to any
+# other handler (e.g. a root/pytest handler at INFO), record.getMessage() does
+# `msg % (args, kwargs, rs)` and raises "not all arguments converted during
+# string formatting". Don't propagate so only our handler ever sees these.
+logger.propagate = False
 
 # How the chain of calls works for LoggingTensor:
 # 1. Call torch.sin

--- a/torch/testing/_internal/logging_tensor.py
+++ b/torch/testing/_internal/logging_tensor.py
@@ -13,13 +13,6 @@ import functools
 from torch._C._profiler import gather_traceback, symbolize_tracebacks
 
 logger = logging.getLogger("LoggingTensor")
-# Records are logged with (args, kwargs, rs) as positional %-args on a message
-# that has no % placeholders; only the dedicated LoggingTensorHandler (which
-# reads record.args directly) can render them. If the record propagates to any
-# other handler (e.g. a root/pytest handler at INFO), record.getMessage() does
-# `msg % (args, kwargs, rs)` and raises "not all arguments converted during
-# string formatting". Don't propagate so only our handler ever sees these.
-logger.propagate = False
 
 # How the chain of calls works for LoggingTensor:
 # 1. Call torch.sin
@@ -72,7 +65,10 @@ class LoggingTensor(torch.Tensor):
 
         with cls.context():
             rs = tree_map(wrap, func(*tree_map(unwrap, args), **tree_map(unwrap, kwargs)))
-        logging.getLogger("LoggingTensor").info(f"{func.__module__}.{func.__name__}", args, kwargs, rs)  # noqa: G004
+        logging.getLogger("LoggingTensor").info(
+            f"{func.__module__}.{func.__name__}",  # noqa: G004
+            extra={"lt_args": args, "lt_kwargs": kwargs, "lt_rs": rs},
+        )
         return rs
 
 class LoggingTensorMode(TorchDispatchMode):
@@ -80,7 +76,10 @@ class LoggingTensorMode(TorchDispatchMode):
         if kwargs is None:
             kwargs = {}
         rs = func(*args, **kwargs)
-        logging.getLogger("LoggingTensor").info(f"{func.__module__}.{func.__name__}", args, kwargs, rs)  # noqa: G004
+        logging.getLogger("LoggingTensor").info(
+            f"{func.__module__}.{func.__name__}",  # noqa: G004
+            extra={"lt_args": args, "lt_kwargs": kwargs, "lt_rs": rs},
+        )
         return rs
 
 class LoggingTensorReentrant(LoggingTensor):
@@ -119,17 +118,17 @@ class LoggingTensorHandler(logging.Handler):
     def emit(self, record):
         fmt_args = ", ".join(
             itertools.chain(
-                (str(tree_map(self._fmt, a)) for a in record.args[0]),
-                (f"{k}={str(tree_map(self._fmt, v))}" for k, v in record.args[1].items()),
+                (str(tree_map(self._fmt, a)) for a in record.lt_args),
+                (f"{k}={str(tree_map(self._fmt, v))}" for k, v in record.lt_kwargs.items()),
             )
         )
-        fmt_rets = tree_map(functools.partial(self._fmt, with_type=True), record.args[2])
+        fmt_rets = tree_map(functools.partial(self._fmt, with_type=True), record.lt_rs)
         self.log_list.append(f'{fmt_rets} = {record.msg}({fmt_args})')
         if self.tracebacks_list is not None:
             self.tracebacks_list.append(record.traceback)
 
 def log_input(name: str, var: object) -> None:
-    logger.info("input", (name,), {}, var)  # noqa: PLE1205
+    logger.info("input", extra={"lt_args": (name,), "lt_kwargs": {}, "lt_rs": var})
 
 class GatherTraceback(logging.Filter):
     def __init__(self, python=True, script=True, cpp=False):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189031

LoggingTensor(Mode).__torch_dispatch__ logged via
`logger.info(f"{op}", args, kwargs, rs)`, passing (args, kwargs, rs) as printf
%-format args on a message with no % placeholders. Any handler that renders the
record -- e.g. pytest's LogCaptureHandler at INFO, or unittest assertLogs --
calls record.getMessage() -> `op % (args, kwargs, rs)` -> "TypeError: not all
arguments converted during string formatting", failing the
test_*_logging_tensor autograd tests (and windows-arm64-build-test / test).

Move the payload off the printf path into record attributes via `extra=` so
record.args is empty and getMessage() returns just the op name (safe for any
handler), and read record.lt_args/lt_kwargs/lt_rs in LoggingTensorHandler.

(An earlier attempt set logger.propagate = False, but that only blocks ancestor
handlers -- pytest's capture handler still rendered the record and raised.)

Fixes windows-arm64-build-test / test (test_vjp_scalar_logging_tensor).