### PR TITLE
Fix test_split_group for order-preserving split_group semantics

### DIFF
--- a/test/distributed/test_fake_pg.py
+++ b/test/distributed/test_fake_pg.py
@@ -755,15 +755,15 @@ class TestFakePG(TestCase):
         )
 
         # Interleaved, unsorted subgroups: each rank shares a group with the
-        # rank two away, and is not always listed first. The child rank must
-        # therefore be the position within the *sorted* subgroup -- it cannot
-        # coincide with the parent rank or with the order ranks were listed in,
-        # which is what makes this a meaningful check of rank assignment.
+        # rank two away, and is not always listed first. split_group preserves
+        # the order ranks are listed in, so the child rank is the position
+        # within the subgroup as given -- which here differs from the parent
+        # rank, making this a meaningful check of rank assignment.
         split_ranks = [[2, 0], [3, 1]]
         new_pg = dist.split_group(split_ranks=split_ranks)
         self.assertIsNotNone(new_pg)
 
-        my_group = sorted(next(g for g in split_ranks if rank in g))
+        my_group = next(g for g in split_ranks if rank in g)
         self.assertEqual(new_pg.size(), len(my_group))
         self.assertEqual(new_pg.rank(), my_group.index(rank))
         # Independent cross-check: the child rank must map back to this


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #189231

test_split_group (added in #186290) asserted that a rank's child group rank
was its position within the *sorted* subgroup. That matched split_group's
behavior at the time, which implicitly sorted each subgroup. #189090
("Support out-of-order ranks in dist.split_group") then removed the implicit
sort from both the Python wrapper and ProcessGroup::splitGroup, so group rank
is now the position in the user-provided list. The two PRs landed back to back,
leaving the test asserting the old sorted semantics against the new
order-preserving behavior.

For split_ranks=[[2, 0], [3, 1]], rank 0 is at list position 1 in [2, 0], so
new_pg.rank() is 1, but the test expected the sorted position 0 -- hence
"Expected 0 but got 1". The fake backend's split() was already correct
(position-in-list, matching NCCL); only the test's expectation and comment were
stale. This drops the sorted() from the expected group and updates the comment.
The subgroups are still interleaved so the group rank differs from the parent
rank, keeping the rank-assignment check meaningful.

Test Plan:

```
python -m pytest test/distributed/test_fake_pg.py -q
```

Authored with the assistance of an AI assistant (Claude).