### PR TITLE
[c10][cuda] Guard noexcept device-guard methods against std::terminate on a sticky GPU error (#189725)

### DIFF
--- a/c10/cuda/impl/CUDAGuardImpl.h
+++ b/c10/cuda/impl/CUDAGuardImpl.h
@@ -58,7 +58,18 @@ struct CUDAGuardImpl final : public c10::impl::DeviceGuardImplInterface {
     C10_CUDA_CHECK(c10::cuda::SetDevice(d.index()));
   }
   void uncheckedSetDevice(Device d) const noexcept override {
-    C10_CUDA_CHECK_WARN(c10::cuda::MaybeSetDevice(d.index()));
+    // noexcept, but MaybeSetDevice() -> SetDevice() can throw via
+    // C10_CUDA_CHECK(cudaGetDevice) on a device carrying a sticky error, and
+    // the throw escapes while evaluating the argument, before
+    // C10_CUDA_CHECK_WARN can demote it. Catch it so a device restore warns
+    // instead of std::terminate.
+    try {
+      C10_CUDA_CHECK_WARN(c10::cuda::MaybeSetDevice(d.index()));
+    } catch (const std::exception& e) {
+      TORCH_WARN("uncheckedSetDevice() ignoring error: ", e.what());
+    } catch (...) {
+      TORCH_WARN("uncheckedSetDevice() ignoring unknown error");
+    }
   }
   Stream getStream(Device d) const override {
     return getCurrentCUDAStream(d.index()).unwrap();
@@ -115,17 +126,28 @@ struct CUDAGuardImpl final : public c10::impl::DeviceGuardImplInterface {
       const noexcept override {
     if (!event)
       return;
-    auto cuda_event = static_cast<cudaEvent_t>(event);
-    DeviceIndex orig_device{-1};
-    C10_CUDA_CHECK_WARN(c10::cuda::GetDevice(&orig_device));
-    C10_CUDA_CHECK_WARN(c10::cuda::SetDevice(device_index));
-    const c10::impl::PyInterpreter* interp = c10::impl::GPUTrace::get_trace();
-    if (C10_UNLIKELY(interp)) {
-      (*interp)->trace_gpu_event_deletion(
-          c10::kCUDA, reinterpret_cast<uintptr_t>(cuda_event));
+    // noexcept: SetDevice() can throw on a device carrying a sticky error (see
+    // uncheckedSetDevice), and SetDevice(orig_device) can also throw via
+    // TORCH_CHECK(device >= 0) if the GetDevice above failed and left
+    // orig_device == -1. Guard the whole body so we warn instead of
+    // terminating.
+    try {
+      auto cuda_event = static_cast<cudaEvent_t>(event);
+      DeviceIndex orig_device{-1};
+      C10_CUDA_CHECK_WARN(c10::cuda::GetDevice(&orig_device));
+      C10_CUDA_CHECK_WARN(c10::cuda::SetDevice(device_index));
+      const c10::impl::PyInterpreter* interp = c10::impl::GPUTrace::get_trace();
+      if (C10_UNLIKELY(interp)) {
+        (*interp)->trace_gpu_event_deletion(
+            c10::kCUDA, reinterpret_cast<uintptr_t>(cuda_event));
+      }
+      C10_CUDA_CHECK_WARN(cudaEventDestroy(cuda_event));
+      C10_CUDA_CHECK_WARN(c10::cuda::SetDevice(orig_device));
+    } catch (const std::exception& e) {
+      TORCH_WARN("destroyEvent() ignoring error: ", e.what());
+    } catch (...) {
+      TORCH_WARN("destroyEvent() ignoring unknown error");
     }
-    C10_CUDA_CHECK_WARN(cudaEventDestroy(cuda_event));
-    C10_CUDA_CHECK_WARN(c10::cuda::SetDevice(orig_device));
   }
 
   void record(

--- a/c10/cuda/test/impl/CUDATest.cpp
+++ b/c10/cuda/test/impl/CUDATest.cpp
@@ -1,9 +1,28 @@
 #include <gtest/gtest.h>
 
+#include <c10/core/Device.h>
+#include <c10/core/DeviceType.h>
+#include <c10/cuda/impl/CUDAGuardImpl.h>
 #include <c10/cuda/impl/CUDATest.h>
 
 using namespace c10::cuda::impl;
 
 TEST(CUDATest, SmokeTest) {
   c10_cuda_test();
+}
+
+// Regression: the device-guard restore path is noexcept, but internally
+// MaybeSetDevice() -> SetDevice() can throw -- via TORCH_CHECK(device >= 0) on
+// the pre-CUDA-12 / HIP path (a pure host check), or via
+// C10_CUDA_CHECK(cudaGetDevice) on a device carrying a sticky error. A leaked
+// throw from a noexcept method calls std::terminate. A negative device index
+// deterministically hits the TORCH_CHECK throw where MaybeSetDevice routes to
+// SetDevice, so uncheckedSetDevice must swallow it (warn) instead of
+// terminating -- if it regresses, this process aborts. On the CUDA-12 branch
+// MaybeSetDevice short-circuits for an invalid index, so this is a benign
+// no-op there.
+TEST(CUDAGuardImplTest, UncheckedSetDeviceSwallowsErrorAndDoesNotTerminate) {
+  CUDAGuardImpl impl;
+  EXPECT_NO_THROW(
+      impl.uncheckedSetDevice(c10::Device(c10::DeviceType::CUDA, -1)));
 }


### PR DESCRIPTION
Summary:

`CUDAGuardImpl::uncheckedSetDevice` and `destroyEvent` are declared `noexcept` and use `C10_CUDA_CHECK_WARN`, which is meant to warn rather than throw — a device-guard restore must never throw. But the argument they pass, `c10::cuda::MaybeSetDevice(...)` / `c10::cuda::SetDevice(...)`, can itself throw: `SetDevice` runs `C10_CUDA_CHECK(cudaGetDevice(&cur_device))`, and on a device that already carries a sticky error (e.g. a prior kernel `hipErrorLaunchFailure` / `cudaErrorLaunchFailure`), `cudaGetDevice` returns that sticky error, so `C10_CUDA_CHECK` throws a `c10::AcceleratorError` while the argument is being evaluated — before `C10_CUDA_CHECK_WARN` can demote it to a warning. That exception escapes the `noexcept` method, and the runtime calls `std::terminate`.

In production this shows up as an op's device-guard destructor (e.g. the AOTInductor `mm` op, or an output `.to()` / `copy_`) calling `uncheckedSetDevice` on scope exit on an already-poisoned device; two GPU worker threads hitting it concurrently produce `terminate called recursively` and an immediate `abort()`, which bypasses the normal exception-handling and error-logging paths (so the offending request that would otherwise be captured is lost).

Fix: wrap the bodies of the two `noexcept` methods in `try { ... } catch (const std::exception& e) { TORCH_WARN(...); }`, so a failed device restore warns instead of terminating. This matches the intended best-effort semantics and lets the sticky error resurface at the next checked op, where it is catchable, instead of aborting the process. The happy path is unchanged: when nothing throws, `C10_CUDA_CHECK_WARN` behaves exactly as before and the `catch` is inert.

`destroyEvent` is guarded as a whole because it has a second throw source as well: `SetDevice(orig_device)` where `orig_device` can be `-1` when the preceding `GetDevice` failed, which throws via `TORCH_CHECK(device >= 0)`.

Alternative considered and rejected as the sole fix: making `c10::cuda::SetDevice` return the `cudaGetDevice` error instead of throwing (every checked caller already wraps it in `C10_CUDA_CHECK`). That leaves `destroyEvent`'s `-1` / `TORCH_CHECK` path exposed and silently changes one unwrapped `MaybeSetDevice` caller (`scatter_cuda.cu`) from throwing to swallowing. Guarding the `noexcept` boundary is comprehensive and lower-risk.

Test Plan: Added CUDAGuardImplTest.UncheckedSetDeviceSwallowsErrorAndDoesNotTerminate (caffe2/c10/cuda/test/impl/CUDATest.cpp): calls uncheckedSetDevice(Device(kCUDA, -1)). On the pre-CUDA-12 / HIP path MaybeSetDevice(-1) -> SetDevice(-1) hits TORCH_CHECK(device >= 0), a host-side throw; with the fix the noexcept guard swallows it and warns so the test passes, and if the fix regresses the leaked throw escapes the noexcept method and aborts the test process. On the CUDA-12 branch MaybeSetDevice short-circuits for an invalid index so the case is a benign no-op there; full coverage of the sticky cudaGetDevice path still needs a poisoned-device death test (follow-up). CI builds and runs the c10 cuda test suite.

Reviewed By: atalman

Differential Revision: D111596208


