### PR TITLE
[submodule] bump cutlass to 4.5.3

### DIFF
--- a/cmake/FileMirroring.cmake
+++ b/cmake/FileMirroring.cmake
@@ -37,7 +37,8 @@ install(DIRECTORY
 # Copy vendored external kernel sources into torch/_inductor.
 # The original Python code raises RuntimeError when the source is missing
 # on CUDA-enabled builds (cutlass submodule should be present).
-set(_cutedsl_src "${PROJECT_SOURCE_DIR}/third_party/cutlass/examples/python/CuTeDSL/blackwell/grouped_gemm.py")
+set(_cutedsl_rel_path "examples/python/CuTeDSL/cute/blackwell/kernel/grouped_gemm/grouped_gemm.py")
+set(_cutedsl_src "${PROJECT_SOURCE_DIR}/third_party/cutlass/${_cutedsl_rel_path}")
 if(EXISTS "${_cutedsl_src}")
   set(_cutedsl_dest "${SKBUILD_PLATLIB_DIR}/torch/_inductor/kernel/vendored_templates/cutedsl/kernels")
   install(FILES "${_cutedsl_src}"

--- a/cmake/FileMirroring.cmake
+++ b/cmake/FileMirroring.cmake
@@ -39,6 +39,10 @@ install(DIRECTORY
 # on CUDA-enabled builds (cutlass submodule should be present).
 set(_cutedsl_rel_path "examples/python/CuTeDSL/cute/blackwell/kernel/grouped_gemm/grouped_gemm.py")
 set(_cutedsl_src "${PROJECT_SOURCE_DIR}/third_party/cutlass/${_cutedsl_rel_path}")
+if(NOT EXISTS "${_cutedsl_src}")
+  set(_cutedsl_rel_path "examples/python/CuTeDSL/blackwell/grouped_gemm.py")
+  set(_cutedsl_src "${PROJECT_SOURCE_DIR}/third_party/cutlass/${_cutedsl_rel_path}")
+endif()
 if(EXISTS "${_cutedsl_src}")
   set(_cutedsl_dest "${SKBUILD_PLATLIB_DIR}/torch/_inductor/kernel/vendored_templates/cutedsl/kernels")
   install(FILES "${_cutedsl_src}"

--- a/torch/_inductor/kernel/templates/cutedsl_mm_grouped.py.jinja
+++ b/torch/_inductor/kernel/templates/cutedsl_mm_grouped.py.jinja
@@ -5,7 +5,8 @@ from torch._inductor.runtime.cutedsl_cache import disk_cache_get, disk_cache_set
 from torch._inductor.runtime.runtime_utils import ceildiv
 from cutlass.utils import TensorMapUpdateMode
 {{gen_defines()}}
-# ---- Import GroupedGemm implementation, copied on PyTorch build from Cutlass repository: cutlass/examples/python/CuTeDSL/blackwell/grouped_gemm.py ----
+# ---- Import GroupedGemm implementation, copied from Cutlass during build. ----
+# Source: examples/python/CuTeDSL/cute/blackwell/kernel/grouped_gemm/grouped_gemm.py
 from torch._inductor.kernel.vendored_templates.cutedsl.kernels.cutedsl_grouped_gemm import (
     GroupedGemmKernel,
 )

--- a/torch/csrc/distributed/c10d/cuda/cutlass/gemm/kernel/persistent_async_input_scheduler.cuh
+++ b/torch/csrc/distributed/c10d/cuda/cutlass/gemm/kernel/persistent_async_input_scheduler.cuh
@@ -218,7 +218,7 @@ public:
 
   CUTLASS_HOST_DEVICE
   static bool
-  can_implement(Arguments const& args) {
+  can_implement(Arguments const& args, KernelHardwareInfo const&) {
     return args.max_swizzle_size >= 1;
   }
 

--- a/torch/csrc/distributed/c10d/cuda/cutlass/gemm/kernel/persistent_async_input_scheduler.cuh
+++ b/torch/csrc/distributed/c10d/cuda/cutlass/gemm/kernel/persistent_async_input_scheduler.cuh
@@ -32,6 +32,7 @@
 
 #pragma once
 #include <cutlass/gemm/kernel/static_tile_scheduler.hpp>
+#include <cutlass/version.h>
 
 namespace {
 
@@ -218,7 +219,11 @@ public:
 
   CUTLASS_HOST_DEVICE
   static bool
+#if defined(CUTLASS_VERSION) && CUTLASS_VERSION >= 450
   can_implement(Arguments const& args, KernelHardwareInfo const&) {
+#else
+  can_implement(Arguments const& args) {
+#endif
     return args.max_swizzle_size >= 1;
   }
 


### PR DESCRIPTION
https://github.com/NVIDIA/cutlass/releases/tag/v4.5.3

Summary: Bump the mirrored CUTLASS submodule pins under `fbcode/caffe2/third_party` and `xplat/caffe2/third_party` from upstream commit `da5e086dab31d63815acafdac9a9c5893b1c69e2` to the CUTLASS `v4.5.3` tag commit `4552152794e8bd3bcfd63cf9b44369e590420dba`.

Test Plan: arc lint fbcode/caffe2/third_party/cutlass.submodule.txt xplat/caffe2/third_party/cutlass.submodule.txt

Differential Revision: D111177502


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo