### PR TITLE
Fix dead ExecuTorch XNNPACK doc link in mobile_optimizer

### DIFF
--- a/docs/source/mobile_optimizer.md
+++ b/docs/source/mobile_optimizer.md
@@ -13,7 +13,7 @@ PyTorch Mobile is no longer actively supported. Redirecting to [ExecuTorch docum
 PyTorch Mobile is no longer actively supported. Please check out
 [ExecuTorch](https://pytorch.org/executorch-overview), PyTorch's
 all-new on-device inference library. You can also review
-documentation on [XNNPACK](https://pytorch.org/executorch/stable/native-delegates-executorch-xnnpack-delegate.html)
+documentation on [XNNPACK](https://pytorch.org/executorch/stable/backends-xnnpack.html)
 and [Vulkan](https://pytorch.org/executorch/stable/native-delegates-executorch-vulkan-delegate.html) delegates.
 ```
 ```{eval-rst}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189292

The nightly `Link checks / lint-urls / lint` job fails on a genuine 404:
the XNNPACK backend doc referenced from mobile_optimizer.md was renamed
by ExecuTorch from `native-delegates-executorch-xnnpack-delegate.html`
(now 404) to `backends-xnnpack.html` (200). Point the link at the new
URL. The sibling Vulkan link still resolves (200) and is left unchanged.

Test Plan:
Reproduced the linter's check for the old and new URLs:

```
$ curl -k -gsL -o /dev/null -w "%{http_code}\n" -A "Mozilla/5.0" \
    https://pytorch.org/executorch/stable/native-delegates-executorch-xnnpack-delegate.html
404
$ curl -k -gsL -o /dev/null -w "%{http_code}\n" -A "Mozilla/5.0" \
    https://pytorch.org/executorch/stable/backends-xnnpack.html
200
```

Authored with Claude.