### PR TITLE
[DO NOT MERGE] Test: re-enable test_optimizer_non_static_param for XPU

### DIFF
--- a/test/dynamo/test_logging.py
+++ b/test/dynamo/test_logging.py
@@ -1339,7 +1339,6 @@ TRACE FX call mul from test_logging.py:N in fn (LoggingTests.test_trace_call_pre
         self.assertGreater(len(records), 0)
         self.assertLess(len(records), 4)
 
-    @xfailIf(TEST_XPU)  # https://github.com/pytorch/pytorch/issues/157778
     @make_logging_test(perf_hints=True)
     @requires_gpu
     def test_optimizer_non_static_param(self, records):


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — CI Validation Test PR

This PR is created **only to validate CI behavior** for issue #188987.

### Purpose

Investigating CI failures in PR #189344. This test PR applies a **minimal fix** to confirm:
1. `test_recompiles` passes when imports are kept (no line number shift)
2. Shard 7 failure is infrastructure-only (not code-related)

### Changes

**Only removes the `@xfailIf(TEST_XPU)` decorator** — no import cleanup:

```diff
-    @xfailIf(TEST_XPU)  # https://github.com/pytorch/pytorch/issues/157778
     @make_logging_test(perf_hints=True)
     @requires_gpu
     def test_optimizer_non_static_param(self, records):
```

### Background

PR #189344 also removed `TEST_XPU` and `xfailIf` imports, causing all subsequent line numbers to shift by -2. This broke `test_recompiles` which hardcodes absolute line numbers for stack trace validation.

Root cause analysis:
- `test_recompiles` uses hardcoded line numbers 201, 204, 207, 210
- Removing 2 import lines shifts these to 199, 202, 205, 208  
- Updating expected values would be 削足适履 (wrong approach)
- Correct fix: keep PR minimal — no import cleanup

### Validation

Test passes on PVC hardware (Intel Data Center GPU Max 1550):
- Hardware: PVC x8
- PyTorch: 2.14.0.dev20260707+xpu
- oneAPI: 2026.0.0
- Result: ✅ PASS

Closes #188987

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98