### PR TITLE
[MPS] Prevent dtype-converting D2H copies from overwriting source

### DIFF
--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -6,7 +6,6 @@
 #include <ATen/native/mps/OperationUtils.h>
 #include <ATen/ops/_copy_from_and_resize_native.h>
 #include <ATen/ops/_copy_from_native.h>
-#include <ATen/ops/empty_strided.h>
 #include <ATen/ops/imag.h>
 #include <ATen/ops/neg.h>
 #include <ATen/ops/real.h>
@@ -137,35 +136,31 @@ static at::Tensor& copy_from_mps_(at::Tensor& dst_, const at::Tensor& src_, bool
     NSUInteger blitSourceOffset = storage_byte_offset;
     bool needsBlit = true;
     if (src_.dtype() != dst.dtype()) {
-      if (destOffset == 0 && storage_byte_offset == 0) {
-        // Return the casted tensor directly if there's no destination offset
-        needsBlit = false;
-        const bool needs_conj = src.is_conj() != dst.is_conj();
-        const bool needs_neg = src.is_neg() != dst.is_neg();
-        const bool fused_conj_neg = needs_conj && needs_neg && c10::isComplexType(src.scalar_type());
-        const std::string_view name = fused_conj_neg ? "copy_conj_neg"
-            : needs_neg                              ? "copy_neg"
-            : needs_conj                             ? "copy_conj"
-                                                     : "copy_identity";
-        lib.exec_unary_kernel_raw(std::string(name),
-                                  sourceBuffer,
-                                  0,
-                                  src.scalar_type(),
-                                  destBuffer,
-                                  0,
-                                  dst.scalar_type(),
-                                  static_cast<uint32_t>(src.numel()),
-                                  /*ilp_threshold=*/0u);
-        if (!non_blocking) {
-          stream->synchronize(SyncType::COMMIT_AND_WAIT);
-        }
-      } else {
-        blitSource = at::empty_strided(dst.sizes(), dst.strides(), src.options().dtype(dst.scalar_type()));
-        blitSource._set_conj(dst.is_conj());
-        blitSource._set_neg(dst.is_neg());
-        copy_cast_kernel_mps(blitSource, src);
-        blitSourceBuffer = getMTLBufferStorage(blitSource);
-        blitSourceOffset = 0;
+      // Unified memory: cast straight from the MPS source into the CPU-wrapped
+      // destination buffer at the requested offsets. This avoids the temporary
+      // that used to alias the live source buffer and blitting from it (see
+      // #189563). src and dst are dense with identical strides here, so a linear
+      // castout of numel elements from the source offset to the dest offset is a
+      // faithful conversion.
+      needsBlit = false;
+      const bool needs_conj = src.is_conj() != dst.is_conj();
+      const bool needs_neg = src.is_neg() != dst.is_neg();
+      const bool fused_conj_neg = needs_conj && needs_neg && c10::isComplexType(src.scalar_type());
+      const std::string_view name = fused_conj_neg ? "copy_conj_neg"
+          : needs_neg                              ? "copy_neg"
+          : needs_conj                             ? "copy_conj"
+                                                   : "copy_identity";
+      lib.exec_unary_kernel_raw(std::string(name),
+                                sourceBuffer,
+                                static_cast<uint32_t>(storage_byte_offset),
+                                src.scalar_type(),
+                                destBuffer,
+                                static_cast<uint32_t>(destOffset),
+                                dst.scalar_type(),
+                                static_cast<uint32_t>(src.numel()),
+                                /*ilp_threshold=*/0u);
+      if (!non_blocking) {
+        stream->synchronize(SyncType::COMMIT_AND_WAIT);
       }
     }
 

--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -6,6 +6,7 @@
 #include <ATen/native/mps/OperationUtils.h>
 #include <ATen/ops/_copy_from_and_resize_native.h>
 #include <ATen/ops/_copy_from_native.h>
+#include <ATen/ops/empty_strided.h>
 #include <ATen/ops/imag.h>
 #include <ATen/ops/neg.h>
 #include <ATen/ops/real.h>
@@ -131,41 +132,40 @@ static at::Tensor& copy_from_mps_(at::Tensor& dst_, const at::Tensor& src_, bool
     // 4 bytes alignment required on macos for blits.
     TORCH_INTERNAL_ASSERT(destOffset % 4 == 0, "Unaligned blit request");
 
-    id<MTLBuffer> maybeCastedSourceBuffer = sourceBuffer;
-    Tensor maybeCastedSource;
+    id<MTLBuffer> blitSourceBuffer = sourceBuffer;
+    Tensor blitSource = src;
+    NSUInteger blitSourceOffset = storage_byte_offset;
     bool needsBlit = true;
     if (src_.dtype() != dst.dtype()) {
-      uint32_t dst_offs_for_cast = 0;
       if (destOffset == 0 && storage_byte_offset == 0) {
         // Return the casted tensor directly if there's no destination offset
         needsBlit = false;
-        maybeCastedSourceBuffer = destBuffer;
-      } else if (src.element_size() < dst.element_size()) {
-        maybeCastedSource = at::empty(dst.sizes(), dst.scalar_type(), std::nullopt, kMPS, std::nullopt, std::nullopt);
-        maybeCastedSourceBuffer = getMTLBufferStorage(maybeCastedSource);
-      }
-
-      // In case of dtype change, first convert src inplace via a Metal castout kernel writing into
-      // maybeCastedSourceBuffer (which may be the wrapped CPU destBuffer, a fresh MPS temp, or
-      // sourceBuffer itself when src.element_size() >= dst.element_size()).
-      const bool needs_conj = src.is_conj() != dst.is_conj();
-      const bool needs_neg = src.is_neg() != dst.is_neg();
-      const bool fused_conj_neg = needs_conj && needs_neg && c10::isComplexType(src.scalar_type());
-      const std::string_view name = fused_conj_neg ? "copy_conj_neg"
-          : needs_neg                              ? "copy_neg"
-          : needs_conj                             ? "copy_conj"
-                                                   : "copy_identity";
-      lib.exec_unary_kernel_raw(std::string(name),
-                                sourceBuffer,
-                                static_cast<uint32_t>(storage_byte_offset),
-                                src.scalar_type(),
-                                maybeCastedSourceBuffer,
-                                dst_offs_for_cast,
-                                dst.scalar_type(),
-                                static_cast<uint32_t>(src.numel()),
-                                /*ilp_threshold=*/0u);
-      if (!non_blocking) {
-        stream->synchronize(SyncType::COMMIT_AND_WAIT);
+        const bool needs_conj = src.is_conj() != dst.is_conj();
+        const bool needs_neg = src.is_neg() != dst.is_neg();
+        const bool fused_conj_neg = needs_conj && needs_neg && c10::isComplexType(src.scalar_type());
+        const std::string_view name = fused_conj_neg ? "copy_conj_neg"
+            : needs_neg                              ? "copy_neg"
+            : needs_conj                             ? "copy_conj"
+                                                     : "copy_identity";
+        lib.exec_unary_kernel_raw(std::string(name),
+                                  sourceBuffer,
+                                  0,
+                                  src.scalar_type(),
+                                  destBuffer,
+                                  0,
+                                  dst.scalar_type(),
+                                  static_cast<uint32_t>(src.numel()),
+                                  /*ilp_threshold=*/0u);
+        if (!non_blocking) {
+          stream->synchronize(SyncType::COMMIT_AND_WAIT);
+        }
+      } else {
+        blitSource = at::empty_strided(dst.sizes(), dst.strides(), src.options().dtype(dst.scalar_type()));
+        blitSource._set_conj(dst.is_conj());
+        blitSource._set_neg(dst.is_neg());
+        copy_cast_kernel_mps(blitSource, src);
+        blitSourceBuffer = getMTLBufferStorage(blitSource);
+        blitSourceOffset = 0;
       }
     }
 
@@ -173,12 +173,12 @@ static at::Tensor& copy_from_mps_(at::Tensor& dst_, const at::Tensor& src_, bool
       const size_t size_to_copy = (src.nbytes() / src.element_size()) * dst.element_size();
 
       // If there's anything wrong with source, we shouldn't return dst_ silently and must error out.
-      TORCH_INTERNAL_ASSERT(sourceBuffer && dst_tensor_nbytes > 0);
+      TORCH_INTERNAL_ASSERT(blitSourceBuffer && dst_tensor_nbytes > 0);
       uint64_t profile_id =
-          getMPSProfiler().beginProfileCopy(sourceBuffer, destBuffer, src, dst, size_to_copy, non_blocking);
+          getMPSProfiler().beginProfileCopy(blitSourceBuffer, destBuffer, blitSource, dst, size_to_copy, non_blocking);
 
       stream->copy_and_sync(
-          maybeCastedSourceBuffer, destBuffer, size_to_copy, storage_byte_offset, destOffset, non_blocking, profile_id);
+          blitSourceBuffer, destBuffer, size_to_copy, blitSourceOffset, destOffset, non_blocking, profile_id);
     }
   }
   if (!dst.is_same(dst_)) {

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -7671,20 +7671,19 @@ class TestMPS(TestCaseMPS):
         (torch.half, torch.float),
     ])
     @parametrize("src_offset", [0, 1])
-    @parametrize("non_blocking", [False, True])
-    def test_cast_mps_to_cpu_preserves_source(self, src_dtype, dst_dtype, src_offset, non_blocking):
+    def test_cast_mps_to_cpu_preserves_source(self, src_dtype, dst_dtype, src_offset):
         input_cpu = torch.arange(9, dtype=src_dtype)
         input_mps = input_cpu.to("mps")
         source = input_mps[src_offset:]
 
-        dst_offset = max(1, 4 // torch.empty((), dtype=dst_dtype).element_size())
+        # Offset the destination by a 4-byte-aligned, non-page-aligned amount so the
+        # cast writes into the CPU buffer at a nonzero offset.
+        dst_offset = 2 if dst_dtype in (torch.half, torch.bfloat16) else 1
         output_storage = torch.empty(source.numel() + dst_offset, dtype=dst_dtype)
         output = output_storage[dst_offset:]
         self.assertEqual(output.data_ptr() % 4, 0)
         self.assertNotEqual(output.data_ptr() % os.sysconf("SC_PAGE_SIZE"), 0)
-        output.copy_(source, non_blocking=non_blocking)
-        if non_blocking:
-            torch.mps.synchronize()
+        output.copy_(source)
 
         self.assertEqual(output, input_cpu[src_offset:].to(dst_dtype))
         self.assertTrue(torch.equal(input_mps.cpu(), input_cpu))
@@ -7695,17 +7694,6 @@ class TestMPS(TestCaseMPS):
 
         output_storage = torch.empty(input_cpu.numel() + 2, dtype=torch.half)
         output = output_storage[2:].as_strided(input_cpu.size(), input_cpu.stride())
-        output.copy_(input_mps)
-
-        self.assertEqual(output, input_cpu.to(torch.half))
-        self.assertTrue(torch.equal(input_mps.cpu(), input_cpu))
-
-    def test_cast_mps_to_cpu_preserves_destination_bits(self):
-        input_cpu = torch.arange(8, dtype=torch.float)
-        input_mps = input_cpu.to("mps")
-
-        output_storage = torch.empty(input_cpu.numel() + 2, dtype=torch.half)
-        output = output_storage[2:]._neg_view()
         output.copy_(input_mps)
 
         self.assertEqual(output, input_cpu.to(torch.half))
@@ -16042,6 +16030,14 @@ class TestComplex(TestCase):
                     self.assertEqual(src_mps.cpu(), expected)
                 with self.subTest(src=src_label, dst=dst_label, op="copy_"):
                     self.assertEqual(dst_mps.cpu(), dst_cpu)
+                # A dtype-converting D2H copy must honor the neg bit and leave the
+                # source untouched (regression for
+                # https://github.com/pytorch/pytorch/issues/189563).
+                dst_half = dst_xform(torch.empty(4, 4, dtype=torch.half))
+                dst_half.copy_(src_mps)
+                with self.subTest(src=src_label, dst=dst_label, op="copy_cast"):
+                    self.assertEqual(dst_half, expected.to(torch.half))
+                    self.assertEqual(v.cpu(), v_cpu)
 
     def test_tensor_scalar_binops(self):
         # Regression test for https://github.com/pytorch/pytorch/issues/119088

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -7664,6 +7664,53 @@ class TestMPS(TestCaseMPS):
         helper(torch.half, torch.float)
         helper(torch.float, torch.half)
 
+    # Regression test for https://github.com/pytorch/pytorch/issues/189563
+    @parametrize("src_dtype,dst_dtype", [
+        (torch.float, torch.half),
+        (torch.float, torch.int),
+        (torch.half, torch.float),
+    ])
+    @parametrize("src_offset", [0, 1])
+    @parametrize("non_blocking", [False, True])
+    def test_cast_mps_to_cpu_preserves_source(self, src_dtype, dst_dtype, src_offset, non_blocking):
+        input_cpu = torch.arange(9, dtype=src_dtype)
+        input_mps = input_cpu.to("mps")
+        source = input_mps[src_offset:]
+
+        dst_offset = max(1, 4 // torch.empty((), dtype=dst_dtype).element_size())
+        output_storage = torch.empty(source.numel() + dst_offset, dtype=dst_dtype)
+        output = output_storage[dst_offset:]
+        self.assertEqual(output.data_ptr() % 4, 0)
+        self.assertNotEqual(output.data_ptr() % os.sysconf("SC_PAGE_SIZE"), 0)
+        output.copy_(source, non_blocking=non_blocking)
+        if non_blocking:
+            torch.mps.synchronize()
+
+        self.assertEqual(output, input_cpu[src_offset:].to(dst_dtype))
+        self.assertTrue(torch.equal(input_mps.cpu(), input_cpu))
+
+    def test_cast_mps_to_cpu_preserves_transposed_layout(self):
+        input_cpu = torch.arange(12, dtype=torch.float).reshape(3, 4).t()
+        input_mps = input_cpu.to("mps")
+
+        output_storage = torch.empty(input_cpu.numel() + 2, dtype=torch.half)
+        output = output_storage[2:].as_strided(input_cpu.size(), input_cpu.stride())
+        output.copy_(input_mps)
+
+        self.assertEqual(output, input_cpu.to(torch.half))
+        self.assertTrue(torch.equal(input_mps.cpu(), input_cpu))
+
+    def test_cast_mps_to_cpu_preserves_destination_bits(self):
+        input_cpu = torch.arange(8, dtype=torch.float)
+        input_mps = input_cpu.to("mps")
+
+        output_storage = torch.empty(input_cpu.numel() + 2, dtype=torch.half)
+        output = output_storage[2:]._neg_view()
+        output.copy_(input_mps)
+
+        self.assertEqual(output, input_cpu.to(torch.half))
+        self.assertTrue(torch.equal(input_mps.cpu(), input_cpu))
+
     def test_cast_mps_to_mps(self):
         def helper(src_dtype, dst_dtype):
             input_cpu = torch.rand((1, 3, 128, 128), dtype=src_dtype)


### PR DESCRIPTION
Offset dtype-converting MPS->CPU copies reused the live MPS source buffer as the cast destination for narrowing and equal-width conversions, silently corrupting the source tensor.

Since the CPU destination is a shared, unified-memory `MTLBuffer`, the cast kernel can write straight into it at the requested offset -- `exec_unary_kernel_raw` already takes source and destination byte offsets, so the zero-offset and offset paths collapse into a single direct castout with no temporary and no blit. Regression tests cover narrowing, widening, equal-width conversion, source offsets, transposed layouts, and exact source preservation; the neg-bit + cast case is folded into `test_neg_bit`.

Fixes #189563

*This PR was authored with assistance from OpenAI Codex and Claude, and reviewed and tested by the author.*