### PR TITLE
[TEST] Refactor `test_c10d_spawn_nccl.py` with `hw_classification`

### DIFF
--- a/test/distributed/test_c10d_spawn_nccl.py
+++ b/test/distributed/test_c10d_spawn_nccl.py
@@ -7,6 +7,7 @@ import torch
 import torch.distributed as c10d
 from torch.testing._internal.common_distributed import requires_nccl, skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     run_tests,
     skip_but_pass_in_sandcastle_if,
     TEST_WITH_DEV_DBG_ASAN,
@@ -22,6 +23,8 @@ NO_NCCL = not hasattr(c10d, "ProcessGroupNCCL")
 if not TEST_WITH_DEV_DBG_ASAN:
 
     class TestDistributedNNFunctionsNccl(TestDistributedNNFunctions):
+        hw_classification = HardwareClassification.CUDA
+
         # Test Common Ops First.
         @requires_nccl()
         @skip_if_lt_x_gpu(2)


### PR DESCRIPTION
### Summary

Classify `TestDistributedNNFunctionsNccl` in `test/distributed/test_c10d_spawn_nccl.py` as `HardwareClassification.MULTI_DEVICE_SPECIFIC` as part of the test hardware classification initiative (#185142, #185590)

NCCL is a CUDA-only communication backend. All 10 tests require 2+ GPUs (`@skip_if_lt_x_gpu(2)`), use `@requires_nccl()`, and hardcode `torch.device(f"cuda:{self.rank}")`. This is consistent with PR #189378 which classified `ProcessGroupNCCLOpTest` as `MULTI_DEVICE_SPECIFIC`.

Depends on: #186918

cc @mansiag05 @vishalgoyal316 @RiyaP2508

