### PR TITLE
Skip `test_tma_stable_reconstruct` on Python 3.13+

### DIFF
--- a/test/dynamo/test_reconstruct.py
+++ b/test/dynamo/test_reconstruct.py
@@ -3,6 +3,7 @@
 import collections
 import contextlib
 import dis
+import sys
 import unittest
 
 import torch
@@ -526,6 +527,10 @@ class ReconstructTest(torch._dynamo.test_case.TestCase):
         res = torch.compile(create_tma, backend="eager")(x)
         self.assertEqual(ref[1].desc, res[1].desc)
 
+    @unittest.skipIf(
+        sys.version_info >= (3, 13),
+        "Tensor in TensorDescriptor not comparable in Python 3.13+",
+    )
     @unittest.skipIf(not HAS_GPU, "requires GPU and Triton")
     @unittest.skipIf(
         not has_triton_tensor_descriptor_host_tma(),


### PR DESCRIPTION
In Python 3.12 and lower the `__eq__` of the (Tritons) `TensorDescriptor` skipped the actual comparison of the tensor when it was the same instance. In newer Python versions default comparison is performed which yields a bool-tensor that is then contextually converted to `bool` which fails with
> RuntimeError: Boolean value of Tensor with more than one value is ambiguous

This skips the test introduced in https://github.com/pytorch/pytorch/pull/155662 to unblock Python 3.13

I guess a generic solution could be in `originate_pairs` to convert any dataclass to a tuple first using `dataclasses.totuple`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98