### PR TITLE
Add bohnstingl to merge_rules and CODEOWNER

### DIFF
--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -466,13 +466,9 @@
   - Lint
   - pull
 
-- name: Control flow operators
+- name: Higher order operators
   patterns:
-  - torch/_higher_order_ops/cond.py
-  - torch/_higher_order_ops/while_loop.py
-  - torch/_higher_order_ops/scan.py
-  - torch/_higher_order_ops/associative_scan.py
-  - torch/_higher_order_ops/switch.py
+  - torch/_higher_order_ops/**
   - torch/_dynamo/variables/higher_order_ops.py
   - docs/source/higher_order_ops/**
   approved_by:

--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -466,6 +466,22 @@
   - Lint
   - pull
 
+- name: Control flow operators
+  patterns:
+  - torch/_higher_order_ops/cond.py
+  - torch/_higher_order_ops/while_loop.py
+  - torch/_higher_order_ops/scan.py
+  - torch/_higher_order_ops/associative_scan.py
+  - torch/_higher_order_ops/switch.py
+  - torch/_dynamo/variables/higher_order_ops.py
+  - docs/source/higher_order_ops/**
+  approved_by:
+  - bohnstingl
+  mandatory_checks_name:
+  - EasyCLA
+  - Lint
+  - pull
+
 - name: Dynamo
   patterns:
   - torch/_dynamo/**

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -124,8 +124,9 @@ test/functorch/test_vmap.py @zou3519 @chillee @kshitij12345
 torch/fx/proxy.py @zou3519
 
 # HOPs
-torch/_higher_order_ops/*.py @zou3519 @aorenste
-torch/_dynamo/variables/higher_order_ops.py @zou3519 @aorenste
+torch/_higher_order_ops/*.py @zou3519 @aorenste @bohnstingl
+torch/_dynamo/variables/higher_order_ops.py @zou3519 @aorenste @bohnstingl
+docs/source/higher_order_ops/ @bohnstingl
 test/test_hop_infra.py @zou3519 @aorenste
 torch/testing/_internal/hop_db.py @tugsbayasgalan @zou3519 @ydwu4 @aorenste
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -124,11 +124,11 @@ test/functorch/test_vmap.py @zou3519 @chillee @kshitij12345
 torch/fx/proxy.py @zou3519
 
 # HOPs
-torch/_higher_order_ops/*.py @zou3519 @aorenste @bohnstingl
+torch/_higher_order_ops/ @zou3519 @aorenste @bohnstingl
 torch/_dynamo/variables/higher_order_ops.py @zou3519 @aorenste @bohnstingl
 docs/source/higher_order_ops/ @bohnstingl
-test/test_hop_infra.py @zou3519 @aorenste
-torch/testing/_internal/hop_db.py @tugsbayasgalan @zou3519 @ydwu4 @aorenste
+test/test_hop_infra.py @zou3519 @aorenste @bohnstingl
+torch/testing/_internal/hop_db.py @tugsbayasgalan @zou3519 @ydwu4 @aorenste @bohnstingl
 
 # AOTAutograd
 torch/_functorch/_aot_autograd/*.py @bdhirsh @aorenste
@@ -231,7 +231,7 @@ torch/backends/cudnn/ @eqy @syed-ahmed @Aidyn-A
 
 # FlexAttention
 /torch/nn/attention/flex_attention.py @drisspg
-/torch/_higher_order_ops/flex_attention.py @drisspg
+/torch/_higher_order_ops/flex_attention.py @drisspg @bohnstingl
 /torch/_inductor/kernel/flex/ @drisspg
 /torch/_inductor/codegen/cpp_flex_attention_template.py @drisspg
 /test/inductor/test_flex_attention.py @drisspg

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -231,7 +231,7 @@ torch/backends/cudnn/ @eqy @syed-ahmed @Aidyn-A
 
 # FlexAttention
 /torch/nn/attention/flex_attention.py @drisspg
-/torch/_higher_order_ops/flex_attention.py @drisspg @bohnstingl
+/torch/_higher_order_ops/flex_attention.py @drisspg
 /torch/_inductor/kernel/flex/ @drisspg
 /torch/_inductor/codegen/cpp_flex_attention_template.py @drisspg
 /test/inductor/test_flex_attention.py @drisspg


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189087

Add bohnstingl as CODEOWNER for control flow operators. There wasn't
really a good split so I granted access for all HOPs.

Authored with the assistance of an AI coding assistant.