### PR TITLE
Reorder stateless RNG key() args + make them kw-only

### DIFF
--- a/torch/func/_random.py
+++ b/torch/func/_random.py
@@ -10,7 +10,7 @@ import torch
 
 
 def key(
-    seed: int, impl: str = "philox4x32-10", device: torch.device | None = None
+    seed: int, *, device: torch.device | None = None, impl: str = "philox4x32-10"
 ) -> torch.Tensor:
     r"""Create a PRNG key from a seed.
 
@@ -21,10 +21,10 @@ def key(
 
     Args:
         seed (int): The seed value for the PRNG.
-        impl (str): PRNG algorithm. Currently only ``"philox4x32-10"`` is
-            supported.
         device (:class:`torch.device`, optional): The desired device for the
             returned key. Default: ``cpu``.
+        impl (str): PRNG algorithm. Currently only ``"philox4x32-10"`` is
+            supported.
 
     Returns:
         A tensor representing the PRNG key.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #178183
* #177898
* #177689
* #178160
* #177882
* #177692
* #189735
* #189767
* __->__ #189768

Addresses beta user feedback by reordering `torch.func._random.key()`'s args in a more natural way and making them kw-only. It's technically BC-breaking for this private API but I don't expect it to be widely used yet so let's make this change while we can.