### PR TITLE
[cond] Register max(size, 1) stride key form in branch output merging

### DIFF
--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -11309,6 +11309,7 @@ class GraphModule(torch.nn.Module):
         compiled = torch.compile(f, backend=backend, dynamic=True, fullgraph=True)
         self.assertEqual(compiled(5, 1000), f(5, 1000))
 
+        # differing sizes still fail on inductor (#189528), hence eager/aot_eager only
         def g(rows: int, cols: int):
             pred = torch.tensor(True)
 

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -11293,6 +11293,36 @@ class GraphModule(torch.nn.Module):
         )(x, y)
         self.assertEqual(compiled_out, out)
 
+    @parametrize("backend", ["eager", "aot_eager"])
+    def test_cond_branch_closure_over_int_args(self, backend):
+        def f(rows: int, cols: int):
+            pred = torch.tensor(True)
+
+            def true_fn():
+                return torch.ones(rows, cols)
+
+            def false_fn():
+                return torch.zeros(rows, cols)
+
+            return torch.cond(pred, true_fn, false_fn)
+
+        compiled = torch.compile(f, backend=backend, dynamic=True, fullgraph=True)
+        self.assertEqual(compiled(5, 1000), f(5, 1000))
+
+        def g(rows: int, cols: int):
+            pred = torch.tensor(True)
+
+            def true_fn():
+                return torch.ones(rows, cols)
+
+            def false_fn():
+                return torch.zeros(rows, cols + 1)
+
+            return torch.cond(pred, true_fn, false_fn)
+
+        compiled = torch.compile(g, backend=backend, dynamic=True, fullgraph=True)
+        self.assertEqual(compiled(5, 7), g(5, 7))
+
 
 class TestAutoFunctionalizeControlFlow(TestCase):
     def check(self, gen_fn, args, device, dynamic) -> torch.fx.GraphModule:

--- a/torch/_higher_order_ops/cond.py
+++ b/torch/_higher_order_ops/cond.py
@@ -680,6 +680,11 @@ def _merge_output(
             nxt_merged_stride_expr = merged_strides[i] * merged_size[i]
             a_stride_expr[_maybe_expr(a_val * a_ex_size[i])] = nxt_merged_stride_expr
             b_stride_expr[_maybe_expr(b_val * b_ex_size[i])] = nxt_merged_stride_expr
+            # fake tensors accumulate contiguous strides as stride * max(size, 1)
+            a_max_key = _maybe_expr(a_val * torch.sym_max(a_ex_size[i], 1))
+            b_max_key = _maybe_expr(b_val * torch.sym_max(b_ex_size[i], 1))
+            a_stride_expr.setdefault(a_max_key, nxt_merged_stride_expr)
+            b_stride_expr.setdefault(b_max_key, nxt_merged_stride_expr)
         return merged_strides
 
     merged_stride: list[int | torch.SymInt] = _bound_stride(


### PR DESCRIPTION
## Related Issue

Fixes #188151

## Why

`_bound_stride` registers expected stride keys as `stride * size`, but fake tensors compute contiguous strides as `stride * max(size, 1)`. Int-input-derived symbols under `dynamic=True` have ranges including 0/1, so the Max does not simplify, the lookup misses, and an internal RuntimeError escapes. Regression from #147130 (2.12+).

## How

- Also register the `max(size, 1)` key form (via `torch.sym_max`, no guards) mapped to the same canonical merged stride expr

cc @chauhang @penguinwu @ezyang @bobrenjc93 @aditvenk @laithsakka @voznesenskym @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @amjames @jataylo @azahed98 @ydwu4 @bdhirsh @aorenste