### PR TITLE
Enable flake8-bugbear B007 (unused loop control variable)

### DIFF
--- a/.ci/libtorch/extract_libtorch_from_wheel.py
+++ b/.ci/libtorch/extract_libtorch_from_wheel.py
@@ -220,7 +220,7 @@ def create_libtorch_zip(
 ) -> Path:
     zip_path = output_dir / f"{zip_prefix}-{version}.zip"
     with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
-        for root, dirs, files in os.walk(libtorch_dir):
+        for root, _dirs, files in os.walk(libtorch_dir):
             for f in files:
                 filepath = Path(root) / f
                 arcname = filepath.relative_to(libtorch_dir.parent)

--- a/.github/scripts/check_doc_redirects.py
+++ b/.github/scripts/check_doc_redirects.py
@@ -119,7 +119,7 @@ def find_missing_redirects(
         List of (old_key, new_url) tuples. new_url is None for deletions.
     """
     missing = []
-    for status, old_path, new_path in changes:
+    for _status, old_path, new_path in changes:
         old_key = path_to_key(old_path)
         if old_key not in existing:
             new_url = path_to_url(new_path) if new_path else None

--- a/.github/scripts/test_gitutils.py
+++ b/.github/scripts/test_gitutils.py
@@ -29,7 +29,7 @@ class TestPeekableIterator(TestCase):
 
     def test_peek(self, input_: str = "abcdef") -> None:
         iter_ = PeekableIterator(input_)
-        for idx, c in enumerate(iter_):
+        for idx, _c in enumerate(iter_):
             if idx + 1 < len(input_):
                 self.assertEqual(iter_.peek(), input_[idx + 1])
             else:

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -2141,7 +2141,7 @@ def get_ghstack_dependent_prs(
     if skip_len > 0:
         rev_list = rev_list[:-skip_len]
     rc: list[tuple[str, GitHubPR]] = []
-    for pr_, sha in _revlist_to_prs(repo, pr, rev_list):
+    for pr_, _sha in _revlist_to_prs(repo, pr, rev_list):
         if not pr_.is_closed():
             if not only_closed:
                 rc.append(("", pr_))

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -711,7 +711,7 @@ def timed(
 
     time_total = 0
     # Dont collect outputs to correctly measure timing
-    for i in range(times):
+    for _i in range(times):
         # If batch_size is 1, it too often collides with other non batch size
         # dimensions resulting in errors.
         if batch_size and batch_size > 1:
@@ -1296,7 +1296,7 @@ def baselines(models, model_iter_fn, example_inputs, args):
     timings = np.zeros((args.repeat, len(models)), np.float64)
     timings.fill(1.0e10)
     for rep in range(args.repeat):
-        for idx, (name, model) in enumerate(models):
+        for idx, (_name, model) in enumerate(models):
             if model is not None:
                 try:
                     timings[rep, idx] = timed(model, model_iter_fn, example_inputs)
@@ -1308,7 +1308,7 @@ def baselines(models, model_iter_fn, example_inputs, args):
     ]
     median = np.median(timings, axis=0)
     speedup = median[0] / median[1:]
-    for idx, (name, model) in enumerate(models[1:]):
+    for idx, (_name, model) in enumerate(models[1:]):
         if model is None:
             speedup[idx] = 0.0
     result = " ".join(

--- a/benchmarks/dynamo/distributed.py
+++ b/benchmarks/dynamo/distributed.py
@@ -34,7 +34,7 @@ def torchviz_model(args, model, inputs, rank):
 
 def profile_model(args, model, inputs, rank):
     with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as prof:
-        for i in range(args.repeat):
+        for _i in range(args.repeat):
             with record_function("Forward"):
                 outputs = model(*inputs)
                 loss = reduce_to_scalar_loss(outputs)

--- a/benchmarks/dynamo/microbenchmarks/analyze_templates.py
+++ b/benchmarks/dynamo/microbenchmarks/analyze_templates.py
@@ -150,7 +150,7 @@ def optimize_templates(N, occurrence_count, benchmark_logs, verbose=False):
         )
 
         # Ensure Triton templates can only be selected if they are included in the N allowed templates
-        for triton_time, template in triton_options:
+        for _triton_time, template in triton_options:
             prob += selection_vars[(shape, template)] <= template_vars[template]
 
     # Print the constraints

--- a/benchmarks/dynamo/microbenchmarks/fx_microbenchmarks.py
+++ b/benchmarks/dynamo/microbenchmarks/fx_microbenchmarks.py
@@ -20,7 +20,7 @@ def main():
     g = huge_graph()
 
     def fn():
-        for n in g.graph.nodes:
+        for _n in g.graph.nodes:
             pass
 
     t = min(timeit.repeat(fn, number=K, repeat=3))

--- a/benchmarks/dynamo/pr_time_benchmarks/benchmarks/mm_loop.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/benchmarks/mm_loop.py
@@ -41,7 +41,7 @@ class Benchmark(BenchmarkBase):
         )
         def f(a, b):
             z = torch.mm(a, b)
-            for i in range(200):
+            for _i in range(200):
                 z = torch.mm(z, b)
             return z
 

--- a/benchmarks/dynamo/pr_time_benchmarks/benchmarks/nested_module.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/benchmarks/nested_module.py
@@ -18,10 +18,10 @@ class NestedModule(nn.Module):
 
         sub_mods = []
         if depth > 0:
-            for i in range(width):
+            for _i in range(width):
                 sub_mods.append(NestedModule(depth - 1, width))
         else:
-            for i in range(width):
+            for _i in range(width):
                 sub_mods.append(nn.ReLU())
         self.sub_mods = nn.Sequential(*sub_mods)
         self.a = 2

--- a/benchmarks/dynamo/summarize_perf.py
+++ b/benchmarks/dynamo/summarize_perf.py
@@ -29,7 +29,7 @@ def find_csv_files(path, perf_compare):
             return f.endswith("_performance.csv")
 
     csv_files = []
-    for root, dirs, files in os.walk(path):
+    for root, _dirs, files in os.walk(path):
         for file in files:
             if is_csv(file):
                 csv_files.append(os.path.join(root, file))

--- a/benchmarks/dynamo/torchbench.py
+++ b/benchmarks/dynamo/torchbench.py
@@ -41,7 +41,7 @@ def _reassign_parameters(model):
     # https://github.com/pyg-team/pytorch_geometric/blob/master/torch_geometric/nn/dense/linear.py#L158-L168
     # Since it is unusual thing to do, we just reassign them to parameters
     def state_dict_hook(module, destination, prefix, local_metadata):
-        for name, param in module.named_parameters():
+        for name, _param in module.named_parameters():
             if isinstance(destination[name], torch.Tensor) and not isinstance(
                 destination[name], torch.nn.Parameter
             ):

--- a/benchmarks/dynamo/training_loss.py
+++ b/benchmarks/dynamo/training_loss.py
@@ -64,7 +64,7 @@ def model_training_evaluation(
     else:
         # Support backends: eager, aot_eager, aot_nvfuser and inductor
         opt_training_iter_fn = torch._dynamo.optimize(backend)(training_iter_fn)
-    for epoch in range(num_epochs):
+    for _epoch in range(num_epochs):
         running_loss = 0.0
         for i, batch in enumerate(train_dataloader, 0):
             batch = {k: v.to(device) for k, v in batch.items()}

--- a/benchmarks/fastrnns/factory.py
+++ b/benchmarks/fastrnns/factory.py
@@ -339,7 +339,7 @@ def layernorm_pytorch_lstm_creator(**kwargs):
         # Layernorm cudnn LSTM in the forward pass
         seq_len = len(input.unbind(0))
         hy, cy = new_hidden
-        for i in range(seq_len):
+        for _i in range(seq_len):
             ln_i(ln_input1)
             ln_h(ln_input1)
             cy = ln_c(cy)

--- a/benchmarks/fastrnns/scratch.py
+++ b/benchmarks/fastrnns/scratch.py
@@ -9,7 +9,7 @@ def fn(x, scale, shift):
 @torch.jit.script
 def recurrent(x, scale, shift):
     y = x
-    for i in range(100):
+    for _i in range(100):
         y = fn(y, scale, shift)
     return y
 
@@ -30,7 +30,7 @@ import torch
 @torch.jit.script
 def recurrent_scaleshift(x, scale, shift):
     y = x
-    for i in range(64):
+    for _i in range(64):
         y = scale * y + shift
     return y
 

--- a/benchmarks/framework_overhead_benchmark/SimpleAddModule.py
+++ b/benchmarks/framework_overhead_benchmark/SimpleAddModule.py
@@ -5,7 +5,7 @@ import torch
 
 def add_tensors_loop(x, y):
     z = torch.add(x, y)
-    for i in range(NUM_LOOP_ITERS):
+    for _i in range(NUM_LOOP_ITERS):
         z = torch.add(z, x)
     return z
 

--- a/benchmarks/functional_autograd_benchmark/functional_autograd_benchmark.py
+++ b/benchmarks/functional_autograd_benchmark/functional_autograd_benchmark.py
@@ -250,7 +250,7 @@ def run_model(
     run_once_fn(model, inp, task, v, maybe_check_consistency=True)
 
     elapsed = []
-    for it in range(args.num_iters):
+    for _it in range(args.num_iters):
         do_sync()
         start = time.time()
         run_once_fn(model, inp, task, v)

--- a/benchmarks/functional_autograd_benchmark/utils.py
+++ b/benchmarks/functional_autograd_benchmark/utils.py
@@ -56,7 +56,7 @@ def extract_weights(mod: nn.Module) -> tuple[tuple[Tensor, ...], list[str]]:
     orig_params = tuple(mod.parameters())
     # Remove all the parameters in the model
     names = []
-    for name, p in list(mod.named_parameters()):
+    for name, _p in list(mod.named_parameters()):
         _del_nested_attr(mod, name.split("."))
         names.append(name)
 

--- a/benchmarks/functional_autograd_benchmark/vision_models.py
+++ b/benchmarks/functional_autograd_benchmark/vision_models.py
@@ -111,7 +111,7 @@ def get_detr(device: torch.device) -> GetterReturnType:
 
     inputs = torch.rand(N, 3, 800, 1200, device=device)
     labels = []
-    for idx in range(N):
+    for _idx in range(N):
         targets = {}
         n_targets: int = int(torch.randint(5, 10, size=()).item())
         label = torch.randint(5, 10, size=(n_targets,), device=device)

--- a/benchmarks/gpt_fast/generate.py
+++ b/benchmarks/gpt_fast/generate.py
@@ -105,7 +105,7 @@ def decode_n_tokens(
     **sampling_kwargs,
 ):
     new_tokens, new_probs = [], []
-    for i in range(num_new_tokens):
+    for _i in range(num_new_tokens):
         with torch.nn.attention.sdpa_kernel(
             torch.nn.attention.SDPBackend.MATH
         ):  # Actually better for Inductor to codegen attention here
@@ -172,7 +172,7 @@ def _load_model(x: GPTModelConfig, device="cuda", precision=torch.bfloat16):
 # Only count activated parameters and buffers.
 def _get_model_size(model):
     model_size = 0
-    for name, child in model.named_children():
+    for _name, child in model.named_children():
         if not isinstance(child, torch.nn.Embedding):
             model_size += sum(
                 p.numel() * p.dtype.itemsize

--- a/benchmarks/gpt_fast/mixtral_moe_model.py
+++ b/benchmarks/gpt_fast/mixtral_moe_model.py
@@ -141,7 +141,7 @@ class Transformer(nn.Module):
         freqs_cis = self.freqs_cis[input_pos]
         x = self.tok_embeddings(idx)
 
-        for i, layer in enumerate(self.layers):
+        for _i, layer in enumerate(self.layers):
             x = layer(x, input_pos, freqs_cis, mask)
         x = self.norm(x)
         logits = self.output(x)

--- a/benchmarks/gpt_fast/model.py
+++ b/benchmarks/gpt_fast/model.py
@@ -160,7 +160,7 @@ class Transformer(nn.Module):
         freqs_cis = self.freqs_cis[input_pos]
         x = self.tok_embeddings(idx)
 
-        for i, layer in enumerate(self.layers):
+        for _i, layer in enumerate(self.layers):
             x = layer(x, input_pos, freqs_cis, mask)
         x = self.norm(x)
         logits = self.output(x)

--- a/benchmarks/inference/server.py
+++ b/benchmarks/inference/server.py
@@ -50,7 +50,7 @@ class FrontendWorker(mp.Process):
         warmup_response_time = None
         response_times = []
 
-        for i in range(self.num_iters + 1):
+        for _i in range(self.num_iters + 1):
             response, request_time = self.response_queue.get()
             if warmup_response_time is None:
                 self.warmup_event.set()

--- a/benchmarks/instruction_counts/execution/runner.py
+++ b/benchmarks/instruction_counts/execution/runner.py
@@ -181,7 +181,7 @@ class Runner:
 
     def _enqueue_new_jobs(self) -> None:
         work_queue: list[WorkOrder] = []
-        for i, work_order in enumerate(self._work_queue):
+        for _i, work_order in enumerate(self._work_queue):
             self._currently_processed = work_order
             cpu_list = self._core_pool.reserve(work_order.timer_args.num_threads)
 

--- a/benchmarks/nested/nested_bmm_bench.py
+++ b/benchmarks/nested/nested_bmm_bench.py
@@ -12,7 +12,7 @@ def bench(nt_a, nt_b, niter):
     start_event = torch.cuda.Event(enable_timing=True)
     end_event = torch.cuda.Event(enable_timing=True)
     start_event.record()
-    for iter in range(niter):
+    for _iter in range(niter):
         nt_a.bmm(nt_b)
     end_event.record()
     torch.cuda.synchronize()

--- a/benchmarks/operator_benchmark/benchmark_utils.py
+++ b/benchmarks/operator_benchmark/benchmark_utils.py
@@ -289,7 +289,7 @@ def random_sample_configs(**configs):
 
     configs_attrs_list = []
     randomsample = RandomSample(configs)
-    for i in range(configs["total_samples"]):
+    for _i in range(configs["total_samples"]):
         tmp_attr_list = randomsample.get_one_set_of_inputs()
         tmp_attr_list.append({"tags": "_".join(configs["tags"])})
         configs_attrs_list.append(tmp_attr_list)

--- a/benchmarks/operator_benchmark/pt/cat_test.py
+++ b/benchmarks/operator_benchmark/pt/cat_test.py
@@ -128,7 +128,7 @@ class CatBenchmark(op_bench.TorchBenchmarkBase):
         if type(sizes) is list and N == -1:
             gen_sizes = sizes
         else:
-            for i in range(N):
+            for _i in range(N):
                 gen_sizes.append(
                     [
                         old_size() if callable(old_size) else old_size

--- a/benchmarks/operator_benchmark/pt/stack_test.py
+++ b/benchmarks/operator_benchmark/pt/stack_test.py
@@ -64,7 +64,7 @@ class StackBenchmark(op_bench.TorchBenchmarkBase):
         if type(sizes) is list and N == -1:
             gen_sizes = sizes
         else:
-            for i in range(N):
+            for _i in range(N):
                 gen_sizes.append(
                     [
                         old_size() if callable(old_size) else old_size

--- a/benchmarks/operator_benchmark/pt_extension/cpp_extension_test.py
+++ b/benchmarks/operator_benchmark/pt_extension/cpp_extension_test.py
@@ -10,7 +10,7 @@ class TestConsumeOp(unittest.TestCase):
         iters = 6
 
         def foo(x):
-            for i in range(iters):
+            for _i in range(iters):
                 result = torch.ops.operator_benchmark._consume(torch.sum(x))
             return result
 
@@ -28,7 +28,7 @@ class TestConsumeOp(unittest.TestCase):
         iters = 6
 
         def foo(x):
-            for i in range(iters):
+            for _i in range(iters):
                 result = torch.ops.operator_benchmark._consume(torch.chunk(x, 2))
             return result
 

--- a/benchmarks/profiler_benchmark/profiler_bench.py
+++ b/benchmarks/profiler_benchmark/profiler_bench.py
@@ -11,19 +11,19 @@ INTERNAL_ITER = None
 
 
 def loop_workload(x):
-    for i in range(INTERNAL_ITER):
+    for _i in range(INTERNAL_ITER):
         x = torch.mm(x, x)
     return x
 
 
 def parallel_workload(x):
     def parallel_task(x):
-        for i in range(int(INTERNAL_ITER / PARALLEL_TASKS_NUM)):
+        for _i in range(int(INTERNAL_ITER / PARALLEL_TASKS_NUM)):
             x = torch.mm(x, x)
         return x
 
     futs = []
-    for i in range(PARALLEL_TASKS_NUM):
+    for _i in range(PARALLEL_TASKS_NUM):
         futs.append(torch.jit._fork(parallel_task, x))
     for i in range(PARALLEL_TASKS_NUM):
         torch.jit._wait(futs[i])

--- a/benchmarks/sparse/triton_ops.py
+++ b/benchmarks/sparse/triton_ops.py
@@ -382,7 +382,7 @@ if __name__ == "__main__":
                 )
                 time_ms_lst = []
                 performance_tflops_lst = []
-                for r in range(args.repeat):
+                for _r in range(args.repeat):
                     try:
                         time_ms, performance_tflops = test_func(x, y, **meta)
                     except triton.compiler.OutOfResources:

--- a/benchmarks/sparse/utils.py
+++ b/benchmarks/sparse/utils.py
@@ -39,7 +39,7 @@ def gen_sparse_coo(shape, nnz):
     dense = np.random.randn(*shape)
     values = []
     indices = [[], []]
-    for n in range(nnz):
+    for _n in range(nnz):
         row = random.randint(0, shape[0] - 1)
         col = random.randint(0, shape[1] - 1)
         indices[0].append(row)

--- a/benchmarks/tensorexpr/benchmark.py
+++ b/benchmarks/tensorexpr/benchmark.py
@@ -291,7 +291,7 @@ class DynamicShape:
     # pre-compute inputs so the creations of random tensors
     # do not add to the compute time
     def load_inputs(self):
-        for i in range(self.SAMPLE_SIZE - 1):
+        for _i in range(self.SAMPLE_SIZE - 1):
             self.instantiate_input()
 
     # returns a randomized shape

--- a/benchmarks/tensorexpr/microbenchmarks.py
+++ b/benchmarks/tensorexpr/microbenchmarks.py
@@ -255,7 +255,7 @@ def run_benchmarks(benchmarks, sizes):
                     for _ in range(10):
                         cg.call([tA, tB, tX])
                     start = time.time()
-                    for it in range(iters):
+                    for _it in range(iters):
                         cg.call([tA, tB, tX])
                     time1 = time.time() - start
 
@@ -264,7 +264,7 @@ def run_benchmarks(benchmarks, sizes):
                     for _ in range(10):
                         tR = fn()
                     start = time.time()
-                    for it in range(iters):
+                    for _it in range(iters):
                         tR = fn()
                     time2 = time.time() - start
 
@@ -297,7 +297,7 @@ def dump_plot(df, sizes):
     keys = []
     vals = []
     indexed = df[df["N"] == df["M"]]
-    for index, row in indexed.iterrows():
+    for _index, row in indexed.iterrows():
         keys.append(row["name"])
         vals.append(row["ratio"])
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2343,7 +2343,7 @@ def coverage_post_process(app, exception):
     if "torch" not in modules:
         missing.add("torch")
 
-    for _, modname, ispkg in pkgutil.walk_packages(
+    for _, modname, _ispkg in pkgutil.walk_packages(
         path=torch.__path__, prefix=torch.__name__ + "."
     ):
         if is_not_internal(modname):

--- a/functorch/dim/__init__.py
+++ b/functorch/dim/__init__.py
@@ -1325,7 +1325,7 @@ def split(tensor: Any, split_size_or_sections: Any, dim: Any = None) -> tuple:
     result = []
     new_levels = list(self_info.levels)
 
-    for i, (result_tensor, size_dim) in enumerate(zip(result_tensors, sizes)):
+    for _i, (result_tensor, size_dim) in enumerate(zip(result_tensors, sizes)):
         new_levels[idx] = DimEntry(size_dim)
         result.append(
             Tensor.from_positional(

--- a/functorch/examples/maml_omniglot/maml-omniglot-ptonly.py
+++ b/functorch/examples/maml_omniglot/maml-omniglot-ptonly.py
@@ -201,7 +201,7 @@ def test(db, net, device, epoch, log):
     qry_losses = []
     qry_accs = []
 
-    for batch_idx in range(n_test_iter):
+    for _batch_idx in range(n_test_iter):
         x_spt, y_spt, x_qry, y_qry = db.next("test")
         task_num, setsz, c_, h, w = x_spt.size()
 

--- a/functorch/examples/maml_omniglot/maml-omniglot-transforms.py
+++ b/functorch/examples/maml_omniglot/maml-omniglot-transforms.py
@@ -199,7 +199,7 @@ def test(db, net, device, epoch, log):
     qry_losses = []
     qry_accs = []
 
-    for batch_idx in range(n_test_iter):
+    for _batch_idx in range(n_test_iter):
         x_spt, y_spt, x_qry, y_qry = db.next("test")
         task_num, setsz, c_, h, w = x_spt.size()
 

--- a/functorch/examples/maml_omniglot/support/omniglot_loaders.py
+++ b/functorch/examples/maml_omniglot/support/omniglot_loaders.py
@@ -120,7 +120,7 @@ class Omniglot(data.Dataset):
 
 def find_classes(root_dir):
     retour = []
-    for root, dirs, files in os.walk(root_dir):
+    for root, _dirs, files in os.walk(root_dir):
         for f in files:
             if f.endswith("png"):
                 r = root.split("/")
@@ -177,10 +177,8 @@ class OmniglotNShot:
                     temp[label] = [img]
 
             self.x = []
-            for (
-                label,
-                imgs,
-            ) in temp.items():  # labels info deserted , each label contains 20imgs
+            # labels info deserted , each label contains 20imgs
+            for imgs in temp.values():
                 self.x.append(np.array(imgs))
 
             # as different class may have different number of imgs
@@ -260,9 +258,9 @@ class OmniglotNShot:
         data_cache = []
 
         # print('preload next 50 caches of batchsz of batch.')
-        for sample in range(10):  # num of episodes
+        for _sample in range(10):  # num of episodes
             x_spts, y_spts, x_qrys, y_qrys = [], [], [], []
-            for i in range(self.batchsz):  # one batch means one set
+            for _i in range(self.batchsz):  # one batch means one set
                 x_spt, y_spt, x_qry, y_qry = [], [], [], []
                 selected_cls = np.random.choice(data_pack.shape[0], self.n_way, False)
 

--- a/functorch/examples/maml_regression/evjang.py
+++ b/functorch/examples/maml_regression/evjang.py
@@ -109,7 +109,7 @@ t_y = t_A * torch.sin(t_x + t_b)
 opt.zero_grad()
 
 t_params = params
-for k in range(5):
+for _k in range(5):
     t_f = net(t_x, t_params)
     t_loss = F.l1_loss(t_f, t_y)
 

--- a/functorch/examples/maml_regression/evjang_transforms.py
+++ b/functorch/examples/maml_regression/evjang_transforms.py
@@ -113,7 +113,7 @@ t_y = t_A * torch.sin(t_x + t_b)
 opt.zero_grad()
 
 t_params = params
-for k in range(5):
+for _k in range(5):
     t_f = net(t_params, t_x)
     t_loss = F.l1_loss(t_f, t_y)
 

--- a/functorch/examples/maml_regression/evjang_transforms_module.py
+++ b/functorch/examples/maml_regression/evjang_transforms_module.py
@@ -109,7 +109,7 @@ t_y = t_A * torch.sin(t_x + t_b)
 opt.zero_grad()
 
 t_params = params
-for k in range(5):
+for _k in range(5):
     t_f = net(t_params, t_x)
     t_loss = F.l1_loss(t_f, t_y)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -423,7 +423,7 @@ external = [
 ]
 ignore = [
     # these ignores are from flake8-bugbear; please fix!
-    "B007", "B008", "B017",
+    "B008", "B017",
     "B018", # Useless expression
     "B023",
     "B028", # No explicit `stacklevel` keyword argument found
@@ -535,6 +535,14 @@ select = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
+# B007 (unused loop control variable) is enabled repo-wide, but these files
+# carry pre-existing ruff-format (PYFMT) debt; reformatting them is out of
+# scope for enabling B007, so it stays suppressed here until they are
+# reformatted.
+"test/test_datapipe.py" = ["B007"]
+"test/test_mps.py" = ["B007"]
+"test/test_sparse_csr.py" = ["B007"]
+"test/quantization/fx/test_quantize_fx.py" = ["B007"]
 "__init__.py" = [
     "F401",
 ]

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_memory.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_memory.py
@@ -364,7 +364,7 @@ class TestMemoryLeaks(TestCase):
         size = 50 * 1024 * 1024 // 4
         iterations = 50
 
-        for i in range(iterations):
+        for _i in range(iterations):
             x = torch.empty(size, device="openreg")
             del x
             gc.collect()
@@ -382,11 +382,11 @@ class TestMemoryLeaks(TestCase):
         num_cycles = 10
         allocations_per_cycle = 100
 
-        for cycle in range(num_cycles):
+        for _cycle in range(num_cycles):
             tensors = []
 
             # Allocate many tensors
-            for i in range(allocations_per_cycle):
+            for _i in range(allocations_per_cycle):
                 t = torch.empty(1000, device="openreg")
                 tensors.append(t)
 

--- a/test/distributed/_composable/fsdp/test_fully_shard_state_dict.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_state_dict.py
@@ -217,7 +217,7 @@ class TestFullyShardStateDictMultiProcess(FSDPTest):
         with context:
             model(inp).sum()
             state_dict = model.state_dict()
-            for name, dtensor in state_dict.items():
+            for dtensor in state_dict.values():
                 self.assertEqual(dtensor.device.type, "cpu")
 
     @skip_if_lt_x_gpu(2)

--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -2216,7 +2216,7 @@ class TestFullyShardNDTraining(FSDPTest):
         fully_shard(
             model, mesh=dp_mesh, reshard_after_forward=reshard_non_layer_modules
         )
-        for (name, param), (_, ref_param) in zip(
+        for (_name, param), (_, ref_param) in zip(
             model.named_parameters(), ref_model.named_parameters()
         ):
             full_param = param.full_tensor()

--- a/test/distributed/elastic/test_control_plane.py
+++ b/test/distributed/elastic/test_control_plane.py
@@ -242,7 +242,7 @@ class WorkerServerTest(TestCase):
 
             # Use the counter multiple times to generate metrics
             # Note: Using minimal/no sleep to avoid timing issues
-            for i in range(3):
+            for _i in range(3):
                 with counter.guard():
                     pass  # Minimal work
 

--- a/test/distributed/tensor/test_matrix_ops.py
+++ b/test/distributed/tensor/test_matrix_ops.py
@@ -263,7 +263,7 @@ class DistMatrixOpsTest(DTensorTestBase):
 
         # Find strategies where output is Partial (contracting dim case)
         # Strategy format: [output, bias, mat1, mat2]
-        for strategies, bias_shape in [
+        for strategies, _bias_shape in [
             (strategies_1d, bias_shape_1d),
             (strategies_2d, bias_shape_2d),
         ]:

--- a/test/distributed/tensor/test_strategy_validation.py
+++ b/test/distributed/tensor/test_strategy_validation.py
@@ -752,7 +752,7 @@ class TestCreatePartialInput(TestCase):
         tensor = torch.tensor([-10.0, -1.0, 5.0, 8.0])
         value_range = (tensor.max() - tensor.min()).item()  # 18.0
 
-        for reduce_op, sign in [("min", 1), ("max", -1)]:
+        for reduce_op, _sign in [("min", 1), ("max", -1)]:
             local = _create_partial_input(tensor, Partial(reduce_op), world_size=2)
             r0, r1 = local._local_tensors[0], local._local_tensors[1]
             # The actual offset applied should exceed value_range

--- a/test/distributed/tensor/test_utils.py
+++ b/test/distributed/tensor/test_utils.py
@@ -1399,7 +1399,7 @@ class Test_StridedShard_Optimizer(DTensorTestBase):
             optim.step()
 
             # Verify parameters still have correct placement after optimizer step
-            for name, param in model.named_parameters():
+            for _name, param in model.named_parameters():
                 self.assertIsInstance(param, DTensor)
                 self.assertEqual(len(param.placements), 2)
 
@@ -1846,7 +1846,7 @@ class TestStridedShardAlltoAll(TestStridedShardCollectiveOpUtils, LocalTensorTes
             mesh_shape,
             tensor_shape,
             src_p,
-            src_tensor_dim,
+            _src_tensor_dim,
             tgt_p,
             tgt_tensor_dim,
             operate_mesh_dim,

--- a/test/distributed/test_c10d_functional_native.py
+++ b/test/distributed/test_c10d_functional_native.py
@@ -154,7 +154,7 @@ class TestWithNCCL(DistributedTestBase):
             "avg",
             "default",
         )
-        for i, (output, input) in enumerate(zip(outputs, inputs)):
+        for i, (output, _input) in enumerate(zip(outputs, inputs)):
             if output.completed:
                 raise AssertionError("Expected output.completed to be False")
             expected = sum(self.ranks) / self.world_size * i

--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -3027,7 +3027,7 @@ class ReducerTest(TestCase):
         reducer_bat = self._create_reducer(model_bat, batched_grad_copy=True)
         loss_fn = nn.CrossEntropyLoss()
 
-        for i in range(3):
+        for _i in range(3):
             input = torch.rand([10, 2], dtype=torch.double)
             target = torch.LongTensor([random.randrange(4) for _ in range(10)])
 
@@ -3073,7 +3073,7 @@ class ReducerTest(TestCase):
         )
         loss_fn = nn.CrossEntropyLoss()
 
-        for i in range(3):
+        for _i in range(3):
             input = torch.rand([10, 2], dtype=torch.double)
             target = torch.LongTensor([random.randrange(4) for _ in range(10)])
 
@@ -3132,7 +3132,7 @@ class ReducerTest(TestCase):
         self.assertIsNone(model_bat.fc3.weight.grad)
 
         # Used parameters should have identical grads
-        for (name_ref, p_ref), (name_bat, p_bat) in zip(
+        for (name_ref, p_ref), (_name_bat, p_bat) in zip(
             model_ref.named_parameters(), model_bat.named_parameters()
         ):
             if p_ref.grad is not None:

--- a/test/distributed/test_c10d_ops_nccl.py
+++ b/test/distributed/test_c10d_ops_nccl.py
@@ -555,7 +555,7 @@ class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
         for idx in range(num_gpus):
             gpu_idx = local_device_ids[idx]
             output_ts.append([])
-            for rank in range(self.world_size):
+            for _rank in range(self.world_size):
                 output_ts[idx].append(torch.tensor([-1]).cuda(gpu_idx))
 
         expected = [[torch.tensor([rank]) for rank in range(self.world_size)]]

--- a/test/distributed/test_data_parallel.py
+++ b/test/distributed/test_data_parallel.py
@@ -594,7 +594,7 @@ class TestDataParallel(TestCase):
             opt_single.step()
             opt_dp.step()
 
-            for (n1, p1), (n2, p2) in zip(
+            for (n1, p1), (_n2, p2) in zip(
                 model_single.named_parameters(), model_dp_base.named_parameters()
             ):
                 self.assertEqual(p1.grad.shape, p2.grad.shape)
@@ -604,7 +604,7 @@ class TestDataParallel(TestCase):
                     lambda msg: f"{msg}\nEpoch {epoch}: gradients differ for {n1}",
                 )
 
-            for (n1, p1), (n2, p2) in zip(
+            for (n1, p1), (_n2, p2) in zip(
                 model_single.named_parameters(), model_dp_base.named_parameters()
             ):
                 self.assertTrue(
@@ -671,7 +671,7 @@ class TestDataParallel(TestCase):
             opt_single.step()
             opt_dp.step()
 
-            for (n1, p1), (n2, p2) in zip(
+            for (n1, p1), (_n2, p2) in zip(
                 model_single.named_parameters(), model_dp_base.named_parameters()
             ):
                 self.assertEqual(p1.grad.shape, p2.grad.shape)
@@ -681,7 +681,7 @@ class TestDataParallel(TestCase):
                     lambda msg: f"{msg}\nEpoch {epoch}: gradients differ for {n1}",
                 )
 
-            for (n1, p1), (n2, p2) in zip(
+            for (n1, p1), (_n2, p2) in zip(
                 model_single.named_parameters(), model_dp_base.named_parameters()
             ):
                 self.assertTrue(

--- a/test/distributed/test_overlap_bucketing_unit.py
+++ b/test/distributed/test_overlap_bucketing_unit.py
@@ -2647,7 +2647,7 @@ class TestBitsetAncestors(TestCase):
 
         g = fx.Graph()
         nodes = [g.placeholder("x")]
-        for i in range(99):
+        for _i in range(99):
             nodes.append(g.call_function(torch.relu, (nodes[-1],)))
         g.output(nodes[-1])
 

--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -1425,7 +1425,7 @@ class SymmMemCollectiveTest(MultiProcContinuousTest):
         self._init_process()
         group_name = dist.group.WORLD.group_name
 
-        for dtype, size_bytes, align_bytes, copy, offset in itertools.product(
+        for dtype, size_bytes, _align_bytes, copy, offset in itertools.product(
             [torch.float, torch.bfloat16],
             [4, 8192, 8196],
             [

--- a/test/dynamo/test_aot_compile.py
+++ b/test/dynamo/test_aot_compile.py
@@ -1569,13 +1569,13 @@ from user code:
             """
             torch.manual_seed(seed)
             getattr(torch, GPU_TYPE).manual_seed(seed)
-            for name, param in module.named_parameters():
+            for _name, param in module.named_parameters():
                 if param.requires_grad:
                     local_param = (
                         param.to_local() if isinstance(param, DTensor) else param
                     )
                     local_param.data.normal_(mean=0.0, std=0.02)
-            for name, buf in module.named_buffers():
+            for _name, buf in module.named_buffers():
                 local_buf = buf.to_local() if isinstance(buf, DTensor) else buf
                 local_buf.data.normal_(mean=0.0, std=0.02)
 

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -2875,8 +2875,8 @@ graph break in loop
 Stack variable source attribution:
   RangeIteratorVariable() originated from:
   File "test_error_messages.py", line N
-                for i in range(2):
-                         ~~~~~^^^
+                for _i in range(2):
+                          ~~~~~^^^
 
 User code traceback:
   File "test_error_messages.py", line N, in test_stack_variable_source_attribution

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -1261,7 +1261,7 @@ from user code:
     def test_graph_break_in_loop(self, records):
         @torch.compile(backend="eager")
         def fn(x):
-            for i in range(2):
+            for _i in range(2):
                 torch._dynamo.graph_break()
             return x + 1
 
@@ -1303,7 +1303,7 @@ User code traceback:
 
         @torch.compile(backend="eager")
         def gn(x):
-            for i in range(2):
+            for _i in range(2):
                 if x.sum() > 0:
                     x = x + 1
                 else:
@@ -1356,7 +1356,7 @@ User code traceback:
     @make_logging_test(graph_breaks=True)
     def test_skip_frame_in_loop_message(self, records):
         def fn(x):
-            for i in range(2):
+            for _i in range(2):
                 with GenericCtxMgr():
                     if x.sum() > 0:
                         x = x + 1
@@ -2543,7 +2543,7 @@ User code traceback:
         global f1, f2, f3
 
         def f1(x):
-            for i in range(2):
+            for _i in range(2):
                 with GenericCtxMgr():
                     if x.sum() > 0:
                         x = x + 1
@@ -2837,7 +2837,7 @@ NOTE: the most recent `torch.compile` tracing attempt might not be where you app
     def test_stack_variable_source_attribution(self, records):
         @torch.compile(backend="eager")
         def fn(x):
-            for i in range(2):
+            for _i in range(2):
                 torch._dynamo.graph_break()
             return x + 1
 

--- a/test/dynamo/test_generator.py
+++ b/test/dynamo/test_generator.py
@@ -681,7 +681,7 @@ class GraphModule(torch.nn.Module):
 
         def fn(t):
             s = 0
-            for b, p in itertools.product(whoo(t), itertools.permutations((4, 5))):
+            for b, _p in itertools.product(whoo(t), itertools.permutations((4, 5))):
                 s += b
             return s
 

--- a/test/dynamo/test_polyfills.py
+++ b/test/dynamo/test_polyfills.py
@@ -203,7 +203,7 @@ class TestGroupTensorsByDeviceAndDtype(TestCase):
             # Perform some tensor computation to ensure the frame is not skipped
             # Sum up results for each dtype group
             total = torch.tensor(0.0)
-            for grouped_tensors, indices in grouped.values():
+            for grouped_tensors, _indices in grouped.values():
                 tensor_list, grad_list = grouped_tensors
                 for t, g in zip(tensor_list, grad_list):
                     if t is not None and g is not None:

--- a/test/dynamo/test_recompiles.py
+++ b/test/dynamo/test_recompiles.py
@@ -599,7 +599,7 @@ class RecompileTests(torch._dynamo.test_case.TestCase):
         @torch.compile(backend=counter, fullgraph=True)
         def apply_patches(f, x, keys):
             patches = []
-            for key, patch in keys:  # noqa: F402
+            for key, patch in keys:  # noqa: F402, B007
                 patches.append(patch)
             x = f(x, key, patches)
             return x

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -77,7 +77,7 @@ def _check_compile_cudagraph_backend(test_case, fn, args):
     # 3 and beyond) do graph replay
     # So we need to get to iteration 3 to test all ways of running.
     outputs = []
-    for i in range(3):
+    for _i in range(3):
         with check_cudagraphs_not_skipped(test_case):
             torch.compiler.cudagraph_mark_step_begin()
             outputs.append(

--- a/test/functorch/test_control_flow_cuda_initialization.py
+++ b/test/functorch/test_control_flow_cuda_initialization.py
@@ -34,8 +34,8 @@ class TestControlFlowInCUDAGraphInitialization(TestCase):
 
         outputs = []
 
-        for p in [pred, torch.logical_not(pred)]:
-            for i in range(3):
+        for _p in [pred, torch.logical_not(pred)]:
+            for _i in range(3):
                 torch.compiler.cudagraph_mark_step_begin()
                 outputs.append(f_compiled(pred, *other_args).clone())
 

--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -1415,7 +1415,7 @@ class TestOperators(TestCase):
                 is_batch_norm_and_training = is_batch_norm_training(
                     op.name, kwarg_values
                 )
-                for loop_out, batched_out in get_fallback_and_vmap_exhaustive(
+                for _loop_out, _batched_out in get_fallback_and_vmap_exhaustive(
                     fn,
                     args,
                     {},
@@ -1534,7 +1534,7 @@ class TestOperators(TestCase):
                 is_batch_norm_and_training = is_batch_norm_training(
                     op.name, sample.kwargs
                 )
-                for loop_out, batched_out in get_fallback_and_vmap_exhaustive(
+                for _loop_out, _batched_out in get_fallback_and_vmap_exhaustive(
                     fn,
                     args,
                     {},
@@ -1546,7 +1546,7 @@ class TestOperators(TestCase):
                     fn, args = get_vjp_fn_and_args_with_cotangents(
                         a_op, sample, cotangents
                     )
-                    for loop_out, batched_out in get_fallback_and_vmap_exhaustive(
+                    for _loop_out, _batched_out in get_fallback_and_vmap_exhaustive(
                         fn,
                         args,
                         {},
@@ -2137,7 +2137,7 @@ class TestOperators(TestCase):
         for shape in shapes:
             input_options = self._make_extremal_inputs(shape, device)
             target_options = self._make_extremal_inputs(shape, device)
-            for input, target, kwargs in self._arg_and_kwarg_options(
+            for input, target, _kwargs in self._arg_and_kwarg_options(
                 (input_options, target_options), kwargs_options
             ):
                 result = torch.nn.functional.l1_loss(input, target)
@@ -2153,7 +2153,7 @@ class TestOperators(TestCase):
         for shape in shapes:
             input_options = self._make_extremal_inputs(shape, device)
             target_options = self._make_extremal_inputs(shape, device)
-            for input, target, kwargs in self._arg_and_kwarg_options(
+            for input, target, _kwargs in self._arg_and_kwarg_options(
                 (input_options, target_options), kwargs_options
             ):
                 result = torch.nn.functional.mse_loss(input, target)
@@ -2168,7 +2168,7 @@ class TestOperators(TestCase):
         kwargs_options = ({"dim": 1}, {})
         for shape in shapes:
             input_options = self._make_extremal_inputs(shape, device)
-            for input, kwargs in self._arg_and_kwarg_options(
+            for input, _kwargs in self._arg_and_kwarg_options(
                 (input_options,), kwargs_options
             ):
                 result = torch.nn.functional.softmax(input)
@@ -2183,7 +2183,7 @@ class TestOperators(TestCase):
         kwargs_options = ({"dim": 1}, {})
         for shape in shapes:
             input_options = self._make_extremal_inputs(shape, device)
-            for input, kwargs in self._arg_and_kwarg_options(
+            for input, _kwargs in self._arg_and_kwarg_options(
                 (input_options,), kwargs_options
             ):
                 result = torch.nn.functional.log_softmax(input)

--- a/test/inductor/test_auto_functionalize.py
+++ b/test/inductor/test_auto_functionalize.py
@@ -1947,7 +1947,7 @@ def forward(self, arg0_1: "f32[2][1]cpu"):
             data = torch.randn((10, 10), dtype=torch.float32)
             result_eager = f_dtype_view(cache.clone(), data)
 
-            for mode_name, mode_ctx in [
+            for _mode_name, mode_ctx in [
                 ("inference", torch.inference_mode()),
                 ("no_grad", torch.no_grad()),
             ]:

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -2769,7 +2769,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
                 ("compiled", out_compiled, "compiled mode"),
             ]
 
-            for mode_name, output, description in test_cases:
+            for _mode_name, output, description in test_cases:
                 loss = output.sum()
                 grads = torch.autograd.grad(loss, (query, key, value))
 

--- a/test/inductor/test_gpu_cpp_wrapper.py
+++ b/test/inductor/test_gpu_cpp_wrapper.py
@@ -454,7 +454,7 @@ class TestGpuWrapper(InductorTestCase):
                 "graph_partition": False,
             }
         )(test_fn)
-        for i in range(3):
+        for _i in range(3):
             res = comp(x, s)
             self.assertEqual(res, expected)
 

--- a/test/inductor/test_memory.py
+++ b/test/inductor/test_memory.py
@@ -513,7 +513,7 @@ class TestOperatorReorderForPeakMemory(TestCase):
             # Look for patterns like "cond" or "cond_1" in the generated code
             # along with their buffer sizes
             lines = code.split("\n")
-            for i, line in enumerate(lines):
+            for _i, line in enumerate(lines):
                 # Match true_graph buffer allocations which indicate cond execution
                 match = re.search(r"true_graph_(\d+)_buf0\s*=.*\((\d+),", line)
                 if match:

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -895,7 +895,7 @@ class TestDumpLaunchTensors(TestCase):
             kernel_bases = {}
             verified_tensor_load = False
 
-            for root, dirs, files in os.walk(cache_dir()):
+            for root, dirs, _files in os.walk(cache_dir()):
                 for d in dirs:
                     if "_run_" in d:
                         full_path = os.path.join(root, d)

--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -70,14 +70,14 @@ class TestUtils(TestCase):
         schema = result._opoverload._schema
         g = torch.tensor([11, 2])
         found = False
-        for arg, val in torch._library.utils.zip_schema(schema, [], {"x": g}):
+        for arg, _val in torch._library.utils.zip_schema(schema, [], {"x": g}):
             if arg.name == "x":
                 found = True
 
         self.assertTrue(found)
 
         found = False
-        for arg, val in torch._library.utils.zip_schema(schema, [g], {}):
+        for arg, _val in torch._library.utils.zip_schema(schema, [g], {}):
             if arg.name == "x":
                 found = True
         self.assertTrue(found)

--- a/test/jit/test_freezing.py
+++ b/test/jit/test_freezing.py
@@ -2488,7 +2488,7 @@ class TestFrozenOptimizations(JitTestCase):
         use_tracing = [True, False]
         bn_running_stats = [True, False]
 
-        for modules, tracing, track_stats in product(
+        for modules, tracing, _track_stats in product(
             module_pairs, use_tracing, bn_running_stats
         ):
 

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -561,7 +561,7 @@ class TestConvolutionNN(NNTestCase):
 
     @unittest.skipIf(not TEST_CUDA, "CUDA not available")
     def test_thnn_conv_strided_padded_dilated(self):
-        for convfn, dims, transposed in (
+        for convfn, dims, _transposed in (
             (torch.nn.functional.conv2d, 2, False),
             (torch.nn.functional.conv_transpose2d, 2, True),
             (torch.nn.functional.conv3d, 3, False),
@@ -1273,7 +1273,7 @@ class TestConvolutionNNDeviceType(NNTestCase):
     @onlyAccelerator
     @skipMPS
     def test_thnn_conv_strided_padded_dilated(self, device):
-        for convfn, dims, transposed in (
+        for convfn, dims, _transposed in (
             (torch.nn.functional.conv2d, 2, False),
             (torch.nn.functional.conv_transpose2d, 2, True),
             (torch.nn.functional.conv3d, 3, False),

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -12148,7 +12148,7 @@ get_out().sum().backward()
             barrier.wait()
             return weakref.ref(tensor.grad)
 
-        for i in range(NUM_ITERS):
+        for _i in range(NUM_ITERS):
             tensor = torch.tensor([1.0, 2.0, 3.0], requires_grad=True)
             (tensor**2).sum().backward()
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -8840,7 +8840,7 @@ class TestMemPool(TestCase):
         # Generate trace entries
         with torch.cuda.use_mem_pool(pool):
             tensors = []
-            for i in range(1000):
+            for _i in range(1000):
                 tensors.append(torch.randn(1024, device="cuda"))
             del tensors
 
@@ -9091,7 +9091,7 @@ class TestMemPool(TestCase):
         tensor_sizes = [24 * 1024 * 1024, 32 * 1024 * 1024]
         alloc_cases = []
         case_no = 0
-        for idx in range(3):
+        for _idx in range(3):
             for stream_idx, stream in enumerate([first_stream, second_stream]):
                 # for second stream in reverse order
                 reverse_order = stream_idx % 2 == 1

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -4817,7 +4817,7 @@ with warnings.catch_warnings(record=True) as w:
         calls = ["decorator", "function"]
         device_types_options = [("cpu", "cuda"), "cpu", None]
 
-        for mode, call, device_types in itertools.product(
+        for mode, call, _device_types in itertools.product(
             modes, calls, device_types_options
         ):
             with torch.library._scoped_library("_torch_testing", "FRAGMENT") as lib:

--- a/test/test_flop_counter.py
+++ b/test/test_flop_counter.py
@@ -255,7 +255,7 @@ class TestFlopCounter(TestCase):
         weight = torch.randn(1, 1, 1, 1, requires_grad=True)
         assert_equivalence(lambda: F.conv2d(x, weight).sum().backward(), 8)
 
-        for in_channels, out_channels, groups in [
+        for in_channels, out_channels, _groups in [
             (1, 1, 1),
             (1, 3, 1),
             (3, 1, 1),

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -2529,7 +2529,7 @@ class TestOptimRenewed(TestCase):
             # Simulate bf16 storage: after each ref step, quantize states to
             # bf16 and back so the reference matches the mixed-precision kernel.
             tracker = TensorTracker()
-            for i in range(7):
+            for _i in range(7):
                 ref_optim.step()
                 bf16_optim.step()
                 for p in params:
@@ -2547,7 +2547,7 @@ class TestOptimRenewed(TestCase):
                         tracker.add(max_exp_avg_sq_bf16)
                         d["max_exp_avg_sq"] = max_exp_avg_sq_bf16.to(torch.float32)
 
-                for e, pc in enumerate(params_c):
+                for _e, pc in enumerate(params_c):
                     tracker.pop_check_set(pc, self)
                     tracker.pop_check_set(pc.grad, self)
 

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -1303,7 +1303,7 @@ def emit_body(
 
             # Figure out the offset of the edge that uses this variable
             derivative_var_name = derivative.var_names[0]
-            for edge_off, a in enumerate(args_with_derivatives):
+            for edge_off, a in enumerate(args_with_derivatives):  # noqa: B007
                 if a.name == derivative_var_name:
                     break
             else:

--- a/tools/autograd/load_derivatives.py
+++ b/tools/autograd/load_derivatives.py
@@ -705,7 +705,7 @@ def create_differentiability_info(
         )
 
     diffinfo_dict = {}
-    for key, defn in defn_dict["dispatch"].items():
+    for key, defn in defn_dict["dispatch"].items():  # noqa: B007
         if key != "Default" and key not in _VALID_AUTOGRAD_KEYS:
             raise RuntimeError(
                 f"Invalid dispatch key {key} in derivatives.yaml for {specification},"

--- a/tools/code_analyzer/gen_operators_yaml.py
+++ b/tools/code_analyzer/gen_operators_yaml.py
@@ -477,7 +477,7 @@ def fill_output(output: dict[str, object], options: Namespace) -> None:
     # to True, since it indicates that this operator list came from something
     # other than a traced operator list.
     include_all_non_op_selectives = False
-    for op_name, op_info in operators.items():
+    for op_info in operators.values():
         include_all_non_op_selectives = (
             include_all_non_op_selectives or op_info.include_all_overloads
         )

--- a/tools/experimental/torchfuzz/codegen.py
+++ b/tools/experimental/torchfuzz/codegen.py
@@ -215,7 +215,7 @@ class FuzzTemplate:
         )
 
         if arg_operations:
-            for i, (node_id, spec) in enumerate(arg_operations):
+            for i, (_node_id, spec) in enumerate(arg_operations):
                 arg_name = f"arg_{i}"
 
                 if isinstance(spec, ScalarSpec):

--- a/tools/experimental/torchfuzz/cuda/_codegen.py
+++ b/tools/experimental/torchfuzz/cuda/_codegen.py
@@ -187,7 +187,7 @@ class DTensorFuzzTemplate(FuzzTemplate):
         )
 
         if arg_operations:
-            for i, (node_id, spec) in enumerate(arg_operations):
+            for i, (_node_id, spec) in enumerate(arg_operations):
                 arg_name = f"arg_{i}"
 
                 if isinstance(spec, ScalarSpec):
@@ -379,7 +379,7 @@ class StreamFuzzTemplate(DefaultFuzzTemplate):
         """
         code_lines = super().args_codegen(arg_operations, constant_operations)
         if arg_operations:
-            for i, (node_id, spec) in enumerate(arg_operations):
+            for i, (_node_id, spec) in enumerate(arg_operations):
                 if isinstance(spec, TensorSpec) and spec.dtype in [
                     torch.float32,
                     torch.float64,
@@ -610,7 +610,7 @@ class DTensorFuzzPlacementsTemplate(DTensorFuzzTemplate):
 
         # Args with random placements using dist_tensor API
         if arg_operations:
-            for i, (node_id, spec) in enumerate(arg_operations):
+            for i, (_node_id, spec) in enumerate(arg_operations):
                 if isinstance(spec, TensorSpec):
                     size_str = str(spec.size)
                     dtype_str = f"torch.{spec.dtype}".replace("torch.torch.", "torch.")
@@ -636,7 +636,7 @@ class DTensorFuzzPlacementsTemplate(DTensorFuzzTemplate):
 
         # Constants (if any) - use same dist_tensor approach
         if constant_operations:
-            for node_id, var_name, spec in constant_operations:
+            for _node_id, var_name, spec in constant_operations:
                 if isinstance(spec, TensorSpec):
                     size_str = str(spec.size)
                     dtype_str = f"torch.{spec.dtype}".replace("torch.torch.", "torch.")

--- a/tools/experimental/torchfuzz/multi_process_fuzzer.py
+++ b/tools/experimental/torchfuzz/multi_process_fuzzer.py
@@ -586,7 +586,7 @@ def run_until_failure(
                     pbar = None
 
                 # Collect results as they complete
-                for seed, future in future_results:
+                for _seed, future in future_results:
                     result: FuzzerResult = future.get()
 
                     if result.ignored_pattern_idx != -1:

--- a/tools/linter/adapters/gb_registry_linter.py
+++ b/tools/linter/adapters/gb_registry_linter.py
@@ -165,7 +165,7 @@ def _update_registry_with_changes(
     # Collect new entries separately to insert them all at once
     new_entries: list[tuple[str, list[dict[str, Any]]]] = []
 
-    for gb_type, (call, file_path) in calls.items():
+    for gb_type, (call, _file_path) in calls.items():
         if gb_type in latest_entry:
             existing_entry = latest_entry[gb_type]
 
@@ -244,7 +244,7 @@ def check_registry_sync(dynamo_dir: Path, registry_path: Path) -> list[LintMessa
     for gb_type, call_list in all_calls.items():
         if len(call_list) > 1:
             first_call = call_list[0][0]
-            for call, file_path in call_list[1:]:
+            for call, _file_path in call_list[1:]:
                 if (
                     call["context"] != first_call["context"]
                     or call["explanation"] != first_call["explanation"]
@@ -321,7 +321,7 @@ def check_registry_sync(dynamo_dir: Path, registry_path: Path) -> list[LintMessa
     renames: dict[str, str] = {}
     remaining_calls = dict(calls)
 
-    for gb_type, (call, file_path) in calls.items():
+    for gb_type, (call, _file_path) in calls.items():
         if gb_type not in latest_entry:
             for existing_gb_type, existing_entry in latest_entry.items():
                 if (
@@ -335,7 +335,7 @@ def check_registry_sync(dynamo_dir: Path, registry_path: Path) -> list[LintMessa
 
     needs_update = bool(renames)
 
-    for gb_type, (call, file_path) in remaining_calls.items():
+    for gb_type, (call, _file_path) in remaining_calls.items():
         if gb_type in latest_entry:
             existing_entry = latest_entry[gb_type]
 

--- a/tools/stats/check_disabled_tests.py
+++ b/tools/stats/check_disabled_tests.py
@@ -209,7 +209,7 @@ def save_results(
 
     # Log the results
     print(f"The following {len(should_be_enabled_tests)} tests should be re-enabled:")
-    for test_id, stats in should_be_enabled_tests.items():
+    for test_id in should_be_enabled_tests:
         disabled_test_name, name, classname, filename = get_disabled_test_name(test_id)
         print(f"  {disabled_test_name} from {filename}")
 

--- a/torch/_dynamo/codegen.py
+++ b/torch/_dynamo/codegen.py
@@ -722,7 +722,7 @@ class PyCodegen:
             self.store(cm_var)
 
         arg_varnames = []
-        for i, arg in enumerate(graphargs):
+        for _i, arg in enumerate(graphargs):
             arg_varname = self.tx.new_pycode_varname("arg")
             arg_varnames.append(arg_varname)
             if arg.pass_arg_as_tensor:

--- a/torch/_dynamo/compiled_autograd.py
+++ b/torch/_dynamo/compiled_autograd.py
@@ -1094,7 +1094,7 @@ class AutogradCompilerInstance:
         # Dynamo guards will error instead of creating aliasing guards unless we unpack them in the graph
         unpack_nodes: OrderedSet[torch.fx.Node] = OrderedSet()
         i: int | None = None
-        for i, node in enumerate(self.fx_tracer.graph.find_nodes(op="placeholder")):
+        for i, node in enumerate(self.fx_tracer.graph.find_nodes(op="placeholder")):  # noqa: B007
             unpack_nodes.update(node.users.keys())
         if i != len(_graph_placeholders) - 1:
             raise AssertionError(

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -1551,7 +1551,7 @@ class SideEffectsProxyDict(collections.abc.MutableMapping[kV, VariableTracker]):
                 continue
             yield Hasher(ConstantVariable.create(k))
 
-        for k, v in self.item_dict.items():
+        for k in self.item_dict:
             if k not in d:
                 yield Hasher(ConstantVariable.create(k))
 

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -660,7 +660,7 @@ def _extract_graph_with_inputs_outputs(
         elif node.op == "output":
             pass
     output_values = []
-    for x, x_desc in zip(outputs, outputs_descs):
+    for x, _x_desc in zip(outputs, outputs_descs):
         if isinstance(x, fx.Node):
             if x not in env:
                 raise RuntimeError(f"Node {x} couldn't be found in env")

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1904,7 +1904,7 @@ class GuardedCache(Generic[T]):
         # Iterate over any entries in the subdir for this key and evaluate
         # guards to determine whether there's a hit.
 
-        for candidate, content, in_local in cls.iterate_over_candidates(
+        for candidate, content, in_local in cls.iterate_over_candidates(  # noqa: B007
             local, remote_cache, key
         ):
             if not hasattr(candidate, "guards_expr"):

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -5564,7 +5564,7 @@ class CppScheduling(BaseScheduling):
             raise AssertionError("expected matched_index_size is not None")
         matched_num_dims = len(matched_index_size)
 
-        for node, ((index_size, _), original_body, _) in node_bodies:
+        for _node, ((index_size, _), original_body, _) in node_bodies:
             if split_var not in original_body.iter_vars:
                 return nodes
             if len(index_size) != matched_num_dims:

--- a/torch/_inductor/codegen/pallas.py
+++ b/torch/_inductor/codegen/pallas.py
@@ -3058,7 +3058,7 @@ class PallasKernel(SIMDKernel):
         # that will be handled by the reshape at store time
 
         # For iter vars, we need to count how many dimensions come after in the output
-        for i, var in enumerate(used_iter_vars):
+        for _i, var in enumerate(used_iter_vars):
             var_name = str(var)
             if var in self.range_tree_nodes:
                 range_entry = self.range_tree_nodes[var]

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -8353,7 +8353,7 @@ class TritonScheduling(SIMDScheduling):
             )
 
             # pyrefly: ignore [bad-assignment]
-            for src_code, kernel, node_group in kernel_code_list:
+            for src_code, _kernel, node_group in kernel_code_list:
                 fused_node_lists = [node.get_nodes() for node in node_group]
                 names = [n.get_name() for nodes in fused_node_lists for n in nodes]
 

--- a/torch/_inductor/fx_passes/auto_chunker/applier.py
+++ b/torch/_inductor/fx_passes/auto_chunker/applier.py
@@ -140,7 +140,7 @@ class ChunkingApplier:
             raise AssertionError("expected non-empty subgraph body")
 
     def replace_tangent_to_one(self) -> None:
-        for idx, node in enumerate(self.overriden_tangent):
+        for _idx, node in enumerate(self.overriden_tangent):
             if not is_tangent_node(node):
                 raise AssertionError(f"expected tangent node, got {node}")
 
@@ -161,7 +161,7 @@ class ChunkingApplier:
         input needs to be chunked.
         E.g. the weight for matmul does not need to be chunked.
         """
-        for node_idx, subgraph_input in enumerate(self.subgraph_input):
+        for _node_idx, subgraph_input in enumerate(self.subgraph_input):
             meta = get_chunking_meta(subgraph_input)
             if meta is None:
                 raise AssertionError("expected chunking meta for subgraph input")
@@ -232,7 +232,7 @@ class ChunkingApplier:
             new_node.meta = {"val": fake_tensor}
             return new_node
 
-        for node_idx, input_node in enumerate(self.subgraph_input):
+        for _node_idx, input_node in enumerate(self.subgraph_input):
             env[input_node] = _create_placeholder_node(input_node)
 
         for overriden_tangent_node in self.overriden_tangent.values():

--- a/torch/_inductor/fx_passes/ddp_fusion.py
+++ b/torch/_inductor/fx_passes/ddp_fusion.py
@@ -571,7 +571,7 @@ def schedule_comm_wait(graph: fx.Graph) -> None:
         # Move wait nodes and all the subsequent nodes in the comm_block to
         # before the first user -- target_node.
         wait_idx = -1
-        for wait_idx, node in enumerate(allreduce.node_list):
+        for wait_idx, node in enumerate(allreduce.node_list):  # noqa: B007
             if node == allreduce.wait_nodes[0]:
                 break
         if wait_idx < 0:

--- a/torch/_inductor/fx_passes/overlap_manual_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_manual_scheduling.py
@@ -366,7 +366,7 @@ class ManualOverlapPreservingBucketer(OverlapPreservingBucketer):
         # Split each key-group into dependency-free sub-buckets so fusing never
         # makes a bucketed collective's input depend on its own output.
         sub_buckets: list[list[fx.Node]] = []
-        for key, key_nodes in grouped_collectives.items():
+        for key_nodes in grouped_collectives.values():
             sub_buckets.extend(self._split_independent_collectives(key_nodes, nodes))
 
         for sub_bucket in sub_buckets:
@@ -563,7 +563,7 @@ class ManualOverlapScheduler(OverlapScheduler):
     def _manual_bucket_collectives(self) -> None:
         """Bucket nodes in each module_bucket from module_bucket_plans."""
         self._obtain_nodes_in_subgraph()
-        for i, nodes in enumerate(self.nodes_in_subgraph):
+        for _i, nodes in enumerate(self.nodes_in_subgraph):
             self.bucketer.manual_bucket_collectives(nodes=nodes)
 
         self.graph.lint()

--- a/torch/_inductor/fx_passes/overlap_preserving_bucketer.py
+++ b/torch/_inductor/fx_passes/overlap_preserving_bucketer.py
@@ -382,7 +382,7 @@ class OverlapPreservingBucketer:
             def _bucket_key(node):
                 return get_full_bucket_key(node, self.bucket_mode)
 
-            for start, info in self.collective_info.items():
+            for start in self.collective_info:
                 stats_num_total_collectives_per_key[_bucket_key(start)] += 1
 
             for i, bucket in enumerate(all_buckets):

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -5158,7 +5158,7 @@ class AlgorithmSelectorCache(PersistentCache):
 
         total_time = 0.0
 
-        for i in range(nruns):
+        for _i in range(nruns):
             torch.cuda.synchronize()
 
             start_evt = torch.cuda.Event(enable_timing=True)

--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -889,7 +889,7 @@ def _get_module_and_submodules(qname: str) -> Sequence[str] | None:
     if spec.submodule_search_locations is not None:
         package = importlib.import_module(qname)
         if hasattr(package, "__path__"):
-            for importer, modname, ispkg in pkgutil.walk_packages(
+            for _importer, modname, _ispkg in pkgutil.walk_packages(
                 path=package.__path__,
                 prefix=qname + ".",
                 onerror=lambda x: None,

--- a/torch/distributed/_local_tensor/__init__.py
+++ b/torch/distributed/_local_tensor/__init__.py
@@ -1560,7 +1560,7 @@ class LocalTensorMode(TorchDispatchMode):
         # TODO: This should either be removed or documented why it's necessary.
         from torch.distributed.tensor import _random as dtensor_random
 
-        for global_name, local_name in _PATCHED_RANDOM_FUNCTIONS:
+        for global_name, _local_name in _PATCHED_RANDOM_FUNCTIONS:
             value = self._old_random_functions.pop(global_name, None)
             if value is not None:
                 mod_name, attr_name = global_name.rsplit(".", 1)

--- a/torch/distributed/tensor/_ops/strategy_validation.py
+++ b/torch/distributed/tensor/_ops/strategy_validation.py
@@ -440,7 +440,7 @@ def _shard_tensors(
 ) -> list[LocalTensor | torch.Tensor]:
     """Create sharded LocalTensors from tensors according to placements."""
     local_tensors: list[LocalTensor | torch.Tensor] = []
-    for tensor_idx, ((name, tensor), placement) in enumerate(
+    for tensor_idx, ((_name, tensor), placement) in enumerate(
         zip(tensors, input_placements)
     ):
         if isinstance(placement, Partial):
@@ -590,7 +590,7 @@ def validate_combination(
         # Uneven shards produce SymInt in LocalTensor's wrapper shape,
         # which breaks C++ overload resolution before __torch_dispatch__
         # can intercept. Return None to signal "untestable".
-        for (name, tensor), placement in zip(tensors, combination[0]):
+        for (_name, tensor), placement in zip(tensors, combination[0]):
             if isinstance(placement, Shard):
                 if tensor.size(placement.dim) % world_size != 0:
                     return None, "uneven shard"
@@ -679,7 +679,7 @@ def validate_aten_combination(
         if not tensors:
             return False, "No tensor args in captured aten call"
 
-        for (name, tensor), placement in zip(tensors, combination[0]):
+        for (_name, tensor), placement in zip(tensors, combination[0]):
             if isinstance(placement, Shard):
                 if tensor.size(placement.dim) % world_size != 0:
                     return None, "uneven shard"

--- a/torchgen/_autoheuristic/pad_mm/collect_known_mm_shapes.py
+++ b/torchgen/_autoheuristic/pad_mm/collect_known_mm_shapes.py
@@ -202,7 +202,7 @@ def main(output_file="mm_shapes.csv"):
 
     # Convert to desired format and filter dtypes
     csv_rows = []
-    for m, k, n, dtype1, dtype2 in shapes:
+    for m, k, n, dtype1, _dtype2 in shapes:
         # Use the first dtype and convert to string
         if dtype1 in dtype_map:
             dtype_str = dtype_map[dtype1]

--- a/torchgen/_autoheuristic/train_decision.py
+++ b/torchgen/_autoheuristic/train_decision.py
@@ -473,7 +473,7 @@ class AHTrainDecisionTree(AHTrain):
         def add_near_best_configs(df):
             new_rows = []
 
-            for index, row in df.iterrows():
+            for _index, row in df.iterrows():
                 dictionary = json.loads(row["choice2time"])
                 min_value = min(dictionary.values())
 

--- a/torchgen/api/autograd.py
+++ b/torchgen/api/autograd.py
@@ -410,7 +410,7 @@ def gen_foreach_derivativeinfo(
         return ref_diff_info, False
 
     map_refarg2foreacharg, map_name2arg = {}, {}
-    for i, (arg, ref_arg) in enumerate(
+    for _i, (arg, ref_arg) in enumerate(
         zip(
             foreach_function.func.arguments.flat_non_out,
             function_schema.arguments.flat_non_out,
@@ -421,7 +421,7 @@ def gen_foreach_derivativeinfo(
 
     all_saved_inputs, all_saved_outputs, all_var_names = [], [], []
     modified_derivative_formulas = []
-    for i, derivative in enumerate(ref_diff_info.derivatives):
+    for _i, derivative in enumerate(ref_diff_info.derivatives):
         modified_formula = derivative.formula.replace("grad", "grads[i]").replace(
             "result", "result[i]"
         )

--- a/torchgen/gen.py
+++ b/torchgen/gen.py
@@ -2024,7 +2024,7 @@ def gen_per_operator_headers(
         dispatch_namespace = dispatch_key.lower()
         dispatch_names = []
 
-        for name, functions in functions_by_root_name.items():
+        for name in functions_by_root_name:
             grouped_functions = grouped_functions_by_root_name.get(name, [])
             declarations = list(
                 concatMap(

--- a/torchgen/yaml_utils.py
+++ b/torchgen/yaml_utils.py
@@ -16,7 +16,7 @@ YamlDumper = Dumper
 class YamlLoader(Loader):
     def construct_mapping(self, node, deep=False):  # type: ignore[no-untyped-def]
         mapping = []
-        for key_node, value_node in node.value:
+        for key_node, _value_node in node.value:
             key = self.construct_object(key_node, deep=deep)  # type: ignore[no-untyped-call]
             if key in mapping:
                 raise AssertionError(


### PR DESCRIPTION
### Summary

Enables flake8-bugbear **B007** (unused loop control variable), one of the remaining bugbear codes still suppressed in the `ignore` list of `pyproject.toml`. Part of #106571.

This removes `B007` from the ignore list and fixes all 169 violations across 110 files so the lint is enforced going forward.

### Approach

Most fixes are mechanical — an unused loop control variable is renamed with a leading underscore (e.g. `for root, dirs, files` -> `for root, _dirs, files`); ruff applied the majority automatically.

Two categories were handled manually:

- **Dict iterations that only use the key or only the value.** Prefixing the unused target with `_` would trade B007 for `PERF102`/`SIM118`, so these were rewritten to `for v in d.values()` / `for k in d` instead, which is cleaner and needs no suppression.
- **Loop variables that are unused in the body but legitimately read after the loop** (for/else index search, closures, and last-value leakage). These cannot be renamed without changing behavior, so they are annotated `# noqa: B007`.

While auditing the manual cases I noticed a latent bug in the `TestLinalgMPS` transpose test in `test/test_mps.py`: the loop body contains only the `maybe_transpose` definition while the assertions are dedented out of the loop, so only the last product combination is exercised. Behavior is left unchanged here (only a `noqa` is added); it can be fixed separately.

### Test plan

Verified with the same ruff version and config the lint CI uses (ruff 0.14.4 via `uv`, `pyproject.toml`, plus the RUFF `exclude_patterns` from `.lintrunner.toml`):

```
# B007 is now clean across the whole repo
uvx ruff@0.14.4 check . --config=pyproject.toml --select B007 \
  --extend-exclude '<lintrunner RUFF exclude_patterns>'
# -> All checks passed!

# no new violations (PERF102/SIM118/F821) in the changed files
uvx ruff@0.14.4 check $(git diff --name-only main) --config=pyproject.toml
# -> All checks passed!

# all changed files still parse
python -m py_compile $(git diff --name-only main | grep '\.py$')
```

The PyTorch unit tests were not run locally because the dev environment used could not build `torch`; the changes are semantics-preserving lint fixes and ruff's `F821` check confirms no rename broke an existing reference.

> Authored with the assistance of an AI coding assistant (Claude).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98 @xmfan @aditvenk