### PR TITLE
[Inductor][xpu] Add Intel GPU PVC device info and support get dram gbps from data sheet.

### DIFF
--- a/test/inductor/test_inductor_scheduler.py
+++ b/test/inductor/test_inductor_scheduler.py
@@ -34,7 +34,6 @@ from torch.testing._internal.common_device_type import (
 from torch.testing._internal.common_utils import (
     parametrize,
     run_tests,
-    skipIfXpu,
     TestCase,
     xfailIfNoAcceleratorTriton,
 )

--- a/test/inductor/test_inductor_scheduler.py
+++ b/test/inductor/test_inductor_scheduler.py
@@ -532,10 +532,6 @@ class TestScheduler(TestCase):
         torch._logging.set_logs()
 
     @xfailIfNoAcceleratorTriton
-    @skipIfXpu(
-        msg="InvalidModule: Invalid SPIR-V module, "
-        "https://github.com/intel/torch-xpu-ops/issues/2329"
-    )
     @dtypes(torch.float, torch.float16)
     @skipCUDAIf(not SM70OrLater, "GPU capability is < SM70")
     @parametrize(

--- a/test/inductor/test_pad_mm.py
+++ b/test/inductor/test_pad_mm.py
@@ -516,7 +516,7 @@ class PadMMTest(TestCase):
         {
             "triton.unique_kernel_names": "original_aten",
             "max_autotune_gemm_backends": "TRITON",
-            "shape_padding": True,
+            "force_shape_pad": True,  # Force pad so that the padding is applied regardless of the heuristic checks on devices.
         }
     )
     def test_original_aten_preserved_pad_mm(self):

--- a/test/inductor/test_pad_mm.py
+++ b/test/inductor/test_pad_mm.py
@@ -516,7 +516,9 @@ class PadMMTest(TestCase):
         {
             "triton.unique_kernel_names": "original_aten",
             "max_autotune_gemm_backends": "TRITON",
-            "force_shape_pad": True,  # Force pad so that the padding is applied regardless of the heuristic checks on devices.
+            # Force padding so it is applied regardless of the device-dependent
+            # is_mm_compute_bound checks in should_pad_common.
+            "force_shape_pad": True,
         }
     )
     def test_original_aten_preserved_pad_mm(self):

--- a/test/inductor/test_snode_runtime.py
+++ b/test/inductor/test_snode_runtime.py
@@ -10,7 +10,6 @@ from torch._inductor.comm_analysis import estimate_nccl_collective_runtime
 from torch._inductor.compile_fx import compile_fx, compile_fx_inner
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import is_collective
-from torch.testing._internal.common_device_type import expectedFailureXPU
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
 
 
@@ -106,8 +105,6 @@ class UnsupportedTests(TestCase):
 class ComputeBoundedTests(TestCase):
     device = DEVICE
 
-    # lack of profiler on XPU
-    @expectedFailureXPU
     def test_conv1d(self):
         def f(x, y):
             return torch.nn.functional.conv1d(x, y)
@@ -115,8 +112,6 @@ class ComputeBoundedTests(TestCase):
         inp = (T(33, 16, 30), T(20, 16, 5))
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    # lack of profiler on XPU
-    @expectedFailureXPU
     def test_conv2d(self):
         def f(x, y):
             return torch.nn.functional.conv2d(x, y, padding=1)
@@ -124,8 +119,6 @@ class ComputeBoundedTests(TestCase):
         inp = (T(8, 4, 3, 3), T(1, 4, 5, 5))
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    # lack of profiler on XPU
-    @expectedFailureXPU
     def test_conv2d_transpose(self):
         def f(x, y):
             return torch.nn.functional.conv_transpose2d(x, y, padding=1)
@@ -133,8 +126,6 @@ class ComputeBoundedTests(TestCase):
         inp = (T(8, 1, 1, 1), T(1, 4, 5, 5))
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    # lack of profiler on XPU
-    @expectedFailureXPU
     def test_conv3d(self):
         def f(x, y):
             return torch.nn.functional.conv3d(x, y)
@@ -142,8 +133,6 @@ class ComputeBoundedTests(TestCase):
         inp = (T(20, 16, 50, 10, 20), T(33, 16, 3, 3, 3))
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    # lack of profiler on XPU
-    @expectedFailureXPU
     def test_mm(self):
         def f(a, b):
             return torch.mm(a, b)
@@ -154,8 +143,6 @@ class ComputeBoundedTests(TestCase):
         )
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    # lack of profiler on XPU
-    @expectedFailureXPU
     def test_addmm(self):
         def f(a, b, c):
             return torch.addmm(a, b, c)
@@ -167,8 +154,6 @@ class ComputeBoundedTests(TestCase):
         )
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    # lack of profiler on XPU
-    @expectedFailureXPU
     def test_bmm(self):
         def f(a, b):
             return torch.bmm(a, b)
@@ -183,8 +168,6 @@ class ComputeBoundedTests(TestCase):
 class MemoryBoundedTests(TestCase):
     device = DEVICE
 
-    # lack of profiler on XPU
-    @expectedFailureXPU
     def test_relu(self):
         def f(a):
             return torch.nn.functional.relu(a)
@@ -192,8 +175,6 @@ class MemoryBoundedTests(TestCase):
         inp = (T(10, 10),)
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    # lack of profiler on XPU
-    @expectedFailureXPU
     def test_horizontal_reduction_pointwise(self):
         def f(a):
             b = a.sum(dim=1)
@@ -203,8 +184,6 @@ class MemoryBoundedTests(TestCase):
         inp = (T(10, 10),)
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    # lack of profiler on XPU
-    @expectedFailureXPU
     def test_pointwise(self):
         def f(x):
             return x.cos()
@@ -212,8 +191,6 @@ class MemoryBoundedTests(TestCase):
         inp = (T(10),)
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    # lack of profiler on XPU
-    @expectedFailureXPU
     @torch._dynamo.config.patch(assume_static_by_default=False)
     def test_dynamic(self):
         def f(x):

--- a/torch/_inductor/analysis/device_info.py
+++ b/torch/_inductor/analysis/device_info.py
@@ -319,11 +319,26 @@ def datasheet_tops(
     return tops / device_info.tops_sparsity_factor
 
 
-def datasheet_dram_bw_gbs(device_name: str) -> float | None:
+def datasheet_dram_bw_gbs(device_name: str | None = None) -> float | None:
     """
     Get the theoretical DRAM bandwidth (GB/s) of the named device from the
     datasheet, or None if the device is not present.
+
+    If ``device_name`` is None, the current device is queried.
     """
+    if device_name is None:
+        if torch.cuda.is_available():
+            device_name = torch.cuda.get_device_name()
+        elif torch.xpu.is_available():
+            device_name = torch.xpu.get_device_name()
+        else:
+            log.info("No supported device available, skipping datasheet lookup")
+            return None
+
+    if device_name is None:
+        log.info("No device found, returning None")
+        return None
+
     device_info = lookup_device_info(device_name)
     if device_info is None:
         log.info("Device %s not in datasheet, returning None", device_name)

--- a/torch/_inductor/analysis/device_info.py
+++ b/torch/_inductor/analysis/device_info.py
@@ -238,11 +238,9 @@ _device_mapping: dict[str, DeviceInfo] = {
             torch.bfloat16: 355.5,
             # not supported, fall back to float32 numbers
             torch.float8_e8m0fnu: 22.2,
-            torch.float8_e8m0fnu: 22.2,
             torch.float8_e4m3fnuz: 22.2,
             torch.float8_e5m2: 22.2,
             torch.float8_e5m2fnuz: 22.2,
-            torch.float8_e8m0fnu: 22.2,
             torch.int8: 711.1,
         },
         dram_bw_gbs=1228.8,
@@ -321,10 +319,11 @@ def datasheet_tops(
 
 def datasheet_dram_bw_gbs(device_name: str | None = None) -> float | None:
     """
-    Get the theoretical DRAM bandwidth (GB/s) of the named device from the
-    datasheet, or None if the device is not present.
+    Get the theoretical DRAM bandwidth (GB/s) of a device from the datasheet,
+    or None if the device is not present.
 
-    If ``device_name`` is None, the current device is queried.
+    If ``device_name`` is given, that named device is looked up; otherwise the
+    current CUDA/XPU device is queried.
     """
     if device_name is None:
         if torch.cuda.is_available():

--- a/torch/_inductor/analysis/device_info.py
+++ b/torch/_inductor/analysis/device_info.py
@@ -220,6 +220,34 @@ _device_mapping: dict[str, DeviceInfo] = {
         dram_bw_gbs=608.0,
         dram_gb=32.0,
     ),
+    # Source:
+    # @lint-ignore https://www.intel.com/content/www/us/en/products/sku/232876/\
+    # intel-data-center-gpu-max-1100/specifications.html
+    "Intel(R) Data Center GPU Max 1100": DeviceInfo(
+        # XeCore count: 56,
+        # vector/matrix engines per XeCore: 8
+        # freq: 1.55GHz
+        tops={
+            # Vector engine
+            torch.float64: 11.1,
+            torch.float32: 22.2,
+            # not specified, fall back to float32 numbers
+            "torch.tf32": 22.2,
+            # Matrix engine
+            torch.float16: 355.5,
+            torch.bfloat16: 355.5,
+            # not supported, fall back to float32 numbers
+            torch.float8_e8m0fnu: 22.2,
+            torch.float8_e8m0fnu: 22.2,
+            torch.float8_e4m3fnuz: 22.2,
+            torch.float8_e5m2: 22.2,
+            torch.float8_e5m2fnuz: 22.2,
+            torch.float8_e8m0fnu: 22.2,
+            torch.int8: 711.1,
+        },
+        dram_bw_gbs=1228.8,
+        dram_gb=48,
+    ),
 }
 _device_mapping["AMD INSTINCT MI350X"] = _device_mapping["AMD MI350X"]
 _device_mapping["AMD INSTINCT MI300X"] = _device_mapping["AMD MI300X"]

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -3235,7 +3235,17 @@ def get_device_tflops(dtype: torch.dtype) -> float:
 
 
 @functools.cache
-def get_gpu_dram_gbps() -> int:
+def get_gpu_dram_gbps() -> Any:
+    """
+    We don't want to throw errors in this function. First check to see if the device is in device_info.py,
+    then fall back to the inaccurate triton estimation.
+    """
+    from .analysis.device_info import datasheet_dram_bw_gbs
+
+    ds_bw = datasheet_dram_bw_gbs()
+    if ds_bw is not None:
+        return float(ds_bw)
+
     from triton.testing import get_dram_gbps
 
     return get_dram_gbps()

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -3235,7 +3235,7 @@ def get_device_tflops(dtype: torch.dtype) -> float:
 
 
 @functools.cache
-def get_gpu_dram_gbps() -> Any:
+def get_gpu_dram_gbps() -> float:
     """
     We don't want to throw errors in this function. First check to see if the device is in device_info.py,
     then fall back to the inaccurate triton estimation.
@@ -3244,7 +3244,7 @@ def get_gpu_dram_gbps() -> Any:
 
     ds_bw = datasheet_dram_bw_gbs()
     if ds_bw is not None:
-        return float(ds_bw)
+        return ds_bw
 
     from triton.testing import get_dram_gbps
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189819

## Motivation
Some Inductor UT can not pass on XPU due to lack of  correct device tflops and dram gdbps.

## Solution
- Add Intel GPU PVC device info which the XPU CI runs on.
- Query dram gbps from the datasheet frist because the `triton.testing.get_dram_gbps` current not work correctly on XPU.

## Test
- Enabled expected failure/skipped cases on XPU.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo