### PR TITLE
[Dynamo] Deprecate TVM backend relay path with FutureWarning

### DIFF
--- a/test/dynamo/test_backends.py
+++ b/test/dynamo/test_backends.py
@@ -171,6 +171,20 @@ class TestOptimizations(torch._dynamo.test_case.TestCase):
             with patch.dict(sys.modules, {"tvm": None}):
                 self.assertRaises(ImportError, backend, gm, [torch.randn(2)])
 
+    def test_tvm_relay_future_warning(self, device):
+        import torch._dynamo.backends.tvm as tvm_backend
+
+        gm = torch.fx.symbolic_trace(lambda x: x + 1)
+        with patch.dict(sys.modules, {"tvm": None}):
+            with self.assertWarns(FutureWarning):
+                self.assertRaises(
+                    ImportError,
+                    tvm_backend._tvm_relay_compile,
+                    gm,
+                    [torch.randn(2)],
+                    {},
+                )
+
     def test_tvm_dispatches_relay_or_relax(self, device):
         import torch._dynamo.backends.tvm as tvm_backend
 

--- a/torch/_dynamo/backends/tvm.py
+++ b/torch/_dynamo/backends/tvm.py
@@ -18,6 +18,12 @@ models on various hardware backends. This module enables:
 
 The backend can be used with torch.compile():
     model = torch.compile(model, backend="tvm")
+
+The scheduler/trials options only apply to the legacy relay frontend
+(removed in TVM 0.20). With the relax frontend, pass a TVM pipeline instead:
+
+    pipeline = tvm.relax.get_pipeline("static_shape_tuning", target="llvm", total_trials=2000)
+    model = torch.compile(model, backend="tvm", options={"pipeline": pipeline})
 """
 
 import functools
@@ -26,6 +32,7 @@ import logging
 import os
 import sys
 import tempfile
+import warnings
 from collections.abc import Callable
 from pathlib import Path
 from types import MappingProxyType
@@ -93,6 +100,12 @@ def _tvm_relay_compile(
     example_inputs: list[torch.Tensor],
     options: MappingProxyType[str, Any],
 ) -> Callable[..., Any]:
+    warnings.warn(
+        "The tvm backend's relay path is deprecated and will be removed; "
+        "install a recent apache-tvm to use the relax frontend instead.",
+        FutureWarning,
+        stacklevel=2,
+    )
     import tvm  # type: ignore[import]
     from tvm import relay  # type: ignore[import]
     from tvm.contrib import graph_executor  # type: ignore[import]


### PR DESCRIPTION
## Why

TVM removed the relay frontend in 0.20, so the tvm backend's relay path only works with old TVM builds and is frozen. Users on it currently get no signal that it is going away.

## How

- Emit a `FutureWarning` on entry to `_tvm_relay_compile`, pointing at the relax frontend
- Document relax tuning via `options={"pipeline": ...}` (added in #189638, which should land first)
- Add `test_tvm_relay_future_warning`, which runs with or without a tvm install

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98