### PR TITLE
Fix protobuf resource-compiler build with clang-cl (RC1106 /bigobj)

### DIFF
--- a/cmake/ProtoBuf.cmake
+++ b/cmake/ProtoBuf.cmake
@@ -33,6 +33,20 @@ macro(custom_protobuf_find)
   set(__caffe2_CMAKE_POSITION_INDEPENDENT_CODE ${CMAKE_POSITION_INDEPENDENT_CODE})
   set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+  # protobuf's CMakeLists.txt injects compiler-only flags (e.g. /bigobj, /utf-8)
+  # via add_definitions(), which CMake also applies to the resource compiler.
+  # protobuf works around this by overriding CMAKE_RC_COMPILE_OBJECT to drop the
+  # compile <FLAGS>, but only when CMAKE_CXX_COMPILER_ID STREQUAL "MSVC". With
+  # clang-cl the id is "Clang" (while MSVC stays true), so the workaround is
+  # skipped and rc.exe fails with "RC1106 invalid option: /bigobj". Install the
+  # same override for the clang-cl case, restoring it afterwards.
+  set(__caffe2_CMAKE_RC_COMPILE_OBJECT "${CMAKE_RC_COMPILE_OBJECT}")
+  if(MSVC AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    enable_language(RC)
+    set(CMAKE_RC_COMPILE_OBJECT
+        "<CMAKE_RC_COMPILER> /l0x409 <DEFINES> /fo<OBJECT> <SOURCE>")
+  endif()
+
   if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0.0")
     message(WARNING "Ancient protobuf forces CMake compatibility")
     set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
@@ -41,6 +55,8 @@ macro(custom_protobuf_find)
   else()
     add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../third_party/protobuf/cmake)
   endif()
+
+  set(CMAKE_RC_COMPILE_OBJECT "${__caffe2_CMAKE_RC_COMPILE_OBJECT}")
 
   set(CMAKE_POSITION_INDEPENDENT_CODE ${__caffe2_CMAKE_POSITION_INDEPENDENT_CODE})
 

--- a/cmake/ProtoBuf.cmake
+++ b/cmake/ProtoBuf.cmake
@@ -44,7 +44,7 @@ macro(custom_protobuf_find)
   if(MSVC AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     enable_language(RC)
     set(CMAKE_RC_COMPILE_OBJECT
-        "<CMAKE_RC_COMPILER> /l0x409 <DEFINES> /fo<OBJECT> <SOURCE>")
+        "<CMAKE_RC_COMPILER> /l0x409 <DEFINES> /fo<OBJECT> <SOURCE>")  # codespell:ignore fo
   endif()
 
   if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0.0")


### PR DESCRIPTION
## Summary

Building PyTorch on Windows with `clang-cl` (e.g. `CC=CXX=clang-cl`) and the
default `BUILD_CUSTOM_PROTOBUF=ON` fails while compiling protobuf's
`version.rc`:fatal error RC1106: invalid option: /bigobj

`/bigobj` is a C/C++ compiler flag that the Windows resource compiler
(`rc.exe`) does not understand.

## Root cause

protobuf's `CMakeLists.txt` adds compiler-only flags such as `/bigobj` and
`/utf-8` via `add_definitions()`, which CMake also applies to the RC language.
protobuf guards against this by overriding `CMAKE_RC_COMPILE_OBJECT` to drop the
compile `<FLAGS>` — but only when `CMAKE_CXX_COMPILER_ID STREQUAL "MSVC"`.

Under `clang-cl` the compiler id is `"Clang"` (while the `MSVC` CMake variable
stays true, since clang-cl uses the MSVC frontend/ABI), so protobuf's workaround
is skipped and `/bigobj` leaks through to `rc.exe`.

This surfaced after #188927 bumped the protobuf submodule from 3.13.0.1 to
21.12. In the old pin the RC workaround was unconditional inside `if(MSVC)`, so
it also covered clang-cl; the newer protobuf narrowed it to the `MSVC`-id case.

## Fix

In `custom_protobuf_find()` (`cmake/ProtoBuf.cmake`), install the same
`CMAKE_RC_COMPILE_OBJECT` override for the clang-cl case
(`MSVC AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC"`) before adding the
protobuf subdirectory, and restore the previous value afterwards. The override
is scoped to the protobuf subbuild; plain MSVC (`cl.exe`) builds already hit
protobuf's built-in workaround and are unaffected.

## Why fix this in PyTorch and not protobuf

The offending global `add_definitions(/bigobj)` and the narrow RC workaround
only exist in protobuf v21.12 (the pinned version); protobuf `main` has already
removed this block entirely. Since PyTorch intentionally pins 21.12 (last
Abseil-free release) and won't receive a backport, the fix belongs in PyTorch's
own protobuf integration layer rather than as a patch to the vendored submodule.

## Test plan

- Windows build with `CC=CXX=clang-cl` and `BUILD_CUSTOM_PROTOBUF=ON` (the
  ROCm Windows wheel configuration) now compiles `version.rc` and links
  protobuf successfully.
- Standard MSVC (`cl.exe`) Windows build is unchanged.

Fixes the Windows nightly failure reported in ROCm/TheRock#6354.