### PR TITLE
Make test_dtensor_dispatch_overhead device-generic

### DIFF
--- a/test/distributed/tensor/test_dtensor_dispatch_overhead.py
+++ b/test/distributed/tensor/test_dtensor_dispatch_overhead.py
@@ -69,19 +69,14 @@ class DistOpDispatchOverHead(DTensorTestBase):
     @skip_if_lt_x_gpu(4)
     @with_comms
     def test_dtensor_add_op_dispatch_overhead(self):
-        if torch.cuda.is_available():
-            device_props = torch.cuda.get_device_name(0)
-            gpu_name = device_props
-            logger.info("running on %s", gpu_name)
-            # TODO: adjust `expected_propagate_time` and `expected_dispatch_time` to target different hardware
-        else:
-            self.skipTest("CUDA not available")
+        # TODO: adjust `expected_propagate_time` and `expected_dispatch_time` to target different hardware
+        logger.info("running on %s", self.device_type)
         expected_propagate_time = 880  # noqa: F841
         expected_dispatch_time = 90  # noqa: F841
         diff_percent_threshold = 0.20  # noqa: F841
         propagator = DTensor._op_dispatcher.sharding_propagator
-        device_mesh = init_device_mesh("cuda", (self.world_size,))
-        input_data = torch.rand(512, 512, device="cuda")
+        device_mesh = init_device_mesh(self.device_type, (self.world_size,))
+        input_data = torch.rand(512, 512, device=self.device_type)
         a = distribute_tensor(input_data, device_mesh, [Shard(0)])
         # warm up
         with TimeCaptureMode() as tcm:


### PR DESCRIPTION
## Summary

Makes `test/distributed/tensor/test_dtensor_dispatch_overhead.py` device-generic so it runs on any supported accelerator (CUDA, XPU, MPS) rather than being hard-coded to CUDA.

Part of the broader device-generic test migration tracked in RFC #174469. /cc @fffrog

## Changes

- Remove manual `torch.cuda.is_available()` guard / `skipTest` inside `test_dtensor_add_op_dispatch_overhead` — device availability is now handled by the `instantiate_device_type_tests` machinery
- Replace `"cuda"` string literal in `init_device_mesh` and `torch.rand` calls with `self.device_type`
- Replace `logger.info` string to reference `self.device_type` instead of a hardcoded backend name

## Faithfulness

- All CPU-path code is untouched
- No test bodies removed or simplified — the timing-threshold comment and all test logic are preserved
- Test count: 1 → 1 (unchanged); class count: 2 → 2 (unchanged)
- CUDA behaviour is preserved: when running on a CUDA system `self.device_type == "cuda"` and the test is identical to the original

## Validation

- `py_compile` clean
- Lint gate (TEST_DEVICE_BIAS) clean — no residual `"cuda"` literals in device-selection positions
- CUDA and XPU legs will be exercised by upstream CI

## Note

Refactor prepared with AI assistance; authored and reviewed by @loganprosser.
