### PR TITLE
Port xpu for test_fa4.

### DIFF
--- a/test/nn/attention/_fa_test_common.py
+++ b/test/nn/attention/_fa_test_common.py
@@ -259,7 +259,13 @@ class FlashAttentionTestMixin:
                 handles["dummy_impl_1"].removed, "dummy_impl_1 should be removed"
             )
         finally:
-            activate_flash_attention_impl(self.impl_name)  # reset for next test
+            # On XPU-only systems, activating "FA4" requires flash_attn (CUDA-only).
+            # Fall back to restoring the default impl instead.
+            xpu_only = torch.xpu.is_available() and not torch.cuda.is_available()
+            if xpu_only:
+                restore_flash_attention_impl()
+            else:
+                activate_flash_attention_impl(self.impl_name)  # reset for next test
 
     def _test_compiled_sdpa_metadata(self, device, dtype, is_causal):
         """Test that torch.compile preserves tensor metadata (shape, stride, dtype)."""

--- a/test/nn/attention/test_fa4.py
+++ b/test/nn/attention/test_fa4.py
@@ -15,15 +15,16 @@ from torch.testing._internal.common_utils import parametrize, run_tests, TestCas
 
 
 def _fa4_dependencies_available() -> bool:
-    if not torch.cuda.is_available():
+    if not (torch.cuda.is_available() or torch.xpu.is_available()):
         return False
-    major, _ = torch.cuda.get_device_capability(torch.cuda.current_device())
-    if major not in (9, 10):
-        return False
-    try:
-        importlib.import_module("flash_attn.cute.interface")
-    except ModuleNotFoundError:
-        return False
+    if torch.cuda.is_available():
+        major, _ = torch.cuda.get_device_capability(torch.cuda.current_device())
+        if major not in (9, 10):
+            return False
+        try:
+            importlib.import_module("flash_attn.cute.interface")
+        except ModuleNotFoundError:
+            return False
     return True
 
 
@@ -37,6 +38,9 @@ class TestFlashAttentionFA4(FlashAttentionTestMixin, TestCase):
     def setUpClass(cls):
         super().setUpClass()
         if not _fa4_dependencies_available():
+            return
+        # On XPU flash_attn package is not required; FA4 is registered via XPU-native path
+        if torch.xpu.is_available() and not torch.cuda.is_available():
             return
         # This might pollute tests.. TODO
         activate_flash_attention_impl("FA4")
@@ -75,6 +79,8 @@ class TestFlashAttentionFA4(FlashAttentionTestMixin, TestCase):
     @unittest.skipUnless(_fa4_dependencies_available(), "FA4 backend unavailable")
     @parametrize("dtype", [torch.float16, torch.bfloat16])
     def test_fa4_kernel_called(self, device, dtype):
+        if device.startswith("xpu"):
+            self.skipTest("test_fa4_kernel_called requires flash_attn package (CUDA-only)")
         self._test_kernel_called(device, dtype)
 
     @unittest.skipUnless(_fa4_dependencies_available(), "FA4 backend unavailable")
@@ -114,6 +120,8 @@ class TestFlashAttentionFA4(FlashAttentionTestMixin, TestCase):
     @parametrize("deterministic", [False, True])
     def test_deterministic_flag_passed_to_backward(self, device, deterministic):
         """Test that deterministic flag is correctly passed through to FA4 backward kernel."""
+        if device.startswith("xpu"):
+            self.skipTest("test_deterministic_flag_passed_to_backward is CUDA-specific (patches _fa4._fa4_import_module)")
         from torch.nn.attention import _fa4
 
         shape = SdpaShape(2, 4, 512, 128)
@@ -167,7 +175,7 @@ class TestFlashAttentionFA4(FlashAttentionTestMixin, TestCase):
             _fa4._fa4_import_module.cache_clear()
 
 
-instantiate_device_type_tests(TestFlashAttentionFA4, globals(), only_for="cuda")
+instantiate_device_type_tests(TestFlashAttentionFA4, globals(), only_for=("cuda", "xpu"), allow_xpu=True)
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
### Summary
This PR ports test_fa4.py and _fa_test_common.py to run on XPU devices. Previously the test suite was CUDA-only because it gated on flash_attn availability. On XPU, FA4 is registered natively via torch-xpu-ops without requiring the flash_attn package.

### Changes
- test/nn/attention/test_fa4.py

   - _fa4_dependencies_available(): Extend to return True when XPU is available, bypassing the CUDA capability check and flash_attn.cute.interface import (XPU FA4 is natively registered)
   - setUpClass(): Skip [activate_flash_attention_impl("FA4")](vscode-file://vscode-app/c:/Users/libohao/AppData/Local/Programs/Microsoft%20VS%20Code/7e7950df89/resources/app/out/vs/code/electron-browser/workbench/workbench.html) on XPU-only — the XPU backend is pre-registered and does not go through the CUDA flash_attn path
   - test_fa4_kernel_called: Skip on XPU — relies on CUDA profiler and flash_attn internals
   - test_deterministic_flag_passed_to_backward: Skip on XPU — patches [_fa4._fa4_import_module](vscode-file://vscode-app/c:/Users/libohao/AppData/Local/Programs/Microsoft%20VS%20Code/7e7950df89/resources/app/out/vs/code/electron-browser/workbench/workbench.html) which is a CUDA-only code path
   - instantiate_device_type_tests: Add "xpu" to only_for and allow_xpu=True to instantiate TestFlashAttentionFA4XPU
- test/nn/attention/_fa_test_common.py
   - _test_multiple_activate_impl finally block: On XPU-only systems, fall back to restore_flash_attention_impl() instead of activate_flash_attention_impl(self.impl_name). The latter calls register_flash_attention_fa4() which unconditionally imports flash_attn.cute.interface (CUDA-only), causing a ModuleNotFoundError on XPU.

### Test Plan
`python test/run_test.py -v -i nn/attention/test_fa4`