### PR TITLE
[Inductor] Fix lowering logic for uint8 triton storage on devices with sm < 89

### DIFF
--- a/test/inductor/test_fp8.py
+++ b/test/inductor/test_fp8.py
@@ -118,7 +118,7 @@ class TestFP8Types(TestCase):
         import torch._inductor.codegen.triton_utils as triton_utils
         from torch._inductor.graph import GraphLowering
 
-        def force_uint8_storage(dtype, arg_name=None):
+        def force_uint8_storage(dtype, arg_name=None, *, device=None):
             return dtype == torch.float8_e4m3fn and (
                 arg_name is None or arg_name.startswith("in_ptr")
             )

--- a/test/inductor/test_fp8.py
+++ b/test/inductor/test_fp8.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: inductor"]
 
+import contextlib
 import functools
 import unittest
 from unittest import mock
@@ -109,19 +110,52 @@ def _prepare_blockwise_scale(
     return inverse_scale.t()
 
 
+@contextlib.contextmanager
+def _simulate_float8_e4m3fn_uint8_storage():
+    # Make float8_e4m3fn behave as it does on SM < 89, where triton lacks native
+    # fp8 support and inputs are read through uint8 storage
+    import torch._inductor.codegen.triton as triton_codegen
+    import torch._inductor.codegen.triton_utils as triton_utils
+    import torch._inductor.lowering as inductor_lowering
+
+    real_supported = inductor_lowering.is_triton_fp8_dtype_supported
+
+    def force_uint8_storage(dtype, arg_name=None, *, device=None):
+        return dtype == torch.float8_e4m3fn and (
+            arg_name is None or arg_name.startswith("in_ptr")
+        )
+
+    def force_unsupported(dtype, device=None, **kwargs):
+        if dtype == torch.float8_e4m3fn:
+            return False
+        return real_supported(dtype, device, **kwargs)
+
+    with (
+        mock.patch.object(
+            triton_utils,
+            "use_uint8_triton_storage_for_cuda_float8_e4m3fn",
+            force_uint8_storage,
+        ),
+        mock.patch.object(
+            triton_codegen,
+            "use_uint8_triton_storage_for_cuda_float8_e4m3fn",
+            force_uint8_storage,
+        ),
+        mock.patch.object(
+            inductor_lowering,
+            "is_triton_fp8_dtype_supported",
+            force_unsupported,
+        ),
+    ):
+        yield
+
+
 class TestFP8Types(TestCase):
     @onlyCUDA
     @skipIfRocm
     @config.patch({"force_disable_caches": True})
     def test_float8_e4m3fn_uint8_decode_codegen(self, device):
-        import torch._inductor.codegen.triton as triton_codegen
-        import torch._inductor.codegen.triton_utils as triton_utils
         from torch._inductor.graph import GraphLowering
-
-        def force_uint8_storage(dtype, arg_name=None, *, device=None):
-            return dtype == torch.float8_e4m3fn and (
-                arg_name is None or arg_name.startswith("in_ptr")
-            )
 
         def fn(t):
             return t.float()
@@ -135,16 +169,7 @@ class TestFP8Types(TestCase):
             source_codes.append(code)
 
         with (
-            mock.patch.object(
-                triton_utils,
-                "use_uint8_triton_storage_for_cuda_float8_e4m3fn",
-                force_uint8_storage,
-            ),
-            mock.patch.object(
-                triton_codegen,
-                "use_uint8_triton_storage_for_cuda_float8_e4m3fn",
-                force_uint8_storage,
-            ),
+            _simulate_float8_e4m3fn_uint8_storage(),
             mock.patch.object(GraphLowering, "save_output_code", save_output_code),
         ):
             torch._dynamo.reset()
@@ -158,6 +183,22 @@ class TestFP8Types(TestCase):
         self.assertIn("'in_ptr0': '*u8'", code)
         self.assertIn("triton_helpers.fp8e4m3fn_to_float32", code)
         self.assertNotIn("'in_ptr0': '*fp8e4nv'", code)
+
+    @onlyCUDA
+    @skipIfRocm
+    @config.patch({"force_disable_caches": True})
+    def test_float8_e4m3fn_uint8_storage_arithmetic_falls_back(self, device):
+        bits = torch.arange(256, device=device, dtype=torch.uint8)
+        t = bits.view(torch.float8_e4m3fn)
+
+        def fn(x):
+            return x == x
+
+        with _simulate_float8_e4m3fn_uint8_storage():
+            torch._dynamo.reset()
+            actual = torch.compile(fn, fullgraph=True)(t)
+        expected = fn(t)
+        self.assertEqual(actual, expected)
 
     @skipCUDAIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
     @parametrize("float8_dtype", (torch.float8_e4m3fn, torch.float8_e5m2))

--- a/torch/_inductor/codegen/triton_utils.py
+++ b/torch/_inductor/codegen/triton_utils.py
@@ -38,7 +38,10 @@ def should_unwrap_unspec_arg(name: str):
 
 
 def use_uint8_triton_storage_for_cuda_float8_e4m3fn(
-    dtype: torch.dtype, arg_name: str | None = None
+    dtype: torch.dtype,
+    arg_name: str | None = None,
+    *,
+    device: torch.device | None = None,
 ) -> bool:
     # Triton rejects fp8e4nv pointer types before sm89, but eager CUDA can
     # still dequantize float8_e4m3fn values by treating storage as raw bytes.
@@ -47,10 +50,11 @@ def use_uint8_triton_storage_for_cuda_float8_e4m3fn(
     if arg_name is not None and not arg_name.startswith("in_ptr"):
         return False
 
-    try:
-        device = V.graph.get_current_device_or_throw()
-    except AttributeError:
-        return False
+    if device is None:
+        try:
+            device = V.graph.get_current_device_or_throw()
+        except AttributeError:
+            return False
 
     if device.type != "cuda":
         return False

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2737,7 +2737,14 @@ def unsupported_input_tensor(t: torch.Tensor, node=None):
         return True
 
     if not is_triton_fp8_dtype_supported(t.dtype, t.device):
-        return True
+        from .codegen.triton_utils import (
+            use_uint8_triton_storage_for_cuda_float8_e4m3fn,
+        )
+
+        if not use_uint8_triton_storage_for_cuda_float8_e4m3fn(
+            t.dtype, device=t.device
+        ):
+            return True
 
     if t.dtype == torch.float8_e8m0fnu:
         if not node:
@@ -2770,6 +2777,8 @@ def unsupported_output_tensor(t: torch.Tensor, node=None):
     if node is not None and node.target in supported_complex_views and t.is_complex():
         return False
     if unsupported_input_tensor(t, node):
+        return True
+    if not is_triton_fp8_dtype_supported(t.dtype, t.device):
         return True
     return t.is_cpu and config.disable_cpp_codegen
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2746,6 +2746,24 @@ def unsupported_input_tensor(t: torch.Tensor, node=None):
         ):
             return True
 
+        # uint8 storage reinterprets fp8 bytes: allow bitcast, views, memory
+        # movement, and dequant (convert out of fp8)
+        if not node:
+            return True
+        return not (
+            isinstance(node.target, torch._ops.OpOverload)
+            and node.target
+            in (
+                aten.view.dtype,
+                aten.cat.default,
+                aten.clone.default,
+                aten._scaled_mm.default,
+                aten._scaled_mm_v2.default,
+                prims.convert_element_type.default,
+            )
+            or (isinstance(node.target, torch._ops.OpOverload) and is_view(node.target))
+        )
+
     if t.dtype == torch.float8_e8m0fnu:
         if not node:
             return True


### PR DESCRIPTION
`TestFP8TypesCUDA.test_float8_e4m3fn_uint8_decode_codegen_cuda` is failing on devices with sm < 89 because `unsupported_input_tensor` returns `True` when `is_triton_fp8_dtype_supported` is `False`, even though the uint8 conversion path is still valid. This PR allows input tensors to be fp8 if uint8 Triton storage is usable, while still preventing fp8 output tensors. The `device` kwarg is needed to query `use_uint8_triton_storage_for_cuda_float8_e4m3fn` during lowering.


Fixes #189560

Authored with assistance from Codex

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @eqy