### PR TITLE
Infra primers for torch.export CFR inference preproc (#189424)

### DIFF
--- a/test/cpp/nativert/test_static_kernel_ops.cpp
+++ b/test/cpp/nativert/test_static_kernel_ops.cpp
@@ -283,6 +283,25 @@ TEST(StaticKernelTest, MulScalar) {
   }
 }
 
+TEST(StaticKernelTest, MulScalarBool) {
+  // A bool tensor times a scalar shows up in torch.export'ed graphs as
+  // `aten.gt(...) * c` (lifting a mask into the int/float range). The static
+  // mul_out kernel dispatches the bool `self` via the kBool path added to it;
+  // compare against the non-static ATen reference, which already supports bool.
+  const std::string graph = R"(graph(%in0_t, %in1_t):
+    %out = torch.ops.aten.mul.Scalar(self=%in0_t, other=%in1_t)
+    return (%out)
+  )";
+
+  at::Tensor mask = at::rand({3, 4}) > 0.5; // bool tensor
+  // bool * int64 -> int64 ; bool * double -> default float
+  for (const c10::IValue& scalar :
+       std::vector<c10::IValue>{c10::IValue(int64_t{38}), c10::IValue(2.5)}) {
+    std::vector<c10::IValue> inputs = {mask, scalar};
+    testStaticKernelEquality(graph, inputs);
+  }
+}
+
 TEST(StaticKernelTest, SymSizeInt) {
   const std::string graph = R"(graph(%self, %dim):
     %out = torch.ops.aten.sym_size.int(self=%self, dim=%dim)

--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -1382,6 +1382,67 @@ class TestDeserialize(TestCase):
 
             self.check_graph(M(), (torch.randn(3), torch.randn(3), torch.randn(3)))
 
+    def test_list_of_int_and_float_lists_custom_op(self):
+        # Example program: a custom op that takes List[List[int]] and
+        # List[List[float]] arguments. Round-tripping it (export -> serialize ->
+        # deserialize) exercises the serde nested-list path end to end: these
+        # args must serialize as as_int_lists / as_float_lists, for both
+        # non-empty and empty lists.
+        with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
+            torch.library.define(
+                "mylib::apply_groups",
+                "(Tensor x, int[][] int_groups, float[][] float_groups) -> Tensor",
+                tags=torch.Tag.pt2_compliant_tag,
+                lib=lib,
+            )
+
+            @torch.library.impl("mylib::apply_groups", "cpu", lib=lib)
+            @torch.library.register_fake("mylib::apply_groups")
+            def apply_groups_impl(x, int_groups, float_groups):
+                bias = sum(v for group in int_groups for v in group) + sum(
+                    v for group in float_groups for v in group
+                )
+                return x + bias
+
+            class NonEmpty(torch.nn.Module):
+                def forward(self, x):
+                    return torch.ops.mylib.apply_groups(
+                        x, [[1, 2], [3, 4, 5]], [[1.5], [2.5, 3.5]]
+                    )
+
+            class Empty(torch.nn.Module):
+                def forward(self, x):
+                    return torch.ops.mylib.apply_groups(x, [], [])
+
+            # The round-trips must succeed; before nested-list support was added,
+            # serialization raised SerializeError on List[List[int/float]] args.
+            self.check_graph(NonEmpty(), (torch.randn(3),))
+            self.check_graph(Empty(), (torch.randn(3),))
+
+            # Pin down the exact serialized argument kinds and values.
+            def _serialized_op_args(mod):
+                ep = torch.export.export(mod, (torch.randn(3),), strict=True)
+                serialized = ExportedProgramSerializer().serialize(ep)
+                nodes = [
+                    n
+                    for n in serialized.exported_program.graph_module.graph.nodes
+                    if n.target and "apply_groups" in n.target
+                ]
+                self.assertEqual(len(nodes), 1)
+                return {i.name: i.arg for i in nodes[0].inputs}
+
+            args = _serialized_op_args(NonEmpty())
+            self.assertEqual(args["int_groups"].type, "as_int_lists")
+            self.assertEqual(args["int_groups"].as_int_lists, [[1, 2], [3, 4, 5]])
+            self.assertEqual(args["float_groups"].type, "as_float_lists")
+            self.assertEqual(args["float_groups"].as_float_lists, [[1.5], [2.5, 3.5]])
+
+            empty_args = _serialized_op_args(Empty())
+            self.assertEqual(empty_args["int_groups"].type, "as_int_lists")
+            self.assertEqual(empty_args["int_groups"].as_int_lists, [])
+            self.assertEqual(empty_args["float_groups"].type, "as_float_lists")
+            self.assertEqual(empty_args["float_groups"].as_float_lists, [])
+
     def test_unbacked_bindings_serialize(self):
         from torch._export.utils import _get_shape_env_from_gm
         from torch.utils._sympy.symbol import prefix_str, symbol_is_type, SymT

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -1416,6 +1416,16 @@ class GraphModuleSerializer(metaclass=Final):
                         return Argument.create(as_strings=[])
                     elif isinstance(elem_type, torch.TensorType):
                         return Argument.create(as_tensors=[])
+                    elif isinstance(elem_type, torch.ListType):
+                        inner_elem_type = elem_type.getElementType()
+                        if isinstance(inner_elem_type, torch.IntType):
+                            return Argument.create(as_int_lists=[])
+                        elif isinstance(inner_elem_type, torch.FloatType):
+                            return Argument.create(as_float_lists=[])
+                        else:
+                            raise SerializeError(
+                                f"Empty list with nested type {elem_type} nyi."
+                            )
                     else:
                         # I believe empty symint lists default to ints, but
                         # please file an issue if this is not the case
@@ -1543,9 +1553,10 @@ class GraphModuleSerializer(metaclass=Final):
                     as_optional_tensors=list(map(serialize_optional_tensor_args, arg))
                 )
             elif all(
-                isinstance(a, tuple) and all(type(x) is int for x in a) for a in arg
+                isinstance(a, (list, tuple)) and all(type(x) is int for x in a)
+                for a in arg
             ):
-                # list of int tuples
+                # list of int lists (List[List[int]])
                 return Argument.create(as_int_lists=[list(t) for t in arg])
             elif all(
                 isinstance(a, (list, tuple)) and all(isinstance(x, float) for x in a)

--- a/torch/nativert/kernels/KernelRegistry.cpp
+++ b/torch/nativert/kernels/KernelRegistry.cpp
@@ -202,8 +202,12 @@ static at::Tensor& mul_out(
       self.is_contiguous() ? at::OptionalIntArrayRef(std::nullopt)
                            : self.strides());
 
-  AT_DISPATCH_ALL_TYPES_AND2(
-      kHalf, kBFloat16, t_output, "mul_Scalar_out", [&]() {
+  // kBool is included so torch.export'ed graphs that do `bool_tensor * scalar`
+  // (e.g. `aten.gt(...) * 38` to lift mask values into the int range) dispatch
+  // cleanly. Bool participates in PyTorch's type promotion and is allowed by
+  // upstream `aten::mul`, so the kernel should follow suit.
+  AT_DISPATCH_ALL_TYPES_AND3(
+      kHalf, kBFloat16, kBool, t_output, "mul_Scalar_out", [&]() {
         using output_t = scalar_t;
         output_t* output_ptr = output.mutable_data_ptr<output_t>();
 
@@ -212,16 +216,22 @@ static at::Tensor& mul_out(
 
         at::parallel_for(0, num_elements, 1, [&](int64_t start, int64_t end) {
           for (int64_t i = start; i < end; ++i) {
-            AT_DISPATCH_ALL_TYPES_AND2(
-                kHalf, kBFloat16, other.type(), "mul_Scalar_other", [&]() {
+            AT_DISPATCH_ALL_TYPES_AND3(
+                kHalf,
+                kBFloat16,
+                kBool,
+                other.type(),
+                "mul_Scalar_other",
+                [&]() {
                   using other_t = scalar_t;
 
                   output_t other_casted = static_cast<output_t>(
                       reinterpret_cast<const other_t*>(other.data_ptr())[0]);
 
-                  AT_DISPATCH_ALL_TYPES_AND2(
+                  AT_DISPATCH_ALL_TYPES_AND3(
                       kHalf,
                       kBFloat16,
+                      kBool,
                       self.scalar_type(),
                       "mul_Scalar_self",
                       [&]() {


### PR DESCRIPTION
Summary:

Infra "primers" that make CFR (main-feed MTML) models runnable through the PyTorch 2 `torch.export` -> Sigmoid/NativeRT path. Each change closes a specific gap hit while exporting, serializing, and serving these nets; together they let a CFR model round-trip through export and execute in the interpreter/NativeRT runtime.

**torch.export serialization** (`caffe2/torch/_export/serde/serialize.py`): serialize `List[List[int]]` and `List[List[float]]` op arguments as `as_int_lists` / `as_float_lists`, including empty nested lists (the element kind is inferred from the schema arg type), and accept arguments passed as actual Python lists rather than only tuples.

**NativeRT `mul.Scalar`** (`caffe2/torch/nativert/kernels/KernelRegistry.cpp`): add `kBool` to the `aten.mul.Scalar` static-kernel dispatch so exported graphs that lift a bool mask into the int/float range (e.g. `aten.gt(...) * 38`) dispatch cleanly, following upstream `aten::mul` type promotion.

**sparsenn torch.export compatibility** (`caffe2/torch/fb/sparsenn/`): add fake/meta implementations for `fb::datafm_sim_hard_search` (plus `_jagged` / `_mt`), `fb::grouped_feature_bitwise_operation`, and `preproc::popcount` so these custom ops trace under export; fix the `ID_LIST` fake to emit 1D int64 offsets matching the runtime op; allocate the `grouped_feature_bitwise_operation` NativeRT output when it is unset; and fix `sigrid_transforms_ops` contiguity (build the ranges tensor with an explicit `c10::kStrided` layout and call `.contiguous()` on the copied tensors) so `caffe2::Tensor`'s `enforce_invariants()` accepts tensors produced by export-traced ops.

**Sigmoid export config** (`sigmoid/inference/export_utils.py`): for PT2 inference export, disable 0/1 specialization (`specialize_int=False`) and enable `automatic_dynamic_shapes` so id-list lengths/values with a sample size of 0 or 1 stay dynamic.

**Localnet benchmark metadata** (`sigrid/feed/prediction_replayer/LocalnetBenchmarkMain.cpp`, `sigrid/predictor/client/localnet/SigridPredictorPytorchLocalModel.cpp`): when `getPredictor()->get_model_metadata()` throws, fall back to `getFeatureMetadataContainer().get_model_metadata("forward")`, which is how exported/sigmoid local nets expose their input metadata.

Unit tests are added for the two open-source changes (serde nested lists and the NativeRT bool `mul.Scalar` dispatch); see the test plan.

Test Plan:
New unit tests covering the two open-source (pytorch) changes:

```
buck2 test fbcode//caffe2/test:test_export -- test_list_of_int_and_float_lists_custom_op
buck2 test fbcode//caffe2/test/cpp/nativert:static_kernel_ops_tests -- StaticKernelTest.MulScalarBool
```

- `test_list_of_int_and_float_lists_custom_op` — defines a custom op with `int[][]` / `float[][]` arguments, exports a module that calls it, and round-trips it through serialize -> deserialize, asserting the nested lists serialize as `as_int_lists` / `as_float_lists` for both non-empty and empty inputs. Result: Pass 1.
- `StaticKernelTest.MulScalarBool` — runs `aten.mul.Scalar` on a bool tensor times int/float scalars through the static kernel and compares against the non-static ATen reference. Result: Pass 1 (full `static_kernel_ops_tests` target: 25/25).

Build verification of the affected C++ targets in dev and opt:

```
buck2 build mode/dev fbcode//caffe2/torch/fb/sparsenn:sparsenn_operators fbcode//sigrid/feed/prediction_replayer:localnet_benchmark fbcode//caffe2/torch/fb/model_transform/fx2trt/packaging:load_net_predictor_lib
buck2 build mode/opt fbcode//sigrid/feed/prediction_replayer:localnet_benchmark fbcode//caffe2/torch/fb/model_transform/fx2trt/packaging:load_net_predictor_lib
```

All builds succeed.

Reviewed By: georgiaphillips, jijiew

Differential Revision: D111165094


