### PR TITLE
Raise a clear error for reductions over batched sparse CSR tensors

### DIFF
--- a/aten/src/ATen/native/sparse/SparseCsrTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseCsrTensorMath.cpp
@@ -1318,7 +1318,9 @@ Tensor reduce_sparse_csr_cpu_template(const Tensor& sparse, IntArrayRef dims_to_
   TORCH_INTERNAL_ASSERT(sparse.device() == kCPU);
 
   const int64_t input_dim = sparse.dim();
-  TORCH_INTERNAL_ASSERT(input_dim == 2);
+  TORCH_CHECK(input_dim == 2,
+      "reduction operations are only supported for 2-dimensional CSR tensors, but got a tensor with ",
+      input_dim, " dimensions");
   auto dims = dims_to_sum.vec();
   maybe_wrap_dims(dims, input_dim);
   if (dims.empty()) {

--- a/aten/src/ATen/native/sparse/cuda/SparseCsrTensorMath.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCsrTensorMath.cu
@@ -676,7 +676,9 @@ Tensor reduce_sparse_csr_cuda_template(const Tensor& sparse, IntArrayRef dims_to
   TORCH_INTERNAL_ASSERT(sparse.is_cuda());
 
   const int64_t input_dim = sparse.dim();
-  TORCH_INTERNAL_ASSERT(input_dim == 2);
+  TORCH_CHECK(input_dim == 2,
+      "reduction operations are only supported for 2-dimensional CSR tensors, but got a tensor with ",
+      input_dim, " dimensions");
   auto dims = dims_to_sum.vec();
   maybe_wrap_dims(dims, input_dim);
   if (dims.size() == 0) {

--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -2981,6 +2981,21 @@ class TestSparseCSR(TestCase):
             run_test(shape, max(shape), index_dtype)
             run_test(shape, shape[0] * shape[1], index_dtype)
 
+    @skipMeta
+    @dtypes(torch.float)
+    def test_reduction_on_batched_csr_errors(self, device, dtype):
+        # regression test for https://github.com/pytorch/pytorch/issues/117259 and
+        # https://github.com/pytorch/pytorch/issues/117242: reducing over a batched
+        # (>2D) CSR tensor used to hit an internal assert instead of raising a clear
+        # error, since only 2D CSR reductions are supported (see gh-29137).
+        batched = torch.randn(1, 1, 1, dtype=dtype, device=device).to_sparse_csr()
+        msg = "only supported for 2-dimensional CSR tensors"
+        with self.assertRaisesRegex(RuntimeError, msg):
+            batched.sum(dim=0, keepdim=True)
+        other = torch.randn(1, 1, 1, dtype=dtype, device=device)
+        with self.assertRaisesRegex(RuntimeError, msg):
+            torch.tensordot(batched, other, ([0], [0]))
+
     @skipIfTorchDynamo()
     @skipMeta
     @dtypes(*all_types_and_complex_and(torch.half, torch.bool, torch.bfloat16))


### PR DESCRIPTION
Fixes #117242
Fixes #117259

### Summary

`sum()`/`prod()` (and `tensordot()`, which lowers to `sum()`) over a sparse CSR tensor with more than two dimensions crash with an internal assert:

```
RuntimeError: input_dim == 2 INTERNAL ASSERT FAILED at ".../SparseCsrTensorMath.cpp", please report a bug to PyTorch.
```

`reduce_sparse_csr_{cpu,cuda}_template` guard the input rank with `TORCH_INTERNAL_ASSERT(input_dim == 2)`. Reducing over batched (>2D) CSR tensors is not implemented yet (tracked by gh-29137), so an ordinary user input trips an assert that tells the user to file a bug against PyTorch instead of getting a clear error.

### Fix

Convert the two rank checks to `TORCH_CHECK` with an actionable message. The device, layout, and wrapped-dim checks in the same functions are genuine internal invariants (guaranteed by the dispatcher and by `maybe_wrap_dims`) and are left as `TORCH_INTERNAL_ASSERT`.

Before:
```python
>>> torch.randn(1, 1, 1).to_sparse_csr().sum(dim=0, keepdim=True)
RuntimeError: input_dim == 2 INTERNAL ASSERT FAILED ... please report a bug to PyTorch.
```
After:
```python
>>> torch.randn(1, 1, 1).to_sparse_csr().sum(dim=0, keepdim=True)
RuntimeError: reduction operations are only supported for 2-dimensional CSR tensors, but got a tensor with 3 dimensions
```

### Scope

CPU and CUDA both dispatch through the two guarded functions, so this covers `sum`, `prod`, and `tensordot` on both backends. `_sparse_csr_sum`/`_sparse_csr_prod` dispatch XPU to `torch-xpu-ops` (out of tree) and there is no MPS sparse CSR reduction kernel, so neither backend is affected here.

### Test

Added `test_reduction_on_batched_csr_errors` (device-generic, covers `sum` and `tensordot`).

```
python test/test_sparse_csr.py \
  TestSparseCSRCPU.test_reduction_on_batched_csr_errors_cpu_float32 \
  TestSparseCSRCUDA.test_reduction_on_batched_csr_errors_cuda_float32 -v
python test/test_sparse_csr.py -k test_sum
python test/test_sparse_csr.py -k reduce
```

All pass; existing reductions unchanged, and a 2D CSR reduction still works.
