### PR TITLE
Validate batch dim in max_pool3d_with_indices_backward

### DIFF
--- a/aten/src/ATen/native/Pool.h
+++ b/aten/src/ATen/native/Pool.h
@@ -321,6 +321,12 @@ max_pool3d_backward_shape_check(
   check_dim_size(indices, ndim, ndim-3, otime);
   check_dim_size(indices, ndim, ndim-2, oheight);
   check_dim_size(indices, ndim, ndim-1, owidth);
+
+  if (ndim == 5) {
+    const int64_t batchSize = input.size(0);
+    check_dim_size(gradOutput, ndim, 0, batchSize);
+    check_dim_size(indices, ndim, 0, batchSize);
+  }
 }
 
 inline void

--- a/aten/src/ATen/native/PoolingChecks.h
+++ b/aten/src/ATen/native/PoolingChecks.h
@@ -196,6 +196,14 @@ pool3d_backward_shape_check(
   if (indices.has_value()) {
     check_trailing_dim_sizes(*indices, ndim, {nslices, otime, oheight, owidth});
   }
+
+  if (ndim == 5) {
+    const int64_t batchSize = input.size(0);
+    check_dim_size(gradOutput, ndim, 0, batchSize);
+    if (indices.has_value()) {
+      check_dim_size(*indices, ndim, 0, batchSize);
+    }
+  }
 }
 
 // TODO(#196230): remove this alias once the torch-xpu-ops pin in

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -1618,6 +1618,23 @@ torch.cuda.synchronize()
                 indices,
             )
 
+    @onlyNativeDeviceTypes
+    def test_max_pool3d_with_indices_backward_batch_mismatch(self, device):
+        grad_output = torch.randn(1, 2, 1, 3, 2, device=device)
+        input = torch.randn(1, 2, 3, 6, 5, device=device)
+        indices = torch.zeros(0, 2, 1, 3, 2, dtype=torch.long, device=device)
+        with self.assertRaisesRegex(RuntimeError, "Expected a tensor of dimension"):
+            torch.ops.aten.max_pool3d_with_indices_backward(
+                grad_output,
+                input,
+                [3, 3, 3],
+                [2, 2, 2],
+                [0, 0, 0],
+                [1, 1, 1],
+                True,
+                indices,
+            )
+
     @onlyCPU
     @dtypes(torch.half, torch.bfloat16)
     def test_avg_pool2d_reduced_floating(self, device, dtype):

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -1843,6 +1843,23 @@ torch.{device_type}.synchronize()
                 indices,
             )
 
+    @onlyNativeDeviceTypes
+    def test_max_pool3d_with_indices_backward_batch_mismatch(self, device):
+        grad_output = torch.randn(1, 2, 1, 3, 2, device=device)
+        input = torch.randn(1, 2, 3, 6, 5, device=device)
+        indices = torch.zeros(0, 2, 1, 3, 2, dtype=torch.long, device=device)
+        with self.assertRaisesRegex(RuntimeError, "Expected a tensor of dimension"):
+            torch.ops.aten.max_pool3d_with_indices_backward(
+                grad_output,
+                input,
+                [3, 3, 3],
+                [2, 2, 2],
+                [0, 0, 0],
+                [1, 1, 1],
+                True,
+                indices,
+            )
+
     @dtypes(torch.float, torch.double)
     @dtypesIfMPS(torch.float)
     @expectedFailureMPS  # test_adaptive_pooling_max_nhwc currently fails on MPS - ISSUE#

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -5263,6 +5263,11 @@ def max_pool3d_backward_shape_check(
     check_dim_size(indices, ndim, ndim - 2, oheight)
     check_dim_size(indices, ndim, ndim - 1, owidth)
 
+    if ndim == 5:
+        batch_size = input.size(0)
+        check_dim_size(grad_output, ndim, 0, batch_size)
+        check_dim_size(indices, ndim, 0, batch_size)
+
 
 def avg_pool3d_backward_shape_check(
     input: Tensor,

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -5363,6 +5363,11 @@ def max_pool3d_backward_shape_check(
     check_dim_size(indices, ndim, ndim - 2, oheight)
     check_dim_size(indices, ndim, ndim - 1, owidth)
 
+    if ndim == 5:
+        batch_size = input.size(0)
+        check_dim_size(grad_output, ndim, 0, batch_size)
+        check_dim_size(indices, ndim, 0, batch_size)
+
 
 def avg_pool3d_backward_shape_check(
     input: Tensor,


### PR DESCRIPTION
Fixes #142459

## Summary

`max_pool3d_with_indices_backward` segfaults when the `indices` tensor has a mismatched batch dimension (e.g. batch 0 while input has batch 1). The backward kernel iterates over `input.size(0)` but indexes into `indices` with the same batch index, causing out-of-bounds access.

The existing `max_pool3d_backward_shape_check` validates channel and spatial dimensions of `gradOutput` and `indices` against the input, but does not validate the batch dimension. By contrast, `max_pool2d_backward_shape_check` already validates batch dim when `ndim == 4`.

This adds the same batch dimension check for the 3D case (`ndim == 5`) in both the C++ shape check (`Pool.h`) and the Python meta registration (`_meta_registrations.py`).

## Changes

- `aten/src/ATen/native/Pool.h` — add batch dim validation in `max_pool3d_backward_shape_check` (mirrors 2D pattern)
- `torch/_meta_registrations.py` — same check in Python meta path
- `test/nn/test_pooling.py` — add `test_max_pool3d_with_indices_backward_batch_mismatch` using the exact inputs from the issue

## Test plan

The new test calls `torch.ops.aten.max_pool3d_with_indices_backward` with `indices` batch dim 0 vs input batch dim 1 (the exact crash scenario from the issue) and asserts a `RuntimeError` is raised instead of segfaulting.

cc @mikaylagawarecki