### PR TITLE
[MPS] Fix linear backward SIGABRT with 1-D weight

### DIFF
--- a/aten/src/ATen/native/mps/operations/Linear.mm
+++ b/aten/src/ATen/native/mps/operations/Linear.mm
@@ -230,6 +230,11 @@ static Tensor _mps_linear_backward_input(IntArrayRef input_size, const Tensor& g
               "MPS device does not support linear backward for non-float inputs");
 
   const Tensor weight_reshaped = weight.is_contiguous() ? weight : weight.contiguous();
+  // The graph below produces incorrect results for a non-contiguous
+  // grad_output (e.g. the stride-0 expanded gradient coming from
+  // sum().backward()) when the reduction dimension is 1, so make it
+  // contiguous like the weight above.
+  const Tensor grad_output_reshaped = grad_output.is_contiguous() ? grad_output : grad_output.contiguous();
 
   struct CachedGraph : public MPSCachedGraph {
     CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
@@ -238,25 +243,25 @@ static Tensor _mps_linear_backward_input(IntArrayRef input_size, const Tensor& g
     MPSGraphTensor* outputTensor_ = nil;
   };
 
-  Tensor output = at::empty(input_size, grad_output.options());
+  Tensor output = at::empty(input_size, grad_output_reshaped.options());
   TORCH_CHECK(output.is_mps());
-  if (grad_output.numel() == 0) {
+  if (grad_output_reshaped.numel() == 0) {
     return output;
   }
 
   MPSStream* stream = getCurrentMPSStream();
 
   @autoreleasepool {
-    std::string key = "mps_linear_backward_input" + getTensorsStringKey({grad_output, weight_reshaped});
+    std::string key = "mps_linear_backward_input" + getTensorsStringKey({grad_output_reshaped, weight_reshaped});
     auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto* mpsGraph, auto* newCachedGraph) {
       newCachedGraph->weightTensor_ = mpsGraphRankedPlaceHolder(mpsGraph, weight_reshaped);
-      newCachedGraph->gradOutputTensor_ = mpsGraphRankedPlaceHolder(mpsGraph, grad_output);
+      newCachedGraph->gradOutputTensor_ = mpsGraphRankedPlaceHolder(mpsGraph, grad_output_reshaped);
 
       // MPS matrixMultiplication crashes for 5D+ tensors on 14.2.1 with `New volume should match old volume`
       // (https://github.com/pytorch/pytorch/issues/114942), so flatten >4D to 2D first. macOS 27 handles N-D
       // matmul directly and instead crashes the MLIR pass manager on the in-graph reshape -> matmul -> reshape
       // (https://github.com/pytorch/pytorch/issues/187201), so skip the reshape there.
-      bool needReshape = grad_output.dim() > 4 && !is_macos_at_least(MacOSVersion::MACOS_27_0);
+      bool needReshape = grad_output_reshaped.dim() > 4 && !is_macos_at_least(MacOSVersion::MACOS_27_0);
       auto gradOutputTensor = needReshape
           ? [mpsGraph flatten2DTensor:newCachedGraph->gradOutputTensor_ axis:-1 name:nil]
           : newCachedGraph->gradOutputTensor_;
@@ -272,7 +277,7 @@ static Tensor _mps_linear_backward_input(IntArrayRef input_size, const Tensor& g
     });
 
     Placeholder weightPlaceholder = Placeholder(cachedGraph->weightTensor_, weight_reshaped);
-    Placeholder gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_output);
+    Placeholder gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_output_reshaped);
     Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output);
 
     auto feeds = dictionaryFromPlaceholders(weightPlaceholder, gradOutputPlaceholder);
@@ -369,12 +374,25 @@ std::tuple<Tensor, Tensor, Tensor> mps_linear_backward(const Tensor& input,
                                                        const Tensor& grad_output,
                                                        const Tensor& weight,
                                                        std::array<bool, 3> output_mask) {
+  // A 1-D weight contracts away the last input dimension in the forward
+  // (see the unsqueeze/squeeze in _mps_linear), so grad_output arrives
+  // without that dimension. Feeding the raw 1-D tensors into the 2-D
+  // matmul graphs below makes MPSGraph verification abort the process
+  // (issue #187988). Restore the collapsed dimension, run the regular
+  // 2-D backward, and squeeze grad_weight back at the end.
+  const bool is_1d_weight = weight.dim() == 1;
+  const Tensor weight_2d = is_1d_weight ? weight.unsqueeze(0) : weight;
+  const Tensor grad_output_2d = is_1d_weight ? grad_output.unsqueeze(-1) : grad_output;
+
   Tensor grad_input, grad_weight, grad_bias;
   if (output_mask[0]) {
-    grad_input = _mps_linear_backward_input(input.sizes(), grad_output, weight);
+    grad_input = _mps_linear_backward_input(input.sizes(), grad_output_2d, weight_2d);
   }
   if (output_mask[1] || output_mask[2]) {
-    std::tie(grad_weight, grad_bias) = _mps_linear_backward_weights(grad_output, input, weight, output_mask[2]);
+    std::tie(grad_weight, grad_bias) = _mps_linear_backward_weights(grad_output_2d, input, weight_2d, output_mask[2]);
+    if (is_1d_weight) {
+      grad_weight = grad_weight.squeeze(0);
+    }
   }
   return std::tuple<Tensor, Tensor, Tensor>{grad_input, grad_weight, grad_bias};
 }

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1516,6 +1516,31 @@ class TestMPS(TestCaseMPS):
 
         self.assertEqual(linear, linear_mps)
 
+    def test_linear_1d_weight_backward(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/187988
+        # Backward through F.linear with a 1-D weight aborted the process
+        # because the backward graphs were built from the raw 1-D operands.
+        # The batch size must span more than one 16KB page so that a
+        # regression in the non-contiguous grad_output handling (zeros past
+        # the first page) is also detected.
+        def helper(shape):
+            x_cpu = torch.randn(shape, requires_grad=True)
+            w_cpu = torch.randn(shape[-1], requires_grad=True)
+            y_cpu = F.linear(x_cpu, w_cpu)
+            y_cpu.sum().backward()
+
+            x_mps = x_cpu.detach().clone().to('mps').requires_grad_(True)
+            w_mps = w_cpu.detach().clone().to('mps').requires_grad_(True)
+            y_mps = F.linear(x_mps, w_mps)
+            self.assertEqual(y_cpu, y_mps)
+            y_mps.sum().backward()
+
+            self.assertEqual(x_cpu.grad, x_mps.grad, atol=1e-4, rtol=1e-4)
+            self.assertEqual(w_cpu.grad, w_mps.grad, atol=1e-4, rtol=1e-4)
+
+        helper((256, 33))
+        helper((4, 7, 33))
+
     def test_linear_bias(self):
         def helper(bias_shape):
             device = "cpu"


### PR DESCRIPTION
Fixes #187988

## Problem

`F.linear` accepts a 1-D weight. The MPS forward handles it by lifting the weight to 2-D and squeezing the output (see `_mps_linear`), but `mps_linear_backward` fed the raw 1-D weight and 1-D grad_output straight into the 2-D matmul graphs. MPSGraph verification then failed and aborted the entire process with SIGABRT, which cannot be caught from Python:

```
error: 'mps.matmul' op contracting dimensions differ 3840 & 33
MPSGraphExecutable.mm:1484: failed assertion 'original module failed verification'
```

Reproduced on macOS with torch 2.13.0:

```python
x = torch.randn(3840, 33, device="mps", requires_grad=True)
w = torch.randn(33, device="mps", requires_grad=True)
F.linear(x, w).sum().backward()   # SIGABRT
```

## Fix

In `mps_linear_backward`, mirror what the forward does: unsqueeze the weight to `[1, in_features]` and grad_output to `[..., 1]`, run the regular 2-D backward graphs, and squeeze grad_weight back to 1-D.

While validating the fix on device I found that `_mps_linear_backward_input` also returns wrong values (zeros past the first 16KB page) for a non-contiguous grad_output when the reduction dimension is 1. This is reachable today without any 1-D weight:

```python
x = torch.randn(3840, 33, device="mps", requires_grad=True)
w = torch.randn(1, 33, device="mps")
F.linear(x, w).sum().backward()   # x.grad is mostly zeros, silently wrong
```

The unsqueezed grad_output from the 1-D path hits the same condition (the expanded stride-0 gradient that `sum()` produces), so the fix makes grad_output contiguous in `_mps_linear_backward_input`, the same guard the function already applies to the weight.

## Validation

The exact tensor operations the fixed code performs were validated on MPS against CPU reference gradients for shapes `(256, 33)`, `(3840, 33)` and `(4, 7, 33)`, including the stride-0 expanded gradient case. Max error observed was about 1e-5, well within the test tolerances.

Added `test_linear_1d_weight_backward` to `test/test_mps.py` next to the existing forward-only `test_linear_1d_weight`. The batch size 256 spans more than one 16KB page so a regression in the non-contiguous grad_output handling is also caught.