### PR TITLE
Add PyTorch AI policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank.md
+++ b/.github/ISSUE_TEMPLATE/blank.md
@@ -6,4 +6,4 @@ labels: ''
 assignees: ''
 ---
 
-**Before submitting, please review the [contribution guide](https://github.com/pytorch/pytorch/wiki/The-Ultimate-Guide-to-PyTorch-Contributions) and [AI-Assisted Development](https://github.com/pytorch/pytorch/blob/main/CONTRIBUTING.md#ai-assisted-development) policy. Issues that do not follow these practices will be automatically closed and users breaking these rules repeatedly may be banned.**
+**Before submitting, please review the [contribution guide](https://github.com/pytorch/pytorch/wiki/The-Ultimate-Guide-to-PyTorch-Contributions) and [AI-Assisted Development](https://github.com/pytorch/pytorch/blob/main/AI_POLICY.md) policy. Issues that do not follow these practices will be automatically closed and users breaking these rules repeatedly may be banned.**

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -5,7 +5,7 @@ body:
 - type: markdown
   attributes:
     value: >
-      #### Before submitting, please review the [contribution guide](https://github.com/pytorch/pytorch/wiki/The-Ultimate-Guide-to-PyTorch-Contributions) and [AI-Assisted Development](https://github.com/pytorch/pytorch/blob/main/CONTRIBUTING.md#ai-assisted-development) policy. Issues that do not follow these practices will be automatically closed and users breaking these rules repeatedly may be banned.
+      #### Before submitting, please review the [contribution guide](https://github.com/pytorch/pytorch/wiki/The-Ultimate-Guide-to-PyTorch-Contributions) and [AI-Assisted Development](https://github.com/pytorch/pytorch/blob/main/AI_POLICY.md) policy. Issues that do not follow these practices will be automatically closed and users breaking these rules repeatedly may be banned.
 - type: markdown
   attributes:
     value: >

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -5,7 +5,7 @@ body:
 - type: markdown
   attributes:
     value: >
-      #### Before submitting, please review the [contribution guide](https://github.com/pytorch/pytorch/wiki/The-Ultimate-Guide-to-PyTorch-Contributions) and [AI-Assisted Development](https://github.com/pytorch/pytorch/blob/main/CONTRIBUTING.md#ai-assisted-development) policy. Issues that do not follow these practices will be automatically closed and users breaking these rules repeatedly may be banned.
+      #### Before submitting, please review the [contribution guide](https://github.com/pytorch/pytorch/wiki/The-Ultimate-Guide-to-PyTorch-Contributions) and [AI-Assisted Development](https://github.com/pytorch/pytorch/blob/main/AI_POLICY.md) policy. Issues that do not follow these practices will be automatically closed and users breaking these rules repeatedly may be banned.
 - type: markdown
   attributes:
     value: >

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -5,7 +5,7 @@ body:
 - type: markdown
   attributes:
     value: >
-      #### Before submitting, please review the [contribution guide](https://github.com/pytorch/pytorch/wiki/The-Ultimate-Guide-to-PyTorch-Contributions) and [AI-Assisted Development](https://github.com/pytorch/pytorch/blob/main/CONTRIBUTING.md#ai-assisted-development) policy. Issues that do not follow these practices will be automatically closed and users breaking these rules repeatedly may be banned.
+      #### Before submitting, please review the [contribution guide](https://github.com/pytorch/pytorch/wiki/The-Ultimate-Guide-to-PyTorch-Contributions) and [AI-Assisted Development](https://github.com/pytorch/pytorch/blob/main/AI_POLICY.md) policy. Issues that do not follow these practices will be automatically closed and users breaking these rules repeatedly may be banned.
 - type: markdown
   attributes:
     value: >

--- a/.github/ISSUE_TEMPLATE/pt2-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/pt2-bug-report.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: >
-        #### Before submitting, please review the [contribution guide](https://github.com/pytorch/pytorch/wiki/The-Ultimate-Guide-to-PyTorch-Contributions) and [AI-Assisted Development](https://github.com/pytorch/pytorch/blob/main/CONTRIBUTING.md#ai-assisted-development) policy. Issues that do not follow these practices will be automatically closed and users breaking these rules repeatedly may be banned.
+        #### Before submitting, please review the [contribution guide](https://github.com/pytorch/pytorch/wiki/The-Ultimate-Guide-to-PyTorch-Contributions) and [AI-Assisted Development](https://github.com/pytorch/pytorch/blob/main/AI_POLICY.md) policy. Issues that do not follow these practices will be automatically closed and users breaking these rules repeatedly may be banned.
   - type: markdown
     attributes:
       value: >

--- a/.github/PULL_REQUEST_TEMPLATE/docs_typo.md
+++ b/.github/PULL_REQUEST_TEMPLATE/docs_typo.md
@@ -4,7 +4,7 @@
 
 Before submitting, please review:
 - [The Ultimate Guide to PyTorch Contributions](https://github.com/pytorch/pytorch/wiki/The-Ultimate-Guide-to-PyTorch-Contributions#getting-started-with-pull-requests)
-- [AI-Assisted Development](CONTRIBUTING.md#ai-assisted-development) policy
+- [AI-Assisted Development](https://github.com/pytorch/pytorch/blob/main/AI_POLICY.md) policy
 
 ---
 

--- a/.github/PULL_REQUEST_TEMPLATE/fix_issue.md
+++ b/.github/PULL_REQUEST_TEMPLATE/fix_issue.md
@@ -2,7 +2,7 @@
 
 Before submitting, please review:
 - [The Ultimate Guide to PyTorch Contributions](https://github.com/pytorch/pytorch/wiki/The-Ultimate-Guide-to-PyTorch-Contributions#getting-started-with-pull-requests)
-- [AI-Assisted Development](https://github.com/pytorch/pytorch/blob/main/CONTRIBUTING.md#ai-assisted-development) policy
+- [AI-Assisted Development](https://github.com/pytorch/pytorch/blob/main/AI_POLICY.md) policy
 
 ---
 

--- a/.github/PULL_REQUEST_TEMPLATE/preapproved.md
+++ b/.github/PULL_REQUEST_TEMPLATE/preapproved.md
@@ -2,7 +2,7 @@
 
 Before submitting, please review:
 - [The Ultimate Guide to PyTorch Contributions](https://github.com/pytorch/pytorch/wiki/The-Ultimate-Guide-to-PyTorch-Contributions#getting-started-with-pull-requests)
-- [AI-Assisted Development](CONTRIBUTING.md#ai-assisted-development) policy
+- [AI-Assisted Development](https://github.com/pytorch/pytorch/blob/main/AI_POLICY.md) policy
 
 ---
 

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,10 +1,10 @@
 We support the use of AI tools to help prepare issues, pull
-requests, reviews, or comments. We expect everyone to be responsible for
-anything they submit, including anything written with AI assistance.
+requests, reviews, or comments. We expect everyone interacting with
+this repo to follow the below policy whenever they use AI tools.
 
 *AI-generated content in comments, issues, or PRs must be clearly disclosed and
 contained* (e.g. using a code block or a quote block). AI-generated content must
-be accompanied by human commentary explaining their relevance. For example:
+be accompanied by human commentary explaining its relevance. For example:
 "Codex produced the following analysis: `<insert codex output here>`, so I
 believe that \<insert human analysis here\>". The only exceptions to this rule
 are the pytorchbot automations.

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,5 +1,5 @@
-We are supportive to contributors using AI tools to help prepare issues, pull
-requests, reviews, or comments. We expect contributors to be responsible for
+We support the use of AI tools to help prepare issues, pull
+requests, reviews, or comments. We expect everyone to be responsible for
 anything they submit, including anything written with AI assistance.
 
 *AI-generated content in comments, issues, or PRs must be clearly disclosed and

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,30 @@
+We are supportive to contributors using AI tools to help prepare issues, pull
+requests, reviews, or comments. We expect contributors to be responsible for
+anything they submit, including anything written with AI assistance.
+
+*AI-generated content in comments, issues, or PRs must be clearly disclosed and
+contained* (e.g. using a code block or a quote block). AI-generated content must
+be accompanied by human commentary explaining their relevance. For example:
+"Codex produced the following analysis: `<insert codex output here>`, so I
+believe that \<insert human analysis here\>". The only exceptions to this rule
+are the pytorchbot automations.
+
+*Please do not respond to comments+questions by pasting raw or lightly reviewed
+AI-generated text.* Other users' comments+questions are requests for your
+understanding, reasoning, and judgment. Unreviewed AI output shifts the burden of
+verification onto the other party and can make discussions slower, noisier, or
+misleading.
+
+*For pull requests, please carefully read the code before submitting it for
+review*, especially if AI tools helped write or rewrite it. Make sure the
+implementation is something you understand, that the important ideas are clear,
+and that the code is high quality. AI-generated code can sometimes be overly
+complex, indirect, inconsistent, or include artifacts that obscure the main idea.
+Before submitting, simplify where possible and make sure the core change is easy
+for maintainers to review. If your PR is not ready for review, please use the
+GitHub draft PR feature.
+
+All contributions should involve a human who understands and can take
+responsibility for the work produced with AI assistance. *We do not accept
+contributions created by fully autonomous agents*, and we may close pull requests
+that appear to have been generated without meaningful human involvement.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -280,9 +280,14 @@ dependencies as well as the nightly binaries into the repo directory.
 
 ## AI-Assisted Development
 
-Please see PyTorch's [AI Policy here](AI_POLICY.md).
+Please see PyTorch's detailed [AI Policy here](AI_POLICY.md).
 
 All the details on how to contribute (with or without AI assistance) are in the [Ultimate Guide to PyTorch Contributions](https://github.com/pytorch/pytorch/wiki/The-Ultimate-Guide-to-PyTorch-Contributions).
+A couple reminders here though:
+
+- **You are personally responsible for what you send**: If the comments, issues or PRs you send are low quality or consistently overly verbose compared to what is expected, your contributions will not be accepted anymore. You are responsible for reviewing, ensuring the accuracy and the quality of everything you send.
+- **PRs must have an associated "actionable" Issue**: Generally, as a new contributor, you should never send a PR that doesn't have a corresponding issue with the "actionable" label. If you just opened the issue, you must wait for a maintainer to review it and mark it actionable before preparing and sending a PR for it.
+- **New features, utility functions, or core extensions**: Create a short and to the point issue about the problem you're encountering. You should NEVER include AI-generated explanation of how to solve the problem (this will be discussed later once it's decided the feature should be implemented).
 
 ## Spin
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -280,18 +280,9 @@ dependencies as well as the nightly binaries into the repo directory.
 
 ## AI-Assisted Development
 
-PyTorch is a project developed and reviewed by humans.
-PyTorch encourages the use of AI in its development, however, PyTorch is a large and technically complex project and it is easy for current LLMs,
-if not properly guided, to produce seemingly correct PRs or issues with major flaws. Because of this, to ensure the health
-of the project, we must limit how contributors, especially those new to the project,
-submit PRs and open issues.
+Please see PyTorch's [AI Policy here](AI_POLICY.md).
 
 All the details on how to contribute (with or without AI assistance) are in the [Ultimate Guide to PyTorch Contributions](https://github.com/pytorch/pytorch/wiki/The-Ultimate-Guide-to-PyTorch-Contributions).
-A couple reminders here though:
-
-- **You are personally responsible for what you send**: If the comments, issues or PRs you send are low quality or consistently overly verbose compared to what is expected, your contributions will not be accepted anymore. You are responsible for reviewing, ensuring the accuracy and the quality of everything you send.
-- **PRs must have an associated "actionable" Issue**: Generally, as a new contributor, you should never send a PR that doesn't have a corresponding issue with the "actionable" label. If you just opened the issue, you must wait for a maintainer to review it and mark it actionable before preparing and sending a PR for it.
-- **New features, utility functions, or core extensions**: Create a short and to the point issue about the problem you're encountering. You should NEVER include AI-generated explanation of how to solve the problem (this will be discussed later once it's decided the feature should be implemented).
 
 ## Spin
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189178

Move the AI contribution guidance into a dedicated AI_POLICY.md file and leave CONTRIBUTING.md as the entry point for the broader contribution guide. Update issue and pull request templates so their AI-assisted development policy links go directly to the new policy document.

Authored with the assistance of an AI assistant.