### PR TITLE
Add guan404ming as TVM backend owner

### DIFF
--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -478,6 +478,16 @@
   - Lint
   - pull
 
+- name: TVM backend
+  patterns:
+  - torch/_dynamo/backends/tvm.py
+  approved_by:
+  - guan404ming
+  mandatory_checks_name:
+  - EasyCLA
+  - Lint
+  - pull
+
 - name: Dynamo
   patterns:
   - torch/_dynamo/**

--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -478,16 +478,6 @@
   - Lint
   - pull
 
-- name: TVM backend
-  patterns:
-  - torch/_dynamo/backends/tvm.py
-  approved_by:
-  - guan404ming
-  mandatory_checks_name:
-  - EasyCLA
-  - Lint
-  - pull
-
 - name: Dynamo
   patterns:
   - torch/_dynamo/**

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -62,6 +62,9 @@ nn/qat/ @jerryzh168
 /torch/distributed/tensor/_ops/_view_ops.py @weifengpy
 /torch/distributed/tensor/_ops/_matrix_ops.py @weifengpy
 
+# TVM backend
+/torch/_dynamo/backends/tvm.py @guan404ming
+
 # ONNX Export
 /torch/_dynamo/backends/onnxrt.py @titaiwangms @xadupre @justinchuby
 /torch/csrc/jit/passes/onnx.h @titaiwangms @xadupre


### PR DESCRIPTION
## Why 

Per @ezyang's invitation (https://github.com/pytorch/pytorch/pull/189012#issuecomment-4896795933), the TVM backend had no owner. I'm currently a Apache TVM committer and volunteered to own this part here in PyTorch as well.

## How

Adds a `TVM backend` merge rule and a `CODEOWNERS` entry for `torch/_dynamo/backends/tvm.py`.