### PR TITLE
[inductor] Drop unused cache_info from CacheCompiledArtifact._validate_and_unpack

### DIFF
--- a/torch/_inductor/standalone_compile.py
+++ b/torch/_inductor/standalone_compile.py
@@ -145,8 +145,8 @@ class CacheCompiledArtifact(CompiledArtifact):
         # (we only expect one)
         return len(cache_info.aot_autograd_artifacts) == 1
 
-    def _validate_and_unpack(self) -> tuple[bytes, CacheInfo, str]:
-        """Validate the cached artifact, returning ``(artifact_bytes, cache_info, key)``.
+    def _validate_and_unpack(self) -> tuple[bytes, str]:
+        """Validate the cached artifact, returning ``(artifact_bytes, key)``.
 
         Single source of the None / empty / multiple aot_autograd_artifacts checks,
         shared by ``_to_binary_bytes`` and ``save``'s unpacked branch. Messages are
@@ -168,7 +168,7 @@ class CacheCompiledArtifact(CompiledArtifact):
                 f"CompiledArtifact has more than one aot_autograd artifact but we only "
                 f"expected one. {cache_info}"
             )
-        return artifact_bytes, cache_info, cache_info.aot_autograd_artifacts[0]
+        return artifact_bytes, cache_info.aot_autograd_artifacts[0]
 
     def _to_binary_bytes(self) -> bytes:
         """Serialize this artifact to the in-memory ``binary`` byte format.
@@ -179,7 +179,7 @@ class CacheCompiledArtifact(CompiledArtifact):
         ``load(format="binary")`` reads back: header, ``torch_key``, the autograd-cache
         ``key`` string, then the opaque ``artifact_bytes``.
         """
-        artifact_bytes, _cache_info, key = self._validate_and_unpack()
+        artifact_bytes, key = self._validate_and_unpack()
 
         from torch.utils._appending_byte_serializer import BytesWriter
 
@@ -212,7 +212,7 @@ class CacheCompiledArtifact(CompiledArtifact):
                     raise AssertionError(f"expected format == 'unpacked', got {format}")
                 # Same None / empty / multiple validation as the binary branch, shared via
                 # _validate_and_unpack; the unpacked branch needs only artifact_bytes.
-                artifact_bytes, _cache_info, _key = self._validate_and_unpack()
+                artifact_bytes, _key = self._validate_and_unpack()
                 if os.path.exists(path):
                     if not os.path.isdir(path):
                         raise AssertionError(f"expected path to be a dir: {path}")


### PR DESCRIPTION
Addresses review feedback on #188377.

`CacheCompiledArtifact._validate_and_unpack` returned `(artifact_bytes, cache_info, key)`, but the middle `cache_info` element was discarded at both call sites: `_to_binary_bytes` needs only `key`, and `save`'s unpacked branch needs only `artifact_bytes`. This narrows the return to `(artifact_bytes, key)` and updates the two callers plus the docstring, so the tuple no longer exposes a value no caller consumes.

Test Plan:

```
python test/inductor/test_codecache.py \
    TestStandaloneCompile.test_is_saveable \
    TestStandaloneCompile.test_save_in_new_path \
    TestStandaloneCompile.test_save_training_artifact_compiles_backward \
    TestStandaloneCompile.test_modify_unpacked_file_device_cpu \
    TestStandaloneCompile.test_modify_unpacked_file_device_cuda
lintrunner --take PYFMT,RUFF,PYREFLY,CODESPELL,FLAKE8 -a
```

All pass: the binary save path (via `_to_binary_bytes`) and the unpacked save branch both exercise the narrowed helper.

Authored with an AI assistant.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo