### PR TITLE
[inductor] Use non-NaN-propagating fmax in softmax persistent reduction

### DIFF
--- a/test/inductor/test_online_softmax.py
+++ b/test/inductor/test_online_softmax.py
@@ -463,7 +463,6 @@ class TestOnlineSoftmax(TestCase):
         opt_f = torch.compile(f)
         torch.testing.assert_close(f(x, y), opt_f(x, y), atol=1e-3, rtol=1e-3)
 
-
     @parametrize("dtype", [torch.bfloat16, torch.float32])
     def test_nan_propagation(self, dtype):
         """

--- a/test/inductor/test_online_softmax.py
+++ b/test/inductor/test_online_softmax.py
@@ -464,6 +464,49 @@ class TestOnlineSoftmax(TestCase):
         torch.testing.assert_close(f(x, y), opt_f(x, y), atol=1e-3, rtol=1e-3)
 
 
+    @parametrize("dtype", [torch.bfloat16, torch.float32])
+    def test_nan_propagation(self, dtype):
+        """
+        The softmax-internal max uses fmax (non-NaN-propagating) for
+        performance, but NaN must still propagate to the final output
+        because the original input flows through exp(x - xmax).
+        Place NaN at the beginning, middle, and end of separate rows.
+
+        This is Triton-only because fmax is only implemented in the
+        Triton persistent reduction path.
+        """
+        if not HAS_TRITON:
+            self.skipTest("requires triton")
+
+        M, N = 4, 1024
+        x = torch.randn(M, N, device=GPU_TYPE, dtype=dtype)
+
+        x[0, 0] = float("nan")
+        x[1, N // 2] = float("nan")
+        x[2, N - 1] = float("nan")
+        # row 3 has no NaN
+
+        ref = torch.softmax(x, dim=-1)
+        act, (code,) = run_and_get_code(torch.compile(torch.softmax), x, dim=-1)
+
+        self.assertIn("fmax2", code)
+
+        # Rows with NaN input must produce all-NaN output
+        for row in range(3):
+            self.assertTrue(
+                ref[row].isnan().all(),
+                f"eager row {row} should be all NaN",
+            )
+            self.assertTrue(
+                act[row].isnan().all(),
+                f"compiled row {row} should be all NaN",
+            )
+
+        # Row without NaN must match exactly
+        self.assertFalse(act[3].isnan().any())
+        torch.testing.assert_close(ref[3], act[3])
+
+
 instantiate_parametrized_tests(TestOnlineSoftmax)
 
 if __name__ == "__main__":

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -229,8 +229,6 @@ def reduction_combine(
         return f"{var} || {next_value}"
     if reduction_type in ("min", "max"):
         return f"{reduction_type}_propagate_nan({var}, {next_value})"
-    if reduction_type == "fmax":
-        return f"std::max({var}, {next_value})"
     if reduction_type == "welford_reduce":
         if helper_val:
             return f"welford_combine({var}, {next_value}, &{helper_val})"
@@ -1725,7 +1723,7 @@ class CppVecOverrides(CppOverrides):
 
     @staticmethod
     def fmaximum(a, b):
-        return f"at::vec::maximum({a}, {b})"
+        return f"decltype({a})::blendv({a}, {b}, {a} < {b})"
 
     @staticmethod
     def square(a):

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -229,6 +229,8 @@ def reduction_combine(
         return f"{var} || {next_value}"
     if reduction_type in ("min", "max"):
         return f"{reduction_type}_propagate_nan({var}, {next_value})"
+    if reduction_type == "fmax":
+        return f"std::max({var}, {next_value})"
     if reduction_type == "welford_reduce":
         if helper_val:
             return f"welford_combine({var}, {next_value}, &{helper_val})"
@@ -1012,6 +1014,11 @@ class CppOverrides(OpOverrides):
 
     @staticmethod
     # pyrefly: ignore [bad-override]
+    def fmaximum(a, b):
+        return f"std::max({a}, {b})"
+
+    @staticmethod
+    # pyrefly: ignore [bad-override]
     def where(a, b, c):
         return f"{a} ? {b} : {c}"
 
@@ -1715,6 +1722,10 @@ class CppVecOverrides(CppOverrides):
             return f"{a_cast} | {b_cast}"
         else:
             return f"at::vec::maximum({a}, {b})"
+
+    @staticmethod
+    def fmaximum(a, b):
+        return f"at::vec::maximum({a}, {b})"
 
     @staticmethod
     def square(a):

--- a/torch/_inductor/codegen/halide.py
+++ b/torch/_inductor/codegen/halide.py
@@ -340,6 +340,11 @@ class HalideOverrides(OpOverrides):
 
     @staticmethod
     # pyrefly: ignore [bad-override]
+    def fmaximum(a, b):
+        return f"hl.max({a}, {b})"
+
+    @staticmethod
+    # pyrefly: ignore [bad-override]
     def where(a, b, c):
         if hasattr(b, "name"):
             c = f"hl.cast({b.name}.type(), {c})"

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -1443,7 +1443,7 @@ class SIMDKernel(Kernel[CSEVariableType], Generic[CSEVariableType]):
         return OpsWrapper._unwrap((mean, m2, rnumel))
 
     def prepare_softmax_twopass_fallback(self, dtype, value):
-        vmax = ops.reduction(dtype, dtype, "max", value)
+        vmax = ops.reduction(dtype, dtype, "fmax", value)
         sub = ops.sub(value, vmax)
         exp = ops.exp(sub)
         vsum = ops.reduction(dtype, dtype, "sum", exp)

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1582,6 +1582,7 @@ class TritonOverrides(OpOverrides):
         return f"tl.maximum({a}, {b}, tl.PropagateNan.ALL)"
 
     @staticmethod
+    # pyrefly: ignore [bad-override]
     def fmaximum(a, b):
         return f"tl.maximum({a}, {b})"
 

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -157,9 +157,9 @@ INNER_REDUCTION_RATIO_THRESHOLD = 8
 
 
 def get_triton_reduction_function(reduction_type):
-    use_helper = reduction_type in ("any", "max", "min", "prod")
+    use_helper = reduction_type in ("any", "max", "min", "prod", "fmax")
     module = "triton_helpers" if use_helper else "tl"
-    if reduction_type in ("max", "min"):
+    if reduction_type in ("max", "min", "fmax"):
         return f"{module}.{reduction_type}2"
     else:
         return f"{module}.{reduction_type}"
@@ -1580,6 +1580,10 @@ class TritonOverrides(OpOverrides):
     # pyrefly: ignore [bad-override]
     def maximum(a, b):
         return f"tl.maximum({a}, {b}, tl.PropagateNan.ALL)"
+
+    @staticmethod
+    def fmaximum(a, b):
+        return f"tl.maximum({a}, {b})"
 
     @staticmethod
     # pyrefly: ignore [bad-override]

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -1914,7 +1914,13 @@ class Reduction(Loops):
     def default_accumulator(
         reduction_type: str, dtype: torch.dtype
     ) -> _NumLike | Sequence[_NumLike]:
-        if reduction_type in ("max", "fmax", "argmax", "argmax_value", "argmax_with_value"):
+        if reduction_type in (
+            "max",
+            "fmax",
+            "argmax",
+            "argmax_value",
+            "argmax_with_value",
+        ):
             if is_float_dtype(dtype):
                 return float("-inf")
             elif is_boolean_dtype(dtype):

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -1263,6 +1263,7 @@ class Scatter(Pointwise):
 REDUCTION_COMBINE_FN: dict[str, Callable[..., OpsValue]] = {
     "any": ops_wrapper("logical_or"),
     "max": ops_wrapper("maximum"),
+    "fmax": ops_wrapper("fmaximum"),
     "min": ops_wrapper("minimum"),
     "prod": ops_wrapper("mul"),
     "sum": ops_wrapper("add"),
@@ -1913,7 +1914,7 @@ class Reduction(Loops):
     def default_accumulator(
         reduction_type: str, dtype: torch.dtype
     ) -> _NumLike | Sequence[_NumLike]:
-        if reduction_type in ("max", "argmax", "argmax_value", "argmax_with_value"):
+        if reduction_type in ("max", "fmax", "argmax", "argmax_value", "argmax_with_value"):
             if is_float_dtype(dtype):
                 return float("-inf")
             elif is_boolean_dtype(dtype):

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -8428,6 +8428,11 @@ maximum = register_pointwise(aten.maximum)
 minimum = register_pointwise(aten.minimum)
 register_lowering(aten.clamp_min)(maximum)
 register_lowering(aten.clamp_max)(minimum)
+register_op_dtype_propagation_rules(
+    "fmaximum",
+    type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
+    override_return_dtype=None,
+)
 neg = register_pointwise(aten.neg)
 abs = register_pointwise(aten.abs)
 reciprocal = register_pointwise_numeric(aten.reciprocal)

--- a/torch/_inductor/ops_handler.py
+++ b/torch/_inductor/ops_handler.py
@@ -44,6 +44,7 @@ ReductionType = Literal[
     "welford_reduce",
     "welford_combine",
     "any",
+    "fmax",
     "max",
     "min",
     "prod",
@@ -359,6 +360,9 @@ class OpsHandler(Generic[T]):
         raise NotImplementedError
 
     def maximum(self, x0: T, x1: T) -> T:
+        raise NotImplementedError
+
+    def fmaximum(self, x0: T, x1: T) -> T:
         raise NotImplementedError
 
     def cos(self, x0: T) -> T:

--- a/torch/_inductor/runtime/triton_helpers.py
+++ b/torch/_inductor/runtime/triton_helpers.py
@@ -252,6 +252,11 @@ def maximum(a, b):
 
 
 @triton.jit
+def fmaximum(a, b):
+    return tl.maximum(a, b)
+
+
+@triton.jit
 def min2(a, dim):
     return tl.reduce(a, dim, minimum)
 
@@ -259,6 +264,11 @@ def min2(a, dim):
 @triton.jit
 def max2(a, dim):
     return tl.reduce(a, dim, maximum)
+
+
+@triton.jit
+def fmax2(a, dim):
+    return tl.reduce(a, dim, fmaximum)
 
 
 @triton.jit


### PR DESCRIPTION
**Issue**: https://github.com/pytorch/pytorch/issues/189161

**What**: Add an "fmax" reduction type (non-NaN-propagating max) and use it in the softmax two-pass fallback path (prepare_softmax_twopass_fallback).

**Why**: The softmax-internal max only stabilizes the computation; its result is never user-visible. NaN still propagates through exp(x - xmax) into the final output regardless. The redundant NaN-propagating max has measurable cost: 1.05x-1.30x speedup on GB200 persistent kernels with bf16 [32768, N] inputs (N=1024 to N=16384).

**How**: Add fmaximum/fmax2 JIT helpers in triton_helpers.py, wire "fmax" as a reduction type through ir.py and triton.py codegen, and switch the two-pass fallback from "max" to "fmax" in simd.py.

Co-Authored-By: Claude

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo