### PR TITLE
[CI] Pin quack to torch's vendored SHA to fix B200 smoke cutlass import crash

### DIFF
--- a/.ci/pytorch/common_utils.sh
+++ b/.ci/pytorch/common_utils.sh
@@ -323,6 +323,10 @@ function install_flash_attn_cute() {
   else
     pip_install flash-attn-4==4.0.0b17
   fi
+  # flash-attn-4 pulls quack unpinned; newer quack needs cutlass._mlir_helpers,
+  # absent from the gated cutlass-dsl 4.5.2. Pin quack to the SHA torch vendors
+  # (torch/_vendor/quack), which uses cutlass._mlir and works with 4.5.2. See #188477.
+  pip_install "git+https://github.com/Dao-AILab/quack.git@99bd7973bf3dc6db40961e413d4bdfea6c6fee3e"
   echo "FlashAttention 4 installation complete."
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189297

The B200 smoke job's test_flex_flash::test_hierarchical_indexing_4d crashes at
runtime with `ModuleNotFoundError: No module named 'cutlass._mlir_helpers'`. The
compiled flex-attention CuTeDSL kernel imports flash_attn.cute, which pulls in
quack, whose recent releases do `from cutlass._mlir_helpers import math`. The
B200 env gates nvidia-cutlass-dsl to 4.5.2 (torch._native _CUTEDSL_REQUIRED_VERSIONS),
which predates that module, so the import fails.

flash-attn-4==4.0.0b17 pulls quack unpinned, so an upstream quack release (~2026-07-04)
silently moved the job to cutlass._mlir_helpers and reddened it -- a dependency
drift, not a PyTorch bug. Pin quack to 99bd7973, the same SHA torch vendors in
torch/_vendor/quack; that revision uses cutlass._mlir (present in 4.5.2), so it is
known-compatible with the gated cutlass-dsl.

This is the same cutlass-dsl version-skew family as #188477.

Test Plan:
CI only (B200). The "B200 Smoke Tests / ...sm100 / test (smoke_b200)" job should
go green; test_flex_flash no longer imports the missing cutlass module. Validated
via the ciflow/b200 label on this PR.

Authored with Claude.