### PR TITLE
[MPS] Ternary elementwise specializations: inner_contiguous, inner_strided, dense ILP, 2D strided

### DIFF
--- a/aten/src/ATen/native/mps/MetalShaderLibrary.h
+++ b/aten/src/ATen/native/mps/MetalShaderLibrary.h
@@ -192,7 +192,16 @@ class MetalShaderLibrary {
       const std::optional<c10::ScalarType> scalar_arg_type = std::nullopt,
       const std::optional<c10::ScalarType> natural_output_dtype = std::nullopt,
       const std::optional<uint32_t> ilp_threshold = std::nullopt);
-  void exec_ternary_kernel(TensorIteratorBase& iter, const std::string& name);
+  // Ternary counterpart of exec_binary_kernel. `ilp_threshold` is strictly
+  // opt-in (std::nullopt disables the dense ILP flavor); there is no
+  // natural_output_dtype because no ternary consumer produces a fixed output
+  // dtype -- out= divergence rides the `_cast_{out}` instantiations instead.
+  void exec_ternary_kernel(
+      TensorIteratorBase& iter,
+      const std::string& name,
+      const std::optional<c10::Scalar> alpha = std::nullopt,
+      const std::optional<c10::ScalarType> scalar_arg_type = std::nullopt,
+      const std::optional<uint32_t> ilp_threshold = std::nullopt);
 
   template <typename T>
   void exec_unary_kernel_with_params(

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -996,6 +996,32 @@ class BundledShaderLibrary : public MetalShaderLibrary {
 // Measured safe for both unary and binary, so a single shared value suffices.
 static constexpr int64_t INNER_CONTIGUOUS_MIN_EXTENT = 16;
 
+// Inner extent below which the generic per-element strided kernel is kept over
+// the inner_strided ILP tile. Measured on M-series with
+// benchmarks/mps/bench_ternary_infra.py --sweep (clamp, f32, stride-0 inner
+// bounds, numel 2^22): inner_strided wins 1.89-2.21x at every measured extent
+// down to 8; below 8 is unmeasured, so the per-element kernel keeps it.
+static constexpr int64_t INNER_STRIDED_MIN_EXTENT = 8;
+
+// True when every operand's innermost-dim stride is either 0 (broadcast) or
+// its element size (unit). This is the layout family where the inner_strided
+// tile's loads have locality and the flavor wins big (1.9-3.3x measured); on
+// large-stride inner runs (e.g. a transposed operand) the loads are scattered
+// gathers and inner_strided measures 4-7% BEHIND the 2D strided kernel, so
+// those layouts stay generic.
+static bool isInnerUnitOrBroadcast(const TensorIteratorBase& iter) {
+  if (iter.ndim() == 0) {
+    return false;
+  }
+  for (const auto i : c10::irange(iter.ntensors())) {
+    const auto s = iter.strides(i)[0];
+    if (s != 0 && s != static_cast<int64_t>(iter.element_size(i))) {
+      return false;
+    }
+  }
+  return true;
+}
+
 // True for a strided view whose innermost coalesced dim is unit-stride for every
 // operand, which the inner_contiguous kernels exploit.
 static bool isInnerContiguous(const TensorIteratorBase& iter) {
@@ -1582,7 +1608,11 @@ void MetalShaderLibrary::exec_binary_kernel(TensorIteratorBase& iter,
   });
 }
 
-void MetalShaderLibrary::exec_ternary_kernel(TensorIteratorBase& iter, const std::string& name) {
+void MetalShaderLibrary::exec_ternary_kernel(TensorIteratorBase& iter,
+                                             const std::string& name,
+                                             const std::optional<c10::Scalar> alpha,
+                                             const std::optional<c10::ScalarType> scalar_arg_type,
+                                             const std::optional<uint32_t> ilp_threshold) {
   // TODO: Figure a better place to downcast double scalars (probably in tensor iterator itself?)
   // Right now running something like 1.0-torch.rand(5, device='mps') will create iterator with
   // double as common dtype (because Python floating point are always 64-bit values)
@@ -1594,11 +1624,12 @@ void MetalShaderLibrary::exec_ternary_kernel(TensorIteratorBase& iter, const std
   }
 
   // Decompose 64-bit tensor into 32-bit ones. Must recurse into the ternary
-  // exec: a binary dispatch here would look up nonexistent 2-input kernel
-  // names for the 3-input op and fail at pipeline creation.
+  // exec (forwarding every option): a binary dispatch here would look up
+  // nonexistent 2-input kernel names for the 3-input op and fail at pipeline
+  // creation.
   if (!iter.can_use_32bit_indexing()) {
     for (auto&& sub_iter : iter.with_32bit_indexing()) {
-      exec_ternary_kernel(sub_iter, name);
+      exec_ternary_kernel(sub_iter, name, alpha, scalar_arg_type, ilp_threshold);
     }
     return;
   }
@@ -1629,23 +1660,84 @@ void MetalShaderLibrary::exec_ternary_kernel(TensorIteratorBase& iter, const std
   // the _cast_{out} instantiations read the runtime input types anyway.
   const auto cast_needed = (input.scalar_type() != other1.scalar_type()) ||
       (input.scalar_type() != other2.scalar_type()) || (input.scalar_type() != out.scalar_type());
-  const auto suffix = iter.is_contiguous() ? "dense" : "strided";
+  const auto alpha_type = scalar_arg_type.value_or(alpha.has_value() ? alpha->type() : iter.common_dtype());
+  const auto alpha_suffix = alpha.has_value() ? fmt::format("_{}", scalarToMetalTypeString(alpha_type)) : "";
+  const bool contig = iter.is_contiguous();
+  // Flavor selection, mirroring exec_binary_kernel. Every specialized flavor
+  // requires !alpha: the alpha family registers only the per-element
+  // dense/strided kernels.
+  // Dense ILP is strictly opt-in per call site: trivial-ALU bandwidth-bound
+  // functors pass a crossover threshold, std::nullopt disables the flavor.
+  bool dense_ilp = contig && !cast_needed && !alpha.has_value() && ilp_threshold.has_value() &&
+      iter.numel() >= static_cast<int64_t>(ilp_threshold.value());
+  // inner_contiguous: every operand is unit-stride in the innermost dim, so
+  // the ILP tile runs over typed consecutive (vectorizable) loads.
+  const bool ic_applicable = !contig && !cast_needed && !alpha.has_value() && isInnerContiguous(iter);
+  bool inner_contiguous = ic_applicable && iter.shape()[0] >= INNER_CONTIGUOUS_MIN_EXTENT;
+  // inner_strided: the kernel decodes the outer coordinate once per thread
+  // and walks the inner run by each operand's constant dim-0 stride. It is
+  // correct for any strided layout; selected by default (a) for the
+  // unit-or-broadcast inner family where its loads have locality (see
+  // isInnerUnitOrBroadcast) and (b) for every cast layout: cast loads pay a
+  // per-element runtime-type switch that dominates the gather cost, so the
+  // amortized decode wins even without locality (measured 1.07x clamp
+  // half-vs-float transposed, 1.48x where with a transposed operand vs the
+  // 2D strided_cast kernel). Non-cast layouts outside (a), e.g. a transposed
+  // operand, measure 4-7% behind the 2D strided kernel and stay generic. The
+  // nonzero output inner stride keeps tile lanes from storing to one
+  // address -- unreachable through public ops (TensorIterator rejects
+  // internal output overlap) but kept as a defensive gate.
+  const bool is_structural = !contig && !alpha.has_value() && iter.ndim() > 0 && iter.strides(0)[0] != 0;
+  bool inner_strided = is_structural && !inner_contiguous && (cast_needed || isInnerUnitOrBroadcast(iter)) &&
+      iter.shape()[0] >= INNER_STRIDED_MIN_EXTENT;
+  // Bench-only override (PYTORCH_TERNARY_FORCE_FLAVOR): pin a flavor for A/B.
+  // A force applies only where the flavor is structurally correct but
+  // bypasses its profitability gates (size thresholds, and the
+  // unit-or-broadcast layout gate for inner_strided); "scalar"/"strided" pin
+  // the per-element kernels.
+  if (auto force = c10::utils::get_env("PYTORCH_TERNARY_FORCE_FLAVOR")) {
+    const auto& fv = force.value();
+    if (fv == "scalar" || fv == "strided") {
+      dense_ilp = false;
+      inner_contiguous = false;
+      inner_strided = false;
+    } else if (fv == "ilp") {
+      dense_ilp = contig && !cast_needed && !alpha.has_value();
+    } else if (fv == "inner_contiguous") {
+      inner_contiguous = ic_applicable;
+      inner_strided = false;
+    } else if (fv == "inner_strided") {
+      inner_strided = is_structural;
+      inner_contiguous = false;
+    }
+  }
+  const char* suffix = contig ? (dense_ilp ? "dense_ilp" C10_METAL_ILP_PER_THREAD_STR : "dense")
+                              : (inner_contiguous ? "inner_contiguous" : (inner_strided ? "inner_strided" : "strided"));
   // TODO: Implicitly pass both input and output types to non-cast kernels
   const auto kernel_name = cast_needed
-      ? fmt::format("{}_{}_cast_{}", name, suffix, scalarToMetalTypeString(out))
-      : fmt::format("{}_{}_{}_{}", name, suffix, scalarToMetalTypeString(out), scalarToMetalTypeString(input));
+      ? fmt::format("{}_{}_cast_{}{}", name, suffix, scalarToMetalTypeString(out), alpha_suffix)
+      : fmt::format(
+            "{}_{}_{}_{}{}", name, suffix, scalarToMetalTypeString(out), scalarToMetalTypeString(input), alpha_suffix);
   dispatch_sync_with_rethrow(mpsStream->queue(), ^() {
     @autoreleasepool {
       auto computeEncoder = mpsStream->commandEncoder();
-      auto binaryPSO = getPipelineStateForFunc(kernel_name);
+      auto ternaryPSO = getPipelineStateForFunc(kernel_name);
       // this function call is a no-op if MPS Profiler is not enabled
-      getMPSProfiler().beginProfileKernel(binaryPSO, kernel_name, {input, other1, other2});
-      [computeEncoder setComputePipelineState:binaryPSO];
+      getMPSProfiler().beginProfileKernel(ternaryPSO, kernel_name, {input, other1, other2});
+      [computeEncoder setComputePipelineState:ternaryPSO];
       // Set input and output tensors
       bind_iter_tensors(computeEncoder, iter);
+      // Alpha rides at buffer 4 (right after the tensors); the shape/type
+      // extras shift to 5 in the _alpha kernel variants.
+      if (alpha) {
+        mtl_setArgs<4>(computeEncoder, getMPSScalar(*alpha, alpha_type));
+      }
       // Iterator is contiguous if all of its elements are dense in storage,
       // i.e. it's true for both row-first and column-first tensors
-      if (iter.is_contiguous()) {
+      if (contig) {
+        if (dense_ilp) {
+          mtl_setBytes(computeEncoder, static_cast<uint32_t>(iter.numel()), 4);
+        }
         if (cast_needed) {
           std::array<int, 3> sizes = {static_cast<int>(c10::elementSize(input.scalar_type())),
                                       static_cast<int>(c10::elementSize(other1.scalar_type())),
@@ -1653,27 +1745,63 @@ void MetalShaderLibrary::exec_ternary_kernel(TensorIteratorBase& iter, const std
           std::array<int, 3> types = {static_cast<int>(input.scalar_type()),
                                       static_cast<int>(other1.scalar_type()),
                                       static_cast<int>(other2.scalar_type())};
-          mtl_setArgs<4>(computeEncoder, sizes, types);
+          if (alpha) {
+            mtl_setArgs<5>(computeEncoder, sizes, types);
+          } else {
+            mtl_setArgs<4>(computeEncoder, sizes, types);
+          }
         }
+      } else if (inner_contiguous) {
+        const std::array<uint32_t, 2> packed = {static_cast<uint32_t>(iter.ndim() - 1),
+                                                static_cast<uint32_t>(iter.shape()[0])};
+        mtl_setBytes(computeEncoder, packed, bindInnerContiguousOuter(computeEncoder, iter, 4, {0, 1, 2, 3}));
       } else {
-        // Please note that shapes and strides of the iterator might be
-        // different than that of its operands, for example binary op
-        // between 4x4 tensor and scalar will result in 1D 16 element iterator
+        // Shared by inner_strided and the generic strided kernel: identical
+        // buffer tables (the non-cast kernels simply don't declare the types
+        // buffer). Please note that shapes and strides of the iterator might
+        // be different than that of its operands, for example a ternary op
+        // involving a scalar will result in a flat 1D iterator.
         std::array<int, 4> types = {static_cast<int>(input.scalar_type()),
                                     static_cast<int>(other1.scalar_type()),
                                     static_cast<int>(other2.scalar_type()),
                                     static_cast<int>(out.scalar_type())};
-        mtl_setArgs<4>(computeEncoder,
-                       iter.shape(),
-                       iter.strides(0),
-                       iter.strides(1),
-                       iter.strides(2),
-                       iter.strides(3),
-                       iter.ndim(),
-                       types);
+        if (alpha) {
+          mtl_setArgs<5>(computeEncoder,
+                         iter.shape(),
+                         iter.strides(0),
+                         iter.strides(1),
+                         iter.strides(2),
+                         iter.strides(3),
+                         iter.ndim(),
+                         types);
+        } else {
+          mtl_setArgs<4>(computeEncoder,
+                         iter.shape(),
+                         iter.strides(0),
+                         iter.strides(1),
+                         iter.strides(2),
+                         iter.strides(3),
+                         iter.ndim(),
+                         types);
+        }
       }
-      mtl_dispatch1DJob(computeEncoder, binaryPSO, iter.numel());
-      getMPSProfiler().endProfileKernel(binaryPSO);
+      if (inner_contiguous || inner_strided) {
+        const auto inner = static_cast<NSUInteger>(iter.shape()[0]);
+        const auto inner_tiles = (inner + c10::metal::ILP_PER_THREAD - 1) / c10::metal::ILP_PER_THREAD;
+        mtl_dispatch2DJob(computeEncoder, ternaryPSO, inner_tiles, static_cast<NSUInteger>(iter.numel()) / inner);
+      } else if (!contig && !alpha) {
+        // 2D strided dispatch: thread_pos.x is the innermost coordinate,
+        // saving one div+mod per element in the kernel decode. The alpha
+        // strided kernels are still 1D, hence the !alpha above.
+        const auto inner = static_cast<NSUInteger>(iter.shape()[0]);
+        mtl_dispatch2DJob(computeEncoder, ternaryPSO, inner, static_cast<NSUInteger>(iter.numel()) / inner);
+      } else {
+        mtl_dispatch1DJob(
+            computeEncoder,
+            ternaryPSO,
+            dense_ilp ? (iter.numel() + c10::metal::ILP_PER_THREAD - 1) / c10::metal::ILP_PER_THREAD : iter.numel());
+      }
+      getMPSProfiler().endProfileKernel(ternaryPSO);
     }
   });
 }

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -959,6 +959,32 @@ class BundledShaderLibrary : public MetalShaderLibrary {
 // Measured safe for both unary and binary, so a single shared value suffices.
 static constexpr int64_t INNER_CONTIGUOUS_MIN_EXTENT = 16;
 
+// Inner extent below which the generic per-element strided kernel is kept over
+// the inner_strided ILP tile. Measured on M-series with
+// benchmarks/mps/bench_ternary_infra.py --sweep (clamp, f32, stride-0 inner
+// bounds, numel 2^22): inner_strided wins 1.89-2.21x at every measured extent
+// down to 8; below 8 is unmeasured, so the per-element kernel keeps it.
+static constexpr int64_t INNER_STRIDED_MIN_EXTENT = 8;
+
+// True when every operand's innermost-dim stride is either 0 (broadcast) or
+// its element size (unit). This is the layout family where the inner_strided
+// tile's loads have locality and the flavor wins big (1.9-3.3x measured); on
+// large-stride inner runs (e.g. a transposed operand) the loads are scattered
+// gathers and inner_strided measures 4-7% BEHIND the 2D strided kernel, so
+// those layouts stay generic.
+static bool isInnerUnitOrBroadcast(const TensorIteratorBase& iter) {
+  if (iter.ndim() == 0) {
+    return false;
+  }
+  for (const auto i : c10::irange(iter.ntensors())) {
+    const auto s = iter.strides(i)[0];
+    if (s != 0 && s != static_cast<int64_t>(iter.element_size(i))) {
+      return false;
+    }
+  }
+  return true;
+}
+
 // True for a strided view whose innermost coalesced dim is unit-stride for every
 // operand, which the inner_contiguous kernels exploit.
 static bool isInnerContiguous(const TensorIteratorBase& iter) {
@@ -1545,7 +1571,11 @@ void MetalShaderLibrary::exec_binary_kernel(TensorIteratorBase& iter,
   });
 }
 
-void MetalShaderLibrary::exec_ternary_kernel(TensorIteratorBase& iter, const std::string& name) {
+void MetalShaderLibrary::exec_ternary_kernel(TensorIteratorBase& iter,
+                                             const std::string& name,
+                                             const std::optional<c10::Scalar> alpha,
+                                             const std::optional<c10::ScalarType> scalar_arg_type,
+                                             const std::optional<uint32_t> ilp_threshold) {
   // TODO: Figure a better place to downcast double scalars (probably in tensor iterator itself?)
   // Right now running something like 1.0-torch.rand(5, device='mps') will create iterator with
   // double as common dtype (because Python floating point are always 64-bit values)
@@ -1557,11 +1587,12 @@ void MetalShaderLibrary::exec_ternary_kernel(TensorIteratorBase& iter, const std
   }
 
   // Decompose 64-bit tensor into 32-bit ones. Must recurse into the ternary
-  // exec: a binary dispatch here would look up nonexistent 2-input kernel
-  // names for the 3-input op and fail at pipeline creation.
+  // exec (forwarding every option): a binary dispatch here would look up
+  // nonexistent 2-input kernel names for the 3-input op and fail at pipeline
+  // creation.
   if (!iter.can_use_32bit_indexing()) {
     for (auto&& sub_iter : iter.with_32bit_indexing()) {
-      exec_ternary_kernel(sub_iter, name);
+      exec_ternary_kernel(sub_iter, name, alpha, scalar_arg_type, ilp_threshold);
     }
     return;
   }
@@ -1592,23 +1623,84 @@ void MetalShaderLibrary::exec_ternary_kernel(TensorIteratorBase& iter, const std
   // the _cast_{out} instantiations read the runtime input types anyway.
   const auto cast_needed = (input.scalar_type() != other1.scalar_type()) ||
       (input.scalar_type() != other2.scalar_type()) || (input.scalar_type() != out.scalar_type());
-  const auto suffix = iter.is_contiguous() ? "dense" : "strided";
+  const auto alpha_type = scalar_arg_type.value_or(alpha.has_value() ? alpha->type() : iter.common_dtype());
+  const auto alpha_suffix = alpha.has_value() ? fmt::format("_{}", scalarToMetalTypeString(alpha_type)) : "";
+  const bool contig = iter.is_contiguous();
+  // Flavor selection, mirroring exec_binary_kernel. Every specialized flavor
+  // requires !alpha: the alpha family registers only the per-element
+  // dense/strided kernels.
+  // Dense ILP is strictly opt-in per call site: trivial-ALU bandwidth-bound
+  // functors pass a crossover threshold, std::nullopt disables the flavor.
+  bool dense_ilp = contig && !cast_needed && !alpha.has_value() && ilp_threshold.has_value() &&
+      iter.numel() >= static_cast<int64_t>(ilp_threshold.value());
+  // inner_contiguous: every operand is unit-stride in the innermost dim, so
+  // the ILP tile runs over typed consecutive (vectorizable) loads.
+  const bool ic_applicable = !contig && !cast_needed && !alpha.has_value() && isInnerContiguous(iter);
+  bool inner_contiguous = ic_applicable && iter.shape()[0] >= INNER_CONTIGUOUS_MIN_EXTENT;
+  // inner_strided: the kernel decodes the outer coordinate once per thread
+  // and walks the inner run by each operand's constant dim-0 stride. It is
+  // correct for any strided layout; selected by default (a) for the
+  // unit-or-broadcast inner family where its loads have locality (see
+  // isInnerUnitOrBroadcast) and (b) for every cast layout: cast loads pay a
+  // per-element runtime-type switch that dominates the gather cost, so the
+  // amortized decode wins even without locality (measured 1.07x clamp
+  // half-vs-float transposed, 1.48x where with a transposed operand vs the
+  // 2D strided_cast kernel). Non-cast layouts outside (a), e.g. a transposed
+  // operand, measure 4-7% behind the 2D strided kernel and stay generic. The
+  // nonzero output inner stride keeps tile lanes from storing to one
+  // address -- unreachable through public ops (TensorIterator rejects
+  // internal output overlap) but kept as a defensive gate.
+  const bool is_structural = !contig && !alpha.has_value() && iter.ndim() > 0 && iter.strides(0)[0] != 0;
+  bool inner_strided = is_structural && !inner_contiguous && (cast_needed || isInnerUnitOrBroadcast(iter)) &&
+      iter.shape()[0] >= INNER_STRIDED_MIN_EXTENT;
+  // Bench-only override (PYTORCH_TERNARY_FORCE_FLAVOR): pin a flavor for A/B.
+  // A force applies only where the flavor is structurally correct but
+  // bypasses its profitability gates (size thresholds, and the
+  // unit-or-broadcast layout gate for inner_strided); "scalar"/"strided" pin
+  // the per-element kernels.
+  if (auto force = c10::utils::get_env("PYTORCH_TERNARY_FORCE_FLAVOR")) {
+    const auto& fv = force.value();
+    if (fv == "scalar" || fv == "strided") {
+      dense_ilp = false;
+      inner_contiguous = false;
+      inner_strided = false;
+    } else if (fv == "ilp") {
+      dense_ilp = contig && !cast_needed && !alpha.has_value();
+    } else if (fv == "inner_contiguous") {
+      inner_contiguous = ic_applicable;
+      inner_strided = false;
+    } else if (fv == "inner_strided") {
+      inner_strided = is_structural;
+      inner_contiguous = false;
+    }
+  }
+  const char* suffix = contig ? (dense_ilp ? "dense_ilp" C10_METAL_ILP_PER_THREAD_STR : "dense")
+                              : (inner_contiguous ? "inner_contiguous" : (inner_strided ? "inner_strided" : "strided"));
   // TODO: Implicitly pass both input and output types to non-cast kernels
   const auto kernel_name = cast_needed
-      ? fmt::format("{}_{}_cast_{}", name, suffix, scalarToMetalTypeString(out))
-      : fmt::format("{}_{}_{}_{}", name, suffix, scalarToMetalTypeString(out), scalarToMetalTypeString(input));
+      ? fmt::format("{}_{}_cast_{}{}", name, suffix, scalarToMetalTypeString(out), alpha_suffix)
+      : fmt::format(
+            "{}_{}_{}_{}{}", name, suffix, scalarToMetalTypeString(out), scalarToMetalTypeString(input), alpha_suffix);
   dispatch_sync_with_rethrow(mpsStream->queue(), ^() {
     @autoreleasepool {
       auto computeEncoder = mpsStream->commandEncoder();
-      auto binaryPSO = getPipelineStateForFunc(kernel_name);
+      auto ternaryPSO = getPipelineStateForFunc(kernel_name);
       // this function call is a no-op if MPS Profiler is not enabled
-      getMPSProfiler().beginProfileKernel(binaryPSO, kernel_name, {input, other1, other2}, mpsStream);
-      [computeEncoder setComputePipelineState:binaryPSO];
+      getMPSProfiler().beginProfileKernel(ternaryPSO, kernel_name, {input, other1, other2}, mpsStream);
+      [computeEncoder setComputePipelineState:ternaryPSO];
       // Set input and output tensors
       bind_iter_tensors(computeEncoder, iter);
+      // Alpha rides at buffer 4 (right after the tensors); the shape/type
+      // extras shift to 5 in the _alpha kernel variants.
+      if (alpha) {
+        mtl_setArgs<4>(computeEncoder, getMPSScalar(*alpha, alpha_type));
+      }
       // Iterator is contiguous if all of its elements are dense in storage,
       // i.e. it's true for both row-first and column-first tensors
-      if (iter.is_contiguous()) {
+      if (contig) {
+        if (dense_ilp) {
+          mtl_setBytes(computeEncoder, static_cast<uint32_t>(iter.numel()), 4);
+        }
         if (cast_needed) {
           std::array<int, 3> sizes = {static_cast<int>(c10::elementSize(input.scalar_type())),
                                       static_cast<int>(c10::elementSize(other1.scalar_type())),
@@ -1616,27 +1708,63 @@ void MetalShaderLibrary::exec_ternary_kernel(TensorIteratorBase& iter, const std
           std::array<int, 3> types = {static_cast<int>(input.scalar_type()),
                                       static_cast<int>(other1.scalar_type()),
                                       static_cast<int>(other2.scalar_type())};
-          mtl_setArgs<4>(computeEncoder, sizes, types);
+          if (alpha) {
+            mtl_setArgs<5>(computeEncoder, sizes, types);
+          } else {
+            mtl_setArgs<4>(computeEncoder, sizes, types);
+          }
         }
+      } else if (inner_contiguous) {
+        const std::array<uint32_t, 2> packed = {static_cast<uint32_t>(iter.ndim() - 1),
+                                                static_cast<uint32_t>(iter.shape()[0])};
+        mtl_setBytes(computeEncoder, packed, bindInnerContiguousOuter(computeEncoder, iter, 4, {0, 1, 2, 3}));
       } else {
-        // Please note that shapes and strides of the iterator might be
-        // different than that of its operands, for example binary op
-        // between 4x4 tensor and scalar will result in 1D 16 element iterator
+        // Shared by inner_strided and the generic strided kernel: identical
+        // buffer tables (the non-cast kernels simply don't declare the types
+        // buffer). Please note that shapes and strides of the iterator might
+        // be different than that of its operands, for example a ternary op
+        // involving a scalar will result in a flat 1D iterator.
         std::array<int, 4> types = {static_cast<int>(input.scalar_type()),
                                     static_cast<int>(other1.scalar_type()),
                                     static_cast<int>(other2.scalar_type()),
                                     static_cast<int>(out.scalar_type())};
-        mtl_setArgs<4>(computeEncoder,
-                       iter.shape(),
-                       iter.strides(0),
-                       iter.strides(1),
-                       iter.strides(2),
-                       iter.strides(3),
-                       iter.ndim(),
-                       types);
+        if (alpha) {
+          mtl_setArgs<5>(computeEncoder,
+                         iter.shape(),
+                         iter.strides(0),
+                         iter.strides(1),
+                         iter.strides(2),
+                         iter.strides(3),
+                         iter.ndim(),
+                         types);
+        } else {
+          mtl_setArgs<4>(computeEncoder,
+                         iter.shape(),
+                         iter.strides(0),
+                         iter.strides(1),
+                         iter.strides(2),
+                         iter.strides(3),
+                         iter.ndim(),
+                         types);
+        }
       }
-      mtl_dispatch1DJob(computeEncoder, binaryPSO, iter.numel());
-      getMPSProfiler().endProfileKernel(binaryPSO, mpsStream);
+      if (inner_contiguous || inner_strided) {
+        const auto inner = static_cast<NSUInteger>(iter.shape()[0]);
+        const auto inner_tiles = (inner + c10::metal::ILP_PER_THREAD - 1) / c10::metal::ILP_PER_THREAD;
+        mtl_dispatch2DJob(computeEncoder, ternaryPSO, inner_tiles, static_cast<NSUInteger>(iter.numel()) / inner);
+      } else if (!contig && !alpha) {
+        // 2D strided dispatch: thread_pos.x is the innermost coordinate,
+        // saving one div+mod per element in the kernel decode. The alpha
+        // strided kernels are still 1D, hence the !alpha above.
+        const auto inner = static_cast<NSUInteger>(iter.shape()[0]);
+        mtl_dispatch2DJob(computeEncoder, ternaryPSO, inner, static_cast<NSUInteger>(iter.numel()) / inner);
+      } else {
+        mtl_dispatch1DJob(
+            computeEncoder,
+            ternaryPSO,
+            dense_ilp ? (iter.numel() + c10::metal::ILP_PER_THREAD - 1) / c10::metal::ILP_PER_THREAD : iter.numel());
+      }
+      getMPSProfiler().endProfileKernel(ternaryPSO, mpsStream);
     }
   });
 }

--- a/benchmarks/mps/bench_ternary_infra.py
+++ b/benchmarks/mps/bench_ternary_infra.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env python3
+"""A/B benchmark for MPS torch.clamp ternary dispatch flavors."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import platform
+import re
+import statistics
+import subprocess
+from contextlib import contextmanager
+
+import torch
+from torch.testing import assert_close
+from torch.utils.benchmark import Timer
+
+
+ENV_VAR = "PYTORCH_TERNARY_FORCE_FLAVOR"
+TIMER_STMT = """for _ in range(K):
+    torch.clamp(x, min=lo, max=hi)
+torch.mps.synchronize()"""
+TRIALS = 3
+INNER_SWEEP = (8, 16, 24, 32, 48, 64, 96, 128, 256, 512, 1024, 4096)
+INNER_STRIDED_MIN_EXTENT = 0
+
+
+@contextmanager
+def ternary_force(flavor: str):
+    old = os.environ.get(ENV_VAR)
+    os.environ[ENV_VAR] = flavor
+    try:
+        yield
+    finally:
+        if old is None:
+            os.environ.pop(ENV_VAR, None)
+        else:
+            os.environ[ENV_VAR] = old
+
+
+def gpu_device_utilization() -> int:
+    out = subprocess.check_output(
+        ["ioreg", "-r", "-d", "1", "-w", "0", "-c", "IOAccelerator"],
+        text=True,
+        stderr=subprocess.STDOUT,
+    )
+    m = re.search(r'"Device Utilization %"=(\d+)', out)
+    if m is None:
+        raise RuntimeError("ioreg did not report Device Utilization %")
+    return int(m.group(1))
+
+
+def ioreg_guard(max_util: int = 20) -> None:
+    # External GPU contention produces garbage numbers; refuse to bench a
+    # busy device.
+    if platform.system() != "Darwin":
+        return
+    util = gpu_device_utilization()
+    print(f"gpu_device_utilization={util}%")
+    if util > max_util:
+        raise RuntimeError(
+            f"GPU busy (Device Utilization {util}% > {max_util}%); not benching"
+        )
+
+
+def dtype_name(dtype: torch.dtype) -> str:
+    return str(dtype).replace("torch.", "")
+
+
+def _rtol_atol(dtype: torch.dtype) -> tuple[float, float]:
+    if dtype in (torch.float16, torch.bfloat16):
+        return 1.0e-2, 1.0e-2
+    return 1.0e-4, 1.0e-5
+
+
+def _k_iterations(numel: int, quick: bool) -> int:
+    base = 16 if quick else 32
+    if numel <= 2**20:
+        return base * 2
+    if numel <= 2**22:
+        return base
+    return max(1, base // 2)
+
+
+def assert_case(
+    x: torch.Tensor, lo: torch.Tensor, hi: torch.Tensor, flavor: str
+) -> None:
+    expected = torch.clamp(x.cpu(), min=lo.cpu(), max=hi.cpu())
+    with ternary_force(flavor):
+        observed = torch.clamp(x, min=lo, max=hi)
+        torch.mps.synchronize()
+    rtol, atol = _rtol_atol(expected.dtype)
+    assert_close(observed.cpu(), expected, rtol=rtol, atol=atol)
+
+
+def run_flavor(
+    x: torch.Tensor,
+    lo: torch.Tensor,
+    hi: torch.Tensor,
+    flavor: str,
+    quick: bool,
+    min_run_time: float,
+) -> float:
+    globals_dict = {
+        "torch": torch,
+        "x": x,
+        "lo": lo,
+        "hi": hi,
+        "K": _k_iterations(x.numel(), quick),
+    }
+    with ternary_force(flavor):
+        t = Timer(stmt=TIMER_STMT, globals=globals_dict)
+        return t.blocked_autorange(min_run_time=min_run_time).median * 1e3
+
+
+def run_pair(
+    x: torch.Tensor,
+    lo: torch.Tensor,
+    hi: torch.Tensor,
+    flavor_a: str,
+    flavor_b: str,
+    quick: bool,
+    min_run_time: float,
+) -> tuple[float, float, float]:
+    assert_case(x, lo, hi, flavor_a)
+    assert_case(x, lo, hi, flavor_b)
+
+    a_times: list[float] = []
+    b_times: list[float] = []
+    for _ in range(TRIALS):
+        a_times.append(run_flavor(x, lo, hi, flavor_a, quick, min_run_time))
+        b_times.append(run_flavor(x, lo, hi, flavor_b, quick, min_run_time))
+    med_a = statistics.median(a_times)
+    med_b = statistics.median(b_times)
+    speedup = med_a / med_b if med_b else float("nan")
+    return med_a, med_b, speedup
+
+
+def make_bounds(
+    x: torch.Tensor, bound_dtype: torch.dtype
+) -> tuple[torch.Tensor, torch.Tensor]:
+    xb = x.to(bound_dtype)
+    return xb - 0.25, xb + 0.25
+
+
+def print_markdown(
+    title: str, rows: list[tuple[str, str, float, float, float]]
+) -> None:
+    print()
+    print(f"### {title}")
+    print("| case | dtype | a_ms | b_ms | speedup_B_over_A |")
+    print("| --- | --- | ---:| ---:| ---:|")
+    for case_name, dtype_name, a_ms, b_ms, speedup in rows:
+        print(
+            f"| {case_name} | {dtype_name} | "
+            f"{a_ms:0.4f} | {b_ms:0.4f} | {speedup:0.4f} |"
+        )
+
+
+def print_summary(rows: list[tuple[str, str, float, float, float]]) -> None:
+    print()
+    print("## Summary")
+    print("| case | dtype | speedup_B_over_A |")
+    print("| --- | --- | ---:|")
+    for case_name, dtype_name, _a, _b, speedup in rows:
+        print(f"| {case_name} | {dtype_name} | {speedup:0.4f} |")
+
+
+def run_dense_contig(
+    rows: list[tuple[str, str, float, float, float]],
+    quick: bool,
+    min_run_time: float,
+) -> None:
+    case_rows: list[tuple[str, str, float, float, float]] = []
+    n_values = [2**18, 2**22, 2**24] if not quick else [2**18, 2**22]
+    for n in n_values:
+        shape_name = f"dense-contig n={n}"
+        for dtype in (torch.float32, torch.float16):
+            x = torch.randn(n, device="mps", dtype=dtype)
+            lo, hi = make_bounds(x, dtype)
+            a_ms, b_ms, speedup = run_pair(
+                x,
+                lo,
+                hi,
+                "scalar",
+                "ilp",
+                quick,
+                min_run_time,
+            )
+            entry = (
+                shape_name,
+                f"{dtype_name(dtype)}/{dtype_name(dtype)}",
+                a_ms,
+                b_ms,
+                speedup,
+            )
+            rows.append(entry)
+            case_rows.append(entry)
+
+        # one mixed-dtype variant requested: half input with float bounds
+        if n == 2**18:
+            x = torch.randn(n, device="mps", dtype=torch.float16)
+            lo = torch.full((n,), -0.25, device="mps", dtype=torch.float32)
+            hi = torch.full((n,), 0.25, device="mps", dtype=torch.float32)
+            a_ms, b_ms, speedup = run_pair(
+                x,
+                lo,
+                hi,
+                "scalar",
+                "ilp",
+                quick,
+                min_run_time,
+            )
+            entry = (shape_name + " mixed", "float16/float32", a_ms, b_ms, speedup)
+            rows.append(entry)
+            case_rows.append(entry)
+
+    print_markdown("dense-contig", case_rows)
+
+
+def run_unit_inner(
+    rows: list[tuple[str, str, float, float, float]],
+    quick: bool,
+    min_run_time: float,
+) -> None:
+    case_rows: list[tuple[str, str, float, float, float]] = []
+    m = 1024 if quick else 4096
+    n = 1024 if quick else 4096
+    shape_name = f"unit-inner broadcast [{m},{n}]"
+    for dtype in (torch.float32, torch.float16):
+        x = torch.randn(m, n, device="mps", dtype=dtype)
+        lo, hi = make_bounds(torch.randn(n, device="mps", dtype=dtype), dtype)
+        a_ms, b_ms, speedup = run_pair(
+            x,
+            lo,
+            hi,
+            "strided",
+            "inner_contiguous",
+            quick,
+            min_run_time,
+        )
+        entry = (
+            shape_name,
+            f"{dtype_name(dtype)}/{dtype_name(dtype)}",
+            a_ms,
+            b_ms,
+            speedup,
+        )
+        rows.append(entry)
+        case_rows.append(entry)
+    print_markdown("unit-inner broadcast", case_rows)
+
+
+def run_channel_broadcast(
+    rows: list[tuple[str, str, float, float, float]],
+    quick: bool,
+    min_run_time: float,
+) -> None:
+    case_rows: list[tuple[str, str, float, float, float]] = []
+    x_shape = (16, 16, 16, 16) if quick else (64, 64, 56, 56)
+    bound_shape = (1, x_shape[1], 1, 1)
+    shape_name = f"channel broadcast {list(x_shape)}"
+    for dtype in (torch.float32, torch.float16):
+        x = torch.randn(*x_shape, device="mps", dtype=dtype)
+        lo, hi = make_bounds(
+            torch.randn(*bound_shape, device="mps", dtype=dtype),
+            dtype,
+        )
+        a_ms, b_ms, speedup = run_pair(
+            x,
+            lo,
+            hi,
+            "strided",
+            "inner_strided",
+            quick,
+            min_run_time,
+        )
+        entry = (
+            shape_name,
+            f"{dtype_name(dtype)}/{dtype_name(dtype)}",
+            a_ms,
+            b_ms,
+            speedup,
+        )
+        rows.append(entry)
+        case_rows.append(entry)
+    print_markdown("channel broadcast", case_rows)
+
+
+def run_transposed(
+    rows: list[tuple[str, str, float, float, float]],
+    quick: bool,
+    min_run_time: float,
+) -> None:
+    case_rows: list[tuple[str, str, float, float, float]] = []
+    size = 1024 if quick else 4096
+    base = torch.randn(size, size, device="mps", dtype=torch.float32)
+    x = base.t()
+    lo, hi = make_bounds(
+        torch.randn(size, size, device="mps", dtype=torch.float32), torch.float32
+    )
+    a_ms, b_ms, speedup = run_pair(
+        x,
+        lo,
+        hi,
+        "strided",
+        "inner_strided",
+        quick,
+        min_run_time,
+    )
+    entry = ("transposed base.t()", "float32/float32", a_ms, b_ms, speedup)
+    rows.append(entry)
+    case_rows.append(entry)
+
+    x16 = x.to(torch.float16)
+    lo16, hi16 = make_bounds(
+        torch.randn(size, size, device="mps", dtype=torch.float16),
+        torch.float16,
+    )
+    a_ms, b_ms, speedup = run_pair(
+        x16,
+        lo16,
+        hi16,
+        "strided",
+        "inner_strided",
+        quick,
+        min_run_time,
+    )
+    entry = ("transposed base.t()", "float16/float16", a_ms, b_ms, speedup)
+    rows.append(entry)
+    case_rows.append(entry)
+
+    # cast path: half transposed input vs float bounds. The per-element
+    # runtime-type switch dominates cast loads, so inner_strided wins here
+    # even without inner locality (gate: cast_needed || unit-or-broadcast).
+    xc = torch.randn(size, size, device="mps", dtype=torch.float16).t()
+    loc = torch.randn(size, size, device="mps") - 0.25
+    hic = torch.randn(size, size, device="mps") + 0.25
+    a_ms, b_ms, speedup = run_pair(
+        xc, loc, hic, "strided", "inner_strided", quick, min_run_time
+    )
+    entry = ("transposed cast", "float16/float32", a_ms, b_ms, speedup)
+    rows.append(entry)
+    case_rows.append(entry)
+
+    print_markdown("transposed", case_rows)
+
+
+def run_scalar_bounds(
+    rows: list[tuple[str, str, float, float, float]],
+    quick: bool,
+    min_run_time: float,
+) -> None:
+    case_rows: list[tuple[str, str, float, float, float]] = []
+    n = 2**18 if quick else 2**22
+    shape_name = f"scalar tensor bounds [{n}]"
+    for dtype in (torch.float32, torch.float16):
+        x = torch.randn(n, device="mps", dtype=dtype)
+        lo = torch.tensor(-0.25, device="mps", dtype=dtype)
+        hi = torch.tensor(0.25, device="mps", dtype=dtype)
+        a_ms, b_ms, speedup = run_pair(
+            x,
+            lo,
+            hi,
+            "strided",
+            "inner_strided",
+            quick,
+            min_run_time,
+        )
+        entry = (shape_name, f"{dtype_name(dtype)}/scalar", a_ms, b_ms, speedup)
+        rows.append(entry)
+        case_rows.append(entry)
+    print_markdown("scalar tensor bounds", case_rows)
+
+
+def run_sweep(
+    rows: list[tuple[str, str, float, float, float]],
+    quick: bool,
+    min_run_time: float,
+) -> int:
+    case_rows: list[tuple[str, str, float, float, float]] = []
+    inners = INNER_SWEEP if not quick else INNER_SWEEP[:4]
+    global INNER_STRIDED_MIN_EXTENT
+    crossover = None
+
+    for inner in inners:
+        outer = max(1, (2**22) // inner)
+        x = torch.randn(outer, inner, device="mps", dtype=torch.float32)
+        lo, hi = make_bounds(
+            torch.randn(outer, 1, device="mps", dtype=torch.float32), torch.float32
+        )
+        a_ms, b_ms, speedup = run_pair(
+            x,
+            lo,
+            hi,
+            "strided",
+            "inner_strided",
+            quick,
+            min_run_time,
+        )
+        case_name = f"sweep inner={inner} (outer={outer})"
+        entry = (case_name, "float32/float32", a_ms, b_ms, speedup)
+        rows.append(entry)
+        case_rows.append(entry)
+        if crossover is None and speedup >= 1.0:
+            crossover = inner
+
+    if crossover is None:
+        crossover = inners[-1]
+    INNER_STRIDED_MIN_EXTENT = crossover
+    print_markdown("sweep x[outer,inner] bounds[outer,1]", case_rows)
+    print(f"INNER_STRIDED_MIN_EXTENT={INNER_STRIDED_MIN_EXTENT}")
+    return INNER_STRIDED_MIN_EXTENT
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--label", default="run")
+    parser.add_argument("--quick", action="store_true")
+    parser.add_argument("--sweep", action="store_true")
+    args = parser.parse_args()
+
+    ioreg_guard()
+    if not torch.backends.mps.is_available():
+        raise RuntimeError("MPS is not available")
+
+    print(f"label={args.label} torch={torch.__version__}")
+    min_run_time = 0.2 if args.quick else 0.5
+
+    torch.manual_seed(0)
+    rows: list[tuple[str, str, float, float, float]] = []
+
+    run_dense_contig(rows, args.quick, min_run_time)
+    run_unit_inner(rows, args.quick, min_run_time)
+    run_channel_broadcast(rows, args.quick, min_run_time)
+    run_transposed(rows, args.quick, min_run_time)
+    run_scalar_bounds(rows, args.quick, min_run_time)
+    if args.sweep:
+        run_sweep(rows, args.quick, min_run_time)
+
+    print_summary(rows)
+
+
+if __name__ == "__main__":
+    main()

--- a/c10/metal/indexing.h
+++ b/c10/metal/indexing.h
@@ -1437,13 +1437,19 @@ kernel void binary_alpha_dense_scalar_lhs_cast(
           uint tid)
 
 // Ternary elementwise ops kernels
-// Right now there are 4 flavors available:
-// - ternary_dense where both input, other1, other2, and output are dense and
-// share the same type
-// - ternary_strided when all inputs are of the same types, but some elements
-// are strided
-// - ternary_dense_cast - inputs are dense, but of different dtypes
-// - ternary_strided_cast - inputs or output are strided and of different dtypes
+// Flavors, mirroring the binary family above:
+// - ternary_dense: input, other1, other2, and output are all dense and share
+// the same type
+// - ternary_dense_ilp: dense ILP_PER_THREAD-wide tile; host-selected only when
+// the caller opts in via ilp_threshold (see exec_ternary_kernel)
+// - ternary_strided: same types, but some operand is strided
+// - ternary_inner_contiguous: strided, but the innermost dim is unit-stride
+// for every operand; runs the ILP tile over the contiguous inner run
+// - ternary_inner_strided: strided with any constant dim-0 strides (stride 0
+// for a broadcast input is fine); decodes the outer coordinate once per thread
+// and walks ILP_PER_THREAD elements of the inner run
+// - ternary_dense_cast / ternary_strided_cast / ternary_inner_strided_cast -
+// as above, but operands are of different dtypes
 // Note about accuracy (for more info see
 // https://github.com/pytorch/pytorch/issues/152736) Sometimes when kernel is
 // invoked to produce `half` output, but one of the arguments is float arguments
@@ -1463,11 +1469,11 @@ kernel void ternary_strided(
     constant long* other1_strides [[buffer(7)]],
     constant long* other2_strides [[buffer(8)]],
     constant uint& ndim [[buffer(9)]],
-    uint index [[thread_position_in_grid]]) {
+    uint2 thread_pos [[thread_position_in_grid]]) {
   F f;
   using res_t = result_of<F, T, T, T>;
   int pos[max_ndim];
-  pos_from_thread_index(int(index), pos, sizes, ndim);
+  pos_from_thread_index(thread_pos, pos, sizes, ndim);
   const auto input_offs = offset_from_coord(pos, input_strides, ndim);
   const auto other1_offs = offset_from_coord(pos, other1_strides, ndim);
   const auto other2_offs = offset_from_coord(pos, other2_strides, ndim);
@@ -1492,11 +1498,11 @@ kernel void ternary_strided_cast(
     constant long* other2_strides [[buffer(8)]],
     constant uint& ndim [[buffer(9)]],
     constant uint4& types [[buffer(10)]],
-    uint index [[thread_position_in_grid]]) {
+    uint2 thread_pos [[thread_position_in_grid]]) {
   F f;
   using res_t = result_of<F, T, T, T>;
   int pos[max_ndim];
-  pos_from_thread_index(int(index), pos, sizes, ndim);
+  pos_from_thread_index(thread_pos, pos, sizes, ndim);
   const auto input_offs = offset_from_coord(pos, input_strides, ndim);
   const auto other1_offs = offset_from_coord(pos, other1_strides, ndim);
   const auto other2_offs = offset_from_coord(pos, other2_strides, ndim);
@@ -1510,6 +1516,134 @@ kernel void ternary_strided_cast(
   ref_at_offs<res_t>(output, output_offs) = static_cast<res_t>(f(a, b, c));
 }
 
+// Strided-ILP flavor: decode the outer coordinate once per thread, then walk
+// ILP_PER_THREAD elements of the innermost run via each operand's constant
+// dim-0 byte stride. Accepts any layout the generic strided kernel does
+// (a stride-0 broadcast input just re-reads the same address), amortizing the
+// per-element coordinate decode over the tile. Loads are per-element gathers
+// (not vectorizable), so the host applies a higher inner-extent gate than
+// inner_contiguous. The host guarantees a nonzero output dim-0 stride so tile
+// lanes never store to the same address. Buffer table matches ternary_strided.
+template <typename T, typename F, typename om_t = T>
+kernel void ternary_inner_strided(
+    device void* output [[buffer(0)]],
+    constant void* input [[buffer(1)]],
+    constant void* other1 [[buffer(2)]],
+    constant void* other2 [[buffer(3)]],
+    constant long* sizes [[buffer(4)]],
+    constant long* output_strides [[buffer(5)]],
+    constant long* input_strides [[buffer(6)]],
+    constant long* other1_strides [[buffer(7)]],
+    constant long* other2_strides [[buffer(8)]],
+    constant uint& ndim [[buffer(9)]],
+    uint2 thread_pos [[thread_position_in_grid]]) {
+  F f;
+  using res_t = result_of<F, T, T, T>;
+  int pos[max_ndim];
+  pos_from_thread_index(uint2(0, thread_pos.y), pos, sizes, ndim);
+  const auto out_base = offset_from_coord(pos, output_strides, ndim);
+  const auto in_base = offset_from_coord(pos, input_strides, ndim);
+  const auto o1_base = offset_from_coord(pos, other1_strides, ndim);
+  const auto o2_base = offset_from_coord(pos, other2_strides, ndim);
+  const int out_s = int(output_strides[0]);
+  const int in_s = int(input_strides[0]);
+  const int o1_s = int(other1_strides[0]);
+  const int o2_s = int(other2_strides[0]);
+  const int inner = int(sizes[0]);
+  const int base = int(thread_pos.x) * ILP_PER_THREAD;
+  if (base + int(ILP_PER_THREAD) <= inner) {
+    array<T, ILP_PER_THREAD> ta;
+    array<T, ILP_PER_THREAD> tb;
+    array<T, ILP_PER_THREAD> tc;
+#pragma unroll
+    for (uint j = 0; j < ILP_PER_THREAD; ++j) {
+      const int i = base + int(j);
+      ta[j] = val_at_offs<T>(input, in_base + i * in_s);
+      tb[j] = val_at_offs<T>(other1, o1_base + i * o1_s);
+      tc[j] = val_at_offs<T>(other2, o2_base + i * o2_s);
+    }
+#pragma unroll
+    for (uint j = 0; j < ILP_PER_THREAD; ++j) {
+      ref_at_offs<res_t>(output, out_base + (base + int(j)) * out_s) =
+          static_cast<res_t>(f(om_t(ta[j]), om_t(tb[j]), om_t(tc[j])));
+    }
+  } else {
+    for (int i = base; i < inner; ++i) {
+      const auto a = val_at_offs<T>(input, in_base + i * in_s);
+      const auto b = val_at_offs<T>(other1, o1_base + i * o1_s);
+      const auto c = val_at_offs<T>(other2, o2_base + i * o2_s);
+      ref_at_offs<res_t>(output, out_base + i * out_s) =
+          static_cast<res_t>(f(om_t(a), om_t(b), om_t(c)));
+    }
+  }
+}
+
+// Cast variant of ternary_inner_strided: operands are read at their runtime
+// dtypes (types.x/y/z) into om_t. There is deliberately no
+// ternary_inner_contiguous_cast: runtime-typed loads go through a per-element
+// switch and cannot vectorize, so this kernel is the single cast-side fast
+// path for unit-inner layouts too.
+template <typename T, typename F, typename om_t = opmath_t<T>>
+kernel void ternary_inner_strided_cast(
+    device void* output [[buffer(0)]],
+    constant void* input [[buffer(1)]],
+    constant void* other1 [[buffer(2)]],
+    constant void* other2 [[buffer(3)]],
+    constant long* sizes [[buffer(4)]],
+    constant long* output_strides [[buffer(5)]],
+    constant long* input_strides [[buffer(6)]],
+    constant long* other1_strides [[buffer(7)]],
+    constant long* other2_strides [[buffer(8)]],
+    constant uint& ndim [[buffer(9)]],
+    constant uint4& types [[buffer(10)]],
+    uint2 thread_pos [[thread_position_in_grid]]) {
+  F f;
+  using res_t = result_of<F, T, T, T>;
+  int pos[max_ndim];
+  pos_from_thread_index(uint2(0, thread_pos.y), pos, sizes, ndim);
+  const auto out_base = offset_from_coord(pos, output_strides, ndim);
+  const auto in_base = offset_from_coord(pos, input_strides, ndim);
+  const auto o1_base = offset_from_coord(pos, other1_strides, ndim);
+  const auto o2_base = offset_from_coord(pos, other2_strides, ndim);
+  const int out_s = int(output_strides[0]);
+  const int in_s = int(input_strides[0]);
+  const int o1_s = int(other1_strides[0]);
+  const int o2_s = int(other2_strides[0]);
+  const int inner = int(sizes[0]);
+  const int base = int(thread_pos.x) * ILP_PER_THREAD;
+  if (base + int(ILP_PER_THREAD) <= inner) {
+    array<om_t, ILP_PER_THREAD> ta;
+    array<om_t, ILP_PER_THREAD> tb;
+    array<om_t, ILP_PER_THREAD> tc;
+#pragma unroll
+    for (uint j = 0; j < ILP_PER_THREAD; ++j) {
+      const int i = base + int(j);
+      ta[j] = val_at_offs<om_t>(
+          input, in_base + i * in_s, static_cast<ScalarType>(types.x));
+      tb[j] = val_at_offs<om_t>(
+          other1, o1_base + i * o1_s, static_cast<ScalarType>(types.y));
+      tc[j] = val_at_offs<om_t>(
+          other2, o2_base + i * o2_s, static_cast<ScalarType>(types.z));
+    }
+#pragma unroll
+    for (uint j = 0; j < ILP_PER_THREAD; ++j) {
+      ref_at_offs<res_t>(output, out_base + (base + int(j)) * out_s) =
+          static_cast<res_t>(f(ta[j], tb[j], tc[j]));
+    }
+  } else {
+    for (int i = base; i < inner; ++i) {
+      const auto a = val_at_offs<om_t>(
+          input, in_base + i * in_s, static_cast<ScalarType>(types.x));
+      const auto b = val_at_offs<om_t>(
+          other1, o1_base + i * o1_s, static_cast<ScalarType>(types.y));
+      const auto c = val_at_offs<om_t>(
+          other2, o2_base + i * o2_s, static_cast<ScalarType>(types.z));
+      ref_at_offs<res_t>(output, out_base + i * out_s) =
+          static_cast<res_t>(f(a, b, c));
+    }
+  }
+}
+
 template <typename T, typename F, typename om_t = opmath_t<T>>
 kernel void ternary_dense(
     device result_of<F, T, T, T>* out [[buffer(0)]],
@@ -1521,6 +1655,114 @@ kernel void ternary_dense(
   using res_t = result_of<F, T, T, T>;
   out[tid] = static_cast<res_t>(
       f(om_t(input[tid]), om_t(other1[tid]), om_t(other2[tid])));
+}
+
+// ILP variant of ternary_dense; mirrors binary_dense_ilp. Selected by the
+// host only when the caller opts in via ilp_threshold (see
+// exec_ternary_kernel). The host-side kernel name encodes the unroll width
+// (e.g. `..._dense_ilp4_...`) so future variants (ilp8, etc.) can coexist.
+template <
+    typename T,
+    typename F,
+    typename om_t = opmath_t<T>,
+    unsigned ILP = ILP_PER_THREAD>
+kernel void ternary_dense_ilp(
+    device result_of<F, T, T, T>* out [[buffer(0)]],
+    constant T* input [[buffer(1)]],
+    constant T* other1 [[buffer(2)]],
+    constant T* other2 [[buffer(3)]],
+    constant uint& numel [[buffer(4)]],
+    uint index [[thread_position_in_grid]]) {
+  F f;
+  using res_t = result_of<F, T, T, T>;
+  uint base = index * ILP;
+  if (base + ILP <= numel) {
+    array<T, ILP> ta;
+    array<T, ILP> tb;
+    array<T, ILP> tc;
+    array<res_t, ILP> to;
+#pragma unroll
+    for (uint j = 0; j < ILP; ++j) {
+      ta[j] = input[base + j];
+      tb[j] = other1[base + j];
+      tc[j] = other2[base + j];
+    }
+#pragma unroll
+    for (uint j = 0; j < ILP; ++j) {
+      to[j] = static_cast<res_t>(f(om_t(ta[j]), om_t(tb[j]), om_t(tc[j])));
+    }
+#pragma unroll
+    for (uint j = 0; j < ILP; ++j) {
+      out[base + j] = to[j];
+    }
+  } else {
+    for (uint i = base; i < numel; ++i) {
+      out[i] = static_cast<res_t>(
+          f(om_t(input[i]), om_t(other1[i]), om_t(other2[i])));
+    }
+  }
+}
+
+// Inner-contiguous ternary: like binary_inner_contiguous, but with a third
+// operand. All four operands are unit-stride in dim 0, so the ILP tile runs
+// over typed consecutive loads that the compiler can vectorize.
+template <typename T, typename F, typename om_t = opmath_t<T>>
+kernel void ternary_inner_contiguous(
+    device void* output [[buffer(0)]],
+    constant void* input [[buffer(1)]],
+    constant void* other1 [[buffer(2)]],
+    constant void* other2 [[buffer(3)]],
+    constant long* outer_sizes [[buffer(4)]],
+    constant long* output_outer_strides [[buffer(5)]],
+    constant long* input_outer_strides [[buffer(6)]],
+    constant long* other1_outer_strides [[buffer(7)]],
+    constant long* other2_outer_strides [[buffer(8)]],
+    constant uint2& ndim_outer_inner [[buffer(9)]],
+    uint2 thread_pos [[thread_position_in_grid]]) {
+  F f;
+  using res_t = result_of<F, T, T, T>;
+  const uint ndim_outer = ndim_outer_inner.x;
+  const uint inner = ndim_outer_inner.y;
+  int pos[max_ndim];
+  pos_from_thread_index(int(thread_pos.y), pos, outer_sizes, ndim_outer);
+  const auto out_base =
+      offset_from_coord(pos, output_outer_strides, ndim_outer);
+  const auto in_base = offset_from_coord(pos, input_outer_strides, ndim_outer);
+  const auto o1_base = offset_from_coord(pos, other1_outer_strides, ndim_outer);
+  const auto o2_base = offset_from_coord(pos, other2_outer_strides, ndim_outer);
+  device res_t* out = reinterpret_cast<device res_t*>(
+      static_cast<device char*>(output) + out_base);
+  constant T* a = reinterpret_cast<constant T*>(
+      static_cast<constant char*>(input) + in_base);
+  constant T* b = reinterpret_cast<constant T*>(
+      static_cast<constant char*>(other1) + o1_base);
+  constant T* c = reinterpret_cast<constant T*>(
+      static_cast<constant char*>(other2) + o2_base);
+  uint base = thread_pos.x * ILP_PER_THREAD;
+  if (base + ILP_PER_THREAD <= inner) {
+    array<T, ILP_PER_THREAD> ta;
+    array<T, ILP_PER_THREAD> tb;
+    array<T, ILP_PER_THREAD> tc;
+    array<res_t, ILP_PER_THREAD> to;
+#pragma unroll
+    for (uint j = 0; j < ILP_PER_THREAD; ++j) {
+      ta[j] = a[base + j];
+      tb[j] = b[base + j];
+      tc[j] = c[base + j];
+    }
+#pragma unroll
+    for (uint j = 0; j < ILP_PER_THREAD; ++j) {
+      to[j] = static_cast<res_t>(f(om_t(ta[j]), om_t(tb[j]), om_t(tc[j])));
+    }
+#pragma unroll
+    for (uint j = 0; j < ILP_PER_THREAD; ++j) {
+      out[base + j] = to[j];
+    }
+  } else {
+    for (uint j = base; j < inner; ++j) {
+      out[j] = static_cast<res_t>(f(om_t(a[j]), om_t(b[j]), om_t(c[j])));
+    }
+  }
 }
 
 template <typename T, typename F, typename om_t = T>
@@ -1561,7 +1803,7 @@ kernel void ternary_dense_cast(
           constant long* other1_strides,                                       \
           constant long* other2_strides,                                       \
           constant uint& ndim,                                                 \
-          uint tid);                                                           \
+          uint2 tid);                                                          \
   template [[host_name(#NAME "_strided_cast_" #DTYPEI)]] kernel void ::c10::   \
       metal::ternary_strided_cast<DTYPEI, NAME##_functor, OMT>(                \
           device void* out,                                                    \
@@ -1575,7 +1817,50 @@ kernel void ternary_dense_cast(
           constant long* other2_strides,                                       \
           constant uint& ndim,                                                 \
           constant uint4& types,                                               \
-          uint tid);                                                           \
+          uint2 tid);                                                          \
+  template [[host_name(#NAME "_inner_strided_" #DTYPEO "_" #DTYPEI)]]          \
+  kernel void ::c10::metal::                                                   \
+      ternary_inner_strided<DTYPEI, NAME##_functor, OMT>(                      \
+          device void* out,                                                    \
+          constant void* input,                                                \
+          constant void* other1,                                               \
+          constant void* other2,                                               \
+          constant long* sizes,                                                \
+          constant long* output_strides,                                       \
+          constant long* input_strides,                                        \
+          constant long* other1_strides,                                       \
+          constant long* other2_strides,                                       \
+          constant uint& ndim,                                                 \
+          uint2 tid);                                                          \
+  template [[host_name(#NAME "_inner_strided_cast_" #DTYPEI)]]                 \
+  kernel void ::c10::metal::                                                   \
+      ternary_inner_strided_cast<DTYPEI, NAME##_functor, OMT>(                 \
+          device void* out,                                                    \
+          constant void* input,                                                \
+          constant void* other1,                                               \
+          constant void* other2,                                               \
+          constant long* sizes,                                                \
+          constant long* output_strides,                                       \
+          constant long* input_strides,                                        \
+          constant long* other1_strides,                                       \
+          constant long* other2_strides,                                       \
+          constant uint& ndim,                                                 \
+          constant uint4& types,                                               \
+          uint2 tid);                                                          \
+  template [[host_name(#NAME "_inner_contiguous_" #DTYPEO "_" #DTYPEI)]]       \
+  kernel void ::c10::metal::                                                   \
+      ternary_inner_contiguous<DTYPEI, NAME##_functor, OMT>(                   \
+          device void* out,                                                    \
+          constant void* input,                                                \
+          constant void* other1,                                               \
+          constant void* other2,                                               \
+          constant long* outer_sizes,                                          \
+          constant long* output_outer_strides,                                 \
+          constant long* input_outer_strides,                                  \
+          constant long* other1_outer_strides,                                 \
+          constant long* other2_outer_strides,                                 \
+          constant uint2& ndim_outer_inner,                                    \
+          uint2 tid);                                                          \
   template [[host_name(#NAME "_dense_" #DTYPEO "_" #DTYPEI)]] kernel void ::   \
       c10::metal::ternary_dense<DTYPEI, NAME##_functor, OMT>(                  \
           device ::c10::metal::                                                \
@@ -1584,6 +1869,17 @@ kernel void ternary_dense_cast(
           constant DTYPEI * input_,                                            \
           constant DTYPEI * other1_,                                           \
           constant DTYPEI * other2_,                                           \
+          uint tid);                                                           \
+  template [[host_name(#NAME "_dense_ilp" C10_METAL_ILP_PER_THREAD_STR         \
+                             "_" #DTYPEO "_" #DTYPEI)]] kernel void ::c10::    \
+      metal::ternary_dense_ilp<DTYPEI, NAME##_functor, OMT>(                   \
+          device ::c10::metal::                                                \
+                  result_of<NAME##_functor, DTYPEI, DTYPEI, DTYPEI> *          \
+              out_,                                                            \
+          constant DTYPEI * input_,                                            \
+          constant DTYPEI * other1_,                                           \
+          constant DTYPEI * other2_,                                           \
+          constant uint & numel,                                               \
           uint tid);                                                           \
   template [[host_name(#NAME "_dense_cast_" #DTYPEI)]] kernel void ::c10::     \
       metal::ternary_dense_cast<DTYPEI, NAME##_functor, OMT>(                  \

--- a/c10/metal/indexing.h
+++ b/c10/metal/indexing.h
@@ -1440,13 +1440,19 @@ kernel void binary_alpha_dense_scalar_lhs_cast(
           uint tid)
 
 // Ternary elementwise ops kernels
-// Right now there are 4 flavors available:
-// - ternary_dense where both input, other1, other2, and output are dense and
-// share the same type
-// - ternary_strided when all inputs are of the same types, but some elements
-// are strided
-// - ternary_dense_cast - inputs are dense, but of different dtypes
-// - ternary_strided_cast - inputs or output are strided and of different dtypes
+// Flavors, mirroring the binary family above:
+// - ternary_dense: input, other1, other2, and output are all dense and share
+// the same type
+// - ternary_dense_ilp: dense ILP_PER_THREAD-wide tile; host-selected only when
+// the caller opts in via ilp_threshold (see exec_ternary_kernel)
+// - ternary_strided: same types, but some operand is strided
+// - ternary_inner_contiguous: strided, but the innermost dim is unit-stride
+// for every operand; runs the ILP tile over the contiguous inner run
+// - ternary_inner_strided: strided with any constant dim-0 strides (stride 0
+// for a broadcast input is fine); decodes the outer coordinate once per thread
+// and walks ILP_PER_THREAD elements of the inner run
+// - ternary_dense_cast / ternary_strided_cast / ternary_inner_strided_cast -
+// as above, but operands are of different dtypes
 // Note about accuracy (for more info see
 // https://github.com/pytorch/pytorch/issues/152736) Sometimes when kernel is
 // invoked to produce `half` output, but one of the arguments is float arguments
@@ -1466,11 +1472,11 @@ kernel void ternary_strided(
     constant long* other1_strides [[buffer(7)]],
     constant long* other2_strides [[buffer(8)]],
     constant uint& ndim [[buffer(9)]],
-    uint index [[thread_position_in_grid]]) {
+    uint2 thread_pos [[thread_position_in_grid]]) {
   F f;
   using res_t = result_of<F, T, T, T>;
   int pos[max_ndim];
-  pos_from_thread_index(int(index), pos, sizes, ndim);
+  pos_from_thread_index(thread_pos, pos, sizes, ndim);
   const auto input_offs = offset_from_coord(pos, input_strides, ndim);
   const auto other1_offs = offset_from_coord(pos, other1_strides, ndim);
   const auto other2_offs = offset_from_coord(pos, other2_strides, ndim);
@@ -1495,11 +1501,11 @@ kernel void ternary_strided_cast(
     constant long* other2_strides [[buffer(8)]],
     constant uint& ndim [[buffer(9)]],
     constant uint4& types [[buffer(10)]],
-    uint index [[thread_position_in_grid]]) {
+    uint2 thread_pos [[thread_position_in_grid]]) {
   F f;
   using res_t = result_of<F, T, T, T>;
   int pos[max_ndim];
-  pos_from_thread_index(int(index), pos, sizes, ndim);
+  pos_from_thread_index(thread_pos, pos, sizes, ndim);
   const auto input_offs = offset_from_coord(pos, input_strides, ndim);
   const auto other1_offs = offset_from_coord(pos, other1_strides, ndim);
   const auto other2_offs = offset_from_coord(pos, other2_strides, ndim);
@@ -1513,6 +1519,134 @@ kernel void ternary_strided_cast(
   ref_at_offs<res_t>(output, output_offs) = static_cast<res_t>(f(a, b, c));
 }
 
+// Strided-ILP flavor: decode the outer coordinate once per thread, then walk
+// ILP_PER_THREAD elements of the innermost run via each operand's constant
+// dim-0 byte stride. Accepts any layout the generic strided kernel does
+// (a stride-0 broadcast input just re-reads the same address), amortizing the
+// per-element coordinate decode over the tile. Loads are per-element gathers
+// (not vectorizable), so the host applies a higher inner-extent gate than
+// inner_contiguous. The host guarantees a nonzero output dim-0 stride so tile
+// lanes never store to the same address. Buffer table matches ternary_strided.
+template <typename T, typename F, typename om_t = T>
+kernel void ternary_inner_strided(
+    device void* output [[buffer(0)]],
+    constant void* input [[buffer(1)]],
+    constant void* other1 [[buffer(2)]],
+    constant void* other2 [[buffer(3)]],
+    constant long* sizes [[buffer(4)]],
+    constant long* output_strides [[buffer(5)]],
+    constant long* input_strides [[buffer(6)]],
+    constant long* other1_strides [[buffer(7)]],
+    constant long* other2_strides [[buffer(8)]],
+    constant uint& ndim [[buffer(9)]],
+    uint2 thread_pos [[thread_position_in_grid]]) {
+  F f;
+  using res_t = result_of<F, T, T, T>;
+  int pos[max_ndim];
+  pos_from_thread_index(uint2(0, thread_pos.y), pos, sizes, ndim);
+  const auto out_base = offset_from_coord(pos, output_strides, ndim);
+  const auto in_base = offset_from_coord(pos, input_strides, ndim);
+  const auto o1_base = offset_from_coord(pos, other1_strides, ndim);
+  const auto o2_base = offset_from_coord(pos, other2_strides, ndim);
+  const int out_s = int(output_strides[0]);
+  const int in_s = int(input_strides[0]);
+  const int o1_s = int(other1_strides[0]);
+  const int o2_s = int(other2_strides[0]);
+  const int inner = int(sizes[0]);
+  const int base = int(thread_pos.x) * ILP_PER_THREAD;
+  if (base + int(ILP_PER_THREAD) <= inner) {
+    array<T, ILP_PER_THREAD> ta;
+    array<T, ILP_PER_THREAD> tb;
+    array<T, ILP_PER_THREAD> tc;
+#pragma unroll
+    for (uint j = 0; j < ILP_PER_THREAD; ++j) {
+      const int i = base + int(j);
+      ta[j] = val_at_offs<T>(input, in_base + i * in_s);
+      tb[j] = val_at_offs<T>(other1, o1_base + i * o1_s);
+      tc[j] = val_at_offs<T>(other2, o2_base + i * o2_s);
+    }
+#pragma unroll
+    for (uint j = 0; j < ILP_PER_THREAD; ++j) {
+      ref_at_offs<res_t>(output, out_base + (base + int(j)) * out_s) =
+          static_cast<res_t>(f(om_t(ta[j]), om_t(tb[j]), om_t(tc[j])));
+    }
+  } else {
+    for (int i = base; i < inner; ++i) {
+      const auto a = val_at_offs<T>(input, in_base + i * in_s);
+      const auto b = val_at_offs<T>(other1, o1_base + i * o1_s);
+      const auto c = val_at_offs<T>(other2, o2_base + i * o2_s);
+      ref_at_offs<res_t>(output, out_base + i * out_s) =
+          static_cast<res_t>(f(om_t(a), om_t(b), om_t(c)));
+    }
+  }
+}
+
+// Cast variant of ternary_inner_strided: operands are read at their runtime
+// dtypes (types.x/y/z) into om_t. There is deliberately no
+// ternary_inner_contiguous_cast: runtime-typed loads go through a per-element
+// switch and cannot vectorize, so this kernel is the single cast-side fast
+// path for unit-inner layouts too.
+template <typename T, typename F, typename om_t = opmath_t<T>>
+kernel void ternary_inner_strided_cast(
+    device void* output [[buffer(0)]],
+    constant void* input [[buffer(1)]],
+    constant void* other1 [[buffer(2)]],
+    constant void* other2 [[buffer(3)]],
+    constant long* sizes [[buffer(4)]],
+    constant long* output_strides [[buffer(5)]],
+    constant long* input_strides [[buffer(6)]],
+    constant long* other1_strides [[buffer(7)]],
+    constant long* other2_strides [[buffer(8)]],
+    constant uint& ndim [[buffer(9)]],
+    constant uint4& types [[buffer(10)]],
+    uint2 thread_pos [[thread_position_in_grid]]) {
+  F f;
+  using res_t = result_of<F, T, T, T>;
+  int pos[max_ndim];
+  pos_from_thread_index(uint2(0, thread_pos.y), pos, sizes, ndim);
+  const auto out_base = offset_from_coord(pos, output_strides, ndim);
+  const auto in_base = offset_from_coord(pos, input_strides, ndim);
+  const auto o1_base = offset_from_coord(pos, other1_strides, ndim);
+  const auto o2_base = offset_from_coord(pos, other2_strides, ndim);
+  const int out_s = int(output_strides[0]);
+  const int in_s = int(input_strides[0]);
+  const int o1_s = int(other1_strides[0]);
+  const int o2_s = int(other2_strides[0]);
+  const int inner = int(sizes[0]);
+  const int base = int(thread_pos.x) * ILP_PER_THREAD;
+  if (base + int(ILP_PER_THREAD) <= inner) {
+    array<om_t, ILP_PER_THREAD> ta;
+    array<om_t, ILP_PER_THREAD> tb;
+    array<om_t, ILP_PER_THREAD> tc;
+#pragma unroll
+    for (uint j = 0; j < ILP_PER_THREAD; ++j) {
+      const int i = base + int(j);
+      ta[j] = val_at_offs<om_t>(
+          input, in_base + i * in_s, static_cast<ScalarType>(types.x));
+      tb[j] = val_at_offs<om_t>(
+          other1, o1_base + i * o1_s, static_cast<ScalarType>(types.y));
+      tc[j] = val_at_offs<om_t>(
+          other2, o2_base + i * o2_s, static_cast<ScalarType>(types.z));
+    }
+#pragma unroll
+    for (uint j = 0; j < ILP_PER_THREAD; ++j) {
+      ref_at_offs<res_t>(output, out_base + (base + int(j)) * out_s) =
+          static_cast<res_t>(f(ta[j], tb[j], tc[j]));
+    }
+  } else {
+    for (int i = base; i < inner; ++i) {
+      const auto a = val_at_offs<om_t>(
+          input, in_base + i * in_s, static_cast<ScalarType>(types.x));
+      const auto b = val_at_offs<om_t>(
+          other1, o1_base + i * o1_s, static_cast<ScalarType>(types.y));
+      const auto c = val_at_offs<om_t>(
+          other2, o2_base + i * o2_s, static_cast<ScalarType>(types.z));
+      ref_at_offs<res_t>(output, out_base + i * out_s) =
+          static_cast<res_t>(f(a, b, c));
+    }
+  }
+}
+
 template <typename T, typename F, typename om_t = opmath_t<T>>
 kernel void ternary_dense(
     device result_of<F, T, T, T>* out [[buffer(0)]],
@@ -1524,6 +1658,114 @@ kernel void ternary_dense(
   using res_t = result_of<F, T, T, T>;
   out[tid] = static_cast<res_t>(
       f(om_t(input[tid]), om_t(other1[tid]), om_t(other2[tid])));
+}
+
+// ILP variant of ternary_dense; mirrors binary_dense_ilp. Selected by the
+// host only when the caller opts in via ilp_threshold (see
+// exec_ternary_kernel). The host-side kernel name encodes the unroll width
+// (e.g. `..._dense_ilp4_...`) so future variants (ilp8, etc.) can coexist.
+template <
+    typename T,
+    typename F,
+    typename om_t = opmath_t<T>,
+    unsigned ILP = ILP_PER_THREAD>
+kernel void ternary_dense_ilp(
+    device result_of<F, T, T, T>* out [[buffer(0)]],
+    constant T* input [[buffer(1)]],
+    constant T* other1 [[buffer(2)]],
+    constant T* other2 [[buffer(3)]],
+    constant uint& numel [[buffer(4)]],
+    uint index [[thread_position_in_grid]]) {
+  F f;
+  using res_t = result_of<F, T, T, T>;
+  uint base = index * ILP;
+  if (base + ILP <= numel) {
+    array<T, ILP> ta;
+    array<T, ILP> tb;
+    array<T, ILP> tc;
+    array<res_t, ILP> to;
+#pragma unroll
+    for (uint j = 0; j < ILP; ++j) {
+      ta[j] = input[base + j];
+      tb[j] = other1[base + j];
+      tc[j] = other2[base + j];
+    }
+#pragma unroll
+    for (uint j = 0; j < ILP; ++j) {
+      to[j] = static_cast<res_t>(f(om_t(ta[j]), om_t(tb[j]), om_t(tc[j])));
+    }
+#pragma unroll
+    for (uint j = 0; j < ILP; ++j) {
+      out[base + j] = to[j];
+    }
+  } else {
+    for (uint i = base; i < numel; ++i) {
+      out[i] = static_cast<res_t>(
+          f(om_t(input[i]), om_t(other1[i]), om_t(other2[i])));
+    }
+  }
+}
+
+// Inner-contiguous ternary: like binary_inner_contiguous, but with a third
+// operand. All four operands are unit-stride in dim 0, so the ILP tile runs
+// over typed consecutive loads that the compiler can vectorize.
+template <typename T, typename F, typename om_t = opmath_t<T>>
+kernel void ternary_inner_contiguous(
+    device void* output [[buffer(0)]],
+    constant void* input [[buffer(1)]],
+    constant void* other1 [[buffer(2)]],
+    constant void* other2 [[buffer(3)]],
+    constant long* outer_sizes [[buffer(4)]],
+    constant long* output_outer_strides [[buffer(5)]],
+    constant long* input_outer_strides [[buffer(6)]],
+    constant long* other1_outer_strides [[buffer(7)]],
+    constant long* other2_outer_strides [[buffer(8)]],
+    constant uint2& ndim_outer_inner [[buffer(9)]],
+    uint2 thread_pos [[thread_position_in_grid]]) {
+  F f;
+  using res_t = result_of<F, T, T, T>;
+  const uint ndim_outer = ndim_outer_inner.x;
+  const uint inner = ndim_outer_inner.y;
+  int pos[max_ndim];
+  pos_from_thread_index(int(thread_pos.y), pos, outer_sizes, ndim_outer);
+  const auto out_base =
+      offset_from_coord(pos, output_outer_strides, ndim_outer);
+  const auto in_base = offset_from_coord(pos, input_outer_strides, ndim_outer);
+  const auto o1_base = offset_from_coord(pos, other1_outer_strides, ndim_outer);
+  const auto o2_base = offset_from_coord(pos, other2_outer_strides, ndim_outer);
+  device res_t* out = reinterpret_cast<device res_t*>(
+      static_cast<device char*>(output) + out_base);
+  constant T* a = reinterpret_cast<constant T*>(
+      static_cast<constant char*>(input) + in_base);
+  constant T* b = reinterpret_cast<constant T*>(
+      static_cast<constant char*>(other1) + o1_base);
+  constant T* c = reinterpret_cast<constant T*>(
+      static_cast<constant char*>(other2) + o2_base);
+  uint base = thread_pos.x * ILP_PER_THREAD;
+  if (base + ILP_PER_THREAD <= inner) {
+    array<T, ILP_PER_THREAD> ta;
+    array<T, ILP_PER_THREAD> tb;
+    array<T, ILP_PER_THREAD> tc;
+    array<res_t, ILP_PER_THREAD> to;
+#pragma unroll
+    for (uint j = 0; j < ILP_PER_THREAD; ++j) {
+      ta[j] = a[base + j];
+      tb[j] = b[base + j];
+      tc[j] = c[base + j];
+    }
+#pragma unroll
+    for (uint j = 0; j < ILP_PER_THREAD; ++j) {
+      to[j] = static_cast<res_t>(f(om_t(ta[j]), om_t(tb[j]), om_t(tc[j])));
+    }
+#pragma unroll
+    for (uint j = 0; j < ILP_PER_THREAD; ++j) {
+      out[base + j] = to[j];
+    }
+  } else {
+    for (uint j = base; j < inner; ++j) {
+      out[j] = static_cast<res_t>(f(om_t(a[j]), om_t(b[j]), om_t(c[j])));
+    }
+  }
 }
 
 template <typename T, typename F, typename om_t = T>
@@ -1564,7 +1806,7 @@ kernel void ternary_dense_cast(
           constant long* other1_strides,                                       \
           constant long* other2_strides,                                       \
           constant uint& ndim,                                                 \
-          uint tid);                                                           \
+          uint2 tid);                                                          \
   template [[host_name(#NAME "_strided_cast_" #DTYPEI)]] kernel void ::c10::   \
       metal::ternary_strided_cast<DTYPEI, NAME##_functor, OMT>(                \
           device void* out,                                                    \
@@ -1578,7 +1820,50 @@ kernel void ternary_dense_cast(
           constant long* other2_strides,                                       \
           constant uint& ndim,                                                 \
           constant uint4& types,                                               \
-          uint tid);                                                           \
+          uint2 tid);                                                          \
+  template [[host_name(#NAME "_inner_strided_" #DTYPEO "_" #DTYPEI)]]          \
+  kernel void ::c10::metal::                                                   \
+      ternary_inner_strided<DTYPEI, NAME##_functor, OMT>(                      \
+          device void* out,                                                    \
+          constant void* input,                                                \
+          constant void* other1,                                               \
+          constant void* other2,                                               \
+          constant long* sizes,                                                \
+          constant long* output_strides,                                       \
+          constant long* input_strides,                                        \
+          constant long* other1_strides,                                       \
+          constant long* other2_strides,                                       \
+          constant uint& ndim,                                                 \
+          uint2 tid);                                                          \
+  template [[host_name(#NAME "_inner_strided_cast_" #DTYPEI)]]                 \
+  kernel void ::c10::metal::                                                   \
+      ternary_inner_strided_cast<DTYPEI, NAME##_functor, OMT>(                 \
+          device void* out,                                                    \
+          constant void* input,                                                \
+          constant void* other1,                                               \
+          constant void* other2,                                               \
+          constant long* sizes,                                                \
+          constant long* output_strides,                                       \
+          constant long* input_strides,                                        \
+          constant long* other1_strides,                                       \
+          constant long* other2_strides,                                       \
+          constant uint& ndim,                                                 \
+          constant uint4& types,                                               \
+          uint2 tid);                                                          \
+  template [[host_name(#NAME "_inner_contiguous_" #DTYPEO "_" #DTYPEI)]]       \
+  kernel void ::c10::metal::                                                   \
+      ternary_inner_contiguous<DTYPEI, NAME##_functor, OMT>(                   \
+          device void* out,                                                    \
+          constant void* input,                                                \
+          constant void* other1,                                               \
+          constant void* other2,                                               \
+          constant long* outer_sizes,                                          \
+          constant long* output_outer_strides,                                 \
+          constant long* input_outer_strides,                                  \
+          constant long* other1_outer_strides,                                 \
+          constant long* other2_outer_strides,                                 \
+          constant uint2& ndim_outer_inner,                                    \
+          uint2 tid);                                                          \
   template [[host_name(#NAME "_dense_" #DTYPEO "_" #DTYPEI)]] kernel void ::   \
       c10::metal::ternary_dense<DTYPEI, NAME##_functor, OMT>(                  \
           device ::c10::metal::                                                \
@@ -1587,6 +1872,17 @@ kernel void ternary_dense_cast(
           constant DTYPEI * input_,                                            \
           constant DTYPEI * other1_,                                           \
           constant DTYPEI * other2_,                                           \
+          uint tid);                                                           \
+  template [[host_name(#NAME "_dense_ilp" C10_METAL_ILP_PER_THREAD_STR         \
+                             "_" #DTYPEO "_" #DTYPEI)]] kernel void ::c10::    \
+      metal::ternary_dense_ilp<DTYPEI, NAME##_functor, OMT>(                   \
+          device ::c10::metal::                                                \
+                  result_of<NAME##_functor, DTYPEI, DTYPEI, DTYPEI> *          \
+              out_,                                                            \
+          constant DTYPEI * input_,                                            \
+          constant DTYPEI * other1_,                                           \
+          constant DTYPEI * other2_,                                           \
+          constant uint & numel,                                               \
           uint tid);                                                           \
   template [[host_name(#NAME "_dense_cast_" #DTYPEI)]] kernel void ::c10::     \
       metal::ternary_dense_cast<DTYPEI, NAME##_functor, OMT>(                  \

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -6621,6 +6621,41 @@ class TestMPS(TestCaseMPS):
         torch.clamp(mps_x, min=mps_min_t, max=mps_max_t, out=mps_out)
         self.assertEqual(mps_out.cpu(), cpu_out)
 
+    def test_clamp_tensor_bounds_flavor_parity(self):
+        # Exercises every ternary dispatch flavor (dense, dense_ilp,
+        # inner_contiguous, inner_strided, strided) against the CPU reference
+        # on the layouts each one serves, using the bench-only forcing knob to
+        # bypass the size thresholds.
+        def helper(x, min_t, max_t):
+            expect = torch.clamp(x, min=min_t, max=max_t)
+            for flavor in ["scalar", "strided", "ilp", "inner_contiguous", "inner_strided"]:
+                with self.subTest(dtype=x.dtype, flavor=flavor, shapes=(x.shape, min_t.shape)):
+                    os.environ["PYTORCH_TERNARY_FORCE_FLAVOR"] = flavor
+                    try:
+                        got = torch.clamp(x.to("mps"), min=min_t.to("mps"), max=max_t.to("mps"))
+                    finally:
+                        del os.environ["PYTORCH_TERNARY_FORCE_FLAVOR"]
+                    self.assertEqual(got.cpu(), expect)
+
+        for dtype in [torch.float32, torch.float16]:
+            x = torch.randn(8, 6, 17, dtype=dtype)
+            full = (torch.rand_like(x) - 0.75, torch.rand_like(x) + 0.75)
+            # dense contiguous, ragged tail (numel % 4 != 0)
+            helper(x, *full)
+            # NCHW-style channel bounds: {0, e, 0} strides (inner_strided)
+            helper(x, torch.randn(1, 6, 1, dtype=dtype) - 0.75, torch.randn(1, 6, 1, dtype=dtype) + 0.75)
+            # trailing-dim bounds: all operands unit-inner (inner_contiguous),
+            # inner extents around the ILP tile boundary
+            for inner in [15, 16, 17]:
+                xi = torch.randn(7, inner, dtype=dtype)
+                helper(xi, torch.randn(inner, dtype=dtype) - 0.75, torch.randn(inner, dtype=dtype) + 0.75)
+            # transposed input: pure layout mismatch, no broadcast
+            helper(x.transpose(0, 2), full[0].transpose(0, 2).contiguous(), full[1].transpose(0, 2).contiguous())
+            # 0-dim tensor bounds: 1D iterator with stride-0 operands
+            helper(x, torch.tensor(-0.5, dtype=dtype), torch.tensor(0.5, dtype=dtype))
+            # mixed dtype (cast kernels): float bounds on half/float input
+            helper(x, full[0].float(), full[1].float())
+
     def test_divmode(self):
         def helper(shape, rounding_mode):
             for dtype in [torch.float32, torch.float16, torch.int32, torch.int64]:

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -7105,6 +7105,41 @@ class TestMPS(TestCaseMPS):
         torch.clamp(mps_x, min=mps_min_t, max=mps_max_t, out=mps_out)
         self.assertEqual(mps_out.cpu(), cpu_out)
 
+    def test_clamp_tensor_bounds_flavor_parity(self):
+        # Exercises every ternary dispatch flavor (dense, dense_ilp,
+        # inner_contiguous, inner_strided, strided) against the CPU reference
+        # on the layouts each one serves, using the bench-only forcing knob to
+        # bypass the size thresholds.
+        def helper(x, min_t, max_t):
+            expect = torch.clamp(x, min=min_t, max=max_t)
+            for flavor in ["scalar", "strided", "ilp", "inner_contiguous", "inner_strided"]:
+                with self.subTest(dtype=x.dtype, flavor=flavor, shapes=(x.shape, min_t.shape)):
+                    os.environ["PYTORCH_TERNARY_FORCE_FLAVOR"] = flavor
+                    try:
+                        got = torch.clamp(x.to("mps"), min=min_t.to("mps"), max=max_t.to("mps"))
+                    finally:
+                        del os.environ["PYTORCH_TERNARY_FORCE_FLAVOR"]
+                    self.assertEqual(got.cpu(), expect)
+
+        for dtype in [torch.float32, torch.float16]:
+            x = torch.randn(8, 6, 17, dtype=dtype)
+            full = (torch.rand_like(x) - 0.75, torch.rand_like(x) + 0.75)
+            # dense contiguous, ragged tail (numel % 4 != 0)
+            helper(x, *full)
+            # NCHW-style channel bounds: {0, e, 0} strides (inner_strided)
+            helper(x, torch.randn(1, 6, 1, dtype=dtype) - 0.75, torch.randn(1, 6, 1, dtype=dtype) + 0.75)
+            # trailing-dim bounds: all operands unit-inner (inner_contiguous),
+            # inner extents around the ILP tile boundary
+            for inner in [15, 16, 17]:
+                xi = torch.randn(7, inner, dtype=dtype)
+                helper(xi, torch.randn(inner, dtype=dtype) - 0.75, torch.randn(inner, dtype=dtype) + 0.75)
+            # transposed input: pure layout mismatch, no broadcast
+            helper(x.transpose(0, 2), full[0].transpose(0, 2).contiguous(), full[1].transpose(0, 2).contiguous())
+            # 0-dim tensor bounds: 1D iterator with stride-0 operands
+            helper(x, torch.tensor(-0.5, dtype=dtype), torch.tensor(0.5, dtype=dtype))
+            # mixed dtype (cast kernels): float bounds on half/float input
+            helper(x, full[0].float(), full[1].float())
+
     def test_divmode(self):
         def helper(shape, rounding_mode):
             for dtype in [torch.float32, torch.float16, torch.int32, torch.int64]:


### PR DESCRIPTION
# [MPS] Ternary elementwise specializations: inner_contiguous, inner_strided, dense ILP, 2D strided

Part of #187455 (migrating remaining MPSGraph elementwise ops to Metal kernels). Shared-infra PR: brings the ternary exec path up to parity with the binary path's specializations and adds one new lineage member, so the pending consumer PRs (`where`, `prelu`, the loss-op tails in #187557) get their noncontiguous fast paths from one place instead of per-op kernels.

## What's added

**Kernels (`c10/metal/indexing.h`):**
- `ternary_dense_ilp` — mirrors `binary_dense_ilp`; strictly opt-in per call site via the new `ilp_threshold` parameter.
- `ternary_inner_contiguous` — mirrors `binary_inner_contiguous` (every operand unit-stride in dim 0; ILP tile over vectorizable typed loads).
- `ternary_inner_strided` + `_cast` — **new**: decodes the outer coordinate once per thread, then walks `ILP_PER_THREAD` elements of the innermost run by each operand's constant dim-0 byte stride. Stride-0 inputs (broadcast bounds/conditions, 0-dim operands) just re-read one address, so this single kernel covers the broadcast, 0-dim, and mixed-dtype layouts without per-pattern kernels. There is deliberately no `inner_contiguous_cast`: runtime-typed loads can't vectorize, so `inner_strided_cast` is the one cast-side fast path.
- `ternary_strided`/`ternary_strided_cast` move from 1D to 2D dispatch (`thread_pos.x` = innermost coordinate), saving one div+mod per element — same as the unary precedent.

**Dispatch (`exec_ternary_kernel`):** merged signature `(iter, name, alpha, scalar_arg_type, ilp_threshold)` folds in the host plumbing carried by #189420 (alpha) and #187557 (ILP); both rebase to consumer-only diffs after this lands. Specialized flavors all require `!alpha`. `PYTORCH_TERNARY_FORCE_FLAVOR` (`scalar|strided|ilp|inner_contiguous|inner_strided`) pins a flavor for A/B benching; a force bypasses profitability gates, never correctness gates.

**Stacked on #189624** (two `exec_ternary_kernel` dispatch bugfixes, split out per the bugfix-first convention) — review only the top commit here; the base commit is that PR.

**Instantiation growth:** the blanket ternary macro goes from 5 to 8 host_names per (op, dtype); clamp (9 dtypes, the only registered ternary op) gains +36 kernel instantiations, measured +452 KB on `libtorch_cpu.dylib` including the new host dispatch code.

## Gate design (the interesting decision)

`inner_strided` is *correct* for any strided layout but only *profitable* in two families, and the gate selects exactly those: (a) unit-or-broadcast inner layouts (`isInnerUnitOrBroadcast`: every operand's inner stride is 0 or its element size), where the loads have locality; and (b) **every cast layout** — cast loads pay a per-element runtime-type switch that dominates the gather cost, so the amortized outer decode wins even without locality (measured 1.07× on clamp half-vs-float with a transposed operand, 1.48× on `where` with a transposed operand). Non-cast layouts outside (a) — e.g. a transposed operand — measure 4–7% *behind* the 2D strided kernel and stay generic; that negative measurement is in the table on purpose. `INNER_STRIDED_MIN_EXTENT = 8` from the sweep below.

## Perf

`benchmarks/mps/bench_ternary_infra.py` (in-tree), `torch.utils.benchmark.Timer`, K-iteration amortized loop behind one sync, 3 interleaved trials, GPU-utilization-guarded, M-series. clamp with tensor bounds (the only trunk ternary consumer).

**Forced A/B within this build** (B = new flavor, A = 2D strided; speedup = A/B):

| case | dtype | A ms | B ms | speedup |
|---|---|---:|---:|---:|
| channel broadcast [64,64,56,56] × [1,64,1,1] → inner_strided | f32 | 23.05 | 8.06 | **2.86×** |
| channel broadcast | f16 | 22.96 | 6.91 | **3.32×** |
| unit-inner broadcast [4096,4096] × [4096] → inner_contiguous | f32 | 20.02 | 10.32 | **1.94×** |
| unit-inner broadcast | f16 | 19.98 | 5.26 | **3.80×** |
| 0-dim tensor bounds [2^22] → inner_strided | f32 | 5.43 | 4.93 | 1.10× |
| 0-dim tensor bounds | f16 | 5.37 | 2.21 | **2.43×** |
| transposed x.t() (no broadcast) → inner_strided **(gated out)** | f32 | 30.07 | 31.30 | 0.96× |
| transposed | f16 | 26.08 | 27.97 | 0.93× |
| transposed **cast** (half x.t() vs float bounds) → inner_strided **(selected: cast rule)** | f16/f32 | 7.78 | 7.24 | **1.07×** |

**Sweep** (x[outer,inner], bounds[outer,1], numel 2^22, f32): inner_strided wins 1.89–2.21× at every extent from 8 to 4096 → `INNER_STRIDED_MIN_EXTENT = 8`.

**Unforced dispatch vs trunk control build** (same machine, alternating runs ×3; control = trunk checkout @ 3b923b1, which already dispatched clamp through the ternary Metal path — the ternary kernels are unchanged between 3b923b1 and this PR's base):

| case | trunk ms | this PR ms | speedup |
|---|---:|---:|---:|
| channel broadcast f32 | 25.65 | 7.94 | **3.23×** |
| channel broadcast f16 | 25.70 | 7.10 | **3.62×** |
| unit-inner broadcast f32 | 23.11 | 10.24 | **2.26×** |
| scalar-bounds f32 | 3.47 | 2.45 | **1.42×** |
| transposed f32 | 30.71 | 30.38 | 1.01× (no regression) |
| dense f32 | 4.90 | 4.87 | 1.01× (no change) |

Routing proof: unforced channel-broadcast matches forced `inner_strided` (8.03 vs 8.07 ms), not forced `strided` (23.3 ms). Cast-transposed routing proof: unforced 7.236 ms == forced inner_strided 7.239 ms, vs forced strided 7.776 ms.

## Tests

- `test_clamp_tensor_bounds_out_dtype` — regression test for bug fix 2 (fails on trunk at pipeline creation).
- `test_clamp_tensor_bounds_flavor_parity` — forces every flavor across the layouts it serves: ragged tails (numel % 4), inner extents 15/16/17 around the tile boundary, transposed, 0-dim bounds, mixed dtype; CPU-parity per flavor.
- Full MPS suite (`run_test.py --mps --keep-going`): sole failure is `TestMetalRewritePass::test_conv` (mobile prepack rewrite), which fails identically on this machine at the base revision and on every branch of this campaign.

## Diff size

**This PR only** — `3e6a3ccd4e6` (#189624 head) → `4e7ed4befd1`:

5 files changed, **+952/−39**.

**Full stack (cumulative, as shown by GitHub against `main`)**:

5 files changed, **+975/−40**. GitHub's Files changed view includes #189624; reviewers of
this PR should review the parent-to-head range above.

### This PR only by file

| file | Δ |
|---|---|
| `c10/metal/indexing.h` | +309/−13 (new kernels + registrations, strided 1D→2D) |
| `aten/src/ATen/native/mps/OperationUtils.mm` | +153/−25 (merged exec, flavor selection, gates) |
| `aten/src/ATen/native/mps/MetalShaderLibrary.h` | +10/−1 (merged signature) |
| `test/test_mps.py` | +35/−0 (flavor-parity coverage) |
| `benchmarks/mps/bench_ternary_infra.py` | +445/−0 (new, in-tree bench) |
| **total** | **+952/−39** |

## Follow-ups (deliberately out of scope)

- Binary `inner_strided` generalization (prelu's NCHW weight layouts) — severed into its own PR with a metallib-size and bench proof.
- `ternary_alpha_dense_ilp` — owned by #189420 (addcmul/addcdiv) once this lands.
- Consumer opt-ins: `where` (parked branch becomes a thin consumer), BCE noncontig/mixed-dtype tails in #187557, mse ILP opt-in in #187553.
- Binary strided 1D→2D, mid-size fused-reduce tuning (tracked separately).
