### PR TITLE
Lazy materialize Function needs_input_grad

### DIFF
--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -5680,6 +5680,7 @@ skipped_tests.add("test_custom_function_boxed_grads_direct_apply")
 skipped_tests.add("test_custom_function_boxed_grads_single_list_arg")
 
 skipped_tests.add("test_pyobject_dispatch_normalizes_tensor_list_output")
+skipped_tests.add("test_needs_input_grad_setter_roundtrip")
 
 # DTensor backward calls a skipped global-shape helper under compiled autograd.
 skipped_tests.add("test_compile_dtensor_local_tensor_act_backward_passthrough")

--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -5680,7 +5680,8 @@ skipped_tests.add("test_custom_function_boxed_grads_direct_apply")
 skipped_tests.add("test_custom_function_boxed_grads_single_list_arg")
 
 skipped_tests.add("test_pyobject_dispatch_normalizes_tensor_list_output")
-skipped_tests.add("test_needs_input_grad_setter_roundtrip")
+skipped_tests.add("test_needs_input_grad_setter_roundtrip_num_inputs_2")
+skipped_tests.add("test_needs_input_grad_setter_roundtrip_num_inputs_25")
 
 # DTensor backward calls a skipped global-shape helper under compiled autograd.
 skipped_tests.add("test_compile_dtensor_local_tensor_act_backward_passthrough")

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2288,6 +2288,31 @@ class TestAutograd(TestCase):
         sum(rx, ry).sum().backward()
         self.assertTrue(was_called[0])
 
+    def test_needs_input_grad_setter_roundtrip(self):
+        sentinel = ([False, True],)
+
+        class NeedsInputGradSetter(Function):
+            @staticmethod
+            def forward(ctx, x, y):
+                return x + y
+
+            @staticmethod
+            def backward(ctx, grad):
+                original = ctx.needs_input_grad
+                self.assertEqual(original, (True, False))
+                ctx.needs_input_grad = sentinel
+                self.assertIs(ctx.needs_input_grad, sentinel)
+                ctx.needs_input_grad = None
+                self.assertIsNone(ctx.needs_input_grad)
+                ctx.needs_input_grad = original
+                self.assertIs(ctx.needs_input_grad, original)
+                return grad, None
+
+        x = torch.randn((), requires_grad=True)
+        y = torch.randn(())
+        NeedsInputGradSetter.apply(x, y).backward()
+        self.assertEqual(x.grad, torch.ones_like(x))
+
     def test_retain_grad(self):
         input = torch.rand(1, 3, requires_grad=True)
         h1 = input * 3

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2288,29 +2288,30 @@ class TestAutograd(TestCase):
         sum(rx, ry).sum().backward()
         self.assertTrue(was_called[0])
 
-    def test_needs_input_grad_setter_roundtrip(self):
+    @parametrize("num_inputs", [2, 25])
+    def test_needs_input_grad_setter_roundtrip(self, num_inputs):
         sentinel = ([False, True],)
 
         class NeedsInputGradSetter(Function):
             @staticmethod
-            def forward(ctx, x, y):
-                return x + y
+            def forward(ctx, *inputs):
+                return inputs[0] + inputs[1]
 
             @staticmethod
             def backward(ctx, grad):
                 original = ctx.needs_input_grad
-                self.assertEqual(original, (True, False))
+                self.assertEqual(original, (True,) + (False,) * (num_inputs - 1))
                 ctx.needs_input_grad = sentinel
                 self.assertIs(ctx.needs_input_grad, sentinel)
                 ctx.needs_input_grad = None
                 self.assertIsNone(ctx.needs_input_grad)
                 ctx.needs_input_grad = original
                 self.assertIs(ctx.needs_input_grad, original)
-                return grad, None
+                return (grad,) + (None,) * (num_inputs - 1)
 
         x = torch.randn((), requires_grad=True)
-        y = torch.randn(())
-        NeedsInputGradSetter.apply(x, y).backward()
+        inputs = (x,) + tuple(torch.randn(()) for _ in range(num_inputs - 1))
+        NeedsInputGradSetter.apply(*inputs).backward()
         self.assertEqual(x.grad, torch.ones_like(x))
 
     def test_retain_grad(self):

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -93,6 +93,29 @@ void throw_python_error() {
   throw std::move(err);
 }
 
+PyObject* materialize_needs_input_grad(THPFunction* self) {
+  if (self->needs_input_grad) {
+    return Py_NewRef(self->needs_input_grad);
+  }
+  if (!self->needs_input_grad_bits_valid) {
+    Py_RETURN_NONE;
+  }
+
+  PyObject* result =
+      PyTuple_New(static_cast<Py_ssize_t>(self->needs_input_grad_bits.size()));
+  if (!result) {
+    return nullptr;
+  }
+  for (const auto i : c10::irange(self->needs_input_grad_bits.size())) {
+    PyTuple_SET_ITEM(
+        result,
+        static_cast<Py_ssize_t>(i),
+        Py_NewRef(self->needs_input_grad_bits[i] ? Py_True : Py_False));
+  }
+  self->needs_input_grad = result;
+  return Py_NewRef(result);
+}
+
 static PyObject* unpack_saved_variables(
     THPFunction* self,
     const std::function<PyObject*(const Variable&)>& unpack_fn) {
@@ -413,6 +436,10 @@ void PyNode::compiled_args(CompiledNodeArgs& args) const {
   args.collect(f->saved_variables, true); // always unpacked as output in eager
   args.collect(f->materialize_grads);
   args.collect(f->is_variable_input);
+  THPObjectPtr needs_input_grad(materialize_needs_input_grad(f));
+  if (!needs_input_grad) {
+    throw_python_error();
+  }
   args.collect(f->needs_input_grad);
   args.collect(f->materialize_non_diff_grads);
   args.collect(f->output_info);
@@ -455,6 +482,10 @@ variable_list PyNode::apply_with_saved(
     const variable_list& inputs,
     SwapSavedVariables& saved) {
   auto* f = reinterpret_cast<THPFunction*>(pyobj());
+  THPObjectPtr needs_input_grad(materialize_needs_input_grad(f));
+  if (!needs_input_grad) {
+    throw_python_error();
+  }
   saved.before(f->compiled_autograd_symints);
   saved.before(f->saved_variables);
   saved.before(f->needs_input_grad);
@@ -570,6 +601,7 @@ static void THPFunction_dealloc(THPFunction* self) {
   self->input_info.~vector();
   self->saved_variables.~vector();
   self->is_variable_input.~vector();
+  self->needs_input_grad_bits.~SmallVector();
   if (self->cdata) {
     auto* slot = self->cdata->pyobj_slot();
     if (slot->load_pyobj() == reinterpret_cast<PyObject*>(self)) {
@@ -595,9 +627,11 @@ static PyObject* THPFunction_new(
   new (&self->input_info) std::vector<VariableInfo>();
   new (&self->saved_variables) std::vector<SavedVariable>();
   new (&self->is_variable_input) std::vector<bool>();
+  new (&self->needs_input_grad_bits) c10::SmallVector<bool, 24>();
   self->materialize_grads = true;
   self->pure_view = false;
   self->materialize_non_diff_grads = true;
+  self->needs_input_grad_bits_valid = false;
   self->clear_saved_tensors_on_access = false;
   self->saved_tensors_accessed_and_cleared = false;
   torch::utils::PyObjectPreservation::init_fresh_nonatomic(*self->cdata, obj);
@@ -943,7 +977,7 @@ struct UnpackedInput {
 struct InputFlags {
   bool is_executable = false;
   edge_list next_edges;
-  THPObjectPtr needs_input_grad;
+  c10::SmallVector<bool, 24> needs_input_grad;
   std::vector<bool> is_variable_input;
 };
 
@@ -965,7 +999,7 @@ std::pair<UnpackedInput, InputFlags> unpack_input(
 
   auto num_args = PyTuple_GET_SIZE(args);
   unpacked.input_tuple = PyTuple_New(num_args);
-  flags.needs_input_grad = PyTuple_New(num_args);
+  flags.needs_input_grad.reserve(num_args);
   unpacked.input_vars.reserve(num_args);
   flags.is_variable_input.reserve(num_args);
   bool profiler_need_input = torch::autograd::profiler::profilerEnabled() &&
@@ -979,7 +1013,7 @@ std::pair<UnpackedInput, InputFlags> unpack_input(
     flags.is_variable_input.push_back(is_variable);
     if (!is_variable) {
       // Non-tensor argument: it can't require grad.
-      PyTuple_SET_ITEM(flags.needs_input_grad.get(), i, Py_NewRef(Py_False));
+      flags.needs_input_grad.push_back(false);
 
       if (profiler_need_input) {
         // The following conversion from PyObject to IValue is expensive
@@ -995,9 +1029,7 @@ std::pair<UnpackedInput, InputFlags> unpack_input(
       unpacked.input_vars.push_back(&tensor);
       const bool requires_grad = tensor.requires_grad();
       any_requires_grad |= requires_grad;
-      PyObject* needs_grad = requires_grad ? Py_True : Py_False;
-      Py_INCREF(needs_grad);
-      PyTuple_SET_ITEM(flags.needs_input_grad.get(), i, needs_grad);
+      flags.needs_input_grad.push_back(requires_grad);
       // tensor -> IValue conversion is expensive, only do it if we need it.
       if (fill_record_function_inputs) {
         unpacked.record_function_inputs.emplace_back(tensor);
@@ -1577,7 +1609,9 @@ PyObject* THPFunction_apply(PyObject* cls, PyObject* args, PyObject* kwargs) {
   // Initialize backward function (and ctx)
   bool is_executable = input_info.is_executable;
   cdata->set_next_edges(std::move(input_info.next_edges));
-  ctx->needs_input_grad = input_info.needs_input_grad.release();
+  Py_CLEAR(ctx->needs_input_grad);
+  ctx->needs_input_grad_bits = std::move(input_info.needs_input_grad);
+  ctx->needs_input_grad_bits_valid = true;
   ctx->is_variable_input = std::move(input_info.is_variable_input);
 
   // Get clear_saved_tensors_on_access from the Function class
@@ -1961,6 +1995,24 @@ int setObject(PyObject* obj, PyObject* value, void* _unused) {
   return 0;
 }
 
+PyObject* getNeedsInputGrad(PyObject* obj, void* _unused) {
+  auto self = (THPFunction*)obj;
+  return materialize_needs_input_grad(self);
+}
+
+int setNeedsInputGrad(PyObject* obj, PyObject* value, void* _unused) {
+  auto self = (THPFunction*)obj;
+  if (Py_IsNone(value)) {
+    value = nullptr;
+  }
+  Py_XDECREF(self->needs_input_grad);
+  Py_XINCREF(value);
+  self->needs_input_grad = value;
+  self->needs_input_grad_bits.clear();
+  self->needs_input_grad_bits_valid = false;
+  return 0;
+}
+
 template <typename M, M THPFunction::* ptr, PyObject* (*Convert)(long)>
 PyObject* getMember(PyObject* obj, void* _unused) {
   auto self = (THPFunction*)obj;
@@ -2022,8 +2074,8 @@ static struct PyGetSetDef THPFunction_properties[] = {
      nullptr,
      nullptr},
     {"needs_input_grad",
-     &getObject<&THPFunction::needs_input_grad>,
-     &setObject<&THPFunction::needs_input_grad>,
+     &getNeedsInputGrad,
+     &setNeedsInputGrad,
      nullptr,
      nullptr},
     {"requires_grad", getRequiresGrad, nullptr, nullptr, nullptr},

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -53,6 +53,8 @@ using namespace torch;
 using namespace torch::autograd;
 using at::Tensor;
 
+// NOLINTBEGIN(hicpp-exception-baseclass)
+
 PyObject* THPFunctionClass = nullptr;
 PyObject* THPGradientEdgeClass = nullptr;
 
@@ -97,23 +99,28 @@ PyObject* materialize_needs_input_grad(THPFunction* self) {
   if (self->needs_input_grad) {
     return Py_NewRef(self->needs_input_grad);
   }
-  if (!self->needs_input_grad_bits_valid) {
+  if (!self->needs_input_grad_bits.has_value()) {
+    // needs_input_grad=None is represented as needs_input_grad=nullptr and
+    // needs_input_grad_bits=nullopt. The needs_input_grad setter/getter, like
+    // other autograd.Function fields, normalizes Py_None to nullptr.
     Py_RETURN_NONE;
   }
 
-  PyObject* result =
-      PyTuple_New(static_cast<Py_ssize_t>(self->needs_input_grad_bits.size()));
+  const auto& needs_input_grad_bits = *self->needs_input_grad_bits;
+  THPObjectPtr result(
+      PyTuple_New(static_cast<Py_ssize_t>(needs_input_grad_bits.size())));
   if (!result) {
     return nullptr;
   }
-  for (const auto i : c10::irange(self->needs_input_grad_bits.size())) {
+  for (const auto i : c10::irange(needs_input_grad_bits.size())) {
     PyTuple_SET_ITEM(
-        result,
+        result.get(),
         static_cast<Py_ssize_t>(i),
-        Py_NewRef(self->needs_input_grad_bits[i] ? Py_True : Py_False));
+        Py_NewRef(needs_input_grad_bits[i] ? Py_True : Py_False));
   }
-  self->needs_input_grad = result;
-  return Py_NewRef(result);
+  self->needs_input_grad = result.release();
+  self->needs_input_grad_bits.reset();
+  return Py_NewRef(self->needs_input_grad);
 }
 
 static PyObject* unpack_saved_variables(
@@ -601,7 +608,7 @@ static void THPFunction_dealloc(THPFunction* self) {
   self->input_info.~vector();
   self->saved_variables.~vector();
   self->is_variable_input.~vector();
-  self->needs_input_grad_bits.~SmallVector();
+  std::destroy_at(&self->needs_input_grad_bits);
   if (self->cdata) {
     auto* slot = self->cdata->pyobj_slot();
     if (slot->load_pyobj() == reinterpret_cast<PyObject*>(self)) {
@@ -627,11 +634,11 @@ static PyObject* THPFunction_new(
   new (&self->input_info) std::vector<VariableInfo>();
   new (&self->saved_variables) std::vector<SavedVariable>();
   new (&self->is_variable_input) std::vector<bool>();
-  new (&self->needs_input_grad_bits) c10::SmallVector<bool, 24>();
+  new (&self->needs_input_grad_bits)
+      std::optional<c10::SmallVector<bool, 24>>();
   self->materialize_grads = true;
   self->pure_view = false;
   self->materialize_non_diff_grads = true;
-  self->needs_input_grad_bits_valid = false;
   self->clear_saved_tensors_on_access = false;
   self->saved_tensors_accessed_and_cleared = false;
   torch::utils::PyObjectPreservation::init_fresh_nonatomic(*self->cdata, obj);
@@ -1610,8 +1617,7 @@ PyObject* THPFunction_apply(PyObject* cls, PyObject* args, PyObject* kwargs) {
   bool is_executable = input_info.is_executable;
   cdata->set_next_edges(std::move(input_info.next_edges));
   Py_CLEAR(ctx->needs_input_grad);
-  ctx->needs_input_grad_bits = std::move(input_info.needs_input_grad);
-  ctx->needs_input_grad_bits_valid = true;
+  ctx->needs_input_grad_bits.emplace(std::move(input_info.needs_input_grad));
   ctx->is_variable_input = std::move(input_info.is_variable_input);
 
   // Get clear_saved_tensors_on_access from the Function class
@@ -2008,8 +2014,7 @@ int setNeedsInputGrad(PyObject* obj, PyObject* value, void* _unused) {
   Py_XDECREF(self->needs_input_grad);
   Py_XINCREF(value);
   self->needs_input_grad = value;
-  self->needs_input_grad_bits.clear();
-  self->needs_input_grad_bits_valid = false;
+  self->needs_input_grad_bits.reset();
   return 0;
 }
 
@@ -2180,3 +2185,5 @@ bool THPFunction_initModule(PyObject* module) {
     return false;
   return true;
 }
+
+// NOLINTEND(hicpp-exception-baseclass)

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -53,15 +53,13 @@ using namespace torch;
 using namespace torch::autograd;
 using at::Tensor;
 
-// NOLINTBEGIN(hicpp-exception-baseclass)
-
 PyObject* THPFunctionClass = nullptr;
 PyObject* THPGradientEdgeClass = nullptr;
 
 #define THPFunction_assert(condition, ...) \
   if (!(condition)) {                      \
     THPUtils_setError(__VA_ARGS__);        \
-    throw python_error();                  \
+    throw_python_error();                  \
   }
 
 // Anonymous namespace for helpful functions used in this file
@@ -92,6 +90,7 @@ inline void check_legacy_fn_attr_access(
 void throw_python_error() {
   python_error err;
   err.persist();
+  // NOLINTNEXTLINE(hicpp-exception-baseclass)
   throw std::move(err);
 }
 
@@ -165,7 +164,7 @@ PyObject* to_py_size(const std::vector<c10::SymInt>& size) {
   auto ret = THPObjectPtr(THPSizeType.tp_alloc(
       &THPSizeType, static_cast<Py_ssize_t>(sym_sizes.size())));
   if (!ret)
-    throw python_error();
+    throw_python_error();
 
   for (auto i : c10::irange(sym_sizes.size())) {
     auto symint = sym_sizes[i];
@@ -287,7 +286,7 @@ auto PyNode::apply_with_saved_impl(
   THPObjectPtr fwdInputMetadatas(
       PyTuple_New(static_cast<Py_ssize_t>(is_variable_input.size())));
   if (!fwdInputMetadatas)
-    throw python_error();
+    throw_python_error();
 
   int offset = 0;
   for (const auto i : c10::irange(is_variable_input.size())) {
@@ -306,7 +305,7 @@ auto PyNode::apply_with_saved_impl(
     // Metadata is a tuple of 4 elements: (layout, device, dtype, size)
     THPObjectPtr fwdInputMetadata(PyTuple_New(4));
     if (!fwdInputMetadata)
-      throw python_error();
+      throw_python_error();
     PyTuple_SET_ITEM(
         fwdInputMetadata.get(), 0, autograd::utils::wrap(input_info.layout));
     PyTuple_SET_ITEM(fwdInputMetadata.get(), 1, device.release());
@@ -797,13 +796,13 @@ static void _wrap_outputs(
     THPObjectPtr py_x(THPVariable_Wrap(x));
     THPObjectPtr py_view_as_method(PyObject_GetAttrString(py_x, "view_as"));
     if (!py_view_as_method)
-      throw python_error();
+      throw_python_error();
     THPObjectPtr args(PyTuple_Pack(1, py_x.get()));
     if (!args)
-      throw python_error();
+      throw_python_error();
     THPObjectPtr result(PyObject_CallObject(py_view_as_method, args));
     if (!result)
-      throw python_error();
+      throw_python_error();
     return THPVariable_Unpack(result);
   };
 
@@ -1230,7 +1229,7 @@ PyObject* process_outputs(
 
   THPObjectPtr outputs(PyTuple_New(num_outputs));
   if (!outputs)
-    throw python_error();
+    throw_python_error();
 
   grad_fn->cdata->clear_input_metadata();
 
@@ -1837,7 +1836,7 @@ PyObject* THPFunction_saved_variables(THPFunction* self, void* _unused) {
       "'saved_variables' is deprecated; use 'saved_tensors'",
       0);
   if (r != 0)
-    throw python_error();
+    throw_python_error();
   TORCH_CHECK(
       !self->saved_tensors_accessed_and_cleared,
       "saved_tensors can only be accessed once when "
@@ -1867,7 +1866,7 @@ PyObject* THPFunction_get_compiled_autograd_symints(
   auto size = self->compiled_autograd_symints.size();
   THPObjectPtr result(PyTuple_New(static_cast<Py_ssize_t>(size)));
   if (!result) {
-    throw python_error();
+    throw_python_error();
   }
   for (const auto i : c10::irange(size)) {
     PyTuple_SET_ITEM(
@@ -2185,5 +2184,3 @@ bool THPFunction_initModule(PyObject* module) {
     return false;
   return true;
 }
-
-// NOLINTEND(hicpp-exception-baseclass)

--- a/torch/csrc/autograd/python_function.h
+++ b/torch/csrc/autograd/python_function.h
@@ -10,6 +10,8 @@
 #include <torch/csrc/autograd/variable.h>
 #include <torch/csrc/utils/object_ptr.h>
 
+#include <c10/util/SmallVector.h>
+
 #include <c10/core/DeviceGuard.h>
 #include <optional>
 
@@ -68,6 +70,7 @@ inline bool ensure_tuple(THPObjectPtr& obj) {
 
   PyObject* tuple = PyTuple_New(1);
   if (!tuple)
+    // NOLINTNEXTLINE(hicpp-exception-baseclass)
     throw python_error();
   PyTuple_SET_ITEM(tuple, 0, obj.release());
   obj = tuple;
@@ -81,6 +84,10 @@ struct THPFunction {
   PyObject_HEAD
 
   PyObject* needs_input_grad;
+  // Optimization: avoid materializing the needs_input_grad Python tuple until
+  // first access. The hot apply path records the values here instead.
+  c10::SmallVector<bool, 24> needs_input_grad_bits;
+  bool needs_input_grad_bits_valid;
 
   // Python tuple of tensors whose variables we should save.  Set
   // by Python with 'save_for_backward'.  If nullptr, no tensors were

--- a/torch/csrc/autograd/python_function.h
+++ b/torch/csrc/autograd/python_function.h
@@ -84,10 +84,10 @@ struct THPFunction {
   PyObject_HEAD
 
   PyObject* needs_input_grad;
-  // Optimization: avoid materializing the needs_input_grad Python tuple until
-  // first access. The hot apply path records the values here instead.
-  c10::SmallVector<bool, 24> needs_input_grad_bits;
-  bool needs_input_grad_bits_valid;
+  // Lazily stores the default ctx.needs_input_grad values until the Python
+  // tuple is first requested. needs_input_grad is authoritative once set,
+  // either by materialization or direct Python assignment.
+  std::optional<c10::SmallVector<bool, 24>> needs_input_grad_bits;
 
   // Python tuple of tensors whose variables we should save.  Set
   // by Python with 'save_for_backward'.  If nullptr, no tensors were


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #189901
* #189897
* #189866
* #189865
* __->__ #189810

Keep ctx->needs_input_grad as the materialized Python tuple, but store the hot apply-path result in needs_input_grad_bits until something asks for the tuple. needs_input_grad_bits_valid is cleared if the property is set directly so stale bits are not materialized later.

This avoids allocating and filling the tuple on the common apply path. The inline bit storage uses capacity 24 to cover the issue-shaped input count without heap allocation.

On the local one-apply 13-in-2-out no-save instruction-count benchmark, this moved from 50,802 to 50,371 instructions.

Authored with assistance from an AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo