### PR TITLE
Reduce memory footprint of test_serialization_2gb_file

### DIFF
--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -1201,19 +1201,36 @@ class TestSerialization(TestCase, SerializationMixin):
 
         with BytesIOContext() as f:
             torch.save(big_model.state_dict(), f)
+            del big_model
+            gc.collect()
             f.seek(0)
             state = torch.load(f)
 
-
+        # BytesIOContext does not close the buffer on exit; release the large
+        # serialized buffer before allocating the filesystem tensor below.
+        f.close()
+        del state, f
         gc.collect()
         if IS_FILESYSTEM_UTF8_ENCODING:
             with TemporaryDirectoryName(suffix='\u975eASCII\u30d1\u30b9') as dname:
                 with TemporaryFileName(dir=dname) as fname:
                     # https://github.com/pytorch/pytorch/issues/185098
-                    data = torch.rand(200, 2048, 2048, dtype=torch.float32)  # ~3.13 GiB storage
+                    tensor_size = 2 * 1024 * 1024 * 1024 + 1024
+                    boundary = 2 * 1024 * 1024 * 1024
+                    data = torch.zeros(tensor_size, dtype=torch.uint8)  # >2 GiB storage
+                    expected = torch.arange(8, dtype=torch.uint8)
+                    data[:8] = expected
+                    data[boundary - 4:boundary + 4] = expected
+                    data[-8:] = expected
                     torch.save(data, fname)
+                    del data
+                    gc.collect()
                     loaded_data = torch.load(fname)
-                    self.assertEqual(loaded_data, data)
+                    self.assertEqual(loaded_data.shape, (tensor_size,))
+                    self.assertEqual(loaded_data.dtype, torch.uint8)
+                    self.assertEqual(loaded_data[:8], expected)
+                    self.assertEqual(loaded_data[boundary - 4:boundary + 4], expected)
+                    self.assertEqual(loaded_data[-8:], expected)
 
     @serialTest()
     def test_serialization_4gb_file(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #184568
* __->__ #189449

The 2GiB serialization test allocated a ~3.13 GiB float32 tensor and
kept the in-memory serialized buffer alive alongside it, which made the
test prone to OOM. Rework it to use a >2 GiB uint8 tensor filled with a
small known pattern at the start, the 2 GiB boundary, and the end, and
free intermediate buffers (the model state dict, the BytesIO buffer, and
the source tensor) with explicit del + gc.collect() before allocating
the next large object. Correctness is now checked by comparing the
pattern at those offsets rather than the whole tensor.

This is orthogonal to the Dynamo reset change and is split out to land
independently.

Test Plan:

```
python test/test_serialization.py -k test_serialization_2gb_file
```

This PR was authored with the assistance of an AI coding assistant.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>