### PR TITLE
flex_gemm: store 2-D block local reductions

### DIFF
--- a/test/inductor/test_flex_gemm.py
+++ b/test/inductor/test_flex_gemm.py
@@ -1125,9 +1125,10 @@ class TestFlexGemmRuntime(FlexGemmTestCase):
         with self.assertRaisesRegex(RuntimeError, "must divide"):
             local_reduce_block_compressed_shape((192, 256), 128, 128)
 
-    def test_block_local_reduce_plans_reject_kernel_frontier(self):
+    def test_block_local_reduce_plans_bind_store_frontier(self):
         from torch._inductor.kernel.flex_gemm.constraints import (
             FlexGemmBlockLocalReduceGeometry,
+            FlexGemmLocalReduceCallbacks,
         )
         from torch._inductor.kernel.flex_gemm.epilogue import (
             FlexGemmBlockLocalReduceContract,
@@ -1157,10 +1158,15 @@ class TestFlexGemmRuntime(FlexGemmTestCase):
             FlexGemmEpilogueLocalReduceConfig.from_output_plan(plan, 0).geometry,
             geometry,
         )
-        with self.assertRaisesRegex(
-            NotImplementedError, "not supported by the QUACK kernel yet"
-        ):
+        with self.assertRaisesRegex(RuntimeError, "generated local-reduce callbacks"):
             FlexGemmRuntimeLocalReducePlan(geometry, out=torch.empty(2, 2))
+        FlexGemmRuntimeLocalReducePlan(
+            geometry,
+            out=torch.empty(2, 2),
+            callbacks=FlexGemmLocalReduceCallbacks(
+                lambda lhs, rhs: lhs, lambda value: value
+            ),
+        )
 
     def test_output_plan_classifies_block_local_reduce_contract(self):
         from torch._inductor.kernel.flex_gemm.constraints import (
@@ -2451,7 +2457,7 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
                     acc.float().view(-1, 4, 2, 4).sum((1, 3)),
                 ),
                 (4, 8),
-                "2-D block local reductions are not supported by the QUACK kernel yet",
+                "2-D block local reductions currently",
             ),
         ),
         name_fn=lambda case: case[0],
@@ -2474,6 +2480,8 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
         with self.assertRaisesRegex(Exception, error):
             torch.compile(fn, backend="inductor", fullgraph=True)(a, b)
 
+    @unittest.skipIf(not SM100OrLater, "SM100+ required")
+    @skipIfNoCuteDSL
     @parametrize(
         "case",
         (
@@ -2481,11 +2489,47 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
             ("amax_negative_dims", lambda x: x.abs().amax((-1, -3))),
             ("sum", lambda x: x.sum((1, 3))),
             ("mean", lambda x: x.mean((1, 3))),
-            ("mx_e8m0_scale", lambda x: mx_e8m0_scale(x.abs().amax((1, 3)))),
         ),
         name_fn=lambda case: case[0],
     )
