### PR TITLE
Fix int64 overflow in im2col/col2im sliding-window count (#189667)

### DIFF
--- a/aten/src/ATen/native/im2col_shape_check.h
+++ b/aten/src/ATen/native/im2col_shape_check.h
@@ -13,9 +13,27 @@ inline int64_t sliding_window_count(
     int64_t dilation,
     int64_t kernel,
     int64_t stride) {
-  return div_rtn<int64_t>(
-             input_size + 2 * pad - (dilation * (kernel - 1) + 1), stride) +
-      1;
+  // Guard the derived-dimension arithmetic: with adversarial dilation/kernel/pad
+  // (e.g. kernel=2**63-2) the int64_t products/sums silently overflow and yield a
+  // spuriously valid positive count, which later drives an out-of-bounds kernel
+  // launch. Compute with checked arithmetic and reject overflow on the host.
+  int64_t kernel_extent = 0; // dilation * (kernel - 1) + 1
+  int64_t two_pad = 0;
+  int64_t numerator = 0;
+  const bool overflow =
+      c10::mul_overflows(dilation, kernel - 1, &kernel_extent) ||
+      c10::add_overflows(kernel_extent, static_cast<int64_t>(1), &kernel_extent) ||
+      c10::mul_overflows(pad, static_cast<int64_t>(2), &two_pad) ||
+      c10::add_overflows(input_size, two_pad, &numerator) ||
+      // kernel_extent came from checked arithmetic, so it cannot be INT64_MIN
+      // and negating it here is safe.
+      c10::add_overflows(numerator, -kernel_extent, &numerator);
+  TORCH_CHECK(
+      !overflow,
+      "Sliding-window count overflowed with input_size=", input_size,
+      ", pad=", pad, ", dilation=", dilation, ", kernel=", kernel,
+      ", stride=", stride);
+  return div_rtn<int64_t>(numerator, stride) + 1;
 }
 
 inline void col2im_shape_check(

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9604,6 +9604,18 @@ class TestNNDeviceType(NNTestCase):
             ], device=device)
             F.fold(tensor_data, 16, 7318349394477056)
 
+        # Host-side overflow guard on the derived sliding-window arithmetic:
+        # adversarial kernel/dilation/padding must be rejected rather than
+        # overflowing int64 into a spuriously valid count (see gh-189667).
+        with self.assertRaisesRegex(RuntimeError, r"Sliding-window count overflowed"):
+            F.unfold(
+                torch.zeros(1, 3, 3, 3, device=device),
+                kernel_size=(2**63 - 2, 2**63 - 2),
+                dilation=(10**12, 10**12),
+                padding=(10**12, 10**12),
+                stride=(10**12, 10**12),
+            )
+
     @onlyCUDA
     @dtypes(torch.float, torch.double)
     # Test asserts GPU RNN slowpath (cudnn disabled) matches CPU. The


### PR DESCRIPTION
Fixes #189667

### Root cause
`sliding_window_count()` in `im2col_shape_check.h` computed
`input_size + 2 * pad - (dilation * (kernel - 1) + 1)` directly in `int64_t`.
Adversarial arguments (e.g. `unfold` with `kernel_size=2**63-2` plus large
`dilation`/`padding`/`stride`) overflow `int64_t` and wrap to a spuriously
valid positive count. That count passes the existing `>= 1` shape check and
then drives an out-of-bounds write in `im2col_kernel` on CUDA (crash under
`compute-sanitizer`).

### Fix
Compute the numerator with checked arithmetic via `c10::mul_overflows` /
`c10::add_overflows` -- the same helper already used a few lines above for the
`kernel_width * kernel_height` product -- and `TORCH_CHECK` on overflow, so the
bad shape is rejected on the host before any kernel launch. Because the guard
lives in the shared helper it covers both the im2col (`unfold`) and col2im
(`fold`) paths, on CPU and CUDA. No new abstraction is introduced.

### Test
Added a CPU-runnable regression case to `test_unfold_invalid_arg`:

```
python test/test_nn.py -k test_unfold_invalid_arg
```

Draft: opening for CI to run the full build + CUDA sanitizer path (CUDA does
not build locally on macOS).
