### PR TITLE
flex_gemm: recognize 2-D block local-reduce contracts

### DIFF
--- a/test/inductor/test_flex_gemm.py
+++ b/test/inductor/test_flex_gemm.py
@@ -1102,6 +1102,91 @@ class TestFlexGemmRuntime(FlexGemmTestCase):
             ),
         )
 
+    def test_block_local_reduce_geometry_and_compressed_shape(self):
+        from torch._inductor.kernel.flex_gemm.constraints import (
+            FlexGemmBlockLocalReduceGeometry,
+            local_reduce_block_compressed_shape,
+        )
+
+        with self.assertRaisesRegex(
+            RuntimeError, "local_reduce_group must be positive"
+        ):
+            FlexGemmBlockLocalReduceGeometry(0, 128)
+        with self.assertRaisesRegex(
+            RuntimeError, "local_reduce_group must be positive"
+        ):
+            FlexGemmBlockLocalReduceGeometry(128, -1)
+        self.assertEqual(
+            local_reduce_block_compressed_shape((256, 256), 128, 128), (2, 2)
+        )
+        self.assertEqual(local_reduce_block_compressed_shape((64, 128), 16, 32), (4, 4))
+        with self.assertRaisesRegex(RuntimeError, "must divide"):
+            local_reduce_block_compressed_shape((256, 192), 128, 128)
+        with self.assertRaisesRegex(RuntimeError, "must divide"):
+            local_reduce_block_compressed_shape((192, 256), 128, 128)
+
+    def test_block_local_reduce_plans_reject_kernel_frontier(self):
+        from torch._inductor.kernel.flex_gemm.constraints import (
+            FlexGemmBlockLocalReduceGeometry,
+        )
+        from torch._inductor.kernel.flex_gemm.epilogue import (
+            FlexGemmBlockLocalReduceContract,
+            FlexGemmOutputPlan,
+        )
+        from torch._inductor.kernel.flex_gemm.runtime import (
+            FlexGemmRuntimeLocalReducePlan,
+        )
+        from torch._inductor.kernel.flex_gemm.template import (
+            FlexGemmEpilogueLocalReduceConfig,
+        )
+
+        geometry = FlexGemmBlockLocalReduceGeometry(128, 128)
+        with self.assertRaisesRegex(RuntimeError, "tensor nodes"):
+            FlexGemmBlockLocalReduceContract(object(), geometry)
+
+        graph = torch.fx.Graph()
+        node = graph.placeholder("x")
+        aux = graph.placeholder("aux")
+        plan = FlexGemmBlockLocalReduceContract(aux, geometry).to_plan(
+            store_node=aux, feeds_main=False
+        )
+        self.assertEqual(plan.geometry, geometry)
+        self.assertFalse(plan.feeds_main)
+        FlexGemmOutputPlan(node, (), plan, local_reduce_aux_index=0)
+        self.assertIs(
+            FlexGemmEpilogueLocalReduceConfig.from_output_plan(plan, 0).geometry,
+            geometry,
+        )
+        with self.assertRaisesRegex(
+            NotImplementedError, "not supported by the QUACK kernel yet"
+        ):
+            FlexGemmRuntimeLocalReducePlan(geometry, out=torch.empty(2, 2))
+
+    def test_output_plan_classifies_block_local_reduce_contract(self):
+        from torch._inductor.kernel.flex_gemm.constraints import (
+            FlexGemmBlockLocalReduceGeometry,
+        )
+        from torch._inductor.kernel.flex_gemm.epilogue import output_plan
+        from torch.fx.experimental.proxy_tensor import make_fx
+
+        def body(a, b):
+            acc = torch.mm(a, b)
+            x = acc.view(2, 128, 2, 128)
+            return acc, x.abs().amax((1, 3))
+
+        graph_module = make_fx(body, tracing_mode="fake")(
+            torch.randn(256, 64), torch.randn(64, 256)
+        )
+        plan = output_plan(graph_module)
+        self.assertIsNotNone(plan.local_reduce)
+        self.assertEqual(
+            plan.local_reduce.geometry, FlexGemmBlockLocalReduceGeometry(128, 128)
+        )
+        self.assertEqual(plan.local_reduce_aux_index, 0)
+        self.assertEqual(plan.aux_outputs, ())
+        self.assertFalse(plan.local_reduce.feeds_main)
+        self.assertIsNotNone(plan.local_reduce.store_node)
+
     def test_local_reduce_feed_main_binary_candidates_support_method_nodes(self):
         from torch._inductor.kernel.flex_gemm.epilogue import (
             local_reduce_feed_main_binary_candidates,
@@ -2366,7 +2451,7 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
                     acc.float().view(-1, 4, 2, 4).sum((1, 3)),
                 ),
                 (4, 8),
-                "local-reduce output contract",
+                "2-D block local reductions are not supported by the QUACK kernel yet",
             ),
         ),
         name_fn=lambda case: case[0],
@@ -2387,6 +2472,114 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
         b = torch.randn(8, n)
 
         with self.assertRaisesRegex(Exception, error):
+            torch.compile(fn, backend="inductor", fullgraph=True)(a, b)
+
+    @parametrize(
+        "case",
+        (
+            ("amax", lambda x: x.abs().amax((1, 3))),
+            ("amax_negative_dims", lambda x: x.abs().amax((-1, -3))),
+            ("sum", lambda x: x.sum((1, 3))),
+            ("mean", lambda x: x.mean((1, 3))),
+            ("mx_e8m0_scale", lambda x: mx_e8m0_scale(x.abs().amax((1, 3)))),
+        ),
+        name_fn=lambda case: case[0],
+    )
+    def test_generated_block_local_reduce_rejects_kernel_frontier(self, case):
+        _, reduce_fn = case
+        m = n = 256
+        block = 128
+
+        def fn(a, b):
+            def epilogue(acc):
+                x = acc.float().view(m // block, block, n // block, block)
+                return acc.relu(), reduce_fn(x)
+
+            return flex_gemm(
+                torch.mm,
+                (a, b),
+                epilogue,
+                kernel_options={"backend": "QUACK"},
+            )
+
+        a = torch.randn(m, 64)
+        b = torch.randn(64, n)
+
+        with self.assertRaisesRegex(
+            Exception,
+            "2-D block local reductions are not supported by the QUACK kernel yet",
+        ):
+            torch.compile(fn, backend="inductor", fullgraph=True)(a, b)
+
+    def test_generated_block_local_reduce_rejects_non_divisible_shape(self):
+        m, n = 256, 192
+
+        def fn(a, b):
+            def epilogue(acc):
+                x = acc.float().view(-1, 128, 1, 128)
+                return acc.relu(), x.abs().amax((1, 3))
+
+            return flex_gemm(
+                torch.mm,
+                (a, b),
+                epilogue,
+                kernel_options={"backend": "QUACK"},
+            )
+
+        a = torch.randn(m, 64)
+        b = torch.randn(64, n)
+
+        with self.assertRaisesRegex(Exception, "must divide"):
+            torch.compile(fn, backend="inductor", fullgraph=True)(a, b)
+
+    @parametrize("dim", (1, 3))
+    def test_generated_block_view_single_dim_reduce_keeps_aux_shape_error(self, dim):
+        m = n = 256
+
+        def fn(a, b):
+            def epilogue(acc):
+                x = acc.float().view(2, 128, 2, 128)
+                return acc.relu(), x.abs().amax(dim)
+
+            return flex_gemm(
+                torch.mm,
+                (a, b),
+                epilogue,
+                kernel_options={"backend": "QUACK"},
+            )
+
+        a = torch.randn(m, 64)
+        b = torch.randn(64, n)
+
+        with self.assertRaisesRegex(
+            Exception, "does not support this aux output shape yet"
+        ):
+            torch.compile(fn, backend="inductor", fullgraph=True)(a, b)
+
+    def test_generated_block_transpose_reduce_keeps_partial_output_error(self):
+        m = n = 256
+
+        def fn(a, b):
+            def epilogue(acc):
+                x = (
+                    acc.float()
+                    .reshape(2, 128, 2, 128)
+                    .transpose(1, 2)
+                    .reshape(2, 2, 128 * 128)
+                )
+                return acc.relu(), x.abs().amax(-1)
+
+            return flex_gemm(
+                torch.mm,
+                (a, b),
+                epilogue,
+                kernel_options={"backend": "QUACK"},
+            )
+
+        a = torch.randn(m, 64)
+        b = torch.randn(64, n)
+
+        with self.assertRaisesRegex(Exception, "partial-output contract"):
             torch.compile(fn, backend="inductor", fullgraph=True)(a, b)
 
     def test_generated_local_reduce_rejects_mixed_row_column_grouping(self):

--- a/torch/_inductor/kernel/flex_gemm/constraints.py
+++ b/torch/_inductor/kernel/flex_gemm/constraints.py
@@ -26,6 +26,16 @@ def grouped_reduce_dims_match(dim: Any, reduce_dims: Sequence[Any]) -> bool:
     return len(dims) == 1 and dims[0] in reduce_dims
 
 
+def grouped_block_reduce_dims_match(dim: Any) -> bool:
+    """Treat equivalent two-dim spellings of a ``(M//bm, bm, N//bn, bn)`` view's
+    grouped dims (1 and 3, negatives included) as one block reduction domain."""
+    if not isinstance(dim, (list, tuple)) or len(dim) != 2:
+        return False
+    if not all(isinstance(item, int) for item in dim):
+        return False
+    return sorted(item % 4 for item in dim) == [1, 3]
+
+
 # The physical feed-main path currently reduces only within one lane-layout M
 # group; cross-warp M stitching needs the two-phase/replay path used by
 # compressed aux reductions. Axis-1 feeds whose groups fit in one TensorSSA
@@ -115,6 +125,9 @@ LOCAL_REDUCE_EXPLICIT_DTYPE_ERROR = (
 LOCAL_REDUCE_INNERMOST_GROUPED_DIM_ERROR = (
     "FlexGEMM local reductions currently support only reductions over the "
     "innermost grouped dimension"
+)
+LOCAL_REDUCE_BLOCK_KERNEL_ERROR = (
+    "FlexGEMM 2-D block local reductions are not supported by the QUACK kernel yet"
 )
 LOCAL_REDUCE_GROUPED_RESHAPE_ERROR = (
     "FlexGEMM local-reduce grouped reshape must split exactly one GEMM output dimension"
@@ -314,6 +327,21 @@ def local_reduce_compressed_shape(
     return tuple(result)
 
 
+def validate_local_reduce_block_groups(group_m: int, group_n: int) -> None:
+    """Keep block local-reduce specs inside the GEMM tile's M x N blocking model."""
+    if group_m <= 0 or group_n <= 0:
+        raise RuntimeError(LOCAL_REDUCE_GROUP_POSITIVE_ERROR)
+
+
+def local_reduce_block_compressed_shape(
+    shape: Sequence[Any], group_m: int, group_n: int
+) -> tuple[Any, ...]:
+    """Compute the explicit aux shape holding one value per bm x bn block."""
+    return local_reduce_compressed_shape(
+        local_reduce_compressed_shape(shape, group_m, 0), group_n, 1
+    )
+
+
 def validate_local_reduce_no_c_alpha_beta(
     effective_C: Any | None, alpha: float, beta: float
 ) -> None:
@@ -434,6 +462,23 @@ class FlexGemmLocalReduceGeometry:
     @property
     def needs_physical_callbacks(self) -> bool:
         return local_reduce_needs_physical_callbacks(self.axis, self.group)
+
+
+@dataclasses.dataclass(frozen=True)
+class FlexGemmBlockLocalReduceGeometry:
+    """Describe the 2-D bm x bn output blocking shared by local-reduce consumers.
+
+    Attributes:
+        group_m: Number of contiguous M elements in each block.
+        group_n: Number of contiguous N elements in each block.
+    """
+
+    group_m: int
+    group_n: int
+
+    def __post_init__(self) -> None:
+        """Reject geometry outside the GEMM tile's M x N blocking model."""
+        validate_local_reduce_block_groups(self.group_m, self.group_n)
 
 
 @dataclasses.dataclass(frozen=True)

--- a/torch/_inductor/kernel/flex_gemm/epilogue.py
+++ b/torch/_inductor/kernel/flex_gemm/epilogue.py
@@ -14,9 +14,12 @@ from torch._inductor.codegen.cutedsl.cutedsl_op_overrides import (
 from torch._inductor.kernel.flex_gemm.constraints import (
     FLEX_GEMM_OUTPUT_PLAN_NODE_ERROR,
     FLEX_GEMM_OUTPUT_TENSOR_ERROR,
+    FlexGemmBlockLocalReduceGeometry,
     FlexGemmLocalReduceGeometry,
+    grouped_block_reduce_dims_match,
     grouped_reduce_dims_match,
     LOCAL_REDUCE_AUX_TENSORSSA_ERROR,
+    local_reduce_block_compressed_shape,
     LOCAL_REDUCE_COMBINE_FN_SUFFIX,
     local_reduce_compressed_shape,
     LOCAL_REDUCE_CONTRACT_NODE_ERROR,
@@ -45,6 +48,7 @@ from torch._inductor.kernel.flex_gemm.quack_reductions import (
     _cute_call,
     _local_reduce_store_arg,
     FlexGemmPhysicalReduction,
+    grouped_block_tensor_layout,
     grouped_tensor_layout,
     GroupedTensorSSAInfo,
     has_local_reduce_store_source,
@@ -56,6 +60,7 @@ from torch._inductor.kernel.flex_gemm.quack_reductions import (
     lower_squeeze,
     lower_tensorssa_reduce,
     lower_view_or_reshape,
+    propagate_block_grouped_geometry,
     propagate_grouped_tensorssa_info,
     reduction_from_node,
     reduction_requires_physical_finalize,
@@ -151,7 +156,7 @@ class FlexGemmCuteDSLOpOverrides(CuteDSLOpOverrides):
 class FlexGemmOutputLocalReducePlan:
     """Bind one local-reduce value to store and/or feed consumers."""
 
-    geometry: FlexGemmLocalReduceGeometry
+    geometry: FlexGemmLocalReduceGeometry | FlexGemmBlockLocalReduceGeometry
     value_node: torch.fx.Node
     store_node: torch.fx.Node | None = None
     feeds_main: bool = False
@@ -219,12 +224,45 @@ class FlexGemmLocalReduceContract:
     ) -> FlexGemmOutputLocalReducePlan:
         """Bind this reduction value to the requested local-reduce consumers."""
         return FlexGemmOutputLocalReducePlan(
-            FlexGemmLocalReduceGeometry(self.group, self.axis),
+            self.geometry,
             self.aux,
             store_node=store_node,
             feeds_main=feeds_main,
             requires_physical_finalize=self.requires_physical_finalize,
         )
+
+    @property
+    def geometry(self) -> FlexGemmLocalReduceGeometry:
+        return FlexGemmLocalReduceGeometry(self.group, self.axis)
+
+
+@dataclasses.dataclass(frozen=True)
+class FlexGemmBlockLocalReduceContract:
+    """Bind one reduced value per bm x bn output block to its producing node."""
+
+    aux: torch.fx.Node
+    geometry: FlexGemmBlockLocalReduceGeometry
+
+    def __post_init__(self) -> None:
+        """Reject invalid block local-reduce source nodes."""
+        if not isinstance(self.aux, torch.fx.Node):
+            raise RuntimeError(LOCAL_REDUCE_CONTRACT_NODE_ERROR)
+
+    def to_plan(
+        self, *, store_node: torch.fx.Node | None, feeds_main: bool
+    ) -> FlexGemmOutputLocalReducePlan:
+        """Bind this block reduction value to the requested local-reduce consumers."""
+        return FlexGemmOutputLocalReducePlan(
+            self.geometry,
+            self.aux,
+            store_node=store_node,
+            feeds_main=feeds_main,
+        )
+
+
+FlexGemmAnyLocalReduceContract = (
+    FlexGemmLocalReduceContract | FlexGemmBlockLocalReduceContract
+)
 
 
 @dataclasses.dataclass
@@ -234,24 +272,31 @@ class FlexGemmLocalReduceAnalysis:
     grouped_tensors: dict[torch.fx.Node, GroupedTensorSSAInfo] = dataclasses.field(
         default_factory=dict
     )
-    contracts: dict[torch.fx.Node, FlexGemmLocalReduceContract] = dataclasses.field(
+    block_grouped_tensors: dict[torch.fx.Node, FlexGemmBlockLocalReduceGeometry] = (
+        dataclasses.field(default_factory=dict)
+    )
+    contracts: dict[torch.fx.Node, FlexGemmAnyLocalReduceContract] = dataclasses.field(
         default_factory=dict
     )
 
     def bind_grouped_layout(self, node: torch.fx.Node, shape: Any, source: Any) -> bool:
         """Record reshapes that introduce grouped TensorSSA provenance."""
-        source_shape = (
-            tensor_meta_shape(source) if isinstance(source, torch.fx.Node) else None
-        )
+        if not isinstance(source, torch.fx.Node):
+            return False
+        source_shape = tensor_meta_shape(source)
+        block_geometry = grouped_block_tensor_layout(shape, source_shape)
+        if block_geometry is not None:
+            self.block_grouped_tensors[node] = block_geometry
+            return True
         layout = grouped_tensor_layout(shape, source_shape)
-        if layout is None or not isinstance(source, torch.fx.Node):
+        if layout is None:
             return False
         validate_local_reduce_tensorssa_group_size(layout.axis, layout.group_size)
         self.grouped_tensors[node] = GroupedTensorSSAInfo(layout)
         return True
 
     def bind_contract(
-        self, node: torch.fx.Node, contract: FlexGemmLocalReduceContract | None
+        self, node: torch.fx.Node, contract: FlexGemmAnyLocalReduceContract | None
     ) -> bool:
         """Record a discovered local-reduce contract and report whether it matched."""
         if contract is None:
@@ -291,15 +336,38 @@ class FlexGemmLocalReduceAnalysis:
             ),
         )
 
+    def bind_block_grouped_reduction(
+        self, node: torch.fx.Node, input_node: Any, dim: Any, dtype: Any = None
+    ) -> bool:
+        """Match reductions covering exactly both grouped block dims and bind them.
+
+        Mismatched dims fall through without raising so single-dim reductions
+        over 4-D block views keep their existing rejection behavior downstream.
+        """
+        if not isinstance(input_node, torch.fx.Node):
+            return False
+        geometry = self.block_grouped_tensors.get(input_node)
+        if geometry is None or not grouped_block_reduce_dims_match(dim):
+            return False
+        if dtype is not None:
+            raise NotImplementedError(LOCAL_REDUCE_EXPLICIT_DTYPE_ERROR)
+        return self.bind_contract(
+            node, FlexGemmBlockLocalReduceContract(node, geometry)
+        )
+
     def has_grouped_tensor(self, value: Any) -> bool:
         """Return whether a value currently has grouped TensorSSA provenance."""
         return isinstance(value, torch.fx.Node) and value in self.grouped_tensors
 
-    def contract_for(self, node: torch.fx.Node) -> FlexGemmLocalReduceContract | None:
+    def contract_for(
+        self, node: torch.fx.Node
+    ) -> FlexGemmAnyLocalReduceContract | None:
         """Return the discovered local-reduce contract for a node, if any."""
         return self.contracts.get(node)
 
-    def contracts_from_inputs(self, *values: Any) -> list[FlexGemmLocalReduceContract]:
+    def contracts_from_inputs(
+        self, *values: Any
+    ) -> list[FlexGemmAnyLocalReduceContract]:
         """Collect known contracts from FX inputs for pointwise propagation."""
         return [
             self.contracts[arg]
@@ -314,14 +382,17 @@ class FlexGemmLocalReduceAnalysis:
         grouped_info = propagate_grouped_tensorssa_info(node, self.grouped_tensors)
         if grouped_info is not None:
             self.grouped_tensors[node] = grouped_info
+        block_geometry = propagate_block_grouped_geometry(
+            node, self.block_grouped_tensors
+        )
+        if block_geometry is not None:
+            self.block_grouped_tensors[node] = block_geometry
         contract = common_local_reduce_contract(
             self.contracts_from_inputs(node.args, node.kwargs), mixed_contract_error
         )
         if contract is None:
             return False
-        self.contracts[node] = FlexGemmLocalReduceContract(
-            node, contract.group, contract.axis, contract.requires_physical_finalize
-        )
+        self.contracts[node] = dataclasses.replace(contract, aux=node)
         return True
 
 
@@ -349,24 +420,22 @@ def fx_node_depends_on(
 
 
 def common_local_reduce_contract(
-    contracts: list[FlexGemmLocalReduceContract],
+    contracts: list[FlexGemmAnyLocalReduceContract],
     mixed_contract_error: str,
-) -> FlexGemmLocalReduceContract | None:
+) -> FlexGemmAnyLocalReduceContract | None:
     """Merge contracts that share one grouped reduction layout."""
     if not contracts:
         return None
     contract = contracts[0]
-    if any(
-        item.group != contract.group or item.axis != contract.axis for item in contracts
-    ):
+    if any(item.geometry != contract.geometry for item in contracts):
         raise NotImplementedError(mixed_contract_error)
     return contract
 
 
 def common_local_reduce_value_contract(
-    contracts: list[FlexGemmLocalReduceContract],
+    contracts: list[FlexGemmAnyLocalReduceContract],
     mixed_contract_error: str,
-) -> FlexGemmLocalReduceContract | None:
+) -> FlexGemmAnyLocalReduceContract | None:
     """Merge contracts for one reusable physical reduction value."""
     contract = common_local_reduce_contract(contracts, mixed_contract_error)
     if contract is None:
@@ -794,6 +863,8 @@ def local_reduce_analysis(
             input_node, dim, _, dtype, _ = reduction
             if analysis.bind_grouped_reduction(node, input_node, dim, dtype):
                 continue
+            if analysis.bind_block_grouped_reduction(node, input_node, dim, dtype):
+                continue
         if (
             node.op == "call_function"
             and node.target is inductor_prims.prepare_softmax_online
@@ -843,9 +914,15 @@ def local_reduce_compressed_aux_plan(
     aux_meta = aux.meta.get("val")
     if contract is None or aux_meta is None or output_meta is None:
         return None
-    expected_aux_shape = local_reduce_compressed_shape(
-        output_meta.shape, contract.group, contract.axis
-    )
+    match contract:
+        case FlexGemmBlockLocalReduceContract(geometry=geometry):
+            expected_aux_shape = local_reduce_block_compressed_shape(
+                output_meta.shape, geometry.group_m, geometry.group_n
+            )
+        case _:
+            expected_aux_shape = local_reduce_compressed_shape(
+                output_meta.shape, contract.group, contract.axis
+            )
     if not statically_known_shape_equal(expected_aux_shape, aux_meta.shape):
         return None
     return contract.to_plan(store_node=aux, feeds_main=False)

--- a/torch/_inductor/kernel/flex_gemm/lowering.py
+++ b/torch/_inductor/kernel/flex_gemm/lowering.py
@@ -17,9 +17,11 @@ from ...ir import IRNode, TensorBox
 from ...lowering import empty_strided, process_subgraph_nodes, register_lowering
 from .constraints import (
     flex_gemm_local_reduce_config_error,
+    FlexGemmBlockLocalReduceGeometry,
     is_flex_gemm_partial_reduction_shape,
     LOCAL_REDUCE_AUX_METADATA_ERROR,
     LOCAL_REDUCE_AUX_OUTPUT_CONTRACT_ERROR,
+    LOCAL_REDUCE_BLOCK_KERNEL_ERROR,
     LOCAL_REDUCE_DENSE_MM_SCOPE_ERROR,
     LOCAL_REDUCE_PARTIAL_OUTPUT_CONTRACT_ERROR,
     statically_known_shape_equal,
@@ -169,7 +171,11 @@ def flex_gemm_local_reduce_metas(
 ) -> tuple[Any, ...]:
     """Return local-reduce output metadata after validating consumer compatibility."""
     validate_flex_gemm_local_reduce_scope(gemm_op, local_reduce)
-    if local_reduce is None or local_reduce.store_node is None:
+    if local_reduce is None:
+        return ()
+    if isinstance(local_reduce.geometry, FlexGemmBlockLocalReduceGeometry):
+        raise NotImplementedError(LOCAL_REDUCE_BLOCK_KERNEL_ERROR)
+    if local_reduce.store_node is None:
         return ()
     local_reduce_meta = local_reduce.store_node.meta.get("val")
     if local_reduce_meta is None:

--- a/torch/_inductor/kernel/flex_gemm/quack_reductions.py
+++ b/torch/_inductor/kernel/flex_gemm/quack_reductions.py
@@ -26,6 +26,7 @@ from torch._inductor.codegen.cutedsl.cutedsl_op_overrides import (
     tensorssa_reduction,
 )
 from torch._inductor.kernel.flex_gemm.constraints import (
+    FlexGemmBlockLocalReduceGeometry,
     grouped_reduce_dims_match,
     LOCAL_REDUCE_EXPLICIT_DTYPE_ERROR,
     LOCAL_REDUCE_GROUPED_RESHAPE_ERROR,
@@ -159,6 +160,32 @@ def _grouped_layout_from_source_shape(
         if _grouped_layout_matches_source_shape(shape, source_shape, layout):
             return layout
     return None
+
+
+def grouped_block_tensor_layout(
+    shape: Any, source_shape: Any | None = None
+) -> FlexGemmBlockLocalReduceGeometry | None:
+    """Recognize exact ``(M//bm, bm, N//bn, bn)`` block reshapes of a 2-D GEMM output."""
+    shape = normalize_shape(shape)
+    source_shape = normalize_shape(source_shape)
+    if (
+        not isinstance(shape, tuple)
+        or not isinstance(source_shape, tuple)
+        or len(shape) != 4
+        or len(source_shape) != 2
+    ):
+        return None
+    m, n = source_shape
+    match shape:
+        case (m_count, int(group_m), n_count, int(group_n)) if (
+            group_m > 0
+            and group_n > 0
+            and _group_count_matches_selected_dim(m_count, m, group_m)
+            and _group_count_matches_selected_dim(n_count, n, group_n)
+        ):
+            return FlexGemmBlockLocalReduceGeometry(group_m, group_n)
+        case _:
+            return None
 
 
 def grouped_tensor_layout(
@@ -531,6 +558,23 @@ def propagate_grouped_tensorssa_info(
     if any(info.layout != layout for info in input_infos):
         raise NotImplementedError(LOCAL_REDUCE_MIXED_GROUPED_LAYOUT_ERROR)
     return GroupedTensorSSAInfo(layout)
+
+
+def propagate_block_grouped_geometry(
+    node: torch.fx.Node,
+    block_grouped_tensors: dict[torch.fx.Node, FlexGemmBlockLocalReduceGeometry],
+) -> FlexGemmBlockLocalReduceGeometry | None:
+    geometries = [
+        block_grouped_tensors[arg]
+        for arg in iter_fx_node_inputs((node.args, node.kwargs))
+        if arg in block_grouped_tensors
+    ]
+    if not geometries:
+        return None
+    geometry = geometries[0]
+    if any(item != geometry for item in geometries):
+        raise NotImplementedError(LOCAL_REDUCE_MIXED_GROUPED_LAYOUT_ERROR)
+    return geometry
 
 
 def shape_arg_value(value: Any) -> Any:

--- a/torch/_inductor/kernel/flex_gemm/runtime.py
+++ b/torch/_inductor/kernel/flex_gemm/runtime.py
@@ -9,8 +9,10 @@ from typing import Any, TypeAlias
 import torch
 import torch._vendor.quack.gemm_config as quack_gemm_config
 from torch._inductor.kernel.flex_gemm.constraints import (
+    FlexGemmBlockLocalReduceGeometry,
     FlexGemmLocalReduceCallbacks,
     FlexGemmLocalReduceGeometry,
+    LOCAL_REDUCE_BLOCK_KERNEL_ERROR,
     LOCAL_REDUCE_CALLBACKS_REQUIRED_ERROR,
     LOCAL_REDUCE_COMBINE_KEY_SUFFIX,
     local_reduce_compressed_shape,
@@ -205,13 +207,15 @@ def normalize_c(
 class FlexGemmRuntimeLocalReducePlan:
     """Runtime plan for one local reduction and its output/feed-main consumers."""
 
-    geometry: FlexGemmLocalReduceGeometry
+    geometry: FlexGemmLocalReduceGeometry | FlexGemmBlockLocalReduceGeometry
     out: torch.Tensor | None = None
     callbacks: FlexGemmLocalReduceCallbacks | None = None
     feeds_main: bool = False
 
     def __post_init__(self) -> None:
         """Reject plans without the output/callback state required by their consumer."""
+        if isinstance(self.geometry, FlexGemmBlockLocalReduceGeometry):
+            raise NotImplementedError(LOCAL_REDUCE_BLOCK_KERNEL_ERROR)
         if self.out is None and not self.feeds_main:
             raise RuntimeError(LOCAL_REDUCE_RUNTIME_OUT_ERROR)
         if self.feeds_main:

--- a/torch/_inductor/kernel/flex_gemm/template.py
+++ b/torch/_inductor/kernel/flex_gemm/template.py
@@ -14,6 +14,7 @@ from torch._inductor.codegen.cutedsl.cutedsl_template import (
     CuteDSLTemplateCaller,
 )
 from torch._inductor.kernel.flex_gemm.constraints import (
+    FlexGemmBlockLocalReduceGeometry,
     FlexGemmLocalReduceGeometry,
     LOCAL_REDUCE_COMBINE_FN_SUFFIX,
     LOCAL_REDUCE_FINALIZE_FN_SUFFIX,
@@ -31,7 +32,7 @@ log = logging.getLogger(__name__)
 class FlexGemmEpilogueLocalReduceConfig:
     """Template-time local-reduce metadata for output and/or feed-main consumers."""
 
-    geometry: FlexGemmLocalReduceGeometry
+    geometry: FlexGemmLocalReduceGeometry | FlexGemmBlockLocalReduceGeometry
     out_index: int | None = None
     feeds_main: bool = False
     requires_physical_finalize: bool = False


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #189316
* #189315
* __->__ #189314
* #189190
* #189188
* #188739
* #188112
* #188470
* #188469
* #188468

Recognize structural 2-D block local-reduce aux outputs of the form
acc.view(M // bm, bm, N // bn, bn) reduced over both grouped dims. This
threads block geometry through the output plan, template metadata, and
runtime plan shape while failing closed with an explicit kernel-frontier
error until the QUACK block-reduce store path lands.

Keep the existing 1-D FlexGemmLocalReduceGeometry representation byte-stable
for generated-code/FileCheck compatibility and add a sibling
FlexGemmBlockLocalReduceGeometry for bm x bn blocks instead of overloading
axis/group semantics. The recognized spelling is the direct 4-D block view
with a single multidim reduce over dims {1, 3} (including negative dim
spellings); single-dim reductions over the block view and transpose/reshape
gymnastics keep their existing generic rejection behavior.

This is compile-side only: block plans are represented and classified, but
lowering and runtime reject them before any QuACK wrapper is emitted.