### PR TITLE
[inductor] Type the compiled-graph runner / boxed-callable surfaces in output_code.py

### DIFF
--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -142,10 +142,11 @@ from .virtualized import V
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator, Sequence
 
-    from torch._inductor.output_code import _StrideExprStr
+    from torch._inductor.output_code import _StrideExprStr, CompiledFnRunner
     from torch._ops import OpOverload
     from torch.export.pt2_archive._package_weights import Weights
 
+    from .codecache import CacheInfo
     from .ir import ExternKernelNode
 
 
@@ -995,7 +996,7 @@ def _compile_fx_inner(
 
         mb_compiled_graph: OutputCode | None = None
         key_info = None
-        cache_info = None
+        cache_info: CacheInfo | None = None
         remote_cache = None
         constants = CompiledFxGraphConstantsWithGm(gm)
         # TODO: this time will be slightly inconsistent with the one computed
@@ -1184,7 +1185,7 @@ def _compile_fx_inner(
         # fx_graph_cache_miss
         # fx_graph_cache_bypass
         # fx_graph_cache_disabled
-        cache_event_metadata: dict[str, Any] = dict(cache_info) if cache_info else {}
+        cache_event_metadata = dict(cache_info) if cache_info else {}
         CompileEventLogger.instant(
             f"fx_graph_cache_{cache_state}",
             metadata=cache_event_metadata,
@@ -1611,7 +1612,7 @@ class _InProcessFxCompile(FxCompile):
                     # not going to touch it for now
 
                     compiled_fn: Any
-                    compiled_fn_runner = None
+                    compiled_fn_runner: CompiledFnRunner | None = None
                     with dynamo_timed(
                         "GraphLowering.compile_to_fn", log_pt2_compile_event=True
                     ):

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -27,7 +27,7 @@ import dataclasses
 import logging
 import os
 from functools import partial
-from typing import Any, cast, TYPE_CHECKING, TypeAlias
+from typing import Any, cast, Protocol, TYPE_CHECKING, TypeAlias
 
 import torch
 from torch._custom_class_base import CustomClassBase
@@ -76,6 +76,24 @@ if TYPE_CHECKING:
 
     from .compile_fx import _CompileFxKwargs
     from .triton_bundler import TritonBundle
+
+    # Boxed calling convention: a single list of inputs in, graph outputs out.
+    # Inductor's compiled-graph entry points and cudagraph wrappers all take
+    # exactly this shape, so we name it rather than repeating Callable[..., Any].
+    _BoxedCallable: TypeAlias = Callable[[Sequence[InputType]], object]
+
+    class CompiledFnRunner(Protocol):
+        """Runner emitted by the Python wrapper when graph_partition is on.
+
+        codegen writes a Runner class (see codegen/wrapper.py) whose partitions
+        hold the per-partition callables and whose recursively_apply_fns rewrites
+        each partition in place (e.g. wrapping it in a cudagraph).
+        """
+
+        partitions: list[Callable[..., Any]]
+
+        def recursively_apply_fns(self, fns: Sequence[Callable[..., Any]]) -> None: ...
+
 
 log = logging.getLogger(__name__)
 
@@ -185,7 +203,7 @@ def maybe_handle_backward_generation(
         if manager is None:
             raise AssertionError("CUDAGraph manager must not be None")
 
-        def compiled_artifact(new_inputs: list[Any]) -> Callable[..., Any]:
+        def compiled_artifact(new_inputs: Sequence[InputType]) -> object:
             manager.set_to_running_backward()  # type: ignore[union-attr]
             return compiled_graph_callable(new_inputs)
 
@@ -443,7 +461,10 @@ def maybe_realign_inputs(
                 mutated_inputs_idxs,
             )
             if new_callable is not compiled_graph.current_callable:
-                compiled_graph.current_callable = new_callable
+                # align_inputs_from_check_idxs preserves the boxed convention but
+                # its wrapper is typed with a list[InputType] parameter; the field
+                # uses the Sequence[InputType] boxed alias, so re-tag it here.
+                compiled_graph.current_callable = cast("_BoxedCallable", new_callable)
 
 
 class CompiledFxGraphConstants:
@@ -498,9 +519,9 @@ class CompiledFxGraph(OutputCode):
     to support FxGraph caching.
     """
 
-    current_callable: Callable[..., Any] | None
-    recursively_apply_fns: Callable[..., Any] | None
-    compiled_fn_runner: Any | None
+    current_callable: _BoxedCallable | None
+    recursively_apply_fns: Callable[[Sequence[Callable[..., Any]]], None] | None
+    compiled_fn_runner: CompiledFnRunner | None
     cache_key: str
     source_code: str = dataclasses.field(repr=False)  # Do not display source_code
     runnable_graph_str: str = dataclasses.field(repr=False)  # Do not display graph
@@ -552,7 +573,7 @@ class CompiledFxGraph(OutputCode):
 
     def __init__(
         self,
-        current_callable: Callable[..., Any] | None,
+        current_callable: _BoxedCallable | None,
         graph: GraphLowering,
         gm: torch.fx.GraphModule,
         output_strides: list[tuple[_StrideExprStr, ...] | None],
@@ -567,7 +588,7 @@ class CompiledFxGraph(OutputCode):
         inputs_to_check: Sequence[int],
         runnable_graph_str: str,
         inductor_post_grad_graph_str: str,
-        compiled_fn_runner: Any | None = None,
+        compiled_fn_runner: CompiledFnRunner | None = None,
         inductor_provenance_mapping_str: str | None = None,
         inductor_provenance_stack_traces_str: str | None = None,
     ) -> None:


### PR DESCRIPTION
### Summary

Replaces the loosely-typed "how the compiled graph is called/cached" surfaces
in the Inductor output-code layer with precise types, so the shapes are
documented at the definition site and checked by the type checker rather than
reconstructed by hand at each call site.

- `CompiledFnRunner` is a `Protocol` describing the `Runner` object the Python
  wrapper emits when `graph_partition` is enabled (produced via
  `getattr(compiled_module, "runner", None)`). It surfaces the two members the
  output-code layer consumes: `partitions` and `recursively_apply_fns`.
  `CompiledFxGraph.compiled_fn_runner` and the matching `compile_fx.py` local
  move from `Any | None` to `CompiledFnRunner | None`.
- `_BoxedCallable` is a named alias for the boxed calling convention
  (`Callable[[Sequence[InputType]], object]`) used by `current_callable`,
  replacing `Callable[..., Any]`. `recursively_apply_fns` is tightened to its
  real `Callable[[Sequence[Callable[..., Any]]], None]` shape.
- `compile_fx.py` reuses the existing `CacheInfo` TypedDict for its `cache_info`
  local (both functions that assign it already return `CacheInfo`) and drops the
  redundant `dict[str, Any]` annotation on `cache_event_metadata`.

The changes are annotation-only (no runtime behavior change).

### Test Plan

```
lintrunner --take PYFMT,RUFF,PYREFLY,CODESPELL,FLAKE8 -a \
  torch/_inductor/output_code.py torch/_inductor/compile_fx.py
```

Pyrefly reports no new errors in either file.

This PR was authored with the assistance of an AI coding assistant.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo