### PR TITLE
Scope cuDNN Engine 5 errata to SM 8.6 GPUs only

### DIFF
--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -14,6 +14,7 @@ C10_DIAGNOSTIC_POP()
 
 #include <ATen/TensorUtils.h>
 #include <ATen/core/Tensor.h>
+#include <ATen/cuda/CUDAContextLight.h>
 #include <ATen/cuda/Exceptions.h>
 #include <ATen/cudnn/Handle.h>
 #include <ATen/native/ConvUtils.h>
@@ -696,9 +697,12 @@ bool plan_errata_exception(
                     }
                 ]
             })");
+  // Only disable Engine 5 on SM 8.6 GPUs (A10G, A2) where it causes
+  // nondeterminism. Other architectures (H100, A100, etc.) are unaffected.
   if (cudnn_frontend::check_errata(
           hardcoded_errata_json_handle_188288, executionPlanTag, handle, []() {
-            return true;
+            auto* prop = at::cuda::getCurrentDeviceProperties();
+            return prop->major == 8 && prop->minor == 6;
           })) {
     return true;
   }


### PR DESCRIPTION
# [cuDNN][Convolution] Scope Engine 5 errata to SM 8.6 GPUs only

## Summary

PR #188318 disabled cuDNN forward convolution Engine 5 unconditionally to fix nondeterminism on SM 8.6 GPUs (A10G, A2). Blocking it globally caused a severe regression on H100/H200 for depthwise-separable convolution models: 5 of 6 affected models dropped below 1.0x speedup (compiled slower than eager).

This fix scopes the errata to SM 8.6 only, preserving the nondeterminism fix where needed while restoring performance everywhere else.

Fixes regression flagged in #188318. [HUD regression report](https://hud.pytorch.org/benchmark/regression/report/af9a8514-5335-4c80-8af2-4a421876d41e).

## Benchmark Results (reproduced on H200, bfloat16, inference, inductor no cudagraphs)

```bash
python benchmarks/dynamo/timm_models.py --performance --cold-start-latency \
  --inference --bfloat16 --backend inductor --disable-cudagraphs \
  --device cuda --exclude-exact torchrec_dlrm --output <output.csv>
```

| Model | Before #188318 (beea4b4) | After #188318 (cbfa95e) | Regression | With this fix | vs Before |
|---|---|---|---|---|---|
| mobilenetv2_100 | 2.463 | 0.482 | -80.4% | 2.444 | -0.8% |
| mobilenetv3_large_100 | 2.367 | 0.557 | -76.5% | 2.367 | +0.0% |
| mobilevit_s | 1.797 | 0.470 | -73.8% | 1.788 | -0.5% |
| tf_efficientnet_b0 | 2.264 | 0.583 | -74.2% | 2.270 | +0.3% |
| ghostnet_100 | 1.776 | 0.610 | -65.7% | 1.774 | -0.1% |
| convnextv2_nano | 2.188 | 1.277 | -41.6% | 2.180 | -0.4% |
| adv_inception_v3 | 2.229 | 2.228 | -0.0% | 2.233 | +0.2% |
| beit_base_patch16_224 | 1.152 | 1.148 | -0.3% | 1.151 | -0.1% |
| deit_base_distilled_patch16_224 | 1.078 | 1.076 | -0.2% | 1.078 | +0.0% |
| deit_tiny_patch16_224.fb_in1k | 1.186 | 1.212 | +2.2% | 1.186 | +0.0% |
| dm_nfnet_f0 | 2.078 | 2.041 | -1.8% | 2.075 | -0.1% |
| inception_v3 | 2.236 | 2.231 | -0.2% | 2.237 | +0.0% |
| nfnet_l0 | 3.362 | 3.397 | +1.0% | 3.358 | -0.1% |
| repvgg_a2 | 2.043 | 2.050 | +0.3% | 2.062 | +0.9% |
| swin_base_patch4_window7_224 | 1.495 | 1.522 | +1.8% | 1.523 | +1.9% |
| visformer_small | 1.615 | 1.620 | +0.3% | 1.619 | +0.2% |
| vit_base_patch14_dinov2.lvd142m | 1.082 | 1.075 | -0.6% | 1.081 | -0.1% |
| vit_base_patch16_siglip_256 | 1.580 | 1.575 | -0.3% | 1.572 | -0.5% |

## Bisection

- **Last stable**: `12a9ea264bf` (Jun 29)
- **First regressed**: `c8f2d26abd0` (Jun 30)
- **Identified commit**: `cbfa95e5395` (#188318)
- Verified: regression appears exactly at the identified commit, reverting at HEAD fully restores performance, non-depthwise models are stable across all commits

Assisted-by: Claude:claude-opus-4-6
