### PR TITLE
 [Inductor] Restrict extern_input_nodes substitution to addmm only

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -4263,6 +4263,117 @@ class TestMaxAutotuneSubproc(TestCase):
             child.join()
             self.assertNotEqual(0, child.exitcode)
 
+    def _get_inputs_graph(self):
+        gm = make_fx(lambda: torch.zeros(2, 3))()
+        return GraphLowering(gm)
+
+    @skipIfXpu(msg="XPU not supported for this get_inputs regression check")
+    def test_get_inputs_non_addmm_extern_mismatched_length(self):
+        """
+        A non-addmm extern choice whose ``input_nodes`` length differs from the
+        scheduler's ``input_nodes`` must not trip the AssertionError guarded
+        for addmm. Regression test for the fix that restricted the
+        ``extern_input_nodes`` substitution (and its length assertion) to
+        ``addmm`` only. The extern benchmark inputs must resolve to the
+        scheduler's input_nodes, in scheduler order.
+        """
+        from torch._inductor.kernel.mm import aten_mm
+
+        with V.set_graph_handler(self._get_inputs_graph()):
+            mat1 = self._create_buffer("mat1", (2, 3))
+            mat2 = self._create_buffer("mat2", (3, 2))
+            extra = self._create_buffer("extra", (2, 2))
+            layout = FixedLayout(torch.device(f"{GPU_TYPE}:0"), torch.float32, (2, 2))
+
+            # extern choice bound to (mat1, mat2) only, while the scheduler
+            # also tracks ``extra`` (e.g. an intermediate buffer the extern
+            # fallback does not consume).
+            extern_choice = aten_mm.bind((mat1, mat2), layout)
+
+            # Must not raise AssertionError for non-addmm extern choices.
+            autotune_args = AlgorithmSelectorCache.get_inputs(
+                choices=[extern_choice],
+                input_nodes=[mat1, mat2, extra],
+                layout=layout,
+                input_gen_fns=None,
+            )
+
+            # Non-addmm path keeps the scheduler's input_nodes for the extern
+            # loop, so every scheduler input must resolve to a benchmark
+            # tensor and the extern input list must mirror the scheduler's
+            # input_nodes in order and shape.
+            sched_nodes = [mat1, mat2, extra]
+            self.assertEqual(len(autotune_args.extern.input_tensors), len(sched_nodes))
+            self.assertEqual(len(autotune_args.triton.input_tensors), len(sched_nodes))
+            for node, tensor in zip(sched_nodes, autotune_args.extern.input_tensors):
+                self.assertEqual(tuple(tensor.size()), tuple(node.get_size()))
+
+    @skipIfXpu(msg="XPU not supported for this get_inputs regression check")
+    def test_get_inputs_addmm_vanilla_1d_bias(self):
+        """
+        For vanilla addmm, the aten extern choice benchmarks the original 1D
+        bias while the triton template benchmarks the expanded 2D bias.
+        ``get_inputs`` must substitute the extern's 1D-bias IR node and back
+        it with the same values as the 2D bias (all rows identical, collapsed
+        to the first row).
+        """
+        from torch._inductor.kernel.mm import aten_addmm
+
+        with V.set_graph_handler(self._get_inputs_graph()):
+            inp_1d = self._create_buffer("bias_1d", (6,))
+            inp_2d = self._create_buffer("bias_2d", (4, 6))
+            mat1 = self._create_buffer("mat1", (4, 8))
+            mat2 = self._create_buffer("mat2", (8, 6))
+            layout = FixedLayout(torch.device(f"{GPU_TYPE}:0"), torch.float32, (4, 6))
+
+            # aten_addmm consumes the 1D bias; the scheduler (and triton
+            # templates) track the expanded 2D bias.
+            extern_choice = aten_addmm.bind((inp_1d, mat1, mat2), layout)
+
+            autotune_args = AlgorithmSelectorCache.get_inputs(
+                choices=[extern_choice],
+                input_nodes=[inp_2d, mat1, mat2],
+                layout=layout,
+                input_gen_fns=None,
+            )
+
+            triton_inputs = autotune_args.triton.input_tensors
+            extern_inputs = autotune_args.extern.input_tensors
+
+            # Triton benchmarks the 2D bias; aten benchmarks the 1D bias.
+            self.assertEqual(tuple(triton_inputs[0].size()), (4, 6))
+            self.assertEqual(tuple(extern_inputs[0].size()), (6,))
+
+            # The 1D bias is the first row of the (now row-broadcast) 2D bias.
+            self.assertTrue(torch.equal(extern_inputs[0], triton_inputs[0][0]))
+
+    @skipIfXpu(msg="XPU not supported for this get_inputs regression check")
+    def test_get_inputs_addmm_mismatched_length_still_guarded(self):
+        """
+        The length assertion is intentionally kept for the ``addmm`` extern
+        choice to guard the ``zip(input_nodes, extern_input_nodes)`` in
+        ``addmm_unique_example_inputs_extern``. A mismatched-length addmm
+        extern must still raise AssertionError.
+        """
+        from torch._inductor.kernel.mm import aten_addmm
+
+        with V.set_graph_handler(self._get_inputs_graph()):
+            inp_1d = self._create_buffer("bias_1d", (6,))
+            mat1 = self._create_buffer("mat1", (4, 8))
+            mat2 = self._create_buffer("mat2", (8, 6))
+            extra = self._create_buffer("extra", (4, 6))
+            layout = FixedLayout(torch.device(f"{GPU_TYPE}:0"), torch.float32, (4, 6))
+
+            extern_choice = aten_addmm.bind((inp_1d, mat1, mat2), layout)
+
+            with self.assertRaises(AssertionError):
+                AlgorithmSelectorCache.get_inputs(
+                    choices=[extern_choice],
+                    input_nodes=[inp_1d, mat1, mat2, extra],
+                    layout=layout,
+                    input_gen_fns=None,
+                )
+
     @parametrize("autotune_in_subproc", (True, False))
     @parametrize("autotune_multi_device", (True, False))
     def test_max_autotune_mm_plus_mm(self, autotune_in_subproc, autotune_multi_device):

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -3967,6 +3967,117 @@ class TestMaxAutotuneSubproc(TestCase):
             child.join()
             self.assertNotEqual(0, child.exitcode)
 
+    def _get_inputs_graph(self):
+        gm = make_fx(lambda: torch.zeros(2, 3))()
+        return GraphLowering(gm)
+
+    @skipIfXpu(msg="XPU not supported for this get_inputs regression check")
+    def test_get_inputs_non_addmm_extern_mismatched_length(self):
+        """
+        A non-addmm extern choice whose ``input_nodes`` length differs from the
+        scheduler's ``input_nodes`` must not trip the AssertionError guarded
+        for addmm. Regression test for the fix that restricted the
+        ``extern_input_nodes`` substitution (and its length assertion) to
+        ``addmm`` only. The extern benchmark inputs must resolve to the
+        scheduler's input_nodes, in scheduler order.
+        """
+        from torch._inductor.kernel.mm import aten_mm
+
+        with V.set_graph_handler(self._get_inputs_graph()):
+            mat1 = self._create_buffer("mat1", (2, 3))
+            mat2 = self._create_buffer("mat2", (3, 2))
+            extra = self._create_buffer("extra", (2, 2))
+            layout = FixedLayout(torch.device(f"{GPU_TYPE}:0"), torch.float32, (2, 2))
+
+            # extern choice bound to (mat1, mat2) only, while the scheduler
+            # also tracks ``extra`` (e.g. an intermediate buffer the extern
+            # fallback does not consume).
+            extern_choice = aten_mm.bind((mat1, mat2), layout)
+
+            # Must not raise AssertionError for non-addmm extern choices.
+            autotune_args = AlgorithmSelectorCache.get_inputs(
+                choices=[extern_choice],
+                input_nodes=[mat1, mat2, extra],
+                layout=layout,
+                input_gen_fns=None,
+            )
+
+            # Non-addmm path keeps the scheduler's input_nodes for the extern
+            # loop, so every scheduler input must resolve to a benchmark
+            # tensor and the extern input list must mirror the scheduler's
+            # input_nodes in order and shape.
+            sched_nodes = [mat1, mat2, extra]
+            self.assertEqual(len(autotune_args.extern.input_tensors), len(sched_nodes))
+            self.assertEqual(len(autotune_args.triton.input_tensors), len(sched_nodes))
+            for node, tensor in zip(sched_nodes, autotune_args.extern.input_tensors):
+                self.assertEqual(tuple(tensor.size()), tuple(node.get_size()))
+
+    @skipIfXpu(msg="XPU not supported for this get_inputs regression check")
+    def test_get_inputs_addmm_vanilla_1d_bias(self):
+        """
+        For vanilla addmm, the aten extern choice benchmarks the original 1D
+        bias while the triton template benchmarks the expanded 2D bias.
+        ``get_inputs`` must substitute the extern's 1D-bias IR node and back
+        it with the same values as the 2D bias (all rows identical, collapsed
+        to the first row).
+        """
+        from torch._inductor.kernel.mm import aten_addmm
+
+        with V.set_graph_handler(self._get_inputs_graph()):
+            inp_1d = self._create_buffer("bias_1d", (6,))
+            inp_2d = self._create_buffer("bias_2d", (4, 6))
+            mat1 = self._create_buffer("mat1", (4, 8))
+            mat2 = self._create_buffer("mat2", (8, 6))
+            layout = FixedLayout(torch.device(f"{GPU_TYPE}:0"), torch.float32, (4, 6))
+
+            # aten_addmm consumes the 1D bias; the scheduler (and triton
+            # templates) track the expanded 2D bias.
+            extern_choice = aten_addmm.bind((inp_1d, mat1, mat2), layout)
+
+            autotune_args = AlgorithmSelectorCache.get_inputs(
+                choices=[extern_choice],
+                input_nodes=[inp_2d, mat1, mat2],
+                layout=layout,
+                input_gen_fns=None,
+            )
+
+            triton_inputs = autotune_args.triton.input_tensors
+            extern_inputs = autotune_args.extern.input_tensors
+
+            # Triton benchmarks the 2D bias; aten benchmarks the 1D bias.
+            self.assertEqual(tuple(triton_inputs[0].size()), (4, 6))
+            self.assertEqual(tuple(extern_inputs[0].size()), (6,))
+
+            # The 1D bias is the first row of the (now row-broadcast) 2D bias.
+            self.assertTrue(torch.equal(extern_inputs[0], triton_inputs[0][0]))
+
+    @skipIfXpu(msg="XPU not supported for this get_inputs regression check")
+    def test_get_inputs_addmm_mismatched_length_still_guarded(self):
+        """
+        The length assertion is intentionally kept for the ``addmm`` extern
+        choice to guard the ``zip(input_nodes, extern_input_nodes)`` in
+        ``addmm_unique_example_inputs_extern``. A mismatched-length addmm
+        extern must still raise AssertionError.
+        """
+        from torch._inductor.kernel.mm import aten_addmm
+
+        with V.set_graph_handler(self._get_inputs_graph()):
+            inp_1d = self._create_buffer("bias_1d", (6,))
+            mat1 = self._create_buffer("mat1", (4, 8))
+            mat2 = self._create_buffer("mat2", (8, 6))
+            extra = self._create_buffer("extra", (4, 6))
+            layout = FixedLayout(torch.device(f"{GPU_TYPE}:0"), torch.float32, (4, 6))
+
+            extern_choice = aten_addmm.bind((inp_1d, mat1, mat2), layout)
+
+            with self.assertRaises(AssertionError):
+                AlgorithmSelectorCache.get_inputs(
+                    choices=[extern_choice],
+                    input_nodes=[inp_1d, mat1, mat2, extra],
+                    layout=layout,
+                    input_gen_fns=None,
+                )
+
     @parametrize("autotune_in_subproc", (True, False))
     @parametrize("autotune_multi_device", (True, False))
     def test_max_autotune_mm_plus_mm(self, autotune_in_subproc, autotune_multi_device):

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -5017,14 +5017,13 @@ class AlgorithmSelectorCache(PersistentCache):
         unique_example_inputs_extern = unique_example_inputs
 
         if extern_choice is not None:
-            if len(extern_choice.input_nodes) != len(input_nodes):
-                raise AssertionError(
-                    "extern_choice.input_nodes length must match input_nodes: "
-                    f"{len(extern_choice.input_nodes)} != {len(input_nodes)}"
-                )
-            extern_input_nodes = extern_choice.input_nodes
-
             if cls._is_extern(extern_choice) and extern_choice.name == "addmm":
+                if len(extern_choice.input_nodes) != len(input_nodes):
+                    raise AssertionError(
+                        "extern_choice.input_nodes length must match input_nodes: "
+                        f"{len(extern_choice.input_nodes)} != {len(input_nodes)}"
+                    )
+                extern_input_nodes = extern_choice.input_nodes
                 unique_example_inputs_extern = addmm_unique_example_inputs_extern()
 
         example_inputs = list(unique_example_inputs.values())

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -5147,14 +5147,13 @@ class AlgorithmSelectorCache(PersistentCache):
         unique_example_inputs_extern = unique_example_inputs
 
         if extern_choice is not None:
-            if len(extern_choice.input_nodes) != len(input_nodes):
-                raise AssertionError(
-                    "extern_choice.input_nodes length must match input_nodes: "
-                    f"{len(extern_choice.input_nodes)} != {len(input_nodes)}"
-                )
-            extern_input_nodes = extern_choice.input_nodes
-
             if extern_choice.name == "addmm":
+                if len(extern_choice.input_nodes) != len(input_nodes):
+                    raise AssertionError(
+                        "extern_choice.input_nodes length must match input_nodes: "
+                        f"{len(extern_choice.input_nodes)} != {len(input_nodes)}"
+                    )
+                extern_input_nodes = extern_choice.input_nodes
                 unique_example_inputs_extern = addmm_unique_example_inputs_extern()
 
         example_inputs = list(unique_example_inputs.values())


### PR DESCRIPTION
  PR #181430 introduced extern_input_nodes logic in get_inputs() to properly
  benchmark addmm's 1D bias in the extern path. The logic applies to all
  extern choices, including an assertion that extern_choice.input_nodes
  matches the scheduler's input_nodes in length.

  This assumption only holds for standard ExternKernelCaller instances like
  addmm, where both lists have the same length (just the bias shape differs:
  1D vs 2D). It breaks for custom ExternKernelCaller subclasses whose
  input_nodes genuinely differ in length from the scheduler's input_nodes —
  for example, eager fallback choices for fused kernels where the extern
  kernel only needs the fused subgraph's external inputs while the
  scheduler's input_nodes additionally includes output buffer nodes that
  other choices (e.g., TritonTemplateCaller) write to in-place as mutated
  inputs.

  The assertion fails with AssertionError for such extern choices.

  PR #181430's sole purpose was fixing addmm's 1D bias benchmarking. The
  extern_input_nodes substitution and the assertion only serve that goal
  — they guard the zip() in addmm_unique_example_inputs_extern() from
  silent truncation. For non-addmm extern choices, the substitution has
  no benefit and the assertion is an incorrect constraint.

  Restrict both the extern_input_nodes substitution and the assertion to
  the addmm case only. For all other extern choices, extern_input_nodes
  stays as input_nodes (same as before PR #181430).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo