### PR TITLE
[Testcase Refactoring][Test] Migrate test_hf_safetensor_e2e.py to skip_if_lt_x_devices

### DIFF
--- a/test/distributed/checkpoint/test_hf_safetensor_e2e.py
+++ b/test/distributed/checkpoint/test_hf_safetensor_e2e.py
@@ -20,7 +20,7 @@ from torch.testing._internal.common_utils import (
 )
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
-    skip_if_lt_x_gpu,
+    skip_if_lt_x_devices,
     with_comms,
 )
 from torch.testing._internal.distributed.checkpoint_utils import with_temp_dir
@@ -277,7 +277,7 @@ class TestSingleRankSaveLoad(TestCase):
 class TestDistributedHFSafetensorsConsolidation(DTensorTestBase):
     @with_comms
     @with_temp_dir
-    @skip_if_lt_x_gpu(2)
+    @skip_if_lt_x_devices(2)
     def test_consolidate_to_one_file(self) -> None:
         if importlib.util.find_spec("safetensors") is None:
             print("safetensors not installed")
@@ -357,7 +357,7 @@ class TestDTensorReshardPlacementChange(DTensorTestBase):
     """
 
     @with_comms
-    @skip_if_lt_x_gpu(2)
+    @skip_if_lt_x_devices(2)
     @with_temp_dir
     def test_1d_to_1d_reshard_placement_change(self) -> None:
         if importlib.util.find_spec("safetensors") is None:
@@ -415,7 +415,7 @@ class TestDTensorReshardPlacementChange(DTensorTestBase):
             )
 
     @with_comms
-    @skip_if_lt_x_gpu(4)
+    @skip_if_lt_x_devices(4)
     @with_temp_dir
     def test_2d_to_2d_reshard_placement_change(self) -> None:
         if importlib.util.find_spec("safetensors") is None:
@@ -475,7 +475,7 @@ class TestDTensorReshardMeshChange(DTensorTestBase):
 
     @with_comms
     @with_temp_dir
-    @skip_if_lt_x_gpu(2)
+    @skip_if_lt_x_devices(2)
     def test_1d_to_2d_reshard_mesh_change(self) -> None:
         if importlib.util.find_spec("safetensors") is None:
             print("safetensors not installed")
@@ -526,7 +526,7 @@ class TestDTensorReshardMeshChange(DTensorTestBase):
 
     @with_comms
     @with_temp_dir
-    @skip_if_lt_x_gpu(4)
+    @skip_if_lt_x_devices(4)
     def test_2d_to_1d_reshard_mesh_change(self) -> None:
         if importlib.util.find_spec("safetensors") is None:
             print("safetensors not installed")
@@ -578,7 +578,7 @@ class TestDTensorReshardMeshChange(DTensorTestBase):
 
     @with_comms
     @with_temp_dir
-    @skip_if_lt_x_gpu(2)
+    @skip_if_lt_x_devices(2)
     def test_dtensor_checkpoint_resharding_with_empty_shard(self):
         """
         Test dtensor checkpoint resharding with dtensor containing empty shards.

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -335,6 +335,41 @@ def skip_if_lt_x_gpu(x, *, allow_cpu=False):
     return decorator
 
 
+def skip_if_lt_x_devices(x, *, allow_cpu=False):
+    """Skip if fewer than x devices available for the current accelerator.
+
+    Unlike @skip_if_lt_x_gpu, this does not hard-code cuda/hpu/xpu.
+    It uses torch.accelerator.current_accelerator() to determine the device type.
+    """
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            acc = torch.accelerator.current_accelerator()
+            if acc is not None:
+                device_type = acc.type
+                device_module = torch.get_device_module(device_type)
+                if device_module.is_available() and device_module.device_count() >= x:
+                    return func(*args, **kwargs)
+
+            # CPU path: allow running a degenerate version if explicitly requested
+            if allow_cpu and acc is None:
+                return func(*args, **kwargs)
+
+            # NOTE: TEST_SKIPS uses "multi-gpu-{x}" naming for historical/
+            # backward-compatibility reasons only. The skip logic itself is
+            # hardware-agnostic and does not assume CUDA/GPU.
+            test_skip = TEST_SKIPS[f"multi-gpu-{x}"]
+            # NOTE: _maybe_handle_skip_if_lt_x_gpu retains "gpu" in its name
+            # for backward compatibility; it is hardware-agnostic.
+            if not _maybe_handle_skip_if_lt_x_gpu(args, test_skip.message):
+                sys.exit(test_skip.exit_code)
+
+        return wrapper
+
+    return decorator
+
+
 def requires_world_size(n: int):
     """
     Decorator to request a specific world size for a test. The test harness can

--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -58,6 +58,7 @@ from torch.testing._internal.common_distributed import (
     MultiThreadedTestCase,
     run_subtests,
     skip_if_lt_x_gpu,
+    skip_if_lt_x_devices,
     TEST_SKIPS,
 )
 from torch.testing._internal.common_utils import (


### PR DESCRIPTION
## Summary
This PR migrates `test/distributed/checkpoint/test_hf_safetensor_e2e.py` from `@skip_if_lt_x_gpu` to `@skip_if_lt_x_devices` (6 decorators across 3 `DTensorTestBase` classes). It also re-exports `skip_if_lt_x_devices` from `common_dtensor.py` and adds the decorator in `common_distributed.py`.

## Changes
- Added `skip_if_lt_x_devices(x, *, allow_cpu=False)` in `common_distributed.py`.
- Re-exported `skip_if_lt_x_devices` from `common_dtensor.py`.
- Replaced 6 `@skip_if_lt_x_gpu` decorators with `@skip_if_lt_x_devices` in `test_hf_safetensor_e2e.py` (4x `@skip_if_lt_x_devices(2)`, 2x `@skip_if_lt_x_devices(4)`).

## Motivation
`@skip_if_lt_x_gpu` only recognizes CUDA, HPU, and XPU. The 6 decorators span 3 `DTensorTestBase` classes: `TestDistributedHFSafetensorsConsolidation`, `TestDTensorReshardPlacementChange`, and `TestDTensorReshardMeshChange`. `TestSingleRankSaveLoad` (extends `TestCase`) has no coupling and is unchanged.

## Test Plan
- CI: `python test/distributed/checkpoint/test_hf_safetensor_e2e.py`
- Verified locally that `@skip_if_lt_x_devices(2)` and `@skip_if_lt_x_devices(4)` correctly skip on CPU and GPU.

## Notes
- The `skip_if_lt_x_devices` implementation comes from #187650. When that PR merges, this branch should rebase to remove the duplicate implementation.
- This is part of the test case refactoring initiative tracked in #185590.

@wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian