### PR TITLE
[AOTInductor] Fix input-handle GPU memory leak when run_impl throws on an input runtime check (#189503)

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -5869,6 +5869,49 @@ class AOTInductorTestsTemplate:
         with self.assertRaisesRegex(Exception, ""):
             aot_inductor_module(y4)
 
+    @patch.dict(os.environ, {"AOTI_RUNTIME_CHECK_INPUTS": "1"})
+    def test_runtime_check_overbound_no_input_leak(self):
+        # When AOTI_RUNTIME_CHECK_INPUTS rejects an over-bound input, the check
+        # throws before the input handles are stolen into RAII. A correct runner
+        # must free those un-stolen handles; otherwise every rejected call leaks
+        # one at::Tensor (and its backing GPU storage) per input.
+        # MPS has no memory_allocated accounting (needed below); skip CPU and MPS.
+        if self.device != GPU_TYPE or self.device == "mps":
+            raise unittest.SkipTest("requires GPU with memory_allocated support")
+
+        class Model(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear = torch.nn.Linear(2048, 2048)
+
+            def forward(self, x):
+                return self.linear(x)
+
+        model = Model().to(self.device)
+        x = torch.randn(8, 2048, device=self.device)  # example within bound
+        dim0 = Dim("b", min=1, max=64)  # compiled upper bound = 64
+        with torch.no_grad():
+            package_path: str = AOTIRunnerUtil.compile(
+                model, (x,), dynamic_shapes={"x": {0: dim0}}
+            )
+        aot_inductor_module = torch._inductor.aoti_load_package(package_path)
+        # in-bound call works and warms up the allocator
+        aot_inductor_module(torch.randn(8, 2048, device=self.device))
+
+        device_interface = get_interface_for_device(GPU_TYPE)
+        device = device_interface.current_device()
+        device_interface.synchronize()
+        mem_before = device_interface.memory_allocated(device)
+        # Repeatedly reject FRESH over-bound inputs; storage must not be retained.
+        for _ in range(64):
+            over = torch.randn(128, 2048, device=self.device)  # 128 > 64 -> rejected
+            with self.assertRaisesRegex(Exception, "dim value is too large"):
+                aot_inductor_module(over)
+            del over
+        device_interface.synchronize()
+        mem_after = device_interface.memory_allocated(device)
+        self.assertEqual(mem_after, mem_before)
+
     def test_add_complex(self):
         class Model(torch.nn.Module):
             def forward(self, a, b):

--- a/torch/csrc/inductor/aoti_runner/model_container_runner.cpp
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner.cpp
@@ -191,6 +191,15 @@ AOTIModelContainerRunner::~AOTIModelContainerRunner() {
 std::vector<at::Tensor> AOTIModelContainerRunner::run_impl(
     std::vector<AtenTensorHandle>& input_handles,
     void* stream_handle) {
+  // The model steals each input handle and nulls its slot (see
+  // steal_from_raw_handles_to_raii_handles). If run_func_ throws before the
+  // steal (e.g. a failed input runtime check), the un-stolen handles would
+  // leak, keeping their input storage alive. Free whatever the model did not
+  // steal on every exit; on success all slots are null so this is a no-op.
+  auto free_unstolen_input_handles = c10::make_scope_exit([&input_handles]() {
+    torch::aot_inductor::free_unstolen_handles(input_handles);
+  });
+
   // For outputs, we only allocate a vector to hold returned tensor handles,
   // not allocating the actual output tensor storage here
   size_t num_outputs = 0;

--- a/torch/csrc/inductor/aoti_torch/tensor_converter.cpp
+++ b/torch/csrc/inductor/aoti_torch/tensor_converter.cpp
@@ -44,4 +44,13 @@ std::vector<at::Tensor> alloc_tensors_by_stealing_from_handles(
   return result;
 }
 
+void free_unstolen_handles(std::vector<AtenTensorHandle>& handles) {
+  for (auto& handle : handles) {
+    if (handle != nullptr) {
+      aoti_torch_delete_tensor_object(handle);
+      handle = nullptr;
+    }
+  }
+}
+
 } // namespace torch::aot_inductor

--- a/torch/csrc/inductor/aoti_torch/tensor_converter.h
+++ b/torch/csrc/inductor/aoti_torch/tensor_converter.h
@@ -23,4 +23,15 @@ TORCH_API std::vector<at::Tensor> alloc_tensors_by_stealing_from_handles(
     AtenTensorHandle* handles,
     size_t length);
 
+// free_unstolen_handles frees any handles a stealing callee did not take. A
+// stealing run (the generated model.so, or
+// alloc_tensors_by_stealing_from_handles) nulls each slot it takes ownership
+// of, so this is safe to run on every exit of a run path: after a fully
+// successful, fully stealing run every slot is null and this is a no-op; if the
+// run throws before stealing, it releases the un-stolen handles instead of
+// leaking their tensor storage.
+//
+// WARNING: Can NOT be called in model.so
+TORCH_API void free_unstolen_handles(std::vector<AtenTensorHandle>& handles);
+
 } // namespace torch::aot_inductor


### PR DESCRIPTION
Summary:

When `AOTI_RUNTIME_CHECK_INPUTS=1`, a compiled AOTInductor model runs its input validation (e.g. the dynamic-dim bound check that raises "dim value is too large") at the start of its generated run, before it steals the caller's input tensors into RAII. On the host side, `AOTIModelContainerRunner::run` / `boxed_run` build the input `AtenTensorHandle`s via `unsafe_alloc_new_handles_from_tensors`, which heap-allocates one `new at::Tensor` per input (each holding a reference to that input's device storage) and passes the raw handles into `run_impl`. When the input check fails, `run_func_` returns a non-success code and `run_impl` throws -- but nothing frees those handles, because on the normal path they are released only when the model steals them. Every rejected request therefore leaks one `at::Tensor` per input, i.e. a retained refcount on the input's GPU storage that the caching allocator never reclaims. Under sustained over-bound traffic this shows up as monotonic HBM growth to OOM (observed crash-looping an MI350X inference tenant after `AOTI_RUNTIME_CHECK_INPUTS` was enabled fleet-wide).

Root cause: ownership of the input handles is transferred to the model only on the success (steal) path; the failure path has no owner, so the handles leak.

Fix: install a `c10::make_scope_exit` at the top of `AOTIModelContainerRunner::run_impl` that frees every non-null slot in `input_handles` on any exit. This is idempotent with the steal -- `steal_from_raw_handles_to_raii_handles` nulls each slot as it takes ownership -- so on success the guard is a no-op, and on an error or throw it releases exactly the handles the model did not steal. The free mirrors the existing idiom in `alloc_tensors_by_stealing_from_handles` (`aoti_torch_delete_tensor_object` followed by nulling the slot). The fix lives in the host runner (libtorch), not in the generated model `.so`, so it covers every AOTInductor model without re-lowering.

Alternative considered: change the codegen so the model steals inputs into RAII before running the input check (so RAII frees them on throw). Rejected because it would require re-lowering and re-exporting every model to take effect; the host-side guard fixes all existing artifacts with a single binary.

Test Plan:
Added `test_runtime_check_overbound_no_input_leak` to `caffe2/test/inductor/test_aot_inductor.py`. It compiles a model with a dynamic dim bound, enables `AOTI_RUNTIME_CHECK_INPUTS=1`, issues 64 over-bound requests that each raise "dim value is too large", and asserts `memory_allocated` is identical before and after the loop.

Run on GPU in opt mode (the default ASAN mode cannot initialize CUDA under nvcc):

```
buck2 test fbcode//mode/opt -m ovr_config//gpu:nvidia -j 8 fbcode//caffe2/test/inductor:test_aot_inductor -- test_runtime_check_overbound_no_input_leak
```

Before the fix (RED): the two GPU variants fail with `mem_after - mem_before = 67108864` bytes = 64 rejected requests x 1 MB per input (`128 x 2048` fp32).

After the fix (GREEN): `Ran 4 tests ... OK (skipped=2)` -- the GPU variants pass with `mem_after == mem_before`.

This diff was authored with assistance from Claude Code (AI pair programmer).

Reviewed By: mrajpal, kqfu

Differential Revision: D111196076




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo