### PR TITLE
Decouple test_block_current_stream in test_c10d_pypg.py from CUDA

### DIFF
--- a/test/distributed/test_c10d_pypg.py
+++ b/test/distributed/test_c10d_pypg.py
@@ -21,12 +21,15 @@ from torch.distributed.distributed_c10d import (
 )
 from torch.futures import Future
 from torch.nn.parallel import DistributedDataParallel as DDP
-from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_distributed import (
     MultiProcessTestCase,
     MultiThreadedTestCase,
 )
 from torch.testing._internal.common_utils import run_tests, TestCase
+
+device_type = (
+    acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
+)
 
 
 def create_work(result):
@@ -474,14 +477,15 @@ class TestPyProcessGroup(TestCase):
         self.assertEqual(dist._new_window(t, group=pg), "fake-window")
         self.assertIs(pg.new_window_tensor, t)
 
-    @unittest.skipIf(not TEST_CUDA, "no cuda/xpu")
+    @unittest.skipIf(not torch.accelerator.is_available(), "no accelerator")
     def test_block_current_stream(self) -> None:
-        torch.cuda.synchronize()
+        device_module = torch.get_device_module(device_type)
+        device_module.synchronize()
 
-        stream = torch.cuda.Stream()
+        stream = device_module.Stream()
         with stream:
             # nothing in queue so instantly resolves
-            event1 = torch.cuda.Event()
+            event1 = device_module.Event()
             event1.record()
             time.sleep(0.1)
             self.assertTrue(event1.query())
@@ -490,7 +494,7 @@ class TestPyProcessGroup(TestCase):
             work.block_current_stream()
 
             # stream is blocked so doesn't resolve
-            event = torch.cuda.Event()
+            event = device_module.Event()
             event.record()
             time.sleep(0.1)
             self.assertFalse(event.query())
@@ -501,13 +505,14 @@ class TestPyProcessGroup(TestCase):
             stream.synchronize()
             self.assertTrue(event.query())
 
-    @unittest.skipIf(not TEST_CUDA, "no cuda/xpu")
+    @unittest.skipIf(not torch.accelerator.is_available(), "no accelerator")
     def test_block_current_stream_use_after_free(self) -> None:
         """
         This tests that the CPU control tensor is not freed before the CUDA kernel executes.
         """
-        torch.cuda.synchronize()
-        stream = torch.cuda.Stream()
+        device_module = torch.get_device_module(device_type)
+        device_module.synchronize()
+        stream = device_module.Stream()
         with stream:
             a = BlockWork()
             a.block_current_stream()
@@ -521,7 +526,7 @@ class TestPyProcessGroup(TestCase):
             del b
 
             # a is still blocking so this doesn't resolve
-            event = torch.cuda.Event()
+            event = device_module.Event()
             event.record()
             time.sleep(0.1)
             self.assertFalse(event.query())

--- a/torch/csrc/distributed/c10d/Work.cpp
+++ b/torch/csrc/distributed/c10d/Work.cpp
@@ -1,3 +1,4 @@
+#include <ATen/DeviceAccelerator.h>
 #include <ATen/ThreadLocalState.h>
 #include <distributed/c10d/ProcessGroup.hpp>
 #include <torch/csrc/distributed/c10d/cuda/StreamBlock.hpp>
@@ -141,9 +142,12 @@ bool Work::wait(std::chrono::milliseconds timeout) {
 }
 
 void Work::blockCurrentStream() {
-  // block cuda stream indefinitely until work is completed.
+  // Block the current accelerator stream indefinitely until work is completed.
+  // Falls back to CUDA when no accelerator is available (backward compat).
+  auto acc = at::accelerator::getAccelerator();
+  auto device_type = acc.value_or(c10::DeviceType::CUDA);
   std::shared_ptr<c10d::cuda::StreamBlock> handle =
-      c10d::cuda::block_stream(std::chrono::milliseconds(0));
+      c10d::cuda::block_stream(std::chrono::milliseconds(0), device_type);
 
   getFuture()->addCallback(
       [handle](c10::ivalue::Future& future) { handle->abort(); });

--- a/torch/csrc/distributed/c10d/cuda/StreamBlock.cpp
+++ b/torch/csrc/distributed/c10d/cuda/StreamBlock.cpp
@@ -5,10 +5,17 @@ namespace c10d::cuda {
 
 C10_DEFINE_REGISTRY(StreamBlockRegistry, StreamBlock, std::chrono::milliseconds)
 
-std::unique_ptr<StreamBlock> block_stream(std::chrono::milliseconds timeout) {
-  auto baton = StreamBlockRegistry()->Create("CUDA", timeout);
-  TORCH_CHECK(baton, "Failed to create StreamBlock");
+std::unique_ptr<StreamBlock> block_stream(
+    std::chrono::milliseconds timeout,
+    c10::DeviceType device_type) {
+  auto key = c10::DeviceTypeName(device_type);
+  auto baton = StreamBlockRegistry()->Create(key, timeout);
+  TORCH_CHECK(baton, "Failed to create StreamBlock for device ", key);
   return baton;
+}
+
+std::unique_ptr<StreamBlock> block_stream(std::chrono::milliseconds timeout) {
+  return block_stream(timeout, c10::DeviceType::CUDA);
 }
 
 } // namespace c10d::cuda

--- a/torch/csrc/distributed/c10d/cuda/StreamBlock.hpp
+++ b/torch/csrc/distributed/c10d/cuda/StreamBlock.hpp
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <memory>
 
+#include <c10/core/DeviceType.h>
 #include <c10/util/Registry.h>
 
 namespace c10d::cuda {
@@ -15,8 +16,19 @@ enum StreamBlockStatus : int32_t {
 };
 
 /*
-StreamBlock implements a baton that will block the active CUDA stream
+StreamBlock implements a baton that will block the active stream
 until aborted by the main process.
+
+Third-party backends register their implementation via:
+  C10_REGISTER_CLASS(StreamBlockRegistry, <DeviceName>, MyStreamBlock)
+
+The constructor receives a std::chrono::milliseconds timeout.
+The implementation must:
+  - Block the current device stream in the constructor
+  - Release the block when abort() is called (may be called from any thread)
+  - Be safe to destruct without waiting if abort() has been called
+
+The backend's <DeviceName> must match c10::DeviceTypeName(device_type).
 */
 class TORCH_API StreamBlock {
  public:
@@ -25,11 +37,18 @@ class TORCH_API StreamBlock {
   virtual StreamBlockStatus status() = 0;
 };
 
+// Block the current stream of the given device type. Looks up the
+// StreamBlockRegistry using c10::DeviceTypeName(device_type) as the key.
+std::unique_ptr<StreamBlock> block_stream(
+    std::chrono::milliseconds timeout,
+    c10::DeviceType device_type);
+
+// Backward-compatible overload: defaults to CUDA.
 std::unique_ptr<StreamBlock> block_stream(std::chrono::milliseconds timeout);
 
-// Declare a registry so we can call the CUDA StreamBlock API from CPU only code
-// (i.e. ProcessGroup/Work objects in libtorch_cpu).
-// The implementation lives defined in StreamBlock.cu.
+// Registry for StreamBlock implementations. The CUDA implementation is
+// defined in StreamBlock.cu. Third-party backends register their own
+// implementation via C10_REGISTER_CLASS with their device name as the key.
 TORCH_DECLARE_REGISTRY(
     StreamBlockRegistry,
     StreamBlock,


### PR DESCRIPTION
## Target test cases

This PR decouples two test cases in test/distributed/test_c10d_pypg.py that were hardcoded to CUDA:

1. TestPyProcessGroup::test_block_current_stream
   - Tests that Work::blockCurrentStream() blocks the device stream until the associated Future completes.

2. TestPyProcessGroup::test_block_current_stream_use_after_free
   - Tests that the CPU control tensor is not freed before the device kernel finishes, verifying memory safety of the StreamBlock mechanism when multiple blocks are queued on the same stream.

Both tests verify the base Work::blockCurrentStream() mechanism, which is used by DDP and other distributed code to synchronize device streams with collective operations. They are not CUDA-specific in purpose -- they test a device-agnostic stream-blocking interface.

## What was changed and why

### 1. StreamBlock.hpp (modified)
- Added #include <c10/core/DeviceType.h>
- Added a new overload: block_stream(timeout, device_type)
  - Looks up StreamBlockRegistry using c10::DeviceTypeName(device_type) as the key (e.g. "CUDA", or any third-party device name)
  - This allows non-CUDA backends to register their own StreamBlock implementations and have them discovered at runtime
- Kept the original block_stream(timeout) as a backward-compatible overload that delegates to block_stream(timeout, kCUDA)
- Updated the StreamBlock class docstring to describe the interface contract that third-party backends must implement:
  - Constructor receives std::chrono::milliseconds timeout
  - Must block the current device stream in the constructor
  - Must release the block when abort() is called (thread-safe)
  - Must be safe to destruct without waiting if abort() was called

### 2. StreamBlock.cpp (modified)
- Implemented block_stream(timeout, device_type) using c10::DeviceTypeName(device_type) as the registry lookup key
- Original block_stream(timeout) now delegates to the new overload with kCUDA, preserving exact backward compatibility

### 3. Work.cpp (modified)
- Added #include <ATen/DeviceAccelerator.h>
- Work::blockCurrentStream() now calls at::accelerator::getAccelerator() to determine the active device type and passes it to block_stream(timeout, device_type)
- Falls back to kCUDA when no accelerator is available (backward compat)
- On CUDA-only machines: getAccelerator() returns kCUDA, DeviceTypeName(kCUDA) returns "CUDA", which matches the existing C10_REGISTER_CLASS(StreamBlockRegistry, CUDA, StreamBlock) in StreamBlock.cu -- behavior is identical to before

### 4. test_c10d_pypg.py (modified)
- Added module-level device_type variable using torch.accelerator.current_accelerator() (same pattern already used in test_c10d_common.py and test_pg_wrapper.py)
- Replaced torch.cuda.synchronize() / Stream() / Event() with torch.get_device_module(device_type).synchronize() / Stream() / Event(), which works with any registered accelerator
- Replaced @skipIf(not TEST_CUDA, ...) with @skipIf(not torch.accelerator.is_available(), ...) which checks for any accelerator rather than only CUDA
- Removed the now-unused TEST_CUDA import

## How third-party backends use these tests

A backend vendor implements a StreamBlock subclass and registers it via the C10_REGISTER_CLASS macro. No PyTorch code changes are needed.

### Interface to implement

The backend must provide a class derived from c10d::cuda::StreamBlock:

  class MyStreamBlock : public c10d::cuda::StreamBlock {
   public:
    // Constructor: must block the current device stream.
    // 'timeout' is the maximum block duration (0 = indefinite).
    MyStreamBlock(std::chrono::milliseconds timeout);

    // Called from any thread when the associated Future completes.
    // Must release the stream block.
    void abort() override;

    // Returns the current status of the block.
    StreamBlockStatus status() override;
  };

### Registration

Register using the device name that matches
c10::DeviceTypeName(device_type) for the backend's device type:

  C10_REGISTER_CLASS(StreamBlockRegistry, <DeviceName>, MyStreamBlock)

For PrivateUse1-based backends, <DeviceName> is the uppercase name set by torch.utils.rename_privateuse1_backend(). For example, if the backend calls rename_privateuse1_backend("mydev"), then <DeviceName> is "MYDEV".

### How it works at runtime

1. torch_npu (or any backend) loads and C10_REGISTER_CLASS static initializer registers the StreamBlock under the device name
2. When Work::blockCurrentStream() is called, at::accelerator::getAccelerator() returns the active device type
3. block_stream(timeout, device_type) looks up the registry using DeviceTypeName(device_type) as the key
4. The registered StreamBlock implementation is instantiated, blocking the device stream
5. When the Future completes, the callback calls abort(), releasing the stream

### Example (third-party backend C++ file)

  #include <torch/csrc/distributed/c10d/cuda/StreamBlock.hpp>

  namespace my_backend {
  class MyStreamBlock : public c10d::cuda::StreamBlock {
    // ... implementation using device-native APIs ...
  };
  }

  using c10d::cuda::StreamBlockRegistry;
  using c10d::cuda::RegistererStreamBlockRegistry;
  C10_REGISTER_CLASS(StreamBlockRegistry, MYDEV, my_backend::MyStreamBlock)

## Backward compatibility

- The original block_stream(timeout) signature is preserved
- On CUDA-only machines, getAccelerator() returns kCUDA, so blockCurrentStream() behavior is identical to before
- ProcessGroupNCCL::WorkNCCL::blockCurrentStream() override is unaffected (it calls synchronize(), bypassing StreamBlock entirely)
- StreamBlock.cu (CUDA implementation) is unchanged

## Test plan

Verified on CPU-only and 8-device accelerator environments:

```
# CPU (no accelerator) - stream tests correctly skipped
python test/distributed/test_c10d_pypg.py
Ran 50 tests in 0.187s
OK (skipped=38)

# Accelerator (8 devices, with backend StreamBlock registered) - all pass
python test/distributed/test_c10d_pypg.py
Ran 50 tests in 5.916s
OK
```

Authored by Claude.