### PR TITLE
[distributed][docs] Fix group_src docstring in irecv

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -2978,7 +2978,7 @@ def irecv(
         group (ProcessGroup, optional): The process group to work on. If None,
             the default process group will be used.
         tag (int, optional): Tag to match recv with remote send
-        group_src (int, optional): Destination rank on ``group``.  Invalid to specify both ``src`` and ``group_src``.
+        group_src (int, optional): Source rank on ``group``.  Invalid to specify both ``src`` and ``group_src``.
 
     Returns:
         A distributed request object.

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -3463,7 +3463,7 @@ def irecv(
         group (ProcessGroup, optional): The process group to work on. If None,
             the default process group will be used.
         tag (int, optional): Tag to match recv with remote send
-        group_src (int, optional): Destination rank on ``group``.  Invalid to specify both ``src`` and ``group_src``.
+        group_src (int, optional): Source rank on ``group``.  Invalid to specify both ``src`` and ``group_src``.
 
     Returns:
         A distributed request object.


### PR DESCRIPTION
Rebase of #183847 onto latest `main` — draft, opened to get a fresh CI run and check whether the aarch64/MPS test failures seen there were unrelated flaky infra (docstring-only change) or something that's actually still broken.

Same one-line fix: `group_src` is the source rank on `group` (this is `irecv`, a receive call), not the destination.

If CI comes back clean here, will close this in favor of re-merging #183847 (or convert this one and close that one, whichever is cleaner to review).