### PR TITLE
[MPS] Fix F.linear with bias corrupting rows when a batch dim exceeds 2^16

### DIFF
--- a/aten/src/ATen/native/mps/operations/Linear.mm
+++ b/aten/src/ATen/native/mps/operations/Linear.mm
@@ -145,9 +145,14 @@ Tensor _mps_linear(const Tensor& input, const Tensor& weight_arg, const std::opt
     static const bool decompose_bias = is_apple_family_or_newer(AppleGPUFamily::APPLE_7_PLUS) &&
         !is_apple_family_or_newer(AppleGPUFamily::APPLE_8_PLUS) && is_macos_at_least(MacOSVersion::MACOS_26_0) &&
         !is_macos_at_least(MacOSVersion::MACOS_27_0);
-    const bool add_bias_after = is_bias_defined && decompose_bias;
+    // linear's leading dims are a fake batch (weight is shared), so a >2D input is one 2D GEMM.
+    // Passing it as a batched NDArray instead triggers a 2^16 batch-index wraparound (#189495) and
+    // a small-batch GEMV perf cliff (#189847); flatten to 2D (a free view here) to avoid both.
+    // A multi-dim bias cannot be flattened, so run the bias-free kernel there and add the bias afterwards.
+    const bool needs_flatten = input.dim() > 2;
+    const bool add_bias_after = is_bias_defined && (decompose_bias || (needs_flatten && bias.dim() > 1));
     const Tensor kernel_bias = add_bias_after ? Tensor() : bias;
-    if (input.dim() > 2 && (!kernel_bias.defined() || kernel_bias.dim() <= 1)) {
+    if (needs_flatten) {
       auto input2d = input.flatten(0, -2);
       auto output2d = output.flatten(0, -2);
       _mps_linear_nograph(input2d, weight, kernel_bias, output2d);

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1749,6 +1749,21 @@ class TestMPS(TestCaseMPS):
         loss = (z - target).pow(2).sum()
         loss.backward()
 
+    @parametrize("shape", [(65537, 17, 32), (2, 65537, 17, 32), (257, 256, 2, 32), (3, 1, 32)])
+    @parametrize("bias_shape", [None, (64,), (1, 64)])
+    def test_linear_large_batch(self, shape, bias_shape):
+        # Regression test for https://github.com/pytorch/pytorch/issues/189495
+        # The fused matmul+bias kernel truncates the innermost batch-dim index to
+        # 16 bits, corrupting outputs when size(-3) > 65536. Any >2D input now
+        # flattens to a single 2D GEMM, so the shapes cover the wraparound cases,
+        # a total-batch-count case, and a seq=1 decode case (#189847); the
+        # multi-dim bias exercises the decomposed bias-add path.
+        x_cpu = torch.randn(shape, device='cpu')
+        w_cpu = torch.randn(64, 32, device='cpu')
+        b_cpu = torch.randn(bias_shape, device='cpu') if bias_shape is not None else None
+        b_mps = b_cpu.to('mps') if b_cpu is not None else None
+        self.assertEqual(F.linear(x_cpu, w_cpu, b_cpu), F.linear(x_cpu.to('mps'), w_cpu.to('mps'), b_mps))
+
     def _linear_helper(self, in_features, out_features, shape, bias=True, backward_pass=False):
         cpu_linear = torch.nn.Linear(in_features=in_features, out_features=out_features, device="cpu", bias=bias)
         mps_linear = torch.nn.Linear(in_features=in_features, out_features=out_features, device="mps", bias=bias)


### PR DESCRIPTION
Fixes #189495
Fixes #189847

## Summary

On MPS, `F.linear`/`nn.Linear` **with a bias** on a >2D contiguous input silently returns wrong results when the innermost batch dimension (`input.size(-3)`) exceeds 65536. Apple's `MPSNDArrayMatrixMultiplication` fused 3-source (A@B+C) kernel truncates that batch coordinate to 16 bits: batch `b` is written to slot `b mod 2^16` (clobbering the victim row), and row `b` itself is left unwritten, exposing stale heap memory, which makes the corruption look nondeterministic. See the issue for a pure Objective-C reproducer (no PyTorch) demonstrating the wraparound, the exact 65536 -> 65537 threshold, and that the 2-source (no-bias) variant is clean.

Per review, the fix now flattens **every** >2D contiguous input to a single 2D GEMM on this path. Linear's leading dims are a fake batch (the weight is shared), so the flatten is a free view and the math is identical; the batched NDArray form was the source of both this wraparound and the seq=1 decode perf cliff (#189847, open PR #189855). This consolidates both issues here and mirrors the graph-path approach taken in #190352.

## Notes for reviewers

- A multi-dimensional bias cannot be flattened (row identity is lost); that corner, also corrupted on stock (verified), is handled by reusing the existing `add_bias_after` decomposition: clean 2-source kernel on the flattened input, then a broadcast `output.add_(bias)`.
- The underlying defect is in Apple's framework, reported to Apple as FB23663591.

## Performance

Measured on M5 Max, macOS 26 (times per call, batched = stock, flattened = this PR):

| shape / weight | dtype | batched (stock) | flattened (this PR) | ratio |
|---|---|---|---|---|
| decode (4096,1,4096) W(4096,4096) | fp32 | 9.70 ms | 9.76 ms | 1.01x |
| decode (4096,1,4096) W(4096,4096) | bf16 | 2.19 ms | 2.18 ms | 1.00x |
| decode (4096,1,4096) W(4096,4096) | fp16 | 2.31 ms | 2.21 ms | 0.96x |
| prefill (32,512,1024) W(1024,1024) | fp32 | 2.47 ms | 2.46 ms | 1.00x |
| prefill (32,512,1024) W(1024,1024) | bf16 | 0.57 ms | 0.57 ms | 0.99x |
| (1024,32,256) W(256,256) | fp32 | 0.36 ms | 0.36 ms | 1.00x |
| (30000,4,64) W(64,64) | fp16 | 0.12 ms | 0.06 ms | 0.48x |
| (30000,4,64) W(64,64) | fp32 | 0.15 ms | 0.44 ms | 3.0x |
| (60000,17,32) W(64,32) | fp16 | 0.41 ms | 0.41 ms | 1.01x |
| (60000,17,32) W(64,32) | fp32 | 0.96 ms | 3.02 ms | 3.1x |

Standard transformer shapes are at parity. The one measured regression is fp32 with tens of thousands of tiny matrices (K, N <= 64), where Apple's fp32 2D GEMM variant is less bandwidth-efficient than the batched kernel; above the 2^16 boundary the batched kernel returns wrong results for these shapes anyway. The #189847 decode cliff does not reproduce on this hardware/OS combination, but flattening removes the cliff structurally on configurations where it does.

## Test plan

The regression test `test_linear_large_batch` covers the failing wraparound shapes (`(65537, 17, 32)` 3D, `(2, 65537, 17, 32)` 4D), a large total-batch-count 4D shape (`(257, 256, 2, 32)`), and a seq=1 decode shape (`(3, 1, 32)`), with no bias, 1D bias, and 2D bias, against CPU:

```
python -m pytest test/test_mps.py -k test_linear_large_batch -v
```

The wraparound shapes fail on stock 2.12.0 / 2.13.0 / 2.14.0.dev20260709 and pass with this change. Neighboring linear tests pass:

```
python -m pytest test/test_mps.py -k "test_linear" -v
```

`lintrunner -a` clean on changed files.

*This PR was authored with the assistance of an AI (Claude Code); the root-cause analysis, reproducers, and fix were human-reviewed.*
