### PR TITLE
test: fix python 3.14 incompatibilities in inductor tests

### DIFF
--- a/test/inductor/test_inductor_utils.py
+++ b/test/inductor/test_inductor_utils.py
@@ -83,7 +83,9 @@ class TestBench(TestCase):
         super().setUpClass()
         x = torch.rand(1024, 10).to(device_type).half()
         w = torch.rand(512, 10).to(device_type).half()
-        cls._bench_fn = functools.partial(torch.nn.functional.linear, x, w)
+        cls._bench_fn = staticmethod(
+            functools.partial(torch.nn.functional.linear, x, w)
+        )
 
     def test_benchmarker(self):
         res = benchmarker.benchmark_gpu(self._bench_fn)

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -3396,9 +3396,9 @@ def forward(self, arg0_1, arg1_1):
             return y
 
         # make sure FLOAT_CONSTANT_C is NOT annotated
-        self.assertFalse("FLOAT_CONSTANT_C" in globals().get("__annotations__", {}))
+        self.assertFalse("FLOAT_CONSTANT_C" in sys.modules[__name__].__annotations__)
         # sanity check: STRING_CONSTANT_C _should_ be annotated
-        self.assertTrue("STRING_CONSTANT_C" in globals().get("__annotations__", {}))
+        self.assertTrue("STRING_CONSTANT_C" in sys.modules[__name__].__annotations__)
 
         x = torch.randn(512, device=GPU_TYPE)
         expected = x + 3.14


### PR DESCRIPTION
- `test_inductor_utils.py`: In Python 3.14, `functools.partial` implements the descriptor protocol (`__get__`). Assigning a `partial` object directly to `cls._bench_fn` caused attribute access on `self._bench_fn` to bind `self` as the first positional argument.
The fix wrapped `functools.partial` in `staticmethod(...)` when `assigning cls._bench_fn` in `TestBench.setUpClass`, preventing unwanted instance binding.
- `test_triton_kernels.py`: In Python 3.14 (PEP 649 / PEP 749), module-level annotations are evaluated lazily via descriptors and `__annotate__` rather than being written eagerly to the raw `globals()` dictionary at execution time. `test_triton_kernel_global_constexpr` was updated to check `sys.modules[__name__].__annotations__` instead of `globals().get("__annotations__", {})`, triggering deferred evaluation and resolving the boolean checks cleanly.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo