### PR TITLE
[Dynamo] Return actual subclass in EventVariable.python_type

### DIFF
--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -240,6 +240,16 @@ class <lambda>(torch.nn.Module):
         # Stream should be newly allocated on each call
         self.assertNotEqual(s0, s1)
 
+    def test_event_subclass_python_type(self):
+        class MyEvent(torch.Event):
+            pass
+
+        def fn(e):
+            return torch.ones(2) if type(e) is MyEvent else torch.zeros(2)
+
+        res = torch.compile(fn, backend="eager", fullgraph=True)(MyEvent())
+        self.assertEqual(res, torch.ones(2))
+
     @requires_cuda
     def test_get_current_stream_return(self):
         def fn(x, s):

--- a/torch/_dynamo/variables/streams.py
+++ b/torch/_dynamo/variables/streams.py
@@ -633,7 +633,7 @@ class EventVariable(VariableTracker):
         return object_richcompare(self, tx, other, op)
 
     def python_type(self) -> type:
-        return torch.Event
+        return type(self.value)
 
     def get_real_python_backed_value(self) -> object:
         return self.value


### PR DESCRIPTION
## Related Issue

Fixes #188325

## Why

- `EventVariable.python_type()` returns a hardcoded `torch.Event`, so `type(e)` checks on user subclasses of `torch.Event` (the device-agnostic subclassing pattern used by out-of-tree backends) trace incorrectly.

## How

- `python_type()` returns `type(self.value)` instead.

Note: this PR originally also threaded subclass types through graph-break reconstruction; that part overlaps with #188406 and has been dropped from this PR.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98