### PR TITLE
[inductor] BatchLinearLHSFusion: skip tensor subclass weights only when aten.cat fails

### DIFF
--- a/test/inductor/test_group_batch_fusion.py
+++ b/test/inductor/test_group_batch_fusion.py
@@ -878,6 +878,51 @@ class TestGroupBatchFusion(TestCase):
         self.compare_gradients(module, traced, rtol=1e-8, atol=1e-8)
         counters.clear()
 
+    def test_batch_linear_lhs_skips_tensor_subclass_weights(self):
+        """batch_linear_lhs match() must return None when weight is a tensor subclass.
+
+        Regression test for incompatibility with torchao W8A8 quantization:
+        fuse() calls torch.cat on the weight example_values, which raises
+        NotImplementedError for subclasses that don't implement aten.cat
+        (e.g. torchao Int8Tensor). The fix guards match() to skip subclasses.
+        See: https://github.com/pytorch/ao/pull/4560
+        """
+        from torch._inductor.fx_passes.group_batch_fusion import BatchLinearLHSFusion
+
+        class _SubclassWeight(torch.Tensor):
+            """Minimal subclass that raises on aten.cat to detect the bug."""
+
+            @classmethod
+            def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
+                if func == torch.ops.aten.cat.default:
+                    raise AssertionError(
+                        "aten.cat called on _SubclassWeight — "
+                        "batch_linear_lhs should have been skipped"
+                    )
+                return func(*args, **(kwargs or {}))
+
+        fusion = BatchLinearLHSFusion()
+        z = 4
+
+        # Build a minimal FX graph: F.linear(x, w) with a subclass weight.
+        graph = torch.fx.Graph()
+        x_node = graph.placeholder("x")
+        w_node = graph.placeholder("w")
+        x_node.meta["example_value"] = torch.randn(2, z)
+        w_node.meta["example_value"] = torch.randn(z, z).as_subclass(_SubclassWeight)
+        linear_node = graph.call_function(
+            torch.nn.functional.linear, args=(x_node, w_node)
+        )
+        linear_node.meta["example_value"] = torch.randn(2, z)
+        graph.output(linear_node)
+
+        # match() must return None (skip) for a subclass weight.
+        result = fusion.match(linear_node)
+        self.assertIsNone(
+            result,
+            "batch_linear_lhs should skip (return None) when weight is a tensor subclass",
+        )
+
 
 class _TestBMMFusionModule(torch.nn.Module):
     def __init__(self) -> None:

--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -10,6 +10,7 @@ import torch
 from torch._dynamo.utils import counters, is_node_meta_valid
 from torch._logging import trace_structured
 from torch.fx.experimental.symbolic_shapes import free_symbols
+from torch._subclasses.fake_tensor import FakeTensor
 from torch.fx.passes.graph_transform_observer import GraphTransformObserver
 from torch.utils._ordered_set import OrderedSet
 
@@ -503,27 +504,22 @@ class BatchLinearLHSFusion(BatchFusion):
             input = get_arg_value(node, 0, "input")
             weight = get_arg_value(node, 1, "weight")
             bias = get_arg_value(node, 2, "bias")
-
-            # Skip fusion when the weight is a tensor subclass (e.g. a quantized
-            # Int8Tensor). fuse() calls torch.cat on the weight example_values,
-            # which fails for subclasses that don't implement aten.cat.
-            # Plain torch.Tensor and FakeTensor (used during tracing) are fine.
-            weight_val = weight.meta.get("example_value")
-            if weight_val is None:
-                weight_val = weight.meta.get("val")
-            if (
-                weight_val is not None
-                and isinstance(weight_val, torch.Tensor)
-                and not isinstance(weight_val, torch._subclasses.fake_tensor.FakeTensor)
-                and type(weight_val) is not torch.Tensor
+            # Skip fusion when weight is a tensor subclass that can't handle aten.cat.
+            # fuse() calls torch.cat on the weight example_values, which fails for
+            # subclasses lacking aten.cat dispatch.  Probe it here so subclasses that
+            # do implement aten.cat (e.g. future torchao versions) still get fused.
+            weight_val = weight.meta.get("example_value", weight.meta.get("val"))
+            if weight_val is not None and type(weight_val) not in (
+                torch.Tensor,
+                FakeTensor,
             ):
-                return None
-
+                try:
+                    _ = torch.cat([weight_val[:1], weight_val[:1]], dim=0)
+                except (RuntimeError, TypeError):
+                    return None
             bias_tensor = None
             if bias is not None:
-                bias_tensor = bias.meta.get("val")
-                if bias_tensor is None:
-                    bias_tensor = bias.meta.get("example_value")
+                bias_tensor = bias.meta.get("val", bias.meta.get("example_value"))
             bias_dim = None if bias_tensor is None else bias_tensor.ndim  # type: ignore[union-attr]
             group_key = ("batch_linear_lhs", bias_dim, input)
         else:

--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -9,8 +9,8 @@ from typing import Any
 import torch
 from torch._dynamo.utils import counters, is_node_meta_valid
 from torch._logging import trace_structured
-from torch.fx.experimental.symbolic_shapes import free_symbols
 from torch._subclasses.fake_tensor import FakeTensor
+from torch.fx.experimental.symbolic_shapes import free_symbols
 from torch.fx.passes.graph_transform_observer import GraphTransformObserver
 from torch.utils._ordered_set import OrderedSet
 

--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -501,7 +501,24 @@ class BatchLinearLHSFusion(BatchFusion):
             node
         ) and is_linear_node_can_be_fused(node):
             input = get_arg_value(node, 0, "input")
+            weight = get_arg_value(node, 1, "weight")
             bias = get_arg_value(node, 2, "bias")
+
+            # Skip fusion when the weight is a tensor subclass (e.g. a quantized
+            # Int8Tensor). fuse() calls torch.cat on the weight example_values,
+            # which fails for subclasses that don't implement aten.cat.
+            # Plain torch.Tensor and FakeTensor (used during tracing) are fine.
+            weight_val = weight.meta.get("example_value")
+            if weight_val is None:
+                weight_val = weight.meta.get("val")
+            if (
+                weight_val is not None
+                and isinstance(weight_val, torch.Tensor)
+                and not isinstance(weight_val, torch._subclasses.fake_tensor.FakeTensor)
+                and type(weight_val) is not torch.Tensor
+            ):
+                return None
+
             bias_tensor = None
             if bias is not None:
                 bias_tensor = bias.meta.get("val")


### PR DESCRIPTION
## Summary

After PR #181854 auto-enabled `batch_linear_lhs` for XPU inference, models using torchao W8A8 quantization crash during `torch.compile` with:

```
NotImplementedError: Int8Tensor dispatch: func=<OpOverload(op=aten.cat, overload=default)>
```

The root cause is `BatchLinearLHSFusion.fuse()` calling `torch.cat(batch_weights_meta)` on weight tensors that are `Int8Tensor` subclasses lacking `aten.cat` dispatch.

## Fix

Replaces the blanket subclass skip with a **capability probe** in `BatchLinearLHSFusion.match()`. Instead of returning `None` for all tensor subclasses, it tries `torch.cat` and only skips fusion if the call actually fails:

```python
try:
    _ = torch.cat([weight_val[:1], weight_val[:1]], dim=0)
except (RuntimeError, TypeError):
    return None
```

- **Without pytorch/ao#4560** (released torchao 0.17.0): probe catches `NotImplementedError` on cat → fusion skipped → no crash
- **With pytorch/ao#4560 + aten.permute.default**: probe passes → fusion fires → quantized perf win (2.4%/6.6%) preserved
- **Plain torch.Tensor / FakeTensor**: type check bypasses the probe entirely → zero overhead

Also applies etafs review suggestion: simplified `bias.meta.get("val", bias.meta.get("example_value"))`.

## Test

Added `test_batch_linear_lhs_skips_tensor_subclass_weights` to `test/inductor/test_group_batch_fusion.py`.

## Validation

Reproduced on XPU nightly (2.14.0.dev20260713+xpu) with torchao 0.17.0 and pytorch/ao#4560 + permute fix. See [comment](https://github.com/pytorch/pytorch/pull/189509#issuecomment-4965079721) for full results.

## References

- Regression-introducing PR: #181854 (auto-enable batch_linear_lhs for XPU)
- torchao issue: pytorch/ao#4560 (add cat/transpose/mm/addmm to Int8Tensor)
- Reproduction branch: https://github.com/xuhancn/dev_llama_up_gate_fusion_op/tree/reproduce_torchao_int8_fusion

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo