### PR TITLE
Fix nightly lint-urls failures on dead and bot-blocked URLs

### DIFF
--- a/cmake/Modules/FindMAGMA.cmake
+++ b/cmake/Modules/FindMAGMA.cmake
@@ -1,7 +1,7 @@
 # - Find MAGMA library
 # This module finds an installed MAGMA library, a matrix algebra library
 # similar to LAPACK for GPU and multicore systems
-# (see http://icl.cs.utk.edu/magma/).
+# (see https://icl.utk.edu/magma/).
 #
 # This module will look for MAGMA library under /usr/local/magma by
 # default. To use a different installed version of the library set

--- a/docs/source/user_guide/torch_compiler/torch.compiler_performance_dashboard.md
+++ b/docs/source/user_guide/torch_compiler/torch.compiler_performance_dashboard.md
@@ -2,7 +2,7 @@
 
 **Author:** [Bin Bao](https://github.com/desertfire) and [Huy Do](https://github.com/huydhn)
 
-PyTorch 2.0's performance is tracked nightly on this [dashboard](https://hud.pytorch.org/benchmark/compilers).
+PyTorch 2.0's performance is tracked nightly on this [dashboard](https://hud.pytorch.org/benchmark/compilers). <!-- @lint-ignore hud.pytorch.org is live but its WAF blocks the URL linter -->
 The performance collection runs on 12 GCP A100 nodes every night. Each node contains a 40GB A100 Nvidia GPU and
 a 6-core 2.2GHz Intel Xeon CPU. The corresponding CI workflow file can be found
 [here](https://github.com/pytorch/pytorch/blob/main/.github/workflows/inductor-perf-test-nightly.yml).

--- a/functorch/dim/README.md
+++ b/functorch/dim/README.md
@@ -7,7 +7,7 @@ _An implementation of [named tensors](https://namedtensor.github.io) with the fu
 
 The tensor input to a resnet might have the shape [8, 3, 224, 224] but informally we think of those dimensions as 'batch', 'channel', 'width', and 'height'. Even though 'width' and 'height' have the same _size_ we still think of them as separate dimensions, and if we have two _different_ images, we think of both as sharing the _same_ 'channel' dimension.
 
-Named tensors gives these dimensions names. [PyTorch's current implementation](https://pytorch.org/docs/stable/named_tensor.html) uses strings to name dimensions. Instead, this library introduces a Python object, a `Dim`, to represent the concept. By expanding the semantics of tensors with dim objects, in addition to naming dimensions, we can get behavior equivalent to batching transforms (xmap, vmap), einops-style rearrangement, and loop-style tensor indexing.
+Named tensors gives these dimensions names. [PyTorch's current implementation](https://docs.pytorch.org/docs/2.8/named_tensor.html) uses strings to name dimensions. Instead, this library introduces a Python object, a `Dim`, to represent the concept. By expanding the semantics of tensors with dim objects, in addition to naming dimensions, we can get behavior equivalent to batching transforms (xmap, vmap), einops-style rearrangement, and loop-style tensor indexing.
 
 A preview:
 
@@ -84,7 +84,7 @@ from torchdim import dims
 batch, channel, width, height = dims(4)
 ```
 
-The existing implementation of [Named Tensors](https://pytorch.org/docs/stable/named_tensor.html) in PyTorch, or [JAX's xmap](https://jax.readthedocs.io/en/latest/notebooks/xmap_tutorial.html) use strings to name dimensions. We call these dimensions _first class_ because they are Python objects.
+The existing implementation of [Named Tensors](https://docs.pytorch.org/docs/2.8/named_tensor.html) in PyTorch, or [JAX's xmap](https://jax.readthedocs.io/en/latest/notebooks/xmap_tutorial.html) use strings to name dimensions. We call these dimensions _first class_ because they are Python objects.
 
 In addition to the normal _positional_ dimensions in a tensor, tensors can also have a separate set of first-class dimensions.
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #189444
* __->__ #189718

The nightly Link checks / lint-urls job was failing on three URLs that
the 403/429/503 WAF carve-out (added in #188510) does not cover: two
returned 000 (no HTTP response) and one returned 404.

- cmake/Modules/FindMAGMA.cmake: the MAGMA homepage moved from
  http://icl.cs.utk.edu/magma/ (dead, 000) to https://icl.utk.edu/magma/.
- functorch/dim/README.md: pytorch.org/docs/stable/named_tensor.html now
  404s because named tensors and its doc were removed in #173895. Pin the
  reference to docs.pytorch.org/docs/2.8/named_tensor.html, the last
  release that still serves the page.
- torch.compiler_performance_dashboard.md: hud.pytorch.org is live but its
  WAF drops the linter's connection (000), so annotate the line with
  @lint-ignore, matching how bot-protected hosts are handled.

Test Plan:
lintrunner passed on the three changed files. Verified each replacement
URL returns 200 and the originals fail (000/404) via curl with the same
user agent the linter uses. The nightly lint-urls job exercises the
end-to-end check.

Authored with Claude.