### PR TITLE
[inductor][rocm] Relax bf16 vmap-dot tolerance on gfx1100 as workaround

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -78,6 +78,7 @@ from torch.nn import functional as F
 from torch.testing import FileCheck, make_tensor
 from torch.testing._internal.common_cuda import (
     _get_torch_cuda_version,
+    _get_torch_rocm_version,
     IS_SM90,
     PLATFORM_SUPPORTS_FLASH_ATTENTION,
     PLATFORM_SUPPORTS_FP8,
@@ -4768,11 +4769,12 @@ for dtype in (torch.int32, torch.int64):
             return torch.dot(a, b) + torch.dot(a, b)
 
         fn = torch.vmap(dot_based)
-        is_gfx1100 = (
-            TEST_WITH_ROCM
-            and torch.cuda.get_device_properties(0).gcnArchName.split(":")[0]
-            == "gfx1100"
+        gcn_arch_name = (
+            torch.cuda.get_device_properties(0).gcnArchName.split(":")[0]
+            if TEST_WITH_ROCM
+            else ""
         )
+        is_gfx11_0_or_5_x = re.fullmatch(r"gfx11[05]\d", gcn_arch_name) is not None
         bmm_codegen_call = (
             "aoti_torch_cuda_bmm_out" if config.cpp_wrapper else "extern_kernels.bmm"
         )
@@ -4798,11 +4800,15 @@ for dtype in (torch.int32, torch.int64):
                     actual, code = run_and_get_code(
                         torch.compile(fn, fullgraph=True), a, b
                     )
-                    # TODO: Temporary workaround bf16 accuracy issue for gfx1100, remove once that it is fixed.
-                    # Root cause is incorrect calculation `expected` in eager mode that uses
-                    # rocBLAS(rocblas_gemvtsm_kernel) on gfx1100
-                    # RDNA4 is ok due to hipBLASLt uses by default.
-                    if is_gfx1100 and dtype == torch.bfloat16:
+                    # Workaround bf16 accuracy issue for gfx1100 root cause is incorrect calculation
+                    # `expected` in eager mode that uses rocBLAS(rocblas_gemvtsm_kernel) on gfx11[0|5]x
+                    # in case of usage of ROCM < 7.13
+                    if (
+                        TEST_WITH_ROCM
+                        and _get_torch_rocm_version() < (7, 13)
+                        and is_gfx11_0_or_5_x
+                        and dtype == torch.bfloat16
+                    ):
                         self.assertEqual(actual, expected, atol=0.05, rtol=0.1)
                     else:
                         self.assertEqual(actual, expected)

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4770,7 +4770,8 @@ for dtype in (torch.int32, torch.int64):
         fn = torch.vmap(dot_based)
         is_gfx1100 = (
             TEST_WITH_ROCM
-            and torch.cuda.get_device_properties(0).gcnArchName.split(":")[0] == "gfx1100"
+            and torch.cuda.get_device_properties(0).gcnArchName.split(":")[0]
+            == "gfx1100"
         )
         bmm_codegen_call = (
             "aoti_torch_cuda_bmm_out" if config.cpp_wrapper else "extern_kernels.bmm"

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4798,8 +4798,10 @@ for dtype in (torch.int32, torch.int64):
                     actual, code = run_and_get_code(
                         torch.compile(fn, fullgraph=True), a, b
                     )
-                    # TODO: Temporary workaround bf16 accuracy issue for gfx1100, remove once that ticket is fixed.
-                    # Issue created https://github.com/AMD-Triton/triton-tickets/issues/1909 to track the fix.
+                    # TODO: Temporary workaround bf16 accuracy issue for gfx1100, remove once that it is fixed.
+                    # Root cause is incorrect calculation `expected` in eager mode that uses
+                    # rocBLAS(rocblas_gemvtsm_kernel) on gfx1100
+                    # RDNA4 is ok due to hipBLASLt uses by default.
                     if is_gfx1100 and dtype == torch.bfloat16:
                         self.assertEqual(actual, expected, atol=0.05, rtol=0.1)
                     else:

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4768,6 +4768,10 @@ for dtype in (torch.int32, torch.int64):
             return torch.dot(a, b) + torch.dot(a, b)
 
         fn = torch.vmap(dot_based)
+        is_gfx1100 = (
+            TEST_WITH_ROCM
+            and torch.cuda.get_device_properties(0).gcnArchName.split(":")[0] == "gfx1100"
+        )
         bmm_codegen_call = (
             "aoti_torch_cuda_bmm_out" if config.cpp_wrapper else "extern_kernels.bmm"
         )
@@ -4793,7 +4797,12 @@ for dtype in (torch.int32, torch.int64):
                     actual, code = run_and_get_code(
                         torch.compile(fn, fullgraph=True), a, b
                     )
-                    self.assertEqual(actual, expected)
+                    # TODO: Temporary workaround bf16 accuracy issue for gfx1100, remove once that ticket is fixed.
+                    # Issue created https://github.com/AMD-Triton/triton-tickets/issues/1909 to track the fix.
+                    if is_gfx1100 and dtype == torch.bfloat16:
+                        self.assertEqual(actual, expected, atol=0.05, rtol=0.1)
+                    else:
+                        self.assertEqual(actual, expected)
                     code_str = "\n".join(code)
                     self.assertNotIn(bmm_codegen_call, code_str)
                     self.assertNotIn(bmm_fallback_call, code_str)


### PR DESCRIPTION
Workaround for ROCm `gfx1100` + `bfloat16` in `test_vmap_dot_decomposes_bmm` to pass CI while investigation on triton side.
On this platform/dtype combination, the small dot-shaped bmm decomposition path shows backend-specific numeric drift (rocBLAS library does incorrect calculation for bf16). This PR relaxes only the test tolerance for that exact case:
- detect `gfx1100` in the test
- ROCM < 7.13
- for `dtype=torch.bfloat16`, use `assertEqual(..., atol=0.05, rtol=0.1)`
- Workaround  for ROCM < 7.13 for passing test without these changes
```
TORCH_BLAS_PREFER_HIPBLASLT=1 PYTORCH_TEST_WITH_ROCM=1 python test/inductor/test_torchinductor.py -v GPUTests.test_vmap_dot_decompos
es_bmm_cuda
```
- **In main branch there is next commit that set hipblaslt as default blas backend:** https://github.com/pytorch/pytorch/commit/10a5f2ff7c90d8c84938b0e789ab2f4145f90b5d and it will fix this test when ROCM >= 7.13.


## Test
```bash
PYTORCH_TEST_WITH_ROCM=1 python test/inductor/test_torchinductor.py -v GPUTests.test_vmap_dot_decomposes_bmm_cuda
test_vmap_dot_decomposes_bmm_cuda (__main__.GPUTests) ... ok

----------------------------------------------------------------------
Ran 1 test in 5.696s

OK
```

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben