### PR TITLE
Reduce peak memory of test_serialization_2gb_file

### DIFF
--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -1201,19 +1201,33 @@ class TestSerialization(TestCase, SerializationMixin):
 
         with BytesIOContext() as f:
             torch.save(big_model.state_dict(), f)
+            del big_model
             f.seek(0)
             state = torch.load(f)
 
-
-        gc.collect()
+        # BytesIOContext does not close the buffer on exit; release the large
+        # serialized buffer before allocating the filesystem tensor below.
+        f.close()
+        del state, f
         if IS_FILESYSTEM_UTF8_ENCODING:
             with TemporaryDirectoryName(suffix='\u975eASCII\u30d1\u30b9') as dname:
                 with TemporaryFileName(dir=dname) as fname:
                     # https://github.com/pytorch/pytorch/issues/185098
-                    data = torch.rand(200, 2048, 2048, dtype=torch.float32)  # ~3.13 GiB storage
+                    tensor_size = 2 * 1024 * 1024 * 1024 + 1024
+                    boundary = 2 * 1024 * 1024 * 1024
+                    data = torch.zeros(tensor_size, dtype=torch.uint8)  # >2 GiB storage
+                    expected = torch.arange(8, dtype=torch.uint8)
+                    data[:8] = expected
+                    data[boundary - 4:boundary + 4] = expected
+                    data[-8:] = expected
                     torch.save(data, fname)
+                    del data
                     loaded_data = torch.load(fname)
-                    self.assertEqual(loaded_data, data)
+                    self.assertEqual(loaded_data.shape, (tensor_size,))
+                    self.assertEqual(loaded_data.dtype, torch.uint8)
+                    self.assertEqual(loaded_data[:8], expected)
+                    self.assertEqual(loaded_data[boundary - 4:boundary + 4], expected)
+                    self.assertEqual(loaded_data[-8:], expected)
 
     @serialTest()
     def test_serialization_4gb_file(self):

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -1199,16 +1199,15 @@ class TestSerialization(TestCase, SerializationMixin):
         gc.collect()
         big_model = torch.nn.Conv2d(20000, 3200, kernel_size=3)
 
-        with BytesIOContext() as f:
+        with contextlib.closing(BytesIOContext()) as f:
             torch.save(big_model.state_dict(), f)
             del big_model
             f.seek(0)
             state = torch.load(f)
 
-        # BytesIOContext does not close the buffer on exit; release the large
-        # serialized buffer before allocating the filesystem tensor below.
-        f.close()
-        del state, f
+        # Release the large serialized buffer (closed on block exit) and the
+        # loaded state before allocating the filesystem tensor below.
+        del state
         if IS_FILESYSTEM_UTF8_ENCODING:
             with TemporaryDirectoryName(suffix='\u975eASCII\u30d1\u30b9') as dname:
                 with TemporaryFileName(dir=dname) as fname:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #184568
* __->__ #189451

test_serialization_2gb_file was OOMing in CI. The default CPU test shard
runs on a linux.4xlarge and executes several test processes at once, so
the memory budget for any single test is well under the machine total.
This test peaked at ~14 GiB, which is enough to tip the shard over.

The peak came from keeping large buffers alive across the two phases of
the test. The measured high-water marks in the original were:

  phase 1 (model + serialized BytesIO + loaded state all live):  7.0 GiB
  phase 2 alloc (3.13 GiB float32 `data`):                       10.2 GiB
  phase 2 load (`data` + `loaded_data` both live):               13.4 GiB
  assertEqual over the full 3.13 GiB tensor:                     14.2 GiB

Two things drove this: nothing was freed between phases, and phase 2
allocated a 3.13 GiB tensor then held both it and the reloaded copy live
while asserting equality over the whole thing.

Fix both:

- Free each large buffer with an explicit `del` right before the next
  large allocation (the model before load, the state/BytesIO before
  phase 2, the source tensor before reload). Refcounting reclaims these
  immediately -- verified that an accompanying gc.collect() freed 0
  additional bytes here, so no gc.collect() is added.
- Shrink phase 2 to a >2 GiB uint8 tensor (the minimum that still
  exercises the zip64 path this test is guarding) and write a known
  8-byte pattern at the start, the 2 GiB boundary, and the end. Verify
  by comparing those slices instead of the whole tensor, so we never
  hold two multi-GiB tensors live at once.

Peak drops from ~14.2 GiB to ~4.8 GiB, and the 4.8 GiB moment is now
just the unavoidable "save state_dict while the model is still live"
step in phase 1.

This is orthogonal to the Dynamo reset change and is split out to land
independently.

Test Plan:

```
python test/test_serialization.py -k test_serialization_2gb_file
```

Peak RSS measured out-of-band via /proc/self/status (VmHWM) with an
instrumented copy of the test body.

This PR was authored with the assistance of an AI coding assistant.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>