### PR TITLE
[dynamo] Add tp_name / tp_doc type slots to VariableTracker

### DIFF
--- a/test/dynamo/test_tp_slots.py
+++ b/test/dynamo/test_tp_slots.py
@@ -20,6 +20,20 @@ from torch._C._dynamo import (
     PyTypeSlots,
 )
 from torch._dynamo.test_case import run_tests, TestCase
+from torch._dynamo.variables.base import VariableTracker
+from torch._dynamo.variables.dicts import ConstDictVariable, OrderedItemsDictVariable
+from torch._dynamo.variables.lists import ListVariable, SizeVariable, TupleVariable
+from torch._dynamo.variables.sets import (
+    DictKeySetVariable,
+    FrozensetVariable,
+    OrderedSetVariable,
+    SetVariable,
+)
+from torch._dynamo.variables.user_defined import UserDefinedObjectVariable
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+)
 
 
 class TestTypeSlots(TestCase):
@@ -321,6 +335,72 @@ class TestTypeSlots(TestCase):
                 has_slot(map_slots, PyMappingSlots.MP_SUBSCRIPT),
                 f"{t.__name__} should have mp_subscript",
             )
+
+
+# Builtin VTs whose type is fixed by the VT class, so tp_name is a static slot
+# and must equal what python_type().__name__ returns.
+_TP_NAME_CASES = {
+    "list": lambda: ListVariable([]),
+    "tuple": lambda: TupleVariable([]),
+    "Size": lambda: SizeVariable([]),
+    "set": lambda: SetVariable([]),
+    "frozenset": lambda: FrozensetVariable([]),
+    "OrderedSet": lambda: OrderedSetVariable([]),
+    "dict_keys": lambda: DictKeySetVariable([]),
+    "dict": lambda: ConstDictVariable({}),
+    "OrderedDict": lambda: OrderedItemsDictVariable({}),
+}
+
+
+class VariableTrackerTpNameDocTests(TestCase):
+    """tp_name / tp_doc slots on VariableTracker (analogous to CPython's
+    PyTypeObject tp_name / tp_doc): describe the type a VT represents, not a
+    per-instance attribute. tp_name backs python_type_name(); tp_doc backs
+    __doc__ reads. Both default to None (derive from python_type())."""
+
+    @parametrize("name", list(_TP_NAME_CASES))
+    def test_tp_name_matches_python_type_name(self, name):
+        vt = _TP_NAME_CASES[name]()
+        self.assertEqual(vt.tp_name, name)
+        self.assertEqual(vt.python_type_name(), name)
+
+    def test_base_slots_default_to_none(self):
+        self.assertIsNone(VariableTracker.tp_name)
+        self.assertIsNone(VariableTracker.tp_doc)
+
+    def test_dynamic_vt_derives_name_from_python_type(self):
+        # UserDefinedObjectVariable represents arbitrary classes, so its type is
+        # per instance: tp_name stays None and python_type_name() derives the
+        # name from python_type() (value_type).
+        class Foo:
+            pass
+
+        self.assertIsNone(UserDefinedObjectVariable.tp_name)
+        self.assertEqual(UserDefinedObjectVariable(Foo()).python_type_name(), "Foo")
+        self.assertEqual(
+            UserDefinedObjectVariable(object()).python_type_name(), "object"
+        )
+
+    def test_tp_doc_absent_is_not_a_constant(self):
+        # No tp_doc declared: const_getattr does not treat __doc__ as a constant
+        # and falls through to NotImplementedError.
+        vt = ConstDictVariable({})
+        self.assertIsNone(vt.tp_doc)
+        with self.assertRaises(NotImplementedError):
+            vt.const_getattr(None, "__doc__")
+
+    def test_tp_doc_backs_dunder_doc(self):
+        # A VT that declares tp_doc answers __doc__ from it (CPython: an
+        # instance's __doc__ resolves to its type's tp_doc).
+        class DocDictVariable(ConstDictVariable):
+            tp_doc = "my docstring"
+
+        self.assertEqual(
+            DocDictVariable({}).const_getattr(None, "__doc__"), "my docstring"
+        )
+
+
+instantiate_parametrized_tests(VariableTrackerTpNameDocTests)
 
 
 if __name__ == "__main__":

--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -338,6 +338,10 @@ class VariableTracker(metaclass=VariableTrackerMeta):
     # (e.g., dynamic types like UserDefinedObjectVariable, or Dynamo-internal VTs).
     _cpython_type: type | tuple[type, ...] | None = None
 
+    # Type name and docstring, analogous to CPython's tp_name / tp_doc slots on PyTypeObject
+    tp_name: str | None = None
+    tp_doc: str | None = None
+
     # fields to leave unmodified in apply()
     _nonvar_fields = {
         "value",
@@ -437,6 +441,8 @@ class VariableTracker(metaclass=VariableTrackerMeta):
             raise NotImplementedError(f"{self} has no type") from None
 
     def python_type_name(self) -> str:
+        if self.tp_name is not None:
+            return self.tp_name
         try:
             return self.python_type().__name__
         except NotImplementedError:
@@ -571,6 +577,9 @@ class VariableTracker(metaclass=VariableTrackerMeta):
 
     def const_getattr(self, tx: InstructionTranslatorBase, name: str) -> Any:
         """getattr(self, name) returning a python constant"""
+        # An instance's `__doc__` resolves to its type's tp_doc in CPython.
+        if name == "__doc__" and self.tp_doc is not None:
+            return self.tp_doc
         raise NotImplementedError
 
     def is_symnode_like(self) -> bool:

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -99,6 +99,7 @@ def _is_set_or_dictview(obj: VariableTracker) -> bool:
 class ConstDictVariable(VariableTracker):
     # PyDict_Type: https://github.com/python/cpython/blob/v3.13.0/Objects/dictobject.c#L4825
     _cpython_type = dict
+    tp_name = "dict"
 
     CONTAINS_GUARD = GuardBuilder.DICT_CONTAINS
     NOT_CONTAINS_GUARD = GuardBuilder.DICT_NOT_CONTAINS
@@ -855,6 +856,7 @@ class OrderedItemsDictVariable(ConstDictVariable):
     # (via _cpython_type) provides move_to_end / popitem(last=), and reconstruct
     # emits `OrderedDict(...)` rather than a bare dict literal.
     _cpython_type = collections.OrderedDict
+    tp_name = "OrderedDict"
 
     def reconstruct(self, codegen: "PyCodegen") -> None:
         # emit `OrderedDict(constructed_dict)`

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -476,9 +476,9 @@ class BaseUserFunctionVariable(VariableTracker):
 
         # missing: __globals__, __closure__, __kwdefautls__, __defaults__
         if name in ("__name__", "__qualname__", "__doc__", "__module__", "__code__"):
-            val = getattr(self, f"get_{name[2:-2]}")()
             if fn_dict.contains(name):
                 return fn_dict.getitem(name)
+            val = getattr(self, f"get_{name[2:-2]}")()
             return ConstantVariable.create(
                 val, source=self.source and AttrSource(self.source, name)
             )

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -1047,6 +1047,7 @@ class CommonListMethodsVariable(BaseListVariable):
 class ListVariable(CommonListMethodsVariable):
     # PyList_Type: https://github.com/python/cpython/blob/v3.13.0/Objects/listobject.c#L3776
     _cpython_type = list
+    tp_name = "list"
     _has_instance_dict = False
 
     def richcompare_impl(
@@ -1687,6 +1688,7 @@ class DequeVariable(CommonListMethodsVariable):
 class TupleVariable(BaseListVariable):
     # PyTuple_Type: https://github.com/python/cpython/blob/v3.13.0/Objects/tupleobject.c#L846
     _cpython_type = tuple
+    tp_name = "tuple"
 
     def richcompare_impl(
         self,
@@ -1783,6 +1785,7 @@ class SizeVariable(TupleVariable):
     """torch.Size(...)"""
 
     _cpython_type = torch.Size
+    tp_name = "Size"
 
     _nonvar_fields = {
         "proxy",

--- a/torch/_dynamo/variables/sets.py
+++ b/torch/_dynamo/variables/sets.py
@@ -84,6 +84,7 @@ class SetVariable(VariableTracker):
 
     # PySet_Type: https://github.com/python/cpython/blob/v3.13.0/Objects/setobject.c#L2436
     _cpython_type = set
+    tp_name = "set"
 
     CONTAINS_GUARD = GuardBuilder.SET_CONTAINS
     NOT_CONTAINS_GUARD = GuardBuilder.SET_NOT_CONTAINS
@@ -806,6 +807,8 @@ class OrderedSetClassVariable(VariableTracker):
 
 
 class OrderedSetVariable(SetVariable):
+    tp_name = "OrderedSet"
+
     def debug_repr(self) -> str:
         if not self.items:
             return "OrderedSet([])"
@@ -888,6 +891,7 @@ class OrderedSetVariable(SetVariable):
 class FrozensetVariable(SetVariable):
     # PyFrozenSet_Type: https://github.com/python/cpython/blob/v3.13.0/Objects/setobject.c#L2526
     _cpython_type = frozenset
+    tp_name = "frozenset"
 
     nb_inplace_subtract_impl = None  # type: ignore[bad-override]
 
@@ -996,6 +1000,8 @@ class FrozensetVariable(SetVariable):
 
 
 class DictKeySetVariable(SetVariable):
+    tp_name = "dict_keys"
+
     def debug_repr(self) -> str:
         if not self.items:
             return "dict_keys([])"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

Adds tp_name and tp_doc class slots on VariableTracker, analogous to CPython's
tp_name / tp_doc slots on PyTypeObject. They describe the type a VT represents:
tp_name backs python_type_name() and tp_doc backs `__doc__` reads (in CPython
an instance's `__doc__` resolves to its type's tp_doc). Both default to None,
meaning "derive from python_type()", so unmigrated VTs are unchanged.

These are deliberately type-level, not per-instance. Instance names that user
code mutates -- e.g. a function object's __name__ via functools.wraps -- are a
separate mechanism (get_name() plus the instance __dict__ / SideEffects) and
are left untouched.

tp_name is declared on the canonical builtin VTs (list, tuple, Size, set,
frozenset, OrderedSet, dict_keys, dict, OrderedDict). Each value equals what
python_type().__name__ already returned, so this is a declarative no-op there.

Also reorders BaseUserFunctionVariable.getattro_impl for __name__ / __doc__ /
__module__ / __qualname__ / __code__ to check the instance __dict__ before
computing the code-object default. A functools.wraps/partial override should
win, and computing the default first could raise (e.g. get_module() on a
function with no globals) and shadow a valid override.

Tests live in test/dynamo/test_tp_slots.py: tp_name matches python_type_name()
for each builtin VT, the base slots default to None, a dynamic VT
(UserDefinedObjectVariable) derives its name from python_type(), and tp_doc
backs __doc__ via const_getattr.

This was authored with the assistance of Claude Code.

Test Plan:
```
pixi run -w pytorch -e pytorch310 python test/dynamo/test_tp_slots.py
pixi run -w pytorch -e pytorch310 python test/dynamo/test_functions.py
pixi run -w pytorch -e pytorch310 python test/dynamo/test_dicts.py
pixi run -w pytorch -e pytorch310 python test/dynamo/test_misc.py
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98