### PR TITLE
Stop recording Function input_info eagerly

### DIFF
--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -152,9 +152,7 @@ static PyObject* unpack_saved_variables(
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* to_py_size(const std::vector<c10::SymInt>& size) {
-  c10::SymIntArrayRef sym_sizes(size);
-
+PyObject* to_py_size(c10::SymIntArrayRef sym_sizes) {
   auto ret = THPObjectPtr(THPSizeType.tp_alloc(
       &THPSizeType, static_cast<Py_ssize_t>(sym_sizes.size())));
   if (!ret)
@@ -271,9 +269,7 @@ auto PyNode::apply_with_saved_impl(
   THPObjectPtr pyInputs(to_py_args(inputs, &_device_guard));
 
   const auto& is_variable_input = py_fn->is_variable_input;
-  const auto& input_infos = py_fn->input_info;
-  // input_info only contains info from variable inputs and should be a subset
-  TORCH_INTERNAL_ASSERT(is_variable_input.size() >= input_infos.size());
+  const auto& next_edges = this->next_edges();
 
   // The gradients returned in the backwards need to match the number of inputs
   // to the forward, and their metadata, so we pass the fwdInputs
@@ -287,13 +283,19 @@ auto PyNode::apply_with_saved_impl(
     if (!is_variable_input[i]) {
       // input at i is not a variable, skip index
       PyTuple_SET_ITEM(fwdInputMetadatas.get(), i, Py_NewRef(Py_None));
-      offset++;
       continue;
     }
 
-    const auto& input_info = input_infos[i - offset];
+    TORCH_INTERNAL_ASSERT(offset < static_cast<int>(next_edges.size()));
+    const auto& edge = next_edges[offset++];
+    if (!edge.is_valid()) {
+      PyTuple_SET_ITEM(fwdInputMetadatas.get(), i, Py_NewRef(Py_None));
+      continue;
+    }
 
-    THPObjectPtr device(THPDevice_New(input_info.device));
+    const auto& input_info = edge.function->input_metadata(edge.input_nr);
+
+    THPObjectPtr device(THPDevice_New(input_info.device()));
     if (!device)
       throw_python_error();
     // Metadata is a tuple of 4 elements: (layout, device, dtype, size)
@@ -301,16 +303,20 @@ auto PyNode::apply_with_saved_impl(
     if (!fwdInputMetadata)
       throw python_error();
     PyTuple_SET_ITEM(
-        fwdInputMetadata.get(), 0, autograd::utils::wrap(input_info.layout));
+        fwdInputMetadata.get(), 0, autograd::utils::wrap(input_info.layout()));
     PyTuple_SET_ITEM(fwdInputMetadata.get(), 1, device.release());
     PyTuple_SET_ITEM(
         fwdInputMetadata.get(),
         2,
-        autograd::utils::wrap(input_info.scalar_type));
-    PyTuple_SET_ITEM(fwdInputMetadata.get(), 3, to_py_size(input_info.size));
+        autograd::utils::wrap(at::typeMetaToScalarType(input_info.dtype())));
+    PyTuple_SET_ITEM(
+        fwdInputMetadata.get(),
+        3,
+        to_py_size(input_info.shape_as_dim_vector()));
 
     PyTuple_SET_ITEM(fwdInputMetadatas.get(), i, fwdInputMetadata.release());
   }
+  TORCH_INTERNAL_ASSERT(offset == static_cast<int>(next_edges.size()));
   THPObjectPtr saved_tensors(unpack_saved_variables(
       py_fn, [](const Variable& var) { return THPVariable_Wrap(var); }));
 
@@ -1226,15 +1232,6 @@ PyObject* process_outputs(
     throw python_error();
 
   grad_fn->cdata->clear_input_metadata();
-
-  // Record type, device, and size information about inputs
-  if (is_executable) {
-    grad_fn->input_info.clear();
-    grad_fn->input_info.reserve(unpacked.input_vars.size());
-    for (const auto* var : unpacked.input_vars) {
-      grad_fn->input_info.emplace_back(*var);
-    }
-  }
 
   std::unordered_set<at::TensorImpl*> to_save_if_setup_context{};
   std::vector<std::optional<at::Tensor>> tensors_to_save{};


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #189866
* #189865
* #189824
* #189822
* __->__ #189820
* #189810
* #189800
* #189788

Python custom Function apply recorded VariableInfo for every tensor input after forward, even though the eager path does not read that metadata. The remaining consumer is compiled autograd's saved apply path, which only needs the metadata when reconstructing forward-input metadata for a saved Python node.

Remove the eager input_info population from process_outputs. When compiled autograd needs the metadata, reconstruct it from the already-recorded next_edges and each edge function's InputMetadata instead of carrying a copied VariableInfo vector through every eager apply.

With clean rebuilds of the parent and this commit, the local 13-in-2-out no-save one-apply instruction-count benchmark improved from 50,654 to 44,740 instructions.

Authored with assistance from an AI assistant.