### PR TITLE
[PT2][export] Fix CollectTracepointsPass KeyError for shared @N call-names (#189569)

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -14483,6 +14483,56 @@ graph():
             [("n", "p@1"), ("p", "n@1")],
         )
 
+    def test_preserve_module_call_signature_shared_alias_multicall(self):
+        """Test that CollectTracepointsPass handles a shared submodule reached
+        through an @N-suffixed alias call-name.
+
+        A submodule shared under two attribute paths, preserved under only one
+        and invoked more than once through the other, produces an `alias@N`
+        call-name whose base is absent from the preserved specs. Export must not
+        raise KeyError, and the exported/unflattened modules must match eager.
+        """
+
+        class Leaf(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.w = torch.nn.Parameter(torch.randn(4))
+
+            def forward(self, x):
+                return x + self.w
+
+        class Mid(torch.nn.Module):
+            def __init__(self, leaf):
+                super().__init__()
+                self.leaf = leaf  # alias to the same Leaf object
+
+            def forward(self, x):
+                # invoke the aliased leaf twice -> "mid.leaf" and "mid.leaf@1"
+                return self.leaf(self.leaf(x))
+
+        class Root(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.leaf = Leaf()  # canonical, preserved path
+                self.mid = Mid(self.leaf)  # shares the same object
+
+            def forward(self, x):
+                x = self.leaf(x)  # call via the canonical (preserved) path
+                x = self.mid(x)  # calls via the alias twice
+                return x
+
+        m = Root()
+        inp = (torch.randn(3, 4),)
+        orig = m(*inp)
+
+        # Without the fix this raises `KeyError: 'mid.leaf'` in
+        # CollectTracepointsPass while collecting the aliased call signature.
+        ep = export(m, inp, preserve_module_call_signature=("leaf",))
+        self.assertTrue(torch.allclose(ep.module()(*inp), orig))
+
+        unf = unflatten(ep)
+        self.assertTrue(torch.allclose(unf(*inp), orig))
+
     def test_stack_trace(self):
         class Foo(torch.nn.Module):
             def __init__(self) -> None:

--- a/torch/_export/passes/collect_tracepoints_pass.py
+++ b/torch/_export/passes/collect_tracepoints_pass.py
@@ -110,7 +110,8 @@ class CollectTracepointsPass(PassBase):
                         path = f"{path}@{suffix}"
 
                         call_fqn = f"{fqn}@{suffix}"
-                        if call_fqn not in self.specs:
+                        # Base call-name may not be a preserved key (shared alias).
+                        if fqn in self.specs and call_fqn not in self.specs:
                             self.specs[call_fqn] = copy_sig(self.specs[fqn])
                         fqn = call_fqn
 


### PR DESCRIPTION
Summary:

During `torch.export.export(..., preserve_module_call_signature=...)`, `CollectTracepointsPass` fails with a `KeyError` when a shared submodule is reached through an `N`-suffixed alias call-name. `self.specs` is keyed only by the FQNs that torchrec's `encapsulate_ir_modules` preserved, and that walk dedups a shared module instance to a single canonical FQN; when the same instance is also invoked (>1x) through a different, non-preserved attribute alias, export emits `<name>N` call-names and the `N` branch clones the base signature via an unguarded `self.specs[fqn]`, which misses. It surfaced on APS IR export of `mtml_ctr_inline_cvr_mbl_feed_model` (Wukong) as `KeyError: 'vl_embedding_arch'`.


**Fix**: Clone the alias signature only when the base call-name is a preserved key (`if fqn in self.specs`); otherwise skip the clone and rename to the alias. Skipping is safe: the alias tracepoint records no signature regardless (recording is gated on `fqn == path`). Applied to both the `fbcode` and `xplat` copies.

Test Plan:
Added `test_preserve_module_call_signature_shared_alias_multicall` to `caffe2/test/export/test_export.py` (both `fbcode` and `xplat` copies). It exports a model whose shared submodule is preserved under its canonical path but also invoked twice through a second attribute alias, then asserts the exported and unflattened modules match eager. This drives the exact `N` shared-alias condition through the real `torch.export` -> `CollectTracepointsPass` path (no torchrec needed).

**Unit test:**
```
buck2 test mode/opt //caffe2/test:test_export -- test_preserve_module_call_signature_shared_alias_multicall
```
- Without the fix: Fail  `KeyError: 'mid.leaf'`.
-
https://www.internalfb.com/intern/testinfra/testrun/4503600003860454


**Repro command:**
```
 buck2 run mode/opt   aps_models/ads/ecosystem/tooling/tools/ir:run_export -- --mast-job-name aps-f1104220689-1104261567
```
 - Without the fix: `[POTENTIAL PT2_IR Error] ... KeyError: 'vl_embedding_arch'.`
- With the fix: `Success. Time taken - 368.7 seconds.`

Differential Revision: D111353852


