### PR TITLE
[AOTInductor] Free un-transferred folded constants on error in run_const_fold (#189505)

### DIFF
--- a/torch/csrc/inductor/aoti_runtime/model_base.h
+++ b/torch/csrc/inductor/aoti_runtime/model_base.h
@@ -926,22 +926,40 @@ class AOTInductorModelBase {
     auto folded_constants =
         model->const_run_impl(stream, proxy_executor, initialization);
 
+    // const_run_impl returns owning raw AtenTensorHandles in the map. The
+    // fallible calls below (cudaEventRecord / XPU barrier /
+    // wait_for_completion) can throw; without cleanup the map's destructor
+    // drops those raw handles without freeing the underlying tensors, leaking
+    // folded-constant GPU memory (the container catches and keeps serving, so
+    // it accumulates). Free the still-owned handles on the error path only.
+    // This header is compiled into model.so, so use only the stable C ABI (no
+    // c10 scope-guard).
+    try {
 #ifdef USE_CUDA
-    AOTI_RUNTIME_CUDA_CHECK(cudaEventRecord(*run_finished_, stream));
+      AOTI_RUNTIME_CUDA_CHECK(cudaEventRecord(*run_finished_, stream));
 #elif defined(USE_XPU)
-    // sycl::queue* queue_ptr = nullptr;
-    // aoti_torch_get_current_sycl_queue((void**)&queue_ptr);
-    run_finished_ = std::make_optional<sycl::event*>(new sycl::event(
-        static_cast<sycl::queue*>(stream)->ext_oneapi_submit_barrier()));
+      // sycl::queue* queue_ptr = nullptr;
+      // aoti_torch_get_current_sycl_queue((void**)&queue_ptr);
+      run_finished_ = std::make_optional<sycl::event*>(new sycl::event(
+          static_cast<sycl::queue*>(stream)->ext_oneapi_submit_barrier()));
 
 #else // !USE_CUDA && !USE_XPU
-    run_finished_ = true;
+      run_finished_ = true;
 #endif // USE_CUDA
 
-    // Wait for the constant folding kernels to complete. The folded
-    // constants may be read by inference on a different stream after
-    // swap_constant_buffer(), which has no GPU synchronization.
-    wait_for_completion();
+      // Wait for the constant folding kernels to complete. The folded
+      // constants may be read by inference on a different stream after
+      // swap_constant_buffer(), which has no GPU synchronization.
+      wait_for_completion();
+    } catch (...) {
+      for (auto& kv : folded_constants) {
+        if (kv.second != nullptr) {
+          (void)aoti_torch_delete_tensor_object(kv.second);
+          kv.second = nullptr;
+        }
+      }
+      throw;
+    }
 
     return folded_constants;
   }

--- a/torch/csrc/inductor/aoti_runtime/model_container.h
+++ b/torch/csrc/inductor/aoti_runtime/model_container.h
@@ -571,25 +571,49 @@ class AOTInductorModelContainer {
     auto& source = use_inactive ? active() : inactive();
     target.fold_state = ConstantState::INITIALIZED;
 
+    // constants_map is bound by rvalue-ref to the caller's folded-constant map
+    // and owns raw AtenTensorHandles. Each is handed to target.map (as an
+    // RAIIAtenTensorHandle) below and its source slot nulled the instant it is
+    // transferred. If a call in the loop throws (node alloc in
+    // insert_or_assign, string ctor), free the not-yet-transferred handles;
+    // already-transferred slots are null so they are skipped -- no double free.
+    // On success every consumed slot is null, so the caller's map is discarded
+    // without freeing (unchanged semantics). model.so-embedded, so stable C ABI
+    // only.
     auto num_constants = models_[0]->num_constants();
-    for (size_t idx = 0; idx < num_constants; idx++) {
-      auto constant_name =
-          std::string(models_[0]->constant_name(static_cast<int64_t>(idx)));
-      auto it = constants_map.find(constant_name);
-      if (it == constants_map.end() &&
-          !(use_inactive && _is_tensor_constant_type(idx))) {
-        continue;
-      }
+    try {
+      for (size_t idx = 0; idx < num_constants; idx++) {
+        auto constant_name =
+            std::string(models_[0]->constant_name(static_cast<int64_t>(idx)));
+        auto it = constants_map.find(constant_name);
+        if (it == constants_map.end() &&
+            !(use_inactive && _is_tensor_constant_type(idx))) {
+          continue;
+        }
 
-      AtenTensorHandle tensor;
-      if (it == constants_map.end()) {
-        aoti_torch_clone(
-            source.map->find(constant_name)->second.get(), &tensor);
-      } else {
-        tensor = it->second;
-      }
+        AtenTensorHandle tensor;
+        if (it == constants_map.end()) {
+          aoti_torch_clone(
+              source.map->find(constant_name)->second.get(), &tensor);
+        } else {
+          tensor = it->second;
+          // Null the source slot before RAIIAtenTensorHandle takes ownership so
+          // a throw in insert_or_assign (which frees the temporary) cannot
+          // leave a dangling handle in constants_map to double free.
+          it->second = nullptr;
+        }
 
-      target.map->insert_or_assign(constant_name, RAIIAtenTensorHandle(tensor));
+        target.map->insert_or_assign(
+            constant_name, RAIIAtenTensorHandle(tensor));
+      }
+    } catch (...) {
+      for (auto& kv : constants_map) {
+        if (kv.second != nullptr) {
+          (void)aoti_torch_delete_tensor_object(kv.second);
+          kv.second = nullptr;
+        }
+      }
+      throw;
     }
     target.update_array(models_[0].get());
   }


### PR DESCRIPTION
Summary:

Constant folding produces a map of owning raw `AtenTensorHandle`s. Two spots drop them without freeing when a later step throws, leaking folded-constant GPU memory; because the container catches the error and keeps serving, these leaks accumulate per failure.

- `AOTInductorModelBase::run_const_fold` (`model_base.h`): after `const_run_impl` builds the map, `cudaEventRecord` / the XPU barrier / `wait_for_completion` can throw and orphan the map's handles.
- `AOTInductorModelContainer::update_constant_buffer` (`model_container.h`): the loop transfers each folded constant into `target.map`; a throw mid-loop (node allocation, string construction) leaks the not-yet-transferred handles.

Fix: try/catch that frees the still-owned handles on the error path. These headers compile into `model.so`, which may only use the stable C ABI, so the cleanup uses `aoti_torch_delete_tensor_object` directly (not a c10 scope-guard). The transfer nulls each source slot the instant it hands ownership to `target.map`, so the cleanup frees only not-yet-transferred handles and never double-frees.

Test Plan:
Compile-verified via an AOTI `model.so` build. The CUDA-error and allocation-failure throw paths are not deterministically reproducible without fault injection, so no dedicated hermetic test is added.

Authored with assistance from Claude Code (AI pair programmer).

Reviewed By: kqfu

Differential Revision: D111300709




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo