### PR TITLE
[Test] Bring `@modules` out-of-tree backend support

### DIFF
--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -15,6 +15,12 @@ from torch.testing._internal.common_device_type import (
     precisionOverride,
     PrivateUse1TestBase,
 )
+from torch.testing._internal.common_modules import (
+    FunctionInput,
+    ModuleInfo,
+    ModuleInput,
+    modules,
+)
 from torch.testing._internal.common_utils import run_tests, TestCase
 from torch.testing._internal.opinfo.core import DecorateInfo, OpInfo
 
@@ -299,6 +305,157 @@ with _temp_test_configs(
     instantiate_device_type_tests(
         TestSupportedOpsWithOverrides, globals(), only_for=("openreg",)
     )
+
+
+def _dummy_module_inputs(module_info, device, dtype, requires_grad, training, **kwargs):
+    return [
+        ModuleInput(
+            constructor_input=FunctionInput(),
+            forward_input=FunctionInput(
+                torch.randn(4, device=device, dtype=dtype, requires_grad=requires_grad)
+            ),
+        )
+    ]
+
+
+def _make_dummy_module(name, **kwargs):
+    module_cls = type(name, (torch.nn.Identity,), {})
+    return ModuleInfo(
+        module_cls,
+        module_inputs_func=_dummy_module_inputs,
+        dtypes=(torch.float32,),
+        **kwargs,
+    )
+
+
+module_normal = _make_dummy_module("module_normal")
+module_skip = _make_dummy_module("module_skip")
+module_xfail = _make_dummy_module("module_xfail")
+
+# Dummy modules for testing combined module_allowlist + module_overrides
+module_combined_supported = _make_dummy_module("module_combined_supported")
+module_combined_skip = _make_dummy_module("module_combined_skip")
+module_combined_unsupported = _make_dummy_module("module_combined_unsupported")
+
+# Declares openreg dtype support via the generic ModuleInfo.dtypesIf dict:
+# on openreg only float64 variants should generate, overriding the base
+# dtypes (float32).
+module_dtypesif = _make_dummy_module(
+    "module_dtypesif", dtypesIf={"openreg": (torch.float64,)}
+)
+
+
+class TestModuleTypeOpenReg(TestCase):
+    _executed: dict = defaultdict(int)
+
+    @classmethod
+    def tearDownClass(cls):
+        should_run = ("module_normal",)
+        should_not_run = ("module_skip", "module_xfail")
+        for module_name in should_run:
+            if cls._executed[module_name] == 0:
+                raise AssertionError(f"{module_name} tests should have run")
+        for module_name in should_not_run:
+            if cls._executed[module_name] != 0:
+                raise AssertionError(f"{module_name} test body should never run")
+        super().tearDownClass()
+
+    @modules([module_normal, module_skip, module_xfail])
+    def test_module(self, device, dtype, module_info, training):
+        if module_info.name in ("module_skip", "module_xfail"):
+            self.fail(f"{module_info.name} deliberately fails")
+        type(self)._executed[module_info.name] += 1
+
+    @modules([module_normal])
+    def test_module_narrow_modules(self, device, dtype, module_info, training):
+        """Verify that having extra entries in module_overrides that are NOT present
+        in the @modules list does not raise a KeyError (safety check in _apply_module_overrides)
+
+        module_overrides includes module_skip and PrivateUse1TestBase.module_overrides
+        also lists module_skip; here @modules only exposes module_normal. The safety
+        check introduced in _apply_module_overrides must silently ignore the missing key.
+        """
+        # If we reach here without a KeyError the safety check worked.
+
+
+class TestModuleAllowlistWithOverrides(TestCase):
+    """Verify that module_allowlist filtering works together with module_overrides.
+
+    module_allowlist filters which modules generate variants.
+    module_overrides adds decorators to those modules that pass the filter.
+    """
+
+    _executed_combined: dict = defaultdict(int)
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls._executed_combined["module_combined_supported"] == 0:
+            raise AssertionError("module_combined_supported should have run")
+        if cls._executed_combined["module_combined_skip"] != 0:
+            raise AssertionError(
+                "module_combined_skip should be skipped by module_overrides"
+            )
+        if cls._executed_combined["module_combined_unsupported"] != 0:
+            raise AssertionError(
+                "module_combined_unsupported should not run (not in module_allowlist)"
+            )
+        super().tearDownClass()
+
+    @modules(
+        [module_combined_supported, module_combined_skip, module_combined_unsupported]
+    )
+    def test_combined_filter(self, device, dtype, module_info, training):
+        type(self)._executed_combined[module_info.name] += 1
+
+
+class TestModuleDtypesIf(TestCase):
+    """Verify ModuleInfo.dtypesIf drives per-backend dtype variant generation.
+
+    module_dtypesif has base dtypes=(float32,) but declares
+    dtypesIf={"openreg": (float64,)}; on openreg exactly the declared float64
+    variant must generate, and the base float32 variant must not.
+    """
+
+    executed_dtypes: list = []
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.executed_dtypes != [torch.float64]:
+            raise AssertionError(
+                f"dtypesIf failed: expected exactly [torch.float64], "
+                f"got {cls.executed_dtypes}"
+            )
+        super().tearDownClass()
+
+    @modules([module_dtypesif])
+    def test_dtypesif(self, device, dtype, module_info, training):
+        type(self).executed_dtypes.append(dtype)
+
+
+OPENREG_MODULE_OVERRIDES = {
+    "module_skip": [DecorateInfo(unittest.skip("skip module_skip"))],
+    "module_xfail": [DecorateInfo(unittest.expectedFailure)],
+}
+with _temp_test_configs(PrivateUse1TestBase, module_overrides=OPENREG_MODULE_OVERRIDES):
+    instantiate_device_type_tests(
+        TestModuleTypeOpenReg, globals(), only_for=("openreg",)
+    )
+
+with _temp_test_configs(
+    PrivateUse1TestBase,
+    module_overrides={
+        "module_combined_skip": [
+            DecorateInfo(unittest.skip("skip via module_overrides"))
+        ],
+    },
+    module_allowlist=("module_combined_supported", "module_combined_skip"),
+):
+    instantiate_device_type_tests(
+        TestModuleAllowlistWithOverrides, globals(), only_for=("openreg",)
+    )
+
+# dtypesIf lives on the ModuleInfo itself, so no _temp_test_configs is needed.
+instantiate_device_type_tests(TestModuleDtypesIf, globals(), only_for=("openreg",))
 
 
 @unittest.skipIf(not dist.is_available(), "Distributed not available, skipping tests")

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -337,13 +337,6 @@ module_combined_supported = _make_dummy_module("module_combined_supported")
 module_combined_skip = _make_dummy_module("module_combined_skip")
 module_combined_unsupported = _make_dummy_module("module_combined_unsupported")
 
-# Declares openreg dtype support via the generic ModuleInfo.dtypesIf dict:
-# on openreg only float64 variants should generate, overriding the base
-# dtypes (float32).
-module_dtypesif = _make_dummy_module(
-    "module_dtypesif", dtypesIf={"openreg": (torch.float64,)}
-)
-
 
 class TestModuleTypeOpenReg(TestCase):
     _executed: dict = defaultdict(int)
@@ -408,30 +401,6 @@ class TestModuleAllowlistWithOverrides(TestCase):
         type(self)._executed_combined[module_info.name] += 1
 
 
-class TestModuleDtypesIf(TestCase):
-    """Verify ModuleInfo.dtypesIf drives per-backend dtype variant generation.
-
-    module_dtypesif has base dtypes=(float32,) but declares
-    dtypesIf={"openreg": (float64,)}; on openreg exactly the declared float64
-    variant must generate, and the base float32 variant must not.
-    """
-
-    executed_dtypes: list = []
-
-    @classmethod
-    def tearDownClass(cls):
-        if cls.executed_dtypes != [torch.float64]:
-            raise AssertionError(
-                f"dtypesIf failed: expected exactly [torch.float64], "
-                f"got {cls.executed_dtypes}"
-            )
-        super().tearDownClass()
-
-    @modules([module_dtypesif])
-    def test_dtypesif(self, device, dtype, module_info, training):
-        type(self).executed_dtypes.append(dtype)
-
-
 OPENREG_MODULE_OVERRIDES = {
     "module_skip": [DecorateInfo(unittest.skip("skip module_skip"))],
     "module_xfail": [DecorateInfo(unittest.expectedFailure)],
@@ -453,9 +422,6 @@ with _temp_test_configs(
     instantiate_device_type_tests(
         TestModuleAllowlistWithOverrides, globals(), only_for=("openreg",)
     )
-
-# dtypesIf lives on the ModuleInfo itself, so no _temp_test_configs is needed.
-instantiate_device_type_tests(TestModuleDtypesIf, globals(), only_for=("openreg",))
 
 
 @unittest.skipIf(not dist.is_available(), "Distributed not available, skipping tests")

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -397,18 +397,21 @@ def _dummy_module_inputs(module_info, device, dtype, requires_grad, training, **
     ]
 
 
-def _make_dummy_module(name, **kwargs):
+def _make_dummy_module(name, dtypes=(torch.float32,), **kwargs):
     module_cls = type(name, (torch.nn.Identity,), {})
     return ModuleInfo(
         module_cls,
         module_inputs_func=_dummy_module_inputs,
-        dtypes=(torch.float32,),
+        dtypes=dtypes,
         **kwargs,
     )
 
 
 module_normal = _make_dummy_module("module_normal")
 module_skip = _make_dummy_module("module_skip")
+module_skip_f32 = _make_dummy_module(
+    "module_skip_f32", dtypes={torch.float32, torch.float64}
+)
 module_xfail = _make_dummy_module("module_xfail")
 
 # Dummy modules for testing combined module_allowlist + module_overrides
@@ -430,9 +433,14 @@ class TestModuleTypeOpenReg(TestCase):
         for module_name in should_not_run:
             if cls._executed[module_name] != 0:
                 raise AssertionError(f"{module_name} test body should never run")
+        if cls._executed["module_skip_f32"] != 1:
+            raise AssertionError(
+                "module_skip_f32 should have run exactly once,"
+                f"but ran {cls._executed['module_skip_f32']} times"
+            )
         super().tearDownClass()
 
-    @modules([module_normal, module_skip, module_xfail])
+    @modules([module_normal, module_skip, module_skip_f32, module_xfail])
     def test_module(self, device, dtype, module_info, training):
         if module_info.name in ("module_skip", "module_xfail"):
             self.fail(f"{module_info.name} deliberately fails")
@@ -482,6 +490,9 @@ class TestModuleAllowlistWithOverrides(TestCase):
 
 OPENREG_MODULE_OVERRIDES = {
     "module_skip": [DecorateInfo(unittest.skip("skip module_skip"))],
+    "module_skip_f32": [
+        DecorateInfo(unittest.skip("skip module_skip_f32"), dtypes=(torch.float32,))
+    ],
     "module_xfail": [DecorateInfo(unittest.expectedFailure)],
 }
 with _temp_test_configs(PrivateUse1TestBase, module_overrides=OPENREG_MODULE_OVERRIDES):

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -416,13 +416,6 @@ module_combined_supported = _make_dummy_module("module_combined_supported")
 module_combined_skip = _make_dummy_module("module_combined_skip")
 module_combined_unsupported = _make_dummy_module("module_combined_unsupported")
 
-# Declares openreg dtype support via the generic ModuleInfo.dtypesIf dict:
-# on openreg only float64 variants should generate, overriding the base
-# dtypes (float32).
-module_dtypesif = _make_dummy_module(
-    "module_dtypesif", dtypesIf={"openreg": (torch.float64,)}
-)
-
 
 class TestModuleTypeOpenReg(TestCase):
     _executed: dict = defaultdict(int)
@@ -487,30 +480,6 @@ class TestModuleAllowlistWithOverrides(TestCase):
         type(self)._executed_combined[module_info.name] += 1
 
 
-class TestModuleDtypesIf(TestCase):
-    """Verify ModuleInfo.dtypesIf drives per-backend dtype variant generation.
-
-    module_dtypesif has base dtypes=(float32,) but declares
-    dtypesIf={"openreg": (float64,)}; on openreg exactly the declared float64
-    variant must generate, and the base float32 variant must not.
-    """
-
-    executed_dtypes: list = []
-
-    @classmethod
-    def tearDownClass(cls):
-        if cls.executed_dtypes != [torch.float64]:
-            raise AssertionError(
-                f"dtypesIf failed: expected exactly [torch.float64], "
-                f"got {cls.executed_dtypes}"
-            )
-        super().tearDownClass()
-
-    @modules([module_dtypesif])
-    def test_dtypesif(self, device, dtype, module_info, training):
-        type(self).executed_dtypes.append(dtype)
-
-
 OPENREG_MODULE_OVERRIDES = {
     "module_skip": [DecorateInfo(unittest.skip("skip module_skip"))],
     "module_xfail": [DecorateInfo(unittest.expectedFailure)],
@@ -532,9 +501,6 @@ with _temp_test_configs(
     instantiate_device_type_tests(
         TestModuleAllowlistWithOverrides, globals(), only_for=("openreg",)
     )
-
-# dtypesIf lives on the ModuleInfo itself, so no _temp_test_configs is needed.
-instantiate_device_type_tests(TestModuleDtypesIf, globals(), only_for=("openreg",))
 
 
 @unittest.skipIf(not dist.is_available(), "Distributed not available, skipping tests")

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -18,6 +18,12 @@ from torch.testing._internal.common_device_type import (
     PrivateUse1TestBase,
     requires_capabilities,
 )
+from torch.testing._internal.common_modules import (
+    FunctionInput,
+    ModuleInfo,
+    ModuleInput,
+    modules,
+)
 from torch.testing._internal.common_utils import run_tests, TestCase
 from torch.testing._internal.opinfo.core import DecorateInfo, OpInfo
 
@@ -378,6 +384,157 @@ class TestCapabilityGating(TestCase):
 
 
 instantiate_device_type_tests(TestCapabilityGating, globals(), only_for="openreg")
+
+
+def _dummy_module_inputs(module_info, device, dtype, requires_grad, training, **kwargs):
+    return [
+        ModuleInput(
+            constructor_input=FunctionInput(),
+            forward_input=FunctionInput(
+                torch.randn(4, device=device, dtype=dtype, requires_grad=requires_grad)
+            ),
+        )
+    ]
+
+
+def _make_dummy_module(name, **kwargs):
+    module_cls = type(name, (torch.nn.Identity,), {})
+    return ModuleInfo(
+        module_cls,
+        module_inputs_func=_dummy_module_inputs,
+        dtypes=(torch.float32,),
+        **kwargs,
+    )
+
+
+module_normal = _make_dummy_module("module_normal")
+module_skip = _make_dummy_module("module_skip")
+module_xfail = _make_dummy_module("module_xfail")
+
+# Dummy modules for testing combined module_allowlist + module_overrides
+module_combined_supported = _make_dummy_module("module_combined_supported")
+module_combined_skip = _make_dummy_module("module_combined_skip")
+module_combined_unsupported = _make_dummy_module("module_combined_unsupported")
+
+# Declares openreg dtype support via the generic ModuleInfo.dtypesIf dict:
+# on openreg only float64 variants should generate, overriding the base
+# dtypes (float32).
+module_dtypesif = _make_dummy_module(
+    "module_dtypesif", dtypesIf={"openreg": (torch.float64,)}
+)
+
+
+class TestModuleTypeOpenReg(TestCase):
+    _executed: dict = defaultdict(int)
+
+    @classmethod
+    def tearDownClass(cls):
+        should_run = ("module_normal",)
+        should_not_run = ("module_skip", "module_xfail")
+        for module_name in should_run:
+            if cls._executed[module_name] == 0:
+                raise AssertionError(f"{module_name} tests should have run")
+        for module_name in should_not_run:
+            if cls._executed[module_name] != 0:
+                raise AssertionError(f"{module_name} test body should never run")
+        super().tearDownClass()
+
+    @modules([module_normal, module_skip, module_xfail])
+    def test_module(self, device, dtype, module_info, training):
+        if module_info.name in ("module_skip", "module_xfail"):
+            self.fail(f"{module_info.name} deliberately fails")
+        type(self)._executed[module_info.name] += 1
+
+    @modules([module_normal])
+    def test_module_narrow_modules(self, device, dtype, module_info, training):
+        """Verify that having extra entries in module_overrides that are NOT present
+        in the @modules list does not raise a KeyError (safety check in _apply_module_overrides)
+
+        module_overrides includes module_skip and PrivateUse1TestBase.module_overrides
+        also lists module_skip; here @modules only exposes module_normal. The safety
+        check introduced in _apply_module_overrides must silently ignore the missing key.
+        """
+        # If we reach here without a KeyError the safety check worked.
+
+
+class TestModuleAllowlistWithOverrides(TestCase):
+    """Verify that module_allowlist filtering works together with module_overrides.
+
+    module_allowlist filters which modules generate variants.
+    module_overrides adds decorators to those modules that pass the filter.
+    """
+
+    _executed_combined: dict = defaultdict(int)
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls._executed_combined["module_combined_supported"] == 0:
+            raise AssertionError("module_combined_supported should have run")
+        if cls._executed_combined["module_combined_skip"] != 0:
+            raise AssertionError(
+                "module_combined_skip should be skipped by module_overrides"
+            )
+        if cls._executed_combined["module_combined_unsupported"] != 0:
+            raise AssertionError(
+                "module_combined_unsupported should not run (not in module_allowlist)"
+            )
+        super().tearDownClass()
+
+    @modules(
+        [module_combined_supported, module_combined_skip, module_combined_unsupported]
+    )
+    def test_combined_filter(self, device, dtype, module_info, training):
+        type(self)._executed_combined[module_info.name] += 1
+
+
+class TestModuleDtypesIf(TestCase):
+    """Verify ModuleInfo.dtypesIf drives per-backend dtype variant generation.
+
+    module_dtypesif has base dtypes=(float32,) but declares
+    dtypesIf={"openreg": (float64,)}; on openreg exactly the declared float64
+    variant must generate, and the base float32 variant must not.
+    """
+
+    executed_dtypes: list = []
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.executed_dtypes != [torch.float64]:
+            raise AssertionError(
+                f"dtypesIf failed: expected exactly [torch.float64], "
+                f"got {cls.executed_dtypes}"
+            )
+        super().tearDownClass()
+
+    @modules([module_dtypesif])
+    def test_dtypesif(self, device, dtype, module_info, training):
+        type(self).executed_dtypes.append(dtype)
+
+
+OPENREG_MODULE_OVERRIDES = {
+    "module_skip": [DecorateInfo(unittest.skip("skip module_skip"))],
+    "module_xfail": [DecorateInfo(unittest.expectedFailure)],
+}
+with _temp_test_configs(PrivateUse1TestBase, module_overrides=OPENREG_MODULE_OVERRIDES):
+    instantiate_device_type_tests(
+        TestModuleTypeOpenReg, globals(), only_for=("openreg",)
+    )
+
+with _temp_test_configs(
+    PrivateUse1TestBase,
+    module_overrides={
+        "module_combined_skip": [
+            DecorateInfo(unittest.skip("skip via module_overrides"))
+        ],
+    },
+    module_allowlist=("module_combined_supported", "module_combined_skip"),
+):
+    instantiate_device_type_tests(
+        TestModuleAllowlistWithOverrides, globals(), only_for=("openreg",)
+    )
+
+# dtypesIf lives on the ModuleInfo itself, so no _temp_test_configs is needed.
+instantiate_device_type_tests(TestModuleDtypesIf, globals(), only_for=("openreg",))
 
 
 @unittest.skipIf(not dist.is_available(), "Distributed not available, skipping tests")

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -468,54 +468,57 @@ class DeviceTypeTestBase(TestCase):
         self._tls.rel_tol = prec
 
     @classmethod
-    def _apply_op_overrides(cls, ops, test=None):
-        class_overrides = cls.op_overrides or {}
-        test_overrides = {} if test is None else getattr(test, "_op_overrides", {})
-
-        if not class_overrides and not test_overrides:
-            return
-
-        op_dict = {op.full_name: op for op in copy.deepcopy(ops.op_list)}
-
-        for op_name, decorators in class_overrides.items():
+    def _apply_class_overrides(cls, info_dict, class_overrides):
+        """Stamps each class_overrides decorator's device_type to this test
+        base's device type and appends it to the matching entry of info_dict
+        (keyed by OpInfo.full_name or ModuleInfo.name).
+        """
+        for name, decorators in class_overrides.items():
             for decorator in decorators:
                 if cls.device_type == "privateuse1":
                     decorator.device_type = torch._C._get_privateuse1_backend_name()
                 else:
                     decorator.device_type = cls.device_type
-                # op_name may not be in op_dict if @ops() has restricted the
-                # OpInfo list to a smaller set than op_overrides covers.
-                if op_name in op_dict:
-                    op_dict[op_name].decorators += (decorator,)
+                # name may not be in info_dict if @ops()/@modules() has
+                # restricted the list to a smaller set than overrides covers.
+                if name in info_dict:
+                    info_dict[name].decorators += (decorator,)
+
+    @classmethod
+    def _apply_op_overrides(cls, op_list, test=None):
+        class_overrides = cls.op_overrides or {}
+        test_overrides = {} if test is None else getattr(test, "_op_overrides", {})
+
+        if not class_overrides and not test_overrides:
+            return op_list
+
+        op_dict = {op.full_name: op for op in copy.deepcopy(op_list)}
+        if len(op_dict) != len(op_list):
+            raise AssertionError("Duplicate op full_names in @ops op_list")
+
+        cls._apply_class_overrides(op_dict, class_overrides)
 
         for op_name, decorators in test_overrides.items():
             for decorator in decorators:
                 if op_name in op_dict:
                     op_dict[op_name].decorators += (decorator,)
 
-        ops.op_list = list(op_dict.values())
+        return list(op_dict.values())
 
     @classmethod
-    def _apply_module_overrides(cls, modules):
+    def _apply_module_overrides(cls, module_info_list):
         class_overrides = cls.module_overrides or {}
 
         if not class_overrides:
-            return
+            return module_info_list
 
-        module_dict = {m.name: m for m in copy.deepcopy(modules.module_info_list)}
+        module_dict = {m.name: m for m in copy.deepcopy(module_info_list)}
+        if len(module_dict) != len(module_info_list):
+            raise AssertionError("Duplicate module names in @modules module_info_list")
 
-        for module_name, decorators in class_overrides.items():
-            for decorator in decorators:
-                if cls.device_type == "privateuse1":
-                    decorator.device_type = torch._C._get_privateuse1_backend_name()
-                else:
-                    decorator.device_type = cls.device_type
-                # module_name may not be in module_dict if @modules() has restricted
-                # the ModuleInfo list to a smaller set than module_overrides covers.
-                if module_name in module_dict:
-                    module_dict[module_name].decorators += (decorator,)
+        cls._apply_class_overrides(module_dict, class_overrides)
 
-        modules.module_info_list = list(module_dict.values())
+        return list(module_dict.values())
 
     # Returns a string representing the device that single device tests should use.
     # Note: single device tests use this device exclusively.
@@ -588,40 +591,38 @@ class DeviceTypeTestBase(TestCase):
         return _check_dtype()
 
     @classmethod
-    def _apply_op_allowlist(cls, ops):
-        """Filters ops.op_list to only include ops declared in op_allowlist.
+    def _apply_op_allowlist(cls, op_list):
+        """Filters op_list to only include ops declared in op_allowlist.
 
         If op_allowlist is None (default), no filtering is applied.
         If op_allowlist is set, only ops whose full_name is in the collection
         will generate test variants.
 
         Args:
-            ops: The ops decorator instance whose op_list will be filtered.
+            op_list: The list of OpInfo entries to filter.
         """
         if cls.op_allowlist is None:
-            return
+            return op_list
 
         supported_set = set(cls.op_allowlist)
-        ops.op_list = [op for op in ops.op_list if op.full_name in supported_set]
+        return [op for op in op_list if op.full_name in supported_set]
 
     @classmethod
-    def _apply_module_allowlist(cls, modules):
-        """Filters modules.module_info_list to only include modules declared in module_allowlist.
+    def _apply_module_allowlist(cls, module_info_list):
+        """Filters module_info_list to only include modules in module_allowlist.
 
         If module_allowlist is None (default), no filtering is applied.
         If module_allowlist is set, only modules whose name is in the collection
         will generate test variants.
 
         Args:
-            modules: The modules decorator instance whose module_info_list will be filtered.
+            module_info_list: The list of ModuleInfo entries to filter.
         """
         if cls.module_allowlist is None:
-            return
+            return module_info_list
 
         supported_set = set(cls.module_allowlist)
-        modules.module_info_list = [
-            m for m in modules.module_info_list if m.name in supported_set
-        ]
+        return [m for m in module_info_list if m.name in supported_set]
 
     @classmethod
     def _init_and_get_primary_device(cls):
@@ -1562,10 +1563,10 @@ class ops(_TestParametrizer):
 
         # Order matters: op_allowlist filters first, then op_overrides adds decorators
         # This ensures op_overrides only applies to ops that passed the op_allowlist filter
-        device_cls._apply_op_allowlist(self)
-        device_cls._apply_op_overrides(self, test)
+        op_list = device_cls._apply_op_allowlist(self.op_list)
+        op_list = device_cls._apply_op_overrides(op_list, test)
         op = check_exhausted_iterator = object()
-        for op in self.op_list:
+        for op in op_list:
             # Determine the set of dtypes to use.
             dtypes: set[torch.dtype] | set[None]
             if isinstance(self.opinfo_dtypes, Sequence):

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -379,6 +379,18 @@ class DeviceTypeTestBase(TestCase):
     # If None (default), all ops in the @ops decorator's op_list generate variants.
     op_allowlist = None  # type: Optional[Collection[str]]
 
+    # Decorators and skips to apply to tests that are parametrized by modules.
+    # Keys are ModuleInfo.name (e.g. "nn.Linear", "nn.Conv2d"). Unlike OpInfo,
+    # ModuleInfo has no variant concept, so there is no "full_name" distinction.
+    module_overrides = None  # type: Optional[dict[str, list[DecorateInfo]]]
+
+    # An optional mechanism to limit which modules generate test variants.
+    # When set, only modules whose name is in this collection will generate tests.
+    # Keys are ModuleInfo.name (e.g. "nn.Linear", "nn.Conv2d").
+    # If None (default), all modules in the @modules decorator's module_info_list
+    # generate variants.
+    module_allowlist = None  # type: Optional[Collection[str]]
+
     # An optional skip mechanism built upon instantiate_device_type_tests(),
     # designed to filter generated tests at different granularities.
     #
@@ -483,6 +495,28 @@ class DeviceTypeTestBase(TestCase):
 
         ops.op_list = list(op_dict.values())
 
+    @classmethod
+    def _apply_module_overrides(cls, modules):
+        class_overrides = cls.module_overrides or {}
+
+        if not class_overrides:
+            return
+
+        module_dict = {m.name: m for m in copy.deepcopy(modules.module_info_list)}
+
+        for module_name, decorators in class_overrides.items():
+            for decorator in decorators:
+                if cls.device_type == "privateuse1":
+                    decorator.device_type = torch._C._get_privateuse1_backend_name()
+                else:
+                    decorator.device_type = cls.device_type
+                # module_name may not be in module_dict if @modules() has restricted
+                # the ModuleInfo list to a smaller set than module_overrides covers.
+                if module_name in module_dict:
+                    module_dict[module_name].decorators += (decorator,)
+
+        modules.module_info_list = list(module_dict.values())
+
     # Returns a string representing the device that single device tests should use.
     # Note: single device tests use this device exclusively.
     @classmethod
@@ -571,6 +605,25 @@ class DeviceTypeTestBase(TestCase):
         ops.op_list = [op for op in ops.op_list if op.full_name in supported_set]
 
     @classmethod
+    def _apply_module_allowlist(cls, modules):
+        """Filters modules.module_info_list to only include modules declared in module_allowlist.
+
+        If module_allowlist is None (default), no filtering is applied.
+        If module_allowlist is set, only modules whose name is in the collection
+        will generate test variants.
+
+        Args:
+            modules: The modules decorator instance whose module_info_list will be filtered.
+        """
+        if cls.module_allowlist is None:
+            return
+
+        supported_set = set(cls.module_allowlist)
+        modules.module_info_list = [
+            m for m in modules.module_info_list if m.name in supported_set
+        ]
+
+    @classmethod
     def _init_and_get_primary_device(cls):
         try:
             return cls.get_primary_device()
@@ -627,6 +680,8 @@ class DeviceTypeTestBase(TestCase):
         *,
         op_overrides=None,
         op_allowlist=None,
+        module_overrides=None,
+        module_allowlist=None,
         test_exclusions=None,
     ):
         """
@@ -639,6 +694,8 @@ class DeviceTypeTestBase(TestCase):
         """
         cls.op_overrides = op_overrides
         cls.op_allowlist = op_allowlist
+        cls.module_overrides = module_overrides
+        cls.module_allowlist = module_allowlist
         cls.test_exclusions = test_exclusions
 
     # Creates device-specific tests.

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -347,6 +347,18 @@ class DeviceTypeTestBase(TestCase):
     # If None (default), all ops in the @ops decorator's op_list generate variants.
     op_allowlist = None  # type: Optional[Collection[str]]
 
+    # Decorators and skips to apply to tests that are parametrized by modules.
+    # Keys are ModuleInfo.name (e.g. "nn.Linear", "nn.Conv2d"). Unlike OpInfo,
+    # ModuleInfo has no variant concept, so there is no "full_name" distinction.
+    module_overrides = None  # type: Optional[dict[str, list[DecorateInfo]]]
+
+    # An optional mechanism to limit which modules generate test variants.
+    # When set, only modules whose name is in this collection will generate tests.
+    # Keys are ModuleInfo.name (e.g. "nn.Linear", "nn.Conv2d").
+    # If None (default), all modules in the @modules decorator's module_info_list
+    # generate variants.
+    module_allowlist = None  # type: Optional[Collection[str]]
+
     # An optional skip mechanism built upon instantiate_device_type_tests(),
     # designed to filter generated tests at different granularities.
     #
@@ -438,6 +450,28 @@ class DeviceTypeTestBase(TestCase):
 
         ops.op_list = list(op_dict.values())
 
+    @classmethod
+    def _apply_module_overrides(cls, modules):
+        class_overrides = cls.module_overrides or {}
+
+        if not class_overrides:
+            return
+
+        module_dict = {m.name: m for m in copy.deepcopy(modules.module_info_list)}
+
+        for module_name, decorators in class_overrides.items():
+            for decorator in decorators:
+                if cls.device_type == "privateuse1":
+                    decorator.device_type = torch._C._get_privateuse1_backend_name()
+                else:
+                    decorator.device_type = cls.device_type
+                # module_name may not be in module_dict if @modules() has restricted
+                # the ModuleInfo list to a smaller set than module_overrides covers.
+                if module_name in module_dict:
+                    module_dict[module_name].decorators += (decorator,)
+
+        modules.module_info_list = list(module_dict.values())
+
     # Returns a string representing the device that single device tests should use.
     # Note: single device tests use this device exclusively.
     @classmethod
@@ -526,6 +560,25 @@ class DeviceTypeTestBase(TestCase):
         ops.op_list = [op for op in ops.op_list if op.full_name in supported_set]
 
     @classmethod
+    def _apply_module_allowlist(cls, modules):
+        """Filters modules.module_info_list to only include modules declared in module_allowlist.
+
+        If module_allowlist is None (default), no filtering is applied.
+        If module_allowlist is set, only modules whose name is in the collection
+        will generate test variants.
+
+        Args:
+            modules: The modules decorator instance whose module_info_list will be filtered.
+        """
+        if cls.module_allowlist is None:
+            return
+
+        supported_set = set(cls.module_allowlist)
+        modules.module_info_list = [
+            m for m in modules.module_info_list if m.name in supported_set
+        ]
+
+    @classmethod
     def _init_and_get_primary_device(cls):
         try:
             return cls.get_primary_device()
@@ -582,6 +635,8 @@ class DeviceTypeTestBase(TestCase):
         *,
         op_overrides=None,
         op_allowlist=None,
+        module_overrides=None,
+        module_allowlist=None,
         test_exclusions=None,
     ):
         """
@@ -594,6 +649,8 @@ class DeviceTypeTestBase(TestCase):
         """
         cls.op_overrides = op_overrides
         cls.op_allowlist = op_allowlist
+        cls.module_overrides = module_overrides
+        cls.module_allowlist = module_allowlist
         cls.test_exclusions = test_exclusions
 
     # Creates device-specific tests.

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -108,6 +108,7 @@ class modules(_TestParametrizer):
         module_info_list = device_cls._apply_module_allowlist(self.module_info_list)
         module_info_list = device_cls._apply_module_overrides(module_info_list)
 
+        module_info = check_exhausted_iterator = object()
         for module_info in module_info_list:
             dtypes = set(module_info.supported_dtypes(device_cls.device_type))
             if self.allowed_dtypes is not None:
@@ -143,6 +144,12 @@ class modules(_TestParametrizer):
                     # Provides an error message for debugging before rethrowing the exception
                     print(f"Failed to instantiate {test_name} for module {module_info.name}!")
                     raise ex
+        if module_info is check_exhausted_iterator:
+            raise ValueError(
+                "An empty module_info_list was passed to @modules. Note that this may "
+                "result from reuse of a generator, or from a module_allowlist that "
+                "filtered out every entry."
+            )
 
 
 def get_module_common_name(module_cls):

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -102,6 +102,12 @@ class modules(_TestParametrizer):
                                'context; use it with instantiate_device_type_tests() instead of '
                                'instantiate_parametrized_tests()')
 
+        # Order matters: module_allowlist filters first, then module_overrides adds
+        # decorators. This ensures module_overrides only applies to modules that
+        # passed the module_allowlist filter.
+        device_cls._apply_module_allowlist(self)
+        device_cls._apply_module_overrides(self)
+
         for module_info in self.module_info_list:
             dtypes = set(module_info.supported_dtypes(device_cls.device_type))
             if self.allowed_dtypes is not None:
@@ -215,6 +221,9 @@ class ModuleInfo:
                  dtypes=floating_types(),  # dtypes this function is expected to work with
                  dtypesIfMPS=(torch.float16, torch.float32,),  # dtypes this function is expected to work with on MPS
                  dtypesIfHpu=(torch.bfloat16, torch.float32,),
+                 dtypesIf: dict[str, tuple] | None = None,  # generic per-device-type dtype
+                                                            # overrides, e.g. dtypesIf={"xpu": (...),
+                                                            # "openreg": (...)}.
                  supports_gradgrad=True,  # whether the op supports second order gradients
                  gradcheck_nondet_tol=0.0,  # tolerance for nondeterminism while performing gradcheck
                  module_memformat_affects_out=False,  # whether converting module to channels last will generate
@@ -231,6 +240,7 @@ class ModuleInfo:
         self.dtypes = dtypes
         self.dtypesIfMPS = dtypesIfMPS
         self.dtypesIfHpu = dtypesIfHpu
+        self.dtypesIf = dict(dtypesIf) if dtypesIf else {}
         self.supports_gradgrad = supports_gradgrad
         self.gradcheck_nondet_tol = gradcheck_nondet_tol
         self.module_memformat_affects_out = module_memformat_affects_out
@@ -254,8 +264,9 @@ class ModuleInfo:
             return self.dtypesIfMPS
         elif device_type == 'hpu':
             return self.dtypesIfHpu
-        else:
-            return self.dtypes
+        elif device_type == 'privateuse1':
+            device_type = torch._C._get_privateuse1_backend_name()
+        return self.dtypesIf.get(device_type, self.dtypes)
 
     @property
     def name(self):

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -221,9 +221,6 @@ class ModuleInfo:
                  dtypes=floating_types(),  # dtypes this function is expected to work with
                  dtypesIfMPS=(torch.float16, torch.float32,),  # dtypes this function is expected to work with on MPS
                  dtypesIfHpu=(torch.bfloat16, torch.float32,),
-                 dtypesIf: dict[str, tuple] | None = None,  # generic per-device-type dtype
-                                                            # overrides, e.g. dtypesIf={"xpu": (...),
-                                                            # "openreg": (...)}.
                  supports_gradgrad=True,  # whether the op supports second order gradients
                  gradcheck_nondet_tol=0.0,  # tolerance for nondeterminism while performing gradcheck
                  module_memformat_affects_out=False,  # whether converting module to channels last will generate
@@ -240,7 +237,6 @@ class ModuleInfo:
         self.dtypes = dtypes
         self.dtypesIfMPS = dtypesIfMPS
         self.dtypesIfHpu = dtypesIfHpu
-        self.dtypesIf = dict(dtypesIf) if dtypesIf else {}
         self.supports_gradgrad = supports_gradgrad
         self.gradcheck_nondet_tol = gradcheck_nondet_tol
         self.module_memformat_affects_out = module_memformat_affects_out
@@ -264,9 +260,8 @@ class ModuleInfo:
             return self.dtypesIfMPS
         elif device_type == 'hpu':
             return self.dtypesIfHpu
-        elif device_type == 'privateuse1':
-            device_type = torch._C._get_privateuse1_backend_name()
-        return self.dtypesIf.get(device_type, self.dtypes)
+        else:
+            return self.dtypes
 
     @property
     def name(self):

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -105,10 +105,10 @@ class modules(_TestParametrizer):
         # Order matters: module_allowlist filters first, then module_overrides adds
         # decorators. This ensures module_overrides only applies to modules that
         # passed the module_allowlist filter.
-        device_cls._apply_module_allowlist(self)
-        device_cls._apply_module_overrides(self)
+        module_info_list = device_cls._apply_module_allowlist(self.module_info_list)
+        module_info_list = device_cls._apply_module_overrides(module_info_list)
 
-        for module_info in self.module_info_list:
+        for module_info in module_info_list:
             dtypes = set(module_info.supported_dtypes(device_cls.device_type))
             if self.allowed_dtypes is not None:
                 dtypes = dtypes.intersection(self.allowed_dtypes)


### PR DESCRIPTION
## Background

`op_overrides` / `op_allowlist` / `set_test_configs()` (#176264, #181703, #181554) let out-of-tree (PrivateUse1) backends reuse OpInfo-based test suites through pure configuration. This PR brings `@modules` to parity with `@ops`.

## Changes

- Add `module_overrides` / `module_allowlist` to `DeviceTypeTestBase` and apply them in the `modules` parametrizer; 
- Add a generic `ModuleInfo.dtypesIf` dict so any backend can declare per-device dtype support

## Test Plan

Added ModuleInfo counterparts of the existing OpInfo configuration tests in `torch_openreg/tests/test_testing.py`.