### PR TITLE
Add public torch.cuda.graph_annotations module

### DIFF
--- a/docs/source/cuda.md
+++ b/docs/source/cuda.md
@@ -115,6 +115,97 @@
     export_graph_data
 ```
 
+## Graph Kernel Annotations (prototype)
+
+`torch.cuda.graph_annotations` annotates the kernels captured in a CUDA
+graph with user metadata, keyed so the annotations can be joined against
+the ``graph node id`` field on kernel events in profiler traces. Enable
+recording per capture with the ``enable_annotations`` argument of
+{class}`torch.cuda.graph`, then wrap regions of the captured workload in
+{func}`~torch.cuda.graph_annotations.mark_kernels` scopes.
+
+These APIs require the `cuda-bindings` package and a CUDA driver that
+supports ``cudaGraphNodeGetToolsId`` (CUDA 13.1 or newer, or an equivalent
+cuda-compat package); recording silently degrades to a no-op otherwise, and
+is not supported on ROCm. Use
+{func}`~torch.cuda.graph_annotations.is_available` to check support.
+
+The end-to-end workflow: annotate during capture, profile the replay,
+then merge the annotations into the exported trace and view it in
+[Perfetto](https://ui.perfetto.dev). During capture:
+
+```python
+import torch
+from torch.cuda.graph_annotations import mark_kernels, get_kernel_annotations
+
+x = torch.randn(1024, 1024, device="cuda")
+
+# Warmup: run the workload once outside capture so lazy initialization
+# (e.g. cuBLAS handles) does not end up in -- or invalidate -- the capture.
+y = x @ x.t()
+z = torch.relu(y) @ x
+torch.cuda.synchronize()
+
+g = torch.cuda.CUDAGraph()
+with torch.cuda.graph(g, enable_annotations=True):
+    with mark_kernels("attention"):
+        y = x @ x.t()
+    with mark_kernels({"name": "mlp", "layer": 3}):
+        z = torch.relu(y) @ x
+
+with torch.profiler.profile() as prof:
+    g.replay()
+    torch.cuda.synchronize()
+prof.export_chrome_trace("trace.json")
+```
+
+Each kernel event in the exported trace carries a ``graph node id`` in its
+``args``; the recorded annotations are keyed by the same ids, so merging
+them into the trace is a dictionary lookup:
+
+```python
+import json
+
+annotations = get_kernel_annotations()
+with open("trace.json") as f:
+    trace = json.load(f)
+for event in trace["traceEvents"]:
+    node_id = event.get("args", {}).get("graph node id")
+    for ann in annotations.get(node_id, []):
+        event["args"].update(ann)
+with open("trace_annotated.json", "w") as f:
+    json.dump(trace, f)
+```
+
+Opening ``trace_annotated.json`` in [Perfetto](https://ui.perfetto.dev)
+(or ``chrome://tracing``) and clicking a kernel from the graph replay now
+shows the annotation fields -- ``name: attention`` or ``name: mlp``,
+``layer: 3`` -- alongside the kernel's grid and block sizes, identifying
+which region of the captured workload each kernel came from.
+
+Because annotations live in a process-global registry keyed by ids that
+match the profiler's, the pickle of ``dict(get_kernel_annotations())``
+can equally be saved next to a trace and joined offline.
+
+```{eval-rst}
+.. currentmodule:: torch.cuda.graph_annotations
+```
+
+```{eval-rst}
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    is_available
+    mark_kernels
+    get_kernel_annotations
+    clear_kernel_annotations
+```
+
+```{eval-rst}
+.. currentmodule:: torch.cuda
+```
+
 (cuda-memory-management-api)=
 
 ```{eval-rst}
@@ -341,6 +432,10 @@ deprecated compatibility APIs.
 
 ```{eval-rst}
 .. py:module:: torch.cuda.gds
+```
+
+```{eval-rst}
+.. py:module:: torch.cuda.graph_annotations
 ```
 
 ```{eval-rst}

--- a/test/test_cuda_graph_utils.py
+++ b/test/test_cuda_graph_utils.py
@@ -10,13 +10,16 @@ from torch.cuda._graph_annotations import (
     _get_stream_id,
     _is_tools_id_unavailable,
     _rekey_annotations,
-    clear_kernel_annotations,
-    get_kernel_annotations,
-    mark_kernels,
     mark_stream,
     resolve_pending_annotations,
 )
 from torch.cuda._utils import _check_cuda_bindings
+from torch.cuda.graph_annotations import (
+    clear_kernel_annotations,
+    get_kernel_annotations,
+    is_available,
+    mark_kernels,
+)
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
@@ -767,6 +770,14 @@ class TestRekeyAnnotations(TestCase):
         annotations = {self._tools_id(1, 10): original}
         _rekey_annotations(annotations, capture_graph_id=1, exec_graph_id=2)
         self.assertEqual(original, ["a"])
+
+
+# Runs everywhere (no capture): the public probe must agree with the private
+# gate that mark_kernels no-ops on, whatever this machine supports.
+class TestIsAvailable(TestCase):
+    def test_matches_private_gate(self):
+        expected = torch.cuda.is_available() and not _is_tools_id_unavailable()
+        self.assertEqual(is_available(), expected)
 
 
 # Pure trace-JSON logic, no CUDA needed. Pins the canonical annotation key

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -2000,7 +2000,7 @@ def _compile_kernel(
         return getattr(result, mangled_name)
 
 
-from . import amp, jiterator, nvtx, profiler, sparse, tunable
+from . import amp, graph_annotations, jiterator, nvtx, profiler, sparse, tunable
 
 
 _POOL_HANDLE = NewType("_POOL_HANDLE", tuple[int, int])
@@ -2084,6 +2084,7 @@ __all__ = [
     "get_stream_from_external",
     "get_sync_debug_mode",
     "graph",
+    "graph_annotations",
     "graph_pool_handle",
     "graphs",
     "has_half",

--- a/torch/cuda/_graph_annotations.py
+++ b/torch/cuda/_graph_annotations.py
@@ -36,11 +36,17 @@ Usage during capture::
     annotations = get_kernel_annotations()
 """
 
+from __future__ import annotations
+
 import importlib.metadata
 from collections import defaultdict
 from contextlib import contextmanager
 from logging import getLogger
-from typing import Any, TypeAlias
+from typing import Any, TYPE_CHECKING, TypeAlias
+
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 import torch
 from torch.cuda._utils import (
@@ -131,6 +137,22 @@ def _is_tools_id_unavailable() -> bool:
         return not _tools_id_available
     _tools_id_available = _probe_tools_id()
     return not _tools_id_available
+
+
+def is_available() -> bool:
+    r"""is_available() -> bool
+
+    Return whether CUDA graph annotation recording is supported.
+
+    Requires a CUDA device, the ``cuda-bindings`` package, and a driver
+    that supports ``cudaGraphNodeGetToolsId`` (CUDA >= 13.1 or an
+    equivalent cuda-compat package). When this returns ``False``,
+    :func:`mark_kernels` is a silent no-op and no annotations are
+    recorded.
+
+    The first call may probe the CUDA driver; the result is cached.
+    """
+    return torch.cuda.is_available() and not _is_tools_id_unavailable()
 
 
 def _get_capture_state(stream: Any) -> _CaptureState | None:
@@ -258,26 +280,48 @@ _pending_scopes: list[tuple[Any, list[int]]] = []
 
 @contextmanager  # type: ignore[arg-type]
 def mark_kernels(annotation: str | dict[str, Any]):
-    """Context manager that records new scope nodes for later annotation.
+    r"""mark_kernels(annotation)
 
-    During capture, records the current stream frontier and its existing
-    direct dependents on entry. On scope exit, traces only the dependent
-    nodes added since entry. After capture, ``resolve_pending_annotations``
-    merges overlapping scopes and stores the final toolsId annotations.
-    If the scope is the first captured work, the entry frontier is empty,
-    so ``mark_kernels`` falls back to the newly created graph roots.
+    Context manager that annotates GPU work captured within its scope.
 
-    Must be called inside an active ``torch.cuda.graph()`` capture. The
-    nodes you expect to annotate must be reachable from the stream frontier
-    that is current on entry. If work runs on a different already-capturing
-    branch, it must first be synchronized with the current stream so that
-    branch becomes reachable from the entry frontier. If the current stream
-    is not capturing, or if ``cudaGraphNodeGetToolsId`` is not available,
-    the context manager is a no-op.
+    Must be used inside an active :class:`torch.cuda.graph` capture with
+    ``enable_annotations=True``. Every kernel, memcpy, and memset node the
+    capture adds within the scope is tagged with :attr:`annotation`. Outside
+    a capture, with annotations disabled, or when :func:`is_available` is
+    ``False``, the context manager is a no-op.
+
+    When scopes overlap on the same node (e.g. nested scopes), their
+    annotation dicts are merged key-by-key with the inner scope winning
+    common keys.
+
+    Implementation: on entry, records the current stream's capture frontier
+    and its existing direct dependents; on scope exit, walks only the
+    dependent nodes added since entry (falling back to newly created graph
+    roots when the scope is the first captured work).
 
     Args:
-        annotation: Arbitrary object appended to the annotation list for
-            every kernel/memcpy/memset node captured within this scope.
+        annotation (str or dict): Metadata to attach to each captured node.
+            A string ``s`` is recorded as ``{"name": s}``. Dict values must
+            be picklable. The key ``"name"`` names the region in trace
+            tooling; ``"stream"`` is reserved for stream-lane assignment.
+
+    .. note::
+        The nodes to annotate must be reachable from the capture frontier of
+        the stream that is current on scope entry. Work on a different
+        already-capturing stream must be synchronized with the current
+        stream first.
+
+    .. warning::
+        This API is in prototype and may change in future releases.
+
+    Example::
+
+        >>> # xdoctest: +SKIP("requires cuda-bindings and driver >= 13.1")
+        >>> g = torch.cuda.CUDAGraph()
+        >>> x = torch.randn(8, device="cuda")
+        >>> with torch.cuda.graph(g, enable_annotations=True):
+        ...     with torch.cuda.graph_annotations.mark_kernels("phase_A"):
+        ...         y = x + 1
     """
     if not _annotations_enabled or _is_tools_id_unavailable():
         yield
@@ -375,13 +419,13 @@ def resolve_pending_annotations() -> None:
             for tools_id in tools_ids:
                 per_tools_id[tools_id].append(annotation)
 
-        for tools_id, annotations in per_tools_id.items():
-            if len(annotations) == 1:
-                _kernel_annotations[tools_id].append(annotations[0])
+        for tools_id, ann_list in per_tools_id.items():
+            if len(ann_list) == 1:
+                _kernel_annotations[tools_id].append(ann_list[0])
                 continue
 
             merged: dict[str, Any] = {}
-            for annotation in annotations:
+            for annotation in ann_list:
                 if isinstance(annotation, dict):
                     for key, value in annotation.items():
                         merged.setdefault(key, value)
@@ -468,13 +512,49 @@ def _rekey_annotations(
     return remapped
 
 
-def get_kernel_annotations() -> dict[int, list[Any]]:
-    """Return the current kernel annotation map (toolsId -> annotations)."""
+def get_kernel_annotations() -> Mapping[int, list[Any]]:
+    r"""get_kernel_annotations() -> Mapping[int, list]
+
+    Return the live registry of recorded kernel annotations.
+
+    Keys are opaque integers matching the ``graph node id`` field that
+    CUPTI-based profilers attach to kernel events; values are the lists of
+    annotation dicts recorded for that node. The registry accumulates
+    across captures and is global to the process.
+
+    The returned mapping is a **live view**: it is updated in place when a
+    graph is instantiated (annotation keys are rekeyed to the executable
+    graph's ids), so a reference obtained early stays current. Keys are
+    valid for joining against a profiler trace once the corresponding
+    graphs have been instantiated. Treat the mapping as read-only; snapshot
+    it with ``dict(...)`` if isolation is needed.
+
+    .. warning::
+        This API is in prototype and may change in future releases.
+
+    Example::
+
+        >>> # xdoctest: +SKIP("requires cuda-bindings and driver >= 13.1")
+        >>> annotations = torch.cuda.graph_annotations.get_kernel_annotations()
+        >>> with open("annotations.pkl", "wb") as f:
+        ...     pickle.dump(dict(annotations), f)
+    """
     return _kernel_annotations
 
 
 def clear_kernel_annotations() -> None:
-    """Clear all recorded kernel annotations and pending scopes."""
+    r"""clear_kernel_annotations() -> None
+
+    Clear all recorded kernel annotations.
+
+    The annotation registry is process-global and accumulates across
+    captures; long-running workloads that capture many graphs should clear
+    it once recorded annotations have been consumed (e.g. after saving
+    them alongside a profiler trace).
+
+    .. warning::
+        This API is in prototype and may change in future releases.
+    """
     _kernel_annotations.clear()
     _pending_scopes.clear()
 

--- a/torch/cuda/graph_annotations.py
+++ b/torch/cuda/graph_annotations.py
@@ -1,0 +1,57 @@
+r"""Annotate kernels captured in CUDA graphs for profiler traces.
+
+During CUDA graph capture, :func:`mark_kernels` tags the GPU work nodes
+(kernels, memcpys, memsets) captured within its scope with user metadata.
+The recorded annotations are keyed by the same ``graph node id`` values
+that CUPTI-based profilers attach to kernel events during graph replay, so
+the annotations can later be joined against a profiler trace to identify
+which kernels belong to which region of the captured workload.
+
+Annotation recording is enabled per capture via the ``enable_annotations``
+argument of :class:`torch.cuda.graph`::
+
+    import torch
+    from torch.cuda.graph_annotations import mark_kernels, get_kernel_annotations
+
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g, enable_annotations=True):
+        with mark_kernels("phase_A"):
+            y = workload_a(x)
+        with mark_kernels({"name": "phase_B", "dtype": "bf16"}):
+            z = workload_b(y)
+
+    annotations = get_kernel_annotations()
+
+The annotation mapping is typically pickled and joined against a profiler
+trace offline (matching each kernel event's ``graph node id`` field).
+
+Requires the ``cuda-bindings`` package and a CUDA driver that supports
+``cudaGraphNodeGetToolsId`` (CUDA >= 13.1, or an equivalent cuda-compat
+package). When unavailable, recording silently degrades to a no-op; use
+:func:`is_available` to check support programmatically.
+
+.. warning::
+    This API is in prototype and may change in future releases.
+"""
+
+from torch.cuda._graph_annotations import (
+    clear_kernel_annotations,
+    get_kernel_annotations,
+    is_available,
+    mark_kernels,
+)
+
+
+__all__ = [
+    "clear_kernel_annotations",
+    "get_kernel_annotations",
+    "is_available",
+    "mark_kernels",
+]
+
+# The implementation lives in the private module (which predates this one and
+# has external users); re-export and claim the names so they present as
+# torch.cuda.graph_annotations APIs (test_correct_module_names requires it).
+for _name in __all__:
+    globals()[_name].__module__ = "torch.cuda.graph_annotations"
+del _name


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #189417
* #189406

Makes the CUDA graph kernel-annotation API public as
torch.cuda.graph_annotations, documented as a prototype. The existing
private module torch.cuda._graph_annotations has external users and is
kept as the implementation; the public module re-exports the public
names from it rather than moving the code, so downstream copies of the
implementation file keep their sync surface. The re-exported functions'
__module__ is set to the public module so they present as
torch.cuda.graph_annotations APIs (test_correct_module_names requires
this). Wrapper functions in the public module were considered and
rejected in favor of plain re-exports.

The initial public surface is deliberately minimal: mark_kernels,
get_kernel_annotations, clear_kernel_annotations, and a new
is_available() probe. Everything else (mark_stream, the resolve/remap
plumbing, get_stream_for_pg, the trace post-processing CLI) stays
private: the resolve/remap steps are driven automatically by
torch.cuda.graph(..., enable_annotations=True), and the rest needs
design work before committing to it.

The documented contract deliberately keeps the annotation keys opaque
("integers matching the profiler's graph node id field") rather than
exposing the toolsId bit packing, and documents get_kernel_annotations
as returning a live Mapping view: annotations are rekeyed in place when
a graph is instantiated (deferred for keep_graph=True), so a reference
obtained early stays current, whereas returning a copy would silently
pickle stale capture-keyed ids.

Review order: torch/cuda/_graph_annotations.py (the public docstrings,
which carry the API contract, now live on the implementation functions;
also adds is_available and renames a local that shadowed the
__future__ annotations import), then the thin re-export module
torch/cuda/graph_annotations.py, the torch.cuda __init__/__all__
wiring, the docs section in cuda.md (including an end-to-end example
from capture through profiler export to viewing annotated kernels in
Perfetto), and finally the test updates which switch to importing the
public names and add an is_available test.

Test Plan:

Ran the full test file on an H100 with cuda-bindings 13.x installed
(driver supports cudaGraphNodeGetToolsId, so live-capture tests run
rather than skip); 37 tests pass, 0 skipped:

```
python test/test_cuda_graph_utils.py
```

Public-API gate:

```
python -m pytest test/test_public_bindings.py::TestPublicBindings::test_correct_module_names -q
```

passes. test_modules_can_be_imported fails identically with and without
this change on this machine (pre-existing missing optional deps:
onnxscript, coremltools, cupti).

Docs build: ran the Sphinx coverage builder (the CI docs-coverage
gate):

```
cd docs && python -m sphinx -b coverage source build/coverage
```

build succeeded; build/coverage/python.txt reports
torch.cuda.graph_annotations at 100% coverage, 0 undocumented, TOTAL 0
undocumented.

The end-to-end example added to cuda.md was executed verbatim on this
machine: capture with mark_kernels scopes, profile the replay, export
the Chrome trace, join annotations by "graph node id", and verify all
3 replayed kernels carry the expected fields (name: attention /
name: mlp, layer: 3) in the annotated trace. The example includes the
warmup step that live execution showed to be required (cuBLAS lazy
init otherwise invalidates the capture).

Verified the public surface directly: torch.cuda.graph_annotations is
importable, "graph_annotations" is in torch.cuda.__all__, every name
in the module's __all__ is identical to (is) the private module's
object with __module__ set to the public module, and is_available()
returns True on this machine.

lintrunner is clean on all changed files.

Authored with Claude Code.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>