### PR TITLE
Fix `auto_functionalized_v2` assertion error with e8m0 inputs in nested compile regions

### DIFF
--- a/test/higher_order_ops/test_invoke_subgraph.py
+++ b/test/higher_order_ops/test_invoke_subgraph.py
@@ -1369,6 +1369,29 @@ class GraphModule(torch.nn.Module):
         x_clone = x.clone()
         self.assertEqual(opt_fn(x, y), fn(x_clone, y))
 
+    def test_input_mutation_with_e8m0_arg(self):
+        # https://github.com/pytorch/pytorch/issues/189522
+        # An e8m0 arg made decompose_auto_functionalized skip the
+        # auto_functionalized_v2(invoke_subgraph) node, tripping its
+        # "auto_functionalized_v2 was not removed" assertion.
+        @nested_compile_region
+        def gn(x, y, scale_e8m0):
+            x.add_(1)
+            return torch.mul(x, y) * scale_e8m0.to(torch.float32)
+
+        def fn(x, y, scale_e8m0):
+            return gn(x, y, scale_e8m0) + gn(x, y, scale_e8m0)
+
+        x = torch.randn(8)
+        y = torch.randn(8)
+        scale = torch.full((8,), 127, dtype=torch.uint8).view(torch.float8_e8m0fnu)
+
+        opt_fn = torch.compile(fn, backend="inductor", fullgraph=True)
+
+        x_clone = x.clone()
+        self.assertEqual(opt_fn(x, y, scale), fn(x_clone, y, scale))
+        self.assertEqual(x, x_clone)
+
     def test_input_mutation_mutiple_times(self):
         @nested_compile_region
         def gn(x, y):

--- a/test/higher_order_ops/test_invoke_subgraph.py
+++ b/test/higher_order_ops/test_invoke_subgraph.py
@@ -1388,6 +1388,29 @@ class GraphModule(torch.nn.Module):
         x_clone = x.clone()
         self.assertEqual(opt_fn(x, y), fn(x_clone, y))
 
+    def test_input_mutation_with_e8m0_arg(self):
+        # https://github.com/pytorch/pytorch/issues/189522
+        # An e8m0 arg made decompose_auto_functionalized skip the
+        # auto_functionalized_v2(invoke_subgraph) node, tripping its
+        # "auto_functionalized_v2 was not removed" assertion.
+        @nested_compile_region
+        def gn(x, y, scale_e8m0):
+            x.add_(1)
+            return torch.mul(x, y) * scale_e8m0.to(torch.float32)
+
+        def fn(x, y, scale_e8m0):
+            return gn(x, y, scale_e8m0) + gn(x, y, scale_e8m0)
+
+        x = torch.randn(8)
+        y = torch.randn(8)
+        scale = torch.full((8,), 127, dtype=torch.uint8).view(torch.float8_e8m0fnu)
+
+        opt_fn = torch.compile(fn, backend="inductor", fullgraph=True)
+
+        x_clone = x.clone()
+        self.assertEqual(opt_fn(x, y, scale), fn(x_clone, y, scale))
+        self.assertEqual(x, x_clone)
+
     def test_input_mutation_mutiple_times(self):
         @nested_compile_region
         def gn(x, y):

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2775,6 +2775,15 @@ def unsupported_output_tensor(t: torch.Tensor, node=None):
 
 
 def fallback_node_due_to_unsupported_type(node: torch.fx.Node, allow_cpu_inputs=True):
+    # auto_functionalized wrappers are never lowered directly; they must always
+    # be processed by decompose_auto_functionalized (its trailing scan asserts
+    # they were removed), so unsupported input types must not skip them here.
+    if node.target in (
+        torch.ops.higher_order.auto_functionalized,
+        torch.ops.higher_order.auto_functionalized_v2,
+    ):
+        return False
+
     # Custom fallback lowering
     if node.target is aten.view_as_complex.default:
         return False

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2913,6 +2913,15 @@ def unsupported_output_tensor(t: torch.Tensor, node=None):
 
 
 def fallback_node_due_to_unsupported_type(node: torch.fx.Node, allow_cpu_inputs=True):
+    # auto_functionalized wrappers are never lowered directly; they must always
+    # be processed by decompose_auto_functionalized (its trailing scan asserts
+    # they were removed), so unsupported input types must not skip them here.
+    if node.target in (
+        torch.ops.higher_order.auto_functionalized,
+        torch.ops.higher_order.auto_functionalized_v2,
+    ):
+        return False
+
     # Custom fallback lowering
     if node.target is aten.view_as_complex.default:
         return False


### PR DESCRIPTION
This PR fixes an `AssertionError: auto_functionalized_v2 was not removed` that occurs when using `nested_compile_region` with input mutation and a `float8_e8m0fnu` tensor input.

In inductor's `decompose_auto_functionalized` pass, `fallback_node_due_to_unsupported_type` was incorrectly skipping `auto_functionalized_v2` nodes when they contained e8m0 inputs. Since these wrappers must always be processed and removed by the pass, we now explicitly return `False` for `auto_functionalized` and `auto_functionalized_v2` targets in `fallback_node_due_to_unsupported_type`.

A regression test `test_input_mutation_with_e8m0_arg` has been added to verify the fix.

Closes #189522

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo