### PR TITLE
Update test_utils.py

### DIFF
--- a/test/distributions/test_utils.py
+++ b/test/distributions/test_utils.py
@@ -1,31 +1,37 @@
-# Owner(s): ["module: distributions"]
-
-import pytest
+import unittest
 
 import torch
 from torch.distributions.utils import tril_matrix_to_vec, vec_to_tril_matrix
-from torch.testing._internal.common_utils import run_tests
-
-
-@pytest.mark.parametrize(
-    "shape",
-    [
-        (2, 2),
-        (3, 3),
-        (2, 4, 4),
-        (2, 2, 4, 4),
-    ],
+from torch.testing._internal.common_utils import TestCase, run_tests
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    parametrize,
 )
-def test_tril_matrix_to_vec(shape):
-    mat = torch.randn(shape)
-    n = mat.shape[-1]
-    for diag in range(-n, n):
-        actual = mat.tril(diag)
-        vec = tril_matrix_to_vec(actual, diag)
-        tril_mat = vec_to_tril_matrix(vec, diag)
-        if not torch.allclose(tril_mat, actual):
-            raise AssertionError("Expected tril_mat and actual to be close")
 
+
+class TestUtils(TestCase):
+
+    @parametrize(
+        "shape",
+        [
+            (2, 2),
+            (3, 3),
+            (2, 4, 4),
+            (2, 2, 4, 4),
+        ],
+    )
+    def test_tril_matrix_to_vec(self, device, shape):
+        mat = torch.randn(shape, device=device)
+        n = mat.shape[-1]
+        for diag in range(-n, n):
+            actual = mat.tril(diag)
+            vec = tril_matrix_to_vec(actual, diag)
+            tril_mat = vec_to_tril_matrix(vec, diag)
+            if not torch.allclose(tril_mat, actual):
+                raise AssertionError("Expected tril_mat and actual to be close")
+
+
+instantiate_device_type_tests(TestUtils, globals())
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributions/test_utils.py
+++ b/test/distributions/test_utils.py
@@ -2,15 +2,14 @@
 
 import torch
 from torch.distributions.utils import tril_matrix_to_vec, vec_to_tril_matrix
-from torch.testing._internal.common_utils import TestCase, run_tests
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     parametrize,
 )
+from torch.testing._internal.common_utils import run_tests, TestCase
 
 
 class TestUtils(TestCase):
-
     @parametrize(
         "shape",
         [
@@ -34,3 +33,4 @@ instantiate_device_type_tests(TestUtils, globals())
 
 if __name__ == "__main__":
     run_tests()
+    

--- a/test/distributions/test_utils.py
+++ b/test/distributions/test_utils.py
@@ -1,4 +1,4 @@
-import unittest
+# Owner(s): ["module: distributions"]
 
 import torch
 from torch.distributions.utils import tril_matrix_to_vec, vec_to_tril_matrix

--- a/test/distributions/test_utils.py
+++ b/test/distributions/test_utils.py
@@ -2,11 +2,8 @@
 
 import torch
 from torch.distributions.utils import tril_matrix_to_vec, vec_to_tril_matrix
-from torch.testing._internal.common_device_type import (
-    instantiate_device_type_tests,
-    parametrize,
-)
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import parametrize, run_tests, TestCase
 
 
 class TestUtils(TestCase):
@@ -30,6 +27,7 @@ class TestUtils(TestCase):
 
 
 instantiate_device_type_tests(TestUtils, globals())
+
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributions/test_utils.py
+++ b/test/distributions/test_utils.py
@@ -27,8 +27,7 @@ class TestUtils(TestCase):
             actual = mat.tril(diag)
             vec = tril_matrix_to_vec(actual, diag)
             tril_mat = vec_to_tril_matrix(vec, diag)
-            if not torch.allclose(tril_mat, actual):
-                raise AssertionError("Expected tril_mat and actual to be close")
+            self.assertEqual(tril_mat, actual, msg=f"diag={diag}, shape={shape}")
 
 
 instantiate_device_type_tests(TestUtils, globals())


### PR DESCRIPTION
Refactor `test/distributions/test_utils.py` from pytest-style tests to PyTorch's `TestCase` + `instantiate_device_type_tests` style.

This change makes `test_tril_matrix_to_vec` device-parametrized so it can run through PyTorch's standard device test framework. Tensor creation now uses the provided `device` argument, allowing supported device/custom backends, including NPU via PrivateUse1 when configured, to reuse the same test.

Changes:
- Replace `pytest.mark.parametrize` with `torch.testing._internal.common_device_type.parametrize`.
- Wrap the test in a `TestCase` subclass.
- Register device-specific test variants with `instantiate_device_type_tests`.
- Add `device=device` to tensor creation.
- Use `self.assertEqual` for tensor comparison with `diag` and `shape` context.
- Keep the distributions owner tag.