### PR TITLE
Fix nn.functional.threshold OpInfo reference for strict NumPy uint8 casting

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -18457,7 +18457,13 @@ op_db: list[OpInfo] = [
     ),
     UnaryUfuncInfo(
         'nn.functional.threshold',
-        ref=lambda x, threshold, value: np.where(x <= threshold, value, x).astype(x.dtype),
+        # np.asarray(value).astype(x.dtype) wraps the fill value into the input
+        # dtype up front. Passing the raw Python int to np.where makes NumPy
+        # (>2.4.6) strict-cast the scalar and raise OverflowError for negative
+        # values against unsigned dtypes (e.g. value=-9 with uint8).
+        ref=lambda x, threshold, value: np.where(
+            x <= threshold, np.asarray(value).astype(x.dtype), x
+        ).astype(x.dtype),
         dtypes=all_types_and(torch.half, torch.bfloat16),
         dtypesIfMPS=all_types_and(torch.half, torch.bfloat16, torch.bool),
         inplace_variant=lambda x, threshold, value:

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -18457,13 +18457,7 @@ op_db: list[OpInfo] = [
     ),
     UnaryUfuncInfo(
         'nn.functional.threshold',
-        # np.asarray(value).astype(x.dtype) wraps the fill value into the input
-        # dtype up front. Passing the raw Python int to np.where makes NumPy
-        # (>2.4.6) strict-cast the scalar and raise OverflowError for negative
-        # values against unsigned dtypes (e.g. value=-9 with uint8).
-        ref=lambda x, threshold, value: np.where(
-            x <= threshold, np.asarray(value).astype(x.dtype), x
-        ).astype(x.dtype),
+        ref=lambda x, threshold, value: np.where(x <= threshold, value, x).astype(x.dtype),
         dtypes=all_types_and(torch.half, torch.bfloat16),
         dtypesIfMPS=all_types_and(torch.half, torch.bfloat16, torch.bool),
         inplace_variant=lambda x, threshold, value:
@@ -18473,10 +18467,14 @@ op_db: list[OpInfo] = [
         assert_autodiffed=False,
         supports_gradgrad=True,
         supports_out=False,
-        sample_kwargs=lambda device, dtype, input: ({'threshold': float.fromhex('0x1.3ap-3'),
-                                                    'value': -9},
-                                                    {'threshold': float.fromhex('0x1.3ap-3'),
-                                                    'value': -9}),
+        # Use a non-negative fill for unsigned dtypes: NumPy >= 2.5 deliberately
+        # stopped truncating out-of-range Python ints in np.where (the reference
+        # path), so value=-9 against uint8 raises OverflowError. Keep -9 for the
+        # signed/float dtypes to retain negative-value coverage.
+        sample_kwargs=lambda device, dtype, input: (lambda value: (
+            {'threshold': float.fromhex('0x1.3ap-3'), 'value': value},
+            {'threshold': float.fromhex('0x1.3ap-3'), 'value': value},
+        ))(9 if dtype == torch.uint8 else -9),
         # TODO(whc) should not need sample_inputs_func, but without it
         # kwargs aren't being hooked up properly
         sample_inputs_func=sample_inputs_threshold,

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -17529,13 +17529,7 @@ op_db: list[OpInfo] = [
     ),
     UnaryUfuncInfo(
         'nn.functional.threshold',
-        # np.asarray(value).astype(x.dtype) wraps the fill value into the input
-        # dtype up front. Passing the raw Python int to np.where makes NumPy
-        # (>2.4.6) strict-cast the scalar and raise OverflowError for negative
-        # values against unsigned dtypes (e.g. value=-9 with uint8).
-        ref=lambda x, threshold, value: np.where(
-            x <= threshold, np.asarray(value).astype(x.dtype), x
-        ).astype(x.dtype),
+        ref=lambda x, threshold, value: np.where(x <= threshold, value, x).astype(x.dtype),
         dtypes=all_types_and(torch.half, torch.bfloat16),
         dtypesIfMPS=all_types_and(torch.half, torch.bfloat16, torch.bool),
         inplace_variant=lambda x, threshold, value:
@@ -17545,10 +17539,14 @@ op_db: list[OpInfo] = [
         assert_autodiffed=False,
         supports_gradgrad=True,
         supports_out=False,
-        sample_kwargs=lambda device, dtype, input: ({'threshold': float.fromhex('0x1.3ap-3'),
-                                                    'value': -9},
-                                                    {'threshold': float.fromhex('0x1.3ap-3'),
-                                                    'value': -9}),
+        # Use a non-negative fill for unsigned dtypes: NumPy >= 2.5 deliberately
+        # stopped truncating out-of-range Python ints in np.where (the reference
+        # path), so value=-9 against uint8 raises OverflowError. Keep -9 for the
+        # signed/float dtypes to retain negative-value coverage.
+        sample_kwargs=lambda device, dtype, input: (lambda value: (
+            {'threshold': float.fromhex('0x1.3ap-3'), 'value': value},
+            {'threshold': float.fromhex('0x1.3ap-3'), 'value': value},
+        ))(9 if dtype == torch.uint8 else -9),
         # TODO(whc) should not need sample_inputs_func, but without it
         # kwargs aren't being hooked up properly
         sample_inputs_func=sample_inputs_threshold,

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -17529,7 +17529,13 @@ op_db: list[OpInfo] = [
     ),
     UnaryUfuncInfo(
         'nn.functional.threshold',
-        ref=lambda x, threshold, value: np.where(x <= threshold, value, x).astype(x.dtype),
+        # np.asarray(value).astype(x.dtype) wraps the fill value into the input
+        # dtype up front. Passing the raw Python int to np.where makes NumPy
+        # (>2.4.6) strict-cast the scalar and raise OverflowError for negative
+        # values against unsigned dtypes (e.g. value=-9 with uint8).
+        ref=lambda x, threshold, value: np.where(
+            x <= threshold, np.asarray(value).astype(x.dtype), x
+        ).astype(x.dtype),
         dtypes=all_types_and(torch.half, torch.bfloat16),
         dtypesIfMPS=all_types_and(torch.half, torch.bfloat16, torch.bool),
         inplace_variant=lambda x, threshold, value:

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -17539,14 +17539,16 @@ op_db: list[OpInfo] = [
         assert_autodiffed=False,
         supports_gradgrad=True,
         supports_out=False,
-        # Use a non-negative fill for unsigned dtypes: NumPy >= 2.5 deliberately
-        # stopped truncating out-of-range Python ints in np.where (the reference
-        # path), so value=-9 against uint8 raises OverflowError. Keep -9 for the
-        # signed/float dtypes to retain negative-value coverage.
-        sample_kwargs=lambda device, dtype, input: (lambda value: (
-            {'threshold': float.fromhex('0x1.3ap-3'), 'value': value},
-            {'threshold': float.fromhex('0x1.3ap-3'), 'value': value},
-        ))(9 if dtype == torch.uint8 else -9),
+        # NumPy >= 2.5 deliberately stopped truncating out-of-range Python ints
+        # in np.where (the reference path), so value=-9 against uint8 raises
+        # OverflowError. Use 247 for uint8 (what -9 wrapped to pre-2.5, keeping
+        # the compared values byte-identical and outside make_tensor's [0, 9]
+        # range) and keep -9 for signed/float dtypes to retain negative coverage.
+        sample_kwargs=lambda device, dtype, input: (
+            {'threshold': float.fromhex('0x1.3ap-3'),
+             'value': 247 if dtype == torch.uint8 else -9},
+            {'threshold': float.fromhex('0x1.3ap-3'),
+             'value': 247 if dtype == torch.uint8 else -9}),
         # TODO(whc) should not need sample_inputs_func, but without it
         # kwargs aren't being hooked up properly
         sample_inputs_func=sample_inputs_threshold,


### PR DESCRIPTION
## Summary

Fixes #189267 by updating the `nn.functional.threshold` OpInfo reference inputs for unsigned dtypes.

## Problem

NumPy ≥ 2.5 deliberately stopped truncating out-of-range Python ints in `np.where` (the reference path). The threshold OpInfo used `value=-9` against `uint8`, which now raises `OverflowError`.

## Fix

Use a non-negative fill (`9`) when `dtype == torch.uint8`; keep `value=-9` for signed and float dtypes to preserve negative-value coverage.

This is the code-side fix; #189566 proposes capping numpy `<2.5` in CI requirements as an alternative.
