### PR TITLE
Fix TSan concurrency group so new PR pushes cancel in-progress runs

### DIFF
--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
`tsan.yml` only triggers on ciflow-tag `push` events (no `pull_request`), so `github.event.pull_request.number` is always empty and the concurrency group fell back to `github.sha` — unique per push. New pushes to a PR therefore never cancelled the prior in-progress run ([29124730043](https://github.com/pytorch/pytorch/actions/runs/29124730043) stayed running after [29125854442](https://github.com/pytorch/pytorch/actions/runs/29125854442) started, same PR).

Use `github.ref_name` (the ciflow tag, stable per PR) as the fallback, matching `trunk.yml`/`pull.yml`.