### PR TITLE
[fx][const_fold] apply skip_folding_node_fn recursively to call_module subgraphs (#189487)

### DIFF
--- a/test/fx/test_fx_const_fold.py
+++ b/test/fx/test_fx_const_fold.py
@@ -751,6 +751,105 @@ class TestConstFold(TestCase):
         )
         self.assertIsNone(mod_folded.const_subgraph_module)
 
+    def test_skip_folding_node_fn_in_subgraph(self):
+        """
+        A call_module node can only be folded as a whole, so if its subgraph
+        contains a node that skip_folding_node_fn says to skip, the whole
+        call_module node should be skipped.
+        """
+
+        class SubModule(torch.nn.Module):
+            def forward(self):
+                return torch.full((5, 10), 2.0) + 1
+
+        def _make_parent() -> torch.fx.GraphModule:
+            ep = torch.export.export(SubModule(), ())
+            parent_graph = torch.fx.Graph()
+            call_mod = parent_graph.call_module("sub", args=())
+            get_item = parent_graph.call_function(
+                operator.getitem, args=(call_mod, slice(None))
+            )
+            parent_graph.output((get_item,))
+            return torch.fx.GraphModule({"sub": ep.module()}, parent_graph)
+
+        # skip_folding_node_fn matches a node *inside* the submodule, so the
+        # whole call_module node must be skipped and nothing gets folded.
+        def skip_full(node: torch.fx.Node) -> bool:
+            return node.target == torch.ops.aten.full.default
+
+        mod_folded: const_fold.FoldedGraphModule = const_fold.split_const_subgraphs(
+            _make_parent(),
+            skip_folding_node_fn=skip_full,
+            device_for_folded_attrs="cpu",
+        )
+        self.assertIsNone(mod_folded.const_subgraph_module)
+
+        # Control: when skip_folding_node_fn matches nothing in the submodule,
+        # the same pure subgraph is still folded as usual.
+        def skip_nothing(node: torch.fx.Node) -> bool:
+            return False
+
+        mod_folded = const_fold.split_const_subgraphs(
+            _make_parent(),
+            skip_folding_node_fn=skip_nothing,
+            device_for_folded_attrs="cpu",
+        )
+        self._verify_const_fold_mod(mod_folded)
+
+    def test_skip_folding_dynamic_node_in_subgraph(self):
+        """
+        A dynamic (symbolic-shape) node inside a call_module subgraph. A call_module
+        folds atomically, so folding it makes const folding *execute* the subgraph
+        at compile time, which crashes with "NameError: name 's..' is not defined"
+        because the shape symbol is only bound at runtime.
+        """
+        import torch.utils._pytree as pytree
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        def _make_parent() -> torch.fx.GraphModule:
+            # Submodule whose forward materializes a tensor of symbolic size
+            sub_graph = torch.fx.Graph()
+            sym = ShapeEnv().create_unbacked_symint()
+            full = sub_graph.call_function(
+                torch.ops.aten.full.default,
+                args=([sym, 1], 0),
+                kwargs={"dtype": torch.bfloat16},
+            )
+            sub_graph.output((full,))
+            sub = torch.fx.GraphModule(torch.nn.Module(), sub_graph)
+
+            parent_graph = torch.fx.Graph()
+            call_mod = parent_graph.call_module("sub", args=())
+            get_item = parent_graph.call_function(operator.getitem, args=(call_mod, 0))
+            parent_graph.output((get_item,))
+            return torch.fx.GraphModule({"sub": sub}, parent_graph)
+
+        # Skips nodes carrying a symbolic value. they can't be evaluated at
+        # compile time, so folding them would fail.
+        def skip_dynamic(node: torch.fx.Node) -> bool:
+            return any(
+                isinstance(a, torch.SymInt)
+                for a in pytree.tree_leaves((node.args, node.kwargs))
+            )
+
+        # Folding this subgraph without skipping fails, because the symbolic size
+        # is unbound at compile time
+        with self.assertRaises(Exception):
+            unguarded = const_fold.split_const_subgraphs(
+                _make_parent(), device_for_folded_attrs="cpu"
+            )
+            unguarded.run_folding()
+
+        # With skip_dynamic, the dynamic node inside the submodule is skipped, so
+        # the call_module is not folded and running folding is a safe no-op.
+        mod_folded = const_fold.split_const_subgraphs(
+            _make_parent(),
+            skip_folding_node_fn=skip_dynamic,
+            device_for_folded_attrs="cpu",
+        )
+        self.assertIsNone(mod_folded.const_subgraph_module)
+        mod_folded.run_folding()
+
     def test_const_fold_partial_graph(self):
         """
         If a model graph is partially const folded,

--- a/torch/fx/experimental/const_fold.py
+++ b/torch/fx/experimental/const_fold.py
@@ -202,6 +202,13 @@ def split_const_subgraphs(
     FoldedGraphModule which runs that constant subgraph on the first run to set
     attributes on the module prior to running the non-constant portion of the
     graph.
+
+    `skip_folding_node_fn`, if provided, may be invoked on nodes owned by nested
+    `call_module` subgraphs, not just top-level nodes: a `call_module` node is
+    folded atomically, so it is skipped if any node inside its subgraph is
+    skipped. Predicates must therefore be node-local; one that needs to resolve a
+    node's `target` to a submodule must use `node.graph.owning_module` rather than
+    a captured top-level module.
     """
 
     import sympy
@@ -231,6 +238,29 @@ def split_const_subgraphs(
                 return _subgraph_has_impure_ops(submodule)
         return False
 
+    def _subgraph_has_skipped_node(
+        module: torch.fx.GraphModule,
+        skip_fn: Callable[[torch.fx.Node], bool],
+    ) -> bool:
+        """
+        Return True if a GraphModule type subgraph contains any node that
+        `skip_fn` says to skip, recursing into nested submodules.
+        """
+        for node in module.graph.nodes:
+            if node.op in {"placeholder", "output"}:
+                continue
+            if skip_fn(node):
+                return True
+            if (
+                node.op == "call_module"
+                # pyrefly: ignore [not-callable]
+                and (submodule := module.get_submodule(node.target))
+                and isinstance(submodule, torch.fx.GraphModule)
+                and _subgraph_has_skipped_node(submodule, skip_fn)
+            ):
+                return True
+        return False
+
     # Build up a list of const_nodes, defined as nodes that are themselves
     # get_attrs, or have all get_attr or other constant node inputs.
     const_nodes: set[torch.fx.Node] = set()
@@ -248,9 +278,20 @@ def split_const_subgraphs(
         ):
             continue
 
-        # If provided skip folding function says to skip, then skip.
-        if skip_folding_node_fn and skip_folding_node_fn(node):
-            continue
+        # If provided skip folding function says to skip, then skip. Also skip a
+        # call_module node whose subgraph contains a node that should be skipped,
+        # since a call_module node can only be folded as a whole.
+        if skip_folding_node_fn is not None:
+            if skip_folding_node_fn(node):
+                continue
+            if (
+                node.op == "call_module"
+                # pyrefly: ignore [not-callable]
+                and (target_mod := mod_traced.get_submodule(node.target))
+                and isinstance(target_mod, torch.fx.GraphModule)
+                and _subgraph_has_skipped_node(target_mod, skip_folding_node_fn)
+            ):
+                continue
 
         # Skip folding side-effectful functions
         if node.is_impure():


### PR DESCRIPTION
Summary:

`split_const_subgraphs` applied `skip_folding_node_fn` only to top-level nodes, so a foldable `call_module` node was still folded when its subgraph contained a node the predicate wanted to skip. This is the same class of gap already fixed for impure ops by `_subgraph_has_impure_ops`. 

This change:
1. Since a `call_module` folds atomically, recurse the predicate into `call_module` subgraphs and skip the node if any node inside its subgraph is skipped. 
2. Also document that `skip_folding_node_fn` may be invoked on submodule-owned nodes, so predicates must be node-local and use `node.graph.owning_module` for any target lookup.

See D91708239 for a motivating case

Test Plan:
`buck2 test fbcode//caffe2/test:fx_const_fold`: all 25 pass, including two new tests that fail without this fix:

`test_skip_folding_node_fn_in_subgraph`: `skip_folding_node_fn` matches a node inside a `call_module` submodule; the `call_module` must be skipped.

`test_skip_folding_dynamic_node_in_subgraph`: reproduces a known crash: a symbolic-shape `aten.full` node inside a submodule. Without the fix, const folding executes the subgraph at compile time and raises `NameError: name 'u0' is not defined`.

<details><summary> e.g. failure trace </summary>

```
A dynamic (symbolic-shape) node inside a call_module subgraph. A call_module ... WARNING: Logging before InitGoogleLogging() is written to STDERR
I0709 14:46:56.808645 3011284 RuntimeEnvironment.cpp:741] ModelTypeName from C2Online Trainer Env Var: MISSING_MODEL_TYPE_NAME
/data/repos/fbsource/buck-out/v2/art/fbcode/b0df5cf7fb9cec4a/caffe2/test/__fx_const_fold__/fx_const_fold#link-tree/torch/fx/graph.py:1994: UserWarning: Raw SymInt value (u0) passed as argument to Graph.create_node(op='call_function', target=aten.full.default). Use create_*_node() helpers for tensor metadata queries or materialize_symints() for general symbolic expressions.
  return self.create_node(
Traceback (most recent call last):
  File "/data/repos/fbsource/buck-out/v2/art/fbcode/b0df5cf7fb9cec4a/caffe2/test/__fx_const_fold__/fx_const_fold#link-tree/torch/fx/graph_module.py", line 495, in __call__
    return super(self.cls, obj).__call__(*args, **kwargs)  # type: ignore[misc]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/repos/fbsource/buck-out/v2/art/fbcode/b0df5cf7fb9cec4a/caffe2/test/__fx_const_fold__/fx_const_fold#link-tree/torch/nn/modules/module.py", line 1778, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/repos/fbsource/buck-out/v2/art/fbcode/b0df5cf7fb9cec4a/caffe2/test/__fx_const_fold__/fx_const_fold#link-tree/torch/nn/modules/module.py", line 1789, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<eval_with_key>.12", line 5, in forward
    full_default = torch.ops.aten.full.default([u0, 1], 0, dtype = torch.bfloat16)
                                                ^^
NameError: name 'u0' is not defined

Call using an FX-traced Module, line 5 of the traced Module's generated forward function:
def forward(self):
    full_default = torch.ops.aten.full.default([u0, 1], 0, dtype = torch.bfloat16)

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
    return (full_default,)

    

FAIL
```

</details>

Full suite (25 passed): https://www.internalfb.com/intern/testinfra/testrun/7881299709713640

Differential Revision: D111299985 (see this for test links)


