### PR TITLE
Skip sccache server init in linux test jobs to avoid transient S3 503 failures

### DIFF
--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -291,6 +291,7 @@ jobs:
           SCCACHE_BUCKET: ossci-compiler-cache-circleci-v2
           SCCACHE_REGION: us-east-1
           SCCACHE_S3_NO_CREDENTIALS: ${{ steps.aws-creds.outcome != 'success' && 'true' || 'false' }}
+          SKIP_SCCACHE_INITIALIZATION: 1
           XLA_CUDA: ${{ contains(inputs.build-environment, 'xla') && '0' || '' }}
           XLA_CLANG_CACHE_S3_BUCKET_NAME: ossci-compiler-clang-cache-circleci-xla
           PYTORCH_TEST_RERUN_DISABLED_TESTS: ${{ matrix.rerun_disabled_tests && '1' || '0' }}


### PR DESCRIPTION
## Summary

Linux test shards (e.g. \`einops\`) intermittently fail during test-step setup with exit code 2, **before any test runs**. Example: [einops job](https://github.com/pytorch/pytorch/actions/runs/28884070392/job/85681766733).

Root cause: \`test.sh\` sources \`common-build.sh\`, which runs \`sccache --start-server\`. On startup sccache does a read probe of a fixed key (\`.sccache_check\`) in the shared \`ossci-compiler-cache-circleci-v2\` bucket. That bucket is hit by every concurrent CI job, so S3 throttles the hot key with a transient **503**:

\`\`\`
sccache: error: Server startup failed: cache storage failed to read: Unexpected (temporary) at read
uri: https://s3.us-east-1.amazonaws.com/ossci-compiler-cache-circleci-v2/.sccache_check
response: status: 503 ... server: AmazonS3
\`\`\`

The probe surfaces the 503 as a fatal error, and under \`set -e\` it aborts the whole job even though the compiler cache is irrelevant to a test shard.

## Fix

Build jobs already avoid this by setting \`SKIP_SCCACHE_INITIALIZATION=1\` (\`_linux-build.yml\`), which skips the explicit \`--start-server\` while still letting sccache be used on-demand for any inline compilation. This applies the same flag to \`_linux-test.yml\`.

_This PR was authored with the help of an AI assistant._