### PR TITLE
[inductor] Decompose broadcast-bias baddbmm before pointwise

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -1534,9 +1534,7 @@ class TestPatternMatcher(TestCase):
         actual, (code) = run_and_get_code(fn3, args[0], args[1], args[2])
         expanded_bias = args[0].expand(4, 6, 8)
         self.assertEqual(expanded_bias.stride(1), 0)
-        self.assertEqual(
-            actual, torch.baddbmm(expanded_bias, args[1], args[2]).relu()
-        )
+        self.assertEqual(actual, torch.baddbmm(expanded_bias, args[1], args[2]).relu())
         FileCheck().check_not("extern_kernels.baddbmm(").check(
             "extern_kernels.bmm("
         ).run(code[0])

--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -1501,6 +1501,68 @@ class TestPatternMatcher(TestCase):
         _, (code) = run_and_get_code(fn2, args[0], args[1], args[2])
         FileCheck().check_not("extern_kernels.addmm(").run(code[0])
 
+    def test_unfuse_broadcast_bias_baddbmm(self):
+        args = [
+            torch.randn(4, 1, 8, device=GPU_TYPE),
+            torch.randn(4, 6, 5, device=GPU_TYPE),
+            torch.randn(4, 5, 8, device=GPU_TYPE),
+        ]
+
+        @torch.compile()
+        def fn(inp, a, b):
+            return torch.ops.aten.baddbmm(inp, a, b)
+
+        actual, (code) = run_and_get_code(fn, args[0], args[1], args[2])
+        self.assertEqual(actual, torch.baddbmm(*args))
+        FileCheck().check("extern_kernels.baddbmm(").run(code[0])
+
+        @torch.compile()
+        def fn2(inp, a, b):
+            return torch.nn.functional.gelu(torch.ops.aten.baddbmm(inp, a, b))
+
+        actual, (code) = run_and_get_code(fn2, args[0], args[1], args[2])
+        self.assertEqual(actual, torch.nn.functional.gelu(torch.baddbmm(*args)))
+        FileCheck().check_not("extern_kernels.baddbmm(").check(
+            "extern_kernels.bmm("
+        ).run(code[0])
+
+        @torch.compile()
+        def fn3(inp, a, b):
+            inp = inp.expand(4, 6, 8)
+            return torch.ops.aten.baddbmm(inp, a, b).relu()
+
+        actual, (code) = run_and_get_code(fn3, args[0], args[1], args[2])
+        expanded_bias = args[0].expand(4, 6, 8)
+        self.assertEqual(expanded_bias.stride(1), 0)
+        self.assertEqual(
+            actual, torch.baddbmm(expanded_bias, args[1], args[2]).relu()
+        )
+        FileCheck().check_not("extern_kernels.baddbmm(").check(
+            "extern_kernels.bmm("
+        ).run(code[0])
+
+    def test_unfuse_broadcast_bias_baddbmm_alpha_beta(self):
+        args = [
+            torch.randn(4, 1, 8, device=GPU_TYPE),
+            torch.randn(4, 6, 5, device=GPU_TYPE),
+            torch.randn(4, 5, 8, device=GPU_TYPE),
+        ]
+
+        @torch.compile()
+        def fn(inp, a, b):
+            return torch.nn.functional.relu(
+                torch.ops.aten.baddbmm(inp, a, b, alpha=0.8, beta=0.2)
+            )
+
+        actual, (code) = run_and_get_code(fn, args[0], args[1], args[2])
+        expected = torch.nn.functional.relu(
+            torch.baddbmm(args[0], args[1], args[2], alpha=0.8, beta=0.2)
+        )
+        self.assertEqual(actual, expected)
+        FileCheck().check_not("extern_kernels.baddbmm(").check(
+            "extern_kernels.bmm("
+        ).run(code[0])
+
     def test_preserve_accumulator_addmm_with_pointwise(self):
         args = [
             torch.randn(10, 20, device=GPU_TYPE),

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -1887,6 +1887,21 @@ def unfuse_bias_add_to_pointwise(match: Match, mat1, mat2, *, inp, alpha, beta):
     extra_check=should_prefer_unfused_baddbmm,
 )
 def unfuse_bias_baddbmm_to_pointwise(match: Match, mat1, mat2, *, inp, alpha, beta):
