### PR TITLE
[Dynamo] Fall back to eager on forward-AD dual tensor inputs

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -8258,6 +8258,30 @@ SavedForBackwardsAOTOutput(idx=5)""",
         opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
         self.assertEqual(fn(x), opt_fn(x))
 
+    def test_dual_tensor_input_graph_breaks(self):
+        import torch.autograd.forward_ad as fwAD
+
+        def fn(x):
+            return (x**2).sum()
+
+        cnt = torch._dynamo.testing.CompileCounter()
+        x = torch.tensor([0.1, 0.2, 0.3])
+        v = torch.ones(3)
+        with fwAD.dual_level():
+            dual = fwAD.make_dual(x, v)
+            expected = fwAD.unpack_dual(fn(dual)).tangent
+            out = torch.compile(fn, backend=cnt)(dual)
+            self.assertEqual(fwAD.unpack_dual(out).tangent, expected)
+        self.assertEqual(cnt.frame_count, 0)
+
+        torch._dynamo.reset()
+        with fwAD.dual_level():
+            dual = fwAD.make_dual(x, v)
+            with self.assertRaisesRegex(
+                torch._dynamo.exc.Unsupported, "dual tensor input"
+            ):
+                torch.compile(fn, backend="eager", fullgraph=True)(dual)
+
 
 class ReproTestsDevice(torch._dynamo.test_case.TestCase):
     @serialTest()

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -6022,5 +6022,15 @@
         "Sparse tensor operations are not yet fully supported in torch.compile with fullgraph=True. Consider using fullgraph=False to allow graph breaks, or move sparse tensor creation outside the compiled region."
       ]
     }
+  ],
+  "GB0375": [
+    {
+      "Gb_type": "Attempted to wrap a dual tensor input",
+      "Context": "",
+      "Explanation": "torch.compile does not support input tensors that carry a forward-mode AD tangent; compiled code would silently drop the tangent.",
+      "Hints": [
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
+    }
   ]
 }

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -2996,6 +2996,20 @@ class VariableBuilder:
             )
 
         if (
+            isinstance(value, torch.Tensor)
+            and torch._C._functorch.peek_interpreter_stack() is None
+            and torch.autograd.forward_ad.unpack_dual(value).tangent is not None
+        ):
+            unimplemented(
+                gb_type="Attempted to wrap a dual tensor input",
+                context="",
+                explanation="torch.compile does not support input tensors that "
+                "carry a forward-mode AD tangent; compiled code would silently "
+                "drop the tangent.",
+                hints=[*graph_break_hints.SUPPORTABLE],
+            )
+
+        if (
             safe_has_grad(value)
             and safe_grad(value) is not None
             # type: ignore[attr-defined]

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -2998,16 +2998,20 @@ class VariableBuilder:
         if (
             isinstance(value, torch.Tensor)
             and torch._C._functorch.peek_interpreter_stack() is None
-            and torch.autograd.forward_ad.unpack_dual(value).tangent is not None
         ):
-            unimplemented(
-                gb_type="Attempted to wrap a dual tensor input",
-                context="",
-                explanation="torch.compile does not support input tensors that "
-                "carry a forward-mode AD tangent; compiled code would silently "
-                "drop the tangent.",
-                hints=[*graph_break_hints.SUPPORTABLE],
-            )
+            try:
+                tangent = torch.autograd.forward_ad.unpack_dual(value).tangent
+            except RuntimeError:
+                tangent = None
+            if tangent is not None:
+                unimplemented(
+                    gb_type="Attempted to wrap a dual tensor input",
+                    context="",
+                    explanation="torch.compile does not support input tensors that "
+                    "carry a forward-mode AD tangent; compiled code would silently "
+                    "drop the tangent.",
+                    hints=[*graph_break_hints.SUPPORTABLE],
+                )
 
         if (
             safe_has_grad(value)


### PR DESCRIPTION
## Related Issue

Fixes #187284

## Why

Passing a forward-AD dual tensor into a compiled function silently drops the tangent (`unpack_dual(out).tangent` is `None` on inductor). Dynamo's fakeification throws the tangent away; backends that still run through the ATen dispatcher only recompute it by accident.

## How

- Graph break when a graph input carries a tangent at the current dual level: the frame falls back to eager and returns the correct tangent; `fullgraph=True` raises a clear error instead
- Exclude the functorch path (`torch.func.jvp`), which is already supported
- Add `test_dual_tensor_input_graph_breaks`

The zero-hessian case in the issue comments is a different root cause (double backward through a compiled backward graph) and is not covered here.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98