### PR TITLE
[Profiler] Mark ignore = dirty for Kineto submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -86,6 +86,7 @@
 	path = third_party/cudnn_frontend
 	url = https://github.com/NVIDIA/cudnn-frontend.git
 [submodule "third_party/kineto"]
+    ignore = dirty
     path = third_party/kineto
     url = https://github.com/pytorch/kineto
 [submodule "third_party/pocketfft"]


### PR DESCRIPTION
https://github.com/pytorch/kineto/pull/1446 drops the dynolog submodule and vendors the headers instead. This means that dynolog was a nested submodule from PyTorch's perspective, and updating it is now causing problems in the backwards compat test when I try to bump the submodule to catch the Kineto-side changes in https://github.com/pytorch/pytorch/pull/189276.

The root cause seems to be that running `git submodule update` across the Kineto hash bump boundary causes the Kineto submodule to be marked as "dirty". Git allegedly never deletes a removed submodule's working tree, so once the Kineto pin moves to a commit where dynolog is no longer a submodule, that directory lingers as untracked content inside the Kineto checkout.