### PR TITLE
docs: Fix Sphinx role for Tensor.T usage warning

### DIFF
--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -6761,7 +6761,7 @@ If ``n`` is the number of dimensions in ``x``,
 ``x.T`` is equivalent to ``x.permute(n-1, n-2, ..., 0)``.
 
 .. warning::
-    The use of :func:`Tensor.T` on tensors of dimension other than 2 to reverse their shape
+    The use of :attr:`Tensor.T` on tensors of dimension other than 2 to reverse their shape
     is deprecated and it will throw an error in a future release. Consider :attr:`~.Tensor.mT`
     to transpose batches of matrices or `x.permute(*torch.arange(x.ndim - 1, -1, -1))` to reverse
     the dimensions of a tensor.


### PR DESCRIPTION
Changed the Sphinx role for Tensor.T from :func: to :attr: in torch/_tensor_docs.py to prevent Sphinx from automatically appending incorrect method parentheses () to the attribute name in the deprecation warning on the documentation website.