### PR TITLE
[MPS] softmax: non-last-dim and huge-row native Metal kernels (perf specializations)

### DIFF
--- a/aten/src/ATen/native/mps/kernels/SoftMaxKernel.h
+++ b/aten/src/ATen/native/mps/kernels/SoftMaxKernel.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <c10/metal/common.h>
+
+struct SoftmaxParams {
+  uint32_t axis_size;
+  uint32_t ndim;
+  uint32_t stride_a;
+  uint32_t stride_b;
+  uint32_t stride_c;
+  uint32_t num_chunks;
+  uint32_t num_col_chunks;
+  ::c10::metal::array<uint32_t, 15> outer_sizes;
+  ::c10::metal::array<uint32_t, 15> outer_strides_a;
+  ::c10::metal::array<uint32_t, 15> outer_strides_b;
+  ::c10::metal::array<uint32_t, 15> outer_strides_c;
+};

--- a/aten/src/ATen/native/mps/kernels/SoftMaxKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/SoftMaxKernel.metal
@@ -178,6 +178,7 @@ kernel void softmax_forward_looped(
 
   float local_max = -INFINITY;
   float local_sum = 0.0f;
+  bool found_nan = false;
   for (uint r = 0; r < axis_size; r += lsize * N_READS) {
     uint base = r + tid * N_READS;
     if (base + N_READS <= axis_size) {
@@ -191,6 +192,7 @@ kernel void softmax_forward_looped(
             x[(base + 2) * sa],
             x[(base + 3) * sa]);
       }
+      found_nan = found_nan || metal::any(metal::isnan(v));
       float chunk_max = fmax(fmax(v.x, v.y), fmax(v.z, v.w));
       float new_max = fmax(local_max, chunk_max);
       local_sum = (new_max > -INFINITY)
@@ -204,6 +206,7 @@ kernel void softmax_forward_looped(
     } else {
       for (uint i = base; i < min(base + uint(N_READS), axis_size); i++) {
         float val = contiguous ? float(x[i]) : float(x[i * sa]);
+        found_nan = found_nan || metal::isnan(val);
         float new_max = fmax(local_max, val);
         local_sum = (new_max > -INFINITY)
             ? local_sum * metal::precise::exp(local_max - new_max) +
@@ -214,8 +217,21 @@ kernel void softmax_forward_looped(
     }
   }
 
+  // A NaN input must poison the whole row (CPU semantics): fmax() drops NaNs,
+  // so a NaN seen while the running max was still -INFINITY never entered
+  // local_sum. Applied after the scan so it is order-independent.
+  if (found_nan) {
+    local_sum = NAN;
+  }
+
   float sg_max = simd_max(local_max);
-  local_sum *= metal::precise::exp(local_max - sg_max);
+  // Only rescale when this thread saw a finite max: if the whole simdgroup
+  // saw just -inf, local_max == sg_max == -INFINITY and exp(-inf - -inf) is
+  // NaN, turning the correct local_sum (0, or NaN from a NaN input) into
+  // 0 * NaN == NaN. local_sum needs no rescale in that case.
+  if (local_max > -INFINITY) {
+    local_sum *= metal::precise::exp(local_max - sg_max);
+  }
   float sg_sum = simd_sum(local_sum);
 
   threadgroup float shared_max[simdgroup_size];
@@ -232,9 +248,14 @@ kernel void softmax_forward_looped(
     float m =
         (simd_lane_id < num_simdgroups) ? shared_max[simd_lane_id] : -INFINITY;
     float global_max = simd_max(m);
-    float s = (simd_lane_id < num_simdgroups)
-        ? shared_sum[simd_lane_id] * metal::precise::exp(m - global_max)
-        : 0.0f;
+    // Same rescale guard as above: a fully masked simdgroup has
+    // m == -INFINITY with a 0 (or NaN-poisoned) sum that must pass through
+    // unscaled; exp(m - global_max) is exp(nan) when global_max is also
+    // -INFINITY (fully masked chunk/row).
+    float s = (simd_lane_id < num_simdgroups) ? shared_sum[simd_lane_id] : 0.0f;
+    if (m > -INFINITY) {
+      s *= metal::precise::exp(m - global_max);
+    }
     float global_sum = simd_sum(s);
     if (simd_lane_id == 0) {
       tg_result[0] = global_max;
@@ -306,6 +327,7 @@ kernel void softmax_forward_2pass_reduce(
 
   float local_max = -INFINITY;
   float local_sum = 0.0f;
+  bool found_nan = false;
   for (uint r = start; r < end; r += lsize * N_READS) {
     uint base = r + tid * N_READS;
     if (base + N_READS <= end) {
@@ -319,6 +341,7 @@ kernel void softmax_forward_2pass_reduce(
             x[(base + 2) * sa],
             x[(base + 3) * sa]);
       }
+      found_nan = found_nan || metal::any(metal::isnan(v));
       float chunk_max = fmax(fmax(v.x, v.y), fmax(v.z, v.w));
       float new_max = fmax(local_max, chunk_max);
       local_sum = (new_max > -INFINITY)
@@ -332,6 +355,7 @@ kernel void softmax_forward_2pass_reduce(
     } else {
       for (uint i = base; i < min(base + uint(N_READS), end); i++) {
         float val = contiguous ? float(x[i]) : float(x[i * sa]);
+        found_nan = found_nan || metal::isnan(val);
         float new_max = fmax(local_max, val);
         local_sum = (new_max > -INFINITY)
             ? local_sum * metal::precise::exp(local_max - new_max) +
@@ -342,8 +366,21 @@ kernel void softmax_forward_2pass_reduce(
     }
   }
 
+  // A NaN input must poison the whole row (CPU semantics): fmax() drops NaNs,
+  // so a NaN seen while the running max was still -INFINITY never entered
+  // local_sum. Applied after the scan so it is order-independent.
+  if (found_nan) {
+    local_sum = NAN;
+  }
+
   float sg_max = simd_max(local_max);
-  local_sum *= metal::precise::exp(local_max - sg_max);
+  // Only rescale when this thread saw a finite max: if the whole simdgroup
+  // saw just -inf, local_max == sg_max == -INFINITY and exp(-inf - -inf) is
+  // NaN, turning the correct local_sum (0, or NaN from a NaN input) into
+  // 0 * NaN == NaN. local_sum needs no rescale in that case.
+  if (local_max > -INFINITY) {
+    local_sum *= metal::precise::exp(local_max - sg_max);
+  }
   float sg_sum = simd_sum(local_sum);
 
   threadgroup float shared_max[simdgroup_size];
@@ -360,9 +397,14 @@ kernel void softmax_forward_2pass_reduce(
     float m =
         (simd_lane_id < num_simdgroups) ? shared_max[simd_lane_id] : -INFINITY;
     float global_max = simd_max(m);
-    float s = (simd_lane_id < num_simdgroups)
-        ? shared_sum[simd_lane_id] * metal::precise::exp(m - global_max)
-        : 0.0f;
+    // Same rescale guard as above: a fully masked simdgroup has
+    // m == -INFINITY with a 0 (or NaN-poisoned) sum that must pass through
+    // unscaled; exp(m - global_max) is exp(nan) when global_max is also
+    // -INFINITY (fully masked chunk/row).
+    float s = (simd_lane_id < num_simdgroups) ? shared_sum[simd_lane_id] : 0.0f;
+    if (m > -INFINITY) {
+      s *= metal::precise::exp(m - global_max);
+    }
     float global_sum = simd_sum(s);
     if (simd_lane_id == 0) {
       partials[(row_id * num_chunks + chunk_id) * 2] = global_max;
@@ -397,10 +439,14 @@ kernel void softmax_forward_2pass_write(
     float chunk_max = partials[(row_id * num_chunks + i) * 2];
     float chunk_sum = partials[(row_id * num_chunks + i) * 2 + 1];
     float new_max = fmax(global_max, chunk_max);
+    // new_max == -INFINITY means every chunk seen so far was fully masked;
+    // both sums are then 0, or NaN when a chunk contained a NaN input. Add
+    // them (instead of zeroing) so NaN poisoning survives; the exp rescales
+    // are unusable here (exp(-inf - -inf) is NaN).
     global_sum = (new_max > -INFINITY)
         ? global_sum * metal::precise::exp(global_max - new_max) +
             chunk_sum * metal::precise::exp(chunk_max - new_max)
-        : 0.0f;
+        : global_sum + chunk_sum;
     global_max = new_max;
   }
   float inv_sum = 1.0f / global_sum;
@@ -801,14 +847,22 @@ kernel void softmax_forward_tiled(
 
   float local_max = -INFINITY;
   float local_sum = 0.0f;
+  bool found_nan = false;
   for (uint b = 0; b < axis_size; b++) {
     float val = float(input[base_a + ulong(b) * sa]);
+    found_nan = found_nan || metal::isnan(val);
     float new_max = fmax(local_max, val);
     local_sum = (new_max > -INFINITY)
         ? local_sum * metal::precise::exp(local_max - new_max) +
             metal::precise::exp(val - new_max)
         : 0.0f;
     local_max = new_max;
+  }
+  // A NaN input must poison the whole row (CPU semantics): fmax() drops NaNs,
+  // so a NaN seen while the running max was still -INFINITY never entered
+  // local_sum. Applied after the scan so it is order-independent.
+  if (found_nan) {
+    local_sum = NAN;
   }
   float inv_sum = 1.0f / local_sum;
 
@@ -918,9 +972,11 @@ kernel void softmax_forward_blocked(
   ulong col_base_a = ulong(batch_idx) * axis_size * sa + ulong(col_global);
   float local_max = -INFINITY;
   float local_sum = 0.0f;
+  bool found_nan = false;
   if (active) {
     for (uint b = axis_tid; b < axis_size; b += num_axis_threads) {
       float val = float(input[col_base_a + ulong(b) * sa]);
+      found_nan = found_nan || metal::isnan(val);
       float new_max = fmax(local_max, val);
       local_sum = (new_max > -INFINITY)
           ? local_sum * metal::precise::exp(local_max - new_max) +
@@ -928,6 +984,12 @@ kernel void softmax_forward_blocked(
           : 0.0f;
       local_max = new_max;
     }
+  }
+  // A NaN input must poison the whole column (CPU semantics): fmax() drops
+  // NaNs, so a NaN seen while the running max was still -INFINITY never
+  // entered local_sum. Applied after the scan so it is order-independent.
+  if (found_nan) {
+    local_sum = NAN;
   }
 
   // Tree reduction across the num_axis_threads sharing each column.
@@ -941,9 +1003,13 @@ kernel void softmax_forward_blocked(
       uint o = tid + s * cols_per_tg;
       float om = mx[o], os = sm[o], mm = mx[tid], ms = sm[tid];
       float nm = fmax(mm, om);
+      // nm == -INFINITY means both halves were fully masked; their sums are
+      // then 0, or NaN when a NaN input was seen. Add them (instead of
+      // zeroing) so NaN poisoning survives; the exp rescales are unusable
+      // here (exp(-inf - -inf) is NaN).
       sm[tid] = (nm > -INFINITY) ? ms * metal::precise::exp(mm - nm) +
               os * metal::precise::exp(om - nm)
-                                 : 0.0f;
+                                 : ms + os;
       mx[tid] = nm;
     }
     threadgroup_barrier(mem_flags::mem_threadgroup);
@@ -1062,9 +1128,11 @@ kernel void softmax_forward_blocked2_reduce(
   ulong col_base_a = ulong(batch_idx) * axis_size * sa + ulong(col_global);
   float local_max = -INFINITY;
   float local_sum = 0.0f;
+  bool found_nan = false;
   if (active) {
     for (uint b = start + axis_tid; b < end; b += num_axis_threads) {
       float val = float(input[col_base_a + ulong(b) * sa]);
+      found_nan = found_nan || metal::isnan(val);
       float new_max = fmax(local_max, val);
       local_sum = (new_max > -INFINITY)
           ? local_sum * metal::precise::exp(local_max - new_max) +
@@ -1072,6 +1140,12 @@ kernel void softmax_forward_blocked2_reduce(
           : 0.0f;
       local_max = new_max;
     }
+  }
+  // A NaN input must poison the whole column (CPU semantics): fmax() drops
+  // NaNs, so a NaN seen while the running max was still -INFINITY never
+  // entered local_sum. Applied after the scan so it is order-independent.
+  if (found_nan) {
+    local_sum = NAN;
   }
 
   threadgroup float* mx = smem;
@@ -1084,9 +1158,13 @@ kernel void softmax_forward_blocked2_reduce(
       uint o = tid + s * cols_per_tg;
       float om = mx[o], os = sm[o], mm = mx[tid], ms = sm[tid];
       float nm = fmax(mm, om);
+      // nm == -INFINITY means both halves were fully masked; their sums are
+      // then 0, or NaN when a NaN input was seen. Add them (instead of
+      // zeroing) so NaN poisoning survives; the exp rescales are unusable
+      // here (exp(-inf - -inf) is NaN).
       sm[tid] = (nm > -INFINITY) ? ms * metal::precise::exp(mm - nm) +
               os * metal::precise::exp(om - nm)
-                                 : 0.0f;
+                                 : ms + os;
       mx[tid] = nm;
     }
     threadgroup_barrier(mem_flags::mem_threadgroup);
@@ -1135,10 +1213,14 @@ kernel void softmax_forward_blocked2_write(
       float cm = partials[(pbase + i) * 2];
       float cs = partials[(pbase + i) * 2 + 1];
       float nm = fmax(global_max, cm);
+      // nm == -INFINITY means every chunk seen so far was fully masked; both
+      // sums are then 0, or NaN when a chunk contained a NaN input. Add them
+      // (instead of zeroing) so NaN poisoning survives; the exp rescales are
+      // unusable here (exp(-inf - -inf) is NaN).
       global_sum = (nm > -INFINITY)
           ? global_sum * metal::precise::exp(global_max - nm) +
               cs * metal::precise::exp(cm - nm)
-          : 0.0f;
+          : global_sum + cs;
       global_max = nm;
     }
   }
@@ -1294,14 +1376,22 @@ kernel void softmax_forward_coalesced(
 
   float local_max = -INFINITY;
   float local_sum = 0.0f;
+  bool found_nan = false;
   for (uint off = tid; off < total; off += lsize) {
     float val = float(input[base_a + ulong(off)]);
+    found_nan = found_nan || metal::isnan(val);
     float new_max = fmax(local_max, val);
     local_sum = (new_max > -INFINITY)
         ? local_sum * metal::precise::exp(local_max - new_max) +
             metal::precise::exp(val - new_max)
         : 0.0f;
     local_max = new_max;
+  }
+  // A NaN input must poison the whole column (CPU semantics): fmax() drops
+  // NaNs, so a NaN seen while the running max was still -INFINITY never
+  // entered local_sum. Applied after the scan so it is order-independent.
+  if (found_nan) {
+    local_sum = NAN;
   }
 
   threadgroup float* mx = smem;
@@ -1315,9 +1405,13 @@ kernel void softmax_forward_coalesced(
       uint o = tid + s * sa;
       float om = mx[o], os = sm[o], mm = mx[tid], ms = sm[tid];
       float nm = fmax(mm, om);
+      // nm == -INFINITY means both halves were fully masked; their sums are
+      // then 0, or NaN when a NaN input was seen. Add them (instead of
+      // zeroing) so NaN poisoning survives; the exp rescales are unusable
+      // here (exp(-inf - -inf) is NaN).
       sm[tid] = (nm > -INFINITY) ? ms * metal::precise::exp(mm - nm) +
               os * metal::precise::exp(om - nm)
-                                 : 0.0f;
+                                 : ms + os;
       mx[tid] = nm;
     }
     threadgroup_barrier(mem_flags::mem_threadgroup);

--- a/aten/src/ATen/native/mps/kernels/SoftMaxKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/SoftMaxKernel.metal
@@ -281,6 +281,167 @@ kernel void softmax_forward_looped(
 // algorithm. Phase 2: each threadgroup combines partials, re-reads input,
 // writes output.
 
+template <typename T>
+kernel void softmax_forward_2pass_reduce(
+    device const T* input [[buffer(0)]],
+    device float* partials [[buffer(1)]],
+    constant SoftmaxParams& params [[buffer(2)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  constexpr int N_READS = 4;
+  uint num_chunks = params.num_chunks;
+  uint chunk_id = tg_id % num_chunks;
+  uint row_id = tg_id / num_chunks;
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  device const T* x = input + offset_a(row_id, params);
+  bool contiguous = (sa == 1);
+
+  uint elems_per_chunk = (axis_size + num_chunks - 1) / num_chunks;
+  uint start = chunk_id * elems_per_chunk;
+  uint end = min(start + elems_per_chunk, axis_size);
+
+  float local_max = -INFINITY;
+  float local_sum = 0.0f;
+  for (uint r = start; r < end; r += lsize * N_READS) {
+    uint base = r + tid * N_READS;
+    if (base + N_READS <= end) {
+      float4 v;
+      if (contiguous) {
+        v = load_vec4(x + base);
+      } else {
+        v = float4(
+            x[base * sa],
+            x[(base + 1) * sa],
+            x[(base + 2) * sa],
+            x[(base + 3) * sa]);
+      }
+      float chunk_max = fmax(fmax(v.x, v.y), fmax(v.z, v.w));
+      float new_max = fmax(local_max, chunk_max);
+      local_sum = (new_max > -INFINITY)
+          ? local_sum * metal::precise::exp(local_max - new_max) +
+              metal::precise::exp(v.x - new_max) +
+              metal::precise::exp(v.y - new_max) +
+              metal::precise::exp(v.z - new_max) +
+              metal::precise::exp(v.w - new_max)
+          : 0.0f;
+      local_max = new_max;
+    } else {
+      for (uint i = base; i < min(base + uint(N_READS), end); i++) {
+        float val = contiguous ? float(x[i]) : float(x[i * sa]);
+        float new_max = fmax(local_max, val);
+        local_sum = (new_max > -INFINITY)
+            ? local_sum * metal::precise::exp(local_max - new_max) +
+                metal::precise::exp(val - new_max)
+            : 0.0f;
+        local_max = new_max;
+      }
+    }
+  }
+
+  float sg_max = simd_max(local_max);
+  local_sum *= metal::precise::exp(local_max - sg_max);
+  float sg_sum = simd_sum(local_sum);
+
+  threadgroup float shared_max[simdgroup_size];
+  threadgroup float shared_sum[simdgroup_size];
+
+  if (simd_lane_id == 0) {
+    shared_max[simdgroup_id] = sg_max;
+    shared_sum[simdgroup_id] = sg_sum;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  uint num_simdgroups = (lsize + simdgroup_size - 1) / simdgroup_size;
+  if (simdgroup_id == 0) {
+    float m =
+        (simd_lane_id < num_simdgroups) ? shared_max[simd_lane_id] : -INFINITY;
+    float global_max = simd_max(m);
+    float s = (simd_lane_id < num_simdgroups)
+        ? shared_sum[simd_lane_id] * metal::precise::exp(m - global_max)
+        : 0.0f;
+    float global_sum = simd_sum(s);
+    if (simd_lane_id == 0) {
+      partials[(row_id * num_chunks + chunk_id) * 2] = global_max;
+      partials[(row_id * num_chunks + chunk_id) * 2 + 1] = global_sum;
+    }
+  }
+}
+
+template <typename T>
+kernel void softmax_forward_2pass_write(
+    device const T* input [[buffer(0)]],
+    device T* output [[buffer(1)]],
+    device const float* partials [[buffer(2)]],
+    constant SoftmaxParams& params [[buffer(3)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]]) {
+  constexpr int N_READS = 4;
+  uint num_chunks = params.num_chunks;
+  uint chunk_id = tg_id % num_chunks;
+  uint row_id = tg_id / num_chunks;
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint sb = params.stride_b;
+  device const T* x = input + offset_a(row_id, params);
+  device T* out = output + offset_b(row_id, params);
+  bool contiguous = (sa == 1);
+
+  float global_max = -INFINITY;
+  float global_sum = 0.0f;
+  for (uint i = 0; i < num_chunks; i++) {
+    float chunk_max = partials[(row_id * num_chunks + i) * 2];
+    float chunk_sum = partials[(row_id * num_chunks + i) * 2 + 1];
+    float new_max = fmax(global_max, chunk_max);
+    global_sum = (new_max > -INFINITY)
+        ? global_sum * metal::precise::exp(global_max - new_max) +
+            chunk_sum * metal::precise::exp(chunk_max - new_max)
+        : 0.0f;
+    global_max = new_max;
+  }
+  float inv_sum = 1.0f / global_sum;
+
+  uint elems_per_chunk = (axis_size + num_chunks - 1) / num_chunks;
+  uint start = chunk_id * elems_per_chunk;
+  uint end = min(start + elems_per_chunk, axis_size);
+
+  for (uint r = start; r < end; r += lsize * N_READS) {
+    uint base = r + tid * N_READS;
+    if (base + N_READS <= end) {
+      float4 v;
+      if (contiguous) {
+        v = metal::precise::exp(load_vec4(x + base) - global_max) * inv_sum;
+      } else {
+        v = float4(
+            metal::precise::exp(float(x[base * sa]) - global_max) * inv_sum,
+            metal::precise::exp(float(x[(base + 1) * sa]) - global_max) *
+                inv_sum,
+            metal::precise::exp(float(x[(base + 2) * sa]) - global_max) *
+                inv_sum,
+            metal::precise::exp(float(x[(base + 3) * sa]) - global_max) *
+                inv_sum);
+      }
+      if (sb == 1) {
+        store_vec4(out + base, v);
+      } else {
+#pragma unroll
+        for (int i = 0; i < N_READS; i++)
+          out[(base + i) * sb] = static_cast<T>(v[i]);
+      }
+    } else {
+      for (uint i = base; i < min(base + uint(N_READS), end); i++) {
+        float val = contiguous ? float(x[i]) : float(x[i * sa]);
+        out[i * sb] =
+            static_cast<T>(metal::precise::exp(val - global_max) * inv_sum);
+      }
+    }
+  }
+}
+
 // Backward: grad_input = output * (grad_output - sum(grad_output * output))
 // stride_a = grad_output strides, stride_b = output strides
 // Writes grad_input contiguously.
@@ -479,11 +640,748 @@ kernel void softmax_backward_looped(
 // Phase 2: each threadgroup sums partial dots, then computes grad_input for its
 // chunk.
 
+template <typename T>
+kernel void softmax_backward_2pass_dot(
+    device const T* grad_output [[buffer(0)]],
+    device const T* output [[buffer(1)]],
+    device float* partial_sums [[buffer(2)]],
+    constant SoftmaxParams& params [[buffer(3)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  constexpr int N_READS = 4;
+  uint num_chunks = params.num_chunks;
+  uint chunk_id = tg_id % num_chunks;
+  uint row_id = tg_id / num_chunks;
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint sb = params.stride_b;
+  device const T* dy = grad_output + offset_a(row_id, params);
+  device const T* y = output + offset_b(row_id, params);
+  bool contiguous = (sa == 1) && (sb == 1);
+
+  uint elems_per_chunk = (axis_size + num_chunks - 1) / num_chunks;
+  uint start = chunk_id * elems_per_chunk;
+  uint end = min(start + elems_per_chunk, axis_size);
+
+  float local_dot = 0.0f;
+  for (uint r = start; r < end; r += lsize * N_READS) {
+    uint base = r + tid * N_READS;
+    if (base + N_READS <= end) {
+      if (contiguous) {
+        local_dot += dot(load_vec4(dy + base), load_vec4(y + base));
+      } else {
+        float4 dy_v = float4(
+            dy[base * sa],
+            dy[(base + 1) * sa],
+            dy[(base + 2) * sa],
+            dy[(base + 3) * sa]);
+        float4 y_v = float4(
+            y[base * sb],
+            y[(base + 1) * sb],
+            y[(base + 2) * sb],
+            y[(base + 3) * sb]);
+        local_dot += dot(dy_v, y_v);
+      }
+    } else {
+      for (uint i = base; i < min(base + uint(N_READS), end); i++)
+        local_dot += (contiguous ? float(dy[i]) : float(dy[i * sa])) *
+            (contiguous ? float(y[i]) : float(y[i * sb]));
+    }
+  }
+
+  threadgroup float shared_dot[simdgroup_size];
+  float d = c10::metal::threadgroup_sum(shared_dot, local_dot, tid, lsize);
+  if (tid == 0)
+    partial_sums[row_id * num_chunks + chunk_id] = d;
+}
+
+template <typename T>
+kernel void softmax_backward_2pass_grad(
+    device const T* grad_output [[buffer(0)]],
+    device const T* output [[buffer(1)]],
+    device T* grad_input [[buffer(2)]],
+    device const float* partial_sums [[buffer(3)]],
+    constant SoftmaxParams& params [[buffer(4)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]]) {
+  constexpr int N_READS = 4;
+  uint num_chunks = params.num_chunks;
+  uint chunk_id = tg_id % num_chunks;
+  uint row_id = tg_id / num_chunks;
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint sb = params.stride_b;
+  uint sc = params.stride_c;
+  device const T* dy = grad_output + offset_a(row_id, params);
+  device const T* y = output + offset_b(row_id, params);
+  device T* dx = grad_input + offset_c(row_id, params);
+  bool contiguous = (sa == 1) && (sb == 1);
+
+  float dot_sum = 0.0f;
+  for (uint i = 0; i < num_chunks; i++)
+    dot_sum += partial_sums[row_id * num_chunks + i];
+
+  uint elems_per_chunk = (axis_size + num_chunks - 1) / num_chunks;
+  uint start = chunk_id * elems_per_chunk;
+  uint end = min(start + elems_per_chunk, axis_size);
+
+  for (uint r = start; r < end; r += lsize * N_READS) {
+    uint base = r + tid * N_READS;
+    if (base + N_READS <= end) {
+      float4 y_v, dy_v;
+      if (contiguous) {
+        y_v = load_vec4(y + base);
+        dy_v = load_vec4(dy + base);
+      } else {
+        y_v = float4(
+            y[base * sb],
+            y[(base + 1) * sb],
+            y[(base + 2) * sb],
+            y[(base + 3) * sb]);
+        dy_v = float4(
+            dy[base * sa],
+            dy[(base + 1) * sa],
+            dy[(base + 2) * sa],
+            dy[(base + 3) * sa]);
+      }
+      float4 result = y_v * (dy_v - dot_sum);
+      if (sc == 1) {
+        store_vec4(dx + base, result);
+      } else {
+#pragma unroll
+        for (int i = 0; i < N_READS; i++)
+          dx[(base + i) * sc] = static_cast<T>(result[i]);
+      }
+    } else {
+      for (uint i = base; i < min(base + uint(N_READS), end); i++) {
+        float yi = contiguous ? float(y[i]) : float(y[i * sb]);
+        float dyi = contiguous ? float(dy[i]) : float(dy[i * sa]);
+        dx[i * sc] = static_cast<T>(yi * (dyi - dot_sum));
+      }
+    }
+  }
+}
+
 // Log-softmax forward 2-pass: for low-occupancy (outer_size < 4, large axis)
 // Phase 1: each threadgroup computes (chunk_max, chunk_sum) via online
 // algorithm Phase 2: combine partials, compute shift = max + log(sum), write
 // output = x - shift Log-softmax backward: grad_input = grad_output -
 // exp(output) * sum(grad_output)
+
+// Tiled forward/backward kernels for non-last-dim softmax.
+// Each thread computes softmax for all axis elements at one inner position.
+// Adjacent threads access adjacent memory - coalesced reads and writes.
+// Uses num_chunks to store the number of inner tiles.
+
+template <typename T>
+kernel void softmax_forward_tiled(
+    device const T* input [[buffer(0)]],
+    device T* output [[buffer(1)]],
+    constant SoftmaxParams& params [[buffer(2)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]]) {
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint sb = params.stride_b;
+  uint num_tiles = params.num_chunks;
+  uint batch_idx = tg_id / num_tiles;
+  uint tile_idx = tg_id % num_tiles;
+  uint inner_pos = tile_idx * lsize + tid;
+
+  if (inner_pos >= sa)
+    return;
+
+  ulong base_a = ulong(batch_idx) * axis_size * sa + inner_pos;
+  ulong base_b = ulong(batch_idx) * axis_size * sb + inner_pos;
+
+  float local_max = -INFINITY;
+  float local_sum = 0.0f;
+  for (uint b = 0; b < axis_size; b++) {
+    float val = float(input[base_a + ulong(b) * sa]);
+    float new_max = fmax(local_max, val);
+    local_sum = (new_max > -INFINITY)
+        ? local_sum * metal::precise::exp(local_max - new_max) +
+            metal::precise::exp(val - new_max)
+        : 0.0f;
+    local_max = new_max;
+  }
+  float inv_sum = 1.0f / local_sum;
+
+  for (uint b = 0; b < axis_size; b++) {
+    float val = float(input[base_a + ulong(b) * sa]);
+    output[base_b + ulong(b) * sb] =
+        static_cast<T>(metal::precise::exp(val - local_max) * inv_sum);
+  }
+}
+
+template <typename T>
+kernel void softmax_backward_tiled(
+    device const T* grad_output [[buffer(0)]],
+    device const T* output [[buffer(1)]],
+    device T* grad_input [[buffer(2)]],
+    constant SoftmaxParams& params [[buffer(3)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]]) {
+  constexpr uint kTileAxisCap = 32;
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint sb = params.stride_b;
+  uint sc = params.stride_c;
+  uint num_tiles = params.num_chunks;
+  uint batch_idx = tg_id / num_tiles;
+  uint tile_idx = tg_id % num_tiles;
+  uint inner_pos = tile_idx * lsize + tid;
+
+  if (inner_pos >= sa)
+    return;
+
+  ulong base_a = ulong(batch_idx) * axis_size * sa + inner_pos;
+  ulong base_b = ulong(batch_idx) * axis_size * sb + inner_pos;
+  ulong base_c = ulong(batch_idx) * axis_size * sc + inner_pos;
+
+  float dot_sum = 0.0f;
+  if (axis_size <= kTileAxisCap) {
+    float dy_cache[kTileAxisCap];
+    float y_cache[kTileAxisCap];
+    for (uint b = 0; b < axis_size; b++) {
+      dy_cache[b] = float(grad_output[base_a + ulong(b) * sa]);
+      y_cache[b] = float(output[base_b + ulong(b) * sb]);
+      dot_sum += dy_cache[b] * y_cache[b];
+    }
+    for (uint b = 0; b < axis_size; b++)
+      grad_input[base_c + ulong(b) * sc] =
+          static_cast<T>(y_cache[b] * (dy_cache[b] - dot_sum));
+  } else {
+    for (uint b = 0; b < axis_size; b++)
+      dot_sum += float(grad_output[base_a + ulong(b) * sa]) *
+          float(output[base_b + ulong(b) * sb]);
+    for (uint b = 0; b < axis_size; b++) {
+      float dyi = float(grad_output[base_a + ulong(b) * sa]);
+      float yi = float(output[base_b + ulong(b) * sb]);
+      grad_input[base_c + ulong(b) * sc] = static_cast<T>(yi * (dyi - dot_sum));
+    }
+  }
+}
+
+// Blocked non-last-dim kernels (cooperative axis reduction).
+//
+// For non-last-dim softmax the axis elements of one column are strided by
+// inner_size in memory, while adjacent columns are unit-strided. The tiled
+// kernel assigns one thread per column and walks the whole axis serially, which
+// is coalesced across threads but offers zero per-column parallelism: when the
+// axis is large (square dim=0, e.g. 1024x1024, or tall dim=0, e.g. 65536x128)
+// each thread does a long serial 2-pass reduction and the kernel runs far below
+// memory bandwidth.
+//
+// These kernels keep the coalesced access pattern (adjacent threads -> adjacent
+// columns) but add per-column parallelism: a threadgroup owns COLS_PER_TG
+// adjacent columns (num_chunks) and packs num_axis_threads (lsize/COLS_PER_TG)
+// threads per column that cooperate over the axis via a shared-memory tree
+// reduction. Unlike the coalesced kernel this works for any axis_size (no 16384
+// cap) because the per-thread axis slice is axis_size/num_axis_threads, and
+// COLS_PER_TG is independent of inner_size so it scales to large inner_size.
+//
+//   tid layout:  col = tid % cols_per_tg, axis_tid = tid / cols_per_tg
+//   col_global = tg_id * cols_per_tg + col
+//   params.num_chunks = cols_per_tg
+
+template <typename T>
+kernel void softmax_forward_blocked(
+    device const T* input [[buffer(0)]],
+    device T* output [[buffer(1)]],
+    constant SoftmaxParams& params [[buffer(2)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]],
+    threadgroup float* smem [[threadgroup(0)]]) {
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint sb = params.stride_b;
+  uint cols_per_tg = params.num_chunks;
+  uint num_axis_threads = lsize / cols_per_tg;
+  uint num_col_tiles = (sa + cols_per_tg - 1) / cols_per_tg;
+  uint batch_idx = tg_id / num_col_tiles;
+  uint col_tile = tg_id % num_col_tiles;
+  uint col = tid % cols_per_tg;
+  uint axis_tid = tid / cols_per_tg;
+  uint col_global = col_tile * cols_per_tg + col;
+  bool active = (col_global < sa);
+
+  // Each thread reduces a strided slice of the axis for its column. Adjacent
+  // tids (adjacent col) read adjacent addresses -> coalesced.
+  ulong col_base_a = ulong(batch_idx) * axis_size * sa + ulong(col_global);
+  float local_max = -INFINITY;
+  float local_sum = 0.0f;
+  if (active) {
+    for (uint b = axis_tid; b < axis_size; b += num_axis_threads) {
+      float val = float(input[col_base_a + ulong(b) * sa]);
+      float new_max = fmax(local_max, val);
+      local_sum = (new_max > -INFINITY)
+          ? local_sum * metal::precise::exp(local_max - new_max) +
+              metal::precise::exp(val - new_max)
+          : 0.0f;
+      local_max = new_max;
+    }
+  }
+
+  // Tree reduction across the num_axis_threads sharing each column.
+  threadgroup float* mx = smem;
+  threadgroup float* sm = smem + lsize;
+  mx[tid] = local_max;
+  sm[tid] = local_sum;
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  for (uint s = num_axis_threads / 2; s > 0; s >>= 1) {
+    if (axis_tid < s) {
+      uint o = tid + s * cols_per_tg;
+      float om = mx[o], os = sm[o], mm = mx[tid], ms = sm[tid];
+      float nm = fmax(mm, om);
+      sm[tid] = (nm > -INFINITY) ? ms * metal::precise::exp(mm - nm) +
+              os * metal::precise::exp(om - nm)
+                                 : 0.0f;
+      mx[tid] = nm;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+
+  float row_max = mx[col];
+  float inv_sum = 1.0f / sm[col];
+
+  if (active) {
+    ulong col_base_b = ulong(batch_idx) * axis_size * sb + ulong(col_global);
+    for (uint b = axis_tid; b < axis_size; b += num_axis_threads) {
+      float val = float(input[col_base_a + ulong(b) * sa]);
+      output[col_base_b + ulong(b) * sb] =
+          static_cast<T>(metal::precise::exp(val - row_max) * inv_sum);
+    }
+  }
+}
+
+template <typename T>
+kernel void softmax_backward_blocked(
+    device const T* grad_output [[buffer(0)]],
+    device const T* output [[buffer(1)]],
+    device T* grad_input [[buffer(2)]],
+    constant SoftmaxParams& params [[buffer(3)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]],
+    threadgroup float* smem [[threadgroup(0)]]) {
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint sb = params.stride_b;
+  uint sc = params.stride_c;
+  uint cols_per_tg = params.num_chunks;
+  uint num_axis_threads = lsize / cols_per_tg;
+  uint num_col_tiles = (sa + cols_per_tg - 1) / cols_per_tg;
+  uint batch_idx = tg_id / num_col_tiles;
+  uint col_tile = tg_id % num_col_tiles;
+  uint col = tid % cols_per_tg;
+  uint axis_tid = tid / cols_per_tg;
+  uint col_global = col_tile * cols_per_tg + col;
+  bool active = (col_global < sa);
+
+  ulong col_base_a = ulong(batch_idx) * axis_size * sa + ulong(col_global);
+  ulong col_base_b = ulong(batch_idx) * axis_size * sb + ulong(col_global);
+  float local_dot = 0.0f;
+  if (active) {
+    for (uint b = axis_tid; b < axis_size; b += num_axis_threads) {
+      local_dot += float(grad_output[col_base_a + ulong(b) * sa]) *
+          float(output[col_base_b + ulong(b) * sb]);
+    }
+  }
+
+  smem[tid] = local_dot;
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  for (uint s = num_axis_threads / 2; s > 0; s >>= 1) {
+    if (axis_tid < s)
+      smem[tid] += smem[tid + s * cols_per_tg];
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+  float dot_sum = smem[col];
+
+  if (active) {
+    ulong col_base_c = ulong(batch_idx) * axis_size * sc + ulong(col_global);
+    for (uint b = axis_tid; b < axis_size; b += num_axis_threads) {
+      float dyi = float(grad_output[col_base_a + ulong(b) * sa]);
+      float yi = float(output[col_base_b + ulong(b) * sb]);
+      grad_input[col_base_c + ulong(b) * sc] =
+          static_cast<T>(yi * (dyi - dot_sum));
+    }
+  }
+}
+
+// Two-pass blocked non-last-dim kernels for the LOW-COLUMN, long-axis case
+// (tall dim=0, e.g. 65536x128: only 128 columns, axis 65536). The single-pass
+// blocked kernel can only spawn inner_size/cols_per_tg threadgroups, which
+// starves occupancy when columns are few. These kernels add an axis-split grid
+// dimension (num_col_chunks chunks) so the grid is
+// outer_before * num_col_tiles * num_col_chunks threadgroups.
+//
+//   tg_id decode: axis_chunk = tg_id % num_col_chunks
+//                 col_tile   = (tg_id / num_col_chunks) % num_col_tiles
+//                 batch_idx  =  tg_id / num_col_chunks  / num_col_tiles
+//   partials layout (2 floats per (column, axis_chunk)):
+//     [(batch * inner + col_global) * num_col_chunks + axis_chunk] * 2 +
+//     {0:max,1:sum}
+
+template <typename T>
+kernel void softmax_forward_blocked2_reduce(
+    device const T* input [[buffer(0)]],
+    device float* partials [[buffer(1)]],
+    constant SoftmaxParams& params [[buffer(2)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]],
+    threadgroup float* smem [[threadgroup(0)]]) {
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint cols_per_tg = params.num_chunks;
+  uint num_axis_chunks = params.num_col_chunks;
+  uint num_axis_threads = lsize / cols_per_tg;
+  uint num_col_tiles = (sa + cols_per_tg - 1) / cols_per_tg;
+
+  uint axis_chunk = tg_id % num_axis_chunks;
+  uint t2 = tg_id / num_axis_chunks;
+  uint col_tile = t2 % num_col_tiles;
+  uint batch_idx = t2 / num_col_tiles;
+  uint col = tid % cols_per_tg;
+  uint axis_tid = tid / cols_per_tg;
+  uint col_global = col_tile * cols_per_tg + col;
+  bool active = (col_global < sa);
+
+  uint elems_per_chunk = (axis_size + num_axis_chunks - 1) / num_axis_chunks;
+  uint start = axis_chunk * elems_per_chunk;
+  uint end = min(start + elems_per_chunk, axis_size);
+
+  ulong col_base_a = ulong(batch_idx) * axis_size * sa + ulong(col_global);
+  float local_max = -INFINITY;
+  float local_sum = 0.0f;
+  if (active) {
+    for (uint b = start + axis_tid; b < end; b += num_axis_threads) {
+      float val = float(input[col_base_a + ulong(b) * sa]);
+      float new_max = fmax(local_max, val);
+      local_sum = (new_max > -INFINITY)
+          ? local_sum * metal::precise::exp(local_max - new_max) +
+              metal::precise::exp(val - new_max)
+          : 0.0f;
+      local_max = new_max;
+    }
+  }
+
+  threadgroup float* mx = smem;
+  threadgroup float* sm = smem + lsize;
+  mx[tid] = local_max;
+  sm[tid] = local_sum;
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  for (uint s = num_axis_threads / 2; s > 0; s >>= 1) {
+    if (axis_tid < s) {
+      uint o = tid + s * cols_per_tg;
+      float om = mx[o], os = sm[o], mm = mx[tid], ms = sm[tid];
+      float nm = fmax(mm, om);
+      sm[tid] = (nm > -INFINITY) ? ms * metal::precise::exp(mm - nm) +
+              os * metal::precise::exp(om - nm)
+                                 : 0.0f;
+      mx[tid] = nm;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+
+  if (axis_tid == 0 && active) {
+    ulong pidx = (ulong(batch_idx) * sa + ulong(col_global)) * num_axis_chunks +
+        axis_chunk;
+    partials[pidx * 2] = mx[col];
+    partials[pidx * 2 + 1] = sm[col];
+  }
+}
+
+template <typename T>
+kernel void softmax_forward_blocked2_write(
+    device const T* input [[buffer(0)]],
+    device T* output [[buffer(1)]],
+    device const float* partials [[buffer(2)]],
+    constant SoftmaxParams& params [[buffer(3)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]]) {
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint sb = params.stride_b;
+  uint cols_per_tg = params.num_chunks;
+  uint num_axis_chunks = params.num_col_chunks;
+  uint num_axis_threads = lsize / cols_per_tg;
+  uint num_col_tiles = (sa + cols_per_tg - 1) / cols_per_tg;
+
+  uint axis_chunk = tg_id % num_axis_chunks;
+  uint t2 = tg_id / num_axis_chunks;
+  uint col_tile = t2 % num_col_tiles;
+  uint batch_idx = t2 / num_col_tiles;
+  uint col = tid % cols_per_tg;
+  uint axis_tid = tid / cols_per_tg;
+  uint col_global = col_tile * cols_per_tg + col;
+  bool active = (col_global < sa);
+
+  // Combine all axis-chunk partials for this column (serial over chunks).
+  float global_max = -INFINITY;
+  float global_sum = 0.0f;
+  if (active) {
+    ulong pbase = (ulong(batch_idx) * sa + ulong(col_global)) * num_axis_chunks;
+    for (uint i = 0; i < num_axis_chunks; i++) {
+      float cm = partials[(pbase + i) * 2];
+      float cs = partials[(pbase + i) * 2 + 1];
+      float nm = fmax(global_max, cm);
+      global_sum = (nm > -INFINITY)
+          ? global_sum * metal::precise::exp(global_max - nm) +
+              cs * metal::precise::exp(cm - nm)
+          : 0.0f;
+      global_max = nm;
+    }
+  }
+  float inv_sum = 1.0f / global_sum;
+
+  uint elems_per_chunk = (axis_size + num_axis_chunks - 1) / num_axis_chunks;
+  uint start = axis_chunk * elems_per_chunk;
+  uint end = min(start + elems_per_chunk, axis_size);
+
+  if (active) {
+    ulong col_base_a = ulong(batch_idx) * axis_size * sa + ulong(col_global);
+    ulong col_base_b = ulong(batch_idx) * axis_size * sb + ulong(col_global);
+    for (uint b = start + axis_tid; b < end; b += num_axis_threads) {
+      float val = float(input[col_base_a + ulong(b) * sa]);
+      output[col_base_b + ulong(b) * sb] =
+          static_cast<T>(metal::precise::exp(val - global_max) * inv_sum);
+    }
+  }
+}
+
+template <typename T>
+kernel void softmax_backward_blocked2_dot(
+    device const T* grad_output [[buffer(0)]],
+    device const T* output [[buffer(1)]],
+    device float* partials [[buffer(2)]],
+    constant SoftmaxParams& params [[buffer(3)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]],
+    threadgroup float* smem [[threadgroup(0)]]) {
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint sb = params.stride_b;
+  uint cols_per_tg = params.num_chunks;
+  uint num_axis_chunks = params.num_col_chunks;
+  uint num_axis_threads = lsize / cols_per_tg;
+  uint num_col_tiles = (sa + cols_per_tg - 1) / cols_per_tg;
+
+  uint axis_chunk = tg_id % num_axis_chunks;
+  uint t2 = tg_id / num_axis_chunks;
+  uint col_tile = t2 % num_col_tiles;
+  uint batch_idx = t2 / num_col_tiles;
+  uint col = tid % cols_per_tg;
+  uint axis_tid = tid / cols_per_tg;
+  uint col_global = col_tile * cols_per_tg + col;
+  bool active = (col_global < sa);
+
+  uint elems_per_chunk = (axis_size + num_axis_chunks - 1) / num_axis_chunks;
+  uint start = axis_chunk * elems_per_chunk;
+  uint end = min(start + elems_per_chunk, axis_size);
+
+  ulong col_base_a = ulong(batch_idx) * axis_size * sa + ulong(col_global);
+  ulong col_base_b = ulong(batch_idx) * axis_size * sb + ulong(col_global);
+  float local_dot = 0.0f;
+  if (active) {
+    for (uint b = start + axis_tid; b < end; b += num_axis_threads) {
+      local_dot += float(grad_output[col_base_a + ulong(b) * sa]) *
+          float(output[col_base_b + ulong(b) * sb]);
+    }
+  }
+
+  smem[tid] = local_dot;
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  for (uint s = num_axis_threads / 2; s > 0; s >>= 1) {
+    if (axis_tid < s)
+      smem[tid] += smem[tid + s * cols_per_tg];
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+
+  if (axis_tid == 0 && active) {
+    ulong pidx = (ulong(batch_idx) * sa + ulong(col_global)) * num_axis_chunks +
+        axis_chunk;
+    partials[pidx] = smem[col];
+  }
+}
+
+template <typename T>
+kernel void softmax_backward_blocked2_grad(
+    device const T* grad_output [[buffer(0)]],
+    device const T* output [[buffer(1)]],
+    device T* grad_input [[buffer(2)]],
+    device const float* partials [[buffer(3)]],
+    constant SoftmaxParams& params [[buffer(4)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]]) {
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint sb = params.stride_b;
+  uint sc = params.stride_c;
+  uint cols_per_tg = params.num_chunks;
+  uint num_axis_chunks = params.num_col_chunks;
+  uint num_axis_threads = lsize / cols_per_tg;
+  uint num_col_tiles = (sa + cols_per_tg - 1) / cols_per_tg;
+
+  uint axis_chunk = tg_id % num_axis_chunks;
+  uint t2 = tg_id / num_axis_chunks;
+  uint col_tile = t2 % num_col_tiles;
+  uint batch_idx = t2 / num_col_tiles;
+  uint col = tid % cols_per_tg;
+  uint axis_tid = tid / cols_per_tg;
+  uint col_global = col_tile * cols_per_tg + col;
+  bool active = (col_global < sa);
+
+  float dot_sum = 0.0f;
+  if (active) {
+    ulong pbase = (ulong(batch_idx) * sa + ulong(col_global)) * num_axis_chunks;
+    for (uint i = 0; i < num_axis_chunks; i++)
+      dot_sum += partials[pbase + i];
+  }
+
+  uint elems_per_chunk = (axis_size + num_axis_chunks - 1) / num_axis_chunks;
+  uint start = axis_chunk * elems_per_chunk;
+  uint end = min(start + elems_per_chunk, axis_size);
+
+  if (active) {
+    ulong col_base_a = ulong(batch_idx) * axis_size * sa + ulong(col_global);
+    ulong col_base_b = ulong(batch_idx) * axis_size * sb + ulong(col_global);
+    ulong col_base_c = ulong(batch_idx) * axis_size * sc + ulong(col_global);
+    for (uint b = start + axis_tid; b < end; b += num_axis_threads) {
+      float dyi = float(grad_output[col_base_a + ulong(b) * sa]);
+      float yi = float(output[col_base_b + ulong(b) * sb]);
+      grad_input[col_base_c + ulong(b) * sc] =
+          static_cast<T>(yi * (dyi - dot_sum));
+    }
+  }
+}
+
+// Coalesced non-last-dim kernels for inner_size < axis_size.
+// Thread t loads input[base + t] (perfectly coalesced).
+// inner_pos = tid % stride_a, axis_tid = tid / stride_a.
+// Multiple axis_tid threads share one inner_pos; reduced in shared memory.
+// num_chunks stores num_axis_threads for the reduction.
+
+template <typename T>
+kernel void softmax_forward_coalesced(
+    device const T* input [[buffer(0)]],
+    device T* output [[buffer(1)]],
+    constant SoftmaxParams& params [[buffer(2)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]],
+    threadgroup float* smem [[threadgroup(0)]]) {
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint sb = params.stride_b;
+  uint inner_pos = tid % sa;
+  uint axis_tid = tid / sa;
+  uint num_axis_threads = params.num_chunks;
+  uint batch_idx = tg_id;
+  ulong base_a = ulong(batch_idx) * axis_size * sa;
+  uint total = axis_size * sa;
+
+  float local_max = -INFINITY;
+  float local_sum = 0.0f;
+  for (uint off = tid; off < total; off += lsize) {
+    float val = float(input[base_a + ulong(off)]);
+    float new_max = fmax(local_max, val);
+    local_sum = (new_max > -INFINITY)
+        ? local_sum * metal::precise::exp(local_max - new_max) +
+            metal::precise::exp(val - new_max)
+        : 0.0f;
+    local_max = new_max;
+  }
+
+  threadgroup float* mx = smem;
+  threadgroup float* sm = smem + lsize;
+  mx[tid] = local_max;
+  sm[tid] = local_sum;
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  for (uint s = num_axis_threads / 2; s > 0; s >>= 1) {
+    if (axis_tid < s) {
+      uint o = tid + s * sa;
+      float om = mx[o], os = sm[o], mm = mx[tid], ms = sm[tid];
+      float nm = fmax(mm, om);
+      sm[tid] = (nm > -INFINITY) ? ms * metal::precise::exp(mm - nm) +
+              os * metal::precise::exp(om - nm)
+                                 : 0.0f;
+      mx[tid] = nm;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+
+  float fmax_val = mx[inner_pos];
+  float finv = 1.0f / sm[inner_pos];
+
+  ulong base_b = ulong(batch_idx) * axis_size * sb;
+  for (uint off = tid; off < total; off += lsize) {
+    float val = float(input[base_a + ulong(off)]);
+    output[base_b + ulong(off)] =
+        static_cast<T>(metal::precise::exp(val - fmax_val) * finv);
+  }
+}
+
+template <typename T>
+kernel void softmax_backward_coalesced(
+    device const T* grad_output [[buffer(0)]],
+    device const T* output [[buffer(1)]],
+    device T* grad_input [[buffer(2)]],
+    constant SoftmaxParams& params [[buffer(3)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]],
+    threadgroup float* smem [[threadgroup(0)]]) {
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint sb = params.stride_b;
+  uint sc = params.stride_c;
+  uint inner_pos = tid % sa;
+  uint axis_tid = tid / sa;
+  uint num_axis_threads = params.num_chunks;
+  uint batch_idx = tg_id;
+  ulong base_a = ulong(batch_idx) * axis_size * sa;
+  ulong base_b = ulong(batch_idx) * axis_size * sb;
+  uint total = axis_size * sa;
+
+  float local_dot = 0.0f;
+  for (uint off = tid; off < total; off += lsize) {
+    local_dot += float(grad_output[base_a + ulong(off)]) *
+        float(output[base_b + ulong(off)]);
+  }
+
+  smem[tid] = local_dot;
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  for (uint s = num_axis_threads / 2; s > 0; s >>= 1) {
+    if (axis_tid < s)
+      smem[tid] += smem[tid + s * sa];
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+
+  float dot_sum = smem[inner_pos];
+
+  ulong base_c = ulong(batch_idx) * axis_size * sc;
+  for (uint off = tid; off < total; off += lsize) {
+    float dyi = float(grad_output[base_a + ulong(off)]);
+    float yi = float(output[base_b + ulong(off)]);
+    grad_input[base_c + ulong(off)] = static_cast<T>(yi * (dyi - dot_sum));
+  }
+}
+
+// Template instantiations
 
 #define instantiate_softmax_forward_single_row(DTYPE)                     \
   template [[host_name("softmax_forward_single_row_" #DTYPE)]] [[kernel]] \
@@ -562,11 +1460,196 @@ kernel void softmax_backward_looped(
       uint simd_lane_id [[thread_index_in_simdgroup]],                      \
       uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
 
-#define instantiate_softmax(DTYPE)                       \
-  instantiate_softmax_forward_single_row(DTYPE)          \
-      instantiate_softmax_forward_looped(DTYPE)          \
-          instantiate_softmax_backward_single_row(DTYPE) \
-              instantiate_softmax_backward_looped(DTYPE)
+#define instantiate_softmax_backward_2pass_dot(DTYPE)                          \
+  template [[host_name("softmax_backward_2pass_dot_" #DTYPE)]] [[kernel]] void \
+  softmax_backward_2pass_dot<DTYPE>(                                           \
+      device const DTYPE* grad_output [[buffer(0)]],                           \
+      device const DTYPE* output [[buffer(1)]],                                \
+      device float* partial_sums [[buffer(2)]],                                \
+      constant SoftmaxParams& params [[buffer(3)]],                            \
+      uint tg_id [[threadgroup_position_in_grid]],                             \
+      uint tid [[thread_position_in_threadgroup]],                             \
+      uint lsize [[threads_per_threadgroup]],                                  \
+      uint simd_lane_id [[thread_index_in_simdgroup]],                         \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+
+#define instantiate_softmax_backward_2pass_grad(DTYPE)                     \
+  template                                                                 \
+      [[host_name("softmax_backward_2pass_grad_" #DTYPE)]] [[kernel]] void \
+      softmax_backward_2pass_grad<DTYPE>(                                  \
+          device const DTYPE* grad_output [[buffer(0)]],                   \
+          device const DTYPE* output [[buffer(1)]],                        \
+          device DTYPE* grad_input [[buffer(2)]],                          \
+          device const float* partial_sums [[buffer(3)]],                  \
+          constant SoftmaxParams& params [[buffer(4)]],                    \
+          uint tg_id [[threadgroup_position_in_grid]],                     \
+          uint tid [[thread_position_in_threadgroup]],                     \
+          uint lsize [[threads_per_threadgroup]]);
+
+#define instantiate_softmax_forward_2pass_reduce(DTYPE)                     \
+  template                                                                  \
+      [[host_name("softmax_forward_2pass_reduce_" #DTYPE)]] [[kernel]] void \
+      softmax_forward_2pass_reduce<DTYPE>(                                  \
+          device const DTYPE* input [[buffer(0)]],                          \
+          device float* partials [[buffer(1)]],                             \
+          constant SoftmaxParams& params [[buffer(2)]],                     \
+          uint tg_id [[threadgroup_position_in_grid]],                      \
+          uint tid [[thread_position_in_threadgroup]],                      \
+          uint lsize [[threads_per_threadgroup]],                           \
+          uint simd_lane_id [[thread_index_in_simdgroup]],                  \
+          uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+
+#define instantiate_softmax_forward_2pass_write(DTYPE)                     \
+  template                                                                 \
+      [[host_name("softmax_forward_2pass_write_" #DTYPE)]] [[kernel]] void \
+      softmax_forward_2pass_write<DTYPE>(                                  \
+          device const DTYPE* input [[buffer(0)]],                         \
+          device DTYPE* output [[buffer(1)]],                              \
+          device const float* partials [[buffer(2)]],                      \
+          constant SoftmaxParams& params [[buffer(3)]],                    \
+          uint tg_id [[threadgroup_position_in_grid]],                     \
+          uint tid [[thread_position_in_threadgroup]],                     \
+          uint lsize [[threads_per_threadgroup]]);
+
+#define instantiate_softmax_forward_coalesced(DTYPE)                          \
+  template [[host_name("softmax_forward_coalesced_" #DTYPE)]] [[kernel]] void \
+  softmax_forward_coalesced<DTYPE>(                                           \
+      device const DTYPE* input [[buffer(0)]],                                \
+      device DTYPE* output [[buffer(1)]],                                     \
+      constant SoftmaxParams& params [[buffer(2)]],                           \
+      uint tg_id [[threadgroup_position_in_grid]],                            \
+      uint tid [[thread_position_in_threadgroup]],                            \
+      uint lsize [[threads_per_threadgroup]],                                 \
+      threadgroup float* smem [[threadgroup(0)]]);
+
+#define instantiate_softmax_backward_coalesced(DTYPE)                          \
+  template [[host_name("softmax_backward_coalesced_" #DTYPE)]] [[kernel]] void \
+  softmax_backward_coalesced<DTYPE>(                                           \
+      device const DTYPE* grad_output [[buffer(0)]],                           \
+      device const DTYPE* output [[buffer(1)]],                                \
+      device DTYPE* grad_input [[buffer(2)]],                                  \
+      constant SoftmaxParams& params [[buffer(3)]],                            \
+      uint tg_id [[threadgroup_position_in_grid]],                             \
+      uint tid [[thread_position_in_threadgroup]],                             \
+      uint lsize [[threads_per_threadgroup]],                                  \
+      threadgroup float* smem [[threadgroup(0)]]);
+
+#define instantiate_softmax_forward_tiled(DTYPE)                          \
+  template [[host_name("softmax_forward_tiled_" #DTYPE)]] [[kernel]] void \
+  softmax_forward_tiled<DTYPE>(                                           \
+      device const DTYPE* input [[buffer(0)]],                            \
+      device DTYPE* output [[buffer(1)]],                                 \
+      constant SoftmaxParams& params [[buffer(2)]],                       \
+      uint tg_id [[threadgroup_position_in_grid]],                        \
+      uint tid [[thread_position_in_threadgroup]],                        \
+      uint lsize [[threads_per_threadgroup]]);
+
+#define instantiate_softmax_forward_blocked(DTYPE)                          \
+  template [[host_name("softmax_forward_blocked_" #DTYPE)]] [[kernel]] void \
+  softmax_forward_blocked<DTYPE>(                                           \
+      device const DTYPE* input [[buffer(0)]],                              \
+      device DTYPE* output [[buffer(1)]],                                   \
+      constant SoftmaxParams& params [[buffer(2)]],                         \
+      uint tg_id [[threadgroup_position_in_grid]],                          \
+      uint tid [[thread_position_in_threadgroup]],                          \
+      uint lsize [[threads_per_threadgroup]],                               \
+      threadgroup float* smem [[threadgroup(0)]]);
+
+#define instantiate_softmax_backward_blocked(DTYPE)                          \
+  template [[host_name("softmax_backward_blocked_" #DTYPE)]] [[kernel]] void \
+  softmax_backward_blocked<DTYPE>(                                           \
+      device const DTYPE* grad_output [[buffer(0)]],                         \
+      device const DTYPE* output [[buffer(1)]],                              \
+      device DTYPE* grad_input [[buffer(2)]],                                \
+      constant SoftmaxParams& params [[buffer(3)]],                          \
+      uint tg_id [[threadgroup_position_in_grid]],                           \
+      uint tid [[thread_position_in_threadgroup]],                           \
+      uint lsize [[threads_per_threadgroup]],                                \
+      threadgroup float* smem [[threadgroup(0)]]);
+
+#define instantiate_softmax_forward_blocked2_reduce(DTYPE)                     \
+  template                                                                     \
+      [[host_name("softmax_forward_blocked2_reduce_" #DTYPE)]] [[kernel]] void \
+      softmax_forward_blocked2_reduce<DTYPE>(                                  \
+          device const DTYPE* input [[buffer(0)]],                             \
+          device float* partials [[buffer(1)]],                                \
+          constant SoftmaxParams& params [[buffer(2)]],                        \
+          uint tg_id [[threadgroup_position_in_grid]],                         \
+          uint tid [[thread_position_in_threadgroup]],                         \
+          uint lsize [[threads_per_threadgroup]],                              \
+          threadgroup float* smem [[threadgroup(0)]]);
+
+#define instantiate_softmax_forward_blocked2_write(DTYPE)                     \
+  template                                                                    \
+      [[host_name("softmax_forward_blocked2_write_" #DTYPE)]] [[kernel]] void \
+      softmax_forward_blocked2_write<DTYPE>(                                  \
+          device const DTYPE* input [[buffer(0)]],                            \
+          device DTYPE* output [[buffer(1)]],                                 \
+          device const float* partials [[buffer(2)]],                         \
+          constant SoftmaxParams& params [[buffer(3)]],                       \
+          uint tg_id [[threadgroup_position_in_grid]],                        \
+          uint tid [[thread_position_in_threadgroup]],                        \
+          uint lsize [[threads_per_threadgroup]]);
+
+#define instantiate_softmax_backward_blocked2_dot(DTYPE)                     \
+  template                                                                   \
+      [[host_name("softmax_backward_blocked2_dot_" #DTYPE)]] [[kernel]] void \
+      softmax_backward_blocked2_dot<DTYPE>(                                  \
+          device const DTYPE* grad_output [[buffer(0)]],                     \
+          device const DTYPE* output [[buffer(1)]],                          \
+          device float* partials [[buffer(2)]],                              \
+          constant SoftmaxParams& params [[buffer(3)]],                      \
+          uint tg_id [[threadgroup_position_in_grid]],                       \
+          uint tid [[thread_position_in_threadgroup]],                       \
+          uint lsize [[threads_per_threadgroup]],                            \
+          threadgroup float* smem [[threadgroup(0)]]);
+
+#define instantiate_softmax_backward_blocked2_grad(DTYPE)                     \
+  template                                                                    \
+      [[host_name("softmax_backward_blocked2_grad_" #DTYPE)]] [[kernel]] void \
+      softmax_backward_blocked2_grad<DTYPE>(                                  \
+          device const DTYPE* grad_output [[buffer(0)]],                      \
+          device const DTYPE* output [[buffer(1)]],                           \
+          device DTYPE* grad_input [[buffer(2)]],                             \
+          device const float* partials [[buffer(3)]],                         \
+          constant SoftmaxParams& params [[buffer(4)]],                       \
+          uint tg_id [[threadgroup_position_in_grid]],                        \
+          uint tid [[thread_position_in_threadgroup]],                        \
+          uint lsize [[threads_per_threadgroup]]);
+
+#define instantiate_softmax_backward_tiled(DTYPE)                          \
+  template [[host_name("softmax_backward_tiled_" #DTYPE)]] [[kernel]] void \
+  softmax_backward_tiled<DTYPE>(                                           \
+      device const DTYPE* grad_output [[buffer(0)]],                       \
+      device const DTYPE* output [[buffer(1)]],                            \
+      device DTYPE* grad_input [[buffer(2)]],                              \
+      constant SoftmaxParams& params [[buffer(3)]],                        \
+      uint tg_id [[threadgroup_position_in_grid]],                         \
+      uint tid [[thread_position_in_threadgroup]],                         \
+      uint lsize [[threads_per_threadgroup]]);
+
+#define instantiate_softmax(DTYPE)                                                  \
+  instantiate_softmax_forward_single_row(                                           \
+      DTYPE) instantiate_softmax_forward_looped(DTYPE)                              \
+      instantiate_softmax_forward_tiled(DTYPE) instantiate_softmax_forward_blocked( \
+          DTYPE) instantiate_softmax_forward_blocked2_reduce(DTYPE)                 \
+          instantiate_softmax_forward_blocked2_write(                               \
+              DTYPE) instantiate_softmax_forward_coalesced(DTYPE)                   \
+              instantiate_softmax_forward_2pass_reduce(                             \
+                  DTYPE) instantiate_softmax_forward_2pass_write(DTYPE)             \
+                  instantiate_softmax_backward_single_row(                          \
+                      DTYPE) instantiate_softmax_backward_looped(DTYPE)             \
+                      instantiate_softmax_backward_tiled(                           \
+                          DTYPE) instantiate_softmax_backward_blocked(DTYPE)        \
+                          instantiate_softmax_backward_blocked2_dot(DTYPE)          \
+                              instantiate_softmax_backward_blocked2_grad(           \
+                                  DTYPE)                                            \
+                                  instantiate_softmax_backward_coalesced(           \
+                                      DTYPE)                                        \
+                                      instantiate_softmax_backward_2pass_dot(       \
+                                          DTYPE)                                    \
+                                          instantiate_softmax_backward_2pass_grad(  \
+                                              DTYPE)
 
 instantiate_softmax(float);
 instantiate_softmax(half);

--- a/aten/src/ATen/native/mps/kernels/SoftMaxKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/SoftMaxKernel.metal
@@ -1,0 +1,582 @@
+#include <ATen/native/mps/kernels/SoftMaxKernel.h>
+#include <c10/metal/reduction_utils.h>
+#include <metal_simdgroup>
+#include <metal_stdlib>
+using namespace metal;
+using c10::metal::simdgroup_size;
+
+static inline ulong offset_a(uint row_idx, constant SoftmaxParams& p) {
+  ulong offset = 0;
+  uint idx = row_idx;
+  for (int d = int(p.ndim) - 2; d >= 0; d--) {
+    uint coord = idx % p.outer_sizes[d];
+    idx /= p.outer_sizes[d];
+    offset += ulong(coord) * ulong(p.outer_strides_a[d]);
+  }
+  return offset;
+}
+
+static inline ulong offset_b(uint row_idx, constant SoftmaxParams& p) {
+  ulong offset = 0;
+  uint idx = row_idx;
+  for (int d = int(p.ndim) - 2; d >= 0; d--) {
+    uint coord = idx % p.outer_sizes[d];
+    idx /= p.outer_sizes[d];
+    offset += ulong(coord) * ulong(p.outer_strides_b[d]);
+  }
+  return offset;
+}
+
+static inline ulong offset_c(uint row_idx, constant SoftmaxParams& p) {
+  ulong offset = 0;
+  uint idx = row_idx;
+  for (int d = int(p.ndim) - 2; d >= 0; d--) {
+    uint coord = idx % p.outer_sizes[d];
+    idx /= p.outer_sizes[d];
+    offset += ulong(coord) * ulong(p.outer_strides_c[d]);
+  }
+  return offset;
+}
+
+static inline float4 load_vec4(device const float* p) {
+  return *reinterpret_cast<device const packed_float4*>(p);
+}
+static inline float4 load_vec4(device const half* p) {
+  return float4(*reinterpret_cast<device const packed_half4*>(p));
+}
+static inline float4 load_vec4(device const bfloat* p) {
+  return float4(float(p[0]), float(p[1]), float(p[2]), float(p[3]));
+}
+
+static inline void store_vec4(device float* p, float4 v) {
+  *reinterpret_cast<device packed_float4*>(p) = v;
+}
+static inline void store_vec4(device half* p, float4 v) {
+  *reinterpret_cast<device packed_half4*>(p) = half4(v);
+}
+static inline void store_vec4(device bfloat* p, float4 v) {
+  p[0] = static_cast<bfloat>(v[0]);
+  p[1] = static_cast<bfloat>(v[1]);
+  p[2] = static_cast<bfloat>(v[2]);
+  p[3] = static_cast<bfloat>(v[3]);
+}
+
+// Forward single-row: values cached in registers (1 read, 1 write).
+// Reads from input using stride_a, writes to output contiguously.
+
+template <typename T, int N_READS = 4>
+kernel void softmax_forward_single_row(
+    device const T* input [[buffer(0)]],
+    device T* output [[buffer(1)]],
+    constant SoftmaxParams& params [[buffer(2)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  // N_READS elements per thread, loaded as N_READS/4 vec4 chunks. A wider
+  // N_READS shrinks the threadgroup (fewer threads -> cheaper TG reduction and
+  // more independent loads in flight per thread), which helps the small-byte
+  // half-precision rows that are reduction/overhead bound rather than
+  // bandwidth bound.
+  constexpr int N_VEC = N_READS / 4;
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint sb = params.stride_b;
+  device const T* x = input + offset_a(tg_id, params);
+  device T* out = output + offset_b(tg_id, params);
+  uint base = tid * N_READS;
+
+  bool contiguous = (sa == 1);
+  float vals[N_READS];
+  float local_max = -INFINITY;
+  if (base + N_READS <= axis_size) {
+    if (contiguous) {
+#pragma unroll
+      for (int c = 0; c < N_VEC; c++) {
+        float4 v = load_vec4(x + base + c * 4);
+        vals[c * 4 + 0] = v.x;
+        vals[c * 4 + 1] = v.y;
+        vals[c * 4 + 2] = v.z;
+        vals[c * 4 + 3] = v.w;
+      }
+    } else {
+#pragma unroll
+      for (int i = 0; i < N_READS; i++)
+        vals[i] = float(x[(base + i) * sa]);
+    }
+#pragma unroll
+    for (int i = 0; i < N_READS; i++)
+      local_max = fmax(local_max, vals[i]);
+  } else {
+    for (int i = 0; i < N_READS; i++) {
+      vals[i] = (base + i < axis_size)
+          ? (contiguous ? float(x[base + i]) : float(x[(base + i) * sa]))
+          : -INFINITY;
+      local_max = fmax(local_max, vals[i]);
+    }
+  }
+
+  threadgroup float shared[simdgroup_size];
+  float row_max = c10::metal::threadgroup_max(shared, local_max, tid, tptg);
+
+  float local_sum = 0.0f;
+#pragma unroll
+  for (int i = 0; i < N_READS; i++) {
+    vals[i] = metal::precise::exp(vals[i] - row_max);
+    local_sum += vals[i];
+  }
+
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  float total_sum = c10::metal::threadgroup_sum(shared, local_sum, tid, tptg);
+  float inv_sum = 1.0f / total_sum;
+
+  if (base + N_READS <= axis_size) {
+    if (sb == 1) {
+#pragma unroll
+      for (int c = 0; c < N_VEC; c++) {
+        float4 result = float4(
+                            vals[c * 4 + 0],
+                            vals[c * 4 + 1],
+                            vals[c * 4 + 2],
+                            vals[c * 4 + 3]) *
+            inv_sum;
+        store_vec4(out + base + c * 4, result);
+      }
+    } else {
+#pragma unroll
+      for (int i = 0; i < N_READS; i++)
+        out[(base + i) * sb] = static_cast<T>(vals[i] * inv_sum);
+    }
+  } else {
+    for (int i = 0; i < N_READS; i++) {
+      if (base + i < axis_size)
+        out[(base + i) * sb] = static_cast<T>(vals[i] * inv_sum);
+    }
+  }
+}
+
+// Forward looped: online softmax fuses max+sum into one pass over memory.
+
+template <typename T>
+kernel void softmax_forward_looped(
+    device const T* input [[buffer(0)]],
+    device T* output [[buffer(1)]],
+    constant SoftmaxParams& params [[buffer(2)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  constexpr int N_READS = 4;
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint sb = params.stride_b;
+  device const T* x = input + offset_a(tg_id, params);
+  device T* out = output + offset_b(tg_id, params);
+  bool contiguous = (sa == 1);
+
+  float local_max = -INFINITY;
+  float local_sum = 0.0f;
+  for (uint r = 0; r < axis_size; r += lsize * N_READS) {
+    uint base = r + tid * N_READS;
+    if (base + N_READS <= axis_size) {
+      float4 v;
+      if (contiguous) {
+        v = load_vec4(x + base);
+      } else {
+        v = float4(
+            x[base * sa],
+            x[(base + 1) * sa],
+            x[(base + 2) * sa],
+            x[(base + 3) * sa]);
+      }
+      float chunk_max = fmax(fmax(v.x, v.y), fmax(v.z, v.w));
+      float new_max = fmax(local_max, chunk_max);
+      local_sum = (new_max > -INFINITY)
+          ? local_sum * metal::precise::exp(local_max - new_max) +
+              metal::precise::exp(v.x - new_max) +
+              metal::precise::exp(v.y - new_max) +
+              metal::precise::exp(v.z - new_max) +
+              metal::precise::exp(v.w - new_max)
+          : 0.0f;
+      local_max = new_max;
+    } else {
+      for (uint i = base; i < min(base + uint(N_READS), axis_size); i++) {
+        float val = contiguous ? float(x[i]) : float(x[i * sa]);
+        float new_max = fmax(local_max, val);
+        local_sum = (new_max > -INFINITY)
+            ? local_sum * metal::precise::exp(local_max - new_max) +
+                metal::precise::exp(val - new_max)
+            : 0.0f;
+        local_max = new_max;
+      }
+    }
+  }
+
+  float sg_max = simd_max(local_max);
+  local_sum *= metal::precise::exp(local_max - sg_max);
+  float sg_sum = simd_sum(local_sum);
+
+  threadgroup float shared_max[simdgroup_size];
+  threadgroup float shared_sum[simdgroup_size];
+  threadgroup float tg_result[2];
+
+  if (simd_lane_id == 0) {
+    shared_max[simdgroup_id] = sg_max;
+    shared_sum[simdgroup_id] = sg_sum;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  uint num_simdgroups = (lsize + simdgroup_size - 1) / simdgroup_size;
+  if (simdgroup_id == 0) {
+    float m =
+        (simd_lane_id < num_simdgroups) ? shared_max[simd_lane_id] : -INFINITY;
+    float global_max = simd_max(m);
+    float s = (simd_lane_id < num_simdgroups)
+        ? shared_sum[simd_lane_id] * metal::precise::exp(m - global_max)
+        : 0.0f;
+    float global_sum = simd_sum(s);
+    if (simd_lane_id == 0) {
+      tg_result[0] = global_max;
+      tg_result[1] = global_sum;
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  float row_max = tg_result[0];
+  float inv_sum = 1.0f / tg_result[1];
+
+  for (uint r = 0; r < axis_size; r += lsize * N_READS) {
+    uint base = r + tid * N_READS;
+    if (base + N_READS <= axis_size) {
+      float4 v;
+      if (contiguous) {
+        v = metal::precise::exp(load_vec4(x + base) - row_max) * inv_sum;
+      } else {
+        v = float4(
+            metal::precise::exp(float(x[base * sa]) - row_max) * inv_sum,
+            metal::precise::exp(float(x[(base + 1) * sa]) - row_max) * inv_sum,
+            metal::precise::exp(float(x[(base + 2) * sa]) - row_max) * inv_sum,
+            metal::precise::exp(float(x[(base + 3) * sa]) - row_max) * inv_sum);
+      }
+      if (sb == 1) {
+        store_vec4(out + base, v);
+      } else {
+#pragma unroll
+        for (int i = 0; i < N_READS; i++)
+          out[(base + i) * sb] = static_cast<T>(v[i]);
+      }
+    } else {
+      for (uint i = base; i < min(base + uint(N_READS), axis_size); i++) {
+        float val = contiguous ? float(x[i]) : float(x[i * sa]);
+        out[i * sb] =
+            static_cast<T>(metal::precise::exp(val - row_max) * inv_sum);
+      }
+    }
+  }
+}
+
+// Two-pass forward for low-occupancy cases (few rows, large axis).
+// Phase 1: each threadgroup computes (chunk_max, chunk_sum) via online
+// algorithm. Phase 2: each threadgroup combines partials, re-reads input,
+// writes output.
+
+// Backward: grad_input = output * (grad_output - sum(grad_output * output))
+// stride_a = grad_output strides, stride_b = output strides
+// Writes grad_input contiguously.
+
+template <typename T, int N_READS = 4>
+kernel void softmax_backward_single_row(
+    device const T* grad_output [[buffer(0)]],
+    device const T* output [[buffer(1)]],
+    device T* grad_input [[buffer(2)]],
+    constant SoftmaxParams& params [[buffer(3)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  // N_READS elements per thread, loaded as N_READS/4 vec4 chunks. A wider
+  // N_READS shrinks the threadgroup (fewer threads -> cheaper TG reduction),
+  // which mirrors the forward 8-wide path so half-precision last-dim fwdbwd
+  // does not lose the forward speedup to a still-narrow backward pass.
+  constexpr int N_VEC = N_READS / 4;
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint sb = params.stride_b;
+  uint sc = params.stride_c;
+  device const T* dy = grad_output + offset_a(tg_id, params);
+  device const T* y = output + offset_b(tg_id, params);
+  device T* dx = grad_input + offset_c(tg_id, params);
+  uint base = tid * N_READS;
+
+  bool contiguous = (sa == 1) && (sb == 1);
+  float dy_vals[N_READS];
+  float y_vals[N_READS];
+  float local_dot = 0.0f;
+  if (base + N_READS <= axis_size) {
+    if (contiguous) {
+#pragma unroll
+      for (int c = 0; c < N_VEC; c++) {
+        float4 dy_v = load_vec4(dy + base + c * 4);
+        float4 y_v = load_vec4(y + base + c * 4);
+        dy_vals[c * 4 + 0] = dy_v.x;
+        dy_vals[c * 4 + 1] = dy_v.y;
+        dy_vals[c * 4 + 2] = dy_v.z;
+        dy_vals[c * 4 + 3] = dy_v.w;
+        y_vals[c * 4 + 0] = y_v.x;
+        y_vals[c * 4 + 1] = y_v.y;
+        y_vals[c * 4 + 2] = y_v.z;
+        y_vals[c * 4 + 3] = y_v.w;
+        local_dot += dot(dy_v, y_v);
+      }
+    } else {
+#pragma unroll
+      for (int i = 0; i < N_READS; i++) {
+        dy_vals[i] = float(dy[(base + i) * sa]);
+        y_vals[i] = float(y[(base + i) * sb]);
+        local_dot += dy_vals[i] * y_vals[i];
+      }
+    }
+  } else {
+    for (int i = 0; i < N_READS; i++) {
+      if (base + i < axis_size) {
+        dy_vals[i] =
+            contiguous ? float(dy[base + i]) : float(dy[(base + i) * sa]);
+        y_vals[i] = contiguous ? float(y[base + i]) : float(y[(base + i) * sb]);
+        local_dot += dy_vals[i] * y_vals[i];
+      }
+    }
+  }
+
+  threadgroup float shared_dot[simdgroup_size];
+  float dot_sum = c10::metal::threadgroup_sum(shared_dot, local_dot, tid, tptg);
+
+  if (base + N_READS <= axis_size) {
+    if (sc == 1) {
+#pragma unroll
+      for (int c = 0; c < N_VEC; c++) {
+        float4 result = float4(
+                            y_vals[c * 4 + 0],
+                            y_vals[c * 4 + 1],
+                            y_vals[c * 4 + 2],
+                            y_vals[c * 4 + 3]) *
+            (float4(
+                 dy_vals[c * 4 + 0],
+                 dy_vals[c * 4 + 1],
+                 dy_vals[c * 4 + 2],
+                 dy_vals[c * 4 + 3]) -
+             dot_sum);
+        store_vec4(dx + base + c * 4, result);
+      }
+    } else {
+#pragma unroll
+      for (int i = 0; i < N_READS; i++)
+        dx[(base + i) * sc] =
+            static_cast<T>(y_vals[i] * (dy_vals[i] - dot_sum));
+    }
+  } else {
+    for (int i = 0; i < N_READS; i++) {
+      if (base + i < axis_size)
+        dx[(base + i) * sc] =
+            static_cast<T>(y_vals[i] * (dy_vals[i] - dot_sum));
+    }
+  }
+}
+
+// Backward looped: vectorized dot product with strided or contiguous access.
+
+template <typename T>
+kernel void softmax_backward_looped(
+    device const T* grad_output [[buffer(0)]],
+    device const T* output [[buffer(1)]],
+    device T* grad_input [[buffer(2)]],
+    constant SoftmaxParams& params [[buffer(3)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  constexpr int N_READS = 4;
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint sb = params.stride_b;
+  uint sc = params.stride_c;
+  device const T* dy = grad_output + offset_a(tg_id, params);
+  device const T* y = output + offset_b(tg_id, params);
+  device T* dx = grad_input + offset_c(tg_id, params);
+  bool contiguous = (sa == 1) && (sb == 1);
+
+  float local_dot = 0.0f;
+  for (uint r = 0; r < axis_size; r += lsize * N_READS) {
+    uint base = r + tid * N_READS;
+    if (base + N_READS <= axis_size) {
+      if (contiguous) {
+        local_dot += dot(load_vec4(dy + base), load_vec4(y + base));
+      } else {
+        float4 dy_v = float4(
+            dy[base * sa],
+            dy[(base + 1) * sa],
+            dy[(base + 2) * sa],
+            dy[(base + 3) * sa]);
+        float4 y_v = float4(
+            y[base * sb],
+            y[(base + 1) * sb],
+            y[(base + 2) * sb],
+            y[(base + 3) * sb]);
+        local_dot += dot(dy_v, y_v);
+      }
+    } else {
+      for (uint i = base; i < min(base + uint(N_READS), axis_size); i++)
+        local_dot += (contiguous ? float(dy[i]) : float(dy[i * sa])) *
+            (contiguous ? float(y[i]) : float(y[i * sb]));
+    }
+  }
+
+  threadgroup float shared_dot[simdgroup_size];
+  float dot_sum =
+      c10::metal::threadgroup_sum(shared_dot, local_dot, tid, lsize);
+
+  for (uint r = 0; r < axis_size; r += lsize * N_READS) {
+    uint base = r + tid * N_READS;
+    if (base + N_READS <= axis_size) {
+      float4 y_v, dy_v;
+      if (contiguous) {
+        y_v = load_vec4(y + base);
+        dy_v = load_vec4(dy + base);
+      } else {
+        y_v = float4(
+            y[base * sb],
+            y[(base + 1) * sb],
+            y[(base + 2) * sb],
+            y[(base + 3) * sb]);
+        dy_v = float4(
+            dy[base * sa],
+            dy[(base + 1) * sa],
+            dy[(base + 2) * sa],
+            dy[(base + 3) * sa]);
+      }
+      float4 result = y_v * (dy_v - dot_sum);
+      if (sc == 1) {
+        store_vec4(dx + base, result);
+      } else {
+#pragma unroll
+        for (int i = 0; i < N_READS; i++)
+          dx[(base + i) * sc] = static_cast<T>(result[i]);
+      }
+    } else {
+      for (uint i = base; i < min(base + uint(N_READS), axis_size); i++) {
+        float yi = contiguous ? float(y[i]) : float(y[i * sb]);
+        float dyi = contiguous ? float(dy[i]) : float(dy[i * sa]);
+        dx[i * sc] = static_cast<T>(yi * (dyi - dot_sum));
+      }
+    }
+  }
+}
+
+// Two-pass backward for low-occupancy cases (few rows, large axis).
+// Phase 1: each threadgroup computes a partial dot(dy, y) over its chunk.
+// Phase 2: each threadgroup sums partial dots, then computes grad_input for its
+// chunk.
+
+// Log-softmax forward 2-pass: for low-occupancy (outer_size < 4, large axis)
+// Phase 1: each threadgroup computes (chunk_max, chunk_sum) via online
+// algorithm Phase 2: combine partials, compute shift = max + log(sum), write
+// output = x - shift Log-softmax backward: grad_input = grad_output -
+// exp(output) * sum(grad_output)
+
+#define instantiate_softmax_forward_single_row(DTYPE)                     \
+  template [[host_name("softmax_forward_single_row_" #DTYPE)]] [[kernel]] \
+  void softmax_forward_single_row<DTYPE, 4>(                              \
+      device const DTYPE* input [[buffer(0)]],                            \
+      device DTYPE* output [[buffer(1)]],                                 \
+      constant SoftmaxParams& params [[buffer(2)]],                       \
+      uint tg_id [[threadgroup_position_in_grid]],                        \
+      uint tid [[thread_position_in_threadgroup]],                        \
+      uint tptg [[threads_per_threadgroup]],                              \
+      uint simd_lane_id [[thread_index_in_simdgroup]],                    \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+
+// 8-wide single-row variant for half-precision last-dim rows.
+#define instantiate_softmax_forward_single_row8(DTYPE)                     \
+  template [[host_name("softmax_forward_single_row8_" #DTYPE)]] [[kernel]] \
+  void softmax_forward_single_row<DTYPE, 8>(                               \
+      device const DTYPE* input [[buffer(0)]],                             \
+      device DTYPE* output [[buffer(1)]],                                  \
+      constant SoftmaxParams& params [[buffer(2)]],                        \
+      uint tg_id [[threadgroup_position_in_grid]],                         \
+      uint tid [[thread_position_in_threadgroup]],                         \
+      uint tptg [[threads_per_threadgroup]],                               \
+      uint simd_lane_id [[thread_index_in_simdgroup]],                     \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+
+#define instantiate_softmax_forward_looped(DTYPE)                          \
+  template [[host_name("softmax_forward_looped_" #DTYPE)]] [[kernel]] void \
+  softmax_forward_looped<DTYPE>(                                           \
+      device const DTYPE* input [[buffer(0)]],                             \
+      device DTYPE* output [[buffer(1)]],                                  \
+      constant SoftmaxParams& params [[buffer(2)]],                        \
+      uint tg_id [[threadgroup_position_in_grid]],                         \
+      uint tid [[thread_position_in_threadgroup]],                         \
+      uint lsize [[threads_per_threadgroup]],                              \
+      uint simd_lane_id [[thread_index_in_simdgroup]],                     \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+
+#define instantiate_softmax_backward_single_row(DTYPE)                     \
+  template [[host_name("softmax_backward_single_row_" #DTYPE)]] [[kernel]] \
+  void softmax_backward_single_row<DTYPE, 4>(                              \
+      device const DTYPE* grad_output [[buffer(0)]],                       \
+      device const DTYPE* output [[buffer(1)]],                            \
+      device DTYPE* grad_input [[buffer(2)]],                              \
+      constant SoftmaxParams& params [[buffer(3)]],                        \
+      uint tg_id [[threadgroup_position_in_grid]],                         \
+      uint tid [[thread_position_in_threadgroup]],                         \
+      uint tptg [[threads_per_threadgroup]],                               \
+      uint simd_lane_id [[thread_index_in_simdgroup]],                     \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+
+// 8-wide single-row backward variant for half-precision last-dim rows.
+#define instantiate_softmax_backward_single_row8(DTYPE)                     \
+  template [[host_name("softmax_backward_single_row8_" #DTYPE)]] [[kernel]] \
+  void softmax_backward_single_row<DTYPE, 8>(                               \
+      device const DTYPE* grad_output [[buffer(0)]],                        \
+      device const DTYPE* output [[buffer(1)]],                             \
+      device DTYPE* grad_input [[buffer(2)]],                               \
+      constant SoftmaxParams& params [[buffer(3)]],                         \
+      uint tg_id [[threadgroup_position_in_grid]],                          \
+      uint tid [[thread_position_in_threadgroup]],                          \
+      uint tptg [[threads_per_threadgroup]],                                \
+      uint simd_lane_id [[thread_index_in_simdgroup]],                      \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+
+#define instantiate_softmax_backward_looped(DTYPE)                          \
+  template [[host_name("softmax_backward_looped_" #DTYPE)]] [[kernel]] void \
+  softmax_backward_looped<DTYPE>(                                           \
+      device const DTYPE* grad_output [[buffer(0)]],                        \
+      device const DTYPE* output [[buffer(1)]],                             \
+      device DTYPE* grad_input [[buffer(2)]],                               \
+      constant SoftmaxParams& params [[buffer(3)]],                         \
+      uint tg_id [[threadgroup_position_in_grid]],                          \
+      uint tid [[thread_position_in_threadgroup]],                          \
+      uint lsize [[threads_per_threadgroup]],                               \
+      uint simd_lane_id [[thread_index_in_simdgroup]],                      \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+
+#define instantiate_softmax(DTYPE)                       \
+  instantiate_softmax_forward_single_row(DTYPE)          \
+      instantiate_softmax_forward_looped(DTYPE)          \
+          instantiate_softmax_backward_single_row(DTYPE) \
+              instantiate_softmax_backward_looped(DTYPE)
+
+instantiate_softmax(float);
+instantiate_softmax(half);
+instantiate_softmax(bfloat);
+
+// 8-wide single-row forward, half precision only (helps small-byte last-dim).
+instantiate_softmax_forward_single_row8(half);
+instantiate_softmax_forward_single_row8(bfloat);
+
+// 8-wide single-row backward, half precision only (matches forward width so
+// last-dim half fwdbwd does not regress against the 8-wide forward).
+instantiate_softmax_backward_single_row8(half);
+instantiate_softmax_backward_single_row8(bfloat);

--- a/aten/src/ATen/native/mps/operations/SoftMax.mm
+++ b/aten/src/ATen/native/mps/operations/SoftMax.mm
@@ -2,6 +2,8 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/native/LinearAlgebraUtils.h>
 #include <ATen/native/mps/OperationUtils.h>
+#include <ATen/native/mps/kernels/SoftMaxKernel.h>
+#include <c10/util/env.h>
 
 #ifdef __OBJC__
 #include <MetalPerformanceShaders/MetalPerformanceShaders.h>
@@ -16,6 +18,92 @@
 #endif
 
 namespace at::native {
+namespace mps {
+
+#ifndef PYTORCH_JIT_COMPILE_SHADERS
+static auto& lib = MetalShaderLibrary::getBundledLibrary();
+#else
+#include <ATen/native/mps/SoftMaxKernel_metallib.h>
+#endif
+
+// Gate that selects the native Metal kernels over the legacy MPSGraph path.
+// The Metal kernels handle every floating-point softmax over an axis with a
+// well-defined extent; the MPSGraph fallback below is retained only for the
+// correctness-required cases the Metal kernels do not cover (currently the
+// pre-macOS-15 ChannelsLast axis remapping). Keeping this as the normal path
+// is what eliminates the per-shape MPSGraph cache growth.
+static bool canUseMetalSoftmax(const Tensor& input) {
+  // Escape hatch (also used by benchmarks/mps/bench_softmax.py for same-build
+  // A/B vs the kept MPSGraph path): force the MPSGraph route. Lets a user opt a
+  // workload back to MPSGraph without rebuilding if a shape regresses.
+  static const bool force_mpsgraph = c10::utils::has_env("PYTORCH_MPS_FORCE_MPSGRAPH_SOFTMAX");
+  if (force_mpsgraph) {
+    return false;
+  }
+  // SoftmaxParams packs sizes/strides as uint32; fall back to MPSGraph for
+  // extents that would overflow it (multi-billion-element tensors).
+  constexpr int64_t kMaxU32 = 0xFFFFFFFFLL;
+  if (input.numel() > kMaxU32) {
+    return false;
+  }
+  for (int64_t d = 0; d < input.dim(); d++) {
+    if (input.size(d) > kMaxU32 || input.stride(d) > kMaxU32) {
+      return false;
+    }
+  }
+  // SoftmaxParams holds 15 outer-dim slots (reduced dim + 15 outer = rank 16);
+  // higher ranks would overflow the param block, so fall back to MPSGraph.
+  return input.dim() > 0 && input.dim() <= 16;
+}
+
+static SoftmaxParams makeForwardParams(const Tensor& input, const Tensor& output, int64_t dim) {
+  SoftmaxParams params = {};
+  int64_t ndim = input.dim();
+  params.axis_size = static_cast<uint32_t>(input.size(dim));
+  params.stride_a = static_cast<uint32_t>(input.stride(dim));
+  params.stride_b = static_cast<uint32_t>(output.stride(dim));
+  params.ndim = static_cast<uint32_t>(ndim);
+  int outer_idx = 0;
+  for (int64_t d = 0; d < ndim; d++) {
+    if (d == dim)
+      continue;
+    params.outer_sizes[outer_idx] = static_cast<uint32_t>(input.size(d));
+    params.outer_strides_a[outer_idx] = static_cast<uint32_t>(input.stride(d));
+    params.outer_strides_b[outer_idx] = static_cast<uint32_t>(output.stride(d));
+    outer_idx++;
+  }
+  return params;
+}
+
+static SoftmaxParams makeBackwardParams(const Tensor& grad,
+                                        const Tensor& output,
+                                        const Tensor& grad_input,
+                                        int64_t dim) {
+  SoftmaxParams params = {};
+  int64_t ndim = grad.dim();
+  params.axis_size = static_cast<uint32_t>(grad.size(dim));
+  params.stride_a = static_cast<uint32_t>(grad.stride(dim));
+  params.stride_b = static_cast<uint32_t>(output.stride(dim));
+  params.stride_c = static_cast<uint32_t>(grad_input.stride(dim));
+  params.ndim = static_cast<uint32_t>(ndim);
+  int outer_idx = 0;
+  for (int64_t d = 0; d < ndim; d++) {
+    if (d == dim)
+      continue;
+    params.outer_sizes[outer_idx] = static_cast<uint32_t>(grad.size(d));
+    params.outer_strides_a[outer_idx] = static_cast<uint32_t>(grad.stride(d));
+    params.outer_strides_b[outer_idx] = static_cast<uint32_t>(output.stride(d));
+    params.outer_strides_c[outer_idx] = static_cast<uint32_t>(grad_input.stride(d));
+    outer_idx++;
+  }
+  return params;
+}
+
+// ============================================================================
+// Legacy MPSGraph fallback (gated). Retained for correctness on the cases the
+// native Metal softmax does not cover. Do not delete; this is the fallback the
+// canUseMetalSoftmax guard routes to.
+// ============================================================================
 
 static void get_shapes(MPSShape* input_shape_readonly,
                        NSMutableArray<NSNumber*>*& input_shape,
@@ -34,32 +122,10 @@ static void get_shapes(MPSShape* input_shape_readonly,
   }
 }
 
-// Note - Currently only supported for 4D image tensors
-
-TORCH_IMPL_FUNC(softmax_mps_out)
-(const Tensor& input_, const int64_t dim, const bool half_to_float, const Tensor& output) {
-  TORCH_CHECK(!half_to_float, "softmax with half to float conversion is not supported on MPS");
-  TORCH_CHECK(c10::isFloatingType(input_.scalar_type()), "softmax only supported for floating types");
+static void softmax_mps_out_graph(const Tensor& input, int64_t dim_, const Tensor& output) {
   static const bool is_macOS_15_0_or_newer = is_macos_at_least(MacOSVersion::MACOS_15_0);
-
-  if (input_.numel() == 0) {
-    return;
-  }
-
-  Tensor input;
-  if (input_.dim() == 0) {
-    input = input_.view(1);
-  } else
-    input = input_;
-
-  int64_t dim_ = maybe_wrap_dim(dim, input.dim());
-  TORCH_CHECK(dim_ >= 0 && dim_ < input.dim(), "Softmax:dim must be non-negative and less than input dimensions");
-
   const auto memory_format = input.suggest_memory_format();
-  // TORCH_CHECK(input.suggest_memory_format() == output.suggest_memory_format(), "Input and output memory format should
-  // match")
 
-  using namespace mps;
   using CachedGraph = MPSUnaryCachedGraph;
   MPSStream* stream = getCurrentMPSStream();
 
@@ -91,8 +157,6 @@ TORCH_IMPL_FUNC(softmax_mps_out)
           assert(0 && "Invalid dim\n");
       }
     }
-
-    NSString* ns_shape_key = [[input_shape valueForKey:@"description"] componentsJoinedByString:@","];
 
     std::string key = "softmax_mps_out" + getTensorsStringKey(input, true, /*exclude_shape*/ true) + ":" +
         mem_format_key + ":" + std::to_string(dim_);
@@ -131,28 +195,10 @@ TORCH_IMPL_FUNC(softmax_mps_out)
   }
 }
 
-TORCH_IMPL_FUNC(softmax_backward_mps_out)
-(const Tensor& grad_, const Tensor& output_, int64_t dim, ScalarType input_dtype, const Tensor& grad_input) {
-  if (output_.numel() == 0) {
-    return;
-  }
-
-  Tensor grad;
-  if (grad_.dim() == 0) {
-    grad = grad_.view(1);
-  } else
-    grad = grad_;
-
-  Tensor output;
-  if (output_.dim() == 0) {
-    output = output_.view(1);
-  } else
-    output = output_;
-
-  int64_t dim_ = maybe_wrap_dim(dim, grad.dim());
-  TORCH_CHECK(dim_ >= 0 && dim_ < grad.dim(), "Grad:dim must be non-negative and less than input dimensions");
-
-  using namespace mps;
+static void softmax_backward_mps_out_graph(const Tensor& grad,
+                                           const Tensor& output,
+                                           int64_t dim_,
+                                           const Tensor& grad_input) {
   using CachedGraph = MPSUnaryGradCachedGraph;
   MPSStream* stream = getCurrentMPSStream();
 
@@ -188,6 +234,178 @@ TORCH_IMPL_FUNC(softmax_backward_mps_out)
 
     auto feeds = dictionaryFromPlaceholders(softmaxPlaceholder, gradOutputPlaceholder);
     runMPSGraph(stream, cachedGraph->graph(), feeds, gradInputPlaceholder);
+  }
+}
+
+} // namespace mps
+
+TORCH_IMPL_FUNC(softmax_mps_out)
+(const Tensor& input_, const int64_t dim, const bool half_to_float, const Tensor& output) {
+  TORCH_CHECK(!half_to_float, "softmax with half to float conversion is not supported on MPS");
+  TORCH_CHECK(c10::isFloatingType(input_.scalar_type()), "softmax only supported for floating types");
+
+  if (input_.numel() == 0) {
+    return;
+  }
+
+  Tensor input;
+  Tensor output_ = output;
+  if (input_.dim() == 0) {
+    input = input_.view(1);
+    // The structured kernel allocates output with the same (scalar) shape as
+    // the input; view it as 1-D so the params/kernel index a valid axis. The
+    // view shares storage, so writes land in the real 0-D output.
+    output_ = output.view(1);
+  } else
+    input = input_;
+
+  int64_t dim_ = maybe_wrap_dim(dim, input.dim());
+  TORCH_CHECK(dim_ >= 0 && dim_ < input.dim(), "Softmax:dim must be non-negative and less than input dimensions");
+
+  if (!mps::canUseMetalSoftmax(input)) {
+    mps::softmax_mps_out_graph(input, dim_, output_);
+    return;
+  }
+  // Last-dim softmax only in this PR: non-last-dim stays on the MPSGraph path
+  // until the native non-last-dim Metal kernels land in a follow-up.
+  if (dim_ != input.dim() - 1) {
+    mps::softmax_mps_out_graph(input, dim_, output_);
+    return;
+  }
+
+  using namespace mps;
+  int64_t axis_size = input.size(dim_);
+  int64_t outer_size = input.numel() / axis_size;
+  auto params = makeForwardParams(input, output_, dim_);
+
+  constexpr int N_READS = 4;
+  int64_t tg_size = std::min(static_cast<int64_t>((axis_size + N_READS - 1) / N_READS), static_cast<int64_t>(1024));
+
+  // 8-wide single-row variant for half-precision last-dim rows: each thread
+  // handles 8 elements (two vec4 loads), halving the threadgroup so the per-row
+  // threadgroup reduction is cheaper. Only for contiguous last-dim half/bfloat
+  // rows that fit the single-row register budget (axis <= 1024 * 8).
+  bool is_half = (input.scalar_type() == at::kHalf || input.scalar_type() == at::kBFloat16);
+  bool wide8_eligible = is_half && (dim_ == input.dim() - 1) && (params.stride_a == 1) && (params.stride_b == 1) &&
+      (axis_size <= 1024 * 8);
+  int64_t tg_size8 = std::min(static_cast<int64_t>((axis_size + 8 - 1) / 8), static_cast<int64_t>(1024));
+
+  MPSStream* stream = getCurrentMPSStream();
+
+  @autoreleasepool {
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      auto metalType = mps::scalarToMetalTypeString(input);
+      id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+      MTLSize threadsPerGroup = MTLSizeMake(tg_size, 1, 1);
+      id<MTLComputePipelineState> kernel;
+      MTLSize srGroup = threadsPerGroup;
+      if (axis_size <= 1024 * N_READS) {
+        if (wide8_eligible) {
+          kernel = mps::lib.getPipelineStateForFunc("softmax_forward_single_row8_" + metalType);
+          srGroup = MTLSizeMake(tg_size8, 1, 1);
+        } else {
+          kernel = mps::lib.getPipelineStateForFunc("softmax_forward_single_row_" + metalType);
+        }
+      } else {
+        kernel = mps::lib.getPipelineStateForFunc("softmax_forward_looped_" + metalType);
+      }
+
+      [encoder setComputePipelineState:kernel];
+      mps::mtl_setArgs(encoder, input, output_, params);
+      MTLSize numGroups = MTLSizeMake(outer_size, 1, 1);
+      [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:srGroup];
+    });
+  }
+}
+
+TORCH_IMPL_FUNC(softmax_backward_mps_out)
+(const Tensor& grad_, const Tensor& output_, int64_t dim, ScalarType input_dtype, const Tensor& grad_input) {
+  if (output_.numel() == 0) {
+    return;
+  }
+
+  Tensor grad;
+  if (grad_.dim() == 0) {
+    grad = grad_.view(1);
+  } else
+    grad = grad_;
+
+  Tensor output;
+  if (output_.dim() == 0) {
+    output = output_.view(1);
+  } else
+    output = output_;
+
+  // The structured kernel allocates grad_input with the same (scalar) shape as
+  // the inputs; view it as 1-D so the params/kernel index a valid axis. The
+  // view shares storage, so writes land in the real 0-D grad_input.
+  Tensor grad_input_ = grad_input;
+  if (grad_input.dim() == 0) {
+    grad_input_ = grad_input.view(1);
+  }
+
+  int64_t dim_ = maybe_wrap_dim(dim, grad.dim());
+  TORCH_CHECK(dim_ >= 0 && dim_ < grad.dim(), "Grad:dim must be non-negative and less than input dimensions");
+
+  // The Metal backward kernel is specialized on a single element type; a mixed
+  // half/float grad_input (e.g. softmax(x_fp16, dtype=fp32).backward()) would
+  // write the wrong element size, so route dtype-mismatched cases to MPSGraph.
+  bool bwd_dtypes_match =
+      grad.scalar_type() == output.scalar_type() && grad_input_.scalar_type() == output.scalar_type();
+  if (!(bwd_dtypes_match && mps::canUseMetalSoftmax(output) && mps::canUseMetalSoftmax(grad))) {
+    mps::softmax_backward_mps_out_graph(grad, output, dim_, grad_input_);
+    return;
+  }
+  // Last-dim softmax only in this PR (mirrors the forward gate).
+  if (dim_ != grad.dim() - 1) {
+    mps::softmax_backward_mps_out_graph(grad, output, dim_, grad_input_);
+    return;
+  }
+
+  using namespace mps;
+  int64_t axis_size = output.size(dim_);
+  int64_t outer_size = output.numel() / axis_size;
+
+  constexpr int N_READS = 4;
+  int64_t tg_size = std::min(static_cast<int64_t>((axis_size + N_READS - 1) / N_READS), static_cast<int64_t>(1024));
+  auto params = makeBackwardParams(grad, output, grad_input_, dim_);
+
+  // 8-wide single-row variant for half-precision last-dim rows: each thread
+  // handles 8 elements (two vec4 loads), halving the threadgroup so the per-row
+  // threadgroup reduction is cheaper. Mirrors the forward 8-wide path so that
+  // last-dim half fwdbwd does not lose the forward speedup to a narrow backward
+  // pass. Only for contiguous last-dim half/bfloat rows that fit the single-row
+  // register budget (axis <= 1024 * 8).
+  bool is_half = (output.scalar_type() == at::kHalf || output.scalar_type() == at::kBFloat16);
+  bool wide8_eligible = is_half && (dim_ == grad.dim() - 1) && (params.stride_a == 1) && (params.stride_b == 1) &&
+      (params.stride_c == 1) && (axis_size <= 1024 * 8);
+  int64_t tg_size8 = std::min(static_cast<int64_t>((axis_size + 8 - 1) / 8), static_cast<int64_t>(1024));
+
+  MPSStream* stream = getCurrentMPSStream();
+
+  @autoreleasepool {
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      auto metalType = mps::scalarToMetalTypeString(output);
+      id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+      MTLSize threadsPerGroup = MTLSizeMake(tg_size, 1, 1);
+      id<MTLComputePipelineState> kernel;
+      MTLSize srGroup = threadsPerGroup;
+      if (axis_size <= 1024 * N_READS) {
+        if (wide8_eligible) {
+          kernel = mps::lib.getPipelineStateForFunc("softmax_backward_single_row8_" + metalType);
+          srGroup = MTLSizeMake(tg_size8, 1, 1);
+        } else {
+          kernel = mps::lib.getPipelineStateForFunc("softmax_backward_single_row_" + metalType);
+        }
+      } else {
+        kernel = mps::lib.getPipelineStateForFunc("softmax_backward_looped_" + metalType);
+      }
+
+      [encoder setComputePipelineState:kernel];
+      mps::mtl_setArgs(encoder, grad, output, grad_input_, params);
+      MTLSize numGroups = MTLSizeMake(outer_size, 1, 1);
+      [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:srGroup];
+    });
   }
 }
 

--- a/aten/src/ATen/native/mps/operations/SoftMax.mm
+++ b/aten/src/ATen/native/mps/operations/SoftMax.mm
@@ -99,6 +99,55 @@ static SoftmaxParams makeBackwardParams(const Tensor& grad,
   return params;
 }
 
+// The tiled non-last-dim kernel (one thread per column, serial axis walk) only
+// wins for a SHORT axis. Above this cap the cooperative blocked kernel is used.
+static constexpr int64_t kSoftmaxTiledAxisCap = 32;
+
+// Launch plan for the blocked non-last-dim kernels.
+//   cols_per_tg      : adjacent columns per threadgroup (coalesced; SIMD width)
+//   tg_size          : threadgroup size = cols_per_tg * num_axis_threads
+//   num_axis_chunks  : axis-split factor across threadgroups (1 => single pass)
+// cols_per_tg is kept at the SIMD width (32) when inner_size allows so each warp
+// load spans 32 adjacent columns; the rest of the threadgroup goes to axis
+// parallelism. When the column count is small (so the single-pass grid would
+// starve occupancy) and the axis is long, num_axis_chunks > 1 splits the axis
+// across threadgroups via the two-pass blocked kernels.
+struct BlockedLaunch {
+  int64_t cols_per_tg;
+  int64_t tg_size;
+  int64_t num_axis_chunks;
+};
+
+static BlockedLaunch computeBlockedLaunch(int64_t inner_size, int64_t axis_size, int64_t outer_before) {
+  int64_t cols_per_tg = std::min<int64_t>(inner_size, 32);
+  int64_t max_axis_threads = 1024 / cols_per_tg;
+  int64_t nat = 1;
+  while (nat * 2 <= max_axis_threads && nat * 2 <= axis_size)
+    nat *= 2;
+  int64_t tg_size = cols_per_tg * nat;
+
+  // Single-pass threadgroup count. The two-pass axis split adds a full extra
+  // global round-trip (partials write + re-read), so it only pays off when the
+  // single-pass grid would badly starve the GPU (very few columns). Above a
+  // small TG floor the single-pass blocked kernel already fills the machine and
+  // is cheaper. Empirically the split wins for the tall, few-column case
+  // (65536x128 -> 4 TGs) but loses for square (1024x1024 -> 32 TGs).
+  int64_t num_col_tiles = (inner_size + cols_per_tg - 1) / cols_per_tg;
+  int64_t single_pass_tgs = num_col_tiles * outer_before;
+  int64_t num_axis_chunks = 1;
+  constexpr int64_t kMinSinglePassTGs = 24; // below this, split the axis
+  constexpr int64_t kTargetTGs = 192; // aim when splitting
+  constexpr int64_t kMinChunkElems = 512; // keep each chunk's work worthwhile
+  if (single_pass_tgs < kMinSinglePassTGs && axis_size >= 2 * kMinChunkElems) {
+    int64_t want = (kTargetTGs + single_pass_tgs - 1) / single_pass_tgs;
+    int64_t max_by_work = axis_size / kMinChunkElems;
+    num_axis_chunks = std::min(want, max_by_work);
+    if (num_axis_chunks < 1)
+      num_axis_chunks = 1;
+  }
+  return {cols_per_tg, tg_size, num_axis_chunks};
+}
+
 // ============================================================================
 // Legacy MPSGraph fallback (gated). Retained for correctness on the cases the
 // native Metal softmax does not cover. Do not delete; this is the fallback the
@@ -266,17 +315,147 @@ TORCH_IMPL_FUNC(softmax_mps_out)
     mps::softmax_mps_out_graph(input, dim_, output_);
     return;
   }
-  // Last-dim softmax only in this PR: non-last-dim stays on the MPSGraph path
-  // until the native non-last-dim Metal kernels land in a follow-up.
-  if (dim_ != input.dim() - 1) {
-    mps::softmax_mps_out_graph(input, dim_, output_);
-    return;
-  }
 
   using namespace mps;
   int64_t axis_size = input.size(dim_);
   int64_t outer_size = input.numel() / axis_size;
   auto params = makeForwardParams(input, output_, dim_);
+
+  // Tiled path: each thread does one complete softmax row at one inner position.
+  // Coalesced across threads, but the per-thread axis reduction is serial, so it
+  // is only a win when the axis is SHORT (otherwise the blocked path below adds
+  // per-column parallelism). The win regime is large inner_size + tiny axis
+  // (e.g. 8x2048x4096 dim=0, axis=8).
+  {
+    int64_t ndim = input.dim();
+    int64_t inner_size = input.stride(dim_);
+    bool use_tiled = (dim_ != ndim - 1) && input.is_contiguous() && output_.is_contiguous();
+    use_tiled = use_tiled && (inner_size >= axis_size) && (axis_size <= kSoftmaxTiledAxisCap);
+    if (use_tiled) {
+      int64_t outer_before = outer_size / inner_size;
+      int64_t tile_tg_size = std::min(inner_size, static_cast<int64_t>(1024));
+      int64_t num_tiles = (inner_size + tile_tg_size - 1) / tile_tg_size;
+      while (num_tiles * outer_before < 64 && tile_tg_size > 32) {
+        tile_tg_size /= 2;
+        num_tiles = (inner_size + tile_tg_size - 1) / tile_tg_size;
+      }
+      params.num_chunks = static_cast<uint32_t>(num_tiles);
+
+      MPSStream* stream = getCurrentMPSStream();
+      @autoreleasepool {
+        dispatch_sync_with_rethrow(stream->queue(), ^() {
+          auto metalType = mps::scalarToMetalTypeString(input);
+          auto kernel = mps::lib.getPipelineStateForFunc("softmax_forward_tiled_" + metalType);
+          id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+          [encoder setComputePipelineState:kernel];
+          mps::mtl_setArgs(encoder, input, output_, params);
+          MTLSize threadsPerGroup = MTLSizeMake(tile_tg_size, 1, 1);
+          MTLSize numGroups = MTLSizeMake(num_tiles * outer_before, 1, 1);
+          [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:threadsPerGroup];
+        });
+      }
+      return;
+    }
+  }
+
+  // Blocked path: cooperative axis reduction for non-last-dim with a long axis
+  // (square dim=0, tall dim=0, inner<axis). A threadgroup owns COLS_PER_TG
+  // adjacent columns and packs num_axis_threads threads per column that
+  // cooperate over the axis. Coalesced reads, per-column parallelism, no axis
+  // cap. Supersedes the old coalesced path for these shapes.
+  {
+    int64_t ndim = input.dim();
+    int64_t inner_size = input.stride(dim_);
+    bool use_blocked = (dim_ != ndim - 1) && input.is_contiguous() && output_.is_contiguous() && (inner_size >= 1);
+    if (use_blocked) {
+      int64_t outer_before = outer_size / inner_size;
+      auto launch = computeBlockedLaunch(inner_size, axis_size, outer_before);
+      int64_t cols_per_tg = launch.cols_per_tg;
+      int64_t tg_size = launch.tg_size;
+      int64_t num_axis_chunks = launch.num_axis_chunks;
+      params.num_chunks = static_cast<uint32_t>(cols_per_tg);
+      params.num_col_chunks = static_cast<uint32_t>(num_axis_chunks);
+      int64_t num_col_tiles = (inner_size + cols_per_tg - 1) / cols_per_tg;
+
+      if (num_axis_chunks > 1) {
+        // Two-pass axis split for low-column / long-axis (raises occupancy).
+        Tensor blk_partials =
+            at::empty({outer_before * inner_size * num_axis_chunks * 2}, input.options().dtype(at::kFloat));
+        MPSStream* stream = getCurrentMPSStream();
+        @autoreleasepool {
+          dispatch_sync_with_rethrow(stream->queue(), ^() {
+            auto metalType = mps::scalarToMetalTypeString(input);
+            id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+            MTLSize threadsPerGroup = MTLSizeMake(tg_size, 1, 1);
+            MTLSize numGroups = MTLSizeMake(num_col_tiles * outer_before * num_axis_chunks, 1, 1);
+
+            auto reduce_kernel = mps::lib.getPipelineStateForFunc("softmax_forward_blocked2_reduce_" + metalType);
+            [encoder setComputePipelineState:reduce_kernel];
+            mps::mtl_setArgs(encoder, input, blk_partials, params);
+            [encoder setThreadgroupMemoryLength:tg_size * 2 * sizeof(float) atIndex:0];
+            [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:threadsPerGroup];
+
+            [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+
+            auto write_kernel = mps::lib.getPipelineStateForFunc("softmax_forward_blocked2_write_" + metalType);
+            [encoder setComputePipelineState:write_kernel];
+            mps::mtl_setArgs(encoder, input, output_, blk_partials, params);
+            [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:threadsPerGroup];
+          });
+        }
+        return;
+      }
+
+      MPSStream* stream = getCurrentMPSStream();
+      @autoreleasepool {
+        dispatch_sync_with_rethrow(stream->queue(), ^() {
+          auto metalType = mps::scalarToMetalTypeString(input);
+          auto kernel = mps::lib.getPipelineStateForFunc("softmax_forward_blocked_" + metalType);
+          id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+          [encoder setComputePipelineState:kernel];
+          mps::mtl_setArgs(encoder, input, output_, params);
+          [encoder setThreadgroupMemoryLength:tg_size * 2 * sizeof(float) atIndex:0];
+          MTLSize threadsPerGroup = MTLSizeMake(tg_size, 1, 1);
+          MTLSize numGroups = MTLSizeMake(num_col_tiles * outer_before, 1, 1);
+          [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:threadsPerGroup];
+        });
+      }
+      return;
+    }
+  }
+
+  // Coalesced path: flat loads with shared memory reduction (legacy; the blocked
+  // path above now covers the non-last-dim contiguous cases).
+  {
+    int64_t ndim = input.dim();
+    int64_t inner_size = input.stride(dim_);
+    bool use_coalesced = (dim_ != ndim - 1) && input.is_contiguous() && output_.is_contiguous() && (inner_size > 1) &&
+        (inner_size < axis_size) && (axis_size <= 16384);
+    if (use_coalesced) {
+      int64_t outer_before = outer_size / inner_size;
+      int64_t nat = 1;
+      while (nat * 2 <= 1024 / inner_size)
+        nat *= 2;
+      int64_t coal_tg_size = inner_size * nat;
+      params.num_chunks = static_cast<uint32_t>(nat);
+
+      MPSStream* stream = getCurrentMPSStream();
+      @autoreleasepool {
+        dispatch_sync_with_rethrow(stream->queue(), ^() {
+          auto metalType = mps::scalarToMetalTypeString(input);
+          auto kernel = mps::lib.getPipelineStateForFunc("softmax_forward_coalesced_" + metalType);
+          id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+          [encoder setComputePipelineState:kernel];
+          mps::mtl_setArgs(encoder, input, output_, params);
+          [encoder setThreadgroupMemoryLength:coal_tg_size * 2 * sizeof(float) atIndex:0];
+          MTLSize threadsPerGroup = MTLSizeMake(coal_tg_size, 1, 1);
+          MTLSize numGroups = MTLSizeMake(outer_before, 1, 1);
+          [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:threadsPerGroup];
+        });
+      }
+      return;
+    }
+  }
 
   constexpr int N_READS = 4;
   int64_t tg_size = std::min(static_cast<int64_t>((axis_size + N_READS - 1) / N_READS), static_cast<int64_t>(1024));
@@ -290,6 +469,18 @@ TORCH_IMPL_FUNC(softmax_mps_out)
       (axis_size <= 1024 * 8);
   int64_t tg_size8 = std::min(static_cast<int64_t>((axis_size + 8 - 1) / 8), static_cast<int64_t>(1024));
 
+  constexpr int64_t kFwdMinOccupancyTG = 8;
+  int64_t elems_per_tg = tg_size * N_READS;
+  int64_t raw_chunks = axis_size / elems_per_tg;
+  int64_t max_chunks = std::min(raw_chunks, static_cast<int64_t>(16));
+  bool use_two_pass_fwd = (raw_chunks >= 8) && (outer_size < kFwdMinOccupancyTG);
+
+  Tensor fwd_partials;
+  if (use_two_pass_fwd) {
+    params.num_chunks = static_cast<uint32_t>(max_chunks);
+    fwd_partials = at::empty({outer_size * max_chunks * 2}, input.options().dtype(at::kFloat));
+  }
+
   MPSStream* stream = getCurrentMPSStream();
 
   @autoreleasepool {
@@ -297,23 +488,39 @@ TORCH_IMPL_FUNC(softmax_mps_out)
       auto metalType = mps::scalarToMetalTypeString(input);
       id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
       MTLSize threadsPerGroup = MTLSizeMake(tg_size, 1, 1);
-      id<MTLComputePipelineState> kernel;
-      MTLSize srGroup = threadsPerGroup;
-      if (axis_size <= 1024 * N_READS) {
-        if (wide8_eligible) {
-          kernel = mps::lib.getPipelineStateForFunc("softmax_forward_single_row8_" + metalType);
-          srGroup = MTLSizeMake(tg_size8, 1, 1);
-        } else {
-          kernel = mps::lib.getPipelineStateForFunc("softmax_forward_single_row_" + metalType);
-        }
-      } else {
-        kernel = mps::lib.getPipelineStateForFunc("softmax_forward_looped_" + metalType);
-      }
 
-      [encoder setComputePipelineState:kernel];
-      mps::mtl_setArgs(encoder, input, output_, params);
-      MTLSize numGroups = MTLSizeMake(outer_size, 1, 1);
-      [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:srGroup];
+      if (use_two_pass_fwd) {
+        auto reduce_kernel = mps::lib.getPipelineStateForFunc("softmax_forward_2pass_reduce_" + metalType);
+        [encoder setComputePipelineState:reduce_kernel];
+        mps::mtl_setArgs(encoder, input, fwd_partials, params);
+        MTLSize numGroups = MTLSizeMake(static_cast<NSUInteger>(params.num_chunks) * outer_size, 1, 1);
+        [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:threadsPerGroup];
+
+        [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+
+        auto write_kernel = mps::lib.getPipelineStateForFunc("softmax_forward_2pass_write_" + metalType);
+        [encoder setComputePipelineState:write_kernel];
+        mps::mtl_setArgs(encoder, input, output_, fwd_partials, params);
+        [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:threadsPerGroup];
+      } else {
+        id<MTLComputePipelineState> kernel;
+        MTLSize srGroup = threadsPerGroup;
+        if (axis_size <= 1024 * N_READS) {
+          if (wide8_eligible) {
+            kernel = mps::lib.getPipelineStateForFunc("softmax_forward_single_row8_" + metalType);
+            srGroup = MTLSizeMake(tg_size8, 1, 1);
+          } else {
+            kernel = mps::lib.getPipelineStateForFunc("softmax_forward_single_row_" + metalType);
+          }
+        } else {
+          kernel = mps::lib.getPipelineStateForFunc("softmax_forward_looped_" + metalType);
+        }
+
+        [encoder setComputePipelineState:kernel];
+        mps::mtl_setArgs(encoder, input, output_, params);
+        MTLSize numGroups = MTLSizeMake(outer_size, 1, 1);
+        [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:srGroup];
+      }
     });
   }
 }
@@ -356,11 +563,6 @@ TORCH_IMPL_FUNC(softmax_backward_mps_out)
     mps::softmax_backward_mps_out_graph(grad, output, dim_, grad_input_);
     return;
   }
-  // Last-dim softmax only in this PR (mirrors the forward gate).
-  if (dim_ != grad.dim() - 1) {
-    mps::softmax_backward_mps_out_graph(grad, output, dim_, grad_input_);
-    return;
-  }
 
   using namespace mps;
   int64_t axis_size = output.size(dim_);
@@ -381,6 +583,146 @@ TORCH_IMPL_FUNC(softmax_backward_mps_out)
       (params.stride_c == 1) && (axis_size <= 1024 * 8);
   int64_t tg_size8 = std::min(static_cast<int64_t>((axis_size + 8 - 1) / 8), static_cast<int64_t>(1024));
 
+  // Tiled path for non-last-dim backward (short axis only; see fwd note).
+  {
+    int64_t ndim = grad.dim();
+    bool use_tiled =
+        (dim_ != ndim - 1) && grad.is_contiguous() && output.is_contiguous() && grad_input_.is_contiguous();
+    int64_t inner_size = grad.stride(dim_);
+    use_tiled = use_tiled && (inner_size >= axis_size) && (axis_size <= kSoftmaxTiledAxisCap);
+    if (use_tiled) {
+      int64_t outer_before = outer_size / inner_size;
+      int64_t tile_tg_size = std::min(inner_size, static_cast<int64_t>(1024));
+      int64_t num_tiles = (inner_size + tile_tg_size - 1) / tile_tg_size;
+      while (num_tiles * outer_before < 64 && tile_tg_size > 32) {
+        tile_tg_size /= 2;
+        num_tiles = (inner_size + tile_tg_size - 1) / tile_tg_size;
+      }
+      params.num_chunks = static_cast<uint32_t>(num_tiles);
+
+      MPSStream* stream = getCurrentMPSStream();
+      @autoreleasepool {
+        dispatch_sync_with_rethrow(stream->queue(), ^() {
+          auto metalType = mps::scalarToMetalTypeString(output);
+          auto kernel = mps::lib.getPipelineStateForFunc("softmax_backward_tiled_" + metalType);
+          id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+          [encoder setComputePipelineState:kernel];
+          mps::mtl_setArgs(encoder, grad, output, grad_input_, params);
+          MTLSize threadsPerGroup = MTLSizeMake(tile_tg_size, 1, 1);
+          MTLSize numGroups = MTLSizeMake(num_tiles * outer_before, 1, 1);
+          [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:threadsPerGroup];
+        });
+      }
+      return;
+    }
+  }
+
+  // Blocked path: cooperative axis reduction for non-last-dim with a long axis.
+  {
+    int64_t ndim = grad.dim();
+    int64_t inner_size = grad.stride(dim_);
+    bool use_blocked = (dim_ != ndim - 1) && grad.is_contiguous() && output.is_contiguous() &&
+        grad_input_.is_contiguous() && (inner_size >= 1);
+    if (use_blocked) {
+      int64_t outer_before = outer_size / inner_size;
+      auto launch = computeBlockedLaunch(inner_size, axis_size, outer_before);
+      int64_t cols_per_tg = launch.cols_per_tg;
+      int64_t blk_tg_size = launch.tg_size;
+      int64_t num_axis_chunks = launch.num_axis_chunks;
+      params.num_chunks = static_cast<uint32_t>(cols_per_tg);
+      params.num_col_chunks = static_cast<uint32_t>(num_axis_chunks);
+      int64_t num_col_tiles = (inner_size + cols_per_tg - 1) / cols_per_tg;
+
+      if (num_axis_chunks > 1) {
+        Tensor blk_partials =
+            at::empty({outer_before * inner_size * num_axis_chunks}, grad.options().dtype(at::kFloat));
+        MPSStream* stream = getCurrentMPSStream();
+        @autoreleasepool {
+          dispatch_sync_with_rethrow(stream->queue(), ^() {
+            auto metalType = mps::scalarToMetalTypeString(output);
+            id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+            MTLSize threadsPerGroup = MTLSizeMake(blk_tg_size, 1, 1);
+            MTLSize numGroups = MTLSizeMake(num_col_tiles * outer_before * num_axis_chunks, 1, 1);
+
+            auto dot_kernel = mps::lib.getPipelineStateForFunc("softmax_backward_blocked2_dot_" + metalType);
+            [encoder setComputePipelineState:dot_kernel];
+            mps::mtl_setArgs(encoder, grad, output, blk_partials, params);
+            [encoder setThreadgroupMemoryLength:blk_tg_size * sizeof(float) atIndex:0];
+            [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:threadsPerGroup];
+
+            [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+
+            auto grad_kernel = mps::lib.getPipelineStateForFunc("softmax_backward_blocked2_grad_" + metalType);
+            [encoder setComputePipelineState:grad_kernel];
+            mps::mtl_setArgs(encoder, grad, output, grad_input_, blk_partials, params);
+            [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:threadsPerGroup];
+          });
+        }
+        return;
+      }
+
+      MPSStream* stream = getCurrentMPSStream();
+      @autoreleasepool {
+        dispatch_sync_with_rethrow(stream->queue(), ^() {
+          auto metalType = mps::scalarToMetalTypeString(output);
+          auto kernel = mps::lib.getPipelineStateForFunc("softmax_backward_blocked_" + metalType);
+          id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+          [encoder setComputePipelineState:kernel];
+          mps::mtl_setArgs(encoder, grad, output, grad_input_, params);
+          [encoder setThreadgroupMemoryLength:blk_tg_size * sizeof(float) atIndex:0];
+          MTLSize threadsPerGroup = MTLSizeMake(blk_tg_size, 1, 1);
+          MTLSize numGroups = MTLSizeMake(num_col_tiles * outer_before, 1, 1);
+          [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:threadsPerGroup];
+        });
+      }
+      return;
+    }
+  }
+
+  // Coalesced path: flat loads with shared memory reduction (legacy).
+  {
+    int64_t ndim = grad.dim();
+    int64_t inner_size = grad.stride(dim_);
+    bool use_coalesced = (dim_ != ndim - 1) && grad.is_contiguous() && output.is_contiguous() &&
+        grad_input_.is_contiguous() && (inner_size > 1) && (inner_size < axis_size) && (axis_size <= 16384);
+    if (use_coalesced) {
+      int64_t outer_before = outer_size / inner_size;
+      int64_t nat = 1;
+      while (nat * 2 <= 1024 / inner_size)
+        nat *= 2;
+      int64_t coal_tg_size = inner_size * nat;
+      params.num_chunks = static_cast<uint32_t>(nat);
+
+      MPSStream* stream = getCurrentMPSStream();
+      @autoreleasepool {
+        dispatch_sync_with_rethrow(stream->queue(), ^() {
+          auto metalType = mps::scalarToMetalTypeString(output);
+          auto kernel = mps::lib.getPipelineStateForFunc("softmax_backward_coalesced_" + metalType);
+          id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+          [encoder setComputePipelineState:kernel];
+          mps::mtl_setArgs(encoder, grad, output, grad_input_, params);
+          [encoder setThreadgroupMemoryLength:coal_tg_size * 2 * sizeof(float) atIndex:0];
+          MTLSize threadsPerGroup = MTLSizeMake(coal_tg_size, 1, 1);
+          MTLSize numGroups = MTLSizeMake(outer_before, 1, 1);
+          [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:threadsPerGroup];
+        });
+      }
+      return;
+    }
+  }
+
+  constexpr int64_t kMinOccupancyTG = 8;
+  int64_t elems_per_tg = tg_size * N_READS;
+  int64_t raw_chunks = axis_size / elems_per_tg;
+  int64_t max_chunks = std::min(raw_chunks, static_cast<int64_t>(16));
+  bool use_two_pass = (raw_chunks >= 8) && (outer_size < kMinOccupancyTG);
+
+  Tensor partial_sums;
+  if (use_two_pass) {
+    params.num_chunks = static_cast<uint32_t>(max_chunks);
+    partial_sums = at::empty({outer_size * max_chunks}, grad.options().dtype(at::kFloat));
+  }
+
   MPSStream* stream = getCurrentMPSStream();
 
   @autoreleasepool {
@@ -388,23 +730,39 @@ TORCH_IMPL_FUNC(softmax_backward_mps_out)
       auto metalType = mps::scalarToMetalTypeString(output);
       id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
       MTLSize threadsPerGroup = MTLSizeMake(tg_size, 1, 1);
-      id<MTLComputePipelineState> kernel;
-      MTLSize srGroup = threadsPerGroup;
-      if (axis_size <= 1024 * N_READS) {
-        if (wide8_eligible) {
-          kernel = mps::lib.getPipelineStateForFunc("softmax_backward_single_row8_" + metalType);
-          srGroup = MTLSizeMake(tg_size8, 1, 1);
-        } else {
-          kernel = mps::lib.getPipelineStateForFunc("softmax_backward_single_row_" + metalType);
-        }
-      } else {
-        kernel = mps::lib.getPipelineStateForFunc("softmax_backward_looped_" + metalType);
-      }
 
-      [encoder setComputePipelineState:kernel];
-      mps::mtl_setArgs(encoder, grad, output, grad_input_, params);
-      MTLSize numGroups = MTLSizeMake(outer_size, 1, 1);
-      [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:srGroup];
+      if (use_two_pass) {
+        auto dot_kernel = mps::lib.getPipelineStateForFunc("softmax_backward_2pass_dot_" + metalType);
+        [encoder setComputePipelineState:dot_kernel];
+        mps::mtl_setArgs(encoder, grad, output, partial_sums, params);
+        MTLSize numGroups = MTLSizeMake(static_cast<NSUInteger>(params.num_chunks) * outer_size, 1, 1);
+        [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:threadsPerGroup];
+
+        [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+
+        auto grad_kernel = mps::lib.getPipelineStateForFunc("softmax_backward_2pass_grad_" + metalType);
+        [encoder setComputePipelineState:grad_kernel];
+        mps::mtl_setArgs(encoder, grad, output, grad_input_, partial_sums, params);
+        [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:threadsPerGroup];
+      } else {
+        id<MTLComputePipelineState> kernel;
+        MTLSize srGroup = threadsPerGroup;
+        if (axis_size <= 1024 * N_READS) {
+          if (wide8_eligible) {
+            kernel = mps::lib.getPipelineStateForFunc("softmax_backward_single_row8_" + metalType);
+            srGroup = MTLSizeMake(tg_size8, 1, 1);
+          } else {
+            kernel = mps::lib.getPipelineStateForFunc("softmax_backward_single_row_" + metalType);
+          }
+        } else {
+          kernel = mps::lib.getPipelineStateForFunc("softmax_backward_looped_" + metalType);
+        }
+
+        [encoder setComputePipelineState:kernel];
+        mps::mtl_setArgs(encoder, grad, output, grad_input_, params);
+        MTLSize numGroups = MTLSizeMake(outer_size, 1, 1);
+        [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:srGroup];
+      }
     });
   }
 }

--- a/benchmarks/mps/bench_analyze.py
+++ b/benchmarks/mps/bench_analyze.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Pair A (forced MPSGraph) vs B (Metal) softmax bench results.
+
+speedup = A_us / B_us  (>1 => Metal FASTER = good; <1 => Metal slower = regression)
+Per cell we take the median over reps of A and of B independently, then ratio.
+A cell is a REGRESSION if speedup < REG_THRESH (default 0.95).
+"""
+
+import glob
+import json
+import os
+import sys
+
+
+OUT = sys.argv[1] if len(sys.argv) > 1 else "/tmp/bench_out"
+REG = float(os.environ.get("REG_THRESH", "0.95"))
+
+
+def load(prefix):
+    cells = {}  # (shape,dtype,kind) -> list of median_us
+    for f in sorted(glob.glob(os.path.join(OUT, prefix + "_*.json"))):
+        try:
+            with open(f) as fh:
+                d = json.load(fh)
+        except Exception as e:
+            print("skip", f, e, file=sys.stderr)
+            continue
+        for r in d["results"]:
+            if "error" in r:
+                continue
+            k = (r["shape"], r["dtype"], r["kind"])
+            cells.setdefault(k, []).append(r["median_us"])
+    return cells
+
+
+def med(xs):
+    xs = sorted(xs)
+    return xs[len(xs) // 2]
+
+
+A = load("A")
+B = load("B")
+keys = sorted(set(A) & set(B))
+rows = []
+for k in keys:
+    a = med(A[k])
+    b = med(B[k])
+    sp = a / b if b > 0 else float("inf")
+    rows.append((k, a, b, sp))
+
+regs = [r for r in rows if r[3] < REG]
+regs.sort(key=lambda r: r[3])
+
+print("=== ALL CELLS (speedup = MPSGraph_us / Metal_us; <1 = Metal slower) ===")
+print(
+    f"{'shape':<22} {'dt':<5} {'kind':<7} {'A(MG)us':>9} {'B(Mtl)us':>9} {'speedup':>7}"
+)
+for k, a, b, sp in sorted(rows, key=lambda r: r[3]):
+    flag = "  REG" if sp < REG else ""
+    print(f"{k[0]:<22} {k[1]:<5} {k[2]:<7} {a:>9.2f} {b:>9.2f} {sp:>7.3f}{flag}")
+
+print()
+print(f"=== REGRESSIONS (speedup < {REG:.2f}): {len(regs)} ===")
+for k, a, b, sp in regs:
+    print(
+        f"{k[0]:<22} {k[1]:<5} {k[2]:<7}  Metal={b:.2f}us MPSGraph={a:.2f}us  "
+        f"{sp:.3f}x  (Metal +{b - a:.2f}us)"
+    )
+print()
+print(f"TOTAL CELLS={len(rows)}  REGRESSIONS={len(regs)}")

--- a/benchmarks/mps/bench_run.sh
+++ b/benchmarks/mps/bench_run.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Drift-free interleaved A/B softmax bench. For each shape we want A (forced
+# MPSGraph) and B (native Metal) measured close in time. The toggle
+# (PYTORCH_MPS_FORCE_MPSGRAPH_SOFTMAX) is read once per process, so each mode
+# runs as its own process; we run A then B back-to-back, REPS times, and pair
+# them offline (median per cell, via bench_analyze.py) to neutralise drift.
+#
+# Usage:  PYTHON=python3 REPS=2 OUT=/tmp/bench_out bash benchmarks/mps/bench_run.sh
+# Requires this checkout importable as `torch` (pip install -e ., or set PYTHONPATH).
+set -e
+HERE="$(cd "$(dirname "$0")" && pwd)"
+PY="${PYTHON:-python3}"
+OUT="${OUT:-/tmp/bench_softmax_out}"
+REPS="${REPS:-2}"
+FOCUS="${BENCH_FOCUS:-0}"
+mkdir -p "$OUT"; rm -f "$OUT"/A_*.json "$OUT"/B_*.json
+for r in $(seq 1 "$REPS"); do
+  echo "[bench] rep $r mode A (forced MPSGraph)"
+  PYTORCH_MPS_FORCE_MPSGRAPH_SOFTMAX=1 BENCH_MODE=A BENCH_TASK=perf BENCH_FOCUS="$FOCUS" \
+    "$PY" "$HERE/bench_softmax.py" > "$OUT/A_$r.json" 2>"$OUT/A_$r.err"
+  echo "[bench] rep $r mode B (native Metal)"
+  BENCH_MODE=B BENCH_TASK=perf BENCH_FOCUS="$FOCUS" \
+    "$PY" "$HERE/bench_softmax.py" > "$OUT/B_$r.json" 2>"$OUT/B_$r.err"
+done
+echo "[bench] done -> $OUT"

--- a/benchmarks/mps/bench_softmax.py
+++ b/benchmarks/mps/bench_softmax.py
@@ -1,0 +1,249 @@
+"""MPS softmax before/after bench (G3) + memory-stability probe (G2).
+
+Same-build comparison of the kept MPSGraph fallback (mode A, forced via
+PYTORCH_MPS_FORCE_MPSGRAPH_SOFTMAX=1) versus the native Metal softmax kernels
+(mode B, env unset). The force toggle is read once per process (static const in
+canUseMetalSoftmax), so each MODE MUST run in its own process. This script is a
+single-mode worker: set BENCH_MODE={A,B} and BENCH_TASK={perf,mem,sanity}.
+The interleaving/orchestration is done by the parent harness (bench_run.sh),
+which alternates A and B per-shape in one session to neutralise thermal drift.
+
+Methodology (perf): torch.utils.benchmark.Timer + blocked_autorange, warmup 30,
+mean over N_TRIALS=5; amortised many-iter-one-sync to dodge the MPS sync floor.
+"""
+
+import json
+import os
+import sys
+
+import torch
+
+
+if not torch.backends.mps.is_available():
+    raise RuntimeError("MPS not available")
+
+MODE = os.environ.get("BENCH_MODE", "B")
+TASK = os.environ.get("BENCH_TASK", "perf")
+DEV = torch.device("mps")
+
+DTYPES = {"f32": torch.float32, "f16": torch.float16, "bf16": torch.bfloat16}
+
+# (name, shape, dim)
+SHAPES = [
+    ("1024x1024_d-1", (1024, 1024), -1),
+    ("1024x1024_d0", (1024, 1024), 0),
+    ("4096x4096_d-1", (4096, 4096), -1),
+    ("4096x4096_d0", (4096, 4096), 0),
+    ("8x2048x4096_d-1", (8, 2048, 4096), -1),
+    ("8x2048x4096_d0", (8, 2048, 4096), 0),
+    ("8x2048x4096_d1", (8, 2048, 4096), 1),
+    ("65536x128_d-1", (65536, 128), -1),
+    ("65536x128_d0", (65536, 128), 0),
+    ("128x65536_d-1", (128, 65536), -1),
+    ("128x65536_d0", (128, 65536), 0),
+    ("512x768_d-1", (512, 768), -1),
+    ("2048x2048_d-1", (2048, 2048), -1),
+]
+
+# Focused regression-confirmation subset (BENCH_FOCUS=1).
+FOCUS_SHAPES = [
+    ("1024x1024_d0", (1024, 1024), 0),
+    ("4096x4096_d0", (4096, 4096), 0),
+    ("65536x128_d0", (65536, 128), 0),
+    ("8x2048x4096_d0", (8, 2048, 4096), 0),  # the WIN (tiled path) - sanity
+    ("1024x1024_d-1", (1024, 1024), -1),  # borderline last-dim
+    ("2048x2048_d-1", (2048, 2048), -1),  # borderline last-dim
+    ("8x2048x4096_d-1", (8, 2048, 4096), -1),  # +323us last-dim reg
+]
+if os.environ.get("BENCH_FOCUS") == "1":
+    SHAPES = FOCUS_SHAPES
+
+
+def amortized_timer(fn, sync, label):
+    """Time fn with one sync amortised over the inner loop to dodge sync floor."""
+    import torch.utils.benchmark as tb
+
+    t = tb.Timer(
+        stmt="for _ in range(I):\n    fn()\nsync()",
+        globals={"fn": fn, "sync": sync, "I": 50},
+        num_threads=1,
+        label=label,
+    )
+    _mrt = float(os.environ.get("BENCH_MIN_RUN_TIME", "1.5"))
+    m = t.blocked_autorange(min_run_time=_mrt)
+    # per-call median in microseconds
+    return (m.median / 50) * 1e6
+
+
+def make_fwd(shape, dim, dt):
+    x = torch.randn(*shape, device=DEV, dtype=dt)
+
+    def fn():
+        return torch.softmax(x, dim=dim)
+
+    return fn
+
+
+def make_fwd_bwd(shape, dim, dt):
+    x = torch.randn(*shape, device=DEV, dtype=dt, requires_grad=True)
+    go = torch.randn(*shape, device=DEV, dtype=dt)
+
+    def fn():
+        y = torch.softmax(x, dim=dim)
+        y.backward(go)
+        x.grad = None
+
+    return fn
+
+
+def sync():
+    torch.mps.synchronize()
+
+
+def run_perf():
+    N_TRIALS = int(os.environ.get("N_TRIALS", "5"))
+    out = []
+    for sname, shape, dim in SHAPES:
+        for dtkey, dt in DTYPES.items():
+            for kind, maker in (("fwd", make_fwd), ("fwdbwd", make_fwd_bwd)):
+                try:
+                    fn = maker(shape, dim, dt)
+                    # warmup
+                    for _ in range(30):
+                        fn()
+                    sync()
+                    trials = []
+                    for _ in range(N_TRIALS):
+                        us = amortized_timer(fn, sync, f"{sname}/{dtkey}/{kind}")
+                        trials.append(us)
+                    trials.sort()
+                    med = trials[len(trials) // 2]
+                    mn = sum(trials) / len(trials)
+                    sd = (sum((t - mn) ** 2 for t in trials) / len(trials)) ** 0.5
+                    out.append(
+                        {
+                            "shape": sname,
+                            "dtype": dtkey,
+                            "kind": kind,
+                            "median_us": med,
+                            "mean_us": mn,
+                            "std_us": sd,
+                            "trials": trials,
+                        }
+                    )
+                except Exception as e:
+                    out.append(
+                        {"shape": sname, "dtype": dtkey, "kind": kind, "error": repr(e)}
+                    )
+    print(json.dumps({"mode": MODE, "results": out}))
+
+
+def run_mem():
+    """G2: loop over ~200 distinct shapes; isolate the per-shape GRAPH cache.
+
+    The MPS *tensor* allocator pool is freed by empty_cache(); the MPSGraph
+    executable cache (keyed per shape) is NOT. To isolate the cache growth from
+    raw tensor data we (a) keep each shape TINY so tensor bytes are negligible,
+    and (b) empty_cache()+synchronize before sampling so the residual driver
+    memory reflects retained graph state, not live/pooled tensors.
+    """
+    torch.mps.empty_cache()
+    torch.mps.synchronize()
+    samples = []
+    start_drv = torch.mps.driver_allocated_memory()
+    start_cur = torch.mps.current_allocated_memory()
+    count = 0
+    # 100 distinct shapes x 2 dims = 200 distinct (shape,dim) softmax keys.
+    # Tiny rows/cols so per-shape tensor bytes << any graph-cache footprint.
+    for i in range(100):
+        rows = 32 + i  # 32..131, distinct each iter
+        cols = 48 + i  # 48..147, distinct each iter (keeps shape unique)
+        for dim in (-1, 0):
+            x = torch.randn(rows, cols, device=DEV, dtype=torch.float32)
+            y = torch.softmax(x, dim=dim)
+            # backward too (distinct bwd graph per shape under MPSGraph)
+            xb = torch.randn(
+                rows, cols, device=DEV, dtype=torch.float32, requires_grad=True
+            )
+            yb = torch.softmax(xb, dim=dim)
+            yb.backward(torch.randn_like(yb))
+            count += 1
+            del x, y, xb, yb
+        if i % 10 == 0:
+            torch.mps.synchronize()
+            # NO empty_cache here: with tiny tensors the live/pooled tensor bytes
+            # are negligible, so growth in driver memory = per-shape graph cache.
+            samples.append(
+                {
+                    "iter": i,
+                    "distinct_shapes": count,
+                    "driver_mb": torch.mps.driver_allocated_memory() / 1e6,
+                    "current_mb": torch.mps.current_allocated_memory() / 1e6,
+                }
+            )
+    torch.mps.synchronize()
+    end_drv = torch.mps.driver_allocated_memory()
+    end_cur = torch.mps.current_allocated_memory()
+    # After draining the tensor pool, whatever driver memory REMAINS above the
+    # start is retained graph/executable state (empty_cache does not rebuild it).
+    torch.mps.empty_cache()
+    torch.mps.synchronize()
+    after_empty_drv = torch.mps.driver_allocated_memory()
+    print(
+        json.dumps(
+            {
+                "mode": MODE,
+                "distinct_shapes": count,
+                "start_driver_mb": start_drv / 1e6,
+                "end_driver_mb": end_drv / 1e6,
+                "delta_driver_mb": (end_drv - start_drv) / 1e6,
+                "after_empty_cache_driver_mb": after_empty_drv / 1e6,
+                "retained_after_empty_mb": (after_empty_drv - start_drv) / 1e6,
+                "start_current_mb": start_cur / 1e6,
+                "end_current_mb": end_cur / 1e6,
+                "samples": samples,
+            }
+        )
+    )
+
+
+def run_sanity():
+    """Confirm correctness vs CPU in this mode (so 'before' is a valid baseline)."""
+    res = []
+    for shape, dim in [
+        ((1024, 1024), -1),
+        ((1024, 1024), 0),
+        ((8, 2048, 64), 1),
+        ((128, 256), -1),
+    ]:
+        for dtkey, dt in DTYPES.items():
+            x = torch.randn(*shape, dtype=torch.float32)
+            xm = x.to(DEV).to(dt)
+            ym = torch.softmax(xm, dim=dim).float().cpu()
+            yc = torch.softmax(x, dim=dim)
+            atol = 2e-2 if dtkey != "f32" else 1e-4
+            ok = torch.allclose(ym, yc, atol=atol, rtol=1e-2)
+            res.append(
+                {
+                    "shape": str(shape),
+                    "dim": dim,
+                    "dtype": dtkey,
+                    "max_abs_err": (ym - yc).abs().max().item(),
+                    "ok": bool(ok),
+                }
+            )
+    allok = all(r["ok"] for r in res)
+    print(json.dumps({"mode": MODE, "all_ok": allok, "checks": res}))
+
+
+if __name__ == "__main__":
+    forced = os.environ.get("PYTORCH_MPS_FORCE_MPSGRAPH_SOFTMAX")
+    sys.stderr.write(
+        f"MODE={MODE} TASK={TASK} FORCE_ENV={forced!r} torch={torch.__file__}\n"
+    )
+    if TASK == "perf":
+        run_perf()
+    elif TASK == "mem":
+        run_mem()
+    elif TASK == "sanity":
+        run_sanity()

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -5194,6 +5194,39 @@ class TestMPS(TestCaseMPS):
         output = loss(pred, target)
         output.backward()
 
+    def test_softmax_metal_kernel_paths(self):
+        # Exercise the specialized large-shape Metal softmax kernels (looped,
+        # two-pass, and the cooperative dim=0 blocked/coalesced paths) that the
+        # small OpInfo softmax samples never reach, plus the leading-(-inf)
+        # masked-row edge case that triggers the online-softmax NaN guard.
+        configs = [
+            ((4, 8192), -1),    # looped: axis_size > 1024 * N_READS
+            ((2, 65536), -1),   # two-pass: few very long rows
+            ((8192, 128), 0),   # cooperative dim=0 (blocked/blocked2)
+            ((128, 8192), 0),   # dim=0 with large inner size
+            ((16, 4097), -1),   # just past the looped threshold
+        ]
+        for shape, dim in configs:
+            cpu_x = torch.randn(shape, dtype=torch.float32, requires_grad=True)
+            mps_x = cpu_x.detach().to("mps").requires_grad_(True)
+            cpu_y = F.softmax(cpu_x, dim=dim)
+            mps_y = F.softmax(mps_x, dim=dim)
+            self.assertEqual(cpu_y, mps_y.to("cpu"))
+            go = torch.randn_like(cpu_y)
+            cpu_y.backward(go)
+            mps_y.backward(go.to("mps"))
+            self.assertEqual(cpu_x.grad, mps_x.grad.to("cpu"))
+            cpu_h = cpu_x.detach().half()
+            self.assertEqual(F.softmax(cpu_h, dim=dim),
+                             F.softmax(cpu_h.to("mps"), dim=dim).to("cpu"))
+        # Leading-(-inf) masked long row must match CPU, never produce a NaN row.
+        for dtype in (torch.float32, torch.float16):
+            cpu_x = torch.randn(4, 8192, dtype=dtype)
+            cpu_x[0, :128] = float("-inf")
+            mps_y = F.softmax(cpu_x.to("mps"), dim=-1).to("cpu")
+            self.assertFalse(torch.isnan(mps_y).any())
+            self.assertEqual(F.softmax(cpu_x, dim=-1), mps_y)
+
     def test_log_softmax(self):
         values = [[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], [[7.0, 8.0, 9.0], [10.0, 11.0, 12.0]]]
         cpu_x = torch.tensor(values, device='cpu', requires_grad=True)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -15931,13 +15931,6 @@ op_db: list[OpInfo] = [
            assert_autodiffed=False,
            supports_forward_ad=True,
            supports_fwgrad_bwgrad=True,
-           skips=(
-               # AssertionError: Tensor-likes are not close!
-               DecorateInfo(
-                   unittest.expectedFailure, 'TestConsistency', 'test_output_grad_match',
-                   device_type='mps', dtypes=(torch.float32,)
-               ),
-           ),
            supports_out=False),
     OpInfo(
         "nn.functional.cross_entropy",


### PR DESCRIPTION
# [MPS] softmax: non-last-dim and huge-row native Metal kernels (perf specializations)

> **Reviewing just this PR.** This is a stacked leaf (cumulative-leaf fork on `main` — external
> contributors can't ghstack), so the GitHub diff shows the softmax core PR **+** this one. To
> see **only what this PR adds on top of #187456**, use this fork compare (renders as a normal
> diff of just this delta):
> **https://github.com/anagnorisis2peripeteia/pytorch/compare/mps-softmax-pr1...mps-softmax-perf**
>
> This PR's own delta — **2 files, +1485 / -44**: `SoftMaxKernel.metal` (+1093, the 2pass +
> coalesced/tiled/blocked kernels), `SoftMax.mm` (+436 / -44, their dispatch + removing core's
> last-dim-only gate).

## What / why

Follow-up to the softmax **core** PR (#187456), stacked on it (Part of #187455). Core migrated
last-dim softmax to native Metal and routed non-last-dim axes and very-long last-dim rows to
the retained MPSGraph fallback. This PR adds the shape-specialized kernels for those cases and
removes core's "last-dim only" gate, so `canUseMetalSoftmax` now takes all supported shapes
natively (the escape hatch and the overflow/ChannelsLast fallbacks stay):

- huge-row two-pass (`forward_2pass_reduce`/`write`, `backward_2pass_dot`/`grad`) for
  low-occupancy long last-dim rows where the single-row/looped kernels underutilize the GPU;
- non-last-dim kernels: a generic coalesced path plus tiled/blocked cooperative axis reductions
  for the short-axis + large-inner regime (e.g. `dim=0` on `[8,2048,4096]`, axis=8).

## Performance

Benchmark: `benchmarks/mps/bench_softmax.py` + `bench_run.sh` (committed). Same-build A/B
(forced-MPSGraph vs native), 3 reps, median, amortized. M4 Pro, parent 815cc61481a. Full sweep
(78 cells): **68 win, 10 at/below 0.95x**.

| cell | MPSGraph | Metal | speedup |
|---|---|---|---|
| 8x2048x4096 dim0 (non-last, tiled) | 6,012 us | 1,032 us | 5.83x |
| 4x65536 f16 dim-1 fwd (huge-row 2pass) | 402 us | 150 us | 2.68x |
| 128x65536 bf16 dim-1 fwd+bwd | 508 us | 456 us | 1.11x |
| 1024x1024 f16 last-dim fwd+bwd | 63.4 us | 54.9 us | 1.16x |
| 512x768 f32 last-dim fwd | 16.9 us | 20.5 us | 0.83x |
| 4x65536 f32 dim0 backward | 1,204 us | 5,940 us | 0.20x |

The residual tail is small f32 last-dim forward (+2-4 us) and **dim=0 backward** on huge low-
occupancy shapes, where MPSGraph's fused dual-input reduce still wins (~1/5 peak across ~13
kernel variants tried). That case is documented and covered by the
`PYTORCH_MPS_FORCE_MPSGRAPH_SOFTMAX` escape hatch; it is a scoped follow-up, not a blocker for
the shapes this PR wins.

## Correctness / Test Plan

- `PYTORCH_TEST_MPS=1 python -m pytest test/test_mps.py -k "softmax_metal or test_softmax" -q`
  now exercises the native non-last-dim and two-pass paths (they no longer fall back).
- Full `--mps` suite -- clean modulo the unrelated `test_metal.py::...test_conv`.

## BC-breaking?

No public API change. f16/bf16 softmax accumulates in fp32.

## Review history

Local review + gate dispositions (autoreview + local_clawsweeper): https://gist.github.com/9d1528bdd58623d9d5653024ae2a4024



---

## Update: masked-row NaN safety (review response)

Two related bugs fixed in the online-softmax kernels:

1. **All-(-inf) simdgroup poisoning**: the cross-lane combine rescale computed `0 * exp(-inf - -inf) = NaN` when an entire simdgroup saw only masked (-inf) values, poisoning finite rows (classic left-padded attention masks; on the two-pass path a fully masked chunk poisoned the row through the partials). Rescales now skip when the local max is -inf — exact, since the corresponding sum is 0.
2. **NaN suppression**: the online guards dropped NaN inputs from the normalization sum (`fmax` discards NaN), losing CPU's row-wide NaN poisoning; small and large dispatch paths disagreed. A per-thread flag now poisons the sum after the scan (order-independent; an in-loop poison could be wiped by a later all--inf chunk), and combine arms add partial sums instead of zeroing so NaN survives.

Cost was isolated pre-vs-post on the identical tree: 0 regressions across 78 cells (worst 0.982x, noise). New tests cover a left-padded (-inf x 4224/8192) row spanning a full simdgroup, a NaN inside a masked prefix on the 65536-wide two-pass path, and a NaN-propagation sweep across every forward dispatch path for softmax and log_softmax.

Review log: https://gist.github.com/anagnorisis2peripeteia/1c135badc1036654ebd0ec53c7e558a4

This PR's commit carries the fixes for the perf kernels it introduces (two-pass, tiled, blocked, blocked2, coalesced); two hunks were adapted to this branch's pre-log_softmax context.
