### PR TITLE
[ROCm] Align manywheel image base with CUDA

### DIFF
--- a/.ci/docker/common/install_rocm.sh
+++ b/.ci/docker/common/install_rocm.sh
@@ -2,13 +2,43 @@
 
 set -ex
 
-# for pip_install function
-source "$(dirname "${BASH_SOURCE[0]}")/common_utils.sh"
-
-ROCM_COMPOSABLE_KERNEL_VERSION="$(cat $(dirname $0)/../ci_commit_pins/rocm-composable-kernel.txt)"
-
 ver() {
     printf "%3d%03d%03d%03d" $(echo "$1" | tr '.' ' ');
+}
+
+write_rocm_env() {
+    local include_therock_sysdeps="${1:-0}"
+
+    cat > /etc/rocm_env.sh << ROCM_ENV
+# ROCm paths
+export ROCM_PATH=/opt/rocm
+export ROCM_HOME=/opt/rocm
+export ROCM_SOURCE_DIR=/opt/rocm
+export ROCM_BIN=/opt/rocm/bin
+export ROCM_CMAKE=/opt/rocm
+export PATH=/opt/rocm/bin:/opt/rocm/llvm/bin:\${PATH}
+export LD_LIBRARY_PATH=/opt/rocm/lib:\${LD_LIBRARY_PATH:-}
+# Device library path
+export HIP_DEVICE_LIB_PATH=/opt/rocm/amdgcn/bitcode
+export MAGMA_HOME=/opt/rocm/magma
+ROCM_ENV
+
+    if [[ "${include_therock_sysdeps}" == "1" ]]; then
+        cat >> /etc/rocm_env.sh << ROCM_ENV
+# Sysdeps include paths (libdrm headers, etc.)
+export CPLUS_INCLUDE_PATH=/opt/rocm/lib/rocm_sysdeps/include:\${CPLUS_INCLUDE_PATH:-}
+export C_INCLUDE_PATH=/opt/rocm/lib/rocm_sysdeps/include:\${C_INCLUDE_PATH:-}
+# Tarball bundles sysdeps (libdrm, liblzma, etc.); expose their libs and .pc files
+if [ -d /opt/rocm/lib/rocm_sysdeps/lib ]; then
+  export LD_LIBRARY_PATH=/opt/rocm/lib/rocm_sysdeps/lib:\${LD_LIBRARY_PATH}
+  export PKG_CONFIG_PATH=/opt/rocm/lib/rocm_sysdeps/lib/pkgconfig:\${PKG_CONFIG_PATH:-}
+fi
+# Disable MSLK for theRock nightly (not yet supported)
+export USE_MSLK=0
+ROCM_ENV
+    fi
+
+    echo "source /etc/rocm_env.sh" >> /etc/bash.bashrc
 }
 
 install_ubuntu() {
@@ -120,31 +150,7 @@ install_ubuntu() {
       echo "=============================================="
 
       # Write environment file (sourced by CI scripts and interactive shells)
-      cat > /etc/rocm_env.sh << ROCM_ENV
-# ROCm paths
-export ROCM_PATH=/opt/rocm
-export ROCM_HOME=/opt/rocm
-export ROCM_SOURCE_DIR=/opt/rocm
-export ROCM_BIN=/opt/rocm/bin
-export ROCM_CMAKE=/opt/rocm
-export PATH=/opt/rocm/bin:/opt/rocm/llvm/bin:\${PATH}
-export LD_LIBRARY_PATH=/opt/rocm/lib:\${LD_LIBRARY_PATH:-}
-# Sysdeps include paths (libdrm headers, etc.)
-export CPLUS_INCLUDE_PATH=/opt/rocm/lib/rocm_sysdeps/include:\${CPLUS_INCLUDE_PATH:-}
-export C_INCLUDE_PATH=/opt/rocm/lib/rocm_sysdeps/include:\${C_INCLUDE_PATH:-}
-# Device library path
-export HIP_DEVICE_LIB_PATH=/opt/rocm/amdgcn/bitcode
-export MAGMA_HOME=/opt/rocm/magma
-# Tarball bundles sysdeps (libdrm, liblzma, etc.); expose their libs and .pc files
-if [ -d /opt/rocm/lib/rocm_sysdeps/lib ]; then
-  export LD_LIBRARY_PATH=/opt/rocm/lib/rocm_sysdeps/lib:\${LD_LIBRARY_PATH}
-  export PKG_CONFIG_PATH=/opt/rocm/lib/rocm_sysdeps/lib/pkgconfig:\${PKG_CONFIG_PATH:-}
-fi
-# Disable MSLK for theRock nightly (not yet supported)
-export USE_MSLK=0
-ROCM_ENV
-
-      echo "source /etc/rocm_env.sh" >> /etc/bash.bashrc
+      write_rocm_env 1
 
       # --- End of theRock nightly tarball installation ---
     else
@@ -245,21 +251,7 @@ EOF
     # alongside PyTorch in .ci/pytorch/build.sh and installed at test time
 
     # Write environment file (sourced by CI scripts and interactive shells)
-    cat > /etc/rocm_env.sh << ROCM_ENV
-# ROCm paths
-export ROCM_PATH=/opt/rocm
-export ROCM_HOME=/opt/rocm
-export ROCM_SOURCE_DIR=/opt/rocm
-export ROCM_BIN=/opt/rocm/bin
-export ROCM_CMAKE=/opt/rocm
-export PATH=/opt/rocm/bin:/opt/rocm/llvm/bin:\${PATH}
-export LD_LIBRARY_PATH=/opt/rocm/lib:\${LD_LIBRARY_PATH:-}
-# Device library path
-export HIP_DEVICE_LIB_PATH=/opt/rocm/amdgcn/bitcode
-export MAGMA_HOME=/opt/rocm/magma
-ROCM_ENV
-
-    echo "source /etc/rocm_env.sh" >> /etc/bash.bashrc
+    write_rocm_env 0
 
     # Cleanup
     apt-get autoclean && apt-get clean
@@ -267,11 +259,57 @@ ROCM_ENV
     fi
 }
 
+install_rhel8() {
+    local version_id
+    version_id=$(grep -oP '(?<=^VERSION_ID=).+' /etc/os-release | tr -d '"')
+    if [[ "${version_id%%.*}" != "8" ]]; then
+        echo "Unable to install ROCm on RHEL-like version ${version_id}; only version 8 is supported"
+        exit 1
+    fi
+
+    yum update -y
+    yum install -y kmod wget
+
+    echo "[ROCm]" > /etc/yum.repos.d/rocm.repo
+    echo "name=ROCm" >> /etc/yum.repos.d/rocm.repo
+    echo "baseurl=https://repo.radeon.com/rocm/rhel8/${ROCM_VERSION}/main" >> /etc/yum.repos.d/rocm.repo
+    echo "enabled=1" >> /etc/yum.repos.d/rocm.repo
+    echo "gpgcheck=1" >> /etc/yum.repos.d/rocm.repo
+    echo "gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key" >> /etc/yum.repos.d/rocm.repo
+
+    local rocm_packages=(
+        amd-smi-lib
+        rccl
+        rocm-dev
+        rocm-libs
+        rocm-utils
+        rocprofiler-devel
+        roctracer-devel
+    )
+
+    if [[ $(ver $ROCM_VERSION) -lt $(ver 7.2) ]]; then
+        # ROCm < 7.2 needs the OpenCL ICD headers available explicitly on AlmaLinux.
+        rocm_packages+=(ocl-icd-devel)
+    fi
+
+    yum install -y --enablerepo=powertools "${rocm_packages[@]}"
+    # numactl-devel fixes the rocSHMEM install issue by providing numa.h.
+    yum install -y numactl-devel
+
+    write_rocm_env 0
+
+    yum clean all
+    rm -rf /var/cache/yum
+}
+
 # Install Python packages depending on the base OS
 ID=$(grep -oP '(?<=^ID=).+' /etc/os-release | tr -d '"')
 case "$ID" in
   ubuntu)
     install_ubuntu
+    ;;
+  almalinux|rhel)
+    install_rhel8
     ;;
   *)
     echo "Unable to determine OS..."

--- a/.ci/docker/manywheel/Dockerfile_2_28
+++ b/.ci/docker/manywheel/Dockerfile_2_28
@@ -147,6 +147,23 @@ ARG ROCM_VERSION=6.0
 ARG PYTORCH_ROCM_ARCH
 ENV PYTORCH_ROCM_ARCH ${PYTORCH_ROCM_ARCH}
 ARG DEVTOOLSET_VERSION=13
+# Install ROCm into the same AlmaLinux base image used by CUDA manywheel builds.
+RUN echo "[ROCm]" > /etc/yum.repos.d/rocm.repo && \
+    echo "name=ROCm" >> /etc/yum.repos.d/rocm.repo && \
+    echo "baseurl=https://repo.radeon.com/rocm/rhel8/${ROCM_VERSION}/main" >> /etc/yum.repos.d/rocm.repo && \
+    echo "enabled=1" >> /etc/yum.repos.d/rocm.repo && \
+    echo "gpgcheck=1" >> /etc/yum.repos.d/rocm.repo && \
+    echo "gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key" >> /etc/yum.repos.d/rocm.repo && \
+    yum install -y \
+        amd-smi-lib \
+        rccl \
+        rocm-dev \
+        rocm-libs \
+        rocm-utils \
+        rocprofiler-devel \
+        roctracer-devel && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 # All rocm clang cfg files load the same rocm.cfg, make sure it points to the right toolchain.
 RUN echo "--gcc-toolchain=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr" >> /opt/rocm/llvm/bin/rocm.cfg
 # Somewhere in ROCm stack, we still use non-existing /opt/rocm/hip path,

--- a/.ci/docker/manywheel/Dockerfile_2_28
+++ b/.ci/docker/manywheel/Dockerfile_2_28
@@ -154,8 +154,9 @@ RUN echo "[ROCm]" > /etc/yum.repos.d/rocm.repo && \
     echo "enabled=1" >> /etc/yum.repos.d/rocm.repo && \
     echo "gpgcheck=1" >> /etc/yum.repos.d/rocm.repo && \
     echo "gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key" >> /etc/yum.repos.d/rocm.repo && \
-    yum install -y \
+    yum install -y --enablerepo=powertools \
         amd-smi-lib \
+        ocl-icd-devel \
         rccl \
         rocm-dev \
         rocm-libs \

--- a/.ci/docker/manywheel/Dockerfile_2_28
+++ b/.ci/docker/manywheel/Dockerfile_2_28
@@ -165,6 +165,10 @@ RUN echo "[ROCm]" > /etc/yum.repos.d/rocm.repo && \
         roctracer-devel && \
     yum clean all && \
     rm -rf /var/cache/yum
+# numactl-devel fixes the rocSHMEM install issue by providing numa.h.
+RUN yum install -y numactl-devel && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 # All rocm clang cfg files load the same rocm.cfg, make sure it points to the right toolchain.
 RUN echo "--gcc-toolchain=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr" >> /opt/rocm/llvm/bin/rocm.cfg
 # Somewhere in ROCm stack, we still use non-existing /opt/rocm/hip path,

--- a/.ci/docker/manywheel/Dockerfile_2_28
+++ b/.ci/docker/manywheel/Dockerfile_2_28
@@ -148,27 +148,8 @@ ARG PYTORCH_ROCM_ARCH
 ENV PYTORCH_ROCM_ARCH ${PYTORCH_ROCM_ARCH}
 ARG DEVTOOLSET_VERSION=13
 # Install ROCm into the same AlmaLinux base image used by CUDA manywheel builds.
-RUN echo "[ROCm]" > /etc/yum.repos.d/rocm.repo && \
-    echo "name=ROCm" >> /etc/yum.repos.d/rocm.repo && \
-    echo "baseurl=https://repo.radeon.com/rocm/rhel8/${ROCM_VERSION}/main" >> /etc/yum.repos.d/rocm.repo && \
-    echo "enabled=1" >> /etc/yum.repos.d/rocm.repo && \
-    echo "gpgcheck=1" >> /etc/yum.repos.d/rocm.repo && \
-    echo "gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key" >> /etc/yum.repos.d/rocm.repo && \
-    yum install -y --enablerepo=powertools \
-        amd-smi-lib \
-        ocl-icd-devel \
-        rccl \
-        rocm-dev \
-        rocm-libs \
-        rocm-utils \
-        rocprofiler-devel \
-        roctracer-devel && \
-    yum clean all && \
-    rm -rf /var/cache/yum
-# numactl-devel fixes the rocSHMEM install issue by providing numa.h.
-RUN yum install -y numactl-devel && \
-    yum clean all && \
-    rm -rf /var/cache/yum
+ADD ./common/install_rocm.sh install_rocm.sh
+RUN bash ./install_rocm.sh && rm install_rocm.sh
 # All rocm clang cfg files load the same rocm.cfg, make sure it points to the right toolchain.
 RUN echo "--gcc-toolchain=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr" >> /opt/rocm/llvm/bin/rocm.cfg
 # Somewhere in ROCm stack, we still use non-existing /opt/rocm/hip path,

--- a/.ci/docker/manywheel/build.sh
+++ b/.ci/docker/manywheel/build.sh
@@ -94,7 +94,7 @@ case ${image} in
         TARGET=rocm_final
         MANY_LINUX_VERSION="2_28"
         DEVTOOLSET_VERSION="13"
-        GPU_IMAGE=rocm/dev-almalinux-8:${GPU_ARCH_VERSION}-complete
+        GPU_IMAGE=amd64/almalinux:8
         PYTORCH_ROCM_ARCH="gfx900;gfx906;gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1103;gfx1200;gfx1201;gfx950;gfx1150;gfx1151"
         DOCKER_GPU_BUILD_ARG="--build-arg ROCM_VERSION=${GPU_ARCH_VERSION} --build-arg PYTORCH_ROCM_ARCH=${PYTORCH_ROCM_ARCH} --build-arg DEVTOOLSET_VERSION=${DEVTOOLSET_VERSION}"
         ;;


### PR DESCRIPTION
## Summary
- Use the same `amd64/almalinux:8` base image for ROCm manywheel builds that CUDA manywheel builds use.
- Route ROCm installation through `.ci/docker/common/install_rocm.sh` instead of inlining the yum setup in the manywheel Dockerfile.
- Add an AlmaLinux/RHEL8 ROCm install path to `install_rocm.sh`, including the RHEL8 ROCm repo setup, ROCm package installation, the pre-7.2 OpenCL ICD header compatibility path, and `numactl-devel` for rocSHMEM's `numa.h` dependency.
- Keep the existing manywheel ROCm post-install steps (`rocm.cfg`, DRM patch, MAGMA, rocSHMEM, MIOpen) in place.

Tracking issue: https://github.com/ROCm/frameworks-internal/issues/17204

## Test plan
- `python3 /tmp/repro_rocm_manywheel_image.py`
- `bash -n .ci/docker/common/install_rocm.sh`
- `bash -n .ci/docker/manywheel/build.sh`
- `git diff --check upstream/main..HEAD`
- Verified ROCm RHEL8 package metadata contains `rocm-dev`, AlmaLinux PowerTools contains `ocl-icd-devel`, and AlmaLinux BaseOS contains `numactl-devel`.
- Current validation approval: https://github.com/amdfaa/toolkit/actions/runs/29853223178 (sandbox: https://github.com/jithunnair-amd/sandbox/actions/runs/29853234112).
- Fresh image validation passed: `manylinux2_28-builder:rocm7.1` https://github.com/pytorch/pytorch/actions/runs/29853051696/job/88711642005 and `manylinux2_28-builder:rocm7.2` https://github.com/pytorch/pytorch/actions/runs/29853051696/job/88711641971.
- Exact referenced validation passed: `manywheel-py3_15t-rocm7_1-build / build` https://github.com/pytorch/pytorch/actions/runs/29853849300/job/88714106486.
- ROCm py3.15/py3.15t build/test/upload jobs in https://github.com/pytorch/pytorch/actions/runs/29853849300 passed for rocm7.1 and rocm7.2.
- Remaining failures in the PR rollup are unrelated to this ROCm manywheel image change: CUDA aarch64 tests and XPU py3.15t test.
- Docker/local container validation could not run in this cloud environment because no container runtime is installed (`docker`, `podman`, `buildah`, and `nerdctl` are unavailable).

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang

Made with Cursor