### PR TITLE
Add retry with backoff to download_mnist.py

### DIFF
--- a/tools/download_mnist.py
+++ b/tools/download_mnist.py
@@ -1,14 +1,22 @@
 import argparse
 import gzip
 import os
+import socket
 import sys
-from urllib.error import URLError
+import time
+from http.client import HTTPException
 from urllib.request import urlretrieve
 
 
 MIRRORS = [
     "https://ossci-datasets.s3.amazonaws.com/mnist/",  # @lint-ignore
 ]
+
+# Number of attempts per mirror before giving up on it. The download hits a
+# single S3 mirror with no built-in retry, so a transient network blip fails
+# the whole job; retry a few times with backoff first.
+RETRIES = 3
+RETRY_BACKOFF_S = 5
 
 RESOURCES = [
     "train-images-idx3-ubyte.gz",
@@ -36,20 +44,25 @@ def download(destination_path: str, resource: str, quiet: bool) -> None:
     else:
         for mirror in MIRRORS:
             url = mirror + resource
-            print(f"Downloading {url} ...")
-            try:
-                hook = None if quiet else report_download_progress
-                urlretrieve(url, destination_path, reporthook=hook)
-            except (URLError, ConnectionError) as e:
-                print(f"Failed to download (trying next):\n{e}")
-                continue
-            finally:
-                if not quiet:
-                    # Just a newline.
-                    print()
-            break
-        else:
-            raise RuntimeError("Error downloading resource!")
+            for attempt in range(1, RETRIES + 1):
+                print(f"Downloading {url} ...")
+                try:
+                    hook = None if quiet else report_download_progress
+                    urlretrieve(url, destination_path, reporthook=hook)
+                    return
+                except (OSError, HTTPException) as e:
+                    # A failed urlretrieve leaves a partial file behind; remove
+                    # it so the exists check above doesn't skip it on a rerun.
+                    if os.path.exists(destination_path):
+                        os.remove(destination_path)
+                    print(f"Failed to download (attempt {attempt}/{RETRIES}):\n{e}")
+                    if attempt < RETRIES:
+                        time.sleep(RETRY_BACKOFF_S * attempt)
+                finally:
+                    if not quiet:
+                        # Just a newline.
+                        print()
+        raise RuntimeError("Error downloading resource!")
 
 
 def unzip(zipped_path: str, quiet: bool) -> None:
@@ -76,6 +89,10 @@ def main() -> None:
         "-q", "--quiet", action="store_true", help="Don't report about progress"
     )
     options = parser.parse_args()
+
+    # urlretrieve has no timeout parameter and defaults to blocking forever on
+    # a stalled connection, which would defeat the retry logic in download().
+    socket.setdefaulttimeout(60)
 
     if not os.path.exists(options.destination):
         os.makedirs(options.destination)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189328

Note from human: this is not a big deal but it's also the kind of thing
coding agents eat for lunch, so whatever.

MNIST download in CI hits a single S3 mirror via urlretrieve with no
retry, so a transient network blip fails the whole job. This adds up to
3 attempts per mirror with linear backoff (5s, 10s), plus three fixes
needed to make the retry actually robust:

The root problem with a naive retry wrapper is that the failure modes
that matter mostly bypass it. urlretrieve has no timeout parameter and
defaults to blocking forever on a stalled connection, so main() now sets
socket.setdefaulttimeout(60) to convert hangs into catchable errors.
Errors raised during the response body read (e.g. ssl.SSLEOFError,
http.client.IncompleteRead) are not wrapped in URLError by urllib, so
the except clause is broadened from (URLError, ConnectionError) to
(OSError, HTTPException), a strict superset since both old types are
OSError subclasses. Finally, a failed urlretrieve leaves a truncated
partial file at the destination which the os.path.exists check would
treat as a completed download on a rerun; the handler now removes it
before retrying or giving up.

An alternative was wrapping the script invocation in the process-level
retry helper from .ci/pytorch/common_utils.sh, but that only covers the
bash callers (not the Windows .bat one) and would still be defeated by
the partial-file and no-timeout issues above, so the fix lives in the
script itself.

Test Plan:

Simulated failures by monkeypatching urlretrieve: an SSLEOFError on
attempt 1 (uncaught by the old except tuple) retries and succeeds, and
all-attempts-fail raises RuntimeError while removing the partial file.
Also ran a real end-to-end download of all 4 MNIST files from S3:

```
python tools/download_mnist.py -d /tmp/mnist_real -q
lintrunner tools/download_mnist.py
```

This PR was authored with the assistance of Claude Code.