### PR TITLE
Make test_serialization device-generic

### DIFF
--- a/test/distributed/test_serialization.py
+++ b/test/distributed/test_serialization.py
@@ -4,12 +4,13 @@ import os
 import pickle
 from io import BytesIO
 from typing import cast
+from unittest import skipIf
 
 import torch
 import torch.distributed as dist
 from torch.distributed._serialization import _streaming_load, _streaming_save
 from torch.distributed.tensor import DeviceMesh, distribute_tensor, DTensor
-from torch.testing._internal.common_utils import requires_cuda, run_tests, TestCase
+from torch.testing._internal.common_utils import run_tests, TEST_ACCELERATOR, TestCase
 
 
 DEBUG_ENV = "TORCH_SERIALIZATION_DEBUG"
@@ -164,9 +165,9 @@ class TestSerialization(TestCase):
         with self.assertRaisesRegex(RuntimeError, "explicit pickle_module"):
             _streaming_load(file, weights_only=True, pickle_module=pickle)
 
-    @requires_cuda
+    @skipIf(not TEST_ACCELERATOR, "requires accelerator")
     def test_cuda(self) -> None:
-        device = torch.device("cuda:0")
+        device = torch.device(f"{torch.accelerator.current_accelerator().type}:0")
 
         tensor = torch.tensor(42, dtype=torch.float, device=device)
         state_dict = {"scalar": tensor}


### PR DESCRIPTION
## Summary
Generalizes `test/distributed/test_serialization.py` from hard-coded `cuda` to a device-parametrized form using `torch.accelerator.current_accelerator()` and the `TEST_ACCELERATOR` guard.

## Changes
- `from torch.testing._internal.common_utils import requires_cuda` → `TEST_ACCELERATOR` (import updated)
- Added `from unittest import skipIf`
- `@requires_cuda` decorator on `test_cuda` → `@skipIf(not TEST_ACCELERATOR, "requires accelerator")`
- `device = torch.device("cuda:0")` → `device = torch.device(f"{torch.accelerator.current_accelerator().type}:0")`

## Faithfulness
CPU test classes/paths are untouched, no test bodies removed, cuda behavior byte-identical; test/class parity preserved.

## Validation
Lint gate (flake8/ruff/pyfmt/TEST_DEVICE_BIAS) clean, py_compile clean; cuda/xpu legs run in CI.

## Note
Refactor prepared with AI assistance; authored and reviewed by @loganprosser.

Refs: #174469
cc @fffrog
