### PR TITLE
use symint-supported view kernel for meta

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -1938,9 +1938,9 @@ Tensor tile_symint(const Tensor& self, SymIntArrayRef reps) {
   return self.repeat_symint(reps);
 }
 
-//
-// templated for ArrayRef<int64_t> and SmallVector<int64_t> use cases
-//
+// Handles both int (ArrayRef<int64_t>/SmallVector<int64_t>) and symbolic
+// (ArrayRef<c10::SymInt>/SymDimVector) shapes and strides; the element type of
+// Vec selects the concrete vs symbolic storage offset.
 template <typename Vec>
 static Tensor alias_with_sizes_and_strides(
     const Tensor& self,
@@ -1957,51 +1957,18 @@ static Tensor alias_with_sizes_and_strides(
         self.key_set(),
         self.dtype(),
         get_qtensorimpl(self)->quantizer());
-    auto* self_tmp_ = self_.unsafeGetTensorImpl();
-    self_tmp_->set_storage_offset(self.storage_offset());
-    self_tmp_->set_sizes_and_strides(sizes, strides);
   } else {
     self_ = at::detail::make_tensor<TensorImpl>(
         c10::TensorImpl::VIEW,
         Storage(self.storage()),
         self.key_set(),
         self.dtype());
-    auto* self_tmp_ = self_.unsafeGetTensorImpl();
-    self_tmp_->set_storage_offset(self.storage_offset());
-    self_tmp_->set_sizes_and_strides(sizes, strides);
   }
-  return self_;
-}
-
-// specialization for symbolic shapes and strides.
-// SymIntArrayRef/ArrayRef<c10::SymInt> and
-// SmallVector<c10::SymInt>/SymDimVector
-template <template <typename...> typename Container>
-static Tensor alias_with_sizes_and_strides(
-    const Tensor& self,
-    const Container<c10::SymInt>& sizes,
-    const Container<c10::SymInt>& strides) {
-  // caller should make sure that sizes and strides are valid for self
-  //(storage is sufficient, strides are non-negative, strides and sizes array
-  // size is the same)
-  Tensor self_;
-  if (self.is_quantized()) {
-    self_ = at::detail::make_tensor<QTensorImpl>(
-        c10::TensorImpl::VIEW,
-        Storage(self.storage()),
-        self.key_set(),
-        self.dtype(),
-        get_qtensorimpl(self)->quantizer());
-    self_.unsafeGetTensorImpl()->set_sizes_and_strides(
-        sizes, strides, self.sym_storage_offset());
+  auto* self_tmp_ = self_.unsafeGetTensorImpl();
+  if constexpr (std::is_same_v<typename Vec::value_type, c10::SymInt>) {
+    self_tmp_->set_sizes_and_strides(sizes, strides, self.sym_storage_offset());
   } else {
-    self_ = at::detail::make_tensor<TensorImpl>(
-        c10::TensorImpl::VIEW,
-        Storage(self.storage()),
-        self.key_set(),
-        self.dtype());
-    self_.unsafeGetTensorImpl()->set_sizes_and_strides(
-        sizes, strides, self.sym_storage_offset());
+    self_tmp_->set_sizes_and_strides(sizes, strides, self.storage_offset());
   }
   return self_;
 }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -8171,8 +8171,8 @@
   device_check: NoCheck
   device_guard: False
   dispatch:
-    Meta, CPU, CUDA, QuantizedCPU, QuantizedCUDA, MPS, MTIA, XPU: view
-    ZeroTensor: view_symint
+    CPU, CUDA, QuantizedCPU, QuantizedCUDA, MPS, MTIA, XPU: view
+    Meta, ZeroTensor: view_symint
     MkldnnCPU: mkldnn_view
     NestedTensorCPU, NestedTensorHPU, NestedTensorCUDA, NestedTensorXPU: view_nested
   tags: core

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -861,6 +861,20 @@ class FakeTensorTest(TestCase):
             b = torch.empty(u0, 16, device="cpu")
         prims.utils.compare_tensor_meta(a, b, check_strides=True)
 
+    def test_stack_symbolic_shapes(self):
+        # torch.stack, for a non-trailing dim, is computed as
+        # cat(...).view(result_sizes). The inner view must not require concrete
+        # sizes when the stacked tensors have symbolic shapes, otherwise it
+        # raises "SymIntArrayRef expected to contain only concrete integers".
+        shape_env = ShapeEnv()
+        with FakeTensorMode(shape_env=shape_env):
+            u0 = shape_env.create_unbacked_symint()
+            u1 = shape_env.create_unbacked_symint()
+            t = torch.empty(u0, u1, device="cpu")
+            out = torch.stack([t, t], dim=1)
+            self.assertEqual(out.dim(), 3)
+            self.assertEqual(out.size(1), 2)
+
     def test_batch_tensor(self):
         x = torch.rand((3, 4, 5))
         b = _add_batch_dim(x, 0, 0)

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -8947,6 +8947,7 @@ def activate_meta():
                 "aten::constant_pad_nd",  # requires_grad mismatch, test_ops.py -k test_fake_crossref_backward_amp_istft_cuda_float32
                 "aten::rot90",  # requires_grad mismatch! test_ops.py -k test_fake_crossref_backward_amp_rot90_cuda_float32
                 "aten::as_strided_scatter",  # requires_grad mismatch, test_ops.py -k test_fake_crossref_backward_no_amp_as_strided_scatter_cuda_float32
+                "aten::stack",  # use the symint-aware C++ meta kernel (stack_meta)
             }
         ):
             pass


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/189349 was created to adress a `RuntimeError: SymIntArrayRef expected to contain only concrete integers` error caused by my earlier PR https://github.com/pytorch/pytorch/pull/188601 which added a C++ stack meta kernel. problem is that view was getting routed to the non-symint aware C++ meta kernel, this PR is a fwd fix to route to the existing one that handles symints. 

i added the test that https://github.com/pytorch/pytorch/pull/189349 introduces 