### PR TITLE
Add an accurate Metal erfc for MPS (eager + inductor)

### DIFF
--- a/c10/metal/special_math.h
+++ b/c10/metal/special_math.h
@@ -61,8 +61,12 @@ inline float erf(T x) {
  * since erfc(-x) < 0.19 here. The scaled-rational construction follows
  * N. Juffa's vectorizable erfcf
  * (https://stackoverflow.com/questions/35966695) with freshly fitted
- * coefficients. Max observed error 4.6 ulp over the fp32-normal range
- * (subnormal results flush to zero on the GPU).
+ * coefficients. Both quotients use ::metal::fast::divide: full-precision
+ * division costs 1.2-2x in erfc-bound ops and would tighten the max error
+ * only to ~5.0 ulp. Exhaustive enumeration of fp32 inputs measures a max
+ * error of 5.6 ulp (4.0e-7 relative, M5; fast-math division rounding is
+ * GPU-dependent) over the normal output range (subnormal results flush to
+ * zero on the GPU).
  */
 template <typename T>
 float erfc(T x) {
@@ -77,7 +81,7 @@ float erfc(T x) {
   }
   // erfc underflows fp32 past 10.06; the clamp also handles +-infinity
   const auto t = ::metal::min(a, 10.5f);
-  const auto q = (t - 4.0f) / (t + 4.0f);
+  const auto q = ::metal::fast::divide(t - 4.0f, t + 4.0f);
   auto p = 5.271875e-03f; // 0x1.597f62p-8
   p = ::metal::fma(p, q, -1.6534764e-02f); // -0x1.0ee7d4p-6
   p = ::metal::fma(p, q, 3.702093e-02f); // 0x1.2f4684p-5
@@ -92,7 +96,8 @@ float erfc(T x) {
   auto e = ::metal::exp(-s);
   // fold in the residual of the squaring: t * t = s + fma(t, t, -s) exactly
   e = ::metal::fma(-e, ::metal::fma(t, t, -s), e);
-  const auto r = (1.0f + p) / ::metal::fma(2.0f, t, 1.0f) * e;
+  const auto den = ::metal::fma(2.0f, t, 1.0f);
+  const auto r = ::metal::fast::divide(1.0f + p, den) * e;
   return xf < 0.0f ? 2.0f - r : r;
 }
 

--- a/c10/metal/special_math.h
+++ b/c10/metal/special_math.h
@@ -48,9 +48,52 @@ inline float erf(T x) {
   return r;
 }
 
+/*
+ * Complementary error function.
+ * 1 - erf(x) loses all significant bits for x > ~3.9 (gh-187806), so it is
+ * used only for |x| <= 0.927734375 (erf's own branch threshold), where erf
+ * is faithfully rounded and the subtraction loses no accuracy (exact by
+ * Sterbenz for erf >= 0.5, a single rounding otherwise). Larger |x|:
+ *   erfc(a) = (1 + p(q)) / (1 + 2a) * exp(-a * a),  q = (a - 4) / (a + 4)
+ * p: degree-9 Remez fit of (1 + 2a) * exp(a * a) * erfc(a) - 1 on
+ * a in [0.927734375, 10.5] against 60-digit references; the rounding of the
+ * squared exp argument is fma-compensated. Negative x: 2 - erfc(-x), safe
+ * since erfc(-x) < 0.19 here. The scaled-rational construction follows
+ * N. Juffa's vectorizable erfcf
+ * (https://stackoverflow.com/questions/35966695) with freshly fitted
+ * coefficients. Max observed error 4.6 ulp over the fp32-normal range
+ * (subnormal results flush to zero on the GPU).
+ */
 template <typename T>
 float erfc(T x) {
-  return 1.0 - erf(x);
+  const auto xf = static_cast<float>(x);
+  // required: metal::min below discards NaN
+  if (::metal::isnan(xf)) {
+    return xf;
+  }
+  const auto a = ::metal::abs(xf);
+  if (a <= 0.927734375f) {
+    return 1.0f - erf(xf);
+  }
+  // erfc underflows fp32 past 10.06; the clamp also handles +-infinity
+  const auto t = ::metal::min(a, 10.5f);
+  const auto q = (t - 4.0f) / (t + 4.0f);
+  auto p = 5.271875e-03f; // 0x1.597f62p-8
+  p = ::metal::fma(p, q, -1.6534764e-02f); // -0x1.0ee7d4p-6
+  p = ::metal::fma(p, q, 3.702093e-02f); // 0x1.2f4684p-5
+  p = ::metal::fma(p, q, -6.6275224e-02f); // -0x1.0f769cp-4
+  p = ::metal::fma(p, q, 9.375815e-02f); // 0x1.80088cp-4
+  p = ::metal::fma(p, q, -1.01042934e-01f); // -0x1.9ddf32p-4
+  p = ::metal::fma(p, q, 6.809548e-02f); // 0x1.16eb4ap-4
+  p = ::metal::fma(p, q, 1.5379757e-02f); // 0x1.f7f6cp-7
+  p = ::metal::fma(p, q, -1.396211e-01f); // -0x1.1df1aap-3
+  p = ::metal::fma(p, q, 2.3299512e-01f); // 0x1.dd2c8cp-3
+  const auto s = t * t;
+  auto e = ::metal::exp(-s);
+  // fold in the residual of the squaring: t * t = s + fma(t, t, -s) exactly
+  e = ::metal::fma(-e, ::metal::fma(t, t, -s), e);
+  const auto r = (1.0f + p) / ::metal::fma(2.0f, t, 1.0f) * e;
+  return xf < 0.0f ? 2.0f - r : r;
 }
 
 template <typename T>

--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -83,6 +83,26 @@ class MPSBasicTests(TestCase):
         if torch.isnan(result).any():
             raise AssertionError("tanh should not produce NaN for large values")
 
+    def test_erfc_tail_accuracy(self):
+        # gh-187806: compiled erfc must lower to c10::metal::erfc, not the
+        # 1 - erf fallback that flushes the tail to zero past x ~ 3.9
+        x = torch.arange(-9.0, 9.0, 2**-10, device="mps")
+
+        @torch.compile
+        def fn(x):
+            return torch.erfc(x)
+
+        actual = fn(x).cpu().double()
+        expected = torch.erfc(x.cpu().double())
+        self.assertEqual(actual, expected, rtol=1e-6, atol=0)
+        # specials and the clamped tail (t = min(|x|, 10.5) in the kernel);
+        # erfc rounds to exactly 0/2 in fp32 well before the clamp
+        inf, nan = float("inf"), float("nan")
+        vals = [0.0, inf, -inf, nan, 10.5, -10.5, 1e30, -1e30]
+        sp = torch.tensor(vals, device="mps")
+        expected_sp = torch.tensor([1.0, 0.0, 2.0, nan, 0.0, 2.0, 0.0, 2.0])
+        self.assertEqual(fn(sp).cpu(), expected_sp, rtol=0, atol=0)
+
     def test_floor(self):
         self.common(lambda x: x.floor(), (torch.rand(1024),))
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -7829,8 +7829,13 @@ class TestMPS(TestCaseMPS):
         x = torch.arange(-9.0, 9.0, 2**-10)
         actual = torch.erfc(x.to('mps')).cpu().double()
         expected = torch.erfc(x.double())
-        rel = ((actual - expected) / expected).abs().max()
-        self.assertLess(rel.item(), 1e-6)
+        self.assertEqual(actual, expected, rtol=1e-6, atol=0)
+        # specials and the clamped tail (t = min(|x|, 10.5) in the kernel);
+        # erfc rounds to exactly 0/2 in fp32 well before the clamp
+        vals = [0.0, float('inf'), float('-inf'), float('nan'), 10.5, -10.5, 1e30, -1e30]
+        expected_sp = torch.tensor([1.0, 0.0, 2.0, float('nan'), 0.0, 2.0, 0.0, 2.0])
+        actual_sp = torch.erfc(torch.tensor(vals, device='mps')).cpu()
+        self.assertEqual(actual_sp, expected_sp, rtol=0, atol=0)
 
     def test_igammac_tail_accuracy(self):
         # igamma.h evaluates 0.5 * erfc(...) on its large-a asymptotic path,

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -7822,6 +7822,26 @@ class TestMPS(TestCaseMPS):
             self.assertFalse(torch.isnan(x.grad).any(), f"NaN in backward for {dtype}")
             self.assertEqual(x.grad, cpu_xg.grad.to('mps'))
 
+    def test_erfc_tail_accuracy(self):
+        # gh-187806: c10::metal::erfc was 1 - erf(x), 100% relative error past
+        # erf's fp32 saturation (~3.9); compare against float64 over the
+        # fp32-normal output range
+        x = torch.arange(-9.0, 9.0, 2**-10)
+        actual = torch.erfc(x.to('mps')).cpu().double()
+        expected = torch.erfc(x.double())
+        rel = ((actual - expected) / expected).abs().max()
+        self.assertLess(rel.item(), 1e-6)
+
+    def test_igammac_tail_accuracy(self):
+        # igamma.h evaluates 0.5 * erfc(...) on its large-a asymptotic path,
+        # so the erfc rewrite fixes the igammac tail too
+        a = torch.full((2048,), 1200.0)
+        x = torch.linspace(1150.0, 1660.0, 2048)
+        actual = torch.special.gammaincc(a.to('mps'), x.to('mps')).cpu().double()
+        expected = torch.special.gammaincc(a.double(), x.double())
+        rel = ((actual - expected) / expected).abs().max()
+        self.assertLess(rel.item(), 5e-4)
+
     # Test hardtanh
     def test_hardtanh(self):
         def helper(shape, min_val, max_val, inplace=False):

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -481,6 +481,7 @@ class MetalOverrides(OpOverrides):
         # Unary special ops
         for name in [
             "erf",
+            "erfc",
             "erfinv",
             "i0",
             "i0e",


### PR DESCRIPTION
Splits the MPS backend portion out of #189234 (gh-187806) per review.

## Problem

`c10::metal::erfc` is `1.0 - erf(x)`: once erf saturates in fp32 (x ~ 3.9), erfc returns 0.0, i.e. 100% relative error over the entire upper tail. Everything consuming it on MPS inherits the flush:

- eager `torch.erfc` / `torch.special.erfc`
- `igammac` (`torch.special.gammaincc`), whose large-a asymptotic path evaluates `0.5 * erfc(...)`
- the gelu cancellation fix in #189234, which rewrites `1 + erf(u)` as `erfc(-u)` and needs an accurate erfc to build on

## Fix

- Below erf's own branch threshold, keep `1 - erf(x)`: exact there.
- Above it: `erfc(a) = (1 + p(q)) / (1 + 2a) * exp(-a * a)` with `q = (a - 4)/(a + 4)`, p a degree-9 Remez fit against 60-digit mpmath references, and the squared exp argument fma-compensated. Negative x via `2 - erfc(-x)`. The scaled-rational construction follows N. Juffa's vectorizable erfcf.
- Both quotients use `::metal::fast::divide` (per review): full-precision division made the branch compute-bound (gelu 1.3-1.7x slower on M2 Max, eager erfc 1.2-1.3x slower than erf on M5) and would tighten the max error only from ~5.6 to ~5.0 ulp.
- `"erfc"` joins the Inductor MPS codegen op set so torch.compile on MPS uses the same implementation.

## Verification (M5)

- erfc accuracy, exhaustive enumeration of all 2^32 fp32 inputs vs float64 over the fp32-normal output range: max 5.6 ulp (4.0e-7 relative) on M5, 5.1 ulp on M2 Max (fast-math division rounding is GPU-dependent). Before: 100% relative error past x ~ 3.9.
- Eager erfc runs at erf speed (was 1.2-1.3x slower with full-precision divides); Inductor output is bitwise identical to eager.
- `gammaincc(1200, x)`: tracks float64 to ~7e-5 relative down to values of 1e-33. Before: flushed to zero below ~1e-8.
- New eager MPS tail tests for erfc and igammac, plus an Inductor regression test (`test_mps_basic.py`, `test_erfc_tail_accuracy`) that fails if the codegen op-set entry is dropped and compiled erfc falls back to `1 - erf`.
- Specials and the clamp branch pinned exactly in both erfc tests: `erfc(0) = 1`, `erfc(+inf) = 0`, `erfc(-inf) = 2`, nan propagates, `erfc(+-10.5) = erfc(+-1e30) =` exactly `0`/`2`.

Base commit: 135435f8981cbfb35368f1a2abc8fa9c2f2c4314.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo
