### PR TITLE
[Testcase Refactoring][Test] Migrate test_save_load_api.py to skip_if_lt_x_devices

### DIFF
--- a/test/distributed/checkpoint/test_save_load_api.py
+++ b/test/distributed/checkpoint/test_save_load_api.py
@@ -10,7 +10,7 @@ from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.testing._internal.common_utils import run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
-    skip_if_lt_x_gpu,
+    skip_if_lt_x_devices,
     with_comms,
 )
 from torch.testing._internal.distributed.checkpoint_utils import with_temp_dir
@@ -34,7 +34,7 @@ class TestSaveAndLoadAPI(DTensorTestBase):
         return 2
 
     @with_comms
-    @skip_if_lt_x_gpu(4)
+    @skip_if_lt_x_devices(4)
     @with_temp_dir
     def test_auto_detect(self):
         model = FSDP(MyTestModule().to(self.device_type))
@@ -64,7 +64,7 @@ class TestSaveAndLoadAPI(DTensorTestBase):
             dcp.load(model.state_dict(), checkpoint_id="abc://abc.abc")
 
     @with_comms
-    @skip_if_lt_x_gpu(2)
+    @skip_if_lt_x_devices(2)
     def test_assert_same_keys(self):
         """Test the `_assert_same_keys` function."""
         model = MyTestModule()

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -335,6 +335,41 @@ def skip_if_lt_x_gpu(x, *, allow_cpu=False):
     return decorator
 
 
+def skip_if_lt_x_devices(x, *, allow_cpu=False):
+    """Skip if fewer than x devices available for the current accelerator.
+
+    Unlike @skip_if_lt_x_gpu, this does not hard-code cuda/hpu/xpu.
+    It uses torch.accelerator.current_accelerator() to determine the device type.
+    """
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            acc = torch.accelerator.current_accelerator()
+            if acc is not None:
+                device_type = acc.type
+                device_module = torch.get_device_module(device_type)
+                if device_module.is_available() and device_module.device_count() >= x:
+                    return func(*args, **kwargs)
+
+            # CPU path: allow running a degenerate version if explicitly requested
+            if allow_cpu and acc is None:
+                return func(*args, **kwargs)
+
+            # NOTE: TEST_SKIPS uses "multi-gpu-{x}" naming for historical/
+            # backward-compatibility reasons only. The skip logic itself is
+            # hardware-agnostic and does not assume CUDA/GPU.
+            test_skip = TEST_SKIPS[f"multi-gpu-{x}"]
+            # NOTE: _maybe_handle_skip_if_lt_x_gpu retains "gpu" in its name
+            # for backward compatibility; it is hardware-agnostic.
+            if not _maybe_handle_skip_if_lt_x_gpu(args, test_skip.message):
+                sys.exit(test_skip.exit_code)
+
+        return wrapper
+
+    return decorator
+
+
 def requires_world_size(n: int):
     """
     Decorator to request a specific world size for a test. The test harness can

--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -58,6 +58,7 @@ from torch.testing._internal.common_distributed import (
     MultiThreadedTestCase,
     run_subtests,
     skip_if_lt_x_gpu,
+    skip_if_lt_x_devices,
     TEST_SKIPS,
 )
 from torch.testing._internal.common_utils import (


### PR DESCRIPTION
## Summary
This PR migrates `test/distributed/checkpoint/test_save_load_api.py` from `@skip_if_lt_x_gpu` to `@skip_if_lt_x_devices`. It also re-exports `skip_if_lt_x_devices` from `common_dtensor.py` and adds the decorator in `common_distributed.py`.

## Changes
- Added `skip_if_lt_x_devices(x, *, allow_cpu=False)` in `common_distributed.py`.
  - Uses `torch.accelerator.current_accelerator()` to detect the current accelerator type.
  - Uses `torch.get_device_module(device_type).device_count()` instead of hard-coding device checks.
- Re-exported `skip_if_lt_x_devices` from `torch/testing/_internal/distributed/_tensor/common_dtensor.py`.
- Replaced `@skip_if_lt_x_gpu(4)` and `@skip_if_lt_x_gpu(2)` with `@skip_if_lt_x_devices(4)` and `@skip_if_lt_x_devices(2)` in `test_save_load_api.py`.

## Motivation
`@skip_if_lt_x_gpu` only recognizes CUDA, HPU, and XPU. `test_save_load_api.py` imports `skip_if_lt_x_gpu` from `common_dtensor` (not `common_distributed` directly), so the re-export is required.

## Test Plan
- CI: `python test/distributed/checkpoint/test_save_load_api.py`
- Verified locally that `@skip_if_lt_x_devices(2)` and `@skip_if_lt_x_devices(4)` correctly skip on CPU and GPU.

## Notes
- The `skip_if_lt_x_devices` implementation comes from #187650. When that PR merges, this branch should rebase to remove the duplicate implementation.
- This is part of the test case refactoring initiative tracked in #185590.

@wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian