### PR TITLE
Move manywheel nightly builds and tests to OSDC runners

### DIFF
--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -48,26 +48,24 @@ name: !{{ build_environment }}
     with GHA's native `container:` directive. They share the same reusable
     workflows but pass `use_container_directive: false` so the build/test
     container is launched via `docker run` from a step instead. -#}
+{%- set release_runner_if = "(github.ref == 'refs/heads/main' || github.ref == 'refs/heads/nightly' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v'))" %}
 {%- if "aarch64" in build_environment %}
-  {%- set build_runs_on = "linux.arm64.r7g.12xlarge.memory" %}
-  {%- set test_runs_on  = "linux.arm64.2xlarge" %}
+  {%- set build_runs_on = "${{ " ~ release_runner_if ~ " && 'rel-l-arm64g3-44-340' || 'l-arm64g3-61-463' }}" %}
   {%- set alpine_image  = "arm64v8/alpine" %}
   {%- set timeout_minutes = 420 %}
-  {%- set runner_prefix = "" %}
+  {%- set runner_prefix = "${{ needs.get-label-type.outputs.label-type }}" %}
   {%- set use_container_directive = true %}
 {%- elif "s390x" in build_environment %}
   {%- set build_runs_on = "linux.s390x" %}
-  {%- set test_runs_on  = "linux.s390x" %}
   {%- set alpine_image  = "docker.io/s390x/alpine" %}
   {%- set timeout_minutes = 420 %}
   {%- set runner_prefix = "" %}
   {%- set use_container_directive = false %}
 {%- else %}
-  {%- set build_runs_on = "linux.12xlarge.memory.ephemeral" %}
-  {%- set test_runs_on  = "" %}{# CPU/CUDA test runners are picked per-matrix entry below #}
+  {%- set build_runs_on = "${{ " ~ release_runner_if ~ " && 'rel-l-x86iavx512-44-340' || 'l-x86iavx512-48-384' }}" %}
   {%- set alpine_image  = "308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine" %}
   {%- set timeout_minutes = common.timeout_minutes %}
-  {%- set runner_prefix = "" %}
+  {%- set runner_prefix = "${{ needs.get-label-type.outputs.label-type }}" %}
   {%- set use_container_directive = true %}
 {%- endif %}
 
@@ -129,7 +127,18 @@ env:
 !{{ common.concurrency(build_environment) }}
 
 jobs:
+  get-label-type:
+    if: github.repository_owner == 'pytorch'
+    name: get-label-type
+    uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
+    with:
+      triggering_actor: ${{ github.triggering_actor }}
+      issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
+      curr_branch: ${{ github.head_ref || github.ref_name }}
+      curr_ref_type: ${{ github.ref_type }}
+      check_experiments: lf
 {%- if pin_docker_image %}
+
   # Computes the manylinux builder image tag suffix at runtime. On release
   # candidate tag pushes (v1.2.3-rc4) it resolves to "-<.ci/docker tree hash>",
   # pinning the build/test/upload jobs to the reproducible image published by
@@ -193,9 +202,7 @@ jobs:
   !{{ job_name }}:
     name: !{{ job_name }}
     if: !{{ owner_if }}
-{%- if pin_docker_image %}
-    needs: get-docker-tag
-{%- endif %}
+    needs: [get-label-type{%- if pin_docker_image %}, get-docker-tag{%- endif %}]
     runs-on: "!{{ runner_prefix }}!{{ build_runs_on }}"
     timeout-minutes: !{{ timeout_minutes }}
     container:
@@ -257,9 +264,7 @@ jobs:
     name: ${{ matrix.build_name }}-build
     if: !{{ owner_if }}
     uses: ./.github/workflows/_binary-build-linux.yml
-{%- if pin_docker_image %}
-    needs: get-docker-tag
-{%- endif %}
+    needs: {% if pin_docker_image %}[get-label-type, get-docker-tag]{% else %}get-label-type{% endif %}
     strategy:
       fail-fast: false
       matrix:
@@ -313,7 +318,7 @@ jobs:
   manywheel-test:
     name: ${{ matrix.build_name }}-test
     if: !{{ owner_if }}
-    needs: [{%- if pin_docker_image %}get-docker-tag, {% endif %}{%- if matrix_standard_configs %}manywheel-build, {% endif %}{%- for n in unified_job_names %}!{{ n }}{%- if not loop.last %}, {% endif %}{%- endfor %}]
+    needs: [get-label-type{%- if pin_docker_image %}, get-docker-tag{%- endif %}{%- if matrix_standard_configs %}, manywheel-build{%- endif %}{%- for n in unified_job_names %}, !{{ n }}{%- endfor %}]
     uses: ./.github/workflows/_binary-test-linux.yml
     strategy:
       fail-fast: false
@@ -321,13 +326,13 @@ jobs:
         include:
         {%- for config in test_standard_configs %}
           {%- if "aarch64" in build_environment %}
-          {%- set _runs_on = "linux.arm64.2xlarge" %}
+          {%- set _runs_on = "l-arm64g3-16-62" %}
           {%- elif "s390x" in build_environment %}
           {%- set _runs_on = "linux.s390x" %}
           {%- elif config['gpu_arch_type'] == "cuda" %}
-          {%- set _runs_on = "linux.g4dn.4xlarge.nvidia.gpu" %}
+          {%- set _runs_on = "l-x86iavx512-29-115-t4" %}
           {%- else %}
-          {%- set _runs_on = "linux.4xlarge" %}
+          {%- set _runs_on = "l-x86iavx512-16-128" %}
           {%- endif %}
           - desired_python: "!{{ config['python_version'] }}"
             desired_cuda: "!{{ config['desired_cuda'] }}"
@@ -362,7 +367,7 @@ jobs:
   manywheel-test-rocm:
     name: ${{ matrix.build_name }}-test
     if: !{{ owner_if }}
-    needs: [{%- if pin_docker_image %}get-docker-tag, {% endif %}manywheel-build]
+    needs: [get-label-type{%- if pin_docker_image %}, get-docker-tag{%- endif %}, manywheel-build]
     uses: ./.github/workflows/_binary-test-rocm-linux.yml
     strategy:
       fail-fast: false
@@ -394,7 +399,7 @@ jobs:
   manywheel-test-xpu:
     name: ${{ matrix.build_name }}-test
     if: !{{ owner_if }}
-    needs: [{%- if pin_docker_image %}get-docker-tag, {% endif %}manywheel-build]
+    needs: [get-label-type{%- if pin_docker_image %}, get-docker-tag{%- endif %}, manywheel-build]
     uses: ./.github/workflows/_binary-test-xpu-linux.yml
     strategy:
       fail-fast: false

--- a/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
@@ -38,6 +38,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  get-label-type:
+    if: github.repository_owner == 'pytorch'
+    name: get-label-type
+    uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
+    with:
+      triggering_actor: ${{ github.triggering_actor }}
+      issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
+      curr_branch: ${{ github.head_ref || github.ref_name }}
+      curr_ref_type: ${{ github.ref_type }}
+      check_experiments: lf
+
   # Computes the manylinux builder image tag suffix at runtime. On release
   # candidate tag pushes (v1.2.3-rc4) it resolves to "-<.ci/docker tree hash>",
   # pinning the build/test/upload jobs to the reproducible image published by
@@ -76,8 +87,8 @@ jobs:
   manywheel-cpu-aarch64-build:
     name: manywheel-cpu-aarch64-build
     if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
-    needs: get-docker-tag
-    runs-on: "linux.arm64.r7g.12xlarge.memory"
+    needs: [get-label-type, get-docker-tag]
+    runs-on: "${{ needs.get-label-type.outputs.label-type }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/nightly' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-arm64g3-44-340' || 'l-arm64g3-61-463' }}"
     timeout-minutes: 420
     container:
       image: pytorch/manylinux2_28_aarch64-builder:cpu-aarch64${{ needs.get-docker-tag.outputs.docker_image_suffix }}
@@ -164,8 +175,8 @@ jobs:
   manywheel-cuda-aarch64-cu126-build:
     name: manywheel-cuda-aarch64-cu126-build
     if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
-    needs: get-docker-tag
-    runs-on: "linux.arm64.r7g.12xlarge.memory"
+    needs: [get-label-type, get-docker-tag]
+    runs-on: "${{ needs.get-label-type.outputs.label-type }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/nightly' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-arm64g3-44-340' || 'l-arm64g3-61-463' }}"
     timeout-minutes: 420
     container:
       image: pytorch/manylinuxaarch64-builder:cuda12.6${{ needs.get-docker-tag.outputs.docker_image_suffix }}
@@ -253,8 +264,8 @@ jobs:
   manywheel-cuda-aarch64-cu130-build:
     name: manywheel-cuda-aarch64-cu130-build
     if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
-    needs: get-docker-tag
-    runs-on: "linux.arm64.r7g.12xlarge.memory"
+    needs: [get-label-type, get-docker-tag]
+    runs-on: "${{ needs.get-label-type.outputs.label-type }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/nightly' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-arm64g3-44-340' || 'l-arm64g3-61-463' }}"
     timeout-minutes: 420
     container:
       image: pytorch/manylinuxaarch64-builder:cuda13.0${{ needs.get-docker-tag.outputs.docker_image_suffix }}
@@ -342,8 +353,8 @@ jobs:
   manywheel-cuda-aarch64-cu132-build:
     name: manywheel-cuda-aarch64-cu132-build
     if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
-    needs: get-docker-tag
-    runs-on: "linux.arm64.r7g.12xlarge.memory"
+    needs: [get-label-type, get-docker-tag]
+    runs-on: "${{ needs.get-label-type.outputs.label-type }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/nightly' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-arm64g3-44-340' || 'l-arm64g3-61-463' }}"
     timeout-minutes: 420
     container:
       image: pytorch/manylinuxaarch64-builder:cuda13.2${{ needs.get-docker-tag.outputs.docker_image_suffix }}
@@ -431,7 +442,7 @@ jobs:
   manywheel-test:
     name: ${{ matrix.build_name }}-test
     if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
-    needs: [get-docker-tag, manywheel-cpu-aarch64-build, manywheel-cuda-aarch64-cu126-build, manywheel-cuda-aarch64-cu130-build, manywheel-cuda-aarch64-cu132-build]
+    needs: [get-label-type, get-docker-tag, manywheel-cpu-aarch64-build, manywheel-cuda-aarch64-cu126-build, manywheel-cuda-aarch64-cu130-build, manywheel-cuda-aarch64-cu132-build]
     uses: ./.github/workflows/_binary-test-linux.yml
     strategy:
       fail-fast: false
@@ -444,7 +455,7 @@ jobs:
             docker_image: "manylinux2_28_aarch64-builder"
             docker_image_tag_prefix: "cpu-aarch64"
             build_name: "manywheel-py3_10-cpu-aarch64"
-            runs_on: "linux.arm64.2xlarge"
+            runs_on: "l-arm64g3-16-62"
           - desired_python: "3.10"
             desired_cuda: "cu126"
             gpu_arch_version: "12.6-aarch64"
@@ -452,7 +463,7 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda12.6"
             build_name: "manywheel-py3_10-cuda-aarch64-12_6"
-            runs_on: "linux.arm64.2xlarge"
+            runs_on: "l-arm64g3-16-62"
           - desired_python: "3.10"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0-aarch64"
@@ -460,7 +471,7 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda13.0"
             build_name: "manywheel-py3_10-cuda-aarch64-13_0"
-            runs_on: "linux.arm64.2xlarge"
+            runs_on: "l-arm64g3-16-62"
           - desired_python: "3.10"
             desired_cuda: "cu132"
             gpu_arch_version: "13.2-aarch64"
@@ -468,7 +479,7 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_10-cuda-aarch64-13_2"
-            runs_on: "linux.arm64.2xlarge"
+            runs_on: "l-arm64g3-16-62"
           - desired_python: "3.11"
             desired_cuda: "cpu"
             gpu_arch_version: ""
@@ -476,7 +487,7 @@ jobs:
             docker_image: "manylinux2_28_aarch64-builder"
             docker_image_tag_prefix: "cpu-aarch64"
             build_name: "manywheel-py3_11-cpu-aarch64"
-            runs_on: "linux.arm64.2xlarge"
+            runs_on: "l-arm64g3-16-62"
           - desired_python: "3.11"
             desired_cuda: "cu126"
             gpu_arch_version: "12.6-aarch64"
@@ -484,7 +495,7 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda12.6"
             build_name: "manywheel-py3_11-cuda-aarch64-12_6"
-            runs_on: "linux.arm64.2xlarge"
+            runs_on: "l-arm64g3-16-62"
           - desired_python: "3.11"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0-aarch64"
@@ -492,7 +503,7 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda13.0"
             build_name: "manywheel-py3_11-cuda-aarch64-13_0"
-            runs_on: "linux.arm64.2xlarge"
+            runs_on: "l-arm64g3-16-62"
           - desired_python: "3.11"
             desired_cuda: "cu132"
             gpu_arch_version: "13.2-aarch64"
@@ -500,7 +511,7 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_11-cuda-aarch64-13_2"
-            runs_on: "linux.arm64.2xlarge"
+            runs_on: "l-arm64g3-16-62"
           - desired_python: "3.12"
             desired_cuda: "cpu"
             gpu_arch_version: ""
@@ -508,7 +519,7 @@ jobs:
             docker_image: "manylinux2_28_aarch64-builder"
             docker_image_tag_prefix: "cpu-aarch64"
             build_name: "manywheel-py3_12-cpu-aarch64"
-            runs_on: "linux.arm64.2xlarge"
+            runs_on: "l-arm64g3-16-62"
           - desired_python: "3.12"
             desired_cuda: "cu126"
             gpu_arch_version: "12.6-aarch64"
@@ -516,7 +527,7 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda12.6"
             build_name: "manywheel-py3_12-cuda-aarch64-12_6"
-            runs_on: "linux.arm64.2xlarge"
+            runs_on: "l-arm64g3-16-62"
           - desired_python: "3.12"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0-aarch64"
@@ -524,7 +535,7 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda13.0"
             build_name: "manywheel-py3_12-cuda-aarch64-13_0"
-            runs_on: "linux.arm64.2xlarge"
+            runs_on: "l-arm64g3-16-62"
           - desired_python: "3.12"
             desired_cuda: "cu132"
             gpu_arch_version: "13.2-aarch64"
@@ -532,7 +543,7 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_12-cuda-aarch64-13_2"
-            runs_on: "linux.arm64.2xlarge"
+            runs_on: "l-arm64g3-16-62"
           - desired_python: "3.13"
             desired_cuda: "cpu"
             gpu_arch_version: ""
@@ -540,7 +551,7 @@ jobs:
             docker_image: "manylinux2_28_aarch64-builder"
             docker_image_tag_prefix: "cpu-aarch64"
             build_name: "manywheel-py3_13-cpu-aarch64"
-            runs_on: "linux.arm64.2xlarge"
+            runs_on: "l-arm64g3-16-62"
           - desired_python: "3.13"
             desired_cuda: "cu126"
             gpu_arch_version: "12.6-aarch64"
@@ -548,7 +559,7 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda12.6"
             build_name: "manywheel-py3_13-cuda-aarch64-12_6"
-            runs_on: "linux.arm64.2xlarge"
+            runs_on: "l-arm64g3-16-62"
           - desired_python: "3.13"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0-aarch64"
@@ -556,7 +567,7 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda13.0"
             build_name: "manywheel-py3_13-cuda-aarch64-13_0"
-            runs_on: "linux.arm64.2xlarge"
+            runs_on: "l-arm64g3-16-62"
           - desired_python: "3.13"
             desired_cuda: "cu132"
             gpu_arch_version: "13.2-aarch64"
@@ -564,7 +575,7 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_13-cuda-aarch64-13_2"
-            runs_on: "linux.arm64.2xlarge"
+            runs_on: "l-arm64g3-16-62"
           - desired_python: "3.14"
             desired_cuda: "cpu"
             gpu_arch_version: ""
@@ -572,7 +583,7 @@ jobs:
             docker_image: "manylinux2_28_aarch64-builder"
             docker_image_tag_prefix: "cpu-aarch64"
             build_name: "manywheel-py3_14-cpu-aarch64"
-            runs_on: "linux.arm64.2xlarge"
+            runs_on: "l-arm64g3-16-62"
           - desired_python: "3.14"
             desired_cuda: "cu126"
             gpu_arch_version: "12.6-aarch64"
@@ -580,7 +591,7 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda12.6"
             build_name: "manywheel-py3_14-cuda-aarch64-12_6"
-            runs_on: "linux.arm64.2xlarge"
+            runs_on: "l-arm64g3-16-62"
           - desired_python: "3.14"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0-aarch64"
@@ -588,7 +599,7 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda13.0"
             build_name: "manywheel-py3_14-cuda-aarch64-13_0"
-            runs_on: "linux.arm64.2xlarge"
+            runs_on: "l-arm64g3-16-62"
           - desired_python: "3.14"
             desired_cuda: "cu132"
             gpu_arch_version: "13.2-aarch64"
@@ -596,7 +607,7 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_14-cuda-aarch64-13_2"
-            runs_on: "linux.arm64.2xlarge"
+            runs_on: "l-arm64g3-16-62"
           - desired_python: "3.14t"
             desired_cuda: "cpu"
             gpu_arch_version: ""
@@ -604,7 +615,7 @@ jobs:
             docker_image: "manylinux2_28_aarch64-builder"
             docker_image_tag_prefix: "cpu-aarch64"
             build_name: "manywheel-py3_14t-cpu-aarch64"
-            runs_on: "linux.arm64.2xlarge"
+            runs_on: "l-arm64g3-16-62"
           - desired_python: "3.14t"
             desired_cuda: "cu126"
             gpu_arch_version: "12.6-aarch64"
@@ -612,7 +623,7 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda12.6"
             build_name: "manywheel-py3_14t-cuda-aarch64-12_6"
-            runs_on: "linux.arm64.2xlarge"
+            runs_on: "l-arm64g3-16-62"
           - desired_python: "3.14t"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0-aarch64"
@@ -620,7 +631,7 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda13.0"
             build_name: "manywheel-py3_14t-cuda-aarch64-13_0"
-            runs_on: "linux.arm64.2xlarge"
+            runs_on: "l-arm64g3-16-62"
           - desired_python: "3.14t"
             desired_cuda: "cu132"
             gpu_arch_version: "13.2-aarch64"
@@ -628,7 +639,7 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_14t-cuda-aarch64-13_2"
-            runs_on: "linux.arm64.2xlarge"
+            runs_on: "l-arm64g3-16-62"
           - desired_python: "3.15"
             desired_cuda: "cpu"
             gpu_arch_version: ""
@@ -636,7 +647,7 @@ jobs:
             docker_image: "manylinux2_28_aarch64-builder"
             docker_image_tag_prefix: "cpu-aarch64"
             build_name: "manywheel-py3_15-cpu-aarch64"
-            runs_on: "linux.arm64.2xlarge"
+            runs_on: "l-arm64g3-16-62"
           - desired_python: "3.15"
             desired_cuda: "cu126"
             gpu_arch_version: "12.6-aarch64"
@@ -644,7 +655,7 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda12.6"
             build_name: "manywheel-py3_15-cuda-aarch64-12_6"
-            runs_on: "linux.arm64.2xlarge"
+            runs_on: "l-arm64g3-16-62"
           - desired_python: "3.15"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0-aarch64"
@@ -652,7 +663,7 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda13.0"
             build_name: "manywheel-py3_15-cuda-aarch64-13_0"
-            runs_on: "linux.arm64.2xlarge"
+            runs_on: "l-arm64g3-16-62"
           - desired_python: "3.15"
             desired_cuda: "cu132"
             gpu_arch_version: "13.2-aarch64"
@@ -660,7 +671,7 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_15-cuda-aarch64-13_2"
-            runs_on: "linux.arm64.2xlarge"
+            runs_on: "l-arm64g3-16-62"
           - desired_python: "3.15t"
             desired_cuda: "cpu"
             gpu_arch_version: ""
@@ -668,7 +679,7 @@ jobs:
             docker_image: "manylinux2_28_aarch64-builder"
             docker_image_tag_prefix: "cpu-aarch64"
             build_name: "manywheel-py3_15t-cpu-aarch64"
-            runs_on: "linux.arm64.2xlarge"
+            runs_on: "l-arm64g3-16-62"
           - desired_python: "3.15t"
             desired_cuda: "cu126"
             gpu_arch_version: "12.6-aarch64"
@@ -676,7 +687,7 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda12.6"
             build_name: "manywheel-py3_15t-cuda-aarch64-12_6"
-            runs_on: "linux.arm64.2xlarge"
+            runs_on: "l-arm64g3-16-62"
           - desired_python: "3.15t"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0-aarch64"
@@ -684,7 +695,7 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda13.0"
             build_name: "manywheel-py3_15t-cuda-aarch64-13_0"
-            runs_on: "linux.arm64.2xlarge"
+            runs_on: "l-arm64g3-16-62"
           - desired_python: "3.15t"
             desired_cuda: "cu132"
             gpu_arch_version: "13.2-aarch64"
@@ -692,7 +703,7 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_15t-cuda-aarch64-13_2"
-            runs_on: "linux.arm64.2xlarge"
+            runs_on: "l-arm64g3-16-62"
     with:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel
@@ -704,7 +715,7 @@ jobs:
       DESIRED_PYTHON: ${{ matrix.desired_python }}
       build_name: ${{ matrix.build_name }}
       build_environment: linux-aarch64-binary-manywheel
-      runner_prefix: ""
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       runs_on: ${{ matrix.runs_on }}
       use_container_directive: true
       ALPINE_IMAGE: "arm64v8/alpine"

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -39,6 +39,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  get-label-type:
+    if: github.repository_owner == 'pytorch'
+    name: get-label-type
+    uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
+    with:
+      triggering_actor: ${{ github.triggering_actor }}
+      issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
+      curr_branch: ${{ github.head_ref || github.ref_name }}
+      curr_ref_type: ${{ github.ref_type }}
+      check_experiments: lf
+
   # Computes the manylinux builder image tag suffix at runtime. On release
   # candidate tag pushes (v1.2.3-rc4) it resolves to "-<.ci/docker tree hash>",
   # pinning the build/test/upload jobs to the reproducible image published by
@@ -77,8 +88,8 @@ jobs:
   manywheel-cpu-build:
     name: manywheel-cpu-build
     if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
-    needs: get-docker-tag
-    runs-on: "linux.12xlarge.memory.ephemeral"
+    needs: [get-label-type, get-docker-tag]
+    runs-on: "${{ needs.get-label-type.outputs.label-type }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/nightly' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-x86iavx512-44-340' || 'l-x86iavx512-48-384' }}"
     timeout-minutes: 280
     container:
       image: pytorch/manylinux2_28-builder:cpu${{ needs.get-docker-tag.outputs.docker_image_suffix }}
@@ -165,8 +176,8 @@ jobs:
   manywheel-cuda-cu126-build:
     name: manywheel-cuda-cu126-build
     if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
-    needs: get-docker-tag
-    runs-on: "linux.12xlarge.memory.ephemeral"
+    needs: [get-label-type, get-docker-tag]
+    runs-on: "${{ needs.get-label-type.outputs.label-type }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/nightly' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-x86iavx512-44-340' || 'l-x86iavx512-48-384' }}"
     timeout-minutes: 280
     container:
       image: pytorch/manylinux2_28-builder:cuda12.6${{ needs.get-docker-tag.outputs.docker_image_suffix }}
@@ -254,8 +265,8 @@ jobs:
   manywheel-cuda-cu130-build:
     name: manywheel-cuda-cu130-build
     if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
-    needs: get-docker-tag
-    runs-on: "linux.12xlarge.memory.ephemeral"
+    needs: [get-label-type, get-docker-tag]
+    runs-on: "${{ needs.get-label-type.outputs.label-type }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/nightly' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-x86iavx512-44-340' || 'l-x86iavx512-48-384' }}"
     timeout-minutes: 280
     container:
       image: pytorch/manylinux2_28-builder:cuda13.0${{ needs.get-docker-tag.outputs.docker_image_suffix }}
@@ -343,8 +354,8 @@ jobs:
   manywheel-cuda-cu132-build:
     name: manywheel-cuda-cu132-build
     if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
-    needs: get-docker-tag
-    runs-on: "linux.12xlarge.memory.ephemeral"
+    needs: [get-label-type, get-docker-tag]
+    runs-on: "${{ needs.get-label-type.outputs.label-type }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/nightly' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-x86iavx512-44-340' || 'l-x86iavx512-48-384' }}"
     timeout-minutes: 280
     container:
       image: pytorch/manylinux2_28-builder:cuda13.2${{ needs.get-docker-tag.outputs.docker_image_suffix }}
@@ -433,7 +444,7 @@ jobs:
     name: ${{ matrix.build_name }}-build
     if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
     uses: ./.github/workflows/_binary-build-linux.yml
-    needs: get-docker-tag
+    needs: [get-label-type, get-docker-tag]
     strategy:
       fail-fast: false
       matrix:
@@ -663,8 +674,8 @@ jobs:
       DOCKER_IMAGE: ${{ matrix.docker_image }}
       DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.docker_image_tag_prefix }}${{ needs.get-docker-tag.outputs.docker_image_suffix }}
       DESIRED_PYTHON: ${{ matrix.desired_python }}
-      runner_prefix: ""
-      runs_on: linux.12xlarge.memory.ephemeral
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      runs_on: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/nightly' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-x86iavx512-44-340' || 'l-x86iavx512-48-384' }}
       use_container_directive: true
       ALPINE_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine"
       PYTORCH_EXTRA_INSTALL_REQUIREMENTS: ${{ matrix.pytorch_extra_install_requirements }}
@@ -677,7 +688,7 @@ jobs:
   manywheel-test:
     name: ${{ matrix.build_name }}-test
     if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
-    needs: [get-docker-tag, manywheel-cpu-build, manywheel-cuda-cu126-build, manywheel-cuda-cu130-build, manywheel-cuda-cu132-build]
+    needs: [get-label-type, get-docker-tag, manywheel-cpu-build, manywheel-cuda-cu126-build, manywheel-cuda-cu130-build, manywheel-cuda-cu132-build]
     uses: ./.github/workflows/_binary-test-linux.yml
     strategy:
       fail-fast: false
@@ -690,7 +701,7 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cpu"
             build_name: "manywheel-py3_10-cpu"
-            runs_on: "linux.4xlarge"
+            runs_on: "l-x86iavx512-16-128"
           - desired_python: "3.10"
             desired_cuda: "cu126"
             gpu_arch_version: "12.6"
@@ -698,7 +709,7 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda12.6"
             build_name: "manywheel-py3_10-cuda12_6"
-            runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
+            runs_on: "l-x86iavx512-29-115-t4"
           - desired_python: "3.10"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0"
@@ -706,7 +717,7 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda13.0"
             build_name: "manywheel-py3_10-cuda13_0"
-            runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
+            runs_on: "l-x86iavx512-29-115-t4"
           - desired_python: "3.10"
             desired_cuda: "cu132"
             gpu_arch_version: "13.2"
@@ -714,7 +725,7 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_10-cuda13_2"
-            runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
+            runs_on: "l-x86iavx512-29-115-t4"
           - desired_python: "3.11"
             desired_cuda: "cpu"
             gpu_arch_version: ""
@@ -722,7 +733,7 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cpu"
             build_name: "manywheel-py3_11-cpu"
-            runs_on: "linux.4xlarge"
+            runs_on: "l-x86iavx512-16-128"
           - desired_python: "3.11"
             desired_cuda: "cu126"
             gpu_arch_version: "12.6"
@@ -730,7 +741,7 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda12.6"
             build_name: "manywheel-py3_11-cuda12_6"
-            runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
+            runs_on: "l-x86iavx512-29-115-t4"
           - desired_python: "3.11"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0"
@@ -738,7 +749,7 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda13.0"
             build_name: "manywheel-py3_11-cuda13_0"
-            runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
+            runs_on: "l-x86iavx512-29-115-t4"
           - desired_python: "3.11"
             desired_cuda: "cu132"
             gpu_arch_version: "13.2"
@@ -746,7 +757,7 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_11-cuda13_2"
-            runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
+            runs_on: "l-x86iavx512-29-115-t4"
           - desired_python: "3.12"
             desired_cuda: "cpu"
             gpu_arch_version: ""
@@ -754,7 +765,7 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cpu"
             build_name: "manywheel-py3_12-cpu"
-            runs_on: "linux.4xlarge"
+            runs_on: "l-x86iavx512-16-128"
           - desired_python: "3.12"
             desired_cuda: "cu126"
             gpu_arch_version: "12.6"
@@ -762,7 +773,7 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda12.6"
             build_name: "manywheel-py3_12-cuda12_6"
-            runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
+            runs_on: "l-x86iavx512-29-115-t4"
           - desired_python: "3.12"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0"
@@ -770,7 +781,7 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda13.0"
             build_name: "manywheel-py3_12-cuda13_0"
-            runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
+            runs_on: "l-x86iavx512-29-115-t4"
           - desired_python: "3.12"
             desired_cuda: "cu132"
             gpu_arch_version: "13.2"
@@ -778,7 +789,7 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_12-cuda13_2"
-            runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
+            runs_on: "l-x86iavx512-29-115-t4"
           - desired_python: "3.13"
             desired_cuda: "cpu"
             gpu_arch_version: ""
@@ -786,7 +797,7 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cpu"
             build_name: "manywheel-py3_13-cpu"
-            runs_on: "linux.4xlarge"
+            runs_on: "l-x86iavx512-16-128"
           - desired_python: "3.13"
             desired_cuda: "cu126"
             gpu_arch_version: "12.6"
@@ -794,7 +805,7 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda12.6"
             build_name: "manywheel-py3_13-cuda12_6"
-            runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
+            runs_on: "l-x86iavx512-29-115-t4"
           - desired_python: "3.13"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0"
@@ -802,7 +813,7 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda13.0"
             build_name: "manywheel-py3_13-cuda13_0"
-            runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
+            runs_on: "l-x86iavx512-29-115-t4"
           - desired_python: "3.13"
             desired_cuda: "cu132"
             gpu_arch_version: "13.2"
@@ -810,7 +821,7 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_13-cuda13_2"
-            runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
+            runs_on: "l-x86iavx512-29-115-t4"
           - desired_python: "3.14"
             desired_cuda: "cpu"
             gpu_arch_version: ""
