### PR TITLE
Enable expandable_segments on Windows (port NVML driver API as prerequisite)

### DIFF
--- a/c10/cuda/CMakeLists.txt
+++ b/c10/cuda/CMakeLists.txt
@@ -73,8 +73,10 @@ if(NOT BUILD_LIBTORCHLESS)
 
   if(NOT WIN32)
   target_link_libraries(c10_cuda PRIVATE dl)
-  target_compile_options(c10_cuda PRIVATE "-DPYTORCH_C10_DRIVER_API_SUPPORTED")
+  else()
+  target_link_libraries(c10_cuda PRIVATE fmt::fmt)
   endif()
+  target_compile_definitions(c10_cuda PRIVATE PYTORCH_C10_DRIVER_API_SUPPORTED)
 
   target_include_directories(
       c10_cuda PUBLIC

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -84,9 +84,9 @@ static int get_self_pid() {
   return _getpid();
 #else
   return getpid();
-#endif
+#endif // _WIN32
 }
-#endif
+#endif // defined(PYTORCH_C10_DRIVER_API_SUPPORTED) || defined(USE_ROCM)
 
 namespace Native {
 
@@ -467,7 +467,7 @@ struct ExpandableSegment {
     static const bool enable_ipc_handles =
         c10::utils::check_env("TORCH_CUDA_EXPANDABLE_SEGMENTS_IPC")
             .value_or(default_enable_ipc);
-#endif
+#endif // _WIN32
 
     // Determine IPC handle type upfront based on config and device capability.
     // Resolve once per segment lifetime: fromShared() pre-sets handle_type_

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1354,7 +1354,11 @@ static std::string reportProcessMemoryInfo(const cudaDeviceProp& prop) {
          NVML_ERROR_INSUFFICIENT_SIZE) {
     procs.resize(size);
   }
+#ifdef _WIN32
+  unsigned int self_pid = _getpid();
+#else
   unsigned int self_pid = getpid();
+#endif
   std::stringstream ss;
   TORCH_INTERNAL_ASSERT(NVML_SUCCESS == r);
   ss << "";

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -438,6 +438,11 @@ struct ExpandableSegment {
       return rangeFromHandles(begin, end);
     }
 
+#ifdef _WIN32
+    // No Win32 IPC handle type implemented; share() still errors clearly
+    // for cross-process use.
+    constexpr bool enable_ipc_handles = false;
+#else
     // In fbcode, IPC handle types for expandable segments are disabled by
     // default because some jobs were failing (see
     // https://github.com/pytorch/pytorch/pull/132890), but can be explicitly
@@ -452,6 +457,7 @@ struct ExpandableSegment {
     static const bool enable_ipc_handles =
         c10::utils::check_env("TORCH_CUDA_EXPANDABLE_SEGMENTS_IPC")
             .value_or(default_enable_ipc);
+#endif
 
     // Determine IPC handle type upfront based on config and device capability.
     // Resolve once per segment lifetime: fromShared() pre-sets handle_type_

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -78,6 +78,16 @@ namespace cuda::CUDACachingAllocator {
 using namespace c10::CachingAllocator;
 using namespace c10::CachingDeviceAllocator;
 
+#if defined(PYTORCH_C10_DRIVER_API_SUPPORTED) || defined(USE_ROCM)
+static int get_self_pid() {
+#ifdef _WIN32
+  return _getpid();
+#else
+  return getpid();
+#endif
+}
+#endif
+
 namespace Native {
 
 //
@@ -590,11 +600,7 @@ struct ExpandableSegment {
     // thereby ensuring that the handle can be correctly matched in
     // ipcMemHandle_to_devptr.
     ShareHeader header{};
-#ifdef _WIN32
-    header.pid = _getpid();
-#else
-    header.pid = getpid();
-#endif
+    header.pid = get_self_pid();
     header.segment_size = segment_size_;
     header.num_handles = end - begin;
     header.handle_type = handle_type_;
@@ -761,6 +767,9 @@ struct ExpandableSegment {
 #ifdef USE_ROCM
       TORCH_INTERNAL_ASSERT(
           false, "expandable segment with fabric handle not supported");
+#elif defined(_WIN32)
+      TORCH_CHECK(
+          false, "IPC expandable segments are not supported on Windows");
 #else
       for (auto i : c10::irange(header.num_handles)) {
         (void)i;
@@ -1360,11 +1369,7 @@ static std::string reportProcessMemoryInfo(const cudaDeviceProp& prop) {
          NVML_ERROR_INSUFFICIENT_SIZE) {
     procs.resize(size);
   }
-#ifdef _WIN32
-  unsigned int self_pid = _getpid();
-#else
-  unsigned int self_pid = getpid();
-#endif
+  unsigned int self_pid = get_self_pid();
   std::stringstream ss;
   TORCH_INTERNAL_ASSERT(NVML_SUCCESS == r);
   ss << "";

--- a/c10/cuda/driver_api.cpp
+++ b/c10/cuda/driver_api.cpp
@@ -4,11 +4,45 @@
 #include <c10/util/Exception.h>
 #include <c10/util/Logging.h>
 #include <cuda_runtime.h>
+
+#ifdef _WIN32
+#include <c10/util/win32-headers.h>
+#include <fmt/os.h>
+#else
 #include <dlfcn.h>
+#endif
 
 namespace c10::cuda {
 
 namespace {
+
+#ifdef _WIN32
+void* nvml_dlopen(const char* name) {
+  return LoadLibraryA(name);
+}
+
+void* nvml_dlsym(void* handle, const char* name) {
+  return reinterpret_cast<void*>(
+      GetProcAddress(static_cast<HMODULE>(handle), name));
+}
+
+std::string nvml_dlerror() {
+  auto err = static_cast<int>(GetLastError());
+  return fmt::windows_error(err, "WinError {}", err).what();
+}
+#else
+void* nvml_dlopen(const char* name) {
+  return dlopen(name, RTLD_LAZY);
+}
+
+void* nvml_dlsym(void* handle, const char* name) {
+  return dlsym(handle, name);
+}
+
+const char* nvml_dlerror() {
+  return dlerror();
+}
+#endif
 
 void* get_symbol(const char* name, int version);
 
@@ -31,16 +65,16 @@ DriverAPI create_driver_api() {
 #undef LOOKUP_LIBCUDA_ENTRY_WITH_VERSION_OPTIONAL
 
   if (handle_1) {
-#define LOOKUP_NVML_ENTRY(name)                          \
-  r.name##_ = ((decltype(&name))dlsym(handle_1, #name)); \
-  TORCH_INTERNAL_ASSERT(r.name##_, "Can't find ", #name, ": ", dlerror())
+#define LOOKUP_NVML_ENTRY(name)                                               \
+  r.name##_ = reinterpret_cast<decltype(&name)>(nvml_dlsym(handle_1, #name)); \
+  TORCH_INTERNAL_ASSERT(r.name##_, "Can't find ", #name, ": ", nvml_dlerror())
     C10_NVML_DRIVER_API(LOOKUP_NVML_ENTRY)
 #undef LOOKUP_NVML_ENTRY
   }
 
   if (handle_1) {
 #define LOOKUP_NVML_ENTRY_OPTIONAL(name) \
-  r.name##_ = ((decltype(&name))dlsym(handle_1, #name));
+  r.name##_ = reinterpret_cast<decltype(&name)>(nvml_dlsym(handle_1, #name));
     C10_NVML_DRIVER_API_OPTIONAL(LOOKUP_NVML_ENTRY_OPTIONAL)
 #undef LOOKUP_NVML_ENTRY_OPTIONAL
   }
@@ -78,7 +112,11 @@ void* get_symbol(const char* name, int version) {
 } // namespace
 
 void* DriverAPI::get_nvml_handle() {
-  static void* nvml_handle = dlopen("libnvidia-ml.so.1", RTLD_LAZY);
+#ifdef _WIN32
+  static void* nvml_handle = nvml_dlopen("nvml.dll");
+#else
+  static void* nvml_handle = nvml_dlopen("libnvidia-ml.so.1");
+#endif
   return nvml_handle;
 }
 

--- a/c10/cuda/driver_api.cpp
+++ b/c10/cuda/driver_api.cpp
@@ -42,7 +42,7 @@ void* nvml_dlsym(void* handle, const char* name) {
 const char* nvml_dlerror() {
   return dlerror();
 }
-#endif
+#endif // _WIN32
 
 void* get_symbol(const char* name, int version);
 

--- a/c10/cuda/driver_api.h
+++ b/c10/cuda/driver_api.h
@@ -3,6 +3,7 @@
 #define NVML_NO_UNVERSIONED_FUNC_DEFS
 #include <nvml.h>
 
+#include <c10/cuda/CUDAMacros.h>
 #include <c10/util/Exception.h>
 
 #define C10_CUDA_DRIVER_CHECK(EXPR)                                        \
@@ -139,7 +140,7 @@ struct DriverAPI {
 #undef CREATE_MEMBER_VERSIONED
 #undef CREATE_MEMBER
 
-  static C10_EXPORT DriverAPI* get();
+  static C10_CUDA_API DriverAPI* get();
   static void* get_nvml_handle();
 };
 

--- a/c10/cuda/driver_api.h
+++ b/c10/cuda/driver_api.h
@@ -139,7 +139,7 @@ struct DriverAPI {
 #undef CREATE_MEMBER_VERSIONED
 #undef CREATE_MEMBER
 
-  static DriverAPI* get();
+  static C10_EXPORT DriverAPI* get();
   static void* get_nvml_handle();
 };
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -8304,11 +8304,6 @@ class TestMemPool(TestCase):
         not EXPANDABLE_SEGMENTS,
         "requires expandable_segments mode (run via test_cuda_expandable_segments.py)",
     )
-    # expandable_segments not supported (PYTORCH_C10_DRIVER_API_SUPPORTED not defined for windows builds)
-    @unittest.skipIf(
-        IS_WINDOWS and SM89OrLater,
-        "expandable_segments not supported (PYTORCH_C10_DRIVER_API_SUPPORTED not defined for windows builds)",
-    )
     @skipIfRocm(msg="expandable_segments mode is not supported on ROCm")
     @unittest.skipIf(IS_FBCODE or IS_SANDCASTLE, "Load_inline doesn't work in fbcode")
     def test_mempool_expandable(self):


### PR DESCRIPTION
Enables `expandable_segments:True` for single-process allocation on Windows. As prerequisite, it ports the c10::cuda driver API to Windows so `PYTORCH_C10_DRIVER_API_SUPPORTED` can be defined.
