### PR TITLE
[CuteDSL][RMSNorm] use const_data_ptr for alignment check

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -16182,6 +16182,15 @@ class TestFusedRMSNormOverrideRouting(TestCase):
         w = torch.randn(128, dtype=torch.float32, device="cuda")
         self.assertTrue(_fused_rms_norm_cond(x, [128], w, 1e-5))
 
+    def test_fwd_cond_fires_without_materializing_cow(self):
+        from torch._native.ops.norm.rmsnorm_impl import _fused_rms_norm_cond
+
+        x = torch.randn(8, 128, dtype=torch.float16, device="cuda")._lazy_clone()
+        w = torch.randn(128, dtype=torch.float16, device="cuda")._lazy_clone()
+        self.assertTrue(_fused_rms_norm_cond(x, [128], w, 1e-5))
+        self.assertTrue(torch._C._is_cow_tensor(x))
+        self.assertTrue(torch._C._is_cow_tensor(w))
+
     def test_fwd_cond_false_on_unsupported_dtype(self):
         # fp64 is outside the override's supported dtype set.
         from torch._native.ops.norm.rmsnorm_impl import _fused_rms_norm_cond
@@ -16365,6 +16374,21 @@ class TestFusedRMSNormOverrideRouting(TestCase):
             )
         )
 
+    def test_bwd_cond_fires_without_materializing_cow(self):
+        from torch._native.ops.norm.rmsnorm_impl import _fused_rms_norm_backward_cond
+
+        shape = (8, 128)
+        x = torch.randn(*shape, dtype=torch.float16, device="cuda")._lazy_clone()
+        w = torch.randn(128, dtype=torch.float16, device="cuda")._lazy_clone()
+        gout = torch.randn(*shape, dtype=torch.float16, device="cuda")._lazy_clone()
+        rstd = torch.empty(shape[0], dtype=torch.float32, device="cuda")._lazy_clone()
+        tensors = (gout, x, rstd, w)
+        self.assertTrue(
+            _fused_rms_norm_backward_cond(gout, x, [128], rstd, w, [True, True])
+        )
+        for tensor in tensors:
+            self.assertTrue(torch._C._is_cow_tensor(tensor))
+
 
 @unittest.skipIf(not TEST_CUDA, "CUDA not available")
 @skipIfNoCuteDSL
@@ -16382,6 +16406,34 @@ class TestFusedRMSNormOverrideNumerics(TestCase):
     Generic per-dtype numerics across many shapes are covered by the OpInfo
     entry in torch/testing/_internal/common_methods_invocations.py.
     """
+
+    def test_fwd_preserves_cow_inputs(self):
+        x = torch.randn(8, 128, dtype=torch.float16, device="cuda")._lazy_clone()
+        w = torch.randn(128, dtype=torch.float16, device="cuda")._lazy_clone()
+        torch.ops.aten._fused_rms_norm(x, [128], w, 1e-5)
+        self.assertTrue(torch._C._is_cow_tensor(x))
+        self.assertTrue(torch._C._is_cow_tensor(w))
+
+    def test_bwd_preserves_cow_inputs(self):
+        shape = (8, 128)
+        x_base = torch.randn(*shape, dtype=torch.float16, device="cuda")
+        w_base = torch.randn(128, dtype=torch.float16, device="cuda")
+        with torch.backends.python_native.operations_disabled("_fused_rms_norm"):
+            _, rstd_base = torch.ops.aten._fused_rms_norm(
+                x_base, [128], w_base, 1e-5
+            )
+        tensors = (
+            torch.randn(*shape, dtype=torch.float16, device="cuda")._lazy_clone(),
+            x_base._lazy_clone(),
+            rstd_base._lazy_clone(),
+            w_base._lazy_clone(),
+        )
+        gout, x, rstd, w = tensors
+        torch.ops.aten._fused_rms_norm_backward(
+            gout, x, [128], rstd, w, [True, True]
+        )
+        for tensor in tensors:
+            self.assertTrue(torch._C._is_cow_tensor(tensor))
 
     def test_weight_none(self):
         dtype = torch.float16

--- a/torch/_native/ops/norm/norms.py
+++ b/torch/_native/ops/norm/norms.py
@@ -68,10 +68,13 @@ def _const_data_ptr(t: torch.Tensor) -> int:
 def _read_only(t: torch.Tensor | None):  # type: ignore[no-untyped-def]
     if t is None:
         return None
+    from cutlass.cute.runtime import from_dlpack
+
     from torch.utils.dlpack import ReadOnlyTensorWrapper
 
     with torch._C.DisableTorchFunctionSubclass():
-        return ReadOnlyTensorWrapper(t)
+        t = ReadOnlyTensorWrapper(t)
+    return from_dlpack(t, enable_tvm_ffi=True)
 
 
 def _reshape_2d(t: torch.Tensor, M: int, N: int) -> torch.Tensor:

--- a/torch/_native/ops/norm/norms.py
+++ b/torch/_native/ops/norm/norms.py
@@ -60,16 +60,30 @@ def _required_align_bytes(t: torch.Tensor, N: int) -> int:
     return math.gcd(N, 128 // (itemsize * 8)) * itemsize
 
 
+def _const_data_ptr(t: torch.Tensor) -> int:
+    with torch._C.DisableTorchFunctionSubclass():
+        return t.const_data_ptr()  # type: ignore[attr-defined]
+
+
+def _read_only(t: torch.Tensor | None):  # type: ignore[no-untyped-def]
+    if t is None:
+        return None
+    from torch.utils.dlpack import ReadOnlyTensorWrapper
+
+    with torch._C.DisableTorchFunctionSubclass():
+        return ReadOnlyTensorWrapper(t)
+
+
 def _reshape_2d(t: torch.Tensor, M: int, N: int) -> torch.Tensor:
     align = _required_align_bytes(t, N)
     if t.ndim == 2 and t.shape[0] == M and t.shape[1] == N and t.is_contiguous():
         # .contiguous() is a no-op on an already-contiguous tensor and would
         # preserve a misaligned base; clone to force a fresh (aligned) buffer.
-        return t if t.data_ptr() % align == 0 else t.clone()
+        return t if _const_data_ptr(t) % align == 0 else t.clone()
     out = t.reshape(M, N).contiguous()
     # reshape can return a view that keeps the original (misaligned) storage
     # offset, and .contiguous() then leaves it untouched.
-    return out if out.data_ptr() % align == 0 else out.clone()
+    return out if _const_data_ptr(out) % align == 0 else out.clone()
 
 
 def _aligned_weight(w: torch.Tensor, N: int) -> torch.Tensor:
@@ -77,7 +91,7 @@ def _aligned_weight(w: torch.Tensor, N: int) -> torch.Tensor:
     # contiguous-but-offset weight, leaving a misaligned base. Weight is only
     # N elements, so always clone rather than perf-gating like the input.
     w = w.reshape(N).contiguous()
-    if w.data_ptr() % _required_align_bytes(w, N) != 0:
+    if _const_data_ptr(w) % _required_align_bytes(w, N) != 0:
         w = w.clone()
     return w
 
@@ -127,7 +141,7 @@ def quack_rmsnorm_fwd(
         per_head=False,
     )
     # compile order: (x, weight, bias, res, out, res_out, rstd, mean, eps)
-    kernel(x, weight, None, None, out, None, rstd, None, eps)
+    kernel(_read_only(x), _read_only(weight), None, None, out, None, rstd, None, eps)
 
     out = out.reshape(input_shape)
     stat_shape = list(input_shape[: -len(normalized_shape)]) + [1] * len(
@@ -186,7 +200,18 @@ def quack_rmsnorm_bwd(
         per_head=False,
     )
     # compile order: (x, weight, dout, dres_out, rstd, dx, dw_partial, dres, db_partial, sm_count)
-    kernel(x, weight, dout, None, rstd_flat, dx, dw_partial, None, None, sm_count)
+    kernel(
+        _read_only(x),
+        _read_only(weight),
+        _read_only(dout),
+        None,
+        _read_only(rstd_flat),
+        dx,
+        dw_partial,
+        None,
+        None,
+        sm_count,
+    )
 
     dx = dx.reshape(input.shape)
     # `dw_partial is not None` implies `weight is not None` (invariant from

--- a/torch/_native/ops/norm/rmsnorm_impl.py
+++ b/torch/_native/ops/norm/rmsnorm_impl.py
@@ -11,7 +11,7 @@ import math
 import torch
 
 from ... import cutedsl_utils as cu
-from .norms import _required_align_bytes
+from .norms import _const_data_ptr, _required_align_bytes
 
 
 def _is_supported(input: torch.Tensor) -> bool:
@@ -92,7 +92,7 @@ def _misaligned_clone_unprofitable(t: torch.Tensor, n: int) -> bool:
     # way, which always lands on an aligned fresh buffer.
     if not t.is_contiguous():
         return False
-    if t.data_ptr() % _required_align_bytes(t, n) == 0:
+    if _const_data_ptr(t) % _required_align_bytes(t, n) == 0:
         return False
     return t.numel() < _MISALIGNED_MIN_NUMEL
 
@@ -158,14 +158,6 @@ def _fused_rms_norm_cond(
     # measured; fall through to aten until we do.
     if weight is not None and not weight.is_contiguous():
         return False
-    # The override reshapes + makes contiguous, which materializes a COW input.
-    # Match the bmm_outer_product cond (triton_impl.py:46) and fall through to
-    # aten so composite-compliance tests don't flag spurious materialization.
-    is_cow = torch._C._is_cow_tensor  # pyrefly: ignore[missing-attribute]
-    if is_cow(input):
-        return False
-    if weight is not None and is_cow(weight):
-        return False
     return True
 
 
@@ -215,10 +207,6 @@ def _fused_rms_norm_backward_cond(
         return False
     if weight is not None and not weight.is_contiguous():
         return False
-    is_cow = torch._C._is_cow_tensor  # pyrefly: ignore[missing-attribute]
-    for t in (grad_out, input, rstd, weight):
-        if t is not None and is_cow(t):
-            return False
     return True
 
 


### PR DESCRIPTION

otherwise fails COW test checks when a mutable `data_ptr` is used e.g.,

```
AssertionError: False is not true : Argument 0 during forward call unexpectedly materializes. Either set `supports_cow_input_no_materialize_forward=False` in this operation's OpInfo, add the arg to the OpInfo's `allow_cow_input_materialize_forward` list, or change the implementation to avoid materialization.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/lib/python3.12/unittest/case.py", line 58, in testPartExecutor
    yield
  File "/usr/lib/python3.12/unittest/case.py", line 634, in run
    self._callTestMethod(testMethod)
  File "/usr/lib/python3.12/unittest/case.py", line 589, in _callTestMethod
    if method() is not None:
       ^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_utils.py", line 3590, in wrapper
    method(*args, **kwargs)
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_utils.py", line 3590, in wrapper
    method(*args, **kwargs)
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_device_type.py", line 627, in instantiated_test
    result = test(self, **param_kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_utils.py", line 1933, in wrapper
    fn(*args, **kwargs)
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_device_type.py", line 1462, in test_wrapper
    raise e_tracked from e
Exception: False is not true : Argument 0 during forward call unexpectedly materializes. Either set `supports_cow_input_no_materialize_forward=False` in this operation's OpInfo, add the arg to the OpInfo's `allow_cow_input_materialize_forward` list, or change the implementation to avoid materialization.

Caused by sample input at index 0: SampleInput(input=Tensor[size=(1, 2, 3), device="cuda:0", dtype=torch.float32], args=((1,2,3),Tensor[size=(1, 2, 3), device="cuda:0", dtype=torch.float32]), kwargs={'eps': '0.5'}, broadcasts_input=False, name='')

To execute this test, run the following from the base repo dir:
    PYTORCH_OPINFO_SAMPLE_INPUT_INDEX=0 python test/test_ops.py TestCompositeComplianceCUDA.test_cow_input_nn_functional_rms_norm_cuda_float32
    ```
    
    authored with codex

cc @ptrblck @msaroufim @tinglvv @nWEIdia @slayton58