### PR TITLE
Reject empty observer_on/fake_quant_on in fused_moving_avg_obs_fake_quant CUDA (#189671)

### DIFF
--- a/aten/src/ATen/native/quantized/cuda/FusedObsFakeQuant.cu
+++ b/aten/src/ATen/native/quantized/cuda/FusedObsFakeQuant.cu
@@ -284,6 +284,14 @@ std::tuple<at::Tensor, at::Tensor> fused_moving_avg_obs_fake_quant_cuda(
     bool per_row_fq,
     bool symmetric_quant) {
   TORCH_CHECK(ch_axis < x.dim(), "Error in fused_moving_avg_obs_fake_quant_cpu: ch_axis must be < self.dim()");
+  // The kernels dereference observer_on[0] / fake_quant_on[0]; an empty flag
+  // tensor yields a null data_ptr and an out-of-bounds read (gh-189671).
+  TORCH_CHECK(
+      observer_on.numel() == 1 && fake_quant_on.numel() == 1,
+      "Error in fused_moving_avg_obs_fake_quant_cuda: observer_on and fake_quant_on must each have exactly one element, but got observer_on.numel()=",
+      observer_on.numel(),
+      " and fake_quant_on.numel()=",
+      fake_quant_on.numel());
   const auto x_contig = x.contiguous();
   // Calculate the size of the dimension we need to quantize over,
   // For per-channel quant we default to axis 0, since it is only for

--- a/test/quantization/core/test_workflow_ops.py
+++ b/test/quantization/core/test_workflow_ops.py
@@ -1100,6 +1100,24 @@ class TestFakeQuantizeOps(TestCase):
 
 
 class TestFusedObsFakeQuant(TestCase):
+    @unittest.skipIf(not TEST_CUDA, "No gpu is not available.")
+    def test_fused_obs_fake_quant_empty_flags(self) -> None:
+        # An empty observer_on / fake_quant_on flag tensor must be rejected on
+        # the host instead of dereferencing a null data_ptr on device (gh-189671).
+        device = "cuda"
+        x = torch.ones(2, 3, dtype=torch.bfloat16, device=device)
+        empty = torch.empty(0, dtype=torch.int64, device=device)
+        one = torch.ones(1, dtype=torch.int64, device=device)
+        running_min = torch.zeros(1, dtype=torch.bfloat16, device=device)
+        running_max = torch.zeros(1, dtype=torch.bfloat16, device=device)
+        scale = torch.ones(1, dtype=torch.float32, device=device)
+        zero_point = torch.zeros(1, dtype=torch.int32, device=device)
+        for observer_on, fake_quant_on in ((empty, one), (one, empty)):
+            with self.assertRaisesRegex(RuntimeError, "must each have exactly one element"):
+                torch.fused_moving_avg_obs_fake_quant(
+                    x, observer_on, fake_quant_on, running_min, running_max,
+                    scale, zero_point, 0.0, 0, 255, 0, False, False)
+
     @given(device=st.sampled_from(['cpu', 'cuda'] if torch.cuda.is_available() else ['cpu']),
            sampled_dtype=st.sampled_from(['bf16', 'fp16', 'fp32']),
            symmetric_quant=st.booleans(), use_bool=st.booleans())


### PR DESCRIPTION
Fixes #189671

### Root cause
The CUDA kernels behind `fused_moving_avg_obs_fake_quant` (`MovingAverageMinMax`
and the qparams helper) unconditionally dereference `observer_on[0]` /
`fake_quant_on[0]`. When either flag tensor is empty its `data_ptr` is null, so
the kernel does a null `__global__` read. Confirmed with `compute-sanitizer`
on a Tesla T4:

```
Invalid __global__ read of size 8 bytes
  at at::native::MovingAverageMinMax<c10::BFloat16>(...)
  Address 0x0 is out of bounds
```

### Fix
Validate on the host in `fused_moving_avg_obs_fake_quant_cuda` that both flag
tensors contain exactly one element before launching any kernel, so a bad input
raises a clear error instead of faulting on device. These flags are always
single-element controls.

### Test
```
python test/quantization/core/test_workflow_ops.py -k test_fused_obs_fake_quant_empty_flags
```
Draft: CI runs the CUDA build + test.
