### PR TITLE
[TEST] Refactor `test_c10d_spawn_gloo.py` with `hw_classification`

### DIFF
--- a/test/distributed/test_c10d_spawn_gloo.py
+++ b/test/distributed/test_c10d_spawn_gloo.py
@@ -23,8 +23,8 @@ from torch.testing._internal.common_utils import (
 # Fails on Python-3.9, see https://github.com/pytorch/pytorch/issues/51619
 
 
-class DistributedDataParallelSingleProcessTest(TestCase):
-    hw_classification = HardwareClassification.CUDA
+class _DDPSingleProcessBase(TestCase):
+    """Shared setup and helpers for DDP single-process test classes."""
 
     def setUp(self):
         super().setUp()
@@ -74,9 +74,17 @@ class DistributedDataParallelSingleProcessTest(TestCase):
             for i, j in zip(ddp.parameters(), net.parameters()):
                 self.assertTrue(i.allclose(j))
 
+
+class DistributedDataParallelSingleProcessTest(_DDPSingleProcessBase):
+    hw_classification = HardwareClassification.GENERIC
+
     @requires_gloo()
     def test_cpu(self):
         self._test_base(nn.Linear(2, 2), [torch.randn(30, 2)])
+
+
+class DistributedDataParallelSingleProcessCUDATest(_DDPSingleProcessBase):
+    hw_classification = HardwareClassification.CUDA
 
     @requires_gloo()
     @skip_but_pass_in_sandcastle_if(not TEST_CUDA, "At least 1 CUDA GPUS needed")

--- a/test/distributed/test_c10d_spawn_gloo.py
+++ b/test/distributed/test_c10d_spawn_gloo.py
@@ -12,6 +12,7 @@ import torch.nn as nn
 from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_distributed import requires_gloo, skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     run_tests,
     skip_but_pass_in_sandcastle_if,
     TEST_WITH_DEV_DBG_ASAN,
@@ -23,6 +24,8 @@ from torch.testing._internal.common_utils import (
 
 
 class DistributedDataParallelSingleProcessTest(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def setUp(self):
         super().setUp()
         self.rank = 0
@@ -127,6 +130,8 @@ class DistributedDataParallelSingleProcessTest(TestCase):
 if not TEST_WITH_DEV_DBG_ASAN:
 
     class TestDistributedNNFunctionsGloo(TestDistributedNNFunctions):
+        hw_classification = HardwareClassification.CUDA
+
         # Test Common Ops First.
         @requires_gloo()
         @skip_if_lt_x_gpu(2)


### PR DESCRIPTION
### Summary

Classify both test classes in `test/distributed/test_c10d_spawn_gloo.py` by hardware scope as part of the test hardware classification initiative (#185142, #185590)

Depends on: #186918

cc @mansiag05 @vishalgoyal316 @RiyaP2508

