### PR TITLE
Reapply "Dispatch index_put_ to fill_ for scalar values (#188267 / #189105)"

### DIFF
--- a/aten/src/ATen/TensorIndexing.cpp
+++ b/aten/src/ATen/TensorIndexing.cpp
@@ -40,28 +40,6 @@ std::ostream& operator<<(std::ostream& stream, const std::vector<TensorIndex>& t
   return stream;
 }
 
-// This mirrors `THPVariable_setitem` in torch/csrc/autograd/python_variable_indexing.cpp
-// for "the assigned value is a Scalar" case
-static inline void set_item(const Tensor& self, ArrayRef<TensorIndex> indices, const Scalar& v) {
-  Tensor value;
-
-  {
-    at::AutoDispatchBelowADInplaceOrView guard;
-    at::Device self_device = self.device();
-
-    // TODO: This qint special case looks very suspicious...
-    if (isQIntType(self.scalar_type())) {
-      value = at::indexing::scalarToTensor(v, device(kCPU).dtype(kFloat), at::Device(kCPU));
-    } else if (self_device.is_cuda()) {
-      value = at::indexing::scalarToTensor(v, self.options(), at::Device(kCPU));
-    } else {
-      value = at::indexing::scalarToTensor(v, self.options(), self_device);
-    }
-  }
-
-  set_item(self, indices, value);
-}
-
 } // namespace indexing
 
 Tensor Tensor::index(ArrayRef<at::indexing::TensorIndex> indices) const {

--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -397,6 +397,22 @@ inline Tensor scalarToTensor(
   }
 }
 
+inline Tensor asTensor(const Tensor& value, const Tensor& target) {
+  return value;
+}
+inline Tensor asTensor(const Scalar& value, const Tensor& target) {
+  at::AutoDispatchBelowADInplaceOrView guard;
+  at::Device target_device = target.device();
+  // TODO: This qint special case looks very suspicious...
+  if (isQIntType(target.scalar_type())) {
+    return scalarToTensor(value, device(kCPU).dtype(kFloat), at::Device(kCPU));
+  } else if (target_device.is_cuda()) {
+    return scalarToTensor(value, target.options(), at::Device(kCPU));
+  } else {
+    return scalarToTensor(value, target.options(), target_device);
+  }
+}
+
 // To match numpy semantics:
 // As a special case for backwards compatibility,
 // strip away unit dimensions from the left of 'src'
@@ -415,6 +431,9 @@ inline SymIntArrayRef slicePrefix1sSize(const SymIntArrayRef& sizes) {
   return sizes.slice(first_non1_src);
 }
 
