### PR TITLE
  [TunableOp] Fix offline sub-matrix detection when a leading dimension aliases a GEMM dim

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -10486,7 +10486,6 @@ class TestLinalgCudaOnly(TestCase):
                 # BLAS PARAMS
                 self.assertTrue("{ function:" in first_row[4])
 
-    # Fails with triton 3.7
     @dtypes(torch.float)
     def test_mm_submatrix_offline_tunableop(self, device, dtype):
         import os
@@ -10632,7 +10631,6 @@ class TestLinalgCudaOnly(TestCase):
             ok = self._compare_untuned_tuned_entries()
             self.assertTrue(ok)
 
-    # Fails with triton 3.7
     @dtypes(torch.float)
     def test_mm_submatrix_leading_dim_alias_offline_tunableop(self, device, dtype):
         # Regression test for https://github.com/ROCm/TheRock/issues/5553

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -10632,6 +10632,58 @@ class TestLinalgCudaOnly(TestCase):
             ok = self._compare_untuned_tuned_entries()
             self.assertTrue(ok)
 
+    # Fails with triton 3.7
+    @dtypes(torch.float)
+    def test_mm_submatrix_leading_dim_alias_offline_tunableop(self, device, dtype):
+        # Regression test for https://github.com/ROCm/TheRock/issues/5553
+        # When a sub-matrix's leading dimension coincides with one of the GEMM
+        # dimensions (m, n, k), offline tuning used to misclassify it as a tight
+        # (non-sub) matrix and silently tuned the wrong shape, dropping the
+        # padded leading dimension. Here lda (== n == 6) is padded and differs
+        # from its tight value (m == 4), so the recorded and tuned param
+        # signatures must match (nt_6_4_2_ld_6_6_6). Before the fix the tuned
+        # entry drifted to nt_6_4_2_ld_6_4_6 and this comparison failed.
+        import os
+
+        with self._tunableop_ctx():
+            torch.cuda.tunable.set_rotating_buffer_size(0)
+            torch.cuda.tunable.set_max_tuning_duration(1)
+            torch.cuda.tunable.set_max_tuning_iterations(1)
+
+            # record a sub-matrix GEMM whose leading dim aliases a GEMM dim
+            torch.cuda.tunable.tuning_enable(False)
+            torch.cuda.tunable.record_untuned_enable(True)
+            self.assertTrue(torch.cuda.tunable.record_untuned_is_enabled())
+
+            # n > m so the padded lda (== n) differs from the tight lda (== m)
+            n = 6
+            m = 4
+            k = 2
+
+            # 'NT' -> records GemmTunableOp_<dtype>_NT, nt_6_4_2_ld_6_6_6
+            matA = torch.rand(n, n, dtype=dtype, device=device).t()
+            matB = torch.rand(n, n, dtype=dtype, device=device)
+            subA = matA[:m, :k]
+            subB = matB[:k, :n]
+            torch.mm(subA, subB)
+
+            untuned_filename = get_tunableop_untuned_filename()
+
+            # tune the recorded GEMM
+            torch.cuda.tunable.tuning_enable(True)
+            torch.cuda.tunable.record_untuned_enable(False)
+            torch.cuda.tunable.set_max_tuning_duration(1)
+            torch.cuda.tunable.set_max_tuning_iterations(1)
+
+            torch.cuda.tunable.tune_gemm_in_file(untuned_filename)
+
+            results_filename = torch.cuda.tunable.get_filename()
+            self.assertTrue(os.path.exists(results_filename))
+
+            # Every recorded Op+Param signature must appear in the tuned results.
+            ok = self._compare_untuned_tuned_entries()
+            self.assertTrue(ok)
+
     @dtypes(torch.float32)
     def test_ops_append_to_existing_file_tunableop(self, device, dtype):
         """If a TunableOp results file already exists (with matching Validator),

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -650,7 +650,16 @@ def _process_single_offline_gemm(untuned_gemm_line: str, gpu_id: int) -> None:
         [ldb, lda, ldc] = [int(g) for g in untuned_gemm_temp[5:8]]
 
     # Detect subMatrix case
-    if all(item in [n, m, k] for item in [lda, ldb, ldc]):
+    # A GEMM is "tight" (not a sub-matrix) only when each leading dimension
+    # equals its expected contiguous value for the given transpose layout.
+    # Checking mere membership in {n, m, k} is wrong: a padded leading
+    # dimension can coincidentally equal one of n/m/k (e.g. lda == n), which
+    # silently rewrites the requested shape and tunes the wrong GEMM.
+    # See https://github.com/ROCm/TheRock/issues/5553
+    lda_tight = m if transA else k
+    ldb_tight = k if transB else n
+    ldc_tight = n
+    if lda == lda_tight and ldb == ldb_tight and ldc == ldc_tight:
         subMatrix = False
     else:
         subMatrix = True


### PR DESCRIPTION
## Summary
  Fixes https://github.com/ROCm/TheRock/issues/5553. Offline TunableOp tuning (`tune_gemm_in_file`) could silently tune the wrong GEMM shape. `_process_single_offline_gemm` decided whether an entry described a sub-matrix (padded leading dimensions) with:
```python
  if all(item in [n, m, k] for item in [lda, ldb, ldc]):
      subMatrix = False
```

  This only checks membership in {n, m, k}. A padded leading dimension can legitimately equal one of n/m/k; when it does, the GEMM is misclassified as tight, the requested leading dimensions are dropped, and contiguous matrices are built instead — tuning a different shape than requested.

Example (from the linked issue): tuning GemmTunableOp_Half_NT,nt_65536_32768_384_ld_65536_65536_65536 (where lda == n == 65536) was silently rewritten to  ...ld_65536_32768_65536 (lda collapsed to m == 32768).

  ## Fix

  Detect the sub-matrix case by comparing each leading dimension against its
  expected contiguous value for the transpose layout:
```
  lda_tight = m if transA else k
  ldb_tight = k if transB else n
  ldc_tight = n
  subMatrix = not (lda == lda_tight and ldb == ldb_tight and ldc == ldc_tight)
```
  The change is strictly one-directional (only ever moves cases tight → sub, never
  the reverse), so genuinely-tight GEMMs are unaffected. Verified that all four
  transpose layouts (NN/NT/TN/TT) still classify as tight.

  ## Test plan

  Adds test_mm_submatrix_leading_dim_alias_offline_tunableop, which records and
  offline-tunes an NT sub-matrix whose lda aliases n (nt_6_4_2_ld_6_6_6) and
  asserts the tuned param signature matches the recorded one.

  Verified on gfx906 (ROCm):
  - New test: passes with the fix, fails without it (tuned entry drifts to
  nt_6_4_2_ld_6_4_6).
  - Existing offline tunableop tests still pass:
  test_mm_submatrix_offline_tunableop, test_matmul_offline_tunableop,
  test_offline_tuning_append_to_existing_file_tunableop,
  test_gemm_bias_offline_tunableop.
  
