### PR TITLE
Fix logical error in dist.broadcast to properly filter sm90+ devices

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -3486,7 +3486,7 @@ def broadcast(
     opts.rootRank = group_src
     opts.rootTensor = 0
     opts.asyncOp = async_op
-    sm90_or_more = not (
+    sm90_or_more = (
         tensor.is_cuda and torch.cuda.get_device_capability(tensor.device)[0] >= 9
     )
     if tensor.is_complex():

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -3491,7 +3491,7 @@ def broadcast(
     )
     if tensor.is_complex():
         tensor = torch.view_as_real(tensor)
-    elif _is_fp8(tensor) and not sm90_or_more:
+    elif _is_fp8(tensor) and not sm90_or_more and tensor.device.type != "hpu":
         # FP8 is supported by NCCL on sm90+, use workaround for older GPUs
         tensor = tensor.view(torch.uint8)
     work = group.broadcast([tensor], opts)


### PR DESCRIPTION
PR https://github.com/pytorch/pytorch/pull/175884 added workaround in torch.distributed.broadcast to cast fp8 with tensor.view(uint8) for devices older than sm90.

sm90_or_more variable has a logical error, as there is added unnecessary negation, which causes to store opposite value as against to variable name. 

Later there is condition ` elif _is_fp8(tensor) and not sm90_or_more:` where we expect to pass for older devices, but currently sm90+ machines are using this path.

Don't use cast to uint8 in HPU devices, as already reinterprets fp8 internally.