### PR TITLE
[Dynamo] Use getattr_static when probing internal attributes

### DIFF
--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -3123,6 +3123,43 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
         self.assertFalse(hasattr(model, "foo"))
         self.assertFalse(hasattr(compiled_model, "foo"))
 
+    def test_custom_getattr_hasattr_no_recursion(self):
+        class Mod(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(4, 4)
+
+            def __getattr__(self, name):
+                try:
+                    return super().__getattr__(name)
+                except AttributeError:
+                    if (
+                        hasattr(self, "custom_attributes")
+                        and name in self.custom_attributes
+                    ):
+                        return self.custom_attributes[name]
+                    raise
+
+            def forward(self, x):
+                return self.linear(x).relu()
+
+        mod = Mod()
+        x = torch.randn(2, 4)
+        compiled_mod = torch.compile(mod, backend="eager", fullgraph=True)
+        self.assertEqual(mod(x), compiled_mod(x))
+
+        class ModWithAttrs(Mod):
+            def __init__(self):
+                super().__init__()
+                self.custom_attributes = {"scale": 2.0}
+
+            def forward(self, x):
+                return self.linear(x) * self.scale
+
+        mod2 = ModWithAttrs()
+        compiled_mod2 = torch.compile(mod2, backend="eager", fullgraph=True)
+        self.assertEqual(mod2(x), compiled_mod2(x))
+
     def test_globals_change_in_other_file(self):
         global _variable, _variable1
 

--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -3160,6 +3160,40 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
         compiled_mod2 = torch.compile(mod2, backend="eager", fullgraph=True)
         self.assertEqual(mod2(x), compiled_mod2(x))
 
+    def test_lazy_module_custom_getattr_no_recursion(self):
+        class LazyMod(torch.nn.modules.lazy.LazyModuleMixin, torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = torch.nn.UninitializedParameter()
+
+            def initialize_parameters(self, x):
+                with torch.no_grad():
+                    self.weight.materialize((x.shape[-1],))
+                    self.weight.fill_(2.0)
+
+            def forward(self, x):
+                return x * self.weight
+
+        class LazyModWithGetattr(LazyMod):
+            def __getattr__(self, name):
+                try:
+                    return super().__getattr__(name)
+                except AttributeError:
+                    if (
+                        hasattr(self, "custom_attributes")
+                        and name in self.custom_attributes
+                    ):
+                        return self.custom_attributes[name]
+                    raise
+
+        mod = LazyMod()
+        mod.__class__ = LazyModWithGetattr
+        x = torch.randn(2, 4)
+        compiled_mod = torch.compile(mod, backend="eager")
+        compiled_mod(x)
+        res = compiled_mod(x)
+        self.assertEqual(x * 2.0, res)
+
     def test_globals_change_in_other_file(self):
         global _variable, _variable1
 

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -642,8 +642,9 @@ class OptimizedModule(torch.nn.Module):
 
     def _call_lazy_check(self, *args: Any, **kwargs: Any) -> Any:
         if (
-            hasattr(self._orig_mod, "_initialize_hook")
-            and hasattr(self._orig_mod, "_infer_parameters")
+            inspect.getattr_static(self._orig_mod, "_initialize_hook", None) is not None
+            and inspect.getattr_static(self._orig_mod, "_infer_parameters", None)
+            is not None
             and callable(self._orig_mod._infer_parameters)
         ):
             # In the case of a lazy module, we want to run

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -515,7 +515,7 @@ class OptimizedModule(torch.nn.Module):
             # Invoke hooks outside of dynamo then pickup the inner frame
             self.forward = self.dynamo_ctx(self._orig_mod.__call__)
 
-        if hasattr(self._orig_mod, "_initialize_hook"):
+        if inspect.getattr_static(self._orig_mod, "_initialize_hook", None) is not None:
             self._forward = self.forward
             self.forward = self._call_lazy_check
 
@@ -691,9 +691,12 @@ def innermost_fn(fn: Callable[..., Any]) -> Callable[..., Any]:
     function. TorchDynamo caches on fn.__code__ object, so its necessary to find
     the innermost function to pass on the optimize, run, disable etc.
     """
+    # getattr_static so probing for these internal attributes never runs a
+    # user-defined __getattr__, which may not tolerate unknown names.
     unaltered_fn = fn
     while (
-        hasattr(unaltered_fn, "_torchdynamo_orig_callable")
+        inspect.getattr_static(unaltered_fn, "_torchdynamo_orig_callable", None)
+        is not None
         # Only follow the chain if _torchdynamo_wrapper_id matches id(fn).
         # This prevents following chains in two cases:
         # 1. Bound methods: id(bound_method) != id(wrapper_function), so we
@@ -701,8 +704,10 @@ def innermost_fn(fn: Callable[..., Any]) -> Callable[..., Any]:
         # 2. functools.wraps copies: When functools.wraps copies
         #    _torchdynamo_orig_callable from a wrapped function, the copied
         #    _torchdynamo_wrapper_id won't match the outer wrapper's id.
-        and getattr(unaltered_fn, "_torchdynamo_wrapper_id", None) == id(unaltered_fn)
+        and inspect.getattr_static(unaltered_fn, "_torchdynamo_wrapper_id", None)
+        == id(unaltered_fn)
     ):
+        # pyrefly: ignore [missing-attribute]
         unaltered_fn = unaltered_fn._torchdynamo_orig_callable
         if not callable(unaltered_fn):
             raise AssertionError(
@@ -1019,7 +1024,8 @@ class _TorchDynamoContext:
 
             # when compiling torch.nn.Module,
             # provide public api OptimizedModule.get_compiler_config()
-            if hasattr(new_mod, "get_compiler_config"):
+            # check mod, not new_mod: OptimizedModule.__getattr__ delegates to mod
+            if inspect.getattr_static(mod, "get_compiler_config", None) is not None:
                 raise AssertionError(
                     "new_mod already has a get_compiler_config attribute"
                 )

--- a/torch/_dynamo/mutation_guard.py
+++ b/torch/_dynamo/mutation_guard.py
@@ -13,6 +13,7 @@ to runtime changes in module state and structure.
 """
 
 import functools
+import inspect
 import weakref
 from collections.abc import MutableMapping
 from typing import Any
@@ -116,8 +117,10 @@ def is_dynamic_nn_module(obj: Any, is_export: bool) -> bool:
         # A monkey patched `.forward` indicates something wacky is going on
         # Similarly a nn module also subclassed as a dict is unusual.
         return True
-    if hasattr(obj, "torchdynamo_force_dynamic"):
-        return obj.torchdynamo_force_dynamic
+    try:
+        return inspect.getattr_static(obj, "torchdynamo_force_dynamic")
+    except AttributeError:
+        pass
     if isinstance(obj, torch.nn.Module) and (
         not is_export or config.install_free_tensors
     ):

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -4042,7 +4042,10 @@ def _get_fake_value_impl(
     if op == "call_module":
         nnmodule = tx.output.nn_modules[node.target]  # type: ignore[index]
 
-        if is_lazy_module(nnmodule) and hasattr(nnmodule, "_initialize_hook"):
+        if (
+            is_lazy_module(nnmodule)
+            and inspect.getattr_static(nnmodule, "_initialize_hook", None) is not None
+        ):
             # In the case of a lazy module, we want to run
             # the pre-hooks which initialize it.
             # Afterwards, lazy module deletes its pre-hooks

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -2582,13 +2582,13 @@ class VariableBuilder:
                 ],
             )
 
-        if getattr(value, "_is_fsdp_managed_module", False):
+        if inspect.getattr_static(value, "_is_fsdp_managed_module", False):
             # See note [Dynamo treats FSDP wrapped modules as UnspecializedNNModule]
             # in fully_sharded_data_parallel.py for more information
 
             # we can't do this assert inside FSDP constructor,
             # since we don't know yet whether dynamo will be used
-            if not getattr(value, "_fsdp_use_orig_params", False):
+            if not inspect.getattr_static(value, "_fsdp_use_orig_params", False):
                 unimplemented(
                     gb_type="FSDP with use_orig_params=False",
                     context="",

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -2298,7 +2298,9 @@ class SkipFunctionVariable(VariableTracker):
             guard_on_source = source
             guard_on_value = value
 
-            while getattr(guard_on_value, "_torchdynamo_orig_callable", False):
+            while inspect.getattr_static(
+                guard_on_value, "_torchdynamo_orig_callable", False
+            ):
                 guard_on_value = guard_on_value._torchdynamo_orig_callable
                 guard_on_source = AttrSource(
                     guard_on_source, "_torchdynamo_orig_callable"
@@ -2658,9 +2660,11 @@ class WrapperUserFunctionVariable(BaseUserFunctionVariable):
         # (the wrapper's original callable matches the root frame's code).
         is_inner_torch_compile = (
             self.attr_to_trace == "_torchdynamo_inline"
-            and getattr(self.wrapper_obj, "_is_torch_compile", False)
+            and inspect.getattr_static(self.wrapper_obj, "_is_torch_compile", False)
             and getattr(
-                getattr(self.wrapper_obj, "_torchdynamo_orig_callable", None),
+                inspect.getattr_static(
+                    self.wrapper_obj, "_torchdynamo_orig_callable", None
+                ),
                 "__code__",
                 None,
             )

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -97,7 +97,7 @@ def initialize_lazy_module(
     useful now that 'allowed' modules graph-break on hooks, calling this first ensures there is no hook
     by the time we trace __call__ and thus no graph-break for lazy allowed modules.
     """
-    if hasattr(mod, "_initialize_hook"):
+    if inspect.getattr_static(mod, "_initialize_hook", None) is not None:
 
         def convert_to_fake(x: Any) -> Any:
             if is_namedtuple(x):


### PR DESCRIPTION
## Related Issue

Fixes #183890
Fixes #180824

## Why

Dynamo's compile entry path probes user modules with `hasattr`/`getattr` for internal attributes (`_torchdynamo_orig_callable`, `_torchdynamo_wrapper_id`, `_initialize_hook`, `get_compiler_config`, `torchdynamo_force_dynamic`, `_is_fsdp_managed_module`, `_fsdp_use_orig_params`). A user `__getattr__` that re-enters itself on missing names (e.g. via `hasattr`) then recurses unboundedly under `torch.compile` even though eager forward works fine.

## How

- Probe with `inspect.getattr_static` (the established pattern, e.g. in `trace_rules.py`/`utils.py`), which never runs user `__getattr__`; all probed names are only ever set as plain attributes, so static lookup is semantics-preserving

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98
