### PR TITLE
[XPU] Enable TestDropoutNNDeviceType on XPU

### DIFF
--- a/test/nn/test_dropout.py
+++ b/test/nn/test_dropout.py
@@ -323,7 +323,7 @@ class TestDropoutNNDeviceType(NNTestCase):
         self.assertEqual(out.size(), x.size())
 
 
-instantiate_device_type_tests(TestDropoutNNDeviceType, globals(), allow_mps=True)
+instantiate_device_type_tests(TestDropoutNNDeviceType, globals(), allow_mps=True, allow_xpu=True)
 instantiate_parametrized_tests(TestDropoutNN)
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Extend `instantiate_device_type_tests` for `TestDropoutNNDeviceType` to add `allow_xpu=True`.
- No op_db changes needed — no matching `DecorateInfo` entries found in `common_methods_invocations.py`.
- No new XPU skip decorators added; existing XPU skips/decorators untouched.

## Test plan
- XPU: 5/5 enabled variants pass on XPU:
  ```
  conda run -n classify_ut_test python -m pytest \
    test/nn/test_dropout.py -v -k "TestDropoutNNDeviceType and xpu" --tb=short
  ```
  Results: test_Dropout_xpu ✓, test_Dropout1d_xpu ✓, test_Dropout2d_xpu ✓,
  test_Dropout3d_xpu ✓, test_empty_dropout_xpu ✓
- CUDA behavior unchanged (validated by CI on a CUDA host).

Authored with an AI assistant.