### PR TITLE
Make test_sac_ilp hardware-independent by pinning device datasheet

### DIFF
--- a/test/distributed/_tools/test_sac_ilp.py
+++ b/test/distributed/_tools/test_sac_ilp.py
@@ -40,6 +40,9 @@ class TestSACILP(TestCase):
         super().setUp()
         self.device = torch.cuda.current_device()
         self.estimate_mode = "operator-level-cost-model"
+        # Pin the roofline device spec so runtime estimates are deterministic
+        # across the physical GPU the test happens to run on.
+        self.gpu_type = "NVIDIA H100"
 
     def _init_model_input_optimizer(
         self,
@@ -106,7 +109,7 @@ class TestSACILP(TestCase):
         # Initializing optimizer states and warm-up
         _run_one_step()
 
-        runtime_estimator = RuntimeEstimator()
+        runtime_estimator = RuntimeEstimator(gpu_type=self.gpu_type)
         with runtime_estimator(estimate_mode_type=self.estimate_mode):
             _run_one_step()  # We use only one iteration for estimation
         return runtime_estimator
@@ -116,7 +119,7 @@ class TestSACILP(TestCase):
         model: torch.nn.Module,
         inp: torch.Tensor,
     ) -> SACEstimator:
-        sac_estimator = SACEstimator()
+        sac_estimator = SACEstimator(gpu_type=self.gpu_type)
         with sac_estimator(estimate_mode_type=self.estimate_mode):
             loss = model(inp).sum()
         loss.backward()

--- a/torch/_inductor/analysis/device_info.py
+++ b/torch/_inductor/analysis/device_info.py
@@ -244,7 +244,9 @@ def lookup_device_info(name: str) -> DeviceInfo | None:
     return _device_mapping.get(name.upper())
 
 
-def datasheet_tops(dtype: torch.dtype, is_tf32: bool = False) -> float | None:
+def datasheet_tops(
+    dtype: torch.dtype, is_tf32: bool = False, device_name: str | None = None
+) -> float | None:
     """
     Get the theoretical *dense* TFLOPS of the device for a given dtype.
 
@@ -252,11 +254,17 @@ def datasheet_tops(dtype: torch.dtype, is_tf32: bool = False) -> float | None:
     (``tops_sparsity_factor > 1``), they are divided by that factor so
     callers always receive the throughput achievable by cuBLAS/cuDNN on
     non-sparse data.
+
+    If ``device_name`` is given, the datasheet is looked up for that named
+    device instead of querying the current device. This lets callers pin a
+    device spec for deterministic, hardware-independent estimates.
     """
-    if torch.cuda.is_available():
-        name: str | None = torch.cuda.get_device_name()
+    if device_name is not None:
+        name: str | None = device_name
+    elif torch.cuda.is_available():
+        name = torch.cuda.get_device_name()
     elif torch.xpu.is_available():
-        name: str | None = torch.xpu.get_device_name()
+        name = torch.xpu.get_device_name()
     else:
         log.info("No supported device available, skipping datasheet lookup")
         return None
@@ -281,3 +289,15 @@ def datasheet_tops(dtype: torch.dtype, is_tf32: bool = False) -> float | None:
         "torch.tf32" if dtype == torch.float32 and is_tf32 else dtype
     ]
     return tops / device_info.tops_sparsity_factor
+
+
+def datasheet_dram_bw_gbs(device_name: str) -> float | None:
+    """
+    Get the theoretical DRAM bandwidth (GB/s) of the named device from the
+    datasheet, or None if the device is not present.
+    """
+    device_info = lookup_device_info(device_name)
+    if device_info is None:
+        log.info("Device %s not in datasheet, returning None", device_name)
+        return None
+    return device_info.dram_bw_gbs

--- a/torch/distributed/_tools/runtime_estimator.py
+++ b/torch/distributed/_tools/runtime_estimator.py
@@ -72,9 +72,19 @@ class RuntimeEstimator(TorchDispatchMode):
 
     _no_fallback_kernel: set[torch._ops._OpNamespace] = set()
     fake_mode: FakeTensorMode
+    gpu_type: str | None = None
 
-    def __init__(self) -> None:
+    def __init__(self, gpu_type: str | None = None) -> None:
+        """
+        Args:
+            gpu_type (str | None): Optional datasheet device name (e.g.
+                ``"NVIDIA H100"``) to pin the roofline peak FLOPS and DRAM
+                bandwidth to instead of querying the current device. This
+                makes ``operator-level-cost-model`` estimates deterministic
+                and hardware-independent. Only affects the roofline estimator.
+        """
         super().__init__()
+        self._gpu_type = gpu_type
         self._estimate: Callable
         self._estimate_mode_type: str
         self._mod_tracker = ModTracker()
@@ -269,7 +279,9 @@ class RuntimeEstimator(TorchDispatchMode):
         if func_packet not in _IGNORE_OPS:
             flat_args_kwargs, args_spec = pytree.tree_flatten((args, kwargs))
             flat_outs, out_spec = pytree.tree_flatten(out)
-            transfer_time = get_transfer_time(flat_args_kwargs, flat_outs)
+            transfer_time = get_transfer_time(
+                flat_args_kwargs, flat_outs, gpu_type=cls.gpu_type
+            )
 
             out_dtypes = {
                 t.dtype
@@ -280,7 +292,9 @@ class RuntimeEstimator(TorchDispatchMode):
             args, kwargs = pytree.tree_unflatten(flat_args_kwargs, args_spec)
             out = pytree.tree_unflatten(flat_outs, out_spec)
 
-            compute_time = get_compute_time(func_packet, args, kwargs, out, out_dtypes)
+            compute_time = get_compute_time(
+                func_packet, args, kwargs, out, out_dtypes, gpu_type=cls.gpu_type
+            )
             # We get the estimated time as the max of the transfer time and
             # compute time. We divide by 1e6 to get the time in ms
             op_time = max(transfer_time, compute_time) / 1e6
@@ -364,6 +378,7 @@ class RuntimeEstimator(TorchDispatchMode):
                 "No FakeTensorMode found, designed to be used under FakeTensorMode"
             )
         RuntimeEstimator.fake_mode = fake_mode
+        RuntimeEstimator.gpu_type = self._gpu_type
         self.total_runtime = 0.0
         self.mod_runtimes = defaultdict(lambda: defaultdict(lambda: 0.0))
         self.mod_fw_pre_order.clear()

--- a/torch/distributed/_tools/sac_estimator.py
+++ b/torch/distributed/_tools/sac_estimator.py
@@ -215,7 +215,13 @@ class SACEstimator(TorchDispatchMode):
                 sac_estimator.display_modulewise_sac_stats(depth=4, print_tabular=True)
     """
 
-    def __init__(self) -> None:
+    def __init__(self, gpu_type: str | None = None) -> None:
+        """
+        Args:
+            gpu_type (str | None): Optional datasheet device name (e.g.
+                ``"NVIDIA H100"``) to pin the roofline estimates to instead of
+                querying the current device. See ``RuntimeEstimator``.
+        """
         self.sac_mod_stats: dict[str, SACStats] = {}
         self.sac_mod_tradeoff_stats: dict[str, SACTradeOffStats] = {}
         self.sac_mod_greedy_order_meta: dict[str, SACGreedyOrderMeta] = {}
@@ -227,6 +233,7 @@ class SACEstimator(TorchDispatchMode):
             self._pack_hook, lambda x: x
         )
         self._saved_tensor_ids: set[int] = set()
+        self._gpu_type = gpu_type
         self._estimate_runtime = RuntimeEstimator._roofline_estimate
 
     def _pack_hook(self, x: torch.Tensor) -> torch.Tensor:
@@ -951,6 +958,7 @@ class SACEstimator(TorchDispatchMode):
         if not isinstance(fake_mode, FakeTensorMode):
             raise AssertionError("SAC Estimator should be called in FakeTensorMode")
         RuntimeEstimator.fake_mode = fake_mode
+        RuntimeEstimator.gpu_type = self._gpu_type
         self._mod_tracker.register_user_hooks(
             pre_fw_hook=self._pre_fw_hook,
             post_fw_hook=self._post_fw_hook,

--- a/torch/utils/_runtime_estimation.py
+++ b/torch/utils/_runtime_estimation.py
@@ -1,4 +1,5 @@
 import torch
+from torch._inductor.analysis.device_info import datasheet_dram_bw_gbs, datasheet_tops
 from torch._inductor.utils import get_device_tflops, get_gpu_dram_gbps
 from torch.fx.experimental.symbolic_shapes import (
     optimization_hint,
@@ -74,12 +75,27 @@ _CREATE_OPS = OrderedSet(
 _IGNORE_OPS = _VIEW_OPS | _CREATE_OPS
 
 
-def flops_to_ns(flops: float | int, dtype: "torch.dtype") -> float:
-    """Convert a FLOPs count to estimated nanoseconds on the current GPU.
+def flops_to_ns(
+    flops: float | int, dtype: "torch.dtype", gpu_type: str | None = None
+) -> float:
+    """Convert a FLOPs count to estimated nanoseconds on the GPU.
 
     Uses 75% of theoretical peak and converts FLOPs to MACs (divide by 2).
+
+    If ``gpu_type`` names a device in the datasheet, its pinned datasheet
+    TFLOPS are used instead of querying the current device, making the
+    estimate deterministic and hardware-independent.
     """
-    peak_gpu_flops = get_device_tflops(dtype) * 1e12
+    if gpu_type is not None:
+        is_tf32 = torch.backends.cuda.matmul.fp32_precision == "tf32"
+        tflops = datasheet_tops(dtype, is_tf32=is_tf32, device_name=gpu_type)
+        if tflops is None:
+            raise ValueError(
+                f"gpu_type {gpu_type!r} has no datasheet entry for {dtype}"
+            )
+    else:
+        tflops = get_device_tflops(dtype)
+    peak_gpu_flops = tflops * 1e12
     if peak_gpu_flops == 0:
         return 0.0
     macs = flops / 2
@@ -87,7 +103,7 @@ def flops_to_ns(flops: float | int, dtype: "torch.dtype") -> float:
 
 
 def get_compute_time(
-    func_packet, args, kwargs, out, out_dtypes, node_meta=None
+    func_packet, args, kwargs, out, out_dtypes, node_meta=None, gpu_type=None
 ) -> float:  # type: ignore[no-untyped-def]
     """
     Estimates the compute time of an aten operator.
@@ -101,6 +117,8 @@ def get_compute_time(
         node_meta: Optional FX node meta dict. Passed through to the flop
             formula as ``_node_meta`` kwarg so formulas can read annotations
             like ``sparsity_hint``.
+        gpu_type: Optional datasheet device name to pin the peak FLOPS to
+            instead of querying the current device.
 
     Returns:
         float: The estimated compute time in nanoseconds.
@@ -116,7 +134,7 @@ def get_compute_time(
         if node_meta is not None:
             extra_kwargs["_node_meta"] = node_meta
         flop_count = flop_count_func(*args, **kwargs, out_val=out, **extra_kwargs)
-        return flops_to_ns(flop_count, dtype)
+        return flops_to_ns(flop_count, dtype, gpu_type=gpu_type)
     return 0.0
 
 
@@ -139,18 +157,25 @@ def get_num_bytes(t: torch.Tensor) -> int:
     return real_numel * t.element_size()
 
 
-def get_transfer_time(flat_args_kwargs, flat_outs) -> float:  # type: ignore[no-untyped-def]
+def get_transfer_time(flat_args_kwargs, flat_outs, gpu_type=None) -> float:  # type: ignore[no-untyped-def]
     """
     Estimates the memory transfer time of input and output tensors.
 
     Args:
         flat_args_kwargs (List[torch.Tensor]): The flat list of arguments and keyword arguments.
         flat_outs (List[torch.Tensor]): The flat list of outputs.
+        gpu_type: Optional datasheet device name to pin the DRAM bandwidth to
+            instead of querying the current device.
 
     Returns:
         float: The estimated memory transfer time in nanoseconds.
     """
-    gpu_memory_bandwidth = get_gpu_dram_gbps()
+    if gpu_type is not None:
+        gpu_memory_bandwidth = datasheet_dram_bw_gbs(gpu_type)
+        if gpu_memory_bandwidth is None:
+            raise ValueError(f"gpu_type {gpu_type!r} not found in datasheet")
+    else:
+        gpu_memory_bandwidth = get_gpu_dram_gbps()
     read_bytes = sum(
         get_num_bytes(t) for t in flat_args_kwargs if isinstance(t, torch.Tensor)
     )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #189278

test/distributed/_tools/test_sac_ilp.py (case1/2/3) was flaky across
GPUs: its AC-decision assertions depend on RuntimeEstimator's roofline
runtime estimates, which read the *live* device's peak FLOPS
(get_device_tflops) and DRAM bandwidth (get_gpu_dram_gbps). Running on a
different card (e.g. L4 vs T4), or even on a card whose reported name
misses the datasheet (this box reports "NVIDIA H100 80GB HBM3", which is
not the datasheet key "NVIDIA H100", so it silently fell back to
Triton's inaccurate estimate), changed the estimates and the resulting
checkpointing decisions.

Fix by letting callers pin the roofline device spec to a datasheet entry
instead of querying the current GPU. Review in dependency order:

- device_info.py: datasheet_tops gains a device_name override; add
  datasheet_dram_bw_gbs for the bandwidth side (there was no datasheet
  accessor for DRAM bandwidth before).
- _runtime_estimation.py: flops_to_ns / get_compute_time /
  get_transfer_time take an optional gpu_type. When set they read the
  datasheet; when the name (or, for tops, the dtype) is absent they
  raise rather than silently reverting to the live device, since a
  silent fallback would reintroduce the exact hardware dependence this
  knob removes. With gpu_type unset, behavior is unchanged, so existing
  inductor / aot_autograd callers are unaffected.
- runtime_estimator.py / sac_estimator.py: expose gpu_type as a
  constructor arg, mirrored onto the RuntimeEstimator class attribute in
  __enter__ (following the existing fake_mode class-attribute pattern,
  since _roofline_estimate is a classmethod).
- test_sac_ilp.py: pin gpu_type="NVIDIA H100".

The tests assert structural properties (AC candidates are a subset of
the transformer layers, discard ratios in (0, 1], feasibility), so no
golden numeric values needed recomputation; they pass against the pinned
H100 spec as-is and now produce a deterministic estimate regardless of
the physical GPU.

Test Plan:

Ran on an H100 box (reported as "NVIDIA H100 80GB HBM3", not in the
datasheet by that name) and confirmed a deterministic estimate and green
tests:

```
python test/distributed/_tools/test_sac_ilp.py -k test_sac_ilp
```

All three cases pass; the estimator prints a fixed
"total_time: 52.767 ms" independent of the live device.

Authored with assistance from Claude Code.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo