### PR TITLE
[inductor][mtia] Fix fp16 reduction accumulator dtype mismatch

### DIFF
--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -5323,6 +5323,23 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                     dtype,
                 )
             else:
+                # When codegen_upcast_to_fp32 is disabled the accumulator keeps
+                # the low-precision src dtype, but an op in the reduction body
+                # (e.g. truediv/libdevice, which upcast unconditionally) can
+                # leave `value` in fp32. Reconcile it to the accumulator dtype so
+                # the loop-carried accumulator type stays consistent; strict
+                # backends reject a fp16 accumulator reassigned to fp32.
+                if (
+                    isinstance(value, CSEVariable)
+                    and value.dtype is not None
+                    and value.dtype != torch_acc_type
+                ):
+                    value = self.cse.generate(
+                        self.compute,
+                        f"{value}.to({acc_type})",
+                        dtype=torch_acc_type,
+                        shape=value.shape,
+                    )
                 combine_fn = ir.get_reduction_combine_fn(reduction_type, src_dtype)
                 updated = combine_fn(accumulator, value)
                 if reduction_type == "dot":


### PR DESCRIPTION
Summary:
On MTIA the Inductor Triton backend sets `codegen_upcast_to_fp32=False`, so a low-precision reduction keeps its source dtype for the loop-carried accumulator (`upcast_acc_dtype(torch.float16)` returns `torch.float16`). But an op inside the reduction body can still upcast the reduced value to fp32 unconditionally -- e.g. the mean `truediv` in the `torch.masked._std_var` two-pass composite -- leaving the accumulated value at fp32 while the accumulator stays fp16. The generic reduction combine never reconciled the two, so the accumulator was reassigned from fp16 to fp32 inside the loop. TritonMTIA's stricter loop-carried type check rejects it: `Loop-carried variable _tmp23 has initial type <fp16> but is re-assigned to <fp32> in loop`.

Fix: in the non-persistent reduction combine in `triton.py`, cast the reduced value to the accumulator dtype before combining when they differ. The cast is guarded on a dtype mismatch, so it is a no-op for backends with `codegen_upcast_to_fp32=True` and only affects the low-precision-accumulator path.

Test Plan:

Before: `masked.std; f16x5x5x5; mask; correction=0.5; keepdim=True` failed with the loop-carried type error.

After: `masked.std` compiles (`1 compiled, 0 errors`); the generated kernel casts the value to fp16 and keeps the `_tmp23` accumulator fp16 throughout.

Differential Revision: D110924494




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo