### PR TITLE
Make TorchScript deprecation warnings hard errors with an escape hatch

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -421,6 +421,29 @@ JIT_EXECUTOR_TESTS = [
     "test_jit_fuser_legacy",
 ]
 
+# TorchScript APIs (torch.jit.script/trace/save/...) raise a RuntimeError unless
+# this escape-hatch env var is set to the exact promised value; see
+# torch/jit/_state.py. Set it for the test files that exercise TorchScript so
+# they keep running until the suite is migrated off TS before 2.15.
+TORCHSCRIPT_SILENCE_ENV = "TORCH_2_14_ONLY_UNSAFE_SILENCE_TORCHSCRIPT_ERROR"
+TORCHSCRIPT_SILENCE_VALUE = "I promise to migrate by 2.15"
+
+
+def _uses_torchscript(test_name: str) -> bool:
+    return (
+        test_name.startswith(
+            (
+                "jit/",
+                "quantization/jit/",
+                "distributed/nn/jit/",
+                "test_jit",
+                "test_tensorexpr",
+            )
+        )
+        or test_name == "test_ops_jit"
+    )
+
+
 INDUCTOR_TESTS = [test for test in TESTS if test.startswith(INDUCTOR_TEST_PREFIX)]
 DISTRIBUTED_TESTS = [test for test in TESTS if test.startswith(DISTRIBUTED_TEST_PREFIX)]
 TORCH_EXPORT_TESTS = [test for test in TESTS if test.startswith("export")]
@@ -507,6 +530,8 @@ def run_test(
         print_to_stderr("SCRIBE_GRAPHQL_ACCESS_TOKEN is NOT set")
 
     env = env or os.environ.copy()
+    if _uses_torchscript(test_module.name):
+        env[TORCHSCRIPT_SILENCE_ENV] = TORCHSCRIPT_SILENCE_VALUE
     maybe_set_hip_visible_devies()
     unittest_args = options.additional_args.copy()
     test_file = test_module.name

--- a/torch/jit/_async.py
+++ b/torch/jit/_async.py
@@ -9,11 +9,10 @@ This is not intended to be imported directly; please use the exposed
 functionalities in `torch.jit`.
 """
 
-import warnings
-
 import torch
 from torch._jit_internal import Future
 from torch.jit._builtins import _register_builtin
+from torch.jit._state import _torchscript_deprecation_error
 from torch.utils import set_module
 
 
@@ -101,9 +100,8 @@ def fork(func, *args, **kwargs):
         mod = Mod()
         assert mod(input) == torch.jit.script(mod).forward(input)
     """
-    warnings.warn(
-        "`torch.jit.fork` is deprecated. Please use `torch.compile` instead.",
-        DeprecationWarning,
+    _torchscript_deprecation_error(
+        "`torch.jit.fork` is deprecated. Please use `torch.compile` instead."
     )
     return torch._C.fork(func, *args, **kwargs)
 
@@ -121,9 +119,8 @@ def wait(future):
     Returns:
         `T`: the return value of the completed task
     """
-    warnings.warn(
-        "`torch.jit.wait` is deprecated. Please use `torch.compile` instead.",
-        DeprecationWarning,
+    _torchscript_deprecation_error(
+        "`torch.jit.wait` is deprecated. Please use `torch.compile` instead."
     )
     return torch._C.wait(future)
 

--- a/torch/jit/_freeze.py
+++ b/torch/jit/_freeze.py
@@ -5,10 +5,9 @@ This is not intended to be imported directly; please use the exposed
 functionalities in `torch.jit`.
 """
 
-import warnings
-
 import torch
 from torch.jit._script import RecursiveScriptModule, ScriptModule
+from torch.jit._state import _torchscript_deprecation_error
 
 
 def freeze(
@@ -103,9 +102,8 @@ def freeze(
         You can remap devices by specifying `map_location` in `torch.jit.load`, however
         device-specific logic may have been baked into the model.
     """
-    warnings.warn(
-        "`torch.jit.freeze` is deprecated. Please use `torch.compile` instead.",
-        DeprecationWarning,
+    _torchscript_deprecation_error(
+        "`torch.jit.freeze` is deprecated. Please use `torch.compile` instead."
     )
     if not isinstance(mod, ScriptModule):
         raise RuntimeError(
@@ -227,9 +225,8 @@ def optimize_for_inference(
         # if built with MKLDNN, convolution will be run with MKLDNN weights
         assert "MKLDNN" in frozen_mod.graph
     """
-    warnings.warn(
-        "`torch.jit.optimize_for_inference` is deprecated. Please use `torch.compile` instead.",
-        DeprecationWarning,
+    _torchscript_deprecation_error(
+        "`torch.jit.optimize_for_inference` is deprecated. Please use `torch.compile` instead."
     )
     if not isinstance(mod, ScriptModule):
         raise RuntimeError(

--- a/torch/jit/_script.py
+++ b/torch/jit/_script.py
@@ -17,7 +17,7 @@ import sys
 import warnings
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from typing import Any, TypeVar
-from typing_extensions import deprecated, Self
+from typing_extensions import Self
 
 import torch
 import torch._jit_internal as _jit_internal
@@ -41,6 +41,7 @@ from torch.jit._state import (
     _enabled,
     _set_jit_function_cache,
     _set_jit_overload_cache,
+    _torchscript_deprecation_error,
     _try_get_jit_cached_function,
     _try_get_jit_cached_overloads,
 )
@@ -356,16 +357,13 @@ class ScriptWarning(Warning):
 
 def script_method(fn):
     if sys.version_info >= (3, 14):
-        warnings.warn(
+        msg = (
             "`torch.jit.script_method` is not supported in Python 3.14+ and may break. "
-            "Please switch to `torch.compile` or `torch.export`.",
-            DeprecationWarning,
+            "Please switch to `torch.compile` or `torch.export`."
         )
     else:
-        warnings.warn(
-            "`torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.",
-            DeprecationWarning,
-        )
+        msg = "`torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`."
+    _torchscript_deprecation_error(msg)
     if not _enabled:
         return fn
     # NOTE: we need to traverse two frames here because the meta-class frame
@@ -771,10 +769,6 @@ if _enabled:
             """
             return self._c.save(str(f), **kwargs)
 
-        @deprecated(
-            "Lite Interpreter is deprecated. Please consider switching to ExecuTorch. \
-            https://docs.pytorch.org/executorch/stable/getting-started.html"
-        )
         def _save_for_lite_interpreter(self, *args, **kwargs):
             r"""Add (or update) the bytecode session to the script model.
 
@@ -788,24 +782,16 @@ if _enabled:
                 _extra_files: Map from filename to contents which will be stored as part of 'f'.
 
             """
-            warnings.warn(
-                "Lite Interpreter is deprecated. Please consider switching to ExecuTorch. \
-                https://docs.pytorch.org/executorch/stable/getting-started.html",
-                DeprecationWarning,
-                stacklevel=2,
+            _torchscript_deprecation_error(
+                "Lite Interpreter is deprecated. Please consider switching to ExecuTorch. "
+                "https://docs.pytorch.org/executorch/stable/getting-started.html"
             )
             return self._c._save_for_mobile(*args, **kwargs)
 
-        @deprecated(
-            "Lite Interpreter is deprecated. Please consider switching to ExecuTorch. \
-            https://docs.pytorch.org/executorch/stable/getting-started.html"
-        )
         def _save_to_buffer_for_lite_interpreter(self, *args, **kwargs):
-            warnings.warn(
-                "Lite Interpreter is deprecated. Please consider switching to ExecuTorch. \
-                https://docs.pytorch.org/executorch/stable/getting-started.html",
-                DeprecationWarning,
-                stacklevel=2,
+            _torchscript_deprecation_error(
+                "Lite Interpreter is deprecated. Please consider switching to ExecuTorch. "
+                "https://docs.pytorch.org/executorch/stable/getting-started.html"
             )
             return self._c._save_to_buffer_for_mobile(*args, **kwargs)
 
@@ -1482,16 +1468,13 @@ def script(
             print(scripted_model([20]))
     """
     if sys.version_info >= (3, 14):
-        warnings.warn(
+        msg = (
             "`torch.jit.script` is not supported in Python 3.14+ and may break. "
-            "Please switch to `torch.compile` or `torch.export`.",
-            DeprecationWarning,
+            "Please switch to `torch.compile` or `torch.export`."
         )
     else:
-        warnings.warn(
-            "`torch.jit.script` is deprecated. Please switch to `torch.compile` or `torch.export`.",
-            DeprecationWarning,
-        )
+        msg = "`torch.jit.script` is deprecated. Please switch to `torch.compile` or `torch.export`."
+    _torchscript_deprecation_error(msg)
     if not _enabled:
         return obj
     try:
@@ -1640,9 +1623,8 @@ def interface(obj: _T) -> _T:
         user_fn_jit(impls, 0, val)
         user_fn_jit(impls, 1, val)
     """
-    warnings.warn(
-        "`torch.jit.interface` is deprecated. Please use `torch.compile` instead.",
-        DeprecationWarning,
+    _torchscript_deprecation_error(
+        "`torch.jit.interface` is deprecated. Please use `torch.compile` instead."
     )
     if not inspect.isclass(obj):
         raise RuntimeError("interface must be applied to a class")

--- a/torch/jit/_serialization.py
+++ b/torch/jit/_serialization.py
@@ -11,12 +11,12 @@ functionalities in `torch.jit`.
 
 import os
 import sys
-import warnings
 
 import torch
 from torch._jit_internal import _get_model_id
 from torch._utils_internal import log_torchscript_usage
 from torch.jit._recursive import wrap_cpp_module
+from torch.jit._state import _torchscript_deprecation_error
 from torch.serialization import validate_cuda_device
 
 
@@ -80,16 +80,13 @@ def save(m, f, _extra_files=None) -> None:
         torch.jit.save(m, 'scriptmodule.pt', _extra_files=extra_files)
     """
     if sys.version_info >= (3, 14):
-        warnings.warn(
+        msg = (
             "`torch.jit.save` is not supported in Python 3.14+ and may break. "
-            "Please switch to `torch.export`.",
-            DeprecationWarning,
+            "Please switch to `torch.export`."
         )
     else:
-        warnings.warn(
-            "`torch.jit.save` is deprecated. Please switch to `torch.export`.",
-            DeprecationWarning,
-        )
+        msg = "`torch.jit.save` is deprecated. Please switch to `torch.export`."
+    _torchscript_deprecation_error(msg)
     log_torchscript_usage("save", model_id=_get_model_id(m))
     if _extra_files is None:
         _extra_files = {}
@@ -167,16 +164,13 @@ def load(f, map_location=None, _extra_files=None, _restore_shapes=False):
         os.remove("scriptmodule.pt")
     """
     if sys.version_info >= (3, 14):
-        warnings.warn(
+        msg = (
             "`torch.jit.load` is not supported in Python 3.14+ and may break. "
-            "Please switch to `torch.export`.",
-            DeprecationWarning,
+            "Please switch to `torch.export`."
         )
     else:
-        warnings.warn(
-            "`torch.jit.load` is deprecated. Please switch to `torch.export`.",
-            DeprecationWarning,
-        )
+        msg = "`torch.jit.load` is deprecated. Please switch to `torch.export`."
+    _torchscript_deprecation_error(msg)
     if isinstance(f, (str, os.PathLike)):
         if not os.path.exists(f):
             raise ValueError(f"The provided filename {f} does not exist")

--- a/torch/jit/_state.py
+++ b/torch/jit/_state.py
@@ -48,6 +48,25 @@ class EnabledProxy:
 _enabled = EnabledProxy()
 
 
+_SILENCE_TORCHSCRIPT_ERROR_ENV = "TORCH_2_14_ONLY_UNSAFE_SILENCE_TORCHSCRIPT_ERROR"
+_SILENCE_TORCHSCRIPT_ERROR_VALUE = "I promise to migrate by 2.15"
+# Read once at import; the escape hatch must be set before `import torch`.
+_torchscript_error_silenced = (
+    os.environ.get(_SILENCE_TORCHSCRIPT_ERROR_ENV) == _SILENCE_TORCHSCRIPT_ERROR_VALUE
+)
+
+
+def _torchscript_deprecation_error(message: str) -> None:
+    if _torchscript_error_silenced:
+        return
+    raise RuntimeError(
+        f"{message} This is now an error. To temporarily silence it, set the "
+        f'environment variable {_SILENCE_TORCHSCRIPT_ERROR_ENV}="'
+        f'{_SILENCE_TORCHSCRIPT_ERROR_VALUE}" before importing torch. '
+        "You must migrate before 2.15."
+    )
+
+
 def disable() -> None:
     _enabled.enabled = False
 

--- a/torch/jit/_trace.py
+++ b/torch/jit/_trace.py
@@ -31,7 +31,7 @@ from torch._jit_internal import (
 )
 from torch.autograd import function
 from torch.jit._script import _CachedForward, script, ScriptModule
-from torch.jit._state import _enabled, _python_cu
+from torch.jit._state import _enabled, _python_cu, _torchscript_deprecation_error
 from torch.nn import Module
 from torch.testing._comparison import default_tolerances
 
@@ -997,16 +997,13 @@ def trace(
 
     """
     if sys.version_info >= (3, 14):
-        warnings.warn(
+        msg = (
             "`torch.jit.trace` is not supported in Python 3.14+ and may break. "
-            "Please switch to `torch.compile` or `torch.export`.",
-            DeprecationWarning,
+            "Please switch to `torch.compile` or `torch.export`."
         )
     else:
-        warnings.warn(
-            "`torch.jit.trace` is deprecated. Please switch to `torch.compile` or `torch.export`.",
-            DeprecationWarning,
-        )
+        msg = "`torch.jit.trace` is deprecated. Please switch to `torch.compile` or `torch.export`."
+    _torchscript_deprecation_error(msg)
     if not _enabled:
         return func
     if optimize is not None:
@@ -1136,16 +1133,13 @@ def trace_module(
 
     """
     if sys.version_info >= (3, 14):
-        warnings.warn(
+        msg = (
             "`torch.jit.trace_method` is not supported in Python 3.14+ and may break. "
-            "Please switch to `torch.compile` or `torch.export`.",
-            DeprecationWarning,
+            "Please switch to `torch.compile` or `torch.export`."
         )
     else:
-        warnings.warn(
-            "`torch.jit.trace_method` is deprecated. Please switch to `torch.compile` or `torch.export`.",
-            DeprecationWarning,
-        )
+        msg = "`torch.jit.trace_method` is deprecated. Please switch to `torch.compile` or `torch.export`."
+    _torchscript_deprecation_error(msg)
     if not _enabled:
         return mod
     if optimize is not None:


### PR DESCRIPTION
## Author Notes

This is just to see what it would take to get this through CI.

## Agent Notes

TorchScript has been deprecated since 2.5 and the public `torch.jit` entry
points already emit `DeprecationWarning`s. This PR turns those warnings into
hard `RuntimeError`s so new usage is caught, while providing a temporary,
explicit opt-out.

### The change

- **`torch/jit/_state.py`** introduces `_torchscript_deprecation_error()`, which
  raises unless the env var `TORCH_2_14_ONLY_UNSAFE_SILENCE_TORCHSCRIPT_ERROR`
  is set to the exact value `"I promise to migrate by 2.15"`. The var is read
  **once at import**, so it must be set before `import torch`.
- The remaining `torch/jit/*.py` files swap each existing `warnings.warn(...)`
  deprecation for a call to the helper, preserving the message text (including
  the Python 3.14+ branch). The two Lite Interpreter save methods also drop
  their now-redundant `@deprecated` decorator; dead `warnings` / `deprecated`
  imports are removed.
- **`test/run_test.py`** sets the escape-hatch env var per test file for the
  files that exercise TorchScript (`jit/`, `quantization/jit/`,
  `distributed/nn/jit/`, `test_jit*`, `test_tensorexpr*`, `test_ops_jit`), so
  those tests keep running under whichever shard they land in.

### Known follow-up

Test files outside those patterns that still call TorchScript APIs (scattered
under `onnx/`, `mobile/`, `dynamo/`, `export/`, `quantization/core/`, etc.) are
intentionally **not** covered here and will error until migrated or skipped.
Surfacing that fallout in CI is a large part of the point of this PR.

This PR was authored with the assistance of an AI coding agent (Claude).
