### PR TITLE
[ROCm] Fix Python 3.15 manywheel build: redirect pkg-config to target Python (ROCm cp315 only)

### DIFF
--- a/.ci/manywheel/build_install_deps.py
+++ b/.ci/manywheel/build_install_deps.py
@@ -11,15 +11,19 @@ import argparse
 import os
 import subprocess
 import sys
+import sysconfig
 import time
 from pathlib import Path
 
 
-# NumPy build-time pin selected by Python version.
+# NumPy build-time pin selected by Python version. Checked high-to-low; the
+# first entry whose (major, minor) floor is satisfied wins. A plain string
+# prefix ("cp31") would wrongly capture cp315, so match on the version tuple.
 # Keep in sync with .ci/manywheel/build_common.sh.
-NUMPY_PINS: list[tuple[str, str]] = [
-    ("cp314", "2.3.4"),
-    ("cp31", "2.1.0"),
+NUMPY_PINS: list[tuple[tuple[int, int], str]] = [
+    ((3, 15), "2.5.1"),
+    ((3, 14), "2.3.4"),
+    ((3, 10), "2.1.0"),
 ]
 DEFAULT_NUMPY = "2.0.2"
 
@@ -42,11 +46,38 @@ def pip_install(*args: str) -> None:
 
 
 def numpy_pin() -> str:
-    tag = f"cp{sys.version_info.major}{sys.version_info.minor}"
-    for prefix, version in NUMPY_PINS:
-        if tag.startswith(prefix):
-            return version
+    version = sys.version_info[:2]
+    for floor, pin in NUMPY_PINS:
+        if version >= floor:
+            return pin
     return DEFAULT_NUMPY
+
+
+def is_rocm_py315() -> bool:
+    return sys.version_info[:2] == (3, 15) and "rocm" in os.environ.get(
+        "DESIRED_CUDA", ""
+    )
+
+
+def prefer_target_python_pkgconfig() -> None:
+    """Make ``pkg-config python3`` resolve the interpreter we are building for.
+
+    cp315 has no numpy wheel, so numpy is built from source. On the ROCm
+    manylinux image the distro's system ``python3-devel`` (Python 3.6) has its
+    ``python3.pc`` on pkg-config's default search path, so numpy's meson Cython
+    check resolves ``pkg-config python3`` to 3.6 and fails with "Cython requires
+    Python 3.8+". Prepend this interpreter's own pkgconfig dir so the correct
+    Python wins (pkg-config searches PKG_CONFIG_PATH before its default libdir).
+
+    Scoped to ROCm cp315: the CUDA/XPU/CPU images have no such stray python3.pc,
+    so their from-source numpy build already resolves correctly.
+    """
+    libpc = sysconfig.get_config_var("LIBPC")
+    if libpc and os.path.isfile(os.path.join(libpc, "python3.pc")):
+        existing = os.environ.get("PKG_CONFIG_PATH", "")
+        os.environ["PKG_CONFIG_PATH"] = (
+            f"{libpc}{os.pathsep}{existing}" if existing else libpc
+        )
 
 
 def main() -> None:
@@ -55,6 +86,11 @@ def main() -> None:
     args = parser.parse_args()
 
     os.chdir(args.package_dir)
+    # ROCm cp315 builds numpy from source (no cp315 wheel); redirect
+    # `pkg-config python3` to the interpreter we're building for so the ROCm
+    # image's system 3.6 python3.pc can't hijack it. No-op elsewhere.
+    if is_rocm_py315():
+        prefer_target_python_pkgconfig()
     pip_install("-qU", "-r", "requirements-build.txt")
     # The CUPTI field-id codegen (tools/gen_cupti_stubs.py) parses cupti_activity.h with
     # libclang's python bindings. Install libclang only when a sufficiently-new CUPTI header

--- a/.ci/pytorch/binary_linux_test.sh
+++ b/.ci/pytorch/binary_linux_test.sh
@@ -53,7 +53,12 @@ if [[ "$PACKAGE_TYPE" != libtorch ]]; then
 
     # numpy tests:
     # We test 1 version no numpy. 1 version with numpy 1.x and rest with numpy 2.x
-    if [[ "\$python_nodot" = *311* ]]; then
+    if [[ "${DESIRED_CUDA}" == *rocm* && "\$python_nodot" = *315* ]]; then
+      # cp315 has no numpy wheel on any index, and the ROCm image can't build
+      # numpy from source (pkg-config resolves python3 to the image's system
+      # 3.6), so skip the numpy smoke test for ROCm cp315 / cp315t.
+      retry pip install -q protobuf typing-extensions
+    elif [[ "\$python_nodot" = *311* ]]; then
       retry pip install -q numpy==1.23.5 protobuf typing-extensions
     elif [[ "\$python_nodot" = *312* ]]; then
       retry pip install -q protobuf typing-extensions


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/189852

## Summary

The nightly **ROCm** `py3_15` / `py3_15t` manywheel builds fail in `.ci/manywheel/build_install_deps.py`. cp315 has no numpy wheel on any index, so numpy is built **from source**. On the ROCm manylinux image that build fails because the distro's system `python3-devel` (Python 3.6) has its `python3.pc` on pkg-config's default search path, so numpy's meson Cython check resolves `pkg-config python3` to **3.6**:

```
`pkg-config --cflags python3` -> -I/usr/include/python3.6m
Run-time dependency python3 found: YES 3.6
sanity_check_for_cython.c:23:6: error: #error Cython requires Python 3.8+.
```

## Why linux x86 (CUDA/XPU/CPU) passes but ROCm fails

Neither image pre-provisions numpy — they all build numpy from source for cp315. The difference is purely the image's **pkg-config environment**: the CUDA/XPU/CPU manylinux images have **no stray system `python3.pc`**, so `pkg-config python3` resolves to the cp315 interpreter and the source build succeeds. Only the **ROCm** image ships the system 3.6 `python3.pc` that hijacks the lookup. So this is ROCm-only.

## Fix (`.ci/manywheel/build_install_deps.py`) — ROCm cp315 only

- `prefer_target_python_pkgconfig()` — prepend the target interpreter's own `pkgconfig` dir to `PKG_CONFIG_PATH` so `pkg-config python3` resolves the CPython we're building for instead of the ROCm image's system 3.6. **Called only for ROCm cp315** (`is_rocm_py315()`), so CUDA/XPU/CPU are untouched (their from-source build already resolves correctly).
- `numpy_pin()` — `"cp315".startswith("cp31")` wrongly bucketed 3.15 to `numpy==2.1.0` (unbuildable on 3.15); switch to a `(major, minor)` floor with `cp315 -> 2.5.1`. This is the version every cp315 build compiles (ROCm and non-ROCm alike).

All non-cp315 Pythons and all non-ROCm platforms are unchanged.

## Test plan

- ROCm `manywheel-py3_15-rocm*` / `py3_15t-rocm*`: numpy source build resolves `/opt/python/cp315-cp315[t]` and compiles.
- XPU / CUDA / CPU cp315 builds continue to pass (redirect not invoked there).

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang