### PR TITLE
Fix gammainc docstring example to call gammainc, not gammaincc

### DIFF
--- a/torch/special/__init__.py
+++ b/torch/special/__init__.py
@@ -922,8 +922,7 @@ Example::
 
     >>> a1 = torch.tensor([4.0])
     >>> a2 = torch.tensor([3.0, 4.0, 5.0])
-    >>> a = torch.special.gammaincc(a1, a2)
-    tensor([0.3528, 0.5665, 0.7350])
+    >>> a = torch.special.gammainc(a1, a2)
     tensor([0.3528, 0.5665, 0.7350])
     >>> b = torch.special.gammainc(a1, a2) + torch.special.gammaincc(a1, a2)
     tensor([1., 1., 1.])


### PR DESCRIPTION
### Description

The `Example::` block in the `torch.special.gammainc` docstring calls `torch.special.gammaincc` (the upper / complementary incomplete gamma function) even though it is documenting `gammainc` (the lower one), and the displayed result is the *lower* value. So the shown code does not produce the shown output. The example also duplicates its output line.

Concretely, the current example reads:

```
>>> a1 = torch.tensor([4.0])
>>> a2 = torch.tensor([3.0, 4.0, 5.0])
>>> a = torch.special.gammaincc(a1, a2)
tensor([0.3528, 0.5665, 0.7350])
tensor([0.3528, 0.5665, 0.7350])
>>> b = torch.special.gammainc(a1, a2) + torch.special.gammaincc(a1, a2)
tensor([1., 1., 1.])
```

But `[0.3528, 0.5665, 0.7350]` is the output of `gammainc`, not `gammaincc`:

```
>>> torch.special.gammainc(torch.tensor([4.0]), torch.tensor([3.0, 4.0, 5.0]))
tensor([0.3528, 0.5665, 0.7350])
>>> torch.special.gammaincc(torch.tensor([4.0]), torch.tensor([3.0, 4.0, 5.0]))
tensor([0.6472, 0.4335, 0.2650])
```

This is a copy-paste slip from the sibling `gammaincc` example just below it. This PR points the example at `gammainc` and removes the duplicated output line, matching the `gammaincc` example's format.

Docs-only change; no functional code is touched.
