### PR TITLE
[inductor] IS_FBCODE xfails for opinfo numeric-property tests

### DIFF
--- a/test/inductor/test_torchinductor_opinfo_properties.py
+++ b/test/inductor/test_torchinductor_opinfo_properties.py
@@ -54,6 +54,7 @@ from torch.testing._internal.common_methods_invocations import (
     unary_ufuncs,
 )
 from torch.testing._internal.common_utils import (
+    IS_FBCODE,
     IS_WINDOWS,
     parametrize,
     skipIfTorchDynamo,
@@ -504,6 +505,50 @@ ROCM_XFAIL_DICTS = {
     "binary_numerical": ROCM_BINARY_NUMERICAL_XFAILS,
 }
 
+# fbcode ships a different Triton fork (triton+fb) and cuBLAS/CUDA/GPU stack than
+# OSS CI (e.g. A100 vs L4), which changes compiled-path numerics. These combos pass
+# in OSS but not in fbcode, so they are merged in only when IS_FBCODE (CUDA).
+FBCODE_BATCH_INVARIANCE_XFAILS = {
+    "aot_eager_decomp_partition": {
+        "bmm": {fp32},
+    },
+    "inductor_default": {
+        "bmm": {fp32},
+    },
+    "inductor_numerics": {
+        "bmm": {fp32},
+    },
+}
+
+FBCODE_UNARY_NUMERICAL_XFAILS = {
+    "inductor_default": {
+        "sqrt": {bf16, fp32},
+    },
+    "inductor_numerics": {
+        "exp2": {bf16, fp32},
+        "expm1": {bf16, fp32},
+        "log1p": {fp32},
+        "reciprocal": {bf16, fp32},
+        "rsqrt": {bf16, fp32},
+        "sin": {fp32},
+        "sqrt": {bf16, fp32},
+        "tan": {bf16, fp32},
+        "tanh": {fp32},
+    },
+}
+
+FBCODE_BINARY_NUMERICAL_XFAILS = {
+    "inductor_numerics": {
+        "fmod": {bf16, fp32},
+    },
+}
+
+FBCODE_XFAIL_DICTS = {
+    "batch_invariance": FBCODE_BATCH_INVARIANCE_XFAILS,
+    "unary_numerical": FBCODE_UNARY_NUMERICAL_XFAILS,
+    "binary_numerical": FBCODE_BINARY_NUMERICAL_XFAILS,
+}
+
 ROCM_RELAXED_PROPERTY_CASES = {
     "eager_equivalence": {
         "inductor_default": {
@@ -529,7 +574,15 @@ ROCM_RELAXED_PROPERTY_CASES = {
 def is_expected_failure(device_type, op_name, backend, test_type, dtype=None):
     """Check if a test is expected to fail."""
     xfail_dicts = ROCM_XFAIL_DICTS if torch.version.hip is not None else XFAIL_DICTS
-    xfails = xfail_dicts.get(test_type, {}).get(backend, {}).get(op_name, set())
+    xfails = set(xfail_dicts.get(test_type, {}).get(backend, {}).get(op_name, set()))
+    # fbcode's Triton fork + cuBLAS/GPU stack differ from OSS CI, so some combos
+    # fail the compiled-vs-eager numerics only in fbcode. Gate on IS_FBCODE (CUDA
+    # only) so OSS does not hit spurious XPASS on these.
+    if IS_FBCODE and torch.version.hip is None:
+        fbcode_xfails = (
+            FBCODE_XFAIL_DICTS.get(test_type, {}).get(backend, {}).get(op_name, set())
+        )
+        xfails = xfails | fbcode_xfails
     return dtype in xfails or ALL in xfails
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189640

Several batch-invariance and unary/binary numerical-property cases in `test/inductor/test_torchinductor_opinfo_properties.py` fail in fbcode but pass in OSS CI. These tests compare the compiled path against eager (and check `bmm` cross-batch bitwise invariance), and fbcode ships a different Triton fork and cuBLAS/CUDA/GPU stack (e.g. A100) than OSS CI (L4), so the compiled numerics differ.

Since these combos pass in OSS, adding them to the shared `*_XFAILS` dicts would cause XPASS failures there. Instead this adds `FBCODE_*_XFAILS` that `is_expected_failure` consults only when `IS_FBCODE` (CUDA), mirroring the existing `torch.version.hip` ROCm gating, so OSS behavior is unchanged.

Gated combos: `bmm` (batch_invariance, fp32) on all three backends; `sqrt` (inductor_default) and `exp2`/`expm1`/`log1p`/`reciprocal`/`rsqrt`/`sin`/`sqrt`/`tan`/`tanh` (inductor_numerics) for unary; `fmod` (inductor_numerics) for binary.

Test Plan:
- fbcode: ran the affected cases in `torchinductor_opinfo_properties` under `@fbcode//mode/opt`; the 22 combos now skip (xfail) instead of failing.
- OSS: verified via PyTorch HUD that these combos are green on `main` (`linux-jammy-cuda13.0-py3.10-gcc11`), so the `IS_FBCODE` gate avoids XPASS.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo