### PR TITLE
[CI] Make checkout retry resilient to container clean failures and cap fetch concurrency

### DIFF
--- a/.github/actions/checkout-pytorch/action.yml
+++ b/.github/actions/checkout-pytorch/action.yml
@@ -46,6 +46,7 @@ runs:
       env:
         NO_SUDO: ${{ inputs.no-sudo }}
       run: |
+        # Use all available CPUs for fetching
         cd "${GITHUB_WORKSPACE}"
         git config --global fetch.parallel 0
         git config --global submodule.fetchJobs 0

--- a/.github/actions/checkout-pytorch/action.yml
+++ b/.github/actions/checkout-pytorch/action.yml
@@ -46,11 +46,9 @@ runs:
       env:
         NO_SUDO: ${{ inputs.no-sudo }}
       run: |
-        # Cap concurrency: unbounded (0 == per-core) fetch bursts to github.com
-        # get throttled into transient HTTP 408/429, especially with submodules.
         cd "${GITHUB_WORKSPACE}"
-        git config --global fetch.parallel 8
-        git config --global submodule.fetchJobs 8
+        git config --global fetch.parallel 0
+        git config --global submodule.fetchJobs 0
 
         # Retry throttled fetches instead of failing hard. Native in git >= 2.54
         # (retries HTTP 429, honoring Retry-After); maxRetries defaults to 0 so

--- a/.github/actions/checkout-pytorch/action.yml
+++ b/.github/actions/checkout-pytorch/action.yml
@@ -46,10 +46,18 @@ runs:
       env:
         NO_SUDO: ${{ inputs.no-sudo }}
       run: |
-        # Use all available CPUs for fetching
+        # Cap concurrency: unbounded (0 == per-core) fetch bursts to github.com
+        # get throttled into transient HTTP 408/429, especially with submodules.
         cd "${GITHUB_WORKSPACE}"
-        git config --global fetch.parallel 0
-        git config --global submodule.fetchJobs 0
+        git config --global fetch.parallel 8
+        git config --global submodule.fetchJobs 8
+
+        # Retry throttled fetches instead of failing hard. Native in git >= 2.54
+        # (retries HTTP 429, honoring Retry-After); maxRetries defaults to 0 so
+        # it must be set explicitly. Inert no-op on older git, so set uncondi-
+        # tionally. retryAfter is the fallback delay when no Retry-After header.
+        git config --global http.maxRetries 3
+        git config --global http.retryAfter 2
 
         # Clean workspace. The default checkout action should also do this, but
         # do it here as well just in case
@@ -106,11 +114,13 @@ runs:
           $* || (sleep 1 && $*) || (sleep 2 && $*) || (sleep 4 && $*) || (sleep 8 && $*)
         }
         echo "${GITHUB_WORKSPACE}"
+        # Clear the contents, not the dir itself, which can't be unlinked when
+        # its parent is root-owned (sudo-less containers). find (not a glob) so
+        # .git is removed too, letting the retry checkout clone in cleanly.
         if [ -z "${NO_SUDO}" ]; then
-          retry sudo rm -rf "${GITHUB_WORKSPACE}"
-          mkdir "${GITHUB_WORKSPACE}"
+          retry sudo find "${GITHUB_WORKSPACE}" -mindepth 1 -delete
         else
-          retry find "${GITHUB_WORKSPACE}" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+          retry find "${GITHUB_WORKSPACE}" -mindepth 1 -delete
         fi
 
     - name: Checkout PyTorch (try again)


### PR DESCRIPTION
Checking out PyTorch is a recurring source of CI flakiness. Two robustness issues in the `checkout-pytorch` action.

**1. The retry safety net is defeated in container runners.** After a failed first checkout, the action reset the workspace and retried. It did `rm -rf "$GITHUB_WORKSPACE"`, but the workspace *directory* can't be unlinked when its parent is root-owned and the job runs as an unprivileged uid with no sudo (the contents are removable, the dir entry is not). That `rm` failed and, under `set -e`, aborted the composite before the retry checkout could run, turning a transient fetch error into a hard failure. Example: [run 29116512761](https://github.com/pytorch/pytorch/actions/runs/29116512761/job/86448178127) hit `HTTP 408` during a promisor fetch, then died on `rm: cannot remove '/__w/pytorch/pytorch': Permission denied`. Fix: clear the workspace *contents* instead (via `find`, so `.git` is included) -- which is what the retry checkout needs to clone into.

**2. Unbounded fetch concurrency.** `fetch.parallel`/`submodule.fetchJobs` were `0` (one job per core); on large runners with 37 recursive submodules that connection burst gets throttled into HTTP 408/429. Cap both at 8.

Authored with the assistance of an AI coding assistant.