### PR TITLE
[ROCm] Fix test_is_pinned_no_context for Python 3.14 forkserver default

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5145,8 +5145,13 @@ import multiprocessing
 
 
 def fork_and_check_is_pinned():
+    # Explicitly use the fork context: this test relies on fork semantics
+    # (a forked child inherits the parent's CUDA context state), and Python
+    # 3.14 changed the default start method on non-macOS POSIX to forkserver,
+    # which would try to pickle the local `worker` function below and fail.
+    mp_ctx = multiprocessing.get_context("fork")
     # Create a pipe to communicate between parent and child processes
-    parent_conn, child_conn = multiprocessing.Pipe()
+    parent_conn, child_conn = mp_ctx.Pipe()
 
     def worker(conn):
         try:
@@ -5160,7 +5165,7 @@ def fork_and_check_is_pinned():
         finally:
             conn.close()
     # Fork a new process
-    p = multiprocessing.Process(target=worker, args=(child_conn,))
+    p = mp_ctx.Process(target=worker, args=(child_conn,))
     p.start()
     # Receive the result from the child process
     result = parent_conn.recv()


### PR DESCRIPTION
test_is_pinned_no_context spawns a worker via a bare multiprocessing.Process(), implicitly relying on the ambient default start method. Python 3.14 changed that default on non-macOS POSIX platforms from "fork" to "forkserver", and this test breaks under the new default for a mechanical reason:

- Under "fork", Process.start() calls os.fork(). The child is a copy-on-write duplicate of the parent's memory, so the target callable (and everything else in the parent's process) is already present in the child -- nothing is ever serialized.
- Under "forkserver", the child is served by a separate, already- running helper process that has none of the parent's state. To hand it a job, multiprocessing must serialize (pickle) the Process object, including its `target` callable, and have the forkserver process unpickle and call it.
- pickle can only serialize a function by reference: it records the function's module and qualified name, and reconstructs it in the target process via import + attribute lookup. This test's target, `worker`, is defined *inside* `fork_and_check_is_pinned()`, so its qualname is `fork_and_check_is_pinned.<locals>.worker` -- there is no module-level attribute path to look it up by, so pickling it raises PicklingError, and the test fails before the CUDA-fork behavior it's meant to check ever runs.

The fix explicitly requests multiprocessing.get_context("fork") for both Pipe() and Process(), bypassing the ambient default (and the pickling it would require) entirely. "fork" remains fully supported in Python 3.14, just no longer the default, so this is not a version-gated workaround.

Authored with AI assistance (Claude Code).

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang