### PR TITLE
cuda graphs: accept None && float graph-partition inputs

### DIFF
--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -273,6 +273,51 @@ if HAS_CUDA_AND_TRITON:
             self.run_twc(foo_opt, zeros)
             self.assertEqual(self.get_root_children(), [0, 0])
 
+        @torch._dynamo.config.patch(capture_scalar_outputs=True)
+        def test_partition_none_input(self):
+            # A graph that materializes a scalar via .item() is partitioned for
+            # cudagraphs, and the partition boundary threads a None buffer as an
+            # input. Recording the partition must accept None inputs; it used to
+            # only allow int/Generator/OpaqueBase and crash on None.
+            def fn(x, y):
+                s = torch.full((1,), 3, dtype=torch.int16).squeeze().item()
+                return (x - y).expand(1, 8, x.shape[0]) - s
+
+            x = torch.randint(5, 30, (24,), dtype=torch.int16, device="cuda")
+            y = torch.randint(5, 30, (1,), dtype=torch.int16, device="cuda")
+            ref = fn(x, y)
+            opt = torch.compile(fn, mode="reduce-overhead", fullgraph=True)
+            for _ in range(3):
+                torch.compiler.cudagraph_mark_step_begin()
+                self.assertEqual(opt(x, y), ref)
+            self.assertIsNotNone(self.get_manager())
+
+        @torch._dynamo.config.patch(capture_scalar_outputs=True)
+        def test_partition_float_input(self):
+            # A data-dependent float scalar (.item() on a float tensor under
+            # capture_scalar_outputs) is threaded as a float graph-partition
+            # input. Recording the partition must accept float inputs; it used
+            # to only allow int/Generator/CustomClassBase/None and crash on float.
+            def fn(a, b, w):
+                s1 = a.item()
+                s2 = b.item()
+                m = torch.matmul(
+                    w, torch.full((w.shape[0], 1), 0.05, device="cuda")
+                ).squeeze()
+                return torch.tan(
+                    torch.divide(m, (2.17 - s2) * s1, rounding_mode="trunc")
+                )
+
+            a = torch.tensor(1.3, dtype=torch.float16, device="cuda")
+            b = torch.tensor(0.7, dtype=torch.float16, device="cuda")
+            w = torch.randn(6, device="cuda")
+            ref = fn(a, b, w)
+            opt = torch.compile(fn, mode="reduce-overhead", fullgraph=True)
+            for _ in range(3):
+                torch.compiler.cudagraph_mark_step_begin()
+                self.assertEqual(opt(a, b, w), ref)
+            self.assertIsNotNone(self.get_manager())
+
         def test_multithreaded_cudagraph_trees(self):
             import queue
             import threading

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -284,6 +284,51 @@ if HAS_CUDA_AND_TRITON:
             self.run_twc(foo_opt, zeros)
             self.assertEqual(self.get_root_children(), [0, 0])
 
+        @torch._dynamo.config.patch(capture_scalar_outputs=True)
+        def test_partition_none_input(self):
+            # A graph that materializes a scalar via .item() is partitioned for
+            # cudagraphs, and the partition boundary threads a None buffer as an
+            # input. Recording the partition must accept None inputs; it used to
+            # only allow int/Generator/OpaqueBase and crash on None.
+            def fn(x, y):
+                s = torch.full((1,), 3, dtype=torch.int16).squeeze().item()
+                return (x - y).expand(1, 8, x.shape[0]) - s
+
+            x = torch.randint(5, 30, (24,), dtype=torch.int16, device="cuda")
+            y = torch.randint(5, 30, (1,), dtype=torch.int16, device="cuda")
+            ref = fn(x, y)
+            opt = torch.compile(fn, mode="reduce-overhead", fullgraph=True)
+            for _ in range(3):
+                torch.compiler.cudagraph_mark_step_begin()
+                self.assertEqual(opt(x, y), ref)
+            self.assertIsNotNone(self.get_manager())
+
+        @torch._dynamo.config.patch(capture_scalar_outputs=True)
+        def test_partition_float_input(self):
+            # A data-dependent float scalar (.item() on a float tensor under
+            # capture_scalar_outputs) is threaded as a float graph-partition
+            # input. Recording the partition must accept float inputs; it used
+            # to only allow int/Generator/CustomClassBase/None and crash on float.
+            def fn(a, b, w):
+                s1 = a.item()
+                s2 = b.item()
+                m = torch.matmul(
+                    w, torch.full((w.shape[0], 1), 0.05, device="cuda")
+                ).squeeze()
+                return torch.tan(
+                    torch.divide(m, (2.17 - s2) * s1, rounding_mode="trunc")
+                )
+
+            a = torch.tensor(1.3, dtype=torch.float16, device="cuda")
+            b = torch.tensor(0.7, dtype=torch.float16, device="cuda")
+            w = torch.randn(6, device="cuda")
+            ref = fn(a, b, w)
+            opt = torch.compile(fn, mode="reduce-overhead", fullgraph=True)
+            for _ in range(3):
+                torch.compiler.cudagraph_mark_step_begin()
+                self.assertEqual(opt(a, b, w), ref)
+            self.assertIsNotNone(self.get_manager())
+
         def test_multithreaded_cudagraph_trees(self):
             import queue
             import threading

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -329,6 +329,52 @@ if HAS_CUDA_AND_TRITON:
                 self.assertEqual(opt(a, b, w), ref)
             self.assertIsNotNone(self.get_manager())
 
+        @torch._dynamo.config.patch(capture_scalar_outputs=True)
+        def test_partition_float_input_not_baked_in(self):
+            # cudagraphify_impl keys re-recording on int inputs only, so a float
+            # partition input used to be baked into the graph at record time and
+            # a replay with a different float silently reused the recorded one.
+            # move_scalars_to_gpu recomputes it as a 0-d device tensor, which the
+            # replay re-reads. Varying the scalars is what makes this test bite.
+            def fn(a, b, w):
+                s1 = a.item()
+                s2 = b.item()
+                m = torch.matmul(
+                    w, torch.full((w.shape[0], 1), 0.05, device="cuda")
+                ).squeeze()
+                return torch.tan(
+                    torch.divide(m, (2.17 - s2) * s1, rounding_mode="trunc")
+                )
+
+            w = torch.full((6,), 10.0 / 6.0, device="cuda")
+            opt = torch.compile(fn, mode="reduce-overhead", fullgraph=True)
+            for av, bv in [(1.3, 0.7), (1.3, 0.7), (0.4, 1.9), (2.6, 0.2), (0.4, 1.9)]:
+                a = torch.tensor(av, dtype=torch.float16, device="cuda")
+                b = torch.tensor(bv, dtype=torch.float16, device="cuda")
+                ref = fn(a, b, w)
+                torch.compiler.cudagraph_mark_step_begin()
+                self.assertEqual(opt(a, b, w), ref)
+            self.assertIsNotNone(self.get_manager())
+
+        @torch._dynamo.config.patch(capture_scalar_outputs=True)
+        def test_scalar_arg_ops_still_compile(self):
+            # Only parameters the schema declares as Tensor may be swapped for a
+            # 0-d device tensor. full's fill_value and clamp's min are Scalars
+            # and reject a tensor outright.
+            def use_full(a, x):
+                return torch.full((4,), a.item(), device="cuda") + x
+
+            def use_clamp(a, x):
+                return torch.clamp(x, min=a.item())
+
+            a = torch.tensor(2.5, device="cuda")
+            x = torch.ones(4, device="cuda")
+            for fn in (use_full, use_clamp):
+                ref = fn(a, x)
+                opt = torch.compile(fn, mode="reduce-overhead", fullgraph=True)
+                torch.compiler.cudagraph_mark_step_begin()
+                self.assertEqual(opt(a, x), ref)
+
         def test_multithreaded_cudagraph_trees(self):
             import queue
             import threading

--- a/tools/experimental/torchfuzz/cuda/__init__.py
+++ b/tools/experimental/torchfuzz/cuda/__init__.py
@@ -55,6 +55,10 @@ Per-template overrides for the CUDA plugin
   ``requires_grad_(True)`` to float args, and overrides ``wrap_body`` to
   partition non-leaf operations across 2-3 ``torch.cuda.Stream()`` contexts
   with proper ``wait_stream`` / event-based synchronization.
+* :class:`ReduceOverheadFuzzTemplate` - reuses the default operator set but
+  swaps in a check that compiles with ``mode="reduce-overhead"`` and runs the
+  program for several steps (warmup / record / replay) with a backward pass,
+  comparing each step against an eager reference to exercise cudagraph_trees.
 * :class:`DTensorFuzzTemplate` - overrides ``imports_codegen`` /
   ``flags_codegen`` for distributed setup, ``args_codegen`` to wrap each arg
   via ``DTensor.from_local`` on a fake-PG 2D mesh, ``return_codegen`` to use
@@ -94,6 +98,7 @@ from torchfuzz.cuda._codegen import (
     DefaultFuzzTemplate,
     DTensorFuzzPlacementsTemplate,
     DTensorFuzzTemplate,
+    ReduceOverheadFuzzTemplate,
     StreamFuzzTemplate,
     UnbackedFuzzTemplate,
 )
@@ -110,6 +115,7 @@ def register_codegen() -> dict[str, type[FuzzTemplate]]:
         "dtensor_placements": DTensorFuzzPlacementsTemplate,
         "unbacked": UnbackedFuzzTemplate,
         "streams": StreamFuzzTemplate,
+        "reduce_overhead": ReduceOverheadFuzzTemplate,
     }
 
 

--- a/tools/experimental/torchfuzz/cuda/_checks.py
+++ b/tools/experimental/torchfuzz/cuda/_checks.py
@@ -3,6 +3,59 @@
 from torchfuzz.checks import Check
 
 
+class EagerVsReduceOverheadCheck(Check):
+    """Exercise cudagraph_trees via ``torch.compile(mode="reduce-overhead")``.
+
+    A single call only warms up; cudagraph_trees records on the second call and
+    replays afterwards, so we run several steps (each preceded by
+    ``cudagraph_mark_step_begin``) and compare every step's output against a
+    fresh eager reference. This targets the cudagraph-specific hazards: recording
+    vs replay correctness, cross-step output overwrite/poison, and (with
+    backward) the separate backward cudagraph tree. The numeric check mirrors
+    the sum-relative-diff heuristic used by the standard numerics check so eager
+    vs inductor kernel differences do not cause false positives, while the gross
+    corruption cudagraph bugs produce (stale/overwritten data) is caught.
+    """
+
+    steps = 4
+
+    def codegen(self, args_tuple: str) -> list[str]:
+        return [
+            f"args = {args_tuple}",
+            "out_eager = fuzzed_program(*args)",
+            "out_eager.sum().backward()",
+            "print('✅ eager + backward success')",
+            "ref_sum = out_eager.detach().double().sum()",
+            "compiled_program = torch.compile(",
+            "    fuzzed_program, mode='reduce-overhead', fullgraph=True",
+            ")",
+            f"for _step in range({self.steps}):",
+            "    torch.compiler.cudagraph_mark_step_begin()",
+            "    out_compiled = compiled_program(*args)",
+            "    out_compiled.sum().backward()",
+            "    torch.cuda.synchronize()",
+            "    cur_sum = out_compiled.detach().double().sum()",
+            "    diff = (ref_sum - cur_sum).abs().item()",
+            "    rel = diff / (ref_sum.abs().item() + 1e-12) * 100",
+            "    if rel > 5 and diff > 1:",
+            "        print(",
+            "            f'❌ reduce-overhead step {_step} differs: '",
+            "            f'rel={rel:.6f}% abs={diff} '",
+            "            f'eager={ref_sum.item()} compiled={cur_sum.item()}'",
+            "        )",
+            "        import sys; sys.exit(1)",
+            "print('✅ reduce-overhead multi-step + backward success')",
+            "# Coverage: report whether cudagraphs actually engaged (many programs",
+            "# legitimately skip -- cpu/scalar/mutation/etc -- so this is not fatal).",
+            "try:",
+            "    import torch._inductor.cudagraph_trees as _ct",
+            "    _mgr = _ct.get_container(torch.cuda.current_device()).tree_manager",
+            "    print(f'cudagraphs_engaged: {_mgr is not None}')",
+            "except Exception as _e:",
+            "    print(f'cudagraphs_engaged: unknown ({_e!r})')",
+        ]
+
+
 class EagerVsFullGraphDynamicCompileCheck(Check):
     """Standard check that runs eager then fullgraph+dynamic compilation."""
 

