### PR TITLE
Make test_fused_attention device-generic

### DIFF
--- a/test/inductor/test_fused_attention.py
+++ b/test/inductor/test_fused_attention.py
@@ -1839,7 +1839,7 @@ if HAS_XPU_AND_TRITON or (HAS_CUDA_AND_TRITON and PLATFORM_SUPPORTS_FUSED_ATTENT
             test_sdpa_rewriter_16_fp32_mask_gpu = functools.partialmethod(
                 TestSDPAPatternRewriterTemplate._test_sdpa_rewriter_16_fp32_mask
             )
-        elif GPU_TYPE == "cuda":
+        elif GPU_TYPE in ("cuda", "xpu"):
             test_sdpa_rewriter_16_inference_gpu = functools.partialmethod(
                 TestSDPAPatternRewriterTemplate._test_sdpa_rewriter_16,
                 check_train=False,


### PR DESCRIPTION
## Summary
Generalizes a CUDA-only guard in `test_fused_attention.py` to also cover XPU, enabling the `test_sdpa_rewriter_16_inference_gpu` test variant to run on Intel XPU accelerators in addition to CUDA.

## Changes
- `GPU_TYPE == "cuda"` → `GPU_TYPE in ("cuda", "xpu")` for the `test_sdpa_rewriter_16_inference_gpu` conditional, aligning with the existing ROCm branch and making the guard device-inclusive rather than CUDA-only

## Faithfulness
CPU test classes/paths are untouched, no test bodies removed, cuda behavior byte-identical; test/class parity preserved.

## Validation
Lint gate (flake8/ruff/pyfmt/TEST_DEVICE_BIAS) clean, py_compile clean; cuda/xpu legs run in CI.

## Note
Refactor prepared with AI assistance; authored and reviewed by @loganprosser.

Refs: #174469
cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @fffrog
