### PR TITLE
[ROCm] Lazy-load libtorch_rocshmem.so to fix import torch deadlock on no-GPU/no-kfd hosts

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1516,7 +1516,19 @@ if(USE_ROCM)
         target_compile_definitions(torch_rocshmem PUBLIC USE_NVSHMEM USE_ROCM)
 
         target_link_libraries(torch_rocshmem PRIVATE roc::rocshmem)
-        target_link_libraries(torch_hip PRIVATE torch_rocshmem)
+        # Do NOT hard-link torch_rocshmem into torch_hip. Doing so makes
+        # libtorch_rocshmem.so a NEEDED of libtorch_hip.so, so it loads on every
+        # `import torch` -- and its upstream rocSHMEM NUMAWrapper global
+        # constructor calls exit() at load time on hosts without a usable GPU /
+        # kfd. That exit() runs atexit handlers, where rocprofiler-sdk's
+        # finalize() deadlocks tearing down its thread pool, hanging (often
+        # intermittently) `import torch`. See pytorch/pytorch#189110.
+        #
+        # Instead, still build + install libtorch_rocshmem.so, but load it
+        # lazily -- only when a GPU is actually present and symmetric memory is
+        # used -- from torch/distributed/_symmetric_memory. add_dependencies
+        # keeps it in the build/install without creating the NEEDED link.
+        add_dependencies(torch_hip torch_rocshmem)
 
         install(TARGETS torch_rocshmem EXPORT Caffe2Targets DESTINATION
           "${TORCH_INSTALL_LIB_DIR}")

--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ctypes
 import math
 import os
 import socket
@@ -2016,6 +2017,33 @@ def rendezvous(
     return _SymmetricMemory.rendezvous(tensor, group_name)
 
 
+def _maybe_load_rocshmem_library() -> None:
+    """Lazily load ``libtorch_rocshmem.so`` on ROCm, only when a GPU is present.
+
+    ``libtorch_rocshmem.so`` is intentionally NOT linked as a hard dependency of
+    ``libtorch_hip.so`` (see ``caffe2/CMakeLists.txt``). Its upstream rocSHMEM
+    ``NUMAWrapper`` global constructor calls ``exit()`` at load time on hosts
+    without a usable GPU / kfd, which triggers a rocprofiler-sdk atexit deadlock
+    and hangs ``import torch`` (pytorch/pytorch#189110). So we load it here, on
+    demand, and only when an actual ROCm GPU is available. This registers the
+    rocSHMEM symmetric-memory ops/bindings for the calls below.
+    """
+    if not torch.version.hip:
+        return
+    try:
+        if not (torch.cuda.is_available() and torch.cuda.device_count() > 0):
+            return
+    except Exception:
+        return
+    lib = os.path.join(os.path.dirname(torch.__file__), "lib", "libtorch_rocshmem.so")
+    if not os.path.exists(lib):
+        return
+    try:
+        ctypes.CDLL(lib, mode=ctypes.RTLD_GLOBAL)
+    except OSError:
+        pass
+
+
 def is_nvshmem_available() -> bool:
     r"""
     is_nvshmem_available() -> bool
@@ -2024,6 +2052,11 @@ def is_nvshmem_available() -> bool:
     build and usable at runtime. On ROCm, rocSHMEM ``VERSION`` must be at
     least 3.3.0 (see ``rocshmem/rocshmem.hpp``).
     """
+    # On ROCm, rocSHMEM is loaded lazily (see _maybe_load_rocshmem_library);
+    # this makes the availability query and its bindings work without
+    # force-loading libtorch_rocshmem.so at `import torch`.
+    _maybe_load_rocshmem_library()
+
     try:
         from torch._C._distributed_c10d import _is_nvshmem_available
     except ImportError:


### PR DESCRIPTION
## Summary

`import torch` from ROCm 2.13 wheels **intermittently hangs forever** on hosts without a usable GPU / kfd (CPU-only nodes, or GPU nodes where `amdgpu`/`amdkfd` isn't loaded). Fixes #189110.

### Root cause (native backtrace)
```
import torch → dlopen(_C…so) → static init
  → libtorch_rocshmem.so: _GLOBAL__sub_I_numa_wrapper.cpp
    → rocshmem::NUMAWrapper::NUMAWrapper()
      → exit()                                   # ctor calls exit() at load
        → __run_exit_handlers
          → rocprofiler::registration::finalize()      (librocprofiler-sdk.so)
            → ThreadPool::destroy_threadpool() → std::thread::join()   # HANGS
```
A **two-bug interaction**:
1. rocSHMEM's `NUMAWrapper` **global constructor calls `exit()`** during `import` when NUMA/GPU init fails on a no-`kfd` host (upstream ROCm/rocSHMEM).
2. that `exit()` runs atexit handlers, where **rocprofiler-sdk's `finalize()` deadlocks** tearing down its thread pool (upstream AMD — "does not exit cleanly"). The teardown is racy, so the hang is **intermittent** (the `agent.cpp:608` kfd warning is a red herring).

`libtorch_rocshmem.so` runs the `NUMAWrapper` ctor on **every** `import torch` only because `torch_hip` **hard-links** it (`target_link_libraries(torch_hip PRIVATE torch_rocshmem)`) — a new dependency in 2.13, which is why this is a 2.13 regression.

## Fix (PyTorch-side mitigation)
Stop force-loading rocSHMEM at import: build + install `libtorch_rocshmem.so` as before, but don't make it a `NEEDED` of `libtorch_hip.so` (`add_dependencies` instead of `target_link_libraries`). Load it **lazily** from `torch/distributed/_symmetric_memory` only when an actual ROCm GPU is present. On non-GPU / no-`kfd` hosts it is never loaded, so neither the `exit()` nor the rocprofiler atexit join runs.

The upstream bugs should be fixed separately: **ROCm/rocSHMEM** (`NUMAWrapper` must not `exit()` from a global ctor) and **AMD rocprofiler-sdk** (`finalize()` must not deadlock in an atexit path).

## ⚠️ Draft — needs ROCm build + testing
I could not build/test this on ROCm. Before merge, please verify on a ROCm build:
- [ ] `import torch` no longer loads `libtorch_rocshmem.so` (`readelf -d torch/lib/libtorch_hip.so | grep rocshmem` shows no `NEEDED`), and imports cleanly (loop it — the hang was intermittent) on a **no-`kfd`** host.
- [ ] `torch.distributed._symmetric_memory.is_nvshmem_available()` still returns `True` and rocSHMEM symmetric-memory ops work on a **real GPU** host (confirms lazy load + op/binding registration still happens).
- [ ] Confirm no other import-time path relies on rocSHMEM ops being pre-registered (if so, they need the same lazy-load hook).

Open question for reviewers: whether `torch._C._distributed_c10d._is_nvshmem_available` (and the `nvshmem_*` ops) are registered from `libtorch_rocshmem.so` (handled here by loading it first) or elsewhere — worth confirming on a GPU build.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang


---

## ⚠️ UPDATE: this draft is INCOMPLETE — do not merge as-is

Testing revealed the CMake change alone breaks import with:
```
ImportError: libtorch_python.so: undefined symbol:
  _ZN4c10d17nvshmem_extension20is_nvshmem_availableEv
```
Reason: `torch/csrc/distributed/c10d/init.cpp:1088-1094` (compiled into `libtorch_python.so`, `#ifdef USE_NVSHMEM`) binds the Python functions `_is_nvshmem_available` / `_nvshmemx_cumodule_init` by **directly referencing** two symbols defined in `libtorch_rocshmem.so`:
- `c10d::nvshmem_extension::is_nvshmem_available()`
- `c10d::nvshmem_extension::nvshmemx_cumodule_init(unsigned long)`

So `libtorch_python.so` has a **load-time dependency** on `libtorch_rocshmem.so`; dropping the `torch_hip → torch_rocshmem` `NEEDED` leaves those unresolved. (Confirmed via `patchelf --remove-needed` on an installed wheel → same `ImportError`.) There is likewise **no no-rebuild mitigation**: the lib must be loaded for those symbols, and loading it runs the deadlocking `NUMAWrapper` ctor.

### Correct fix (still needs implementing + ROCm build/test)
Decouple those two bindings from the load-time symbol reference:
1. Add `extern "C"` shims in `rocshmem_extension.cu` (e.g. `torch_rocshmem_is_available()`, `torch_rocshmem_cumodule_init()`).
2. In `init.cpp`, change `_is_nvshmem_available` / `_nvshmemx_cumodule_init` to lazily `dlopen("libtorch_rocshmem.so")` + `dlsym` the shims, **guarded on kfd presence** (`/sys/class/kfd/kfd/topology/nodes`), returning `false`/no-op otherwise. This removes the `UND` refs from `libtorch_python.so`, so the CMake link drop no longer breaks import.
3. Must not regress the **CUDA/NVSHMEM** path (same `#ifdef USE_NVSHMEM`) — the CUDA build defines these symbols in a different (linked) lib.

Marking as WIP until the `init.cpp` decoupling lands and is validated on a real-GPU ROCm build (rocSHMEM symm-mem still works) and a no-`kfd` host (`import torch` no longer hangs, loop-tested since it's intermittent).
