### PR TITLE
[MPS] Migrate nan_to_num to a Metal kernel with an ILP dense variant

### DIFF
--- a/aten/src/ATen/native/mps/MetalShaderLibrary.h
+++ b/aten/src/ATen/native/mps/MetalShaderLibrary.h
@@ -199,7 +199,8 @@ class MetalShaderLibrary {
       TensorIteratorBase& iter,
       const std::string& name,
       T params,
-      const std::string& params_type_name);
+      const std::string& params_type_name,
+      const std::optional<uint32_t> ilp_threshold = std::nullopt);
   template <typename T>
   void exec_binary_kernel_with_params(
       TensorIteratorBase& iter,

--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -13,6 +13,7 @@
 #include <ATen/native/mps/MetalShaderLibrary.h>
 #include <ATen/native/mps/TensorFactory.h>
 #include <c10/core/ScalarType.h>
+#include <c10/metal/common.h>
 #include <fmt/format.h>
 #include <torch/library.h>
 #include <limits>
@@ -699,12 +700,13 @@ template <typename T>
 void MetalShaderLibrary::exec_unary_kernel_with_params(TensorIteratorBase& iter,
                                                        const std::string& name,
                                                        T params,
-                                                       const std::string& params_type_name) {
+                                                       const std::string& params_type_name,
+                                                       const std::optional<uint32_t> ilp_threshold) {
   using namespace at::mps;
   // Decompose 64-bit tensor into 32-bit ones
   if (!iter.can_use_32bit_indexing()) {
     for (auto&& sub_iter : iter.with_32bit_indexing()) {
-      exec_unary_kernel_with_params(sub_iter, name, params, params_type_name);
+      exec_unary_kernel_with_params(sub_iter, name, params, params_type_name, ilp_threshold);
     }
     return;
   }
@@ -715,9 +717,16 @@ void MetalShaderLibrary::exec_unary_kernel_with_params(TensorIteratorBase& iter,
   if (length == 0) {
     return;
   }
+  // ILP is opt-in per call site (mirrors exec_unary_kernel's opt-in castout
+  // ILP): callers that know their functor is cheap enough to be
+  // bandwidth-bound pass a crossover threshold; everyone else keeps the
+  // one-thread-per-element dense kernel.
+  const bool dense_ilp = iter.is_contiguous() && ilp_threshold.has_value() && length >= ilp_threshold.value();
   auto kernel_name = fmt::format("{}_{}_{}_{}{}",
                                  name,
-                                 iter.is_contiguous() ? "dense" : "strided",
+                                 dense_ilp                  ? "dense_ilp"
+                                     : iter.is_contiguous() ? "dense"
+                                                            : "strided",
                                  scalarToMetalTypeString(outputTensor),
                                  scalarToMetalTypeString(inputTensor),
                                  fmt::format("_{}", params_type_name));
@@ -741,6 +750,10 @@ void MetalShaderLibrary::exec_unary_kernel_with_params(TensorIteratorBase& iter,
         const auto inner = static_cast<NSUInteger>(iter.shape()[0]);
         const auto outer = static_cast<NSUInteger>(length) / inner;
         mtl_dispatch2DJob(computeEncoder, cplState, inner, outer);
+      } else if (dense_ilp) {
+        mtl_setBytes(computeEncoder, length, 3);
+        mtl_dispatch1DJob(
+            computeEncoder, cplState, (length + c10::metal::ILP_PER_THREAD - 1) / c10::metal::ILP_PER_THREAD);
       } else {
         mtl_dispatch1DJob(computeEncoder, cplState, length);
       }

--- a/aten/src/ATen/native/mps/kernels/UnaryKernel.h
+++ b/aten/src/ATen/native/mps/kernels/UnaryKernel.h
@@ -1,0 +1,12 @@
+#pragma once
+
+// Replacement values are computed per-dtype on the host (CUDA-style: the
+// posinf/neginf defaults are the input dtype's max/lowest) and ride at float,
+// which represents half/bfloat extrema exactly; the struct is always
+// instantiated at T = float.
+template <typename T>
+struct NanToNumParams {
+  T nan;
+  T posinf;
+  T neginf;
+};

--- a/aten/src/ATen/native/mps/kernels/UnaryKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/UnaryKernel.metal
@@ -1,3 +1,4 @@
+#include <ATen/native/mps/kernels/UnaryKernel.h>
 #include <c10/metal/indexing.h>
 #include <c10/metal/special_math.h>
 #include <c10/metal/utils.h>
@@ -794,3 +795,33 @@ REGISTER_UNARY_ALPHA_OP(polygamma, char, int, float);
 REGISTER_UNARY_ALPHA_OP(polygamma, short, int, float);
 REGISTER_UNARY_ALPHA_OP(polygamma, int, int, float);
 REGISTER_UNARY_ALPHA_OP(polygamma, long, int, float);
+
+// Replacement values are computed per-dtype on the host and ride at float
+// (exact for half/bfloat extrema), mirroring the CUDA kernel's
+// Scalar-to-scalar_t conversion.
+inline float nan_to_num_replace(float x, NanToNumParams<float> params) {
+  return ::metal::isnan(x)
+      ? params.nan
+      : (::metal::isinf(x) ? (x > 0.0f ? params.posinf : params.neginf) : x);
+}
+
+struct nan_to_num_functor {
+  template <typename T, enable_if_t<is_scalar_floating_point_v<T>, bool> = true>
+  inline T operator()(const T x, const NanToNumParams<float> params) {
+    return static_cast<T>(nan_to_num_replace(float(x), params));
+  }
+  template <typename T, enable_if_t<is_complex_v<T>, bool> = true>
+  inline T operator()(const T x, const NanToNumParams<float> params) {
+    // per-component, matching CPU/CUDA
+    return T(
+        nan_to_num_replace(float(x.x), params),
+        nan_to_num_replace(float(x.y), params));
+  }
+};
+
+typedef NanToNumParams<float> NanToNumParams_float;
+REGISTER_UNARY_ALPHA_OP(nan_to_num, float, NanToNumParams_float, float);
+REGISTER_UNARY_ALPHA_OP(nan_to_num, half, NanToNumParams_float, half);
+REGISTER_UNARY_ALPHA_OP(nan_to_num, bfloat, NanToNumParams_float, bfloat);
+REGISTER_UNARY_ALPHA_OP(nan_to_num, float2, NanToNumParams_float, float2);
+REGISTER_UNARY_ALPHA_OP(nan_to_num, half2, NanToNumParams_float, half2);

--- a/aten/src/ATen/native/mps/operations/TensorCompare.mm
+++ b/aten/src/ATen/native/mps/operations/TensorCompare.mm
@@ -14,7 +14,6 @@
 #else
 #include <ATen/ops/eq.h>
 #include <ATen/ops/isin_native.h>
-#include <ATen/ops/nan_to_num_native.h>
 #include <ATen/ops/ones_like_native.h>
 #include <ATen/ops/result_type.h>
 #include <ATen/ops/where_native.h>
@@ -216,102 +215,6 @@ static void where_kernel_mps(TensorIterator& iter) {
   if (needsGather(out)) {
     out.copy_(out_);
   }
-}
-
-Tensor& nan_to_num_out_mps(const Tensor& self,
-                           std::optional<double> nan,
-                           std::optional<double> pos_inf,
-                           std::optional<double> neg_inf,
-                           Tensor& result) {
-  TORCH_CHECK(self.scalar_type() == result.scalar_type(),
-              "nan_to_num: dtype of out: ",
-              result.scalar_type(),
-              " should be same as input: ",
-              self.scalar_type());
-  if (result.numel() == 0) {
-    return result;
-  }
-  if (c10::isIntegralType(self.scalar_type(), /*includeBool=*/true)) {
-    at::native::resize_output(result, self.sizes());
-    result.copy_(self);
-    return result;
-  }
-  using namespace mps;
-  struct CachedGraph : public MPSCachedGraph {
-    CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
-    MPSGraphTensor* selfTensor = nil;
-    MPSGraphTensor* outputTensor = nil;
-    MPSGraphTensor* nanReplacementTensor = nil;
-    MPSGraphTensor* posInfReplacementTensor = nil;
-    MPSGraphTensor* negInfReplacementTensor = nil;
-  };
-
-  @autoreleasepool {
-    std::string key = "nan_to_num" + getTensorsStringKey({self});
-    MPSDataType self_dtype = getMPSScalarType(self.scalar_type());
-
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      newCachedGraph->selfTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
-      newCachedGraph->nanReplacementTensor = mpsGraphRankedPlaceHolder(mpsGraph, self_dtype, @[ @1 ]);
-      newCachedGraph->posInfReplacementTensor = mpsGraphRankedPlaceHolder(mpsGraph, self_dtype, @[ @1 ]);
-      newCachedGraph->negInfReplacementTensor = mpsGraphRankedPlaceHolder(mpsGraph, self_dtype, @[ @1 ]);
-
-      MPSGraphTensor* nanFreeTensor =
-          [mpsGraph selectWithPredicateTensor:[mpsGraph isNaNWithTensor:newCachedGraph->selfTensor name:nil]
-                          truePredicateTensor:newCachedGraph->nanReplacementTensor
-                         falsePredicateTensor:newCachedGraph->selfTensor
-                                         name:nil];
-      MPSGraphTensor* subZeroTensor = [mpsGraph lessThanWithPrimaryTensor:nanFreeTensor
-                                                          secondaryTensor:[mpsGraph constantWithScalar:0.0
-                                                                                              dataType:self_dtype]
-                                                                     name:nil];
-      MPSGraphTensor* isInfTensor = [mpsGraph isInfiniteWithTensor:nanFreeTensor name:nil];
-      // workaround for Monterey; On Ventura the output of lessThan() is always Boolean
-      if (subZeroTensor.dataType != MPSDataTypeBool) {
-        subZeroTensor = castMPSTensor(mpsGraph, subZeroTensor, kBool);
-      }
-      if (isInfTensor.dataType != MPSDataTypeBool) {
-        isInfTensor = castMPSTensor(mpsGraph, isInfTensor, kBool);
-      }
-      MPSGraphTensor* isNegInfTensor = [mpsGraph logicalANDWithPrimaryTensor:subZeroTensor
-                                                             secondaryTensor:isInfTensor
-                                                                        name:nil];
-      MPSGraphTensor* negInfFreeTensor = [mpsGraph selectWithPredicateTensor:isNegInfTensor
-                                                         truePredicateTensor:newCachedGraph->negInfReplacementTensor
-                                                        falsePredicateTensor:nanFreeTensor
-                                                                        name:nil];
-      newCachedGraph->outputTensor = [mpsGraph selectWithPredicateTensor:[mpsGraph isInfiniteWithTensor:negInfFreeTensor
-                                                                                                   name:nil]
-                                                     truePredicateTensor:newCachedGraph->posInfReplacementTensor
-                                                    falsePredicateTensor:negInfFreeTensor
-                                                                    name:nil];
-    });
-    MPSScalar nanReplacementScalar, posInfReplacementScalar, negInfReplacementScalar;
-    AT_DISPATCH_FLOATING_TYPES_AND2(kBFloat16, kHalf, self.scalar_type(), "nan_to_num_mps", [&]() {
-      scalar_t nan_replacement = static_cast<scalar_t>(nan.value_or(0.));
-      scalar_t pos_inf_replacement =
-          pos_inf.has_value() ? static_cast<scalar_t>(pos_inf.value()) : std::numeric_limits<scalar_t>::max();
-      scalar_t neg_inf_replacement =
-          neg_inf.has_value() ? static_cast<scalar_t>(neg_inf.value()) : std::numeric_limits<scalar_t>::lowest();
-
-      nanReplacementScalar = getMPSScalar(nan_replacement, self.scalar_type());
-      posInfReplacementScalar = getMPSScalar(pos_inf_replacement, self.scalar_type());
-      negInfReplacementScalar = getMPSScalar(neg_inf_replacement, self.scalar_type());
-    });
-
-    MPSStream* stream = getCurrentMPSStream();
-    Placeholder selfPlaceholder = Placeholder(cachedGraph->selfTensor, self);
-    Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor, result);
-
-    NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* feeds = @{
-      selfPlaceholder.getMPSGraphTensor() : selfPlaceholder.getMPSGraphTensorData(),
-      cachedGraph->nanReplacementTensor : getMPSGraphTensorFromScalar(stream, nanReplacementScalar),
-      cachedGraph->posInfReplacementTensor : getMPSGraphTensorFromScalar(stream, posInfReplacementScalar),
-      cachedGraph->negInfReplacementTensor : getMPSGraphTensorFromScalar(stream, negInfReplacementScalar),
-    };
-    runMPSGraph(stream, cachedGraph->graph(), feeds, outputPlaceholder);
-  }
-  return result;
 }
 
 static void isneginf_kernel_mps(TensorIteratorBase& iter) {

--- a/aten/src/ATen/native/mps/operations/UnaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryKernel.mm
@@ -1,9 +1,11 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/Dispatch.h>
 #include <ATen/TensorIterator.h>
 #include <ATen/mps/MPSProfiler.h>
 #include <ATen/native/Pow.h>
 #include <ATen/native/UnaryOps.h>
 #include <ATen/native/mps/OperationUtils.h>
+#include <ATen/native/mps/kernels/UnaryKernel.h>
 #include <fmt/format.h>
 
 namespace at::native {
@@ -66,6 +68,36 @@ static void polygamma_kernel(TensorIteratorBase& iter, int64_t order) {
   }
 }
 
+// Replacement values are computed per-dtype like the CUDA kernel (posinf and
+// neginf default to the input dtype's max/lowest) and ride at float, which
+// represents half/bfloat extrema exactly. Integral inputs never reach the
+// stub (nan_to_num_out copies them through).
+static void nan_to_num_kernel_mps(TensorIteratorBase& iter,
+                                  std::optional<double> nan,
+                                  std::optional<double> pos_inf,
+                                  std::optional<double> neg_inf) {
+  if (isComplexType(iter.common_dtype())) {
+    AT_DISPATCH_COMPLEX_TYPES_AND(kComplexHalf, iter.common_dtype(), "nan_to_num_mps", [&]() {
+      using value_t = c10::scalar_value_type<scalar_t>::type;
+      NanToNumParams<float> params{static_cast<float>(static_cast<value_t>(nan.value_or(0.))),
+                                   static_cast<float>(pos_inf.has_value() ? static_cast<value_t>(*pos_inf)
+                                                                          : std::numeric_limits<value_t>::max()),
+                                   static_cast<float>(neg_inf.has_value() ? static_cast<value_t>(*neg_inf)
+                                                                          : std::numeric_limits<value_t>::lowest())};
+      lib.exec_unary_kernel_with_params(iter, "nan_to_num", params, "NanToNumParams_float", /*ilp_threshold=*/1u << 18);
+    });
+    return;
+  }
+  AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, iter.common_dtype(), "nan_to_num_mps", [&]() {
+    NanToNumParams<float> params{static_cast<float>(static_cast<scalar_t>(nan.value_or(0.))),
+                                 static_cast<float>(pos_inf.has_value() ? static_cast<scalar_t>(*pos_inf)
+                                                                        : std::numeric_limits<scalar_t>::max()),
+                                 static_cast<float>(neg_inf.has_value() ? static_cast<scalar_t>(*neg_inf)
+                                                                        : std::numeric_limits<scalar_t>::lowest())};
+    lib.exec_unary_kernel_with_params(iter, "nan_to_num", params, "NanToNumParams_float", /*ilp_threshold=*/1u << 18);
+  });
+}
+
 REGISTER_UNARY_TI_DISPATCH(exp);
 REGISTER_UNARY_TI_DISPATCH(expm1);
 REGISTER_UNARY_TI_DISPATCH(erf);
@@ -102,4 +134,5 @@ REGISTER_DISPATCH(special_erfcx_stub, erfcx_kernel);
 REGISTER_DISPATCH(round_decimals_stub, round_decimals_kernel);
 REGISTER_DISPATCH(pow_tensor_scalar_stub, pow_tensor_scalar_kernel);
 REGISTER_DISPATCH(polygamma_stub, polygamma_kernel);
+REGISTER_DISPATCH(nan_to_num_stub, nan_to_num_kernel_mps);
 } // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3333,8 +3333,7 @@
 
 - func: nan_to_num.out(Tensor self, float? nan=None, float? posinf=None, float? neginf=None, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
-    CPU, CUDA, MTIA, XPU: nan_to_num_out
-    MPS: nan_to_num_out_mps
+    CPU, CUDA, MTIA, XPU, MPS: nan_to_num_out
     SparseCPU, SparseCUDA, SparseMPS, SparseXPU: nan_to_num_sparse_out
   tags: pointwise
 

--- a/c10/metal/indexing.h
+++ b/c10/metal/indexing.h
@@ -338,6 +338,40 @@ kernel void unary_alpha_dense(
   output[index] = f(input[index], alpha);
 }
 
+// ILP variant of unary_alpha_dense; mirrors unary_dense. Selected by the host
+// only when the caller opts in via ilp_threshold (see
+// exec_unary_kernel_with_params).
+template <typename T, typename T2, typename F>
+kernel void unary_alpha_dense_ilp(
+    device result_of<F, T, T2>* output [[buffer(0)]],
+    constant T* input [[buffer(1)]],
+    constant T2& alpha [[buffer(2)]],
+    constant uint& numel [[buffer(3)]],
+    uint index [[thread_position_in_grid]]) {
+  F f;
+  uint base = index * ILP_PER_THREAD;
+  if (base + ILP_PER_THREAD <= numel) {
+    array<T, ILP_PER_THREAD> tmp_in;
+    array<result_of<F, T, T2>, ILP_PER_THREAD> tmp_out;
+#pragma unroll
+    for (uint j = 0; j < ILP_PER_THREAD; ++j) {
+      tmp_in[j] = input[base + j];
+    }
+#pragma unroll
+    for (uint j = 0; j < ILP_PER_THREAD; ++j) {
+      tmp_out[j] = f(tmp_in[j], alpha);
+    }
+#pragma unroll
+    for (uint j = 0; j < ILP_PER_THREAD; ++j) {
+      output[base + j] = tmp_out[j];
+    }
+  } else {
+    for (uint i = base; i < numel; ++i) {
+      output[i] = f(input[i], alpha);
+    }
+  }
+}
+
 template <typename T, typename T2, typename F>
 kernel void unary_alpha_strided(
     device void* output [[buffer(0)]],
@@ -371,6 +405,15 @@ kernel void unary_alpha_strided(
               output,                                                      \
           constant DTYPEI * input,                                         \
           constant DTYPEA & alpha,                                         \
+          uint index);                                                     \
+  template [[host_name(#NAME "_dense_ilp_" #DTYPEO "_" #DTYPEI             \
+                             "_" #DTYPEA)]] kernel void ::c10::metal::     \
+      unary_alpha_dense_ilp<DTYPEI, DTYPEA, NAME##_functor>(               \
+          device ::c10::metal::result_of<NAME##_functor, DTYPEI, DTYPEA> * \
+              output,                                                      \
+          constant DTYPEI * input,                                         \
+          constant DTYPEA & alpha,                                         \
+          constant uint & numel,                                           \
           uint index);                                                     \
   template [[host_name(#NAME "_strided_" #DTYPEO "_" #DTYPEI               \
                              "_" #DTYPEA)]] kernel void ::c10::metal::     \

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -8765,6 +8765,21 @@ class TestMPS(TestCaseMPS):
         outputMPS = torch.nan_to_num(inputMPS, nan=2.0, posinf=1.0, neginf=-1.0)
         self.assertEqual(outputMPS, outputCPU)
 
+    def test_nan_to_num_complex(self):
+        # Complex nan_to_num is new on MPS (the MPSGraph path raised); the
+        # replacement applies per component like CPU/CUDA. complex32 exceeds
+        # CPU/CUDA support, so it compares against the complex64 CPU result
+        # with half-extrema (65504) defaults per its value type.
+        x = torch.tensor([complex(float('nan'), 1.0),
+                          complex(float('inf'), float('-inf')),
+                          complex(2.0, float('nan')), 1 + 2j])
+        self.assertEqual(torch.nan_to_num(x.to('mps')).cpu(), torch.nan_to_num(x))
+        self.assertEqual(torch.nan_to_num(x.to('mps'), nan=1.0, posinf=3.0, neginf=-3.0).cpu(),
+                         torch.nan_to_num(x, nan=1.0, posinf=3.0, neginf=-3.0))
+        actual = torch.nan_to_num(x.to(torch.complex32).to('mps')).cpu().to(torch.complex64)
+        expected = torch.nan_to_num(x, posinf=65504.0, neginf=-65504.0)
+        self.assertEqual(actual, expected)
+
     # Test where
     def test_where(self):
         def helper(shape, x_shape, y_shape, cond_dtype=torch.bool, x_dtype=torch.float):

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -19830,9 +19830,6 @@ op_db: list[OpInfo] = [
                    skips=(
                        DecorateInfo(unittest.skip("Skipped! sparse backward not supported"),
                                     'TestSparseUnaryUfuncs', 'test_sparse_fn_grad'),
-                       # AssertionError: The values for attribute 'shape' do not match: torch.Size([20]) != torch.Size([0]).
-                       DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out', device_type='mps'),
-                       DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out_warning', device_type='mps'),
                    ),
                    # Passing numpy_kwargs via sample_kwargs, as numpy does comparison
                    # with BFloat16 in float, since it currently doesn't support BFloat16.


### PR DESCRIPTION
Replaces the MPSGraph `nan_to_num` with a Metal kernel on the shared `exec_unary_kernel` iterator path

## ILP dense variant

Adds `unary_alpha_dense_ilp` (a direct mirror of `unary_dense`) plus **opt-in** `ilp_threshold` routing in `exec_unary_kernel_with_params`. For a trivial-ALU op like nan_to_num the 1-elem/thread alpha kernel loses ~15-20% to the graph's fused select at large float16 shapes (bandwidth-bound). Routing is opt-in per call site, so every existing alpha/params op keeps its exact current dispatch; nan_to_num opts in at the same 256K crossover the plain path uses.

## Scalar handling

Replacement values are computed per-dtype on the host like the CUDA kernel (`posinf`/`neginf` default to the input dtype's `max()`/`lowest()`, so float16 gets 65504) and ride at float, which represents half/bfloat extrema exactly. Overflowing explicit kwargs single-round to inf like CPU/CUDA.

## Behavior fixes vs the old graph path

- **Complex support is new**: the graph path raised on complex inputs. complex64 now aligns MPS with CPU/CUDA (MPS was the outlier); complex32 exceeds both (they raise), applying the replacement per component. Covered by a new `test_mps.py` test.
- **`out=` resize bug fixed**: the old body returned early on `result.numel() == 0` before resizing a wrong-shaped empty out tensor - the root cause of the two `TestCommon` `test_out`/`test_out_warning` MPS xfails, which are now removed.

Standalone parity sweep vs CPU: f32/f16/bf16 x 5 kwarg combinations, complex64/complex32 per-component, signed zero / -nan / subnormals, overflowing kwargs, integral passthrough, in-place on strided views, `out=`, empty, ILP tail sizes (`numel % 4 != 0`) and the 256K crossover edges. Metal path measured 1.0-3.6x over the MPSGraph baseline across 26 shape/dtype cells on M4 Pro with no regressions.
