### PR TITLE
[BE] Switch ubuntu-rocm CI image off conda to a deadsnakes venv

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -354,10 +354,10 @@ case "$tag" in
   ;;
 esac
 
-# ubuntu/Dockerfile provisions Python from a deadsnakes venv keyed on
-# PYTHON_VERSION, while the rocm/xpu images still express it as
-# ANACONDA_PYTHON_VERSION (they keep conda). Mirror the value so both flavors
-# get what they expect.
+# The ubuntu and ubuntu-rocm images provision Python from a deadsnakes venv
+# keyed on PYTHON_VERSION, while the xpu image still expresses it as
+# ANACONDA_PYTHON_VERSION (it keeps conda). Mirror the value so every flavor
+# gets what it expects.
 if [ -z "${PYTHON_VERSION}" ]; then
   PYTHON_VERSION="${ANACONDA_PYTHON_VERSION}"
 fi

--- a/.ci/docker/common/install_conda.sh
+++ b/.ci/docker/common/install_conda.sh
@@ -66,11 +66,6 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
              pip \
              "icu<78"
 
-  # Miniforge installer doesn't install sqlite by default
-  if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
-    conda_install sqlite
-  fi
-
   # Install llvm-8 as it is required to compile llvmlite-0.30.0 from source
   # and libpython-static for torch deploy
   conda_install llvmdev=8.0.0 "libpython-static=${ANACONDA_PYTHON_VERSION}"

--- a/.ci/docker/common/install_rocm.sh
+++ b/.ci/docker/common/install_rocm.sh
@@ -26,6 +26,10 @@ install_ubuntu() {
     apt-get install -y libc++1
     apt-get install -y libc++abi1
 
+    # sqlite3 CLI is used below to fix up MIOpen kdb files. It used to be pulled
+    # in via conda; now that the image is conda-free, install it explicitly.
+    apt-get install -y sqlite3
+
     # When ROCM_VERSION=nightly, install ROCm from TheRock nightly tarballs
     # Mirrors: https://github.com/ROCm/TheRock/blob/main/dockerfiles/install_rocm_tarball.sh
     if [[ "${ROCM_VERSION}" == "nightly" ]]; then
@@ -223,7 +227,7 @@ EOF
             HIP_TAG=rocm-6.4.0
             CLR_HASH=600f5b0d2baed94d5121e2174a9de0851b040b0c  # branch release/rocm-rel-6.4-statco-hotfix
         fi
-        # clr build needs CppHeaderParser but can only find it using conda's python
+        # clr build needs CppHeaderParser; install it into the active Python env
         python -m pip install CppHeaderParser
         git clone https://github.com/ROCm/HIP -b $HIP_TAG
         HIP_COMMON_DIR=$(readlink -f HIP)
@@ -233,8 +237,8 @@ EOF
         popd
         mkdir -p clr/build
         pushd clr/build
-        # Need to point CMake to the correct python installation to find CppHeaderParser
-        cmake .. -DPython3_EXECUTABLE=/opt/conda/envs/py_${ANACONDA_PYTHON_VERSION}/bin/python3 -DCLR_BUILD_HIP=ON -DHIP_COMMON_DIR=$HIP_COMMON_DIR
+        # Point CMake at the active Python interpreter so it can find CppHeaderParser
+        cmake .. -DPython3_EXECUTABLE="$(python -c 'import sys; print(sys.executable)')" -DCLR_BUILD_HIP=ON -DHIP_COMMON_DIR=$HIP_COMMON_DIR
         make -j
         cp hipamd/lib/libamdhip64.so.6.4.* /opt/rocm/lib/libamdhip64.so.6.4.*
         popd

--- a/.ci/docker/common/install_rocm.sh
+++ b/.ci/docker/common/install_rocm.sh
@@ -26,10 +26,6 @@ install_ubuntu() {
     apt-get install -y libc++1
     apt-get install -y libc++abi1
 
-    # sqlite3 CLI is used below to fix up MIOpen kdb files. It used to be pulled
-    # in via conda; now that the image is conda-free, install it explicitly.
-    apt-get install -y sqlite3
-
     # When ROCM_VERSION=nightly, install ROCm from TheRock nightly tarballs
     # Mirrors: https://github.com/ROCm/TheRock/blob/main/dockerfiles/install_rocm_tarball.sh
     if [[ "${ROCM_VERSION}" == "nightly" ]]; then
@@ -207,6 +203,10 @@ EOF
       fi
     fi
 
+    # sqlite3 CLI is used just below to fix up the MIOpen kdb files (previously
+    # pulled in via conda). Only this non-nightly path runs that fixup.
+    apt-get install -y sqlite3
+
     # ROCm 6.0 had a regression where journal_mode was enabled on the kdb files resulting in permission errors at runtime
     for kdb in /opt/rocm/share/miopen/db/*.kdb
     do
@@ -227,8 +227,9 @@ EOF
             HIP_TAG=rocm-6.4.0
             CLR_HASH=600f5b0d2baed94d5121e2174a9de0851b040b0c  # branch release/rocm-rel-6.4-statco-hotfix
         fi
-        # clr build needs CppHeaderParser; install it into the active Python env
-        python -m pip install CppHeaderParser
+        # clr build needs CppHeaderParser; install it via pip_install so it lands
+        # in the active env as jenkins (keeps venv files jenkins-owned)
+        pip_install CppHeaderParser
         git clone https://github.com/ROCm/HIP -b $HIP_TAG
         HIP_COMMON_DIR=$(readlink -f HIP)
         git clone https://github.com/jeffdaily/clr

--- a/.ci/docker/ubuntu-rocm/Dockerfile
+++ b/.ci/docker/ubuntu-rocm/Dockerfile
@@ -24,15 +24,19 @@ ARG KATEX
 COPY ./common/install_docs_reqs.sh install_docs_reqs.sh
 RUN bash ./install_docs_reqs.sh && rm install_docs_reqs.sh
 
-# Install conda and other packages (e.g., numpy, pytest)
-ARG ANACONDA_PYTHON_VERSION
+# Install python (via deadsnakes) into a venv and the CI requirements
+ARG PYTHON_VERSION
+ARG PYTHON_FREETHREADED
 ARG BUILD_ENVIRONMENT
-ENV ANACONDA_PYTHON_VERSION=$ANACONDA_PYTHON_VERSION
-ENV PATH /opt/conda/envs/py_$ANACONDA_PYTHON_VERSION/bin:/opt/conda/bin:$PATH
-COPY requirements-ci.txt /opt/conda/requirements-ci.txt
-COPY ./common/install_conda.sh install_conda.sh
+ENV PYTHON_VERSION=$PYTHON_VERSION
+ENV PYTHON_FREETHREADED=$PYTHON_FREETHREADED
+ENV VENV_PATH=/opt/python-${PYTHON_VERSION}-venv
+ENV VIRTUAL_ENV=${VENV_PATH}
+ENV PATH=${VENV_PATH}/bin:$PATH
+COPY requirements-ci.txt /opt/requirements-ci.txt
+COPY ./common/install_python.sh install_python.sh
 COPY ./common/common_utils.sh common_utils.sh
-RUN bash ./install_conda.sh && rm install_conda.sh common_utils.sh /opt/conda/requirements-ci.txt
+RUN bash ./install_python.sh && rm install_python.sh common_utils.sh /opt/requirements-ci.txt
 
 # Install gcc
 ARG GCC_VERSION
@@ -87,8 +91,6 @@ RUN bash ./install_amdsmi.sh
 RUN rm install_amdsmi.sh
 
 ARG INDUCTOR_BENCHMARKS
-ARG ANACONDA_PYTHON_VERSION
-ENV ANACONDA_PYTHON_VERSION=$ANACONDA_PYTHON_VERSION
 COPY ./common/install_inductor_benchmark_deps.sh install_inductor_benchmark_deps.sh
 COPY ./common/common_utils.sh common_utils.sh
 COPY ci_commit_pins/huggingface-requirements.txt huggingface-requirements.txt

--- a/.ci/docker/ubuntu-rocm/Dockerfile
+++ b/.ci/docker/ubuntu-rocm/Dockerfile
@@ -27,7 +27,6 @@ RUN bash ./install_docs_reqs.sh && rm install_docs_reqs.sh
 # Install python (via deadsnakes) into a venv and the CI requirements
 ARG PYTHON_VERSION
 ARG PYTHON_FREETHREADED
-ARG BUILD_ENVIRONMENT
 ENV PYTHON_VERSION=$PYTHON_VERSION
 ENV PYTHON_FREETHREADED=$PYTHON_FREETHREADED
 ENV VENV_PATH=/opt/python-${PYTHON_VERSION}-venv
@@ -35,8 +34,7 @@ ENV VIRTUAL_ENV=${VENV_PATH}
 ENV PATH=${VENV_PATH}/bin:$PATH
 COPY requirements-ci.txt /opt/requirements-ci.txt
 COPY ./common/install_python.sh install_python.sh
-COPY ./common/common_utils.sh common_utils.sh
-RUN bash ./install_python.sh && rm install_python.sh common_utils.sh /opt/requirements-ci.txt
+RUN bash ./install_python.sh && rm install_python.sh /opt/requirements-ci.txt
 
 # Install gcc
 ARG GCC_VERSION
@@ -51,6 +49,9 @@ RUN bash ./install_clang.sh && rm install_clang.sh
 # Install rocm
 ARG ROCM_VERSION
 ENV ROCM_VERSION=${ROCM_VERSION}
+# install_rocm.sh reads BUILD_ENVIRONMENT (nightly gfx950 family detection)
+ARG BUILD_ENVIRONMENT
+ENV BUILD_ENVIRONMENT=${BUILD_ENVIRONMENT}
 RUN mkdir ci_commit_pins
 COPY ./common/common_utils.sh common_utils.sh
 COPY ./ci_commit_pins/rocm-composable-kernel.txt ci_commit_pins/rocm-composable-kernel.txt
@@ -88,6 +89,9 @@ ENV LC_ALL C.UTF-8
 # Install amdsmi
 COPY ./common/install_amdsmi.sh install_amdsmi.sh
 RUN bash ./install_amdsmi.sh
+# install_amdsmi.sh runs `pip install` as root, which can leave venv files
+# root-owned; hand the venv back to jenkins (mirrors ubuntu/Dockerfile).
+RUN chown -R jenkins:jenkins ${VENV_PATH}
 RUN rm install_amdsmi.sh
 
 ARG INDUCTOR_BENCHMARKS
@@ -132,9 +136,6 @@ RUN rm install_openmpi.sh
 COPY ./common/common_utils.sh common_utils.sh
 COPY ci_commit_pins/rocm-origami.txt rocm-origami.txt
 RUN bash -c 'source common_utils.sh && env_run pip install "rocm-origami==$(cat rocm-origami.txt)"' && rm -f common_utils.sh rocm-origami.txt
-
-ARG BUILD_ENVIRONMENT
-ENV BUILD_ENVIRONMENT ${BUILD_ENVIRONMENT}
 
 USER jenkins
 CMD ["bash"]


### PR DESCRIPTION
## Problem

The `ubuntu-rocm` CI Docker image still provisions Python via conda, while the main `ubuntu` CI images use a deadsnakes venv (`install_python.sh` + `VENV_PATH`). This brings the ROCm image onto the same Python-provisioning path.

## Changes

- **`ubuntu-rocm/Dockerfile`**: provision Python from a per-version deadsnakes venv (`install_python.sh`, keyed on `PYTHON_VERSION`) instead of `install_conda.sh` / `ANACONDA_PYTHON_VERSION`; drop the redundant `ANACONDA_PYTHON_VERSION` arg from the inductor-benchmarks stage.
- **`build.sh`**: keep mirroring `PYTHON_VERSION` from `ANACONDA_PYTHON_VERSION`, and correct the comment (only the xpu image still keeps conda).
- **`install_conda.sh`**: drop the now-unreachable rocm-only `conda_install sqlite` branch (`ubuntu-xpu` is the only remaining `install_conda.sh` consumer and does not need the sqlite CLI).

`install_rocm.sh` is left unchanged: main already installs ROCm from TheRock wheels into the active Python environment, and this PR provisions that environment (the venv) before the ROCm install step.

The minifier `isolate_fails` UTF-8 fix is already on main and is not part of this PR.

Tracked in AIPYTORCH-781.

## Validation

Rebased onto `origin/main` (`fac4103fdcf`). Unique commits: conda-to-venv switch and review cleanup. Diff is the three files above.

On the previous head (`758079183e6`): all `linux-noble-rocm-py3.11-mi350` shards passed, including default shard 6 (`MinifierIsolateTests.test_after_aot_gpu_runtime_error`). Remaining reds were `inductor-cpu` `aoti_fallback` (unstable) x2 and `build-docker (cpu)`.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @azahed98
