### PR TITLE
Add missing skip markers to TestZeroRedundancyOptimizerDistributed

### DIFF
--- a/test/distributed/optim/test_zero_redundancy_optimizer.py
+++ b/test/distributed/optim/test_zero_redundancy_optimizer.py
@@ -482,6 +482,7 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
             s2.step()
             self.assertEqual(x, x2)
 
+    @skip_if_no_gpu
     def test_sharding(self):
         """
         Check ZeroRedundancyOptimizer's parameter sharding at construction
@@ -504,6 +505,7 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
             sum(sizes),
         )
 
+    @skip_if_no_gpu
     def test_add_param_group(self):
         """Check that ZeroRedundancyOptimizer properly handles adding a new
         parameter group a posteriori and that all ranks get a shard of the


### PR DESCRIPTION
The tests required GPUs and will fail hard in the `setup_pg` function when there are less than 2 GPUs available because `world_size` is always set to at least 2.