### PR TITLE
[c10d] Use _coalescing_manager for abort instead of hardcoded NCCL group calls

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -2799,7 +2799,7 @@ def _abort_process_group(group: ProcessGroup | None = None):
         # abort calls won't deadlock each other.
         # For details, please see: https://github.com/pytorch/pytorch/issues/119797
         coalescing_device = (
-            device if getattr(backend, "supports_coalescing", False) else None
+            device if backend is not None and backend.supports_coalescing else None
         )
         # Drop any pending coalesced ops; everything is being aborted anyway
         # and _coalescing_manager requires an empty op list on entry.

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -2798,8 +2798,11 @@ def _abort_process_group(group: ProcessGroup | None = None):
         # semantic for NCCL). This ensures that different communicators'
         # abort calls won't deadlock each other.
         # For details, please see: https://github.com/pytorch/pytorch/issues/119797
+        # getattr instead of a direct attribute access because custom Python
+        # backends are ProcessGroup subclasses, which don't expose the
+        # Backend.supports_coalescing property.
         coalescing_device = (
-            device if backend is not None and backend.supports_coalescing else None
+            device if getattr(backend, "supports_coalescing", False) else None
         )
         # Drop any pending coalesced ops; everything is being aborted anyway
         # and _coalescing_manager requires an empty op list on entry.

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -2787,26 +2787,28 @@ def _abort_process_group(group: ProcessGroup | None = None):
     if _world.pg_map.get(pg, None) is None:
         raise ValueError("Invalid process group specified or has been destroyed.")
 
+    device = torch.accelerator.current_accelerator() or torch.device("cpu")
     try:
-        backend = pg._get_backend(
-            torch.accelerator.current_accelerator() or torch.device("cpu")
-        )
+        backend = pg._get_backend(device)
     except RuntimeError:
         backend = None
 
     if group is None or group == GroupMember.WORLD:
-        # Abort all backends within a ncclGroupStart|End semantic.
-        # This ensures that different NCCL communicators' abort calls won't
-        # deadlock each other.
+        # Abort all backends within a coalescing region (ncclGroupStart|End
+        # semantic for NCCL). This ensures that different communicators'
+        # abort calls won't deadlock each other.
         # For details, please see: https://github.com/pytorch/pytorch/issues/119797
-        if is_nccl_available() and isinstance(backend, ProcessGroupNCCL):
-            backend._group_start()
-        for pg_to_abort in sorted(
-            _world.pg_names, key=lambda x: _world.pg_names[x], reverse=True
-        ):
-            pg_to_abort.abort()
-        if is_nccl_available() and isinstance(backend, ProcessGroupNCCL):
-            backend._group_end()
+        coalescing_device = (
+            device if getattr(backend, "supports_coalescing", False) else None
+        )
+        # Drop any pending coalesced ops; everything is being aborted anyway
+        # and _coalescing_manager requires an empty op list on entry.
+        _world.pg_coalesce_state.pop(pg, None)
+        with _coalescing_manager(pg, coalescing_device):
+            for pg_to_abort in sorted(
+                _world.pg_names, key=lambda x: _world.pg_names[x], reverse=True
+            ):
+                pg_to_abort.abort()
 
         _update_default_pg(None)
         _world.pg_map.clear()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189770

_abort_process_group previously hardcoded the NCCL-specific ncclGroupStart/End wrapping (is_nccl_available() + isinstance(backend, ProcessGroupNCCL) + backend._group_start()/_group_end()) around the abort-all loop. This switches it to the generic _coalescing_manager context manager gated on the backend's supports_coalescing property, matching the pattern batch_isend_irecv already uses. Backends that support coalescing (NCCL or any third-party backend overriding supportsCoalescing()) get the group semantics that prevent multi-communicator abort deadlocks (#119797); other backends get a no-op wrapper via device=None.

For NCCL this is behavior-preserving: abort() records no collectives, so endCoalescing sees coalescedComm_ == nullptr and just calls groupEnd(), identical to the old _group_end(). Since _coalescing_manager raises if the group already has queued coalesced ops, the abort path drops any pending pg_coalesce_state entry first (everything is being aborted anyway; the non-world branch already handles this case with a warning).

Test Plan:

Verified at runtime by loading the new _abort_process_group into an installed torch build and exercising both paths:

- 2-rank/2-GPU NCCL test: allreduce on world + subgroup, abort the whole world (coalescing path), re-init, abort a single subgroup. Both ranks pass with clean NCCL Abort COMPLETE.
- Dummy Python backend test (mirrors test_c10d_common.py test_abort): abort succeeds through the non-coalescing (device=None) path, pg._aborted set, world state cleared.

```
NCCL_SOCKET_IFNAME=lo python agent_space/test_abort_nccl.py
python agent_space/test_abort_dummy.py
lintrunner torch/distributed/distributed_c10d.py
```

Authored with Claude Code.