### PR TITLE
Validate divisor params in lr_scheduler constructors (#177833)

### DIFF
--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -475,6 +475,76 @@ class TestLRScheduler(TestCase):
         with self.assertRaises(ValueError):
             LinearLR(self.opt, start_factor=start_factor, total_iters=iters)
 
+    def test_scheduler_rejects_nonpositive_divisor_params(self):
+        # https://github.com/pytorch/pytorch/issues/177833
+        # These parameters are used as divisors or modulo bases in get_lr, so
+        # non-positive values must be rejected at construction time instead of
+        # crashing with ZeroDivisionError at step time.
+        cases = [
+            (lambda v: StepLR(self.opt, step_size=v), "step_size"),
+            (lambda v: CosineAnnealingLR(self.opt, T_max=v), "T_max"),
+            (lambda v: PolynomialLR(self.opt, total_iters=v), "total_iters"),
+            (lambda v: LinearLR(self.opt, total_iters=v), "total_iters"),
+            (
+                lambda v: CyclicLR(
+                    self.opt,
+                    base_lr=0.01,
+                    max_lr=0.1,
+                    step_size_up=v,
+                    cycle_momentum=False,
+                ),
+                "step_size_up",
+            ),
+            (
+                lambda v: CyclicLR(
+                    self.opt,
+                    base_lr=0.01,
+                    max_lr=0.1,
+                    step_size_up=10,
+                    step_size_down=v,
+                    cycle_momentum=False,
+                ),
+                "step_size_down",
+            ),
+            (
+                lambda v: OneCycleLR(
+                    self.opt, max_lr=0.1, total_steps=10, div_factor=v
+                ),
+                "div_factor",
+            ),
+            (
+                lambda v: OneCycleLR(
+                    self.opt, max_lr=0.1, total_steps=10, final_div_factor=v
+                ),
+                "final_div_factor",
+            ),
+        ]
+        for ctor, param_name in cases:
+            for value in (0, -1):
+                with self.assertRaisesRegex(ValueError, param_name):
+                    ctor(value)
+        for factor in (0.0, -0.5):
+            with self.assertRaisesRegex(ValueError, "factor"):
+                ConstantLR(self.opt, factor=factor)
+
+    def test_scheduler_accepts_minimal_positive_divisor_params(self):
+        StepLR(self.opt, step_size=1)
+        CosineAnnealingLR(self.opt, T_max=1)
+        PolynomialLR(self.opt, total_iters=1)
+        LinearLR(self.opt, total_iters=1)
+        CyclicLR(
+            self.opt,
+            base_lr=0.01,
+            max_lr=0.1,
+            step_size_up=1,
+            step_size_down=1,
+            cycle_momentum=False,
+        )
+        OneCycleLR(
+            self.opt, max_lr=0.1, total_steps=10, div_factor=1.0, final_div_factor=1.0
+        )
+        ConstantLR(self.opt, factor=1.0)
+
     def test_constantlr_with_epoch(self):
         # lr = 0.025     if epoch < 5
         # lr = 0.005    if 5 <= epoch

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -527,6 +527,30 @@ class TestLRScheduler(TestCase):
             with self.assertRaisesRegex(ValueError, "factor"):
                 ConstantLR(self.opt, factor=factor)
 
+    def test_invalid_divisor_params_do_not_mutate_optimizer(self):
+        # A failed construction must leave the optimizer untouched so the same
+        # optimizer can be reused once the arguments are fixed.
+        cases = [
+            lambda opt: StepLR(opt, step_size=0),
+            lambda opt: CosineAnnealingLR(opt, T_max=0),
+            lambda opt: PolynomialLR(opt, total_iters=0),
+            lambda opt: LinearLR(opt, total_iters=0),
+            lambda opt: CyclicLR(opt, base_lr=0.01, max_lr=0.1, step_size_up=0),
+            lambda opt: CyclicLR(
+                opt, base_lr=0.01, max_lr=0.1, step_size_up=10, step_size_down=0
+            ),
+            lambda opt: OneCycleLR(opt, max_lr=0.1, total_steps=10, div_factor=0),
+            lambda opt: OneCycleLR(opt, max_lr=0.1, total_steps=10, final_div_factor=0),
+            lambda opt: ConstantLR(opt, factor=0.0),
+        ]
+        for ctor in cases:
+            param = torch.nn.Parameter(torch.zeros(()))
+            opt = SGD([param], lr=0.05, momentum=0.5)
+            before = dict(opt.param_groups[0])
+            with self.assertRaises(ValueError):
+                ctor(opt)
+            self.assertEqual(opt.param_groups[0], before)
+
     def test_scheduler_accepts_minimal_positive_divisor_params(self):
         StepLR(self.opt, step_size=1)
         CosineAnnealingLR(self.opt, T_max=1)

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -625,6 +625,8 @@ class StepLR(LRScheduler):
         gamma: float = 0.1,
         last_epoch: int = -1,
     ) -> None:
+        if step_size <= 0:
+            raise ValueError(f"step_size must be positive, but got {step_size}")
         self.step_size = step_size
         self.gamma = gamma
         super().__init__(optimizer, last_epoch)
@@ -810,9 +812,9 @@ class ConstantLR(LRScheduler):
         total_iters: int = 5,
         last_epoch: int = -1,
     ) -> None:
-        if factor > 1.0 or factor < 0:
+        if factor > 1.0 or factor <= 0:
             raise ValueError(
-                "Constant multiplicative factor expected to be between 0 and 1."
+                f"factor must be positive and at most 1, but got {factor}"
             )
 
         self.factor = factor
@@ -920,13 +922,16 @@ class LinearLR(LRScheduler):
     ) -> None:
         if start_factor > 1.0 or start_factor <= 0:
             raise ValueError(
-                "Starting multiplicative factor expected to be greater than 0 and less or equal to 1."
+                f"start_factor must be positive and at most 1, but got {start_factor}"
             )
 
         if end_factor > 1.0 or end_factor < 0:
             raise ValueError(
-                "Ending multiplicative factor expected to be between 0 and 1."
+                f"end_factor must be between 0 and 1, but got {end_factor}"
             )
+
+        if total_iters <= 0:
+            raise ValueError(f"total_iters must be positive, but got {total_iters}")
 
         self.start_factor = start_factor
         self.end_factor = end_factor
@@ -1268,6 +1273,8 @@ class PolynomialLR(LRScheduler):
         power: float = 1.0,
         last_epoch: int = -1,
     ) -> None:
+        if total_iters <= 0:
+            raise ValueError(f"total_iters must be positive, but got {total_iters}")
         self.total_iters = total_iters
         self.power = power
         super().__init__(optimizer, last_epoch)
@@ -1392,6 +1399,8 @@ class CosineAnnealingLR(LRScheduler):
         eta_min: float = 0.0,
         last_epoch: int = -1,
     ) -> None:
+        if T_max <= 0:
+            raise ValueError(f"T_max must be positive, but got {T_max}")
         self.T_max = T_max
         self.eta_min = eta_min
         super().__init__(optimizer, last_epoch)
@@ -1911,6 +1920,13 @@ class CyclicLR(LRScheduler):
                 _update_param_group_val(group, "lr", lr)
 
         self.max_lrs = _format_param("max_lr", optimizer, max_lr)
+
+        if step_size_up <= 0:
+            raise ValueError(f"step_size_up must be positive, but got {step_size_up}")
+        if step_size_down is not None and step_size_down <= 0:
+            raise ValueError(
+                f"step_size_down must be positive, but got {step_size_down}"
+            )
 
         # pyrefly: ignore [bad-assignment]
         step_size_up = float(step_size_up)
@@ -2484,6 +2500,16 @@ class OneCycleLR(LRScheduler):
             )
         else:
             self._anneal_func_type = anneal_strategy
+
+        # Validate div_factor and final_div_factor
+        if div_factor <= 0:
+            raise ValueError(
+                f"div_factor must be positive, but got {div_factor}"
+            )
+        if final_div_factor <= 0:
+            raise ValueError(
+                f"final_div_factor must be positive, but got {final_div_factor}"
+            )
 
         # Initialize learning rate variables
         max_lrs = _format_param("max_lr", self.optimizer, max_lr)

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -813,9 +813,7 @@ class ConstantLR(LRScheduler):
         last_epoch: int = -1,
     ) -> None:
         if factor > 1.0 or factor <= 0:
-            raise ValueError(
-                f"factor must be positive and at most 1, but got {factor}"
-            )
+            raise ValueError(f"factor must be positive and at most 1, but got {factor}")
 
         self.factor = factor
         self.total_iters = total_iters
@@ -1914,19 +1912,21 @@ class CyclicLR(LRScheduler):
             raise TypeError(f"{type(optimizer).__name__} is not an Optimizer")
         self.optimizer = optimizer
 
-        base_lrs = _format_param("base_lr", optimizer, base_lr)
-        if last_epoch == -1:
-            for lr, group in zip(base_lrs, optimizer.param_groups, strict=True):
-                _update_param_group_val(group, "lr", lr)
-
-        self.max_lrs = _format_param("max_lr", optimizer, max_lr)
-
+        # Validate step sizes before any optimizer state is mutated below, so a
+        # failed construction leaves the optimizer untouched.
         if step_size_up <= 0:
             raise ValueError(f"step_size_up must be positive, but got {step_size_up}")
         if step_size_down is not None and step_size_down <= 0:
             raise ValueError(
                 f"step_size_down must be positive, but got {step_size_down}"
             )
+
+        base_lrs = _format_param("base_lr", optimizer, base_lr)
+        if last_epoch == -1:
+            for lr, group in zip(base_lrs, optimizer.param_groups, strict=True):
+                _update_param_group_val(group, "lr", lr)
+
+        self.max_lrs = _format_param("max_lr", optimizer, max_lr)
 
         # pyrefly: ignore [bad-assignment]
         step_size_up = float(step_size_up)
@@ -2503,9 +2503,7 @@ class OneCycleLR(LRScheduler):
 
         # Validate div_factor and final_div_factor
         if div_factor <= 0:
-            raise ValueError(
-                f"div_factor must be positive, but got {div_factor}"
-            )
+            raise ValueError(f"div_factor must be positive, but got {div_factor}")
         if final_div_factor <= 0:
             raise ValueError(
                 f"final_div_factor must be positive, but got {final_div_factor}"


### PR DESCRIPTION
## Issues

Fixes #177833
Fixes #193682

Related: #192655

## Summary

Learning-rate schedulers whose formulas divide or take a modulo by constructor parameters accepted non-positive values. This change validates:

- `StepLR.step_size`
- `CosineAnnealingLR.T_max`
- `PolynomialLR.total_iters` and `LinearLR.total_iters`
- `CyclicLR.step_size_up` and `step_size_down`
- `OneCycleLR.div_factor` and `final_div_factor`
- `ConstantLR.factor`

Invalid values now raise a `ValueError` at construction that names the parameter and value. `CyclicLR` validates its step sizes before updating optimizer parameter groups, so failed construction leaves the optimizer reusable.

This follows the approach and review feedback from the stale #178295.

## Root cause and user impact

The parameters above were used as divisors or modulo bases without constructor validation. The previous behavior was not uniform:

- Zero-valued divisors could fail later with `ZeroDivisionError` or invalid arithmetic.
- `LinearLR(total_iters=0)` silently applied `start_factor` permanently during normal chainable stepping; its closed-form path failed with `ZeroDivisionError`.
- `StepLR(step_size=-1)` silently decayed the learning rate on every step because every integer is divisible by `-1`.

The new checks therefore prevent both delayed exceptions and silent incorrect schedules.

## Scope

`ConstantLR.total_iters=0` is tracked separately by #192655. Zero may reasonably mean a no-op there, so this PR does not choose between no-op and rejection semantics for that parameter.

## BC-breaking?

Yes, narrowly: configurations with invalid non-positive values now fail during construction. Some previously failed only when stepped, while `LinearLR(total_iters=0)` and negative `StepLR.step_size` had observable but incorrect behavior. Valid positive configurations are unchanged.

## Test plan

- Added negative tests for zero and negative values with parameter-specific errors.
- Added positive-boundary coverage for minimal valid values.
- Added regression coverage that failed construction does not mutate optimizer parameter groups.
- Targeted scheduler tests: 27 passed.
- `ruff check torch/optim/lr_scheduler.py test/optim/test_lrscheduler.py`

## Checklist

- [x] Added or updated tests
- [x] Checked Python lint
- [ ] Updated documentation (not applicable)
- [ ] Included benchmark results (not applicable)