### PR TITLE
Fix unload utility for newer Triton pyds

### DIFF
--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1397,7 +1397,9 @@ def unload_xpu_triton_pyds() -> None:
                             result,
                             torch._inductor.runtime.triton_heuristics.TritonCompileResult,
                         ):
+                            # pyrefly: ignore [missing-attribute]
                             if hasattr(result.kernel.run, "mod"):
+                                # pyrefly: ignore [missing-attribute]
                                 result.kernel.run.mod.__del__()
         del sys.modules[module_name]
 

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1398,9 +1398,9 @@ def unload_xpu_triton_pyds() -> None:
                             torch._inductor.runtime.triton_heuristics.TritonCompileResult,
                         ):
                             # pyrefly: ignore [missing-attribute]
-                            if hasattr(result.kernel.run, "mod"):
-                                # pyrefly: ignore [missing-attribute]
-                                result.kernel.run.mod.__del__()
+                            run = result.kernel.run
+                            if hasattr(run, "mod"):
+                                run.mod.__del__()
         del sys.modules[module_name]
 
     # unload spirv_utils.pyd

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1397,17 +1397,15 @@ def unload_xpu_triton_pyds() -> None:
                             result,
                             torch._inductor.runtime.triton_heuristics.TritonCompileResult,
                         ):
-                            mod = getattr(result.kernel.run, "mod", None)
-                            if mod is not None:
-                                mod.__del__()
+                            if hasattr(result.kernel.run, "mod"):
+                                result.kernel.run.mod.__del__()
         del sys.modules[module_name]
 
     # unload spirv_utils.pyd
     if "triton.runtime.driver" in sys.modules:
         driver_mod = sys.modules["triton.runtime.driver"]
-        utils_obj = getattr(driver_mod.driver.active, "utils", None)
-        if utils_obj is not None:
-            utils_cls = type(utils_obj)
+        if hasattr(driver_mod.driver.active, "utils"):
+            utils_cls = type(driver_mod.driver.active.utils)
             if hasattr(utils_cls, "instance"):
                 del utils_cls.instance
             elif hasattr(utils_cls, "_instance"):

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1397,15 +1397,22 @@ def unload_xpu_triton_pyds() -> None:
                             result,
                             torch._inductor.runtime.triton_heuristics.TritonCompileResult,
                         ):
-                            # pyrefly: ignore [missing-attribute]
-                            result.kernel.run.mod.__del__()
+                            mod = getattr(result.kernel.run, "mod", None)
+                            if mod is not None:
+                                mod.__del__()
         del sys.modules[module_name]
 
     # unload spirv_utils.pyd
     if "triton.runtime.driver" in sys.modules:
-        mod = sys.modules["triton.runtime.driver"]
-        del type(mod.driver.active.utils).instance
-        del mod.driver.active.utils
+        driver_mod = sys.modules["triton.runtime.driver"]
+        utils_obj = getattr(driver_mod.driver.active, "utils", None)
+        if utils_obj is not None:
+            utils_cls = type(utils_obj)
+            if hasattr(utils_cls, "instance"):
+                del utils_cls.instance
+            elif hasattr(utils_cls, "_instance"):
+                utils_cls._instance = None
+            del driver_mod.driver.active.utils
 
     gc.collect()
 


### PR DESCRIPTION
unload_xpu_triton_pyds() hardcodes two intel-xpu-backend-for-triton internals that no longer exist in current backends:
 - XPULauncher.mod was removed when the per-kernel launcher was replaced with a shared driver-level launcher (intel/intel-xpu-backend-for-triton#6650)
 -  XPUUtils's singleton attribute was renamed instance -> _instance (intel/intel-xpu-backend-for-triton#6767)

Both raise AttributeError during fresh_cache() teardown on Windows+XPU, failing every affected test. Guard both accesses defensively instead of assuming either shape.

Note: cleans up all kernel/test-scoped cache artifacts, but a couple of small shared native .pyd files may still linger in the temp dir, since newer backends keep them alive via references outside this function's reach (pre-existing ignore_errors=is_windows() here already tolerates partial cleanup).

Fixes: https://github.com/intel/torch-xpu-ops/issues/4038
Fixes: https://github.com/intel/torch-xpu-ops/issues/4037

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo