### PR TITLE
Fix `bmm_flop`/`addmm_flop`/`baddbmm_flop` crash on extra positional out arg

### DIFF
--- a/test/test_flop_counter.py
+++ b/test/test_flop_counter.py
@@ -890,6 +890,34 @@ class TestFlopCounter(TestCase):
 
         self.assertExpectedInline(get_total_flops(mode), """2000""")
 
+    def test_matmul_flop_formula_extra_positional_out(self):
+        # Regression test: Inductor's count_flops_fx can hand a matmul flop
+        # formula the output as an extra trailing positional arg, while
+        # shape_wrapper simultaneously passes out_shape by keyword.
+        # shape_wrapper strips the extra trailing positional before forwarding
+        # to the formula, preventing a TypeError collision on out_shape.
+        from torch.utils.flop_counter import flop_registry
+
+        # Mirrors FlopCounterMode._count_flops: f(*args, **kwargs, out_val=out),
+        # where args carries the output shape as a trailing positional.
+        a, b = (8, 128, 64), (8, 64, 32)
+        out = (8, 128, 32)
+        expected_bmm = 8 * 128 * 32 * 2 * 64
+        self.assertEqual(
+            flop_registry[torch.ops.aten.bmm](a, b, out, out_val=out), expected_bmm
+        )
+        self.assertEqual(
+            flop_registry[torch.ops.aten.baddbmm](out, a, b, out, out_val=out),
+            expected_bmm,
+        )
+
+        a2, b2 = (128, 64), (64, 32)
+        out2 = (128, 32)
+        self.assertEqual(
+            flop_registry[torch.ops.aten.addmm](out2, a2, b2, out2, out_val=out2),
+            128 * 32 * 2 * 64,
+        )
+
     def test_hook_registration(self):
         model = torch.nn.Linear(100, 100)
         x = torch.randn(3, 100)

--- a/torch/utils/flop_counter.py
+++ b/torch/utils/flop_counter.py
@@ -169,12 +169,12 @@ def mm_flop(a_shape, b_shape, *args, out_shape=None, **kwargs) -> int:
     return m * n * 2 * k
 
 @register_flop_formula(aten.addmm)
-def addmm_flop(self_shape, a_shape, b_shape, out_shape=None, **kwargs) -> int:
+def addmm_flop(self_shape, a_shape, b_shape, *args, **kwargs) -> int:
     """Count flops for addmm."""
     return mm_flop(a_shape, b_shape)
 
 @register_flop_formula(aten.bmm)
-def bmm_flop(a_shape, b_shape, out_shape=None, **kwargs) -> int:
+def bmm_flop(a_shape, b_shape, *args, **kwargs) -> int:
     """Count flops for the bmm operation."""
     # Inputs should be a list of length 2.
     # Inputs contains the shapes of two tensor.
@@ -189,7 +189,7 @@ def bmm_flop(a_shape, b_shape, out_shape=None, **kwargs) -> int:
     return flop
 
 @register_flop_formula(aten.baddbmm)
-def baddbmm_flop(self_shape, a_shape, b_shape, out_shape=None, **kwargs) -> int:
+def baddbmm_flop(self_shape, a_shape, b_shape, *args, **kwargs) -> int:
     """Count flops for the baddbmm operation."""
     # Inputs should be a list of length 3.
     # Inputs contains the shapes of three tensors.


### PR DESCRIPTION
Summary:
Inductor's scheduler estimates op cost via `count_flops_fx` (`torch/_inductor/fx_utils.py`), which runs the op inside `FlopCounterMode`. For a `.out`-variant matmul node, the output tensor is reconstructed as an extra trailing positional argument. `FlopCounterMode._count_flops` then invokes the registered formula as `flop_count_func(*args, **kwargs, out_val=out)`, and `shape_wrapper` additionally forwards the result as the `out_shape` keyword.

`bmm_flop`, `addmm_flop`, and `baddbmm_flop` declared `out_shape` as a positional-or-keyword parameter with no `*args` sponge, so the stray positional bound to `out_shape` and then the `out_shape=` keyword collided with it, raising `TypeError: bmm_flop() got multiple values for argument 'out_shape'` and failing the whole training compile (observed on MLHub flow f1111479288). `mm_flop` already had `*args` and was immune; the three siblings did not.

The fix gives all three formulas a `*args` sponge and drops the unused `out_shape` parameter. The stray trailing positional is now absorbed by `*args`, and the `out_shape=` keyword that `shape_wrapper` always forwards is harmlessly captured by `**kwargs` (none of these three formulas read `out_shape`). `shape_wrapper` itself is left unchanged.

Authored with the assistance of an AI coding agent (Claude Code).

Test Plan:
Added `test_matmul_flop_formula_extra_positional_out` to `caffe2/test/test_flop_counter.py`, which reproduces the exact `_count_flops` call shape (output passed as a trailing positional plus `out_val`) for `bmm`, `baddbmm`, and `addmm` and asserts the correct FLOP counts instead of a `TypeError`.

Verified by driving the real `flop_registry` with that call shape (bmm/baddbmm/addmm with the output as a trailing positional plus `out_val=`, and the normal keyword-only path) through a torch-enabled binary — all assertions pass:

```
ALL FLOP REGRESSION ASSERTIONS PASSED
```

Lint clean on all changed files:

```
arc lint fbcode/caffe2/torch/utils/flop_counter.py xplat/caffe2/torch/utils/flop_counter.py \
  fbcode/caffe2/test/test_flop_counter.py xplat/caffe2/test/test_flop_counter.py
ok No lint issues.
```

Differential Revision: D111658247
