### PR TITLE
Fix broken URLs flagged by nightly lint-urls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ endif()
 
 # This define is needed to preserve behavior given anticpated changes to
 # cccl/thrust
-# https://nvidia.github.io/cccl/libcudacxx/standard_api/numerics_library/complex.html
+# https://github.com/NVIDIA/cccl/blob/main/docs/libcudacxx/standard_api/numerics_library/complex.rst
 string(APPEND CMAKE_CUDA_FLAGS
        " -DLIBCUDACXX_ENABLE_SIMPLIFIED_COMPLEX_OPERATIONS")
 

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ In this mode PyTorch computations will run on your CPU, not your GPU.
 python -m pip install --no-build-isolation -v -e .
 ```
 
-Note on OpenMP: The desired OpenMP implementation is Intel OpenMP (iomp). In order to link against iomp, you'll need to manually download the library and set up the building environment by tweaking `CMAKE_INCLUDE_PATH` and `LIB`. The instruction [here](https://github.com/pytorch/pytorch/blob/main/docs/source/notes/windows.rst#building-from-source) is an example for setting up both MKL and Intel OpenMP. Without these configurations for CMake, Microsoft Visual C OpenMP runtime (vcomp) will be used.
+Note on OpenMP: The desired OpenMP implementation is Intel OpenMP (iomp). In order to link against iomp, you'll need to manually download the library and set up the building environment by tweaking `CMAKE_INCLUDE_PATH` and `LIB`. The instruction [here](https://docs.pytorch.org/docs/main/notes/windows.html#building-from-source) is an example for setting up both MKL and Intel OpenMP. Without these configurations for CMake, Microsoft Visual C OpenMP runtime (vcomp) will be used.
 
 **CUDA based build**
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -239,7 +239,7 @@ git tag -f  v1.12.0-rc2
 git push origin  v1.12.0-rc2
 ```
 
-Pushing a release candidate tag should trigger the `binary_build` workflows. This trigger functionality is configured in [`linux_binary_build_workflow.yml.j2]`][(https://github.com/pytorch/pytorch/blob/main/.github/pytorch-circleci-labels.yml](https://github.com/pytorch/pytorch/blob/main/.github/templates/linux_binary_build_workflow.yml.j2#L19-L22)) and in the matching templates for the other OSes.
+Pushing a release candidate tag should trigger the `binary_build` workflows. This trigger functionality is configured in [`linux_binary_build_workflow.yml.j2`](https://github.com/pytorch/pytorch/blob/main/.github/templates/linux_binary_build_workflow.yml.j2#L19-L22) and in the matching templates for the other OSes.
 
 To view the state of the release build, please navigate to [HUD](https://hud.pytorch.org/hud/pytorch/pytorch/release%2F1.12). And make sure all binary builds are successful.
 ### Release Candidate Storage

--- a/android/README.md
+++ b/android/README.md
@@ -31,13 +31,13 @@ dependencies {
 
 ##### Nightly
 
-Nightly(snapshots) builds are published every night from `master` branch to [nexus sonatype snapshots repository](https://oss.sonatype.org/#nexus-search;quick~pytorch_android)
+Nightly(snapshots) builds are published every night from `master` branch to the [Sonatype Central snapshots repository](https://central.sonatype.com/repository/maven-snapshots/)
 
 To use them repository must be specified explicitly:
 ```groovy
 repositories {
     maven {
-        url "https://oss.sonatype.org/content/repositories/snapshots"
+        url "https://central.sonatype.com/repository/maven-snapshots/"
     }
 }
 

--- a/aten/src/ATen/cuda/cub_definitions.cuh
+++ b/aten/src/ATen/cuda/cub_definitions.cuh
@@ -13,7 +13,7 @@
 #define USE_GLOBAL_CUB_WRAPPED_NAMESPACE() true
 
 // There were many bc-breaking changes in major version release of CCCL v3.0.0
-// Please see https://nvidia.github.io/cccl/cccl/3.0_migration_guide.html
+// Please see https://github.com/NVIDIA/cccl/blob/main/docs/cccl/3.0_migration_guide.rst
 #if CUB_VERSION >= 300400
 #define CUB_V3_4_PLUS() true
 #define CUB_V3_PLUS() false

--- a/aten/src/ATen/cuda/tunable/GemmCommon.h
+++ b/aten/src/ATen/cuda/tunable/GemmCommon.h
@@ -1,6 +1,6 @@
 // Original TunableOp is from onnxruntime.
 // https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/core/framework/tunable.h
-// https://github.com/microsoft/onnxruntime/tree/main/onnxruntime/core/providers/rocm/tunable
+// https://github.com/microsoft/onnxruntime/tree/main/onnxruntime/core/providers/cuda/tunable
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //
@@ -73,7 +73,7 @@ inline const char* BLASTypeName(Half v) {
   return "f16_r";
 }
 
-//https://github.com/ROCm/hipBLASLt/blob/develop/library/src/include/auxiliary.hpp#L175
+//https://github.com/ROCm/hipBLASLt/blob/develop/library/src/amd_detail/include/auxiliary.hpp
 template <>
 inline const char* BLASTypeName(Float8_e4m3fn v) {
   return "f8_r";

--- a/aten/src/ATen/cuda/tunable/StreamTimer.cpp
+++ b/aten/src/ATen/cuda/tunable/StreamTimer.cpp
@@ -1,6 +1,6 @@
 // Original TunableOp is from onnxruntime.
 // https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/core/framework/tunable.h
-// https://github.com/microsoft/onnxruntime/tree/main/onnxruntime/core/providers/rocm/tunable
+// https://github.com/microsoft/onnxruntime/tree/main/onnxruntime/core/providers/cuda/tunable
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //

--- a/aten/src/ATen/cuda/tunable/StreamTimer.h
+++ b/aten/src/ATen/cuda/tunable/StreamTimer.h
@@ -1,6 +1,6 @@
 // Original TunableOp is from onnxruntime.
 // https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/core/framework/tunable.h
-// https://github.com/microsoft/onnxruntime/tree/main/onnxruntime/core/providers/rocm/tunable
+// https://github.com/microsoft/onnxruntime/tree/main/onnxruntime/core/providers/cuda/tunable
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //

--- a/aten/src/ATen/cuda/tunable/Tunable.cpp
+++ b/aten/src/ATen/cuda/tunable/Tunable.cpp
@@ -1,6 +1,6 @@
 // Original TunableOp is from onnxruntime.
 // https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/core/framework/tunable.h
-// https://github.com/microsoft/onnxruntime/tree/main/onnxruntime/core/providers/rocm/tunable
+// https://github.com/microsoft/onnxruntime/tree/main/onnxruntime/core/providers/cuda/tunable
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //

--- a/aten/src/ATen/cuda/tunable/Tunable.h
+++ b/aten/src/ATen/cuda/tunable/Tunable.h
@@ -1,6 +1,6 @@
 // Original TunableOp is from onnxruntime.
 // https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/core/framework/tunable.h
-// https://github.com/microsoft/onnxruntime/tree/main/onnxruntime/core/providers/rocm/tunable
+// https://github.com/microsoft/onnxruntime/tree/main/onnxruntime/core/providers/cuda/tunable
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //

--- a/aten/src/ATen/cuda/tunable/TunableGemm.h
+++ b/aten/src/ATen/cuda/tunable/TunableGemm.h
@@ -1,6 +1,6 @@
 // Original TunableOp is from onnxruntime.
 // https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/core/framework/tunable.h
-// https://github.com/microsoft/onnxruntime/tree/main/onnxruntime/core/providers/rocm/tunable
+// https://github.com/microsoft/onnxruntime/tree/main/onnxruntime/core/providers/cuda/tunable
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //

--- a/aten/src/ATen/cuda/tunable/TunableOp.h
+++ b/aten/src/ATen/cuda/tunable/TunableOp.h
@@ -1,6 +1,6 @@
 // Original TunableOp is from onnxruntime.
 // https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/core/framework/tunable.h
-// https://github.com/microsoft/onnxruntime/tree/main/onnxruntime/core/providers/rocm/tunable
+// https://github.com/microsoft/onnxruntime/tree/main/onnxruntime/core/providers/cuda/tunable
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 //

--- a/benchmarks/dynamo/summarize_perf.py
+++ b/benchmarks/dynamo/summarize_perf.py
@@ -48,8 +48,8 @@ def find_csv_files(path, perf_compare):
 def main(directory, amp, float32, perf_compare):
     """
     Given a directory containing multiple CSVs from --performance benchmark
-    runs, aggregates and generates summary statistics similar to the web UI at
-    https://torchci-git-fork-huydhn-add-compilers-bench-74abf8-fbopensource.vercel.app/benchmark/compilers
+    runs, aggregates and generates summary statistics similar to the compilers
+    benchmark web UI.
 
     This is most useful if you've downloaded CSVs from CI and need to quickly
     look at aggregate stats.  The CSVs are expected to follow exactly the same

--- a/c10/xpu/XPUFunctions.cpp
+++ b/c10/xpu/XPUFunctions.cpp
@@ -135,7 +135,7 @@ inline void initGlobalDevicePoolState() {
           ") is not officially supported by PyTorch XPU. Running workloads on this device may result in unexpected behavior.\n",
           "For stable and fully supported execution, please use GPUs based on Intel Arc (Alchemist) series or newer.\n",
           "Refer to the hardware prerequisites for more information: ",
-          "https://github.com/pytorch/pytorch/blob/main/docs/source/notes/get_start_xpu.rst#hardware-prerequisite");
+          "https://docs.pytorch.org/docs/main/notes/get_start_xpu.html#hardware-prerequisite");
     }
   }
 

--- a/docs/source/notes/autograd.md
+++ b/docs/source/notes/autograd.md
@@ -295,7 +295,7 @@ mode. If you cannot avoid such use in your case, you can always switch back
 to no-grad mode.
 
 For details on inference mode please see
-[Inference Mode](https://pytorch.org/cppdocs/notes/inference_mode.html).
+[Inference Mode](https://docs.pytorch.org/docs/2.9/notes/autograd.html#inference-mode).
 
 For implementation details of inference mode see
 [RFC-0011-InferenceMode](https://github.com/pytorch/rfcs/pull/17).

--- a/docs/source/user_guide/torch_compiler/torch.compiler_dynamo_deepdive.md
+++ b/docs/source/user_guide/torch_compiler/torch.compiler_dynamo_deepdive.md
@@ -200,7 +200,7 @@ program is compiled into
 executed by this interpreter. To learn more about these bytecodes, see
 the [dis module](https://docs.python.org/3/library/dis.html) from the
 standard library. See also [the developer
-docs](https://devguide.python.org/internals/interpreter/) for an
+docs](https://devguide.python.org/internals/) for an
 introduction to CPython’s interpreter. We will assume that the reader is
 familiar with the notion of a stack machine.
 
@@ -351,7 +351,7 @@ discuss how Dynamo addresses a rather important correctness issue.
 At this point, we have a way to trace programs completely disregarding control flow.
 And for that, we have reimplemented all of CPython… If this sounds like a bit of an
 overkill, that is because it is.
-[torch.jit.trace](https://pytorch.org/docs/main/generated/torch.jit.trace.html)
+[torch.jit.trace](https://docs.pytorch.org/docs/2.9/generated/torch.jit.trace.html)
 already implements this without all this machinery, so what gives?
 
 The issue with `torch.jit.trace`, as it is warned in its docs, is that

--- a/functorch/COMPILE_README.md
+++ b/functorch/COMPILE_README.md
@@ -72,4 +72,4 @@ aot_function(f, ts_compiler, ts_compiler)(torch.randn(3, requires_grad=True))
 * Min-cut [recomputation](https://dev-discuss.pytorch.org/t/min-cut-optimal-recomputation-i-e-activation-checkpointing-with-aotautograd/467) with AOT Autograd.
 
 ## Tutorials
-You can use this [tutorial](https://pytorch.org/functorch/nightly/tutorials/aot_autograd_optimizations.html) to play with AOT Autograd.
+You can use this [tutorial](https://docs.pytorch.org/functorch/stable/notebooks/aot_autograd_optimizations.html) to play with AOT Autograd.

--- a/test/autograd/test_functional.py
+++ b/test/autograd/test_functional.py
@@ -25,7 +25,7 @@ from torch.testing._internal.logging_tensor import LoggingTensor
 # TODO: maybe move somewhere so other tests can also use
 #
 # NB: Not all factory functions included. A complete(?) list can be found here:
-#     https://pytorch.org/cppdocs/notes/tensor_creation.html
+#     https://docs.pytorch.org/docs/2.9/torch.html#creation-ops
 base_ctors_dict = {
     "ones": torch.ones,
     "zeros": torch.zeros,

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -10283,7 +10283,7 @@ class TestCudaDeviceParametrized(TestCase):
             # This writes allows wait_for_cpu to proceed
             # This is an atomic store at system scope according to this rule:
             # "the scope is thread_scope_system and it is a load or store that affects a naturally-aligned object of sizes 1, 2, 4, 8, or 16 bytes on mapped memory"
-            # https://nvidia.github.io/cccl/libcudacxx/extended_api/memory_model.html#atomicity
+            # https://github.com/NVIDIA/cccl/blob/main/docs/libcudacxx/extended_api/memory_model.rst
 
             # Note that every CPU store is implicitly system scope,
             # even if we don't use C++ atomics like this:

--- a/tools/testing/upload_artifacts.py
+++ b/tools/testing/upload_artifacts.py
@@ -129,7 +129,7 @@ def trigger_upload_test_stats_intermediate_workflow() -> None:
     # The GITHUB_TOKEN cannot trigger workflow so this isn't used for now
     print("Triggering upload_test_stats_intermediate workflow")
     x = requests.post(
-        "https://api.github.com/repos/pytorch/pytorch/actions/workflows/upload_test_stats_intermediate.yml/dispatches",
+        "https://api.github.com/repos/pytorch/pytorch/actions/workflows/upload_test_stats_intermediate.yml/dispatches",  # @lint-ignore
         headers={
             "Accept": "application/vnd.github.v3+json",
             "Authorization": f"Bearer {os.environ.get('GITHUB_TOKEN')}",

--- a/torch/_dynamo/bytecode_transformation.py
+++ b/torch/_dynamo/bytecode_transformation.py
@@ -667,7 +667,7 @@ def linetable_writer(
 ) -> tuple[list[int], Callable[[int, int], None], Callable[[int], None]]:
     """
     Used to create typing.CodeType.co_linetable
-    See https://github.com/python/cpython/blob/main/Objects/lnotab_notes.txt
+    See https://github.com/python/cpython/blob/3.10/Objects/lnotab_notes.txt
     This is the internal format of the line number table for Python 3.10
     """
     if sys.version_info[:2] != (3, 10):

--- a/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
+++ b/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
@@ -1498,7 +1498,6 @@ def create_functional_call(
     strict_out_tuple: bool = True,
 ) -> Callable[..., Any]:
     # Redundant with dynamo, but worth having in case this gets invoked elsewhere.
-    # https://github.com/pytorch/pytorch/issues/103569
 
     @simple_wraps(mod)
     def functional_call(*args: Any, **kwargs: Any) -> Any:

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -88,7 +88,7 @@ mm_template = TritonTemplate(
     grid=mm_grid,
     source=load_kernel_template("triton_mm")
     if (torch.version.hip is None) or triton_version >= "3.3.0"
-    # FIXME: To get around rocm failures like https://github.com/pytorch/pytorch/actions/runs/13123783322/job/36617154943
+    # FIXME: To get around rocm failures.
     # The only difference between the two templates is M >= BLOCK_M and N >= BLOCK_N checking.
     # See more details in https://github.com/pytorch/pytorch/pull/146293
     else load_kernel_template("triton_mm_rocm"),

--- a/torch/_inductor/template_heuristics/cutedsl.py
+++ b/torch/_inductor/template_heuristics/cutedsl.py
@@ -26,7 +26,7 @@ def get_exhaustive_groupgemm_configs() -> list[CuTeGemmConfig]:
     """
     Returns the exhaustive configuration set for the Blackwell CuTeDSL Grouped GEMM kernel.
     For information regarding valid config sets, see:
-    https://github.com/NVIDIA/cutlass/blob/main/examples/python/CuTeDSL/blackwell/grouped_gemm.py
+    https://github.com/NVIDIA/cutlass/blob/main/examples/python/CuTeDSL/cute/blackwell/kernel/grouped_gemm/grouped_gemm.py
     """
 
     # Tile_n is always the same regardless of 2cta

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -5600,7 +5600,7 @@ allocated during inference mode. A view tensor is an inference
 tensor if and only if the tensor it is a view of is an inference tensor.
 
 For details on inference mode please see
-`Inference Mode <https://pytorch.org/cppdocs/notes/inference_mode.html>`_.
+`Inference Mode <https://docs.pytorch.org/docs/2.9/notes/autograd.html#inference-mode>`_.
 
 Args:
     {input}

--- a/torch/csrc/api/include/torch/data/datasets/chunk.h
+++ b/torch/csrc/api/include/torch/data/datasets/chunk.h
@@ -306,7 +306,7 @@ struct ChunkDatasetOptions {
 /// while the `ExampleSampler` determines the order of Examples that are
 /// returned in each `get_batch` call. The hierarchical sampling approach used
 /// here is inspired by this paper
-/// http://martin.zinkevich.org/publications/nips2010.pdf
+/// https://proceedings.neurips.cc/paper_files/paper/2010/file/abea47ba24142ed16b7d8fbf2c740e0d-Paper.pdf
 template <
     typename ChunkReader,
     typename ChunkSampler = samplers::RandomSampler,

--- a/torch/distributed/_mesh_layout.py
+++ b/torch/distributed/_mesh_layout.py
@@ -31,7 +31,7 @@ class _FlatLayout:
     A canonical CuTe layout for a single dimension of a DeviceMesh
 
     Utility class for representing an integer layout by borrowing ideas from CuTe Layout Algebra.
-    See https://docs.nvidia.com/cutlass/media/docs/cpp/cute/02_layout_algebra.html for more details.
+    See https://github.com/NVIDIA/cutlass/blob/main/media/docs/cpp/cute/02_layout_algebra.md for more details.
 
     Each layout is represented as a list of sizes and strides. We use it as a way for mechanical bookkeeping
     of the integers such as ranks in a SPMD mesh, and the transformation on top of it.

--- a/torch/distributions/kl.py
+++ b/torch/distributions/kl.py
@@ -262,7 +262,7 @@ def _kl_continuous_bernoulli_continuous_bernoulli(p, q):
 
 @register_kl(Dirichlet, Dirichlet)
 def _kl_dirichlet_dirichlet(p, q):
-    # From http://bariskurt.com/kullback-leibler-divergence-between-two-dirichlet-and-beta-distributions/
+    # From https://statproofbook.github.io/P/dir-kl.html
     sum_p_concentration = p.concentration.sum(-1)
     sum_q_concentration = q.concentration.sum(-1)
     t1 = sum_p_concentration.lgamma() - sum_q_concentration.lgamma()

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -329,7 +329,7 @@ Examples::
     tensor(0, dtype=torch.int32)
 
 .. _LAPACK's getrf:
-    https://www.netlib.org/lapack/explore-html-3.6.1/dd/d9a/group__double_g_ecomputational_ga0019443faea08275ca60a734d0593e60.html
+    https://www.netlib.org/lapack/explore-html/
 """,
 )
 
@@ -967,7 +967,7 @@ Examples::
     tensor([1, 2, 3], dtype=torch.int32)
 
 .. _LAPACK's sytrf:
-    https://www.netlib.org/lapack/explore-html-3.6.1/d3/db6/group__double_s_ycomputational_gad91bde1212277b3e909eb6af7f64858a.html
+    https://www.netlib.org/lapack/explore-html/
 """,
 )
 
@@ -1025,7 +1025,7 @@ Examples::
     tensor(0, dtype=torch.int32)
 
 .. _LAPACK's sytrf:
-    https://www.netlib.org/lapack/explore-html-3.6.1/d3/db6/group__double_s_ycomputational_gad91bde1212277b3e909eb6af7f64858a.html
+    https://www.netlib.org/lapack/explore-html/
 """,
 )
 
@@ -2563,7 +2563,7 @@ Returns:
     A named tuple `(LU, pivots, info)`.
 
 .. _LAPACK's getrf:
-    https://www.netlib.org/lapack/explore-html-3.6.1/dd/d9a/group__double_g_ecomputational_ga0019443faea08275ca60a734d0593e60.html
+    https://www.netlib.org/lapack/explore-html/
 """,
 )
 

--- a/torch/nativert/OVERVIEW.md
+++ b/torch/nativert/OVERVIEW.md
@@ -9,7 +9,7 @@ However, its support doesn't end there; by default it integrates with the torch
 dispatcher, inheriting its backend
 [support matrix](https://docs.pytorch.org/docs/stable/backends.html). Moreover,
 it supports the execution of
-[AOTInductor](https://github.com/pytorch/pytorch/blob/main/docs/source/torch.compiler_aot_inductor.rst)-lowered
+[AOTInductor](https://docs.pytorch.org/docs/main/torch.compiler_aot_inductor.html)-lowered
 artifacts, and can be extended to support other delegate backends as seen fit.
 
 This document is intended to provide an overview of the foundational NativeRT

--- a/torch/optim/asgd.py
+++ b/torch/optim/asgd.py
@@ -189,7 +189,7 @@ ASGD.__doc__ = rf"""Implements Averaged Stochastic Gradient Descent.
         {_capturable_doc}
 
     .. _Acceleration of stochastic approximation by averaging:
-        https://meyn.ece.ufl.edu/wp-content/uploads/sites/77/archive/spm_files/Courses/ECE555-2011/555media/poljud92.pdf
+        https://doi.org/10.1137/0330046
 
     """
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189063

The nightly `Link checks / lint-urls / lint` job was failing on 28 broken
URLs across the repo (accumulated link rot). This updates each to a current
live equivalent, or removes it where no good replacement exists. Every
replacement was verified to resolve (HTTP 200, or the expected redirect for
doi.org).

Review by category:
- Moved docs (rst->md, removed cppdocs notes, relocated functorch tutorials)
  now point to the current docs.pytorch.org / GitHub source pages.
- Upstream refs (NVIDIA CCCL/CUTLASS, onnxruntime tunable, hipBLASLt, CPython
  lnotab_notes) point to their current locations.
- Academic citations use canonical stable hosts (NeurIPS proceedings, DOI).
- Ephemeral links removed: a Vercel preview URL, a one-off CI-run link, and a
  deleted issue reference (surrounding explanatory comments are kept).
- The api.github.com dispatch endpoint in upload_artifacts.py is live code
  that 404s only due to auth; annotated with `@lint-ignore` rather than
  changed.

Fixes #189055

Test Plan:

```
# every replacement URL was checked to resolve
curl -sS -m 20 -o /dev/null -w '%{http_code}' <url>   # 200 (302 for doi.org)
# lint over changed files
lintrunner <changed files>
```

Authored with assistance from Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98