### PR TITLE
[cpp_extension] Fail fast instead of deadlocking on a stale FileBaton…

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1130,6 +1130,35 @@ class TestDeviceLazyInit(TestCase):
         self.assertRegex(str(exc), pattern)
 
 
+class TestFileBaton(TestCase):
+    def test_wait_times_out_on_stale_lock(self):
+        # A lock left behind by a killed process (OOM/SIGKILL/cancelled job)
+        # must not deadlock waiters forever; with a timeout, wait() should fail
+        # fast with an actionable message instead of spinning indefinitely.
+        # See https://github.com/pytorch/pytorch/issues/189245.
+        from torch.utils.file_baton import FileBaton
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            lock_path = os.path.join(tmp_dir, "lock")
+
+            # Simulate a holder that acquired the lock and was killed before
+            # releasing it, leaving the lock file behind.
+            holder = FileBaton(lock_path)
+            self.assertTrue(holder.try_acquire())
+
+            waiter = FileBaton(lock_path, wait_seconds=0.01, timeout_seconds=0.5)
+            self.assertFalse(waiter.try_acquire())
+            with self.assertRaisesRegex(RuntimeError, "Timed out.*stale"):
+                waiter.wait()
+
+    def test_wait_defaults_to_no_timeout(self):
+        # The default preserves the historical wait-forever behavior so
+        # existing callers are unaffected.
+        from torch.utils.file_baton import FileBaton
+
+        self.assertIsNone(FileBaton("unused").timeout_seconds)
+
+
 instantiate_device_type_tests(
     TestDeviceLazyInit, globals(), except_for=["cpu"], allow_xpu=True
 )

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -2342,7 +2342,20 @@ def _jit_compile(name,
             logger.info('Bumping to version %s and re-building as %s_v%s...', version, name, version)
         name = f'{name}_v{version}'
 
-    baton = FileBaton(os.path.join(build_directory, 'lock'))
+    # Guard against a permanent deadlock if the process that acquired the lock
+    # was killed (OOM, SIGKILL, cancelled job) without releasing it. Waiting on
+    # a sibling's JIT build for this long is unambiguously abnormal, so fail
+    # fast with an actionable message instead of hanging forever. Override with
+    # PYTORCH_JIT_LOCK_TIMEOUT (seconds; empty or "0" disables the timeout).
+    _lock_timeout_env = os.environ.get('PYTORCH_JIT_LOCK_TIMEOUT')
+    if _lock_timeout_env is None:
+        lock_timeout_seconds: float | None = 3600.0
+    else:
+        lock_timeout_seconds = float(_lock_timeout_env) or None
+    baton = FileBaton(
+        os.path.join(build_directory, 'lock'),
+        timeout_seconds=lock_timeout_seconds,
+    )
     if baton.try_acquire():
         try:
             if version != old_version:

--- a/torch/utils/file_baton.py
+++ b/torch/utils/file_baton.py
@@ -7,7 +7,8 @@ import warnings
 class FileBaton:
     """A primitive, file-based synchronization utility."""
 
-    def __init__(self, lock_file_path, wait_seconds=0.1, warn_after_seconds=None) -> None:
+    def __init__(self, lock_file_path, wait_seconds=0.1, warn_after_seconds=None,
+                 timeout_seconds=None) -> None:
         """
         Create a new :class:`FileBaton`.
 
@@ -17,11 +18,19 @@ class FileBaton:
                 calling ``wait()``.
             warn_after_seconds: The seconds to wait before showing
                 lock file path to warn existing lock file.
+            timeout_seconds: If not ``None``, the maximum number of seconds
+                ``wait()`` will block before raising ``RuntimeError``. This
+                guards against a permanent deadlock when the process that
+                acquired the lock was killed (e.g. by OOM, ``SIGKILL``, or a
+                cancelled job) and never released the lock file. ``None``
+                (the default) preserves the previous behavior of waiting
+                indefinitely.
         """
         self.lock_file_path = lock_file_path
         self.wait_seconds = wait_seconds
         self.fd = None
         self.warn_after_seconds = warn_after_seconds
+        self.timeout_seconds = timeout_seconds
 
     def try_acquire(self) -> bool | None:
         """
@@ -49,8 +58,18 @@ class FileBaton:
         while os.path.exists(self.lock_file_path):
             time.sleep(self.wait_seconds)
 
+            elapsed = time.time() - start_time
+
+            if self.timeout_seconds is not None and elapsed > self.timeout_seconds:
+                raise RuntimeError(
+                    f'Timed out after {self.timeout_seconds:g} seconds waiting for '
+                    f'lock file "{self.lock_file_path}". The process that acquired the '
+                    f'lock may have been killed (e.g. by the OOM killer, SIGKILL, or a '
+                    f'cancelled job) without releasing it, leaving a stale lock. Delete '
+                    f'the lock file and retry.')
+
             if self.warn_after_seconds is not None:
-                if time.time() - start_time > self.warn_after_seconds and not has_warned:
+                if elapsed > self.warn_after_seconds and not has_warned:
                     warnings.warn(f'Waited on lock file "{self.lock_file_path}" for '
                                   f'{self.warn_after_seconds} seconds.', stacklevel=2)
                     has_warned = True


### PR DESCRIPTION
… lock

FileBaton.wait() spins while the lock file exists and only returns once the holder calls release(). The lock file is created with O_CREAT | O_EXCL, which -- unlike an OS flock -- is not removed when the holding process dies. If a process that acquired the lock is killed before releasing it (OOM killer, SIGKILL, Ctrl+C, or a cancelled Slurm job), the lock file is left behind and every subsequent cpp_extension.load() blocks forever in wait(): a permanent deadlock.

Add an optional timeout_seconds to FileBaton. When set, wait() raises a RuntimeError naming the lock file and explaining that the holder was likely killed and the lock is stale, instead of spinning indefinitely. The default is None, which preserves the previous wait-forever behavior, so existing callers are unaffected.

_jit_compile() now constructs the baton with a generous default timeout of 3600s, overridable via the PYTORCH_JIT_LOCK_TIMEOUT environment variable (empty or "0" disables the timeout). Waiting on a sibling's JIT build for an hour is unambiguously abnormal, so this turns the permanent hang into an actionable error while leaving normal builds untouched.

Fixes #189245.