### PR TITLE
[RFC] Expose Kineto custom logger registration

### DIFF
--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -125,6 +125,7 @@ libtorch_profiler_sources = [
     "torch/csrc/profiler/standalone/nvtx_observer.cpp",
     "torch/csrc/profiler/standalone/privateuse1_observer.cpp",
     "torch/csrc/profiler/standalone/privateuse1_profiler.cpp",
+    "torch/csrc/profiler/standalone/custom_logger_registry.cpp",
     "torch/csrc/profiler/stubs/base.cpp",
     "torch/csrc/profiler/orchestration/vulkan.cpp",
     "torch/csrc/profiler/perf.cpp",

--- a/test/profiler/csv_logger.cpp
+++ b/test/profiler/csv_logger.cpp
@@ -1,0 +1,81 @@
+#include <torch/extension.h>
+
+#ifdef USE_KINETO
+
+#include <fstream>
+#include <string>
+
+#include <libkineto.h>
+#include <output_base.h>
+#include <torch/csrc/profiler/standalone/custom_logger_registry.h>
+
+namespace torch::profiler::impl {
+
+class CsvLogger : public libkineto::ActivityLogger {
+ public:
+  explicit CsvLogger(const std::string& filename) : out_(filename) {
+    if (out_.is_open()) {
+      out_ << "name,start_us,duration_us,device_id,resource_id,correlation_id"
+           << std::endl;
+    }
+  }
+
+  ~CsvLogger() override {
+    if (out_.is_open()) {
+      out_.close();
+    }
+  }
+
+  void handleDeviceInfo(const libkineto::DeviceInfo&, int64_t) override {}
+  void handleResourceInfo(const libkineto::ResourceInfo&, int64_t) override {}
+  void handleOverheadInfo(const OverheadInfo&, int64_t) override {}
+  void handleTraceSpan(const libkineto::TraceSpan&) override {}
+
+  void handleActivity(const libkineto::ITraceActivity& activity) override {
+    if (!out_.is_open()) {
+      return;
+    }
+    const std::string& name = activity.name();
+    if (name.find(',') != std::string::npos) {
+      out_ << '"' << name << '"';
+    } else {
+      out_ << name;
+    }
+    out_ << ',' << libkineto::ITraceActivity::nsToUs(activity.timestamp())
+         << ',' << libkineto::ITraceActivity::nsToUs(activity.duration())
+         << ',' << activity.deviceId()
+         << ',' << activity.resourceId()
+         << ',' << activity.correlationId()
+         << std::endl;
+  }
+
+  void handleGenericActivity(
+      const libkineto::GenericTraceActivity& activity) override {
+    handleActivity(activity);
+  }
+
+  void handleTraceStart(
+      const std::unordered_map<std::string, std::string>&,
+      const std::string&) override {}
+
+  void finalizeMemoryTrace(
+      const std::string&,
+      const libkineto::Config&) override {}
+
+  void finalizeTrace(
+      const libkineto::Config&,
+      std::unique_ptr<libkineto::ActivityBuffers>,
+      int64_t,
+      std::unordered_map<std::string, std::vector<std::string>>&) override {}
+
+ private:
+  std::ofstream out_;
+};
+
+REGISTER_CUSTOM_LOGGER("csv", CsvLogger);
+
+} // namespace torch::profiler::impl
+
+#endif // USE_KINETO
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {}

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -3699,6 +3699,89 @@ class TestExperimentalUtils(TestCase):
         self.assertEqual(n1, n2)
 
 
+    @unittest.skipIf(not kineto_available(), "Kineto is required")
+    def test_export_csv_protocol(self):
+        """Load the CsvLogger extension (registered via CustomLoggerRegistry),
+        profile real ops, export through the csv protocol, and verify the
+        output CSV against the column schema used by the mock events."""
+        import csv
+
+        import torch.utils.cpp_extension
+
+        test_dir = os.path.dirname(os.path.abspath(__file__))
+        torch_dir = os.path.dirname(torch.__file__)
+        kineto_include = os.path.join(
+            torch_dir, "..", "third_party", "kineto", "libkineto", "include"
+        )
+        old_cwd = os.getcwd()
+        os.chdir(test_dir)
+        try:
+            torch.utils.cpp_extension.load(
+                name="csv_logger_lib",
+                sources=["csv_logger.cpp"],
+                extra_include_paths=[kineto_include],
+                extra_cflags=["-DUSE_KINETO"],
+                verbose=True,
+            )
+        finally:
+            os.chdir(old_cwd)
+
+        expected_headers = [
+            "name",
+            "start_us",
+            "duration_us",
+            "device_id",
+            "resource_id",
+            "correlation_id",
+        ]
+        expected_names = [
+            "test_csv_export",
+            "aten::ones",
+            "aten::empty",
+            "aten::fill_",
+            "aten::add"
+        ]
+
+        with TemporaryFileName(suffix=".csv") as csv_path:
+            with profile(
+                activities=[ProfilerActivity.CPU],
+            ) as prof:
+                with record_function("test_csv_export"):
+                    x = torch.ones(10, 10)
+                    y = x + x
+
+            prof.export_using_protocol(csv_path, "csv")
+
+            with open(csv_path) as f:
+                reader = csv.reader(f)
+                headers = next(reader)
+                self.assertEqual(headers, expected_headers)
+                rows = list(reader)
+
+            self.assertGreater(len(rows), 0)
+            activity_names = [row[0] for row in rows]
+            for an, en in zip(activity_names, expected_names):
+                self.assertTrue(
+                    an == en,
+                    f"Expected 'test_csv_export' in activities, got: {activity_names}",
+                )
+            for row in rows:
+                self.assertEqual(len(row), len(expected_headers))
+                for field in row[1:]:
+                    self.assertTrue(
+                        field.lstrip("-").isdigit(),
+                        f"Expected integer field, got: {field}",
+                    )
+
+        mock_profile = self.load_mock_profile()
+        mock_events = mock_profile.kineto_results.events()
+        self.assertGreater(len(mock_events), 0)
+        for event in mock_events:
+            self.assertIsInstance(event.name, str)
+            self.assertIsInstance(event._start_us, int)
+            self.assertIsInstance(event._duration_us, int)
+
+
 class TestPrivateUse1ProfilerState(TestCase):
     """Tests for PrivateUse1 profiler state selection logic."""
 

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -3698,12 +3698,11 @@ class TestExperimentalUtils(TestCase):
         n2 = names(prof2)
         self.assertEqual(n1, n2)
 
-
     @unittest.skipIf(not kineto_available(), "Kineto is required")
     def test_export_csv_protocol(self):
         """Load the CsvLogger extension (registered via CustomLoggerRegistry),
         profile real ops, export through the csv protocol, and verify the
-        output CSV against the column schema used by the mock events."""
+        output CSV against the column schema."""
         import csv
 
         import torch.utils.cpp_extension
@@ -3739,7 +3738,7 @@ class TestExperimentalUtils(TestCase):
             "aten::ones",
             "aten::empty",
             "aten::fill_",
-            "aten::add"
+            "aten::add",
         ]
 
         with TemporaryFileName(suffix=".csv") as csv_path:
@@ -3760,26 +3759,20 @@ class TestExperimentalUtils(TestCase):
 
             self.assertGreater(len(rows), 0)
             activity_names = [row[0] for row in rows]
+            self.assertEqual(len(activity_names), len(expected_names))
             for an, en in zip(activity_names, expected_names):
-                self.assertTrue(
-                    an == en,
-                    f"Expected 'test_csv_export' in activities, got: {activity_names}",
+                self.assertEqual(
+                    an,
+                    en,
+                    f"Expected '{en}' but got '{an}', activities: {activity_names}",
                 )
             for row in rows:
                 self.assertEqual(len(row), len(expected_headers))
-                for field in row[1:]:
+                for val in row[1:]:
                     self.assertTrue(
-                        field.lstrip("-").isdigit(),
-                        f"Expected integer field, got: {field}",
+                        val.lstrip("-").isdigit(),
+                        f"Expected integer field, got: {val}",
                     )
-
-        mock_profile = self.load_mock_profile()
-        mock_events = mock_profile.kineto_results.events()
-        self.assertGreater(len(mock_events), 0)
-        for event in mock_events:
-            self.assertIsInstance(event.name, str)
-            self.assertIsInstance(event._start_us, int)
-            self.assertIsInstance(event._duration_us, int)
 
 
 class TestPrivateUse1ProfilerState(TestCase):

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -983,6 +983,26 @@ class profile:
 
     export_chrome_trace.__doc__ = EventList.export_chrome_trace.__doc__
 
+    def export_using_protocol(self, path: str, protocol_name: str | None = None):
+        if protocol_name is None or protocol_name == "chrome":
+            self.export_chrome_trace(path)
+            return
+
+        if not kineto_available():
+            log.error("Exporting with a custom protocol requires kineto.")
+        else:
+            kineto_path = f"{protocol_name}://{path}"
+            self.kineto_results.save(kineto_path)
+
+        import torch._inductor.config as inductor_config
+
+        if inductor_config.trace.provenance_tracking_to_timeline:
+            log.error(
+                "Adding stack trace to compiled kernel is not available "
+                "for protocol: %s.",
+                protocol_name,
+            )
+
     def export_stacks(self, path: str, metric: str = "self_cpu_time_total"):
         self._ensure_function_events()
         if self._function_events is None:

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -984,20 +984,32 @@ class profile:
     export_chrome_trace.__doc__ = EventList.export_chrome_trace.__doc__
 
     def export_using_protocol(self, path: str, protocol_name: str | None = None):
+        """Export trace using a registered Kineto protocol.
+
+        When ``protocol_name`` is ``None`` or ``"chrome"``, this falls back to
+        :meth:`export_chrome_trace`.  Otherwise the path is forwarded to
+        Kineto's save as ``<protocol_name>://<path>``.
+
+        Args:
+            path (str): Path where the trace will be written.
+            protocol_name (str | None): Registered protocol name, or ``None``
+                to use the default chrome trace export.
+        """
         if protocol_name is None or protocol_name == "chrome":
             self.export_chrome_trace(path)
             return
 
         if not kineto_available():
             log.error("Exporting with a custom protocol requires kineto.")
-        else:
-            kineto_path = f"{protocol_name}://{path}"
-            self.kineto_results.save(kineto_path)
+            return
+
+        kineto_path = f"{protocol_name}://{path}"
+        self.kineto_results.save(kineto_path)  # type: ignore[union-attr]
 
         import torch._inductor.config as inductor_config
 
         if inductor_config.trace.provenance_tracking_to_timeline:
-            log.error(
+            log.warning(
                 "Adding stack trace to compiled kernel is not available "
                 "for protocol: %s.",
                 protocol_name,

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -34,6 +34,7 @@
 #include <ApproximateClock.h>
 #include <libkineto.h>
 #include <time_since_epoch.h>
+#include <torch/csrc/profiler/standalone/custom_logger_registry.h>
 #include <torch/csrc/profiler/standalone/privateuse1_profiler.h>
 
 #ifndef _MSC_VER
@@ -975,10 +976,13 @@ void prepareProfiler(
     return;
   }
 
+#ifdef USE_KINETO
+  // Forward registered custom logger factories to Kineto.
+  torch::profiler::impl::CustomLoggerRegistry::instance().onKinetoInit();
+
   // Forward registered PrivateUse1 profiler factory to Kineto.
   // Only for KINETO_PRIVATEUSE1 state where backend provides its own
   // IActivityProfiler.
-#ifdef USE_KINETO
   if (config.state == ProfilerState::KINETO_PRIVATEUSE1) {
     torch::profiler::impl::PrivateUse1ProfilerRegistry::instance()
         .onKinetoInit();

--- a/torch/csrc/profiler/standalone/custom_logger_registry.cpp
+++ b/torch/csrc/profiler/standalone/custom_logger_registry.cpp
@@ -8,6 +8,8 @@
 
 #ifdef USE_KINETO
 
+#include <vector>
+
 #include <c10/util/Exception.h>
 #include <torch/csrc/profiler/standalone/custom_logger_registry.h>
 
@@ -25,27 +27,25 @@ void CustomLoggerRegistry::registerLogger(
     CustomLoggerFactory factory) {
   std::lock_guard<std::mutex> lock(mutex_);
 
-  if (loggers_.count(protocol)) {
+  if (loggers_.contains(protocol)) {
     TORCH_WARN(
-        "Custom logger for protocol '", protocol,
+        "Custom logger for protocol '",
+        protocol,
         "' already registered, overwriting");
   }
 
   loggers_[protocol] = std::move(factory);
 
-  // If Kineto was already initialized, register immediately
   if (kineto_initialized_ && !registered_with_kineto_) {
     registerWithKineto();
   } else if (kineto_initialized_ && registered_with_kineto_) {
-    // Kineto already initialized and we already registered others,
-    // register this new one immediately
     libkineto::registerLoggerFactory(protocol, loggers_[protocol]);
   }
 }
 
 bool CustomLoggerRegistry::hasLogger(const std::string& protocol) const {
   std::lock_guard<std::mutex> lock(mutex_);
-  return loggers_.count(protocol) > 0;
+  return loggers_.contains(protocol);
 }
 
 size_t CustomLoggerRegistry::numLoggers() const {
@@ -59,14 +59,25 @@ bool CustomLoggerRegistry::isRegisteredWithKineto() const {
 }
 
 void CustomLoggerRegistry::registerWithKineto() {
-  // Note: Caller must hold mutex_
   if (loggers_.empty() || registered_with_kineto_) {
     return;
   }
 
-  // Register all logger factories with Kineto
+  std::vector<std::string> failed;
   for (const auto& [protocol, factory] : loggers_) {
-    libkineto::registerLoggerFactory(protocol, factory);
+    try {
+      libkineto::registerLoggerFactory(protocol, factory);
+    } catch (const std::exception& e) {
+      TORCH_WARN(
+          "Failed to register logger for protocol '",
+          protocol,
+          "' with Kineto: ",
+          e.what());
+      failed.push_back(protocol);
+    }
+  }
+  for (const auto& protocol : failed) {
+    loggers_.erase(protocol);
   }
 
   registered_with_kineto_ = true;
@@ -76,7 +87,6 @@ void CustomLoggerRegistry::onKinetoInit() {
   std::lock_guard<std::mutex> lock(mutex_);
   kineto_initialized_ = true;
 
-  // If loggers were registered before Kineto init, register them now
   if (!loggers_.empty() && !registered_with_kineto_) {
     registerWithKineto();
   }

--- a/torch/csrc/profiler/standalone/custom_logger_registry.cpp
+++ b/torch/csrc/profiler/standalone/custom_logger_registry.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifdef USE_KINETO
+
+#include <c10/util/Exception.h>
+#include <torch/csrc/profiler/standalone/custom_logger_registry.h>
+
+#include <libkineto.h>
+
+namespace torch::profiler::impl {
+
+CustomLoggerRegistry& CustomLoggerRegistry::instance() {
+  static CustomLoggerRegistry registry;
+  return registry;
+}
+
+void CustomLoggerRegistry::registerLogger(
+    const std::string& protocol,
+    CustomLoggerFactory factory) {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  if (loggers_.count(protocol)) {
+    TORCH_WARN(
+        "Custom logger for protocol '", protocol,
+        "' already registered, overwriting");
+  }
+
+  loggers_[protocol] = std::move(factory);
+
+  // If Kineto was already initialized, register immediately
+  if (kineto_initialized_ && !registered_with_kineto_) {
+    registerWithKineto();
+  } else if (kineto_initialized_ && registered_with_kineto_) {
+    // Kineto already initialized and we already registered others,
+    // register this new one immediately
+    libkineto::registerLoggerFactory(protocol, loggers_[protocol]);
+  }
+}
+
+bool CustomLoggerRegistry::hasLogger(const std::string& protocol) const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return loggers_.count(protocol) > 0;
+}
+
+size_t CustomLoggerRegistry::numLoggers() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return loggers_.size();
+}
+
+bool CustomLoggerRegistry::isRegisteredWithKineto() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return registered_with_kineto_;
+}
+
+void CustomLoggerRegistry::registerWithKineto() {
+  // Note: Caller must hold mutex_
+  if (loggers_.empty() || registered_with_kineto_) {
+    return;
+  }
+
+  // Register all logger factories with Kineto
+  for (const auto& [protocol, factory] : loggers_) {
+    libkineto::registerLoggerFactory(protocol, factory);
+  }
+
+  registered_with_kineto_ = true;
+}
+
+void CustomLoggerRegistry::onKinetoInit() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  kineto_initialized_ = true;
+
+  // If loggers were registered before Kineto init, register them now
+  if (!loggers_.empty() && !registered_with_kineto_) {
+    registerWithKineto();
+  }
+}
+
+} // namespace torch::profiler::impl
+
+#endif // USE_KINETO

--- a/torch/csrc/profiler/standalone/custom_logger_registry.h
+++ b/torch/csrc/profiler/standalone/custom_logger_registry.h
@@ -22,70 +22,25 @@
 
 namespace torch::profiler::impl {
 
-// Factory function type that creates an ActivityLogger instance
-// The string parameter is the URL/filename passed to the logger
 using CustomLoggerFactory =
-    std::function<std::unique_ptr<libkineto::ActivityLogger>(const std::string&)>;
+    std::function<std::unique_ptr<libkineto::ActivityLogger>(
+        const std::string&)>;
 
-// Registry for custom ActivityLogger factories.
-//
-// This registry allows users to register custom ActivityLogger implementations
-// with Kineto, enabling custom trace output formats (e.g., Perfetto, Chrome
-// Trace with extensions, custom binary formats) without modifying Kineto code.
-//
-// Usage:
-//   1. Implement libkineto::ActivityLogger with custom output format
-//   2. Use REGISTER_CUSTOM_LOGGER macro to register with a protocol name
-//   3. PyTorch forwards the factory to Kineto during initialization
-//   4. Use the logger by specifying the protocol in profiler config
-//
-// Example:
-//   class PerfettoLogger : public libkineto::ActivityLogger {
-//    public:
-//     explicit PerfettoLogger(const std::string& filename);
-//     void handleActivity(const libkineto::ITraceActivity& activity) override;
-//     void finalizeTrace(...) override;
-//   };
-//
-//   REGISTER_CUSTOM_LOGGER("perfetto", PerfettoLogger)
-//
-//   Then in Python:
-//     with torch.profiler.profile(
-//       activities=[...],
-//       on_trace_ready=torch.profiler.tensorboard_trace_handler(
-//         "perfetto://output.perfetto"
-//       )
-//     )
-//
+// Registry for custom ActivityLogger factories that are forwarded to Kineto.
 class TORCH_API CustomLoggerRegistry {
  public:
   static CustomLoggerRegistry& instance();
 
-  // Register a factory function for creating a custom logger.
-  // The protocol string identifies this logger type (e.g., "perfetto", "custom").
-  // This should be called during static initialization.
   void registerLogger(const std::string& protocol, CustomLoggerFactory factory);
-
-  // Check if a logger has been registered for the given protocol.
   bool hasLogger(const std::string& protocol) const;
-
-  // Get the number of registered loggers.
   size_t numLoggers() const;
-
-  // Check if the loggers have been registered with Kineto.
-  // Useful for testing to verify the registration logic.
   bool isRegisteredWithKineto() const;
-
-  // Mark that Kineto has been initialized.
-  // If loggers were registered before Kineto init, they will be forwarded.
   void onKinetoInit();
 
  private:
   CustomLoggerRegistry() = default;
 
-  // Register all loggers with Kineto's activity logger registry.
-  // Caller must hold mutex_.
-  void registerWithKineto();
+  void registerWithKineto(); // caller must hold mutex_
 
   mutable std::mutex mutex_;
   std::unordered_map<std::string, CustomLoggerFactory> loggers_;
@@ -93,27 +48,20 @@ class TORCH_API CustomLoggerRegistry {
   bool kineto_initialized_ = false;
 };
 
-// Helper struct for static registration via macro.
 template <typename LoggerClass>
 struct RegisterCustomLogger {
   RegisterCustomLogger(const std::string& protocol) {
     CustomLoggerRegistry::instance().registerLogger(
         protocol,
-        [](const std::string& url) -> std::unique_ptr<libkineto::ActivityLogger> {
+        [](const std::string& url)
+            -> std::unique_ptr<libkineto::ActivityLogger> {
           return std::make_unique<LoggerClass>(url);
         });
   }
 };
 
-// Macro for registering a custom activity logger.
-// The logger class must implement libkineto::ActivityLogger.
-//
-// Usage:
-//   REGISTER_CUSTOM_LOGGER("perfetto", PerfettoLogger)
-//
-// The protocol string will be used to identify this logger when configuring
-// the profiler output.
-#define REGISTER_CUSTOM_LOGGER(protocol, LoggerClass)                \
+// Usage: REGISTER_CUSTOM_LOGGER("perfetto", PerfettoLogger)
+#define REGISTER_CUSTOM_LOGGER(protocol, LoggerClass)               \
   static ::torch::profiler::impl::RegisterCustomLogger<LoggerClass> \
       custom_logger_register_##LoggerClass(protocol)
 

--- a/torch/csrc/profiler/standalone/custom_logger_registry.h
+++ b/torch/csrc/profiler/standalone/custom_logger_registry.h
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#ifdef USE_KINETO
+
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+#include <torch/csrc/Export.h>
+
+#include <output_base.h>
+
+namespace torch::profiler::impl {
+
+// Factory function type that creates an ActivityLogger instance
+// The string parameter is the URL/filename passed to the logger
+using CustomLoggerFactory =
+    std::function<std::unique_ptr<libkineto::ActivityLogger>(const std::string&)>;
+
+// Registry for custom ActivityLogger factories.
+//
+// This registry allows users to register custom ActivityLogger implementations
+// with Kineto, enabling custom trace output formats (e.g., Perfetto, Chrome
+// Trace with extensions, custom binary formats) without modifying Kineto code.
+//
+// Usage:
+//   1. Implement libkineto::ActivityLogger with custom output format
+//   2. Use REGISTER_CUSTOM_LOGGER macro to register with a protocol name
+//   3. PyTorch forwards the factory to Kineto during initialization
+//   4. Use the logger by specifying the protocol in profiler config
+//
+// Example:
+//   class PerfettoLogger : public libkineto::ActivityLogger {
+//    public:
+//     explicit PerfettoLogger(const std::string& filename);
+//     void handleActivity(const libkineto::ITraceActivity& activity) override;
+//     void finalizeTrace(...) override;
+//   };
+//
+//   REGISTER_CUSTOM_LOGGER("perfetto", PerfettoLogger)
+//
+//   Then in Python:
+//     with torch.profiler.profile(
+//       activities=[...],
+//       on_trace_ready=torch.profiler.tensorboard_trace_handler(
+//         "perfetto://output.perfetto"
+//       )
+//     )
+//
+class TORCH_API CustomLoggerRegistry {
+ public:
+  static CustomLoggerRegistry& instance();
+
+  // Register a factory function for creating a custom logger.
+  // The protocol string identifies this logger type (e.g., "perfetto", "custom").
+  // This should be called during static initialization.
+  void registerLogger(const std::string& protocol, CustomLoggerFactory factory);
+
+  // Check if a logger has been registered for the given protocol.
+  bool hasLogger(const std::string& protocol) const;
+
+  // Get the number of registered loggers.
+  size_t numLoggers() const;
+
+  // Check if the loggers have been registered with Kineto.
+  // Useful for testing to verify the registration logic.
+  bool isRegisteredWithKineto() const;
+
+  // Mark that Kineto has been initialized.
+  // If loggers were registered before Kineto init, they will be forwarded.
+  void onKinetoInit();
+
+ private:
+  CustomLoggerRegistry() = default;
+
+  // Register all loggers with Kineto's activity logger registry.
+  // Caller must hold mutex_.
+  void registerWithKineto();
+
+  mutable std::mutex mutex_;
+  std::unordered_map<std::string, CustomLoggerFactory> loggers_;
+  bool registered_with_kineto_ = false;
+  bool kineto_initialized_ = false;
+};
+
+// Helper struct for static registration via macro.
+template <typename LoggerClass>
+struct RegisterCustomLogger {
+  RegisterCustomLogger(const std::string& protocol) {
+    CustomLoggerRegistry::instance().registerLogger(
+        protocol,
+        [](const std::string& url) -> std::unique_ptr<libkineto::ActivityLogger> {
+          return std::make_unique<LoggerClass>(url);
+        });
+  }
+};
+
+// Macro for registering a custom activity logger.
+// The logger class must implement libkineto::ActivityLogger.
+//
+// Usage:
+//   REGISTER_CUSTOM_LOGGER("perfetto", PerfettoLogger)
+//
+// The protocol string will be used to identify this logger when configuring
+// the profiler output.
+#define REGISTER_CUSTOM_LOGGER(protocol, LoggerClass)                \
+  static ::torch::profiler::impl::RegisterCustomLogger<LoggerClass> \
+      custom_logger_register_##LoggerClass(protocol)
+
+} // namespace torch::profiler::impl
+
+#endif // USE_KINETO

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -856,7 +856,22 @@ def tensorboard_trace_handler(
             file_name = file_name + ".gz"
         file_path = os.path.join(dir_name, file_name)
         if save_protocol is not None:
-            prof.export_using_protocol(file_path, save_protocol)
+            if use_gzip:
+                with tempfile.NamedTemporaryFile(
+                    suffix=ext, dir=dir_name, delete=False
+                ) as fp:
+                    tmp_path = fp.name
+                try:
+                    prof.export_using_protocol(tmp_path, save_protocol)
+                    with (
+                        open(tmp_path, "rb") as fin,
+                        gzip.open(file_path, "wb") as fout,
+                    ):
+                        fout.writelines(fin)
+                finally:
+                    os.unlink(tmp_path)
+            else:
+                prof.export_using_protocol(file_path, save_protocol)
         else:
             prof.export_chrome_trace(file_path, use_python_export=use_python_export)
 

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -502,6 +502,19 @@ class _KinetoProfile:
         self._monitor_window_id = None
         return obs
 
+    def export_using_protocol(self, path: str, protocol_name: str | None = None):
+        """Export trace using a registered Kineto protocol.
+
+        When ``protocol_name`` is ``None`` or ``"chrome"``, this falls back to
+        :meth:`export_chrome_trace`.  Otherwise the path is forwarded to
+        Kineto's save as ``<protocol_name>://<path>``.
+        """
+        if self.profiler is None:
+            raise AssertionError(
+                "Profiler must be initialized before exporting with a protocol"
+            )
+        self.profiler.export_using_protocol(path, protocol_name)
+
     def export_stacks(self, path: str, metric: str = "self_cpu_time_total"):
         """Save stack traces to a file
 
@@ -800,15 +813,32 @@ def tensorboard_trace_handler(
     worker_name: str | None = None,
     use_gzip: bool = False,
     use_python_export: bool = False,
+    save_protocol: str | None = None,
+    save_extension: str | None = None,
 ):
     """
     Outputs tracing files to directory of ``dir_name``, then that directory can be
     directly delivered to tensorboard as logdir.
     ``worker_name`` should be unique for each worker in distributed scenario,
     it will be set to '[hostname]_[pid]' by default.
+
+    Args:
+        dir_name: Output directory for tracing files
+        worker_name: Unique name per worker for creating output filename
+        use_gzip: Flag whether the output file should be gzipped
+        use_python_export: Only honored for chrome protocol, flags whether
+            to utilize the python or libkineto implementation for chrome export
+        save_protocol: Kineto logger protocol name (e.g. ``"perfetto"``).
+            When ``None``, the default chrome trace export is used.
+        save_extension: File extension including the leading dot
+            (e.g. ``".pftrace"``).  Required when ``save_protocol`` is set.
+            Defaults to ``".pt.trace.json"`` when no protocol is specified.
     """
     import socket
     import time
+
+    if save_protocol is not None and save_extension is None:
+        raise ValueError("save_extension is required when save_protocol is set")
 
     def handler_fn(prof) -> None:
         nonlocal worker_name
@@ -819,14 +849,16 @@ def tensorboard_trace_handler(
                 raise RuntimeError("Can't create directory: " + dir_name) from e
         if not worker_name:
             worker_name = f"{socket.gethostname()}_{os.getpid()}"
+        ext = save_extension if save_extension is not None else ".pt.trace.json"
         # Use nanosecond here to avoid naming clash when exporting the trace
-        file_name = f"{worker_name}.{time.time_ns()}.pt.trace.json"
+        file_name = f"{worker_name}.{time.time_ns()}{ext}"
         if use_gzip:
             file_name = file_name + ".gz"
-        prof.export_chrome_trace(
-            os.path.join(dir_name, file_name),
-            use_python_export=use_python_export,
-        )
+        file_path = os.path.join(dir_name, file_name)
+        if save_protocol is not None:
+            prof.export_using_protocol(file_path, save_protocol)
+        else:
+            prof.export_chrome_trace(file_path, use_python_export=use_python_export)
 
     return handler_fn
 


### PR DESCRIPTION
Working draft RFC for changes made to support Pytorch users registering their own custom loggers and exposing a new public method for explicitly defining which logger kineto should utilize when exporting.