### PR TITLE
Make test_graph_transform_observer device-generic

### DIFF
--- a/test/inductor/test_graph_transform_observer.py
+++ b/test/inductor/test_graph_transform_observer.py
@@ -11,7 +11,7 @@ import torch._inductor.config as inductor_config
 from torch._inductor.test_case import run_tests, TestCase
 from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FUSED_ATTENTION
 from torch.testing._internal.common_utils import IS_LINUX
-from torch.testing._internal.inductor_utils import HAS_CUDA_AND_TRITON
+from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
 
 
 try:
@@ -28,10 +28,7 @@ HAS_DOT = shutil.which("dot") is not None
 class TestGraphTransformObserver(TestCase):
     def test_sdpa_rewriter(self):
         if not (
-            HAS_CUDA_AND_TRITON
-            and PLATFORM_SUPPORTS_FUSED_ATTENTION
-            and HAS_PYDOT
-            and HAS_DOT
+            HAS_GPU and PLATFORM_SUPPORTS_FUSED_ATTENTION and HAS_PYDOT and HAS_DOT
         ):
             return
 
@@ -52,9 +49,9 @@ class TestGraphTransformObserver(TestCase):
         compiled_fn = torch.compile(dot_prod_attention, fullgraph=True)
 
         tensor_shape = (4, 2, 16, 32)
-        q = torch.randn(tensor_shape, device="cuda")
-        k = torch.randn(tensor_shape, device="cuda")
-        v = torch.randn(tensor_shape, device="cuda")
+        q = torch.randn(tensor_shape, device=GPU_TYPE)
+        k = torch.randn(tensor_shape, device=GPU_TYPE)
+        v = torch.randn(tensor_shape, device=GPU_TYPE)
         compiled_fn(q, k, v)
 
         found_input_svg = False


### PR DESCRIPTION
## Summary

Makes `test/inductor/test_graph_transform_observer.py` device-generic so it runs on any supported accelerator (CUDA, XPU, MPS) rather than being hard-coded to CUDA.

Part of the broader device-generic test migration tracked in RFC #174469. /cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @fffrog

## Changes

- Replace `HAS_CUDA_AND_TRITON` import with `GPU_TYPE, HAS_GPU` from `inductor_utils`
- Replace `HAS_CUDA_AND_TRITON` skip guard in `test_sdpa_rewriter` with `HAS_GPU`
- Replace three `device="cuda"` literals in `test_sdpa_rewriter` with `device=GPU_TYPE`

## Faithfulness

- All CPU-path code is untouched
- No test bodies removed or simplified — `test_sdpa_rewriter` logic is identical except device substitution
- Test count: 1 → 1 (unchanged); class count: 1 → 1 (unchanged)
- CUDA behaviour is preserved: when running on a CUDA system `GPU_TYPE == "cuda"` and `HAS_GPU == HAS_CUDA_AND_TRITON` (for CUDA systems)

## Validation

- `py_compile` clean
- Lint gate (TEST_DEVICE_BIAS) clean — no residual `"cuda"` literals in device-selection positions
- CUDA and XPU legs will be exercised by upstream CI

## Note

Refactor prepared with AI assistance; authored and reviewed by @loganprosser.
