### PR TITLE
[Docs] Add accelerator backend test reuse guide

### DIFF
--- a/docs/source/accelerator/index.md
+++ b/docs/source/accelerator/index.md
@@ -51,6 +51,7 @@ amp
 profiler
 distributed
 ci
+testing
 ```
 
 [OpenReg URL]: https://github.com/pytorch/pytorch/tree/main/test/cpp_extensions/open_registration_extension/torch_openreg "OpenReg URL"

--- a/docs/source/accelerator/testing.md
+++ b/docs/source/accelerator/testing.md
@@ -24,29 +24,25 @@ This document describes the available infrastructure and recommended workflow fo
 
 ## Test Reuse Strategy
 
-OOT backends should adopt tests incrementally based on their current level of support. Tests can be selected by category using the `--hw-classification` flag:
+OOT backends should focus on `ACCELERATOR` tests — these define the common functionality expected across all backends. The full classification scheme is listed below for reference:
 
 | Classification                 | Meaning                                      |
 | ------------------------------ | -------------------------------------------- |
 | `GENERIC`                      | No accelerator needed — pure framework logic |
-| `DEVICE_GENERIC`               | Expected to run on all accelerator backends  |
+| `ACCELERATOR`                  | Expected to run on all accelerator backends  |
 | `CPU` / `CUDA` / `MPS` / `XPU` | Specific device type (use sparingly)         |
 
 
 ### Generic Tests
 
-Generic tests validate framework functionality that does not depend on accelerator support. OOT backends can run these tests directly in their PyTorch environment:
+Generic tests validate framework functionality that does not depend on accelerator support. These tests are already exercised by PyTorch's own CPU CI across all supported architectures, so OOT backends do not need to run them.
+
+### Accelerator Tests
+
+Accelerator tests represent the common functionality PyTorch expects from accelerator backends. OOT backends should aim to pass as many of these as possible:
 
 ```bash
-python test/run_test.py --hw-classification GENERIC
-```
-
-### Device-generic Tests
-
-Device-generic tests represent the common functionality PyTorch expects from accelerator backends. OOT backends should aim to pass as many of these as possible:
-
-```bash
-python test/run_test.py --hw-classification DEVICE_GENERIC
+python test/run_test.py --hw-classification ACCELERATOR
 ```
 
 However, backend feature coverage may differ during bring-up. Common gaps include:
@@ -59,19 +55,7 @@ OOT backends can adapt upstream tests through the configuration options describe
 
 ### Device-specific Tests
 
-Device-specific tests target functionality or behavior tied to a particular device type (e.g. `CPU`, `CUDA`, `MPS`, `XPU`):
-
-```bash
-python test/run_test.py --hw-classification CUDA
-```
-
-If an OOT backend provides equivalent functionality, applicable tests may be reused through the normal device test instantiation flow:
-
-```bash
-python test/run_test.py -i test_torch
-```
-
-Some tests may still be blocked by legacy device guards such as `@onlyCUDA` or `@onlyOn(["cuda"])`. In this case, [`bypass_device_restrictions`](#bypass_device_restrictions) can be enabled to run the tests on the OOT backend device.
+Device-specific tests target functionality or behavior tied to a particular device type (e.g. `CPU`, `CUDA`, `MPS`, `XPU`). These tests use device-specific APIs and should not be run by OOT backends.
 
 
 
@@ -80,18 +64,21 @@ Some tests may still be blocked by legacy device guards such as `@onlyCUDA` or `
 OOT backends can adjust test coverage through the following configuration options.
 These options allow backends to start with supported functionality and gradually expand coverage as support improves.
 
+The following configuration options are currently supported:
+
+| Configuration              | Type              | Purpose                                                   |
+| -------------------------- | ----------------- | --------------------------------------------------------- |
+| `op_allowlist`             | `Collection[str]` | Limit `@ops` tests to a supported operator subset         |
+| `op_overrides`             | `dict`            | Customize `@ops` test behavior per-operator               |
+| `test_exclusions`          | `dict`            | Exclude unsupported test classes, methods, or dtype variants |
+| `bypass_device_restrictions` | `bool`          | Override legacy `@onlyCUDA` / `@onlyOn` guards             |
+
+All configurations except `bypass_device_restrictions` are set through `PrivateUse1TestBase.set_test_configs()` (inherited from [`DeviceTypeTestBase`](https://github.com/pytorch/pytorch/blob/main/torch/testing/_internal/common_device_type.py)). Each call to `set_test_configs()` fully replaces the existing configuration: omitted keyword arguments are reset to `None`. Therefore, provide all desired configurations in a single call. `bypass_device_restrictions` is configured separately as a class attribute on the test subclass.
 
 
 ### Restricting Test Scope
 
-Test scope restriction allows OOT backends to reuse upstream tests selectively based on their supported functionality. Unsupported cases can be excluded and test behavior can be customized through the following configurations:
-
-| Configuration     | Type              | Purpose                                                      |
-| ----------------- | ----------------- | ------------------------------------------------------------ |
-| `op_allowlist`    | `Collection[str]` | Limit `@ops` tests to a supported operator subset            |
-| `test_exclusions` | `dict`            | Exclude unsupported test classes, methods, or dtype variants |
-
-> These configurations can be set through `set_test_configs()`. Calling `set_test_configs()` without arguments resets all configurations to `None`.
+Test scope restriction allows OOT backends to reuse upstream tests selectively based on their supported functionality. Unsupported cases can be excluded through `op_allowlist` and `test_exclusions`.
 
 #### `op_allowlist`
 
@@ -163,19 +150,142 @@ class TestPrimsOpenReg(TestPrims):
 instantiate_device_type_tests(TestPrimsOpenReg, globals(), only_for="openreg")
 ```
 
+> note: `bypass_device_restrictions` is a short-term workaround for OOT backends. Once you confirm that a test works on your backend device, please consider upstreaming the fix by removing unnecessary legacy guards or opening an issue to discuss the required changes.
 
 
 ## Bring-up Workflow
 
-A recommended order for adopting PyTorch tests in a new OOT backend:
+A recommended order for adopting PyTorch tests in a new OOT backend.
 
-1. **Identify reusable tests** — use `--hw-classification GENERIC DEVICE_GENERIC` to find tests that may be reused.
-2. **Restrict unsupported ops** — use `op_allowlist` to run only supported operators during early bring-up.
-3. **Handle backend differences** — add `op_overrides` for expected failures, skips, and precision differences.
-4. **Exclude incompatible tests** — use `test_exclusions` only for functionality that cannot reasonably be reused.
+### 0. Verify backend registration
 
-> If a reusable test is blocked by legacy device guards (such as `onlyCUDA`), set `bypass_device_restrictions = True` when the backend supports the required functionality.
+Confirm that your OOT backend is properly registered and visible through the accelerator API:
 
-For a complete runnable example, see [test_testing.py][OpenReg test_testing].
+```python
+import torch
 
-[OpenReg test_testing]: https://github.com/pytorch/pytorch/blob/main/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+# Verify that the accelerator API sees your backend
+assert torch.accelerator.is_available()
+assert torch.accelerator.device_count() > 0
+
+# Check the registered PrivateUse1 backend name
+print(f"PrivateUse1 backend name: {torch._C._get_privateuse1_backend_name()}")
+
+# Check the current accelerator backend
+backend = torch.accelerator.current_accelerator().type
+print(f"Current accelerator backend: {backend}")
+
+# Make sure this matches the backend name registered by your OOT backend
+assert backend == "my_backend"  # replace with your backend name
+
+# Verify tensor creation uses your backend
+t = torch.tensor([1, 2, 3], device=backend)
+assert t.device.type == backend
+print(f"Tensor device: {t.device}")
+```
+
+### 1. Run accelerator tests to assess coverage
+
+Run tests classified as `ACCELERATOR` to evaluate initial backend coverage and identify tests that require additional configuration:
+
+```bash
+# Runs all tests with ACCELERATOR classification across the test suite
+python test/run_test.py --hw-classification ACCELERATOR
+```
+
+During early bring-up, you could start with a single test file and gradually expand the scope. For example:
+
+```bash
+python test/run_test.py -i test_torch --hw-classification ACCELERATOR
+```
+
+### 2. Restrict unsupported ops
+
+If some `@ops`-parametrized tests fail because your backend does not yet implement certain operators, you can use `op_allowlist` to limit tests to your supported subset.
+
+For example, suppose a test subclass `TestTorchDeviceType` which has tests parametrized over the full operator database:
+
+```python
+from torch.testing._internal.common_device_type import ops, instantiate_device_type_tests
+from torch.testing._internal.opinfo.core import op_db
+
+class TestFoo(TestCase):
+    @ops(op_db)
+    def test_bar(self, device, dtype, op):
+        ...
+```
+
+If only `add`, `mul`, `sin`, and `cos` are implemented on your backend, `test_bar` will fail for every other op. Use `op_allowlist` to run it only for those four:
+
+```python
+PrivateUse1TestBase.set_test_configs(
+    op_allowlist=("add.Tensor", "mul.Tensor", "sin", "cos"),
+)
+```
+
+### 3. Handle backend differences
+
+If a test passes functionally but produces slightly different numerical results (e.g. precision differences), you can use `op_overrides` to relax tolerances.
+
+For example, suppose an upstream test checks `div` with a tight tolerance that your backend cannot match on `float32`:
+
+```python
+class TestFoo(TestCase):
+    @ops([op for op in op_db if op.name == "div"])
+    def test_div(self, device, dtype, op):
+        x = torch.tensor([1.0, 2.0], device=device, dtype=dtype)
+        expected = x / x
+        actual = op(x, x)
+        self.assertEqual(actual, expected)  # defaults: atol=1e-5, rtol=1e-5
+        # Fails on your backend: actual differs beyond the default tolerance
+```
+
+Use `op_overrides` to widen the tolerance for this specific test:
+
+```python
+from torch.testing._internal.common_device_type import PrivateUse1TestBase, precisionOverride
+from torch.testing._internal.opinfo.core import DecorateInfo
+
+PrivateUse1TestBase.set_test_configs(
+    op_overrides={
+        "div.Tensor": [
+            DecorateInfo(
+                precisionOverride({torch.float32: 1e-2}),
+                "TestFoo", "test_div",
+            ),
+        ],
+    },
+)
+```
+
+### 4. Exclude incompatible tests
+
+If some test classes or methods cover functionality your backend does not yet support, you can use `test_exclusions` to skip them.
+
+For example, suppose a test class has methods your backend does not yet support:
+
+```python
+class TestTensorOps(TestCase):
+
+    def test_basic(self, device):
+        ...
+
+    def test_advanced_indexing(self, device):
+        # Your backend does not support this indexing pattern yet
+        ...
+```
+
+Use `test_exclusions` to skip `test_advanced_indexing` while still running `test_basic`:
+
+```python
+PrivateUse1TestBase.set_test_configs(
+    test_exclusions={
+        "TestTensorOps": ["test_advanced_indexing"],
+    },
+)
+```
+
+
+> If a reusable test is blocked by legacy device guards (such as `@onlyCUDA`), set `bypass_device_restrictions = True` on your subclass when the backend supports the required functionality.
+
+For a complete runnable example, see [test_testing.py](https://github.com/pytorch/pytorch/blob/main/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py).

--- a/docs/source/accelerator/testing.md
+++ b/docs/source/accelerator/testing.md
@@ -1,0 +1,181 @@
+# Test Suite Reuse
+
+## Background
+
+PyTorch maintains a large, comprehensive test suite covering operators, modules, framework functionality, and device behavior.
+Tests are categorized according to their hardware requirements:
+
+- **Generic tests** — validate framework logic independent of accelerator support.
+- **Device-generic tests** — validate behavior expected to be consistent across accelerator backends.
+- **Device-specific tests** — rely on capabilities or behavior specific to a particular device type.
+
+Among these, **device-generic tests define the baseline functionality that PyTorch expects accelerator backends to support**.
+
+Instead of maintaining an independent test suite, out-of-tree (OOT) backends can reuse upstream tests to validate compatibility with PyTorch's backend requirements and expected behavior.
+
+PyTorch provides two mechanisms to support this workflow:
+
+1. **Hardware classification** — categorize tests by hardware requirements and filter applicable tests at runtime.
+2. **Test reuse configuration** — adapt upstream tests to an OOT backend's capabilities without modifying upstream tests, including limiting unsupported cases, handling expected differences, and gradually expanding coverage.
+
+This document describes the available infrastructure and recommended workflow for OOT backends to reuse PyTorch's upstream tests.
+
+
+
+## Test Reuse Strategy
+
+OOT backends should adopt tests incrementally based on their current level of support. Tests can be selected by category using the `--hw-classification` flag:
+
+| Classification                 | Meaning                                      |
+| ------------------------------ | -------------------------------------------- |
+| `GENERIC`                      | No accelerator needed — pure framework logic |
+| `DEVICE_GENERIC`               | Expected to run on all accelerator backends  |
+| `CPU` / `CUDA` / `MPS` / `XPU` | Specific device type (use sparingly)         |
+
+
+### Generic Tests
+
+Generic tests validate framework functionality that does not depend on accelerator support. OOT backends can run these tests directly in their PyTorch environment:
+
+```bash
+python test/run_test.py --hw-classification GENERIC
+```
+
+### Device-generic Tests
+
+Device-generic tests represent the common functionality PyTorch expects from accelerator backends. OOT backends should aim to pass as many of these as possible:
+
+```bash
+python test/run_test.py --hw-classification DEVICE_GENERIC
+```
+
+However, backend feature coverage may differ during bring-up. Common gaps include:
+
+- Missing operator implementations.
+- Partial dtype support for operators.
+- Backend-specific numerical behavior or precision differences.
+
+OOT backends can adapt upstream tests through the configuration options described in [Test Reuse Configuration](#test-reuse-configuration) below, rather than forking and modifying the tests.
+
+### Device-specific Tests
+
+Device-specific tests target functionality or behavior tied to a particular device type (e.g. `CPU`, `CUDA`, `MPS`, `XPU`):
+
+```bash
+python test/run_test.py --hw-classification CUDA
+```
+
+If an OOT backend provides equivalent functionality, applicable tests may be reused through the normal device test instantiation flow:
+
+```bash
+python test/run_test.py -i test_torch
+```
+
+Some tests may still be blocked by legacy device guards such as `@onlyCUDA` or `@onlyOn(["cuda"])`. In this case, [`bypass_device_restrictions`](#bypass_device_restrictions) can be enabled to run the tests on the OOT backend device.
+
+
+
+## Test Reuse Configuration
+
+OOT backends can adjust test coverage through the following configuration options.
+These options allow backends to start with supported functionality and gradually expand coverage as support improves.
+
+
+
+### Restricting Test Scope
+
+Test scope restriction allows OOT backends to reuse upstream tests selectively based on their supported functionality. Unsupported cases can be excluded and test behavior can be customized through the following configurations:
+
+| Configuration     | Type              | Purpose                                                      |
+| ----------------- | ----------------- | ------------------------------------------------------------ |
+| `op_allowlist`    | `Collection[str]` | Limit `@ops` tests to a supported operator subset            |
+| `test_exclusions` | `dict`            | Exclude unsupported test classes, methods, or dtype variants |
+
+> These configurations can be set through `set_test_configs()`. Calling `set_test_configs()` without arguments resets all configurations to `None`.
+
+#### `op_allowlist`
+
+Limit `@ops`-parametrized tests to supported operators. Values match `OpInfo.full_name` (e.g. `"add.Tensor"`, `"linalg.norm"`):
+
+```python
+PrivateUse1TestBase.set_test_configs(
+    op_allowlist=("add.Tensor", "sub.Tensor", "mul.Tensor")
+)
+```
+
+Ops not in the allowlist produce no test variants.
+
+#### `test_exclusions`
+
+Exclude incompatible test classes, methods, or dtype variants during device test generation:
+
+```python
+PrivateUse1TestBase.set_test_configs(
+    test_exclusions={
+        "TestCUDAGraphs": "*",                       # whole class
+        "TestTensorIndexing": ["test_index_put"],    # specific methods
+        "TestDtypeAware": {                          # dtype-level
+            "test_dtype_filter": {"dtypes": [torch.float32]},
+        },
+    }
+)
+```
+
+For dtype-level exclusions, a tuple variant `(float64, int32)` is excluded if **any** of its component dtypes appears in the excluded list.
+
+
+
+### Adjusting Test Behavior
+
+#### `op_overrides`
+
+Customize `@ops` tests per-operator without modifying upstream `OpInfo` definitions, for example to relax precision requirements:
+
+```python
+import torch
+from torch.testing._internal.common_device_type import PrivateUse1TestBase, precisionOverride
+from torch.testing._internal.opinfo.core import DecorateInfo
+
+PrivateUse1TestBase.set_test_configs(
+    op_overrides={
+        "op_precision": [DecorateInfo(precisionOverride({torch.float32: 1e-2}))],
+    }
+)
+```
+
+Overrides are applied on top of existing `OpInfo` decorators. When both `op_allowlist` and `op_overrides` are set, `op_allowlist` filters first, then `op_overrides` is applied to the remaining operators.
+
+
+
+### Expanding Test Scope
+
+#### `bypass_device_restrictions`
+
+Some upstream tests may be applicable to an OOT backend but blocked by legacy device guards such as `@onlyCUDA` or `@onlyOn`. Enable `bypass_device_restrictions = True` directly on the test class to run them:
+
+```python
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from test_prims import TestPrims
+
+class TestPrimsOpenReg(TestPrims):
+    bypass_device_restrictions = True
+
+instantiate_device_type_tests(TestPrimsOpenReg, globals(), only_for="openreg")
+```
+
+
+
+## Bring-up Workflow
+
+A recommended order for adopting PyTorch tests in a new OOT backend:
+
+1. **Identify reusable tests** — use `--hw-classification GENERIC DEVICE_GENERIC` to find tests that may be reused.
+2. **Restrict unsupported ops** — use `op_allowlist` to run only supported operators during early bring-up.
+3. **Handle backend differences** — add `op_overrides` for expected failures, skips, and precision differences.
+4. **Exclude incompatible tests** — use `test_exclusions` only for functionality that cannot reasonably be reused.
+
+> If a reusable test is blocked by legacy device guards (such as `onlyCUDA`), set `bypass_device_restrictions = True` when the backend supports the required functionality.
+
+For a complete runnable example, see [test_testing.py][OpenReg test_testing].
+
+[OpenReg test_testing]: https://github.com/pytorch/pytorch/blob/main/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py

--- a/docs/source/accelerator/testing.md
+++ b/docs/source/accelerator/testing.md
@@ -2,83 +2,62 @@
 
 ## Background
 
-PyTorch maintains a large, comprehensive test suite covering operators, modules, framework functionality, and device behavior.
-Tests are categorized according to their hardware requirements:
+PyTorch has a large upstream test suite. OOT backends can reuse these tests directly to ensure quality. Two mechanisms make this possible: **test classification** and **dynamic test configuration**. Without requiring changes to upstream tests.
 
-- **Generic tests** — validate framework logic independent of accelerator support.
-- **Device-generic tests** — validate behavior expected to be consistent across accelerator backends.
-- **Device-specific tests** — rely on capabilities or behavior specific to a particular device type.
+## Core Mechanisms
 
-Among these, **device-generic tests define the baseline functionality that PyTorch expects accelerator backends to support**.
+### Test Classification
 
-Instead of maintaining an independent test suite, out-of-tree (OOT) backends can reuse upstream tests to validate compatibility with PyTorch's backend requirements and expected behavior.
-
-PyTorch provides two mechanisms to support this workflow:
-
-1. **Hardware classification** — categorize tests by hardware requirements and filter applicable tests at runtime.
-2. **Test reuse configuration** — adapt upstream tests to an OOT backend's capabilities without modifying upstream tests, including limiting unsupported cases, handling expected differences, and gradually expanding coverage.
-
-This document describes the available infrastructure and recommended workflow for OOT backends to reuse PyTorch's upstream tests.
+Test classification labels each test class (`GENERIC` / `ACCELERATOR` / device-specific), enabling runtime filtering via `--hw-classification` (supported by both `unittest` and `pytest`).
 
 
-
-## Test Reuse Strategy
-
-OOT backends should focus on `ACCELERATOR` tests — these define the common functionality expected across all backends. The full classification scheme is listed below for reference:
-
-| Classification                 | Meaning                                      |
-| ------------------------------ | -------------------------------------------- |
-| `GENERIC`                      | No accelerator needed — pure framework logic |
-| `ACCELERATOR`                  | Expected to run on all accelerator backends  |
-| `CPU` / `CUDA` / `MPS` / `XPU` | Specific device type (use sparingly)         |
+| Classification                 | Test scope                                                |
+| ------------------------------ | --------------------------------------------------------- |
+| `GENERIC`                      | Validates framework functionality that is independent of accelerator support. |
+| `ACCELERATOR`                  | Validates common functionality expected from accelerator backends.  |
+| Device-specific (`CPU`, `CUDA`, `XPU`, `MPS`) | Validates functionality or behavior specific to a particular backend.          |
 
 
-### Generic Tests
+**For OOT backends, upstream test reuse should primarily focus on `ACCELERATOR` tests.** `GENERIC` tests are already covered by upstream CPU CI. Device-specific tests target built-in backends. OOT backends typically maintain their own device-specific tests downstream.
 
-Generic tests validate framework functionality that does not depend on accelerator support. These tests are already exercised by PyTorch's own CPU CI across all supported architectures, so OOT backends do not need to run them.
 
-### Accelerator Tests
+**Running upstream `ACCELERATOR` tests**
 
-Accelerator tests represent the common functionality PyTorch expects from accelerator backends. OOT backends should aim to pass as many of these as possible:
+Configure the following environment variables before running the upstream test suite:
+
+- `PYTORCH_TESTING_DEVICE_FOR_CUSTOM` adds the specified custom device type(s) for testing.
+- `PYTORCH_TESTING_DEVICE_ONLY_FOR` limits testing to the specified device type(s).
 
 ```bash
+export PYTORCH_TESTING_DEVICE_FOR_CUSTOM=<your_backend>
+export PYTORCH_TESTING_DEVICE_ONLY_FOR=<your_backend>
+# Run the full upstream ACCELERATOR test suite
 python test/run_test.py --hw-classification ACCELERATOR
 ```
 
-However, backend feature coverage may differ during bring-up. Common gaps include:
+### Dynamic Test Configuration
+
+`ACCELERATOR` tests cover a broad range of accelerator functionality. During backend bring-up, OOT backends often add support for accelerator features incrementally, so some tests may not yet be applicable. Common cases include:
 
 - Missing operator implementations.
 - Partial dtype support for operators.
 - Backend-specific numerical behavior or precision differences.
 
-OOT backends can adapt upstream tests through the configuration options described in [Test Reuse Configuration](#test-reuse-configuration) below, rather than forking and modifying the tests.
-
-### Device-specific Tests
-
-Device-specific tests target functionality or behavior tied to a particular device type (e.g. `CPU`, `CUDA`, `MPS`, `XPU`). These tests use device-specific APIs and should not be run by OOT backends.
+Dynamic Test Configuration provides a set of configuration options that allow OOT backends to **control upstream tests reuse** without modifying the tests themselves:
 
 
+| Option | What it does | When to use |
+|---|---|---|
+| `op_allowlist` | Operator test allowlist | Early bring-up |
+| `test_exclusions` | Exclude class/method/dtype-level variants | Unsupported features |
+| `op_overrides` | Per-operator decorator overrides | Specific ops need special handling |
+| `bypass_device_restrictions` | Skip `@onlyCUDA` and similar guards | Temporary workaround |
 
-## Test Reuse Configuration
+OOT backends configure all options except `bypass_device_restrictions` through `PrivateUse1TestBase.set_test_configs()` (inherited from [`DeviceTypeTestBase`](https://github.com/pytorch/pytorch/blob/main/torch/testing/_internal/common_device_type.py)). 
 
-OOT backends can adjust test coverage through the following configuration options.
-These options allow backends to start with supported functionality and gradually expand coverage as support improves.
+Each call to `set_test_configs()` fully replaces the existing configuration: omitted keyword arguments are reset to `None`. Therefore, provide all desired configurations in a single call. 
 
-The following configuration options are currently supported:
-
-| Configuration              | Type              | Purpose                                                   |
-| -------------------------- | ----------------- | --------------------------------------------------------- |
-| `op_allowlist`             | `Collection[str]` | Limit `@ops` tests to a supported operator subset         |
-| `op_overrides`             | `dict`            | Customize `@ops` test behavior per-operator               |
-| `test_exclusions`          | `dict`            | Exclude unsupported test classes, methods, or dtype variants |
-| `bypass_device_restrictions` | `bool`          | Override legacy `@onlyCUDA` / `@onlyOn` guards             |
-
-All configurations except `bypass_device_restrictions` are set through `PrivateUse1TestBase.set_test_configs()` (inherited from [`DeviceTypeTestBase`](https://github.com/pytorch/pytorch/blob/main/torch/testing/_internal/common_device_type.py)). Each call to `set_test_configs()` fully replaces the existing configuration: omitted keyword arguments are reset to `None`. Therefore, provide all desired configurations in a single call. `bypass_device_restrictions` is configured separately as a class attribute on the test subclass.
-
-
-### Restricting Test Scope
-
-Test scope restriction allows OOT backends to reuse upstream tests selectively based on their supported functionality. Unsupported cases can be excluded through `op_allowlist` and `test_exclusions`.
+`bypass_device_restrictions` is configured separately as a class attribute on the test subclass.
 
 #### `op_allowlist`
 
@@ -94,7 +73,7 @@ Ops not in the allowlist produce no test variants.
 
 #### `test_exclusions`
 
-Exclude incompatible test classes, methods, or dtype variants during device test generation:
+Exclude incompatible test classes, methods, or dtype variants:
 
 ```python
 PrivateUse1TestBase.set_test_configs(
@@ -110,139 +89,12 @@ PrivateUse1TestBase.set_test_configs(
 
 For dtype-level exclusions, a tuple variant `(float64, int32)` is excluded if **any** of its component dtypes appears in the excluded list.
 
-
-
-### Adjusting Test Behavior
-
 #### `op_overrides`
 
-Customize `@ops` tests per-operator without modifying upstream `OpInfo` definitions, for example to relax precision requirements:
+Customize `@ops` tests per-operator, for example to relax precision:
 
 ```python
 import torch
-from torch.testing._internal.common_device_type import PrivateUse1TestBase, precisionOverride
-from torch.testing._internal.opinfo.core import DecorateInfo
-
-PrivateUse1TestBase.set_test_configs(
-    op_overrides={
-        "op_precision": [DecorateInfo(precisionOverride({torch.float32: 1e-2}))],
-    }
-)
-```
-
-Overrides are applied on top of existing `OpInfo` decorators. When both `op_allowlist` and `op_overrides` are set, `op_allowlist` filters first, then `op_overrides` is applied to the remaining operators.
-
-
-
-### Expanding Test Scope
-
-#### `bypass_device_restrictions`
-
-Some upstream tests may be applicable to an OOT backend but blocked by legacy device guards such as `@onlyCUDA` or `@onlyOn`. Enable `bypass_device_restrictions = True` directly on the test class to run them:
-
-```python
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
-from test_prims import TestPrims
-
-class TestPrimsOpenReg(TestPrims):
-    bypass_device_restrictions = True
-
-instantiate_device_type_tests(TestPrimsOpenReg, globals(), only_for="openreg")
-```
-
-> note: `bypass_device_restrictions` is a short-term workaround for OOT backends. Once you confirm that a test works on your backend device, please consider upstreaming the fix by removing unnecessary legacy guards or opening an issue to discuss the required changes.
-
-
-## Bring-up Workflow
-
-A recommended order for adopting PyTorch tests in a new OOT backend.
-
-### 0. Verify backend registration
-
-Confirm that your OOT backend is properly registered and visible through the accelerator API:
-
-```python
-import torch
-
-# Verify that the accelerator API sees your backend
-assert torch.accelerator.is_available()
-assert torch.accelerator.device_count() > 0
-
-# Check the registered PrivateUse1 backend name
-print(f"PrivateUse1 backend name: {torch._C._get_privateuse1_backend_name()}")
-
-# Check the current accelerator backend
-backend = torch.accelerator.current_accelerator().type
-print(f"Current accelerator backend: {backend}")
-
-# Make sure this matches the backend name registered by your OOT backend
-assert backend == "my_backend"  # replace with your backend name
-
-# Verify tensor creation uses your backend
-t = torch.tensor([1, 2, 3], device=backend)
-assert t.device.type == backend
-print(f"Tensor device: {t.device}")
-```
-
-### 1. Run accelerator tests to assess coverage
-
-Run tests classified as `ACCELERATOR` to evaluate initial backend coverage and identify tests that require additional configuration:
-
-```bash
-# Runs all tests with ACCELERATOR classification across the test suite
-python test/run_test.py --hw-classification ACCELERATOR
-```
-
-During early bring-up, you could start with a single test file and gradually expand the scope. For example:
-
-```bash
-python test/run_test.py -i test_torch --hw-classification ACCELERATOR
-```
-
-### 2. Restrict unsupported ops
-
-If some `@ops`-parametrized tests fail because your backend does not yet implement certain operators, you can use `op_allowlist` to limit tests to your supported subset.
-
-For example, suppose a test subclass `TestTorchDeviceType` which has tests parametrized over the full operator database:
-
-```python
-from torch.testing._internal.common_device_type import ops, instantiate_device_type_tests
-from torch.testing._internal.opinfo.core import op_db
-
-class TestFoo(TestCase):
-    @ops(op_db)
-    def test_bar(self, device, dtype, op):
-        ...
-```
-
-If only `add`, `mul`, `sin`, and `cos` are implemented on your backend, `test_bar` will fail for every other op. Use `op_allowlist` to run it only for those four:
-
-```python
-PrivateUse1TestBase.set_test_configs(
-    op_allowlist=("add.Tensor", "mul.Tensor", "sin", "cos"),
-)
-```
-
-### 3. Handle backend differences
-
-If a test passes functionally but produces slightly different numerical results (e.g. precision differences), you can use `op_overrides` to relax tolerances.
-
-For example, suppose an upstream test checks `div` with a tight tolerance that your backend cannot match on `float32`:
-
-```python
-class TestFoo(TestCase):
-    @ops([op for op in op_db if op.name == "div"])
-    def test_div(self, device, dtype, op):
-        x = torch.tensor([1.0, 2.0], device=device, dtype=dtype)
-        expected = x / x
-        actual = op(x, x)
-        self.assertEqual(actual, expected)  # defaults: atol=1e-5, rtol=1e-5
-        # Fails on your backend: actual differs beyond the default tolerance
-```
-
-Use `op_overrides` to widen the tolerance for this specific test:
-
-```python
 from torch.testing._internal.common_device_type import PrivateUse1TestBase, precisionOverride
 from torch.testing._internal.opinfo.core import DecorateInfo
 
@@ -254,38 +106,160 @@ PrivateUse1TestBase.set_test_configs(
                 "TestFoo", "test_div",
             ),
         ],
+    }
+)
+```
+
+Overrides are applied on top of existing `OpInfo` decorators.
+
+#### `bypass_device_restrictions`
+
+Some upstream tests are blocked by legacy device guards like `@onlyCUDA`. Set `bypass_device_restrictions = True` on the test class to run them:
+
+```python
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from test_prims import TestPrims
+
+class TestPrimsOpenReg(TestPrims):
+    bypass_device_restrictions = True
+
+instantiate_device_type_tests(TestPrimsOpenReg, globals(), only_for="openreg")
+```
+
+> This is a temporary workaround for OOT backends. Once you confirm that a test works on your backend device, please consider upstreaming the fix by removing unnecessary legacy guards or opening an issue to discuss the required changes.
+
+
+**Example** — a complete configuration combining multiple options:
+
+```python
+import torch
+from torch.testing._internal.common_device_type import (
+    PrivateUse1TestBase,
+    instantiate_device_type_tests,
+    precisionOverride,
+)
+from torch.testing._internal.opinfo.core import DecorateInfo
+from test_ops import TestOps
+
+PrivateUse1TestBase.set_test_configs(
+    op_allowlist=("add.Tensor", "mul.Tensor", "sin", "cos"),
+    test_exclusions={
+        "TestTensorIndexing": ["test_index_put"],
+    },
+    op_overrides={
+        "div.Tensor": [
+            DecorateInfo(
+                precisionOverride({torch.float32: 1e-2}),
+                "TestOps", "test_div",
+            ),
+        ],
+    },
+)
+
+instantiate_device_type_tests(TestOps, globals(), only_for="openreg")
+```
+
+
+## Bring-up Workflow
+
+A step-by-step workflow for bringing a new OOT backend from initial bring-up to passing upstream `ACCELERATOR` tests.
+
+### 1. Verify backend registration
+
+Confirm that your OOT backend is properly registered, recognized by the accelerator API, and can be used to create tensors:
+
+```python
+import torch
+
+# Verify that the accelerator API sees your backend
+assert torch.accelerator.is_available()
+assert torch.accelerator.device_count() > 0
+
+# Verify the registered PrivateUse1 backend name
+assert torch._C._get_privateuse1_backend_name() == "<your_backend>"
+
+# Verify the current accelerator
+backend = torch.accelerator.current_accelerator().type
+assert backend == "<your_backend>"
+
+# Verify tensor creation
+t = torch.tensor([1, 2, 3], device=backend)
+assert t.device.type == backend
+```
+
+### 2. Configure environment variables
+
+Configure the upstream test infrastructure to run only on your backend:
+
+```bash
+export PYTORCH_TESTING_DEVICE_FOR_CUSTOM=<your_backend>
+export PYTORCH_TESTING_DEVICE_ONLY_FOR=<your_backend>
+```
+
+### 3. Run accelerator tests to assess coverage
+
+Run tests classified as `ACCELERATOR` to evaluate initial backend coverage and identify unsupported functionality and tests that require configuration:
+
+```bash
+# Runs all tests with ACCELERATOR classification across the test suite
+python test/run_test.py --hw-classification ACCELERATOR
+```
+
+During early bring-up, start with a single test file and gradually expand the scope. For example:
+
+```bash
+python test/run_test.py -i test_torch --hw-classification ACCELERATOR
+```
+
+For tests that do not yet pass, analyze the failures and choose the appropriate configuration described in Steps 4–6.
+
+### 4. Restrict to supported ops
+
+Use `op_allowlist` if required operators are not yet implemented:
+
+```python
+PrivateUse1TestBase.set_test_configs(
+    op_allowlist=("add.Tensor", "mul.Tensor", "sin", "cos"),
+)
+```
+
+### 5. Handle precision differences
+
+Use `op_overrides` for backend-specific numerical or precision differences:
+
+```python
+PrivateUse1TestBase.set_test_configs(
+    op_allowlist=("add.Tensor", "div.Tensor"),
+    op_overrides={
+        "div.Tensor": [
+            DecorateInfo(
+                precisionOverride({torch.float32: 1e-2}),
+                "TestFoo", "test_div",
+            ),
+        ],
     },
 )
 ```
 
-### 4. Exclude incompatible tests
+### 6. Exclude unsupported features
 
-If some test classes or methods cover functionality your backend does not yet support, you can use `test_exclusions` to skip them.
-
-For example, suppose a test class has methods your backend does not yet support:
-
-```python
-class TestTensorOps(TestCase):
-
-    def test_basic(self, device):
-        ...
-
-    def test_advanced_indexing(self, device):
-        # Your backend does not support this indexing pattern yet
-        ...
-```
-
-Use `test_exclusions` to skip `test_advanced_indexing` while still running `test_basic`:
+Use `test_exclusions` for functionality or dtypes that are not yet supported:
 
 ```python
 PrivateUse1TestBase.set_test_configs(
+    op_allowlist=("add.Tensor", "mul.Tensor"),
     test_exclusions={
         "TestTensorOps": ["test_advanced_indexing"],
     },
 )
 ```
 
+### 7. Gradually expand coverage
 
-> If a reusable test is blocked by legacy device guards (such as `@onlyCUDA`), set `bypass_device_restrictions = True` on your subclass when the backend supports the required functionality.
+As support improves, gradually remove entries from `op_allowlist`, `test_exclusions`, and `op_overrides` where they are no longer needed.
 
-For a complete runnable example, see [test_testing.py](https://github.com/pytorch/pytorch/blob/main/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py).
+For a complete runnable configuration example, see [test_testing.py](https://github.com/pytorch/pytorch/blob/main/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py).
+
+## Suggestions
+
+- Connect your downstream repo to upstream CI via CRCR (see [CI Integration](ci.md)).


### PR DESCRIPTION
## Summary

This PR adds a guideline document for out-of-tree (OOT) accelerator backend developers on reusing PyTorch's upstream test suite.

The guide covers:

- Test categorization and the role of hardware classification in selecting applicable tests.
- Test reuse strategies for OOT backends, including adapting upstream tests to match backend capabilities without modifying upstream tests.
- Configuration options for handling unsupported functionality, expected backend differences, and gradually expanding test coverage.
- A recommended bring-up workflow for incrementally adopting upstream tests.