### PR TITLE
Checkout determinator script from base ref, not PR head

### DIFF
--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -89,10 +89,27 @@ jobs:
       - name: Checkout PyTorch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          # Use the default ref (the merge commit for pull_request events) so the
+          # determinator script always reflects the current base branch, even when
+          # a PR's own branch is far behind main. See #189113/#189171: main's build
+          # workflow no longer has an EC2 fallback, so a stale determinator script
+          # here can emit a runner-label prefix (e.g. "lf.") that main's build job
+          # no longer knows how to route.
           fetch-depth: 1
           sparse-checkout: |
             .github/scripts/runner_determinator.py
+          sparse-checkout-cone-mode: false
+
+      - name: Checkout .ci/docker from PR head
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # .ci/docker is hashed from the PR's own branch (not the merge commit) so
+          # the resulting image tag reflects the docker changes the PR is actually
+          # introducing. See #182579.
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 1
+          path: pr-head
+          sparse-checkout: |
             .ci/docker
           sparse-checkout-cone-mode: false
 
@@ -100,7 +117,7 @@ jobs:
         id: ci-docker-hash
         shell: bash
         run: |
-          echo "ci-docker-hash=$(git rev-parse HEAD:.ci/docker)" >> "$GITHUB_OUTPUT"
+          echo "ci-docker-hash=$(git -C pr-head rev-parse HEAD:.ci/docker)" >> "$GITHUB_OUTPUT"
 
       - name: Install dependencies
         run: python3 -m pip install urllib3==1.26.18 PyGithub==2.3.0
@@ -111,18 +128,6 @@ jobs:
           curr_branch="${{ inputs.curr_branch }}"
           curr_ref_type="${{ inputs.curr_ref_type }}"
           echo "Current branch is '$curr_branch'"
-
-          # The workflow YAML is loaded from main (via @main in callers) but the
-          # script is checked out from the PR head, so PRs that predate a newly
-          # added optional flag will reject it. Probe --help and only pass flags
-          # the checked-out script supports.
-          extra_args=()
-          help_text="$(python3 .github/scripts/runner_determinator.py --help 2>&1 || true)"
-          if grep -q -- '--workflow-name' <<<"$help_text"; then
-            extra_args+=(--workflow-name "${WORKFLOW_NAME}")
-          else
-            echo "::warning::runner_determinator.py on this branch is missing --workflow-name; skipping. Rebase the PR onto main to pick it up."
-          fi
 
           python3 .github/scripts/runner_determinator.py \
             --github-token "$GITHUB_TOKEN" \
@@ -135,7 +140,7 @@ jobs:
             --eligible-experiments "$CHECK_EXPERIMENTS" \
             --opt-out-experiments "$OPT_OUT_EXPERIMENTS" \
             --pr-number "${PR_NUMBER}" \
-            "${extra_args[@]}"
+            --workflow-name "${WORKFLOW_NAME}"
 
       - name: Determine runner configuration
         id: set-runner-info


### PR DESCRIPTION
_runner-determinator.yml checked out .github/scripts/runner_determinator.py from github.event.pull_request.head.sha, so PRs whose branch predates a change to the script (e.g. the "lf." -> "lf-" prefix rename, or the EC2 build-path removal in #189113/#189171) run a stale copy. That stale copy can emit a runner-label prefix main's build workflow no longer knows how to route (e.g. "lf.l-x86iavx512-8-64" - a dead EC2-era dotted prefix glued onto a post-#189113 ARC-only label), leaving the job stuck unroutable instead of just landing on the wrong fleet.

The PR-head ref was introduced in #182579 only so ci-docker-hash reflects the PR's own .ci/docker tree, not to let PRs self-test determinator changes. Split the checkout in two: the script now comes from the default ref (main, or the merge commit for pull_request events, which still includes the PR's own edits to the script), while .ci/docker keeps using head.sha via a separate sparse checkout under pr-head/.

This also removes the --help probing for --workflow-name, since the script is no longer stale relative to main and always supports the flag.