### PR TITLE
Skip building unused XNNPACK microkernels-all; guard GCC14 workaround

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -561,6 +561,12 @@ if(USE_XNNPACK AND NOT USE_SYSTEM_XNNPACK)
     set(XNNPACK_BUILD_BENCHMARKS OFF CACHE BOOL "")
     set(XNNPACK_BUILD_TESTS OFF CACHE BOOL "")
 
+    # microkernels-all (XNNPACK's non-production microkernel variants) is only
+    # consumed by XNNPACK's own tests/benchmarks, both disabled above. It is
+    # never linked into Caffe2_DEPENDENCY_LIBS (only microkernels-prod is), so
+    # building it wastes compile time for output that's discarded.
+    set(XNNPACK_BUILD_ALL_MICROKERNELS OFF CACHE BOOL "")
+
     # Disable ARM BF16 and FP16 vector for now; unused and causes build failures because
     # these new ISA features may not be supported on older compilers
     set(XNNPACK_ENABLE_ARM_BF16 OFF CACHE BOOL "")
@@ -598,7 +604,9 @@ if(USE_XNNPACK AND NOT USE_SYSTEM_XNNPACK)
 
     if(CMAKE_C_COMPILER_ID STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL "14")
       foreach(xnn_tgt IN ITEMS XNNPACK microkernels-prod microkernels-all)
+        if(TARGET ${xnn_tgt})
           target_compile_options(${xnn_tgt} PRIVATE -Wno-error=incompatible-pointer-types)
+        endif()
       endforeach()
     endif()
 


### PR DESCRIPTION
## Summary
Split out of #188867 per review feedback (the KleidiAI SME feature and this change are logically independent, and bundling them made #188867 harder to review/revert as a unit):

- Disables `XNNPACK_BUILD_ALL_MICROKERNELS`, since `microkernels-all` is only consumed by XNNPACK's own tests/benchmarks (both already disabled) and is never linked into `Caffe2_DEPENDENCY_LIBS` (only `microkernels-prod` is) — building it wastes compile time for output that's discarded.
- Guards the GCC 14 `-Wno-error=incompatible-pointer-types` workaround with a `target-existence` check, since skipping `microkernels-all` means the `foreach` may hit a target that was never created.

## Test plan
- [x] Configured and built on aarch64 (DGX Spark / GB10) with GCC 14; confirmed `microkernels-all` is no longer built and the GCC14 workaround loop doesn't fail on the now-absent target.
- [ ] CI

AI assistance was used (Claude) to help draft this split-out commit from #188867.