### PR TITLE
[XPU] Register linalg._powsum and _foreach_powsum.Scalar for XPU

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -11413,6 +11413,7 @@
   dispatch:
     CompositeExplicitAutograd: foreach_tensor_powsum_slow
     CUDA: foreach_tensor_powsum_cuda
+    XPU: foreach_tensor_powsum_xpu
   autogen: _foreach_powsum.Scalar_out
 
 - func: _foreach_pow.List(Tensor[] self, Tensor[] exponent) -> Tensor[]
@@ -14560,7 +14561,7 @@
   variants: function
   dispatch:
     CompositeExplicitAutograd: linalg__powsum_slow
-    CPU, CUDA: linalg__powsum
+    CPU, CUDA, XPU: linalg__powsum
   tags: reduction
 
 - func: linalg_matrix_norm(Tensor self, Scalar ord, int[] dim=[-2,-1], bool keepdim=False, *, ScalarType? dtype=None) -> Tensor


### PR DESCRIPTION
Registers the XPU dispatch keys for `linalg._powsum` and `_foreach_powsum.Scalar` so the kernels added in torch-xpu-ops (PR: https://github.com/intel/torch-xpu-ops/pull/4195) can be reached.

#### Changes

No new ops or schemas are introduced; this only wires existing op definitions to the XPU backend in `aten/src/ATen/native/native_functions.yaml`:
- `linalg__powsum`: add `XPU` to the existing `CPU, CUDA` dispatch list (shared host function).
- `_foreach_powsum.Scalar`: add `XPU: foreach_tensor_powsum_xpu`.

#### Testing

With the torch-xpu-ops kernels built in, the upstream `test_powsum*` / `test_foreach_powsum*` tests in `test/test_linalg.py` pass on the XPU device (6 passed, 1 skipped `@onlyCPU`).