### PR TITLE
Fix dcp privateuse1 stream support

### DIFF
--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -157,9 +157,7 @@ class _OverlappingCpuLoader(_TensorLoader):
             stream.device_type if stream else _get_available_device_type()
         )
         self.device_module = _get_device_module(self.device_type)
-        self.stream = cast(
-            torch.cuda.Stream, stream or self.device_module.current_stream()
-        )
+        self.stream = stream or self.device_module.current_stream()
         if self.stream != self.device_module.current_stream():
             self.stream.wait_stream(self.device_module.current_stream())
 
@@ -388,18 +386,19 @@ def _write_files_from_queue(
             file_name, storage_key, write_items = file_queue.get_nowait()
             loader: _TensorLoader
 
-            custom_backend_name = torch._C._get_privateuse1_backend_name()
-            custom_device_mod = getattr(torch, custom_backend_name, None)
+            device_type = _get_available_device_type()
+            if device_type is not None:
+                device_mod = _get_device_module(device_type)
+                has_stream_support = hasattr(device_mod, "current_stream")
+            else:
+                has_stream_support = False
 
             # TODO: Using the OverlappingCpuLoader with multiple threads creates significant
             # performance degradation, observed as being related to cuda stream syncs. We
             # should try to fix this and use _OverlappingCpuLoader for all threaded cases
             if (
                 thread_count == 1
-                and (
-                    torch.cuda.is_available()
-                    or (custom_device_mod and custom_device_mod.is_available())
-                )
+                and has_stream_support
                 and inflight_threshhold > 0
             ):
                 loader = _OverlappingCpuLoader(

--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -396,11 +396,7 @@ def _write_files_from_queue(
             # TODO: Using the OverlappingCpuLoader with multiple threads creates significant
             # performance degradation, observed as being related to cuda stream syncs. We
             # should try to fix this and use _OverlappingCpuLoader for all threaded cases
-            if (
-                thread_count == 1
-                and has_stream_support
-                and inflight_threshhold > 0
-            ):
+            if thread_count == 1 and has_stream_support and inflight_threshhold > 0:
                 loader = _OverlappingCpuLoader(
                     planner.resolve_data,
                     inflight_threshhold=inflight_threshhold,

--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -157,7 +157,7 @@ class _OverlappingCpuLoader(_TensorLoader):
             stream.device_type if stream else _get_available_device_type()
         )
         self.device_module = _get_device_module(self.device_type)
-        self.stream = stream or self.device_module.current_stream()
+        self.stream = cast(torch.Stream, stream or self.device_module.current_stream())
         if self.stream != self.device_module.current_stream():
             self.stream.wait_stream(self.device_module.current_stream())
 
@@ -382,16 +382,18 @@ def _write_files_from_queue(
     serialization_format: SerializationFormat,
 ) -> None:
     try:
+        device_type = _get_available_device_type()
+        if device_type is not None:
+            device_mod = _get_device_module(device_type)
+            has_stream_support = hasattr(device_mod, "current_stream") and hasattr(
+                device_mod, "stream"
+            )
+        else:
+            has_stream_support = False
+
         while True:
             file_name, storage_key, write_items = file_queue.get_nowait()
             loader: _TensorLoader
-
-            device_type = _get_available_device_type()
-            if device_type is not None:
-                device_mod = _get_device_module(device_type)
-                has_stream_support = hasattr(device_mod, "current_stream")
-            else:
-                has_stream_support = False
 
             # TODO: Using the OverlappingCpuLoader with multiple threads creates significant
             # performance degradation, observed as being related to cuda stream syncs. We


### PR DESCRIPTION
Fixes: #165097
### Summary:

- Replace hardcoded CUDA/PrivateUse1 availability checks in `_write_files_from_queue` with generic `_get_available_device_type()` and a `hasattr(device_mod, "current_stream")` capability.