### PR TITLE
[torchTLX] move codebase to triton-beta / fbtriton (#189094)

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1847,6 +1847,12 @@ class triton:
     Config specific to codegen/triton.py
     """
 
+    # No-op unless fbtriton (a Triton fork) is installed
+    tlx_mode: Literal["default", "allow", "force"] = cast(
+        Literal["default", "allow", "force"],
+        os.environ.get("TORCHINDUCTOR_TLX_MODE", "default"),
+    )
+
     # Use cudagraphs on output code
     cudagraphs = os.environ.get("TORCHINDUCTOR_CUDAGRAPHS") == "1"
 

--- a/torch/_inductor/kernel/mm_common.py
+++ b/torch/_inductor/kernel/mm_common.py
@@ -265,6 +265,3 @@ def is_batch_stride_largest_or_zero(mat1, mat2, layout) -> bool:
 
 _KERNEL_TEMPLATE_DIR = Path(__file__).parent / "templates"
 load_kernel_template = partial(load_template, template_dir=_KERNEL_TEMPLATE_DIR)
-
-_KERNEL_TEMPLATE_FB_DIR = Path(__file__).parent.parent / "fb" / "tlx_templates"
-load_fb_kernel_template = partial(load_template, template_dir=_KERNEL_TEMPLATE_FB_DIR)

--- a/torch/_inductor/template_heuristics/tlx.py
+++ b/torch/_inductor/template_heuristics/tlx.py
@@ -1,5 +1,10 @@
-from torch._inductor import config
-
-
-if config.is_fbcode():
-    import torch._inductor.fb.tlx_templates.registry  # noqa: F401  # type: ignore[import-not-used]
+# TorchTLX lives in the fbtriton, not in
+# PyTorch. Importing the integration registers TLX template heuristics and
+# installs config.inductor_choices_class; it succeeds only when the active
+# Triton is the fbtriton fork
+# and fails cleanly on trunk triton. Actual engagement is
+# still gated at runtime by TORCHINDUCTOR_TLX_MODE (config.triton.tlx_mode).
+try:
+    import triton.language.extra.tlx.inductor.registry  # noqa: F401  # type: ignore[import-not-used]
+except ImportError:
+    pass

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -4900,16 +4900,13 @@ def is_collective_op(op_name: str) -> bool:
 
 @lru_cache
 def tlx_only_cuda_options() -> list[str]:
-    if config.is_fbcode():
-        try:
-            from torch._inductor.fb.tlx_templates.registry import tlx_only_cuda_options
+    try:
+        # Succeeds only when fbtriton (a Triton fork) is installed
+        from triton.language.extra.tlx.inductor.registry import tlx_only_cuda_options
 
-            return tlx_only_cuda_options
+        return tlx_only_cuda_options
 
-        except ImportError:
-            return []
-
-    else:
+    except ImportError:
         return []
 
 


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookexperimental/triton/pull/1926

TorchTLX lives in an `fb/` folder of Inductor with minimal hooks visible to OSS. Now that OSS fbtriton is available and more non-Triton DSLs are adopted as an Inductor backend DSL, this diff open-sources torchTLX.

To minimize disruption to OSS PyTorch, future iterations of torchTLX will happen in OSS fbtriton.

Reviewed By: htyu

Differential Revision: D110802590


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo