### PR TITLE
[ROCm] Align manywheel image base with CUDA

### DIFF
--- a/.ci/docker/manywheel/Dockerfile_2_28
+++ b/.ci/docker/manywheel/Dockerfile_2_28
@@ -145,6 +145,23 @@ ARG ROCM_VERSION=6.0
 ARG PYTORCH_ROCM_ARCH
 ENV PYTORCH_ROCM_ARCH ${PYTORCH_ROCM_ARCH}
 ARG DEVTOOLSET_VERSION=13
+# Install ROCm into the same AlmaLinux base image used by CUDA manywheel builds.
+RUN echo "[ROCm]" > /etc/yum.repos.d/rocm.repo && \
+    echo "name=ROCm" >> /etc/yum.repos.d/rocm.repo && \
+    echo "baseurl=https://repo.radeon.com/rocm/rhel8/${ROCM_VERSION}/main" >> /etc/yum.repos.d/rocm.repo && \
+    echo "enabled=1" >> /etc/yum.repos.d/rocm.repo && \
+    echo "gpgcheck=1" >> /etc/yum.repos.d/rocm.repo && \
+    echo "gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key" >> /etc/yum.repos.d/rocm.repo && \
+    yum install -y \
+        amd-smi-lib \
+        rccl \
+        rocm-dev \
+        rocm-libs \
+        rocm-utils \
+        rocprofiler-devel \
+        roctracer-devel && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 # All rocm clang cfg files load the same rocm.cfg, make sure it points to the right toolchain.
 RUN echo "--gcc-toolchain=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr" >> /opt/rocm/llvm/bin/rocm.cfg
 # Somewhere in ROCm stack, we still use non-existing /opt/rocm/hip path,

--- a/.ci/docker/manywheel/build.sh
+++ b/.ci/docker/manywheel/build.sh
@@ -94,7 +94,7 @@ case ${image} in
         TARGET=rocm_final
         MANY_LINUX_VERSION="2_28"
         DEVTOOLSET_VERSION="13"
-        GPU_IMAGE=rocm/dev-almalinux-8:${GPU_ARCH_VERSION}-complete
+        GPU_IMAGE=amd64/almalinux:8
         PYTORCH_ROCM_ARCH="gfx900;gfx906;gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1103;gfx1200;gfx1201;gfx950;gfx1150;gfx1151"
         DOCKER_GPU_BUILD_ARG="--build-arg ROCM_VERSION=${GPU_ARCH_VERSION} --build-arg PYTORCH_ROCM_ARCH=${PYTORCH_ROCM_ARCH} --build-arg DEVTOOLSET_VERSION=${DEVTOOLSET_VERSION}"
         ;;


### PR DESCRIPTION
## Summary
- Use the same `amd64/almalinux:8` base image for ROCm manywheel builds that CUDA manywheel builds use.
- Install ROCm explicitly from the ROCm RHEL8 package repository inside `rocm_final` before applying the existing ROCm `rocm.cfg`, DRM, rocSHMEM, MAGMA, and MIOpen setup.

Tracking issue: https://github.com/ROCm/frameworks-internal/issues/17204

## Test plan
- `python3 /tmp/repro_rocm_manywheel_image.py`
- `bash -n .ci/docker/manywheel/build.sh`
- Verified ROCm RHEL8 package metadata contains the requested packages for 6.4.4, 7.0.2, 7.1.1, and 7.2.1.
- Approved with `ciflow/binaries,ciflow/binaries_wheel`: https://github.com/amdfaa/toolkit/actions/runs/29036126928 (sandbox: https://github.com/jithunnair-amd/sandbox/actions/runs/29036140700)
- Validation started: HUD https://hud.pytorch.org/pr/189436; Build manywheel docker images https://github.com/pytorch/pytorch/actions/runs/29036074646; linux-binary-manywheel https://github.com/pytorch/pytorch/actions/runs/29036189652 and https://github.com/pytorch/pytorch/actions/runs/29036191935
- Docker/local container validation could not run in this cloud environment because no container runtime is installed (`docker`, `podman`, `buildah`, and `nerdctl` are unavailable).

Made with Cursor

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang