### PR TITLE
Make test_fully_shard_state_dict device-generic

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_state_dict.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_state_dict.py
@@ -141,14 +141,14 @@ class TestFullyShardStateDictMultiProcess(FSDPTest):
             )
         else:
             model = model.cpu()
-            model = model.cuda()
+            model = model.to(device_type.type)
             self.assertTrue(
                 sd["weight"]._local_tensor.untyped_storage().data_ptr()
                 != model.weight._local_tensor.untyped_storage().data_ptr()
             )
 
         torch.manual_seed(42 + self.rank)
-        inp = torch.rand(mlp_dim, mlp_dim, device="cuda")
+        inp = torch.rand(mlp_dim, mlp_dim, device=device_type.type)
         for _ in range(5):
             optim.zero_grad()
             loss = model(inp).sum()


### PR DESCRIPTION
## Summary
Two residual hard-coded CUDA references in `TestFullyShardStateDictMultiProcess` are replaced with the existing `device_type` parametrization already used throughout the file.

## Changes
- `model.cuda()` → `model.to(device_type.type)` in `_test_dp_state_dict_save_load`
- `torch.rand(..., device="cuda")` → `torch.rand(..., device=device_type.type)` in the same method

## Faithfulness
CPU test classes/paths are untouched, no test bodies removed, cuda behavior byte-identical; test/class parity preserved.

## Validation
Lint gate (flake8/ruff/pyfmt/TEST_DEVICE_BIAS) clean, py_compile clean; cuda/xpu legs run in CI.

## Note
Refactor prepared with AI assistance; authored and reviewed by @loganprosser.

Refs: #174469
cc @fffrog
