### PR TITLE
[T278829272][Claude Code] Gate TLX flex_attention choices on tlx_mode (#189324)

### DIFF
--- a/torch/_inductor/kernel/flex/flex_attention.py
+++ b/torch/_inductor/kernel/flex/flex_attention.py
@@ -12,6 +12,7 @@ from typing import Any, cast, TYPE_CHECKING
 import sympy
 
 import torch
+from torch._inductor import config
 from torch._inductor.virtualized import V
 from torch.nn.attention.flex_attention import _Backend
 from torch.utils._sympy.functions import FloorDiv
@@ -540,27 +541,30 @@ def flex_attention(
             raise error
 
     # Let the active choices handler append any backend-specific flex-attention
-    # template choices (e.g. TLX on Blackwell in fbcode). No-op by default.
-    choices = V.choices.append_flex_attention_choices(
-        choices,
-        configs,
-        [
-            query,
-            key,
-            value,
-            logsumexp,
-            max_scores,
-            kv_num_blocks,
-            kv_indices,
-            full_kv_num_blocks,
-            full_kv_indices,
-        ],
-        [subgraph_buffer, mask_graph_buffer],
-        layout,
-        original_kernel_options,
-        SPARSE_Q_BLOCK_SIZE,
-        SPARSE_KV_BLOCK_SIZE,
-    )
+    # template choices (TLX on Blackwell). V.choices is TLXInductorChoices only
+    # when the fbtriton TLX integration is installed; gate on tlx_mode here since
+    # that override (unlike get_template_configs) does not re-check the knob.
+    if config.triton.tlx_mode is not None:
+        choices = V.choices.append_flex_attention_choices(
+            choices,
+            configs,
+            [
+                query,
+                key,
+                value,
+                logsumexp,
+                max_scores,
+                kv_num_blocks,
+                kv_indices,
+                full_kv_num_blocks,
+                full_kv_indices,
+            ],
+            [subgraph_buffer, mask_graph_buffer],
+            layout,
+            original_kernel_options,
+            SPARSE_Q_BLOCK_SIZE,
+            SPARSE_KV_BLOCK_SIZE,
+        )
 
     if not choices and invalid_block_options is not None:
         raise_flex_kernel_options_error(


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookexperimental/triton/pull/1961

15 `caffe2/test/inductor:flex_attention` tests broke on Hopper/Blackwell CI, root-caused to D94284002.

`V.choices` is `TLXInductorChoices` whenever the fbtriton TLX integration is installed. Its `append_flex_attention_choices` was the only method on the class that did not gate on the torchTLX knob: on every flex_attention lowering it unconditionally ran `from .flex_attention_templates import append_tlx_flex_attention_choice`, and that import executes a module-level `TritonTemplate("tlx_blackwell_flex_attention_ws", ...)` build that broke the standard (non-TLX) flex_attention lowering path with an `InductorError`.

This diff gates the `V.choices.append_flex_attention_choices(...)` call site in `flex_attention.py` on `config.triton.tlx_mode is not None`, so the TLX handler (and its import) is only reached when torchTLX is enabled; the standard lowering path is left untouched otherwise. Unlike `get_template_configs`, the TLX `append_flex_attention_choices` override does not re-check the knob internally, so the gate has to live at the call site.

fbtriton availability itself is handled exactly as for mm/addmm: `V.choices` is `TLXInductorChoices` only when the fbtriton integration import succeeds (it installs `config.inductor_choices_class`), and the base no-op handler otherwise. Per daohang's review there is therefore no `is_fbcode()` guard -- after open-sourcing torchTLX that would wrongly disable TLX for OSS PyTorch built against fbtriton.

Stacked on D111169890, which renames the knob's off-state from the string `"default"` to `None` (hence `is not None` rather than `!= "default"`).

Authored with Claude Code.

Test Plan:
Stacked on D111169890. Ran the previously-failing sweep locally on a B200 (sm_100) devgpu:

```
buck2 test fbcode//mode/opt -c fbcode.platform010_cuda_version=12.8 fbcode//caffe2/test/inductor:flex_attention -- --run-disabled --regex 'test_(symmetric_bias|strided_inputs_q_s1_k_s3_v_s3)'
```

Result: `Pass 22. Fail 0.` — the 12 `test_symmetric_bias_*` and 3 `test_strided_inputs_q_s1_k_s3_v_s3_*` cases that were failing, plus 7 already-passing cases matched by the filter. This matches the task's H100 analysis, where the same sweep goes from Pass 7 / Fail 15 to Pass 22 / Fail 0 once the gate is applied. (The `platform010_cuda_version=12.8` flag just targets the local B200; the CI repro on H100 needs no extra flags.)

`arc f` and `arc lint -a` clean on both changed files.

Differential Revision: D111065524


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo