### PR TITLE
Add reindexer to Dtype ir

### DIFF
--- a/test/inductor/test_fp8.py
+++ b/test/inductor/test_fp8.py
@@ -5,13 +5,15 @@ import unittest
 from unittest import mock
 
 import torch
+import torch._inductor.lowering as inductor_lowering
 from torch import Tensor
 from torch._C import FileCheck
-from torch._inductor import config, inductor_prims, utils
+from torch._inductor import config, inductor_prims, ir, utils
 from torch._inductor.fx_passes.misc_patterns import _misc_patterns_init
+from torch._inductor.lowering import clone as lowering_clone, register_lowering
 from torch._inductor.pattern_matcher import PatternMatcherPass
 from torch._inductor.test_case import run_tests, TestCase
-from torch._inductor.utils import run_and_get_code
+from torch._inductor.utils import run_and_get_code, sympy_index_symbol_with_prefix
 from torch.nn.functional import scaled_mm, ScalingType  # type: ignore[attr-defined]
 from torch.testing._internal.common_cuda import (
     _get_torch_cuda_version,
@@ -42,6 +44,7 @@ from torch.testing._internal.inductor_utils import (
     HAS_CUDA_AND_TRITON,
     is_big_gpu,
 )
+from torch.utils._sympy.symbol import SymT
 from torch.utils._triton import has_triton_tma_device
 
 
@@ -1541,6 +1544,61 @@ class TestFP8Lowering(TestCase):
                         input_values[1][i],
                         msg=lambda msg: f"{msg}\nidx {i} seed {seed}",
                     )
+
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
+    @onlyCUDA
+    def test_mxfp8_dtype_view_indexer_e2e(self, device):
+        with (
+            torch.library._scoped_library("test_fp8", "FRAGMENT") as lib,
+            mock.patch.dict(inductor_lowering.lowerings),
+        ):
+            lib.define("dtype_view_indexing_consumer(Tensor x) -> Tensor")
+            torch.library.impl(lib, "dtype_view_indexing_consumer", "CUDA")(
+                lambda x: x.clone()
+            )
+            torch.library.impl(lib, "dtype_view_indexing_consumer", "Meta")(
+                lambda x: torch.empty_like(x)
+            )
+
+            def lowering(x):
+                x.realize()
+                ir.as_storage_and_layout(x.unwrap_view(), freeze=True)
+                index = [
+                    sympy_index_symbol_with_prefix(SymT.INDEX, i)
+                    for i in range(len(x.get_size()))
+                ]
+                x.make_indexer()(index)
+                return lowering_clone(x)
+
+            register_lowering(
+                torch.ops.test_fp8.dtype_view_indexing_consumer.default,
+                type_promotion_kind=None,
+            )(lowering)
+
+            def fn(x):
+                x = x.reshape(128, 4, 32)
+                amax = torch.amax(torch.abs(x), -1, keepdim=True).float()
+                descale = amax / torch.finfo(torch.float8_e4m3fn).max
+                exponent = torch.where(
+                    torch.isnan(descale),
+                    torch.full((), 255, dtype=torch.uint8, device=x.device),
+                    (
+                        torch.clamp(torch.ceil(torch.log2(descale)), min=-127, max=127)
+                        + 127
+                    ).to(torch.uint8),
+                )
+                scale = exponent.view(torch.float8_e8m0fnu)
+                return torch.ops.test_fp8.dtype_view_indexing_consumer.default(
+                    scale
+                ).squeeze(-1)
+
+            x = torch.randn((128, 128), device=device, dtype=torch.bfloat16)
+            expected = fn(x)
+            actual = torch.compile(fn, fullgraph=True)(x)
+
+        self.assertEqual(actual.shape, (128, 4))
+        self.assertEqual(actual.dtype, torch.float8_e8m0fnu)
+        self.assertEqual(actual.view(torch.uint8), expected.view(torch.uint8))
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
     @onlyOn(["cuda", "xpu", "cpu"])

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -4142,6 +4142,12 @@ class DtypeView(BaseView):
     def get_size(self) -> Sequence[Expr]:
         return self.data.get_size()
 
+    def make_reindexer(self) -> Callable[[Sequence[Expr]], Sequence[Expr]]:
+        def reindex(index: Sequence[Expr]) -> Sequence[Expr]:
+            return index
+
+        return reindex
+
     def make_loader(self) -> Callable[[Sequence[Expr]], OpsValue]:
         inner = self.data.make_loader()
 


### PR DESCRIPTION
## Human Note
Simpleish fix I dont know why this didnt land in the past but this does make sense to me. Appears to be the combo of view into an op that needs to materialize, in this case scaled_mm


## Agent Report
# PTQ Investigation Report

## Issue

Inductor could raise `NotImplementedError: make_reindexer NYI on DtypeView(...)` when a dtype bitcast view, such as a `uint8` scale tensor viewed as `torch.float8_e8m0fnu`, needed an indexer. This matches the MXFP8 `torch.compile` failure mode from the issue.

## Root cause

`DtypeView` preserves the underlying tensor's shape and logical indexing, but unlike other `BaseView` subclasses it did not implement `make_reindexer()`. When later compiler paths needed `BaseView.make_indexer()` for a realized dtype view, the base implementation raised instead of composing the underlying indexer with an identity reindex.

## Fix

Added `DtypeView.make_reindexer()` as an identity mapping. This lets `BaseView.make_indexer()` reuse the underlying storage/layout indexer while preserving the dtype bitcast semantics. Added a regression test covering a `DtypeView` over a strided buffer and checking both the identity reindexer and the composed index expression.

## Repro

<details>
<summary>Repro Script</summary>

```python
import torch
from torch._inductor import ir
from torch._inductor.utils import sympy_index_symbol


def main() -> None:
    base = ir.Buffer(
        name="buf",
        layout=ir.FixedLayout(
            torch.device("cuda"),
            dtype=torch.uint8,
            size=[2, 3],
            stride=[3, 1],
        ),
    )
    dtype_view = ir.DtypeView(data=base, target_dtype=torch.float8_e8m0fnu)
    i0 = sympy_index_symbol("i0")
    i1 = sympy_index_symbol("i1")
    print(dtype_view.make_indexer()([i0, i1]))


if __name__ == "__main__":
    main()
```

Before the fix:

```text
NotImplementedError: make_reindexer NYI on DtypeView(
  Buffer(name='buf', layout=FixedLayout('cuda', torch.uint8, size=[2, 3], stride=[3, 1])),
  torch.float8_e8m0fnu,
  origins=OrderedSet([])
)
```

After the fix:

```text
3*i0 + i1
```

</details>

## Validation

Tests run:

```bash
./.venv/bin/python repro.py
```

```bash
cd pytorch && ../.venv/bin/python -m pytest test/inductor/test_dependencies.py::TestDependencies::test_dtype_view_make_indexer_preserves_underlying_indexing -q
```

Result: `1 passed in 1.84s`.

```bash
cd pytorch && INDUCTOR_TEST_DISABLE_FRESH_CACHE=1 TORCHINDUCTOR_COMPILE_THREADS=1 ../.venv/bin/python -m pytest test/inductor/test_fp8.py -k test_mx_fusion -q
```

Result: `1 passed, 1 skipped, 642 deselected in 6.80s`.

Prerequisite checks:

```bash
cd pytorch && git diff --check
```

Result: passed.

```bash
cd pytorch && ../.venv/bin/spin fixlint
```

Result: Python lint subsets completed with `ok No lint issues`, but the overall command exited nonzero because of unrelated pre-existing ShellCheck findings in CI shell scripts (`test/run_test.sh` and `.ci/pytorch/test.sh`).

## Remaining uncertainty

I did not run the original torchao benchmark because this job does not include the torchao checkout used in the issue. The repro exercises the exact `DtypeView.make_indexer()` failure that produced the reported `make_reindexer NYI on DtypeView` exception.


Fixes #168995


<details>
<summary>Repro Script</summary>

```python
import torch
from torch._inductor import ir
from torch._inductor.utils import sympy_index_symbol


def main() -> None:
    base = ir.Buffer(
        name="buf",
        layout=ir.FixedLayout(
            torch.device("cuda"),
            dtype=torch.uint8,
            size=[2, 3],
            stride=[3, 1],
        ),
    )
    dtype_view = ir.DtypeView(data=base, target_dtype=torch.float8_e8m0fnu)
    i0 = sympy_index_symbol("i0")
    i1 = sympy_index_symbol("i1")
    print(dtype_view.make_indexer()([i0, i1]))


if __name__ == "__main__":
    main()
```

</details>


<details>
<summary>Agent Worklog</summary>

## Run 1

### Context loaded
Read `prime.md`, `PTQ_CONTEXT.md`, `system_prompt.md`, the existing worklog, and `pytorch/AGENTS.md`. The repo is on detached `HEAD` at `a059c4af893` with a clean source tree.

### Reproduced DtypeView indexer failure
No `repro.py` existed, so I added a minimal repro that constructs the Inductor `DtypeView` state from the reported exception and calls `make_indexer()`. Running `./.venv/bin/python repro.py` fails with `NotImplementedError: make_reindexer NYI on DtypeView(...)`, matching the reported compiler failure mode.

### Implemented identity DtypeView reindexing
Added `DtypeView.make_reindexer()` as an identity mapping because dtype bitcasts preserve the logical index space. Added a regression test that constructs a dtype view over a strided buffer and verifies both the reindexer and composed indexer.

### Validation
`./.venv/bin/python repro.py` now prints `3*i0 + i1`. The targeted regression test passed with `../.venv/bin/python -m pytest test/inductor/test_dependencies.py::TestDependencies::test_dtype_view_make_indexer_preserves_underlying_indexing -q`. The existing MX fusion coverage passed with `INDUCTOR_TEST_DISABLE_FRESH_CACHE=1 TORCHINDUCTOR_COMPILE_THREADS=1 ../.venv/bin/python -m pytest test/inductor/test_fp8.py -k test_mx_fusion -q` (1 passed, 1 skipped). `../.venv/bin/spin fixlint` ran; Python lint subsets passed, but the overall command failed on unrelated pre-existing ShellCheck findings in CI shell scripts.

</details>

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo