### PR TITLE
Extend "Fix positional arg overflow in TritonBenchmarkRequest when template inputs are deduplicated" to CUTLASS backend

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -32,6 +32,7 @@ from torch._inductor.autotune_process import (
     AutotuneProcessPool,
     ExternKernelBenchmarkRequest,
     get_visible_devices_env_var,
+    TensorMeta,
     TritonBenchmarkRequest,
     TuningProcess,
     TuningProcessPool,

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -3529,6 +3529,80 @@ class TestMaxAutotune(TestCase):
         expected = torch.einsum("...ab,...aA,...bB->...AB", grad.float(), q0.float(), q1.float())
         torch.testing.assert_close(result, expected)
 
+    @unittest.skipUnless(HAS_CUDA_AND_TRITON, "requires CUDA and Triton")
+    def test_nontail_input_dedup_trimming(self):
+        """Non-tail deduplication must keep trailing tensors, not truncate.
+
+        Simulates a 4-input template (A, B, C, D) where B (index 1) was
+        deduplicated to A. The kernel signature has 3 input pointers:
+        arg_A, arg_C, arg_D. A naive tail-truncation would drop D (index 3)
+        instead of B (index 1). The name_to_idx logic must keep [0, 2, 3].
+        """
+        dev = GPU_TYPE
+        t_A = torch.randn(4, 4, device=dev)
+        t_B = torch.randn(4, 4, device=dev)
+        t_C = torch.randn(4, 4, device=dev)
+        t_D = torch.randn(4, 4, device=dev)
+        out = torch.empty(4, 4, device=dev)
+
+        class FakeKernelSelf:
+            with_bandwidth_info = False
+
+        def fake_run(*args, **kwargs):
+            pass
+
+        fake_run.__self__ = FakeKernelSelf()
+
+        class FakeKernel:
+            run = fake_run
+            triton_meta = {
+                "signature": {
+                    "arg_A": "*fp32",
+                    "arg_C": "*fp32",
+                    "arg_D": "*fp32",
+                    "out_ptr0": "*fp32",
+                    "ks0": "i32",
+                    "ks1": "i32",
+                },
+            }
+
+        class FakeModule:
+            triton_mm_plus_mm = FakeKernel()
+
+        input_meta = [
+            TensorMeta(device=t.device, dtype=t.dtype, sizes=t.shape,
+                       strides=t.stride(), offset=0)
+            for t in [t_A, t_B, t_C, t_D]
+        ]
+        output_meta = TensorMeta(
+            device=out.device, dtype=out.dtype, sizes=out.shape,
+            strides=out.stride(), offset=0,
+        )
+
+        req = TritonBenchmarkRequest(
+            kernel_name="triton_mm_plus_mm",
+            input_tensor_meta=input_meta,
+            output_tensor_meta=output_meta,
+            extra_args=[1, 1, 1],
+            module_path="/dev/null",
+            module_cache_key="fake_key",
+            num_stages=1,
+            num_warps=4,
+            input_param_names=("arg_A", "arg_B", "arg_C", "arg_D"),
+        )
+
+        with patch(
+            "torch._inductor.autotune_process.PyCodeCache.load_by_key_path",
+            return_value=FakeModule(),
+        ):
+            fn = req.make_run_fn(t_A, t_B, t_C, t_D, out=out)
+
+        kept = fn.args[:3]
+        self.assertEqual(len(kept), 3)
+        self.assertIs(kept[0], t_A)
+        self.assertIs(kept[1], t_C)
+        self.assertIs(kept[2], t_D)
+
 
 @instantiate_parametrized_tests
 class TestTemplateConfigPruning(TestCase):
@@ -3803,41 +3877,6 @@ class TestTemplateConfigPruning(TestCase):
                     captured_smem <= smem_estimation,
                     f"Estimated maximum smem should exceed actual smem used for config {c}",
                 )
-
-
-    @unittest.skipUnless(HAS_CUDA_AND_TRITON, "requires CUDA and Triton")
-    def test_bmm_input_dedup_no_stream_overflow(self):
-        """Autotuning bmm after a self-referential bmm must not crash.
-
-        The first compilation produces template kernels where both operands
-        alias the same buffer (input deduplication).  The second compilation's
-        autotuning must handle the reduced parameter count without overflowing
-        positional args into the stream keyword.
-        """
-        dev = GPU_TYPE
-        B, N = 2, 128
-
-        grad = torch.randn(B, N, N, device=dev)
-        m0 = torch.randn(B, N, N, device=dev)
-        m1 = torch.randn(B, N, N, device=dev)
-        q0 = torch.randn(B, N, N, device=dev)
-        q1 = torch.randn(B, N, N, device=dev)
-
-        @torch.compile(fullgraph=True, dynamic=False, mode="max-autotune-no-cudagraphs")
-        def update(grad, m0, m1, beta):
-            outer0 = torch.einsum("...ab,...Ab->...aA", grad, grad)
-            m0.lerp_(outer0, 1 - beta)
-            outer1 = torch.einsum("...ab,...aB->...bB", grad, grad)
-            m1.lerp_(outer1, 1 - beta)
-
-        @torch.compile(fullgraph=True, dynamic=False, mode="max-autotune-no-cudagraphs")
-        def project(grad, q0, q1):
-            return torch.einsum("...ab,...aA,...bB->...AB", grad, q0, q1)
-
-        update(grad, m0, m1, 0.999)
-        result = project(grad.float(), q0.float(), q1.float())
-        expected = torch.einsum("...ab,...aA,...bB->...AB", grad.float(), q0.float(), q1.float())
-        torch.testing.assert_close(result, expected)
 
 
 class TestMaxAutotunePrecompile(TestCase):

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -3495,6 +3495,40 @@ class TestMaxAutotune(TestCase):
         self.assertNotIn("acc.to(tl.float16)", code[0])
         self.assertNotIn("acc.to(tl.bfloat16)", code[0])
 
+    @unittest.skipUnless(HAS_CUDA_AND_TRITON, "requires CUDA and Triton")
+    def test_bmm_input_dedup_no_stream_overflow(self):
+        """Autotuning bmm after a self-referential bmm must not crash.
+
+        The first compilation produces template kernels where both operands
+        alias the same buffer (input deduplication).  The second compilation's
+        autotuning must handle the reduced parameter count without overflowing
+        positional args into the stream keyword.
+        """
+        dev = GPU_TYPE
+        B, N = 2, 128
+
+        grad = torch.randn(B, N, N, device=dev)
+        m0 = torch.randn(B, N, N, device=dev)
+        m1 = torch.randn(B, N, N, device=dev)
+        q0 = torch.randn(B, N, N, device=dev)
+        q1 = torch.randn(B, N, N, device=dev)
+
+        @torch.compile(fullgraph=True, dynamic=False, mode="max-autotune-no-cudagraphs")
+        def update(grad, m0, m1, beta):
+            outer0 = torch.einsum("...ab,...Ab->...aA", grad, grad)
+            m0.lerp_(outer0, 1 - beta)
+            outer1 = torch.einsum("...ab,...aB->...bB", grad, grad)
+            m1.lerp_(outer1, 1 - beta)
+
+        @torch.compile(fullgraph=True, dynamic=False, mode="max-autotune-no-cudagraphs")
+        def project(grad, q0, q1):
+            return torch.einsum("...ab,...aA,...bB->...AB", grad, q0, q1)
+
+        update(grad, m0, m1, 0.999)
+        result = project(grad.float(), q0.float(), q1.float())
+        expected = torch.einsum("...ab,...aA,...bB->...AB", grad.float(), q0.float(), q1.float())
+        torch.testing.assert_close(result, expected)
+
 
 @instantiate_parametrized_tests
 class TestTemplateConfigPruning(TestCase):

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -3771,6 +3771,41 @@ class TestTemplateConfigPruning(TestCase):
                 )
 
 
+    @unittest.skipUnless(HAS_CUDA_AND_TRITON, "requires CUDA and Triton")
+    def test_bmm_input_dedup_no_stream_overflow(self):
+        """Autotuning bmm after a self-referential bmm must not crash.
+
+        The first compilation produces template kernels where both operands
+        alias the same buffer (input deduplication).  The second compilation's
+        autotuning must handle the reduced parameter count without overflowing
+        positional args into the stream keyword.
+        """
+        dev = GPU_TYPE
+        B, N = 2, 128
+
+        grad = torch.randn(B, N, N, device=dev)
+        m0 = torch.randn(B, N, N, device=dev)
+        m1 = torch.randn(B, N, N, device=dev)
+        q0 = torch.randn(B, N, N, device=dev)
+        q1 = torch.randn(B, N, N, device=dev)
+
+        @torch.compile(fullgraph=True, dynamic=False, mode="max-autotune-no-cudagraphs")
+        def update(grad, m0, m1, beta):
+            outer0 = torch.einsum("...ab,...Ab->...aA", grad, grad)
+            m0.lerp_(outer0, 1 - beta)
+            outer1 = torch.einsum("...ab,...aB->...bB", grad, grad)
+            m1.lerp_(outer1, 1 - beta)
+
+        @torch.compile(fullgraph=True, dynamic=False, mode="max-autotune-no-cudagraphs")
+        def project(grad, q0, q1):
+            return torch.einsum("...ab,...aA,...bB->...AB", grad, q0, q1)
+
+        update(grad, m0, m1, 0.999)
+        result = project(grad.float(), q0.float(), q1.float())
+        expected = torch.einsum("...ab,...aA,...bB->...AB", grad.float(), q0.float(), q1.float())
+        torch.testing.assert_close(result, expected)
+
+
 class TestMaxAutotunePrecompile(TestCase):
     def test_precompilation_threads(self):
         import threading

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -24,7 +24,7 @@ from torch._dynamo import reset
 from torch._dynamo.device_interface import get_interface_for_device
 from torch._dynamo.exc import BackendCompilerFailed
 from torch._dynamo.testing import rand_strided, reset_rng_state
-from torch._dynamo.utils import counters, same
+from torch._dynamo.utils import counters, identity, same
 from torch._inductor import config
 from torch._inductor.autotune_process import (
     _TestBenchmarkRequest,
@@ -32,7 +32,6 @@ from torch._inductor.autotune_process import (
     AutotuneProcessPool,
     ExternKernelBenchmarkRequest,
     get_visible_devices_env_var,
-    TensorMeta,
     TritonBenchmarkRequest,
     TuningProcess,
     TuningProcessPool,
@@ -53,6 +52,7 @@ from torch._inductor.select_algorithm import (
     clear_feedback_savers,
     clear_preprocessing_fns,
     ExternKernelCaller,
+    GeneratedCodeCache,
     NoValidChoicesError,
     TritonTemplate,
     TritonTemplateCaller,
@@ -2423,6 +2423,7 @@ class TestMaxAutotune(TestCase):
                         'input_nodes':[
                             "[[10,22],[22,1],torch.float32,device(type='cuda',index=0),0]",
                             "[[22,30],[30,1],torch.float32,device(type='cuda',index=0),0]"],
+                        'input_aliasing':(0,1),
                         'num_stages':1,'num_warps':2,'prefix_args':0,'suffix_args':0,'call_sizes':[10,30],
                         'layout':"[[10,30],[30,1],torch.float32,device(type='cuda',index=0),0]",
                         'num_consumer_groups':0,'num_buffers_warp_spec':0,'epilogue_fn_hash':'identity','tma_store':False,
@@ -2465,6 +2466,7 @@ class TestMaxAutotune(TestCase):
                     'input_nodes':[
                         "[[s77,s27],[s27,1],torch.float32,device(type='cuda',index=0),0]",
                         "[[s27,s94],[s94,1],torch.float32,device(type='cuda',index=0),0]"],
+                    'input_aliasing':(0,1),
                     'num_stages':1,'num_warps':2,'prefix_args':0,'suffix_args':0,'call_sizes':[s77,s94],
                     'layout':"[[s77,s94],[s94,1],torch.float32,device(type='cuda',index=0),0]",'num_consumer_groups':0,
                     'num_buffers_warp_spec':0,'epilogue_fn_hash':'identity','tma_store':False,
@@ -2632,6 +2634,90 @@ class TestMaxAutotune(TestCase):
             self.assertEqual(compile_results, eager_results, atol=0.05, rtol=0.05)
             self.assertEqual(hits(), 4)
             self.assertEqual(misses(), 4)
+
+    def test_generated_code_cache_key_input_aliasing(self):
+        """make_key must distinguish aliased inputs, e.g. mm(x, x), from
+        distinct inputs with identical layouts, and stay name-insensitive."""
+
+        def make_layout():
+            return FixedLayout(torch.device("cpu"), torch.float32, [8, 8], [8, 1])
+
+        a = Buffer(name="buf_a", layout=make_layout())
+        b = Buffer(name="buf_b", layout=make_layout())
+
+        def key(*input_nodes):
+            return GeneratedCodeCache().make_key(
+                input_nodes=input_nodes,
+                num_stages=1,
+                num_warps=4,
+                call_sizes=[8, 8],
+                prefix_args=0,
+                suffix_args=0,
+                epilogue_fn=identity,
+                epilogue_fn_hash=None,
+                tma_store=False,
+                tma_load_for_template_epilogue=False,
+                transpose_discontiguous_tensor_descriptors_override=None,
+                subgraphs=None,
+                workspace_arg=None,
+                layout=make_layout(),
+                num_consumer_groups=0,
+                num_buffers_warp_spec=0,
+                kwargs={},
+            )
+
+        # Identical layouts but different aliasing must not collide.
+        self.assertNotEqual(key(a, a), key(a, b))
+        # The aliasing pattern is insensitive to buffer names.
+        self.assertEqual(key(a, a), key(b, b))
+        self.assertEqual(key(a, b), key(b, a))
+        self.assertIn("'input_aliasing': (0, 1)", key(a, b))
+
+    @unittest.skipUnless(HAS_CUDA_AND_TRITON, "requires CUDA and Triton")
+    @config.patch(
+        {
+            "test_configs.max_mm_configs": 4,
+            "max_autotune_gemm_backends": "TRITON",
+        }
+    )
+    def test_bmm_template_cache_aliased_then_distinct_inputs(self):
+        """Cached template code generated for aliased bmm operands must not
+        be reused for distinct operands with identical layouts.
+
+        The first compilation caches bmm kernels whose operands alias one
+        buffer (codegen collapses them into a single kernel argument). The
+        second compilation autotunes bmm nodes with distinct operands of the
+        same layouts; before the aliasing-aware cache key those hit the
+        one-argument cached kernels and crashed during benchmarking.
+        See https://github.com/pytorch/pytorch/issues/188069.
+        """
+
+        def update(grad, m0, m1, beta):
+            outer0 = torch.einsum("...ab,...Ab->...aA", grad, grad)
+            m0.lerp_(outer0, 1 - beta)
+            outer1 = torch.einsum("...ab,...aB->...bB", grad, grad)
+            m1.lerp_(outer1, 1 - beta)
+
+        def project(grad, q0, q1):
+            return torch.einsum("...ab,...aA,...bB->...AB", grad, q0, q1)
+
+        B, N = 2, 128
+        with fresh_cache():
+            grad = torch.randn(B, N, N, device=GPU_TYPE)
+            m0 = torch.randn(B, N, N, device=GPU_TYPE)
+            m1 = torch.randn(B, N, N, device=GPU_TYPE)
+            q0 = torch.randn(B, N, N, device=GPU_TYPE)
+            q1 = torch.randn(B, N, N, device=GPU_TYPE)
+
+            compile_kwargs = {
+                "fullgraph": True,
+                "dynamic": False,
+                "mode": "max-autotune-no-cudagraphs",
+            }
+            torch.compile(update, **compile_kwargs)(grad, m0, m1, 0.999)
+            result = torch.compile(project, **compile_kwargs)(grad, q0, q1)
+
+            self.assertEqual(result, project(grad, q0, q1), atol=1e-2, rtol=1e-2)
 
     @fresh_cache()
     @unittest.skipIf(
@@ -3495,114 +3581,6 @@ class TestMaxAutotune(TestCase):
         # No truncation casts should exist since there are no fused epilogue ops
         self.assertNotIn("acc.to(tl.float16)", code[0])
         self.assertNotIn("acc.to(tl.bfloat16)", code[0])
-
-    @unittest.skipUnless(HAS_CUDA_AND_TRITON, "requires CUDA and Triton")
-    def test_bmm_input_dedup_no_stream_overflow(self):
-        """Autotuning bmm after a self-referential bmm must not crash.
-
-        The first compilation produces template kernels where both operands
-        alias the same buffer (input deduplication).  The second compilation's
-        autotuning must handle the reduced parameter count without overflowing
-        positional args into the stream keyword.
-        """
-        dev = GPU_TYPE
-        B, N = 2, 128
-
-        grad = torch.randn(B, N, N, device=dev)
-        m0 = torch.randn(B, N, N, device=dev)
-        m1 = torch.randn(B, N, N, device=dev)
-        q0 = torch.randn(B, N, N, device=dev)
-        q1 = torch.randn(B, N, N, device=dev)
-
-        @torch.compile(fullgraph=True, dynamic=False, mode="max-autotune-no-cudagraphs")
-        def update(grad, m0, m1, beta):
-            outer0 = torch.einsum("...ab,...Ab->...aA", grad, grad)
-            m0.lerp_(outer0, 1 - beta)
-            outer1 = torch.einsum("...ab,...aB->...bB", grad, grad)
-            m1.lerp_(outer1, 1 - beta)
-
-        @torch.compile(fullgraph=True, dynamic=False, mode="max-autotune-no-cudagraphs")
-        def project(grad, q0, q1):
-            return torch.einsum("...ab,...aA,...bB->...AB", grad, q0, q1)
-
-        update(grad, m0, m1, 0.999)
-        result = project(grad.float(), q0.float(), q1.float())
-        expected = torch.einsum("...ab,...aA,...bB->...AB", grad.float(), q0.float(), q1.float())
-        torch.testing.assert_close(result, expected)
-
-    @unittest.skipUnless(HAS_CUDA_AND_TRITON, "requires CUDA and Triton")
-    def test_nontail_input_dedup_trimming(self):
-        """Non-tail deduplication must keep trailing tensors, not truncate.
-
-        Simulates a 4-input template (A, B, C, D) where B (index 1) was
-        deduplicated to A. The kernel signature has 3 input pointers:
-        arg_A, arg_C, arg_D. A naive tail-truncation would drop D (index 3)
-        instead of B (index 1). The name_to_idx logic must keep [0, 2, 3].
-        """
-        dev = GPU_TYPE
-        t_A = torch.randn(4, 4, device=dev)
-        t_B = torch.randn(4, 4, device=dev)
-        t_C = torch.randn(4, 4, device=dev)
-        t_D = torch.randn(4, 4, device=dev)
-        out = torch.empty(4, 4, device=dev)
-
-        class FakeKernelSelf:
-            with_bandwidth_info = False
-
-        def fake_run(*args, **kwargs):
-            pass
-
-        fake_run.__self__ = FakeKernelSelf()
-
-        class FakeKernel:
-            run = fake_run
-            triton_meta = {
-                "signature": {
-                    "arg_A": "*fp32",
-                    "arg_C": "*fp32",
-                    "arg_D": "*fp32",
-                    "out_ptr0": "*fp32",
-                    "ks0": "i32",
-                    "ks1": "i32",
-                },
-            }
-
-        class FakeModule:
-            triton_mm_plus_mm = FakeKernel()
-
-        input_meta = [
-            TensorMeta(device=t.device, dtype=t.dtype, sizes=t.shape,
-                       strides=t.stride(), offset=0)
-            for t in [t_A, t_B, t_C, t_D]
-        ]
-        output_meta = TensorMeta(
-            device=out.device, dtype=out.dtype, sizes=out.shape,
-            strides=out.stride(), offset=0,
-        )
-
-        req = TritonBenchmarkRequest(
-            kernel_name="triton_mm_plus_mm",
-            input_tensor_meta=input_meta,
-            output_tensor_meta=output_meta,
-            extra_args=[1, 1, 1],
-            module_path="/dev/null",
-            module_cache_key="fake_key",
-            num_stages=1,
-            num_warps=4,
-            input_param_names=("arg_A", "arg_B", "arg_C", "arg_D"),
-        )
-
-        with patch(
-            "torch._inductor.autotune_process.PyCodeCache.load_by_key_path",
-            return_value=FakeModule(),
-        ):
-            fn = req.make_run_fn(t_A, t_B, t_C, t_D, out=out)
-
-        kept = fn.args[:3]
-        self.assertEqual(len(kept), 3)
-        self.assertIs(kept[0], t_A)
-        self.assertIs(kept[1], t_C)
-        self.assertIs(kept[2], t_D)
 
 
 @instantiate_parametrized_tests

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -2717,7 +2717,7 @@ class TestMaxAutotune(TestCase):
             torch.compile(update, **compile_kwargs)(grad, m0, m1, 0.999)
             result = torch.compile(project, **compile_kwargs)(grad, q0, q1)
 
-            self.assertEqual(result, project(grad, q0, q1), atol=1e-2, rtol=1e-2)
+            self.assertEqual(result, project(grad, q0, q1), atol=0.5, rtol=0.05)
 
     @fresh_cache()
     @unittest.skipIf(

--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -686,6 +686,7 @@ class TritonBenchmarkRequest(BenchmarkRequest):
         kpack: int = 0,  # ROCm specific gemm parameter
         workspace_size: int | None = None,  # size of workspace buffer in bytes
         workspace_zero_fill: bool = False,  # whether to zero-fill workspace
+        input_param_names: tuple[str, ...] | None = None,
     ) -> None:
         super().__init__(kernel_name, input_tensor_meta, output_tensor_meta, extra_args)
         self.module_path = module_path
@@ -699,6 +700,7 @@ class TritonBenchmarkRequest(BenchmarkRequest):
         self.kpack = kpack
         self.workspace_size = workspace_size
         self.workspace_zero_fill = workspace_zero_fill
+        self.input_param_names = input_param_names
         self._benchmark_module: Any | None = None
 
     def make_run_fn(
@@ -722,17 +724,29 @@ class TritonBenchmarkRequest(BenchmarkRequest):
         # Template input deduplication can reduce the kernel's parameter
         # count below len(input_tensors) when a cached candidate compiled
         # with aliased inputs is benchmarked for a graph with distinct
-        # inputs.  Read the compiled signature to detect the mismatch.
+        # inputs.  Match by param name to keep the right tensors.
         triton_meta = getattr(kernel, "triton_meta", None)
         if triton_meta is not None:
-            n_kernel_args = len(triton_meta.get("signature", {}))
-            n_expected_inputs = max(n_kernel_args - 1, 0)
-            if len(input_tensors) > n_expected_inputs:
+            sig = triton_meta.get("signature", {})
+            kernel_input_names = [
+                k
+                for k, v in sig.items()
+                if v.startswith("*")
+                and not k.startswith(("out_ptr", "in_out_ptr", "ws_ptr"))
+            ]
+            if len(input_tensors) > len(kernel_input_names):
+                if self.input_param_names is not None:
+                    name_to_idx = {
+                        n: i for i, n in enumerate(self.input_param_names)
+                    }
+                    keep = [name_to_idx[k] for k in kernel_input_names]
+                else:
+                    keep = list(range(len(kernel_input_names)))
                 autotuning_log.debug(
                     "Trimming input_tensors from %d to %d for %s",
-                    len(input_tensors), n_expected_inputs, self.kernel_name,
+                    len(input_tensors), len(keep), self.kernel_name,
                 )
-                input_tensors = input_tensors[:n_expected_inputs]
+                input_tensors = tuple(input_tensors[i] for i in keep)
 
         extra_args = list(self.extra_args)
 

--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -716,7 +716,24 @@ class TritonBenchmarkRequest(BenchmarkRequest):
             self.module_path,
         )
 
-        run_method = getattr(mod, self.kernel_name).run
+        kernel = getattr(mod, self.kernel_name)
+        run_method = kernel.run
+
+        # Template input deduplication can reduce the kernel's parameter
+        # count below len(input_tensors) when a cached candidate compiled
+        # with aliased inputs is benchmarked for a graph with distinct
+        # inputs.  Read the compiled signature to detect the mismatch.
+        triton_meta = getattr(kernel, "triton_meta", None)
+        if triton_meta is not None:
+            n_kernel_args = len(triton_meta.get("signature", {}))
+            n_expected_inputs = max(n_kernel_args - 1, 0)
+            if len(input_tensors) > n_expected_inputs:
+                autotuning_log.debug(
+                    "Trimming input_tensors from %d to %d for %s",
+                    len(input_tensors), n_expected_inputs, self.kernel_name,
+                )
+                input_tensors = input_tensors[:n_expected_inputs]
+
         extra_args = list(self.extra_args)
 
         # Recreate workspace tensor if needed (for TMA templates)

--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -1040,6 +1040,14 @@ class CUTLASSBenchmarkRequest(GPUDeviceBenchmarkMixin, BenchmarkRequest):
 
         self.ensure_dll_loaded()
         self.update_workspace_size()
+        # Deduplicate aliased inputs: def_kernel collapses inputs that share
+        # a buffer name into one kernel parameter (dict-keyed), so the C++
+        # function has fewer pointer args than len(input_tensors).
+        if isinstance(self.input_tensor_meta, list):
+            seen: dict[str | None, torch.Tensor] = {}
+            for tensor, meta in zip(input_tensors, self.input_tensor_meta):
+                seen.setdefault(meta.name, tensor)
+            input_tensors = tuple(seen.values())
         args = [c_void_p(tensor.data_ptr()) for tensor in list(input_tensors) + [out]]
         autotuning_log.debug(
             "make_run_fn: self.kernel_name=%s, self.source_file=%s, self.hash_key=%s, self.DLL=%s, args=%s, self.extra_args=%s",

--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -686,7 +686,6 @@ class TritonBenchmarkRequest(BenchmarkRequest):
         kpack: int = 0,  # ROCm specific gemm parameter
         workspace_size: int | None = None,  # size of workspace buffer in bytes
         workspace_zero_fill: bool = False,  # whether to zero-fill workspace
-        input_param_names: tuple[str, ...] | None = None,
     ) -> None:
         super().__init__(kernel_name, input_tensor_meta, output_tensor_meta, extra_args)
         self.module_path = module_path
@@ -700,7 +699,6 @@ class TritonBenchmarkRequest(BenchmarkRequest):
         self.kpack = kpack
         self.workspace_size = workspace_size
         self.workspace_zero_fill = workspace_zero_fill
-        self.input_param_names = input_param_names
         self._benchmark_module: Any | None = None
 
     def make_run_fn(
@@ -718,36 +716,7 @@ class TritonBenchmarkRequest(BenchmarkRequest):
             self.module_path,
         )
 
-        kernel = getattr(mod, self.kernel_name)
-        run_method = kernel.run
-
-        # Template input deduplication can reduce the kernel's parameter
-        # count below len(input_tensors) when a cached candidate compiled
-        # with aliased inputs is benchmarked for a graph with distinct
-        # inputs.  Match by param name to keep the right tensors.
-        triton_meta = getattr(kernel, "triton_meta", None)
-        if triton_meta is not None:
-            sig = triton_meta.get("signature", {})
-            kernel_input_names = [
-                k
-                for k, v in sig.items()
-                if v.startswith("*")
-                and not k.startswith(("out_ptr", "in_out_ptr", "ws_ptr"))
-            ]
-            if len(input_tensors) > len(kernel_input_names):
-                if self.input_param_names is not None:
-                    name_to_idx = {
-                        n: i for i, n in enumerate(self.input_param_names)
-                    }
-                    keep = [name_to_idx[k] for k in kernel_input_names]
-                else:
-                    keep = list(range(len(kernel_input_names)))
-                autotuning_log.debug(
-                    "Trimming input_tensors from %d to %d for %s",
-                    len(input_tensors), len(keep), self.kernel_name,
-                )
-                input_tensors = tuple(input_tensors[i] for i in keep)
-
+        run_method = getattr(mod, self.kernel_name).run
         extra_args = list(self.extra_args)
 
         # Recreate workspace tensor if needed (for TMA templates)

--- a/torch/_inductor/codegen/cutlass/template.py
+++ b/torch/_inductor/codegen/cutlass/template.py
@@ -85,6 +85,11 @@ class CUTLASSTemplate(KernelTemplate):
     def supports_epilogue_fusion(op: GemmOperation, device_type: str) -> bool:
         return False
 
+    def _input_aliasing(self) -> tuple[int, ...]:
+        names = [node.get_name() for node in self.input_nodes]
+        first_seen: dict[str, int] = {}
+        return tuple(first_seen.setdefault(n, i) for i, n in enumerate(names))
+
     def make_key(self, name: str, input_key: str, layout_repr: str) -> str:
         """
         Make a key for the code cache. The idea of the method is to cache
@@ -99,10 +104,10 @@ class CUTLASSTemplate(KernelTemplate):
                 (
                     input_key,
                     self.input_reorder,
-                    # output layout, same as self.output_node.get_layout()
                     layout_repr,
                     self.get_runtime_arg_info(),
                     name,
+                    self._input_aliasing(),
                 )
             ).encode("utf-8")
         ).hexdigest()

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2505,6 +2505,7 @@ class GenerateAndLoadResult(NamedTuple):
     prologue_supported_inputs: OrderedSet[str]
     kernel_args_sizevars_keys: tuple[sympy.Expr, ...]
     kernel_options: dict[str, Any]
+    input_param_names: tuple[str, ...]
 
 
 class GeneratedCodeCacheEntry(NamedTuple):
@@ -2940,6 +2941,7 @@ class TritonTemplate(KernelTemplate):
         mod = PyCodeCache.load(code, extra, set_sys_modules=False)
 
         input_call_args = tuple(kernel.args.input_buffers.keys())
+        input_param_names = tuple(kernel.args.input_buffers.values())
         prologue_supported_inputs = kernel.prologue_supported_inputs.copy()
         kernel_args_sizevars_keys = tuple(kernel.args.sizevars.keys())
 
@@ -2953,6 +2955,7 @@ class TritonTemplate(KernelTemplate):
             prologue_supported_inputs,
             kernel_args_sizevars_keys,
             kernel_options,
+            input_param_names,
         )
 
     def generate(  # type: ignore[override]
@@ -3147,6 +3150,7 @@ class TritonTemplate(KernelTemplate):
             workspace_zero_fill=workspace_zero_fill,
             input_tensor_meta=TensorMeta.from_irnodes(kernel_input_nodes),  # type: ignore[arg-type]
             output_tensor_meta=TensorMeta.from_irnodes(layout),
+            input_param_names=result.input_param_names,
         )
 
         # Convolution-specific parameters to include in logging

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -2505,7 +2505,6 @@ class GenerateAndLoadResult(NamedTuple):
     prologue_supported_inputs: OrderedSet[str]
     kernel_args_sizevars_keys: tuple[sympy.Expr, ...]
     kernel_options: dict[str, Any]
-    input_param_names: tuple[str, ...]
 
 
 class GeneratedCodeCacheEntry(NamedTuple):
@@ -2615,11 +2614,22 @@ class GeneratedCodeCache:
         ):
             return None
 
+        # def_kernel deduplicates kernel arguments by buffer name, so inputs
+        # with identical layouts can still generate different code depending
+        # on which of them alias the same buffer, e.g. mm(x, x) (one kernel
+        # arg) vs mm(a, b) (two). Key the aliasing structure name-insensitively.
+        names = [node.get_name() for node in input_nodes]
+        first_seen: dict[str, int] = {}
+        input_aliasing = tuple(
+            first_seen.setdefault(name, i) for i, name in enumerate(names)
+        )
+
         return repr(
             {
                 "input_nodes": [
                     layout_key(input.get_layout()) for input in input_nodes
                 ],
+                "input_aliasing": input_aliasing,
                 "num_stages": num_stages,
                 "num_warps": num_warps,
                 "prefix_args": prefix_args,
@@ -2941,7 +2951,6 @@ class TritonTemplate(KernelTemplate):
         mod = PyCodeCache.load(code, extra, set_sys_modules=False)
 
         input_call_args = tuple(kernel.args.input_buffers.keys())
-        input_param_names = tuple(kernel.args.input_buffers.values())
         prologue_supported_inputs = kernel.prologue_supported_inputs.copy()
         kernel_args_sizevars_keys = tuple(kernel.args.sizevars.keys())
 
@@ -2955,7 +2964,6 @@ class TritonTemplate(KernelTemplate):
             prologue_supported_inputs,
             kernel_args_sizevars_keys,
             kernel_options,
-            input_param_names,
         )
 
     def generate(  # type: ignore[override]
@@ -3150,7 +3158,6 @@ class TritonTemplate(KernelTemplate):
             workspace_zero_fill=workspace_zero_fill,
             input_tensor_meta=TensorMeta.from_irnodes(kernel_input_nodes),  # type: ignore[arg-type]
             output_tensor_meta=TensorMeta.from_irnodes(layout),
-            input_param_names=result.input_param_names,
         )
 
         # Convolution-specific parameters to include in logging


### PR DESCRIPTION
after #188268 is merged, this extends that fix to cutlass -- do not merge before #188268

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo