### PR TITLE
[ROCm][inductor][UT] Re-enable conv2d backward parametrized test on ROCm by using fp16 on NAVI

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -106,6 +106,7 @@ from torch.testing._internal.common_quantization import (
 from torch.testing._internal.common_utils import (
     DeterministicGuard,
     instantiate_parametrized_tests,
+    isRocmArchAnyOf,
     IS_ARM64,
     IS_CPU_EXT_SVE_SUPPORTED,
     IS_FBCODE,
@@ -113,9 +114,6 @@ from torch.testing._internal.common_utils import (
     IS_MACOS,
     IS_X86,
     MACOS_VERSION,
-    MI200_ARCH,
-    MI300_ARCH,
-    MI350_ARCH,
     NAVI_ARCH,
     parametrize,
     recover_orig_fp32_precision,
@@ -6131,9 +6129,6 @@ for dtype in (torch.int32, torch.int64):
             check_lowp=False,
         )
 
-    # The forced Triton conv-backward autotune below compiles pathologically
-    # slowly on these ROCm arches, timing out CI. Skip until fixed (see #178945).
-    @skipIfRocmArch(NAVI_ARCH + MI350_ARCH + MI300_ARCH + MI200_ARCH)
     @skip_if_cpu
     @config.patch(
         {
@@ -6199,29 +6194,35 @@ for dtype in (torch.int32, torch.int64):
         output_h = (input_h + 2 * padding - dilation * (kernel - 1) - 1) // stride + 1
         output_w = (input_w + 2 * padding - dilation * (kernel - 1) - 1) // stride + 1
 
+        dtype = torch.float32
+        use_fp16 = False
+        rtol = 0.001
         if TEST_WITH_ROCM:
             # using the same error tolerance as test_convolution1.
             atol = 6e-5
-            rtol = 0.001
+            if isRocmArchAnyOf(NAVI_ARCH):
+                use_fp16 = True
+                dtype = torch.float16
+                atol = 3e-1
         else:
             # Greatest absolute difference: 0.00027943775057792664 at index (92, 109, 0, 0) (up to 0.0002 allowed)
             # Greatest relative difference: 0.007547957822680473 at index (92, 109, 0, 0) (up to 0.001 allowed)
             atol = 3e-4
-            rtol = 0.001
 
-        weight = torch.randn([out_channels, in_channels // groups, kernel, kernel])
+        weight = torch.randn([out_channels, in_channels // groups, kernel, kernel], dtype=dtype)
         if nhwc:
             weight = weight.to(memory_format=torch.channels_last)
         self.common(
             fn,
             (
-                torch.randn([2, out_channels, output_h, output_w]),
-                torch.randn([2, in_channels, input_h, input_w]),
+                torch.randn([2, out_channels, output_h, output_w], dtype=dtype),
+                torch.randn([2, in_channels, input_h, input_w], dtype=dtype),
                 weight,
             ),
             atol=atol,
             rtol=rtol,
             check_lowp=False,
+            reference_in_float=not use_fp16,
         )
 
     @skip_if_cpu

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -106,13 +106,13 @@ from torch.testing._internal.common_quantization import (
 from torch.testing._internal.common_utils import (
     DeterministicGuard,
     instantiate_parametrized_tests,
-    isRocmArchAnyOf,
     IS_ARM64,
     IS_CPU_EXT_SVE_SUPPORTED,
     IS_FBCODE,
     IS_LINUX,
     IS_MACOS,
     IS_X86,
+    isRocmArchAnyOf,
     MACOS_VERSION,
     NAVI_ARCH,
     parametrize,
@@ -6209,7 +6209,9 @@ for dtype in (torch.int32, torch.int64):
             # Greatest relative difference: 0.007547957822680473 at index (92, 109, 0, 0) (up to 0.001 allowed)
             atol = 3e-4
 
-        weight = torch.randn([out_channels, in_channels // groups, kernel, kernel], dtype=dtype)
+        weight = torch.randn(
+            [out_channels, in_channels // groups, kernel, kernel], dtype=dtype
+        )
         if nhwc:
             weight = weight.to(memory_format=torch.channels_last)
         self.common(


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/188564

## Summary
This PR re-enables `test_conv2d_backward_parametrized` on ROCm by replacing the broad ROCm skip with a targeted NAVI path:
- Remove the `skipIfRocmArch(...)` decorator for this test.
- On NAVI (`isRocmArchAnyOf(NAVI_ARCH)`), run the test inputs in `fp16`.
- Use NAVI-specific tolerances and `reference_in_float=False` for the fp16 path to avoid fp32-reference drift.
The rationale is architecture-specific:
- **CDNA**: slowness of this test on CDNA wasn't observed. If I'm wrong, please share logs (cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @frgossen)
- **RDNA**: WMMA is not available for fp32, but is present for fp16, so switch this test to fp16 for now.
## Test
```
time PYTORCH_TEST_WITH_ROCM=1 python test/inductor/test_torchinductor.py -k 'test_conv2d_backward_parametrized'
.......
----------------------------------------------------------------------
Ran 384 tests in 535.660s

OK (skipped=192)

real    9m8.510s
user    45m19.362s
sys     0m49.648s
```


Related PR/issues:
https://github.com/pytorch/pytorch/pull/188671
https://github.com/pytorch/pytorch/pull/178945
https://github.com/pytorch/pytorch/issues/188564