### PR TITLE
[profiler] Clamp orphaned Python events to their parent's end

### DIFF
--- a/test/cpp/profiler/test_profiler_collection.cpp
+++ b/test/cpp/profiler/test_profiler_collection.cpp
@@ -37,6 +37,7 @@
 
 #include <c10/util/Exception.h>
 #include <torch/csrc/autograd/profiler_kineto.h>
+#include <torch/csrc/profiler/collection.h>
 #include <torch/csrc/profiler/standalone/privateuse1_profiler.h>
 
 #include <GenericTraceActivity.h>
@@ -261,6 +262,149 @@ TEST(ProfilerCollectionTest, DuplicateFlowIdHandledGracefully) {
   }
   EXPECT_TRUE(saw_per_id_warning);
   EXPECT_TRUE(saw_summary_warning);
+}
+
+namespace {
+using torch::profiler::impl::EventType;
+using torch::profiler::impl::ExtraFields;
+using torch::profiler::impl::PyFrameState;
+using torch::profiler::impl::Result;
+
+std::shared_ptr<Result> makePyCall(int64_t start_ns, int64_t end_ns, uint64_t tid) {
+  PyFrameState frame{0, at::StringView("f.py"), at::StringView("fn")};
+  PyFrameState caller{0, at::StringView("caller.py"), at::StringView("caller")};
+  ExtraFields<EventType::PyCall>::args_t args{frame, std::nullopt, std::nullopt};
+  return Result::create(
+      start_ns,
+      tid,
+      torch::profiler::impl::kineto::DeviceAndResource(),
+      ExtraFields<EventType::PyCall>(end_ns, tid, caller, std::move(args)));
+}
+
+std::shared_ptr<Result> makePyCCall(int64_t start_ns, int64_t end_ns, uint64_t tid) {
+  PyFrameState caller{0, at::StringView("caller.py"), at::StringView("caller")};
+  return Result::create(
+      start_ns,
+      tid,
+      torch::profiler::impl::kineto::DeviceAndResource(),
+      ExtraFields<EventType::PyCCall>(
+          end_ns, tid, caller, at::StringView("<built-in method foo>")));
+}
+
+// A cpu_op (RecordFunction) frame, used as a non-Python frame nested between two
+// Python frames (mirrors the autograd engine's evaluate_function frame).
+std::shared_ptr<Result> makeTorchOp(int64_t start_ns, int64_t end_ns, uint64_t tid) {
+  torch::profiler::impl::TorchOpBasicFields basic;
+  basic.name_ = "autograd::engine::evaluate_function";
+  return Result::create(
+      start_ns,
+      tid,
+      torch::profiler::impl::kineto::DeviceAndResource(),
+      ExtraFields<EventType::TorchOp>(
+          std::move(basic),
+          /*correlation_id=*/0,
+          /*end_time_ns=*/end_ns,
+          /*inputs=*/{},
+          /*concrete_inputs=*/{},
+          /*jit_stack=*/{},
+          /*jit_modules=*/{},
+          /*extra_args=*/{},
+          /*extra_meta=*/{},
+          /*kwinputs=*/{},
+          /*device_fallback=*/torch::profiler::impl::FallbackPair{},
+          /*allow_tf32_cublas=*/false,
+          /*perf_event_counters=*/nullptr));
+}
+
+} // namespace
+
+// These tests exercise clampOverrunningPythonEvents directly on hand-built trees
+// (parent_ links wired manually), so they neither depend on nor require exposing
+// the internal build_tree pass.
+
+// A Python C-call whose return event was dropped has its end clamped past its
+// caller. The clamp must bring it back to the caller's end (a callee cannot
+// outlive its caller).
+TEST(ProfilerTreeClampTest, OrphanChildClampedToParentEnd) {
+  const uint64_t tid = 1;
+  auto parent = makePyCall(/*start=*/100, /*end=*/200, tid);
+  auto child = makePyCCall(/*start=*/150, /*end=*/10000, tid);
+  child->parent_ = parent;
+  std::vector<std::shared_ptr<Result>> events{parent, child};
+
+  torch::profiler::impl::clampOverrunningPythonEvents(events);
+
+  EXPECT_EQ(child->endTimeNS(), 200);
+  EXPECT_EQ(parent->endTimeNS(), 200);
+}
+
+// Frames genuinely on the stack when profiling stops are all clamped to the
+// SAME profiler-end, so child end == parent end. The clamp must leave these
+// untouched (they are not orphans).
+TEST(ProfilerTreeClampTest, OnStackAtStopNotClamped) {
+  const uint64_t tid = 1;
+  auto parent = makePyCall(/*start=*/100, /*end=*/10000, tid);
+  auto child = makePyCCall(/*start=*/150, /*end=*/10000, tid);
+  child->parent_ = parent;
+  std::vector<std::shared_ptr<Result>> events{parent, child};
+
+  torch::profiler::impl::clampOverrunningPythonEvents(events);
+
+  EXPECT_EQ(child->endTimeNS(), 10000);
+  EXPECT_EQ(parent->endTimeNS(), 10000);
+}
+
+// The orphan's nearest Python ancestor is separated from it by a non-Python
+// cpu_op frame (as with autograd's evaluate_function between run_backward and
+// apply). The clamp must walk past the cpu_op to the Python ancestor.
+TEST(ProfilerTreeClampTest, OrphanClampedThroughNonPythonParent) {
+  const uint64_t tid = 1;
+  auto py_ancestor = makePyCCall(/*start=*/100, /*end=*/200, tid);
+  auto cpu_op = makeTorchOp(/*start=*/110, /*end=*/190, tid);
+  auto orphan = makePyCall(/*start=*/120, /*end=*/10000, tid);
+  orphan->parent_ = cpu_op;
+  cpu_op->parent_ = py_ancestor;
+  std::vector<std::shared_ptr<Result>> events{py_ancestor, cpu_op, orphan};
+
+  torch::profiler::impl::clampOverrunningPythonEvents(events);
+
+  // orphan's nearest Python ancestor is the PyCCall (end 200), reached by
+  // walking past the cpu_op.
+  EXPECT_EQ(orphan->endTimeNS(), 200);
+  EXPECT_EQ(py_ancestor->endTimeNS(), 200);
+}
+
+// A short event whose Python-ancestor link is stale -- it starts AFTER that
+// ancestor already returned (as seen with a mis-attributed `apply` on an
+// autograd worker) -- is not a duration bug. The `ancestor_end >= event_start`
+// guard must leave it untouched; clamping would wrongly force end < start. The
+// parent link is set directly to model the mis-attribution regardless of how it
+// arose during tree building.
+TEST(ProfilerTreeClampTest, StaleAncestorAttributionNotClamped) {
+  const uint64_t tid = 1;
+  auto ancestor = makePyCCall(/*start=*/100, /*end=*/200, tid);
+  auto child = makePyCall(/*start=*/500, /*end=*/600, tid);
+  child->parent_ = ancestor;
+  std::vector<std::shared_ptr<Result>> events{ancestor, child};
+
+  torch::profiler::impl::clampOverrunningPythonEvents(events);
+
+  EXPECT_EQ(child->endTimeNS(), 600);
+}
+
+// A child whose nearest Python ancestor is on a DIFFERENT Python thread is not a
+// real caller/callee (build_tree can pair unrelated threads when start_tid_ is
+// unresolved). The python_tid guard must leave it untouched even though it is
+// nested and overruns.
+TEST(ProfilerTreeClampTest, DifferentPythonThreadNotClamped) {
+  auto ancestor = makePyCCall(/*start=*/100, /*end=*/5000, /*tid=*/1);
+  auto child = makePyCall(/*start=*/500, /*end=*/10000, /*tid=*/2);
+  child->parent_ = ancestor;
+  std::vector<std::shared_ptr<Result>> events{ancestor, child};
+
+  torch::profiler::impl::clampOverrunningPythonEvents(events);
+
+  EXPECT_EQ(child->endTimeNS(), 10000);
 }
 
 #endif // USE_KINETO

--- a/torch/csrc/profiler/collection.cpp
+++ b/torch/csrc/profiler/collection.cpp
@@ -1472,6 +1472,59 @@ void build_tree(std::vector<std::shared_ptr<Result>>& sorted_events) {
 
   set_in_tree_building(sorted_events, false);
 }
+} // namespace
+
+// Clamps a Python event whose recorded end overruns its nearest Python
+// ancestor's end (an orphan whose return was never delivered, e.g. a dropped
+// C_RETURN on a GIL-releasing C-call) back down to the ancestor's end.
+// sorted_events must be start-time ascending so clamps cascade to children.
+void clampOverrunningPythonEvents(
+    std::vector<std::shared_ptr<Result>>& sorted_events) {
+  auto python_tid = [](const std::shared_ptr<Result>& r) {
+    size_t tid = std::numeric_limits<size_t>::max();
+    r->visit_if_base<PyExtraFieldsBase>(
+        [&](const auto& i) { tid = i.python_tid_; });
+    return tid;
+  };
+  for (auto& event : sorted_events) {
+    const auto tag = event->tag();
+    if (tag != EventType::PyCall && tag != EventType::PyCCall) {
+      continue;
+    }
+    std::shared_ptr<Result> ancestor = event->parent_.lock();
+    while (ancestor) {
+      const auto ancestor_tag = ancestor->tag();
+      if (ancestor_tag == EventType::PyCall ||
+          ancestor_tag == EventType::PyCCall) {
+        break;
+      }
+      ancestor = ancestor->parent_.lock();
+    }
+    if (!ancestor) {
+      continue;
+    }
+    // build_tree links by start_tid_, which is unresolved for threads already
+    // running at profiler start, so only clamp within one Python thread.
+    if (python_tid(event) != python_tid(ancestor)) {
+      continue;
+    }
+    // Only clamp genuinely nested events (event starts within the ancestor).
+    const auto ancestor_end_ns = ancestor->endTimeNS();
+    if (event->endTimeNS() > ancestor_end_ns &&
+        ancestor_end_ns >= event->start_time_ns_) {
+      event->visit(c10::overloaded(
+          [ancestor_end_ns](ExtraFields<EventType::PyCall>& i) {
+            i.end_time_ns_ = ancestor_end_ns;
+          },
+          [ancestor_end_ns](ExtraFields<EventType::PyCCall>& i) {
+            i.end_time_ns_ = ancestor_end_ns;
+          },
+          [](auto&) {}));
+    }
+  }
+}
+
+namespace {
 
 /**
  * Adjust r's duration to be the max of its current duration and the sum of all
@@ -1682,6 +1735,7 @@ RecordQueue::getRecords(
     }
   }
 
+  bool have_python_events = false;
   if (python_tracer_) {
     std::vector<std::shared_ptr<torch::profiler::impl::Result>> ev;
     try {
@@ -1723,18 +1777,28 @@ RecordQueue::getRecords(
       }
       out.push_back(i);
     }
+    have_python_events = !ev.empty();
     python_tracer_.reset();
   }
 
-  if (config_.experimental_config.adjust_timestamps) {
+  // Clamp orphaned Python events (and optionally adjust timestamps) before
+  // emitting Kineto events so the fix reaches the recorded durations. Gated to
+  // skip the extra sort + build_tree when there is nothing to fix. The clamped
+  // ends survive the reset, which lets the final build_tree rebuild cleanly.
+  if (have_python_events || config_.experimental_config.adjust_timestamps) {
     std::stable_sort(out.begin(), out.end(), [](const auto& a, const auto& b) {
       return a->start_time_ns_ < b->start_time_ns_;
     });
     build_tree(out);
-    adjust_timestamps(out);
+    if (have_python_events) {
+      clampOverrunningPythonEvents(out);
+    }
+    if (config_.experimental_config.adjust_timestamps) {
+      adjust_timestamps(out);
+    }
     for (auto& r : out) {
       r->parent_.reset();
-      // Reset these so that second build_tree can happen
+      // Reset these so that the final build_tree can happen
       r->finished_ = false;
       r->children_.clear();
     }

--- a/torch/csrc/profiler/collection.h
+++ b/torch/csrc/profiler/collection.h
@@ -467,6 +467,12 @@ struct TORCH_API Result : public std::enable_shared_from_this<Result> {
   }
 };
 
+// Clamps Python events whose end overruns their nearest Python ancestor (an
+// orphan whose return was never delivered) down to the ancestor's end. Expects a
+// built tree, start-time ascending. TORCH_API only so it can be unit-tested.
+TORCH_API void clampOverrunningPythonEvents(
+    std::vector<std::shared_ptr<Result>>& sorted_events);
+
 struct KinetoObserverContext : public at::ObserverContext {
   struct Event {
     TorchOpBasicFields basic_fields_;


### PR DESCRIPTION
Summary:
Fixes Kineto/PyTorch-profiler traces where a Python event runs until trace-end, corrupting CPU-overhead analysis. When CPython never delivers a Python frame's return to the profiler (e.g. a dropped `PyTrace_C_RETURN` for a pybind11 boxed C-call on a thread that released the GIL mid-call), `PythonTracer`'s replay leaves the frame open and clamps its end to the profiler-end timestamp, so the event overruns its own caller by hundreds of ms.

A callee cannot outlive its caller. A new post-pass `clampOverrunningPythonEvents` (run after `build_tree`) clamps any Python event whose end exceeds its nearest Python-ancestor's end down to that ancestor's end. It walks past intervening non-Python frames to reach the Python caller, never clamps against a non-Python or Kineto/GPU end. Frames genuinely on-stack when profiling stopped are unaffected (the whole stack is clamped to the same profiler-end). A `python_tid` guard skips clamping across unrelated threads whose `start_tid_` could not be resolved.

The clamp runs before `addKinetoEvents` so the corrected durations reach the Kineto trace; this requires the parent links first, so the pre-`addKinetoEvents` `build_tree`+sort (previously gated on `adjust_timestamps`) now also runs when Python events are present, and is skipped otherwise.

Test Plan:
New C++ unit tests directly drive `build_tree` and pass:

`OrphanChildClampedToParentEnd` (orphan whose direct parent is Python), `OrphanClampedThroughNonPythonParent` (orphan separated from its Python ancestor by a cpu_op frame), and `OnStackAtStopNotClamped` (a stack clamped to a common profiler-end is left untouched).


End-to-end on an APS DLRM GPU job (rank 0, with_stack), counting genuine orphans (a Python event that starts within its nearest Python ancestor but whose end exceeds it): before the fix, 10 genuine orphans per profiler cycle (90 across 9 cycles), all `permute_2D_sparse_data` with 106-358ms durations. With the fix: 0 genuine orphans across all 9 cycles ([trace](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/traces/dynocli/aps-hjli-creturn-fix-4a956b17f5/0/rank-0.Jul_13_15_52_49.5259.pt.trace.json.gz&bucket=aps_traces) after applying this fix).

Reviewed By: sanrise

Differential Revision: D111805950


