### PR TITLE
Make test_symm_mem_registry device-generic

### DIFF
--- a/test/inductor/test_symm_mem_registry.py
+++ b/test/inductor/test_symm_mem_registry.py
@@ -14,7 +14,7 @@ import torch
 from torch._library.simple_registry import singleton, SymmMemArgsHolder
 from torch.library import Library  # noqa: SCOPED_LIBRARY
 from torch.testing._internal.common_utils import run_tests, TestCase
-from torch.testing._internal.inductor_utils import HAS_CUDA_AND_TRITON
+from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
 
 
 def register_symm_mem_args(op, arg_names):
@@ -238,7 +238,7 @@ class TestFunctionalOpCompile(TestCase):
         torch._dynamo.reset()
         super().tearDown()
 
-    @unittest.skipIf(not HAS_CUDA_AND_TRITON, "Requires CUDA and Triton")
+    @unittest.skipIf(not HAS_GPU, "Requires GPU and Triton")
     def test_functional_op_compiles_with_symm_mem_args(self):
         """Test that a functional op with registered symm_mem_args compiles and runs."""
         lib = Library("test_func_symm", "DEF")  # noqa: SCOPED_LIBRARY
@@ -249,7 +249,7 @@ class TestFunctionalOpCompile(TestCase):
         def meta_impl(input, group_name):
             return torch.empty_like(input)
 
-        @torch.library.impl(lib, "my_functional_op", "CUDA")
+        @torch.library.impl(lib, "my_functional_op", GPU_TYPE.upper())
         def cuda_impl(input, group_name):
             return input + 1.0
 
@@ -260,7 +260,7 @@ class TestFunctionalOpCompile(TestCase):
         def f_compiled(x):
             return torch.ops.test_func_symm.my_functional_op(x, "test_group")
 
-        x = torch.randn(4, 4, device="cuda")
+        x = torch.randn(4, 4, device=GPU_TYPE)
 
         eager_result = f_eager(x.clone())
         compiled_result = f_compiled(x.clone())
@@ -275,7 +275,7 @@ class TestFunctionalOpCompile(TestCase):
         self.assertTrue(entry.symm_mem_args.is_symm_mem_arg("input"))
         self.assertFalse(entry.symm_mem_args.is_symm_mem_arg("group_name"))
 
-    @unittest.skipIf(not HAS_CUDA_AND_TRITON, "Requires CUDA and Triton")
+    @unittest.skipIf(not HAS_GPU, "Requires GPU and Triton")
     def test_functional_op_with_multiple_symm_mem_args(self):
         """Test that multiple symm_mem args are registered and visible during compilation."""
         lib = Library("test_func_multi", "DEF")  # noqa: SCOPED_LIBRARY
@@ -288,7 +288,7 @@ class TestFunctionalOpCompile(TestCase):
         def meta_impl(input, out, group_name):
             return torch.empty_like(input)
 
-        @torch.library.impl(lib, "my_multi_arg_op", "CUDA")
+        @torch.library.impl(lib, "my_multi_arg_op", GPU_TYPE.upper())
         def cuda_impl(input, out, group_name):
             # use both symm_mem args to verify functionality
             return input + out
@@ -300,8 +300,8 @@ class TestFunctionalOpCompile(TestCase):
         def f_compiled(x, y):
             return torch.ops.test_func_multi.my_multi_arg_op(x, y, "test_group")
 
-        x = torch.randn(4, 4, device="cuda")
-        y = torch.randn(4, 4, device="cuda")
+        x = torch.randn(4, 4, device=GPU_TYPE)
+        y = torch.randn(4, 4, device=GPU_TYPE)
 
         eager_result = f_eager(x.clone(), y.clone())
         compiled_result = f_compiled(x.clone(), y.clone())


### PR DESCRIPTION
## Summary

Makes `test/inductor/test_symm_mem_registry.py` device-generic so it runs on any supported accelerator (CUDA, XPU, MPS) rather than being hard-coded to CUDA.

Part of the broader device-generic test migration tracked in RFC #174469. /cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @fffrog

## Changes

- Replace `HAS_CUDA_AND_TRITON` import with `GPU_TYPE, HAS_GPU` from `inductor_utils`
- Replace two `@unittest.skipIf(not HAS_CUDA_AND_TRITON, ...)` decorators with `HAS_GPU`
- Replace `"CUDA"` dispatch key string in two `@torch.library.impl` decorators with `GPU_TYPE.upper()` (correct: `get_gpu_type()` returns lowercase `"cuda"`/`"xpu"`, `.upper()` produces valid dispatch key strings)
- Replace four `device="cuda"` literals with `device=GPU_TYPE`

## Faithfulness

- All CPU-path code is untouched
- No test bodies removed or simplified — all 19 test methods are preserved verbatim except device substitutions
- Test count: 19 → 19 (unchanged); class count: 3 → 3 (unchanged)
- CUDA behaviour is preserved: on CUDA systems `GPU_TYPE == "cuda"`, `GPU_TYPE.upper() == "CUDA"`, and all skip conditions are equivalent

## Validation

- `py_compile` clean
- Lint gate (TEST_DEVICE_BIAS) clean — no residual `"cuda"` literals in device-selection positions
- CUDA and XPU legs will be exercised by upstream CI

## Note

Refactor prepared with AI assistance; authored and reviewed by @loganprosser.
