### PR TITLE
revert the std::latch changes in ParallelNative (D109888039 + D110655102) (#189204)

### DIFF
--- a/aten/src/ATen/ParallelNative.cpp
+++ b/aten/src/ATen/ParallelNative.cpp
@@ -12,8 +12,6 @@
 #endif // C10_MOBILE
 
 #include <atomic>
-#include <latch>
-#include <memory>
 #include <utility>
 
 #ifdef _OPENMP
@@ -154,20 +152,16 @@ void invoke_parallel(
   std::tie(num_tasks, chunk_size) =
       internal::calc_num_tasks_and_chunk_size(begin, end, grain_size);
 
-  struct State {
+  struct {
     std::atomic_flag err_flag = ATOMIC_FLAG_INIT;
     std::exception_ptr eptr;
-    std::latch latch;
-    explicit State(size_t n) : latch(static_cast<ptrdiff_t>(n)) {}
-  };
-  // shared_ptr so the latch outlives every worker's count_down(): a worker's
-  // pool job holds a reference until after it returns from count_down(), so
-  // the last reference (and thus destruction) can never race the notify. A
-  // stack-local latch is a use-after-free -- the coordinator's wait() can
-  // return and unwind this frame while a worker is still touching the latch.
-  auto state = std::make_shared<State>(num_tasks);
+    std::mutex mutex;
+    std::atomic_size_t remaining{0};
+    std::condition_variable cv;
+  } state;
 
-  auto task = [state, f, begin, end, chunk_size](size_t task_id) {
+  auto task = [f, &state, begin, end, chunk_size]
+      (size_t task_id) {
     int64_t local_start = static_cast<int64_t>(begin + task_id * chunk_size);
     if (local_start < end) {
       int64_t local_end = std::min(end, static_cast<int64_t>(chunk_size + local_start));
@@ -175,19 +169,30 @@ void invoke_parallel(
         ParallelRegionGuard guard(static_cast<int>(task_id));
         f(local_start, local_end);
       } catch (...) {
-        if (!state->err_flag.test_and_set()) {
-          state->eptr = std::current_exception();
+        if (!state.err_flag.test_and_set()) {
+          state.eptr = std::current_exception();
         }
       }
     }
-    state->latch.count_down();
+    {
+      std::unique_lock<std::mutex> lk(state.mutex);
+      if (--state.remaining == 0) {
+        state.cv.notify_one();
+      }
+    }
   };
+  state.remaining = num_tasks;
   _run_with_pool(std::move(task), num_tasks);
 
   // Wait for all tasks to finish.
-  state->latch.wait();
-  if (state->eptr) {
-    std::rethrow_exception(state->eptr);
+  {
+    std::unique_lock<std::mutex> lk(state.mutex);
+    if (state.remaining != 0) {
+      state.cv.wait(lk);
+    }
+  }
+  if (state.eptr) {
+    std::rethrow_exception(state.eptr);
   }
 }
 


### PR DESCRIPTION
Summary:

Folding the two separate reverts (D110920814 and D110920859) into one diff, since they both touch ParallelNative.cpp and have to land together. D110655102 was a use-after-free fixup layered on top of D109888039's std::latch simplification, so reverting just one of them leaves the file half-reverted. This backs out both and restores the pre-std::latch waiting logic.

Test Plan:
Mechanical revert of two already-landed diffs. Leaning on CI (test_parallel) to confirm ParallelNative still builds and passes with the old logic restored.
-----
Test locally
  # 1. Check out the revert diff
  sl goto D110922852 --reason "check out revert diff to verify - sl help goto"

  # 2. Lease a paired glasses+phone constellation (runs a few min)
  maui sf nova
  maui con -g remote -p remote

  # 3. Get the live serials (glasses = greatwhite_cf_emu, phone = sdk_phone64)
  adb devices -l          # e.g. glasses 127.0.0.1:15557, phone 127.0.0.1:15556
  #   confirm both booted:
  adb -s 127.0.0.1:15557 shell getprop sys.boot_completed   # -> 1
  adb -s 127.0.0.1:15556 shell getprop sys.boot_completed   # -> 1

  # 4. Build + deploy the assistant native runtime to the cuttlefish glasses
  python3 xplat/assistant/oacr/native/scripts/build.py hypernova \
      --strip --deploy --emulator --deploy_serial 127.0.0.1:15557
  #   -> ends with "✓ assistant started successfully!"

  # 5. Run the previously-failing weather E2E (NOTE: no -c; -t selects one config; map roles->serials)
  unset DEVICE_SERIAL
  jest-e2e arvr/js/projects/Wearables/smartglasses/gauntlet/utilities/__e2e__/hypernova-assistant-online-query-weather-android-today-gauntlet.js -l \
      -t
  '{"device":"greatwhite-cuttlefish-android-phone-emulator","glasses":"greatwhite-cuttlefish","phone":"android-phone-emulator","isOSTest":"false","artifactsUnderTest":"[\"StellaStagingForAndroid\"]"}'
  \
      --deviceOverrides glasses=127.0.0.1:15557,phone=127.0.0.1:15556

https://www.internalfb.com/intern/testinfra/diagnostics/24206848027981227.562950299541421.1783452405/?section=%22summary%22

Reviewed By: jessiezheng123

Differential Revision: D110922852


