### PR TITLE
[operator_benchmark] Upload test reports to GHA artifacts

### DIFF
--- a/.github/workflows/operator_benchmark.yml
+++ b/.github/workflows/operator_benchmark.yml
@@ -72,6 +72,10 @@ jobs:
       build-environment: ${{ needs.x86-opbenchmark-build.outputs.build-environment }}
       docker-image: ${{ needs.x86-opbenchmark-build.outputs.docker-image }}
       test-matrix: ${{ needs.x86-opbenchmark-build.outputs.test-matrix }}
+      # Upload test reports (incl. operator_benchmark_eager_float32_cpu.csv) to
+      # GHA artifacts instead of S3, so the perf baseline can be regenerated
+      # from a run's output CSV.
+      use-gha: "1"
       use-arc: true
       python-version: "3.10"
       compiler: gcc11
@@ -109,6 +113,10 @@ jobs:
       build-environment: ${{ needs.aarch64-opbenchmark-build.outputs.build-environment }}
       docker-image: ${{ needs.aarch64-opbenchmark-build.outputs.docker-image }}
       test-matrix: ${{ needs.aarch64-opbenchmark-build.outputs.test-matrix }}
+      # Upload test reports (incl. operator_benchmark_eager_float32_cpu.csv) to
+      # GHA artifacts instead of S3, so the perf baseline can be regenerated
+      # from a run's output CSV.
+      use-gha: "1"
       use-arc: true
       python-version: "3.10"
       compiler: gcc13


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189040

Route the operator_benchmark test-report upload to GHA artifacts (use-gha)
instead of S3 for the x86/aarch64 opbenchmark test jobs. This makes the run's
operator_benchmark_eager_float32_cpu.csv downloadable via `gh run download`,
so the perf baselines (x86_64/aarch64 _expected_ci_operator_benchmark_eager_
float32_cpu.csv) can be regenerated from an actual runner's output when they
drift (the check currently fails with many IMPROVED / Baseline-Not-Found cases
after a runner/measurement change).