### PR TITLE
Bundle unversioned libnuma for ROCm wheels

### DIFF
--- a/.ci/manywheel/repair_wheel.py
+++ b/.ci/manywheel/repair_wheel.py
@@ -171,6 +171,16 @@ def rocm_os_deps() -> list[Path]:
     ]
 
 
+def rocm_os_dep_aliases(os_lib: Path) -> list[str]:
+    """Additional filenames needed for OS deps bundled into ROCm wheels."""
+    if os_lib.name.startswith("libnuma.so."):
+        # rocSHMEM calls dlopen("libnuma.so") at import time. The wheel bundles
+        # libnuma.so.1, but wheel installers do not preserve symlinks portably,
+        # so ship a second real file with the unversioned loader name.
+        return ["libnuma.so"]
+    return []
+
+
 def find_rocm_lib(rocm_home: Path, basename: str) -> Path | None:
     """Locate a ROCm library, falling back from lib/ to lib64/ to a wider search."""
     for sub in ("lib", "lib64"):
@@ -225,6 +235,8 @@ def rocm_bundle(rocm_home: Path) -> tuple[list[BundledLib], list[AuxFile]]:
     for os_lib in rocm_os_deps():
         if os_lib.is_file():
             libs.append(BundledLib(src=os_lib, dest_name=os_lib.name))
+            for alias in rocm_os_dep_aliases(os_lib):
+                libs.append(BundledLib(src=os_lib, dest_name=alias))
 
     archs = rocm_arch_filter(os.environ.get("PYTORCH_ROCM_ARCH", ""))
     aux: list[AuxFile] = []


### PR DESCRIPTION
Fixes #189110

Summary:
- bundle an additional `torch/lib/libnuma.so` copy for ROCm wheels when `libnuma.so.1` is present
- keep the existing `libnuma.so.1` bundle unchanged
- avoid relying on wheel installers to preserve symlinks

Root cause:
`libtorch_rocshmem.so` can call `dlopen("libnuma.so")` during `import torch`. The ROCm wheel currently bundles `libnuma.so.1`, but not the unversioned loader name, so rocSHMEM can fail early on hosts without the system development symlink installed. This contributes to the `import torch` hang tracked in #189110.

Fix:
Add a small alias hook for ROCm OS runtime dependencies. For versioned `libnuma.so.*`, the repair step now copies the same source file into the wheel twice:

- `torch/lib/libnuma.so.1`
- `torch/lib/libnuma.so`

Using a real file rather than a symlink keeps this portable across wheel pack/install implementations.

Test plan:
- `python3 -m py_compile .ci/manywheel/repair_wheel.py`
- local unit-style check with mocked `ROCM_SO_FILES` and `rocm_os_deps()` verifying that `rocm_bundle()` emits both `libnuma.so.1` and `libnuma.so` from the same source


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang