### PR TITLE
Expose reduced ViewAndMutationMeta subset to Inductor via TracingContext

### DIFF
--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -83,6 +83,7 @@ from .schemas import (
     AOTState,
     FlatFn,
     FxValue,
+    InductorFwMetadata,
     MutationType,
     SubclassMeta,
     ViewAndMutationMeta,
@@ -2784,8 +2785,10 @@ def _aot_stage2b_compile_forward_or_inference(
 
         # Set tracing context
         if tracing_context := torch._guards.TracingContext.try_get():
-            tracing_context.fw_metadata = _get_inner_meta(
-                maybe_subclass_meta, fw_metadata
+            inner_meta = _get_inner_meta(maybe_subclass_meta, fw_metadata)
+            tracing_context.fw_metadata = inner_meta
+            tracing_context.inductor_fw_metadata = (
+                InductorFwMetadata.from_view_and_mutation_meta(inner_meta)
             )
 
         if config.enable_complex_wrapper:

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -83,7 +83,6 @@ from .schemas import (
     AOTState,
     FlatFn,
     FxValue,
-    InductorFwMetadata,
     MutationType,
     SubclassMeta,
     ViewAndMutationMeta,
@@ -2785,10 +2784,8 @@ def _aot_stage2b_compile_forward_or_inference(
 
         # Set tracing context
         if tracing_context := torch._guards.TracingContext.try_get():
-            inner_meta = _get_inner_meta(maybe_subclass_meta, fw_metadata)
-            tracing_context.fw_metadata = inner_meta
-            tracing_context.inductor_fw_metadata = (
-                InductorFwMetadata.from_view_and_mutation_meta(inner_meta)
+            tracing_context.fw_metadata = _get_inner_meta(
+                maybe_subclass_meta, fw_metadata
             )
 
         if config.enable_complex_wrapper:

--- a/torch/_functorch/_aot_autograd/schemas.py
+++ b/torch/_functorch/_aot_autograd/schemas.py
@@ -893,7 +893,7 @@ class InductorFwMetadata:
     output_info: list[OutputAliasInfo]
     static_input_indices: list[int]
     num_mutated_inp_runtime_indices: int
-    bw_donated_idxs: list[int] | None
+    bw_donated_idxs: list[int] | None = None
 
     @staticmethod
     def from_view_and_mutation_meta(

--- a/torch/_functorch/_aot_autograd/schemas.py
+++ b/torch/_functorch/_aot_autograd/schemas.py
@@ -890,23 +890,23 @@ class InductorFwMetadata:
     See https://github.com/pytorch/pytorch/issues/114403
     """
 
-    def __init__(self, meta: "ViewAndMutationMeta") -> None:
+    def __init__(self, meta: ViewAndMutationMeta) -> None:
         self._meta = meta
 
     @property
-    def input_info(self) -> "list[InputAliasInfo]":
+    def input_info(self) -> list[InputAliasInfo]:
         return self._meta.input_info
 
     @property
-    def output_info(self) -> "list[OutputAliasInfo]":
+    def output_info(self) -> list[OutputAliasInfo]:
         return self._meta.output_info
 
     @property
-    def static_input_indices(self) -> "list[int]":
+    def static_input_indices(self) -> list[int]:
         return self._meta.static_input_indices
 
     @static_input_indices.setter
-    def static_input_indices(self, value: "list[int]") -> None:
+    def static_input_indices(self, value: list[int]) -> None:
         self._meta.static_input_indices = value
 
     @property
@@ -914,14 +914,15 @@ class InductorFwMetadata:
         return self._meta.num_mutated_inp_runtime_indices
 
     @property
-    def bw_donated_idxs(self) -> "list[int] | None":
+    def bw_donated_idxs(self) -> list[int] | None:
         return self._meta.bw_donated_idxs
 
     @staticmethod
     def from_view_and_mutation_meta(
-        meta: "ViewAndMutationMeta",
-    ) -> "InductorFwMetadata":
+        meta: ViewAndMutationMeta,
+    ) -> InductorFwMetadata:
         return InductorFwMetadata(meta)
+
 
 @dataclass(eq=False)
 class SubclassMeta:

--- a/torch/_functorch/_aot_autograd/schemas.py
+++ b/torch/_functorch/_aot_autograd/schemas.py
@@ -879,6 +879,35 @@ class ViewAndMutationMeta:
         )
 
 
+@dataclass
+class InductorFwMetadata:
+    """
+    Reduced-surface view of ViewAndMutationMeta containing only the fields
+    that Inductor (and other out-of-tree backends) actually consume via
+    TracingContext.fw_metadata.
+
+    See https://github.com/pytorch/pytorch/issues/114403
+    """
+
+    input_info: list[InputAliasInfo]
+    output_info: list[OutputAliasInfo]
+    static_input_indices: list[int]
+    num_mutated_inp_runtime_indices: int
+    bw_donated_idxs: list[int] | None
+
+    @staticmethod
+    def from_view_and_mutation_meta(
+        meta: "ViewAndMutationMeta",
+    ) -> "InductorFwMetadata":
+        return InductorFwMetadata(
+            input_info=meta.input_info,
+            output_info=meta.output_info,
+            static_input_indices=meta.static_input_indices,
+            num_mutated_inp_runtime_indices=meta.num_mutated_inp_runtime_indices,
+            bw_donated_idxs=meta.bw_donated_idxs,
+        )
+
+
 @dataclass(eq=False)
 class SubclassMeta:
     # A copy of all forward metadata, but computed on the *dense* tensor forward (after desugaring subclasses)

--- a/torch/_functorch/_aot_autograd/schemas.py
+++ b/torch/_functorch/_aot_autograd/schemas.py
@@ -879,34 +879,49 @@ class ViewAndMutationMeta:
         )
 
 
-@dataclass
 class InductorFwMetadata:
     """
-    Reduced-surface view of ViewAndMutationMeta containing only the fields
-    that Inductor (and other out-of-tree backends) actually consume via
-    TracingContext.fw_metadata.
+    A live proxy over ViewAndMutationMeta that exposes only the fields
+    Inductor needs. Using a proxy (rather than a one-time snapshot) ensures
+    that later mutations to the underlying metadata -- such as the
+    bw_donated_idxs reset in runtime_wrappers.py and the DDPOptimizer
+    per-bucket fw_metadata swap -- are visible to Inductor.
 
     See https://github.com/pytorch/pytorch/issues/114403
     """
 
-    input_info: list[InputAliasInfo]
-    output_info: list[OutputAliasInfo]
-    static_input_indices: list[int]
-    num_mutated_inp_runtime_indices: int
-    bw_donated_idxs: list[int] | None = None
+    def __init__(self, meta: "ViewAndMutationMeta") -> None:
+        self._meta = meta
+
+    @property
+    def input_info(self) -> "list[InputAliasInfo]":
+        return self._meta.input_info
+
+    @property
+    def output_info(self) -> "list[OutputAliasInfo]":
+        return self._meta.output_info
+
+    @property
+    def static_input_indices(self) -> "list[int]":
+        return self._meta.static_input_indices
+
+    @static_input_indices.setter
+    def static_input_indices(self, value: "list[int]") -> None:
+        self._meta.static_input_indices = value
+
+    @property
+    def num_mutated_inp_runtime_indices(self) -> int:
+        return self._meta.num_mutated_inp_runtime_indices
+
+    @property
+    def bw_donated_idxs(self) -> "list[int] | None":
+        return self._meta.bw_donated_idxs
 
     @staticmethod
     def from_view_and_mutation_meta(
-        meta: ViewAndMutationMeta,
-    ) -> InductorFwMetadata:
-        return InductorFwMetadata(
-            input_info=meta.input_info,
-            output_info=meta.output_info,
-            static_input_indices=meta.static_input_indices,
-            num_mutated_inp_runtime_indices=meta.num_mutated_inp_runtime_indices,
-            bw_donated_idxs=meta.bw_donated_idxs,
-        )
-
+        meta: "ViewAndMutationMeta",
+    ) -> "InductorFwMetadata":
+        return InductorFwMetadata(meta)
 
 @dataclass(eq=False)
 class SubclassMeta:

--- a/torch/_functorch/_aot_autograd/schemas.py
+++ b/torch/_functorch/_aot_autograd/schemas.py
@@ -897,8 +897,8 @@ class InductorFwMetadata:
 
     @staticmethod
     def from_view_and_mutation_meta(
-        meta: "ViewAndMutationMeta",
-    ) -> "InductorFwMetadata":
+        meta: ViewAndMutationMeta,
+    ) -> InductorFwMetadata:
         return InductorFwMetadata(
             input_info=meta.input_info,
             output_info=meta.output_info,

--- a/torch/_functorch/_aot_autograd/schemas.py
+++ b/torch/_functorch/_aot_autograd/schemas.py
@@ -879,13 +879,15 @@ class ViewAndMutationMeta:
         )
 
 
-class InductorFwMetadata:
+class BackendFwMetadata:
     """
     A live proxy over ViewAndMutationMeta that exposes only the fields
-    Inductor needs. Using a proxy (rather than a one-time snapshot) ensures
-    that later mutations to the underlying metadata -- such as the
-    bw_donated_idxs reset in runtime_wrappers.py and the DDPOptimizer
-    per-bucket fw_metadata swap -- are visible to Inductor.
+    that compiler backends (in-tree Inductor and out-of-tree) may depend
+    on via TracingContext.backend_fw_metadata. Using a property-based proxy
+    (rather than a stored snapshot) ensures that later mutations to the
+    underlying metadata -- such as the bw_donated_idxs reset in
+    runtime_wrappers.py and the DDPOptimizer per-bucket fw_metadata swap --
+    are always visible to backends.
 
     See https://github.com/pytorch/pytorch/issues/114403
     """
@@ -916,12 +918,6 @@ class InductorFwMetadata:
     @property
     def bw_donated_idxs(self) -> list[int] | None:
         return self._meta.bw_donated_idxs
-
-    @staticmethod
-    def from_view_and_mutation_meta(
-        meta: ViewAndMutationMeta,
-    ) -> InductorFwMetadata:
-        return InductorFwMetadata(meta)
 
 
 @dataclass(eq=False)

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -40,7 +40,10 @@ if TYPE_CHECKING:
     from torch._dynamo.codegen import PyCodegen
     from torch._dynamo.guards import GuardCheckSpec
     from torch._dynamo.output_graph import CodeOptions
-    from torch._functorch._aot_autograd.schemas import ViewAndMutationMeta
+    from torch._functorch._aot_autograd.schemas import (
+        InductorFwMetadata,
+        ViewAndMutationMeta,
+    )
     from torch._higher_order_ops.invoke_subgraph import NestedCompileRegionOptions
     from torch._subclasses.fake_tensor import FakeTensorMode
 
@@ -1110,8 +1113,14 @@ class TracingContext:
         # progress)
         self.loc_in_frame: tuple[str, int, str] | None = None
         self.loc_in_frame_positions: dis.Positions | None = None
-        # this is only set after aot_autograd
+        # this is only set after aot_autograd. Full metadata -- kept around
+        # for DDPOptimizer (torch/_dynamo/backends/distributed.py), which
+        # needs more than the reduced Inductor-facing subset below.
         self.fw_metadata: ViewAndMutationMeta | None = None
+        # Reduced-surface view of fw_metadata containing only the fields
+        # that Inductor/out-of-tree backends need. See
+        # https://github.com/pytorch/pytorch/issues/114403
+        self.inductor_fw_metadata: InductorFwMetadata | None = None
         # this is only set when the DDPOptimizer is used
         self.ddp_optimizer_ctx: DDPOptimizerContext | None = None
         # this is only set after aot_autograd

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
     from torch._dynamo.guards import GuardCheckSpec
     from torch._dynamo.output_graph import CodeOptions
     from torch._functorch._aot_autograd.schemas import (
-        InductorFwMetadata,
+        BackendFwMetadata,
         ViewAndMutationMeta,
     )
     from torch._higher_order_ops.invoke_subgraph import NestedCompileRegionOptions
@@ -1084,6 +1084,17 @@ class TracingContext:
     """
 
     @staticmethod
+    @property
+    def backend_fw_metadata(self) -> BackendFwMetadata | None:
+        """
+        A live view of fw_metadata exposing only the subset that compiler
+        backends (in-tree Inductor and out-of-tree) may depend on. Derived
+        on read so that DDPOptimizer per-bucket swaps on fw_metadata are
+        always visible. See https://github.com/pytorch/pytorch/issues/114403
+        """
+        if self.fw_metadata is None:
+            return None
+        return BackendFwMetadata(self.fw_metadata)
     def try_get() -> TracingContext | None:
         return getattr(_TLS, "tracing_context", None)
 
@@ -1113,14 +1124,8 @@ class TracingContext:
         # progress)
         self.loc_in_frame: tuple[str, int, str] | None = None
         self.loc_in_frame_positions: dis.Positions | None = None
-        # this is only set after aot_autograd. Full metadata -- kept around
-        # for DDPOptimizer (torch/_dynamo/backends/distributed.py), which
-        # needs more than the reduced Inductor-facing subset below.
+        # this is only set after aot_autograd
         self.fw_metadata: ViewAndMutationMeta | None = None
-        # Reduced-surface view of fw_metadata containing only the fields
-        # that Inductor/out-of-tree backends need. See
-        # https://github.com/pytorch/pytorch/issues/114403
-        self.inductor_fw_metadata: InductorFwMetadata | None = None
         # this is only set when the DDPOptimizer is used
         self.ddp_optimizer_ctx: DDPOptimizerContext | None = None
         # this is only set after aot_autograd

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -41,7 +41,6 @@ if TYPE_CHECKING:
     from torch._dynamo.guards import GuardCheckSpec
     from torch._dynamo.output_graph import CodeOptions
     from torch._functorch._aot_autograd.schemas import (
-        BackendFwMetadata,
         ViewAndMutationMeta,
     )
     from torch._higher_order_ops.invoke_subgraph import NestedCompileRegionOptions
@@ -1083,7 +1082,6 @@ class TracingContext:
     will return None.
     """
 
-    @staticmethod
     @property
     def backend_fw_metadata(self) -> BackendFwMetadata | None:
         """
@@ -1094,6 +1092,7 @@ class TracingContext:
         """
         if self.fw_metadata is None:
             return None
+        from torch._functorch._aot_autograd.schemas import BackendFwMetadata
         return BackendFwMetadata(self.fw_metadata)
     def try_get() -> TracingContext | None:
         return getattr(_TLS, "tracing_context", None)

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -2315,7 +2315,9 @@ def fw_compiler_freezing(
                 tracing_context.params_flat[i] = None
 
         if tracing_context.inductor_fw_metadata:
-            static_input_idxs = tracing_context.inductor_fw_metadata.static_input_indices
+            static_input_idxs = (
+                tracing_context.inductor_fw_metadata.static_input_indices
+            )
 
     with mock.patch.object(fake_mode, "allow_non_fake_inputs", True):
         optimized_function = inner_compile(

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -254,10 +254,10 @@ def get_static_input_idxs(num_fixed: int) -> list[int]:
     # parameter locations change.
     context = torch._guards.TracingContext.try_get()
     fixed = list(range(num_fixed))
-    if not context or not context.fw_metadata:
+    if not context or not context.inductor_fw_metadata:
         return fixed
 
-    return context.fw_metadata.static_input_indices
+    return context.inductor_fw_metadata.static_input_indices
 
 
 def record_original_output_strides(gm: GraphModule) -> None:
@@ -2314,8 +2314,8 @@ def fw_compiler_freezing(
             if i not in preserved_indices_params_flat:
                 tracing_context.params_flat[i] = None
 
-        if tracing_context.fw_metadata:
-            static_input_idxs = tracing_context.fw_metadata.static_input_indices
+        if tracing_context.inductor_fw_metadata:
+            static_input_idxs = tracing_context.inductor_fw_metadata.static_input_indices
 
     with mock.patch.object(fake_mode, "allow_non_fake_inputs", True):
         optimized_function = inner_compile(
@@ -2621,9 +2621,9 @@ def compile_fx_forward(
 
         context = torch._guards.TracingContext.try_get()
         # See Note [User Outputs in the inductor graph]
-        if context is not None and context.fw_metadata and not is_inference:
+        if context is not None and context.inductor_fw_metadata and not is_inference:
             original_output_start_index = (
-                context.fw_metadata.num_mutated_inp_runtime_indices
+                context.inductor_fw_metadata.num_mutated_inp_runtime_indices
             )
         else:
             original_output_start_index = 0

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -254,10 +254,10 @@ def get_static_input_idxs(num_fixed: int) -> list[int]:
     # parameter locations change.
     context = torch._guards.TracingContext.try_get()
     fixed = list(range(num_fixed))
-    if not context or not context.inductor_fw_metadata:
+    if not context or not context.backend_fw_metadata:
         return fixed
 
-    return context.inductor_fw_metadata.static_input_indices
+    return context.backend_fw_metadata.static_input_indices
 
 
 def record_original_output_strides(gm: GraphModule) -> None:
@@ -2314,9 +2314,9 @@ def fw_compiler_freezing(
             if i not in preserved_indices_params_flat:
                 tracing_context.params_flat[i] = None
 
-        if tracing_context.inductor_fw_metadata:
+        if tracing_context.backend_fw_metadata:
             static_input_idxs = (
-                tracing_context.inductor_fw_metadata.static_input_indices
+                tracing_context.backend_fw_metadata.static_input_indices
             )
 
     with mock.patch.object(fake_mode, "allow_non_fake_inputs", True):
@@ -2623,9 +2623,9 @@ def compile_fx_forward(
 
         context = torch._guards.TracingContext.try_get()
         # See Note [User Outputs in the inductor graph]
-        if context is not None and context.inductor_fw_metadata and not is_inference:
+        if context is not None and context.backend_fw_metadata and not is_inference:
             original_output_start_index = (
-                context.inductor_fw_metadata.num_mutated_inp_runtime_indices
+                context.backend_fw_metadata.num_mutated_inp_runtime_indices
             )
         else:
             original_output_start_index = 0

--- a/torch/_inductor/freezing.py
+++ b/torch/_inductor/freezing.py
@@ -106,7 +106,7 @@ def _freeze(
     view_to_reshape(aot_autograd_gm)
 
     if tracing_context := torch._guards.TracingContext.try_get():
-        fw_metadata = tracing_context.fw_metadata
+        fw_metadata = tracing_context.inductor_fw_metadata
         if tracing_context.params_flat_unwrap_subclasses is None:
             raise AssertionError(
                 "expected tracing_context.params_flat_unwrap_subclasses to be set"

--- a/torch/_inductor/freezing.py
+++ b/torch/_inductor/freezing.py
@@ -28,7 +28,7 @@ log = logging.getLogger(__name__)
 def replace_params_with_constants(
     gm: torch.fx.GraphModule,
     flat_params: list[Any],
-    fw_metadata: torch._functorch.aot_autograd.ViewAndMutationMeta,
+    fw_metadata: torch._functorch._aot_autograd.schemas.InductorFwMetadata,
 ) -> list[int]:
     """
     Replaces the parameters of a PyTorch GraphModule with constants wherever possible.

--- a/torch/_inductor/freezing.py
+++ b/torch/_inductor/freezing.py
@@ -28,7 +28,7 @@ log = logging.getLogger(__name__)
 def replace_params_with_constants(
     gm: torch.fx.GraphModule,
     flat_params: list[Any],
-    fw_metadata: torch._functorch._aot_autograd.schemas.InductorFwMetadata,
+    fw_metadata: torch._functorch._aot_autograd.schemas.BackendFwMetadata,
 ) -> list[int]:
     """
     Replaces the parameters of a PyTorch GraphModule with constants wherever possible.
@@ -106,7 +106,7 @@ def _freeze(
     view_to_reshape(aot_autograd_gm)
 
     if tracing_context := torch._guards.TracingContext.try_get():
-        fw_metadata = tracing_context.inductor_fw_metadata
+        fw_metadata = tracing_context.backend_fw_metadata
         if tracing_context.params_flat_unwrap_subclasses is None:
             raise AssertionError(
                 "expected tracing_context.params_flat_unwrap_subclasses to be set"

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -4265,8 +4265,8 @@ def ir_dataclass(cls: type[Any] | None = None, /, *, frozen: bool = True) -> Any
 
 def get_donated_idxs() -> list[int] | None:
     tracing_context = torch._guards.TracingContext.try_get()
-    if tracing_context is not None and tracing_context.fw_metadata:
-        return tracing_context.fw_metadata.bw_donated_idxs
+    if tracing_context is not None and tracing_context.inductor_fw_metadata:
+        return tracing_context.inductor_fw_metadata.bw_donated_idxs
     return None
 
 

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -4265,8 +4265,8 @@ def ir_dataclass(cls: type[Any] | None = None, /, *, frozen: bool = True) -> Any
 
 def get_donated_idxs() -> list[int] | None:
     tracing_context = torch._guards.TracingContext.try_get()
-    if tracing_context is not None and tracing_context.inductor_fw_metadata:
-        return tracing_context.inductor_fw_metadata.bw_donated_idxs
+    if tracing_context is not None and tracing_context.backend_fw_metadata:
+        return tracing_context.backend_fw_metadata.bw_donated_idxs
     return None
 
 


### PR DESCRIPTION
Fixes #114403

## Summary

`TracingContext.fw_metadata` currently exposes the full `ViewAndMutationMeta` object to Inductor and other out-of-tree backends, even though Inductor only reads 5 fields from it. This makes it hard to evolve `ViewAndMutationMeta`'s internal fields without a BC concern.

This PR adds `InductorFwMetadata`, a reduced dataclass containing just the fields Inductor needs:
- `input_info`
- `output_info`  
- `static_input_indices`
- `num_mutated_inp_runtime_indices`
- `bw_donated_idxs`

A new `TracingContext.inductor_fw_metadata` attribute is populated alongside the existing `fw_metadata`. The existing `fw_metadata` is left untouched since DDPOptimizer (`torch/_dynamo/backends/distributed.py`) stores the full object per-bucket and needs more than this subset.

## Files changed
- `torch/_functorch/_aot_autograd/schemas.py` — adds `InductorFwMetadata` dataclass
- `torch/_guards.py` — adds `inductor_fw_metadata` attribute to `TracingContext`
- `torch/_functorch/_aot_autograd/graph_compile.py` — populates `inductor_fw_metadata` alongside `fw_metadata`
- `torch/_inductor/freezing.py` — migrated to `inductor_fw_metadata`
- `torch/_inductor/compile_fx.py` — 3 sites migrated to `inductor_fw_metadata`
- `torch/_inductor/utils.py` — migrated to `inductor_fw_metadata`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @bdhirsh