### PR TITLE
Port XPU for test_masked.py

### DIFF
--- a/test/test_masked.py
+++ b/test/test_masked.py
@@ -16,7 +16,7 @@ from torch.testing._internal.common_utils import \
 from torch.testing._internal.common_methods_invocations import \
     (op_db, SampleInput)
 from torch.testing._internal.common_device_type import \
-    (instantiate_device_type_tests, ops, onlyNativeDeviceTypes, precisionOverride)
+    (instantiate_device_type_tests, ops, onlyNativeDeviceTypes, precisionOverride, skipOps, skip)
 
 
 def apply_masked_reduction_along_dim(op, input, *args, **kwargs):
@@ -298,6 +298,10 @@ class TestMasked(TestCase):
     @suppress_warnings
     @ops(masked_ops_with_non_strided_support)
     @precisionOverride({torch.bfloat16: 5e-3, torch.float16: 5e-3})
+    @skipOps([
+        # FIXME: scatter_gather_base_kernel_func not implemented for ComplexFloat/ComplexDouble on XPU (sparse_coo inputs)
+        skip('masked.prod', dtypes=[torch.complex64, torch.complex128], device_type='xpu'),
+    ])
     def test_mask_layout(self, layout, device, dtype, op, sample_inputs):
         for sample in sample_inputs:
             t_inp, t_args, t_kwargs = sample.input, sample.args, sample.kwargs
@@ -431,7 +435,7 @@ class TestMasked(TestCase):
         self.assertEqual(dense, expected)
 
 
-instantiate_device_type_tests(TestMasked, globals(), except_for='meta')
+instantiate_device_type_tests(TestMasked, globals(), except_for='meta', allow_xpu=True)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/test_masked.py
+++ b/test/test_masked.py
@@ -17,7 +17,7 @@ from torch.testing._internal.common_utils import \
 from torch.testing._internal.common_methods_invocations import \
     (op_db, SampleInput)
 from torch.testing._internal.common_device_type import \
-    (instantiate_device_type_tests, ops, precisionOverride)
+    (instantiate_device_type_tests, ops, precisionOverride, skipOps, skip)
 
 
 def apply_masked_reduction_along_dim(op, input, *args, **kwargs):
@@ -298,6 +298,10 @@ class TestMasked(TestCase):
     @suppress_warnings
     @ops(masked_ops_with_non_strided_support)
     @precisionOverride({torch.bfloat16: 5e-3, torch.float16: 5e-3})
+    @skipOps([
+        # FIXME: scatter_gather_base_kernel_func not implemented for ComplexFloat/ComplexDouble on XPU (sparse_coo inputs)
+        skip('masked.prod', dtypes=[torch.complex64, torch.complex128], device_type='xpu'),
+    ])
     def test_mask_layout(self, layout, device, dtype, op, sample_inputs):
         for sample in sample_inputs:
             t_inp, t_args, t_kwargs = sample.input, sample.args, sample.kwargs
@@ -437,7 +441,7 @@ class TestMaskedGeneric(TestCase):
         self.assertEqual(dense, expected)
 
 
-instantiate_device_type_tests(TestMasked, globals(), except_for='meta')
+instantiate_device_type_tests(TestMasked, globals(), except_for='meta', allow_xpu=True)
 instantiate_parametrized_tests(TestMaskedGeneric)
 
 if __name__ == "__main__":

--- a/test/test_masked.py
+++ b/test/test_masked.py
@@ -17,7 +17,7 @@ from torch.testing._internal.common_utils import \
 from torch.testing._internal.common_methods_invocations import \
     (op_db, SampleInput)
 from torch.testing._internal.common_device_type import \
-    (instantiate_device_type_tests, ops, precisionOverride, skipOps, skip)
+    (instantiate_device_type_tests, ops, precisionOverride)
 
 
 def apply_masked_reduction_along_dim(op, input, *args, **kwargs):
@@ -298,10 +298,6 @@ class TestMasked(TestCase):
     @suppress_warnings
     @ops(masked_ops_with_non_strided_support)
     @precisionOverride({torch.bfloat16: 5e-3, torch.float16: 5e-3})
-    @skipOps([
-        # FIXME: scatter_gather_base_kernel_func not implemented for ComplexFloat/ComplexDouble on XPU (sparse_coo inputs)
-        skip('masked.prod', dtypes=[torch.complex64, torch.complex128], device_type='xpu'),
-    ])
     def test_mask_layout(self, layout, device, dtype, op, sample_inputs):
         for sample in sample_inputs:
             t_inp, t_args, t_kwargs = sample.input, sample.args, sample.kwargs

--- a/torch/testing/_internal/opinfo/definitions/_masked.py
+++ b/torch/testing/_internal/opinfo/definitions/_masked.py
@@ -567,6 +567,14 @@ op_db: list[OpInfo] = [
                 device_type="cuda",
                 dtypes=(torch.bool, *integral_types(), *complex_types()),
             ),
+            # FIXME: scatter_gather_base_kernel_func not implemented for ComplexFloat/ComplexDouble on XPU (sparse_coo inputs)
+            DecorateInfo(
+                unittest.skip("Skipped!"),
+                "TestMasked",
+                "test_mask_layout",
+                device_type="xpu",
+                dtypes=(torch.complex64, torch.complex128),
+            ),
             # Driver issue of XPU, see https://github.com/intel/torch-xpu-ops/issues/2295
             DecorateInfo(
                 unittest.skip("Skipped!"),


### PR DESCRIPTION
For https://github.com/pytorch/pytorch/issues/114850, we will port masked-op test cases to Intel GPU. We could enable Intel GPU with the following methods and try the best to keep the original code styles:

- Instantiate device-type tests with XPU enabled via `instantiate_device_type_tests()`

- Add targeted skips with `skipOps` for known XPU failures

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98


### Summary

Skip test_mask_layout for masked.prod with complex64/complex128 on XPU, where scatter_gather_base_kernel_func is not yet implemented for complex types in the XPU backend. Also adds allow_xpu=True to instantiate_device_type_tests to properly enable XPU test variants. 



### Changes

- Import skipOps and skip from common_device_type and add @skipOps on test_mask_layout to skip masked.prod for complex64/complex128 on XPU.
- Add allow_xpu=True to instantiate_device_type_tests so XPU test variants are properly instantiated and the skips take effect.


### Test Plan
`pytest -v test/test_masked.py  `




