### PR TITLE
[inductor] Handle symbolic float scalars in FX wrapper metadata hook and reference analysis (#189044)

### DIFF
--- a/test/inductor/test_fxir_backend.py
+++ b/test/inductor/test_fxir_backend.py
@@ -884,6 +884,29 @@ class FxirTestCase(InductorTestCase):
         self.assertEqual(len(perm_arg), 3)
         self.assertEqual(tuple(perm_arg), (0, 2, 1))
 
+    def test_node_metadata_hook_sym_call_method(self):
+        """
+        Inductor's FX wrapper creates symbolic-scalar call_method nodes (e.g.
+        __ceil__ for a float-bound arange size). The metadata hook must compute
+        their value via the method dunder instead of asserting on a node whose
+        op is not call_function.
+        """
+        from torch._export.passes._node_metadata_hook import _node_metadata_hook
+        from torch._subclasses.fake_tensor import FakeTensorMode
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        shape_env = ShapeEnv()
+        fake_mode = FakeTensorMode(shape_env=shape_env)
+        sym_float = shape_env.create_unbacked_symfloat()
+
+        graph = torch.fx.Graph()
+        arg = graph.placeholder("x")
+        arg.meta["val"] = sym_float
+        ceil_node = graph.call_method("__ceil__", (arg,))
+
+        _node_metadata_hook(ceil_node, fake_mode=fake_mode)
+        self.assertIsInstance(ceil_node.meta["val"], torch.SymInt)
+
 
 @instantiate_parametrized_tests
 class AOTFxirTestCase(InductorTestCase):

--- a/test/test_sympy_utils.py
+++ b/test/test_sympy_utils.py
@@ -37,6 +37,7 @@ from torch.utils._sympy.interp import sympy_interp
 from torch.utils._sympy.numbers import int_oo, IntInfinity, NegativeIntInfinity
 from torch.utils._sympy.printers import CppPrinter
 from torch.utils._sympy.reference import (
+    OptimizedPythonReferenceAnalysis,
     PythonReferenceAnalysis,
     ReferenceAnalysis,
     TensorReferenceAnalysis,
@@ -1097,6 +1098,79 @@ class TestSympyFunctions(TestCase):
         x = sympy.Symbol("x", integer=True)
         self.assertIsInstance(TorchSymMin(128 * x, 512 * x), TorchSymMin)
         self.assertIsInstance(TorchSymMax(128 * x, 512 * x), TorchSymMax)
+
+
+class TestOptimizedPythonReferenceAnalysis(TestCase):
+    @staticmethod
+    def _symfloat():
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        return ShapeEnv().create_unbacked_symfloat()
+
+    @staticmethod
+    def _symint():
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        return ShapeEnv().create_unbacked_symint()
+
+    def test_float_to_int_casts_symfloat(self):
+        # A symbolic float must lower to a SymInt rather than stay a SymFloat;
+        # e.g. the float-bound arange length ceil((end - start) / step) feeds a
+        # tensor size, which must be integral. The unoptimized default no-ops on
+        # symbolic inputs, which would leave a SymFloat here.
+        for cast in (
+            OptimizedPythonReferenceAnalysis.floor_to_int,
+            OptimizedPythonReferenceAnalysis.ceil_to_int,
+            OptimizedPythonReferenceAnalysis.trunc_to_int,
+        ):
+            result = cast(self._symfloat(), torch.int64)
+            self.assertIsInstance(result, torch.SymInt)
+
+    def test_symint_passthrough(self):
+        si = self._symint()
+        for cast in (
+            OptimizedPythonReferenceAnalysis.floor_to_int,
+            OptimizedPythonReferenceAnalysis.ceil_to_int,
+            OptimizedPythonReferenceAnalysis.trunc_to_int,
+        ):
+            self.assertIs(cast(si, torch.int64), si)
+
+    def test_concrete_float(self):
+        self.assertEqual(
+            OptimizedPythonReferenceAnalysis.floor_to_int(3.9, torch.int64), 3
+        )
+        self.assertEqual(
+            OptimizedPythonReferenceAnalysis.ceil_to_int(3.1, torch.int64), 4
+        )
+        self.assertEqual(
+            OptimizedPythonReferenceAnalysis.trunc_to_int(3.9, torch.int64), 3
+        )
+
+    def test_proxy_symfloat_routes_through_dunder(self):
+        # The production caller (the Inductor FX wrapper) evaluates the analysis
+        # under proxy tracing, so the input is a Proxy wrapping a SymFloat rather
+        # than a bare SymFloat. _is_float_symbolic must detect it, and the cast
+        # must emit the integer-producing dunder.
+        from torch.utils._sympy.reference import _is_float_symbolic
+
+        graph = torch.fx.Graph()
+        tracer = torch.fx.proxy.GraphAppendingTracer(graph)
+
+        fnode = graph.placeholder("f")
+        fnode.meta["val"] = self._symfloat()
+        fproxy = torch.fx.Proxy(fnode, tracer)
+        self.assertTrue(_is_float_symbolic(fproxy))
+
+        inode = graph.placeholder("i")
+        inode.meta["val"] = self._symint()
+        iproxy = torch.fx.Proxy(inode, tracer)
+        self.assertFalse(_is_float_symbolic(iproxy))
+
+        result = OptimizedPythonReferenceAnalysis.ceil_to_int(fproxy, torch.int64)
+        self.assertIsInstance(result, torch.fx.Proxy)
+        self.assertTrue(
+            any(n.op == "call_method" and n.target == "__ceil__" for n in graph.nodes)
+        )
 
 
 class TestSingletonInt(TestCase):

--- a/torch/_export/passes/_node_metadata_hook.py
+++ b/torch/_export/passes/_node_metadata_hook.py
@@ -35,6 +35,32 @@ def _node_metadata_hook(
     # pyrefly: ignore [bad-assignment]
     fake_mode = fake_mode or contextlib.nullcontext()
 
+    # Inductor's FX wrapper can create symbolic scalar call_method nodes (e.g.
+    # __sym_float__/__ceil__ for a float-bound arange size) while this hook is
+    # active. They are not call_function nodes, so compute their value via the
+    # method dunder and skip the call_function-only handling below.
+    _SYM_DUNDER_METHODS = (
+        "__sym_float__",
+        "__sym_int__",
+        "__ceil__",
+        "__floor__",
+        "__trunc__",
+        "__round__",
+    )
+    if node.op == "call_method" and node.target in _SYM_DUNDER_METHODS:
+        fake_args, fake_kwargs = pytree.tree_map_only(
+            torch.fx.Node, lambda arg: arg.meta["val"], (node.args, node.kwargs)
+        )
+        # pyrefly: ignore [bad-context-manager]
+        with fake_mode, enable_python_dispatcher():
+            node.meta["val"] = getattr(fake_args[0], node.target)(
+                *fake_args[1:], **fake_kwargs
+            )
+        if metadata is not None:
+            for k, v in metadata.items():
+                node.meta[k] = v
+        return
+
     if node.op != "call_function" or not callable(node.target):
         raise AssertionError(f"node: {node}, target: {node.target}")
 

--- a/torch/utils/_sympy/printers.py
+++ b/torch/utils/_sympy/printers.py
@@ -510,8 +510,9 @@ class CppPrinter(ExprPrinter):
                     + ")"
                 )
             elif exp == -1:
-                # pyrefly: ignore [missing-attribute]
-                r = "1.0/" + self._print(base)
+                # Parenthesize the base so a compound denominator (e.g. an Add
+                # like ``k + 20``) is not mis-parsed as ``1.0/k + 20``.
+                r = "1.0/" + self.parenthesize(base, PRECEDENCE["Mul"], strict=True)
             else:  # exp == 0
                 r = "1.0"
 

--- a/torch/utils/_sympy/reference.py
+++ b/torch/utils/_sympy/reference.py
@@ -357,6 +357,16 @@ class PythonReferenceAnalysis(ReferenceAnalysis):
 
 # Like PythonReferenceAnalysis, but some export-unfriendly choices of
 # operators to make things faster
+def _is_float_symbolic(x: object) -> bool:
+    """True for a symbolic float value, whether a SymFloat or a Proxy wrapping
+    one (the latter occurs while inductor traces sympy expressions)."""
+    if isinstance(x, torch.SymFloat):
+        return True
+    if isinstance(x, torch.fx.Proxy):
+        return isinstance(x.node.meta.get("val"), (float, torch.SymFloat))
+    return False
+
+
 class OptimizedPythonReferenceAnalysis(PythonReferenceAnalysis):
     @staticmethod
     def sym_sum(args):
@@ -366,18 +376,26 @@ class OptimizedPythonReferenceAnalysis(PythonReferenceAnalysis):
     def floor_to_int(x, dtype):
         if isinstance(x, (int, float)):
             return math.floor(x)
+        # A symbolic float must be lowered to an int; the no-op default would
+        # leave a SymFloat where an int is required (e.g. a tensor size).
+        if _is_float_symbolic(x):
+            return x.__floor__()
         return x
 
     @staticmethod
     def ceil_to_int(x, dtype):
         if isinstance(x, (int, float)):
             return math.ceil(x)
+        if _is_float_symbolic(x):
+            return x.__ceil__()
         return x
 
     @staticmethod
     def trunc_to_int(x, dtype):
         if isinstance(x, (int, float)):
             return math.trunc(x)
+        if _is_float_symbolic(x):
+            return x.__trunc__()
         return x
 
 


### PR DESCRIPTION
Summary:

When the Inductor FX wrapper backend (`fx_wrapper=True`, used by MTIA) lowers an op whose size depends on a symbolic float -- e.g. `torch.arange(start, end=3.1, dtype=torch.float32)` with a dynamic integer `start`, whose length is `ceil((end - start) / step)` -- it materializes the size computation as `__sym_float__` / `__ceil__` `call_method` nodes and evaluates them through the sympy reference analysis. Three gaps in core made this fail:

1. `_node_metadata_hook` (installed by the FX wrapper via `_set_node_metadata_hook`) asserts that every newly created node is a `call_function`, raising `AssertionError: node: sym_float, target: __sym_float__` on the symbolic-scalar `call_method` nodes the wrapper itself creates. We now compute the node value via the method dunder for the known symbolic dunders (`__sym_float__`, `__sym_int__`, `__ceil__`, `__floor__`, `__trunc__`, `__round__`) and return, instead of asserting.

2. `OptimizedPythonReferenceAnalysis.{floor,ceil,trunc}_to_int` no-op on symbolic inputs (`return x`), so a `SymFloat` flows through unchanged where an integer is required -- e.g. a tensor size passed to `empty_strided`. We now lower a symbolic float to an int via the matching dunder, gated by a new `_is_float_symbolic` helper (true for a `SymFloat` or a `Proxy` wrapping one).

3. `CppPrinter._print_Pow` printed a reciprocal `Pow(base, -1)` as `"1.0/" + base` without parenthesizing `base`, so `1/(k + 20)` with a compound `Add` denominator printed as `1.0/k + 20` (wrong precedence), silently mangling the division. The `exp < -1` branch already parenthesizes; `exp == -1` did not. We parenthesize the base via `self.parenthesize(base, PRECEDENCE["Mul"], strict=True)` (wraps compound denominators, leaves atoms/function calls bare). This is a general Inductor codegen correctness bug (any `1/(a+b)` through `CppPrinter`); it is required here because the downstream MTIA diff switches shape inference to `CppPrinter`, and a nested integer `FloorDiv` output `(s+1760)//((s//88)+20)` was being emitted as `floor(1.0/20 + (s//88)*(s+1760))` and computing the wrong value.

Changed files:
- `torch/_export/passes/_node_metadata_hook.py`: handle symbolic scalar `call_method` nodes.
- `torch/utils/_sympy/reference.py`: `_is_float_symbolic` helper; lower symbolic floats to int in `floor/ceil/trunc_to_int`.
- `torch/utils/_sympy/printers.py`: parenthesize the base of a `Pow(base, -1)` reciprocal in `CppPrinter._print_Pow`.
- `test/test_sympy_utils.py`, `test/inductor/test_fxir_backend.py`: unit tests.

Test Plan:
Unit: `buck2 test fbcode//caffe2/test/inductor:fxir_backend -- --regex test_node_metadata_hook_sym_call_method`; `TestOptimizedPythonReferenceAnalysis` in `test/test_sympy_utils.py`.

Reciprocal-parenthesization fix verified via the downstream MTIA shape-inf e2e: `test_floordiv_shape_expr_output` now returns the correct value (was 1848, now 88) on artemis across `test_dynamic_shapes_basic_ops`, `test_dynamic_memory_allocation`, `test_dynamic_shapes_pacific` (Pass 6 / Fail 0). No golden churn: `test_fba_shape_inf_lib-artemis` Pass 32 / Fail 0.

Differential Revision: D110056858




cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo