### PR TITLE
[BE][Ez]: Apply missing std::move calls via clang-tidy

### DIFF
--- a/aten/src/ATen/FunctionalInverses.cpp
+++ b/aten/src/ATen/FunctionalInverses.cpp
@@ -239,7 +239,7 @@ Tensor FunctionalInverses::split_Tensor_inverse(const Tensor& base, const Tensor
     auto dim_size = base.sym_size(dim);
     auto start = split_size * mutated_view_idx;
     auto end = split_size + start;
-    if (end > dim_size) end = dim_size;
+    if (end > dim_size) end = std::move(dim_size);
 
     if (inverse_return_mode == InverseReturnMode::AlwaysView) {
       // NB: assumes mutated_view is a narrowed view of base.
@@ -258,7 +258,7 @@ Tensor FunctionalInverses::split_with_sizes_inverse(const Tensor& base, const Te
         start += split_sizes[i];
     }
     auto end = start + split_sizes[mutated_view_idx];
-    if (end > dim_size) end = dim_size;
+    if (end > dim_size) end = std::move(dim_size);
 
     if (inverse_return_mode == InverseReturnMode::AlwaysView) {
       // NB: assumes mutated_view is a narrowed view of base.

--- a/aten/src/ATen/TensorGeometry.h
+++ b/aten/src/ATen/TensorGeometry.h
@@ -2,6 +2,7 @@
 
 #include <ATen/core/TensorBase.h>
 #include <c10/core/WrapDimMinimal.h>
+#include <utility>
 
 namespace at {
 
@@ -26,7 +27,7 @@ struct TORCH_API TensorGeometry {
       strides_[i] = expected_stride;
       expected_stride *= sizes_[i];
     }
-    numel_ = expected_stride;
+    numel_ = std::move(expected_stride);
   }
 
   explicit TensorGeometry(const TensorBase& t)

--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -690,7 +690,7 @@ struct TORCH_API TensorType : public SharedType {
       at::IntArrayRef strides) const {
     auto cloned = clone();
     auto ssizes = SymbolicShape(sizes);
-    cloned->sizes_ = ssizes;
+    cloned->sizes_ = std::move(ssizes);
     cloned->strides_ = computeStrideProps(sizes, strides);
     return cloned;
   }
@@ -726,7 +726,7 @@ struct TORCH_API TensorType : public SharedType {
     auto strides = computeStrideProps(
         *concrete_sizes,
         contiguousStridesOf(*concrete_sizes));
-    cloned->strides_ = strides;
+    cloned->strides_ = std::move(strides);
     return cloned;
   }
 

--- a/aten/src/ATen/functorch/BatchRulesScatterOps.cpp
+++ b/aten/src/ATen/functorch/BatchRulesScatterOps.cpp
@@ -892,7 +892,7 @@ Tensor get_expanded_index(const Tensor& index, SymIntArrayRef self_size, int64_t
   // Now apply expand to index_
   {
     VmapSymDimVector new_index_shape = {self_size.begin(), self_size.end()};
-    new_index_shape[dim] = idx_size;
+    new_index_shape[dim] = std::move(idx_size);
     index_ = index_.expand_symint(new_index_shape);
   }
   return index_;

--- a/aten/src/ATen/native/LossNLL.cpp
+++ b/aten/src/ATen/native/LossNLL.cpp
@@ -621,7 +621,7 @@ static Tensor cross_entropy_loss_label_smoothing(
         ret = smooth_loss.sum();
         break;
       case Reduction::None:
-        ret = smooth_loss;
+        ret = std::move(smooth_loss);
         break;
       default:
         TORCH_CHECK(false, "Invalid reduction type encountered in cross_entropy: ", reduction);

--- a/aten/src/ATen/native/SpectralOps.cpp
+++ b/aten/src/ATen/native/SpectralOps.cpp
@@ -592,7 +592,7 @@ static Tensor fft_hfftn_impl(
     auto c2c_dims = IntArrayRef(desc.dim).slice(0, desc.dim.size() - 1);
     tmp = at::_fft_c2c(x, c2c_dims, norm, /*forward=*/true);
   } else {
-    tmp = x;
+    tmp = std::move(x);
   }
 
   const auto last_dim = desc.dim.back();

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -1515,7 +1515,7 @@ Tensor narrow_copy_sparse(
   } else {
     /* This means we are narrowing on a dense dim, which is in effect just a
         regular narrow on _values() */
-    new_indices = indices;
+    new_indices = std::move(indices);
     int64_t dense_dim = dim - sparse_dim + 1;
     new_values = self._values().narrow_copy(dense_dim, start, length);
   }

--- a/aten/src/ATen/native/Unique.cpp
+++ b/aten/src/ATen/native/Unique.cpp
@@ -421,7 +421,7 @@ std::tuple<Tensor, Tensor, Tensor> _unique_dim_cpu_template(
       input_sorted[i] = input_flat[indices[i]];
     }
   } else {
-    input_sorted = input_flat;
+    input_sorted = std::move(input_flat);
   }
 
   Tensor inverse_indices = at::empty(indices.size(), self.options().dtype(kLong));

--- a/aten/src/ATen/native/mkldnn/MKLDNNConversions.cpp
+++ b/aten/src/ATen/native/mkldnn/MKLDNNConversions.cpp
@@ -516,13 +516,13 @@ static std::vector<Tensor> mkldnn_reorder_mkldnn_rnn_layer_weight(
     reverse);
 
   if (should_use_plain_format(w1_)) {
-    packed_w1 = weight0;
+    packed_w1 = std::move(weight0);
   } else {
     packed_w1 = new_with_itensor_mkldnn(std::move(w1_), optTypeMetaToScalarType(weight0.options().dtype_opt()), weight0.options().device_opt());
   }
 
   if (should_use_plain_format(w2_)) {
-    packed_w2 = weight1;
+    packed_w2 = std::move(weight1);
   } else {
     packed_w2 = new_with_itensor_mkldnn(std::move(w2_), optTypeMetaToScalarType(weight1.options().dtype_opt()), weight1.options().device_opt());
   }

--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -1351,8 +1351,8 @@ static at::Tensor linear_int8_with_onednn_weight(
     params.N = N;
     params.out_dtype = out_dtype;
     params.output_size = output_size;
-    params.primitive = primitive;
-    params.packed_weight = expected_weight;
+    params.primitive = std::move(primitive);
+    params.packed_weight = std::move(expected_weight);
     // keep a copy rather than a view of weight scales
     params.weight_scales = tensor(wei_scales_t.get_desc());
     memcpy(params.weight_scales.get_data_handle(), wei_scales_t.get_data_handle(), wei_scales_t.get_desc().get_size());
@@ -1361,9 +1361,9 @@ static at::Tensor linear_int8_with_onednn_weight(
     params.src_zero_point = input_zero_point != 0 ? std::make_optional<tensor>(src_zp_t) : std::nullopt;
     params.dst_zero_point = output_zero_point != 0 ? std::make_optional<tensor>(dst_zp_t) : std::nullopt;
     params.bias = with_bias ? std::make_optional<tensor>(onednn_bias) : std::nullopt;
-    params.scratchpad = scratchpad;
-    params.src = src;
-    params.dst = dst;
+    params.scratchpad = std::move(scratchpad);
+    params.src = std::move(src);
+    params.dst = std::move(dst);
     params.src1 = binary_post_op == "add" ? std::make_optional<tensor>(src1) : std::nullopt;
     params.init_args();
     qlinear_forward_params_map[cache_key] = params;

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -1886,7 +1886,7 @@ Tensor _sparse_sum_backward_cpu(const Tensor& grad_, const SparseTensor& input_,
       });
     }
     else {
-      grad_input_values = grad_values_expand;
+      grad_input_values = std::move(grad_values_expand);
     }
     bool grad_is_coalesced = input.is_coalesced();
     return at::_sparse_coo_tensor_with_dims_and_tensors(input_sparse_dim, input_dense_dim, input_sizes, input_indices.clone(at::MemoryFormat::Contiguous), grad_input_values, grad.options(), grad_is_coalesced);

--- a/c10/core/AutogradState.cpp
+++ b/c10/core/AutogradState.cpp
@@ -1,5 +1,7 @@
 #include <c10/core/AutogradState.h>
 
+#include <utility>
+
 namespace c10 {
 
 namespace {
@@ -17,7 +19,7 @@ AutogradState& AutogradState::get_tls_state() {
 }
 
 void AutogradState::set_tls_state(AutogradState state) {
-  autograd_state_tls = state;
+  autograd_state_tls = std::move(state);
 }
 
 } // namespace c10

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1367,7 +1367,7 @@ static std::string reportProcessMemoryInfo(const cudaDeviceProp& prop) {
     }
     ss << " has " << format_size(proc.usedGpuMemory) << " memory in use. ";
   }
-  return ss.str();
+  return std::move(ss).str();
 #else
   return "";
 #endif
@@ -2475,7 +2475,7 @@ class DeviceCachingAllocator {
           SegmentRange(block->ptr, block->size), ss);
       offset = static_cast<const char*>(block->ptr) - full_range.ptr;
     }
-    return ShareableHandle{.offset = offset, .handle = ss.str()};
+    return ShareableHandle{.offset = offset, .handle = std::move(ss).str()};
   }
 
   void recordStream(Block* block, cuda::CUDAStream stream) {

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -423,8 +423,11 @@ static PyObject* THPModule_swap_tensor_impl(PyObject* _unused, PyObject* args) {
   at::Tensor tmp_b = b->cdata;
 
   // Swap the Tensor Impl
-  a->cdata = std::move(tmp_b);
-  b->cdata = std::move(tmp_a);
+  // NOLINTBEGIN(performance-use-std-move): the extra refcount from copying
+  // (rather than moving) tmp_a/tmp_b is load-bearing, see NB comment above.
+  a->cdata = tmp_b;
+  b->cdata = tmp_a;
+  // NOLINTEND(performance-use-std-move)
 
   // Fix up the PyObjects associated with each TensorImpl
   a->cdata.unsafeGetTensorImpl()->pyobj_slot()->store_pyobj(a_);

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -423,8 +423,8 @@ static PyObject* THPModule_swap_tensor_impl(PyObject* _unused, PyObject* args) {
   at::Tensor tmp_b = b->cdata;
 
   // Swap the Tensor Impl
-  a->cdata = tmp_b;
-  b->cdata = tmp_a;
+  a->cdata = std::move(tmp_b);
+  b->cdata = std::move(tmp_a);
 
   // Fix up the PyObjects associated with each TensorImpl
   a->cdata.unsafeGetTensorImpl()->pyobj_slot()->store_pyobj(a_);

--- a/torch/csrc/api/include/torch/nn/functional/activation.h
+++ b/torch/csrc/api/include/torch/nn/functional/activation.h
@@ -198,7 +198,7 @@ inline Tensor gumbel_softmax(
     auto y_hard = torch::zeros_like(logits).scatter_(dim, index, 1.0);
     ret = y_hard - y_soft.detach() + y_soft;
   } else {
-    ret = y_soft;
+    ret = std::move(y_soft);
   }
   return ret;
 }

--- a/torch/csrc/autograd/functions/accumulate_grad.cpp
+++ b/torch/csrc/autograd/functions/accumulate_grad.cpp
@@ -179,7 +179,7 @@ variable_list AccumulateGrad::apply_with_saved(
       grad_copy,
       grads[0],
       !post_hooks().empty());
-  variable_copy.mutable_grad() = functional_grad;
+  variable_copy.mutable_grad() = std::move(functional_grad);
 
   auto& hook = tensor_post_acc_grad_hooks();
   if (hook != nullptr) {

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -1190,9 +1190,9 @@ void enableProfiler(
 
   if (has_cpu) {
     auto state_info_ptr = std::make_shared<ProfilerStateInfo>();
-    state_info_ptr->state_ptr = state_ptr;
+    state_info_ptr->state_ptr = std::move(state_ptr);
     state_info_ptr->scopes = scopes;
-    profiler_state_info_ptr = state_info_ptr;
+    profiler_state_info_ptr = std::move(state_info_ptr);
   }
 }
 

--- a/torch/csrc/functorch/init.cpp
+++ b/torch/csrc/functorch/init.cpp
@@ -22,6 +22,7 @@
 #include <c10/core/InferenceMode.h>
 
 #include <iostream>
+#include <utility>
 
 // This file contains functorch's Python bindings.
 
@@ -258,7 +259,7 @@ static int64_t _grad_increment_nesting() {
   if (prev_inference_mode) {
     auto state = c10::AutogradState::get_tls_state();
     state.set_inference_mode(false);
-    c10::AutogradState::set_tls_state(state);
+    c10::AutogradState::set_tls_state(std::move(state));
   }
   return initAndPushDynamicLayer(
       TransformType::Grad,
@@ -277,7 +278,7 @@ static int64_t _grad_decrement_nesting() {
   if (meta.prevInferenceMode_) {
     auto state = c10::AutogradState::get_tls_state();
     state.set_inference_mode(true);
-    c10::AutogradState::set_tls_state(state);
+    c10::AutogradState::set_tls_state(std::move(state));
   }
   return layer.layerId();
 }
@@ -290,7 +291,7 @@ static int64_t _jvp_increment_nesting() {
   if (prev_inference_mode) {
     auto state = c10::AutogradState::get_tls_state();
     state.set_inference_mode(false);
-    c10::AutogradState::set_tls_state(state);
+    c10::AutogradState::set_tls_state(std::move(state));
   }
   return initAndPushDynamicLayer(
       TransformType::Jvp,
@@ -309,7 +310,7 @@ static int64_t _jvp_decrement_nesting() {
   if (meta.prevInferenceMode_) {
     auto state = c10::AutogradState::get_tls_state();
     state.set_inference_mode(true);
-    c10::AutogradState::set_tls_state(state);
+    c10::AutogradState::set_tls_state(std::move(state));
   }
   return layer.layerId();
 }

--- a/torch/csrc/jit/frontend/concrete_module_type.cpp
+++ b/torch/csrc/jit/frontend/concrete_module_type.cpp
@@ -82,7 +82,7 @@ std::shared_ptr<ConcreteModuleType> ConcreteModuleType::fromJitType(
   // Not make_shared because the constructor is private.
   auto ret = std::shared_ptr<ConcreteModuleType>(new ConcreteModuleType());
   ret->jitType_ = std::move(type);
-  ret->data_ = builder;
+  ret->data_ = std::move(builder);
 
   return ret;
 }

--- a/torch/csrc/jit/passes/freeze_module.cpp
+++ b/torch/csrc/jit/passes/freeze_module.cpp
@@ -758,7 +758,7 @@ class AttributePropagator {
 
     auto subgraph = n->g(attr::Subgraph);
     func(subgraph);
-    module_ = attrModule;
+    module_ = std::move(attrModule);
   }
 
   bool moduleEscapes(Module& subModule, std::shared_ptr<Graph>& graph) {

--- a/torch/csrc/jit/tensorexpr/mem_dependency_checker.cpp
+++ b/torch/csrc/jit/tensorexpr/mem_dependency_checker.cpp
@@ -1006,7 +1006,7 @@ void MemDependencyChecker::visit(const IfThenElsePtr& v) {
   mergeScope(trueScope, enclosingScope, false);
   mergeScope(falseScope, enclosingScope, false);
 
-  currentScope_ = enclosingScope;
+  currentScope_ = std::move(enclosingScope);
 }
 
 void MemDependencyChecker::visit(const CompareSelectPtr& v) {
@@ -1043,7 +1043,7 @@ void MemDependencyChecker::visit(const CompareSelectPtr& v) {
   mergeScope(trueScope, enclosingScope, false);
   mergeScope(falseScope, enclosingScope, false);
 
-  currentScope_ = enclosingScope;
+  currentScope_ = std::move(enclosingScope);
 }
 
 // Inserts accesses for a map of buffers (ie. for inputs and outputs).

--- a/torch/csrc/jit/tensorexpr/registerizer.cpp
+++ b/torch/csrc/jit/tensorexpr/registerizer.cpp
@@ -286,13 +286,13 @@ void RegisterizerAnalysis::visit(const CondPtr& v) {
       std::make_shared<Scope>(false_stmt, prev_scope, ++conditionId_);
 
   if (true_stmt) {
-    currentScope_ = true_scope;
+    currentScope_ = std::move(true_scope);
     true_stmt->accept(this);
     mergeHiddenScope(true);
     mergeCurrentScopeIntoParent();
   }
   if (false_stmt) {
-    currentScope_ = false_scope;
+    currentScope_ = std::move(false_scope);
     false_stmt->accept(this);
     mergeHiddenScope(true);
     mergeCurrentScopeIntoParent();
@@ -330,14 +330,14 @@ void RegisterizerAnalysis::visit(const IfThenElsePtr& v) {
   exprConditionals_.insert(false_scope->conditionId());
 
   if (true_value) {
-    currentScope_ = true_scope;
+    currentScope_ = std::move(true_scope);
     true_value->accept(this);
     mergeHiddenScope(false);
     mergeCurrentScopeIntoParent();
   }
 
   if (false_value) {
-    currentScope_ = false_scope;
+    currentScope_ = std::move(false_scope);
     false_value->accept(this);
     mergeHiddenScope(false);
     mergeCurrentScopeIntoParent();
@@ -632,7 +632,7 @@ void RegisterizerAnalysis::mergeCurrentScopeIntoParent() {
     }
   }
 
-  currentScope_ = parent;
+  currentScope_ = std::move(parent);
 }
 
 std::vector<std::shared_ptr<AccessInfo>> RegisterizerAnalysis::getCandidates() {

--- a/torch/csrc/profiler/collection.cpp
+++ b/torch/csrc/profiler/collection.cpp
@@ -1375,7 +1375,7 @@ void build_tree(std::vector<std::shared_ptr<Result>>& sorted_events) {
     stacks.erase(start_tid);
     auto new_frame = event->parent_.lock();
     if (new_frame != nullptr) {
-      stacks[start_tid] = new_frame;
+      stacks[start_tid] = std::move(new_frame);
     }
   };
 


### PR DESCRIPTION
Missing std::move calls suggested by the new clang-tidy rule in nightly: [performance-use-std-move](https://clang.llvm.org/extra/clang-tidy/checks/performance/use-std-move.html) . Double checked with Claude and Codex . Only one false positive in the entire codebase. The check is very conservative by default.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @EikanWang