### PR TITLE
Use `ArrayRef<const Variable*> in autograd.Function.apply

### DIFF
--- a/torch/csrc/autograd/custom_function.cpp
+++ b/torch/csrc/autograd/custom_function.cpp
@@ -8,6 +8,35 @@
 
 namespace torch::autograd {
 
+static const Variable& input_at(const variable_list& inputs, size_t i) {
+  return inputs[i];
+}
+
+static const Variable& input_at(
+    at::ArrayRef<const Variable*> inputs,
+    size_t i) {
+  return *inputs[i];
+}
+
+static variable_list call_jvp(
+    const variable_list& inputs,
+    variable_list input_grads,
+    const _jvp_fn_t& jvp_user_function) {
+  return jvp_user_function(inputs, std::move(input_grads));
+}
+
+static variable_list call_jvp(
+    at::ArrayRef<const Variable*> inputs,
+    variable_list input_grads,
+    const _jvp_fn_t& jvp_user_function) {
+  variable_list owned;
+  owned.reserve(inputs.size());
+  for (const auto* input : inputs) {
+    owned.emplace_back(*input);
+  }
+  return jvp_user_function(std::move(owned), std::move(input_grads));
+}
+
 // This function has two main goals:
 //  1) Use the user-provided jvp function to populate the outputs' forward
 //  gradient 2) Perform error checking to ensure that view and inplace ops are
@@ -26,8 +55,9 @@ namespace torch::autograd {
 //  sure that its
 //    forward grad was also modified inplace and already present on the
 //    corresponding output.
+template <typename InputVarsType>
 static void _process_forward_mode_AD(
-    const variable_list& inputs,
+    const InputVarsType& inputs,
     std::unordered_map<at::TensorImpl*, size_t> inputs_mapping,
     const at::ArrayRef<std::optional<Variable>> raw_outputs,
     const optional_variable_list& outputs,
@@ -54,7 +84,7 @@ static void _process_forward_mode_AD(
     grad_impls.resize(num_inputs);
 
     for (const auto i : c10::irange(num_inputs)) {
-      const auto& inp = inputs[i];
+      const auto& inp = input_at(inputs, i);
       if (inp.is_view() && impl::get_view_autograd_meta(inp)->has_fw_view()) {
         inputs_bases.emplace(
             impl::get_view_autograd_meta(inp)
@@ -71,7 +101,7 @@ static void _process_forward_mode_AD(
   // Extract the input's forward gradients and record any info we will need
   // later
   for (const auto i : c10::irange(num_inputs)) {
-    const auto& inp = inputs[i];
+    const auto& inp = input_at(inputs, i);
     if (!inp.defined()) {
       continue;
     }
@@ -95,7 +125,7 @@ static void _process_forward_mode_AD(
   torch::autograd::variable_list forward_grads;
   {
     at::AutoFwGradMode fw_grad_mode(false);
-    forward_grads = jvp_user_function(inputs, std::move(input_grads));
+    forward_grads = call_jvp(inputs, std::move(input_grads), jvp_user_function);
   }
 
   const auto num_forward_grads = forward_grads.size();
@@ -173,7 +203,7 @@ static void _process_forward_mode_AD(
           // have a common base)
           const auto matching_input_idx =
               inputs_bases[out_view_info.base_.unsafeGetTensorImpl()];
-          const auto& matching_input = inputs[matching_input_idx];
+          const auto& matching_input = input_at(inputs, matching_input_idx);
 
           const auto& matching_input_grad = matching_input._fw_grad(level);
 
@@ -442,8 +472,9 @@ static optional_variable_list _process_backward_mode_ad(
   return outputs;
 }
 
-optional_variable_list _wrap_outputs(
-    const variable_list& input_vars,
+template <typename InputVarsType>
+static optional_variable_list _wrap_outputs_impl(
+    const InputVarsType& input_vars,
     const std::unordered_set<at::TensorImpl*>& non_differentiable,
     const std::unordered_set<at::TensorImpl*>& dirty_inputs,
     const at::ArrayRef<std::optional<Variable>> raw_outputs,
@@ -455,7 +486,10 @@ optional_variable_list _wrap_outputs(
   std::unordered_map<at::TensorImpl*, size_t> inputs_mapping;
   inputs_mapping.reserve(input_vars.size());
   for (const auto i : c10::irange(input_vars.size())) {
-    inputs_mapping.emplace(input_vars[i].unsafeGetTensorImpl(), i);
+    const auto& input_var = input_at(input_vars, i);
+    if (input_var.defined()) {
+      inputs_mapping.emplace(input_var.unsafeGetTensorImpl(), i);
+    }
   }
 
   // Limit pure views to 1-1 mapping as it is unclear if it is even
@@ -486,6 +520,52 @@ optional_variable_list _wrap_outputs(
       jvp_user_function);
 
   return outputs;
+}
+
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+optional_variable_list _wrap_outputs(
+    const variable_list& input_vars,
+    const std::unordered_set<at::TensorImpl*>& non_differentiable,
+    const std::unordered_set<at::TensorImpl*>& dirty_inputs,
+    const at::ArrayRef<std::optional<Variable>> raw_outputs,
+    const c10::intrusive_ptr<Node>& cdata,
+    const _jvp_fn_t& jvp_user_function,
+    const std::unordered_set<at::TensorImpl*>& to_save_if_setup_context,
+    const _view_as_self_fn_t& view_as_self_fn,
+    bool pure_view) {
+  return _wrap_outputs_impl(
+      input_vars,
+      non_differentiable,
+      dirty_inputs,
+      raw_outputs,
+      cdata,
+      jvp_user_function,
+      to_save_if_setup_context,
+      view_as_self_fn,
+      pure_view);
+}
+
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+optional_variable_list _wrap_outputs(
+    at::ArrayRef<const Variable*> input_vars,
+    const std::unordered_set<at::TensorImpl*>& non_differentiable,
+    const std::unordered_set<at::TensorImpl*>& dirty_inputs,
+    const at::ArrayRef<std::optional<Variable>> raw_outputs,
+    const c10::intrusive_ptr<Node>& cdata,
+    const _jvp_fn_t& jvp_user_function,
+    const std::unordered_set<at::TensorImpl*>& to_save_if_setup_context,
+    const _view_as_self_fn_t& view_as_self_fn,
+    bool pure_view) {
+  return _wrap_outputs_impl(
+      input_vars,
+      non_differentiable,
+      dirty_inputs,
+      raw_outputs,
+      cdata,
+      jvp_user_function,
+      to_save_if_setup_context,
+      view_as_self_fn,
+      pure_view);
 }
 
 void check_variable_result(

--- a/torch/csrc/autograd/custom_function.h
+++ b/torch/csrc/autograd/custom_function.h
@@ -27,6 +27,17 @@ TORCH_API std::vector<std::optional<Variable>> _wrap_outputs(
     const _view_as_self_fn_t& view_as_self_fn,
     bool pure_view);
 
+TORCH_API std::vector<std::optional<Variable>> _wrap_outputs(
+    at::ArrayRef<const Variable*> input_vars,
+    const std::unordered_set<at::TensorImpl*>& non_differentiable,
+    const std::unordered_set<at::TensorImpl*>& dirty_inputs,
+    const at::ArrayRef<std::optional<Variable>> raw_outputs,
+    const c10::intrusive_ptr<Node>& cdata,
+    const _jvp_fn_t& jvp_user_function,
+    const std::unordered_set<at::TensorImpl*>& to_save_if_setup_context,
+    const _view_as_self_fn_t& view_as_self_fn,
+    bool pure_view);
+
 TORCH_API void check_variable_result(
     const at::TensorBase& original,
     const at::TensorBase& result,

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -4,6 +4,7 @@
 
 #include <ATen/ATen.h>
 #include <ATen/SequenceNumber.h>
+#include <c10/util/SmallVector.h>
 #include <c10/util/irange.h>
 #include <pybind11/pybind11.h>
 #include <structmember.h>
@@ -658,7 +659,7 @@ static std::unordered_set<at::TensorImpl*> _parse_non_differentiable(
 // mappings for output tensors as well.
 static void _wrap_outputs(
     THPFunction* self,
-    const variable_list& input_vars,
+    at::ArrayRef<const Variable*> input_vars,
     PyObject* raw_output,
     PyObject* outputs,
     bool is_executable,
@@ -931,7 +932,9 @@ static std::unordered_set<at::TensorImpl*> _parse_non_differentiable(
 
 struct UnpackedInput {
   THPObjectPtr input_tuple;
-  variable_list input_vars;
+  // Borrowed from Tensor arguments kept alive by input_tuple. Avoids copying
+  // at::Tensor handles on the common apply path.
+  c10::SmallVector<const Variable*, 24> input_vars;
   // record_function_inputs is for RECORD_FUNCTION only
   std::vector<c10::IValue> record_function_inputs;
 };
@@ -944,6 +947,15 @@ struct InputFlags {
 };
 
 namespace {
+edge_list collect_next_edges(at::ArrayRef<const Variable*> input_vars) {
+  edge_list next_edges;
+  next_edges.reserve(input_vars.size());
+  for (const auto* input_var : input_vars) {
+    next_edges.emplace_back(torch::autograd::impl::gradient_edge(*input_var));
+  }
+  return next_edges;
+}
+
 std::pair<UnpackedInput, InputFlags> unpack_input(
     PyObject* args,
     bool fill_record_function_inputs) {
@@ -953,8 +965,11 @@ std::pair<UnpackedInput, InputFlags> unpack_input(
   auto num_args = PyTuple_GET_SIZE(args);
   unpacked.input_tuple = PyTuple_New(num_args);
   flags.needs_input_grad = PyTuple_New(num_args);
+  unpacked.input_vars.reserve(num_args);
+  flags.is_variable_input.reserve(num_args);
   bool profiler_need_input = torch::autograd::profiler::profilerEnabled() &&
       torch::autograd::profiler::getProfilerConfig().report_input_shapes;
+  bool any_requires_grad = false;
 
   for (const auto i : c10::irange(num_args)) {
     PyObject* arg = PyTuple_GET_ITEM(args, i);
@@ -976,8 +991,10 @@ std::pair<UnpackedInput, InputFlags> unpack_input(
       }
     } else {
       const auto& tensor = THPVariable_Unpack(arg);
-      unpacked.input_vars.push_back(tensor);
-      PyObject* needs_grad = tensor.requires_grad() ? Py_True : Py_False;
+      unpacked.input_vars.push_back(&tensor);
+      const bool requires_grad = tensor.requires_grad();
+      any_requires_grad |= requires_grad;
+      PyObject* needs_grad = requires_grad ? Py_True : Py_False;
       Py_INCREF(needs_grad);
       PyTuple_SET_ITEM(flags.needs_input_grad.get(), i, needs_grad);
       // tensor -> IValue conversion is expensive, only do it if we need it.
@@ -989,11 +1006,10 @@ std::pair<UnpackedInput, InputFlags> unpack_input(
     PyTuple_SET_ITEM(unpacked.input_tuple.get(), i, arg);
   }
 
-  flags.is_executable =
-      GradMode::is_enabled() && any_variable_requires_grad(unpacked.input_vars);
-  flags.next_edges =
-      (flags.is_executable ? collect_next_edges(unpacked.input_vars)
-                           : edge_list());
+  flags.is_executable = GradMode::is_enabled() && any_requires_grad;
+  flags.next_edges = flags.is_executable
+      ? collect_next_edges(unpacked.input_vars)
+      : edge_list();
   return std::make_pair(std::move(unpacked), std::move(flags));
 }
 
@@ -1049,7 +1065,7 @@ void _append_subgraph(
 torch::jit::Node* _trace_pre_record(
     PyObject* op_obj,
     PyObject* input_objects,
-    const variable_list& input_vars) {
+    at::ArrayRef<const Variable*> input_vars) {
   if (!jit::tracer::isTracing()) {
     return nullptr;
   }
@@ -1073,14 +1089,19 @@ torch::jit::Node* _trace_pre_record(
 
   Py_INCREF(op_obj);
   auto pyobj = THPObjectPtr(op_obj);
+  variable_list owned;
+  owned.reserve(input_vars.size());
+  for (const auto* input_var : input_vars) {
+    owned.emplace_back(*input_var);
+  }
   return jit::tracer::preRecordPythonTrace(
-      std::move(pyobj), arg_types, input_vars, std::move(scalar_args));
+      std::move(pyobj), arg_types, owned, std::move(scalar_args));
 }
 
 void _trace_post_record(
     torch::jit::Node* node,
     PyObject* op_obj,
-    const variable_list& input_vars,
+    at::ArrayRef<const Variable*> /* input_vars */,
     PyObject* output_objects,
     bool is_inplace,
     bool unpack_output) {
@@ -1177,8 +1198,8 @@ PyObject* process_outputs(
   if (is_executable) {
     grad_fn->input_info.clear();
     grad_fn->input_info.reserve(unpacked.input_vars.size());
-    for (auto& var : unpacked.input_vars) {
-      grad_fn->input_info.emplace_back(var);
+    for (const auto* var : unpacked.input_vars) {
+      grad_fn->input_info.emplace_back(*var);
     }
   }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #189911
* #189901
* #189897
* #189866
* #189865
* #189810
* #189800
* __->__ #189788

THPFunction_apply only needs borrowed tensor handles for most of its bookkeeping. Store Python tensor inputs as an ArrayRef-compatible SmallVector<const Variable*, 24> and thread those borrowed Variables through output wrapping so the common path avoids constructing a variable_list and bumping TensorImpl refcounts.

Tracing and the user JVP callback still materialize a variable_list at the boundary that requires owned tensor handles.

On the local one-apply 13-in-2-out no-save instruction-count benchmark, this moved from 54,090 to 51,030 instructions.