### PR TITLE
[llvm21] caffe2/test: fix clang21 build + test failures exposed by llvm-fb 21

### DIFF
--- a/test/profiler/test_cpp_thread.cpp
+++ b/test/profiler/test_cpp_thread.cpp
@@ -1,5 +1,6 @@
 
 #include <torch/csrc/autograd/profiler_kineto.h>  // @manual
+#include <torch/csrc/utils/pybind.h>
 #include <torch/torch.h>
 #include <string>
 

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -1094,6 +1094,11 @@ class TestTensorCreation(TestCase):
         elif dtype == torch.int16:
             # CPU min and max float -> int16 conversion is divergent.
             vals = (-2, -1.5, -.5, 0, .5, 1.5, 2)
+        elif dtype == torch.int8:
+            # CPU min and max float -> int8 conversion is divergent under clang-21
+            # (out-of-range float->int is UB; codegen differs from numpy's
+            # reference). Drop the out-of-range extremes, mirroring int16 above.
+            vals = (-2, -1.5, -.5, 0, .5, 1.5, 2)
 
         self._float_to_int_conversion_helper(vals, device, dtype, refs)
 


### PR DESCRIPTION
Summary:
Newer clang (clang-21) surfaces two issues in caffe2/test:

1. `profiler/test_cpp_thread.cpp` fails to compile: the `PYBIND11_OVERRIDE` / `PYBIND11_MODULE` macros and the `py::` alias are undeclared because clang-21 no longer transitively includes pybind11 via `<torch/torch.h>`. Add the canonical `#include <torch/csrc/utils/pybind.h>`, which provides the `PYBIND11_*` macros and `namespace py = pybind11`. This is just a missing include exposed by the newer compiler, not a behavior change.

2. `test_tensor_creation_ops.py::test_float_to_int_conversion_finite_cpu_int8` fails: converting an out-of-range float to an integer is undefined behavior in C++, and clang-21 codegen diverges from numpy's reference for the min/max float -> int8 values. Add a CPU int8 case that excludes the out-of-range extremes, mirroring the existing int16 CPU-divergence case just above.

Test Plan:
- Build the `profiler/test_cpp_thread` target and confirm it compiles under clang-21.
- Run `test_tensor_creation_ops TestTensorCreationCPU.test_float_to_int_conversion_finite_cpu_int8` and confirm it passes.

Duplicate of #189613 (original author has not signed EasyCLA), re-authored so it can be landed.

Differential Revision: D111538402