### PR TITLE
Remove the use-arc parameter from linux build/test/docs workflows

### DIFF
--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -47,11 +47,6 @@ on:
         description: prefix for runner label
         type: string
         default: ""
-      use-arc:
-        required: false
-        type: boolean
-        default: false
-        description: If true, use ARC (OSDC) runner path instead of EC2.
       python-version:
         required: false
         type: string
@@ -74,7 +69,7 @@ on:
 
 jobs:
   build-docs:
-    if: github.repository_owner == 'pytorch' && inputs.use-arc
+    if: github.repository_owner == 'pytorch'
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -109,11 +109,6 @@ on:
         required: false
         type: string
         default: ""
-      use-arc:
-        required: false
-        type: boolean
-        default: false
-        description: If true, use ARC (OSDC) runner path instead of EC2.
       python-version:
         required: false
         type: string
@@ -154,7 +149,7 @@ jobs:
       contents: read
       actions: read
     # Don't run on forked repos
-    if: github.repository_owner == 'pytorch' && inputs.use-arc
+    if: github.repository_owner == 'pytorch'
     runs-on: ${{ inputs.runner_prefix }}${{ startsWith(inputs.runner, 'l-') && inputs.runner || contains(inputs.runner, 'arm64') && 'l-arm64g4-16-62' || 'l-x86iavx512-8-64' }}
     container:
       image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/${{ inputs.docker-image-name }}${{ inputs.ci-docker-hash && format('-{0}', inputs.ci-docker-hash) || '' }}

--- a/.github/workflows/_linux-test-stable-fa3.yml
+++ b/.github/workflows/_linux-test-stable-fa3.yml
@@ -33,11 +33,6 @@ on:
         required: false
         type: string
         default: "gha-artifacts"
-      use-arc:
-        required: false
-        type: boolean
-        default: false
-        description: If true, use ARC (OSDC) runner path instead of EC2.
       python-version:
         required: false
         type: string
@@ -73,7 +68,7 @@ env:
 jobs:
   test:
     # Don't run on forked repos
-    if: github.repository_owner == 'pytorch' && inputs.use-arc
+    if: github.repository_owner == 'pytorch'
     runs-on: mt-l-x86iamx-22-225-h100
     container:
       image: ${{ inputs.docker-image }}

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -73,11 +73,6 @@ on:
         required: false
         type: number
         default: 1
-      use-arc:
-        required: false
-        type: boolean
-        default: false
-        description: If true, use ARC (OSDC) runner path instead of EC2.
       python-version:
         required: false
         type: string
@@ -125,7 +120,7 @@ env:
 jobs:
   test:
     # Don't run on forked repos or empty test matrix
-    if: github.repository_owner == 'pytorch' && toJSON(fromJSON(inputs.test-matrix).include) != '[]' && inputs.use-arc
+    if: github.repository_owner == 'pytorch' && toJSON(fromJSON(inputs.test-matrix).include) != '[]'
     strategy:
       matrix: ${{ fromJSON(inputs.test-matrix) }}
       fail-fast: false

--- a/.github/workflows/attention_op_microbenchmark.yml
+++ b/.github/workflows/attention_op_microbenchmark.yml
@@ -46,7 +46,6 @@ jobs:
           { config: "attention_microbenchmark_test", shard: 1, num_shards: 1, runner: "linux.aws.a100" },
           { config: "attention_microbenchmark_test", shard: 1, num_shards: 1, runner: "linux.aws.h100" },
         ]}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"
@@ -63,7 +62,6 @@ jobs:
       build-environment: ${{ needs.attn-microbenchmark-build.outputs.build-environment }}
       docker-image: ${{ needs.attn-microbenchmark-build.outputs.docker-image }}
       test-matrix: ${{ needs.attn-microbenchmark-build.outputs.test-matrix }}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"
@@ -86,7 +84,6 @@ jobs:
         { include: [
           { config: "operator_microbenchmark_test", shard: 1, num_shards: 1, runner: "linux.dgx.b200" },
         ]}
-      use-arc: true
       python-version: "3.12"
       compiler: gcc11
       cuda-version: "13.0"
@@ -103,7 +100,6 @@ jobs:
       build-environment: ${{ needs.opmicrobenchmark-build-b200.outputs.build-environment }}
       docker-image: ${{ needs.opmicrobenchmark-build-b200.outputs.docker-image }}
       test-matrix: ${{ needs.opmicrobenchmark-build-b200.outputs.test-matrix }}
-      use-arc: true
       python-version: "3.12"
       compiler: gcc11
       cuda-version: "13.0"

--- a/.github/workflows/b200-distributed.yml
+++ b/.github/workflows/b200-distributed.yml
@@ -41,7 +41,6 @@ jobs:
       runner_prefix: "mt-"
       runner: l-x86iavx512-16-128
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
-      use-arc: true
       build-environment: linux-jammy-cuda13.0-py3.12-gcc11-distributed-b200
       docker-image-name: ci-image:pytorch-linux-jammy-cuda13.0-cudnn9-py3.12-gcc11
       cuda-arch-list: '10.0'

--- a/.github/workflows/b200-symm-mem.yml
+++ b/.github/workflows/b200-symm-mem.yml
@@ -41,7 +41,6 @@ jobs:
       runner_prefix: "mt-"
       runner: l-x86iavx512-16-128
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
-      use-arc: true
       build-environment: linux-jammy-cuda13.0-py3.12-gcc11-sm100-symm
       docker-image-name: ci-image:pytorch-linux-jammy-cuda13.0-cudnn9-py3.12-gcc11
       cuda-arch-list: '10.0'

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -56,7 +56,6 @@ jobs:
         { include: [
           { config: "docs_test", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge" },
         ]}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
     secrets: inherit
@@ -71,7 +70,6 @@ jobs:
       build-environment: ${{ needs.linux-jammy-py3_10-gcc11-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-py3_10-gcc11-build.outputs.docker-image }}
       run-doxygen: true
-      use-arc: true
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       python-version: "3.10"
       compiler: gcc11

--- a/.github/workflows/dtensor.yml
+++ b/.github/workflows/dtensor.yml
@@ -47,7 +47,6 @@ jobs:
         { include: [
           { config: "dtensor", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g5.12xlarge.nvidia.gpu" },
         ]}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"
@@ -61,7 +60,6 @@ jobs:
       build-environment: linux-jammy-cuda13.0-py3.10-gcc11
       docker-image: ${{ needs.dtensor-build.outputs.docker-image }}
       test-matrix: ${{ needs.dtensor-build.outputs.test-matrix }}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"

--- a/.github/workflows/dynamo-unittest.yml
+++ b/.github/workflows/dynamo-unittest.yml
@@ -54,7 +54,6 @@ jobs:
           { config: "dynamo_wrapped", shard: 2, num_shards: 3, runner: "${{ needs.get-label-type.outputs.label-type }}linux.c7i.2xlarge" },
           { config: "dynamo_wrapped", shard: 3, num_shards: 3, runner: "${{ needs.get-label-type.outputs.label-type }}linux.c7i.2xlarge" },
         ]}
-      use-arc: true
       python-version: ${{ matrix.python-version }}
       compiler: clang18
       cuda-version: cpu
@@ -72,7 +71,6 @@ jobs:
       build-environment: linux-jammy-py${{ matrix.python-version }}-clang18
       docker-image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/ci-image:pytorch-linux-jammy-py${{ matrix.python-version }}-clang18-${{ needs.get-label-type.outputs.ci-docker-hash }}
       test-matrix: ${{ needs.dynamo-build.outputs.test-matrix }}
-      use-arc: true
       python-version: ${{ matrix.python-version }}
       compiler: clang18
       cuda-version: cpu

--- a/.github/workflows/h100-cutlass-backend.yml
+++ b/.github/workflows/h100-cutlass-backend.yml
@@ -51,7 +51,6 @@ jobs:
         { include: [
           { config: "h100_cutlass_backend", shard: 1, num_shards: 1, runner: "linux.aws.h100", owners: ["oncall:pt2"] },
         ]}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"
@@ -67,7 +66,6 @@ jobs:
       build-environment: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm90-build-cutlass-backend.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm90-build-cutlass-backend.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm90-build-cutlass-backend.outputs.test-matrix }}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"

--- a/.github/workflows/h100-distributed.yml
+++ b/.github/workflows/h100-distributed.yml
@@ -48,7 +48,6 @@ jobs:
         { include: [
           { config: "h100_distributed", shard: 1, num_shards: 1, runner: "linux.aws.h100.8" },
         ]}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"
@@ -64,7 +63,6 @@ jobs:
       build-environment: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm90-build-dist.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm90-build-dist.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm90-build-dist.outputs.test-matrix }}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"

--- a/.github/workflows/h100-symm-mem.yml
+++ b/.github/workflows/h100-symm-mem.yml
@@ -48,7 +48,6 @@ jobs:
         { include: [
           { config: "h100-symm-mem", shard: 1, num_shards: 1, runner: "linux.aws.h100.4" },
         ]}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"
@@ -64,7 +63,6 @@ jobs:
       build-environment: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm90-build-symm.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm90-build-symm.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm90-build-symm.outputs.test-matrix }}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"

--- a/.github/workflows/inductor-micro-benchmark-x86.yml
+++ b/.github/workflows/inductor-micro-benchmark-x86.yml
@@ -46,7 +46,6 @@ jobs:
         { include: [
           { config: "inductor-micro-benchmark-cpu-x86", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.24xl.spr-metal", owners: ["oncall:pt2"] },
         ]}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: cpu
@@ -63,7 +62,6 @@ jobs:
       docker-image: ${{ needs.inductor-build.outputs.docker-image }}
       test-matrix: ${{ needs.inductor-build.outputs.test-matrix }}
       timeout-minutes: 720
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: cpu

--- a/.github/workflows/inductor-micro-benchmark.yml
+++ b/.github/workflows/inductor-micro-benchmark.yml
@@ -47,7 +47,6 @@ jobs:
         { include: [
           { config: "inductor-micro-benchmark", shard: 1, num_shards: 1, runner: "linux.aws.a100", owners: ["oncall:pt2"] },
         ]}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"
@@ -64,7 +63,6 @@ jobs:
       docker-image: ${{ needs.build.outputs.docker-image }}
       test-matrix: ${{ needs.build.outputs.test-matrix }}
       timeout-minutes: 720
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"

--- a/.github/workflows/inductor-nightly.yml
+++ b/.github/workflows/inductor-nightly.yml
@@ -53,7 +53,6 @@ jobs:
           { config: "dynamic_cpu_max_autotune_inductor_amp_freezing_torchbench", shard: 2, num_shards: 2, runner: "linux.8xlarge.amx" },
         ]}
       build-additional-packages: "vision audio torchao"
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: cpu
@@ -70,7 +69,6 @@ jobs:
       docker-image: ${{ needs.nightly-inductor-benchmarks-build.outputs.docker-image }}
       test-matrix: ${{ needs.nightly-inductor-benchmarks-build.outputs.test-matrix }}
       timeout-minutes: 720
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: cpu

--- a/.github/workflows/inductor-pallas.yml
+++ b/.github/workflows/inductor-pallas.yml
@@ -45,7 +45,6 @@ jobs:
         { include: [
           { config: "inductor-pallas-gpu", shard: 1, num_shards: 1, runner: "linux.aws.h100" },
         ]}
-      use-arc: true
       python-version: "3.12"
       compiler: gcc11
       cuda-version: "13.0"
@@ -61,7 +60,6 @@ jobs:
       build-environment: ${{ needs.linux-jammy-py3_12-inductor-pallas-gpu-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-py3_12-inductor-pallas-gpu-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-py3_12-inductor-pallas-gpu-build.outputs.test-matrix }}
-      use-arc: true
       python-version: "3.12"
       compiler: gcc11
       cuda-version: "13.0"
@@ -80,7 +78,6 @@ jobs:
         { include: [
           { config: "inductor-pallas-tpu", shard: 1, num_shards: 1, runner: "linux.google.tpuv7x.1" },
         ]}
-      use-arc: true
       python-version: "3.12"
     secrets: inherit
 

--- a/.github/workflows/inductor-perf-compare.yml
+++ b/.github/workflows/inductor-perf-compare.yml
@@ -49,7 +49,6 @@ jobs:
           { config: "inductor_torchbench_perf_compare", shard: 1, num_shards: 1, runner: "linux.aws.a100" },
         ]}
       build-additional-packages: "vision audio fbgemm torchao"
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"
@@ -70,7 +69,6 @@ jobs:
       monitor-log-interval: 15
       monitor-data-collect-interval: 4
       export-profiler-trace: "1"
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"

--- a/.github/workflows/inductor-perf-test-b200.yml
+++ b/.github/workflows/inductor-perf-test-b200.yml
@@ -91,7 +91,6 @@ jobs:
       # usually the bottleneck
       runner: l-x86iavx512-48-384
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
-      use-arc: true
       build-environment: linux-jammy-cuda13.0-py3.12-gcc11-sm100
       docker-image-name: ci-image:pytorch-linux-jammy-cuda13.0-cudnn9-py3.12-gcc11-inductor-benchmarks
       cuda-arch-list: '10.0'
@@ -115,7 +114,6 @@ jobs:
       dashboard-tag: training-true-inference-true-default-true-dynamic-true-cudagraphs-true-cppwrapper-true-aotinductor-true-freezing_cudagraphs-true
       docker-image: ${{ needs.build.outputs.docker-image }}
       test-matrix: ${{ needs.build.outputs.test-matrix }}
-      use-arc: true
       aws-role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_s3_and_ecr_read_only
       timeout-minutes: 720
       disable-monitor: false
@@ -135,7 +133,6 @@ jobs:
       dashboard-tag: training-true-inference-true-default-true-dynamic-true-cudagraphs-true-cppwrapper-true-aotinductor-true-freezing_cudagraphs-true-maxautotune-true-freeze_autotune_cudagraphs-true
       docker-image: ${{ needs.build.outputs.docker-image }}
       test-matrix: ${{ needs.build.outputs.test-matrix }}
-      use-arc: true
       timeout-minutes: 1440
       aws-role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_s3_and_ecr_read_only
       disable-monitor: false
@@ -154,7 +151,6 @@ jobs:
       dashboard-tag: training-${{ inputs.training }}-inference-${{ inputs.inference }}-default-${{ inputs.default }}-dynamic-${{ inputs.dynamic }}-cudagraphs-${{ inputs.cudagraphs }}-cppwrapper-${{ inputs.cppwrapper }}-aotinductor-${{ inputs.aotinductor }}-maxautotune-${{ inputs.maxautotune }}-freezing_cudagraphs-${{ inputs.freezing_cudagraphs }}
       docker-image: ${{ needs.build.outputs.docker-image }}
       test-matrix: ${{ needs.build.outputs.test-matrix }}
-      use-arc: true
       aws-role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_s3_and_ecr_read_only
       timeout-minutes: 720
       export-profiler-trace: "1"

--- a/.github/workflows/inductor-perf-test-nightly-aarch64.yml
+++ b/.github/workflows/inductor-perf-test-nightly-aarch64.yml
@@ -129,7 +129,6 @@ jobs:
         ]}
       selected-test-configs: ${{ inputs.benchmark_configs }}
       build-additional-packages: "vision audio torchao"
-      use-arc: true
     secrets: inherit
 
 
@@ -148,7 +147,6 @@ jobs:
       disable-monitor: false
       monitor-log-interval: 15
       monitor-data-collect-interval: 4
-      use-arc: true
     secrets: inherit
 
 
@@ -163,5 +161,4 @@ jobs:
       docker-image: ${{ needs.linux-jammy-aarch64-py3_10-inductor-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-aarch64-py3_10-inductor-build.outputs.test-matrix }}
       timeout-minutes: 720
-      use-arc: true
     secrets: inherit

--- a/.github/workflows/inductor-perf-test-nightly-h100.yml
+++ b/.github/workflows/inductor-perf-test-nightly-h100.yml
@@ -136,7 +136,6 @@ jobs:
         ]}
       selected-test-configs: ${{ inputs.benchmark_configs }}
       build-additional-packages: "vision audio fbgemm torchao"
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"
@@ -161,7 +160,6 @@ jobs:
       monitor-data-collect-interval: 4
       export-profiler-trace: "1"
       enable-torch-trace: "1"
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"
@@ -186,7 +184,6 @@ jobs:
       monitor-data-collect-interval: 4
       export-profiler-trace: "1"
       enable-torch-trace: "1"
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"
@@ -213,7 +210,6 @@ jobs:
       monitor-data-collect-interval: 4
       export-profiler-trace: "1"
       enable-torch-trace: "1"
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"

--- a/.github/workflows/inductor-perf-test-nightly-rocm-mi300.yml
+++ b/.github/workflows/inductor-perf-test-nightly-rocm-mi300.yml
@@ -89,7 +89,6 @@ jobs:
     with:
       runner_prefix: "mt-"
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
-      use-arc: true
       build-environment: linux-jammy-rocm-py3.10-mi300
       docker-image-name: ci-image:pytorch-linux-jammy-rocm-n-py3-benchmarks
       test-matrix: |

--- a/.github/workflows/inductor-perf-test-nightly-rocm-mi350.yml
+++ b/.github/workflows/inductor-perf-test-nightly-rocm-mi350.yml
@@ -91,7 +91,6 @@ jobs:
     with:
       runner_prefix: "mt-"
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
-      use-arc: true
       build-environment: linux-jammy-rocm-py3.10-mi350
       docker-image-name: ci-image:pytorch-linux-jammy-rocm-n-py3-benchmarks
       test-matrix: |

--- a/.github/workflows/inductor-perf-test-nightly-x86-zen.yml
+++ b/.github/workflows/inductor-perf-test-nightly-x86-zen.yml
@@ -101,7 +101,6 @@ jobs:
           { config: "inductor_torchbench_perf_cpu_x86_zen", shard: 4, num_shards: 4, runner: "linux.24xlarge.amd" },
         ]}
       selected-test-configs: ${{ inputs.benchmark_configs }}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
     secrets: inherit
@@ -121,7 +120,6 @@ jobs:
       disable-monitor: false
       monitor-log-interval: 15
       monitor-data-collect-interval: 4
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
     secrets: inherit
@@ -140,7 +138,6 @@ jobs:
       disable-monitor: false
       monitor-log-interval: 15
       monitor-data-collect-interval: 4
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
     secrets: inherit

--- a/.github/workflows/inductor-perf-test-nightly-x86.yml
+++ b/.github/workflows/inductor-perf-test-nightly-x86.yml
@@ -102,7 +102,6 @@ jobs:
         ]}
       selected-test-configs: ${{ inputs.benchmark_configs }}
       build-additional-packages: "vision audio torchao"
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
     secrets: inherit
@@ -122,7 +121,6 @@ jobs:
       disable-monitor: false
       monitor-log-interval: 15
       monitor-data-collect-interval: 4
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
     secrets: inherit
@@ -142,7 +140,6 @@ jobs:
       disable-monitor: false
       monitor-log-interval: 15
       monitor-data-collect-interval: 4
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
     secrets: inherit

--- a/.github/workflows/inductor-perf-test-nightly-xpu.yml
+++ b/.github/workflows/inductor-perf-test-nightly-xpu.yml
@@ -91,7 +91,6 @@ jobs:
       docker-image-name: ci-image:pytorch-linux-noble-xpu-n-py3-inductor-benchmarks
       runner: l-x86iavx512-48-384
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
-      use-arc: true
       test-matrix: |
         { include: [
           { config: "inductor_huggingface_perf_xpu", shard: 1, num_shards: 5, runner: "linux.idc.xpu" },

--- a/.github/workflows/inductor-perf-test-nightly.yml
+++ b/.github/workflows/inductor-perf-test-nightly.yml
@@ -116,7 +116,6 @@ jobs:
         ]}
       selected-test-configs: ${{ inputs.benchmark_configs }}
       build-additional-packages: "vision audio fbgemm torchao"
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"
@@ -138,7 +137,6 @@ jobs:
       disable-monitor: false
       monitor-log-interval: 15
       monitor-data-collect-interval: 4
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"
@@ -163,7 +161,6 @@ jobs:
       disable-monitor: false
       monitor-log-interval: 15
       monitor-data-collect-interval: 4
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"
@@ -187,7 +184,6 @@ jobs:
       disable-monitor: false
       monitor-log-interval: 15
       monitor-data-collect-interval: 4
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"

--- a/.github/workflows/inductor-periodic.yml
+++ b/.github/workflows/inductor-periodic.yml
@@ -62,7 +62,6 @@ jobs:
           { config: "aot_inductor_torchbench", shard: 2, num_shards: 2, runner: "linux.g5.4xlarge.nvidia.gpu" },
         ]}
       build-additional-packages: "vision audio fbgemm torchao"
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"
@@ -78,7 +77,6 @@ jobs:
       build-environment: ${{ needs.periodic-dynamo-benchmarks-build.outputs.build-environment }}
       docker-image: ${{ needs.periodic-dynamo-benchmarks-build.outputs.docker-image }}
       test-matrix: ${{ needs.periodic-dynamo-benchmarks-build.outputs.test-matrix }}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"
@@ -134,7 +132,6 @@ jobs:
           { config: "inductor_torchbench_smoketest_perf", shard: 1, num_shards: 1, runner: "linux.aws.a100" },
         ]}
       build-additional-packages: "vision audio fbgemm torchao"
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"
@@ -150,7 +147,6 @@ jobs:
       build-environment: ${{ needs.inductor-smoke-build.outputs.build-environment }}
       docker-image: ${{ needs.inductor-smoke-build.outputs.docker-image }}
       test-matrix: ${{ needs.inductor-smoke-build.outputs.test-matrix }}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"
@@ -206,7 +202,6 @@ jobs:
           { config: "dynamic_cpu_aot_inductor_amp_freezing_torchbench", shard: 2, num_shards: 2, runner: "linux.8xlarge.amx" },
         ]}
       build-additional-packages: "vision audio torchao"
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: cpu
@@ -222,7 +217,6 @@ jobs:
       build-environment: ${{ needs.periodic-inductor-benchmarks-cpu-build.outputs.build-environment }}
       docker-image: ${{ needs.periodic-inductor-benchmarks-cpu-build.outputs.docker-image }}
       test-matrix: ${{ needs.periodic-inductor-benchmarks-cpu-build.outputs.test-matrix }}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: cpu

--- a/.github/workflows/inductor-rocm-mi200.yml
+++ b/.github/workflows/inductor-rocm-mi200.yml
@@ -39,7 +39,6 @@ jobs:
     with:
       runner_prefix: "mt-"
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
-      use-arc: true
       build-environment: linux-jammy-rocm-py3.10-mi200
       docker-image-name: ci-image:pytorch-linux-jammy-rocm-n-py3
       test-matrix: |

--- a/.github/workflows/inductor-rocm-mi300.yml
+++ b/.github/workflows/inductor-rocm-mi300.yml
@@ -44,7 +44,6 @@ jobs:
     with:
       runner_prefix: "mt-"
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
-      use-arc: true
       build-environment: linux-noble-rocm-py3.12-mi300
       docker-image-name: ci-image:pytorch-linux-noble-rocm-n-py3
       test-matrix: |

--- a/.github/workflows/inductor-rocm-mi350.yml
+++ b/.github/workflows/inductor-rocm-mi350.yml
@@ -47,7 +47,6 @@ jobs:
     with:
       runner_prefix: "mt-"
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
-      use-arc: true
       build-environment: linux-noble-rocm-py3.12-mi350
       docker-image-name: ci-image:pytorch-linux-noble-rocm-n-py3
       test-matrix: |

--- a/.github/workflows/inductor-unittest.yml
+++ b/.github/workflows/inductor-unittest.yml
@@ -52,7 +52,6 @@ jobs:
           { config: "inductor_cpp_wrapper", shard: 1, num_shards: 2, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g5.4xlarge.nvidia.gpu" },
           { config: "inductor_cpp_wrapper", shard: 2, num_shards: 2, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g5.4xlarge.nvidia.gpu" },
         ]}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"
@@ -68,7 +67,6 @@ jobs:
       build-environment: ${{ needs.inductor-build.outputs.build-environment }}
       docker-image: ${{ needs.inductor-build.outputs.docker-image }}
       test-matrix: ${{ needs.inductor-build.outputs.test-matrix }}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"
@@ -87,7 +85,6 @@ jobs:
         { include: [
           { config: "inductor-halide", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.12xlarge" },
         ]}
-      use-arc: true
       python-version: "3.12"
       compiler: gcc11
     secrets: inherit
@@ -102,7 +99,6 @@ jobs:
       build-environment: ${{ needs.inductor-halide-build.outputs.build-environment }}
       docker-image: ${{ needs.inductor-halide-build.outputs.docker-image }}
       test-matrix: ${{ needs.inductor-halide-build.outputs.test-matrix }}
-      use-arc: true
       python-version: "3.12"
       compiler: gcc11
     secrets: inherit
@@ -120,7 +116,6 @@ jobs:
         { include: [
           { config: "inductor-triton-cpu", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.8xlarge.amx" },
         ]}
-      use-arc: true
       python-version: "3.12"
       compiler: gcc11
     secrets: inherit
@@ -135,7 +130,6 @@ jobs:
       build-environment: ${{ needs.inductor-triton-cpu-build.outputs.build-environment }}
       docker-image: ${{ needs.inductor-triton-cpu-build.outputs.docker-image }}
       test-matrix: ${{ needs.inductor-triton-cpu-build.outputs.test-matrix }}
-      use-arc: true
       python-version: "3.12"
       compiler: gcc11
     secrets: inherit
@@ -154,7 +148,6 @@ jobs:
           { config: "inductor_amx", shard: 1, num_shards: 2, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge.amx" },
           { config: "inductor_amx", shard: 2, num_shards: 2, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge.amx" },
         ]}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
     secrets: inherit
@@ -169,7 +162,6 @@ jobs:
       build-environment: ${{ needs.inductor-cpu-build.outputs.build-environment }}
       docker-image: ${{ needs.inductor-cpu-build.outputs.docker-image }}
       test-matrix: ${{ needs.inductor-cpu-build.outputs.test-matrix }}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
     secrets: inherit
@@ -191,7 +183,6 @@ jobs:
           { config: "inductor_core", shard: 1, num_shards: 2, runner: "${{ needs.get-label-type.outputs.label-type }}linux.c7i.2xlarge" },
           { config: "inductor_core", shard: 2, num_shards: 2, runner: "${{ needs.get-label-type.outputs.label-type }}linux.c7i.2xlarge" },
         ]}
-      use-arc: true
       python-version: "${{ matrix.python-version }}"
       compiler: clang18
     secrets: inherit
@@ -207,7 +198,6 @@ jobs:
       build-environment: linux-jammy-py${{ matrix.python-version }}-clang18
       docker-image: ghcr.io/pytorch/ci-image:pytorch-linux-jammy-py${{ matrix.python-version }}-clang18
       test-matrix: ${{ needs.inductor-cpu-core-build.outputs.test-matrix }}
-      use-arc: true
       python-version: "${{ matrix.python-version }}"
       compiler: clang18
     secrets: inherit

--- a/.github/workflows/inductor.yml
+++ b/.github/workflows/inductor.yml
@@ -67,7 +67,6 @@ jobs:
           { config: "inductor_torchbench", shard: 2, num_shards: 2, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g5.4xlarge.nvidia.gpu" },
         ]}
       build-additional-packages: "vision audio fbgemm torchao"
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"
@@ -84,7 +83,6 @@ jobs:
       docker-image: ${{ needs.inductor-build.outputs.docker-image }}
       test-matrix: ${{ needs.inductor-build.outputs.test-matrix }}
       enable-torch-trace: "1"
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"
@@ -109,7 +107,6 @@ jobs:
           { config: "inductor_torchbench_cpu_smoketest_perf", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.24xl.spr-metal" },
         ]}
       build-additional-packages: "vision audio torchao"
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: cpu
@@ -125,7 +122,6 @@ jobs:
       build-environment: ${{ needs.inductor-cpu-build.outputs.build-environment }}
       docker-image: ${{ needs.inductor-cpu-build.outputs.docker-image }}
       test-matrix: ${{ needs.inductor-cpu-build.outputs.test-matrix }}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: cpu

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -55,7 +55,6 @@ jobs:
       build-environment: linux-jammy-py3.10-gcc11
       docker-image-name: ci-image:pytorch-linux-jammy-py3.10-clang18
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
     secrets: inherit
@@ -72,7 +71,6 @@ jobs:
       docker-image: ${{ needs.docs-build.outputs.docker-image }}
       push: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || startsWith(github.event.ref, 'refs/tags/v') }}
       run-doxygen: true
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
     secrets:

--- a/.github/workflows/operator_benchmark.yml
+++ b/.github/workflows/operator_benchmark.yml
@@ -56,7 +56,6 @@ jobs:
         { include: [
           { config: "cpu_operator_benchmark_${{ inputs.test_mode || 'short' }}", shard: 1, num_shards: 1, runner: "linux.12xlarge" },
         ]}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: cpu
@@ -72,7 +71,6 @@ jobs:
       build-environment: ${{ needs.x86-opbenchmark-build.outputs.build-environment }}
       docker-image: ${{ needs.x86-opbenchmark-build.outputs.docker-image }}
       test-matrix: ${{ needs.x86-opbenchmark-build.outputs.test-matrix }}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: cpu
@@ -93,7 +91,6 @@ jobs:
         { include: [
           { config: "cpu_operator_benchmark_short", shard: 1, num_shards: 1, runner: "linux.arm64.m8g.4xlarge" },
         ]}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc13
       cuda-version: cpu
@@ -109,7 +106,6 @@ jobs:
       build-environment: ${{ needs.aarch64-opbenchmark-build.outputs.build-environment }}
       docker-image: ${{ needs.aarch64-opbenchmark-build.outputs.docker-image }}
       test-matrix: ${{ needs.aarch64-opbenchmark-build.outputs.test-matrix }}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc13
       cuda-version: cpu

--- a/.github/workflows/operator_microbenchmark.yml
+++ b/.github/workflows/operator_microbenchmark.yml
@@ -49,7 +49,6 @@ jobs:
           { config: "operator_microbenchmark_test", shard: 1, num_shards: 1, runner: "linux.aws.h100" },
           { config: "operator_microbenchmark_test", shard: 1, num_shards: 1, runner: "linux.aws.a100" },
         ]}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"
@@ -66,7 +65,6 @@ jobs:
       build-environment: ${{ needs.opmicrobenchmark-build.outputs.build-environment }}
       docker-image: ${{ needs.opmicrobenchmark-build.outputs.docker-image }}
       test-matrix: ${{ needs.opmicrobenchmark-build.outputs.test-matrix }}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"
@@ -89,7 +87,6 @@ jobs:
         { include: [
           { config: "operator_microbenchmark_test", shard: 1, num_shards: 1, runner: "linux.dgx.b200" },
         ]}
-      use-arc: true
       python-version: "3.12"
       compiler: gcc11
       cuda-version: "13.0"
@@ -106,7 +103,6 @@ jobs:
       build-environment: ${{ needs.opmicrobenchmark-build-b200.outputs.build-environment }}
       docker-image: ${{ needs.opmicrobenchmark-build-b200.outputs.docker-image }}
       test-matrix: ${{ needs.opmicrobenchmark-build-b200.outputs.test-matrix }}
-      use-arc: true
       python-version: "3.12"
       compiler: gcc11
       cuda-version: "13.0"

--- a/.github/workflows/operator_microbenchmark_compare.yml
+++ b/.github/workflows/operator_microbenchmark_compare.yml
@@ -95,7 +95,6 @@ jobs:
           { config: "operator_microbenchmark_${{ inputs.operator }}_test", shard: 1, num_shards: 1, runner: "linux.dgx.b200" },
           { config: "operator_microbenchmark_${{ inputs.operator }}_baseline", shard: 1, num_shards: 1, runner: "linux.dgx.b200" }
         ]}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "12.8"
@@ -113,7 +112,6 @@ jobs:
       build-environment: ${{ needs.build-b200.outputs.build-environment }}
       docker-image: ${{ needs.build-b200.outputs.docker-image }}
       test-matrix: ${{ needs.build-b200.outputs.test-matrix }}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "12.8"

--- a/.github/workflows/periodic-rocm-mi200.yml
+++ b/.github/workflows/periodic-rocm-mi200.yml
@@ -48,7 +48,6 @@ jobs:
     with:
       runner_prefix: "mt-"
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
-      use-arc: true
       build-environment: linux-jammy-rocm-py3.10-mi200
       docker-image-name: ci-image:pytorch-linux-jammy-rocm-n-py3
       test-matrix: |

--- a/.github/workflows/periodic-rocm-mi300.yml
+++ b/.github/workflows/periodic-rocm-mi300.yml
@@ -48,7 +48,6 @@ jobs:
     with:
       runner_prefix: "mt-"
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
-      use-arc: true
       build-environment: linux-noble-rocm-py3.12-mi300
       docker-image-name: ci-image:pytorch-linux-noble-rocm-n-py3
       test-matrix: |

--- a/.github/workflows/periodic-rocm-mi350.yml
+++ b/.github/workflows/periodic-rocm-mi350.yml
@@ -53,7 +53,6 @@ jobs:
     with:
       runner_prefix: "mt-"
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
-      use-arc: true
       build-environment: linux-noble-rocm-py3.12-mi350
       docker-image-name: ci-image:pytorch-linux-noble-rocm-n-py3
       test-matrix: |

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -77,7 +77,6 @@ jobs:
           { config: "multigpu", shard: 1, num_shards: 2, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g5.12xlarge.nvidia.gpu", owners: ["oncall:distributed"] },
           { config: "multigpu", shard: 2, num_shards: 2, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g5.12xlarge.nvidia.gpu", owners: ["oncall:distributed"] },
         ]}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"
@@ -94,7 +93,6 @@ jobs:
       build-environment: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-build.outputs.test-matrix }}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"
@@ -120,7 +118,6 @@ jobs:
           { config: "default", shard: 6, num_shards: 7, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g6.4xlarge.experimental.nvidia.gpu", owners: ["oncall:debug-build"] },
           { config: "default", shard: 7, num_shards: 7, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g6.4xlarge.experimental.nvidia.gpu", owners: ["oncall:debug-build"] },
         ]}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"
@@ -137,7 +134,6 @@ jobs:
       build-environment: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-debug-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-debug-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-debug-build.outputs.test-matrix }}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"
@@ -164,7 +160,6 @@ jobs:
           { config: "default", shard: 7, num_shards: 8, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g5.4xlarge.nvidia.gpu", owners: ["module:slowgradcheck"] },
           { config: "default", shard: 8, num_shards: 8, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g5.4xlarge.nvidia.gpu", owners: ["module:slowgradcheck"] },
         ]}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"
@@ -182,7 +177,6 @@ jobs:
       docker-image: ${{ needs.linux-jammy-cuda13_0-py3-gcc11-slow-gradcheck-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-cuda13_0-py3-gcc11-slow-gradcheck-build.outputs.test-matrix }}
       timeout-minutes: 300
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -100,7 +100,6 @@ jobs:
           { config: "libtorch_agnostic_targetting", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge" },
           { config: "openreg", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge" },
         ]}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
     secrets: inherit
@@ -119,7 +118,6 @@ jobs:
       docker-image: ${{ needs.linux-jammy-py3_10-gcc11-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-py3_10-gcc11-build.outputs.test-matrix }}
       tests-to-include: ${{ github.event.inputs.tests-to-include || '' }}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
     secrets: inherit
@@ -148,7 +146,6 @@ jobs:
           { config: "default", shard: 5, num_shards: 5, runner: "${{ needs.get-label-type.outputs.label-type }}linux.arm64.m8g.4xlarge" },
           { config: "openreg", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.arm64.m8g.4xlarge" },
         ]}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc13
     secrets: inherit
@@ -166,7 +163,6 @@ jobs:
       docker-image: ${{ needs.linux-jammy-aarch64-py3_10-gcc13-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-aarch64-py3_10-gcc13-build.outputs.test-matrix }}
       tests-to-include: ${{ github.event.inputs.tests-to-include || '' }}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc13
     secrets: inherit
@@ -200,7 +196,6 @@ jobs:
           { config: "einops", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge" },
           { config: "openreg", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge" },
         ]}
-      use-arc: true
       python-version: "3.14t"
       compiler: clang18
     secrets: inherit
@@ -216,7 +211,6 @@ jobs:
       build-environment: linux-jammy-py3.14t-clang18
       docker-image: ${{ needs.linux-jammy-py3_14t-clang18-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-py3_14t-clang18-build.outputs.test-matrix }}
-      use-arc: true
       python-version: "3.14t"
       compiler: clang18
     secrets: inherit
@@ -245,7 +239,6 @@ jobs:
         { include: [
           { config: "default", shard: 1, num_shards: 1 },
         ]}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
     secrets: inherit
@@ -278,7 +271,6 @@ jobs:
           { config: "default", shard: 7, num_shards: 7, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
           { config: "openreg", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
         ]}
-      use-arc: true
       python-version: "3.10"
       compiler: clang18
       # TODO (huydhn): Add this back once other workflow migrates
@@ -299,7 +291,6 @@ jobs:
       docker-image: ${{ needs.linux-jammy-py3_10-clang18-asan-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-py3_10-clang18-asan-build.outputs.test-matrix }}
       tests-to-include: ${{ github.event.inputs.tests-to-include || '' }}
-      use-arc: true
       python-version: "3.10"
       compiler: clang18
       # TODO (huydhn): Add this back once other workflow migrates
@@ -338,7 +329,6 @@ jobs:
           { config: "openreg", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge" },
           { config: "onnx", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
         ]}
-      use-arc: true
       python-version: "3.10"
       compiler: clang18
     secrets: inherit
@@ -357,7 +347,6 @@ jobs:
       docker-image: ${{ needs.linux-jammy-py3_10-clang18-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-py3_10-clang18-build.outputs.test-matrix }}
       tests-to-include: ${{ github.event.inputs.tests-to-include || '' }}
-      use-arc: true
       python-version: "3.10"
       compiler: clang18
     secrets: inherit
@@ -393,7 +382,6 @@ jobs:
           { config: "einops", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge" },
           { config: "openreg", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge" },
         ]}
-      use-arc: true
       python-version: "3.14"
       compiler: clang18
     secrets: inherit
@@ -411,7 +399,6 @@ jobs:
       docker-image: ${{ needs.linux-jammy-py3_14-clang18-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-py3_14-clang18-build.outputs.test-matrix }}
       tests-to-include: ${{ github.event.inputs.tests-to-include || '' }}
-      use-arc: true
       python-version: "3.14"
       compiler: clang18
     secrets: inherit
@@ -436,7 +423,6 @@ jobs:
         { include: [
           { config: "default", shard: 1, num_shards: 1 },
         ]}
-      use-arc: true
       python-version: "3.10"
       compiler: clang18
       cuda-version: "13.0"
@@ -463,7 +449,6 @@ jobs:
         { include: [
           { config: "default", shard: 1, num_shards: 1 },
         ]}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
     secrets: inherit
@@ -487,7 +472,6 @@ jobs:
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
       # TODO (huydhn): Add this back once other workflow migrates
       # sync-tag: rocm-build
-      use-arc: true
       python-version: "3.10"
     secrets: inherit
 
@@ -515,7 +499,6 @@ jobs:
           { config: "default", shard: 3, num_shards: 4, runner: "linux.idc.xpu" },
           { config: "default", shard: 4, num_shards: 4, runner: "linux.idc.xpu" },
         ]}
-      use-arc: true
       python-version: "3.10"
     secrets: inherit
 
@@ -536,7 +519,6 @@ jobs:
         { include: [
           { config: "dynamo_cpython", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.c7i.2xlarge" },
         ]}
-      use-arc: true
       python-version: "3.13"
       compiler: clang18
     secrets: inherit
@@ -549,7 +531,6 @@ jobs:
       build-environment: linux-jammy-py3.13-clang18
       docker-image: ${{ needs.dynamo-cpython-build.outputs.docker-image }}
       test-matrix: ${{ needs.dynamo-cpython-build.outputs.test-matrix }}
-      use-arc: true
       python-version: "3.13"
       compiler: clang18
     secrets: inherit

--- a/.github/workflows/riscv64.yml
+++ b/.github/workflows/riscv64.yml
@@ -39,7 +39,6 @@ jobs:
       docker-image-name: ci-image:pytorch-linux-noble-riscv64-py3.12-gcc14-cross-build
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
       runner: linux.c7i.2xlarge
-      use-arc: true
       python-version: "3.12"
       compiler: gcc14
       cuda-version: cpu

--- a/.github/workflows/rocm-mi200.yml
+++ b/.github/workflows/rocm-mi200.yml
@@ -48,7 +48,6 @@ jobs:
     with:
       runner_prefix: "mt-"
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
-      use-arc: true
       build-environment: linux-jammy-rocm-py3.10-mi200
       docker-image-name: ci-image:pytorch-linux-jammy-rocm-n-py3
       sync-tag: rocm-build

--- a/.github/workflows/rocm-mi300.yml
+++ b/.github/workflows/rocm-mi300.yml
@@ -44,7 +44,6 @@ jobs:
     with:
       runner_prefix: "mt-"
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
-      use-arc: true
       build-environment: linux-noble-rocm-py3.12-mi300
       docker-image-name: ci-image:pytorch-linux-noble-rocm-n-py3
       test-matrix: |

--- a/.github/workflows/rocm-mi350.yml
+++ b/.github/workflows/rocm-mi350.yml
@@ -46,7 +46,6 @@ jobs:
     with:
       runner_prefix: "mt-"
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
-      use-arc: true
       build-environment: linux-noble-rocm-py3.12-mi350
       docker-image-name: ci-image:pytorch-linux-noble-rocm-n-py3
       test-matrix: |

--- a/.github/workflows/rocm-navi31.yml
+++ b/.github/workflows/rocm-navi31.yml
@@ -45,7 +45,6 @@ jobs:
     with:
       runner_prefix: "mt-"
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
-      use-arc: true
       build-environment: linux-jammy-rocm-py3.10-navi31
       docker-image-name: ci-image:pytorch-linux-jammy-rocm-n-py3
       sync-tag: rocm-build

--- a/.github/workflows/rocm-nightly.yml
+++ b/.github/workflows/rocm-nightly.yml
@@ -45,7 +45,6 @@ jobs:
     with:
       runner_prefix: "mt-"
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
-      use-arc: true
       build-environment: linux-noble-rocm-nightly-py3.12-gfx942
       docker-image-name: ci-image:pytorch-linux-noble-rocm-nightly-py3
       test-matrix: |

--- a/.github/workflows/slow-rocm-mi200.yml
+++ b/.github/workflows/slow-rocm-mi200.yml
@@ -52,7 +52,6 @@ jobs:
     with:
       runner_prefix: "mt-"
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
-      use-arc: true
       build-environment: linux-jammy-rocm-py3.10-mi200
       docker-image-name: ci-image:pytorch-linux-jammy-rocm-n-py3
       sync-tag: rocm-build

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -62,7 +62,6 @@ jobs:
           { config: "slow", shard: 2, num_shards: 3, runner: "linux.g5.4xlarge.nvidia.gpu" },
           { config: "slow", shard: 3, num_shards: 3, runner: "linux.g5.4xlarge.nvidia.gpu" },
         ]}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"
@@ -79,7 +78,6 @@ jobs:
       build-environment: linux-jammy-cuda13.0-py3.10-gcc11-sm86
       docker-image: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm86-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm86-build.outputs.test-matrix }}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"
@@ -99,7 +97,6 @@ jobs:
           { config: "slow", shard: 1, num_shards: 2, runner: "linux.2xlarge" },
           { config: "slow", shard: 2, num_shards: 2, runner: "linux.2xlarge" },
         ]}
-      use-arc: true
       python-version: "3.10"
       compiler: clang18
     secrets: inherit
@@ -115,7 +112,6 @@ jobs:
       build-environment: ${{ needs.linux-jammy-py3_10-clang18-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-py3_10-clang18-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-py3_10-clang18-build.outputs.test-matrix }}
-      use-arc: true
       python-version: "3.10"
       compiler: clang18
     secrets: inherit
@@ -137,7 +133,6 @@ jobs:
           { config: "slow", shard: 3, num_shards: 3, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
         ]}
       sync-tag: asan-build
-      use-arc: true
       python-version: "3.10"
       compiler: clang18
     secrets: inherit
@@ -154,7 +149,6 @@ jobs:
       docker-image: ${{ needs.linux-jammy-py3_10-clang18-asan-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-py3_10-clang18-asan-build.outputs.test-matrix }}
       sync-tag: asan-test
-      use-arc: true
       python-version: "3.10"
       compiler: clang18
     secrets: inherit

--- a/.github/workflows/test-b200.yml
+++ b/.github/workflows/test-b200.yml
@@ -67,7 +67,6 @@ jobs:
           { config: "smoke_b200", shard: 1, num_shards: 1, runner: "linux.dgx.b200" },
         ]}
       # config: "smoke_b200" maps to test_python_smoke_b200() in .ci/pytorch/test.sh
-      use-arc: true
       python-version: "3.12"
       compiler: gcc11
       cuda-version: "13.0"
@@ -83,7 +82,6 @@ jobs:
       build-environment: ${{ needs.linux-jammy-cuda13_0-py3_12-gcc11-sm100-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-cuda13_0-py3_12-gcc11-sm100-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-cuda13_0-py3_12-gcc11-sm100-build.outputs.test-matrix }}
-      use-arc: true
       python-version: "3.12"
       compiler: gcc11
       cuda-version: "13.0"

--- a/.github/workflows/test-h100.yml
+++ b/.github/workflows/test-h100.yml
@@ -52,7 +52,6 @@ jobs:
         { include: [
           { config: "smoke", shard: 1, num_shards: 1, runner: "linux.aws.h100" },
         ]}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"
@@ -68,7 +67,6 @@ jobs:
       build-environment: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm90-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm90-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm90-build.outputs.test-matrix }}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"
@@ -85,7 +83,6 @@ jobs:
       docker-image: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm90-build.outputs.docker-image }}
       timeout-minutes: 30
       s3-bucket: gha-artifacts
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"

--- a/.github/workflows/torchtitan.yml
+++ b/.github/workflows/torchtitan.yml
@@ -71,7 +71,6 @@ jobs:
           { config: "torchtitan_features_integration", shard: 1, num_shards: 1, runner: "linux.g5.48xlarge.nvidia.gpu" },
           { config: "torchtitan_models_integration", shard: 1, num_shards: 1, runner: "linux.g5.48xlarge.nvidia.gpu" }
         ]}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: ${{ needs.get-cuda-version.outputs.stable-cuda }}
