### PR TITLE
[MPS] Migrate threshold and threshold_backward to Metal

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Activation.h
+++ b/aten/src/ATen/native/mps/kernels/Activation.h
@@ -1,6 +1,12 @@
 #pragma once
 
 template <typename T>
+struct ThresholdParams {
+  T threshold;
+  T value;
+};
+
+template <typename T>
 struct ELUParams {
   T alpha;
   T scale;

--- a/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
@@ -119,6 +119,33 @@ REGISTER_BINARY_OP(hardswish_backward, float, float);
 REGISTER_BINARY_OP(hardswish_backward, half, half);
 REGISTER_BINARY_OP(hardswish_backward, bfloat, bfloat);
 
+// Shared by threshold() and threshold_backward(): the meta function builds the
+// iterator as (self, other) with other = self (forward) or grad (backward,
+// with value = 0), computing `self <= threshold ? value : other`.
+struct threshold_functor {
+  template <typename T>
+  inline T operator()(
+      const T self,
+      const T other,
+      const ThresholdParams<T> params) {
+    return self <= params.threshold ? params.value : other;
+  }
+};
+
+#define REGISTER_THRESHOLD_OP(T)                  \
+  typedef ThresholdParams<T> ThresholdParams_##T; \
+  REGISTER_BINARY_ALPHA_OP(threshold, T, ThresholdParams_##T, T);
+
+REGISTER_THRESHOLD_OP(float);
+REGISTER_THRESHOLD_OP(half);
+REGISTER_THRESHOLD_OP(bfloat);
+REGISTER_THRESHOLD_OP(long);
+REGISTER_THRESHOLD_OP(int);
+REGISTER_THRESHOLD_OP(short);
+REGISTER_THRESHOLD_OP(char);
+REGISTER_THRESHOLD_OP(uchar);
+REGISTER_THRESHOLD_OP(bool);
+
 struct elu_functor {
   template <typename T>
   inline T operator()(const T self_, const ELUParams<T> params) {

--- a/aten/src/ATen/native/mps/operations/Activation.mm
+++ b/aten/src/ATen/native/mps/operations/Activation.mm
@@ -19,8 +19,6 @@
 #include <ATen/ops/softplus_backward_native.h>
 #include <ATen/ops/softplus_native.h>
 #include <ATen/ops/tanh_backward_native.h>
-#include <ATen/ops/threshold_backward_native.h>
-#include <ATen/ops/threshold_native.h>
 #endif
 
 using namespace at::mps;
@@ -156,106 +154,6 @@ TORCH_IMPL_FUNC(tanh_backward_out_mps)(const Tensor& grad_output, const Tensor& 
 
     auto feeds = dictionaryFromPlaceholders(gradOutputPlaceholder, outputPlaceholder);
     runMPSGraph(stream, cachedGraph->graph(), feeds, gradInputPlaceholder);
-  }
-}
-
-TORCH_IMPL_FUNC(threshold_out_mps)
-(const Tensor& self, const Scalar& threshold, const Scalar& value, const Tensor& result) {
-  using namespace mps;
-  using CachedGraph = MPSUnaryCachedGraph;
-  TORCH_CHECK(self.is_mps());
-
-  if (result.numel() == 0)
-    return;
-
-  MPSStream* stream = getCurrentMPSStream();
-
-  @autoreleasepool {
-    std::string key = "threshold_out_mps" + getTensorsStringKey({self}) + ":" + std::to_string(threshold.to<double>()) +
-        ":" + std::to_string(value.to<double>());
-
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
-
-      MPSGraphTensor* thresholdTensor = [mpsGraph constantWithScalar:threshold.to<double>()
-                                                               shape:@[ @1 ]
-                                                            dataType:getMPSDataType(self)];
-
-      MPSGraphTensor* valueTensor = [mpsGraph constantWithScalar:value.to<double>()
-                                                           shape:@[ @1 ]
-                                                        dataType:getMPSDataType(self)];
-
-      // x > threshold
-      MPSGraphTensor* predicateTensor = [mpsGraph greaterThanWithPrimaryTensor:inputTensor
-                                                               secondaryTensor:thresholdTensor
-                                                                          name:nil];
-
-      // result = (self > threshold) ? self : value
-      MPSGraphTensor* outputTensor = [mpsGraph selectWithPredicateTensor:predicateTensor
-                                                     truePredicateTensor:inputTensor
-                                                    falsePredicateTensor:valueTensor
-                                                                    name:nil];
-
-      newCachedGraph->inputTensor_ = inputTensor;
-      newCachedGraph->outputTensor_ = outputTensor;
-    });
-
-    Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self);
-    Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, result);
-
-    auto feeds = dictionaryFromPlaceholders(selfPlaceholder);
-    runMPSGraph(stream, cachedGraph->graph(), feeds, outputPlaceholder);
-  }
-}
-
-TORCH_IMPL_FUNC(threshold_backward_out_mps)
-(const Tensor& grad, const Tensor& self, const Scalar& threshold, const Tensor& gradInput) {
-  using namespace mps;
-  using CachedGraph = MPSUnaryGradCachedGraph;
-  TORCH_CHECK(self.is_mps());
-  TORCH_CHECK(grad.is_mps());
-
-  if (gradInput.numel() == 0)
-    return;
-
-  MPSStream* stream = getCurrentMPSStream();
-
-  @autoreleasepool {
-    std::string key =
-        "threshold_backward_out_mps" + getTensorsStringKey({self, grad}) + ":" + std::to_string(threshold.to<double>());
-
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
-      MPSGraphTensor* gradTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad);
-
-      MPSGraphTensor* thresholdTensor = [mpsGraph constantWithScalar:threshold.to<double>()
-                                                               shape:@[ @1 ]
-                                                            dataType:getMPSDataType(self)];
-
-      MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0 dataType:inputTensor.dataType];
-
-      // x > threshold
-      MPSGraphTensor* predicateTensor = [mpsGraph greaterThanWithPrimaryTensor:inputTensor
-                                                               secondaryTensor:thresholdTensor
-                                                                          name:nil];
-
-      // result = (self > threshold) ? grad : zeroTensor
-      MPSGraphTensor* gradInputTensor = [mpsGraph selectWithPredicateTensor:predicateTensor
-                                                        truePredicateTensor:gradTensor
-                                                       falsePredicateTensor:zeroTensor
-                                                                       name:nil];
-
-      newCachedGraph->gradOutputTensor_ = gradTensor;
-      newCachedGraph->inputTensor_ = inputTensor;
-      newCachedGraph->gradInputTensor_ = gradInputTensor;
-    });
-
-    Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self);
-    Placeholder gradPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad);
-    Placeholder outputPlaceholder = Placeholder(cachedGraph->gradInputTensor_, gradInput);
-
-    auto feeds = dictionaryFromPlaceholders(gradPlaceholder, selfPlaceholder);
-    runMPSGraph(stream, cachedGraph->graph(), feeds, outputPlaceholder);
   }
 }
 

--- a/aten/src/ATen/native/mps/operations/ActivationKernel.mm
+++ b/aten/src/ATen/native/mps/operations/ActivationKernel.mm
@@ -83,6 +83,17 @@ static void hardswish_backward_kernel(at::TensorIterator& iter) {
   lib.exec_binary_kernel(iter, "hardswish_backward");
 }
 
+static void threshold_kernel(TensorIteratorBase& iter, const Scalar& threshold, const Scalar& value) {
+  AT_DISPATCH_ALL_TYPES_AND3(c10::kHalf, c10::kBFloat16, c10::kBool, iter.common_dtype(), "threshold_mps", [&]() {
+    ThresholdParams<scalar_t> params{threshold.to<scalar_t>(), value.to<scalar_t>()};
+    lib.exec_binary_kernel_with_params(
+        iter,
+        "threshold",
+        params,
+        fmt::format("ThresholdParams_{}", mps::scalarToMetalTypeString(iter.common_dtype())));
+  });
+}
+
 static void elu_kernel(TensorIteratorBase& iter, const Scalar& alpha, const Scalar& scale, const Scalar& input_scale) {
   AT_DISPATCH_FLOATING_TYPES_AND2(c10::kHalf, c10::kBFloat16, iter.common_dtype(), "elu_mps", [&]() {
     ELUParams<scalar_t> params{alpha.to<scalar_t>(), scale.to<scalar_t>(), input_scale.to<scalar_t>()};
@@ -341,6 +352,7 @@ Tensor log_sigmoid_backward_mps(const Tensor& grad_output, const Tensor& self, c
   return grad_input;
 }
 
+REGISTER_DISPATCH(threshold_stub, threshold_kernel);
 REGISTER_DISPATCH(hardshrink_stub, hardshrink_kernel);
 REGISTER_DISPATCH(softshrink_stub, softshrink_kernel);
 REGISTER_DISPATCH(shrink_backward_stub, shrink_backward_kernel);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -6094,15 +6094,13 @@
   structured: True
   structured_inherits: TensorIteratorBase
   dispatch:
-    CPU, CUDA, XPU: threshold_out
-    MPS: threshold_out_mps
+    CPU, CUDA, XPU, MPS: threshold_out
 
 - func: threshold_backward.grad_input(Tensor grad_output, Tensor self, Scalar threshold, *, Tensor(a!) grad_input) -> Tensor(a!)
   structured: True
   structured_inherits: TensorIteratorBase
   dispatch:
-    CPU, CUDA, XPU: threshold_backward_out
-    MPS: threshold_backward_out_mps
+    CPU, CUDA, XPU, MPS: threshold_backward_out
     SparseCPU, SparseCUDA, SparseXPU: threshold_backward_sparse_out
     SparseCsrCPU, SparseCsrCUDA, SparseCsrMeta, SparseCsrXPU: threshold_backward_sparse_compressed_out
 

--- a/benchmarks/mps/bench_threshold.py
+++ b/benchmarks/mps/bench_threshold.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""A/B benchmark for MPS threshold/relu fwd+bwd (Metal vs MPSGraph baseline).
+
+Run once with a stock nightly (label=mpsgraph) and once with this build
+(label=metal); Timer.blocked_autorange median per cell.
+"""
+
+import argparse
+
+import torch
+import torch.nn.functional as F
+from torch.utils.benchmark import Timer
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--label", default="run")
+parser.add_argument(
+    "--dtype", default="float32", choices=["float32", "float16", "bfloat16"]
+)
+args = parser.parse_args()
+dtype = getattr(torch, args.dtype)
+
+print(f"label={args.label} dtype={args.dtype} torch={torch.__version__}")
+print(f"{'config':<36} {'median (ms)':>12}")
+shapes = [(1024,), (64, 4096), (512, 768), (2048, 2048), (16, 128, 1024)]
+for shape in shapes:
+    x = torch.randn(*shape, device="mps", dtype=dtype, requires_grad=True)
+    t = Timer(
+        stmt="y = F.threshold(x, 0.5, 0.0); y.backward(g); x.grad = None",
+        globals={"F": F, "x": x, "g": torch.ones(shape, device="mps", dtype=dtype)},
+    )
+    m = t.blocked_autorange(min_run_time=0.5).median * 1e3
+    print(f"threshold {str(shape):<26} {m:>12.3f}")
+    xr = torch.randn(*shape, device="mps", dtype=dtype, requires_grad=True)
+    tr = Timer(
+        stmt="y = torch.relu(xr); y.backward(g); xr.grad = None",
+        globals={
+            "torch": torch,
+            "xr": xr,
+            "g": torch.ones(shape, device="mps", dtype=dtype),
+        },
+    )
+    m = tr.blocked_autorange(min_run_time=0.5).median * 1e3
+    print(f"relu      {str(shape):<26} {m:>12.3f}")

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -25504,14 +25504,6 @@ python_ref_db = [
         "_refs.nn.functional.threshold",
         torch_opinfo_name="nn.functional.threshold",
         supports_out=True,
-        skips=(
-            # MPS threshold maps NaN to `value` (uses x > threshold), but the
-            # reference keeps NaN; mismatch only on float dtypes.
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref',
-                         device_type='mps', dtypes=(torch.float16, torch.bfloat16, torch.float32)),
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref_torch_fallback',
-                         device_type='mps', dtypes=(torch.float16, torch.bfloat16, torch.float32)),
-        ),
     ),
     PythonRefInfo(
         "_refs.nn.functional.dropout",


### PR DESCRIPTION
# [MPS] Migrate threshold and threshold_backward to Metal

## What / why

Part of #187455. `threshold_out_mps` and `threshold_backward_out_mps` are two of the
remaining `LookUpOrCreateCachedGraph` sites: each distinct shape compiles and caches an
MPSGraph with no eviction. Since `relu`'s backward routes through `threshold_backward`,
every ReLU training step grows the cache on shape-varying workloads.

The migration reuses upstream's design: the structured meta functions build the iterator as
`(self, other)` with `other = self` (forward) or `other = grad, value = 0` (backward), so a
single Metal functor `self <= threshold ? value : other` on the existing
`exec_binary_kernel_with_params` lineage serves both directions. The MPS structured impls
and their graph code are deleted (net -100 lines in Activation.mm) and the yaml dispatch
joins the shared `CPU, CUDA, XPU, MPS: threshold_out` / `threshold_backward_out` rows.
dtype surface is unchanged, including bool (MPS supports it beyond CPU per OpInfo
`dtypesIfMPS`).

**Semantics fix included:** the old MPSGraph path computed `x > threshold ? x : value`,
which sends NaN to `value`; the reference (and CPU/CUDA) keep NaN. The Metal functor matches
CPU/CUDA exactly, so the two now-stale MPS `expectedFailure` decorations on
`_refs.nn.functional.threshold` (test_python_ref / _torch_fallback, f16/bf16/f32) are
removed in this PR — those 6 instances now pass.

## Performance

Benchmark: `benchmarks/mps/bench_threshold.py` (committed). Interleaved A/B vs stock
nightly (MPSGraph), `Timer.blocked_autorange` median, 3 reps, M4 Pro.

Isolated op (no autograd), fp32:

| shape | MPSGraph (ms) | Metal (ms) | speedup |
|---|---|---|---|
| threshold_backward (2048, 1024) | 0.218 | 0.080 | 2.73x |
| threshold_backward (16, 128, 1024) | 0.086 | 0.080 | 1.08x |
| threshold_backward (2048, 2048) | 0.216 | 0.208 | 1.04x |

Composite fwd+bwd training step (fp32): threshold up to 5.7x (64x4096), relu backward
6.5x at small sizes, 1.4-2.1x typical; two mid-size composite cells read 0.87-0.92x under
streaming (no-sync) measurement while the isolated op wins on the same shapes -- a stream
pipelining artifact of the composite measurement, not kernel cost.

## Correctness / Test Plan

- `PYTORCH_TEST_MPS=1 python -m pytest test/test_mps.py -k "threshold or (consistency and relu)" -q`
  (43 passed; OpInfo owns coverage -- no new standalone test needed for an elementwise
  structured op).
- NaN semantics vs CPU: `F.threshold([nan, 1, 0], 0.5, -9)` returns `[nan, 1, -9]` on both.
- Registry goldens (`HasDecompTest`, `test_public_bindings`) clean; full `--mps` suite clean
  modulo the pre-existing `test_metal.py::...test_conv`.
- Known pre-existing limitations (shared with the `exec_binary_kernel` family, e.g.
  `elu_backward`, `add.out`): direct aten calls with mixed input dtypes or a mismatched
  `out=` dtype raise (missing cast-kernel variants); autograd never produces these, OpInfo
  declares `supports_out=False`. Documented for a follow-up on the shared infra.

## BC-breaking?

No public API change. NaN handling now matches CPU/CUDA (was silently divergent).

## Review history

Local review + gate dispositions: https://gist.github.com/5aa9907b58da25379e5a258aa357a198