-    def test_generated_block_local_reduce_rejects_kernel_frontier(self, case):
+    def test_generated_block_local_reduce_store_matches_reference(self, case):
+        _, reduce_fn = case
+        m = n = 256
+        k = 64
+        block = 128
+
+        def fn(a, b):
+            def epilogue(acc):
+                x = acc.float().view(m // block, block, n // block, block)
+                return acc.relu(), reduce_fn(x)
+
+            return flex_gemm(
+                torch.mm,
+                (a, b),
+                epilogue,
+                kernel_options={"backend": "QUACK"},
+            )
+
+        a = torch.randn(m, k, device="cuda", dtype=torch.bfloat16)
+        b = torch.randn(k, n, device="cuda", dtype=torch.bfloat16)
+        actual, aux = torch.compile(fn, backend="inductor", fullgraph=True)(a, b)
+        reference = a.float() @ b.float()
+        expected_aux = reduce_fn(reference.view(m // block, block, n // block, block))
+
+        self.assertEqual(aux.shape, (2, 2))
+        torch.testing.assert_close(
+            actual.float(), reference.relu(), atol=1e-1, rtol=1e-2
+        )
+        torch.testing.assert_close(aux.float(), expected_aux, atol=1e-3, rtol=1e-3)
+
+    @unittest.skipIf(not SM100OrLater, "SM100+ required")
+    @skipIfNoCuteDSL
+    @parametrize(
+        "case",
+        (("mx_e8m0_scale", lambda x: mx_e8m0_scale(x.abs().amax((1, 3)))),),
+        name_fn=lambda case: case[0],
+    )
+    def test_generated_block_local_reduce_rejects_deferred_reductions(self, case):
         _, reduce_fn = case
         m = n = 256
         block = 128
@@ -2502,13 +2546,10 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
                 kernel_options={"backend": "QUACK"},
             )
 
-        a = torch.randn(m, 64)
-        b = torch.randn(64, n)
+        a = torch.randn(m, 64, device="cuda", dtype=torch.bfloat16)
+        b = torch.randn(64, n, device="cuda", dtype=torch.bfloat16)
 
-        with self.assertRaisesRegex(
-            Exception,
-            "2-D block local reductions are not supported by the QUACK kernel yet",
-        ):
+        with self.assertRaisesRegex(Exception, "2-D block local reductions currently"):
             torch.compile(fn, backend="inductor", fullgraph=True)(a, b)
 
     def test_generated_block_local_reduce_rejects_non_divisible_shape(self):

--- a/tools/vendoring/quack/flex_gemm_patches/0011-flex-gemm-block-local-reduce-store.patch
+++ b/tools/vendoring/quack/flex_gemm_patches/0011-flex-gemm-block-local-reduce-store.patch
@@ -1,0 +1,390 @@
+Support the first FlexGEMM 2-D block local-reduce STORE slice. The block mode
+reuses generated local-reduce combine/finalize callbacks but carries explicit
+128x128 M/N group metadata so the epilogue can replay N fragments inside a
+block, then use the existing M-axis lane/warp shared-memory combine to store one
+compressed value per CTA-local block.
+
+diff --git a/epi_ops.py b/epi_ops.py
+index de134691751..78a9ed520c8 100644
+--- a/epi_ops.py
++++ b/epi_ops.py
+@@ -1225,6 +1225,9 @@ class GroupedLocalReduce(VecReduce):
+         group = gemm.local_reduce_group
+         axis = gemm.local_reduce_axis
+         smem_warps = max(gemm.epi_smem_warp_shape_mnk()[0] - 1, 0)
++        if gemm.local_reduce_is_block and smem_warps > 0:
++            size = gemm.cta_tile_shape_mnk[1] * smem_warps
++            return (f"s_{self.name}", cute.struct.Align[cute.struct.MemRange[Float32, size], 16])
+         if axis == 0 and group > 32 and smem_warps > 0:
+             size = gemm.cta_tile_shape_mnk[1] * smem_warps
+             return (f"s_{self.name}", cute.struct.Align[cute.struct.MemRange[Float32, size], 16])
+@@ -1234,6 +1237,10 @@ class GroupedLocalReduce(VecReduce):
+         group = gemm.local_reduce_group
+         axis = gemm.local_reduce_axis
+         smem_warps = max(gemm.epi_smem_warp_shape_mnk()[0] - 1, 0)
++        if gemm.local_reduce_is_block and smem_warps > 0:
++            return getattr(storage_epi, f"s_{self.name}").get_tensor(
++                cute.make_layout((gemm.cta_tile_shape_mnk[1], smem_warps))
++            )
+         if axis == 0 and group > 32 and smem_warps > 0:
+             return getattr(storage_epi, f"s_{self.name}").get_tensor(
+                 cute.make_layout((gemm.cta_tile_shape_mnk[1], smem_warps))
+@@ -1257,9 +1264,15 @@ class GroupedLocalReduce(VecReduce):
+             group = const_expr(gemm.local_reduce_group)
+             axis = const_expr(gemm.local_reduce_axis)
+             tile_M, tile_N = ctx.tile_M, ctx.tile_N
+-            tile = tile_N if const_expr(axis == 1) else tile_M
+-            assert group != 0 and group <= tile
+-            assert tile % group == 0
++            if const_expr(gemm.local_reduce_is_block):
++                assert gemm.local_reduce_group_m == 128
++                assert gemm.local_reduce_group_n == 128
++                assert tile_M == 128
++                assert tile_N % 128 == 0
++            else:
++                tile = tile_N if const_expr(axis == 1) else tile_M
++                assert group != 0 and group <= tile
++                assert tile % group == 0
+             if const_expr(param[3]):
+                 assert axis == 0
+                 tiled_copy = ctx.tiled_copy_t2r if ctx.tiled_copy_t2r is not None else ctx.tiled_copy_r2s
+@@ -1349,6 +1362,156 @@ class GroupedLocalReduce(VecReduce):
+             limit_n = min(cute.size(param_tensor, mode=[2]) - tile_coord_mnkl[1] * tile_N, tile_N)
+             if const_expr(axis == 1):
+                 local_fragment_n = const_expr(cute.size(tDrReduce_cur.shape, mode=[0]))
++            if const_expr(gemm.local_reduce_is_block):
++                assert combine_fn is not None
++                assert finalize_fn is not None
++                assert not varlen_manager.varlen_m
++                group_m = const_expr(gemm.local_reduce_group_m)
++                group_n = const_expr(gemm.local_reduce_group_n)
++                local_fragment_n = const_expr(cute.size(tDrReduce_cur.shape, mode=[0]))
++                assert group_m == 128
++                assert group_n == 128
++                assert tile_M == group_m
++                assert tile_N == group_n
++                assert group_n % local_fragment_n == 0
++                fragments_per_n_group = const_expr(group_n // local_fragment_n)
++                if const_expr((epi_coord[1] + 1) % fragments_per_n_group == 0):
++                    lane_layout_MN, warp_layout_MN = _get_lane_warp_layouts(
++                        tiled_copy, tiled_copy_t2r is None
++                    )
++                    lanes_in_M = cute.size(lane_layout_MN, mode=[0])
++                    lanes_in_N = cute.size(lane_layout_MN, mode=[1])
++                    if const_expr(group_m <= lanes_in_M):
++                        assert lanes_in_M % group_m == 0
++                        reduction_group = const_expr(group_m)
++                    else:
++                        assert group_m % lanes_in_M == 0
++                        reduction_group = const_expr(lanes_in_M)
++                    if const_expr(lanes_in_N > 1):
++                        assert lane_layout_MN.stride[1] == 1
++                    group_start_epi_n = const_expr(epi_coord[1] + 1 - fragments_per_n_group)
++                    for i in cutlass.range(cute.size(tDrReduce_flt), unroll_full=True):
++                        tDrReduce_first = tDrReduce[
++                            None, None, None, epi_coord[0], group_start_epi_n
++                        ]
++                        tDrReduce_first_flt = cute.filter_zeros(tDrReduce_first)
++                        group_value = tDrReduce_first_flt[i]
++                        for fragment_idx in cutlass.range_constexpr(1, fragments_per_n_group):
++                            tDrReduce_fragment = tDrReduce[
++                                None,
++                                None,
++                                None,
++                                epi_coord[0],
++                                group_start_epi_n + fragment_idx,
++                            ]
++                            tDrReduce_fragment_flt = cute.filter_zeros(tDrReduce_fragment)
++                            group_value = combine_fn(group_value, tDrReduce_fragment_flt[i])
++                        tDrReduce_flt[i] = group_value
++                    tDrReduce_block = layout_utils.convert_layout_zero_stride(
++                        tDrReduce_cur, tDrReduce_cur.layout
++                    )[None, 0]
++                    tDcD_block = layout_utils.convert_layout_zero_stride(
++                        tDcD_cur, tDrReduce_cur.layout
++                    )[None, 0]
++                    tDrReduce_flt = cute.filter_zeros(tDrReduce_block)
++                    tDcD_flt = cute.filter_zeros(tDcD_block)
++                    if const_expr(reduction_group > 1):
++                        for i in cutlass.range(cute.size(tDrReduce_flt), unroll_full=True):
++                            reduction_rows = reduction_group // 2
++                            while reduction_rows > 0:
++                                tDrReduce_flt[i] = combine_fn(
++                                    tDrReduce_flt[i],
++                                    cute.arch.shuffle_sync_bfly(
++                                        tDrReduce_flt[i],
++                                        offset=cute.crd2idx((reduction_rows, 0), lane_layout_MN),
++                                    ),
++                                )
++                                reduction_rows = reduction_rows // 2
++                    groups_per_cta_m = const_expr(tile_M // group_m)
++                    groups_per_cta_n = const_expr(tile_N // group_n)
++                    mReduce = param_tensor[batch_idx, None, None]
++                    gReduce = cute.local_tile(
++                        mReduce,
++                        (groups_per_cta_m, groups_per_cta_n),
++                        (tile_coord_mnkl[0], tile_coord_mnkl[1]),
++                    )
++                    limit_group_m = param_tensor.shape[1]
++                    limit_group_n = param_tensor.shape[2]
++                    if const_expr(group_m > lanes_in_M):
++                        sReduce = state[1]
++                        assert sReduce is not None
++                        warp_M = warp_layout_MN[0]
++                        warps_in_M = const_expr(cute.size(warp_M))
++                        group_warps = const_expr(group_m // lanes_in_M)
++                        assert group_warps <= warps_in_M
++                        assert groups_per_cta_m * group_warps <= warps_in_M
++                        warp_idx = cute.arch.make_warp_uniform(tidx // cute.arch.WARP_SIZE)
++                        warp_coord = warp_layout_MN.get_hier_coord(warp_idx)
++                        warp_m_idx = warp_coord[0]
++                        warp_n_idx = warp_coord[1]
++                        for i in cutlass.range(cute.size(tDrReduce_flt), unroll_full=True):
++                            row_idx = tDcD_flt[i][0]
++                            n_idx = tDcD_flt[i][1]
++                            group_m_idx = row_idx // group_m
++                            group_n_idx = n_idx // group_n
++                            group_warp_start = group_m_idx * group_warps
++                            group_warp_idx = warp_m_idx - group_warp_start
++                            smem_warp_idx = warp_m_idx - group_m_idx - 1
++                            if (
++                                row_idx % lanes_in_M == 0
++                                and n_idx % group_n == group_n - local_fragment_n
++                                and warp_n_idx == 0
++                                and group_warp_idx > 0
++                                and group_warp_idx < group_warps
++                            ):
++                                sReduce[group_n_idx, smem_warp_idx] = tDrReduce_flt[i]
++                        gemm.epilogue_barrier.arrive_and_wait()
++                        for i in cutlass.range(cute.size(tDrReduce_flt), unroll_full=True):
++                            row_idx = tDcD_flt[i][0]
++                            n_idx = tDcD_flt[i][1]
++                            group_m_idx = row_idx // group_m
++                            group_n_idx = n_idx // group_n
++                            group_warp_start = group_m_idx * group_warps
++                            global_group_m_idx = tile_coord_mnkl[0] * groups_per_cta_m + group_m_idx
++                            global_group_n_idx = tile_coord_mnkl[1] * groups_per_cta_n + group_n_idx
++                            group_value = tDrReduce_flt[i]
++                            if (
++                                row_idx % group_m == 0
++                                and n_idx % group_n == group_n - local_fragment_n
++                                and warp_m_idx == group_warp_start
++                                and warp_n_idx == 0
++                            ):
++                                for warp_offset in cutlass.range_constexpr(1, group_warps):
++                                    smem_warp_idx = group_warp_start + warp_offset - group_m_idx - 1
++                                    group_value = combine_fn(group_value, sReduce[group_n_idx, smem_warp_idx])
++                                group_value = finalize_fn(group_value)
++                                if const_expr(param_tensor.element_type != Float32):
++                                    group_value = group_value.to(param_tensor.element_type)
++                                if (
++                                    global_group_m_idx < limit_group_m
++                                    and global_group_n_idx < limit_group_n
++                                ):
++                                    gReduce[group_m_idx, group_n_idx] = group_value
++                        gemm.epilogue_barrier.arrive_and_wait()
++                    else:
++                        for i in cutlass.range(cute.size(tDrReduce_flt), unroll_full=True):
++                            row_idx = tDcD_flt[i][0]
++                            n_idx = tDcD_flt[i][1]
++                            group_m_idx = row_idx // group_m
++                            group_n_idx = n_idx // group_n
++                            global_group_m_idx = tile_coord_mnkl[0] * groups_per_cta_m + group_m_idx
++                            global_group_n_idx = tile_coord_mnkl[1] * groups_per_cta_n + group_n_idx
++                            if (
++                                row_idx % group_m == 0
++                                and n_idx % group_n == group_n - local_fragment_n
++                                and global_group_m_idx < limit_group_m
++                                and global_group_n_idx < limit_group_n
++                            ):
++                                group_value = finalize_fn(tDrReduce_flt[i])
++                                if const_expr(param_tensor.element_type != Float32):
++                                    group_value = group_value.to(param_tensor.element_type)
++                                gReduce[group_m_idx, group_n_idx] = group_value
++                return
+             if const_expr(axis == 1 and group > local_fragment_n):
+                 assert combine_fn is not None
+                 assert finalize_fn is not None
+diff --git a/gemm_act.py b/gemm_act.py
+index 7d76cbd105b..a148c699003 100644
+--- a/gemm_act.py
++++ b/gemm_act.py
+@@ -138,8 +138,11 @@ class GemmActMixin(ComposableEpiMixin):
+         ("tensor_epilogue_returns_aux", cutlass.Constexpr, False),
+         ("tensor_epilogue_returns_local_reduce", cutlass.Constexpr, False),
+         ("local_reduce_feeds_main", cutlass.Constexpr, False),
++        ("local_reduce_is_block", cutlass.Constexpr, False),
+         ("local_reduce_group", cutlass.Constexpr, 0),
+         ("local_reduce_axis", cutlass.Constexpr, 1),
++        ("local_reduce_group_m", cutlass.Constexpr, 0),
++        ("local_reduce_group_n", cutlass.Constexpr, 0),
+     )
+ 
+     @mlir_namedtuple
+@@ -151,8 +154,11 @@ class GemmActMixin(ComposableEpiMixin):
+         tensor_epilogue_returns_aux: cutlass.Constexpr[bool] = False
+         tensor_epilogue_returns_local_reduce: cutlass.Constexpr[bool] = False
+         local_reduce_feeds_main: cutlass.Constexpr[bool] = False
++        local_reduce_is_block: cutlass.Constexpr[bool] = False
+         local_reduce_group: cutlass.Constexpr[int] = 0
+         local_reduce_axis: cutlass.Constexpr[int] = 1
++        local_reduce_group_m: cutlass.Constexpr[int] = 0
++        local_reduce_group_n: cutlass.Constexpr[int] = 0
+         local_reduce_combine_fn: cutlass.Constexpr[Optional[Callable]] = None
+         local_reduce_finalize_fn: cutlass.Constexpr[Optional[Callable]] = None
+         alpha: Optional[Float32 | cute.Tensor] = None
+@@ -197,11 +203,17 @@ class GemmActMixin(ComposableEpiMixin):
+         d["tensor_epilogue_returns_aux"] = args.tensor_epilogue_returns_aux
+         d["tensor_epilogue_returns_local_reduce"] = args.tensor_epilogue_returns_local_reduce
+         d["local_reduce_feeds_main"] = args.local_reduce_feeds_main
++        d["local_reduce_is_block"] = args.local_reduce_is_block
+         d["local_reduce_group"] = args.local_reduce_group
+         d["local_reduce_axis"] = args.local_reduce_axis
++        d["local_reduce_group_m"] = args.local_reduce_group_m
++        d["local_reduce_group_n"] = args.local_reduce_group_n
+         self.local_reduce_feeds_main = args.local_reduce_feeds_main
++        self.local_reduce_is_block = args.local_reduce_is_block
+         self.local_reduce_group = args.local_reduce_group
+         self.local_reduce_axis = args.local_reduce_axis
++        self.local_reduce_group_m = args.local_reduce_group_m
++        self.local_reduce_group_n = args.local_reduce_group_n
+         for key in ("mRowVecBroadcast", "mColVecBroadcast"):
+             if key in self.concat_layout and key in d:
+                 d[key] = layout_utils.concat_to_interleave(d[key], 1)
+@@ -212,8 +224,10 @@ class GemmActMixin(ComposableEpiMixin):
+         result = super().epi_smem_bytes(args, cta_tile_shape_mnk, epi_tile, warp_shape_mnk)
+         if (
+             args.mLocalReduce is not None
+-            and args.local_reduce_axis == 0
+-            and args.local_reduce_group > 32
++            and (
++                (args.local_reduce_axis == 0 and args.local_reduce_group > 32)
++                or args.local_reduce_is_block
++            )
+         ):
+             smem_warps = max((warp_shape_mnk[0] if warp_shape_mnk is not None else 1) - 1, 0)
+             result += EpiSmemBytes(
+@@ -652,6 +666,9 @@ def _compile_gemm_act(
+     local_reduce_ndim,
+     local_reduce_group,
+     local_reduce_axis,
++    local_reduce_is_block,
++    local_reduce_group_m,
++    local_reduce_group_n,
+     local_reduce_stride_divisibility,
+     local_reduce_combine_key,
+     local_reduce_finalize_key,
+@@ -753,7 +770,13 @@ def _compile_gemm_act(
+         fake_tensor(dtype, (1,), leading_dim=0, divisibility=1)
+         for dtype in tensor_epilogue_scalar_dtypes
+     ) or None
+-    if local_reduce_dtype is not None and local_reduce_axis == 0:
++    if local_reduce_dtype is not None and local_reduce_is_block:
++        local_reduce_shape = (
++            (l, cute.sym_int(), cute.sym_int())
++            if local_reduce_ndim == 3
++            else (cute.sym_int(), cute.sym_int())
++        )
++    elif local_reduce_dtype is not None and local_reduce_axis == 0:
+         local_reduce_shape = (
+             (l, cute.sym_int(), n) if local_reduce_ndim == 3 else (cute.sym_int(), n)
+         )
+@@ -812,8 +835,11 @@ def _compile_gemm_act(
+         tensor_epilogue_returns_aux=tensor_epilogue_returns_aux,
+         tensor_epilogue_returns_local_reduce=tensor_epilogue_returns_local_reduce,
+         local_reduce_feeds_main=local_reduce_feeds_main,
++        local_reduce_is_block=local_reduce_is_block,
+         local_reduce_group=local_reduce_group,
+         local_reduce_axis=local_reduce_axis,
++        local_reduce_group_m=local_reduce_group_m,
++        local_reduce_group_n=local_reduce_group_n,
+         local_reduce_combine_fn=local_reduce_combine_fn,
+         local_reduce_finalize_fn=local_reduce_finalize_fn,
+         alpha=fake_scalar(alpha_mode, Float32),
+@@ -894,6 +920,9 @@ def gemm_act(
+     local_reduce_out: Optional[Tensor] = None,
+     local_reduce_group: int = 0,
+     local_reduce_axis: int = 1,
++    local_reduce_is_block: bool = False,
++    local_reduce_group_m: int = 0,
++    local_reduce_group_n: int = 0,
+     local_reduce_combine_key: Optional[str] = None,
+     local_reduce_finalize_key: Optional[str] = None,
+     alpha: float | Tensor = 1.0,
+@@ -1023,6 +1052,8 @@ def gemm_act(
+             "tensor_epilogue_returns_local_reduce requires local_reduce_out and vice versa"
+         )
+     if local_reduce_feeds_main:
++        if local_reduce_is_block:
++            raise NotImplementedError("local_reduce_feeds_main does not support block local reductions")
+         if local_reduce_axis != 0:
+             raise NotImplementedError("local_reduce_feeds_main currently supports only axis 0")
+         if local_reduce_group <= 0:
+@@ -1043,18 +1074,35 @@ def gemm_act(
+     if local_reduce_out is not None and tensor_epilogue_fn is None and tensor_epilogue_key is None:
+         raise RuntimeError("local_reduce_out requires tensor_epilogue_fn")
+     if local_reduce_out is not None:
+-        if local_reduce_group <= 0:
+-            raise RuntimeError("local_reduce_group must be positive")
+-        if local_reduce_axis not in (0, 1):
+-            raise RuntimeError("local_reduce_axis must be 0 or 1")
+-        if (local_reduce_axis == 0 or local_reduce_group > 32) and (
+-            local_reduce_combine_key is None or local_reduce_finalize_key is None
+-        ):
+-            raise RuntimeError(
+-                "physical local reductions require generated local-reduce callback keys"
+-            )
++        if local_reduce_is_block:
++            if local_reduce_group_m != 128 or local_reduce_group_n != 128:
++                raise NotImplementedError(
++                    "block local reductions currently support only 128x128 groups"
++                )
++            if tile_M != 128 or tile_N != 128 or cluster_M != 1 or cluster_N != 1:
++                raise NotImplementedError(
++                    "block local reductions require tile_M=128, tile_N=128, and cluster_M=cluster_N=1"
++                )
++            if local_reduce_combine_key is None or local_reduce_finalize_key is None:
++                raise RuntimeError(
++                    "physical local reductions require generated local-reduce callback keys"
++                )
++        else:
++            if local_reduce_group <= 0:
++                raise RuntimeError("local_reduce_group must be positive")
++            if local_reduce_axis not in (0, 1):
++                raise RuntimeError("local_reduce_axis must be 0 or 1")
++            if (local_reduce_axis == 0 or local_reduce_group > 32) and (
++                local_reduce_combine_key is None or local_reduce_finalize_key is None
++            ):
++                raise RuntimeError(
++                    "physical local reductions require generated local-reduce callback keys"
++                )
+         if local_reduce_out.ndim != 3:
+             raise NotImplementedError("QUACK local_reduce_out must be 3-D")
++    if local_reduce_is_block:
++        local_reduce_group = local_reduce_group_n
++        local_reduce_axis = 1
+     concat_layout = tuple(sorted(concat_layout)) if concat_layout else ()
+     local_reduce_dtype = (
+         torch2cute_dtype_map[local_reduce_out.dtype]
+@@ -1103,6 +1151,9 @@ def gemm_act(
+         local_reduce_out.ndim if local_reduce_out is not None else 0,
+         local_reduce_group,
+         local_reduce_axis,
++        local_reduce_is_block,
++        local_reduce_group_m,
++        local_reduce_group_n,
+         local_reduce_stride_divisibility,
+         local_reduce_combine_key,
+         local_reduce_finalize_key,
+@@ -1144,8 +1195,11 @@ def gemm_act(
+         tensor_epilogue_returns_aux=None,
+         tensor_epilogue_returns_local_reduce=None,
+         local_reduce_feeds_main=None,
++        local_reduce_is_block=None,
+         local_reduce_group=None,
+         local_reduce_axis=None,
++        local_reduce_group_m=None,
++        local_reduce_group_n=None,
+         local_reduce_combine_fn=None,
+         local_reduce_finalize_fn=None,
+         alpha=scalar_arg(alpha, alpha_mode, Float32),

--- a/tools/vendoring/quack/flex_gemm_patches/series
+++ b/tools/vendoring/quack/flex_gemm_patches/series
@@ -13,3 +13,4 @@
 0008-flex-gemm-local-reduce-feed-main.patch
 0009-flex-gemm-scalar-epilogue-args.patch
 0010-flex-gemm-fragment-group-32.patch
+0011-flex-gemm-block-local-reduce-store.patch

--- a/torch/_inductor/kernel/flex_gemm/constraints.py
+++ b/torch/_inductor/kernel/flex_gemm/constraints.py
@@ -126,9 +126,17 @@ LOCAL_REDUCE_INNERMOST_GROUPED_DIM_ERROR = (
     "FlexGEMM local reductions currently support only reductions over the "
     "innermost grouped dimension"
 )
-LOCAL_REDUCE_BLOCK_KERNEL_ERROR = (
-    "FlexGEMM 2-D block local reductions are not supported by the QUACK kernel yet"
+LOCAL_REDUCE_BLOCK_GROUP_ERROR = (
+    "FlexGEMM 2-D block local reductions currently support only 128x128 groups"
 )
+LOCAL_REDUCE_BLOCK_FEED_MAIN_ERROR = (
+    "FlexGEMM 2-D block local reductions cannot feed the main output yet"
+)
+LOCAL_REDUCE_BLOCK_CONFIG_ERROR = (
+    "FlexGEMM 2-D block local-reduce aux outputs require non-swap_ab configs "
+    "with tile_m=128 and tile_n=128"
+)
+LOCAL_REDUCE_BLOCK_REDUCTION_ERROR = "FlexGEMM 2-D block local reductions currently support only min/max/sum/mean store reductions"
 LOCAL_REDUCE_GROUPED_RESHAPE_ERROR = (
     "FlexGEMM local-reduce grouped reshape must split exactly one GEMM output dimension"
 )
@@ -333,6 +341,13 @@ def validate_local_reduce_block_groups(group_m: int, group_n: int) -> None:
         raise RuntimeError(LOCAL_REDUCE_GROUP_POSITIVE_ERROR)
 
 
+def validate_supported_local_reduce_block_groups(group_m: int, group_n: int) -> None:
+    """Limit the first block-store kernel slice to one CTA-local 128x128 block."""
+    validate_local_reduce_block_groups(group_m, group_n)
+    if group_m != 128 or group_n != 128:
+        raise NotImplementedError(LOCAL_REDUCE_BLOCK_GROUP_ERROR)
+
+
 def local_reduce_block_compressed_shape(
     shape: Sequence[Any], group_m: int, group_n: int
 ) -> tuple[Any, ...]:
@@ -371,6 +386,24 @@ def flex_gemm_local_reduce_config_fields(
                 config.cluster_m,
                 config.cluster_n,
             )
+
+
+def validate_flex_gemm_block_local_reduce_config(
+    config: Any, group_m: int, group_n: int
+) -> bool:
+    """Return whether a QuACK config can store one value per 128x128 CTA block."""
+    swap_ab, tile_m, tile_n, cluster_m, cluster_n = (
+        flex_gemm_local_reduce_config_fields(config)
+    )
+    return (
+        not swap_ab
+        and group_m == 128
+        and group_n == 128
+        and tile_m == 128
+        and tile_n == 128
+        and cluster_m == 1
+        and cluster_n == 1
+    )
 
 
 def validate_flex_gemm_local_reduce_config(config: Any, group: int, axis: int) -> bool:

--- a/torch/_inductor/kernel/flex_gemm/epilogue.py
+++ b/torch/_inductor/kernel/flex_gemm/epilogue.py
@@ -20,6 +20,8 @@ from torch._inductor.kernel.flex_gemm.constraints import (
     grouped_reduce_dims_match,
     LOCAL_REDUCE_AUX_TENSORSSA_ERROR,
     local_reduce_block_compressed_shape,
+    LOCAL_REDUCE_BLOCK_FEED_MAIN_ERROR,
+    LOCAL_REDUCE_BLOCK_REDUCTION_ERROR,
     LOCAL_REDUCE_COMBINE_FN_SUFFIX,
     local_reduce_compressed_shape,
     LOCAL_REDUCE_CONTRACT_NODE_ERROR,
@@ -54,6 +56,7 @@ from torch._inductor.kernel.flex_gemm.quack_reductions import (
     has_local_reduce_store_source,
     is_shape_preserving_pointwise_node,
     iter_fx_node_inputs,
+    lower_block_tensorssa_reduce,
     lower_full_scalar,
     lower_getitem,
     lower_prepare_softmax_online,
@@ -184,7 +187,11 @@ class FlexGemmOutputLocalReducePlan:
 
     @property
     def needs_physical_callbacks(self) -> bool:
-        return self.requires_physical_finalize or self.geometry.needs_physical_callbacks
+        return (
+            isinstance(self.geometry, FlexGemmBlockLocalReduceGeometry)
+            or self.requires_physical_finalize
+            or self.geometry.needs_physical_callbacks
+        )
 
 
 @dataclasses.dataclass(frozen=True)
@@ -916,6 +923,9 @@ def local_reduce_compressed_aux_plan(
         return None
     match contract:
         case FlexGemmBlockLocalReduceContract(geometry=geometry):
+            reduction = reduction_from_node(aux)
+            if reduction is None or reduction[4] not in ("max", "min", "sum", "mean"):
+                raise NotImplementedError(LOCAL_REDUCE_BLOCK_REDUCTION_ERROR)
             expected_aux_shape = local_reduce_block_compressed_shape(
                 output_meta.shape, geometry.group_m, geometry.group_n
             )
@@ -936,6 +946,8 @@ def local_reduce_feed_main_output_plan(
     feed_contract = common_local_reduce_feed_main_contract((output, *aux_outputs))
     if feed_contract is None:
         return None
+    if isinstance(feed_contract, FlexGemmBlockLocalReduceContract):
+        raise NotImplementedError(LOCAL_REDUCE_BLOCK_FEED_MAIN_ERROR)
     return FlexGemmOutputPlan(
         output,
         aux_outputs,
@@ -1041,7 +1053,11 @@ def materialize_flex_gemm_epilogue(
     gemm_op: torch._ops.OpOverload,
     outputs: FlexGemmOutputPlan,
     epilogue_arg_placeholders: tuple[torch.fx.Node, ...] = (),
-) -> tuple[str, str, tuple[FlexGemmLocalReduceGeometry, ...]]:
+) -> tuple[
+    str,
+    str,
+    tuple[FlexGemmLocalReduceGeometry | FlexGemmBlockLocalReduceGeometry, ...],
+]:
     """Build the generated CuTeDSL epilogue callable from a classified FX body.
 
     Also returns the grouped TensorSSA fragment geometries the epilogue relies
@@ -1057,6 +1073,7 @@ def materialize_flex_gemm_epilogue(
         )
     }
     grouped_tensors: dict[torch.fx.Node, GroupedTensorSSAInfo] = {}
+    block_grouped_tensors: dict[torch.fx.Node, FlexGemmBlockLocalReduceGeometry] = {}
     local_reduce_store_sources: dict[torch.fx.Node, Any] = {}
     local_reduce_physical_reductions: dict[
         torch.fx.Node, FlexGemmPhysicalReduction
@@ -1141,18 +1158,28 @@ def materialize_flex_gemm_epilogue(
                         grouped_tensors,
                         local_reduce_store_sources,
                         node is local_reduce_feed_main_input,
+                        block_grouped_tensors,
                     )
                     if lowered_view is not None:
                         env[node] = lowered_view
                         continue
-                    lowered_reduce = lower_tensorssa_reduce(
+                    lowered_reduce = lower_block_tensorssa_reduce(
                         node,
                         env,
                         kernel,
-                        grouped_tensors,
+                        block_grouped_tensors,
                         local_reduce_store_sources,
                         local_reduce_physical_reductions,
                     )
+                    if lowered_reduce is None:
+                        lowered_reduce = lower_tensorssa_reduce(
+                            node,
+                            env,
+                            kernel,
+                            grouped_tensors,
+                            local_reduce_store_sources,
+                            local_reduce_physical_reductions,
+                        )
                     if lowered_reduce is not None:
                         if (
                             local_reduce_feed_main is not None
@@ -1232,6 +1259,11 @@ def materialize_flex_gemm_epilogue(
                         )
                         if grouped_info is not None:
                             grouped_tensors[node] = grouped_info
+                        block_geometry = propagate_block_grouped_geometry(
+                            node, block_grouped_tensors
+                        )
+                        if block_geometry is not None:
+                            block_grouped_tensors[node] = block_geometry
                     continue
                 raise NotImplementedError(
                     f"unsupported FlexGEMM epilogue node: {node.format_node()}"
@@ -1293,8 +1325,13 @@ def materialize_flex_gemm_epilogue(
         f"{body}    return {result}\n",
         tuple(
             OrderedSet(
-                FlexGemmLocalReduceGeometry(info.group_size, info.axis)
-                for info in grouped_tensors.values()
+                (
+                    *(
+                        FlexGemmLocalReduceGeometry(info.group_size, info.axis)
+                        for info in grouped_tensors.values()
+                    ),
+                    *block_grouped_tensors.values(),
+                )
             )
         ),
     )

--- a/torch/_inductor/kernel/flex_gemm/lowering.py
+++ b/torch/_inductor/kernel/flex_gemm/lowering.py
@@ -21,11 +21,13 @@ from .constraints import (
     is_flex_gemm_partial_reduction_shape,
     LOCAL_REDUCE_AUX_METADATA_ERROR,
     LOCAL_REDUCE_AUX_OUTPUT_CONTRACT_ERROR,
-    LOCAL_REDUCE_BLOCK_KERNEL_ERROR,
+    LOCAL_REDUCE_BLOCK_CONFIG_ERROR,
     LOCAL_REDUCE_DENSE_MM_SCOPE_ERROR,
     LOCAL_REDUCE_PARTIAL_OUTPUT_CONTRACT_ERROR,
     statically_known_shape_equal,
+    validate_flex_gemm_block_local_reduce_config,
     validate_flex_gemm_local_reduce_config,
+    validate_supported_local_reduce_block_groups,
 )
 
 
@@ -174,7 +176,9 @@ def flex_gemm_local_reduce_metas(
     if local_reduce is None:
         return ()
     if isinstance(local_reduce.geometry, FlexGemmBlockLocalReduceGeometry):
-        raise NotImplementedError(LOCAL_REDUCE_BLOCK_KERNEL_ERROR)
+        validate_supported_local_reduce_block_groups(
+            local_reduce.geometry.group_m, local_reduce.geometry.group_n
+        )
     if local_reduce.store_node is None:
         return ()
     local_reduce_meta = local_reduce.store_node.meta.get("val")
@@ -204,12 +208,19 @@ def flex_gemm_config_keys_for_local_reduce(
         gemm_config_key,
     )
 
+    def config_supports_geometry(config: Any, geometry: Any) -> bool:
+        if isinstance(geometry, FlexGemmBlockLocalReduceGeometry):
+            return validate_flex_gemm_block_local_reduce_config(
+                config, geometry.group_m, geometry.group_n
+            )
+        return validate_flex_gemm_local_reduce_config(
+            config, geometry.group, geometry.axis
+        )
+
     if not tuned:
         default_key = default_gemm_config_key(device, m, n)
         if all(
-            validate_flex_gemm_local_reduce_config(
-                dict(default_key), geometry.group, geometry.axis
-            )
+            config_supports_geometry(dict(default_key), geometry)
             for geometry in local_reduce_geometries
         ):
             return (default_key,)
@@ -218,13 +229,11 @@ def flex_gemm_config_keys_for_local_reduce(
     configs = candidate_configs
     for geometry in local_reduce_geometries:
         configs = tuple(
-            config
-            for config in configs
-            if validate_flex_gemm_local_reduce_config(
-                config, geometry.group, geometry.axis
-            )
+            config for config in configs if config_supports_geometry(config, geometry)
         )
         if not configs:
+            if isinstance(geometry, FlexGemmBlockLocalReduceGeometry):
+                raise NotImplementedError(LOCAL_REDUCE_BLOCK_CONFIG_ERROR)
             raise NotImplementedError(
                 flex_gemm_local_reduce_config_error(
                     candidate_configs,

--- a/torch/_inductor/kernel/flex_gemm/quack_reductions.py
+++ b/torch/_inductor/kernel/flex_gemm/quack_reductions.py
@@ -27,7 +27,9 @@ from torch._inductor.codegen.cutedsl.cutedsl_op_overrides import (
 )
 from torch._inductor.kernel.flex_gemm.constraints import (
     FlexGemmBlockLocalReduceGeometry,
+    grouped_block_reduce_dims_match,
     grouped_reduce_dims_match,
+    LOCAL_REDUCE_BLOCK_REDUCTION_ERROR,
     LOCAL_REDUCE_EXPLICIT_DTYPE_ERROR,
     LOCAL_REDUCE_GROUPED_RESHAPE_ERROR,
     LOCAL_REDUCE_INNERMOST_GROUPED_DIM_ERROR,
@@ -619,6 +621,8 @@ def lower_view_or_reshape(
     grouped_tensors: dict[torch.fx.Node, GroupedTensorSSAInfo],
     local_reduce_store_sources: dict[torch.fx.Node, Any],
     preserve_value_layout: bool = False,
+    block_grouped_tensors: dict[torch.fx.Node, FlexGemmBlockLocalReduceGeometry]
+    | None = None,
 ) -> Any | None:
     view_args = view_or_reshape_args(node)
     if view_args is None:
@@ -632,9 +636,16 @@ def lower_view_or_reshape(
         return _cute_arg(source_node, env)
     if not isinstance(source_node, torch.fx.Node):
         return None
-    grouped_layout = grouped_tensor_layout(shape, tensor_meta_shape(source_node))
+    source_shape = tensor_meta_shape(source_node)
+    block_geometry = grouped_block_tensor_layout(shape, source_shape)
+    if block_geometry is not None and block_grouped_tensors is not None:
+        block_grouped_tensors[node] = block_geometry
+        return _cute_arg(source_node, env)
+    grouped_layout = grouped_tensor_layout(shape, source_shape)
     if grouped_layout is None:
-        if source_node in grouped_tensors:
+        if source_node in grouped_tensors or (
+            block_grouped_tensors is not None and source_node in block_grouped_tensors
+        ):
             return _cute_arg(source_node, env)
         return None
     validate_local_reduce_tensorssa_group_size(
@@ -810,6 +821,70 @@ def lower_prepare_softmax_online(
     _, sum_store = _keepdim_and_broadcast(kernel, sum_reduced, info, source)
     local_reduce_store_sources[node] = (max_store, sum_store)
     return max_store, sum_store
+
+
+def lower_block_tensorssa_reduce(
+    node: torch.fx.Node,
+    env: dict[torch.fx.Node, Any],
+    kernel: Any,
+    block_grouped_tensors: dict[torch.fx.Node, FlexGemmBlockLocalReduceGeometry],
+    local_reduce_store_sources: dict[torch.fx.Node, Any],
+    local_reduce_physical_reductions: dict[torch.fx.Node, FlexGemmPhysicalReduction]
+    | None = None,
+) -> Any | None:
+    """Lower 2-D block reductions to N-fragment partials and a physical M combine."""
+    reduction = reduction_from_node(node)
+    if reduction is None:
+        return None
+    input_node, dim, keepdim, dtype, reduction_type = reduction
+    if dtype is not None:
+        raise NotImplementedError(LOCAL_REDUCE_EXPLICIT_DTYPE_ERROR)
+    if not isinstance(input_node, torch.fx.Node):
+        return None
+    geometry = block_grouped_tensors.get(input_node)
+    if geometry is None:
+        return None
+    if not grouped_block_reduce_dims_match(dim):
+        raise NotImplementedError(LOCAL_REDUCE_INNERMOST_GROUPED_DIM_ERROR)
+    if reduction_type not in ("max", "min", "sum", "mean"):
+        raise NotImplementedError(LOCAL_REDUCE_BLOCK_REDUCTION_ERROR)
+    reduction_name = cast(
+        ReductionType, "sum" if reduction_type == "mean" else reduction_type
+    )
+    desc = tensorssa_reduction(reduction_name)
+    finalize_expr = (
+        f"value / {float(geometry.group_m * geometry.group_n)!r}"
+        if reduction_type == "mean"
+        else "value"
+    )
+    if local_reduce_physical_reductions is not None:
+        local_reduce_physical_reductions[node] = FlexGemmPhysicalReduction(
+            desc.combine_expr, finalize_expr
+        )
+    source = _cute_arg(input_node, env)
+    n_info = GroupedTensorSSAInfo(
+        GroupedTensorSSALayout(axis=1, group_size=geometry.group_n)
+    )
+    n_grouped_source = _generate_like(
+        kernel, f"{source}.reshape({n_info.layout.tensorssa_shape(source)})", source
+    )
+    reduced = _generate_like(
+        kernel,
+        f"{n_grouped_source}.reduce({desc.cute_op}, init_val={desc.init_val}, reduction_profile={n_info.layout.reduction_profile})",
+        n_grouped_source,
+    )
+    keepdim_source, grouped_store_source = _keepdim_and_broadcast(
+        kernel, reduced, n_info, n_grouped_source
+    )
+    local_reduce_store_sources[node] = _generate_like(
+        kernel,
+        f"{grouped_store_source}.reshape({source}.shape)",
+        grouped_store_source,
+        source,
+    )
+    if keepdim:
+        return keepdim_source
+    return reduced
 
 
 def lower_tensorssa_reduce(

--- a/torch/_inductor/kernel/flex_gemm/runtime.py
+++ b/torch/_inductor/kernel/flex_gemm/runtime.py
@@ -12,7 +12,8 @@ from torch._inductor.kernel.flex_gemm.constraints import (
     FlexGemmBlockLocalReduceGeometry,
     FlexGemmLocalReduceCallbacks,
     FlexGemmLocalReduceGeometry,
-    LOCAL_REDUCE_BLOCK_KERNEL_ERROR,
+    local_reduce_block_compressed_shape,
+    LOCAL_REDUCE_BLOCK_FEED_MAIN_ERROR,
     LOCAL_REDUCE_CALLBACKS_REQUIRED_ERROR,
     LOCAL_REDUCE_COMBINE_KEY_SUFFIX,
     local_reduce_compressed_shape,
@@ -24,6 +25,7 @@ from torch._inductor.kernel.flex_gemm.constraints import (
     validate_local_reduce_out_shape,
     validate_local_reduce_runtime_dense_mm,
     validate_local_reduce_selected_dim_divisible,
+    validate_supported_local_reduce_block_groups,
 )
 from torch._inductor.runtime.cache_dir_utils import cache_dir
 from torch._prims_common import is_expandable_to
@@ -214,16 +216,27 @@ class FlexGemmRuntimeLocalReducePlan:
 
     def __post_init__(self) -> None:
         """Reject plans without the output/callback state required by their consumer."""
-        if isinstance(self.geometry, FlexGemmBlockLocalReduceGeometry):
-            raise NotImplementedError(LOCAL_REDUCE_BLOCK_KERNEL_ERROR)
         if self.out is None and not self.feeds_main:
             raise RuntimeError(LOCAL_REDUCE_RUNTIME_OUT_ERROR)
+        if isinstance(self.geometry, FlexGemmBlockLocalReduceGeometry):
+            validate_supported_local_reduce_block_groups(
+                self.geometry.group_m, self.geometry.group_n
+            )
+            if self.feeds_main:
+                raise NotImplementedError(LOCAL_REDUCE_BLOCK_FEED_MAIN_ERROR)
+            if self.callbacks is None:
+                raise RuntimeError(LOCAL_REDUCE_CALLBACKS_REQUIRED_ERROR)
+            return
         if self.feeds_main:
             if self.callbacks is None:
                 raise RuntimeError(LOCAL_REDUCE_CALLBACKS_REQUIRED_ERROR)
             validate_local_reduce_feed_main_capability(self.axis, self.group)
         elif self.geometry.needs_physical_callbacks and self.callbacks is None:
             raise RuntimeError(LOCAL_REDUCE_CALLBACKS_REQUIRED_ERROR)
+
+    @property
+    def is_block(self) -> bool:
+        return isinstance(self.geometry, FlexGemmBlockLocalReduceGeometry)
 
     @property
     def group(self) -> int:
@@ -246,16 +259,26 @@ def validate_runtime_local_reduce(
     if plan is None:
         return
     validate_local_reduce_runtime_dense_mm(a.ndim)
-    validate_local_reduce_selected_dim_divisible(expected_shape, plan.group, plan.axis)
     validate_local_reduce_no_c_alpha_beta(effective_C, alpha, beta)
+    if isinstance(plan.geometry, FlexGemmBlockLocalReduceGeometry):
+        validate_supported_local_reduce_block_groups(
+            plan.geometry.group_m, plan.geometry.group_n
+        )
+        expected_local_reduce_shape = local_reduce_block_compressed_shape(
+            expected_shape, plan.geometry.group_m, plan.geometry.group_n
+        )
+    else:
+        validate_local_reduce_selected_dim_divisible(
+            expected_shape, plan.group, plan.axis
+        )
+        expected_local_reduce_shape = local_reduce_compressed_shape(
+            expected_shape, plan.group, plan.axis
+        )
     local_reduce_out = plan.out
     if local_reduce_out is None:
         return
     check_matrix("local_reduce_out", local_reduce_out)
     check_matrix_row_major_layout("local_reduce_out", local_reduce_out)
-    expected_local_reduce_shape = local_reduce_compressed_shape(
-        expected_shape, plan.group, plan.axis
-    )
     validate_local_reduce_out_shape(local_reduce_out.shape, expected_local_reduce_shape)
 
 
@@ -304,15 +327,31 @@ def local_reduce_gemm_act_kwargs(
     if local_reduce is None:
         return {}
     local_reduce_combine_key, local_reduce_finalize_key = callback_keys
-    return {
+    result = {
         "tensor_epilogue_returns_local_reduce": local_reduce_out is not None,
         "local_reduce_feeds_main": local_reduce.feeds_main,
         "local_reduce_out": local_reduce_out,
-        "local_reduce_group": local_reduce.group,
-        "local_reduce_axis": local_reduce.axis,
         "local_reduce_combine_key": local_reduce_combine_key,
         "local_reduce_finalize_key": local_reduce_finalize_key,
     }
+    if isinstance(local_reduce.geometry, FlexGemmBlockLocalReduceGeometry):
+        result.update(
+            {
+                "local_reduce_is_block": True,
+                "local_reduce_group": local_reduce.geometry.group_n,
+                "local_reduce_axis": 1,
+                "local_reduce_group_m": local_reduce.geometry.group_m,
+                "local_reduce_group_n": local_reduce.geometry.group_n,
+            }
+        )
+    else:
+        result.update(
+            {
+                "local_reduce_group": local_reduce.group,
+                "local_reduce_axis": local_reduce.axis,
+            }
+        )
+    return result
 
 
 def dispatch_gemm_act(

--- a/torch/_inductor/kernel/flex_gemm/template.py
+++ b/torch/_inductor/kernel/flex_gemm/template.py
@@ -64,6 +64,10 @@ class FlexGemmEpilogueLocalReduceConfig:
         )
 
     @property
+    def is_block(self) -> bool:
+        return isinstance(self.geometry, FlexGemmBlockLocalReduceGeometry)
+
+    @property
     def group(self) -> int:
         return self.geometry.group
 
@@ -73,7 +77,11 @@ class FlexGemmEpilogueLocalReduceConfig:
 
     @property
     def needs_physical_callbacks(self) -> bool:
-        return self.requires_physical_finalize or self.geometry.needs_physical_callbacks
+        return (
+            self.is_block
+            or self.requires_physical_finalize
+            or self.geometry.needs_physical_callbacks
+        )
 
 
 @dataclasses.dataclass(frozen=True)
@@ -160,6 +168,7 @@ class FlexGemmEpilogueKernel(CuteDSLTemplateKernel):
             """
             import torch
             from torch._inductor.kernel.flex_gemm.constraints import (
+                FlexGemmBlockLocalReduceGeometry,
                 FlexGemmLocalReduceCallbacks,
                 FlexGemmLocalReduceGeometry,
             )
@@ -246,7 +255,13 @@ class FlexGemmEpilogueKernel(CuteDSLTemplateKernel):
     def _local_reduce_geometry(
         self, local_reduce: FlexGemmEpilogueLocalReduceConfig
     ) -> str:
-        """Render the shared grouped M/N local-reduce geometry."""
+        """Render the shared grouped M/N or 2-D block local-reduce geometry."""
+        if isinstance(local_reduce.geometry, FlexGemmBlockLocalReduceGeometry):
+            return (
+                "FlexGemmBlockLocalReduceGeometry("
+                f"group_m={local_reduce.geometry.group_m!r}, "
+                f"group_n={local_reduce.geometry.group_n!r})"
+            )
         return (
             "FlexGemmLocalReduceGeometry("
             f"group={local_reduce.group!r}, axis={local_reduce.axis!r})"

--- a/torch/_vendor/quack/epi_ops.py
+++ b/torch/_vendor/quack/epi_ops.py
@@ -1225,6 +1225,9 @@ class GroupedLocalReduce(VecReduce):
         group = gemm.local_reduce_group
         axis = gemm.local_reduce_axis
         smem_warps = max(gemm.epi_smem_warp_shape_mnk()[0] - 1, 0)
+        if gemm.local_reduce_is_block and smem_warps > 0:
+            size = gemm.cta_tile_shape_mnk[1] * smem_warps
+            return (f"s_{self.name}", cute.struct.Align[cute.struct.MemRange[Float32, size], 16])
         if axis == 0 and group > 32 and smem_warps > 0:
             size = gemm.cta_tile_shape_mnk[1] * smem_warps
             return (f"s_{self.name}", cute.struct.Align[cute.struct.MemRange[Float32, size], 16])
@@ -1234,6 +1237,10 @@ class GroupedLocalReduce(VecReduce):
         group = gemm.local_reduce_group
         axis = gemm.local_reduce_axis
         smem_warps = max(gemm.epi_smem_warp_shape_mnk()[0] - 1, 0)
+        if gemm.local_reduce_is_block and smem_warps > 0:
+            return getattr(storage_epi, f"s_{self.name}").get_tensor(
+                cute.make_layout((gemm.cta_tile_shape_mnk[1], smem_warps))
+            )
         if axis == 0 and group > 32 and smem_warps > 0:
             return getattr(storage_epi, f"s_{self.name}").get_tensor(
                 cute.make_layout((gemm.cta_tile_shape_mnk[1], smem_warps))
@@ -1257,9 +1264,15 @@ class GroupedLocalReduce(VecReduce):
             group = const_expr(gemm.local_reduce_group)
             axis = const_expr(gemm.local_reduce_axis)
             tile_M, tile_N = ctx.tile_M, ctx.tile_N
-            tile = tile_N if const_expr(axis == 1) else tile_M
-            assert group != 0 and group <= tile
-            assert tile % group == 0
+            if const_expr(gemm.local_reduce_is_block):
+                assert gemm.local_reduce_group_m == 128
+                assert gemm.local_reduce_group_n == 128
+                assert tile_M == 128
+                assert tile_N % 128 == 0
+            else:
+                tile = tile_N if const_expr(axis == 1) else tile_M
+                assert group != 0 and group <= tile
+                assert tile % group == 0
             if const_expr(param[3]):
                 assert axis == 0
                 tiled_copy = ctx.tiled_copy_t2r if ctx.tiled_copy_t2r is not None else ctx.tiled_copy_r2s
@@ -1349,6 +1362,156 @@ class GroupedLocalReduce(VecReduce):
             limit_n = min(cute.size(param_tensor, mode=[2]) - tile_coord_mnkl[1] * tile_N, tile_N)
             if const_expr(axis == 1):
                 local_fragment_n = const_expr(cute.size(tDrReduce_cur.shape, mode=[0]))
+            if const_expr(gemm.local_reduce_is_block):
+                assert combine_fn is not None
+                assert finalize_fn is not None
+                assert not varlen_manager.varlen_m
+                group_m = const_expr(gemm.local_reduce_group_m)
+                group_n = const_expr(gemm.local_reduce_group_n)
+                local_fragment_n = const_expr(cute.size(tDrReduce_cur.shape, mode=[0]))
+                assert group_m == 128
+                assert group_n == 128
+                assert tile_M == group_m
+                assert tile_N == group_n
+                assert group_n % local_fragment_n == 0
+                fragments_per_n_group = const_expr(group_n // local_fragment_n)
+                if const_expr((epi_coord[1] + 1) % fragments_per_n_group == 0):
+                    lane_layout_MN, warp_layout_MN = _get_lane_warp_layouts(
+                        tiled_copy, tiled_copy_t2r is None
+                    )
+                    lanes_in_M = cute.size(lane_layout_MN, mode=[0])
+                    lanes_in_N = cute.size(lane_layout_MN, mode=[1])
+                    if const_expr(group_m <= lanes_in_M):
+                        assert lanes_in_M % group_m == 0
+                        reduction_group = const_expr(group_m)
+                    else:
+                        assert group_m % lanes_in_M == 0
+                        reduction_group = const_expr(lanes_in_M)
+                    if const_expr(lanes_in_N > 1):
+                        assert lane_layout_MN.stride[1] == 1
+                    group_start_epi_n = const_expr(epi_coord[1] + 1 - fragments_per_n_group)
+                    for i in cutlass.range(cute.size(tDrReduce_flt), unroll_full=True):
+                        tDrReduce_first = tDrReduce[
+                            None, None, None, epi_coord[0], group_start_epi_n
+                        ]
+                        tDrReduce_first_flt = cute.filter_zeros(tDrReduce_first)
+                        group_value = tDrReduce_first_flt[i]
+                        for fragment_idx in cutlass.range_constexpr(1, fragments_per_n_group):
+                            tDrReduce_fragment = tDrReduce[
+                                None,
+                                None,
+                                None,
+                                epi_coord[0],
+                                group_start_epi_n + fragment_idx,
+                            ]
+                            tDrReduce_fragment_flt = cute.filter_zeros(tDrReduce_fragment)
+                            group_value = combine_fn(group_value, tDrReduce_fragment_flt[i])
+                        tDrReduce_flt[i] = group_value
+                    tDrReduce_block = layout_utils.convert_layout_zero_stride(
+                        tDrReduce_cur, tDrReduce_cur.layout
+                    )[None, 0]
+                    tDcD_block = layout_utils.convert_layout_zero_stride(
+                        tDcD_cur, tDrReduce_cur.layout
+                    )[None, 0]
+                    tDrReduce_flt = cute.filter_zeros(tDrReduce_block)
+                    tDcD_flt = cute.filter_zeros(tDcD_block)
+                    if const_expr(reduction_group > 1):
+                        for i in cutlass.range(cute.size(tDrReduce_flt), unroll_full=True):
+                            reduction_rows = reduction_group // 2
+                            while reduction_rows > 0:
+                                tDrReduce_flt[i] = combine_fn(
+                                    tDrReduce_flt[i],
+                                    cute.arch.shuffle_sync_bfly(
+                                        tDrReduce_flt[i],
+                                        offset=cute.crd2idx((reduction_rows, 0), lane_layout_MN),
+                                    ),
+                                )
+                                reduction_rows = reduction_rows // 2
+                    groups_per_cta_m = const_expr(tile_M // group_m)
+                    groups_per_cta_n = const_expr(tile_N // group_n)
+                    mReduce = param_tensor[batch_idx, None, None]
+                    gReduce = cute.local_tile(
+                        mReduce,
+                        (groups_per_cta_m, groups_per_cta_n),
+                        (tile_coord_mnkl[0], tile_coord_mnkl[1]),
+                    )
+                    limit_group_m = param_tensor.shape[1]
+                    limit_group_n = param_tensor.shape[2]
+                    if const_expr(group_m > lanes_in_M):
+                        sReduce = state[1]
+                        assert sReduce is not None
+                        warp_M = warp_layout_MN[0]
+                        warps_in_M = const_expr(cute.size(warp_M))
+                        group_warps = const_expr(group_m // lanes_in_M)
+                        assert group_warps <= warps_in_M
+                        assert groups_per_cta_m * group_warps <= warps_in_M
+                        warp_idx = cute.arch.make_warp_uniform(tidx // cute.arch.WARP_SIZE)
+                        warp_coord = warp_layout_MN.get_hier_coord(warp_idx)
+                        warp_m_idx = warp_coord[0]
+                        warp_n_idx = warp_coord[1]
+                        for i in cutlass.range(cute.size(tDrReduce_flt), unroll_full=True):
+                            row_idx = tDcD_flt[i][0]
+                            n_idx = tDcD_flt[i][1]
+                            group_m_idx = row_idx // group_m
+                            group_n_idx = n_idx // group_n
+                            group_warp_start = group_m_idx * group_warps
+                            group_warp_idx = warp_m_idx - group_warp_start
+                            smem_warp_idx = warp_m_idx - group_m_idx - 1
+                            if (
+                                row_idx % lanes_in_M == 0
+                                and n_idx % group_n == group_n - local_fragment_n
+                                and warp_n_idx == 0
+                                and group_warp_idx > 0
+                                and group_warp_idx < group_warps
+                            ):
+                                sReduce[group_n_idx, smem_warp_idx] = tDrReduce_flt[i]
+                        gemm.epilogue_barrier.arrive_and_wait()
+                        for i in cutlass.range(cute.size(tDrReduce_flt), unroll_full=True):
+                            row_idx = tDcD_flt[i][0]
+                            n_idx = tDcD_flt[i][1]
+                            group_m_idx = row_idx // group_m
+                            group_n_idx = n_idx // group_n
+                            group_warp_start = group_m_idx * group_warps
+                            global_group_m_idx = tile_coord_mnkl[0] * groups_per_cta_m + group_m_idx
+                            global_group_n_idx = tile_coord_mnkl[1] * groups_per_cta_n + group_n_idx
+                            group_value = tDrReduce_flt[i]
+                            if (
+                                row_idx % group_m == 0
+                                and n_idx % group_n == group_n - local_fragment_n
+                                and warp_m_idx == group_warp_start
+                                and warp_n_idx == 0
+                            ):
+                                for warp_offset in cutlass.range_constexpr(1, group_warps):
+                                    smem_warp_idx = group_warp_start + warp_offset - group_m_idx - 1
+                                    group_value = combine_fn(group_value, sReduce[group_n_idx, smem_warp_idx])
+                                group_value = finalize_fn(group_value)
+                                if const_expr(param_tensor.element_type != Float32):
+                                    group_value = group_value.to(param_tensor.element_type)
+                                if (
+                                    global_group_m_idx < limit_group_m
+                                    and global_group_n_idx < limit_group_n
+                                ):
+                                    gReduce[group_m_idx, group_n_idx] = group_value
+                        gemm.epilogue_barrier.arrive_and_wait()
+                    else:
+                        for i in cutlass.range(cute.size(tDrReduce_flt), unroll_full=True):
+                            row_idx = tDcD_flt[i][0]
+                            n_idx = tDcD_flt[i][1]
+                            group_m_idx = row_idx // group_m
+                            group_n_idx = n_idx // group_n
+                            global_group_m_idx = tile_coord_mnkl[0] * groups_per_cta_m + group_m_idx
+                            global_group_n_idx = tile_coord_mnkl[1] * groups_per_cta_n + group_n_idx
+                            if (
+                                row_idx % group_m == 0
+                                and n_idx % group_n == group_n - local_fragment_n
+                                and global_group_m_idx < limit_group_m
+                                and global_group_n_idx < limit_group_n
+                            ):
+                                group_value = finalize_fn(tDrReduce_flt[i])
+                                if const_expr(param_tensor.element_type != Float32):
+                                    group_value = group_value.to(param_tensor.element_type)
+                                gReduce[group_m_idx, group_n_idx] = group_value
+                return
             if const_expr(axis == 1 and group > local_fragment_n):
                 assert combine_fn is not None
                 assert finalize_fn is not None

--- a/torch/_vendor/quack/gemm_act.py
+++ b/torch/_vendor/quack/gemm_act.py
@@ -138,8 +138,11 @@ class GemmActMixin(ComposableEpiMixin):
         ("tensor_epilogue_returns_aux", cutlass.Constexpr, False),
         ("tensor_epilogue_returns_local_reduce", cutlass.Constexpr, False),
         ("local_reduce_feeds_main", cutlass.Constexpr, False),
+        ("local_reduce_is_block", cutlass.Constexpr, False),
         ("local_reduce_group", cutlass.Constexpr, 0),
         ("local_reduce_axis", cutlass.Constexpr, 1),
+        ("local_reduce_group_m", cutlass.Constexpr, 0),
+        ("local_reduce_group_n", cutlass.Constexpr, 0),
     )
 
     @mlir_namedtuple
@@ -151,8 +154,11 @@ class GemmActMixin(ComposableEpiMixin):
         tensor_epilogue_returns_aux: cutlass.Constexpr[bool] = False
         tensor_epilogue_returns_local_reduce: cutlass.Constexpr[bool] = False
         local_reduce_feeds_main: cutlass.Constexpr[bool] = False
+        local_reduce_is_block: cutlass.Constexpr[bool] = False
         local_reduce_group: cutlass.Constexpr[int] = 0
         local_reduce_axis: cutlass.Constexpr[int] = 1
+        local_reduce_group_m: cutlass.Constexpr[int] = 0
+        local_reduce_group_n: cutlass.Constexpr[int] = 0
         local_reduce_combine_fn: cutlass.Constexpr[Optional[Callable]] = None
         local_reduce_finalize_fn: cutlass.Constexpr[Optional[Callable]] = None
         alpha: Optional[Float32 | cute.Tensor] = None
@@ -197,11 +203,17 @@ class GemmActMixin(ComposableEpiMixin):
         d["tensor_epilogue_returns_aux"] = args.tensor_epilogue_returns_aux
         d["tensor_epilogue_returns_local_reduce"] = args.tensor_epilogue_returns_local_reduce
         d["local_reduce_feeds_main"] = args.local_reduce_feeds_main
+        d["local_reduce_is_block"] = args.local_reduce_is_block
         d["local_reduce_group"] = args.local_reduce_group
         d["local_reduce_axis"] = args.local_reduce_axis
+        d["local_reduce_group_m"] = args.local_reduce_group_m
+        d["local_reduce_group_n"] = args.local_reduce_group_n
         self.local_reduce_feeds_main = args.local_reduce_feeds_main
+        self.local_reduce_is_block = args.local_reduce_is_block
         self.local_reduce_group = args.local_reduce_group
         self.local_reduce_axis = args.local_reduce_axis
+        self.local_reduce_group_m = args.local_reduce_group_m
+        self.local_reduce_group_n = args.local_reduce_group_n
         for key in ("mRowVecBroadcast", "mColVecBroadcast"):
             if key in self.concat_layout and key in d:
                 d[key] = layout_utils.concat_to_interleave(d[key], 1)
@@ -212,8 +224,10 @@ class GemmActMixin(ComposableEpiMixin):
         result = super().epi_smem_bytes(args, cta_tile_shape_mnk, epi_tile, warp_shape_mnk)
         if (
             args.mLocalReduce is not None
-            and args.local_reduce_axis == 0
-            and args.local_reduce_group > 32
+            and (
+                (args.local_reduce_axis == 0 and args.local_reduce_group > 32)
+                or args.local_reduce_is_block
+            )
         ):
             smem_warps = max((warp_shape_mnk[0] if warp_shape_mnk is not None else 1) - 1, 0)
             result += EpiSmemBytes(
@@ -652,6 +666,9 @@ def _compile_gemm_act(
     local_reduce_ndim,
     local_reduce_group,
     local_reduce_axis,
+    local_reduce_is_block,
+    local_reduce_group_m,
+    local_reduce_group_n,
     local_reduce_stride_divisibility,
     local_reduce_combine_key,
     local_reduce_finalize_key,
@@ -753,7 +770,13 @@ def _compile_gemm_act(
         fake_tensor(dtype, (1,), leading_dim=0, divisibility=1)
         for dtype in tensor_epilogue_scalar_dtypes
     ) or None
-    if local_reduce_dtype is not None and local_reduce_axis == 0:
+    if local_reduce_dtype is not None and local_reduce_is_block:
+        local_reduce_shape = (
+            (l, cute.sym_int(), cute.sym_int())
+            if local_reduce_ndim == 3
+            else (cute.sym_int(), cute.sym_int())
+        )
+    elif local_reduce_dtype is not None and local_reduce_axis == 0:
         local_reduce_shape = (
             (l, cute.sym_int(), n) if local_reduce_ndim == 3 else (cute.sym_int(), n)
         )
@@ -812,8 +835,11 @@ def _compile_gemm_act(
         tensor_epilogue_returns_aux=tensor_epilogue_returns_aux,
         tensor_epilogue_returns_local_reduce=tensor_epilogue_returns_local_reduce,
         local_reduce_feeds_main=local_reduce_feeds_main,
+        local_reduce_is_block=local_reduce_is_block,
         local_reduce_group=local_reduce_group,
         local_reduce_axis=local_reduce_axis,
+        local_reduce_group_m=local_reduce_group_m,
+        local_reduce_group_n=local_reduce_group_n,
         local_reduce_combine_fn=local_reduce_combine_fn,
         local_reduce_finalize_fn=local_reduce_finalize_fn,
         alpha=fake_scalar(alpha_mode, Float32),
@@ -894,6 +920,9 @@ def gemm_act(
     local_reduce_out: Optional[Tensor] = None,
     local_reduce_group: int = 0,
     local_reduce_axis: int = 1,
+    local_reduce_is_block: bool = False,
+    local_reduce_group_m: int = 0,
+    local_reduce_group_n: int = 0,
     local_reduce_combine_key: Optional[str] = None,
     local_reduce_finalize_key: Optional[str] = None,
     alpha: float | Tensor = 1.0,
@@ -1023,6 +1052,8 @@ def gemm_act(
             "tensor_epilogue_returns_local_reduce requires local_reduce_out and vice versa"
         )
     if local_reduce_feeds_main:
+        if local_reduce_is_block:
+            raise NotImplementedError("local_reduce_feeds_main does not support block local reductions")
         if local_reduce_axis != 0:
             raise NotImplementedError("local_reduce_feeds_main currently supports only axis 0")
         if local_reduce_group <= 0:
@@ -1043,18 +1074,35 @@ def gemm_act(
     if local_reduce_out is not None and tensor_epilogue_fn is None and tensor_epilogue_key is None:
         raise RuntimeError("local_reduce_out requires tensor_epilogue_fn")
     if local_reduce_out is not None:
-        if local_reduce_group <= 0:
-            raise RuntimeError("local_reduce_group must be positive")
-        if local_reduce_axis not in (0, 1):
-            raise RuntimeError("local_reduce_axis must be 0 or 1")
-        if (local_reduce_axis == 0 or local_reduce_group > 32) and (
-            local_reduce_combine_key is None or local_reduce_finalize_key is None
-        ):
-            raise RuntimeError(
-                "physical local reductions require generated local-reduce callback keys"
-            )
+        if local_reduce_is_block:
+            if local_reduce_group_m != 128 or local_reduce_group_n != 128:
+                raise NotImplementedError(
+                    "block local reductions currently support only 128x128 groups"
+                )
+            if tile_M != 128 or tile_N != 128 or cluster_M != 1 or cluster_N != 1:
+                raise NotImplementedError(
+                    "block local reductions require tile_M=128, tile_N=128, and cluster_M=cluster_N=1"
+                )
+            if local_reduce_combine_key is None or local_reduce_finalize_key is None:
+                raise RuntimeError(
+                    "physical local reductions require generated local-reduce callback keys"
+                )
+        else:
+            if local_reduce_group <= 0:
+                raise RuntimeError("local_reduce_group must be positive")
+            if local_reduce_axis not in (0, 1):
+                raise RuntimeError("local_reduce_axis must be 0 or 1")
+            if (local_reduce_axis == 0 or local_reduce_group > 32) and (
+                local_reduce_combine_key is None or local_reduce_finalize_key is None
+            ):
+                raise RuntimeError(
+                    "physical local reductions require generated local-reduce callback keys"
+                )
         if local_reduce_out.ndim != 3:
             raise NotImplementedError("QUACK local_reduce_out must be 3-D")
+    if local_reduce_is_block:
+        local_reduce_group = local_reduce_group_n
+        local_reduce_axis = 1
     concat_layout = tuple(sorted(concat_layout)) if concat_layout else ()
     local_reduce_dtype = (
         torch2cute_dtype_map[local_reduce_out.dtype]
@@ -1103,6 +1151,9 @@ def gemm_act(
         local_reduce_out.ndim if local_reduce_out is not None else 0,
         local_reduce_group,
         local_reduce_axis,
+        local_reduce_is_block,
+        local_reduce_group_m,
+        local_reduce_group_n,
         local_reduce_stride_divisibility,
         local_reduce_combine_key,
         local_reduce_finalize_key,
@@ -1144,8 +1195,11 @@ def gemm_act(
         tensor_epilogue_returns_aux=None,
         tensor_epilogue_returns_local_reduce=None,
         local_reduce_feeds_main=None,
+        local_reduce_is_block=None,
         local_reduce_group=None,
         local_reduce_axis=None,
+        local_reduce_group_m=None,
+        local_reduce_group_n=None,
         local_reduce_combine_fn=None,
         local_reduce_finalize_fn=None,
         alpha=scalar_arg(alpha, alpha_mode, Float32),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #189316
* __->__ #189315
* #189314
* #189190
* #189188
* #188739
* #188112
* #188470
* #188469
* #188468

Enable the first QUACK-backed 2-D block local-reduce STORE path for
128x128 block-scale aux outputs. The compiler now threads block geometry into
runtime dispatch with explicit block kwargs, requires generated physical
callbacks, and gates configs to non-swap 128x128 CTA-local blocks
(tile_m=128, tile_n=128, cluster_m=cluster_n=1). Feed-main block reductions
remain rejected until the replay/feed slice.

The vendored GroupedLocalReduce block mode composes the existing primitives:
it replays N fragments inside the 128-column block, then reduces the resulting
per-row partials through the M-axis lane shuffle and warp shared-memory path,
finalizes once, and stores one value per compressed block. The N replay keeps
the current fragment intact until all fragments have been read so maxima/sums
from the final N fragment are not dropped.

Supported store reductions are min/max/sum/mean; mx_e8m0 block-scale
composition stays in the next slice. Validation covered a structured
row/column position probe, a seed-0 random repro, a two-config block sweep, the
block-local-reduce tests, local-reduce tests with pytest-xdist, vendor patch
check, py_compile, lintrunner, diff check, and the full FlexGEMM suite with
pytest -n 20.