### PR TITLE
Compute libnvrtc shorthash with CMake file(SHA256) instead of Python

### DIFF
--- a/cmake/public/cuda.cmake
+++ b/cmake/public/cuda.cmake
@@ -131,19 +131,9 @@ endif()
 # find lbnvrtc.so
 set(CUDA_NVRTC_LIB "${CUDA_nvrtc_LIBRARY}" CACHE FILEPATH "")
 if(CUDA_NVRTC_LIB AND NOT CUDA_NVRTC_SHORTHASH)
-  find_package(Python COMPONENTS Interpreter)
-  execute_process(
-    COMMAND "${Python_EXECUTABLE}" -c
-    "import hashlib;hash=hashlib.sha256();hash.update(open('${CUDA_NVRTC_LIB}','rb').read());print(hash.hexdigest()[:8])"
-    RESULT_VARIABLE _retval
-    OUTPUT_VARIABLE CUDA_NVRTC_SHORTHASH)
-  if(NOT _retval EQUAL 0)
-    message(WARNING "Failed to compute shorthash for libnvrtc.so")
-    set(CUDA_NVRTC_SHORTHASH "XXXXXXXX")
-  else()
-    string(STRIP "${CUDA_NVRTC_SHORTHASH}" CUDA_NVRTC_SHORTHASH)
-    message(STATUS "${CUDA_NVRTC_LIB} shorthash is ${CUDA_NVRTC_SHORTHASH}")
-  endif()
+  file(SHA256 "${CUDA_NVRTC_LIB}" _cuda_nvrtc_sha256)
+  string(SUBSTRING "${_cuda_nvrtc_sha256}" 0 8 CUDA_NVRTC_SHORTHASH)
+  message(STATUS "${CUDA_NVRTC_LIB} shorthash is ${CUDA_NVRTC_SHORTHASH}")
 endif()
 
 # Create new style imported libraries.

--- a/cmake/public/cuda.cmake
+++ b/cmake/public/cuda.cmake
@@ -128,7 +128,7 @@ endif()
 
 # ---[ CUDA libraries wrapper
 
-# find lbnvrtc.so
+# find libnvrtc.so
 set(CUDA_NVRTC_LIB "${CUDA_nvrtc_LIBRARY}" CACHE FILEPATH "")
 if(CUDA_NVRTC_LIB AND NOT CUDA_NVRTC_SHORTHASH)
   file(SHA256 "${CUDA_NVRTC_LIB}" _cuda_nvrtc_sha256)


### PR DESCRIPTION
## Summary

The NVRTC "shorthash" (first 8 hex chars of the sha256 of `libnvrtc.so`) was
computed by spawning the Python interpreter to run a `hashlib` one-liner, which
required a local `find_package(Python COMPONENTS Interpreter)` inside
`cmake/public/cuda.cmake`. CMake has provided `file(SHA256)` since 3.x, so this
can be done natively with no interpreter and no subprocess:

```cmake
file(SHA256 "${CUDA_NVRTC_LIB}" _cuda_nvrtc_sha256)
string(SUBSTRING "${_cuda_nvrtc_sha256}" 0 8 CUDA_NVRTC_SHORTHASH)
```

Besides being simpler and faster, this removes the only `find_package(Python)`
that runs after Python is first resolved at the top level. That re-find silently
unsets and recomputes `Python_SOABI` (FindPython does so on every invocation),
which is a footgun for any code that sets `Python_SOABI` to work around
FindPython limitations. `cuda.cmake` is also a public, installed module
re-included by downstream `find_package(Torch)` via `Caffe2Config.cmake`, so
dropping the Python dependency there is a small correctness win too.

`file(SHA256)` hard-errors on an unreadable file where the old code fell back to
`"XXXXXXXX"`, but the enclosing guard already requires `CUDA_NVRTC_LIB` to be a
resolved library path, so the file exists.

This PR was authored with the assistance of an AI coding assistant.

## Test Plan

Verified CMake's `file(SHA256)` + `string(SUBSTRING 0 8)` is byte-identical to
the previous Python `hashlib` `hexdigest()[:8]` on the same input (both print
`8fafd5d4`). Only reached on CUDA builds (guarded by `USE_CUDA` and
`CUDA_NVRTC_LIB`); end-to-end validation is a CUDA configure logging the expected
`shorthash is <8 hex>`.
