### PR TITLE
Fix weights_only unpickler blocklist asymmetry

### DIFF
--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -1406,6 +1406,51 @@ class TestSerialization(TestCase, SerializationMixin):
                 with self.assertRaisesRegex(pickle.UnpicklingError, error_msg):
                     torch.load(f, weights_only=True)
 
+    def test_weights_only_blocklist_code_execution_modules(self):
+        import marshal
+        with BytesIOContext() as f:
+            torch.save(marshal.loads, f)
+            f.seek(0)
+            with safe_globals([marshal.loads]):
+                with self.assertRaisesRegex(
+                    pickle.UnpicklingError,
+                    "marshal.loads whose module marshal is blocked",
+                ):
+                    torch.load(f, weights_only=True)
+
+    def test_weights_only_blocklist_builtins_eval(self):
+        with BytesIOContext() as f:
+            torch.save(eval, f)
+            f.seek(0)
+            with safe_globals([eval]):
+                with self.assertRaisesRegex(
+                    pickle.UnpicklingError,
+                    "builtins.eval which is blocked",
+                ):
+                    torch.load(f, weights_only=True)
+
+    def test_weights_only_blocklist_builtins_getattr(self):
+        with BytesIOContext() as f:
+            torch.save(getattr, f)
+            f.seek(0)
+            with safe_globals([getattr]):
+                with self.assertRaisesRegex(
+                    pickle.UnpicklingError,
+                    "builtins.getattr which is blocked",
+                ):
+                    torch.load(f, weights_only=True)
+
+    def test_weights_only_blocklist_pickle_module(self):
+        with BytesIOContext() as f:
+            torch.save(pickle.loads, f)
+            f.seek(0)
+            with safe_globals([pickle.loads]):
+                with self.assertRaisesRegex(
+                    pickle.UnpicklingError,
+                    "pickle.loads whose module pickle is blocked",
+                ):
+                    torch.load(f, weights_only=True)
+
     @parametrize("unsafe_global", [True, False])
     def test_weights_only_error(self, unsafe_global):
         sd = {'t': TwoTensor(torch.randn(2), torch.randn(2))}

--- a/torch/_weights_only_unpickler.py
+++ b/torch/_weights_only_unpickler.py
@@ -82,6 +82,27 @@ _blocklisted_modules = [
     "os",
     "posix",
     "nt",
+    "subprocess",
+    "commands",
+    "ctypes",
+    "runpy",
+    "importlib",
+    "pickle",
+    "_pickle",
+    "cPickle",
+    "marshal",
+]
+
+# individual globals that are never allowed, even if the user attempts to
+# allowlist them via add_safe_globals
+_blocklisted_globals = [
+    "builtins.eval",
+    "builtins.exec",
+    "builtins.compile",
+    "builtins.__import__",
+    "builtins.getattr",
+    "builtins.setattr",
+    "builtins.delattr",
 ]
 
 _marked_safe_globals_set: set[Callable | tuple[Callable, str]] = set()
@@ -334,6 +355,10 @@ class Unpickler:
                 if module in _blocklisted_modules:
                     raise UnpicklingError(
                         f"Trying to load unsupported GLOBAL {full_path} whose module {module} is blocked."
+                    )
+                if full_path in _blocklisted_globals:
+                    raise UnpicklingError(
+                        f"Trying to load unsupported GLOBAL {full_path} which is blocked."
                     )
                 if full_path in _get_allowed_globals():
                     self.append(_get_allowed_globals()[full_path])


### PR DESCRIPTION
## Summary

Fixes #189445

The `_blocklisted_modules` in `torch/_weights_only_unpickler.py` only blocked `os`, `sys`, `posix`, and `nt` — but other dangerous code-execution primitives (`eval`, `exec`, `subprocess.*`, `pickle.loads`, `marshal.*`, etc.) could bypass security when explicitly added via `add_safe_globals`. This made the blocklist asymmetric: `os.system` was hard-rejected even when allowlisted, while `eval` was not.

**Changes:**

- **Expanded `_blocklisted_modules`** to cover: `subprocess`, `commands` (Py2 alias), `ctypes`, `runpy`, `importlib`, `pickle`, `_pickle`, `cPickle` (Py2 alias), `marshal`
- **Added `_blocklisted_globals`** for individual dangerous builtins that cannot be module-blocked: `eval`, `exec`, `compile`, `__import__`, `getattr`, `setattr`, `delattr`
- Both checks fire **before** the allowlist lookup, ensuring these primitives are never loadable regardless of user configuration
- Added 4 tests covering module-level blocks and globals-level blocks

## Test plan

- [x] `test_weights_only_blocklist_code_execution_modules` — verifies `marshal` module is blocked even with `safe_globals`
- [x] `test_weights_only_blocklist_builtins_eval` — verifies `builtins.eval` is blocked even with `safe_globals`
- [x] `test_weights_only_blocklist_builtins_getattr` — verifies `builtins.getattr` is blocked (attribute gadget attacks)
- [x] `test_weights_only_blocklist_pickle_module` — verifies `pickle.loads` is blocked (re-entrant deserialization)
- [x] Regression tested: normal `torch.save`/`torch.load` of tensors and model state dicts still works
- [x] Linting passes (`ruff check`, `flake8`)

