### PR TITLE
Skip GHA stats artifacts from other workflow attempts

### DIFF
--- a/tools/stats/upload_stats_lib.py
+++ b/tools/stats/upload_stats_lib.py
@@ -64,7 +64,7 @@ def _get_artifact_urls(prefix: str, workflow_run_id: int) -> dict[Path, str]:
 
 def _download_artifact(
     artifact_name: Path, artifact_url: str, workflow_run_attempt: int
-) -> Path:
+) -> Path | None:
     # [Artifact run attempt]
     # All artifacts on a workflow share a single namespace. However, we can
     # re-run a workflow and produce a new set of artifacts. To avoid name
@@ -81,6 +81,7 @@ def _download_artifact(
                     f"Skipping {artifact_name} as it is an invalid run attempt. "
                     f"Expected {workflow_run_attempt}, found {found_run_attempt}."
                 )
+                return None
 
     print(f"Downloading {artifact_name}")
 
@@ -128,7 +129,9 @@ def download_gha_artifacts(
     artifact_urls = _get_artifact_urls(prefix, workflow_run_id)
     paths = []
     for name, url in artifact_urls.items():
-        paths.append(_download_artifact(Path(name), url, workflow_run_attempt))
+        path = _download_artifact(Path(name), url, workflow_run_attempt)
+        if path is not None:
+            paths.append(path)
     return paths
 
 

--- a/tools/test/test_upload_stats_lib.py
+++ b/tools/test/test_upload_stats_lib.py
@@ -14,7 +14,11 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))
 
 from tools.stats.upload_metrics import add_global_metric, emit_metric, global_metrics
-from tools.stats.upload_stats_lib import get_s3_resource, remove_nan_inf
+from tools.stats.upload_stats_lib import (
+    download_gha_artifacts,
+    get_s3_resource,
+    remove_nan_inf,
+)
 
 
 sys.path.remove(str(REPO_ROOT))
@@ -277,6 +281,73 @@ class TestUploadStats(unittest.TestCase):
                 unclean,
                 f"Expected {unclean} when input is {unclean}, got {unclean_output}",
             )
+
+
+class TestDownloadGhaArtifacts(unittest.TestCase):
+    def test_download_gha_artifacts_skips_invalid_run_attempt(self) -> None:
+        artifact_name = Path("test-reports-runattempt1-test-job.zip")
+
+        with (
+            mock.patch(
+                "tools.stats.upload_stats_lib._get_artifact_urls",
+                return_value={artifact_name: "https://example.com/artifact"},
+            ),
+            mock.patch("tools.stats.upload_stats_lib.requests.get") as mock_get,
+        ):
+            paths = download_gha_artifacts("test-reports", 12345, 2)
+
+        self.assertEqual(paths, [])
+        mock_get.assert_not_called()
+
+    def test_download_gha_artifacts_downloads_matching_run_attempt(self) -> None:
+        artifact_name = Path("test-reports-runattempt2-test-job.zip")
+        response = mock.Mock(content=b"zip-bytes")
+        mock_file = mock.mock_open()
+
+        with (
+            mock.patch(
+                "tools.stats.upload_stats_lib._get_artifact_urls",
+                return_value={artifact_name: "https://example.com/artifact"},
+            ),
+            mock.patch(
+                "tools.stats.upload_stats_lib._get_request_headers", return_value={}
+            ),
+            mock.patch(
+                "tools.stats.upload_stats_lib.requests.get", return_value=response
+            ) as mock_get,
+            mock.patch("builtins.open", mock_file),
+        ):
+            paths = download_gha_artifacts("test-reports", 12345, 2)
+
+        self.assertEqual(paths, [artifact_name])
+        mock_get.assert_called_once_with("https://example.com/artifact", headers={})
+        mock_file.assert_called_once_with(artifact_name, "wb")
+        mock_file().write.assert_called_once_with(b"zip-bytes")
+
+    def test_download_gha_artifacts_downloads_without_run_attempt_marker(self) -> None:
+        artifact_name = Path("test-reports-test-job.zip")
+        response = mock.Mock(content=b"zip-bytes")
+        mock_file = mock.mock_open()
+
+        with (
+            mock.patch(
+                "tools.stats.upload_stats_lib._get_artifact_urls",
+                return_value={artifact_name: "https://example.com/artifact"},
+            ),
+            mock.patch(
+                "tools.stats.upload_stats_lib._get_request_headers", return_value={}
+            ),
+            mock.patch(
+                "tools.stats.upload_stats_lib.requests.get", return_value=response
+            ) as mock_get,
+            mock.patch("builtins.open", mock_file),
+        ):
+            paths = download_gha_artifacts("test-reports", 12345, 2)
+
+        self.assertEqual(paths, [artifact_name])
+        mock_get.assert_called_once_with("https://example.com/artifact", headers={})
+        mock_file.assert_called_once_with(artifact_name, "wb")
+        mock_file().write.assert_called_once_with(b"zip-bytes")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Fixing an Issue

## Issue

Fixes #189157

## Summary

### What Problem This Solves

`_download_artifact()` already detected when an artifact name's `runattemptN` did not match the requested `workflow_run_attempt`, but it only printed `Skipping ...` and then kept going. That meant a previous-attempt GitHub fallback artifact could still be downloaded, returned by `download_gha_artifacts()`, and later mirrored into the current attempt's S3 prefix after `upload_artifacts.py` strips `-runattemptN` from the filename.

### Changes

The production change is intentionally small: make the existing skip branch actually stop, then only keep paths that were downloaded.

```diff
 if found_run_attempt != workflow_run_attempt:
     print(...)
+    return None

-paths.append(_download_artifact(Path(name), url, workflow_run_attempt))
+path = _download_artifact(Path(name), url, workflow_run_attempt)
+if path is not None:
+    paths.append(path)
```

Matching `runattemptN` artifacts still download normally, and legacy artifact names without a `runattemptN` marker keep their existing behavior.

### Evidence

The focused tests cover the three relevant cases:

```text
runattempt1 + requested attempt 2 -> skipped, no requests.get(), returns []
runattempt2 + requested attempt 2 -> downloaded and returned
no runattempt marker + requested attempt 2 -> downloaded and returned
```

Local validation run:

- `python -m unittest tools.test.test_upload_stats_lib.TestDownloadGhaArtifacts`
- `python tools/test/test_upload_stats_lib.py`
- `python -m py_compile tools/stats/upload_stats_lib.py tools/stats/upload_artifacts.py tools/test/test_upload_stats_lib.py`
- `git diff --check -- tools/stats/upload_stats_lib.py tools/test/test_upload_stats_lib.py`
- WSL Ubuntu-22.04 / Miniforge env `prw-pytorch-pr-py310`: `python -m spin fixlint -- tools/stats/upload_stats_lib.py tools/test/test_upload_stats_lib.py`

### Possible call chain / impact

```text
tools.stats.upload_artifacts
  -> get_artifacts(... workflow_run_attempt ...)
    -> download_gha_artifacts(...)
      -> _download_artifact(...)
```

This only affects the GitHub-hosted fallback artifact path. Primary S3 artifact upload/download behavior, artifact naming, and downstream stats parsing are unchanged.

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No