### PR TITLE
[XPU] Register _spsolve for SparseCsrXPU backend

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -14680,6 +14680,7 @@
   python_module: sparse
   dispatch:
     SparseCsrCUDA: _sparse_csr_linear_solve
+    SparseCsrXPU: _sparse_csr_linear_solve_xpu
 
 - func: linalg_solve.out(Tensor A, Tensor B, *, bool left=True, Tensor(a!) out) -> Tensor(a!)
   python_module: linalg

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -14695,6 +14695,7 @@
   python_module: sparse
   dispatch:
     SparseCsrCUDA: _sparse_csr_linear_solve
+    SparseCsrXPU: _sparse_csr_linear_solve_xpu
 
 - func: linalg_solve.out(Tensor A, Tensor B, *, bool left=True, Tensor(a!) out) -> Tensor(a!)
   python_module: linalg


### PR DESCRIPTION
Adds a `SparseCsrXPU` dispatch entry for `aten::_spsolve` in `native_functions.yaml`, mapping it to `_sparse_csr_linear_solve_xpu`, which is implemented in third_party/torch-xpu-ops. This enables `torch.sparse.spsolve` on XPU, alongside the existing SparseCsrCUDA backend.

#### Related XPU PR

The kernel implementation live in https://github.com/intel/torch-xpu-ops/pull/4286.
Its tests are present in https://github.com/intel/torch-xpu-ops/pull/5076.

#### Changes & Testing

See linked XPU PRs for more information