### PR TITLE
Preload full bundled cuDNN set with RTLD_GLOBAL to prevent sublibrary version mismatch

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -322,22 +322,37 @@ def _get_cuda_dep_paths(path: str, lib_folder: str, lib_name: str) -> list[str]:
     return nvidia_lib_paths + lib_paths
 
 
-def _preload_cuda_lib(lib_folder: str, lib_name: str, required: bool = True) -> None:  # type: ignore[valid-type]
-    """Preloads cuda library if it could not be found otherwise."""
+def _preload_cuda_lib(
+    lib_folder: str,
+    lib_name: str,
+    required: bool = True,
+    mode: int | None = None,
+    load_all: bool = False,
+) -> None:  # type: ignore[valid-type]
+    """Preloads cuda library if it could not be found otherwise.
+
+    ``mode`` is forwarded to ``ctypes.CDLL`` (e.g. ``ctypes.RTLD_GLOBAL``).
+    When ``load_all`` is set, every library matching ``lib_name`` in the first
+    directory that contains a match is loaded (used to preload the full cuDNN
+    set of dispatcher + engine sub-libraries).
+    """
     # Should only be called on Linux if default path resolution have failed
     if platform.system() != "Linux":
         raise AssertionError(f"Should only be called on Linux, got {platform.system()}")
 
-    lib_path = None
+    lib_paths: list[str] = []
     for path in sys.path:
         candidate_lib_paths = _get_cuda_dep_paths(path, lib_folder, lib_name)
         if candidate_lib_paths:
-            lib_path = candidate_lib_paths[0]
+            lib_paths = candidate_lib_paths if load_all else candidate_lib_paths[:1]
             break
-    if not lib_path and required:
+    if not lib_paths and required:
         raise ValueError(f"{lib_name} not found in the system path {sys.path}")
-    if lib_path:
-        ctypes.CDLL(lib_path)
+    for lib_path in lib_paths:
+        if mode is not None:
+            ctypes.CDLL(lib_path, mode=mode)
+        else:
+            ctypes.CDLL(lib_path)
 
 
 def _preload_cuda_deps(err: OSError | None = None, required: bool = True) -> None:
@@ -375,7 +390,26 @@ def _preload_cuda_deps(err: OSError | None = None, required: bool = True) -> Non
     # some of these wheels (e.g. just a cupti wheel alongside a system CUDA)
     # preloads the ones present instead of aborting on the first missing one.
     for lib_folder, lib_name in cuda_libs:
-        _preload_cuda_lib(lib_folder, lib_name, required=required)
+        if lib_folder == "cudnn":
+            # Preload the full bundled cuDNN set (dispatcher + engine sub-libs
+            # that get dlopen'd by soname at runtime) with RTLD_GLOBAL so the
+            # bundled copies win over a system cuDNN on the loader path, see
+            # https://github.com/pytorch/pytorch/issues/188892
+            _preload_cuda_lib(
+                lib_folder,
+                "libcudnn.so.*[0-9]",
+                required=required,
+                mode=ctypes.RTLD_GLOBAL,
+            )
+            _preload_cuda_lib(
+                lib_folder,
+                "libcudnn_*.so.*[0-9]",
+                required=False,
+                mode=ctypes.RTLD_GLOBAL,
+                load_all=True,
+            )
+        else:
+            _preload_cuda_lib(lib_folder, lib_name, required=required)
 
     # libnvToolsExt is Optional Dependency
     _preload_cuda_lib("nvtx", "libnvToolsExt.so.*[0-9]", required=False)


### PR DESCRIPTION
Fixes #188892

## Problem

cuDNN 9 is split into a dispatcher (`libcudnn.so`) plus a set of engine sub-libraries (`libcudnn_graph.so`, `libcudnn_engines_*.so`, `libcudnn_ops.so`, ...) that `libcudnn`/`libcudnn_graph` `dlopen` **by soname at runtime**.

`torch._C._preload_cuda_deps` (in `torch/__init__.py`) only preloaded `libcudnn.so`, and with the default `RTLD_LOCAL`. So when `libcudnn_graph.so` later `dlopen`s a sub-library (e.g. `libcudnn_engines_tensor_ir.so`), the loader is free to resolve it from a **system cuDNN** on the loader path. That mixes versions and crashes on the first conv with `CUDNN_STATUS_SUBLIBRARY_VERSION_MISMATCH`, as reported in #188892.

## Fix

Preload the **full bundled cuDNN set** (dispatcher + all `libcudnn_*` engine sub-libraries) with `RTLD_GLOBAL`. Because `dlopen` reuses a library already loaded under the same soname, loading the bundled copies first makes them win over any system copy when cuDNN does its internal `dlopen`. The dispatcher is loaded first, then the engine sub-libraries.

- `_preload_cuda_lib` gains `mode` (forwarded to `ctypes.CDLL`) and `load_all` (load every match in the first matching dir, not just the first). Backward compatible.
- cuDNN is special-cased in `_preload_cuda_deps`; the engine sub-libs are best-effort (`required=False`), while `libcudnn.so` keeps the caller's `required`. Verified against a real bundled cuDNN layout: sub-libs carry `$ORIGIN` RUNPATH, so out-of-order preloads still resolve their siblings from the bundled directory.

Note: this fully addresses version-mixing for self-consistent wheels (cuDNN >= 9.23 which bundle `libcudnn_engines_tensor_ir.so`). Wheels that omit a sub-library entirely still need a self-consistent cuDNN pin.