### PR TITLE
[native] Pin nvmath-python version

### DIFF
--- a/.ci/pytorch/common_utils.sh
+++ b/.ci/pytorch/common_utils.sh
@@ -349,7 +349,7 @@ function install_cutlass_dsl() {
 
 function install_nvmath() {
   echo "Installing nvmath-python from PyPI..."
-  pip_install nvmath-python
+  pip_install nvmath-python==0.9.0
   # nvmath-python upgrades numpy to 2.x; realign scipy to a matching build. See #189034.
   pip_install "scipy==1.13.1"
   echo "nvmath-python installation complete."

--- a/.ci/pytorch/common_utils.sh
+++ b/.ci/pytorch/common_utils.sh
@@ -389,7 +389,7 @@ function install_flydsl() {
 
 function install_nvmath() {
   echo "Installing nvmath-python from PyPI..."
-  pip_install nvmath-python
+  pip_install nvmath-python==0.9.0
   # nvmath-python upgrades numpy to 2.x; realign scipy to a matching build. See #189034.
   pip_install "scipy==1.13.1"
   echo "nvmath-python installation complete."


### PR DESCRIPTION
Pin nvmath-python to 0.9.0 (min. version needed for the `polarx` methods)