### PR TITLE
Set Python_SOABI when cross-compiling so extension modules get a valid suffix

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -876,6 +876,35 @@ if(BUILD_PYTHON)
     endif()
     # Observers are required in the python build
     caffe2_update_option(USE_OBSERVERS ON)
+    # When cross-compiling, FindPython does not run the interpreter to determine
+    # Python_SOABI unless CMAKE_CROSSCOMPILING_EMULATOR is set (policy CMP0190),
+    # so it is left empty. Python_add_library with WITH_SOABI would then emit
+    # extension modules without a platform suffix -- e.g. an untagged _C.so that
+    # the target interpreter cannot import, and that setup.py's f"_C{EXT_SUFFIX}"
+    # package_data does not collect. A cross-python setup provides a directly
+    # runnable interpreter that reports the target's config, so when SOABI is
+    # empty, query it from the interpreter and set Python_SOABI once, for every
+    # downstream WITH_SOABI consumer.
+    #
+    # Only fill an *empty* value: a non-empty Python_SOABI is authoritative. With
+    # an emulator FindPython ran the target interpreter to compute it, and this
+    # bare invocation would run the wrong interpreter (or fail to exec the target
+    # binary), so we must not second-guess it.
+    if(CMAKE_CROSSCOMPILING AND NOT Python_SOABI)
+      execute_process(
+        COMMAND "${Python_EXECUTABLE}" -c
+                "import sysconfig; print(sysconfig.get_config_var('SOABI') or '')"
+        OUTPUT_VARIABLE _python_target_soabi
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+      if(_python_target_soabi)
+        message(WARNING
+          "FindPython left Python_SOABI empty while cross-compiling (it does not run "
+          "the interpreter without CMAKE_CROSSCOMPILING_EMULATOR); setting it from the "
+          "target interpreter's SOABI '${_python_target_soabi}' so Python extension "
+          "modules get a valid suffix.")
+        set(Python_SOABI "${_python_target_soabi}")
+      endif()
+    endif()
   else()
     message(WARNING "Python dependencies not met. Not compiling with python. Suppress this warning with -DBUILD_PYTHON=OFF")
     caffe2_update_option(BUILD_PYTHON OFF)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -892,6 +892,34 @@ if(BUILD_PYTHON)
         caffe2_update_option(USE_NUMPY ON)
       endif()
     endif()
+    # When cross-compiling, FindPython does not run the interpreter to determine
+    # Python_SOABI unless CMAKE_CROSSCOMPILING_EMULATOR is set (policy CMP0190),
+    # so it is left empty. Python_add_library with WITH_SOABI would then emit
+    # extension modules without a platform suffix -- an untagged _C.so that the
+    # target interpreter will not import. A cross-python setup provides a
+    # directly runnable interpreter that reports the target's config, so when
+    # SOABI is empty, query it from the interpreter and set Python_SOABI once,
+    # for every downstream WITH_SOABI consumer.
+    #
+    # Only fill an *empty* value: a non-empty Python_SOABI is authoritative. With
+    # an emulator FindPython ran the target interpreter to compute it, and this
+    # bare invocation would run the wrong interpreter (or fail to exec the target
+    # binary), so we must not second-guess it.
+    if(CMAKE_CROSSCOMPILING AND NOT Python_SOABI)
+      execute_process(
+        COMMAND "${Python_EXECUTABLE}" -c
+                "import sysconfig; print(sysconfig.get_config_var('SOABI') or '')"
+        OUTPUT_VARIABLE _python_target_soabi
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+      if(_python_target_soabi)
+        message(WARNING
+          "FindPython left Python_SOABI empty while cross-compiling (it does not run "
+          "the interpreter without CMAKE_CROSSCOMPILING_EMULATOR); setting it from the "
+          "target interpreter's SOABI '${_python_target_soabi}' so Python extension "
+          "modules get a valid suffix.")
+        set(Python_SOABI "${_python_target_soabi}")
+      endif()
+    endif()
   else()
     message(WARNING "Python dependencies not met. Not compiling with python. Suppress this warning with -DBUILD_PYTHON=OFF")
     caffe2_update_option(BUILD_PYTHON OFF)


### PR DESCRIPTION
## Summary

Since #180243 the `torch._C` extension is built by CMake via
`Python_add_library(_C MODULE WITH_SOABI ...)`. `WITH_SOABI` names the module
using `Python_SOABI`, which CMake's FindPython only computes by running the
interpreter **when not cross-compiling**: under `CMAKE_CROSSCOMPILING` the query
is skipped unless `CMAKE_CROSSCOMPILING_EMULATOR` is set (policy `CMP0190`), so
`Python_SOABI` is left empty and `WITH_SOABI` silently emits an untagged `_C.so`.

That breaks cross builds: the extension is installed under a name the target
interpreter will not import, so `import torch._C` fails. This is the conda-forge
linux-aarch64 failure in
[pytorch-cpu-feedstock#526](https://github.com/conda-forge/pytorch-cpu-feedstock/pull/526).

When this was first diagnosed the symptom was different: `setup.py` collected the
extension via `package_data = f"_C{sysconfig.get_config_var('EXT_SUFFIX')}"`, the
untagged name did not match, and `_C` was dropped from the wheel entirely.
#180248 has since removed `setup.py`, and `_C` is now collected by
`install(TARGETS _C ...)`, so it ships under the wrong name rather than going
missing. Either way the target cannot import it.

#190003 has since widened which builds hit this. It forwards `CMAKE_SYSTEM_NAME`
and `CMAKE_SYSTEM_PROCESSOR` from the environment before `project()`, which is
exactly what puts CMake into cross-compile mode, so a cross setup that passes
them that way now takes the empty-`Python_SOABI` path too. Such a build
previously stayed in native mode -- `CMAKE_CROSSCOMPILING` false, `Python_SOABI`
computed normally -- and so never produced an untagged module. That makes this
the completion of #190003 rather than a conda-forge-only concern.

CMake's sanctioned cross path (`CMP0190` + an emulator) assumes the target
interpreter is run under qemu/wine. That does not fit conda-forge's crossenv,
where the interpreter is a build-native binary that reports the target's config
and is directly runnable -- no emulator. So when `Python_SOABI` is empty while
cross-compiling, we query `SOABI` from the interpreter (which crossenv answers
with the target's value) and set it once, right where FindPython resolves the
`Development.Module` component. Every downstream `WITH_SOABI` consumer (`_C`, and
the CUDA-only `_nccl_ep`) then gets the correct suffix, and `WITH_SOABI` still
composes the platform-specific filename.

The override deliberately only fills an **empty** `Python_SOABI`. A non-empty
value is authoritative and left untouched: with an emulator FindPython ran the
target interpreter to compute it, whereas this bare invocation would run the
wrong interpreter (or fail to exec the target binary), so it must not
second-guess a value FindPython already produced.

It sets `Python_SOABI` centrally rather than overriding each target's `SUFFIX`
because FindPython recomputes `Python_SOABI` on every `find_package(Python)`, so
a manual value only survives if nothing re-finds Python afterwards. That now
holds unconditionally: since #189386 replaced the libnvrtc shorthash with
`file(SHA256)`, no `find_package(Python)` runs after this one at all.

An alternative considered was passing `-DPython_SOABI=...`; FindPython unsets and
recomputes the variable on each find, so a command-line value is not honored.

This PR was authored with the assistance of an AI coding assistant.

## Test Plan

### Cross-build validation (real linux-aarch64 crossenv)

Validated against a genuine conda-forge-style cross environment: cross compilers
plus a `linux-aarch64` target prefix, joined by `crossenv`, so `Python_EXECUTABLE`
is an interpreter that **runs on x86_64 but reports the target's config**
(SOABI `cpython-312-aarch64-linux-gnu`, platform `linux-aarch64`) -- the setup
this fix is written for.

```
mamba create -p $ROOT/build-env -c conda-forge python=3.12 crossenv cmake ninja \
      gcc_linux-aarch64 gxx_linux-aarch64 sysroot_linux-aarch64
conda create -p $ROOT/target-env --platform linux-aarch64 -c conda-forge python=3.12 numpy
export PATH="$ROOT/build-env/bin:$PATH"
$ROOT/build-env/bin/python -m crossenv \
  --sysconfigdata-file $ROOT/target-env/lib/python3.12/_sysconfigdata_aarch64_conda_linux_gnu.py \
  --cc aarch64-conda-linux-gnu-gcc --cxx aarch64-conda-linux-gnu-c++ \
  --ar aarch64-conda-linux-gnu-ar \
  --sysroot $ROOT/build-env/aarch64-conda-linux-gnu/sysroot \
  $ROOT/target-env/bin/python $ROOT/cross-venv
```

PyTorch itself was then configured twice with that interpreter, the two runs
differing **only** in `cmake/Dependencies.cmake`:

```
cmake -S . -B $B -G Ninja \
  -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 \
  -DCMAKE_C_COMPILER=aarch64-conda-linux-gnu-gcc \
  -DCMAKE_CXX_COMPILER=aarch64-conda-linux-gnu-c++ \
  -DCMAKE_SYSROOT=$ROOT/build-env/aarch64-conda-linux-gnu/sysroot \
  -DPython_EXECUTABLE=$ROOT/cross-venv/cross/bin/python \
  -DPython_INCLUDE_DIR=$ROOT/target-env/include/python3.12 \
  -DUSE_CUDA=0 -DUSE_DISTRIBUTED=0 -DBUILD_TEST=0 -DUSE_MKLDNN=0 \
  -DUSE_NUMPY=0 -DUSE_OPENMP=0 -DUSE_KINETO=0 -DBLAS=Eigen
```

Both configures succeed; the resulting `_C` target in the generated build system:

| | `_C` output in `build.ninja` |
| --- | --- |
| without this patch (current `viable/strict`) | `torch/_C.so` -- untagged, the reported bug |
| with this patch | `torch/_C.cpython-312-aarch64-linux-gnu.so` |

The configure log shows the override firing with
`cpython-312-aarch64-linux-gnu`. This also exercises the central-override design
end to end: the value survives from the override in `Dependencies.cmake` all the
way to target generation, with no later `find_package(Python)` resetting it.

Scope: this covers configure and the generated build system, where the module
name is decided. A full aarch64 compile was not run, and the box has no
`qemu-user`, so importing an aarch64 artifact there was not possible; end-to-end
execution remains the conda-forge build below.

### Supporting checks

In a standalone FindPython project: (a) a non-empty `Python_SOABI` is preserved
and only an empty one takes the override path, and (b) setting `Python_SOABI`
before the `Python_add_library` calls (no intervening `find_package`) drives the
suffix of every `WITH_SOABI` module:

```cmake
set(Python_SOABI "cpython-312-aarch64-linux-gnu")
Python_add_library(_C MODULE WITH_SOABI stub.c)        # -> _C.cpython-312-aarch64-linux-gnu.so
Python_add_library(_nccl_ep MODULE WITH_SOABI stub.c)  # -> _nccl_ep.cpython-312-aarch64-linux-gnu.so
```

Native builds are unchanged: the `CMAKE_CROSSCOMPILING` guard is not taken and
FindPython's `Python_SOABI` already equals `EXT_SUFFIX` there.

The #190003 interaction was checked separately (cmake 3.28.3), since it governs
*which* builds reach the empty-`SOABI` condition in the first place:

```
# native, no toolchain vars
cmake -S . -B b1
# -> CMAKE_CROSSCOMPILING=FALSE  Python_SOABI=cpython-310-x86_64-linux-gnu

# toolchain vars in the environment, WITHOUT #190003's forwarding block
CMAKE_SYSTEM_NAME=Linux CMAKE_SYSTEM_PROCESSOR=aarch64 cmake -S . -B b4
# -> CMAKE_CROSSCOMPILING=FALSE  Python_SOABI=cpython-310-x86_64-linux-gnu

# same, WITH the forwarding block (current main)
CMAKE_SYSTEM_NAME=Linux CMAKE_SYSTEM_PROCESSOR=aarch64 cmake -S . -B b2
# -> CMAKE_CROSSCOMPILING=TRUE   Python_SOABI=''

# -D flags (the conda-forge CMAKE_ARGS path)
cmake -S . -B b3 -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64
# -> CMAKE_CROSSCOMPILING=TRUE   Python_SOABI=''
```

macOS is unaffected: `CMAKE_OSX_ARCHITECTURES=x86_64` on an arm64 host leaves
`CMAKE_CROSSCOMPILING` false, and macOS SOABI (`cpython-3XY-darwin`) carries no
architecture component, so no arch-mismatched module name can arise there.

End-to-end validation is a conda-forge linux-aarch64 build
([pytorch-cpu-feedstock#526](https://github.com/conda-forge/pytorch-cpu-feedstock/pull/526))
confirming `_C.cpython-3XY-aarch64-linux-gnu.so` is installed and
`import torch._C` succeeds.
