### PR TITLE
Add mode="eager-numerics" and accuracy_high sugar to torch.compile

### DIFF
--- a/test/inductor/test_config.py
+++ b/test/inductor/test_config.py
@@ -194,6 +194,30 @@ class TestInductorConfig(TestCase):
             max_autotune_no_cudagraphs_opts.get("triton.cudagraphs", False), False
         )
 
+        max_precision_opts = torch._inductor.list_mode_options("max-precision")
+        self.assertEqual(max_precision_opts["emulate_precision_casts"], True)
+        self.assertEqual(
+            max_precision_opts["eager_numerics.use_pytorch_libdevice"], True
+        )
+        self.assertEqual(max_precision_opts["use_fast_math"], False)
+
+    def test_accuracy_high(self):
+        opt_fn = torch.compile(dummy_fn, accuracy_high=True)
+        compiler_config = opt_fn.get_compiler_config()
+        for key, value in torch._inductor.list_mode_options("max-precision").items():
+            self.assertEqual(compiler_config[key], value)
+
+        self.assertRaises(
+            RuntimeError,
+            lambda: torch.compile(dummy_fn, accuracy_high=True, mode="max-autotune"),
+        )
+        self.assertRaises(
+            RuntimeError,
+            lambda: torch.compile(
+                dummy_fn, accuracy_high=True, options={"max_autotune": True}
+            ),
+        )
+
     def test_invalid_backend(self):
         self.assertRaises(
             torch._dynamo.exc.InvalidBackend,

--- a/test/inductor/test_config.py
+++ b/test/inductor/test_config.py
@@ -194,17 +194,17 @@ class TestInductorConfig(TestCase):
             max_autotune_no_cudagraphs_opts.get("triton.cudagraphs", False), False
         )
 
-        max_precision_opts = torch._inductor.list_mode_options("max-precision")
-        self.assertEqual(max_precision_opts["emulate_precision_casts"], True)
+        eager_numerics_opts = torch._inductor.list_mode_options("eager-numerics")
+        self.assertEqual(eager_numerics_opts["emulate_precision_casts"], True)
         self.assertEqual(
-            max_precision_opts["eager_numerics.use_pytorch_libdevice"], True
+            eager_numerics_opts["eager_numerics.use_pytorch_libdevice"], True
         )
-        self.assertEqual(max_precision_opts["use_fast_math"], False)
+        self.assertEqual(eager_numerics_opts["use_fast_math"], False)
 
     def test_accuracy_high(self):
         opt_fn = torch.compile(dummy_fn, accuracy_high=True)
         compiler_config = opt_fn.get_compiler_config()
-        for key, value in torch._inductor.list_mode_options("max-precision").items():
+        for key, value in torch._inductor.list_mode_options("eager-numerics").items():
             self.assertEqual(compiler_config[key], value)
 
         self.assertRaises(

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -3083,6 +3083,7 @@ def compile(
     name: str | None = None,
     disable: builtins.bool = False,
     dynamic_shapes: _Any = None,
+    accuracy_high: builtins.bool = False,
 ) -> _Callable[_InputT, _RetT]: ...
 
 
@@ -3099,6 +3100,7 @@ def compile(
     name: str | None = None,
     disable: builtins.bool = False,
     dynamic_shapes: _Any = None,
+    accuracy_high: builtins.bool = False,
 ) -> _Callable[[_Callable[_InputT, _RetT]], _Callable[_InputT, _RetT]]: ...
 
 
@@ -3116,6 +3118,7 @@ def compile(
     recompile_limit: builtins.int | None = None,
     isolate_recompiles: builtins.bool = False,
     dynamic_shapes: _Any = None,
+    accuracy_high: builtins.bool = False,
 ) -> (
     _Callable[[_Callable[_InputT, _RetT]], _Callable[_InputT, _RetT]]
     | _Callable[_InputT, _RetT]
@@ -3160,7 +3163,8 @@ def compile(
 
         - To register an out-of-tree custom backend:
           https://docs.pytorch.org/docs/main/user_guide/torch_compiler/torch.compiler_custom_backends.html#registering-custom-backends
-       mode (str): Can be either "default", "reduce-overhead", "max-autotune" or "max-autotune-no-cudagraphs"
+       mode (str): Can be either "default", "reduce-overhead", "max-autotune", "max-autotune-no-cudagraphs"
+        or "max-precision"
 
         - "default" is the default mode, which is a good balance between performance and overhead
 
@@ -3177,6 +3181,13 @@ def compile(
           It enables CUDA graphs by default on GPU.
 
         - "max-autotune-no-cudagraphs" is a mode similar to "max-autotune" but without CUDA graphs
+
+        - "max-precision" is a mode that trades some performance for numerics closer to eager.
+          It preserves fp16/bf16 downcast-upcast pairs across fused ops instead of eliding them,
+          uses the CUDA toolkit's libdevice for transcendental functions instead of Triton's bundled
+          version, and disables FTZ and fast-math codegen. It does not change TF32/matmul precision;
+          use `torch.set_float32_matmul_precision("highest")` and
+          `torch.backends.cudnn.allow_tf32 = False` for that.
 
         - To see the exact configs that each mode sets you can call `torch._inductor.list_mode_options()`
 
@@ -3227,6 +3238,8 @@ def compile(
         by a non-isolated region hitting its recompile limit does NOT bleed
         into isolated regions — each region manages its own RUN_ONLY state.
         Default False.
+       accuracy_high (bool): Shorthand for ``mode="max-precision"``. Can't be combined
+        with ``mode`` or ``options``.
 
     Example::
 
@@ -3287,9 +3300,17 @@ def compile(
                 recompile_limit=recompile_limit,
                 isolate_recompiles=isolate_recompiles,
                 dynamic_shapes=dynamic_shapes,
+                accuracy_high=accuracy_high,
             )
 
         return fn
+
+    if accuracy_high:
+        if mode is not None or options is not None:
+            raise RuntimeError(
+                "accuracy_high can't be specified together with mode or options."
+            )
+        mode = "max-precision"
 
     if mode is not None and options is not None:
         raise RuntimeError(

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -3164,7 +3164,7 @@ def compile(
         - To register an out-of-tree custom backend:
           https://docs.pytorch.org/docs/main/user_guide/torch_compiler/torch.compiler_custom_backends.html#registering-custom-backends
        mode (str): Can be either "default", "reduce-overhead", "max-autotune", "max-autotune-no-cudagraphs"
-        or "max-precision"
+        or "eager-numerics"
 
         - "default" is the default mode, which is a good balance between performance and overhead
 
@@ -3182,12 +3182,14 @@ def compile(
 
         - "max-autotune-no-cudagraphs" is a mode similar to "max-autotune" but without CUDA graphs
 
-        - "max-precision" is a mode that trades some performance for numerics closer to eager.
-          It preserves fp16/bf16 downcast-upcast pairs across fused ops instead of eliding them,
-          uses the CUDA toolkit's libdevice for transcendental functions instead of Triton's bundled
-          version, and disables FTZ and fast-math codegen. It does not change TF32/matmul precision;
-          use `torch.set_float32_matmul_precision("highest")` and
-          `torch.backends.cudnn.allow_tf32 = False` for that.
+        - "eager-numerics" is a mode that trades some performance for numerics closer to eager.
+          Note that this is not strictly "higher precision"; e.g. it preserves fp16/bf16
+          downcast-upcast pairs across fused ops instead of eliding them, which matches eager's
+          rounding behavior but is not more precise in an absolute sense. It also uses the CUDA
+          toolkit's libdevice for transcendental functions instead of Triton's bundled version, and
+          disables FTZ and fast-math codegen. It does not change TF32/matmul precision; use
+          `torch.set_float32_matmul_precision("highest")` and `torch.backends.cudnn.allow_tf32 = False`
+          for that.
 
         - To see the exact configs that each mode sets you can call `torch._inductor.list_mode_options()`
 
@@ -3238,7 +3240,7 @@ def compile(
         by a non-isolated region hitting its recompile limit does NOT bleed
         into isolated regions — each region manages its own RUN_ONLY state.
         Default False.
-       accuracy_high (bool): Shorthand for ``mode="max-precision"``. Can't be combined
+       accuracy_high (bool): Shorthand for ``mode="eager-numerics"``. Can't be combined
         with ``mode`` or ``options``.
 
     Example::
@@ -3310,7 +3312,7 @@ def compile(
             raise RuntimeError(
                 "accuracy_high can't be specified together with mode or options."
             )
-        mode = "max-precision"
+        mode = "eager-numerics"
 
     if mode is not None and options is not None:
         raise RuntimeError(

--- a/torch/_inductor/__init__.py
+++ b/torch/_inductor/__init__.py
@@ -366,7 +366,7 @@ def list_mode_options(
         >>> torch._inductor.list_mode_options()
     """
 
-    mode_options: dict[str, dict[str, bool]] = {
+    mode_options: dict[str, dict[str, Any]] = {
         "default": {},
         # lite backend for opt-in optimizations
         "lite": lite_mode_options,
@@ -385,6 +385,20 @@ def list_mode_options(
             "max_autotune": True,
             "triton.cudagraphs": True,
             "coordinate_descent_tuning": True,
+        },
+        # trade some performance for numerics closer to eager
+        "max-precision": {
+            "emulate_precision_casts": True,
+            "emulate_precision_casts_on_saved_tensors": True,
+            "eager_numerics.use_pytorch_libdevice": True,
+            "eager_numerics.disable_ftz": True,
+            "eager_numerics.division_rounding": True,
+            "use_fast_math": False,
+            "cpp.enable_unsafe_math_opt_flag": False,
+            "cpp.enable_floating_point_contract_flag": "off",
+            "rocm.use_fast_math": False,
+            "rocm.flush_denormals": False,
+            "cutlass.use_fast_math": False,
         },
     }
     try:

--- a/torch/_inductor/__init__.py
+++ b/torch/_inductor/__init__.py
@@ -387,7 +387,7 @@ def list_mode_options(
             "coordinate_descent_tuning": True,
         },
         # trade some performance for numerics closer to eager
-        "max-precision": {
+        "eager-numerics": {
             "emulate_precision_casts": True,
             "emulate_precision_casts_on_saved_tensors": True,
             "eager_numerics.use_pytorch_libdevice": True,


### PR DESCRIPTION
Fixes #189334.

## Summary

Achieving eager-like numerics in torch.compile today requires knowing about scattered Inductor config knobs (emulate_precision_casts, eager_numerics.use_pytorch_libdevice, use_fast_math, per backend fast-math C++ flags, etc). There was no single high-level switch, so users who need strict numerical fidelity over speed had to discover and combine these internal flags manually.

This adds "eager-numerics" as a new entry in torch._inductor.list_mode_options(), the existing extensibility point used by "reduce-overhead" and "max-autotune". It bundles the knobs that keep Inductor's codegen closer to eager: preserving fp16/bf16 downcast-upcast pairs across fused ops instead of eliding them, using the CUDA toolkit's libdevice for transcendental functions instead of Triton's bundled version, and disabling FTZ and fast-math codegen paths (CPU, ROCm, CUTLASS). accuracy_high=True is added to torch.compile() as sugar that maps to mode="eager-numerics", matching the two API shapes proposed in the issue; it raises RuntimeError if combined with mode or options, mirroring the existing mode/options mutual exclusion check.

Note this is deliberately named "eager-numerics" rather than "max-precision" (see PR discussion below): some of the bundled flags, like emulate_precision_casts, reduce precision relative to what Inductor would otherwise compute, they just make the result closer to eager's rounding behavior. "Precision" and "matches eager" are not the same axis.

TF32 and matmul precision (torch.backends.cuda.matmul.fp32_precision, cudnn, mkldnn) are global process-wide flags, not torch._inductor.config keys, so they cannot be set through the mode's config dict the way the other knobs are. Rather than mutating global backend state as a side effect of compiling one function, the new mode leaves them alone and the docstring points users at torch.set_float32_matmul_precision("highest") and torch.backends.cudnn.allow_tf32 = False instead.

LLM used: Claude Code

## Test plan

New tests in test/inductor/test_config.py:
```
python test/inductor/test_config.py -k test_api_options
python test/inductor/test_config.py -k test_accuracy_high
```

Full existing suite to check for regressions:
```
python test/inductor/test_config.py
```

Manual sanity check:
```python
import torch
print(torch._inductor.list_mode_options('eager-numerics'))

@torch.compile(accuracy_high=True)
def f(x):
    return torch.sin(x) + torch.cos(x)
print(f(torch.randn(8)))
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo