### PR TITLE
[xpu][skip] Skip test_combo_kernel_dynamic_scale_rblock on XPU

### DIFF
--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -1233,6 +1233,10 @@ class ComboKernelTests(TestCase):
         self.assertEqual(torch._inductor.metrics.generated_kernel_count, 5)
 
     @requires_gpu_and_triton
+    @skipIfXpu(
+        msg="dynamic_scale_rblock requires GPU-specific device properties "
+        "(major, regs_per_multiprocessor, warp_size) not available on XPU"
+    )
     @torch._inductor.config.patch(
         {
             "combo_kernel_per_subkernel_blocks": True,


### PR DESCRIPTION
Fixes #187810
Fixes #187811

## Summary
Skip `test_combo_kernel_dynamic_scale_rblock` on XPU for both `ComboKernelTests` and `ComboKernelTestsPerSubkernelBlocks` (inherits the skip from parent class).

## Root Cause
The test was added in #186957 to validate occupancy-driven rblock halving for combo kernel reductions. This optimization requires:

1. `device_prop.regs_per_multiprocessor` — Intel GPU does not expose per-EU register totals (GRF is per-thread, not a unified per-EU pool like NVIDIA's SM)
2. Triton `compiled_binary.n_regs` — Intel Triton backend cannot yet report register usage for a compiled kernel. This is the core blocker:   even if device properties were fully mapped, the occupancy calculation in `_iter_rblock_scale_candidates` would fail at `launcher.n_regs`.
3. `device_prop.major >= 8` — NVIDIA compute capability concept

Other properties could theoretically be mapped (warp_size from sub_group_sizes, etc.), but without `n_regs` the feature cannot function.

## Future XPU enablement
Once Intel Triton backend supports `compiled_binary.n_regs`, this feature can be enabled by:
- Mapping `warp_size` from `sub_group_sizes` in `DeviceProperties.create()`
- Providing `regs_per_multiprocessor` equivalent for Intel GPU
- Extending the device type gate in `_could_rblock_scale` to include "xpu"

## Fix
Add `@skipIfXpu(msg=...)` to `test_combo_kernel_dynamic_scale_rblock` in `ComboKernelTests`. The subclass `ComboKernelTestsPerSubkernelBlocks` inherits the skip automatically.

## Test plan
```bash
python test/inductor/test_combo_kernels.py \
    ComboKernelTests.test_combo_kernel_dynamic_scale_rblock
# OK (skipped=1)

python test/inductor/test_combo_kernels.py \
    ComboKernelTestsPerSubkernelBlocks.test_combo_kernel_dynamic_scale_rblock
# OK (skipped=1)

# Other tests in the file load and run normally
python -m pytest test/inductor/test_combo_kernels.py --collect-only
# collected 135 items
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @gujinghui @fengyuan14 @guangyey