### PR TITLE
[XPU] Re-enable test_saved_lowp_checkpoint_truncates_subsequent_uses

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -1650,9 +1650,8 @@ class CudaReproTests(TestCase):
 
         self.assertEqual(ref, res)
 
-    @skipIfXpu(msg="https://github.com/pytorch/pytorch/issues/180948")
     @parametrize("lowp_dtype", [torch.bfloat16, torch.float16])
-    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @unittest.skipIf(not (TEST_CUDA or TEST_XPU), "requires CUDA or XPU")
     @config.patch(
         emulate_precision_casts=False,
         emulate_precision_casts_on_saved_tensors=True,


### PR DESCRIPTION
Fixes #180948

## Problem

`test_saved_lowp_checkpoint_truncates_subsequent_uses` was skipped on XPU with `@skipIfXpu(msg="...#180948")`. The test validates that activation checkpointing with `emulate_precision_casts_on_saved_tensors=True` correctly inserts lowp cast operations in compiled Triton code.

## Fix

Remove `@skipIfXpu` and relax the skip condition to allow XPU:

```diff
-    @skipIfXpu(msg="https://github.com/pytorch/pytorch/issues/180948")
     @parametrize("lowp_dtype", [torch.bfloat16, torch.float16])
-    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @unittest.skipIf(not (TEST_CUDA or TEST_XPU), "requires CUDA or XPU")
```

## Verification

Tested on PVC (Intel Data Center GPU Max 1550):

```
Environment:
  Hardware: Intel Data Center GPU Max 1550 (PVC) x8
  PyTorch: 2.14.0.dev20260707+xpu
  oneAPI: 2026.0.0 (fresh environment)

Results:
  torch.bfloat16: ✅ assert_close PASS, code contains .to(tl.bfloat16) PASS
  torch.float16:  ✅ assert_close PASS, code contains .to(tl.float16)  PASS
```

### Test Plan
```bash
python test/inductor/test_cuda_repro.py CudaReproTests.test_saved_lowp_checkpoint_truncates_subsequent_uses_bfloat16 -v
python test/inductor/test_cuda_repro.py CudaReproTests.test_saved_lowp_checkpoint_truncates_subsequent_uses_float16 -v
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mruberry