### PR TITLE
[dynamo, nested graph breaks] suppress NGB in tree_map fast path

### DIFF
--- a/test/dynamo/test_nested_graph_breaks.py
+++ b/test/dynamo/test_nested_graph_breaks.py
@@ -1692,6 +1692,53 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(result, x + 2)
         self.assertEqual(cnts.frame_count, 2)
 
+    def test_tree_map_graph_break_preserves_structure(self):
+        from torch.utils._pytree import tree_map
+
+        def fn():
+            inps = [torch.randn(3)]
+            return tree_map(lambda x: torch.zeros_like(x, requires_grad=True), inps)
+
+        cnts = torch._dynamo.testing.CompileCounter()
+        result = torch.compile(fn, backend=cnts)()
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
+        self.assertIsInstance(result[0], torch.Tensor)
+        self.assertEqual(result[0].shape, (3,))
+        self.assertTrue(result[0].requires_grad)
+
+    def test_tree_map_graph_break_nested_structure(self):
+        from torch.utils._pytree import tree_map
+
+        def fn():
+            inps = {"a": [torch.randn(3)], "b": (torch.randn(2), torch.randn(4))}
+            return tree_map(lambda x: torch.zeros_like(x, requires_grad=True), inps)
+
+        result = torch.compile(fn, backend="eager")()
+        self.assertIsInstance(result, dict)
+        self.assertIsInstance(result["a"], list)
+        self.assertEqual(len(result["a"]), 1)
+        self.assertIsInstance(result["b"], tuple)
+        self.assertEqual(len(result["b"]), 2)
+        self.assertEqual(result["b"][0].shape, (2,))
+        self.assertEqual(result["b"][1].shape, (4,))
+
+    def test_tree_map_with_path_graph_break_preserves_structure(self):
+        from torch.utils._pytree import tree_map_with_path
+
+        def fn():
+            inps = [torch.randn(3), torch.randn(2)]
+            return tree_map_with_path(
+                lambda path, x: torch.zeros_like(x, requires_grad=True), inps
+            )
+
+        result = torch.compile(fn, backend="eager")()
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].shape, (3,))
+        self.assertEqual(result[1].shape, (2,))
+        self.assertTrue(result[0].requires_grad)
+
     def test_cxx_pytree_treespec_leaf_namespace(self):
         import torch.utils._cxx_pytree as cxx_pytree
 

--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -433,7 +433,6 @@ def forward(self, x_1):
 
         self._test(f, [torch.randn(2), torch.randn(2)])
 
-    @torch._dynamo.config.patch(nested_graph_breaks=False)
     def test_proxy_tensor(self):
         def f_grad(x):
             val = x.cos().cos().sum()

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -5328,6 +5328,7 @@ class InstructionTranslatorBase(
         self.has_no_inlined_calls = True
         self.parent = None
         self.is_child_tracer_active = False
+        self._tree_map_fast_path_active = False
         self.debug_locals = []
 
         self.package = package

--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -1256,11 +1256,18 @@ class VariableTracker(metaclass=VariableTrackerMeta):
             rest,
             tree_map_kwargs,
         )
-        return tree_map_fn_copy.call_function(
-            tx,
-            [map_fn, self, *rest],
-            tree_map_kwargs,
-        )
+        # The fallback inlines tree_map normally, creating a proper frame,
+        # so NGB can work correctly here -- clear the fast path flag.
+        prev = tx._tree_map_fast_path_active
+        tx._tree_map_fast_path_active = False
+        try:
+            return tree_map_fn_copy.call_function(
+                tx,
+                [map_fn, self, *rest],
+                tree_map_kwargs,
+            )
+        finally:
+            tx._tree_map_fast_path_active = prev
 
     def call_tree_map_with_path(
         self,
@@ -1334,11 +1341,16 @@ class VariableTracker(metaclass=VariableTrackerMeta):
             tree_map_kwargs,
             keypath,
         )
-        return tree_map_fn_copy.call_function(
-            tx,
-            [map_fn, self, *rest],
-            tree_map_kwargs,
-        )
+        prev = tx._tree_map_fast_path_active
+        tx._tree_map_fast_path_active = False
+        try:
+            return tree_map_fn_copy.call_function(
+                tx,
+                [map_fn, self, *rest],
+                tree_map_kwargs,
+            )
+        finally:
+            tx._tree_map_fast_path_active = prev
 
     def set_name_hint(self, name: str) -> None:
         pass

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -507,11 +507,13 @@ class BaseUserFunctionVariable(VariableTracker):
             and self.get_filename().endswith("torch/optim/lr_scheduler.py")
         ):
             return ConstantVariable.create(None)
+        # The tree_map fast path doesn't create an InliningIT for tree_map,
+        # so NGB resume functions would miss the tree_map continuation.
         return tx.inline_user_function_return(
             self,
             [*self.self_args(), *args],
             kwargs,
-            allow_nested_graph_breaks=True,
+            allow_nested_graph_breaks=not tx._tree_map_fast_path_active,
         )
 
     def call_obj_hasattr(
@@ -913,23 +915,28 @@ class UserFunctionVariable(BaseUserFunctionVariable):
         first_tree = tree_map_args[1]
         rest = tree_map_args[2:]
 
-        if is_tree_map_with_path:
-            return first_tree.call_tree_map_with_path(
-                tx,
-                tree_map_fn,
-                map_fn,
-                rest,
-                tree_map_kwargs,
-                keypath=(),
-            )
-        else:
-            return first_tree.call_tree_map(
-                tx,
-                tree_map_fn,
-                map_fn,
-                rest,
-                tree_map_kwargs,
-            )
+        prev = tx._tree_map_fast_path_active
+        tx._tree_map_fast_path_active = True
+        try:
+            if is_tree_map_with_path:
+                return first_tree.call_tree_map_with_path(
+                    tx,
+                    tree_map_fn,
+                    map_fn,
+                    rest,
+                    tree_map_kwargs,
+                    keypath=(),
+                )
+            else:
+                return first_tree.call_tree_map(
+                    tx,
+                    tree_map_fn,
+                    map_fn,
+                    rest,
+                    tree_map_kwargs,
+                )
+        finally:
+            tx._tree_map_fast_path_active = prev
 
     def _is_tree_map_function(self) -> bool:
         return (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

The tree_map fast path (`_maybe_call_tree_map_fastpath`) processes
tree_map at the variable level without creating an InliningIT for
tree_map itself. When a graph-breaking lambda is mapped over a tree
(e.g. `tree_map(lambda x: torch.zeros_like(x, requires_grad=True),
[tensor])`), NGB generates resume functions with the frame chain
`lambda -> fn` -- missing the tree_map frame entirely. The resume
function stores the bare tensor output directly, skipping
`treespec.unflatten()`, so `tree_map([tensor])` returns a bare
`Tensor` instead of `[Tensor]`.

Fix: set a `_tree_map_fast_path_active` flag on `tx` during fast path
execution. `BaseUserFunctionVariable.call_function` checks this flag
and passes `allow_nested_graph_breaks=False`, so any graph break inside
the mapped function propagates to the caller. The caller handles it by
emitting tree_map as a regular Python call in the output code, where it
executes eagerly with correct structure.

The flag is cleared in `_tree_map_fallback` and
`_tree_map_with_path_fallback` since those paths inline tree_map
normally (creating a proper frame where NGB works correctly).

Test Plan:

```
python test/dynamo/test_nested_graph_breaks.py NestedGraphBreakTests.test_tree_map_graph_break_preserves_structure NestedGraphBreakTests.test_tree_map_graph_break_nested_structure NestedGraphBreakTests.test_tree_map_with_path_graph_break_preserves_structure
python test/test_proxy_tensor.py -k test_proxy_tensor
python test/dynamo/test_nested_graph_breaks.py
python test/dynamo/test_misc.py
```

Co-authored-by: Claude <noreply@anthropic.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98