### PR TITLE
Fix OOB read in batch_norm_backward_reduce with inconsistent inputs

### DIFF
--- a/aten/src/ATen/native/cuda/Normalization.cu
+++ b/aten/src/ATen/native/cuda/Normalization.cu
@@ -735,6 +735,17 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> batch_norm_backward_reduce_cuda(const
   c10::MaybeOwned<Tensor> weight_maybe_owned = at::borrow_from_optional_tensor(weight_opt);
   const Tensor& weight = *weight_maybe_owned;
 
+  TORCH_CHECK(input.dim() >= 2,
+      "batch_norm_backward_reduce: expected input to have at least 2 dimensions, but got input of sizes ",
+      input.sizes());
+  const auto n_channels = input.size(1);
+  TORCH_CHECK(grad_output.numel() == input.numel(),
+      "batch_norm_backward_reduce: expected grad_output to have the same number of elements as input (",
+      input.numel(), "), but got ", grad_output.numel());
+  TORCH_CHECK(mean.numel() == n_channels && invstd.numel() == n_channels,
+      "batch_norm_backward_reduce: expected mean and invstd to each have one element per channel (",
+      n_channels, "), but got ", mean.numel(), " and ", invstd.numel(), " elements");
+
   if (at::cuda::detail::canUse32BitIndexMath(grad_output) &&
       batch_norm_use_channels_last_kernels(grad_output) &&
       batch_norm_use_channels_last_kernels(input) &&

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7365,6 +7365,25 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         _batch_norm_stats(torch.randn(1, 96, 112, 112, dtype=torch.float, device='cuda'), torch.channels_last, (0, 2, 3))
         _batch_norm_stats(torch.randn(1, 96, 112, 112, 112, dtype=torch.float, device='cuda'), torch.channels_last_3d, (0, 2, 3, 4))
 
+    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
+    def test_batch_norm_backward_reduce_invalid_shapes_cuda(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/188958.
+        # A non-empty input paired with an inconsistent (empty) grad_out/invstd used
+        # to launch the channels-last reduce kernel with mismatched buffers, causing
+        # an out-of-bounds read. The op must validate shapes instead.
+        input = torch.full((2, 2), float('nan'), dtype=torch.float64, device='cuda')
+        mean = torch.zeros(2, dtype=torch.float64, device='cuda')
+        # grad_out has the wrong number of elements (0 vs input's 4)
+        grad_out = torch.ones(0, 128, dtype=torch.float64, device='cuda')
+        invstd = torch.ones(0, 16, 16, 3, dtype=torch.float64, device='cuda')
+        with self.assertRaisesRegex(RuntimeError, "batch_norm_backward_reduce"):
+            torch.batch_norm_backward_reduce(grad_out, input, mean, invstd, None, False, False, False)
+        # invstd has the wrong number of channels (grad_out now consistent with input)
+        grad_out = torch.ones(2, 2, dtype=torch.float64, device='cuda')
+        bad_invstd = torch.ones(0, dtype=torch.float64, device='cuda')
+        with self.assertRaisesRegex(RuntimeError, "mean and invstd"):
+            torch.batch_norm_backward_reduce(grad_out, input, mean, bad_invstd, None, False, False, False)
+
     def test_flatten(self):
         tensor_input = torch.randn(2, 1, 2, 3)
 


### PR DESCRIPTION
`batch_norm_backward_reduce_cuda` derives the channels-last reduce kernel's loop bounds (`reduction_size`, `stride`) from `input`, but the kernel reads from `grad_output`, `mean`, and `invstd`. When a non-empty input is paired with an empty or otherwise inconsistent `grad_output`/`invstd` (e.g. fuzzer-generated), those tensors have null/short storage, so the kernel reads out of bounds -- an illegal memory access reported by `compute-sanitizer`.

The non-channels-last path is implicitly protected because it reshapes `grad_output` to the input shape (which throws on a numel mismatch), but it does not validate `mean`/`invstd`, and the channels-last path validates nothing. This adds explicit validation at the common entry point so both paths reject inconsistent inputs with a clear error instead of launching a kernel with mismatched buffers:
- `grad_output` must have the same number of elements as `input`
- `mean` and `invstd` must have one element per channel

Fixes #188958

## Verification (compute-sanitizer, A40 / sm_86)

Repro:
```python
import torch
grad_out = torch.full((0, 128), 1.0, dtype=torch.float64, device='cuda')
input    = torch.full((2, 2),   float('nan'), dtype=torch.float64, device='cuda')
mean     = torch.full((2,),     0.0, dtype=torch.float64, device='cuda')
invstd   = torch.full((0, 16, 16, 3), 1.0, dtype=torch.float64, device='cuda')
torch.batch_norm_backward_reduce(grad_out, input, mean, invstd, None, False, False, False)
torch.cuda.synchronize()
```

**Before:**
```
Invalid __global__ read of size 8 bytes
    at ... batch_norm_backward_reduce_channels_last_kernel<(int)4, double, double, double>
    Address 0x0 is out of bounds
```
**After:** raises `RuntimeError: batch_norm_backward_reduce: expected grad_output to have the same number of elements as input (4), but got 0`, and `compute-sanitizer` reports `ERROR SUMMARY: 0 errors`.

## Test
```
python test/test_nn.py -v TestNN.test_batch_norm_backward_reduce_invalid_shapes_cuda   # new regression test
python test/test_nn.py -v TestNN.test_sync_batchnorm_accuracy_cuda                      # valid usage unaffected
```
