### PR TITLE
[dynamo, 3.15] Fix test_bytecode_utils

### DIFF
--- a/test/dynamo/test_bytecode_utils.py
+++ b/test/dynamo/test_bytecode_utils.py
@@ -33,10 +33,7 @@ class BytecodeTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(len(l1), len(l2))
         for p1, p2 in zip(l1, l2):
             self.assertEqual(p1, p2)
-        # TODO co_lnotab is deprecated in 3.12 and will be removed in 3.14
-        # In 3.11+,. it is computed lazily from other linetable attributes (e.g. co_linetable),
-        # so we do not set this attribute ourselves.
-        self.assertEqual(fn.__code__.co_lnotab, result[1].co_lnotab)
+        self.assertEqual(list(fn.__code__.co_lines()), list(result[1].co_lines()))
 
     @skipIfNotPy311
     def test_linetable_311_writer2(self):
@@ -77,7 +74,7 @@ def fn():
         self.assertEqual(len(l1), len(l2))
         for p1, p2 in zip(l1, l2):
             self.assertEqual(p1, p2)
-        self.assertEqual(fn.__code__.co_lnotab, result[1].co_lnotab)
+        self.assertEqual(list(fn.__code__.co_lines()), list(result[1].co_lines()))
 
     @unittest.skipIf(
         sys.version_info >= (3, 11),
@@ -412,7 +409,7 @@ def fn():
             self.assertIsNone(inst.starts_line)
             if inst.opname.startswith("LOAD"):
                 self.assertNotIn(inst.argval, varname_map)
-                if inst.opname not in ("LOAD_GLOBAL", "LOAD_ATTR"):
+                if inst.opname not in ("LOAD_GLOBAL", "LOAD_ATTR", "LOAD_COMMON_CONSTANT"):
                     self.assertIsNone(inst.arg)
             self.assertFalse(inst.opname.startswith("RETURN"))
 

--- a/test/dynamo/test_bytecode_utils.py
+++ b/test/dynamo/test_bytecode_utils.py
@@ -409,7 +409,11 @@ def fn():
             self.assertIsNone(inst.starts_line)
             if inst.opname.startswith("LOAD"):
                 self.assertNotIn(inst.argval, varname_map)
-                if inst.opname not in ("LOAD_GLOBAL", "LOAD_ATTR", "LOAD_COMMON_CONSTANT"):
+                if inst.opname not in (
+                    "LOAD_GLOBAL",
+                    "LOAD_ATTR",
+                    "LOAD_COMMON_CONSTANT",
+                ):
                     self.assertIsNone(inst.arg)
             self.assertFalse(inst.opname.startswith("RETURN"))
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #178393
* #179094
* #188029
* #187631
* __->__ #189306

Two changes to update this for 3.15
- co_lnotab has been deprecated since 3.10, and was removed in 3.15.  It was replaced by co_lines, which we can use
instead
- LOAD_COMMON_CONSTANT can load None in 3.15, so is now used for functions that return None.  We don't clear its arg, so
add it as an exception for that check.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98