### PR TITLE
[CUDA][cuBLAS] Change cuBLAS default workspace size for SM 11.0 to 32 MiB 

### DIFF
--- a/aten/src/ATen/cuda/CublasHandlePool.cpp
+++ b/aten/src/ATen/cuda/CublasHandlePool.cpp
@@ -178,7 +178,9 @@ size_t parseChosenWorkspaceSize() {
 #else
   /* :4096:2:16:8 default, 32MiB for Hopper and Blackwell */
   cudaDeviceProp* properties = at::cuda::getCurrentDeviceProperties();
-  const bool use32mb = properties != nullptr && (properties->major == 9 || properties->major == 10 || properties->major == 12);
+  const bool use32mb = properties != nullptr &&
+      (properties->major == 9 || properties->major == 10 ||
+       properties->major == 11 || properties->major == 12);
   const size_t default_size = use32mb ? 4096 * 8 * 1024 : 4096 * 1024 * 2 + 16 * 1024 * 8;
 #endif
 

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -9061,6 +9061,24 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
         n = 50_000
         A = torch.ones(n, n, dtype=dtype, device=device)
         B = torch.randn(n, dtype=dtype, device=device)
+
+        if (
+            torch.device(device).type == "cuda"
+            and dtype == torch.float32
+            and not TEST_WITH_ROCM
+            and torch.cuda.get_device_capability(device) == (11, 0)
+        ):
+            # Remove this sentinel when zero-workspace cublasSgemv works on SM 11.0.
+            previous_workspace_size = torch.backends.cuda.cublas_workspace_size()
+            cublas_error = "CUBLAS_STATUS_NOT_SUPPORTED.*cublasSgemv"
+            try:
+                torch.backends.cuda.cublas_workspace_size(0)
+                with self.assertRaisesRegex(RuntimeError, cublas_error):
+                    torch.matmul(A, B)
+            finally:
+                torch.backends.cuda.cublas_workspace_size(previous_workspace_size)
+                torch._C._cuda_clearCublasWorkspaces()
+
         C = torch.matmul(A, B)
 
         # Sanity Checks


### PR DESCRIPTION
Thor is closest to datacenter blackwell, and current defaults cause `CUBLAS_STATUS_NOT_SUPPORTED` in e.g., 

```
python test/test_linalg.py TestLinalgCUDA.test_matmul_mv_cuda_float32
```

I assume there are basically internal users of SM 11.0 that would complain? CC @ngimel 


authored with codex

cc @ptrblck @msaroufim @tinglvv @nWEIdia @csarofeen