### PR TITLE
[CRCR] promote crcr-test to L3

### DIFF
--- a/.github/allowlist.yml
+++ b/.github/allowlist.yml
@@ -30,10 +30,11 @@
 #   - org2/downstream-repo2
 #
 # L3:
-#   - org3/downstream-repo3: @oncall1,oncall2
+#   <LABEL_NAME>:
+#     org3/downstream-repo3: [@oncall1,@oncall2]
 #
 # L4:
-#   - org4/downstream-repo4: @oncall1,oncall2
+#   - org4/downstream-repo4: [@oncall1,@oncall2]
 
 L1:
   - riseproject-dev/pytorch-ci
@@ -42,7 +43,10 @@ L1:
 
 L2:
   # Canonical test repo for CRCR.
-  - pytorch/crcr-test
   - TorchedHat/pytorch-redhat-ci
   - Ascend/pytorch
   - torch-spyre/torch-spyre
+
+L3:
+  crcr-test:
+    pytorch/crcr-test: [atalman, can-gaa-hou, fffrog, jewelkm89, KarhouTam, subinz1]


### PR DESCRIPTION
Promote pytorch/crcr-test to L3 for testing. Along with creating a label named `ciflow/crcr/crcr-test`