### PR TITLE
Move vLLM wheel build to OSDC release runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -94,5 +94,7 @@ self-hosted-runner:
     - mt-l-x86iamx-8-16
     - mt-rel-l-x86iavx512-8-64
     - mt-rel-l-arm64g4-16-62
+    - mt-rel-l-x86iavx512-44-340
+    - mt-rel-l-arm64g3-44-340
     - mt-l-arm64g3-61-463
     - mt-l-x86iamx-22-225-h100

--- a/.github/workflows/build-vllm-wheel.yml
+++ b/.github/workflows/build-vllm-wheel.yml
@@ -33,19 +33,19 @@ jobs:
           - platform: manylinux_2_28_x86_64
             device: cu130
             manylinux-image: 'pytorch/manylinux2_28-builder:cuda13.0'
-            runner: mt-l-x86iavx512-48-384
+            runner: mt-rel-l-x86iavx512-44-340
           - platform: manylinux_2_28_x86_64
             device: cu132
             manylinux-image: 'pytorch/manylinux2_28-builder:cuda13.2'
-            runner: mt-l-x86iavx512-48-384
+            runner: mt-rel-l-x86iavx512-44-340
           - platform: manylinux_2_28_aarch64
             device: cu130
             manylinux-image: 'pytorch/manylinuxaarch64-builder:cuda13.0'
-            runner: mt-l-arm64g3-61-463
+            runner: mt-rel-l-arm64g3-44-340
           - platform: manylinux_2_28_aarch64
             device: cu132
             manylinux-image: 'pytorch/manylinuxaarch64-builder:cuda13.2'
-            runner: mt-l-arm64g3-61-463
+            runner: mt-rel-l-arm64g3-44-340
     name: "Build ${{ matrix.device }} vLLM wheel on ${{ matrix.platform }}"
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 480


### PR DESCRIPTION
Move the vLLM wheel build to the dedicated release-isolated ARC runners from pytorch/ci-infra#888 so release wheel builds don't share a node with CI:

- x86 (cu130/cu132): `mt-l-x86iavx512-48-384` -> `mt-rel-l-x86iavx512-44-340`
- aarch64 (cu130/cu132): `mt-l-arm64g3-61-463` -> `mt-rel-l-arm64g3-44-340`

Note: the release runners are smaller (44 vCPU / 340 GiB) than the current pool, notably for aarch64 (was 61 vCPU / 463 GiB).

Authored with the assistance of Claude Code.