### PR TITLE
Make test_group_batch_fusion device-generic

### DIFF
--- a/test/inductor/test_group_batch_fusion.py
+++ b/test/inductor/test_group_batch_fusion.py
@@ -28,7 +28,7 @@ class _TestHighwaySelfGating(torch.nn.Module):
         self,
         d_model: int,
         size: int,
-        device="cuda",
+        device=GPU_TYPE,
     ) -> None:
         super().__init__()
         self.size = size
@@ -55,7 +55,7 @@ class _TestHighwaySelfGating(torch.nn.Module):
 
 
 class MyModule(torch.nn.Module):
-    def __init__(self, z: int, has_bias: bool, device="cuda") -> None:
+    def __init__(self, z: int, has_bias: bool, device=GPU_TYPE) -> None:
         super().__init__()
         self.z = z
         self.device = device


### PR DESCRIPTION
## Summary
Replaces two hardcoded `device="cuda"` default arguments in module `__init__` signatures with `GPU_TYPE` from `torch.testing._internal.inductor_utils`, making these modules (and the tests that exercise them) device-generic.

## Changes
- `device="cuda"` default in `_TestHighwaySelfGating.__init__` → `device=GPU_TYPE`
- `device="cuda"` default in `MyModule.__init__` → `device=GPU_TYPE`
- `GPU_TYPE` was already imported from `torch.testing._internal.inductor_utils`; no new import needed

## Faithfulness
CPU test classes/paths are untouched, no test bodies removed, cuda behavior byte-identical; test/class parity preserved.

## Validation
Lint gate (flake8/ruff/pyfmt/TEST_DEVICE_BIAS) clean, py_compile clean; cuda/xpu legs run in CI.

## Note
Refactor prepared with AI assistance; authored and reviewed by @loganprosser.

Refs: #174469
cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @fffrog
