### PR TITLE
Fix distribution rsample gradient tests on XPU/CUDA by using freeze_rng_state

### DIFF
--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -2610,12 +2610,13 @@ class TestDistributions(DistributionsTestCase):
             ref_dist.rvs = self._get_logistic_normal_ref_sampler(base_dist)
             mean_th = torch.tensor(mean)
             std_th = torch.tensor(np.sqrt(np.diag(cov)))
-            self._check_sampler_sampler(
-                LogisticNormal(mean_th, std_th),
-                ref_dist,
-                f"LogisticNormal(loc={mean_th}, scale={std_th})",
-                multivariate=True,
-            )
+            with freeze_rng_state():
+                self._check_sampler_sampler(
+                    LogisticNormal(mean_th, std_th),
+                    ref_dist,
+                    f"LogisticNormal(loc={mean_th}, scale={std_th})",
+                    multivariate=True,
+                )
 
     def test_mixture_same_family_shape(self):
         normal_case_1d = MixtureSameFamily(

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -118,6 +118,7 @@ from torch.testing._internal.common_device_type import (
     skipMPS,
 )
 from torch.testing._internal.common_utils import (
+    freeze_rng_state,
     gradcheck,
     load_tests,
     run_tests,
@@ -2301,9 +2302,8 @@ class TestDistributions(DistributionsTestCase):
         self._gradcheck_log_prob(Uniform, (low, 1.0))
         self._gradcheck_log_prob(Uniform, (0.0, high))
 
-        state = torch.get_rng_state()
-        rand = low.new(low.size()).uniform_()
-        torch.set_rng_state(state)
+        with freeze_rng_state():
+            rand = low.new(low.size()).uniform_()
         u = Uniform(low, high).rsample()
         u.backward(torch.ones_like(u))
         self.assertEqual(low.grad, 1 - rand)
@@ -2354,9 +2354,8 @@ class TestDistributions(DistributionsTestCase):
         self._gradcheck_log_prob(Cauchy, (loc, 1.0))
         self._gradcheck_log_prob(Cauchy, (0.0, scale))
 
-        state = torch.get_rng_state()
-        eps = loc.new(loc.size()).cauchy_()
-        torch.set_rng_state(state)
+        with freeze_rng_state():
+            eps = loc.new(loc.size()).cauchy_()
         c = Cauchy(loc, scale).rsample()
         c.backward(torch.ones_like(c))
         self.assertEqual(loc.grad, torch.ones_like(scale))
@@ -2383,9 +2382,8 @@ class TestDistributions(DistributionsTestCase):
         self._gradcheck_log_prob(HalfCauchy, (scale,))
         self._gradcheck_log_prob(HalfCauchy, (1.0,))
 
-        state = torch.get_rng_state()
-        eps = scale.new(scale.size()).cauchy_().abs_()
-        torch.set_rng_state(state)
+        with freeze_rng_state():
+            eps = scale.new(scale.size()).cauchy_().abs_()
         c = HalfCauchy(scale).rsample()
         c.backward(torch.ones_like(c))
         self.assertEqual(scale.grad, eps)
@@ -2769,9 +2767,8 @@ class TestDistributions(DistributionsTestCase):
         self._gradcheck_log_prob(Normal, (loc, 1.0))
         self._gradcheck_log_prob(Normal, (0.0, scale))
 
-        state = torch.get_rng_state()
-        eps = torch.normal(torch.zeros_like(loc), torch.ones_like(scale))
-        torch.set_rng_state(state)
+        with freeze_rng_state():
+            eps = torch.normal(torch.zeros_like(loc), torch.ones_like(scale))
         z = Normal(loc, scale).rsample()
         z.backward(torch.ones_like(z))
         self.assertEqual(loc.grad, torch.ones_like(loc))
@@ -3471,9 +3468,8 @@ class TestDistributions(DistributionsTestCase):
         self.assertEqual(Exponential(50.0).sample((1,)).size(), (1,))
 
         self._gradcheck_log_prob(Exponential, (rate,))
-        state = torch.get_rng_state()
-        eps = rate.new(rate.size()).exponential_()
-        torch.set_rng_state(state)
+        with freeze_rng_state():
+            eps = rate.new(rate.size()).exponential_()
         z = Exponential(rate).rsample()
         z.backward(torch.ones_like(z))
         self.assertEqual(rate.grad, -eps / rate**2)
@@ -3539,9 +3535,8 @@ class TestDistributions(DistributionsTestCase):
         self._gradcheck_log_prob(Laplace, (loc, 1.0))
         self._gradcheck_log_prob(Laplace, (0.0, scale))
 
-        state = torch.get_rng_state()
-        eps = torch.ones_like(loc).uniform_(-0.5, 0.5)
-        torch.set_rng_state(state)
+        with freeze_rng_state():
+            eps = torch.ones_like(loc).uniform_(-0.5, 0.5)
         z = Laplace(loc, scale).rsample()
         z.backward(torch.ones_like(z))
         self.assertEqual(loc.grad, torch.ones_like(loc))

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -119,6 +119,7 @@ from torch.testing._internal.common_device_type import (
     skipMPS,
 )
 from torch.testing._internal.common_utils import (
+    freeze_rng_state,
     gradcheck,
     load_tests,
     run_tests,
@@ -2299,9 +2300,8 @@ class TestDistributions(DistributionsTestCase):
         self._gradcheck_log_prob(Uniform, (low, 1.0))
         self._gradcheck_log_prob(Uniform, (0.0, high))
 
-        state = torch.get_rng_state()
-        rand = low.new(low.size()).uniform_()
-        torch.set_rng_state(state)
+        with freeze_rng_state():
+            rand = low.new(low.size()).uniform_()
         u = Uniform(low, high).rsample()
         u.backward(torch.ones_like(u))
         self.assertEqual(low.grad, 1 - rand)
@@ -2352,9 +2352,8 @@ class TestDistributions(DistributionsTestCase):
         self._gradcheck_log_prob(Cauchy, (loc, 1.0))
         self._gradcheck_log_prob(Cauchy, (0.0, scale))
 
-        state = torch.get_rng_state()
-        eps = loc.new(loc.size()).cauchy_()
-        torch.set_rng_state(state)
+        with freeze_rng_state():
+            eps = loc.new(loc.size()).cauchy_()
         c = Cauchy(loc, scale).rsample()
         c.backward(torch.ones_like(c))
         self.assertEqual(loc.grad, torch.ones_like(scale))
@@ -2381,9 +2380,8 @@ class TestDistributions(DistributionsTestCase):
         self._gradcheck_log_prob(HalfCauchy, (scale,))
         self._gradcheck_log_prob(HalfCauchy, (1.0,))
 
-        state = torch.get_rng_state()
-        eps = scale.new(scale.size()).cauchy_().abs_()
-        torch.set_rng_state(state)
+        with freeze_rng_state():
+            eps = scale.new(scale.size()).cauchy_().abs_()
         c = HalfCauchy(scale).rsample()
         c.backward(torch.ones_like(c))
         self.assertEqual(scale.grad, eps)
@@ -2767,9 +2765,8 @@ class TestDistributions(DistributionsTestCase):
         self._gradcheck_log_prob(Normal, (loc, 1.0))
         self._gradcheck_log_prob(Normal, (0.0, scale))
 
-        state = torch.get_rng_state()
-        eps = torch.normal(torch.zeros_like(loc), torch.ones_like(scale))
-        torch.set_rng_state(state)
+        with freeze_rng_state():
+            eps = torch.normal(torch.zeros_like(loc), torch.ones_like(scale))
         z = Normal(loc, scale).rsample()
         z.backward(torch.ones_like(z))
         self.assertEqual(loc.grad, torch.ones_like(loc))
@@ -3470,9 +3467,8 @@ class TestDistributions(DistributionsTestCase):
         self.assertEqual(Exponential(50.0).sample((1,)).size(), (1,))
 
         self._gradcheck_log_prob(Exponential, (rate,))
-        state = torch.get_rng_state()
-        eps = rate.new(rate.size()).exponential_()
-        torch.set_rng_state(state)
+        with freeze_rng_state():
+            eps = rate.new(rate.size()).exponential_()
         z = Exponential(rate).rsample()
         z.backward(torch.ones_like(z))
         self.assertEqual(rate.grad, -eps / rate**2)
@@ -3538,9 +3534,8 @@ class TestDistributions(DistributionsTestCase):
         self._gradcheck_log_prob(Laplace, (loc, 1.0))
         self._gradcheck_log_prob(Laplace, (0.0, scale))
 
-        state = torch.get_rng_state()
-        eps = torch.ones_like(loc).uniform_(-0.5, 0.5)
-        torch.set_rng_state(state)
+        with freeze_rng_state():
+            eps = torch.ones_like(loc).uniform_(-0.5, 0.5)
         z = Laplace(loc, scale).rsample()
         z.backward(torch.ones_like(z))
         self.assertEqual(loc.grad, torch.ones_like(loc))

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -2612,13 +2612,12 @@ class TestDistributions(DistributionsTestCase):
             ref_dist.rvs = self._get_logistic_normal_ref_sampler(base_dist)
             mean_th = torch.tensor(mean)
             std_th = torch.tensor(np.sqrt(np.diag(cov)))
-            with freeze_rng_state():
-                self._check_sampler_sampler(
-                    LogisticNormal(mean_th, std_th),
-                    ref_dist,
-                    f"LogisticNormal(loc={mean_th}, scale={std_th})",
-                    multivariate=True,
-                )
+            self._check_sampler_sampler(
+                LogisticNormal(mean_th, std_th),
+                ref_dist,
+                f"LogisticNormal(loc={mean_th}, scale={std_th})",
+                multivariate=True,
+            )
 
     def test_mixture_same_family_shape(self):
         normal_case_1d = MixtureSameFamily(

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -2612,12 +2612,13 @@ class TestDistributions(DistributionsTestCase):
             ref_dist.rvs = self._get_logistic_normal_ref_sampler(base_dist)
             mean_th = torch.tensor(mean)
             std_th = torch.tensor(np.sqrt(np.diag(cov)))
-            self._check_sampler_sampler(
-                LogisticNormal(mean_th, std_th),
-                ref_dist,
-                f"LogisticNormal(loc={mean_th}, scale={std_th})",
-                multivariate=True,
-            )
+            with freeze_rng_state():
+                self._check_sampler_sampler(
+                    LogisticNormal(mean_th, std_th),
+                    ref_dist,
+                    f"LogisticNormal(loc={mean_th}, scale={std_th})",
+                    multivariate=True,
+                )
 
     def test_mixture_same_family_shape(self):
         normal_case_1d = MixtureSameFamily(


### PR DESCRIPTION
Fixes:
https://github.com/intel/torch-xpu-ops/issues/4020

`torch.get_rng_state()` only saves/restores CPU RNG state. On XPU/CUDA, `rsample()` draws from the device RNG, which is not restored, so `eps` and `rsample()` consume different random numbers and the gradient assertion fails.

`freeze_rng_state()` correctly freezes RNG state across all backends, fixing 6 tests: test_uniform, test_cauchy, test_halfcauchy, test_normal, test_exponential, test_laplace on XPU/CUDA.

This follows review feedback on PR #188079 to leverage existing PyTorch test utilities.