### PR TITLE
[Dynamo] Bind rank-0 tensor inputs in the TVM relay backend

### DIFF
--- a/test/dynamo/test_backends.py
+++ b/test/dynamo/test_backends.py
@@ -168,6 +168,22 @@ class TestOptimizations(torch._dynamo.test_case.TestCase):
             "tvm", device, boxed=False, backward=False, options={"opt_level": 0}
         )
 
+    @unittest.skipIf(not has_tvm(), "requires tvm")
+    def test_tvm_scalar_tensor_input(self, device):
+        class ScalarParam(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.scale = torch.nn.Parameter(torch.tensor(3.0))
+
+            def forward(self, x):
+                return x + self.scale
+
+        model = ScalarParam().eval().to(device)
+        x = torch.randn(2, 10, device=device)
+        expected = model(x)
+        compiled = torch.compile(model, backend="tvm")
+        self.assertTrue(same(expected, compiled(x), tol=0.01))
+
     def test_tvm_scheduler_backends(self, device):
         from torch._dynamo.backends.tvm import tvm_auto_scheduler, tvm_meta_schedule
 

--- a/torch/_dynamo/backends/tvm.py
+++ b/torch/_dynamo/backends/tvm.py
@@ -198,20 +198,16 @@ def _tvm_relay_compile(
     def exec_tvm(*i_args: torch.Tensor) -> list[torch.Tensor]:
         args = [a.contiguous() for a in i_args]
         for idx, arg in enumerate(args, 0):
-            if arg.dim() != 0:
-                if arg.requires_grad:
-                    arg = arg.detach()
-                inp_name = f"inp_{idx}"
-                if inp_name not in active_inputs:
-                    log.warning(
-                        "input %s skipped as not found in tvm's runtime library",
-                        inp_name,
-                    )
-                    continue
-                m.set_input(
+            inp_name = f"inp_{idx}"
+            if inp_name not in active_inputs:
+                log.warning(
+                    "input %s skipped as not found in tvm's runtime library",
                     inp_name,
-                    to_tvm_tensor(arg),
                 )
+                continue
+            if arg.requires_grad:
+                arg = arg.detach()
+            m.set_input(inp_name, to_tvm_tensor(arg))
         m.run()
         return [to_torch_tensor(m.get_output(i)) for i in range(m.get_num_outputs())]
 


### PR DESCRIPTION
## Related Issue

Fixes #169188

## Why

`exec_tvm` filters runtime arguments by rank before binding them, so a rank-0 input is never passed to TVM and the graph executor silently uses its default zero value. A scalar `nn.Parameter` captured by Dynamo hits exactly this and produces wrong numerics instead of an error.

Reworks #184997, which had the same fix but tested it against mocked TVM modules.

## How

- Drop the rank filter and bind every argument TVM reports as an active input
- Add `test_tvm_scalar_tensor_input`, gated only on `has_tvm()` so it covers both the relay and relax paths

Verified against TVM v0.19.0 built from source, since relay was removed in TVM 0.20 and no pip wheel ships it. The output was off by exactly the parameter value before the fix and matches eager after; the new test fails without the fix and passes with it. The relax path already handled rank-0 inputs correctly.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98