### PR TITLE
[CD][ROCm] Ship bare .so alias to fix intermittent import torch deadlock

### DIFF
--- a/.ci/manywheel/repair_wheel.py
+++ b/.ci/manywheel/repair_wheel.py
@@ -332,6 +332,20 @@ def repair_wheel(
             shutil.copy(lib.src, dest)
             if lib.needed_alias:
                 replace_needed(torch_dir, lib.needed_alias, lib.dest_name)
+            # Some bundled deps are dlopen'd by their *bare* soname at runtime,
+            # not just via NEEDED. In particular rocSHMEM's NUMAWrapper global
+            # ctor does dlopen("libnuma.so"). The original build_rocm.sh shipped
+            # OS deps under bare names; this pipeline keeps them versioned
+            # (e.g. libnuma.so.1), so add a bare-name symlink next to the
+            # versioned file. Without it that dlopen fails and rocSHMEM calls
+            # exit() at load, tripping a rocprofiler-sdk atexit deadlock that
+            # hangs `import torch` on no-GPU/no-kfd hosts. See
+            # pytorch/pytorch#189110.
+            if ".so." in lib.dest_name:
+                bare = lib.dest_name.split(".so.", 1)[0] + ".so"
+                bare_path = torch_lib / bare
+                if not bare_path.exists():
+                    bare_path.symlink_to(lib.dest_name)
 
         # Copy auxiliary content (gfx kernel files, MIOpen db, RCCL algos, ...)
         for aux in aux_files:


### PR DESCRIPTION
## Summary

`import torch` from ROCm 2.13 wheels **intermittently hangs forever** on hosts without a usable GPU / kfd (CPU-only nodes, or GPU nodes where `amdgpu`/`amdkfd` isn't loaded). Fixes #189110.

This is related to this fix PR in upstream: https://github.com/ROCm/rocm-systems/pull/6640 (this is not included in pytorch, hence a failure)

### Root cause (native backtrace)
```
import torch → dlopen(_C) → static init of libtorch_rocshmem.so
  → rocshmem::NUMAWrapper::NUMAWrapper()          (upstream rocSHMEM global ctor)
     → dlopen("libnuma.so") == NULL  →  exit(1)    (at library-load time!)
        → atexit → rocprofiler::registration::finalize()
           → ThreadPool::destroy_threadpool() → std::thread::join()   # HANGS
```

### Why it regressed here (and why 0513 was fine but 0514 hangs)
This is a **packaging** regression from the ROCm manywheel pipeline port (#182696), not the rocSHMEM binary:

| | bundled `libnuma` | `dlopen("libnuma.so")` from `$ORIGIN` | result |
|---|---|---|---|
| old `build_rocm.sh` (0513) | **`libnuma.so`** (bare) | resolves | ✅ no `exit()` → never hangs |
| new `repair_wheel.py` (0514+) | **`libnuma.so.1`** only | fails (no bare name in-wheel) | ❌ `exit(1)` → rocprofiler atexit deadlock → intermittent hang |

The old `build_rocm.sh` renamed bundled OS deps to **bare** sonames, so `torch/lib` shipped `libnuma.so`. `repair_wheel.py` keeps them **versioned** (`libnuma.so.1`). rocSHMEM's `NUMAWrapper` global ctor does `dlopen("libnuma.so")` (bare) via `libtorch_rocshmem.so`'s `$ORIGIN` RPATH — with only `libnuma.so.1` present it fails and `exit(1)`s at load, tripping a **racy** rocprofiler-sdk atexit `finalize()` deadlock (hence the intermittency; the `agent.cpp:608` kfd warning is a red herring). Same rocSHMEM binary in both wheels — only the bundled `libnuma` filename differs.

## Fix
When bundling a versioned OS dep, also create a **bare-name symlink** (`libnuma.so` → `libnuma.so.1`, etc.), restoring `build_rocm.sh` behavior. The bare symlink satisfies rocSHMEM's `dlopen`; the versioned file still satisfies `NEEDED` references.

**Verified:** adding this symlink to an installed wheel makes `import torch` succeed deterministically on a no-`kfd` host (loop-tested; the hang no longer reproduces).

## Follow-ups (upstream)
The underlying rocSHMEM bug — `NUMAWrapper` must not `exit()` from a global constructor, and should `dlopen("libnuma.so.1")` — is already fixed upstream *after* PyTorch's pinned commit (`cb8a2d6`): ROCm/rocm-systems **#5918** (runtime numalib check) and **#6640** (link numa directly, no `dlopen` — removes `numa_wrapper.cpp`). Bumping `ROCSHMEM_VERSION` in `.ci/docker/common/install_rocSHMEM.sh` would also fix it and is worth doing separately. The rocprofiler-sdk atexit `finalize()` deadlock ("does not exit cleanly") is a separate AMD-side bug.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang