### PR TITLE
Introduce Inductor lowering for _philox_uniform

### DIFF
--- a/test/test_stateless_rng.py
+++ b/test/test_stateless_rng.py
@@ -487,6 +487,10 @@ class TestStatelessRNGDistribution(TestCase):
 
 
 class TestStatelessRNGCompile(TestCase):
+    def setUp(self):
+        super().setUp()
+        torch._dynamo.reset()
+
     def test_split_fullgraph(self, device):
         key = random.key(42, device=device)
 
@@ -582,6 +586,24 @@ class TestStatelessRNGCompile(TestCase):
 
         self.assertEqual(result, gen(key, shape))
         self.assertLess(extra, 1.5 * out_bytes)  # no extra full-size clone
+
+    @onlyAccelerator
+    @dtypes(torch.float32, torch.bfloat16, torch.float16)
+    @parametrize("shape", [(1000,), (64, 64), (3, 5, 7)])  # incl. 3D, non-mult-of-4
+    @parametrize("bounds", [(0.0, 1.0), (-1.0, 5.0)])
+    def test_uniform_lowering_bit_identical(self, device, dtype, shape, bounds):
+        # The Inductor lowering for uniform must be bit-identical to eager.
+        if torch.device(device).type == "cuda" and not HAS_TRITON:
+            self.skipTest("CUDA inductor codegen requires triton")
+        low, high = bounds
+        key = random.key(2024, device=device)
+
+        @torch.compile(fullgraph=True)
+        def f(k):
+            return random.uniform(k, shape, low=low, high=high, dtype=dtype)
+
+        expected = random.uniform(key, shape, low=low, high=high, dtype=dtype)
+        self.assertEqual(f(key), expected, atol=0, rtol=0)  # bit-exact
 
 
 instantiate_device_type_tests(TestStatelessRNGKey, globals(), only_for=("cuda",))

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -1344,6 +1344,16 @@ pointwise_overrides_data: dict[str, OverridesData] = dict(
         else f"libdevice.mul_rn({x}, {y})",
         name="mul_rn",
     ),
+    # High 32 bits of the unsigned product of two int32 values (hardware __umulhi).
+    umulhi=OverridesData(
+        type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
+        cpp=lambda x, y: (
+            f"static_cast<int32_t>((static_cast<uint64_t>(static_cast<uint32_t>({x}))"
+            f" * static_cast<uint64_t>(static_cast<uint32_t>({y}))) >> 32)"
+        ),
+        triton=lambda x, y: f"tl.umulhi({x}, {y})",
+        name="umulhi",
+    ),
     # erfinv, exp2, expit, gammaln
     igamma=OverridesData(
         type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT,

--- a/torch/_inductor/fx_passes/reinplace.py
+++ b/torch/_inductor/fx_passes/reinplace.py
@@ -383,8 +383,7 @@ inplaceable_ops: dict[Callable[..., Any], InplaceableOp] = {
         extra_check=should_reinplace_scatter,
     ),
     # Stateless Philox RNG: reinplace the functionalized clone onto the dead
-    # output buffer, so out-of-place uniform()/normal() don't pay an extra copy.
-    aten._philox_uniform.default: InplaceableOp(aten._philox_uniform_.default, 0),
+    # output buffer, so out-of-place normal() doesn't pay an extra copy.
     aten._philox_normal.default: InplaceableOp(aten._philox_normal_.default, 0),
 }
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2913,6 +2913,94 @@ def philox_rand(size, seed, offset, stride, device, dtype):
     return random_values_node, offset_node
 
 
+@register_lowering(aten._philox_uniform, type_promotion_kind=None)
+def _philox_uniform(self, key, low=0.0, high=1.0):
+    # Inline, bit-identical philox4x32-10 + uniform_real so out-of-place uniform()
+    # fuses with consumers and needs no output clone (`self` is a write-only
+    # template). Mirrors StatelessPhilox4x32.cuh + PhiloxDistribution.cu.
+    # digits = std::numeric_limits<T>::digits (TransformationHelper.h uniform_real).
+    digits_for = {torch.float32: 24, torch.float16: 11, torch.bfloat16: 8}
+    device = self.get_device()
+    dtype = self.get_dtype()
+    size = self.get_size()
+    # Inline only 4-elems-per-call float dtypes with a single key; else fall back.
+    if dtype not in digits_for or len(key.get_size()) != 1:
+        return fallback_handler(aten._philox_uniform.default)(self, key, low, high)
+
+    digits = digits_for[dtype]
+    mantissa_mask = (1 << digits) - 1
+    divisor = 1.0 / (1 << digits)
+    low = float(low)
+    scale = float(high) - low
+
+    key_loader = key.make_loader()
+    indexer = ir.FixedLayout(
+        device, dtype, size, ir.FlexibleLayout.contiguous_strides(size)
+    ).make_indexer()
+
+    def inner_fn(index):
+        i32, i64 = torch.int32, torch.int64
+
+        def C(u):  # uint32 literal as signed int32
+            return ops.constant(u - (1 << 32) if u >= (1 << 31) else u, i32)
+
+        # int32 mul/add/xor wrap mod 2^32 = uint32 arithmetic for free.
+        def lo32(a, b):  # low 32 of a * b
+            return ops.mul(a, b)
+
+        def hi32(a, b):  # high 32 of a * b (unsigned)
+            return ops.umulhi(a, b)
+
+        xor = ops.bitwise_xor
+        SA, SB = C(0xD2511F53), C(0xCD9E8D57)
+
+        def philox_round(x, y, z, w, kx, ky):
+            return (
+                xor(xor(hi32(SB, z), y), kx),
+                lo32(SB, z),
+                xor(xor(hi32(SA, x), w), ky),
+                lo32(SA, x),
+            )
+
+        # seed = key[0], offset = key[1] (uint64); lo/hi split the 64-bit values.
+        seed = ops.to_dtype(key_loader([sympy.Integer(0)]), i64)
+        offset = ops.to_dtype(key_loader([sympy.Integer(1)]), i64)
+        lin = indexer(index)
+        oc = ops.add(offset, ops.index_expr(FloorDiv(lin, 4), i64))  # offset + chunk
+
+        def lo(v):  # low 32 bits (to_dtype truncates)
+            return ops.to_dtype(v, i32)
+
+        def hi(v):  # high 32 bits
+            return ops.to_dtype(ops.bitwise_right_shift(v, ops.constant(32, i64)), i32)
+
+        x, y, z, w = lo(oc), hi(oc), C(0), C(0)
+        kx, ky = lo(seed), hi(seed)
+        for _ in range(9):
+            x, y, z, w = philox_round(x, y, z, w, kx, ky)
+            kx, ky = ops.add(kx, C(0x9E3779B9)), ops.add(ky, C(0xBB67AE85))
+        x, y, z, w = philox_round(x, y, z, w, kx, ky)
+
+        # Select this element's lane (i % 4) of the 4 generated values.
+        lane = ops.index_expr(ModularIndexing(lin, 1, 4), i32)
+        u = ops.where(
+            ops.eq(lane, C(0)),
+            x,
+            ops.where(ops.eq(lane, C(1)), y, ops.where(ops.eq(lane, C(2)), z, w)),
+        )
+
+        # uniform_real: (u & mantissa_mask) * 2^-digits, then affine to [low, high).
+        f32 = torch.float32
+        val = ops.to_dtype(ops.bitwise_and(u, C(mantissa_mask)), f32)
+        val = ops.mul(val, ops.constant(divisor, f32))
+        val = ops.add(ops.mul(val, ops.constant(scale, f32)), ops.constant(low, f32))
+        return ops.to_dtype(val, dtype)
+
+    return Pointwise.create(
+        device=device, dtype=dtype, inner_fn=inner_fn, ranges=list(size)
+    )
+
+
 @register_lowering(aten.native_dropout, type_promotion_kind=None)
 def native_dropout(x, p, train):
     if config.fallback_random:

--- a/torch/_inductor/ops_handler.py
+++ b/torch/_inductor/ops_handler.py
@@ -457,6 +457,10 @@ class OpsHandler(Generic[T]):
     def bitwise_right_shift(self, x0: T, x1: T) -> T:
         raise NotImplementedError
 
+    def umulhi(self, x0: T, x1: T) -> T:
+        # High 32 bits of the product of two uint32 values (hardware __umulhi).
+        raise NotImplementedError
+
     def rsqrt(self, x0: T) -> T:
         raise NotImplementedError
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #189107
* #188495

Allows for fusion with surrounding ops when utilized for e.g. dropout and guaranteed bitwise-equivalent with eager. Sidesteps the perf bug for uniform fixed in #188495 since that only affects fallbacks.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo