### PR TITLE
Fix tensorify_python_scalars dropping add/sub alpha kwarg

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -17765,6 +17765,30 @@ class DynamoOpPromotionTests(torch._dynamo.test_case.TestCase):
         result = compiled(torch.randn(1024), 256)
         self.assertEqual(result, 4)
 
+    @torch._dynamo.config.patch(capture_scalar_outputs=True)
+    def test_tensorify_add_sub_alpha_from_item(self):
+        """add/sub with a non-unit `alpha` and a `.item()` scalar operand must
+        preserve `alpha`. The tensorify pass rebuilds the op from node.args
+        only; `alpha` is keyword-only (node.kwargs) and was previously dropped,
+        turning add(a, b, alpha=k) into a + b. Must run on aot_eager/inductor
+        (the pass does not run under backend="eager")."""
+
+        def fn(a, b):
+            s = b.item()
+            return (
+                torch.add(torch.sigmoid(a), s, alpha=-0.9248),
+                torch.sub(torch.sigmoid(a), s, alpha=3.5),
+            )
+
+        a = torch.tensor(0.5)
+        b = torch.tensor(2.0)
+        expected = fn(a, b)
+        for backend in ("aot_eager", "inductor"):
+            with self.subTest(backend=backend):
+                torch._dynamo.reset()
+                got = torch.compile(fn, backend=backend, fullgraph=True)(a, b)
+                self.assertEqual(got, expected)
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/fx/passes/_tensorify_python_scalars.py
+++ b/torch/fx/passes/_tensorify_python_scalars.py
@@ -367,7 +367,10 @@ def _tensorify_impl(
                         args.append(a)
 
                 if transform:
-                    replacement_proxy = replacement_op(*args)
+                    # Preserve keyword-only args (e.g. add/sub `alpha`) which
+                    # live in node.kwargs; the loop above only rebuilds
+                    # positional args, so without this they are dropped.
+                    replacement_proxy = replacement_op(*args, **node.kwargs)
 
                     if (
                         compute_dtype != node.meta["val"].dtype


### PR DESCRIPTION
Summary:
`tensorify_python_scalars` rewrites tensor ops whose operand is a Python/SymFloat scalar (e.g. from `tensor.item()` under `capture_scalar_outputs`) back into tensor-tensor ops, replacing the scalar with a `convert_element_type` of the source. When it rebuilds the replacement node it uses `replacement_op(*args)`, reconstructing from `node.args` only. For `aten.add.Tensor` / `aten.sub.Tensor` the `alpha` argument is keyword-only, so it lives in `node.kwargs` and was silently dropped — turning `add(a, b, alpha=k)` into `a + b`. Because the pass runs on the AOT-autograd joint graph before decomposition, nothing downstream re-applies `alpha`, so the factor is lost for the whole compiled program.

Root cause and fix: forward the original node's kwargs when rebuilding the op — `replacement_op(*args, **node.kwargs)`. For the supported ops the only kwargs are scalar constants (`alpha` for add/sub, `rounding_mode` for div), so passing them straight through is correct and minimal; mul/pow/comparison ops carry no kwargs and are unaffected. This also covers `sub` and the in-place `add_`/`sub_`.

The bug only manifests on backends that run this pass (aot_eager, inductor); `backend="eager"` is unaffected. It was found via a fuzzer-generated program `add(sigmoid(x), y.item(), alpha=-0.9248)` whose MTIA/CPU output diverged because it computed `sigmoid(x) + y` instead of `sigmoid(x) - 0.9248*y`.

Test Plan:
Added `DynamoOpPromotionTests.test_tensorify_add_sub_alpha_from_item` covering add and sub with a non-unit `alpha` and a `.item()` scalar operand, asserting compiled output matches eager on aot_eager and inductor.

```
buck2 test //caffe2/test/dynamo:test_misc -- DynamoOpPromotionTests.test_tensorify_add_sub_alpha_from_item
```

Also verified the minimal repro matches eager across eager/aot_eager/inductor (with inductor caches disabled), and that the originating MTIA fuzzer reproducer now passes.

This change was authored with the assistance of an AI coding assistant.

Differential Revision: D111371624




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98