### PR TITLE
Enable oneDNN for Windows ARM64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,7 +218,9 @@ set(CPU_RISCV OFF)
 
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "(AMD64|x86_64)")
   set(CPU_INTEL ON)
-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)")
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64|ARM64)")
+  # Linux reports "aarch64", macOS "arm64", and native Windows on Arm "ARM64".
+  # CMake MATCHES is case-sensitive, so accept each spelling.
   set(CPU_AARCH64 ON)
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(ppc64le)")
   set(CPU_POWER ON)


### PR DESCRIPTION
### Summary

Windows ARM64 builds registered no quantized engines, causing `test\test_torch.py TestTorch.test_qengine` to fail with `quantized engine NoQEngine is not supported` and leaving `torch.backends.quantized.supported_engines` empty.

The root cause is CPU architecture detection in CMake. On Windows ARM64, `CMAKE_SYSTEM_PROCESSOR` is `"ARM64"` (uppercase), but the detection only matched lowercase `arm64`/`aarch64`. Because CMake's `MATCHES` is case-sensitive, `CPU_AARCH64` was never set. `USE_MKLDNN` is gated on `CPU_AARCH64`, so oneDNN (MKLDNN) was silently disabled and no CPU quantized backend was compiled in.

### Changes

- Recognize uppercase `ARM64` in `CMAKE_SYSTEM_PROCESSOR` when   setting `CPU_AARCH64`

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01