### PR TITLE
[inductor] Fix with_effects star deps keyed by buffer name instead of operation name

### DIFF
--- a/test/higher_order_ops/test_with_effects.py
+++ b/test/higher_order_ops/test_with_effects.py
@@ -262,6 +262,75 @@ def forward(self, arg0_1, arg1_1, arg2_1):
 
     @unittest.skipIf(IS_WINDOWS, "Skipped on Windows!")
     @skipIfNoDynamoSupport
+    def test_compile_inductor_effect_ordering_scheduler_deps(self):
+        # The effect-chain StarDeps recorded in V.graph.additional_star_deps
+        # must survive to the scheduler as real dependencies between the
+        # effectful ops. The scheduler looks them up by operation name
+        # ("opN"); keying them by buffer name ("bufN") silently drops them,
+        # leaving the ops free to be reordered by passes like simple_overlap
+        # (deadlocking collectives that rely on effect ordering).
+        from torch._inductor import config as inductor_config
+        from torch._inductor.virtualized import V
+
+        with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
+            torch.library.define("mylib::effectful_id", "(Tensor x) -> Tensor", lib=lib)
+
+            def effectful_id(x):
+                return x.clone()
+
+            lib.impl("effectful_id", effectful_id, "CompositeExplicitAutograd")
+            handle = _register_effectful_op(
+                torch.ops.mylib.effectful_id.default, _EffectType.ORDERED
+            )
+            try:
+
+                def f(x):
+                    a = torch.ops.mylib.effectful_id(x)
+                    b = torch.ops.mylib.effectful_id(x)
+                    return a + b
+
+                captured: list[dict] = []
+
+                def capture(nodes):
+                    op_names = {n.get_name() for n in nodes}
+                    star_deps = {
+                        k: set(v) for k, v in V.graph.additional_star_deps.items()
+                    }
+                    unmet = {
+                        n.get_name(): {d.name for d in n.unmet_dependencies}
+                        for n in nodes
+                    }
+                    captured.append(
+                        {"op_names": op_names, "star_deps": star_deps, "unmet": unmet}
+                    )
+                    return nodes
+
+                torch._dynamo.reset()
+                with inductor_config.patch(_pre_fusion_custom_pass=capture):
+                    inputs = (torch.randn(2, 3),)
+                    res = torch.compile(f, backend="inductor", fullgraph=True)(*inputs)
+                self.assertTrue(torch.allclose(res, f(*inputs)))
+
+                self.assertTrue(captured, "expected at least one Inductor compile")
+                state = captured[0]
+                self.assertTrue(
+                    state["star_deps"], "expected effect-chain star deps to be recorded"
+                )
+                # Every recorded effect dependency must be keyed by an
+                # operation the scheduler knows about...
+                for op_name in state["star_deps"]:
+                    self.assertIn(op_name, state["op_names"])
+                # ...and materialize as a scheduler dependency so the second
+                # effectful op cannot be reordered before the first.
+                scheduled_deps = set().union(*state["unmet"].values())
+                for deps in state["star_deps"].values():
+                    for dep in deps:
+                        self.assertIn(dep, scheduled_deps)
+            finally:
+                handle.destroy()
+
+    @unittest.skipIf(IS_WINDOWS, "Skipped on Windows!")
+    @skipIfNoDynamoSupport
     def test_compile_inductor_external_op_return_none(self):
         with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
             torch.library.define(

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -9239,7 +9239,10 @@ def with_effects(token, op, *args, **kwargs):
             # Patch has_side_effects to return True
             new_op.has_side_effects = lambda: True  # pyrefly: ignore[missing-attribute]
             if prev_effect_buffer:
-                op_name = new_op.get_name()  # pyrefly: ignore[missing-attribute]
+                # Keyed by operation name ("opN"): the scheduler looks these up
+                # via BaseSchedulerNode.get_name(), not the buffer name ("bufN").
+                # pyrefly: ignore[missing-attribute]
+                op_name = new_op.get_operation_name()
                 V.graph.additional_star_deps[op_name].add(prev_effect_buffer.get_name())
         # Update the effectful ops chain to point to the latest operation
         V.graph.effectful_ops[effect_type] = (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189209

The with_effects lowering records effect-chain ordering into V.graph.additional_star_deps keyed by new_op.get_name(). For FallbackKernel (an OperationBuffer), get_name() resolves to Buffer.get_name() and returns the buffer name (bufN), but Scheduler.compute_dependencies looks entries up by BaseSchedulerNode.get_name(), which returns the operation name (opN). The keys never match, so every effect-chain StarDep is silently dropped and effectful ops sharing only graph inputs have no scheduler-visible ordering edges between them.

This went unnoticed until enable_simple_overlap became the default (#184240): the pass hoists collectives past nodes with no dependency edges, which reorders effectful custom ops. In torchcomms this hoists a blocking recv above the paired send in compiled graphs and deadlocks all ranks (meta-pytorch/torchcomms CI has hung at FullgraphCompileTest::test_fullgraph_compile_send_recv on every main run since the 20260625 nightly).

Fix by keying with get_operation_name(), matching the scheduler lookup and the sibling additional_buffer_deps convention used by control_deps.

Test Plan:

New regression test asserts the recorded star deps are keyed by scheduler-known operation names and materialize as unmet_dependencies:

```
python test/higher_order_ops/test_with_effects.py -k test_compile_inductor_effect_ordering_scheduler_deps
```

Fails before the fix (star deps keyed by buf2/buf3, scheduler nodes are op0..op4), passes after. Existing with_effects inductor tests (print/dce/effects_and_*, 7 tests) still pass.

Also verified end-to-end on 4xH100 with meta-pytorch/torchcomms: with this patch applied to the 20260706 nightly and simple_overlap left enabled, the previously deadlocking FullgraphCompileTest.py passes (22 tests, 210 subtests) and the generated code preserves send/recv program order on every rank.

Authored with Claude Code.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo