### PR TITLE
[ROCm][CI] Make ROCM_SO_FILES a single shared source of truth for wheel bundling + preload

### DIFF
--- a/.ci/manywheel/repair_wheel.py
+++ b/.ci/manywheel/repair_wheel.py
@@ -15,6 +15,7 @@ Environment variables:
 """
 
 import argparse
+import importlib.util
 import os
 import platform
 import shutil
@@ -115,35 +116,47 @@ def aarch64_extra_deps(use_cuda: bool) -> list[Path]:
 
 
 # ROCm shared libs to bundle. Discovered under $ROCM_HOME/{lib,lib64}.
-ROCM_SO_FILES: list[str] = [
-    "libMIOpen.so",
-    "libamdhip64.so",
-    "libhipblas.so",
-    "libhipfft.so",
-    "libhiprand.so",
-    "libhipsolver.so",
-    "libhipsparse.so",
-    "libhsa-runtime64.so",
-    "libamd_comgr.so",
-    "libmagma.so",
-    "librccl.so",
-    "librocblas.so",
-    "librocfft.so",
-    "librocm_smi64.so",
-    "librocrand.so",
-    "librocsolver.so",
-    "librocsparse.so",
-    "libroctracer64.so",
-    "libroctx64.so",
-    "libhipblaslt.so",
-    "libhipsparselt.so",
-    "libhiprtc.so",
-    "librocprofiler-sdk.so",
-    "librocprofiler-register.so",
-    "libhsa-amd-aqlprofile64.so",
-    "librocm-core.so",
-    "librocroller.so",
-]
+#
+# The canonical list lives in torch/_rocm_libs.py, the single source of truth
+# shared with torch/__init__.py::_preload_rocm_deps, so the wheel-bundled set and
+# the runtime-preloaded set never drift. We load it by file path (this script
+# must not ``import torch`` -- the compiled extension may not import in the build
+# container) preferring the copy inside the wheel being repaired, falling back to
+# the source tree. ``ROCM_SO_FILES`` there is the leaf-first preload subset;
+# ``ROCM_SO_FILES_BUNDLE_ONLY`` are the extra libs bundled but not preloaded
+# (MAGMA, the profiler stack, rocRoller). Order is irrelevant here (we just copy
+# + patchelf each file).
+
+
+def load_rocm_so_files(unpacked_torch: Path | None = None) -> list[str]:
+    """Load the full set of ROCm libs to bundle from torch/_rocm_libs.py.
+
+    Reads the module by file path (no ``import torch``), preferring the copy in
+    the unpacked wheel's ``torch/`` dir, then the in-repo source tree.
+    """
+    candidates: list[Path] = []
+    if unpacked_torch is not None:
+        candidates.append(unpacked_torch / "_rocm_libs.py")
+    # repair_wheel.py lives at <root>/.ci/manywheel/, so the source tree copy is
+    # <root>/torch/_rocm_libs.py.
+    candidates.append(Path(__file__).resolve().parents[2] / "torch" / "_rocm_libs.py")
+
+    for path in candidates:
+        if path.is_file():
+            spec = importlib.util.spec_from_file_location("torch_rocm_libs", path)
+            if spec is None or spec.loader is None:
+                continue
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            return list(module.ROCM_SO_FILES_ALL)
+    sys.exit(
+        "Could not locate torch/_rocm_libs.py (looked in: "
+        + ", ".join(str(p) for p in candidates)
+        + ")"
+    )
+
+
+ROCM_SO_FILES: list[str] = load_rocm_so_files()
 
 
 def rocm_os_deps() -> list[Path]:

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -381,33 +381,12 @@ def _preload_cuda_deps(err: OSError | None = None, required: bool = True) -> Non
     _preload_cuda_lib("nvtx", "libnvToolsExt.so.*[0-9]", required=False)
 
 
-# ROCm runtime libs a TheRock-built libtorch DT_NEEDEDs, mirroring the set
-# bundled by .ci/manywheel/repair_wheel.py::ROCM_SO_FILES. Ordered leaf-first so
-# that RTLD_GLOBAL preloading satisfies inter-lib NEEDED entries as we go.
-_rocm_core_libs: list[str] = [
-    "libamd_comgr.so",
-    "libhsa-runtime64.so",
-    "libamdhip64.so",
-    "libhiprtc.so",
-    "librocm-core.so",
-    "librocm_smi64.so",
-    "libroctx64.so",
-    "libroctracer64.so",
-    "librocblas.so",
-    "libhipblas.so",
-    "libhipblaslt.so",
-    "librocfft.so",
-    "libhipfft.so",
-    "librocrand.so",
-    "libhiprand.so",
-    "librocsolver.so",
-    "libhipsolver.so",
-    "librocsparse.so",
-    "libhipsparse.so",
-    "libhipsparselt.so",
-    "libMIOpen.so",
-    "librccl.so",
-]
+# Canonical, leaf-first list of ROCm runtime libs a TheRock-built libtorch
+# DT_NEEDEDs. Kept in torch/_rocm_libs.py so it is the single source of truth
+# shared with .ci/manywheel/repair_wheel.py (which bundles these plus the
+# bundle-only extras). Leaf-first order matters: RTLD_GLOBAL preloading must
+# satisfy inter-lib NEEDED entries as we go.
+from torch._rocm_libs import ROCM_SO_FILES as _rocm_core_libs
 
 
 def _preload_rocm_deps() -> None:

--- a/torch/_rocm_libs.py
+++ b/torch/_rocm_libs.py
@@ -1,0 +1,66 @@
+"""Canonical list of ROCm shared libraries bundled into / preloaded by torch.
+
+Single source of truth shared by two very different consumers, so the two never
+drift apart:
+
+* ``torch/__init__.py`` imports :data:`ROCM_SO_FILES` and RTLD_GLOBAL-preloads
+  each one (via ``_preload_rocm_deps``) so a TheRock-built wheel is importable
+  without ``LD_LIBRARY_PATH``. Only libs that a TheRock-built libtorch actually
+  ``DT_NEEDED``\\s belong here, and the **order matters**: it is leaf-first so
+  each preload satisfies the inter-lib ``NEEDED`` entries of the ones loaded
+  after it.
+* ``.ci/manywheel/repair_wheel.py`` copies every lib in
+  :data:`ROCM_SO_FILES` **plus** :data:`ROCM_SO_FILES_BUNDLE_ONLY` into
+  ``torch/lib/`` and patchelf-rewrites ``NEEDED`` entries. Order is irrelevant
+  there (it just copies + rewrites each file).
+
+The module is intentionally import-light: it holds only plain string lists and
+imports nothing (in particular not ``torch``), so it can be loaded both as the
+``torch._rocm_libs`` submodule and standalone-by-path from an unpacked wheel by
+``repair_wheel.py`` (which must not ``import torch`` in the build container).
+"""
+
+# Core ROCm runtime libs a TheRock-built libtorch DT_NEEDEDs. Ordered LEAF-FIRST
+# so RTLD_GLOBAL preloading satisfies inter-lib NEEDED entries as we go. This is
+# the set torch/__init__.py::_preload_rocm_deps preloads.
+ROCM_SO_FILES: list[str] = [
+    "libamd_comgr.so",
+    "libhsa-runtime64.so",
+    "libamdhip64.so",
+    "libhiprtc.so",
+    "librocm-core.so",
+    "librocm_smi64.so",
+    "libroctx64.so",
+    "libroctracer64.so",
+    "librocblas.so",
+    "libhipblas.so",
+    "libhipblaslt.so",
+    "librocfft.so",
+    "libhipfft.so",
+    "librocrand.so",
+    "libhiprand.so",
+    "librocsolver.so",
+    "libhipsolver.so",
+    "librocsparse.so",
+    "libhipsparse.so",
+    "libhipsparselt.so",
+    "libMIOpen.so",
+    "librccl.so",
+]
+
+# Extra libs that are BUNDLED into the wheel by repair_wheel.py but are NOT part
+# of the preload set, because libtorch does not DT_NEEDED them (they are optional
+# / dlopen'd at runtime): MAGMA, the rocprofiler/aqlprofile profiler stack, and
+# the rocRoller hipBLASLt backend. They ship in the wheel so they are available
+# when something loads them, but they need not be RTLD_GLOBAL-preloaded to make
+# ``import torch`` succeed.
+ROCM_SO_FILES_BUNDLE_ONLY: list[str] = [
+    "libmagma.so",
+    "librocprofiler-sdk.so",
+    "librocprofiler-register.so",
+    "libhsa-amd-aqlprofile64.so",
+    "librocroller.so",
+]
+
+# Full set of ROCm libs bundled into torch/lib/ by repair_wheel.py.
+ROCM_SO_FILES_ALL: list[str] = ROCM_SO_FILES + ROCM_SO_FILES_BUNDLE_ONLY


### PR DESCRIPTION
## Summary

The set of ROCm shared libraries that ship with a ROCm wheel was duplicated in two places that had drifted apart:

- `.ci/manywheel/repair_wheel.py::ROCM_SO_FILES` (27 entries) — the libs copied into `torch/lib/` and patchelf-rewritten during wheel repair.
- `torch/__init__.py::_rocm_core_libs` (22 entries) — the leaf-first list `_preload_rocm_deps()` RTLD_GLOBAL-preloads so a TheRock-built wheel imports without `LD_LIBRARY_PATH` (added in #188454, whose comment already noted it "mirrors" `ROCM_SO_FILES`).

This PR makes them a single source of truth. It adds an import-light `torch/_rocm_libs.py` (pure string lists, imports nothing — in particular not `torch`) holding:

- `ROCM_SO_FILES` — the canonical **leaf-first** preload subset (the 22 libs a TheRock-built libtorch `DT_NEEDED`s; order matters for RTLD_GLOBAL preload).
- `ROCM_SO_FILES_BUNDLE_ONLY` — the 5 extra libs that are bundled into the wheel but not preloaded because libtorch does not `DT_NEEDED` them (they are optional / `dlopen`'d): MAGMA, the rocprofiler/aqlprofile profiler stack, and rocRoller (hipBLASLt backend).
- `ROCM_SO_FILES_ALL = ROCM_SO_FILES + ROCM_SO_FILES_BUNDLE_ONLY` — the full bundle set.

Wiring:

- `torch/__init__.py` imports `ROCM_SO_FILES` (as `_rocm_core_libs`), preserving the leaf-first preload order exactly.
- `.ci/manywheel/repair_wheel.py` loads the module **by file path** (it must not `import torch` — the compiled extension may not import in the build container), preferring the copy inside the unpacked wheel being repaired and falling back to the in-repo source tree, and bundles `ROCM_SO_FILES_ALL`.

This is a behavior-preserving refactor: the wheel-bundled set and the runtime preload set are unchanged; they just can no longer drift. Follow-up to #188454 (the list this deduplicates was introduced there).

Related issue: ROCm/frameworks-internal#17214

## Test plan

- [x] `ROCM_SO_FILES_ALL` is **set-equal** to the original 27-entry `repair_wheel.py::ROCM_SO_FILES` bundle set (no duplicates; preload subset and bundle-only set are disjoint) — proves the wheel bundling is unchanged.
- [x] `ROCM_SO_FILES` is **byte-identical in order** to the on-`main` `torch/__init__.py::_rocm_core_libs` — preserves leaf-first preload order.
- [x] `repair_wheel.py`'s loader resolves `_rocm_libs.py` from both the source tree and a simulated unpacked-wheel layout.
- [x] `python -m py_compile` passes on `torch/_rocm_libs.py`, `torch/__init__.py`, `.ci/manywheel/repair_wheel.py`.
- [ ] CI: ROCm manywheel wheel build (`ciflow/binaries_wheel`) exercises `repair_wheel.py`; `import torch` on gfx942 (`ciflow/rocm-mi300`) exercises the shared import.

## Validation

- rocm-mi300 (import torch on gfx942) + linux-binary-manywheel (ROCm wheel build exercising repair_wheel.py) triggered via `ciflow/rocm-mi300` + `ciflow/binaries_wheel`.
- HUD: https://hud.pytorch.org/pr/189296

Made with Cursor


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang