### PR TITLE
[XPU] Enable TestBinaryUfuncsCUDA on XPU

### DIFF
--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -4817,7 +4817,9 @@ instantiate_device_type_tests(
 instantiate_device_type_tests(
     TestBinaryUfuncsDevice, globals(), allow_xpu=True, except_for="cpu"
 )
-instantiate_device_type_tests(TestBinaryUfuncsCUDA, globals(), only_for="cuda")
+instantiate_device_type_tests(
+    TestBinaryUfuncsCUDA, globals(), only_for=("cuda", "xpu"), allow_xpu=True
+)
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary
- Extend `instantiate_device_type_tests(TestBinaryUfuncsCUDA, ...)` from `only_for="cuda"` to `only_for=("cuda", "xpu"), allow_xpu=True`.
- `test_copysign_nan_sign` (regresses #181804, a CUDA-specific bug where `__half`/`__nv_bfloat16` device-intrinsic conversions in `c10::cuda::compat::copysign` lost the NaN sign bit, fixed in #183959) is fully device-generic (`device` parameter, `.to(device)`, no hardcoded `"cuda"`/`.cuda()`), so it was only restricted to CUDA because that's where the original bug lived.
- XPU's `copysign` kernel (`CopysignKernel.cpp`) uses `sycl::copysign` on the widened `opmath_t` (float) for Half/BFloat16, correctly preserving the NaN sign bit during widening -- unlike CUDA's original bug. Independently confirmed by an existing torch-xpu-ops CI log showing `TestBinaryUfuncsXPU::test_copysign_nan_sign_xpu_{bfloat16,float16}` already passing downstream.
- No decorator parity changes needed (only `@dtypes(...)` present, already device-generic).
- No `common_methods_invocations.py` changes: no `DecorateInfo` entry references `TestBinaryUfuncsCUDA` or `test_copysign_nan_sign`.

## Test plan
```
pytest test/test_binary_ufuncs.py -k "TestBinaryUfuncsCUDA and xpu" --tb=long -q
# 2 passed, 0 failed
```

Authored with an AI assistant.