### PR TITLE
Make test_device_mesh device-generic

### DIFF
--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -99,7 +99,7 @@ class DeviceMeshTestGlooBackend(DTensorTestBase):
         mesh = init_device_mesh(self.device_type, (self.world_size,))
         mesh_group = mesh.get_group()
         default_group = _get_default_group()
-        if torch.cuda.is_available():
+        if torch.accelerator.is_available():
             self.assertNotEqual(mesh_group, default_group)
             self.assertEqual(get_world_size(mesh_group), get_world_size(default_group))
         else:


### PR DESCRIPTION
## Summary
Replaces the `torch.cuda.is_available()` availability check in `DeviceMeshTest` with the device-agnostic `torch.accelerator.is_available()`, allowing the test to run correctly on CUDA, XPU, and other accelerator backends without hard-coding CUDA.

## Changes
- `torch.cuda.is_available()` → `torch.accelerator.is_available()` in `DeviceMeshTest.test_device_mesh_get_group`

## Faithfulness
CPU test classes/paths are untouched, no test bodies removed, cuda behavior byte-identical; test/class parity preserved.

## Validation
Lint gate (flake8/ruff/pyfmt/TEST_DEVICE_BIAS) clean, py_compile clean; cuda/xpu legs run in CI.

## Note
Refactor prepared with AI assistance; authored and reviewed by @loganprosser.

Refs: #174469
cc @fffrog
