### PR TITLE
[inductor] Replace ExternKernel/ComputedBuffer plumbing tuples with dataclasses + Protocol

### DIFF
--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -5142,7 +5142,7 @@ class CppScheduling(BaseScheduling):
                     raise AssertionError((var_ranges, constraints.ranges, node.snodes))
                 indexing_exprs.update(constraints.exprs)
             if var_ranges is None:
-                raise AssertionError(node.snodes)
+                raise AssertionError("expected at least one snode to set var_ranges")
             return ir.ExtraIndexingConstraints(var_ranges, list(indexing_exprs))
 
         if not isinstance(node, SchedulerNode):

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -5128,20 +5128,22 @@ class CppScheduling(BaseScheduling):
     def reset_kernel_group(self):
         self.kernel_group = KernelGroup()
 
-    def _get_indexing_ranges_exprs(self, node):
+    def _get_indexing_ranges_exprs(self, node) -> ir.ExtraIndexingConstraints:
         if isinstance(node, FusedSchedulerNode):
             if len(node.snodes) <= 0:
                 raise AssertionError(node.snodes)
             var_ranges = None
             indexing_exprs = OrderedSet[Any]()
             for snode in node.snodes:
-                v, exprs = self._get_indexing_ranges_exprs(snode)
+                constraints = self._get_indexing_ranges_exprs(snode)
                 if var_ranges is None:
-                    var_ranges = v
-                if var_ranges != v:
-                    raise AssertionError((var_ranges, v, node.snodes))
-                indexing_exprs.update(exprs)
-            return var_ranges, list(indexing_exprs)
+                    var_ranges = constraints.ranges
+                if var_ranges != constraints.ranges:
+                    raise AssertionError((var_ranges, constraints.ranges, node.snodes))
+                indexing_exprs.update(constraints.exprs)
+            if var_ranges is None:
+                raise AssertionError(node.snodes)
+            return ir.ExtraIndexingConstraints(var_ranges, list(indexing_exprs))
 
         if not isinstance(node, SchedulerNode):
             raise AssertionError("expected isinstance(node, SchedulerNode)")
@@ -5149,7 +5151,9 @@ class CppScheduling(BaseScheduling):
         if not isinstance(comp_buffer, ir.ComputedBuffer):
             raise AssertionError("expected isinstance(comp_buffer, ir.ComputedBuffer)")
         _, body, _ = comp_buffer.get_default_sizes_body()
-        return body.var_ranges, list(body.indexing_exprs.values())
+        return ir.ExtraIndexingConstraints(
+            body.var_ranges, list(body.indexing_exprs.values())
+        )
 
     def _snapshot_node_loop_states(self, node):
         if isinstance(node, SchedulerNode):
@@ -5598,7 +5602,7 @@ class CppScheduling(BaseScheduling):
 
         if extra_indexing_ranges is None:
             raise AssertionError("extra_indexing_ranges is None")
-        extra_indexing_constraints = (
+        extra_indexing_constraints = ir.ExtraIndexingConstraints(
             extra_indexing_ranges,
             list(extra_indexing_exprs),
         )

--- a/torch/_inductor/comm_lowering.py
+++ b/torch/_inductor/comm_lowering.py
@@ -426,13 +426,7 @@ def register_comm_lowerings():
         tensors = [ir.ExternKernel.require_contiguous(t) for t in tensors]
         kernel = c10d.batch_p2p_ops.default
         with V.graph.fake_mode:
-            (
-                example_output,
-                tensor_args,
-                non_tensor_args,
-                unflatten_args,
-                unbacked_bindings,
-            ) = ir._CollectiveKernel.process_kernel(
+            result = ir._CollectiveKernel.process_kernel(
                 kernel,
                 op_list,
                 peer_list,
@@ -440,14 +434,18 @@ def register_comm_lowerings():
                 tensors,
                 group_name,
             )
-        if unbacked_bindings:
-            raise AssertionError(f"{kernel} {unbacked_bindings}")
+        example_output = result.example_output
+        tensor_args = result.tensor_args
+        non_tensor_args = result.non_tensor_args
+        unflatten_args = result.unflatten_args
+        if result.unbacked_bindings:
+            raise AssertionError(f"{kernel} {result.unbacked_bindings}")
         for op, tensor_arg in zip(op_list, tensor_args):
             tensor_arg.realize()
             if op == "irecv":
                 V.graph.mark_buffer_mutated(tensor_arg.get_name())
 
-        device = tensor_args[0].get_device()
+        device = tensor_args[0].get_device_or_error()
         packed = ir._CollectiveKernel(
             ir.MultiOutputLayout(device=device),
             kernel,

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -20,6 +20,7 @@ from typing import (
     ClassVar,
     Literal,
     overload,
+    Protocol,
     SupportsFloat,
     SupportsInt,
     TYPE_CHECKING,
@@ -132,6 +133,7 @@ from .utils import (
     sympy_product,
     sympy_subs,
     tensor_is_aligned,
+    VarRanges,
 )
 from .virtualized import ops, OpsValue, V
 
@@ -5336,6 +5338,19 @@ class ShapeAsConstantBuffer(IRNode):
         return False
 
 
+@dataclasses.dataclass(frozen=True)
+class ExtraIndexingConstraints:
+    """Extra indexing constraints appended during simplify_and_reorder.
+
+    Produced by the cpp fusion path to force compatible index/reduce ranges
+    across scheduler nodes, then threaded through simplify_and_reorder and
+    recompute_size_and_body. Replaces a bare tuple[VarRanges, list[Expr]].
+    """
+
+    ranges: VarRanges
+    exprs: list[sympy.Expr]
+
+
 @ir_dataclass(frozen=False)
 class ComputedBuffer(OperationBuffer):
     """
@@ -5578,7 +5593,7 @@ class ComputedBuffer(OperationBuffer):
 
     def simplify_and_reorder(
         self,
-        extra_indexing_constraints: tuple[dict[Any, Any], list[Any]] | None = None,
+        extra_indexing_constraints: ExtraIndexingConstraints | None = None,
         recompute_sizes_body_func: Callable[..., Any] | None = None,
     ) -> tuple[tuple[list[Expr], list[Expr]], LoopBody | None]:
         """
@@ -5615,34 +5630,17 @@ class ComputedBuffer(OperationBuffer):
 
         index_formulas = [*body.indexing_exprs.values()]
         if extra_indexing_constraints is not None:
-            if not (
-                isinstance(extra_indexing_constraints, tuple)
-                and len(extra_indexing_constraints) == 2
-            ):
-                raise AssertionError(
-                    "Expected isinstance(extra_indexing_constraints, tuple) and len(extra_indexing_constraints) == 2"
-                )
-            extra_indexing_ranges, extra_indexing_expr = extra_indexing_constraints
-            if not isinstance(extra_indexing_ranges, dict):
-                raise AssertionError(type(extra_indexing_ranges))
-            if not isinstance(extra_indexing_expr, list):
-                raise AssertionError(type(extra_indexing_expr))
-            if not all(isinstance(f, Expr) for f in extra_indexing_expr):
-                raise AssertionError(
-                    "Expected all(isinstance(f, Expr) for f in extra_indexing_expr)"
-                )
-
             expected_var_ranges = body.var_ranges
-            if expected_var_ranges != extra_indexing_ranges:
+            if expected_var_ranges != extra_indexing_constraints.ranges:
                 raise AssertionError(
                     (
                         expected_var_ranges,
-                        extra_indexing_ranges,
+                        extra_indexing_constraints.ranges,
                     )
                 )
             # remove already existing expressions
             extra_indexing_expr = [
-                e for e in extra_indexing_expr if e not in index_formulas
+                e for e in extra_indexing_constraints.exprs if e not in index_formulas
             ]
             index_formulas += extra_indexing_expr
 
@@ -5811,6 +5809,17 @@ class FinalizeCodegenResult:
     call_args: list[str]
 
 
+class _HasAliasingOrMutation(Protocol):
+    """Minimal view of scheduler.BaseSchedulerNode used by prologue fusion.
+
+    ir.py cannot import scheduler (circular), so this documents the single
+    method consumed by has_aliasing_or_mutation_for_prologue_fusion instead
+    of typing the argument as Any.
+    """
+
+    def has_aliasing_or_mutation(self) -> bool: ...
+
+
 class TemplateBuffer(OperationBuffer):
     """
     Base class for template operators that support epilogue and prologue fusion.
@@ -5951,7 +5960,7 @@ class TemplateBuffer(OperationBuffer):
 
     def simplify_and_reorder(
         self,
-        extra_indexing_constraints: tuple[dict[Any, Any], list[Any]] | None = None,
+        extra_indexing_constraints: ExtraIndexingConstraints | None = None,
         recompute_sizes_body_func: Callable[..., Any] | None = None,
     ) -> tuple[tuple[Sequence[Expr], list[Expr]], LoopBody | None]:
         return (
@@ -5969,7 +5978,9 @@ class TemplateBuffer(OperationBuffer):
     def get_allowed_prologue_inps(self) -> OrderedSet[str]:
         return self.allowed_prologue_inps
 
-    def has_aliasing_or_mutation_for_prologue_fusion(self, scheduler_node: Any) -> bool:
+    def has_aliasing_or_mutation_for_prologue_fusion(
+        self, scheduler_node: _HasAliasingOrMutation
+    ) -> bool:
         """Return whether this template's aliasing/mutation blocks prologue fusion.
 
         The default preserves the scheduler's conservative behavior. External
@@ -6896,6 +6907,22 @@ def _fallback_kernel_symbol_tracking_context(
     return nullcontext()
 
 
+@dataclasses.dataclass(frozen=True)
+class ProcessKernelResult:
+    """Structured result of ExternKernel.process_kernel.
+
+    Replaces the positional 5-tuple that was unpacked at every call site.
+    unflatten_args(new_tensor_args, new_non_tensor_args) reconstructs the
+    original (args, kwargs) tree from replacement lists.
+    """
+
+    example_output: Any
+    tensor_args: list[IRNode]
+    non_tensor_args: list[object]
+    unflatten_args: Callable[[Any, Any], Any]
+    unbacked_bindings: dict[sympy.Symbol, pytree.KeyPath] | None
+
+
 @ir_dataclass(frozen=False)
 class ExternKernel(InputsKernel):
     """
@@ -7129,16 +7156,10 @@ class ExternKernel(InputsKernel):
     @classmethod
     def process_kernel(
         cls, kernel: _OpOverloads, *args: Any, **kwargs: Any
-    ) -> tuple[
-        Any,
-        list[Any],
-        list[Any],
-        Callable[[Any, Any], Any],
-        dict[sympy.Symbol, pytree.KeyPath] | None,
-    ]:
+    ) -> ProcessKernelResult:
         """Partition kernel args into tensor and non-tensor, realize tensor inputs,
-        re-run fake tensor propagation with the realized strides, and return
-        (example_output, tensor_args, non_tensor_args, unflatten_args, unbacked_bindings).
+        re-run fake tensor propagation with the realized strides, and return a
+        ProcessKernelResult.
 
         unflatten_args(new_tensor_args, new_non_tensor_args) reconstructs the
         original (args, kwargs) tree from replacement lists.
@@ -7290,12 +7311,12 @@ class ExternKernel(InputsKernel):
                     msg = f"{msg} Found from : \n {stack_trace}"
                 V.graph.disable_cudagraphs_reason = msg
 
-        return (
-            example_output,
-            tensor_args,
-            non_tensor_args,
-            unflatten_args,
-            unbacked_bindings,
+        return ProcessKernelResult(
+            example_output=example_output,
+            tensor_args=tensor_args,
+            non_tensor_args=non_tensor_args,
+            unflatten_args=unflatten_args,
+            unbacked_bindings=unbacked_bindings,
         )
 
     @classmethod
@@ -9405,7 +9426,7 @@ class FallbackKernel(ExternKernelAlloc):
 
     @staticmethod
     def find_device(
-        tensor_args: Sequence[torch.Tensor] | None, example_output: Sequence[Any]
+        tensor_args: Sequence[IRNode] | None, example_output: Sequence[Any]
     ) -> Any:
         non_torch_bind_tensor_args = (
             [t for t in tensor_args if not isinstance(t, TorchBindObject)]
@@ -9783,13 +9804,12 @@ class FallbackKernel(ExternKernelAlloc):
             context = nullcontext()
 
         with context:
-            (
-                example_output,
-                tensor_args,
-                non_tensor_args,
-                unflatten_args,
-                unbacked_bindings,
-            ) = cls.process_kernel(kernel, *args, **kwargs)
+            result = cls.process_kernel(kernel, *args, **kwargs)
+        example_output = result.example_output
+        tensor_args = result.tensor_args
+        non_tensor_args = result.non_tensor_args
+        unflatten_args = result.unflatten_args
+        unbacked_bindings = result.unbacked_bindings
 
         # For ops with registered symm_mem args, realize those args as
         # symmetric memory buffers before creating the FallbackKernel.
@@ -11524,15 +11544,12 @@ class _CollectiveKernel(FallbackKernel):
         **kwargs: Any,
     ) -> None:
         with V.graph.fake_mode:
-            (
-                _example_output,
-                tensor_args,
-                non_tensor_args,
-                unflatten_args,
-                unbacked_bindings,
-            ) = cls.process_kernel(kernel, inputs, *args, **kwargs)
-        if unbacked_bindings:
-            raise AssertionError(f"{kernel} {unbacked_bindings}")
+            result = cls.process_kernel(kernel, inputs, *args, **kwargs)
+        tensor_args = result.tensor_args
+        non_tensor_args = result.non_tensor_args
+        unflatten_args = result.unflatten_args
+        if result.unbacked_bindings:
+            raise AssertionError(f"{kernel} {result.unbacked_bindings}")
         device = None
         for tensor_arg in tensor_args:
             if isinstance(tensor_arg, NonTensorObj):
@@ -11599,15 +11616,13 @@ class _CollectiveKernel(FallbackKernel):
         **kwargs: Any,
     ) -> list[MultiOutput] | _CollectiveKernel:
         with V.graph.fake_mode:
-            (
-                example_output,
-                tensor_args,
-                non_tensor_args,
-                unflatten_args,
-                unbacked_bindings,
-            ) = cls.process_kernel(kernel, inputs, *args, **kwargs)
-        if unbacked_bindings:
-            raise AssertionError(f"{kernel}, {unbacked_bindings}")
+            result = cls.process_kernel(kernel, inputs, *args, **kwargs)
+        example_output = result.example_output
+        tensor_args = result.tensor_args
+        non_tensor_args = result.non_tensor_args
+        unflatten_args = result.unflatten_args
+        if result.unbacked_bindings:
+            raise AssertionError(f"{kernel}, {result.unbacked_bindings}")
         for tensor_arg in tensor_args:
             if not isinstance(tensor_arg, TorchBindObject):
                 tensor_arg.realize()
@@ -11775,21 +11790,15 @@ class _WaitKernel(_CollectiveKernel):
     @classmethod
     def create_wait(cls, kernel: _OpOverloads, inp: TensorBox) -> None:
         with V.graph.fake_mode:
-            (
-                _example_output,
-                tensor_args,
-                non_tensor_args,
-                unflatten_args,
-                unbacked_bindings,
-            ) = cls.process_kernel(kernel, inp)
-        if unbacked_bindings:
-            raise AssertionError(f"{kernel} {unbacked_bindings}")
+            result = cls.process_kernel(kernel, inp)
+        if result.unbacked_bindings:
+            raise AssertionError(f"{kernel} {result.unbacked_bindings}")
         packed = cls(
             NoneLayout(device=inp.get_device()),
             kernel,
-            tensor_args,
-            non_tensor_args,
-            unflatten_args,
+            result.tensor_args,
+            result.non_tensor_args,
+            result.unflatten_args,
         )
         packed.mutation_outputs.append(
             MutationOutput(NoneLayout(device=inp.get_device()), inp, packed)

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -7159,10 +7159,7 @@ class ExternKernel(InputsKernel):
     ) -> ProcessKernelResult:
         """Partition kernel args into tensor and non-tensor, realize tensor inputs,
         re-run fake tensor propagation with the realized strides, and return a
-        ProcessKernelResult.
-
-        unflatten_args(new_tensor_args, new_non_tensor_args) reconstructs the
-        original (args, kwargs) tree from replacement lists.
+        ProcessKernelResult (see that class for field semantics).
         """
         binded_args = {"args": args, "kwargs": kwargs}
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -2235,7 +2235,7 @@ class SchedulerNode(BaseSchedulerNode):
 
     def _compute_attrs(
         self,
-        extra_indexing_constraints: tuple[dict[Any, Any], list[Any]] | None = None,
+        extra_indexing_constraints: ir.ExtraIndexingConstraints | None = None,
         recompute_sizes_body_func: Callable[_P, _T] | None = None,
     ) -> None:
         if not isinstance(self.node, (ir.ComputedBuffer, ir.TemplateBuffer)):
@@ -2271,7 +2271,7 @@ class SchedulerNode(BaseSchedulerNode):
 
     def recompute_size_and_body(
         self,
-        extra_indexing_constraints: tuple[dict[Any, Any], list[Any]] | None = None,
+        extra_indexing_constraints: ir.ExtraIndexingConstraints | None = None,
         recompute_sizes_body_func: Callable[..., Any] | None = None,
     ) -> None:
         fake_deps: OrderedSet[Dep] = OrderedSet(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #189258

This replaces three loosely-typed plumbing values in the Inductor IR layer
with precise types, so the shapes are documented at the definition site and
checked by the type checker rather than reconstructed by hand at each call
site.

ProcessKernelResult replaces the positional 5-tuple returned by
ExternKernel.process_kernel and unpacked at five call sites (FallbackKernel
and the _CollectiveKernel / _WaitKernel creators in ir.py, plus batch_p2p in
comm_lowering.py). Making find_device's parameter type accurate
(Sequence[IRNode], not Sequence[torch.Tensor]) and using get_device_or_error
where a device is required were needed once the tensor_args field carried the
precise list[IRNode] type through those call sites.

ExtraIndexingConstraints replaces the tuple[dict, list] | None threaded
through ComputedBuffer/TemplateBuffer.simplify_and_reorder and
SchedulerNode._compute_attrs / recompute_size_and_body, produced by the cpp
fusion path. The dataclass lets us delete the runtime isinstance/len asserts
that previously validated the tuple shape.

_HasAliasingOrMutation is a Protocol for the scheduler node passed to
TemplateBuffer.has_aliasing_or_mutation_for_prologue_fusion. The runtime
value is a scheduler.BaseSchedulerNode that ir.py cannot import (circular),
so the Protocol documents the single method consumed and removes the Any
escape hatch.

Suggested review order: the three type definitions in ir.py, then the
producers/consumers in codegen/cpp.py and scheduler.py, then the mechanical
call-site updates.

Test Plan:
Type-only / semantics-preserving refactor; the dataclass fields hold exactly
the values the old tuple positions did. Verified with the type checker and
linters (the local build is stale, so runtime validation is deferred to CI):

```
lintrunner --take PYFMT,RUFF,PYREFLY,CODESPELL,FLAKE8 \
  torch/_inductor/ir.py \
  torch/_inductor/scheduler.py \
  torch/_inductor/codegen/cpp.py \
  torch/_inductor/comm_lowering.py
```

pyrefly is clean on all four files; it also caught the two find_device /
get_device latent mismatches that the previous loose typing masked. Full
inductor CI exercises the changed code paths.

This PR was authored with the assistance of an AI coding assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo