### PR TITLE
[TEST] Refactor test_c10d_pypg.py with hw_classification

### DIFF
--- a/test/distributed/test_c10d_pypg.py
+++ b/test/distributed/test_c10d_pypg.py
@@ -2,7 +2,6 @@
 
 import os
 import time
-import unittest
 import weakref
 from datetime import timedelta
 
@@ -21,7 +20,7 @@ from torch.distributed.distributed_c10d import (
 )
 from torch.futures import Future
 from torch.nn.parallel import DistributedDataParallel as DDP
-from torch.testing._internal.common_cuda import TEST_CUDA
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import (
     MultiProcessTestCase,
     MultiThreadedTestCase,
@@ -485,12 +484,11 @@ class TestPyProcessGroupGeneric(TestCase):
         self.assertIs(pg.new_window_tensor, t)
 
 
-@unittest.skipIf(not TEST_CUDA, "no cuda/xpu")
 class TestPyProcessGroupCUDA(TestCase):
     hw_classification = HardwareClassification.CUDA
 
     def test_block_current_stream(self) -> None:
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
 
         stream = torch.cuda.Stream()
         with stream:
@@ -519,7 +517,7 @@ class TestPyProcessGroupCUDA(TestCase):
         """
         This tests that the CPU control tensor is not freed before the CUDA kernel executes.
         """
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
         stream = torch.cuda.Stream()
         with stream:
             a = BlockWork()
@@ -629,6 +627,9 @@ class TestBatchSendRecv(MultiProcessTestCase):
 
         dist.barrier()
         dist.destroy_process_group()
+
+
+instantiate_device_type_tests(TestPyProcessGroupCUDA, globals(), only_for="cuda")
 
 
 if __name__ == "__main__":

--- a/test/distributed/test_c10d_pypg.py
+++ b/test/distributed/test_c10d_pypg.py
@@ -26,7 +26,11 @@ from torch.testing._internal.common_distributed import (
     MultiProcessTestCase,
     MultiThreadedTestCase,
 )
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 def create_work(result):
@@ -266,12 +270,16 @@ class AbstractDDPSingleRank(test_c10d_common.CommonDistributedDataParallelTest):
 
 
 class TestDDPWithWorkSubclass(AbstractDDPSingleRank, MultiThreadedTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @property
     def use_wrapper(self):
         return False
 
 
 class TestDDPWithWorkWrapper(AbstractDDPSingleRank, MultiThreadedTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @property
     def use_wrapper(self):
         return True
@@ -290,7 +298,9 @@ class BlockWork(dist._Work):
         return self.future_
 
 
-class TestPyProcessGroup(TestCase):
+class TestPyProcessGroupGeneric(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_attr_overrides(self):
         pg = DummyAttrProcessGroup(0, 1)
         self.assertEqual(pg.name(), "dummy-attr")
@@ -474,7 +484,11 @@ class TestPyProcessGroup(TestCase):
         self.assertEqual(dist._new_window(t, group=pg), "fake-window")
         self.assertIs(pg.new_window_tensor, t)
 
-    @unittest.skipIf(not TEST_CUDA, "no cuda/xpu")
+
+@unittest.skipIf(not TEST_CUDA, "no cuda/xpu")
+class TestPyProcessGroupCUDA(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def test_block_current_stream(self) -> None:
         torch.cuda.synchronize()
 
@@ -501,7 +515,6 @@ class TestPyProcessGroup(TestCase):
             stream.synchronize()
             self.assertTrue(event.query())
 
-    @unittest.skipIf(not TEST_CUDA, "no cuda/xpu")
     def test_block_current_stream_use_after_free(self) -> None:
         """
         This tests that the CPU control tensor is not freed before the CUDA kernel executes.
@@ -534,6 +547,8 @@ class TestPyProcessGroup(TestCase):
 
 
 class TestBatchSendRecv(MultiProcessTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self._spawn_processes()


### PR DESCRIPTION
Annotate all test classes in `test/distributed/test_c10d_pypg.py` with `hw_classification` as part of the ongoing test refactoring initiative. 

Requires [#186918](https://github.com/pytorch/pytorch/pull/186918) to be merged first.

### Changes

- **`TestDDPWithWorkSubclass`** → `GENERIC`: single-rank fake Python PG on CPU, tests DDP Work subclass dispatch
- **`TestDDPWithWorkWrapper`** → `GENERIC`: same as above via C++ wrapper shim path
- **`TestPyProcessGroup`** → **split** into:
  - **`TestPyProcessGroupGeneric`** (`GENERIC`, 14 methods): tests Python↔C++ trampoline dispatch for all collective overrides, coalescing manager, reconfigure/window delegation — all CPU, no real device
  - **`TestPyProcessGroupCUDA`** (`CUDA`, 2 methods): tests `block_current_stream` using `torch.cuda.Stream/Event` — CUDA-specific, cannot generalize
- **`TestBatchSendRecv`** → `GENERIC`: `batch_isend_irecv` end-to-end with custom Python PG backends using CPU tensors

### Test plan

```bash
python test/distributed/test_c10d_pypg.py -v
```

<sub>Authored with an AI assistant.</sub>