### PR TITLE
autograd: add ctx.set_output_grad_dtype

### DIFF
--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -5698,6 +5698,14 @@ test_autograd = load_test_module("test_autograd")
 test_custom_ops = load_test_module("test_custom_ops")
 test_higher_order_ops = load_test_module("dynamo/test_higher_order_ops")
 
+# grad_dtype is not supported in compile (every eager test here is already
+# skipIfTorchDynamo). Most of them also report the dtype they observed by
+# setattr-ing on the Function class, which dynamo cannot trace once compiled
+# autograd inlines the backward.
+for name in dir(test_autograd.TestAutograd):
+    if name.startswith("test_ctx_output_grad_dtype"):
+        skipped_tests.add(name)
+
 TestAutogradWithCompiledAutograd = wrap_test_class(test_autograd.TestAutograd)
 TestNestedCheckpointWithCompiledAutograd = wrap_test_class(
     test_autograd.TestNestedCheckpoint

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -4354,7 +4354,7 @@ class TestAutograd(TestCase):
             def backward(ctx, g):
                 return g
 
-        with self.assertRaisesRegex(RuntimeError, "one declaration per output"):
+        with self.assertRaisesRegex(RuntimeError, "number of declarations to match"):
             CountMismatch.apply(x)
 
         class TooFewDeclarations(torch.autograd.Function):
@@ -4367,7 +4367,7 @@ class TestAutograd(TestCase):
             def backward(ctx, g0, g1):
                 return g0 + g1
 
-        with self.assertRaisesRegex(RuntimeError, "one declaration per output"):
+        with self.assertRaisesRegex(RuntimeError, "number of declarations to match"):
             TooFewDeclarations.apply(x)
 
         class BadDeclarationType(torch.autograd.Function):
@@ -4393,7 +4393,7 @@ class TestAutograd(TestCase):
             def backward(ctx, g, gs):
                 return g
 
-        with self.assertRaisesRegex(RuntimeError, "differentiable tensor output"):
+        with self.assertRaisesRegex(RuntimeError, "not a differentiable tensor"):
             DtypeForNonTensor.apply(x)
 
         class DtypeForNonDifferentiable(torch.autograd.Function):
@@ -4408,8 +4408,50 @@ class TestAutograd(TestCase):
             def backward(ctx, g):
                 return g
 
-        with self.assertRaisesRegex(RuntimeError, "differentiable tensor output"):
+        with self.assertRaisesRegex(RuntimeError, "not a differentiable tensor"):
             DtypeForNonDifferentiable.apply(x)
+
+    @skipIfTorchDynamo("grad_dtype not supported in compile")
+    def test_ctx_output_grad_dtype_called_twice(self):
+        # set_output_grad_dtype may be called at most once per invocation.
+        class CalledTwice(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x):
+                ctx.set_output_grad_dtype(torch.float32)
+                ctx.set_output_grad_dtype(torch.float64)
+                return x.clone()
+
+            @staticmethod
+            def backward(ctx, g):
+                return g
+
+        x = torch.tensor([1.0, 2.0], requires_grad=True)
+        with self.assertRaisesRegex(RuntimeError, "can only be called once"):
+            CalledTwice.apply(x)
+
+    @skipIfTorchDynamo("grad_dtype not supported in compile")
+    def test_ctx_output_grad_dtype_return_as_is_non_differentiable(self):
+        # mark_non_differentiable records the raw output's TensorImpl, so
+        # differentiability must be checked on the raw output, not its wrapper.
+        class ReturnAsIs(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x, y):
+                out = x.to(torch.bfloat16)
+                ctx.mark_non_differentiable(y)
+                ctx.set_output_grad_dtype(torch.float32, None)
+                return out, y
+
+            @staticmethod
+            def backward(ctx, g_out, g_y):
+                ReturnAsIs.seen_grad_dtype = g_out.dtype
+                return g_out.to(torch.float32), None
+
+        x = torch.tensor([1.0, 2.0], requires_grad=True)
+        y = torch.tensor([3.0, 4.0])
+        out, out_y = ReturnAsIs.apply(x, y)
+        self.assertFalse(out_y.requires_grad)
+        out.sum().backward()
+        self.assertEqual(ReturnAsIs.seen_grad_dtype, torch.float32)
 
     def test_gc_in_destructor(self):
         """

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -4179,6 +4179,238 @@ class TestAutograd(TestCase):
         z2.sum().backward()
         self.assertEqual(l.grad.dtype, torch.float32)
 
+    @skipIfTorchDynamo("grad_dtype not supported in compile")
+    @parametrize(
+        "declared,expected",
+        [
+            # unset -> slot defaults to storage dtype; explicit up/down casts the
+            # incoming fp64 grad; None passes it through uncast; the output's own
+            # dtype requests the default explicitly.
+            ("unset", torch.bfloat16),
+            (torch.float32, torch.float32),
+            (torch.float16, torch.float16),
+            (None, torch.float64),
+            (torch.bfloat16, torch.bfloat16),
+        ],
+    )
+    def test_ctx_output_grad_dtype(self, declared, expected):
+        # ctx.set_output_grad_dtype controls the dtype of the gradient the
+        # engine hands to backward, independent of the output's storage dtype.
+        # The output is bf16; a downstream node returns an fp64 gradient for it.
+        class Downstream(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x):
+                return x.clone()
+
+            @staticmethod
+            def backward(ctx, g):
+                return torch.ones_like(g, dtype=torch.float64)
+
+        class DeclareOutput(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x, declared):
+                out = x.to(torch.bfloat16)
+                if declared != "unset":
+                    ctx.set_output_grad_dtype(declared)
+                return out
+
+            @staticmethod
+            def backward(ctx, g):
+                DeclareOutput.seen = g.dtype
+                return g.to(torch.float32), None
+
+        x = torch.tensor([1.0, 2.0], requires_grad=True)
+        out = DeclareOutput.apply(x, declared)
+        self.assertEqual(out.dtype, torch.bfloat16)
+        Downstream.apply(out).sum().backward()
+        self.assertEqual(DeclareOutput.seen, expected)
+
+    @skipIfTorchDynamo("grad_dtype not supported in compile")
+    def test_ctx_output_grad_dtype_multiple_outputs(self):
+        # Positional declarations line up with returned values: a concrete
+        # dtype, the default (via the output's own dtype), and None for a
+        # non-tensor output.
+        class MultiOutput(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x):
+                t1 = x.sin()
+                t2 = x.cos()
+                ctx.set_output_grad_dtype(torch.float64, t2.dtype, None)
+                return t1, t2, "not a tensor"
+
+            @staticmethod
+            def backward(ctx, g1, g2, g3):
+                MultiOutput.seen = (g1.dtype, g2.dtype, g3)
+                return g1.to(torch.float32) + g2.to(torch.float32)
+
+        x = torch.tensor([1.0, 2.0], requires_grad=True)
+        t1, t2, s = MultiOutput.apply(x)
+        self.assertEqual(s, "not a tensor")
+        (t1.sum() + t2.sum()).backward()
+        self.assertEqual(MultiOutput.seen[0], torch.float64)
+        self.assertEqual(MultiOutput.seen[1], torch.float32)
+        self.assertIsNone(MultiOutput.seen[2])
+
+    @skipIfTorchDynamo("grad_dtype not supported in compile")
+    def test_ctx_output_grad_dtype_aliased_outputs(self):
+        # setup_context can declare distinct grad dtypes for output slots whose
+        # tensors alias the same storage.
+        class SetupContext(torch.autograd.Function):
+            @staticmethod
+            def forward(x):
+                base = x.to(torch.bfloat16)
+                return base.view_as(base), base.view_as(base)
+
+            @staticmethod
+            def setup_context(ctx, inputs, output):
+                ctx.set_output_grad_dtype(torch.float32, torch.float64)
+
+            @staticmethod
+            def backward(ctx, g0, g1):
+                SetupContext.output_grad_dtypes = (g0.dtype, g1.dtype)
+                return g0.to(torch.float32) + g1.to(torch.float32)
+
+        x = torch.tensor([1.0, 2.0], requires_grad=True)
+        out0, out1 = SetupContext.apply(x)
+        (out0.sum() + out1.sum()).backward()
+        self.assertEqual(
+            SetupContext.output_grad_dtypes, (torch.float32, torch.float64)
+        )
+
+    @skipIfTorchDynamo("grad_dtype not supported in compile")
+    def test_ctx_output_grad_dtype_accumulation(self):
+        # A declared grad dtype also governs the dtype the engine accumulates
+        # in when the output fans out to multiple consumers: the two fp64
+        # incoming gradients are accumulated as fp32 (the declared dtype), so
+        # backward sees fp32.
+        class Consumer(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x):
+                return x.clone()
+
+            @staticmethod
+            def backward(ctx, g):
+                return torch.ones_like(g, dtype=torch.float64)
+
+        class Fanout(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x):
+                out = x.to(torch.bfloat16)
+                ctx.set_output_grad_dtype(torch.float32)
+                return out
+
+            @staticmethod
+            def backward(ctx, g):
+                Fanout.seen = g.dtype
+                return g.to(torch.float32)
+
+        x = torch.tensor([1.0, 2.0], requires_grad=True)
+        out = Fanout.apply(x)
+        (Consumer.apply(out).sum() + Consumer.apply(out).sum()).backward()
+        self.assertEqual(Fanout.seen, torch.float32)
+
+    @skipIfTorchDynamo("grad_dtype not supported in compile")
+    def test_ctx_output_grad_dtype_setup_context(self):
+        # The API is equally usable from setup_context.
+        class UseSetup(torch.autograd.Function):
+            @staticmethod
+            def forward(x):
+                return x.to(torch.bfloat16)
+
+            @staticmethod
+            def setup_context(ctx, inputs, output):
+                ctx.set_output_grad_dtype(torch.float32)
+
+            @staticmethod
+            def backward(ctx, g):
+                UseSetup.seen = g.dtype
+                return g.to(torch.float32)
+
+        class Downstream(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x):
+                return x.clone()
+
+            @staticmethod
+            def backward(ctx, g):
+                return torch.ones_like(g, dtype=torch.float64)
+
+        x = torch.tensor([1.0, 2.0], requires_grad=True)
+        out = UseSetup.apply(x)
+        Downstream.apply(out).sum().backward()
+        self.assertEqual(UseSetup.seen, torch.float32)
+
+    @skipIfTorchDynamo("grad_dtype not supported in compile")
+    def test_ctx_output_grad_dtype_validation(self):
+        x = torch.tensor([1.0, 2.0], requires_grad=True)
+
+        class CountMismatch(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x):
+                ctx.set_output_grad_dtype(torch.float32, torch.float32)
+                return x.clone()
+
+            @staticmethod
+            def backward(ctx, g):
+                return g
+
+        with self.assertRaisesRegex(RuntimeError, "one declaration per output"):
+            CountMismatch.apply(x)
+
+        class TooFewDeclarations(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x):
+                ctx.set_output_grad_dtype(torch.float32)
+                return x.clone(), x.clone()
+
+            @staticmethod
+            def backward(ctx, g0, g1):
+                return g0 + g1
+
+        with self.assertRaisesRegex(RuntimeError, "one declaration per output"):
+            TooFewDeclarations.apply(x)
+
+        class BadDeclarationType(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x):
+                ctx.set_output_grad_dtype("float32")
+                return x.clone()
+
+            @staticmethod
+            def backward(ctx, g):
+                return g
+
+        with self.assertRaisesRegex(RuntimeError, "torch.dtype or None"):
+            BadDeclarationType.apply(x)
+
+        class DtypeForNonTensor(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x):
+                ctx.set_output_grad_dtype(None, torch.float32)
+                return x.clone(), "not a tensor"
+
+            @staticmethod
+            def backward(ctx, g, gs):
+                return g
+
+        with self.assertRaisesRegex(RuntimeError, "differentiable tensor output"):
+            DtypeForNonTensor.apply(x)
+
+        class DtypeForNonDifferentiable(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x):
+                out = x.clone()
+                ctx.mark_non_differentiable(out)
+                ctx.set_output_grad_dtype(torch.float32)
+                return out
+
+            @staticmethod
+            def backward(ctx, g):
+                return g
+
+        with self.assertRaisesRegex(RuntimeError, "differentiable tensor output"):
+            DtypeForNonDifferentiable.apply(x)
+
     def test_gc_in_destructor(self):
         """
         Previously, if a Function destructor triggered a garbage collection,

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -4453,6 +4453,26 @@ class TestAutograd(TestCase):
         out.sum().backward()
         self.assertEqual(ReturnAsIs.seen_grad_dtype, torch.float32)
 
+    @skipIfTorchDynamo("grad_dtype not supported in compile")
+    def test_ctx_output_grad_dtype_no_leak_from_returned_input(self):
+        # The output defaults to its dtype while leaf accumulation uses x.grad_dtype.
+        class ReturnInput(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x):
+                return x
+
+            @staticmethod
+            def backward(ctx, g):
+                ReturnInput.seen_grad_dtype = g.dtype
+                return g
+
+        x = torch.tensor([1.0, 2.0], dtype=torch.float32, requires_grad=True)
+        x.grad_dtype = torch.float64
+        out = ReturnInput.apply(x)
+        out.sum().backward()
+        self.assertEqual(ReturnInput.seen_grad_dtype, torch.float32)
+        self.assertEqual(x.grad.dtype, torch.float64)
+
     def test_gc_in_destructor(self):
         """
         Previously, if a Function destructor triggered a garbage collection,

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -234,40 +234,41 @@ class FunctionCtx:
     def set_output_grad_dtype(self, *dtypes: "torch.dtype | None") -> None:
         r"""Declare the gradient dtype for each of this Function's outputs.
 
-        This should be called from either the :func:`setup_context` or
-        :func:`forward` methods. If called more than once, only the last call
-        takes effect; each call overwrites the declarations from the previous
-        one. Each argument corresponds positionally to the value this Function
-        returns at the same index, so the number of declarations must match the
-        number of returned values. This lets a Function define the dtype
-        contract for gradients entering its output slots independently of the
-        outputs' storage dtypes.
+        This should be called at most once, from either the
+        :func:`setup_context` or :func:`forward` methods. The number of
+        declarations must match the number of returned values, and each argument
+        corresponds positionally to the output at the same index.
 
-        For each output slot the declaration means:
+        For each output, pass the dtype your backward should receive its
+        gradient in:
 
-        - a concrete :class:`torch.dtype` (only valid for a differentiable
-          Tensor output): the incoming gradient is converted to that dtype.
-        - ``None``: no conversion is performed. For a differentiable Tensor the
-          gradient passes through as-is; for a non-Tensor or non-differentiable
-          output there is no gradient, so ``None`` is the only valid choice.
+        - Pass a :class:`torch.dtype` and the engine guarantees the gradient
+          handed to backward has that dtype. This is only valid for a
+          differentiable Tensor output.
+        - Pass ``None`` and the gradient is handed to backward with whatever
+          dtype it already has. This is also the only valid choice for a
+          non-Tensor or non-differentiable output, which has no gradient.
+        - Omit this call (or pass the output's own dtype) and the gradient is
+          handed to backward in the output's dtype, which is the default.
 
-        If this method is not called, every output keeps the default behavior of
-        converting the incoming gradient to that output's storage dtype. To
-        request that default explicitly when calling this method, pass the
-        output's own ``dtype`` for its slot.
-
-        For example, casting the first output's gradient to ``float32``, letting
-        the second output's gradient pass through uncast (``None``), and using
-        ``None`` for the trailing non-Tensor output that has no gradient::
+        For example::
 
             >>> # xdoctest: +SKIP
             >>> @staticmethod
             >>> def forward(ctx, x):
             >>>     t1 = x.sin()
             >>>     t2 = x.cos()
-            >>>     ctx.set_output_grad_dtype(torch.float32, None, None)
-            >>>     return t1, t2, "not a tensor"
+            >>>     t3 = x.tan()
+            >>>     ctx.set_output_grad_dtype(torch.float32, t2.dtype, None, None)
+            >>>     return t1, t2, t3, "not a tensor"
+
+        casts ``t1``'s gradient to ``float32``, requests the default explicitly
+        for ``t2`` via ``t2.dtype``, leaves the differentiable ``t3``'s gradient
+        uncast with ``None``, and uses ``None`` as the placeholder for the
+        trailing non-Tensor output.
         """
+        if self.output_grad_dtypes is not None:
+            raise RuntimeError("set_output_grad_dtype can only be called once")
         self.output_grad_dtypes = dtypes
 
     def set_materialize_grads(self, value: bool):

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -231,6 +231,45 @@ class FunctionCtx:
         """
         self.non_differentiable = args
 
+    def set_output_grad_dtype(self, *dtypes: "torch.dtype | None") -> None:
+        r"""Declare the gradient dtype for each of this Function's outputs.
+
+        This should be called from either the :func:`setup_context` or
+        :func:`forward` methods. If called more than once, only the last call
+        takes effect; each call overwrites the declarations from the previous
+        one. Each argument corresponds positionally to the value this Function
+        returns at the same index, so the number of declarations must match the
+        number of returned values. This lets a Function define the dtype
+        contract for gradients entering its output slots independently of the
+        outputs' storage dtypes.
+
+        For each output slot the declaration means:
+
+        - a concrete :class:`torch.dtype` (only valid for a differentiable
+          Tensor output): the incoming gradient is converted to that dtype.
+        - ``None``: no conversion is performed. For a differentiable Tensor the
+          gradient passes through as-is; for a non-Tensor or non-differentiable
+          output there is no gradient, so ``None`` is the only valid choice.
+
+        If this method is not called, every output keeps the default behavior of
+        converting the incoming gradient to that output's storage dtype. To
+        request that default explicitly when calling this method, pass the
+        output's own ``dtype`` for its slot.
+
+        For example, casting the first output's gradient to ``float32``, letting
+        the second output's gradient pass through uncast (``None``), and using
+        ``None`` for the trailing non-Tensor output that has no gradient::
+
+            >>> # xdoctest: +SKIP
+            >>> @staticmethod
+            >>> def forward(ctx, x):
+            >>>     t1 = x.sin()
+            >>>     t2 = x.cos()
+            >>>     ctx.set_output_grad_dtype(torch.float32, None, None)
+            >>>     return t1, t2, "not a tensor"
+        """
+        self.output_grad_dtypes = dtypes
+
     def set_materialize_grads(self, value: bool):
         r"""Set whether to materialize grad tensors. Default is ``True``.
 

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -36,6 +36,8 @@ _P = ParamSpec("_P")
 
 # Formerly known as: _ContextMethodMixin
 class FunctionCtx:
+    output_grad_dtypes: "tuple[torch.dtype | None, ...] | None"
+
     def save_for_backward(self, *tensors: torch.Tensor):
         r"""Save given tensors for a future call to :func:`~Function.backward`.
 

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -262,10 +262,10 @@ class FunctionCtx:
             >>>     ctx.set_output_grad_dtype(torch.float32, t2.dtype, None, None)
             >>>     return t1, t2, t3, "not a tensor"
 
-        casts ``t1``'s gradient to ``float32``, requests the default explicitly
-        for ``t2`` via ``t2.dtype``, leaves the differentiable ``t3``'s gradient
-        uncast with ``None``, and uses ``None`` as the placeholder for the
-        trailing non-Tensor output.
+        This ensures that backward receives ``t1``'s gradient in ``float32``,
+        keeps the default behavior for ``t2``'s gradient via ``t2.dtype``,
+        passes ``t3``'s gradient through uncast with ``None``, and uses ``None``
+        as the placeholder for the trailing non-Tensor output.
         """
         if self.output_grad_dtypes is not None:
             raise RuntimeError("set_output_grad_dtype can only be called once")

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -14,6 +14,7 @@
 
 #include <ATen/FuncTorchTLS.h>
 #include <ATen/functorch/DynamicLayer.h>
+#include <torch/csrc/Dtype.h>
 #include <torch/csrc/DynamicTypes.h>
 #include <torch/csrc/Exceptions.h>
 #include <torch/csrc/THP.h>
@@ -588,6 +589,7 @@ static int THPFunction_traverse(THPFunction* self, visitproc visit, void* arg) {
   Py_VISIT(self->dirty_tensors);
   Py_VISIT(self->compiled_autograd_backward_state);
   Py_VISIT(self->saved_for_forward);
+  Py_VISIT(self->output_grad_dtypes);
   return traverse_node(self->cdata, visit, arg);
 }
 
@@ -598,6 +600,7 @@ static int THPFunction_clear(THPFunction* self) {
   Py_CLEAR(self->dirty_tensors);
   Py_CLEAR(self->compiled_autograd_backward_state);
   Py_CLEAR(self->saved_for_forward);
+  Py_CLEAR(self->output_grad_dtypes);
   return 0;
 }
 
@@ -641,6 +644,7 @@ static PyObject* THPFunction_new(
   self->materialize_non_diff_grads = true;
   self->clear_saved_tensors_on_access = false;
   self->saved_tensors_accessed_and_cleared = false;
+  self->output_grad_dtypes = nullptr;
   torch::utils::PyObjectPreservation::init_fresh_nonatomic(*self->cdata, obj);
   return obj;
 }
@@ -687,6 +691,57 @@ static std::unordered_set<at::TensorImpl*> _mark_dirty(THPFunction* self) {
 static std::unordered_set<at::TensorImpl*> _parse_non_differentiable(
     THPFunction* self);
 
+// Parse and consume positional grad-dtype declarations.
+static std::optional<std::vector<std::optional<at::ScalarType>>>
+_parse_output_grad_dtypes(
+    THPFunction* self,
+    Py_ssize_t num_outputs,
+    const std::vector<std::optional<Variable>>& raw_output_vars,
+    const std::unordered_set<at::TensorImpl*>& non_differentiable) {
+  PyObject* dtypes = self->output_grad_dtypes;
+  if (dtypes == nullptr) {
+    return std::nullopt;
+  }
+  THPFunction_assert(
+      PyTuple_Check(dtypes),
+      "set_output_grad_dtype expects the declarations to be a tuple but got ",
+      THPUtils_typename(dtypes));
+  THPFunction_assert(
+      PyTuple_GET_SIZE(dtypes) == num_outputs,
+      "set_output_grad_dtype expected one declaration per output: the "
+      "Function returned ",
+      num_outputs,
+      " values but ",
+      PyTuple_GET_SIZE(dtypes),
+      " declarations were provided");
+  std::vector<std::optional<at::ScalarType>> result;
+  result.reserve(num_outputs);
+  for (const auto i : c10::irange(num_outputs)) {
+    PyObject* d = PyTuple_GET_ITEM(dtypes, i);
+    if (d == Py_None) {
+      result.emplace_back(std::nullopt);
+      continue;
+    }
+    THPFunction_assert(
+        THPDtype_Check(d),
+        "set_output_grad_dtype expects each declaration to be a torch.dtype "
+        "or None, but got ",
+        THPUtils_typename(d));
+    const auto& raw_output_var = raw_output_vars[i];
+    THPFunction_assert(
+        raw_output_var.has_value() &&
+            non_differentiable.count(raw_output_var->unsafeGetTensorImpl()) ==
+                0 &&
+            isDifferentiableType(raw_output_var->scalar_type()),
+        "set_output_grad_dtype only accepts a concrete dtype for a "
+        "differentiable tensor output; pass None for output ",
+        i);
+    result.emplace_back(reinterpret_cast<THPDtype*>(d)->scalar_type);
+  }
+  Py_CLEAR(self->output_grad_dtypes);
+  return result;
+}
+
 // Given a Python tuple of raw output tensors (raw_output), set each of
 // the corresponding entries in a different Python tuple (outputs) with
 // these tensors wrapped with variables.  We save the gradient function (self)
@@ -726,6 +781,9 @@ static void _wrap_outputs(
       raw_output_vars.emplace_back();
     }
   }
+
+  auto output_grad_dtypes = _parse_output_grad_dtypes(
+      self, num_outputs, raw_output_vars, non_differentiable);
 
   _jvp_fn_t jvp_user_function = [self](
                                     variable_list inputs,
@@ -841,6 +899,11 @@ static void _wrap_outputs(
         bool use_zeros_like =
             is_differentiable && num_outputs > 1 && wrapped_output->is_nested();
         self->output_info.emplace_back(wrapped_output.value(), use_zeros_like);
+        // Other output slots were validated to have a None declaration.
+        if (output_grad_dtypes.has_value() && is_differentiable) {
+          cdata_if_executable->mutable_input_metadata(i).set_grad_dtype(
+              (*output_grad_dtypes)[i]);
+        }
       }
       PyTuple_SetItem(
           outputs, i, THPVariable_Wrap(std::move(wrapped_output.value())));
@@ -2189,6 +2252,11 @@ static struct PyGetSetDef THPFunction_properties[] = {
     {"dirty_tensors",
      &getObject<&THPFunction::dirty_tensors>,
      &setObject<&THPFunction::dirty_tensors>,
+     nullptr,
+     nullptr},
+    {"output_grad_dtypes",
+     &getObject<&THPFunction::output_grad_dtypes>,
+     &setObject<&THPFunction::output_grad_dtypes>,
      nullptr,
      nullptr},
     {"saved_for_forward",

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -704,16 +704,16 @@ _parse_output_grad_dtypes(
   }
   THPFunction_assert(
       PyTuple_Check(dtypes),
-      "set_output_grad_dtype expects the declarations to be a tuple but got ",
+      "set_output_grad_dtype expects the declarations to be a tuple, but got: "
+      "%s",
       THPUtils_typename(dtypes));
   THPFunction_assert(
       PyTuple_GET_SIZE(dtypes) == num_outputs,
-      "set_output_grad_dtype expected one declaration per output: the "
-      "Function returned ",
+      "set_output_grad_dtype expected the number of declarations to match the "
+      "number of outputs: the Function returned %zd values but %zd "
+      "declarations were provided",
       num_outputs,
-      " values but ",
-      PyTuple_GET_SIZE(dtypes),
-      " declarations were provided");
+      PyTuple_GET_SIZE(dtypes));
   std::vector<std::optional<at::ScalarType>> result;
   result.reserve(num_outputs);
   for (const auto i : c10::irange(num_outputs)) {
@@ -724,8 +724,8 @@ _parse_output_grad_dtypes(
     }
     THPFunction_assert(
         THPDtype_Check(d),
-        "set_output_grad_dtype expects each declaration to be a torch.dtype "
-        "or None, but got ",
+        "set_output_grad_dtype expects each declaration to be a torch.dtype or "
+        "None, but got %s",
         THPUtils_typename(d));
     const auto& raw_output_var = raw_output_vars[i];
     THPFunction_assert(
@@ -733,8 +733,11 @@ _parse_output_grad_dtypes(
             non_differentiable.count(raw_output_var->unsafeGetTensorImpl()) ==
                 0 &&
             isDifferentiableType(raw_output_var->scalar_type()),
-        "set_output_grad_dtype only accepts a concrete dtype for a "
-        "differentiable tensor output; pass None for output ",
+        "set_output_grad_dtype: got a concrete dtype for output %zd, but that "
+        "output is not a differentiable tensor (it is a non-tensor, was marked "
+        "non-differentiable, or has a non-differentiable dtype). Pass None for "
+        "output %zd instead.",
+        i,
         i);
     result.emplace_back(reinterpret_cast<THPDtype*>(d)->scalar_type);
   }
@@ -892,10 +895,15 @@ static void _wrap_outputs(
         // If one of the grad outputs is undefined, a correctly-shaped zeros
         // should be used instead. To construct these for NJT, zeros_like() must
         // be used until we have factory function support.
+        //
+        // Match differentiability to what mark_non_differentiable recorded,
+        // which is keyed on the raw output's TensorImpl.
+        const auto& raw_output_var = raw_output_vars[i];
+        TORCH_INTERNAL_ASSERT(raw_output_var.has_value());
         bool is_differentiable =
-            (non_differentiable.count(wrapped_output->unsafeGetTensorImpl()) ==
-                 0 &&
-             isDifferentiableType(wrapped_output->scalar_type()));
+            non_differentiable.count(raw_output_var->unsafeGetTensorImpl()) ==
+                0 &&
+            isDifferentiableType(raw_output_var->scalar_type());
         bool use_zeros_like =
             is_differentiable && num_outputs > 1 && wrapped_output->is_nested();
         self->output_info.emplace_back(wrapped_output.value(), use_zeros_like);

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -907,10 +907,13 @@ static void _wrap_outputs(
         bool use_zeros_like =
             is_differentiable && num_outputs > 1 && wrapped_output->is_nested();
         self->output_info.emplace_back(wrapped_output.value(), use_zeros_like);
-        // Other output slots were validated to have a None declaration.
-        if (output_grad_dtypes.has_value() && is_differentiable) {
+        // Set every differentiable output's grad_dtype, defaulting to its dtype.
+        if (is_differentiable) {
+          const auto grad_dtype = output_grad_dtypes.has_value()
+              ? (*output_grad_dtypes)[i]
+              : std::optional<at::ScalarType>(raw_output_var->scalar_type());
           cdata_if_executable->mutable_input_metadata(i).set_grad_dtype(
-              (*output_grad_dtypes)[i]);
+              grad_dtype);
         }
       }
       PyTuple_SetItem(

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -907,7 +907,7 @@ static void _wrap_outputs(
         bool use_zeros_like =
             is_differentiable && num_outputs > 1 && wrapped_output->is_nested();
         self->output_info.emplace_back(wrapped_output.value(), use_zeros_like);
-        // Set every differentiable output's grad_dtype, defaulting to its dtype.
+        // Set each differentiable output's grad_dtype, defaulting to its dtype.
         if (is_differentiable) {
           const auto grad_dtype = output_grad_dtypes.has_value()
               ? (*output_grad_dtypes)[i]

--- a/torch/csrc/autograd/python_function.h
+++ b/torch/csrc/autograd/python_function.h
@@ -140,6 +140,11 @@ struct THPFunction {
   bool clear_saved_tensors_on_access;
   bool saved_tensors_accessed_and_cleared;
 
+  // Owned tuple of per-output grad dtype declarations recorded by
+  // set_output_grad_dtype; consumed while wrapping outputs. nullptr when the
+  // API was not called.
+  PyObject* output_grad_dtypes = nullptr;
+
   PyObject* saved_for_forward;
   // The C++ PyNode for this THPFunction. Ownership follows the same
   // pattern as TensorImpl/THPVariable: THPFunction holds a strong


### PR DESCRIPTION
See docstring

~Add `ctx.set_output_grad_dtype(output, dtype)`, allowing an `autograd.Function` to declare the gradient dtype contract for one of its outputs independently of the output's storage dtype.~

Declarations are matched to Function output slots by Python object identity
 - A concrete dtype converts incoming gradients to that dtype.
 - `None` accepts incoming gradients without conversion.
 - An output without a declaration retains the existing behavior.~

~This API may only be called from `forward` or `setup_context`. Calls from other phases are rejected.~

`get_input_grad_dtype` has been moved to a separate follow-up PR

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo