### PR TITLE
Relax bias.grad tolerance in test_batchnorm_nhwc_cpu (aarch64 flake)

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4432,7 +4432,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             self.assertTrue(ref_out.is_contiguous())
             self.assertEqual(out, ref_out)
             self.assertEqual(bn.weight.grad, ref_bn.weight.grad, atol=precision, rtol=precision)
-            self.assertEqual(bn.bias.grad, ref_bn.bias.grad)
+            self.assertEqual(bn.bias.grad, ref_bn.bias.grad, atol=precision, rtol=precision)
             self.assertEqual(input.grad, ref_input.grad)
 
         # test NC11 and N1HW; test mixed dtype


### PR DESCRIPTION
## Author Notes

Not sure what changed to cause this, but `test_batchnorm_nhwc_cpu` is quite flaky on trunk right now.

## Agent Notes

`test/test_nn.py::TestNN::test_batchnorm_nhwc_cpu` has been failing consistently on `linux-jammy-aarch64-py3.10 / test-osdc`. The failure is always the same assertion on the BatchNorm3d `channels_last_3d` float32 path:

```
self.assertEqual(bn.bias.grad, ref_bn.bias.grad)
AssertionError: Tensor-likes are not close!
Greatest absolute difference: 2.002716064453125e-05 (up to 1e-05 allowed)
```

**Root cause:** a borderline floating-point accumulation-order difference on ARM, not a numeric bug. The same commit both passes and fails across reruns, and the reported error (`2.0e-5`) is only ~2x over the default float32 `atol` of `1e-5`. The `bias.grad` assert was using the default tolerance while the sibling `weight.grad` assert on the adjacent line already relaxes to the per-dtype `precision` argument (`1e-4` for float32/bfloat16 in the 3D loop). `bias.grad` and `weight.grad` are produced by the same BatchNorm backward reduction over the same elements, so holding `bias.grad` to a tighter tolerance is inconsistent.

**Fix:** pass the same `atol=precision, rtol=precision` to the `bias.grad` assert. This only affects the float32/bfloat16 3D cases that already relax `weight.grad`; float16 (`precision=None`) and the 2D loop (no precision) keep the default tolerance, so there is no behavior change on the non-flaky paths.

### Test Plan

```
python test/test_nn.py TestNN.test_batchnorm_nhwc_cpu
```

Fixes https://github.com/pytorch/pytorch/issues/106543

This PR was authored with the help of Claude (an AI assistant).