@@ -818,7 +829,7 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cpu"
             build_name: "manywheel-py3_14-cpu"
-            runs_on: "linux.4xlarge"
+            runs_on: "l-x86iavx512-16-128"
           - desired_python: "3.14"
             desired_cuda: "cu126"
             gpu_arch_version: "12.6"
@@ -826,7 +837,7 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda12.6"
             build_name: "manywheel-py3_14-cuda12_6"
-            runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
+            runs_on: "l-x86iavx512-29-115-t4"
           - desired_python: "3.14"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0"
@@ -834,7 +845,7 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda13.0"
             build_name: "manywheel-py3_14-cuda13_0"
-            runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
+            runs_on: "l-x86iavx512-29-115-t4"
           - desired_python: "3.14"
             desired_cuda: "cu132"
             gpu_arch_version: "13.2"
@@ -842,7 +853,7 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_14-cuda13_2"
-            runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
+            runs_on: "l-x86iavx512-29-115-t4"
           - desired_python: "3.14t"
             desired_cuda: "cpu"
             gpu_arch_version: ""
@@ -850,7 +861,7 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cpu"
             build_name: "manywheel-py3_14t-cpu"
-            runs_on: "linux.4xlarge"
+            runs_on: "l-x86iavx512-16-128"
           - desired_python: "3.14t"
             desired_cuda: "cu126"
             gpu_arch_version: "12.6"
@@ -858,7 +869,7 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda12.6"
             build_name: "manywheel-py3_14t-cuda12_6"
-            runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
+            runs_on: "l-x86iavx512-29-115-t4"
           - desired_python: "3.14t"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0"
@@ -866,7 +877,7 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda13.0"
             build_name: "manywheel-py3_14t-cuda13_0"
-            runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
+            runs_on: "l-x86iavx512-29-115-t4"
           - desired_python: "3.14t"
             desired_cuda: "cu132"
             gpu_arch_version: "13.2"
@@ -874,7 +885,7 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_14t-cuda13_2"
-            runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
+            runs_on: "l-x86iavx512-29-115-t4"
           - desired_python: "3.15"
             desired_cuda: "cpu"
             gpu_arch_version: ""
@@ -882,7 +893,7 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cpu"
             build_name: "manywheel-py3_15-cpu"
-            runs_on: "linux.4xlarge"
+            runs_on: "l-x86iavx512-16-128"
           - desired_python: "3.15"
             desired_cuda: "cu126"
             gpu_arch_version: "12.6"
@@ -890,7 +901,7 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda12.6"
             build_name: "manywheel-py3_15-cuda12_6"
-            runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
+            runs_on: "l-x86iavx512-29-115-t4"
           - desired_python: "3.15"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0"
@@ -898,7 +909,7 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda13.0"
             build_name: "manywheel-py3_15-cuda13_0"
-            runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
+            runs_on: "l-x86iavx512-29-115-t4"
           - desired_python: "3.15"
             desired_cuda: "cu132"
             gpu_arch_version: "13.2"
@@ -906,7 +917,7 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_15-cuda13_2"
-            runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
+            runs_on: "l-x86iavx512-29-115-t4"
           - desired_python: "3.15t"
             desired_cuda: "cpu"
             gpu_arch_version: ""
@@ -914,7 +925,7 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cpu"
             build_name: "manywheel-py3_15t-cpu"
-            runs_on: "linux.4xlarge"
+            runs_on: "l-x86iavx512-16-128"
           - desired_python: "3.15t"
             desired_cuda: "cu126"
             gpu_arch_version: "12.6"
@@ -922,7 +933,7 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda12.6"
             build_name: "manywheel-py3_15t-cuda12_6"
-            runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
+            runs_on: "l-x86iavx512-29-115-t4"
           - desired_python: "3.15t"
             desired_cuda: "cu130"
             gpu_arch_version: "13.0"
@@ -930,7 +941,7 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda13.0"
             build_name: "manywheel-py3_15t-cuda13_0"
-            runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
+            runs_on: "l-x86iavx512-29-115-t4"
           - desired_python: "3.15t"
             desired_cuda: "cu132"
             gpu_arch_version: "13.2"
@@ -938,7 +949,7 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_15t-cuda13_2"
-            runs_on: "linux.g4dn.4xlarge.nvidia.gpu"
+            runs_on: "l-x86iavx512-29-115-t4"
     with:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel
@@ -950,7 +961,7 @@ jobs:
       DESIRED_PYTHON: ${{ matrix.desired_python }}
       build_name: ${{ matrix.build_name }}
       build_environment: linux-binary-manywheel
-      runner_prefix: ""
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       runs_on: ${{ matrix.runs_on }}
       use_container_directive: true
       ALPINE_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine"
@@ -960,7 +971,7 @@ jobs:
   manywheel-test-rocm:
     name: ${{ matrix.build_name }}-test
     if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
-    needs: [get-docker-tag, manywheel-build]
+    needs: [get-label-type, get-docker-tag, manywheel-build]
     uses: ./.github/workflows/_binary-test-rocm-linux.yml
     strategy:
       fail-fast: false
@@ -1092,7 +1103,7 @@ jobs:
   manywheel-test-xpu:
     name: ${{ matrix.build_name }}-test
     if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
-    needs: [get-docker-tag, manywheel-build]
+    needs: [get-label-type, get-docker-tag, manywheel-build]
     uses: ./.github/workflows/_binary-test-xpu-linux.yml
     strategy:
       fail-fast: false

--- a/.github/workflows/generated-linux-s390x-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-s390x-binary-manywheel-nightly.yml
@@ -39,11 +39,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  get-label-type:
+    if: github.repository_owner == 'pytorch'
+    name: get-label-type
+    uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
+    with:
+      triggering_actor: ${{ github.triggering_actor }}
+      issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
+      curr_branch: ${{ github.head_ref || github.ref_name }}
+      curr_ref_type: ${{ github.ref_type }}
+      check_experiments: lf
 
   manywheel-build:
     name: ${{ matrix.build_name }}-build
     if: ${{ github.repository_owner == 'pytorch' }}
     uses: ./.github/workflows/_binary-build-linux.yml
+    needs: get-label-type
     strategy:
       fail-fast: false
       matrix:
@@ -125,7 +136,7 @@ jobs:
   manywheel-test:
     name: ${{ matrix.build_name }}-test
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: [manywheel-build, ]
+    needs: [get-label-type, manywheel-build]
     uses: ./.github/workflows/_binary-test-linux.yml
     strategy:
       fail-fast: false


### PR DESCRIPTION
Migrate the linux manywheel nightly build **and** test jobs off EC2 onto OSDC:

**Build jobs** → release-isolated ARC runners from pytorch/ci-infra#888 (same r7a/r7g.12xlarge instance types as the old EC2 labels), so release wheel builds don't share a node with CI:
- x86: `linux.12xlarge.memory.ephemeral` -> `mt-rel-l-x86iavx512-44-340`
- aarch64: `linux.arm64.r7g.12xlarge.memory` -> `mt-rel-l-arm64g3-44-340`

**Test jobs** (`manywheel-test`) → regular multi-tenant OSDC CI runners (mapped via `.github/arc.yaml`):
- CPU: `linux.4xlarge` -> `mt-l-x86iavx512-16-128`
- CUDA: `linux.g4dn.4xlarge.nvidia.gpu` -> `mt-l-x86iavx512-29-115-t4` (T4)
- aarch64: `linux.arm64.2xlarge` -> `mt-l-arm64g3-16-62`

Change is in the template (`linux_binary_build_workflow.yml.j2`) + regenerated; s390x is unchanged. Build/test jobs already use the GHA `container:` directive (the CUDA test container already gets `--gpus all` via `_binary-test-linux.yml`). New labels registered in `actionlint.yaml`.

Authored with the assistance of Claude Code.