### PR TITLE
Fix #188957

### DIFF
--- a/.claude/skills/cuda-index-width/SKILL.md
+++ b/.claude/skills/cuda-index-width/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: cuda-index-width
+description: Choose 32-bit vs 64-bit index math in PyTorch CUDA kernels. Use when fixing large-tensor indexing overflows, deciding whether to use int64_t, canUse32BitIndexMath, CUDA_KERNEL_LOOP_TYPE, or AT_DISPATCH_INDEX_TYPES, and when considering binary-size or performance impact of index-type templating.
+---
+
+# CUDA Index Width in PyTorch
+
+Use this skill when a CUDA kernel overflows `int` indexing, fails near `2^31` elements, or needs a review of `int` vs `int64_t` index math.
+
+## Start with the overflow site
+
+Do not blindly convert all index variables to `int64_t`. Find the expression that can exceed 32 bits and classify where it runs:
+
+- **One-time setup per CTA or per output element group**: prefer one local 64-bit cast at the first multiply.
+- **Hot per-element linear indexing**: template the kernel on `index_t` and dispatch `int` vs `int64_t`.
+- **Unsupported algorithm with 32-bit-only assumptions**: add a clear `TORCH_CHECK(canUse32BitIndexMath(...))` instead of silently overflowing.
+- **Grid dimension overflow**: changing arithmetic type is not enough; add tiling/striding over that dimension.
+
+## Canonical utilities
+
+Include/use the existing PyTorch utilities instead of ad hoc checks:
+
+```cpp
+#include <ATen/native/CanUse32BitIndexMath.h>
+#include <ATen/cuda/detail/KernelUtils.h>
+```
+
+- `at::native::canUse32BitIndexMath(tensor, INT_MAX)` checks both `numel` and maximum storage offset.
+- For CUDA files that already include cuda detail wrappers, `at::cuda::detail::canUse32BitIndexMath` may be available as an alias.
+- `AT_DISPATCH_INDEX_TYPES(cond ? ScalarType::Int : ScalarType::Long, "name", [&] { ... });` provides `index_t`.
+- `CUDA_KERNEL_LOOP_TYPE(index, nthreads, index_t)` keeps grid-stride loops correct for either width.
+
+Check every tensor whose offsets are computed with the selected index type, not just the output tensor.
+
+## Fix patterns
+
+### 1. Localized base-offset overflow
+
+If only a base pointer offset can overflow and it is computed outside the hot loop, keep the kernel otherwise unchanged:
+
+```cpp
+int64_t plane = blockIdx.x;
+input = input + plane * strideD;
+output = output + plane * osizeH * osizeW;
+```
+
+This avoids doubling kernel instantiations and keeps inner-loop arithmetic 32-bit. Use this when dimensions inside the tile still fit in `int`.
+
+### 2. Grid-stride linear kernels
+
+If the loop index, modulo/division decomposition, or final `data[index]` access can exceed 32 bits, template the kernel:
+
+```cpp
+template <typename scalar_t, typename index_t>
+__global__ void kernel(index_t n, const scalar_t* in, scalar_t* out) {
+  CUDA_KERNEL_LOOP_TYPE(index, n, index_t) {
+    out[index] = in[index];
+  }
+}
+
+AT_DISPATCH_INDEX_TYPES(
+    canUse32BitIndexMath(out, INT_MAX) && canUse32BitIndexMath(in, INT_MAX)
+        ? ScalarType::Int
+        : ScalarType::Long,
+    "kernel_index_type",
+    [&] {
+      kernel<scalar_t, index_t><<<blocks, threads, 0, stream>>>(n, in, out);
+      C10_CUDA_KERNEL_LAUNCH_CHECK();
+    });
+```
+
+Prefer this over unconditionally changing the loop index to `int64_t`, because 64-bit division/modulo in a hot CUDA loop can be measurable.
+
+### 3. TensorInfo/accessor or strided kernels
+
+When offsets are computed from sizes/strides, dispatch on an index type only if all participating tensors pass `canUse32BitIndexMath` for that type. Remember that a small `numel()` tensor can still need 64-bit offsets if it is a large strided view.
+
+### 4. 32-bit-only kernels
+
+If supporting 64-bit indexing would require a larger algorithm rewrite or would exceed CUDA launch limits, fail early:
+
+```cpp
+TORCH_CHECK(
+    canUse32BitIndexMath(input) && canUse32BitIndexMath(output),
+    "op_name: tensors must fit into 32-bit index math");
+```
+
+Only use this when the operator already has a documented or accepted size limitation; do not turn a reported correctness bug into an unnecessary limitation.
+
+## Binary-size and performance tradeoffs
+
+Templating on `index_t` duplicates each affected kernel for every scalar dtype and memory-format specialization. Before adding index dispatch to several kernels, ask whether the overflow is in a hot path or only in one setup expression.
+
+A/B candidate fixes when the choice is not obvious:
+
+1. Build each candidate from a clean diff using the same build environment.
+2. Record changed CUDA object and library sizes:
+   ```bash
+   stat -c '%s %n' build/aten/src/ATen/CMakeFiles/torch_cuda.dir/native/cuda/<file>.cu.o torch/lib/libtorch_cuda.so
+   ```
+3. Check symbol multiplication for the kernel name:
+   ```bash
+   nm -S --size-sort -C torch/lib/libtorch_cuda.so | rg '<kernel_name>|index_t|long|int'
+   ```
+4. If hot-loop arithmetic changed, benchmark representative small and large tensors; do not report performance from sanitizer runs.
+
+Default decision:
+
+- **One or two 64-bit setup multiplies**: prefer the local cast.
+- **Per-element indexing may exceed 32 bits**: prefer `index_t` dispatch.
+- **Existing kernel family already dispatches `index_t`**: extend the existing pattern.
+- **Changing many scalar-specialized kernels**: consider binary size before templating all of them.
+
+## Tests for large-index fixes
+
+Add a regression that crosses the exact boundary that failed:
+
+- Use the smallest dtype and output size that still exercises the overflow.
+- Assert `tensor.numel() > torch.iinfo(torch.int32).max` or assert the specific offset boundary.
+- Sample values from both below and above the boundary; avoid full-tensor CPU comparisons for huge tensors.
+- Run the original repro under compute-sanitizer for memory bugs:
+  ```bash
+  CUDA_LAUNCH_BLOCKING=1 PYTORCH_NO_CUDA_MEMORY_CACHING=1 compute-sanitizer --tool memcheck --error-exitcode=99 <python> repro.py
+  ```
+
+For PyTorch tests, prefer adding the regression near related pooling/indexing tests and guard expensive cases with `@largeTensorTest` and the relevant device decorator.
+
+## Review checklist
+
+- [ ] The exact overflowing expression is identified.
+- [ ] 64-bit math is limited to the expressions that need it, or the kernel is templated when the hot index needs it.
+- [ ] `canUse32BitIndexMath` considers every tensor whose offsets use the selected type.
+- [ ] CUDA launch dimensions still fit hardware limits.
+- [ ] The test fails before the fix and passes after it, or the report explains why pre-fix failure was not rerun.
+- [ ] Binary-size/performance impact is mentioned if new `index_t` dispatch duplicates kernels.

