### PR TITLE
[inductor] Generalize reinplacing to functional ATen ops with an in-place variant

### DIFF
--- a/test/inductor/test_inplacing_pass.py
+++ b/test/inductor/test_inplacing_pass.py
@@ -868,6 +868,26 @@ class TestReinplacingPassCorrectness(InductorTestCase):
             if my_wait_functional._opoverload in inplaceable_ops:
                 del inplaceable_ops[my_wait_functional._opoverload]
 
+    # digamma has no decomp; uniform does (exercises the override-decomp path).
+    @parametrize("name", ["digamma", "uniform"])
+    def test_functional_op_reinplaced(self, name):
+        # A functional op over a dead buffer is reinplaced via its in-place variant.
+        functional_op = getattr(aten, name).default
+        inplace_op = getattr(aten, name + "_").default
+
+        def f(x):
+            buf = torch.empty_like(x)  # dead, written by the functional op only
+            return functional_op(buf)
+
+        x = torch.randn(8)  # CPU; reinplacing is device-independent
+        gm = make_fx(f, tracing_mode="fake")(x)
+        reinplace_inplaceable_ops_core(gm.graph)
+        gm.graph.lint()
+
+        targets = [node.target for node in gm.graph.nodes]
+        self.assertIn(inplace_op, targets)
+        self.assertNotIn(functional_op, targets)
+
 
 instantiate_parametrized_tests(TestReinplacingPassCorrectness)
 

--- a/test/inductor/test_inplacing_pass.py
+++ b/test/inductor/test_inplacing_pass.py
@@ -868,16 +868,13 @@ class TestReinplacingPassCorrectness(InductorTestCase):
             if my_wait_functional._opoverload in inplaceable_ops:
                 del inplaceable_ops[my_wait_functional._opoverload]
 
-    # digamma has no decomp; uniform does (exercises the override-decomp path).
-    @parametrize("name", ["digamma", "uniform"])
-    def test_functional_op_reinplaced(self, name):
-        # A functional op over a dead buffer is reinplaced via its in-place variant.
-        functional_op = getattr(aten, name).default
-        inplace_op = getattr(aten, name + "_").default
-
+    def test_functional_op_reinplaced(self):
+        # A fallback functional op over a dead buffer is reinplaced via its
+        # in-place variant (uniform lowers as a fallback and has a decomp, so it
+        # also exercises the override-decomp path).
         def f(x):
             buf = torch.empty_like(x)  # dead, written by the functional op only
-            return functional_op(buf)
+            return aten.uniform.default(buf)
 
         x = torch.randn(8)  # CPU; reinplacing is device-independent
         gm = make_fx(f, tracing_mode="fake")(x)
@@ -885,8 +882,23 @@ class TestReinplacingPassCorrectness(InductorTestCase):
         gm.graph.lint()
 
         targets = [node.target for node in gm.graph.nodes]
-        self.assertIn(inplace_op, targets)
-        self.assertNotIn(functional_op, targets)
+        self.assertIn(aten.uniform_.default, targets)
+        self.assertNotIn(aten.uniform.default, targets)
+
+    def test_op_with_real_lowering_not_reinplaced(self):
+        # cumsum has a real lowering (plus a registered fallback handler), so it
+        # must NOT be reinplaced: reinplacing to cumsum_ would discard the
+        # lowering and, on int/bool inputs, change dtype (cumsum promotes to
+        # int64, which the in-place `self` can't hold).
+        def f(x):
+            buf = torch.empty_like(x)
+            return aten.cumsum.default(buf, 0)
+
+        for x in (torch.randn(8), torch.zeros(8, dtype=torch.bool)):
+            gm = make_fx(f, tracing_mode="fake")(x)
+            reinplace_inplaceable_ops_core(gm.graph)
+            targets = [node.target for node in gm.graph.nodes]
+            self.assertNotIn(aten.cumsum_.default, targets)
 
 
 instantiate_parametrized_tests(TestReinplacingPassCorrectness)

--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -112,6 +112,20 @@ class TestDispatcherPythonBindings(TestCase):
         y = torch._C._dispatch_call_boxed(sin, x)
         self.assertEqual(y, x.sin())
 
+    def test_inplace_variant(self) -> None:
+        # OpOverload._inplace_variant maps a functional op to its in-place
+        # counterpart: both <base> and <base>_functional map to <base>_, via
+        # naming convention plus schema validation.
+        aten = torch.ops.aten
+        self.assertEqual(aten.uniform.default._inplace_variant, aten.uniform_.default)
+        self.assertEqual(aten.digamma.default._inplace_variant, aten.digamma_.default)
+        self.assertEqual(
+            aten.normal_functional.default._inplace_variant, aten.normal_.default
+        )
+        # In-place ops and ops with no in-place variant return None.
+        self.assertIsNone(aten.uniform_.default._inplace_variant)
+        self.assertIsNone(aten.mm.default._inplace_variant)
+
 
 class TestPythonRegistration(TestCase):
     test_ns = "_test_python_registration"

--- a/torch/_inductor/fx_passes/reinplace.py
+++ b/torch/_inductor/fx_passes/reinplace.py
@@ -1,4 +1,5 @@
 # mypy: allow-untyped-defs
+import functools
 import itertools
 import logging
 import operator
@@ -408,6 +409,31 @@ for outplace_op, inplace_op in inplaceable_foreach_ops_lowerings.items():
 inplaceable_triton_ops = OrderedSet([triton_kernel_wrapper_functional])
 
 
+@functools.lru_cache(None)
+def _maybe_inplaceable_op(target):
+    """Synthesize an InplaceableOp from a functional op's in-place counterpart
+    (OpOverload._inplace_variant), so reinplacing handles ops like uniform,
+    normal, digamma, and _philox_uniform without a manual registry entry.
+    Returns None when not applicable."""
+    from torch._inductor.lowering import fallbacks, lowerings
+
+    if not isinstance(target, torch._ops.OpOverload):
+        return None
+    inplace = target._inplace_variant
+    if inplace is None:
+        return None
+    # Reinplace only fallbacks (a real lowering allocates cleanly); skip view
+    # mutators; and skip in-place targets with their own lowering (e.g.
+    # bernoulli_, which must be decomposed for RNG correctness).
+    if (
+        (target in lowerings and target not in fallbacks)
+        or torch.Tag.inplace_view in inplace.tags
+        or (inplace in lowerings and inplace not in fallbacks)
+    ):
+        return None
+    return InplaceableOp(inplace, 0)
+
+
 # Operators that don't depend on the tensor data
 META_ONLY_OPS = OrderedSet(
     [
@@ -809,7 +835,9 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
         return tensors_to_clone
 
     for node in graph.nodes:
-        if (inplaceable_op := inplaceable_ops.get(node.target)) is not None:
+        if inplaceable_op := (
+            inplaceable_ops.get(node.target) or _maybe_inplaceable_op(node.target)
+        ):
             # Check if ALL mutated args can be inplaced
             # Only convert if we don't need to clone any tensor
             mutated_args = [node.args[idx] for idx in inplaceable_op.mutated_args]
@@ -819,6 +847,11 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
                     if copy_node is not None:
                         replace_dict[copy_node] = copy_node.args[0]
                 node.target = inplaceable_op.inplace_op
+                # Tell lowering this in-place op came from reinplacing, so
+                # make_fallback may override a decomp it would otherwise assert
+                # on (e.g. uniform_, normal_ are decomposed but never survive
+                # functionalization, so reinplacing reintroduces them).
+                node.meta["reinplaced_from_functional"] = True
         elif node.target is torch.ops.higher_order.auto_functionalized_v2:
             _mutable_op = node.args[0]
             kwargs = node.kwargs

--- a/torch/_inductor/fx_passes/reinplace.py
+++ b/torch/_inductor/fx_passes/reinplace.py
@@ -1,5 +1,4 @@
 # mypy: allow-untyped-defs
-import functools
 import itertools
 import logging
 import operator
@@ -409,27 +408,56 @@ for outplace_op, inplace_op in inplaceable_foreach_ops_lowerings.items():
 inplaceable_triton_ops = OrderedSet([triton_kernel_wrapper_functional])
 
 
-@functools.lru_cache(None)
-def _maybe_inplaceable_op(target):
+def _maybe_inplaceable_op(node):
     """Synthesize an InplaceableOp from a functional op's in-place counterpart
     (OpOverload._inplace_variant), so reinplacing handles ops like uniform,
-    normal, digamma, and _philox_uniform without a manual registry entry.
+    normal, and _philox_uniform without a manual registry entry.
     Returns None when not applicable."""
-    from torch._inductor.lowering import fallbacks, lowerings
+    from torch._inductor.lowering import lowerings
 
+    target = node.target
     if not isinstance(target, torch._ops.OpOverload):
         return None
     inplace = target._inplace_variant
     if inplace is None:
         return None
-    # Reinplace only fallbacks (a real lowering allocates cleanly); skip view
-    # mutators; and skip in-place targets with their own lowering (e.g.
-    # bernoulli_, which must be decomposed for RNG correctness).
-    if (
-        (target in lowerings and target not in fallbacks)
-        or torch.Tag.inplace_view in inplace.tags
-        or (inplace in lowerings and inplace not in fallbacks)
-    ):
+
+    def has_non_fallback_lowering(op):
+        # A real lowering, as opposed to a fallback handler. Membership in
+        # `fallbacks` is not the inverse: an op like cumsum has both a real scan
+        # lowering and a registered fallback handler.
+        lowering = lowerings.get(op)
+        return lowering is not None and not getattr(
+            lowering, "_is_fallback_handler", False
+        )
+
+    def preserves_dtype():
+        # A synthesized in-place op writes its result into `self`, so it's only
+        # valid when the op preserves `self`'s dtype (excludes type-promoting
+        # ops, e.g. cumsum on an int/bool input promotes to int64).
+        out = node.meta.get("val")
+        arg = node.args[0] if node.args else None
+        val = arg.meta.get("val") if isinstance(arg, torch.fx.Node) else None
+        return (
+            isinstance(out, torch.Tensor)
+            and isinstance(val, torch.Tensor)
+            and out.dtype == val.dtype
+        )
+
+    # Only reinplace ops that lower as a fallback: an op with a real lowering
+    # allocates its output cleanly (no wasted clone), and reinplacing it would
+    # both discard that lowering and risk a dtype change (e.g. cumsum promotes
+    # an int/bool input to int64, which the in-place `self` can't hold).
+    if has_non_fallback_lowering(target):
+        return None
+    # Skip view/metadata mutators (set_, transpose_, ...).
+    if torch.Tag.inplace_view in inplace.tags:
+        return None
+    # Skip in-place targets with their own real lowering (e.g. bernoulli_, which
+    # asserts it must be decomposed for RNG correctness).
+    if has_non_fallback_lowering(inplace):
+        return None
+    if not preserves_dtype():
         return None
     return InplaceableOp(inplace, 0)
 
@@ -836,7 +864,7 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
 
     for node in graph.nodes:
         if inplaceable_op := (
-            inplaceable_ops.get(node.target) or _maybe_inplaceable_op(node.target)
+            inplaceable_ops.get(node.target) or _maybe_inplaceable_op(node)
         ):
             # Check if ALL mutated args can be inplaced
             # Only convert if we don't need to clone any tensor

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1395,6 +1395,11 @@ class GraphLowering(torch.fx.Interpreter):
             if not isinstance(target, torch._ops.OpOverload):
                 raise AssertionError(f"{target} is not an OpOverload")
             base_name = target.name().split(".")[0]
+            # Reinplaced ops may be decomposed but still need a fallback.
+            reinplaced = bool(
+                self.current_node is not None
+                and self.current_node.meta.get("reinplaced_from_functional")
+            )
             if base_name in FALLBACK_ALLOW_LIST:
                 make_fallback(
                     target,
@@ -1402,7 +1407,7 @@ class GraphLowering(torch.fx.Interpreter):
                     get_decomp_fn=self.get_decomp_fn,
                     override_decomp=True,
                 )
-            elif config.implicit_fallbacks:
+            elif config.implicit_fallbacks or reinplaced:
                 error = (
                     MissingOperatorWithDecomp
                     if get_decompositions([target])
@@ -1443,6 +1448,7 @@ class GraphLowering(torch.fx.Interpreter):
                     target,
                     layout_constraint=decided_constraint,
                     get_decomp_fn=self.get_decomp_fn,
+                    override_decomp=reinplaced,
                 )
 
             elif get_decompositions([target]):

--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -863,6 +863,51 @@ class OpOverload(OperatorBase, Generic[_P, _T]):
             self._schema.name, self._schema.overload_name
         )
 
+    @cached_property
+    def _inplace_variant(self) -> "OpOverload | None":
+        """The in-place counterpart of this functional op, or None.
+
+        Uses the codegen naming convention + schema validation. The functional is
+        named either ``<base>`` with in-place ``<base>_`` (e.g. uniform/uniform_),
+        or, when ``<base>`` was taken, ``<base>_functional`` with in-place
+        ``<base>_`` (e.g. normal_functional/normal_). None if this op isn't
+        functional or no in-place variant validates.
+        """
+        schema = self._schema
+        # Must be a functional op returning a single Tensor from a Tensor self.
+        if (
+            schema.is_mutable
+            or not schema.arguments
+            or str(schema.arguments[0].type) != "Tensor"
+            or len(schema.returns) != 1
+            or str(schema.returns[0].type) != "Tensor"
+        ):
+            return None
+        base = self._opname
+        if base.endswith("functional"):
+            inplace_base = base[: -len("functional")]
+        else:
+            inplace_base = base + "_"
+        ns = getattr(torch.ops, self._namespace, None)
+        packet = getattr(ns, inplace_base, None) if ns is not None else None
+        inplace = getattr(packet, self._overloadname, None) if packet else None
+        if not isinstance(inplace, OpOverload):
+            return None
+        # The variant must mutate self (arg0) and otherwise match this op's args.
+        ischema = inplace._schema
+        if (
+            not ischema.is_mutable
+            or len(ischema.arguments) != len(schema.arguments)
+            or ischema.arguments[0].alias_info is None
+            or not ischema.arguments[0].alias_info.is_write
+            or any(
+                str(x.type) != str(y.type)
+                for x, y in zip(schema.arguments[1:], ischema.arguments[1:])
+            )
+        ):
+            return None
+        return inplace
+
     # it's a no-op since OpOverload object is immutable and must be unique for a given op overload.
     def __deepcopy__(self, memo=None):
         return self


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #189080

Broader fix for #188495

Under `torch.compile`, functionalization rewrites in-place ops (e.g. `uniform_`) into functional ones that clone self before writing. For **write-only ops**, that clone is wasted and survives as an Inductor fallback, doubling peak memory. Inductor's reinplacing pass only undid this for a hand-maintained `inplaceable_ops` registry.

This PR generalizes this to any functional op with a valid in-place variant when the buffer is dead:
* Introduces new property `OpOverload._inplace_variant` using a naming convention + schema validation to identify an in-place variant
* Marks reinplaced nodes in `node.meta` so GraphLowering can pass `override_decomp` appropriately, avoiding an error for reintroduced in-place ops with `make_fallback`'s fallback-vs-decomp assertion

Covers `_philox_uniform` / `_philox_normal`, `uniform` / `normal`, and fallbacks like `digamma` / `gcd`. Note that `bernoulli.Tensor` is excluded because reinplacing to eager would break RNG determinism; a decomp should be added for this op variant instead (`bernoulli.default` already has one). This is left to a future PR.

Test Plan:
```python
python -m pytest test/inductor/test_inplacing_pass.py \
  test/test_stateless_rng.py test/test_functionalization_of_rng_ops.py \
  "test/test_python_dispatch.py::TestDispatcherPythonBindings" -q
```

Alternative approach: signal to functionalization some other way that an op is write-only rather than read-modify-write, avoiding the need for reinplacing entirely.

Authored with assistance from Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo