### PR TITLE
[ONNX] Run CUDA export verification tests on CUDAExecutionProvider

### DIFF
--- a/test/onnx/onnx_test_common.py
+++ b/test/onnx/onnx_test_common.py
@@ -85,7 +85,7 @@ class _TestONNXRuntime(pytorch_test_common.ExportTestCase):
     is_script = False
     check_shape = True
     check_dtype = True
-    # OnnxBackend override; None keeps the VerificationOptions default (ORT CPU).
+    # OnnxBackend override; None uses the VerificationOptions default backend.
     ort_backend: verification.OnnxBackend | None = None
 
     def setUp(self):

--- a/test/onnx/onnx_test_common.py
+++ b/test/onnx/onnx_test_common.py
@@ -53,6 +53,9 @@ def run_model_test(test_suite: _TestONNXRuntime, *args, **kwargs):
         options.check_shape = test_suite.check_shape
     if hasattr(test_suite, "check_dtype"):
         options.check_dtype = test_suite.check_dtype
+    ort_backend = getattr(test_suite, "ort_backend", None)
+    if ort_backend is not None:
+        options.backend = ort_backend
 
     names = {f.name for f in dataclasses.fields(options)}
     keywords_to_pop = []
@@ -82,6 +85,8 @@ class _TestONNXRuntime(pytorch_test_common.ExportTestCase):
     is_script = False
     check_shape = True
     check_dtype = True
+    # OnnxBackend override; None keeps the VerificationOptions default (ORT CPU).
+    ort_backend: verification.OnnxBackend | None = None
 
     def setUp(self):
         super().setUp()

--- a/test/onnx/onnx_test_common.py
+++ b/test/onnx/onnx_test_common.py
@@ -55,7 +55,7 @@ def run_model_test(test_suite: _TestONNXRuntime, *args, **kwargs):
         options.check_dtype = test_suite.check_dtype
     ort_backend = getattr(test_suite, "ort_backend", None)
     if ort_backend is not None:
-        options.backend = ort_backend
+        options.backend = verification.OnnxBackend(ort_backend)
 
     names = {f.name for f in dataclasses.fields(options)}
     keywords_to_pop = []
@@ -85,8 +85,9 @@ class _TestONNXRuntime(pytorch_test_common.ExportTestCase):
     is_script = False
     check_shape = True
     check_dtype = True
-    # OnnxBackend override; None uses the VerificationOptions default backend.
-    ort_backend: verification.OnnxBackend | None = None
+    # Optional ORT execution provider name; None uses the VerificationOptions
+    # default backend.
+    ort_backend: str | None = None
 
     def setUp(self):
         super().setUp()

--- a/test/onnx/test_pytorch_onnx_onnxruntime_cuda.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime_cuda.py
@@ -3,7 +3,7 @@
 import unittest
 
 import onnx_test_common
-import onnxruntime  # noqa: F401
+import onnxruntime
 import parameterized
 from onnx_test_common import MAX_ONNX_OPSET_VERSION, MIN_ONNX_OPSET_VERSION
 from pytorch_test_common import (
@@ -28,6 +28,14 @@ from torch.testing._internal import common_utils
 )
 class TestONNXRuntime_cuda(onnx_test_common._TestONNXRuntime):
     ort_backend = OnnxBackend.ONNX_RUNTIME_CUDA
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        if "CUDAExecutionProvider" not in onnxruntime.get_available_providers():
+            raise unittest.SkipTest(
+                "onnxruntime CUDAExecutionProvider is not available"
+            )
 
     @skipIfUnsupportedMinOpsetVersion(9)
     @skipIfNoCuda

--- a/test/onnx/test_pytorch_onnx_onnxruntime_cuda.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime_cuda.py
@@ -16,6 +16,7 @@ from test_pytorch_onnx_onnxruntime import _parameterized_class_attrs_and_values
 
 import torch
 from torch.cuda.amp import autocast
+from torch.onnx._internal.torchscript_exporter.verification import OnnxBackend
 from torch.testing._internal import common_utils
 
 
@@ -26,6 +27,8 @@ from torch.testing._internal import common_utils
     class_name_func=onnx_test_common.parameterize_class_name,
 )
 class TestONNXRuntime_cuda(onnx_test_common._TestONNXRuntime):
+    ort_backend = OnnxBackend.ONNX_RUNTIME_CUDA
+
     @skipIfUnsupportedMinOpsetVersion(9)
     @skipIfNoCuda
     def test_gelu_fp16(self):

--- a/test/onnx/test_pytorch_onnx_onnxruntime_cuda.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime_cuda.py
@@ -16,7 +16,6 @@ from test_pytorch_onnx_onnxruntime import _parameterized_class_attrs_and_values
 
 import torch
 from torch.cuda.amp import autocast
-from torch.onnx._internal.torchscript_exporter.verification import OnnxBackend
 from torch.testing._internal import common_utils
 
 
@@ -27,15 +26,13 @@ from torch.testing._internal import common_utils
     class_name_func=onnx_test_common.parameterize_class_name,
 )
 class TestONNXRuntime_cuda(onnx_test_common._TestONNXRuntime):
-    ort_backend = OnnxBackend.ONNX_RUNTIME_CUDA
+    ort_backend = "CUDAExecutionProvider"
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        if "CUDAExecutionProvider" not in onnxruntime.get_available_providers():
-            raise unittest.SkipTest(
-                "onnxruntime CUDAExecutionProvider is not available"
-            )
+        if cls.ort_backend not in onnxruntime.get_available_providers():
+            raise unittest.SkipTest(f"onnxruntime {cls.ort_backend} is not available")
 
     @skipIfUnsupportedMinOpsetVersion(9)
     @skipIfNoCuda


### PR DESCRIPTION
## Issue

Fixes #177952

## Summary

`run_model_test` in test/onnx/onnx_test_common.py always verified exports with the
default `VerificationOptions` backend (`CPUExecutionProvider`), which has no bfloat16
`Add`/`Sub`/`Mul` kernel, so `TestONNXRuntime_cuda::test_arithmetic_bfp16` failed with
`NOT_IMPLEMENTED : Could not find an implementation for Add(14)`. This adds an optional
`ort_backend` suite attribute (default `None`, keeping CPU for all existing suites) and
routes `TestONNXRuntime_cuda` to the already-supported `OnnxBackend.ONNX_RUNTIME_CUDA`.
Verified on an RTX 4050 (torch 2.12.1+cu126, onnxruntime-gpu 1.22.0):
`test_pytorch_onnx_onnxruntime_cuda.py -k test_arithmetic_bfp16` goes from
`FAILED (errors=32, skipped=20)` to `OK (skipped=20)`; the whole file runs
312 tests, `OK (skipped=138)`; `test_custom_ops.py` and `test_autograd_funs.py`
(the other `run_model_test` callers) still pass.

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable) — N/A, test-only change
- [ ] Included benchmark results (for PRs impacting perf) — N/A

## BC-breaking?

No. Test-only change; `ort_backend` defaults to `None`, so every existing suite keeps
the CPU execution provider.

cc @justinchuby @titaiwangms
