### PR TITLE
[llvm21] test_float_to_int_conversion_finite: fold int8 into int16 branch

### DIFF
--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -1091,13 +1091,11 @@ class TestTensorCreation(TestCase):
             # Note: numpy -2.0 or -1.5 -> uint8 conversion is undefined
             #       see https://github.com/pytorch/pytorch/issues/97794
             refs = (0, 254, 255, 0, 0, 0, 1, 2)
-        elif dtype == torch.int16:
-            # CPU min and max float -> int16 conversion is divergent.
-            vals = (-2, -1.5, -.5, 0, .5, 1.5, 2)
-        elif dtype == torch.int8:
-            # CPU min and max float -> int8 conversion is divergent under clang-21
-            # (out-of-range float->int is UB; codegen differs from numpy's
-            # reference). Drop the out-of-range extremes, mirroring int16 above.
+        elif dtype in (torch.int8, torch.int16):
+            # CPU min and max float -> int8/int16 conversion is divergent.
+            # (int8 also diverges under clang-21: out-of-range float->int is UB
+            # and codegen differs from numpy's reference.) Drop the out-of-range
+            # extremes.
             vals = (-2, -1.5, -.5, 0, .5, 1.5, 2)
 
         self._float_to_int_conversion_helper(vals, device, dtype, refs)


### PR DESCRIPTION
Follow-up to #189717 addressing @albanD's review comment ("You can re-use the condition above") on `test/test_tensor_creation_ops.py`.

In `test_float_to_int_conversion_finite`, the `torch.int8` and `torch.int16` CPU branches used identical `vals`. This folds them into a single `dtype in (torch.int8, torch.int16)` case instead of duplicating the branch.

No behavior change: the set of test values for int8 and int16 is unchanged.

## Test Plan
- `python test/test_tensor_creation_ops.py TestTensorCreationCPU.test_float_to_int_conversion_finite_cpu_int8`
- `python test/test_tensor_creation_ops.py TestTensorCreationCPU.test_float_to_int_conversion_finite_cpu_int16`
