### PR TITLE
[cuda graphs] Standardize string annotations on the "name" key

### DIFF
--- a/test/test_cuda_graph_utils.py
+++ b/test/test_cuda_graph_utils.py
@@ -104,7 +104,7 @@ class TestMarkKernels(TestCase):
                 annotations,
                 lambda msg: f"{msg}\nmemset toolsId {hex(tools_id)} was not annotated",
             )
-            self.assertEqual(annotations[tools_id], [{"str": "reduction"}])
+            self.assertEqual(annotations[tools_id], [{"name": "reduction"}])
 
     def test_single_scope_at_capture_start_uses_root_fallback(self):
         graph = torch.cuda.CUDAGraph()
@@ -121,7 +121,7 @@ class TestMarkKernels(TestCase):
         self.assertGreater(len(annotations), 0)
         for anns in annotations.values():
             for ann in anns:
-                self.assertEqual(ann, {"str": "phase_a"})
+                self.assertEqual(ann, {"name": "phase_a"})
 
     def test_multiple_scopes_no_overlap(self):
         graph = torch.cuda.CUDAGraph()
@@ -138,9 +138,9 @@ class TestMarkKernels(TestCase):
         scope_2_ids = set()
         for tid, anns in annotations.items():
             self.assertEqual(len(anns), 1)
-            if anns[0] == {"str": "scope_1"}:
+            if anns[0] == {"name": "scope_1"}:
                 scope_1_ids.add(tid)
-            elif anns[0] == {"str": "scope_2"}:
+            elif anns[0] == {"name": "scope_2"}:
                 scope_2_ids.add(tid)
 
         self.assertGreater(len(scope_1_ids), 0)
@@ -208,7 +208,7 @@ class TestMarkKernels(TestCase):
         self.assertGreater(total_annotated, 0)
         for anns in annotations.values():
             for ann in anns:
-                self.assertEqual(ann, {"str": "tagged"})
+                self.assertEqual(ann, {"name": "tagged"})
 
     def test_nested_scopes_innermost_wins(self):
         """With nested string scopes, the innermost name wins."""
@@ -233,9 +233,9 @@ class TestMarkKernels(TestCase):
             )
             ann = anns[0]
             self.assertIsInstance(ann, dict)
-            if ann["str"] == "outer":
+            if ann["name"] == "outer":
                 outer_ids.add(tid)
-            elif ann["str"] == "inner":
+            elif ann["name"] == "inner":
                 inner_ids.add(tid)
 
         self.assertGreater(len(outer_ids), 0, "Should have outer-only kernels")
@@ -316,6 +316,28 @@ class TestMarkKernels(TestCase):
             self.assertEqual(ann["In msg nelems"], 1024)
             self.assertEqual(ann["dtype"], "bfloat16")
 
+    def test_string_scope_in_dict_scope_contends_for_name(self):
+        """A string annotation wraps to {"name": ...}, so a string scope
+        nested inside a dict scope with a "name" key contends for the same
+        slot; the inner scope wins. This pins the wrapped-string format and
+        the merge ordering as observable pickle-format behavior."""
+        graph = torch.cuda.CUDAGraph()
+        x = torch.randn(8, device="cuda")
+
+        with torch.cuda.graph(graph, enable_annotations=True):
+            with mark_kernels({"name": "outer", "dtype": "bfloat16"}):
+                with mark_kernels("inner"):
+                    _ = x + 1
+
+        annotations = get_kernel_annotations()
+        self.assertGreater(len(annotations), 0)
+        for anns in annotations.values():
+            self.assertEqual(len(anns), 1)
+            ann = anns[0]
+            # Inner string scope wins the "name" slot; outer-only keys survive.
+            self.assertEqual(ann["name"], "inner")
+            self.assertEqual(ann["dtype"], "bfloat16")
+
     def test_no_enable_records_nothing(self):
         # Without enable_annotations=True the capture is un-annotated, so
         # mark_kernels is a no-op and nothing is recorded.
@@ -343,7 +365,7 @@ class TestMarkKernels(TestCase):
         self.assertGreater(len(annotations), 0)
         for anns in annotations.values():
             for ann in anns:
-                self.assertEqual(ann, {"str": "auto"})
+                self.assertEqual(ann, {"name": "auto"})
 
     def test_enable_annotations_does_not_clear(self):
         """Annotations from a previous graph survive a second capture."""
@@ -495,7 +517,7 @@ class TestMarkKernels(TestCase):
         graph_ids_by_name: dict[str, set] = {}
         for tools_id, anns in get_kernel_annotations().items():
             self.assertEqual(len(anns), 1)
-            graph_ids_by_name.setdefault(anns[0]["str"], set()).add(tools_id >> 32)
+            graph_ids_by_name.setdefault(anns[0]["name"], set()).add(tools_id >> 32)
 
         self.assertIn("graph_a", graph_ids_by_name)
         self.assertIn("graph_b", graph_ids_by_name)
@@ -594,7 +616,7 @@ class TestMarkKernels(TestCase):
         annotations = get_kernel_annotations()
         self.assertEqual(len(annotations), 1)
         for anns in annotations.values():
-            self.assertEqual(anns, [{"str": "tagged"}])
+            self.assertEqual(anns, [{"name": "tagged"}])
 
 
 # cuda.bindings is NVIDIA-only; get_graph_data has no ROCm equivalent.
@@ -745,6 +767,52 @@ class TestRekeyAnnotations(TestCase):
         annotations = {self._tools_id(1, 10): original}
         _rekey_annotations(annotations, capture_graph_id=1, exec_graph_id=2)
         self.assertEqual(original, ["a"])
+
+
+# Pure trace-JSON logic, no CUDA needed. Pins the canonical annotation key
+# ("name") and reader tolerance for the two legacy pickle spellings: dicts
+# keyed "str" and bare unwrapped strings.
+class TestAnnotateTrace(TestCase):
+    @staticmethod
+    def _trace_with_kernel(graph_node_id):
+        return {
+            "traceEvents": [
+                {
+                    "ph": "X",
+                    "cat": "kernel",
+                    "name": "k",
+                    "pid": 0,
+                    "tid": 7,
+                    "ts": 100,
+                    "dur": 10,
+                    "args": {"graph node id": graph_node_id, "stream": 7},
+                }
+            ]
+        }
+
+    def _annotated_args(self, annotations):
+        from torch.cuda._annotate_cuda_graph_trace import annotate_trace
+
+        trace = self._trace_with_kernel(42)
+        count = annotate_trace(trace, annotations)
+        self.assertEqual(count, 1)
+        [event] = [e for e in trace["traceEvents"] if e.get("cat") == "kernel"]
+        return event["args"]
+
+    def test_canonical_name_key(self):
+        args = self._annotated_args({42: [{"name": "phase_a", "dtype": "bf16"}]})
+        self.assertEqual(args["name"], "phase_a")
+        self.assertEqual(args["dtype"], "bf16")
+
+    def test_legacy_str_key_maps_to_name(self):
+        args = self._annotated_args({42: [{"str": "phase_a"}]})
+        self.assertEqual(args["name"], "phase_a")
+        self.assertNotIn("str", args)
+
+    def test_legacy_bare_string_maps_to_name(self):
+        args = self._annotated_args({42: ["phase_a"]})
+        self.assertEqual(args["name"], "phase_a")
+        self.assertNotIn("annotation", args)
 
 
 if __name__ == "__main__":

--- a/torch/cuda/_annotate_cuda_graph_trace.py
+++ b/torch/cuda/_annotate_cuda_graph_trace.py
@@ -157,11 +157,14 @@ def annotate_trace(
             for ann in annotations[graph_node_id]:
                 if isinstance(ann, dict):
                     for key, value in ann.items():
-                        args[key] = str(value)
+                        # Legacy pickles wrapped bare strings as {"str": ...};
+                        # the canonical key is "name".
+                        args["name" if key == "str" else key] = str(value)
                     if "stream" in ann:
                         stream_id = int(ann["stream"])
                 else:
-                    args["annotation"] = str(ann)
+                    # Legacy pickles stored bare strings unwrapped.
+                    args["name"] = str(ann)
             annotated += 1
 
         # Reassign stream: use annotated stream if available, else default

--- a/torch/cuda/_graph_annotations.py
+++ b/torch/cuda/_graph_annotations.py
@@ -284,7 +284,7 @@ def mark_kernels(annotation: str | dict[str, Any]):
         return
 
     if isinstance(annotation, str):
-        annotation = {"str": annotation}
+        annotation = {"name": annotation}
 
     stream = _cuda_runtime.cudaStream_t(  # pyrefly: ignore[missing-attribute]
         init_value=torch.cuda.current_stream().cuda_stream
@@ -527,7 +527,7 @@ def mark_stream(stream: torch.cuda.Stream, annotation: str | dict[str, Any]):
             yield
     else:
         if isinstance(annotation, str):
-            annotation = {"str": annotation}
+            annotation = {"name": annotation}
         if isinstance(annotation, dict):
             annotation["stream"] = _get_stream_id(stream)
         with mark_kernels(annotation):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #189417
* __->__ #189406

mark_kernels spelled the same concept three ways: bare strings were
wrapped as {"str": ...} at the recording sites, the overlapping-scope
merge fallback in resolve_pending_annotations used "name", and the trace
post-processor rendered non-dict values under "annotation". The result
was that identical mark_kernels("phase_A") calls surfaced under
different args columns in Perfetto depending on which path the
annotation took, and downstream tooling had to know all three
spellings. This standardizes the pickled interchange format on
{"name": ...} before the API is made public, matching the convention
already used by dict-annotation callers and the merge fallback.

Recording sites (mark_kernels, mark_stream) now wrap bare strings as
{"name": ...}. The trace post-processor stays tolerant of both legacy
spellings so previously written annotation pickles still render: a
"str" dict key is rewritten to "name", and bare non-dict values now
land under "name" rather than "annotation". The alternative of keeping
the "annotation" fallback for bare values was rejected: it would
preserve byte-identical re-rendering of old pickles but carry the
legacy column indefinitely, defeating the point of converging on one
key.

Wrapping strings into dicts also makes the nested-scope merge ordering
observable: a string scope nested inside a dict scope that already has
a "name" key now contends for that slot (inner scope wins, per the
existing setdefault ordering). A new test pins that behavior, and a new
CUDA-free TestAnnotateTrace class pins the canonical key plus both
legacy-spelling tolerances in the post-processor.

Test Plan:

Ran the full test file on an H100 with cuda-bindings 13.x installed
(driver supports cudaGraphNodeGetToolsId, so the live-capture tests
run rather than skip):

```
python test/test_cuda_graph_utils.py
```

All 36 tests pass (0 skipped). Also verified end-to-end that a capture
with mark_kernels("phase_A") records [{"name": "phase_A"}] and that
annotate_trace renders it as a "name" args field on the matching
kernel event:

```
python -c "
import torch
from torch.cuda._graph_annotations import mark_kernels, get_kernel_annotations, clear_kernel_annotations
from torch.cuda._annotate_cuda_graph_trace import annotate_trace
clear_kernel_annotations()
g = torch.cuda.CUDAGraph()
x = torch.randn(8, device='cuda')
with torch.cuda.graph(g, enable_annotations=True):
    with mark_kernels('phase_A'):
        _ = x + 1
anns = get_kernel_annotations()
nid = next(iter(anns))
trace = {'traceEvents': [{'ph':'X','cat':'kernel','name':'k','pid':0,'tid':7,'ts':1,'dur':1,'args':{'graph node id': nid, 'stream': 7}}]}
annotate_trace(trace, dict(anns))
assert trace['traceEvents'][0]['args']['name'] == 'phase_A'
"
```

lintrunner is clean on the three changed files.

Authored with Claude Code.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>