### PR TITLE
[inductor] Read templates as UTF-8 in load_template

### DIFF
--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -4832,7 +4832,7 @@ def is_nonfreeable_buffers(dep: Dep) -> bool:
 # Make sure to also include your jinja templates within torch_package_data in setup.py, or this function won't be able to find them
 def load_template(name: str, template_dir: Path) -> str:
     """Load a template file and return its content."""
-    with open(template_dir / f"{name}.py.jinja") as f:
+    with open(template_dir / f"{name}.py.jinja", encoding="utf-8") as f:
         return f.read()
 
 


### PR DESCRIPTION
Summary:
`load_template` in `torch/_inductor/utils.py` opened template `.py.jinja` files without specifying an encoding, so Python used the locale's default encoding. On hosts whose locale resolves to ascii (e.g. a `C`/`POSIX` locale with UTF-8 mode disabled, `PYTHONUTF8=0`), reading a template that contains non-ASCII characters raises `UnicodeDecodeError`, which surfaces during Inductor lowering as `LoweringException: UnicodeDecodeError: 'ascii' codec can't decode byte ...` wrapped in an `InductorError`.

Several fb kernel templates contain non-ASCII bytes (for example a right-arrow, U+2192, in comments in `fb/tlx_templates/tlx_flex_attention.py.jinja`, plus characters in the flex templates), so any flex_attention / flex_decoding compilation that reaches the template loader fails. Because the failure depends on the host locale, the affected tests (e.g. `caffe2/test/inductor:flex_decoding`) were flaky: they failed only on ascii-locale hosts and passed on UTF-8 hosts.

The fix opens template files with `encoding="utf-8"`. `load_template` is the single reader behind every Inductor template loader (`load_fb_kernel_template`, `load_flex_template`, and `load_kernel_template` are all `functools.partial(load_template, ...)`), so this one-line change makes template loading locale-independent for all of them.

Authored with the assistance of Claude Code (AI).

Test Plan:
Reproduced the failure and verified the fix in the exact failing configuration (`@//mode/opt`) by forcing the ascii locale, on the previously-flaky `flex_decoding` test.

Without the fix (reverted), forcing the failure locale:

```
buck2 test @//mode/opt fbcode//caffe2/test/inductor:flex_decoding -- --run-disabled --env LC_ALL=C --env PYTHONUTF8=0 --regex 'test_head_dependent_mask_mod_float16_score_mod0_head_dims0_cuda_float16'
```

Result: FAIL with `UnicodeDecodeError: 'ascii' codec can't decode byte 0xe1 ...` raised from `load_template` (`torch/_inductor/utils.py:4836`).

With the fix, same command and locale: Pass 2, Fail 0.

Lint:

```
lintrunner --take RUFF,FLAKE8,PYFMT torch/_inductor/utils.py
```

Result: ok No lint issues.

Differential Revision: D110966152




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo