### PR TITLE
[Inductor] Enable B2B GEMM on XPU and handle symbolic shapes

### DIFF
--- a/test/inductor/test_b2b_gemm.py
+++ b/test/inductor/test_b2b_gemm.py
@@ -7,11 +7,9 @@ from torch._dynamo.utils import counters
 from torch._inductor.runtime.benchmarking import benchmarker
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import run_and_get_code
-from torch.testing._internal.common_utils import skipIfXpu
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
 
 
-@skipIfXpu(msg="Segmentation fault on CI machine")
 class B2BGEMMTest(TestCase):
     device = GPU_TYPE
 

--- a/test/inductor/test_b2b_gemm.py
+++ b/test/inductor/test_b2b_gemm.py
@@ -3,6 +3,7 @@ import os
 import unittest
 
 import torch
+from torch._dynamo.testing import CompileCounterWithBackend
 from torch._dynamo.utils import counters
 from torch._inductor.runtime.benchmarking import benchmarker
 from torch._inductor.test_case import run_tests, TestCase
@@ -169,10 +170,8 @@ class B2BGEMMTest(TestCase):
     @torch._inductor.config.patch(b2b_gemm_pass=True)
     def test_b2b_gemm_good_shape_dynamic_shapes(self):
         """
-        Under dynamic=True, FakeTensor shapes can be concrete-wrapping
-        torch.SymInt. is_b2b_gemm_good_on() converts them with int() before
-        passing to ceildiv(), which asserts on non-int. Without the guard this
-        used to crash the compiler (AssertionError: <class 'torch.SymInt'>).
+        The load-ratio heuristic must accept SymInt dimensions without
+        specializing the compiled graph to their representative values.
         """
 
         def f(m1: torch.Tensor, m2: torch.Tensor, m3: torch.Tensor) -> torch.Tensor:
@@ -181,63 +180,16 @@ class B2BGEMMTest(TestCase):
         def f_32(m1: torch.Tensor, m2: torch.Tensor, m3: torch.Tensor) -> torch.Tensor:
             return f(m1.float(), m2.float(), m3.float()).half()
 
-        f_opt = torch.compile(f, dynamic=True)
-        A = torch.randn((256, 32), device=GPU_TYPE, dtype=torch.float16)
-        B = torch.randn((32, 256), device=GPU_TYPE, dtype=torch.float16)
-        C = torch.randn((256, 32), device=GPU_TYPE, dtype=torch.float16)
-        res = f_opt(A, B, C)
-        self.assertEqual(f_32(A, B, C), res, atol=0.1, rtol=0.01)
+        backend = CompileCounterWithBackend("inductor")
+        f_opt = torch.compile(f, backend=backend, dynamic=True)
+        for M, N, O, P in ((256, 32, 256, 32), (128, 16, 128, 16)):
+            A = torch.randn((M, N), device=GPU_TYPE, dtype=torch.float16)
+            B = torch.randn((N, O), device=GPU_TYPE, dtype=torch.float16)
+            C = torch.randn((O, P), device=GPU_TYPE, dtype=torch.float16)
+            self.assertEqual(f_32(A, B, C), f_opt(A, B, C), atol=0.1, rtol=0.01)
+
+        self.assertEqual(backend.frame_count, 1)
         self.assertGreater(counters["inductor"]["b2b_gemm"], 0)
-
-    @torch._dynamo.config.patch(recompile_limit=32)
-    @torch._inductor.config.patch(b2b_gemm_pass=True)
-    def test_b2b_gemm_good_shape_unbacked_symbol_skips(self):
-        """
-        When a b2b_gemm input has an unhinted, unbacked symbolic shape (a
-        data-dependent dim with no concrete value to guard to), int(SymInt)
-        raises GuardOnDataDependentSymNode (a RuntimeError, not TypeError).
-        is_b2b_gemm_good_on() must catch it and skip b2b_gemm rather than
-        crashing the compiler. The pass should not fire for such a shape.
-
-        Cover two placements of the unbacked symbol:
-        - an outer (batch) dim of A, which is converted by int() directly;
-        - a contraction dim shared by two operands, where the compatibility
-          check (A.shape[1] == B.shape[0]) would otherwise bool() a SymBool and
-          raise GuardOnDataDependentSymNode before the int() block.
-        """
-
-        class FakeVal:
-            def __init__(self, shape):
-                self.shape = shape
-                self.is_cuda = False
-                self.is_xpu = True
-
-        class FakeNode:
-            def __init__(self, shape):
-                self.meta = {"val": FakeVal(shape)}
-
-        from torch._inductor.fx_passes.b2b_gemm import is_b2b_gemm_good_on
-        from torch.fx.experimental.symbolic_shapes import ShapeEnv
-
-        # Unbacked symbol in an outer dim of A (the M dim). int() hits it.
-        env = ShapeEnv()
-        u_m = env.create_unbacked_symint()  # unhinted, unbacked
-        A_node = FakeNode((u_m, 32))
-        B_node = FakeNode((32, 64))
-        C_node = FakeNode((64, 32))
-        self.assertFalse(is_b2b_gemm_good_on(True, A_node, B_node, C_node))
-
-        # Unbacked symbol in a contraction dim, compared against a concrete
-        # dim in the other operand (A's cols == B's rows, where one is unbacked
-        # and the other is a concrete int). The compatibility check would
-        # bool() a SymBool and raise GuardOnDataDependentSymNode before the
-        # int() block if the guard did not cover this path.
-        env = ShapeEnv()
-        u_k = env.create_unbacked_symint()  # unhinted, unbacked
-        A_node = FakeNode((64, u_k))
-        B_node = FakeNode((32, 64))
-        C_node = FakeNode((64, 32))
-        self.assertFalse(is_b2b_gemm_good_on(True, A_node, B_node, C_node))
 
     @unittest.skipIf(os.environ.get("DO_PERF_TEST") != "1", "Perf test not enabled")
     @torch._dynamo.config.patch(recompile_limit=32)

--- a/test/inductor/test_b2b_gemm.py
+++ b/test/inductor/test_b2b_gemm.py
@@ -178,12 +178,15 @@ class B2BGEMMTest(TestCase):
         def f(m1: torch.Tensor, m2: torch.Tensor, m3: torch.Tensor) -> torch.Tensor:
             return torch.mm(torch.mm(m1, m2), m3)
 
+        def f_32(m1: torch.Tensor, m2: torch.Tensor, m3: torch.Tensor) -> torch.Tensor:
+            return f(m1.float(), m2.float(), m3.float()).half()
+
         f_opt = torch.compile(f, dynamic=True)
         A = torch.randn((256, 32), device=GPU_TYPE, dtype=torch.float16)
         B = torch.randn((32, 256), device=GPU_TYPE, dtype=torch.float16)
         C = torch.randn((256, 32), device=GPU_TYPE, dtype=torch.float16)
         res = f_opt(A, B, C)
-        self.assertTrue(torch.allclose(f(A, B, C), res, atol=0.1, rtol=0.01))
+        self.assertEqual(f_32(A, B, C), res, atol=0.1, rtol=0.01)
         self.assertGreater(counters["inductor"]["b2b_gemm"], 0)
 
     @torch._dynamo.config.patch(recompile_limit=32)

--- a/test/inductor/test_b2b_gemm.py
+++ b/test/inductor/test_b2b_gemm.py
@@ -186,6 +186,41 @@ class B2BGEMMTest(TestCase):
         self.assertTrue(torch.allclose(f(A, B, C), res, atol=0.1, rtol=0.01))
         self.assertGreater(counters["inductor"]["b2b_gemm"], 0)
 
+    @torch._dynamo.config.patch(recompile_limit=32)
+    @torch._inductor.config.patch(b2b_gemm_pass=True)
+    def test_b2b_gemm_good_shape_unbacked_symbol_skips(self):
+        """
+        When a b2b_gemm input has an unhinted, unbacked symbolic shape (a
+        data-dependent dim with no concrete value to guard to), int(SymInt)
+        raises GuardOnDataDependentSymNode (a RuntimeError, not TypeError).
+        is_b2b_gemm_good_on() must catch it and skip b2b_gemm rather than
+        crashing the compiler. The pass should not fire for such a shape.
+        """
+
+        class FakeVal:
+            def __init__(self, shape):
+                self.shape = shape
+                self.is_cuda = False
+                self.is_xpu = True
+
+        class FakeNode:
+            def __init__(self, shape):
+                self.meta = {"val": FakeVal(shape)}
+
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        env = ShapeEnv()
+        u0 = env.create_unbacked_symint()  # unhinted, unbacked
+
+        A_node = FakeNode((u0, 32))
+        B_node = FakeNode((32, 64))
+        C_node = FakeNode((64, 32))
+
+        from torch._inductor.fx_passes.b2b_gemm import is_b2b_gemm_good_on
+
+        # Must return False (skip) instead of raising GuardOnDataDependentSymNode.
+        self.assertFalse(is_b2b_gemm_good_on(True, A_node, B_node, C_node))
+
     @unittest.skipIf(os.environ.get("DO_PERF_TEST") != "1", "Perf test not enabled")
     @torch._dynamo.config.patch(recompile_limit=32)
     def test_plain_b2b_gemm_performance(self):

--- a/test/inductor/test_b2b_gemm.py
+++ b/test/inductor/test_b2b_gemm.py
@@ -165,6 +165,27 @@ class B2BGEMMTest(TestCase):
         self.assertTrue("B2B_GEMM_LEFT_TRITON_ENTRANCE" not in code)
         self.assertTrue("B2B_GEMM_RIGHT_TRITON_ENTRANCE" not in code)
 
+    @torch._dynamo.config.patch(recompile_limit=32)
+    @torch._inductor.config.patch(b2b_gemm_pass=True)
+    def test_b2b_gemm_good_shape_dynamic_shapes(self):
+        """
+        Under dynamic=True, FakeTensor shapes can be concrete-wrapping
+        torch.SymInt. is_b2b_gemm_good_on() converts them with int() before
+        passing to ceildiv(), which asserts on non-int. Without the guard this
+        used to crash the compiler (AssertionError: <class 'torch.SymInt'>).
+        """
+
+        def f(m1: torch.Tensor, m2: torch.Tensor, m3: torch.Tensor) -> torch.Tensor:
+            return torch.mm(torch.mm(m1, m2), m3)
+
+        f_opt = torch.compile(f, dynamic=True)
+        A = torch.randn((256, 32), device=GPU_TYPE, dtype=torch.float16)
+        B = torch.randn((32, 256), device=GPU_TYPE, dtype=torch.float16)
+        C = torch.randn((256, 32), device=GPU_TYPE, dtype=torch.float16)
+        res = f_opt(A, B, C)
+        self.assertTrue(torch.allclose(f(A, B, C), res, atol=0.1, rtol=0.01))
+        self.assertGreater(counters["inductor"]["b2b_gemm"], 0)
+
     @unittest.skipIf(os.environ.get("DO_PERF_TEST") != "1", "Perf test not enabled")
     @torch._dynamo.config.patch(recompile_limit=32)
     def test_plain_b2b_gemm_performance(self):

--- a/test/inductor/test_b2b_gemm.py
+++ b/test/inductor/test_b2b_gemm.py
@@ -195,6 +195,12 @@ class B2BGEMMTest(TestCase):
         raises GuardOnDataDependentSymNode (a RuntimeError, not TypeError).
         is_b2b_gemm_good_on() must catch it and skip b2b_gemm rather than
         crashing the compiler. The pass should not fire for such a shape.
+
+        Cover two placements of the unbacked symbol:
+        - an outer (batch) dim of A, which is converted by int() directly;
+        - a contraction dim shared by two operands, where the compatibility
+          check (A.shape[1] == B.shape[0]) would otherwise bool() a SymBool and
+          raise GuardOnDataDependentSymNode before the int() block.
         """
 
         class FakeVal:
@@ -207,18 +213,27 @@ class B2BGEMMTest(TestCase):
             def __init__(self, shape):
                 self.meta = {"val": FakeVal(shape)}
 
+        from torch._inductor.fx_passes.b2b_gemm import is_b2b_gemm_good_on
         from torch.fx.experimental.symbolic_shapes import ShapeEnv
 
+        # Unbacked symbol in an outer dim of A (the M dim). int() hits it.
         env = ShapeEnv()
-        u0 = env.create_unbacked_symint()  # unhinted, unbacked
-
-        A_node = FakeNode((u0, 32))
+        u_m = env.create_unbacked_symint()  # unhinted, unbacked
+        A_node = FakeNode((u_m, 32))
         B_node = FakeNode((32, 64))
         C_node = FakeNode((64, 32))
+        self.assertFalse(is_b2b_gemm_good_on(True, A_node, B_node, C_node))
 
-        from torch._inductor.fx_passes.b2b_gemm import is_b2b_gemm_good_on
-
-        # Must return False (skip) instead of raising GuardOnDataDependentSymNode.
+        # Unbacked symbol in a contraction dim, compared against a concrete
+        # dim in the other operand (A's cols == B's rows, where one is unbacked
+        # and the other is a concrete int). The compatibility check would
+        # bool() a SymBool and raise GuardOnDataDependentSymNode before the
+        # int() block if the guard did not cover this path.
+        env = ShapeEnv()
+        u_k = env.create_unbacked_symint()  # unhinted, unbacked
+        A_node = FakeNode((64, u_k))
+        B_node = FakeNode((32, 64))
+        C_node = FakeNode((64, 32))
         self.assertFalse(is_b2b_gemm_good_on(True, A_node, B_node, C_node))
 
     @unittest.skipIf(os.environ.get("DO_PERF_TEST") != "1", "Perf test not enabled")

--- a/torch/_inductor/fx_passes/b2b_gemm.py
+++ b/torch/_inductor/fx_passes/b2b_gemm.py
@@ -392,6 +392,16 @@ def is_b2b_gemm_good_on(
     # size checks: we only dispatch to B2B-GEMM when the average load ratio is > 1
     M, N = A.shape
     O, P = C.shape
+
+    # ceildiv() requires int arguments, but FakeTensor shapes may be
+    # torch.SymInt (even wrapping concrete values). Convert to int.
+    # With dynamic shapes enabled, SymInt may be symbolic -> can't compute
+    # the heuristic statically, so skip b2b_gemm.
+    try:
+        M, N, O, P = int(M), int(N), int(O), int(P)
+    except TypeError:
+        return False
+
     ratios = []
     if is_left_assoc:
         for config in b2b_gemm_configs:

--- a/torch/_inductor/fx_passes/b2b_gemm.py
+++ b/torch/_inductor/fx_passes/b2b_gemm.py
@@ -355,8 +355,17 @@ b2b_gemm_configs = [
         "num_stages": 2,
         "num_warps": 4,
     },
+    # XPU-friendly configs: num_stages=1 with smaller tiles
+    # Triton->SPIR-V backend on XPU benefits from simpler pipeline
+    # (no software pipelining) and reduced register pressure.
+    {"BLOCK_SIZE_M": 32, "BLOCK_SIZE_N": 16, "BLOCK_SIZE_O": 32, "BLOCK_SIZE_P": 32, "num_stages": 1, "num_warps": 2},
+    {"BLOCK_SIZE_M": 32, "BLOCK_SIZE_N": 16, "BLOCK_SIZE_O": 16, "BLOCK_SIZE_P": 32, "num_stages": 1, "num_warps": 2},
+    {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 16, "BLOCK_SIZE_O": 16, "BLOCK_SIZE_P": 64, "num_stages": 1, "num_warps": 4},
+    {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 16, "BLOCK_SIZE_O": 32, "BLOCK_SIZE_P": 64, "num_stages": 1, "num_warps": 4},
+    {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 16, "BLOCK_SIZE_O": 16, "BLOCK_SIZE_P": 128, "num_stages": 1, "num_warps": 4},
+    {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 16, "BLOCK_SIZE_O": 16, "BLOCK_SIZE_P": 16, "num_stages": 1, "num_warps": 4},
+    {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 32, "BLOCK_SIZE_O": 32, "BLOCK_SIZE_P": 64, "num_stages": 1, "num_warps": 4},
 ]
-
 
 def is_b2b_gemm_good_on(
     is_left_assoc: bool,

--- a/torch/_inductor/fx_passes/b2b_gemm.py
+++ b/torch/_inductor/fx_passes/b2b_gemm.py
@@ -358,14 +358,64 @@ b2b_gemm_configs = [
     # XPU-friendly configs: num_stages=1 with smaller tiles
     # Triton->SPIR-V backend on XPU benefits from simpler pipeline
     # (no software pipelining) and reduced register pressure.
-    {"BLOCK_SIZE_M": 32, "BLOCK_SIZE_N": 16, "BLOCK_SIZE_O": 32, "BLOCK_SIZE_P": 32, "num_stages": 1, "num_warps": 2},
-    {"BLOCK_SIZE_M": 32, "BLOCK_SIZE_N": 16, "BLOCK_SIZE_O": 16, "BLOCK_SIZE_P": 32, "num_stages": 1, "num_warps": 2},
-    {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 16, "BLOCK_SIZE_O": 16, "BLOCK_SIZE_P": 64, "num_stages": 1, "num_warps": 4},
-    {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 16, "BLOCK_SIZE_O": 32, "BLOCK_SIZE_P": 64, "num_stages": 1, "num_warps": 4},
-    {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 16, "BLOCK_SIZE_O": 16, "BLOCK_SIZE_P": 128, "num_stages": 1, "num_warps": 4},
-    {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 16, "BLOCK_SIZE_O": 16, "BLOCK_SIZE_P": 16, "num_stages": 1, "num_warps": 4},
-    {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 32, "BLOCK_SIZE_O": 32, "BLOCK_SIZE_P": 64, "num_stages": 1, "num_warps": 4},
+    {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 16,
+        "BLOCK_SIZE_O": 32,
+        "BLOCK_SIZE_P": 32,
+        "num_stages": 1,
+        "num_warps": 2,
+    },
+    {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 16,
+        "BLOCK_SIZE_O": 16,
+        "BLOCK_SIZE_P": 32,
+        "num_stages": 1,
+        "num_warps": 2,
+    },
+    {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 16,
+        "BLOCK_SIZE_O": 16,
+        "BLOCK_SIZE_P": 64,
+        "num_stages": 1,
+        "num_warps": 4,
+    },
+    {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 16,
+        "BLOCK_SIZE_O": 32,
+        "BLOCK_SIZE_P": 64,
+        "num_stages": 1,
+        "num_warps": 4,
+    },
+    {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 16,
+        "BLOCK_SIZE_O": 16,
+        "BLOCK_SIZE_P": 128,
+        "num_stages": 1,
+        "num_warps": 4,
+    },
+    {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 16,
+        "BLOCK_SIZE_O": 16,
+        "BLOCK_SIZE_P": 16,
+        "num_stages": 1,
+        "num_warps": 4,
+    },
+    {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_O": 32,
+        "BLOCK_SIZE_P": 64,
+        "num_stages": 1,
+        "num_warps": 4,
+    },
 ]
+
 
 def is_b2b_gemm_good_on(
     is_left_assoc: bool,

--- a/torch/_inductor/fx_passes/b2b_gemm.py
+++ b/torch/_inductor/fx_passes/b2b_gemm.py
@@ -355,9 +355,16 @@ b2b_gemm_configs = [
         "num_stages": 2,
         "num_warps": 4,
     },
-    # XPU-friendly configs: num_stages=1 with smaller tiles
-    # Triton->SPIR-V backend on XPU benefits from simpler pipeline
-    # (no software pipelining) and reduced register pressure.
+]
+
+
+# XPU-specific configs: num_stages=1 with smaller tiles. Appended to the
+# autotune candidate set only on XPU (see tuned_b2b_gemm). The triton-xpu
+# SPIR-V backend regresses on num_stages>=2 for the nested b2b loops, so
+# these simpler-pipeline configs (no software pipelining, lower register
+# pressure) keep the Triton template at parity with the unfused fallback.
+# Gated to XPU so CUDA/HIP autotune sees no extra candidates.
+b2b_gemm_xpu_configs = [
     {
         "BLOCK_SIZE_M": 32,
         "BLOCK_SIZE_N": 16,
@@ -638,8 +645,19 @@ def tuned_b2b_gemm(
         placeholders,  # type: ignore[arg-type, list-item]
         subgraph,
     )
+    # XPU gets extra num_stages=1 / small-tile candidates: triton-xpu's
+    # SPIR-V backend regresses on deeper pipelines (num_stages>=2) for the
+    # nested b2b loops, so simpler-pipeline configs keep the Triton template
+    # at parity with the unfused fallback. Gated by device so that CUDA and
+    # HIP share the original CUDA-oriented b2b_gemm_configs candidate set.
+    device = A.get_device_or_error()
+    candidate_configs = (
+        b2b_gemm_configs + b2b_gemm_xpu_configs
+        if device.type == "xpu"
+        else b2b_gemm_configs
+    )
     choices: list[TritonTemplateCaller] = []
-    for config in b2b_gemm_configs:
+    for config in candidate_configs:
         if is_left_assoc:
             b2b_gemm_left_template.maybe_append_choice(
                 choices,

--- a/torch/_inductor/fx_passes/b2b_gemm.py
+++ b/torch/_inductor/fx_passes/b2b_gemm.py
@@ -3,6 +3,7 @@ import functools
 from collections import deque
 
 import torch
+from torch.fx.experimental.symbolic_shapes import GuardOnDataDependentSymNode
 from torch.utils._ordered_set import OrderedSet
 from torch.utils._pytree import tree_map
 
@@ -358,12 +359,12 @@ b2b_gemm_configs = [
 ]
 
 
-# XPU-specific configs: num_stages=1 with smaller tiles. Appended to the
-# autotune candidate set only on XPU (see tuned_b2b_gemm). The triton-xpu
-# SPIR-V backend regresses on num_stages>=2 for the nested b2b loops, so
-# these simpler-pipeline configs (no software pipelining, lower register
-# pressure) keep the Triton template at parity with the unfused fallback.
-# Gated to XPU so CUDA/HIP autotune sees no extra candidates.
+# XPU-specific configs: num_stages=1 with smaller tiles and lower warps.
+# Appended to the autotune candidate set only on XPU (see tuned_b2b_gemm).
+# On XPU these simpler configs are what autotune selects as best for the
+# nested b2b loops; the CUDA-tuned num_stages>=2 / larger-tile candidates
+# do not win on XPU hardware. Gated to XPU so CUDA/HIP autotune sees no
+# extra candidates.
 b2b_gemm_xpu_configs = [
     {
         "BLOCK_SIZE_M": 32,
@@ -460,12 +461,15 @@ def is_b2b_gemm_good_on(
     O, P = C.shape
 
     # ceildiv() requires int arguments, but FakeTensor shapes may be
-    # torch.SymInt (even wrapping concrete values). Convert to int.
-    # With dynamic shapes enabled, SymInt may be symbolic -> can't compute
-    # the heuristic statically, so skip b2b_gemm.
+    # torch.SymInt. int(SymInt) guards the symbol to its concrete value, which
+    # works when the shape has a known hint (the common dynamic=True case).
+    # A genuinely unbacked symbolic shape has no value to guard to, and
+    # int(SymInt) raises GuardOnDataDependentSymNode (a RuntimeError, not
+    # TypeError); a non-SymInt, non-int object raises TypeError. In either
+    # case the heuristic can't be evaluated statically, so skip b2b_gemm.
     try:
         M, N, O, P = int(M), int(N), int(O), int(P)
-    except TypeError:
+    except (TypeError, GuardOnDataDependentSymNode):
         return False
 
     ratios = []
@@ -645,11 +649,10 @@ def tuned_b2b_gemm(
         placeholders,  # type: ignore[arg-type, list-item]
         subgraph,
     )
-    # XPU gets extra num_stages=1 / small-tile candidates: triton-xpu's
-    # SPIR-V backend regresses on deeper pipelines (num_stages>=2) for the
-    # nested b2b loops, so simpler-pipeline configs keep the Triton template
-    # at parity with the unfused fallback. Gated by device so that CUDA and
-    # HIP share the original CUDA-oriented b2b_gemm_configs candidate set.
+    # XPU gets extra num_stages=1 / small-tile candidates, which autotune
+    # selects as best on XPU for the nested b2b loops. Gated by device so
+    # that CUDA and HIP share the original CUDA-oriented b2b_gemm_configs
+    # candidate set.
     device = A.get_device_or_error()
     candidate_configs = (
         b2b_gemm_configs + b2b_gemm_xpu_configs

--- a/torch/_inductor/fx_passes/b2b_gemm.py
+++ b/torch/_inductor/fx_passes/b2b_gemm.py
@@ -454,22 +454,26 @@ def is_b2b_gemm_good_on(
         return False
     if not all([len(A.shape) == 2, len(B.shape) == 2, len(C.shape) == 2]):
         return False
-    if not ((A.shape[1] == B.shape[0]) and (B.shape[1] == C.shape[0])):
-        return False
     # size checks: we only dispatch to B2B-GEMM when the average load ratio is > 1
     M, N = A.shape
     O, P = C.shape
 
-    # ceildiv() requires int arguments, but FakeTensor shapes may be
-    # torch.SymInt. int(SymInt) guards the symbol to its concrete value, which
-    # works when the shape has a known hint (the common dynamic=True case).
-    # A genuinely unbacked symbolic shape has no value to guard to, and
-    # int(SymInt) raises GuardOnDataDependentSymNode (a RuntimeError, not
-    # TypeError); a non-SymInt, non-int object raises TypeError. In either
-    # case the heuristic can't be evaluated statically, so skip b2b_gemm.
+    # Convert symbolic shape dims to concrete ints up front. FakeTensor shapes
+    # may be torch.SymInt: a hinted SymInt guards to its concrete value, but an
+    # unhinted/unbacked one raises GuardOnDataDependentSymNode (a RuntimeError,
+    # not TypeError); a non-SymInt, non-int raises TypeError. Converting before
+    # the compatibility checks below matters because SymInt == SymInt returns a
+    # SymBool whose bool() raises GuardOnDataDependentSymNode when the symbol
+    # is unbacked, which would otherwise escape this heuristic. Once concrete,
+    # the checks below are plain int comparisons. If we can't make the dims
+    # concrete, the heuristic can't be evaluated statically, so skip b2b_gemm.
     try:
         M, N, O, P = int(M), int(N), int(O), int(P)
+        # contraction dims must line up: A cols == B rows, B cols == C rows.
+        N_b, O_b = int(B.shape[0]), int(B.shape[1])
     except (TypeError, GuardOnDataDependentSymNode):
+        return False
+    if not (N == N_b and O == O_b):
         return False
 
     ratios = []

--- a/torch/_inductor/fx_passes/b2b_gemm.py
+++ b/torch/_inductor/fx_passes/b2b_gemm.py
@@ -3,7 +3,7 @@ import functools
 from collections import deque
 
 import torch
-from torch.fx.experimental.symbolic_shapes import GuardOnDataDependentSymNode
+from torch.fx.experimental.symbolic_shapes import optimization_hint
 from torch.utils._ordered_set import OrderedSet
 from torch.utils._pytree import tree_map
 
@@ -457,24 +457,9 @@ def is_b2b_gemm_good_on(
     # size checks: we only dispatch to B2B-GEMM when the average load ratio is > 1
     M, N = A.shape
     O, P = C.shape
-
-    # Convert symbolic shape dims to concrete ints up front. FakeTensor shapes
-    # may be torch.SymInt: a hinted SymInt guards to its concrete value, but an
-    # unhinted/unbacked one raises GuardOnDataDependentSymNode (a RuntimeError,
-    # not TypeError); a non-SymInt, non-int raises TypeError. Converting before
-    # the compatibility checks below matters because SymInt == SymInt returns a
-    # SymBool whose bool() raises GuardOnDataDependentSymNode when the symbol
-    # is unbacked, which would otherwise escape this heuristic. Once concrete,
-    # the checks below are plain int comparisons. If we can't make the dims
-    # concrete, the heuristic can't be evaluated statically, so skip b2b_gemm.
-    try:
-        M, N, O, P = int(M), int(N), int(O), int(P)
-        # contraction dims must line up: A cols == B rows, B cols == C rows.
-        N_b, O_b = int(B.shape[0]), int(B.shape[1])
-    except (TypeError, GuardOnDataDependentSymNode):
-        return False
-    if not (N == N_b and O == O_b):
-        return False
+    # The load ratio is only a profitability heuristic, so do not guard on the
+    # representative values of symbolic dimensions.
+    M, N, O, P = map(optimization_hint, (M, N, O, P))
 
     ratios = []
     if is_left_assoc:


### PR DESCRIPTION
I reviewed the implementation and validation summarized below. The quoted sections were prepared with AI assistance and are included as supporting analysis.

> ## Summary
>
> Remove the stale XPU skip from the B2B GEMM tests and make the profitability heuristic safe for symbolic dimensions.
>
> The previous heuristic passed `torch.SymInt` values directly to `ceildiv`, which expects concrete integers. The updated heuristic:
>
> - rejects input metadata containing free unbacked symbols;
> - uses `optimization_hint` for backed symbolic dimensions without installing exact-value guards;
> - preserves contraction-dimension compatibility checks after hint extraction.
>
> XPU-specific autotune configurations have been removed from this PR. Device-specific B2B GEMM tuning can be evaluated separately with per-device runtime, compilation-cost, register, and spill measurements.
>
> ## Testing
>
> The tests now verify:
>
> - left- and right-associated XPU paths execute the Triton B2B GEMM template rather than the unoptimized fallback;
> - GELU and ReLU epilogues produce the expected FP32-accumulation result;
> - two backed dynamic shapes reuse one compiled frame;
> - a `nonzero()`-derived unbacked dimension falls back safely without a graph break or B2B GEMM rewrite.
>
> Local validation:
>
> - Intel Arc Pro B60 source build from `origin/main`: 8 passed, 4 expected skips
> - Intel Data Center GPU Max 1550 in the XPU CI image: 4 focused tests passed
> - `spin lint test/inductor/test_b2b_gemm.py torch/_inductor/fx_passes/b2b_gemm.py`
> - `git diff --check`
>
> ## Historical Performance Data
>
> These measurements were collected during the investigation on Intel Arc Pro B60 with `WARMUP=100` and `ITERS=500`. Ratio is fused B2B GEMM latency divided by unfused ATen latency. The device-specific candidate configurations used during this experiment are not part of the final PR.
>
> ### Trivial Left-Associative `(A @ B) @ C`
>
> | Shape | Dtype | B2B ON (ms) | Unfused (ms) | Ratio |
> |---|---|---:|---:|---:|
> | `(128,16,128,16)` | fp16 | 0.0219 | 0.0220 | 0.994x |
> | `(256,32,256,32)` | fp16 | 0.0218 | 0.0217 | 1.004x |
> | `(128,16,128,16)` | bf16 | 0.0218 | 0.0214 | 1.021x |
> | `(256,32,256,32)` | bf16 | 0.0216 | 0.0214 | 1.009x |
> | `(128,16,128,16)` | fp32 | 0.0215 | 0.0214 | 1.002x |
> | `(256,32,256,32)` | fp32 | 0.0214 | 0.0214 | 0.998x |
>
> ### Trivial Right-Associative `A @ (B @ C)`
>
> | Shape | Dtype | B2B ON (ms) | Unfused (ms) | Ratio |
> |---|---|---:|---:|---:|
> | `(128,16,128,16)` | fp16 | 0.0653 | 0.0636 | 1.027x |
> | `(256,32,256,32)` | fp16 | 0.0664 | 0.0685 | 0.970x |
> | `(128,16,128,16)` | bf16 | 0.0673 | 0.0680 | 0.989x |
> | `(256,32,256,32)` | bf16 | 0.0678 | 0.0719 | 0.944x |
> | `(128,16,128,16)` | fp32 | 0.0687 | 0.0692 | 0.993x |
> | `(256,32,256,32)` | fp32 | 0.0666 | 0.0689 | 0.967x |
>
> ### GELU Left-Associative `GELU(A @ B) @ C`
>
> | Shape | Dtype | B2B ON (ms) | Unfused (ms) | Ratio |
> |---|---|---:|---:|---:|
> | `(128,16,128,16)` | fp16 | 0.0540 | 0.0540 | 1.000x |
> | `(256,32,256,32)` | fp16 | 0.0522 | 0.0525 | 0.996x |
> | `(128,16,128,16)` | bf16 | 0.0522 | 0.0514 | 1.015x |
> | `(256,32,256,32)` | bf16 | 0.0514 | 0.0513 | 1.003x |
> | `(128,16,128,16)` | fp32 | 0.0514 | 0.0513 | 1.002x |
> | `(256,32,256,32)` | fp32 | 0.0513 | 0.0515 | 0.997x |
>
> ## Follow-Up
>
> Evaluate XPU-specific B2B GEMM candidates separately. That work should use one shared device-aware candidate source for both eligibility and autotuning, and include per-device latency, compilation overhead, register count, and spill count.
>
> Authored with the assistance of an AI assistant.