+    if config.keep_addmm_fused_for_half_dtypes and inp.meta["val"].dtype in (
+        torch.bfloat16,
+        torch.float16,
+    ):
+        if inp.meta["val"].device.type != "xpu":
+            return
+        if not (
+            inp.op == "call_function"
+            and inp.target is torch.ops.prims.convert_element_type.default
+            and inp.args[0].meta["val"].dtype.is_floating_point
+            and torch.finfo(inp.args[0].meta["val"].dtype).bits
+            > torch.finfo(inp.meta["val"].dtype).bits
+        ):
+            return
+
     def repl(inp, x1, x2, alpha, beta):
         bmm_result = torch.bmm(x1, x2)
         if alpha != 1:

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -1818,6 +1818,17 @@ def should_prefer_unfused_addmm(match):
     return all(is_pointwise_use(use) for use in output.users)
 
 
+def should_prefer_unfused_baddbmm(match):
+    inp = match.kwargs["inp"]
+    if not is_gpu(inp.meta["val"].device.type):
+        return False
+
+    output = match.output_node()
+    if not _is_bias_like_addmm_input(inp, output):
+        return False
+    return all(is_pointwise_use(use) for use in output.users)
+
+
 @register_graph_pattern(
     CallFunction(
         aten.addmm,
@@ -1857,6 +1868,32 @@ def unfuse_bias_add_to_pointwise(match: Match, mat1, mat2, *, inp, alpha, beta):
         if beta != 1:
             inp = beta * inp
         return inp + mm_result
+
+    # pyrefly: ignore [bad-argument-type]
+    match.replace_by_example(repl, [inp, mat1, mat2, alpha, beta])
+
+
+@register_graph_pattern(
+    CallFunction(
+        aten.baddbmm,
+        KeywordArg("inp"),
+        Arg(),
+        Arg(),
+        beta=KeywordArg("beta"),
+        alpha=KeywordArg("alpha"),
+    ),
+    # pyrefly: ignore [bad-argument-type]
+    pass_dict=pass_patterns[2],
+    extra_check=should_prefer_unfused_baddbmm,
+)
+def unfuse_bias_baddbmm_to_pointwise(match: Match, mat1, mat2, *, inp, alpha, beta):
+    def repl(inp, x1, x2, alpha, beta):
+        bmm_result = torch.bmm(x1, x2)
+        if alpha != 1:
+            bmm_result = alpha * bmm_result
+        if beta != 1:
+            inp = beta * inp
+        return inp + bmm_result
 
     # pyrefly: ignore [bad-argument-type]
     match.replace_by_example(repl, [inp, mat1, mat2, alpha, beta])


### PR DESCRIPTION
Fixes #187093.

## Summary
- Extend the existing addmm bias-unfuse post-grad pattern to broadcast-bias `baddbmm`.
- Only rewrite on GPU when the `baddbmm` input is bias-like or broadcast and all users are pointwise.
- Preserve standalone `baddbmm`, explicit stride-0 expanded bias, and alpha/beta semantics.
- Let the decomposed `bmm + bias` form expose the bias add to normal pointwise fusion.

## Test Plan
- `python -m py_compile torch/_inductor/fx_passes/post_grad.py test/inductor/test_pattern_matcher.py`
- `git diff --check`
- Attempted: `python test/inductor/test_pattern_matcher.py -k "unfuse_broadcast_bias_baddbmm" -v`
  - Blocked because it imported installed `torch==2.5.1+cu121` and hit stale API drift.
- Attempted: `PYTHONPATH=. python test/inductor/test_pattern_matcher.py -k "unfuse_broadcast_bias_baddbmm" -v`
  - Blocked because this checkout is unbuilt and missing generated `torch/version.py`.
- `spin`/`lintrunner` not run locally: neither tool is installed and no local `.venv` was present.

AI-assisted-by: OpenAI Codex

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo