### PR TITLE
Move unbacked-parity regression policy into the benchmark; widen MobileBert

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1185,11 +1185,11 @@ test_inductor_torchbench_smoketest_perf() {
 
 test_unbacked_parity_smoketest() {
   # Check that unbacked batch-only has performance parity with backed batch-only
-  # Fails if any model regresses >THRESHOLD% consistently across 3 retries
+  # Fails if any model regresses beyond its per-model threshold (defined in the
+  # benchmark, see benchmarks/dynamo/common.py) consistently across 3 retries.
   TEST_REPORTS_DIR=$(pwd)/test/test-reports
   mkdir -p "$TEST_REPORTS_DIR"
 
-  local THRESHOLD=1.0
   local MAX_RETRIES=3
   local MODELS="MobileBertForMaskedLM|DistilBertForMaskedLM|DistillGPT2|T5Small"
 
@@ -1206,24 +1206,12 @@ test_unbacked_parity_smoketest() {
   check_regressions() {
     local run_num=$1
     local output_file="$TEST_REPORTS_DIR/unbacked_parity_results_run${run_num}.txt"
-    # Parse the comparison table and check for regressions > threshold
-    # Returns 0 if regressions found, 1 if no regressions
-    local regressions=()
-    while IFS= read -r line; do
-      # Issue 3: Broadened regex to match model names with hyphens, slashes, dots
-      # Match lines like: "  ModelName                      10.000      10.500    +5.0%"
-      if [[ "$line" =~ ^[[:space:]]+([A-Za-z0-9_./-]+)[[:space:]]+([0-9.]+)[[:space:]]+([0-9.]+)[[:space:]]+\+([0-9.]+)% ]]; then
-        local model="${BASH_REMATCH[1]}"
-        local diff="${BASH_REMATCH[4]}"
-        # Nit: Use awk instead of bc -l to avoid dependency on bc
-        if awk "BEGIN{exit !($diff > $THRESHOLD)}"; then
-          regressions+=("$model:+${diff}%")
-        fi
-      fi
-    done < "$output_file"
-
-    if [[ ${#regressions[@]} -gt 0 ]]; then
-      echo "Regressions found: ${regressions[*]}"
+    # The regression policy (per-model thresholds) lives in the benchmark itself
+    # (_run_compare_backed_unbacked in benchmarks/dynamo/common.py), which emits a
+    # canonical "UNBACKED_PARITY_REGRESSION:" verdict line. This just detects it.
+    # Returns 0 if a regression was reported, 1 otherwise.
+    if grep -q "^UNBACKED_PARITY_REGRESSION:" "$output_file"; then
+      grep "^UNBACKED_PARITY_REGRESSION:" "$output_file"
       return 0
     fi
     return 1
@@ -1289,7 +1277,7 @@ test_unbacked_parity_smoketest() {
 
   # Check for regressions
   if ! check_regressions 1; then
-    echo "✅ PASSED: No regressions above ${THRESHOLD}% threshold"
+    echo "✅ PASSED: No regressions above per-model thresholds"
     exit 0
   fi
 
@@ -1315,7 +1303,7 @@ test_unbacked_parity_smoketest() {
   local required=$((MAX_RETRIES / 2 + 1))
   if [[ $regression_count -ge $required ]]; then
     echo ""
-    echo "❌ REGRESSION CONFIRMED: Detected in $regression_count/$MAX_RETRIES runs (threshold: ${THRESHOLD}%)"
+    echo "❌ REGRESSION CONFIRMED: Detected in $regression_count/$MAX_RETRIES runs"
     exit 1
   else
     echo ""

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -4037,6 +4037,11 @@ UNBACKED_PARITY_THRESHOLDS = {"MobileBertForMaskedLM": 3.0}
 DEFAULT_UNBACKED_PARITY_THRESHOLD = 1.0
 
 
+def _unbacked_parity_diff_pct(backed_ms, unbacked_ms):
+    """Percent by which the unbacked compiled time exceeds the backed one."""
+    return (unbacked_ms - backed_ms) / backed_ms * 100
+
+
 def _run_compare_backed_unbacked(runner, args):
     """Run backed and unbacked per-model, alternating, and compare speedup."""
     import re
@@ -4055,7 +4060,7 @@ def _run_compare_backed_unbacked(runner, args):
             b_ms = modes.get("backed_ms")
             u_ms = modes.get("unbacked_ms")
             if b_ms is not None and u_ms is not None:
-                ms_diff_pct = (u_ms - b_ms) / b_ms * 100
+                ms_diff_pct = _unbacked_parity_diff_pct(b_ms, u_ms)
                 print(
                     f"  {name:<40s} {b_ms:>10.3f} {u_ms:>11.3f} {ms_diff_pct:>+7.1f}%",
                     flush=True,
@@ -4168,7 +4173,7 @@ def _run_compare_backed_unbacked(runner, args):
         ):
             b_ms = all_results[model]["backed_ms"]
             u_ms = all_results[model]["unbacked_ms"]
-            ms_diff_pct = (u_ms - b_ms) / b_ms * 100
+            ms_diff_pct = _unbacked_parity_diff_pct(b_ms, u_ms)
             print(
                 f"  => diff: {ms_diff_pct:+.1f}% ({b_ms:.3f} ms vs {u_ms:.3f} ms)",
                 flush=True,
@@ -4192,13 +4197,15 @@ def _run_compare_backed_unbacked(runner, args):
     for name, modes in all_results.items():
         b_ms = modes.get("backed_ms")
         u_ms = modes.get("unbacked_ms")
-        if b_ms and u_ms:
-            diff_pct = (u_ms - b_ms) / b_ms * 100
+        if b_ms is not None and u_ms is not None:
+            diff_pct = _unbacked_parity_diff_pct(b_ms, u_ms)
             threshold = UNBACKED_PARITY_THRESHOLDS.get(
                 name, DEFAULT_UNBACKED_PARITY_THRESHOLD
             )
             if diff_pct > threshold:
-                regressions.append(f"{name}:+{diff_pct:.1f}% (threshold {threshold:.1f}%)")
+                regressions.append(
+                    f"{name}: +{diff_pct:.2f}% > {threshold:.1f}% threshold"
+                )
     if regressions:
         print(f"UNBACKED_PARITY_REGRESSION: {', '.join(regressions)}", flush=True)
     else:

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -4027,6 +4027,16 @@ def main(runner, original_dir=None, args=None):
                 process_entry(0, runner, original_dir, args)
 
 
+# Per-model tolerance (percent) for the backed-vs-unbacked compiled-time parity
+# check. Most models track backed vs unbacked to within ~0.5%. MobileBertForMaskedLM
+# has bimodal compiled timings (backed and unbacked land in different modes
+# independently), so its backed-vs-unbacked diff is ~+-2% run-to-run jitter with no
+# directional regression; it gets a wider band so the noise doesn't red the periodic
+# job while a genuine regression is still caught.
+UNBACKED_PARITY_THRESHOLDS = {"MobileBertForMaskedLM": 3.0}
+DEFAULT_UNBACKED_PARITY_THRESHOLD = 1.0
+
+
 def _run_compare_backed_unbacked(runner, args):
     """Run backed and unbacked per-model, alternating, and compare speedup."""
     import re
@@ -4174,6 +4184,25 @@ def _run_compare_backed_unbacked(runner, args):
             print(f"  => diff: {diff_pct:+.1f}% (ratio-based, no ms data)", flush=True)
 
     print_comparison(all_results)
+
+    # Emit a canonical regression verdict using per-model thresholds. The CI
+    # wrapper (.ci/pytorch/test.sh) detects the UNBACKED_PARITY_REGRESSION line
+    # rather than re-deriving the threshold, so the policy lives here as data.
+    regressions = []
+    for name, modes in all_results.items():
+        b_ms = modes.get("backed_ms")
+        u_ms = modes.get("unbacked_ms")
+        if b_ms and u_ms:
+            diff_pct = (u_ms - b_ms) / b_ms * 100
+            threshold = UNBACKED_PARITY_THRESHOLDS.get(
+                name, DEFAULT_UNBACKED_PARITY_THRESHOLD
+            )
+            if diff_pct > threshold:
+                regressions.append(f"{name}:+{diff_pct:.1f}% (threshold {threshold:.1f}%)")
+    if regressions:
+        print(f"UNBACKED_PARITY_REGRESSION: {', '.join(regressions)}", flush=True)
+    else:
+        print("UNBACKED_PARITY_OK: no per-model regressions", flush=True)
 
 
 def write_csv_when_exception(args, name: str, status: str, device=None):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189813

The periodic inductor_huggingface_unbacked_parity job intermittently reds on
MobileBertForMaskedLM with no real regression behind it. Its backed and unbacked
compiled times are ~equal and land in a bimodal distribution independently, so
the backed-vs-unbacked diff is ~+-2% autotune/measurement jitter -- centered at
zero over 16 independent runs, and a pre-onset build reproduces the same
variance, so it is not a code regression.

Move the regression policy out of the CI shell script and into the benchmark
(_run_compare_backed_unbacked in benchmarks/dynamo/common.py), next to the
comparison itself, as a per-model threshold table (MobileBertForMaskedLM = 3.0%,
others 1.0%). The benchmark now emits a canonical UNBACKED_PARITY_REGRESSION /
UNBACKED_PARITY_OK verdict line, and .ci/pytorch/test.sh detects that line
instead of re-deriving the threshold in bash.

Test Plan:
- bash -n .ci/pytorch/test.sh; benchmarks/dynamo/common.py parses.
- Real run (a100): MobileBert +0.8% -> UNBACKED_PARITY_OK -> wrapper PASS.
- Simulated: MobileBert +2% & DistilBert +1.2% -> flags DistilBert only (stays
  1.0%); MobileBert +3.5% -> flagged (>3.0%); all-clean -> OK.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98