### PR TITLE
[CI] Default linux checkout to blobless instead of treeless

### DIFF
--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -26,7 +26,13 @@ inputs:
   checkout-mode:
     description: Checkout mode passed to checkout-pytorch (one of "normal", "blobless", "treeless").
     required: false
-    default: 'treeless'
+    # blobless (blob:none), not treeless (tree:0): these jobs materialize the
+    # full working tree, so with treeless git must fetch every tree object
+    # on demand from github.com during checkout (amplified by recursive
+    # submodules), and those promisor fetches are a common source of transient
+    # HTTP 408/429 flakiness. blobless downloads all trees up front so checkout
+    # needs no lazy tree fetch; only file blobs are fetched, in one batch.
+    default: 'blobless'
   github-token:
     description: GITHUB_TOKEN, needed to retrieve the workflow job id.
     required: false


### PR DESCRIPTION
Not ready for review yet, need to understand the pros and cons of blobless v.s. treeless better before pushing this out

`setup-linux` checks out with a treeless partial clone (`--filter=tree:0`), which downloads no tree objects up front. Since linux build and test jobs materialize the full working tree, git then fetches every tree object on demand from github.com during `git checkout` (amplified by the 37 recursive submodules on build jobs). Those lazy promisor fetches are a recurring source of transient HTTP 408/429 flakiness, e.g. [run 29116512761](https://github.com/pytorch/pytorch/actions/runs/29116512761/job/86448178127):

```
error: RPC failed; HTTP 408 curl 22 The requested URL returned error: 408
fatal: could not fetch 7671090f... from promisor remote
```

Switch to blobless (`--filter=blob:none`): all trees are downloaded up front so checkout needs no lazy tree fetch; only file blobs are fetched, in a single batch. These jobs check out the full tree anyway, so the blob cost is paid either way -- treeless only defers and fragments it into fragile per-tree round trips. The trade is ~195MB more trees in the initial fetch per job (still ~7x smaller than a full clone). Jobs wanting another mode still override explicitly (e.g. `_docs.yml` uses `normal`).

Authored with the assistance of an AI coding assistant.