### PR TITLE
Make test_package device-generic

### DIFF
--- a/test/dynamo/test_package.py
+++ b/test/dynamo/test_package.py
@@ -24,6 +24,7 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_TORCHDYNAMO,
 )
 from torch.testing._internal.inductor_utils import (
+    GPU_TYPE,
     HAS_CUDA_AND_TRITON,
     HAS_XPU_AND_TRITON,
 )
@@ -89,7 +90,7 @@ class TestPackage(torch._inductor.test_case.TestCase):
         class MyModule(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.linear = torch.nn.Linear(10, 10, device="cuda")
+                self.linear = torch.nn.Linear(10, 10, device=GPU_TYPE)
 
             def forward(self, x):
                 return self.linear(x)
@@ -97,7 +98,7 @@ class TestPackage(torch._inductor.test_case.TestCase):
         fn = MyModule()
         package = CompilePackage(fn.forward)
         compiled_fn = torch._dynamo.optimize("inductor", package=package)(fn)
-        x = torch.randn(10, 10, device="cuda")
+        x = torch.randn(10, 10, device=GPU_TYPE)
         compiled_fn(x)
 
     @parametrize("backend", ("eager", "inductor"))


### PR DESCRIPTION
## Summary
Replaces hard-coded `device="cuda"` tensor/module construction in `test/dynamo/test_package.py` with the `GPU_TYPE` variable from `inductor_utils`, making the test portable across GPU backends.

## Changes
- Import `GPU_TYPE` from `torch.testing._internal.inductor_utils`
- `torch.nn.Linear(..., device="cuda")` → `torch.nn.Linear(..., device=GPU_TYPE)`
- `torch.randn(..., device="cuda")` → `torch.randn(..., device=GPU_TYPE)`

## Faithfulness
CPU test classes/paths are untouched, no test bodies removed, cuda behavior byte-identical; test/class parity preserved.

## Validation
Lint gate (flake8/ruff/pyfmt/TEST_DEVICE_BIAS) clean, py_compile clean; cuda/xpu legs run in CI.

## Note
Refactor prepared with AI assistance; authored and reviewed by @loganprosser.

Refs: #174469
cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @fffrog
