### PR TITLE
[Dynamo] Skip guards on unused constant ops

### DIFF
--- a/test/dynamo/test_lazy_constant.py
+++ b/test/dynamo/test_lazy_constant.py
@@ -563,15 +563,37 @@ class ComputedLazyConstantTests(TestCase):
         cases = [
             (lambda t, a, b: (t.sin(), a - b), [(t, 5, 2), (t, 9, 3)]),
             (lambda t, a, b: (t.sin(), a * b), [(t, 5, 2), (t, 9, 3)]),
-            (lambda t, a, b: (t.sin(), a / b), [(t, 5, 2), (t, 9, 3)]),
-            (lambda t, a, b: (t.sin(), a // b), [(t, 5, 2), (t, 9, 3)]),
-            (lambda t, a, b: (t.sin(), a % b), [(t, 5, 2), (t, 9, 3)]),
             (lambda t, a, b: (t.sin(), a + b), [(t, "x", "y"), (t, "p", "q")]),
         ]
         for i, (fn, arg_sets) in enumerate(cases):
             with self.subTest(case=i):
                 torch._dynamo.reset()
                 self._check(fn, arg_sets, expected_frames=1)
+
+    def test_unused_computed_inplace_op_does_not_recompile(self):
+        t = torch.ones(2)
+
+        def fn(t, a, b):
+            a += b
+            return t.sin(), a
+
+        self._check(fn, [(t, 1, 2), (t, 3, 4)], expected_frames=1)
+
+    def test_unused_division_recompiles(self):
+        t = torch.ones(2)
+
+        def fn(t, a, b):
+            return t.sin(), a / b
+
+        self._check(fn, [(t, 4, 2), (t, 9, 3)], expected_frames=2)
+
+    def test_operand_type_change_recompiles(self):
+        t = torch.ones(2)
+
+        def fn(t, a, b):
+            return t.sin(), a + b
+
+        self._check(fn, [(t, 1, 2), (t, 3, 4), (t, 1.5, 2.5)], expected_frames=2)
 
     def test_chained_computed_constants_do_not_recompile(self):
         t = torch.ones(2)

--- a/test/dynamo/test_lazy_constant.py
+++ b/test/dynamo/test_lazy_constant.py
@@ -540,5 +540,94 @@ class LazyConstantVariableTests(TestCase):
         self.assertEqual(counter_multi.frame_count, 1)
 
 
+class ComputedLazyConstantTests(TestCase):
+    def _check(self, fn, arg_sets, expected_frames):
+        counter = CompileCounter()
+        opt_fn = torch.compile(fn, backend=counter)
+        for args in arg_sets:
+            eager = fn(*args)
+            compiled = opt_fn(*args)
+            self.assertTrue(same(eager, compiled))
+        self.assertEqual(counter.frame_count, expected_frames)
+
+    def test_unused_computed_int_does_not_recompile(self):
+        t = torch.ones(2)
+
+        def fn(t, a, b):
+            return t.sin(), a + b
+
+        self._check(fn, [(t, 1, 2), (t, 3, 4), (t, 100, -5)], expected_frames=1)
+
+    def test_unused_computed_ops_do_not_recompile(self):
+        t = torch.ones(2)
+        cases = [
+            (lambda t, a, b: (t.sin(), a - b), [(t, 5, 2), (t, 9, 3)]),
+            (lambda t, a, b: (t.sin(), a * b), [(t, 5, 2), (t, 9, 3)]),
+            (lambda t, a, b: (t.sin(), a / b), [(t, 5, 2), (t, 9, 3)]),
+            (lambda t, a, b: (t.sin(), a // b), [(t, 5, 2), (t, 9, 3)]),
+            (lambda t, a, b: (t.sin(), a % b), [(t, 5, 2), (t, 9, 3)]),
+            (lambda t, a, b: (t.sin(), a + b), [(t, "x", "y"), (t, "p", "q")]),
+        ]
+        for i, (fn, arg_sets) in enumerate(cases):
+            with self.subTest(case=i):
+                torch._dynamo.reset()
+                self._check(fn, arg_sets, expected_frames=1)
+
+    def test_chained_computed_constants_do_not_recompile(self):
+        t = torch.ones(2)
+
+        def fn(t, a, b):
+            return t.sin(), (a + b) * 2 - a
+
+        self._check(fn, [(t, 1, 2), (t, 7, 5)], expected_frames=1)
+
+    def test_computed_constant_in_branch_recompiles(self):
+        t = torch.ones(2)
+
+        def fn(t, a, b):
+            if a + b > 5:
+                return t + 1
+            return t - 1
+
+        self._check(fn, [(t, 1, 2), (t, 7, 5)], expected_frames=2)
+
+    def test_computed_constant_in_tensor_math_recompiles(self):
+        t = torch.ones(2)
+
+        def fn(t, a, b):
+            return t * (a + b)
+
+        self._check(fn, [(t, 1.5, 2.0), (t, 3.25, 4.0)], expected_frames=2)
+
+    def test_computed_constant_as_dict_key_realizes(self):
+        t = torch.ones(2)
+
+        def fn(t, a, b):
+            d = {a + b: t}
+            return d[a + b].sin()
+
+        self._check(fn, [(t, 1, 2), (t, 3, 4)], expected_frames=2)
+
+    def test_computed_constant_as_list_index_realizes(self):
+        t = torch.ones(2)
+
+        def fn(t, a, b):
+            lst = [t, t + 1, t + 2]
+            return lst[a + b]
+
+        self._check(fn, [(t, 0, 1), (t, 1, 1)], expected_frames=2)
+
+    def test_computed_constant_type_query_does_not_recompile(self):
+        t = torch.ones(2)
+
+        def fn(t, a, b):
+            c = a + b
+            if isinstance(c, str):
+                return t.sin(), c
+            return t.cos(), c
+
+        self._check(fn, [(t, "a", "b"), (t, "c", "d")], expected_frames=1)
+
+
 if __name__ == "__main__":
     run_tests()

--- a/test/dynamo/test_lazy_constant.py
+++ b/test/dynamo/test_lazy_constant.py
@@ -603,6 +603,37 @@ class ComputedLazyConstantTests(TestCase):
 
         self._check(fn, [(t, 1, 2), (t, 7, 5)], expected_frames=1)
 
+    def test_long_left_associated_chain_no_recursion_error(self):
+        t = torch.ones(2)
+
+        def fn(t, vals):
+            total = 0
+            for v in vals:
+                total = total + v
+            return t.sin(), total
+
+        n = 300
+        arg_sets = [(t, list(range(n))), (t, list(range(1, n + 1)))]
+        self._check(fn, arg_sets, expected_frames=2)
+
+    @torch._dynamo.config.patch(computed_lazy_constant_max_nodes=2)
+    def test_over_budget_chain_falls_back_to_guards(self):
+        t = torch.ones(2)
+
+        def fn(t, a):
+            return t.sin(), a + a + a + a
+
+        self._check(fn, [(t, 1), (t, 2)], expected_frames=2)
+
+    @torch._dynamo.config.patch(computed_lazy_constant_max_nodes=0)
+    def test_disabled_computed_lazy_constant_installs_guards(self):
+        t = torch.ones(2)
+
+        def fn(t, a, b):
+            return t.sin(), a + b
+
+        self._check(fn, [(t, 1, 2), (t, 3, 4)], expected_frames=2)
+
     def test_computed_constant_in_branch_recompiles(self):
         t = torch.ones(2)
 

--- a/test/dynamo/test_lazy_constant.py
+++ b/test/dynamo/test_lazy_constant.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: dynamo"]
 
 import keyword
+import sys
 
 import torch
 import torch._dynamo
@@ -613,6 +614,19 @@ class ComputedLazyConstantTests(TestCase):
             return t.sin(), total
 
         n = 300
+        arg_sets = [(t, list(range(n))), (t, list(range(1, n + 1)))]
+        self._check(fn, arg_sets, expected_frames=2)
+
+    def test_recursion_limit_sized_chain_no_recursion_error(self):
+        t = torch.ones(2)
+
+        def fn(t, vals):
+            total = 0
+            for v in vals:
+                total = total + v
+            return t.sin(), total
+
+        n = sys.getrecursionlimit()
         arg_sets = [(t, list(range(n))), (t, list(range(1, n + 1)))]
         self._check(fn, arg_sets, expected_frames=2)
 

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -10917,7 +10917,7 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
 
         @torch.compile(backend=counter)
         def fn(x):
-            return x * x
+            return torch.ones(2) * x
 
         fn(0)
         fn(1)

--- a/torch/_dynamo/codegen.py
+++ b/torch/_dynamo/codegen.py
@@ -309,6 +309,9 @@ class PyCodegen:
             # Recompute from the operands at runtime instead of burning in the value
             self.uses[value] += 1
             self.call_reconstruct(value)
+            if allow_cache and value in self.tempvars:
+                self._output.append(create_dup_top())
+                self.add_cache(value)
         elif value.is_python_constant() and is_safe_constant(
             value.as_python_constant()
         ):

--- a/torch/_dynamo/codegen.py
+++ b/torch/_dynamo/codegen.py
@@ -46,6 +46,7 @@ from .variables.functions import (
     ContextlibContextManagerLocalGeneratorObjectVariable,
     LocalGeneratorObjectVariable,
 )
+from .variables.lazy import ComputedLazyConstantVariable
 from .variables.nn_module import NNModuleVariable
 from .variables.script_object import CustomClassObjectVariable
 from .variables.tensor import (
@@ -304,7 +305,13 @@ class PyCodegen:
             ):
                 return self(value.source)
 
-        if value.is_python_constant() and is_safe_constant(value.as_python_constant()):
+        if isinstance(value, ComputedLazyConstantVariable) and not value.is_realized():
+            # Recompute from the operands at runtime instead of burning in the value
+            self.uses[value] += 1
+            self.call_reconstruct(value)
+        elif value.is_python_constant() and is_safe_constant(
+            value.as_python_constant()
+        ):
             output.append(self.create_load_const(value.as_python_constant()))
         elif isinstance(value, TensorWithTFOverrideVariable):
             graph_outputs_key = self.add_graph_output(value)

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -161,6 +161,9 @@ specialize_int = False
 # support codegen on float (this is to be fixed).
 specialize_float = False
 
+# Max ops per ComputedLazyConstantVariable chain before realizing under guards; 0 disables
+computed_lazy_constant_max_nodes = 64
+
 # legacy config, does nothing now!
 dynamic_shapes = True
 

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -2979,10 +2979,11 @@ def is_int_specialization_case(value: Any, source: Any) -> bool:
 
 def specialize_symnode(arg: Any) -> Any:
     from .variables import ConstantVariable, LazyVariableTracker, SymNodeVariable
+    from .variables.lazy import ComputedLazyConstantVariable
 
     # Guard and specialize
     if isinstance(arg, LazyVariableTracker):
-        if not arg.is_realized():
+        if not arg.is_realized() and not isinstance(arg, ComputedLazyConstantVariable):
             # Find if the arg would be realized as SymNodeVariable later on. If yes,
             # realize it and specialize. Else return the arg.
 

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -264,6 +264,43 @@ BUILTIN_TO_TENSOR_RFN_MAP: dict[Callable[..., Any], Callable[..., Any]] = {}
 # opt-out).
 _MISSING_SENTINEL = object()
 
+# Ops whose result type depends only on operand types (excludes pow: 2**-1 is a float)
+_COMPUTED_LAZY_CONSTANT_OPS: frozenset[Callable[..., Any]] = frozenset(
+    [
+        operator.add,
+        operator.sub,
+        operator.mul,
+        operator.truediv,
+        operator.floordiv,
+        operator.mod,
+    ]
+)
+
+
+def _try_computed_lazy_constant(
+    fn: Callable[..., Any], args: list[VariableTracker]
+) -> VariableTracker | None:
+    """Build a ComputedLazyConstantVariable for fn(*args), or None to fall back."""
+    from .lazy import ComputedLazyConstantVariable, LazyConstantVariable
+
+    if fn not in _COMPUTED_LAZY_CONSTANT_OPS or len(args) != 2:
+        return None
+    any_unrealized = False
+    for arg in args:
+        if (
+            isinstance(arg, (LazyConstantVariable, ComputedLazyConstantVariable))
+            and not arg.is_realized()
+        ):
+            any_unrealized = True
+        elif not isinstance(arg, ConstantVariable):
+            return None
+    if not any_unrealized:
+        return None
+    try:
+        return ComputedLazyConstantVariable.create(fn, args)
+    except (TypeError, ArithmeticError):
+        return None
+
 
 def populate_builtin_to_tensor_fn_map() -> None:
     global BUILTIN_TO_TENSOR_FN_MAP
@@ -1076,30 +1113,35 @@ class BuiltinVariable(BaseBuiltinVariable):
         ],
         VariableTracker | None,
     ]:
-        from .lazy import LazyConstantVariable, LazyVariableTracker
+        from .lazy import (
+            ComputedLazyConstantVariable,
+            LazyConstantVariable,
+            LazyVariableTracker,
+        )
 
         obj = BuiltinVariable(fn)
         handlers: list[_HandlerCallback] = []
 
+        lazy_constant_types = (LazyConstantVariable, ComputedLazyConstantVariable)
         lazy_types = [t for t in arg_types if issubclass(t, LazyVariableTracker)]
         if lazy_types:
-            if not all(issubclass(t, LazyConstantVariable) for t in lazy_types):
+            if not all(issubclass(t, lazy_constant_types) for t in lazy_types):
                 # Realize non-constant lazy args and re-dispatch.  Any
-                # LazyConstantVariable args are kept and handled on the
+                # lazy constant args are kept and handled on the
                 # second dispatch through the branch below.
                 return lambda tx, args, kwargs: obj.call_function(
                     tx,
                     [
                         a.realize()
                         if isinstance(a, LazyVariableTracker)
-                        and not isinstance(a, LazyConstantVariable)
+                        and not isinstance(a, lazy_constant_types)
                         else a
                         for a in args
                     ],
                     kwargs,
                 )
 
-            # Only LazyConstantVariable lazy types.  Install type guards
+            # Only lazy constant types.  Install type guards
             # and resolve the dispatch type.  If the resolved type is
             # ConstantVariable (the common case), delegate to a handler
             # built for ConstantVariable.  Otherwise (e.g. specialize_int=
@@ -1108,7 +1150,7 @@ class BuiltinVariable(BaseBuiltinVariable):
             inner_handler = BuiltinVariable._make_handler(
                 fn,
                 [
-                    ConstantVariable if issubclass(t, LazyConstantVariable) else t
+                    ConstantVariable if issubclass(t, lazy_constant_types) else t
                     for t in arg_types
                 ],
                 has_kwargs,
@@ -1119,14 +1161,18 @@ class BuiltinVariable(BaseBuiltinVariable):
                 args: list[VariableTracker],
                 kwargs: dict[str, VariableTracker],
             ) -> VariableTracker | None:
+                if not kwargs:
+                    result = _try_computed_lazy_constant(fn, args)
+                    if result is not None:
+                        return result
                 for a in args:
-                    if isinstance(a, LazyConstantVariable):
+                    if isinstance(a, lazy_constant_types):
                         if a.get_handler_type_for_dispatch() is not ConstantVariable:
                             return obj.call_function(
                                 tx,
                                 [
                                     v.realize()
-                                    if isinstance(v, LazyConstantVariable)
+                                    if isinstance(v, lazy_constant_types)
                                     else v
                                     for v in args
                                 ],

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -264,15 +264,11 @@ BUILTIN_TO_TENSOR_RFN_MAP: dict[Callable[..., Any], Callable[..., Any]] = {}
 # opt-out).
 _MISSING_SENTINEL = object()
 
-# Ops whose result type depends only on operand types (excludes pow: 2**-1 is a float)
 _COMPUTED_LAZY_CONSTANT_OPS: frozenset[Callable[..., Any]] = frozenset(
     [
         operator.add,
         operator.sub,
         operator.mul,
-        operator.truediv,
-        operator.floordiv,
-        operator.mod,
     ]
 )
 
@@ -283,6 +279,7 @@ def _try_computed_lazy_constant(
     """Build a ComputedLazyConstantVariable for fn(*args), or None to fall back."""
     from .lazy import ComputedLazyConstantVariable, LazyConstantVariable
 
+    fn = IN_PLACE_DESUGARING_MAP.get(fn, fn)
     if fn not in _COMPUTED_LAZY_CONSTANT_OPS or len(args) != 2:
         return None
     any_unrealized = False
@@ -296,10 +293,7 @@ def _try_computed_lazy_constant(
             return None
     if not any_unrealized:
         return None
-    try:
-        return ComputedLazyConstantVariable.create(fn, args)
-    except (TypeError, ArithmeticError):
-        return None
+    return ComputedLazyConstantVariable.create(fn, args)
 
 
 def populate_builtin_to_tensor_fn_map() -> None:

--- a/torch/_dynamo/variables/lazy.py
+++ b/torch/_dynamo/variables/lazy.py
@@ -563,8 +563,8 @@ class ComputedLazyConstantVariable(LazyVariableTracker):
     def create(  # pyrefly: ignore[bad-param-name-override, bad-override]
         op: Callable[..., Any],
         args: list[VariableTracker],
-    ) -> VariableTracker:
-        """Compute op(*args) eagerly; raises if the result is not a base literal."""
+    ) -> VariableTracker | None:
+        """Compute op(*args) eagerly; returns None to fall back to realization."""
         from .constant import ConstantVariable
 
         lazy_vars: list[LazyConstantVariable] = []
@@ -578,11 +578,13 @@ class ComputedLazyConstantVariable(LazyVariableTracker):
                 return arg.peek_value()
             return arg.as_python_constant()
 
-        value = op(*[get_value(arg) for arg in args])
+        values = [get_value(arg) for arg in args]
+        try:
+            value = op(*values)
+        except Exception:
+            return None
         if not ConstantVariable.is_base_literal(value):
-            raise TypeError(
-                f"ComputedLazyConstantVariable cannot wrap value of type {type(value)}"
-            )
+            return None
         if not lazy_vars:
             return ConstantVariable.create(value)
         return ComputedLazyConstantVariable(

--- a/torch/_dynamo/variables/lazy.py
+++ b/torch/_dynamo/variables/lazy.py
@@ -63,6 +63,54 @@ class LazyCache:
         del self.source_location
 
 
+class ComputedLazyCache:
+    """Like LazyCache, but for sourceless constants computed from lazy operands."""
+
+    def __init__(
+        self,
+        value: Any,
+        lazy_vars: list[LazyConstantVariable],
+        args: list[VariableTracker],
+        op: Callable[..., Any],
+    ) -> None:
+        self.value = value
+        self.lazy_vars = lazy_vars
+        self.args = args
+        self.op = op
+        self.name_hint: str | None = None
+        self.source_location: SourceLocation | None = None
+        self.vt: VariableTracker | None = None
+
+    def realize(self) -> None:
+        if self.vt is not None:
+            raise AssertionError(
+                "ComputedLazyCache.realize() called but vt is already set"
+            )
+        from ..symbolic_convert import InstructionTranslator
+        from .constant import ConstantVariable
+        from .tensor import SymNodeVariable
+
+        any_symbolic = False
+        for lazy_var in self.lazy_vars:
+            if isinstance(lazy_var.realize(), SymNodeVariable):
+                any_symbolic = True
+
+        if any_symbolic:
+            # The precomputed constant is stale; recompute symbolically
+            from .builtin import BuiltinVariable
+
+            tx = InstructionTranslator.current_tx()
+            realized_args = [arg.realize() for arg in self.args]
+            self.vt = BuiltinVariable(self.op).call_function(tx, realized_args, {})
+        else:
+            self.vt = ConstantVariable.create(self.value)
+
+        if self.name_hint is not None:
+            self.vt.set_name_hint(self.name_hint)
+        if self.source_location is not None and self.vt.source_location is None:
+            self.vt.set_source_location(self.source_location)
+
+
 class LazyVariableTracker(VariableTracker, metaclass=VariableTrackerMeta):
     """
     A structure that defers the creation of the actual VariableTracker
@@ -104,10 +152,10 @@ class LazyVariableTracker(VariableTracker, metaclass=VariableTrackerMeta):
 
         return LazyVariableTracker(LazyCache(value, source), source=source, **options)
 
-    def __init__(self, _cache: LazyCache, **kwargs: Any) -> None:
-        if not isinstance(_cache, LazyCache):
+    def __init__(self, _cache: LazyCache | ComputedLazyCache, **kwargs: Any) -> None:
+        if not isinstance(_cache, (LazyCache, ComputedLazyCache)):
             raise AssertionError(
-                f"_cache must be a LazyCache instance, got {type(_cache).__name__}"
+                f"_cache must be a LazyCache or ComputedLazyCache instance, got {type(_cache).__name__}"
             )
         super().__init__(**kwargs)
         self._cache = _cache
@@ -217,10 +265,24 @@ class LazyVariableTracker(VariableTracker, metaclass=VariableTrackerMeta):
 
         value_cls = type(value)
         if issubclass(value_cls, LazyVariableTracker):
-            # Allow LazyConstantVariable to stay lazy when returning from a frame
-            keep_lazy = allow_lazy_constant and isinstance(value, LazyConstantVariable)
+            # Allow LazyConstantVariable and ComputedLazyConstantVariable to
+            # stay lazy when returning from a frame
+            keep_lazy = allow_lazy_constant and isinstance(
+                value, (LazyConstantVariable, ComputedLazyConstantVariable)
+            )
             if keep_lazy:
-                result = value
+                if isinstance(value, ComputedLazyConstantVariable):
+                    if value.is_realized():
+                        result = cls.realize_all(
+                            value.realize(), cache, allow_lazy_constant=True
+                        )
+                    else:
+                        # Output bytecode recomputes the value; operands only need TYPE_MATCH
+                        for lazy_var in value._cache.lazy_vars:
+                            lazy_var._ensure_type_guard()
+                        result = value
+                else:
+                    result = value
             else:
                 result = cls.realize_all(
                     value.realize(), cache, allow_lazy_constant=allow_lazy_constant
@@ -294,6 +356,7 @@ class LazyVariableTracker(VariableTracker, metaclass=VariableTrackerMeta):
             raise AssertionError(
                 "original_source() called on an already realized LazyVariableTracker"
             )
+        # pyrefly: ignore[missing-attribute]
         return self._cache.source
 
 
@@ -484,6 +547,122 @@ class LazyConstantVariable(LazyVariableTracker):
         if realized_type is not None:
             return issubclass(realized_type, cls)
         return issubclass(ConstantVariable, cls)
+
+
+class ComputedLazyConstantVariable(LazyVariableTracker):
+    """
+    Result of a supported op over lazy constant operands.  The value is computed
+    eagerly at trace time but guards are deferred: if never realized, output
+    bytecode recomputes it from the operands (TYPE_MATCH only); realization
+    realizes the operands, installing their CONSTANT_MATCH guards.
+    """
+
+    _cache: ComputedLazyCache  # pyrefly: ignore[bad-override]
+
+    @staticmethod
+    def create(  # pyrefly: ignore[bad-param-name-override, bad-override]
+        op: Callable[..., Any],
+        args: list[VariableTracker],
+    ) -> VariableTracker:
+        """Compute op(*args) eagerly; raises if the result is not a base literal."""
+        from .constant import ConstantVariable
+
+        lazy_vars: list[LazyConstantVariable] = []
+
+        def get_value(arg: VariableTracker) -> Any:
+            if isinstance(arg, ComputedLazyConstantVariable) and not arg.is_realized():
+                lazy_vars.extend(arg._cache.lazy_vars)
+                return arg._cache.value
+            if isinstance(arg, LazyConstantVariable) and not arg.is_realized():
+                lazy_vars.append(arg)
+                return arg.peek_value()
+            return arg.as_python_constant()
+
+        value = op(*[get_value(arg) for arg in args])
+        if not ConstantVariable.is_base_literal(value):
+            raise TypeError(
+                f"ComputedLazyConstantVariable cannot wrap value of type {type(value)}"
+            )
+        if not lazy_vars:
+            return ConstantVariable.create(value)
+        return ComputedLazyConstantVariable(
+            ComputedLazyCache(value, lazy_vars, list(args), op)
+        )
+
+    def __init__(self, _cache: ComputedLazyCache, **kwargs: Any) -> None:
+        if not isinstance(_cache, ComputedLazyCache):
+            raise AssertionError(
+                f"_cache must be a ComputedLazyCache instance, got {type(_cache).__name__}"
+            )
+        super().__init__(_cache, **kwargs)
+
+    def _ensure_operand_type_guards(self) -> None:
+        # Type queries on the result depend on the operand types
+        for lazy_var in self._cache.lazy_vars:
+            lazy_var._ensure_type_guard()
+
+    def python_type(self) -> type:
+        if self.is_realized():
+            return super().python_type()
+        self._ensure_operand_type_guards()
+        return type(self._cache.value)
+
+    def is_tensor(self) -> bool:
+        if self.is_realized():
+            return super().is_tensor()
+        self._ensure_operand_type_guards()
+        return False
+
+    def _might_realize_symbolic(self) -> bool:
+        # Mirrors LazyConstantVariable._maybe_realize_for_type
+        from .tensor import SymNodeVariable
+
+        for lazy_var in self._cache.lazy_vars:
+            if lazy_var.is_realized():
+                if type.__instancecheck__(SymNodeVariable, lazy_var.realize()):
+                    return True
+            else:
+                value_type = lazy_var.peek_type()
+                if value_type is int and not config.specialize_int:
+                    return True
+                if value_type is float and not config.specialize_float:
+                    return True
+        return False
+
+    def get_handler_type_for_dispatch(self) -> type:
+        from .constant import ConstantVariable
+
+        if not self.is_realized() and not self._might_realize_symbolic():
+            self._ensure_operand_type_guards()
+            return ConstantVariable
+        return type(self.realize())
+
+    def lazy_isinstance(self, cls: type) -> bool:
+        from .constant import ConstantVariable
+        from .tensor import SymNodeVariable
+
+        if self.is_realized():
+            return type.__instancecheck__(cls, self.realize())
+        if not issubclass(ConstantVariable, cls) and not issubclass(
+            SymNodeVariable, cls
+        ):
+            self._ensure_operand_type_guards()
+            return False
+        if self._might_realize_symbolic():
+            return type.__instancecheck__(cls, self.realize())
+        self._ensure_operand_type_guards()
+        return issubclass(ConstantVariable, cls)
+
+    def reconstruct(self, codegen: Any) -> None:
+        from ..bytecode_transformation import create_call_function
+
+        cache = self._cache
+        codegen.add_push_null(
+            lambda: codegen.load_import_from("operator", cache.op.__name__)
+        )
+        for arg in cache.args:
+            codegen(arg)
+        codegen.extend_output(create_call_function(len(cache.args), False))
 
 
 class LazySymNodeFormatString:

--- a/torch/_dynamo/variables/lazy.py
+++ b/torch/_dynamo/variables/lazy.py
@@ -72,11 +72,13 @@ class ComputedLazyCache:
         lazy_vars: list[LazyConstantVariable],
         args: list[VariableTracker],
         op: Callable[..., Any],
+        num_nodes: int,
     ) -> None:
         self.value = value
         self.lazy_vars = lazy_vars
         self.args = args
         self.op = op
+        self.num_nodes = num_nodes
         self.name_hint: str | None = None
         self.source_location: SourceLocation | None = None
         self.vt: VariableTracker | None = None
@@ -567,11 +569,18 @@ class ComputedLazyConstantVariable(LazyVariableTracker):
         """Compute op(*args) eagerly; returns None to fall back to realization."""
         from .constant import ConstantVariable
 
+        max_nodes = config.computed_lazy_constant_max_nodes
+        if max_nodes <= 0:
+            return None
+
         lazy_vars: list[LazyConstantVariable] = []
+        num_nodes = 1
 
         def get_value(arg: VariableTracker) -> Any:
+            nonlocal num_nodes
             if isinstance(arg, ComputedLazyConstantVariable) and not arg.is_realized():
                 lazy_vars.extend(arg._cache.lazy_vars)
+                num_nodes += arg._cache.num_nodes
                 return arg._cache.value
             if isinstance(arg, LazyConstantVariable) and not arg.is_realized():
                 lazy_vars.append(arg)
@@ -579,6 +588,9 @@ class ComputedLazyConstantVariable(LazyVariableTracker):
             return arg.as_python_constant()
 
         values = [get_value(arg) for arg in args]
+        # realize/reconstruct recurse through args; unbounded chains overflow the stack
+        if num_nodes > max_nodes:
+            return None
         try:
             value = op(*values)
         except Exception:
@@ -588,7 +600,7 @@ class ComputedLazyConstantVariable(LazyVariableTracker):
         if not lazy_vars:
             return ConstantVariable.create(value)
         return ComputedLazyConstantVariable(
-            ComputedLazyCache(value, lazy_vars, list(args), op)
+            ComputedLazyCache(value, lazy_vars, list(args), op, num_nodes)
         )
 
     def __init__(self, _cache: ComputedLazyCache, **kwargs: Any) -> None:


### PR DESCRIPTION
## Related Issue

Part of #187590

## Why

Using a constant in an op (e.g. `a + b`) guards on the operand values, even if the result is never used in graph computation. Changing those values then recompiles for no reason.

## How

- Adds `ComputedLazyConstantVariable`: computes the result at trace time, skips value guards; output bytecode recomputes it at runtime
- Falls back to the guarded path once the result affects tracing (control flow, tensor math, etc.)
- Caps chain size via `computed_lazy_constant_max_nodes` (default 64, 0 disables); over-cap operands realize under guards, avoiding `RecursionError` on long chains (e.g. TorchRec KJT sums)
- Adds a 300-term chain regression test; updates `test_unbacked_sources_scalar` so its scalar still flows into the graph

Authored with an AI assistant (Claude Code).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98
