### PR TITLE
[inductor] Read kernel templates as UTF-8 to fix locale-dependent flaky failures

### DIFF
--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -1,8 +1,12 @@
 # Owner(s): ["module: inductor"]
 
+import builtins
 import importlib.util
+import tempfile
 import unittest
 from collections.abc import Callable, Iterator
+from pathlib import Path
+from unittest import mock
 
 from sympy import I, Max, Min, Symbol, sympify
 
@@ -17,7 +21,12 @@ from torch._inductor.fx_utils import (
     FakeTensorUpdater,
     get_fake,
 )
-from torch._inductor.utils import get_device_tflops, sympy_str, sympy_subs
+from torch._inductor.utils import (
+    get_device_tflops,
+    load_template,
+    sympy_str,
+    sympy_subs,
+)
 from torch._inductor.virtualized import V
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.ops import aten
@@ -310,6 +319,38 @@ class TestUtils(TestCase):
 
 
 instantiate_device_type_tests(TestUtils, globals(), allow_xpu=True)
+
+
+class TestLoadTemplate(TestCase):
+    def test_load_template_uses_utf8(self):
+        # load_template must decode templates as UTF-8 regardless of the ambient
+        # locale. On a host whose default encoding is ascii, reading a template
+        # that contains a non-ascii byte otherwise raises UnicodeDecodeError,
+        # producing a host-dependent (flaky) compile failure.
+        real_open = builtins.open
+
+        def ascii_default_open(*args, **kwargs):
+            # Emulate an ascii-locale host: open() with no explicit encoding
+            # decodes as ascii (open's 4th positional arg is encoding).
+            if kwargs.get("encoding") is None and (len(args) < 4 or args[3] is None):
+                kwargs["encoding"] = "ascii"
+            return real_open(*args, **kwargs)
+
+        with tempfile.TemporaryDirectory() as d:
+            (Path(d) / "t.py.jinja").write_text("# unicode \u2014\n", encoding="utf-8")
+            with mock.patch("builtins.open", ascii_default_open):
+                content = load_template("t", Path(d))
+        self.assertIn("\u2014", content)
+
+    def test_load_template_invalid_utf8_names_the_file(self):
+        # A template that is genuinely not valid UTF-8 (e.g. saved in a non-UTF-8
+        # codepage) must raise an error that names the offending file, not an
+        # opaque UnicodeDecodeError that hides which template is bad.
+        with tempfile.TemporaryDirectory() as d:
+            (Path(d) / "bad.py.jinja").write_bytes(b"# not utf-8: \x97\n")
+            with self.assertRaises(ValueError) as cm:
+                load_template("bad", Path(d))
+        self.assertIn("bad.py.jinja", str(cm.exception))
 
 
 class TestRuntimeEstimation(TestCase):

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -4832,8 +4832,15 @@ def is_nonfreeable_buffers(dep: Dep) -> bool:
 # Make sure to also include your jinja templates within torch_package_data in setup.py, or this function won't be able to find them
 def load_template(name: str, template_dir: Path) -> str:
     """Load a template file and return its content."""
-    with open(template_dir / f"{name}.py.jinja") as f:
-        return f.read()
+    path = template_dir / f"{name}.py.jinja"
+    try:
+        with open(path, encoding="utf-8") as f:
+            return f.read()
+    except UnicodeDecodeError as e:
+        # Name the offending file: a bare UnicodeDecodeError hides which
+        # template is malformed, which is easy to misdiagnose when it surfaces
+        # deep inside kernel lowering.
+        raise ValueError(f"Template {path} is not valid UTF-8: {e}") from e
 
 
 def should_fallback_by_default(node: torch.fx.Node) -> bool:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189196

load_template opened .py.jinja kernel templates without specifying an
encoding, so open() used the process's locale-preferred encoding. On CI hosts
whose locale is C/POSIX (ASCII), reading a template that contains a non-ASCII
character (e.g. an em dash in a comment) raised UnicodeDecodeError and failed
compilation. Because the fleet is locale-heterogeneous, the same test passed
or failed depending on which host it landed on, and passed on retry -- i.e. it
presented as flaky rather than as a deterministic failure.

The failure surfaced through the FB TLX flex-attention template
(tlx_flex_attention.py.jinja), imported lazily during flex_attention lowering,
so it manifested as flaky flex_attention/flex_decoding tests. The OSS
cutedsl_mm_grouped.py.jinja template contains the same latent issue and is
fixed by the same change since all template loads funnel through load_template.

The fix reads templates as UTF-8 explicitly, which is correct because these
are repo-owned source files that are already valid UTF-8. It also wraps a
decode failure in a ValueError that names the offending template file: a bare
UnicodeDecodeError hides which template is malformed, which is what made the
original failure hard to diagnose (the message only said "can't decode byte
0xe2 in position 16312", with no filename).

Fixes T278775453, T278775455, T278775457 (and other flex_attention tests that
flaked from the same root cause).

Test Plan:

```
python test/inductor/test_utils.py TestLoadTemplate
lintrunner -a torch/_inductor/utils.py test/inductor/test_utils.py
```

test_load_template_uses_utf8 verifies a valid-UTF-8 template loads under a
simulated ASCII-locale host; test_load_template_invalid_utf8_names_the_file
verifies a non-UTF-8 template raises an error that names the file.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo