### PR TITLE
Skip a subtest of `test_qconv2d_fp8`

### DIFF
--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -8491,6 +8491,9 @@ class TestQuantizedConv(TestCase):
             if output_dtype is not None and not (use_bias and use_channelwise):
                 # Remove some test combination to reduce UT test time
                 continue
+            # Skip this subtest of test_qconv2d_fp8 due to accuracy issues
+            if nd == 2 and pointwise_post_op == PointwisePostOp() and (groups, use_bias, use_channelwise, output_dtype) == (3, True, True, torch.bfloat16):
+                continue
             conv_mod = getattr(torch.nn, f"Conv{nd}d")(
                 input_channels_per_group * groups,
                 output_channels_per_group * groups,

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -8839,6 +8839,9 @@ class TestQuantizedConv(TestCase):
             if output_dtype is not None and not (use_bias and use_channelwise):
                 # Remove some test combination to reduce UT test time
                 continue
+            # Skip this subtest of test_qconv2d_fp8 due to accuracy issues
+            if nd == 2 and pointwise_post_op == PointwisePostOp() and (groups, use_bias, use_channelwise, output_dtype) == (3, True, True, torch.bfloat16):
+                continue
             conv_mod = getattr(torch.nn, f"Conv{nd}d")(
                 input_channels_per_group * groups,
                 output_channels_per_group * groups,


### PR DESCRIPTION
This test using BFloat16 with 3 groups fails when using bias and channelwise:

> Mismatched elements: 1 / 288 (0.3%)
> Greatest absolute difference: 0.00390625 at index (1, 0, 3, 0) (up to 1e-06 allowed)
> Greatest relative difference: 0.005347593687474728 at index (1, 0, 3, 0) (up to 1e-05 allowed)

Assuming the accuracy is not enough to pass this reliably, skip it instead.

I tested that on 3 different CPUs with 2.12.0 and 2.13.0.
The differences are the exact same in all cases so this seems to be an inherent issue of the reduced precision.

e1a20988f3724317a7ee79c1777d574a8282a122 mentioned:
> OneDNN does not support quantized fp8 convolution until v3.9 but the version used in PyTorch is v3.7.2. 

So maybe that is related.

I further traced it to a20f775e82564d2a9979221ed7f3b8d7cf54ce90 where `_make_qconv_tensors_fp8` now returns the bias tensor as bfloat16 instead of float. Reverting only that part of the change makes the test pass too

It also depends on the seed of the test: Changing the order makes it pass or fail, so the slight change of the values by generating the random values in float instead of BF16 might just trigger a "less unfortunate" case