### PR TITLE
[WIP]Add XPU Triton int8 mm templates and BMG device support

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2170,6 +2170,11 @@ class triton:
     enable_persistent_tma_matmul = (
         os.environ.get("ENABLE_PERSISTENT_TMA_MATMUL", "0") == "1"
     )
+    # Enable BMG (Battlemage/Xe2) optimized persistent GEMM template.
+    # Uses block2D pointers with automatic software pipelining via num_stages.
+    enable_bmg_persistent_mm = (
+        os.environ.get("ENABLE_BMG_PERSISTENT_MM", "1") == "1"
+    )
     # Should TMA store be enable from templates. TODO: Remove once we
     # can autotune over the result.
     enable_template_tma_store = os.environ.get("ENABLE_TEMPLATE_TMA_STORE", "0") == "1"

--- a/torch/_inductor/heuristics/template/triton.py
+++ b/torch/_inductor/heuristics/template/triton.py
@@ -21,6 +21,8 @@ from ... import config
 from ...kernel.bmm import bmm_template
 from ...kernel.mm import (
     blackwell_ws_persistent_device_tma_mm_template,
+    bmg_tiled2d_mm_template,
+    bmg_persistent_mm_template,
     get_scaling_options,
     get_tile_size,
     mm_template,
@@ -3483,6 +3485,84 @@ class XPUInt8MMTemplateConfigHeuristic(INT8MMTemplateConfigMixin, XPUConfigHeuri
         # TODO(coconutruben): remove this once we have validated exhaustive support
         # for scaled_mm
         self.exhaustive_configs = self.int8_mm_configs
+
+
+# ═══ BMG (Battlemage/Xe2) Template Heuristics ═══
+# BMG-optimized persistent template exploits:
+#   - Block2D hardware DMA (via tl.make_block_ptr)
+#   - Persistent dispatch with GROUP_M swizzle for LLC reuse
+#   - Triton num_stages for automatic software pipelining
+#   - NOTE: Manual UNROLL_K is harmful on XPU (7.4x code bloat via IGC)
+#   - NOTE: Manual PREFETCH_DIST redundant with num_stages
+
+
+@register_template_heuristic(bmg_persistent_mm_template.uid, "xpu", op_name="int_mm")
+class XPUBMGPersistentInt8MMTemplateConfigHeuristic(
+    INT8MMTemplateConfigMixin, XPUConfigHeuristic
+):
+    """BMG persistent MM template heuristic for XPU — INT8 GEMM"""
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Oracle-verified configs for INT8 on BMG (118 shapes tested)
+        # 7 configs cover all 66 winning shapes for bmg_persistent
+        self.mm_configs = [
+            # config_1: BM=256,BN=128,BK=64,NS=3,NW=16 (17 wins)
+            GemmConfig(256, 128, 64, 3, 16),
+            # config_4: BM=256,BN=256,BK=64,NS=2,NW=32 (16 wins)
+            GemmConfig(256, 256, 64, 2, 32),
+            # config_6: BM=128,BN=512,BK=64,NS=2,NW=32 (15 wins)
+            GemmConfig(128, 512, 64, 2, 32),
+            # config_7: BM=256,BN=256,BK=128,NS=2,NW=32 (8 wins)
+            GemmConfig(256, 256, 128, 2, 32),
+            # config_5: BM=32,BN=256,BK=32,NS=2,NW=8 (6 wins)
+            GemmConfig(32, 256, 32, 2, 8),
+            # config_3: BM=8,BN=512,BK=32,NS=2,NW=8 (3 wins)
+            GemmConfig(8, 512, 32, 2, 8),
+            # config_2: BM=8,BN=512,BK=32,NS=2,NW=16 (1 win)
+            GemmConfig(8, 512, 32, 2, 16),
+        ]
+        self.exhaustive_configs = self.mm_configs
+
+    def _get_template_configs_impl(
+        self,
+        kernel_inputs: KernelInputs,
+        op_name: str,
+        **kwargs,
+    ) -> Generator[dict[str, Any], None, None]:
+        """Add BMG-specific template kwargs for INT8."""
+        for template_kwargs in super()._get_template_configs_impl(
+            kernel_inputs, op_name, **kwargs
+        ):
+            yield {
+                **template_kwargs,
+                "NUM_SMS": get_num_sms(),
+            }
+
+
+# ═══ BMG Tiled 2D Template Heuristics ═══
+# For M≤32 bandwidth-bound shapes: 2D grid, block_ptr loads, small BLOCK_M, large BLOCK_N
+
+
+@register_template_heuristic(bmg_tiled2d_mm_template.uid, "xpu", op_name="int_mm")
+class XPUBMGTiled2DInt8MMTemplateConfigHeuristic(
+    INT8MMTemplateConfigMixin, XPUConfigHeuristic
+):
+    """BMG tiled 2D MM template for XPU — INT8 GEMM (bandwidth-bound M≤32)"""
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Oracle-verified configs for INT8 tiled2d on BMG (118 shapes tested)
+        # 3 configs cover all 52 winning shapes for bmg_tiled2d
+        self.mm_configs = [
+            # config_5: BM=32,BN=256,BK=32,NS=2,NW=8 (24 wins)
+            GemmConfig(32, 256, 32, 2, 8),
+            # config_3: BM=8,BN=512,BK=32,NS=2,NW=8 (19 wins)
+            GemmConfig(8, 512, 32, 2, 8),
+            # config_2: BM=8,BN=512,BK=32,NS=2,NW=16 (9 wins)
+            GemmConfig(8, 512, 32, 2, 16),
+        ]
+        self.exhaustive_configs = self.mm_configs
 
 
 @register_template_heuristic(mm_plus_mm_template.uid, "xpu")

--- a/torch/_inductor/heuristics/template/triton.py
+++ b/torch/_inductor/heuristics/template/triton.py
@@ -3504,22 +3504,13 @@ class XPUBMGPersistentInt8MMTemplateConfigHeuristic(
 
     def __init__(self) -> None:
         super().__init__()
-        # Oracle-verified configs for INT8 on BMG (118 shapes tested)
-        # 7 configs cover all 66 winning shapes for bmg_persistent
         self.mm_configs = [
-            # config_1: BM=256,BN=128,BK=64,NS=3,NW=16 (17 wins)
             GemmConfig(256, 128, 64, 3, 16),
-            # config_4: BM=256,BN=256,BK=64,NS=2,NW=32 (16 wins)
             GemmConfig(256, 256, 64, 2, 32),
-            # config_6: BM=128,BN=512,BK=64,NS=2,NW=32 (15 wins)
             GemmConfig(128, 512, 64, 2, 32),
-            # config_7: BM=256,BN=256,BK=128,NS=2,NW=32 (8 wins)
             GemmConfig(256, 256, 128, 2, 32),
-            # config_5: BM=32,BN=256,BK=32,NS=2,NW=8 (6 wins)
             GemmConfig(32, 256, 32, 2, 8),
-            # config_3: BM=8,BN=512,BK=32,NS=2,NW=8 (3 wins)
             GemmConfig(8, 512, 32, 2, 8),
-            # config_2: BM=8,BN=512,BK=32,NS=2,NW=16 (1 win)
             GemmConfig(8, 512, 32, 2, 16),
         ]
         self.exhaustive_configs = self.mm_configs
@@ -3552,14 +3543,9 @@ class XPUBMGTiled2DInt8MMTemplateConfigHeuristic(
 
     def __init__(self) -> None:
         super().__init__()
-        # Oracle-verified configs for INT8 tiled2d on BMG (118 shapes tested)
-        # 3 configs cover all 52 winning shapes for bmg_tiled2d
         self.mm_configs = [
-            # config_5: BM=32,BN=256,BK=32,NS=2,NW=8 (24 wins)
             GemmConfig(32, 256, 32, 2, 8),
-            # config_3: BM=8,BN=512,BK=32,NS=2,NW=8 (19 wins)
             GemmConfig(8, 512, 32, 2, 8),
-            # config_2: BM=8,BN=512,BK=32,NS=2,NW=16 (9 wins)
             GemmConfig(8, 512, 32, 2, 16),
         ]
         self.exhaustive_configs = self.mm_configs

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -53,6 +53,7 @@ from ..utils import (
     use_decompose_k_choice,
     use_nv_universal_gemm_template,
     use_triton_blackwell_tma_template,
+    use_triton_bmg_template,
     use_triton_scaling_template,
     use_triton_template,
     use_triton_tma_template,
@@ -108,6 +109,24 @@ persistent_mm_template = TritonTemplate(
     name="mm_persistent",
     grid=persistent_mm_grid,
     source=load_kernel_template("triton_persistent_mm"),
+)
+
+# BMG (Battlemage/Xe2) optimized persistent MM template
+# Uses block2D pointers for hardware descriptor DMA with automatic
+# software pipelining via num_stages to exploit DPAS/SEND on BMG's architecture
+bmg_persistent_mm_template = TritonTemplate(
+    name="mm_bmg_persistent",
+    grid=persistent_mm_grid,
+    source=load_kernel_template("triton_bmg_persistent_mm"),
+)
+
+# BMG tiled 2D template for small M (1-32)
+# Non-persistent, 2D grid (grid_m, grid_n), block_ptr loads
+# Focuses on maximizing DRAM bandwidth for memory-bound shapes
+bmg_tiled2d_mm_template = TritonTemplate(
+    name="mm_bmg_tiled2d",
+    grid=mm_grid,
+    source=load_kernel_template("triton_bmg_tiled2d_mm"),
 )
 
 
@@ -593,6 +612,11 @@ def tuned_int_mm(mat1, mat2, *, layout=None):
         layout, enable_int32=True, check_max_autotune=False
     ):
         templates_to_use.append(mm_template)
+        # BMG-optimized persistent template with block2D and automatic software pipelining
+        if use_triton_bmg_template(layout, check_max_autotune=False):
+            templates_to_use.append(bmg_persistent_mm_template)
+            # Tiled 2D template for small M (bandwidth-bound)
+            templates_to_use.append(bmg_tiled2d_mm_template)
 
     # Single unified call for all templates
     choices.extend(

--- a/torch/_inductor/kernel/templates/triton_bmg_persistent_mm.py.jinja
+++ b/torch/_inductor/kernel/templates/triton_bmg_persistent_mm.py.jinja
@@ -1,0 +1,72 @@
+{{def_kernel("A", "B")}}
+    M = {{size("A", 0)}}
+    N = {{size("B", 1)}}
+    K = {{size("A", 1)}}
+    if M * N == 0:
+        return
+    stride_am = {{stride("A", 0)}}
+    stride_ak = {{stride("A", 1)}}
+    stride_bk = {{stride("B", 0)}}
+    stride_bn = {{stride("B", 1)}}
+
+    # ═══ BMG Persistent GEMM with Block2D ═══
+    #
+    # Persistent dispatch with GROUP_M swizzle for LLC reuse.
+    # Block2D loads via tl.make_block_ptr → hardware 2D DMA on BMG.
+    # Relies on Triton's num_stages for automatic software pipelining.
+
+    start_pid = tl.program_id(0).to(INDEX_DTYPE)
+    grid_m = tl.cdiv(M, BLOCK_M)
+    grid_n = tl.cdiv(N, BLOCK_N)
+    num_tiles = grid_m * grid_n
+    width = GROUP_M * grid_n
+
+    # Persistent tile loop: each WG processes multiple tiles
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS):
+
+        # L2-friendly tile ordering
+        group_id = tile_id // width
+        group_size = min(grid_m - group_id * GROUP_M, GROUP_M)
+        pid_m = group_id * GROUP_M + (tile_id % group_size)
+        pid_n = (tile_id % width) // (group_size)
+        tl.assume(pid_m >= 0)
+        tl.assume(pid_n >= 0)
+
+        rm = pid_m * BLOCK_M
+        rn = pid_n * BLOCK_N
+
+        # Block2D pointers
+        a_block_ptr = tl.make_block_ptr(
+            base=A,
+            shape=(M, K),
+            strides=(stride_am, stride_ak),
+            offsets=(rm, 0),
+            block_shape=(BLOCK_M, BLOCK_K),
+            order=(1, 0),
+        )
+        b_block_ptr = tl.make_block_ptr(
+            base=B,
+            shape=(K, N),
+            strides=(stride_bk, stride_bn),
+            offsets=(0, rn),
+            block_shape=(BLOCK_K, BLOCK_N),
+            order=(0, 1),
+        )
+
+        acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=ACC_TYPE)
+
+        for k_idx in range(0, tl.cdiv(K, BLOCK_K)):
+            a = tl.load(a_block_ptr, boundary_check=(0, 1), padding_option="zero")
+            b = tl.load(b_block_ptr, boundary_check=(0, 1), padding_option="zero")
+            acc = tl.dot(a, b, acc, out_dtype=ACC_TYPE)
+            a_block_ptr = tl.advance(a_block_ptr, (0, BLOCK_K))
+            b_block_ptr = tl.advance(b_block_ptr, (BLOCK_K, 0))
+
+        # Store output tile
+        idx_m = rm + tl.arange(0, BLOCK_M)
+        idx_n = rn + tl.arange(0, BLOCK_N)
+        idx_m = idx_m[:, None]
+        idx_n = idx_n[None, :]
+        mask = (idx_m < M) & (idx_n < N)
+
+        {{store_output(("idx_m", "idx_n"), "acc", "mask", indent_width=8, val_shape=("BLOCK_M", "BLOCK_N"))}}

--- a/torch/_inductor/kernel/templates/triton_bmg_tiled2d_mm.py.jinja
+++ b/torch/_inductor/kernel/templates/triton_bmg_tiled2d_mm.py.jinja
@@ -1,0 +1,60 @@
+{{def_kernel("A", "B")}}
+    M = {{size("A", 0)}}
+    N = {{size("B", 1)}}
+    K = {{size("A", 1)}}
+    if M * N == 0:
+        return
+    stride_am = {{stride("A", 0)}}
+    stride_ak = {{stride("A", 1)}}
+    stride_bk = {{stride("B", 0)}}
+    stride_bn = {{stride("B", 1)}}
+
+    # ═══ BMG Decode-Optimized GEMM (M≤32, bandwidth-bound) ═══
+    #
+    # Non-persistent, 2D grid, block2D loads via tl.make_block_ptr.
+    # Optimized for small M (decode): small BLOCK_M, large BLOCK_N.
+    # Relies on Triton's num_stages for automatic software pipelining.
+
+    pid_m = tl.program_id(0).to(INDEX_DTYPE)
+    pid_n = tl.program_id(1).to(INDEX_DTYPE)
+    tl.assume(pid_m >= 0)
+    tl.assume(pid_n >= 0)
+
+    rm = pid_m * BLOCK_M
+    rn = pid_n * BLOCK_N
+
+    # Block2D pointers → hardware 2D DMA descriptors on BMG
+    a_block_ptr = tl.make_block_ptr(
+        base=A,
+        shape=(M, K),
+        strides=(stride_am, stride_ak),
+        offsets=(rm, 0),
+        block_shape=(BLOCK_M, BLOCK_K),
+        order=(1, 0),
+    )
+    b_block_ptr = tl.make_block_ptr(
+        base=B,
+        shape=(K, N),
+        strides=(stride_bk, stride_bn),
+        offsets=(0, rn),
+        block_shape=(BLOCK_K, BLOCK_N),
+        order=(0, 1),
+    )
+
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=ACC_TYPE)
+
+    for k_idx in range(0, tl.cdiv(K, BLOCK_K)):
+        a = tl.load(a_block_ptr, boundary_check=(0, 1), padding_option="zero")
+        b = tl.load(b_block_ptr, boundary_check=(0, 1), padding_option="zero")
+        acc = tl.dot(a, b, acc, out_dtype=ACC_TYPE)
+        a_block_ptr = tl.advance(a_block_ptr, (0, BLOCK_K))
+        b_block_ptr = tl.advance(b_block_ptr, (BLOCK_K, 0))
+
+    # Store output
+    idx_m = rm + tl.arange(0, BLOCK_M)
+    idx_n = rn + tl.arange(0, BLOCK_N)
+    idx_m = idx_m[:, None]
+    idx_n = idx_n[None, :]
+    mask = (idx_m < M) & (idx_n < N)
+
+    {{store_output(("idx_m", "idx_n"), "acc", "mask", indent_width=4, val_shape=("BLOCK_M", "BLOCK_N"))}}

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2338,6 +2338,39 @@ def use_triton_scaling_template(
 
 
 @functools.lru_cache(maxsize=1)
+def is_bmg_device() -> bool:
+    """Detect Intel BMG (Battlemage/Xe2) GPU — Arc B580/B570/Pro B60/B70."""
+    if not torch.xpu.is_available():
+        return False
+    props = torch.xpu.get_device_properties(torch.xpu.current_device())
+    device_name = props.name.lower()
+    # BMG device names contain "b580", "b570", "b60", "b70", or "battlemage"
+    bmg_keywords = ("b580", "b570", "b60", "b70", "battlemage", "bmg")
+    return any(kw in device_name for kw in bmg_keywords)
+
+
+def use_triton_bmg_template(
+    layout: Layout,
+    check_max_autotune: bool = True,
+) -> bool:
+    """Check if BMG-optimized Triton persistent template should be used.
+
+    Conditions:
+      1. XPU device is BMG (Battlemage/Xe2)
+      2. Triton template is generally enabled
+      3. config.triton.enable_bmg_persistent_mm is True (default: True)
+    """
+    if not is_bmg_device():
+        return False
+    # enable_int32=True is needed for int_mm (output dtype=int32)
+    if not use_triton_template(
+        layout, enable_int32=True, check_max_autotune=check_max_autotune
+    ):
+        return False
+    return getattr(config.triton, "enable_bmg_persistent_mm", True)
+
+
+@functools.lru_cache(maxsize=1)
 def ensure_cute_available() -> bool:
     """Check if CuTeDSL is importable; cache the result for reuse.
 


### PR DESCRIPTION
- Add is_bmg_device() to detect Intel BMG (Battlemage/Xe2) GPUs
- Add use_triton_bmg_template() for BMG-optimized Triton persistent template
- Add triton_bmg_persistent_mm.py.jinja template for int8 matmul
- Add triton_bmg_tiled2d_mm.py.jinja template for decode shapes
- Update config.py with BMG persistent mm config options
- Update triton.py template heuristics for XPU int support
- Update mm.py kernel dispatch for BMG templates

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo