### PR TITLE
[test] Add opt-in sign-sensitive special-value parity check (copysign, atan2, reciprocal)

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -516,6 +516,99 @@ class TestCommon(TestCase):
                 atol, rtol = 1e-3, 1e-3
             self.assertEqual(cuda_results, cpu_results, atol=atol, rtol=rtol)
 
+    @ops(
+        op_db,
+        allowed_dtypes=floating_and_complex_types_and(torch.float16, torch.bfloat16),
+    )
+    def test_sign_sensitive_special_values(self, device, dtype, op):
+        """Opt-in via check_sign_sensitive_special_values=True on the OpInfo.
+        Checks isnan/isinf mask parity and signed-zero signbit parity between
+        eager and compiled outputs (torch.allclose treats +0.0 == -0.0)."""
+        if not op.check_sign_sensitive_special_values:
+            self.skipTest("check_sign_sensitive_special_values not enabled for this op")
+        if op.skip_correctness_check_compile_vs_eager:
+            self.skipTest("skip_correctness_check_compile_vs_eager is set")
+
+        def check_sign_sensitive(eager_out, compiled_out, *, label=""):
+            if isinstance(eager_out, (list, tuple)):
+                for i, (e, c) in enumerate(zip(eager_out, compiled_out)):
+                    check_sign_sensitive(e, c, label=f"{label}[{i}]")
+                return
+
+            if isinstance(eager_out, dict):
+                for k in eager_out:
+                    check_sign_sensitive(
+                        eager_out[k], compiled_out[k], label=f"{label}[{k!r}]"
+                    )
+                return
+
+            if not isinstance(eager_out, torch.Tensor):
+                return
+
+            if not (eager_out.is_floating_point() or eager_out.is_complex()):
+                return
+
+            prefix = f"{label}: " if label else ""
+
+            # isnan parity
+            eager_nan = torch.isnan(eager_out)
+            compiled_nan = torch.isnan(compiled_out)
+            if not torch.equal(eager_nan, compiled_nan):
+                mask = eager_nan != compiled_nan
+                self.fail(
+                    f"{prefix}isnan mismatch at positions {mask.nonzero(as_tuple=False).tolist()}: "
+                    f"eager={eager_out[mask].tolist()} compiled={compiled_out[mask].tolist()}"
+                )
+
+            # isinf parity
+            eager_inf = torch.isinf(eager_out)
+            compiled_inf = torch.isinf(compiled_out)
+            if not torch.equal(eager_inf, compiled_inf):
+                mask = eager_inf != compiled_inf
+                self.fail(
+                    f"{prefix}isinf mismatch at positions {mask.nonzero(as_tuple=False).tolist()}: "
+                    f"eager={eager_out[mask].tolist()} compiled={compiled_out[mask].tolist()}"
+                )
+
+            # signbit parity for +-0.0 only; infinity sign is already covered by
+            # the existing allclose-based correctness check.
+            sign_mask = (
+                ~eager_nan
+                & ~compiled_nan
+                & ~eager_inf
+                & ~compiled_inf
+                & (eager_out == 0)
+                & (compiled_out == 0)
+            )
+            if not sign_mask.any():
+                return
+
+            eager_sign = torch.signbit(eager_out)
+            compiled_sign = torch.signbit(compiled_out)
+            mismatch = (eager_sign != compiled_sign) & sign_mask
+            if mismatch.any():
+                self.fail(
+                    f"{prefix}signbit mismatch at positions {mismatch.nonzero(as_tuple=False).tolist()}: "
+                    f"eager={eager_out[mismatch].tolist()} compiled={compiled_out[mismatch].tolist()}"
+                )
+
+        inputs_fn = (
+            op.reference_inputs
+            if op.reference_inputs_func is not None
+            else op.sample_inputs
+        )
+        samples = list(inputs_fn(device, dtype, requires_grad=False))
+        if not samples:
+            self.skipTest("no inputs generated")
+
+        compiled_op = torch.compile(op.op)
+
+        for i, sample in enumerate(samples):
+            with self.subTest(i=i):
+                eager_out = op.op(sample.input, *sample.args, **sample.kwargs)
+                compiled_out = compiled_op(sample.input, *sample.args, **sample.kwargs)
+                check_sign_sensitive(eager_out, compiled_out, label=f"sample[{i}]")
+
     # Tests that experimental Python References can propagate shape, dtype,
     # and device metadata properly.
     # See https://github.com/pytorch/pytorch/issues/78050 for a discussion of stride propagation.

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -13590,6 +13590,8 @@ op_db: list[OpInfo] = [
                     supports_fwgrad_bwgrad=True,
                     promotes_int_to_float=True,
                     supports_rhs_python_scalar=False,
+                    # IEEE 754-2008 §9.2.1 specifies signed-zero results for boundary inputs.
+                    check_sign_sensitive_special_values=True,
                     skips=(
                         # Incorrectly attempts to use a scalar for the second argument
                         DecorateInfo(unittest.expectedFailure, 'TestJit', 'test_jit_alias_remapping'),
@@ -14078,7 +14080,9 @@ op_db: list[OpInfo] = [
                     # https://github.com/pytorch/pytorch/issues/80411
                     gradcheck_fast_mode=True,
                     supports_forward_ad=True,
-                    supports_fwgrad_bwgrad=True),
+                    supports_fwgrad_bwgrad=True,
+                    # The sign bit is the entire output of copysign.
+                    check_sign_sensitive_special_values=True),
     OpInfo('corrcoef',
            dtypes=all_types_and_complex_and(torch.half, torch.bfloat16),
            sample_inputs_func=sample_inputs_corrcoef,
@@ -19842,6 +19846,8 @@ op_db: list[OpInfo] = [
                    supports_forward_ad=True,
                    supports_fwgrad_bwgrad=True,
                    promotes_int_to_float=True,
+                   # Sign of zero propagates to the sign of the resulting infinity.
+                   check_sign_sensitive_special_values=True,
                    skips=(
                        # Reference: https://github.com/pytorch/pytorch/issues/45690
                        DecorateInfo(unittest.skip("Skipped!"), 'TestUnaryUfuncs', 'test_reference_numerics_extremal',

--- a/torch/testing/_internal/opinfo/core.py
+++ b/torch/testing/_internal/opinfo/core.py
@@ -941,6 +941,11 @@ class OpInfo:
 
     skip_correctness_check_compile_vs_eager: bool = False
 
+    # Whether test_sign_sensitive_special_values (test_ops.py) checks isnan/isinf
+    # mask parity and signed-zero signbit parity between eager and torch.compile.
+    # torch.allclose treats +0.0 == -0.0, so it can't catch that divergence.
+    check_sign_sensitive_special_values: bool = False
+
     # True if the op produces nondeterministic output (e.g. uninitialized
     # memory) that cannot be meaningfully compared across calls.
     has_nondeterministic_output: bool = False


### PR DESCRIPTION
Fixes #188680

`torch.allclose` treats +0.0 and -0.0 as equal (IEEE 754 defines them as
equal under `==`), so the default compile-vs-eager correctness check in
`test_ops.py` cannot detect a compiler pass that silently normalizes
signed zero (e.g. `-0.0 -> +0.0`). This adds an opt-in check, off by
default, for ops where that distinction is part of the observable
behavior.

New `OpInfo` field `check_sign_sensitive_special_values: bool = False`.
When set, `test_sign_sensitive_special_values` runs the op's
`reference_inputs` (falling back to `sample_inputs`) through eager and
`torch.compile`, and asserts:
- isnan mask parity
- isinf mask parity
- signbit parity, restricted to positions where both outputs are finite
  zero (infinity sign is already enforced by the existing allclose-based
  correctness check, so it isn't re-checked here)

Seed ops for this PR, chosen because signed-zero/signed-infinity behavior
is part of their documented contract rather than an implementation detail:
- `copysign` - sign copying is the entire purpose of the op
- `atan2` - IEEE 754-2008 Sec 9.2.1 specifies signed-zero results at
  boundary inputs
- `reciprocal` - sign of a zero input propagates to the sign of the
  resulting infinity

Scope intentionally kept small per discussion on #188680 - this is a
targeted guardrail for a handful of ops with observable special-value
semantics, not a general exact-correctness requirement.

cc @morrison-turnansky