### PR TITLE
Support dist.split_group on CPU-only (gloo) process groups

### DIFF
--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -2052,6 +2052,57 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
     def test_alltoall_multidim_cuda(self):
         self._test_alltoall_multidim(lambda t: t.clone().cuda())
 
+    def _test_split_group(self, backend):
+        store = c10d.FileStore(self.file_name, self.world_size)
+        c10d.init_process_group(
+            backend, rank=self.rank, world_size=self.world_size, store=store
+        )
+        pg = c10d.distributed_c10d._get_default_group()
+        parent_backend = pg._get_backend(torch.device("cpu"))
+
+        mid = self.world_size // 2
+        first_half = list(range(mid))
+        second_half = list(range(mid, self.world_size))
+        my_ranks = first_half if self.rank < mid else second_half
+
+        ng1 = c10d.split_group(pg, [first_half, second_half])
+        self.assertIsNotNone(ng1)
+        self.assertEqual(ng1.group_desc, "default_pg:split:0")
+        backend1 = ng1._get_backend(torch.device("cpu"))
+        self.assertEqual(parent_backend.options._timeout, backend1.options._timeout)
+
+        self.assertEqual(dist.get_process_group_ranks(ng1), my_ranks)
+        self.assertEqual(dist.get_rank(ng1), my_ranks.index(self.rank))
+
+        tensor = torch.full((1,), self.rank)
+        dist.broadcast(tensor, src=my_ranks[0], group=ng1)
+        self.assertEqual(tensor, torch.full((1,), my_ranks[0]))
+
+        tensor = torch.ones(2)
+        dist.all_reduce(tensor, group=ng1)
+        self.assertEqual(tensor, torch.full((2,), float(len(my_ranks))))
+
+        # ranks outside every split get None
+        ng2 = c10d.split_group(pg, [first_half])
+        if self.rank < mid:
+            self.assertIsNotNone(ng2)
+            self.assertEqual(ng2.group_desc, "default_pg:split:1")
+        else:
+            self.assertIsNone(ng2)
+
+        dist.destroy_process_group()
+
+    @requires_gloo()
+    def test_split_group_cpu_only(self):
+        # No accelerator/bound device is required to split a cpu:gloo group.
+        self._test_split_group("cpu:gloo")
+
+    @requires_gloo()
+    def test_split_group_bare_gloo(self):
+        # A bare "gloo" registers the same backend for cpu and cuda; the
+        # split must reuse a single child backend for both device types.
+        self._test_split_group("gloo")
+
 
 class DistributedDataParallelTest(
     test_c10d_common.CommonDistributedDataParallelTest, MultiProcessTestCase

--- a/torch/csrc/distributed/c10d/ProcessGroup.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.cpp
@@ -202,6 +202,9 @@ c10::intrusive_ptr<ProcessGroup> ProcessGroup::splitGroup(
   std::string groupDesc = desc.has_value()
       ? desc.value()
       : c10::str(getGroupDesc(), ":split:", incrementSplitCount());
+  // A single backend may serve multiple device types (e.g. a bare "gloo"
+  // group registers the same backend for cpu and cuda); split it only once.
+  std::unordered_map<BackendType, c10::intrusive_ptr<Backend>> splitBackends;
   for (const auto& pair : deviceTypeToBackendType_) {
     c10::DeviceType deviceType = pair.first;
     BackendType backendType = pair.second;
@@ -210,14 +213,21 @@ c10::intrusive_ptr<ProcessGroup> ProcessGroup::splitGroup(
       continue;
     }
 
-    auto parentBackend = getBackend(deviceType);
-    auto backendOpts =
-        opts.has_value() ? opts.value() : parentBackend->getBackendOptions();
-    backendOpts->group_name = groupName;
-    backendOpts->timeout =
-        timeout.has_value() ? timeout.value() : backendOpts->timeout;
-    backendOpts->group_desc = groupDesc;
-    auto splitBackend = parentBackend->split(store, ranks, backendOpts);
+    auto splitIt = splitBackends.find(backendType);
+    c10::intrusive_ptr<Backend> splitBackend;
+    if (splitIt != splitBackends.end()) {
+      splitBackend = splitIt->second;
+    } else {
+      auto parentBackend = getBackend(deviceType);
+      auto backendOpts =
+          opts.has_value() ? opts.value() : parentBackend->getBackendOptions();
+      backendOpts->group_name = groupName;
+      backendOpts->timeout =
+          timeout.has_value() ? timeout.value() : backendOpts->timeout;
+      backendOpts->group_desc = groupDesc;
+      splitBackend = parentBackend->split(store, ranks, backendOpts);
+      splitBackends.emplace(backendType, splitBackend);
+    }
     if (splitBackend == nullptr) {
       continue;
     }

--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
@@ -781,15 +781,27 @@ c10::intrusive_ptr<Backend> ProcessGroupGloo::split(
     glooOpts = ProcessGroupGloo::Options::create_default();
   }
 
+  // The child must not share the parent's devices: a gloo device routes
+  // incoming connections to pairs via a per-device sequence counter, and the
+  // lazy-init connect path assumes a remote pair's sequence number equals its
+  // rank, which only holds for a device serving a single context. Sharing
+  // devices would hang the child's first collective under lazy init.
+  auto childOpts = ProcessGroupGloo::Options::create_default(glooOpts->timeout);
+  childOpts->threads = glooOpts->threads;
+  childOpts->group_name = glooOpts->group_name;
+  childOpts->group_desc = glooOpts->group_desc;
+  childOpts->use_pg_for_symm_mem_rendezvous =
+      glooOpts->use_pg_for_symm_mem_rendezvous;
+
   // TODO: we need to get rid of globalRanksInGroup eventually.
   std::vector<uint64_t> globalRanksInGroup;
   globalRanksInGroup.reserve(ranks.size());
   for (auto rank : ranks) {
     globalRanksInGroup.emplace_back(groupRanks()[rank]);
   }
-  glooOpts->global_ranks_in_group = std::move(globalRanksInGroup);
+  childOpts->global_ranks_in_group = std::move(globalRanksInGroup);
   auto pg = c10::make_intrusive<ProcessGroupGloo>(
-      store->clone(), groupRank, ranks.size(), glooOpts);
+      store->clone(), groupRank, ranks.size(), childOpts);
   return c10::static_intrusive_pointer_cast<Backend>(pg);
 }
 

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -3456,7 +3456,19 @@ options :class:`~torch.distributed.ProcessGroupNCCL.Options`).
       processGroupGloo, "_Options", backendOptions)
       .def(py::init<>())
       .def_readwrite("_devices", &::c10d::ProcessGroupGloo::Options::devices)
-      .def_readwrite("_threads", &::c10d::ProcessGroupGloo::Options::threads);
+      .def_readwrite("_threads", &::c10d::ProcessGroupGloo::Options::threads)
+      .def(
+          "__copy__",
+          [](const ::c10d::ProcessGroupGloo::Options& self) {
+            return ::c10d::ProcessGroupGloo::Options(self);
+          })
+      .def(
+          "__deepcopy__",
+          [](const ::c10d::ProcessGroupGloo::Options& self,
+             const py::dict& memo) {
+            return ::c10d::ProcessGroupGloo::Options(self);
+          },
+          py::arg("memo"));
 
   processGroupGloo
       .def_static(

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -5829,8 +5829,8 @@ def split_group(
     """
     Create a new process group split from the given parent process group.
 
-    warning:: This is an experimental API. Only the ``NCCL`` and custom plugin backends
-    are supported. Other backends will raise an error.
+    warning:: This is an experimental API. Only the ``NCCL``, ``Gloo`` and custom plugin
+    backends are supported. Other backends will raise an error.
     Users of this API must guarantee that all ranks in the parent group enter this API call,
     and the split of the sub groups is the same across all ranks in the parent group.
 
@@ -5875,10 +5875,6 @@ def split_group(
     global _world
     default_pg = _get_default_group()
     device_id = default_pg.bound_device_id
-    if not device_id and not _use_torchcomms_enabled():
-        raise RuntimeError(
-            "No device associated with the default pg, not safe to split any process groups"
-        )
     global_rank = default_pg.rank()
     global_world_size = default_pg.size()
 
@@ -5900,22 +5896,36 @@ def split_group(
 
     parent_group_rank = parent_global_to_group_ranks[global_rank]
 
-    if torch.accelerator.is_available():
-        parent_backend = parent_pg._get_backend(
-            torch.accelerator.current_accelerator()  # pyrefly: ignore[bad-argument-type]
-        )
-    elif _use_torchcomms_enabled():
-        # torchcomms supports CPU/gloo splitting; no accelerator is required.
-        parent_backend = parent_pg._get_backend(
-            torch.device("cpu")  # pyrefly: ignore[bad-argument-type]
-        )
+    # Resolve the device whose backend drives the split: the current
+    # accelerator if the parent group has a backend for it, otherwise CPU
+    # (e.g. a cpu-only gloo parent group).
+    parent_device_types = {d.type for d in parent_pg._device_types}
+    acc = torch.accelerator.current_accelerator(check_available=True)
+    if acc is not None and acc.type in parent_device_types:
+        split_device = acc
+    elif "cpu" in parent_device_types:
+        split_device = torch.device("cpu")
     else:
         raise RuntimeError(
             "No backend for the parent process group or its backend does not support splitting"
         )
+    parent_backend = parent_pg._get_backend(split_device)
+
+    # A backend that also serves CPU (gloo, or a bare "gloo" group that
+    # registers the same backend for cpu and the accelerator) needs no bound
+    # device to split. Accelerator-only backends (e.g. NCCL) split the parent
+    # communicator eagerly, which is only safe once the default pg has
+    # initialized it -- guaranteed by a bound device id.
+    cpu_capable = "cpu" in parent_device_types and (
+        split_device.type == "cpu"
+        or parent_pg._get_backend(torch.device("cpu")) is parent_backend
+    )
+    if not device_id and not cpu_capable and not _use_torchcomms_enabled():
+        raise RuntimeError(
+            "No device associated with the default pg, not safe to split any process groups"
+        )
 
     # if the parent backend does not support splitting, raise error
-    # currently this API only support NCCL and XCCL backend
     if (
         not parent_backend or not parent_backend.supports_splitting
     ) and not _use_torchcomms_enabled():
@@ -5937,12 +5947,11 @@ def split_group(
     # loop honors this filter so unwanted backends are never split.
     device_types_filter: list[torch.device] | None = None
     if backend is not None:
-        parent_devices = {d.type for d in parent_pg._device_types}
         parent_device_backends = _parse_backend_string(
-            parent_backend_str, available_devices=parent_devices
+            parent_backend_str, available_devices=parent_device_types
         )
         requested_device_backends = _parse_backend_string(
-            str(backend), available_devices=parent_devices
+            str(backend), available_devices=parent_device_types
         )
         for device_type, requested_be in requested_device_backends.items():
             if device_type not in parent_device_backends:
@@ -6013,18 +6022,6 @@ def split_group(
     global_ranks_in_my_group = [parent_group_to_global_ranks[rank] for rank in my_group]
     split_pg.bound_device_id = device_id  # type: ignore[union-attr]
 
-    if torch.accelerator.is_available():
-        split_backend_class = split_pg._get_backend(
-            torch.accelerator.current_accelerator()  # pyrefly: ignore[bad-argument-type]
-        )
-    elif _use_torchcomms_enabled():
-        # torchcomms supports CPU/gloo splitting; no accelerator is required.
-        split_backend_class = split_pg._get_backend(torch.device("cpu"))
-    else:
-        raise RuntimeError(
-            "No backend for the parent process group or its backend does not support splitting"
-        )
-
     if split_pg.group_name != group_name:
         raise AssertionError(
             f"group name should be set to {group_name} but got {split_pg.group_name}"
@@ -6044,6 +6041,7 @@ def split_group(
     )
 
     if _use_torchcomms_enabled():
+        split_backend_class = split_pg._get_backend(split_device)
         # pyrefly: ignore [missing-attribute]
         _world.comms.append(split_backend_class.get_comm())
     return split_pg


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189103

split_group unconditionally required the default pg to have a bound device id and resolved the parent backend via torch.accelerator.current_accelerator(), so a cpu:gloo-only process group (or a bare "gloo" group on a machine without an eagerly-bound accelerator) could not be split even though ProcessGroupGloo::split exists and supports_splitting is true. The fix has five parts, best reviewed in this order:

1. distributed_c10d.py: split_group now picks the device that drives the split from the parent group's registered device types - the current accelerator if the parent has a backend for it, otherwise CPU. The bound-device-id requirement is kept only for the case that actually needs it (accelerator-only backends like NCCL, where splitting requires an eagerly initialized parent communicator); a backend that also serves CPU needs no bound device. The two accelerator-based backend lookups after the split are replaced with the resolved split_device.

2. init.cpp: ProcessGroupGloo::_Options gains __copy__/__deepcopy__ bindings (same pattern as ProcessGroupNCCL::Options). Without these, split_group's copy.deepcopy(parent_backend.options) fails on gloo options because pybind11-held intrusive_ptr objects are not picklable by default.

3. ProcessGroup.cpp: splitGroup deduplicates backend splits by BackendType. A bare "gloo" group registers the same backend instance for cpu and cuda; the old loop called split() once per device type, creating two child gloo backends (and two rendezvous rounds) where the parent had one. Now the child mirrors the parent topology: one backend shared across its device types.

4. ProcessGroupGloo.cpp: split() no longer reuses the parent's Options (and hence the parent's transport devices) for the child; it creates fresh default devices, carrying over timeout/threads/group metadata. Sharing the parent's device broke TORCH_GLOO_LAZY_INIT: a gloo tcp device hands out pair addresses from a per-device sequence counter, and the lazy connect path (Context::getPair) assumes a remote pair's sequence number equals its rank, which only holds when a device serves a single context. The child's pairs got parent-offset sequence numbers, connections routed to the wrong pairs, and the child's first collective hung (caught by ProcessGroupGlooLazyInitTest in CI, which runs the whole gloo suite with TORCH_GLOO_LAZY_INIT=1).

5. test_c10d_gloo.py: new tests test_split_group_cpu_only and test_split_group_bare_gloo (4 ranks, FileStore, no device_id) covering both halves of a 2-way split, timeout inheritance, group rank assignment, broadcast and all_reduce over the child group, non-member None returns, and the incrementing split desc counter. Via the ProcessGroupGlooLazyInitTest and ProcessGroupGlooFRTest subclasses these also run under lazy init and flight recorder.

Test Plan:

Ran on a 2x H100 devgpu (world_size 4 via spawn):

```
GLOO_SOCKET_IFNAME=lo python test/distributed/test_c10d_gloo.py ProcessGroupGlooTest -k test_split_group
GLOO_SOCKET_IFNAME=lo python test/distributed/test_c10d_gloo.py ProcessGroupGlooFRTest -k test_split_group
GLOO_SOCKET_IFNAME=lo python test/distributed/test_c10d_gloo.py ProcessGroupGlooTest
GLOO_SOCKET_IFNAME=lo python test/distributed/test_c10d_gloo.py ProcessGroupGlooLazyInitTest
NCCL_SOCKET_IFNAME=lo GLOO_SOCKET_IFNAME=lo python test/distributed/test_c10d_nccl.py ProcessGroupNCCLGroupTest -k split_group
NCCL_SOCKET_IFNAME=lo GLOO_SOCKET_IFNAME=lo python test/distributed/test_device_mesh.py DeviceMeshTest -k eager
MASTER_ADDR=127.0.0.1 MASTER_PORT=29517 python test/distributed/test_fake_backend_new_group.py
lintrunner --skip CLANGTIDY <changed files>
```

All pass (both full gloo suites: 70 tests each, 1 pre-existing skip each). Also smoke-tested copy.deepcopy(ProcessGroupGloo._Options()) and a standalone 4-rank lazy-init split/broadcast script.

This PR was authored with the assistance of an AI assistant (Claude).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>