### PR TITLE
[Dynamo] Store backend tags in the registry

### DIFF
--- a/test/dynamo/test_backends.py
+++ b/test/dynamo/test_backends.py
@@ -272,6 +272,7 @@ class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
         def cleanup_backend():
             backend_registry._COMPILER_FNS.pop(backend_name, None)
             backend_registry._BACKENDS.pop(backend_name, None)
+            backend_registry._BACKEND_TAGS.pop(backend_name, None)
 
         self.addCleanup(cleanup_backend)
 
@@ -360,12 +361,15 @@ class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
 
             orig_backends = dict(registry._BACKENDS)
             orig_compiler_fns = dict(registry._COMPILER_FNS)
+            orig_backend_tags = dict(registry._BACKEND_TAGS)
 
             def restore_registry():
                 registry._BACKENDS.clear()
                 registry._BACKENDS.update(orig_backends)
                 registry._COMPILER_FNS.clear()
                 registry._COMPILER_FNS.update(orig_compiler_fns)
+                registry._BACKEND_TAGS.clear()
+                registry._BACKEND_TAGS.update(orig_backend_tags)
                 registry._lazy_import.cache_clear()
                 registry._discover_entrypoint_backends.cache_clear()
 

--- a/torch/_dynamo/backends/registry.py
+++ b/torch/_dynamo/backends/registry.py
@@ -13,6 +13,7 @@ Key components:
 - CompilerFn: Type for backend compiler functions that transform FX graphs
 - _BACKENDS: Registry mapping backend names to entry points
 - _COMPILER_FNS: Registry mapping backend names to loaded compiler functions
+- _BACKEND_TAGS: Registry mapping backend names to their tags
 
 Example usage:
     @register_backend
@@ -79,6 +80,7 @@ CompilerFn = Callable[[fx.GraphModule, list[torch.Tensor]], CompiledFn]
 
 _BACKENDS: dict[str, EntryPoint | None] = {}
 _COMPILER_FNS: dict[str, CompilerFn] = {}
+_BACKEND_TAGS: dict[str, tuple[str, ...]] = {}
 _default_backend: str | CompilerFn = "inductor"
 
 
@@ -106,10 +108,10 @@ def register_backend(
     name = name or compiler_fn.__name__
     if name in _COMPILER_FNS:
         raise AssertionError(f"duplicate name: {name}")
-    if compiler_fn not in _BACKENDS:
+    if name not in _BACKENDS:
         _BACKENDS[name] = None
     _COMPILER_FNS[name] = compiler_fn
-    compiler_fn._tags = tuple(tags)  # type: ignore[attr-defined]
+    _BACKEND_TAGS[name] = tuple(tags)
     return compiler_fn
 
 
@@ -150,8 +152,7 @@ def list_backends(exclude_tags=("debug", "experimental")) -> list[str]:  # type:
     backends = [
         name
         for name in _BACKENDS
-        if name not in _COMPILER_FNS
-        or not exclude_tags_set.intersection(_COMPILER_FNS[name]._tags)  # type: ignore[attr-defined]
+        if not exclude_tags_set.intersection(_BACKEND_TAGS.get(name, ()))
     ]
     return sorted(backends)
 


### PR DESCRIPTION
## Why

`register_backend` guards the `_BACKENDS` insert with `compiler_fn not in _BACKENDS`, but `_BACKENDS` is keyed by name, so the guard can never be false. Tags are stashed on the compiler function via `setattr`, which needs a `type: ignore[attr-defined]` at both the write and the read site, and leaves entry-point backends with no place to declare tags.

## How

- Fix the guard to check `name`
- Store tags in a `_BACKEND_TAGS` dict keyed by backend name, dropping both type ignores

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98