### PR TITLE
[Inductor] Fix undefined unbacked symbol in cond branch strides

### DIFF
--- a/test/inductor/test_control_flow.py
+++ b/test/inductor/test_control_flow.py
@@ -236,6 +236,16 @@ class CondModels:
 
             return y.sum() - torch.cond(x.sum() > 0, true_fn, false_fn, (x,))
 
+    class MismatchedOutputSizeInnerDim(torch.nn.Module):
+        def forward(self, p, x, y):
+            def true_fn(x, y):
+                return x * 2
+
+            def false_fn(x, y):
+                return y.clone()
+
+            return torch.cond(p, true_fn, false_fn, (x, y))
+
     class FunctionalCall(torch.nn.Module):
         def __init__(self):
             super().__init__()
@@ -777,6 +787,22 @@ class CondTests(TestCase):
                 torch.randn(10, 20),
                 torch.randn(10, 20),
             },
+            device=device,
+            dynamic=dynamic,
+        )
+
+    @requires_gpu
+    @parametrize("device", ["cpu", GPU_TYPE])
+    @parametrize("dynamic", [True, False])
+    def test_cond_mismatched_branch_output_size_inner_dim(self, device, dynamic):
+        # inner dim mismatch puts an unbacked symbol in the merged
+        # output strides, which must not leak into subgraph codegen
+        self._run_test(
+            model=CondModels.MismatchedOutputSizeInnerDim(),
+            inputs=(
+                torch.randn(10, 20),
+                torch.randn(10, 21),
+            ),
             device=device,
             dynamic=dynamic,
         )

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -10877,7 +10877,7 @@ class Conditional(ExternKernel):
         def _require_exact_strides(
             graph_outputs: Sequence[IRNode],
             fake_tensors: Sequence[torch.Tensor],
-            branch_fakes: Sequence[Any],
+            branch_fakes: Sequence[torch.Tensor | int | None],
         ) -> list[IRNode]:
             ret = []
             for output, fake, branch_fake in zip(
@@ -10889,7 +10889,7 @@ class Conditional(ExternKernel):
                     strides = fake.stride()
                     # merged strides can contain unbacked symbols (from mismatched
                     # branch output shapes) undefined inside the subgraph
-                    if any(has_free_unbacked_symbols(s) for s in strides):
+                    if has_free_unbacked_symbols(strides):
                         strides = branch_fake.stride()
                     ret.append(
                         # pyrefly: ignore [bad-argument-type]
@@ -10916,9 +10916,10 @@ class Conditional(ExternKernel):
                 ]
                 with V.set_graph_handler(subgraph.graph):
                     subgraph.graph.run(*fake_operands)
-                    # Force subgraph outputs to have the expected strides from
-                    # FakeTensor metadata. This ensures both branches produce
-                    # outputs with consistent strides.
+                    # Force subgraph outputs to the expected strides from
+                    # FakeTensor metadata. Branches share the merged strides
+                    # unless those carry an unbacked symbol (mismatched inner
+                    # dims), in which case each branch keeps its own strides.
                     subgraph.graph.graph_outputs = _require_exact_strides(
                         subgraph.graph.graph_outputs, fake_outputs, branch_fakes
                     )

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -10890,6 +10890,7 @@ class Conditional(ExternKernel):
                     # merged strides can contain unbacked symbols (from mismatched
                     # branch output shapes) undefined inside the subgraph
                     if has_free_unbacked_symbols(strides):
+                        # pyrefly: ignore [missing-attribute]
                         strides = branch_fake.stride()
                     ret.append(
                         # pyrefly: ignore [bad-argument-type]
@@ -10911,7 +10912,7 @@ class Conditional(ExternKernel):
                 branch_out_args = subgraph.graph_module.graph.output_node().args[0]
                 if not isinstance(branch_out_args, Sequence):
                     raise AssertionError(type(branch_out_args))
-                branch_fakes = [
+                branch_fakes: list[Any] = [
                     a.meta["val"] if isinstance(a, Node) else a for a in branch_out_args
                 ]
                 with V.set_graph_handler(subgraph.graph):

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -10877,16 +10877,24 @@ class Conditional(ExternKernel):
         def _require_exact_strides(
             graph_outputs: Sequence[IRNode],
             fake_tensors: Sequence[torch.Tensor],
+            branch_fakes: Sequence[Any],
         ) -> list[IRNode]:
             ret = []
-            for output, fake in zip(graph_outputs, fake_tensors):
+            for output, fake, branch_fake in zip(
+                graph_outputs, fake_tensors, branch_fakes
+            ):
                 if isinstance(output, ShapeAsConstantBuffer):
                     ret.append(output)
                 else:
+                    strides = fake.stride()
+                    # merged strides can contain unbacked symbols (from mismatched
+                    # branch output shapes) undefined inside the subgraph
+                    if any(has_free_unbacked_symbols(s) for s in strides):
+                        strides = branch_fake.stride()
                     ret.append(
                         # pyrefly: ignore [bad-argument-type]
                         ExternKernel.require_exact_strides(
-                            TensorBox(output), fake.stride(), allow_padding=False
+                            TensorBox(output), strides, allow_padding=False
                         )
                     )
             # pyrefly: ignore [bad-return]
@@ -10900,13 +10908,19 @@ class Conditional(ExternKernel):
                     example_inputs=fake_operands,
                     subgraph_name=subgraph.name,
                 )
+                branch_out_args = subgraph.graph_module.graph.output_node().args[0]
+                if not isinstance(branch_out_args, Sequence):
+                    raise AssertionError(type(branch_out_args))
+                branch_fakes = [
+                    a.meta["val"] if isinstance(a, Node) else a for a in branch_out_args
+                ]
                 with V.set_graph_handler(subgraph.graph):
                     subgraph.graph.run(*fake_operands)
                     # Force subgraph outputs to have the expected strides from
                     # FakeTensor metadata. This ensures both branches produce
                     # outputs with consistent strides.
                     subgraph.graph.graph_outputs = _require_exact_strides(
-                        subgraph.graph.graph_outputs, fake_outputs
+                        subgraph.graph.graph_outputs, fake_outputs, branch_fakes
                     )
 
         if true_fn.graph is None:


### PR DESCRIPTION
## Related Issue

Fixes #189528

## Why

`Conditional.create` forces branch subgraph outputs to the merged cond output's strides, which contain an unbacked symbol bound only in the outer graph when branch shapes mismatch in an inner dim, so subgraph codegen hits `NameError: name 'u0' is not defined`. Regression from #169963.

## How

- When merged strides contain unbacked symbols, the branch's own output strides are required instead (equivalent constraint, since merged strides derive from the branch metas)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98 @ydwu4 @bdhirsh