### PR TITLE
[Dynamo] Support pipeline option in TVM relax path

### DIFF
--- a/test/dynamo/test_backends.py
+++ b/test/dynamo/test_backends.py
@@ -1,4 +1,5 @@
 # Owner(s): ["module: dynamo"]
+import importlib.util
 import sys
 import unittest
 from unittest.mock import MagicMock, patch
@@ -160,6 +161,22 @@ class TestOptimizations(torch._dynamo.test_case.TestCase):
         self._check_backend_works("tvm", device)
         self._check_backend_works("tvm", device, options={"scheduler": None})
         self._check_backend_works("tvm", device, options={"opt_level": 0})
+
+    @unittest.skipIf(not has_tvm(), "requires tvm")
+    def test_tvm_relax_pipeline_option(self, device):
+        if importlib.util.find_spec("tvm.relax.frontend.torch") is None:
+            self.skipTest("requires the tvm relax frontend")
+        import tvm
+
+        model = Seq().eval().to(device)
+        x = torch.randn(2, 10, device=device)
+        expected = model(x)
+        for pipeline in ("zero", tvm.relax.get_pipeline("zero")):
+            torch._dynamo.reset()
+            compiled = torch.compile(
+                model, backend="tvm", options={"pipeline": pipeline}
+            )
+            self.assertTrue(same(expected, compiled(x), tol=0.01))
 
     def test_tvm_scheduler_backends(self, device):
         from torch._dynamo.backends.tvm import tvm_auto_scheduler, tvm_meta_schedule

--- a/torch/_dynamo/backends/tvm.py
+++ b/torch/_dynamo/backends/tvm.py
@@ -85,12 +85,7 @@ def _tvm_relax_compile(
             "falling back to the default relax pipeline.",
             scheduler,
         )
-    pipeline = options.get("pipeline", None)
-    if isinstance(pipeline, str):
-        from tvm import relax  # type: ignore[import]
-
-        pipeline = relax.get_pipeline(pipeline)
-    return relax_dynamo(pipeline=pipeline)(gm, example_inputs)
+    return relax_dynamo(pipeline=options.get("pipeline", None))(gm, example_inputs)
 
 
 def _tvm_relay_compile(

--- a/torch/_dynamo/backends/tvm.py
+++ b/torch/_dynamo/backends/tvm.py
@@ -85,7 +85,12 @@ def _tvm_relax_compile(
             "falling back to the default relax pipeline.",
             scheduler,
         )
-    return relax_dynamo()(gm, example_inputs)
+    pipeline = options.get("pipeline", None)
+    if isinstance(pipeline, str):
+        from tvm import relax  # type: ignore[import]
+
+        pipeline = relax.get_pipeline(pipeline)
+    return relax_dynamo(pipeline=pipeline)(gm, example_inputs)
 
 
 def _tvm_relay_compile(


### PR DESCRIPTION
## Why

On TVM >= 0.20 the tvm backend always builds with the default relax pipeline; the relay-only `scheduler`/`trials` options have no effect, so there is no way to configure tuning.

## How

Pass `options={"pipeline": ...}` through to `relax_dynamo`: a string is resolved with `tvm.relax.get_pipeline(name)`, a Pass object is passed straight through. Any pipeline TVM ships or a user-built one works, with no mapping layer on the PyTorch side.

Verified locally against `apache-tvm==0.25.0.post1` with the new `test_tvm_relax_pipeline_option`.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98