### PR TITLE
[dynamo] Make fbcode custom-op preload in fx_graph_runnable repros best-effort

### DIFF
--- a/torch/_dynamo/debug_utils.py
+++ b/torch/_dynamo/debug_utils.py
@@ -82,7 +82,18 @@ if use_buck:
         "//deeplearning/fbgemm/fbgemm_gpu:sparse_ops",
     ]
     cur_target = libfb.py.build_info.BuildInfo.get_build_rule().replace("fbcode:", "//")  # type: ignore[possibly-undefined]
-    extra_imports = "\n".join([f'torch.ops.load_library("{x}")' for x in extra_deps])
+    # Preload common fbcode custom-op libraries so repros that use those ops
+    # work out of the box. Best-effort: a repro whose graph doesn't use these
+    # ops (or that is run outside a buck target linking them) must not fail
+    # just because the library isn't present.
+    _extra_deps_list = "\n".join(f'    "{x}",' for x in extra_deps)
+    extra_imports = (
+        f"for _extra_dep in [\n{_extra_deps_list}\n]:\n"
+        "    try:\n"
+        "        torch.ops.load_library(_extra_dep)\n"
+        "    except OSError:\n"
+        "        pass\n"
+    )
 
 
 BUCK_CMD_PREFIX = ["buck2", "run", "@mode/dev-nosan"]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189656

The `fx_graph_runnable` repro that Dynamo emits preloads a few common fbcode custom-op libraries (sparsenn, fbgemm_gpu) via `torch.ops.load_library("//buck:target")`. In fbcode (`use_buck`) these lines were emitted unconditionally at the top of every generated repro, so the script aborted with `OSError: ... cannot open shared object file` whenever it ran somewhere those libraries are not linked. `test/dynamo/test_fx_graph_runnable.py` hits exactly this: it writes the payload to a temp file and runs it with plain `sys.executable`, in a link-tree that only depends on `//caffe2:torch`. The graphs under test (`a @ b`, `x + 1`, ...) use none of the preloaded ops, so the preload served no purpose there other than to make the repro exit non-zero and fail the test. The path is fbcode-only, so OSS was unaffected and the failures were internal-only.

The fix wraps each preload in a best-effort `try/except OSError`. When a repro actually uses these ops and runs inside a buck target that links them, `load_library` still succeeds exactly as before. When the library is absent, the preload is skipped instead of aborting the whole script; a repro that genuinely needs a missing op now fails later at op resolution with a clearer error. This mirrors the existing non-portable-`load_library` handling in `test/inductor/test_aot_inductor_custom_ops.py`.

Test Plan:
The affected code path only runs in fbcode (`use_buck`), so it was verified there. All 13 previously-failing `FxGraphRunnableTest` cases now pass:

```
buck2 test @fbcode//mode/opt fbcode//caffe2/test/dynamo:test_dynamo -- \
  --run-disabled --exact \
  'fbcode//caffe2/test/dynamo:test_dynamo - test_fx_graph_runnable.py::FxGraphRunnableTest::test_two_inputs_matmul' \
  # ...and the other 12 test_fx_graph_runnable cases
# -> Pass 13. Fail 0.
```

Lint (OSS): `lintrunner -a --take RUFF,PYFMT torch/_dynamo/debug_utils.py` -> ok, no issues.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98