### PR TITLE
[distributed] Add DeviceMesh.abort() API

### DIFF
--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -228,6 +228,55 @@ class DeviceMeshTest(DTensorTestBase):
         self.assertTrue(tp_mesh.get_group() in groups)
         self.assertTrue(dp_mesh.get_group() in groups)
 
+    @with_comms()
+    def test_abort_2d_mesh(self):
+        mesh_2d = init_device_mesh(
+            self.device_type, (2, self.world_size // 2), mesh_dim_names=("dp", "tp")
+        )
+        groups = mesh_2d.get_all_groups()
+        group_names = [pg.group_name for pg in groups]
+
+        mesh_2d.abort()
+
+        for name in group_names:
+            self.assertNotIn(name, [_world.pg_names[pg] for pg in _world.pg_names])
+
+    @with_comms()
+    def test_abort_1d_mesh(self):
+        mesh_1d = init_device_mesh(
+            self.device_type, (self.world_size,), mesh_dim_names=("world",)
+        )
+        group = mesh_1d.get_group()
+        default_group = _get_default_group()
+        if group is default_group:
+            # 1D mesh reused the WORLD PG; aborting it tears down the
+            # default group which conflicts with @with_comms teardown.
+            return
+        group_name = group.group_name
+
+        mesh_1d.abort()
+
+        self.assertNotIn(group_name, [_world.pg_names[pg] for pg in _world.pg_names])
+
+    @with_comms()
+    def test_abort_submesh_raises(self):
+        mesh_2d = init_device_mesh(
+            self.device_type, (2, self.world_size // 2), mesh_dim_names=("dp", "tp")
+        )
+        submesh = mesh_2d["tp"]
+
+        with self.assertRaisesRegex(RuntimeError, "not supported on a submesh"):
+            submesh.abort()
+
+    @with_comms()
+    def test_abort_no_backend(self):
+        mesh = DeviceMesh(
+            self.device_type,
+            torch.arange(self.world_size),
+            _init_backend=False,
+        )
+        mesh.abort()
+
     @with_comms
     def test_get_local_rank_raises_exception(self):
         mesh_shape = (2, self.world_size // 2)

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -883,6 +883,72 @@ else:
             """
             return [self.get_group(i) for i in range(len(self._layout))]
 
+        def abort(self) -> None:
+            """
+            Abort all process groups associated with this DeviceMesh.
+
+            When a rank in a DeviceMesh exits prematurely, other ranks can call
+            this method to abort the mesh's process groups instead of hanging.
+
+            This method must be called on a root mesh. Calling it on a submesh
+            raises ``RuntimeError`` because the scope of a submesh abort is
+            ambiguous.
+
+            .. note:: This API is experimental. For NCCL backends, aborts are
+                performed concurrently using group semantics to avoid deadlocks.
+                For other backends, ``abort()`` is called serially on each
+                process group.
+            """
+            from torch.distributed.distributed_c10d import (
+                _cleanup_process_group_global_state,
+            )
+
+            if self._root_mesh is not None:
+                raise RuntimeError(
+                    "abort() is not supported on a submesh. "
+                    "Call abort() on the root mesh instead."
+                )
+
+            if not hasattr(self, "_dim_group_names"):
+                return
+
+            seen: set[str] = set()
+            pgs: list[ProcessGroup] = []
+            for name in self._dim_group_names:
+                if name not in seen:
+                    seen.add(name)
+                    pg = _resolve_process_group(name)
+                    if pg is not None:
+                        pgs.append(pg)
+
+            for flat_mesh in self._flatten_mapping.values():
+                if hasattr(flat_mesh, "_dim_group_names"):
+                    for name in flat_mesh._dim_group_names:
+                        if name not in seen:
+                            seen.add(name)
+                            pg = _resolve_process_group(name)
+                            if pg is not None:
+                                pgs.append(pg)
+
+            if not pgs:
+                return
+
+            device = torch.accelerator.current_accelerator() or torch.device("cpu")
+            try:
+                pgs[0]._start_coalescing(device)
+                coalescing = True
+            except RuntimeError:
+                coalescing = False
+
+            for pg in pgs:
+                pg.abort()
+
+            if coalescing:
+                pgs[0]._end_coalescing(device)
+
+            for pg in pgs:
+                _cleanup_process_group_global_state(pg)
+
         def _create_sub_mesh(
             self,
             layout: _MeshLayout,

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -838,6 +838,72 @@ else:
             """
             return [self.get_group(i) for i in range(len(self._layout))]
 
+        def abort(self) -> None:
+            """
+            Abort all process groups associated with this DeviceMesh.
+
+            When a rank in a DeviceMesh exits prematurely, other ranks can call
+            this method to abort the mesh's process groups instead of hanging.
+
+            This method must be called on a root mesh. Calling it on a submesh
+            raises ``RuntimeError`` because the scope of a submesh abort is
+            ambiguous.
+
+            .. note:: This API is experimental. For NCCL backends, aborts are
+                performed concurrently using group semantics to avoid deadlocks.
+                For other backends, ``abort()`` is called serially on each
+                process group.
+            """
+            from torch.distributed.distributed_c10d import (
+                _cleanup_process_group_global_state,
+            )
+
+            if self._root_mesh is not None:
+                raise RuntimeError(
+                    "abort() is not supported on a submesh. "
+                    "Call abort() on the root mesh instead."
+                )
+
+            if not hasattr(self, "_dim_group_names"):
+                return
+
+            seen: set[str] = set()
+            pgs: list[ProcessGroup] = []
+            for name in self._dim_group_names:
+                if name not in seen:
+                    seen.add(name)
+                    pg = _resolve_process_group(name)
+                    if pg is not None:
+                        pgs.append(pg)
+
+            for flat_mesh in self._flatten_mapping.values():
+                if hasattr(flat_mesh, "_dim_group_names"):
+                    for name in flat_mesh._dim_group_names:
+                        if name not in seen:
+                            seen.add(name)
+                            pg = _resolve_process_group(name)
+                            if pg is not None:
+                                pgs.append(pg)
+
+            if not pgs:
+                return
+
+            device = torch.accelerator.current_accelerator() or torch.device("cpu")
+            try:
+                pgs[0]._start_coalescing(device)
+                coalescing = True
+            except RuntimeError:
+                coalescing = False
+
+            for pg in pgs:
+                pg.abort()
+
+            if coalescing:
+                pgs[0]._end_coalescing(device)
+
+            for pg in pgs:
+                _cleanup_process_group_global_state(pg)
+
         def _create_sub_mesh(
             self,
             layout: _MeshLayout,


### PR DESCRIPTION
## Summary

Adds `DeviceMesh.abort()` to concurrently abort all process groups owned by a mesh, preventing the deadlock described in #173815.

When a rank exits prematurely, other ranks need to abort the mesh's process groups. The naive approach of looping over `mesh.get_all_groups()` and calling `abort()` serially deadlocks because NCCL requires `ncclGroupStart`/`ncclGroupEnd` semantics for concurrent abort of multiple communicators (see #119797).

`DeviceMesh.abort()` handles this by:
- Collecting all unique process groups (dimension groups + flattened-mesh groups)
- Wrapping `pg.abort()` calls in `_group_start()`/`_group_end()` for NCCL backends
- Cleaning up per-PG global state via `_cleanup_process_group_global_state`

Per the discussion in #173815, calling `abort()` on a submesh raises `RuntimeError` because the scope is ambiguous — users must call it on the root mesh.

Fixes #173815