### PR TITLE
[test] Add missing @onlyCUDA decorator to test_honor_sm_carveout

### DIFF
--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -1840,6 +1840,7 @@ class TestFP8Matmul(TestCase):
         self.assertEqual(out_fp32, out_fp8.to(torch.float))
 
     @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/164271")
+    @onlyCUDA
     @unittest.skipIf(IS_WINDOWS, "Windows doesn't support row-wise scaling")
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
     @unittest.skipIf(not SM90OrLater, "sm89 kernel isn't opted into carveout yet")


### PR DESCRIPTION
## Summary

Adds missing `@onlyCUDA` decorator to `test_honor_sm_carveout` to prevent the CPU test variant from failing.

## Problem

The test uses `torch.profiler.ProfilerActivity.CUDA` to profile CUDA kernel grid sizes. When `instantiate_device_type_tests` generates a CPU variant, the CUDA profiler returns zero events, causing:

```
ValueError: not enough values to unpack (expected 4, got 0)
```

when the test attempts to unpack exactly 4 kernel events from the profiler output.

## Root Cause

This decorator was previously added in #184771 (commit `53826ac579e`) but accidentally removed the next day by the automated skip-inliner in #185013 (commit `9661ae6e541`) which replaced `@onlyCUDA` with `@skipIfRocm` instead of preserving both.

## Changes

```diff
 @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/164271")
+@onlyCUDA
 @unittest.skipIf(IS_WINDOWS, "Windows doesn't support row-wise scaling")
 @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
 @unittest.skipIf(not SM90OrLater, "sm89 kernel isn't opted into carveout yet")
 def test_honor_sm_carveout(self, device) -> None:
```

Both decorators are needed:
- `@skipIfRocm` - Skip on ROCm (issue #164271)
- `@onlyCUDA` - Skip on CPU (test profiles CUDA kernels)

## Test Plan

**Before fix:**
```bash
$ python3 test/test_scaled_matmul_cuda.py TestFP8MatmulCPU.test_honor_sm_carveout_cpu -v
...
ValueError: not enough values to unpack (expected 4, got 0)
FAILED
```

**After fix:**
```bash
$ python3 test/test_scaled_matmul_cuda.py TestFP8MatmulCPU.test_honor_sm_carveout_cpu -v
test_honor_sm_carveout_cpu (__main__.TestFP8MatmulCPU) ... skipped 'Only runs on cuda'
----------------------------------------------------------------------
Ran 1 test in 0.001s
OK (skipped=1)
```

Tested locally and confirmed the fix resolves the issue.

---

Fixes #189409

cc:@ezyang, @RiyaP2508, @drisspg, @slayton58
