### PR TITLE
Add FakeStore type stub to _distributed_c10d.pyi

### DIFF
--- a/torch/_C/_distributed_c10d.pyi
+++ b/torch/_C/_distributed_c10d.pyi
@@ -314,6 +314,9 @@ class FileStore(Store):
 class HashStore(Store):
     def __init__(self) -> None: ...
 
+class FakeStore(Store):
+    def __init__(self) -> None: ...
+
 class TCPStore(Store):
     def __init__(
         self,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #189259

#186290 reimplemented FakeStore as a C++ class exported via pybind as
torch._C._distributed_c10d.FakeStore, and re-exported it from
torch.testing._internal.distributed.fake_pg. But the hand-written stub
torch/_C/_distributed_c10d.pyi was never updated, so typecheckers flag
`from torch._C._distributed_c10d import ... FakeStore` as importing a
non-existent attribute. This adds the missing stub, mirroring HashStore
(a Store subclass with a no-arg constructor), matching the actual pybind
definition which derives from the Store base and exposes only py::init<>().

Test Plan:

Verified the symbol exists at runtime:

```
python -c "from torch._C._distributed_c10d import FakeStore; print(FakeStore)"
```

Authored with the assistance of Claude.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>