### PR TITLE
[XPU] Re-enable test_optimizer_non_static_param for XPU

### DIFF
--- a/test/dynamo/test_logging.py
+++ b/test/dynamo/test_logging.py
@@ -25,8 +25,6 @@ from torch.testing._internal.common_utils import (
     munge_exc,
     skipIfTorchDynamo,
     skipIfWindows,
-    TEST_XPU,
-    xfailIf,
 )
 from torch.testing._internal.inductor_utils import (
     HAS_CUDA_AND_TRITON,
@@ -227,13 +225,13 @@ class LoggingTests(LoggingTestCase):
         self.assertIn(
             """\
     - User stack trace:
-    -   File [file_path], line 201, in outmost_fn
+    -   File [file_path], line 199, in outmost_fn
     -     return outer_fn(x, ys, zs)
-    -   File [file_path], line 204, in outer_fn
+    -   File [file_path], line 202, in outer_fn
     -     return fn(x, ys, zs)
-    -   File [file_path], line 207, in fn
+    -   File [file_path], line 205, in fn
     -     return inner(x, ys, zs)
-    -   File [file_path], line 210, in inner
+    -   File [file_path], line 208, in inner
     -     for y, z in zip(ys, zs):""",
             record_str,
         )
@@ -1339,7 +1337,6 @@ TRACE FX call mul from test_logging.py:N in fn (LoggingTests.test_trace_call_pre
         self.assertGreater(len(records), 0)
         self.assertLess(len(records), 4)
 
-    @xfailIf(TEST_XPU)  # https://github.com/pytorch/pytorch/issues/157778
     @make_logging_test(perf_hints=True)
     @requires_gpu
     def test_optimizer_non_static_param(self, records):


### PR DESCRIPTION
Fixes pytorch/pytorch#188987
Resolves pytorch/pytorch#157778

## Problem

`test_optimizer_non_static_param` was marked as `@xfailIf(TEST_XPU)` (expected to fail on XPU) because `torch.accelerator.Graph` support was missing on XPU. This caused CI to report "unexpected success" once the underlying issue was fixed:

```
test_optimizer_non_static_param ... unexpected success

FAILED (unexpected successes=1)
```

## Root Cause

XPU Graph support was added in PR #176421 (April 2026). The `@xfailIf(TEST_XPU)` decorator was never removed after the fix landed.

**Timeline**:
- 2025-07-08: Issue #157778 created (XPU Graph support missing)
- 2025-07-11: `@xfailIf(TEST_XPU)` added as workaround
- **2026-04-01**: XPU Graph support added (PR #176421) ← THE FIX
- 2026-04-07: Issue #157778 closed
- 2026-07-06: Issue #188987 opened — test passes but decorator causes "unexpected success"

## Fix

Remove the outdated `@xfailIf(TEST_XPU)` decorator and its now-unused imports (`TEST_XPU`, `xfailIf`). Update `test_recompiles` expected line numbers to reflect the 2-line shift.

```diff
-    TEST_XPU,
-    xfailIf,
 )
 ...
-    -   File [file_path], line 201, in outmost_fn
+    -   File [file_path], line 199, in outmost_fn
     ...
-    @xfailIf(TEST_XPU)  # https://github.com/pytorch/pytorch/issues/157778
     @make_logging_test(perf_hints=True)
     @requires_gpu
     def test_optimizer_non_static_param(self, records):
```

**Note on `test_recompiles`**: `test_recompiles` validates PyTorch recompile logging by checking exact stack trace line numbers of functions defined within the test file. Removing 2 import lines shifts all subsequent line numbers by -2, so the expected assertions must be updated accordingly (`line 201` → `line 199`, etc.).

## Verification

**Environment**:
- Hardware: Intel Data Center GPU Max 1550 (PVC) x8
- PyTorch: 2.14.0.dev20260707+xpu (nightly)
- oneAPI: 2026.0.0 (fresh environment, no cache)

**Post-fix**:
```
test_optimizer_non_static_param ... ok

OK
```

### CI Validation (test PR #189407)

A test PR was created to validate CI behavior before updating this PR:

| Shards | Result |
|--------|--------|
| Shard 4 (`test_recompiles` + `test_optimizer_non_static_param`) | ✅ PASS |
| Shards 1–8, 11–12 | ✅ PASS |
| Shards 9, 10 | ❌ `test_create_with_external_constants_xpu` SIGSEGV — pre-existing bug, unrelated to this PR |

### Test Plan
```bash
python test/dynamo/test_logging.py LoggingTests.test_optimizer_non_static_param -v
python test/dynamo/test_logging.py LoggingTests.test_recompiles -v
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98