+inline void copy_to(const Tensor& dst, const Scalar& src) {
+  dst.fill_(src);
+}
 inline void copy_to(const Tensor& dst, const Tensor& src) {
   // Use TORCH_GUARD_OR_FALSE with sym_eq to avoid data-dependent-expression
   // errors with unbacked symbolic sizes.  When we can't prove equality,
@@ -710,11 +729,15 @@ inline Tensor get_item(
 // torch/csrc/autograd/python_variable_indexing.cpp for "the assigned value is a
 // Tensor" case See NOTE [ Setting `disable_slice_optimization` when calling C++
 // tensor indexing functions from Python ]
+template <typename T>
 inline void set_item(
     const Tensor& self,
     const ArrayRef<TensorIndex>& indices,
-    const Tensor& value,
+    const T& value,
     bool disable_slice_optimization = false) {
+  static_assert(
+      std::is_same_v<T, Tensor> || std::is_same_v<T, Scalar>,
+      "T must be either at::Tensor or at::Scalar");
   at::Device self_device = self.device();
   SymIntArrayRef self_sizes = self.sym_sizes();
 
@@ -766,13 +789,14 @@ inline void set_item(
     return;
   }
 
-  SymIntArrayRef valueSizes = value.sym_sizes();
+  Tensor valueTensor = asTensor(value, self);
+  SymIntArrayRef valueSizes = valueTensor.sym_sizes();
   SymIntArrayRef slicedValueSizes = slicePrefix1sSize(valueSizes);
   Tensor valuesSliced;
   if (!valueSizes.equals(slicedValueSizes)) {
-    valuesSliced = value.view_symint(slicedValueSizes);
+    valuesSliced = valueTensor.view_symint(slicedValueSizes);
   } else {
-    valuesSliced = value;
+    valuesSliced = std::move(valueTensor);
   }
   dispatch_index_put_(sliced, std::move(tensorIndices), valuesSliced);
   return;

--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -405,7 +405,7 @@ inline Tensor asTensor(const Scalar& value, const Tensor& target) {
   at::Device target_device = target.device();
   // TODO: This qint special case looks very suspicious...
   if (isQIntType(target.scalar_type())) {
-    return scalarToTensor(value, device(kCPU).dtype(kFloat), at::Device(kCPU));
+    return scalarToTensor(value, at::device(kCPU).dtype(kFloat), at::Device(kCPU));
   } else if (target_device.is_cuda()) {
     return scalarToTensor(value, target.options(), at::Device(kCPU));
   } else {

--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -405,7 +405,8 @@ inline Tensor asTensor(const Scalar& value, const Tensor& target) {
   at::Device target_device = target.device();
   // TODO: This qint special case looks very suspicious...
   if (isQIntType(target.scalar_type())) {
-    return scalarToTensor(value, at::device(kCPU).dtype(kFloat), at::Device(kCPU));
+    return scalarToTensor(
+        value, at::device(kCPU).dtype(kFloat), at::Device(kCPU));
   } else if (target_device.is_cuda()) {
     return scalarToTensor(value, target.options(), at::Device(kCPU));
   } else {

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2695,6 +2695,19 @@ torch.cuda.synchronize()
     @unittest.skipIf(
         not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
     )
+    def test_graph_scalar_assignment(self):
+        x = torch.zeros(2, 2, device="cuda")
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g):
+            x[0, 1] = 5.0
+
+        x.zero_()  # Reset the side-effect of capture execution
+        g.replay()
+        self.assertEqual(x[0, 1].item(), 5.0)
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
     def test_graph_capture_stale_default_stream_error(self):
         """Default-stream warmup + side-stream capture raises a clear error
         (not an opaque CUDA crash) when override is not enabled."""

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2788,6 +2788,19 @@ torch.cuda.synchronize()
     @unittest.skipIf(
         not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
     )
+    def test_graph_scalar_assignment(self):
+        x = torch.zeros(2, 2, device="cuda")
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g):
+            x[0, 1] = 5.0
+
+        x.zero_()  # Reset the side-effect of capture execution
+        g.replay()
+        self.assertEqual(x[0, 1].item(), 5.0)
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
     def test_graph_capture_stale_default_stream_error(self):
         """Default-stream warmup + side-stream capture raises a clear error
         (not an opaque CUDA crash) when override is not enabled."""

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2788,6 +2788,10 @@ torch.cuda.synchronize()
     @unittest.skipIf(
         not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
     )
+    @unittest.skipIf(
+        not torch.cuda.get_arch_list(),
+        "torch was built without CUDA kernels (GPU sections stripped)",
+    )
     def test_graph_scalar_assignment(self):
         x = torch.zeros(2, 2, device="cuda")
         g = torch.cuda.CUDAGraph()

--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -1452,9 +1452,8 @@ def forward(self, a_1):
             r, """\
 def forward(self, x_1):
     sym_size_int = torch.ops.aten.sym_size.int(x_1, 0)
-    scalar_tensor = torch.ops.aten.scalar_tensor.default(sym_size_int, dtype = torch.float32, layout = torch.strided, device = device(type='cpu'));  sym_size_int = None
     select = torch.ops.aten.select.int(x_1, 0, 0)
-    copy_ = torch.ops.aten.copy_.default(select, scalar_tensor);  select = scalar_tensor = copy_ = None
+    fill_ = torch.ops.aten.fill_.Scalar(select, sym_size_int);  select = sym_size_int = fill_ = None
     return x_1"""
         )
 
@@ -1492,11 +1491,9 @@ def forward(self, gravity_1, mask_1):
 def forward(self, crop_camera_1, mask_1):
     index = torch.ops.aten.index.Tensor(crop_camera_1, [mask_1])
     eye = torch.ops.aten.eye.default(3, device = device(type='cpu'), pin_memory = False)
-    _tensor_constant0 = self._tensor_constant0
-    lift_fresh_copy = torch.ops.aten.lift_fresh_copy.default(_tensor_constant0);  _tensor_constant0 = None
     select = torch.ops.aten.select.int(eye, 0, 0)
     select_1 = torch.ops.aten.select.int(select, 0, 0);  select = None
-    copy_ = torch.ops.aten.copy_.default(select_1, lift_fresh_copy);  select_1 = lift_fresh_copy = copy_ = None
+    fill_ = torch.ops.aten.fill_.Scalar(select_1, -1);  select_1 = fill_ = None
     sym_size_int = torch.ops.aten.sym_size.int(index, 0)
     expand = torch.ops.aten.expand.default(eye, [sym_size_int, 3, 3])
     view = torch.ops.aten.view.default(expand, [sym_size_int, 3, 3]);  expand = None

--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -1457,9 +1457,8 @@ def forward(self, a_1):
             r, """\
 def forward(self, x_1):
     sym_size_int = torch.ops.aten.sym_size.int(x_1, 0)
-    scalar_tensor = torch.ops.aten.scalar_tensor.default(sym_size_int, dtype = torch.float32, layout = torch.strided, device = device(type='cpu'));  sym_size_int = None
     select = torch.ops.aten.select.int(x_1, 0, 0)
-    copy_ = torch.ops.aten.copy_.default(select, scalar_tensor);  select = scalar_tensor = copy_ = None
+    fill_ = torch.ops.aten.fill_.Scalar(select, sym_size_int);  select = sym_size_int = fill_ = None
     return x_1"""
         )
 
@@ -1497,11 +1496,9 @@ def forward(self, gravity_1, mask_1):
 def forward(self, crop_camera_1, mask_1):
     index = torch.ops.aten.index.Tensor(crop_camera_1, [mask_1])
     eye = torch.ops.aten.eye.default(3, device = device(type='cpu'), pin_memory = False)
-    _tensor_constant0 = self._tensor_constant0
-    lift_fresh_copy = torch.ops.aten.lift_fresh_copy.default(_tensor_constant0);  _tensor_constant0 = None
     select = torch.ops.aten.select.int(eye, 0, 0)
     select_1 = torch.ops.aten.select.int(select, 0, 0);  select = None
-    copy_ = torch.ops.aten.copy_.default(select_1, lift_fresh_copy);  select_1 = lift_fresh_copy = copy_ = None
+    fill_ = torch.ops.aten.fill_.Scalar(select_1, -1);  select_1 = fill_ = None
     sym_size_int = torch.ops.aten.sym_size.int(index, 0)
     expand = torch.ops.aten.expand.default(eye, [sym_size_int, 3, 3])
     view = torch.ops.aten.view.default(expand, [sym_size_int, 3, 3]);  expand = None

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2067,6 +2067,8 @@ class TestTorchDeviceType(TestCase):
         expect_no_sync = (lambda: _ind_put_fn(x, mask, 1.),
                           lambda: _ind_put_fn(x, mask_cpu, y),
                           lambda: _ind_put_fn(x, ind, y),
+                          lambda: _ind_put_fn(x, 0, 5.),
+                          lambda: _ind_put_fn(x, slice(0, 1), 5.),
                           lambda: _ind_get_fn(x, mask_cpu),
                           lambda: _ind_get_fn(x, ind),
                           lambda: torch.nn.functional.one_hot(ind, num_classes=size),

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2106,6 +2106,8 @@ class TestTorchDeviceType(TestCase):
         expect_no_sync = (lambda: _ind_put_fn(x, mask, 1.),
                           lambda: _ind_put_fn(x, mask_cpu, y),
                           lambda: _ind_put_fn(x, ind, y),
+                          lambda: _ind_put_fn(x, 0, 5.),
+                          lambda: _ind_put_fn(x, slice(0, 1), 5.),
                           lambda: _ind_get_fn(x, mask_cpu),
                           lambda: _ind_get_fn(x, ind),
                           lambda: torch.nn.functional.one_hot(ind, num_classes=size),

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -141,15 +141,9 @@ static Variable sequenceToVariable(c10::TensorOptions options, PyObject* seq) {
       options, kLong, std::nullopt, seq);
 }
 
-inline Variable valueToTensor(
+static inline Scalar valueToScalar(
     c10::TensorOptions options,
-    PyObject* value,
-    const at::Device& device) {
-  if (THPVariable_Check(value)) {
-    return THPVariable_Unpack(value);
-  }
-  at::AutoDispatchBelowADInplaceOrView guard; // TODO: remove
-  at::tracer::impl::NoTracerDispatchMode tracer_guard;
+    PyObject* value) {
   Scalar scalar;
   if (THPUtils_checkLong(value) || PyBool_Check(value)) {
     scalar = Scalar(THPUtils_unpackLong(value));
@@ -171,15 +165,41 @@ inline Variable valueToTensor(
         " to a ",
         torch::utils::options_to_string(options));
   }
+  return scalar;
+}
+
+Variable valueToTensor(
+    c10::TensorOptions options,
+    PyObject* value,
+    const at::Device& device) {
+  if (THPVariable_Check(value)) {
+    return THPVariable_Unpack(value);
+  }
+  auto scalar = valueToScalar(options, value);
   // lift_fresh is supposed to be used in situations where you are guaranteed to
   // get a plain Tensor which is not true for cpu device but not for non cpu
   // device
+  at::AutoDispatchBelowADInplaceOrView guard; // TODO: remove
+  at::tracer::impl::NoTracerDispatchMode tracer_guard;
   if (device == at::kCPU && !scalar.isSymbolic()) {
     return at::lift_fresh(
         at::indexing::scalarToTensor(scalar, options, device));
   } else {
     return at::indexing::scalarToTensor(scalar, options, device);
   }
+}
+
+static inline Tensor asTensor(const Tensor& value, const Tensor& target) {
+  return value;
+}
+static inline Tensor asTensor(const Scalar& value, const Tensor& self) {
+  at::AutoDispatchBelowADInplaceOrView guard;
+  at::tracer::impl::NoTracerDispatchMode tracer_guard;
+  Tensor tensor = at::indexing::asTensor(value, self);
+  if (tensor.device() == at::kCPU && !value.isSymbolic()) {
+    return at::lift_fresh(tensor);
+  }
+  return tensor;
 }
 
 static void recordSliceTrace(PyObject* obj) {
@@ -468,11 +488,15 @@ PyObject* THPVariable_getitem(PyObject* self, PyObject* index) {
   END_HANDLE_TH_ERRORS
 }
 
+template <typename T>
 static void dispatch_set_item(
     const Tensor& self,
     ArrayRef<at::indexing::TensorIndex> indices,
-    const Tensor& value,
+    const T& value,
     bool disable_slice_optimization = false) {
+  static_assert(
+      std::is_same_v<T, Tensor> || std::is_same_v<T, Scalar>,
+      "T must be either at::Tensor or at::Scalar");
   pybind11::gil_scoped_release no_gil;
   at::indexing::set_item(self, indices, value, disable_slice_optimization);
 }
@@ -485,38 +509,19 @@ static void dispatch_set_item(
 // 2. Python N-D setter calls C++ `at::indexing::handleDimInMultiDimIndexing`
 // for each dim, after converting Python index to C++ TensorIndex. If advanced
 // indexing is needed, it calls C++ `at::indexing::dispatch_index_put_`.
-int THPVariable_setitem(PyObject* self, PyObject* index, PyObject* py_value) {
-  HANDLE_TH_ERRORS
-  if (py_value == nullptr) {
-    TORCH_CHECK_TYPE(false, "Tensor does not support deleting items");
-  }
-  const bool skip_torch_function = consume_should_skip_torch_function();
-  if (!skip_torch_function &&
-      ((check_has_torch_function(self)) ||
-       (check_has_torch_function(py_value)))) {
-    py::object ret = py::reinterpret_steal<py::object>(
-        handle_torch_function_indexing(self, index, py_value));
-    return 0;
-  }
-
-  const auto& self_ = THPVariable_Unpack(self);
-  if (self_.layout() == kSparse || self_.layout() == kSparseCsr ||
-      self_.layout() == kSparseCsc || self_.layout() == kSparseBsr ||
-      self_.layout() == kSparseBsc) {
-    TORCH_CHECK_TYPE(false, "Cannot assign to a sparse tensor");
-  }
+template <typename T>
+static int THPVariable_setitem_impl(
+    PyObject* self,
+    const Tensor& self_,
+    PyObject* index,
+    PyObject* py_value,
+    const T& value,
+    bool skip_torch_function) {
+  static_assert(
+      std::is_same_v<T, Tensor> || std::is_same_v<T, Scalar>,
+      "T must be either at::Tensor or at::Scalar");
   OptionalDeviceGuard device_guard(device_of(self_));
   at::Device self_device = self_.device();
-  Variable value;
-  // TODO: This qint special case looks very suspicious...
-  if (isQIntType(self_.scalar_type())) {
-    value =
-        valueToTensor(device(kCPU).dtype(kFloat), py_value, at::Device(kCPU));
-  } else if (self_device.is_cuda()) {
-    value = valueToTensor(self_.options(), py_value, at::Device(kCPU));
-  } else {
-    value = valueToTensor(self_.options(), py_value, self_device);
-  }
 
   // handle simple types: ellipsis, none, bool
   if (Py_IsFalse(index)) {
@@ -590,18 +595,59 @@ int THPVariable_setitem(PyObject* self, PyObject* index, PyObject* py_value) {
 
   {
     pybind11::gil_scoped_release no_gil;
-    SymIntArrayRef valueSizes = value.sym_sizes();
+    Tensor valueTensor = asTensor(value, self_);
+    SymIntArrayRef valueSizes = valueTensor.sym_sizes();
     SymIntArrayRef slicedValueSizes =
         at::indexing::slicePrefix1sSize(valueSizes);
     torch::autograd::Variable valuesSliced;
     if (!valueSizes.equals(slicedValueSizes)) {
-      valuesSliced = value.view_symint(slicedValueSizes);
+      valuesSliced = valueTensor.view_symint(slicedValueSizes);
     } else {
-      valuesSliced = value;
+      valuesSliced = valueTensor;
     }
     at::indexing::dispatch_index_put_(
         sliced, std::move(variableIndices), valuesSliced);
     return 0;
+  }
+}
+
+int THPVariable_setitem(PyObject* self, PyObject* index, PyObject* py_value) {
+  HANDLE_TH_ERRORS
+  if (py_value == nullptr) {
+    TORCH_CHECK_TYPE(false, "Tensor does not support deleting items");
+  }
+  const bool skip_torch_function = consume_should_skip_torch_function();
+  if (!skip_torch_function &&
+      ((check_has_torch_function(self)) ||
+       (check_has_torch_function(py_value)))) {
+    py::object ret = py::reinterpret_steal<py::object>(
+        handle_torch_function_indexing(self, index, py_value));
+    return 0;
+  }
+
+  const auto& self_ = THPVariable_Unpack(self);
+  if (self_.layout() == kSparse || self_.layout() == kSparseCsr ||
+      self_.layout() == kSparseCsc || self_.layout() == kSparseBsr ||
+      self_.layout() == kSparseBsc) {
+    TORCH_CHECK_TYPE(false, "Cannot assign to a sparse tensor");
+  }
+
+  if (THPVariable_Check(py_value)) {
+    return THPVariable_setitem_impl<Tensor>(
+        self,
+        self_,
+        index,
+        py_value,
+        THPVariable_Unpack(py_value),
+        skip_torch_function);
+  } else {
+    return THPVariable_setitem_impl<Scalar>(
+        self,
+        self_,
+        index,
+        py_value,
+        valueToScalar(self_.options(), py_value),
+        skip_torch_function);
   }
   END_HANDLE_TH_ERRORS_RET(-1)
 }

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -603,7 +603,7 @@ static int THPVariable_setitem_impl(
     if (!valueSizes.equals(slicedValueSizes)) {
       valuesSliced = valueTensor.view_symint(slicedValueSizes);
     } else {
-      valuesSliced = valueTensor;
+      valuesSliced = std::move(valueTensor);
     }
     at::indexing::dispatch_index_put_(
         sliced, std::move(variableIndices), valuesSliced);

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -141,15 +141,9 @@ static Variable sequenceToVariable(c10::TensorOptions options, PyObject* seq) {
       options, kLong, std::nullopt, seq);
 }
 
-inline Variable valueToTensor(
+static inline Scalar valueToScalar(
     c10::TensorOptions options,
-    PyObject* value,
-    const at::Device& device) {
-  if (THPVariable_Check(value)) {
-    return THPVariable_Unpack(value);
-  }
-  at::AutoDispatchBelowADInplaceOrView guard; // TODO: remove
-  at::tracer::impl::NoTracerDispatchMode tracer_guard;
+    PyObject* value) {
   Scalar scalar;
   if (THPUtils_checkLong(value) || PyBool_Check(value)) {
     // uint64 values above INT64_MAX must not go through signed long long unpack
@@ -178,15 +172,41 @@ inline Variable valueToTensor(
         " to a ",
         torch::utils::options_to_string(options));
   }
+  return scalar;
+}
+
+Variable valueToTensor(
+    c10::TensorOptions options,
+    PyObject* value,
+    const at::Device& device) {
+  if (THPVariable_Check(value)) {
+    return THPVariable_Unpack(value);
+  }
+  auto scalar = valueToScalar(options, value);
   // lift_fresh is supposed to be used in situations where you are guaranteed to
   // get a plain Tensor which is not true for cpu device but not for non cpu
   // device
+  at::AutoDispatchBelowADInplaceOrView guard; // TODO: remove
+  at::tracer::impl::NoTracerDispatchMode tracer_guard;
   if (device == at::kCPU && !scalar.isSymbolic()) {
     return at::lift_fresh(
         at::indexing::scalarToTensor(scalar, options, device));
   } else {
     return at::indexing::scalarToTensor(scalar, options, device);
   }
+}
+
+static inline Tensor asTensor(const Tensor& value, const Tensor& target) {
+  return value;
+}
+static inline Tensor asTensor(const Scalar& value, const Tensor& self) {
+  at::AutoDispatchBelowADInplaceOrView guard;
+  at::tracer::impl::NoTracerDispatchMode tracer_guard;
+  Tensor tensor = at::indexing::asTensor(value, self);
+  if (tensor.device() == at::kCPU && !value.isSymbolic()) {
+    return at::lift_fresh(tensor);
+  }
+  return tensor;
 }
 
 static void recordSliceTrace(PyObject* obj) {
@@ -475,11 +495,15 @@ PyObject* THPVariable_getitem(PyObject* self, PyObject* index) {
   END_HANDLE_TH_ERRORS
 }
 
+template <typename T>
 static void dispatch_set_item(
     const Tensor& self,
     ArrayRef<at::indexing::TensorIndex> indices,
-    const Tensor& value,
+    const T& value,
     bool disable_slice_optimization = false) {
+  static_assert(
+      std::is_same_v<T, Tensor> || std::is_same_v<T, Scalar>,
+      "T must be either at::Tensor or at::Scalar");
   pybind11::gil_scoped_release no_gil;
   at::indexing::set_item(self, indices, value, disable_slice_optimization);
 }
@@ -492,38 +516,19 @@ static void dispatch_set_item(
 // 2. Python N-D setter calls C++ `at::indexing::handleDimInMultiDimIndexing`
 // for each dim, after converting Python index to C++ TensorIndex. If advanced
 // indexing is needed, it calls C++ `at::indexing::dispatch_index_put_`.
-int THPVariable_setitem(PyObject* self, PyObject* index, PyObject* py_value) {
-  HANDLE_TH_ERRORS
-  if (py_value == nullptr) {
-    TORCH_CHECK_TYPE(false, "Tensor does not support deleting items");
-  }
-  const bool skip_torch_function = consume_should_skip_torch_function();
-  if (!skip_torch_function &&
-      ((check_has_torch_function(self)) ||
-       (check_has_torch_function(py_value)))) {
-    py::object ret = py::reinterpret_steal<py::object>(
-        handle_torch_function_indexing(self, index, py_value));
-    return 0;
-  }
-
-  const auto& self_ = THPVariable_Unpack(self);
-  if (self_.layout() == kSparse || self_.layout() == kSparseCsr ||
-      self_.layout() == kSparseCsc || self_.layout() == kSparseBsr ||
-      self_.layout() == kSparseBsc) {
-    TORCH_CHECK_TYPE(false, "Cannot assign to a sparse tensor");
-  }
+template <typename T>
+static int THPVariable_setitem_impl(
+    PyObject* self,
+    const Tensor& self_,
+    PyObject* index,
+    PyObject* py_value,
+    const T& value,
+    bool skip_torch_function) {
+  static_assert(
+      std::is_same_v<T, Tensor> || std::is_same_v<T, Scalar>,
+      "T must be either at::Tensor or at::Scalar");
   OptionalDeviceGuard device_guard(device_of(self_));
   at::Device self_device = self_.device();
-  Variable value;
-  // TODO: This qint special case looks very suspicious...
-  if (isQIntType(self_.scalar_type())) {
-    value =
-        valueToTensor(device(kCPU).dtype(kFloat), py_value, at::Device(kCPU));
-  } else if (self_device.is_cuda()) {
-    value = valueToTensor(self_.options(), py_value, at::Device(kCPU));
-  } else {
-    value = valueToTensor(self_.options(), py_value, self_device);
-  }
 
   // handle simple types: ellipsis, none, bool
   if (Py_IsFalse(index)) {
@@ -597,18 +602,59 @@ int THPVariable_setitem(PyObject* self, PyObject* index, PyObject* py_value) {
 
   {
     pybind11::gil_scoped_release no_gil;
-    SymIntArrayRef valueSizes = value.sym_sizes();
+    Tensor valueTensor = asTensor(value, self_);
+    SymIntArrayRef valueSizes = valueTensor.sym_sizes();
     SymIntArrayRef slicedValueSizes =
         at::indexing::slicePrefix1sSize(valueSizes);
     torch::autograd::Variable valuesSliced;
     if (!valueSizes.equals(slicedValueSizes)) {
-      valuesSliced = value.view_symint(slicedValueSizes);
+      valuesSliced = valueTensor.view_symint(slicedValueSizes);
     } else {
-      valuesSliced = value;
+      valuesSliced = valueTensor;
     }
     at::indexing::dispatch_index_put_(
         sliced, std::move(variableIndices), valuesSliced);
     return 0;
+  }
+}
+
+int THPVariable_setitem(PyObject* self, PyObject* index, PyObject* py_value) {
+  HANDLE_TH_ERRORS
+  if (py_value == nullptr) {
+    TORCH_CHECK_TYPE(false, "Tensor does not support deleting items");
+  }
+  const bool skip_torch_function = consume_should_skip_torch_function();
+  if (!skip_torch_function &&
+      ((check_has_torch_function(self)) ||
+       (check_has_torch_function(py_value)))) {
+    py::object ret = py::reinterpret_steal<py::object>(
+        handle_torch_function_indexing(self, index, py_value));
+    return 0;
+  }
+
+  const auto& self_ = THPVariable_Unpack(self);
+  if (self_.layout() == kSparse || self_.layout() == kSparseCsr ||
+      self_.layout() == kSparseCsc || self_.layout() == kSparseBsr ||
+      self_.layout() == kSparseBsc) {
+    TORCH_CHECK_TYPE(false, "Cannot assign to a sparse tensor");
+  }
+
+  if (THPVariable_Check(py_value)) {
+    return THPVariable_setitem_impl<Tensor>(
+        self,
+        self_,
+        index,
+        py_value,
+        THPVariable_Unpack(py_value),
+        skip_torch_function);
+  } else {
+    return THPVariable_setitem_impl<Scalar>(
+        self,
+        self_,
+        index,
+        py_value,
+        valueToScalar(self_.options(), py_value),
+        skip_torch_function);
   }
   END_HANDLE_TH_ERRORS_RET(-1)
 }

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -610,7 +610,7 @@ static int THPVariable_setitem_impl(
     if (!valueSizes.equals(slicedValueSizes)) {
       valuesSliced = valueTensor.view_symint(slicedValueSizes);
     } else {
-      valuesSliced = valueTensor;
+      valuesSliced = std::move(valueTensor);
     }
     at::indexing::dispatch_index_put_(
         sliced, std::move(variableIndices), valuesSliced);


### PR DESCRIPTION
This reapplies #188267 / #189105 which has been reverted due to Meta internal CI failures. I also addressed https://github.com/pytorch/pytorch/pull/189105#issuecomment-4917329182

I will not merge it myself this time but leave it to @ngimel, @Skylion007, @izaitsevfb, or @atalman so the Meta internal CI failures can be dealt with.