### PR TITLE
[inductor] Fix compute_ancestors KeyError from self-referential mutation copy

### DIFF
--- a/test/inductor/test_auto_functionalize.py
+++ b/test/inductor/test_auto_functionalize.py
@@ -2102,6 +2102,58 @@ def forward(self, arg0_1: "f32[2][1]cpu"):
                     counters["inductor"]["fix_auto_functionalized_dtype_views"], 2
                 )
 
+    def test_reinplace_mutated_empty_no_self_edge(self):
+        # Regression test for a Scheduler.compute_ancestors KeyError.
+        #
+        # An auto_functionalized custom op that mutates freshly allocated (empty)
+        # output buffers whose results are then reshaped forces the reinplace pass
+        # to fold a realization back onto the op's own buffer. That produced a
+        # scheduler node with a non-weak MemoryDep on the buffer it also writes --
+        # a self-edge -- and compute_ancestors looked up name_to_ancestors[op]
+        # before it was populated, raising KeyError: 'opN'.
+        #
+        # Mirrors flash_attn._flash_attn_backward writing dq/dk/dv into empties.
+        D = 512
+        with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
+            torch.library.define(
+                "mylib::attn_bwd",
+                "(Tensor dout, Tensor(a!) dq, Tensor(b!) dk, Tensor(c!) dv) -> Tensor",
+                tags=torch.Tag.pt2_compliant_tag,
+                lib=lib,
+            )
+
+            @torch.library.impl("mylib::attn_bwd", "cpu", lib=lib)
+            def attn_bwd(dout, dq, dk, dv):
+                src = dout.reshape(dq.shape)
+                dq.copy_(src)
+                dk.copy_(src)
+                dv.copy_(src)
+                return torch.zeros_like(dq)  # workspace, discarded by caller
+
+            @torch.library.register_fake("mylib::attn_bwd", lib=lib)
+            def _(dout, dq, dk, dv):
+                return torch.empty_like(dq)
+
+            def f(dout, weight, num_heads):
+                head_dim = D // num_heads
+                seqlen = dout.shape[0]
+                dq = torch.empty(1, seqlen, num_heads, head_dim, dtype=dout.dtype)
+                dk = torch.empty(1, seqlen, num_heads, head_dim, dtype=dout.dtype)
+                dv = torch.empty(1, seqlen, num_heads, head_dim, dtype=dout.dtype)
+                torch.ops.mylib.attn_bwd(dout, dq, dk, dv)  # return discarded
+                a = dq.reshape(1, seqlen, D)
+                b = dk.reshape(1, seqlen, D)
+                c = dv.reshape(1, seqlen, D)
+                return (a + b + c) @ weight
+
+            dout = torch.randn(128, D)
+            weight = torch.randn(D, D)
+            torch._dynamo.mark_dynamic(dout, 0)
+
+            expected = f(dout, weight, 8)
+            got = torch.compile(f, fullgraph=True, dynamic=True)(dout, weight, 8)
+            self.assertEqual(got, expected)
+
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1781,6 +1781,20 @@ class GraphLowering(torch.fx.Interpreter):
                 f"old_kwargs length ({len(old_kwargs)}) != new_kwargs length ({len(new_kwargs)})"
             )
 
+        def already_reflected(old_arg: Any, new_arg: Any) -> bool:
+            # No propagation is needed when new_arg already reflects the
+            # mutation of old_arg: either they are the same object, or they are
+            # distinct IR nodes aliasing the same buffer (e.g. an in-place op
+            # whose output was not cloned). Emitting copy_ in the aliasing case
+            # would lower to a self-referential (buf = buf) node, which the
+            # scheduler's compute_ancestors cannot represent (self-edge).
+            if old_arg is new_arg:
+                return True
+            if isinstance(old_arg, ir.IRNode) and isinstance(new_arg, ir.IRNode):
+                name = old_arg.maybe_get_name()
+                return name is not None and name == new_arg.maybe_get_name()
+            return False
+
         if fx_node.target is torch.ops.higher_order.triton_kernel_wrapper_mutation:
             kwargs = fx_node.kwargs["kwargs"]
             if not isinstance(kwargs, dict):
@@ -1797,7 +1811,7 @@ class GraphLowering(torch.fx.Interpreter):
             for name in mutated:
                 old_arg = old_kwargs["kwargs"][name]
                 new_arg = new_kwargs["kwargs"][name]
-                if old_arg is new_arg:
+                if already_reflected(old_arg, new_arg):
                     continue
 
                 self.call_function(torch.ops.aten.copy_.default, (old_arg, new_arg), {})
@@ -1822,7 +1836,7 @@ class GraphLowering(torch.fx.Interpreter):
                     new_arg = (new_arg,)  # type: ignore[assignment]
 
                 for old_arg_item, new_arg_item in zip(old_arg, new_arg):  # type: ignore[call-overload]
-                    if old_arg_item is new_arg_item:
+                    if already_reflected(old_arg_item, new_arg_item):
                         continue
                     self.call_function(
                         torch.ops.aten.copy_.default, (old_arg_item, new_arg_item), {}

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -5110,6 +5110,12 @@ class Scheduler:
             ancestors: OrderedSet[str] = OrderedSet()
             for dep in node.unmet_dependencies:
                 dep_node_name = self.name_to_buf[dep.name].defining_op_name()
+                # A node can transiently depend on a buffer it also writes (a
+                # self-edge, e.g. from a mutating op whose read and write
+                # resolve to the same buffer). A node is never its own
+                # ancestor, so skip it rather than KeyError on itself.
+                if dep_node_name == node.get_name():
+                    continue
                 ancestors.add(dep_node_name)
                 ancestors |= name_to_ancestors[dep_node_name]
             name_to_ancestors[node.get_name()] = ancestors
@@ -5128,22 +5134,20 @@ class Scheduler:
         name_to_min_distance: dict[str, int] = {}
         name_to_max_distance: dict[str, int] = {}
         for node in self.nodes:
-            if not node.unmet_dependencies:
+            # Skip self-edges (a node depending on a buffer it also writes); a
+            # node is not at any distance from itself. See compute_ancestors.
+            dep_ops = [
+                op
+                for dep in node.unmet_dependencies
+                if (op := self.name_to_buf[dep.name].defining_op_name())
+                != node.get_name()
+            ]
+            if not dep_ops:
                 min_dist = 0
                 max_dist = 0
             else:
-                dep_min_dists = [
-                    name_to_min_distance[self.name_to_buf[dep.name].defining_op_name()]
-                    + 1
-                    for dep in node.unmet_dependencies
-                ]
-                dep_max_dists = [
-                    name_to_max_distance[self.name_to_buf[dep.name].defining_op_name()]
-                    + 1
-                    for dep in node.unmet_dependencies
-                ]
-                min_dist = min(dep_min_dists)
-                max_dist = max(dep_max_dists)
+                min_dist = min(name_to_min_distance[op] + 1 for op in dep_ops)
+                max_dist = max(name_to_max_distance[op] + 1 for op in dep_ops)
             name_to_min_distance[node.get_name()] = min_dist
             name_to_max_distance[node.get_name()] = max_dist
             node.min_input_distance = min_dist


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189288

Fixes #189271.

Root cause: GraphLowering.propagate_mutation emits copy_(old_arg, new_arg) to
reflect an in-place op's mutation back onto its original argument, guarding the
"no copy needed" case with Python object identity (old_arg is new_arg). When an
op mutates a buffer in place with no clone, new_arg aliases the same storage as
old_arg but, under dynamic shapes, is wrapped in a distinct IR object (a reshape
of the mutated buffer yields a new wrapper differing only in an irrelevant
size-1-dim stride expression). The identity guard misses this, so a copy_ is
emitted and lowered via mutate_to's fast path into a Pointwise that loads and
stores the same buffer (buf = buf) -- a self-referential MemoryDep.
Scheduler.compute_ancestors sets name_to_ancestors[op] only after visiting an
op's deps, so a self-dependency raises KeyError on the op's own name
(compute_input_distances has the same lookup). This is a longstanding latent bug
(reproduces back to at least 2.10), exposed by flash_attn._flash_attn_backward
writing dq/dk/dv into freshly allocated buffers that are then reshaped under a
dynamic sequence length.

The primary fix is in propagate_mutation: strengthen the guard from object
identity to buffer identity (matching get_name()). Because old_arg and new_arg
are the same op argument here, a matching buffer name means no clone was
inserted and the copy is a genuine no-op; a differing name means a clone
happened and the copy is still emitted. Comparing layouts instead would be
wrong: old and new differ only in a size-1-dim stride, which strict layout
equality would fail to match, reintroducing the crash.

As defense-in-depth, compute_ancestors and compute_input_distances now tolerate
a self-edge (a node is never its own ancestor / at a distance from itself),
which also covers other self-edge sources.

Test Plan:

New regression test (fails before this change, passes after):

```
python test/inductor/test_auto_functionalize.py \
    AutoFunctionalizeTests.test_reinplace_mutated_empty_no_self_edge
```

No regressions in the affected areas:

```
python -m pytest test/inductor/test_auto_functionalize.py -q   # 44 passed, 1 skipped
python -m pytest test/inductor/test_control_deps.py -q         # 11 passed
```

Also confirmed the scheduler backstop handles the self-edge on its own: with the
propagate_mutation fix reverted, the reproducer still compiles and is correct.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo