### PR TITLE
docs: document torch.ao.quantization.fuser_method_mappings public APIs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -357,13 +357,6 @@ coverage_ignore_functions = [
     # torch.ao.quantization.fuse_modules
     "fuse_known_modules",
     "fuse_modules_qat",
-    # torch.ao.quantization.fuser_method_mappings
-    "fuse_conv_bn",
-    "fuse_conv_bn_relu",
-    "fuse_convtranspose_bn",
-    "fuse_linear_bn",
-    "get_fuser_method",
-    "get_fuser_method_new",
     # torch.ao.quantization.fx.convert
     "convert",
     "convert_custom_module",

--- a/docs/source/quantization-support.md
+++ b/docs/source/quantization-support.md
@@ -180,6 +180,26 @@ Quantization to work with this as well.
 
 ```
 
+## torch.ao.quantization.fuser_method_mappings
+```{eval-rst}
+.. currentmodule:: torch.ao.quantization.fuser_method_mappings
+```
+
+```{eval-rst}
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+    :template: classtemplate.rst
+
+    fuse_conv_bn
+    fuse_conv_bn_relu
+    fuse_convtranspose_bn
+    fuse_linear_bn
+    get_fuser_method
+    get_fuser_method_new
+
+```
+
 ## torch.ao.quantization.fx.custom_config
 
 This module contains a few CustomConfig classes that's used in both eager mode and FX graph mode quantization


### PR DESCRIPTION
## Summary

The six public functions in `torch.ao.quantization.fuser_method_mappings` already ship with real docstrings, but they were suppressed from the docs coverage report via `coverage_ignore_functions` in `docs/source/conf.py`, so none of them rendered a documentation page:

- `fuse_conv_bn`
- `fuse_conv_bn_relu`
- `fuse_convtranspose_bn`
- `fuse_linear_bn`
- `get_fuser_method`
- `get_fuser_method_new`

This PR removes those entries from the ignore list and adds an `autosummary` block for the module in `docs/source/quantization-support.md`, matching the style already used by the neighbouring `torch.ao.quantization.backend_config.utils` section.

No Python source is modified. Each function's canonical `__module__` is `torch.ao.quantization.fuser_method_mappings`, which matches the `currentmodule` used by the new directive, so no duplicate-object descriptions are introduced.

## Test plan

```
# each function has a meaningful docstring and resolves under the documented module path
python -c "import torch.ao.quantization.fuser_method_mappings as m; \
names=['fuse_conv_bn','fuse_conv_bn_relu','fuse_convtranspose_bn','fuse_linear_bn','get_fuser_method','get_fuser_method_new']; \
assert all(getattr(m,n).__doc__ and getattr(m,n).__module__=='torch.ao.quantization.fuser_method_mappings' for n in names)"

# conf.py still parses after removing the entries
python -m py_compile docs/source/conf.py

# authoritative docs coverage check (CI)
cd docs && make coverage   # docs/build/coverage/python.txt -> 0 undocumented
```

> This PR was authored with the assistance of an AI coding assistant (Claude Code).