### PR TITLE
flex_gemm: extend feed-main to trailing pointwise and axis-1 fragments

### DIFF
--- a/test/inductor/test_flex_gemm.py
+++ b/test/inductor/test_flex_gemm.py
@@ -3808,6 +3808,332 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
     @skipIfNoCuteDSL
     @unittest.skipIf(not TEST_CUDA, "CUDA required")
     @unittest.skipIf(not SM100OrLater, "SM100+ required")
+    def test_mm_local_m_reduce_feed_main_supports_trailing_fp8_quant(self):
+        m = 128
+        n = 64
+        group = 32
+
+        def epilogue_fn(acc):
+            x = acc.float().view(-1, group, n)
+            scale = x.sum(1, keepdim=True)
+            return (x * scale.reciprocal()).view(m, n).to(torch.float8_e4m3fn)
+
+        def high_precision_fn(acc):
+            x = acc.view(-1, group, n)
+            return (x * x.sum(1, keepdim=True).reciprocal()).view(m, n)
+
+        def fn(a, b):
+            return flex_gemm(
+                torch.mm,
+                (a, b),
+                epilogue_fn,
+                kernel_options={"backend": "QUACK"},
+            )
+
+        a = torch.rand(m, 64, device="cuda", dtype=torch.bfloat16)
+        b = torch.rand(64, n, device="cuda", dtype=torch.bfloat16)
+        actual, (code,) = run_and_get_code(
+            torch.compile(fn, backend="inductor", fullgraph=True), a, b
+        )
+
+        self.assertEqual(actual.dtype, torch.float8_e4m3fn)
+        self.assertMatchesLowPrecisionEager(
+            actual,
+            epilogue_fn(a @ b),
+            high_precision_fn(a.double() @ b.double()),
+            a.shape[1],
+        )
+        self.assertPhysicalFeedMainCode(code, group)
+        FileCheck().check("cutlass.Float8E4M3FN").check("feeds_main=True").run(code)
+
+    @skipIfNoCuteDSL
+    @unittest.skipIf(not TEST_CUDA, "CUDA required")
+    @unittest.skipIf(not SM100OrLater, "SM100+ required")
+    def test_mm_local_m_reduce_feed_main_supports_trailing_pointwise_chain(self):
+        m = 128
+        n = 64
+        group = 8
+
+        def epilogue_fn(acc):
+            x = acc.float().view(-1, group, n)
+            scale = x.sum(1, keepdim=True)
+            return (x * scale.reciprocal()).view(m, n) * 0.5 + 1.0
+
+        def fn(a, b):
+            return flex_gemm(
+                torch.mm,
+                (a, b),
+                epilogue_fn,
+                kernel_options={"backend": "QUACK"},
+            )
+
+        a = torch.rand(m, 64, device="cuda", dtype=torch.bfloat16)
+        b = torch.rand(64, n, device="cuda", dtype=torch.bfloat16)
+        actual, (code,) = run_and_get_code(
+            torch.compile(fn, backend="inductor", fullgraph=True), a, b
+        )
+
+        self.assertMatchesEpilogue(
+            actual,
+            epilogue_fn(a @ b),
+            epilogue_fn(a.double() @ b.double()),
+            a.shape[1],
+        )
+        self.assertPhysicalFeedMainCode(code, group)
+        FileCheck().check("feeds_main=True").run(code)
+
+    @skipIfNoCuteDSL
+    @unittest.skipIf(not TEST_CUDA, "CUDA required")
+    @unittest.skipIf(not SM100OrLater, "SM100+ required")
+    def test_mm_local_m_reduce_feed_main_trailing_quant_with_scale_store(self):
+        m = 128
+        n = 64
+        group = 32
+
+        def epilogue_fn(acc):
+            x = acc.float().view(-1, group, n)
+            scale = x.sum(1, keepdim=True)
+            quant = (x * scale.reciprocal()).view(m, n).to(torch.float8_e4m3fn)
+            return quant, scale.squeeze(1)
+
+        def fn(a, b):
+            return flex_gemm(
+                torch.mm,
+                (a, b),
+                epilogue_fn,
+                kernel_options={"backend": "QUACK"},
+            )
+
+        a = torch.rand(m, 64, device="cuda", dtype=torch.bfloat16)
+        b = torch.rand(64, n, device="cuda", dtype=torch.bfloat16)
+        (actual, aux), (code,) = run_and_get_code(
+            torch.compile(fn, backend="inductor", fullgraph=True), a, b
+        )
+
+        high_precision_acc = a.double() @ b.double()
+        high_precision_x = high_precision_acc.view(-1, group, n)
+        self.assertEqual(actual.dtype, torch.float8_e4m3fn)
+        self.assertMatchesLowPrecisionEager(
+            actual,
+            epilogue_fn(a @ b)[0],
+            (
+                high_precision_x * high_precision_x.sum(1, keepdim=True).reciprocal()
+            ).view(m, n),
+            a.shape[1],
+        )
+        torch.testing.assert_close(
+            aux,
+            high_precision_x.sum(1).float(),
+            atol=1e-3,
+            rtol=1e-3,
+        )
+        FileCheck().check("local_reduce=FlexGemmRuntimeLocalReducePlan").check(
+            self.localReduceGeometryPattern(group, 0)
+        ).check("out=").check("feeds_main=True").check(
+            "callbacks=FlexGemmLocalReduceCallbacks"
+        ).run(code)
+
+    @skipIfNoCuteDSL
+    @unittest.skipIf(not TEST_CUDA, "CUDA required")
+    @unittest.skipIf(not SM100OrLater, "SM100+ required")
+    @parametrize("group", (4, 8, 16))
+    def test_mm_local_n_reduce_feed_main_fragment_group_sum(self, group):
+        m = 128
+        n = 128
+
+        def epilogue_fn(acc):
+            x = acc.float().view(m, -1, group)
+            scale = x.sum(-1, keepdim=True)
+            return (x * scale.reciprocal()).view(m, n)
+
+        def fn(a, b):
+            return flex_gemm(
+                torch.mm,
+                (a, b),
+                epilogue_fn,
+                kernel_options={"backend": "QUACK"},
+            )
+
+        a = torch.rand(m, 64, device="cuda", dtype=torch.bfloat16)
+        b = torch.rand(64, n, device="cuda", dtype=torch.bfloat16)
+        actual, (code,) = run_and_get_code(
+            torch.compile(fn, backend="inductor", fullgraph=True), a, b
+        )
+
+        self.assertMatchesLowPrecisionEager(
+            actual,
+            epilogue_fn(a @ b),
+            epilogue_fn(a.double() @ b.double()),
+            a.shape[1],
+        )
+        FileCheck().check("cute.ReductionOp.ADD").check_not(
+            "local_reduce=FlexGemmRuntimeLocalReducePlan"
+        ).run(code)
+
+    @skipIfNoCuteDSL
+    @unittest.skipIf(not TEST_CUDA, "CUDA required")
+    @unittest.skipIf(not SM100OrLater, "SM100+ required")
+    @parametrize("group", (4, 8, 16))
+    def test_mm_local_n_reduce_feed_main_fragment_group_fp8_quant(self, group):
+        m = 128
+        n = 128
+
+        def epilogue_fn(acc):
+            x = acc.float().view(m, -1, group)
+            scale = x.abs().amax(-1, keepdim=True).clamp(min=1e-12) / 448.0
+            return (x * scale.reciprocal()).view(m, n).to(torch.float8_e4m3fn)
+
+        def high_precision_fn(acc):
+            x = acc.view(m, -1, group)
+            scale = x.abs().amax(-1, keepdim=True).clamp(min=1e-12) / 448.0
+            return (x * scale.reciprocal()).view(m, n)
+
+        def fn(a, b):
+            return flex_gemm(
+                torch.mm,
+                (a, b),
+                epilogue_fn,
+                kernel_options={"backend": "QUACK"},
+            )
+
+        a = torch.randn(m, 64, device="cuda", dtype=torch.bfloat16)
+        b = torch.randn(64, n, device="cuda", dtype=torch.bfloat16)
+        actual, (code,) = run_and_get_code(
+            torch.compile(fn, backend="inductor", fullgraph=True), a, b
+        )
+
+        self.assertEqual(actual.dtype, torch.float8_e4m3fn)
+        self.assertMatchesLowPrecisionEager(
+            actual,
+            epilogue_fn(a @ b),
+            high_precision_fn(a.double() @ b.double()),
+            a.shape[1],
+        )
+        FileCheck().check("cutlass.Float8E4M3FN").check_not(
+            "local_reduce=FlexGemmRuntimeLocalReducePlan"
+        ).run(code)
+
+    @skipIfNoCuteDSL
+    @unittest.skipIf(not TEST_CUDA, "CUDA required")
+    @unittest.skipIf(not SM100OrLater, "SM100+ required")
+    @parametrize("group", (4, 8, 16))
+    def test_mm_local_n_reduce_feed_main_fragment_group_scale_store(self, group):
+        m = 128
+        n = 128
+
+        def epilogue_fn(acc):
+            x = acc.float().view(m, -1, group)
+            scale = x.abs().amax(-1, keepdim=True).clamp(min=1e-12) / 448.0
+            return (x * scale.reciprocal()).view(m, n), scale.squeeze(-1)
+
+        def fn(a, b):
+            return flex_gemm(
+                torch.mm,
+                (a, b),
+                epilogue_fn,
+                kernel_options={"backend": "QUACK"},
+            )
+
+        a = torch.randn(m, 64, device="cuda", dtype=torch.bfloat16)
+        b = torch.randn(64, n, device="cuda", dtype=torch.bfloat16)
+        (actual, aux), (code,) = run_and_get_code(
+            torch.compile(fn, backend="inductor", fullgraph=True), a, b
+        )
+
+        expected, _ = epilogue_fn(a @ b)
+        high_precision_expected, high_precision_aux = epilogue_fn(
+            a.double() @ b.double()
+        )
+        self.assertMatchesLowPrecisionEager(
+            actual,
+            expected,
+            high_precision_expected,
+            a.shape[1],
+        )
+        torch.testing.assert_close(
+            aux,
+            high_precision_aux.float(),
+            atol=1e-3,
+            rtol=1e-3,
+        )
+        self.assertLocalReduceAuxCode(code, group)
+        FileCheck().check_not("feeds_main=True").run(code)
+
+    @skipIfNoCuteDSL
+    @unittest.skipIf(not TEST_CUDA, "CUDA required")
+    @unittest.skipIf(not SM100OrLater, "SM100+ required")
+    def test_mm_local_n_reduce_feed_main_fragment_group_tuned(self):
+        m = 128
+        n = 128
+        group = 16
+
+        def epilogue_fn(acc):
+            x = acc.float().view(m, -1, group)
+            scale = x.abs().amax(-1, keepdim=True).clamp(min=1e-12) / 448.0
+            return (x * scale.reciprocal()).view(m, n).to(torch.float8_e4m3fn)
+
+        def high_precision_fn(acc):
+            x = acc.view(m, -1, group)
+            scale = x.abs().amax(-1, keepdim=True).clamp(min=1e-12) / 448.0
+            return (x * scale.reciprocal()).view(m, n)
+
+        def fn(a, b):
+            return flex_gemm(
+                torch.mm,
+                (a, b),
+                epilogue_fn,
+                kernel_options={"backend": "QUACK", "tuned": True},
+            )
+
+        a = torch.randn(m, 64, device="cuda", dtype=torch.bfloat16)
+        b = torch.randn(64, n, device="cuda", dtype=torch.bfloat16)
+        actual, (code,) = run_and_get_code(
+            torch.compile(fn, backend="inductor", fullgraph=True), a, b
+        )
+
+        self.assertEqual(actual.dtype, torch.float8_e4m3fn)
+        self.assertMatchesLowPrecisionEager(
+            actual,
+            epilogue_fn(a @ b),
+            high_precision_fn(a.double() @ b.double()),
+            a.shape[1],
+        )
+        FileCheck().check("cutlass.Float8E4M3FN").check_not(
+            "local_reduce=FlexGemmRuntimeLocalReducePlan"
+        ).run(code)
+
+    @skipIfNoCuteDSL
+    @unittest.skipIf(not TEST_CUDA, "CUDA required")
+    @unittest.skipIf(not SM100OrLater, "SM100+ required")
+    @parametrize("group", (32, 128))
+    def test_mm_local_n_reduce_feed_main_rejects_multi_fragment_group(self, group):
+        torch._dynamo.reset()
+        m = 128
+        n = 256
+
+        def epilogue_fn(acc):
+            x = acc.float().view(m, -1, group)
+            scale = x.sum(-1, keepdim=True)
+            return (x * scale.reciprocal()).view(m, n)
+
+        def fn(a, b):
+            return flex_gemm(
+                torch.mm,
+                (a, b),
+                epilogue_fn,
+                kernel_options={"backend": "QUACK"},
+            )
+
+        a = torch.rand(m, 64, device="cuda", dtype=torch.bfloat16)
+        b = torch.rand(64, n, device="cuda", dtype=torch.bfloat16)
+        with self.assertRaisesRegex(
+            Exception, "axis-1 groups larger than one TensorSSA fragment"
+        ):
+            torch.compile(fn, backend="inductor", fullgraph=True)(a, b)
+
+    @skipIfNoCuteDSL
+    @unittest.skipIf(not TEST_CUDA, "CUDA required")
+    @unittest.skipIf(not SM100OrLater, "SM100+ required")
     @parametrize(
         "case",
         (

--- a/test/inductor/test_flex_gemm.py
+++ b/test/inductor/test_flex_gemm.py
@@ -30,6 +30,7 @@ from torch.testing._internal.common_utils import (
 
 
 try:
+    import cutlass
     import cutlass.cute as cute
 except ImportError:
     cute = None
@@ -76,6 +77,51 @@ if cute is not None:
         )
         aux = acc * row_scale + tile_bias
         return main, aux
+
+    @cute.jit
+    def fragment_group32_sum_feed_epilogue(acc):
+        """Mirror the generated axis-1 group-32 TensorSSA feed epilogue.
+
+        Uses the same symbolic min()/repeat fragment expressions as generated
+        code, so a config whose per-thread fragment extent is smaller than the
+        group would silently reduce partial groups and fail the reference check.
+        """
+        tmp0 = acc.to(cutlass.Float32)
+        tmp1 = tmp0.reshape(
+            (
+                (
+                    1,
+                    cutlass.const_expr(min(32, cute.size(tmp0.shape, mode=[0]))),
+                    cutlass.const_expr(
+                        cute.size(tmp0.shape, mode=[0])
+                        // min(32, cute.size(tmp0.shape, mode=[0]))
+                    ),
+                ),
+                1,
+                1,
+            )
+        )
+        tmp2 = tmp1.reduce(
+            cute.ReductionOp.ADD,
+            init_val=0.0,
+            reduction_profile=((None, 1, None), 1, 1),
+        )
+        tmp3 = tmp2.reshape(
+            (
+                (
+                    1,
+                    1,
+                    cutlass.const_expr(
+                        cute.size(tmp1.shape, mode=[0])
+                        // min(32, cute.size(tmp1.shape, mode=[0]))
+                    ),
+                ),
+                1,
+                1,
+            )
+        )
+        tmp4 = tmp3.broadcast_to(tmp1.shape)
+        return tmp1 * (cute.full_like(tmp4, 1.0) / tmp4)
 
 
 class TestFlexGemmRuntimeImport(TestCase):
@@ -393,6 +439,8 @@ class FlexGemmTestCase(TestCase):
         )
         if callbacks:
             file_check = file_check.check("callbacks=FlexGemmLocalReduceCallbacks")
+        else:
+            file_check = file_check.check_not("callbacks=FlexGemmLocalReduceCallbacks")
         file_check.check_not("local_reduce_out=").check_not(
             "local_reduce_group="
         ).check_not("local_reduce_axis=").check_not("local_reduce_op").run(code)
@@ -408,13 +456,18 @@ class FlexGemmTestCase(TestCase):
         from torch._inductor.kernel.flex_gemm.constraints import (
             FlexGemmLocalReduceCallbacks,
             FlexGemmLocalReduceGeometry,
+            MAX_TENSORSSA_LOCAL_REDUCE_GROUP_WITHOUT_PHYSICAL_CALLBACKS,
         )
         from torch._inductor.kernel.flex_gemm.runtime import (
             FlexGemmRuntimeLocalReducePlan,
         )
 
         callbacks = None
-        if feeds_main or axis == 0 or group > 16:
+        if (
+            feeds_main
+            or axis == 0
+            or group > MAX_TENSORSSA_LOCAL_REDUCE_GROUP_WITHOUT_PHYSICAL_CALLBACKS
+        ):
             callbacks = FlexGemmLocalReduceCallbacks(
                 combine_fn=lambda lhs, rhs: lhs,
                 finalize_fn=lambda value: value,
@@ -1138,6 +1191,56 @@ class TestFlexGemmRuntime(FlexGemmTestCase):
                 (a.double() @ b.double()) * row_scale.double(),
                 a.shape[1],
             )
+
+    @unittest.skipIf(not SM100OrLater, "SM100+ required")
+    def test_mm_fragment_group32_forced_config_extremes_match_reference(self):
+        """Pin the empirically verified g32 axis-1 fragment contract per config.
+
+        Every config passing the axis-1 group-32 gate was verified to expose a
+        full 32-lane fragment to the generated TensorSSA reduce; keep the
+        extreme tile_n configs as regression sentinels for that geometry.
+        """
+        from torch._inductor.kernel.flex_gemm.constraints import (
+            validate_flex_gemm_local_reduce_config,
+        )
+        from torch._inductor.kernel.flex_gemm.runtime import gemm_epilogue
+        from torch._inductor.template_heuristics.flex_gemm import (
+            candidate_gemm_configs_for_device,
+            gemm_config_key,
+        )
+
+        m, n, k, group = 128, 256, 64, 32
+        a = torch.rand(m, k, device="cuda", dtype=torch.bfloat16)
+        b = torch.rand(k, n, device="cuda", dtype=torch.bfloat16)
+        gated = [
+            config
+            for config in candidate_gemm_configs_for_device(a.device)
+            if validate_flex_gemm_local_reduce_config(config, group, 1)
+        ]
+        self.assertTrue(gated)
+        tile_ns = sorted({config.tile_n for config in gated})
+        selected = [
+            next(config for config in gated if config.tile_n == tile_n)
+            for tile_n in (tile_ns[0], tile_ns[-1])
+        ]
+        x = (a.double() @ b.double()).view(m, -1, group)
+        expected = (x * x.sum(-1, keepdim=True).reciprocal()).view(m, n)
+        wrong_group = (a.double() @ b.double()).view(m, -1, group // 2)
+        wrong_expected = (
+            wrong_group * wrong_group.sum(-1, keepdim=True).reciprocal()
+        ).view(m, n)
+        for config in selected:
+            out = gemm_epilogue(
+                a,
+                b,
+                fragment_group32_sum_feed_epilogue,
+                f"test_flex_gemm_fragment_group32_tile_n_{config.tile_n}",
+                out_dtype=torch.float32,
+                config_key=gemm_config_key(config),
+            )
+            torch.testing.assert_close(out.double(), expected, atol=1e-4, rtol=1e-4)
+            # A partial-fragment reduce would match the half-group reference.
+            self.assertGreater((out.double() - wrong_expected).abs().max(), 1e-2)
 
     @unittest.skipIf(not SM100OrLater, "SM100+ required")
     @parametrize("shape", ((128, 512, 256), (512, 128, 256), (256, 256, 256)))
@@ -1923,7 +2026,7 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
             aux, high_precision_aux.float(), atol=1e-3, rtol=1e-3
         )
         FileCheck().check("epilogue_arg_kinds=('scalar',)").run(code)
-        self.assertLocalReduceAuxCode(code, group, callbacks=True)
+        self.assertLocalReduceAuxCode(code, group)
 
     @parametrize(
         "case",
@@ -2705,6 +2808,77 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
         torch.testing.assert_close(aux.float(), expected_aux.float())
         FileCheck().check(code_check).check("local_reduce_finalize_fn").run(code)
         self.assertLocalReduceAuxCode(code, group, callbacks=True)
+
+    @skipIfNoCuteDSL
+    @unittest.skipIf(not TEST_CUDA, "CUDA required")
+    @unittest.skipIf(not SM100OrLater, "SM100+ required")
+    def test_mm_tuple_aux_fragment_group_mx_scale_keeps_physical_finalizer(self):
+        m = 64
+        n = 128
+        k = 64
+        group = 32
+
+        def epilogue_fn(acc):
+            x = acc.float().view(m, -1, group)
+            return acc.relu(), mx_e8m0_scale(x.abs().amax(-1))
+
+        def fn(a, b):
+            return flex_gemm(
+                torch.mm,
+                (a, b),
+                epilogue_fn,
+                kernel_options={"backend": "QUACK"},
+            )
+
+        a = torch.ones(m, k, device="cuda", dtype=torch.bfloat16)
+        b = torch.ones(k, n, device="cuda", dtype=torch.bfloat16)
+        (actual, aux), (code,) = run_and_get_code(
+            torch.compile(fn, backend="inductor", fullgraph=True), a, b
+        )
+
+        expected, expected_aux = epilogue_fn(a @ b)
+        torch.testing.assert_close(actual, expected)
+        torch.testing.assert_close(aux.float(), expected_aux.float())
+        # The mx exponent bitcast only lowers in the physical scalar finalizer,
+        # so full-fragment groups must keep the callback path even though group
+        # 32 now fits one TensorSSA fragment.
+        FileCheck().check("bitcast").check("local_reduce_finalize_fn").run(code)
+        self.assertLocalReduceAuxCode(code, group, callbacks=True)
+
+    @skipIfNoCuteDSL
+    @unittest.skipIf(not TEST_CUDA, "CUDA required")
+    @unittest.skipIf(not SM100OrLater, "SM100+ required")
+    def test_mm_fragment_group_mx_quant_feed_rejects_physical_finalizer(self):
+        m = 64
+        n = 128
+        k = 64
+        group = 32
+
+        def epilogue_fn(acc):
+            x = acc.float().view(m, -1, group)
+            scale = mx_e8m0_scale(x.abs().amax(-1, keepdim=True))
+            return (
+                (x * scale.reciprocal()).view(m, n).to(torch.float8_e4m3fn),
+                scale.squeeze(-1),
+            )
+
+        def fn(a, b):
+            return flex_gemm(
+                torch.mm,
+                (a, b),
+                epilogue_fn,
+                kernel_options={"backend": "QUACK"},
+            )
+
+        a = torch.ones(m, k, device="cuda", dtype=torch.bfloat16)
+        b = torch.ones(k, n, device="cuda", dtype=torch.bfloat16)
+        # Full mx quantization needs the physically finalized scale fed back
+        # into the main output, which is outside the scalar-finalize contract;
+        # group 32 documents this boundary next to the supported scale store.
+        with self.assertRaisesRegex(
+            Exception, "finalize expressions to depend only on the reduced value"
+        ):
+            torch.compile(fn, backend="inductor", fullgraph=True)(a, b)
 
     @skipIfNoCuteDSL
     @unittest.skipIf(not TEST_CUDA, "CUDA required")
@@ -3936,7 +4110,7 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
     @skipIfNoCuteDSL
     @unittest.skipIf(not TEST_CUDA, "CUDA required")
     @unittest.skipIf(not SM100OrLater, "SM100+ required")
-    @parametrize("group", (4, 8, 16))
+    @parametrize("group", (4, 8, 16, 32))
     def test_mm_local_n_reduce_feed_main_fragment_group_sum(self, group):
         m = 128
         n = 128
@@ -3973,7 +4147,7 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
     @skipIfNoCuteDSL
     @unittest.skipIf(not TEST_CUDA, "CUDA required")
     @unittest.skipIf(not SM100OrLater, "SM100+ required")
-    @parametrize("group", (4, 8, 16))
+    @parametrize("group", (4, 8, 16, 32))
     def test_mm_local_n_reduce_feed_main_fragment_group_fp8_quant(self, group):
         m = 128
         n = 128
@@ -4016,7 +4190,7 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
     @skipIfNoCuteDSL
     @unittest.skipIf(not TEST_CUDA, "CUDA required")
     @unittest.skipIf(not SM100OrLater, "SM100+ required")
-    @parametrize("group", (4, 8, 16))
+    @parametrize("group", (4, 8, 16, 32))
     def test_mm_local_n_reduce_feed_main_fragment_group_scale_store(self, group):
         m = 128
         n = 128
@@ -4062,10 +4236,10 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
     @skipIfNoCuteDSL
     @unittest.skipIf(not TEST_CUDA, "CUDA required")
     @unittest.skipIf(not SM100OrLater, "SM100+ required")
-    def test_mm_local_n_reduce_feed_main_fragment_group_tuned(self):
+    @parametrize("group", (16, 32))
+    def test_mm_local_n_reduce_feed_main_fragment_group_tuned(self, group):
         m = 128
         n = 128
-        group = 16
 
         def epilogue_fn(acc):
             x = acc.float().view(m, -1, group)
@@ -4148,7 +4322,7 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
     @skipIfNoCuteDSL
     @unittest.skipIf(not TEST_CUDA, "CUDA required")
     @unittest.skipIf(not SM100OrLater, "SM100+ required")
-    @parametrize("group", (32, 128))
+    @parametrize("group", (64, 128))
     def test_mm_local_n_reduce_feed_main_rejects_multi_fragment_group(self, group):
         torch._dynamo.reset()
         m = 128

--- a/test/inductor/test_flex_gemm.py
+++ b/test/inductor/test_flex_gemm.py
@@ -4101,6 +4101,49 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
         FileCheck().check("cutlass.Float8E4M3FN").check_not(
             "local_reduce=FlexGemmRuntimeLocalReducePlan"
         ).run(code)
+        # Plan-less grouped fragments must gate tuned candidates like a plan:
+        # swap_ab configs would regroup the wrong accumulator elements.
+        self.assertIn("swap_ab', False", code)
+        self.assertNotIn("swap_ab', True", code)
+
+    @skipIfNoCuteDSL
+    @unittest.skipIf(not TEST_CUDA, "CUDA required")
+    @unittest.skipIf(not SM100OrLater, "SM100+ required")
+    def test_mm_local_n_reduce_feed_main_fragment_group_skinny_default_config(self):
+        m = 128
+        n = 4096
+        group = 16
+
+        def epilogue_fn(acc):
+            x = acc.float().view(m, -1, group)
+            scale = x.abs().amax(-1, keepdim=True).clamp(min=1e-12) / 448.0
+            return (x * scale.reciprocal()).view(m, n)
+
+        def fn(a, b):
+            return flex_gemm(
+                torch.mm,
+                (a, b),
+                epilogue_fn,
+                kernel_options={"backend": "QUACK"},
+            )
+
+        a = torch.randn(m, 64, device="cuda", dtype=torch.bfloat16)
+        b = torch.randn(64, n, device="cuda", dtype=torch.bfloat16)
+        actual, (code,) = run_and_get_code(
+            torch.compile(fn, backend="inductor", fullgraph=True), a, b
+        )
+
+        self.assertMatchesLowPrecisionEager(
+            actual,
+            epilogue_fn(a @ b),
+            epilogue_fn(a.double() @ b.double()),
+            a.shape[1],
+        )
+        FileCheck().check_not("local_reduce=FlexGemmRuntimeLocalReducePlan").run(code)
+        # The skinny-shape default config must satisfy the same grouped-fragment
+        # gate as tuned candidates even without a runtime local-reduce plan.
+        self.assertIn("swap_ab', False", code)
+        self.assertNotIn("swap_ab', True", code)
 
     @skipIfNoCuteDSL
     @unittest.skipIf(not TEST_CUDA, "CUDA required")

--- a/tools/vendoring/quack/flex_gemm_patches/0010-flex-gemm-fragment-group-32.patch
+++ b/tools/vendoring/quack/flex_gemm_patches/0010-flex-gemm-fragment-group-32.patch
@@ -1,0 +1,20 @@
+Allow axis-1 compressed local reductions up to one full 32-lane TensorSSA
+fragment without generated physical callbacks. Generated epilogues reshape
+per-thread fragments with symbolic min()/repeat extents, and every config
+admitted by the Inductor-side local-reduce capability gate provides at least
+a 32-wide contiguous N extent per thread, so a 32-element N group completes
+in-fragment; the kernel's dynamic replay gate still guards larger groups.
+
+diff --git a/gemm_act.py b/gemm_act.py
+index 1111111..2222222 100644
+--- a/gemm_act.py
++++ b/gemm_act.py
+@@ -1047,7 +1047,7 @@ def gemm_act(
+             raise RuntimeError("local_reduce_group must be positive")
+         if local_reduce_axis not in (0, 1):
+             raise RuntimeError("local_reduce_axis must be 0 or 1")
+-        if (local_reduce_axis == 0 or local_reduce_group > 16) and (
++        if (local_reduce_axis == 0 or local_reduce_group > 32) and (
+             local_reduce_combine_key is None or local_reduce_finalize_key is None
+         ):
+             raise RuntimeError(

--- a/tools/vendoring/quack/flex_gemm_patches/series
+++ b/tools/vendoring/quack/flex_gemm_patches/series
@@ -12,3 +12,4 @@
 0007-flex-gemm-large-n-local-reduce.patch
 0008-flex-gemm-local-reduce-feed-main.patch
 0009-flex-gemm-scalar-epilogue-args.patch
+0010-flex-gemm-fragment-group-32.patch

--- a/torch/_inductor/kernel/flex_gemm/constraints.py
+++ b/torch/_inductor/kernel/flex_gemm/constraints.py
@@ -26,8 +26,10 @@ def grouped_reduce_dims_match(dim: Any, reduce_dims: Sequence[Any]) -> bool:
     return len(dims) == 1 and dims[0] in reduce_dims
 
 
-# Feed-main currently reduces only within one lane-layout M group; cross-warp M
-# stitching needs the two-phase/replay path used by compressed aux reductions.
+# The physical feed-main path currently reduces only within one lane-layout M
+# group; cross-warp M stitching needs the two-phase/replay path used by
+# compressed aux reductions. Axis-1 feeds whose groups fit in one TensorSSA
+# fragment lower as plain generated TensorSSA without a feed plan.
 MAX_SAME_WARP_LOCAL_REDUCE_FEED_MAIN_GROUP = 32
 MAX_TENSORSSA_LOCAL_REDUCE_GROUP_WITHOUT_PHYSICAL_CALLBACKS = 16
 LOCAL_REDUCE_FEED_MAIN_AXIS_ERROR = (
@@ -36,6 +38,10 @@ LOCAL_REDUCE_FEED_MAIN_AXIS_ERROR = (
 LOCAL_REDUCE_FEED_MAIN_SAME_WARP_ERROR = (
     "FlexGEMM local-reduce feed-main currently supports only same-warp axis-0 "
     f"groups <= {MAX_SAME_WARP_LOCAL_REDUCE_FEED_MAIN_GROUP}"
+)
+LOCAL_REDUCE_FEED_MAIN_AXIS1_FRAGMENT_ERROR = (
+    "FlexGEMM local-reduce feed-main for axis-1 groups larger than one "
+    "TensorSSA fragment is not supported yet"
 )
 LOCAL_REDUCE_DIVISIBLE_SHAPE_ERROR = (
     "local_reduce_group must divide the selected FlexGEMM output dimension"

--- a/torch/_inductor/kernel/flex_gemm/constraints.py
+++ b/torch/_inductor/kernel/flex_gemm/constraints.py
@@ -31,7 +31,7 @@ def grouped_reduce_dims_match(dim: Any, reduce_dims: Sequence[Any]) -> bool:
 # compressed aux reductions. Axis-1 feeds whose groups fit in one TensorSSA
 # fragment lower as plain generated TensorSSA without a feed plan.
 MAX_SAME_WARP_LOCAL_REDUCE_FEED_MAIN_GROUP = 32
-MAX_TENSORSSA_LOCAL_REDUCE_GROUP_WITHOUT_PHYSICAL_CALLBACKS = 16
+MAX_TENSORSSA_LOCAL_REDUCE_GROUP_WITHOUT_PHYSICAL_CALLBACKS = 32
 LOCAL_REDUCE_FEED_MAIN_AXIS_ERROR = (
     "FlexGEMM local-reduce feed-main currently supports only axis 0"
 )

--- a/torch/_inductor/kernel/flex_gemm/epilogue.py
+++ b/torch/_inductor/kernel/flex_gemm/epilogue.py
@@ -22,6 +22,7 @@ from torch._inductor.kernel.flex_gemm.constraints import (
     LOCAL_REDUCE_CONTRACT_NODE_ERROR,
     LOCAL_REDUCE_EXPLICIT_DTYPE_ERROR,
     LOCAL_REDUCE_FEED_MAIN_ARG_NAME,
+    LOCAL_REDUCE_FEED_MAIN_AXIS1_FRAGMENT_ERROR,
     LOCAL_REDUCE_FEED_MAIN_MIXED_CONTRACT_ERROR,
     LOCAL_REDUCE_FINALIZE_FN_SUFFIX,
     LOCAL_REDUCE_FINALIZE_SCALAR_ONLY_ERROR,
@@ -33,6 +34,7 @@ from torch._inductor.kernel.flex_gemm.constraints import (
     LOCAL_REDUCE_SINGLE_PHYSICAL_FINALIZE_ERROR,
     LOCAL_REDUCE_SOURCE_EXPRESSION_ERROR,
     local_reduce_unsupported_tensorssa_error,
+    MAX_TENSORSSA_LOCAL_REDUCE_GROUP_WITHOUT_PHYSICAL_CALLBACKS,
     statically_known_shape_equal,
     validate_local_reduce_feed_main_capability,
     validate_local_reduce_group_axis,
@@ -534,6 +536,34 @@ def local_reduce_feed_main_binary_candidates(
     return ((lhs, rhs), (rhs, lhs))
 
 
+def local_reduce_feed_main_grouped_reduction(
+    value: Any,
+    grouped_source: torch.fx.Node,
+    layout: Any,
+) -> bool:
+    """Detect a grouped feed-main reduction without binding a value contract."""
+    if not isinstance(value, torch.fx.Node):
+        return False
+    reduction = reduction_from_node(value)
+    if reduction is not None:
+        input_node, dim, keepdim, dtype, _ = reduction
+        return (
+            dtype is None
+            and bool(keepdim)
+            and grouped_reduce_dims_match(dim, layout.reduce_dims)
+            and (
+                input_node is grouped_source
+                or fx_node_depends_on(input_node, grouped_source)
+            )
+        )
+    if not is_shape_preserving_pointwise_node(value):
+        return False
+    return any(
+        local_reduce_feed_main_grouped_reduction(arg, grouped_source, layout)
+        for arg in iter_fx_node_inputs((value.args, value.kwargs))
+    )
+
+
 def local_reduce_feed_main_candidate_contract(
     grouped_source: Any,
     value: Any,
@@ -551,8 +581,19 @@ def local_reduce_feed_main_candidate_contract(
     if not isinstance(source_node, torch.fx.Node):
         return None
     layout = grouped_tensor_layout(input_shape, tensor_meta_shape(source_node))
-    if layout is None or layout.axis != 0:
+    if layout is None:
         return None
+    if layout.axis != 0:
+        if not local_reduce_feed_main_grouped_reduction(value, grouped_source, layout):
+            return None
+        if (
+            layout.group_size
+            <= MAX_TENSORSSA_LOCAL_REDUCE_GROUP_WITHOUT_PHYSICAL_CALLBACKS
+        ):
+            # Intentional fallthrough: axis-1 feeds within one TensorSSA
+            # fragment lower as plain generated TensorSSA without a feed plan.
+            return None
+        raise NotImplementedError(LOCAL_REDUCE_FEED_MAIN_AXIS1_FRAGMENT_ERROR)
     validate_local_reduce_feed_main_capability(layout.axis, layout.group_size)
     source_meta = source_node.meta.get("val")
     if output_meta is not None and source_meta is not None:
@@ -602,14 +643,28 @@ def local_reduce_feed_main_source_contract(
 def local_reduce_feed_main_plan(
     output: torch.fx.Node,
 ) -> FlexGemmLocalReduceContract | None:
-    """Match same-warp grouped-M reductions that QuACK can broadcast."""
+    """Match grouped reductions fed back into the output, recursing through
+    trailing shape-preserving pointwise nodes to the un-grouping view."""
     view_args = view_or_reshape_args(output)
-    if view_args is None:
+    if view_args is not None:
+        source, _ = view_args
+        if not isinstance(source, torch.fx.Node):
+            return None
+        return local_reduce_feed_main_source_contract(source, output.meta.get("val"))
+    if not is_shape_preserving_pointwise_node(output):
         return None
-    source, _ = view_args
-    if not isinstance(source, torch.fx.Node):
-        return None
-    return local_reduce_feed_main_source_contract(source, output.meta.get("val"))
+    contracts = [
+        contract
+        for arg in iter_fx_node_inputs((output.args, output.kwargs))
+        for contract in (local_reduce_feed_main_plan(arg),)
+        if contract is not None
+    ]
+    return validate_feed_main_source_contract(
+        output,
+        common_local_reduce_value_contract(
+            contracts, LOCAL_REDUCE_ONE_PHYSICAL_VALUE_ERROR
+        ),
+    )
 
 
 def common_local_reduce_feed_main_contract(

--- a/torch/_inductor/kernel/flex_gemm/epilogue.py
+++ b/torch/_inductor/kernel/flex_gemm/epilogue.py
@@ -58,6 +58,7 @@ from torch._inductor.kernel.flex_gemm.quack_reductions import (
     lower_view_or_reshape,
     propagate_grouped_tensorssa_info,
     reduction_from_node,
+    reduction_requires_physical_finalize,
     squeeze_source_node,
     tensor_meta_shape,
     unsupported_reduction_from_node,
@@ -154,6 +155,7 @@ class FlexGemmOutputLocalReducePlan:
     value_node: torch.fx.Node
     store_node: torch.fx.Node | None = None
     feeds_main: bool = False
+    requires_physical_finalize: bool = False
 
     def __post_init__(self) -> None:
         """Reject invalid local-reduce output nodes."""
@@ -177,7 +179,7 @@ class FlexGemmOutputLocalReducePlan:
 
     @property
     def needs_physical_callbacks(self) -> bool:
-        return self.geometry.needs_physical_callbacks
+        return self.requires_physical_finalize or self.geometry.needs_physical_callbacks
 
 
 @dataclasses.dataclass(frozen=True)
@@ -204,6 +206,7 @@ class FlexGemmLocalReduceContract:
     aux: torch.fx.Node
     group: int
     axis: int
+    requires_physical_finalize: bool = False
 
     def __post_init__(self) -> None:
         """Reject invalid local-reduce source nodes and geometry."""
@@ -220,6 +223,7 @@ class FlexGemmLocalReduceContract:
             self.aux,
             store_node=store_node,
             feeds_main=feeds_main,
+            requires_physical_finalize=self.requires_physical_finalize,
         )
 
 
@@ -316,7 +320,7 @@ class FlexGemmLocalReduceAnalysis:
         if contract is None:
             return False
         self.contracts[node] = FlexGemmLocalReduceContract(
-            node, contract.group, contract.axis
+            node, contract.group, contract.axis, contract.requires_physical_finalize
         )
         return True
 
@@ -758,7 +762,14 @@ def local_reduce_contract_from_grouped_input(
         if not raise_invalid_dims:
             return None
         raise NotImplementedError(LOCAL_REDUCE_INNERMOST_GROUPED_DIM_ERROR)
-    return FlexGemmLocalReduceContract(node, info.group_size, info.axis)
+    return FlexGemmLocalReduceContract(
+        node,
+        info.group_size,
+        info.axis,
+        requires_physical_finalize=reduction_requires_physical_finalize(
+            node, info.layout
+        ),
+    )
 
 
 def local_reduce_analysis(

--- a/torch/_inductor/kernel/flex_gemm/epilogue.py
+++ b/torch/_inductor/kernel/flex_gemm/epilogue.py
@@ -953,8 +953,14 @@ def materialize_flex_gemm_epilogue(
     gemm_op: torch._ops.OpOverload,
     outputs: FlexGemmOutputPlan,
     epilogue_arg_placeholders: tuple[torch.fx.Node, ...] = (),
-) -> tuple[str, str]:
-    """Build the generated CuTeDSL epilogue callable from a classified FX body."""
+) -> tuple[str, str, tuple[FlexGemmLocalReduceGeometry, ...]]:
+    """Build the generated CuTeDSL epilogue callable from a classified FX body.
+
+    Also returns the grouped TensorSSA fragment geometries the epilogue relies
+    on: grouped reshapes bake the accumulator fragment orientation into the
+    generated code, so config selection must gate on them (no swap_ab, tile
+    divisibility) even when no runtime local-reduce plan exists.
+    """
     gemm = gemm_node(graph_module, gemm_op)
     kernel = FlexGemmCuteDSLKernel()
     env: dict[torch.fx.Node, Any] = {
@@ -1197,4 +1203,10 @@ def materialize_flex_gemm_epilogue(
         f"{local_reduce_source}"
         f"@cute.jit\ndef {name}({epilogue_params}):\n"
         f"{body}    return {result}\n",
+        tuple(
+            OrderedSet(
+                FlexGemmLocalReduceGeometry(info.group_size, info.axis)
+                for info in grouped_tensors.values()
+            )
+        ),
     )

--- a/torch/_inductor/kernel/flex_gemm/lowering.py
+++ b/torch/_inductor/kernel/flex_gemm/lowering.py
@@ -181,10 +181,17 @@ def flex_gemm_config_keys_for_local_reduce(
     device,
     m: int,
     n: int,
-    local_reduce,
+    local_reduce_geometries: tuple[Any, ...],
     tuned: bool,
 ) -> tuple[tuple[Any, ...], ...]:
-    """Select QuACK config keys after applying local-reduce layout constraints."""
+    """Select QuACK config keys after applying grouped-layout config constraints.
+
+    Every grouped geometry constrains the config the same way, whether it backs
+    a runtime local-reduce plan or a plan-less grouped TensorSSA fragment
+    reshape in the generated epilogue: swap_ab reorients the accumulator
+    fragment and non-divisible tiles split groups across fragments, so either
+    would silently regroup the wrong elements.
+    """
     from torch._inductor.template_heuristics.flex_gemm import (
         candidate_gemm_configs_for_device,
         default_gemm_config_key,
@@ -193,33 +200,35 @@ def flex_gemm_config_keys_for_local_reduce(
 
     if not tuned:
         default_key = default_gemm_config_key(device, m, n)
-        if local_reduce is None or validate_flex_gemm_local_reduce_config(
-            dict(default_key), local_reduce.group, local_reduce.axis
+        if all(
+            validate_flex_gemm_local_reduce_config(
+                dict(default_key), geometry.group, geometry.axis
+            )
+            for geometry in local_reduce_geometries
         ):
             return (default_key,)
 
     candidate_configs = candidate_gemm_configs_for_device(device)
-    if local_reduce is None:
-        return tuple(gemm_config_key(config) for config in candidate_configs)
-
-    local_reduce_configs = tuple(
-        config
-        for config in candidate_configs
-        if validate_flex_gemm_local_reduce_config(
-            config, local_reduce.group, local_reduce.axis
-        )
-    )
-    if not local_reduce_configs:
-        raise NotImplementedError(
-            flex_gemm_local_reduce_config_error(
-                candidate_configs,
-                local_reduce.group,
-                local_reduce.axis,
+    configs = candidate_configs
+    for geometry in local_reduce_geometries:
+        configs = tuple(
+            config
+            for config in configs
+            if validate_flex_gemm_local_reduce_config(
+                config, geometry.group, geometry.axis
             )
         )
+        if not configs:
+            raise NotImplementedError(
+                flex_gemm_local_reduce_config_error(
+                    candidate_configs,
+                    geometry.group,
+                    geometry.axis,
+                )
+            )
     if tuned:
-        return tuple(gemm_config_key(config) for config in local_reduce_configs)
-    return (gemm_config_key(local_reduce_configs[0]),)
+        return tuple(gemm_config_key(config) for config in configs)
+    return (gemm_config_key(configs[0]),)
 
 
 @register_lowering(flex_gemm_hop, type_promotion_kind=None)
@@ -335,14 +344,17 @@ def flex_gemm_lowering(gemm_op, subgraph, args, gemm_kwargs, kernel_options):
     template_local_reduce = FlexGemmEpilogueLocalReduceConfig.from_output_plan(
         outputs.local_reduce, local_reduce_out_index
     )
-    epilogue_name, epilogue_source = materialize_flex_gemm_epilogue(
+    epilogue_name, epilogue_source, grouped_geometries = materialize_flex_gemm_epilogue(
         subgraph.graph_module, gemm_op, outputs, epilogue_arg_placeholders
     )
+    local_reduce_geometries = OrderedSet(grouped_geometries)
+    if outputs.local_reduce is not None:
+        local_reduce_geometries.add(outputs.local_reduce.geometry)
     quack_config_keys = flex_gemm_config_keys_for_local_reduce(
         layout.device,
         gemm_args[mat1_index].get_size()[-2],
         gemm_args[mat2_index].get_size()[-1],
-        outputs.local_reduce,
+        tuple(local_reduce_geometries),
         tuned,
     )
     epilogue_arg_indices = tuple(

--- a/torch/_inductor/kernel/flex_gemm/quack_reductions.py
+++ b/torch/_inductor/kernel/flex_gemm/quack_reductions.py
@@ -3,9 +3,11 @@
 
 FlexGEMM recognizes a narrow local-reduction contract inside the GEMM output
 tile: an epilogue reshapes the accumulator to expose contiguous groups along M
-or N, then reduces only that grouped dimension. Supported small N-axis groups
-lower as ordinary in-fragment TensorSSA reductions; larger N groups produce
-TensorSSA partials that QuACK combines physically.
+or N, then reduces only that grouped dimension. N-axis groups up to one 32-lane
+fragment lower as ordinary in-fragment TensorSSA reductions; larger N groups
+produce TensorSSA partials that QuACK combines physically, and reductions
+feeding physical-only finalize ops (mx_e8m0_scale) stay on the callback path
+regardless of group size.
 M-axis groups currently always use QuACK's physical row-lane/warp combine path,
 even when the group is small enough to fit in one fragment. Inductor owns the
 FX pattern matching and output contracts; these helpers describe the supported
@@ -37,6 +39,7 @@ from torch._inductor.kernel.flex_gemm.constraints import (
 from torch._inductor.ops_handler import ReductionType
 from torch._inductor.shape_propagation import get_broadcasted_shape
 from torch._inductor.virtualized import V
+from torch.utils._ordered_set import OrderedSet
 
 
 def normalize_shape(shape: Any) -> Any:
@@ -227,6 +230,10 @@ FLEX_GEMM_POINTWISE_OP_NAMES = frozenset(
         "nvfp4_e4m3_scale",
     )
 )
+
+# mx_e8m0_scale's exponent bitcast/shift only lowers inside the physical scalar
+# finalizer; nvfp4_e4m3_scale has a TensorSSA clamp form and needs no callbacks.
+PHYSICAL_FINALIZE_OP_NAMES = frozenset(("mx_e8m0_scale",))
 
 PYTHON_POINTWISE_TARGETS = frozenset(
     (
@@ -466,6 +473,37 @@ def is_pointwise_node(node: torch.fx.Node) -> bool:
         node.target in PYTHON_POINTWISE_TARGETS
         or _cute_op_name(node.target) in FLEX_GEMM_POINTWISE_OP_NAMES
     )
+
+
+def reduction_requires_physical_finalize(
+    node: torch.fx.Node, layout: GroupedTensorSSALayout
+) -> bool:
+    """Return whether a fragment-sized grouped reduce must keep QuACK callbacks.
+
+    Ops in ``PHYSICAL_FINALIZE_OP_NAMES`` only lower inside the physical scalar
+    finalizer, so reductions feeding them must stay on the combine/finalize
+    callback path even when the group fits one TensorSSA fragment. Only
+    fragment-multiple groups can use QuACK's physical partial scheme; smaller
+    groups keep the TensorSSA path and reject at the finalize-op lowering.
+    """
+    if layout.group_size % 32 != 0 or local_reduce_needs_physical_callbacks(
+        layout.axis, layout.group_size
+    ):
+        return False
+    stack = list(node.users)
+    seen: OrderedSet[torch.fx.Node] = OrderedSet()
+    while stack:
+        user = stack.pop()
+        if user in seen:
+            continue
+        seen.add(user)
+        if user.op == "call_function" and (
+            _cute_op_name(user.target) in PHYSICAL_FINALIZE_OP_NAMES
+        ):
+            return True
+        if is_shape_preserving_pointwise_node(user):
+            stack.extend(user.users)
+    return False
 
 
 def is_shape_preserving_pointwise_node(node: torch.fx.Node) -> bool:
@@ -761,7 +799,10 @@ def lower_tensorssa_reduce(
         f"value / {info.group_size}.0" if reduction_type == "mean" else "value"
     )
     source = _cute_arg(input_node, env)
-    if info.layout.needs_physical_combine:
+    needs_physical_combine = info.layout.needs_physical_combine or (
+        reduction_requires_physical_finalize(node, info.layout)
+    )
+    if needs_physical_combine:
         if local_reduce_physical_reductions is not None:
             local_reduce_physical_reductions[node] = FlexGemmPhysicalReduction(
                 desc.combine_expr, finalize_expr
@@ -774,7 +815,7 @@ def lower_tensorssa_reduce(
         f"{source}.reduce({desc.cute_op}, init_val={desc.init_val}, reduction_profile={info.layout.reduction_profile})",
         source,
     )
-    if reduction_type == "mean" and not info.layout.needs_physical_combine:
+    if reduction_type == "mean" and not needs_physical_combine:
         reduced = _generate_like(
             kernel, f"{reduced} / {float(info.group_size)!r}", reduced
         )

--- a/torch/_inductor/kernel/flex_gemm/template.py
+++ b/torch/_inductor/kernel/flex_gemm/template.py
@@ -34,6 +34,7 @@ class FlexGemmEpilogueLocalReduceConfig:
     geometry: FlexGemmLocalReduceGeometry
     out_index: int | None = None
     feeds_main: bool = False
+    requires_physical_finalize: bool = False
 
     @classmethod
     def from_output_plan(
@@ -48,12 +49,17 @@ class FlexGemmEpilogueLocalReduceConfig:
             if not local_reduce.feeds_main:
                 raise RuntimeError(LOCAL_REDUCE_TEMPLATE_OUT_INDEX_ERROR)
             return FlexGemmEpilogueLocalReduceConfig(
-                local_reduce.geometry, feeds_main=True
+                local_reduce.geometry,
+                feeds_main=True,
+                requires_physical_finalize=local_reduce.requires_physical_finalize,
             )
         if out_index is None:
             raise RuntimeError(LOCAL_REDUCE_TEMPLATE_OUT_INDEX_ERROR)
         return FlexGemmEpilogueLocalReduceConfig(
-            local_reduce.geometry, out_index, local_reduce.feeds_main
+            local_reduce.geometry,
+            out_index,
+            local_reduce.feeds_main,
+            local_reduce.requires_physical_finalize,
         )
 
     @property
@@ -66,7 +72,7 @@ class FlexGemmEpilogueLocalReduceConfig:
 
     @property
     def needs_physical_callbacks(self) -> bool:
-        return self.geometry.needs_physical_callbacks
+        return self.requires_physical_finalize or self.geometry.needs_physical_callbacks
 
 
 @dataclasses.dataclass(frozen=True)

--- a/torch/_vendor/quack/gemm_act.py
+++ b/torch/_vendor/quack/gemm_act.py
@@ -1047,7 +1047,7 @@ def gemm_act(
             raise RuntimeError("local_reduce_group must be positive")
         if local_reduce_axis not in (0, 1):
             raise RuntimeError("local_reduce_axis must be 0 or 1")
-        if (local_reduce_axis == 0 or local_reduce_group > 16) and (
+        if (local_reduce_axis == 0 or local_reduce_group > 32) and (
             local_reduce_combine_key is None or local_reduce_finalize_key is None
         ):
             raise RuntimeError(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #189316
* #189315
* #189314
* #189493
* __->__ #189190
* #189188
* #188739
* #188112
* #188470
* #188469
* #188468

The feed-main matcher now recurses through trailing shape-preserving
pointwise nodes after the un-grouping view, so quant casts like
.to(float8_e4m3fn) compose with physical axis-0 feeds. Axis-1 groups
within one TensorSSA fragment (<= 16) are covered as the contract they
already lower to: pure generated TensorSSA with no runtime plan.
Axis-1 groups beyond a fragment now reject explicitly instead of
failing with misleading physical-reduce errors.