### PR TITLE
[MPS] Migrate threshold, threshold_backward, hardtanh_backward and tanh_backward to Metal kernels

### DIFF
--- a/aten/src/ATen/native/mps/MetalShaderLibrary.h
+++ b/aten/src/ATen/native/mps/MetalShaderLibrary.h
@@ -205,7 +205,8 @@ class MetalShaderLibrary {
       TensorIteratorBase& iter,
       const std::string& name,
       T params,
-      const std::string& params_type_name);
+      const std::string& params_type_name,
+      const std::optional<uint32_t> ilp_threshold = std::nullopt);
 
  protected:
   virtual MTLLibrary_t getLibrary();

--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -13,6 +13,7 @@
 #include <ATen/native/mps/MetalShaderLibrary.h>
 #include <ATen/native/mps/TensorFactory.h>
 #include <c10/core/ScalarType.h>
+#include <c10/metal/common.h>
 #include <fmt/format.h>
 #include <torch/library.h>
 #include <limits>
@@ -754,7 +755,8 @@ template <typename T>
 void MetalShaderLibrary::exec_binary_kernel_with_params(TensorIteratorBase& iter,
                                                         const std::string& name,
                                                         T params,
-                                                        const std::string& params_type_name) {
+                                                        const std::string& params_type_name,
+                                                        const std::optional<uint32_t> ilp_threshold) {
   using namespace mps;
   // TODO: Figure a better place to downcast double scalars (probably in tensor iterator itself?)
   // Right now running something like 1.0-torch.rand(5, device='mps') will create iterator with
@@ -769,7 +771,7 @@ void MetalShaderLibrary::exec_binary_kernel_with_params(TensorIteratorBase& iter
   // Decompose 64-bit tensor into 32-bit ones
   if (!iter.can_use_32bit_indexing()) {
     for (auto&& sub_iter : iter.with_32bit_indexing()) {
-      exec_binary_kernel_with_params(sub_iter, name, params, params_type_name);
+      exec_binary_kernel_with_params(sub_iter, name, params, params_type_name, ilp_threshold);
     }
     return;
   }
@@ -794,7 +796,11 @@ void MetalShaderLibrary::exec_binary_kernel_with_params(TensorIteratorBase& iter
 
   MPSStream* mpsStream = getCurrentMPSStream();
   const auto cast_needed = input.scalar_type() != other.scalar_type();
-  const auto suffix = iter.is_contiguous() ? "dense" : "strided";
+  // ILP is opt-in per call site (mirrors exec_unary_kernel_with_params):
+  // callers with cheap bandwidth-bound functors pass a crossover threshold.
+  const bool dense_ilp = iter.is_contiguous() && !cast_needed && ilp_threshold.has_value() &&
+      iter.numel() >= static_cast<int64_t>(ilp_threshold.value());
+  const auto suffix = dense_ilp ? "dense_ilp" : (iter.is_contiguous() ? "dense" : "strided");
   // TODO: Implicitly pass both input and output types to non-cast kernels
   const auto kernel_name = cast_needed
       ? fmt::format("{}_{}_cast_{}_{}", name, suffix, scalarToMetalTypeString(out), params_type_name)
@@ -817,6 +823,9 @@ void MetalShaderLibrary::exec_binary_kernel_with_params(TensorIteratorBase& iter
       // i.e. it's true for both row-first and column-first tensors
       if (iter.is_contiguous()) {
         detail::mtl_setArg(computeEncoder, params, 3);
+        if (dense_ilp) {
+          mtl_setBytes(computeEncoder, static_cast<uint32_t>(iter.numel()), 4);
+        }
         if (cast_needed) {
           std::array<int, 4> size_and_types = {static_cast<int>(c10::elementSize(input.scalar_type())),
                                                static_cast<int>(c10::elementSize(other.scalar_type())),
@@ -835,7 +844,10 @@ void MetalShaderLibrary::exec_binary_kernel_with_params(TensorIteratorBase& iter
         mtl_setArgs<3>(
             computeEncoder, params, iter.shape(), iter.strides(0), iter.strides(1), iter.strides(2), ndim_and_types);
       }
-      mtl_dispatch1DJob(computeEncoder, binaryPSO, iter.numel());
+      mtl_dispatch1DJob(
+          computeEncoder,
+          binaryPSO,
+          dense_ilp ? (iter.numel() + c10::metal::ILP_PER_THREAD - 1) / c10::metal::ILP_PER_THREAD : iter.numel());
       getMPSProfiler().endProfileKernel(binaryPSO);
     }
   });

--- a/aten/src/ATen/native/mps/kernels/Activation.h
+++ b/aten/src/ATen/native/mps/kernels/Activation.h
@@ -1,5 +1,13 @@
 #pragma once
 
+// min/max are converted to opmath precision (float) on the host, matching the
+// CUDA kernel, so this struct is always instantiated at T = float.
+template <typename T>
+struct HardtanhBackwardParams {
+  T min;
+  T max;
+};
+
 template <typename T>
 struct ELUParams {
   T alpha;

--- a/aten/src/ATen/native/mps/kernels/Activation.h
+++ b/aten/src/ATen/native/mps/kernels/Activation.h
@@ -8,6 +8,14 @@ struct HardtanhBackwardParams {
   T max;
 };
 
+// threshold/value ride at float for floating dtypes (CUDA opmath convention);
+// integral dtypes instantiate at scalar_t for exactness.
+template <typename T>
+struct ThresholdParams {
+  T threshold;
+  T value;
+};
+
 template <typename T>
 struct ELUParams {
   T alpha;

--- a/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
@@ -119,6 +119,28 @@ REGISTER_BINARY_OP(hardswish_backward, float, float);
 REGISTER_BINARY_OP(hardswish_backward, half, half);
 REGISTER_BINARY_OP(hardswish_backward, bfloat, bfloat);
 
+// min/max ride at opmath (float) precision, mirroring the CUDA kernel's
+// Scalar-to-opmath conversion.
+struct hardtanh_backward_functor {
+  template <typename T>
+  inline T operator()(
+      const T grad_output,
+      const T self,
+      const HardtanhBackwardParams<float> params) {
+    const float sf = float(self);
+    return (sf <= params.min || sf >= params.max) ? T(0) : grad_output;
+  }
+};
+
+#define REGISTER_HARDTANH_BACKWARD_OP(T) \
+  REGISTER_BINARY_ALPHA_OP(              \
+      hardtanh_backward, T, HardtanhBackwardParams_float, T);
+
+typedef HardtanhBackwardParams<float> HardtanhBackwardParams_float;
+REGISTER_HARDTANH_BACKWARD_OP(float);
+REGISTER_HARDTANH_BACKWARD_OP(half);
+REGISTER_HARDTANH_BACKWARD_OP(bfloat);
+
 struct elu_functor {
   template <typename T>
   inline T operator()(const T self_, const ELUParams<T> params) {
@@ -353,6 +375,26 @@ REGISTER_BINARY_OP(sigmoid_backward, half, half);
 REGISTER_BINARY_OP(sigmoid_backward, bfloat, bfloat);
 REGISTER_BINARY_OP(sigmoid_backward, float2, float2);
 REGISTER_BINARY_OP(sigmoid_backward, half2, half2);
+
+struct tanh_backward_functor {
+  template <typename T, enable_if_t<is_scalar_floating_point_v<T>, bool> = true>
+  inline T operator()(const T grad_output, const T output) {
+    const float of = float(output);
+    return static_cast<T>(float(grad_output) * (1.0f - of * of));
+  }
+  template <typename T, enable_if_t<is_complex_v<T>, bool> = true>
+  inline T operator()(const T grad_output, const T output) {
+    return c10::metal::mul(
+        grad_output,
+        c10::metal::conj(T(1, 0) - c10::metal::mul(output, output)));
+  }
+};
+
+REGISTER_BINARY_OP(tanh_backward, float, float);
+REGISTER_BINARY_OP(tanh_backward, half, half);
+REGISTER_BINARY_OP(tanh_backward, bfloat, bfloat);
+REGISTER_BINARY_OP(tanh_backward, float2, float2);
+REGISTER_BINARY_OP(tanh_backward, half2, half2);
 
 struct glu_functor {
   template <typename T>

--- a/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
@@ -141,6 +141,48 @@ REGISTER_HARDTANH_BACKWARD_OP(float);
 REGISTER_HARDTANH_BACKWARD_OP(half);
 REGISTER_HARDTANH_BACKWARD_OP(bfloat);
 
+// Shared by threshold() and threshold_backward(): the meta function builds the
+// iterator as (self, other) with other = self (forward) or grad (backward,
+// with value = 0), computing `self <= threshold ? value : other`. For floating
+// dtypes the scalars ride at opmath (float) precision like the CUDA kernel --
+// no quantization to half/bfloat and no Scalar overflow throw; integral dtypes
+// keep exact scalar_t params (float would lose int64 exactness past 2^24).
+struct threshold_functor {
+  template <typename T, enable_if_t<is_scalar_floating_point_v<T>, bool> = true>
+  inline T operator()(
+      const T self,
+      const T other,
+      const ThresholdParams<float> params) {
+    return float(self) <= params.threshold ? static_cast<T>(params.value)
+                                           : other;
+  }
+  template <
+      typename T,
+      enable_if_t<!is_scalar_floating_point_v<T>, bool> = true>
+  inline T operator()(
+      const T self,
+      const T other,
+      const ThresholdParams<T> params) {
+    return self <= params.threshold ? params.value : other;
+  }
+};
+
+typedef ThresholdParams<float> ThresholdParams_float;
+REGISTER_BINARY_ALPHA_OP(threshold, float, ThresholdParams_float, float);
+REGISTER_BINARY_ALPHA_OP(threshold, half, ThresholdParams_float, half);
+REGISTER_BINARY_ALPHA_OP(threshold, bfloat, ThresholdParams_float, bfloat);
+
+#define REGISTER_THRESHOLD_INT_OP(T)              \
+  typedef ThresholdParams<T> ThresholdParams_##T; \
+  REGISTER_BINARY_ALPHA_OP(threshold, T, ThresholdParams_##T, T);
+
+REGISTER_THRESHOLD_INT_OP(long);
+REGISTER_THRESHOLD_INT_OP(int);
+REGISTER_THRESHOLD_INT_OP(short);
+REGISTER_THRESHOLD_INT_OP(char);
+REGISTER_THRESHOLD_INT_OP(uchar);
+REGISTER_THRESHOLD_INT_OP(bool);
+
 struct elu_functor {
   template <typename T>
   inline T operator()(const T self_, const ELUParams<T> params) {

--- a/aten/src/ATen/native/mps/operations/Activation.mm
+++ b/aten/src/ATen/native/mps/operations/Activation.mm
@@ -14,11 +14,9 @@
 #include <ATen/ops/_prelu_kernel_native.h>
 #include <ATen/ops/gelu_backward_native.h>
 #include <ATen/ops/gelu_native.h>
-#include <ATen/ops/hardtanh_backward_native.h>
 #include <ATen/ops/relu_native.h>
 #include <ATen/ops/softplus_backward_native.h>
 #include <ATen/ops/softplus_native.h>
-#include <ATen/ops/tanh_backward_native.h>
 #include <ATen/ops/threshold_backward_native.h>
 #include <ATen/ops/threshold_native.h>
 #endif
@@ -116,46 +114,6 @@ TORCH_IMPL_FUNC(log_softmax_backward_mps_out)
     // Create dictionary of inputs and outputs
     auto feeds = dictionaryFromPlaceholders(gradPlaceholder, outputPlaceholder);
     runMPSGraph(stream, cachedGraph->graph(), feeds, resultPlaceholder);
-  }
-}
-
-TORCH_IMPL_FUNC(tanh_backward_out_mps)(const Tensor& grad_output, const Tensor& output, const Tensor& grad_input) {
-  using namespace mps;
-  using CachedGraph = MPSUnaryGradCachedGraph;
-  TORCH_CHECK(grad_input.is_mps());
-
-  if (grad_output.numel() == 0) {
-    return;
-  }
-
-  MPSStream* stream = getCurrentMPSStream();
-
-  @autoreleasepool {
-    std::string key = "tanh_backward_out_mps:" + getMPSTypeString(grad_output);
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSGraphTensor* gradOutputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(grad_output));
-      MPSGraphTensor* outputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(output));
-
-      MPSGraphTensor* unitTensor = [mpsGraph constantWithScalar:1.0 shape:@[ @1 ] dataType:getMPSDataType(grad_output)];
-      MPSGraphTensor* tanh2Tensor = [mpsGraph squareWithTensor:outputTensor name:nil];
-      MPSGraphTensor* oneMinusTanh2Tensor = [mpsGraph subtractionWithPrimaryTensor:unitTensor
-                                                                   secondaryTensor:tanh2Tensor
-                                                                              name:nil];
-      MPSGraphTensor* gradInputTensor = [mpsGraph multiplicationWithPrimaryTensor:gradOutputTensor
-                                                                  secondaryTensor:oneMinusTanh2Tensor
-                                                                             name:nil];
-
-      newCachedGraph->gradOutputTensor_ = gradOutputTensor;
-      newCachedGraph->outputTensor_ = outputTensor;
-      newCachedGraph->gradInputTensor_ = gradInputTensor;
-    });
-
-    Placeholder gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_output);
-    Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output);
-    Placeholder gradInputPlaceholder = Placeholder(cachedGraph->gradInputTensor_, grad_input);
-
-    auto feeds = dictionaryFromPlaceholders(gradOutputPlaceholder, outputPlaceholder);
-    runMPSGraph(stream, cachedGraph->graph(), feeds, gradInputPlaceholder);
   }
 }
 
@@ -539,92 +497,6 @@ std::tuple<Tensor, Tensor> prelu_backward_mps(const Tensor& grad_output, const T
     runMPSGraph(stream, cachedGraph->graph(), feeds, results);
   }
   return std::tuple<Tensor, Tensor>{grad_input, weight_grad};
-}
-
-// -------------------------------------------------
-// Hardtanh backward
-
-Tensor hardtanh_backward_mps(const Tensor& grad_output, const Tensor& self, const Scalar& min, const Scalar& max) {
-  Tensor grad_input =
-      at::empty(grad_output.sizes(), grad_output.scalar_type(), std::nullopt, kMPS, std::nullopt, std::nullopt);
-  grad_input = hardtanh_backward_out_mps(grad_output, self, min, max, grad_input);
-  return grad_input;
-}
-
-// Hardtanh backward
-Tensor& hardtanh_backward_out_mps(const Tensor& grad_output,
-                                  const Tensor& self,
-                                  const Scalar& min,
-                                  const Scalar& max,
-                                  Tensor& grad_input) {
-  using namespace mps;
-  using CachedGraph = MPSUnaryGradCachedGraph;
-  TORCH_CHECK(grad_output.is_mps());
-
-  // Empty output
-  if (grad_input.numel() == 0)
-    return grad_input;
-
-  MPSStream* stream = getCurrentMPSStream();
-
-  @autoreleasepool {
-    std::string key = "hardtanh_backward_out_mps:" + getTensorsStringKey({grad_output}) + ":" +
-        std::to_string(min.to<double>()) + ":" + std::to_string(max.to<double>());
-
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSGraphTensor* gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_output);
-      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
-
-      // TODO: Compute gradient
-      MPSGraphTensor* unitTensor = [mpsGraph constantWithScalar:1.0f
-                                                          shape:@[ @1 ]
-                                                       dataType:getMPSDataType(grad_output)];
-      MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0f
-                                                          shape:@[ @1 ]
-                                                       dataType:getMPSDataType(grad_output)];
-      MPSGraphTensor* minTensor = [mpsGraph constantWithScalar:min.to<double>()
-                                                         shape:@[ @1 ]
-                                                      dataType:getMPSDataType(grad_output)];
-      MPSGraphTensor* maxTensor = [mpsGraph constantWithScalar:max.to<double>()
-                                                         shape:@[ @1 ]
-                                                      dataType:getMPSDataType(grad_output)];
-      MPSGraphTensor* greaterThanMaxPredicateTensor = [mpsGraph greaterThanWithPrimaryTensor:inputTensor
-                                                                             secondaryTensor:maxTensor
-                                                                                        name:nil];
-      MPSGraphTensor* lesserThanMinPredicateTensor = [mpsGraph lessThanWithPrimaryTensor:inputTensor
-                                                                         secondaryTensor:minTensor
-                                                                                    name:nil];
-      MPSGraphTensor* greaterThanMaxGradTensor = [mpsGraph selectWithPredicateTensor:greaterThanMaxPredicateTensor
-                                                                 truePredicateTensor:zeroTensor
-                                                                falsePredicateTensor:unitTensor
-                                                                                name:nil];
-      MPSGraphTensor* lesserThanMinGradTensor = [mpsGraph selectWithPredicateTensor:lesserThanMinPredicateTensor
-                                                                truePredicateTensor:zeroTensor
-                                                               falsePredicateTensor:unitTensor
-                                                                               name:nil];
-      MPSGraphTensor* gradTensor = [mpsGraph multiplicationWithPrimaryTensor:greaterThanMaxGradTensor
-                                                             secondaryTensor:lesserThanMinGradTensor
-                                                                        name:nil];
-      MPSGraphTensor* gradInputTensor = [mpsGraph multiplicationWithPrimaryTensor:gradTensor
-                                                                  secondaryTensor:gradOutputTensor
-                                                                             name:nil];
-
-      newCachedGraph->gradOutputTensor_ = gradOutputTensor;
-      newCachedGraph->inputTensor_ = inputTensor;
-      newCachedGraph->gradInputTensor_ = gradInputTensor;
-    });
-
-    Placeholder gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_output);
-    Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self);
-    Placeholder gradInputPlaceholder = Placeholder(cachedGraph->gradInputTensor_, grad_input);
-
-    // Create dictionary of inputs and outputs
-    auto feeds = dictionaryFromPlaceholders(gradOutputPlaceholder, selfPlaceholder);
-    auto results = dictionaryFromPlaceholders(gradInputPlaceholder);
-    runMPSGraph(stream, cachedGraph->graph(), feeds, results);
-  }
-
-  return grad_input;
 }
 
 } // namespace at::native

--- a/aten/src/ATen/native/mps/operations/Activation.mm
+++ b/aten/src/ATen/native/mps/operations/Activation.mm
@@ -17,8 +17,6 @@
 #include <ATen/ops/relu_native.h>
 #include <ATen/ops/softplus_backward_native.h>
 #include <ATen/ops/softplus_native.h>
-#include <ATen/ops/threshold_backward_native.h>
-#include <ATen/ops/threshold_native.h>
 #endif
 
 using namespace at::mps;
@@ -114,106 +112,6 @@ TORCH_IMPL_FUNC(log_softmax_backward_mps_out)
     // Create dictionary of inputs and outputs
     auto feeds = dictionaryFromPlaceholders(gradPlaceholder, outputPlaceholder);
     runMPSGraph(stream, cachedGraph->graph(), feeds, resultPlaceholder);
-  }
-}
-
-TORCH_IMPL_FUNC(threshold_out_mps)
-(const Tensor& self, const Scalar& threshold, const Scalar& value, const Tensor& result) {
-  using namespace mps;
-  using CachedGraph = MPSUnaryCachedGraph;
-  TORCH_CHECK(self.is_mps());
-
-  if (result.numel() == 0)
-    return;
-
-  MPSStream* stream = getCurrentMPSStream();
-
-  @autoreleasepool {
-    std::string key = "threshold_out_mps" + getTensorsStringKey({self}) + ":" + std::to_string(threshold.to<double>()) +
-        ":" + std::to_string(value.to<double>());
-
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
-
-      MPSGraphTensor* thresholdTensor = [mpsGraph constantWithScalar:threshold.to<double>()
-                                                               shape:@[ @1 ]
-                                                            dataType:getMPSDataType(self)];
-
-      MPSGraphTensor* valueTensor = [mpsGraph constantWithScalar:value.to<double>()
-                                                           shape:@[ @1 ]
-                                                        dataType:getMPSDataType(self)];
-
-      // x > threshold
-      MPSGraphTensor* predicateTensor = [mpsGraph greaterThanWithPrimaryTensor:inputTensor
-                                                               secondaryTensor:thresholdTensor
-                                                                          name:nil];
-
-      // result = (self > threshold) ? self : value
-      MPSGraphTensor* outputTensor = [mpsGraph selectWithPredicateTensor:predicateTensor
-                                                     truePredicateTensor:inputTensor
-                                                    falsePredicateTensor:valueTensor
-                                                                    name:nil];
-
-      newCachedGraph->inputTensor_ = inputTensor;
-      newCachedGraph->outputTensor_ = outputTensor;
-    });
-
-    Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self);
-    Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, result);
-
-    auto feeds = dictionaryFromPlaceholders(selfPlaceholder);
-    runMPSGraph(stream, cachedGraph->graph(), feeds, outputPlaceholder);
-  }
-}
-
-TORCH_IMPL_FUNC(threshold_backward_out_mps)
-(const Tensor& grad, const Tensor& self, const Scalar& threshold, const Tensor& gradInput) {
-  using namespace mps;
-  using CachedGraph = MPSUnaryGradCachedGraph;
-  TORCH_CHECK(self.is_mps());
-  TORCH_CHECK(grad.is_mps());
-
-  if (gradInput.numel() == 0)
-    return;
-
-  MPSStream* stream = getCurrentMPSStream();
-
-  @autoreleasepool {
-    std::string key =
-        "threshold_backward_out_mps" + getTensorsStringKey({self, grad}) + ":" + std::to_string(threshold.to<double>());
-
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
-      MPSGraphTensor* gradTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad);
-
-      MPSGraphTensor* thresholdTensor = [mpsGraph constantWithScalar:threshold.to<double>()
-                                                               shape:@[ @1 ]
-                                                            dataType:getMPSDataType(self)];
-
-      MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0 dataType:inputTensor.dataType];
-
-      // x > threshold
-      MPSGraphTensor* predicateTensor = [mpsGraph greaterThanWithPrimaryTensor:inputTensor
-                                                               secondaryTensor:thresholdTensor
-                                                                          name:nil];
-
-      // result = (self > threshold) ? grad : zeroTensor
-      MPSGraphTensor* gradInputTensor = [mpsGraph selectWithPredicateTensor:predicateTensor
-                                                        truePredicateTensor:gradTensor
-                                                       falsePredicateTensor:zeroTensor
-                                                                       name:nil];
-
-      newCachedGraph->gradOutputTensor_ = gradTensor;
-      newCachedGraph->inputTensor_ = inputTensor;
-      newCachedGraph->gradInputTensor_ = gradInputTensor;
-    });
-
-    Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self);
-    Placeholder gradPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad);
-    Placeholder outputPlaceholder = Placeholder(cachedGraph->gradInputTensor_, gradInput);
-
-    auto feeds = dictionaryFromPlaceholders(gradPlaceholder, selfPlaceholder);
-    runMPSGraph(stream, cachedGraph->graph(), feeds, outputPlaceholder);
   }
 }
 

--- a/aten/src/ATen/native/mps/operations/ActivationKernel.mm
+++ b/aten/src/ATen/native/mps/operations/ActivationKernel.mm
@@ -89,12 +89,33 @@ static void hardswish_backward_kernel(at::TensorIterator& iter) {
 static void hardtanh_backward_kernel(TensorIterator& iter, const Scalar& min, const Scalar& max) {
   AT_DISPATCH_FLOATING_TYPES_AND2(c10::kHalf, c10::kBFloat16, iter.common_dtype(), "hardtanh_backward_mps", [&]() {
     HardtanhBackwardParams<float> params{min.to<float>(), max.to<float>()};
-    lib.exec_binary_kernel_with_params(iter, "hardtanh_backward", params, "HardtanhBackwardParams_float");
+    lib.exec_binary_kernel_with_params(
+        iter, "hardtanh_backward", params, "HardtanhBackwardParams_float", /*ilp_threshold=*/1u << 18);
   });
 }
 
 static void tanh_backward_kernel(TensorIteratorBase& iter) {
   lib.exec_binary_kernel(iter, "tanh_backward");
+}
+
+// Floating dtypes: scalars convert to float (opmath) once on the host like
+// the CUDA kernel -- no quantization to half/bfloat and no Scalar::to<Half>
+// overflow throw. Integral dtypes keep exact scalar_t params.
+static void threshold_kernel(TensorIteratorBase& iter, const Scalar& threshold, const Scalar& value) {
+  if (c10::isFloatingType(iter.common_dtype())) {
+    ThresholdParams<float> params{threshold.to<float>(), value.to<float>()};
+    lib.exec_binary_kernel_with_params(iter, "threshold", params, "ThresholdParams_float", /*ilp_threshold=*/1u << 18);
+    return;
+  }
+  AT_DISPATCH_INTEGRAL_TYPES_AND(c10::kBool, iter.common_dtype(), "threshold_mps", [&]() {
+    ThresholdParams<scalar_t> params{threshold.to<scalar_t>(), value.to<scalar_t>()};
+    lib.exec_binary_kernel_with_params(
+        iter,
+        "threshold",
+        params,
+        fmt::format("ThresholdParams_{}", mps::scalarToMetalTypeString(iter.common_dtype())),
+        /*ilp_threshold=*/1u << 18);
+  });
 }
 
 static void elu_kernel(TensorIteratorBase& iter, const Scalar& alpha, const Scalar& scale, const Scalar& input_scale) {
@@ -355,6 +376,7 @@ Tensor log_sigmoid_backward_mps(const Tensor& grad_output, const Tensor& self, c
   return grad_input;
 }
 
+REGISTER_DISPATCH(threshold_stub, threshold_kernel);
 REGISTER_DISPATCH(hardtanh_backward_stub, hardtanh_backward_kernel);
 REGISTER_DISPATCH(tanh_backward_stub, tanh_backward_kernel);
 REGISTER_DISPATCH(hardshrink_stub, hardshrink_kernel);

--- a/aten/src/ATen/native/mps/operations/ActivationKernel.mm
+++ b/aten/src/ATen/native/mps/operations/ActivationKernel.mm
@@ -83,6 +83,20 @@ static void hardswish_backward_kernel(at::TensorIterator& iter) {
   lib.exec_binary_kernel(iter, "hardswish_backward");
 }
 
+// min/max convert to float (opmath) once on the host, matching the CUDA
+// kernel; the params struct is instantiated at float for every dtype. The
+// dispatch macro only enforces the supported-dtype set (scalar_t is unused).
+static void hardtanh_backward_kernel(TensorIterator& iter, const Scalar& min, const Scalar& max) {
+  AT_DISPATCH_FLOATING_TYPES_AND2(c10::kHalf, c10::kBFloat16, iter.common_dtype(), "hardtanh_backward_mps", [&]() {
+    HardtanhBackwardParams<float> params{min.to<float>(), max.to<float>()};
+    lib.exec_binary_kernel_with_params(iter, "hardtanh_backward", params, "HardtanhBackwardParams_float");
+  });
+}
+
+static void tanh_backward_kernel(TensorIteratorBase& iter) {
+  lib.exec_binary_kernel(iter, "tanh_backward");
+}
+
 static void elu_kernel(TensorIteratorBase& iter, const Scalar& alpha, const Scalar& scale, const Scalar& input_scale) {
   AT_DISPATCH_FLOATING_TYPES_AND2(c10::kHalf, c10::kBFloat16, iter.common_dtype(), "elu_mps", [&]() {
     ELUParams<scalar_t> params{alpha.to<scalar_t>(), scale.to<scalar_t>(), input_scale.to<scalar_t>()};
@@ -341,6 +355,8 @@ Tensor log_sigmoid_backward_mps(const Tensor& grad_output, const Tensor& self, c
   return grad_input;
 }
 
+REGISTER_DISPATCH(hardtanh_backward_stub, hardtanh_backward_kernel);
+REGISTER_DISPATCH(tanh_backward_stub, tanh_backward_kernel);
 REGISTER_DISPATCH(hardshrink_stub, hardshrink_kernel);
 REGISTER_DISPATCH(softshrink_stub, softshrink_kernel);
 REGISTER_DISPATCH(shrink_backward_stub, shrink_backward_kernel);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -6094,15 +6094,13 @@
   structured: True
   structured_inherits: TensorIteratorBase
   dispatch:
-    CPU, CUDA, XPU: threshold_out
-    MPS: threshold_out_mps
+    CPU, CUDA, XPU, MPS: threshold_out
 
 - func: threshold_backward.grad_input(Tensor grad_output, Tensor self, Scalar threshold, *, Tensor(a!) grad_input) -> Tensor(a!)
   structured: True
   structured_inherits: TensorIteratorBase
   dispatch:
-    CPU, CUDA, XPU: threshold_backward_out
-    MPS: threshold_backward_out_mps
+    CPU, CUDA, XPU, MPS: threshold_backward_out
     SparseCPU, SparseCUDA, SparseXPU: threshold_backward_sparse_out
     SparseCsrCPU, SparseCsrCUDA, SparseCsrMeta, SparseCsrXPU: threshold_backward_sparse_compressed_out
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -12137,14 +12137,12 @@
 - func: hardtanh_backward.grad_input(Tensor grad_output, Tensor self, Scalar min_val, Scalar max_val, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
   dispatch:
-    CPU, CUDA, XPU: hardtanh_backward_out
-    MPS: hardtanh_backward_out_mps
+    CPU, CUDA, XPU, MPS: hardtanh_backward_out
 
 - func: hardtanh_backward(Tensor grad_output, Tensor self, Scalar min_val, Scalar max_val) -> Tensor
   python_module: nn
   dispatch:
-    CPU, CUDA, XPU: hardtanh_backward
-    MPS: hardtanh_backward_mps
+    CPU, CUDA, XPU, MPS: hardtanh_backward
 
 - func: hardtanh_(Tensor(a!) self, Scalar min_val=-1, Scalar max_val=1) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
@@ -13325,8 +13323,7 @@
   structured: True
   structured_inherits: TensorIteratorBase
   dispatch:
-    CPU, CUDA, MTIA, XPU: tanh_backward_out
-    MPS: tanh_backward_out_mps
+    CPU, CUDA, MTIA, XPU, MPS: tanh_backward_out
   tags: pointwise
 
 - func: tanh_backward(Tensor grad_output, Tensor output) -> Tensor

--- a/benchmarks/mps/bench_activations.py
+++ b/benchmarks/mps/bench_activations.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""A/B benchmark for MPS activation backward ops migrated from MPSGraph to
+Metal: hardtanh_backward and tanh_backward.
+
+Run once with a stock nightly wheel (MPSGraph baseline) and once with this
+build (Metal); each cell amortizes K iterations behind a single
+torch.mps.synchronize() so the ~110us sync floor does not mask kernel cost.
+"""
+
+import argparse
+
+import torch
+from torch.utils.benchmark import Timer
+
+
+K = 20
+SHAPES = [(4096,), (512, 768), (2048, 2048), (16, 128, 1024), (32, 4096)]
+DTYPES = [torch.float32, torch.float16]
+
+
+def bench_cell(stmt, glb):
+    t = Timer(stmt=stmt, globals=glb)
+    return t.blocked_autorange(min_run_time=0.4).median / K * 1e3
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--label", default="run")
+    args = parser.parse_args()
+    print(f"label={args.label} torch={torch.__version__}")
+
+    aten = torch.ops.aten
+    for dt in DTYPES:
+        for shape in SHAPES:
+            x = torch.randn(*shape, device="mps", dtype=dt)
+            g = torch.randn(*shape, device="mps", dtype=dt)
+            y = torch.tanh(x)
+            glb = {"torch": torch, "aten": aten, "x": x, "g": g, "y": y, "K": K}
+            cells = {
+                "hardtanh_bwd": "\nfor _ in range(K): aten.hardtanh_backward(g, x, -1, 1)\ntorch.mps.synchronize()",
+                "tanh_bwd": "\nfor _ in range(K): aten.tanh_backward(g, y)\ntorch.mps.synchronize()",
+            }
+            for name, stmt in cells.items():
+                ms = bench_cell(stmt, glb)
+                print(
+                    f"{name} {str(dt).replace('torch.', ''):<9} {str(shape):<17} {ms:10.5f}"
+                )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/mps/bench_threshold.py
+++ b/benchmarks/mps/bench_threshold.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""A/B benchmark for MPS threshold/threshold_backward migrated from MPSGraph
+to Metal (threshold_backward is also relu's backward).
+
+Run once with a stock nightly wheel (MPSGraph baseline) and once with this
+build (Metal); each cell amortizes K iterations behind a single
+torch.mps.synchronize() so the ~110us sync floor does not mask kernel cost.
+"""
+
+import argparse
+
+import torch
+import torch.nn.functional as F
+from torch.utils.benchmark import Timer
+
+
+K = 20
+SHAPES = [(4096,), (64, 4096), (512, 768), (2048, 2048), (16, 128, 1024)]
+DTYPES = [torch.float32, torch.float16]
+
+
+def bench_cell(stmt, glb):
+    t = Timer(stmt=stmt, globals=glb)
+    return t.blocked_autorange(min_run_time=0.4).median / K * 1e3
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--label", default="run")
+    args = parser.parse_args()
+    print(f"label={args.label} torch={torch.__version__}")
+
+    for dt in DTYPES:
+        for shape in SHAPES:
+            x = torch.randn(*shape, device="mps", dtype=dt)
+            g = torch.randn(*shape, device="mps", dtype=dt)
+            glb = {"torch": torch, "F": F, "x": x, "g": g, "K": K}
+            cells = {
+                "threshold_fwd": "\nfor _ in range(K): F.threshold(x, 0.5, 0.0)\ntorch.mps.synchronize()",
+                "threshold_bwd": "\nfor _ in range(K): torch.ops.aten.threshold_backward(g, x, 0.5)\ntorch.mps.synchronize()",
+                "relu_bwd": "\nfor _ in range(K): torch.ops.aten.threshold_backward(g, x, 0)\ntorch.mps.synchronize()",
+            }
+            for name, stmt in cells.items():
+                ms = bench_cell(stmt, glb)
+                print(
+                    f"{name} {str(dt).replace('torch.', ''):<9} {str(shape):<17} {ms:10.5f}"
+                )
+        # integral dtype leg (exact scalar_t params path)
+        xi = torch.randint(-100, 100, (2048, 2048), device="mps", dtype=torch.int64)
+        glb = {"torch": torch, "F": F, "xi": xi, "K": K}
+        ms = bench_cell(
+            "\nfor _ in range(K): F.threshold(xi, 3, -1)\ntorch.mps.synchronize()", glb
+        )
+        print(f"threshold_fwd int64     (2048, 2048)      {ms:10.5f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/c10/metal/indexing.h
+++ b/c10/metal/indexing.h
@@ -822,6 +822,43 @@ kernel void binary_alpha_dense(
   out[tid] = f(input[tid], other[tid], alpha);
 }
 
+// ILP variant of binary_alpha_dense; mirrors unary_alpha_dense_ilp. Selected
+// by the host only when the caller opts in via ilp_threshold (see
+// exec_binary_kernel_with_params).
+template <typename T, typename T2, typename F>
+kernel void binary_alpha_dense_ilp(
+    device result_of<F, T, T, T2>* out [[buffer(0)]],
+    constant T* input [[buffer(1)]],
+    constant T* other [[buffer(2)]],
+    constant T2& alpha [[buffer(3)]],
+    constant uint& numel [[buffer(4)]],
+    uint tid [[thread_position_in_grid]]) {
+  F f;
+  uint base = tid * ILP_PER_THREAD;
+  if (base + ILP_PER_THREAD <= numel) {
+    array<T, ILP_PER_THREAD> tmp_in;
+    array<T, ILP_PER_THREAD> tmp_other;
+    array<result_of<F, T, T, T2>, ILP_PER_THREAD> tmp_out;
+#pragma unroll
+    for (uint j = 0; j < ILP_PER_THREAD; ++j) {
+      tmp_in[j] = input[base + j];
+      tmp_other[j] = other[base + j];
+    }
+#pragma unroll
+    for (uint j = 0; j < ILP_PER_THREAD; ++j) {
+      tmp_out[j] = f(tmp_in[j], tmp_other[j], alpha);
+    }
+#pragma unroll
+    for (uint j = 0; j < ILP_PER_THREAD; ++j) {
+      out[base + j] = tmp_out[j];
+    }
+  } else {
+    for (uint i = base; i < numel; ++i) {
+      out[i] = f(input[i], other[i], alpha);
+    }
+  }
+}
+
 template <typename T, typename F, typename om_t = T>
 kernel void binary_dense_cast(
     device result_of<F, T, T>* out [[buffer(0)]],
@@ -1257,6 +1294,17 @@ kernel void binary_alpha_dense_scalar_lhs_cast(
           DTYPEO,                                                             \
           ::c10::metal::result_of<NAME##_functor, DTYPEI, DTYPEI, DTYPEA>>,   \
       "Output dtype mismatch for binary op " #NAME " and input " #DTYPEI);    \
+  template [[host_name(#NAME "_dense_ilp_" #DTYPEO "_" #DTYPEI                \
+                             "_" #DTYPEA)]] kernel void ::c10::metal::        \
+      binary_alpha_dense_ilp<DTYPEI, DTYPEA, NAME##_functor>(                 \
+          device ::c10::metal::                                               \
+                  result_of<NAME##_functor, DTYPEI, DTYPEI, DTYPEA> *         \
+              out,                                                            \
+          constant DTYPEI * input,                                            \
+          constant DTYPEI * other,                                            \
+          constant DTYPEA & alpha,                                            \
+          constant uint & numel,                                              \
+          uint tid);                                                          \
   template [[host_name(#NAME "_strided_" #DTYPEO "_" #DTYPEI                  \
                              "_" #DTYPEA)]] kernel void ::c10::metal::        \
       binary_alpha_strided<DTYPEI, DTYPEA, NAME##_functor>(                   \

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -15910,6 +15910,30 @@ class TestComplex(TestCase):
                 with self.subTest(src=src_label, dst=dst_label, op="copy_"):
                     self.assertEqual(dst_mps.cpu(), dst_cpu)
 
+    def test_tanh_backward_complex(self):
+        # The MPSGraph implementation computed grad * (1 - out^2) without the
+        # conjugate, silently producing wrong complex gradients; the Metal
+        # kernel computes grad * conj(1 - out^2) like CPU/CUDA. Compare both
+        # the raw kernel and an end-to-end autograd call against CPU.
+        torch.manual_seed(0)
+        grad64 = torch.randn(64, dtype=torch.complex64)
+        out64 = torch.tanh(torch.randn(64, dtype=torch.complex64))
+        expected = torch.ops.aten.tanh_backward(grad64, out64)
+        # chalf has no CPU reference, so both dtypes compare against the
+        # complex64 CPU result on the same values (chalf at half tolerance).
+        for dtype, atol in [(torch.complex64, 1e-5), (torch.complex32, 1e-2)]:
+            grad, out = grad64.to(dtype).to("mps"), out64.to(dtype).to("mps")
+            actual = torch.ops.aten.tanh_backward(grad, out)
+            self.assertEqual(actual.cpu().to(torch.complex64), expected, atol=atol, rtol=atol)
+        # scale keeps draws away from tanh's poles at i*pi/2, where gradients
+        # blow up and float noise amplifies past any sane tolerance
+        x_cpu = (torch.randn(64, dtype=torch.complex64) * 0.5).requires_grad_()
+        x_mps = x_cpu.detach().to("mps").requires_grad_()
+        torch.tanh(x_cpu).abs().sum().backward()
+        torch.tanh(x_mps).abs().sum().backward()
+        # a missing conj produces O(1) errors; observed float noise is ~1e-6
+        self.assertEqual(x_mps.grad.cpu(), x_cpu.grad, atol=1e-4, rtol=1e-4)
+
     def test_tensor_scalar_binops(self):
         # Regression test for https://github.com/pytorch/pytorch/issues/119088
         def to_cpu(x):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -15918,12 +15918,15 @@ class TestComplex(TestCase):
         torch.manual_seed(0)
         grad64 = torch.randn(64, dtype=torch.complex64)
         out64 = torch.tanh(torch.randn(64, dtype=torch.complex64))
-        expected = torch.ops.aten.tanh_backward(grad64, out64)
-        # chalf has no CPU reference, so both dtypes compare against the
-        # complex64 CPU result on the same values (chalf at half tolerance).
+        # chalf has no CPU kernel, so reference the complex64 CPU result on the
+        # SAME rounded inputs the MPS kernel sees (upcast back to complex64 for
+        # the CPU compute). Referencing the unrounded complex64 values would
+        # fold input-rounding error into the tolerance and could mask a real
+        # kernel bug at chalf's loose 1e-2 tolerance.
         for dtype, atol in [(torch.complex64, 1e-5), (torch.complex32, 1e-2)]:
-            grad, out = grad64.to(dtype).to("mps"), out64.to(dtype).to("mps")
-            actual = torch.ops.aten.tanh_backward(grad, out)
+            grad, out = grad64.to(dtype), out64.to(dtype)
+            expected = torch.ops.aten.tanh_backward(grad.to(torch.complex64), out.to(torch.complex64))
+            actual = torch.ops.aten.tanh_backward(grad.to("mps"), out.to("mps"))
             self.assertEqual(actual.cpu().to(torch.complex64), expected, atol=atol, rtol=atol)
         # scale keeps draws away from tanh's poles at i*pi/2, where gradients
         # blow up and float noise amplifies past any sane tolerance

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -25504,14 +25504,6 @@ python_ref_db = [
         "_refs.nn.functional.threshold",
         torch_opinfo_name="nn.functional.threshold",
         supports_out=True,
-        skips=(
-            # MPS threshold maps NaN to `value` (uses x > threshold), but the
-            # reference keeps NaN; mismatch only on float dtypes.
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref',
-                         device_type='mps', dtypes=(torch.float16, torch.bfloat16, torch.float32)),
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref_torch_fallback',
-                         device_type='mps', dtypes=(torch.float16, torch.bfloat16, torch.float32)),
-        ),
     ),
     PythonRefInfo(
         "_refs.nn.functional.dropout",


### PR DESCRIPTION
# [MPS] Migrate hardtanh_backward and tanh_backward to Metal kernels

Part of the MPSGraph shape-keyed graph-cache elimination effort (#187455). Replaces the MPSGraph implementations of `hardtanh_backward` and `tanh_backward` with Metal kernels on the shared `exec_binary_kernel` iterator path, removing two more shape-keyed graph-cache entries.

## Complex correctness fix

The MPSGraph `tanh_backward` computed `grad * (1 - out^2)` **without the conjugate**, so complex tanh gradients on MPS were silently wrong (tanh is in `SUPPORTED_COMPLEX_OPS`, so this was user-reachable). The Metal functor computes `grad * conj(1 - out^2)` like CPU/CUDA (mirroring the existing `sigmoid_backward` functor), and `TestComplex.test_tanh_backward_complex` is added since no existing CI covers complex backward on MPS (`MPS_GRAD_DTYPES` is float-only and `TestMathBits` is not instantiated for MPS).

## Scalar handling

hardtanh's `min`/`max` convert to opmath (`float`) once on the host, matching the CUDA kernel's `Scalar`-to-opmath conversion, so the params struct is instantiated at `float` for every dtype. This avoids quantizing the scalars to half/bfloat (and the `Scalar::to<Half>` overflow throw for out-of-half-range values).

## Behavior deltas vs the old graph path (all aligning MPS with CPU/CUDA)

- `hardtanh_backward` now zeroes the gradient **at** the clip boundaries (`self <= min || self >= max`); the graph used strict comparisons and passed the gradient through at exactly `min`/`max`. Verified bit-exact vs CPU at the boundaries for float32/float16/bfloat16.
- `hardtanh_backward` on integral dtypes now raises like CPU/CUDA (`AT_DISPATCH_FLOATING_TYPES_AND2`); the graph path accepted them.
- `out=`/`grad_input=` with a dtype differing from the inputs now errors, same as the already-migrated `sigmoid_backward`; autograd never produces this pattern.

Known pre-existing gap (not introduced here, shared with `elu_backward`): mixed *input* dtypes hit a host-side cast-kernel naming mismatch in `exec_binary_kernel_with_params`; planned as a small follow-up infra fix.

## Perf

`benchmarks/mps/bench_activations.py` (Timer.blocked_autorange, K=20 amortized behind one synchronize, median of 3 interleaved A/B reps vs stock nightly), M4 Pro:

| op | dtype | shape | speedup |
|---|---|---|---|
| hardtanh_bwd | f32 | (4096,) | 2.68x |
| tanh_bwd | f32 | (4096,) | 2.62x |
| hardtanh_bwd | f32 | (512, 768) | 1.62x |
| tanh_bwd | f32 | (512, 768) | 1.45x |
| hardtanh_bwd | f32 | (2048, 2048) | 1.01x |
| tanh_bwd | f32 | (2048, 2048) | 1.00x |
| hardtanh_bwd | f32 | (16, 128, 1024) | 1.04x |
| tanh_bwd | f32 | (16, 128, 1024) | 1.01x |
| hardtanh_bwd | f32 | (32, 4096) | 1.99x |
| tanh_bwd | f32 | (32, 4096) | 2.57x |
| hardtanh_bwd | f16 | (4096,) | 2.68x |
| tanh_bwd | f16 | (4096,) | 2.65x |
| hardtanh_bwd | f16 | (512, 768) | 1.76x |
| tanh_bwd | f16 | (512, 768) | 2.14x |
| hardtanh_bwd | f16 | (2048, 2048) | 1.01x |
| tanh_bwd | f16 | (2048, 2048) | 1.01x |
| hardtanh_bwd | f16 | (16, 128, 1024) | 0.97x |
| tanh_bwd | f16 | (16, 128, 1024) | 1.04x |
| hardtanh_bwd | f16 | (32, 4096) | 2.44x |
| tanh_bwd | f16 | (32, 4096) | 2.59x |

20/20 cells, 0 regressions (threshold 0.95): wins at small/mid shapes where graph dispatch overhead dominates, parity at bandwidth-bound large shapes.

## Scope boundary

softplus fwd/bwd were migrated in an earlier draft of this PR but reverted: the Metal kernel is ALU-bound (`exp` + `log1p` per element at one element per thread) and loses to the graph's bandwidth-bound fusion at large float16 shapes (0.51x worst). softplus stays on MPSGraph until the shared elementwise kernels grow a vectorized dense path.

## Not tested

- Integral `hardtanh_backward` on MPS (now raises by design, matching CPU/CUDA).
- Mixed-input-dtype direct aten calls (pre-existing shared-infra gap above; the old graph path hard-aborted uncatchably on the same inputs).

## Test plan

```
python -m pytest test/test_mps.py -k "hardtanh or tanh"
python -m pytest test/test_ops.py -k "mps and (hardtanh or tanh)"
python -m pytest test/test_modules.py -k "mps and (Hardtanh or Tanh)"
python benchmarks/mps/bench_activations.py
```

Full `--mps` CI matrix run locally (13 files): only failure is `test_metal.py` (mobile Metal prepack, `USE_PYTORCH_METAL=OFF` desktop-build artifact, fails identically on baseline).


---

## Update: threshold + threshold_backward folded in (from #189393)

Per review guidance the two PRs overlapped all five activation files, so the threshold migration now lands here, with one fix relative to the #189393 head: **floating dtypes convert threshold/value to float (opmath) once on the host** like the CUDA kernel — the previous `ThresholdParams<scalar_t>` quantized scalars to half/bfloat (biasing comparisons) and threw `Scalar` overflow errors for values like `threshold=1e5` on a half tensor. Integral dtypes keep exact `scalar_t` params (float-typed params would lose int64 exactness past 2^24).

This update also adds an **opt-in ILP (4-elem/thread) dense variant for binary alpha/params kernels** (`binary_alpha_dense_ilp` + `ilp_threshold` in `exec_binary_kernel_with_params`), mirroring the unary variant in #189489: relu's backward (`threshold_backward` at >=2M elements) sat 8-13% behind the graph on the 1-elem/thread path; with the ILP variant those cells are wins. Default-off — every other alpha/params op keeps its exact current dispatch.

Combined bench (canonical amortized template, 3-rep interleaved A/B vs stock nightly): 51/51 cells 0 regressions; threshold wins to 5.6x, `threshold_fwd` 2048x2048 flipped 0.99x -> 1.43x with ILP. Full `--mps` matrix on the exact head: 29884 passed, `test_metal` only (known desktop artifact).


Review log: https://gist.github.com/anagnorisis2peripeteia/1c37a81bba4ad6b3b5015f74fafedf5e



---

## Update: complex32 test reference tightened (addresses review)

Per the review comment, `test_tanh_backward_complex` computed its chalf reference from the unrounded complex64 values, so the 1e-2 tolerance absorbed input-rounding error on top of kernel error and could mask a real kernel bug. The reference is now computed from the **same rounded inputs the MPS kernel receives** (upcast to complex64 for the CPU compute), so the tolerance bounds kernel error alone; the complex64 leg is unchanged (its inputs are already full precision). Verified on a fresh build: complex64 leg passes at 1e-5 (confirms the conj kernel is live) and complex32 at 1e-2 against the tightened reference.

Review log (this round): https://gist.github.com/anagnorisis2peripeteia/9913cf3f1dceafbbac1d053003124825
