### PR TITLE
 ROCm CK FMHA: gate the tile-tail OOB stopgap to gfx950 to fix MI300X QPS regression (#189730) (#189730)

### DIFF
--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_fwd_ck.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_fwd_ck.hip
@@ -3,6 +3,7 @@
  ******************************************************************************/
 
 #include <ATen/native/transformers/hip/flash_attn/flash_common_hip.hpp>
+#include <ATen/detail/CUDAHooksInterface.h>
 #include <fmha_fwd.hpp>
 #include <mask.hpp>
 
@@ -422,8 +423,8 @@ mha_fwd_ck(const at::Tensor &q,                      // batch_size x seqlen_q x 
     // Hand the kernel seqlen-padded *allocations* (the extra rows are mapped
     // scratch) while leaving seqlen_q/seqlen_k unchanged, so the kernel's logical
     // masking is identical and numerics are unchanged; the real rows are copied
-    // back into the caller-visible tensors below. Engages only for tile-unaligned
-    // seqlens on the non-swapped path; skipped when seqlenq_ngroups_swapped is
+    // back into the caller-visible tensors below. Engages only on gfx950 (MI350X)
+    // for tile-unaligned seqlens on the non-swapped path; skipped when seqlenq_ngroups_swapped is
     // active (that fast path reshapes seqlen_q into the batch/group dim, so the
     // tile-tail over-read does not apply).
     // Scope: covers Q/K/V (read) and O/LSE (write) only. attn_bias (bias_ptr,
@@ -438,8 +439,13 @@ mha_fwd_ck(const at::Tensor &q,                      // batch_size x seqlen_q x 
     constexpr int kCkSeqTileLCM = 256; // >= every fwd kM0/kN0 in the generated set
     const int seqlen_q_pad = round_multiple(seqlen_q, kCkSeqTileLCM);
     const int seqlen_k_pad = round_multiple(seqlen_k, kCkSeqTileLCM);
+    // Restrict to gfx950 (MI350X): the only arch observed to fault on the tile-
+    // tail over-read. Elsewhere (e.g. gfx942/MI300X) the pad+copy is pure
+    // overhead with no fault to avoid. Placed last so isGPUArch is evaluated only
+    // for the rare tile-unaligned non-swapped shapes.
     const bool ck_oob_guard = !seqlenq_ngroups_swapped &&
-        ((seqlen_q_pad != seqlen_q) || (seqlen_k_pad != seqlen_k));
+        ((seqlen_q_pad != seqlen_q) || (seqlen_k_pad != seqlen_k)) &&
+        at::detail::getCUDAHooks().isGPUArch({"gfx950"});
     if (ck_oob_guard) {
         if (seqlen_q_pad != seqlen_q) {
             q_arg   = at::pad(q_padded, {0, 0, 0, 0, 0, seqlen_q_pad - seqlen_q});


### PR DESCRIPTION
Summary:
D108370469 added a host-side stopgap in `mha_fwd_ck.hip` that pads Q/K/V/O/LSE seqlen allocations up to `kCkSeqTileLCM` (256) and copies the results back, to work around a gfx950 (MI350X) memory-access fault on tile-unaligned attention shapes. The guard had no architecture gate, so it also engaged on gfx942 (MI300X), which never exhibited the fault.

Root cause of the regression: on every FMHA call with tile-unaligned seqlens the stopgap does ~5 extra HBM allocations (Q/K/V pad + O/LSE scratch) plus ~5 full-tensor copies (3 pad-in, 2 copy-back). With OBA OC shapes (e.g. seqlen_q=4 -> 256 is a 64x row amplification) this compounds into a ~17-19% e2e QPS regression, confirmed by bisection to the single commit and reproduced on both ROCm 6.2.1 and 7.0.

Fix: restrict `ck_oob_guard` to gfx950 via `at::detail::getCUDAHooks().isGPUArch({"gfx950"})` (the canonical arch check used elsewhere in ATen). It is the last `&&` operand, so `isGPUArch` is evaluated only for the rare tile-unaligned non-swapped shapes. On gfx942 the guard is now always false, so `q_arg/k_arg/v_arg` stay bound to `q_padded/k_padded/v_padded` and no copy-back runs -- bit-identical to pre-D108370469 behavior and the fast path is fully restored. gfx950 behavior is unchanged, so the OOB fault fix is preserved.

Alternatives considered: (2) also lowering `kCkSeqTileLCM` to the true gfx950 tile size to shrink the MI350X amplification, and (3) upstreaming CK `kPadSeqLen` fwd instances and removing the host stopgap entirely. Both are complementary follow-ups; this diff takes the minimal, zero-risk-for-MI300X arch gate.

Applied identically to the `fbcode/` and `xplat/` copies.

Authored with the assistance of an AI coding assistant (Claude Code).


Test Plan:
`arc lint` on both changed files: clean.

```
$ arc lint fbcode/.../ck/mha_fwd_ck.hip xplat/.../ck/mha_fwd_ck.hip
ok No lint issues.
```

cc jeffdaily sunway513 jithunnair-amd pruthvistony ROCmSupport jataylo hongxiayang naromero77amd pragupta jerrymannil xinyazhang

Reviewed By: xw285cornell

Differential Revision: D111745062

Pulled By: goldcoderZ




cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang