### PR TITLE
[Testcase Refactoring] Enable PrivateUse1 tests and add hw-classification in test_transformer

### DIFF
--- a/test/distributed/pipelining/test_transformer.py
+++ b/test/distributed/pipelining/test_transformer.py
@@ -3,7 +3,11 @@
 import torch
 from torch.distributed.pipelining import pipeline, SplitPoint
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 d_hid = 16
@@ -35,6 +39,8 @@ class TransformerLike(torch.nn.Module):
 
 
 class TransformerTests(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def test_ir(self, device):
         transformer = TransformerLike().to(device)
         x = torch.randn(microbatch_size, d_hid, device=device)
@@ -74,10 +80,7 @@ class TransformerTests(TestCase):
         print(f"Equivalence test passed {torch.sum(out)} ref {torch.sum(ref)}")
 
 
-devices = ["cpu", "cuda", "hpu", "xpu"]
-instantiate_device_type_tests(
-    TransformerTests, globals(), only_for=devices, allow_xpu=True
-)
+instantiate_device_type_tests(TransformerTests, globals(), allow_xpu=True)
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary
Enable the `test_ir` device-type variant for out-of-tree PrivateUse1 accelerators in `test/distributed/pipelining/test_transformer.py`, and classify `TransformerTests` as `HardwareClassification.ACCELERATOR`.

## Changes
- Drop the `only_for=["cpu", "cuda", "hpu", "xpu"]` argument (and the now-unused `devices` list) from `instantiate_device_type_tests`, keeping `allow_xpu=True`. With `only_for` removed, `get_desired_device_type_test_bases` auto-registers `PrivateUse1TestBase` when `_is_privateuse1_backend_available()`, so the PrivateUse1 variant of `test_ir` is generated alongside the existing cpu/cuda/hpu/xpu variants. Zero-loss: HPU is added unconditionally on `TEST_HPU`, XPU via `allow_xpu`, and the only addition is PrivateUse1.
- Set `hw_classification = HardwareClassification.ACCELERATOR` on `TransformerTests`. `test_ir` builds a model on `device`, runs `pipeline(...)` and asserts the pipelined output matches eager -- accelerator-generic behavior with no CUDA-specific paths. The classification is metadata: it only filters tests when `--hw-classification` is passed; normal discovery/execution is unchanged.

## Motivation
`test_ir` was never generated for out-of-tree PrivateUse1 accelerators because the explicit `only_for` list excluded PrivateUse1. Dropping it lets the framework's existing PrivateUse1 infrastructure (`PrivateUse1TestBase`, `_is_privateuse1_backend_available`) discover the backend automatically. The `HardwareClassification.ACCELERATOR` tag participates in the hardware-classification filtering initiative, so `--hw-classification ACCELERATOR` selects this test across every accelerator backend.

## Test Plan
```
python test/distributed/pipelining/test_transformer.py -v
python test/distributed/pipelining/test_transformer.py -v --hw-classification ACCELERATOR
python test/distributed/pipelining/test_transformer.py -v --hw-classification CPU
python test/distributed/pipelining/test_transformer.py -v --hw-classification GENERIC
```
Verified on a PrivateUse1 host (8 devices): the PrivateUse1 variant of `test_ir` is auto-generated (`TransformerTestsPRIVATEUSE1`) and passes alongside `test_ir_cpu` (normal run: Ran 2, OK). `--hw-classification ACCELERATOR` includes `test_ir` (total=2, passed=2); `--hw-classification CPU` and `--hw-classification GENERIC` filter it out (mismatched=2, Ran 0 each), confirming the filter is category-specific.

## Notes
This is part of the test case refactoring initiative tracked in #185590.
