### PR TITLE
[Dynamo] Fix self-referential bw_compiler on backend re-entry

### DIFF
--- a/test/dynamo/test_backends.py
+++ b/test/dynamo/test_backends.py
@@ -419,6 +419,26 @@ class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
         opt_f(torch.randn(3, 3))
         self.assertTrue(backend_run)
 
+    def test_aot_autograd_reentrant_bw_compiler(self):
+        # re-entry with an already-wrapped bw_compiler must not self-reference
+        from functorch.compile import make_boxed_func
+        from torch._dynamo.backends.common import aot_autograd
+
+        def my_compiler(gm, example_inputs):
+            return make_boxed_func(gm.forward)
+
+        backend = aot_autograd(fw_compiler=my_compiler)
+
+        torch.compile(lambda x: x.sin() + 1, backend=backend)(
+            torch.randn(3, requires_grad=True)
+        ).sum().backward()
+        torch.compile(lambda x: x.cos() * 2, backend=backend)(
+            torch.randn(3, requires_grad=True)
+        ).sum().backward()
+
+        bw_compiler = backend.kwargs["bw_compiler"]
+        self.assertFalse(hasattr(bw_compiler, "compiler_fn"))
+
     def test_lookup_backend(self):
         from torch._dynamo import lookup_backend
 

--- a/test/dynamo/test_backends.py
+++ b/test/dynamo/test_backends.py
@@ -420,7 +420,7 @@ class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
         self.assertTrue(backend_run)
 
     def test_aot_autograd_reentrant_bw_compiler(self):
-        # re-entry with an already-wrapped bw_compiler must not self-reference
+        # re-entry with an already-wrapped bw_compiler must leave it untouched
         from functorch.compile import make_boxed_func
         from torch._dynamo.backends.common import aot_autograd
 
@@ -432,12 +432,37 @@ class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
         torch.compile(lambda x: x.sin() + 1, backend=backend)(
             torch.randn(3, requires_grad=True)
         ).sum().backward()
+        bw_compiler = backend.kwargs["bw_compiler"]
         torch.compile(lambda x: x.cos() * 2, backend=backend)(
             torch.randn(3, requires_grad=True)
         ).sum().backward()
 
-        bw_compiler = backend.kwargs["bw_compiler"]
+        self.assertIs(backend.kwargs["bw_compiler"], bw_compiler)
         self.assertFalse(hasattr(bw_compiler, "compiler_fn"))
+
+    def test_aot_autograd_reentrant_serializable_bw_compiler(self):
+        # re-entry must not re-wrap a SerializableAOTDispatchCompiler's compiler_fn
+        from functorch.compile import make_boxed_func
+        from torch._dynamo.backends.common import aot_autograd
+        from torch._functorch._aot_autograd.schemas import (
+            SerializableAOTDispatchCompiler,
+        )
+
+        def my_compiler(gm, example_inputs):
+            return make_boxed_func(gm.forward)
+
+        bw_compiler = SerializableAOTDispatchCompiler(object, my_compiler)
+        backend = aot_autograd(fw_compiler=my_compiler, bw_compiler=bw_compiler)
+
+        torch.compile(lambda x: x.sin() + 1, backend=backend)(
+            torch.randn(3, requires_grad=True)
+        ).sum().backward()
+        wrapped_fn = bw_compiler.compiler_fn
+        torch.compile(lambda x: x.cos() * 2, backend=backend)(
+            torch.randn(3, requires_grad=True)
+        ).sum().backward()
+
+        self.assertIs(bw_compiler.compiler_fn, wrapped_fn)
 
     def test_lookup_backend(self):
         from torch._dynamo import lookup_backend

--- a/torch/_dynamo/backends/common.py
+++ b/torch/_dynamo/backends/common.py
@@ -121,7 +121,7 @@ class AotAutograd:
         if isinstance(bw_compiler, SerializableAOTDispatchCompiler):
             bw_compiler.compiler_fn = wrap_bw_compiler(bw_compiler.compiler_fn)
         elif getattr(bw_compiler, "_is_wrapped_bw_compiler", False):
-            bw_compiler.compiler_fn = bw_compiler  # pyrefly: ignore [missing-attribute]
+            pass  # already wrapped, keep as-is
         else:
             bw_compiler = wrap_bw_compiler(bw_compiler)
 

--- a/torch/_dynamo/backends/common.py
+++ b/torch/_dynamo/backends/common.py
@@ -119,10 +119,9 @@ class AotAutograd:
         bw_compiler = self.kwargs.get("bw_compiler") or self.kwargs["fw_compiler"]
 
         if isinstance(bw_compiler, SerializableAOTDispatchCompiler):
-            bw_compiler.compiler_fn = wrap_bw_compiler(bw_compiler.compiler_fn)
-        elif getattr(bw_compiler, "_is_wrapped_bw_compiler", False):
-            pass  # already wrapped, keep as-is
-        else:
+            if not getattr(bw_compiler.compiler_fn, "_is_wrapped_bw_compiler", False):
+                bw_compiler.compiler_fn = wrap_bw_compiler(bw_compiler.compiler_fn)
+        elif not getattr(bw_compiler, "_is_wrapped_bw_compiler", False):
             bw_compiler = wrap_bw_compiler(bw_compiler)
 
         self.kwargs["bw_compiler"] = bw_compiler


### PR DESCRIPTION
## Why

When one `aot_autograd` backend compiles a second, distinct graph, `AotAutograd.__call__` re-enters with `bw_compiler` already wrapped. The `_is_wrapped_bw_compiler` branch then ran `bw_compiler.compiler_fn = bw_compiler`, grafting a self-referential attribute (and needing a `type: ignore`) instead of leaving the wrapper untouched. The branch only exists to be idempotent.

## How

- Leave `bw_compiler` as-is when it is already wrapped
- Add `test_aot_autograd_reentrant_bw_compiler`, which fails before this change

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98