### PR TITLE
ubuntu-cross-riscv: fetch zlib from GitHub releases (robustness follow-up to #175237)

### DIFF
--- a/.ci/docker/ubuntu-cross-riscv/Dockerfile
+++ b/.ci/docker/ubuntu-cross-riscv/Dockerfile
@@ -52,7 +52,7 @@ WORKDIR /opt
 
 # Build zlib (for compression)
 RUN echo "--- Building zlib ---" \
-    && wget -c https://www.zlib.net/zlib-${ZLIB_VERSION}.tar.gz \
+    && wget -c https://github.com/madler/zlib/releases/download/v${ZLIB_VERSION}/zlib-${ZLIB_VERSION}.tar.gz \
     && tar -xf zlib-${ZLIB_VERSION}.tar.gz --no-same-permissions --no-same-owner \
     && cd zlib-${ZLIB_VERSION}/ \
     && mkdir build && cd build \

--- a/.ci/docker/ubuntu-cross-riscv/Dockerfile
+++ b/.ci/docker/ubuntu-cross-riscv/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y \
     ccache \
     git \
     wget \
+    curl \
     python3-pip \
     python3-venv \
     python-is-python3 \
@@ -52,8 +53,8 @@ WORKDIR /opt
 
 # Build zlib (for compression)
 RUN echo "--- Building zlib ---" \
-    && wget -c https://github.com/madler/zlib/releases/download/v${ZLIB_VERSION}/zlib-${ZLIB_VERSION}.tar.gz \
-    && tar -xf zlib-${ZLIB_VERSION}.tar.gz --no-same-permissions --no-same-owner \
+    && curl -fsSL https://github.com/madler/zlib/releases/download/v${ZLIB_VERSION}/zlib-${ZLIB_VERSION}.tar.gz \
+        | tar -xz --no-same-permissions --no-same-owner \
     && cd zlib-${ZLIB_VERSION}/ \
     && mkdir build && cd build \
     && ../configure --prefix=${SYSROOT} \


### PR DESCRIPTION
Refs #175193. Robustness follow-up to #175237.

## Scope (read first)

This does **not** address the primary action item on #175193 -- per @malfet, that is separating non-standard/experimental docker builds into their own workflow so they do not block mainstream x86/aarch64 builds. This PR only removes the fragile download URL that caused the original breakage, and is safe to take or leave independently of that larger effort. Happy to take on the workflow-separation work separately if wanted.

## Root cause

The `ubuntu-cross-riscv` image fetches zlib from `https://www.zlib.net/zlib-${ZLIB_VERSION}.tar.gz`, but zlib.net only hosts the *current* release. When a new zlib ships, the pinned `ZLIB_VERSION` tarball disappears from that URL and the build fails with a 404. That is what happened originally (1.3.1 removed after 1.3.2 released); #175237 fixed it by bumping the pinned version, but the next zlib release will 404 the same way.

## Change

Fetch from `github.com/madler/zlib/releases`, which retains every tagged release permanently, so a pinned version never disappears. This also makes zlib consistent with how this same Dockerfile already fetches `libffi` and `xz` (both use `github.com/.../releases/download`).

## Test plan

Vendor URL is fragile, release URL is durable:
```
curl -sIL https://www.zlib.net/zlib-1.3.1.tar.gz                                      # 404
curl -sIL https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz  # 200
curl -sIL https://github.com/madler/zlib/releases/download/v1.3.2/zlib-1.3.2.tar.gz  # 200
```
Built this Dockerfile (`--target final`) with the change on a reproducible x86 runner; the image builds through the zlib layer and to completion:
```
docker buildx build --target final -f .ci/docker/ubuntu-cross-riscv/Dockerfile .ci/docker
```

cc @malfet @zklaus @huydhn @pytorch/pytorch-dev-infra @luhenry