### PR TITLE
[MPS] Migrate addcmul/addcdiv to Metal (takes the AdamW inner loop off the graph cache)

### DIFF
--- a/aten/src/ATen/native/mps/MetalShaderLibrary.h
+++ b/aten/src/ATen/native/mps/MetalShaderLibrary.h
@@ -192,7 +192,11 @@ class MetalShaderLibrary {
       const std::optional<c10::ScalarType> scalar_arg_type = std::nullopt,
       const std::optional<c10::ScalarType> natural_output_dtype = std::nullopt,
       const std::optional<uint32_t> ilp_threshold = std::nullopt);
-  void exec_ternary_kernel(TensorIteratorBase& iter, const std::string& name);
+  void exec_ternary_kernel(
+      TensorIteratorBase& iter,
+      const std::string& name,
+      const std::optional<c10::Scalar> alpha = std::nullopt,
+      const std::optional<c10::ScalarType> scalar_arg_type = std::nullopt);
 
   template <typename T>
   void exec_unary_kernel_with_params(

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -1582,7 +1582,10 @@ void MetalShaderLibrary::exec_binary_kernel(TensorIteratorBase& iter,
   });
 }
 
-void MetalShaderLibrary::exec_ternary_kernel(TensorIteratorBase& iter, const std::string& name) {
+void MetalShaderLibrary::exec_ternary_kernel(TensorIteratorBase& iter,
+                                             const std::string& name,
+                                             const std::optional<c10::Scalar> alpha,
+                                             const std::optional<c10::ScalarType> scalar_arg_type) {
   // TODO: Figure a better place to downcast double scalars (probably in tensor iterator itself?)
   // Right now running something like 1.0-torch.rand(5, device='mps') will create iterator with
   // double as common dtype (because Python floating point are always 64-bit values)
@@ -1593,10 +1596,11 @@ void MetalShaderLibrary::exec_ternary_kernel(TensorIteratorBase& iter, const std
     return;
   }
 
-  // Decompose 64-bit tensor into 32-bit ones
+  // Decompose 64-bit tensor into 32-bit ones (must recurse into the TERNARY
+  // exec, not the binary one: sub-iters have three inputs).
   if (!iter.can_use_32bit_indexing()) {
     for (auto&& sub_iter : iter.with_32bit_indexing()) {
-      exec_binary_kernel(sub_iter, name);
+      exec_ternary_kernel(sub_iter, name, alpha, scalar_arg_type);
     }
     return;
   }
@@ -1622,13 +1626,20 @@ void MetalShaderLibrary::exec_ternary_kernel(TensorIteratorBase& iter, const std
   convert_double_scalar(other2);
 
   MPSStream* mpsStream = getCurrentMPSStream();
-  const auto cast_needed =
-      (input.scalar_type() != other1.scalar_type()) || (input.scalar_type() != other2.scalar_type());
+  // out= with a dtype differing from the compute dtype also takes the cast
+  // kernel: the name is keyed on out, so the out-typed instantiation reads the
+  // runtime-typed inputs and stores natively (the graph path used castMPSTensor
+  // for the same purpose).
+  const auto cast_needed = (input.scalar_type() != other1.scalar_type()) ||
+      (input.scalar_type() != other2.scalar_type()) || (out.scalar_type() != input.scalar_type());
   const auto suffix = iter.is_contiguous() ? "dense" : "strided";
+  const auto alpha_type = scalar_arg_type.value_or(alpha.has_value() ? alpha->type() : iter.common_dtype());
+  const auto alpha_suffix = alpha.has_value() ? fmt::format("_{}", scalarToMetalTypeString(alpha_type)) : "";
   // TODO: Implicitly pass both input and output types to non-cast kernels
   const auto kernel_name = cast_needed
-      ? fmt::format("{}_{}_cast_{}", name, suffix, scalarToMetalTypeString(out))
-      : fmt::format("{}_{}_{}_{}", name, suffix, scalarToMetalTypeString(out), scalarToMetalTypeString(input));
+      ? fmt::format("{}_{}_cast_{}{}", name, suffix, scalarToMetalTypeString(out), alpha_suffix)
+      : fmt::format(
+            "{}_{}_{}_{}{}", name, suffix, scalarToMetalTypeString(out), scalarToMetalTypeString(input), alpha_suffix);
   dispatch_sync_with_rethrow(mpsStream->queue(), ^() {
     @autoreleasepool {
       auto computeEncoder = mpsStream->commandEncoder();
@@ -1638,6 +1649,11 @@ void MetalShaderLibrary::exec_ternary_kernel(TensorIteratorBase& iter, const std
       [computeEncoder setComputePipelineState:binaryPSO];
       // Set input and output tensors
       bind_iter_tensors(computeEncoder, iter);
+      // Alpha rides at buffer 4 (right after the tensors); the shape/type
+      // extras shift to 5 in the _alpha kernel variants.
+      if (alpha) {
+        mtl_setArgs<4>(computeEncoder, getMPSScalar(*alpha, alpha_type));
+      }
       // Iterator is contiguous if all of its elements are dense in storage,
       // i.e. it's true for both row-first and column-first tensors
       if (iter.is_contiguous()) {
@@ -1648,7 +1664,11 @@ void MetalShaderLibrary::exec_ternary_kernel(TensorIteratorBase& iter, const std
           std::array<int, 3> types = {static_cast<int>(input.scalar_type()),
                                       static_cast<int>(other1.scalar_type()),
                                       static_cast<int>(other2.scalar_type())};
-          mtl_setArgs<4>(computeEncoder, sizes, types);
+          if (alpha) {
+            mtl_setArgs<5>(computeEncoder, sizes, types);
+          } else {
+            mtl_setArgs<4>(computeEncoder, sizes, types);
+          }
         }
       } else {
         // Please note that shapes and strides of the iterator might be
@@ -1658,14 +1678,25 @@ void MetalShaderLibrary::exec_ternary_kernel(TensorIteratorBase& iter, const std
                                     static_cast<int>(other1.scalar_type()),
                                     static_cast<int>(other2.scalar_type()),
                                     static_cast<int>(out.scalar_type())};
-        mtl_setArgs<4>(computeEncoder,
-                       iter.shape(),
-                       iter.strides(0),
-                       iter.strides(1),
-                       iter.strides(2),
-                       iter.strides(3),
-                       iter.ndim(),
-                       types);
+        if (alpha) {
+          mtl_setArgs<5>(computeEncoder,
+                         iter.shape(),
+                         iter.strides(0),
+                         iter.strides(1),
+                         iter.strides(2),
+                         iter.strides(3),
+                         iter.ndim(),
+                         types);
+        } else {
+          mtl_setArgs<4>(computeEncoder,
+                         iter.shape(),
+                         iter.strides(0),
+                         iter.strides(1),
+                         iter.strides(2),
+                         iter.strides(3),
+                         iter.ndim(),
+                         types);
+        }
       }
       mtl_dispatch1DJob(computeEncoder, binaryPSO, iter.numel());
       getMPSProfiler().endProfileKernel(binaryPSO);

--- a/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
@@ -854,3 +854,36 @@ INSTANTIATE_LERP(half);
 INSTANTIATE_LERP(bfloat);
 INSTANTIATE_LERP(float2);
 INSTANTIATE_LERP(long);
+
+struct addcmul_functor {
+  template <typename T, typename TA>
+  inline T operator()(const T a, const T b, const T c, const TA alpha) {
+    return static_cast<T>(
+        a + c10::metal::mul(static_cast<T>(alpha), c10::metal::mul(b, c)));
+  }
+};
+
+struct addcdiv_functor {
+  template <typename T, typename TA>
+  inline T operator()(const T a, const T b, const T c, const TA alpha) {
+    return static_cast<T>(
+        a + c10::metal::mul(static_cast<T>(alpha), c10::metal::div(b, c)));
+  }
+};
+
+REGISTER_OPMATH_TERNARY_ALPHA_OP(addcmul, float, float, float);
+REGISTER_OPMATH_TERNARY_ALPHA_OP(addcmul, half, float, half);
+REGISTER_OPMATH_TERNARY_ALPHA_OP(addcmul, bfloat, float, bfloat);
+REGISTER_TERNARY_ALPHA_OP(addcmul, long, long, long);
+REGISTER_TERNARY_ALPHA_OP(addcmul, int, int, int);
+REGISTER_TERNARY_ALPHA_OP(addcmul, short, short, short);
+REGISTER_TERNARY_ALPHA_OP(addcmul, char, char, char);
+REGISTER_TERNARY_ALPHA_OP(addcmul, uchar, uchar, uchar);
+REGISTER_TERNARY_ALPHA_OP(addcmul, float2, float2, float2);
+REGISTER_TERNARY_ALPHA_OP(addcmul, half2, half2, half2);
+
+REGISTER_OPMATH_TERNARY_ALPHA_OP(addcdiv, float, float, float);
+REGISTER_OPMATH_TERNARY_ALPHA_OP(addcdiv, half, float, half);
+REGISTER_OPMATH_TERNARY_ALPHA_OP(addcdiv, bfloat, float, bfloat);
+REGISTER_TERNARY_ALPHA_OP(addcdiv, float2, float2, float2);
+REGISTER_TERNARY_ALPHA_OP(addcdiv, half2, half2, half2);

--- a/aten/src/ATen/native/mps/operations/PointwiseOps.mm
+++ b/aten/src/ATen/native/mps/operations/PointwiseOps.mm
@@ -1,116 +1,35 @@
 //  Copyright © 2022 Apple Inc.
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/Dispatch.h>
+#include <ATen/TensorIterator.h>
+#include <ATen/native/PointwiseOps.h>
 #include <ATen/native/mps/OperationUtils.h>
 
-#ifndef AT_PER_OPERATOR_HEADERS
-#include <ATen/Functions.h>
-#include <ATen/NativeFunctions.h>
-#else
-#include <ATen/ops/addcdiv_native.h>
-#include <ATen/ops/addcmul_native.h>
-#endif
 namespace at::native {
-// scope the MPS's internal methods to not expose them to at::native
-namespace mps {
 
-static void addc_mul_div_out_mps(const Tensor& self,
-                                 const Tensor& tensor1,
-                                 const Tensor& tensor2,
-                                 const Scalar& value_opt, // default value = 1.0
-                                 const Tensor& output,
-                                 const bool is_div,
-                                 const std::string& op_name) {
-  if (value_opt.toDouble() == 0.0) {
-    output.copy_(self);
-    return;
-  }
+#ifndef PYTORCH_JIT_COMPILE_SHADERS
+static auto& lib = mps::MetalShaderLibrary::getBundledLibrary();
+#else
+#include <ATen/native/mps/BinaryKernel_metallib.h>
+#endif
 
-  if (output.numel() == 0) {
-    return;
-  }
-
-  MPSStream* mpsStream = getCurrentMPSStream();
-
-  struct CachedGraph : public MPSCachedGraph {
-    CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
-    MPSGraphTensor *inputTensor = nil, *outputTensor = nil;
-    MPSGraphTensor *firstTensor = nil, *secondTensor = nil, *valueTensor = nil;
-  };
-
-  @autoreleasepool {
-    bool contiguousOutput = !needsGather(output);
-    Tensor output_ = output;
-    if (!contiguousOutput) {
-      output_ = at::empty_like(self, MemoryFormat::Contiguous);
-    }
-
-    std::string key = op_name + getTensorsStringKey({self, tensor1, tensor2});
-
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      ScalarType common_dtype =
-          c10::promoteTypes(self.scalar_type(), c10::promoteTypes(tensor1.scalar_type(), tensor2.scalar_type()));
-      newCachedGraph->inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
-      newCachedGraph->firstTensor = mpsGraphRankedPlaceHolder(mpsGraph, tensor1);
-      newCachedGraph->secondTensor = mpsGraphRankedPlaceHolder(mpsGraph, tensor2);
-      newCachedGraph->valueTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSScalarType(self.scalar_type()), @[ @1 ]);
-
-      // the tensor to be optionally multiplied by value_scalar
-      MPSGraphTensor* multiplicandTensor = nil;
-      auto firstTensor = castMPSTensor(mpsGraph, newCachedGraph->firstTensor, common_dtype);
-      auto secondTensor = castMPSTensor(mpsGraph, newCachedGraph->secondTensor, common_dtype);
-      if (is_div) {
-        multiplicandTensor = [mpsGraph divisionWithPrimaryTensor:firstTensor secondaryTensor:secondTensor name:nil];
-      } else {
-        multiplicandTensor = [mpsGraph multiplicationWithPrimaryTensor:firstTensor
-                                                       secondaryTensor:secondTensor
-                                                                  name:nil];
-      }
-      // the tensor to be added to input_tensor
-      MPSGraphTensor* addendTensor =
-          [mpsGraph multiplicationWithPrimaryTensor:multiplicandTensor
-                                    secondaryTensor:castMPSTensor(mpsGraph, newCachedGraph->valueTensor, common_dtype)
-                                               name:nil];
-      auto outputTensor =
-          [mpsGraph additionWithPrimaryTensor:castMPSTensor(mpsGraph, newCachedGraph->inputTensor, common_dtype)
-                              secondaryTensor:addendTensor
-                                         name:nil];
-      newCachedGraph->outputTensor = castMPSTensor(mpsGraph, outputTensor, output.scalar_type());
-    });
-
-    // Inputs as placeholders
-    Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor, self);
-    Placeholder tensor1Placeholder = Placeholder(cachedGraph->firstTensor, tensor1);
-    Placeholder tensor2Placeholder = Placeholder(cachedGraph->secondTensor, tensor2);
-    Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor, !contiguousOutput ? output_ : output);
-    MPSScalar value_scalar = getMPSScalar(value_opt, self.scalar_type());
-
-    // Create dictionary of inputs and outputs
-    NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* feeds = @{
-      selfPlaceholder.getMPSGraphTensor() : selfPlaceholder.getMPSGraphTensorData(),
-      tensor1Placeholder.getMPSGraphTensor() : tensor1Placeholder.getMPSGraphTensorData(),
-      tensor2Placeholder.getMPSGraphTensor() : tensor2Placeholder.getMPSGraphTensorData(),
-      cachedGraph->valueTensor : getMPSGraphTensorFromScalar(mpsStream, value_scalar),
-    };
-
-    runMPSGraph(mpsStream, cachedGraph->graph(), feeds, outputPlaceholder);
-
-    if (!contiguousOutput) {
-      output.copy_(output_);
-    }
-  }
+// value stays at float precision for reduced-float dtypes (CPU uses
+// value.to<float>, CUDA an accscalar); quantizing it to half/bfloat first
+// diverges (e.g. sub-denormal values silently become 0) and Scalar::to<Half>
+// is a checked conversion that would throw for out-of-range values.
+static c10::ScalarType addc_alpha_type(c10::ScalarType common) {
+  return c10::isReducedFloatingType(common) ? c10::ScalarType::Float : common;
 }
 
-} // namespace mps
-
-// APIs exposed to at::native scope
-TORCH_IMPL_FUNC(addcmul_out_mps)
-(const Tensor& self, const Tensor& tensor1, const Tensor& tensor2, const Scalar& value, const Tensor& output) {
-  mps::addc_mul_div_out_mps(self, tensor1, tensor2, value, output, false, "addcmul_out_mps");
+static void addcmul_mps_kernel(TensorIteratorBase& iter, const Scalar& value) {
+  lib.exec_ternary_kernel(iter, "addcmul", value, addc_alpha_type(iter.output().scalar_type()));
 }
 
-TORCH_IMPL_FUNC(addcdiv_out_mps)
-(const Tensor& self, const Tensor& tensor1, const Tensor& tensor2, const Scalar& value, const Tensor& output) {
-  mps::addc_mul_div_out_mps(self, tensor1, tensor2, value, output, true, "addcdiv_out_mps");
+static void addcdiv_mps_kernel(TensorIteratorBase& iter, const Scalar& value) {
+  lib.exec_ternary_kernel(iter, "addcdiv", value, addc_alpha_type(iter.output().scalar_type()));
 }
+
+REGISTER_DISPATCH(addcmul_stub, addcmul_mps_kernel)
+REGISTER_DISPATCH(addcdiv_stub, addcdiv_mps_kernel)
 
 } // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -9371,8 +9371,7 @@
   structured_inherits: TensorIteratorBase
   device_check: NoCheck   # TensorIterator
   dispatch:
-    CPU, CUDA, MTIA, XPU: addcmul_out
-    MPS: addcmul_out_mps
+    CPU, CUDA, MTIA, XPU, MPS: addcmul_out
   tags: pointwise
 
 - func: addcmul(Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1) -> Tensor
@@ -9392,8 +9391,7 @@
   structured_inherits: TensorIteratorBase
   device_check: NoCheck   # TensorIterator
   dispatch:
-    CPU, CUDA, MTIA, XPU: addcdiv_out
-    MPS: addcdiv_out_mps
+    CPU, CUDA, MTIA, XPU, MPS: addcdiv_out
   tags: pointwise
 
 - func: addcdiv(Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1) -> Tensor

--- a/c10/metal/indexing.h
+++ b/c10/metal/indexing.h
@@ -1500,6 +1500,105 @@ kernel void ternary_dense_cast(
   out[tid] = static_cast<res_t>(f(a, b, c));
 }
 
+// Ternary-with-alpha variants (e.g. addcmul/addcdiv's `value` scalar): the
+// alpha rides as a typed kernel argument right after the tensor operands.
+template <typename T, typename TA, typename F, typename om_t = T>
+kernel void ternary_alpha_strided(
+    device void* output [[buffer(0)]],
+    constant void* input [[buffer(1)]],
+    constant void* other1 [[buffer(2)]],
+    constant void* other2 [[buffer(3)]],
+    constant TA& alpha [[buffer(4)]],
+    constant long* sizes [[buffer(5)]],
+    constant long* output_strides [[buffer(6)]],
+    constant long* input_strides [[buffer(7)]],
+    constant long* other1_strides [[buffer(8)]],
+    constant long* other2_strides [[buffer(9)]],
+    constant uint& ndim [[buffer(10)]],
+    uint index [[thread_position_in_grid]]) {
+  F f;
+  using res_t = result_of<F, T, T, T, TA>;
+  int pos[max_ndim];
+  pos_from_thread_index(int(index), pos, sizes, ndim);
+  const auto input_offs = offset_from_coord(pos, input_strides, ndim);
+  const auto other1_offs = offset_from_coord(pos, other1_strides, ndim);
+  const auto other2_offs = offset_from_coord(pos, other2_strides, ndim);
+  const auto output_offs = offset_from_coord(pos, output_strides, ndim);
+  const auto a = val_at_offs<T>(input, input_offs);
+  const auto b = val_at_offs<T>(other1, other1_offs);
+  const auto c = val_at_offs<T>(other2, other2_offs);
+  ref_at_offs<res_t>(output, output_offs) =
+      static_cast<res_t>(f(om_t(a), om_t(b), om_t(c), alpha));
+}
+
+template <typename T, typename TA, typename F, typename om_t = opmath_t<T>>
+kernel void ternary_alpha_strided_cast(
+    device void* output [[buffer(0)]],
+    constant void* input [[buffer(1)]],
+    constant void* other1 [[buffer(2)]],
+    constant void* other2 [[buffer(3)]],
+    constant TA& alpha [[buffer(4)]],
+    constant long* sizes [[buffer(5)]],
+    constant long* output_strides [[buffer(6)]],
+    constant long* input_strides [[buffer(7)]],
+    constant long* other1_strides [[buffer(8)]],
+    constant long* other2_strides [[buffer(9)]],
+    constant uint& ndim [[buffer(10)]],
+    constant uint4& types [[buffer(11)]],
+    uint index [[thread_position_in_grid]]) {
+  F f;
+  using res_t = result_of<F, T, T, T, TA>;
+  int pos[max_ndim];
+  pos_from_thread_index(int(index), pos, sizes, ndim);
+  const auto input_offs = offset_from_coord(pos, input_strides, ndim);
+  const auto other1_offs = offset_from_coord(pos, other1_strides, ndim);
+  const auto other2_offs = offset_from_coord(pos, other2_strides, ndim);
+  const auto output_offs = offset_from_coord(pos, output_strides, ndim);
+  const auto a =
+      val_at_offs<om_t>(input, input_offs, static_cast<ScalarType>(types.x));
+  const auto b =
+      val_at_offs<om_t>(other1, other1_offs, static_cast<ScalarType>(types.y));
+  const auto c =
+      val_at_offs<om_t>(other2, other2_offs, static_cast<ScalarType>(types.z));
+  ref_at_offs<res_t>(output, output_offs) =
+      static_cast<res_t>(f(a, b, c, alpha));
+}
+
+template <typename T, typename TA, typename F, typename om_t = T>
+kernel void ternary_alpha_dense(
+    device result_of<F, T, T, T, TA>* out [[buffer(0)]],
+    constant T* input [[buffer(1)]],
+    constant T* other1 [[buffer(2)]],
+    constant T* other2 [[buffer(3)]],
+    constant TA& alpha [[buffer(4)]],
+    uint tid [[thread_position_in_grid]]) {
+  F f;
+  using res_t = result_of<F, T, T, T, TA>;
+  out[tid] = static_cast<res_t>(
+      f(om_t(input[tid]), om_t(other1[tid]), om_t(other2[tid]), alpha));
+}
+
+template <typename T, typename TA, typename F, typename om_t = T>
+kernel void ternary_alpha_dense_cast(
+    device result_of<F, T, T, T, TA>* out [[buffer(0)]],
+    constant void* input [[buffer(1)]],
+    constant void* other1 [[buffer(2)]],
+    constant void* other2 [[buffer(3)]],
+    constant TA& alpha [[buffer(4)]],
+    constant uint3& sizes [[buffer(5)]],
+    constant uint3& types [[buffer(6)]],
+    uint tid [[thread_position_in_grid]]) {
+  F f;
+  using res_t = result_of<F, T, T, T, TA>;
+  const auto a =
+      val_at_offs<om_t>(input, tid * sizes.x, static_cast<ScalarType>(types.x));
+  const auto b = val_at_offs<om_t>(
+      other1, tid * sizes.y, static_cast<ScalarType>(types.y));
+  const auto c = val_at_offs<om_t>(
+      other2, tid * sizes.z, static_cast<ScalarType>(types.z));
+  out[tid] = static_cast<res_t>(f(a, b, c, alpha));
+}
+
 #define REGISTER_TERNARY_OP_(NAME, DTYPEI, DTYPEO, OMT)                        \
   static_assert(                                                               \
       ::metal::is_same_v<                                                      \
@@ -1553,6 +1652,76 @@ kernel void ternary_dense_cast(
           constant uint3& sizes,                                               \
           constant uint3& types,                                               \
           uint tid)
+
+#define REGISTER_TERNARY_ALPHA_OP_(NAME, DTYPEI, DTYPEA, DTYPEO, OMT)         \
+  static_assert(                                                              \
+      ::metal::is_same_v<                                                     \
+          DTYPEO,                                                             \
+          ::c10::metal::                                                      \
+              result_of<NAME##_functor, DTYPEI, DTYPEI, DTYPEI, DTYPEA>>,     \
+      "Output dtype mismatch for ternary op " #NAME " and input " #DTYPEI);   \
+  template [[host_name(#NAME "_strided_" #DTYPEO "_" #DTYPEI                  \
+                             "_" #DTYPEA)]] kernel void ::c10::metal::        \
+      ternary_alpha_strided<DTYPEI, DTYPEA, NAME##_functor, OMT>(             \
+          device void* out,                                                   \
+          constant void* input,                                               \
+          constant void* other1,                                              \
+          constant void* other2,                                              \
+          constant DTYPEA& alpha,                                             \
+          constant long* sizes,                                               \
+          constant long* output_strides,                                      \
+          constant long* input_strides,                                       \
+          constant long* other1_strides,                                      \
+          constant long* other2_strides,                                      \
+          constant uint& ndim,                                                \
+          uint tid);                                                          \
+  template [[host_name(#NAME "_strided_cast_" #DTYPEI                         \
+                             "_" #DTYPEA)]] kernel void ::c10::metal::        \
+      ternary_alpha_strided_cast<DTYPEI, DTYPEA, NAME##_functor, OMT>(        \
+          device void* out,                                                   \
+          constant void* input,                                               \
+          constant void* other1,                                              \
+          constant void* other2,                                              \
+          constant DTYPEA& alpha,                                             \
+          constant long* sizes,                                               \
+          constant long* output_strides,                                      \
+          constant long* input_strides,                                       \
+          constant long* other1_strides,                                      \
+          constant long* other2_strides,                                      \
+          constant uint& ndim,                                                \
+          constant uint4& types,                                              \
+          uint tid);                                                          \
+  template [[host_name(#NAME "_dense_" #DTYPEO "_" #DTYPEI                    \
+                             "_" #DTYPEA)]] kernel void ::c10::metal::        \
+      ternary_alpha_dense<DTYPEI, DTYPEA, NAME##_functor, OMT>(               \
+          device ::c10::metal::                                               \
+                  result_of<NAME##_functor, DTYPEI, DTYPEI, DTYPEI, DTYPEA> * \
+              out_,                                                           \
+          constant DTYPEI * input_,                                           \
+          constant DTYPEI * other1_,                                          \
+          constant DTYPEI * other2_,                                          \
+          constant DTYPEA & alpha,                                            \
+          uint tid);                                                          \
+  template [[host_name(#NAME "_dense_cast_" #DTYPEI                           \
+                             "_" #DTYPEA)]] kernel void ::c10::metal::        \
+      ternary_alpha_dense_cast<DTYPEI, DTYPEA, NAME##_functor, OMT>(          \
+          device ::c10::metal::                                               \
+                  result_of<NAME##_functor, DTYPEI, DTYPEI, DTYPEI, DTYPEA> * \
+              out_,                                                           \
+          constant void* input,                                               \
+          constant void* other1,                                              \
+          constant void* other2,                                              \
+          constant DTYPEA& alpha,                                             \
+          constant uint3& sizes,                                              \
+          constant uint3& types,                                              \
+          uint tid)
+
+#define REGISTER_TERNARY_ALPHA_OP(NAME, DTYPEI, DTYPEA, DTYPEO) \
+  REGISTER_TERNARY_ALPHA_OP_(NAME, DTYPEI, DTYPEA, DTYPEO, DTYPEI)
+
+#define REGISTER_OPMATH_TERNARY_ALPHA_OP(NAME, DTYPEI, DTYPEA, DTYPEO) \
+  REGISTER_TERNARY_ALPHA_OP_(                                          \
+      NAME, DTYPEI, DTYPEA, DTYPEO, ::c10::metal::opmath_t<DTYPEI>)
 
 // OpMath ternary Op promotes inputs to higher precision type before Functor
 // call

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -3304,6 +3304,34 @@ class TestMPS(TestCaseMPS):
         helper((2, 8, 4, 5), 0.2)
         helper((2, 3, 4, 5), 1.0)  # value of 1 should be ignored internally
 
+    def test_addcdiv_complex32(self):
+        # complex32 has no CPU addcdiv, so compare against a widened complex64
+        # CPU reference (the graph path supported chalf; the Metal kernels must
+        # keep it).
+        x = torch.randn(64, dtype=torch.complex64)
+        y = torch.randn(64, dtype=torch.complex64)
+        z = torch.randn(64, dtype=torch.complex64)
+        z = torch.where(z.abs() < 0.1, z + 0.5, z)  # avoid division blowups
+        expected = torch.addcdiv(x, y, z, value=0.5)
+        actual = torch.addcdiv(x.to(torch.complex32).to('mps'),
+                               y.to(torch.complex32).to('mps'),
+                               z.to(torch.complex32).to('mps'), value=0.5)
+        self.assertEqual(actual.cpu().to(torch.complex64), expected, atol=1e-2, rtol=1e-2)
+
+    def test_addcmul_addcdiv_out_dtype(self):
+        # out= with a dtype differing from the inputs takes the cast kernel
+        # (the graph path handled this via castMPSTensor).
+        for op in (torch.addcmul, torch.addcdiv):
+            for in_dt, out_dt in ((torch.float32, torch.float16), (torch.float16, torch.float32)):
+                x = torch.randn(32, dtype=in_dt)
+                y = torch.randn(32, dtype=in_dt)
+                z = torch.randn(32, dtype=in_dt).abs().clamp_min(0.25)
+                out_mps = torch.empty(32, dtype=out_dt, device='mps')
+                out_cpu = torch.empty(32, dtype=out_dt)
+                op(x.to('mps'), y.to('mps'), z.to('mps'), value=0.5, out=out_mps)
+                op(x, y, z, value=0.5, out=out_cpu)
+                self.assertEqual(out_mps.cpu(), out_cpu, atol=2e-3, rtol=2e-3)
+
     def test_addcdiv_transpose(self):
         # Regression test for issue https://github.com/pytorch/pytorch/issues/118115
         # Testing continuity of all input tensors

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -13464,8 +13464,6 @@ op_db: list[OpInfo] = [
            skips=(
                # TODO: update sample inputs with for_inplace_variant kwarg to support this test
                DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_variant_consistency_eager'),
-               # AssertionError: The supported dtypes for addcmul on device type mps are incorrect!
-               DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes', device_type='mps'),
            ),
            sample_inputs_func=sample_inputs_addcmul_addcdiv,
            reference_inputs_func=partial(
@@ -26409,19 +26407,6 @@ python_ref_db = [
                          dtypes=(torch.float16,), device_type="cpu"),
             DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_python_ref_torch_fallback',
                          dtypes=(torch.float16,), device_type="cpu"),
-            # AssertionError: Tensor-likes are not close!
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_python_ref', device_type='mps', dtypes=(
-                    torch.uint8, torch.int8, torch.int64, torch.int32,
-                    torch.int16,
-                )
-            ),
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_python_ref_torch_fallback', device_type='mps', dtypes=(
-                    torch.uint8, torch.int8, torch.int64, torch.int32,
-                    torch.int16,
-                )
-            ),
         ),
     ),
     ElementwiseBinaryPythonRefInfo(


### PR DESCRIPTION
# [MPS] Migrate addcmul/addcdiv to Metal (takes the AdamW inner loop off the graph cache)

## What / why

Part of #187455. `addc_mul_div_out_mps` is the PointwiseOps graph-cache site: every distinct
parameter shape compiles and caches an MPSGraph. Adam/AdamW call `addcmul_`/`addcdiv_`
per parameter, per step, so shape-varying training grows the cache continuously and every
small parameter tensor pays graph lookup/encode overhead each iteration.

Infrastructure (reusable): `c10/metal/indexing.h` gains `ternary_alpha_{dense,strided}[_cast]`
kernel templates and `REGISTER_TERNARY_ALPHA_OP` (twinning the binary-alpha convention), and
`exec_ternary_kernel` threads an optional `Scalar` alpha. The op layer is then small:
functors via `c10::metal::mul/div` in BinaryKernel.metal, stub registrations replacing 116
lines of graph code in PointwiseOps.mm, and the yaml rows joining the shared
`CPU, CUDA, MTIA, XPU, MPS` structured impls.

**Three MPSGraph-era divergences from CPU/CUDA are fixed by the migration** (each was
encoded in stale xfails/skips, removed here):
- integer addcmul computed wrong results (xfailed "Tensor-likes are not close" on all int
  dtypes; the Metal kernels compute ints exactly, and `test_dtypes`' "supported dtypes are
  incorrect" xfail is gone too);
- the `value` scalar was quantized to half/bfloat before computing (CPU uses
  `value.to<float>`, CUDA an accscalar): sub-denormal values silently became 0 — biasing
  fp16 optimizer steps — and out-of-range values threw a spurious overflow error; alpha now
  rides at float precision for reduced-float dtypes;
- `value == 0` short-circuited to `copy_(self)`, masking the div-by-zero NaNs CPU/CUDA
  produce; `addcdiv(a, b, 0, value=0)` is now NaN on both.

Also fixes a latent infra bug: `exec_ternary_kernel`'s 64-bit split recursed into
`exec_binary_kernel` (wrong arity).

## Performance

Benchmark: `benchmarks/mps/bench_addcmul.py` (committed). Interleaved A/B vs stock nightly,
`Timer.blocked_autorange` median, 3 reps, M4 Pro, fp32:

| cell | MPSGraph (ms) | Metal (ms) | speedup |
|---|---|---|---|
| addcmul (4096,) | 0.1102 | 0.0023 | 47.9x |
| addcdiv (4096,) | 0.0150 | 0.0024 | 6.3x |
| addcmul (4096, 4096) | 1.376 | 1.186 | 1.16x |
| addcmul (1048576,) | 0.0431 | 0.0419 | 1.03x |
| addcdiv (1048576,) / (4096,4096) / 3D | — | — | 0.99–1.00x |
| addcmul_ strided (2048,2048)ᵀ in-place | 0.1993 | 0.2029 | 0.98x |

Small parameter-sized tensors (the optimizer case) win dramatically — the graph
lookup/encode overhead dominated them; large tensors are memory-bound parity. 9 cells,
zero < 0.95x.

## Correctness / Test Plan

- `PYTORCH_TEST_MPS=1 python -m pytest test/test_mps.py -k "addcmul or addcdiv" -q` (20
  OpInfo cases) and `test/test_ops.py -k "addcmul and mps"` (38 passed — including the
  previously-xfailed integer `_refs` cases, which now match CPU).
- Smoke: f32/f16/bf16 (incl. `value=1e-7` and `1e5` parity vs CPU), int dtypes,
  strided+broadcast, complex64+complex32 (chalf keeps its pre-existing support),
  `value==0` zero-divisor parity, live fp32+fp16 AdamW steps.
- Full `--mps` suite clean modulo the pre-existing `test_metal.py::...test_conv`.
- Coverage owner: OpInfo (elementwise structured op); no standalone test added.

## BC-breaking?

No public API change. Integer results, reduced-float `value` handling, and `value==0`
NaN propagation now match CPU/CUDA (all three were silently divergent).

## Review history

Local review + gate dispositions: https://gist.github.com/5aa9907b58da25379e5a258aa357a198



---

## Update: complex32 addcdiv restored + cross-dtype `out=` fixed

Responding to review: the initial head dropped two behaviors the MPSGraph path supported.

- **complex32 `addcdiv`**: the graph ran chalf addcdiv (runtime-verified on the graph-path build); the Metal registrations covered `addcmul` half2 but not `addcdiv`. Registered now (`c10::metal::div` is complex-generic), with a chalf test against a widened complex64 CPU reference.
- **`out=` with a dtype differing from the inputs**: the graph cast results via `castMPSTensor`; the ternary path's `cast_needed` only considered input dtypes, so e.g. `torch.addcmul(f32, f32, f32, out=f16)` failed PSO lookup. `cast_needed` now includes the out-dtype mismatch — the out-keyed cast instantiation reads runtime-typed inputs and stores natively — and the alpha suffix keys off the output dtype so cast host_names line up. Tested f32<->f16 both ops vs CPU.
- One documented divergence toward higher precision: f16 inputs with an f32 `out=` now compute at float (CPU computes at the common f16 and upcasts on store).

Review log: https://gist.github.com/anagnorisis2peripeteia/54527b98ae3f3edcef0bbe17bf863c27
