### PR TITLE
fx: Fix incorrect return_annotation for tuple types in operator schemas

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -352,30 +352,28 @@ class TestFX(JitTestCase):
         self.assertEqual(torch.sin(x + y), gm(x, y))
 
     def test_tuple_return_annotation_for_schemas(self):
-        import typing
-        from torch.fx.operator_schemas import get_signature_for_torch_op
 
         # Target an op that returns multiple tensors (e.g., var_mean)
         op = torch.ops.aten.var_mean.default
-        
+
         # get_signature_for_torch_op returns a list of signatures
         sigs = get_signature_for_torch_op(op)
         self.assertTrue(len(sigs) > 0, "Expected at least one signature")
-        
+
         # Grab the first signature schema
         sig = sigs[0]
         ret_ann = sig.return_annotation
 
         # 1. Ensure it's not a raw Python tuple (The bug you fixed)
         self.assertNotEqual(
-            type(ret_ann), tuple, 
+            type(ret_ann), tuple,
             "return_annotation should be a generic type hint, not a raw tuple of types"
         )
 
         # 2. Ensure it resolves to a proper tuple typing origin (tuple or typing.Tuple)
         origin = getattr(ret_ann, "__origin__", None)
         self.assertIn(
-            origin, (tuple, typing.Tuple), 
+            origin, (tuple, tuple),
             f"Expected tuple or typing.Tuple origin, got {origin}"
         )
 
@@ -383,7 +381,7 @@ class TestFX(JitTestCase):
         args = getattr(ret_ann, "__args__", None)
         self.assertIsNotNone(args, "Tuple annotation must have __args__")
         self.assertTrue(
-            all(issubclass(a, torch.Tensor) for a in args), 
+            all(issubclass(a, torch.Tensor) for a in args),
             "Inner tuple arguments should be subclass of torch.Tensor"
         )
 

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -351,6 +351,42 @@ class TestFX(JitTestCase):
         x, y = torch.rand(1), torch.rand(1)
         self.assertEqual(torch.sin(x + y), gm(x, y))
 
+    def test_tuple_return_annotation_for_schemas(self):
+        import typing
+        from torch.fx.operator_schemas import get_signature_for_torch_op
+
+        # Target an op that returns multiple tensors (e.g., var_mean)
+        op = torch.ops.aten.var_mean.default
+        
+        # get_signature_for_torch_op returns a list of signatures
+        sigs = get_signature_for_torch_op(op)
+        self.assertTrue(len(sigs) > 0, "Expected at least one signature")
+        
+        # Grab the first signature schema
+        sig = sigs[0]
+        ret_ann = sig.return_annotation
+
+        # 1. Ensure it's not a raw Python tuple (The bug you fixed)
+        self.assertNotEqual(
+            type(ret_ann), tuple, 
+            "return_annotation should be a generic type hint, not a raw tuple of types"
+        )
+
+        # 2. Ensure it resolves to a proper tuple typing origin (tuple or typing.Tuple)
+        origin = getattr(ret_ann, "__origin__", None)
+        self.assertIn(
+            origin, (tuple, typing.Tuple), 
+            f"Expected tuple or typing.Tuple origin, got {origin}"
+        )
+
+        # 3. Ensure the inner arguments are properly set to torch.Tensor
+        args = getattr(ret_ann, "__args__", None)
+        self.assertIsNotNone(args, "Tuple annotation must have __args__")
+        self.assertTrue(
+            all(issubclass(a, torch.Tensor) for a in args), 
+            "Inner tuple arguments should be subclass of torch.Tensor"
+        )
+
     def test_boxed_arg_indices_codegen(self):
         def multi_boxed_call(left, passthrough, right):
             return left[0] + left[1] + passthrough + right[0]

--- a/torch/fx/operator_schemas.py
+++ b/torch/fx/operator_schemas.py
@@ -147,7 +147,7 @@ def _torchscript_schema_to_signature_impl(
     elif len(return_types) == 1:
         return_type = return_types[0]
     else:
-        return_type = tuple(return_types)
+        return_type = tuple.__class_getitem__(tuple(return_types))
 
     return inspect.Signature(parameters, return_annotation=return_type)
 


### PR DESCRIPTION
Fixes #189106

### Description
Currently, `get_signature_for_torch_op` returns incorrect annotations for operations that return multiple tensors (e.g., `aten.var_mean.default`). Instead of returning standard `tuple[torch.Tensor, torch.Tensor]`, it returns a raw Python tuple of types `(<class 'torch.Tensor'>, <class 'torch.Tensor'>)`, which causes issues with static type checkers and downstream inspection tools.

**The Fix:**
Used `tuple.__class_getitem__` to correctly construct the tuple type annotation dynamically while appeasing strict static type checkers (like PyRefly/Ruff) that block the `typing.Tuple` syntax.

### Testing
- [x] Reproduced the issue locally and verified the output format matches the expected `tuple[...]`.
- [x] Passed `lintrunner` locally without any type-ignore hacks.