### PR TITLE
Fix exact job_id matching for S3 CI artifacts

### DIFF
--- a/tools/stats/upload_stats_lib.py
+++ b/tools/stats/upload_stats_lib.py
@@ -105,7 +105,7 @@ def download_s3_artifacts(
     for obj in objs:
         object_name = Path(obj.key).name
         # target an artifact for a specific job_id if provided, otherwise skip the download.
-        if job_id is not None and str(job_id) not in object_name:
+        if job_id is not None and not object_name.endswith(f"_{job_id}.zip"):
             continue
         found_one = True
         p = Path(Path(obj.key).name)

--- a/tools/test/test_upload_stats_lib.py
+++ b/tools/test/test_upload_stats_lib.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import gzip
 import inspect
 import json
+import os
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 from typing import Any
@@ -14,7 +16,11 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))
 
 from tools.stats.upload_metrics import add_global_metric, emit_metric, global_metrics
-from tools.stats.upload_stats_lib import get_s3_resource, remove_nan_inf
+from tools.stats.upload_stats_lib import (
+    download_s3_artifacts,
+    get_s3_resource,
+    remove_nan_inf,
+)
 
 
 sys.path.remove(str(REPO_ROOT))
@@ -254,6 +260,41 @@ class TestUploadStats(unittest.TestCase):
         emit_metric("metric_name", metric)
 
         self.assertTrue(self.emitted_metric["did_not_emit"])
+
+    def test_download_s3_artifacts_matches_exact_job_id_suffix(
+        self, mock_resource: Any
+    ) -> None:
+        class MockBody:
+            def __init__(self, data: bytes) -> None:
+                self.data = data
+
+            def read(self) -> bytes:
+                return self.data
+
+        class MockS3Object:
+            def __init__(self, key: str) -> None:
+                self.key = key
+
+            def get(self) -> dict[str, MockBody]:
+                return {"Body": MockBody(self.key.encode())}
+
+        objects = [
+            MockS3Object("pytorch/pytorch/111/2/artifact/logs-test-run_123.zip"),
+            MockS3Object("pytorch/pytorch/111/2/artifact/logs-test-run_9123.zip"),
+            MockS3Object("pytorch/pytorch/111/2/artifact/logs-test-run_1234.zip"),
+            MockS3Object("pytorch/pytorch/111/2/artifact/logs-test-run_456.zip"),
+        ]
+        mock_resource.return_value.Bucket.return_value.objects.filter.return_value = objects
+
+        old_cwd = Path.cwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            os.chdir(temp_dir)
+            try:
+                artifact_paths = download_s3_artifacts("logs-test", 111, 2, job_id=123)
+            finally:
+                os.chdir(old_cwd)
+
+        self.assertEqual(artifact_paths, [Path("logs-test-run_123.zip")])
 
     def test_remove_nan_inf(self, _mocked_resource: Any) -> None:
         checks = [

--- a/tools/test/test_upload_stats_lib.py
+++ b/tools/test/test_upload_stats_lib.py
@@ -284,7 +284,9 @@ class TestUploadStats(unittest.TestCase):
             MockS3Object("pytorch/pytorch/111/2/artifact/logs-test-run_1234.zip"),
             MockS3Object("pytorch/pytorch/111/2/artifact/logs-test-run_456.zip"),
         ]
-        mock_resource.return_value.Bucket.return_value.objects.filter.return_value = objects
+        mock_resource.return_value.Bucket.return_value.objects.filter.return_value = (
+            objects
+        )
 
         old_cwd = Path.cwd()
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
# Fixing an Issue

Before submitting, please review:
- [The Ultimate Guide to PyTorch Contributions](https://github.com/pytorch/pytorch/wiki/The-Ultimate-Guide-to-PyTorch-Contributions#getting-started-with-pull-requests)
- [AI-Assisted Development](https://github.com/pytorch/pytorch/blob/main/CONTRIBUTING.md#ai-assisted-development) policy

---

## Issue

Fixes #189615

## Summary

### What Problem This Solves

`download_s3_artifacts(..., job_id=...)` is used by PyTorch CI stats tooling to narrow S3 artifact downloads to a specific GitHub Actions job. The helper already lists artifacts under the requested workflow run and run attempt, but the optional `job_id` filter is what selects the one artifact for the job currently being processed.

The previous filter checked whether the job id digits appeared anywhere in the artifact filename. That means requesting `job_id=123` could also match sibling artifact names such as `logs-test-run_9123.zip` or `logs-test-run_1234.zip`, even though those filenames belong to different job ids. In other words, the filter treated the job id like a loose substring instead of the final job-id token in the artifact name.

For the utilization stats path, that can turn a single-job lookup into multiple downloaded artifact paths. The caller treats `len(artifact_paths) > 1` as an ambiguous result and skips processing for that job, so an imprecise filename match can prevent utilization stats from being uploaded for the requested job.

### Changes

This updates the job-specific filter in `download_s3_artifacts()` to require the artifact filename to end with the final `_<job_id>.zip` token:

```diff
-        if job_id is not None and str(job_id) not in object_name:
+        if job_id is not None and not object_name.endswith(f"_{job_id}.zip"):
             continue
```

The prefix-based S3 object listing is unchanged, and calls without a `job_id` continue to use the existing prefix-only behavior.

### Evidence

A focused unit test covers the ambiguous suffix case with these mocked S3 artifact names:

```text
logs-test-run_123.zip
logs-test-run_9123.zip
logs-test-run_1234.zip
logs-test-run_456.zip
```

With `job_id=123`, the expected result is only:

```text
logs-test-run_123.zip
```

Validation run for this PR:

```text
/home/zxy/miniforge3/envs/prw-pytorch-pr-py310/bin/python tools/test/test_upload_stats_lib.py
/home/zxy/miniforge3/envs/prw-pytorch-pr-py310/bin/python -m spin fixlint -- tools/stats/upload_stats_lib.py tools/test/test_upload_stats_lib.py
git diff --check
```

### Possible call chain / impact

```text
upload_utilization_stats.py
  -> _get_utilization_data_from_s3(...)
  -> download_s3_artifacts(..., job_id)
  -> S3 artifact filename filter
  -> len(artifact_paths) > 1 branch skips utilization stats processing
```

This PR narrows only the `job_id` filename match inside `download_s3_artifacts()`. It does not change S3 prefix selection, artifact download/extraction, utilization stats parsing, or callers that do not pass a `job_id`.

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No.

## Validation

- `/home/zxy/miniforge3/envs/prw-pytorch-pr-py310/bin/python tools/test/test_upload_stats_lib.py`
- `/home/zxy/miniforge3/envs/prw-pytorch-pr-py310/bin/python -m spin fixlint -- tools/stats/upload_stats_lib.py tools/test/test_upload_stats_lib.py`
- `git diff --check`