### PR TITLE
Fix duplicate LC_RPATH from macOS libomp embedding on conda/pixi builds

### DIFF
--- a/tools/embed_libomp_macos.py
+++ b/tools/embed_libomp_macos.py
@@ -101,15 +101,30 @@ def main() -> int:
     libomp_dir_real = libomp_path.parent.resolve()
     for rp in rpaths:
         if Path(rp).resolve() == libomp_dir_real:
-            subprocess.check_call(
-                [
-                    "install_name_tool",
-                    "-rpath",
-                    rp,
-                    "@loader_path",
-                    str(libtorch_cpu),
-                ]
-            )
+            if "@loader_path" in rpaths:
+                # @loader_path is already an rpath (CMAKE_INSTALL_RPATH adds
+                # it to every torch library). Renaming would write a second,
+                # identical LC_RPATH, which dyld rejects at load time on
+                # macOS 15.4+ ("duplicate LC_RPATH"). Drop the build-time
+                # rpath instead.
+                subprocess.check_call(
+                    [
+                        "install_name_tool",
+                        "-delete_rpath",
+                        rp,
+                        str(libtorch_cpu),
+                    ]
+                )
+            else:
+                subprocess.check_call(
+                    [
+                        "install_name_tool",
+                        "-rpath",
+                        rp,
+                        "@loader_path",
+                        str(libtorch_cpu),
+                    ]
+                )
             return 0
 
     # No matching rpath -- add @loader_path if not already present.


### PR DESCRIPTION
## Summary

Fixes a macOS import failure for from-source builds in conda/pixi
environments: the build completes, but `import torch` fails with

```
ImportError: dlopen(.../torch/_C.cpython-313-darwin.so, 0x0002): Library not loaded: @rpath/libtorch_cpu.dylib
  Referenced from: .../torch/lib/libtorch_python.dylib
  Reason: tried: ... '.../torch/lib/libtorch_cpu.dylib' (duplicate LC_RPATH '@loader_path'), ...
```

## Root cause

`tools/embed_libomp_macos.py` (from #180239, invoked at install time via
`cmake/PostBuildSteps.cmake`) handles the conda-style layout by renaming the
rpath that points at the build-time libomp directory to `@loader_path`.
Every torch library already carries `@loader_path` via `CMAKE_INSTALL_RPATH`
(`cmake/Dependencies.cmake:13`), so the rename writes a second, identical
`LC_RPATH` into `libtorch_cpu.dylib`. dyld on macOS 15.4+ refuses to load an
image with duplicate `LC_RPATH` entries; older dyld tolerated the duplicate
silently, and the CD wheels never showed it because delocate normalizes
rpaths afterwards.

The triggering configuration is a conda/pixi env providing libomp: the env
lib dir ends up as an rpath on `libtorch_cpu.dylib` (via
`CMAKE_INSTALL_RPATH_USE_LINK_PATH` and/or the conda toolchain's
`-Wl,-rpath,$PREFIX/lib`), which is exactly the rename target.

## Fix

In the rename branch, when `@loader_path` is already among the rpaths,
delete the build-time rpath instead of renaming it. The rename is kept for
layouts without a preexisting `@loader_path` (e.g. builds run with
`-DCMAKE_SKIP_INSTALL_RPATH=ON`, where `LDFLAGS`-injected rpaths survive but
CMake-managed ones are stripped); the `add_rpath` branch was already
guarded.

Workaround for already-built trees until a rebuild picks this up:

```
install_name_tool -delete_rpath @loader_path torch/lib/libtorch_cpu.dylib
```

## Test plan

All four decision branches exercised with `parse_otool` /
`install_name_tool` mocked; the pre-fix script provably issues the
duplicate-creating rename in the conda case, the fixed one issues
`-delete_rpath`:

<details>
<summary>mock test (ALL CASES PASS)</summary>

```python
import importlib.util, sys, tempfile
from pathlib import Path
from unittest import mock

def load(path, name):
    spec = importlib.util.spec_from_file_location(name, path)
    m = importlib.util.module_from_spec(spec)
    spec.loader.exec_module(m)
    return m

def run_case(script, rpaths, libs, tmp):
    m = load(script, "emb")
    omp_dir = tmp / "omp"; lib_dir = tmp / "lib"
    omp_dir.mkdir(exist_ok=True); lib_dir.mkdir(exist_ok=True)
    (omp_dir / "libomp.dylib").write_bytes(b"x")
    (lib_dir / "libtorch_cpu.dylib").write_bytes(b"x")
    calls = []
    with mock.patch.object(m, "parse_otool", return_value=(rpaths, libs)), \
         mock.patch.object(m.subprocess, "check_call", lambda cmd, *a, **k: calls.append(cmd)), \
         mock.patch.object(sys, "argv", ["x", "--libomp-path", str(omp_dir/"libomp.dylib"), "--lib-dir", str(lib_dir)]):
        m.main()
    return [" ".join(c[:3]) for c in calls]

with tempfile.TemporaryDirectory() as td:
    tmp = Path(td); env_rp = str(tmp / "omp")
    # conda-style (@loader_path + env rpath): fixed script must delete, not rename
    c = run_case("tools/embed_libomp_macos.py", ["@loader_path", env_rp], ["@rpath/libomp.dylib"], tmp)
    assert "-delete_rpath" in c[0], c
    # env rpath only: rename preserved
    c = run_case("tools/embed_libomp_macos.py", [env_rp], ["@rpath/libomp.dylib"], tmp)
    assert "-rpath" in c[0], c
    # homebrew abs load command, @loader_path present: only the -change rewrite
    c = run_case("tools/embed_libomp_macos.py", ["@loader_path"], [str(tmp/"omp"/"libomp.dylib")], tmp)
    assert len(c) == 1 and "-change" in c[0], c
    # not linked against libomp: untouched
    c = run_case("tools/embed_libomp_macos.py", ["@loader_path"], ["@rpath/libc++.dylib"], tmp)
    assert c == [], c
print("ALL CASES PASS")
```

</details>

```
lintrunner tools/embed_libomp_macos.py   # clean
```

Reported by a user building viable/strict `84cc6889912` in a pixi env on
macOS 15.4+; that environment reproduces the failure and can confirm the
fix end-to-end.

This PR was authored with the assistance of Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
