### PR TITLE
[TEST] Refactor test_c10d_spawn_ucc.py with hw_classification

### DIFF
--- a/test/distributed/test_c10d_spawn_ucc.py
+++ b/test/distributed/test_c10d_spawn_ucc.py
@@ -6,6 +6,7 @@ from test_c10d_spawn import _torch_dist_nn_available, TestDistributedNNFunctions
 import torch.distributed as c10d
 from torch.testing._internal.common_distributed import requires_ucc, skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     run_tests,
     skip_but_pass_in_sandcastle,
     skip_but_pass_in_sandcastle_if,
@@ -22,6 +23,8 @@ NO_UCC = not hasattr(c10d, "ProcessGroupUCC")
 if not TEST_WITH_DEV_DBG_ASAN:
 
     class TestDistributedNNFunctionsUcc(TestDistributedNNFunctions):
+        hw_classification = HardwareClassification.CUDA
+
         # Test Common Ops First.
         @requires_ucc()
         @skip_if_lt_x_gpu(2)


### PR DESCRIPTION
## Summary
- Classify `TestDistributedNNFunctionsUcc` as `CUDA`
- All 6 test methods require UCC backend with 2+ GPUs

Follows [RFC Test class classification](https://github.com/pytorch/pytorch/issues/185142).

cc @vishalgoyal316