### PR TITLE
flex_gemm: support mx block-scale stores

### DIFF
--- a/test/inductor/test_flex_gemm.py
+++ b/test/inductor/test_flex_gemm.py
@@ -2489,6 +2489,7 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
             ("amax_negative_dims", lambda x: x.abs().amax((-1, -3))),
             ("sum", lambda x: x.sum((1, 3))),
             ("mean", lambda x: x.mean((1, 3))),
+            ("mx_e8m0_scale", lambda x: mx_e8m0_scale(x.abs().amax((1, 3)))),
         ),
         name_fn=lambda case: case[0],
     )
@@ -2520,37 +2521,9 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
         torch.testing.assert_close(
             actual.float(), reference.relu(), atol=1e-1, rtol=1e-2
         )
-        torch.testing.assert_close(aux.float(), expected_aux, atol=1e-3, rtol=1e-3)
-
-    @unittest.skipIf(not SM100OrLater, "SM100+ required")
-    @skipIfNoCuteDSL
-    @parametrize(
-        "case",
-        (("mx_e8m0_scale", lambda x: mx_e8m0_scale(x.abs().amax((1, 3)))),),
-        name_fn=lambda case: case[0],
-    )
-    def test_generated_block_local_reduce_rejects_deferred_reductions(self, case):
-        _, reduce_fn = case
-        m = n = 256
-        block = 128
-
-        def fn(a, b):
-            def epilogue(acc):
-                x = acc.float().view(m // block, block, n // block, block)
-                return acc.relu(), reduce_fn(x)
-
-            return flex_gemm(
-                torch.mm,
-                (a, b),
-                epilogue,
-                kernel_options={"backend": "QUACK"},
-            )
-
-        a = torch.randn(m, 64, device="cuda", dtype=torch.bfloat16)
-        b = torch.randn(64, n, device="cuda", dtype=torch.bfloat16)
-
-        with self.assertRaisesRegex(Exception, "2-D block local reductions currently"):
-            torch.compile(fn, backend="inductor", fullgraph=True)(a, b)
+        torch.testing.assert_close(
+            aux.float(), expected_aux.float(), atol=1e-3, rtol=1e-3
+        )
 
     def test_generated_block_local_reduce_rejects_non_divisible_shape(self):
         m, n = 256, 192

--- a/tools/vendoring/quack/flex_gemm_patches/0011-flex-gemm-block-local-reduce-store.patch
+++ b/tools/vendoring/quack/flex_gemm_patches/0011-flex-gemm-block-local-reduce-store.patch
@@ -5,7 +5,7 @@ block, then use the existing M-axis lane/warp shared-memory combine to store one
 compressed value per CTA-local block.
 
 diff --git a/epi_ops.py b/epi_ops.py
-index de134691751..78a9ed520c8 100644
+index de134691751..c1d5e492d5a 100644
 --- a/epi_ops.py
 +++ b/epi_ops.py
 @@ -1225,6 +1225,9 @@ class GroupedLocalReduce(VecReduce):
@@ -48,7 +48,7 @@ index de134691751..78a9ed520c8 100644
              if const_expr(param[3]):
                  assert axis == 0
                  tiled_copy = ctx.tiled_copy_t2r if ctx.tiled_copy_t2r is not None else ctx.tiled_copy_r2s
-@@ -1349,6 +1362,156 @@ class GroupedLocalReduce(VecReduce):
+@@ -1349,6 +1362,160 @@ class GroupedLocalReduce(VecReduce):
              limit_n = min(cute.size(param_tensor, mode=[2]) - tile_coord_mnkl[1] * tile_N, tile_N)
              if const_expr(axis == 1):
                  local_fragment_n = const_expr(cute.size(tDrReduce_cur.shape, mode=[0]))
@@ -174,14 +174,16 @@ index de134691751..78a9ed520c8 100644
 +                                for warp_offset in cutlass.range_constexpr(1, group_warps):
 +                                    smem_warp_idx = group_warp_start + warp_offset - group_m_idx - 1
 +                                    group_value = combine_fn(group_value, sReduce[group_n_idx, smem_warp_idx])
-+                                group_value = finalize_fn(group_value)
++                                finalized_group_value = finalize_fn(group_value)
 +                                if const_expr(param_tensor.element_type != Float32):
-+                                    group_value = group_value.to(param_tensor.element_type)
++                                    store_group_value = finalized_group_value.to(param_tensor.element_type)
++                                else:
++                                    store_group_value = finalized_group_value
 +                                if (
 +                                    global_group_m_idx < limit_group_m
 +                                    and global_group_n_idx < limit_group_n
 +                                ):
-+                                    gReduce[group_m_idx, group_n_idx] = group_value
++                                    gReduce[group_m_idx, group_n_idx] = store_group_value
 +                        gemm.epilogue_barrier.arrive_and_wait()
 +                    else:
 +                        for i in cutlass.range(cute.size(tDrReduce_flt), unroll_full=True):
@@ -197,10 +199,12 @@ index de134691751..78a9ed520c8 100644
 +                                and global_group_m_idx < limit_group_m
 +                                and global_group_n_idx < limit_group_n
 +                            ):
-+                                group_value = finalize_fn(tDrReduce_flt[i])
++                                finalized_group_value = finalize_fn(tDrReduce_flt[i])
 +                                if const_expr(param_tensor.element_type != Float32):
-+                                    group_value = group_value.to(param_tensor.element_type)
-+                                gReduce[group_m_idx, group_n_idx] = group_value
++                                    store_group_value = finalized_group_value.to(param_tensor.element_type)
++                                else:
++                                    store_group_value = finalized_group_value
++                                gReduce[group_m_idx, group_n_idx] = store_group_value
 +                return
              if const_expr(axis == 1 and group > local_fragment_n):
                  assert combine_fn is not None

--- a/torch/_inductor/kernel/flex_gemm/epilogue.py
+++ b/torch/_inductor/kernel/flex_gemm/epilogue.py
@@ -910,6 +910,32 @@ def local_reduce_aux_result(
     return aux_result
 
 
+def block_local_reduce_base_reduction_type(
+    analysis: FlexGemmLocalReduceAnalysis,
+    node: torch.fx.Node,
+    geometry: FlexGemmBlockLocalReduceGeometry,
+) -> str | None:
+    """Find the reduction feeding a block contract through pointwise finalizers."""
+    stack = [node]
+    seen: OrderedSet[torch.fx.Node] = OrderedSet()
+    while stack:
+        current = stack.pop()
+        if current in seen:
+            continue
+        seen.add(current)
+        reduction = reduction_from_node(current)
+        if reduction is not None:
+            return reduction[4]
+        for arg in iter_fx_node_inputs((current.args, current.kwargs)):
+            contract = analysis.contract_for(arg)
+            if (
+                isinstance(contract, FlexGemmBlockLocalReduceContract)
+                and contract.geometry == geometry
+            ):
+                stack.append(arg)
+    return None
+
+
 def local_reduce_compressed_aux_plan(
     analysis: FlexGemmLocalReduceAnalysis,
     output: Any,
@@ -923,8 +949,10 @@ def local_reduce_compressed_aux_plan(
         return None
     match contract:
         case FlexGemmBlockLocalReduceContract(geometry=geometry):
-            reduction = reduction_from_node(aux)
-            if reduction is None or reduction[4] not in ("max", "min", "sum", "mean"):
+            reduction_type = block_local_reduce_base_reduction_type(
+                analysis, aux, geometry
+            )
+            if reduction_type not in ("max", "min", "sum", "mean"):
                 raise NotImplementedError(LOCAL_REDUCE_BLOCK_REDUCTION_ERROR)
             expected_aux_shape = local_reduce_block_compressed_shape(
                 output_meta.shape, geometry.group_m, geometry.group_n

--- a/torch/_vendor/quack/epi_ops.py
+++ b/torch/_vendor/quack/epi_ops.py
@@ -1484,14 +1484,16 @@ class GroupedLocalReduce(VecReduce):
                                 for warp_offset in cutlass.range_constexpr(1, group_warps):
                                     smem_warp_idx = group_warp_start + warp_offset - group_m_idx - 1
                                     group_value = combine_fn(group_value, sReduce[group_n_idx, smem_warp_idx])
-                                group_value = finalize_fn(group_value)
+                                finalized_group_value = finalize_fn(group_value)
                                 if const_expr(param_tensor.element_type != Float32):
-                                    group_value = group_value.to(param_tensor.element_type)
+                                    store_group_value = finalized_group_value.to(param_tensor.element_type)
+                                else:
+                                    store_group_value = finalized_group_value
                                 if (
                                     global_group_m_idx < limit_group_m
                                     and global_group_n_idx < limit_group_n
                                 ):
-                                    gReduce[group_m_idx, group_n_idx] = group_value
+                                    gReduce[group_m_idx, group_n_idx] = store_group_value
                         gemm.epilogue_barrier.arrive_and_wait()
                     else:
                         for i in cutlass.range(cute.size(tDrReduce_flt), unroll_full=True):
@@ -1507,10 +1509,12 @@ class GroupedLocalReduce(VecReduce):
                                 and global_group_m_idx < limit_group_m
                                 and global_group_n_idx < limit_group_n
                             ):
-                                group_value = finalize_fn(tDrReduce_flt[i])
+                                finalized_group_value = finalize_fn(tDrReduce_flt[i])
                                 if const_expr(param_tensor.element_type != Float32):
-                                    group_value = group_value.to(param_tensor.element_type)
-                                gReduce[group_m_idx, group_n_idx] = group_value
+                                    store_group_value = finalized_group_value.to(param_tensor.element_type)
+                                else:
+                                    store_group_value = finalized_group_value
+                                gReduce[group_m_idx, group_n_idx] = store_group_value
                 return
             if const_expr(axis == 1 and group > local_fragment_n):
                 assert combine_fn is not None


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189316
* #189315
* #189314
* #189190
* #189188
* #188739
* #188112
* #188470
* #188469
* #188468

Compose 2-D block local-reduce stores with physical-only finalizers such as
mx_e8m0_scale. Block aux plan classification now traces a shape-preserving
pointwise finalizer back to its base block reduction, allowing the existing
physical finalize callback composition to encode the final store value.

The vendored block store path keeps the finalized Float32 value separate from
the converted store value so CuTeDSL does not see a dynamic-region variable
change type when writing Float8E8M0FNU aux tensors.

Validation: block-local-reduce tests cover min/max/sum/mean plus mx_e8m0_scale;
vendor patch check, py_compile, lintrunner, diff check, and the full
FlexGEMM suite with pytest -n 20 are green. Benchmark scenario:
TORCHINDUCTOR_CACHE_DIR=/tmp/block2d_bench_cache2 /tmp/block2d_mx_bench.py on
m=n=k=1024 bf16 block128x128 mx_e8m0 store reported CUDA-event median 24.989us;
CUDA graph capture was attempted first but this compiled path rejected stream
capture.