### PR TITLE
[ROCm][CI] Make ROCM_SO_FILES a single shared source of truth for wheel bundling + preload

### DIFF
--- a/.ci/manywheel/repair_wheel.py
+++ b/.ci/manywheel/repair_wheel.py
@@ -15,6 +15,7 @@ Environment variables:
 """
 
 import argparse
+import importlib.util
 import os
 import platform
 import shutil
@@ -114,36 +115,39 @@ def aarch64_extra_deps(use_cuda: bool) -> list[Path]:
     return deps
 
 
-# ROCm shared libs to bundle. Discovered under $ROCM_HOME/{lib,lib64}.
-ROCM_SO_FILES: list[str] = [
-    "libMIOpen.so",
-    "libamdhip64.so",
-    "libhipblas.so",
-    "libhipfft.so",
-    "libhiprand.so",
-    "libhipsolver.so",
-    "libhipsparse.so",
-    "libhsa-runtime64.so",
-    "libamd_comgr.so",
-    "libmagma.so",
-    "librccl.so",
-    "librocblas.so",
-    "librocfft.so",
-    "librocm_smi64.so",
-    "librocrand.so",
-    "librocsolver.so",
-    "librocsparse.so",
-    "libroctracer64.so",
-    "libroctx64.so",
-    "libhipblaslt.so",
-    "libhipsparselt.so",
-    "libhiprtc.so",
-    "librocprofiler-sdk.so",
-    "librocprofiler-register.so",
-    "libhsa-amd-aqlprofile64.so",
-    "librocm-core.so",
-    "librocroller.so",
-]
+# ROCm shared libs to bundle (discovered under $ROCM_HOME/{lib,lib64}). The list
+# is NOT defined here: it shares a single source of truth with the preload list
+# in torch/__init__.py. Both come from torch/_rocm_libs.py -- torch/__init__.py
+# imports ROCM_SO_FILES, and load_rocm_so_files() below reads ROCM_SO_FILES_ALL
+# (the preloaded core libs plus the bundle-only extras) straight off disk.
+def load_rocm_so_files(unpacked_roots: tuple[Path, ...] = ()) -> list[str]:
+    """Return the ROCm shared-lib basenames to bundle, from torch/_rocm_libs.py.
+
+    This script runs before the freshly built wheel is importable (and must not
+    ``import torch`` regardless), so we read the dependency-free source-of-truth
+    module straight off disk by file path. Prefer a copy that ships inside an
+    unpacked wheel -- the exact list that wheel was built with -- and fall back to
+    the source tree this script lives in (``.ci/manywheel/`` -> ``torch/``).
+    """
+    candidates: list[Path] = []
+    for root in unpacked_roots:
+        candidates += [root / "_rocm_libs.py", root / "torch" / "_rocm_libs.py"]
+    # Source-tree copy: this file is <repo>/.ci/manywheel/repair_wheel.py.
+    candidates.append(Path(__file__).resolve().parents[2] / "torch" / "_rocm_libs.py")
+
+    for path in candidates:
+        if path.is_file():
+            spec = importlib.util.spec_from_file_location("torch_rocm_libs", path)
+            if spec is None or spec.loader is None:
+                continue
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            return list(module.ROCM_SO_FILES_ALL)
+    sys.exit(
+        "Could not locate torch/_rocm_libs.py (searched: "
+        + ", ".join(str(c) for c in candidates)
+        + ")"
+    )
 
 
 def rocm_os_deps() -> list[Path]:
@@ -215,7 +219,7 @@ def rocm_bundle(rocm_home: Path) -> tuple[list[BundledLib], list[AuxFile]]:
     rewritten to the renamed copies via patchelf in repair_wheel().
     """
     libs: list[BundledLib] = []
-    for stem in ROCM_SO_FILES:
+    for stem in load_rocm_so_files():
         path = find_rocm_lib(rocm_home, stem)
         if path is None:
             sys.exit(f"Required ROCm library not found: {stem}")

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -381,33 +381,12 @@ def _preload_cuda_deps(err: OSError | None = None, required: bool = True) -> Non
     _preload_cuda_lib("nvtx", "libnvToolsExt.so.*[0-9]", required=False)
 
 
-# ROCm runtime libs a TheRock-built libtorch DT_NEEDEDs, mirroring the set
-# bundled by .ci/manywheel/repair_wheel.py::ROCM_SO_FILES. Ordered leaf-first so
-# that RTLD_GLOBAL preloading satisfies inter-lib NEEDED entries as we go.
-_rocm_core_libs: list[str] = [
-    "libamd_comgr.so",
-    "libhsa-runtime64.so",
-    "libamdhip64.so",
-    "libhiprtc.so",
-    "librocm-core.so",
-    "librocm_smi64.so",
-    "libroctx64.so",
-    "libroctracer64.so",
-    "librocblas.so",
-    "libhipblas.so",
-    "libhipblaslt.so",
-    "librocfft.so",
-    "libhipfft.so",
-    "librocrand.so",
-    "libhiprand.so",
-    "librocsolver.so",
-    "libhipsolver.so",
-    "librocsparse.so",
-    "libhipsparse.so",
-    "libhipsparselt.so",
-    "libMIOpen.so",
-    "librccl.so",
-]
+# ROCm runtime libs a TheRock-built libtorch DT_NEEDEDs. These share a single
+# source of truth with the set bundled by .ci/manywheel/repair_wheel.py: both
+# import the basenames from torch/_rocm_libs.py (a dependency-free module).
+# ROCM_SO_FILES is ordered leaf-first so that RTLD_GLOBAL preloading satisfies
+# inter-lib NEEDED entries as we go.
+from torch._rocm_libs import ROCM_SO_FILES as _rocm_core_libs
 
 
 def _preload_rocm_deps() -> None:

--- a/torch/_rocm_libs.py
+++ b/torch/_rocm_libs.py
@@ -1,0 +1,69 @@
+"""Single source of truth for the ROCm shared-library basenames used by the
+ROCm wheel tooling.
+
+This module is intentionally dependency-free (no ``torch`` import, no third-party
+imports) so it can be consumed two very different ways:
+
+- ``torch/__init__.py`` imports ``ROCM_SO_FILES`` (as ``_rocm_core_libs``) and
+  preloads those libs, leaf-first, with ``RTLD_GLOBAL`` before ``import torch._C``
+  so a TheRock ROCm wheel is self-resolving.
+- ``.ci/manywheel/repair_wheel.py`` loads this file *by path* (it runs before the
+  built wheel is importable) and bundles ``ROCM_SO_FILES_ALL`` into the wheel.
+
+Two lists, one union:
+
+- ``ROCM_SO_FILES``            -- the runtime core libs that must be preloaded.
+                                  Ordered leaf-first so that ``RTLD_GLOBAL``
+                                  preloading satisfies inter-lib NEEDED entries as
+                                  we go.
+- ``ROCM_SO_FILES_BUNDLE_ONLY`` -- libs that ship in the wheel but are NOT
+                                  preloaded, because libtorch does not DT_NEEDED
+                                  them (they are optional / ``dlopen``'d at
+                                  runtime): MAGMA, the rocprofiler / aqlprofile
+                                  profiler stack, and the rocRoller hipBLASLt
+                                  backend. Preload order is irrelevant for these,
+                                  so this list is kept in the (order-insensitive)
+                                  form the bundler used historically.
+- ``ROCM_SO_FILES_ALL``        -- the union that the wheel bundler ships. Set-equal
+                                  to the historical ``repair_wheel.py`` list.
+"""
+
+ROCM_SO_FILES: list[str] = [
+    "libamd_comgr.so",
+    "libhsa-runtime64.so",
+    "libamdhip64.so",
+    "libhiprtc.so",
+    "librocm-core.so",
+    "librocm_smi64.so",
+    "libroctx64.so",
+    "libroctracer64.so",
+    "librocblas.so",
+    "libhipblas.so",
+    "libhipblaslt.so",
+    "librocfft.so",
+    "libhipfft.so",
+    "librocrand.so",
+    "libhiprand.so",
+    "librocsolver.so",
+    "libhipsolver.so",
+    "librocsparse.so",
+    "libhipsparse.so",
+    "libhipsparselt.so",
+    "libMIOpen.so",
+    "librccl.so",
+]
+
+# Bundled into the wheel but intentionally NOT preloaded: libtorch has no
+# DT_NEEDED entry for these, so nothing needs their symbols resolved at import
+# time. They are optional / loaded on demand (MAGMA linear-algebra, the
+# rocprofiler + aqlprofile profiling stack, and the rocRoller hipBLASLt backend).
+ROCM_SO_FILES_BUNDLE_ONLY: list[str] = [
+    "libmagma.so",
+    "librocprofiler-sdk.so",
+    "librocprofiler-register.so",
+    "libhsa-amd-aqlprofile64.so",
+    "librocroller.so",
+]
+
+# Every ROCm shared lib that the wheel bundler ships.
+ROCM_SO_FILES_ALL: list[str] = ROCM_SO_FILES + ROCM_SO_FILES_BUNDLE_ONLY


