### PR TITLE
[Dynamo] Suggest close backend names on InvalidBackend

### DIFF
--- a/test/dynamo/test_backends.py
+++ b/test/dynamo/test_backends.py
@@ -345,6 +345,10 @@ class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
         with self.assertRaisesRegex(InvalidBackend, "did you mean: 'inductor'"):
             lookup_backend("indutcor")
 
+        with self.assertRaises(InvalidBackend) as cm:
+            lookup_backend("zzzzzzzz")
+        self.assertNotIn("did you mean", str(cm.exception))
+
     def test_lookup_custom_backend(self):
         from torch._dynamo import list_backends
 

--- a/test/dynamo/test_backends.py
+++ b/test/dynamo/test_backends.py
@@ -338,6 +338,13 @@ class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
         opt_f(torch.randn(3, 3))
         self.assertTrue(backend_run)
 
+    def test_lookup_backend_suggestion(self):
+        from torch._dynamo.backends.registry import lookup_backend
+        from torch._dynamo.exc import InvalidBackend
+
+        with self.assertRaisesRegex(InvalidBackend, "did you mean: 'inductor'"):
+            lookup_backend("indutcor")
+
     def test_lookup_custom_backend(self):
         from torch._dynamo import list_backends
 

--- a/torch/_dynamo/backends/registry.py
+++ b/torch/_dynamo/backends/registry.py
@@ -129,9 +129,7 @@ def lookup_backend(compiler_fn: str | CompilerFn) -> CompilerFn:
 
             from ..exc import InvalidBackend
 
-            suggestions = difflib.get_close_matches(
-                compiler_fn, list_backends(exclude_tags=()), n=2
-            )
+            suggestions = difflib.get_close_matches(compiler_fn, list_backends(), n=2)
             raise InvalidBackend(name=compiler_fn, suggestions=suggestions)
 
         if compiler_fn not in _COMPILER_FNS:

--- a/torch/_dynamo/backends/registry.py
+++ b/torch/_dynamo/backends/registry.py
@@ -125,9 +125,14 @@ def lookup_backend(compiler_fn: str | CompilerFn) -> CompilerFn:
         if compiler_fn not in _BACKENDS:
             _lazy_import()
         if compiler_fn not in _BACKENDS:
+            import difflib
+
             from ..exc import InvalidBackend
 
-            raise InvalidBackend(name=compiler_fn)
+            suggestions = difflib.get_close_matches(
+                compiler_fn, list_backends(exclude_tags=()), n=2
+            )
+            raise InvalidBackend(name=compiler_fn, suggestions=suggestions)
 
         if compiler_fn not in _COMPILER_FNS:
             entry_point = _BACKENDS[compiler_fn]

--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -239,10 +239,15 @@ class TorchRuntimeError(TorchDynamoException):
 
 
 class InvalidBackend(TorchDynamoException):
-    def __init__(self, name: str) -> None:
-        super().__init__(
-            f"Invalid backend: {name!r}, see `torch._dynamo.list_backends()` for available backends."
+    def __init__(self, name: str, suggestions: list[str] | None = None) -> None:
+        msg = f"Invalid backend: {name!r}"
+        msg += (
+            f", did you mean: {', '.join(map(repr, suggestions))}?"
+            if suggestions
+            else "."
         )
+        msg += " See `torch._dynamo.list_backends()` for available backends."
+        super().__init__(msg)
 
 
 class ResetRequired(TorchDynamoException):


### PR DESCRIPTION
## Why

A typo in the backend string only points at `list_backends()`:

```
Invalid backend: 'indutcor'. See `torch._dynamo.list_backends()` for available backends.
```

## How

- Compute close matches with `difflib.get_close_matches` at the raise site and thread them into `InvalidBackend`, giving:

```
Invalid backend: 'indutcor', did you mean: 'inductor'? See `torch._dynamo.list_backends()` for available backends.
```

The phrasing mirrors the analogous OpInfo lookup in `torch/distributed/tensor/_ops/strategy_validation.py`.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98