### PR TITLE
Fix misleading full-backward-hook warning for pre-hook-only modules (#189093)

### DIFF
--- a/test/nn/test_module_hooks.py
+++ b/test/nn/test_module_hooks.py
@@ -543,6 +543,37 @@ class TestModuleHooks(TestCase):
         self.assertEqual(len(w), 1)
         self.assertTrue("should be a Tensor or a tuple of Tensors" in str(w[0].message))
 
+    def test_full_backward_pre_hook_no_warning_without_input_grad(self):
+        # A module with only a full backward *pre*-hook must not emit the
+        # "Full backward hook is firing" warning when no input requires grad:
+        # that warning is only relevant to full backward hooks, which receive
+        # grad_input. Pre-hooks only receive grad_output, so firing from the
+        # output side is expected. See
+        # https://github.com/pytorch/pytorch/issues/189093
+        def pre_hook(module, grad_output):
+            return None
+
+        def hook(module, grad_input, grad_output):
+            return None
+
+        warn_text = "Full backward hook is firing"
+        x = torch.randn(2, 4)  # does not require grad
+
+        model = nn.Linear(4, 4, bias=False)
+        model.register_full_backward_pre_hook(pre_hook)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            model(x).sum().backward()
+        self.assertEqual([m for m in w if warn_text in str(m.message)], [])
+
+        # A full backward hook with no input grads should still warn.
+        model = nn.Linear(4, 4, bias=False)
+        model.register_full_backward_hook(hook)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            model(x).sum().backward()
+        self.assertEqual(len([m for m in w if warn_text in str(m.message)]), 1)
+
 
 def _hook_to_pickle(*args, **kwargs):
     pass

--- a/torch/utils/hooks.py
+++ b/torch/utils/hooks.py
@@ -223,11 +223,14 @@ class BackwardHook:
                 # Special case if no input required gradients, this hook should call the user
                 # hook directly
                 if self.input_tensors_index is None:
-                    warnings.warn("Full backward hook is firing when gradients are computed "
-                                  "with respect to module outputs since no inputs require gradients. See "
-                                  "https://docs.pytorch.org/docs/main/generated/torch.nn.Module.html#torch.nn.Module.register_full_backward_hook "
-                                  "for more details.",
-                                  stacklevel=5)
+                    # Only full backward hooks (not pre-hooks) receive grad_input
+                    # here, so only warn about them firing without input grads.
+                    if self.user_hooks:
+                        warnings.warn("Full backward hook is firing when gradients are computed "
+                                      "with respect to module outputs since no inputs require gradients. See "
+                                      "https://docs.pytorch.org/docs/main/generated/torch.nn.Module.html#torch.nn.Module.register_full_backward_hook "
+                                      "for more details.",
+                                      stacklevel=5)
                     grad_inputs = self._pack_with_none([], [], self.n_inputs)
                     for user_hook in self.user_hooks:
                         res = user_hook(self.module, grad_inputs, self.grad_outputs)


### PR DESCRIPTION
Fixes #189093

## Summary

`nn.Module.register_full_backward_pre_hook` currently emits a warning worded for `register_full_backward_hook` when a module's forward inputs do not require grad, even though no full backward hook is registered:

```
Full backward hook is firing when gradients are computed with respect to module
outputs since no inputs require gradients. See .../register_full_backward_hook ...
```

This is noisy for a very common setup: training modules whose batch inputs do not require grad while their parameters do. A full backward **pre**-hook is still useful there (it can prepare state once output grads are available), and firing from the output side is expected — so the warning is misleading.

## Root cause

In `BackwardHook.setup_output_hook` (`torch/utils/hooks.py`), the warning sits at the top of the `if self.input_tensors_index is None:` branch, which is entered for both full backward hooks and full backward pre-hooks. Only `self.user_hooks` (full backward hooks) receive `grad_input` and are the subject of the warning; pre-hooks only receive `grad_output`.

## Fix

Guard the warning with `if self.user_hooks:`. The `grad_input` packing, the user-hook loop (already a no-op when `user_hooks` is empty), and the `self.grad_outputs = None` reset are intentionally left outside the guard, so full-hook behaviour and per-backward state cleanup are unchanged.

## Test plan

Added `test_full_backward_pre_hook_no_warning_without_input_grad` in `test/nn/test_module_hooks.py`: it asserts a pre-hook-only module emits no "Full backward hook is firing" warning when the input does not require grad, and that a full backward hook in the same situation **still** warns. The test fails before this change (`1 != 0`) and passes after it.

```
python test/nn/test_module_hooks.py -k test_full_backward_pre_hook_no_warning_without_input_grad
python test/nn/test_module_hooks.py TestModuleHooks
```

> This PR was authored with the assistance of an AI coding assistant (Claude Code).