### PR TITLE
Make functorch dim test_split device-generic

### DIFF
--- a/test/functorch/dim/test_split.py
+++ b/test/functorch/dim/test_split.py
@@ -3,7 +3,9 @@ import unittest
 
 import torch
 from functorch.dim import Dim, dims, Tensor
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     run_tests,
     TEST_WITH_TORCHDYNAMO,
     TestCase,
@@ -12,6 +14,8 @@ from torch.testing._internal.common_utils import (
 
 class TestSplit(TestCase):
     """Comprehensive tests for first-class dimension split operations."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def setUp(self):
         super().setUp()
@@ -320,35 +324,6 @@ class TestSplit(TestCase):
             self.assertEqual(part.order(x, split_dims[i], z).shape, (10, 5, 20))
             self.assertEqual(split_dims[i].size, 5)
 
-    def test_device_handling(self):
-        """Test split behavior with different devices."""
-        if torch.cuda.is_available():
-            # Test on CUDA
-            cuda_tensor = torch.randn(3, 12, 5, device="cuda")
-            x, y, z = dims(3)
-            t = cuda_tensor[x, y, z]
-
-            d1, d2 = Dim("d1", 4), Dim("d2", 8)
-            result = t.split([d1, d2], dim=y)
-
-            for i, part in enumerate(result):
-                ordered = part.order(x, d1 if i == 0 else d2, z)
-                self.assertEqual(ordered.device.type, "cuda")
-                self.assertEqual(ordered.shape[0], 3)
-                self.assertEqual(ordered.shape[2], 5)
-
-        # Test on CPU
-        cpu_tensor = torch.randn(3, 12, 5)
-        x, y, z = dims(3)
-        t = cpu_tensor[x, y, z]
-
-        d1, d2 = Dim("d1", 4), Dim("d2", 8)
-        result = t.split([d1, d2], dim=y)
-
-        for i, part in enumerate(result):
-            ordered = part.order(x, d1 if i == 0 else d2, z)
-            self.assertEqual(ordered.device, torch.device("cpu"))
-
     def test_split_preserves_dtype(self):
         """Test that split preserves tensor dtype."""
         for dtype in [torch.float32, torch.float64, torch.int32, torch.int64]:
@@ -463,6 +438,31 @@ class TestSplit(TestCase):
             self.assertTrue(isinstance(part, torch.Tensor))
             self.assertFalse(hasattr(part, "dims"))  # Should be regular tensor
 
+
+class TestSplitDevice(TestCase):
+    """Device-generic tests for split behavior across accelerators."""
+
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def test_device_handling(self, device):
+        """Test split behavior preserves device placement."""
+        tensor = torch.randn(3, 12, 5, device=device)
+        x, y, z = dims(3)
+        t = tensor[x, y, z]
+
+        d1, d2 = Dim("d1", 4), Dim("d2", 8)
+        result = t.split([d1, d2], dim=y)
+
+        for i, part in enumerate(result):
+            ordered = part.order(x, d1 if i == 0 else d2, z)
+            self.assertEqual(ordered.device.type, torch.device(device).type)
+            self.assertEqual(ordered.shape[0], 3)
+            self.assertEqual(ordered.shape[2], 5)
+
+
+instantiate_device_type_tests(
+    TestSplitDevice, globals(), allow_mps=True, allow_xpu=True
+)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/functorch/dim/test_split.py
+++ b/test/functorch/dim/test_split.py
@@ -3,6 +3,7 @@ import unittest
 
 import torch
 from functorch.dim import Dim, dims, Tensor
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     run_tests,
     TEST_WITH_TORCHDYNAMO,
@@ -320,35 +321,6 @@ class TestSplit(TestCase):
             self.assertEqual(part.order(x, split_dims[i], z).shape, (10, 5, 20))
             self.assertEqual(split_dims[i].size, 5)
 
-    def test_device_handling(self):
-        """Test split behavior with different devices."""
-        if torch.cuda.is_available():
-            # Test on CUDA
-            cuda_tensor = torch.randn(3, 12, 5, device="cuda")
-            x, y, z = dims(3)
-            t = cuda_tensor[x, y, z]
-
-            d1, d2 = Dim("d1", 4), Dim("d2", 8)
-            result = t.split([d1, d2], dim=y)
-
-            for i, part in enumerate(result):
-                ordered = part.order(x, d1 if i == 0 else d2, z)
-                self.assertEqual(ordered.device.type, "cuda")
-                self.assertEqual(ordered.shape[0], 3)
-                self.assertEqual(ordered.shape[2], 5)
-
-        # Test on CPU
-        cpu_tensor = torch.randn(3, 12, 5)
-        x, y, z = dims(3)
-        t = cpu_tensor[x, y, z]
-
-        d1, d2 = Dim("d1", 4), Dim("d2", 8)
-        result = t.split([d1, d2], dim=y)
-
-        for i, part in enumerate(result):
-            ordered = part.order(x, d1 if i == 0 else d2, z)
-            self.assertEqual(ordered.device, torch.device("cpu"))
-
     def test_split_preserves_dtype(self):
         """Test that split preserves tensor dtype."""
         for dtype in [torch.float32, torch.float64, torch.int32, torch.int64]:
@@ -463,6 +435,29 @@ class TestSplit(TestCase):
             self.assertTrue(isinstance(part, torch.Tensor))
             self.assertFalse(hasattr(part, "dims"))  # Should be regular tensor
 
+
+class TestSplitDevice(TestCase):
+    """Device-generic tests for split behavior across accelerators."""
+
+    def test_device_handling(self, device):
+        """Test split behavior preserves device placement."""
+        tensor = torch.randn(3, 12, 5, device=device)
+        x, y, z = dims(3)
+        t = tensor[x, y, z]
+
+        d1, d2 = Dim("d1", 4), Dim("d2", 8)
+        result = t.split([d1, d2], dim=y)
+
+        for i, part in enumerate(result):
+            ordered = part.order(x, d1 if i == 0 else d2, z)
+            self.assertEqual(ordered.device.type, torch.device(device).type)
+            self.assertEqual(ordered.shape[0], 3)
+            self.assertEqual(ordered.shape[2], 5)
+
+
+instantiate_device_type_tests(
+    TestSplitDevice, globals(), allow_mps=True, allow_xpu=True
+)
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary
Makes `test/functorch/dim/test_split.py` device-generic (RFC #174469). The single
device-dependent test is moved into a `TestSplitDevice` class run via
`instantiate_device_type_tests(..., allow_mps=True, allow_xpu=True)`; the CPU
first-class-dim tests are untouched.

## Test plan
```
python -m pytest test/functorch/dim/test_split.py -v
```
Verified locally on cpu (24 passed) and mps (23 passed); cuda/xpu via CI.

cc @fffrog

---
This PR was authored with the assistance of an AI coding assistant.
