### PR TITLE
Fix segfault in replication_pad{1d,2d}_backward on channel mismatch

### DIFF
--- a/aten/src/ATen/native/ReplicationPadding.cpp
+++ b/aten/src/ATen/native/ReplicationPadding.cpp
@@ -63,18 +63,24 @@ TORCH_META_FUNC(replication_pad1d_backward) (
   IntArrayRef paddingSize
 ) {
   int64_t dimw = 1;
+  int64_t dimc = 0;
   TORCH_CHECK(paddingSize.size() == 2, "padding size is expected to be 2");
   int64_t pad_l = paddingSize[0];
   int64_t pad_r = paddingSize[1];
 
   if (input.ndimension() == 3) {
     dimw++;
+    dimc++;
   }
 
   /* sizes */
+  int64_t ichannel = input.size(dimc);
   int64_t iwidth = input.size(dimw);
   int64_t owidth  = iwidth + pad_l + pad_r;
 
+  TORCH_CHECK(ichannel == gradOutput.size(dimc),
+      "gradOutput channel unexpected. Expected: ", ichannel,
+      ", Got: ", gradOutput.size(dimc));
   TORCH_CHECK(owidth == gradOutput.size(dimw),
       "gradOutput width unexpected. Expected: ", owidth,
       " Got: ", gradOutput.size(dimw));
@@ -187,20 +193,26 @@ void replication_pad2d_backward_out_cpu_template(
   int pad_r = paddingSize[1];
   int pad_t = paddingSize[2];
   int pad_b = paddingSize[3];
+  int dimc = 0;
   int dimw = 2;
   int dimh = 1;
 
   if (input.dim() == 4) {
+    dimc++;
     dimw++;
     dimh++;
   }
 
   /* sizes */
+  int64_t ichannel = input.size(dimc);
   int64_t iheight = input.size(dimh);
   int64_t iwidth = input.size(dimw);
   int64_t oheight = iheight + pad_t + pad_b;
   int64_t owidth  = iwidth + pad_l + pad_r;
 
+  TORCH_CHECK(ichannel == gradOutput.size(dimc),
+      "gradOutput channel unexpected. Expected: ", ichannel, ", Got: ",
+      gradOutput.size(dimc));
   TORCH_CHECK(owidth == gradOutput.size(dimw),
       "gradOutput width unexpected. Expected: ", owidth, ", Got: ",
       gradOutput.size(dimw));

--- a/aten/src/ATen/native/cuda/ReplicationPadding.cu
+++ b/aten/src/ATen/native/cuda/ReplicationPadding.cu
@@ -242,19 +242,25 @@ void replication_pad2d_backward_out_cuda_template(
   const auto padR = paddingSize[1];
   const auto padT = paddingSize[2];
   const auto padB = paddingSize[3];
+  int dimc = 0;
   int dimh = 1;
   int dimw = 2;
 
   int numInputDims = input.dim();
   if (numInputDims == 4) {
+    dimc++;
     dimh++;
     dimw++;
   }
+  const auto ichannel = input.size(dimc);
   const auto iheight = input.size(dimh);
   const auto iwidth = input.size(dimw);
   const auto oheight = iheight + padT + padB;
   const auto owidth  = iwidth + padL + padR;
 
+  TORCH_CHECK(ichannel == gradOutput.size(dimc),
+      "gradOutput channel unexpected. Expected: ", ichannel, ", Got: ",
+      gradOutput.size(dimc));
   TORCH_CHECK(owidth == gradOutput.size(dimw),
       "gradOutput width unexpected. Expected: ", owidth, ", Got: ",
       gradOutput.size(dimw));

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9155,6 +9155,21 @@ class TestNNDeviceType(NNTestCase):
         with self.assertRaisesRegex(RuntimeError, 'padding size is expected to be 6'):
             torch._C._nn.replication_pad3d(torch.randn([2]), padding=[])
 
+    @onlyNativeDeviceTypes
+    @skipMPS  # MPS routes through a separate kernel (mps::pad_out_template) that does not validate the channel dim
+    def test_ReplicationPad_backward_channel_mismatch(self, device):
+        # regression test for https://github.com/pytorch/pytorch/issues/142834: a
+        # gradOutput whose channel dim doesn't match the input used to segfault in
+        # the backward pass instead of raising a clear error.
+        for backward, inp, grad_output, padding in [
+            (torch.ops.aten.replication_pad1d_backward,
+             torch.ones(2, 2, 4, device=device), torch.ones(2, 0, 8, device=device), [2, 2]),
+            (torch.ops.aten.replication_pad2d_backward,
+             torch.ones(2, 2, 4, 4, device=device), torch.ones(2, 0, 6, 8, device=device), [2, 2, 1, 1]),
+        ]:
+            with self.assertRaisesRegex(RuntimeError, "gradOutput channel unexpected"):
+                backward(grad_output, inp, padding)
+
     def test_ReplicationPad1d_large(self, device):
         shapes = ([2, 65736, 4], [65736, 2, 4])
         pl, pr = 3, 4


### PR DESCRIPTION
Fixes #142834.

`replication_pad2d_backward` (and the 1d variant) segfaulted when `gradOutput`'s channel dimension did not match the input's. The backward shape validation checked the spatial dims (width/height) but never the channel dim, so a `gradOutput` with a mismatched channel count (e.g. 0 channels) passed the checks, a non-empty `gradInput` was allocated from the input's shape, and the kernel then read `gradOutput` out of bounds -> SIGSEGV.

The 3d backward already validates the channel dim; this mirrors that check into the 1d backward (in its `TORCH_META_FUNC`, so it covers all backends) and the 2d backward (both the CPU template and the CUDA template). All three now raise a clear `gradOutput channel unexpected` error instead of crashing. Legitimate empty and no-batch inputs are unaffected because their channel dims still match.

## Test plan

The reporter's reproducer now raises a clear error instead of crashing, on both CPU and CUDA:

```python
torch.ops.aten.replication_pad2d_backward(torch.full((2, 0, 6, 8), 1.), torch.full((2, 2, 4, 4), 1.), [2, 2, 1, 1])
```

Added a device-generic regression test (`test_ReplicationPad_backward_channel_mismatch`, covering 1d and 2d) and ran the full ReplicationPad suite:

```
python test/test_nn.py -k ReplicationPad -v
```

All 18 ReplicationPad tests pass on CPU and CUDA, including the existing empty-input and no-batch-dim tests (confirming valid inputs are not rejected).
