### PR TITLE
Show example output in nn.Tanh docstring

### DIFF
--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -421,8 +421,9 @@ class Tanh(Module):
     Examples::
 
         >>> m = nn.Tanh()
-        >>> input = torch.randn(2)
-        >>> output = m(input)
+        >>> input = torch.tensor([-2.0, -0.5, 0.0, 0.5, 2.0])
+        >>> m(input)
+        tensor([-0.9640, -0.4621,  0.0000,  0.4621,  0.9640])
     """
 
     def forward(self, input: Tensor) -> Tensor:


### PR DESCRIPTION
Fixes #189384

The `nn.Tanh` docstring example used `torch.randn(2)` and never displayed the result, so the rendered docs page left readers unable to see what the module produces without running the code.

This replaces the random input with a small fixed tensor covering the interesting parts of the curve (saturation at +-2, midrange at +-0.5, and 0) and shows the actual output, following the style of the deterministic examples in `torch/nn/modules/padding.py`. A fixed input keeps the shown output stable under the doctest runs in CI, which collect this class docstring.

Rendered example:

    >>> m = nn.Tanh()
    >>> input = torch.tensor([-2.0, -0.5, 0.0, 0.5, 2.0])
    >>> m(input)
    tensor([-0.9640, -0.4621,  0.0000,  0.4621,  0.9640])

The output line was verified character-exact against real torch and passes a strict stdlib doctest run (stricter than the xdoctest CI run) of the edited docstring.

Authored with an AI assistant (Claude).

cc @svekars @sekyondaMeta @AlannaBurke