### PR TITLE
Add dLSE support to flex flash

### DIFF
--- a/test/inductor/test_flex_flash.py
+++ b/test/inductor/test_flex_flash.py
@@ -2393,22 +2393,72 @@ class TestFlexFlash(InductorTestCase):
 
     @xfailIfSM120OrLater
     @dtypes(torch.float16, torch.bfloat16)
-    def test_flash_backend_raises_on_grad_logsumexp(self, device, dtype):
-        from torch._dynamo.exc import BackendCompilerFailed
-
-        q, k, v = create_test_tensors(dtype=dtype, device=device, requires_grad=True)
-        lse_mask = torch.randn(2, 4, 512, device=device)
-
-        compiled_flex = torch.compile(flex_attention)
-        out, lse = compiled_flex(
-            q, k, v, return_lse=True, kernel_options={"BACKEND": "FLASH"}
+    def test_flash_backend_supports_grad_logsumexp(self, device, dtype):
+        torch.manual_seed(0)
+        q, k, v = create_test_tensors(
+            batch_size=1,
+            num_heads=1,
+            seq_len=128,
+            dim=32,
+            dtype=dtype,
+            device=device,
         )
-        loss = out.mean() + (lse * lse_mask).sum()
-        with self.assertRaisesRegex(
-            BackendCompilerFailed,
-            "FLASH backend backward does not support differentiating through logsumexp",
+        grad_out = torch.randn_like(q)
+        grad_lse = torch.randn(1, 1, 128, device=device, dtype=torch.float32) * 3
+
+        def run_backend(backend, q_in, k_in, v_in):
+            compiled_flex = torch.compile(
+                functools.partial(
+                    flex_attention,
+                    score_mod=_times_two,
+                    scale=1.0,
+                    return_lse=True,
+                    kernel_options={"BACKEND": backend},
+                )
+            )
+            out, lse = compiled_flex(q_in, k_in, v_in)
+            return torch.autograd.grad(
+                (out, lse), (q_in, k_in, v_in), (grad_out, grad_lse)
+            )
+
+        q_flash, k_flash, v_flash = [
+            t.detach().clone().requires_grad_() for t in (q, k, v)
+        ]
+        q_triton, k_triton, v_triton = [
+            t.detach().clone().requires_grad_() for t in (q, k, v)
+        ]
+        grads_flash = run_backend("FLASH", q_flash, k_flash, v_flash)
+        grads_triton = run_backend("TRITON", q_triton, k_triton, v_triton)
+
+        q_ref, k_ref, v_ref = [t.detach().float().requires_grad_() for t in (q, k, v)]
+        out_ref, lse_ref = flex_attention(
+            q_ref,
+            k_ref,
+            v_ref,
+            score_mod=_times_two,
+            scale=1.0,
+            return_lse=True,
+        )
+        grads_ref = torch.autograd.grad(
+            (out_ref, lse_ref),
+            (q_ref, k_ref, v_ref),
+            (grad_out.float(), grad_lse),
+        )
+
+        for grad_flash, grad_triton, grad_ref in zip(
+            grads_flash, grads_triton, grads_ref
         ):
-            loss.backward()
+            self.assertTrue(torch.isfinite(grad_flash).all())
+            self.assertTrue(torch.isfinite(grad_triton).all())
+            self.assertTrue(torch.isfinite(grad_ref).all())
+            atol = 2 * (grad_ref + 0.3 - 0.3 - grad_ref).abs().max().item()
+            triton_error = (
+                (grad_triton - grad_ref.to(grad_triton.dtype)).abs().max().item()
+            )
+            flash_error = (
+                (grad_flash - grad_ref.to(grad_flash.dtype)).abs().max().item()
+            )
+            self.assertLessEqual(flash_error, 2 * triton_error + atol)
 
     @dtypes(torch.float16, torch.bfloat16)
     def test_flash_backend_raises_on_return_max_scores(self, device, dtype):

--- a/torch/_inductor/kernel/flex/flex_attention.py
+++ b/torch/_inductor/kernel/flex/flex_attention.py
@@ -906,16 +906,9 @@ def flex_attention_backward(*args, **kwargs):
         score_mod_other_buffers=score_mod_other_buffers,
     ):
         needs_block_mask = not is_trivial_mask_graph(mask_graph.graph_module)
-
-        # TODO: Implement dLSE support in flash-attention backward by folding
-        # grad_logsumexp into the dPsum preprocess step.
         if grad_logsumexp is not None:
-            raise NotImplementedError(
-                "FLASH backend backward does not support differentiating through "
-                "logsumexp (dLSE). This happens when the loss depends on the LSE "
-                "output of flex_attention. "
-                "Use BACKEND='TRITON' or avoid differentiating through logsumexp."
-            )
+            (grad_logsumexp,) = maybe_realize([grad_logsumexp])
+
         score_is_trivial = is_trivial_score_graph(fw_graph.graph_module)
         return create_flex_flash_attention_backward_kernel(
             query,
@@ -924,6 +917,7 @@ def flex_attention_backward(*args, **kwargs):
             out,
             logsumexp,
             grad_out,
+            grad_logsumexp,
             scale,
             kernel_options,
             SPARSE_Q_BLOCK_SIZE,

--- a/torch/_inductor/kernel/flex/flex_flash_attention.py
+++ b/torch/_inductor/kernel/flex/flex_flash_attention.py
@@ -668,6 +668,7 @@ def create_flex_flash_attention_backward_kernel(
     out: TensorBox,
     logsumexp: TensorBox,
     grad_out: TensorBox,
+    grad_logsumexp: TensorBox | None,
     scale: float,
     kernel_options: dict[str, Any],
     sparse_q_block_size: int,
@@ -738,6 +739,19 @@ def create_flex_flash_attention_backward_kernel(
     sparse_q_block_size = V.graph.sizevars.guard_int(sparse_q_block_size)
     sparse_kv_block_size = V.graph.sizevars.guard_int(sparse_kv_block_size)
 
+    has_dlse = grad_logsumexp is not None
+    if (
+        has_dlse
+        and V.graph.sizevars.statically_known_equals(head_dim, 256)
+        and V.graph.sizevars.statically_known_equals(v_head_dim, 256)
+        and torch.cuda.get_device_capability(device)[0] in (10, 11)
+    ):
+        raise NotImplementedError(
+            "FLASH backend dLSE is not supported by the SM100/SM110 dedicated "
+            "head_dim=256 FA4 backward kernel. Use BACKEND='TRITON' for this "
+            "configuration."
+        )
+
     choices: list[Any] = []
 
     input_nodes: list[TensorBox] = [
@@ -779,6 +793,8 @@ def create_flex_flash_attention_backward_kernel(
     dq_kv_order_spt_for_flash = dq_kv_order_spt if has_dq_write_order else None
     if has_dq_kv_order:
         input_nodes.append(dq_kv_order)
+    if has_dlse:
+        input_nodes.append(cast(TensorBox, grad_logsumexp))
 
     supports_dq_kv_order = False
     supports_spt = False
@@ -881,6 +897,7 @@ def create_flex_flash_attention_backward_kernel(
                 HAS_DQ_WRITE_ORDER_FULL=dq_write_order_full is not None,
                 HAS_DQ_KV_ORDER=has_dq_kv_order,
                 DQ_KV_ORDER_SPT=dq_kv_order_spt_for_flash,
+                HAS_DLSE=has_dlse,
                 AUX_SCALAR_SYMBOLS=aux_scalar_symbols,
                 SUPPORTS_DQ_KV_ORDER=supports_dq_kv_order,
                 SUPPORTS_SPT=supports_spt,

--- a/torch/_inductor/kernel/flex/templates/flash_attention_backward.py.jinja
+++ b/torch/_inductor/kernel/flex/templates/flash_attention_backward.py.jinja
@@ -1,17 +1,17 @@
 {% if HAS_BLOCK_MASK and HAS_DQ_WRITE_ORDER and HAS_DQ_WRITE_ORDER_FULL and HAS_DQ_KV_ORDER %}
-{{def_kernel("Q", "K", "V", "OUT", "D_OUT", "LSE", "DK", "DV", "Q_NUM_BLKS", "Q_IDX", "FULL_Q_NUM_BLKS", "FULL_Q_IDX", "DQ_WRITE_ORDER", "DQ_WRITE_ORDER_FULL", "DQ_KV_ORDER")}}
+{{def_kernel("Q", "K", "V", "OUT", "D_OUT", "LSE", "DK", "DV", "Q_NUM_BLKS", "Q_IDX", "FULL_Q_NUM_BLKS", "FULL_Q_IDX", "DQ_WRITE_ORDER", "DQ_WRITE_ORDER_FULL", "DQ_KV_ORDER", "DLSE")}}
 {% elif HAS_BLOCK_MASK and HAS_DQ_WRITE_ORDER and HAS_DQ_WRITE_ORDER_FULL %}
-{{def_kernel("Q", "K", "V", "OUT", "D_OUT", "LSE", "DK", "DV", "Q_NUM_BLKS", "Q_IDX", "FULL_Q_NUM_BLKS", "FULL_Q_IDX", "DQ_WRITE_ORDER", "DQ_WRITE_ORDER_FULL")}}
+{{def_kernel("Q", "K", "V", "OUT", "D_OUT", "LSE", "DK", "DV", "Q_NUM_BLKS", "Q_IDX", "FULL_Q_NUM_BLKS", "FULL_Q_IDX", "DQ_WRITE_ORDER", "DQ_WRITE_ORDER_FULL", "DLSE")}}
 {% elif HAS_BLOCK_MASK and HAS_DQ_WRITE_ORDER and HAS_DQ_KV_ORDER %}
-{{def_kernel("Q", "K", "V", "OUT", "D_OUT", "LSE", "DK", "DV", "Q_NUM_BLKS", "Q_IDX", "FULL_Q_NUM_BLKS", "FULL_Q_IDX", "DQ_WRITE_ORDER", "DQ_KV_ORDER")}}
+{{def_kernel("Q", "K", "V", "OUT", "D_OUT", "LSE", "DK", "DV", "Q_NUM_BLKS", "Q_IDX", "FULL_Q_NUM_BLKS", "FULL_Q_IDX", "DQ_WRITE_ORDER", "DQ_KV_ORDER", "DLSE")}}
 {% elif HAS_BLOCK_MASK and HAS_DQ_WRITE_ORDER %}
-{{def_kernel("Q", "K", "V", "OUT", "D_OUT", "LSE", "DK", "DV", "Q_NUM_BLKS", "Q_IDX", "FULL_Q_NUM_BLKS", "FULL_Q_IDX", "DQ_WRITE_ORDER")}}
+{{def_kernel("Q", "K", "V", "OUT", "D_OUT", "LSE", "DK", "DV", "Q_NUM_BLKS", "Q_IDX", "FULL_Q_NUM_BLKS", "FULL_Q_IDX", "DQ_WRITE_ORDER", "DLSE")}}
 {% elif HAS_BLOCK_MASK and HAS_DQ_KV_ORDER %}
-{{def_kernel("Q", "K", "V", "OUT", "D_OUT", "LSE", "DK", "DV", "Q_NUM_BLKS", "Q_IDX", "FULL_Q_NUM_BLKS", "FULL_Q_IDX", "DQ_KV_ORDER")}}
+{{def_kernel("Q", "K", "V", "OUT", "D_OUT", "LSE", "DK", "DV", "Q_NUM_BLKS", "Q_IDX", "FULL_Q_NUM_BLKS", "FULL_Q_IDX", "DQ_KV_ORDER", "DLSE")}}
 {% elif HAS_BLOCK_MASK %}
-{{def_kernel("Q", "K", "V", "OUT", "D_OUT", "LSE", "DK", "DV", "Q_NUM_BLKS", "Q_IDX", "FULL_Q_NUM_BLKS", "FULL_Q_IDX")}}
+{{def_kernel("Q", "K", "V", "OUT", "D_OUT", "LSE", "DK", "DV", "Q_NUM_BLKS", "Q_IDX", "FULL_Q_NUM_BLKS", "FULL_Q_IDX", "DLSE")}}
 {% else %}
-{{def_kernel("Q", "K", "V", "OUT", "D_OUT", "LSE", "DK", "DV")}}
+{{def_kernel("Q", "K", "V", "OUT", "D_OUT", "LSE", "DK", "DV", "DLSE")}}
 {% endif %}
     from flash_attn.cute.interface import _flash_attn_bwd
 
@@ -157,5 +157,6 @@
         dk=dk_out_transposed,
         dv=dv_out_transposed,
         block_sparse_tensors=block_sparse_tensors,
-        deterministic={{DETERMINISTIC_BACKWARD_ENABLED}},
+        deterministic={{DETERMINISTIC_BACKWARD_ENABLED}},{% if HAS_DLSE %}
+        dlse=DLSE,{% endif %}
     )


### PR DESCRIPTION
## Human Note
Rebased the FlexAttention FLASH dLSE support onto latest origin/main and fixed the PR lintrunner PYFMT failure in test/inductor/test_flex_flash.py. The change threads grad_logsumexp through FA4 backward, preserves the no-dLSE path, and keeps the known SM100/SM110 head_dim=256/head_dim_v=256 dLSE limitation guarded with a targeted NotImplementedError. Local changed-file lintrunner groups now pass with lintrunner==0.12.7.

## Agent Report
# FlexFlash dLSE support summary

## What changed

- Installed `flash-attn-4 4.0.0b21` in the PTQ job venv.
- Confirmed FA4 b21 supports dLSE in `_flash_attn_bwd(..., dlse=...)` by folding `dLSE` into the backward preprocess `D` term.
- Updated PyTorch FlexAttention FLASH backward lowering to pass `grad_logsumexp` into the FA4 backward template instead of raising `NotImplementedError`.
- Assumed the FA4 beta `_flash_attn_bwd(..., dlse=...)` API is available after upgrading to b21; PyPI wheel inspection shows dLSE first appeared in `flash-attn-4 4.0.0b5`.
- Added a clear guard for the one FA4 caveat found: SM100/SM110 dedicated `head_dim=256, head_dim_v=256` backward still does not accept `dlse`.
- Replaced the old negative regression test with a gradient parity test that differentiates through returned LSE and compares FLASH, TRITON, and fp32 reference gradients.

## Files changed

- `pytorch/torch/_inductor/kernel/flex/flex_attention.py`
- `pytorch/torch/_inductor/kernel/flex/flex_flash_attention.py`
- `pytorch/torch/_inductor/kernel/flex/templates/flash_attention_backward.py.jinja`
- `pytorch/test/inductor/test_flex_flash.py`

## Validation

Passed:

```bash
../.venv/bin/python -m py_compile torch/_inductor/kernel/flex/flex_attention.py torch/_inductor/kernel/flex/flex_flash_attention.py test/inductor/test_flex_flash.py
PYTORCH_TEST_WITH_INDUCTOR=1 INDUCTOR_TEST_DISABLE_FRESH_CACHE=1 TORCHINDUCTOR_COMPILE_THREADS=1 ../.venv/bin/pytest test/inductor/test_flex_flash.py -k "supports_grad_logsumexp" -v
PYTORCH_TEST_WITH_INDUCTOR=1 INDUCTOR_TEST_DISABLE_FRESH_CACHE=1 TORCHINDUCTOR_COMPILE_THREADS=1 ../.venv/bin/python test/inductor/test_flex_flash.py TestFlexFlashCUDA.test_flash_backend_supports_grad_logsumexp_cuda_float16 TestFlexFlashCUDA.test_flash_backend_supports_grad_logsumexp_cuda_bfloat16
PYTORCH_TEST_WITH_INDUCTOR=1 INDUCTOR_TEST_DISABLE_FRESH_CACHE=1 TORCHINDUCTOR_COMPILE_THREADS=1 ../.venv/bin/python test/inductor/test_flex_flash.py TestFlexFlashCUDA.test_flash_backend_return_lse_matches_triton_and_reference_cuda_float16 TestFlexFlashCUDA.test_flash_backend_return_lse_matches_triton_and_reference_cuda_bfloat16
PYTORCH_TEST_WITH_INDUCTOR=1 INDUCTOR_TEST_DISABLE_FRESH_CACHE=1 TORCHINDUCTOR_COMPILE_THREADS=1 ../.venv/bin/python test/inductor/test_flex_flash.py TestFlexFlashCUDA.test_flash_attention_score_mod_cases_backward_times_two_cuda_float16
PYTORCH_TEST_WITH_INDUCTOR=1 INDUCTOR_TEST_DISABLE_FRESH_CACHE=1 TORCHINDUCTOR_COMPILE_THREADS=1 ../.venv/bin/python agent_space/fuzz_flex_flash_dlse.py
git diff --check
uv tool run --python 3.10 --from lintrunner==0.12.7 lintrunner --take PYFMT --force-color test/inductor/test_flex_flash.py
```

After PR CI reported a PYFMT failure in `test/inductor/test_flex_flash.py`, the formatting patch was applied and both changed-file lintrunner groups from CI were rerun locally with `lintrunner==0.12.7`; both reported no lint issues.

The fuzz covered 6 fp16/bf16 cases across dense and causal block-mask paths, trivial and nontrivial score mods, varied shapes, and random nonzero `grad_lse`, comparing FLASH out/LSE/dQ/dK/dV against TRITON and fp32 eager reference.

Also passed ad hoc CUDA repros for:

- original dLSE failure shape, now producing finite gradients;
- no-dLSE FLASH backward, to check compatibility;
- causal block-mask dLSE FLASH backward, to check the block-mask template signature path.

## Remaining caveat

FA4 b21 still rejects `dlse` in its SM100/SM110 dedicated `head_dim=256, head_dim_v=256` backward kernel. The PyTorch lowering now raises a targeted `NotImplementedError` for that configuration instead of falling into an FA4 assertion.


<details>
<summary>Agent Worklog</summary>

# FlexFlash dLSE support worklog

## 2026-07-13

- Upgraded the job venv from `flash-attn-4 4.0.0b19` to `flash-attn-4 4.0.0b21` with `python -m pip install --pre --upgrade flash-attn-4`.
- Confirmed FA4 b21 exposes `_flash_attn_bwd(..., dlse=None)` and implements the dLSE fold in backward preprocess as `D' = D - dLSE`.
- Reproduced the original PyTorch failure before code changes with a small compiled `flex_attention(..., return_lse=True, BACKEND='FLASH')` backward: `InductorError: LoweringException: NotImplementedError: FLASH backend backward does not support differentiating through logsumexp (dLSE)`.
- Removed the PyTorch FLASH-backward dLSE hard error and threaded `grad_logsumexp` into the FlexFlash backward template.
- Assumed the FA4 beta `_flash_attn_bwd(..., dlse=...)` API is available after upgrading to b21; PyPI wheel inspection shows dLSE first appeared in `flash-attn-4 4.0.0b5`.
- Added a clear PyTorch-side guard for FA4's remaining SM100/SM110 dedicated `head_dim=256, head_dim_v=256` dLSE limitation.
- Replaced the old negative regression test with a FLASH-vs-TRITON-vs-fp32 reference gradient test that differentiates through returned LSE with a nontrivial score mod.

## Validation

Commands run from `pytorch/` unless noted:

```bash
../.venv/bin/python -m py_compile torch/_inductor/kernel/flex/flex_attention.py torch/_inductor/kernel/flex/flex_flash_attention.py test/inductor/test_flex_flash.py
```

```bash
PYTORCH_TEST_WITH_INDUCTOR=1 INDUCTOR_TEST_DISABLE_FRESH_CACHE=1 TORCHINDUCTOR_COMPILE_THREADS=1 ../.venv/bin/python - <<'PY'
import torch
from torch.nn.attention.flex_attention import flex_attention

torch.manual_seed(0)
device = "cuda"
dtype = torch.float16
q = torch.randn(1, 1, 128, 32, device=device, dtype=dtype, requires_grad=True)
k = torch.randn(1, 1, 128, 32, device=device, dtype=dtype, requires_grad=True)
v = torch.randn(1, 1, 128, 32, device=device, dtype=dtype, requires_grad=True)
lse_mask = torch.randn(1, 1, 128, device=device)
compiled = torch.compile(flex_attention)
out, lse = compiled(q, k, v, return_lse=True, kernel_options={"BACKEND": "FLASH"})
loss = out.mean() + (lse * lse_mask).sum()
loss.backward()
torch.cuda.synchronize()
print("ok", q.grad.abs().max().item(), k.grad.abs().max().item(), v.grad.abs().max().item())
PY
```

Result: passed, printed nonzero finite gradients.

```bash
PYTORCH_TEST_WITH_INDUCTOR=1 INDUCTOR_TEST_DISABLE_FRESH_CACHE=1 TORCHINDUCTOR_COMPILE_THREADS=1 ../.venv/bin/pytest test/inductor/test_flex_flash.py -k "supports_grad_logsumexp" -v
```

Result: `2 passed, 259 deselected`.

```bash
PYTORCH_TEST_WITH_INDUCTOR=1 INDUCTOR_TEST_DISABLE_FRESH_CACHE=1 TORCHINDUCTOR_COMPILE_THREADS=1 ../.venv/bin/python test/inductor/test_flex_flash.py TestFlexFlashCUDA.test_flash_backend_supports_grad_logsumexp_cuda_float16 TestFlexFlashCUDA.test_flash_backend_supports_grad_logsumexp_cuda_bfloat16
```

Result: passed.

```bash
PYTORCH_TEST_WITH_INDUCTOR=1 INDUCTOR_TEST_DISABLE_FRESH_CACHE=1 TORCHINDUCTOR_COMPILE_THREADS=1 ../.venv/bin/python test/inductor/test_flex_flash.py TestFlexFlashCUDA.test_flash_backend_return_lse_matches_triton_and_reference_cuda_float16 TestFlexFlashCUDA.test_flash_backend_return_lse_matches_triton_and_reference_cuda_bfloat16
```

Result: passed.

```bash
PYTORCH_TEST_WITH_INDUCTOR=1 INDUCTOR_TEST_DISABLE_FRESH_CACHE=1 TORCHINDUCTOR_COMPILE_THREADS=1 ../.venv/bin/python test/inductor/test_flex_flash.py TestFlexFlashCUDA.test_flash_attention_score_mod_cases_backward_times_two_cuda_float16
```

Result: passed.

```bash
PYTORCH_TEST_WITH_INDUCTOR=1 INDUCTOR_TEST_DISABLE_FRESH_CACHE=1 TORCHINDUCTOR_COMPILE_THREADS=1 ../.venv/bin/python - <<'PY'
import torch
from torch.nn.attention.flex_attention import flex_attention

torch.manual_seed(1)
q = torch.randn(1, 1, 128, 32, device="cuda", dtype=torch.float16, requires_grad=True)
k = torch.randn_like(q, requires_grad=True)
v = torch.randn_like(q, requires_grad=True)
out = torch.compile(flex_attention)(q, k, v, kernel_options={"BACKEND": "FLASH"})
loss = out.square().mean()
loss.backward()
torch.cuda.synchronize()
print("ok_no_dlse", q.grad.abs().max().item(), k.grad.abs().max().item(), v.grad.abs().max().item())
PY
```

Result: passed.

```bash
PYTORCH_TEST_WITH_INDUCTOR=1 INDUCTOR_TEST_DISABLE_FRESH_CACHE=1 TORCHINDUCTOR_COMPILE_THREADS=1 ../.venv/bin/python - <<'PY'
import torch
from torch.nn.attention.flex_attention import create_block_mask, flex_attention

def causal_mask(_b, _h, q_idx, kv_idx):
    return q_idx >= kv_idx

torch.manual_seed(2)
device = "cuda"
dtype = torch.float16
major, _ = torch.cuda.get_device_capability(device)
block_size = (256, 128) if major == 10 else (128, 64 if major == 8 else 128)
q = torch.randn(1, 1, 256, 32, device=device, dtype=dtype, requires_grad=True)
k = torch.randn_like(q, requires_grad=True)
v = torch.randn_like(q, requires_grad=True)
block_mask = create_block_mask(causal_mask, 1, 1, 256, 256, device=device, BLOCK_SIZE=block_size)
out, lse = torch.compile(flex_attention)(
    q, k, v, block_mask=block_mask, return_lse=True, kernel_options={"BACKEND": "FLASH"}
)
loss = out.square().mean() + (lse * torch.randn_like(lse)).sum()
loss.backward()
torch.cuda.synchronize()
print("ok_block_dlse", q.grad.abs().max().item(), k.grad.abs().max().item(), v.grad.abs().max().item())
PY
```

Result: passed.

```bash
PYTORCH_TEST_WITH_INDUCTOR=1 INDUCTOR_TEST_DISABLE_FRESH_CACHE=1 TORCHINDUCTOR_COMPILE_THREADS=1 ../.venv/bin/python agent_space/fuzz_flex_flash_dlse.py
```

Result: passed 6 fuzz cases covering fp16/bf16, dense and causal block-mask paths, trivial and nontrivial score mods, varied shapes, and random nonzero `grad_lse`. Each case compared FLASH out/LSE/dQ/dK/dV against TRITON and fp32 eager reference.

```bash
git diff --check
```

Result: passed.

## Notes

- `pip index --pre` / PyPI shows the current package version as `4.0.0b21`; this appears to be the intended "4.21" beta naming.
- A pytest selection combining unrelated existing tests hit pytest/test-runner interaction failures, but the same selected tests pass with PyTorch's test-runner invocation recommended by the failure output.

## CI lint follow-up

- Triage command: `~/dotfiles/scripts/github_ci_triage https://github.com/pytorch/pytorch/pull/189784 --job-name lintrunner --max-jobs 5 --output-dir agent_space/ci_logs`.
- Failure was `lintrunner-noclang-partial / lint` PYFMT on `test/inductor/test_flex_flash.py`.
- Applied the PYFMT formatting patch around the new dLSE gradient parity test.
- Local validation passed with direct `lintrunner==0.12.7` over the same changed-file linter groups used by CI. The repo wrapper `.github/scripts/lintrunner.sh` was not usable in this shell because it expects `spin`.

</details>

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Chillee @yanboliang @BoyuanFeng @liangel-02 @howardzhang-cv