### PR TITLE
[dynamo,3.14] Guard PyStackRef_DUP and f_executable against null stackrefs

### DIFF
--- a/torch/csrc/dynamo/cpython_defs.c
+++ b/torch/csrc/dynamo/cpython_defs.c
@@ -247,7 +247,11 @@ static void THP_take_ownership(PyFrameObject* f, _PyInterpreterFrame* frame) {
   _PyFrame_Copy(frame, new_frame);
   // _PyFrame_Copy takes the reference to the executable,
   // so we need to restore it.
-  frame->f_executable = PyStackRef_DUP(new_frame->f_executable);
+  if (PyStackRef_IsNull(new_frame->f_executable)) {
+    frame->f_executable = PyStackRef_NULL;
+  } else {
+    frame->f_executable = PyStackRef_DUP(new_frame->f_executable);
+  }
   f->f_frame = new_frame;
   new_frame->owner = FRAME_OWNED_BY_FRAME_OBJECT;
   if (_PyFrame_IsIncomplete(new_frame)) {

--- a/torch/csrc/dynamo/eval_frame.c
+++ b/torch/csrc/dynamo/eval_frame.c
@@ -99,6 +99,9 @@ static PyObject* THPPyInterpreterFrame_f_locals(
 static PyObject* THPPyInterpreterFrame_f_executable(
     THPPyInterpreterFrame* self,
     PyObject* _noargs) {
+  if (PyStackRef_IsNull(self->frame->f_executable)) {
+    Py_RETURN_NONE;
+  }
   return PyStackRef_AsPyObjectNew(self->frame->f_executable);
 }
 #elif IS_PYTHON_3_13_PLUS
@@ -268,7 +271,11 @@ const char* get_frame_name(THP_EVAL_API_FRAME_OBJECT* frame) {
 
 #if IS_PYTHON_3_14_PLUS
 static void dup_obj(_PyStackRef* dst, _PyStackRef src) {
-  *dst = PyStackRef_DUP(src);
+  if (PyStackRef_IsNull(src)) {
+    *dst = PyStackRef_NULL;
+  } else {
+    *dst = PyStackRef_DUP(src);
+  }
 }
 #else
 static void dup_obj(PyObject** dst, PyObject* src) {


### PR DESCRIPTION
In CPython 3.14 (pycore_stackref.h), PyStackRef_DUP(ref) explicitly asserts that the input stackref must not be null:
  https://github.com/python/cpython/blob/main/Include/internal/pycore_stackref.h#L413
  https://github.com/python/cpython/blob/main/Include/internal/pycore_stackref.h#L612

When TorchDynamo copies or initializes CPython interpreter frames in eval_frame.c and cpython_defs.c, several slots in localsplus can be PyStackRef_NULL. Unconditionally calling PyStackRef_DUP(src) or PyStackRef_AsPyObjectNew(src) on those slots violates the CPython 3.14 contract and triggers SIGABRT whenever CPython assertions are enabled (--with-assertions).

Note that PR #163796 removed an older null check in dup_obj:

```
-  if (PyStackRef_IsNull(src)) {
-    *dst = (_PyStackRef){0};
-  } else {
-    *dst = PyStackRef_DUP(src);
-  }
```

That removal occurred because (_PyStackRef){0} (bits == 0) was invalid in CPython free-threading (Py_GIL_DISABLED) builds, where PyStackRef_NULL is defined with bits == 1 (Py_TAG_DEFERRED). However, removing the null check entirely caused PyStackRef_DUP to be called on null stackrefs. I am not sure why upstream CI did not catch this crash; it's possible that `--with-assertions` isn't enabled. In my local testing with asserts enabled, these assertions do fire pretty quickly.

This commit fixes these issues by guarding PyStackRef_DUP and PyStackRef_AsPyObjectNew with PyStackRef_IsNull(src) checks, and assigning PyStackRef_NULL directly.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98