### PR TITLE
[inductor] Fix IndentationError in imports_for_benchmark_kernel for multi-line get_raw_stream (#189589)

### DIFF
--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -627,6 +627,31 @@ class TestCodegenTriton(InductorTestCase):
         code_str = " ".join(code)
         self.assertNotIn("tt.pointer_range", code_str)
 
+    def test_imports_for_benchmark_kernel_multiline_get_raw_stream(self):
+        # Regression: a backend whose import_get_raw_stream_as returns a
+        # multi-line snippet (e.g. the CPU override, which MTIA uses) must not
+        # break the textwrap.dedent of the benchmark-kernel imports. Formatting
+        # before dedenting used to leave the imports indented (IndentationError).
+        # TritonKernel and ComboKernel carry identical copies of this helper.
+        from torch._inductor.codegen.triton_combo_kernel import ComboKernel
+
+        class FakeDeviceOps:
+            def import_get_raw_stream_as(self, name):
+                return f"def {name}(_):\n    return 0"
+
+        class FakeGraph:
+            device_ops = FakeDeviceOps()
+
+        for kernel_cls in (TritonKernel, ComboKernel):
+            with V.set_graph_handler(FakeGraph()):
+                # imports_for_benchmark_kernel does not use self.
+                imports = kernel_cls.imports_for_benchmark_kernel(None)
+            # Compiles without IndentationError and the top-level imports stay at
+            # column 0 (they would be indented if dedent ran after substitution).
+            compile(imports, "<benchmark_kernel_imports>", "exec")
+            self.assertIn("\nfrom torch._dynamo.testing import rand_strided\n", imports)
+            self.assertIn("\nimport torch\n", imports)
+
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -6622,13 +6622,15 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         return result
 
     def imports_for_benchmark_kernel(self):
+        # Dedent BEFORE substituting get_raw_stream: a multi-line override would
+        # otherwise collapse dedent's common prefix and misindent the imports.
         return textwrap.dedent(
             """
             from torch._dynamo.testing import rand_strided
             {}
             import torch
-        """.format(V.graph.device_ops.import_get_raw_stream_as("get_raw_stream"))
-        )
+            """
+        ).format(V.graph.device_ops.import_get_raw_stream_as("get_raw_stream"))
 
     def _get_heuristic(self):
         if self.fixed_config:

--- a/torch/_inductor/codegen/triton_combo_kernel.py
+++ b/torch/_inductor/codegen/triton_combo_kernel.py
@@ -1605,13 +1605,15 @@ class ComboKernel(Kernel):
         return result
 
     def imports_for_benchmark_kernel(self) -> str:
+        # Dedent BEFORE substituting get_raw_stream: a multi-line override would
+        # otherwise collapse dedent's common prefix and misindent the imports.
         return textwrap.dedent(
             """
             from torch._dynamo.testing import rand_strided
             {}
             import torch
-        """.format(V.graph.device_ops.import_get_raw_stream_as("get_raw_stream"))
-        )
+            """
+        ).format(V.graph.device_ops.import_get_raw_stream_as("get_raw_stream"))
 
     def uniquify_block_sizes(
         self, code: IndentedBuffer, num_kernel: int, uniquify: list[str]


### PR DESCRIPTION
Summary:

`TritonScheduling.imports_for_benchmark_kernel` formatted the template before dedenting: `textwrap.dedent("""...{}...""".format(V.graph.device_ops.import_get_raw_stream_as("get_raw_stream")))`. On backends whose `import_get_raw_stream_as` returns a multi-line snippet — the CPU override, which MTIA uses because it lowers with `device=cpu`, emits `def get_raw_stream(_):` / `return 0` — the injected column-0 `def` line collapses `textwrap.dedent`'s common-leading-whitespace to 0, so the surrounding `from torch._dynamo.testing import rand_strided` / `import torch` lines keep their indentation and the generated benchmark-kernel module fails to import with `IndentationError: unexpected indent`.

Fix: dedent the template first, then `.format()` the `get_raw_stream` snippet into the placeholder at column 0. Equivalent for single-line backends (CUDA/XPU import lines); correct for multi-line ones (CPU/MTIA).

This surfaced when exercising MTIA compile-time GEMM autotuning, whose generated benchmark kernels run set_driver_to_cpu() and thus take the CPU get_raw_stream override.

Test Plan:
E2E (Athena): the bug only manifests when MTIA's multi-line CPU `get_raw_stream` override is formatted into a generated benchmark kernel during compile-time autotuning. Lowered `1089450796_11` (merge) with `MTIAC_ENABLE_INDUCTOR_TRITON_AUTOTUNE=template` (benchmark kernels run `set_driver_to_cpu()`): 0 `IndentationError`, the autotune benchmark kernels import and run, `config.yaml` produced.

Not unit-tested: surfaces only in generated benchmark-kernel codegen on a multi-line `import_get_raw_stream_as` backend (CPU/MTIA); exercised end-to-end above.

Authored with AI assistance.

Reviewed By: zhang-cx

Differential Revision: D111502071




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo