### PR TITLE
[MPS]  Fix uint8 casting in MPS `copy_` kernels

### DIFF
--- a/c10/metal/utils.h
+++ b/c10/metal/utils.h
@@ -248,6 +248,38 @@ inline common_dtype<T, U> fmod(T x, U y) {
 }
 
 // cast_to primitives
+namespace detail {
+template <
+    typename U,
+    ::metal::enable_if_t<is_scalar_integral_v<U>, bool> = true>
+inline uchar cast_to_uchar(const U from) {
+  return static_cast<uchar>(static_cast<long>(from));
+}
+
+template <
+    typename U,
+    ::metal::enable_if_t<is_scalar_floating_point_v<U>, bool> = true>
+inline uchar cast_to_uchar(const U from) {
+  return static_cast<uchar>(static_cast<long>(static_cast<float>(from)));
+}
+
+template <
+    typename T,
+    typename U,
+    ::metal::enable_if_t<!::metal::is_same_v<T, uchar>, bool> = true>
+inline T cast_scalar_to_scalar(const U from) {
+  return static_cast<T>(from);
+}
+
+template <
+    typename T,
+    typename U,
+    ::metal::enable_if_t<::metal::is_same_v<T, uchar>, bool> = true>
+inline T cast_scalar_to_scalar(const U from) {
+  return cast_to_uchar(from);
+}
+}
+
 //  - No-op if types as the same
 template <
     typename T,
@@ -264,7 +296,7 @@ template <
         !::metal::is_same_v<U, T> && (is_complex_v<T> == is_complex_v<U>),
         bool> = true>
 inline T cast_to(const U from) {
-  return static_cast<T>(from);
+  return detail::cast_scalar_to_scalar<T>(from);
 }
 
 // - Scalar to complex
@@ -292,7 +324,7 @@ template <
         !is_complex_v<T> && !::metal::is_same_v<T, bool> && is_complex_v<U>,
         bool> = true>
 inline T cast_to(const U from) {
-  return static_cast<T>(from.x);
+  return detail::cast_scalar_to_scalar<T>(from.x);
 }
 
 // Generalizable math operators (used for both scalar and complex)

--- a/c10/metal/utils.h
+++ b/c10/metal/utils.h
@@ -278,7 +278,7 @@ template <
 inline T cast_scalar_to_scalar(const U from) {
   return cast_to_uchar(from);
 }
-}
+} // namespace detail
 
 //  - No-op if types as the same
 template <

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -4403,6 +4403,23 @@ class TestMPS(TestCaseMPS):
             helper((1, 5), (4, 0, 5), src_dtype, dst_dtype)
             helper((3, 1, 0), (3, 5, 0), src_dtype, dst_dtype)
             helper((0, 1, 0), (0, 5, 0), src_dtype, dst_dtype)
+
+        def check_uint8_broadcast(src, dst_shape):
+            cpu_dst = torch.zeros(dst_shape, dtype=torch.uint8)
+            cpu_result = cpu_dst.copy_(src)
+            mps_dst = torch.zeros(dst_shape, dtype=torch.uint8, device="mps")
+            mps_result = mps_dst.copy_(src.to("mps"))
+            self.assertEqual(cpu_result, mps_result)
+
+        # Regression test for https://github.com/pytorch/pytorch/issues/160744
+        for src_dtype in (torch.float32, torch.int32):
+            for dst_shape in ((), (1,), (1, 1, 1), (3,), (2, 2)):
+                check_uint8_broadcast(torch.tensor(-1, dtype=src_dtype), dst_shape)
+
+        for value in (-1.0, 0.0, 1.0, 255.0):
+            check_uint8_broadcast(torch.full((1,), value, dtype=torch.float32), (3,))
+            check_uint8_broadcast(torch.full((1, 1), value, dtype=torch.float32), (2, 2))
+
         # Regression test for https://github.com/pytorch/pytorch/issues/107867
         self.assertEqual(torch.tensor([[1]], device='mps').item(), 1.0)
 


### PR DESCRIPTION
Fixes #160744

On MPS, `copy_` from a negative floating point source into a `torch.uint8` destination can produce `0` for broadcasted shapes like `[3]` and `[2, 2]`.

CPU and CUDA convert `float -> uint8` through a signed integer intermediate, `-1.0` becomes `255` 
MPS Metal helper was casting directly to `uchar`, which is platform divergent for float to unsigned conversion

Metal `uchar` destination casts through a signed integer intermediate in `c10/metal/utils.h`, matching CPU/CUDA path

## Test plan

- `python test/test_mps.py -k test_copy_broadcasting`
- Repro script from #160744 now matches CPU for scalar and broadcasted `uint8` outputs.

<img width="601" height="207" alt="image" src="https://github.com/user-attachments/assets/8b38921e-8c6a-4299-bfda-1d004048d2e8" />


cc @jhavukainen @malfet 
