### PR TITLE
Use python_type_name instead of hardcoded types

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -17902,6 +17902,7 @@ class DynamoOpPromotionTests(torch._dynamo.test_case.TestCase):
                 got = torch.compile(fn, backend=backend, fullgraph=True)(a, b)
                 self.assertEqual(got, expected)
 
+
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests
 

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -8888,6 +8888,22 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
         self.assertEqual(result.shape, expected.shape)
         self.assertEqual(result, expected)
 
+    def test_python_type_name_mirrors_cpython_tp_name(self):
+        """Test python_type_name() mirrors CPython's tp_name slot."""
+        from torch._dynamo.variables.constant import ConstantVariable
+
+        # python_type_name() should return CPython's tp_name string
+        test_cases = [
+            (42, "int"),
+            ("hello", "str"),
+            (None, "NoneType"),
+            (..., "ellipsis"),
+        ]
+
+        for value, expected_tp_name in test_cases:
+            vt = ConstantVariable(value)
+            self.assertEqual(vt.python_type_name(), expected_tp_name)
+
     def test_guard_failure_fn(self):
         def fn(x, y, k):
             x = x + 1
@@ -17885,7 +17901,6 @@ class DynamoOpPromotionTests(torch._dynamo.test_case.TestCase):
                 torch._dynamo.reset()
                 got = torch.compile(fn, backend=backend, fullgraph=True)(a, b)
                 self.assertEqual(got, expected)
-
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -458,42 +458,19 @@ class VariableTracker(metaclass=VariableTrackerMeta):
             raise NotImplementedError(f"{self} has no type") from None
 
     def python_type_name(self) -> str:
+        """
+        Return the type name for the Python type this VariableTracker represents.
+
+        Mirrors CPython's tp_name slot (PyTypeObject.tp_name). In Python 3.10+,
+        type.__name__ matches CPython's tp_name exactly (e.g., "list", "NoneType").
+
+        Note: There are no external callers outside torch._dynamo that rely on this.
+        Internal uses should prefer this over hardcoded type name strings.
+        """
         try:
             return self.python_type().__name__
         except NotImplementedError:
             return "<unknown type>"
-
-    @property
-    def tp_name(self) -> str:
-        """
-        Return the CPython tp_name for the type this VariableTracker represents.
-
-        This mirrors CPython's tp_name slot, which is a string field on PyTypeObject
-        that holds the type's name as it appears in error messages and __class__.__name__.
-
-        CPython reference: Objects/typeobject.c, Objects/listobject.c, etc.
-        Each PyTypeObject has a .tp_name field with the canonical type name.
-
-        Returns:
-            str: The CPython tp_name for this type, or "object" as the default fallback.
-
-        Examples:
-            >>> ListVariable(...).tp_name
-            "list"
-            >>> ConstantVariable(None).tp_name
-            "NoneType"
-            >>> ConstantVariable(...).tp_name
-            "ellipsis"
-        """
-        try:
-            py_type = self.python_type()
-        except NotImplementedError:
-            # For VTs without a static Python type (e.g., UserDefinedObjectVariable),
-            # use "object" as the default, matching PyBaseObject_Type.tp_name
-            return "object"
-
-        # In Python 3.10+, type.__name__ matches CPython's tp_name exactly
-        return py_type.__name__
 
     def as_python_constant(self) -> Any:
         """For constants"""

--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -463,6 +463,38 @@ class VariableTracker(metaclass=VariableTrackerMeta):
         except NotImplementedError:
             return "<unknown type>"
 
+    @property
+    def tp_name(self) -> str:
+        """
+        Return the CPython tp_name for the type this VariableTracker represents.
+
+        This mirrors CPython's tp_name slot, which is a string field on PyTypeObject
+        that holds the type's name as it appears in error messages and __class__.__name__.
+
+        CPython reference: Objects/typeobject.c, Objects/listobject.c, etc.
+        Each PyTypeObject has a .tp_name field with the canonical type name.
+
+        Returns:
+            str: The CPython tp_name for this type, or "object" as the default fallback.
+
+        Examples:
+            >>> ListVariable(...).tp_name
+            "list"
+            >>> ConstantVariable(None).tp_name
+            "NoneType"
+            >>> ConstantVariable(...).tp_name
+            "ellipsis"
+        """
+        try:
+            py_type = self.python_type()
+        except NotImplementedError:
+            # For VTs without a static Python type (e.g., UserDefinedObjectVariable),
+            # use "object" as the default, matching PyBaseObject_Type.tp_name
+            return "object"
+
+        # In Python 3.10+, type.__name__ matches CPython's tp_name exactly
+        return py_type.__name__
+
     def as_python_constant(self) -> Any:
         """For constants"""
         raise AsPythonConstantNotImplementedError(self)

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -1099,15 +1099,14 @@ class DictViewVariable(VariableTracker):
     def repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         if self.kv == "keys":
             items = ", ".join(tracked_repr(tx, key.vt) for key in self.view_items)
-            return VariableTracker.build(tx, f"dict_keys([{items}])")
-        if self.kv == "values":
+        elif self.kv == "values":
             items = ", ".join(tracked_repr(tx, value) for value in self.view_items)
-            return VariableTracker.build(tx, f"dict_values([{items}])")
-        items = ", ".join(
-            f"({tracked_repr(tx, key.vt)}, {tracked_repr(tx, value)})"
-            for key, value in self.view_items
-        )
-        return VariableTracker.build(tx, f"dict_items([{items}])")
+        else:  # items
+            items = ", ".join(
+                f"({tracked_repr(tx, key.vt)}, {tracked_repr(tx, value)})"
+                for key, value in self.view_items
+            )
+        return VariableTracker.build(tx, f"{self.python_type_name()}([{items}])")
 
     def call_method(
         self,

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -1536,10 +1536,10 @@ class DequeVariable(CommonListMethodsVariable):
     def repr_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         items = ", ".join(tracked_repr(tx, item) for item in self.items)
         if self.maxlen.as_python_constant() is None:
-            return VariableTracker.build(tx, f"deque([{items}])")
+            return VariableTracker.build(tx, f"{self.python_type_name()}([{items}])")
         return VariableTracker.build(
             tx,
-            f"deque([{items}], maxlen={tracked_repr(tx, self.maxlen)})",
+            f"{self.python_type_name()}([{items}], maxlen={tracked_repr(tx, self.maxlen)})",
         )
 
     def as_python_constant(self) -> collections.deque[Any]:

--- a/torch/_dynamo/variables/sets.py
+++ b/torch/_dynamo/variables/sets.py
@@ -161,7 +161,7 @@ class SetVariable(VariableTracker):
     def repr_impl(self, tx: "InstructionTranslatorBase") -> "VariableTracker":
         # https://github.com/python/cpython/blob/3.13/Objects/setobject.c#L763-L822
         if not self.items:
-            return VariableTracker.build(tx, "set()")
+            return VariableTracker.build(tx, f"{self.python_type_name()}()")
         items = ", ".join(tracked_repr(tx, item.vt) for item in self.set_items)
         return VariableTracker.build(tx, "{" + items + "}")
 
@@ -818,7 +818,7 @@ class OrderedSetVariable(SetVariable):
 
     def repr_impl(self, tx: "InstructionTranslatorBase") -> "VariableTracker":
         items = ", ".join(tracked_repr(tx, item.vt) for item in self.set_items)
-        return VariableTracker.build(tx, f"OrderedSet([{items}])")
+        return VariableTracker.build(tx, f"{self.python_type_name()}([{items}])")
 
     def as_python_constant(self) -> OrderedSet[Any]:
         return OrderedSet([k.vt.as_python_constant() for k in self.set_items])
@@ -917,9 +917,9 @@ class FrozensetVariable(SetVariable):
     def repr_impl(self, tx: "InstructionTranslatorBase") -> "VariableTracker":
         # https://github.com/python/cpython/blob/3.13/Objects/setobject.c#L763-L822
         if not self.items:
-            return VariableTracker.build(tx, "frozenset()")
+            return VariableTracker.build(tx, f"{self.python_type_name()}()")
         items = ", ".join(tracked_repr(tx, item.vt) for item in self.set_items)
-        return VariableTracker.build(tx, f"frozenset({{{items}}})")
+        return VariableTracker.build(tx, f"{self.python_type_name()}({{{items}}})")
 
     def reconstruct(self, codegen: "PyCodegen") -> None:
         codegen.add_push_null(

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -4938,7 +4938,7 @@ class DefaultDictVariable(UserDefinedDictVariable):
             raise AssertionError("_base_vt must not be None for defaultdict repr")
         return VariableTracker.build(
             tx,
-            f"defaultdict({tracked_repr(tx, self.default_factory)}, "
+            f"{self.python_type_name()}({tracked_repr(tx, self.default_factory)}, "
             f"{tracked_repr(tx, self._base_vt)})",
         )
 


### PR DESCRIPTION
Enhanced python_type_name( ) docstring to document that it mirrors CPython's tp_name slot, and replaced 6 hardcoded type name strings with calls to python_type_name( ). Uses existing infrastructure to match CPython's type names 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98