### PR TITLE
[ROCm][Inductor] Support CK-Tile universal GEMM API change in ROCm 7.14

### DIFF
--- a/.ci/pytorch/rocm_utils.sh
+++ b/.ci/pytorch/rocm_utils.sh
@@ -44,6 +44,26 @@ build_rocm_ck_wheel() {
   pushd "$ck_dir" >/dev/null || return 1
   git fetch --depth 1 https://github.com/ROCm/composable_kernel.git "$ck_commit"
   git checkout FETCH_HEAD
+
+  # ck4inductor packages include/ck but not include/ck_tile, so the CK-Tile inductor
+  # backend has no headers to compile against now that ROCm no longer installs them
+  # system-wide. Patch it here until the fix lands upstream; bail out rather than build
+  # a wheel that is silently missing the headers.
+  local ck_include_unpatched='"ck4inductor.include" = ["ck/**/*.hpp"]'
+  local ck_include_patched='"ck4inductor.include" = ["ck/**/*.hpp", "ck_tile/**/*.hpp", "ck_tile/**/*.inc"]'
+  if grep -qxF "$ck_include_unpatched" pyproject.toml; then
+    echo "Patching pyproject.toml to package ck_tile headers"
+    if ! python -c 'import sys; s = open("pyproject.toml").read(); open("pyproject.toml", "w").write(s.replace(sys.argv[1], sys.argv[2], 1))' "$ck_include_unpatched" "$ck_include_patched"; then
+      echo "build_rocm_ck_wheel: failed to patch pyproject.toml" >&2
+      popd >/dev/null || true
+      return 1
+    fi
+  elif ! grep -qF 'ck_tile/**/*.hpp' pyproject.toml; then
+    echo "build_rocm_ck_wheel: unrecognized ck4inductor.include package-data in pyproject.toml" >&2
+    popd >/dev/null || true
+    return 1
+  fi
+
   python -m build --wheel --no-isolation --outdir "$output_dir"
   popd >/dev/null || return 1
 

--- a/test/inductor/test_ck_backend.py
+++ b/test/inductor/test_ck_backend.py
@@ -560,6 +560,123 @@ class TestCKBackend(TestCase):
             torch.testing.assert_close(Y_compiled, Y_eager)
 
 
+@unittest.skipIf(not torch.version.hip, "ROCM only")
+class TestCKTileUniversalGemmTemplate(TestCase):
+    _MODULE = "torch._inductor.codegen.rocm.ck_tile_universal_gemm_template"
+
+    def setUp(self):
+        super().setUp()
+        from torch._inductor.codegen.rocm import ck_tile_universal_gemm_template
+
+        self._ck_tile = ck_tile_universal_gemm_template
+        self._ck_tile._ck_tile_universal_gemm_v2_api.cache_clear()
+
+    def _write_pipeline_header(self, rocm_home: str, body: str) -> None:
+        header_dir = os.path.join(
+            rocm_home,
+            "include",
+            os.path.dirname(self._ck_tile._CK_TILE_PIPELINE_PROBLEM_HEADER),
+        )
+        os.makedirs(header_dir, exist_ok=True)
+        with open(
+            os.path.join(
+                header_dir,
+                os.path.basename(self._ck_tile._CK_TILE_PIPELINE_PROBLEM_HEADER),
+            ),
+            "w",
+        ) as f:
+            f.write(body)
+
+    def test_header_probe_legacy_api(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as rocm_home:
+            self._write_pipeline_header(
+                rocm_home,
+                """
+struct UniversalGemmPipelineProblem
+{
+    template<typename ADataType_,
+             typename BDataType_,
+             typename AccDataType_,
+             typename GemmShape_,
+             typename GemmUniversalTraits_,
+             ck_tile::GemmPipelineScheduler Scheduler_,
+             bool HasHotLoop_    = true,
+             ck_tile::TailNumber TailNum_ = ck_tile::TailNumber::Full>
+    {};
+""",
+            )
+            self.assertFalse(self._ck_tile._ck_tile_universal_gemm_v2_api(rocm_home))
+
+    def test_header_probe_v2_api(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as rocm_home:
+            self._write_pipeline_header(
+                rocm_home,
+                """
+struct UniversalGemmPipelineProblem
+{
+    template<typename ADataType_,
+             typename BDataType_,
+             typename AccDataType_,
+             typename GemmShape_,
+             typename GemmUniversalTraits_,
+             ck_tile::GemmPipelineScheduler Scheduler_,
+             typename AElementWise_ = ck_tile::element_wise::PassThrough,
+             bool HasHotLoop_    = true,
+             ck_tile::TailNumber TailNum_ = ck_tile::TailNumber::Full>
+    {};
+""",
+            )
+            self.assertTrue(self._ck_tile._ck_tile_universal_gemm_v2_api(rocm_home))
+
+    def test_emit_v1_legacy_instance(self):
+        from unittest.mock import patch
+
+        tmpl = self._ck_tile.CKTileGemmTemplate
+        with patch(
+            f"{self._MODULE}._ck_tile_universal_gemm_v2_api", return_value=False
+        ):
+            code = object.__new__(tmpl).emit_ck_instance(self._ck_tile.ops()[0])
+        self.assertIn("has_hot_loop_v", code)
+        self.assertIn("GemmPipelineProblem", code)
+        self.assertNotIn(
+            "using Kernel = ck_tile::GemmKernel<TilePartitioner, GemmPipeline, GemmEpilogue>;",
+            code,
+        )
+
+    def test_emit_v2_simplified_instance(self):
+        from unittest.mock import patch
+
+        tmpl = self._ck_tile.CKTileGemmTemplate
+        with patch(f"{self._MODULE}._ck_tile_universal_gemm_v2_api", return_value=True):
+            code = object.__new__(tmpl).emit_ck_instance(self._ck_tile.ops()[0])
+        self.assertNotIn("TailHandler", code)
+        self.assertNotIn("has_hot_loop_v", code)
+        self.assertIn(
+            "using Kernel = ck_tile::GemmKernel<TilePartitioner, GemmPipeline, GemmEpilogue>;",
+            code,
+        )
+
+    def test_kernel_launch_v1_has_tail_handler(self):
+        tmpl = self._ck_tile.CKTileGemmTemplate
+        code = tmpl._template_from_string(tmpl.gemm_kernel_launch).render(
+            instance_namespace="test_ns", use_v2_api=False
+        )
+        self.assertIn("TailHandler", code)
+        self.assertIn("filter_op", code)
+
+    def test_kernel_launch_v2_no_tail_handler(self):
+        tmpl = self._ck_tile.CKTileGemmTemplate
+        code = tmpl._template_from_string(tmpl.gemm_kernel_launch).render(
+            instance_namespace="test_ns", use_v2_api=True
+        )
+        self.assertNotIn("TailHandler", code)
+        self.assertIn("kBlockPerCU", code)
+
+
 if __name__ == "__main__":
     from torch._inductor.utils import is_big_gpu
 

--- a/test/inductor/test_ck_backend.py
+++ b/test/inductor/test_ck_backend.py
@@ -1,6 +1,9 @@
 # Owner(s): ["module: inductor"]
+import contextlib
 import logging
 import os
+import shlex
+import subprocess
 import tempfile
 import unittest
 from unittest.mock import patch
@@ -13,6 +16,7 @@ except ImportError:
 
 import torch
 from torch._inductor import config
+from torch._inductor.ir import Buffer, FixedLayout
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import try_import_ck_lib
 from torch.testing import FileCheck
@@ -555,49 +559,7 @@ class TestCKBackend(TestCase):
             torch.testing.assert_close(Y_compiled, Y_eager)
 
 
-@unittest.skipIf(not torch.version.hip, "ROCM only")
-class TestCKTileUniversalGemmTemplate(TestCase):
-    _MODULE = "torch._inductor.codegen.rocm.ck_tile_universal_gemm_template"
-
-    def setUp(self):
-        super().setUp()
-        from torch._inductor.codegen.rocm import ck_tile_universal_gemm_template
-
-        self._ck_tile = ck_tile_universal_gemm_template
-        # _ck_tile_universal_gemm_v2_api is functools.cache'd on rocm_home.
-        self._ck_tile._ck_tile_universal_gemm_v2_api.cache_clear()
-
-    def _require_ck_lib(self):
-        ck_dir, _, _, _ = try_import_ck_lib()
-        if not ck_dir:
-            raise unittest.SkipTest("Composable Kernel library is not installed")
-
-    def _sample_ck_tile_op(self):
-        ck_ops = self._ck_tile.ops()
-        self.assertTrue(len(ck_ops) > 0, "expected CK-Tile gemm ops to be defined")
-        return ck_ops[0]
-
-    def _write_pipeline_header(self, rocm_home: str, body: str) -> None:
-        header_dir = os.path.join(
-            rocm_home,
-            "include",
-            os.path.dirname(self._ck_tile._CK_TILE_PIPELINE_PROBLEM_HEADER),
-        )
-        os.makedirs(header_dir, exist_ok=True)
-        with open(
-            os.path.join(
-                header_dir,
-                os.path.basename(self._ck_tile._CK_TILE_PIPELINE_PROBLEM_HEADER),
-            ),
-            "w",
-        ) as f:
-            f.write(body)
-
-    def test_header_probe_legacy_api(self):
-        with tempfile.TemporaryDirectory() as rocm_home:
-            self._write_pipeline_header(
-                rocm_home,
-                """
+_LEGACY_PIPELINE_HEADER = """
 template <typename ADataType_,
           typename BDataType_,
           typename CDataType_,
@@ -613,15 +575,9 @@ template <typename ADataType_,
 struct UniversalGemmPipelineProblem
 {
 };
-""",
-            )
-            self.assertFalse(self._ck_tile._ck_tile_universal_gemm_v2_api(rocm_home))
+"""
 
-    def test_header_probe_v2_api(self):
-        with tempfile.TemporaryDirectory() as rocm_home:
-            self._write_pipeline_header(
-                rocm_home,
-                """
+_V2_PIPELINE_HEADER = """
 template <typename AsDataType_,
           typename BsDataType_,
           typename EDataType_,
@@ -638,9 +594,153 @@ template <typename AsDataType_,
 struct UniversalGemmPipelineProblem
 {
 };
-""",
+"""
+
+
+@instantiate_parametrized_tests
+@unittest.skipIf(not torch.version.hip, "ROCM only")
+class TestCKTileUniversalGemmTemplate(TestCase):
+    _MODULE = "torch._inductor.codegen.rocm.ck_tile_universal_gemm_template"
+
+    def setUp(self):
+        super().setUp()
+        from torch._inductor.codegen.rocm import ck_tile_universal_gemm_template
+
+        self._ck_tile = ck_tile_universal_gemm_template
+        # _ck_tile_universal_gemm_v2_api is functools.cache'd on the search path.
+        self._ck_tile._ck_tile_universal_gemm_v2_api.cache_clear()
+
+    # ops() names the half-precision instances "FP16", but _TORCH_DTYPE_TO_CK maps
+    # torch.float16 to "F16", so check_dtypes never matches them. bfloat16 is the
+    # only dtype for which CK-Tile instances are currently reachable.
+    _DTYPE = torch.bfloat16
+    _CK_DTYPE = "BF16"
+
+    def _make_template(self, m=2048, n=2048, k=2048):
+        device = torch.device("cuda")
+        X = Buffer(name="X", layout=FixedLayout(device, self._DTYPE, [m, k]))
+        W = Buffer(name="W", layout=FixedLayout(device, self._DTYPE, [k, n]))
+        return self._ck_tile.CKTileGemmTemplate(
+            [X, W], FixedLayout(device, self._DTYPE, [m, n])
+        )
+
+    def _find_ck_tile_op(self, pipeline="CompV3", epilogue="Default"):
+        for op in self._ck_tile.ops():
+            if (
+                (op.pipeline, op.epilogue) == (pipeline, epilogue)
+                and (op.layout_a, op.layout_b, op.layout_c) == ("Row", "Row", "Row")
+                and op.datatype_a == self._CK_DTYPE
+            ):
+                return op
+        raise AssertionError(f"no CK-Tile gemm op for {pipeline=} {epilogue=}")
+
+    def _compile_ck_tile_source(self, source: str) -> None:
+        from torch._inductor.codegen.rocm.compile_command import rocm_compile_command
+
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("ROCm device required to select --offload-arch")
+        arch = torch.cuda.get_device_properties(0).gcnArchName.split(":")[0]
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            src_path = os.path.join(tmp_dir, "instance.hip")
+            with open(src_path, "w") as f:
+                f.write(source)
+            with config.patch({"rocm.arch": [arch]}):
+                cmd = rocm_compile_command(
+                    [src_path],
+                    os.path.join(tmp_dir, "instance.o"),
+                    "o",
+                    ["-fsyntax-only"],
+                )
+            result = subprocess.run(
+                shlex.split(cmd), capture_output=True, text=True, check=False
             )
-            self.assertTrue(self._ck_tile._ck_tile_universal_gemm_v2_api(rocm_home))
+        if result.returncode != 0:
+            self.fail(f"{cmd}\n{result.stdout}\n{result.stderr}")
+
+    def _write_pipeline_header(self, include_root: str, body: str) -> None:
+        header_dir = os.path.join(
+            include_root,
+            "include",
+            os.path.dirname(self._ck_tile._CK_TILE_PIPELINE_PROBLEM_HEADER),
+        )
+        os.makedirs(header_dir, exist_ok=True)
+        with open(
+            os.path.join(
+                header_dir,
+                os.path.basename(self._ck_tile._CK_TILE_PIPELINE_PROBLEM_HEADER),
+            ),
+            "w",
+        ) as f:
+            f.write(body)
+
+    @contextlib.contextmanager
+    def _probe_env(self, rocm_home_header=None, ck_dir_header=None):
+        """
+        A fake ROCm install plus an empty CK directory, so that the header the
+        probe picks is determined by the test rather than by the environment.
+        """
+        with (
+            tempfile.TemporaryDirectory() as rocm_home,
+            tempfile.TemporaryDirectory() as ck_dir,
+        ):
+            if rocm_home_header is not None:
+                self._write_pipeline_header(rocm_home, rocm_home_header)
+            if ck_dir_header is not None:
+                self._write_pipeline_header(ck_dir, ck_dir_header)
+            with config.patch({"rocm.ck_dir": ck_dir}):
+                yield rocm_home
+
+    def _probe(self, rocm_home):
+        return self._ck_tile._ck_tile_universal_gemm_v2_api(
+            rocm_home, config.rocm.ck_dir
+        )
+
+    def test_header_probe_legacy_api(self):
+        with self._probe_env(rocm_home_header=_LEGACY_PIPELINE_HEADER) as rocm_home:
+            self.assertFalse(self._probe(rocm_home))
+
+    def test_header_probe_v2_api(self):
+        with self._probe_env(rocm_home_header=_V2_PIPELINE_HEADER) as rocm_home:
+            self.assertTrue(self._probe(rocm_home))
+
+    def test_header_probe_prefers_ck_dir_over_rocm_home(self):
+        """
+        The compiler searches the CK directory before $ROCM_HOME, so the probe
+        has to resolve the header the same way.
+        """
+        with self._probe_env(
+            rocm_home_header=_LEGACY_PIPELINE_HEADER,
+            ck_dir_header=_V2_PIPELINE_HEADER,
+        ) as rocm_home:
+            self.assertTrue(self._probe(rocm_home))
+
+    def test_header_probe_on_installed_header(self):
+        """
+        The synthetic headers above cannot catch the probe silently failing to
+        classify the real thing, which is how this shipped broken once already.
+        """
+        header_path = self._ck_tile._find_ck_tile_header(
+            config.rocm.rocm_home, config.rocm.ck_dir
+        )
+        if header_path is None:
+            raise unittest.SkipTest("ck_tile headers are not installed")
+        with open(header_path) as f:
+            header_text = f.read()
+        self.assertIsNotNone(
+            self._ck_tile._header_has_v2_universal_gemm_pipeline(header_text),
+            f"could not classify the universal GEMM API in {header_path}",
+        )
+
+    def test_header_probe_handles_long_template_clause(self):
+        padding = "".join(f"          typename Unused{i}_ = void,\n" for i in range(64))
+        header_text = _V2_PIPELINE_HEADER.replace(
+            "          typename AElementWise_",
+            padding + "          typename AElementWise_",
+        )
+        self.assertTrue(
+            self._ck_tile._header_has_v2_universal_gemm_pipeline(header_text)
+        )
 
     def test_header_probe_does_not_use_later_flatmm_signature(self):
         header_text = """
@@ -674,48 +774,41 @@ struct FlatmmPipelineProblem
 
     @patch(f"{_MODULE}.torch.version.hip", "7.14.0")
     def test_header_probe_fallback_v2_when_header_missing(self):
-        with tempfile.TemporaryDirectory() as rocm_home:
-            self.assertTrue(self._ck_tile._ck_tile_universal_gemm_v2_api(rocm_home))
+        with self._probe_env() as rocm_home:
+            self.assertTrue(self._probe(rocm_home))
 
     @patch(f"{_MODULE}.torch.version.hip", "7.2.0")
     def test_header_probe_fallback_v1_when_header_missing(self):
-        with tempfile.TemporaryDirectory() as rocm_home:
-            self.assertFalse(self._ck_tile._ck_tile_universal_gemm_v2_api(rocm_home))
+        with self._probe_env() as rocm_home:
+            self.assertFalse(self._probe(rocm_home))
 
     @patch(f"{_MODULE}.torch.version.hip", "7.14.0")
     def test_header_probe_fallback_v2_when_header_unrecognized(self):
-        with tempfile.TemporaryDirectory() as rocm_home:
-            self._write_pipeline_header(
-                rocm_home,
-                """
-struct UniversalGemmPipelineProblem
-{
-};
-""",
-            )
-            self.assertTrue(self._ck_tile._ck_tile_universal_gemm_v2_api(rocm_home))
+        header = "struct UniversalGemmPipelineProblem\n{\n};\n"
+        with self._probe_env(rocm_home_header=header) as rocm_home:
+            self.assertTrue(self._probe(rocm_home))
 
-    def test_emit_v1_legacy_instance(self):
-        self._require_ck_lib()
-        tmpl = self._ck_tile.CKTileGemmTemplate
-        code = object.__new__(tmpl).emit_ck_instance(
-            self._sample_ck_tile_op(), use_v2_api=False
+    @patch(f"{_MODULE}.torch.version.hip", "7.rc1")
+    def test_header_probe_fallback_tolerates_malformed_hip_version(self):
+        with self._probe_env() as rocm_home:
+            self.assertFalse(self._probe(rocm_home))
+
+    @parametrize("epilogue", ("Default", "CShuffle"))
+    def test_emit_v1_legacy_instance(self, epilogue):
+        code = self._make_template().emit_ck_instance(
+            self._find_ck_tile_op(epilogue=epilogue), use_v2_api=False
         )
         self.assertIn("has_hot_loop_v", code)
         self.assertIn("GemmPipelineProblem", code)
-        self.assertNotIn(
-            "using Kernel = ck_tile::GemmKernel<TilePartitioner, GemmPipeline, GemmEpilogue>;",
-            code,
-        )
+        self.assertIn("BaseGemmPipeline", code)
 
-    def test_emit_v2_simplified_instance(self):
-        self._require_ck_lib()
-        tmpl = self._ck_tile.CKTileGemmTemplate
-        code = object.__new__(tmpl).emit_ck_instance(
-            self._sample_ck_tile_op(), use_v2_api=True
+    @parametrize("epilogue", ("Default", "CShuffle"))
+    def test_emit_v2_simplified_instance(self, epilogue):
+        code = self._make_template().emit_ck_instance(
+            self._find_ck_tile_op(epilogue=epilogue), use_v2_api=True
         )
-        self.assertNotIn("TailHandler", code)
         self.assertNotIn("has_hot_loop_v", code)
+        self.assertNotIn("BaseGemmPipeline", code)
         self.assertIn(
             "using Kernel = ck_tile::GemmKernel<TilePartitioner, GemmPipeline, GemmEpilogue>;",
             code,
@@ -726,8 +819,8 @@ struct UniversalGemmPipelineProblem
         code = tmpl._template_from_string(tmpl.gemm_kernel_launch).render(
             instance_namespace="test_ns", use_v2_api=False
         )
-        self.assertIn("TailHandler", code)
-        self.assertIn("filter_op", code)
+        self.assertIn("BaseGemmPipeline::TailHandler", code)
+        self.assertIn("has_hot_loop_v", code)
 
     def test_kernel_launch_v2_no_tail_handler(self):
         tmpl = self._ck_tile.CKTileGemmTemplate
@@ -735,7 +828,49 @@ struct UniversalGemmPipelineProblem
             instance_namespace="test_ns", use_v2_api=True
         )
         self.assertNotIn("TailHandler", code)
-        self.assertIn("kBlockPerCU", code)
+        self.assertNotIn("BaseGemmPipeline", code)
+        self.assertIn("Kernel::GridSize", code)
+
+    @parametrize("use_v2_api", (True, False))
+    def test_cshuffle_epilogue_offered_only_with_v2_api(self, use_v2_api):
+        """
+        Pre-change ck_tile cannot compile the CShuffle epilogue we emit, so those
+        instances must not reach autotuning and burn a compile each.
+        """
+        template = self._make_template()
+        with (
+            config.patch({"rocm.ck_tile_max_profiling_configs": None}),
+            patch.object(
+                self._ck_tile,
+                "_ck_tile_universal_gemm_v2_api",
+                lambda *_: use_v2_api,
+            ),
+        ):
+            epilogues = {op.epilogue for op in template.gen_ops()}
+        self.assertIn("Default", epilogues)
+        self.assertEqual("CShuffle" in epilogues, use_v2_api)
+
+    @parametrize("pipeline", ("CompV3", "CompV4", "Mem"))
+    @parametrize("epilogue", ("Default", "CShuffle"))
+    def test_offered_instance_compiles(self, epilogue, pipeline):
+        """
+        Every instance filter_op accepts must compile against the ck_tile headers
+        installed on this host, whichever universal GEMM API they expose.
+        """
+        template = self._make_template()
+        op = self._find_ck_tile_op(pipeline=pipeline, epilogue=epilogue)
+        if template.filter_op(op) is None:
+            raise unittest.SkipTest(f"{pipeline}/{epilogue} not offered on this ROCm")
+        use_v2_api = self._probe(config.rocm.rocm_home)
+        self._compile_ck_tile_source(
+            "\n".join(
+                [
+                    template.header().getvalue(),
+                    template.globals().getvalue(),
+                    template.emit_ck_instance(op, use_v2_api=use_v2_api),
+                ]
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_ck_backend.py
+++ b/test/inductor/test_ck_backend.py
@@ -1,6 +1,9 @@
 # Owner(s): ["module: inductor"]
+import contextlib
 import logging
 import os
+import shlex
+import subprocess
 import tempfile
 import unittest
 from unittest.mock import patch
@@ -13,6 +16,7 @@ except ImportError:
 
 import torch
 from torch._inductor import config
+from torch._inductor.ir import Buffer, FixedLayout
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import try_import_ck_lib
 from torch.testing import FileCheck
@@ -562,49 +566,7 @@ class TestCKBackend(TestCase):
             torch.testing.assert_close(Y_compiled, Y_eager)
 
 
-@unittest.skipIf(not torch.version.hip, "ROCM only")
-class TestCKTileUniversalGemmTemplate(TestCase):
-    _MODULE = "torch._inductor.codegen.rocm.ck_tile_universal_gemm_template"
-
-    def setUp(self):
-        super().setUp()
-        from torch._inductor.codegen.rocm import ck_tile_universal_gemm_template
-
-        self._ck_tile = ck_tile_universal_gemm_template
-        # _ck_tile_universal_gemm_v2_api is functools.cache'd on rocm_home.
-        self._ck_tile._ck_tile_universal_gemm_v2_api.cache_clear()
-
-    def _require_ck_lib(self):
-        ck_dir, _, _, _ = try_import_ck_lib()
-        if not ck_dir:
-            raise unittest.SkipTest("Composable Kernel library is not installed")
-
-    def _sample_ck_tile_op(self):
-        ck_ops = self._ck_tile.ops()
-        self.assertTrue(len(ck_ops) > 0, "expected CK-Tile gemm ops to be defined")
-        return ck_ops[0]
-
-    def _write_pipeline_header(self, rocm_home: str, body: str) -> None:
-        header_dir = os.path.join(
-            rocm_home,
-            "include",
-            os.path.dirname(self._ck_tile._CK_TILE_PIPELINE_PROBLEM_HEADER),
-        )
-        os.makedirs(header_dir, exist_ok=True)
-        with open(
-            os.path.join(
-                header_dir,
-                os.path.basename(self._ck_tile._CK_TILE_PIPELINE_PROBLEM_HEADER),
-            ),
-            "w",
-        ) as f:
-            f.write(body)
-
-    def test_header_probe_legacy_api(self):
-        with tempfile.TemporaryDirectory() as rocm_home:
-            self._write_pipeline_header(
-                rocm_home,
-                """
+_LEGACY_PIPELINE_HEADER = """
 template <typename ADataType_,
           typename BDataType_,
           typename CDataType_,
@@ -620,15 +582,9 @@ template <typename ADataType_,
 struct UniversalGemmPipelineProblem
 {
 };
-""",
-            )
-            self.assertFalse(self._ck_tile._ck_tile_universal_gemm_v2_api(rocm_home))
+"""
 
-    def test_header_probe_v2_api(self):
-        with tempfile.TemporaryDirectory() as rocm_home:
-            self._write_pipeline_header(
-                rocm_home,
-                """
+_V2_PIPELINE_HEADER = """
 template <typename AsDataType_,
           typename BsDataType_,
           typename EDataType_,
@@ -645,9 +601,153 @@ template <typename AsDataType_,
 struct UniversalGemmPipelineProblem
 {
 };
-""",
+"""
+
+
+@instantiate_parametrized_tests
+@unittest.skipIf(not torch.version.hip, "ROCM only")
+class TestCKTileUniversalGemmTemplate(TestCase):
+    _MODULE = "torch._inductor.codegen.rocm.ck_tile_universal_gemm_template"
+
+    def setUp(self):
+        super().setUp()
+        from torch._inductor.codegen.rocm import ck_tile_universal_gemm_template
+
+        self._ck_tile = ck_tile_universal_gemm_template
+        # _ck_tile_universal_gemm_v2_api is functools.cache'd on the search path.
+        self._ck_tile._ck_tile_universal_gemm_v2_api.cache_clear()
+
+    # ops() names the half-precision instances "FP16", but _TORCH_DTYPE_TO_CK maps
+    # torch.float16 to "F16", so check_dtypes never matches them. bfloat16 is the
+    # only dtype for which CK-Tile instances are currently reachable.
+    _DTYPE = torch.bfloat16
+    _CK_DTYPE = "BF16"
+
+    def _make_template(self, m=2048, n=2048, k=2048):
+        device = torch.device("cuda")
+        X = Buffer(name="X", layout=FixedLayout(device, self._DTYPE, [m, k]))
+        W = Buffer(name="W", layout=FixedLayout(device, self._DTYPE, [k, n]))
+        return self._ck_tile.CKTileGemmTemplate(
+            [X, W], FixedLayout(device, self._DTYPE, [m, n])
+        )
+
+    def _find_ck_tile_op(self, pipeline="CompV3", epilogue="Default"):
+        for op in self._ck_tile.ops():
+            if (
+                (op.pipeline, op.epilogue) == (pipeline, epilogue)
+                and (op.layout_a, op.layout_b, op.layout_c) == ("Row", "Row", "Row")
+                and op.datatype_a == self._CK_DTYPE
+            ):
+                return op
+        raise AssertionError(f"no CK-Tile gemm op for {pipeline=} {epilogue=}")
+
+    def _compile_ck_tile_source(self, source: str) -> None:
+        from torch._inductor.codegen.rocm.compile_command import rocm_compile_command
+
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("ROCm device required to select --offload-arch")
+        arch = torch.cuda.get_device_properties(0).gcnArchName.split(":")[0]
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            src_path = os.path.join(tmp_dir, "instance.hip")
+            with open(src_path, "w") as f:
+                f.write(source)
+            with config.patch({"rocm.arch": [arch]}):
+                cmd = rocm_compile_command(
+                    [src_path],
+                    os.path.join(tmp_dir, "instance.o"),
+                    "o",
+                    ["-fsyntax-only"],
+                )
+            result = subprocess.run(
+                shlex.split(cmd), capture_output=True, text=True, check=False
             )
-            self.assertTrue(self._ck_tile._ck_tile_universal_gemm_v2_api(rocm_home))
+        if result.returncode != 0:
+            self.fail(f"{cmd}\n{result.stdout}\n{result.stderr}")
+
+    def _write_pipeline_header(self, include_root: str, body: str) -> None:
+        header_dir = os.path.join(
+            include_root,
+            "include",
+            os.path.dirname(self._ck_tile._CK_TILE_PIPELINE_PROBLEM_HEADER),
+        )
+        os.makedirs(header_dir, exist_ok=True)
+        with open(
+            os.path.join(
+                header_dir,
+                os.path.basename(self._ck_tile._CK_TILE_PIPELINE_PROBLEM_HEADER),
+            ),
+            "w",
+        ) as f:
+            f.write(body)
+
+    @contextlib.contextmanager
+    def _probe_env(self, rocm_home_header=None, ck_dir_header=None):
+        """
+        A fake ROCm install plus an empty CK directory, so that the header the
+        probe picks is determined by the test rather than by the environment.
+        """
+        with (
+            tempfile.TemporaryDirectory() as rocm_home,
+            tempfile.TemporaryDirectory() as ck_dir,
+        ):
+            if rocm_home_header is not None:
+                self._write_pipeline_header(rocm_home, rocm_home_header)
+            if ck_dir_header is not None:
+                self._write_pipeline_header(ck_dir, ck_dir_header)
+            with config.patch({"rocm.ck_dir": ck_dir}):
+                yield rocm_home
+
+    def _probe(self, rocm_home):
+        return self._ck_tile._ck_tile_universal_gemm_v2_api(
+            rocm_home, config.rocm.ck_dir
+        )
+
+    def test_header_probe_legacy_api(self):
+        with self._probe_env(rocm_home_header=_LEGACY_PIPELINE_HEADER) as rocm_home:
+            self.assertFalse(self._probe(rocm_home))
+
+    def test_header_probe_v2_api(self):
+        with self._probe_env(rocm_home_header=_V2_PIPELINE_HEADER) as rocm_home:
+            self.assertTrue(self._probe(rocm_home))
+
+    def test_header_probe_prefers_ck_dir_over_rocm_home(self):
+        """
+        The compiler searches the CK directory before $ROCM_HOME, so the probe
+        has to resolve the header the same way.
+        """
+        with self._probe_env(
+            rocm_home_header=_LEGACY_PIPELINE_HEADER,
+            ck_dir_header=_V2_PIPELINE_HEADER,
+        ) as rocm_home:
+            self.assertTrue(self._probe(rocm_home))
+
+    def test_header_probe_on_installed_header(self):
+        """
+        The synthetic headers above cannot catch the probe silently failing to
+        classify the real thing, which is how this shipped broken once already.
+        """
+        header_path = self._ck_tile._find_ck_tile_header(
+            config.rocm.rocm_home, config.rocm.ck_dir
+        )
+        if header_path is None:
+            raise unittest.SkipTest("ck_tile headers are not installed")
+        with open(header_path) as f:
+            header_text = f.read()
+        self.assertIsNotNone(
+            self._ck_tile._header_has_v2_universal_gemm_pipeline(header_text),
+            f"could not classify the universal GEMM API in {header_path}",
+        )
+
+    def test_header_probe_handles_long_template_clause(self):
+        padding = "".join(f"          typename Unused{i}_ = void,\n" for i in range(64))
+        header_text = _V2_PIPELINE_HEADER.replace(
+            "          typename AElementWise_",
+            padding + "          typename AElementWise_",
+        )
+        self.assertTrue(
+            self._ck_tile._header_has_v2_universal_gemm_pipeline(header_text)
+        )
 
     def test_header_probe_does_not_use_later_flatmm_signature(self):
         header_text = """
@@ -681,48 +781,41 @@ struct FlatmmPipelineProblem
 
     @patch(f"{_MODULE}.torch.version.hip", "7.14.0")
     def test_header_probe_fallback_v2_when_header_missing(self):
-        with tempfile.TemporaryDirectory() as rocm_home:
-            self.assertTrue(self._ck_tile._ck_tile_universal_gemm_v2_api(rocm_home))
+        with self._probe_env() as rocm_home:
+            self.assertTrue(self._probe(rocm_home))
 
     @patch(f"{_MODULE}.torch.version.hip", "7.2.0")
     def test_header_probe_fallback_v1_when_header_missing(self):
-        with tempfile.TemporaryDirectory() as rocm_home:
-            self.assertFalse(self._ck_tile._ck_tile_universal_gemm_v2_api(rocm_home))
+        with self._probe_env() as rocm_home:
+            self.assertFalse(self._probe(rocm_home))
 
     @patch(f"{_MODULE}.torch.version.hip", "7.14.0")
     def test_header_probe_fallback_v2_when_header_unrecognized(self):
-        with tempfile.TemporaryDirectory() as rocm_home:
-            self._write_pipeline_header(
-                rocm_home,
-                """
-struct UniversalGemmPipelineProblem
-{
-};
-""",
-            )
-            self.assertTrue(self._ck_tile._ck_tile_universal_gemm_v2_api(rocm_home))
+        header = "struct UniversalGemmPipelineProblem\n{\n};\n"
+        with self._probe_env(rocm_home_header=header) as rocm_home:
+            self.assertTrue(self._probe(rocm_home))
 
-    def test_emit_v1_legacy_instance(self):
-        self._require_ck_lib()
-        tmpl = self._ck_tile.CKTileGemmTemplate
-        code = object.__new__(tmpl).emit_ck_instance(
-            self._sample_ck_tile_op(), use_v2_api=False
+    @patch(f"{_MODULE}.torch.version.hip", "7.rc1")
+    def test_header_probe_fallback_tolerates_malformed_hip_version(self):
+        with self._probe_env() as rocm_home:
+            self.assertFalse(self._probe(rocm_home))
+
+    @parametrize("epilogue", ("Default", "CShuffle"))
+    def test_emit_v1_legacy_instance(self, epilogue):
+        code = self._make_template().emit_ck_instance(
+            self._find_ck_tile_op(epilogue=epilogue), use_v2_api=False
         )
         self.assertIn("has_hot_loop_v", code)
         self.assertIn("GemmPipelineProblem", code)
-        self.assertNotIn(
-            "using Kernel = ck_tile::GemmKernel<TilePartitioner, GemmPipeline, GemmEpilogue>;",
-            code,
-        )
+        self.assertIn("BaseGemmPipeline", code)
 
-    def test_emit_v2_simplified_instance(self):
-        self._require_ck_lib()
-        tmpl = self._ck_tile.CKTileGemmTemplate
-        code = object.__new__(tmpl).emit_ck_instance(
-            self._sample_ck_tile_op(), use_v2_api=True
+    @parametrize("epilogue", ("Default", "CShuffle"))
+    def test_emit_v2_simplified_instance(self, epilogue):
+        code = self._make_template().emit_ck_instance(
+            self._find_ck_tile_op(epilogue=epilogue), use_v2_api=True
         )
-        self.assertNotIn("TailHandler", code)
         self.assertNotIn("has_hot_loop_v", code)
+        self.assertNotIn("BaseGemmPipeline", code)
         self.assertIn(
             "using Kernel = ck_tile::GemmKernel<TilePartitioner, GemmPipeline, GemmEpilogue>;",
             code,
@@ -733,8 +826,8 @@ struct UniversalGemmPipelineProblem
         code = tmpl._template_from_string(tmpl.gemm_kernel_launch).render(
             instance_namespace="test_ns", use_v2_api=False
         )
-        self.assertIn("TailHandler", code)
-        self.assertIn("filter_op", code)
+        self.assertIn("BaseGemmPipeline::TailHandler", code)
+        self.assertIn("has_hot_loop_v", code)
 
     def test_kernel_launch_v2_no_tail_handler(self):
         tmpl = self._ck_tile.CKTileGemmTemplate
@@ -742,7 +835,49 @@ struct UniversalGemmPipelineProblem
             instance_namespace="test_ns", use_v2_api=True
         )
         self.assertNotIn("TailHandler", code)
-        self.assertIn("kBlockPerCU", code)
+        self.assertNotIn("BaseGemmPipeline", code)
+        self.assertIn("Kernel::GridSize", code)
+
+    @parametrize("use_v2_api", (True, False))
+    def test_cshuffle_epilogue_offered_only_with_v2_api(self, use_v2_api):
+        """
+        Pre-change ck_tile cannot compile the CShuffle epilogue we emit, so those
+        instances must not reach autotuning and burn a compile each.
+        """
+        template = self._make_template()
+        with (
+            config.patch({"rocm.ck_tile_max_profiling_configs": None}),
+            patch.object(
+                self._ck_tile,
+                "_ck_tile_universal_gemm_v2_api",
+                lambda *_: use_v2_api,
+            ),
+        ):
+            epilogues = {op.epilogue for op in template.gen_ops()}
+        self.assertIn("Default", epilogues)
+        self.assertEqual("CShuffle" in epilogues, use_v2_api)
+
+    @parametrize("pipeline", ("CompV3", "CompV4", "Mem"))
+    @parametrize("epilogue", ("Default", "CShuffle"))
+    def test_offered_instance_compiles(self, epilogue, pipeline):
+        """
+        Every instance filter_op accepts must compile against the ck_tile headers
+        installed on this host, whichever universal GEMM API they expose.
+        """
+        template = self._make_template()
+        op = self._find_ck_tile_op(pipeline=pipeline, epilogue=epilogue)
+        if template.filter_op(op) is None:
+            raise unittest.SkipTest(f"{pipeline}/{epilogue} not offered on this ROCm")
+        use_v2_api = self._probe(config.rocm.rocm_home)
+        self._compile_ck_tile_source(
+            "\n".join(
+                [
+                    template.header().getvalue(),
+                    template.globals().getvalue(),
+                    template.emit_ck_instance(op, use_v2_api=use_v2_api),
+                ]
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_ck_backend.py
+++ b/test/inductor/test_ck_backend.py
@@ -553,6 +553,123 @@ class TestCKBackend(TestCase):
             torch.testing.assert_close(Y_compiled, Y_eager)
 
 
+@unittest.skipIf(not torch.version.hip, "ROCM only")
+class TestCKTileUniversalGemmTemplate(TestCase):
+    _MODULE = "torch._inductor.codegen.rocm.ck_tile_universal_gemm_template"
+
+    def setUp(self):
+        super().setUp()
+        from torch._inductor.codegen.rocm import ck_tile_universal_gemm_template
+
+        self._ck_tile = ck_tile_universal_gemm_template
+        self._ck_tile._ck_tile_universal_gemm_v2_api.cache_clear()
+
+    def _write_pipeline_header(self, rocm_home: str, body: str) -> None:
+        header_dir = os.path.join(
+            rocm_home,
+            "include",
+            os.path.dirname(self._ck_tile._CK_TILE_PIPELINE_PROBLEM_HEADER),
+        )
+        os.makedirs(header_dir, exist_ok=True)
+        with open(
+            os.path.join(
+                header_dir,
+                os.path.basename(self._ck_tile._CK_TILE_PIPELINE_PROBLEM_HEADER),
+            ),
+            "w",
+        ) as f:
+            f.write(body)
+
+    def test_header_probe_legacy_api(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as rocm_home:
+            self._write_pipeline_header(
+                rocm_home,
+                """
+struct UniversalGemmPipelineProblem
+{
+    template<typename ADataType_,
+             typename BDataType_,
+             typename AccDataType_,
+             typename GemmShape_,
+             typename GemmUniversalTraits_,
+             ck_tile::GemmPipelineScheduler Scheduler_,
+             bool HasHotLoop_    = true,
+             ck_tile::TailNumber TailNum_ = ck_tile::TailNumber::Full>
+    {};
+""",
+            )
+            self.assertFalse(self._ck_tile._ck_tile_universal_gemm_v2_api(rocm_home))
+
+    def test_header_probe_v2_api(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as rocm_home:
+            self._write_pipeline_header(
+                rocm_home,
+                """
+struct UniversalGemmPipelineProblem
+{
+    template<typename ADataType_,
+             typename BDataType_,
+             typename AccDataType_,
+             typename GemmShape_,
+             typename GemmUniversalTraits_,
+             ck_tile::GemmPipelineScheduler Scheduler_,
+             typename AElementWise_ = ck_tile::element_wise::PassThrough,
+             bool HasHotLoop_    = true,
+             ck_tile::TailNumber TailNum_ = ck_tile::TailNumber::Full>
+    {};
+""",
+            )
+            self.assertTrue(self._ck_tile._ck_tile_universal_gemm_v2_api(rocm_home))
+
+    def test_emit_v1_legacy_instance(self):
+        from unittest.mock import patch
+
+        tmpl = self._ck_tile.CKTileGemmTemplate
+        with patch(
+            f"{self._MODULE}._ck_tile_universal_gemm_v2_api", return_value=False
+        ):
+            code = object.__new__(tmpl).emit_ck_instance(self._ck_tile.ops()[0])
+        self.assertIn("has_hot_loop_v", code)
+        self.assertIn("GemmPipelineProblem", code)
+        self.assertNotIn(
+            "using Kernel = ck_tile::GemmKernel<TilePartitioner, GemmPipeline, GemmEpilogue>;",
+            code,
+        )
+
+    def test_emit_v2_simplified_instance(self):
+        from unittest.mock import patch
+
+        tmpl = self._ck_tile.CKTileGemmTemplate
+        with patch(f"{self._MODULE}._ck_tile_universal_gemm_v2_api", return_value=True):
+            code = object.__new__(tmpl).emit_ck_instance(self._ck_tile.ops()[0])
+        self.assertNotIn("TailHandler", code)
+        self.assertNotIn("has_hot_loop_v", code)
+        self.assertIn(
+            "using Kernel = ck_tile::GemmKernel<TilePartitioner, GemmPipeline, GemmEpilogue>;",
+            code,
+        )
+
+    def test_kernel_launch_v1_has_tail_handler(self):
+        tmpl = self._ck_tile.CKTileGemmTemplate
+        code = tmpl._template_from_string(tmpl.gemm_kernel_launch).render(
+            instance_namespace="test_ns", use_v2_api=False
+        )
+        self.assertIn("TailHandler", code)
+        self.assertIn("filter_op", code)
+
+    def test_kernel_launch_v2_no_tail_handler(self):
+        tmpl = self._ck_tile.CKTileGemmTemplate
+        code = tmpl._template_from_string(tmpl.gemm_kernel_launch).render(
+            instance_namespace="test_ns", use_v2_api=True
+        )
+        self.assertNotIn("TailHandler", code)
+        self.assertIn("kBlockPerCU", code)
+
+
 if __name__ == "__main__":
     from torch._inductor.utils import is_big_gpu
 

--- a/test/inductor/test_ck_backend.py
+++ b/test/inductor/test_ck_backend.py
@@ -569,7 +569,13 @@ class TestCKTileUniversalGemmTemplate(TestCase):
         from torch._inductor.codegen.rocm import ck_tile_universal_gemm_template
 
         self._ck_tile = ck_tile_universal_gemm_template
+        # _ck_tile_universal_gemm_v2_api is functools.cache'd on rocm_home.
         self._ck_tile._ck_tile_universal_gemm_v2_api.cache_clear()
+
+    def _sample_ck_tile_op(self):
+        ck_ops = self._ck_tile.ops()
+        self.assertTrue(len(ck_ops) > 0, "expected CK-Tile gemm ops to be defined")
+        return ck_ops[0]
 
     def _write_pipeline_header(self, rocm_home: str, body: str) -> None:
         header_dir = os.path.join(
@@ -639,7 +645,7 @@ struct UniversalGemmPipelineProblem
         with patch(
             f"{self._MODULE}._ck_tile_universal_gemm_v2_api", return_value=False
         ):
-            code = object.__new__(tmpl).emit_ck_instance(self._ck_tile.ops()[0])
+            code = object.__new__(tmpl).emit_ck_instance(self._sample_ck_tile_op())
         self.assertIn("has_hot_loop_v", code)
         self.assertIn("GemmPipelineProblem", code)
         self.assertNotIn(
@@ -652,7 +658,7 @@ struct UniversalGemmPipelineProblem
 
         tmpl = self._ck_tile.CKTileGemmTemplate
         with patch(f"{self._MODULE}._ck_tile_universal_gemm_v2_api", return_value=True):
-            code = object.__new__(tmpl).emit_ck_instance(self._ck_tile.ops()[0])
+            code = object.__new__(tmpl).emit_ck_instance(self._sample_ck_tile_op())
         self.assertNotIn("TailHandler", code)
         self.assertNotIn("has_hot_loop_v", code)
         self.assertIn(

--- a/test/inductor/test_ck_backend.py
+++ b/test/inductor/test_ck_backend.py
@@ -1,7 +1,9 @@
 # Owner(s): ["module: inductor"]
 import logging
 import os
+import tempfile
 import unittest
+from unittest.mock import patch
 
 
 try:
@@ -565,6 +567,11 @@ class TestCKTileUniversalGemmTemplate(TestCase):
         # _ck_tile_universal_gemm_v2_api is functools.cache'd on rocm_home.
         self._ck_tile._ck_tile_universal_gemm_v2_api.cache_clear()
 
+    def _require_ck_lib(self):
+        ck_dir, _, _, _ = try_import_ck_lib()
+        if not ck_dir:
+            raise unittest.SkipTest("Composable Kernel library is not installed")
+
     def _sample_ck_tile_op(self):
         ck_ops = self._ck_tile.ops()
         self.assertTrue(len(ck_ops) > 0, "expected CK-Tile gemm ops to be defined")
@@ -587,58 +594,113 @@ class TestCKTileUniversalGemmTemplate(TestCase):
             f.write(body)
 
     def test_header_probe_legacy_api(self):
-        import tempfile
-
         with tempfile.TemporaryDirectory() as rocm_home:
             self._write_pipeline_header(
                 rocm_home,
                 """
+template <typename ADataType_,
+          typename BDataType_,
+          typename CDataType_,
+          typename BlockGemmShape_,
+          typename Traits_,
+          GemmPipelineScheduler Scheduler_ = GemmPipelineScheduler::Intrawave,
+          bool HasHotLoop_                 = true,
+          TailNumber TailNum_              = TailNumber::Full,
+          typename ComputeDataType_        = ADataType_,
+          bool FixedVectorSize_            = false,
+          index_t VectorSizeA_             = 1,
+          index_t VectorSizeB_             = 1>
 struct UniversalGemmPipelineProblem
 {
-    template<typename ADataType_,
-             typename BDataType_,
-             typename AccDataType_,
-             typename GemmShape_,
-             typename GemmUniversalTraits_,
-             ck_tile::GemmPipelineScheduler Scheduler_,
-             bool HasHotLoop_    = true,
-             ck_tile::TailNumber TailNum_ = ck_tile::TailNumber::Full>
-    {};
+};
 """,
             )
             self.assertFalse(self._ck_tile._ck_tile_universal_gemm_v2_api(rocm_home))
 
     def test_header_probe_v2_api(self):
-        import tempfile
+        with tempfile.TemporaryDirectory() as rocm_home:
+            self._write_pipeline_header(
+                rocm_home,
+                """
+template <typename AsDataType_,
+          typename BsDataType_,
+          typename EDataType_,
+          typename BlockGemmShape_,
+          typename Traits_,
+          GemmPipelineScheduler Scheduler_ = GemmPipelineScheduler::Intrawave,
+          typename AElementWise_           = ck_tile::element_wise::PassThrough,
+          typename BElementWise_           = ck_tile::element_wise::PassThrough,
+          typename AComputeDataType_       = AsDataType_,
+          typename BComputeDataType_       = BsDataType_,
+          bool FixedVectorSize_            = false,
+          index_t VectorSizeA_             = 1,
+          index_t VectorSizeB_             = 1>
+struct UniversalGemmPipelineProblem
+{
+};
+""",
+            )
+            self.assertTrue(self._ck_tile._ck_tile_universal_gemm_v2_api(rocm_home))
 
+    def test_header_probe_does_not_use_later_flatmm_signature(self):
+        header_text = """
+template <typename AsDataType_,
+          typename BsDataType_,
+          typename EDataType_,
+          typename BlockGemmShape_,
+          typename Traits_,
+          GemmPipelineScheduler Scheduler_ = GemmPipelineScheduler::Intrawave,
+          typename AElementWise_           = ck_tile::element_wise::PassThrough,
+          typename BElementWise_           = ck_tile::element_wise::PassThrough>
+struct UniversalGemmPipelineProblem
+{
+};
+
+template <typename ADataType_,
+          typename BDataType_,
+          typename CDataType_,
+          typename BlockGemmShape_,
+          typename Traits_,
+          GemmPipelineScheduler Scheduler_ = GemmPipelineScheduler::Intrawave,
+          bool HasHotLoop_                 = true,
+          TailNumber TailNum_              = TailNumber::Full>
+struct FlatmmPipelineProblem
+{
+};
+"""
+        self.assertTrue(
+            self._ck_tile._header_has_v2_universal_gemm_pipeline(header_text)
+        )
+
+    @patch(f"{_MODULE}.torch.version.hip", "7.14.0")
+    def test_header_probe_fallback_v2_when_header_missing(self):
+        with tempfile.TemporaryDirectory() as rocm_home:
+            self.assertTrue(self._ck_tile._ck_tile_universal_gemm_v2_api(rocm_home))
+
+    @patch(f"{_MODULE}.torch.version.hip", "7.2.0")
+    def test_header_probe_fallback_v1_when_header_missing(self):
+        with tempfile.TemporaryDirectory() as rocm_home:
+            self.assertFalse(self._ck_tile._ck_tile_universal_gemm_v2_api(rocm_home))
+
+    @patch(f"{_MODULE}.torch.version.hip", "7.14.0")
+    def test_header_probe_fallback_v2_when_header_unrecognized(self):
         with tempfile.TemporaryDirectory() as rocm_home:
             self._write_pipeline_header(
                 rocm_home,
                 """
 struct UniversalGemmPipelineProblem
 {
-    template<typename ADataType_,
-             typename BDataType_,
-             typename AccDataType_,
-             typename GemmShape_,
-             typename GemmUniversalTraits_,
-             ck_tile::GemmPipelineScheduler Scheduler_,
-             typename AElementWise_ = ck_tile::element_wise::PassThrough,
-             bool HasHotLoop_    = true,
-             ck_tile::TailNumber TailNum_ = ck_tile::TailNumber::Full>
-    {};
+};
 """,
             )
             self.assertTrue(self._ck_tile._ck_tile_universal_gemm_v2_api(rocm_home))
 
     def test_emit_v1_legacy_instance(self):
-        from unittest.mock import patch
-
+        self._require_ck_lib()
         tmpl = self._ck_tile.CKTileGemmTemplate
-        with patch(
-            f"{self._MODULE}._ck_tile_universal_gemm_v2_api", return_value=False
-        ):
-            code = object.__new__(tmpl).emit_ck_instance(self._sample_ck_tile_op())
+        code = object.__new__(tmpl).emit_ck_instance(
+            self._sample_ck_tile_op(), use_v2_api=False
+        )
         self.assertIn("has_hot_loop_v", code)
         self.assertIn("GemmPipelineProblem", code)
         self.assertNotIn(
@@ -647,11 +709,11 @@ struct UniversalGemmPipelineProblem
         )
 
     def test_emit_v2_simplified_instance(self):
-        from unittest.mock import patch
-
+        self._require_ck_lib()
         tmpl = self._ck_tile.CKTileGemmTemplate
-        with patch(f"{self._MODULE}._ck_tile_universal_gemm_v2_api", return_value=True):
-            code = object.__new__(tmpl).emit_ck_instance(self._sample_ck_tile_op())
+        code = object.__new__(tmpl).emit_ck_instance(
+            self._sample_ck_tile_op(), use_v2_api=True
+        )
         self.assertNotIn("TailHandler", code)
         self.assertNotIn("has_hot_loop_v", code)
         self.assertIn(

--- a/test/inductor/test_ck_backend.py
+++ b/test/inductor/test_ck_backend.py
@@ -806,7 +806,9 @@ struct FlatmmPipelineProblem
             self._find_ck_tile_op(epilogue=epilogue), use_v2_api=False
         )
         self.assertIn("has_hot_loop_v", code)
-        self.assertIn("GemmPipelineProblem", code)
+        # "GemmPipelineProblem" alone would also match "UniversalGemmPipelineProblem",
+        # which both API variants emit.
+        self.assertIn("ck_tile::GemmPipelineProblem<", code)
         self.assertIn("BaseGemmPipeline", code)
 
     @parametrize("epilogue", ("Default", "CShuffle"))
@@ -864,6 +866,9 @@ struct FlatmmPipelineProblem
         Every instance filter_op accepts must compile against the ck_tile headers
         installed on this host, whichever universal GEMM API they expose.
         """
+        rocm = config.rocm
+        if self._ck_tile._find_ck_tile_header(rocm.rocm_home, rocm.ck_dir) is None:
+            raise unittest.SkipTest("ck_tile headers are not installed")
         template = self._make_template()
         op = self._find_ck_tile_op(pipeline=pipeline, epilogue=epilogue)
         if template.filter_op(op) is None:

--- a/test/inductor/test_ck_backend.py
+++ b/test/inductor/test_ck_backend.py
@@ -77,7 +77,7 @@ class TestCKBackend(TestCase):
         "max_autotune_gemm_backends",
         (
             subtest("CK", decorators=[skipIfRocmVersionAtLeast([7, 14])]),
-            subtest("CKTILE", decorators=[skipIfRocmVersionAtLeast([7, 14])]),
+            "CKTILE",
             "ATen,CK",
         ),
         name_fn=lambda b: {

--- a/test/inductor/test_ck_backend.py
+++ b/test/inductor/test_ck_backend.py
@@ -1,7 +1,9 @@
 # Owner(s): ["module: inductor"]
 import logging
 import os
+import tempfile
 import unittest
+from unittest.mock import patch
 
 
 try:
@@ -572,6 +574,11 @@ class TestCKTileUniversalGemmTemplate(TestCase):
         # _ck_tile_universal_gemm_v2_api is functools.cache'd on rocm_home.
         self._ck_tile._ck_tile_universal_gemm_v2_api.cache_clear()
 
+    def _require_ck_lib(self):
+        ck_dir, _, _, _ = try_import_ck_lib()
+        if not ck_dir:
+            raise unittest.SkipTest("Composable Kernel library is not installed")
+
     def _sample_ck_tile_op(self):
         ck_ops = self._ck_tile.ops()
         self.assertTrue(len(ck_ops) > 0, "expected CK-Tile gemm ops to be defined")
@@ -594,58 +601,113 @@ class TestCKTileUniversalGemmTemplate(TestCase):
             f.write(body)
 
     def test_header_probe_legacy_api(self):
-        import tempfile
-
         with tempfile.TemporaryDirectory() as rocm_home:
             self._write_pipeline_header(
                 rocm_home,
                 """
+template <typename ADataType_,
+          typename BDataType_,
+          typename CDataType_,
+          typename BlockGemmShape_,
+          typename Traits_,
+          GemmPipelineScheduler Scheduler_ = GemmPipelineScheduler::Intrawave,
+          bool HasHotLoop_                 = true,
+          TailNumber TailNum_              = TailNumber::Full,
+          typename ComputeDataType_        = ADataType_,
+          bool FixedVectorSize_            = false,
+          index_t VectorSizeA_             = 1,
+          index_t VectorSizeB_             = 1>
 struct UniversalGemmPipelineProblem
 {
-    template<typename ADataType_,
-             typename BDataType_,
-             typename AccDataType_,
-             typename GemmShape_,
-             typename GemmUniversalTraits_,
-             ck_tile::GemmPipelineScheduler Scheduler_,
-             bool HasHotLoop_    = true,
-             ck_tile::TailNumber TailNum_ = ck_tile::TailNumber::Full>
-    {};
+};
 """,
             )
             self.assertFalse(self._ck_tile._ck_tile_universal_gemm_v2_api(rocm_home))
 
     def test_header_probe_v2_api(self):
-        import tempfile
+        with tempfile.TemporaryDirectory() as rocm_home:
+            self._write_pipeline_header(
+                rocm_home,
+                """
+template <typename AsDataType_,
+          typename BsDataType_,
+          typename EDataType_,
+          typename BlockGemmShape_,
+          typename Traits_,
+          GemmPipelineScheduler Scheduler_ = GemmPipelineScheduler::Intrawave,
+          typename AElementWise_           = ck_tile::element_wise::PassThrough,
+          typename BElementWise_           = ck_tile::element_wise::PassThrough,
+          typename AComputeDataType_       = AsDataType_,
+          typename BComputeDataType_       = BsDataType_,
+          bool FixedVectorSize_            = false,
+          index_t VectorSizeA_             = 1,
+          index_t VectorSizeB_             = 1>
+struct UniversalGemmPipelineProblem
+{
+};
+""",
+            )
+            self.assertTrue(self._ck_tile._ck_tile_universal_gemm_v2_api(rocm_home))
 
+    def test_header_probe_does_not_use_later_flatmm_signature(self):
+        header_text = """
+template <typename AsDataType_,
+          typename BsDataType_,
+          typename EDataType_,
+          typename BlockGemmShape_,
+          typename Traits_,
+          GemmPipelineScheduler Scheduler_ = GemmPipelineScheduler::Intrawave,
+          typename AElementWise_           = ck_tile::element_wise::PassThrough,
+          typename BElementWise_           = ck_tile::element_wise::PassThrough>
+struct UniversalGemmPipelineProblem
+{
+};
+
+template <typename ADataType_,
+          typename BDataType_,
+          typename CDataType_,
+          typename BlockGemmShape_,
+          typename Traits_,
+          GemmPipelineScheduler Scheduler_ = GemmPipelineScheduler::Intrawave,
+          bool HasHotLoop_                 = true,
+          TailNumber TailNum_              = TailNumber::Full>
+struct FlatmmPipelineProblem
+{
+};
+"""
+        self.assertTrue(
+            self._ck_tile._header_has_v2_universal_gemm_pipeline(header_text)
+        )
+
+    @patch(f"{_MODULE}.torch.version.hip", "7.14.0")
+    def test_header_probe_fallback_v2_when_header_missing(self):
+        with tempfile.TemporaryDirectory() as rocm_home:
+            self.assertTrue(self._ck_tile._ck_tile_universal_gemm_v2_api(rocm_home))
+
+    @patch(f"{_MODULE}.torch.version.hip", "7.2.0")
+    def test_header_probe_fallback_v1_when_header_missing(self):
+        with tempfile.TemporaryDirectory() as rocm_home:
+            self.assertFalse(self._ck_tile._ck_tile_universal_gemm_v2_api(rocm_home))
+
+    @patch(f"{_MODULE}.torch.version.hip", "7.14.0")
+    def test_header_probe_fallback_v2_when_header_unrecognized(self):
         with tempfile.TemporaryDirectory() as rocm_home:
             self._write_pipeline_header(
                 rocm_home,
                 """
 struct UniversalGemmPipelineProblem
 {
-    template<typename ADataType_,
-             typename BDataType_,
-             typename AccDataType_,
-             typename GemmShape_,
-             typename GemmUniversalTraits_,
-             ck_tile::GemmPipelineScheduler Scheduler_,
-             typename AElementWise_ = ck_tile::element_wise::PassThrough,
-             bool HasHotLoop_    = true,
-             ck_tile::TailNumber TailNum_ = ck_tile::TailNumber::Full>
-    {};
+};
 """,
             )
             self.assertTrue(self._ck_tile._ck_tile_universal_gemm_v2_api(rocm_home))
 
     def test_emit_v1_legacy_instance(self):
-        from unittest.mock import patch
-
+        self._require_ck_lib()
         tmpl = self._ck_tile.CKTileGemmTemplate
-        with patch(
-            f"{self._MODULE}._ck_tile_universal_gemm_v2_api", return_value=False
-        ):
-            code = object.__new__(tmpl).emit_ck_instance(self._sample_ck_tile_op())
+        code = object.__new__(tmpl).emit_ck_instance(
+            self._sample_ck_tile_op(), use_v2_api=False
+        )
         self.assertIn("has_hot_loop_v", code)
         self.assertIn("GemmPipelineProblem", code)
         self.assertNotIn(
@@ -654,11 +716,11 @@ struct UniversalGemmPipelineProblem
         )
 
     def test_emit_v2_simplified_instance(self):
-        from unittest.mock import patch
-
+        self._require_ck_lib()
         tmpl = self._ck_tile.CKTileGemmTemplate
-        with patch(f"{self._MODULE}._ck_tile_universal_gemm_v2_api", return_value=True):
-            code = object.__new__(tmpl).emit_ck_instance(self._sample_ck_tile_op())
+        code = object.__new__(tmpl).emit_ck_instance(
+            self._sample_ck_tile_op(), use_v2_api=True
+        )
         self.assertNotIn("TailHandler", code)
         self.assertNotIn("has_hot_loop_v", code)
         self.assertIn(

--- a/test/inductor/test_ck_backend.py
+++ b/test/inductor/test_ck_backend.py
@@ -562,7 +562,13 @@ class TestCKTileUniversalGemmTemplate(TestCase):
         from torch._inductor.codegen.rocm import ck_tile_universal_gemm_template
 
         self._ck_tile = ck_tile_universal_gemm_template
+        # _ck_tile_universal_gemm_v2_api is functools.cache'd on rocm_home.
         self._ck_tile._ck_tile_universal_gemm_v2_api.cache_clear()
+
+    def _sample_ck_tile_op(self):
+        ck_ops = self._ck_tile.ops()
+        self.assertTrue(len(ck_ops) > 0, "expected CK-Tile gemm ops to be defined")
+        return ck_ops[0]
 
     def _write_pipeline_header(self, rocm_home: str, body: str) -> None:
         header_dir = os.path.join(
@@ -632,7 +638,7 @@ struct UniversalGemmPipelineProblem
         with patch(
             f"{self._MODULE}._ck_tile_universal_gemm_v2_api", return_value=False
         ):
-            code = object.__new__(tmpl).emit_ck_instance(self._ck_tile.ops()[0])
+            code = object.__new__(tmpl).emit_ck_instance(self._sample_ck_tile_op())
         self.assertIn("has_hot_loop_v", code)
         self.assertIn("GemmPipelineProblem", code)
         self.assertNotIn(
@@ -645,7 +651,7 @@ struct UniversalGemmPipelineProblem
 
         tmpl = self._ck_tile.CKTileGemmTemplate
         with patch(f"{self._MODULE}._ck_tile_universal_gemm_v2_api", return_value=True):
-            code = object.__new__(tmpl).emit_ck_instance(self._ck_tile.ops()[0])
+            code = object.__new__(tmpl).emit_ck_instance(self._sample_ck_tile_op())
         self.assertNotIn("TailHandler", code)
         self.assertNotIn("has_hot_loop_v", code)
         self.assertIn(

--- a/torch/_inductor/codegen/rocm/ck_tile_universal_gemm_template.py
+++ b/torch/_inductor/codegen/rocm/ck_tile_universal_gemm_template.py
@@ -23,18 +23,19 @@ log = logging.getLogger(__name__)
 
 _CK_TILE_PIPELINE_PROBLEM_HEADER = "ck_tile/ops/gemm/pipeline/gemm_pipeline_problem.hpp"
 _SCHEDULER_PARAM = "GemmPipelineScheduler Scheduler_"
+# ck_tile headers place Scheduler_ within a few KB of UniversalGemmPipelineProblem.
+_HEADER_SCHEDULER_MAX_DISTANCE = 4000
+# Enough to cover the template parameters immediately following Scheduler_.
+_HEADER_AFTER_SCHEDULER_WINDOW = 800
 
 
 def _ck_tile_rocm_include_dir(rocm_home: str | None) -> str | None:
     if rocm_home:
         return os.path.join(rocm_home, "include")
-    try:
-        from torch.utils import cpp_extension
+    from torch.utils import cpp_extension
 
-        if cpp_extension.ROCM_HOME:
-            return os.path.join(cpp_extension.ROCM_HOME, "include")
-    except Exception:
-        pass
+    if cpp_extension.ROCM_HOME:
+        return os.path.join(cpp_extension.ROCM_HOME, "include")
     rocm_home = os.environ.get("ROCM_HOME") or os.environ.get("ROCM_PATH")
     if rocm_home:
         return os.path.join(rocm_home, "include")
@@ -52,32 +53,18 @@ def _header_has_v2_universal_gemm_pipeline(header_text: str) -> bool | None:
         return None
 
     sched_pos = header_text.find(_SCHEDULER_PARAM, pos)
-    if sched_pos < 0 or sched_pos - pos > 4000:
+    if sched_pos < 0 or sched_pos - pos > _HEADER_SCHEDULER_MAX_DISTANCE:
         return None
 
-    after_scheduler = header_text[sched_pos : sched_pos + 800]
+    after_scheduler = header_text[
+        sched_pos : sched_pos + _HEADER_AFTER_SCHEDULER_WINDOW
+    ]
     elemwise_pos = after_scheduler.find("AElementWise_")
     hotloop_pos = after_scheduler.find("HasHotLoop_")
     if elemwise_pos >= 0 and (hotloop_pos < 0 or elemwise_pos < hotloop_pos):
         return True
     if hotloop_pos >= 0 and (elemwise_pos < 0 or hotloop_pos < elemwise_pos):
         return False
-    return None
-
-
-def _rocm_version_tuple() -> tuple[int, int] | None:
-    if torch.version.hip is not None:
-        return tuple(int(v) for v in torch.version.hip.split(".")[:2])  # type: ignore[return-value]
-
-    rocm_home = _ck_tile_rocm_include_dir(None)
-    if rocm_home is not None:
-        import re
-
-        match = re.search(
-            r"rocm[-/](\d+)\.(\d+)", os.path.dirname(rocm_home), re.IGNORECASE
-        )
-        if match:
-            return int(match.group(1)), int(match.group(2))
     return None
 
 
@@ -98,14 +85,17 @@ def _ck_tile_universal_gemm_v2_api(rocm_home: str | None) -> bool:
             header_v2 = _header_has_v2_universal_gemm_pipeline(header_text)
             if header_v2 is not None:
                 return header_v2
+            log.debug(
+                "Could not determine CK-Tile universal GEMM API from %s; "
+                "falling back to torch.version.hip",
+                header_path,
+            )
         except OSError:
             pass
 
     # torch.version.hip is the HIP version, conventionally aligned with ROCm.
-    rocm_version = _rocm_version_tuple()
-    if rocm_version is not None:
-        return rocm_version >= (7, 14)
-    return False
+    rocm_version = tuple(int(v) for v in torch.version.hip.split(".")[:2])
+    return rocm_version >= (7, 14)
 
 
 def is_static_int(number):

--- a/torch/_inductor/codegen/rocm/ck_tile_universal_gemm_template.py
+++ b/torch/_inductor/codegen/rocm/ck_tile_universal_gemm_template.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs, disable-error-code="attr-defined, valid-type"
 import functools
 import logging
+import os
 import random
 from collections import defaultdict
 from dataclasses import asdict, dataclass
@@ -20,13 +21,91 @@ from ...utils import IndentedBuffer
 log = logging.getLogger(__name__)
 
 
-def _ck_tile_universal_gemm_v2_api() -> bool:
-    # ROCm 7.14+ ck_tile headers use a simplified UniversalGemmPipelineProblem
-    # API (no has_hot_loop / tail_number template parameters).
+_CK_TILE_PIPELINE_PROBLEM_HEADER = "ck_tile/ops/gemm/pipeline/gemm_pipeline_problem.hpp"
+_SCHEDULER_PARAM = "GemmPipelineScheduler Scheduler_"
+
+
+def _ck_tile_rocm_include_dir(rocm_home: str | None) -> str | None:
+    if rocm_home:
+        return os.path.join(rocm_home, "include")
+    try:
+        from torch.utils import cpp_extension
+
+        if cpp_extension.ROCM_HOME:
+            return os.path.join(cpp_extension.ROCM_HOME, "include")
+    except Exception:
+        pass
+    rocm_home = os.environ.get("ROCM_HOME") or os.environ.get("ROCM_PATH")
+    if rocm_home:
+        return os.path.join(rocm_home, "include")
+    try:
+        from torch.utils.cpp_extension import _join_rocm_home
+
+        return _join_rocm_home("include")
+    except OSError:
+        return None
+
+
+def _header_has_v2_universal_gemm_pipeline(header_text: str) -> bool | None:
+    pos = header_text.find("UniversalGemmPipelineProblem")
+    if pos < 0:
+        return None
+
+    sched_pos = header_text.find(_SCHEDULER_PARAM, pos)
+    if sched_pos < 0 or sched_pos - pos > 4000:
+        return None
+
+    after_scheduler = header_text[sched_pos : sched_pos + 800]
+    elemwise_pos = after_scheduler.find("AElementWise_")
+    hotloop_pos = after_scheduler.find("HasHotLoop_")
+    if elemwise_pos >= 0 and (hotloop_pos < 0 or elemwise_pos < hotloop_pos):
+        return True
+    if hotloop_pos >= 0 and (elemwise_pos < 0 or hotloop_pos < elemwise_pos):
+        return False
+    return None
+
+
+def _rocm_version_tuple() -> tuple[int, int] | None:
+    if torch.version.hip is not None:
+        return tuple(int(v) for v in torch.version.hip.split(".")[:2])  # type: ignore[return-value]
+
+    rocm_home = _ck_tile_rocm_include_dir(None)
+    if rocm_home is not None:
+        import re
+
+        match = re.search(
+            r"rocm[-/](\d+)\.(\d+)", os.path.dirname(rocm_home), re.IGNORECASE
+        )
+        if match:
+            return int(match.group(1)), int(match.group(2))
+    return None
+
+
+@functools.cache
+def _ck_tile_universal_gemm_v2_api(rocm_home: str | None) -> bool:
+    # ck_tile headers are resolved from $ROCM_HOME at kernel compile time, not
+    # from torch.version.hip (frozen at PyTorch build time). Probe the header
+    # hipcc will use; fall back to the HIP version string when unavailable.
     if torch.version.hip is None:
         return False
-    rocm_version = tuple(int(v) for v in torch.version.hip.split(".")[:2])
-    return rocm_version >= (7, 14)
+
+    rocm_include = _ck_tile_rocm_include_dir(rocm_home)
+    if rocm_include is not None:
+        header_path = os.path.join(rocm_include, _CK_TILE_PIPELINE_PROBLEM_HEADER)
+        try:
+            with open(header_path) as header_file:
+                header_text = header_file.read()
+            header_v2 = _header_has_v2_universal_gemm_pipeline(header_text)
+            if header_v2 is not None:
+                return header_v2
+        except OSError:
+            pass
+
+    # torch.version.hip is the HIP version, conventionally aligned with ROCm.
+    rocm_version = _rocm_version_tuple()
+    if rocm_version is not None:
+        return rocm_version >= (7, 14)
+    return False
 
 
 def is_static_int(number):
@@ -239,12 +318,7 @@ class CKTileGemmTemplate(CKTileTemplate):
     This class is used for rendering CK-Tile Universal GEMM kernels
     """
 
-    gemm_kernel_launch_v1 = r"""
-        using {{instance_namespace}}::BaseGemmPipeline;
-        using {{instance_namespace}}::TilePartitioner;
-
-        constexpr auto TileK = {{instance_namespace}}::TileK;
-
+    gemm_kernel_launch = r"""
         const auto BiasTerms = std::array<const void*, 0> ();
         const auto BiasStrides = std::array<int32_t, 0> ();
 
@@ -267,6 +341,25 @@ class CKTileGemmTemplate(CKTileTemplate):
             *workspace_size = 0;
             return 0;
         }
+
+        {% if use_v2_api %}
+        using Kernel = {{instance_namespace}}::Kernel;
+
+        if (!Kernel::IsSupportedArgument(kargs)) {
+            throw std::runtime_error("invalid argument");
+        }
+        auto stream_config = ck_tile::stream_config{stream};
+        auto grid_size = Kernel::GridSize(M, N, kBatch);
+        auto block_size = Kernel::BlockSize();
+        constexpr auto lds_bytes = 0;
+        constexpr auto kBlockPerCU = 1;
+        auto gemm = ck_tile::make_kernel<kBlockPerCU>(Kernel{}, grid_size, block_size, lds_bytes, kargs);
+        ck_tile::launch_kernel(stream_config, gemm);
+        {% else %}
+        using {{instance_namespace}}::BaseGemmPipeline;
+        using {{instance_namespace}}::TilePartitioner;
+
+        constexpr auto TileK = {{instance_namespace}}::TileK;
 
         const ck_tile::index_t k_grain     = kBatch * TileK;
         const ck_tile::index_t K_split     = (K + k_grain - 1) / k_grain * TileK;
@@ -281,6 +374,7 @@ class CKTileGemmTemplate(CKTileTemplate):
             using Kernel = {{instance_namespace}}::Kernel<has_hot_loop_v, tail_number_v>;
 
             if (!Kernel::IsSupportedArgument(kargs)) {
+                // we do our best to statically avoid this case in filter_op
                 throw std::runtime_error("invalid argument");
             }
             auto stream_config = ck_tile::stream_config{stream};
@@ -293,42 +387,7 @@ class CKTileGemmTemplate(CKTileTemplate):
         };
 
         BaseGemmPipeline::TailHandler(Run, has_hot_loop, tail_num);
-    """
-
-    gemm_kernel_launch_v2 = r"""
-        const auto BiasTerms = std::array<const void*, 0> ();
-        const auto BiasStrides = std::array<int32_t, 0> ();
-
-        auto kargs = ck_tile::UniversalGemmKernelArgs<> {
-           {X},
-           {W},
-           BiasTerms,
-           Y,
-           M,
-           N,
-           K,
-           {LDA},
-           {LDB},
-           BiasStrides,
-           LDC,
-           kBatch
-        };
-
-        if (workspace_size) {
-            *workspace_size = 0;
-            return 0;
-        }
-
-        using Kernel = {{instance_namespace}}::Kernel;
-
-        if (!Kernel::IsSupportedArgument(kargs)) {
-            throw std::runtime_error("invalid argument");
-        }
-        auto stream_config = ck_tile::stream_config{stream};
-        auto grid_size = Kernel::GridSize(M, N, kBatch);
-        auto block_size = Kernel::BlockSize();
-        auto gemm = ck_tile::make_kernel<1>(Kernel{}, grid_size, block_size, 0, kargs);
-        ck_tile::launch_kernel(stream_config, gemm);
+        {% endif %}
     """
 
     gemm_template = r"""{{version_comment}}
@@ -673,7 +732,7 @@ class CKTileGemmTemplate(CKTileTemplate):
                 return r"""
             using DsDataType = ck_tile::tuple<>; // no bias terms for vanilla GEMM
             using DsLayout = ck_tile::tuple<>;
-            constexpr auto ELayout = CLayout;
+            using ELayout = CLayout;
             using CDEElementWise = ck_tile::element_wise::PassThrough; // no-op
             using EpilogueProblem = ck_tile::CShuffleEpilogueProblem<ADataType,
                                                                      BDataType,
@@ -718,7 +777,7 @@ class CKTileGemmTemplate(CKTileTemplate):
             using GemmPipeline = ck_tile::GemmPipelineAgBgCr{pipeline_type}<UniversalGemmProblem>;
         """
 
-        use_v2_api = _ck_tile_universal_gemm_v2_api()
+        use_v2_api = _ck_tile_universal_gemm_v2_api(config.rocm.rocm_home)
         if use_v2_api:
             rendered_pipeline_problem = ""
             rendered_universal_gemm_problem = ""
@@ -798,13 +857,11 @@ class CKTileGemmTemplate(CKTileTemplate):
 */
 """
 
-        kernel_launch_template = (
-            self.gemm_kernel_launch_v2
-            if _ck_tile_universal_gemm_v2_api()
-            else self.gemm_kernel_launch_v1
-        )
-        kernel_launch = self._template_from_string(kernel_launch_template).render(
+        use_v2_api = _ck_tile_universal_gemm_v2_api(config.rocm.rocm_home)
+
+        kernel_launch = self._template_from_string(self.gemm_kernel_launch).render(
             instance_namespace=op.name(),
+            use_v2_api=use_v2_api,
         )
 
         return self._template_from_string(self.gemm_template).render(
@@ -819,7 +876,6 @@ class CKTileGemmTemplate(CKTileTemplate):
                     f"int32_t {arg}" for arg in ["M", "N", "K", "LDA", "LDB", "LDC"]
                 ],
             ),
-            instance_namespace=op.name(),
             kernel_launch=kernel_launch,
             version_comment=version_comment,
         )

--- a/torch/_inductor/codegen/rocm/ck_tile_universal_gemm_template.py
+++ b/torch/_inductor/codegen/rocm/ck_tile_universal_gemm_template.py
@@ -723,9 +723,7 @@ class CKTileGemmTemplate(CKTileTemplate):
             rendered_pipeline_problem = ""
             rendered_universal_gemm_problem = ""
             rendered_pipeline = render_pipeline_v2(op.pipeline)
-            rendered_kernel = (
-                "using Kernel = ck_tile::GemmKernel<TilePartitioner, GemmPipeline, GemmEpilogue>;"
-            )
+            rendered_kernel = "using Kernel = ck_tile::GemmKernel<TilePartitioner, GemmPipeline, GemmEpilogue>;"
         else:
             rendered_pipeline_problem = r"""
         using Traits  =

--- a/torch/_inductor/codegen/rocm/ck_tile_universal_gemm_template.py
+++ b/torch/_inductor/codegen/rocm/ck_tile_universal_gemm_template.py
@@ -20,6 +20,15 @@ from ...utils import IndentedBuffer
 log = logging.getLogger(__name__)
 
 
+def _ck_tile_universal_gemm_v2_api() -> bool:
+    # ROCm 7.14+ ck_tile headers use a simplified UniversalGemmPipelineProblem
+    # API (no has_hot_loop / tail_number template parameters).
+    if torch.version.hip is None:
+        return False
+    rocm_version = tuple(int(v) for v in torch.version.hip.split(".")[:2])
+    return rocm_version >= (7, 14)
+
+
 def is_static_int(number):
     import sympy
 
@@ -230,18 +239,11 @@ class CKTileGemmTemplate(CKTileTemplate):
     This class is used for rendering CK-Tile Universal GEMM kernels
     """
 
-    gemm_template = r"""{{version_comment}}
-    {{headers}}
-    {{globals}}
-    {{instance_definition}}
-    extern "C" {
-    PT_EXPORT {{kernel_definition}} {
-
+    gemm_kernel_launch_v1 = r"""
         using {{instance_namespace}}::BaseGemmPipeline;
         using {{instance_namespace}}::TilePartitioner;
 
         constexpr auto TileK = {{instance_namespace}}::TileK;
-        constexpr auto kPrefetchStages = BaseGemmPipeline::PrefetchStages;
 
         const auto BiasTerms = std::array<const void*, 0> ();
         const auto BiasStrides = std::array<int32_t, 0> ();
@@ -272,7 +274,6 @@ class CKTileGemmTemplate(CKTileTemplate):
         const bool has_hot_loop            = BaseGemmPipeline::BlockHasHotloop(num_loop);
         const ck_tile::TailNumber tail_num = BaseGemmPipeline::GetBlockLoopTailNum(num_loop);
 
-        // run the kernel
         const auto Run = [&](const auto has_hot_loop_, const auto tail_number_) {
             constexpr bool has_hot_loop_v = has_hot_loop_.value;
             constexpr auto tail_number_v = tail_number_.value;
@@ -280,7 +281,6 @@ class CKTileGemmTemplate(CKTileTemplate):
             using Kernel = {{instance_namespace}}::Kernel<has_hot_loop_v, tail_number_v>;
 
             if (!Kernel::IsSupportedArgument(kargs)) {
-                // we do our best to statically avoid this case in `filter_op`
                 throw std::runtime_error("invalid argument");
             }
             auto stream_config = ck_tile::stream_config{stream};
@@ -293,7 +293,51 @@ class CKTileGemmTemplate(CKTileTemplate):
         };
 
         BaseGemmPipeline::TailHandler(Run, has_hot_loop, tail_num);
+    """
 
+    gemm_kernel_launch_v2 = r"""
+        const auto BiasTerms = std::array<const void*, 0> ();
+        const auto BiasStrides = std::array<int32_t, 0> ();
+
+        auto kargs = ck_tile::UniversalGemmKernelArgs<> {
+           {X},
+           {W},
+           BiasTerms,
+           Y,
+           M,
+           N,
+           K,
+           {LDA},
+           {LDB},
+           BiasStrides,
+           LDC,
+           kBatch
+        };
+
+        if (workspace_size) {
+            *workspace_size = 0;
+            return 0;
+        }
+
+        using Kernel = {{instance_namespace}}::Kernel;
+
+        if (!Kernel::IsSupportedArgument(kargs)) {
+            throw std::runtime_error("invalid argument");
+        }
+        auto stream_config = ck_tile::stream_config{stream};
+        auto grid_size = Kernel::GridSize(M, N, kBatch);
+        auto block_size = Kernel::BlockSize();
+        auto gemm = ck_tile::make_kernel<1>(Kernel{}, grid_size, block_size, 0, kargs);
+        ck_tile::launch_kernel(stream_config, gemm);
+    """
+
+    gemm_template = r"""{{version_comment}}
+    {{headers}}
+    {{globals}}
+    {{instance_definition}}
+    extern "C" {
+    PT_EXPORT {{kernel_definition}} {
+{{kernel_launch}}
         return 0;
     } // kernel definition
     } // extern C
@@ -581,35 +625,21 @@ class CKTileGemmTemplate(CKTileTemplate):
                                                        TilePartitionerGroupNum,
                                                        TilePartitionerM01>;
 
-        using Traits  =
-            ck_tile::TileGemmTraits<kPadM, kPadN, kPadK, ALayout, BLayout, CLayout>;
-
         using GemmUniversalTraits =
             ck_tile::TileGemmUniversalTraits<kPadM, kPadN, kPadK, DoubleSmemBuffer,
                                              ALayout, BLayout, CLayout, TransposeC>;
 
-        using GemmPipelineProblem =
-            ck_tile::GemmPipelineProblem<ADataType, BDataType, AccDataType, GemmShape, Traits>;
+        {{rendered_pipeline_problem}}
 
         {{rendered_scheduler}}
 
-        template<bool has_hot_loop_v, ck_tile::TailNumber tail_number_v>
-        using UniversalGemmProblem =
-            ck_tile::UniversalGemmPipelineProblem<ADataType,
-                                                  BDataType,
-                                                  AccDataType,
-                                                  GemmShape,
-                                                  GemmUniversalTraits,
-                                                  scheduler,
-                                                  has_hot_loop_v,
-                                                  tail_number_v>;
+        {{rendered_universal_gemm_problem}}
 
         {{rendered_pipeline}}
 
         {{rendered_epilogue}}
 
-        template<bool has_hot_loop_v, ck_tile::TailNumber tail_number_v>
-        using Kernel = ck_tile::GemmKernel<TilePartitioner, GemmPipeline<has_hot_loop_v, tail_number_v>, GemmEpilogue>;
+        {{rendered_kernel}}
     }
 
 """
@@ -667,12 +697,59 @@ class CKTileGemmTemplate(CKTileTemplate):
             else:
                 raise AssertionError("Epilogue must be set")
 
-        def render_pipeline(pipeline_type):
+        def render_pipeline_v1(pipeline_type):
             return rf"""
             using BaseGemmPipeline = ck_tile::BaseGemmPipelineAgBgCr{pipeline_type}<GemmPipelineProblem>;
 
             template<bool has_hot_loop_v, ck_tile::TailNumber tail_number_v>
             using GemmPipeline = ck_tile::GemmPipelineAgBgCr{pipeline_type}<UniversalGemmProblem<has_hot_loop_v, tail_number_v>>;
+        """
+
+        def render_pipeline_v2(pipeline_type):
+            return rf"""
+            using UniversalGemmProblem =
+                ck_tile::UniversalGemmPipelineProblem<ADataType,
+                                                      BDataType,
+                                                      AccDataType,
+                                                      GemmShape,
+                                                      GemmUniversalTraits,
+                                                      scheduler>;
+
+            using GemmPipeline = ck_tile::GemmPipelineAgBgCr{pipeline_type}<UniversalGemmProblem>;
+        """
+
+        use_v2_api = _ck_tile_universal_gemm_v2_api()
+        if use_v2_api:
+            rendered_pipeline_problem = ""
+            rendered_universal_gemm_problem = ""
+            rendered_pipeline = render_pipeline_v2(op.pipeline)
+            rendered_kernel = (
+                "using Kernel = ck_tile::GemmKernel<TilePartitioner, GemmPipeline, GemmEpilogue>;"
+            )
+        else:
+            rendered_pipeline_problem = r"""
+        using Traits  =
+            ck_tile::TileGemmTraits<kPadM, kPadN, kPadK, ALayout, BLayout, CLayout>;
+
+        using GemmPipelineProblem =
+            ck_tile::GemmPipelineProblem<ADataType, BDataType, AccDataType, GemmShape, Traits>;
+        """
+            rendered_universal_gemm_problem = r"""
+        template<bool has_hot_loop_v, ck_tile::TailNumber tail_number_v>
+        using UniversalGemmProblem =
+            ck_tile::UniversalGemmPipelineProblem<ADataType,
+                                                  BDataType,
+                                                  AccDataType,
+                                                  GemmShape,
+                                                  GemmUniversalTraits,
+                                                  scheduler,
+                                                  has_hot_loop_v,
+                                                  tail_number_v>;
+        """
+            rendered_pipeline = render_pipeline_v1(op.pipeline)
+            rendered_kernel = r"""
+        template<bool has_hot_loop_v, ck_tile::TailNumber tail_number_v>
+        using Kernel = ck_tile::GemmKernel<TilePartitioner, GemmPipeline<has_hot_loop_v, tail_number_v>, GemmEpilogue>;
         """
 
         def render_scheduler(scheduler_type):
@@ -683,9 +760,12 @@ class CKTileGemmTemplate(CKTileTemplate):
         rendered_definition = self._template_from_string(template_definition).render(
             operation_name=op.name(),
             **asdict(op),
+            rendered_pipeline_problem=rendered_pipeline_problem,
             rendered_scheduler=render_scheduler(op.scheduler),
-            rendered_pipeline=render_pipeline(op.pipeline),
+            rendered_universal_gemm_problem=rendered_universal_gemm_problem,
+            rendered_pipeline=rendered_pipeline,
             rendered_epilogue=render_epilogue(op.epilogue),
+            rendered_kernel=rendered_kernel,
             has_double_smem_buffer=("true" if op.pipeline == "CompV4" else "false"),
         )
         return rendered_definition
@@ -720,6 +800,15 @@ class CKTileGemmTemplate(CKTileTemplate):
 */
 """
 
+        kernel_launch_template = (
+            self.gemm_kernel_launch_v2
+            if _ck_tile_universal_gemm_v2_api()
+            else self.gemm_kernel_launch_v1
+        )
+        kernel_launch = self._template_from_string(kernel_launch_template).render(
+            instance_namespace=op.name(),
+        )
+
         return self._template_from_string(self.gemm_template).render(
             headers=self.header().getvalue(),
             globals=self.globals().getvalue(),
@@ -733,6 +822,7 @@ class CKTileGemmTemplate(CKTileTemplate):
                 ],
             ),
             instance_namespace=op.name(),
+            kernel_launch=kernel_launch,
             version_comment=version_comment,
         )
 

--- a/torch/_inductor/codegen/rocm/ck_tile_universal_gemm_template.py
+++ b/torch/_inductor/codegen/rocm/ck_tile_universal_gemm_template.py
@@ -10,6 +10,7 @@ from typing import Any
 import torch
 from torch._inductor import config
 from torch._inductor.codegen.rocm.ck_tile_template import CKTileTemplate
+from torch._inductor.codegen.rocm.compile_command import _rocm_system_include_dir
 from torch._inductor.codegen.rocm.rocm_kernel import ROCmTemplateKernel
 from torch._inductor.codegen.rocm.rocm_template import ArgInfo
 from torch._inductor.ir import Buffer, Layout
@@ -22,43 +23,29 @@ log = logging.getLogger(__name__)
 
 
 _CK_TILE_PIPELINE_PROBLEM_HEADER = "ck_tile/ops/gemm/pipeline/gemm_pipeline_problem.hpp"
+_STRUCT_ANCHOR = "struct UniversalGemmPipelineProblem"
 _SCHEDULER_PARAM = "GemmPipelineScheduler Scheduler_"
-# ck_tile headers place Scheduler_ within a few KB of UniversalGemmPipelineProblem.
-_HEADER_SCHEDULER_MAX_DISTANCE = 4000
-# Enough to cover the template parameters immediately following Scheduler_.
-_HEADER_AFTER_SCHEDULER_WINDOW = 800
-
-
-def _ck_tile_rocm_include_dir(rocm_home: str | None) -> str | None:
-    if rocm_home:
-        return os.path.join(rocm_home, "include")
-    from torch.utils import cpp_extension
-
-    if cpp_extension.ROCM_HOME:
-        return os.path.join(cpp_extension.ROCM_HOME, "include")
-    rocm_home = os.environ.get("ROCM_HOME") or os.environ.get("ROCM_PATH")
-    if rocm_home:
-        return os.path.join(rocm_home, "include")
-    try:
-        from torch.utils.cpp_extension import _join_rocm_home
-
-        return _join_rocm_home("include")
-    except OSError:
-        return None
+# ck_tile writes the template parameter list above the struct name.
+_HEADER_TEMPLATE_MAX_BACKWARD = 900
 
 
 def _header_has_v2_universal_gemm_pipeline(header_text: str) -> bool | None:
-    pos = header_text.find("UniversalGemmPipelineProblem")
+    pos = header_text.find(_STRUCT_ANCHOR)
     if pos < 0:
         return None
 
-    sched_pos = header_text.find(_SCHEDULER_PARAM, pos)
-    if sched_pos < 0 or sched_pos - pos > _HEADER_SCHEDULER_MAX_DISTANCE:
+    template_start = header_text.rfind(
+        "template", max(0, pos - _HEADER_TEMPLATE_MAX_BACKWARD), pos
+    )
+    if template_start < 0:
         return None
 
-    after_scheduler = header_text[
-        sched_pos : sched_pos + _HEADER_AFTER_SCHEDULER_WINDOW
-    ]
+    template_block = header_text[template_start:pos]
+    sched_pos = template_block.rfind(_SCHEDULER_PARAM)
+    if sched_pos < 0:
+        return None
+
+    after_scheduler = template_block[sched_pos:]
     elemwise_pos = after_scheduler.find("AElementWise_")
     hotloop_pos = after_scheduler.find("HasHotLoop_")
     if elemwise_pos >= 0 and (hotloop_pos < 0 or elemwise_pos < hotloop_pos):
@@ -76,22 +63,21 @@ def _ck_tile_universal_gemm_v2_api(rocm_home: str | None) -> bool:
     if torch.version.hip is None:
         return False
 
-    rocm_include = _ck_tile_rocm_include_dir(rocm_home)
-    if rocm_include is not None:
+    try:
+        rocm_include = _rocm_system_include_dir(rocm_home)
         header_path = os.path.join(rocm_include, _CK_TILE_PIPELINE_PROBLEM_HEADER)
-        try:
-            with open(header_path) as header_file:
-                header_text = header_file.read()
-            header_v2 = _header_has_v2_universal_gemm_pipeline(header_text)
-            if header_v2 is not None:
-                return header_v2
-            log.debug(
-                "Could not determine CK-Tile universal GEMM API from %s; "
-                "falling back to torch.version.hip",
-                header_path,
-            )
-        except OSError:
-            pass
+        with open(header_path) as header_file:
+            header_text = header_file.read()
+        header_v2 = _header_has_v2_universal_gemm_pipeline(header_text)
+        if header_v2 is not None:
+            return header_v2
+        log.debug(
+            "Could not determine CK-Tile universal GEMM API from %s; "
+            "falling back to torch.version.hip",
+            header_path,
+        )
+    except OSError:
+        pass
 
     # torch.version.hip is the HIP version, conventionally aligned with ROCm.
     rocm_version = tuple(int(v) for v in torch.version.hip.split(".")[:2])
@@ -619,7 +605,7 @@ class CKTileGemmTemplate(CKTileTemplate):
 
         return op
 
-    def emit_ck_instance(self, op: "CKTileGemmOperation"):
+    def emit_ck_instance(self, op: "CKTileGemmOperation", *, use_v2_api: bool):
         """
         This method is used to generate code which defines the type alias for the generated kernel class
         """
@@ -767,7 +753,6 @@ class CKTileGemmTemplate(CKTileTemplate):
             using GemmPipeline = ck_tile::GemmPipelineAgBgCr{pipeline_type}<UniversalGemmProblem>;
         """
 
-        use_v2_api = _ck_tile_universal_gemm_v2_api(config.rocm.rocm_home)
         if use_v2_api:
             rendered_pipeline_problem = ""
             rendered_universal_gemm_problem = ""
@@ -834,7 +819,8 @@ class CKTileGemmTemplate(CKTileTemplate):
         X, W = self.input_nodes
         Y = self.output_node
 
-        instance_definition = self.emit_ck_instance(op)
+        use_v2_api = _ck_tile_universal_gemm_v2_api(config.rocm.rocm_home)
+        instance_definition = self.emit_ck_instance(op, use_v2_api=use_v2_api)
 
         version_comment = rf"""/**
 * Generated code for CK inductor backend
@@ -846,8 +832,6 @@ class CKTileGemmTemplate(CKTileTemplate):
 * torch.version.git_version={getattr(torch.version, "git_version", "None")}
 */
 """
-
-        use_v2_api = _ck_tile_universal_gemm_v2_api(config.rocm.rocm_home)
 
         kernel_launch = self._template_from_string(self.gemm_kernel_launch).render(
             instance_namespace=op.name(),

--- a/torch/_inductor/codegen/rocm/ck_tile_universal_gemm_template.py
+++ b/torch/_inductor/codegen/rocm/ck_tile_universal_gemm_template.py
@@ -10,7 +10,7 @@ from typing import Any
 import torch
 from torch._inductor import config
 from torch._inductor.codegen.rocm.ck_tile_template import CKTileTemplate
-from torch._inductor.codegen.rocm.compile_command import _rocm_system_include_dir
+from torch._inductor.codegen.rocm.compile_command import _rocm_header_search_dirs
 from torch._inductor.codegen.rocm.rocm_kernel import ROCmTemplateKernel
 from torch._inductor.codegen.rocm.rocm_template import ArgInfo
 from torch._inductor.ir import Buffer, Layout
@@ -25,8 +25,6 @@ log = logging.getLogger(__name__)
 _CK_TILE_PIPELINE_PROBLEM_HEADER = "ck_tile/ops/gemm/pipeline/gemm_pipeline_problem.hpp"
 _STRUCT_ANCHOR = "struct UniversalGemmPipelineProblem"
 _SCHEDULER_PARAM = "GemmPipelineScheduler Scheduler_"
-# ck_tile writes the template parameter list above the struct name.
-_HEADER_TEMPLATE_MAX_BACKWARD = 900
 
 
 def _header_has_v2_universal_gemm_pipeline(header_text: str) -> bool | None:
@@ -34,9 +32,8 @@ def _header_has_v2_universal_gemm_pipeline(header_text: str) -> bool | None:
     if pos < 0:
         return None
 
-    template_start = header_text.rfind(
-        "template", max(0, pos - _HEADER_TEMPLATE_MAX_BACKWARD), pos
-    )
+    # ck_tile writes the template parameter list above the struct name.
+    template_start = header_text.rfind("template", 0, pos)
     if template_start < 0:
         return None
 
@@ -55,32 +52,55 @@ def _header_has_v2_universal_gemm_pipeline(header_text: str) -> bool | None:
     return None
 
 
+def _find_ck_tile_header(rocm_home: str | None, ck_dir: str | None) -> str | None:
+    for include_dir in _rocm_header_search_dirs(rocm_home, ck_dir):
+        header_path = os.path.join(include_dir, _CK_TILE_PIPELINE_PROBLEM_HEADER)
+        if os.path.exists(header_path):
+            return header_path
+    return None
+
+
 @functools.cache
-def _ck_tile_universal_gemm_v2_api(rocm_home: str | None) -> bool:
-    # ck_tile headers are resolved from $ROCM_HOME at kernel compile time, not
-    # from torch.version.hip (frozen at PyTorch build time). Probe the header
-    # hipcc will use; fall back to the HIP version string when unavailable.
+def _ck_tile_universal_gemm_v2_api(rocm_home: str | None, ck_dir: str | None) -> bool:
+    # ck_tile headers come from the compiler's include path at kernel compile
+    # time, not from torch.version.hip, which is frozen when PyTorch is built.
+    # Probe the header the compiler will pick, and say so loudly when we cannot:
+    # the version fallback below is the very signal we are trying to avoid.
     if torch.version.hip is None:
         return False
 
     try:
-        rocm_include = _rocm_system_include_dir(rocm_home)
-        header_path = os.path.join(rocm_include, _CK_TILE_PIPELINE_PROBLEM_HEADER)
-        with open(header_path) as header_file:
-            header_text = header_file.read()
-        header_v2 = _header_has_v2_universal_gemm_pipeline(header_text)
-        if header_v2 is not None:
-            return header_v2
-        log.debug(
-            "Could not determine CK-Tile universal GEMM API from %s; "
-            "falling back to torch.version.hip",
-            header_path,
-        )
-    except OSError:
-        pass
+        header_path = _find_ck_tile_header(rocm_home, ck_dir)
+        if header_path is None:
+            reason = f"{_CK_TILE_PIPELINE_PROBLEM_HEADER} is not on the include path"
+        else:
+            with open(header_path) as header_file:
+                header_v2 = _header_has_v2_universal_gemm_pipeline(header_file.read())
+            if header_v2 is not None:
+                return header_v2
+            reason = f"the template clause in {header_path} was not recognized"
+    except OSError as e:
+        reason = str(e)
 
     # torch.version.hip is the HIP version, conventionally aligned with ROCm.
-    rocm_version = tuple(int(v) for v in torch.version.hip.split(".")[:2])
+    try:
+        rocm_version = tuple(int(v) for v in torch.version.hip.split(".")[:2])
+    except ValueError:
+        log.warning(
+            "Could not probe the CK-Tile universal GEMM API (%s) and "
+            "torch.version.hip=%s is unparsable; assuming the legacy API",
+            reason,
+            torch.version.hip,
+        )
+        return False
+
+    log.warning(
+        "Could not probe the CK-Tile universal GEMM API (%s); falling back to "
+        "torch.version.hip=%s, which reflects the ROCm PyTorch was built against "
+        "rather than the headers these kernels compile against",
+        reason,
+        torch.version.hip,
+    )
     return rocm_version >= (7, 14)
 
 
@@ -585,6 +605,21 @@ class CKTileGemmTemplate(CKTileTemplate):
             return False
         return True
 
+    def check_epilogue(self, op: "CKTileGemmOperation"):
+        """
+        Pre-v2 CShuffleEpilogueProblem takes a memory_operation_enum argument
+        with no default, which we don't emit, so those instances don't compile.
+        ck_tile dropped it one release after it simplified
+        UniversalGemmPipelineProblem, so a snapshot taken between the two is
+        misclassified as supported here; both shipped ROCm releases are on one
+        side or the other.
+        """
+        if op.epilogue == "CShuffle" and not _ck_tile_universal_gemm_v2_api(
+            config.rocm.rocm_home, config.rocm.ck_dir
+        ):
+            return False
+        return True
+
     def filter_op(self, op: "CKTileGemmOperation"):
         """
         Determines whether a given op definition is suitable for the current
@@ -594,6 +629,8 @@ class CKTileGemmTemplate(CKTileTemplate):
 
         Returns None if the op is not suitable, otherwise returns the op to be used.
         """
+        if not self.check_epilogue(op):
+            return None
         if not self.check_dtypes(op):
             return None
         if not self.check_layouts(op):
@@ -819,7 +856,9 @@ class CKTileGemmTemplate(CKTileTemplate):
         X, W = self.input_nodes
         Y = self.output_node
 
-        use_v2_api = _ck_tile_universal_gemm_v2_api(config.rocm.rocm_home)
+        use_v2_api = _ck_tile_universal_gemm_v2_api(
+            config.rocm.rocm_home, config.rocm.ck_dir
+        )
         instance_definition = self.emit_ck_instance(op, use_v2_api=use_v2_api)
 
         version_comment = rf"""/**

--- a/torch/_inductor/codegen/rocm/compile_command.py
+++ b/torch/_inductor/codegen/rocm/compile_command.py
@@ -19,37 +19,42 @@ def _rocm_system_include_dir(rocm_home: str | None = None) -> str:
     return cpp_extension._join_rocm_home("include")
 
 
-def _rocm_include_paths(dst_file_ext: str) -> list[str]:
+def _ck_dir() -> str:
     from torch.utils import cpp_extension
-
-    rocm_include = _rocm_system_include_dir()
 
     if config.is_fbcode():
         from libfb.py import parutil
 
-        ck_path = parutil.get_dir_path("composable-kernel-headers")
-    else:
-        if not config.rocm.ck_dir:
-            ck_dir, _, _, _ = try_import_ck_lib()
-            if not ck_dir:
-                log.warning("Unspecified Composable Kernel directory")
-            config.rocm.ck_dir = ck_dir
-        ck_path = config.rocm.ck_dir or cpp_extension._join_rocm_home(
-            "composable_kernel"
-        )
+        return parutil.get_dir_path("composable-kernel-headers")
 
+    if not config.rocm.ck_dir:
+        ck_dir, _, _, _ = try_import_ck_lib()
+        if not ck_dir:
+            log.warning("Unspecified Composable Kernel directory")
+        config.rocm.ck_dir = ck_dir
+    return config.rocm.ck_dir or cpp_extension._join_rocm_home("composable_kernel")
+
+
+def _rocm_header_search_dirs(
+    rocm_home: str | None = None, ck_dir: str | None = None
+) -> list[str]:
+    # CK has to take priority over ROCm since CK is potentially more up-to-date.
+    ck_path = ck_dir or _ck_dir()
     log.debug("Using ck path %s", ck_path)
-
-    ck_include = os.path.join(ck_path, "include")
-    ck_library_include = os.path.join(ck_path, "library", "include")
-
-    # CK has to take priority over ROCm include paths
-    # Since CK is potentially more up-to-date
-    paths = [
-        os.path.realpath(p) for p in (ck_include, ck_library_include, rocm_include)
+    return [
+        os.path.realpath(p)
+        for p in (
+            os.path.join(ck_path, "include"),
+            os.path.join(ck_path, "library", "include"),
+            _rocm_system_include_dir(rocm_home),
+        )
     ]
+
+
+def _rocm_include_paths(dst_file_ext: str) -> list[str]:
+    paths = _rocm_header_search_dirs()
     if dst_file_ext == "exe":
-        ck_utility_include = os.path.join(ck_path, "library", "src", "utility")
+        ck_utility_include = os.path.join(_ck_dir(), "library", "src", "utility")
         paths.append(os.path.realpath(ck_utility_include))
     return paths
 

--- a/torch/_inductor/codegen/rocm/compile_command.py
+++ b/torch/_inductor/codegen/rocm/compile_command.py
@@ -9,14 +9,20 @@ from torch._inductor.utils import is_linux, try_import_ck_lib
 log = logging.getLogger(__name__)
 
 
+def _rocm_system_include_dir(rocm_home: str | None = None) -> str:
+    from torch.utils import cpp_extension
+
+    if rocm_home:
+        return os.path.join(rocm_home, "include")
+    if config.rocm.rocm_home:
+        return os.path.join(config.rocm.rocm_home, "include")
+    return cpp_extension._join_rocm_home("include")
+
+
 def _rocm_include_paths(dst_file_ext: str) -> list[str]:
     from torch.utils import cpp_extension
 
-    rocm_include = (
-        os.path.join(config.rocm.rocm_home, "include")
-        if config.rocm.rocm_home
-        else cpp_extension._join_rocm_home("include")
-    )
+    rocm_include = _rocm_system_include_dir()
 
     if config.is_fbcode():
         from libfb.py import parutil


### PR DESCRIPTION
ROCm 7.14+ ck_tile headers changed UniversalGemmPipelineProblem: the simplified API no longer passes has_hot_loop / tail_number into the pipeline problem, and the generated kernel type is no longer templated on those values.
Inductor still emitted the legacy signature, so CK-Tile GEMM codegen failed to compile against newer ROCm installs.

Detect the API at codegen time rather than from torch.version.hip, which is frozen when PyTorch is built and says nothing about the headers these kernels actually compile against. The probe resolves ck_tile/ops/gemm/pipeline/gemm_pipeline_problem.hpp through the same ordered include list the compiler uses (the CK directory, then $ROCM_HOME), anchors on struct UniversalGemmPipelineProblem, scans backward to the preceding template clause, and compares AElementWise_ against HasHotLoop_ after GemmPipelineScheduler Scheduler_. torch.version.hip >= 7.14 remains a fallback for when the header is missing or unrecognized, but every path reaching it now logs a warning naming the reason, and an unparsable version string degrades to the legacy API instead of raising out of choice generation.

Emit the legacy TailHandler / templated-kernel path for v1 headers and the simplified UniversalGemmPipelineProblem + non-templated GemmKernel path for v2, sharing one launch template between both paths.

CShuffle needed two fixes. ELayout was written as an invalid constexpr assignment instead of a type alias, a pre-existing bug that made every CShuffle instance fail to compile and be silently pruned during autotune. Once they compile, they still cannot be offered against pre-v2 headers, where CShuffleEpilogueProblem takes a memory_operation_enum argument with no default whose value depends on kBatch. Emitting that argument would mean resolving kBatch before the split-K choice is made, so filter_op drops CShuffle unless the v2 probe succeeds instead; that keeps the instances out of autotuning rather than spending a failed compile on each. ck_tile removed the argument one release after it simplified the pipeline problem, so a snapshot taken between the two would be misclassified here. Both shipped ROCm releases fall on one side or the other, so this is accepted rather than adding a second probe.

Review in the order the codegen runs: the include-path plumbing in compile_command.py and the header probe, then the v1/v2 emission split, then the CShuffle gate, then the tests.

Patch ck4inductor's pyproject.toml at wheel-build time to package the ck_tile headers, which ROCm no longer installs system-wide. The patch is a no-op once the fix lands upstream in composable_kernel.

Unskip CK Tile inductor tests which were skipped as part of https://github.com/pytorch/pytorch/pull/188593

Test Plan:
PYTORCH_TEST_WITH_ROCM=1 python3 test/inductor/test_ck_backend.py -k standalone_cktile -v
PYTORCH_TEST_WITH_ROCM=1 python3 test/inductor/test_ck_backend.py TestCKTileUniversalGemmTemplate -v

Authored with Opus 5.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben