### PR TITLE
[MPS] Fix avg_pool2d/adaptive_avg_pool2d backward on channels_last inputs

### DIFF
--- a/aten/src/ATen/native/mps/operations/Pooling.mm
+++ b/aten/src/ATen/native/mps/operations/Pooling.mm
@@ -667,6 +667,29 @@ static void avg_pool2d_template(const Tensor& input,
   TORCH_CHECK_NOT_IMPLEMENTED(!c10::isComplexType(input.scalar_type()), "Not implemented for complex");
   const Tensor& grad_output = *(at::borrow_from_optional_tensor(grad_output_opt));
   const bool is_backward_pass = grad_output.defined();
+
+  // The channels_last raw-buffer path in pool2d_template mis-sizes the Metal
+  // buffer for the backward pass, which either aborts (SIGABRT) or produces
+  // wrong gradients. Compute the gradient on contiguous tensors and restride
+  // the result to match. See https://github.com/pytorch/pytorch/issues/175190
+  if (is_backward_pass &&
+      input.suggest_memory_format(/*channels_last_strides_exact_match=*/true) == MemoryFormat::ChannelsLast) {
+    auto grad_input_contig = at::empty(output.sizes(), output.options());
+    avg_pool2d_template(input.contiguous(),
+                        grad_input_contig,
+                        grad_output.contiguous(),
+                        kernel_size,
+                        stride,
+                        padding,
+                        dilation,
+                        ceil_mode,
+                        count_include_pad,
+                        divisor_override,
+                        op_name);
+    output.copy_(grad_input_contig);
+    return;
+  }
+
   const bool use_divisor = divisor_override.has_value() && divisor_override.value() != 0;
 
   // custom divisor isn't supported natively in avgPooling2DWithSourceTensor().

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -1102,10 +1102,10 @@ torch.cuda.synchronize()
         expected = inp.unfold(-2, 2, 2).unfold(-2, 2, 2).amax(dim=(-2, -1))
         self.assertEqual(out, expected)
 
-    @expectedFailureMPS  # TODO: fixme
     @gcIfJetson
     @dtypes(torch.float, torch.double)
     @dtypesIfCUDA(torch.half, torch.float, torch.double)
+    @dtypesIfMPS(torch.float)
     def test_avg_pool2d_nhwc(self, device, dtype):
         def helper(
             n,

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -801,6 +801,19 @@ class TestAvgPool(TestCaseMPS):
             padding=(0, 1), stride=2)
         self.assertFalse(torch.isnan(y).any())
 
+    def test_avg_pool2d_backward_channels_last(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/175190
+        # AvgPool2d / AdaptiveAvgPool2d backward used to abort (SIGABRT) on MPS
+        # for channels_last inputs; forward worked but backward mis-sized the
+        # Metal buffer.
+        for pool in (torch.nn.AvgPool2d(2), torch.nn.AdaptiveAvgPool2d((4, 4))):
+            base = torch.randn(4, 3, 8, 8)
+            cpu_x = base.clone().to(memory_format=torch.channels_last).requires_grad_(True)
+            mps_x = base.detach().to("mps").to(memory_format=torch.channels_last).requires_grad_(True)
+            pool(cpu_x).sum().backward()
+            pool(mps_x).sum().backward()
+            self.assertEqual(cpu_x.grad, mps_x.grad.cpu())
+
     # Test some cases for avg_pool2d which used to mismatch CPU results.
     # Addresses this issue: https://github.com/pytorch/pytorch/issues/160743
     def test_avg_pool2d_ceil_mode_mismatch(self):


### PR DESCRIPTION
Fixes #175190

### Summary

`AvgPool2d` / `AdaptiveAvgPool2d` **backward** on MPS either aborts the process (SIGABRT — `buffer is not large enough` from `MPSNDArray`) or silently produces wrong gradients when the input is `channels_last`. Forward works fine; only backward fails.

### Root cause

`pool2d_template` takes a `channels_last` fast path that **skips the gather step** and hands the raw tensor buffer to MPSGraph as if it were NHWC-packed. For the backward pass this mis-sizes the Metal buffer, so `MPSNDArray` creation either asserts (crash) or reads out of bounds (garbage gradients). The reporter's `.contiguous()` workaround avoids the fast path, confirming the diagnosis.

### Fix

In `avg_pool2d_template`, detect the backward + `channels_last` case and compute the gradient on **contiguous** tensors via a recursive call — whose inputs are no longer `channels_last`, so it takes the safe path — then copy the result into the output, restriding as needed. The common NCHW path and the forward pass are untouched; only the previously-broken `channels_last` backward case is rerouted.

### Reproducer (fixed by this PR)

```python
import torch, torch.nn as nn
pool = nn.AvgPool2d(2)
x = torch.randn(4, 3, 8, 8).to("mps").to(memory_format=torch.channels_last).requires_grad_(True)
pool(x).sum().backward()   # before: SIGABRT / wrong grad; after: correct grad matching CPU
```

### Test Plan

Added a regression test `test_avg_pool2d_backward_channels_last` (covers both `AvgPool2d` and `AdaptiveAvgPool2d`).

```
python test/test_mps.py -k test_avg_pool2d_backward_channels_last
python test/test_mps.py -k avg_pool2d
python test/test_mps.py -k adaptive_avg_pool2d
```

New regression test passes (previously crashed / mismatched); existing `avg_pool2d` and `adaptive_avg_pool2d` tests still pass. Manually verified gradients match CPU across stride, padding, `count_include_pad`, `ceil_mode`, and adaptive output sizes on `channels_last` inputs.

### Note

This reroutes the broken `channels_last` backward through the contiguous path, which forgoes the (currently-broken) fast-path optimization for that specific case in favor of correctness. A follow-up could fix the buffer sizing in the fast path directly.

> This PR was authored with the assistance of an AI coding agent (Claude Code).
