### PR TITLE
[TEST] Refactor test_c10d_spawn_ucc.py with hw_classification

### DIFF
--- a/test/distributed/test_c10d_spawn_ucc.py
+++ b/test/distributed/test_c10d_spawn_ucc.py
@@ -6,6 +6,7 @@ from test_c10d_spawn import _torch_dist_nn_available, TestDistributedNNFunctions
 import torch.distributed as c10d
 from torch.testing._internal.common_distributed import requires_ucc, skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     run_tests,
     skip_but_pass_in_sandcastle,
     skip_but_pass_in_sandcastle_if,
@@ -22,6 +23,8 @@ NO_UCC = not hasattr(c10d, "ProcessGroupUCC")
 if not TEST_WITH_DEV_DBG_ASAN:
 
     class TestDistributedNNFunctionsUcc(TestDistributedNNFunctions):
+        hw_classification = HardwareClassification.MULTI_DEVICE_SPECIFIC
+
         # Test Common Ops First.
         @requires_ucc()
         @skip_if_lt_x_gpu(2)


### PR DESCRIPTION
Classify TestDistributedNNFunctionsUcc as MULTI_DEVICE_GENERIC per the test classification RFC (#185142, #185590).

UCC (Unified Collective Communication) is a vendor-agnostic backend — these
distributed collective tests (broadcast, reduce, allreduce, all_gather,
all_to_all) are not tied to a specific accelerator. Classification reflects
intent, not the current runtime behavior of inherited base class code
(which hardcodes CUDA and will be refactored separately).

Changes:
- `hw_classification = HardwareClassification.MULTI_DEVICE_GENERIC`

Test Plan:
  python test/distributed/test_c10d_spawn_ucc.py -v

Depends on: #186918

@mansiag05 @vishalgoyal316 @RiyaP2508