### PR TITLE
make the return more specified

### DIFF
--- a/torch/nn/utils/weight_norm.py
+++ b/torch/nn/utils/weight_norm.py
@@ -2,6 +2,7 @@
 r"""Weight Normalization from https://arxiv.org/abs/1602.07868."""
 
 from typing import Any, TypeVar
+import torch
 from typing_extensions import deprecated
 
 from torch import _weight_norm, norm_except_dim
@@ -22,8 +23,7 @@ class WeightNorm:
         self.name = name
         self.dim = dim
 
-    # TODO Make return type more specific
-    def compute_weight(self, module: Module) -> Any:
+    def compute_weight(self, module: Module) -> torch.Tensor:
         g = getattr(module, self.name + "_g")
         v = getattr(module, self.name + "_v")
         return _weight_norm(v, g, self.dim)

--- a/torch/nn/utils/weight_norm.py
+++ b/torch/nn/utils/weight_norm.py
@@ -2,9 +2,9 @@
 r"""Weight Normalization from https://arxiv.org/abs/1602.07868."""
 
 from typing import Any, TypeVar
-import torch
 from typing_extensions import deprecated
 
+import torch
 from torch import _weight_norm, norm_except_dim
 from torch.nn.modules import Module
 from torch.nn.parameter import Parameter, UninitializedParameter


### PR DESCRIPTION
Replaced the `Any` return type with `torch.Tensor` since `_weight_norm` always returns a Tensor. 