### PR TITLE
[CI/CD] Copy newer CUPTI headers into manywheel binary-build images

### DIFF
--- a/.ci/docker/common/install_cuda.sh
+++ b/.ci/docker/common/install_cuda.sh
@@ -87,8 +87,11 @@ function install_cupti_headers {
   target_dir="/usr/local/cupti-headers-${major_minor}"
 
   # The CUDA toolkit runfile ships an older CUPTI than the standalone redist
-  # archive, so stage the newer headers where the build can pick them up. The
-  # headers are architecture independent, so always grab the x86_64 archive.
+  # archive, so stage the newer headers in a non-default location where they are
+  # available for inspection without poisoning the build's include search path.
+  # Staged for every CUDA version so the binary-build Dockerfiles can COPY the
+  # directory unconditionally. The headers are architecture independent, so
+  # always grab the x86_64 archive.
   redist_url="https://developer.download.nvidia.com/compute/cuda/redist/cuda_cupti/linux-x86_64"
   archive="cuda_cupti-linux-x86_64-${cupti_version}-archive"
 
@@ -186,8 +189,6 @@ function install_130 {
 
   install_nvshmem 13 $NVSHMEM_VERSION
 
-  install_cupti_headers $CUDA_CUPTI_VERSION
-
   CUDA_VERSION=13.0 bash install_nccl.sh
 
   CUDA_VERSION=13.0 bash install_cusparselt.sh $CUSPARSELT_VERSION
@@ -206,8 +207,6 @@ function install_132 {
   install_cudnn 13 $CUDNN_VERSION
 
   install_nvshmem 13 $NVSHMEM_VERSION
-
-  install_cupti_headers $CUDA_CUPTI_VERSION
 
   CUDA_VERSION=13.2 bash install_nccl.sh
 
@@ -235,5 +234,6 @@ do
     *) echo "bad argument $1"; exit 1
         ;;
     esac
+    install_cupti_headers $CUDA_CUPTI_VERSION
     shift
 done

--- a/.ci/docker/manywheel/Dockerfile_2_28
+++ b/.ci/docker/manywheel/Dockerfile_2_28
@@ -137,6 +137,8 @@ FROM cpu_final as cuda_final
 RUN rm -rf /usr/local/cuda-${BASE_CUDA_VERSION}
 COPY --from=cuda     /usr/local/cuda-${BASE_CUDA_VERSION}  /usr/local/cuda-${BASE_CUDA_VERSION}
 COPY --from=magma    /usr/local/cuda-${BASE_CUDA_VERSION}  /usr/local/cuda-${BASE_CUDA_VERSION}
+# Newer CUPTI headers staged outside the default include path (see CUDA_CUPTI_VERSION in install_cuda.sh)
+COPY --from=cuda     /usr/local/cupti-headers-13.3         /usr/local/cupti-headers-13.3
 RUN ln -sf /usr/local/cuda-${BASE_CUDA_VERSION} /usr/local/cuda
 ENV PATH=/usr/local/cuda/bin:$PATH
 

--- a/.ci/docker/manywheel/Dockerfile_cuda_aarch64
+++ b/.ci/docker/manywheel/Dockerfile_cuda_aarch64
@@ -96,6 +96,8 @@ ARG BASE_CUDA_VERSION
 RUN rm -rf /usr/local/cuda-${BASE_CUDA_VERSION}
 COPY --from=cuda     /usr/local/cuda-${BASE_CUDA_VERSION}  /usr/local/cuda-${BASE_CUDA_VERSION}
 COPY --from=magma    /usr/local/cuda-${BASE_CUDA_VERSION}  /usr/local/cuda-${BASE_CUDA_VERSION}
+# Newer CUPTI headers staged outside the default include path (see CUDA_CUPTI_VERSION in install_cuda.sh)
+COPY --from=cuda     /usr/local/cupti-headers-13.3         /usr/local/cupti-headers-13.3
 COPY --from=nvpl /opt/nvpl/lib/  /usr/local/lib/
 COPY --from=nvpl /opt/nvpl/include/  /usr/local/include/
 COPY --from=arm_compute /acl /acl


### PR DESCRIPTION
#189214 added `install_cupti_headers`, which stages the newer standalone CUPTI redist headers into `/usr/local/cupti-headers-<major.minor>` for the CUDA-13 build containers. However, the manywheel binary-build images only COPY `/usr/local/cuda-<ver>` out of the `cuda` build stage, so the staged headers never reach the final binary-build images.

This copies `/usr/local/cupti-headers-13.3` into the `cuda_final` stages of `Dockerfile_2_28` and `Dockerfile_cuda_aarch64`. The headers are available for python-side inspection.

Since the Dockerfile COPY is unconditional, the source directory must exist for every CUDA version. `install_cupti_headers` was therefore moved into the argument loop so it runs for all versions (including 12.x); 

Touching `.ci/docker/` re-hashes the images, so CI will rebuild them and exercise the new `COPY` steps end-to-end.

Authored-with: Claude Opus 4.8 (Claude Code)