### PR TITLE
Treat PrivateUse1 as CUDA-like under env override to reuse CUDA optimization paths in shared `at::native` operators

### DIFF
--- a/aten/src/ATen/AccumulateType.cpp
+++ b/aten/src/ATen/AccumulateType.cpp
@@ -6,15 +6,20 @@ c10::ScalarType toAccumulateType(c10::ScalarType type, c10::DeviceType device) {
   switch (type) {
 #define DEFINE_CASE(scalar_t, TypeNum)                                                             \
     case ScalarType::TypeNum:                                                                      \
-      switch (device) {                                                                            \
-        case DeviceType::CUDA:                                                                     \
-          return CppTypeToScalarType<at::acc_type_device<scalar_t, c10::DeviceType::CUDA>>::value; \
-        case DeviceType::XPU:                                                                      \
-          return CppTypeToScalarType<at::acc_type_device<scalar_t, c10::DeviceType::XPU>>::value;  \
-        case DeviceType::MPS:                                                                      \
-          return CppTypeToScalarType<at::acc_type_device<scalar_t, c10::DeviceType::MPS>>::value;  \
-        default:                                                                                   \
-          return CppTypeToScalarType<at::acc_type_device<scalar_t, c10::DeviceType::CPU>>::value;  \
+      switch (device) {
+        case DeviceType::CUDA:
+          return CppTypeToScalarType<at::acc_type_device<scalar_t, c10::DeviceType::CUDA>>::value;
+        case DeviceType::PrivateUse1:
+          if (c10::Device::privateUse1MatchesCuda()) {
+            return CppTypeToScalarType<at::acc_type_device<scalar_t, c10::DeviceType::CUDA>>::value;
+          }
+          [[fallthrough]];
+        case DeviceType::XPU:
+          return CppTypeToScalarType<at::acc_type_device<scalar_t, c10::DeviceType::XPU>>::value;
+        case DeviceType::MPS:
+          return CppTypeToScalarType<at::acc_type_device<scalar_t, c10::DeviceType::MPS>>::value;
+        default:
+          return CppTypeToScalarType<at::acc_type_device<scalar_t, c10::DeviceType::CPU>>::value;
       }
 
     AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_EXCEPT_COMPLEX_HALF_F8NZ(DEFINE_CASE)
@@ -25,7 +30,8 @@ c10::ScalarType toAccumulateType(c10::ScalarType type, c10::DeviceType device) {
 }
 
 c10::ScalarType toAccumulateType(c10::ScalarType type, bool is_cuda) {
-  return is_cuda ? toAccumulateType(type, c10::DeviceType::CUDA) : toAccumulateType(type, c10::DeviceType::CPU);
+  return is_cuda ? toAccumulateType(type, c10::DeviceType::CUDA)
+                 : toAccumulateType(type, c10::DeviceType::CPU);
 }
 
 }

--- a/aten/src/ATen/AccumulateType.cpp
+++ b/aten/src/ATen/AccumulateType.cpp
@@ -4,28 +4,34 @@ namespace at {
 
 c10::ScalarType toAccumulateType(c10::ScalarType type, c10::DeviceType device) {
   switch (type) {
-#define DEFINE_CASE(scalar_t, TypeNum)                                                             \
-    case ScalarType::TypeNum:                                                                      \
-      switch (device) {
-        case DeviceType::CUDA:
-          return CppTypeToScalarType<at::acc_type_device<scalar_t, c10::DeviceType::CUDA>>::value;
-        case DeviceType::PrivateUse1:
-          if (c10::Device::privateUse1MatchesCuda()) {
-            return CppTypeToScalarType<at::acc_type_device<scalar_t, c10::DeviceType::CUDA>>::value;
-          }
-          [[fallthrough]];
-        case DeviceType::XPU:
-          return CppTypeToScalarType<at::acc_type_device<scalar_t, c10::DeviceType::XPU>>::value;
-        case DeviceType::MPS:
-          return CppTypeToScalarType<at::acc_type_device<scalar_t, c10::DeviceType::MPS>>::value;
-        default:
-          return CppTypeToScalarType<at::acc_type_device<scalar_t, c10::DeviceType::CPU>>::value;
-      }
+#define DEFINE_CASE(scalar_t, TypeNum)                                      \
+  case ScalarType::TypeNum:                                                 \
+    switch (device) {                                                       \
+      case DeviceType::CUDA:                                                \
+        return CppTypeToScalarType<                                         \
+            at::acc_type_device<scalar_t, c10::DeviceType::CUDA>>::value;   \
+      case DeviceType::PrivateUse1:                                         \
+        if (c10::Device::privateUse1MatchesCuda()) {                        \
+          return CppTypeToScalarType<                                       \
+              at::acc_type_device<scalar_t, c10::DeviceType::CUDA>>::value; \
+        }                                                                   \
+        [[fallthrough]];                                                    \
+      case DeviceType::XPU:                                                 \
+        return CppTypeToScalarType<                                         \
+            at::acc_type_device<scalar_t, c10::DeviceType::XPU>>::value;    \
+      case DeviceType::MPS:                                                 \
+        return CppTypeToScalarType<                                         \
+            at::acc_type_device<scalar_t, c10::DeviceType::MPS>>::value;    \
+      default:                                                              \
+        return CppTypeToScalarType<                                         \
+            at::acc_type_device<scalar_t, c10::DeviceType::CPU>>::value;    \
+    }
 
     AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_EXCEPT_COMPLEX_HALF_F8NZ(DEFINE_CASE)
 #undef DEFINE_CASE
 
-    default: TORCH_INTERNAL_ASSERT(false, "Unrecognized ScalarType: ", type);
+    default:
+      TORCH_INTERNAL_ASSERT(false, "Unrecognized ScalarType: ", type);
   }
 }
 
@@ -34,4 +40,4 @@ c10::ScalarType toAccumulateType(c10::ScalarType type, bool is_cuda) {
                  : toAccumulateType(type, c10::DeviceType::CPU);
 }
 
-}
+} // namespace at

--- a/aten/src/ATen/AccumulateType.cpp
+++ b/aten/src/ATen/AccumulateType.cpp
@@ -10,18 +10,18 @@ c10::ScalarType toAccumulateType(c10::ScalarType type, c10::DeviceType device) {
       case DeviceType::CUDA:                                                \
         return CppTypeToScalarType<                                         \
             at::acc_type_device<scalar_t, c10::DeviceType::CUDA>>::value;   \
-      case DeviceType::PrivateUse1:                                         \
-        if (c10::Device::privateUse1MatchesCuda()) {                        \
-          return CppTypeToScalarType<                                       \
-              at::acc_type_device<scalar_t, c10::DeviceType::CUDA>>::value; \
-        }                                                                   \
-        [[fallthrough]];                                                    \
       case DeviceType::XPU:                                                 \
         return CppTypeToScalarType<                                         \
             at::acc_type_device<scalar_t, c10::DeviceType::XPU>>::value;    \
       case DeviceType::MPS:                                                 \
         return CppTypeToScalarType<                                         \
             at::acc_type_device<scalar_t, c10::DeviceType::MPS>>::value;    \
+      case DeviceType::PrivateUse1:                                         \
+        if (c10::Device::privateUse1MatchesCuda()) {                        \
+          return CppTypeToScalarType<                                       \
+              at::acc_type_device<scalar_t, c10::DeviceType::CUDA>>::value; \
+        }                                                                   \
+        [[fallthrough]];                                                    \
       default:                                                              \
         return CppTypeToScalarType<                                         \
             at::acc_type_device<scalar_t, c10::DeviceType::CPU>>::value;    \

--- a/aten/src/ATen/native/ReduceOpsUtils.h
+++ b/aten/src/ATen/native/ReduceOpsUtils.h
@@ -217,8 +217,11 @@ inline TensorIterator make_reduction(
   // efficiency.
   // not generalize this to common mismatched input/output types to avoid cross
   // product of templated kernel launches.
-  const bool gpu_lowp_to_f32 = (
-        (self.is_cuda() || self.is_xpu()) && (self.scalar_type() == kHalf || self.scalar_type() == kBFloat16) && out_dtype == kFloat);
+  const bool gpu_lowp_to_f32 =
+      ((c10::Device::isCudaOrPrivateUse1MatchesCuda(self.device().type()) ||
+        self.is_xpu()) &&
+       (self.scalar_type() == kHalf || self.scalar_type() == kBFloat16) &&
+       out_dtype == kFloat);
   auto in_dtype = gpu_lowp_to_f32 ? self.scalar_type()
                    : self.is_complex() ? c10::toComplexType(out_dtype)
                                        : out_dtype;
@@ -254,7 +257,8 @@ inline TensorIterator make_reduction(
   // We don't generalize this to common mismatched input/output types to avoid cross
   // product of templated kernel launches.
   if (self.scalar_type() == dtype1 ||
-      (self.is_cuda() && self.scalar_type() == kHalf && dtype1 == kFloat)) {
+      (c10::Device::isCudaOrPrivateUse1MatchesCuda(self.device().type()) &&
+       self.scalar_type() == kHalf && dtype1 == kFloat)) {
     return TensorIterator::reduce_op(viewed_result1, viewed_result2, self);
   }
   return TensorIterator::reduce_op(viewed_result1, viewed_result2, self.to(dtype1));
@@ -450,7 +454,7 @@ inline TensorIterator make_reduction(
   // not generalize this to common mismatched input/output types to avoid cross
   // product of templated kernel launches.
   const bool gpu_lowp_to_f32 =
-      (self.is_cuda() &&
+      (c10::Device::isCudaOrPrivateUse1MatchesCuda(self.device().type()) &&
        (self.scalar_type() == kHalf || self.scalar_type() == kBFloat16) &&
        out_dtype == kFloat);
   auto in_dtype = gpu_lowp_to_f32 ? self.scalar_type() : out_dtype;

--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -679,7 +679,7 @@ AdvancedIndex::AdvancedIndex(const Tensor& src, TensorList indices_list) {
   // For CUDA/MPS/XPU tensors, force all index tensors to have the same striding
   // to simplify the CUDA/MPS/XPU kernel.
   if (indices.size() >= 2 &&
-      (this->src.device().type() == kCUDA ||
+      (c10::Device::isCudaOrPrivateUse1MatchesCuda(this->src.device().type()) ||
        this->src.device().type() == kMPS ||
        this->src.device().type() == kXPU)) {
     if (!all_strides_match(indices)) {

--- a/c10/core/Device.cpp
+++ b/c10/core/Device.cpp
@@ -1,5 +1,6 @@
 #include <c10/core/Device.h>
 #include <c10/util/Exception.h>
+#include <c10/util/env.h>
 
 #include <algorithm>
 #include <array>
@@ -155,6 +156,17 @@ std::string Device::str() const {
     str.append(std::to_string(index()));
   }
   return str;
+}
+
+bool Device::privateUse1MatchesCuda() {
+  static const bool privateuse1_matches_cuda =
+      c10::utils::check_env("PYTORCH_PRIVATEUSE1_MATCHES_CUDA").value_or(false);
+  return privateuse1_matches_cuda;
+}
+
+bool Device::isCudaOrPrivateUse1MatchesCuda(DeviceType type) {
+  return type == DeviceType::CUDA ||
+      (type == DeviceType::PrivateUse1 && privateUse1MatchesCuda());
 }
 
 std::ostream& operator<<(std::ostream& stream, const Device& device) {

--- a/c10/core/Device.h
+++ b/c10/core/Device.h
@@ -87,6 +87,13 @@ struct C10_API Device final {
     return type_ == DeviceType::PrivateUse1;
   }
 
+  /// Return true if PrivateUse1 should use CUDA semantics.
+  static bool privateUse1MatchesCuda();
+
+  /// Return true if the device is CUDA or PrivateUse1 should use CUDA
+  /// semantics.
+  static bool isCudaOrPrivateUse1MatchesCuda(DeviceType type);
+
   /// Return true if the device is of MPS type.
   bool is_mps() const noexcept {
     return type_ == DeviceType::MPS;


### PR DESCRIPTION
Introduce a single opt-in switch:

- A static helper `c10::Device::privateUse1MatchesCuda()` that reads the env var `PYTORCH_PRIVATEUSE1_MATCHES_CUDA` once and caches the result.
- A convenience helper `c10::Device::isCudaOrPrivateUse1MatchesCuda(DeviceType)` that returns true for `DeviceType::CUDA`, or for `DeviceType::PrivateUse1` when the env var is enabled.
- Replace `self.is_cuda()` / `device == kCUDA` in the three identified code paths with `isCudaOrPrivateUse1MatchesCuda(self.device().type())`, so `privateuse1` reaches the CUDA optimization branch under the env override.
- In `toAccumulateType`, add a `case DeviceType::PrivateUse1` that returns the CUDA accumulate type when the env var is enabled, and `[[fallthrough]]` to the default (CPU) accumulate type otherwise.

### Key properties

- **Backward compatible**: the env var defaults to off. No existing CPU/CUDA/MPS/XPU code path changes behavior; no existing `privateuse1` backend is affected unless it explicitly opts in.
- **Additive**: no existing operator logic is modified — only the device predicate in the gating condition.
- **Single switch, multiple beneficiaries**: one env var unlocks three independent optimization paths (index stride alignment, float-precision renorm accumulation, no-cast low-precision reductions) without per-operator special-casing.
- **Scope-limited**: only the three verified `at::native` code paths are affected in this request. The mechanism is general and can be extended to other CUDA-gated shared operators in follow-up work, but this issue requests only the three identified above.

fixes #189046 