### PR TITLE
[Inductor] Bound exact index expressions for int32 indexing eligibility

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -2512,6 +2512,50 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
         )
 
     @skipCUDAIf(not SM80OrLater, "uses bfloat16 which requires SM >= 80")
+    @skipCUDAIf(not SM90OrLater, "needs at least 6 GiB of GPU memory headroom")
+    def test_chunked_unrolled_slice_gather_int32_overflow(self):
+        # Regression for an int32-indexing miscompile when an unrolled chunked
+        # loop containing a per-chunk F.linear and a gather gets fused into one
+        # pointwise kernel. Per-chunk buffer storage individually fits in int32,
+        # but the cross-buffer index `V * x0` reaches `V * total_numel` which
+        # overflows int32, and a separate kernel-level fusion synthesizes
+        # exactly that expression. Result before the fix: cudaErrorIllegalAddress.
+        torch.manual_seed(0)
+        T, D, V_, CHUNKSZ = 16384, 128, 200008, 2048
+        x = torch.randn(1, T, D, device=device_type, dtype=torch.bfloat16)
+        targets = torch.randint(0, V_, (1, T), device=device_type, dtype=torch.int64)
+        W = torch.randn(V_, D, device=device_type, dtype=torch.bfloat16) * 0.01
+        bias = torch.zeros(V_, device=device_type, dtype=torch.bfloat16)
+
+        def fwd(x, targets, W, bias):
+            seqlen = x.shape[-2]
+            out = torch.empty(x.shape[:-1], device=x.device, dtype=torch.float32)
+            for start in range(0, seqlen, CHUNKSZ):
+                end = start + CHUNKSZ
+                chunk_x = x[..., start:end, :]
+                chunk_targets = targets[..., start:end]
+                logits = torch.nn.functional.linear(chunk_x, W) + bias
+                m = logits.amax(dim=-1, keepdim=True)
+                tok = (
+                    torch.log(
+                        torch.sum(torch.exp(logits - m), dim=-1, dtype=torch.float32)
+                    )
+                    + m.squeeze(-1).to(torch.float32)
+                    - torch.gather(logits, -1, chunk_targets[..., None])
+                    .squeeze(-1)
+                    .to(torch.float32)
+                )
+                out[..., start:end] = tok
+            return out
+
+        eager = fwd(x, targets, W, bias)
+        opt = torch.compile(fwd, dynamic=False, fullgraph=True)
+        compiled = opt(x, targets, W, bias)
+        torch.cuda.synchronize()
+        # bf16 matmul + log_sum_exp leaves some slack; loose tol is fine here,
+        # the test is about not crashing.
+        self.assertTrue(torch.allclose(eager, compiled, atol=1e-2, rtol=1e-2))
+
     def test_int64_index_intermediate(self):
         def foo(inp):
             view_23 = torch.ops.aten.view.default(inp, [-1, 8192, 8192])
@@ -3149,7 +3193,7 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
     @unittest.skipUnless(HAS_GPU, "requires GPU")
     def test_fused_slice_scatter_int32_const_overflow(self):
         # End-to-end repro for the int32 address-constant overflow guarded
-        # by SIMDKernelFeatures.any_index_expr_const_overflows_int32.
+        # by SIMDKernelFeatures.any_index_expr_overflows_int32.
         # On unfixed builds the fused backward kernel raises
         #   ValueError('Scalar -2779057358 is out of range for type int32')
         # because slice_scatter.backward + mm.backward fuse into a kernel

--- a/test/inductor/test_indexing.py
+++ b/test/inductor/test_indexing.py
@@ -725,8 +725,9 @@ instantiate_parametrized_tests(ExprPrinterTests)
 
 
 class TestIndexConstOverflowInt32(InductorTestCase):
-    """Tests for
-    ``SIMDKernelFeatures.any_index_expr_const_overflows_int32``."""
+    """Tests for the constant-offset check in
+    ``SIMDKernelFeatures.any_index_expr_overflows_int32`` (index evaluated at
+    the origin)."""
 
     def make_feats(self, indices):
         # Bypass __init__ (needs V.graph) and shadow scheduler_nodes().
@@ -739,7 +740,7 @@ class TestIndexConstOverflowInt32(InductorTestCase):
         return feats
 
     def check(self, indices):
-        return self.make_feats(indices).any_index_expr_const_overflows_int32()
+        return self.make_feats(indices).any_index_expr_overflows_int32()
 
     def test_production_constant_detected(self):
         x0, x1 = sympy.symbols("x0 x1", integer=True)
@@ -771,6 +772,55 @@ class TestIndexConstOverflowInt32(InductorTestCase):
         good = sympy.Integer(42) + x0
         bad = sympy.Integer(-(2**31) - 1) + x0
         self.assertTrue(self.check([good, bad]))
+
+
+class TestIndexExprUpperBounds(InductorTestCase):
+    """Tests for the variable-scaled bound check in
+    ``SIMDKernelFeatures.any_index_expr_overflows_int32``, which bounds the
+    addressing expression over each loop variable's iteration range (catching
+    fused `V * x0` terms while letting a stride on a size-1 dim drop out)."""
+
+    def make_feats(self, deps):
+        node = types.SimpleNamespace(
+            read_writes=types.SimpleNamespace(reads=deps, writes=[])
+        )
+        feats = SIMDKernelFeatures.__new__(SIMDKernelFeatures)
+        feats.scheduler_nodes = lambda: [node]
+        return feats
+
+    def dep(self, index, var_names, sizes):
+        return MemoryDep("buf", index, tuple(var_names), tuple(sizes))
+
+    def check(self, deps):
+        return self.make_feats(deps).any_index_expr_overflows_int32()
+
+    def test_chunked_cross_buffer_overflow_caught(self):
+        # `V * x0 + i`: per-chunk stride V over the fused numel overflows int32
+        # even though no single buffer's storage does.
+        x0, i = sympy.symbols("x0 i", integer=True)
+        dep = self.dep(410_000_000 * x0 + i, [x0, i], [16384, 128])
+        self.assertTrue(self.check([dep]))
+
+    def test_in_range_index_not_flagged(self):
+        # stride 16 over numel 4M stays within int32.
+        x0 = sympy.Symbol("x0", integer=True)
+        dep = self.dep(16 * x0, [x0], [4_000_000])
+        self.assertFalse(self.check([dep]))
+
+    def test_stride_on_size_one_dim_drops_out(self):
+        # Layout shape=(1, 1M), stride=(1M, 1): the large stride multiplies a
+        # size-1 dim and must not force int64 (the Option A false positive).
+        d0, d1 = sympy.symbols("d0 d1", integer=True)
+        dep = self.dep(1_000_000 * d0 + d1, [d0, d1], [1, 1_000_000])
+        self.assertFalse(self.check([dep]))
+
+    def test_symbolic_size_skipped(self):
+        # Dynamic dims are covered by the storage-size check; the precise bound
+        # skips them rather than flagging or crashing on a symbolic size.
+        s0 = sympy.Symbol("s0", integer=True, positive=True)
+        d0 = sympy.Symbol("d0", integer=True)
+        dep = self.dep(1_000_000_000_000 * d0, [d0], [s0])
+        self.assertFalse(self.check([dep]))
 
 
 class TestEvaluateMinMax(InductorTestCase):

--- a/torch/_inductor/codegen/simd_kernel_features.py
+++ b/torch/_inductor/codegen/simd_kernel_features.py
@@ -146,17 +146,36 @@ class SIMDKernelFeatures:
         from .simd import SIMDScheduling
 
         if SIMDScheduling.can_use_32bit_indexing(total_numel, buffers):
-            # Fused address expressions may carry a constant term that
-            # overflows int32 even when numel/storage_size are within range.
-            if self.any_index_expr_const_overflows_int32():
+            # Fused address expressions can overflow int32 even when
+            # numel/storage_size are within range, so check them directly.
+            if self.any_index_expr_overflows_int32():
                 return torch.int64
             return torch.int32
         return torch.int64
 
     @cache_on_self
-    def any_index_expr_const_overflows_int32(self) -> bool:
-        """Return True if any MemoryDep index has a constant term outside
-        [-2**31, 2**31 - 1]."""
+    def any_index_expr_overflows_int32(self) -> bool:
+        """Return True if any MemoryDep addressing expression can overflow int32.
+
+        Two complementary checks are applied to each index:
+
+        - Constant offset: the index evaluated at the origin (every loop
+          variable set to 0) must lie within [-2**31, 2**31 - 1]. This is cheap
+          and independent of loop-var ranges, so it also covers deps whose sizes
+          are symbolic.
+        - Variable-scaled bound: the index bounded over the actual iteration
+          range of every loop variable must not exceed 2**31 - 1. This catches
+          overflow such as the `V * x0` synthesized when unrolled chunked-loop
+          slices are stitched into one pointwise kernel (`V` a per-chunk stride,
+          `x0` spanning the fused numel); unlike a `numel * max_stride` proxy it
+          is exact, since a stride on a size-1 dim multiplies an empty range and
+          drops out. Deps with a symbolic loop-var size, or whose bound is
+          unknown/indirect (infinite), are skipped here and left to the
+          constant-offset and per-buffer storage-size checks.
+        """
+        from torch.utils._sympy.numbers import int_oo
+        from torch.utils._sympy.value_ranges import bound_sympy, ValueRanges
+
         int32_max = sympy.Integer(2**31 - 1)
         int32_min = sympy.Integer(-(2**31))
         for node in self.scheduler_nodes():
@@ -166,13 +185,36 @@ class SIMDKernelFeatures:
                 index = dep.index
                 if not isinstance(index, sympy.Expr):
                     continue
+
+                # Constant offset (index at the origin).
                 try:
                     const_part = index.subs(
                         {s: sympy.Integer(0) for s in index.free_symbols}
                     )
-                    if not isinstance(const_part, sympy.Expr):
-                        continue
-                    if const_part > int32_max or const_part < int32_min:
+                    if isinstance(const_part, sympy.Expr) and (
+                        const_part > int32_max or const_part < int32_min
+                    ):
+                        return True
+                except (ZeroDivisionError, TypeError, ValueError):
+                    pass
+
+                # Variable-scaled bound over concrete loop-var ranges. A
+                # ValueRanges bound must be concrete, so skip a dep with any
+                # symbolic loop-var size.
+                sizes = dep.size
+                if any(getattr(s, "free_symbols", None) for s in sizes):
+                    continue
+                try:
+                    var_ranges = {
+                        var: ValueRanges(0, max(int(size) - 1, 0))
+                        for var, size in zip(dep.var_names, sizes)
+                    }
+                    upper = bound_sympy(index, var_ranges).upper
+                    if (
+                        isinstance(upper, sympy.Expr)
+                        and not upper.has(int_oo, sympy.oo)
+                        and upper > int32_max
+                    ):
                         return True
                 except (ZeroDivisionError, TypeError, ValueError):
                     continue


### PR DESCRIPTION
# [Inductor] Bound exact index expressions for int32 indexing eligibility

## Summary

Decide int32-vs-int64 indexing by checking the **actual addressing
expressions** a kernel will emit, instead of approximating them with a
per-buffer storage-size or stride proxy.

## Background / Root cause

When unrolled chunked-loop slices are fused into a single pointwise kernel, the
per-chunk index takes the form `c_K + V*x0 + i`, where `V` is a per-chunk stride
read from a buffer layout and `x0` ranges over the fused kernel's full `numel`.
The product `V * numel` can overflow int32 even when `numel` and every
individual buffer's `storage_size` fit in int32, producing a silent indexing
miscompile (`cudaErrorIllegalAddress`).

`SIMDScheduling.can_use_32bit_indexing` only inspected `numel` and per-buffer
storage sizes, so it never saw this synthesized cross-buffer term.

A natural proxy fix is `numel * max_stride` (the largest stride across all buffer
layouts). But it is a one-sided over-estimate: for a buffer whose largest stride
sits on a **size-1 dim** (e.g. `shape=(1, V), stride=(V, 1)`), the proxy reports
`numel * V` and forces int64 even though that stride is multiplied by an empty
range in real indexing. That regresses normal pointwise/reduction kernels back
to int64 and breaks block-pointer codegen.

## What this PR does

The offending term is not hidden: it is literally a `MemoryDep.index` sympy
expression, and each loop variable's iteration range is available as `dep.size`.
So we check it directly.

After `can_use_32bit_indexing` passes, `select_index_dtype` now calls
`SIMDKernelFeatures.any_index_expr_overflows_int32`, which applies **two
complementary checks** to every read/write index and returns int64 if either
trips:

1. **Constant offset** — the index evaluated at the origin (every loop variable
   set to 0) must lie within `[-2**31, 2**31 - 1]`. This is the pre-existing
   check (formerly `any_index_expr_const_overflows_int32`); it is cheap and
   independent of loop-var ranges, so it also covers deps whose sizes are
   symbolic. It catches a large *constant* offset (e.g.
   `slice_begin * total_cols` in slice-scatter backward fusion).

2. **Variable-scaled bound** — `bound_sympy(index, {var: [0, size-1]}).upper`
   must not exceed `2**31 - 1`. This is exact rather than a proxy: a stride on a
   size-1 dim multiplies an empty range and drops out, and the fused `V*x0` term
   is captured precisely because it is the actual expression being bounded. This
   is the new logic that replaces the `numel * max_stride` proxy.

`can_use_32bit_indexing` is left as the buffer-only `numel` + per-buffer-storage
check that the template path (`select_algorithm.py`, which has no node schedule)
needs.

### Why the two checks differ (and why both are kept)

They evaluate the index at different points and are not redundant:

| | catches | evaluated at | works with symbolic sizes? |
|---|---|---|---|
| constant-offset check | huge constant offset | origin (all vars = 0) | yes |
| variable-scaled bound | `V*x0`-style terms | max of each var's range | no (skipped) |

The chunked overflow lives entirely in the variable-scaled term: at the origin
the expression is just `c_K` (small), so the constant-offset check alone would
miss it.

### Edge cases

- **Dynamic shapes** are out of scope of the variable-scaled bound: a
  `ValueRanges` bound must be concrete, so a dep with any symbolic loop-var size
  is skipped and left to the constant-offset and storage-size checks.
- **Unknown/indirect (infinite) bounds** are skipped, since those accesses stay
  within their buffer and are already covered by the storage-size check, so
  indirect indexing does not regress to int64.
- The two checks live in **separate `try` blocks** so a rare failure in one
  (e.g. a `ZeroDivisionError` while substituting the origin) does not skip the
  other.

## Alternatives considered

- **Gate a strict check on "some buffer larger than `numel`"**, or **require
  >= 2 oversized buffers** — both narrow the `max_stride` proxy's false
  positives but remain heuristics over buffer sizes.
- **Detect the chunked-slice fusion structurally in the IR** — would require
  threading the node schedule through `select_index_dtype`.

Checking the actual index expressions subsumes all of these: it is the ground
truth the heuristics were approximating.

## Test Plan

```bash
python -m pytest test/inductor/test_indexing.py -q
python -m pytest test/inductor/test_indexing.py::TestIndexExprUpperBounds \
                 test/inductor/test_indexing.py::TestIndexConstOverflowInt32 -q
```

GPU regressions:

```bash
python test/inductor/test_cuda_repro.py CudaReproTests.test_chunked_unrolled_slice_gather_int32_overflow
python test/inductor/test_cuda_repro.py CudaReproTests.test_int64_index_intermediate
python test/inductor/test_cuda_repro.py CudaReproTests.test_fused_slice_scatter_int32_const_overflow
python test/inductor/test_torchinductor_strided_blocks.py TritonBlockPointerTestGPU
```

Results:

- `test_chunked_unrolled_slice_gather_int32_overflow` still forces int64 (no
  illegal access).
- The block-pointer suite (104 tests) and dynamic-shape cases regain int32.
- The size-1-large-stride case that the `max_stride` proxy mis-flagged now uses
  int32 (covered by the new unit test
  `TestIndexExprUpperBounds::test_stride_on_size_one_dim_drops_out`).

## New tests

- `test/inductor/test_indexing.py`
  - `TestIndexConstOverflowInt32` — constant-offset check (origin).
  - `TestIndexExprUpperBounds` — variable-scaled bound check: chunked `V*x0`
    overflow caught, in-range index not flagged, size-1-dim stride drops out,
    symbolic size skipped.
- `test/inductor/test_cuda_repro.py`
  - `test_chunked_unrolled_slice_gather_int32_overflow` — end-to-end repro.

## Files changed

- `torch/_inductor/codegen/simd_kernel_features.py` — the check
  (`any_index_expr_overflows_int32`) and its single call site.
- `test/inductor/test_indexing.py`, `test/inductor/test_cuda_repro.py` — tests.

(`torch/_inductor/codegen/simd.py` has no net change: `can_use_32bit_indexing`
is left exactly as on `main`.)

---

This change was authored with the assistance of an AI coding assistant.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo
