### PR TITLE
[CI] Download sccache from upstream releases directly

### DIFF
--- a/.ci/docker/common/install_cache.sh
+++ b/.ci/docker/common/install_cache.sh
@@ -3,23 +3,15 @@
 set -ex
 
 install_ubuntu() {
-  echo "Installing pkg-config and libssl-dev"
-  apt-get update && apt-get install -y pkg-config libssl-dev curl
-  echo "Installing rust"
-  curl https://sh.rustup.rs -sSf | sh -s -- -y
-  echo "Checking out sccache repo"
-  git clone https://github.com/mozilla/sccache -b v0.16.0
-  cd sccache
-  echo "Building sccache"
-  . "$HOME/.cargo/env" && cargo build --release --features="dist-client dist-server"
-  cp target/release/sccache /opt/cache/bin
-  cp target/release/sccache-dist /opt/cache/bin
-  echo "Cleaning up"
-  cd ..
-  rm -rf sccache
-  rustup self uninstall -y
-  apt-get remove -y pkg-config libssl-dev
-  apt-get autoclean && apt-get clean
+  ARCH=$(uname -m)
+  VERSION=0.16.0
+  FEATURES="sccache sccache-dist"
+  echo "Downloading sccache binaries from GitHub mozilla/sccache release"
+  for feature in $FEATURES; do
+    curl --retry 3 -fsSL https://github.com/mozilla/sccache/releases/download/v${VERSION}/${feature}-v${VERSION}-${ARCH}-unknown-linux-musl.tar.gz | \
+      tar -xz -C /opt/cache/bin --strip-components=1 ${feature}-v${VERSION}-${ARCH}-unknown-linux-musl/${feature}
+    chmod a+x /opt/cache/bin/${feature}
+  done
 
   echo "Downloading old sccache binary from S3 repo for PCH builds"
   curl --retry 3 https://s3.amazonaws.com/ossci-linux/sccache -o /opt/cache/bin/sccache-0.2.14a
@@ -38,7 +30,6 @@ export PATH="/opt/cache/bin:$PATH"
 
 # Setup compiler cache
 install_ubuntu
-chmod a+x /opt/cache/bin/sccache
 
 function write_sccache_stub() {
   # Unset LD_PRELOAD for ps because of asan + ps issues


### PR DESCRIPTION
The official releases are available straight at https://github.com/mozilla/sccache/releases. Download the binaries from there rather than building them by hand