--- a/tools/experimental/torchfuzz/cuda/_codegen.py
+++ b/tools/experimental/torchfuzz/cuda/_codegen.py
@@ -521,6 +521,37 @@ class StreamFuzzTemplate(DefaultFuzzTemplate):
         return new_lines
 
 
+class ReduceOverheadFuzzTemplate(DefaultFuzzTemplate):
+    """Template that exercises cudagraph_trees via mode="reduce-overhead".
+
+    Reuses DefaultFuzzTemplate's operator set but swaps in a check that runs the
+    compiled program for several steps (warmup -> record -> replay) with a
+    backward pass, comparing every step's output to an eager reference. This
+    drives the cudagraph record/replay/checkpoint machinery rather than a single
+    compiled call.
+    """
+
+    def __init__(self):
+        super().__init__()
+        from torchfuzz.cuda._checks import EagerVsReduceOverheadCheck
+
+        self.check = EagerVsReduceOverheadCheck()
+
+    def args_codegen(self, arg_operations, constant_operations=None):
+        """Mark float args requires_grad so the backward tree is exercised."""
+        code_lines = super().args_codegen(arg_operations, constant_operations)
+        if arg_operations:
+            for i, (node_id, spec) in enumerate(arg_operations):
+                if isinstance(spec, TensorSpec) and spec.dtype in [
+                    torch.float32,
+                    torch.float64,
+                    torch.float16,
+                    torch.bfloat16,
+                ]:
+                    code_lines.append(f"arg_{i} = arg_{i}.requires_grad_(True)")
+        return code_lines
+
+
 class DTensorFuzzPlacementsTemplate(DTensorFuzzTemplate):
     """DTensor template with randomized placements (Replicate, Shard, Partial).
 

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -1913,9 +1913,12 @@ class CUDAGraphNode:
         ):
             for i, inp in enumerate(inputs):
                 if not isinstance(inp, torch.Tensor):
-                    if not isinstance(inp, (int, torch.Generator, CustomClassBase)):
+                    if inp is not None and not isinstance(
+                        inp, (int, float, torch.Generator, CustomClassBase)
+                    ):
                         raise AssertionError(
-                            f"expected int, Generator, or CustomClassBase, got {type(inp)}"
+                            "expected Tensor, int, float, Generator, "
+                            f"CustomClassBase, or None, got {type(inp)}"
                         )
 
                     recording_inputs.append(inp)

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -1931,9 +1931,12 @@ class CUDAGraphNode:
         ):
             for i, inp in enumerate(inputs):
                 if not isinstance(inp, torch.Tensor):
-                    if not isinstance(inp, (int, torch.Generator, CustomClassBase)):
+                    if inp is not None and not isinstance(
+                        inp, (int, float, torch.Generator, CustomClassBase)
+                    ):
                         raise AssertionError(
-                            f"expected int, Generator, or CustomClassBase, got {type(inp)}"
+                            "expected Tensor, int, float, Generator, "
+                            f"CustomClassBase, or None, got {type(inp)}"
                         )
 
                     recording_inputs.append(inp)

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -313,6 +313,10 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
         move_constructors_to_gpu
     )
 
+    GraphTransformObserver(gm, "move_scalars_to_cuda").apply_graph_pass(
+        move_scalars_to_gpu
+    )
+
     fake_tensor_updater.incremental_update()
 
     for device, custom_backend_pass in custom_backend_passes.items():
@@ -2519,3 +2523,169 @@ def move_constructors_to_gpu(graph: fx.Graph) -> None:
         allow_inputs=allow_inputs_outputs,
         allow_outputs=allow_inputs_outputs,
     )(graph)
+
+
+_SCALAR_ARITH_TO_ATEN: dict[Any, torch._ops.OpOverload] = {
+    operator.add: torch.ops.aten.add.Tensor,
+    operator.sub: torch.ops.aten.sub.Tensor,
+    operator.mul: torch.ops.aten.mul.Tensor,
+    operator.truediv: torch.ops.aten.div.Tensor,
+}
+
+
+class ScalarToDeviceTensorPass:
+    """
+    Recompute float ``.item()`` scalars as 0-d device tensors.
+
+    A float produced by ``.item()`` on a device tensor and then consumed by a
+    device op reaches the kernel as a launch argument. cudagraphs bake launch
+    arguments in when the graph is recorded, and ``cudagraphify_impl`` keys
+    re-recording on int inputs only, so a replay silently reuses the float
+    captured at record time. Mirroring the scalar expression as 0-d device
+    tensors keeps the value in memory, which every replay re-reads.
+
+    Ints are deliberately left alone: they are symbolic sizes, and the int
+    specialization key already forces a re-record when they change.
+    """
+
+    def __init__(self, target: str) -> None:
+        self.target = target
+        self.fake_mode: Any = None
+        self.mirrored: dict[fx.Node, fx.Node] = {}
+
+    def _is_float_scalar(self, node: fx.Node) -> bool:
+        return isinstance(node.meta.get("val"), (torch.SymFloat, float))
+
+    def _item_source(self, node: fx.Node) -> fx.Node | None:
+        """``.item()`` on a tensor already on the target device -> that tensor."""
+        if node.target is not torch.ops.aten._local_scalar_dense.default:
+            return None
+        src = node.args[0]
+        if not isinstance(src, fx.Node):
+            return None
+        val = src.meta.get("val")
+        if not isinstance(val, torch.Tensor) or val.device.type != self.target:
+            return None
+        return src
+
+    def _build(
+        self, graph: fx.Graph, op: Any, args: tuple[Any, ...], kwargs: Any = None
+    ) -> fx.Node:
+        node = graph.call_function(op, args, kwargs or {})
+        fake_args = pytree.tree_map_only(fx.Node, lambda n: n.meta["val"], args)
+        with self.fake_mode:
+            node.meta["val"] = op(*fake_args, **(kwargs or {}))
+        return node
+
+    def _mirror(self, node: fx.Node) -> fx.Node | None:
+        """0-d float64 device tensor holding the same value as scalar ``node``."""
+        if node in self.mirrored:
+            return self.mirrored[node]
+
+        graph = node.graph
+        src = self._item_source(node)
+        if src is not None:
+            with graph.inserting_after(node):
+                out = self._build(
+                    graph,
+                    torch.ops.prims.convert_element_type.default,
+                    (src, torch.float64),
+                )
+            self.mirrored[node] = out
+            return out
+
+        aten_op = _SCALAR_ARITH_TO_ATEN.get(node.target)
+        if aten_op is None:
+            return None
+
+        # Mirror operands first; each is placed after its own (earlier) scalar
+        # node, so it dominates this one.
+        operands: list[Any] = []
+        for arg in node.args:
+            if isinstance(arg, fx.Node):
+                sub = self._mirror(arg)
+                if sub is None:
+                    return None
+                operands.append(sub)
+            elif isinstance(arg, (int, float)) and not isinstance(arg, bool):
+                operands.append(arg)
+            else:
+                return None
+
+        # Materialize literals and then the op itself, advancing the insertion
+        # anchor so each node is defined before the one that consumes it.
+        anchor = node
+        resolved: list[fx.Node] = []
+        for operand in operands:
+            if isinstance(operand, fx.Node):
+                resolved.append(operand)
+                continue
+            with graph.inserting_after(anchor):
+                const = self._build(
+                    graph,
+                    torch.ops.aten.scalar_tensor.default,
+                    (operand,),
+                    {"dtype": torch.float64, "device": torch.device(self.target)},
+                )
+            anchor = const
+            resolved.append(const)
+
+        with graph.inserting_after(anchor):
+            out = self._build(graph, aten_op, tuple(resolved))
+        self.mirrored[node] = out
+        return out
+
+    def __call__(self, graph: fx.Graph) -> None:
+        for node in graph.nodes:
+            val = node.meta.get("val")
+            if isinstance(val, torch.Tensor) and val.device.type == self.target:
+                self.fake_mode = getattr(val, "fake_mode", None)
+                if self.fake_mode is not None:
+                    break
+        if self.fake_mode is None:
+            return
+
+        for node in list(graph.nodes):
+            if node.op != "call_function" or not isinstance(
+                node.target, torch._ops.OpOverload
+            ):
+                continue
+            val = node.meta.get("val")
+            if not isinstance(val, torch.Tensor):
+                continue
+            if val.device.type != self.target or not val.dtype.is_floating_point:
+                continue
+
+            schema_args = node.target._schema.arguments
+            for idx, arg in enumerate(node.args):
+                if not isinstance(arg, fx.Node) or not self._is_float_scalar(arg):
+                    continue
+                # Only rewrite parameters the schema actually declares as
+                # Tensor; Scalar parameters (full's fill_value, clamp's min)
+                # reject a tensor outright.
+                if idx >= len(schema_args) or str(schema_args[idx].type) != "Tensor":
+                    continue
+                mirror = self._mirror(arg)
+                if mirror is None:
+                    continue
+                # Cast to the consumer's result dtype so type promotion, and
+                # therefore the consumer's output dtype, is unchanged.
+                with graph.inserting_before(node):
+                    cast = self._build(
+                        graph,
+                        torch.ops.prims.convert_element_type.default,
+                        (mirror, val.dtype),
+                    )
+                node.update_arg(idx, cast)
+
+
+def move_scalars_to_gpu(graph: fx.Graph) -> None:
+    """
+    Recompute float ``.item()`` scalars as 0-d device tensors for cudagraphs.
+    """
+    if not (
+        torch._inductor.config.triton.cudagraphs
+        and torch._inductor.config.graph_partition
+    ):
+        return
+    ScalarToDeviceTensorPass(get_gpu_type())(graph)


### PR DESCRIPTION
With `capture_scalar_outputs` set, a graph that materializes a scalar via `.item()` is partitioned for cudagraphs, and inductor threads a `None` or `float` buffer across the partition boundary as a graph input (e.g. partition0_args = [x, y, buf1=None, u0]). The record path in `_allocate_and_copy_recording_inputs` only accepted `Tensor`, `int`, `Generator`, or `OpaqueBase` and raised `AssertionError` on `None` or `float`, even though replay, input copy, and `check_invariants` already tolerate these additional input types. Let `None` and `float` pass through the record path like the other non-tensor inputs.

Fails before the fix with "expected int, Generator, or OpaqueBase, got NoneType"; passes after.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo