### PR TITLE
Fix multilabel_margin_loss decomposition for -1 padded targets

### DIFF
--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -5775,6 +5775,8 @@ def multilabel_margin_loss_forward(
     z = z / dim
     # masks loss
     z = torch.where(is_target, 0, z)
+    # drops contributions from padded target slots (positions at/after the first -1)
+    z = torch.where(target_mask.T.unsqueeze(dim=-1), z, 0)
     # reduction
     if reduction == Reduction.MEAN.value:
         z = z.sum(dim=(0, -1)).mean()

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -1695,6 +1695,7 @@ def reference_inputs_like_fns(op, device, dtype, requires_grad, **kwargs):
 def sample_inputs_multilabel_margin_loss(op_info, device, dtype, requires_grad, **kwargs):
     _make_tensor = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)
     make_target = partial(_make_tensor, dtype=torch.long, requires_grad=False)
+    make_target_tensor = partial(torch.tensor, device=device, dtype=torch.long, requires_grad=False)
 
     inputs = (
         ([], make_target([], low=0, high=1), {}),
@@ -1703,6 +1704,8 @@ def sample_inputs_multilabel_margin_loss(op_info, device, dtype, requires_grad, 
         ([M, S], make_target([M, S], low=0, high=S), {"reduction": "none"}),
         ([M, S], make_target([M, S], low=0, high=S), {"reduction": "mean"}),
         ([M, S], make_target([M, S], low=0, high=S), {"reduction": "sum"}),
+        # labels after the first -1 are ignored; exercises the padded-slot path
+        ([5], make_target_tensor([0, 1, -1, -1, -1]), {}),
     )
 
     for shape, target, kwargs in inputs:


### PR DESCRIPTION
### Summary

The `multilabel_margin_loss` forward decomposition
(`torch/_decomp/decompositions.py`) masks the loss along the input axis (via
`is_target`), but never drops the "u-slots" coming from padded target positions
(indices at or after the first `-1`). When the target contains `-1` padding —
the standard ignore marker — those slots gather `input[0]` and contribute
spurious margin terms, so the compiled forward loss and backward gradient
disagree with eager.

```python
import torch
import torch.nn.functional as F

x = torch.tensor([[1.0, -1.0, 0.5, 0.3, -0.2]], requires_grad=True)
target = torch.tensor([[0, 1, -1, -1, -1]])

loss = F.multilabel_margin_loss(x, target)           # eager: 1.48
loss_c = torch.compile(lambda z: F.multilabel_margin_loss(z, target))(x)  # 1.96 before this PR
```

Both `inductor` and `aot_eager` are affected, confirming the bug is in the
decomposition rather than a lowering.

### Fix

The gather-safe mask (`target_mask`) that builds `tidx0`/`tidx1` already
identifies the real target positions; apply that same mask to the loss on the
u-slot axis so padded slots contribute nothing. When no `-1` is present
`target_mask` is all-`True`, so this is a no-op for the unpadded case.

The decomposition test did not catch this because
`sample_inputs_multilabel_margin_loss` only generates targets with `low=0` (no
`-1`); this PR adds a padded-target sample so `test_decomp` exercises the path.
(`reference_inputs` already covers `-1`, but those inputs are not used by the
decomposition test.)

Fixes #185464

### Test plan

Compared the decomposition (`aot_eager`) against eager on CPU over 900 random
cases spanning all reductions, batched and 1-D inputs, and targets with and
without `-1` padding — forward loss and input gradient matched in every case.

```
python test/test_decomp.py -k multilabel_margin_loss
```