### PR TITLE
Preserve strides for CuTeDSL grouped MM fake tensors

### DIFF
--- a/torch/_inductor/kernel/templates/cutedsl_mm_grouped.py.jinja
+++ b/torch/_inductor/kernel/templates/cutedsl_mm_grouped.py.jinja
@@ -1,6 +1,5 @@
 import functools
 
-from torch._inductor.ir import get_stride_order
 from torch._inductor.runtime.cutedsl_cache import disk_cache_get, disk_cache_set
 from torch._inductor.runtime.runtime_utils import ceildiv
 from cutlass.utils import TensorMapUpdateMode
@@ -57,10 +56,10 @@ _TORCH_TO_CUTLASS_DTYPE = {
 
 def _to_fake_cute_tensor(t, assumed_align=16):
     dyn_shape = tuple(map(int, t.shape))
-    stride_order = tuple(get_stride_order(t.stride()))
-    return cute.runtime.make_fake_compact_tensor(
-        _TORCH_TO_CUTLASS_DTYPE[t.dtype], dyn_shape,
-        stride_order=stride_order, assumed_align=assumed_align,
+    dyn_stride = tuple(map(int, t.stride()))
+    return cute.runtime.make_fake_tensor(
+        _TORCH_TO_CUTLASS_DTYPE[t.dtype], dyn_shape, dyn_stride,
+        assumed_align=assumed_align,
     )
 
 


### PR DESCRIPTION
CuTeDSL grouped MM compiles kernels with fake tensor descriptors. 
The template used `make_fake_compact_tensor` with a stride order derived from `get_stride_order`. 
That is not enough for non-compact inputs: a padded A tensor with logical K=64 and row stride 72 has the same stride order as a compact row stride 64, so runtime descriptor validation can reject the real tensor.

Build the fake descriptor from the tensor's explicit strides instead. This keeps the fake CuTe tensor aligned with grouped MM operands, including padded A layouts.

This fixes the padded-A grouped GEMM cases in `inductor/test_cutedsl_grouped_mm`:

- `TestCuTeDSLGroupedGemm::test_grouped_gemm_assorted_layouts_layout_A_padded_layout_B_broadcasted`
- `TestCuTeDSLGroupedGemm::test_grouped_gemm_assorted_layouts_layout_A_padded_layout_B_contiguous`

Both cases construct `A` with a row pitch larger than logical `K`. The current fake descriptor is compact and encodes the row stride as `K`, so runtime validation rejects the actual padded tensor stride.

Authored with gpt-5.5 xhigh.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo