### PR TITLE
[Inductor][CUTLASS] Register decomposition for CUTLASS based sparse semi-structured matmul

### DIFF
--- a/test/test_sparse_semi_structured.py
+++ b/test/test_sparse_semi_structured.py
@@ -296,6 +296,43 @@ class SparseSemiStructuredTensorCompileTest(torch._dynamo.test_case.TestCase):
         output = torch.compile(fn)(x)
         output.backward(output)
 
+    @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
+    @unittest.skipIf(IS_WINDOWS, "torch.compile not supported on windows")
+    @unittest.skipIf(TEST_WITH_ROCM, "Not supported on ROCm")
+    def test_cutlass_mm_functionalization_decomp(self):
+        """Test that semi_structured::cutlass_mm decomposes under FunctionalTensorMode.
+
+        This verifies the register_torch_dispatch(FunctionalTensorMode) registration
+        works correctly -- the custom op should decompose into aten._sparse_semi_structured_mm
+        (or _addmm) + pad/narrow. Does not require actual CUTLASS execution (uses FakeTensorMode).
+        """
+        from torch._subclasses.fake_tensor import FakeTensorMode
+        from torch._subclasses.functional_tensor import (
+            FunctionalTensor,
+            FunctionalTensorMode,
+        )
+
+        from torch.sparse.semi_structured import _ensure_cutlass_mm_registered
+
+        _ensure_cutlass_mm_registered()
+
+        out_features, k, n = 32, 64, 16
+        with FakeTensorMode() as fake_mode:
+            dense = torch.randn(k, n, device="cuda", dtype=torch.float16)
+            packed = torch.randn(out_features, k // 2, device="cuda", dtype=torch.float16)
+            meta = torch.randint(0, 10, (out_features, k // 16), device="cuda", dtype=torch.int16)
+
+            with FunctionalTensorMode():
+                dense_f = FunctionalTensor.to_functional(dense)
+                packed_f = FunctionalTensor.to_functional(packed)
+                meta_f = FunctionalTensor.to_functional(meta)
+
+                result = torch.ops.semi_structured.cutlass_mm(
+                    dense_f, packed_f, meta_f, None, out_features, 8, 8, False
+                )
+
+            self.assertEqual(result.shape, torch.Size([out_features, n]))
+
 
 class TestSparseSemiStructured(TestCase):
     def setUp(self):

--- a/torch/sparse/semi_structured.py
+++ b/torch/sparse/semi_structured.py
@@ -721,8 +721,7 @@ def _ensure_cutlass_mm_registered():
 
     from torch.library import custom_op
 
-    @custom_op("semi_structured::cutlass_mm", mutates_args=())
-    def cutlass_mm(
+    def _cutlass_mm_impl(
         dense: torch.Tensor,
         packed: torch.Tensor,
         meta: torch.Tensor,
@@ -750,6 +749,10 @@ def _ensure_cutlass_mm_registered():
             return res.t().contiguous() if should_transpose_dense else res.contiguous()
         return res.t().contiguous() if should_transpose_dense else res
 
+    cutlass_mm = custom_op("semi_structured::cutlass_mm", mutates_args=())(
+        _cutlass_mm_impl
+    )
+
     @cutlass_mm.register_fake
     def _cutlass_mm_fake(
         dense: torch.Tensor,
@@ -770,6 +773,19 @@ def _ensure_cutlass_mm_registered():
             dtype=dense.dtype,
             device=dense.device,
         )
+
+    from torch._subclasses.functional_tensor import (
+        _has_unrecognized_tensor_types,
+        FunctionalTensorMode,
+    )
+
+    def _cutlass_mm_decomp(mode, op, types, args, kwargs):
+        if _has_unrecognized_tensor_types(types):
+            return NotImplemented
+        with mode:
+            return _cutlass_mm_impl(*args, **kwargs)
+
+    cutlass_mm.register_torch_dispatch(FunctionalTensorMode, _cutlass_mm_decomp)
 
 
 _cusparselt_mm_registered = False

--- a/torch/sparse/semi_structured.py
+++ b/torch/sparse/semi_structured.py
@@ -779,7 +779,12 @@ def _ensure_cutlass_mm_registered():
         FunctionalTensorMode,
     )
 
-    def _cutlass_mm_decomp(mode, op, types, args, kwargs):
+    # Unlike triton custom ops (which guard with custom_triton_ops_decomposition_disabled
+    # to keep the opaque op in exported programs), we decompose unconditionally here.
+    # The decomposition targets (aten._sparse_semi_structured_mm, pad, narrow) are real
+    # ATen ops with proper meta registrations and are fully serializable, so export
+    # consumers benefit from seeing the underlying ops rather than an opaque custom op.
+    def _cutlass_mm_decomp(mode, _op, types, args, kwargs):
         if _has_unrecognized_tensor_types(types):
             return NotImplemented
         with mode:


### PR DESCRIPTION
`semi_structured::cutlass_mm` was registered as a custom op, so the AOT/Inductor path treated it as opaque. As a result, the inner `aten._sparse_semi_structured_mm` was not visible to Inductor, so the sparse semi-structured mm lowering/autotune path did not run and the local autotune cache for `sparse_semi_structured_mm` stayed empty.

This caused the test: 
```
test/inductor/test_cutlass_backend.py::TestCutlassBackend::test_max_autotune_cutlass_backend_sparse_semi_structured_mm_dynamic_False
```
to fail with an empty cache error.

This change factors the CUTLASS custom op body into a shared `_cutlass_mm_impl` and registers a `FunctionalTensorMode` torch-dispatch decomposition for `semi_structured::cutlass_mm`. During functionalization, the custom op now expands into its underlying ATen operations, including `aten._sparse_semi_structured_mm`, while eager execution continues to use the same implementation as before.

cc @eqy 