### PR TITLE
Gil acquire bool conversion

### DIFF
--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -394,12 +394,19 @@ namespace detail {
 // exception and reports success via the bool conversion -- check it before
 // touching any GIL-dependent Python API.
 //
-// If the interpreter is finalizing, disarm() so our destructor skips
-// PyThreadState_DeleteCurrent: thread-state deletion isn't allowed during
-// shutdown (see gil_scoped_acquire::disarm()'s own comment).
+// Finalization can start at any point, so no single check fully closes the
+// race; checking both ends narrows it to just the acquire call itself.
+// Checked before: skip the attempt outright rather than run acquisition
+// machinery we know is unsafe mid-shutdown. Checked after: finalization may
+// have started during the acquire, so disarm() there too, so our destructor
+// skips PyThreadState_DeleteCurrent (thread-state deletion isn't allowed
+// during shutdown; see gil_scoped_acquire::disarm()'s own comment).
 class SafeGilScopedAcquire {
  public:
   SafeGilScopedAcquire() {
+    if (Py_IsFinalizing()) {
+      return;
+    }
     try {
       guard_.emplace();
     } catch (const std::exception& e) {

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -389,22 +389,14 @@ struct PyWarningHandler {
 
 namespace detail {
 
-// pybind11::gil_scoped_acquire's constructor can throw (e.g. if creating a
-// new Python thread state fails). Callers reachable from noexcept contexts
-// (destructors, refcount-management callbacks) must use this instead of
-// pybind11::gil_scoped_acquire directly, since an exception escaping a
-// noexcept function calls std::terminate. Check the bool conversion before
-// touching any Python API that requires the GIL; if it's false, the GIL
-// could not be acquired and the caller must leak rather than touch
-// refcounts without holding it.
+// Acquiring the GIL can throw; letting that escape a noexcept context
+// (destructors, refcount callbacks) calls std::terminate. This catches the
+// exception and reports success via the bool conversion -- check it before
+// touching any GIL-dependent Python API.
 //
-// NB: deliberately still uses the default (not _simple) gil_scoped_acquire.
-// gil_scoped_acquire_simple (PyGILState_Ensure) inherits CPython's behavior
-// of hanging or killing a non-main thread that acquires the GIL during
-// interpreter finalization -- exactly what the default gil_scoped_acquire
-// was built to avoid (see its own comment in pybind11/gil.h). Since these
-// callers commonly run during exit-handler teardown, that tradeoff would
-// replace a rare, loud crash with a more likely, silent hang.
+// If the interpreter is finalizing, disarm() so our destructor skips
+// PyThreadState_DeleteCurrent: thread-state deletion isn't allowed during
+// shutdown (see gil_scoped_acquire::disarm()'s own comment).
 class SafeGilScopedAcquire {
  public:
   SafeGilScopedAcquire() {
@@ -412,6 +404,10 @@ class SafeGilScopedAcquire {
       guard_.emplace();
     } catch (const std::exception& e) {
       LOG(ERROR) << "Failed to acquire the GIL: " << e.what();
+      return;
+    }
+    if (Py_IsFinalizing()) {
+      guard_->disarm();
     }
   }
   explicit operator bool() const {

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -390,17 +390,13 @@ struct PyWarningHandler {
 namespace detail {
 
 // Acquiring the GIL can throw; letting that escape a noexcept context
-// (destructors, refcount callbacks) calls std::terminate. This catches the
-// exception and reports success via the bool conversion -- check it before
-// touching any GIL-dependent Python API.
+// (destructors, refcount callbacks) calls std::terminate. Catches it and
+// reports success via the bool conversion -- check before touching any
+// GIL-dependent Python API.
 //
-// Finalization can start at any point, so no single check fully closes the
-// race; checking both ends narrows it to just the acquire call itself.
-// Checked before: skip the attempt outright rather than run acquisition
-// machinery we know is unsafe mid-shutdown. Checked after: finalization may
-// have started during the acquire, so disarm() there too, so our destructor
-// skips PyThreadState_DeleteCurrent (thread-state deletion isn't allowed
-// during shutdown; see gil_scoped_acquire::disarm()'s own comment).
+// Finalization can start at any point, so this checks Py_IsFinalizing both
+// before acquiring (skip outright) and after (disarm(), since thread-state
+// deletion isn't allowed mid-shutdown).
 class SafeGilScopedAcquire {
  public:
   SafeGilScopedAcquire() {

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -2,12 +2,14 @@
 
 #include <exception>
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <system_error>
 
 #include <ATen/detail/FunctionTraits.h>
 #include <c10/util/Exception.h>
+#include <c10/util/Logging.h>
 #include <c10/util/StringUtil.h>
 #include <pybind11/pybind11.h>
 #include <torch/csrc/Export.h>
@@ -386,6 +388,37 @@ struct PyWarningHandler {
 };
 
 namespace detail {
+
+// pybind11::gil_scoped_acquire's constructor can throw (e.g. if creating a
+// new Python thread state fails). Callers reachable from noexcept contexts
+// (destructors, refcount-management callbacks) must use this instead of
+// pybind11::gil_scoped_acquire directly, since an exception escaping a
+// noexcept function calls std::terminate. Check acquired() before touching
+// any Python API that requires the GIL.
+//
+// NB: deliberately still uses the default (not _simple) gil_scoped_acquire.
+// gil_scoped_acquire_simple (PyGILState_Ensure) inherits CPython's behavior
+// of hanging or killing a non-main thread that acquires the GIL during
+// interpreter finalization -- exactly what the default gil_scoped_acquire
+// was built to avoid (see its own comment in pybind11/gil.h). Since these
+// callers commonly run during exit-handler teardown, that tradeoff would
+// replace a rare, loud crash with a more likely, silent hang.
+class SafeGilScopedAcquire {
+ public:
+  SafeGilScopedAcquire() {
+    try {
+      guard_.emplace();
+    } catch (const std::exception& e) {
+      LOG(ERROR) << "Failed to acquire the GIL: " << e.what();
+    }
+  }
+  bool acquired() const {
+    return guard_.has_value();
+  }
+
+ private:
+  std::optional<pybind11::gil_scoped_acquire> guard_;
+};
 
 struct noop_gil_scoped_release {
   // user-defined constructor (i.e. not defaulted) to avoid

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -392,7 +392,10 @@ namespace detail {
 // Acquiring the GIL can throw; letting that escape a noexcept context
 // (destructors, refcount callbacks) calls std::terminate. Catches it and
 // reports success via the bool conversion -- check before touching any
-// GIL-dependent Python API.
+// GIL-dependent Python API. Also owns the rest of "is it safe to touch
+// Python right now": skips acquiring entirely if Python was never
+// initialized or has already fully finalized, so callers don't each need
+// their own Py_IsInitialized()/Py_IsFinalizing() guard.
 //
 // Finalization can start at any point, so this checks Py_IsFinalizing both
 // before acquiring (skip outright) and after (disarm(), since thread-state
@@ -400,7 +403,7 @@ namespace detail {
 class SafeGilScopedAcquire {
  public:
   SafeGilScopedAcquire() {
-    if (Py_IsFinalizing()) {
+    if (!Py_IsInitialized() || Py_IsFinalizing()) {
       return;
     }
     try {

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -393,8 +393,10 @@ namespace detail {
 // new Python thread state fails). Callers reachable from noexcept contexts
 // (destructors, refcount-management callbacks) must use this instead of
 // pybind11::gil_scoped_acquire directly, since an exception escaping a
-// noexcept function calls std::terminate. Check acquired() before touching
-// any Python API that requires the GIL.
+// noexcept function calls std::terminate. Check the bool conversion before
+// touching any Python API that requires the GIL; if it's false, the GIL
+// could not be acquired and the caller must leak rather than touch
+// refcounts without holding it.
 //
 // NB: deliberately still uses the default (not _simple) gil_scoped_acquire.
 // gil_scoped_acquire_simple (PyGILState_Ensure) inherits CPython's behavior
@@ -412,7 +414,7 @@ class SafeGilScopedAcquire {
       LOG(ERROR) << "Failed to acquire the GIL: " << e.what();
     }
   }
-  bool acquired() const {
+  explicit operator bool() const {
     return guard_.has_value();
   }
 

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -342,22 +342,14 @@ struct PyWarningHandler {
 
 namespace detail {
 
-// pybind11::gil_scoped_acquire's constructor can throw (e.g. if creating a
-// new Python thread state fails). Callers reachable from noexcept contexts
-// (destructors, refcount-management callbacks) must use this instead of
-// pybind11::gil_scoped_acquire directly, since an exception escaping a
-// noexcept function calls std::terminate. Check the bool conversion before
-// touching any Python API that requires the GIL; if it's false, the GIL
-// could not be acquired and the caller must leak rather than touch
-// refcounts without holding it.
+// Acquiring the GIL can throw; letting that escape a noexcept context
+// (destructors, refcount callbacks) calls std::terminate. This catches the
+// exception and reports success via the bool conversion -- check it before
+// touching any GIL-dependent Python API.
 //
-// NB: deliberately still uses the default (not _simple) gil_scoped_acquire.
-// gil_scoped_acquire_simple (PyGILState_Ensure) inherits CPython's behavior
-// of hanging or killing a non-main thread that acquires the GIL during
-// interpreter finalization -- exactly what the default gil_scoped_acquire
-// was built to avoid (see its own comment in pybind11/gil.h). Since these
-// callers commonly run during exit-handler teardown, that tradeoff would
-// replace a rare, loud crash with a more likely, silent hang.
+// If the interpreter is finalizing, disarm() so our destructor skips
+// PyThreadState_DeleteCurrent: thread-state deletion isn't allowed during
+// shutdown (see gil_scoped_acquire::disarm()'s own comment).
 class SafeGilScopedAcquire {
  public:
   SafeGilScopedAcquire() {
@@ -365,6 +357,10 @@ class SafeGilScopedAcquire {
       guard_.emplace();
     } catch (const std::exception& e) {
       LOG(ERROR) << "Failed to acquire the GIL: " << e.what();
+      return;
+    }
+    if (Py_IsFinalizing()) {
+      guard_->disarm();
     }
   }
   explicit operator bool() const {

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -3,11 +3,13 @@
 
 #include <exception>
 #include <memory>
+#include <optional>
 #include <string>
 #include <system_error>
 
 #include <ATen/detail/FunctionTraits.h>
 #include <c10/util/Exception.h>
+#include <c10/util/Logging.h>
 #include <c10/util/StringUtil.h>
 #include <pybind11/pybind11.h>
 #include <torch/csrc/Export.h>
@@ -339,6 +341,37 @@ struct PyWarningHandler {
 };
 
 namespace detail {
+
+// pybind11::gil_scoped_acquire's constructor can throw (e.g. if creating a
+// new Python thread state fails). Callers reachable from noexcept contexts
+// (destructors, refcount-management callbacks) must use this instead of
+// pybind11::gil_scoped_acquire directly, since an exception escaping a
+// noexcept function calls std::terminate. Check acquired() before touching
+// any Python API that requires the GIL.
+//
+// NB: deliberately still uses the default (not _simple) gil_scoped_acquire.
+// gil_scoped_acquire_simple (PyGILState_Ensure) inherits CPython's behavior
+// of hanging or killing a non-main thread that acquires the GIL during
+// interpreter finalization -- exactly what the default gil_scoped_acquire
+// was built to avoid (see its own comment in pybind11/gil.h). Since these
+// callers commonly run during exit-handler teardown, that tradeoff would
+// replace a rare, loud crash with a more likely, silent hang.
+class SafeGilScopedAcquire {
+ public:
+  SafeGilScopedAcquire() {
+    try {
+      guard_.emplace();
+    } catch (const std::exception& e) {
+      LOG(ERROR) << "Failed to acquire the GIL: " << e.what();
+    }
+  }
+  bool acquired() const {
+    return guard_.has_value();
+  }
+
+ private:
+  std::optional<pybind11::gil_scoped_acquire> guard_;
+};
 
 struct noop_gil_scoped_release {
   // user-defined constructor (i.e. not defaulted) to avoid

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -347,12 +347,19 @@ namespace detail {
 // exception and reports success via the bool conversion -- check it before
 // touching any GIL-dependent Python API.
 //
-// If the interpreter is finalizing, disarm() so our destructor skips
-// PyThreadState_DeleteCurrent: thread-state deletion isn't allowed during
-// shutdown (see gil_scoped_acquire::disarm()'s own comment).
+// Finalization can start at any point, so no single check fully closes the
+// race; checking both ends narrows it to just the acquire call itself.
+// Checked before: skip the attempt outright rather than run acquisition
+// machinery we know is unsafe mid-shutdown. Checked after: finalization may
+// have started during the acquire, so disarm() there too, so our destructor
+// skips PyThreadState_DeleteCurrent (thread-state deletion isn't allowed
+// during shutdown; see gil_scoped_acquire::disarm()'s own comment).
 class SafeGilScopedAcquire {
  public:
   SafeGilScopedAcquire() {
+    if (Py_IsFinalizing()) {
+      return;
+    }
     try {
       guard_.emplace();
     } catch (const std::exception& e) {

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -346,8 +346,10 @@ namespace detail {
 // new Python thread state fails). Callers reachable from noexcept contexts
 // (destructors, refcount-management callbacks) must use this instead of
 // pybind11::gil_scoped_acquire directly, since an exception escaping a
-// noexcept function calls std::terminate. Check acquired() before touching
-// any Python API that requires the GIL.
+// noexcept function calls std::terminate. Check the bool conversion before
+// touching any Python API that requires the GIL; if it's false, the GIL
+// could not be acquired and the caller must leak rather than touch
+// refcounts without holding it.
 //
 // NB: deliberately still uses the default (not _simple) gil_scoped_acquire.
 // gil_scoped_acquire_simple (PyGILState_Ensure) inherits CPython's behavior
@@ -365,7 +367,7 @@ class SafeGilScopedAcquire {
       LOG(ERROR) << "Failed to acquire the GIL: " << e.what();
     }
   }
-  bool acquired() const {
+  explicit operator bool() const {
     return guard_.has_value();
   }
 

--- a/torch/csrc/PyInterpreter.cpp
+++ b/torch/csrc/PyInterpreter.cpp
@@ -1,5 +1,6 @@
 #include <ATen/core/PythonFallbackKernel.h>
 #include <ATen/core/PythonOpRegistrationTrampoline.h>
+#include <torch/csrc/Exceptions.h>
 #include <torch/csrc/PyInterpreter.h>
 #include <torch/csrc/THP.h>
 #include <torch/csrc/utils/python_arg_parser.h>
@@ -239,14 +240,24 @@ void ConcretePyInterpreterVTable::decref(PyObject* pyobj) const {
   // PyObjects stored in them.
   if (!Py_IsInitialized())
     return;
-  pybind11::gil_scoped_acquire gil;
+  // decref/incref/try_incref/refcnt are reachable from noexcept callers, so
+  // they must use SafeGilScopedAcquire (see its comment) rather than a bare
+  // pybind11::gil_scoped_acquire.
+  torch::detail::SafeGilScopedAcquire gil;
+  if (!gil.acquired()) {
+    // Leak pyobj rather than touch its refcount without the GIL held.
+    return;
+  }
   Py_DECREF(pyobj);
 }
 
 void ConcretePyInterpreterVTable::incref(PyObject* pyobj) const {
   if (!Py_IsInitialized())
     return;
-  pybind11::gil_scoped_acquire gil;
+  torch::detail::SafeGilScopedAcquire gil;
+  if (!gil.acquired()) {
+    return;
+  }
   Py_INCREF(pyobj);
 }
 
@@ -254,7 +265,10 @@ bool ConcretePyInterpreterVTable::try_incref(
     const c10::impl::PyObjectSlot& pyobj_slot) const {
   if (!Py_IsInitialized())
     return false;
-  pybind11::gil_scoped_acquire gil;
+  torch::detail::SafeGilScopedAcquire gil;
+  if (!gil.acquired()) {
+    return false;
+  }
   PyObject* pyobj = pyobj_slot.load_pyobj();
   if (!pyobj) {
     return false;
@@ -265,7 +279,10 @@ bool ConcretePyInterpreterVTable::try_incref(
 size_t ConcretePyInterpreterVTable::refcnt(PyObject* pyobj) const {
   if (!Py_IsInitialized() || pyobj == nullptr)
     return 0;
-  pybind11::gil_scoped_acquire gil;
+  torch::detail::SafeGilScopedAcquire gil;
+  if (!gil.acquired()) {
+    return 0;
+  }
   return Py_REFCNT(pyobj);
 }
 

--- a/torch/csrc/PyInterpreter.cpp
+++ b/torch/csrc/PyInterpreter.cpp
@@ -235,11 +235,9 @@ py::object torchDispatchFromTensorImpl(
 }
 
 void ConcretePyInterpreterVTable::decref(PyObject* pyobj) const {
-  // Leak the pyobj if not initialized.  This can happen if we are running
-  // exit handlers that are destructing tensors with residual (owned)
-  // PyObjects stored in them.
-  if (!Py_IsInitialized())
-    return;
+  // Leak the pyobj if the GIL can't be acquired (e.g. Python isn't
+  // initialized).  This can happen if we are running exit handlers that are
+  // destructing tensors with residual (owned) PyObjects stored in them.
   torch::detail::SafeGilScopedAcquire gil;
   if (!gil) {
     return;
@@ -248,8 +246,6 @@ void ConcretePyInterpreterVTable::decref(PyObject* pyobj) const {
 }
 
 void ConcretePyInterpreterVTable::incref(PyObject* pyobj) const {
-  if (!Py_IsInitialized())
-    return;
   torch::detail::SafeGilScopedAcquire gil;
   if (!gil) {
     return;
@@ -259,8 +255,6 @@ void ConcretePyInterpreterVTable::incref(PyObject* pyobj) const {
 
 bool ConcretePyInterpreterVTable::try_incref(
     const c10::impl::PyObjectSlot& pyobj_slot) const {
-  if (!Py_IsInitialized())
-    return false;
   torch::detail::SafeGilScopedAcquire gil;
   if (!gil) {
     return false;
@@ -273,7 +267,7 @@ bool ConcretePyInterpreterVTable::try_incref(
 }
 
 size_t ConcretePyInterpreterVTable::refcnt(PyObject* pyobj) const {
-  if (!Py_IsInitialized() || pyobj == nullptr)
+  if (pyobj == nullptr)
     return 0;
   torch::detail::SafeGilScopedAcquire gil;
   if (!gil) {

--- a/torch/csrc/PyInterpreter.cpp
+++ b/torch/csrc/PyInterpreter.cpp
@@ -244,8 +244,7 @@ void ConcretePyInterpreterVTable::decref(PyObject* pyobj) const {
   // they must use SafeGilScopedAcquire (see its comment) rather than a bare
   // pybind11::gil_scoped_acquire.
   torch::detail::SafeGilScopedAcquire gil;
-  if (!gil.acquired()) {
-    // Leak pyobj rather than touch its refcount without the GIL held.
+  if (!gil) {
     return;
   }
   Py_DECREF(pyobj);
@@ -255,7 +254,7 @@ void ConcretePyInterpreterVTable::incref(PyObject* pyobj) const {
   if (!Py_IsInitialized())
     return;
   torch::detail::SafeGilScopedAcquire gil;
-  if (!gil.acquired()) {
+  if (!gil) {
     return;
   }
   Py_INCREF(pyobj);
@@ -266,7 +265,7 @@ bool ConcretePyInterpreterVTable::try_incref(
   if (!Py_IsInitialized())
     return false;
   torch::detail::SafeGilScopedAcquire gil;
-  if (!gil.acquired()) {
+  if (!gil) {
     return false;
   }
   PyObject* pyobj = pyobj_slot.load_pyobj();
@@ -280,7 +279,7 @@ size_t ConcretePyInterpreterVTable::refcnt(PyObject* pyobj) const {
   if (!Py_IsInitialized() || pyobj == nullptr)
     return 0;
   torch::detail::SafeGilScopedAcquire gil;
-  if (!gil.acquired()) {
+  if (!gil) {
     return 0;
   }
   return Py_REFCNT(pyobj);

--- a/torch/csrc/PyInterpreter.cpp
+++ b/torch/csrc/PyInterpreter.cpp
@@ -240,9 +240,6 @@ void ConcretePyInterpreterVTable::decref(PyObject* pyobj) const {
   // PyObjects stored in them.
   if (!Py_IsInitialized())
     return;
-  // decref/incref/try_incref/refcnt are reachable from noexcept callers, so
-  // they must use SafeGilScopedAcquire (see its comment) rather than a bare
-  // pybind11::gil_scoped_acquire.
   torch::detail::SafeGilScopedAcquire gil;
   if (!gil) {
     return;

--- a/torch/csrc/PyInterpreter.cpp
+++ b/torch/csrc/PyInterpreter.cpp
@@ -244,9 +244,6 @@ void ConcretePyInterpreterVTable::decref(PyObject* pyobj) const {
   // PyObjects stored in them.
   if (!Py_IsInitialized())
     return;
-  // decref/incref/try_incref/refcnt are reachable from noexcept callers, so
-  // they must use SafeGilScopedAcquire (see its comment) rather than a bare
-  // pybind11::gil_scoped_acquire.
   torch::detail::SafeGilScopedAcquire gil;
   if (!gil) {
     return;

--- a/torch/csrc/PyInterpreter.cpp
+++ b/torch/csrc/PyInterpreter.cpp
@@ -1,5 +1,6 @@
 #include <ATen/core/PythonFallbackKernel.h>
 #include <ATen/core/PythonOpRegistrationTrampoline.h>
+#include <torch/csrc/Exceptions.h>
 #include <torch/csrc/PyInterpreter.h>
 #include <torch/csrc/THP.h>
 #include <torch/csrc/autograd/generated/VariableType.h>
@@ -243,14 +244,24 @@ void ConcretePyInterpreterVTable::decref(PyObject* pyobj) const {
   // PyObjects stored in them.
   if (!Py_IsInitialized())
     return;
-  pybind11::gil_scoped_acquire gil;
+  // decref/incref/try_incref/refcnt are reachable from noexcept callers, so
+  // they must use SafeGilScopedAcquire (see its comment) rather than a bare
+  // pybind11::gil_scoped_acquire.
+  torch::detail::SafeGilScopedAcquire gil;
+  if (!gil.acquired()) {
+    // Leak pyobj rather than touch its refcount without the GIL held.
+    return;
+  }
   Py_DECREF(pyobj);
 }
 
 void ConcretePyInterpreterVTable::incref(PyObject* pyobj) const {
   if (!Py_IsInitialized())
     return;
-  pybind11::gil_scoped_acquire gil;
+  torch::detail::SafeGilScopedAcquire gil;
+  if (!gil.acquired()) {
+    return;
+  }
   Py_INCREF(pyobj);
 }
 
@@ -258,7 +269,10 @@ bool ConcretePyInterpreterVTable::try_incref(
     const c10::impl::PyObjectSlot& pyobj_slot) const {
   if (!Py_IsInitialized())
     return false;
-  pybind11::gil_scoped_acquire gil;
+  torch::detail::SafeGilScopedAcquire gil;
+  if (!gil.acquired()) {
+    return false;
+  }
   PyObject* pyobj = pyobj_slot.load_pyobj();
   if (!pyobj) {
     return false;
@@ -269,7 +283,10 @@ bool ConcretePyInterpreterVTable::try_incref(
 size_t ConcretePyInterpreterVTable::refcnt(PyObject* pyobj) const {
   if (!Py_IsInitialized() || pyobj == nullptr)
     return 0;
-  pybind11::gil_scoped_acquire gil;
+  torch::detail::SafeGilScopedAcquire gil;
+  if (!gil.acquired()) {
+    return 0;
+  }
   return Py_REFCNT(pyobj);
 }
 

--- a/torch/csrc/PyInterpreter.cpp
+++ b/torch/csrc/PyInterpreter.cpp
@@ -248,8 +248,7 @@ void ConcretePyInterpreterVTable::decref(PyObject* pyobj) const {
   // they must use SafeGilScopedAcquire (see its comment) rather than a bare
   // pybind11::gil_scoped_acquire.
   torch::detail::SafeGilScopedAcquire gil;
-  if (!gil.acquired()) {
-    // Leak pyobj rather than touch its refcount without the GIL held.
+  if (!gil) {
     return;
   }
   Py_DECREF(pyobj);
@@ -259,7 +258,7 @@ void ConcretePyInterpreterVTable::incref(PyObject* pyobj) const {
   if (!Py_IsInitialized())
     return;
   torch::detail::SafeGilScopedAcquire gil;
-  if (!gil.acquired()) {
+  if (!gil) {
     return;
   }
   Py_INCREF(pyobj);
@@ -270,7 +269,7 @@ bool ConcretePyInterpreterVTable::try_incref(
   if (!Py_IsInitialized())
     return false;
   torch::detail::SafeGilScopedAcquire gil;
-  if (!gil.acquired()) {
+  if (!gil) {
     return false;
   }
   PyObject* pyobj = pyobj_slot.load_pyobj();
@@ -284,7 +283,7 @@ size_t ConcretePyInterpreterVTable::refcnt(PyObject* pyobj) const {
   if (!Py_IsInitialized() || pyobj == nullptr)
     return 0;
   torch::detail::SafeGilScopedAcquire gil;
-  if (!gil.acquired()) {
+  if (!gil) {
     return 0;
   }
   return Py_REFCNT(pyobj);

--- a/torch/csrc/autograd/profiler_python.cpp
+++ b/torch/csrc/autograd/profiler_python.cpp
@@ -23,6 +23,7 @@
 #include <c10/util/Semaphore.h>
 #include <c10/util/flat_hash_map.h>
 #include <c10/util/irange.h>
+#include <torch/csrc/Exceptions.h>
 #include <torch/csrc/autograd/python_variable.h>
 #include <torch/csrc/profiler/collection.h>
 #include <torch/csrc/profiler/containers.h>
@@ -690,7 +691,6 @@ static PyObject* c_call_callback(
 class PythonTracer final : public python_tracer::PythonTracerBase {
  public:
   PythonTracer(torch::profiler::impl::RecordQueue* queue);
-  // NOLINTNEXTLINE(bugprone-exception-escape)
   ~PythonTracer() override;
 
   static int pyProfileFn(
@@ -1212,16 +1212,16 @@ void PythonTracer::restart() {
 #endif
 }
 
-// NOLINTNEXTLINE(bugprone-exception-escape)
 PythonTracer::~PythonTracer() {
   if (active_) {
     TORCH_WARN("`PythonTracer::stop()` was not called.");
     stop();
   }
-  if (Py_IsInitialized() && !Py_IsFinalizing()) {
-    pybind11::gil_scoped_acquire gil;
-    Py_XDECREF((PyObject*)shared_ctx_);
+  torch::detail::SafeGilScopedAcquire gil;
+  if (!gil) {
+    return;
   }
+  Py_XDECREF((PyObject*)shared_ctx_);
 }
 
 void PythonTracer::recordPyCall(

--- a/torch/csrc/autograd/python_anomaly_mode.h
+++ b/torch/csrc/autograd/python_anomaly_mode.h
@@ -18,13 +18,13 @@ struct PyAnomalyMetadata : public AnomalyMetadata {
     dict_ = PyDict_New();
   }
   ~PyAnomalyMetadata() override {
-    // If python is already dead, leak the wrapped python objects
-    if (Py_IsInitialized()) {
-      torch::detail::SafeGilScopedAcquire gil;
-      if (gil) {
-        Py_DECREF(dict_);
-      }
+    // Leak the wrapped python object if the GIL can't be acquired (e.g.
+    // python is already dead).
+    torch::detail::SafeGilScopedAcquire gil;
+    if (!gil) {
+      return;
     }
+    Py_DECREF(dict_);
   }
   void store_stack() override;
   void print_stack(const std::string& current_node_name) override;

--- a/torch/csrc/autograd/python_anomaly_mode.h
+++ b/torch/csrc/autograd/python_anomaly_mode.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <pybind11/pybind11.h>
+#include <torch/csrc/Exceptions.h>
 #include <torch/csrc/autograd/anomaly_mode.h>
 #include <torch/csrc/python_headers.h>
 #include <torch/csrc/utils/pybind.h>
@@ -16,12 +17,13 @@ struct PyAnomalyMetadata : public AnomalyMetadata {
     // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
     dict_ = PyDict_New();
   }
-  // NOLINTNEXTLINE(bugprone-exception-escape)
   ~PyAnomalyMetadata() override {
     // If python is already dead, leak the wrapped python objects
     if (Py_IsInitialized()) {
-      pybind11::gil_scoped_acquire gil;
-      Py_DECREF(dict_);
+      torch::detail::SafeGilScopedAcquire gil;
+      if (gil) {
+        Py_DECREF(dict_);
+      }
     }
   }
   void store_stack() override;

--- a/torch/csrc/autograd/python_hook.cpp
+++ b/torch/csrc/autograd/python_hook.cpp
@@ -102,7 +102,7 @@ PyFunctionTensorPreHook::~PyFunctionTensorPreHook() {
   // If python is already dead, leak the wrapped python objects
   if (Py_IsInitialized()) {
     torch::detail::SafeGilScopedAcquire gil;
-    if (gil.acquired()) {
+    if (gil) {
       Py_DECREF(dict);
     }
   }
@@ -131,7 +131,7 @@ PyFunctionPreHook::~PyFunctionPreHook() {
   // If python is already dead, leak the wrapped python objects
   if (Py_IsInitialized()) {
     torch::detail::SafeGilScopedAcquire gil;
-    if (gil.acquired()) {
+    if (gil) {
       Py_DECREF(dict);
     }
   }
@@ -155,7 +155,7 @@ PyFunctionPostHook::~PyFunctionPostHook() {
   // If python is already dead, leak the wrapped python objects
   if (Py_IsInitialized()) {
     torch::detail::SafeGilScopedAcquire gil;
-    if (gil.acquired()) {
+    if (gil) {
       Py_DECREF(dict);
     }
   }
@@ -219,7 +219,7 @@ PyFunctionTensorPostAccGradHooks::~PyFunctionTensorPostAccGradHooks() {
   // If python is already dead, leak the wrapped python objects
   if (Py_IsInitialized()) {
     torch::detail::SafeGilScopedAcquire gil;
-    if (gil.acquired()) {
+    if (gil) {
       Py_DECREF(dict);
     }
   }

--- a/torch/csrc/autograd/python_hook.cpp
+++ b/torch/csrc/autograd/python_hook.cpp
@@ -99,13 +99,13 @@ PyFunctionTensorPreHook::PyFunctionTensorPreHook(
 }
 
 PyFunctionTensorPreHook::~PyFunctionTensorPreHook() {
-  // If python is already dead, leak the wrapped python objects
-  if (Py_IsInitialized()) {
-    torch::detail::SafeGilScopedAcquire gil;
-    if (gil) {
-      Py_DECREF(dict);
-    }
+  // Leak the wrapped python object if the GIL can't be acquired (e.g.
+  // python is already dead).
+  torch::detail::SafeGilScopedAcquire gil;
+  if (!gil) {
+    return;
   }
+  Py_DECREF(dict);
 }
 
 auto PyFunctionTensorPreHook::operator()(const variable_list& values)
@@ -128,13 +128,13 @@ PyFunctionPreHook::PyFunctionPreHook(PyObject* dict) : dict(dict) {
 }
 
 PyFunctionPreHook::~PyFunctionPreHook() {
-  // If python is already dead, leak the wrapped python objects
-  if (Py_IsInitialized()) {
-    torch::detail::SafeGilScopedAcquire gil;
-    if (gil) {
-      Py_DECREF(dict);
-    }
+  // Leak the wrapped python object if the GIL can't be acquired (e.g.
+  // python is already dead).
+  torch::detail::SafeGilScopedAcquire gil;
+  if (!gil) {
+    return;
   }
+  Py_DECREF(dict);
 }
 
 auto PyFunctionPreHook::operator()(const variable_list& grad_outputs_)
@@ -152,13 +152,13 @@ PyFunctionPostHook::PyFunctionPostHook(PyObject* dict) : dict(dict) {
 }
 
 PyFunctionPostHook::~PyFunctionPostHook() {
-  // If python is already dead, leak the wrapped python objects
-  if (Py_IsInitialized()) {
-    torch::detail::SafeGilScopedAcquire gil;
-    if (gil) {
-      Py_DECREF(dict);
-    }
+  // Leak the wrapped python object if the GIL can't be acquired (e.g.
+  // python is already dead).
+  torch::detail::SafeGilScopedAcquire gil;
+  if (!gil) {
+    return;
   }
+  Py_DECREF(dict);
 }
 
 auto PyFunctionPostHook::operator()(
@@ -216,13 +216,13 @@ PyFunctionTensorPostAccGradHooks::PyFunctionTensorPostAccGradHooks(
 }
 
 PyFunctionTensorPostAccGradHooks::~PyFunctionTensorPostAccGradHooks() {
-  // If python is already dead, leak the wrapped python objects
-  if (Py_IsInitialized()) {
-    torch::detail::SafeGilScopedAcquire gil;
-    if (gil) {
-      Py_DECREF(dict);
-    }
+  // Leak the wrapped python object if the GIL can't be acquired (e.g.
+  // python is already dead).
+  torch::detail::SafeGilScopedAcquire gil;
+  if (!gil) {
+    return;
   }
+  Py_DECREF(dict);
 }
 
 auto PyFunctionTensorPostAccGradHooks::operator()(const Variable& tensor)

--- a/torch/csrc/autograd/python_hook.cpp
+++ b/torch/csrc/autograd/python_hook.cpp
@@ -98,12 +98,13 @@ PyFunctionTensorPreHook::PyFunctionTensorPreHook(
   Py_INCREF(dict);
 }
 
-// NOLINTNEXTLINE(bugprone-exception-escape)
 PyFunctionTensorPreHook::~PyFunctionTensorPreHook() {
   // If python is already dead, leak the wrapped python objects
   if (Py_IsInitialized()) {
-    pybind11::gil_scoped_acquire gil;
-    Py_DECREF(dict);
+    torch::detail::SafeGilScopedAcquire gil;
+    if (gil.acquired()) {
+      Py_DECREF(dict);
+    }
   }
 }
 
@@ -126,12 +127,13 @@ PyFunctionPreHook::PyFunctionPreHook(PyObject* dict) : dict(dict) {
   Py_INCREF(dict);
 }
 
-// NOLINTNEXTLINE(bugprone-exception-escape)
 PyFunctionPreHook::~PyFunctionPreHook() {
   // If python is already dead, leak the wrapped python objects
   if (Py_IsInitialized()) {
-    pybind11::gil_scoped_acquire gil;
-    Py_DECREF(dict);
+    torch::detail::SafeGilScopedAcquire gil;
+    if (gil.acquired()) {
+      Py_DECREF(dict);
+    }
   }
 }
 
@@ -149,12 +151,13 @@ PyFunctionPostHook::PyFunctionPostHook(PyObject* dict) : dict(dict) {
   Py_INCREF(dict);
 }
 
-// NOLINTNEXTLINE(bugprone-exception-escape)
 PyFunctionPostHook::~PyFunctionPostHook() {
   // If python is already dead, leak the wrapped python objects
   if (Py_IsInitialized()) {
-    pybind11::gil_scoped_acquire gil;
-    Py_DECREF(dict);
+    torch::detail::SafeGilScopedAcquire gil;
+    if (gil.acquired()) {
+      Py_DECREF(dict);
+    }
   }
 }
 
@@ -212,12 +215,13 @@ PyFunctionTensorPostAccGradHooks::PyFunctionTensorPostAccGradHooks(
   Py_INCREF(dict);
 }
 
-// NOLINTNEXTLINE(bugprone-exception-escape)
 PyFunctionTensorPostAccGradHooks::~PyFunctionTensorPostAccGradHooks() {
   // If python is already dead, leak the wrapped python objects
   if (Py_IsInitialized()) {
-    pybind11::gil_scoped_acquire gil;
-    Py_DECREF(dict);
+    torch::detail::SafeGilScopedAcquire gil;
+    if (gil.acquired()) {
+      Py_DECREF(dict);
+    }
   }
 }
 

--- a/torch/csrc/autograd/python_hook.cpp
+++ b/torch/csrc/autograd/python_hook.cpp
@@ -102,12 +102,13 @@ PyFunctionTensorPreHook::PyFunctionTensorPreHook(
   Py_INCREF(dict);
 }
 
-// NOLINTNEXTLINE(bugprone-exception-escape)
 PyFunctionTensorPreHook::~PyFunctionTensorPreHook() {
   // If python is already dead, leak the wrapped python objects
   if (Py_IsInitialized()) {
-    pybind11::gil_scoped_acquire gil;
-    Py_DECREF(dict);
+    torch::detail::SafeGilScopedAcquire gil;
+    if (gil.acquired()) {
+      Py_DECREF(dict);
+    }
   }
 }
 
@@ -131,12 +132,13 @@ PyFunctionPreHook::PyFunctionPreHook(PyObject* dict) : dict(dict) {
   Py_INCREF(dict);
 }
 
-// NOLINTNEXTLINE(bugprone-exception-escape)
 PyFunctionPreHook::~PyFunctionPreHook() {
   // If python is already dead, leak the wrapped python objects
   if (Py_IsInitialized()) {
-    pybind11::gil_scoped_acquire gil;
-    Py_DECREF(dict);
+    torch::detail::SafeGilScopedAcquire gil;
+    if (gil.acquired()) {
+      Py_DECREF(dict);
+    }
   }
 }
 
@@ -154,12 +156,13 @@ PyFunctionPostHook::PyFunctionPostHook(PyObject* dict) : dict(dict) {
   Py_INCREF(dict);
 }
 
-// NOLINTNEXTLINE(bugprone-exception-escape)
 PyFunctionPostHook::~PyFunctionPostHook() {
   // If python is already dead, leak the wrapped python objects
   if (Py_IsInitialized()) {
-    pybind11::gil_scoped_acquire gil;
-    Py_DECREF(dict);
+    torch::detail::SafeGilScopedAcquire gil;
+    if (gil.acquired()) {
+      Py_DECREF(dict);
+    }
   }
 }
 
@@ -217,12 +220,13 @@ PyFunctionTensorPostAccGradHooks::PyFunctionTensorPostAccGradHooks(
   Py_INCREF(dict);
 }
 
-// NOLINTNEXTLINE(bugprone-exception-escape)
 PyFunctionTensorPostAccGradHooks::~PyFunctionTensorPostAccGradHooks() {
   // If python is already dead, leak the wrapped python objects
   if (Py_IsInitialized()) {
-    pybind11::gil_scoped_acquire gil;
-    Py_DECREF(dict);
+    torch::detail::SafeGilScopedAcquire gil;
+    if (gil.acquired()) {
+      Py_DECREF(dict);
+    }
   }
 }
 

--- a/torch/csrc/autograd/python_hook.cpp
+++ b/torch/csrc/autograd/python_hook.cpp
@@ -106,7 +106,7 @@ PyFunctionTensorPreHook::~PyFunctionTensorPreHook() {
   // If python is already dead, leak the wrapped python objects
   if (Py_IsInitialized()) {
     torch::detail::SafeGilScopedAcquire gil;
-    if (gil.acquired()) {
+    if (gil) {
       Py_DECREF(dict);
     }
   }
@@ -136,7 +136,7 @@ PyFunctionPreHook::~PyFunctionPreHook() {
   // If python is already dead, leak the wrapped python objects
   if (Py_IsInitialized()) {
     torch::detail::SafeGilScopedAcquire gil;
-    if (gil.acquired()) {
+    if (gil) {
       Py_DECREF(dict);
     }
   }
@@ -160,7 +160,7 @@ PyFunctionPostHook::~PyFunctionPostHook() {
   // If python is already dead, leak the wrapped python objects
   if (Py_IsInitialized()) {
     torch::detail::SafeGilScopedAcquire gil;
-    if (gil.acquired()) {
+    if (gil) {
       Py_DECREF(dict);
     }
   }
@@ -224,7 +224,7 @@ PyFunctionTensorPostAccGradHooks::~PyFunctionTensorPostAccGradHooks() {
   // If python is already dead, leak the wrapped python objects
   if (Py_IsInitialized()) {
     torch::detail::SafeGilScopedAcquire gil;
-    if (gil.acquired()) {
+    if (gil) {
       Py_DECREF(dict);
     }
   }

--- a/torch/csrc/autograd/python_saved_variable_hooks.cpp
+++ b/torch/csrc/autograd/python_saved_variable_hooks.cpp
@@ -2,6 +2,7 @@
 #include <torch/csrc/autograd/python_saved_variable_hooks.h>
 
 #include <c10/core/SafePyObject.h>
+#include <torch/csrc/Exceptions.h>
 #include <torch/csrc/PyInterpreter.h>
 #include <torch/csrc/THP.h>
 
@@ -51,15 +52,16 @@ PySavedVariableHooks::retrieve_unpack_hook_data() const {
       c10::SafePyObject(data_, getPyInterpreter()));
 }
 
-// NOLINTNEXTLINE(bugprone-exception-escape)
 PySavedVariableHooks::~PySavedVariableHooks() {
-  // If python is already dead, leak the wrapped python objects
-  if (Py_IsInitialized()) {
-    py::gil_scoped_acquire gil;
-    Py_XDECREF(pack_hook_);
-    Py_XDECREF(unpack_hook_);
-    Py_XDECREF(data_);
+  // Leak the wrapped python objects if the GIL can't be acquired (e.g.
+  // python is already dead).
+  torch::detail::SafeGilScopedAcquire gil;
+  if (!gil) {
+    return;
   }
+  Py_XDECREF(pack_hook_);
+  Py_XDECREF(unpack_hook_);
+  Py_XDECREF(data_);
 }
 
 void PyDefaultSavedVariableHooks::push_hooks(

--- a/torch/csrc/distributed/c10d/py/PyProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/py/PyProcessGroup.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <torch/csrc/Exceptions.h>
 #include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
 #include <torch/csrc/jit/python/pybind_utils.h>
 #include <torch/csrc/utils/pybind.h>
@@ -71,8 +72,15 @@ class PyProcessGroup : public ProcessGroup {
 
     ~PyWorkHolder() override {
       // GIL must be held when freeing python objects.
-      py::gil_scoped_acquire gil;
-      pyWork_ = py::object();
+      torch::detail::SafeGilScopedAcquire gil;
+      if (gil) {
+        pyWork_ = py::object();
+      } else {
+        // Leak rather than touch the refcount without the GIL: release()
+        // nulls the pointer without a decref, so pyWork_'s own destructor
+        // becomes a no-op.
+        pyWork_.release();
+      }
     }
 
     bool wait(std::chrono::milliseconds timeout = kNoTimeout) override {
@@ -462,12 +470,15 @@ class TORCH_PYTHON_API PythonOnCompletionHook {
   PythonOnCompletionHook(py::object hook) : hook_(std::move(hook)) {}
   PythonOnCompletionHook(const PythonOnCompletionHook&) = default;
 
-  // NOLINTNEXTLINE(bugprone-exception-escape)
   ~PythonOnCompletionHook() {
-    py::gil_scoped_acquire ag;
-    hook_.dec_ref();
+    torch::detail::SafeGilScopedAcquire ag;
+    if (ag) {
+      hook_.dec_ref();
+    }
     // Explicitly set hook_ to nullptr to prevent py::object's dtor
-    // to decref on the PyObject again.
+    // to decref on the PyObject again. If the GIL could not be acquired
+    // above, this deliberately leaks the reference rather than touching
+    // the refcount without the GIL held.
     // See Note [Destructing py::object] in python_ivalue.h
     hook_.ptr() = nullptr;
   }

--- a/torch/csrc/distributed/c10d/python_callback_work.cpp
+++ b/torch/csrc/distributed/c10d/python_callback_work.cpp
@@ -1,5 +1,7 @@
 #include <torch/csrc/distributed/c10d/python_callback_work.hpp>
 
+#include <torch/csrc/Exceptions.h>
+
 namespace c10d {
 
 PythonCallbackWork::PythonCallbackWork(py::function callback)
@@ -9,12 +11,15 @@ PythonCallbackWork::PythonCallbackWork(py::function callback)
       c10::ListType::create(c10::TensorType::get()));
 }
 
-// NOLINTNEXTLINE(bugprone-exception-escape)
 PythonCallbackWork::~PythonCallbackWork() {
-  py::gil_scoped_acquire ag;
-  callback_.dec_ref();
+  torch::detail::SafeGilScopedAcquire ag;
+  if (ag.acquired()) {
+    callback_.dec_ref();
+  }
   // Explicitly set callback_ to nullptr to prevent py::object's dtor
-  // to decref on the PyObject again.
+  // to decref on the PyObject again. If the GIL could not be acquired
+  // above, this deliberately leaks the reference rather than touching
+  // the refcount without the GIL held.
   // See Note [Destructing py::object] in python_ivalue.h
   callback_.ptr() = nullptr;
 }

--- a/torch/csrc/distributed/c10d/python_callback_work.cpp
+++ b/torch/csrc/distributed/c10d/python_callback_work.cpp
@@ -13,13 +13,11 @@ PythonCallbackWork::PythonCallbackWork(py::function callback)
 
 PythonCallbackWork::~PythonCallbackWork() {
   torch::detail::SafeGilScopedAcquire ag;
-  if (ag.acquired()) {
+  if (ag) {
     callback_.dec_ref();
   }
   // Explicitly set callback_ to nullptr to prevent py::object's dtor
-  // to decref on the PyObject again. If the GIL could not be acquired
-  // above, this deliberately leaks the reference rather than touching
-  // the refcount without the GIL held.
+  // to decref on the PyObject again.
   // See Note [Destructing py::object] in python_ivalue.h
   callback_.ptr() = nullptr;
 }

--- a/torch/csrc/distributed/c10d/python_comm_hook.cpp
+++ b/torch/csrc/distributed/c10d/python_comm_hook.cpp
@@ -7,14 +7,12 @@ namespace c10d {
 
 PythonCommHook::~PythonCommHook() {
   torch::detail::SafeGilScopedAcquire ag;
-  if (ag.acquired()) {
+  if (ag) {
     state_.dec_ref();
     hook_.dec_ref();
   }
   // Explicitly set state_ and hook_ to nullptr to prevent py::object's dtor
-  // to decref on the PyObject again. If the GIL could not be acquired
-  // above, this deliberately leaks the references rather than touching
-  // the refcount without the GIL held.
+  // to decref on the PyObject again.
   // See Note [Destructing py::object] in python_ivalue.h
   state_.ptr() = nullptr;
   hook_.ptr() = nullptr;

--- a/torch/csrc/distributed/c10d/python_comm_hook.cpp
+++ b/torch/csrc/distributed/c10d/python_comm_hook.cpp
@@ -1,16 +1,20 @@
 #include <torch/csrc/distributed/c10d/python_comm_hook.h>
 
+#include <torch/csrc/Exceptions.h>
 #include <torch/csrc/jit/python/pybind_utils.h>
 
 namespace c10d {
 
-// NOLINTNEXTLINE(bugprone-exception-escape)
 PythonCommHook::~PythonCommHook() {
-  py::gil_scoped_acquire ag;
-  state_.dec_ref();
-  hook_.dec_ref();
+  torch::detail::SafeGilScopedAcquire ag;
+  if (ag.acquired()) {
+    state_.dec_ref();
+    hook_.dec_ref();
+  }
   // Explicitly set state_ and hook_ to nullptr to prevent py::object's dtor
-  // to decref on the PyObject again.
+  // to decref on the PyObject again. If the GIL could not be acquired
+  // above, this deliberately leaks the references rather than touching
+  // the refcount without the GIL held.
   // See Note [Destructing py::object] in python_ivalue.h
   state_.ptr() = nullptr;
   hook_.ptr() = nullptr;

--- a/torch/csrc/distributed/rpc/py_rref.cpp
+++ b/torch/csrc/distributed/rpc/py_rref.cpp
@@ -143,13 +143,11 @@ PyRRef::PyRRef(const py::object& value, const py::object& type_hint)
 PyRRef::~PyRRef() {
   if (type_.has_value()) {
     torch::detail::SafeGilScopedAcquire ag;
-    if (ag.acquired()) {
+    if (ag) {
       (*type_).dec_ref();
     }
     // explicitly setting PyObject* to nullptr to prevent py::object's dtor to
-    // decref on the PyObject again. If the GIL could not be acquired above,
-    // this deliberately leaks the reference rather than touching the
-    // refcount without the GIL held.
+    // decref on the PyObject again.
     // See Note [Destructing py::object] in python_ivalue.h
     (*type_).ptr() = nullptr;
   }

--- a/torch/csrc/distributed/rpc/py_rref.cpp
+++ b/torch/csrc/distributed/rpc/py_rref.cpp
@@ -1,5 +1,6 @@
 #include <torch/csrc/distributed/rpc/py_rref.h>
 
+#include <torch/csrc/Exceptions.h>
 #include <torch/csrc/autograd/autograd.h>
 #include <torch/csrc/distributed/autograd/autograd.h>
 #include <torch/csrc/distributed/autograd/rpc_messages/rref_backward_req.h>
@@ -139,13 +140,16 @@ PyRRef::PyRRef(const py::object& value, const py::object& type_hint)
         return rref;
       }()) {}
 
-// NOLINTNEXTLINE(bugprone-exception-escape)
 PyRRef::~PyRRef() {
   if (type_.has_value()) {
-    pybind11::gil_scoped_acquire ag;
-    (*type_).dec_ref();
+    torch::detail::SafeGilScopedAcquire ag;
+    if (ag.acquired()) {
+      (*type_).dec_ref();
+    }
     // explicitly setting PyObject* to nullptr to prevent py::object's dtor to
-    // decref on the PyObject again.
+    // decref on the PyObject again. If the GIL could not be acquired above,
+    // this deliberately leaks the reference rather than touching the
+    // refcount without the GIL held.
     // See Note [Destructing py::object] in python_ivalue.h
     (*type_).ptr() = nullptr;
   }

--- a/torch/csrc/distributed/rpc/unpickled_python_call.cpp
+++ b/torch/csrc/distributed/rpc/unpickled_python_call.cpp
@@ -1,5 +1,6 @@
 #include <torch/csrc/distributed/rpc/unpickled_python_call.h>
 
+#include <torch/csrc/Exceptions.h>
 #include <torch/csrc/distributed/rpc/python_rpc_handler.h>
 
 namespace torch::distributed::rpc {
@@ -13,13 +14,16 @@ UnpickledPythonCall::UnpickledPythonCall(
   pythonUdf_ = pythonRpcHandler.deserialize(serializedPyObj);
 }
 
-// NOLINTNEXTLINE(bugprone-exception-escape)
 UnpickledPythonCall::~UnpickledPythonCall() {
+  torch::detail::SafeGilScopedAcquire acquire;
+  if (acquire) {
+    pythonUdf_.dec_ref();
+  }
   // explicitly setting PyObject* to nullptr to prevent py::object's dtor to
-  // decref on the PyObject again.
+  // decref on the PyObject again. If the GIL could not be acquired above,
+  // this deliberately leaks the reference rather than touching the
+  // refcount without the GIL held.
   // See Note [Destructing py::object] in python_ivalue.h
-  py::gil_scoped_acquire acquire;
-  pythonUdf_.dec_ref();
   pythonUdf_.ptr() = nullptr;
 }
 

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -9,6 +9,7 @@
 #include <pybind11/pytypes.h>
 #include <torch/csrc/Device.h>
 #include <torch/csrc/Dtype.h>
+#include <torch/csrc/Exceptions.h>
 #include <torch/csrc/Export.h>
 #include <torch/csrc/Layout.h>
 #include <torch/csrc/QScheme.h>
@@ -84,10 +85,14 @@ struct VISIBILITY_HIDDEN PythonFunctionGuard {
   PythonFunctionGuard& operator=(PythonFunctionGuard&&) = delete;
 
   ~PythonFunctionGuard() {
-    pybind11::gil_scoped_acquire ag;
-    func_.dec_ref();
+    torch::detail::SafeGilScopedAcquire ag;
+    if (ag) {
+      func_.dec_ref();
+    }
     // explicitly setting PyObject* to nullptr to prevent py::object's dtor to
-    // decref on the PyObject again.
+    // decref on the PyObject again. If the GIL could not be acquired above,
+    // this deliberately leaks the reference rather than touching the
+    // refcount without the GIL held.
     // See Note [Destructing py::object] in python_ivalue.h
     func_.ptr() = nullptr;
   }

--- a/torch/csrc/jit/python/python_ivalue.h
+++ b/torch/csrc/jit/python/python_ivalue.h
@@ -94,13 +94,11 @@ struct C10_EXPORT ConcretePyObjectHolder final : PyObjectHolder {
   // https://docs.python.org/3/c-api/refcounting.html#c.Py_XDECREF
   ~ConcretePyObjectHolder() override {
     torch::detail::SafeGilScopedAcquire ag;
-    if (ag.acquired()) {
+    if (ag) {
       py_obj_.dec_ref();
     }
     // explicitly setting PyObject* to nullptr to prevent py::object's dtor to
-    // decref on the PyObject again. If the GIL could not be acquired above,
-    // this deliberately leaks the reference rather than touching the
-    // refcount without the GIL held.
+    // decref on the PyObject again.
     py_obj_.ptr() = nullptr;
   }
 

--- a/torch/csrc/jit/python/python_ivalue.h
+++ b/torch/csrc/jit/python/python_ivalue.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <ATen/core/ivalue.h>
 #include <pybind11/pybind11.h>
+#include <torch/csrc/Exceptions.h>
 #include <torch/csrc/jit/python/pybind_utils.h>
 #include <torch/csrc/python_headers.h>
 #include <torch/csrc/utils/pybind.h>
@@ -92,10 +93,14 @@ struct C10_EXPORT ConcretePyObjectHolder final : PyObjectHolder {
   // Py_XDECREF(NULL) underlying.
   // https://docs.python.org/3/c-api/refcounting.html#c.Py_XDECREF
   ~ConcretePyObjectHolder() override {
-    pybind11::gil_scoped_acquire ag;
-    py_obj_.dec_ref();
+    torch::detail::SafeGilScopedAcquire ag;
+    if (ag.acquired()) {
+      py_obj_.dec_ref();
+    }
     // explicitly setting PyObject* to nullptr to prevent py::object's dtor to
-    // decref on the PyObject again.
+    // decref on the PyObject again. If the GIL could not be acquired above,
+    // this deliberately leaks the reference rather than touching the
+    // refcount without the GIL held.
     py_obj_.ptr() = nullptr;
   }
 


### PR DESCRIPTION
pybind11::gil_scoped_acquire's constructor can throw (e.g. if creating a new Python thread state fails). Several destructors and refcount-management callbacks called it directly while noexcept, so a throw there would call std::terminate.

Adds SafeGilScopedAcquire: catches the exception, reports success via an explicit bool conversion, and owns the rest of "is it safe to touch Python right now" (Py_IsInitialized/Py_IsFinalizing) so callers don't each need their own guard. Also checks Py_IsFinalizing() both before and after acquiring, disarming the guard during interpreter shutdown so its destructor doesn't call PyThreadState_DeleteCurrent, which isn't allowed post-finalization.

Converts every noexcept-reachable raw gil_scoped_acquire call site this touches, including several missed on the first pass (PyWorkHolder, PythonOnCompletionHook, PythonFunctionGuard, UnpickledPythonCall, PySavedVariableHooks, PythonTracer) — found via a script matching every remaining gil_scoped_acquire call to a destructor within a few lines above it.

This PR was authored with the assistance of an AI coding assistant.