### PR TITLE
Replace boto3-optionality CI job with a tools unit test

### DIFF
--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -595,10 +595,6 @@ class TestTryMerge(TestCase):
                 "name": "lintrunner / linux-job",
                 "expected": "lintrunner / linux-job",
             },
-            {
-                "name": "Test `run_test.py` is usable without boto3",
-                "expected": "Test `run_test.py` is usable without boto3",
-            },
         ]
 
         for case in test_cases:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -237,32 +237,6 @@ jobs:
         PYTHONPATH=$(pwd) pytest tools/test -o "python_files=test*.py"
         PYTHONPATH=$(pwd) pytest .github/scripts -o "python_files=test*.py"
 
-  test_run_test:
-    name: Test `run_test.py` is usable without boto3
-    if: ${{ github.repository == 'pytorch/pytorch' }}
-    runs-on: linux.24_04.4x
-    steps:
-      - name: Checkout PyTorch
-        uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
-        with:
-          submodules: false
-          fetch-depth: 1
-      - name: Setup Python 3.10
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: '3.10'
-          architecture: x64
-          cache: pip
-      - name: Install dependencies
-        run: |
-          python3 -m pip install --upgrade pip
-          pip install pytest-rerunfailures==11.1.* pytest-flakefinder==1.1.* pytest-xdist==3.3.* expecttest==0.3.* fbscribelogger==0.1.* numpy==1.24.*
-          pip install torch --pre --index-url https://download.pytorch.org/whl/nightly/cpu/
-      - name: Run run_test.py (nonretryable)
-        run: |
-          # Run test_vulkan, which is a fast noop on Linux
-          python3 test/run_test.py --include test_vulkan --verbose
-
   test_collect_env:
     if: ${{ github.repository == 'pytorch/pytorch' }}
     name: Test collect_env

--- a/tools/test/test_run_test_no_boto3.py
+++ b/tools/test/test_run_test_no_boto3.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# run_test.py must stay usable when boto3 is absent (e.g. a contributor's
+# machine): boto3 is only used to upload metrics/stats to S3 and its import is
+# guarded in tools/stats/upload_metrics.py. run_test.py itself can't be imported
+# without a built torch, but the only boto3 dependency in its import chain lives
+# in tools/stats, so we exercise that here in a fresh interpreter with boto3
+# blocked via sys.modules[...] = None (which makes `import boto3` raise).
+_CHECK = """
+import sys
+sys.modules["boto3"] = None
+from tools.stats.import_test_stats import (
+    ADDITIONAL_CI_FILES_FOLDER,
+    TEST_CLASS_TIMES_FILE,
+    TEST_TIMES_FILE,
+)
+from tools.stats.upload_metrics import add_global_metric, emit_metric
+import tools.stats.upload_metrics as m
+assert m.EMIT_METRICS is False, f"EMIT_METRICS should be False without boto3, got {m.EMIT_METRICS}"
+"""
+
+
+class TestRunTestNoBoto3(unittest.TestCase):
+    def test_stats_imports_without_boto3(self) -> None:
+        result = subprocess.run(
+            [sys.executable, "-c", _CHECK],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"run_test.py stats imports failed without boto3:\n{result.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #189058
* __->__ #189057

The "Test `run_test.py` is usable without boto3" job ran on a bare
GitHub runner and pip-installed a nightly torch from
download.pytorch.org on every run. That endpoint intermittently fails
the TLS handshake, and pip's built-in retries all fall inside the same
bad window, so the job flaked. It also could not follow the "deps baked
into docker" convention the rest of the lint workflow uses, because no
CI image ships a real torch and the linter image (which does have the
pytest deps) ironically ships boto3, defeating the job's purpose.

The invariant being protected is narrow: run_test.py must stay usable
when boto3 is absent. boto3 is only used to upload metrics/stats to S3,
and its import is already guarded in tools/stats/upload_metrics.py. That
guarded import is the entire boto3 dependency in run_test.py's import
chain, and it lives in tools/stats, which needs no torch. The old job
only dragged in a full torch download to satisfy run_test.py's other
top-level imports, which are incidental to what was being tested.

So this removes the job and replaces it with a subprocess-based unit
test in tools/test that runs inside the existing docker-based
"Test tools" job (pytest tools/test): no torch, no network. The test
launches a fresh interpreter with boto3 blocked and imports exactly what
run_test.py pulls from tools/stats, asserting EMIT_METRICS is False. A
subprocess is required because upload_stats_lib and boto3 get imported
(with boto3 present) before an in-process test could block them, so
reloading would just re-succeed.

Test Plan:

Ran the new test locally:

```
python tools/test/test_run_test_no_boto3.py
```

Confirmed the block mechanism actually catches a regression: simulating
an unguarded import exits non-zero:

```
python -c 'import sys; sys.modules["boto3"] = None; import tools.stats.upload_stats_lib'
```

This PR was authored with the assistance of Claude (an AI assistant).