### PR TITLE
[inductor][overlap] Disable simple_overlap by default

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1231,7 +1231,7 @@ class aten_distributed_optimizations:
     #   - No collective reordering (preserves NCCL stream ordering)
     #   - No memory regression (each move verified individually)
     #   - Predictable (no runtime estimation, no heuristics)
-    enable_simple_overlap: bool = True
+    enable_simple_overlap: bool = False
 
     # Enable overlap scheduling pass
     enable_overlap_scheduling: bool = False


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #189729

Addressing:

https://github.com/meta-pytorch/torchcomms/pull/3095

https://github.com/pytorch/pytorch/issues/189454

Simple_overlap preserves ordering only of CollectiveKernel. 
Custom_ops can have collectives too. 
Disabling temporary to not result in hangs, will be enabled after the fix.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo