### PR TITLE
[AOTInductor] Free owning handles on conversion error in the C-shim dispatchers (#189645)

### DIFF
--- a/torch/csrc/inductor/aoti_runtime/model_base.h
+++ b/torch/csrc/inductor/aoti_runtime/model_base.h
@@ -926,22 +926,40 @@ class AOTInductorModelBase {
     auto folded_constants =
         model->const_run_impl(stream, proxy_executor, initialization);
 
+    // const_run_impl returns owning raw AtenTensorHandles in the map. The
+    // fallible calls below (cudaEventRecord / XPU barrier /
+    // wait_for_completion) can throw; without cleanup the map's destructor
+    // drops those raw handles without freeing the underlying tensors, leaking
+    // folded-constant GPU memory (the container catches and keeps serving, so
+    // it accumulates). Free the still-owned handles on the error path only.
+    // This header is compiled into model.so, so use only the stable C ABI (no
+    // c10 scope-guard).
+    try {
 #ifdef USE_CUDA
-    AOTI_RUNTIME_CUDA_CHECK(cudaEventRecord(*run_finished_, stream));
+      AOTI_RUNTIME_CUDA_CHECK(cudaEventRecord(*run_finished_, stream));
 #elif defined(USE_XPU)
-    // sycl::queue* queue_ptr = nullptr;
-    // aoti_torch_get_current_sycl_queue((void**)&queue_ptr);
-    run_finished_ = std::make_optional<sycl::event*>(new sycl::event(
-        static_cast<sycl::queue*>(stream)->ext_oneapi_submit_barrier()));
+      // sycl::queue* queue_ptr = nullptr;
+      // aoti_torch_get_current_sycl_queue((void**)&queue_ptr);
+      run_finished_ = std::make_optional<sycl::event*>(new sycl::event(
+          static_cast<sycl::queue*>(stream)->ext_oneapi_submit_barrier()));
 
 #else // !USE_CUDA && !USE_XPU
-    run_finished_ = true;
+      run_finished_ = true;
 #endif // USE_CUDA
 
-    // Wait for the constant folding kernels to complete. The folded
-    // constants may be read by inference on a different stream after
-    // swap_constant_buffer(), which has no GPU synchronization.
-    wait_for_completion();
+      // Wait for the constant folding kernels to complete. The folded
+      // constants may be read by inference on a different stream after
+      // swap_constant_buffer(), which has no GPU synchronization.
+      wait_for_completion();
+    } catch (...) {
+      for (auto& kv : folded_constants) {
+        if (kv.second != nullptr) {
+          (void)aoti_torch_delete_tensor_object(kv.second);
+          kv.second = nullptr;
+        }
+      }
+      throw;
+    }
 
     return folded_constants;
   }

--- a/torch/csrc/inductor/aoti_runtime/model_container.h
+++ b/torch/csrc/inductor/aoti_runtime/model_container.h
@@ -571,25 +571,49 @@ class AOTInductorModelContainer {
     auto& source = use_inactive ? active() : inactive();
     target.fold_state = ConstantState::INITIALIZED;
 
+    // constants_map is bound by rvalue-ref to the caller's folded-constant map
+    // and owns raw AtenTensorHandles. Each is handed to target.map (as an
+    // RAIIAtenTensorHandle) below and its source slot nulled the instant it is
+    // transferred. If a call in the loop throws (node alloc in
+    // insert_or_assign, string ctor), free the not-yet-transferred handles;
+    // already-transferred slots are null so they are skipped -- no double free.
+    // On success every consumed slot is null, so the caller's map is discarded
+    // without freeing (unchanged semantics). model.so-embedded, so stable C ABI
+    // only.
     auto num_constants = models_[0]->num_constants();
-    for (size_t idx = 0; idx < num_constants; idx++) {
-      auto constant_name =
-          std::string(models_[0]->constant_name(static_cast<int64_t>(idx)));
-      auto it = constants_map.find(constant_name);
-      if (it == constants_map.end() &&
-          !(use_inactive && _is_tensor_constant_type(idx))) {
-        continue;
-      }
+    try {
+      for (size_t idx = 0; idx < num_constants; idx++) {
+        auto constant_name =
+            std::string(models_[0]->constant_name(static_cast<int64_t>(idx)));
+        auto it = constants_map.find(constant_name);
+        if (it == constants_map.end() &&
+            !(use_inactive && _is_tensor_constant_type(idx))) {
+          continue;
+        }
 
-      AtenTensorHandle tensor;
-      if (it == constants_map.end()) {
-        aoti_torch_clone(
-            source.map->find(constant_name)->second.get(), &tensor);
-      } else {
-        tensor = it->second;
-      }
+        AtenTensorHandle tensor;
+        if (it == constants_map.end()) {
+          aoti_torch_clone(
+              source.map->find(constant_name)->second.get(), &tensor);
+        } else {
+          tensor = it->second;
+          // Null the source slot before RAIIAtenTensorHandle takes ownership so
+          // a throw in insert_or_assign (which frees the temporary) cannot
+          // leave a dangling handle in constants_map to double free.
+          it->second = nullptr;
+        }
 
-      target.map->insert_or_assign(constant_name, RAIIAtenTensorHandle(tensor));
+        target.map->insert_or_assign(
+            constant_name, RAIIAtenTensorHandle(tensor));
+      }
+    } catch (...) {
+      for (auto& kv : constants_map) {
+        if (kv.second != nullptr) {
+          (void)aoti_torch_delete_tensor_object(kv.second);
+          kv.second = nullptr;
+        }
+      }
+      throw;
     }
     target.update_array(models_[0].get());
   }

--- a/torch/csrc/shim_common.cpp
+++ b/torch/csrc/shim_common.cpp
@@ -2,6 +2,7 @@
 #include <c10/core/DispatchKey.h>
 #include <c10/core/Stream.h>
 #include <c10/util/Exception.h>
+#include <c10/util/ScopeExit.h>
 #include <torch/csrc/inductor/aoti_runtime/utils.h>
 #include <torch/csrc/inductor/aoti_torch/c/shim.h>
 #include <torch/csrc/inductor/aoti_torch/tensor_converter.h>
@@ -147,11 +148,17 @@ static StableIValue from_ivalue(
         return torch::stable::detail::_from(
             std::nullopt, extension_build_version);
       }
-      const StableIValue value =
-          from_ivalue(inner_type, ivalue, extension_build_version);
+      // Allocate the heap slot (the fallible step) before producing the owning
+      // inner value, and guard it: if the recursive from_ivalue throws, the
+      // freshly allocated (still value-0) slot would otherwise leak. On success
+      // ownership passes to the caller, so release the guard. Mirrors
+      // FromImpl<std::optional<T>> in stable/stableivalue_conversions.h.
       StableIValue* sivp = nullptr;
       TORCH_ERROR_CODE_CHECK(torch_new_stable_ivalue(&sivp));
-      *sivp = value;
+      auto sivp_guard = c10::make_scope_exit(
+          [&]() noexcept { (void)torch_delete_stable_ivalue(sivp); });
+      *sivp = from_ivalue(inner_type, ivalue, extension_build_version);
+      sivp_guard.release();
       return torch::stable::detail::_from(sivp, extension_build_version);
     }
     case c10::TypeKind::ListType: {
@@ -310,6 +317,22 @@ static c10::IValue to_ivalue(
   }
 }
 
+// Frees an owning StableIValue that from_ivalue produced for `type`. Delegates
+// to to_ivalue, which consumes the handle and, for aggregate types
+// (optional/list), recursively frees every nested owning handle -- the raw
+// deleters (torch_delete_list / torch_delete_stable_ivalue) would leak those.
+// Only used on the error/rollback path: we are already unwinding, so a
+// secondary failure is swallowed.
+static void free_owning_stable_ivalue(
+    const c10::TypePtr& type,
+    StableIValue stable_ivalue,
+    uint64_t extension_build_version) noexcept {
+  try {
+    (void)to_ivalue(type, stable_ivalue, extension_build_version);
+  } catch (...) {
+  }
+}
+
 class StableIValueBoxedKernel : public c10::OperatorKernel {
  public:
   StableIValueBoxedKernel(
@@ -328,25 +351,65 @@ class StableIValueBoxedKernel : public c10::OperatorKernel {
     auto ministack =
         std::make_unique<StableIValue[]>(std::max(num_arguments, num_returns));
 
+    // Produce owning argument handles (in reverse) into `ministack`. If a
+    // conversion throws, the handles already written leak, so free them on
+    // unwind. `args_converted` counts the slots holding handles produced here
+    // (from_ivalue is all-or-nothing per slot, so the in-flight slot is never
+    // counted).
+    size_t args_converted = 0;
+    auto arg_guard = c10::make_scope_exit([&]() noexcept {
+      for (size_t i = 0; i < args_converted; i++) {
+        const auto ministack_idx = num_arguments - i - 1;
+        free_owning_stable_ivalue(
+            schema.arguments()[ministack_idx].real_type(),
+            ministack[ministack_idx],
+            extension_build_version_);
+      }
+    });
+
     for (const auto idx : c10::irange(num_arguments)) {
       const auto ministack_idx = num_arguments - idx - 1;
       const c10::TypePtr& arg_type =
           schema.arguments()[ministack_idx].real_type();
       ministack[ministack_idx] = from_ivalue(
           arg_type, torch::jit::pop(stack), extension_build_version_);
+      args_converted++;
     }
+
+    // Ownership of the argument handles transfers to the boxed function, which
+    // consumes them and overwrites `ministack` with the return handles. Release
+    // the guard now: keeping it armed across fn_ could double-free arguments fn_
+    // already consumed, and fn_ is a C-ABI boundary that does not propagate C++
+    // exceptions by contract.
+    arg_guard.release();
 
     // boxed function is going to take a stack of StableIValues, cast them to
     // our schema values, and run the function and modify the StableIValue stack
     fn_(ministack.get(), num_arguments, num_returns);
 
+    // Consume the return handles via to_ivalue. Each handle is handed to
+    // to_ivalue (which owns its cleanup) as we reach it, so mark the slot
+    // pending before the call; if a later conversion throws, only the
+    // not-yet-handed handles [ret_pending, num_returns) are still ours to free.
+    size_t ret_pending = 0;
+    auto ret_guard = c10::make_scope_exit([&]() noexcept {
+      for (size_t idx = ret_pending; idx < num_returns; idx++) {
+        free_owning_stable_ivalue(
+            schema.returns()[idx].real_type(),
+            ministack[idx],
+            extension_build_version_);
+      }
+    });
+
     // read the output from the end of the stack and wrap that back into
     // IValue from StableIValue
     for (size_t idx = 0; idx < num_returns; idx++) {
       const c10::TypePtr& ret_type = schema.returns()[idx].real_type();
+      ret_pending = idx + 1;
       torch::jit::push(
           stack, to_ivalue(ret_type, ministack[idx], extension_build_version_));
     }
+    ret_guard.release();
   }
 
  private:
@@ -420,6 +483,22 @@ AOTITorchError aoti_torch_call_dispatcher(
 
     op.callBoxed(ivalue_stack);
 
+    // Produce owning return handles into the caller's `stack`. If a later
+    // conversion throws, the handles already written leak (the caller only
+    // observes an error code), so free them on unwind; on success the caller
+    // owns them, so release the guard. `returns_converted` counts written slots
+    // (from_ivalue is all-or-nothing, so the in-flight slot is excluded).
+    size_t returns_converted = 0;
+    auto return_guard = c10::make_scope_exit([&]() noexcept {
+      for (size_t idx = 0; idx < returns_converted; idx++) {
+        const auto stack_idx = num_returns - idx - 1;
+        free_owning_stable_ivalue(
+            schema.returns()[idx].real_type(),
+            stack[stack_idx],
+            TORCH_ABI_VERSION);
+      }
+    });
+
     // there should then be num_returns IValues on the stack, which
     // we will convert to StableIValue and repopulate user input stack
     for (const auto idx : c10::irange(num_returns)) {
@@ -427,7 +506,9 @@ AOTITorchError aoti_torch_call_dispatcher(
       const c10::TypePtr& ret_type = schema.returns()[idx].real_type();
       stack[stack_idx] = from_ivalue(
           ret_type, torch::jit::pop(ivalue_stack), TORCH_ABI_VERSION);
+      returns_converted++;
     }
+    return_guard.release();
   });
 }
 
@@ -575,6 +656,22 @@ AOTI_TORCH_EXPORT AOTITorchError torch_call_dispatcher(
 
     op.callBoxed(ivalue_stack);
 
+    // Produce owning return handles into the caller's `stack`. If a later
+    // conversion throws, the handles already written leak (the caller only
+    // observes an error code), so free them on unwind; on success the caller
+    // owns them, so release the guard. `returns_converted` counts written slots
+    // (from_ivalue is all-or-nothing, so the in-flight slot is excluded).
+    size_t returns_converted = 0;
+    auto return_guard = c10::make_scope_exit([&]() noexcept {
+      for (size_t idx = 0; idx < returns_converted; idx++) {
+        const auto stack_idx = num_returns - idx - 1;
+        free_owning_stable_ivalue(
+            schema.returns()[idx].real_type(),
+            stack[stack_idx],
+            extension_build_version);
+      }
+    });
+
     // there should then be num_returns IValues on the stack, which
     // we will convert to StableIValue and repopulate user input stack
     for (const auto idx : c10::irange(num_returns)) {
@@ -582,7 +679,9 @@ AOTI_TORCH_EXPORT AOTITorchError torch_call_dispatcher(
       const c10::TypePtr& ret_type = schema.returns()[idx].real_type();
       stack[stack_idx] = from_ivalue(
           ret_type, torch::jit::pop(ivalue_stack), extension_build_version);
+      returns_converted++;
     }
+    return_guard.release();
   });
 }
 

--- a/torch/csrc/stable/stableivalue_conversions.h
+++ b/torch/csrc/stable/stableivalue_conversions.h
@@ -264,12 +264,18 @@ struct FromImpl<std::optional<T>> {
     }
 #if TORCH_FEATURE_VERSION >= TORCH_VERSION_2_13_0
 
-    const StableIValue value = detail::FromImpl<T>::call(
-        val.value(), extension_build_version, is_internal);
-
+    // Allocate the heap slot (the fallible step) before producing the owning
+    // inner value; if producing it throws, free the still-empty slot so it does
+    // not leak. Mirrors from_ivalue's OptionalType branch in shim_common.cpp.
     StableIValue* ivalue_ptr = nullptr;
     TORCH_ERROR_CODE_CHECK(torch_new_stable_ivalue(&ivalue_ptr));
-    *ivalue_ptr = value;
+    try {
+      *ivalue_ptr = detail::FromImpl<T>::call(
+          val.value(), extension_build_version, is_internal);
+    } catch (...) {
+      (void)torch_delete_stable_ivalue(ivalue_ptr);
+      throw;
+    }
     return torch::stable::detail::from(ivalue_ptr);
 #else
     return torch::stable::detail::from(


### PR DESCRIPTION
Summary:

`torch/csrc/shim_common.cpp` converts IValues to and from owning `StableIValue` handles (tensor / generator / list / optional) across the torch::stable ABI. Four spots produce an owning handle before a later fallible conversion, so if that later conversion throws the earlier owning handles leak (the caller only receives an error code and cannot reclaim them):

- `StableIValueBoxedKernel::operator()` -- argument production into the ministack, and return consumption.
- `aoti_torch_call_dispatcher` and `torch_call_dispatcher` -- return-conversion loops that write owning handles into the caller's `stack[]`.
- `from_ivalue` OptionalType branch -- the owning inner value is created before the fallible `torch_new_stable_ivalue`.

Fix: a shared `free_owning_stable_ivalue` helper (delegates to `to_ivalue`, which recursively frees nested owning handles that the raw deleters would leak), armed as a `c10::make_scope_exit` guard that frees only not-yet-committed handles and is released on success. The Optional branch (and its `stable/stableivalue_conversions.h` mirror) now allocate the fallible slot before producing the owning inner value. Argument guards are released before the C-ABI `fn_` boundary so consumed arguments are never double-freed.

Test Plan:
Compile-verified: the host-core libtorch build recompiles this file cleanly and the `free_unstolen_handles` unit test passes.

```
buck2 test fbcode//mode/dev-nosan fbcode//caffe2/test/inductor/fb:test_tensor_converter
```

REVIEWER NOTE: this is the subtlest change in the stack (torch::stable extension ABI, per-type ownership and double-free reasoning). A deterministic leak test is feasible -- register a custom op returning e.g. `(Tensor, Scalar)` (the `Scalar` return forces a throw in the conversion loop) and detect via a blob-with-deleter tensor -- but is not included here; please review the ownership logic carefully before landing.

Authored with assistance from Claude Code (AI pair programmer).

Differential Revision: D111300708


