### PR TITLE
[autograd] Guard end-of-backward leaf syncs that cross a CUDA graph capture boundary

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2884,6 +2884,143 @@ torch.cuda.synchronize()
         finally:
             torch.autograd.graph.set_override_stale_capture_stream(False)
 
+    class _NoWgrad(torch.autograd.Function):
+        """Uses the weight in forward but returns an undefined grad for it
+        (delayed-wgrad pattern: the real wgrad is computed out of band)."""
+
+        @staticmethod
+        def forward(ctx, x, w):
+            ctx.save_for_backward(w)
+            return x @ w.t()
+
+        @staticmethod
+        def backward(ctx, gy):
+            (w,) = ctx.saved_tensors
+            return gy @ w, None
+
+    def _warmup_no_wgrad(self):
+        """Warmup on the default stream so the weight's AccumulateGrad caches
+        a stale (default) stream, then return (x, w, keepalive).
+
+        AccumulateGrad nodes are cached weakly: `keepalive` retains the warmup
+        graph so the stale node survives until capture (as DDP/FSDP do by
+        stashing grad accumulators)."""
+        w = torch.nn.Parameter(torch.randn(16, 16, device="cuda"))
+        x = torch.randn(4, 16, device="cuda")
+        for _ in range(3):
+            y = self._NoWgrad.apply(x, w)
+            y.sum().backward(retain_graph=True)
+        torch.cuda.synchronize()
+        return x, w, y
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    def test_graph_capture_undefined_grad_stale_leaf_error(self):
+        """A leaf whose incoming grads are all undefined short-circuits out
+        of the input buffer before stream reconciliation, so the override
+        cannot fix its stale stream; the end-of-backward leaf sync must raise
+        a clear error instead of invalidating the capture."""
+        x, w, keepalive = self._warmup_no_wgrad()
+
+        s = torch.cuda.Stream()
+        with torch.cuda.stream(s):
+            g = torch.cuda.CUDAGraph()
+            g.capture_begin(capture_error_mode="relaxed")
+            try:
+                with self.assertRaisesRegex(
+                    RuntimeError, "across the capture boundary"
+                ):
+                    self._NoWgrad.apply(x, w).sum().backward()
+            finally:
+                g.capture_end()
+        torch.cuda.synchronize()
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    def test_graph_capture_undefined_grad_stale_leaf_override(self):
+        """With the override enabled, the meaningless sync with the stale
+        undefined-grad leaf is skipped and capture + replay succeed."""
+        x, w, keepalive = self._warmup_no_wgrad()
+
+        torch.autograd.graph.set_override_stale_capture_stream(True)
+        try:
+            s = torch.cuda.Stream()
+            with torch.cuda.stream(s):
+                g = torch.cuda.CUDAGraph()
+                g.capture_begin()
+                self._NoWgrad.apply(x, w).sum().backward()
+                g.capture_end()
+            torch.cuda.current_stream().wait_stream(s)
+            g.replay()
+            torch.cuda.synchronize()
+            self.assertIsNone(w.grad)
+        finally:
+            torch.autograd.graph.set_override_stale_capture_stream(False)
+
+    class _CpuComputeCudaWeight(torch.autograd.Function):
+        """CPU compute that references a CUDA weight: its AccumulateGrad is
+        created where apply() runs, and the weight's grad is undefined."""
+
+        @staticmethod
+        def forward(ctx, x_cpu, w_cuda):
+            return x_cpu * 2
+
+        @staticmethod
+        def backward(ctx, g):
+            return g * 2, None
+
+    def _capture_reverse_leaf(self):
+        """Build the reverse crossing: the weight's AccumulateGrad is created
+        inside the capture (its metadata stream is the capturing stream), and
+        backward() runs with the non-capturing default stream current. The
+        CPU root and CPU intermediate nodes produce no other stream syncs, so
+        the end-of-backward leaf sync is the only capture crossing."""
+        w = torch.nn.Parameter(torch.randn(8, device="cuda"))
+        x = torch.randn(8)  # CPU
+
+        s = torch.cuda.Stream()
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.stream(s):
+            g.capture_begin(capture_error_mode="relaxed")
+            torch.ones(4, device="cuda").mul_(2)  # non-empty capture
+            loss = self._CpuComputeCudaWeight.apply(x, w).sum()
+        return g, s, loss
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    def test_graph_capture_capturing_leaf_noncapturing_caller_error(self):
+        """Reverse direction of the leaf-sync guard: leaf stream capturing,
+        caller stream not."""
+        g, s, loss = self._capture_reverse_leaf()
+        try:
+            with self.assertRaisesRegex(RuntimeError, "across the capture boundary"):
+                loss.backward()
+        finally:
+            with torch.cuda.stream(s):
+                g.capture_end()
+        torch.cuda.synchronize()
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    def test_graph_capture_capturing_leaf_noncapturing_caller_override(self):
+        """Reverse direction with the override: the sync is skipped and the
+        capture completes and replays."""
+        torch.autograd.graph.set_override_stale_capture_stream(True)
+        try:
+            g, s, loss = self._capture_reverse_leaf()
+            loss.backward()
+            with torch.cuda.stream(s):
+                g.capture_end()
+            torch.cuda.current_stream().wait_stream(s)
+            g.replay()
+            torch.cuda.synchronize()
+        finally:
+            torch.autograd.graph.set_override_stale_capture_stream(False)
+
     @unittest.skipIf(
         not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
     )

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2913,6 +2913,7 @@ torch.cuda.synchronize()
         torch.cuda.synchronize()
         return x, w, y
 
+    @skipIfRocm(msg="hipBLASLt lazy handle initialization fails during graph capture")
     @unittest.skipIf(
         not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
     )
@@ -2936,6 +2937,7 @@ torch.cuda.synchronize()
                 g.capture_end()
         torch.cuda.synchronize()
 
+    @skipIfRocm(msg="hipBLASLt lazy handle initialization fails during graph capture")
     @unittest.skipIf(
         not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
     )

--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -548,11 +548,22 @@ def set_override_stale_capture_stream(enabled: bool) -> None:
     stream, allowing the capture to proceed. This is a process-global setting
     and is not thread-local.
 
+    The flag also governs the end-of-backward sync between each leaf's stream
+    and the caller's current stream. A leaf whose incoming gradients are all
+    undefined (e.g. patterns that compute certain gradients out of band and
+    return ``None`` from autograd) cannot be reconciled by the override, so
+    when exactly one of the two streams is capturing, that sync would cross
+    the capture boundary: with the flag enabled the sync is skipped (work on
+    a non-capturing stream is not part of the capture, so the ordering has no
+    effect on it); with the flag disabled a ``RuntimeError`` is raised.
+
     Args:
         enabled (bool): If ``True``, override stale non-capturing streams with
-            the producer's capturing stream during CUDA graph capture. If
-            ``False`` (the process-initial state), raise an error only when the
-            stale stream is the default stream (stream 0); other stale streams
+            the producer's capturing stream during CUDA graph capture, and
+            skip end-of-backward leaf syncs that would cross the capture
+            boundary. If ``False`` (the process-initial state), raise an error
+            when the stale stream is the default stream (stream 0) or when a
+            leaf sync would cross the capture boundary; other stale streams
             are left unchanged.
     """
     return torch._C._set_override_stale_capture_stream(enabled)

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -8,6 +8,7 @@
 #include <torch/csrc/autograd/variable.h>
 #include <torch/csrc/dynamo/compiled_autograd.h>
 
+#include <ATen/Context.h>
 #include <ATen/DeviceAccelerator.h>
 #include <ATen/DeviceGuard.h>
 #include <ATen/ExpandUtils.h>
@@ -204,7 +205,10 @@ C10_DEFINE_TLS_static(std::shared_ptr<ReadyQueue>, tls_local_ready_queue);
 //  2. remembering the "leaf streams" (streams each backward leaf node ran on)
 //  3. during exec_post_processing, for each leaf stream, sync the remembered
 //     current streams (on the leaf stream's device) with that
-//     leaf stream.
+//     leaf stream. If exactly one of the two streams is capturing a CUDA
+//     graph, this sync would cross the capture boundary; it is skipped under
+//     torch.autograd.graph.set_override_stale_capture_stream(True) and is an
+//     error otherwise.
 
 int NodeTask::getReentrantDepth() const {
   std::shared_ptr<GraphTask> graph_task = base_.lock();
@@ -723,7 +727,9 @@ void GraphTask::exec_post_processing() {
 
   // See Note [Streaming backwards].
   // Syncs caller_current_stream with leaf streams, so final_callbacks may use
-  // any grad on its device's current stream.
+  // any grad on its device's current stream. (Under
+  // set_override_stale_capture_stream(True), syncs that would cross a CUDA
+  // graph capture boundary are skipped; see below.)
   if (!leaf_streams.empty()) {
     for (const auto& leaf_stream : leaf_streams) {
       // stash_current_cuda/privateuse1_streams() stashed streams for all device
@@ -738,6 +744,45 @@ void GraphTask::exec_post_processing() {
 
       if (caller_current_stream.has_value() &&
           caller_current_stream != leaf_stream) {
+        // If exactly one of the two streams is capturing, this sync would
+        // cross the CUDA graph capture boundary and invalidate the capture
+        // (cudaErrorStreamCaptureIsolation). The common case is a leaf that
+        // ran on a stale non-capturing stream during capture: when all of a
+        // leaf's incoming grads are undefined, InputBuffer::add returns
+        // before its stream reconciliation, so the stale-capture-stream
+        // override never reconciles the leaf's stream. Work on a
+        // non-capturing stream is not part of the capture (and captured work
+        // produces no eager-visible results), so this ordering edge is
+        // meaningless in either direction: skip it under the override,
+        // otherwise raise an actionable error instead of the CUDA error.
+        if (caller_current_stream->is_capturing() !=
+            leaf_stream.is_capturing()) {
+          if (at::globalContext().overrideStaleCaptureStream()) {
+            TORCH_WARN_ONCE(
+                "Skipping the end-of-backward sync between a leaf stream and "
+                "the caller's current stream because exactly one of them is "
+                "capturing a CUDA graph (see "
+                "torch.autograd.graph.set_override_stale_capture_stream).");
+            continue;
+          }
+          TORCH_CHECK(
+              false,
+              "During CUDA graph capture, autograd tried to synchronize "
+              "streams across the capture boundary (leaf stream ",
+              leaf_stream.id(),
+              " on device ",
+              static_cast<int>(leaf_stream.device_index()),
+              leaf_stream.is_capturing() ? " is capturing but the caller's "
+                                           "stream is not"
+                                         : " is not capturing but the "
+                                           "caller's stream is",
+              "), which would invalidate the capture. A common cause is an "
+              "autograd leaf from warmup holding a stale stream. Either run "
+              "warmup on the capture stream, delete references to the "
+              "autograd graph (e.g. `del loss`) before capture, call "
+              "backward() with the capturing stream current, or call "
+              "torch.autograd.graph.set_override_stale_capture_stream(True).");
+        }
         auto event = c10::Event{leaf_stream.device_type()};
         event.record(leaf_stream);
         caller_current_stream->wait(event);
@@ -756,9 +801,9 @@ void GraphTask::exec_post_processing() {
     // final_callbacks run on the per-device caller_current_streams (the ambient
     // streams surrounding the user's call to backward()). This has two
     // benefits:
-    //  1. caller_current_streams have been synced with leaf_streams, so
-    //  callbacks may
-    //     safely access any grad.
+    //  1. caller_current_streams have been synced with leaf_streams (except
+    //     for syncs skipped under set_override_stale_capture_stream during
+    //     CUDA graph capture), so callbacks may safely access any grad.
     //  2. The callback's results can safely be used on (user-facing)
     //  caller_current_streams
     //     after backward().


### PR DESCRIPTION
 Fixes #189977.

When backward runs under CUDA graph capture, a leaf node can still hold a stream cached from a pre-capture warmup run. #180090 redirects such stale streams, but only where a gradient is actually handed into a node. A leaf whose incoming gradients are all undefined (patterns that compute some gradients out of band and return None from autograd) short-circuits out of the input buffer before that redirect runs, so its stale stream survives.

At the end of every backward the engine makes the caller's stream wait on each leaf's stream. When exactly one of those two streams is capturing, the wait crosses the capture boundary and capture fails with an opaque CUDA error (`cudaErrorStreamCaptureIsolation`). This happens in both directions: a capturing caller waiting on a stale non-capturing leaf (the common case), and a non-capturing caller waiting on a capturing leaf (e.g. an autograd graph rooted on the CPU, where this final leaf sync is the only crossing).

Guard that wait: when exactly one side is capturing, skip the (meaningless) sync under `set_override_stale_capture_stream(True)`, otherwise raise an actionable error naming the offending stream and the ways to fix it. Extend the flag's documentation accordingly. Adds tests for the error and the override path in each of the two boundary directions.

cc @ezyang @albanD @gqchen @nikitaved @soulitzer @Varal7 @bobrenjc93 @ptrblck @msaroufim @eqy @tinglvv @nWEIdia