### PR TITLE
[Dynamo] Raise error for dynamic shapes in TVM relay path

### DIFF
--- a/test/dynamo/test_backends.py
+++ b/test/dynamo/test_backends.py
@@ -1,4 +1,5 @@
 # Owner(s): ["module: dynamo"]
+import importlib.machinery
 import importlib.util
 import sys
 import unittest
@@ -255,6 +256,30 @@ class TestOptimizations(torch._dynamo.test_case.TestCase):
                 self.assertIs(tvm_backend.tvm(gm, [torch.randn(2)]), sentinel)
             relax.assert_called_once()
             relay.assert_called_once()
+
+    def test_tvm_dynamic_shapes_error(self, device):
+        def fn(x):
+            return x.view(x.size(0), -1) + 1
+
+        x = torch.randn(2, 3, device=device)
+        compiled = torch.compile(fn, backend="tvm", dynamic=True)
+        # stub tvm imports; the error fires before any tvm API is used.
+        # find_spec() reads __spec__ off modules already in sys.modules, so
+        # the relay stub needs a real ModuleSpec to route to the relay path.
+        relay_stub = MagicMock()
+        relay_stub.__spec__ = importlib.machinery.ModuleSpec("tvm.relay", None)
+        stubs = {
+            "tvm": MagicMock(),
+            "tvm.contrib": MagicMock(),
+            "tvm.relay": relay_stub,
+        }
+        with patch.dict(sys.modules, stubs):
+            with self.assertRaisesRegex(
+                torch._dynamo.exc.BackendCompilerFailed,
+                "does not support dynamic shapes",
+            ):
+                compiled(x)
+        torch._dynamo.reset()
 
     @onlyHPU
     def test_intel_gaudi_backend(self, device):

--- a/torch/_dynamo/backends/tvm.py
+++ b/torch/_dynamo/backends/tvm.py
@@ -110,6 +110,16 @@ def _tvm_relay_compile(
     from tvm import relay  # type: ignore[import]
     from tvm.contrib import graph_executor  # type: ignore[import]
 
+    if any(
+        isinstance(x, (torch.SymInt, torch.SymFloat, torch.SymBool))
+        for x in example_inputs
+    ):
+        raise RuntimeError(
+            "The TVM (relay) backend does not support dynamic shapes: got symbolic "
+            "scalar graph inputs. Either compile with dynamic=False or use TVM's "
+            "relax frontend instead: from tvm.relax.frontend.torch import relax_dynamo; "
+            "torch.compile(model, backend=relax_dynamo())."
+        )
     jit_mod = torch.jit.trace(gm, example_inputs)
     device = device_from_inputs(example_inputs)
     shape_list = [(f"inp_{idx}", i.shape) for idx, i in enumerate(example_inputs)]


### PR DESCRIPTION
## Related Issue

closes #169111

## Why

With `dynamic=True`, Dynamo passes SymInt scalars as graph inputs, and the tvm backend feeds them straight into `torch.jit.trace`, which fails with a cryptic `Tracer cannot infer type ... got value of type SymInt` error. The relay path is trace-based and cannot support dynamic shapes.

## How

- Detect symbolic scalar inputs right before `torch.jit.trace` and raise an actionable error pointing users to `dynamic=False` or TVM's relax frontend
- Add `test_tvm_dynamic_shapes_error`, which stubs tvm in `sys.modules` so it runs with or without a tvm install

The check sits on the trace path so it will not block the relax dispatch added in #189010.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98