### PR TITLE
[DTensor] Fix spurious cross-device FakeTensor mismatch in multi-threaded tests

### DIFF
--- a/torch/distributed/tensor/_sharding_prop.py
+++ b/torch/distributed/tensor/_sharding_prop.py
@@ -12,6 +12,7 @@ from torch._guards import detect_fake_mode
 from torch._logging import LazyString
 from torch._ops import OpOverload
 from torch._subclasses import FakeTensorMode
+from torch._subclasses.fake_tensor import disable_fake_tensor_cache
 from torch.distributed._functional_collectives import _are_we_tracing
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor._decompositions import DecompShardingStrategy
@@ -531,8 +532,15 @@ class ShardingPropagator:
         # NOTE: We must call the tracing in fake tensor mode so that it avoids
         # materializing memory.
         # NOTE: Use _fake_mode_lock to serialize access when running in
-        # multi-threaded tests (lock must be set to threading.Lock()).
-        # This is a nullcontext by default.
+        # multi-threaded tests (lock must be set to threading.Lock()); it is a
+        # nullcontext by default. An engaged lock is our signal that we are in a
+        # multi-threaded test, where each rank is a thread with a distinct
+        # current device. The FakeTensorMode dispatch cache is process-global,
+        # but the fake args built below use the mesh's index-less device type
+        # (e.g. "xpu"), which fake mode resolves to the calling thread's current
+        # device. A cache entry populated by one thread would then hand another
+        # thread a fake tensor on the wrong device index, yielding a spurious
+        # cross-device mismatch, so we bypass the cache in that mode.
         # NOTE: disable_proxy_modes_tracing() prevents make_fx from tracing
         # into shard propagation. This op runs purely to derive output
         # metadata (global shape/stride/dtype); it is not part of the real
@@ -542,9 +550,18 @@ class ShardingPropagator:
         # on empty_strided placeholders that no real output consumes.
         from torch.fx.experimental.proxy_tensor import disable_proxy_modes_tracing
 
-        with ShardingPropagator._fake_mode_lock:
+        fake_mode_lock = ShardingPropagator._fake_mode_lock
+        in_multi_threaded_test = not isinstance(fake_mode_lock, nullcontext)
+        with fake_mode_lock:
             fake_mode = detect_fake_mode() or FakeTensorMode()
-            with fake_mode, disable_proxy_modes_tracing():
+        
+            cache_ctx = (
+                disable_fake_tensor_cache(fake_mode)
+                if in_multi_threaded_test
+                else nullcontext()
+            )
+
+            with fake_mode, cache_ctx, disable_proxy_modes_tracing():
                 fake_args = op_schema.gen_fake_args()
                 fake_kwargs = op_schema.gen_fake_kwargs()
                 fake_out = op_schema.op(*fake_args, **fake_kwargs)
@@ -1117,3 +1134,4 @@ class ShardingPropagator:
             if existing_dims == target_dims:
                 return None
         return OpSchema(dims_variant, (input_spec, target_dims), {})
+

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -5,6 +5,7 @@ import contextlib
 import os
 import re
 import sys
+import threading
 import time
 import warnings
 from abc import ABC, abstractmethod
@@ -1178,7 +1179,15 @@ class FSDPTestMultiThread(MultiThreadedTestCase):
 
     def setUp(self):
         super().setUp()
+        from torch.distributed.tensor._sharding_prop import ShardingPropagator
+        self._orig_fake_mode_lock = ShardingPropagator._fake_mode_lock
+        ShardingPropagator._fake_mode_lock = threading.Lock()
         self._spawn_threads()
+
+    def tearDown(self):
+        from torch.distributed.tensor._sharding_prop import ShardingPropagator
+        ShardingPropagator._fake_mode_lock = self._orig_fake_mode_lock
+        super().tearDown()
 
     def run_subtests(self, *args, **kwargs):
         return run_subtests(self, *args, **kwargs)
@@ -1747,3 +1756,4 @@ class SkipModel(nn.Module):
         x = self.linear_skip(x)
         x = self.nested_linear(x)
         return x
+


### PR DESCRIPTION
## Problem
Multi-threaded DTensor tests (those built on `FSDPTestMultiThread`) can fail with a spurious device-propagation error such as:

_RuntimeError: Unhandled FakeTensor Device Propagation for aten.where.self, found two different devices xpu:0, xpu:2_

## Fix
- `common_fsdp.py`: `FSDPTestMultiThread.setUp` swaps `ShardingPropagator._fake_mode_lock` from `nullcontext()` to a real `threading.Lock()` (restored in `tearDown`). This serializes fake-mode tracing across threads and signals that we are in the multi-threaded test.
	
- `_sharding_prop.py`: when that lock is engaged, tracing runs under `disable_fake_tensor_cache`, so no thread reads another thread's device-tagged result.

## Test Plan
python test/distributed/_composable/fsdp/test_fully_shard_extensions.py

Fails with the device-mismatch error before the fix; passes after.