### PR TITLE
Make test_replicate_mixed_precision device-generic

### DIFF
--- a/test/distributed/_composable/test_replicate_mixed_precision.py
+++ b/test/distributed/_composable/test_replicate_mixed_precision.py
@@ -708,7 +708,7 @@ class TestReplicateMixedPrecisionCasts(FSDPTestMultiThread):
             torch.bfloat16, torch.bfloat16, torch.bfloat16, True
         )
         model = Model()
-        inp = Input(torch.randn(2, 10).cuda())
+        inp = Input(torch.randn(2, 10).to(device_type))
 
         replicate(model, mp_policy=mp_policy)
         loss = model(inp).sum()


### PR DESCRIPTION
## Summary
One residual `.cuda()` call in `TestReplicateMixedPrecisionCasts` was replaced with `.to(device_type)`, making the test fully device-generic via the existing `device_type` parametrization already present in the file.

## Changes
- `torch.randn(2, 10).cuda()` → `torch.randn(2, 10).to(device_type)` in `test_cast_input_to_param_dtype` (line 711)

## Faithfulness
CPU test classes/paths are untouched, no test bodies removed, cuda behavior byte-identical; test/class parity preserved.

## Validation
Lint gate (flake8/ruff/pyfmt/TEST_DEVICE_BIAS) clean, py_compile clean; cuda/xpu legs run in CI.

## Note
Refactor prepared with AI assistance; authored and reviewed by @loganprosser.

Refs: #174469
cc @fffrog