@@ -88,7 +87,6 @@ jobs:
       build-environment: linux-jammy-cuda${{ needs.get-cuda-version.outputs.stable-cuda }}-py3-gcc11
       docker-image: ${{ needs.build.outputs.docker-image }}
       test-matrix: ${{ needs.build.outputs.test-matrix }}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: ${{ needs.get-cuda-version.outputs.stable-cuda }}

--- a/.github/workflows/trunk-rocm-sandbox.yml
+++ b/.github/workflows/trunk-rocm-sandbox.yml
@@ -47,7 +47,6 @@ jobs:
     with:
       runner_prefix: "mt-"
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
-      use-arc: true
       build-environment: linux-jammy-rocm-py3.10
       docker-image-name: ci-image:pytorch-linux-jammy-rocm-n-py3
       sync-tag: rocm-build

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -84,7 +84,6 @@ jobs:
         { include: [
           { config: "default", shard: 1, num_shards: 1 },
         ]}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"
@@ -115,7 +114,6 @@ jobs:
           { config: "distributed", shard: 3, num_shards: 3, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g4dn.12xlarge.nvidia.gpu" },
           { config: "pr_time_benchmarks", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g4dn.metal.nvidia.gpu" },
         ]}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"
@@ -136,7 +134,6 @@ jobs:
       docker-image: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-build.outputs.test-matrix }}
       tests-to-include: ${{ github.event.inputs.tests-to-include || '' }}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"
@@ -163,7 +160,6 @@ jobs:
           { config: "aoti_cross_compile_for_windows", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}l-x86aavx2-29-113-l4", win_torch_wheel_artifact: "win-vs2022-cuda13.0-py3" },
         ]}
       tests-to-include: ${{ github.event.inputs.tests-to-include || '' }}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"
@@ -187,7 +183,6 @@ jobs:
         { include: [
           { config: "default", shard: 1, num_shards: 1 },
         ]}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"
@@ -314,7 +309,6 @@ jobs:
           { config: "distributed", shard: 2, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.2" },
           { config: "distributed", shard: 3, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.2" },
         ]}
-      use-arc: true
       python-version: "3.10"
     secrets: inherit
 
@@ -345,7 +339,6 @@ jobs:
       docker-image-name: ci-image:pytorch-linux-jammy-cuda13.0-cudnn9-py3-gcc11-inductor-benchmarks
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
       cuda-arch-list: '8.0'
-      use-arc: true
       python-version: "3.12"
       compiler: gcc11
       cuda-version: "13.0"
@@ -367,7 +360,6 @@ jobs:
         { include: [
           { config: "verify_cachebench", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge" },
         ]}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
     secrets: inherit
@@ -386,7 +378,6 @@ jobs:
       docker-image: ${{ needs.verify-cachebench-cpu-build.outputs.docker-image }}
       test-matrix: ${{ needs.verify-cachebench-cpu-build.outputs.test-matrix }}
       tests-to-include: ${{ github.event.inputs.tests-to-include || '' }}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
     secrets: inherit
@@ -404,7 +395,6 @@ jobs:
       build-environment: linux-jammy-py3.10-gcc11-full-debug-build-only
       docker-image-name: ci-image:pytorch-linux-jammy-py3.10-clang18
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc11
     secrets: inherit
@@ -428,7 +418,6 @@ jobs:
           { config: "default", shard: 4, num_shards: 5, runner: "${{ needs.get-label-type.outputs.label-type }}linux.arm64.m7g.4xlarge" },
           { config: "default", shard: 5, num_shards: 5, runner: "${{ needs.get-label-type.outputs.label-type }}linux.arm64.m7g.4xlarge" },
         ]}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc13
     secrets: inherit
@@ -443,7 +432,6 @@ jobs:
       build-environment: ${{ needs.linux-jammy-aarch64-py3_10-gcc13-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-aarch64-py3_10-gcc13-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-aarch64-py3_10-gcc13-build.outputs.test-matrix }}
-      use-arc: true
       python-version: "3.10"
       compiler: gcc13
     secrets: inherit

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -42,7 +42,6 @@ jobs:
         { include: [
           { config: "tsan", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge" },
         ]}
-      use-arc: true
       python-version: "3.14t"
       compiler: clang18
     secrets: inherit
@@ -57,7 +56,6 @@ jobs:
       build-environment: linux-jammy-py3.14t-clang18-tsan
       docker-image: ${{ needs.linux-jammy-py3_14t-clang18-tsan-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-py3_14t-clang18-tsan-build.outputs.test-matrix }}
-      use-arc: true
       python-version: "3.14t"
       compiler: clang18
     secrets: inherit

--- a/.github/workflows/xpu.yml
+++ b/.github/workflows/xpu.yml
@@ -43,7 +43,6 @@ jobs:
       docker-image-name: ci-image:pytorch-linux-jammy-xpu-n-1-py3
       runner: l-x86iavx512-48-384
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
-      use-arc: true
       test-matrix: |
         { include: [
           { config: "default", shard: 1, num_shards: 6, runner: "linux.idc.xpu" },
@@ -66,7 +65,6 @@ jobs:
       docker-image-name: ci-image:pytorch-linux-noble-xpu-n-py3
       runner: l-x86iavx512-48-384
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
-      use-arc: true
       test-matrix: |
         { include: [
           { config: "default", shard: 1, num_shards: 12, runner: "linux.idc.xpu" },
@@ -105,7 +103,6 @@ jobs:
       docker-image-name: ci-image:pytorch-linux-noble-xpu-n-py3-client
       runner: l-x86iavx512-48-384
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
-      use-arc: true
       test-matrix: |
         { include: [
           { config: "smoke_xpu", shard: 1, num_shards: 1, runner: "linux.client.xpu" },


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189171
* #189170
* #189169

With every EC2 path now deleted, use-arc no longer selects between two
jobs in _linux-build, _linux-test, _docs, and _linux-test-stable-fa3 -- it
is always the OSDC/ARC job. Drop the input from those four reusable
workflows, drop the now-constant `&& inputs.use-arc` job guards (the
surviving job runs unconditionally for the pytorch org), and strip
`use-arc: true` from every call site that targeted them (~150 lines across
the caller workflows).

The runner-mapping logic is unaffected: the runs-on label expression and
the map_ec2_to_arc.py step were never gated on use-arc; they are intrinsic
to the OSDC job and keep running as before.

The `use-arc` input on the setup-linux composite action is intentionally
kept (it still gates real setup steps and defaults to the EC2 path), so the
`use-arc: true` passed to setup-linux is preserved. Fully retiring that,
plus the dead use-arc output on _runner-determinator, is left for a
follow-up.

Authored with the assistance of Claude Code.