### PR TITLE
[mtia] Support legacy ctor Tensor::new (#189580)

### DIFF
--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -540,6 +540,7 @@ void check_base_legacy_new(
         c10::DispatchKey::HPU,
         c10::DispatchKey::MPS,
         c10::DispatchKey::Meta,
+        c10::DispatchKey::MTIA,
         c10::DispatchKey::PrivateUse1,
     });
     TORCH_CHECK(


### PR DESCRIPTION
Summary:

Enable the legacy `Tensor.new(size)` factory for MTIA tensors by adding the MTIA dispatch key to the ATen allowlist. This resolves a `RuntimeError` where the MTIA key was previously rejected, which blocked `torch.distributions rsample()` operations (like Laplace, Cauchy, and Geometric) that rely on this factory to initialize uniform tensors on the same device.

Test Plan: Added MTIA specific tests

Differential Revision: D111498068


