### PR TITLE
[ROCm][CI] Fix py3.15 ROCm manywheel numpy source build (pkg-config python3)

### DIFF
--- a/.ci/manywheel/build_install_deps.py
+++ b/.ci/manywheel/build_install_deps.py
@@ -11,6 +11,7 @@ import argparse
 import os
 import subprocess
 import sys
+import sysconfig
 import time
 from pathlib import Path
 
@@ -49,12 +50,34 @@ def numpy_pin() -> str:
     return DEFAULT_NUMPY
 
 
+def prefer_interpreter_pkgconfig() -> None:
+    """Make ``pkg-config python3`` resolve to the interpreter we build for.
+
+    For a CPython with no prebuilt numpy wheel yet (e.g. a freshly added
+    version), pip builds numpy from source and meson's Cython sanity check
+    resolves the ``python3`` pkg-config dependency for the include/link flags.
+    The ROCm manylinux image ships the system Python 3.6 pkg-config file on the
+    default search path, so that lookup returns Python 3.6 and Cython aborts
+    with "Cython requires Python 3.8+". Prepending the active interpreter's own
+    pkgconfig dir makes pkg-config find the correct ``python3.pc`` first; it is
+    a no-op for Pythons whose numpy comes from a wheel (no source build).
+    """
+    libpc = sysconfig.get_config_var("LIBPC")
+    if not libpc or not os.path.isdir(libpc):
+        return
+    existing = os.environ.get("PKG_CONFIG_PATH", "")
+    os.environ["PKG_CONFIG_PATH"] = os.pathsep.join(
+        [libpc, *([existing] if existing else [])]
+    )
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("package_dir", type=Path)
     args = parser.parse_args()
 
     os.chdir(args.package_dir)
+    prefer_interpreter_pkgconfig()
     pip_install("-qU", "-r", "requirements-build.txt")
     # Skip when sharing build/ across Pythons in build_all.sh -- the per-Python
     # bits (libtorch_python, _C.so) are invalidated by tools/setup_helpers/cmake.py.

--- a/.ci/pytorch/binary_linux_test.sh
+++ b/.ci/pytorch/binary_linux_test.sh
@@ -53,6 +53,15 @@ if [[ "$PACKAGE_TYPE" != libtorch ]]; then
 
     # numpy tests:
     # We test 1 version no numpy. 1 version with numpy 1.x and rest with numpy 2.x
+    # Pythons without a prebuilt numpy wheel (e.g. 3.15) build numpy from source;
+    # meson's Cython sanity check resolves the 'python3' pkg-config dependency, which
+    # on the ROCm manylinux image returns the system Python 3.6 and aborts with
+    # "Cython requires Python 3.8+". Prepend the active interpreter's own pkgconfig
+    # dir so pkg-config resolves to it. No-op when numpy comes from a wheel.
+    numpy_libpc="\$(python -c 'import os, sysconfig; p = sysconfig.get_config_var("LIBPC"); print(p if p and os.path.isdir(p) else "")')"
+    if [[ -n "\$numpy_libpc" ]]; then
+      export PKG_CONFIG_PATH="\$numpy_libpc\${PKG_CONFIG_PATH:+:\$PKG_CONFIG_PATH}"
+    fi
     if [[ "\$python_nodot" = *311* ]]; then
       retry pip install -q numpy==1.23.5 protobuf typing-extensions
     elif [[ "\$python_nodot" = *312* ]]; then


### PR DESCRIPTION
## Summary

Python 3.15 has no prebuilt numpy wheel on PyPI yet, so pip builds numpy from source for every arch. meson's Cython sanity check resolves the `python3` pkg-config dependency to get Python include/link flags. The ROCm `manylinux2_28-builder` image ships the system Python 3.6 pkg-config file on the default search path, so `pkg-config python3` returns Python 3.6 (`-I/usr/include/python3.6m`) and Cython aborts with `#error Cython requires Python 3.8+`.

CUDA/CPU/XPU manylinux images do not carry that system `python3` pkg-config entry, so meson falls back to the correct interpreter and their py3.15 builds succeed. All ROCm builds for Python versions that ship a prebuilt numpy wheel (3.11-3.14) also succeed because numpy is never built from source there.

This shows up in two separate places, each fixed the same way (prepend the active interpreter's own pkgconfig directory, `sysconfig` `LIBPC`, to `PKG_CONFIG_PATH` before numpy is installed, so `pkg-config python3` resolves to the interpreter being built for; no-op when numpy comes from a wheel):

- Build stage (`.ci/manywheel/build_install_deps.py`): fixes `manywheel-py3_15/py3_15t-rocm*-build`.
- Binary smoke-test stage (`.ci/pytorch/binary_linux_test.sh`): the smoke test runs a separate in-container script that re-installs numpy from source, so it hit the identical failure in `manywheel-py3_15/py3_15t-rocm*-test` (and flakily in a couple other rocm test shards) after the build was fixed.

Reference: original failing build job https://github.com/pytorch/pytorch/actions/runs/28734817308/job/85207010577 (numpy meson build, `pkg-config --modversion python3` -> 3.6); failing smoke-test job https://github.com/pytorch/pytorch/actions/runs/28952344908/job/85981822513.

## Test plan

- [ ] `ciflow/binaries_wheel` `linux-binary-manywheel` (run https://github.com/pytorch/pytorch/actions/runs/28978925760, HUD https://hud.pytorch.org/pr/189266): `manywheel-py3_15-rocm7_1/7_2-build` and `py3_15t` variants build past the numpy source-build step.
- [ ] Same run: `manywheel-py3_15/py3_15t-rocm7_1/7_2-test` smoke tests pass the numpy source build in `binary_linux_test.sh`.
- [ ] Confirm `py3_11`-`py3_14` ROCm builds/tests remain green (numpy installed from wheel, unchanged).
- [ ] Confirm CUDA/CPU/XPU py3.15 builds/tests remain green (behavior unchanged; `LIBPC` already resolves to the correct interpreter).

Made with Cursor

Tracking issue: https://github.com/ROCm/frameworks-internal/issues/17233

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang
