### PR TITLE
[MPS] Fix SDPA batch and head broadcasting

### DIFF
--- a/aten/src/ATen/native/mps/operations/Attention.mm
+++ b/aten/src/ATen/native/mps/operations/Attention.mm
@@ -51,7 +51,7 @@ static std::tuple<Tensor, Tensor> sdpa_general_mps(const Tensor& query,
                                                    bool is_causal,
                                                    const std::optional<Tensor>& dropout_mask,
                                                    std::optional<double> scale,
-                                                   const Tensor& orig_query,
+                                                   const Tensor& expanded_query,
                                                    bool unsqueezed) {
   using namespace mps;
   // MPSGraph fallback path doesn't combine causal + attn_mask correctly
@@ -171,11 +171,11 @@ static std::tuple<Tensor, Tensor> sdpa_general_mps(const Tensor& query,
   auto final_out = out;
   auto final_attn = attn;
   if (unsqueezed) {
-    if (orig_query.dim() == 3) {
+    if (expanded_query.dim() == 3) {
       final_out = out.squeeze(0);
       final_attn = attn.squeeze(0);
     } else {
-      std::vector<int64_t> prefix_shape(orig_query.sizes().begin(), orig_query.sizes().end() - 3);
+      std::vector<int64_t> prefix_shape(expanded_query.sizes().begin(), expanded_query.sizes().end() - 3);
 
       auto out_shape = prefix_shape;
       auto attn_shape = prefix_shape;
@@ -204,7 +204,7 @@ static std::tuple<Tensor, Tensor> sdpa_vector_fast_mps(const Tensor& q_,
                                                        bool is_causal,
                                                        const std::optional<Tensor>& dropout_mask,
                                                        std::optional<double> scale,
-                                                       const Tensor& orig_query,
+                                                       const Tensor& expanded_query,
                                                        bool unsqueezed) {
   TORCH_CHECK(q_.size(3) == k_.size(3) && q_.size(3) == v_.size(3),
               "sdpa_vector_fast_mps expects query, key, and value to have the same head dimension");
@@ -274,9 +274,9 @@ static std::tuple<Tensor, Tensor> sdpa_vector_fast_mps(const Tensor& q_,
     }
   });
   // reshape back to original dimension
-  auto final_out = unsqueezed ? out.view_as(orig_query) : out;
-  auto final_attn = unsqueezed ? (orig_query.dim() == 3 ? attn.squeeze(0) : [&]{
-    std::vector<int64_t> shape(orig_query.sizes().begin(), orig_query.sizes().end() - 3);
+  auto final_out = unsqueezed ? out.view_as(expanded_query) : out;
+  auto final_attn = unsqueezed ? (expanded_query.dim() == 3 ? attn.squeeze(0) : [&]{
+    std::vector<int64_t> shape(expanded_query.sizes().begin(), expanded_query.sizes().end() - 3);
     shape.insert(shape.end(), {attn.size(1), attn.size(2), attn.size(3)});
     return attn.view(shape);
   }()) : attn;
@@ -293,7 +293,7 @@ static std::tuple<Tensor, Tensor> sdpa_vector_2pass_mps(const Tensor& q_,
                                                         bool is_causal,
                                                         const std::optional<Tensor>& dropout_mask,
                                                         std::optional<double> scale,
-                                                        const Tensor& orig_query,
+                                                        const Tensor& expanded_query,
                                                         bool unsqueezed) {
   TORCH_CHECK(q_.size(3) == k_.size(3) && q_.size(3) == v_.size(3),
               "sdpa_vector_2pass_mps expects query, key, and value to have the same head dimension");
@@ -322,7 +322,7 @@ static std::tuple<Tensor, Tensor> sdpa_vector_2pass_mps(const Tensor& q_,
   auto sums = at::empty({batchSize, num_heads, seq_len_q, blocks}, q_.options().dtype(kFloat));
   auto maxs = at::empty({batchSize, num_heads, seq_len_q, blocks}, q_.options().dtype(kFloat));
 
-  auto scale_factor = sdp::calculate_scale(orig_query, scale).expect_float();
+  auto scale_factor = sdp::calculate_scale(expanded_query, scale).expect_float();
   const bool has_mask = mask_.has_value();
 
   MPSStream* mpsStream = getCurrentMPSStream();
@@ -377,7 +377,7 @@ static std::tuple<Tensor, Tensor> sdpa_vector_2pass_mps(const Tensor& q_,
     }
   });
 
-  auto final_out = unsqueezed ? out.view_as(orig_query) : out;
+  auto final_out = unsqueezed ? out.view_as(expanded_query) : out;
   return {std::move(final_out), std::move(intermediate)};
 }
 
@@ -390,7 +390,7 @@ static std::tuple<Tensor, Tensor> sdpa_full_attention_mps(const Tensor& q_,
                                                           bool is_causal,
                                                           const std::optional<Tensor>& dropout_mask,
                                                           std::optional<double> scale,
-                                                          const Tensor& orig_query,
+                                                          const Tensor& expanded_query,
                                                           bool unsqueezed) {
   using namespace mps;
 
@@ -426,7 +426,7 @@ static std::tuple<Tensor, Tensor> sdpa_full_attention_mps(const Tensor& q_,
     mask_kv_seq_stride = mask_tensor.stride(3);
   }
 
-  float scale_factor = sdp::calculate_scale(orig_query, scale).expect_float();
+  float scale_factor = sdp::calculate_scale(expanded_query, scale).expect_float();
   auto out = at::empty_like(q_);
 
   constexpr uint wm = 4;
@@ -478,8 +478,11 @@ static std::tuple<Tensor, Tensor> sdpa_full_attention_mps(const Tensor& q_,
     }
   });
 
-  auto final_out = unsqueezed ? out.view_as(orig_query) : out;
-  return {final_out, final_out};
+  auto final_out = unsqueezed ? out.view_as(expanded_query) : out;
+  auto attn_sizes = final_out.sym_sizes().vec();
+  attn_sizes.back() = k_.sym_size(2);
+  auto attn_weights = at::empty_symint(attn_sizes, final_out.options());
+  return {std::move(final_out), std::move(attn_weights)};
 }
 
 // Flash-attention prefill (kernels in Attention.metal). Picks block sizes
@@ -552,7 +555,7 @@ static std::tuple<Tensor, Tensor> sdpa_prefill_mps(const Tensor& q_,
                                                    const std::optional<Tensor>& mask_,
                                                    bool is_causal,
                                                    std::optional<double> scale,
-                                                   const Tensor& orig_query,
+                                                   const Tensor& expanded_query,
                                                    bool unsqueezed) {
   using namespace mps;
 
@@ -578,7 +581,7 @@ static std::tuple<Tensor, Tensor> sdpa_prefill_mps(const Tensor& q_,
   params.qL = static_cast<int>(qL);
   params.kL = static_cast<int>(kL);
   params.gqa_factor = gqa_factor;
-  params.scale = sdp::calculate_scale(orig_query, scale).expect_float();
+  params.scale = sdp::calculate_scale(expanded_query, scale).expect_float();
   params.softcapping = 1.0f;
   params.Q_strides[0] = static_cast<int>(q_.stride(0));
   params.Q_strides[1] = static_cast<int>(q_.stride(1));
@@ -680,8 +683,11 @@ static std::tuple<Tensor, Tensor> sdpa_prefill_mps(const Tensor& q_,
     }
   });
 
-  auto final_out = unsqueezed ? out.view_as(orig_query) : out;
-  return {final_out, final_out};
+  auto final_out = unsqueezed ? out.view_as(expanded_query) : out;
+  auto attn_sizes = final_out.sym_sizes().vec();
+  attn_sizes.back() = k_.sym_size(2);
+  auto attn_weights = at::empty_symint(attn_sizes, final_out.options());
+  return {std::move(final_out), std::move(attn_weights)};
 }
 
 std::tuple<Tensor, Tensor> _scaled_dot_product_attention_math_mps(const Tensor& query,

--- a/aten/src/ATen/native/mps/operations/Attention.mm
+++ b/aten/src/ATen/native/mps/operations/Attention.mm
@@ -35,8 +35,8 @@ static inline std::tuple<Tensor, bool> ensure_4d(const Tensor& x) {
   if (x.dim() == 3) {
     return {x.unsqueeze(0), true};
   } else if (x.dim() > 4) {
-    auto batchSize = c10::multiply_integers(x.sizes().begin(), x.sizes().end() - 3);
-    return {x.reshape({batchSize, x.size(-3), x.size(-2), x.size(-1)}), true};
+    auto batchSize = c10::multiply_integers(x.sym_sizes().begin(), x.sym_sizes().end() - 3);
+    return {x.reshape_symint({batchSize, x.sym_size(-3), x.sym_size(-2), x.sym_size(-1)}), true};
   } else {
     return {x, false};
   }
@@ -479,7 +479,7 @@ static std::tuple<Tensor, Tensor> sdpa_full_attention_mps(const Tensor& q_,
   });
 
   auto final_out = unsqueezed ? out.view_as(orig_query) : out;
-  return {std::move(final_out), std::move(final_out)};
+  return {final_out, final_out};
 }
 
 // Flash-attention prefill (kernels in Attention.metal). Picks block sizes
@@ -681,7 +681,7 @@ static std::tuple<Tensor, Tensor> sdpa_prefill_mps(const Tensor& q_,
   });
 
   auto final_out = unsqueezed ? out.view_as(orig_query) : out;
-  return {std::move(final_out), std::move(final_out)};
+  return {final_out, final_out};
 }
 
 std::tuple<Tensor, Tensor> _scaled_dot_product_attention_math_mps(const Tensor& query,
@@ -719,43 +719,39 @@ std::tuple<Tensor, Tensor> _scaled_dot_product_attention_math_mps(const Tensor& 
   }
 
   const auto outer_dims = enable_gqa ? 3 : 2;
-  auto outer_shape = at::infer_size_dimvector(query.sizes().slice(0, query.dim() - outer_dims),
-                                              key_.sizes().slice(0, key_.dim() - outer_dims));
-  outer_shape = at::infer_size_dimvector(outer_shape, value_.sizes().slice(0, value_.dim() - outer_dims));
+  auto outer_shape = at::infer_size_symdimvector(query.sym_sizes().slice(0, query.dim() - outer_dims),
+                                                 key_.sym_sizes().slice(0, key_.dim() - outer_dims));
+  outer_shape = at::infer_size_symdimvector(outer_shape, value_.sym_sizes().slice(0, value_.dim() - outer_dims));
 
   auto broadcast = [&](const Tensor& t) {
     auto shape = outer_shape;
     if (enable_gqa) {
-      shape.push_back(t.size(-3) == 1 ? query.size(-3) : t.size(-3));
+      shape.push_back(t.size(-3) == 1 ? query.sym_size(-3) : t.sym_size(-3));
     }
-    shape.append({t.size(-2), t.size(-1)});
-    return t.expand(shape);
+    shape.append({t.sym_size(-2), t.sym_size(-1)});
+    return t.expand_symint(shape);
   };
 
   Tensor query_expanded = broadcast(query);
-  auto query_tuple = ensure_4d(query_expanded);
-  Tensor q_ = std::get<0>(query_tuple);
-  bool unsqueezed = std::get<1>(query_tuple);
+  auto [q_, unsqueezed] = ensure_4d(query_expanded);
 
-  auto key_tuple = ensure_4d(broadcast(key_));
-  Tensor k_ = std::get<0>(key_tuple);
+  Tensor k_ = std::get<0>(ensure_4d(broadcast(key_)));
 
-  auto value_tuple = ensure_4d(broadcast(value_));
-  Tensor v_ = std::get<0>(value_tuple);
+  Tensor v_ = std::get<0>(ensure_4d(broadcast(value_)));
 
   if (q_.size(0) == 0 || q_.size(1) == 0 || q_.size(2) == 0 || k_.size(2) == 0 || v_.size(3) == 0) {
-    auto out_shape = query_expanded.sizes().vec();
-    out_shape.back() = v_.size(3);
-    auto attn_shape = query_expanded.sizes().vec();
-    attn_shape.back() = k_.size(2);
-    return {at::zeros(out_shape, query.options()), at::zeros(attn_shape, query.options())};
+    auto out_shape = query_expanded.sym_sizes().vec();
+    out_shape.back() = v_.sym_size(3);
+    auto attn_shape = query_expanded.sym_sizes().vec();
+    attn_shape.back() = k_.sym_size(2);
+    return {at::zeros_symint(out_shape, query.options()), at::zeros_symint(attn_shape, query.options())};
   }
 
   std::optional<Tensor> mask_;
   if (attn_mask) {
-    auto mask_shape = query_expanded.sizes().vec();
-    mask_shape.back() = k_.size(2);
-    mask_ = std::get<0>(ensure_4d(attn_mask->expand(mask_shape)));
+    auto mask_shape = query_expanded.sym_sizes().vec();
+    mask_shape.back() = k_.sym_size(2);
+    mask_ = std::get<0>(ensure_4d(attn_mask->expand_symint(mask_shape)));
   }
 
   int query_head_dim = q_.size(3);

--- a/aten/src/ATen/native/mps/operations/Attention.mm
+++ b/aten/src/ATen/native/mps/operations/Attention.mm
@@ -719,10 +719,9 @@ std::tuple<Tensor, Tensor> _scaled_dot_product_attention_math_mps(const Tensor& 
   }
 
   const auto outer_dims = enable_gqa ? 3 : 2;
-  auto outer_shape = at::infer_size_dimvector(
-      query.sizes().slice(0, query.dim() - outer_dims), key_.sizes().slice(0, key_.dim() - outer_dims));
-  outer_shape =
-      at::infer_size_dimvector(outer_shape, value_.sizes().slice(0, value_.dim() - outer_dims));
+  auto outer_shape = at::infer_size_dimvector(query.sizes().slice(0, query.dim() - outer_dims),
+                                              key_.sizes().slice(0, key_.dim() - outer_dims));
+  outer_shape = at::infer_size_dimvector(outer_shape, value_.sizes().slice(0, value_.dim() - outer_dims));
 
   auto broadcast = [&](const Tensor& t) {
     auto shape = outer_shape;

--- a/aten/src/ATen/native/mps/operations/Attention.mm
+++ b/aten/src/ATen/native/mps/operations/Attention.mm
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <optional>
 
+#include <ATen/ExpandUtils.h>
 #include <ATen/core/Tensor.h>
 #include <ATen/native/mps/OperationUtils.h>
 #include <ATen/native/transformers/attention.h>
@@ -16,6 +17,7 @@
 #include <ATen/ops/_scaled_dot_product_attention_math_for_mps_native.h>
 #include <ATen/ops/empty.h>
 #include <ATen/ops/empty_like.h>
+#include <ATen/ops/zeros.h>
 #endif
 
 namespace at {
@@ -34,7 +36,7 @@ static inline std::tuple<Tensor, bool> ensure_4d(const Tensor& x) {
     return {x.unsqueeze(0), true};
   } else if (x.dim() > 4) {
     auto batchSize = c10::multiply_integers(x.sizes().begin(), x.sizes().end() - 3);
-    return {x.view({batchSize, x.size(-3), x.size(-2), x.size(-1)}), true};
+    return {x.reshape({batchSize, x.size(-3), x.size(-2), x.size(-1)}), true};
   } else {
     return {x, false};
   }
@@ -716,22 +718,45 @@ std::tuple<Tensor, Tensor> _scaled_dot_product_attention_math_mps(const Tensor& 
                     ") must be divisible by the key tensor's head dimension (" + std::to_string(k_heads) + ").");
   }
 
-  auto query_tuple = ensure_4d(query);
+  const auto outer_dims = enable_gqa ? 3 : 2;
+  auto outer_shape = at::infer_size_dimvector(
+      query.sizes().slice(0, query.dim() - outer_dims), key_.sizes().slice(0, key_.dim() - outer_dims));
+  outer_shape =
+      at::infer_size_dimvector(outer_shape, value_.sizes().slice(0, value_.dim() - outer_dims));
+
+  auto broadcast = [&](const Tensor& t) {
+    auto shape = outer_shape;
+    if (enable_gqa) {
+      shape.push_back(t.size(-3) == 1 ? query.size(-3) : t.size(-3));
+    }
+    shape.append({t.size(-2), t.size(-1)});
+    return t.expand(shape);
+  };
+
+  Tensor query_expanded = broadcast(query);
+  auto query_tuple = ensure_4d(query_expanded);
   Tensor q_ = std::get<0>(query_tuple);
   bool unsqueezed = std::get<1>(query_tuple);
 
-  auto key_tuple = ensure_4d(key_);
+  auto key_tuple = ensure_4d(broadcast(key_));
   Tensor k_ = std::get<0>(key_tuple);
 
-  auto value_tuple = ensure_4d(value_);
+  auto value_tuple = ensure_4d(broadcast(value_));
   Tensor v_ = std::get<0>(value_tuple);
+
+  if (q_.size(0) == 0 || q_.size(1) == 0 || q_.size(2) == 0 || k_.size(2) == 0 || v_.size(3) == 0) {
+    auto out_shape = query_expanded.sizes().vec();
+    out_shape.back() = v_.size(3);
+    auto attn_shape = query_expanded.sizes().vec();
+    attn_shape.back() = k_.size(2);
+    return {at::zeros(out_shape, query.options()), at::zeros(attn_shape, query.options())};
+  }
 
   std::optional<Tensor> mask_;
   if (attn_mask) {
-    auto maskExpandedDims = query.sizes().vec();
-    maskExpandedDims[maskExpandedDims.size() - 1] = k_.size(2);
-    mask_ = attn_mask->expand(maskExpandedDims);
-    std::tie(*mask_, std::ignore) = ensure_4d(*mask_);
+    auto mask_shape = query_expanded.sizes().vec();
+    mask_shape.back() = k_.size(2);
+    mask_ = std::get<0>(ensure_4d(attn_mask->expand(mask_shape)));
   }
 
   int query_head_dim = q_.size(3);
@@ -777,7 +802,7 @@ std::tuple<Tensor, Tensor> _scaled_dot_product_attention_math_mps(const Tensor& 
       prefill_mask_compatible && prefill_head_dim_supported && prefill_q_long_enough && (k_.size(2) > 0);
 
   if (!supports_fast_sdpa && !supports_prefill) {
-    return sdpa_general_mps(q_, k_, v_, mask_, dropout_p, is_causal, dropout_mask, scale, query, unsqueezed);
+    return sdpa_general_mps(q_, k_, v_, mask_, dropout_p, is_causal, dropout_mask, scale, query_expanded, unsqueezed);
   }
 
   // Kernels load head-dim elements linearly, so stride(-1) == 1 is the only hard requirement
@@ -788,16 +813,16 @@ std::tuple<Tensor, Tensor> _scaled_dot_product_attention_math_mps(const Tensor& 
   Tensor v_contig = can_use_kernel_strides(v_) ? v_ : v_.contiguous();
 
   if (supports_prefill) {
-    return sdpa_prefill_mps(q_contig, k_contig, v_contig, mask_, is_causal, scale, query, unsqueezed);
+    return sdpa_prefill_mps(q_contig, k_contig, v_contig, mask_, is_causal, scale, query_expanded, unsqueezed);
   }
 
   // for short sequences, differentiate based on key sequence length
   if ((k_.size(2) >= 1024) || (k_.size(1) < q_.size(1) && k_.size(2) >= 4096)) {
     return sdpa_vector_2pass_mps(
-        q_contig, k_contig, v_contig, mask_, dropout_p, is_causal, dropout_mask, scale, query, unsqueezed);
+        q_contig, k_contig, v_contig, mask_, dropout_p, is_causal, dropout_mask, scale, query_expanded, unsqueezed);
   } else {
     return sdpa_vector_fast_mps(
-        q_contig, k_contig, v_contig, mask_, dropout_p, is_causal, dropout_mask, scale, query, unsqueezed);
+        q_contig, k_contig, v_contig, mask_, dropout_p, is_causal, dropout_mask, scale, query_expanded, unsqueezed);
   }
 }
 } // namespace native

--- a/test/inductor/test_mps_basic.py
+++ b/test/inductor/test_mps_basic.py
@@ -296,6 +296,27 @@ class MPSBasicTests(TestCase):
         mask = torch.zeros(B, 1, S, S, device=self.device, dtype=dtype)
         self.assertEqual(torch.compile(fn)(q, k, v, mask), fn(q, k, v, mask))
 
+    @parametrize(
+        "q_shape,kv_shape",
+        [
+            ((1, 4, 4, 64), (2, 4, 16, 64)),
+            ((2, 1, 4, 64), (2, 4, 16, 64)),
+            ((2, 4, 4, 64), (2, 1, 16, 64)),
+            ((4, 4, 64), (2, 4, 16, 64)),
+            ((2, 1, 4, 4, 64), (1, 3, 4, 16, 64)),
+            ((2, 0, 4, 8), (2, 1, 16, 8)),
+        ],
+    )
+    def test_sdpa_broadcast_batch_and_heads(self, q_shape, kv_shape):
+        torch.manual_seed(0)
+
+        def fn(q, k, v):
+            return torch.nn.functional.scaled_dot_product_attention(q, k, v)
+
+        q = torch.randn(q_shape, device=self.device)
+        k = torch.randn(kv_shape, device=self.device)
+        self.assertEqual(torch.compile(fn)(q, k, k), fn(q, k, k))
+
     def test_nested_masked_cat(self):
         # Regression test for YOLOv3 compilation failure on MPS.
         # See https://github.com/pytorch/pytorch/actions/runs/23477894502

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2411,6 +2411,52 @@ class TestSDPA(NNTestCase):
             expected_shape[-1] = v_shape[-1]
             self.assertEqual(actual.shape, torch.Size(expected_shape))
 
+    @parametrize("dtype", [torch.float32, torch.float16])
+    @parametrize("broadcast", ["q_batch", "kv_batch", "q_head", "kv_head"])
+    @parametrize(
+        "qL,kL,head_dim",
+        [(4, 16, 64), (4, 1024, 64), (32, 32, 64), (4, 16, 8)],  # MPS vector, 2-pass, prefill, MPSGraph paths
+    )
+    def test_sdpa_math_broadcast_batch_and_heads(self, device, dtype, broadcast, qL, kL, head_dim):
+        torch.manual_seed(1729)
+        B, NH = 2, 4
+        qb = 1 if broadcast == "q_batch" else B
+        kb = 1 if broadcast == "kv_batch" else B
+        qh = 1 if broadcast == "q_head" else NH
+        kh = 1 if broadcast == "kv_head" else NH
+        q = torch.randn(qb, qh, qL, head_dim, dtype=dtype, device=device)
+        k = torch.randn(kb, kh, kL, head_dim, dtype=dtype, device=device)
+        v = torch.randn(kb, kh, kL, head_dim, dtype=dtype, device=device)
+        with sdpa_kernel(backends=[SDPBackend.MATH]):
+            actual = F.scaled_dot_product_attention(q, k, v)
+            expected = F.scaled_dot_product_attention(
+                q.expand(B, NH, qL, head_dim), k.expand(B, NH, kL, head_dim), v.expand(B, NH, kL, head_dim)
+            )
+        self.assertEqual(actual, expected)
+
+    @parametrize(
+        "q_shape,kv_shape,mask_shape",
+        [
+            ((4, 4, 64), (2, 4, 16, 64), None),
+            ((2, 1, 4, 4, 64), (1, 3, 4, 16, 64), (1, 3, 1, 4, 16)),
+            ((2, 0, 4, 8), (2, 1, 16, 8), None),
+        ],
+    )
+    def test_sdpa_math_broadcast_prefix_and_empty_dims(self, device, q_shape, kv_shape, mask_shape):
+        torch.manual_seed(1729)
+        q = torch.randn(q_shape, device=device)
+        k = torch.randn(kv_shape, device=device)
+        v = torch.randn(kv_shape, device=device)
+        mask = None if mask_shape is None else torch.randn(mask_shape, device=device)
+
+        with sdpa_kernel(backends=[SDPBackend.MATH]):
+            actual = F.scaled_dot_product_attention(q, k, v, attn_mask=mask)
+            outer_shape = torch.broadcast_shapes(q.shape[:-2], k.shape[:-2], v.shape[:-2])
+            expanded = tuple(t.expand(outer_shape + t.shape[-2:]) for t in (q, k, v))
+            mask = None if mask is None else mask.expand(outer_shape + (q.size(-2), k.size(-2)))
+            expected = F.scaled_dot_product_attention(*expanded, attn_mask=mask)
+        self.assertEqual(actual, expected)
+
     def test_sdpa_export_unbacked_attn_mask(self, device):
         """SDPA backend selection should not crash on unbacked symbolic mask shapes."""
 

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2435,14 +2435,18 @@ class TestSDPA(NNTestCase):
         self.assertEqual(actual, expected)
 
     @parametrize(
-        "q_shape,kv_shape,mask_shape",
+        "q_shape,kv_shape,mask_shape,enable_gqa,is_causal",
         [
-            ((4, 4, 64), (2, 4, 16, 64), None),
-            ((2, 1, 4, 4, 64), (1, 3, 4, 16, 64), (1, 3, 1, 4, 16)),
-            ((2, 0, 4, 8), (2, 1, 16, 8), None),
+            ((4, 4, 64), (2, 4, 16, 64), None, False, False),
+            ((2, 1, 4, 4, 64), (1, 3, 4, 16, 64), (1, 3, 1, 4, 16), False, False),
+            ((2, 0, 4, 8), (2, 1, 16, 8), None, False, False),
+            ((1, 8, 4, 64), (2, 2, 16, 64), None, True, False),
+            ((1, 4, 4, 64), (2, 1, 16, 64), None, False, True),
         ],
     )
-    def test_sdpa_math_broadcast_prefix_and_empty_dims(self, device, q_shape, kv_shape, mask_shape):
+    def test_sdpa_math_broadcast_prefix_and_empty_dims(
+        self, device, q_shape, kv_shape, mask_shape, enable_gqa, is_causal
+    ):
         torch.manual_seed(1729)
         q = torch.randn(q_shape, device=device)
         k = torch.randn(kv_shape, device=device)
@@ -2450,11 +2454,24 @@ class TestSDPA(NNTestCase):
         mask = None if mask_shape is None else torch.randn(mask_shape, device=device)
 
         with sdpa_kernel(backends=[SDPBackend.MATH]):
-            actual = F.scaled_dot_product_attention(q, k, v, attn_mask=mask)
-            outer_shape = torch.broadcast_shapes(q.shape[:-2], k.shape[:-2], v.shape[:-2])
-            expanded = tuple(t.expand(outer_shape + t.shape[-2:]) for t in (q, k, v))
+            actual = F.scaled_dot_product_attention(
+                q, k, v, attn_mask=mask, is_causal=is_causal, enable_gqa=enable_gqa
+            )
+            outer_dims = 3 if enable_gqa else 2
+            outer_shape = torch.broadcast_shapes(
+                q.shape[:-outer_dims], k.shape[:-outer_dims], v.shape[:-outer_dims]
+            )
+            expanded = tuple(t.expand(outer_shape + t.shape[-outer_dims:]) for t in (q, k, v))
+            if enable_gqa:
+                factor = q.size(-3) // k.size(-3)
+                q_expanded, k_expanded, v_expanded = expanded
+                expanded = (
+                    q_expanded,
+                    k_expanded.repeat_interleave(factor, -3),
+                    v_expanded.repeat_interleave(factor, -3),
+                )
             mask = None if mask is None else mask.expand(outer_shape + (q.size(-2), k.size(-2)))
-            expected = F.scaled_dot_product_attention(*expanded, attn_mask=mask)
+            expected = F.scaled_dot_product_attention(*expanded, attn_mask=mask, is_causal=is_causal)
         self.assertEqual(actual, expected)
 
     def test_sdpa_export_unbacked_attn_mask(self, device):

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -6541,12 +6541,12 @@ def meta__scaled_dot_product_attention_math_for_mps(
     q_prefix, k_prefix, v_prefix = query.shape[:-3], key.shape[:-3], value.shape[:-3]
     prefix = list(torch.broadcast_shapes(q_prefix, k_prefix, v_prefix))
     qh, kh, vh = query.size(-3), key.size(-3), value.size(-3)
-    num_head = qh if enable_gqa else torch.broadcast_shapes((qh,), (kh,), (vh,))[0]
+    num_heads = qh if enable_gqa else torch.broadcast_shapes((qh,), (kh,), (vh,))[0]
 
     # sdpa_vector_2pass_mps and sdpa_vector_fast_mps are intentionally left out.
     # See https://github.com/pytorch/pytorch/issues/177603 for additional context.
-    out = query.new_empty(prefix + [num_head, query.size(-2), value.size(-1)])
-    attn = query.new_empty(prefix + [num_head, query.size(-2), key.size(-2)])
+    out = query.new_empty(prefix + [num_heads, query.size(-2), value.size(-1)])
+    attn = query.new_empty(prefix + [num_heads, query.size(-2), key.size(-2)])
     return out, attn
 
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -6538,41 +6538,16 @@ def meta__scaled_dot_product_attention_math_for_mps(
     scale: float | None = None,
     enable_gqa: bool = False,
 ) -> tuple[Tensor, Tensor]:
-    def ensure_4d(x):
-        if x.dim() == 3:
-            return x.unsqueeze(0), True
-        elif x.dim() > 4:
-            batch_size = 1
-            for i in range(x.dim() - 3):
-                batch_size *= x.shape[i]
-            return x.view(batch_size, x.size(-3), x.size(-2), x.size(-1)), True
-        else:
-            return x, False
-
-    q_, unsqueezed = ensure_4d(query)
-    k_, _ = ensure_4d(key)
-    v_, _ = ensure_4d(value)
-
-    batch_size, num_head, q_size, _ = q_.shape
-    _, _, max_seq_length, value_head_size = v_.shape
-
-    def sdpa_general_mps():
-        out = q_.new_empty((batch_size, num_head, q_size, value_head_size))
-        attn = q_.new_empty((batch_size, num_head, q_size, max_seq_length))
-        if unsqueezed:
-            if query.dim() == 3:
-                out = out.squeeze(0)
-                attn = attn.squeeze(0)
-            else:
-                out_shape = list(query.shape[:-3]) + list(out.shape[1:4])
-                attn_shape = list(query.shape[:-3]) + list(attn.shape[1:4])
-                out = out.view(out_shape)
-                attn = attn.view(attn_shape)
-        return out, attn
+    q_prefix, k_prefix, v_prefix = query.shape[:-3], key.shape[:-3], value.shape[:-3]
+    prefix = list(torch.broadcast_shapes(q_prefix, k_prefix, v_prefix))
+    qh, kh, vh = query.size(-3), key.size(-3), value.size(-3)
+    num_head = qh if enable_gqa else torch.broadcast_shapes((qh,), (kh,), (vh,))[0]
 
     # sdpa_vector_2pass_mps and sdpa_vector_fast_mps are intentionally left out.
     # See https://github.com/pytorch/pytorch/issues/177603 for additional context.
-    return sdpa_general_mps()
+    out = query.new_empty(prefix + [num_head, query.size(-2), value.size(-1)])
+    attn = query.new_empty(prefix + [num_head, query.size(-2), key.size(-2)])
+    return out, attn
 
 
 @register_meta([aten._scaled_dot_product_efficient_attention])


### PR DESCRIPTION
Bug:
```
import torch
import torch.nn.functional as F

DEVICE = "mps"

q = torch.randn(1, 1, 64, device=DEVICE)
k = torch.randn(2, 1, 1, 64, device=DEVICE)

with torch.nn.attention.sdpa_kernel([torch.nn.attention.SDPBackend.MATH]):
    out = F.scaled_dot_product_attention(q, k, k)

print(out.shape)
```

Gives:
```
Traceback (most recent call last):
  File "/Users/salia/Desktop/pytorch/temp.py", line 10, in <module>
    out = F.scaled_dot_product_attention(q, k, k)
RuntimeError: shape '[1, 1, 64]' is invalid for input of size 128
```

Same thing works on CPU.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo