### PR TITLE
[BE] some small cleanups to pack analyzer

### DIFF
--- a/test/inductor/test_interval_mask_packing.py
+++ b/test/inductor/test_interval_mask_packing.py
@@ -10,6 +10,7 @@ from torch._inductor.kernel.flex.interval_mask_packing import (
 )
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.virtualized import V
+from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
@@ -18,8 +19,38 @@ from torch.testing._internal.common_utils import (
 from torch.testing._internal.inductor_utils import MockGraphHandler
 
 
+def piecewise_affine_mask(_b, _h, q_idx, kv_idx):
+    """Build bounded windows over two piecewise-affine coordinates."""
+    row_coord = torch.where(q_idx < 64, q_idx + 64, q_idx + 320)
+    shifted_kv = kv_idx - 512
+    col_coord = torch.where(shifted_kv < 64, shifted_kv + 64, shifted_kv + 320)
+    primary = (kv_idx < 512) & (kv_idx >= row_coord - 32) & (kv_idx <= row_coord)
+    secondary = (
+        (kv_idx >= 512)
+        & (kv_idx < 640)
+        & (col_coord >= row_coord - 16)
+        & (col_coord <= row_coord)
+    )
+    return primary | secondary
+
+
+def piecewise_aux_index_mask(_b, _h, q_idx, kv_idx, offsets):
+    """Load a lane-uniform bound through a piecewise-affine index."""
+    selected_q = torch.where(q_idx < 64, q_idx, q_idx + 64)
+    return kv_idx >= torch.ops.aten.index.Tensor(offsets, [selected_q])
+
+
+def piecewise_strided_guard_mask(_b, _h, q_idx, kv_idx):
+    """Use a non-interval lane predicate as a piecewise guard."""
+    mapped_kv = torch.where(kv_idx % 2 == 0, kv_idx, kv_idx + 1)
+    return mapped_kv <= q_idx
+
+
 @instantiate_parametrized_tests
 class TestIntervalMaskPacking(InductorTestCase):
+    def _trace_mask(self, mask, *extra_args):
+        return make_fx(mask)(*(torch.tensor(i) for i in range(4)), *extra_args)
+
     def _expected_packed_mask_interval(self, case_name, q_idx, kv_idx, lane):
         match case_name:
             case "causal":
@@ -258,7 +289,7 @@ class TestIntervalMaskPacking(InductorTestCase):
         q_idx = graph.placeholder("q_idx")
         kv_idx = graph.placeholder("kv_idx")
         terms = []
-        for offset in range(9):
+        for offset in range(17):
             shifted_q = graph.call_function(torch.ops.aten.add.Scalar, (q_idx, offset))
             terms.append(
                 graph.call_function(torch.ops.aten.eq.Tensor, (kv_idx, shifted_q))
@@ -402,6 +433,47 @@ class TestIntervalMaskPacking(InductorTestCase):
         self.assertIn("min(", intervals[0].render_upper())
         self.assertIn("aux_tensors[0]", intervals[0].render_upper())
         self.assertIn("cutlass.Int32(32)", intervals[0].render_upper())
+
+    def test_packed_mask_interval_selector_piecewise_affine_coordinates(self):
+        """Pack bounded windows over two piecewise-affine index mappings."""
+        graph_module = self._trace_mask(piecewise_affine_mask)
+
+        with V.set_graph_handler(MockGraphHandler()):
+            intervals = select_packed_mask_intervals(graph_module)
+
+        self.assertIsNotNone(intervals)
+        for q in (0, 15, 63, 64, 65, 127):
+            for kv in range(0, 641, 32):
+                expected_lanes = piecewise_affine_mask(
+                    None, None, torch.tensor(q), kv + torch.arange(32)
+                )
+                expected_mask = sum(
+                    int(value) << lane for lane, value in enumerate(expected_lanes)
+                )
+                with V.set_graph_handler(MockGraphHandler()):
+                    actual_mask = self._eval_packed_mask_intervals(intervals, q, kv)
+                self.assertEqual(actual_mask, expected_mask)
+
+    def test_packed_mask_interval_selector_piecewise_aux_index(self):
+        offsets = torch.zeros(256, dtype=torch.int32)
+        graph_module = self._trace_mask(piecewise_aux_index_mask, offsets)
+
+        with V.set_graph_handler(MockGraphHandler()):
+            intervals = select_packed_mask_intervals(graph_module)
+
+        self.assertIsNotNone(intervals)
+        self.assertEqual(len(intervals), 2)
+        rendered = "\n".join(interval.render_lower() for interval in intervals)
+        self.assertEqual(rendered.count("aux_tensors[0]"), 2)
+        self.assertIn("(q_idx[0] + cutlass.Int32(64))", rendered)
+
+    def test_packed_mask_interval_selector_rejects_piecewise_strided_guard(self):
+        graph_module = self._trace_mask(piecewise_strided_guard_mask)
+
+        with V.set_graph_handler(MockGraphHandler()):
+            intervals = select_packed_mask_intervals(graph_module)
+
+        self.assertIsNone(intervals)
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_interval_mask_packing.py
+++ b/test/inductor/test_interval_mask_packing.py
@@ -10,7 +10,6 @@ from torch._inductor.kernel.flex.interval_mask_packing import (
 )
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.virtualized import V
-from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
@@ -19,38 +18,8 @@ from torch.testing._internal.common_utils import (
 from torch.testing._internal.inductor_utils import MockGraphHandler
 
 
-def piecewise_affine_mask(_b, _h, q_idx, kv_idx):
-    """Build bounded windows over two piecewise-affine coordinates."""
-    row_coord = torch.where(q_idx < 64, q_idx + 64, q_idx + 320)
-    shifted_kv = kv_idx - 512
-    col_coord = torch.where(shifted_kv < 64, shifted_kv + 64, shifted_kv + 320)
-    primary = (kv_idx < 512) & (kv_idx >= row_coord - 32) & (kv_idx <= row_coord)
-    secondary = (
-        (kv_idx >= 512)
-        & (kv_idx < 640)
-        & (col_coord >= row_coord - 16)
-        & (col_coord <= row_coord)
-    )
-    return primary | secondary
-
-
-def piecewise_aux_index_mask(_b, _h, q_idx, kv_idx, offsets):
-    """Load a lane-uniform bound through a piecewise-affine index."""
-    selected_q = torch.where(q_idx < 64, q_idx, q_idx + 64)
-    return kv_idx >= torch.ops.aten.index.Tensor(offsets, [selected_q])
-
-
-def piecewise_strided_guard_mask(_b, _h, q_idx, kv_idx):
-    """Use a non-interval lane predicate as a piecewise guard."""
-    mapped_kv = torch.where(kv_idx % 2 == 0, kv_idx, kv_idx + 1)
-    return mapped_kv <= q_idx
-
-
 @instantiate_parametrized_tests
 class TestIntervalMaskPacking(InductorTestCase):
-    def _trace_mask(self, mask, *extra_args):
-        return make_fx(mask)(*(torch.tensor(i) for i in range(4)), *extra_args)
-
     def _expected_packed_mask_interval(self, case_name, q_idx, kv_idx, lane):
         match case_name:
             case "causal":
@@ -289,7 +258,7 @@ class TestIntervalMaskPacking(InductorTestCase):
         q_idx = graph.placeholder("q_idx")
         kv_idx = graph.placeholder("kv_idx")
         terms = []
-        for offset in range(17):
+        for offset in range(9):
             shifted_q = graph.call_function(torch.ops.aten.add.Scalar, (q_idx, offset))
             terms.append(
                 graph.call_function(torch.ops.aten.eq.Tensor, (kv_idx, shifted_q))
@@ -433,47 +402,6 @@ class TestIntervalMaskPacking(InductorTestCase):
         self.assertIn("min(", intervals[0].render_upper())
         self.assertIn("aux_tensors[0]", intervals[0].render_upper())
         self.assertIn("cutlass.Int32(32)", intervals[0].render_upper())
-
-    def test_packed_mask_interval_selector_piecewise_affine_coordinates(self):
-        """Pack bounded windows over two piecewise-affine index mappings."""
-        graph_module = self._trace_mask(piecewise_affine_mask)
-
-        with V.set_graph_handler(MockGraphHandler()):
-            intervals = select_packed_mask_intervals(graph_module)
-
-        self.assertIsNotNone(intervals)
-        for q in (0, 15, 63, 64, 65, 127):
-            for kv in range(0, 641, 32):
-                expected_lanes = piecewise_affine_mask(
-                    None, None, torch.tensor(q), kv + torch.arange(32)
-                )
-                expected_mask = sum(
-                    int(value) << lane for lane, value in enumerate(expected_lanes)
-                )
-                with V.set_graph_handler(MockGraphHandler()):
-                    actual_mask = self._eval_packed_mask_intervals(intervals, q, kv)
-                self.assertEqual(actual_mask, expected_mask)
-
-    def test_packed_mask_interval_selector_piecewise_aux_index(self):
-        offsets = torch.zeros(256, dtype=torch.int32)
-        graph_module = self._trace_mask(piecewise_aux_index_mask, offsets)
-
-        with V.set_graph_handler(MockGraphHandler()):
-            intervals = select_packed_mask_intervals(graph_module)
-
-        self.assertIsNotNone(intervals)
-        self.assertEqual(len(intervals), 2)
-        rendered = "\n".join(interval.render_lower() for interval in intervals)
-        self.assertEqual(rendered.count("aux_tensors[0]"), 2)
-        self.assertIn("(q_idx[0] + cutlass.Int32(64))", rendered)
-
-    def test_packed_mask_interval_selector_rejects_piecewise_strided_guard(self):
-        graph_module = self._trace_mask(piecewise_strided_guard_mask)
-
-        with V.set_graph_handler(MockGraphHandler()):
-            intervals = select_packed_mask_intervals(graph_module)
-
-        self.assertIsNone(intervals)
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/kernel/flex/interval_mask_packing.py
+++ b/torch/_inductor/kernel/flex/interval_mask_packing.py
@@ -23,7 +23,6 @@ import sympy
 
 import torch
 from torch.fx import GraphModule
-from torch.utils._ordered_set import OrderedSet
 from torch.utils._sympy.functions import FloorDiv, Max, Min
 
 from ...codegen.cutedsl.lane_analysis import decompose_affine_lane_expr
@@ -35,7 +34,7 @@ perf_hint_log = torch._logging.getArtifactLogger(__name__, "perf_hints")
 
 
 # Fall back to scalar mask lowering before interval expansion makes generated CuTe too large.
-MAX_PACKED_MASK_INTERVALS_FOR_CODE_SIZE = 16
+MAX_PACKED_MASK_INTERVALS_FOR_CODE_SIZE = 8
 LANE_UNIFORM_BINARY_OPS: Mapping[object, str] = {
     torch.ops.aten.add.Tensor: "+",
     torch.ops.aten.add.Scalar: "+",
@@ -124,6 +123,20 @@ def _simplify_expr(expr: sympy.Expr) -> sympy.Expr:
     return V.graph.sizevars.simplify(expr)
 
 
+def render_sympy_args(
+    args: Sequence[sympy.Expr],
+    symbol_codes: Mapping[sympy.Symbol, str] | None,
+) -> list[str] | None:
+    """Render every child expression, returning ``None`` if any is unsupported."""
+    rendered = []
+    for arg in args:
+        cute_arg = sympy_to_cute_index(arg, symbol_codes)
+        if cute_arg is None:
+            return None
+        rendered.append(cute_arg)
+    return rendered
+
+
 def sympy_to_cute_index(
     expr: sympy.Expr, symbol_codes: Mapping[sympy.Symbol, str] | None = None
 ) -> str | None:
@@ -140,41 +153,25 @@ def sympy_to_cute_index(
             if expr.name == "kv_idx":
                 return "kv_idx[0]"
         case FloorDiv():
-            lhs, rhs = (sympy_to_cute_index(arg, symbol_codes) for arg in expr.args)
-            if lhs is not None and rhs is not None:
-                return f"({lhs} // {rhs})"
-        case sympy.Add():
-            args = []
-            for arg in expr.args:
-                cute_arg = sympy_to_cute_index(arg, symbol_codes)
-                if cute_arg is None:
-                    return None
-                args.append(cute_arg)
-            return "(" + " + ".join(args) + ")"
-        case sympy.Mul():
-            args = []
-            for arg in expr.args:
-                cute_arg = sympy_to_cute_index(arg, symbol_codes)
-                if cute_arg is None:
-                    return None
-                args.append(cute_arg)
-            return "(" + " * ".join(args) + ")"
+            args = render_sympy_args(expr.args, symbol_codes)
+            if args is not None:
+                return f"({args[0]} // {args[1]})"
+        case sympy.Add() | sympy.Mul():
+            args = render_sympy_args(expr.args, symbol_codes)
+            if args is None:
+                return None
+            separator = " + " if isinstance(expr, sympy.Add) else " * "
+            return "(" + separator.join(args) + ")"
         case Min() | Max():
-            args = []
-            for arg in expr.args:
-                cute_arg = sympy_to_cute_index(arg, symbol_codes)
-                if cute_arg is None:
-                    return None
-                args.append(cute_arg)
+            args = render_sympy_args(expr.args, symbol_codes)
+            if args is None:
+                return None
             op = "min" if isinstance(expr, Min) else "max"
             return f"{op}(" + ", ".join(args) + ")"
     if isinstance(expr, (sympy.Min, sympy.Max)):
-        args = []
-        for arg in expr.args:
-            cute_arg = sympy_to_cute_index(arg, symbol_codes)
-            if cute_arg is None:
-                return None
-            args.append(cute_arg)
+        args = render_sympy_args(expr.args, symbol_codes)
+        if args is None:
+            return None
         op = "min" if isinstance(expr, sympy.Min) else "max"
         return f"{op}(" + ", ".join(args) + ")"
     return None
@@ -221,21 +218,20 @@ class PackedMaskAnalyzer:
     is analyzed over the packed lane expression ``kv_idx + mask_lane`` and
     becomes the interval ``[doc_offsets[b_idx] - kv_idx, q_idx + 128 - kv_idx)``.
 
-    placeholders: FX placeholders for the mask_mod ABI and captured inputs.
+    nonnegative_indices: FX index placeholders that do not need wraparound handling.
     q_idx: FX placeholder for the scalar query index.
     kv_idx: FX placeholder for the first KV index in the packed 32-lane window.
     q_symbol: SymPy symbol used for q_idx during interval analysis.
     kv_symbol: SymPy symbol used for the packed window base KV index.
     lane_symbol: SymPy symbol for the lane offset within the packed window.
     symbol_codes: CuTe renderings for temporary symbols introduced for aux loads.
-    placeholder_codes: CuTe renderings for captured scalar and tensor placeholders.
+    placeholder_codes: CuTe renderings for lane-uniform ABI and captured placeholders.
     placeholder_exprs: SymPy expressions for captured scalar placeholders.
     aux_load_symbols: Stable symbols assigned to supported lane-uniform aux loads.
-    expression_overrides: Branch substitutions for piecewise integer expressions.
     next_symbol_id: Counter for naming temporary aux-load symbols.
     """
 
-    placeholders: Sequence[torch.fx.Node]
+    nonnegative_indices: tuple[torch.fx.Node, ...]
     q_idx: torch.fx.Node
     kv_idx: torch.fx.Node
     q_symbol: sympy.Symbol = dataclasses.field(
@@ -256,94 +252,13 @@ class PackedMaskAnalyzer:
     placeholder_exprs: Mapping[torch.fx.Node, sympy.Expr] = dataclasses.field(
         default_factory=dict
     )
-    aux_load_symbols: dict[tuple[torch.fx.Node, str], sympy.Symbol] = dataclasses.field(
-        default_factory=dict
-    )
-    expression_overrides: Mapping[torch.fx.Node, torch.fx.Node] = dataclasses.field(
+    aux_load_symbols: dict[torch.fx.Node, sympy.Symbol] = dataclasses.field(
         default_factory=dict
     )
     next_symbol_id: int = 0
 
-    def node_to_intervals_with_piecewise(
-        self,
-        node: torch.fx.Node,
-        expression_overrides: Mapping[torch.fx.Node, torch.fx.Node] | None = None,
-        split_depth: int = 0,
-    ) -> MaybeIntervalSet:
-        """Lower boolean graphs after splitting piecewise expressions."""
-        overrides = expression_overrides or {}
-        where = self.find_piecewise_where(node, overrides)
-        if where is not None:
-            return self.split_piecewise_where(node, where, overrides, split_depth)
-        self.expression_overrides = overrides
-        return self.node_to_intervals(node)
-
-    def find_piecewise_where(
-        self,
-        value: object,
-        expression_overrides: Mapping[torch.fx.Node, torch.fx.Node],
-    ) -> torch.fx.Node | None:
-        """Find the first reachable unresolved ``aten.where`` node."""
-        visited = OrderedSet()
-        pending = [value]
-        while pending:
-            current = pending.pop()
-            if not isinstance(current, torch.fx.Node) or current in visited:
-                continue
-            visited.add(current)
-            if current in expression_overrides:
-                pending.append(expression_overrides[current])
-            elif current.target is torch.ops.aten.where.self:
-                return current
-            else:
-                pending.extend(reversed(current.all_input_nodes))
-        return None
-
-    def split_piecewise_where(
-        self,
-        node: torch.fx.Node,
-        where: torch.fx.Node,
-        expression_overrides: Mapping[torch.fx.Node, torch.fx.Node],
-        split_depth: int,
-    ) -> MaybeIntervalSet:
-        """Analyze both arms of one ``where`` under its interval guard."""
-        if 1 << (split_depth + 1) > MAX_PACKED_MASK_INTERVALS_FOR_CODE_SIZE:
-            return None
-        condition, true_value, false_value = where.args
-        if not isinstance(condition, torch.fx.Node):
-            return None
-        if not isinstance(true_value, torch.fx.Node):
-            return None
-        if not isinstance(false_value, torch.fx.Node):
-            return None
-        if self.find_piecewise_where(condition, expression_overrides) is not None:
-            return None
-
-        # P(where(C, T, F)) == (C & P(T)) | (~C & P(F)). Splitting the whole
-        # predicate keeps repeated uses of the same where on the same branch.
-        branches = []
-        for branch_value, condition_is_true in (
-            (true_value, True),
-            (false_value, False),
-        ):
-            branch_overrides = dict(expression_overrides)
-            branch_overrides[where] = branch_value
-            intervals = self.node_to_intervals_with_piecewise(
-                node, branch_overrides, split_depth + 1
-            )
-            guard = self.node_to_intervals_with_piecewise(
-                condition, branch_overrides, split_depth + 1
-            )
-            if not condition_is_true:
-                guard = self.complement_intervals(guard)
-            branches.append(self.intersect_interval_sets(intervals, guard))
-
-        return self.union_interval_sets(*branches)
-
     def node_to_intervals(self, node: torch.fx.Node) -> MaybeIntervalSet:
         """Lower one supported boolean FX node into packed mask intervals."""
-        if node in self.expression_overrides:
-            return self.node_to_intervals(self.expression_overrides[node])
         if is_bool_full_node(node, True):
             return (PackedMaskInterval.full(),)
         if is_bool_full_node(node, False):
@@ -526,22 +441,17 @@ class PackedMaskAnalyzer:
         rhs_base, rhs_divisor = rhs_expr.args
         if lhs_divisor != rhs_divisor:
             return None
-        block_start = None
         if lhs_base == self.q_symbol and rhs_base == self.kv_symbol + self.lane_symbol:
-            block_start = V.graph.sizevars.simplify(
-                lhs_expr * lhs_divisor - self.kv_symbol
-            )
+            q_block = lhs_expr
         elif (
             rhs_base == self.q_symbol and lhs_base == self.kv_symbol + self.lane_symbol
         ):
-            block_start = V.graph.sizevars.simplify(
-                rhs_expr * rhs_divisor - self.kv_symbol
-            )
-        if block_start is None:
+            q_block = rhs_expr
+        else:
             return None
-        lower = V.graph.sizevars.simplify(block_start)
-        upper = V.graph.sizevars.simplify(block_start + lhs_divisor)
-        return self.interval_if_renderable(lower, upper)
+        block_start = V.graph.sizevars.simplify(q_block * lhs_divisor - self.kv_symbol)
+        block_end = V.graph.sizevars.simplify(block_start + lhs_divisor)
+        return self.interval_if_renderable(block_start, block_end)
 
     def interval_if_renderable(
         self, lower: sympy.Expr, upper: sympy.Expr
@@ -553,69 +463,50 @@ class PackedMaskAnalyzer:
             return (PackedMaskInterval(lower, upper),)
         return None
 
-    def normalize_interval_union(self, intervals: MaybeIntervalSet) -> MaybeIntervalSet:
-        """Drop exact empty/duplicate intervals and enforce the code-size cap."""
-        if intervals is None:
-            return None
-        result = []
-        for interval in intervals:
-            lower = V.graph.sizevars.simplify(interval.lower_lane)
-            upper = V.graph.sizevars.simplify(interval.upper_lane_exclusive)
-            if lower == upper:
-                continue
-            normalized = PackedMaskInterval(lower, upper)
-            if normalized not in result:
-                result.append(normalized)
-            if len(result) > MAX_PACKED_MASK_INTERVALS_FOR_CODE_SIZE:
-                return None
-        return tuple(result)
-
-    def union_interval_sets(self, *interval_sets: MaybeIntervalSet) -> MaybeIntervalSet:
-        """Union interval sets, propagating unsupported analysis."""
-        result = []
-        for intervals in interval_sets:
-            if intervals is None:
-                return None
-            result.extend(intervals)
-        return self.normalize_interval_union(tuple(result))
-
-    def intersect_interval_sets(
-        self, intervals: MaybeIntervalSet, new_intervals: MaybeIntervalSet
-    ) -> MaybeIntervalSet:
-        """Intersect interval sets, propagating unsupported analysis."""
-        intervals = self.normalize_interval_union(intervals)
-        new_intervals = self.normalize_interval_union(new_intervals)
-        if intervals is None or new_intervals is None:
-            return None
-        return self.normalize_interval_union(
-            self.merge_intersection(intervals, new_intervals)
-        )
-
     def complement_intervals(self, intervals: MaybeIntervalSet) -> MaybeIntervalSet:
         """Complement a keep-set within the 32-lane window via De Morgan.
 
         The complement of a union of intervals is the intersection of each
         interval's two complement pieces, which stays interval-representable.
         Interval bounds may be symbolic, so this composes existing renderable
-        bounds instead of sorting; merge_intersection caps the blowup.
+        bounds instead of sorting; intersect_interval_sets caps the blowup.
         """
         if intervals is None:
             return None
         result: MaybeIntervalSet = (PackedMaskInterval.full(),)
         for interval in intervals:
-            pieces = (
-                PackedMaskInterval(sympy.Integer(0), interval.lower_lane),
-                PackedMaskInterval(interval.upper_lane_exclusive, sympy.Integer(32)),
+            result = self.intersect_interval_sets(
+                result,
+                (
+                    PackedMaskInterval(sympy.Integer(0), interval.lower_lane),
+                    PackedMaskInterval(
+                        interval.upper_lane_exclusive, sympy.Integer(32)
+                    ),
+                ),
             )
-            result = self.intersect_interval_sets(result, pieces)
         return result
 
-    def merge_intersection(
-        self,
-        intervals: IntervalSet,
-        new_intervals: IntervalSet,
+    def union_interval_sets(
+        self, intervals: MaybeIntervalSet, new_intervals: MaybeIntervalSet
     ) -> MaybeIntervalSet:
-        """Intersect two interval sets, falling back if code size would grow too much."""
+        """Union supported interval sets while enforcing the code-size cap."""
+        if intervals is None or new_intervals is None:
+            return None
+        if (
+            len(intervals) + len(new_intervals)
+            > MAX_PACKED_MASK_INTERVALS_FOR_CODE_SIZE
+        ):
+            return None
+        return intervals + new_intervals
+
+    def intersect_interval_sets(
+        self,
+        intervals: MaybeIntervalSet,
+        new_intervals: MaybeIntervalSet,
+    ) -> MaybeIntervalSet:
+        """Intersect supported interval sets while enforcing the code-size cap."""
+        if intervals is None or new_intervals is None:
+            return None
         if (
             len(intervals) * len(new_intervals)
             > MAX_PACKED_MASK_INTERVALS_FOR_CODE_SIZE
@@ -633,35 +524,26 @@ class PackedMaskAnalyzer:
 
     def fx_mask_expr_to_sympy(self, expr: object) -> sympy.Expr | None:
         """Translate a mask expression with kv_idx expanded by mask_lane."""
-        if isinstance(expr, torch.fx.Node) and expr in self.expression_overrides:
-            expr = self.expression_overrides[expr]
         index_symbols = {
             self.q_idx: self.q_symbol,
             self.kv_idx: self.kv_symbol + self.lane_symbol,
         }
         index_symbols.update(self.placeholder_exprs)
-        return fx_aux_index_to_sympy(expr, index_symbols, self.mask_node_to_sympy)
-
-    def mask_node_to_sympy(self, node: torch.fx.Node) -> sympy.Expr | None:
-        """Resolve branch substitutions before translating supported aux loads."""
-        if node in self.expression_overrides:
-            return self.fx_mask_expr_to_sympy(self.expression_overrides[node])
-        return self.mask_aux_load_to_symbol(node)
+        return fx_aux_index_to_sympy(expr, index_symbols, self.mask_aux_load_to_symbol)
 
     def mask_aux_load_to_symbol(self, node: torch.fx.Node) -> sympy.Expr | None:
         """Assign a temporary SymPy symbol to a supported aux tensor load."""
         if not is_aten_index_node(node):
             return None
+        if node in self.aux_load_symbols:
+            return self.aux_load_symbols[node]
         lane_uniform_code = self.render_lane_uniform_scalar_expr(node)
         if lane_uniform_code is None:
             return None
-        cache_key = (node, lane_uniform_code)
-        if cache_key in self.aux_load_symbols:
-            return self.aux_load_symbols[cache_key]
         symbol = sympy.Symbol(f"mask_bound_{self.next_symbol_id}", integer=True)
         self.next_symbol_id += 1
         self.symbol_codes[symbol] = lane_uniform_code
-        self.aux_load_symbols[cache_key] = symbol
+        self.aux_load_symbols[node] = symbol
         return symbol
 
     def render_lane_uniform_scalar_expr(
@@ -681,22 +563,9 @@ class PackedMaskAnalyzer:
             return f"cutlass.Int32({index})"
         if not isinstance(expr, torch.fx.Node):
             return None
-        if expr in self.expression_overrides:
-            return self.render_lane_uniform_scalar_expr(
-                self.expression_overrides[expr],
-                for_index=for_index,
-                index_dim_size=index_dim_size,
-            )
 
         if expr is self.kv_idx:
             return None
-        if expr is self.q_idx:
-            return "q_idx[0]"
-        if len(self.placeholders) >= 2:
-            if expr is self.placeholders[0]:
-                return "b_idx[0]"
-            if expr is self.placeholders[1]:
-                return "h_idx[0]"
         if expr in self.placeholder_codes:
             return self.placeholder_codes[expr]
 
@@ -758,8 +627,7 @@ class PackedMaskAnalyzer:
             if (
                 dim_size is not None
                 and isinstance(index, torch.fx.Node)
-                and index
-                not in (self.q_idx, self.placeholders[0], self.placeholders[1])
+                and index not in self.nonnegative_indices
             ):
                 if not isinstance(dim_size, int | sympy.Integer):
                     return None
@@ -796,7 +664,7 @@ class PackedMaskAuxPlaceholderMap:
         codes: dict[torch.fx.Node, str] = {}
         exprs: dict[torch.fx.Node, sympy.Expr] = {}
         tensor_idx = 0
-        for placeholder, buffer in zip(placeholders[4:], other_buffers):
+        for placeholder, buffer in zip(placeholders, other_buffers):
             if isinstance(buffer, sympy.Expr):
                 rendered = sympy_to_cute_index(buffer, symbol_codes)
                 if rendered is None:
@@ -806,7 +674,7 @@ class PackedMaskAuxPlaceholderMap:
             else:
                 codes[placeholder] = f"aux_tensors[{tensor_idx}]"
                 tensor_idx += 1
-        for placeholder in placeholders[4 + len(other_buffers) :]:
+        for placeholder in placeholders[len(other_buffers) :]:
             codes[placeholder] = f"aux_tensors[{tensor_idx}]"
             tensor_idx += 1
         return cls(codes, exprs)
@@ -830,27 +698,32 @@ def select_packed_mask_intervals(
     if len(placeholders) < 4 or len(output) != 1:
         return None
 
-    q_idx, kv_idx = placeholders[2], placeholders[3]
+    b_idx, h_idx, q_idx, kv_idx, *aux_placeholders = placeholders
     output_val = output[0].args[0]
     if not isinstance(output_val, torch.fx.Node):
         return None
 
     symbol_codes = dict(aux_scalar_symbol_codes or {})
     placeholder_map = PackedMaskAuxPlaceholderMap.from_placeholders(
-        placeholders, other_buffers, symbol_codes
+        aux_placeholders, other_buffers, symbol_codes
     )
     if placeholder_map is None:
         return None
 
     analyzer = PackedMaskAnalyzer(
-        placeholders=placeholders,
+        nonnegative_indices=(b_idx, h_idx, q_idx),
         q_idx=q_idx,
         kv_idx=kv_idx,
         symbol_codes=symbol_codes,
-        placeholder_codes=placeholder_map.codes,
+        placeholder_codes={
+            b_idx: "b_idx[0]",
+            h_idx: "h_idx[0]",
+            q_idx: "q_idx[0]",
+            **placeholder_map.codes,
+        },
         placeholder_exprs=placeholder_map.exprs,
     )
-    intervals = analyzer.node_to_intervals_with_piecewise(output_val)
+    intervals = analyzer.node_to_intervals(output_val)
     if intervals is None:
         perf_hint_log.info(
             "flex FLASH: mask_mod could not be lowered to packed 32-lane intervals; "

--- a/torch/_inductor/kernel/flex/interval_mask_packing.py
+++ b/torch/_inductor/kernel/flex/interval_mask_packing.py
@@ -23,6 +23,7 @@ import sympy
 
 import torch
 from torch.fx import GraphModule
+from torch.utils._ordered_set import OrderedSet
 from torch.utils._sympy.functions import FloorDiv, Max, Min
 
 from ...codegen.cutedsl.lane_analysis import decompose_affine_lane_expr
@@ -34,7 +35,7 @@ perf_hint_log = torch._logging.getArtifactLogger(__name__, "perf_hints")
 
 
 # Fall back to scalar mask lowering before interval expansion makes generated CuTe too large.
-MAX_PACKED_MASK_INTERVALS_FOR_CODE_SIZE = 8
+MAX_PACKED_MASK_INTERVALS_FOR_CODE_SIZE = 16
 LANE_UNIFORM_BINARY_OPS: Mapping[object, str] = {
     torch.ops.aten.add.Tensor: "+",
     torch.ops.aten.add.Scalar: "+",
@@ -230,6 +231,7 @@ class PackedMaskAnalyzer:
     placeholder_codes: CuTe renderings for captured scalar and tensor placeholders.
     placeholder_exprs: SymPy expressions for captured scalar placeholders.
     aux_load_symbols: Stable symbols assigned to supported lane-uniform aux loads.
+    expression_overrides: Branch substitutions for piecewise integer expressions.
     next_symbol_id: Counter for naming temporary aux-load symbols.
     """
 
@@ -254,13 +256,94 @@ class PackedMaskAnalyzer:
     placeholder_exprs: Mapping[torch.fx.Node, sympy.Expr] = dataclasses.field(
         default_factory=dict
     )
-    aux_load_symbols: dict[torch.fx.Node, sympy.Symbol] = dataclasses.field(
+    aux_load_symbols: dict[tuple[torch.fx.Node, str], sympy.Symbol] = dataclasses.field(
+        default_factory=dict
+    )
+    expression_overrides: Mapping[torch.fx.Node, torch.fx.Node] = dataclasses.field(
         default_factory=dict
     )
     next_symbol_id: int = 0
 
+    def node_to_intervals_with_piecewise(
+        self,
+        node: torch.fx.Node,
+        expression_overrides: Mapping[torch.fx.Node, torch.fx.Node] | None = None,
+        split_depth: int = 0,
+    ) -> MaybeIntervalSet:
+        """Lower boolean graphs after splitting piecewise expressions."""
+        overrides = expression_overrides or {}
+        where = self.find_piecewise_where(node, overrides)
+        if where is not None:
+            return self.split_piecewise_where(node, where, overrides, split_depth)
+        self.expression_overrides = overrides
+        return self.node_to_intervals(node)
+
+    def find_piecewise_where(
+        self,
+        value: object,
+        expression_overrides: Mapping[torch.fx.Node, torch.fx.Node],
+    ) -> torch.fx.Node | None:
+        """Find the first reachable unresolved ``aten.where`` node."""
+        visited = OrderedSet()
+        pending = [value]
+        while pending:
+            current = pending.pop()
+            if not isinstance(current, torch.fx.Node) or current in visited:
+                continue
+            visited.add(current)
+            if current in expression_overrides:
+                pending.append(expression_overrides[current])
+            elif current.target is torch.ops.aten.where.self:
+                return current
+            else:
+                pending.extend(reversed(current.all_input_nodes))
+        return None
+
+    def split_piecewise_where(
+        self,
+        node: torch.fx.Node,
+        where: torch.fx.Node,
+        expression_overrides: Mapping[torch.fx.Node, torch.fx.Node],
+        split_depth: int,
+    ) -> MaybeIntervalSet:
+        """Analyze both arms of one ``where`` under its interval guard."""
+        if 1 << (split_depth + 1) > MAX_PACKED_MASK_INTERVALS_FOR_CODE_SIZE:
+            return None
+        condition, true_value, false_value = where.args
+        if not isinstance(condition, torch.fx.Node):
+            return None
+        if not isinstance(true_value, torch.fx.Node):
+            return None
+        if not isinstance(false_value, torch.fx.Node):
+            return None
+        if self.find_piecewise_where(condition, expression_overrides) is not None:
+            return None
+
+        # P(where(C, T, F)) == (C & P(T)) | (~C & P(F)). Splitting the whole
+        # predicate keeps repeated uses of the same where on the same branch.
+        branches = []
+        for branch_value, condition_is_true in (
+            (true_value, True),
+            (false_value, False),
+        ):
+            branch_overrides = dict(expression_overrides)
+            branch_overrides[where] = branch_value
+            intervals = self.node_to_intervals_with_piecewise(
+                node, branch_overrides, split_depth + 1
+            )
+            guard = self.node_to_intervals_with_piecewise(
+                condition, branch_overrides, split_depth + 1
+            )
+            if not condition_is_true:
+                guard = self.complement_intervals(guard)
+            branches.append(self.intersect_interval_sets(intervals, guard))
+
+        return self.union_interval_sets(*branches)
+
     def node_to_intervals(self, node: torch.fx.Node) -> MaybeIntervalSet:
         """Lower one supported boolean FX node into packed mask intervals."""
+        if node in self.expression_overrides:
+            return self.node_to_intervals(self.expression_overrides[node])
         if is_bool_full_node(node, True):
             return (PackedMaskInterval.full(),)
         if is_bool_full_node(node, False):
@@ -291,9 +374,8 @@ class PackedMaskAnalyzer:
             case torch.ops.aten.eq.Tensor | torch.ops.aten.eq.Scalar:
                 return self.equality_to_intervals(node.args[0], node.args[1])
             case torch.ops.aten.ne.Tensor | torch.ops.aten.ne.Scalar:
-                intervals = self.equality_to_intervals(node.args[0], node.args[1])
-                return (
-                    None if intervals is None else self.complement_intervals(intervals)
+                return self.complement_intervals(
+                    self.equality_to_intervals(node.args[0], node.args[1])
                 )
             case (
                 torch.ops.aten.logical_not.default | torch.ops.aten.bitwise_not.default
@@ -301,10 +383,7 @@ class PackedMaskAnalyzer:
                 child = node.args[0]
                 if not isinstance(child, torch.fx.Node):
                     return None
-                intervals = self.node_to_intervals(child)
-                return (
-                    None if intervals is None else self.complement_intervals(intervals)
-                )
+                return self.complement_intervals(self.node_to_intervals(child))
             case _:
                 return None
 
@@ -316,16 +395,9 @@ class PackedMaskAnalyzer:
             return None
         lhs_intervals = self.node_to_intervals(lhs)
         rhs_intervals = self.node_to_intervals(rhs)
-        if lhs_intervals is None or rhs_intervals is None:
-            return None
         if intersect:
-            return self.merge_intersection(lhs_intervals, rhs_intervals)
-        if (
-            len(lhs_intervals) + len(rhs_intervals)
-            > MAX_PACKED_MASK_INTERVALS_FOR_CODE_SIZE
-        ):
-            return None
-        return lhs_intervals + rhs_intervals
+            return self.intersect_interval_sets(lhs_intervals, rhs_intervals)
+        return self.union_interval_sets(lhs_intervals, rhs_intervals)
 
     def comparison_to_intervals(
         self,
@@ -481,7 +553,45 @@ class PackedMaskAnalyzer:
             return (PackedMaskInterval(lower, upper),)
         return None
 
-    def complement_intervals(self, intervals: IntervalSet) -> MaybeIntervalSet:
+    def normalize_interval_union(self, intervals: MaybeIntervalSet) -> MaybeIntervalSet:
+        """Drop exact empty/duplicate intervals and enforce the code-size cap."""
+        if intervals is None:
+            return None
+        result = []
+        for interval in intervals:
+            lower = V.graph.sizevars.simplify(interval.lower_lane)
+            upper = V.graph.sizevars.simplify(interval.upper_lane_exclusive)
+            if lower == upper:
+                continue
+            normalized = PackedMaskInterval(lower, upper)
+            if normalized not in result:
+                result.append(normalized)
+            if len(result) > MAX_PACKED_MASK_INTERVALS_FOR_CODE_SIZE:
+                return None
+        return tuple(result)
+
+    def union_interval_sets(self, *interval_sets: MaybeIntervalSet) -> MaybeIntervalSet:
+        """Union interval sets, propagating unsupported analysis."""
+        result = []
+        for intervals in interval_sets:
+            if intervals is None:
+                return None
+            result.extend(intervals)
+        return self.normalize_interval_union(tuple(result))
+
+    def intersect_interval_sets(
+        self, intervals: MaybeIntervalSet, new_intervals: MaybeIntervalSet
+    ) -> MaybeIntervalSet:
+        """Intersect interval sets, propagating unsupported analysis."""
+        intervals = self.normalize_interval_union(intervals)
+        new_intervals = self.normalize_interval_union(new_intervals)
+        if intervals is None or new_intervals is None:
+            return None
+        return self.normalize_interval_union(
+            self.merge_intersection(intervals, new_intervals)
+        )
+
+    def complement_intervals(self, intervals: MaybeIntervalSet) -> MaybeIntervalSet:
         """Complement a keep-set within the 32-lane window via De Morgan.
 
         The complement of a union of intervals is the intersection of each
@@ -489,16 +599,15 @@ class PackedMaskAnalyzer:
         Interval bounds may be symbolic, so this composes existing renderable
         bounds instead of sorting; merge_intersection caps the blowup.
         """
-        result: IntervalSet = (PackedMaskInterval.full(),)
+        if intervals is None:
+            return None
+        result: MaybeIntervalSet = (PackedMaskInterval.full(),)
         for interval in intervals:
             pieces = (
                 PackedMaskInterval(sympy.Integer(0), interval.lower_lane),
                 PackedMaskInterval(interval.upper_lane_exclusive, sympy.Integer(32)),
             )
-            merged = self.merge_intersection(result, pieces)
-            if merged is None:
-                return None
-            result = merged
+            result = self.intersect_interval_sets(result, pieces)
         return result
 
     def merge_intersection(
@@ -524,26 +633,35 @@ class PackedMaskAnalyzer:
 
     def fx_mask_expr_to_sympy(self, expr: object) -> sympy.Expr | None:
         """Translate a mask expression with kv_idx expanded by mask_lane."""
+        if isinstance(expr, torch.fx.Node) and expr in self.expression_overrides:
+            expr = self.expression_overrides[expr]
         index_symbols = {
             self.q_idx: self.q_symbol,
             self.kv_idx: self.kv_symbol + self.lane_symbol,
         }
         index_symbols.update(self.placeholder_exprs)
-        return fx_aux_index_to_sympy(expr, index_symbols, self.mask_aux_load_to_symbol)
+        return fx_aux_index_to_sympy(expr, index_symbols, self.mask_node_to_sympy)
+
+    def mask_node_to_sympy(self, node: torch.fx.Node) -> sympy.Expr | None:
+        """Resolve branch substitutions before translating supported aux loads."""
+        if node in self.expression_overrides:
+            return self.fx_mask_expr_to_sympy(self.expression_overrides[node])
+        return self.mask_aux_load_to_symbol(node)
 
     def mask_aux_load_to_symbol(self, node: torch.fx.Node) -> sympy.Expr | None:
         """Assign a temporary SymPy symbol to a supported aux tensor load."""
         if not is_aten_index_node(node):
             return None
-        if node in self.aux_load_symbols:
-            return self.aux_load_symbols[node]
         lane_uniform_code = self.render_lane_uniform_scalar_expr(node)
         if lane_uniform_code is None:
             return None
+        cache_key = (node, lane_uniform_code)
+        if cache_key in self.aux_load_symbols:
+            return self.aux_load_symbols[cache_key]
         symbol = sympy.Symbol(f"mask_bound_{self.next_symbol_id}", integer=True)
         self.next_symbol_id += 1
         self.symbol_codes[symbol] = lane_uniform_code
-        self.aux_load_symbols[node] = symbol
+        self.aux_load_symbols[cache_key] = symbol
         return symbol
 
     def render_lane_uniform_scalar_expr(
@@ -563,6 +681,12 @@ class PackedMaskAnalyzer:
             return f"cutlass.Int32({index})"
         if not isinstance(expr, torch.fx.Node):
             return None
+        if expr in self.expression_overrides:
+            return self.render_lane_uniform_scalar_expr(
+                self.expression_overrides[expr],
+                for_index=for_index,
+                index_dim_size=index_dim_size,
+            )
 
         if expr is self.kv_idx:
             return None
@@ -726,7 +850,7 @@ def select_packed_mask_intervals(
         placeholder_codes=placeholder_map.codes,
         placeholder_exprs=placeholder_map.exprs,
     )
-    intervals = analyzer.node_to_intervals(output_val)
+    intervals = analyzer.node_to_intervals_with_piecewise(output_val)
     if intervals is None:
         perf_hint_log.info(
             "flex FLASH: mask_mod could not be lowered to packed 32-lane intervals; "


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189500


## Summary

UPDATE: I did all the below it was pretty and fun and nice lil trick but in the end no perf gains. I changed the PR to just do the simplifications I made along the way

---

What does this do, at a high level it enables us to continue to use pack-analyzer for where expressions.

A good example of this is 

```python
def mask_mod(_b, _h, q_idx, kv_idx):
    window_end = torch.where(q_idx < 64, q_idx + 64, q_idx + 320)
    return (kv_idx >= window_end - 32) & (kv_idx <= window_end)
```

So both true and false  expressions are capable with using pack anayzer but before we couldnt use if there was a `where` gluing together. 

The pack in isolation are

```
 
   q_idx < 64:   q_idx + 32  <= kv_idx <= q_idx + 64
   q_idx >= 64:  q_idx + 288 <= kv_idx <= q_idx + 320

or in intervals
 
   q_idx < 64:   [q_idx + 32, q_idx + 65)
   q_idx >= 64:  [q_idx + 288, q_idx + 321)
```

So what we do to enable this is glue together with 

`Pack(where( Condition, True, False))) = (Condition & Pack(true) | ~Condition & Pack(false))

where | = interval union


This ends up producing code of the form:

```Py
  @cute.jit
    def mask_mod(b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors, aux_scalars=None):
        mask_mod_packed = cute.make_rmem_tensor(1, dtype=cutlass.Uint32)
        mask_mod_packed[0] = cutlass.Uint32(0)
        mask_mod_packed[0] = mask_mod_packed[0] | (utils.shr_u32(cutlass.Uint32(0xFFFFFFFF), cutlass.Uint32(min(max(cutlass.Int32(32) - min(cutlass.Int32(32), (cutlass.Int32(2048) + (cutlass.Int32(-32) * q_idx[0])), (cutlass.Int32(65) + q_idx[0] + (cutlass.Int32(-1) * kv_idx[0]))), cutlass.Int32(0)), cutlass.Int32(32)))) & utils.shl_u32(cutlass.Uint32(0xFFFFFFFF), cutlass.Uint32(min(max(max(cutlass.Int32(0), (cutlass.Int32(32) + q_idx[0] + (cutlass.Int32(-1) * kv_idx[0]))), cutlass.Int32(0)), cutlass.Int32(32)))))

        mask_mod_packed[0] = mask_mod_packed[0] | (utils.shr_u32(cutlass.Uint32(0xFFFFFFFF), cutlass.Uint32(min(max(cutlass.Int32(32) - min(cutlass.Int32(32), (cutlass.Int32(321) + q_idx[0] + (cutlass.Int32(-1) * kv_idx[0]))), cutlass.Int32(0)), cutlass.Int32(32)))) & utils.shl_u32(cutlass.Uint32(0xFFFFFFFF), cutlass.Uint32(min(max(max(cutlass.Int32(0), (cutlass.Int32(2048) + (cutlass.Int32(-32) * q_idx[0])), (cutlass.Int32(288) + q_idx[0] + (cutlass.Int32(-1) * kv_idx[0]))), cutlass.Int32(0)), cutlass.Int32(32)))))
````


### Other tweaks
As you can see from above the MAX_PACKED_MASK_INTERVALS_FOR_CODE_SIZE is now pretty large so I bumped to 16. I measured to see if there is a perf hit from doing this (that was chosen arbitrarily somewhat before) and no we good.

we also had to do some updates to our aux_loads caching so that  `offsets[q_idx]` from being reused for the
   `offsets[q_idx + 64]` , baiscally since we analyze both sides of the branch it was possible to have the acutal index expression hit, so we needed to add the actual indexing expression to the cache key.
   
I.e. it is this now
 ```python
   cache[(start_node, "offsets[q_idx]")]
   cache[(start_node, "offsets[q_idx + 64]")]
```
	



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Chillee @yanboliang @BoyuanFeng @liangel-02 @howardzhang-cv