### PR TITLE
[dynamo] Route set/dict-view/list dunder methods through tp_slots

### DIFF
--- a/test/dynamo/test_sequence_ops.py
+++ b/test/dynamo/test_sequence_ops.py
@@ -3,7 +3,6 @@
 """Tests for sequence protocol operations (sq_*) in PyTorch Dynamo."""
 
 import collections
-import unittest
 
 import torch
 import torch._dynamo.test_case
@@ -231,12 +230,6 @@ class TestSqConcat(torch._dynamo.test_case.TestCase):
             self.assertEqual(list(d), list(ref))
             self.assertEqual(d.maxlen, ref.maxlen)
 
-    # In-place concat (+=) on a deque subclass is not yet supported: it routes
-    # to the base deque __iadd__, whose type-identity check rejects the RHS
-    # UserDefinedDeque operand (it is not unwrapped to its base deque first),
-    # raising TypeError. Eager's deque.__iadd__ accepts any iterable. Tracked
-    # for a later gate.
-    @unittest.expectedFailure
     @make_dynamo_test
     def test_user_defined_deque_inplace_concat(self):
         a = UserDefinedDeque([1, 2])

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -218,7 +218,7 @@ from .ctx_manager import (
     PreserveVersionContextVariable,
     RecordFunctionVariable,
 )
-from .dicts import ConstDictVariable, MappingProxyVariable, SetVariable
+from .dicts import ConstDictVariable, MappingProxyVariable
 from .distributed import WorldMetaClassVariable
 from .functions import (
     BoundBuiltinMethodVariable,
@@ -290,6 +290,7 @@ from .sets import (
     FrozensetVariable,
     OrderedSetClassVariable,
     OrderedSetVariable,
+    SetVariable,
 )
 from .streams import EventVariable, StreamContextVariable, StreamVariable
 from .tensor import (

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -67,7 +67,6 @@ from .object_protocol import (
     mro_lookup,
     vt_getitem,
 )
-from .sets import SetVariable
 
 
 if TYPE_CHECKING:
@@ -1264,25 +1263,6 @@ class DictKeysVariable(DictViewVariable):
             {},
         )
 
-    def call_method(
-        self,
-        tx: "InstructionTranslatorBase",
-        name: str,
-        args: list[VariableTracker],
-        kwargs: dict[str, VariableTracker],
-    ) -> VariableTracker:
-        if name in (
-            "__and__",
-            "__iand__",
-            "__xor__",
-            "__ixor__",
-        ):
-            # These methods always returns a set
-            m = getattr(self.set_items, name)
-            r = m(args[0].set_items)  # type: ignore[attr-defined]
-            return SetVariable(r)
-        return super().call_method(tx, name, args, kwargs)
-
 
 class DictValuesVariable(DictViewVariable):
     # PyDictValues_Type: https://github.com/python/cpython/blob/e76aa128fe/Objects/dictobject.c#L6615
@@ -1437,25 +1417,6 @@ class DictItemsVariable(DictViewVariable):
         if self.dv_dict.source and not is_constant_source(self.dv_dict.source):
             tx.output.guard_on_key_order.add(self.dv_dict.source)
         return DictItemsIterator(self.dv_dict.items)
-
-    def call_method(
-        self,
-        tx: "InstructionTranslatorBase",
-        name: str,
-        args: list[VariableTracker],
-        kwargs: dict[str, VariableTracker],
-    ) -> VariableTracker:
-        if name in (
-            "__and__",
-            "__iand__",
-            "__xor__",
-            "__ixor__",
-        ):
-            # These methods always returns a set
-            fn_hdl = getattr(self.set_items, name)
-            ret_val = fn_hdl(args[0].set_items)  # type: ignore[attr-defined]
-            return SetVariable(ret_val)
-        return super().call_method(tx, name, args, kwargs)
 
 
 kV = HashableTracker | str

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -497,7 +497,7 @@ class BaseListVariable(VariableTracker):
                 [self, args[0]],
                 kwargs,
             )
-        elif name in ("__add__", "__iadd__"):
+        elif name == "__add__":
             if kwargs or len(args) != 1:
                 raise_args_mismatch(
                     tx,
@@ -505,23 +505,16 @@ class BaseListVariable(VariableTracker):
                     "1 args and 0 kwargs",
                     f"{len(args)} args and {len(kwargs)} kwargs",
                 )
-
-            if type(self) is not type(args[0]):
-                tp_name = self.python_type_name()
-                other = args[0].python_type_name()
-                raise_observed_exception(
-                    TypeError,
+            return self.sq_concat_impl(tx, args[0])
+        elif name == "__iadd__":
+            if kwargs or len(args) != 1:
+                raise_args_mismatch(
                     tx,
-                    args=[
-                        f'can only concatenate {tp_name} (not "{other}") to {tp_name}'
-                    ],
+                    name,
+                    "1 args and 0 kwargs",
+                    f"{len(args)} args and {len(kwargs)} kwargs",
                 )
-
-            if name == "__add__":
-                return type(self)(self.items + args[0].items)  # type: ignore[attr-defined]
-            else:
-                self.items += args[0].items  # type: ignore[attr-defined]
-                return self
+            return self.sq_inplace_concat_impl(tx, args[0])
         elif name == "__reversed__":
             # list/tuple/namedtuple __reversed__: reverse iterator over items.
             if args or kwargs:

--- a/torch/_dynamo/variables/sets.py
+++ b/torch/_dynamo/variables/sets.py
@@ -355,9 +355,6 @@ class SetVariable(VariableTracker):
             py_type = self.python_type()
             return self._fast_set_method(tx, getattr(py_type, name), args, kwargs)
 
-        # Lazy imports to avoid circular dependencies
-        from .dicts import DictItemsVariable, DictKeysVariable
-
         if name == "add":
             if kwargs or len(args) != 1:
                 raise_args_mismatch(
@@ -537,92 +534,6 @@ class SetVariable(VariableTracker):
             return SourcelessBuilder.create(tx, op.get(name)).call_function(
                 tx, [self, other], {}
             )
-        elif name in ("__and__", "__xor__", "__sub__"):
-            m = {
-                "__and__": "intersection",
-                "__xor__": "symmetric_difference",
-                "__sub__": "difference",
-            }.get(name)
-            if not isinstance(
-                args[0],
-                (
-                    SetVariable,
-                    variables.UserDefinedSetVariable,
-                    DictItemsVariable,
-                    DictKeysVariable,
-                ),
-            ):
-                raise_observed_exception(
-                    TypeError,
-                    tx,
-                    args=[
-                        f"unsupported operand type(s) for {name}: '{self.python_type_name()}' and '{args[0].python_type_name()}'"
-                    ],
-                )
-            if m is None:
-                raise AssertionError(f"Unexpected set method name: {name}")
-            return self.call_method(tx, m, args, kwargs)
-        elif name in ("__rand__", "__rxor__", "__rsub__"):
-            m = {
-                "__rand__": "__and__",
-                "__rxor__": "__xor__",
-                "__rsub__": "__sub__",
-            }.get(name)
-            if not isinstance(
-                args[0],
-                (
-                    SetVariable,
-                    variables.UserDefinedSetVariable,
-                    DictItemsVariable,
-                    DictKeysVariable,
-                ),
-            ):
-                raise_observed_exception(
-                    TypeError,
-                    tx,
-                    args=[
-                        f"unsupported operand type(s) for {name}: '{args[0].python_type_name()}' and '{self.python_type_name()}'"
-                    ],
-                )
-            if m is None:
-                raise AssertionError(f"Unexpected reverse set method name: {name}")
-            return args[0].call_method(tx, m, [self], kwargs)
-        elif name in ("__iand__", "__ior__", "__ixor__", "__isub__"):
-            if not isinstance(
-                args[0],
-                (
-                    SetVariable,
-                    variables.UserDefinedSetVariable,
-                    DictItemsVariable,
-                    DictKeysVariable,
-                ),
-            ):
-                raise_observed_exception(
-                    TypeError,
-                    tx,
-                    args=[
-                        f"unsupported operand type(s) for {name}: '{self.python_type_name()}' and '{args[0].python_type_name()}'"
-                    ],
-                )
-            m = {
-                "__iand__": "intersection_update",
-                "__ior__": "update",
-                "__ixor__": "symmetric_difference_update",
-                "__isub__": "difference_update",
-            }.get(name)
-            if m is None:
-                raise AssertionError(f"Unexpected inplace set method name: {name}")
-            self.call_method(tx, m, args, kwargs)
-            return self
-        elif name == "__len__":
-            if args or kwargs:
-                raise_args_mismatch(
-                    tx,
-                    name,
-                    "0 args and 0 kwargs",
-                    f"{len(args)} args and {len(kwargs)} kwargs",
-                )
-            return VariableTracker.build(tx, len(self.items))
         elif name == "copy":
             if args or kwargs:
                 raise_args_mismatch(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189274

Several SetVariable, dict-view, and list VariableTrackers reimplemented the
number/sequence-protocol dunders (__and__, __or__, __xor__, __sub__ and their
reflected/in-place variants; __add__/__iadd__) directly inside call_method.
VariableTracker.call_method already dispatches these dunders to the
nb_*_impl / sq_*_impl slots, so the call_method branches were duplicating (and
in places diverging from) the slot implementations that the BINARY_OP path
already uses.

This consolidates every affected VT onto its slot:

- SetVariable: drop the __and__/__xor__/__sub__ (+ reflected + in-place)
  branches; base.call_method routes them to the existing nb_*_impl. This also
  fixes explicit s.__and__(non_set) / s.__and__(dict_keys), which previously
  raised TypeError but should return NotImplemented per CPython.

- DictKeysVariable / DictItemsVariable: drop the __and__/__iand__/__xor__/
  __ixor__ branches that recomputed a set; DictViewVariable already defines
  nb_and_impl/nb_xor_impl. Since real dict_keys/dict_items have no in-place
  variants, this stops fabricating a set for the (nonexistent) __iand__/__ixor__.
  SetVariable is now imported into builder.py directly from .sets rather than
  re-exported through .dicts.

- BaseListVariable: __add__/__iadd__ delegate to the sq_concat_impl /
  sq_inplace_concat_impl slots instead of an inline, type-identity-checked
  concat. base.call_method routes __add__ to nb_add_impl (which lists do not
  implement), so delegating to the sequence slot -- the same path the +
  operator already uses -- is required; a plain deletion would break explicit
  l.__add__(x). This fixes two latent bugs: list.__iadd__(iterable) was
  rejected with TypeError (CPython extends, accepting any iterable) and
  tuple.__iadd__ mutated the tuple in place.

DefaultDictVariable's __ior__ branch is intentionally left as-is: it already
delegates to nb_inplace_or_impl (added deliberately in #185429) and is a
validating slot entry point, not a reimplementation.

The removed deque-subclass in-place-concat expected-failure in
test_sequence_ops.py now passes and is un-skipped.

Test Plan:

```
python test/dynamo/test_sets.py
python test/dynamo/test_dicts.py
python test/dynamo/test_list.py
python test/dynamo/test_sequence_ops.py
python test/dynamo/test_functions.py
python test/dynamo/test_misc.py
PYTORCH_TEST_WITH_DYNAMO=1 python test/cpython/v3_13/test_list.py
PYTORCH_TEST_WITH_DYNAMO=1 python test/cpython/v3_13/test_userlist.py
PYTORCH_TEST_WITH_DYNAMO=1 python test/cpython/v3_13/test_tuple.py
PYTORCH_TEST_WITH_DYNAMO=1 python test/cpython/v3_13/test_dict.py
PYTORCH_TEST_WITH_DYNAMO=1 python test/cpython/v3_13/test_userdict.py
PYTORCH_TEST_WITH_DYNAMO=1 python test/cpython/v3_13/test_ordered_dict.py
PYTORCH_TEST_WITH_DYNAMO=1 python test/cpython/v3_13/test_defaultdict.py
PYTORCH_TEST_WITH_DYNAMO=1 python test/cpython/v3_13/test_set.py
```

All pass. Behavior parity between eager and torch.compile was additionally
spot-checked for dict-view/set/list dunders including the TypeError messages
for mismatched operands.

Authored with assistance from Claude Code.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98