### PR TITLE
[Dynamo] Remove dead code in tvm and common backends

### DIFF
--- a/torch/_dynamo/backends/common.py
+++ b/torch/_dynamo/backends/common.py
@@ -96,12 +96,6 @@ class AotAutograd:
 
         # NB: don't delete counter increment
         counters["aot_autograd"]["total"] += 1
-        use_fallback = False
-
-        if use_fallback:
-            log.debug("Unable to use AOT Autograd because graph has mutation")
-            counters["aot_autograd"]["not_ok"] += 1
-            return gm
 
         def wrap_bw_compiler(bw_compiler_fn: Callable[P, R]) -> Callable[..., R]:
             def _wrapped_bw_compiler(*args: P.args, **kwargs: P.kwargs) -> R:

--- a/torch/_dynamo/backends/tvm.py
+++ b/torch/_dynamo/backends/tvm.py
@@ -51,8 +51,6 @@ def tvm(
 ) -> Callable[..., Any]:
     if options is None:
         options = MappingProxyType({"scheduler": None, "trials": 20000, "opt_level": 3})
-    if options is None:
-        raise AssertionError("options must not be None")
     try:
         import tvm  # type: ignore[import]
         from tvm import relay  # type: ignore[import]


### PR DESCRIPTION
## Why

Two branches in `torch/_dynamo/backends` can never execute. `tvm()` assigns `options` a default when it is `None`, then immediately re-checks it for `None`. `AotAutograd.__call__` assigns `use_fallback = False` and then branches on it, so the fallback and its `not_ok` counter increment are dead.

## How

- Drop the redundant `if options is None` check in `tvm()`
- Drop the `use_fallback` branch in `AotAutograd.__call__`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98