### PR TITLE
[inductor] cpp_wrapper: null-guard assert_size_stride for optional outputs

### DIFF
--- a/test/inductor/test_cpp_wrapper_custom_ops.py
+++ b/test/inductor/test_cpp_wrapper_custom_ops.py
@@ -188,6 +188,91 @@ class TestCppWrapperCustomOps(InductorTestCase):
         )
         self.assertIn("callBoxed", code_str)
 
+    @unittest.skipIf(not HAS_CPU, "requires CPU")
+    @config.patch(implicit_fallbacks=True)
+    def test_optional_output_size_assert_is_null_guarded(self):
+        # A fallback custom op can declare an optional output (Tensor?) that is
+        # absent (None) at runtime. Under cpp_wrapper the C-shim writes a null
+        # AtenTensorHandle for the absent output; an unconditional
+        # assert_size_stride on that slot (its fake kernel returned a tensor)
+        # would dereference the null handle -> SIGSEGV (seen with fbgemm's
+        # block_bucketize_sparse_features_inference). The fix emits the assert
+        # for schema-optional outputs under a runtime null guard.
+        #
+        # Force the op onto the C-shim path (custom_ops_to_c_shims) and inspect
+        # the generated code: the optional output (distinct fake shape 11x13) is
+        # asserted inside `if (buf != nullptr) { ... }`, while the required (8x4)
+        # output keeps an unconditional assert. Codegen runs before the .so is
+        # loaded, so the absent hand-written C-shim symbol does not matter here.
+        import io
+        import logging
+
+        from torch._inductor.codecache import output_code_log
+
+        with torch.library._scoped_library("test_null_guard", "FRAGMENT") as lib:
+            lib.define("f(Tensor x) -> (Tensor, Tensor?)")
+            lib.impl("f", lambda x: (x + 1, None), "CompositeExplicitAutograd")
+            lib.impl(
+                "f",
+                lambda x: (
+                    torch.empty_like(x),
+                    torch.empty(11, 13, dtype=x.dtype, device=x.device),
+                ),
+                "Meta",
+            )
+
+            op = torch.ops.test_null_guard.f.default
+            c_shims = {
+                op: [
+                    "AOTITorchError aoti_torch_cpu_f(AtenTensorHandle x, "
+                    "AtenTensorHandle* r0, AtenTensorHandle* r1)"
+                ]
+            }
+
+            def fn(x):
+                a, b = torch.ops.test_null_guard.f(x)
+                return a + 1, b
+
+            x = torch.randn(8, 4)
+
+            cap = io.StringIO()
+            handler = logging.StreamHandler(cap)
+            output_code_log.addHandler(handler)
+            prev_level = output_code_log.level
+            output_code_log.setLevel(logging.DEBUG)
+            try:
+                with config.patch(
+                    {"debug": True, "aot_inductor.custom_ops_to_c_shims": c_shims}
+                ):
+                    compiled = torch.compile(
+                        fn, fullgraph=True, options={"cpp_wrapper": True}
+                    )
+                    try:
+                        compiled(x)
+                    except Exception:
+                        # No real C-shim symbol is provided, so the generated .so
+                        # fails to load; codegen has already emitted the wrapper.
+                        pass
+            finally:
+                output_code_log.setLevel(prev_level)
+                output_code_log.removeHandler(handler)
+
+        code = cap.getvalue()
+        assert_lines = [ln for ln in code.splitlines() if "assert_size_stride" in ln]
+        self.assertTrue(assert_lines, "expected assert_size_stride in generated code")
+        # Optional Tensor? output (fake shape 11x13) must be null-guarded.
+        optional = [ln for ln in assert_lines if "13" in ln]
+        self.assertTrue(optional, "optional output should still be size-asserted")
+        self.assertTrue(
+            all("nullptr" in ln for ln in optional),
+            f"optional Tensor? output assert must be runtime null-guarded: {optional}",
+        )
+        # Required (non-optional) outputs keep an unconditional assert.
+        self.assertTrue(
+            any("nullptr" not in ln for ln in assert_lines),
+            f"required outputs must keep unconditional asserts: {assert_lines}",
+        )
+
 
 if __name__ == "__main__":
     run_tests(needs="filelock")

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -2289,10 +2289,16 @@ class CppWrapperCpu(PythonWrapperCodegen):
         size: str,
         stride: str,
         op_name: str,
+        maybe_null: bool = False,
     ) -> None:
         if V.graph.aot_mode and V.graph.is_const_graph:
             return
         stmt = f'assert_size_stride({name}, {size}, {stride}, "{op_name}");'
+        if maybe_null:
+            # Optional (Tensor?) output may be a null handle at runtime; assert
+            # only when it is actually present, else aoti_torch_get_dim would
+            # dereference null.
+            stmt = f"if ({name} != nullptr) {{ {stmt} }}"
         if V.graph.aot_mode:
             guarded = f"if (_check_aoti_runtime_check_inputs_env()) {{ {stmt} }}"
             if V.graph.is_dual_wrapper_mode:

--- a/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
@@ -120,6 +120,7 @@ class CppWrapperCpuArrayRef(CppWrapperCpu):
         size: str,
         stride: str,
         op_name: str,
+        maybe_null: bool = False,
     ) -> None:
         # Inputs/outputs are ArrayRefTensor, not AtenTensorHandle, so
         # assert_size_stride would fail to compile.

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1303,10 +1303,11 @@ class AssertSizeStrideLine(WrapperLine):
     size: str
     stride: str
     op_name: str = "input"
+    maybe_null: bool = False
 
     def codegen(self, code: IndentedBuffer) -> None:
         self.wrapper._codegen_assert_size_stride(
-            code, self.name, self.size, self.stride, self.op_name
+            code, self.name, self.size, self.stride, self.op_name, self.maybe_null
         )
 
     @staticmethod
@@ -1806,10 +1807,12 @@ class PythonWrapperCodegen(CodeGen):
                 self.write_assert_size_stride(name, size, stride, "input")
 
     def write_assert_size_stride(
-        self, name: str, size: str, stride: str, op_name: str
+        self, name: str, size: str, stride: str, op_name: str, maybe_null: bool = False
     ) -> None:
         """Queue an assert_size_stride for emission during replay."""
-        self.writeline(AssertSizeStrideLine(self, name, size, stride, op_name))
+        self.writeline(
+            AssertSizeStrideLine(self, name, size, stride, op_name, maybe_null)
+        )
 
     def _codegen_assert_size_stride(
         self,
@@ -1818,13 +1821,19 @@ class PythonWrapperCodegen(CodeGen):
         size: str,
         stride: str,
         op_name: str,
+        maybe_null: bool = False,
     ) -> None:
         """Emit one assert_size_stride line to `code` (replay-phase target).
 
         Subclasses override to change the emitted form (e.g., C++ assert with
         an AOTI runtime env guard).
         """
-        code.writeline(f"assert_size_stride({name}, {size}, {stride}, {op_name!r})")
+        stmt = f"assert_size_stride({name}, {size}, {stride}, {op_name!r})"
+        if maybe_null:
+            # Optional (Tensor?) output may be absent at runtime; assert only
+            # when it is actually present.
+            stmt = f"if {name} is not None: {stmt}"
+        code.writeline(stmt)
 
     def write_assert_div_by_zero(self, divisor_str: str, op_name: str) -> None:
         """Queue a div-by-zero AOTI check for emission during replay.

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -7833,7 +7833,9 @@ class ExternKernel(InputsKernel):
                             "Expected isinstance(self.inputs[0], IRNode)"
                         )
                     name = self.inputs[0].get_name()
-        wrapper.write_assert_size_stride(name, size, stride, op_name)
+        wrapper.write_assert_size_stride(
+            name, size, stride, op_name, maybe_null=getattr(self, "maybe_null", False)
+        )
 
     def codegen_alignment_asserts(self, wrapper: PythonWrapperCodegen) -> None:
         if config.alignment_asserts and not V.graph.cpp_wrapper:
@@ -9865,6 +9867,17 @@ class FallbackKernel(ExternKernelAlloc):
                 unbacked_bindings=unbacked_bindings,
             )
 
+        # Returns declared Tensor? (optional) may be absent at runtime; their
+        # output handle can be null even when the meta kernel produced a tensor.
+        optional_return_idxs: OrderedSet[int] = OrderedSet()
+        if isinstance(kernel, torch._ops.OpOverload):
+            for ret_idx, ret in enumerate(kernel._schema.returns):
+                ret_type = ret.real_type
+                if isinstance(ret_type, torch.OptionalType) and isinstance(
+                    ret_type.getElementType(), torch.TensorType
+                ):
+                    optional_return_idxs.add(ret_idx)
+
         def generate_output(output: Any, indices: list[tuple[Any, int]]) -> Any:
             if isinstance(output, (list, tuple)):
                 return type(output)(
@@ -9877,10 +9890,16 @@ class FallbackKernel(ExternKernelAlloc):
                     for key, val in output.items()
                 }
             elif isinstance(output, torch.Tensor):
+                # A Tensor? (optional) return may be absent (a null handle) at
+                # runtime even when the meta produced a tensor; mark it so its
+                # size/stride assert is guarded by a runtime null check rather
+                # than unconditionally dereferencing the handle.
+                flat_idx = indices[0][1] if indices else 0
                 buf = MultiOutput(
                     cls.tensor_to_layout(output),
                     packed,
                     indices,
+                    maybe_null=flat_idx in optional_return_idxs,
                 )
                 if (
                     config.assume_unaligned_fallback_output
@@ -9999,12 +10018,14 @@ class MultiOutput(ExternKernel):
         input: IRNode,
         indices: list[tuple[Any, ...]],
         skip_size_stride_alignment_checks: bool = False,
+        maybe_null: bool = False,
     ) -> None:
         super().__init__(None, layout, [input], ())
         self.name = V.graph.register_buffer(self)
         V.graph.register_operation(self)
         self.indices = indices
         self.skip_size_stride_alignment_checks = skip_size_stride_alignment_checks
+        self.maybe_null = maybe_null
 
     @cache_on_self_and_args("MultiOutput")
     def get_free_symbol_uses(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #189035

A fallback op's optional (Tensor?) output can be null at runtime, but
cpp_wrapper emitted an unconditional assert_size_stride on it (when the fake
kernel returned a tensor), dereferencing the null handle -> SIGSEGV.

Emit the assert for schema-optional outputs under a runtime null guard:
`if (buf != nullptr) { assert_size_stride(...); }`. Present optionals are
still checked; required outputs are unchanged.

Test Plan: test_optional_output_size_assert_is_null_guarded in
test/inductor/test_cpp_wrapper_custom_ops.py

Generated with assistance from Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo