### PR TITLE
[fake_tensor] Avoid redundant FakeTensor.layout reads in extract_tensor_metadata

### DIFF
--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -1344,12 +1344,15 @@ def extract_tensor_metadata(t: Tensor) -> TensorMetadata:
     """
     Extract the TensorMetadata of a tensor.
     """
+    # Read layout/sparseness once (hot-path Python properties on FakeTensor).
+    layout = t.layout
+    _is_sparse_any: bool = is_sparse_any(t)
     memory_format = suggest_memory_format(t)
     # Don't call is_contiguous() on a Tensor which has symbolic sizes or things
     # will go badly (guards will be messed up?)
     if (
         t._has_symbolic_sizes_strides
-        or is_sparse_any(t)
+        or _is_sparse_any
         or not t.is_contiguous(memory_format=memory_format)
     ):
         memory_format = None  # type: ignore[assignment]
@@ -1359,13 +1362,13 @@ def extract_tensor_metadata(t: Tensor) -> TensorMetadata:
     return TensorMetadata(
         t.dtype,
         t.shape,
-        t.stride() if t.layout == torch.strided else (),
+        t.stride() if layout == torch.strided else (),
         t.device,
-        t.layout,
+        layout,
         memory_format,
         storage_offset,
         # Only set storage_bytes for tensors that have storage (not sparse)
-        t.untyped_storage().nbytes() if not is_sparse_any(t) else None,
+        t.untyped_storage().nbytes() if not _is_sparse_any else None,
         t.requires_grad,
         t.is_quantized,
         t.is_conj(),
@@ -1373,8 +1376,8 @@ def extract_tensor_metadata(t: Tensor) -> TensorMetadata:
         t.is_inference(),
         t.is_sparse,
         t.is_coalesced() if t.is_sparse else None,
-        t.dense_dim() if is_sparse_any(t) else None,
-        t.sparse_dim() if is_sparse_any(t) else None,
+        t.dense_dim() if _is_sparse_any else None,
+        t.sparse_dim() if _is_sparse_any else None,
     )
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #189039

PR #183670 (a0f5237fb280, "Fix MKLDNN to_dense fake layout handling") turned
FakeTensor.layout and FakeTensor.is_mkldnn into Python @property overrides.
They must be Python-level: an MKLDNN fake tensor is backed by a strided meta
tensor and carries its real (mkldnn) layout in a dispatch_keys side channel,
because a meta tensor cannot itself hold the mkldnn layout ("Unsupported
device type for mkldnn layout: meta"). Before that PR, FakeTensor.layout was
the native C++ getset.

extract_tensor_metadata runs on the FakeTensorMode dispatch cache-key hot path
and reads .layout 11 times per call: twice directly and inside four
is_sparse_any() calls (is_sparse_any == is_sparse_coo or is_sparse_compressed,
both layout-based). That redundancy was free with the C++ getset but became
expensive once .layout was a Python property, regressing PT2 compile-time
instruction count by ~1-3% across ~20 pr_time benchmarks (e.g. add_loop_eager
+2.97%, aotdispatcher_*_cpu +2.4-2.6%, symint_sum +2.02%).

Fix: read t.layout and is_sparse_any(t) once into locals and reuse them,
dropping the per-call .layout property invocations from 11 to 4. This is a
pure read de-duplication -- t is not mutated in the function, so the produced
TensorMetadata (and thus the dispatch cache key) is bit-identical. The
.layout / is_mkldnn properties from #183670 are left unchanged.

Alternative considered: memoizing FakeTensor.layout on the instance (keyed on
dispatch_keys, invalidated on reassignment). Rejected -- it adds per-instance
state plus cache-invalidation logic for a smaller win; de-duplicating the
reads is simpler, stateless, and recovers more of the regression.

Measurements (H100, benchmarks/dynamo/pr_time_benchmarks,
compile_time_instruction_count):

  symint_sum:       2,805,131,042 -> 2,748,080,737  (-2.03%; regression was +2.02%)
  symint_sum_loop:  3,759,189,592 -> 3,698,787,263  (-1.61%; regression was +1.47%)

Both return to their pre-#183670 levels.

Test Plan:

Instruction count before/after (the numbers above):

```
python benchmarks/dynamo/pr_time_benchmarks/benchmarks/symint_sum.py /tmp/out.csv
cat /tmp/out.csv
```

Correctness (fake tensor + mkldnn/sparse to_dense unaffected):

```
python test/test_fake_tensor.py
# Ran 438 tests ... OK (skipped=17, expected failures=4)
```

Lint:

```
lintrunner torch/_subclasses/fake_tensor.py
# ok No lint issues.
```

Authored-with: Claude Code (Anthropic AI assistant)