### PR TITLE
Gate nvmath _foreach_mm path on cuBLASLt grouped GEMM version

### DIFF
--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -2161,6 +2161,13 @@ class TestForeachMM(TestCase):
         name_fn=lambda label, shapes: label,
     )
     def test_foreach_mm_nvmath(self, label, shapes):
+        from torch._native.ops.foreach_mm.impl import _check_nvmath_cublaslt
+
+        if not _check_nvmath_cublaslt():
+            self.skipTest(
+                "cuBLASLt grouped GEMM unavailable (nvmath present but "
+                "cublasLtGroupedMatrixLayoutCreate missing)"
+            )
         self._check(shapes, torch.bfloat16, "cuda")
 
 

--- a/torch/_native/ops/foreach_mm/impl.py
+++ b/torch/_native/ops/foreach_mm/impl.py
@@ -35,8 +35,7 @@ Notes:
 """
 
 import warnings
-from functools import cache
-from typing import Literal
+from typing import Literal, Optional
 
 import torch
 
@@ -50,10 +49,46 @@ _NVMATH_DEPS = [
     ("nvmath-python", "nvmath.bindings"),
 ]
 
+# Probe result cache: None = not yet probed. Availability is a process-global
+# property of the loaded cuBLASLt, so it is resolved once and reused.
+_nvmath_available: Optional[bool] = None
 
-@cache
+
+def _probe_grouped_matrix_layout() -> bool:
+    """True iff the loaded cuBLASLt exposes cublasLtGroupedMatrixLayoutCreate.
+
+    nvmath resolves cuBLASLt symbols lazily, so on toolkits that predate grouped
+    GEMM the missing entrypoint only surfaces as a FunctionNotFoundError when the
+    kernel runs. Probe once with a minimal valid 1-group layout (valid device
+    pointers, so it is safe when the symbol exists); only a missing-symbol error
+    means unavailable -- any other error implies the entrypoint is present.
+    """
+    if not torch.cuda.is_available():
+        return False
+    try:
+        from cuda.bindings.runtime import cudaDataType
+        from nvmath.bindings import cublasLt
+    except Exception:
+        return False
+    dims = torch.ones(1, dtype=torch.int32, device="cuda")
+    p = dims.data_ptr()
+    try:
+        layout = cublasLt.grouped_matrix_layout_create(
+            cudaDataType.CUDA_R_16BF, 1, p, p, p
+        )
+    except Exception as e:
+        return type(e).__name__ != "FunctionNotFoundError"
+    cublasLt.matrix_layout_destroy(layout)
+    return True
+
+
 def _check_nvmath_cublaslt() -> bool:
-    return _unavailable_reason(_NVMATH_DEPS) is None
+    global _nvmath_available
+    if _nvmath_available is None:
+        _nvmath_available = (
+            _unavailable_reason(_NVMATH_DEPS) is None and _probe_grouped_matrix_layout()
+        )
+    return _nvmath_available
 
 
 def _k_n_16_byte_aligned(a: torch.Tensor, b: torch.Tensor, elem_size: int) -> bool:
@@ -218,7 +253,10 @@ def _warn_nvmath_unavailable_once() -> None:
     if _nvmath_warned:
         return
     _nvmath_warned = True
-    reason = _unavailable_reason(_NVMATH_DEPS)
+    reason = (
+        _unavailable_reason(_NVMATH_DEPS)
+        or "cuBLASLt lacks cublasLtGroupedMatrixLayoutCreate"
+    )
     warnings.warn(
         f"_foreach_mm: nvmath cublasLt grouped GEMM unavailable ({reason}), "
         f"using slower fallback.",

--- a/torch/_native/ops/foreach_mm/impl.py
+++ b/torch/_native/ops/foreach_mm/impl.py
@@ -49,46 +49,32 @@ _NVMATH_DEPS = [
     ("nvmath-python", "nvmath.bindings"),
 ]
 
-# Probe result cache: None = not yet probed. Availability is a process-global
-# property of the loaded cuBLASLt, so it is resolved once and reused.
+# cublasLtGroupedMatrixLayoutCreate, used by the nvmath grouped GEMM path, was
+# introduced in cuBLAS 13.2.0 (CUDA 13.1) and is experimental as of that release.
+# cublasLtGetVersion() encodes the version as 10000*major + 100*minor + patch.
+# This is the cuBLAS library version, not the CUDA toolkit version.
+_MIN_CUBLASLT_GROUPED_GEMM_VERSION = 130200
+
+# Availability is a process-global property of the loaded cuBLASLt; resolve once.
 _nvmath_available: bool | None = None
-
-
-def _probe_grouped_matrix_layout() -> bool:
-    """True iff the loaded cuBLASLt exposes cublasLtGroupedMatrixLayoutCreate.
-
-    nvmath resolves cuBLASLt symbols lazily, so on toolkits that predate grouped
-    GEMM the missing entrypoint only surfaces as a FunctionNotFoundError when the
-    kernel runs. Probe once with a minimal valid 1-group layout (valid device
-    pointers, so it is safe when the symbol exists); only a missing-symbol error
-    means unavailable -- any other error implies the entrypoint is present.
-    """
-    if not torch.cuda.is_available():
-        return False
-    try:
-        from cuda.bindings import runtime  # pyrefly: ignore[missing-import]
-        from nvmath.bindings import cublasLt  # pyrefly: ignore[missing-import]
-    except Exception:
-        return False
-    dims = torch.ones(1, dtype=torch.int32, device="cuda")
-    p = dims.data_ptr()
-    try:
-        layout = cublasLt.grouped_matrix_layout_create(
-            runtime.cudaDataType.CUDA_R_16BF, 1, p, p, p
-        )
-    except Exception as e:
-        return type(e).__name__ != "FunctionNotFoundError"
-    cublasLt.matrix_layout_destroy(layout)
-    return True
 
 
 def _check_nvmath_cublaslt() -> bool:
     global _nvmath_available
     if _nvmath_available is None:
-        _nvmath_available = (
-            _unavailable_reason(_NVMATH_DEPS) is None and _probe_grouped_matrix_layout()
-        )
+        _nvmath_available = _nvmath_grouped_gemm_available()
     return _nvmath_available
+
+
+def _nvmath_grouped_gemm_available() -> bool:
+    if _unavailable_reason(_NVMATH_DEPS) is not None:
+        return False
+    try:
+        from nvmath.bindings import cublasLt  # pyrefly: ignore[missing-import]
+
+        return cublasLt.get_version() >= _MIN_CUBLASLT_GROUPED_GEMM_VERSION
+    except Exception:
+        return False
 
 
 def _k_n_16_byte_aligned(a: torch.Tensor, b: torch.Tensor, elem_size: int) -> bool:

--- a/torch/_native/ops/foreach_mm/impl.py
+++ b/torch/_native/ops/foreach_mm/impl.py
@@ -35,7 +35,7 @@ Notes:
 """
 
 import warnings
-from typing import Literal, Optional
+from typing import Literal
 
 import torch
 
@@ -51,7 +51,7 @@ _NVMATH_DEPS = [
 
 # Probe result cache: None = not yet probed. Availability is a process-global
 # property of the loaded cuBLASLt, so it is resolved once and reused.
-_nvmath_available: Optional[bool] = None
+_nvmath_available: bool | None = None
 
 
 def _probe_grouped_matrix_layout() -> bool:
@@ -66,15 +66,15 @@ def _probe_grouped_matrix_layout() -> bool:
     if not torch.cuda.is_available():
         return False
     try:
-        from cuda.bindings.runtime import cudaDataType
-        from nvmath.bindings import cublasLt
+        from cuda.bindings import runtime  # pyrefly: ignore[missing-import]
+        from nvmath.bindings import cublasLt  # pyrefly: ignore[missing-import]
     except Exception:
         return False
     dims = torch.ones(1, dtype=torch.int32, device="cuda")
     p = dims.data_ptr()
     try:
         layout = cublasLt.grouped_matrix_layout_create(
-            cudaDataType.CUDA_R_16BF, 1, p, p, p
+            runtime.cudaDataType.CUDA_R_16BF, 1, p, p, p
         )
     except Exception as e:
         return type(e).__name__ != "FunctionNotFoundError"

--- a/torch/_native/ops/foreach_mm/impl.py
+++ b/torch/_native/ops/foreach_mm/impl.py
@@ -35,6 +35,7 @@ Notes:
 """
 
 import warnings
+from functools import cache
 from typing import Literal
 
 import torch
@@ -55,18 +56,10 @@ _NVMATH_DEPS = [
 # This is the cuBLAS library version, not the CUDA toolkit version.
 _MIN_CUBLASLT_GROUPED_GEMM_VERSION = 130200
 
-# Availability is a process-global property of the loaded cuBLASLt; resolve once.
-_nvmath_available: bool | None = None
 
-
+# Cached: availability is a process-global property of the loaded cuBLASLt.
+@cache
 def _check_nvmath_cublaslt() -> bool:
-    global _nvmath_available
-    if _nvmath_available is None:
-        _nvmath_available = _nvmath_grouped_gemm_available()
-    return _nvmath_available
-
-
-def _nvmath_grouped_gemm_available() -> bool:
     if _unavailable_reason(_NVMATH_DEPS) is not None:
         return False
     try:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189757

The nvmath cuBLASLt grouped GEMM backend for _foreach_mm (added in #185530)
calls cublasLtGroupedMatrixLayoutCreate. That entrypoint was introduced in
cuBLAS 13.2.0 (CUDA 13.1); on older toolkits nvmath resolves the symbol
lazily and only fails when the kernel runs, raising
nvmath.bindings._internal.utils.FunctionNotFoundError. This broke the
Limited CI on H100 smoke job (issue #189716, cuBLAS 13.0.x):
_check_nvmath_cublaslt() only verified that the nvmath Python package
imports, so it routed _foreach_mm to the nvmath path and every
TestForeachMM test errored instead of falling back.

Gate _check_nvmath_cublaslt() on cublasLt.get_version() >=
_MIN_CUBLASLT_GROUPED_GEMM_VERSION (130200 = cuBLAS 13.2.0). Note this is
the cuBLAS library version, not the CUDA toolkit version. When the loaded
cuBLASLt is too old the router falls back to cutlass_grouped_mm/mm_loop and
the nvmath-specific tests skip cleanly.

I gate on the cuBLAS version rather than reverting #185530 (5 weeks old with
follow-up work on top; the feature is correct where the API exists). A
version check is preferred over calling the symbol to probe it: the symbol
is only reachable via grouped_matrix_layout_create, which needs valid device
arguments and would be unsafe to invoke speculatively.

Test Plan:
lintrunner clean on both files; py_compile passes. Full execution requires
nvmath + a CUDA runner and is left to CI: the H100 smoke job (cuBLAS 13.0)
should skip test_foreach_mm_nvmath_* and pass test_foreach_mm_cuda_* via
fallback, while runners with cuBLAS >= 13.2.0 continue to exercise nvmath.

```
lintrunner -a torch/_native/ops/foreach_mm/impl.py test/test_foreach.py
python -m py_compile torch/_native/ops/foreach_mm/impl.py test/test_foreach.py
```

Authored with Claude.