### PR TITLE
Skip redundant contiguity rescan in empty_tensor_restride (robust) (#189277)

### DIFF
--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -2413,6 +2413,9 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
         "If you are seeing this error, that means empty_tensor_restride was "
         "called before setting correct numel");
 #endif
+    // Set when the branch writes canonical row-major strides, so the trailing
+    // refresh can skip recomputing contiguity (see _refresh_contiguous).
+    bool assume_contiguous = false;
     switch (memory_format) {
       case MemoryFormat::Contiguous: {
         // dim_ is a virtual call, don't repeat it
@@ -2431,6 +2434,9 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
           }
           TORCH_CHECK(!overflowed, "Stride calculation overflowed");
         }
+        // Sparse tensors are never reported contiguous (compute_contiguous()
+        // returns false for them), so only claim contiguity otherwise.
+        assume_contiguous = !is_sparse();
         break;
       }
       case MemoryFormat::ChannelsLast: {
@@ -2455,8 +2461,9 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
         TORCH_INTERNAL_ASSERT(false, "invalid memory format ", memory_format);
     }
     // recompute contiguous flag, as currently NHWC/NCHW flags are not mutually
-    // exclusive see #24090
-    refresh_contiguous();
+    // exclusive see #24090. has_symbolic_sizes_strides_ returned early above,
+    // so dispatch straight to the non-symbolic path with the contiguity hint.
+    _refresh_contiguous(assume_contiguous);
   }
 
   bool is_strides_like(at::MemoryFormat memory_format) const {
@@ -2715,7 +2722,13 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     return is_contiguous_ || compute_non_overlapping_and_dense();
   }
 
-  void _refresh_contiguous() {
+  // assume_contiguous: the caller just wrote canonical row-major strides, so
+  // both (row-major) contiguity and non-overlapping-and-dense are already known
+  // true, independent of rank. Passing true skips the redundant O(dim) rescans
+  // in compute_contiguous()/compute_non_overlapping_and_dense() while still
+  // running the rank-dependent channels-last disambiguation below, so the
+  // single switch stays the source of truth.
+  void _refresh_contiguous(bool assume_contiguous = false) {
     // Note:
     // Dim 0, 1, 2 will never be a channels last 2d/3d format
     // Dim 3+ is possibly be a channels last 2d format (Dim 4 only at this
@@ -2723,24 +2736,24 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     // this point)
     switch (dim()) {
       case 4: {
-        _set_is_contiguous(compute_contiguous());
+        _set_is_contiguous(assume_contiguous || compute_contiguous());
         _set_is_channels_last_contiguous(compute_channels_last_contiguous_2d());
         _set_is_channels_last_3d_contiguous(false);
         _set_is_channels_last(compute_strides_like_channels_last_2d());
         _set_is_channels_last_3d(false);
         _set_is_non_overlapping_and_dense(
-            compute_is_non_overlapping_and_dense_dim4());
+            assume_contiguous || compute_is_non_overlapping_and_dense_dim4());
         break;
       }
       case 5: {
-        _set_is_contiguous(compute_contiguous());
+        _set_is_contiguous(assume_contiguous || compute_contiguous());
         _set_is_channels_last_contiguous(compute_channels_last_contiguous_2d());
         _set_is_channels_last_3d_contiguous(
             compute_channels_last_contiguous_3d_dim5());
         _set_is_channels_last(compute_channels_last_2d_dim5());
         _set_is_channels_last_3d(compute_channels_last_3d_dim5());
         _set_is_non_overlapping_and_dense(
-            compute_is_non_overlapping_and_dense_dim5());
+            assume_contiguous || compute_is_non_overlapping_and_dense_dim5());
         break;
       }
       default:
@@ -2749,13 +2762,13 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
         // mean the tensor is strided like channels_last: for strides on channel
         // dimension could suggest desired memory_layout, but it doesn't affect
         // memory storage
-        _set_is_contiguous(compute_contiguous());
+        _set_is_contiguous(assume_contiguous || compute_contiguous());
         _set_is_channels_last_contiguous(false);
         _set_is_channels_last_3d_contiguous(false);
         _set_is_channels_last(false);
         _set_is_channels_last_3d(false);
         _set_is_non_overlapping_and_dense(
-            compute_is_non_overlapping_and_dense_anydim());
+            assume_contiguous || compute_is_non_overlapping_and_dense_anydim());
         break;
     }
   }


### PR DESCRIPTION
Summary:

`TensorImpl::empty_tensor_restride(MemoryFormat::Contiguous)` writes canonical row-major strides and then calls `refresh_contiguous()`, which re-scans sizes/strides via the out-of-line `compute_contiguous()` to recompute the six contiguity flags. Once row-major strides have just been written, that scan is redundant: `is_contiguous_` and `is_non_overlapping_and_dense_` are known `true` regardless of rank.

This adds an `assume_contiguous` hint to `_refresh_contiguous()`. When set, the two rank-independent flags are short-circuited to `true` (`assume_contiguous || compute_...()`), skipping the `compute_contiguous()` scan, while the rank-dependent channels-last disambiguation still runs through the same single `switch`. `empty_tensor_restride` sets the hint to `!is_sparse()` only in the `Contiguous` branch and passes it through.

This supersedes the earlier PerfAICT attempt (D110828270), which duplicated the rank-4/5 knowledge into `empty_tensor_restride` and hardcoded the `default`-case flag values there. That was fragile: a future channels-last format for another rank (or a column-major layout) would silently get the wrong flags because the fast-path never consulted the switch. Here the switch remains the single source of truth, so the optimization is robust to new layouts, and it additionally covers the rank-4/5 contiguous path (which the codemod left unoptimized) while preserving channels-last correctness for ambiguous tensors like `NC11`. Sparse tensors take the unchanged path since `compute_contiguous()` reports them non-contiguous.

Test Plan:
Relies on existing `c10`/ATen contiguity coverage; behavior is unchanged for all inputs (the hint only substitutes provably-true results). Verified reasoning against `_refresh_contiguous` and the `compute_channels_last_*` paths for ambiguous 4D/5D tensors.

Authored with assistance from an AI coding assistant.

Reviewed By: ezyang


