### PR TITLE
Fix test_linetable_311 co_lines comparison on Python 3.11

### DIFF
--- a/test/dynamo/test_bytecode_utils.py
+++ b/test/dynamo/test_bytecode_utils.py
@@ -11,6 +11,21 @@ from torch._dynamo import bytecode_analysis, bytecode_transformation
 from torch._dynamo.testing import skipIfNotPy311, skipIfNotPy312
 
 
+def coalesced_co_lines(code):
+    # co_lines() entries are not guaranteed to be maximally coalesced: our
+    # linetable assembler can emit adjacent entries with the same line number
+    # (e.g. around EXTENDED_ARG) that CPython's compiler would fold into one.
+    # This is a benign encoding difference (co_positions is unaffected), so
+    # merge contiguous same-line entries before comparing.
+    result = []
+    for start, end, lineno in code.co_lines():
+        if result and result[-1][2] == lineno and result[-1][1] == start:
+            result[-1] = (result[-1][0], end, lineno)
+        else:
+            result.append((start, end, lineno))
+    return result
+
+
 class BytecodeTests(torch._dynamo.test_case.TestCase):
     @skipIfNotPy311
     def test_linetable_311_writer1(self):
@@ -33,7 +48,7 @@ class BytecodeTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(len(l1), len(l2))
         for p1, p2 in zip(l1, l2):
             self.assertEqual(p1, p2)
-        self.assertEqual(list(fn.__code__.co_lines()), list(result[1].co_lines()))
+        self.assertEqual(coalesced_co_lines(fn.__code__), coalesced_co_lines(result[1]))
 
     @skipIfNotPy311
     def test_linetable_311_writer2(self):
@@ -74,7 +89,7 @@ def fn():
         self.assertEqual(len(l1), len(l2))
         for p1, p2 in zip(l1, l2):
             self.assertEqual(p1, p2)
-        self.assertEqual(list(fn.__code__.co_lines()), list(result[1].co_lines()))
+        self.assertEqual(coalesced_co_lines(fn.__code__), coalesced_co_lines(result[1]))
 
     @unittest.skipIf(
         sys.version_info >= (3, 11),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #189604
* __->__ #189603

test_linetable_311_writer2 has been failing on Python 3.11 since #189306,
which replaced the line-table equality check from co_lnotab (removed in 3.15)
with a raw list(co_lines()) comparison. co_lines() is sensitive to how adjacent
instructions sharing a line are grouped into linetable entries: our linetable
assembler emits a separate entry per instruction around EXTENDED_ARG, whereas
CPython's compiler folds contiguous same-line instructions into one entry. The
line mapping is identical (co_positions is equal, and the code runs correctly),
so this is a benign encoding difference, but the raw list comparison flagged it
(2062 vs 2575 entries). writer1 happened not to hit this, so only writer2 failed.

Fix: compare a coalesced form of co_lines() that merges contiguous same-line
entries, which normalizes the grouping while still validating the line mapping.
This works across 3.11-3.15 (unlike co_lnotab, which is gone in 3.15).

Test Plan:

```
python test/dynamo/test_bytecode_utils.py BytecodeTests.test_linetable_311_writer1 BytecodeTests.test_linetable_311_writer2
python test/dynamo/test_bytecode_utils.py
```

Both pass on Python 3.11.15 (20 ran, 2 skipped).

Authored-with: Claude (Anthropic AI assistant).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98