### PR TITLE
[MPS] Fix two exec_ternary_kernel dispatch bugs

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -1593,10 +1593,12 @@ void MetalShaderLibrary::exec_ternary_kernel(TensorIteratorBase& iter, const std
     return;
   }
 
-  // Decompose 64-bit tensor into 32-bit ones
+  // Decompose 64-bit tensor into 32-bit ones. Must recurse into the ternary
+  // exec: a binary dispatch here would look up nonexistent 2-input kernel
+  // names for the 3-input op and fail at pipeline creation.
   if (!iter.can_use_32bit_indexing()) {
     for (auto&& sub_iter : iter.with_32bit_indexing()) {
-      exec_binary_kernel(sub_iter, name);
+      exec_ternary_kernel(sub_iter, name);
     }
     return;
   }
@@ -1622,8 +1624,11 @@ void MetalShaderLibrary::exec_ternary_kernel(TensorIteratorBase& iter, const std
   convert_double_scalar(other2);
 
   MPSStream* mpsStream = getCurrentMPSStream();
-  const auto cast_needed =
-      (input.scalar_type() != other1.scalar_type()) || (input.scalar_type() != other2.scalar_type());
+  // An out= dtype differing from the (matching) inputs also needs the cast
+  // kernel: non-cast names are only registered for matching in/out pairs, and
+  // the _cast_{out} instantiations read the runtime input types anyway.
+  const auto cast_needed = (input.scalar_type() != other1.scalar_type()) ||
+      (input.scalar_type() != other2.scalar_type()) || (input.scalar_type() != out.scalar_type());
   const auto suffix = iter.is_contiguous() ? "dense" : "strided";
   // TODO: Implicitly pass both input and output types to non-cast kernels
   const auto kernel_name = cast_needed

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -6603,6 +6603,23 @@ class TestMPS(TestCaseMPS):
         helper((4, 2, 3), (1, 2, 3))
         helper((2, 3), (2, 3))
 
+    def test_clamp_tensor_bounds_out_dtype(self):
+        # Regression test: ternary ops with an out= dtype differing from the
+        # (matching) input dtypes must route to the _cast_ kernel. Previously
+        # the dispatcher only compared the inputs against each other and
+        # formatted an unregistered non-cast kernel name, failing at pipeline
+        # creation.
+        cpu_x = torch.randn(4, 5, device="cpu", dtype=torch.float32)
+        cpu_min_t = torch.full((4, 5), -0.5, device="cpu", dtype=torch.float32)
+        cpu_max_t = torch.full((4, 5), 0.5, device="cpu", dtype=torch.float32)
+        cpu_out = torch.empty(4, 5, device="cpu", dtype=torch.float16)
+        mps_x = cpu_x.to("mps")
+        mps_min_t = cpu_min_t.to("mps")
+        mps_max_t = cpu_max_t.to("mps")
+        mps_out = torch.empty(4, 5, device="mps", dtype=torch.float16)
+        torch.clamp(cpu_x, min=cpu_min_t, max=cpu_max_t, out=cpu_out)
+        torch.clamp(mps_x, min=mps_min_t, max=mps_max_t, out=mps_out)
+        self.assertEqual(mps_out.cpu(), cpu_out)
 
     def test_divmode(self):
         def helper(shape, rounding_mode):


### PR DESCRIPTION
# [MPS] Fix two exec_ternary_kernel dispatch bugs

Part of #187455. Both bugs make valid ternary ops fail at Metal pipeline creation ("Failed to create function state object"); clamp with tensor bounds is the only ternary consumer on trunk, so both surface through `torch.clamp`.

**1. 64-bit-indexing split dispatched to the binary exec.** `exec_ternary_kernel`'s `can_use_32bit_indexing` fallback recursed into `exec_binary_kernel` (copy-paste from the binary path), so the 3-input sub-iterators looked up 2-input kernel names with the wrong operand count and buffer table. Any ternary op on a tensor needing 64-bit indexing (>2^31 elements or byte offsets) failed. Now recurses into the ternary exec.

**2. `cast_needed` ignored the output dtype.** The check compared the inputs against each other but never against `out`, so e.g.

```python
x = torch.randn(4, 5, device="mps")
out = torch.empty(4, 5, device="mps", dtype=torch.float16)
torch.clamp(x, min=lo, max=hi, out=out)  # lo/hi float32 tensors
```

formatted the non-cast kernel name `clamp_dense_half_float`, which is only registered for matching in/out dtype pairs → pipeline-creation failure. The output dtype now participates, routing to the `_cast_{out}` instantiation (out-typed template, reads runtime input types, stores natively). Note the cast kernels' compute precision is immaterial for clamp: min/max commute with monotone rounding, so compute-at-out-dtype and compute-at-common-then-cast produce identical results; non-monotone future consumers (e.g. lerp) pick their `om_t` via the OPMATH registration at migration time (#152736).

## Test plan

New regression test `test_clamp_tensor_bounds_out_dtype` (fails on trunk at pipeline creation, passes with the fix). The 64-bit fix is an arity-only change covered by inspection — exercising it requires a >2^31-element tensor.

```
python test/test_mps.py -k clamp_tensor_bounds
PYTORCH_TESTING_DEVICE_ONLY_FOR=mps PYTORCH_TEST_WITH_SLOW=1 python test/run_test.py --verbose --mps --keep-going
```

Full-suite result: sole failure is `TestMetalRewritePass::test_conv` (mobile prepack rewrite), which fails identically on this machine at the base revision and on every branch of this campaign.

Split out of the ternary-specializations work (stacked follow-up) per the bugfix-first convention.

| file | Δ |
|---|---|
| `aten/src/ATen/native/mps/OperationUtils.mm` | +9/−4 |
| `test/test_mps.py` | +17/−0 |
