### PR TITLE
Make test_control_deps device-generic

### DIFF
--- a/test/inductor/test_control_deps.py
+++ b/test/inductor/test_control_deps.py
@@ -10,13 +10,14 @@ from torch.testing import FileCheck
 from torch.testing._internal.common_utils import IS_LINUX
 from torch.testing._internal.inductor_utils import (
     GPU_TYPE,
-    HAS_CUDA_AND_TRITON,
     HAS_GPU_AND_TRITON,
     requires_gpu,
 )
 
 
-requires_cuda_triton = unittest.skipUnless(HAS_CUDA_AND_TRITON, "requires CUDA")
+requires_cuda_triton = unittest.skipUnless(
+    HAS_GPU_AND_TRITON, "requires GPU and triton"
+)
 
 
 class TestControlDeps(InductorTestCase):
@@ -662,25 +663,25 @@ class TestControlDeps(InductorTestCase):
         from torch._inductor.utils import run_and_get_code
 
         def fn(x):
-            s1 = torch.cuda.Stream()
-            s2 = torch.cuda.Stream()
-            event_s1 = torch.cuda.Event()
-            event_s2 = torch.cuda.Event()
-            with torch.cuda.stream(s1):
+            s1 = torch.Stream(device=GPU_TYPE)
+            s2 = torch.Stream(device=GPU_TYPE)
+            event_s1 = torch.Event()
+            event_s2 = torch.Event()
+            with s1:
                 a = x * 2
                 event_s1.record(s1)
-            with torch.cuda.stream(s2):
+            with s2:
                 event_s1.wait(s2)
                 b = a + 1
                 event_s2.record(s2)
-            with torch.cuda.stream(s1):
+            with s1:
                 event_s2.wait(s1)
                 c = b * 2
             s1.synchronize()
             s2.synchronize()
             return c
 
-        x = torch.randn(1024, device="cuda")
+        x = torch.randn(1024, device=GPU_TYPE)
         expected = fn(x)
         result, _ = run_and_get_code(torch.compile(fn), x)
         self.assertEqual(result, expected)


### PR DESCRIPTION
## Summary

Makes `test/inductor/test_control_deps.py` device-generic so it runs on any supported accelerator (CUDA, XPU, MPS) rather than being hard-coded to CUDA.

Part of the broader device-generic test migration tracked in RFC #174469. /cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @fffrog

## Changes

- Replace `HAS_CUDA_AND_TRITON` / `requires_cuda_triton` imports with `HAS_GPU_AND_TRITON` equivalent
- Replace `requires_cuda_triton` skip guard at module level with `HAS_GPU_AND_TRITON`
- In one test function body: replace `torch.cuda.Stream(...)` / `torch.cuda.Event()` / `torch.cuda.stream(...)` with device-generic `torch.Stream(device=GPU_TYPE)` / `torch.Event()` / `with s1:`
- Replace `device="cuda"` literals with `device=GPU_TYPE`

## Faithfulness

- All CPU-path code is untouched
- No test bodies removed or simplified — all 11 test methods are preserved verbatim except device substitutions
- Test count: 11 → 11 (unchanged); class count: 1 → 1 (unchanged)
- CUDA behaviour is preserved: on CUDA systems `GPU_TYPE == "cuda"` and all stream/event semantics are identical

## Validation

- `py_compile` clean
- Lint gate (TEST_DEVICE_BIAS) clean — no residual `"cuda"` literals in device-selection positions
- CUDA and XPU legs will be exercised by upstream CI

## Note

Refactor prepared with AI assistance; authored and reviewed by @loganprosser.
