### PR TITLE
fix(invoke_subgraph): Support Tensor! custom ops in input-mutating regions

### DIFF
--- a/test/higher_order_ops/test_invoke_subgraph.py
+++ b/test/higher_order_ops/test_invoke_subgraph.py
@@ -1496,10 +1496,35 @@ class GraphModule(torch.nn.Module):
             x_clone = x.clone()
             y = torch.randn(8, requires_grad=False)
 
-            opt_fn = torch.compile(fn, backend="inductor", fullgraph=True)
+            backend = AotEagerAndRecordGraphs()
+            opt_fn = torch.compile(fn, backend=backend, fullgraph=True)
 
             self.assertEqual(opt_fn(x, y), fn(x_clone, y))
             self.assertEqual(x_clone, x)
+
+            self.assertExpectedInline(
+                normalize_gm(backend.fw_graphs[0].print_readable(print_output=False)),
+                """\
+class <lambda>(torch.nn.Module):
+    def forward(self, arg0_1: "f32[8]", arg1_1: "f32[8]"):
+        auto_functionalized_subgraph_0 = self.auto_functionalized_subgraph_0
+        _tree_spec_constant0 = self._tree_spec_constant0
+        auto_functionalized_v2 = torch.ops.higher_order.auto_functionalized_v2(torch.ops.higher_order.invoke_subgraph, subgraph = auto_functionalized_subgraph_0, identifier = 'auto_functionalized_subgraph_0', arg0 = arg1_1, _arg1_base_index = 0, _all_bases = [arg0_1], _op_schema = _tree_spec_constant0);  auto_functionalized_subgraph_0 = arg1_1 = _tree_spec_constant0 = None
+        getitem: "f32[8]" = auto_functionalized_v2[0]
+        getitem_1: "f32[8]" = auto_functionalized_v2[1];  auto_functionalized_v2 = None
+        copy_: "f32[8]" = torch.ops.aten.copy_.default(arg0_1, getitem_1);  arg0_1 = getitem_1 = copy_ = None
+        return (getitem,)
+    class auto_functionalized_subgraph_0(torch.nn.Module):
+        def forward(self, arg0_1: "f32[8]", arg1_1: "f32[8]"):
+            empty_like: "f32[8]" = torch.ops.aten.empty_like.default(arg0_1, pin_memory = False)
+            auto_functionalized_v2 = torch.ops.higher_order.auto_functionalized_v2(torch.ops.mylib.scale_into.default, x = arg0_1, scale = 2.0, _out_base_index = 0, _all_bases = [empty_like]);  empty_like = None
+            getitem_1: "f32[8]" = auto_functionalized_v2[1];  auto_functionalized_v2 = None
+            add: "f32[8]" = torch.ops.aten.add.Tensor(arg1_1, getitem_1);  getitem_1 = None
+            mul: "f32[8]" = torch.ops.aten.mul.Tensor(add, arg0_1);  arg0_1 = None
+            copy_: "f32[8]" = torch.ops.aten.copy_.default(arg1_1, add);  arg1_1 = add = copy_ = None
+            return (mul,)""",
+                ignore_empty_lines=True,
+            )
 
     def test_simple_module(self):
         mod = torch.nn.Linear(8, 8)

--- a/test/higher_order_ops/test_invoke_subgraph.py
+++ b/test/higher_order_ops/test_invoke_subgraph.py
@@ -1472,6 +1472,35 @@ class GraphModule(torch.nn.Module):
         ):
             opt_fn(x, y)
 
+    @torch._dynamo.config.patch(inline_single_use_invoke_subgraph=False)
+    def test_input_mutation_alias_annotated_custom_op(self):
+        with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
+            lib.define("scale_into(Tensor x, Tensor! out, float scale) -> ()")
+
+            def scale_into(x, out, scale):
+                out.copy_(x * scale)
+
+            lib.impl("scale_into", scale_into, "CompositeExplicitAutograd")
+
+            @nested_compile_region
+            def gn(x, y):
+                out = torch.empty_like(y)
+                torch.ops.mylib.scale_into(y, out, 2.0)
+                x.add_(out)
+                return torch.mul(x, y)
+
+            def fn(x, y):
+                return gn(x, y)
+
+            x = torch.randn(8, requires_grad=False)
+            x_clone = x.clone()
+            y = torch.randn(8, requires_grad=False)
+
+            opt_fn = torch.compile(fn, backend="inductor", fullgraph=True)
+
+            self.assertEqual(opt_fn(x, y), fn(x_clone, y))
+            self.assertEqual(x_clone, x)
+
     def test_simple_module(self):
         mod = torch.nn.Linear(8, 8)
 

--- a/test/higher_order_ops/test_invoke_subgraph.py
+++ b/test/higher_order_ops/test_invoke_subgraph.py
@@ -24,6 +24,7 @@ from torch._dynamo.testing import (
     InductorAndRecordGraphs,
     normalize_gm,
 )
+from torch._higher_order_ops.auto_functionalize import FunctionalCallableWithEpilogue
 from torch._higher_order_ops.schema import find_hop_schema
 from torch._inductor import config as inductor_config
 from torch._inductor.pattern_matcher import (
@@ -31,6 +32,7 @@ from torch._inductor.pattern_matcher import (
     PatternMatcherPass,
     register_graph_pattern,
 )
+from torch.fx.graph import _BoxedCodeGen
 from torch.testing._internal.common_cuda import SM80OrLater
 from torch.testing._internal.common_utils import (
     run_tests,
@@ -1526,6 +1528,26 @@ class <lambda>(torch.nn.Module):
             return (mul,)""",
                 ignore_empty_lines=True,
             )
+
+    def test_input_mutation_boxed_subgraph(self):
+        class Mod(torch.nn.Module):
+            def forward(self, x, y):
+                x.add_(y)
+                return (torch.mul(x, y),)
+
+        gm = torch.fx.symbolic_trace(Mod())
+        gm.graph.set_codegen(_BoxedCodeGen())
+        gm.recompile()
+        self.assertTrue(gm._boxed_call)
+
+        x = torch.randn(8, requires_grad=False)
+        y = torch.randn(8, requires_grad=False)
+
+        x_clone = x.clone()
+        ref = Mod()(x_clone, y)
+
+        self.assertEqual(FunctionalCallableWithEpilogue(gm)([x, y]), ref)
+        self.assertEqual(x_clone, x)
 
     def test_simple_module(self):
         mod = torch.nn.Linear(8, 8)

--- a/test/higher_order_ops/test_invoke_subgraph.py
+++ b/test/higher_order_ops/test_invoke_subgraph.py
@@ -1492,6 +1492,7 @@ class GraphModule(torch.nn.Module):
             def fn(x, y):
                 return gn(x, y)
 
+            # x is mutated in place, so it cannot require grad (autograd leaf error).
             x = torch.randn(8, requires_grad=False)
             x_clone = x.clone()
             y = torch.randn(8, requires_grad=False)

--- a/torch/_higher_order_ops/auto_functionalize.py
+++ b/torch/_higher_order_ops/auto_functionalize.py
@@ -619,7 +619,17 @@ class FunctionalCallableWithEpilogue:
 
     def __call__(self, *args, **kwargs):
         # Functionalize to inline the epilogue graph (copy_ ops) for better fusion.
-        functionalized = torch.func.functionalize(self.orig_callable)
+        # Python functionalization so mutable custom ops reach auto_functionalized_v2.
+        from torch._subclasses.functional_tensor import (
+            dispatch_functionalize,
+            FunctionalTensorMode,
+        )
+
+        functionalized = dispatch_functionalize(
+            self.orig_callable,
+            FunctionalTensorMode(),
+            propagate_input_mutations=True,
+        )
         if self._boxed_call:
             # Not all callers respect _boxed_call (e.g. reenter_make_fx
             # always calls f(*args)). Detect which convention was used.

--- a/torch/_subclasses/functional_tensor.py
+++ b/torch/_subclasses/functional_tensor.py
@@ -811,10 +811,16 @@ def dispatch_functionalize(
         disable_above = torch._C._ExcludeDispatchKeyGuard(
             torch._C.DispatchKeySet(torch._C.DispatchKey.Functionalize)
         )
+        flat_inputs: list[Any] = []
+        flat_func_inputs: list[Any] = []
         with disable_above:
             with mode:
                 func_args = pytree.tree_map_only(torch.Tensor, to_fun, args)
                 func_kwargs = pytree.tree_map_only(torch.Tensor, to_fun, kwargs)
+                if propagate_input_mutations:
+                    # A boxed func clears its input list, so flatten before the call.
+                    flat_inputs = pytree.arg_tree_leaves(*args, **kwargs)
+                    flat_func_inputs = pytree.arg_tree_leaves(*func_args, **func_kwargs)
                 func_outputs = func(*func_args, **func_kwargs)
                 outputs = pytree.tree_map_only(FunctionalTensor, from_fun, func_outputs)
 
@@ -822,10 +828,7 @@ def dispatch_functionalize(
                 from torch._C._functorch import _propagate_functional_input_mutation
 
                 # Runs outside of mode so the copy_ mutates the caller's tensors.
-                for arg, func_arg in zip(
-                    pytree.arg_tree_leaves(*args, **kwargs),
-                    pytree.arg_tree_leaves(*func_args, **func_kwargs),
-                ):
+                for arg, func_arg in zip(flat_inputs, flat_func_inputs):
                     if isinstance(func_arg, FunctionalTensor):
                         _propagate_functional_input_mutation(arg, func_arg.elem)
 

--- a/torch/_subclasses/functional_tensor.py
+++ b/torch/_subclasses/functional_tensor.py
@@ -789,8 +789,6 @@ def dispatch_functionalize(
     *,
     propagate_input_mutations: bool = False,
 ) -> Callable[..., Any]:
-    from torch._C._functorch import _propagate_functional_input_mutation
-
     # TODO: pull these from aot autograd
     def to_fun(t: object) -> object:
         if isinstance(t, torch.Tensor):
@@ -821,6 +819,8 @@ def dispatch_functionalize(
                 outputs = pytree.tree_map_only(FunctionalTensor, from_fun, func_outputs)
 
             if propagate_input_mutations:
+                from torch._C._functorch import _propagate_functional_input_mutation
+
                 # Runs outside of mode so the copy_ mutates the caller's tensors.
                 for arg, func_arg in zip(
                     pytree.arg_tree_leaves(*args, **kwargs),

--- a/torch/_subclasses/functional_tensor.py
+++ b/torch/_subclasses/functional_tensor.py
@@ -782,9 +782,15 @@ def disable_functional_mode() -> Generator[None, None, None]:
 # - Doing so means that it does not automatically compose with other
 #   functorch transforms, since these transforms always run above __torch_dispatch__.
 #   That's why this util lives here, and not in functorch.
+# - Input mutations are only propagated back when propagate_input_mutations is set.
 def dispatch_functionalize(
-    func: Callable[..., Any], mode: FunctionalTensorMode = FunctionalTensorMode()
+    func: Callable[..., Any],
+    mode: FunctionalTensorMode = FunctionalTensorMode(),
+    *,
+    propagate_input_mutations: bool = False,
 ) -> Callable[..., Any]:
+    from torch._C._functorch import _propagate_functional_input_mutation
+
     # TODO: pull these from aot autograd
     def to_fun(t: object) -> object:
         if isinstance(t, torch.Tensor):
@@ -807,11 +813,21 @@ def dispatch_functionalize(
         disable_above = torch._C._ExcludeDispatchKeyGuard(
             torch._C.DispatchKeySet(torch._C.DispatchKey.Functionalize)
         )
-        with disable_above, mode:
-            func_args = pytree.tree_map_only(torch.Tensor, to_fun, args)
-            func_kwargs = pytree.tree_map_only(torch.Tensor, to_fun, kwargs)
-            func_outputs = func(*func_args, **func_kwargs)
-            outputs = pytree.tree_map_only(FunctionalTensor, from_fun, func_outputs)
+        with disable_above:
+            with mode:
+                func_args = pytree.tree_map_only(torch.Tensor, to_fun, args)
+                func_kwargs = pytree.tree_map_only(torch.Tensor, to_fun, kwargs)
+                func_outputs = func(*func_args, **func_kwargs)
+                outputs = pytree.tree_map_only(FunctionalTensor, from_fun, func_outputs)
+
+            if propagate_input_mutations:
+                # Runs outside of mode so the copy_ mutates the caller's tensors.
+                for arg, func_arg in zip(
+                    pytree.arg_tree_leaves(*args, **kwargs),
+                    pytree.arg_tree_leaves(*func_args, **func_kwargs),
+                ):
+                    if isinstance(func_arg, FunctionalTensor):
+                        _propagate_functional_input_mutation(arg, func_arg.elem)
 
             return outputs
 


### PR DESCRIPTION
### What does this PR do?

First contribution!

→ Found that when the subgraph mutates inputs [can_auto_functionalize](https://github.com/pytorch/pytorch/blob/3380bd93519b34ab59cac5453d91505824da7fd6/torch/_higher_order_ops/invoke_subgraph.py#L1090) routes to `do_auto_functionalize_v2` whose [FunctionalCallableWithEpilogue](https://github.com/pytorch/pytorch/blob/3380bd93519b34ab59cac5453d91505824da7fd6/torch/_higher_order_ops/auto_functionalize.py#L622) functionalizes with `torch.func.functionalize` (C++), and the [C++ fallback](https://github.com/pytorch/pytorch/blob/3380bd93519b34ab59cac5453d91505824da7fd6/aten/src/ATen/FunctionalizeFallbackKernel.cpp#L63) rejects any alias info and cannot reach `auto_functionalized_v2`.
→ Fixed by pointing that wrapper at Python functionalization, the way the [non-mutating path already does](https://github.com/pytorch/pytorch/blob/3380bd93519b34ab59cac5453d91505824da7fd6/torch/_higher_order_ops/invoke_subgraph.py#L1110-L1115) with an opt-in `propagate_input_mutations` on `dispatch_functionalize` so the epilogue `copy_` still happens :)

Fixes #189523

cc @bdhirsh @zou3519 @aorenste @bohnstingl @ezyang @chauhang @penguinwu @bobrenjc93

### Verification and Testing

→ <ins>Locally</ins>: Issue repro fixed, epilogue `copy_` still emitted (mutations are not silently dropped), tests run across `test_invoke_subgraph` / `test_auto_functionalize` / `test_functionalization` / `test_base_hop` with no new failures, plus `test_aotdispatch` clean over the tests it reached.

```
python test/higher_order_ops/test_invoke_subgraph.py -k test_input_mutation_alias_annotated_custom_op
```

**Before**

<details>
<summary>Command output</summary><br>

```text
E
=========================================================================================
ERROR: test_input_mutation_alias_annotated_custom_op (__main__.TestInvokeSubgraphCompile)
-----------------------------------------------------------------------------------------
Traceback (most recent call last):
  File "common_utils.py", line 3590, in wrapper
    method(*args, **kwargs)
  File "contextlib.py", line 79, in inner
    return func(*args, **kwds)
  File "test_invoke_subgraph.py", line 1501, in test_input_mutation_alias_annotated_custom_op
    self.assertEqual(opt_fn(x, y), fn(x_clone, y))
  File "eval_frame.py", line 1205, in compile_wrapper
    raise e.remove_dynamo_frames() from None  # see TORCHDYNAMO_VERBOSE=1
  File "output_graph.py", line 3282, in _call_user_compiler
    raise BackendCompilerFailed(
  File "output_graph.py", line 3254, in _call_user_compiler
    compiled_fn = compiler_fn(gm, example_inputs)
  File "after_dynamo.py", line 163, in __call__
    compiled_gm = compiler_fn(gm, example_inputs)
  File "__init__.py", line 2965, in __call__
    return compile_fx(
  File "compile_fx.py", line 2921, in compile_fx
    return _maybe_wrap_and_compile_fx_main(
  File "compile_fx.py", line 3005, in _maybe_wrap_and_compile_fx_main
    return _compile_fx_main(
  File "compile_fx.py", line 3210, in _compile_fx_main
    return dynamo_common.aot_autograd(
  File "common.py", line 151, in __call__
    cg = aot_module_simplified(
  File "aot_autograd.py", line 1229, in aot_module_simplified
    aot_state = create_aot_state(
  File "aot_autograd.py", line 587, in create_aot_state
    fw_metadata = run_functionalized_fw_and_collect_metadata(
  File "collect_metadata_analysis.py", line 221, in inner
    flat_f_outs = f(*flat_f_args)
  File "graph_capture_wrappers.py", line 1536, in functional_call
    out = PropagateUnbackedSymInts(mod).run(*args)
  File "interpreter.py", line 197, in run
    self.env[node] = self.run_node(node)
  File "symbolic_shapes.py", line 9006, in run_node
    result = super().run_node(n)
  File "interpreter.py", line 294, in run_node
    return getattr(self, n.op)(n.target, args, kwargs)
  File "interpreter.py", line 377, in call_function
    return target(*args, **kwargs)
  File "invoke_subgraph.py", line 258, in __call__
    return super().__call__(subgraph, identifier, *operands)
  File "_ops.py", line 549, in __call__
    return self.dispatch(dispatch_key_set.highestPriorityTypeId(), *args, **kwargs)
  File "_ops.py", line 537, in dispatch
    return kernel(*args, **kwargs)
  File "_ops.py", line 341, in maybe_run_autograd
    return self(*args, **kwargs)
  File "invoke_subgraph.py", line 258, in __call__
    return super().__call__(subgraph, identifier, *operands)
  File "_ops.py", line 549, in __call__
    return self.dispatch(dispatch_key_set.highestPriorityTypeId(), *args, **kwargs)
  File "_ops.py", line 431, in dispatch
    result = handler(mode, *args, **kwargs)
  File "_ops.py", line 198, in functionalize_dispatch_mode_fn
    return fn(PythonFunctionalizeAPI(mode), *args, **kwargs)
  File "invoke_subgraph.py", line 1103, in _
    return do_auto_functionalize_v2(
  File "auto_functionalize.py", line 694, in do_auto_functionalize_v2
    return _do_auto_functionalize_v2_for_generic_mutable_operator(
  File "auto_functionalize.py", line 877, in _do_auto_functionalize_v2_for_generic_mutable_operator
    unwrapped_outs = auto_functionalized_v2(
  File "auto_functionalize.py", line 416, in __call__
    return super().__call__(_mutable_op, **kwargs)
  File "_ops.py", line 549, in __call__
    return self.dispatch(dispatch_key_set.highestPriorityTypeId(), *args, **kwargs)
  File "_ops.py", line 431, in dispatch
    result = handler(mode, *args, **kwargs)
  File "utils.py", line 666, in impl
    return mode.__torch_dispatch__(hop, [], args, kwargs)
  File "_compile.py", line 54, in inner
    return disable_fn(*args, **kwargs)
  File "eval_frame.py", line 1468, in _fn
    return fn(*args, **kwargs)
  File "_stats.py", line 29, in wrapper
    return fn(*args, **kwargs)
  File "fake_tensor.py", line 1688, in __torch_dispatch__
    return self.dispatch(func, types, args, kwargs)
  File "fake_tensor.py", line 2476, in dispatch
    return self._cached_dispatch_impl(func, types, args, kwargs)
  File "fake_tensor.py", line 1836, in _cached_dispatch_impl
    output = self._dispatch_impl(func, types, args, kwargs)
  File "fake_tensor.py", line 2853, in _dispatch_impl
    return registered_hop_fake_fns[func](*args, **kwargs)
  File "auto_functionalize.py", line 1137, in auto_functionalized_v2_fake
    result = auto_functionalized_v2_dense(
  File "auto_functionalize.py", line 1058, in auto_functionalized_v2_dense
    out = call_op(
  File "utils.py", line 1290, in call_op
    return op(*bound_args, **bound_kwargs)
  File "utils.py", line 1248, in __call__
    return self._op(*args, **kwargs)
  File "invoke_subgraph.py", line 258, in __call__
    return super().__call__(subgraph, identifier, *operands)
  File "_ops.py", line 549, in __call__
    return self.dispatch(dispatch_key_set.highestPriorityTypeId(), *args, **kwargs)
  File "_ops.py", line 431, in dispatch
    result = handler(mode, *args, **kwargs)
  File "utils.py", line 666, in impl
    return mode.__torch_dispatch__(hop, [], args, kwargs)
  File "_compile.py", line 54, in inner
    return disable_fn(*args, **kwargs)
  File "eval_frame.py", line 1468, in _fn
    return fn(*args, **kwargs)
  File "_stats.py", line 29, in wrapper
    return fn(*args, **kwargs)
  File "fake_tensor.py", line 1688, in __torch_dispatch__
    return self.dispatch(func, types, args, kwargs)
  File "fake_tensor.py", line 2476, in dispatch
    return self._cached_dispatch_impl(func, types, args, kwargs)
  File "fake_tensor.py", line 1836, in _cached_dispatch_impl
    output = self._dispatch_impl(func, types, args, kwargs)
  File "fake_tensor.py", line 2853, in _dispatch_impl
    return registered_hop_fake_fns[func](*args, **kwargs)
  File "invoke_subgraph.py", line 1150, in _
    return subgraph(*operands)
  File "auto_functionalize.py", line 629, in __call__
    return functionalized(*args, **kwargs)
  File "eager_transforms.py", line 1783, in wrapped
    func_outputs = func(*func_args, **func_kwargs)
  File "graph_module.py", line 1002, in call_wrapped
    return self._wrapped_call(self, *args, **kwargs)
  File "graph_module.py", line 509, in __call__
    raise e
  File "graph_module.py", line 495, in __call__
    return super(self.cls, obj).__call__(*args, **kwargs)  # type: ignore[misc]
  File "module.py", line 1778, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "module.py", line 1789, in _call_impl
    return forward_call(*args, **kwargs)
  File "<eval_with_key>.8", line 6, in forward
    scale_into = torch.ops.mylib.scale_into(l_y_, out, 2.0);  scale_into = None
  File "_ops.py", line 1350, in __call__
    return self._op(*args, **kwargs)
torch._dynamo.exc.BackendCompilerFailed: backend='inductor' raised:
RuntimeError: Found a custom (non-ATen) operator whose output has alias annotations: mylib::scale_into(Tensor x, Tensor($0! -> ) out, float scale) -> (). We only support functionalizing operators whose outputs do not have alias annotations (e.g. 'Tensor(a)' is a Tensor with an alias annotation whereas 'Tensor' is a Tensor without. The '(a)' is the alias annotation). The alias annotation specifies that the output Tensor shares storage with an input that has the same annotation. Please check if (1) the output needs to be an output (if not, don't return it), (2) if the output doesn't share storage with any inputs, then delete the alias annotation. (3) if the output indeed shares storage with an input, then add a .clone() before returning it to prevent storage sharing and then delete the alias annotation. Otherwise, please file an issue on GitHub.

While executing %invoke_subgraph : [num_users=1] = call_function[target=torch.ops.higher_order.invoke_subgraph](args = (%subgraph_0, subgraph_0, %l_y_, %l_x_), kwargs = {})
Original traceback:
  File "test_invoke_subgraph.py", line 1493, in fn
    return gn(x, y)

Use tlparse to see full graph. (https://github.com/pytorch/tlparse?tab=readme-ov-file#tlparse-parse-structured-pt2-logs)

Set TORCHDYNAMO_VERBOSE=1 for the internal stack trace (please do this especially if you're reporting a bug to PyTorch). For even more developer context, set TORCH_LOGS="+dynamo"

To execute this test, run the following from the base repo dir:
    python test/higher_order_ops/test_invoke_subgraph.py TestInvokeSubgraphCompile.test_input_mutation_alias_annotated_custom_op

This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0

--------------------------------------------------------------------------
Ran 1 test in 0.406s

FAILED (errors=1)
```

</details>

**After**

<img src="https://github.com/user-attachments/assets/3821fb25-6385-4d2e-8039-b174871a306e" />

### Environment

* `torch` version: `2.14.0a0+git3380bd9` (source build, `USE_CUDA=0`)
* Platform: `Linux-6.8.0-1063-gcp-x86_64-with-glibc2.35`
* Python version: `3.10.12`
* The issue's repro is CUDA-flavored but the failure is raised during tracing under `FakeTensorMode` and is device-independent; in this case it was reproduced and fixed on CPU.