### PR TITLE
[symm_mem] Make NVSHMEM free collective-safe via deferred drain

### DIFF
--- a/test/distributed/test_nvshmem.py
+++ b/test/distributed/test_nvshmem.py
@@ -4,7 +4,9 @@
 # python test/distributed/test_nvshmem.py
 
 
+import gc
 import os
+from unittest import mock
 
 import torch
 import torch.distributed as dist
@@ -101,6 +103,53 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
         out = symm_mem.empty(numel, dtype=dtype, device=self.device)
         self.assertEqual(out.device, self.device)
         symm_mem.rendezvous(out, group=group_name)
+
+    # Bypass the implicit mempool: with it, deletions only return blocks to
+    # the caching allocator's pool and allocations are served from its cache,
+    # so the NVSHMEM allocator's free()/alloc() (and thus the drain under
+    # test) would never run.
+    @mock.patch.object(symm_mem, "_use_implicit_mempool", False)
+    def test_out_of_order_free(self) -> None:
+        # nvshmem_free is collective but tensor storage destruction is not. The
+        # allocator queues frees and drains them at the next collective alloc,
+        # freeing only allocations that every rank has released. Exercise ranks
+        # releasing different subsets in different orders: the drain must
+        # converge (a rank-count mismatch in the drain all-gather would hang)
+        # and later symmetric collectives must still be correct.
+        self._init_device()
+        group_name = dist.group.WORLD.group_name
+
+        dtype = torch.float
+        numel = 1024
+
+        def alloc():
+            return symm_mem.empty(numel, dtype=dtype, device=self.device)
+
+        # Collective, lockstep allocations => identical alloc_ids across ranks.
+        tensors = {i: alloc() for i in range(4)}
+
+        # Each rank queues a different subset, in a different order. free() is
+        # not collective, so the subsets need not agree here.
+        for i in [(0, 2), (3, 1)][self.rank % 2]:
+            del tensors[i]
+        gc.collect()
+
+        # Triggers a drain whose per-rank pending sets differ, so the
+        # intersection is empty and nothing is collectively freed -- but the
+        # protocol must still terminate in lockstep across ranks.
+        extra = alloc()
+
+        # Now every rank releases everything, so the next drain sees a full
+        # intersection and collectively frees the queued allocations.
+        tensors.clear()
+        del extra
+        gc.collect()
+
+        out = alloc()
+        symm_mem.rendezvous(out, group=group_name)
+        out.fill_(self.rank)
+        torch.ops.symm_mem.nvshmem_broadcast(out, 0, group_name)
+        self.assertEqual(out, torch.zeros(numel, dtype=dtype, device=self.device))
 
     def test_mempool_tensor_factory(self) -> None:
         """

--- a/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cpp
@@ -13,7 +13,12 @@
 #include <c10/util/error.h>
 #include <c10/util/flat_hash_map.h>
 
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <map>
 #include <mutex>
+#include <vector>
 
 // Starting from NVSHMEM 3.3.9, nvshmem_host.h exists so that we can cleanly
 // include only the nvshmem host library headers:
@@ -31,14 +36,24 @@ namespace symmetric_memory {
 /* Start of NVSHMEMSymmetricMemory implementation */
 
 static StoreExchange storeExchange = StoreExchange("NVSHMEMSymmetricMemory");
+static StoreExchange freeStoreExchange =
+    StoreExchange("NVSHMEMSymmetricMemoryFree");
 
 struct NVSHMEMAllocation {
   void* ptr;
   size_t buffer_size;
   int device_idx;
+  uint64_t alloc_id;
 
-  NVSHMEMAllocation(void* ptr, size_t buffer_size, int device_idx)
-      : ptr(ptr), buffer_size(buffer_size), device_idx(device_idx) {}
+  NVSHMEMAllocation(
+      void* ptr,
+      size_t buffer_size,
+      int device_idx,
+      uint64_t alloc_id)
+      : ptr(ptr),
+        buffer_size(buffer_size),
+        device_idx(device_idx),
+        alloc_id(alloc_id) {}
 
   // Delete copy and move operations to prevent double-free
   NVSHMEMAllocation(const NVSHMEMAllocation&) = delete;
@@ -46,13 +61,23 @@ struct NVSHMEMAllocation {
   NVSHMEMAllocation(NVSHMEMAllocation&&) = delete;
   NVSHMEMAllocation& operator=(NVSHMEMAllocation&&) = delete;
 
-  ~NVSHMEMAllocation() {
+  void collective_free() {
+    if (ptr == nullptr) {
+      return;
+    }
     // Avoid calling CUDA functions after driver shutting down
     if (is_finalizing()) {
+      ptr = nullptr;
       return;
     }
     c10::cuda::CUDAGuard guard(device_idx);
     nvshmem_free(ptr); // nvshmem_free has no return value
+    ptr = nullptr;
+  }
+
+  ~NVSHMEMAllocation() {
+    // nvshmem_free is collective. Storage destruction is not, so the allocator
+    // defers actual frees to rank-synchronized allocation boundaries.
   }
 };
 
@@ -377,20 +402,43 @@ class NVSHMEMSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
     initialize_nvshmem_with_store(
         group->getStore(), group->getRank(), group->getSize(), device_idx);
 
+    drain_pending_frees_(group->getStore(), group->getRank(), group->getSize());
+
     auto ptr = nvshmem_malloc(size);
     // If size is 0 (which is legal allocation request) we shouldn't error out
     TORCH_CHECK(ptr != nullptr || size == 0, "nvshmem_malloc failed");
     {
       std::lock_guard<std::mutex> lock(mutex_);
       allocations_.try_emplace(
-          ptr, std::make_unique<NVSHMEMAllocation>(ptr, size, device_idx));
+          ptr,
+          std::make_unique<NVSHMEMAllocation>(
+              ptr, size, device_idx, next_alloc_id_++));
     }
     return ptr;
   }
 
   void free(void* ptr) override {
     std::lock_guard<std::mutex> lock(mutex_);
-    allocations_.erase(ptr);
+    auto it = allocations_.find(ptr);
+    if (it == allocations_.end()) {
+      return;
+    }
+
+    std::vector<SymmMemKey> stale_keys;
+    for (const auto& entry : symm_mems_) {
+      if (entry.first.first == ptr) {
+        stale_keys.push_back(entry.first);
+      }
+    }
+    for (const auto& key : stale_keys) {
+      symm_mems_.erase(key);
+    }
+
+    // nvshmem_free is collective, but tensor storage destruction is not.
+    // Queue this allocation and drain it at a future collective alloc boundary.
+    auto alloc_id = it->second->alloc_id;
+    pending_frees_.emplace(alloc_id, std::move(it->second));
+    allocations_.erase(it);
   };
 
   size_t get_alloc_size(void* ptr) override {
@@ -488,8 +536,62 @@ class NVSHMEMSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
   }
 
  private:
+  static constexpr uint64_t kNoPendingFree =
+      std::numeric_limits<uint64_t>::max();
+
+  uint64_t next_pending_free_at_or_after_(uint64_t alloc_id) {
+    auto it = pending_frees_.lower_bound(alloc_id);
+    if (it == pending_frees_.end()) {
+      return kNoPendingFree;
+    }
+    return it->first;
+  }
+
+  void drain_pending_frees_(
+      const c10::intrusive_ptr<c10d::Store>& store,
+      int rank,
+      int world_size) {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    // Repeatedly all-gather each rank's next pending id at or after
+    // search_from. Equal candidates are the stored intersection and are safe to
+    // collectively free; unequal candidates advance the search.
+    uint64_t search_from = 0;
+    while (true) {
+      auto candidate = next_pending_free_at_or_after_(search_from);
+      auto candidates =
+          freeStoreExchange.all_gather(store, rank, world_size, candidate);
+
+      uint64_t next_search_from = candidate;
+      bool all_match = candidate != kNoPendingFree;
+      for (const auto peer_candidate : candidates) {
+        if (peer_candidate == kNoPendingFree) {
+          return;
+        }
+        all_match &= peer_candidate == candidate;
+        next_search_from = std::max(next_search_from, peer_candidate);
+      }
+
+      if (!all_match) {
+        search_from = next_search_from;
+        continue;
+      }
+
+      auto it = pending_frees_.find(candidate);
+      TORCH_INTERNAL_ASSERT(
+          it != pending_frees_.end(),
+          "rank-agreed pending NVSHMEM free is missing locally");
+      it->second->collective_free();
+      pending_frees_.erase(it);
+      search_from = candidate + 1;
+    }
+  }
   std::mutex mutex_;
   std::unordered_map<void*, std::unique_ptr<NVSHMEMAllocation>> allocations_;
+  std::map<uint64_t, std::unique_ptr<NVSHMEMAllocation>> pending_frees_;
+  // Assigned in lockstep (alloc() is collective), so alloc_id is comparable
+  // across ranks.
+  uint64_t next_alloc_id_{0};
   ska::flat_hash_map<
       SymmMemKey,
       c10::intrusive_ptr<NVSHMEMSymmetricMemory>,

--- a/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cpp
@@ -77,7 +77,7 @@ struct NVSHMEMAllocation {
 
   // nvshmem_free is collective. Storage destruction is not, so the allocator
   // defers actual frees to rank-synchronized allocation boundaries.
-  
+
   ~NVSHMEMAllocation() = default;
 };
 

--- a/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cpp
@@ -424,9 +424,13 @@ class NVSHMEMSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
       return;
     }
 
-    std::erase_if(symm_mems_, [&](const auto& entry) {
-      return entry.first.first == ptr;
-    });
+    for (auto it = symm_mems_.begin(); it != symm_mems_.end();) {
+      if (it->first.first == ptr) {
+        it = symm_mems_.erase(it);
+      } else {
+        ++it;
+      }
+    }
 
     // nvshmem_free is collective, but tensor storage destruction is not.
     // Queue this allocation and drain it at a future collective alloc boundary.

--- a/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cpp
@@ -75,10 +75,10 @@ struct NVSHMEMAllocation {
     ptr = nullptr;
   }
 
-  ~NVSHMEMAllocation() {
-    // nvshmem_free is collective. Storage destruction is not, so the allocator
-    // defers actual frees to rank-synchronized allocation boundaries.
-  }
+  // nvshmem_free is collective. Storage destruction is not, so the allocator
+  // defers actual frees to rank-synchronized allocation boundaries.
+  
+  ~NVSHMEMAllocation() = default;
 };
 
 // A map from group name to rank-to-global rank mapping
@@ -424,15 +424,9 @@ class NVSHMEMSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
       return;
     }
 
-    std::vector<SymmMemKey> stale_keys;
-    for (const auto& entry : symm_mems_) {
-      if (entry.first.first == ptr) {
-        stale_keys.push_back(entry.first);
-      }
-    }
-    for (const auto& key : stale_keys) {
-      symm_mems_.erase(key);
-    }
+    std::erase_if(symm_mems_, [&](const auto& entry) {
+      return entry.first.first == ptr;
+    });
 
     // nvshmem_free is collective, but tensor storage destruction is not.
     // Queue this allocation and drain it at a future collective alloc boundary.


### PR DESCRIPTION
**Summary**:

`nvshmem_free` is a collective op (all PEs must call it together, in the same order), but PyTorch tensor storage destruction is not collective. It still holds its allocation. The previous `~NVSHMEMAllocation` called `nvshmem_free` directly from the storage deleter, so divergent free order across ranks could desynchronize or hang.

This defers the actual `nvshmem_free` out of the dtor and drains it at the next collective allocation boundary, freeing only allocations that every rank has released:

- Each allocation gets a monotonic `alloc_id`, assigned in lockstep (guaranteed identical across ranks because `nvshmem_malloc` is itself collective).
- `free()` no longer frees; it queues the allocation into `pending_frees_` and drops stale `symm_mems_` cache entries.
- `alloc()` first calls `drain_pending_frees_()`, which repeatedly all-gathers each rank's next pending `alloc_id` over the store and collectively frees the agreed-upon intersection. The loop is lockstep across ranks (every rank makes the same number of all-gather calls), so it converges without deadlock.
- `~NVSHMEMAllocation` becomes a no-op; `collective_free()` holds the real `nvshmem_free` (still guarded by `is_finalizing()`).

**Why this design**:

Freeing symmetric memory must be collective, but the trigger (storage destruction) is inherently local and unordered. Rather than forcing collective semantics onto every tensor free (which would require all ranks to free in the same order), we let frees accumulate locally and reconcile them at the next `alloc()`, the natural point where all ranks are already synchronized. The store-based all-gather of "next pending id" lets ranks agree on the safe-to-free set without assuming identical free order.

Trade-off: freed memory is not returned to NVSHMEM until the next collective `alloc()`. An alloc-quiet / free-heavy phase holds that memory resident. This is inherent to making free collective-safe.

Authored with Claude Opus 4.8 & Fable