### PR TITLE
[CI/CD] Install newer CUPTI headers for CUDA-13 containers

### DIFF
--- a/.ci/docker/common/install_cuda.sh
+++ b/.ci/docker/common/install_cuda.sh
@@ -93,9 +93,12 @@ function install_cupti_headers {
   archive="cuda_cupti-linux-x86_64-${cupti_version}-archive"
 
   tmp_dir=$(mktemp -d)
-  curl -fsL "${redist_url}/${archive}.tar.xz" | tar -xJ -C "${tmp_dir}"
+  pushd "${tmp_dir}"
+  wget -q "${redist_url}/${archive}.tar.xz"
+  tar xf "${archive}.tar.xz"
   mkdir -p "${target_dir}"
-  cp -a "${tmp_dir}/${archive}/include/"* "${target_dir}/"
+  cp -a "${archive}/include/"* "${target_dir}/"
+  popd
 
   rm -rf "${tmp_dir}"
   echo "CUPTI ${cupti_version} headers installed to ${target_dir}."

--- a/.ci/docker/common/install_cuda.sh
+++ b/.ci/docker/common/install_cuda.sh
@@ -11,6 +11,7 @@ else
 fi
 
 NVSHMEM_VERSION=3.4.5
+CUDA_CUPTI_VERSION=13.3.75
 
 function install_cuda {
   version=$1
@@ -78,6 +79,26 @@ function install_nvshmem {
   rm -rf "${tmpdir}"
 
   echo "nvSHMEM ${nvshmem_version} for CUDA ${cuda_major_version} (${arch_path}) installed."
+}
+
+function install_cupti_headers {
+  cupti_version=$1                  # e.g. "13.3.75"
+  major_minor=${cupti_version%.*}   # e.g. "13.3"
+  target_dir="/usr/local/cupti-headers-${major_minor}"
+
+  # The CUDA toolkit runfile ships an older CUPTI than the standalone
+  # nvidia-cuda-cupti wheel, so pull the newer headers into a throwaway venv
+  # and stage them somewhere the build can pick them up.
+  tmp_venv=$(mktemp -d)
+  python3 -m venv "${tmp_venv}"
+  "${tmp_venv}/bin/pip" install -q --no-deps "nvidia-cuda-cupti==${cupti_version}"
+
+  include_dir=$(dirname "$("${tmp_venv}/bin/python" -c "import glob, sys; print(glob.glob(sys.prefix + '/**/cupti_activity.h', recursive=True)[0])")")
+  mkdir -p "${target_dir}"
+  cp -a "${include_dir}/"* "${target_dir}/"
+
+  rm -rf "${tmp_venv}"
+  echo "CUPTI ${cupti_version} headers installed to ${target_dir}."
 }
 
 function install_124 {
@@ -162,6 +183,8 @@ function install_130 {
 
   install_nvshmem 13 $NVSHMEM_VERSION
 
+  install_cupti_headers $CUDA_CUPTI_VERSION
+
   CUDA_VERSION=13.0 bash install_nccl.sh
 
   CUDA_VERSION=13.0 bash install_cusparselt.sh $CUSPARSELT_VERSION
@@ -180,6 +203,8 @@ function install_132 {
   install_cudnn 13 $CUDNN_VERSION
 
   install_nvshmem 13 $NVSHMEM_VERSION
+
+  install_cupti_headers $CUDA_CUPTI_VERSION
 
   CUDA_VERSION=13.2 bash install_nccl.sh
 

--- a/.ci/docker/common/install_cuda.sh
+++ b/.ci/docker/common/install_cuda.sh
@@ -86,18 +86,18 @@ function install_cupti_headers {
   major_minor=${cupti_version%.*}   # e.g. "13.3"
   target_dir="/usr/local/cupti-headers-${major_minor}"
 
-  # The CUDA toolkit runfile ships an older CUPTI than the standalone
-  # nvidia-cuda-cupti wheel, so pull the newer headers into a throwaway venv
-  # and stage them somewhere the build can pick them up.
-  tmp_venv=$(mktemp -d)
-  python3 -m venv "${tmp_venv}"
-  "${tmp_venv}/bin/pip" install -q --no-deps "nvidia-cuda-cupti==${cupti_version}"
+  # The CUDA toolkit runfile ships an older CUPTI than the standalone redist
+  # archive, so stage the newer headers where the build can pick them up. The
+  # headers are architecture independent, so always grab the x86_64 archive.
+  redist_url="https://developer.download.nvidia.com/compute/cuda/redist/cuda_cupti/linux-x86_64"
+  archive="cuda_cupti-linux-x86_64-${cupti_version}-archive"
 
-  include_dir=$(dirname "$("${tmp_venv}/bin/python" -c "import glob, sys; print(glob.glob(sys.prefix + '/**/cupti_activity.h', recursive=True)[0])")")
+  tmp_dir=$(mktemp -d)
+  curl -fsL "${redist_url}/${archive}.tar.xz" | tar -xJ -C "${tmp_dir}"
   mkdir -p "${target_dir}"
-  cp -a "${include_dir}/"* "${target_dir}/"
+  cp -a "${tmp_dir}/${archive}/include/"* "${target_dir}/"
 
-  rm -rf "${tmp_venv}"
+  rm -rf "${tmp_dir}"
   echo "CUPTI ${cupti_version} headers installed to ${target_dir}."
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #189214

The CUDA-13 toolkit runfile ships an older CUPTI than the standalone redist archive.
Add `install_cupti_headers` helper that downloads the `cuda_cupti` redist tarball and stages its headers into /usr/local/cupti-headers-<major.minor>, and invoke it from the CUDA 13.0 and 13.2 installers.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>