### PR TITLE
[dynamo, nested graph breaks] fix NGB for custom_ops, nn_module hooks, and wrapper subclass hasattr

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -16872,6 +16872,38 @@ def forward(self, L_x_ : torch.Tensor):
         result = opt()
         self.assertEqual(result.shape, (3, 7))
 
+    @torch._dynamo.config.patch(nested_graph_breaks=True)
+    def test_custom_op_register_fake_inside_traced_function(self):
+        """Custom op defined with register_fake inside a traced function must
+        work under NGB. The register_fake side effect mutates _abstract_fn on
+        the real CustomOpDef, which NGB suppress ensures happens eagerly.
+        """
+        from typing import Tuple
+
+        def get_my_op():
+            @torch.library.custom_op("test::ngb_id", mutates_args=[])
+            def ngb_id(x: torch.Tensor) -> Tuple[torch.Tensor]:
+                return (x.clone(),)
+
+            @ngb_id.register_fake
+            def _(x: torch.Tensor) -> Tuple[torch.Tensor]:
+                return (x.clone(),)
+
+            return ngb_id
+
+        def fn(x):
+            my_op = get_my_op()
+            return my_op(x)
+
+        cnt = torch._dynamo.testing.CompileCounter()
+        opt = torch.compile(fn, backend=cnt)
+        x = torch.randn(3)
+        result = opt(x)
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0], x)
+        self.assertGreaterEqual(cnt.frame_count, 1)
+
 
 instantiate_parametrized_tests(MiscTests)
 

--- a/test/dynamo/test_subclasses.py
+++ b/test/dynamo/test_subclasses.py
@@ -2544,6 +2544,24 @@ class GraphModule(torch.nn.Module):
         out_test = torch.compile(f, backend="aot_eager", fullgraph=True)(x)
         self.assertEqual(out_ref, out_test)
 
+    def test_wrapper_subclass_hasattr_tensor_flatten(self):
+        from torch.utils._python_dispatch import is_traceable_wrapper_subclass
+
+        cnt = torch._dynamo.testing.CompileCounter()
+
+        @torch.compile(backend=cnt)
+        def f(x):
+            if is_traceable_wrapper_subclass(x):
+                return torch.add(x, 1)
+            return torch.mul(x, 2)
+
+        x = ScaledTensor(torch.randn(2, 4), torch.randn(3), constant=2)
+        result = f(x)
+        expected = torch.add(x, 1)
+        self.assertEqual(result._data, expected._data)
+        self.assertEqual(cnt.frame_count, 1)
+        self.assertEqual(cnt.op_count, 1)
+
     def test_support_bases(self):
         import torch.fx._symbolic_trace
 

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -3568,7 +3568,9 @@ if torch.distributed.is_available():
 # Modules in MOD_INLINELIST where nested graph breaks should be suppressed.
 # These are large internal modules that are inlined for correctness but whose
 # internal operations are not worth compiling as separate NGB subgraphs.
-NGB_SUPPRESS_INLINELIST: set[str] = set()
+NGB_SUPPRESS_INLINELIST: set[str] = {
+    "torch._library.custom_ops",
+}
 
 if torch.distributed.is_available():
     NGB_SUPPRESS_INLINELIST.add("torch.distributed")

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -1402,14 +1402,18 @@ class UnspecializedNNModuleVariable(UserDefinedObjectVariable):
             if not tx.output.side_effects.has_pending_mutation_of_attr(self, name):
                 hooks_dict = getattr(self.value, name)
                 if isinstance(hooks_dict, dict) and len(hooks_dict) == 0:
-                    if self.source:
-                        hooks_source = AttrSource(self.source, name)
+                    hooks_source = (
+                        AttrSource(self.source, name) if self.source else None
+                    )
+                    if hooks_source:
                         install_guard(
                             hooks_source.make_guard(
                                 GuardBuilder.EMPTY_NN_MODULE_HOOKS_DICT
                             )
                         )
-                    return variables.ConstDictVariable({}, user_cls=type(hooks_dict))
+                    return variables.ConstDictVariable(
+                        {}, user_cls=type(hooks_dict), source=hooks_source
+                    )
 
         # For non-empty hook dicts, one way is to just fallback to VariableTracker.build() and create a ConstDictVariable.
         # However, ConstDictVariable guards on keys. This can cause recompiles when the same hook is installed for

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -638,10 +638,6 @@ class TensorVariable(VariableTracker):
     ) -> ConstantVariable:
         from . import GetAttrVariable
 
-        # TODO - This is not a good solution but solves an accuracy issue.
-        # Today, getattro_impl returns GetAttrVariable for both non-existent
-        # attributes and existing attributes. This is a bug and requires more
-        # deep dive.
         if name in all_tensor_attrs:
             return ConstantVariable.create(True)
 
@@ -649,9 +645,20 @@ class TensorVariable(VariableTracker):
             var = VariableTracker.build(tx, getattr).call_function(
                 tx, [self, VariableTracker.build(tx, name)], {}
             )
-            # in the event that TensorVariable returns NotImplemented
-            # GetAttrBuiltinVariable.call_function returns GetAttrVariable
-            ret_val = not isinstance(var, GetAttrVariable)
+            # getattro_impl returns GetAttrVariable as a fallback for both
+            # non-existent and existing-but-unhandled attributes. When that
+            # happens, disambiguate by checking the fake tensor directly.
+            # Only do this for wrapper subclasses to avoid leaking
+            # FakeTensor-internal attributes (e.g. fake_device).
+            if isinstance(var, GetAttrVariable):
+                fake_val = self.as_proxy().node.meta.get("example_value")
+                ret_val = (
+                    fake_val is not None
+                    and is_traceable_wrapper_subclass(fake_val)
+                    and hasattr(fake_val, name)
+                )
+            else:
+                ret_val = True
         except (AttributeError, ObservedAttributeError):
             ret_val = False
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

Three NGB-related fixes:

1. **NGB suppress for `torch._library.custom_ops`**: When `register_fake` is
   called inside a traced function, the side effect (mutating `_abstract_fn` on
   the real `CustomOpDef`) must execute eagerly. Add `torch._library.custom_ops`
   to `NGB_SUPPRESS_INLINELIST` so graph breaks in this module propagate to the
   caller instead of being handled via NGB subgraphs.

2. **Empty hooks dict source**: `ConstDictVariable` for empty nn.Module hook
   dicts (e.g. `_forward_hooks`) was created without a source, causing weakref
   reconstruction failures in `RemovableHandle` under NGB. Pass
   `source=hooks_source` so the dict can be properly reconstructed.

3. **Wrapper subclass `hasattr` fix**: `TensorVariable.call_obj_hasattr`
   returned `False` for existing attributes on wrapper subclasses (e.g.
   `__tensor_flatten__`) because `getattro_impl` returns `GetAttrVariable` as
   a fallback for both non-existent and existing-but-unhandled attributes.
   Disambiguate by checking `hasattr(fake_val, name)` on the fake tensor when
   `GetAttrVariable` is returned. This is gated on
   `is_traceable_wrapper_subclass(fake_val)` to prevent leaking
   FakeTensor-internal attributes (e.g. `fake_device`).

Test Plan:

```
python test/dynamo/test_misc.py MiscTests.test_custom_op_register_fake_inside_traced_function
python test/dynamo/test_subclasses.py SubclassTests.test_wrapper_subclass_hasattr_tensor_flatten
python test/dynamo/test_subclasses.py -k hasattr
python test/dynamo/test_misc.py
python test/dynamo/test_subclasses.py
```

Co-authored-by: Claude <noreply@anthropic.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98