### PR TITLE
[inductor] Fix data-dependent GuardOnDataDependentSymNode in get_fill_order

### DIFF
--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -312,6 +312,39 @@ class TestUtils(TestCase):
 instantiate_device_type_tests(TestUtils, globals(), allow_xpu=True)
 
 
+class TestFillOrder(TestCase):
+    def test_get_fill_order_unbacked_stride_no_shape_env(self):
+        # get_stride_order / get_fill_order are called in several places
+        # without an explicit shape_env (e.g. GraphLowering.run_node's
+        # fixed-layout path). When a stride is an unbacked expression the
+        # plain argsort path used to guard and raise
+        # GuardOnDataDependentSymNode. get_fill_order now recovers the
+        # shape_env from the symbolic strides and routes through argsort_sym.
+        from torch._inductor.ir import get_fill_order, get_stride_order
+        from torch._subclasses.fake_tensor import FakeTensorMode
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        shape_env = ShapeEnv()
+        with FakeTensorMode(shape_env=shape_env):
+            u0 = shape_env.create_unbacked_symint()
+            # u0 vs a concrete value is genuinely data-dependent.
+            seq = [5, u0, 1]
+            # No shape_env passed: must not raise GuardOnDataDependentSymNode.
+            self.assertEqual(len(get_fill_order(seq)), 3)
+            self.assertEqual(len(get_stride_order(seq)), 3)
+            # An explicitly passed shape_env yields the same result.
+            self.assertEqual(get_fill_order(seq), get_fill_order(seq, shape_env))
+
+    def test_get_fill_order_matches_argsort_when_static(self):
+        # For fully static strides the recovery is a no-op and the result
+        # matches the plain argsort path.
+        from torch._inductor.ir import get_fill_order
+        from torch._inductor.utils import argsort
+
+        for seq in ([32, 8, 8, 1], [1, 8, 8, 32], [4, 2, 7], []):
+            self.assertEqual(list(get_fill_order(seq)), argsort(seq))
+
+
 class TestRuntimeEstimation(TestCase):
     def test_get_compute_time_units(self):
         """TFLOPS-to-FLOPS/s conversion must use 1e12, not 1e15."""

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -344,6 +344,17 @@ def get_fill_order(
     """
     Convert strides to fill order (argsort)
     """
+    if shape_env is None:
+        # Recover a shape_env from any symbolic stride so that unbacked
+        # comparisons route through argsort_sym (which resolves
+        # data-dependent comparisons via optimization hints) instead of the
+        # plain argsort path, whose sorted() would guard and raise
+        # GuardOnDataDependentSymNode. Callers that already pass a shape_env
+        # are unaffected.
+        for s in seq:
+            if isinstance(s, torch.SymInt):
+                shape_env = s.node.shape_env
+                break
     if shape_env is None or all(isinstance(s, (int, sympy.Integer)) for s in seq):
         sorted_idx: Sequence[int] = argsort(seq)
     else:


### PR DESCRIPTION
### Summary

`get_stride_order` / `get_fill_order` are called in several places without a
`shape_env`, most notably from `GraphLowering.run_node` when a node needs a
fixed layout:

```python
ir.get_stride_order(n.meta["val"].stride())
```

With no `shape_env`, `get_fill_order` took the plain `argsort` path, which uses
`sorted(range(n), key=seq.__getitem__, reverse=True)`. When a stride is an
unbacked expression (e.g. `3600*Max(1, u0)`), Python's sort coerces the symbolic
comparison to `bool`, installing a guard and raising:

```
GuardOnDataDependentSymNode: Could not guard on data-dependent expression
3600*Max(1, u0) > 3600 (unhinted: 3600*Max(1, u0) > 3600). (Size-like symbols: u0)
```

### Root cause

The crashing call site simply did not pass a `shape_env`, unlike the sibling
`inductor_force_stride_order` lowering which passes `V.graph.sizevars.shape_env`
and therefore already routes through `argsort_sym`. `argsort_sym` resolves
data-dependent comparisons via `optimization_hint` (a non-guarding, hint-based
ordering), so it never raises.

### Fix

Rather than degrade the generic `argsort` (which would silently return a
lower-quality order for symbolic input and surprise other callers),
this centralizes the fix in `get_fill_order`: when no `shape_env` is passed, it
recovers one from the symbolic strides themselves (`torch.SymInt` carries
`.node.shape_env`) and routes symbolic sequences through `argsort_sym`. Fully
static sequences are unchanged, and callers that already pass a `shape_env` are
unaffected.

### Why this is safe

The resulting order only feeds layout heuristics. `require_stride_order` inserts
a copy and freezes it to the chosen layout while preserving logical data, so the
ordering choice can never change numerics -- it only affects which physical
layout is materialized. By recovering the `shape_env` we now make the same
hint-based (most-likely-correct) layout choice that the explicit-`shape_env`
callers already make, instead of falling back to an arbitrary order.

### Test Plan

```
python test/inductor/test_utils.py TestFillOrder
```

The new tests verify (1) for fully static strides `get_fill_order` matches the
plain `argsort` path, and (2) for an unbacked stride with no `shape_env` passed,
`get_fill_order` / `get_stride_order` no longer raise
`GuardOnDataDependentSymNode` and produce the same order as when the `shape_env`
is passed explicitly.

_This PR was authored with the assistance of an AI coding assistant._
