### PR TITLE
Use SafePyObject in PyAnomalyMetadata and PySavedVariableHooks

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -11805,38 +11805,20 @@ for shape in [(1,), ()]:
             with self.assertRaisesRegex(CustomError, "unpack"):
                 out.backward()
 
-    def test_saved_tensor_hooks_pack_error_then_unpack(self):
-        # mark_dirty attaches grad_fn before packing runs, so a raising pack
-        # hook leaves a live tensor whose SavedVariable never finished.
-        class CustomError(Exception):
-            pass
+    def test_saved_tensor_hooks_pack_error_then_data_access(self):
+        # register_hooks sets hooks_ before running pack_hook, so a raising
+        # pack_hook leaves the SavedVariable with hooks but no packed data.
+        a = torch.randn(5, requires_grad=True)
+        y = a * a
 
-        class error_on_pack_hook(torch.autograd.graph.saved_tensors_hooks):
-            def __init__(self) -> None:
-                def pack_hook(x):
-                    raise CustomError("pack")
+        def bad_pack(t):
+            raise ValueError("boom")
 
-                super().__init__(pack_hook, lambda x: x)
+        with self.assertRaisesRegex(ValueError, "boom"):
+            y.grad_fn._raw_saved_self.register_hooks(bad_pack, lambda x: x)
 
-        class MarkDirtyFunc(torch.autograd.Function):
-            @staticmethod
-            def forward(ctx, x):
-                ctx.save_for_backward(x)
-                ctx.mark_dirty(x)
-                return x
-
-            @staticmethod
-            def backward(ctx, grad):
-                ctx.saved_tensors
-                return grad
-
-        a = torch.ones(2, requires_grad=True).clone()
-        with error_on_pack_hook():
-            with self.assertRaisesRegex(CustomError, "pack"):
-                MarkDirtyFunc.apply(a)
-
-        with self.assertRaisesRegex(RuntimeError, "call_pack_hook was not called"):
-            a.sum().backward()
+        with self.assertRaisesRegex(RuntimeError, "pack hook raised"):
+            y.grad_fn._raw_saved_self.data
 
     def test_saved_tensor_hooks_custom_function_intermediates(self):
         class Func(torch.autograd.Function):

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -11805,6 +11805,39 @@ for shape in [(1,), ()]:
             with self.assertRaisesRegex(CustomError, "unpack"):
                 out.backward()
 
+    def test_saved_tensor_hooks_pack_error_then_unpack(self):
+        # mark_dirty attaches grad_fn before packing runs, so a raising pack
+        # hook leaves a live tensor whose SavedVariable never finished.
+        class CustomError(Exception):
+            pass
+
+        class error_on_pack_hook(torch.autograd.graph.saved_tensors_hooks):
+            def __init__(self) -> None:
+                def pack_hook(x):
+                    raise CustomError("pack")
+
+                super().__init__(pack_hook, lambda x: x)
+
+        class MarkDirtyFunc(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x):
+                ctx.save_for_backward(x)
+                ctx.mark_dirty(x)
+                return x
+
+            @staticmethod
+            def backward(ctx, grad):
+                ctx.saved_tensors
+                return grad
+
+        a = torch.ones(2, requires_grad=True).clone()
+        with error_on_pack_hook():
+            with self.assertRaisesRegex(CustomError, "pack"):
+                MarkDirtyFunc.apply(a)
+
+        with self.assertRaisesRegex(RuntimeError, "call_pack_hook was not called"):
+            a.sum().backward()
+
     def test_saved_tensor_hooks_custom_function_intermediates(self):
         class Func(torch.autograd.Function):
             @staticmethod

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -412,7 +412,7 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
       .def("save", &ProfilerResult::save)
       .def(
           "trace_activities",
-          [](py::object self) {
+          [](const py::object& self) {
             auto& r = self.cast<ProfilerResult&>();
             auto* activities = r.traceActivities();
             if (!activities) {
@@ -633,7 +633,7 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
 
   _C_m.def(
       "_register_py_class_for_device",
-      [](const std::string& device, py::object python_type_class) {
+      [](const std::string& device, const py::object& python_type_class) {
         auto cls = python_type_class.ptr();
         registerPythonTensorClass(device, cls);
       });
@@ -707,7 +707,7 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
             // of the hook functions for us
             s.register_hooks(
                 std::make_unique<torch::autograd::PySavedVariableHooks>(
-                    pack_hook, unpack_hook));
+                    std::move(pack_hook), std::move(unpack_hook)));
           })
       .def_property_readonly(
           "data",

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -730,8 +730,7 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
           "data",
           [](const torch::autograd::SavedVariable& s) -> py::object {
             if (s.has_hooks()) {
-              // has_hooks() guarantees retrieve_unpack_hook_data() returns a
-              // value (or throws) rather than std::nullopt.
+              // has_hooks() guarantees a value here (or a throw).
               auto opt = s.retrieve_unpack_hook_data();
               py::gil_scoped_acquire gil;
               const auto& [_unpack_fn, data_obj] = *opt;

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -414,7 +414,7 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
       .def("save", &ProfilerResult::save)
       .def(
           "trace_activities",
-          [](py::object self) {
+          [](const py::object& self) {
             auto& r = self.cast<ProfilerResult&>();
             auto* activities = r.traceActivities();
             if (!activities) {
@@ -650,7 +650,7 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
 
   _C_m.def(
       "_register_py_class_for_device",
-      [](const std::string& device, py::object python_type_class) {
+      [](const std::string& device, const py::object& python_type_class) {
         auto cls = python_type_class.ptr();
         registerPythonTensorClass(device, cls);
       });
@@ -724,7 +724,7 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
             // of the hook functions for us
             s.register_hooks(
                 std::make_unique<torch::autograd::PySavedVariableHooks>(
-                    pack_hook, unpack_hook));
+                    std::move(pack_hook), std::move(unpack_hook)));
           })
       .def_property_readonly(
           "data",

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -414,7 +414,7 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
       .def("save", &ProfilerResult::save)
       .def(
           "trace_activities",
-          [](const py::object& self) {
+          [](py::object self) {
             auto& r = self.cast<ProfilerResult&>();
             auto* activities = r.traceActivities();
             if (!activities) {
@@ -650,7 +650,7 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
 
   _C_m.def(
       "_register_py_class_for_device",
-      [](const std::string& device, const py::object& python_type_class) {
+      [](const std::string& device, py::object python_type_class) {
         auto cls = python_type_class.ptr();
         registerPythonTensorClass(device, cls);
       });
@@ -730,13 +730,13 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
           "data",
           [](const torch::autograd::SavedVariable& s) -> py::object {
             if (s.has_hooks()) {
+              // has_hooks() guarantees retrieve_unpack_hook_data() returns a
+              // value (or throws) rather than std::nullopt.
               auto opt = s.retrieve_unpack_hook_data();
-              TORCH_INTERNAL_ASSERT(opt.has_value());
               py::gil_scoped_acquire gil;
               const auto& [_unpack_fn, data_obj] = *opt;
-              PyObject* raw = data_obj.ptr(getPyInterpreter());
-              TORCH_INTERNAL_ASSERT(raw != nullptr);
-              return py::reinterpret_borrow<py::object>(raw);
+              return py::reinterpret_borrow<py::object>(
+                  data_obj.ptr(getPyInterpreter()));
             } else {
               return py::cast(s.get_raw_data().value());
             }
@@ -744,14 +744,13 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
       .def_property_readonly(
           "unpack_hook",
           [](const torch::autograd::SavedVariable& s) -> py::object {
-            auto opt = s.retrieve_unpack_hook_data();
+            auto opt = s.retrieve_unpack_hook();
             if (!opt.has_value()) {
               return py::none();
             }
             py::gil_scoped_acquire gil;
-            const auto& [unpack_safe, _unused_data] = *opt;
-            auto* unpack_ptr = unpack_safe.ptr(getPyInterpreter());
-            return py::reinterpret_borrow<py::function>(unpack_ptr);
+            return py::reinterpret_borrow<py::function>(
+                opt->ptr(getPyInterpreter()));
           });
 
   m.def(

--- a/torch/csrc/autograd/python_anomaly_mode.h
+++ b/torch/csrc/autograd/python_anomaly_mode.h
@@ -1,8 +1,11 @@
 #pragma once
 
-#include <pybind11/pybind11.h>
-#include <torch/csrc/autograd/anomaly_mode.h>
 #include <torch/csrc/python_headers.h>
+
+#include <c10/core/SafePyObject.h>
+#include <pybind11/pybind11.h>
+#include <torch/csrc/PyInterpreter.h>
+#include <torch/csrc/autograd/anomaly_mode.h>
 #include <torch/csrc/utils/pybind.h>
 
 namespace torch::autograd {
@@ -11,29 +14,27 @@ struct PyAnomalyMetadata : public AnomalyMetadata {
   static constexpr const char* ANOMALY_TRACE_KEY = "traceback_";
   static constexpr const char* ANOMALY_PARENT_KEY = "parent_";
 
-  PyAnomalyMetadata() {
-    pybind11::gil_scoped_acquire gil;
-    // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
-    dict_ = PyDict_New();
-  }
-  // NOLINTNEXTLINE(bugprone-exception-escape)
-  ~PyAnomalyMetadata() override {
-    // If python is already dead, leak the wrapped python objects
-    if (Py_IsInitialized()) {
-      pybind11::gil_scoped_acquire gil;
-      Py_DECREF(dict_);
-    }
-  }
+  // dict_ is a SafePyObject so destruction routes through
+  // PyInterpreter::decref instead of a hand-written destructor here.
+  PyAnomalyMetadata()
+      : dict_(
+            [] {
+              pybind11::gil_scoped_acquire gil;
+              return PyDict_New();
+            }(),
+            getPyInterpreter()) {}
+  ~PyAnomalyMetadata() override = default;
+
   void store_stack() override;
   void print_stack(const std::string& current_node_name) override;
   void assign_parent(const c10::intrusive_ptr<Node>& parent_node) override;
 
   PyObject* dict() {
-    return dict_;
+    return dict_.ptr(getPyInterpreter());
   }
 
  private:
-  PyObject* dict_{nullptr};
+  c10::SafePyObject dict_;
 };
 void _print_stack(
     PyObject* trace_stack,

--- a/torch/csrc/autograd/python_anomaly_mode.h
+++ b/torch/csrc/autograd/python_anomaly_mode.h
@@ -14,8 +14,7 @@ struct PyAnomalyMetadata : public AnomalyMetadata {
   static constexpr const char* ANOMALY_TRACE_KEY = "traceback_";
   static constexpr const char* ANOMALY_PARENT_KEY = "parent_";
 
-  // dict_ is a SafePyObject so destruction routes through
-  // PyInterpreter::decref instead of a hand-written destructor here.
+  // dict_ is a SafePyObject, so no hand-written destructor is needed.
   PyAnomalyMetadata()
       : dict_(
             [] {

--- a/torch/csrc/autograd/python_saved_variable_hooks.cpp
+++ b/torch/csrc/autograd/python_saved_variable_hooks.cpp
@@ -9,31 +9,35 @@ namespace py = pybind11;
 
 namespace torch::autograd {
 PySavedVariableHooks::PySavedVariableHooks(
-    py::function& pack_hook,
-    py::function& unpack_hook)
-    : // steals the reference (we will decref ourselves)
-      pack_hook_(pack_hook.release().ptr()),
-      unpack_hook_(unpack_hook.release().ptr()) {}
+    // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
+    py::function&& pack_hook,
+    // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
+    py::function&& unpack_hook)
+    : // steals the reference
+      pack_hook_(std::move(pack_hook).release().ptr(), getPyInterpreter()),
+      unpack_hook_(std::move(unpack_hook).release().ptr(), getPyInterpreter()) {
+}
 
 // We don't use pybind for call_pack_hook and call_unpack_hook to avoid
 // https://github.com/pytorch/pytorch/issues/34172
 void PySavedVariableHooks::call_pack_hook(const at::Tensor& tensor) {
   py::gil_scoped_acquire acquire;
   THPObjectPtr obj(THPVariable_Wrap(tensor));
-  THPObjectPtr packed(
-      PyObject_CallFunctionObjArgs(pack_hook_, obj.get(), nullptr));
+  THPObjectPtr packed(PyObject_CallFunctionObjArgs(
+      pack_hook_.ptr(getPyInterpreter()), obj.get(), nullptr));
   if (!packed) {
     throw python_error();
   }
-  data_ = packed.release();
-  // obj is decrefed on exit, packed has their references stolen
-  // pack_hook_ and data_ will be manually decrefed when the saved variable is
-  // released
+  data_.emplace(packed.release(), getPyInterpreter());
+  // obj is decrefed on exit, packed's reference is stolen by data_
 }
 
 at::Tensor PySavedVariableHooks::call_unpack_hook() {
   py::gil_scoped_acquire acquire;
-  THPObjectPtr res(PyObject_CallFunctionObjArgs(unpack_hook_, data_, nullptr));
+  THPObjectPtr res(PyObject_CallFunctionObjArgs(
+      unpack_hook_.ptr(getPyInterpreter()),
+      data().ptr(getPyInterpreter()),
+      nullptr));
   if (!res) {
     throw python_error();
   }
@@ -43,27 +47,11 @@ at::Tensor PySavedVariableHooks::call_unpack_hook() {
       THPUtils_typename(res));
   return THPVariable_Unpack(res);
   // res is decrefed on exit
-  // unpack_hook_ will be manually decrefed when the saved variable is released
 }
 
 std::optional<std::pair<c10::SafePyObject, c10::SafePyObject>>
 PySavedVariableHooks::retrieve_unpack_hook_data() const {
-  Py_INCREF(unpack_hook_);
-  Py_INCREF(data_);
-  return std::make_pair(
-      c10::SafePyObject(unpack_hook_, getPyInterpreter()),
-      c10::SafePyObject(data_, getPyInterpreter()));
-}
-
-// NOLINTNEXTLINE(bugprone-exception-escape)
-PySavedVariableHooks::~PySavedVariableHooks() {
-  // If python is already dead, leak the wrapped python objects
-  if (Py_IsInitialized()) {
-    py::gil_scoped_acquire gil;
-    Py_XDECREF(pack_hook_);
-    Py_XDECREF(unpack_hook_);
-    Py_XDECREF(data_);
-  }
+  return std::make_pair(unpack_hook_, data());
 }
 
 void PyDefaultSavedVariableHooks::push_hooks(
@@ -93,7 +81,8 @@ std::unique_ptr<SavedVariableHooks> PyDefaultSavedVariableHooks::get_hooks() {
       py::reinterpret_steal<py::function>(pack_hook.release());
   py::function unpack_hook_ =
       py::reinterpret_steal<py::function>(unpack_hook.release());
-  return std::make_unique<PySavedVariableHooks>(pack_hook_, unpack_hook_);
+  return std::make_unique<PySavedVariableHooks>(
+      std::move(pack_hook_), std::move(unpack_hook_));
 }
 
 } // namespace torch::autograd

--- a/torch/csrc/autograd/python_saved_variable_hooks.cpp
+++ b/torch/csrc/autograd/python_saved_variable_hooks.cpp
@@ -14,9 +14,14 @@ PySavedVariableHooks::PySavedVariableHooks(
     // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
     py::function&& unpack_hook)
     : // steals the reference
-      pack_hook_(std::move(pack_hook).release().ptr(), getPyInterpreter()),
-      unpack_hook_(std::move(unpack_hook).release().ptr(), getPyInterpreter()) {
-}
+      pack_hook_(
+          std::in_place,
+          std::move(pack_hook).release().ptr(),
+          getPyInterpreter()),
+      unpack_hook_(
+          std::in_place,
+          std::move(unpack_hook).release().ptr(),
+          getPyInterpreter()) {}
 
 // We don't use pybind for call_pack_hook and call_unpack_hook to avoid
 // https://github.com/pytorch/pytorch/issues/34172
@@ -24,7 +29,7 @@ void PySavedVariableHooks::call_pack_hook(const at::Tensor& tensor) {
   py::gil_scoped_acquire acquire;
   THPObjectPtr obj(THPVariable_Wrap(tensor));
   THPObjectPtr packed(PyObject_CallFunctionObjArgs(
-      pack_hook_.ptr(getPyInterpreter()), obj.get(), nullptr));
+      pack_hook_->ptr(getPyInterpreter()), obj.get(), nullptr));
   TORCH_CHECK_PYTHON(packed);
   data_.emplace(packed.release(), getPyInterpreter());
   // obj is decrefed on exit, packed's reference is stolen by data_
@@ -33,7 +38,7 @@ void PySavedVariableHooks::call_pack_hook(const at::Tensor& tensor) {
 at::Tensor PySavedVariableHooks::call_unpack_hook() {
   py::gil_scoped_acquire acquire;
   THPObjectPtr res(PyObject_CallFunctionObjArgs(
-      unpack_hook_.ptr(getPyInterpreter()),
+      unpack_hook_->ptr(getPyInterpreter()),
       data().ptr(getPyInterpreter()),
       nullptr));
   TORCH_CHECK_PYTHON(res);
@@ -47,7 +52,12 @@ at::Tensor PySavedVariableHooks::call_unpack_hook() {
 
 std::optional<std::pair<c10::SafePyObject, c10::SafePyObject>>
 PySavedVariableHooks::retrieve_unpack_hook_data() const {
-  return std::make_pair(unpack_hook_, data());
+  return std::make_pair(*unpack_hook_, data());
+}
+
+std::optional<c10::SafePyObject> PySavedVariableHooks::retrieve_unpack_hook()
+    const {
+  return unpack_hook_;
 }
 
 void PyDefaultSavedVariableHooks::push_hooks(

--- a/torch/csrc/autograd/python_saved_variable_hooks.cpp
+++ b/torch/csrc/autograd/python_saved_variable_hooks.cpp
@@ -9,29 +9,33 @@ namespace py = pybind11;
 
 namespace torch::autograd {
 PySavedVariableHooks::PySavedVariableHooks(
-    py::function& pack_hook,
-    py::function& unpack_hook)
-    : // steals the reference (we will decref ourselves)
-      pack_hook_(pack_hook.release().ptr()),
-      unpack_hook_(unpack_hook.release().ptr()) {}
+    // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
+    py::function&& pack_hook,
+    // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
+    py::function&& unpack_hook)
+    : // steals the reference
+      pack_hook_(std::move(pack_hook).release().ptr(), getPyInterpreter()),
+      unpack_hook_(std::move(unpack_hook).release().ptr(), getPyInterpreter()) {
+}
 
 // We don't use pybind for call_pack_hook and call_unpack_hook to avoid
 // https://github.com/pytorch/pytorch/issues/34172
 void PySavedVariableHooks::call_pack_hook(const at::Tensor& tensor) {
   py::gil_scoped_acquire acquire;
   THPObjectPtr obj(THPVariable_Wrap(tensor));
-  THPObjectPtr packed(
-      PyObject_CallFunctionObjArgs(pack_hook_, obj.get(), nullptr));
+  THPObjectPtr packed(PyObject_CallFunctionObjArgs(
+      pack_hook_.ptr(getPyInterpreter()), obj.get(), nullptr));
   TORCH_CHECK_PYTHON(packed);
-  data_ = packed.release();
-  // obj is decrefed on exit, packed has their references stolen
-  // pack_hook_ and data_ will be manually decrefed when the saved variable is
-  // released
+  data_.emplace(packed.release(), getPyInterpreter());
+  // obj is decrefed on exit, packed's reference is stolen by data_
 }
 
 at::Tensor PySavedVariableHooks::call_unpack_hook() {
   py::gil_scoped_acquire acquire;
-  THPObjectPtr res(PyObject_CallFunctionObjArgs(unpack_hook_, data_, nullptr));
+  THPObjectPtr res(PyObject_CallFunctionObjArgs(
+      unpack_hook_.ptr(getPyInterpreter()),
+      data().ptr(getPyInterpreter()),
+      nullptr));
   TORCH_CHECK_PYTHON(res);
   TORCH_CHECK_TYPE(
       THPVariable_Check(res),
@@ -39,27 +43,11 @@ at::Tensor PySavedVariableHooks::call_unpack_hook() {
       THPUtils_typename(res));
   return THPVariable_Unpack(res);
   // res is decrefed on exit
-  // unpack_hook_ will be manually decrefed when the saved variable is released
 }
 
 std::optional<std::pair<c10::SafePyObject, c10::SafePyObject>>
 PySavedVariableHooks::retrieve_unpack_hook_data() const {
-  Py_INCREF(unpack_hook_);
-  Py_INCREF(data_);
-  return std::make_pair(
-      c10::SafePyObject(unpack_hook_, getPyInterpreter()),
-      c10::SafePyObject(data_, getPyInterpreter()));
-}
-
-// NOLINTNEXTLINE(bugprone-exception-escape)
-PySavedVariableHooks::~PySavedVariableHooks() {
-  // If python is already dead, leak the wrapped python objects
-  if (Py_IsInitialized()) {
-    py::gil_scoped_acquire gil;
-    Py_XDECREF(pack_hook_);
-    Py_XDECREF(unpack_hook_);
-    Py_XDECREF(data_);
-  }
+  return std::make_pair(unpack_hook_, data());
 }
 
 void PyDefaultSavedVariableHooks::push_hooks(
@@ -89,7 +77,8 @@ std::unique_ptr<SavedVariableHooks> PyDefaultSavedVariableHooks::get_hooks() {
       py::reinterpret_steal<py::function>(pack_hook.release());
   py::function unpack_hook_ =
       py::reinterpret_steal<py::function>(unpack_hook.release());
-  return std::make_unique<PySavedVariableHooks>(pack_hook_, unpack_hook_);
+  return std::make_unique<PySavedVariableHooks>(
+      std::move(pack_hook_), std::move(unpack_hook_));
 }
 
 } // namespace torch::autograd

--- a/torch/csrc/autograd/python_saved_variable_hooks.h
+++ b/torch/csrc/autograd/python_saved_variable_hooks.h
@@ -14,17 +14,24 @@ namespace py = pybind11;
 namespace torch::autograd {
 
 struct PySavedVariableHooks : public SavedVariableHooks {
-  PySavedVariableHooks(py::function& pack_hook, py::function& unpack_hook);
+  PySavedVariableHooks(py::function&& pack_hook, py::function&& unpack_hook);
   void call_pack_hook(const at::Tensor& tensor) override;
   at::Tensor call_unpack_hook() override;
-  ~PySavedVariableHooks() override;
+  ~PySavedVariableHooks() override = default;
   std::optional<std::pair<c10::SafePyObject, c10::SafePyObject>>
   retrieve_unpack_hook_data() const override;
 
  private:
-  PyObject* pack_hook_;
-  PyObject* unpack_hook_;
-  PyObject* data_ = nullptr;
+  const c10::SafePyObject& data() const {
+    TORCH_CHECK(data_.has_value(), "call_pack_hook was not called");
+    return *data_;
+  }
+
+  // SafePyObject destructs through PyInterpreter::decref, so no manual
+  // destructor is needed here.
+  c10::SafePyObject pack_hook_;
+  c10::SafePyObject unpack_hook_;
+  std::optional<c10::SafePyObject> data_;
 };
 
 struct PyDefaultSavedVariableHooks {

--- a/torch/csrc/autograd/python_saved_variable_hooks.h
+++ b/torch/csrc/autograd/python_saved_variable_hooks.h
@@ -13,12 +13,11 @@ namespace py = pybind11;
 
 namespace torch::autograd {
 
+// Copy/move are already deleted on SavedVariableHooks; clang-tidy doesn't
+// see that inherited deletion, hence the suppression below.
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions)
 struct PySavedVariableHooks : public SavedVariableHooks {
   PySavedVariableHooks(py::function&& pack_hook, py::function&& unpack_hook);
-  PySavedVariableHooks(const PySavedVariableHooks&) = delete;
-  PySavedVariableHooks& operator=(const PySavedVariableHooks&) = delete;
-  PySavedVariableHooks(PySavedVariableHooks&&) = delete;
-  PySavedVariableHooks& operator=(PySavedVariableHooks&&) = delete;
   void call_pack_hook(const at::Tensor& tensor) override;
   at::Tensor call_unpack_hook() override;
   ~PySavedVariableHooks() override {

--- a/torch/csrc/autograd/python_saved_variable_hooks.h
+++ b/torch/csrc/autograd/python_saved_variable_hooks.h
@@ -15,21 +15,35 @@ namespace torch::autograd {
 
 struct PySavedVariableHooks : public SavedVariableHooks {
   PySavedVariableHooks(py::function&& pack_hook, py::function&& unpack_hook);
+  PySavedVariableHooks(const PySavedVariableHooks&) = delete;
+  PySavedVariableHooks& operator=(const PySavedVariableHooks&) = delete;
+  PySavedVariableHooks(PySavedVariableHooks&&) = delete;
+  PySavedVariableHooks& operator=(PySavedVariableHooks&&) = delete;
   void call_pack_hook(const at::Tensor& tensor) override;
   at::Tensor call_unpack_hook() override;
-  ~PySavedVariableHooks() override = default;
+  ~PySavedVariableHooks() override {
+    // Each SafePyObject's own destructor routes through
+    // PyInterpreter::decref, which acquires the GIL; batch that into one
+    // acquisition here instead of three independent ones.
+    py::gil_scoped_acquire gil;
+    pack_hook_.reset();
+    unpack_hook_.reset();
+    data_.reset();
+  }
   std::optional<std::pair<c10::SafePyObject, c10::SafePyObject>>
   retrieve_unpack_hook_data() const override;
+  std::optional<c10::SafePyObject> retrieve_unpack_hook() const override;
 
  private:
   const c10::SafePyObject& data() const {
-    TORCH_CHECK(data_.has_value(), "call_pack_hook was not called");
+    TORCH_CHECK(
+        data_.has_value(),
+        "the pack hook raised before saving data for this tensor");
     return *data_;
   }
 
-  // SafePyObject destructs through PyInterpreter::decref, no manual dtor.
-  c10::SafePyObject pack_hook_;
-  c10::SafePyObject unpack_hook_;
+  std::optional<c10::SafePyObject> pack_hook_;
+  std::optional<c10::SafePyObject> unpack_hook_;
   std::optional<c10::SafePyObject> data_;
 };
 

--- a/torch/csrc/autograd/python_saved_variable_hooks.h
+++ b/torch/csrc/autograd/python_saved_variable_hooks.h
@@ -22,9 +22,7 @@ struct PySavedVariableHooks : public SavedVariableHooks {
   void call_pack_hook(const at::Tensor& tensor) override;
   at::Tensor call_unpack_hook() override;
   ~PySavedVariableHooks() override {
-    // Each SafePyObject's own destructor routes through
-    // PyInterpreter::decref, which acquires the GIL; batch that into one
-    // acquisition here instead of three independent ones.
+    // Batch the three SafePyObject decrefs under one GIL acquisition.
     py::gil_scoped_acquire gil;
     pack_hook_.reset();
     unpack_hook_.reset();

--- a/torch/csrc/autograd/python_saved_variable_hooks.h
+++ b/torch/csrc/autograd/python_saved_variable_hooks.h
@@ -27,8 +27,7 @@ struct PySavedVariableHooks : public SavedVariableHooks {
     return *data_;
   }
 
-  // SafePyObject destructs through PyInterpreter::decref, so no manual
-  // destructor is needed here.
+  // SafePyObject destructs through PyInterpreter::decref, no manual dtor.
   c10::SafePyObject pack_hook_;
   c10::SafePyObject unpack_hook_;
   std::optional<c10::SafePyObject> data_;

--- a/torch/csrc/autograd/saved_variable.h
+++ b/torch/csrc/autograd/saved_variable.h
@@ -71,6 +71,13 @@ class TORCH_API SavedVariable {
     return hooks_->retrieve_unpack_hook_data();
   }
 
+  std::optional<c10::SafePyObject> retrieve_unpack_hook() const {
+    if (!hooks_) {
+      return std::nullopt;
+    }
+    return hooks_->retrieve_unpack_hook();
+  }
+
  private:
   // This field contains either:
   // 1. the variable to save

--- a/torch/csrc/autograd/saved_variable_hooks.h
+++ b/torch/csrc/autograd/saved_variable_hooks.h
@@ -14,8 +14,7 @@ struct TORCH_API SavedVariableHooks {
     TORCH_CHECK(
         false, "Compiled Autograd only supports python saved tensor hooks ");
   }
-  // Unlike retrieve_unpack_hook_data(), this does not require pack data to
-  // be available, since the unpack hook itself does not depend on it.
+  // Unlike retrieve_unpack_hook_data(), doesn't require pack data to exist.
   virtual std::optional<c10::SafePyObject> retrieve_unpack_hook() const {
     return std::nullopt;
   }

--- a/torch/csrc/autograd/saved_variable_hooks.h
+++ b/torch/csrc/autograd/saved_variable_hooks.h
@@ -14,6 +14,11 @@ struct TORCH_API SavedVariableHooks {
     TORCH_CHECK(
         false, "Compiled Autograd only supports python saved tensor hooks ");
   }
+  // Unlike retrieve_unpack_hook_data(), this does not require pack data to
+  // be available, since the unpack hook itself does not depend on it.
+  virtual std::optional<c10::SafePyObject> retrieve_unpack_hook() const {
+    return std::nullopt;
+  }
 };
 
 } // namespace torch::autograd

--- a/torch/csrc/autograd/saved_variable_hooks.h
+++ b/torch/csrc/autograd/saved_variable_hooks.h
@@ -6,6 +6,11 @@
 namespace torch::autograd {
 
 struct TORCH_API SavedVariableHooks {
+  SavedVariableHooks() = default;
+  SavedVariableHooks(const SavedVariableHooks&) = delete;
+  SavedVariableHooks& operator=(const SavedVariableHooks&) = delete;
+  SavedVariableHooks(SavedVariableHooks&&) = delete;
+  SavedVariableHooks& operator=(SavedVariableHooks&&) = delete;
   virtual void call_pack_hook(const at::Tensor& tensor) = 0;
   virtual at::Tensor call_unpack_hook() = 0;
   virtual ~SavedVariableHooks() = default;


### PR DESCRIPTION
Replace the raw `PyObject*` members in `PyAnomalyMetadata` and `PySavedVariableHooks` with `c10::SafePyObject`, so cleanup routes through the shared `PyInterpreter::decref` path instead of two hand-written `Py_XDECREF` destructors.

This also fixes a real segfault: `SavedVariable::set_hooks_and_pack_data` sets `hooks_` before calling `call_pack_hook`, so a raising pack hook left `data_` unset while `has_hooks()` stayed true -- the old code then did an unguarded `Py_INCREF(nullptr)` the next time `.data` was read. `PySavedVariableHooks::data()` now `TORCH_CHECK`s instead, turning the crash into a catchable `RuntimeError` (label: `bug fixes`, not `not user facing`). `SavedTensor.unpack_hook` no longer depends on that same check, since the hook itself is valid regardless of whether packing succeeded.

Test: `test_saved_tensor_hooks_pack_error_then_data_access` reproduces the crash path and asserts `RuntimeError` instead of a segfault.
