### PR TITLE
[SymmMem] Fix tile_reduce to deliver the reduced tile only to root

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/nvshmem_extension.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/nvshmem_extension.cu
@@ -953,15 +953,17 @@ __global__ void tile_reduce_kernel(
   auto block_src_tensor = nvshmemx::Tensor(block_src_ptr, block_layout);
   auto block_dst_tensor = nvshmemx::Tensor(block_dst_ptr, block_layout);
 
-  // Making these empty to avoid nvshmemx::tile_sum_reduce_block() from doing
-  // additional range checks
+  // Making these empty to avoid nvshmemx::tile_sum_rooted_reduce_block() from
+  // doing additional range checks
   auto start_coord = nvshmemx::make_shape();
   auto boundary = nvshmemx::make_shape();
 
-  // Use one-shot pull to reduce the tile
+  // Rooted reduce: the reduced tile is delivered only to `root`'s dst. The
+  // plain `tile_sum_reduce_block` is an AllReduce that writes the result to
+  // every PE (and ignores `root`), which would contaminate non-root out tiles.
   uint64_t flag = 0;
   constexpr auto algo = nvshmemx::tile_coll_algo_t::NVLS_ONE_SHOT_PULL_NBI;
-  nvshmemx::tile_sum_reduce_block<decltype(block_src_tensor), decltype(block_dst_tensor), decltype(boundary), algo>(
+  nvshmemx::tile_sum_rooted_reduce_block<decltype(block_src_tensor), decltype(block_dst_tensor), decltype(boundary), algo>(
       team, block_src_tensor, block_dst_tensor, start_coord, boundary, root, flag /* unused */);
 
   // Wait for the operation to complete
@@ -1061,8 +1063,8 @@ void multi_root_tile_reduce(
   int i = 0, my_tile_idx = 0, root = world_size;
   // Note: if there is no tile for the current rank, my_tile_idx will remain
   // initial value 0, and root will remain `world_size`. This is OK. In
-  // `nvshmemx::tile_sum_reduce_block`, this rank would skip the reduction
-  // operation, but would still participate in the barrier.
+  // `nvshmemx::tile_sum_rooted_reduce_block`, a rank whose own PE id does not
+  // match `root` skips writing its dst, but still participates in the barrier.
   for (auto& in_tile : in_tiles) {
     TORCH_CHECK(in_tile.dim() == 2, "Only 2D tensors are supported");
     c10d::symmetric_memory::rendezvous(in_tile, group_name);

--- a/torch/csrc/distributed/c10d/symm_mem/nvshmem_extension.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/nvshmem_extension.cu
@@ -1028,15 +1028,17 @@ __global__ void tile_reduce_kernel(
   auto block_src_tensor = nvshmemx::Tensor(block_src_ptr, block_layout);
   auto block_dst_tensor = nvshmemx::Tensor(block_dst_ptr, block_layout);
 
-  // Making these empty to avoid nvshmemx::tile_sum_reduce_block() from doing
-  // additional range checks
+  // Making these empty to avoid nvshmemx::tile_sum_rooted_reduce_block() from
+  // doing additional range checks
   auto start_coord = nvshmemx::make_shape();
   auto boundary = nvshmemx::make_shape();
 
-  // Use one-shot pull to reduce the tile
+  // Rooted reduce: the reduced tile is delivered only to `root`'s dst. The
+  // plain `tile_sum_reduce_block` is an AllReduce that writes the result to
+  // every PE (and ignores `root`), which would contaminate non-root out tiles.
   uint64_t flag = 0;
   constexpr auto algo = nvshmemx::tile_coll_algo_t::NVLS_ONE_SHOT_PULL_NBI;
-  nvshmemx::tile_sum_reduce_block<decltype(block_src_tensor), decltype(block_dst_tensor), decltype(boundary), algo>(
+  nvshmemx::tile_sum_rooted_reduce_block<decltype(block_src_tensor), decltype(block_dst_tensor), decltype(boundary), algo>(
       team, block_src_tensor, block_dst_tensor, start_coord, boundary, root, flag /* unused */);
 
   // Wait for the operation to complete
@@ -1136,8 +1138,8 @@ void multi_root_tile_reduce(
   int i = 0, my_tile_idx = 0, root = world_size;
   // Note: if there is no tile for the current rank, my_tile_idx will remain
   // initial value 0, and root will remain `world_size`. This is OK. In
-  // `nvshmemx::tile_sum_reduce_block`, this rank would skip the reduction
-  // operation, but would still participate in the barrier.
+  // `nvshmemx::tile_sum_rooted_reduce_block`, a rank whose own PE id does not
+  // match `root` skips writing its dst, but still participates in the barrier.
   for (auto& in_tile : in_tiles) {
     TORCH_CHECK(in_tile.dim() == 2, "Only 2D tensors are supported");
     c10d::symmetric_memory::rendezvous(in_tile, group_name);


### PR DESCRIPTION
## Summary

`tile_reduce_kernel` — which backs both `torch.ops.symm_mem.tile_reduce` and
`torch.ops.symm_mem.multi_root_tile_reduce` — invoked
`nvshmemx::tile_sum_reduce_block`. For the `NVLS_ONE_SHOT_PULL_NBI` algorithm
that primitive is an **AllReduce**: it writes the reduced tile to *every* PE and
ignores the `root` argument.

As a result, non-root output tiles were contaminated with the reduced value
(e.g. `world_size * (world_size - 1) / 2`) instead of remaining zero. Both
`NVSHMEMTileCommTest.test_tile_reduce_*` and `test_multi_root_tile_reduce_*`
fail with tensor mismatches on NVLS-capable hardware.

## Fix

Switch to `nvshmemx::tile_sum_rooted_reduce_block`, the rooted-reduce variant,
which delivers the reduced tile only to `root` and leaves non-root outputs
untouched. This matches the ops' contract (the tests expect a zero output
everywhere except the root's tile).

## Test plan

The covering tests are gated by `@requires_nvls`, so they only execute on
NVLS / NVLink-SHARP (NVSwitch) hardware such as GB200 NVL72 — on other runners
they skip, which is why this was not caught by CI:

```
python test/distributed/test_nvshmem.py -k test_tile_reduce -v
python test/distributed/test_nvshmem.py -k test_multi_root_tile_reduce -v
```

Before this change, non-root output tiles hold the reduced value; after it they
remain zero, matching the tests' expected output.

## Notes

The tile-reduce feature was added in #162243 and #164757; this only changes
which collective primitive the kernel calls.

---
Authored with Claude Opus 4.8.
