### PR TITLE
[TEST] Actually check the required number of gpus in `test_dtensor_pp_integration`

### DIFF
--- a/test/distributed/pipelining/test_dtensor_pp_integration.py
+++ b/test/distributed/pipelining/test_dtensor_pp_integration.py
@@ -33,7 +33,6 @@ from torch.testing._internal.common_distributed import (
 from torch.testing._internal.common_utils import (
     run_tests,
     skip_but_pass_in_sandcastle_if,
-    TEST_MULTIACCELERATOR,
 )
 
 
@@ -140,7 +139,8 @@ def _loss_fn(output: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
 def _requires_multi_gpu(func):
     @requires_accelerator_dist_backend(["nccl", "xccl"])
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 4+ GPUs"
+        torch.accelerator.device_count() < 4,
+        f"{backend} test requires 4+ GPUs",
     )
     @functools.wraps(func)
     def wrapper(*args, **kwargs):


### PR DESCRIPTION
test requires 4 gpu but only checked multigpu

authored with codex

cc @mruberry