### PR TITLE
[fmha_fwd][rocm] Extend CK ck_tile FMHA seqlen-pad guard to the GQA swap path

### DIFF
--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_fwd_ck.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_fwd_ck.hip
@@ -422,10 +422,8 @@ mha_fwd_ck(const at::Tensor &q,                      // batch_size x seqlen_q x 
     // Hand the kernel seqlen-padded *allocations* (the extra rows are mapped
     // scratch) while leaving seqlen_q/seqlen_k unchanged, so the kernel's logical
     // masking is identical and numerics are unchanged; the real rows are copied
-    // back into the caller-visible tensors below. Engages only for tile-unaligned
-    // seqlens on the non-swapped path; skipped when seqlenq_ngroups_swapped is
-    // active (that fast path reshapes seqlen_q into the batch/group dim, so the
-    // tile-tail over-read does not apply).
+    // back into the caller-visible tensors below. Engages on any tile-unaligned
+    // seqlen, including the seqlenq_ngroups_swapped (GQA decode) path.
     // Scope: covers Q/K/V (read) and O/LSE (write) only. attn_bias (bias_ptr,
     // seqlen_q x seqlen_k) and the dropout randval buffer (p / rand_val_ptr) are
     // touched by the same round_up(seqlen, tile) pattern but are left unpadded
@@ -438,12 +436,17 @@ mha_fwd_ck(const at::Tensor &q,                      // batch_size x seqlen_q x 
     constexpr int kCkSeqTileLCM = 256; // >= every fwd kM0/kN0 in the generated set
     const int seqlen_q_pad = round_multiple(seqlen_q, kCkSeqTileLCM);
     const int seqlen_k_pad = round_multiple(seqlen_k, kCkSeqTileLCM);
-    const bool ck_oob_guard = !seqlenq_ngroups_swapped &&
-        ((seqlen_q_pad != seqlen_q) || (seqlen_k_pad != seqlen_k));
+    const bool ck_oob_guard =
+        (seqlen_q_pad != seqlen_q) || (seqlen_k_pad != seqlen_k);
     if (ck_oob_guard) {
         if (seqlen_q_pad != seqlen_q) {
             q_arg   = at::pad(q_padded, {0, 0, 0, 0, 0, seqlen_q_pad - seqlen_q});
-            out_arg = at::empty({out.size(0), seqlen_q_pad, out.size(2), out.size(3)}, out.options());
+            // Allocate O/LSE scratch from the logical kernel dims (post-swap
+            // num_heads/seqlen_q), not out.sizes(): on the seqlenq_ngroups_swapped
+            // path `out` is still [b, 1, num_heads*seqlen_q, d], so out.size(2)/(3)
+            // would be wrong here.
+            out_arg = at::empty(
+                {batch_size, seqlen_q_pad, num_heads, head_size_8x}, out.options());
             lse_arg = at::empty({batch_size, num_heads, seqlen_q_pad}, softmax_lse.options());
         }
         if (seqlen_k_pad != seqlen_k) {
@@ -491,9 +494,13 @@ mha_fwd_ck(const at::Tensor &q,                      // batch_size x seqlen_q x 
         float t = fmha_fwd(traits, args, stream_config);
         TORCH_CHECK(t >= 0, "invalid argument for fmha_fwd");
         if (ck_oob_guard && seqlen_q_pad != seqlen_q) {
-            // copy the real rows out of the padded scratch into the caller tensors
-            out.copy_(out_arg.narrow(1, 0, seqlen_q));
-            softmax_lse.copy_(lse_arg.narrow(2, 0, seqlen_q));
+            // copy the real rows out of the padded scratch into the caller tensors.
+            // reshape() maps the [b, seqlen_q, num_heads, d] scratch back onto out's
+            // actual shape (same element count), covering the swapped layout where
+            // out is [b, 1, num_heads*seqlen_q, d].
+            out.copy_(out_arg.narrow(1, 0, seqlen_q).reshape(out.sizes()));
+            softmax_lse.copy_(
+                lse_arg.narrow(2, 0, seqlen_q).reshape(softmax_lse.sizes()));
         }
     }
     else {


### PR DESCRIPTION
Summary:
Follow-up to the gfx9 CK ck_tile FMHA tile-tail OOB guard: the guard excluded
the seqlenq_ngroups_swapped (GQA decode) path, but that path is exactly where a
real MoE/MTML inference model still faults during AOTT GPU lowering on AMD
(MI300X gfx942): "Memory access fault by GPU node-N ... Reason: Unknown".

Root cause: for GQA decode (seqlen_q==1, num_heads > num_heads_k) F.sdpa's CK
flash path transposes (b,1,(hk*ngroups),d) -> (b,ngroups,hk,d), making
seqlen_q=ngroups. For the faulting request ngroups=2000 (pad 2048) and
seqlen_k=656 (pad 768) are both tile-unaligned, so CK selects a no-seqlen-pad
fwd instance that writes round_up(seqlen_q, kM0=128)=2048 rows into the
[b, ngroups, hk, d] output -- over-writing O/LSE ~0.5 MB past the buffer and
faulting (decoded via a temporary TORCH_WARN at the call site: b=32 hq=2 hk=2
sq=2000 sk=656 d=128 swap=1, last kernel before the fault =
ck_tile::FmhaFwdKernel<... TileFmhaTraits<kPadSeqLenQ=1,kPadSeqLenK=1...>>,
grid {1,2,32}). The original guard's `!seqlenq_ngroups_swapped` exclusion left
this case unprotected.

Fix:
- Drop the `!seqlenq_ngroups_swapped` exclusion so the guard engages on any
  tile-unaligned seqlen, including the swap path.
- Allocate the O/LSE scratch from the logical post-swap kernel dims
  ({batch, seqlen_q_pad, num_heads, head_size_8x}) instead of out.sizes(): on
  the swap path `out` is still [b, 1, num_heads*seqlen_q, d], so out.size(2)/(3)
  would be wrong.
- Copy the real rows back via reshape(out.sizes()) / reshape(softmax_lse.sizes())
  so the padded scratch maps onto the caller's actual layout for both the swap
  and non-swap cases.

Durable follow-up (unchanged): CK should generate/select kPadSeqLen fwd
instances upstream, after which this host guard can be removed.

Test Plan:
Reproduced and fixed on MI300X (gfx942) via the from-source lowering binary
(re_mvai_cinder) on the failing autotune request (model 2118627168), classic mode.

BEFORE (this commit absent): "Memory access fault by GPU node-2 ... Reason:
Unknown" at the scripted-model validation forward pass. With the caching
allocator disabled (PYTORCH_NO_HIP_MEMORY_CACHING=1) the same fault is
deterministic and resolves to "Write access to a read-only page" on the CK
FmhaFwd kernel, swap=1 guard=0.

AFTER (this commit):
- PYTORCH_NO_HIP_MEMORY_CACHING=1 (deterministic repro): swap-path calls now log
  guard=1, 0 memory faults, "Scripted model validation forward pass completed
  successfully", Done to_torch_package.
- Normal caching allocator (production-like): 0 memory faults, validation
  completed, "Upload lowered model ... size: 30483746255 bytes", lowering
  completed in ~402s.

Numerics: the lowering's own scripted-model validation forward pass (5 real
dumped requests) is a correctness check and passes; the swapped copy-back layout
is byte-identical to the guard-off path (same contiguous logical strides).

Differential Revision: D108947199




cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang