### PR TITLE
Route only TorchComms-owned backends through comms

### DIFF
--- a/test/distributed/test_c10d_torchcomms.py
+++ b/test/distributed/test_c10d_torchcomms.py
@@ -390,10 +390,186 @@ class TestC10dTorchCommsInitAutoQualify(C10dTorchCommsTestBase):
             wait_all_ranks=True,
         )
 
+    def test_new_group_nccl_lazy_builds_per_peer_group(self):
+        # Passing backend="nccl-lazy" builds a per-peer, lazily-initialized
+        # group (a dedicated comm + stream per send/recv peer) usable for P2P.
+        # use_local_synchronization makes it members-only. The parent must be
+        # device-bound (it is, in this class).
+        ranks = list(range(self.world_size))
+        g = dist.new_group(
+            ranks=ranks, backend="nccl-lazy", use_local_synchronization=True
+        )
+        self.assertEqual(dist.get_process_group_ranks(g), ranks)
+        # P2P round-trip over the lazy group: 0 -> 1 -> ... -> 0
+        dev = torch.device(f"cuda:{self.rank}")
+        send_to = (self.rank + 1) % self.world_size
+        recv_from = (self.rank - 1) % self.world_size
+        if self.rank % 2 == 0:
+            dist.send(
+                torch.full((4,), float(self.rank), device=dev), dst=send_to, group=g
+            )
+            r = torch.empty(4, device=dev)
+            dist.recv(r, src=recv_from, group=g)
+        else:
+            r = torch.empty(4, device=dev)
+            dist.recv(r, src=recv_from, group=g)
+            dist.send(
+                torch.full((4,), float(self.rank), device=dev), dst=send_to, group=g
+            )
+        self.assertEqual(r[0].item(), float(recv_from))
+
+    def test_non_torchcomms_backend_falls_through_to_c10d(self):
+        # Under torchcomms, a backend TorchComms does not own (registered the way
+        # mooncake registers a custom c10d backend) must route through the normal
+        # ProcessGroup path, not new_comm. Use a gloo-backed stand-in.
+        def _creator(store, grank, gsize, timeout):
+            return dist.ProcessGroupGloo(store, grank, gsize, timeout)
+
+        name = "tc_gate_stub"
+        if name not in dist.Backend.backend_list:
+            dist.Backend.register_backend(name, _creator, devices=["cpu", "cuda"])
+
+        ranks = list(range(self.world_size))
+        g = dist.new_group(ranks=ranks, backend=name)
+        be = g._get_backend(torch.device("cpu"))
+        # The c10d creator ran (real ProcessGroupGloo), not a TorchComms wrapper.
+        self.assertNotIn("BackendWrapper", type(be).__name__)
+        t = torch.tensor([self._rank_value], dtype=torch.float32)
+        dist.all_reduce(t, group=g)
+        self.assertEqual(t.item(), sum(range(1, self.world_size + 1)))
+
 
 instantiate_device_type_tests(
     TestC10dTorchCommsInitAutoQualify, globals(), only_for=["cuda"]
 )
