### PR TITLE
[Testcase Refactoring][Test] Migrate test_fine_tuning.py to skip_if_lt_x_devices

### DIFF
--- a/test/distributed/checkpoint/e2e/test_fine_tuning.py
+++ b/test/distributed/checkpoint/e2e/test_fine_tuning.py
@@ -16,7 +16,7 @@ from torch.distributed.checkpoint.state_dict import (
 )
 from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
-from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+from torch.testing._internal.common_distributed import skip_if_lt_x_devices
 from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
@@ -181,7 +181,7 @@ class TestFineTuning(DTensorTestBase):
                 storage_writer=dist_cp.FileSystemWriter(finetune_dir),
             )
 
-    @skip_if_lt_x_gpu(4)
+    @skip_if_lt_x_devices(4)
     @with_comms
     @with_temp_dir
     def test_fine_tuning(self) -> None:

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -335,6 +335,41 @@ def skip_if_lt_x_gpu(x, *, allow_cpu=False):
     return decorator
 
 
+def skip_if_lt_x_devices(x, *, allow_cpu=False):
+    """Skip if fewer than x devices available for the current accelerator.
+
+    Unlike @skip_if_lt_x_gpu, this does not hard-code cuda/hpu/xpu.
+    It uses torch.accelerator.current_accelerator() to determine the device type.
+    """
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            acc = torch.accelerator.current_accelerator()
+            if acc is not None:
+                device_type = acc.type
+                device_module = torch.get_device_module(device_type)
+                if device_module.is_available() and device_module.device_count() >= x:
+                    return func(*args, **kwargs)
+
+            # CPU path: allow running a degenerate version if explicitly requested
+            if allow_cpu and acc is None:
+                return func(*args, **kwargs)
+
+            # NOTE: TEST_SKIPS uses "multi-gpu-{x}" naming for historical/
+            # backward-compatibility reasons only. The skip logic itself is
+            # hardware-agnostic and does not assume CUDA/GPU.
+            test_skip = TEST_SKIPS[f"multi-gpu-{x}"]
+            # NOTE: _maybe_handle_skip_if_lt_x_gpu retains "gpu" in its name
+            # for backward compatibility; it is hardware-agnostic.
+            if not _maybe_handle_skip_if_lt_x_gpu(args, test_skip.message):
+                sys.exit(test_skip.exit_code)
+
+        return wrapper
+
+    return decorator
+
+
 def requires_world_size(n: int):
     """
     Decorator to request a specific world size for a test. The test harness can


### PR DESCRIPTION
## Summary
This PR migrates `test/distributed/checkpoint/e2e/test_fine_tuning.py` from `@skip_if_lt_x_gpu(4)` to `@skip_if_lt_x_devices(4)`. It also adds the `skip_if_lt_x_devices` decorator in `torch/testing/_internal/common_distributed.py`.

This is a step toward making checkpoint distributed tests device-agnostic for out-of-tree backends.

## Changes
- Added `skip_if_lt_x_devices(x, *, allow_cpu=False)` in `common_distributed.py`.
  - Uses `torch.accelerator.current_accelerator()` to detect the current accelerator type.
  - Uses `torch.get_device_module(device_type).device_count()` instead of hard-coding `torch.cuda.device_count()` / `torch.hpu.device_count()` / `torch.xpu.device_count()`.
- Replaced `@skip_if_lt_x_gpu(4)` with `@skip_if_lt_x_devices(4)` in `test_fine_tuning.py`.

## Motivation
`@skip_if_lt_x_gpu` only recognizes CUDA, HPU, and XPU. New accelerators (e.g., `PrivateUse1`-based out-of-tree backends) are silently skipped even when enough devices are available. A generic decorator lets distributed tests adapt to any accelerator supported by `torch.accelerator`.

## Test Plan
- CI: `python test/distributed/checkpoint/e2e/test_fine_tuning.py`
- Verified locally that `@skip_if_lt_x_devices(4)` correctly skips on CPU and GPU.

## Notes
- The `skip_if_lt_x_devices` implementation comes from #187650. When that PR merges, this branch should rebase to remove the duplicate implementation.
- This is part of the test case refactoring initiative tracked in #185590.
- Existing `@skip_if_lt_x_gpu` is intentionally left unchanged to avoid a large-scale migration in one PR.

@wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian