### PR TITLE
[DEBUG] Profile the XPU SYCL device-link bottleneck

### DIFF
--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -155,6 +155,30 @@ if [[ "$BUILD_ENVIRONMENT" == *xpu* ]]; then
   if [[ "$BUILD_ENVIRONMENT" == *client* ]]; then
     export TORCH_XPU_ARCH_LIST=bmg
   fi
+
+  # [DEBUG - do not merge] Profile the SYCL device-link bottleneck.
+  # The torch_xpu_ops device link is a single ninja step that dominates the XPU
+  # build (~11 min). -fsycl-max-parallel-link-jobs is already set to the core
+  # count, so this instrumentation tells us whether that link is CPU-bound
+  # (scales with cores -> bigger runner helps) or memory-bound (AOT codegen jobs
+  # thrash RAM -> more RAM / fewer link jobs). Sampled lines are prefixed
+  # [xpu-resmon] so they can be extracted from the job log.
+  echo "[xpu-debug] nproc=$(nproc) MAX_JOBS=${MAX_JOBS:-<unset>}"
+  grep -E 'MemTotal|MemAvailable|SwapTotal' /proc/meminfo | sed 's/^/[xpu-debug] /' || true
+  for f in /sys/fs/cgroup/memory.max /sys/fs/cgroup/memory/memory.limit_in_bytes; do
+    [ -r "$f" ] && echo "[xpu-debug] cgroup $(basename "$f")=$(cat "$f")"
+  done
+  (
+    set +x  # avoid xtrace spam from the sampling loop
+    while true; do
+      stats=$(free -m | awk '/^Mem:/{mt=$2; ma=$7} /^Swap:/{su=$3} END{printf "mem_total_mb=%s mem_avail_mb=%s swap_used_mb=%s", mt, ma, su}')
+      load=$(awk '{print $1}' /proc/loadavg)
+      procs=$(pgrep -c -f 'ocloc|sycl-post-link|clang-offload|llvm-foreach|icpx' 2>/dev/null || echo 0)
+      echo "[xpu-resmon] $(date +%H:%M:%S) ${stats} load1=${load} toolchain_procs=${procs}"
+      sleep 10
+    done
+  ) &
+  trap_add "kill $! 2>/dev/null || true" EXIT
 fi
 
 # sccache will fail for CUDA builds if all cores are used for compiling
@@ -271,6 +295,16 @@ if [[ "$BUILD_ENVIRONMENT" != *libtorch* ]]; then
     fi
     python -m build --wheel --no-isolation
   fi
+
+  if [[ "$BUILD_ENVIRONMENT" == *xpu* && -d build ]]; then
+    # [DEBUG - do not merge] Confirm the parallel-link job count actually baked
+    # into the generated ninja graph, and show the device-link rule flags.
+    echo "[xpu-debug] fsycl-max-parallel-link-jobs values in build.ninja:"
+    grep -rhoE '\-fsycl-max-parallel-link-jobs=[0-9]+' build/ 2>/dev/null | sort | uniq -c || true
+    echo "[xpu-debug] SYCL device-link flags:"
+    grep -rhoE '\-fsycl[^ "]*|--offload-compress' build/build.ninja 2>/dev/null | sort -u | head -40 || true
+  fi
+
   pip_install_whl "$(echo dist/*.whl)"
 
   # Smoke-test tools/build_with_debinfo.py against the real build tree: it must


### PR DESCRIPTION
Do not merge - temporary diagnostic.

## Why
`linux-noble-xpu-n-py3.10 / build` takes ~35-45 min vs 5-15 min for the other builds in the same workflow. Profiling [pull run 28986110660](https://github.com/pytorch/pytorch/actions/runs/28986110660) showed the Build step is ~33 min even with **sccache at 99.93% hit rate** - because sccache caches only host C/C++, not SYCL device code. The single `Building SYCL device link file ... torch_xpu_ops` ninja edge alone takes **~11 min**.

`-fsycl-max-parallel-link-jobs` is already set to the core count in torch-xpu-ops `BuildFlags.cmake` (MAX_JOBS is unset for XPU, so it falls back to `ProcessorCount`), so the link already runs ~32-way on the `c7i.8xlarge` (32 vCPU / 64 GiB). Two hypotheses remain:
- **CPU-bound** -> a larger core count helps.
- **Memory-bound** (concurrent AOT codegen thrashing 64 GiB) -> more RAM / fewer link jobs helps.

## What this adds (XPU-only, no cost to other builds)
- Logs `nproc`, `MAX_JOBS`, `/proc/meminfo`, cgroup memory limits at build start.
- Background sampler (`[xpu-resmon]`, every 10s): available memory, swap used, 1-min load, and count of live SYCL toolchain processes (`ocloc`/`sycl-post-link`/...).
- After the build, dumps the actual `-fsycl-max-parallel-link-jobs=N` from `build.ninja` and the SYCL device-link flags.

Correlating the `[xpu-resmon]` samples with the ~11 min device-link window classifies the bottleneck: high load + many toolchain procs + memory fine = CPU-bound; memory near zero / swap active + few procs = memory-bound.

## Test plan
```
bash -n .ci/pytorch/build.sh
lintrunner -a .ci/pytorch/build.sh
```
Then trigger with the `ciflow/xpu` label and read the noble-xpu build job log.

Authored with the assistance of an AI coding assistant (Claude Code).