### PR TITLE
Cleanup/cuda indexing stale remnants

### DIFF
--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -691,7 +691,7 @@ inline void dot_check(const Tensor& self, const Tensor& other) {
   TORCH_CHECK(
       (self.numel() <= INT_MAX) && (self.stride(0) <= INT_MAX) &&
           (other.stride(0) <= INT_MAX),
-      "dot only supports n, incx, incy with the bound [val] <= %d",
+      "dot only supports n, incx, incy with the bound [val] <= ",
       INT_MAX);
 }
 

--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -832,7 +832,7 @@ inline void dot_check(const Tensor& self, const Tensor& other) {
   TORCH_CHECK(
       (self.numel() <= INT_MAX) && (self.stride(0) <= INT_MAX) &&
           (other.stride(0) <= INT_MAX),
-      "dot only supports n, incx, incy with the bound [val] <= %d",
+      "dot only supports n, incx, incy with the bound [val] <= ",
       INT_MAX);
 }
 

--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -72,7 +72,6 @@ __global__ void indexing_backward_kernel_many_indices(
   int smem_offset = threadIdx.y * C10_WARP_SIZE;
 
   int laneIdx = threadIdx.x % C10_WARP_SIZE;
-  int64_t grad_row = 0;
 
   for (int64_t z = blockIdx.z; z < outer_dim; z += gridDim.z) {
     // Init duplicates every time we compute a new set of entries:
@@ -992,8 +991,8 @@ static size_t getSliceSize(const Tensor & dst,
   }
 
   TORCH_CHECK(dstSliceSize == srcSliceSize,
-             "Source/destination tensor have different slice sizes (%ld vs %ld)",
-             dstSliceSize, srcSliceSize);
+             "Source/destination tensor have different slice sizes (",
+             dstSliceSize, " vs ", srcSliceSize, ")");
 
   if (mismatch) {
     TORCH_WARN_ONCE(
@@ -1028,7 +1027,6 @@ __global__ void indexFuncSmallIndex(cuda::detail::TensorInfo<T, IndexType> dst,
   // this is a good choice (small number of chosen indices), since
   // re-accessing indices in addition to src elements can be slow.
   for (IndexType srcIndex = 0; srcIndex < indices.sizes[0]; ++srcIndex) {
-    // Lua indices begin at 1
     IndexType dstIndex =
         indices.data[cuda::detail::IndexToOffset<const IndicesType, IndexType, IdxDim>::get(srcIndex, indices)];
     CUDA_KERNEL_ASSERT(dstIndex < dstAddDimSize);
@@ -1087,7 +1085,6 @@ __global__ void indexFuncLargeIndex(cuda::detail::TensorInfo<T, IndexType> dst,
       srcIndex = linearIndex % innerSize;
     }
 
-    // Lua indices begin at 1
     IndexType dstIndex =
         indices.data[cuda::detail::IndexToOffset<const IndicesType, IndexType, IdxDim>::get(srcIndex, indices)];
     CUDA_KERNEL_ASSERT(dstIndex < dstAddDimSize);

--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -73,7 +73,6 @@ __global__ void indexing_backward_kernel_many_indices(
   int smem_offset = threadIdx.y * C10_WARP_SIZE;
 
   int laneIdx = threadIdx.x % C10_WARP_SIZE;
-  int64_t grad_row = 0;
 
   for (int64_t z = blockIdx.z; z < outer_dim; z += gridDim.z) {
     // Init duplicates every time we compute a new set of entries:
@@ -993,8 +992,8 @@ static size_t getSliceSize(const Tensor & dst,
   }
 
   TORCH_CHECK(dstSliceSize == srcSliceSize,
-             "Source/destination tensor have different slice sizes (%ld vs %ld)",
-             dstSliceSize, srcSliceSize);
+             "Source/destination tensor have different slice sizes (",
+             dstSliceSize, " vs ", srcSliceSize, ")");
 
   if (mismatch) {
     TORCH_WARN_ONCE(
@@ -1029,7 +1028,6 @@ __global__ void indexFuncSmallIndex(cuda::detail::TensorInfo<T, IndexType> dst,
   // this is a good choice (small number of chosen indices), since
   // re-accessing indices in addition to src elements can be slow.
   for (IndexType srcIndex = 0; srcIndex < indices.sizes[0]; ++srcIndex) {
-    // Lua indices begin at 1
     IndexType dstIndex =
         indices.data[cuda::detail::IndexToOffset<const IndicesType, IndexType, IdxDim>::get(srcIndex, indices)];
     CUDA_KERNEL_ASSERT(dstIndex < dstAddDimSize);
@@ -1088,7 +1086,6 @@ __global__ void indexFuncLargeIndex(cuda::detail::TensorInfo<T, IndexType> dst,
       srcIndex = linearIndex % innerSize;
     }
 
-    // Lua indices begin at 1
     IndexType dstIndex =
         indices.data[cuda::detail::IndexToOffset<const IndicesType, IndexType, IdxDim>::get(srcIndex, indices)];
     CUDA_KERNEL_ASSERT(dstIndex < dstAddDimSize);

--- a/aten/src/ATen/native/quantized/cpu/QnnpackUtils.h
+++ b/aten/src/ATen/native/quantized/cpu/QnnpackUtils.h
@@ -203,8 +203,10 @@ struct PackedConvWeightsQnnp : public ConvPackedParamsBase<kSpatialDim> {
         calloc(1, sizeof(struct pytorch_qnnp_operator)));
     if (convolution == nullptr) {
       TORCH_INTERNAL_ASSERT(
-          false, "failed to allocate %zu bytes for pytorch_qnnp_operator structure",
-          sizeof(struct pytorch_qnnp_operator));
+          false,
+          "failed to allocate ",
+          sizeof(struct pytorch_qnnp_operator),
+          " bytes for pytorch_qnnp_operator structure");
     }
 
     convolution_op =
@@ -278,8 +280,7 @@ struct PackedConvWeightsQnnp : public ConvPackedParamsBase<kSpatialDim> {
     if (zero_buffer == nullptr) {
       pytorch_qnnp_delete_operator(convolution);
       TORCH_INTERNAL_ASSERT(
-          false, "failed to allocate %zu bytes for zero padding",
-          zero_size);
+          false, "failed to allocate ", zero_size, " bytes for zero padding");
     }
     // Need to set to input zero point
     // memset(zero_buffer, input_zero_point, zero_size);

--- a/aten/src/ATen/native/vulkan/ops/BinaryOp.cpp
+++ b/aten/src/ATen/native/vulkan/ops/BinaryOp.cpp
@@ -89,7 +89,7 @@ static Tensor binary_op_preprocess_other_arg(const Tensor& other_arg) {
       default:
         TORCH_CHECK(
             false,
-            "binary_op_tensor, doesn't support type %s",
+            "binary_op_tensor, doesn't support type ",
             other.scalar_type());
         break;
     }

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -1115,8 +1115,7 @@ static PyObject* THPModule_setSDPUseCuDNN(PyObject* _unused, PyObject* arg) {
   HANDLE_TH_ERRORS
   TORCH_CHECK(
       PyBool_Check(arg),
-      "set_sdp_use_cudnn expects a bool, "
-      "but got %s",
+      "set_sdp_use_cudnn expects a bool, but got ",
       THPUtils_typename(arg));
   at::globalContext().setSDPUseCuDNN(Py_IsTrue(arg));
   Py_RETURN_NONE;

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -1133,8 +1133,7 @@ static PyObject* THPModule_setSDPUseCuDNN(PyObject* _unused, PyObject* arg) {
   HANDLE_TH_ERRORS
   TORCH_CHECK(
       PyBool_Check(arg),
-      "set_sdp_use_cudnn expects a bool, "
-      "but got %s",
+      "set_sdp_use_cudnn expects a bool, but got ",
       THPUtils_typename(arg));
   at::globalContext().setSDPUseCuDNN(Py_IsTrue(arg));
   Py_RETURN_NONE;

--- a/torch/csrc/jit/runtime/autodiff.cpp
+++ b/torch/csrc/jit/runtime/autodiff.cpp
@@ -837,7 +837,7 @@ Gradient differentiate(std::shared_ptr<Graph>& graph) {
   TORCH_CHECK(
       graph.use_count() == 1,
       "differentiate will mutate and destroy the graph, so it requires "
-      "graph.use_count() == 1, but found %d",
+      "graph.use_count() == 1, but found ",
       graph.use_count());
   std::swap(graph, grad_desc.f);
   // XXX: Take care when handling outputs - they can be duplicated!

--- a/torch/csrc/jit/serialization/pickle.cpp
+++ b/torch/csrc/jit/serialization/pickle.cpp
@@ -24,8 +24,9 @@ c10::StrongTypePtr customClassResolver(const c10::QualifiedName& qn) {
   if (type == nullptr) {
     TORCH_CHECK(
         false,
-        "Couldn't resolve type '{}', did you forget to add its build dependency?",
-        qn.qualifiedName());
+        "Couldn't resolve type '",
+        qn.qualifiedName(),
+        "', did you forget to add its build dependency?");
   }
   // Passing nullptr is a little bit sus, but should be fine:
   // 1. The lifetime of the class type is not tied to a specific

--- a/torch/csrc/serialization.cpp
+++ b/torch/csrc/serialization.cpp
@@ -347,8 +347,9 @@ c10::intrusive_ptr<c10::StorageImpl> THPStorage_readFileRaw(
     size_t _storage_nbytes = storage->nbytes();
     TORCH_CHECK(
         _storage_nbytes == nbytes,
-        "storage has wrong byte size: expected %ld got %ld",
+        "storage has wrong byte size: expected ",
         nbytes,
+        " got ",
         _storage_nbytes);
   }
 

--- a/torch/csrc/serialization.cpp
+++ b/torch/csrc/serialization.cpp
@@ -344,8 +344,9 @@ c10::intrusive_ptr<c10::StorageImpl> THPStorage_readFileRaw(
     size_t _storage_nbytes = storage->nbytes();
     TORCH_CHECK(
         _storage_nbytes == nbytes,
-        "storage has wrong byte size: expected %ld got %ld",
+        "storage has wrong byte size: expected ",
         nbytes,
+        " got ",
         _storage_nbytes);
   }
 

--- a/torch/nativert/graph/Graph.cpp
+++ b/torch/nativert/graph/Graph.cpp
@@ -53,10 +53,11 @@ size_t expectImpl(std::string_view source, char expected, size_t curPos) {
   }
   TORCH_CHECK(
       expected == source[curPos],
-      "Parser error: expected '{}' at position {}, but found '{}'.",
-      expected,
-      curPos,
-      source[curPos]);
+      fmt::format(
+          "Parser error: expected '{}' at position {}, but found '{}'.",
+          expected,
+          curPos,
+          source[curPos]));
   curPos++;
   return curPos;
 }


### PR DESCRIPTION
The PR fixes assertion messages that used printf-style specifiers (`%d/%s/%zu/%ld`) inside `TORCH_CHECK`/`TORCH_INTERNAL_ASSERT`.
It also drops stale remnants in `Indexing.cu`: two `// Lua indices begin at 1` comments (code is 0-based) and a dead, shadowed `grad_row` decl.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01