### PR TITLE
Guard zero-width embedding_dense_backward_cuda against null-pointer read (#189668)

### DIFF
--- a/aten/src/ATen/native/cuda/Embedding.cu
+++ b/aten/src/ATen/native/cuda/Embedding.cu
@@ -274,6 +274,13 @@ Tensor embedding_dense_backward_cuda(const Tensor & grad_, const Tensor & indice
   auto grad = grad_.contiguous().view({num_indices, grad_.size(-1)});
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
+  // With zero embedding width (or no rows) there is nothing to accumulate and
+  // the gradient is empty; launching the backward kernels would dereference a
+  // null data_ptr of the empty gradient (gh-189668).
+  if (num_weights == 0 || grad_.size(-1) == 0) {
+    return at::zeros({num_weights, grad_.size(-1)}, grad_.options());
+  }
+
   if (num_indices <= 3072 && !scale_grad_by_freq) {
     auto indices_contig = indices.contiguous();
     auto grad_weight = at::zeros({num_weights, grad_.size(-1)}, grad_.options());

--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -357,6 +357,17 @@ class TestEmbeddingNNDeviceType(NNTestCase):
                 compiled(x, float_indices)
 
     @dtypesIfCUDA(torch.float16, torch.float64)
+    @dtypes(torch.float32)
+    def test_embedding_dense_backward_zero_width(self, device, dtype):
+        # Dense embedding backward with zero embedding width must not launch a
+        # kernel over the empty gradient and read a null pointer (gh-189668);
+        # the gradient is simply an empty tensor of the weight's shape.
+        weight = torch.zeros(10, 0, device=device, dtype=dtype, requires_grad=True)
+        idx = torch.zeros(3, dtype=torch.long, device=device)
+        torch.nn.functional.embedding(idx, weight).sum().backward()
+        self.assertEqual(weight.grad.shape, weight.shape)
+        self.assertEqual(weight.grad, torch.zeros_like(weight))
+
     @dtypesIfXPU(torch.float16, torch.float64)
     @dtypes(torch.float64)
     def test_embedding_backward(self, device, dtype):


### PR DESCRIPTION
Fixes #189668

### Root cause
`embedding_dense_backward_cuda` forms `grad_weight` as
`{num_weights, grad_.size(-1)}` and launches `embedding_backward_feature_kernel`
(or the sort-based path) over it. With zero embedding width (e.g. a `(10, 0)`
weight) the gradient is empty, its `data_ptr` is null, and the kernel does a
null `__global__` read. `compute-sanitizer` on a Tesla T4:

```
Invalid __global__ read of size 4 bytes
  at embedding_backward_feature_kernel<float, float, long>(...)
  Address 0x0 is out of bounds
```

### Fix
When there are no rows or no columns there is nothing to accumulate, so return
the correctly-shaped zero gradient before launching any kernel. Covers both
backward paths.

### Test
```
python test/nn/test_embedding.py -k test_embedding_dense_backward_zero_width
```
Draft: CI runs the CUDA build + test.
