### PR TITLE
[TEST][Inductor][CUDA] Bump tolerances for `test_comprehensive_combinations_cuda_float16`

### DIFF
--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -417,7 +417,7 @@ inductor_override_kwargs["cuda"] = {
     ("linalg.cross", f16): {"reference_in_float": True},
     ("addr", f16): {"reference_in_float": True},
     ("baddbmm", f16): {"atol": 2e-3, "rtol": 0.002},  # decomp affects accuracy
-    ("combinations", f16): {"grad_atol": 2e-3, "grad_rtol": 0.01},
+    ("combinations", f16): {"grad_atol": 2e-3, "grad_rtol": 0.01}, # inductor does accum in fp16
     ("angle", f64): {"reference_in_float": True},
     ("asin", f16): {"reference_in_float": True},
     ("atanh", f16): {"reference_in_float": True},

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -417,7 +417,10 @@ inductor_override_kwargs["cuda"] = {
     ("linalg.cross", f16): {"reference_in_float": True},
     ("addr", f16): {"reference_in_float": True},
     ("baddbmm", f16): {"atol": 2e-3, "rtol": 0.002},  # decomp affects accuracy
-    ("combinations", f16): {"grad_atol": 2e-3, "grad_rtol": 0.01}, # inductor does accum in fp16
+    ("combinations", f16): {
+        "grad_atol": 2e-3,
+        "grad_rtol": 0.01,
+    },  # inductor does accum in fp16
     ("angle", f64): {"reference_in_float": True},
     ("asin", f16): {"reference_in_float": True},
     ("atanh", f16): {"reference_in_float": True},

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -417,6 +417,7 @@ inductor_override_kwargs["cuda"] = {
     ("linalg.cross", f16): {"reference_in_float": True},
     ("addr", f16): {"reference_in_float": True},
     ("baddbmm", f16): {"atol": 2e-3, "rtol": 0.002},  # decomp affects accuracy
+    ("combinations", f16): {"grad_atol": 2e-3, "grad_rtol": 0.01},
     ("angle", f64): {"reference_in_float": True},
     ("asin", f16): {"reference_in_float": True},
     ("atanh", f16): {"reference_in_float": True},


### PR DESCRIPTION
combinations uses index_put underneath which appears to do fp16 accum in inductor

authored with codex

example failure
```
_assert_equal_with_significant_stride_check
    assert_equal_fn(
  File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/test_case.py", line 129, in assertEqual
    return super().assertEqual(x, y, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_utils.py", line 4608, in assertEqual
    raise error_metas.pop()[0].to_error(  # type: ignore[index]
AssertionError: Tensor-likes are not close!

Mismatched elements: 1 / 4 (25.0%)
Greatest absolute difference: 0.001953125 at index (0,) (up to 1e-05 allowed)
Greatest relative difference: 0.00199127197265625 at index (0,) (up to 0.001 allowed)
```

cc @ptrblck @msaroufim @tinglvv @nWEIdia @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo