### PR TITLE
Make test_dtensor device-generic

### DIFF
--- a/test/distributed/tensor/test_dtensor.py
+++ b/test/distributed/tensor/test_dtensor.py
@@ -1425,7 +1425,7 @@ class DTensorMeshTest(DTensorTestBase):
                 placements=None,
             )
 
-        x = make_dtensor(1, 1, dtype=torch.bfloat16, device="cuda")
+        x = make_dtensor(1, 1, dtype=torch.bfloat16, device=self.device_type)
 
         # Fails with AssertionError: P1972527564
         torch.cond(


### PR DESCRIPTION
## Summary
Replaces a hardcoded `device="cuda"` argument with `self.device_type` in `DTensorMeshTest.test_dtensor_cond`, making the test run on any accelerator backend (cuda, xpu, mps, etc.) rather than being locked to CUDA.

## Changes
- `device="cuda"` → `device=self.device_type` in `DTensorMeshTest.test_dtensor_cond` (line ~1428)

## Faithfulness
CPU test classes/paths are untouched, no test bodies removed, cuda behavior byte-identical; test/class parity preserved.

## Validation
Lint gate (flake8/ruff/pyfmt/TEST_DEVICE_BIAS) clean, py_compile clean; cuda/xpu legs run in CI.

## Note
Refactor prepared with AI assistance; authored and reviewed by @loganprosser.

Refs: #174469
cc @fffrog
