### PR TITLE
[Windows] fix torch.jit.load fails when path contains non-ascii characters

### DIFF
--- a/caffe2/serialize/file_adapter.cc
+++ b/caffe2/serialize/file_adapter.cc
@@ -4,12 +4,19 @@
 #include <cstdio>
 #include <string>
 #include "caffe2/core/common.h"
+#ifdef _WIN32
+#include <c10/util/Unicode.h>
+#endif
 
 namespace caffe2 {
 namespace serialize {
 
 FileAdapter::RAIIFile::RAIIFile(const std::string& file_name) {
+#ifdef _WIN32
+  fp_ = _wfopen(c10::u8u16(file_name).c_str(), L"rb");
+#else
   fp_ = fopen(file_name.c_str(), "rb");
+#endif
   if (fp_ == nullptr) {
     auto old_errno = errno;
 #if defined(_WIN32) && (defined(__MINGW32__) || defined(_MSC_VER))

--- a/caffe2/serialize/inline_container.cc
+++ b/caffe2/serialize/inline_container.cc
@@ -27,6 +27,8 @@
 #include "caffe2/serialize/versions.h"
 #include "miniz.h"
 
+#include <filesystem>
+
 #ifdef _WIN32
 #include <Windows.h>
 #endif // _WIN32
@@ -722,9 +724,9 @@ void PyTorchStreamWriter::setup(const string& file_name) {
 
   const std::string dir_name = parentdir(file_name);
   if (!dir_name.empty()) {
-    struct stat st;
-    bool dir_exists =
-        (stat(dir_name.c_str(), &st) == 0 && (st.st_mode & S_IFDIR));
+    std::error_code ec;
+    bool dir_exists = std::filesystem::is_directory(
+        std::filesystem::path((const char8_t*)dir_name.c_str()), ec);
     TORCH_CHECK(
         dir_exists, "Parent directory ", dir_name, " does not exist.");
   }
@@ -735,9 +737,8 @@ void PyTorchStreamWriter::setup(const string& file_name) {
     try {
       file_stream_.exceptions(std::ios_base::failbit | std::ios_base::badbit);
       file_stream_.open(
-          file_name,
-          std::ofstream::out | std::ofstream::trunc | std::ofstream::binary
-        );
+          std::filesystem::path((const char8_t*)file_name.c_str()),
+          std::ofstream::out | std::ofstream::trunc | std::ofstream::binary);
     } catch (const std::ios_base::failure&) {
 #ifdef _WIN32
       // Windows have verbose error code, we prefer to use it than std errno.

--- a/test/jit/test_save_load.py
+++ b/test/jit/test_save_load.py
@@ -4,6 +4,7 @@ import io
 import os
 import sys
 import unittest
+import warnings
 from pathlib import Path
 from typing import NamedTuple, Optional
 
@@ -11,9 +12,11 @@ import torch
 from torch import Tensor
 from torch.testing._internal.common_cuda import SM120OrLater
 from torch.testing._internal.common_utils import (
+    IS_FILESYSTEM_UTF8_ENCODING,
     IS_WINDOWS,
     raise_on_run_directly,
     skipIfTorchDynamo,
+    TemporaryDirectoryName,
     TemporaryFileName,
 )
 
@@ -403,6 +406,59 @@ class TestSaveLoad(JitTestCase):
 
         x = torch.tensor([1.0, 2.0, 3.0, 4.0])
         self.assertTrue(torch.equal(m(x), m2(x)))
+
+    @unittest.skipIf(
+        not IS_FILESYSTEM_UTF8_ENCODING,
+        "requires UTF-8 filesystem encoding",
+    )
+    @skipIfTorchDynamo("Not a suitable test for TorchDynamo")
+    def test_save_load_non_ascii_path(self):
+        class MyMod(torch.nn.Module):
+            def forward(self, x):
+                return x + 1
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            m = torch.jit.script(MyMod())
+            x = torch.tensor([1.0, 2.0, 3.0])
+            expected = m(x)
+
+            for suffix in [
+                "用户_流星",  # Chinese
+                "ユーザー",  # Japanese
+                "данные",  # Cyrillic
+                "données_réseau",  # Accented Latin
+            ]:
+                with self.subTest(suffix=suffix):
+                    with TemporaryDirectoryName(suffix=suffix) as dname:
+                        path = os.path.join(dname, "model.pt")
+                        torch.jit.save(m, path)
+                        loaded = torch.jit.load(path)
+                        self.assertEqual(loaded(x), expected)
+
+    @unittest.skipIf(
+        not IS_FILESYSTEM_UTF8_ENCODING,
+        "requires UTF-8 filesystem encoding",
+    )
+    @skipIfTorchDynamo("Not a suitable test for TorchDynamo")
+    def test_save_load_non_ascii_nested_path(self):
+        class MyMod(torch.nn.Module):
+            def forward(self, x):
+                return x * 2
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            m = torch.jit.script(MyMod())
+            x = torch.tensor([1.0, 2.0])
+            expected = m(x)
+
+            with TemporaryDirectoryName(suffix="非ASCII") as dname:
+                nested = os.path.join(dname, "データ", "モデル")
+                os.makedirs(nested)
+                path = os.path.join(nested, "model.pt")
+                torch.jit.save(m, path)
+                loaded = torch.jit.load(path)
+                self.assertEqual(loaded(x), expected)
 
     def test_save_nonexit_file(self):
         class Foo(torch.nn.Module):
@@ -1200,6 +1256,24 @@ class TestSaveLoadFlatbuffer(JitTestCase):
         torch._C._get_model_extra_files_from_buffer(script_module_io, re_extra_files)
 
         self.assertEqual(extra_files, re_extra_files)
+
+    @unittest.skipIf(
+        not IS_FILESYSTEM_UTF8_ENCODING,
+        "requires UTF-8 filesystem encoding",
+    )
+    def test_save_load_non_ascii_path_flatbuffer(self):
+        class MyMod(torch.nn.Module):
+            def forward(self, x):
+                return x + 1
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            m = torch.jit.script(MyMod())
+
+            with TemporaryDirectoryName(suffix="用户_données") as dname:
+                path = os.path.join(dname, "model.ptl")
+                m._save_for_lite_interpreter(path, _use_flatbuffer=True)
+                self.assertTrue(os.path.exists(path))
 
 
 if __name__ == "__main__":

--- a/torch/csrc/jit/serialization/export_module.cpp
+++ b/torch/csrc/jit/serialization/export_module.cpp
@@ -866,7 +866,8 @@ void ExportModule(
   }
   std::ofstream ofile;
   ofile.open(
-      std::filesystem::path((const char8_t*)filename.c_str()), std::ios::binary | std::ios::out);
+      std::filesystem::path((const char8_t*)filename.c_str()),
+      std::ios::binary | std::ios::out);
   if (ofile.fail()) {
     std::stringstream message;
     if (errno == ENOENT) {

--- a/torch/csrc/jit/serialization/export_module.cpp
+++ b/torch/csrc/jit/serialization/export_module.cpp
@@ -32,6 +32,7 @@
 #include <ATen/core/jit_type.h>
 #include <ATen/core/qualified_name.h>
 #include <cerrno>
+#include <filesystem>
 #include <sstream>
 #include <string>
 #include <unordered_map>
@@ -864,7 +865,8 @@ void ExportModule(
     return;
   }
   std::ofstream ofile;
-  ofile.open(filename, std::ios::binary | std::ios::out);
+  ofile.open(
+      std::filesystem::path((const char8_t*)filename.c_str()), std::ios::binary | std::ios::out);
   if (ofile.fail()) {
     std::stringstream message;
     if (errno == ENOENT) {


### PR DESCRIPTION
Fixes:
- #75171

Fixes torch.jit.save and torch.jit.load failing with RuntimeError: Parent directory ... does not exist when the file path contains non-ASCII characters on Windows.

Root cause: The C++ serialization code passed UTF-8 encoded `std::string` paths to narrow-string POSIX APIs like `fopen()`. On Windows, these APIs interpret bytes using the active ANSI code page, not UTF-8, so any character outside that code page causes the path lookup to fail.

Test plan
```
python test/test_jit.py TestSaveLoad.test_save_load_non_ascii_path TestSaveLoad.test_save_load_non_ascii_nested_path TestSaveLoadFlatbuffer.test_save_load_non_ascii_path_flatbuffer -v
```