+
+
+@unittest.skipIf(not _TORCHCOMM_AVAILABLE, "TorchComms is not installed")
+class TestC10dTorchCommsMixedBackends(C10dTorchCommsTestBase):
+    """Verify subgroup creation from a mixed-backend parent under torchcomms.
+
+    The parent PG mixes ``cuda:nccl`` with ``cpu:fake``. Under torchcomms,
+    ``new_group`` builds each subgroup directly via ``new_comm`` (a members-only
+    store rendezvous), so a non-splittable device backend in the parent (here
+    ``cpu:fake``) is no obstacle: members construct the subgroup and non-members
+    return ``NON_GROUP_MEMBER`` without any parent split.
+    """
+
+    @classmethod
+    def _init_pg(cls, rank, world_size, rdvz_file):
+        torch.distributed.config.use_torchcomms = True
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        os.environ["RANK"] = str(rank)
+        os.environ["WORLD_SIZE"] = str(world_size)
+        os.environ["TORCHCOMM_STORE_PATH"] = rdvz_file
+        os.environ["LOCAL_RANK"] = str(rank)
+
+        store = dist.FileStore(rdvz_file, world_size)
+        device_id = torch.device(f"cuda:{rank}")
+        torch.cuda.set_device(rank)
+
+        dist.init_process_group(
+            backend="cuda:nccl,cpu:fake",
+            world_size=world_size,
+            rank=rank,
+            store=store,
+            device_id=device_id,
+        )
+        cls.pg = dist.distributed_c10d._get_default_group()
+        torch.set_default_device(device_id)
+
+    @property
+    def _rank_value(self):
+        return self.rank + 1
+
+    def test_mixed_backend_subgroup(self):
+        subg_ranks = list(range(self.world_size // 2))
+        ng = dist.new_group(ranks=subg_ranks)
+
+        if self.rank in subg_ranks:
+            self.assertEqual(dist.get_process_group_ranks(ng), subg_ranks)
+            tensor = torch.tensor([self._rank_value], dtype=torch.float32)
+            dist.all_reduce(tensor, group=ng)
+            self.assertEqual(tensor.item(), sum(r + 1 for r in subg_ranks))
+        else:
+            self.assertIs(ng, dist.GroupMember.NON_GROUP_MEMBER)
+
+
+instantiate_device_type_tests(
+    TestC10dTorchCommsMixedBackends, globals(), only_for=["cuda"]
+)
+
+
+class TestTorchCommsHandlesBackend(TestCase):
+    """Unit-test the pure routing logic of ``_torchcomms_handles_backend``.
+
+    This decides whether a backend is one TorchComms can construct (so it goes
+    through ``new_comm`` / ``split_group``) versus a custom c10d plugin such as
+    ``mooncake`` that must fall through to the normal ProcessGroup path. The
+    function depends only on ``_TORCHCOMM_AVAILABLE`` and the two
+    ``is_backend_*`` callables, all of which we patch -- so these tests run even
+    when torchcomms is not installed.
+    """
+
+    def _patch(self, available=True, built=(), registered=()):
+        built, registered = set(built), set(registered)
+        return mock.patch.multiple(
+            c10d,
+            _TORCHCOMM_AVAILABLE=available,
+            _torchcomms_is_backend_built=lambda name: name in built,
+            _torchcomms_is_backend_registered=lambda name: name in registered,
+            create=True,
+        )
+
+    def test_unavailable_returns_false(self):
+        with self._patch(available=False, built=["nccl"]):
+            self.assertFalse(c10d._torchcomms_handles_backend("nccl"))
+            self.assertFalse(c10d._torchcomms_handles_backend(None))
+
+    def test_none_backend_inherits_parent(self):
+        with self._patch(built=[]):
+            self.assertTrue(c10d._torchcomms_handles_backend(None))
+
+    def test_builtin_backend(self):
+        with self._patch(built=["nccl"]):
+            self.assertTrue(c10d._torchcomms_handles_backend("nccl"))
+
+    def test_registered_backend(self):
+        with self._patch(registered=["myadapter"]):
+            self.assertTrue(c10d._torchcomms_handles_backend("myadapter"))
+
+    def test_custom_backend_falls_through(self):
+        with self._patch(built=["nccl"]):
+            self.assertFalse(c10d._torchcomms_handles_backend("mooncake"))
+            self.assertFalse(c10d._torchcomms_handles_backend("ucc"))
+
+    def test_case_insensitive(self):
+        with self._patch(built=["nccl"]):
+            self.assertTrue(c10d._torchcomms_handles_backend("NCCL"))
+
+    def test_nccl_lazy_is_own_backend(self):
+        # nccl-lazy is a distinct built torchcomms backend, not aliased to nccl:
+        # it is handled iff nccl-lazy itself is built/registered.
+        with self._patch(built=["nccl-lazy"]):
+            self.assertTrue(c10d._torchcomms_handles_backend("nccl-lazy"))
+        with self._patch(built=["nccl"]):
+            self.assertFalse(c10d._torchcomms_handles_backend("nccl-lazy"))
+        with self._patch(built=[]):
+            self.assertFalse(c10d._torchcomms_handles_backend("nccl-lazy"))
+
+    def test_qualified_all_handled(self):
+        with self._patch(built=["gloo", "nccl"]):
+            self.assertTrue(c10d._torchcomms_handles_backend("cpu:gloo,cuda:nccl"))
+
+    def test_qualified_one_unhandled_falls_through(self):
+        with self._patch(built=["gloo"]):
+            self.assertFalse(c10d._torchcomms_handles_backend("cpu:gloo,cuda:mooncake"))
+
+    def test_empty_parts_are_skipped(self):
+        with self._patch(built=["nccl"]):
+            self.assertTrue(c10d._torchcomms_handles_backend("nccl,"))
+            self.assertTrue(c10d._torchcomms_handles_backend(" nccl , "))
 
 
 class TestC10dTorchCommsNewGroupHelper(TestCase):

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -233,6 +233,39 @@ def _is_torchcomms_backend(backend: str) -> bool:
     )
 
 
+def _torchcomms_handles_backend(backend) -> bool:
+    """True if TorchComms can create a comm for *backend*.
+
+    Backends TorchComms doesn't own -- custom c10d plugins such as ``mooncake``
+    or ``ucc`` -- must fall through to the normal ProcessGroup path even when
+    TorchComms is enabled, rather than being routed through ``new_comm`` /
+    ``split_group`` (which cannot construct them).
+
+    ``backend`` may be ``None`` (inherits the parent's TorchComms-owned
+    backend), a bare name (``"nccl"``), or a device-qualified string
+    (``"cpu:gloo,cuda:nccl"``). A built-in backend reports via
+    ``is_backend_built``; a backend dynamically registered through
+    ``torchcomms.register_backend`` (e.g. a Python adapter) reports via
+    ``_is_backend_registered`` -- so registering such an adapter is enough to
+    move that backend onto the native TorchComms path with no change here.
+    """
+    if not _TORCHCOMM_AVAILABLE:
+        return False
+    if backend is None:
+        return True
+    for part in str(backend).lower().split(","):
+        part = part.strip()
+        name = part.split(":", 1)[1] if ":" in part else part
+        if not name:
+            continue
+        if not (
+            _torchcomms_is_backend_registered(name)
+            or _torchcomms_is_backend_built(name)
+        ):
+            return False
+    return True
+
+
 def _pg_options_to_hints(pg_options: object) -> dict[str, str] | None:
     """Convert ProcessGroupNCCL.Options to a torchcomms hints dict."""
     if pg_options is None:
@@ -2418,6 +2451,7 @@ def init_process_group(
         and device_id is not None
         and ":" not in backend
         and backend not in (Backend.UNDEFINED, Backend.MPI, Backend.FAKE)
+        and _torchcomms_handles_backend(backend)
     ):
         bare = backend.lower()
         qualified: dict[str, str] = {}
@@ -2700,7 +2734,11 @@ def _new_process_group_helper(
         # a single store can be reused by multiple groups.
         backend_prefix_store = PrefixStore(f"{device}/", prefix_store)
 
-        if _use_torchcomms_enabled() and backend_str not in [Backend.FAKE]:
+        if (
+            _use_torchcomms_enabled()
+            and backend_str not in [Backend.FAKE]
+            and _torchcomms_handles_backend(backend_str)
+        ):
             torch_device = torch.device(device)
             # Pass this rank's actual device WITH its index. A device-type-only
             # torch.device(device) makes the TorchComms bootstrap default the


### PR DESCRIPTION

Summary:
Add _torchcomms_handles_backend() and gate the TorchComms path (in
init_process_group backend auto-qualification and _new_process_group_helper) on
it. Backends TorchComms does not own -- custom c10d plugins such as mooncake --
then keep their native c10d creation path instead of being forced through
new_comm. Built-in backends report via is_backend_built; dynamically registered
adapters report via _is_backend_registered.

Test Plan:
test/distributed/test_c10d_torchcomms.py (custom/unowned backend falls through).
