### PR TITLE
[dynamo] Implement range.__contains__ non-integer fallback

### DIFF
--- a/test/dynamo/test_sequence_ops.py
+++ b/test/dynamo/test_sequence_ops.py
@@ -1344,6 +1344,54 @@ class TestRangeDynamicBounds(torch._dynamo.test_case.TestCase):
         self.assertEqual(fn(), [0, 1, 2, 3, 4])
 
 
+class TestRangeContains(torch._dynamo.test_case.TestCase):
+    # range.__contains__ uses the arithmetic fast path only for exact int/bool
+    # operands; everything else falls back to an __eq__ linear scan, matching
+    # CPython range_contains / _PySequence_IterSearch.
+    def test_non_int_members(self):
+        class AlwaysEq:
+            def __eq__(self, other):
+                return True
+
+            def __hash__(self):
+                return 0
+
+        class IntSubclassEq(int):
+            def __eq__(self, other):
+                return True
+
+            def __hash__(self):
+                return 0
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn():
+            return (
+                1.0 in range(3),
+                True in range(3),
+                (1 + 0j) in range(3),
+                AlwaysEq() in range(3),
+                IntSubclassEq(11) in range(10),
+                5 in range(3),
+                2.5 in range(3),
+            )
+
+        self.assertEqual(fn(), (True, True, True, True, True, False, False))
+
+    def test_negative_step_and_strided(self):
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn():
+            return (
+                -1 in range(0, -20, -1),
+                1.0 in range(0, -20, -1),
+                2 in range(0, 101, 2),
+                1 in range(0, 101, 2),
+                2.0 in range(0, 101, 2),
+                100.0 in range(0, 101, 2),
+            )
+
+        self.assertEqual(fn(), (True, False, True, False, True, True))
+
+
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests
 

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -796,8 +796,10 @@ class RangeVariable(BaseListVariable):
     def sq_contains(
         self, tx: "InstructionTranslatorBase", item: VariableTracker
     ) -> VariableTracker:
-        # ref: https://github.com/python/cpython/blob/v3.13.0/Objects/rangeobject.c#L482-L490
-        return VariableTracker.build(tx, self.range_count(item))
+        # range_contains: https://github.com/python/cpython/blob/60403a5409ff2c3f3b07dd2ca91a7a3e096839c7/Objects/rangeobject.c#L482-L490
+        if maybe_get_python_type(item) in (int, bool):
+            return VariableTracker.build(tx, bool(self.range_count(item)))
+        return iter_contains(self.unpack_var_sequence(tx), item, tx)
 
     def tp_iter_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         # ref: https://github.com/python/cpython/blob/v3.13.3/Objects/rangeobject.c#L896-L927


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #185424
* #189576
* __->__ #189575

Dynamo's `RangeVariable.sq_contains` delegated unconditionally to the integer
arithmetic fast path (`start <= x < stop` plus a stride-modulo test), which
returns false for any operand whose type is not int/float. So `(1+0j) in
range(3)` was False, `test_range.RangeTest.test_types`'s `assertIn` failed, and
the raised AssertionError surfaced as gb0088 "Observed exception".

CPython `range_contains` (Objects/rangeobject.c) uses the arithmetic path ONLY
for exact `int`/`bool` operands (`PyLong_CheckExact || PyBool_Check`); every
other operand falls back to `_PySequence_IterSearch`, an `==` linear scan that
never coerces the operand. In particular the fast path must NOT apply to int
subclasses: an `int` subclass with a custom `__eq__` is matched by comparison,
not arithmetic.

The fix gates the fast path on `maybe_get_python_type(item) in (int, bool)`
(exact type) and otherwise falls back to `iter_contains` over the range
elements, the same `__eq__` scan list/tuple already use. This also fixes a
latent bug where the old code returned the count int rather than a bool.

Test Plan:

```
CUDA_VISIBLE_DEVICES= PYTORCH_TESTING_DEVICE_ONLY_FOR=cpu PYTORCH_TEST_WITH_DYNAMO=1 \
  python test/cpython/v3_13/test_range.py RangeTest.test_types
CUDA_VISIBLE_DEVICES= PYTORCH_TESTING_DEVICE_ONLY_FOR=cpu PYTORCH_TEST_WITH_DYNAMO=1 \
  python test/cpython/v3_13/test_range.py
CUDA_VISIBLE_DEVICES= PYTORCH_TESTING_DEVICE_ONLY_FOR=cpu \
  python test/dynamo/test_sequence_ops.py TestRangeContains
CUDA_VISIBLE_DEVICES= PYTORCH_TESTING_DEVICE_ONLY_FOR=cpu \
  python test/dynamo/test_sequence_ops.py
```

Authored with the help of an AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98