### PR TITLE
[dynamo] Route list/tuple __add__ through slot wrappers

### DIFF
--- a/test/dynamo/test_sequence_ops.py
+++ b/test/dynamo/test_sequence_ops.py
@@ -294,6 +294,39 @@ class TestSqConcat(torch._dynamo.test_case.TestCase):
         # Result respects maxlen of 3
         self.assertEqual(list(d), [2, 3, 4])
 
+    # --- Inplace deque repeat (*=) ---
+
+    @make_dynamo_test
+    def test_deque_inplace_repeat(self):
+        d = collections.deque([1, 2])
+        d *= 3
+        self.assertEqual(list(d), [1, 2, 1, 2, 1, 2])
+
+    @make_dynamo_test
+    def test_deque_inplace_repeat_with_maxlen(self):
+        d = collections.deque([1, 2], maxlen=3)
+        d *= 3
+        # A bounded deque keeps the last maxlen items after repeating.
+        self.assertEqual(list(d), [2, 1, 2])
+
+    @make_dynamo_test
+    def test_deque_inplace_repeat_maxlen_zero(self):
+        d = collections.deque([1, 2], maxlen=0)
+        d *= 3
+        self.assertEqual(list(d), [])
+
+    @make_dynamo_test
+    def test_deque_inplace_repeat_zero(self):
+        d = collections.deque([1, 2, 3])
+        d *= 0
+        self.assertEqual(list(d), [])
+
+    @make_dynamo_test
+    def test_deque_inplace_repeat_negative(self):
+        d = collections.deque([1, 2, 3])
+        d *= -1
+        self.assertEqual(list(d), [])
+
     # --- list re-init (list.__init__) ---
 
     @make_dynamo_test

--- a/test/dynamo/test_tp_slots.py
+++ b/test/dynamo/test_tp_slots.py
@@ -11,6 +11,7 @@ import collections.abc
 import dataclasses
 import enum
 
+import torch
 from torch._C._dynamo import (
     get_type_slots,
     has_slot,
@@ -20,6 +21,16 @@ from torch._C._dynamo import (
     PyTypeSlots,
 )
 from torch._dynamo.test_case import run_tests, TestCase
+from torch._dynamo.variables.base import VariableTracker
+from torch._dynamo.variables.dicts import ConstDictVariable
+from torch._dynamo.variables.lists import (
+    DequeVariable,
+    ListVariable,
+    RangeVariable,
+    SizeVariable,
+    TupleVariable,
+)
+from torch._dynamo.variables.sets import FrozensetVariable, SetVariable
 
 
 class TestTypeSlots(TestCase):
@@ -321,6 +332,85 @@ class TestTypeSlots(TestCase):
                 has_slot(map_slots, PyMappingSlots.MP_SUBSCRIPT),
                 f"{t.__name__} should have mp_subscript",
             )
+
+
+class TestSlotImplConformance(TestCase):
+    """Every C-level sq/mp/nb slot a container type fills must have a matching
+    ``*_impl`` override on its VariableTracker.
+
+    Operator dispatch reads slot presence from the real CPython type
+    (``get_type_slots``) and then calls the VT's ``*_impl``. If the type fills a
+    slot the VT never overrides, dispatch silently falls through to the base
+    graph-break default (see ``VariableTracker.sq_*_impl`` / ``nb_*_impl``). This
+    test turns that latent gap into a hard failure at test time.
+    """
+
+    # Concrete container types with a 1:1 VariableTracker. Value-polymorphic VTs
+    # (ConstantVariable, TensorVariable) dispatch by value rather than per-slot
+    # overrides and are out of scope.
+    TYPE_TO_VT = {
+        list: ListVariable,
+        tuple: TupleVariable,
+        range: RangeVariable,
+        collections.deque: DequeVariable,
+        torch.Size: SizeVariable,
+        dict: ConstDictVariable,
+        set: SetVariable,
+        frozenset: FrozensetVariable,
+    }
+
+    # Slot names that do not follow the ``<slot>_impl`` convention.
+    _NO_IMPL_SUFFIX = {"SQ_LENGTH", "MP_LENGTH", "SQ_CONTAINS"}
+
+    # (python_type, method) pairs exempt from the override requirement, with the
+    # reason dispatch does not need a dedicated override.
+    _EXEMPT = {
+        # These types fill both sq_length and mp_length (CPython compat); length
+        # dispatch uses sq_length, which they do override.
+        (list, "mp_length"): "uses sq_length",
+        (tuple, "mp_length"): "uses sq_length",
+        (range, "mp_length"): "uses sq_length",
+        (torch.Size, "mp_length"): "uses sq_length",
+        # bool() dispatches via generic_bool, not a per-slot nb_bool_impl.
+        (range, "nb_bool_impl"): "bool() via generic_bool",
+    }
+
+    _GROUPS = (
+        (PySequenceSlots, 0),
+        (PyMappingSlots, 1),
+        (PyNumberSlots, 2),
+    )
+
+    @classmethod
+    def _slot_method(cls, member):
+        name = member.name.lower()
+        return name if member.name in cls._NO_IMPL_SUFFIX else name + "_impl"
+
+    @staticmethod
+    def _is_overridden(vt_cls, method):
+        vt_attr = getattr(vt_cls, method, None)
+        base_attr = getattr(VariableTracker, method, None)
+        return vt_attr is not None and vt_attr is not base_attr
+
+    def test_filled_slots_have_impl_override(self):
+        missing = []
+        for py_type, vt_cls in self.TYPE_TO_VT.items():
+            slots = get_type_slots(py_type)
+            for enum_cls, idx in self._GROUPS:
+                bits = slots[idx]
+                for member in enum_cls.__members__.values():
+                    if not has_slot(bits, member):
+                        continue
+                    method = self._slot_method(member)
+                    if (py_type, method) in self._EXEMPT:
+                        continue
+                    if not self._is_overridden(vt_cls, method):
+                        missing.append(
+                            f"{py_type.__name__}/{vt_cls.__name__}: "
+                            f"fills {enum_cls.__name__}.{member.name} but "
+                            f"{vt_cls.__name__} does not override {method}"
+                        )
+        self.assertEqual(missing, [], "\n".join(missing))
 
 
 if __name__ == "__main__":

--- a/test/dynamo/test_tp_slots.py
+++ b/test/dynamo/test_tp_slots.py
@@ -11,7 +11,6 @@ import collections.abc
 import dataclasses
 import enum
 
-import torch
 from torch._C._dynamo import (
     get_type_slots,
     has_slot,
@@ -21,16 +20,6 @@ from torch._C._dynamo import (
     PyTypeSlots,
 )
 from torch._dynamo.test_case import run_tests, TestCase
-from torch._dynamo.variables.base import VariableTracker
-from torch._dynamo.variables.dicts import ConstDictVariable
-from torch._dynamo.variables.lists import (
-    DequeVariable,
-    ListVariable,
-    RangeVariable,
-    SizeVariable,
-    TupleVariable,
-)
-from torch._dynamo.variables.sets import FrozensetVariable, SetVariable
 
 
 class TestTypeSlots(TestCase):
@@ -332,85 +321,6 @@ class TestTypeSlots(TestCase):
                 has_slot(map_slots, PyMappingSlots.MP_SUBSCRIPT),
                 f"{t.__name__} should have mp_subscript",
             )
-
-
-class TestSlotImplConformance(TestCase):
-    """Every C-level sq/mp/nb slot a container type fills must have a matching
-    ``*_impl`` override on its VariableTracker.
-
-    Operator dispatch reads slot presence from the real CPython type
-    (``get_type_slots``) and then calls the VT's ``*_impl``. If the type fills a
-    slot the VT never overrides, dispatch silently falls through to the base
-    graph-break default (see ``VariableTracker.sq_*_impl`` / ``nb_*_impl``). This
-    test turns that latent gap into a hard failure at test time.
-    """
-
-    # Concrete container types with a 1:1 VariableTracker. Value-polymorphic VTs
-    # (ConstantVariable, TensorVariable) dispatch by value rather than per-slot
-    # overrides and are out of scope.
-    TYPE_TO_VT = {
-        list: ListVariable,
-        tuple: TupleVariable,
-        range: RangeVariable,
-        collections.deque: DequeVariable,
-        torch.Size: SizeVariable,
-        dict: ConstDictVariable,
-        set: SetVariable,
-        frozenset: FrozensetVariable,
-    }
-
-    # Slot names that do not follow the ``<slot>_impl`` convention.
-    _NO_IMPL_SUFFIX = {"SQ_LENGTH", "MP_LENGTH", "SQ_CONTAINS"}
-
-    # (python_type, method) pairs exempt from the override requirement, with the
-    # reason dispatch does not need a dedicated override.
-    _EXEMPT = {
-        # These types fill both sq_length and mp_length (CPython compat); length
-        # dispatch uses sq_length, which they do override.
-        (list, "mp_length"): "uses sq_length",
-        (tuple, "mp_length"): "uses sq_length",
-        (range, "mp_length"): "uses sq_length",
-        (torch.Size, "mp_length"): "uses sq_length",
-        # bool() dispatches via generic_bool, not a per-slot nb_bool_impl.
-        (range, "nb_bool_impl"): "bool() via generic_bool",
-    }
-
-    _GROUPS = (
-        (PySequenceSlots, 0),
-        (PyMappingSlots, 1),
-        (PyNumberSlots, 2),
-    )
-
-    @classmethod
-    def _slot_method(cls, member):
-        name = member.name.lower()
-        return name if member.name in cls._NO_IMPL_SUFFIX else name + "_impl"
-
-    @staticmethod
-    def _is_overridden(vt_cls, method):
-        vt_attr = getattr(vt_cls, method, None)
-        base_attr = getattr(VariableTracker, method, None)
-        return vt_attr is not None and vt_attr is not base_attr
-
-    def test_filled_slots_have_impl_override(self):
-        missing = []
-        for py_type, vt_cls in self.TYPE_TO_VT.items():
-            slots = get_type_slots(py_type)
-            for enum_cls, idx in self._GROUPS:
-                bits = slots[idx]
-                for member in enum_cls.__members__.values():
-                    if not has_slot(bits, member):
-                        continue
-                    method = self._slot_method(member)
-                    if (py_type, method) in self._EXEMPT:
-                        continue
-                    if not self._is_overridden(vt_cls, method):
-                        missing.append(
-                            f"{py_type.__name__}/{vt_cls.__name__}: "
-                            f"fills {enum_cls.__name__}.{member.name} but "
-                            f"{vt_cls.__name__} does not override {method}"
-                        )
-        self.assertEqual(missing, [], "\n".join(missing))
 
 
 if __name__ == "__main__":

--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -1087,15 +1087,20 @@ class VariableTracker(metaclass=VariableTrackerMeta):
             from .object_protocol import generic_hash
 
             return generic_hash(tx, self)
-        elif name == "__add__":
-            # ref: https://github.com/python/cpython/blob/3.13/Objects/typeobject.c#L10231-L10233
-            #      https://github.com/python/cpython/blob/3.13/Objects/typeobject.c#L8551-L8561
-            return self.nb_add_impl(tx, args[0])
-        elif name == "__radd__":
-            # ref: https://github.com/python/cpython/blob/3.13/Objects/typeobject.c#L8563-L8573
-            return self.nb_add_impl(tx, args[0], reverse=True)
-        elif name == "__iadd__":
-            return self.nb_inplace_add_impl(tx, args[0])
+        elif name in ("__add__", "__radd__", "__iadd__"):
+            if kwargs or len(args) != 1:
+                raise_observed_exception(
+                    TypeError,
+                    tx,
+                    args=[f"expected 1 argument, got {len(args)}"],
+                )
+            from .object_protocol import slot_wrapper_add, slot_wrapper_iadd
+
+            if name == "__add__":
+                return slot_wrapper_add(tx, self, args[0])
+            if name == "__radd__":
+                return slot_wrapper_add(tx, self, args[0], reverse=True)
+            return slot_wrapper_iadd(tx, self, args[0])
         elif name == "__sub__":
             # ref: https://github.com/python/cpython/blob/3.13/Objects/typeobject.c#L10231-L10233
             #      https://github.com/python/cpython/blob/3.13/Objects/typeobject.c#L8551-L8561

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -96,11 +96,13 @@ from .object_protocol import (
     binary_iop,
     binary_op,
     generic_abs,
+    generic_add,
     generic_bool,
     generic_float,
     generic_getattr,
     generic_getiter,
     generic_hash,
+    generic_inplace_add,
     generic_inplace_multiply,
     generic_int,
     generic_invert,
@@ -117,10 +119,8 @@ from .object_protocol import (
     ternary_op,
     type_implements_mp_length,
     type_implements_sq_length,
-    vt_add,
     vt_getitem,
     vt_identity_compare,
-    vt_inplace_add,
 )
 from .sets import FrozensetVariable, SetVariable
 from .tensor import (
@@ -2797,12 +2797,12 @@ class BuiltinVariable(BaseBuiltinVariable):
     def call_add(
         self, tx: "InstructionTranslatorBase", a: VariableTracker, b: VariableTracker
     ) -> VariableTracker | None:
-        return vt_add(tx, a, b)
+        return generic_add(tx, a, b)
 
     def call_iadd(
         self, tx: "InstructionTranslatorBase", a: VariableTracker, b: VariableTracker
     ) -> VariableTracker | None:
-        return vt_inplace_add(tx, a, b)
+        return generic_inplace_add(tx, a, b)
 
     def call_and_(
         self, tx: "InstructionTranslatorBase", a: VariableTracker, b: VariableTracker

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -497,24 +497,6 @@ class BaseListVariable(VariableTracker):
                 [self, args[0]],
                 kwargs,
             )
-        elif name == "__add__":
-            if kwargs or len(args) != 1:
-                raise_args_mismatch(
-                    tx,
-                    name,
-                    "1 args and 0 kwargs",
-                    f"{len(args)} args and {len(kwargs)} kwargs",
-                )
-            return self.sq_concat_impl(tx, args[0])
-        elif name == "__iadd__":
-            if kwargs or len(args) != 1:
-                raise_args_mismatch(
-                    tx,
-                    name,
-                    "1 args and 0 kwargs",
-                    f"{len(args)} args and {len(kwargs)} kwargs",
-                )
-            return self.sq_inplace_concat_impl(tx, args[0])
         elif name == "__reversed__":
             # list/tuple/namedtuple __reversed__: reverse iterator over items.
             if args or kwargs:
@@ -1488,6 +1470,31 @@ class DequeVariable(CommonListMethodsVariable):
         # Implements PySequence_InPlaceConcat for deque
         # ref: https://github.com/python/cpython/blob/v3.13.0/Modules/_collectionsmodule.c#L572-L584
         self.call_method(tx, "extend", [other], {})
+        return self
+
+    def sq_inplace_repeat_impl(
+        self,
+        tx: "InstructionTranslatorBase",
+        count: VariableTracker,
+    ) -> VariableTracker:
+        # deque_inplace_repeat: https://github.com/python/cpython/blob/v3.13.0/Modules/_collectionsmodule.c#L811
+        if not self.is_mutable():
+            raise AssertionError(
+                f"sq_inplace_repeat_impl reached an immutable {type(self).__name__}; "
+                "every construction site should set mutation_type."
+            )
+        n = count.as_python_constant()
+        try:
+            new_items = self.items * n
+        except (MemoryError, OverflowError) as e:
+            raise_observed_exception(type(e), tx, args=list(e.args))
+        # A bounded deque drops from the left, keeping the last maxlen items
+        # (maxlen == 0 yields an empty deque).
+        maxlen = self.maxlen.as_python_constant()
+        if maxlen is not None:
+            new_items = new_items[-maxlen:] if maxlen else new_items[:0]
+        tx.output.side_effects.mutation(self)
+        self.items[:] = new_items
         return self
 
     def debug_repr(self) -> str:

--- a/torch/_dynamo/variables/object_protocol.py
+++ b/torch/_dynamo/variables/object_protocol.py
@@ -628,7 +628,7 @@ def sequence_delitem(
             if idx < 0:
                 if type_implements_sq_length(s_type):
                     length = s.sq_length(tx)
-                    i = vt_add(tx, i, length)
+                    i = generic_add(tx, i, length)
         return s.sq_ass_item_impl(tx, i, None)
 
     if type_implements_mp_ass_subscript(s_type):
@@ -1259,7 +1259,7 @@ def binary_iop(
 
 
 # add / inplace add needs special handling
-def vt_add(
+def generic_add(
     tx: "InstructionTranslatorBase",
     v: VariableTracker,
     w: VariableTracker,
@@ -1276,7 +1276,7 @@ def vt_add(
     binop_type_error(tx, v, w, "+")
 
 
-def vt_inplace_add(
+def generic_inplace_add(
     tx: "InstructionTranslatorBase",
     v: VariableTracker,
     w: VariableTracker,
@@ -1505,6 +1505,58 @@ def slot_wrapper_imul(
     if type_implements_sq_inplace_repeat(self_type):
         return sequence_inplace_repeat(tx, self, other)
     return slot_wrapper_mul(tx, self, other)
+
+
+# ---------------------------------------------------------------------------
+# Type-object slot wrappers for ``__add__`` / ``__radd__`` / ``__iadd__``
+
+#   BINSLOT (__add__,  nb_add,      slot_nb_add, "+")           [typeobject.c L10915]
+#   RBINSLOT(__radd__, nb_add,      slot_nb_add, "+")           [L10917]
+#   SQSLOT  (__add__,  sq_concat,   NULL, wrap_binaryfunc)      [L11017]
+#   IBSLOT  (__iadd__, nb_inplace_add, ...)                     [L10960]
+#   SQSLOT  (__iadd__, sq_inplace_concat, NULL, ...)            [L11031]
+#
+# Distinct from ``generic_add`` / ``generic_inplace_add``, which mirror the
+# operator-level ``PyNumber_Add`` (cross-operand priority, sq_concat fallback).
+# ---------------------------------------------------------------------------
+
+
+def slot_wrapper_add(
+    tx: "InstructionTranslatorBase",
+    self: VariableTracker,
+    other: VariableTracker,
+    reverse: bool = False,
+) -> VariableTracker:
+    """``self.__add__(other)`` / ``self.__radd__(other)`` slot wrapper."""
+    self_type = maybe_get_python_type(self)
+    if type_implements_nb_add(self_type):
+        return self.nb_add_impl(tx, other, reverse=reverse)
+    # No SQSLOT(__radd__): sq_concat backs only the forward __add__.
+    if not reverse and type_implements_sq_concat(self_type):
+        return self.sq_concat_impl(tx, other)
+    raise_type_error(
+        tx,
+        f"unsupported operand type(s) for +: "
+        f"'{self.python_type_name()}' and '{other.python_type_name()}'",
+    )
+
+
+def slot_wrapper_iadd(
+    tx: "InstructionTranslatorBase",
+    self: VariableTracker,
+    other: VariableTracker,
+) -> VariableTracker:
+    """``self.__iadd__(other)`` slot wrapper.
+
+    Mirrors ``slot_wrapper_imul``: when neither ``nb_inplace_add`` nor
+    ``sq_inplace_concat`` is installed, fall back to the non-inplace slot.
+    """
+    self_type = maybe_get_python_type(self)
+    if type_implements_nb_inplace_add(self_type):
+        return self.nb_inplace_add_impl(tx, other)
+    if type_implements_sq_inplace_concat(self_type):
+        return self.sq_inplace_concat_impl(tx, other)
+    return slot_wrapper_add(tx, self, other)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189554

Dynamo modeled the __add__/__radd__/__iadd__ method calls in two
inconsistent places. BaseListVariable.call_method special-cased __add__
and __iadd__ to reach sq_concat_impl/sq_inplace_concat_impl, because the
generic VariableTracker.call_method routed __add__ straight to
nb_add_impl -- which is wrong for sequences: list.__add__ is the
tp_as_sequence sq_concat slot, not the tp_as_number nb_add slot. This is
the same nb-vs-sq slot duality that __mul__ already handled via
slot_wrapper_mul/slot_wrapper_imul, but __add__ had no equivalent.

This change adds slot_wrapper_add/slot_wrapper_iadd mirroring the mul
wrappers: try nb_add first, fall back to sq_concat (iadd tries the
inplace slots first, then the non-inplace slot). CPython installs both a
BINSLOT(__add__, nb_add) and SQSLOT(__add__, sq_concat), with nb_add
first, so the wrapper checks nb before sq. Unlike __mul__ there is no
SQSLOT(__radd__), so the sq_concat fallback is gated on `not reverse`.
base.py now routes __add__/__radd__/__iadd__ through the wrappers and the
BaseListVariable special-casing is deleted.

To keep the file's naming convention consistent, the operator-level add
helpers vt_add/vt_inplace_add are renamed to generic_add/
generic_inplace_add, matching their generic_multiply siblings. The
convention is now: generic_* mirrors the abstract.c operator algorithm
(PyNumber_Add), slot_wrapper_* mirrors the typeobject.c slotdefs method
wrapper. Only + and * have an nb/sq dual, so no other operator needs this.

While auditing which container VariableTrackers override the *_impl for
each C slot their type fills, DequeVariable turned out to fill
sq_inplace_repeat without a sq_inplace_repeat_impl override, so
`deque *= n` silently graph-broke. Implement it, respecting maxlen (a
bounded deque keeps the last maxlen items after repeating).

Review order: object_protocol.py (rename + new wrappers) -> base.py
(routing) -> lists.py (delete special-case, add deque impl) ->
builtin.py (call-site rename) -> tests.

Test Plan:
```
python test/dynamo/test_nb_operators.py
python test/dynamo/test_nb_multiply.py
python test/dynamo/test_sequence_ops.py
python test/dynamo/test_list.py
python test/dynamo/test_deque_reconstruct.py
```

Authored with the assistance of Claude (an AI assistant).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98