### PR TITLE
Fix flaky inductor test_filtered_ops_cache: assert cache misses, not wall-clock

### DIFF
--- a/test/inductor/test_cutlass_backend.py
+++ b/test/inductor/test_cutlass_backend.py
@@ -2240,7 +2240,6 @@ class TestCutlassBackend(TestCase):
     @skipXPUIf(not Xe2_Or_Later, "")
     @skipCUDAIf(not SM90OrLater, "need sm_90")
     @xfailIfSM120OrLater
-    @mock.patch.dict(os.environ, {"PATH": _get_path_without_sccache()})
     def test_filtered_ops_cache(self):
         class TestModel(torch.nn.Module):
             def forward(self, B):
@@ -2253,21 +2252,23 @@ class TestCutlassBackend(TestCase):
         B = torch.randn(M, M).to(GPU_TYPE).half()
         model = TestModel().to(GPU_TYPE)
 
-        start_time = time.time()
-        with config.patch(
-            {
-                "max_autotune": True,
-                "max_autotune_gemm_backends": "CUTLASS",
-                "cutlass.cutlass_max_profiling_configs": 1,
-            }
+        counters.clear()
+        with (
+            fresh_cache(),
+            config.patch(
+                {
+                    "max_autotune": True,
+                    "max_autotune_gemm_backends": "CUTLASS",
+                    "cutlass.cutlass_max_profiling_configs": 1,
+                }
+            ),
         ):
             _ = torch.compile(model)(B)
 
-        if GPU_TYPE == "xpu":
-            time_limit = 100
-        else:
-            time_limit = 60
-        self.assertTrue(time.time() - start_time < time_limit)
+        # All 100 matmuls share one input shape/dtype/layout, so they map to a
+        # single filtered-ops cache key: op filtering runs exactly once (one
+        # miss) and the remaining lowerings hit the cache.
+        self.assertEqual(counters["inductor"]["cutlass_filtered_ops_cache_miss"], 1)
 
     @skipXPUIf(not Xe2_Or_Later, "")
     @skipCUDAIf(not SM90OrLater, "need sm_90")

--- a/torch/_inductor/codegen/cutlass/gemm_template.py
+++ b/torch/_inductor/codegen/cutlass/gemm_template.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import torch
 import torch.utils._pytree as pytree
+from torch._dynamo.utils import counters
 from torch._inductor.autotune_process import TensorMeta
 from torch._inductor.codegen.cutlass.cache import maybe_fetch_ops
 from torch._inductor.codegen.wrapper import PythonWrapperCodegen
@@ -1051,6 +1052,8 @@ class CUTLASSGemmTemplate(CUTLASSTemplate, ABC):
         if self.cache_key in self.filtered_ops_cache:
             log.debug("Using cached ops for %s", self.cache_key)
             return self.filtered_ops_cache[self.cache_key]
+
+        counters["inductor"]["cutlass_filtered_ops_cache_miss"] += 1
 
         with dynamo_timed("CUTLASSGemmTemplate.maybe_fetch_ops"):
             maybe_ops = maybe_fetch_ops(self.device_type)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189570

test_filtered_ops_cache verified the CUTLASS filtered-ops cache indirectly by
timing a compile of 100 identical matmuls and asserting it finished under a
fixed wall-clock budget (60s CUDA / 100s XPU). That threshold reacts to CI
machine load, GPU contention, and cold NVCC/CUTLASS compiles rather than to the
cache itself, which made the test flaky.

Replace the timing proxy with a direct signal. gen_ops now bumps a
counters["inductor"]["cutlass_filtered_ops_cache_miss"] counter each time it
actually runs op filtering (the cache-miss path). The 100 matmuls share one
input shape/dtype/layout, so they map to a single cache key: filtering must run
exactly once and the remaining lowerings hit the cache. The test wraps the
compile in fresh_cache() so the class-level cache starts empty, then asserts the
miss counter equals 1. This is also a stronger check -- a cache regression
drives the count toward 100 and fails deterministically instead of merely
slowing the test down.

Test Plan:
buck2 test fbcode//caffe2/test/inductor:cutlass_backend -- test_filtered_ops_cache
passes on SM90 hardware. Lint clean via:
lintrunner -a --take RUFF,PYFMT torch/_inductor/codegen/cutlass/gemm_template.py test/inductor/test_cutlass_backend.py

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo