### PR TITLE
[MemoryViz] Decimate over-long stacked-area polygons so the summarize…

### DIFF
--- a/test/profiler/test_memory_viz.js
+++ b/test/profiler/test_memory_viz.js
@@ -1530,6 +1530,38 @@ function test_unpickle_protocol5_dict_with_values() {
   assertEqual(result.a, 42, 'dict value parsed correctly');
 }
 
+function test_summarized_band_decimated_for_long_trace() {
+  console.log('test_summarized_band_decimated_for_long_trace');
+  // A long trace gives the whole-trace summarized band one point per action,
+  // which can exceed Chrome's ~2M-point polygon limit and render as nothing.
+  // With max_entries=0 every block is summarized, so the band gets one point
+  // per alloc. Verify the band is decimated below the point budget while its
+  // peak (the final, monotonically-largest value) is preserved exactly.
+  const N = 120000;
+  const S = 1024;
+  const traces = [];
+  for (let i = 0; i < N; i++) {
+    traces.push({ action: 'alloc', addr: 0x100000 + i * S, size: S, frames: [], stream: 0 });
+  }
+  const snapshot = makeSnapshot({ traces });
+  const result = process_alloc_data(snapshot, 0, false, 0, false);
+
+  for (const d of result.allocations_over_time) {
+    assert(d.timesteps.length <= 100002, `series ${d.elem} within point budget`);
+    assertEqual(d.offsets.length, d.timesteps.length, `series ${d.elem} offsets aligned`);
+    if (Array.isArray(d.size)) {
+      assertEqual(d.size.length, d.timesteps.length, `series ${d.elem} size aligned`);
+    }
+  }
+  const summ = result.summarized_mem;
+  assert(summ.timesteps.length < N, 'summarized band was decimated');
+  assertEqual(summ.size.at(-1), N * S, 'peak summarized value preserved');
+  let max_summ = 0;
+  for (const v of summ.size) if (v > max_summ) max_summ = v;
+  assertEqual(max_summ, N * S, 'max summarized value preserved');
+  assertEqual(result.max_at_time.length, N, 'max_at_time is not decimated');
+}
+
 // ============================================================
 // Run all tests
 // ============================================================
@@ -1586,6 +1618,7 @@ test_unpickle_protocol4_still_works();
 test_unpickle_protocol6_rejected();
 test_unpickle_bytearray8();
 test_unpickle_protocol5_dict_with_values();
+test_summarized_band_decimated_for_long_trace();
 
 console.log(`\n${passed} passed, ${failed} failed`);
 process.exit(failed > 0 ? 1 : 0);

--- a/torch/utils/viz/process_alloc_data.js
+++ b/torch/utils/viz/process_alloc_data.js
@@ -81,6 +81,11 @@
 //     - Segment snapshot data (segments array) is NOT affected by ring buffer overflow.
 //     - The segment snapshot is always complete regardless of overflow.
 
+// Point budget for a single stacked-area <polygon>. Chrome/Skia stops
+// rasterizing a polygon somewhere under ~2 million points; series longer than
+// this are decimated before rendering (see process_alloc_data).
+const MAX_POLYGON_POINTS = 100000;
+
 /**
  * Returns true if pool_id represents a private (user-created) memory pool,
  * as opposed to the default pool [0, 0].
@@ -1067,6 +1072,42 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries, includ
     }
   }
   data.push(summarized_mem);
+
+  // Chrome/Skia silently fails to rasterize an SVG <polygon> past roughly two
+  // million points. A band live across the whole trace gains a point per
+  // timestep (most notably the summarized band), so long traces make it exceed
+  // that limit and render as nothing. Decimate any over-long series to a safe
+  // budget, keeping the extremes of both the lower (offset) and upper
+  // (offset+size) edges in each bucket so peaks survive.
+  for (const d of data) {
+    const n = d.timesteps.length;
+    if (n <= MAX_POLYGON_POINTS) continue;
+    const size_is_array = Array.isArray(d.size);
+    const n_buckets = Math.floor(MAX_POLYGON_POINTS / 4);
+    const bucket = n / n_buckets;
+    const keep = new Set([0, n - 1]);
+    for (let b = 0; b < n_buckets; b++) {
+      const start = Math.floor(b * bucket);
+      const end = Math.min(n, Math.floor((b + 1) * bucket));
+      let lo_i = -1, hi_i = -1, lo = Infinity, hi = -Infinity;
+      let top_lo_i = -1, top_hi_i = -1, top_lo = Infinity, top_hi = -Infinity;
+      for (let i = start; i < end; i++) {
+        const bottom = d.offsets[i];
+        const top = bottom + (size_is_array ? d.size[i] : d.size);
+        if (bottom < lo) { lo = bottom; lo_i = i; }
+        if (bottom > hi) { hi = bottom; hi_i = i; }
+        if (top < top_lo) { top_lo = top; top_lo_i = i; }
+        if (top > top_hi) { top_hi = top; top_hi_i = i; }
+      }
+      for (const i of [lo_i, hi_i, top_lo_i, top_hi_i]) {
+        if (i >= 0) keep.add(i);
+      }
+    }
+    const idx = Array.from(keep).sort((a, b) => a - b);
+    d.timesteps = idx.map(i => d.timesteps[i]);
+    d.offsets = idx.map(i => d.offsets[i]);
+    if (size_is_array) d.size = idx.map(i => d.size[i]);
+  }
 
   return {
     max_size,


### PR DESCRIPTION
…d band renders

The "Active Memory Timeline" / "Allocated Memory (incl. Private Pools)" views build one stacked-area <polygon> per allocation series and advance a point onto each live series at every alloc/free action. A series that stays live across the whole trace therefore gains one point per timestep. The global summarized band is always such a series, so on a long trace (e.g. ~1M+ recorded actions) it grows to ~2M polygon points.

Chrome/Skia silently stops rasterizing an SVG <polygon> beyond roughly two million points: the element stays in the DOM with a valid bounding box, but paints nothing. The result is that at low Detail, memory that folds out of individually-drawn blocks and into the summarized band disappears entirely instead of showing up as the band. This was verified against a real snapshot: the summarized polygon held 1,017,561 points and rendered zero pixels, while the identical geometry filled correctly in a non-browser rasterizer and rendered fine once its point count was reduced.

Fix: after the timeline is built, decimate any series whose point count exceeds a budget (MAX_POLYGON_POINTS = 100000). Points are bucketed and, per bucket, the extremes of both the lower edge (offset) and upper edge (offset+size) are kept, plus the first and last points, so peaks and valleys survive. max_size and max_at_time are left untouched, so the y-axis and minimap remain exact. On the real snapshot this takes the summarized band from 1,017,561 to 71,508 points with the peak preserved, and it renders.

Test Plan:

```
node test/profiler/test_memory_viz.js
```

216 passed, 0 failed, including a new test that builds a 120k-action trace, asserts every series stays within the point budget with aligned offset/size/timestep arrays, that the band's peak is preserved, and that max_at_time is not decimated.

This PR was authored with the assistance of an AI coding assistant.