### PR TITLE
[autograd] Guard capture-boundary stream syncs missed by #180090

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2804,6 +2804,360 @@ torch.cuda.synchronize()
         finally:
             torch.autograd.graph.set_override_stale_capture_stream(False)
 
+    class _NoWgrad(torch.autograd.Function):
+        """Uses the weight in forward but returns an undefined grad for it
+        (delayed-wgrad pattern: the real wgrad is computed out of band)."""
+
+        @staticmethod
+        def forward(ctx, x, w):
+            ctx.save_for_backward(w)
+            return x @ w.t()
+
+        @staticmethod
+        def backward(ctx, gy):
+            (w,) = ctx.saved_tensors
+            return gy @ w, None
+
+    def _warmup_no_wgrad(self, requires_input_grad):
+        """Warmup on the default stream so the weight's AccumulateGrad caches
+        a stale (default) stream, then return (x, w, keepalive).
+
+        AccumulateGrad nodes are cached weakly: `keepalive` retains the warmup
+        graph so the stale node survives until capture (as DDP/FSDP do by
+        stashing grad accumulators)."""
+        w = torch.nn.Parameter(torch.randn(16, 16, device="cuda"))
+        x = torch.randn(4, 16, device="cuda", requires_grad=requires_input_grad)
+        for _ in range(3):
+            y = self._NoWgrad.apply(x, w)
+            y.sum().backward(retain_graph=True)
+            x.grad = None
+        torch.cuda.synchronize()
+        return x, w, y
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    def test_graph_capture_undefined_grad_stale_leaf_error(self):
+        """A leaf whose incoming grads are all undefined short-circuits out
+        of the input buffer before stream reconciliation, so the override
+        cannot fix its stale stream; the end-of-backward leaf sync must raise
+        a clear error instead of invalidating the capture."""
+        x, w, keepalive = self._warmup_no_wgrad(requires_input_grad=False)  # noqa: F841
+
+        s = torch.cuda.Stream()
+        with torch.cuda.stream(s):
+            g = torch.cuda.CUDAGraph()
+            g.capture_begin(capture_error_mode="relaxed")
+            try:
+                with self.assertRaisesRegex(
+                    RuntimeError, "across the capture boundary"
+                ):
+                    self._NoWgrad.apply(x, w).sum().backward()
+            finally:
+                g.capture_end()
+        torch.cuda.synchronize()
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    def test_graph_capture_undefined_grad_stale_side_stream_leaf_error(self):
+        """Same, with warmup on a non-default side stream: the leaf-sync
+        guard must also catch non-default stale leaf streams (which the
+        input buffer's default-stream error does not cover)."""
+        warmup_stream = torch.cuda.Stream()
+        with torch.cuda.stream(warmup_stream):
+            w = torch.nn.Parameter(torch.randn(16, 16, device="cuda"))
+            x = torch.randn(4, 16, device="cuda")
+            for _ in range(3):
+                y = self._NoWgrad.apply(x, w)
+                y.sum().backward(retain_graph=True)
+        torch.cuda.synchronize()
+
+        s = torch.cuda.Stream()
+        with torch.cuda.stream(s):
+            g = torch.cuda.CUDAGraph()
+            g.capture_begin(capture_error_mode="relaxed")
+            try:
+                with self.assertRaisesRegex(
+                    RuntimeError, "across the capture boundary"
+                ):
+                    self._NoWgrad.apply(x, w).sum().backward()
+            finally:
+                g.capture_end()
+        torch.cuda.synchronize()
+        del y
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    def test_graph_capture_undefined_grad_stale_leaf_override(self):
+        """With the override enabled, the meaningless sync with the stale
+        undefined-grad leaf is skipped and capture + replay succeed."""
+        x, w, keepalive = self._warmup_no_wgrad(requires_input_grad=False)  # noqa: F841
+
+        torch.autograd.graph.set_override_stale_capture_stream(True)
+        try:
+            s = torch.cuda.Stream()
+            with torch.cuda.stream(s):
+                g = torch.cuda.CUDAGraph()
+                g.capture_begin()
+                self._NoWgrad.apply(x, w).sum().backward()
+                g.capture_end()
+            torch.cuda.current_stream().wait_stream(s)
+            g.replay()
+            torch.cuda.synchronize()
+            self.assertIsNone(w.grad)
+        finally:
+            torch.autograd.graph.set_override_stale_capture_stream(False)
+
+    class _CpuComputeCudaWeight(torch.autograd.Function):
+        """CPU compute that references a CUDA weight: its AccumulateGrad is
+        created where apply() runs, and the weight's grad is undefined."""
+
+        @staticmethod
+        def forward(ctx, x_cpu, w_cuda):
+            return x_cpu * 2
+
+        @staticmethod
+        def backward(ctx, g):
+            return g * 2, None
+
+    def _capture_reverse_leaf(self):
+        """Build the reverse crossing: the weight's AccumulateGrad is created
+        inside the capture (its metadata stream is the capturing stream), and
+        backward() runs with the non-capturing default stream current. The
+        CPU root and CPU intermediate nodes produce no other stream syncs, so
+        the end-of-backward leaf sync is the only capture crossing."""
+        w = torch.nn.Parameter(torch.randn(8, device="cuda"))
+        x = torch.randn(8)  # CPU
+
+        s = torch.cuda.Stream()
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.stream(s):
+            g.capture_begin(capture_error_mode="relaxed")
+            torch.ones(4, device="cuda").mul_(2)  # non-empty capture
+            loss = self._CpuComputeCudaWeight.apply(x, w).sum()
+        return g, s, loss
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    def test_graph_capture_capturing_leaf_noncapturing_caller_error(self):
+        """Reverse direction of the leaf-sync guard: leaf stream capturing,
+        caller stream not."""
+        g, s, loss = self._capture_reverse_leaf()
+        try:
+            with self.assertRaisesRegex(RuntimeError, "across the capture boundary"):
+                loss.backward()
+        finally:
+            with torch.cuda.stream(s):
+                g.capture_end()
+        torch.cuda.synchronize()
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    def test_graph_capture_capturing_leaf_noncapturing_caller_override(self):
+        """Reverse direction with the override: the sync is skipped and the
+        capture completes and replays."""
+        torch.autograd.graph.set_override_stale_capture_stream(True)
+        try:
+            g, s, loss = self._capture_reverse_leaf()
+            loss.backward()
+            with torch.cuda.stream(s):
+                g.capture_end()
+            torch.cuda.current_stream().wait_stream(s)
+            g.replay()
+            torch.cuda.synchronize()
+        finally:
+            torch.autograd.graph.set_override_stale_capture_stream(False)
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    def test_graph_capture_override_stale_stream_undefined_grad_mixed(self):
+        """Defined grads (input) and undefined grads (weight) together: the
+        defined edge is redirected by the override in InputBuffer::add, the
+        undefined edge is handled by the leaf-sync guard."""
+        x, w, keepalive = self._warmup_no_wgrad(requires_input_grad=True)  # noqa: F841
+
+        torch.autograd.graph.set_override_stale_capture_stream(True)
+        try:
+            s = torch.cuda.Stream()
+            with torch.cuda.stream(s):
+                g = torch.cuda.CUDAGraph()
+                g.capture_begin()
+                self._NoWgrad.apply(x, w).sum().backward()
+                g.capture_end()
+            torch.cuda.current_stream().wait_stream(s)
+            g.replay()
+            torch.cuda.synchronize()
+            self.assertIsNotNone(x.grad)
+            self.assertIsNone(w.grad)
+        finally:
+            torch.autograd.graph.set_override_stale_capture_stream(False)
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    def test_graph_capture_grad_of_stale_graph_override(self):
+        """torch.autograd.grad of a graph built before capture: captured
+        grads record leaf streams through the capture path; the override
+        must reconcile the stale node streams."""
+        w = torch.nn.Parameter(torch.randn(16, 16, device="cuda"))
+        x = torch.randn(4, 16, device="cuda")
+        loss = (x @ w.t()).sum()  # built on the default stream, not freed
+        torch.cuda.synchronize()
+
+        torch.autograd.graph.set_override_stale_capture_stream(True)
+        try:
+            s = torch.cuda.Stream()
+            with torch.cuda.stream(s):
+                g = torch.cuda.CUDAGraph()
+                g.capture_begin()
+                (gw,) = torch.autograd.grad(loss, w, retain_graph=True)
+                g.capture_end()
+            torch.cuda.current_stream().wait_stream(s)
+            g.replay()
+            torch.cuda.synchronize()
+            self.assertEqual(gw.shape, w.shape)
+        finally:
+            torch.autograd.graph.set_override_stale_capture_stream(False)
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    def test_graph_capture_backward_queue_callback(self):
+        """Regression test (no changed code path): engine final callbacks run
+        on the caller's (capturing) streams and must not break capture."""
+        cb_out = torch.zeros(4, 16, device="cuda")
+
+        s = torch.cuda.Stream()
+        with torch.cuda.stream(s):
+            model = torch.nn.Linear(16, 16, device="cuda")
+            x = torch.ones(4, 16, device="cuda")
+            model(x).sum().backward()
+            model.zero_grad()
+            torch.cuda.synchronize()
+
+            g = torch.cuda.CUDAGraph()
+            g.capture_begin()
+            loss = model(x).sum()
+            # queue_callback is only legal during backward: enqueue from a hook.
+            loss.register_hook(
+                lambda grad: torch.autograd.Variable._execution_engine.queue_callback(
+                    lambda: cb_out.fill_(3.0)
+                )
+            )
+            loss.backward()
+            g.capture_end()
+        torch.cuda.current_stream().wait_stream(s)
+        g.replay()
+        torch.cuda.synchronize()
+        self.assertEqual(cb_out.sum().item(), 3.0 * cb_out.numel())
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    def test_graph_capture_backward_explicit_grad_root(self):
+        """Regression test (no changed code path): backward(gradient=...)
+        inside capture seeds the root input buffer with the capturing stream
+        and must work."""
+        s = torch.cuda.Stream()
+        with torch.cuda.stream(s):
+            model = torch.nn.Linear(16, 16, device="cuda")
+            x = torch.ones(4, 16, device="cuda")
+            y = model(x)
+            y.backward(torch.ones_like(y))
+            model.zero_grad()
+            torch.cuda.synchronize()
+
+            g = torch.cuda.CUDAGraph()
+            g.capture_begin()
+            y = model(x)
+            y.backward(torch.ones_like(y))
+            g.capture_end()
+        torch.cuda.current_stream().wait_stream(s)
+        g.replay()
+        torch.cuda.synchronize()
+        for p in model.parameters():
+            self.assertIsNotNone(p.grad)
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    @unittest.skipIf(not TEST_MULTIGPU, "requires multiple devices")
+    def test_graph_capture_multidevice_accum_stream_error(self):
+        """A gradient whose device matches neither the producer's nor the
+        consumer's canonical device would be accumulated on that device's
+        current (non-capturing) stream during capture; this must raise a
+        clear error instead of invalidating the capture."""
+
+        class TwoDeviceOut(torch.autograd.Function):
+            # First (cuda:0) output pins the node's canonical stream to
+            # cuda:0; grads for the second output arrive on cuda:1. Views
+            # avoid launching cuda:1 kernels inside the capture.
+            @staticmethod
+            def forward(ctx, x, y1):
+                return x * 2, y1.view_as(y1)
+
+            @staticmethod
+            def backward(ctx, g0, g1):
+                return g0 * 2, None
+
+        class FromDev0(torch.autograd.Function):
+            # Canonical stream also on cuda:0 (first output); backward
+            # returns a pre-saved cuda:1 gradient, so the consumer's cuda:1
+            # buffer position accumulates on that device's current stream
+            # (case C) with capturing producers.
+            @staticmethod
+            def forward(ctx, marker0, y1):
+                ctx.save_for_backward(torch.ones_like(y1))
+                return marker0 * 2, y1.view_as(y1)
+
+            @staticmethod
+            def backward(ctx, gm, gy_unused):
+                (ones,) = ctx.saved_tensors
+                return gm * 2, ones
+
+        # Warmup on a non-default side stream: stale-but-non-default streams
+        # pass through the input-buffer checks, so backward reaches the
+        # accumulation-stream check under capture.
+        warmup_stream = torch.cuda.Stream()
+        with torch.cuda.stream(warmup_stream):
+            x = torch.randn(4, device="cuda:0", requires_grad=True)
+            y1 = torch.randn(4, device="cuda:1")
+
+            def fwd():
+                out0, out1 = TwoDeviceOut.apply(x, y1)
+                m1, _ = FromDev0.apply(out0, out1)
+                m2, _ = FromDev0.apply(out0, out1)
+                return (m1 + m2).sum()
+
+            fwd().backward()
+            x.grad = None
+        torch.cuda.synchronize()
+
+        s = torch.cuda.Stream()
+        with torch.cuda.stream(s):
+            g = torch.cuda.CUDAGraph()
+            g.capture_begin(capture_error_mode="relaxed")
+            try:
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "matches neither the producer's nor the consumer's",
+                ):
+                    fwd().backward()
+            finally:
+                g.capture_end()
+        # The aborted mid-capture backward leaves a partially captured graph
+        # and grads-in-flight on both devices; tear everything down so later
+        # capture tests start clean.
+        del g, x, y1, fwd
+        gc.collect()
+        for dev in range(2):
+            torch.cuda.synchronize(dev)
+
     @unittest.skipIf(
         not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
     )

--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -548,11 +548,22 @@ def set_override_stale_capture_stream(enabled: bool) -> None:
     stream, allowing the capture to proceed. This is a process-global setting
     and is not thread-local.
 
+    The flag also governs the end-of-backward sync between each leaf's stream
+    and the caller's current stream. A leaf whose incoming gradients are all
+    undefined (e.g. patterns that compute certain gradients out of band and
+    return ``None`` from autograd) cannot be reconciled by the override, so
+    when exactly one of the two streams is capturing, that sync would cross
+    the capture boundary: with the flag enabled the sync is skipped (work on
+    a non-capturing stream is not part of the capture, so the ordering has no
+    effect on it); with the flag disabled a ``RuntimeError`` is raised.
+
     Args:
         enabled (bool): If ``True``, override stale non-capturing streams with
-            the producer's capturing stream during CUDA graph capture. If
-            ``False`` (the process-initial state), raise an error only when the
-            stale stream is the default stream (stream 0); other stale streams
+            the producer's capturing stream during CUDA graph capture, and
+            skip end-of-backward leaf syncs that would cross the capture
+            boundary. If ``False`` (the process-initial state), raise an error
+            when the stale stream is the default stream (stream 0) or when a
+            leaf sync would cross the capture boundary; other stale streams
             are left unchanged.
     """
     return torch._C._set_override_stale_capture_stream(enabled)

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -8,6 +8,7 @@
 #include <torch/csrc/autograd/variable.h>
 #include <torch/csrc/dynamo/compiled_autograd.h>
 
+#include <ATen/Context.h>
 #include <ATen/DeviceAccelerator.h>
 #include <ATen/DeviceGuard.h>
 #include <ATen/ExpandUtils.h>
@@ -204,7 +205,10 @@ C10_DEFINE_TLS_static(std::shared_ptr<ReadyQueue>, tls_local_ready_queue);
 //  2. remembering the "leaf streams" (streams each backward leaf node ran on)
 //  3. during exec_post_processing, for each leaf stream, sync the remembered
 //     current streams (on the leaf stream's device) with that
-//     leaf stream.
+//     leaf stream. If exactly one of the two streams is capturing a CUDA
+//     graph, this sync would cross the capture boundary; it is skipped under
+//     torch.autograd.graph.set_override_stale_capture_stream(True) and is an
+//     error otherwise.
 
 int NodeTask::getReentrantDepth() const {
   std::shared_ptr<GraphTask> graph_task = base_.lock();
@@ -723,7 +727,9 @@ void GraphTask::exec_post_processing() {
 
   // See Note [Streaming backwards].
   // Syncs caller_current_stream with leaf streams, so final_callbacks may use
-  // any grad on its device's current stream.
+  // any grad on its device's current stream. (Under
+  // set_override_stale_capture_stream(True), syncs that would cross a CUDA
+  // graph capture boundary are skipped; see below.)
   if (!leaf_streams.empty()) {
     for (const auto& leaf_stream : leaf_streams) {
       // stash_current_cuda/privateuse1_streams() stashed streams for all device
@@ -738,6 +744,45 @@ void GraphTask::exec_post_processing() {
 
       if (caller_current_stream.has_value() &&
           caller_current_stream != leaf_stream) {
+        // If exactly one of the two streams is capturing, this sync would
+        // cross the CUDA graph capture boundary and invalidate the capture
+        // (cudaErrorStreamCaptureIsolation). The common case is a leaf that
+        // ran on a stale non-capturing stream during capture: when all of a
+        // leaf's incoming grads are undefined, InputBuffer::add returns
+        // before its stream reconciliation, so the stale-capture-stream
+        // override never reconciles the leaf's stream. Work on a
+        // non-capturing stream is not part of the capture (and captured work
+        // produces no eager-visible results), so this ordering edge is
+        // meaningless in either direction: skip it under the override,
+        // otherwise raise an actionable error instead of the CUDA error.
+        if (caller_current_stream->is_capturing() !=
+            leaf_stream.is_capturing()) {
+          if (at::globalContext().overrideStaleCaptureStream()) {
+            TORCH_WARN_ONCE(
+                "Skipping the end-of-backward sync between a leaf stream and "
+                "the caller's current stream because exactly one of them is "
+                "capturing a CUDA graph (see "
+                "torch.autograd.graph.set_override_stale_capture_stream).");
+            continue;
+          }
+          TORCH_CHECK(
+              false,
+              "During CUDA graph capture, autograd tried to synchronize "
+              "streams across the capture boundary (leaf stream ",
+              leaf_stream.id(),
+              " on device ",
+              static_cast<int>(leaf_stream.device_index()),
+              leaf_stream.is_capturing() ? " is capturing but the caller's "
+                                           "stream is not"
+                                         : " is not capturing but the "
+                                           "caller's stream is",
+              "), which would invalidate the capture. A common cause is an "
+              "autograd leaf from warmup holding a stale stream. Either run "
+              "warmup on the capture stream, delete references to the "
+              "autograd graph (e.g. `del loss`) before capture, call "
+              "backward() with the capturing stream current, or call "
+              "torch.autograd.graph.set_override_stale_capture_stream(True).");
+        }
         auto event = c10::Event{leaf_stream.device_type()};
         event.record(leaf_stream);
         caller_current_stream->wait(event);
@@ -756,9 +801,9 @@ void GraphTask::exec_post_processing() {
     // final_callbacks run on the per-device caller_current_streams (the ambient
     // streams surrounding the user's call to backward()). This has two
     // benefits:
-    //  1. caller_current_streams have been synced with leaf_streams, so
-    //  callbacks may
-    //     safely access any grad.
+    //  1. caller_current_streams have been synced with leaf_streams (except
+    //     for syncs skipped under set_override_stale_capture_stream during
+    //     CUDA graph capture), so callbacks may safely access any grad.
     //  2. The callback's results can safely be used on (user-facing)
     //  caller_current_streams
     //     after backward().

--- a/torch/csrc/autograd/input_buffer.cpp
+++ b/torch/csrc/autograd/input_buffer.cpp
@@ -364,6 +364,29 @@ void InputBuffer::add(
     auto& ready_event = ready_events[pos];
     auto& ready_stream = ready_streams[pos];
     TORCH_INTERNAL_ASSERT(accum_stream && ready_stream);
+    // If the accumulation stream is not capturing but a stream it must sync
+    // with below is, the sync would cross the CUDA graph capture boundary
+    // and invalidate the capture. This arises when the gradient lives on a
+    // device other than the producer's and consumer's canonical devices
+    // (case C above): the accumulation then runs on that device's current
+    // stream, which on an autograd worker thread is its non-capturing
+    // default stream. No stream on that device is known to have joined the
+    // capture, so there is nothing to redirect to; raise an actionable
+    // error instead of the opaque CUDA error.
+    TORCH_CHECK(
+        !(!accum_stream->is_capturing() &&
+          (opt_producer_stream->is_capturing() ||
+           ready_stream->is_capturing()) &&
+          device != opt_consumer_stream->device() &&
+          device != opt_producer_stream->device()),
+        "During CUDA graph capture, autograd node '",
+        fn->name(),
+        "' received a gradient on device ",
+        device,
+        ", which matches neither the producer's nor the consumer's canonical "
+        "device, so it would be accumulated on that device's current stream, "
+        "which is not part of the capture. Keep gradients on the producing/"
+        "consuming devices during CUDA graph capture.");
     // 1)
     if (*accum_stream != *opt_producer_stream) {
       auto event = c10::Event{device_type};


### PR DESCRIPTION
## Summary

`torch.autograd.graph.set_override_stale_capture_stream` (#180090) reconciles stale non-capturing streams in `InputBuffer::add`, but two engine sync sites can still cross the CUDA graph capture boundary and invalidate a capture with an opaque `cudaErrorStreamCaptureIsolation`:

1. **End-of-backward leaf sync** (`GraphTask::exec_post_processing`). A leaf whose incoming grads are all undefined short-circuits out of `InputBuffer::add` before its stream reconciliation, so the #180090 override never fires for it — yet the leaf still executes under its stale stream guard and registers that stream in `leaf_streams`. The engine then records an event on the stale (non-capturing) stream and makes the capturing caller stream wait on it. Hit in practice by delayed-wgrad training (Transformer Engine `delay_wgrad_compute`, used by Megatron-Core MoE + Megatron-FSDP full-iteration capture): weight grads are computed out of band, so those weights' autograd edges deliver undefined grads while their `AccumulateGrad` nodes hold default-stream metadata from eager warmup. The **reverse** crossing (capturing leaf, non-capturing caller) is also reachable — e.g. a CPU-rooted backward whose CUDA leaf was created inside the capture — and is guarded by the same check.

   Fix: if exactly one of {caller stream, leaf stream} is capturing, skip the sync under the override (work on a non-capturing stream is not part of the capture, so the ordering edge is meaningless in either direction; a `TORCH_WARN_ONCE` makes the skip diagnosable), otherwise raise an actionable error — same UX as #180090.

2. **Case-C accumulation stream** (`InputBuffer::add`, Nth producer). A gradient whose device matches neither the producer's nor the consumer's canonical device accumulates on that device's current stream — on the engine worker thread this is normally the (non-capturing) default stream, and the accumulation syncs then cross the boundary. There is no known capture-joined stream on that device to redirect to, so this raises an actionable error instead of the CUDA error.


cc @eqy @soulitzer @ngimel (reviewers of #180090)
