### PR TITLE
make post-processing in codegen mandatory

### DIFF
--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -9729,143 +9729,143 @@ class Scheduler:
             self.previous_node = None
         self.flush()
         
-        def _codegen_loop(self, nodes: list[BaseSchedulerNode]) -> None:
-            for node in nodes:
-                if log.isEnabledFor(logging.DEBUG):
-                    try:
-                        log.debug(
-                            "Generating code for node %s with estimated runtime %f",
-                            node.get_name(),
-                            node.get_estimated_runtime(),
-                        )
-                    except Exception:
-                        log.debug(
-                            "Generating code for node %s with estimated runtime 0.0",
-                            node.get_name(),
-                        )
-    
-                self.enter_context(node)
-    
-                # pyrefly: ignore [unbound-name]
-                if config.size_asserts:
-                    V.graph.wrapper_code.codegen_deferred_input_asserts(
-                        dep.name for dep in node.read_writes.reads
+    def _codegen_loop(self, nodes: list[BaseSchedulerNode]) -> None:
+        for node in nodes:
+            if log.isEnabledFor(logging.DEBUG):
+                try:
+                    log.debug(
+                        "Generating code for node %s with estimated runtime %f",
+                        node.get_name(),
+                        node.get_estimated_runtime(),
                     )
-    
-                if device := node.get_device():
-                    if (
-                        device != self.current_device
-                        or node.is_extern()
-                        or node.is_template()
-                    ):
-                        self.flush()
-                    if device != self.current_device:
-                        if self.current_device and device_need_guard(
-                            self.current_device.type
-                        ):
-                            # Exit stream context before exiting device guard
-                            if self.current_stream_idx is not None:
-                                self.generate_stream_ctx_exit()
-                            V.graph.wrapper_code.codegen_device_guard_exit()
-                        self.current_device = device
-                        if device_need_guard(device.type):
-                            if device.index is None:
-                                raise AssertionError("device should have an index")
-                            # Compute num_streams if we have multi-stream nodes
-                            num_streams = 1
-                            if self._has_multi_stream_nodes():
-                                # Count unique streams (excluding default stream 0)
-                                unique_streams = OrderedSet(self.node_to_stream.values())
-                                num_streams = (
-                                    max(unique_streams) + 1 if unique_streams else 1
-                                )
-                            V.graph.wrapper_code.codegen_device_guard_enter(
-                                device.index,
-                                num_streams,
-                                self.stream_idx_to_user_obj_idx,
-                            )
-    
-                # Handle stream context switching for multi-stream scheduling.
-                # This runs for all nodes (including device-less sync ops like
-                # record_event/wait_event) so they are placed inside the correct
-                # stream context. Only switch when inside a device guard (i.e.
-                # current_device is set), since stream variables are declared there.
-                if self._has_multi_stream_nodes() and self.current_device is not None:
-                    self.generate_stream_ctx_switching(node)
-    
-                # Emit deferred alignment copies for inputs first used by this
-                # node.  This runs *after* stream context switching so the copy
-                # executes on the same stream as the consuming kernel.
-                # TODO: inputs read on multiple streams should be copied in the
-                # prologue instead, to avoid cross-stream races.
-                V.graph.wrapper_code.codegen_deferred_alignment_copies(
+                except Exception:
+                    log.debug(
+                        "Generating code for node %s with estimated runtime 0.0",
+                        node.get_name(),
+                    )
+
+            self.enter_context(node)
+
+            # pyrefly: ignore [unbound-name]
+            if config.size_asserts:
+                V.graph.wrapper_code.codegen_deferred_input_asserts(
                     dep.name for dep in node.read_writes.reads
                 )
-    
-                self.current_node = node
-                self.buffer_names_to_free.update(node.last_usage)
-    
-                if node.is_template():
-                    prologue, template_node, epilogue = node.get_prologue_template_epilogue(
-                        list(node.get_nodes())
-                    )
-                    # pyrefly: ignore [unbound-name]
-                    self.get_backend(device).codegen_template(
-                        template_node, epilogue, prologue
-                    )
-                elif node.is_extern():
-                    self.codegen_extern_call(node)
-                elif node.is_foreach():
-                    node = typing.cast(ForeachKernelSchedulerNode, node)
-                    # pyrefly: ignore [unbound-name]
-                    backend_ = self.get_backend(device)
-                    from .codegen.cuda_combined_scheduling import CUDACombinedScheduling
-                    from .codegen.simd import SIMDScheduling
-                    from .codegen.xpu.xpu_combined_scheduling import XPUCombinedScheduling
-    
-                    if isinstance(
-                        backend_,
-                        (SIMDScheduling, CUDACombinedScheduling, XPUCombinedScheduling),
+
+            if device := node.get_device():
+                if (
+                    device != self.current_device
+                    or node.is_extern()
+                    or node.is_template()
+                ):
+                    self.flush()
+                if device != self.current_device:
+                    if self.current_device and device_need_guard(
+                        self.current_device.type
                     ):
-                        backend = backend_
-                    else:
-                        raise AssertionError(f"{type(self)=}")
-                    backend.codegen_combo_kernel(node)
-                elif isinstance(node, FusedNestedReductions):
-                    # pyrefly: ignore [unbound-name]
-                    self.get_backend(device).codegen_nested_reduction(node)
-                elif isinstance(node, FusedMixOrderReductions):
-                    # pyrefly: ignore [unbound-name]
-                    self.get_backend(device).codegen_mix_order_reduction(node)
-                elif isinstance(node, (FusedSchedulerNode, SchedulerNode)):
-                    # pyrefly: ignore [unbound-name]
-                    self.get_backend(device).codegen_node(node)
-                else:
-                    if not isinstance(node, NopKernelSchedulerNode):
-                        raise AssertionError("expected node to be a NopKernelSchedulerNode")
-                    node.mark_run()
-    
+                        # Exit stream context before exiting device guard
+                        if self.current_stream_idx is not None:
+                            self.generate_stream_ctx_exit()
+                        V.graph.wrapper_code.codegen_device_guard_exit()
+                    self.current_device = device
+                    if device_need_guard(device.type):
+                        if device.index is None:
+                            raise AssertionError("device should have an index")
+                        # Compute num_streams if we have multi-stream nodes
+                        num_streams = 1
+                        if self._has_multi_stream_nodes():
+                            # Count unique streams (excluding default stream 0)
+                            unique_streams = OrderedSet(self.node_to_stream.values())
+                            num_streams = (
+                                max(unique_streams) + 1 if unique_streams else 1
+                            )
+                        V.graph.wrapper_code.codegen_device_guard_enter(
+                            device.index,
+                            num_streams,
+                            self.stream_idx_to_user_obj_idx,
+                        )
+
+            # Handle stream context switching for multi-stream scheduling.
+            # This runs for all nodes (including device-less sync ops like
+            # record_event/wait_event) so they are placed inside the correct
+            # stream context. Only switch when inside a device guard (i.e.
+            # current_device is set), since stream variables are declared there.
+            if self._has_multi_stream_nodes() and self.current_device is not None:
+                self.generate_stream_ctx_switching(node)
+
+            # Emit deferred alignment copies for inputs first used by this
+            # node.  This runs *after* stream context switching so the copy
+            # executes on the same stream as the consuming kernel.
+            # TODO: inputs read on multiple streams should be copied in the
+            # prologue instead, to avoid cross-stream races.
+            V.graph.wrapper_code.codegen_deferred_alignment_copies(
+                dep.name for dep in node.read_writes.reads
+            )
+
+            self.current_node = node
+            self.buffer_names_to_free.update(node.last_usage)
+
+            if node.is_template():
+                prologue, template_node, epilogue = node.get_prologue_template_epilogue(
+                    list(node.get_nodes())
+                )
                 # pyrefly: ignore [unbound-name]
-                if config.triton.debug_sync_kernel:
-                    # pyrefly: ignore [unbound-name]
-                    self.get_backend(device).codegen_sync()
-    
-                self.available_buffer_names.update(node.get_buffer_names())
-                self.completed_operations.update(node.get_operation_names())
-    
-                if not isinstance(node, NopKernelSchedulerNode):
-                    device = node.get_device()
-                    if (
-                        device is not None
-                        and device.type != "meta"
-                        and self.get_backend(device).ready_to_flush()
-                    ):
-                        self.flush()
-    
-                if all(isinstance(n, SchedulerNode) for n in node.get_nodes()):
-                    self.previous_node = node
+                self.get_backend(device).codegen_template(
+                    template_node, epilogue, prologue
+                )
+            elif node.is_extern():
+                self.codegen_extern_call(node)
+            elif node.is_foreach():
+                node = typing.cast(ForeachKernelSchedulerNode, node)
+                # pyrefly: ignore [unbound-name]
+                backend_ = self.get_backend(device)
+                from .codegen.cuda_combined_scheduling import CUDACombinedScheduling
+                from .codegen.simd import SIMDScheduling
+                from .codegen.xpu.xpu_combined_scheduling import XPUCombinedScheduling
+
+                if isinstance(
+                    backend_,
+                    (SIMDScheduling, CUDACombinedScheduling, XPUCombinedScheduling),
+                ):
+                    backend = backend_
                 else:
-                    self.previous_node = None
+                    raise AssertionError(f"{type(self)=}")
+                backend.codegen_combo_kernel(node)
+            elif isinstance(node, FusedNestedReductions):
+                # pyrefly: ignore [unbound-name]
+                self.get_backend(device).codegen_nested_reduction(node)
+            elif isinstance(node, FusedMixOrderReductions):
+                # pyrefly: ignore [unbound-name]
+                self.get_backend(device).codegen_mix_order_reduction(node)
+            elif isinstance(node, (FusedSchedulerNode, SchedulerNode)):
+                # pyrefly: ignore [unbound-name]
+                self.get_backend(device).codegen_node(node)
+            else:
+                if not isinstance(node, NopKernelSchedulerNode):
+                    raise AssertionError("expected node to be a NopKernelSchedulerNode")
+                node.mark_run()
+
+            # pyrefly: ignore [unbound-name]
+            if config.triton.debug_sync_kernel:
+                # pyrefly: ignore [unbound-name]
+                self.get_backend(device).codegen_sync()
+
+            self.available_buffer_names.update(node.get_buffer_names())
+            self.completed_operations.update(node.get_operation_names())
+
+            if not isinstance(node, NopKernelSchedulerNode):
+                device = node.get_device()
+                if (
+                    device is not None
+                    and device.type != "meta"
+                    and self.get_backend(device).ready_to_flush()
+                ):
+                    self.flush()
+
+            if all(isinstance(n, SchedulerNode) for n in node.get_nodes()):
+                self.previous_node = node
+            else:
+                self.previous_node = None
 
         if self.current_device != self.default_device_context:
             # when default_device_context is not None, we are codegen

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -9723,142 +9723,149 @@ class Scheduler:
         # Deferred to just before the first kernel that reads each input.
         V.graph.wrapper_code.register_alignment_check_inputs()
 
-        for node in nodes:
-            if log.isEnabledFor(logging.DEBUG):
-                try:
-                    log.debug(
-                        "Generating code for node %s with estimated runtime %f",
-                        node.get_name(),
-                        node.get_estimated_runtime(),
+        try:
+            self._codegen_loop(nodes)
+        finally:
+            self.previous_node = None
+        self.flush()
+        
+        def _codegen_loop(self, nodes: list[BaseSchedulerNode]) -> None:
+            for node in nodes:
+                if log.isEnabledFor(logging.DEBUG):
+                    try:
+                        log.debug(
+                            "Generating code for node %s with estimated runtime %f",
+                            node.get_name(),
+                            node.get_estimated_runtime(),
+                        )
+                    except Exception:
+                        log.debug(
+                            "Generating code for node %s with estimated runtime 0.0",
+                            node.get_name(),
+                        )
+    
+                self.enter_context(node)
+    
+                # pyrefly: ignore [unbound-name]
+                if config.size_asserts:
+                    V.graph.wrapper_code.codegen_deferred_input_asserts(
+                        dep.name for dep in node.read_writes.reads
                     )
-                except Exception:
-                    log.debug(
-                        "Generating code for node %s with estimated runtime 0.0",
-                        node.get_name(),
-                    )
-
-            self.enter_context(node)
-
-            # pyrefly: ignore [unbound-name]
-            if config.size_asserts:
-                V.graph.wrapper_code.codegen_deferred_input_asserts(
+    
+                if device := node.get_device():
+                    if (
+                        device != self.current_device
+                        or node.is_extern()
+                        or node.is_template()
+                    ):
+                        self.flush()
+                    if device != self.current_device:
+                        if self.current_device and device_need_guard(
+                            self.current_device.type
+                        ):
+                            # Exit stream context before exiting device guard
+                            if self.current_stream_idx is not None:
+                                self.generate_stream_ctx_exit()
+                            V.graph.wrapper_code.codegen_device_guard_exit()
+                        self.current_device = device
+                        if device_need_guard(device.type):
+                            if device.index is None:
+                                raise AssertionError("device should have an index")
+                            # Compute num_streams if we have multi-stream nodes
+                            num_streams = 1
+                            if self._has_multi_stream_nodes():
+                                # Count unique streams (excluding default stream 0)
+                                unique_streams = OrderedSet(self.node_to_stream.values())
+                                num_streams = (
+                                    max(unique_streams) + 1 if unique_streams else 1
+                                )
+                            V.graph.wrapper_code.codegen_device_guard_enter(
+                                device.index,
+                                num_streams,
+                                self.stream_idx_to_user_obj_idx,
+                            )
+    
+                # Handle stream context switching for multi-stream scheduling.
+                # This runs for all nodes (including device-less sync ops like
+                # record_event/wait_event) so they are placed inside the correct
+                # stream context. Only switch when inside a device guard (i.e.
+                # current_device is set), since stream variables are declared there.
+                if self._has_multi_stream_nodes() and self.current_device is not None:
+                    self.generate_stream_ctx_switching(node)
+    
+                # Emit deferred alignment copies for inputs first used by this
+                # node.  This runs *after* stream context switching so the copy
+                # executes on the same stream as the consuming kernel.
+                # TODO: inputs read on multiple streams should be copied in the
+                # prologue instead, to avoid cross-stream races.
+                V.graph.wrapper_code.codegen_deferred_alignment_copies(
                     dep.name for dep in node.read_writes.reads
                 )
-
-            if device := node.get_device():
-                if (
-                    device != self.current_device
-                    or node.is_extern()
-                    or node.is_template()
-                ):
-                    self.flush()
-                if device != self.current_device:
-                    if self.current_device and device_need_guard(
-                        self.current_device.type
+    
+                self.current_node = node
+                self.buffer_names_to_free.update(node.last_usage)
+    
+                if node.is_template():
+                    prologue, template_node, epilogue = node.get_prologue_template_epilogue(
+                        list(node.get_nodes())
+                    )
+                    # pyrefly: ignore [unbound-name]
+                    self.get_backend(device).codegen_template(
+                        template_node, epilogue, prologue
+                    )
+                elif node.is_extern():
+                    self.codegen_extern_call(node)
+                elif node.is_foreach():
+                    node = typing.cast(ForeachKernelSchedulerNode, node)
+                    # pyrefly: ignore [unbound-name]
+                    backend_ = self.get_backend(device)
+                    from .codegen.cuda_combined_scheduling import CUDACombinedScheduling
+                    from .codegen.simd import SIMDScheduling
+                    from .codegen.xpu.xpu_combined_scheduling import XPUCombinedScheduling
+    
+                    if isinstance(
+                        backend_,
+                        (SIMDScheduling, CUDACombinedScheduling, XPUCombinedScheduling),
                     ):
-                        # Exit stream context before exiting device guard
-                        if self.current_stream_idx is not None:
-                            self.generate_stream_ctx_exit()
-                        V.graph.wrapper_code.codegen_device_guard_exit()
-                    self.current_device = device
-                    if device_need_guard(device.type):
-                        if device.index is None:
-                            raise AssertionError("device should have an index")
-                        # Compute num_streams if we have multi-stream nodes
-                        num_streams = 1
-                        if self._has_multi_stream_nodes():
-                            # Count unique streams (excluding default stream 0)
-                            unique_streams = OrderedSet(self.node_to_stream.values())
-                            num_streams = (
-                                max(unique_streams) + 1 if unique_streams else 1
-                            )
-                        V.graph.wrapper_code.codegen_device_guard_enter(
-                            device.index,
-                            num_streams,
-                            self.stream_idx_to_user_obj_idx,
-                        )
-
-            # Handle stream context switching for multi-stream scheduling.
-            # This runs for all nodes (including device-less sync ops like
-            # record_event/wait_event) so they are placed inside the correct
-            # stream context. Only switch when inside a device guard (i.e.
-            # current_device is set), since stream variables are declared there.
-            if self._has_multi_stream_nodes() and self.current_device is not None:
-                self.generate_stream_ctx_switching(node)
-
-            # Emit deferred alignment copies for inputs first used by this
-            # node.  This runs *after* stream context switching so the copy
-            # executes on the same stream as the consuming kernel.
-            # TODO: inputs read on multiple streams should be copied in the
-            # prologue instead, to avoid cross-stream races.
-            V.graph.wrapper_code.codegen_deferred_alignment_copies(
-                dep.name for dep in node.read_writes.reads
-            )
-
-            self.current_node = node
-            self.buffer_names_to_free.update(node.last_usage)
-
-            if node.is_template():
-                prologue, template_node, epilogue = node.get_prologue_template_epilogue(
-                    list(node.get_nodes())
-                )
-                # pyrefly: ignore [unbound-name]
-                self.get_backend(device).codegen_template(
-                    template_node, epilogue, prologue
-                )
-            elif node.is_extern():
-                self.codegen_extern_call(node)
-            elif node.is_foreach():
-                node = typing.cast(ForeachKernelSchedulerNode, node)
-                # pyrefly: ignore [unbound-name]
-                backend_ = self.get_backend(device)
-                from .codegen.cuda_combined_scheduling import CUDACombinedScheduling
-                from .codegen.simd import SIMDScheduling
-                from .codegen.xpu.xpu_combined_scheduling import XPUCombinedScheduling
-
-                if isinstance(
-                    backend_,
-                    (SIMDScheduling, CUDACombinedScheduling, XPUCombinedScheduling),
-                ):
-                    backend = backend_
+                        backend = backend_
+                    else:
+                        raise AssertionError(f"{type(self)=}")
+                    backend.codegen_combo_kernel(node)
+                elif isinstance(node, FusedNestedReductions):
+                    # pyrefly: ignore [unbound-name]
+                    self.get_backend(device).codegen_nested_reduction(node)
+                elif isinstance(node, FusedMixOrderReductions):
+                    # pyrefly: ignore [unbound-name]
+                    self.get_backend(device).codegen_mix_order_reduction(node)
+                elif isinstance(node, (FusedSchedulerNode, SchedulerNode)):
+                    # pyrefly: ignore [unbound-name]
+                    self.get_backend(device).codegen_node(node)
                 else:
-                    raise AssertionError(f"{type(self)=}")
-                backend.codegen_combo_kernel(node)
-            elif isinstance(node, FusedNestedReductions):
+                    if not isinstance(node, NopKernelSchedulerNode):
+                        raise AssertionError("expected node to be a NopKernelSchedulerNode")
+                    node.mark_run()
+    
                 # pyrefly: ignore [unbound-name]
-                self.get_backend(device).codegen_nested_reduction(node)
-            elif isinstance(node, FusedMixOrderReductions):
-                # pyrefly: ignore [unbound-name]
-                self.get_backend(device).codegen_mix_order_reduction(node)
-            elif isinstance(node, (FusedSchedulerNode, SchedulerNode)):
-                # pyrefly: ignore [unbound-name]
-                self.get_backend(device).codegen_node(node)
-            else:
+                if config.triton.debug_sync_kernel:
+                    # pyrefly: ignore [unbound-name]
+                    self.get_backend(device).codegen_sync()
+    
+                self.available_buffer_names.update(node.get_buffer_names())
+                self.completed_operations.update(node.get_operation_names())
+    
                 if not isinstance(node, NopKernelSchedulerNode):
-                    raise AssertionError("expected node to be a NopKernelSchedulerNode")
-                node.mark_run()
-
-            # pyrefly: ignore [unbound-name]
-            if config.triton.debug_sync_kernel:
-                # pyrefly: ignore [unbound-name]
-                self.get_backend(device).codegen_sync()
-
-            self.available_buffer_names.update(node.get_buffer_names())
-            self.completed_operations.update(node.get_operation_names())
-
-            if not isinstance(node, NopKernelSchedulerNode):
-                device = node.get_device()
-                if (
-                    device is not None
-                    and device.type != "meta"
-                    and self.get_backend(device).ready_to_flush()
-                ):
-                    self.flush()
-
-            if all(isinstance(n, SchedulerNode) for n in node.get_nodes()):
-                self.previous_node = node
-            else:
-                self.previous_node = None
+                    device = node.get_device()
+                    if (
+                        device is not None
+                        and device.type != "meta"
+                        and self.get_backend(device).ready_to_flush()
+                    ):
+                        self.flush()
+    
+                if all(isinstance(n, SchedulerNode) for n in node.get_nodes()):
+                    self.previous_node = node
+                else:
+                    self.previous_node = None
 
         if self.current_device != self.default_device_context:
             # when default_device_context is not None, we are codegen
@@ -9871,8 +9878,6 @@ class Scheduler:
                 # important for nested indentation codegen-ing.
                 V.graph.wrapper_code.codegen_device_guard_exit()
 
-        self.previous_node = None
-        self.flush()
 
     def benchmark_combo_kernel(
         self, node_list: Sequence[BaseSchedulerNode], node_benchmark_results


### PR DESCRIPTION
We hit this in HeavyBall when running our tests. Some nodes are sometimes left dirty which can cause tests to fail when invoked often enough. I did not investigate whether this same pattern should be applied to other functions as well.

Repro:

```PYTHON
"""
Minimal reproduction of the invariant violation in
torch/_inductor/scheduler.py Scheduler._codegen (~L9692).

_codegen checks self.previous_node is None at entry (L9715) and resets it
at exit (L9874), but the reset is not in a finally block. If codegen throws
mid-loop, previous_node stays dirty and the next call raises
AssertionError("expected previous_node to be None").
"""


class Node:
    def __init__(self, name, *, fail=False):
        self.name = name
        self._fail = fail

    def codegen(self):
        if self._fail:
            raise RuntimeError(f"{self.name}: codegen failed")

    def get_nodes(self):
        return [self]


# -- Buggy pattern (current code) -----------------------------------------

class BuggyCodegen:
    def __init__(self):
        self.previous_node = None

    def _codegen(self, nodes):
        if self.previous_node is not None:
            raise AssertionError("expected previous_node to be None")
        self._codegen_loop(nodes)
        self.previous_node = None  # not in a finally
        self.flush()

    def _codegen_loop(self, nodes):
        for node in nodes:
            node.codegen()
            self.previous_node = node

    def flush(self):
        pass


# -- Fixed pattern ---------------------------------------------------------

class FixedCodegen:
    def __init__(self):
        self.previous_node = None

    def _codegen(self, nodes):
        if self.previous_node is not None:
            raise AssertionError("expected previous_node to be None")
        try:
            self._codegen_loop(nodes)
        finally:
            self.previous_node = None
        self.flush()

    def _codegen_loop(self, nodes):
        for node in nodes:
            node.codegen()
            self.previous_node = node

    def flush(self):
        pass


# -- Demonstrate -----------------------------------------------------------

nodes = [Node("a"), Node("b", fail=True), Node("c")]

buggy = BuggyCodegen()
try:
    buggy._codegen(nodes)
except RuntimeError:
    pass

assert buggy.previous_node is not None, "expected dirty state"
print(f"bug: previous_node = {buggy.previous_node.name!r} (should be None)")

try:
    buggy._codegen(nodes)
    raise SystemExit("should not reach here")
except AssertionError as e:
    print(f"bug: next call raises AssertionError: {e}")


fixed = FixedCodegen()
try:
    fixed._codegen(nodes)
except RuntimeError:
    pass

assert fixed.previous_node is None
print(f"fix: previous_node = {fixed.previous_node!r}")
fixed._codegen([Node("a"), Node("c")])
print("fix: next call succeeds")
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo