### PR TITLE
DEMO DO NOT LAND: break boto3 optionality to exercise the CI test

### DIFF
--- a/tools/stats/import_test_stats.py
+++ b/tools/stats/import_test_stats.py
@@ -6,6 +6,9 @@ import datetime
 import json
 import os
 import shutil
+
+import boto3  # DEMO: unguarded boto3 import to prove the CI test catches it
+
 from pathlib import Path
 from typing import Any, cast, TYPE_CHECKING
 from urllib.request import urlopen


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189058
* #189057

Adds an unguarded `import boto3` to tools/stats/import_test_stats.py,
which run_test.py imports at module load. This is exactly the regression
the previous commit's test guards against: with boto3 absent the import
now hard-fails. Purpose is to watch the "Test tools" CI job go red and
confirm the guard works end-to-end. Revert (drop this commit) before
landing.

Test Plan:

```
python tools/test/test_run_test_no_boto3.py
```

Now FAILS with "ModuleNotFoundError: import of boto3 halted", whereas it
passed on the parent commit.

This PR was authored with the assistance of Claude (an AI assistant).