### PR TITLE
[XPU][AOTInductor] Fix SIGSEGV in run_const_fold when stream is nullptr

### DIFF
--- a/torch/csrc/inductor/aoti_runtime/model_base.h
+++ b/torch/csrc/inductor/aoti_runtime/model_base.h
@@ -918,6 +918,9 @@ class AOTInductorModelBase {
       delete *run_finished_;
       run_finished_.reset();
     }
+    if (stream == nullptr) {
+      aoti_torch_get_current_xpu_stream(this->device_idx_, (void**)&stream);
+    }
 #else // !USE_CUDA && !USE_XPU
     run_finished_ = false;
 #endif
@@ -938,8 +941,6 @@ class AOTInductorModelBase {
 #ifdef USE_CUDA
       AOTI_RUNTIME_CUDA_CHECK(cudaEventRecord(*run_finished_, stream));
 #elif defined(USE_XPU)
-      // sycl::queue* queue_ptr = nullptr;
-      // aoti_torch_get_current_sycl_queue((void**)&queue_ptr);
       run_finished_ = std::make_optional<sycl::event*>(new sycl::event(
           static_cast<sycl::queue*>(stream)->ext_oneapi_submit_barrier()));
 


### PR DESCRIPTION
When AOTInductorModelContainerRunnerXpu is constructed with external weights (caller-supplied), the external-constants constructor in model_container.h calls run_const_fold(false, nullptr, nullptr) with a null stream.

The XPU path in run_const_fold() (model_base.h) was missing the null stream guard that already exists in run(). It directly dereferenced the stream pointer:

  static_cast<sycl::queue*>(stream)->ext_oneapi_submit_barrier()

When stream == nullptr, this is a null pointer dereference → SIGSEGV.

The same file already handles this correctly in run():
  if (stream == nullptr) {
    aoti_torch_get_current_xpu_stream(this->device_idx_, (void**)&stream);
  }

Apply the same guard in run_const_fold() for the XPU path. Also remove stale commented-out code.

Fixes pytorch/pytorch#189510
Fixes pytorch/pytorch#189511
Fixes pytorch/pytorch#189514
Fixes pytorch/pytorch#189515