### PR TITLE
[Dynamo] Fix test_tvm to actually run against a real tvm install

### DIFF
--- a/test/dynamo/test_backends.py
+++ b/test/dynamo/test_backends.py
@@ -100,7 +100,9 @@ class TestOptimizations(torch._dynamo.test_case.TestCase):
         self.assertTrue(same(r1, r2))
         self.assertTrue(same(r1, r3))
 
-    def _check_backend_works(self, backend, device, boxed=True, options=None):
+    def _check_backend_works(
+        self, backend, device, boxed=True, options=None, backward=True
+    ):
         model = Seq().eval()
         model.to(device)
 
@@ -123,9 +125,10 @@ class TestOptimizations(torch._dynamo.test_case.TestCase):
         r2 = compiled_model(input2)
         self.assertTrue(same(r1, r2.float(), tol=0.01))
 
-        r1.sum().backward()
-        r2.sum().backward()
-        self.assertTrue(same(input1.grad, input2.grad.float(), tol=0.01))
+        if backward:
+            r1.sum().backward()
+            r2.sum().backward()
+            self.assertTrue(same(input1.grad, input2.grad.float(), tol=0.01))
 
         # Clean up compilation state before test returns to avoid false positive
         # memory leak detection (leak check runs before tearDown)
@@ -157,9 +160,13 @@ class TestOptimizations(torch._dynamo.test_case.TestCase):
 
     @unittest.skipIf(not has_tvm(), "requires tvm")
     def test_tvm(self, device):
-        self._check_backend_works("tvm", device)
-        self._check_backend_works("tvm", device, options={"scheduler": None})
-        self._check_backend_works("tvm", device, options={"opt_level": 0})
+        self._check_backend_works("tvm", device, boxed=False, backward=False)
+        self._check_backend_works(
+            "tvm", device, boxed=False, backward=False, options={"scheduler": None}
+        )
+        self._check_backend_works(
+            "tvm", device, boxed=False, backward=False, options={"opt_level": 0}
+        )
 
     def test_tvm_scheduler_backends(self, device):
         from torch._dynamo.backends.tvm import tvm_auto_scheduler, tvm_meta_schedule


### PR DESCRIPTION
## Why

`test_tvm` is always skipped in CI (tvm is not installed) and fails whenever tvm actually is installed, so it has never guarded anything. Two reasons:

- the tvm backend returns a plain unboxed callable, so the `boxed_assert` helper fails on `fn._boxed_call`
- the backend is inference-only: outputs come back through DLPack with no grad_fn, so the backward numerics check in `_check_backend_works` can never pass

## How

- Add a `backward` flag to `_check_backend_works` so inference-only backends can check forward numerics only
- Run `test_tvm` with `boxed=False, backward=False`

Verified locally against `apache-tvm==0.25.0.post1`: the whole `TestOptimizationsCPU` suite passes, including `test_tvm`.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98