### PR TITLE
Move s390x build into a dedicated _s390x-build.yml workflow

### DIFF
--- a/.github/workflows/_s390x-build.yml
+++ b/.github/workflows/_s390x-build.yml
@@ -1,0 +1,227 @@
+# Owner(s): ["module: POWER"]
+name: linux-s390x-build
+
+on:
+  workflow_call:
+    inputs:
+      build-environment:
+        required: true
+        type: string
+        description: Top-level label for what's being built/tested.
+      docker-image-name:
+        required: true
+        type: string
+        description: Name of the docker image to build with.
+      build-generates-artifacts:
+        required: false
+        type: boolean
+        default: true
+        description: If set, upload generated build artifacts.
+      sync-tag:
+        required: false
+        type: string
+        default: ""
+        description: |
+          If this is set, our linter will use this to make sure that every other
+          job with the same `sync-tag` is identical.
+      cuda-arch-list:
+        required: false
+        type: string
+        default: "7.5"
+        description: |
+          List of CUDA architectures CI build should target.
+      runner:
+        required: false
+        type: string
+        default: "linux.s390x"
+        description: |
+          Label of the runner this job should run on.
+      test-matrix:
+        required: false
+        type: string
+        description: |
+          An option JSON description of what test configs to run later on. This
+          is moved here from the Linux test workflow so that we can apply filter
+          logic using test-config labels earlier and skip unnecessary builds
+      selected-test-configs:
+        description: |
+          A comma-separated list of test configurations from the test matrix to keep,
+          The empty list means we are going to keep every configurations by defaults
+        required: false
+        type: string
+        default: ""
+      allow-reuse-old-whl:
+        description: |
+          If set, the build try to pull an old wheel from s3 that was built on a
+          commit with no cpp changes from this commit
+        required: false
+        type: boolean
+        default: true
+      build-additional-packages:
+        description: |
+          If set, the build job will also builds these packages and saves their
+          wheels as artifacts
+        required: false
+        type: string
+        default: ""
+
+    secrets:
+      HUGGING_FACE_HUB_TOKEN:
+        required: false
+        description: |
+          HF Auth token to avoid rate limits when downloading models or datasets from hub
+
+    outputs:
+      docker-image:
+        value: ${{ inputs.docker-image-name }}
+        description: The docker image containing the built PyTorch.
+      test-matrix:
+        value: ${{ jobs.build.outputs.test-matrix }}
+        description: An optional JSON description of what test configs to run later on.
+      build-environment:
+        value: ${{ jobs.build.outputs.build-environment }}
+        description: Top-level label for what's being built/tested.
+
+jobs:
+  build:
+    # Don't run on forked repos
+    if: github.repository_owner == 'pytorch'
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 480
+    outputs:
+      test-matrix: ${{ steps.filter.outputs.test-matrix }}
+      build-environment: ${{ inputs.build-environment }}
+    steps:
+      - name: Setup Linux
+        id: setup-linux
+        uses: pytorch/pytorch/.github/actions/setup-linux@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if can use old whl build
+        id: use-old-whl
+        uses: ./.github/actions/reuse-old-whl
+        if: ${{ inputs.allow-reuse-old-whl }}
+        with:
+          build-environment: ${{ inputs.build-environment }}
+          run-id: ${{ github.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          job-id: ${{ steps.setup-linux.outputs.job-id }}
+          job-name: ${{ steps.setup-linux.outputs.job-name }}
+
+      # Apply the filter logic to the build step too if the test-config label is already there
+      - name: Select all requested test configurations (if the test matrix is available)
+        id: filter
+        uses: ./.github/actions/filter-test-configs
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          test-matrix: ${{ inputs.test-matrix }}
+          selected-test-configs: ${{ inputs.selected-test-configs }}
+          job-name: ${{ steps.setup-linux.outputs.job-name }}
+
+      - name: Build
+        if: (steps.filter.outputs.is-test-matrix-empty == 'False' || inputs.test-matrix == '') && steps.use-old-whl.outputs.reuse != 'true'
+        id: build
+        env:
+          BUILD_ENVIRONMENT: ${{ inputs.build-environment }}
+          BRANCH: ${{ steps.setup-linux.outputs.branch }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
+          # Do not set SCCACHE_S3_KEY_PREFIX to share the cache between all build jobs
+          SCCACHE_BUCKET: ossci-compiler-cache-circleci-v2
+          SCCACHE_REGION: us-east-1
+          XLA_CLANG_CACHE_S3_BUCKET_NAME: ossci-compiler-clang-cache-circleci-xla
+          PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+          TORCH_CUDA_ARCH_LIST: ${{ inputs.cuda-arch-list }}
+          DOCKER_IMAGE: ${{ inputs.docker-image-name }}
+          XLA_CUDA: ${{ contains(inputs.build-environment, 'xla') && '0' || '' }}
+          OUR_GITHUB_JOB_ID: ${{ steps.setup-linux.outputs.job-id }}
+          HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
+          BUILD_ADDITIONAL_PACKAGES: ${{ inputs.build-additional-packages }}
+          RUNNER: ${{ inputs.runner }}
+        run: |
+          START_TIME=$(date +%s)
+          JENKINS_USER=
+          USED_IMAGE="${DOCKER_IMAGE}"
+          # ensure that docker container cleanly exits in 12 hours
+          # if for some reason cleanup action doesn't stop container
+          # when job is cancelled
+          DOCKER_SHELL_CMD="sleep 12h"
+
+          # since some steps are skipped on s390x, if they are necessary, run them here
+          env | grep '^GITHUB' >> "/tmp/github_env_${GITHUB_RUN_ID}"
+          env | grep '^CI' >> "/tmp/github_env_${GITHUB_RUN_ID}"
+
+          # Leaving 1GB for the runner and other things
+          TOTAL_AVAILABLE_MEMORY_IN_GB=$(awk '/MemTotal/ { printf "%.3f \n", $2/1024/1024 - 1 }' /proc/meminfo)
+          # https://docs.docker.com/engine/containers/resource_constraints/#--memory-swap-details, the 3GB swap
+          # comes from https://github.com/pytorch/test-infra/pull/6058
+          TOTAL_MEMORY_WITH_SWAP=$(("${TOTAL_AVAILABLE_MEMORY_IN_GB%.*}" + 3))
+
+          # detached container should get cleaned up by the Cleanup docker step
+          # Used for JENKINS_USER and DOCKER_SHELL_CMD, which can be empty
+          # shellcheck disable=SC2086
+          container_name=$(docker run \
+            -e BUILD_ENVIRONMENT \
+            -e MAX_JOBS="$(nproc --ignore=2)" \
+            -e PR_NUMBER \
+            -e SHA1 \
+            -e BRANCH \
+            -e SCCACHE_BUCKET \
+            -e SCCACHE_REGION \
+            -e XLA_CUDA \
+            -e XLA_CLANG_CACHE_S3_BUCKET_NAME \
+            -e SKIP_SCCACHE_INITIALIZATION=1 \
+            -e TORCH_CUDA_ARCH_LIST \
+            -e PR_LABELS \
+            -e OUR_GITHUB_JOB_ID \
+            -e HUGGING_FACE_HUB_TOKEN \
+            -e BUILD_ADDITIONAL_PACKAGES \
+            -e RUNNER \
+            --memory="${TOTAL_AVAILABLE_MEMORY_IN_GB%.*}g" \
+            --memory-swap="${TOTAL_MEMORY_WITH_SWAP}g" \
+            --env-file="/tmp/github_env_${GITHUB_RUN_ID}" \
+            --security-opt seccomp=unconfined \
+            --cap-add=SYS_PTRACE \
+            --tty \
+            --detach \
+            ${JENKINS_USER} \
+            -v "${GITHUB_WORKSPACE}:/var/lib/jenkins/workspace" \
+            -w /var/lib/jenkins/workspace \
+            "${USED_IMAGE}" \
+            ${DOCKER_SHELL_CMD}
+          )
+
+          # sometimes there are intermittent network errors, do a couple of retries
+          docker exec -t "${container_name}" sh -c "python3 -m pip install -r requirements.txt || \
+              (sleep 15 && python3 -m pip install -r requirements.txt) || \
+              (sleep 30 && python3 -m pip install -r requirements.txt) || \
+              (sleep 60 && python3 -m pip install -r requirements.txt) || \
+              (sleep 300 && python3 -m pip install -r requirements.txt)"
+
+          docker exec -t "${container_name}" sh -c '.ci/pytorch/build.sh'
+
+          END_TIME=$(date +%s)
+          echo "build_time=$((END_TIME - START_TIME))" >> "$GITHUB_OUTPUT"
+
+      - name: Archive artifacts into zip
+        if: inputs.build-generates-artifacts && steps.build.outcome != 'skipped' && steps.use-old-whl.outputs.reuse != 'true'
+        run: |
+          zip -1 -r artifacts.zip dist/ build/custom_test_artifacts build/lib build/bin .additional_ci_files
+
+      - name: Store PyTorch Build Artifacts for s390x
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: inputs.build-generates-artifacts && (steps.build.outcome != 'skipped' || steps.use-old-whl.outputs.reuse == 'true')
+        with:
+          name: ${{ inputs.build-environment }}
+          retention-days: 14
+          if-no-files-found: error
+          path: artifacts.zip
+
+      - name: Cleanup docker
+        if: always()
+        shell: bash
+        run: |
+          # on s390x stop the container for clean worker stop
+          docker stop -a || true
+          docker kill -a || true

--- a/.github/workflows/s390.yml
+++ b/.github/workflows/s390.yml
@@ -17,7 +17,7 @@ jobs:
   linux-manylinux-2_28-py3-cpu-s390x-build:
     if: github.repository_owner == 'pytorch'
     name: linux-manylinux-2_28-py3-cpu-s390x
-    uses: ./.github/workflows/_linux-build.yml
+    uses: ./.github/workflows/_s390x-build.yml
     with:
       build-environment: linux-s390x-binary-manywheel
       docker-image-name: pytorch/manylinuxs390x-builder:cpu-s390x

--- a/.github/workflows/s390x-periodic.yml
+++ b/.github/workflows/s390x-periodic.yml
@@ -34,7 +34,7 @@ jobs:
   linux-manylinux-2_28-py3-cpu-s390x-build:
     if: github.repository_owner == 'pytorch'
     name: linux-manylinux-2_28-py3-cpu-s390x
-    uses: ./.github/workflows/_linux-build.yml
+    uses: ./.github/workflows/_s390x-build.yml
     with:
       build-environment: linux-s390x-binary-manywheel
       docker-image-name: pytorch/manylinuxs390x-builder:cpu-s390x


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #189117
* #189116
* #189113
* __->__ #189115

s390x runs on self-hosted linux.s390x runners and can't use OSDC/ARC, so it
was the last caller stuck on the EC2 path in _linux-build.yml. Extract its
build path into its own workflow; s390.yml and s390x-periodic.yml now call
it. Outputs are unchanged, so the s390x test jobs are unaffected.

Authored with the assistance of Claude Code.