### PR TITLE
Fix lintrunner-noclang-all: noqa the type-narrowing FakeTensor isinstance in conv fake impl

### DIFF
--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -2079,7 +2079,7 @@ def conv(
     )
 
     def expect_fake_tensor(name: str, value: object) -> FakeTensor:
-        if not isinstance(value, FakeTensor):
+        if not isinstance(value, FakeTensor):  # noqa: ISINSTANCE_FAKE_TENSOR
             raise AssertionError(
                 "Expected fake convolution tensor arguments to be FakeTensors, "
                 f"but {name} was {type(value).__name__}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189769

#188978 added the ISINSTANCE_FAKE_TENSOR lintrunner rule (flagging
isinstance(x, FakeTensor) across torch/**/*.py) and swept existing uses to
is_fake, but missed one occurrence in torch/_subclasses/fake_impls.py. The PR's
diff-based lint passed, but Lint / lintrunner-noclang-all (which runs the new
rule over all files) reds on it:

    torch/_subclasses/fake_impls.py:2082
    Error (ISINSTANCE_FAKE_TENSOR) isinstance(x, FakeTensor)

Here the isinstance is intentional: expect_fake_tensor() uses it to narrow
`object` to `FakeTensor` (it returns FakeTensor and callers read .fake_device),
and the conv fake impl legitimately expects Python FakeTensors. Swapping to
is_fake would drop the type narrowing and change the semantics, so per the
linter's own guidance add a `# noqa: ISINSTANCE_FAKE_TENSOR` to the line
instead.

Test Plan:
```
lintrunner --take ISINSTANCE_FAKE_TENSOR torch/_subclasses/fake_impls.py
```

Authored with Claude.