--- a/aten/src/ATen/native/cuda/AdaptiveAveragePooling.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveAveragePooling.cu
@@ -21,6 +21,7 @@
 #endif
 
 #include <ATen/native/AdaptivePooling.h>
+#include <ATen/native/CanUse32BitIndexMath.h>
 
 #include <algorithm>
 #include <cfloat>
@@ -49,49 +50,48 @@ namespace {
    *    this function adaptively average pools an input 4D tensor along dimensions 2 and 3
    *    4D input, 4D output
    */
-   template <typename scalar_t>
+   template <typename scalar_t, typename index_t>
   __global__ void adaptive_average_pool(const scalar_t *input, scalar_t *output,
-                          int isizeH, int isizeW,
-                          int osizeH, int osizeW,
+                          index_t isizeH, index_t isizeW,
+                          index_t osizeH, index_t osizeW,
                           int64_t istrideD, int64_t istrideH, int64_t istrideW)
   {
     using opmath_t = at::opmath_type<scalar_t>;
     // iterators on output pixels
-    int oh, ow;
+    index_t oh, ow;
 
     // select input/output plane based on thread/block ID
-    int o_plane = blockIdx.x;
-    int i_plane = o_plane;
+    const index_t plane = blockIdx.x;
 
-    output = output + o_plane*osizeH*osizeW;
-    input = input + i_plane*istrideD;
+    output = output + plane*osizeH*osizeW;
+    input = input + plane*istrideD;
 
-    int ostartH = blockDim.y*blockIdx.y + threadIdx.y;
-    int oendH = osizeH;
-    const int ostepH = blockDim.y*gridDim.y;
+    index_t ostartH = blockDim.y*blockIdx.y + threadIdx.y;
+    index_t oendH = osizeH;
+    const index_t ostepH = blockDim.y*gridDim.y;
 
-    int ostartW = threadIdx.x;
-    int oendW = osizeW;
-    const int ostepW = blockDim.x;
+    index_t ostartW = threadIdx.x;
+    index_t oendW = osizeW;
+    const index_t ostepW = blockDim.x;
 
     // For all output pixels...
     for(oh = ostartH; oh < oendH; oh += ostepH) {
 
-      int istartH = START_IND(oh, osizeH, isizeH);
-      int iendH   = END_IND(oh, osizeH, isizeH);
-      int kH = iendH - istartH;
+      index_t istartH = START_IND(oh, osizeH, isizeH);
+      index_t iendH   = END_IND(oh, osizeH, isizeH);
+      index_t kH = iendH - istartH;
 
       for(ow = ostartW; ow < oendW; ow += ostepW) {
 
-        int istartW = START_IND(ow, osizeW, isizeW);
-        int iendW   = END_IND(ow, osizeW, isizeW);
-        int kW = iendW - istartW;
+        index_t istartW = START_IND(ow, osizeW, isizeW);
+        index_t iendW   = END_IND(ow, osizeW, isizeW);
+        index_t kW = iendW - istartW;
 
         // Compute the average pooling over corresponding input pixels
         const scalar_t *ptr_input = input + istartH*istrideH + istartW*istrideW;
         scalar_t *ptr_output = output + oh*osizeW + ow;
         opmath_t sum = static_cast<opmath_t>(0);
-        int ih, iw;
+        index_t ih, iw;
         for(ih = 0; ih < kH; ++ih) {
           for(iw = 0; iw < kW; ++iw) {
             scalar_t val = ptr_input[iw*istrideW];
@@ -109,49 +109,48 @@ namespace {
    * Description:
    *    this function computes the gradInput from gradOutput
    */
-   template <typename T>
+   template <typename T, typename index_t>
   __global__ void adaptive_average_gradinput(
     T *gradInput, const T *gradOutput,
-    int isizeH, int isizeW, int osizeH, int osizeW
+    index_t isizeH, index_t isizeW, index_t osizeH, index_t osizeW
   )
   {
     // iterators on input pixels
-    int ih, iw;
+    index_t ih, iw;
 
     // select input/output plane based on thread/block ID
-    int i_plane = blockIdx.x;
-    int o_plane = i_plane;
+    const index_t plane = blockIdx.x;
 
-    gradOutput = gradOutput + o_plane*osizeH*osizeW;
-    gradInput = gradInput + i_plane*isizeH*isizeW;
+    gradOutput = gradOutput + plane*osizeH*osizeW;
+    gradInput = gradInput + plane*isizeH*isizeW;
 
-    int istartH = blockDim.y*blockIdx.y + threadIdx.y;
-    int iendH = isizeH;
-    int istepH = blockDim.y*gridDim.y;
+    index_t istartH = blockDim.y*blockIdx.y + threadIdx.y;
+    index_t iendH = isizeH;
+    index_t istepH = blockDim.y*gridDim.y;
 
-    int istartW = threadIdx.x;
-    int iendW = isizeW;
-    int istepW = blockDim.x;
+    index_t istartW = threadIdx.x;
+    index_t iendW = isizeW;
+    index_t istepW = blockDim.x;
 
     // compute gradInput
     for(ih = istartH; ih < iendH; ih += istepH) {
 
-      int ostartH = START_IND(ih, isizeH, osizeH);
-      int oendH   = END_IND(ih, isizeH, osizeH);
+      index_t ostartH = START_IND(ih, isizeH, osizeH);
+      index_t oendH   = END_IND(ih, isizeH, osizeH);
 
       for(iw = istartW; iw < iendW; iw += istepW) {
 
-        int ostartW = START_IND(iw, isizeW, osizeW);
-        int oendW   = END_IND(iw, isizeW, osizeW);
+        index_t ostartW = START_IND(iw, isizeW, osizeW);
+        index_t oendW   = END_IND(iw, isizeW, osizeW);
 
         // Compute the gradients over corresponding output pixels
         T *ptr_gradInput = gradInput + ih*isizeW + iw;
 
-        int oh, ow;
+        index_t oh, ow;
         for(oh = ostartH; oh < oendH; ++oh) {
-          int kH = START_IND(oh, osizeH, isizeH) - END_IND(oh, osizeH, isizeH);
+          index_t kH = START_IND(oh, osizeH, isizeH) - END_IND(oh, osizeH, isizeH);
           for(ow = ostartW; ow < oendW; ++ow) {
-            int kW = START_IND(ow, osizeW, isizeW) - END_IND(ow, osizeW, isizeW);
+            index_t kW = START_IND(ow, osizeW, isizeW) - END_IND(ow, osizeW, isizeW);
             T grad_delta = gradOutput[ow + oh*osizeW] / kH / kW;
             *ptr_gradInput += grad_delta;
           }
@@ -165,49 +164,48 @@ namespace {
    *    this function computes the gradInput from gradOutput
    *    (uses atomic add)
    */
-   template <typename T>
+   template <typename T, typename index_t>
   __global__ void atomic_adaptive_average_gradinput(
     T *gradInput, const T *gradOutput,
-    int isizeH, int isizeW, int osizeH, int osizeW
+    index_t isizeH, index_t isizeW, index_t osizeH, index_t osizeW
   )
   {
     // iterators on output indices
-    int oh, ow;
+    index_t oh, ow;
 
     // select input/output plane based on thread/block ID
-    int o_plane = blockIdx.x;
-    int i_plane = o_plane;
+    const index_t plane = blockIdx.x;
 
-    gradOutput = gradOutput + o_plane*osizeW*osizeH;
-    gradInput = gradInput + i_plane*isizeW*isizeH;
+    gradOutput = gradOutput + plane*osizeW*osizeH;
+    gradInput = gradInput + plane*isizeW*isizeH;
 
-    int ostartH = blockDim.y*blockIdx.y + threadIdx.y;
-    int oendH = osizeH;
-    int ostepH = blockDim.y*gridDim.y;
+    index_t ostartH = blockDim.y*blockIdx.y + threadIdx.y;
+    index_t oendH = osizeH;
+    index_t ostepH = blockDim.y*gridDim.y;
 
-    int ostartW = threadIdx.x;
-    int oendW = osizeW;
-    int ostepW = blockDim.x;
+    index_t ostartW = threadIdx.x;
+    index_t oendW = osizeW;
+    index_t ostepW = blockDim.x;
 
     // For all output pixels...
     for(oh = ostartH; oh < oendH; oh += ostepH) {
 
-      int istartH = START_IND(oh, osizeH, isizeH);
-      int iendH   = END_IND(oh, osizeH, isizeH);
-      int kH = iendH - istartH;
+      index_t istartH = START_IND(oh, osizeH, isizeH);
+      index_t iendH   = END_IND(oh, osizeH, isizeH);
+      index_t kH = iendH - istartH;
 
       for(ow = ostartW; ow < oendW; ow += ostepW) {
 
-        int istartW = START_IND(ow, osizeW, isizeW);
-        int iendW   = END_IND(ow, osizeW, isizeW);
-        int kW = iendW - istartW;
+        index_t istartW = START_IND(ow, osizeW, isizeW);
+        index_t iendW   = END_IND(ow, osizeW, isizeW);
+        index_t kW = iendW - istartW;
 
         // Compute the gradients for over corresponding input pixels
         T *ptr_gradInput = gradInput + istartH*isizeW + istartW;
         const T *ptr_gradOutput = gradOutput + oh*osizeW + ow;
         T grad_delta = *ptr_gradOutput / kW / kH;
 
-        int ih, iw;
+        index_t ih, iw;
         for(ih = 0; ih < kH; ++ih) {
           for(iw = 0; iw < kW; ++iw) {
             // atomic add since different threads could update same variable
@@ -571,6 +569,10 @@ namespace {
           return;
         }
 
+        const auto index_type =
+            canUse32BitIndexMath(input_) && canUse32BitIndexMath(output)
+            ? ScalarType::Int
+            : ScalarType::Long;
         AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16,
             input_.scalar_type(), "adaptive_avg_pool2d_cuda", [&] {
               const scalar_t *input_data = input_.const_data_ptr<scalar_t>();
@@ -581,12 +583,16 @@ namespace {
               dim3 blocks(grid_x, blocksH);
               dim3 threads(32, 8);
 
-              // run averagepool kernel
-              adaptive_average_pool <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>> (
-                input_data, output_data,
-                isizeH, isizeW, osizeH, osizeW,
-                istrideD, istrideH, istrideW);
-              C10_CUDA_KERNEL_LAUNCH_CHECK();
+              AT_DISPATCH_INDEX_TYPES(
+                  index_type, "adaptive_avg_pool2d_cuda_index", [&] {
+                    // run averagepool kernel
+                    adaptive_average_pool<scalar_t, index_t>
+                        <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+                            input_data, output_data,
+                            isizeH, isizeW, osizeH, osizeW,
+                            istrideD, istrideH, istrideW);
+                    C10_CUDA_KERNEL_LAUNCH_CHECK();
+                  });
             }
           );
         break;
@@ -725,6 +731,11 @@ namespace {
         if (input.ndimension() == 4) grid_x *= input.size(-4);
 
           //bool atomic = (isizeW%osizeW != 0) || (isizeH%osizeH != 0);
+        const auto index_type =
+            canUse32BitIndexMath(input) && canUse32BitIndexMath(gradInput) &&
+                canUse32BitIndexMath(gradOutput)
+            ? ScalarType::Int
+            : ScalarType::Long;
         AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16,
             input.scalar_type(), "adaptive_avg_pool2d_backward_cuda", [&] {
               const scalar_t *gradOutput_data = gradOutput.const_data_ptr<scalar_t>();
@@ -735,22 +746,27 @@ namespace {
               dim3 blocks(grid_x, blocksH);
               dim3 threads(32, 8);
 
-              if(atomic)
-              {
-                // run updateGradInput kernel, accumulate gradients atomically
-                atomic_adaptive_average_gradinput <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>> (
-                  gradInput_data, gradOutput_data,
-                  isizeH, isizeW, osizeH, osizeW);
-                C10_CUDA_KERNEL_LAUNCH_CHECK();
-              }
-              else
-              {
-                // run updateGradInput kernel
-                adaptive_average_gradinput <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>> (
-                  gradInput_data, gradOutput_data,
-                  isizeH, isizeW, osizeH, osizeW);
-                C10_CUDA_KERNEL_LAUNCH_CHECK();
-              }
+              AT_DISPATCH_INDEX_TYPES(
+                  index_type, "adaptive_avg_pool2d_backward_cuda_index", [&] {
+                    if(atomic)
+                    {
+                      // run updateGradInput kernel, accumulate gradients atomically
+                      atomic_adaptive_average_gradinput<scalar_t, index_t>
+                          <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+                              gradInput_data, gradOutput_data,
+                              isizeH, isizeW, osizeH, osizeW);
+                      C10_CUDA_KERNEL_LAUNCH_CHECK();
+                    }
+                    else
+                    {
+                      // run updateGradInput kernel
+                      adaptive_average_gradinput<scalar_t, index_t>
+                          <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+                              gradInput_data, gradOutput_data,
+                              isizeH, isizeW, osizeH, osizeW);
+                      C10_CUDA_KERNEL_LAUNCH_CHECK();
+                    }
+                  });
             }
           );
         break;

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -28,6 +28,7 @@ from torch.testing._internal.common_device_type import (
     largeTensorTest,
     onlyAccelerator,
     onlyCPU,
+    onlyCUDA,
     onlyMPS,
     TEST_WITH_ROCM,
 )
@@ -518,6 +519,33 @@ class TestPoolingNNDeviceType(NNTestCase):
         out = avg_pool(input)
         self.assertFalse(torch.isinf(out).any())
         self.assertFalse(torch.isnan(out).any())
+
+    @onlyCUDA
+    @largeTensorTest("10GB", device="cuda")
+    def test_adaptive_avg_pool2d_backward_large_index_offsets(self, device):
+        height = 32769
+        width = 65536
+        channels = 2
+        output_width = 1024
+        input = torch.as_strided(
+            torch.empty((1,), dtype=torch.half, device=device),
+            (1, channels, height, width),
+            (0, 0, 0, 0),
+        )
+        self.assertGreater(input.numel(), torch.iinfo(torch.int32).max)
+        grad_output = torch.ones(
+            (1, channels, height, output_width), dtype=torch.half, device=device
+        )
+
+        grad_input = torch.ops.aten._adaptive_avg_pool2d_backward(grad_output, input)
+        sample = grad_input[
+            0,
+            [0, 0, 1],
+            [0, height - 1, height - 1],
+            [0, 0, width - 1],
+        ]
+        expected = torch.full_like(sample, 1 / (width // output_width))
+        self.assertEqual(sample, expected)
 
     @expectedFailureMPS  # No double, float shape prop does not work
     @dtypes(torch.float, torch.double)


### PR DESCRIPTION
## Human Note
Spoke with Eddie on this one (will have you review). This was int64 index realted. Techincally if you look at the agent notes I could have solved this by not doing the index_t 
templatization. I just need to make sure the base offset was int64 but I also wanted to work on a lil skill for doing this in the future since this comes up quite often.

I feel as though we should have some automated binary increase ci job. I have alos said this in the past I might add something.

## Agent Report
# Report: pytorch/pytorch#188957

## Summary

The reported CUDA illegal memory access in `adaptive_avg_pool2d` backward is reproducible on this worktree under `compute-sanitizer`. The failing kernel was `atomic_adaptive_average_gradinput<float>` for large contiguous NCHW tensors where flattened offsets cross `2^31` elements.

I also added a PyTorch-local skill at `.claude/skills/cuda-index-width/SKILL.md` documenting how to choose between local `int64_t` casts, `index_t` templating, `canUse32BitIndexMath`, and explicit 32-bit index checks in PyTorch CUDA kernels.

## Root cause

The contiguous CUDA adaptive average pooling kernels used `int` for shape/index math. For the issue shape, channel plane `2048` has base offset:

```text
2048 * 1024 * 1024 == 2^31 elements
```

That signed 32-bit product overflows before being added to the `gradInput` pointer, producing a pointer far before the allocation and causing invalid global atomics.

A broader audit showed that the same contiguous kernels also had plane-local spatial offset expressions that were still typed as `int`. Some generated code handled the crafted huge-spatial scratch case correctly, but the source did not encode the invariant. The final fix follows the PyTorch large-index pattern instead of relying on codegen behavior.

## Fix

`aten/src/ATen/native/cuda/AdaptiveAveragePooling.cu` now templates the contiguous NCHW forward, non-atomic backward, and atomic backward kernels on `index_t`. The launch sites choose `ScalarType::Int` or `ScalarType::Long` using `canUse32BitIndexMath` over the tensors whose offsets are computed, then launch the corresponding `index_t` specialization with `AT_DISPATCH_INDEX_TYPES`.

This keeps normal tensors on 32-bit index arithmetic and routes large tensors or large storage-offset views to 64-bit index arithmetic. The tradeoff is binary size: each affected contiguous kernel now has `int` and `long` instantiations for each scalar dtype. `nm -C torch/lib/libtorch_cuda.so` confirms both variants are present for `adaptive_average_pool`, `adaptive_average_gradinput`, and `atomic_adaptive_average_gradinput`.

Measured A/B binary size impact by reversing the patch, rebuilding baseline, reapplying the patch, and rebuilding final in the same worktree/build environment:

| Artifact | Baseline bytes | Final bytes | Delta |
|---|---:|---:|---:|
| `AdaptiveAveragePooling.cu.o` | 294,600 | 356,208 | +61,608 |
| `torch/lib/libtorch_cuda.so` | 290,017,992 | 290,029,792 | +11,800 |

The raw measurements are in `agent_space/index_width_size_compare.tsv`.

A CUDA large-tensor regression test was added in `test/nn/test_pooling.py` for `_adaptive_avg_pool2d_backward`. It uses a shape-only zero-stride input with two channels and a `32769 x 65536` spatial plane so both the channel plane offset and a within-plane spatial offset cross `INT_MAX`, while avoiding huge input storage. The test samples values below and above those boundaries.

## Repro

<details>
<summary>Repro Script</summary>

```python
import torch
print("torch:", torch.__version__)
dev = torch.device('cuda')
x = torch.randn(1, 2050, 1024, 1024, dtype=torch.float32, device=dev, requires_grad=True)
out = torch.nn.functional.adaptive_avg_pool2d(x, (256, 256))
out.sum().backward()
torch.cuda.synchronize()
```

Run command:

```bash
CUDA_LAUNCH_BLOCKING=1 PYTORCH_NO_CUDA_MEMORY_CACHING=1 compute-sanitizer --tool memcheck --error-exitcode=99 ~/.ptq_workspace/jobs/20260706-pytorch-188957/.venv/bin/python ~/.ptq_workspace/jobs/20260706-pytorch-188957/repro.py
```

Post-fix output:

```text
========= COMPUTE-SANITIZER
torch: 2.14.0a0+gita059c4a
========= ERROR SUMMARY: 0 errors
```

Before the fix, the same command reported invalid 4-byte global atomics in `atomic_adaptive_average_gradinput<float>` from blocks around `2048`/`2049` and exited with CUDA illegal address.

</details>

## Validation

Tests:

```bash
cd ~/.ptq_workspace/jobs/20260706-pytorch-188957/pytorch && ../.venv/bin/python test/nn/test_pooling.py TestPoolingNNDeviceTypeCUDA.test_adaptive_avg_pool2d_backward_large_index_offsets_cuda
```

Latest result:

```text
.
----------------------------------------------------------------------
Ran 1 test in 1.184s

OK
```

Original repro validation:

```bash
CUDA_LAUNCH_BLOCKING=1 PYTORCH_NO_CUDA_MEMORY_CACHING=1 compute-sanitizer --tool memcheck --error-exitcode=99 ~/.ptq_workspace/jobs/20260706-pytorch-188957/.venv/bin/python ~/.ptq_workspace/jobs/20260706-pytorch-188957/repro.py
```

Latest result: `ERROR SUMMARY: 0 errors`.

Additional scratch validation:

```bash
cd ~/.ptq_workspace/jobs/20260706-pytorch-188957 && CUDA_LAUNCH_BLOCKING=1 ./.venv/bin/python agent_space/repro_large_index_offsets.py
```

Result: sampled `gradInput` values match `1 / 64` for positions below and above the 32-bit offset boundary.

Prerequisite checks:

- Rebuilt PyTorch successfully after the final CUDA source change with `bash ~/.ptq_workspace/scripts/rebuild.sh ~/.ptq_workspace/jobs/20260706-pytorch-188957/pytorch`.
- Ran `../.venv/bin/spin fixlint` after the final code changes. It exited nonzero due to unrelated repo-wide lint findings in `.ci/pytorch/*.sh`, `torch/headeronly/util/Half.h`, and `torch/headeronly/util/complex.h`. The invoked lintrunner categories reported `ok No lint issues` for the changed-file checks.
- `git diff --check` passes.

## Artifacts

- `fix.diff` generated at `~/.ptq_workspace/jobs/20260706-pytorch-188957/fix.diff`.
- `worklog.md` updated with reproduction, fix, validation, lint status, and the skill follow-up.


Fixes #188957


<details>
<summary>Repro Script</summary>

```python
import torch
print("torch:", torch.__version__)
dev = torch.device('cuda')
x = torch.randn(1, 2050, 1024, 1024, dtype=torch.float32, device=dev, requires_grad=True)
out = torch.nn.functional.adaptive_avg_pool2d(x, (256, 256))
out.sum().backward()
torch.cuda.synchronize()
```

</details>


<details>
<summary>Agent Worklog</summary>

## Run 1

### Reproduced invalid atomic
Ran `compute-sanitizer --tool memcheck --error-exitcode=99` on the provided `repro.py` using the job venv. It reports invalid 4-byte global atomics in `atomic_adaptive_average_gradinput<float>` from blocks around `2048`/`2049`, then exits with CUDA illegal address. This confirms the issue is reproducible in this worktree.

### Patched contiguous CUDA plane offsets
Traced the failing block index to `blockIdx.x * isizeH * isizeW` in `AdaptiveAveragePooling.cu`. For channel plane 2048 and a `1024 x 1024` plane, the `int` product wraps at `2^31` elements before pointer arithmetic. Changed the contiguous adaptive average pooling kernels to promote the plane index to `int64_t` before multiplying by plane strides, and added a CUDA large-tensor regression for backward with `float16`.

### Rebuilt PyTorch
Ran `bash ~/.ptq_workspace/scripts/rebuild.sh ~/.ptq_workspace/jobs/20260706-pytorch-188957/pytorch`. The editable torch package rebuilt and reinstalled successfully.

### Validated fix
The new targeted CUDA unittest `TestPoolingNNDeviceTypeCUDA.test_adaptive_avg_pool2d_backward_large_plane_offset_cuda` passes. The original `repro.py` now passes under compute-sanitizer memcheck with `ERROR SUMMARY: 0 errors`.

### Lint status
Ran `../.venv/bin/spin fixlint` twice after code changes. It exits nonzero due to unrelated repo-wide lint findings in `.ci/pytorch/*.sh`, `torch/headeronly/util/Half.h`, and `torch/headeronly/util/complex.h`; the lintrunner categories it invoked for changed files reported `ok No lint issues`, and the final git diff remains limited to `AdaptiveAveragePooling.cu` and `test_pooling.py`.

### Wrote final artifacts
Generated `fix.diff` from the PyTorch worktree and wrote `report.md` with the root cause, fix, repro output, validation, and lint caveat.

## Follow-up

### Added PyTorch-local CUDA index-width skill
Created `.claude/skills/cuda-index-width/SKILL.md` in the PyTorch worktree. The skill documents when to use a local `int64_t` cast, when to template kernels with `index_t` and `AT_DISPATCH_INDEX_TYPES`, how to think about binary-size/performance tradeoffs, and what large-index tests should cover.

### Expanded fix to full contiguous index dispatch
Applied the new skill to the rest of the contiguous NCHW kernels. The forward, non-atomic backward, and atomic backward kernels now template their shape/index math on `index_t`, and the launch sites choose `int` vs `long` via `canUse32BitIndexMath` over the tensors whose offsets are computed. This preserves 32-bit arithmetic for normal tensors and uses 64-bit indexing for large tensor/storage-offset cases.

### Added broader large-index regression
Replaced the earlier plane-only regression with `TestPoolingNNDeviceTypeCUDA.test_adaptive_avg_pool2d_backward_large_index_offsets_cuda`. It uses a shape-only zero-stride input with two channels and a `32769 x 65536` spatial plane so both the channel plane offset and a within-plane spatial offset cross `INT_MAX`, then samples below and above the boundary.

### Final validation
Rebuilt PyTorch after the final CUDA formatting changes. The updated large-index regression passes, the original issue `repro.py` reports `ERROR SUMMARY: 0 errors` under compute-sanitizer memcheck, and a scratch large-index repro in `agent_space/repro_large_index_offsets.py` returns the expected sampled values. `nm -C torch/lib/libtorch_cuda.so` shows both `int` and `long` instantiations for the affected contiguous kernels. `git diff --check` passes. `spin fixlint` still exits nonzero on unrelated repo-wide lint findings, while changed-file lintrunner checks report `ok No lint issues`.

### Binary size A/B
Saved the final patch, reversed it, rebuilt the baseline, recorded sizes, reapplied the patch, rebuilt the final version, and recorded sizes in `agent_space/index_width_size_compare.tsv`. `AdaptiveAveragePooling.cu.o` grew from 294,600 to 356,208 bytes (+61,608); `torch/lib/libtorch_cuda.so` grew from 290,017,992 to 290,029,792 bytes (+11,800). After restoring the final patch, the updated large-index regression and original compute-sanitizer repro both still pass.

</details>

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*