### PR TITLE
Fix H100 FA3 ci

### DIFF
--- a/.ci/pytorch/test_fa3_abi_stable.sh
+++ b/.ci/pytorch/test_fa3_abi_stable.sh
@@ -19,6 +19,19 @@ echo "Installing ABI Stable FA3 wheel"
 $MAYBE_SUDO pip -q install einops ninja
 $MAYBE_SUDO pip -q install flash-attn-3 --index-url https://download.pytorch.org/whl/cu130
 
+# To be as robust against upstream changes as possible, minimally only stage
+# the relevant test files in a clean dir
+HARNESS_DIR="$(mktemp -d)"
+cp flash-attention/hopper/test_flash_attn.py \
+   flash-attention/hopper/test_util.py \
+   flash-attention/hopper/padding.py \
+   "${HARNESS_DIR}/"
+
+# Everything that imports torch must run from a dir other than the pytorch
+# source root: from the root, `import torch` resolves to the unbuilt ./torch
+# source package (no generated torch/version.py) and shadows the installed build.
+pushd "${HARNESS_DIR}"
+
 # Smoke check that the wheel is importable the way upstream intends: as an
 # installed package. Prefer the packaged flash_attn_3.flash_attn_interface
 # (see #2458); fall back to the legacy top-level module for older wheels.
@@ -31,15 +44,6 @@ except ImportError:
     print("FA3 import: legacy top-level flash_attn_interface")
 EOF
 
-# To be as robust against upstream changes as possible, minimally only stage
-# the relevant test files in a clean dir
-HARNESS_DIR="$(mktemp -d)"
-cp flash-attention/hopper/test_flash_attn.py \
-   flash-attention/hopper/test_util.py \
-   flash-attention/hopper/padding.py \
-   "${HARNESS_DIR}/"
-
-pushd "${HARNESS_DIR}"
 export FLASH_ATTENTION_ENABLE_OPCHECK=TRUE  # Enable testing for compile on the smoke tests
 pytest -v -s \
   "test_flash_attn.py::test_flash_attn_output[1-1-192-False-False-False-0.0-False-False-mha-dtype0]" \

--- a/.ci/pytorch/test_fa3_abi_stable.sh
+++ b/.ci/pytorch/test_fa3_abi_stable.sh
@@ -19,9 +19,28 @@ echo "Installing ABI Stable FA3 wheel"
 $MAYBE_SUDO pip -q install einops ninja
 $MAYBE_SUDO pip -q install flash-attn-3 --index-url https://download.pytorch.org/whl/cu130
 
-pushd flash-attention/hopper
+# Smoke check that the wheel is importable the way upstream intends: as an
+# installed package. Prefer the packaged flash_attn_3.flash_attn_interface
+# (see #2458); fall back to the legacy top-level module for older wheels.
+python3 - <<'EOF'
+try:
+    from flash_attn_3.flash_attn_interface import flash_attn_func  # packaged (new)
+    print("FA3 import: packaged flash_attn_3.flash_attn_interface")
+except ImportError:
+    from flash_attn_interface import flash_attn_func  # loose top-level (legacy)
+    print("FA3 import: legacy top-level flash_attn_interface")
+EOF
+
+# To be as robust against upstream changes as possible, minimally only stage
+# the relevant test files in a clean dir
+HARNESS_DIR="$(mktemp -d)"
+cp flash-attention/hopper/test_flash_attn.py \
+   flash-attention/hopper/test_util.py \
+   flash-attention/hopper/padding.py \
+   "${HARNESS_DIR}/"
+
+pushd "${HARNESS_DIR}"
 export FLASH_ATTENTION_ENABLE_OPCHECK=TRUE  # Enable testing for compile on the smoke tests
-export PYTHONPATH=$PWD
 pytest -v -s \
   "test_flash_attn.py::test_flash_attn_output[1-1-192-False-False-False-0.0-False-False-mha-dtype0]" \
   "test_flash_attn.py::test_flash_attn_varlen_output[511-1-64-True-False-False-0.0-False-False-gqa-dtype2]" \


### PR DESCRIPTION
https://github.com/Dao-AILab/flash-attention/pull/2458 added a new directory flash_attn_3 under `flash-attn/hopper`. That change + the fact that we relied on exporting the PYTHONPATH to `flash-attn/hopper` meant that our tests importing `flash_attn_3._C` became overshadowed by the new flash_attn_3 python only dir, which has no module _C. 

This fix detangles our CI from the upstream churn as much as we can. We want to continue running the upstream tests, but stick to our old wheels. To do that, I'm just copying over the relevant test files (vs the whole hopper folder) and running the tests from a clean harness dir. This should avoid future changes breaking us. Though @liangel-02 we may want to rebuild the wheels post the PR above (to include the newly added python files to the package).

Test plan:
https://github.com/pytorch/pytorch/actions/runs/29061209748/job/86265811447

Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189498

