### PR TITLE
[inductor][fb] Whole-graph batch_addmm->bmm fusion for independent same-shape addmm (#189184)

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -371,6 +371,17 @@ pre_grad_fusion_options: dict[str, dict[str, Any]] = {
 # Call `torch._inductor.fx_passes.group_batch_fusion.list_group_batch_fusions(False)` to see available fusions.
 post_grad_fusion_options: dict[str, dict[str, Any]] = {}
 
+# fbcode-only: whole-graph batching of independent same-(M, K, N) aten.addmm
+# ops into a single bmm. Unlike batch_linear_post_grad's depth-bounded BFS
+# candidate search, this groups matching addmm ops across the entire graph --
+# needed for the per-feature embedding-projection pattern in ads ranking
+# models, where same-shape projections are separated by other matmuls the BFS
+# stops at. Empty dict disables the pass. Recognized options:
+#   "selective" (bool, default True): skip addmm ops whose downstream consumer
+#       Inductor would epilogue-fuse into a template kernel.
+#   "min_group_size" (int, default 4): minimum same-shape group size to batch.
+batch_addmm_fusion_options: dict[str, Any] = {}
+
 # enable reordering pass for improving memory locality
 reorder_for_locality = True
 

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -162,6 +162,22 @@ def reject_current_device_nodes(graph: torch.fx.Graph) -> None:
         )
 
 
+def _maybe_apply_batch_addmm_fusion(
+    gm: torch.fx.GraphModule, graph_transform_observer: Callable[..., Any]
+) -> None:
+    """fbcode-only: whole-graph batching of independent same-(M, K, N) addmm ops
+    into a bmm, gated by config.batch_addmm_fusion_options (empty disables)."""
+    if not (config.is_fbcode() and config.batch_addmm_fusion_options):
+        return
+    from .fb.batch_addmm_fusion import apply_batch_addmm_fusion
+
+    graph_transform_observer(gm, "batch_addmm_fusion").apply_graph_pass(
+        functools.partial(
+            apply_batch_addmm_fusion, options=config.batch_addmm_fusion_options
+        )
+    )
+
+
 def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
     """
     Passes that run on after grad.  This is called once on the forwards
@@ -197,6 +213,8 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
         GraphTransformObserver(gm, "post_grad_custom_pre_pass").apply_graph_pass(
             post_grad_custom_pre_pass
         )
+
+    _maybe_apply_batch_addmm_fusion(gm, GraphTransformObserver)
 
     if torch._C._has_mkldnn:
         if (


### PR DESCRIPTION
Summary:

## What

Adds a config-gated Inductor post-grad pass (`caffe2/torch/_inductor/fx_passes/fb/batch_addmm_fusion.py`, fbcode-only) that batches independent same-`(M, K, N)` `aten.addmm` ops into a single `bmm` (+ per-node bias add + `select`) across the *whole* graph. It targets the per-feature embedding-projection pattern in ads ranking models, where hundreds of small same-shape projections can share one batched GEMM.

Enable per-model via `torch._inductor.config.batch_addmm_fusion_options` (empty dict disables). Options: `selective` (default True; skip addmms whose downstream consumer Inductor would epilogue-fuse into a `triton_tem_fused_addmm_*` template) and `min_group_size` (default 4).

## Why a new pass instead of `batch_linear_post_grad`

The Optimus `group_batch_fusion` driver collects fusion candidates via a depth-bounded BFS (`get_fusion_candidates`) that stops descending at the first node whose `match()` is non-None. So it cannot group same-shape addmms that are separated by *other* matmuls — e.g. the per-feature layer-1 projections that sit behind their own layer-2 addmm, which halts the walk. Raising `max_fuse_search_depth` does not help, because the walk stops at the match, not at the depth limit.

This pass instead groups every addmm across the whole graph by `(M_expr, K, N)`, filters each shape group to a mutually independent subset (full backward reachability, no depth limit, so no cycles after fusion), and fuses upstream-group-first. It reuses the exact algorithm validated in `m10n_hw_codesign/inference/model_analyzer/experiments/fusion/fuse_independent_addmm.py`, now moved to a production-appropriate home.

## How it is wired (prod-deployable, no callable plumbing)

`post_grad_passes` invokes it directly at the post-grad pre stage under `config.is_fbcode() and config.batch_addmm_fusion_options`, mirroring the `b2b_gemm_pass` precedent. Because it is driven by a config value (not a callable), it rides through `AOTInductorLowerSettings.aot_inductor_config` (the dict is `ast.literal_eval`'d and applied via `config.patch`), so no additional lowering-settings plumbing is required. Fires are recorded in `counters["inductor"]["batch_addmm_fusion"]`.

## Benchmark harness

`benchmark_comparison.py` `gemm_fusion_*` / gbf configs are repointed from the experiments standalone `post_grad_pass=` callable to `aot_inductor_config_override={"batch_addmm_fusion_options": {...}}`, so the harness exercises the production path. Adds a `combo_cat5` config (combo + cat5 without batch_addmm) as an isolation control.

## Test Plan

Unit test (whole-graph FX pass, CPU, includes the case the Optimus BFS cannot do -- two same-shape groups separated by an intervening matmul):

```
buck2 run mode/opt //caffe2/test/inductor/fb:batch_addmm_fusion_fb -- -v
```

```
test_fuses_two_groups_across_intervening_matmul ... ok
test_min_group_size_not_met ... ok
test_nonselective_fuses_epilogue_group ... ok
test_nonselective_fuses_naked_group ... ok
test_selective_fuses_naked_group ... ok
test_selective_skips_epilogue_group ... ok
Ran 6 tests in 0.073s
OK
```


`gemm_fusion_non_selective_and_combo_cat5` (drives `batch_addmm`) vs `baseline`: T2 42,373 vs 39,381 QPS (+7.6%), T3 38,257 vs 37,246 QPS (+2.7%). This is the config-level win (bundles combo + cat5 + batch_addmm); the pass's isolated marginal contribution vs `combo_cat5` is being measured with 3 paired trials.

Verified the config knob threads end-to-end: the config-2 AOTI compile config shows `batch_addmm_fusion_options: {'selective': False}`.

Authored with the assistance of an AI coding agent.

Test Plan:
Unit test (whole-graph FX pass, CPU):

```
buck2 run mode/opt //caffe2/test/inductor/fb:batch_addmm_fusion_fb -- -v
```

6/6 pass: test_fuses_two_groups_across_intervening_matmul, test_min_group_size_not_met, test_nonselective_fuses_epilogue_group, test_nonselective_fuses_naked_group, test_selective_fuses_naked_group, test_selective_skips_epilogue_group.


```

| Threads | baseline QPS | gemm_fusion_non_selective_and_combo_cat5 QPS | delta |
| --- | --- | --- | --- |
| T=2 | 39381 | 42373 | +7.6% |
| T=3 | 37246 | 38257 | +2.7% |

Isolation of the batch_addmm marginal contribution, same model and hardware, paired trials, cold re-lowering per trial. A = `combo_cat5` (combo + cat5, no batch_addmm). B = `gemm_fusion_non_selective_and_combo_cat5` (A + batch_addmm, selective=False).


T=2 QPS:

| Trial | A (combo_cat5) | B (+batch_addmm) | B - A |
| --- | --- | --- | --- |
| 1 | 41594 | 42533 | +2.3% |
| 2 | 41426 | 42450 | +2.5% |

T=3 QPS:

| Trial | A (combo_cat5) | B (+batch_addmm) | B - A |
| --- | --- | --- | --- |
| 1 | 38051 | 38428 | +1.0% |
| 2 | 37924 | 38345 | +1.1% |

Trial 3 in progress; table will be updated with the 3-trial median and CV.

Config knob threads through to the AOTI compile config: the `gemm_fusion_non_selective_and_combo_cat5` lowering shows `batch_addmm_fusion_options: {'selective': False}`.

Authored with the assistance of an AI coding agent.

Reviewed By: dhawal55

Differential Revision: D110397341




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo