### PR TITLE
Fix pointless_cumsum_replacement dropping cumsum's explicit dtype

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -937,7 +937,12 @@ class TestPatternMatcher(TestCase):
             x = torch.full([10, 10], True, dtype=torch.int32)
             return torch.cumsum(x, 1)
 
-        for fn in (fn1, fn2, fn3, fn4, fn5, fn6):
+        def fn7():
+            # explicit dtype= must be honored, not the input full()'s dtype
+            x = torch.full([2, 4, 4], 1, dtype=torch.bool)
+            return torch.cumsum(x, 1, dtype=torch.bfloat16)
+
+        for fn in (fn1, fn2, fn3, fn4, fn5, fn6, fn7):
             result, (code,) = run_and_get_code(torch.compile(fn, fullgraph=True))
             self.assertNotIn("aten.cumsum", code)
             self.assertEqual(result, fn())

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -1015,7 +1015,12 @@ def mm_plus_mm(match: Match, mat1, mat2, mat3, mat4):
 def pointless_cumsum_replacement(match: Match, shape, fill_value, device, dtype, dim):
     """Based on a pattern in OPTForCausalLM"""
 
-    if is_integer_dtype(dtype) or is_boolean_dtype(dtype):
+    # An explicit dtype= on cumsum overrides the input dtype (and the int64
+    # promotion below); the pattern only captures the input full()'s dtype.
+    explicit_dtype = match.output_node().kwargs.get("dtype")
+    if explicit_dtype is not None:
+        dtype = explicit_dtype
+    elif is_integer_dtype(dtype) or is_boolean_dtype(dtype):
         # cumsum promotes all integral types to int64
         dtype = torch.int64
 


### PR DESCRIPTION
### Summary

The inductor post-grad pattern `pointless_cumsum_replacement`
(`torch/_inductor/fx_passes/post_grad.py`) matches `cumsum(full(...))` and
rewrites it into an `arange`-based expression. The pattern captures the input
`full()`'s dtype but **not** the `dtype=` keyword passed to `cumsum`, so an
explicit dtype was silently dropped — bool/integer inputs were promoted to
`int64` even when `cumsum` was asked for e.g. `bfloat16`, producing a compiled
result whose dtype disagrees with eager.

```python
import torch

def f():
    ones = torch.ones((2, 4, 4), dtype=torch.bool)
    return ones.cumsum(1, dtype=torch.bfloat16)

print(f().dtype)                    # torch.bfloat16
print(torch.compile(f)().dtype)     # torch.int64  <- wrong (before this PR)
```

This is a silent-correctness bug. The HuggingFace DETR-family sine position
embeddings build a tensor with exactly this construct, so every model in that
family (DETR, Sam2/Sam3, MaskFormer, ...) crashes under `torch.compile` in
fp16/bf16 with `mat1 and mat2 must have the same dtype`.

### Fix

Read the explicit dtype off the matched `cumsum` node and honor it over the
input dtype (and the `int64` promotion). Reading it from the node — rather than
adding a pattern `KeywordArg` — keeps the common no-dtype path (the original
`OPTForCausalLM` pattern) matching, since that kwarg is absent there.

Fixes #189518

### Test plan

Extended `test_pointless_cumsum` in `test/inductor/test_pattern_matcher.py`
with an explicit-dtype case (`fn7`), which fails before this change (compiled
`int64` vs eager `bfloat16`) and passes after, with the pattern still applied:

```
python test/inductor/test_pattern_matcher.py -k test_pointless_cumsum
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo