### PR TITLE
[ATen][quantized][cpu] Fuse fp16 dynamic-linear bias-add (avoid add_ TensorIterator dispatch) (#189497)

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
@@ -2,6 +2,7 @@
 #include <ATen/core/Tensor.h>
 #include <ATen/Context.h>
 #include <ATen/Parallel.h>
+#include <ATen/TensorIterator.h>
 #include <ATen/native/quantized/cpu/fbgemm_utils.h>
 #include <ATen/native/quantized/cpu/QnnpackUtils.h>
 #include <ATen/native/quantized/cpu/OnednnUtils.h>
@@ -440,10 +441,24 @@ at::Tensor& PackedLinearWeightFp16::apply_dynamic_impl(
     }
   });
 
-  // Add bias term
+  // Add bias term via a fused parallel loop over rows: avoids the add_
+  // TensorIterator dispatch while preserving parallelism over the M*N output.
   if (bias_.has_value()) {
     TORCH_CHECK(bias_->dim() == 1);
-    output.add_(*bias_);
+    const at::Tensor bias_contig = bias_->contiguous();
+    TORCH_CHECK(bias_contig.numel() == N);
+    const float* const __restrict bias_ptr =
+        bias_contig.const_data_ptr<float>();
+    const int64_t grain =
+        std::max<int64_t>(1, at::internal::GRAIN_SIZE / std::max<int64_t>(1, N));
+    at::parallel_for(0, M, grain, [&](int64_t begin, int64_t end) {
+      for (const auto row : c10::irange(begin, end)) {
+        float* const __restrict out_row = output_data + row * N;
+        for (const auto col : c10::irange(N)) {
+          out_row[col] += bias_ptr[col];
+        }
+      }
+    });
   }
 
   return output;


### PR DESCRIPTION
Summary:

PackedLinearWeightFp16::apply_dynamic_impl (fp16 dynamic linear) adds the bias with a
separate output.add_(*bias_) pass after the FBGEMM GEMM. That routes a simple row-broadcast
add through the ATen TensorIterator machinery (iterator build, broadcast configuration,
dispatch) plus a second streaming pass over the M*N output -- per-call overhead that
dominates at the small/mid output sizes typical of ranking inference (few rows, many layers).

Replace the add_ with a fused row-wise at::parallel_for over the just-computed output:
__restrict pointers so the compiler vectorizes out_row[col] += bias_ptr[col] to the same AVX
add the ATen kernel emits, with no runtime alias check and no TensorIterator build.

No size gate. Microbenchmarked across shapes from 1K to 128M elements (see Test Plan): the
fused parallel_for is at parity-to-faster than add_ everywhere -- 2-8x faster in the small/mid
ranking-inference regime (where the TensorIterator dispatch dominates) and within noise of
add_ at large out-of-distribution sizes. At the small M that dominates inference, at::parallel_for
runs inline on the calling thread (a single sub-grain chunk), so no extra thread group is
launched where the win actually lives; it only forks for large M, where it matches add_.

Numerically identical: out[m,n] += bias[n] in fp32, one add per element in the same order as
the broadcast add_ -- no reassociation, bit-identical output. Guards preserved (bias dim == 1,
plus a numel == N check for the raw-pointer loop).

On fusing bias into the GEMM epilogue instead (reviewer question): the fp16 cblas_gemm_compute
has no bias parameter and no output-processing hook -- its only epilogue is beta accumulation
(C = beta*C + A*B), so bias must be applied by the caller. The int8 fbgemmPacked path fuses bias
via ReQuantizeForFloat/outProcess, but the legacy fp16 kernel has no such hook ("will soon be
upgraded to match the new fbgemm interface"), so a post-GEMM pass is required today. In-kernel
fp16 bias fusion would be a separate FBGEMM change (extend GemmParams<float16> and the fp16
epilogue), out of scope for this caller-side change.

Core-ATen (aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp), exercised by every fp16
dynamic-linear model; behavior-exact and unit-test-covered.

Test Plan:
## Build
- buck2 build fbcode//mode/opt-clang //caffe2:_ATen-cpu -> PASS
- (OSS) python setup.py develop

## Unit tests
- pytest test/quantization/ -k test_qlinear_dynamic_fp16 -> Pass (packed fp16 dynamic-linear path with bias; confirms numerical equivalence)
- buck2 test //caffe2/test/quantization:test_quantization -- --regex 'test_qlinear_dynamic_fp16' -> Pass 2 / Fail 0
  testrun: https://www.internalfb.com/intern/testinfra/testrun/21955048215718165

## Correctness (behavior-preserving)
- Numerically identical to output.add_(*bias_): out[m,n] += bias[n] in fp32, one add per element in the same broadcast order -- no reassociation, bit-identical output. Guards preserved (bias dim == 1, numel == N).

## Microbenchmark (op-level) -- fused parallel_for vs baseline add_, swept 1K -> 128M elements
folly cpp_benchmark mode/opt, 96-thread ATen intra-op pool. Relative to baseline add_ (>100% = faster).

| Shape M x N   | M*N  | add_ time | fused parallel_for       |
|---------------|------|-----------|--------------------------|
| 1 x 1024      | 1K   | 474 ns    | 7.7x faster              |
| 8 x 1024      | 8K   | 1.0 us    | 2.3x faster              |
| 64 x 1024     | 64K  | 66 us     | ~parity (100%)           |
| 256 x 1024    | 256K | 69 us     | 105%                     |
| 1024 x 1024   | 1M   | 69 us     | 100%                     |
| 2048 x 1024   | 2M   | 75 us     | 104%                     |
| 4096 x 1024   | 4M   | 85 us     | 108%                     |
| 8192 x 1024   | 8M   | 97 us     | 103%                     |
| 16384 x 1024  | 16M  | 158 us    | ~parity (91-101%)        |
| 32768 x 1024  | 32M  | 292 us    | 119%                     |
| 65536 x 1024  | 64M  | 1.19 ms   | 106%                     |
| 16384 x 4096  | 64M  | 0.98-1.45 ms | ~parity (85-117%, 3 runs) |
| 32768 x 4096  | 128M | 3.90 ms   | 97%                      |

Conclusion: NO size gate is needed. The fused parallel_for is at parity-to-faster than add_ across the entire range -- 2-8x in the small/mid regime that dominates ranking inference (TensorIterator dispatch eliminated; at small M the parallel_for runs inline, so no fork-join), and within a noisy parity band at large out-of-distribution sizes (16M+ implies tens of thousands of rows -- not an inference shape). At the largest sizes the run-to-run variance is dominated by the memory-bound add_ baseline itself (e.g. 16384x4096 add_ ranges 0.98-1.45ms across runs while the fused loop stays ~1.1-1.3ms); there is no systematic pessimization at any size.

## Canary (Internal, ads serving)
- ServiceLab admarket_adranker: COMPLETE, CLEAN.
- Canary CLEAN: adranker + adfinder.
- Canary Strobelight A/B (adranker): apply_dynamic_impl inclusive ~-0.24pp; build_borrowing_binary_op (add_ TensorIterator) halved; GEMM flat.

Differential Revision: D110316471


