### PR TITLE
[MPS] Blit CPU<->MPS copies directly from pinned buffers with event-deferred reclaim

### DIFF
--- a/aten/src/ATen/mps/MPSAllocator.h
+++ b/aten/src/ATen/mps/MPSAllocator.h
@@ -426,6 +426,9 @@ class MPSHeapAllocatorImpl {
   void release_buffers(BufferPool& pool);
   bool release_available_cached_buffers(AllocParams& params);
   bool release_cached_buffers();
+  // waits for buffers parked in-flight in the pool's pending-free list to finish
+  // on the GPU and returns them to the pool; returns true if any were reclaimed
+  bool wait_for_pending_free_buffers(BufferPool& pool);
   // free unused cached blocks to reclaim GPU memory if memory pressure is high
   void garbage_collect_cached_buffers(AllocParams& params);
   // returns the suitable buffer pool type for the usage or

--- a/aten/src/ATen/mps/MPSAllocator.mm
+++ b/aten/src/ATen/mps/MPSAllocator.mm
@@ -9,6 +9,7 @@
 #include <c10/util/env.h>
 
 #include <atomic>
+#include <unordered_map>
 
 namespace at::mps {
 
@@ -298,7 +299,11 @@ BufferBlock* MPSHeapAllocatorImpl::alloc_buffer_block(size_t size, uint32_t usag
         // Free enough available cached blocks to satisfy alloc and retry alloc.
         (release_available_cached_buffers(params) && alloc_buffer(params)) ||
         // Free all cached buffers and retry alloc.
-        (release_cached_buffers() && alloc_buffer(params));
+        (release_cached_buffers() && alloc_buffer(params)) ||
+        // Last resort: wait for buffers parked in-flight (freed but still used by
+        // the GPU) to complete, reclaim them, and retry -- avoids a spurious
+        // watermark OOM when those buffers are about to drain anyway.
+        (wait_for_pending_free_buffers(pool) && (get_free_buffer(params) || alloc_buffer(params)));
   }
 
   BufferBlock* buffer_block = params.buffer_block;
@@ -550,6 +555,9 @@ void MPSHeapAllocatorImpl::garbage_collect_cached_buffers(AllocParams& params) {
 id<MTLBuffer> MPSHeapAllocatorImpl::malloc(size_t size, uint32_t usage) {
   std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
+  // Return any buffers parked in-flight by free() whose GPU work has since
+  // completed back to their pools before serving this allocation.
+  freeInactiveBuffers();
   BufferBlock* buffer_block = alloc_buffer_block(size, usage);
   return buffer_block ? buffer_block->buffer : nullptr;
 }
@@ -685,6 +693,20 @@ bool MPSHeapAllocatorImpl::waitForEvents(c10::ArrayRef<const void*> buffers) {
   return waitedForEvent;
 }
 
+bool MPSHeapAllocatorImpl::wait_for_pending_free_buffers(BufferPool& pool) {
+  std::vector<const void*> buffers;
+  {
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
+    buffers.reserve(pool.buffers_pending_free.size());
+    for (BufferBlock* buffer_block : pool.buffers_pending_free) {
+      buffers.push_back(buffer_block->buffer);
+    }
+  }
+  // waitForEvents CPU-waits on the in-flight buffers and calls freeInactiveBuffers,
+  // returning the completed ones to the pool for the caller to retry allocation.
+  return !buffers.empty() && waitForEvents(buffers);
+}
+
 id_t MPSHeapAllocatorImpl::getBufferId(const void* ptr) {
   std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
@@ -731,9 +753,20 @@ void MPSHeapAllocatorImpl::free(void* ptr) {
 
     buffer_block = get_allocated_buffer_block(ptr);
     TORCH_INTERNAL_ASSERT(buffer_block);
-    const BufferPool& pool = *buffer_block->heap->pool;
+    BufferPool& pool = *buffer_block->heap->pool;
     if (!(pool.usage & UsageFlags::SCALAR)) {
-      free_buffer(buffer_block);
+      // A buffer marked by recordEvents (used by the GPU in a context where a
+      // subsequent CPU reuse could race it, e.g. a pinned-memory copy) and still
+      // referenced by an in-flight command buffer must not be recycled yet:
+      // handing it to a new allocation could let the CPU overwrite it before the
+      // GPU is done. Park it in limbo; freeInactiveBuffers() reclaims it once its
+      // command buffer completes. Unmarked buffers are only GPU-accessed, so
+      // serial-stream ordering already makes immediate reuse safe.
+      if (buffer_block->event && buffer_block->retainCount() > 1) {
+        pool.buffers_pending_free.insert(buffer_block);
+      } else {
+        free_buffer(buffer_block);
+      }
       return;
     }
   }
@@ -971,7 +1004,10 @@ class MPSPinnedAllocator final : public c10::Allocator {
     }
     auto& shared = _getSharedAllocator();
     c10::DataPtr mps_dp = shared.allocate(nbytes);
-    auto host_ptr_pair = shared.getSharedBufferPtr(mps_dp.get());
+    // shared.allocate() returns a DataPtr whose data pointer is the id<MTLBuffer>
+    // itself; capture it before mps_dp is moved into the backing storage.
+    void* mtl_buffer = mps_dp.get();
+    auto host_ptr_pair = shared.getSharedBufferPtr(mtl_buffer);
     TORCH_INTERNAL_ASSERT(host_ptr_pair.first, "MPS pinned allocator: failed to map shared buffer");
     void* cpu_ptr = const_cast<void*>(host_ptr_pair.first);
     // Hold a refcount on the source MPS storage so the MTLBuffer stays alive
@@ -984,7 +1020,7 @@ class MPSPinnedAllocator final : public c10::Allocator {
     auto* ctx = new PinnedCtx{std::move(mps_storage), cpu_ptr};
     {
       std::lock_guard<std::mutex> lk(s_mutex);
-      s_pinned_ptrs.insert(cpu_ptr);
+      s_pinned_buffers.emplace(cpu_ptr, mtl_buffer);
     }
     return {cpu_ptr, ctx, &deleter, c10::Device(c10::DeviceType::CPU)};
   }
@@ -995,11 +1031,17 @@ class MPSPinnedAllocator final : public c10::Allocator {
     default_copy_data(dest, src, count);
   }
   static bool isPinned(const void* ptr) {
+    return getMTLBuffer(ptr) != nullptr;
+  }
+  // Returns the shared MTLBuffer backing a pinned host allocation (the base of
+  // the storage, keyed by the host-visible pointer), or nullptr if not pinned.
+  static void* getMTLBuffer(const void* ptr) {
     if (!ptr) {
-      return false;
+      return nullptr;
     }
     std::lock_guard<std::mutex> lk(s_mutex);
-    return s_pinned_ptrs.find(ptr) != s_pinned_ptrs.end();
+    auto it = s_pinned_buffers.find(ptr);
+    return it == s_pinned_buffers.end() ? nullptr : it->second;
   }
 
  private:
@@ -1014,15 +1056,15 @@ class MPSPinnedAllocator final : public c10::Allocator {
     auto* pinned = static_cast<PinnedCtx*>(ctx);
     {
       std::lock_guard<std::mutex> lk(s_mutex);
-      s_pinned_ptrs.erase(pinned->cpu_ptr);
+      s_pinned_buffers.erase(pinned->cpu_ptr);
     }
     delete pinned;
   }
   static std::mutex s_mutex;
-  static std::unordered_set<const void*> s_pinned_ptrs;
+  static std::unordered_map<const void*, void*> s_pinned_buffers;
 };
 std::mutex MPSPinnedAllocator::s_mutex;
-std::unordered_set<const void*> MPSPinnedAllocator::s_pinned_ptrs;
+std::unordered_map<const void*, void*> MPSPinnedAllocator::s_pinned_buffers;
 
 MPSPinnedAllocator& _getPinnedAllocator() {
   static MPSPinnedAllocator s_mps_pinned_alloc;
@@ -1041,6 +1083,10 @@ c10::Allocator* getMPSPinnedAllocator() {
   // MPS requires unified memory (enforced in MPSHeapAllocatorImpl::init_allocator),
   // so shared (unified-memory) buffers backing the pinned alias are always usable.
   return &_getPinnedAllocator();
+}
+
+void* getMPSPinnedMTLBuffer(const void* host_ptr) {
+  return MPSPinnedAllocator::getMTLBuffer(host_ptr);
 }
 
 // torch.is_pinned() implementation

--- a/aten/src/ATen/mps/MPSAllocatorInterface.h
+++ b/aten/src/ATen/mps/MPSAllocatorInterface.h
@@ -79,4 +79,10 @@ c10::Allocator* getMPSPinnedAllocator();
 
 bool isMPSPinnedPtr(const void* data);
 
+// If host_ptr is the base of an MPS-pinned CPU allocation, returns the shared
+// MTLBuffer backing it (as an opaque pointer, bit-castable to id<MTLBuffer>),
+// so CPU<->MPS copies can blit from/to it directly instead of wrapping the host
+// pages with newBufferWithBytesNoCopy. Returns nullptr otherwise.
+void* getMPSPinnedMTLBuffer(const void* host_ptr);
+
 } // namespace at::mps

--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -1,6 +1,7 @@
 //  Copyright © 2022 Apple Inc.
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/TensorIterator.h>
+#include <ATen/mps/MPSAllocatorInterface.h>
 #include <ATen/mps/MPSProfiler.h>
 #include <ATen/native/mps/Copy.h>
 #include <ATen/native/mps/OperationUtils.h>
@@ -74,14 +75,24 @@ static void* pageAlignedBlockPtr(const void* ptr, NSUInteger size, NSUInteger* a
   return (void*)alignedAddress;
 }
 
-// Returns an autoreleased MTLBuffer and byte offset for the host side of a
-// CPU<->MPS copy; it stays valid for the caller's enclosing @autoreleasepool. The
-// host pages are wrapped with newBufferWithBytesNoCopy, retaining the storage
-// across an async copy so the pages outlive the in-flight blit.
+// Returns an MTLBuffer and byte offset for the host side of a CPU<->MPS copy that
+// the caller must not release: a pinned tensor's own shared MTLBuffer is returned
+// borrowed (kept alive by the tensor), otherwise the host pages are wrapped in an
+// autoreleased newBufferWithBytesNoCopy (valid for the caller's @autoreleasepool),
+// retaining the storage across an async copy so the pages outlive the in-flight blit.
 static std::pair<id<MTLBuffer>, NSUInteger> buffer_with_offset_from_tensor(const at::Tensor& cpu_tensor,
                                                                            size_t nbytes,
                                                                            bool non_blocking) {
   const auto byte_offset = cpu_tensor.storage_offset() * cpu_tensor.itemsize();
+  // Blit directly from/to the pinned tensor's own shared MTLBuffer, avoiding the
+  // newBufferWithBytesNoCopy wrapper. Metal blit offsets must be 4-byte aligned.
+  if (void* pinned = at::mps::getMPSPinnedMTLBuffer(cpu_tensor.storage().data()); pinned && byte_offset % 4 == 0) {
+    // Mark the buffer so that if it is freed while this copy's blit is still in
+    // flight, the allocator defers recycling it instead of handing it to a new
+    // allocation that could CPU-overwrite it before the GPU is done.
+    at::mps::getIMPSAllocator()->recordEvents({pinned});
+    return {__builtin_bit_cast(id<MTLBuffer>, pinned), static_cast<NSUInteger>(byte_offset)};
+  }
   id<MTLDevice> device = MPSDevice::getInstance()->device();
   const void* host = static_cast<const char*>(cpu_tensor.storage().data()) + byte_offset;
   NSUInteger alignedLength = 0;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #189512

Builds on the pinned CPU-aliased storage. When the host side of a CPU<->MPS copy
is a pinned tensor, its storage already owns a shared (unified-memory) MTLBuffer,
so buffer_with_offset_from_tensor returns that buffer directly (borrowed, kept
alive by the tensor) instead of wrapping the host pages in a fresh
newBufferWithBytesNoCopy. getMPSPinnedMTLBuffer recovers the backing MTLBuffer
from the host pointer via a small map in the pinned allocator.

Freeing a pinned buffer while its blit is still in flight would otherwise let the
allocator recycle it and a later pinned allocation CPU-overwrite it before the GPU
reads it. To make this safe the copy marks the buffer via recordEvents; free()
parks such in-flight buffers in buffers_pending_free instead of recycling them,
and malloc()/allocation pressure reclaim them once their command buffer completes
(freeInactiveBuffers / waitForEvents). This wires up the previously-dormant
MPSAllocator event machinery, scoped to CPU-written shared buffers so GPU-only
buffer reuse (already safe under serial-stream ordering) is unaffected.

Test Plan: pinned CPU<->MPS round-trips and an async free-then-reuse stress test
(free a pinned source mid-copy, then immediately reallocate pinned buffers) match
eager with zero corruption; GPU-only reuse shows no extra memory growth.

Authored with assistance from Claude Code.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>