### PR TITLE
[TEST] Add hw_classification to test_c10d_ops_nccl.py, test_c10d_spawn_ucc.py, test_ce_colls.py, test_api.py, test_common_rules.py (DTensor)

### DIFF
--- a/test/distributed/tensor/test_api.py
+++ b/test/distributed/tensor/test_api.py
@@ -16,7 +16,8 @@ from torch.distributed.tensor import (
     Shard,
 )
 from torch.distributed.tensor.debug import CommDebugMode
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
     DTensorTestBase,
@@ -44,6 +45,8 @@ c10d_ops = torch.ops.c10d
 
 
 class DTensorAPITest(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         # hard code world size to 4 as we need to test
@@ -445,6 +448,8 @@ class DTensorAPITest(DTensorTestBase):
 DTensorAPITestWithLocalTensor = create_local_tensor_test_class(
     DTensorAPITest, skipped_tests=["test_checkpoint_apis_check_partial_placement"]
 )
+
+instantiate_device_type_tests(DTensorAPITest, globals())
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/tensor/test_api.py
+++ b/test/distributed/tensor/test_api.py
@@ -16,7 +16,6 @@ from torch.distributed.tensor import (
     Shard,
 )
 from torch.distributed.tensor.debug import CommDebugMode
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
@@ -448,8 +447,6 @@ class DTensorAPITest(DTensorTestBase):
 DTensorAPITestWithLocalTensor = create_local_tensor_test_class(
     DTensorAPITest, skipped_tests=["test_checkpoint_apis_check_partial_placement"]
 )
-
-instantiate_device_type_tests(DTensorAPITest, globals())
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/tensor/test_common_rules.py
+++ b/test/distributed/tensor/test_common_rules.py
@@ -6,7 +6,8 @@ from torch.distributed.tensor import DeviceMesh
 from torch.distributed.tensor._dtensor_spec import DTensorSpec, TensorMeta
 from torch.distributed.tensor._op_schema import OpSchema
 from torch.distributed.tensor._ops._common_rules import einop_rule, pointwise_rule
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorContinuousTestBase,
 )
@@ -16,6 +17,8 @@ aten = torch.ops.aten
 
 
 class CommonRulesTest(DTensorContinuousTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     # hard code world size to 4 as we need to test
     # at least with 2d mesh
     world_size = 4
@@ -399,6 +402,8 @@ class CommonRulesTest(DTensorContinuousTestBase):
         self.assertEqual(schema_suggestion.args_schema[0].dim_map, mat1)
         self.assertEqual(schema_suggestion.args_schema[1].dim_map, mat1)
 
+
+instantiate_device_type_tests(CommonRulesTest, globals(), except_for="cpu")
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/tensor/test_common_rules.py
+++ b/test/distributed/tensor/test_common_rules.py
@@ -6,7 +6,6 @@ from torch.distributed.tensor import DeviceMesh
 from torch.distributed.tensor._dtensor_spec import DTensorSpec, TensorMeta
 from torch.distributed.tensor._op_schema import OpSchema
 from torch.distributed.tensor._ops._common_rules import einop_rule, pointwise_rule
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorContinuousTestBase,
@@ -402,8 +401,6 @@ class CommonRulesTest(DTensorContinuousTestBase):
         self.assertEqual(schema_suggestion.args_schema[0].dim_map, mat1)
         self.assertEqual(schema_suggestion.args_schema[1].dim_map, mat1)
 
-
-instantiate_device_type_tests(CommonRulesTest, globals(), except_for="cpu")
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/test_c10d_ops_nccl.py
+++ b/test/distributed/test_c10d_ops_nccl.py
@@ -31,6 +31,7 @@ from torch.testing._internal.common_distributed import (
     requires_nccl_version,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_LINUX,
     run_tests,
     skip_but_pass_in_sandcastle_if,
@@ -47,6 +48,8 @@ if TEST_WITH_DEV_DBG_ASAN:
 
 
 class ProcessGroupNCCLOpTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+
     @classmethod
     def backend_str(cls) -> str:
         return "nccl"

--- a/test/distributed/test_c10d_spawn_ucc.py
+++ b/test/distributed/test_c10d_spawn_ucc.py
@@ -6,6 +6,7 @@ from test_c10d_spawn import _torch_dist_nn_available, TestDistributedNNFunctions
 import torch.distributed as c10d
 from torch.testing._internal.common_distributed import requires_ucc, skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     run_tests,
     skip_but_pass_in_sandcastle,
     skip_but_pass_in_sandcastle_if,
@@ -22,6 +23,8 @@ NO_UCC = not hasattr(c10d, "ProcessGroupUCC")
 if not TEST_WITH_DEV_DBG_ASAN:
 
     class TestDistributedNNFunctionsUcc(TestDistributedNNFunctions):
+        hw_classification = HardwareClassification.CUDA
+
         # Test Common Ops First.
         @requires_ucc()
         @skip_if_lt_x_gpu(2)

--- a/test/distributed/test_ce_colls.py
+++ b/test/distributed/test_ce_colls.py
@@ -10,7 +10,11 @@ from torch.testing._internal.common_distributed import (
     skip_if_lt_x_gpu,
     skip_if_rocm_ver_atleast_multiprocess,
 )
-from torch.testing._internal.common_utils import requires_cuda_p2p_access, run_tests
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    requires_cuda_p2p_access,
+    run_tests,
+)
 
 
 if not dist.is_available() or not dist.is_nccl_available():
@@ -24,6 +28,8 @@ if not dist.is_available() or not dist.is_nccl_available():
 @requires_nccl_version((2, 28), "Need NCCL 2.28+ for CE collectives")
 @requires_cuda_p2p_access()
 class NCCLCopyEngineCollectives(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+
     @classmethod
     def backend_str(cls) -> str | None:
         return "nccl"


### PR DESCRIPTION
## Summary
- Classify `ProcessGroupNCCLOpTest` as `CUDA`
- All 32 test methods test NCCL collective operations requiring 2+ CUDA GPUs — class structurally locked to NCCL backend

Follows [RFC Test class classification](https://github.com/pytorch/pytorch/issues/185142).

cc @vishalgoyal316

---

Combined with #189400, #189539, #190377, #190378 into a single PR covering
5 test files:
- test/distributed/test_c10d_ops_nccl.py
- test/distributed/test_c10d_spawn_ucc.py
- test/distributed/test_ce_colls.py
- test/distributed/tensor/test_api.py
- test/distributed/tensor/test_common_rules.py

Each adds hw_classification per the device-agnostic testing initiative.
