### PR TITLE
docs: fix sparse CSR index examples

### DIFF
--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -6873,7 +6873,7 @@ Example::
 
     >>> csr = torch.eye(5,5).to_sparse_csr()
     >>> csr.crow_indices()
-    tensor([0, 1, 2, 3, 4, 5], dtype=torch.int32)
+    tensor([0, 1, 2, 3, 4, 5])
 
 """,
 )
@@ -6894,7 +6894,7 @@ Example::
 
     >>> csr = torch.eye(5,5).to_sparse_csr()
     >>> csr.col_indices()
-    tensor([0, 1, 2, 3, 4], dtype=torch.int32)
+    tensor([0, 1, 2, 3, 4])
 
 """,
 )


### PR DESCRIPTION
Fixes #189392.

The `crow_indices()` and `col_indices()` doc examples currently show `dtype=torch.int32`, but `torch.eye(5,5).to_sparse_csr()` produces int64 indices by default. The real repr therefore omits the dtype suffix.

This updates both examples to match the observed default output.

Verification:
- `python3 -m py_compile torch/_tensor_docs.py`
- `python3 - <<'PY' ...` confirmed `crow_indices()`/`col_indices()` print without a dtype suffix and both dtypes are `torch.int64`.
