### PR TITLE
[CI] Realign scipy after nvmath install to fix H100 smoke NumPy ABI crash

### DIFF
--- a/.ci/pytorch/common_utils.sh
+++ b/.ci/pytorch/common_utils.sh
@@ -346,6 +346,11 @@ function install_cutlass_dsl() {
 function install_nvmath() {
   echo "Installing nvmath-python from PyPI..."
   pip_install nvmath-python
+  # nvmath-python pulls in numpy>=2, overriding the image's numpy 1.x pin. The
+  # image's scipy is built against numpy 1.x, so scipy imports (e.g. test_foreach
+  # via opinfo fft) then hit a numpy ABI ValueError. Realign scipy to a numpy-2
+  # compatible build. See https://github.com/pytorch/pytorch/issues/189034.
+  pip_install "scipy==1.13.1"
   echo "nvmath-python installation complete."
 }
 

--- a/.ci/pytorch/common_utils.sh
+++ b/.ci/pytorch/common_utils.sh
@@ -346,10 +346,7 @@ function install_cutlass_dsl() {
 function install_nvmath() {
   echo "Installing nvmath-python from PyPI..."
   pip_install nvmath-python
-  # nvmath-python pulls in numpy>=2, overriding the image's numpy 1.x pin. The
-  # image's scipy is built against numpy 1.x, so scipy imports (e.g. test_foreach
-  # via opinfo fft) then hit a numpy ABI ValueError. Realign scipy to a numpy-2
-  # compatible build. See https://github.com/pytorch/pytorch/issues/189034.
+  # nvmath-python upgrades numpy to 2.x; realign scipy to a matching build. See #189034.
   pip_install "scipy==1.13.1"
   echo "nvmath-python installation complete."
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189294

install_nvmath does an unpinned `pip install nvmath-python`, which pulls
numpy>=2 into the H100 smoke venv, overriding the CI image's numpy 1.x pin.
The image's scipy (1.10.1) is built against numpy 1.x, so once numpy is 2.x
any scipy import raises a binary-incompatibility ValueError ("numpy.dtype
size changed"). The smoke job's test_foreach transitively imports scipy via
torch.testing._internal.opinfo.definitions.fft, so it crashes at collection
and reds the "Limited CI on H100" smoke job (continuously since ~2026-07-03,
when the unpinned nvmath/numpy resolution drifted to numpy 2.2.6).

This is a CI dependency version skew, not a PyTorch bug: torch itself works
fine under numpy 2.x (the other smoke suites pass). Realign scipy to 1.13.1,
which supports numpy 2 (>=1.22.4,<2.3), immediately after installing nvmath so
the numpy/scipy pair is consistent. Mirrors the compatible numpy==2.0.2 +
scipy==1.13.1 set already used in test.sh's numpy_2 path.

Fixes #189034.

Test Plan:
CI: the "Limited CI on H100 / ...sm90 / test (smoke)" job should go green;
test_foreach no longer crashes importing scipy. Verified locally that
scipy==1.13.1 imports cleanly against numpy 2.2.6.

Authored with Claude.