### PR TITLE
Make test_pg_wrapper device-generic

### DIFF
--- a/test/distributed/test_pg_wrapper.py
+++ b/test/distributed/test_pg_wrapper.py
@@ -372,9 +372,9 @@ if not TEST_WITH_DEV_DBG_ASAN:
         @skip_if_lt_x_gpu(2)
         @with_dist_debug_levels(levels=["DETAIL"])
         def test_reduce_scatter_tensor_coalesced_debug_mode(self):
-            torch.cuda.set_device(self.rank)
+            torch.accelerator.set_device_index(self.rank)
             pg = self._create_wrapper_pg(with_new_group=True)
-            dev = torch.cuda.current_device()
+            dev = torch.accelerator.current_device_index()
 
             out_shapes = [(2, 2), (3, 3)]
             in_shapes = [(s[0] * self.world_size,) + s[1:] for s in out_shapes]


### PR DESCRIPTION
## Summary
Replaces two `torch.cuda` device-index calls inside `test_reduce_scatter_tensor_coalesced_debug_mode` with their `torch.accelerator` equivalents, making the test backend-agnostic.

## Changes
- `torch.cuda.set_device(self.rank)` → `torch.accelerator.set_device_index(self.rank)`
- `torch.cuda.current_device()` → `torch.accelerator.current_device_index()`

## Faithfulness
CPU test classes/paths are untouched, no test bodies removed, cuda behavior byte-identical; test/class parity preserved.

## Validation
Lint gate (flake8/ruff/pyfmt/TEST_DEVICE_BIAS) clean, py_compile clean; cuda/xpu legs run in CI.

## Note
Refactor prepared with AI assistance; authored and reviewed by @loganprosser.

Refs: #174469
cc @fffrog
