### PR TITLE
test/inductor: relax FlexAttention invalid-block-size regex

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -5417,7 +5417,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
             "Invalid FlexAttention forward kernel options: Q and KV block sizes "
             "must be divisible by the selected tile sizes.*"
             "SPARSE_Q_BLOCK_SIZE=96.*SPARSE_KV_BLOCK_SIZE=96.*"
-            "BLOCK_M=128.*BLOCK_N=32"
+            "BLOCK_M=\\d+.*BLOCK_N=\\d+"
         )
         block_mask = create_block_mask(
             noop_mask, 1, 8, 128, 128, BLOCK_SIZE=96, device=device


### PR DESCRIPTION
This updates `test/inductor/test_flex_attention.py::test_invalid_block_size` to avoid
a brittle assertion on exact tuned tile sizes.
The test previously expected:
- `BLOCK_M=128`
- `BLOCK_N=32`
On ROCm/RDNA, the runtime may choose different forward tiles (e.g. `64x64`) while still
raising the same intended error:
`Q/KV block sizes must be divisible by selected tile sizes`.
The fix changes the regex to accept dynamic tile values via `BLOCK_M=\d+` and `BLOCK_N=\d+`
This preserves semantic coverage and removes backend/autotune-specific flakiness.

## Test
```
root@RSB-RORLAB-09:~/pytorch# PYTORCH_TEST_WITH_ROCM=1 python test/inductor/test_flex_attention.py TestFlexAttentionCUDA.test_invalid_block_size_cuda
.
----------------------------------------------------------------------
Ran 1 test in 1.415s

OK
```

Refs:
https://github.com/pytorch/pytorch/pull/186876/

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo