### PR TITLE
Widen unbacked-parity regression threshold for MobileBertForMaskedLM

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1193,6 +1193,19 @@ test_unbacked_parity_smoketest() {
   local MAX_RETRIES=3
   local MODELS="MobileBertForMaskedLM|DistilBertForMaskedLM|DistillGPT2|T5Small"
 
+  # Per-model regression threshold override (percent). Most models track backed
+  # vs unbacked to within +-0.5%, but MobileBertForMaskedLM has bimodal compiled
+  # timings (~101ms vs ~103ms) where backed and unbacked independently land in
+  # different modes, giving up to +-1.7% run-to-run jitter with no directional
+  # regression. Use a wider band for it so noise doesn't red the periodic job
+  # while still catching a genuine regression.
+  model_threshold() {
+    case "$1" in
+      MobileBertForMaskedLM) echo "3.0" ;;
+      *) echo "$THRESHOLD" ;;
+    esac
+  }
+
   # Issue 6: Write per-run output files for post-failure debugging
   run_comparison() {
     local run_num=$1
@@ -1216,8 +1229,10 @@ test_unbacked_parity_smoketest() {
         local model="${BASH_REMATCH[1]}"
         local diff="${BASH_REMATCH[4]}"
         # Nit: Use awk instead of bc -l to avoid dependency on bc
-        if awk "BEGIN{exit !($diff > $THRESHOLD)}"; then
-          regressions+=("$model:+${diff}%")
+        local model_thr
+        model_thr=$(model_threshold "$model")
+        if awk "BEGIN{exit !($diff > $model_thr)}"; then
+          regressions+=("$model:+${diff}% (threshold ${model_thr}%)")
         fi
       fi
     done < "$output_file"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189812

The periodic inductor_huggingface_unbacked_parity job intermittently reds on
MobileBertForMaskedLM (e.g. "Regressions found: MobileBertForMaskedLM:+1.2%")
with no real regression behind it.

MobileBert's backed and unbacked compiled times are ~equal and land in a
bimodal (~101ms / ~103ms) distribution independently, so the backed-vs-unbacked
diff is dominated by autotune/measurement jitter, not a directional slowdown.
Over 16 independent runs the diff is centered at zero (mean/median ~0%, ~+-2%
spread, 50/50 sign split) -- an autotune-selection flake. Building a pre-onset
commit reproduces the same variance, confirming it is not a code regression.

Add a per-model threshold override: MobileBertForMaskedLM uses a 3.0% band
(comfortably above the ~1.7% jitter observed on the a10g runner) while the
other three models keep the strict 1.0% threshold, so the flake is suppressed
without loosening the check for models that are actually stable.

Test Plan:
- bash -n .ci/pytorch/test.sh (no syntax errors)
- Simulated check_regressions: MobileBert +1.7% -> ok, +3.2% -> flagged;
  DistilBertForMaskedLM +1.7% -> still flagged at 1.0%.