### PR TITLE
[MPS] Enable concurrent dispatch for compute encoder

### DIFF
--- a/aten/src/ATen/mps/MPSStream.mm
+++ b/aten/src/ATen/mps/MPSStream.mm
@@ -63,7 +63,7 @@ id<MTLDevice> MPSStream::device() const {
 
 id<MTLComputeCommandEncoder> MPSStream::commandEncoder() {
   if (!_commandEncoder) {
-    _commandEncoder = [commandBuffer() computeCommandEncoder].retain;
+    _commandEncoder = [commandBuffer() computeCommandEncoderWithDispatchType:MTLDispatchTypeConcurrent].retain;
   }
 
   return _commandEncoder;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #189785

This change improves some workloads by allowing independent kernel executions to be done at the same time. The following script measures the performance of one of these workloads:

<details><summary>Click to expand</summary>

```python
import torch
import torch.utils.benchmark as benchmark

def two_chained_sines(a, b):
    for _ in range(100):
        a = torch.sin(a)
        b = torch.sin(b)

device = 'mps'
dtype = torch.float32
sizes = [128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768]
results = []

print(f"device={device} dtype={dtype}")

for n in sizes:
    a = torch.randn(n, device=device, dtype=dtype)
    b = torch.randn(n, device=device, dtype=dtype)

    t = benchmark.Timer(
        stmt="f(a, b)",
        globals={"f": two_chained_sines, "a": a, "b": b},
        label="two matmuls",
        sub_label=f"n={n}",
        description=device,
    )

    # One warmup iter
    for _ in range(2):
        res = t.blocked_autorange(min_run_time=0.2)

    results.append(res)

    del a, b
    if device != "cpu":
        getattr(torch, device).empty_cache()

compare = benchmark.Compare(results)
compare.print()
```

</details>

As the printouts show, this seems to give nearly 2x speedup for the tested cases:

<details><summary>Click to expand</summary>

Before change:

```
device=mps dtype=torch.float32
[---- two matmuls ----]
               |   mps 
1 threads: ------------
      n=128    |  302.7
      n=256    |  306.6
      n=512    |  326.5
      n=1024   |  351.5
      n=2048   |  349.0
      n=4096   |  360.2
      n=8192   |  361.5
      n=16384  |  435.3
      n=32768  |  589.7

Times are in microseconds (us).
```

After change:

```
device=mps dtype=torch.float32
[---- two matmuls ----]
               |   mps 
1 threads: ------------
      n=128    |  152.4
      n=256    |  148.3
      n=512    |  148.3
      n=1024   |  148.4
      n=2048   |  152.5
      n=4096   |  168.9
      n=8192   |  205.2
      n=16384  |  234.0
      n=32768  |  281.8

Times are in microseconds (us).
```

</details>