### PR TITLE
[aot_autograd] Hoist IndentedBuffer to torch.utils; subclass it in PySourceBuilder

### DIFF
--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -99,7 +99,6 @@ from torch._guards import (
     Source,
     StorageOverlap,
 )
-from torch._inductor.utils import IndentedBuffer
 from torch._library.fake_class_registry import FakeScriptObject
 from torch._library.opaque_object import get_opaque_obj_info, is_opaque_constant_type
 from torch._logging import structured
@@ -112,6 +111,7 @@ from torch.fx.experimental.symbolic_shapes import (
     SYMPY_INTERP,
 )
 from torch.utils import _pytree as pytree
+from torch.utils._indented_buffer import IndentedBuffer
 from torch.utils._ordered_set import OrderedSet
 from torch.utils._traceback import format_frame, report_compile_source_on_error
 from torch.utils.weak import TensorWeakRef
@@ -5138,7 +5138,7 @@ class CheckFunctionManager:
 
 
 def build_guard_function(code_parts: list[str], closure_args: str) -> tuple[str, str]:
-    from torch._inductor.utils import IndentedBuffer
+    from torch.utils._indented_buffer import IndentedBuffer
 
     csepass = PyExprCSEPass()
     try:

--- a/torch/_functorch/_aot_autograd/codegen.py
+++ b/torch/_functorch/_aot_autograd/codegen.py
@@ -21,19 +21,23 @@ import threading
 from collections.abc import Callable, Iterator
 
 import torch
+from torch.utils._indented_buffer import IndentedBuffer
 
 
 log = logging.getLogger(__name__)
 
 
-class PySourceBuilder:
+class PySourceBuilder(IndentedBuffer):
     """Builds indented Python source for compile/exec, along with the globals
     the generated code closes over and a monotonic fresh-name counter.
 
-    Body lines are written WITHOUT leading whitespace; indentation is managed
-    by the ``indent()`` context manager so call sites read as plain code. Pass
+    Inherits the indentation primitive (``writeline``/``indent()``) from
+    IndentedBuffer: body lines are written WITHOUT leading whitespace and
+    indentation is managed by the ``indent()`` context manager so call sites
+    read as plain code. This subclass adds the exec layer (globals binding,
+    fresh-name generation, and ``build()`` via _compile_and_exec_source). Pass
     ``fn_name``/``artifact_name`` to emit a ``def`` header and enable
-    ``build()``, which routes through _compile_and_exec_source.
+    ``build()``.
     """
 
     def __init__(
@@ -43,26 +47,13 @@ class PySourceBuilder:
         args: str = "args",
         artifact_name: str | None = None,
     ) -> None:
-        self.lines: list[str] = []
+        super().__init__()
         self.globals: dict[str, object] = {}
         self._name_counter: int = 0
-        self._indent: int = 0
         self._fn_name = fn_name
         self._artifact_name = artifact_name
         if fn_name is not None:
             self.writeline(f"def {fn_name}({args}):")
-
-    @contextlib.contextmanager
-    def indent(self, offset: int = 1) -> Iterator[None]:
-        self._indent += offset
-        try:
-            yield
-        finally:
-            self._indent -= offset
-
-    def writeline(self, line: str) -> None:
-        """Append one line at the current indent level (paired with indent())."""
-        self.lines.append("    " * self._indent + line)
 
     def emit(self, line: str, indent: int = 1) -> None:
         """Append one line at an explicit absolute indent level.
@@ -70,7 +61,11 @@ class PySourceBuilder:
         Convenient for recursive generators that thread an indent depth instead
         of nesting indent() context managers.
         """
-        self.lines.append("    " * indent + line)
+        saved, self._indent = self._indent, indent
+        try:
+            self.writeline(line)
+        finally:
+            self._indent = saved
 
     def fresh_name(self, prefix: str) -> str:
         name = f"{prefix}_{self._name_counter}"
@@ -91,7 +86,9 @@ class PySourceBuilder:
         return self.add_global(self.fresh_name(prefix), value)
 
     def getvalue(self) -> str:
-        return "\n".join(self.lines)
+        # Join without a trailing newline (unlike IndentedBuffer.getvalue).
+        assert all(isinstance(li, str) for li in self._lines)  # noqa: S101
+        return "\n".join(self._lines)  # type: ignore[arg-type]
 
     def build(
         self, *, wrapped_fn: Callable[..., object] | None = None

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -104,6 +104,10 @@ from .utils import (
 )
 
 
+if typing.TYPE_CHECKING:
+    from .codegen import PySourceBuilder
+
+
 def _snapshot_external_objects(ctx: Any) -> None:
     """Snapshot the external object registry onto ctx for backward restore."""
     ctx._external_objects = {
@@ -806,19 +810,18 @@ class _RuntimeForwardEpilogue:
 
 
 def _codegen_capture_orig_inputs(
-    rw_lines: list[str],
+    buf: "PySourceBuilder",
     epilogue_args_idx: tuple[int, ...],
 ) -> None:
     if epilogue_args_idx:
         idx_str = ", ".join(f"{i}: args[{i}]" for i in epilogue_args_idx)
-        rw_lines.append(f"    orig_inputs = {{{idx_str}}}")
+        buf.emit(f"orig_inputs = {{{idx_str}}}", indent=1)
     else:
-        rw_lines.append("    orig_inputs = {}")
+        buf.emit("orig_inputs = {}", indent=1)
 
 
 def _codegen_increment_mutation_versions(
-    rw_lines: list[str],
-    rw_globals: dict[str, object],
+    buf: "PySourceBuilder",
     keep_input_mutations: bool,
     runtime_metadata: ViewAndMutationMeta,
 ) -> None:
@@ -826,80 +829,78 @@ def _codegen_increment_mutation_versions(
         keep_input_mutations
         and runtime_metadata.mutated_graph_handled_indices_seen_by_autograd
     ):
-        rw_globals["_increment_version_"] = torch.autograd.graph.increment_version
+        buf.add_global("_increment_version_", torch.autograd.graph.increment_version)
         mut_idx = tuple(runtime_metadata.mutated_graph_handled_indices_seen_by_autograd)
         gen_expr = ", ".join(f"args[{i}]" for i in mut_idx)
-        rw_lines.append(f"    _increment_version_(({gen_expr},))")
+        buf.emit(f"_increment_version_(({gen_expr},))", indent=1)
 
 
 def _codegen_normalize_as_list(
-    lines: list[str], var_name: str, *, indent_level: int
+    buf: "PySourceBuilder", var_name: str, *, indent_level: int
 ) -> None:
-    indent = "    " * indent_level
-    lines.append(f"{indent}if isinstance({var_name}, tuple):")
-    lines.append(f"{indent}    {var_name} = list({var_name})")
-    lines.append(f"{indent}elif not isinstance({var_name}, list):")
-    lines.append(f"{indent}    {var_name} = [{var_name}]")
+    buf.emit(f"if isinstance({var_name}, tuple):", indent=indent_level)
+    buf.emit(f"{var_name} = list({var_name})", indent=indent_level + 1)
+    buf.emit(f"elif not isinstance({var_name}, list):", indent=indent_level)
+    buf.emit(f"{var_name} = [{var_name}]", indent=indent_level + 1)
 
 
 def _codegen_compiled_fn_invocation(
-    rw_lines: list[str],
-    rw_globals: dict[str, object],
+    buf: "PySourceBuilder",
     trace_joint: bool,
     indices_of_inps_to_detach: list[int],
     disable_amp: bool,
 ) -> None:
-    rw_lines.append("    with _first_ctx_():")
+    buf.emit("with _first_ctx_():", indent=1)
     # trace_joint is known at codegen time. Only the joint/training path needs
     # forced view replay; inference wrappers should not touch this TLS state.
     if trace_joint:
-        rw_lines.append("        args_ = list(args)")
+        buf.emit("args_ = list(args)", indent=2)
         for idx in indices_of_inps_to_detach:
-            rw_lines.append(
-                f"        if isinstance(args_[{idx}], torch.Tensor): "
-                f"args_[{idx}] = args_[{idx}].detach()"
+            buf.emit(
+                f"if isinstance(args_[{idx}], torch.Tensor): "
+                f"args_[{idx}] = args_[{idx}].detach()",
+                indent=2,
             )
-        rw_lines.append(
-            "        prev_view_replay_enabled = torch._C._is_view_replay_enabled()"
+        buf.emit(
+            "prev_view_replay_enabled = torch._C._is_view_replay_enabled()", indent=2
         )
-        rw_lines.append("        try:")
-        rw_lines.append("            if not prev_view_replay_enabled:")
-        rw_lines.append("                torch._C._set_view_replay_enabled(True)")
-        rw_lines.append("            with torch.enable_grad():")
-        rw_lines.append("                _on_before_call_()")
+        buf.emit("try:", indent=2)
+        buf.emit("if not prev_view_replay_enabled:", indent=3)
+        buf.emit("torch._C._set_view_replay_enabled(True)", indent=4)
+        buf.emit("with torch.enable_grad():", indent=3)
+        buf.emit("_on_before_call_()", indent=4)
         if disable_amp:
-            rw_globals["_DisableAutocast_"] = torch._C._DisableAutocast
-            rw_lines.append("                with _DisableAutocast_():")
-            rw_lines.append("                    all_outs = _compiled_fn_(args_)")
-            _codegen_normalize_as_list(rw_lines, "all_outs", indent_level=5)
+            buf.add_global("_DisableAutocast_", torch._C._DisableAutocast)
+            buf.emit("with _DisableAutocast_():", indent=4)
+            buf.emit("all_outs = _compiled_fn_(args_)", indent=5)
+            _codegen_normalize_as_list(buf, "all_outs", indent_level=5)
         else:
-            rw_lines.append("                all_outs = _compiled_fn_(args_)")
-            _codegen_normalize_as_list(rw_lines, "all_outs", indent_level=4)
-        rw_lines.append("        finally:")
-        rw_lines.append(
-            "            if torch._C._is_view_replay_enabled() != prev_view_replay_enabled:"
+            buf.emit("all_outs = _compiled_fn_(args_)", indent=4)
+            _codegen_normalize_as_list(buf, "all_outs", indent_level=4)
+        buf.emit("finally:", indent=2)
+        buf.emit(
+            "if torch._C._is_view_replay_enabled() != prev_view_replay_enabled:",
+            indent=3,
         )
-        rw_lines.append(
-            "                torch._C._set_view_replay_enabled(prev_view_replay_enabled)"
+        buf.emit(
+            "torch._C._set_view_replay_enabled(prev_view_replay_enabled)", indent=4
         )
     else:
-        rw_lines.append("        grad_enabled = torch.is_grad_enabled()")
-        rw_lines.append("        try:")
-        rw_lines.append(
-            "            if grad_enabled: torch._C._set_grad_enabled(False)"
-        )
-        rw_lines.append("            _on_before_call_()")
+        buf.emit("grad_enabled = torch.is_grad_enabled()", indent=2)
+        buf.emit("try:", indent=2)
+        buf.emit("if grad_enabled: torch._C._set_grad_enabled(False)", indent=3)
+        buf.emit("_on_before_call_()", indent=3)
         if disable_amp:
-            rw_globals["_DisableAutocast_"] = torch._C._DisableAutocast
-            rw_lines.append("            with _DisableAutocast_():")
-            rw_lines.append("                all_outs = _compiled_fn_(args)")
-            _codegen_normalize_as_list(rw_lines, "all_outs", indent_level=4)
+            buf.add_global("_DisableAutocast_", torch._C._DisableAutocast)
+            buf.emit("with _DisableAutocast_():", indent=3)
+            buf.emit("all_outs = _compiled_fn_(args)", indent=4)
+            _codegen_normalize_as_list(buf, "all_outs", indent_level=4)
         else:
-            rw_lines.append("            all_outs = _compiled_fn_(args)")
-            _codegen_normalize_as_list(rw_lines, "all_outs", indent_level=3)
-        rw_lines.append("        finally:")
-        rw_lines.append("            if grad_enabled: torch._C._set_grad_enabled(True)")
-    rw_lines.append("    del args")
+            buf.emit("all_outs = _compiled_fn_(args)", indent=3)
+            _codegen_normalize_as_list(buf, "all_outs", indent_level=3)
+        buf.emit("finally:", indent=2)
+        buf.emit("if grad_enabled: torch._C._set_grad_enabled(True)", indent=3)
+    buf.emit("del args", indent=1)
 
 
 # signatures mirror the _RuntimeForwardEpilogue reference methods
@@ -911,48 +912,49 @@ _EpilogueReplayAliasesFn = Callable[[dict[int, Tensor], list[Any]], list[Any]]
 
 
 def _codegen_epilogue(
-    rw_lines: list[str],
-    rw_globals: dict[str, object],
+    buf: "PySourceBuilder",
     runtime_metadata: ViewAndMutationMeta,
     apply_mutations_fn: _EpilogueApplyMutationsFn | None,
     replay_aliases_fn: _EpilogueReplayAliasesFn | None,
     num_mutated_runtime_inps: int,
     expected_outs: int,
 ) -> None:
-    rw_lines.append(f"    if len(all_outs) != {expected_outs}:")
-    rw_lines.append(
-        f'        raise AssertionError(f"expected {expected_outs} outputs, '
-        f'got {{len(all_outs)}}")'
+    buf.emit(f"if len(all_outs) != {expected_outs}:", indent=1)
+    buf.emit(
+        f'raise AssertionError(f"expected {expected_outs} outputs, '
+        f'got {{len(all_outs)}}")',
+        indent=2,
     )
 
     if num_mutated_runtime_inps > 0:
-        rw_lines.append(f"    updated_inputs = all_outs[:{num_mutated_runtime_inps}]")
-        rw_lines.append(f"    fw_outs = all_outs[{num_mutated_runtime_inps}:]")
-        rw_lines.append("    _apply_mutations_(orig_inputs, updated_inputs)")
-        rw_globals["_apply_mutations_"] = apply_mutations_fn
+        buf.emit(f"updated_inputs = all_outs[:{num_mutated_runtime_inps}]", indent=1)
+        buf.emit(f"fw_outs = all_outs[{num_mutated_runtime_inps}:]", indent=1)
+        buf.emit("_apply_mutations_(orig_inputs, updated_inputs)", indent=1)
+        buf.add_global("_apply_mutations_", apply_mutations_fn)
     else:
-        rw_lines.append("    fw_outs = all_outs")
+        buf.emit("fw_outs = all_outs", indent=1)
 
     if runtime_metadata.num_outputs_aliased > 0:
-        rw_globals["_replay_aliases_"] = replay_aliases_fn
-        rw_lines.append("    ret_outs = _replay_aliases_(orig_inputs, fw_outs)")
+        buf.add_global("_replay_aliases_", replay_aliases_fn)
+        buf.emit("ret_outs = _replay_aliases_(orig_inputs, fw_outs)", indent=1)
     else:
-        rw_lines.append("    ret_outs = fw_outs")
+        buf.emit("ret_outs = fw_outs", indent=1)
 
     if runtime_metadata.dynamic_outputs:
-        rw_globals["_mark_dynamic_"] = mark_dynamo_propagated_dynamic_indices
+        buf.add_global("_mark_dynamic_", mark_dynamo_propagated_dynamic_indices)
         for i, o in enumerate(runtime_metadata.output_info):
             if o.dynamic_dims is not None:
                 dims_name = f"_dyn_dims_{i}"
-                rw_globals[dims_name] = o.dynamic_dims
-                rw_lines.append(f"    _mark_dynamic_(ret_outs[{i}], {dims_name})")
+                buf.add_global(dims_name, o.dynamic_dims)
+                buf.emit(f"_mark_dynamic_(ret_outs[{i}], {dims_name})", indent=1)
 
     if runtime_metadata.grad_enabled_mutation is not None:
-        rw_lines.append(
-            f"    torch._C._set_grad_enabled({runtime_metadata.grad_enabled_mutation!r})"
+        buf.emit(
+            f"torch._C._set_grad_enabled({runtime_metadata.grad_enabled_mutation!r})",
+            indent=1,
         )
 
-    rw_lines.append("    return ret_outs")
+    buf.emit("return ret_outs", indent=1)
 
 
 def _create_runtime_wrapper(
@@ -1075,11 +1077,13 @@ def _create_runtime_wrapper(
             artifact_name="mutation_epilogue",
         )
         buf.bind(torch=torch, _unwrap_tensoralias=_unwrap_tensoralias)
+        wrote_body = False
         with buf.indent():
             for i, inpt_idx in enumerate(runtime_metadata.mutated_inp_runtime_indices):
                 meta = runtime_metadata.input_info[inpt_idx]
                 if not meta.mutates_data and not meta.mutates_metadata:
                     continue
+                wrote_body = True
                 oi = f"orig_inputs[{inpt_idx}]"
                 ui = f"updated_inputs[{i}]"
                 if meta.mutates_storage_metadata:
@@ -1128,7 +1132,7 @@ def _create_runtime_wrapper(
                             buf.writeline(f"raise RuntimeError({msg_name})")
                         else:
                             buf.writeline(f"{oi}.copy_({ui})")
-            if len(buf.lines) == 1:
+            if not wrote_body:
                 buf.writeline("pass")
 
         codegen_apply_mutations = typing.cast(_EpilogueApplyMutationsFn, buf.build())
@@ -1149,19 +1153,14 @@ def _create_runtime_wrapper(
         artifact_name="runtime_wrapper_orchestration",
     )
     buf.bind(torch=torch)
-    rw_lines = buf.lines
-    rw_globals = buf.globals
 
-    _codegen_capture_orig_inputs(rw_lines, epilogue_args_idx)
-    _codegen_increment_mutation_versions(
-        rw_lines, rw_globals, keep_input_mutations, runtime_metadata
-    )
+    _codegen_capture_orig_inputs(buf, epilogue_args_idx)
+    _codegen_increment_mutation_versions(buf, keep_input_mutations, runtime_metadata)
     _codegen_compiled_fn_invocation(
-        rw_lines, rw_globals, trace_joint, indices_of_inps_to_detach, disable_amp
+        buf, trace_joint, indices_of_inps_to_detach, disable_amp
     )
     _codegen_epilogue(
-        rw_lines,
-        rw_globals,
+        buf,
         runtime_metadata,
         codegen_apply_mutations,
         codegen_alias_fn,
@@ -3245,10 +3244,10 @@ def _codegen_compiled_forward(
             buf.writeline("with _DisableAutocast_():")
             with buf.indent():
                 buf.writeline("fw_outs = _compiled_fw_(list(args))")
-                _codegen_normalize_as_list(buf.lines, "fw_outs", indent_level=2)
+                _codegen_normalize_as_list(buf, "fw_outs", indent_level=2)
         else:
             buf.writeline("fw_outs = _compiled_fw_(list(args))")
-            _codegen_normalize_as_list(buf.lines, "fw_outs", indent_level=1)
+            _codegen_normalize_as_list(buf, "fw_outs", indent_level=1)
 
         buf.writeline("_save_(ctx, fw_outs)")
         buf.writeline("return _finalize_(ctx, fw_outs)")

--- a/torch/_functorch/_aot_autograd/subclass_codegen.py
+++ b/torch/_functorch/_aot_autograd/subclass_codegen.py
@@ -551,7 +551,7 @@ def _codegen_subclass_wrapper_source(
     else:
         state.emit(f"return {result_tuple}")
 
-    source = "\n".join(state.lines)
+    source = state.getvalue()
     return source, state.globals
 
 
@@ -570,7 +570,7 @@ def _codegen_subclass_wrap_source(
     )
     result_tuple = f"({', '.join(result_exprs)},)" if result_exprs else "()"
     state.emit(f"return {result_tuple}")
-    source = "\n".join(state.lines)
+    source = state.getvalue()
     return source, state.globals
 
 

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -11,7 +11,6 @@ import inspect
 import io
 import itertools
 import logging
-import math
 import operator
 import os
 import platform
@@ -21,7 +20,6 @@ import statistics
 import sys
 import sysconfig
 import tempfile
-import textwrap
 import time
 import unittest
 from collections.abc import (
@@ -35,20 +33,18 @@ from collections.abc import (
 )
 from datetime import datetime
 from functools import lru_cache
-from io import StringIO
 from typing import (
     Any,
     cast,
     Concatenate,
     Generic,
     Literal,
-    NamedTuple,
     Protocol,
     TYPE_CHECKING,
     TypeAlias,
     TypeGuard,
 )
-from typing_extensions import dataclass_transform, ParamSpec, Self, TypeVar
+from typing_extensions import dataclass_transform, ParamSpec, TypeVar
 from unittest import mock
 
 import sympy
@@ -59,6 +55,16 @@ from torch._inductor.analysis.device_info import datasheet_tops
 from torch._inductor.runtime.hints import DeviceProperties
 from torch.fx.passes.regional_inductor import _needs_inductor_compile
 from torch.utils._dtype_abbrs import dtype_abbrs
+
+# The IndentedBuffer primitive and its line-map helpers live in torch.utils so
+# they can be shared across layers (dynamo guards, AOTAutograd codegen) without
+# importing this heavy module. Re-exported here for existing inductor call sites.
+from torch.utils._indented_buffer import (
+    DeferredLineBase,
+    IndentedBuffer,
+    LineContext,  # noqa: F401
+    ValueWithLineMap,  # noqa: F401
+)
 from torch.utils._ordered_set import OrderedSet
 from torch.utils._pytree import tree_flatten, tree_map_only
 from torch.utils._triton import has_triton_package
@@ -1603,182 +1609,6 @@ def get_dtype_size(dtype: torch.dtype) -> int:
     return torch.empty((), dtype=dtype).element_size()
 
 
-class LineContext(NamedTuple):
-    context: Any
-
-
-@dataclasses.dataclass
-class ValueWithLineMap:
-    value: str
-    line_map: list[tuple[int, LineContext]]
-
-
-class IndentedBuffer:
-    tabwidth = 4
-
-    def __init__(self, initial_indent: int = 0) -> None:
-        self._lines: list[DeferredLineBase | LineContext | str] = []
-        self._indent = initial_indent
-
-    @contextlib.contextmanager
-    def set_tabwidth(self, tabwidth: int) -> Iterator[None]:
-        prev = self.tabwidth
-        try:
-            self.tabwidth = tabwidth
-            yield
-        finally:
-            self.tabwidth = prev
-
-    def getvaluewithlinemap(self) -> ValueWithLineMap:
-        buf = StringIO()
-        p = 1
-        linemap: list[tuple[int, LineContext]] = []
-        for li in self._lines:
-            if isinstance(li, DeferredLineBase):
-                line = li()
-                if line is None:
-                    continue
-            elif isinstance(li, LineContext):
-                linemap.append((p, li.context))
-                continue
-            else:
-                line = li
-            if not isinstance(line, str):
-                raise AssertionError(f"Expected str, got {type(line)}")
-            buf.write(line)
-            buf.write("\n")
-            p += 1 + line.count("\n")
-        return ValueWithLineMap(buf.getvalue(), linemap)
-
-    def getvalue(self) -> str:
-        return self.getvaluewithlinemap().value
-
-    def getrawvalue(self) -> str:
-        buf = StringIO()
-        for li in self._lines:
-            if isinstance(li, DeferredLineBase):
-                line = li()
-                if line is None:
-                    continue
-            elif isinstance(li, LineContext):
-                continue
-            else:
-                line = li
-            if not isinstance(line, str):
-                raise AssertionError(f"Expected str, got {type(line)}")
-            # backslash implies line continuation
-            if line.endswith("\\"):
-                buf.write(line[:-1])
-            else:
-                buf.write(line)
-                buf.write("\n")
-        return buf.getvalue()
-
-    def get_lines_ref(self):
-        return self._lines
-
-    def clear(self) -> None:
-        self._lines.clear()
-
-    def __bool__(self) -> bool:
-        return bool(self._lines)
-
-    def prefix(self) -> str:
-        return " " * (self._indent * self.tabwidth)
-
-    def newline(self) -> None:
-        self.writeline("\n")
-
-    def writeline(self, line: LineContext | DeferredLineBase | str) -> None:
-        if isinstance(line, LineContext):
-            self._lines.append(line)
-        elif isinstance(line, DeferredLineBase):
-            self._lines.append(line.with_prefix(self.prefix()))
-        elif line.strip():
-            self._lines.append(f"{self.prefix()}{line}")
-        else:
-            self._lines.append("")
-
-    def writeline_jit(self, line: LineContext | DeferredLineBase | str) -> None:
-        """Write to JIT buffer only. On a plain IndentedBuffer, same as writeline."""
-        self.writeline(line)
-
-    def writeline_aot(self, line: LineContext | DeferredLineBase | str) -> None:
-        """Write to AOTI buffer only. No-op on a plain IndentedBuffer."""
-
-    def splice_jit(self, other_code: IndentedBuffer | str, strip: bool = False) -> None:
-        """Splice to JIT buffer only. On a plain IndentedBuffer, same as splice."""
-        self.splice(other_code, strip=strip)
-
-    def splice_aot(self, other_code: IndentedBuffer | str, strip: bool = False) -> None:
-        """Splice to AOTI buffer only. No-op on a plain IndentedBuffer."""
-
-    def writelines(self, lines: Sequence[LineContext | DeferredLineBase | str]) -> None:
-        for line in lines:
-            self.writeline(line)
-
-    def indent(self, offset: int = 1) -> contextlib.AbstractContextManager[None]:
-        @contextlib.contextmanager
-        def ctx() -> Iterator[None]:
-            self._indent += offset
-            try:
-                yield
-            finally:
-                self._indent -= offset
-
-        return ctx()
-
-    def do_indent(self, offset: int = 1) -> None:
-        self._indent += offset
-
-    def do_unindent(self, offset: int = 1) -> None:
-        self._indent -= offset
-
-    def splice(self, other_code: IndentedBuffer | str, strip: bool = False) -> None:
-        if isinstance(other_code, IndentedBuffer):
-            dedent = float("inf")
-
-            for line in other_code._lines:
-                if not isinstance(line, LineContext) and line:
-                    dedent = min(dedent, len(line) - len(line.lstrip()))
-            if math.isinf(dedent):
-                dedent = 0
-            for line in other_code._lines:
-                if isinstance(line, LineContext):
-                    self._lines.append(line)
-                else:
-                    IndentedBuffer.writeline(self, line[int(dedent) :])
-        else:
-            other_code = textwrap.dedent(other_code)
-            if strip:
-                other_code = other_code.lstrip()
-            if not other_code:
-                return
-            other_code = other_code.rstrip()
-            for s in other_code.split("\n"):
-                IndentedBuffer.writeline(self, s)
-
-    def map(self, func: Callable[[Any], Any]) -> IndentedBuffer:
-        res = IndentedBuffer(initial_indent=self._indent)
-        res._lines = [func(line) for line in self._lines]
-        return res
-
-    def __repr__(self) -> str:
-        return f"{type(self)}({self.getvalue()})"
-
-    def __add__(self, other: Self) -> IndentedBuffer:
-        if self._indent != other._indent:
-            raise AssertionError(f"Indent mismatch: {self._indent} != {other._indent}")
-        res = IndentedBuffer(initial_indent=self._indent)
-        # TODO(rec): or should this be self.__class__(initial_indent=self._indent)?
-        res.writelines(self._lines)
-        res.writelines(other._lines)
-        return res
-
-    def contains(self, new_line: DeferredLineBase | LineContext | str) -> bool:
-        return new_line in self._lines
-
-
 class DualIndentedBuffer(IndentedBuffer):
     """IndentedBuffer that simultaneously accumulates JIT and AOTI output.
 
@@ -1918,38 +1748,6 @@ def restore_stdout_stderr() -> Iterator[None]:
         yield
     finally:
         sys.stdout, sys.stderr = initial_stdout, initial_stderr
-
-
-class DeferredLineBase:
-    """A line that can be 'unwritten' at a later time"""
-
-    def __init__(self, line: str):
-        if not line.strip():
-            line = ""
-        self.line = line
-
-    def __call__(self) -> str | None:
-        """Returns either self.line or None to indicate the line has been 'unwritten'"""
-        raise NotImplementedError
-
-    def _new_line(self, line: str) -> Self:
-        """Returns a new deferred line with the same condition"""
-        raise NotImplementedError
-
-    def with_prefix(self, prefix: str) -> Self:
-        return self._new_line(f"{prefix}{self.line}")
-
-    def lstrip(self) -> Self:
-        return self._new_line(self.line.lstrip())
-
-    def __getitem__(self, index: int | slice) -> Self:
-        return self._new_line(self.line[index])
-
-    def __bool__(self) -> bool:
-        return bool(self.line)
-
-    def __len__(self) -> int:
-        return len(self.line)
 
 
 class DelayReplaceLine(DeferredLineBase):

--- a/torch/utils/_indented_buffer.py
+++ b/torch/utils/_indented_buffer.py
@@ -1,0 +1,234 @@
+"""
+IndentedBuffer: a line-oriented buffer that tracks indentation as source is
+appended and renders it (optionally with a line map for traceback remapping).
+
+This is the shared primitive underneath inductor's codegen buffers
+(torch._inductor.utils re-exports these names and subclasses IndentedBuffer for
+its JIT/AOTI variants), dynamo's guard codegen (IndentedBufferWithPrefix), and
+AOTAutograd's runtime-wrapper codegen (PySourceBuilder). It lives in torch.utils
+so those layers can share it without importing across the _functorch -> _inductor
+edge or pulling in the heavy torch._inductor.utils module. The cluster depends
+only on the standard library.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import math
+import textwrap
+from dataclasses import dataclass
+from io import StringIO
+from typing import Any, NamedTuple, TYPE_CHECKING
+from typing_extensions import Self
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator, Sequence
+
+
+class LineContext(NamedTuple):
+    context: Any
+
+
+@dataclass
+class ValueWithLineMap:
+    value: str
+    line_map: list[tuple[int, LineContext]]
+
+
+class IndentedBuffer:
+    tabwidth = 4
+
+    def __init__(self, initial_indent: int = 0) -> None:
+        self._lines: list[DeferredLineBase | LineContext | str] = []
+        self._indent = initial_indent
+
+    @contextlib.contextmanager
+    def set_tabwidth(self, tabwidth: int) -> Iterator[None]:
+        prev = self.tabwidth
+        try:
+            self.tabwidth = tabwidth
+            yield
+        finally:
+            self.tabwidth = prev
+
+    def getvaluewithlinemap(self) -> ValueWithLineMap:
+        buf = StringIO()
+        p = 1
+        linemap: list[tuple[int, LineContext]] = []
+        for li in self._lines:
+            if isinstance(li, DeferredLineBase):
+                line = li()
+                if line is None:
+                    continue
+            elif isinstance(li, LineContext):
+                linemap.append((p, li.context))
+                continue
+            else:
+                line = li
+            if not isinstance(line, str):
+                raise AssertionError(f"Expected str, got {type(line)}")
+            buf.write(line)
+            buf.write("\n")
+            p += 1 + line.count("\n")
+        return ValueWithLineMap(buf.getvalue(), linemap)
+
+    def getvalue(self) -> str:
+        return self.getvaluewithlinemap().value
+
+    def getrawvalue(self) -> str:
+        buf = StringIO()
+        for li in self._lines:
+            if isinstance(li, DeferredLineBase):
+                line = li()
+                if line is None:
+                    continue
+            elif isinstance(li, LineContext):
+                continue
+            else:
+                line = li
+            if not isinstance(line, str):
+                raise AssertionError(f"Expected str, got {type(line)}")
+            # backslash implies line continuation
+            if line.endswith("\\"):
+                buf.write(line[:-1])
+            else:
+                buf.write(line)
+                buf.write("\n")
+        return buf.getvalue()
+
+    def get_lines_ref(self):
+        return self._lines
+
+    def clear(self) -> None:
+        self._lines.clear()
+
+    def __bool__(self) -> bool:
+        return bool(self._lines)
+
+    def prefix(self) -> str:
+        return " " * (self._indent * self.tabwidth)
+
+    def newline(self) -> None:
+        self.writeline("\n")
+
+    def writeline(self, line: LineContext | DeferredLineBase | str) -> None:
+        if isinstance(line, LineContext):
+            self._lines.append(line)
+        elif isinstance(line, DeferredLineBase):
+            self._lines.append(line.with_prefix(self.prefix()))
+        elif line.strip():
+            self._lines.append(f"{self.prefix()}{line}")
+        else:
+            self._lines.append("")
+
+    def writeline_jit(self, line: LineContext | DeferredLineBase | str) -> None:
+        """Write to JIT buffer only. On a plain IndentedBuffer, same as writeline."""
+        self.writeline(line)
+
+    def writeline_aot(self, line: LineContext | DeferredLineBase | str) -> None:
+        """Write to AOTI buffer only. No-op on a plain IndentedBuffer."""
+
+    def splice_jit(self, other_code: IndentedBuffer | str, strip: bool = False) -> None:
+        """Splice to JIT buffer only. On a plain IndentedBuffer, same as splice."""
+        self.splice(other_code, strip=strip)
+
+    def splice_aot(self, other_code: IndentedBuffer | str, strip: bool = False) -> None:
+        """Splice to AOTI buffer only. No-op on a plain IndentedBuffer."""
+
+    def writelines(self, lines: Sequence[LineContext | DeferredLineBase | str]) -> None:
+        for line in lines:
+            self.writeline(line)
+
+    def indent(self, offset: int = 1) -> contextlib.AbstractContextManager[None]:
+        @contextlib.contextmanager
+        def ctx() -> Iterator[None]:
+            self._indent += offset
+            try:
+                yield
+            finally:
+                self._indent -= offset
+
+        return ctx()
+
+    def do_indent(self, offset: int = 1) -> None:
+        self._indent += offset
+
+    def do_unindent(self, offset: int = 1) -> None:
+        self._indent -= offset
+
+    def splice(self, other_code: IndentedBuffer | str, strip: bool = False) -> None:
+        if isinstance(other_code, IndentedBuffer):
+            dedent = float("inf")
+
+            for line in other_code._lines:
+                if not isinstance(line, LineContext) and line:
+                    dedent = min(dedent, len(line) - len(line.lstrip()))
+            if math.isinf(dedent):
+                dedent = 0
+            for line in other_code._lines:
+                if isinstance(line, LineContext):
+                    self._lines.append(line)
+                else:
+                    IndentedBuffer.writeline(self, line[int(dedent) :])
+        else:
+            other_code = textwrap.dedent(other_code)
+            if strip:
+                other_code = other_code.lstrip()
+            if not other_code:
+                return
+            other_code = other_code.rstrip()
+            for s in other_code.split("\n"):
+                IndentedBuffer.writeline(self, s)
+
+    def map(self, func: Callable[[Any], Any]) -> IndentedBuffer:
+        res = IndentedBuffer(initial_indent=self._indent)
+        res._lines = [func(line) for line in self._lines]
+        return res
+
+    def __repr__(self) -> str:
+        return f"{type(self)}({self.getvalue()})"
+
+    def __add__(self, other: Self) -> IndentedBuffer:
+        if self._indent != other._indent:
+            raise AssertionError(f"Indent mismatch: {self._indent} != {other._indent}")
+        res = IndentedBuffer(initial_indent=self._indent)
+        # TODO(rec): or should this be self.__class__(initial_indent=self._indent)?
+        res.writelines(self._lines)
+        res.writelines(other._lines)
+        return res
+
+    def contains(self, new_line: DeferredLineBase | LineContext | str) -> bool:
+        return new_line in self._lines
+
+
+class DeferredLineBase:
+    """A line that can be 'unwritten' at a later time"""
+
+    def __init__(self, line: str):
+        if not line.strip():
+            line = ""
+        self.line = line
+
+    def __call__(self) -> str | None:
+        """Returns either self.line or None to indicate the line has been 'unwritten'"""
+        raise NotImplementedError
+
+    def _new_line(self, line: str) -> Self:
+        """Returns a new deferred line with the same condition"""
+        raise NotImplementedError
+
+    def with_prefix(self, prefix: str) -> Self:
+        return self._new_line(f"{prefix}{self.line}")
+
+    def lstrip(self) -> Self:
+        return self._new_line(self.line.lstrip())
+
+    def __getitem__(self, index: int | slice) -> Self:
+        return self._new_line(self.line[index])
+
+    def __bool__(self) -> bool:
+        return bool(self.line)
+
+    def __len__(self) -> int:
+        return len(self.line)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* (to be filled)

Follow-up to #188298. That PR added PySourceBuilder with a hand-rolled indent
buffer, which was a third copy of torch._inductor.utils.IndentedBuffer (already
subclassed cross-layer by torch._dynamo.guards.IndentedBufferWithPrefix). This
PR removes the divergence.

The IndentedBuffer primitive cluster (LineContext, ValueWithLineMap,
DeferredLineBase, IndentedBuffer) has zero torch-internal deps (stdlib only), so
it is relocated verbatim to a new core module torch/utils/_indented_buffer.py
that any layer can depend on without reaching across the _functorch -> _inductor
edge or importing the heavy torch._inductor.utils module (sympy,
DeviceProperties, ...). torch._inductor.utils re-exports the four names so its
existing call sites and subclasses (DualIndentedBuffer, AotOnlyBuffer,
FakeIndentedBuffer, DelayReplaceLine) are unchanged. torch._dynamo.guards now
imports IndentedBuffer from the light module too.

PySourceBuilder then subclasses the hoisted IndentedBuffer and keeps only the
genuinely-new exec layer (globals binding, fresh-name generation, build() via
_compile_and_exec_source) plus emit() (absolute-indent writes for recursive
generators) and a getvalue() override that joins without a trailing newline to
keep generated source byte-identical.

This PR also completes the runtime_wrappers.py conversion #188298 started: the
remaining _codegen_* helpers that appended hardcoded-indent strings to a raw
buf.lines list (aliased out of the builder, which left buf._indent stuck at 0 --
flagged in review) now take the builder and write via emit(). No path aliases
buf.lines/buf.globals anymore, so writeline()/indent() and emit() flow through a
single consistent buffer. Generated source is unchanged.

Suggested review order: torch/utils/_indented_buffer.py (the relocation), then
torch/_inductor/utils.py and torch/_dynamo/guards.py (re-export + import
switch), then codegen_utils.py (the subclass), then runtime_wrappers.py and
subclass_codegen.py (the helper conversions and getvalue() calls).

Authored with the assistance of an AI coding assistant.

Test Plan:
```
lintrunner --take PYFMT,RUFF,PYREFLY,CODESPELL,FLAKE8 -a <changed files>
python test/functorch/test_subclass_codegen.py
python test/functorch/test_codegen_mutation_epilogue.py
python test/functorch/test_codegen_backward_epilogue.py
python test/dynamo/test_structured_trace.py
```
The functorch codegen tests assert the generated source via assertExpectedInline;
they pass unchanged, confirming the generated source is byte-identical.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98