### PR TITLE
Reject groups > channels in channel_shuffle to avoid FPE

### DIFF
--- a/aten/src/ATen/native/ChanelShuffle.cpp
+++ b/aten/src/ATen/native/ChanelShuffle.cpp
@@ -26,6 +26,9 @@ Tensor channel_shuffle_cpu(const Tensor& self, int64_t groups) {
   TORCH_CHECK(groups > 0,
               "Number of groups to divide channels in must be positive.",
               " Value of groups:", groups);
+  TORCH_CHECK(groups <= c,
+              "Number of groups must not exceed number of channels. Got ",
+              groups, " groups and ", c, " channels.");
   TORCH_CHECK((c % groups) == 0,
               "Number of channels must be divisible by groups. Got ",
               c, " channels and ", groups, " groups.");
@@ -51,6 +54,9 @@ Tensor channel_shuffle(const Tensor& self, int64_t groups) {
   TORCH_CHECK(groups > 0,
               "Number of groups to divide channels in must be positive.",
               " Value of groups:", groups);
+  TORCH_CHECK(groups <= c,
+              "Number of groups must not exceed number of channels. Got ",
+              groups, " groups and ", c, " channels.");
   TORCH_CHECK((c % groups) == 0,
               "Number of channels must be divisible by groups. Got ",
               c, " channels and ", groups, " groups.");
@@ -76,6 +82,9 @@ Tensor math_channel_shuffle(const Tensor& self, int64_t groups) {
   TORCH_CHECK(groups > 0,
               "Number of groups to divide channels in must be positive.",
               " Value of groups:", groups);
+  TORCH_CHECK(groups <= c,
+              "Number of groups must not exceed number of channels. Got ",
+              groups, " groups and ", c, " channels.");
   TORCH_CHECK((c % groups) == 0,
               "Number of channels must be divisible by groups. Got ",
               c, " channels and ", groups, " groups.");

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5973,6 +5973,17 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             groups = 2
             torch.native_channel_shuffle(input_tensor, groups)
 
+        # Regression test for #153231: groups > channels used to FPE in the
+        # CPU kernel when channels_per_group became 0.
+        with self.assertRaisesRegex(RuntimeError,
+                                    "Number of groups must not exceed number of channels.*"):
+            torch.native_channel_shuffle(input_tensor, 5)
+        with self.assertRaisesRegex(RuntimeError,
+                                    "Number of groups must not exceed number of channels.*"):
+            # Adversarial repro from the issue (1 channel, huge groups).
+            torch.native_channel_shuffle(
+                torch.ones([1, 1, 15, 3], dtype=torch.int32), 2615494409475630863)
+
         with self.assertRaisesRegex(RuntimeError,
                                     "channel_shuffle expects input with > 2 dims,.*"):
             input_tensor = torch.rand([1, 2])
@@ -5990,6 +6001,9 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         with self.assertRaisesRegex(RuntimeError,
                                     "Number of channels must be divisible by groups.*"):
             torch.native_channel_shuffle(meta_tensor, 2)
+        with self.assertRaisesRegex(RuntimeError,
+                                    "Number of groups must not exceed number of channels.*"):
+            torch.native_channel_shuffle(meta_tensor, 5)
         with self.assertRaisesRegex(RuntimeError,
                                     "channel_shuffle expects input with > 2 dims,.*"):
             torch.native_channel_shuffle(torch.empty([1, 2], device="meta"), 2)

--- a/torch/_refs/nn/functional/__init__.py
+++ b/torch/_refs/nn/functional/__init__.py
@@ -320,6 +320,10 @@ def channel_shuffle(input: TensorLikeType, groups: int) -> TensorLikeType:
         lambda: f"Number of groups to divide channels in must be positive. Value of groups:{groups}",
     )
     torch._check(
+        groups <= c,
+        lambda: f"Number of groups must not exceed number of channels. Got {groups} groups and {c} channels.",
+    )
+    torch._check(
         (c % groups) == 0,
         lambda: f"Number of channels must be divisible by groups. Got {c} channels and {groups} groups.",
     )

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -9791,6 +9791,35 @@ def sample_inputs_channel_shuffle(op_info, device, dtype, requires_grad, **kwarg
         for shape, groups in shapes_groups
     )
 
+
+def error_inputs_channel_shuffle(op_info, device, **kwargs):
+    make_arg = partial(make_tensor, device=device, dtype=torch.float32)
+
+    # groups must be positive
+    yield ErrorInput(
+        SampleInput(make_arg((1, 4, 2, 2)), args=(0,)),
+        error_regex=r"Number of groups to divide channels in must be positive",
+    )
+
+    # groups must not exceed number of channels (#153231)
+    yield ErrorInput(
+        SampleInput(make_arg((1, 3, 2, 2)), args=(5,)),
+        error_regex=r"Number of groups must not exceed number of channels",
+    )
+
+    # channels must be divisible by groups
+    yield ErrorInput(
+        SampleInput(make_arg((1, 3, 2, 2)), args=(2,)),
+        error_regex=r"Number of channels must be divisible by groups",
+    )
+
+    # input must have > 2 dims
+    yield ErrorInput(
+        SampleInput(make_arg((1, 4)), args=(2,)),
+        error_regex=r"channel_shuffle expects input with > 2 dims",
+    )
+
+
 def sample_inputs_binary_cross_entropy(op_info, device, dtype, requires_grad, logits=False, **kwargs):
     make = partial(make_tensor, device=device, dtype=dtype)
     # Lower bounds must be greater than 'eps' defined in gradcheck.py::gradgradcheck() -> eps
@@ -23730,6 +23759,7 @@ op_db: list[OpInfo] = [
     OpInfo(
         "nn.functional.channel_shuffle",
         sample_inputs_func=sample_inputs_channel_shuffle,
+        error_inputs_func=error_inputs_channel_shuffle,
         dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
         supports_out=False,
         supports_forward_ad=True,


### PR DESCRIPTION
Fixes #153231

## Summary
`native_channel_shuffle` / `channel_shuffle` could hit a floating-point exception when `groups` exceeded the channel count, because `channels_per_group` became 0 in the CPU kernel.

This adds an explicit `TORCH_CHECK(groups <= channels, ...)` on all three C++ entry points (`channel_shuffle_cpu`, `channel_shuffle`, `math_channel_shuffle`) and mirrors it in the Python ref implementation. Prior PR #153781 added the CPU-only check but stalled without tests; this also covers the CompositeImplicitAutograd fallback path used by non-CPU backends (same lesson as #173500 / #181029).

## Test plan
- [x] Extended `test_channel_shuffle_input_checks` with `groups > channels` cases (including the adversarial issue repro) on CPU and meta
- [x] Added OpInfo `error_inputs_channel_shuffle` for device-agnostic coverage
- [ ] CI: `test_nn.py::test_channel_shuffle_input_checks`
- [ ] CI: OpInfo error input tests for `nn.functional.channel_shuffle`

cc @albanD @jbschlosser @mikaylagawarecki