### PR TITLE
docs: fix PyTorch brand name consistency

### DIFF
--- a/docs/source/distributed.checkpoint.md
+++ b/docs/source/distributed.checkpoint.md
@@ -134,7 +134,7 @@ In addition to the above entrypoints, `Stateful` objects, as described below, pr
   :members:
 ```
 
-This [example](https://github.com/pytorch/pytorch/blob/main/torch/distributed/checkpoint/examples/fsdp_checkpoint_example.py) shows how to use Pytorch Distributed Checkpoint to save a FSDP model.
+This [example](https://github.com/pytorch/pytorch/blob/main/torch/distributed/checkpoint/examples/fsdp_checkpoint_example.py) shows how to use PyTorch Distributed Checkpoint to save a FSDP model.
 
 The following types define the IO interface used during checkpoint:
 

--- a/docs/source/hub.md
+++ b/docs/source/hub.md
@@ -1,10 +1,10 @@
 # torch.hub
 
-Pytorch Hub is a pre-trained model repository designed to facilitate research reproducibility.
+PyTorch Hub is a pre-trained model repository designed to facilitate research reproducibility.
 
 ## Publishing models
 
-Pytorch Hub supports publishing pre-trained models(model definitions and pre-trained weights)
+PyTorch Hub supports publishing pre-trained models(model definitions and pre-trained weights)
 to a GitHub repository by adding a simple `hubconf.py` file;
 
 `hubconf.py` can have multiple entrypoints. Each entrypoint is defined as a python function
@@ -71,7 +71,7 @@ You can see the full script in
 
 ## Loading models from Hub
 
-Pytorch Hub provides convenient APIs to explore all available models in hub
+PyTorch Hub provides convenient APIs to explore all available models in hub
 through {func}`torch.hub.list()`, show docstring and examples through
 {func}`torch.hub.help()` and load the pre-trained models using
 {func}`torch.hub.load()`.

--- a/docs/source/notes/cuda.md
+++ b/docs/source/notes/cuda.md
@@ -67,7 +67,7 @@ with torch.cuda.device(1):
 
 ## TensorFloat-32 (TF32) on Ampere (and later) devices
 
-After Pytorch 2.9, we provide a new sets of APIs to control the TF32 behavior in a more fine-grained way, and
+After PyTorch 2.9, we provide a new sets of APIs to control the TF32 behavior in a more fine-grained way, and
 suggest to use the new APIs for better control.
 We can set float32 precision per backend and per operators. We can also override the global setting for a specific operator.
 

--- a/docs/source/notes/mkldnn.md
+++ b/docs/source/notes/mkldnn.md
@@ -13,7 +13,7 @@ MKLDNN is an open-source cross-platform performance library of basic building bl
 for deep learning applications.
 
 ```python
-# The flag below controls whether enable MKLDNN backend in Pytorch.
+# The flag below controls whether enable MKLDNN backend in PyTorch.
 torch.backends.mkldnn.enabled = True
 ```
 

--- a/docs/source/user_guide/index.md
+++ b/docs/source/user_guide/index.md
@@ -13,7 +13,7 @@ This guide is a work in progress.
 :maxdepth: 1
 :caption: Introduction
 
-Pytorch Overview <https://docs.pytorch.org/tutorials/beginner/deep_learning_60min_blitz.html>
+PyTorch Overview <https://docs.pytorch.org/tutorials/beginner/deep_learning_60min_blitz.html>
 Get Started <https://pytorch.org/get-started/locally/>
 Learn the Basics <https://docs.pytorch.org/tutorials/beginner/basics/intro.html>
 ```

--- a/docs/source/user_guide/torch_compiler/torch.compiler_faq.md
+++ b/docs/source/user_guide/torch_compiler/torch.compiler_faq.md
@@ -555,7 +555,7 @@ This should just be used for **debugging purposes** and is in no way a
 replacement for the PyTorch API, as it is **much less performant** and, as a
 private API, **may change without notice**. At any rate, `torch._numpy` is a
 Python implementation of NumPy in terms of PyTorch and it is used internally by `torch.compile` to
-transform NumPy code into Pytorch code. It is rather easy to read and modify,
+transform NumPy code into PyTorch code. It is rather easy to read and modify,
 so if you find any bug in it feel free to submit a PR fixing it or simply open
 an issue.
 


### PR DESCRIPTION
## Summary
Fix 'Pytorch' to 'PyTorch' brand name in 6 documentation files.

## Changes
- docs/source/hub.md (3 instances)
- docs/source/distributed.checkpoint.md (1 instance)
- docs/source/notes/cuda.md (1 instance)
- docs/source/notes/mkldnn.md (1 instance)
- docs/source/user_guide/index.md (1 instance)
- docs/source/user_guide/torch_compiler/torch.compiler_faq.md (1 instance)

## Context
This PR addresses the maintainer's request to focus only on brand name fixes. The original PR #189023 included additional changes (DDP links, VS versions, import statements) which have been removed to keep this PR focused and minimal.

Total: 8 insertions(+), 8 deletions(-) across 6 files.