### PR TITLE
[Test] Replaced 'torch.cuda.is_available()' with 'torch.accelerator.current_accelerator().type' in /test/fx/test_common_passes.py

### DIFF
--- a/test/fx/test_common_passes.py
+++ b/test/fx/test_common_passes.py
@@ -75,9 +75,11 @@ Test_Cases = [
     MutationTorchTensorCall,
 ]
 Factory_Test_Cases = [FactoryFunctionCall, MutationFactory]
+
 Devices = ["cpu"]
-if torch.cuda.is_available():
-    Devices.append("cuda")
+device_type = torch.accelerator.current_accelerator().type
+if device_type and device_type not in Devices:
+    Devices.append(device_type)
 
 
 def name_fn(common_pass, f, device):


### PR DESCRIPTION
## Summary
This PR updates the hardware detection logic in /test/fx/test_common_passes.py to replace the hard-coded torch.cuda.is_available() check with the generic torch.accelerator.current_accelerator().type API.
This is a critical step toward making the FX test suite device-agnostic, ensuring seamless support for non-NVIDIA hardware backend  such as PrivateUse1.

## Changes
- Replaced torch.cuda.is_available() with torch.accelerator.current_accelerator().type in /test/fx/test_common_passes.py.
Migrated the test infrastructure to use the unified accelerator interface instead of relying on CUDA-specific backend calls.

## Motivation
The original hard-coded torch.cuda.is_available() check strictly limits test execution to NVIDIA GPUs. By migrating to torch.accelerator, the test suite can now dynamically detect and adapt to any supported hardware accelerator (e.g., NPU, XPU). This refactoring prevents silent test skipping on out-of-tree backends and ensures broader hardware compatibility for FX common passes.

## Test Plan
- CI: `python test/test_fx.py TestCommonPass`
- Verified locally that `TestCommonPass` correctly tests on CPU and correct backend.

## Notes
- This is part of the test case refactoring initiative tracked in https://github.com/pytorch/pytorch/issues/185590.

@wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian