### PR TITLE
Migrate upload-test-stats-while-running to OSDC/ARC

### DIFF
--- a/.github/workflows/upload-test-stats-while-running.yml
+++ b/.github/workflows/upload-test-stats-while-running.yml
@@ -15,25 +15,12 @@ permissions:
   contents: read
 
 jobs:
-  get-label-type:
-    name: get-label-type
-    # Don't run on forked repos
-    if: github.repository_owner == 'pytorch'
-    uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
-    with:
-      triggering_actor: ${{ github.triggering_actor }}
-      issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
-      curr_branch: ${{ github.head_ref || github.ref_name }}
-      curr_ref_type: ${{ github.ref_type }}
-      check_experiments: "arc,lf"
-
   upload_test_stats_while_running:
     # Don't run on forked repos
     if: github.repository_owner == 'pytorch'
     name: Upload test stats while running
-    needs: get-label-type
-    # OSDC ARC runner, equivalent of linux.2xlarge.
-    runs-on: "${{ needs.get-label-type.outputs.label-type }}l-x86iavx512-8-64"
+    # Meta OSDC ARC runner, equivalent of linux.2xlarge.
+    runs-on: l-x86iavx512-8-64
     # ARC has no host docker daemon, so run inside a container. The
     # actions-runner image ships no python; uv provisions it below.
     container:

--- a/.github/workflows/upload-test-stats-while-running.yml
+++ b/.github/workflows/upload-test-stats-while-running.yml
@@ -18,7 +18,7 @@ jobs:
   upload_test_stats_while_running:
     if: github.repository_owner == 'pytorch'
     name: Upload test stats while running
-    runs-on: mt-l-x86iavx512-8-64
+    runs-on: mt-l-x86iamx-8-16
     container:
       image: ghcr.io/actions/actions-runner:latest
     steps:

--- a/.github/workflows/upload-test-stats-while-running.yml
+++ b/.github/workflows/upload-test-stats-while-running.yml
@@ -20,7 +20,7 @@ jobs:
     if: github.repository_owner == 'pytorch'
     name: Upload test stats while running
     # Meta OSDC ARC runner, equivalent of linux.2xlarge.
-    runs-on: l-x86iavx512-8-64
+    runs-on: mt-l-x86iavx512-8-64
     # ARC has no host docker daemon, so run inside a container. The
     # actions-runner image ships no python; uv provisions it below.
     container:

--- a/.github/workflows/upload-test-stats-while-running.yml
+++ b/.github/workflows/upload-test-stats-while-running.yml
@@ -16,13 +16,9 @@ permissions:
 
 jobs:
   upload_test_stats_while_running:
-    # Don't run on forked repos
     if: github.repository_owner == 'pytorch'
     name: Upload test stats while running
-    # Meta OSDC ARC runner, equivalent of linux.2xlarge.
     runs-on: mt-l-x86iavx512-8-64
-    # ARC has no host docker daemon, so run inside a container. The
-    # actions-runner image ships no python; uv provisions it below.
     container:
       image: ghcr.io/actions/actions-runner:latest
     steps:

--- a/.github/workflows/upload-test-stats-while-running.yml
+++ b/.github/workflows/upload-test-stats-while-running.yml
@@ -10,20 +10,57 @@ concurrency:
   group: upload-test-stats-while-running
   cancel-in-progress: true
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
+  get-label-type:
+    name: get-label-type
+    # Don't run on forked repos
+    if: github.repository_owner == 'pytorch'
+    uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
+    with:
+      triggering_actor: ${{ github.triggering_actor }}
+      issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
+      curr_branch: ${{ github.head_ref || github.ref_name }}
+      curr_ref_type: ${{ github.ref_type }}
+      check_experiments: "arc,lf"
+
   upload_test_stats_while_running:
+    # Don't run on forked repos
     if: github.repository_owner == 'pytorch'
     name: Upload test stats while running
-    runs-on: linux.2xlarge
+    needs: get-label-type
+    # OSDC ARC runner, equivalent of linux.2xlarge.
+    runs-on: "${{ needs.get-label-type.outputs.label-type }}l-x86iavx512-8-64"
+    # ARC has no host docker daemon, so run inside a container. The
+    # actions-runner image ships no python; uv provisions it below.
+    container:
+      image: ghcr.io/actions/actions-runner:latest
     steps:
       - name: Setup Linux
         uses: pytorch/pytorch/.github/actions/setup-linux@main
         with:
+          use-arc: true
           submodules: false
+
+      - name: Setup uv
+        uses: pytorch/test-infra/.github/actions/setup-uv@main
+        with:
+          python-version: "3.12"
+          activate-environment: true
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/arc
+          aws-region: us-east-1
+          role-duration-seconds: 18000
 
       - name: Install requirements
         run: |
-          python3 -m pip install requests==2.32.2 boto3==1.35.42
+          uv pip install requests==2.32.2 boto3==1.35.42
 
       - name: Upload test stats
         env:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189210

Move the hourly test-stats uploader off the EC2 linux.2xlarge runner onto
an OSDC/ARC runner. It now runs in a container (ARC has no host docker),
uses setup-linux's ARC path, and assumes role/arc for gha-artifacts S3
access (the EC2 instance role is gone).

Authored with the assistance of Claude Code.