### PR TITLE
[XCCL] Fix test_monitored_barrier_allreduce_hang test for xccl backend

### DIFF
--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -8902,7 +8902,8 @@ class DistributedTest:
                 # wrapper PG is enabled or not, since with wrapper pg, it will
                 # fail in a collective synchronization check and not actually
                 # call into the nccl pg.
-                if dist.get_debug_level() == dist.DebugLevel.DETAIL:
+                # xccl backend throws 'Timed out waiting' error
+                if dist.get_debug_level() == dist.DebugLevel.DETAIL or BACKEND = "xccl":
                     err_regex = "Timed out waiting"
                 else:
                     err_regex = "caught collective operation timeout"


### PR DESCRIPTION
This PR fixes the issues: https://github.com/intel/torch-xpu-ops/issues/2701; https://github.com/intel/torch-xpu-ops/issues/2702

The default XCCL runtime error message is same as the one under the `TORCH_DISTRIBUTED_DEBUG=DETAIL` flag. Adding the xccl option to the test to keep it clean. 