### PR TITLE
PERF: improve cuda/xpu Stream.__hash__

### DIFF
--- a/torch/cuda/streams.py
+++ b/torch/cuda/streams.py
@@ -116,8 +116,13 @@ class Stream(torch._C._CudaStreamBase):
             return super().__eq__(o)
         return False
 
-    def __hash__(self):
-        return hash((self.cuda_stream, self.device))
+    # Since ``__eq__`` is defined above, ``__hash__`` must be set explicitly.
+    # Reuse the base ``torch.Stream`` hash -- a C-level
+    # ``hash_combine`` over ``stream_id``/``device_index``/``device_type`` --
+    # instead of ``hash((self.cuda_stream, self.device))``, which would allocate
+    # a ``torch.device`` (and read the ``cuda_stream`` handle) on every call.
+    # It stays consistent with ``__eq__``, which compares those same fields.
+    __hash__ = torch.Stream.__hash__
 
     def __repr__(self):
         return f"<torch.cuda.Stream device={self.device} cuda_stream={self.cuda_stream:#x}>"

--- a/torch/xpu/streams.py
+++ b/torch/xpu/streams.py
@@ -96,8 +96,18 @@ class Stream(torch._C._XpuStreamBase):
             return super().__eq__(o)
         return False
 
-    def __hash__(self):
-        return hash((self.sycl_queue, self.device))
+    # Since ``__eq__`` is defined above, ``__hash__`` must be set explicitly.
+    # Reuse the base ``torch.Stream`` hash -- a C-level ``hash_combine`` over
+    # ``stream_id``/``device_index``/``device_type`` -- instead of
+    # ``hash((self.sycl_queue, self.device))``, which would allocate a
+    # ``torch.device`` (and read the ``sycl_queue`` handle) on every call.
+    # Dropping ``sycl_queue`` from the hash is safe: ``__eq__`` compares the
+    # underlying ``XPUStream`` (i.e. ``stream_id``/``device_index``/
+    # ``device_type``), not the queue pointer, and ``sycl_queue`` is itself
+    # derived from that same stream. So equal streams necessarily share those
+    # three fields (and hence this hash), keeping ``__hash__`` consistent with
+    # ``__eq__``.
+    __hash__ = torch.Stream.__hash__
 
     def __repr__(self) -> str:
         return f"torch.xpu.Stream(device={self.device} sycl_queue={self.sycl_queue:#x})"


### PR DESCRIPTION
## Summary

`torch.cuda.Stream.__hash__` and `torch.xpu.Stream.__hash__` are defined as `hash((self.cuda_stream, self.device))` / `hash((self.sycl_queue, self.device))`. `self.device` builds a fresh `torch.device` object on every call (plus a
native-handle property read and a tuple allocation), so hashing a stream seems to have some overhead. 

These overrides exist because defining `__eq__` on the class forces to set `__hash__` (otherwise it becomes `None`, since the C bases `_CudaStreamBase` / `_XpuStreamBase` are unhashable). 
This MR proposes to reuse the base `torch.Stream.__hash__`.

## Performance

Using the following snippet: 
```py
import torch, timeit
s = torch.cuda.current_stream()
N = 1_000_000

torch.cuda.Stream.__hash__ = lambda self: hash((self.cuda_stream, self.device))
t_old = timeit.timeit(lambda: hash(s), number=N) / N * 1e9

torch.cuda.Stream.__hash__ = torch.Stream.__hash__
t_new = timeit.timeit(lambda: hash(s), number=N) / N * 1e9

print(f"old: {t_old:.1f} ns\nnew: {t_new:.1f} ns\nspeedup: {t_old/t_new:.2f}x")
```
I get about 4X speed up

## Disclaimer

Maybe there is a subtlety that i am not seeing justifying the existing implementation, in which case I would be interested to know :) 