### PR TITLE
[CI] Fix bare runner labels on rocm/cuda build jobs

### DIFF
--- a/.github/workflows/inductor-periodic.yml
+++ b/.github/workflows/inductor-periodic.yml
@@ -88,8 +88,10 @@ jobs:
     uses: ./.github/workflows/_linux-build.yml
     needs: get-default-label-prefix
     with:
+      runner_prefix: "${{ needs.get-default-label-prefix.outputs.label-type }}"
       build-environment: linux-jammy-rocm-py3.10-mi350
       docker-image-name: ci-image:pytorch-linux-jammy-rocm-n-py3-benchmarks
+      ci-docker-hash: ${{ needs.get-default-label-prefix.outputs.ci-docker-hash }}
       test-matrix: |
         { include: [
           { config: "dynamic_inductor_huggingface", shard: 1, num_shards: 1, runner: "${{ needs.get-default-label-prefix.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.1" },

--- a/.github/workflows/operator_microbenchmark.yml
+++ b/.github/workflows/operator_microbenchmark.yml
@@ -113,9 +113,12 @@ jobs:
     if: github.repository_owner == 'pytorch'
     name: opmicrobenchmark-build-rocm
     uses: ./.github/workflows/_linux-build.yml
+    needs: get-label-type
     with:
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       build-environment: linux-jammy-rocm-py3_10
       docker-image-name: ci-image:pytorch-linux-jammy-rocm-n-py3-benchmarks
+      ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
       test-matrix: |
         { include: [
           { config: "operator_microbenchmark_test", shard: 1, num_shards: 1, runner: "linux.rocm.gpu.gfx950.1" },

--- a/.github/workflows/operator_microbenchmark_compare.yml
+++ b/.github/workflows/operator_microbenchmark_compare.yml
@@ -54,9 +54,11 @@ jobs:
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       runner: linux.12xlarge.memory
       build-environment: linux-jammy-cuda12.8-py3.10-gcc11-sm80
       docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc11
+      ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
       cuda-arch-list: '8.0 9.0'
       test-matrix: |
         { include: [
@@ -122,9 +124,12 @@ jobs:
     if: github.repository_owner == 'pytorch' && inputs.gpu == 'MI300X'
     name: build-rocm
     uses: ./.github/workflows/_linux-build.yml
+    needs: get-label-type
     with:
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       build-environment: linux-jammy-rocm-py3_10
       docker-image-name: ci-image:pytorch-linux-jammy-rocm-n-py3-benchmarks
+      ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
       test-matrix: |
         { include: [
           { config: "operator_microbenchmark_${{ inputs.operator }}_test", shard: 1, num_shards: 1, runner: "linux.rocm.gpu.gfx950.1" },


### PR DESCRIPTION
Several build jobs calling `_linux-build.yml` were missing two inputs, which kept them from ever running.

**1. `runner_prefix`.** When unset and no `l-`-prefixed `runner` is passed, `runs-on` resolves to a bare `l-x86iavx512-8-64` (no `mt-`/`lf-` prefix), which no runner ever claims, so the job hangs in `queued`. Observed on `rocm-periodic-dynamo-benchmarks-build` ([stuck run](https://github.com/pytorch/pytorch/actions/runs/29084642565/job/86335412336)). These build machines are ordinary x86 Linux runners (the rocm/cuda distinction only affects test shards), so they now source `runner_prefix` from the determinator's `label-type` output like their siblings; the two rocm jobs with no determinator dependency gain a `needs: get-label-type` edge.

**2. `ci-docker-hash`.** The container image is `.../pytorch/${docker-image-name}${ci-docker-hash && '-'+hash}`, and `docker-builds.yml` only ever pushes `ci-image` tags of the form `<docker-image-name>-<hash>` (`hash = git rev-parse HEAD:.ci/docker`). Jobs that omitted `ci-docker-hash` resolved to the bare, never-pushed tag, so `Initialize containers` couldn't pull the image. For the rocm jobs this was latent until the `runner_prefix` fix let them progress far enough to pull.

I audited every `_linux-build.yml` caller for both problems. The fixed jobs below were the only enabled ones affected:

| File | Job | Fix |
|---|---|---|
| `inductor-periodic.yml` | `rocm-periodic-dynamo-benchmarks-build` | prefix + hash |
| `operator_microbenchmark.yml` | `opmicrobenchmark-build-rocm` | prefix + hash |
| `operator_microbenchmark_compare.yml` | `build-rocm` | prefix + hash |
| `operator_microbenchmark_compare.yml` | `build-cuda` | prefix + hash |

The disabled `vllm.yml` build job (`if: false`, migrating to OSDC) has both gaps but doesn't run, so it's left untouched.

Authored with the assistance of an AI coding assistant.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang