### PR TITLE
Fix `aten.stack` fake-tensor meta on symbolic shapes (regression from #188601)

### DIFF
--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -963,6 +963,20 @@ class FakeTensorTest(TestCase):
             b = torch.empty(u0, 16, device="cpu")
         prims.utils.compare_tensor_meta(a, b, check_strides=True)
 
+    def test_stack_symbolic_shapes(self):
+        # torch.stack, for a non-trailing dim, is computed as
+        # cat(...).view(result_sizes). The inner view must not require concrete
+        # sizes when the stacked tensors have symbolic shapes, otherwise it
+        # raises "SymIntArrayRef expected to contain only concrete integers".
+        shape_env = ShapeEnv()
+        with FakeTensorMode(shape_env=shape_env):
+            u0 = shape_env.create_unbacked_symint()
+            u1 = shape_env.create_unbacked_symint()
+            t = torch.empty(u0, u1, device="cpu")
+            out = torch.stack([t, t], dim=1)
+            self.assertEqual(out.dim(), 3)
+            self.assertEqual(out.size(1), 2)
+
     def test_batch_tensor(self):
         x = torch.rand((3, 4, 5))
         b = _add_batch_dim(x, 0, 0)

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -3382,7 +3382,6 @@ class FakeTensorMode(TorchDispatchMode):
         aten.view_as_complex.default,
         aten.set_.source_Storage_storage_offset,
         aten._sparse_coo_tensor_with_dims_and_tensors.default,
-        aten.stack.default,
     )
 
     _unbacked_special_fake_handling_ops = ordered_set(


### PR DESCRIPTION

#188601 added `aten.stack.default` to
`FakeTensorMode._cpp_meta_supports_symint`. This regressed fake-tensor tracing of `torch.stack` whenever the inputs have symbolic (`SymInt`) shapes:

```
RuntimeError: SymIntArrayRef expected to contain only concrete integers
```

Repro (no external project needed):

```python
from torch._subclasses.fake_tensor import FakeTensorMode
from torch.fx.experimental.symbolic_shapes import ShapeEnv

shape_env = ShapeEnv()
with FakeTensorMode(shape_env=shape_env):
    u0 = shape_env.create_unbacked_symint()
    u1 = shape_env.create_unbacked_symint()
    t = torch.empty(u0, u1)
    torch.stack([t, t], dim=1)   # raises on current main
```

Why it broke
------------
`_cpp_meta_supports_symint` lists ops whose meta kernel can size its output directly from `SymInt` inputs. `FakeTensorMode._dispatch_impl` uses it to choose how to compute meta for an op with symbolic sizes:

* op NOT in the set -> run the op's Python decomposition *under* `FakeTensorMode`, so every inner op is re-dispatched through `FakeTensorMode`'s `SymInt`-aware handling.
* op IN the set -> trust its meta kernel and run it directly.

The premise for adding stack was the new C++ `stack_meta` kernel (also from #188601). But that C++ kernel never actually runs: stack already has a Python meta registered from `torch._refs.stack` (via `activate_meta()`), which shadows the C++ registration -- `torch._C._dispatch_dump("aten::stack")` shows the C++ entry as `Meta (inactive)`. So the meta that runs is `torch._refs.stack`, which for a non-trailing dim computes:

```python
out = cat(tensors, dim)
return out.view(result_sizes)
```

On the direct path this inner `Tensor.view` on symbolic sizes hits the C++ view meta, which requires concrete integers and raises the error above. Before #188601, stack was not in the set, so `torch._refs.stack` ran as a decomposition under `FakeTensorMode`, where the inner view is `SymInt`-aware and succeeds.

This was originally reported by Helion (a Triton kernel compiler that traces kernels with symbolic tile/block sizes), but it is not Helion-specific -- it reproduces with plain `FakeTensorMode` as shown above.

Fix
---
Remove `aten.stack.default` from `_cpp_meta_supports_symint`, restoring the decomposition-under-`FakeTensorMode` path. This is a one-line revert of the regressing change. The now-inactive C++ `stack_meta` and its `native_functions.yaml` entry from #188601 are left in place (dead but harmless); making that kernel actually usable would be a separate change.

Test
----
`test_fake_tensor.py::FakeTensorTest::test_stack_symbolic_shapes` stacks two unbacked-`SymInt` tensors; it fails on current main with the error above and passes with this change.