### PR TITLE
Make test_overlap_bucketing_unit device-generic

### DIFF
--- a/test/distributed/test_overlap_bucketing_unit.py
+++ b/test/distributed/test_overlap_bucketing_unit.py
@@ -116,7 +116,7 @@ class TestOverlapPreservingBucketing(InductorTestCase):
 
         store = FakeStore()
         dist.init_process_group(backend="fake", rank=0, world_size=2, store=store)
-        cls.device = "cuda"
+        cls.device = device_type
 
     @classmethod
     def tearDownClass(cls):
@@ -1143,7 +1143,7 @@ class TestCrossPGOverlap(InductorTestCase):
 
         store = FakeStore()
         dist.init_process_group(backend="fake", rank=0, world_size=2, store=store)
-        cls.device = "cuda"
+        cls.device = device_type
 
         # Create two separate process groups for cross-PG testing
         cls.pg1 = dist.new_group(ranks=[0, 1])
@@ -1392,7 +1392,7 @@ class TestFusibleNodeOverlap(InductorTestCase):
 
         store = FakeStore()
         dist.init_process_group(backend="fake", rank=0, world_size=2, store=store)
-        cls.device = "cuda"
+        cls.device = device_type
 
     @classmethod
     def tearDownClass(cls):
@@ -1563,7 +1563,7 @@ class TestOverlapSchedulingFixes(InductorTestCase):
 
         store = FakeStore()
         dist.init_process_group(backend="fake", rank=0, world_size=16, store=store)
-        cls.device = "cuda"
+        cls.device = device_type
 
     @classmethod
     def tearDownClass(cls):
@@ -1874,9 +1874,9 @@ class TestForeachGroupsUnit(InductorTestCase):
             _pre_bucket_all_gather,
         )
 
-        t1 = torch.randn(10, device="cuda")
-        t2 = torch.randn(20, device="cuda", dtype=torch.float16)
-        t3 = torch.randn(10, device="cuda")
+        t1 = torch.randn(10, device=device_type)
+        t2 = torch.randn(20, device=device_type, dtype=torch.float16)
+        t3 = torch.randn(10, device=device_type)
         ag_ins = [t1, t2, t3]
         out_dtypes = [torch.float32, torch.float16, torch.float32]
         out_dtype_ints = [_ALL_DTYPES.index(d) for d in out_dtypes]
@@ -2167,7 +2167,7 @@ class TestCoalescedCollectiveOverlap(InductorTestCase):
 
         store = FakeStore()
         dist.init_process_group(backend="fake", rank=0, world_size=8, store=store)
-        cls.device = "cuda"
+        cls.device = device_type
 
     @classmethod
     def tearDownClass(cls):
@@ -2326,7 +2326,7 @@ class TestProfileGuidedEstimatorIntegration(InductorTestCase):
 
         store = FakeStore()
         dist.init_process_group(backend="fake", rank=0, world_size=2, store=store)
-        cls.device = "cuda"
+        cls.device = device_type
 
     @classmethod
     def tearDownClass(cls):
@@ -2412,7 +2412,7 @@ class TestPreBucketingFsdpCollectives(InductorTestCase):
 
         store = FakeStore()
         dist.init_process_group(backend="fake", rank=0, world_size=64, store=store)
-        cls.device = "cuda"
+        cls.device = device_type
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
## Summary

Makes `test/distributed/test_overlap_bucketing_unit.py` device-generic so it runs on any supported accelerator (CUDA, XPU, MPS) rather than being hard-coded to CUDA.

Part of the broader device-generic test migration tracked in RFC #174469. /cc @fffrog

## Changes

- Replace `cls.device = "cuda"` with `cls.device = device_type` in 7 `setUpClass` methods (using the pre-existing module-level `device_type = get_devtype().type` variable)
- Replace 3 `device="cuda"` literals in tensor constructors with `device=device_type`

## Faithfulness

- All CPU-path code is untouched
- No test bodies removed or simplified — all 43 test methods are preserved verbatim except device substitutions
- Test count: 43 → 43 (unchanged); class count: 11 → 11 (unchanged)
- CUDA behaviour is preserved: on CUDA systems `device_type == "cuda"` and all tensor operations are identical

## Validation

- `py_compile` clean
- Lint gate (TEST_DEVICE_BIAS) clean — no residual `"cuda"` literals in device-selection positions
- CUDA and XPU legs will be exercised by upstream CI

## Note

Refactor prepared with AI assistance; authored and reviewed by @loganprosser.
