### PR TITLE
Register nccl-lazy TorchComms backend

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1125,6 +1125,7 @@ def configure_extension_build() -> tuple[
         "mpi = torch.distributed.distributed_c10d:_register_builtin_mpi_backend",
         "gloo = torch.distributed.distributed_c10d:_register_builtin_gloo_backend",
         "nccl = torch.distributed.distributed_c10d:_register_builtin_nccl_backend",
+        "nccl-lazy = torch.distributed.distributed_c10d:_register_builtin_nccl_lazy_backend",
         "ucc = torch.distributed.distributed_c10d:_register_builtin_ucc_backend",
         "xccl = torch.distributed.distributed_c10d:_register_builtin_xccl_backend",
     ]

--- a/test/distributed/test_c10d_torchcomms.py
+++ b/test/distributed/test_c10d_torchcomms.py
@@ -372,6 +372,34 @@ class TestC10dTorchCommsInitAutoQualify(C10dTorchCommsTestBase):
         self.assertIsNotNone(default_pg.bound_device_id)
         self.assertEqual(default_pg.bound_device_id.type, "cuda")
 
+    def test_new_group_nccl_lazy_builds_per_peer_group(self):
+        # Passing backend="nccl-lazy" builds a per-peer, lazily-initialized
+        # group (a dedicated comm + stream per send/recv peer) usable for P2P.
+        # use_local_synchronization makes it members-only. The parent must be
+        # device-bound (it is, in this class).
+        ranks = list(range(self.world_size))
+        g = dist.new_group(
+            ranks=ranks, backend="nccl-lazy", use_local_synchronization=True
+        )
+        self.assertEqual(dist.get_process_group_ranks(g), ranks)
+        # P2P round-trip over the lazy group: 0 -> 1 -> ... -> 0
+        dev = torch.device(f"cuda:{self.rank}")
+        send_to = (self.rank + 1) % self.world_size
+        recv_from = (self.rank - 1) % self.world_size
+        if self.rank % 2 == 0:
+            dist.send(
+                torch.full((4,), float(self.rank), device=dev), dst=send_to, group=g
+            )
+            r = torch.empty(4, device=dev)
+            dist.recv(r, src=recv_from, group=g)
+        else:
+            r = torch.empty(4, device=dev)
+            dist.recv(r, src=recv_from, group=g)
+            dist.send(
+                torch.full((4,), float(self.rank), device=dev), dst=send_to, group=g
+            )
+        self.assertEqual(r[0].item(), float(recv_from))
+
 
 instantiate_device_type_tests(
     TestC10dTorchCommsInitAutoQualify, globals(), only_for=["cuda"]

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -650,6 +650,30 @@ def _register_builtin_nccl_backend() -> None:
     )
 
 
+def _create_nccl_lazy_process_group(
+    opts: _DistributedBackendOptions, backend_options: Any | None
+) -> C10DBackend | None:
+    # nccl-lazy is a TorchComms-only per-peer variant of NCCL: it lazily creates
+    # a dedicated 2-rank communicator per send/recv peer (matching
+    # ProcessGroupNCCL) so P2P to different peers can overlap. It is constructed
+    # on the TorchComms branch of _new_process_group_helper; this creator only
+    # runs when torchcomms is disabled, in which case there is nothing to build.
+    raise RuntimeError(
+        "The nccl-lazy backend is only available when torchcomms is enabled "
+        "(e.g. via dist_config.use_torchcomms)."
+    )
+
+
+def _register_builtin_nccl_lazy_backend() -> None:
+    Backend.register_backend(
+        "nccl-lazy",
+        _create_nccl_lazy_process_group,
+        extended_api=True,
+        devices=["cuda"],
+        _backend_type=ProcessGroup.BackendType.CUSTOM,
+    )
+
+
 def _register_builtin_ucc_backend() -> None:
     Backend.register_backend(
         Backend.UCC,


### PR DESCRIPTION

Summary:
Register NCCL_LAZY ("nccl-lazy") as a first-class backend: add it to
Backend.backend_list, mark it cuda-capable in backend_capability, and map it to
ProcessGroup.BackendType.CUSTOM in backend_type_map. This lets
new_group(backend="nccl-lazy", use_local_synchronization=True) build a members-
only, per-peer lazy NCCL group through the normal new_group machinery (the lazy
semantics map to TorchComms' "nccl-lazy" backend) instead of a bespoke code path.

Test Plan:
test/distributed/test_c10d_torchcomms.py (nccl-lazy per-peer group creation).

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/pytorch/pull/189068).
* #189074
* #189073
* #189072
* #189071
* #189070
* #189069
* __->__ #189068