### PR TITLE
Type nn.Module.__call__ to match forward via a generic Module

### DIFF
--- a/test/typing/fail/module_call.py
+++ b/test/typing/fail/module_call.py
@@ -1,0 +1,29 @@
+# flake8: noqa
+# Opting into a call signature via `nn.Module[params, return]` rejects an
+# incompatible `forward` override and mistyped `model(...)` / helper calls.
+from typing_extensions import ParamSpec, TypeVar
+
+from torch import nn, Tensor
+
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+
+
+class BadModule(nn.Module[[Tensor], Tensor]):
+    def forward(self, x: str) -> int:  # E: [override]
+        return 1
+
+
+class TensorModule(nn.Module[[Tensor], Tensor]):
+    def forward(self, x: Tensor) -> Tensor:
+        return x
+
+
+def call_generic(module: nn.Module[_P, _R], *args: _P.args, **kwargs: _P.kwargs) -> _R:
+    return module(*args, **kwargs)
+
+
+def check(t: TensorModule) -> None:
+    t("bad")  # E: incompatible type "str"; expected "Tensor"
+    call_generic(t, "bad")  # E: incompatible type "str"; expected "Tensor"

--- a/test/typing/pass/module_call.py
+++ b/test/typing/pass/module_call.py
@@ -1,0 +1,32 @@
+# A typed `nn.Module[params, return]` subclass gives `model(...)` the same
+# typed signature/return as `forward`, while a bare `nn.Module` is unchanged
+# (any arguments, `Any` return). See torch/nn/modules/module.py.
+from typing import Any
+from typing_extensions import assert_type, ParamSpec, TypeVar
+
+from torch import nn, Tensor
+
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+
+
+class TensorModule(nn.Module[[Tensor], Tensor]):
+    def forward(self, x: Tensor) -> Tensor:
+        return x
+
+
+class UntypedModule(nn.Module):  # bare Module -> Module[..., Any]
+    def forward(self, x: Tensor) -> Tensor:
+        return x
+
+
+def call_generic(module: nn.Module[_P, _R], *args: _P.args, **kwargs: _P.kwargs) -> _R:
+    return module(*args, **kwargs)
+
+
+def check(x: Tensor) -> None:
+    assert_type(TensorModule()(x), Tensor)  # typed __call__
+    assert_type(TensorModule().forward(x), Tensor)  # typed forward
+    assert_type(call_generic(TensorModule(), x), Tensor)  # generic over a Module
+    assert_type(UntypedModule()(x), Any)  # bare Module keeps `Any`

--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -1646,7 +1646,7 @@ class _WrappedMethod(torch.nn.Module):
         # share state of method's self module
         _sync_state(method.__self__, self)
         # redirect forward to method
-        self.forward = method
+        self.forward = method  # type: ignore[method-assign]
 
 
 def wrap_method(method):

--- a/torch/cuda/graphs.py
+++ b/torch/cuda/graphs.py
@@ -1042,7 +1042,7 @@ def make_graphed_callables(
 
                 return new_fwd
 
-            func.forward = make_graphed_forward(
+            func.forward = make_graphed_forward(  # type: ignore[method-assign]
                 func, func.training, graphed, func.forward
             )
             ret.append(func)

--- a/torch/distributed/pipelining/_IR.py
+++ b/torch/distributed/pipelining/_IR.py
@@ -625,7 +625,7 @@ class Pipe(torch.nn.Module):
                 "To run pipeline locally, invoke the Pipe object directly, not `split_gm`"
             )
 
-        self.split_gm.forward = throw
+        self.split_gm.forward = throw  # type: ignore[method-assign]
 
         # Make submodules use custom direct-serialized GraphModule
         i = 0

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -1653,13 +1653,13 @@ def patch_forward(obj: torch.nn.Module, new_method):
     original_method = obj.forward
 
     # Patch the method
-    obj.forward = new_method.__get__(obj, obj.__class__)
+    obj.forward = new_method.__get__(obj, obj.__class__)  # type: ignore[method-assign]
 
     try:
         yield
     finally:
         # Restore the original method
-        obj.forward = original_method
+        obj.forward = original_method  # type: ignore[method-assign]
 
 
 @contextmanager

--- a/torch/fx/experimental/rewriter.py
+++ b/torch/fx/experimental/rewriter.py
@@ -139,7 +139,7 @@ def _rewrite(
                         else:
                             self.__dict__[k] = copy.copy(v)
 
-            RewrittenModule.forward = AST_Rewriter().rewrite(
+            RewrittenModule.forward = AST_Rewriter().rewrite(  # type: ignore[method-assign]
                 cast(FunctionType, m.forward)
             )
             return RewrittenModule(m)

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -224,7 +224,7 @@ def _deserialize_graph_module(
     """
 
     # Try to retrieve the forward source in a backward-compatible way
-    _CodeOnlyModule.forward = forward
+    _CodeOnlyModule.forward = forward  # type: ignore[method-assign]
 
     tracer_cls = body.get("_tracer_cls")
     if tracer_cls is None:
@@ -983,7 +983,7 @@ class {module_name}(torch.nn.Module):
                 f"torch._C._profiler._RecordFunctionFast('## {filename} ##')",
             )
 
-        cls.forward = _forward_from_src(self._code, python_code.globals, co_fields)
+        cls.forward = _forward_from_src(self._code, python_code.globals, co_fields)  # type: ignore[method-assign]
 
         # Determine whether this class explicitly defines a __call__ implementation
         # to wrap. If it does, save it in order to have wrapped_call invoke it.

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -7,8 +7,8 @@ import warnings
 import weakref
 from collections import namedtuple, OrderedDict
 from collections.abc import Callable, Iterator, Mapping
-from typing import Any, Optional, overload, TypeVar, Union
-from typing_extensions import Self
+from typing import Any, cast, Generic, Optional, overload, TYPE_CHECKING, Union
+from typing_extensions import ParamSpec, Self, TypeVar
 
 import torch
 from torch import device, dtype, Tensor
@@ -35,6 +35,13 @@ _grad_t = tuple[Tensor, ...] | Tensor
 # of `T` to annotate `self`. Many methods of `Module` return `self` and we want those return values to be
 # the type of the subclass, not the looser type of `Module`.
 T = TypeVar("T", bound="Module")
+
+# `Module` is generic over the parameters and return type of `forward`/`__call__`
+# so that a typed subclass gets a precise `model(...)` signature. The defaults
+# (`...`/`Any`) make a bare `nn.Module` behave exactly as before: any arguments,
+# `Any` return. See the `if TYPE_CHECKING` branches on `forward`/`__call__`.
+_P = ParamSpec("_P", default=...)
+_R = TypeVar("_R", default=Any)
 
 
 class _IncompatibleKeys(
@@ -404,7 +411,7 @@ def _forward_unimplemented(self, *input: Any) -> None:
     )
 
 
-class Module:
+class Module(Generic[_P, _R]):
     r"""Base class for all neural network modules.
 
     Your models should also subclass this class.
@@ -523,7 +530,13 @@ class Module:
         if self.call_super_init:
             super().__init__(*args, **kwargs)
 
-    forward: Callable[..., Any] = _forward_unimplemented
+    if TYPE_CHECKING:
+        # Expose the parametrized signature to type checkers while keeping the
+        # runtime value-assignment (see `_forward_unimplemented` above) that
+        # dodges mypy's contravariance rules on overrides.
+        def forward(self, *input: _P.args, **kwargs: _P.kwargs) -> _R: ...
+    else:
+        forward: Callable[..., Any] = _forward_unimplemented
 
     def register_buffer(
         self, name: str, tensor: Tensor | None, persistent: bool = True
@@ -1780,7 +1793,10 @@ class Module:
     # torchrec tests the code consistency with the following code
     # fmt: off
     def _call_impl(self, *args, **kwargs):
-        forward_call = (self._slow_forward if torch._C._get_tracing_state() else self.forward)
+        # `forward_call` is dynamic dispatch (tracing vs. the typed `forward`);
+        # keep it `Any`-typed so the generic `forward` return type does not leak
+        # into this internal machinery.
+        forward_call = cast("Callable[..., Any]", self._slow_forward if torch._C._get_tracing_state() else self.forward)
         # If we don't have any hooks, we want to skip the rest of the logic in
         # this function, and just call forward.
         if not (self._backward_hooks or self._backward_pre_hooks or self._forward_hooks or self._forward_pre_hooks
@@ -1914,7 +1930,13 @@ class Module:
             raise
     # fmt: on
 
-    __call__: Callable[..., Any] = _wrapped_call_impl
+    if TYPE_CHECKING:
+        # Give `model(...)` the same typed signature/return as `forward`. The
+        # runtime `__call__` is still `_wrapped_call_impl` (compiled call,
+        # hooks, tracing, `_call_impl`); only the static type is refined here.
+        def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> _R: ...
+    else:
+        __call__: Callable[..., Any] = _wrapped_call_impl
 
     def __getstate__(self):
         state = self.__dict__.copy()

--- a/torch/xpu/graphs.py
+++ b/torch/xpu/graphs.py
@@ -516,7 +516,7 @@ def make_graphed_callables(
 
                 return new_fwd
 
-            func.forward = make_graphed_forward(
+            func.forward = make_graphed_forward(  # type: ignore[method-assign]
                 func, func.training, graphed, func.forward
             )
             ret.append(func)


### PR DESCRIPTION
Make `torch.nn.Module` generic over the parameter and return types of
`forward`/`__call__`, so a typed subclass gets a precise `model(...)`
signature. Runtime behavior is unchanged.

`Module.__call__` was typed `Callable[..., Any]`, so `model(...)` inferred
`Any` even when a subclass had a fully typed `forward`. `Module` is now
`Generic[_P, _R]` with PEP 696 defaults (`_P = ...`, `_R = Any`). Under
`TYPE_CHECKING`, `forward` and `__call__` are exposed as
`def (*_P.args, **_P.kwargs) -> _R`; at runtime the assignments are exactly
as before (`forward = _forward_unimplemented`,
`__call__ = _wrapped_call_impl`), so compiled calls, hooks, tracing, and
`_call_impl` are untouched. The defaults make a bare `nn.Module` behave as
before (any args, `Any` return), so existing code needs no changes. A
subclass opts into precise typing by parametrizing the base:

    class TensorModule(nn.Module[[Tensor], Tensor]):
        def forward(self, x: Tensor) -> Tensor: ...
    reveal_type(TensorModule()(x))  # Tensor

Suggested review order:

1. torch/nn/modules/module.py: the core change (generic base, the two
   `TYPE_CHECKING` branches, and the `cast` in `_call_impl` that keeps the
   generic `forward` return from leaking into Module's internal hook
   machinery).
2. The `# type: ignore[method-assign]` additions: because `forward` is now a
   typed method, the internal sites that reassign `.forward` on a
   statically-typed Module need suppression under mypy (pyrefly does not
   flag these).
3. test/typing/{pass,fail}/module_call.py: focused coverage.

Alternatives considered: an external Protocol only helps at typed
boundaries, not at direct `model(...)` calls; typing only `__call__` and
leaving `forward` a value would drop the incompatible-override check and a
typed `.forward()`. An opt-in mixin would also work.

The generic-Module approach was checked against pyright,
mypy, ty, and pyrefly. 

Test Plan:

Typed pattern verified against the real API across four checkers; positive
probes report 0 errors, the three negatives are rejected on the marked
lines:

```
mypy --python-version 3.11 --follow-imports=silent test/typing/pass/module_call.py   # 0 errors
mypy --python-version 3.11 --follow-imports=silent test/typing/fail/module_call.py   # errors on the 3 marked lines
pyrefly check --python-version 3.12 <standalone pattern probes>                       # pass: 0, fail: 3
ty check --python-version 3.12 <standalone pattern probes>                            # pass: 0, fail: 3
```

No new diagnostics introduced (before/after diff over real torch):

```
pyrefly check torch/nn/                    # 0 new
mypy --follow-imports=silent torch/nn/     # 0 new
```

The focused tests are run in CI by test/test_typing.py (mypy over
test/typing/*); run locally against a built torch with:

```
python test/test_typing.py -k module_call
```

Runtime/JIT smoke check: the change was applied to an installed `torch==2.13.0+cpu` (whose module.py matches this branch line-for-line) and compared against a baseline with no change. `jit.script`, `jit.trace`, and `torch.compile` all pass for existing modules, `nn.Sequential`, and a subclass that opts in via`nn.Module[[Tensor], Tensor]` (including as a scripted submodule);`state_dict` round-trip and `deepcopy` also pass. Making `Module` `Generic` does not appear to disturb the TorchScript frontend.

Closes #74746.

(This change was authored with the assistance of an AI assistant. I have looked over the code though!)
