### PR TITLE
[inductor] Fall back to ATEN for CUDA ConvTranspose2d; fix H100-only inductor test failures

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -12271,6 +12271,7 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
             subtest(False, name="inductor", decorators=[unittest.expectedFailure]),
         ],
     )
+    @with_tf32_off
     def test_randn_order_preserved(self, fallback_random):
         if self.device == "cpu":
             raise unittest.SkipTest("conv2d randn ordering requires CUDA")
@@ -12295,6 +12296,7 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
             self.assertEqual(compiled_out, eager_out)
 
     @config.patch(fallback_random=True)
+    @with_tf32_off
     def test_tuple_output_rng_order_preserved(self):
         if self.device == "cpu":
             raise unittest.SkipTest("conv2d randn ordering requires CUDA")
@@ -19489,6 +19491,7 @@ if RUN_GPU:
             self.assertFalse("out_ptr0" in code)
             self.assertEqual(fn_opt(*inps), fn(*inps))
 
+        @config.patch("triton.coalesce_tiling_analysis", True)
         def test_reduction_hint_inner_with_high_tiling_ratio(self):
             """Test inner reduction hint with high tiling score ratio."""
 

--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -709,11 +709,18 @@ def convolution(
                     num_warps=num_warps,
                     **cfg.kwargs,
                 )
+    # The Triton conv2d backward-input kernels miscompile on CUDA (wrong results
+    # on sm90, ptxas illegal memory access on sm100) with no perf win, so keep
+    # them on ROCm and fall back to ATEN on CUDA. Same rationale as the
+    # convolution_backward lowering. See
+    # https://github.com/pytorch/pytorch/issues/187081.
+    disable_triton_conv_bwd = device_type == "cuda" and not torch.version.hip
     if (
         torch._inductor.utils._use_conv_autotune_backend("TRITON")
         and use_triton_template(layout)
         and transposed
         and ndim == 2
+        and not disable_triton_conv_bwd
     ):
         # ConvTranspose2d is mathematically identical to conv_backward_input:
         # the input plays the role of grad_output and the same weight layout


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189660

Six inductor tests fail on H100 (sm90) but pass on OSS CI hardware (sm86). They have three independent, environment-specific root causes; this fixes all three.

ConvTranspose2d forward (`test_conv_transpose2d_forward_triton`): the lowering in `torch/_inductor/kernel/conv.py` reuses the `convolution2d_bwd_input` Triton template for the transposed case. That template's non-unrolled reduction loop miscompiles on CUDA -- wrong results on sm90, and per #187081 a ptxas illegal memory access on sm100 -- with no perf benefit over ATEN. The template math is correct (a stride-1 ConvTranspose2d forward is exactly conv_backward_input with the input as grad_output), which is why ATEN produces correct results. This branch was the only conv path missing the `disable_triton_conv_bwd` guard that `convolution_backward` already applies, so it still emitted the Triton kernel on CUDA. The fix honors `disable_triton_conv_bwd` here too: Triton stays on ROCm, CUDA falls back to ATEN. Clamping `num_warps` to 4 (as the forward conv template does for triton#1254) is not sufficient here -- the autotuner's winning kernel was already 4 warps and still produced garbage.

Reduction hint (`test_reduction_hint_inner_with_high_tiling_ratio`): the test asserts `ReductionHint.INNER`, which is only produced by the DEFAULT->INNER tiling-ratio upgrade in `SIMDKernelFeatures.get_reduction_hint`. That upgrade only runs when `triton.coalesce_tiling_analysis` is enabled, whose default differs by environment. The test now patches it on so the assertion is deterministic.

RNG order (`test_randn_order_preserved`, `test_tuple_output_rng_order_preserved`): the RNG ordering these tests check is preserved correctly (`fallback_random=True` makes the draws bit-identical to eager); the residual mismatch is TF32-magnitude `conv2d` noise measured against the default float32 tolerance, which appears on H100 but not on sm86. Adding `@with_tf32_off` keeps the exact-equality intent.

Test Plan:

Verified on H100 (sm90) via fbcode RE (the local GPU is an A100, which does not reproduce the sm90 miscompile). All six originally-failing tests pass:

```
buck2 test @fbcode//mode/opt fbcode//caffe2/test/inductor:test_inductor_cuda -- --exact --run-disabled \
  'fbcode//caffe2/test/inductor:test_inductor_cuda - test_conv_transpose2d_forward_triton_dilation_1_stride_1_padding_0_kernel_3_channels_groups3_nhwc_True_cuda (caffe2.test.inductor.test_torchinductor.GPUTests)' \
  'fbcode//caffe2/test/inductor:test_inductor_cuda - test_conv_transpose2d_forward_triton_dilation_1_stride_1_padding_1_kernel_3_channels_groups3_nhwc_True_cuda (caffe2.test.inductor.test_torchinductor.GPUTests)' \
  'fbcode//caffe2/test/inductor:test_inductor_cuda - test_conv_transpose2d_forward_triton_dilation_2_stride_1_padding_1_kernel_3_channels_groups3_nhwc_True_cuda (caffe2.test.inductor.test_torchinductor.GPUTests)' \
  'fbcode//caffe2/test/inductor:test_inductor_cuda - test_randn_order_preserved_fallback_cuda (caffe2.test.inductor.test_torchinductor.GPUTests)' \
  'fbcode//caffe2/test/inductor:test_inductor_cuda - test_tuple_output_rng_order_preserved_cuda (caffe2.test.inductor.test_torchinductor.GPUTests)' \
  'fbcode//caffe2/test/inductor:test_inductor_cuda - test_reduction_hint_inner_with_high_tiling_ratio (caffe2.test.inductor.test_torchinductor.TritonCodeGenTests)'
# Pass 7. Fail 0.
```

Regression check (transposed-conv siblings and nchw variants routed through the changed branch): Pass, 0 fail.

Equivalent OSS invocation:

```
python test/inductor/test_torchinductor.py -k "test_conv_transpose2d_forward_triton or test_randn_order_preserved or test_tuple_output_rng_order_preserved or test_reduction_hint_inner_with_high_tiling_ratio"
```

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo