### PR TITLE
[inductor] Deflake test_autotune_conv1x1 by pinning conv backend to TRITON

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -1232,6 +1232,7 @@ class TestMaxAutotune(TestCase):
             {
                 "max_autotune": True,
                 "max_autotune_gemm_backends": "TRITON",
+                "max_autotune_conv_backends": "TRITON",
                 "max_autotune_gemm_search_space": search_space,
             }
         ):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189608

test_autotune_conv1x1 asserts that the generated code never falls back to
`extern_kernels.convolution`, but it only set
`max_autotune_gemm_backends="TRITON"` and left
`max_autotune_conv_backends` at its default of `"ATEN,TRITON"`. The ATen
extern convolution therefore stayed in the conv autotune candidate set
alongside the Triton conv template. For this tiny 1x1 conv (`4x3x32x32`,
`16x3x1x1`) the two candidates benchmark within ~3% of each other, so
measurement noise let ATen win on a meaningful fraction of runs (~7/24 on
ROCm), which emitted `extern_kernels.convolution` and failed the
`check_not`.

Also pinning `max_autotune_conv_backends="TRITON"` drops the ATen
extern-conv candidate (it is only added when "ATEN" is in that config),
leaving the Triton candidates (`conv1x1_via_mm` and the Triton conv
template). The empty-choices fallback that would otherwise re-add ATen
does not fire because those Triton choices remain, so
`extern_kernels.convolution` can no longer be emitted regardless of
benchmark noise. This matches the test's original intent.

Test Plan:
```
python test/inductor/test_max_autotune.py -k test_autotune_conv1x1
```
On ROCm, stress-run the above (previously ~7/24 runs failed) to confirm
the flake is gone.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo