### PR TITLE
Fix flaky test_shutdown_terminates_sidecar_worker_pool

### DIFF
--- a/test/inductor/test_compile_worker.py
+++ b/test/inductor/test_compile_worker.py
@@ -115,20 +115,41 @@ class TestCompileWorker(TestCase):
         code = textwrap.dedent(
             """
             import operator
+            import os
             import subprocess
             import time
 
-            from torch._inductor.compile_worker.subproc_pool import SubprocPool
+            from torch._inductor.compile_worker.subproc_pool import (
+                _test_signal_then_sleep,
+                SubprocPool,
+            )
 
+            # Warm the pool so the sidecar and its worker pool are fully up.
             pool = SubprocPool(2)
             assert pool.submit(operator.add, 1, 2).result() == 3
-            pool.submit(time.sleep, 5)
-            time.sleep(0.5)
 
+            # Submit a job that signals (via a sentinel file) once a worker is
+            # actually executing it, then blocks far longer than the shutdown
+            # timeout below.
+            signal_path = os.environ["WORKER_SIGNAL_PATH"]
+            pool.submit(_test_signal_then_sleep, signal_path, 120)
+
+            # Readiness barrier: wait until a worker is provably running the job
+            # before timing the shutdown, so process/worker startup cost stays
+            # out of the shutdown budget.
+            deadline = time.time() + 60
+            while not os.path.exists(signal_path):
+                if time.time() >= deadline:
+                    raise RuntimeError("worker never started the long-running job")
+                time.sleep(0.05)
+
+            # Bound the shutdown well below the running job's sleep so a
+            # regression that waits for the in-flight job (instead of
+            # terminating it) is detected quickly.
             wait = pool.process.wait
 
             def short_wait(timeout=None):
-                return wait(timeout=2)
+                return wait(timeout=30)
 
             pool.process.wait = short_wait
 
@@ -143,12 +164,17 @@ class TestCompileWorker(TestCase):
             """
         )
         with tempfile.TemporaryDirectory() as cwd:
+            signal_path = os.path.join(cwd, "worker_started")
             result = subprocess.run(
                 [sys.executable, "-c", code],
                 cwd=cwd,
                 capture_output=True,
                 text=True,
-                timeout=20,
+                env={**os.environ, "WORKER_SIGNAL_PATH": signal_path},
+                # Generous backstop: the child pays multiple heavyweight process
+                # cold-starts (esp. in fbcode). A real regression still fails
+                # fast via the bounded shutdown wait above.
+                timeout=120,
             )
         self.assertEqual(
             result.returncode,

--- a/torch/_inductor/compile_worker/subproc_pool.py
+++ b/torch/_inductor/compile_worker/subproc_pool.py
@@ -9,6 +9,7 @@ import struct
 import subprocess
 import sys
 import threading
+import time
 import traceback
 import typing
 from collections.abc import Callable
@@ -542,3 +543,12 @@ class TestException(RuntimeError):
 
 def raise_testexc() -> Never:
     raise TestException
+
+
+def _test_signal_then_sleep(signal_path: str, seconds: float) -> None:
+    # Test helper: announce that this worker has begun executing by creating
+    # signal_path, then block. Lets a test wait until a job is actually running
+    # in a worker before acting on the pool (e.g. shutting it down).
+    with open(signal_path, "w"):
+        pass
+    time.sleep(seconds)

--- a/torch/_inductor/compile_worker/subproc_pool.py
+++ b/torch/_inductor/compile_worker/subproc_pool.py
@@ -16,6 +16,7 @@ from collections.abc import Callable
 from concurrent.futures import Future, ProcessPoolExecutor
 from concurrent.futures.process import BrokenProcessPool
 from enum import Enum, IntEnum
+from pathlib import Path
 from typing import Any, IO, TypeVar
 from typing_extensions import Never, ParamSpec
 
@@ -549,6 +550,5 @@ def _test_signal_then_sleep(signal_path: str, seconds: float) -> None:
     # Test helper: announce that this worker has begun executing by creating
     # signal_path, then block. Lets a test wait until a job is actually running
     # in a worker before acting on the pool (e.g. shutting it down).
-    with open(signal_path, "w"):
-        pass
+    Path(signal_path).touch()
     time.sleep(seconds)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189166

The test spawns a child process that creates a SubprocPool, runs a job in a
worker, and asserts the sidecar shuts down promptly while that worker is still
busy. Its runtime is dominated by heavyweight process cold-starts: in fbcode
each of the child, the sidecar, and its forked workers is a full binary that
imports torch and spins up the service framework. That baseline (~18-20s) sat
right at the outer subprocess.run(timeout=20), so any host contention tipped it
over; the flaky failures were the outer timeout firing, with pass and fail
durations both clustered at the 20s boundary.

The root cause is that process/worker startup cost was being charged against the
shutdown budget. The fix separates untimed setup from the timed region:

- Submit a job that creates a sentinel file once a worker is actually executing
  it, then blocks (new _test_signal_then_sleep helper). A readiness barrier
  waits (generous timeout) for that sentinel before the shutdown is initiated,
  so cold-start cost is no longer in the shutdown budget. This also makes the
  test reliably exercise the terminate-a-running-worker path instead of the
  queued cancel_futures path that the old fixed 0.5s sleep could race into.
- Keep the shutdown wait bounded (30s, well under the 120s the job sleeps) so a
  regression that waits for the in-flight job instead of terminating it is still
  detected quickly.
- Raise the outer subprocess timeout to 120s as a pure hang backstop.

Fixes T278749262.

Test Plan:

Reproduced the flake and validated the fix under stress in the mode CI uses
(opt); before the fix, runs clustered at the 20s timeout and flaked, after the
fix all runs pass:

```
buck2 test @fbcode//mode/opt fbcode//caffe2/test/inductor:compile_worker \
    -- 'test_shutdown_terminates_sidecar_worker_pool' --stress-runs 25
# Pass 50. Fail 0.
```

```
lintrunner -a test/inductor/test_compile_worker.py \
    torch/_inductor/compile_worker/subproc_pool.py
# ok No lint issues.
```

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo