### PR TITLE
[inductor][rocm] Skip HIP reduction-loop pipelining for indirect-load kernels

### DIFF
--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -3236,6 +3236,10 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         self.per_subkernel_blocks: bool = per_subkernel_blocks
         super().__init__(tiling, **kwargs)
         self.cse = TritonCSE(self.newvar_prefix, self.suffix)
+        # Set when this kernel emits an indirect-indexed (e.g. index_select)
+        # load. Used to skip HIP reduction-loop software pipelining, whose AMD
+        # make_ttgir pass crashes on pipelined loops with indirect loads.
+        self._has_indirect_load: bool = False
         # Cache of values that can be reused for the prologue.
         self.prologue_cache: dict[str, str] = {}
         self.prologue: IndentedBuffer = IndentedBuffer()
@@ -4551,6 +4555,8 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         load_counts[name] += 1
         make_line: Callable[[str], str | DelayReplaceLine] = identity
         indirect_indexing = self.is_indirect_indexing(index)
+        if indirect_indexing:
+            self._has_indirect_load = True
         original_index = index
         dtype = V.graph.get_dtype(name)
         uses_uint8_storage = use_uint8_triton_storage_for_cuda_float8_e4m3fn(dtype, var)
@@ -6367,8 +6373,17 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                         "rsplit_end" if self.cooperative_reduction else f"{prefix}numel"
                     )
                     # Conditionalize pipelining on HIP for Triton due to
-                    # reports of numerical inaccuracies on older Triton
-                    if torch.version.hip and get_triton_version() > (3, 2):
+                    # reports of numerical inaccuracies on older Triton. Skip it
+                    # only for kernels with an indirect (index_select) load: the
+                    # AMD make_ttgir pipeliner crashes on pipelined reduction
+                    # loops containing indirect loads. Other reductions keep
+                    # num_stages=2. The config is a master override.
+                    if (
+                        torch.version.hip
+                        and get_triton_version() > (3, 2)
+                        and config.triton.hip_reduction_loop_pipelining
+                        and not self._has_indirect_load
+                    ):
                         num_stages = ", num_stages = 2"
                     else:
                         num_stages = ""

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2089,6 +2089,14 @@ class triton:
     # used for debugging cooperative reduction codegen, always generate cooperative_reductions
     force_cooperative_reductions = False
 
+    # On HIP/ROCm (Triton > 3.2) the reduction loop is software-pipelined with
+    # `tl.range(..., num_stages=2)`. This can crash the AMD backend `make_ttgir`
+    # PassManager for reduction loops containing indirect (index_select) loads.
+    # Set False to disable the pipelining (no num_stages on the reduction loop).
+    hip_reduction_loop_pipelining = (
+        os.environ.get("TORCHINDUCTOR_HIP_REDUCTION_LOOP_PIPELINING", "1") == "1"
+    )
+
     # Lower/upper bounds between two-step variance and Welford variance for
     # non-split CUDA Triton half/bfloat16 reductions. Mid-sized reductions use
     # two-step for throughput; smaller reductions keep the old heuristic because


### PR DESCRIPTION
Summary:
On HIP/ROCm with Triton > 3.2, Inductor software-pipelines the reduction loop by emitting `tl.range(..., num_stages=2)` (added for numerical reasons on newer Triton). When that reduction loop contains an indirect (`index_select`) load, the AMD Triton backend crashes during `make_ttgir`: `triton/backends/amd/compiler.py make_ttgir -> RuntimeError: PassManager::run failed`. This blocks AOTInductor lowering of several Ads merge-net models (e.g. HIM CMF `ads_mtml_adfinder_heavyweight_ctr_facebook_model`, the IG/CMF VM models) whose fused RMSNorm/conv reductions carry an `index_select` (feature broadcast) inside the reduction — they fail in autotuning with `LoweringStageException` regardless of lowering config.

This makes the pipelining surgical: `TritonKernel` now tracks `_has_indirect_load` (set when it emits an indirect-indexed load), and the reduction loop emits `num_stages=2` only when the kernel has no indirect load. Normal reductions keep pipelining unchanged (no perf change); only the exact crashing pattern (reduction loop + indirect load) drops it. A new config `triton.hip_reduction_loop_pipelining` (default True; env `TORCHINDUCTOR_HIP_REDUCTION_LOOP_PIPELINING`) is a master override.

Co-authored with Claude Code.

Test Plan: HIM CMF (`ads_mtml_adfinder_heavyweight_ctr_facebook_model`, 1078000097), MI350x gfx950, ROCm 7.0.2.1, optimized+gbf config, AOTInductor lowering + mts_gpu_bench. Before this change: `make_ttgir` / `PassManager::run failed` during autotuning (22 occurrences), lowering aborts, no QPS. After: lowers cleanly (zero make_ttgir crashes) and benchmarks — T=2 14.7 ms / 69,709 QPS. Normal reductions are unaffected (num_stages=2 still emitted when the kernel has no indirect load).

Differential Revision: D108428507




cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben