### PR TITLE
[XPU][Test] Enable SimpleKinetoInitializationTest on XPU

### DIFF
--- a/test/profiler/test_kineto.py
+++ b/test/profiler/test_kineto.py
@@ -54,7 +54,8 @@ if torch.{device_type}.is_available():
 instantiate_device_type_tests(
     SimpleKinetoInitializationTest,
     globals(),
-    only_for=("cuda",),
+    only_for=("cuda", "xpu"),
+    allow_xpu=True,
 )
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Extend `instantiate_device_type_tests` for `SimpleKinetoInitializationTest` to `only_for=("cuda", "xpu"), allow_xpu=True`
- The test body already uses dynamic `torch.{device_type}.{api}()` dispatch (`is_available`, `init`) with `hasattr` guards — no hardcoded `torch.cuda.*` calls, making it fully compatible with XPU out of the box
- No new XPU skip decorators added; existing XPU skips/decorators untouched
- `common_methods_invocations.py` unchanged (not an OpInfo test class — no DecorateInfo entries to widen)

## Test plan

- Locally verified on XPU host:
  ```
  $ python -m pytest test/profiler/test_kineto.py -v -k "SimpleKinetoInitializationTest" --tb=short
  SimpleKinetoInitializationTestXPU::test_kineto_profiler_with_environment_variable_xpu PASSED [12.18s]
  ```
- CUDA behavior unchanged (validated by CI on a CUDA host)

Authored with an AI assistant.