### PR DESCRIPTION
## Summary

The ROCm shared-library basename list was duplicated in two places that had drifted apart:

- `.ci/manywheel/repair_wheel.py::ROCM_SO_FILES` (27 entries) — the libs bundled into the wheel.
- `torch/__init__.py::_rocm_core_libs` (22 entries) — the libs preloaded `RTLD_GLOBAL`, leaf-first, before `import torch._C` (added in #188454).

This makes them a single source of truth. A new dependency-free module `torch/_rocm_libs.py` holds:

- `ROCM_SO_FILES` — the leaf-first preload core libs (exactly main's `_rocm_core_libs`, order-identical).
- `ROCM_SO_FILES_BUNDLE_ONLY` — the 5 libs bundled but **not** preloaded: `libmagma.so`, `librocprofiler-sdk.so`, `librocprofiler-register.so`, `libhsa-amd-aqlprofile64.so`, `librocroller.so`.
- `ROCM_SO_FILES_ALL` — the union (set-equal to main's `repair_wheel.py::ROCM_SO_FILES`).

Wiring:

- `torch/__init__.py` imports `ROCM_SO_FILES as _rocm_core_libs` (leaf-first preload order preserved).
- `.ci/manywheel/repair_wheel.py` loads the module **by file path** (no `import torch`, since it runs before the built wheel is importable) — preferring an unpacked-wheel copy, falling back to the source tree — and bundles `ROCM_SO_FILES_ALL`.

Why the two lists differ (and why that's correct):

- The 5 bundle-only libs are shipped but not preloaded because libtorch has no `DT_NEEDED` entry for them — they are optional / `dlopen`'d at runtime (MAGMA, the rocprofiler + aqlprofile profiler stack, and the rocRoller hipBLASLt backend). Nothing needs their symbols resolved at import time.
- The order differs because preload must be leaf-first so `RTLD_GLOBAL` satisfies inter-lib `NEEDED` entries as it goes, whereas the wheel bundler's copy order is irrelevant.

Behavior-preserving: `ROCM_SO_FILES_ALL` is set-equal to the original 27-entry bundle set, and the preload order is byte-for-byte identical to main's `_rocm_core_libs`.

Related issue: ROCm/frameworks-internal#17214

## Test plan

Local (pre-push):
- Asserted `ROCM_SO_FILES` == main's `_rocm_core_libs` (order-identical, 22 libs).
- Asserted `set(ROCM_SO_FILES_ALL)` == `set(` main's `repair_wheel.py::ROCM_SO_FILES` `)` (27 libs); `ROCM_SO_FILES_BUNDLE_ONLY` == the 5-lib difference.
- Verified `load_rocm_so_files()` resolves from both the source tree and a simulated unpacked-wheel (`torch-*/torch/_rocm_libs.py`) layout.
- `python -m py_compile` on all three files.

CI:
- `ciflow/binaries_wheel` exercises `repair_wheel.py` (ROCm manywheel build path).
- `ciflow/rocm-mi300` exercises the `torch/__init__.py` import on gfx942.

Made with Cursor

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang