### PR TITLE
Pin flash-attention checkout in FA3 ABI-stable H100 smoke test

### DIFF
--- a/.github/workflows/_linux-test-stable-fa3.yml
+++ b/.github/workflows/_linux-test-stable-fa3.yml
@@ -95,6 +95,9 @@ jobs:
         with:
           repository: Dao-AILab/flash-attention
           path: flash-attention
+          # Pin to match the flash_attn_3==3.0.0 wheel; later upstream commits
+          # add hopper/flash_attn_3, which shadows the installed wheel's _C.
+          ref: 73c992c8ca746935548df620ef3c1b6238fe6e68
 
       - name: Configure AWS credentials
         id: aws-creds


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189295

The `Limited CI on H100 / ...sm90-FA3-ABI-stable-test / test` job has been
failing every run since 2026-07-03 at pytest collection with:

    ModuleNotFoundError: No module named 'flash_attn_3._C'

Root cause: this is not a PyTorch regression but an unpinned external
dependency drifting. The smoke test (.ci/pytorch/test_fa3_abi_stable.sh)
installs the prebuilt ABI-stable wheel flash_attn_3==3.0.0 -- which ships
the compiled flash_attn_3._C extension -- and then checks out
Dao-AILab/flash-attention with no `ref`, so it floats to that repo's
default-branch HEAD, purely to obtain the test files. It runs pytest with
PYTHONPATH=flash-attention/hopper.

On 2026-07-03 upstream commit 002cce0a1 ("[FA3] uv installation support",
message: "Expose flash_attn_3 as package so imports work correctly") added
a hopper/flash_attn_3/ source directory containing only Python files and no
compiled _C. Because hopper/ is on PYTHONPATH, `import flash_attn_3` now
resolves to that source package, shadowing the installed wheel; the source
package has no _C, so `import flash_attn_3._C` fails. The error being a
ModuleNotFoundError on the ._C submodule (rather than a .so load error) is
the fingerprint of this shadowing.

Fix: pin the checkout to 73c992c8ca746935548df620ef3c1b6238fe6e68, the
parent of the breaking commit -- the last upstream revision whose hopper/
tests match the flash_attn_3==3.0.0 wheel, and exactly the state CI used on
2026-07-02 when the job last passed. Pinning also stops the next upstream
restructure from silently breaking this job.

I chose pinning over stripping the shadowing directory from PYTHONPATH: the
latter would paper over the underlying version skew between the test files
and the wheel, whereas pinning keeps the tests aligned with the artifact
under test.

Test Plan:
Confirmed the failure signature and timeline from CI logs, and verified the
wheel and pin against the upstream repo:

```
# FA3 job flipped success -> failure between the 07-02 22:25 and 07-03 05:20
# Limited CI on H100 runs; the upstream break landed 07-03 03:42Z.
gh api repos/Dao-AILab/flash-attention/commits/002cce0a1 \
  -q '{sha:.sha, parent:.parents[0].sha}'
# parent: 73c992c8ca746935548df620ef3c1b6238fe6e68

# The wheel the test installs (ships compiled _C via abi3):
curl -gsL https://download.pytorch.org/whl/cu130/flash-attn-3/ \
  | grep -o 'flash_attn_3-3.0.0[^"]*x86_64.whl'
# flash_attn_3-3.0.0-cp39-abi3-manylinux_2_28_x86_64.whl
```

Full validation requires the H100 job to run in CI on this change.

Authored with Claude.