### PR TITLE
Stop running the vllm-test workflow (vllm.yml)

### DIFF
--- a/.github/workflows/vllm.yml
+++ b/.github/workflows/vllm.yml
@@ -21,7 +21,9 @@ permissions:
 jobs:
   build:
     name: vllm-x-pytorch-build
-    if: github.repository_owner == 'pytorch'
+    # Disabled: vLLM CI is being migrated to OSDC. Re-enable by restoring the
+    # `github.repository_owner == 'pytorch'` guard.
+    if: false
     uses: ./.github/workflows/_linux-build.yml
     with:
       # When building vLLM, uv doesn't like that we rename wheel without changing the wheel metadata
@@ -56,6 +58,7 @@ jobs:
 
   test:
     name: vllm-x-pytorch-test
+    if: false
     uses: ./.github/workflows/_linux-test.yml
     needs: build
     with:


### PR DESCRIPTION
Gate both jobs in `vllm.yml` (`vllm-test`) with `if: false` so the workflow no longer runs on push to main/release, `ciflow/vllm/*` tags, or `workflow_dispatch`.

Disable it first, and if we really don't need it anymore, delete it next