### PR TITLE
Fix sparse-dense mul dropping data when broadcasting a size-1 sparse dim

### DIFF
--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -25,6 +25,7 @@
 #else
 #include <ATen/ops/_sparse_addmm.h>
 #include <ATen/ops/_sparse_addmm_native.h>
+#include <ATen/ops/_sparse_broadcast_to.h>
 #include <ATen/ops/_sparse_coo_tensor_with_dims_and_tensors.h>
 #include <ATen/ops/_sparse_mm_native.h>
 #include <ATen/ops/_sparse_sum.h>
@@ -861,7 +862,29 @@ static Tensor& intersection_binary_op_sparse_dense_out(
   // Always coalesce when sparse broadcasts over dense,
   // because new sparse dimensions are created and
   // repeated indices have to be eliminated because of that.
-  const auto s = (coalesce || d_dim > s_dim) ? s_.coalesce() : s_;
+  const auto s_coalesced = (coalesce || d_dim > s_dim) ? s_.coalesce() : s_;
+
+  // A size-1 sparse dimension of the sparse operand has to broadcast up to the
+  // result size. The intersection logic below reuses the sparse indices as-is
+  // and does not expand them, which would silently drop all but the index-0
+  // slice along such a dimension. Materialize the broadcast here so each
+  // specified element is replicated across the broadcasted sparse dimensions.
+  // See https://github.com/pytorch/pytorch/issues/188900.
+  const auto s = [&]() -> Tensor {
+    const auto n_sparse = s_coalesced.sparse_dim();
+    const auto s_ndim = s_coalesced.dim();
+    const auto res_ndim = static_cast<int64_t>(res_shape.size());
+    auto bcast_shape = s_coalesced.sizes().vec();
+    bool needs_bcast = false;
+    for (const auto j : c10::irange(n_sparse)) {
+      const auto res_size = res_shape[res_ndim - s_ndim + j];
+      if (bcast_shape[j] == 1 && res_size != 1) {
+        bcast_shape[j] = res_size;
+        needs_bcast = true;
+      }
+    }
+    return needs_bcast ? at::_sparse_broadcast_to(s_coalesced, bcast_shape) : s_coalesced;
+  }();
 
   const auto sparse_dim = s.sparse_dim();
   const auto dense_dim = s.dense_dim();

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -4163,6 +4163,20 @@ class TestSparse(TestSparseBase):
                 # TODO: uncomment once supported
                 # check_autograd(x, y)
 
+    @expectedFailureMPS
+    @dtypes(torch.double)
+    def test_sparse_dense_mul_broadcast_singleton(self, device, dtype):
+        # Regression test for https://github.com/pytorch/pytorch/issues/188900
+        # A size-1 sparse dimension that must broadcast up used to silently drop
+        # data: only index 0 along the broadcast dimension was populated, and the
+        # rest were left as zeros.
+        s = torch.tensor([[1., 2.], [3., 4.]], dtype=dtype, device=device).to_sparse_coo()
+        s1 = s[:, :, None]  # (2, 2, 1): trailing size-1 sparse dim
+        d = torch.ones(1, 1, 3, dtype=dtype, device=device)  # broadcasts to (2, 2, 3)
+        expected = s1.to_dense() * d
+        self.assertEqual((s1 * d).to_dense(), expected)
+        self.assertEqual((d * s1).to_dense(), expected)  # commutativity
+
     @coalescedonoff
     @expectedFailureMPS
     @dtypes(*all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16))


### PR DESCRIPTION
Fixes #188900

### Summary

Multiplying a dense tensor by a sparse COO tensor whose **size-1 sparse dimension must broadcast up** to a larger size silently dropped data: only the index-0 slice along the broadcast dimension was populated, and the rest were left as zeros. No error or warning was raised.

### Root cause

In `intersection_binary_op_sparse_dense_out` (`aten/src/ATen/native/sparse/SparseTensorMath.cpp`), when the sparse operand has at least as many dimensions as the dense operand, the code assumes the result `nnz` is unchanged and reuses the sparse indices as-is. For a size-1 sparse dimension broadcasting to size `N`, the `nnz` must grow by a factor of `N` and the indices must be expanded. Reusing them pins every specified element to index 0 of the broadcast dimension.

### Fix

Materialize the broadcast of the sparse operand's size-1 sparse dimensions up front via `_sparse_broadcast_to`, which replicates each specified element across the broadcasted dimensions. This reuses the existing, correct broadcasting logic instead of duplicating index-expansion code, and only runs when a sparse dimension actually needs to broadcast (so the common path is unchanged).

### Reproducer (fixed by this PR)

```python
import torch
s = torch.tensor([[1., 2.], [3., 4.]]).to_sparse_coo()
s1 = s[:, :, None]      # (2, 2, 1) sparse, trailing size-1 dim
d = torch.ones(1, 1, 3) # broadcasts to (2, 2, 3)
print((s1 * d).to_dense())
# before: only [:, :, 0] populated; after: values replicated across all 3 slots
```

### Test Plan

Added a regression test `test_sparse_dense_mul_broadcast_singleton` and verified existing coverage still passes:

```
python test/test_sparse.py -k test_sparse_dense_mul_broadcast_singleton
python test/test_sparse.py -k test_sparse_dense_mul
python test/test_sparse.py -k test_sparse_sparse_mul
python test/test_sparse.py -k test_full_broadcast_to
```

New regression test passes; existing sparse `mul` and `broadcast_to` tests still pass.

> This PR was authored with the assistance of an AI coding agent (Claude Code).
