### PR TITLE
[profiler][cupti] Make CUPTI monitor buffer_size / flush_period_s config-only

### DIFF
--- a/test/profiler/test_cupti_monitor.py
+++ b/test/profiler/test_cupti_monitor.py
@@ -153,21 +153,21 @@ class TestCuptiRecords(TestCase):
         self.assertEqual(fields[memcpy], all_memcpy)
 
     @unittest.skipIf(not TEST_CUPTI_V13_3, "requires libcupti >= 13.3")
-    def test_monitor_buffer_size_from_env(self):
-        # The per-buffer pool size is user-configurable: an explicit buffer_size
-        # arg wins, otherwise TORCH_CUPTI_MONITOR_BUFFER_SIZE is honored, else the
-        # 4 MiB default. No CUDA -- this only reads the constructor config.
-        import unittest.mock
+    def test_monitor_buffer_size_and_flush_period_config(self):
+        # buffer_size and flush_period_s are constructor settings (no env var): the
+        # defaults otherwise. No CUDA -- this only reads the constructor config.
+        from torch.profiler._cupti.monitor import (
+            _DEFAULT_BUFFER_SIZE,
+            _DEFAULT_FLUSH_PERIOD_S,
+            CuptiMonitor,
+        )
 
-        from torch.profiler._cupti.monitor import _DEFAULT_BUFFER_SIZE, CuptiMonitor
-
-        self.assertEqual(CuptiMonitor().buffer_size, _DEFAULT_BUFFER_SIZE)
-        with unittest.mock.patch.dict(
-            "os.environ", {"TORCH_CUPTI_MONITOR_BUFFER_SIZE": "1048576"}
-        ):
-            self.assertEqual(CuptiMonitor().buffer_size, 1048576)
-            # An explicit arg overrides the env var.
-            self.assertEqual(CuptiMonitor(buffer_size=2048).buffer_size, 2048)
+        m = CuptiMonitor()
+        self.assertEqual(m.buffer_size, _DEFAULT_BUFFER_SIZE)
+        self.assertEqual(m.flush_period_s, _DEFAULT_FLUSH_PERIOD_S)
+        m = CuptiMonitor(buffer_size=2048, flush_period_s=-1.0)
+        self.assertEqual(m.buffer_size, 2048)
+        self.assertEqual(m.flush_period_s, -1.0)
 
     @unittest.skipIf(not TEST_CUPTI_V13_3, "requires libcupti >= 13.3")
     def test_monitor_external_correlation_not_started(self):

--- a/torch/profiler/_cupti/monitor.py
+++ b/torch/profiler/_cupti/monitor.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import ctypes
 import json
 import logging
-import os
 import threading
 import time
 from collections.abc import Callable, Iterable, Mapping
@@ -102,8 +101,8 @@ class CuptiMonitor:
     def __init__(
         self,
         *,
-        buffer_size: int | None = None,
-        flush_period_s: float | None = None,
+        buffer_size: int = _DEFAULT_BUFFER_SIZE,
+        flush_period_s: float = _DEFAULT_FLUSH_PERIOD_S,
     ) -> None:
         # The monitor is the engine and the multiplexer: it owns the single CUPTI
         # subscription + buffer pool + native decode worker, which demuxes each
@@ -115,17 +114,11 @@ class CuptiMonitor:
         # selection, decoded columnar against a record layout computed from the
         # field-size spec (no captured layout needed). This requires libcupti >= 13.2.
         #
-        # Per-buffer pool size (bytes). An explicit arg wins; otherwise it comes from
-        # TORCH_CUPTI_MONITOR_BUFFER_SIZE (default 4 MiB). Bigger buffers complete less
-        # often (fewer worker wakeups, lower overhead) at the cost of more pinned host
-        # memory and coarser delivery.
-        if buffer_size is None:
-            buffer_size = int(
-                os.environ.get("TORCH_CUPTI_MONITOR_BUFFER_SIZE", _DEFAULT_BUFFER_SIZE)
-            )
+        # Per-buffer pool size (bytes), default 4 MiB. Bigger buffers complete less often
+        # (fewer worker wakeups, lower overhead) at the cost of more pinned host memory and
+        # coarser delivery.
         self.buffer_size = buffer_size
-        # Background-drain flush period (seconds). An explicit arg wins; otherwise it
-        # comes from TORCH_CUPTI_MONITOR_FLUSH_PERIOD_S (default 1.0). Sign-encoded:
+        # Background-drain flush period (seconds), default 1.0. Sign-encoded:
         #   > 0  -> background flush thread drains every flush_period_s.
         #    0   -> background flush thread drains continuously (no wait between flushes).
         #   < 0  -> NO background flush thread; the caller must drive flush() itself
@@ -139,12 +132,6 @@ class CuptiMonitor:
         #           only reads buffers CUPTI already handed over), and that this still
         #           avoids the corruption is what confirms it. Driving flush() only from
         #           the quiescent foreground avoids the race.
-        if flush_period_s is None:
-            flush_period_s = float(
-                os.environ.get(
-                    "TORCH_CUPTI_MONITOR_FLUSH_PERIOD_S", _DEFAULT_FLUSH_PERIOD_S
-                )
-            )
         self.flush_period_s = flush_period_s
         self._cupti = cupti_python.pylibcupti()
         # The CUPTI subscriber handle.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189062

Drop the TORCH_CUPTI_MONITOR_BUFFER_SIZE and TORCH_CUPTI_MONITOR_FLUSH_PERIOD_S
env vars: buffer_size and flush_period_s are now plain CuptiMonitor constructor
settings (defaulting to the same 4 MiB / 1.0 s), matching the move to config
methods over env vars for the monitor. Also drops the now-unused `import os`.

Note: CuptiMonitor is normally reached through the process-wide instance()
singleton, which constructs it with no args -- so these settings are now only
adjustable by constructing CuptiMonitor directly (as tests do). If a production
path needs to tune them, thread the values through instance() (or add a global
configure()), since the env-var override is gone.

Test Plan:
```
lintrunner --take PYFMT,RUFF,FLAKE8 torch/profiler/_cupti/monitor.py \
  test/profiler/test_cupti_monitor.py
python test/profiler/test_cupti_monitor.py -k buffer_size_and_flush_period
```
test_monitor_buffer_size_and_flush_period_config checks the defaults and an
explicit-arg override; no CUDA needed.

Authored with the assistance of an AI coding assistant (Claude).