### PR TITLE
Raise RuntimeError if failed to allocate pin memory on XPU

### DIFF
--- a/aten/src/ATen/xpu/CachingHostAllocator.cpp
+++ b/aten/src/ATen/xpu/CachingHostAllocator.cpp
@@ -14,6 +14,11 @@ struct XPUCachingHostAllocatorImpl
   void allocate_host_memory(size_t size, void** ptr) override {
     *ptr = sycl::aligned_alloc_host(
         kHostAlignment, size, c10::xpu::get_device_context());
+    TORCH_CHECK(
+        *ptr != nullptr,
+        "Failed to allocate ",
+        CachingAllocator::format_size(size),
+        " of pinned host memory.");
   }
 
   void free_block(Block* block) override {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #189681

# Motivation
Previously, failing to allocate a large-sized host pin buffer would crash. Here, refine the logic to avoid a crash.

reproduer:
```python
import torch
size = 32*1024**3
cpu_tensor = torch.zeros((size, 1), dtype=torch.int8, device="cpu", pin_memory=True)
```

<img width="764" height="72" alt="image" src="https://github.com/user-attachments/assets/a3fae0ef-97e6-4ba7-8021-644980876b0d" />



