### PR TITLE
[MPS] add linalg eig

### DIFF
--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -2939,7 +2939,9 @@ static std::tuple<Tensor&, Tensor&> linalg_eig_out_info(const Tensor& input, Ten
     auto imag_values = real_imag_values.slice(/*dim=*/-1, /*start=*/input.size(-1));
 
     // if the imaginary part is zero we don't need to do anything
-    bool is_zero_imag = at::all(imag_values == 0.0).item().toBool();
+    const bool is_zero_imag = input.is_mps()
+        ? at::all(imag_values.view(kInt).bitwise_and(0x7fffffff) == 0).item().toBool()
+        : at::all(imag_values == 0.0).item().toBool();
     if (is_zero_imag) {
       values.copy_(real_values);
       if (compute_eigenvectors) {

--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.h
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.h
@@ -50,6 +50,11 @@ struct EighParams {
   float tol;
 };
 
+struct EigParams {
+  uint32_t n;
+  uint32_t compute_v;
+};
+
 // for LU streaming-panel kernels
 C10_METAL_CONSTEXPR unsigned kLUStreamNT = 256;
 C10_METAL_CONSTEXPR unsigned kLUStreamWarpsPerTG =

--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
@@ -3330,6 +3330,39 @@ constant float kEigOvfl = 3.40282347e+38f;
 constant float kEigLarfgSafmin = 1.9721523e-31f; // 'S' / 'E' (slarfg)
 constant float kEigRtmin = 1.08420217e-19f; // sqrt(2^-126) (slartg)
 constant float kEigRtmax = 6.51872567e+18f; // sqrt(2^126 / 2)
+constant float kEigScaleMin = 9.09494702e-13f; // sqrt('S') / 'P' (sgeev)
+constant float kEigScaleMax = 1.09951163e+12f; // 1 / kEigScaleMin
+
+static inline float eig_scale_float(float x, float scale) {
+  if (scale == 1.0f) {
+    return x;
+  }
+  const uint bits = as_type<uint>(x);
+  const uint mantissa = bits & 0x007fffffu;
+  const uint sign = bits & 0x80000000u;
+  if ((bits & 0x7f800000u) == 0u) {
+    if (mantissa == 0u) {
+      return x;
+    }
+    if (scale > 1.0f) {
+      const float magnitude = float(mantissa) * ldexp(scale, -149);
+      return sign == 0u ? magnitude : -magnitude;
+    }
+    const uint scaled_mantissa = uint(rint(float(mantissa) * scale));
+    return as_type<float>(sign | scaled_mantissa);
+  }
+  const float y = x * scale;
+  if (fabs(y) >= kEigSafmin || !isfinite(y)) {
+    return y;
+  }
+  int x_exp, scale_exp;
+  const float x_mantissa = frexp(fabs(x), x_exp);
+  const float scale_mantissa = frexp(scale, scale_exp);
+  const float units =
+      ldexp(x_mantissa * scale_mantissa, x_exp + scale_exp + 149);
+  const uint scaled_mantissa = uint(rint(units));
+  return as_type<float>(sign | scaled_mantissa);
+}
 
 // Fortran SIGN(a, b): |a| if b >= 0 else -|a| (not copysign: SIGN(x,-0)=+x)
 static inline float eig_sign(float a, float b) {
@@ -3892,9 +3925,37 @@ kernel void eig_qr_float(
 #define OUTRE(i) outre_s[(i) - 1]
 #define OUTIM(i) outim_s[(i) - 1]
 
+  uint local_max_bits = 0u;
+  for (uint idx = tid; idx < n * n; idx += nt) {
+    local_max_bits = max(local_max_bits, as_type<uint>(A_b[idx]) & 0x7fffffffu);
+  }
+  scr[tid] = as_type<float>(local_max_bits);
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  uint anrm_bits = 0u;
+  for (uint t = 0; t < nt; ++t) {
+    anrm_bits = max(anrm_bits, as_type<uint>(scr[t]));
+  }
+  float input_scale = 1.0f;
+  float output_scale = 1.0f;
+  if (anrm_bits != 0u && anrm_bits < as_type<uint>(kEigScaleMin)) {
+    const float anrm = as_type<float>(anrm_bits);
+    if ((anrm_bits & 0x7f800000u) == 0u) {
+      const float mantissa = float(anrm_bits & 0x007fffffu);
+      input_scale = ldexp(kEigScaleMin, 149) / mantissa;
+      output_scale = mantissa * ldexp(kEigScaleMax, -149);
+    } else {
+      input_scale = kEigScaleMin / anrm;
+      output_scale = anrm / kEigScaleMin;
+    }
+  } else if (anrm_bits > as_type<uint>(kEigScaleMax)) {
+    const float anrm = as_type<float>(anrm_bits);
+    input_scale = kEigScaleMax / anrm;
+    output_scale = anrm / kEigScaleMax;
+  }
+
   // load A into H; init Q = I
   for (uint idx = tid; idx < n * n; idx += nt) {
-    Htg[idx] = A_b[idx];
+    Htg[idx] = eig_scale_float(A_b[idx], input_scale);
     if (wantv) {
       Qtg[idx] = (idx % n) == (idx / n) ? 1.0f : 0.0f;
     }
@@ -3903,7 +3964,7 @@ kernel void eig_qr_float(
 
   if (n == 1) {
     if (tid == 0) {
-      val_b[0] = Htg[0];
+      val_b[0] = eig_scale_float(Htg[0], output_scale);
       val_b[1] = 0.0f;
       if (wantv) {
         vec_b[0] = 1.0f;
@@ -4268,8 +4329,8 @@ kernel void eig_qr_float(
   // write eigenvalues (geev layout: wr | wi); on info > 0 the leading entries
   // are unconverged garbage, matching LAPACK (the host raises on info anyway)
   for (uint idx = 1 + tid; idx <= n; idx += nt) {
-    val_b[idx - 1] = WR1(idx);
-    val_b[n + idx - 1] = WI1(idx);
+    val_b[idx - 1] = eig_scale_float(WR1(idx), output_scale);
+    val_b[n + idx - 1] = eig_scale_float(WI1(idx), output_scale);
   }
   if (tid == 0) {
     infos[b] = info;
@@ -4629,9 +4690,10 @@ kernel void eig_make_complex_float(
   const uint off = tid % (n * n);
   const uint j = off / n;
   const float wi = values[bidx * n + j].y;
-  if (wi == 0.0f) {
+  const uint wi_bits = as_type<uint>(wi);
+  if ((wi_bits & 0x7fffffffu) == 0u) {
     out[tid] = float2(vr[tid], 0.0f);
-  } else if (wi > 0.0f) {
+  } else if ((wi_bits & 0x80000000u) == 0u) {
     out[tid] = float2(vr[tid], vr[tid + n]);
   } else {
     out[tid] = float2(vr[tid - n], -vr[tid]);
@@ -4641,32 +4703,39 @@ kernel void eig_make_complex_float(
 // Right-eigenvector backsolve for the hybrid large-matrix path.
 kernel void eig_trevc_col_float(
     device const float* T [[buffer(0)]],
-    device const float* cnorm [[buffer(1)]],
+    device const float* aux [[buffer(1)]], // [diag|sub|super|cnorm|scale] rows
     device float* X [[buffer(2)]],
     constant uint& n [[buffer(3)]],
+    constant uint& kbase [[buffer(4)]],
+    constant uint& xim_off [[buffer(5)]],
     threadgroup float* xtg [[threadgroup(0)]],
     uint3 thread_pos [[thread_position_in_threadgroup]],
     uint3 tpg [[threads_per_threadgroup]],
     uint3 tg_pos [[threadgroup_position_in_grid]]) {
   const uint tid = thread_pos.x;
   const uint nt = tpg.x;
-  const uint ki = tg_pos.x + 1; // 1-based eigenvector column
+  const uint ki = kbase + tg_pos.x + 1; // 1-based eigenvector column
   device const float* T_b = T + ulong(tg_pos.y) * n * n; // column-major, ld = n
-  device const float* cn_b = cnorm + ulong(tg_pos.y) * n;
+  device const float* aux_b = aux + ulong(tg_pos.y) * 5 * n;
   device float* X_b = X + ulong(tg_pos.y) * n * n; // column-major, ld = n
 #define TT(i, j) T_b[((i) - 1) + ((j) - 1) * n]
-#define CN1(j) cn_b[(j) - 1]
+// the serial solve reads diag/sub/superdiag entries scalar-by-scalar; strided
+// TT loads make each a fresh cache line, so they come gathered contiguous
+#define DG1(j) aux_b[(j) - 1] // TT(j, j)
+#define SB1(j) aux_b[n + (j) - 1] // TT(j+1, j)
+#define SP1(j) aux_b[2 * n + (j) - 1] // TT(j, j+1)
+#define CN1(j) aux_b[3 * n + (j) - 1]
 #define XRE(i) xtg[(i) - 1]
-#define XIM(i) xtg[n + (i) - 1]
-  if (ki < n && TT(ki + 1, ki) != 0.0f) {
+#define XIM(i) xtg[xim_off + (i) - 1]
+  if (ki < n && SB1(ki) != 0.0f) {
     return; // left column of a 2x2 block: written by the ki+1 threadgroup
   }
+  const bool pair = ki > 1 && SB1(ki - 1) != 0.0f;
   const float smlnum_tv = kEigSafmin * (float(n) / kEigUlp);
   const float bignum_tv = (1.0f - kEigUlp) / smlnum_tv;
-  const bool pair = ki > 1 && TT(ki, ki - 1) != 0.0f;
-  const float wr = TT(ki, ki);
+  const float wr = DG1(ki);
   const float wi =
-      pair ? sqrt(fabs(TT(ki, ki - 1))) * sqrt(fabs(TT(ki - 1, ki))) : 0.0f;
+      pair ? sqrt(fabs(SB1(ki - 1))) * sqrt(fabs(SP1(ki - 1))) : 0.0f;
   const float smin = max(kEigUlp * (fabs(wr) + fabs(wi)), smlnum_tv);
 
   if (!pair) {
@@ -4686,7 +4755,7 @@ kernel void eig_trevc_col_float(
       const uint ju = uint(j);
       uint j1 = ju;
       jnxt = j - 1;
-      if (j > 1 && TT(ju, ju - 1) != 0.0f) {
+      if (j > 1 && SB1(ju - 1) != 0.0f) {
         j1 = ju - 1;
         jnxt = j - 2;
       }
@@ -4702,7 +4771,7 @@ kernel void eig_trevc_col_float(
             1,
             1,
             smin,
-            TT(ju, ju),
+            DG1(ju),
             0.0f,
             0.0f,
             0.0f,
@@ -4741,10 +4810,10 @@ kernel void eig_trevc_col_float(
             2,
             1,
             smin,
-            TT(ju - 1, ju - 1),
-            TT(ju - 1, ju),
-            TT(ju, ju - 1),
-            TT(ju, ju),
+            DG1(ju - 1),
+            SP1(ju - 1),
+            SB1(ju - 1),
+            DG1(ju),
             b1,
             0.0f,
             b2,
@@ -4785,11 +4854,11 @@ kernel void eig_trevc_col_float(
   } else {
     // ---- complex right eigenvector (pair in columns ki-1, ki) ----
     float x0re, x0im; // seeds for XRE(ki-1), XIM(ki)
-    if (fabs(TT(ki - 1, ki)) >= fabs(TT(ki, ki - 1))) {
+    if (fabs(SP1(ki - 1)) >= fabs(SB1(ki - 1))) {
       x0re = 1.0f;
-      x0im = wi / TT(ki - 1, ki);
+      x0im = wi / SP1(ki - 1);
     } else {
-      x0re = -wi / TT(ki, ki - 1);
+      x0re = -wi / SB1(ki - 1);
       x0im = 1.0f;
     }
     if (tid == 0) {
@@ -4811,7 +4880,7 @@ kernel void eig_trevc_col_float(
       const uint ju = uint(j);
       uint j1 = ju;
       jnxt = j - 1;
-      if (j > 1 && TT(ju, ju - 1) != 0.0f) {
+      if (j > 1 && SB1(ju - 1) != 0.0f) {
         j1 = ju - 1;
         jnxt = j - 2;
       }
@@ -4825,7 +4894,7 @@ kernel void eig_trevc_col_float(
             1,
             2,
             smin,
-            TT(ju, ju),
+            DG1(ju),
             0.0f,
             0.0f,
             0.0f,
@@ -4870,10 +4939,10 @@ kernel void eig_trevc_col_float(
             2,
             2,
             smin,
-            TT(ju - 1, ju - 1),
-            TT(ju - 1, ju),
-            TT(ju, ju - 1),
-            TT(ju, ju),
+            DG1(ju - 1),
+            SP1(ju - 1),
+            SB1(ju - 1),
+            DG1(ju),
             b1r,
             b1i,
             b2r,
@@ -4921,6 +4990,9 @@ kernel void eig_trevc_col_float(
     }
   }
 #undef TT
+#undef DG1
+#undef SB1
+#undef SP1
 #undef CN1
 #undef XRE
 #undef XIM

--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
@@ -3319,3 +3319,1734 @@ kernel void eigh_jacobi(
 
 REGISTER_EIGH_JACOBI(float);
 REGISTER_EIGH_JACOBI(float2);
+
+// Batched small-matrix LAPACK sgeev port.
+constant float kEigSafmin = 1.17549435e-38f; // 'S'
+constant float kEigEps = 5.9604645e-08f; // 'E' (rounded eps, 2^-24)
+constant float kEigUlp = 1.1920929e-07f; // 'P' (eps * base, 2^-23)
+constant float kEigSafmn2 = 4.44089210e-16f; // 2^-51 (slanv2)
+constant float kEigSafmx2 = 2.25179981e+15f; // 2^51
+constant float kEigOvfl = 3.40282347e+38f;
+constant float kEigLarfgSafmin = 1.9721523e-31f; // 'S' / 'E' (slarfg)
+constant float kEigRtmin = 1.08420217e-19f; // sqrt(2^-126) (slartg)
+constant float kEigRtmax = 6.51872567e+18f; // sqrt(2^126 / 2)
+
+// Fortran SIGN(a, b): |a| if b >= 0 else -|a| (not copysign: SIGN(x,-0)=+x)
+static inline float eig_sign(float a, float b) {
+  return b >= 0.0f ? fabs(a) : -fabs(a);
+}
+
+static inline float eig_lapy2(float x, float y) {
+  float xa = fabs(x), ya = fabs(y);
+  float w = max(xa, ya), z = min(xa, ya);
+  return z == 0.0f ? w : w * sqrt(1.0f + (z / w) * (z / w));
+}
+
+// scaled two-pass 2-norm over a threadgroup-memory vector, stride 1
+static inline float eig_nrm2_tg(threadgroup const float* x, uint len) {
+  float amax = 0.0f;
+  for (uint i = 0; i < len; ++i) {
+    amax = max(amax, fabs(x[i]));
+  }
+  if (amax == 0.0f) {
+    return 0.0f;
+  }
+  float s = 0.0f;
+  for (uint i = 0; i < len; ++i) {
+    float t = x[i] / amax;
+    s += t * t;
+  }
+  return amax * sqrt(s);
+}
+
+// SLADIV (Baudin-Smith robust complex division): (p, q) = (a + bi) / (c + di)
+static inline float eig_sladiv2(
+    float a,
+    float b,
+    float c,
+    float d,
+    float r,
+    float t) {
+  if (r != 0.0f) {
+    float br = b * r;
+    if (br != 0.0f) {
+      return (a + br) * t;
+    }
+    return a * t + (b * t) * r;
+  }
+  return (a + d * (b / c)) * t;
+}
+
+static inline void eig_sladiv1(
+    float a,
+    float b,
+    float c,
+    float d,
+    thread float& p,
+    thread float& q) {
+  float r = d / c;
+  float t = 1.0f / (c + d * r);
+  p = eig_sladiv2(a, b, c, d, r, t);
+  q = eig_sladiv2(b, -a, c, d, r, t);
+}
+
+static inline void eig_sladiv(
+    float a,
+    float b,
+    float c,
+    float d,
+    thread float& p,
+    thread float& q) {
+  float aa = a, bb = b, cc = c, dd = d;
+  float ab = max(fabs(a), fabs(b));
+  float cd = max(fabs(c), fabs(d));
+  float s = 1.0f;
+  const float be = 2.0f / (kEigEps * kEigEps);
+  if (ab >= 0.5f * kEigOvfl) {
+    aa *= 0.5f;
+    bb *= 0.5f;
+    s *= 2.0f;
+  }
+  if (cd >= 0.5f * kEigOvfl) {
+    cc *= 0.5f;
+    dd *= 0.5f;
+    s *= 0.5f;
+  }
+  if (ab <= kEigSafmin * 2.0f / kEigEps) {
+    aa *= be;
+    bb *= be;
+    s /= be;
+  }
+  if (cd <= kEigSafmin * 2.0f / kEigEps) {
+    cc *= be;
+    dd *= be;
+    s *= be;
+  }
+  if (fabs(d) <= fabs(c)) {
+    eig_sladiv1(aa, bb, cc, dd, p, q);
+  } else {
+    eig_sladiv1(bb, aa, dd, cc, p, q);
+    q = -q;
+  }
+  p *= s;
+  q *= s;
+}
+
+// SLARTG (LAPACK 3.10 scaled version)
+static inline void eig_slartg(
+    float f,
+    float g,
+    thread float& c,
+    thread float& s,
+    thread float& r) {
+  float f1 = fabs(f), g1 = fabs(g);
+  if (g == 0.0f) {
+    c = 1.0f;
+    s = 0.0f;
+    r = f;
+  } else if (f == 0.0f) {
+    c = 0.0f;
+    s = eig_sign(1.0f, g);
+    r = g1;
+  } else if (
+      f1 > kEigRtmin && f1 < kEigRtmax && g1 > kEigRtmin && g1 < kEigRtmax) {
+    float d = sqrt(f * f + g * g);
+    c = f1 / d;
+    r = eig_sign(d, f);
+    s = g / r;
+  } else {
+    float u = min(1.0f / kEigSafmin, max(kEigSafmin, max(f1, g1)));
+    float fs = f / u, gs = g / u;
+    float d = sqrt(fs * fs + gs * gs);
+    c = fabs(fs) / d;
+    r = eig_sign(d, f);
+    s = gs / r;
+    r = r * u;
+  }
+}
+
+// SLARFG on registers, nr in {2, 3}: v[0]=alpha in, v[0]=beta out, returns tau
+static inline float eig_slarfg_reg(uint nr, thread float* v) {
+  float xnorm = nr == 3 ? eig_lapy2(v[1], v[2]) : fabs(v[1]);
+  if (xnorm == 0.0f) {
+    return 0.0f;
+  }
+  float alpha = v[0];
+  float beta = -eig_sign(eig_lapy2(alpha, xnorm), alpha);
+  uint knt = 0;
+  if (fabs(beta) < kEigLarfgSafmin) {
+    const float rsafmn = 1.0f / kEigLarfgSafmin;
+    do {
+      knt++;
+      v[1] *= rsafmn;
+      if (nr == 3) {
+        v[2] *= rsafmn;
+      }
+      beta *= rsafmn;
+      alpha *= rsafmn;
+    } while (fabs(beta) < kEigLarfgSafmin && knt < 20);
+    xnorm = nr == 3 ? eig_lapy2(v[1], v[2]) : fabs(v[1]);
+    beta = -eig_sign(eig_lapy2(alpha, xnorm), alpha);
+  }
+  float tau = (beta - alpha) / beta;
+  float scal = 1.0f / (alpha - beta);
+  v[1] *= scal;
+  if (nr == 3) {
+    v[2] *= scal;
+  }
+  for (uint j = 0; j < knt; ++j) {
+    beta *= kEigLarfgSafmin;
+  }
+  v[0] = beta;
+  return tau;
+}
+
+// Standardize a real 2x2 matrix to Schur form.
+static inline void eig_slanv2(
+    thread float& a,
+    thread float& b,
+    thread float& c,
+    thread float& d,
+    thread float& rt1r,
+    thread float& rt1i,
+    thread float& rt2r,
+    thread float& rt2i,
+    thread float& cs,
+    thread float& sn) {
+  if (c == 0.0f) {
+    cs = 1.0f;
+    sn = 0.0f;
+  } else if (b == 0.0f) {
+    // swap rows and columns
+    cs = 0.0f;
+    sn = 1.0f;
+    float temp = d;
+    d = a;
+    a = temp;
+    b = -c;
+    c = 0.0f;
+  } else if ((a - d) == 0.0f && eig_sign(1.0f, b) != eig_sign(1.0f, c)) {
+    cs = 1.0f;
+    sn = 0.0f;
+  } else {
+    float temp = a - d;
+    float p = 0.5f * temp;
+    float bcmax = max(fabs(b), fabs(c));
+    float bcmis = min(fabs(b), fabs(c)) * eig_sign(1.0f, b) * eig_sign(1.0f, c);
+    float scale = max(fabs(p), bcmax);
+    float z = (p / scale) * p + (bcmax / scale) * bcmis;
+    if (z >= 4.0f * kEigEps) {
+      // real eigenvalues; compute a and d
+      z = p + eig_sign(sqrt(scale) * sqrt(z), p);
+      a = d + z;
+      d = d - (bcmax / z) * bcmis;
+      float tau = eig_lapy2(c, z);
+      cs = z / tau;
+      sn = c / tau;
+      b = b - c;
+      c = 0.0f;
+    } else {
+      // complex or nearly-equal real eigenvalues: make diagonal equal
+      uint count = 0;
+      float sigma = b + c;
+      do {
+        count++;
+        scale = max(fabs(temp), fabs(sigma));
+        if (scale >= kEigSafmx2) {
+          sigma *= kEigSafmn2;
+          temp *= kEigSafmn2;
+        } else if (scale <= kEigSafmn2) {
+          sigma *= kEigSafmx2;
+          temp *= kEigSafmx2;
+        } else {
+          break;
+        }
+      } while (count <= 20);
+      p = 0.5f * temp;
+      float tau = eig_lapy2(sigma, temp);
+      cs = sqrt(0.5f * (1.0f + fabs(sigma) / tau));
+      sn = -(p / (tau * cs)) * eig_sign(1.0f, sigma);
+      float aa = a * cs + b * sn;
+      float bb = -a * sn + b * cs;
+      float cc = c * cs + d * sn;
+      float dd = -c * sn + d * cs;
+      // parentheses defeat FMA contraction (LAPACK issue #1031)
+      a = aa * cs + cc * sn;
+      b = (bb * cs) + (dd * sn);
+      c = -(aa * sn) + (cc * cs);
+      d = -bb * sn + dd * cs;
+      temp = 0.5f * (a + d);
+      a = temp;
+      d = temp;
+      if (c != 0.0f) {
+        if (b != 0.0f) {
+          if (eig_sign(1.0f, b) == eig_sign(1.0f, c)) {
+            // real eigenvalues: reduce to upper triangular form
+            float sab = sqrt(fabs(b));
+            float sac = sqrt(fabs(c));
+            p = eig_sign(sab * sac, c);
+            tau = 1.0f / sqrt(fabs(b + c));
+            a = temp + p;
+            d = temp - p;
+            b = b - c;
+            c = 0.0f;
+            float cs1 = sab * tau;
+            float sn1 = sac * tau;
+            temp = cs * cs1 - sn * sn1;
+            sn = cs * sn1 + sn * cs1;
+            cs = temp;
+          }
+        } else {
+          b = -c;
+          c = 0.0f;
+          temp = cs;
+          cs = -sn;
+          sn = temp;
+        }
+      }
+    }
+  }
+  rt1r = a;
+  rt2r = d;
+  if (c == 0.0f) {
+    rt1i = 0.0f;
+    rt2i = 0.0f;
+  } else {
+    rt1i = sqrt(fabs(b)) * sqrt(fabs(c));
+    rt2i = -rt1i;
+  }
+}
+
+// Solve the SLALN2 cases used by the eigenvector backsolve.
+static inline void eig_slaln2(
+    uint na,
+    uint nw,
+    float smin,
+    float a11,
+    float a12,
+    float a21,
+    float a22,
+    float b1r,
+    float b1i,
+    float b2r,
+    float b2i,
+    float wr,
+    float wi,
+    thread float* x,
+    thread float& scale,
+    thread float& xnorm) {
+  const float smlnum = 2.0f * kEigSafmin;
+  const float bignum = 1.0f / smlnum;
+  const float smini = max(smin, smlnum);
+  scale = 1.0f;
+  if (na == 1) {
+    if (nw == 1) {
+      float csr = a11 - wr;
+      float cnorm = fabs(csr);
+      if (cnorm < smini) {
+        csr = smini;
+        cnorm = smini;
+      }
+      float bnorm = fabs(b1r);
+      if (cnorm < 1.0f && bnorm > 1.0f && bnorm > bignum * cnorm) {
+        scale = 1.0f / bnorm;
+      }
+      x[0] = (b1r * scale) / csr;
+      xnorm = fabs(x[0]);
+    } else {
+      float csr = a11 - wr;
+      float csi = -wi;
+      float cnorm = fabs(csr) + fabs(csi);
+      if (cnorm < smini) {
+        csr = smini;
+        csi = 0.0f;
+        cnorm = smini;
+      }
+      float bnorm = fabs(b1r) + fabs(b1i);
+      if (cnorm < 1.0f && bnorm > 1.0f && bnorm > bignum * cnorm) {
+        scale = 1.0f / bnorm;
+      }
+      eig_sladiv(scale * b1r, scale * b1i, csr, csi, x[0], x[2]);
+      xnorm = fabs(x[0]) + fabs(x[2]);
+    }
+    return;
+  }
+  // 2x2 system; crv holds C column-major: {c11, c21, c12, c22}
+  float crv[4];
+  crv[0] = a11 - wr;
+  crv[3] = a22 - wr;
+  crv[1] = a21;
+  crv[2] = a12;
+  const bool cswap[4] = {false, false, true, true};
+  const bool rswap[4] = {false, true, false, true};
+  const uint ipivot[4][4] = {
+      {1, 2, 3, 4}, {2, 1, 4, 3}, {3, 4, 1, 2}, {4, 3, 2, 1}};
+  if (nw == 1) {
+    float cmax = 0.0f;
+    uint icmax = 0;
+    for (uint j = 0; j < 4; ++j) {
+      if (fabs(crv[j]) > cmax) {
+        cmax = fabs(crv[j]);
+        icmax = j + 1;
+      }
+    }
+    if (cmax < smini) {
+      float bnorm = max(fabs(b1r), fabs(b2r));
+      if (smini < 1.0f && bnorm > 1.0f && bnorm > bignum * smini) {
+        scale = 1.0f / bnorm;
+      }
+      float temp = scale / smini;
+      x[0] = temp * b1r;
+      x[1] = temp * b2r;
+      xnorm = temp * bnorm;
+      return;
+    }
+    // Gaussian elimination with complete pivoting
+    float ur11 = crv[icmax - 1];
+    float cr21 = crv[ipivot[icmax - 1][1] - 1];
+    float ur12 = crv[ipivot[icmax - 1][2] - 1];
+    float cr22 = crv[ipivot[icmax - 1][3] - 1];
+    float ur11r = 1.0f / ur11;
+    float lr21 = ur11r * cr21;
+    float ur22 = cr22 - ur12 * lr21;
+    if (fabs(ur22) < smini) {
+      ur22 = smini;
+    }
+    float br1 = rswap[icmax - 1] ? b2r : b1r;
+    float br2 = rswap[icmax - 1] ? b1r : b2r;
+    br2 = br2 - lr21 * br1;
+    float bbnd = max(fabs(br1 * (ur22 * ur11r)), fabs(br2));
+    if (bbnd > 1.0f && fabs(ur22) < 1.0f && bbnd >= bignum * fabs(ur22)) {
+      scale = 1.0f / bbnd;
+    }
+    float xr2 = (br2 * scale) / ur22;
+    float xr1 = (scale * br1) * ur11r - xr2 * (ur11r * ur12);
+    x[0] = cswap[icmax - 1] ? xr2 : xr1;
+    x[1] = cswap[icmax - 1] ? xr1 : xr2;
+    xnorm = max(fabs(xr1), fabs(xr2));
+    if (xnorm > 1.0f && cmax > 1.0f && xnorm > bignum / cmax) {
+      float temp = cmax / bignum;
+      x[0] *= temp;
+      x[1] *= temp;
+      xnorm *= temp;
+      scale *= temp;
+    }
+    return;
+  }
+  // complex 2x2
+  float civ[4];
+  civ[0] = -wi;
+  civ[1] = 0.0f;
+  civ[2] = 0.0f;
+  civ[3] = -wi;
+  float cmax = 0.0f;
+  uint icmax = 0;
+  for (uint j = 0; j < 4; ++j) {
+    if (fabs(crv[j]) + fabs(civ[j]) > cmax) {
+      cmax = fabs(crv[j]) + fabs(civ[j]);
+      icmax = j + 1;
+    }
+  }
+  if (cmax < smini) {
+    float bnorm = max(fabs(b1r) + fabs(b1i), fabs(b2r) + fabs(b2i));
+    if (smini < 1.0f && bnorm > 1.0f && bnorm > bignum * smini) {
+      scale = 1.0f / bnorm;
+    }
+    float temp = scale / smini;
+    x[0] = temp * b1r;
+    x[1] = temp * b2r;
+    x[2] = temp * b1i;
+    x[3] = temp * b2i;
+    xnorm = temp * bnorm;
+    return;
+  }
+  float ur11 = crv[icmax - 1];
+  float ui11 = civ[icmax - 1];
+  float cr21 = crv[ipivot[icmax - 1][1] - 1];
+  float ci21 = civ[ipivot[icmax - 1][1] - 1];
+  float ur12 = crv[ipivot[icmax - 1][2] - 1];
+  float ui12 = civ[ipivot[icmax - 1][2] - 1];
+  float cr22 = crv[ipivot[icmax - 1][3] - 1];
+  float ci22 = civ[ipivot[icmax - 1][3] - 1];
+  float ur11r, ui11r, lr21, li21, ur12s, ui12s, ur22, ui22;
+  if (icmax == 1 || icmax == 4) {
+    // off-diagonals of the pivoted C are real
+    if (fabs(ur11) > fabs(ui11)) {
+      float temp = ui11 / ur11;
+      ur11r = 1.0f / (ur11 * (1.0f + temp * temp));
+      ui11r = -temp * ur11r;
+    } else {
+      float temp = ur11 / ui11;
+      ui11r = -1.0f / (ui11 * (1.0f + temp * temp));
+      ur11r = -temp * ui11r;
+    }
+    lr21 = cr21 * ur11r;
+    li21 = cr21 * ui11r;
+    ur12s = ur12 * ur11r;
+    ui12s = ur12 * ui11r;
+    ur22 = cr22 - ur12 * lr21;
+    ui22 = ci22 - ur12 * li21;
+  } else {
+    // diagonals of the pivoted C are real
+    ur11r = 1.0f / ur11;
+    ui11r = 0.0f;
+    lr21 = cr21 * ur11r;
+    li21 = ci21 * ur11r;
+    ur12s = ur12 * ur11r;
+    ui12s = ui12 * ur11r;
+    ur22 = cr22 - ur12 * lr21 + ui12 * li21;
+    ui22 = -ur12 * li21 - ui12 * lr21;
+  }
+  float u22abs = fabs(ur22) + fabs(ui22);
+  if (u22abs < smini) {
+    ur22 = smini;
+    ui22 = 0.0f;
+  }
+  float br1, br2, bi1, bi2;
+  if (rswap[icmax - 1]) {
+    br2 = b1r;
+    br1 = b2r;
+    bi2 = b1i;
+    bi1 = b2i;
+  } else {
+    br1 = b1r;
+    br2 = b2r;
+    bi1 = b1i;
+    bi2 = b2i;
+  }
+  br2 = br2 - lr21 * br1 + li21 * bi1;
+  bi2 = bi2 - li21 * br1 - lr21 * bi1;
+  float bbnd =
+      max((fabs(br1) + fabs(bi1)) * (u22abs * (fabs(ur11r) + fabs(ui11r))),
+          fabs(br2) + fabs(bi2));
+  if (bbnd > 1.0f && u22abs < 1.0f && bbnd >= bignum * u22abs) {
+    scale = 1.0f / bbnd;
+    br1 *= scale;
+    bi1 *= scale;
+    br2 *= scale;
+    bi2 *= scale;
+  }
+  float xr2, xi2;
+  eig_sladiv(br2, bi2, ur22, ui22, xr2, xi2);
+  float xr1 = ur11r * br1 - ui11r * bi1 - ur12s * xr2 + ui12s * xi2;
+  float xi1 = ui11r * br1 + ur11r * bi1 - ui12s * xr2 - ur12s * xi2;
+  if (cswap[icmax - 1]) {
+    x[0] = xr2;
+    x[1] = xr1;
+    x[2] = xi2;
+    x[3] = xi1;
+  } else {
+    x[0] = xr1;
+    x[1] = xr2;
+    x[2] = xi1;
+    x[3] = xi2;
+  }
+  xnorm = max(fabs(xr1) + fabs(xi1), fabs(xr2) + fabs(xi2));
+  if (xnorm > 1.0f && cmax > 1.0f && xnorm > bignum / cmax) {
+    float temp = cmax / bignum;
+    x[0] *= temp;
+    x[1] *= temp;
+    x[2] *= temp;
+    x[3] *= temp;
+    xnorm *= temp;
+    scale *= temp;
+  }
+}
+
+kernel void eig_qr_float(
+    device const float* A [[buffer(0)]],
+    device float* values [[buffer(1)]],
+    device float* vectors [[buffer(2)]],
+    device int* infos [[buffer(3)]],
+    constant EigParams& params [[buffer(4)]],
+    threadgroup float* Htg [[threadgroup(0)]],
+    threadgroup float* Qtg [[threadgroup(1)]],
+    threadgroup float* scr [[threadgroup(2)]],
+    uint3 thread_pos [[thread_position_in_threadgroup]],
+    uint3 tpg [[threads_per_threadgroup]],
+    uint3 tg_pos [[threadgroup_position_in_grid]]) {
+  const uint tid = thread_pos.x;
+  const uint nt = tpg.x;
+  const uint n = params.n;
+  const bool wantv = params.compute_v != 0u;
+  const uint b = tg_pos.x;
+  device const float* A_b = A + b * n * n; // column-major, ld = n
+  device float* val_b = values + b * 2 * n; // wr | wi
+  device float* vec_b = vectors + b * n * n; // column-major, ld = n
+
+// 1-based accessors matching the Fortran sources
+#define HH(i, j) Htg[((i) - 1) + ((j) - 1) * n]
+#define QQ(i, j) Qtg[((i) - 1) + ((j) - 1) * n]
+  threadgroup float* wr_s = scr; // n
+  threadgroup float* wi_s = scr + n; // n
+  threadgroup float* cn_s = scr + 2 * n; // n: strict-upper column 1-norms
+  threadgroup float* xre_s = scr + 3 * n; // n
+  threadgroup float* xim_s = scr + 4 * n; // n
+  threadgroup float* outre_s = scr + 5 * n; // n
+  threadgroup float* outim_s = scr + 6 * n; // n
+#define WR1(i) wr_s[(i) - 1]
+#define WI1(i) wi_s[(i) - 1]
+#define CN1(i) cn_s[(i) - 1]
+#define XRE(i) xre_s[(i) - 1]
+#define XIM(i) xim_s[(i) - 1]
+#define OUTRE(i) outre_s[(i) - 1]
+#define OUTIM(i) outim_s[(i) - 1]
+
+  // load A into H; init Q = I
+  for (uint idx = tid; idx < n * n; idx += nt) {
+    Htg[idx] = A_b[idx];
+    if (wantv) {
+      Qtg[idx] = (idx % n) == (idx / n) ? 1.0f : 0.0f;
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  if (n == 1) {
+    if (tid == 0) {
+      val_b[0] = Htg[0];
+      val_b[1] = 0.0f;
+      if (wantv) {
+        vec_b[0] = 1.0f;
+      }
+      infos[b] = 0;
+    }
+    return;
+  }
+
+  // ==== sgehd2: unblocked Hessenberg reduction, Q accumulated forward ====
+  for (uint j = 1; j + 2 <= n; ++j) {
+    const uint m = n - j; // reflector length (>= 2)
+    threadgroup float* col = &HH(j + 1, j); // col[0]=alpha, col[1..m-1]=x
+    // slarfg(m, col) executed redundantly; thread 0 commits column writes
+    float xnorm = eig_nrm2_tg(col + 1, m - 1);
+    float tau = 0.0f;
+    if (xnorm != 0.0f) {
+      float alpha = col[0];
+      float beta = -eig_sign(eig_lapy2(alpha, xnorm), alpha);
+      uint knt = 0;
+      if (fabs(beta) < kEigLarfgSafmin) {
+        const float rsafmn = 1.0f / kEigLarfgSafmin;
+        do {
+          knt++;
+          if (tid == 0) {
+            for (uint i = 1; i < m; ++i) {
+              col[i] *= rsafmn;
+            }
+          }
+          threadgroup_barrier(mem_flags::mem_threadgroup);
+          beta *= rsafmn;
+          alpha *= rsafmn;
+        } while (fabs(beta) < kEigLarfgSafmin && knt < 20);
+        xnorm = eig_nrm2_tg(col + 1, m - 1);
+        beta = -eig_sign(eig_lapy2(alpha, xnorm), alpha);
+      }
+      tau = (beta - alpha) / beta;
+      if (tid == 0) {
+        float scal = 1.0f / (alpha - beta);
+        for (uint i = 1; i < m; ++i) {
+          col[i] *= scal;
+        }
+        float bout = beta;
+        for (uint kk = 0; kk < knt; ++kk) {
+          bout *= kEigLarfgSafmin;
+        }
+        col[0] = bout;
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    if (tau != 0.0f) {
+      // left: rows j+1..n, cols j+1..n  (v(1)=1 implicit, tail in col[1..])
+      for (uint c = j + 1 + tid; c <= n; c += nt) {
+        float sum = HH(j + 1, c);
+        for (uint i = 1; i < m; ++i) {
+          sum += col[i] * HH(j + 1 + i, c);
+        }
+        sum *= tau;
+        HH(j + 1, c) -= sum;
+        for (uint i = 1; i < m; ++i) {
+          HH(j + 1 + i, c) -= sum * col[i];
+        }
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      // right: rows 1..n, cols j+1..n; Q accumulates the same reflector
+      for (uint r = 1 + tid; r <= n; r += nt) {
+        float sum = HH(r, j + 1);
+        for (uint i = 1; i < m; ++i) {
+          sum += HH(r, j + 1 + i) * col[i];
+        }
+        sum *= tau;
+        HH(r, j + 1) -= sum;
+        for (uint i = 1; i < m; ++i) {
+          HH(r, j + 1 + i) -= sum * col[i];
+        }
+        if (wantv) {
+          float qsum = QQ(r, j + 1);
+          for (uint i = 1; i < m; ++i) {
+            qsum += QQ(r, j + 1 + i) * col[i];
+          }
+          qsum *= tau;
+          QQ(r, j + 1) -= qsum;
+          for (uint i = 1; i < m; ++i) {
+            QQ(r, j + 1 + i) -= qsum * col[i];
+          }
+        }
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+  }
+  // zero the sub-Hessenberg reflector storage
+  for (uint idx = tid; idx < n * n; idx += nt) {
+    uint ri = idx % n + 1, cj = idx / n + 1;
+    if (ri > cj + 1) {
+      Htg[idx] = 0.0f;
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // ==== slahqr: double-shift QR iteration (ilo=1, ihi=n) ====
+  const float smlnum = kEigSafmin * (float(n) / kEigUlp);
+  uint i1 = 1, i2 = n;
+  const uint itmax = 30 * max(10u, n);
+  uint kdefl = 0;
+  int info = 0;
+  uint i = n;
+  while (i >= 1) {
+    uint l = 1;
+    bool deflated = false;
+    for (uint its = 0; its <= itmax; ++its) {
+      // look for a single small subdiagonal element
+      uint k = l; // value if the scan falls through
+      for (uint kk = i; kk >= l + 1; --kk) {
+        if (fabs(HH(kk, kk - 1)) <= smlnum) {
+          k = kk;
+          break;
+        }
+        float tst = fabs(HH(kk - 1, kk - 1)) + fabs(HH(kk, kk));
+        if (tst == 0.0f) {
+          if (kk >= 3) {
+            tst += fabs(HH(kk - 1, kk - 2));
+          }
+          if (kk + 1 <= n) {
+            tst += fabs(HH(kk + 1, kk));
+          }
+        }
+        if (fabs(HH(kk, kk - 1)) <= kEigUlp * tst) {
+          // Ahues & Tisseur conservative deflation criterion
+          float ab = max(fabs(HH(kk, kk - 1)), fabs(HH(kk - 1, kk)));
+          float ba = min(fabs(HH(kk, kk - 1)), fabs(HH(kk - 1, kk)));
+          float aa =
+              max(fabs(HH(kk, kk)), fabs(HH(kk - 1, kk - 1) - HH(kk, kk)));
+          float bb =
+              min(fabs(HH(kk, kk)), fabs(HH(kk - 1, kk - 1) - HH(kk, kk)));
+          float s = aa + ab;
+          if (ba * (ab / s) <= max(smlnum, kEigUlp * (bb * (aa / s)))) {
+            k = kk;
+            break;
+          }
+        }
+      }
+      l = k;
+      if (l > 1) {
+        if (tid == 0) {
+          HH(l, l - 1) = 0.0f;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+      }
+      if (l + 1 >= i) {
+        deflated = true;
+        break;
+      }
+      kdefl++;
+      if (!wantv) {
+        i1 = l;
+        i2 = i;
+      }
+      float h11, h12, h21, h22;
+      if (kdefl % 20 == 0) {
+        float s = fabs(HH(i, i - 1)) + fabs(HH(i - 1, i - 2));
+        h11 = 0.75f * s + HH(i, i);
+        h12 = -0.4375f * s;
+        h21 = s;
+        h22 = h11;
+      } else if (kdefl % 10 == 0) {
+        float s = fabs(HH(l + 1, l)) + fabs(HH(l + 2, l + 1));
+        h11 = 0.75f * s + HH(l, l);
+        h12 = -0.4375f * s;
+        h21 = s;
+        h22 = h11;
+      } else {
+        h11 = HH(i - 1, i - 1);
+        h21 = HH(i, i - 1);
+        h12 = HH(i - 1, i);
+        h22 = HH(i, i);
+      }
+      float rt1r, rt1i, rt2r, rt2i;
+      float s = fabs(h11) + fabs(h12) + fabs(h21) + fabs(h22);
+      if (s == 0.0f) {
+        rt1r = rt1i = rt2r = rt2i = 0.0f;
+      } else {
+        h11 /= s;
+        h21 /= s;
+        h12 /= s;
+        h22 /= s;
+        float tr = (h11 + h22) / 2.0f;
+        float det = (h11 - tr) * (h22 - tr) - h12 * h21;
+        float rtdisc = sqrt(fabs(det));
+        if (det >= 0.0f) {
+          rt1r = tr * s;
+          rt2r = rt1r;
+          rt1i = rtdisc * s;
+          rt2i = -rt1i;
+        } else {
+          rt1r = tr + rtdisc;
+          rt2r = tr - rtdisc;
+          if (fabs(rt1r - h22) <= fabs(rt2r - h22)) {
+            rt1r = rt1r * s;
+            rt2r = rt1r;
+          } else {
+            rt2r = rt2r * s;
+            rt1r = rt2r;
+          }
+          rt1i = 0.0f;
+          rt2i = 0.0f;
+        }
+      }
+      // look for two consecutive small subdiagonal elements
+      float v[3];
+      uint mm = l;
+      for (uint m2 = i - 2; m2 >= l; --m2) {
+        float h21s = HH(m2 + 1, m2);
+        float ss = fabs(HH(m2, m2) - rt2r) + fabs(rt2i) + fabs(h21s);
+        h21s = HH(m2 + 1, m2) / ss;
+        v[0] = h21s * HH(m2, m2 + 1) +
+            (HH(m2, m2) - rt1r) * ((HH(m2, m2) - rt2r) / ss) -
+            rt1i * (rt2i / ss);
+        v[1] = h21s * (HH(m2, m2) + HH(m2 + 1, m2 + 1) - rt1r - rt2r);
+        v[2] = h21s * HH(m2 + 2, m2 + 1);
+        ss = fabs(v[0]) + fabs(v[1]) + fabs(v[2]);
+        v[0] /= ss;
+        v[1] /= ss;
+        v[2] /= ss;
+        mm = m2;
+        if (m2 == l) {
+          break;
+        }
+        if (fabs(HH(m2, m2 - 1)) * (fabs(v[1]) + fabs(v[2])) <= kEigUlp *
+                fabs(v[0]) *
+                (fabs(HH(m2 - 1, m2 - 1)) + fabs(HH(m2, m2)) +
+                 fabs(HH(m2 + 1, m2 + 1)))) {
+          break;
+        }
+      }
+      // double-shift QR sweep: chase the bulge from mm to i-1
+      for (uint kb = mm; kb + 1 <= i; ++kb) {
+        const uint nr = min(3u, i - kb + 1);
+        if (kb > mm) {
+          v[0] = HH(kb, kb - 1);
+          v[1] = HH(kb + 1, kb - 1);
+          v[2] = nr == 3 ? HH(kb + 2, kb - 1) : 0.0f;
+        }
+        float t1 = eig_slarfg_reg(nr, v);
+        if (tid == 0) {
+          if (kb > mm) {
+            HH(kb, kb - 1) = v[0];
+            HH(kb + 1, kb - 1) = 0.0f;
+            if (kb < i - 1) {
+              HH(kb + 2, kb - 1) = 0.0f;
+            }
+          } else if (mm > l) {
+            // written this way (not plain negation) to survive v(2)/v(3)
+            // underflow, as in slahqr
+            HH(kb, kb - 1) = HH(kb, kb - 1) * (1.0f - t1);
+          }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        const float v2 = v[1];
+        const float t2 = t1 * v2;
+        if (nr == 3) {
+          const float v3 = v[2];
+          const float t3 = t1 * v3;
+          for (uint jj = kb + tid; jj <= i2; jj += nt) {
+            float sum = HH(kb, jj) + v2 * HH(kb + 1, jj) + v3 * HH(kb + 2, jj);
+            HH(kb, jj) -= sum * t1;
+            HH(kb + 1, jj) -= sum * t2;
+            HH(kb + 2, jj) -= sum * t3;
+          }
+          threadgroup_barrier(mem_flags::mem_threadgroup);
+          const uint rhi = min(kb + 3, i);
+          for (uint jj = i1 + tid; jj <= rhi; jj += nt) {
+            float sum = HH(jj, kb) + v2 * HH(jj, kb + 1) + v3 * HH(jj, kb + 2);
+            HH(jj, kb) -= sum * t1;
+            HH(jj, kb + 1) -= sum * t2;
+            HH(jj, kb + 2) -= sum * t3;
+          }
+          if (wantv) {
+            for (uint jj = 1 + tid; jj <= n; jj += nt) {
+              float sum =
+                  QQ(jj, kb) + v2 * QQ(jj, kb + 1) + v3 * QQ(jj, kb + 2);
+              QQ(jj, kb) -= sum * t1;
+              QQ(jj, kb + 1) -= sum * t2;
+              QQ(jj, kb + 2) -= sum * t3;
+            }
+          }
+          threadgroup_barrier(mem_flags::mem_threadgroup);
+        } else {
+          for (uint jj = kb + tid; jj <= i2; jj += nt) {
+            float sum = HH(kb, jj) + v2 * HH(kb + 1, jj);
+            HH(kb, jj) -= sum * t1;
+            HH(kb + 1, jj) -= sum * t2;
+          }
+          threadgroup_barrier(mem_flags::mem_threadgroup);
+          for (uint jj = i1 + tid; jj <= i; jj += nt) {
+            float sum = HH(jj, kb) + v2 * HH(jj, kb + 1);
+            HH(jj, kb) -= sum * t1;
+            HH(jj, kb + 1) -= sum * t2;
+          }
+          if (wantv) {
+            for (uint jj = 1 + tid; jj <= n; jj += nt) {
+              float sum = QQ(jj, kb) + v2 * QQ(jj, kb + 1);
+              QQ(jj, kb) -= sum * t1;
+              QQ(jj, kb + 1) -= sum * t2;
+            }
+          }
+          threadgroup_barrier(mem_flags::mem_threadgroup);
+        }
+      }
+    }
+    if (!deflated) {
+      info = int(i); // eigenvalues info+1..n (1-based) did converge
+      break;
+    }
+    if (l == i) {
+      if (tid == 0) {
+        WR1(i) = HH(i, i);
+        WI1(i) = 0.0f;
+      }
+    } else { // l == i-1: standardize the 2x2 block
+      float a = HH(i - 1, i - 1), bq = HH(i - 1, i), c = HH(i, i - 1),
+            d = HH(i, i);
+      float rt1r, rt1i, rt2r, rt2i, cs, sn;
+      eig_slanv2(a, bq, c, d, rt1r, rt1i, rt2r, rt2i, cs, sn);
+      if (tid == 0) {
+        HH(i - 1, i - 1) = a;
+        HH(i - 1, i) = bq;
+        HH(i, i - 1) = c;
+        HH(i, i) = d;
+        WR1(i - 1) = rt1r;
+        WI1(i - 1) = rt1i;
+        WR1(i) = rt2r;
+        WI1(i) = rt2i;
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      if (wantv) {
+        // srot on trailing rows, leading columns, and Q
+        for (uint jj = i + 1 + tid; jj <= i2; jj += nt) {
+          float x = HH(i - 1, jj), y = HH(i, jj);
+          HH(i - 1, jj) = cs * x + sn * y;
+          HH(i, jj) = cs * y - sn * x;
+        }
+        for (uint jj = i1 + tid; jj + 2 <= i; jj += nt) {
+          float x = HH(jj, i - 1), y = HH(jj, i);
+          HH(jj, i - 1) = cs * x + sn * y;
+          HH(jj, i) = cs * y - sn * x;
+        }
+        for (uint jj = 1 + tid; jj <= n; jj += nt) {
+          float x = QQ(jj, i - 1), y = QQ(jj, i);
+          QQ(jj, i - 1) = cs * x + sn * y;
+          QQ(jj, i) = cs * y - sn * x;
+        }
+      }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    kdefl = 0;
+    if (l == 1) {
+      break;
+    }
+    i = l - 1;
+  }
+
+  // write eigenvalues (geev layout: wr | wi); on info > 0 the leading entries
+  // are unconverged garbage, matching LAPACK (the host raises on info anyway)
+  for (uint idx = 1 + tid; idx <= n; idx += nt) {
+    val_b[idx - 1] = WR1(idx);
+    val_b[n + idx - 1] = WI1(idx);
+  }
+  if (tid == 0) {
+    infos[b] = info;
+  }
+  if (!wantv || info != 0) {
+    return;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // ==== strevc (side='R', howmny='B') + sgeev normalization epilogue ====
+  const float smlnum_tv = kEigSafmin * (float(n) / kEigUlp);
+  const float bignum_tv = (1.0f - kEigUlp) / smlnum_tv;
+  // strict-upper column 1-norms of T for overflow control
+  for (uint j = 1 + tid; j <= n; j += nt) {
+    float ssum = 0.0f;
+    for (uint r = 1; r + 1 <= j; ++r) {
+      ssum += fabs(HH(r, j));
+    }
+    CN1(j) = ssum;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  int ip = 0;
+  for (uint ki = n; ki >= 1; --ki) {
+    if (ip == 1) {
+      ip = 0;
+      continue;
+    }
+    if (ki > 1 && HH(ki, ki - 1) != 0.0f) {
+      ip = -1;
+    }
+    const float wr = HH(ki, ki);
+    const float wi = ip != 0
+        ? sqrt(fabs(HH(ki, ki - 1))) * sqrt(fabs(HH(ki - 1, ki)))
+        : 0.0f;
+    const float smin = max(kEigUlp * (fabs(wr) + fabs(wi)), smlnum_tv);
+
+    if (ip == 0) {
+      // ---- real right eigenvector ----
+      if (tid == 0) {
+        XRE(ki) = 1.0f;
+        for (uint kk = 1; kk + 1 <= ki; ++kk) {
+          XRE(kk) = -HH(kk, ki);
+        }
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      int jnxt = int(ki) - 1;
+      for (int j = int(ki) - 1; j >= 1; --j) {
+        if (j > jnxt) {
+          continue;
+        }
+        const uint ju = uint(j);
+        uint j1 = ju;
+        jnxt = j - 1;
+        if (j > 1 && HH(ju, ju - 1) != 0.0f) {
+          j1 = ju - 1;
+          jnxt = j - 2;
+        }
+        float x[4];
+        float scale, xnorm;
+        if (j1 == ju) {
+          eig_slaln2(
+              1,
+              1,
+              smin,
+              HH(ju, ju),
+              0.0f,
+              0.0f,
+              0.0f,
+              XRE(ju),
+              0.0f,
+              0.0f,
+              0.0f,
+              wr,
+              0.0f,
+              x,
+              scale,
+              xnorm);
+          if (xnorm > 1.0f && CN1(ju) > bignum_tv / xnorm) {
+            x[0] /= xnorm;
+            scale /= xnorm;
+          }
+          if (scale != 1.0f) {
+            for (uint kk = 1 + tid; kk <= ki; kk += nt) {
+              XRE(kk) *= scale;
+            }
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+          }
+          if (tid == 0) {
+            XRE(ju) = x[0];
+          }
+          threadgroup_barrier(mem_flags::mem_threadgroup);
+          for (uint kk = 1 + tid; kk + 1 <= ju; kk += nt) {
+            XRE(kk) -= x[0] * HH(kk, ju);
+          }
+          threadgroup_barrier(mem_flags::mem_threadgroup);
+        } else {
+          eig_slaln2(
+              2,
+              1,
+              smin,
+              HH(ju - 1, ju - 1),
+              HH(ju - 1, ju),
+              HH(ju, ju - 1),
+              HH(ju, ju),
+              XRE(ju - 1),
+              0.0f,
+              XRE(ju),
+              0.0f,
+              wr,
+              0.0f,
+              x,
+              scale,
+              xnorm);
+          if (xnorm > 1.0f) {
+            float beta = max(CN1(ju - 1), CN1(ju));
+            if (beta > bignum_tv / xnorm) {
+              x[0] /= xnorm;
+              x[1] /= xnorm;
+              scale /= xnorm;
+            }
+          }
+          if (scale != 1.0f) {
+            for (uint kk = 1 + tid; kk <= ki; kk += nt) {
+              XRE(kk) *= scale;
+            }
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+          }
+          if (tid == 0) {
+            XRE(ju - 1) = x[0];
+            XRE(ju) = x[1];
+          }
+          threadgroup_barrier(mem_flags::mem_threadgroup);
+          for (uint kk = 1 + tid; kk + 2 <= ju; kk += nt) {
+            XRE(kk) -= x[0] * HH(kk, ju - 1) + x[1] * HH(kk, ju);
+          }
+          threadgroup_barrier(mem_flags::mem_threadgroup);
+        }
+      }
+      // back-transform: out_re = Q(:,1:ki) * x(1:ki)
+      for (uint r = 1 + tid; r <= n; r += nt) {
+        float ssum = 0.0f;
+        for (uint c = 1; c <= ki; ++c) {
+          ssum += QQ(r, c) * XRE(c);
+        }
+        OUTRE(r) = ssum;
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      // strevc max-abs normalization fused with the sgeev unit-2-norm scaling
+      float emax = 0.0f;
+      for (uint r = 1; r <= n; ++r) {
+        emax = max(emax, fabs(OUTRE(r)));
+      }
+      const float remax = 1.0f / emax;
+      float nrm = 0.0f;
+      for (uint r = 1; r <= n; ++r) {
+        float t = OUTRE(r) * remax;
+        nrm += t * t;
+      }
+      const float scl = remax / sqrt(nrm);
+      for (uint r = 1 + tid; r <= n; r += nt) {
+        vec_b[(r - 1) + (ki - 1) * n] = OUTRE(r) * scl;
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+    } else {
+      // ---- complex right eigenvector (pair in columns ki-1, ki) ----
+      if (tid == 0) {
+        if (fabs(HH(ki - 1, ki)) >= fabs(HH(ki, ki - 1))) {
+          XRE(ki - 1) = 1.0f;
+          XIM(ki) = wi / HH(ki - 1, ki);
+        } else {
+          XRE(ki - 1) = -wi / HH(ki, ki - 1);
+          XIM(ki) = 1.0f;
+        }
+        XRE(ki) = 0.0f;
+        XIM(ki - 1) = 0.0f;
+        for (uint kk = 1; kk + 2 <= ki; ++kk) {
+          XRE(kk) = -XRE(ki - 1) * HH(kk, ki - 1);
+          XIM(kk) = -XIM(ki) * HH(kk, ki);
+        }
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      int jnxt = int(ki) - 2;
+      for (int j = int(ki) - 2; j >= 1; --j) {
+        if (j > jnxt) {
+          continue;
+        }
+        const uint ju = uint(j);
+        uint j1 = ju;
+        jnxt = j - 1;
+        if (j > 1 && HH(ju, ju - 1) != 0.0f) {
+          j1 = ju - 1;
+          jnxt = j - 2;
+        }
+        float x[4];
+        float scale, xnorm;
+        if (j1 == ju) {
+          eig_slaln2(
+              1,
+              2,
+              smin,
+              HH(ju, ju),
+              0.0f,
+              0.0f,
+              0.0f,
+              XRE(ju),
+              XIM(ju),
+              0.0f,
+              0.0f,
+              wr,
+              wi,
+              x,
+              scale,
+              xnorm);
+          if (xnorm > 1.0f && CN1(ju) > bignum_tv / xnorm) {
+            x[0] /= xnorm;
+            x[2] /= xnorm;
+            scale /= xnorm;
+          }
+          if (scale != 1.0f) {
+            for (uint kk = 1 + tid; kk <= ki; kk += nt) {
+              XRE(kk) *= scale;
+              XIM(kk) *= scale;
+            }
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+          }
+          if (tid == 0) {
+            XRE(ju) = x[0];
+            XIM(ju) = x[2];
+          }
+          threadgroup_barrier(mem_flags::mem_threadgroup);
+          for (uint kk = 1 + tid; kk + 1 <= ju; kk += nt) {
+            XRE(kk) -= x[0] * HH(kk, ju);
+            XIM(kk) -= x[2] * HH(kk, ju);
+          }
+          threadgroup_barrier(mem_flags::mem_threadgroup);
+        } else {
+          eig_slaln2(
+              2,
+              2,
+              smin,
+              HH(ju - 1, ju - 1),
+              HH(ju - 1, ju),
+              HH(ju, ju - 1),
+              HH(ju, ju),
+              XRE(ju - 1),
+              XIM(ju - 1),
+              XRE(ju),
+              XIM(ju),
+              wr,
+              wi,
+              x,
+              scale,
+              xnorm);
+          if (xnorm > 1.0f) {
+            float beta = max(CN1(ju - 1), CN1(ju));
+            if (beta > bignum_tv / xnorm) {
+              float rec = 1.0f / xnorm;
+              x[0] *= rec;
+              x[1] *= rec;
+              x[2] *= rec;
+              x[3] *= rec;
+              scale *= rec;
+            }
+          }
+          if (scale != 1.0f) {
+            for (uint kk = 1 + tid; kk <= ki; kk += nt) {
+              XRE(kk) *= scale;
+              XIM(kk) *= scale;
+            }
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+          }
+          if (tid == 0) {
+            XRE(ju - 1) = x[0];
+            XRE(ju) = x[1];
+            XIM(ju - 1) = x[2];
+            XIM(ju) = x[3];
+          }
+          threadgroup_barrier(mem_flags::mem_threadgroup);
+          for (uint kk = 1 + tid; kk + 2 <= ju; kk += nt) {
+            XRE(kk) -= x[0] * HH(kk, ju - 1) + x[1] * HH(kk, ju);
+            XIM(kk) -= x[2] * HH(kk, ju - 1) + x[3] * HH(kk, ju);
+          }
+          threadgroup_barrier(mem_flags::mem_threadgroup);
+        }
+      }
+      // back-transform both columns (xre(ki) = 0 and xim(ki-1) = 0 make the
+      // full 1..ki sums equal LAPACK's gemv + beta form)
+      for (uint r = 1 + tid; r <= n; r += nt) {
+        float sre = 0.0f, sim = 0.0f;
+        for (uint c = 1; c <= ki; ++c) {
+          sre += QQ(r, c) * XRE(c);
+          sim += QQ(r, c) * XIM(c);
+        }
+        OUTRE(r) = sre;
+        OUTIM(r) = sim;
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      float emax = 0.0f;
+      for (uint r = 1; r <= n; ++r) {
+        emax = max(emax, fabs(OUTRE(r)) + fabs(OUTIM(r)));
+      }
+      const float remax = 1.0f / emax;
+      // sgeev epilogue: joint unit 2-norm, then rotate the largest component
+      // (first max of re^2+im^2, isamax semantics) onto the real axis
+      float nre = 0.0f, nim = 0.0f;
+      for (uint r = 1; r <= n; ++r) {
+        float sre = OUTRE(r) * remax, sim = OUTIM(r) * remax;
+        nre += sre * sre;
+        nim += sim * sim;
+      }
+      const float scl = remax / eig_lapy2(sqrt(nre), sqrt(nim));
+      float kmax = -1.0f;
+      uint karg = 1;
+      for (uint r = 1; r <= n; ++r) {
+        float t = OUTRE(r) * scl, u = OUTIM(r) * scl;
+        float mag = t * t + u * u;
+        if (mag > kmax) {
+          kmax = mag;
+          karg = r;
+        }
+      }
+      float cs, sn, rr;
+      eig_slartg(OUTRE(karg) * scl, OUTIM(karg) * scl, cs, sn, rr);
+      for (uint r = 1 + tid; r <= n; r += nt) {
+        float t = OUTRE(r) * scl, u = OUTIM(r) * scl;
+        vec_b[(r - 1) + (ki - 2) * n] = cs * t + sn * u;
+        vec_b[(r - 1) + (ki - 1) * n] = r == karg ? 0.0f : cs * u - sn * t;
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      ip = 1;
+    }
+    if (ki == 1) {
+      break;
+    }
+  }
+#undef HH
+#undef QQ
+#undef WR1
+#undef WI1
+#undef CN1
+#undef XRE
+#undef XIM
+#undef OUTRE
+#undef OUTIM
+}
+
+// Decode LAPACK GEEV's packed real eigenvector format into complex vectors.
+// One thread per output element; all tensors batched column-major.
+kernel void eig_make_complex_float(
+    device float2* out [[buffer(0)]],
+    device const float2* values [[buffer(1)]],
+    device const float* vr [[buffer(2)]],
+    constant uint& n [[buffer(3)]],
+    uint tid [[thread_position_in_grid]]) {
+  const uint bidx = tid / (n * n);
+  const uint off = tid % (n * n);
+  const uint j = off / n;
+  const float wi = values[bidx * n + j].y;
+  if (wi == 0.0f) {
+    out[tid] = float2(vr[tid], 0.0f);
+  } else if (wi > 0.0f) {
+    out[tid] = float2(vr[tid], vr[tid + n]);
+  } else {
+    out[tid] = float2(vr[tid - n], -vr[tid]);
+  }
+}
+
+// Right-eigenvector backsolve for the hybrid large-matrix path.
+kernel void eig_trevc_col_float(
+    device const float* T [[buffer(0)]],
+    device const float* cnorm [[buffer(1)]],
+    device float* X [[buffer(2)]],
+    constant uint& n [[buffer(3)]],
+    threadgroup float* xtg [[threadgroup(0)]],
+    uint3 thread_pos [[thread_position_in_threadgroup]],
+    uint3 tpg [[threads_per_threadgroup]],
+    uint3 tg_pos [[threadgroup_position_in_grid]]) {
+  const uint tid = thread_pos.x;
+  const uint nt = tpg.x;
+  const uint ki = tg_pos.x + 1; // 1-based eigenvector column
+  device const float* T_b = T + ulong(tg_pos.y) * n * n; // column-major, ld = n
+  device const float* cn_b = cnorm + ulong(tg_pos.y) * n;
+  device float* X_b = X + ulong(tg_pos.y) * n * n; // column-major, ld = n
+#define TT(i, j) T_b[((i) - 1) + ((j) - 1) * n]
+#define CN1(j) cn_b[(j) - 1]
+#define XRE(i) xtg[(i) - 1]
+#define XIM(i) xtg[n + (i) - 1]
+  if (ki < n && TT(ki + 1, ki) != 0.0f) {
+    return; // left column of a 2x2 block: written by the ki+1 threadgroup
+  }
+  const float smlnum_tv = kEigSafmin * (float(n) / kEigUlp);
+  const float bignum_tv = (1.0f - kEigUlp) / smlnum_tv;
+  const bool pair = ki > 1 && TT(ki, ki - 1) != 0.0f;
+  const float wr = TT(ki, ki);
+  const float wi =
+      pair ? sqrt(fabs(TT(ki, ki - 1))) * sqrt(fabs(TT(ki - 1, ki))) : 0.0f;
+  const float smin = max(kEigUlp * (fabs(wr) + fabs(wi)), smlnum_tv);
+
+  if (!pair) {
+    // ---- real right eigenvector ----
+    if (tid == 0) {
+      XRE(ki) = 1.0f;
+    }
+    for (uint kk = 1 + tid; kk + 1 <= ki; kk += nt) {
+      XRE(kk) = -TT(kk, ki);
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    int jnxt = int(ki) - 1;
+    for (int j = int(ki) - 1; j >= 1; --j) {
+      if (j > jnxt) {
+        continue;
+      }
+      const uint ju = uint(j);
+      uint j1 = ju;
+      jnxt = j - 1;
+      if (j > 1 && TT(ju, ju - 1) != 0.0f) {
+        j1 = ju - 1;
+        jnxt = j - 2;
+      }
+      float x[4];
+      float scale, xnorm;
+      if (j1 == ju) {
+        // read shared x state into registers before any thread commits writes:
+        // device-memory latency can desync the simdgroups by more than the
+        // whole solve, so a read after tid 0's commit would see the new value
+        const float b1 = XRE(ju);
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        eig_slaln2(
+            1,
+            1,
+            smin,
+            TT(ju, ju),
+            0.0f,
+            0.0f,
+            0.0f,
+            b1,
+            0.0f,
+            0.0f,
+            0.0f,
+            wr,
+            0.0f,
+            x,
+            scale,
+            xnorm);
+        if (xnorm > 1.0f && CN1(ju) > bignum_tv / xnorm) {
+          x[0] /= xnorm;
+          scale /= xnorm;
+        }
+        if (scale != 1.0f) {
+          for (uint kk = 1 + tid; kk <= ki; kk += nt) {
+            XRE(kk) *= scale;
+          }
+          threadgroup_barrier(mem_flags::mem_threadgroup);
+        }
+        if (tid == 0) {
+          XRE(ju) = x[0];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (uint kk = 1 + tid; kk + 1 <= ju; kk += nt) {
+          XRE(kk) -= x[0] * TT(kk, ju);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+      } else {
+        const float b1 = XRE(ju - 1);
+        const float b2 = XRE(ju);
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        eig_slaln2(
+            2,
+            1,
+            smin,
+            TT(ju - 1, ju - 1),
+            TT(ju - 1, ju),
+            TT(ju, ju - 1),
+            TT(ju, ju),
+            b1,
+            0.0f,
+            b2,
+            0.0f,
+            wr,
+            0.0f,
+            x,
+            scale,
+            xnorm);
+        if (xnorm > 1.0f) {
+          float beta = max(CN1(ju - 1), CN1(ju));
+          if (beta > bignum_tv / xnorm) {
+            x[0] /= xnorm;
+            x[1] /= xnorm;
+            scale /= xnorm;
+          }
+        }
+        if (scale != 1.0f) {
+          for (uint kk = 1 + tid; kk <= ki; kk += nt) {
+            XRE(kk) *= scale;
+          }
+          threadgroup_barrier(mem_flags::mem_threadgroup);
+        }
+        if (tid == 0) {
+          XRE(ju - 1) = x[0];
+          XRE(ju) = x[1];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (uint kk = 1 + tid; kk + 2 <= ju; kk += nt) {
+          XRE(kk) -= x[0] * TT(kk, ju - 1) + x[1] * TT(kk, ju);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+      }
+    }
+    for (uint r = 1 + tid; r <= n; r += nt) {
+      X_b[(r - 1) + (ki - 1) * n] = r <= ki ? XRE(r) : 0.0f;
+    }
+  } else {
+    // ---- complex right eigenvector (pair in columns ki-1, ki) ----
+    float x0re, x0im; // seeds for XRE(ki-1), XIM(ki)
+    if (fabs(TT(ki - 1, ki)) >= fabs(TT(ki, ki - 1))) {
+      x0re = 1.0f;
+      x0im = wi / TT(ki - 1, ki);
+    } else {
+      x0re = -wi / TT(ki, ki - 1);
+      x0im = 1.0f;
+    }
+    if (tid == 0) {
+      XRE(ki - 1) = x0re;
+      XIM(ki) = x0im;
+      XRE(ki) = 0.0f;
+      XIM(ki - 1) = 0.0f;
+    }
+    for (uint kk = 1 + tid; kk + 2 <= ki; kk += nt) {
+      XRE(kk) = -x0re * TT(kk, ki - 1);
+      XIM(kk) = -x0im * TT(kk, ki);
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    int jnxt = int(ki) - 2;
+    for (int j = int(ki) - 2; j >= 1; --j) {
+      if (j > jnxt) {
+        continue;
+      }
+      const uint ju = uint(j);
+      uint j1 = ju;
+      jnxt = j - 1;
+      if (j > 1 && TT(ju, ju - 1) != 0.0f) {
+        j1 = ju - 1;
+        jnxt = j - 2;
+      }
+      float x[4];
+      float scale, xnorm;
+      if (j1 == ju) {
+        const float b1r = XRE(ju);
+        const float b1i = XIM(ju);
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        eig_slaln2(
+            1,
+            2,
+            smin,
+            TT(ju, ju),
+            0.0f,
+            0.0f,
+            0.0f,
+            b1r,
+            b1i,
+            0.0f,
+            0.0f,
+            wr,
+            wi,
+            x,
+            scale,
+            xnorm);
+        if (xnorm > 1.0f && CN1(ju) > bignum_tv / xnorm) {
+          x[0] /= xnorm;
+          x[2] /= xnorm;
+          scale /= xnorm;
+        }
+        if (scale != 1.0f) {
+          for (uint kk = 1 + tid; kk <= ki; kk += nt) {
+            XRE(kk) *= scale;
+            XIM(kk) *= scale;
+          }
+          threadgroup_barrier(mem_flags::mem_threadgroup);
+        }
+        if (tid == 0) {
+          XRE(ju) = x[0];
+          XIM(ju) = x[2];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (uint kk = 1 + tid; kk + 1 <= ju; kk += nt) {
+          XRE(kk) -= x[0] * TT(kk, ju);
+          XIM(kk) -= x[2] * TT(kk, ju);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+      } else {
+        const float b1r = XRE(ju - 1);
+        const float b1i = XIM(ju - 1);
+        const float b2r = XRE(ju);
+        const float b2i = XIM(ju);
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        eig_slaln2(
+            2,
+            2,
+            smin,
+            TT(ju - 1, ju - 1),
+            TT(ju - 1, ju),
+            TT(ju, ju - 1),
+            TT(ju, ju),
+            b1r,
+            b1i,
+            b2r,
+            b2i,
+            wr,
+            wi,
+            x,
+            scale,
+            xnorm);
+        if (xnorm > 1.0f) {
+          float beta = max(CN1(ju - 1), CN1(ju));
+          if (beta > bignum_tv / xnorm) {
+            float rec = 1.0f / xnorm;
+            x[0] *= rec;
+            x[1] *= rec;
+            x[2] *= rec;
+            x[3] *= rec;
+            scale *= rec;
+          }
+        }
+        if (scale != 1.0f) {
+          for (uint kk = 1 + tid; kk <= ki; kk += nt) {
+            XRE(kk) *= scale;
+            XIM(kk) *= scale;
+          }
+          threadgroup_barrier(mem_flags::mem_threadgroup);
+        }
+        if (tid == 0) {
+          XRE(ju - 1) = x[0];
+          XRE(ju) = x[1];
+          XIM(ju - 1) = x[2];
+          XIM(ju) = x[3];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (uint kk = 1 + tid; kk + 2 <= ju; kk += nt) {
+          XRE(kk) -= x[0] * TT(kk, ju - 1) + x[1] * TT(kk, ju);
+          XIM(kk) -= x[2] * TT(kk, ju - 1) + x[3] * TT(kk, ju);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+      }
+    }
+    for (uint r = 1 + tid; r <= n; r += nt) {
+      X_b[(r - 1) + (ki - 2) * n] = r <= ki ? XRE(r) : 0.0f;
+      X_b[(r - 1) + (ki - 1) * n] = r <= ki ? XIM(r) : 0.0f;
+    }
+  }
+#undef TT
+#undef CN1
+#undef XRE
+#undef XIM
+}
+
+// Normalize the hybrid path's eigenvectors in place.
+kernel void eig_normalize_float(
+    device float* V [[buffer(0)]],
+    device const float* values [[buffer(1)]],
+    constant uint& n [[buffer(2)]],
+    threadgroup float* scr [[threadgroup(0)]],
+    threadgroup uint* scri [[threadgroup(1)]],
+    uint3 thread_pos [[thread_position_in_threadgroup]],
+    uint3 tpg [[threads_per_threadgroup]],
+    uint3 tg_pos [[threadgroup_position_in_grid]]) {
+  const uint tid = thread_pos.x;
+  const uint nt = tpg.x;
+  const uint ki = tg_pos.x + 1; // 1-based column
+  device float* V_b = V + ulong(tg_pos.y) * n * n; // column-major, ld = n
+  device const float* val_b = values + ulong(tg_pos.y) * 2 * n; // wr | wi
+  const float wi = val_b[n + ki - 1];
+  if (wi < 0.0f) {
+    return; // second column of a pair: rotated by the ki-1 threadgroup
+  }
+  device float* vre = V_b + (ki - 1) * n;
+  if (wi == 0.0f) {
+    // scl = 1 / snrm2(v); max-abs pre-scale keeps the squares finite
+    float lmax = 0.0f;
+    for (uint r = tid; r < n; r += nt) {
+      lmax = max(lmax, fabs(vre[r]));
+    }
+    scr[tid] = lmax;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    float emax = 0.0f;
+    for (uint t = 0; t < nt; ++t) {
+      emax = max(emax, scr[t]);
+    }
+    if (emax == 0.0f) {
+      return;
+    }
+    const float remax = 1.0f / emax;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    float lsum = 0.0f;
+    for (uint r = tid; r < n; r += nt) {
+      const float t = vre[r] * remax;
+      lsum += t * t;
+    }
+    scr[tid] = lsum;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    float nrm = 0.0f;
+    for (uint t = 0; t < nt; ++t) {
+      nrm += scr[t];
+    }
+    const float scl = remax / sqrt(nrm);
+    for (uint r = tid; r < n; r += nt) {
+      vre[r] *= scl;
+    }
+  } else {
+    device float* vim = V_b + ki * n; // column ki+1 holds the imaginary part
+    float lmax = 0.0f;
+    for (uint r = tid; r < n; r += nt) {
+      lmax = max(lmax, fabs(vre[r]) + fabs(vim[r]));
+    }
+    scr[tid] = lmax;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    float emax = 0.0f;
+    for (uint t = 0; t < nt; ++t) {
+      emax = max(emax, scr[t]);
+    }
+    if (emax == 0.0f) {
+      return;
+    }
+    const float remax = 1.0f / emax;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    float lre = 0.0f;
+    float lim = 0.0f;
+    for (uint r = tid; r < n; r += nt) {
+      const float t = vre[r] * remax;
+      const float u = vim[r] * remax;
+      lre += t * t;
+      lim += u * u;
+    }
+    scr[tid] = lre;
+    scr[nt + tid] = lim;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    float nre = 0.0f;
+    float nim = 0.0f;
+    for (uint t = 0; t < nt; ++t) {
+      nre += scr[t];
+      nim += scr[nt + t];
+    }
+    const float scl = remax / eig_lapy2(sqrt(nre), sqrt(nim));
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    // isamax semantics: first strict maximum of re^2 + im^2
+    float lbest = -1.0f;
+    uint lidx = 0;
+    for (uint r = tid; r < n; r += nt) {
+      const float t = vre[r] * scl;
+      const float u = vim[r] * scl;
+      const float mag = t * t + u * u;
+      if (mag > lbest) {
+        lbest = mag;
+        lidx = r;
+      }
+    }
+    scr[tid] = lbest;
+    scri[tid] = lidx;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    float kmax = -1.0f;
+    uint karg = 0;
+    for (uint t = 0; t < nt; ++t) {
+      const bool better = scr[t] > kmax || (scr[t] == kmax && scri[t] < karg);
+      if (better) {
+        kmax = scr[t];
+        karg = scri[t];
+      }
+    }
+    float cs, sn, rr;
+    eig_slartg(vre[karg] * scl, vim[karg] * scl, cs, sn, rr);
+    // every thread has read row karg; rendezvous before overwriting it
+    threadgroup_barrier(mem_flags::mem_device);
+    for (uint r = tid; r < n; r += nt) {
+      const float t = vre[r] * scl;
+      const float u = vim[r] * scl;
+      vre[r] = cs * t + sn * u;
+      vim[r] = r == karg ? 0.0f : cs * u - sn * t;
+    }
+  }
+}

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -42,6 +42,7 @@
 #include <ATen/ops/linalg_lu_solve.h>
 #include <ATen/ops/linalg_qr.h>
 #include <ATen/ops/linalg_qr_native.h>
+#include <ATen/ops/linalg_solve_triangular.h>
 #include <ATen/ops/linalg_solve_triangular_native.h>
 #include <ATen/ops/linalg_svd.h>
 #include <ATen/ops/linalg_vector_norm.h>
@@ -61,7 +62,9 @@
 
 #include <c10/util/env.h>
 #include <algorithm>
+#include <cmath>
 #include <cstring>
+#include <limits>
 #include <string>
 #include <unordered_set>
 
@@ -1899,23 +1902,33 @@ static bool linalg_eig_hybrid_mps(Tensor& eigenvalues, Tensor& eigenvectors, Ten
   using namespace mps;
   const int64_t n64 = input.size(-1);
   int n = static_cast<int>(n64);
+  const int64_t m64 = n64 - 1; // reflector count
   const int64_t batch = std::max<int64_t>(1, batchCount(input));
   const auto cpu_f = input.options().device(at::kCPU);
-  auto A_cm = input.to(at::kCPU).mT().contiguous(); // [b] holds A column-major
-  auto Z_cm = at::empty(A_cm.sizes(), cpu_f);
-  auto refl_cm = at::empty(A_cm.sizes(), cpu_f); // gehrd reflectors (A copy)
-  auto tau = at::empty({batch, n64 - 1}, cpu_f);
+  const auto cpu_pinned = cpu_f.pinned_memory(true); // page-aligned: uploads skip staging+sync
+  // TZ[0] holds A (overwritten by the Schur T), TZ[1] the hseqr Z, both in
+  // per-matrix column-major layout, packed so the post-hseqr upload is one copy
+  auto TZ_cm = at::empty({2, batch, n64, n64}, cpu_pinned);
+  auto A_cm = TZ_cm[0];
+  auto Z_cm = TZ_cm[1];
+  A_cm.view(input.sizes()).copy_(input.mT()); // transposes on the GPU, blits into pinned
+  auto Vt_cpu = at::zeros({batch, m64, n64}, cpu_pinned); // WY reflectors, one per row
+  auto tau = at::empty({batch, m64}, cpu_pinned);
   auto bal = at::empty({batch, n64}, cpu_f);
-  auto values_cpu = at::empty(eigenvalues.sizes(), eigenvalues.options().device(at::kCPU));
+  auto aux_cpu = at::empty({batch, 5, n64}, cpu_pinned); // diag|sub|super|cnorm|row-scale
+  auto perm = at::empty({batch, n64}, cpu_f.dtype(at::kLong));
+  auto values_cpu = at::empty(eigenvalues.sizes(), eigenvalues.options().device(at::kCPU).pinned_memory(true));
   auto values_flat = values_cpu.view({batch, 2 * n64});
   std::vector<int> ilos(batch);
   std::vector<int> ihis(batch);
 
   float* a_all = A_cm.data_ptr<float>();
   float* z_all = Z_cm.data_ptr<float>();
-  float* refl_all = refl_cm.data_ptr<float>();
+  float* vt_all = Vt_cpu.data_ptr<float>();
   float* tau_all = tau.data_ptr<float>();
   float* bal_all = bal.data_ptr<float>();
+  float* aux_all = aux_cpu.data_ptr<float>();
+  int64_t* p_all = perm.data_ptr<int64_t>();
   float* val_all = values_flat.data_ptr<float>();
   char jobS = 'S';
   char compI = 'I';
@@ -1929,9 +1942,31 @@ static bool linalg_eig_hybrid_mps(Tensor& eigenvalues, Tensor& eigenvectors, Ten
   shseqr_(&jobS, &compI, &n, &ilo1, &ihi1, a_all, &n, val_all, val_all + n64, z_all, &n, &wk_hs, &lwork, &info);
   lwork = std::max({static_cast<int>(wk_hrd) + 1, static_cast<int>(wk_hs) + 1, n});
   auto work = at::empty({lwork}, cpu_f);
+  bool any_scale = false;
+  bool any_perm = false;
+  const float eig_smlnum = std::sqrt(std::numeric_limits<float>::min()) / std::numeric_limits<float>::epsilon();
+  const float eig_bignum = 1.0f / eig_smlnum;
+  std::vector<float> eig_output_scale(batch, 1.0f);
   // batch entries stay serial: concurrent Accelerate LAPACK is bit-unstable
   for (int64_t b = 0; b < batch; ++b) {
     float* a = a_all + b * n64 * n64;
+    float anrm = 0.0f;
+    for (int64_t i = 0; i < n64 * n64; ++i) {
+      anrm = std::max(anrm, std::fabs(a[i]));
+    }
+    float target = anrm;
+    if (anrm > 0.0f && anrm < eig_smlnum) {
+      target = eig_smlnum;
+    } else if (anrm > eig_bignum) {
+      target = eig_bignum;
+    }
+    if (target != anrm) {
+      const float scale = target / anrm;
+      for (int64_t i = 0; i < n64 * n64; ++i) {
+        a[i] *= scale;
+      }
+      eig_output_scale[b] = anrm / target;
+    }
     char balB = 'B';
     int ilo_b = 1;
     int ihi_b = n;
@@ -1940,95 +1975,51 @@ static bool linalg_eig_hybrid_mps(Tensor& eigenvalues, Tensor& eigenvectors, Ten
     if (info_b != 0) {
       return false;
     }
-    sgehrd_(&n, &ilo_b, &ihi_b, a, &n, tau_all + b * (n64 - 1), work.data_ptr<float>(), &lwork, &info_b);
+    sgehrd_(&n, &ilo_b, &ihi_b, a, &n, tau_all + b * m64, work.data_ptr<float>(), &lwork, &info_b);
     if (info_b != 0) {
       return false;
     }
-    std::memcpy(refl_all + b * n64 * n64, a, sizeof(float) * n64 * n64);
-    float* val_b = val_all + b * 2 * n64;
-    float* z_b = z_all + b * n64 * n64;
-    shseqr_(
-        &jobS, &compI, &n, &ilo_b, &ihi_b, a, &n, val_b, val_b + n64, z_b, &n, work.data_ptr<float>(), &lwork, &info_b);
-    if (info_b != 0) {
-      return false; // rare non-convergence: match the CPU backend exactly
-    }
     ilos[b] = ilo_b;
     ihis[b] = ihi_b;
-  }
-
-  // dense compact-WY blocks for Q: V columns get an explicit unit + zeros, so
-  // reflectors outside [ilo, ihi-1] (tau = 0, set by gehrd) stay inert and the
-  // block partition is uniform across batch entries
-  const int64_t nb = 128;
-  const int64_t nrefl = n64 - 1;
-  const int64_t nblk = (nrefl + nb - 1) / nb;
-  auto Vs = at::zeros({batch, nblk, n64, nb}, cpu_f);
-  float* vs_all = Vs.data_ptr<float>();
-  for (int64_t b = 0; b < batch; ++b) {
-    for (int64_t j = 1; j <= nrefl; ++j) { // 1-based reflector index
-      const int64_t k = (j - 1) / nb;
-      const int64_t c = (j - 1) % nb;
-      float* vcol = vs_all + ((b * nblk + k) * n64) * nb + c; // row stride nb
-      vcol[j * nb] = 1.0f;
-      const float* rcol = refl_all + b * n64 * n64 + (j - 1) * n64;
-      for (int64_t i = j + 2; i <= ihis[b]; ++i) { // 1-based rows
-        vcol[(i - 1) * nb] = rcol[i - 1];
+    // reflector rows for the single-block compact-WY Q (transposed layout, so
+    // extraction is one contiguous copy per reflector). tau == 0 reflectors
+    // (outside [ilo, ihi-1] or an exact-zero column) become v = 0 with
+    // tau = 1: H stays the identity and T_wy^-1 below stays invertible
+    float* tb = tau_all + b * m64;
+    float* vtb = vt_all + b * m64 * n64;
+    for (int64_t j = 1; j <= m64; ++j) {
+      if (tb[j - 1] == 0.0f) {
+        tb[j - 1] = 1.0f;
+        continue;
+      }
+      float* vrow = vtb + (j - 1) * n64;
+      vrow[j] = 1.0f;
+      if (ihi_b - 1 > j) {
+        std::memcpy(vrow + j + 1, a + (j - 1) * n64 + j + 1, sizeof(float) * (ihi_b - 1 - j));
       }
     }
-  }
-  auto G = Vs.mT().matmul(Vs); // per-block Gram matrices, g[r][c] = v_r . v_c
-  auto Tblk = at::zeros({batch, nblk, nb, nb}, cpu_f);
-  const float* g_all = G.data_ptr<float>();
-  float* tb_all = Tblk.data_ptr<float>();
-  for (int64_t b = 0; b < batch; ++b) {
-    for (int64_t k = 0; k < nblk; ++k) {
-      const float* g = g_all + (b * nblk + k) * nb * nb;
-      float* t = tb_all + (b * nblk + k) * nb * nb;
-      for (int64_t c = 0; c < nb; ++c) {
-        const int64_t j = k * nb + c + 1;
-        const float tj = j <= nrefl ? tau_all[b * (n64 - 1) + j - 1] : 0.0f;
-        t[c * nb + c] = tj;
-        // forward recurrence: T(0:c-1, c) = -tau_j * T(0:c-1, 0:c-1) @ g(0:c-1, c)
-        for (int64_t r = 0; r < c; ++r) {
-          float s = 0.0f;
-          for (int64_t d = r; d < c; ++d) {
-            s += t[r * nb + d] * g[d * nb + c];
-          }
-          t[r * nb + c] = -tj * s;
-        }
-      }
-    }
-  }
-
-  // sgebak('B', 'R'): per-row scaling on [ilo, ihi], then the interleaved
-  // swap sequence (ilo-1 down to 1, ihi+1 up to n), simulated into perm
-  bool any_scale = false;
-  bool any_perm = false;
-  auto row_scale = at::empty({batch, n64}, cpu_f);
-  auto perm = at::empty({batch, n64}, cpu_f.dtype(at::kLong));
-  float* rs_all = row_scale.data_ptr<float>();
-  int64_t* p_all = perm.data_ptr<int64_t>();
-  for (int64_t b = 0; b < batch; ++b) {
+    // sgebak('B', 'R') prep: per-row scaling on [ilo, ihi] into aux row 4, and
+    // the interleaved swap sequence (ilo-1 down to 1, ihi+1 up to n) into perm
     const float* sc = bal_all + b * n64;
-    float* rs = rs_all + b * n64;
+    float* rs = aux_all + (b * 5 + 4) * n64;
     int64_t* p = p_all + b * n64;
     for (int64_t i = 0; i < n64; ++i) {
       rs[i] = 1.0f;
       p[i] = i;
     }
-    if (ilos[b] != ihis[b]) {
-      for (int64_t i = ilos[b]; i <= ihis[b]; ++i) {
+    if (ilo_b != ihi_b) {
+      for (int64_t i = ilo_b; i <= ihi_b; ++i) {
         rs[i - 1] = sc[i - 1];
         any_scale |= sc[i - 1] != 1.0f;
       }
     }
     for (int64_t ii = 1; ii <= n64; ++ii) {
       int64_t i = ii;
-      if (i >= ilos[b] && i <= ihis[b]) {
+      if (i >= ilo_b && i <= ihi_b) {
         continue;
       }
-      if (i < ilos[b]) {
-        i = ilos[b] - ii;
+      if (i < ilo_b) {
+        i = ilo_b - ii;
       }
       const int64_t kk = static_cast<int64_t>(sc[i - 1]);
       if (kk == i) {
@@ -2038,14 +2029,85 @@ static bool linalg_eig_hybrid_mps(Tensor& eigenvalues, Tensor& eigenvectors, Ten
       any_perm = true;
     }
   }
+  // Q1 = H(1)...H(n-1) as one compact-WY block, encoded and committed now so
+  // the GPU forms it in the shadow of the CPU hseqr loop below. With G = V^T V,
+  // T_wy^-1 = diag(1/tau) + striu(G), and the triangular solve only reads the
+  // upper triangle, so overwriting G's diagonal with 1/tau is all the assembly
+  // needed: Q1 = I - V solve(T_wy^-1, V^T). gebak's row scaling commutes into
+  // Q1, so it is folded in here instead of a launch on the critical tail.
+  auto stream = getCurrentMPSStream();
+  const auto mps_f = input.options();
+  auto Vt_dev = at::empty(Vt_cpu.sizes(), mps_f);
+  Vt_dev.copy_(Vt_cpu, /*non_blocking=*/true);
+  auto tau_dev = at::empty(tau.sizes(), mps_f);
+  tau_dev.copy_(tau, /*non_blocking=*/true);
+  auto G = Vt_dev.matmul(Vt_dev.mT());
+  G.diagonal(0, -2, -1).copy_(tau_dev.reciprocal());
+  auto Q1 = at::eye(n64, mps_f).sub(Vt_dev.mT().matmul(at::linalg_solve_triangular(G, Vt_dev, /*upper=*/true)));
+  if (any_scale) {
+    auto rs_dev = at::empty({batch, n64}, mps_f);
+    rs_dev.copy_(aux_cpu.select(1, 4), /*non_blocking=*/true);
+    Q1.mul_(rs_dev.unsqueeze(-1));
+  }
+  stream->synchronize(SyncType::COMMIT_AND_CONTINUE);
+  for (int64_t b = 0; b < batch; ++b) {
+    float* a = a_all + b * n64 * n64;
+    float* val_b = val_all + b * 2 * n64;
+    float* z_b = z_all + b * n64 * n64;
+    int ilo_b = ilos[b];
+    int ihi_b = ihis[b];
+    int info_b = 0;
+    shseqr_(
+        &jobS, &compI, &n, &ilo_b, &ihi_b, a, &n, val_b, val_b + n64, z_b, &n, work.data_ptr<float>(), &lwork, &info_b);
+    if (info_b != 0) {
+      return false; // rare non-convergence: match the CPU backend exactly
+    }
+    if (eig_output_scale[b] != 1.0f) {
+      for (int64_t j = 0; j < 2 * n64; ++j) {
+        val_b[j] *= eig_output_scale[b];
+      }
+    }
+    // gather what the serial trevc solve reads scalar-by-scalar into contiguous
+    // arrays (strided T reads make each one a cache miss): diag, sub- and
+    // superdiagonal, plus the strict-upper column 1-norms it uses as guards
+    float* dg = aux_all + b * 5 * n64;
+    float* sb = dg + n64;
+    float* sp = dg + 2 * n64;
+    float* cw = dg + 3 * n64;
+    for (int64_t j = 0; j < n64; ++j) {
+      const float* col = a + j * n64;
+      dg[j] = col[j];
+      sb[j] = j + 1 < n64 ? col[j + 1] : 0.0f;
+      sp[j] = j + 1 < n64 ? a[j + (j + 1) * n64] : 0.0f;
+      // 4 accumulators: cnorm is only an overflow-guard magnitude, and the
+      // old on-device tree reduction reassociated the sum too
+      float s0 = 0.0f;
+      float s1 = 0.0f;
+      float s2 = 0.0f;
+      float s3 = 0.0f;
+      int64_t i = 0;
+      for (; i + 4 <= j; i += 4) {
+        s0 += std::fabs(col[i]);
+        s1 += std::fabs(col[i + 1]);
+        s2 += std::fabs(col[i + 2]);
+        s3 += std::fabs(col[i + 3]);
+      }
+      for (; i < j; ++i) {
+        s0 += std::fabs(col[i]);
+      }
+      cw[j] = (s0 + s1) + (s2 + s3);
+    }
+  }
 
   // GPU tail
-  eigenvalues.copy_(values_cpu);
-  auto T_dev = A_cm.to(at::kMPS); // [b] holds the Schur form T column-major
-  auto Z_dev = Z_cm.to(at::kMPS);
-  auto cn = T_dev.abs().tril(-1).sum(-1); // strict-upper column norms of T
-  auto X_dev = at::empty({batch, n64, n64}, input.options());
-  auto stream = getCurrentMPSStream();
+  eigenvalues.copy_(values_cpu, /*non_blocking=*/true);
+  auto TZ_dev = at::empty(TZ_cm.sizes(), mps_f);
+  TZ_dev.copy_(TZ_cm, /*non_blocking=*/true);
+  auto T_dev = TZ_dev[0]; // Schur form T, column-major
+  auto Z_dev = TZ_dev[1];
+  auto aux_dev = at::empty(aux_cpu.sizes(), mps_f);
+  aux_dev.copy_(aux_cpu, /*non_blocking=*/true);
+  auto X_dev = at::empty({batch, n64, n64}, mps_f);
   {
     auto pso = lib.getPipelineStateForFunc("eig_trevc_col_float");
     dispatch_sync_with_rethrow(stream->queue(), ^() {
@@ -2053,33 +2115,29 @@ static bool linalg_eig_hybrid_mps(Tensor& eigenvalues, Tensor& eigenvectors, Ten
         auto computeEncoder = stream->commandEncoder();
         getMPSProfiler().beginProfileKernel(pso, "eig_trevc_col", {input});
         [computeEncoder setComputePipelineState:pso];
-        mtl_setArgs(computeEncoder, T_dev, cn, X_dev, static_cast<uint32_t>(n));
+        mtl_setArgs(computeEncoder, T_dev, aux_dev, X_dev, static_cast<uint32_t>(n), 0u, static_cast<uint32_t>(n));
         [computeEncoder setThreadgroupMemoryLength:static_cast<NSUInteger>((2 * n64 * 4 + 15) / 16 * 16) atIndex:0];
         [computeEncoder dispatchThreadgroups:MTLSizeMake(n, batch, 1) threadsPerThreadgroup:MTLSizeMake(64, 1, 1)];
         getMPSProfiler().endProfileKernel(pso);
       }
     });
   }
-  // back-transform: C = Z @ X, then Q applied block by block in reverse,
-  // C := C - V (T (V^T C)). Full-height contiguous operands: narrowing V and
-  // C to the touched rows halves the flops but routes the GEMMs and sub_
-  // through strided paths that are ~20x slower than the extra work
-  auto C = Z_dev.mT().matmul(X_dev.mT());
-  auto Vs_dev = Vs.to(at::kMPS);
-  auto Tb_dev = Tblk.to(at::kMPS);
-  for (int64_t k = nblk - 1; k >= 0; --k) {
-    auto Vk = Vs_dev.select(1, k);
-    auto W = Tb_dev.select(1, k).matmul(Vk.mT().matmul(C));
-    C.sub_(Vk.matmul(W));
-  }
-  if (any_scale) {
-    C.mul_(row_scale.to(at::kMPS).unsqueeze(-1));
-  }
+  // back-transform: eigenvectors = Q1 (Z X), with Q1 (and gebak's row scaling)
+  // already formed in the hseqr shadow. Full contiguous operands: narrowing to
+  // the touched rows routes the GEMMs through strided paths ~20x slower than
+  // the extra work. The last GEMM writes straight into the column-major
+  // eigenvector buffer unless gebak permuted rows (rare).
+  auto ZX = Z_dev.mT().matmul(X_dev.mT());
   if (any_perm) {
+    auto C = Q1.matmul(ZX);
     auto idx = perm.to(at::kMPS).unsqueeze(-1).expand({batch, n64, n64}).contiguous();
-    C = C.gather(1, idx);
+    eigenvectors.copy_(C.gather(1, idx).reshape(eigenvectors.sizes()));
+  } else {
+    // the out view is C^T (row-major alias of the column-major buffer), so
+    // compute (Q1 ZX)^T = ZX^T Q1^T straight into it
+    auto out = eigenvectors.mT().reshape({batch, n64, n64});
+    at::matmul_out(out, ZX.mT(), Q1.mT());
   }
-  eigenvectors.copy_(C.reshape(eigenvectors.sizes()));
   {
     auto pso = lib.getPipelineStateForFunc("eig_normalize_float");
     dispatch_sync_with_rethrow(stream->queue(), ^() {
@@ -2118,7 +2176,9 @@ static void linalg_eig_kernel_mps(Tensor& eigenvalues,
   // is sequential with data-dependent deflation, and every other backend does
   // the same (CUDA/MAGMA runs it on the CPU, MLX throws Metal-NYI).
   const int64_t tg_limit = static_cast<int64_t>([MPSDevice::getInstance()->device() maxThreadgroupMemoryLength]);
-  const int64_t tg_bytes = ((compute_eigenvectors ? 2 : 1) * n * n + 8 * n + 16) * static_cast<int64_t>(sizeof(float));
+  const int64_t scratch_elems = std::max<int64_t>(8 * n, 64);
+  const int64_t tg_bytes =
+      ((compute_eigenvectors ? 2 : 1) * n * n + scratch_elems + 16) * static_cast<int64_t>(sizeof(float));
   const bool layouts_ok = eigenvalues.is_contiguous() && infos.is_contiguous() &&
       (!compute_eigenvectors || eigenvectors.mT().is_contiguous());
   // batch*n >= 1024 is the measured M5 Pro break-even: GPU wall time is flat
@@ -2139,7 +2199,7 @@ static void linalg_eig_kernel_mps(Tensor& eigenvalues,
         const auto align16 = [](int64_t bytes) { return static_cast<NSUInteger>((bytes + 15) / 16 * 16); };
         [computeEncoder setThreadgroupMemoryLength:align16(n * n * 4) atIndex:0];
         [computeEncoder setThreadgroupMemoryLength:align16(compute_eigenvectors ? n * n * 4 : 4) atIndex:1];
-        [computeEncoder setThreadgroupMemoryLength:align16(8 * n * 4) atIndex:2];
+        [computeEncoder setThreadgroupMemoryLength:align16(scratch_elems * 4) atIndex:2];
         [computeEncoder dispatchThreadgroups:MTLSizeMake(batch, 1, 1) threadsPerThreadgroup:MTLSizeMake(64, 1, 1)];
         getMPSProfiler().endProfileKernel(pso);
       }

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -1,6 +1,7 @@
 //  Copyright © 2022 Apple Inc.
 
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/Config.h>
 #include <ATen/ceil_div.h>
 #include <ATen/mps/MPSProfiler.h>
 #include <ATen/native/BatchLinearAlgebra.h>
@@ -60,6 +61,7 @@
 
 #include <c10/util/env.h>
 #include <algorithm>
+#include <cstring>
 #include <string>
 #include <unordered_set>
 
@@ -1863,6 +1865,345 @@ static void eigh_kernel_mps(const Tensor& eigenvalues,
   }
 }
 
+#if AT_BUILD_WITH_LAPACK()
+extern "C" {
+void sgebal_(char* job, int* n, float* a, int* lda, int* ilo, int* ihi, float* scale, int* info);
+void sgehrd_(int* n, int* ilo, int* ihi, float* a, int* lda, float* tau, float* work, int* lwork, int* info);
+void shseqr_(char* job,
+             char* compz,
+             int* n,
+             int* ilo,
+             int* ihi,
+             float* h,
+             int* ldh,
+             float* wr,
+             float* wi,
+             float* z,
+             int* ldz,
+             float* work,
+             int* lwork,
+             int* info);
+}
+#endif
+
+// Hybrid GEEV for large fp32 matrices: the sequential QR iteration (gebal +
+// gehrd + hseqr) stays on the CPU, and the data-parallel tail moves to the
+// GPU: trevc backsolves, the Q back-transform (hseqr runs with compz='I' so
+// Q is applied from gehrd's reflectors as blocked compact-WY GEMMs), gebak,
+// and the sgeev normalization. Profiled on M5 Pro that tail is 16% (n=1024)
+// to 22% (n=2048) of sgeev. Returns false to request the full CPU fallback.
+static bool linalg_eig_hybrid_mps(Tensor& eigenvalues, Tensor& eigenvectors, Tensor& infos, const Tensor& input) {
+#if !AT_BUILD_WITH_LAPACK()
+  return false;
+#else
+  using namespace mps;
+  const int64_t n64 = input.size(-1);
+  int n = static_cast<int>(n64);
+  const int64_t batch = std::max<int64_t>(1, batchCount(input));
+  const auto cpu_f = input.options().device(at::kCPU);
+  auto A_cm = input.to(at::kCPU).mT().contiguous(); // [b] holds A column-major
+  auto Z_cm = at::empty(A_cm.sizes(), cpu_f);
+  auto refl_cm = at::empty(A_cm.sizes(), cpu_f); // gehrd reflectors (A copy)
+  auto tau = at::empty({batch, n64 - 1}, cpu_f);
+  auto bal = at::empty({batch, n64}, cpu_f);
+  auto values_cpu = at::empty(eigenvalues.sizes(), eigenvalues.options().device(at::kCPU));
+  auto values_flat = values_cpu.view({batch, 2 * n64});
+  std::vector<int> ilos(batch);
+  std::vector<int> ihis(batch);
+
+  float* a_all = A_cm.data_ptr<float>();
+  float* z_all = Z_cm.data_ptr<float>();
+  float* refl_all = refl_cm.data_ptr<float>();
+  float* tau_all = tau.data_ptr<float>();
+  float* bal_all = bal.data_ptr<float>();
+  float* val_all = values_flat.data_ptr<float>();
+  char jobS = 'S';
+  char compI = 'I';
+  int info = 0;
+  int ilo1 = 1;
+  int ihi1 = n;
+  int lwork = -1;
+  float wk_hrd = 0.0f;
+  float wk_hs = 0.0f;
+  sgehrd_(&n, &ilo1, &ihi1, a_all, &n, tau_all, &wk_hrd, &lwork, &info);
+  shseqr_(&jobS, &compI, &n, &ilo1, &ihi1, a_all, &n, val_all, val_all + n64, z_all, &n, &wk_hs, &lwork, &info);
+  lwork = std::max({static_cast<int>(wk_hrd) + 1, static_cast<int>(wk_hs) + 1, n});
+  auto work = at::empty({lwork}, cpu_f);
+  // batch entries stay serial: concurrent Accelerate LAPACK is bit-unstable
+  for (int64_t b = 0; b < batch; ++b) {
+    float* a = a_all + b * n64 * n64;
+    char balB = 'B';
+    int ilo_b = 1;
+    int ihi_b = n;
+    int info_b = 0;
+    sgebal_(&balB, &n, a, &n, &ilo_b, &ihi_b, bal_all + b * n64, &info_b);
+    if (info_b != 0) {
+      return false;
+    }
+    sgehrd_(&n, &ilo_b, &ihi_b, a, &n, tau_all + b * (n64 - 1), work.data_ptr<float>(), &lwork, &info_b);
+    if (info_b != 0) {
+      return false;
+    }
+    std::memcpy(refl_all + b * n64 * n64, a, sizeof(float) * n64 * n64);
+    float* val_b = val_all + b * 2 * n64;
+    float* z_b = z_all + b * n64 * n64;
+    shseqr_(
+        &jobS, &compI, &n, &ilo_b, &ihi_b, a, &n, val_b, val_b + n64, z_b, &n, work.data_ptr<float>(), &lwork, &info_b);
+    if (info_b != 0) {
+      return false; // rare non-convergence: match the CPU backend exactly
+    }
+    ilos[b] = ilo_b;
+    ihis[b] = ihi_b;
+  }
+
+  // dense compact-WY blocks for Q: V columns get an explicit unit + zeros, so
+  // reflectors outside [ilo, ihi-1] (tau = 0, set by gehrd) stay inert and the
+  // block partition is uniform across batch entries
+  const int64_t nb = 128;
+  const int64_t nrefl = n64 - 1;
+  const int64_t nblk = (nrefl + nb - 1) / nb;
+  auto Vs = at::zeros({batch, nblk, n64, nb}, cpu_f);
+  float* vs_all = Vs.data_ptr<float>();
+  for (int64_t b = 0; b < batch; ++b) {
+    for (int64_t j = 1; j <= nrefl; ++j) { // 1-based reflector index
+      const int64_t k = (j - 1) / nb;
+      const int64_t c = (j - 1) % nb;
+      float* vcol = vs_all + ((b * nblk + k) * n64) * nb + c; // row stride nb
+      vcol[j * nb] = 1.0f;
+      const float* rcol = refl_all + b * n64 * n64 + (j - 1) * n64;
+      for (int64_t i = j + 2; i <= ihis[b]; ++i) { // 1-based rows
+        vcol[(i - 1) * nb] = rcol[i - 1];
+      }
+    }
+  }
+  auto G = Vs.mT().matmul(Vs); // per-block Gram matrices, g[r][c] = v_r . v_c
+  auto Tblk = at::zeros({batch, nblk, nb, nb}, cpu_f);
+  const float* g_all = G.data_ptr<float>();
+  float* tb_all = Tblk.data_ptr<float>();
+  for (int64_t b = 0; b < batch; ++b) {
+    for (int64_t k = 0; k < nblk; ++k) {
+      const float* g = g_all + (b * nblk + k) * nb * nb;
+      float* t = tb_all + (b * nblk + k) * nb * nb;
+      for (int64_t c = 0; c < nb; ++c) {
+        const int64_t j = k * nb + c + 1;
+        const float tj = j <= nrefl ? tau_all[b * (n64 - 1) + j - 1] : 0.0f;
+        t[c * nb + c] = tj;
+        // forward recurrence: T(0:c-1, c) = -tau_j * T(0:c-1, 0:c-1) @ g(0:c-1, c)
+        for (int64_t r = 0; r < c; ++r) {
+          float s = 0.0f;
+          for (int64_t d = r; d < c; ++d) {
+            s += t[r * nb + d] * g[d * nb + c];
+          }
+          t[r * nb + c] = -tj * s;
+        }
+      }
+    }
+  }
+
+  // sgebak('B', 'R'): per-row scaling on [ilo, ihi], then the interleaved
+  // swap sequence (ilo-1 down to 1, ihi+1 up to n), simulated into perm
+  bool any_scale = false;
+  bool any_perm = false;
+  auto row_scale = at::empty({batch, n64}, cpu_f);
+  auto perm = at::empty({batch, n64}, cpu_f.dtype(at::kLong));
+  float* rs_all = row_scale.data_ptr<float>();
+  int64_t* p_all = perm.data_ptr<int64_t>();
+  for (int64_t b = 0; b < batch; ++b) {
+    const float* sc = bal_all + b * n64;
+    float* rs = rs_all + b * n64;
+    int64_t* p = p_all + b * n64;
+    for (int64_t i = 0; i < n64; ++i) {
+      rs[i] = 1.0f;
+      p[i] = i;
+    }
+    if (ilos[b] != ihis[b]) {
+      for (int64_t i = ilos[b]; i <= ihis[b]; ++i) {
+        rs[i - 1] = sc[i - 1];
+        any_scale |= sc[i - 1] != 1.0f;
+      }
+    }
+    for (int64_t ii = 1; ii <= n64; ++ii) {
+      int64_t i = ii;
+      if (i >= ilos[b] && i <= ihis[b]) {
+        continue;
+      }
+      if (i < ilos[b]) {
+        i = ilos[b] - ii;
+      }
+      const int64_t kk = static_cast<int64_t>(sc[i - 1]);
+      if (kk == i) {
+        continue;
+      }
+      std::swap(p[i - 1], p[kk - 1]);
+      any_perm = true;
+    }
+  }
+
+  // GPU tail
+  eigenvalues.copy_(values_cpu);
+  auto T_dev = A_cm.to(at::kMPS); // [b] holds the Schur form T column-major
+  auto Z_dev = Z_cm.to(at::kMPS);
+  auto cn = T_dev.abs().tril(-1).sum(-1); // strict-upper column norms of T
+  auto X_dev = at::empty({batch, n64, n64}, input.options());
+  auto stream = getCurrentMPSStream();
+  {
+    auto pso = lib.getPipelineStateForFunc("eig_trevc_col_float");
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      @autoreleasepool {
+        auto computeEncoder = stream->commandEncoder();
+        getMPSProfiler().beginProfileKernel(pso, "eig_trevc_col", {input});
+        [computeEncoder setComputePipelineState:pso];
+        mtl_setArgs(computeEncoder, T_dev, cn, X_dev, static_cast<uint32_t>(n));
+        [computeEncoder setThreadgroupMemoryLength:static_cast<NSUInteger>((2 * n64 * 4 + 15) / 16 * 16) atIndex:0];
+        [computeEncoder dispatchThreadgroups:MTLSizeMake(n, batch, 1) threadsPerThreadgroup:MTLSizeMake(64, 1, 1)];
+        getMPSProfiler().endProfileKernel(pso);
+      }
+    });
+  }
+  // back-transform: C = Z @ X, then Q applied block by block in reverse,
+  // C := C - V (T (V^T C)). Full-height contiguous operands: narrowing V and
+  // C to the touched rows halves the flops but routes the GEMMs and sub_
+  // through strided paths that are ~20x slower than the extra work
+  auto C = Z_dev.mT().matmul(X_dev.mT());
+  auto Vs_dev = Vs.to(at::kMPS);
+  auto Tb_dev = Tblk.to(at::kMPS);
+  for (int64_t k = nblk - 1; k >= 0; --k) {
+    auto Vk = Vs_dev.select(1, k);
+    auto W = Tb_dev.select(1, k).matmul(Vk.mT().matmul(C));
+    C.sub_(Vk.matmul(W));
+  }
+  if (any_scale) {
+    C.mul_(row_scale.to(at::kMPS).unsqueeze(-1));
+  }
+  if (any_perm) {
+    auto idx = perm.to(at::kMPS).unsqueeze(-1).expand({batch, n64, n64}).contiguous();
+    C = C.gather(1, idx);
+  }
+  eigenvectors.copy_(C.reshape(eigenvectors.sizes()));
+  {
+    auto pso = lib.getPipelineStateForFunc("eig_normalize_float");
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      @autoreleasepool {
+        auto computeEncoder = stream->commandEncoder();
+        getMPSProfiler().beginProfileKernel(pso, "eig_normalize", {input});
+        [computeEncoder setComputePipelineState:pso];
+        mtl_setArgs(computeEncoder, eigenvectors, eigenvalues, static_cast<uint32_t>(n));
+        [computeEncoder setThreadgroupMemoryLength:2 * 64 * sizeof(float) atIndex:0];
+        [computeEncoder setThreadgroupMemoryLength:64 * sizeof(uint32_t) atIndex:1];
+        [computeEncoder dispatchThreadgroups:MTLSizeMake(n, batch, 1) threadsPerThreadgroup:MTLSizeMake(64, 1, 1)];
+        getMPSProfiler().endProfileKernel(pso);
+      }
+    });
+  }
+  infos.zero_();
+  return true;
+#endif
+}
+
+static void linalg_eig_kernel_mps(Tensor& eigenvalues,
+                                  Tensor& eigenvectors,
+                                  Tensor& infos,
+                                  const Tensor& input,
+                                  bool compute_eigenvectors) {
+  using namespace mps;
+  if (input.numel() == 0) {
+    infos.zero_();
+    return;
+  }
+  const auto n = input.size(-1);
+  const int64_t batch = std::max<int64_t>(1, batchCount(input));
+  // Batched small matrices run a native Metal GEEV (one matrix per
+  // threadgroup; LAPACK sgehd2+slahqr+strevc port in LinearAlgebra.metal).
+  // Everything else round-trips through the CPU: GEEV's shifted QR iteration
+  // is sequential with data-dependent deflation, and every other backend does
+  // the same (CUDA/MAGMA runs it on the CPU, MLX throws Metal-NYI).
+  const int64_t tg_limit = static_cast<int64_t>([MPSDevice::getInstance()->device() maxThreadgroupMemoryLength]);
+  const int64_t tg_bytes = ((compute_eigenvectors ? 2 : 1) * n * n + 8 * n + 16) * static_cast<int64_t>(sizeof(float));
+  const bool layouts_ok = eigenvalues.is_contiguous() && infos.is_contiguous() &&
+      (!compute_eigenvectors || eigenvectors.mT().is_contiguous());
+  // batch*n >= 1024 is the measured M5 Pro break-even: GPU wall time is flat
+  // in batch (concurrent threadgroups) while CPU scales linearly, so the gate
+  // is where batch * per-matrix CPU time crosses the flat GPU time.
+  if (input.scalar_type() == kFloat && batch * n >= 1024 && tg_bytes <= tg_limit && layouts_ok) {
+    auto A_cm = input.mT().contiguous(); // A in per-matrix column-major layout
+    auto pso = lib.getPipelineStateForFunc("eig_qr_float");
+    auto stream = getCurrentMPSStream();
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      @autoreleasepool {
+        auto computeEncoder = stream->commandEncoder();
+        getMPSProfiler().beginProfileKernel(pso, "eig_qr", {input});
+        [computeEncoder setComputePipelineState:pso];
+        EigParams params{static_cast<uint32_t>(n), compute_eigenvectors ? 1u : 0u};
+        mtl_setArgs(
+            computeEncoder, A_cm, eigenvalues, compute_eigenvectors ? eigenvectors : eigenvalues, infos, params);
+        const auto align16 = [](int64_t bytes) { return static_cast<NSUInteger>((bytes + 15) / 16 * 16); };
+        [computeEncoder setThreadgroupMemoryLength:align16(n * n * 4) atIndex:0];
+        [computeEncoder setThreadgroupMemoryLength:align16(compute_eigenvectors ? n * n * 4 : 4) atIndex:1];
+        [computeEncoder setThreadgroupMemoryLength:align16(8 * n * 4) atIndex:2];
+        [computeEncoder dispatchThreadgroups:MTLSizeMake(batch, 1, 1) threadsPerThreadgroup:MTLSizeMake(64, 1, 1)];
+        getMPSProfiler().endProfileKernel(pso);
+      }
+    });
+    return;
+  }
+  // Large-matrix hybrid: the sequential QR iteration stays on the CPU while
+  // the trevc backsolves, Q back-transform and normalization run on the GPU.
+  // n >= 512 is the measured M5 Pro break-even for that tail.
+  const bool hybrid_fits = compute_eigenvectors && input.scalar_type() == kFloat && n >= 512 &&
+      2 * n * static_cast<int64_t>(sizeof(float)) <= tg_limit && layouts_ok;
+  if (hybrid_fits && linalg_eig_hybrid_mps(eigenvalues, eigenvectors, infos, input)) {
+    return;
+  }
+  // CPU LAPACK round-trip. Batch entries stay serial: concurrent Accelerate
+  // GEEV calls are bit-unstable (eigenvector signs flip run to run), and
+  // serial keeps this path bit-identical to the CPU backend.
+  auto values_cpu = at::empty(eigenvalues.sizes(), eigenvalues.options().device(at::kCPU));
+  auto infos_cpu = at::zeros(infos.sizes(), infos.options().device(at::kCPU));
+  Tensor vectors_cpu;
+  if (compute_eigenvectors) {
+    vectors_cpu = at::empty(eigenvectors.mT().sizes(), eigenvectors.options().device(at::kCPU)).mT();
+  }
+  linalg_eig_stub(at::kCPU, values_cpu, vectors_cpu, infos_cpu, input.to(at::kCPU), compute_eigenvectors);
+  eigenvalues.copy_(values_cpu);
+  if (compute_eigenvectors) {
+    eigenvectors.copy_(vectors_cpu);
+  }
+  infos.copy_(infos_cpu);
+}
+
+static void linalg_eig_make_complex_eigenvectors_mps(const Tensor& complex_vectors,
+                                                     const Tensor& complex_values,
+                                                     const Tensor& real_vectors) {
+  using namespace mps;
+  // Decode LAPACK GEEV's packed real eigenvector format. Elementwise and
+  // data-parallel, so run on-device when the layouts are the canonical
+  // batched column-major ones the orchestration produces.
+  const auto numel = complex_vectors.numel();
+  if (real_vectors.scalar_type() == kFloat && numel <= std::numeric_limits<int32_t>::max() &&
+      complex_vectors.mT().is_contiguous() && real_vectors.mT().is_contiguous() && complex_values.is_contiguous()) {
+    auto pso = lib.getPipelineStateForFunc("eig_make_complex_float");
+    auto stream = getCurrentMPSStream();
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      @autoreleasepool {
+        auto computeEncoder = stream->commandEncoder();
+        [computeEncoder setComputePipelineState:pso];
+        mtl_setArgs(computeEncoder,
+                    complex_vectors,
+                    complex_values,
+                    real_vectors,
+                    static_cast<uint32_t>(complex_vectors.size(-1)));
+        mtl_dispatch1DJob(computeEncoder, pso, numel);
+      }
+    });
+    return;
+  }
+  // fallback: CPU copies
+  auto vectors_cpu = at::empty(complex_vectors.mT().sizes(), complex_vectors.options().device(at::kCPU)).mT();
+  linalg_eig_make_complex_eigenvectors_stub(
+      at::kCPU, vectors_cpu, complex_values.to(at::kCPU), real_vectors.to(at::kCPU));
+  complex_vectors.copy_(vectors_cpu);
+}
+
 static Tensor& cholesky_inverse_kernel_impl_mps(Tensor& result, Tensor& infos, bool upper) {
   using namespace mps;
   TORCH_CHECK(result.is_mps(), "Output tensor is not MPS");
@@ -2300,6 +2641,8 @@ REGISTER_DISPATCH(orgqr_stub, mps::orgqr_stub_impl);
 REGISTER_DISPATCH(cholesky_inverse_stub, mps::cholesky_inverse_kernel_impl_mps);
 REGISTER_DISPATCH(svd_stub, mps::svd_kernel_mps);
 REGISTER_DISPATCH(linalg_eigh_stub, mps::eigh_kernel_mps);
+REGISTER_DISPATCH(linalg_eig_stub, mps::linalg_eig_kernel_mps);
+REGISTER_DISPATCH(linalg_eig_make_complex_eigenvectors_stub, mps::linalg_eig_make_complex_eigenvectors_mps);
 REGISTER_DISPATCH(lstsq_stub, mps::lstsq_kernel_mps);
 
 } // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -14427,17 +14427,17 @@
   python_module: linalg
   variants: function
   dispatch:
-    CPU, CUDA: linalg_eig
+    CPU, CUDA, MPS: linalg_eig
 
 - func: linalg_eig.out(Tensor self, *, Tensor(a!) eigenvalues, Tensor(b!) eigenvectors) -> (Tensor(a!) eigenvalues, Tensor(b!) eigenvectors)
   python_module: linalg
   dispatch:
-    CPU, CUDA: linalg_eig_out
+    CPU, CUDA, MPS: linalg_eig_out
 
 - func: _linalg_eigvals(Tensor self) -> Tensor
   python_module: linalg
   dispatch:
-    CPU, CUDA: _linalg_eigvals
+    CPU, CUDA, MPS: _linalg_eigvals
 
 - func: linalg_eigvals(Tensor self) -> Tensor
   python_module: linalg
@@ -14445,7 +14445,7 @@
 - func: linalg_eigvals.out(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   python_module: linalg
   dispatch:
-    CPU, CUDA: linalg_eigvals_out
+    CPU, CUDA, MPS: linalg_eigvals_out
 
 # This function is exposes the `compute_v` flag, which is then used to implement `linalg.eigh` and
 # `linalg.eigvalsh` as composite functions that call this one

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -7819,7 +7819,6 @@ for dtype in (torch.int32, torch.int64):
         TEST_WITH_ROCM and not torch.cuda.has_magma,
         "ROCm hipsolver backend does not currently support eig",
     )
-    @xfail_if_mps_unimplemented  # aten::linalg_eig not implemented for MPS
     @skipIfNoLapack
     def test_linalg_eig_stride_consistency(self):
         def fn(x):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -11362,6 +11362,56 @@ class TestConv3dChannelsLast3dMPS(NNTestCase):
 
 
 class TestLinalgMPS(TestCaseMPS):
+    @dtypes(torch.float32, torch.complex64)
+    @parametrize("shape", [(2, 2), (52, 52), (129, 129), (3, 5, 33, 33)])
+    def test_linalg_eig(self, device, dtype, shape):
+        torch.manual_seed(0)
+        a = torch.randn(shape, dtype=dtype)
+        w_cpu, v_cpu = torch.linalg.eig(a)
+        w, v = torch.linalg.eig(a.to(device))
+        self.assertEqual(w.cpu(), w_cpu, atol=0, rtol=0)
+        self.assertEqual(v.cpu(), v_cpu, atol=0, rtol=0)
+        self.assertEqual(torch.linalg.eigvals(a.to(device)).cpu(), w_cpu, atol=0, rtol=0)
+        av, vw = a.to(device).to(w.dtype) @ v, v * w.unsqueeze(-2)
+        self.assertEqual(av, vw, atol=2e-3, rtol=1e-4)
+
+    @parametrize("n", [7, 24, 60])
+    def test_linalg_eig_metal_batched(self, device, n):
+        torch.manual_seed(0)
+        batch = max(8, -(-1024 // n))  # batch*n >= 1024 hits the Metal geev kernel
+        a = torch.randn(batch, n, n) * 2
+        w, v = torch.linalg.eig(a.to(device))
+        w, v = w.cpu(), v.cpu()
+        w_cpu = torch.linalg.eig(a)[0]
+        dmat = (w.unsqueeze(-1) - w_cpu.unsqueeze(-2)).abs()
+        chamfer = torch.maximum(dmat.amin(-1).amax(-1), dmat.amin(-2).amax(-1))
+        self.assertEqual(chamfer, torch.zeros_like(chamfer), atol=5e-4, rtol=0)
+        rec = (a.to(w.dtype) @ v - v * w.unsqueeze(-2)).abs().amax(dim=(-2, -1))
+        self.assertEqual(rec, torch.zeros_like(rec), atol=2e-3, rtol=0)
+        self.assertEqual(torch.linalg.vector_norm(v, dim=-2), torch.ones(batch, n), atol=1e-5, rtol=0)
+        # deterministic across runs
+        w2, v2 = torch.linalg.eig(a.to(device))
+        self.assertEqual(w2.cpu(), w, atol=0, rtol=0)
+        self.assertEqual(v2.cpu(), v, atol=0, rtol=0)
+
+    @parametrize("shape", [(512, 512), (700, 700), (2, 520, 520)])
+    def test_linalg_eig_hybrid_large(self, device, shape):
+        torch.manual_seed(0)
+        a = torch.randn(shape) * 2
+        w, v = torch.linalg.eig(a.to(device))
+        w, v = w.cpu(), v.cpu()
+        w_cpu = torch.linalg.eig(a)[0]
+        dmat = (w.unsqueeze(-1) - w_cpu.unsqueeze(-2)).abs()
+        chamfer = torch.maximum(dmat.amin(-1).amax(-1), dmat.amin(-2).amax(-1))
+        self.assertEqual(chamfer, torch.zeros_like(chamfer), atol=5e-4, rtol=0)
+        rec = (a.to(w.dtype) @ v - v * w.unsqueeze(-2)).abs().amax(dim=(-2, -1))
+        self.assertEqual(rec, torch.zeros_like(rec), atol=2e-3, rtol=0)
+        norms = torch.linalg.vector_norm(v, dim=-2)
+        self.assertEqual(norms, torch.ones(shape[:-1]), atol=1e-5, rtol=0)
+        w2, v2 = torch.linalg.eig(a.to(device))
+        self.assertEqual(w2.cpu(), w, atol=0, rtol=0)
+        self.assertEqual(v2.cpu(), v, atol=0, rtol=0)
+
     def _test_addmm_addmv(self, f, t, m, v, *, alpha=None, beta=None, transpose_out=False):
         dtype = t.dtype
         numpy_dtype = dtype

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -11394,6 +11394,23 @@ class TestLinalgMPS(TestCaseMPS):
         self.assertEqual(w2.cpu(), w, atol=0, rtol=0)
         self.assertEqual(v2.cpu(), v, atol=0, rtol=0)
 
+    @parametrize("scale", [1e-38, 1e38])
+    def test_linalg_eig_metal_extreme_scale(self, device, scale):
+        batch = 342  # batch*n >= 1024 hits the Metal geev kernel
+        base = torch.tensor(
+            [[0.0, 1.0, 0.0], [0.0, 0.0, 1.0], [1.0, 0.0, 0.0]]
+        )
+        a = (base * scale).expand(batch, -1, -1).clone()
+        w_cpu = torch.linalg.eigvals(a)
+        w, v = torch.linalg.eig(a.to(device))
+        w, v = w.cpu(), v.cpu()
+        dmat = (w.unsqueeze(-1) - w_cpu.unsqueeze(-2)).abs() / scale
+        chamfer = torch.maximum(dmat.amin(-1).amax(-1), dmat.amin(-2).amax(-1))
+        self.assertEqual(chamfer, torch.zeros_like(chamfer), atol=5e-4, rtol=0)
+        rec = (a.to(w.dtype) @ v - v * w.unsqueeze(-2)).abs().amax(dim=(-2, -1)) / scale
+        self.assertEqual(rec, torch.zeros_like(rec), atol=2e-3, rtol=0)
+        self.assertTrue(torch.isfinite(v).all())
+
     @parametrize("shape", [(512, 512), (700, 700), (2, 520, 520)])
     def test_linalg_eig_hybrid_large(self, device, shape):
         torch.manual_seed(0)
@@ -11411,6 +11428,26 @@ class TestLinalgMPS(TestCaseMPS):
         w2, v2 = torch.linalg.eig(a.to(device))
         self.assertEqual(w2.cpu(), w, atol=0, rtol=0)
         self.assertEqual(v2.cpu(), v, atol=0, rtol=0)
+
+    @parametrize("scale", [1e-38, 1e38])
+    def test_linalg_eig_hybrid_extreme_scale(self, device, scale):
+        n = 512
+        a = torch.zeros(n, n)
+        a[:3, :3] = (
+            torch.tensor(
+                [[0.0, 1.0, 0.0], [0.0, 0.0, 1.0], [1.0, 0.0, 0.0]]
+            )
+            * scale
+        )
+        w_cpu = torch.linalg.eigvals(a)
+        w, v = torch.linalg.eig(a.to(device))
+        w, v = w.cpu(), v.cpu()
+        dmat = (w.unsqueeze(-1) - w_cpu.unsqueeze(-2)).abs() / scale
+        chamfer = torch.maximum(dmat.amin(-1).amax(-1), dmat.amin(-2).amax(-1))
+        self.assertEqual(chamfer, torch.tensor(0.0), atol=5e-4, rtol=0)
+        rec = (a.to(w.dtype) @ v - v * w.unsqueeze(-2)).abs().max() / scale
+        self.assertEqual(rec, torch.tensor(0.0), atol=2e-3, rtol=0)
+        self.assertTrue(torch.isfinite(v).all())
 
     def _test_addmm_addmv(self, f, t, m, v, *, alpha=None, beta=None, transpose_out=False):
         dtype = t.dtype

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -98,7 +98,9 @@ if torch.backends.mps.is_available():
             "linalg.cond",
             "linalg.cross",
             "linalg.diagonal",
+            "linalg.eig",
             "linalg.eigh",
+            "linalg.eigvals",
             "linalg.eigvalsh",
             "linalg.householder_product",
             "linalg.lstsq",
@@ -366,8 +368,6 @@ if torch.backends.mps.is_available():
             # Failures due to lack of op implementation on MPS backend
             "logspace": None,
             "logspacetensor_overload": None,
-            "linalg.eig": None,
-            "linalg.eigvals": None,
             "put": None,
             "frexp": None,
             "geqrf": None,
@@ -864,6 +864,9 @@ if torch.backends.mps.is_available():
             # Unimplemented ops
             "_chunk_cat": [torch.float16, torch.float32],
             "sparse.mmreduce": [torch.float32],  # csr not supported
+            # eig backward needs linalg_solve on complex; MPS lu_factor is float-only
+            "linalg.eig": [torch.float32],
+            "linalg.eigvals": [torch.float32],
             "linalg.householder_product": None,
             "linalg.lstsq": [torch.float32],
             "linalg.lstsqgrad_oriented": [torch.float32],

--- a/torch/testing/_internal/opinfo/definitions/linalg.py
+++ b/torch/testing/_internal/opinfo/definitions/linalg.py
@@ -27,6 +27,7 @@ from torch.testing._internal.common_device_type import (
 from torch.testing._internal.common_dtype import (
     all_types_and_complex,
     all_types_and_complex_and,
+    empty_types,
     floating_and_complex_types,
     floating_and_complex_types_and,
     floating_types,
@@ -1372,6 +1373,8 @@ op_db: list[OpInfo] = [
         aten_name="linalg_eig",
         op=torch.linalg.eig,
         dtypes=floating_and_complex_types(),
+        # eig backward needs linalg_solve on complex; MPS lu_factor is float-only
+        backward_dtypesIfMPS=empty_types(),
         sample_inputs_func=sample_inputs_linalg_eig,
         check_batched_forward_grad=False,
         check_batched_grad=False,
@@ -1404,8 +1407,6 @@ op_db: list[OpInfo] = [
                 device_type="mps",
                 dtypes=[torch.float32],
             ),
-            # Exception: The operator 'aten::linalg_eig' is not currently implemented for the MPS device
-            DecorateInfo(unittest.expectedFailure, "TestCommon", device_type="mps"),
         ),
         decorators=[skipCUDAIfNoMagma, skipCPUIfNoLapack, with_tf32_off],
     ),
@@ -1414,6 +1415,8 @@ op_db: list[OpInfo] = [
         aten_name="linalg_eigvals",
         op=torch.linalg.eigvals,
         dtypes=floating_and_complex_types(),
+        # eig backward needs linalg_solve on complex; MPS lu_factor is float-only
+        backward_dtypesIfMPS=empty_types(),
         sample_inputs_func=sample_inputs_linalg_invertible,
         check_batched_forward_grad=False,
         check_batched_grad=False,
@@ -1443,8 +1446,6 @@ op_db: list[OpInfo] = [
                 device_type="mps",
                 dtypes=[torch.float32],
             ),
-            # Exception: The operator 'aten::linalg_eig' is not currently implemented for the MPS device
-            DecorateInfo(unittest.expectedFailure, "TestCommon", device_type="mps"),
         ),
     ),
     OpInfo(


### PR DESCRIPTION
Add linalg eig to MPS, comparing speed vs CPU:

| Batch | N | Input shape | CPU average (ms) | MPS average (ms) | MPS speedup |
|---:|---:|:---|---:|---:|---:|
| 1024 | 2 | 1024 x 2 x 2 | 0.326 | 0.580 | 0.563x |
| 512 | 4 | 512 x 4 x 4 | 0.780 | 0.677 | 1.151x |
| 256 | 8 | 256 x 8 x 8 | 1.240 | 0.853 | 1.454x |
| 128 | 16 | 128 x 16 x 16 | 2.262 | 1.078 | 2.099x |
| 64 | 24 | 64 x 24 x 24 | 2.824 | 1.482 | 1.906x |
| 64 | 32 | 64 x 32 x 32 | 5.043 | 2.083 | 2.422x |
| 32 | 48 | 32 x 48 x 48 | 6.833 | 3.867 | 1.767x |
| 32 | 60 | 32 x 60 x 60 | 11.759 | 5.294 | 2.221x |
| 1 | 512 | 1 x 512 x 512 | 52.102 | 52.250 | 0.997x |
| 2 | 512 | 2 x 512 x 512 | 115.463 | 109.585 | 1.054x |
| 4 | 512 | 4 x 512 x 512 | 236.164 | 217.682 | 1.085x |
| 1 | 700 | 1 x 700 x 700 | 88.871 | 84.387 | 1.053x |
| 2 | 700 | 2 x 700 x 700 | 173.903 | 158.844 | 1.095x |
| 1 | 1024 | 1 x 1024 x 1024 | 229.894 | 205.976 | 1.116x |
| 1 | 2048 | 1 x 2048 x 2048 | 923.781 | 741.248 | 1.246x |
| 1 | 4096 | 1 x 4096 x 4096 | 6892.506 | 4864.662 | 1.417x |


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo