### PR TITLE
Fix block_diag_scipy dtype expectation with NumPy 2

### DIFF
--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -22,6 +22,7 @@ from torch.testing._internal.common_utils import (
     suppress_warnings,
     torch_to_numpy_dtype_dict,
     numpy_to_torch_dtype_dict,
+    numpy_to_torch_dtype,
     slowTest,
     set_default_dtype,
     set_default_tensor_type,
@@ -417,8 +418,7 @@ class TestTensorCreation(TestCase):
 
         expected_scipy_types = [
             torch.float64,
-            # windows scipy block_diag returns int32 types
-            torch.int32 if IS_WINDOWS else torch.int64,
+            numpy_to_torch_dtype(np.array(0).dtype),
             torch.complex128,
             torch.float64
         ]


### PR DESCRIPTION
The test expected `scipy.linalg.block_diag` integer output to become `int32 `on Windows, but NumPy 2 uses `int64 `as the default integer dtype on 64-bit Windows. This caused both CPU and CUDA variants to fail on Windows ARM64 with torch.int64 != torch.int32.

Previous code hardcoded expected integer dtype using `"IS_WINDOWS"` Use a generic function to derive the expected dtype. `numpy_to_torch_dtype ` will resolve automatically to the underlying platform so expectation matches all numpy versions

Test Plan:
```bash
python test/test_tensor_creation_ops.py TestTensorCreationCPU.test_block_diag_scipy