### PR TITLE
[XPU] Enable TestComplexTensor and functorch eager transforms tests on XPU

### DIFF
--- a/test/complex_tensor/test_complex_tensor.py
+++ b/test/complex_tensor/test_complex_tensor.py
@@ -193,7 +193,7 @@ class TestComplexBwdGradients(TestCase):
         self.check_grad(device, dtype, op)
 
 
-instantiate_device_type_tests(TestComplexTensor, globals())
+instantiate_device_type_tests(TestComplexTensor, globals(), allow_xpu=True)
 instantiate_device_type_tests(TestComplexBwdGradients, globals())
 
 

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -5668,11 +5668,12 @@ class TestGradTrackingTensorToList(TestCase):
         self.assertEqual(result, [2.0 + 4.0j, 6.0 + 8.0j])
 
 
-only_for = ("cpu", "cuda")
+only_for = ("cpu", "cuda", "xpu")
 instantiate_device_type_tests(
     TestGradTransform,
     globals(),
     only_for=only_for,
+    allow_xpu=True,
 )
 instantiate_device_type_tests(
     TestVmapOfGrad,
@@ -5693,6 +5694,7 @@ instantiate_device_type_tests(
     TestLinearize,
     globals(),
     only_for=only_for,
+    allow_xpu=True,
 )
 instantiate_device_type_tests(
     TestVmapJvpInplaceView,
@@ -5708,11 +5710,13 @@ instantiate_device_type_tests(
     TestComposability,
     globals(),
     only_for=only_for,
+    allow_xpu=True,
 )
 instantiate_device_type_tests(
     TestExamplesCorrectness,
     globals(),
     only_for=only_for,
+    allow_xpu=True,
 )
 instantiate_device_type_tests(
     TestHigherOrderOperatorInteraction,
@@ -5723,6 +5727,7 @@ instantiate_device_type_tests(
     TestFunctionalize,
     globals(),
     only_for=only_for,
+    allow_xpu=True,
 )
 instantiate_device_type_tests(
     TestAutogradFunction,
@@ -5746,6 +5751,7 @@ instantiate_device_type_tests(
     TestCompileTransforms,
     globals(),
     only_for=only_for,
+    allow_xpu=True,
 )
 instantiate_device_type_tests(
     TestGradTrackingTensorToList, globals(), only_for=only_for


### PR DESCRIPTION
## Summary

Enable XPU instantiation for two groups of test classes:

1. **TestComplexTensor** (`test/complex_tensor/test_complex_tensor.py`):
   Added `allow_xpu=True` to `instantiate_device_type_tests` for `TestComplexTensor`.

2. **Functorch eager transforms** (`test/functorch/test_eager_transforms.py`):
   Extended `only_for` to include `"xpu"` and added `allow_xpu=True` for 6 classes:
   `TestGradTransform`, `TestLinearize`, `TestComposability`,
   `TestExamplesCorrectness`, `TestFunctionalize`, `TestCompileTransforms`.

All these classes were already device-generic. No `op_db`/`DecorateInfo` changes
were needed (no `common_methods_invocations.py` entries for these classes).
No new XPU skip decorators added.

## Test Plan

```
# TestComplexTensor
conda activate classify_ut_test
cd /tmp && python -m pytest /home/daisyden/daisy_pytorch/test/complex_tensor/test_complex_tensor.py \
  -k TestComplexTensorXPU -v --timeout 600
Expected: 253 passed, 6 skipped, 0 failed

# Functorch eager transforms
cd /tmp && python -m pytest /home/daisyden/daisy_pytorch/test/functorch/test_eager_transforms.py \
  -k "TestGradTransformXPU or TestLinearizeXPU or TestComposabilityXPU or \
      TestExamplesCorrectnessXPU or TestFunctionalizeXPU or TestCompileTransformsXPU" \
  --timeout 600 --tb=line -q
Expected: 164 passed, 5 skipped, 0 failed
```

Environment: `torch 2.13.0+xpu`, `torch.xpu.is_available() == True`.

This PR was authored with the assistance of an AI coding assistant.