### PR TITLE
Auto-triage open source PRs when a maintainer engages

### DIFF
--- a/.github/scripts/auto_triage.py
+++ b/.github/scripts/auto_triage.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Add the "triaged" label to an "open source" PR when a maintainer comments or
+reviews it. A maintainer is anyone who could approve the PR per the files it
+touches, as defined by .github/merge_rules.yaml.
+
+Invoked by .github/workflows/auto-triage.yml. All inputs come from environment
+variables and are treated as untrusted data: the PR state and merge rules are
+re-fetched/re-parsed from trusted server-side sources before any decision.
+"""
+
+from __future__ import annotations
+
+import os
+
+from label_utils import BOT_AUTHORS, gh_add_labels
+from trymerge import GitHubPR, is_maintainer_for_pr
+
+
+OPEN_SOURCE_LABEL = "open source"
+TRIAGED_LABEL = "triaged"
+# Explicitly excluded actors, plus the bots whose automated chatter must never
+# self-trigger triage.
+EXCLUDED_USERS = {"jansel", *BOT_AUTHORS}
+
+
+def main() -> None:
+    actor = os.environ["ACTOR"]
+    pr_num = int(os.environ["PR_NUM"])
+    dry_run = os.environ.get("DRY_RUN", "0") == "1"
+
+    if actor in EXCLUDED_USERS:
+        print(f"Skipping: {actor} is excluded")
+        return
+
+    pr = GitHubPR("pytorch", "pytorch", pr_num)
+    labels = pr.get_labels()
+    if OPEN_SOURCE_LABEL not in labels:
+        print(f"Skipping: PR #{pr_num} does not have the '{OPEN_SOURCE_LABEL}' label")
+        return
+    if TRIAGED_LABEL in labels:
+        print(f"Skipping: PR #{pr_num} already has the '{TRIAGED_LABEL}' label")
+        return
+
+    if not is_maintainer_for_pr(pr, actor):
+        print(f"Skipping: {actor} is not a maintainer for PR #{pr_num}")
+        return
+
+    print(f"Adding '{TRIAGED_LABEL}' to PR #{pr_num} (triggered by {actor})")
+    gh_add_labels("pytorch", "pytorch", pr_num, [TRIAGED_LABEL], dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -31,6 +31,7 @@ from trymerge import (
     get_drci_classifications,
     gh_get_team_members,
     GitHubPR,
+    is_maintainer_for_pr,
     iter_issue_timeline_until_comment,
     JobCheckState,
     main as trymerge_main,
@@ -352,6 +353,38 @@ class TestTryMerge(TestCase):
         pr = GitHubPR("pytorch", "pytorch", 115495)
         # Test that PR with the correct approvers doesn't raise any exception
         self.assertTrue(find_matching_merge_rule(pr, repo) is not None)
+
+    @mock.patch("trymerge.gh_get_team_members", return_value=[])
+    @mock.patch("trymerge.read_merge_rules", side_effect=mocked_read_merge_rules)
+    def test_is_maintainer_for_pr_global_rule(self, *args: Any) -> None:
+        "Approver of an all-files rule is a maintainer for any PR"
+        pr = GitHubPR("pytorch", "pytorch", 95233)
+        self.assertTrue(is_maintainer_for_pr(pr, "ngimel", DummyGitRepo()))
+
+    @mock.patch("trymerge.gh_get_team_members", return_value=[])
+    @mock.patch("trymerge.read_merge_rules", side_effect=mocked_read_merge_rules)
+    def test_is_maintainer_for_pr_wrong_area(self, *args: Any) -> None:
+        "Approver of only an unrelated narrow rule is not a maintainer"
+        # PR 95233 does not touch .github/ci_commit_pins/xla.txt, so the xla
+        # rule (approved_by pytorchbot) does not cover it.
+        pr = GitHubPR("pytorch", "pytorch", 95233)
+        self.assertFalse(is_maintainer_for_pr(pr, "pytorchbot", DummyGitRepo()))
+
+    @mock.patch("trymerge.gh_get_team_members", return_value=[])
+    @mock.patch("trymerge.read_merge_rules", side_effect=mocked_read_merge_rules)
+    def test_is_maintainer_for_pr_not_an_approver(self, *args: Any) -> None:
+        "Someone absent from every covering rule is not a maintainer"
+        pr = GitHubPR("pytorch", "pytorch", 95233)
+        self.assertFalse(is_maintainer_for_pr(pr, "nonmember", DummyGitRepo()))
+
+    @mock.patch("trymerge.gh_get_team_members", return_value=["team_member_login"])
+    @mock.patch("trymerge.read_merge_rules", side_effect=mocked_read_merge_rules)
+    def test_is_maintainer_for_pr_team_expansion(self, *args: Any) -> None:
+        "Team references in approved_by are expanded to their members"
+        # The "super" rule is approved_by pytorch/metamates; expansion above
+        # makes team_member_login a maintainer.
+        pr = GitHubPR("pytorch", "pytorch", 95233)
+        self.assertTrue(is_maintainer_for_pr(pr, "team_member_login", DummyGitRepo()))
 
     @mock.patch("trymerge.read_merge_rules", side_effect=mocked_read_merge_rules)
     def test_lint_fails(self, *args: Any) -> None:

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -1480,6 +1480,19 @@ def _find_non_matching_files(patterns: list[str], files: list[str]) -> list[str]
     ]
 
 
+def resolve_rule_approvers(rule: MergeRule) -> set[str]:
+    """Expand a rule's approved_by list into concrete logins, resolving any
+    org/team references to their members."""
+    approvers: set[str] = set()
+    for approver in rule.approved_by:
+        if "/" in approver:
+            org, name = approver.split("/")
+            approvers.update(gh_get_team_members(org, name))
+        else:
+            approvers.add(approver)
+    return approvers
+
+
 def find_matching_merge_rule(
     pr: GitHubPR,
     repo: GitRepo | None = None,
@@ -1562,13 +1575,7 @@ def find_matching_merge_rule(
             continue
 
         # Does the PR have the required approvals for this rule?
-        rule_approvers = set()
-        for approver in rule.approved_by:
-            if "/" in approver:
-                org, name = approver.split("/")
-                rule_approvers.update(gh_get_team_members(org, name))
-            else:
-                rule_approvers.add(approver)
+        rule_approvers = resolve_rule_approvers(rule)
         approvers_intersection = approved_by.intersection(rule_approvers)
         # If rule requires approvers but they aren't the ones that reviewed PR
         if len(approvers_intersection) == 0 and len(rule_approvers) > 0:
@@ -1669,6 +1676,23 @@ def find_matching_merge_rule(
     if reject_reason_score == 20000:
         raise MandatoryChecksMissingError(reject_reason, rule)
     raise MergeRuleFailedError(reject_reason, rule)
+
+
+def is_maintainer_for_pr(pr: GitHubPR, actor: str, repo: GitRepo | None = None) -> bool:
+    """Return True if `actor` could approve this PR per merge_rules.yaml, i.e.
+    they are an approver of some rule that covers every file the PR touches.
+
+    Unlike find_matching_merge_rule, this only answers the maintainer question:
+    it ignores review state and mandatory checks. Approver resolution (including
+    org/team expansion) is shared via resolve_rule_approvers.
+    """
+    changed_files = pr.get_changed_files()
+    for rule in read_merge_rules(repo, pr.org, pr.project):
+        if _find_non_matching_files(rule.patterns, changed_files):
+            continue
+        if actor in resolve_rule_approvers(rule):
+            return True
+    return False
 
 
 def checks_to_str(checks: list[tuple[str, str | None]]) -> str:

--- a/.github/workflows/auto-triage-run.yml
+++ b/.github/workflows/auto-triage-run.yml
@@ -1,0 +1,89 @@
+# Owner(s): ["module: ci"]
+name: Auto-triage open source PRs Run
+
+# Privileged half of the auto-triage automation. Triggered by workflow_run, so
+# it always executes the trusted default-branch workflow file and checked-out
+# code -- the PR-triggerable capture job (auto-triage.yml) never runs with the
+# PAT. It consumes the recorded {actor, pr_num} purely as data, re-derives all
+# PR state from the API, and adds the "triaged" label if the actor is a
+# maintainer for the PR.
+
+on:
+  workflow_run:
+    workflows: ["Auto-triage open source PRs"]
+    types: [completed]
+
+jobs:
+  triage:
+    if: |
+      github.repository == 'pytorch/pytorch' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow.path == '.github/workflows/auto-triage.yml'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    environment: pytorchbot-env
+    # These permissions scope the default GITHUB_TOKEN, used only for the
+    # artifact download and checkout below. The label write is performed by
+    # GH_PYTORCHBOT_TOKEN (a PAT), which is required because resolving org/team
+    # approvers in merge_rules.yaml needs read:org that the default token lacks.
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Download request artifact
+        id: download
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          REPO: ${{ github.repository }}
+        run: |
+          if gh run download "$RUN_ID" --repo "$REPO" --name auto-triage-request --dir auto-triage-request; then
+            echo "found=1" >> "$GITHUB_OUTPUT"
+          else
+            # No artifact: the capture job was skipped by its gates. Nothing to do.
+            echo "No auto-triage-request artifact on run $RUN_ID; nothing to triage."
+            echo "found=0" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Validate request
+        id: request
+        if: steps.download.outputs.found == '1'
+        run: |
+          PR_NUM=$(cat auto-triage-request/pr_num.txt)
+          ACTOR=$(cat auto-triage-request/actor.txt)
+          if ! [[ "$PR_NUM" =~ ^[0-9]+$ ]]; then
+            echo "::error::Invalid PR number in artifact: '$PR_NUM'"
+            exit 1
+          fi
+          if ! [[ "$ACTOR" =~ ^[A-Za-z0-9-]+$ ]]; then
+            echo "::error::Invalid actor login in artifact: '$ACTOR'"
+            exit 1
+          fi
+          echo "pr_num=$PR_NUM" >> "$GITHUB_OUTPUT"
+          echo "actor=$ACTOR" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout repo
+        if: steps.download.outputs.found == '1'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 1
+
+      - name: Setup Python
+        if: steps.download.outputs.found == '1'
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: '3.10'
+          check-latest: false
+          cache: pip
+          architecture: x64
+
+      - if: steps.download.outputs.found == '1'
+        run: pip install pyyaml==6.0.2
+
+      - name: Auto-triage
+        if: steps.download.outputs.found == '1'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
+          PR_NUM: ${{ steps.request.outputs.pr_num }}
+          ACTOR: ${{ steps.request.outputs.actor }}
+        run: python3 .github/scripts/auto_triage.py

--- a/.github/workflows/auto-triage.yml
+++ b/.github/workflows/auto-triage.yml
@@ -1,0 +1,48 @@
+# Owner(s): ["module: ci"]
+name: Auto-triage open source PRs
+
+# Capture-only job: this runs on PR-triggerable events and therefore holds NO
+# secrets. It records the {actor, pr_num} of a maintainer engagement into an
+# artifact; the privileged maintainer-check + label-add happens in
+# auto-triage-run.yml, which runs trusted default-branch code via workflow_run.
+
+on:
+  pull_request_review:
+    types: [submitted]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+
+jobs:
+  capture:
+    name: capture
+    # Cheap gates so we only record when it can matter: the event is on a PR,
+    # it carries the "open source" label, and it isn't already triaged.
+    if: >
+      github.repository == 'pytorch/pytorch' &&
+      (github.event.issue.pull_request || github.event.pull_request) &&
+      contains(github.event.*.labels.*.name, 'open source') &&
+      !contains(github.event.*.labels.*.name, 'triaged')
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Record request
+        # Untrusted inputs (ACTOR, PR_NUM) are passed as env vars, never
+        # interpolated into the shell. They are only written verbatim to files
+        # and validated by the downstream privileged job before use.
+        env:
+          PR_NUM: ${{ github.event.issue.number || github.event.pull_request.number }}
+          ACTOR: ${{ github.event.comment.user.login || github.event.review.user.login }}
+        run: |
+          mkdir -p auto-triage-request
+          printf '%s' "$PR_NUM" > auto-triage-request/pr_num.txt
+          printf '%s' "$ACTOR" > auto-triage-request/actor.txt
+
+      - name: Upload request artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: auto-triage-request
+          path: auto-triage-request/
+          retention-days: 1
+          if-no-files-found: error


### PR DESCRIPTION
## Author Notes

Excluding jason for now until his bot is migrated.

## Agent Notes

> **Updated:** restructured into the two-workflow (capture + privileged) design per review, so the org-scoped PAT never lives in a PR-triggerable job.

Adds automation that applies the `triaged` label to a PR carrying the `open source` label as soon as a maintainer comments on or reviews it, where "maintainer" means someone who could approve the PR under `.github/merge_rules.yaml` for the files it actually touches.

- **Two-workflow split (capture vs. privilege).** To keep the PAT off any PR-triggerable job:
  - `auto-triage.yml` runs on `pull_request_review` / `issue_comment` and holds **no secrets** (`contents: read`). It only records `{actor, pr_num}` into an artifact.
  - `auto-triage-run.yml` is triggered by `workflow_run`, so it always executes trusted default-branch code. It runs under `environment: pytorchbot-env`, validates the recorded actor/pr_num as pure data, then does the maintainer check + label add with the PAT.
  - Because the PAT lives only in the `workflow_run` job (which fork PRs cannot influence), there is no exfiltration path. The run job's `permissions:` scope only the default `GITHUB_TOKEN` (artifact download + checkout); the label write goes through the PAT, as noted in a comment there.
- **Reuses the merge-rule machinery.** A new public helper `is_maintainer_for_pr` in `trymerge.py` runs the same rule/file matching as `find_matching_merge_rule`, but drops the review-state and mandatory-check requirements since triage only cares about who could stamp the change. The approver-resolution logic (expanding `approved_by`, including org/team refs, into concrete logins) is extracted into a shared `resolve_rule_approvers` helper called by both, so the two paths resolve approvers identically.
- **Token choice.** Uses `GH_PYTORCHBOT_TOKEN` rather than the default `GITHUB_TOKEN`, because resolving org/team entries in `merge_rules.yaml` (e.g. `pytorch/pytorch-dev-infra`) requires `read:org`, which `GITHUB_TOKEN` lacks. `nightly.yml`'s metamates-rule job sets the same precedent.
- **Exclusions.** `jansel` is excluded for now, alongside the existing bot authors so automated chatter never self-triggers triage.

### Test Plan

```
python -m pytest .github/scripts/test_trymerge.py -k is_maintainer_for_pr -v
python -m pytest .github/scripts/test_trymerge.py
spin lint
```

Unit tests cover the maintainer helper (global rule, wrong area, non-approver, org-team expansion) and the full trymerge suite guards `find_matching_merge_rule`, which now shares `resolve_rule_approvers`. The driver script was exercised against all branches (excluded user, bot author, missing `open source` label, already `triaged`, non-maintainer, and the maintainer happy path) with a mocked `GitHubPR` in `DRY_RUN`, confirming the label is added only in the happy path.

This change was authored with the assistance of an AI coding agent.