### PR TITLE
Fix concurrent-fetch ref race in shim version linters

### DIFF
--- a/tools/linter/adapters/_stable_shim_utils.py
+++ b/tools/linter/adapters/_stable_shim_utils.py
@@ -9,7 +9,9 @@ Consumed by:
 
 from __future__ import annotations
 
+import functools
 import re
+import subprocess
 import sys
 from enum import Enum
 from pathlib import Path
@@ -430,6 +432,62 @@ class PreprocessorTracker:
     def identifiers_used(self) -> list[IdentifierUse]:
         found = self._identifier_accumulator.identifiers_used()
         return found if found is not None else []
+
+
+@functools.cache
+def merge_base_with_main() -> str:
+    """
+    Merge-base of HEAD with origin's current main. Raises on any git failure.
+
+    Cached so git runs once per process no matter how many files the adapter
+    is asked to lint. main is resolved to a SHA and fetched by SHA with
+    --no-write-fetch-head so no local refs are written: lintrunner runs
+    adapters concurrently in one repo, and concurrent fetches racing to update
+    refs/remotes/origin/main fail with "cannot lock ref ... unable to update
+    local ref".
+    """
+    result = subprocess.run(
+        ["git", "ls-remote", "origin", "refs/heads/main"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        raise RuntimeError(
+            f"Failed to resolve main on origin. Error: {result.stderr.strip()}"
+        )
+    main_sha = result.stdout.split()[0]
+
+    have_commit = subprocess.run(
+        ["git", "cat-file", "-e", f"{main_sha}^{{commit}}"],
+        capture_output=True,
+        timeout=5,
+    )
+    if have_commit.returncode != 0:
+        result = subprocess.run(
+            ["git", "fetch", "--no-write-fetch-head", "origin", main_sha],
+            capture_output=True,
+            text=True,
+            timeout=600,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"Failed to fetch {main_sha} from origin. "
+                f"Error: {result.stderr.strip()}"
+            )
+
+    result = subprocess.run(
+        ["git", "merge-base", "HEAD", main_sha],
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Failed to find merge-base with origin main ({main_sha}). "
+            f"Error: {result.stderr.strip()}"
+        )
+    return result.stdout.strip()
 
 
 def get_current_version() -> tuple[int, int, int]:

--- a/tools/linter/adapters/generated_shims_version_linter.py
+++ b/tools/linter/adapters/generated_shims_version_linter.py
@@ -25,6 +25,7 @@ from tools.linter.adapters._stable_shim_utils import (
     get_current_version,
     LintMessage,
     LintSeverity,
+    merge_base_with_main,
 )
 
 
@@ -112,27 +113,7 @@ def _read_at_merge_base(filename: str) -> str | None:
     Return `filename` contents at the merge-base of HEAD with origin/main, or
     None if the file did not exist at that point. Raises if git operations fail.
     """
-    result = subprocess.run(
-        ["git", "fetch", "origin", "main"],
-        capture_output=True,
-        text=True,
-        timeout=600,
-    )
-    if result.returncode != 0:
-        raise RuntimeError(f"Failed to fetch origin. Error: {result.stderr.strip()}")
-
-    result = subprocess.run(
-        ["git", "merge-base", "HEAD", "origin/main"],
-        capture_output=True,
-        text=True,
-        timeout=5,
-    )
-    if result.returncode != 0:
-        raise RuntimeError(
-            f"Failed to find merge-base with origin/main. "
-            f"Error: {result.stderr.strip()}"
-        )
-    merge_base = result.stdout.strip()
+    merge_base = merge_base_with_main()
 
     # `git show <ref>:<path>` requires <path> relative to the repo root;
     # lintrunner may pass `filename` as an absolute path.

--- a/tools/linter/adapters/stable_shim_version_linter.py
+++ b/tools/linter/adapters/stable_shim_version_linter.py
@@ -23,6 +23,7 @@ from tools.linter.adapters._stable_shim_utils import (
     get_current_version,
     LintMessage,
     LintSeverity,
+    merge_base_with_main,
     MULTILINE_MATCHERS,
     PreprocessorTracker,
 )
@@ -77,42 +78,7 @@ def get_added_lines(filename: str) -> set[int]:
             added_lines.update(parse_diff(result.stdout))
 
         # Get merge-base with origin/main to check all PR commits
-        result = subprocess.run(
-            ["git", "fetch", "origin", "main"],
-            capture_output=True,
-            text=True,
-            timeout=600,
-        )
-        if result.returncode != 0:
-            # A parallel fetcher may have advanced origin/main while we were
-            # fetching, producing a lock error. If origin/main resolves locally,
-            # the existing ref is at least as fresh as what we asked for.
-            verify = subprocess.run(
-                ["git", "rev-parse", "--verify", "origin/main"],
-                capture_output=True,
-                text=True,
-                timeout=5,
-            )
-            if verify.returncode != 0:
-                raise RuntimeError(
-                    f"Failed to fetch origin/main and no usable local copy exists. "
-                    f"Fetch error: {result.stderr.strip()}"
-                )
-
-        result = subprocess.run(
-            ["git", "merge-base", "HEAD", "origin/main"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-        if result.returncode != 0:
-            raise RuntimeError(
-                f"Failed to find merge-base with origin/main. "
-                f"Make sure origin/main exists (run 'git fetch origin main'). "
-                f"Error: {result.stderr.strip()}"
-            )
-
-        merge_base = result.stdout.strip()
+        merge_base = merge_base_with_main()
         result = subprocess.run(
             ["git", "diff", f"{merge_base}..HEAD", filename],
             capture_output=True,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189120

The GENERATED_SHIMS_VERSION linter crashed in CI with "cannot lock ref
'refs/remotes/origin/main' ... unable to update local ref". Root cause:
each shim linter adapter runs "git fetch origin main" into the same
repo, and lintrunner runs adapters concurrently, so parallel fetches
race on the compare-and-swap update of the shared tracking ref; the
loser exits nonzero even though the fetch itself succeeded.

The fix removes the shared mutable state instead of tolerating the
race: resolve main to a SHA with ls-remote, fetch that SHA with
--no-write-fetch-head (skipped when the commit is already local), and
compute the merge-base against the SHA. No local refs are ever written,
so there is nothing for concurrent processes to race on. The logic is
deduplicated into a functools.cache'd merge_base_with_main() helper in
_stable_shim_utils.py, replacing per-file fetches in both
generated_shims_version_linter.py and stable_shim_version_linter.py
(whose fetch-failure fallback could silently use a stale origin/main).
Any git failure now raises rather than proceeding best-effort.

An alternative was to keep fetching the branch and tolerate the lock
error (via stderr sniffing or a rev-parse fallback), but that papers
over the race and can lint against a stale ref; fetching an immutable
SHA eliminates it outright.

Test Plan:

Both adapters run clean end to end:

```
python3 tools/linter/adapters/generated_shims_version_linter.py torchgen/aoti/fallback_ops.py
python3 tools/linter/adapters/stable_shim_version_linter.py -- torch/csrc/stable/c/shim.h
```

Failure path verified in a throwaway clone with origin pointed at an
unreachable host: merge_base_with_main() raises RuntimeError ("Failed
to resolve main on origin") instead of proceeding with a stale ref.

Authored with Claude Code.