### PR TITLE
Make test_c10d_logger device-generic

### DIFF
--- a/test/distributed/test_c10d_logger.py
+++ b/test/distributed/test_c10d_logger.py
@@ -16,11 +16,12 @@ if not dist.is_available():
     sys.exit(0)
 
 from torch.testing._internal.common_distributed import DistributedTestBase, TEST_SKIPS
-from torch.testing._internal.common_fsdp import get_devtype
 from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
 
 
-device_type = get_devtype().type
+device_type = (
+    acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
+)
 
 if TEST_WITH_DEV_DBG_ASAN:
     print(


### PR DESCRIPTION
## Summary

Replaces get_devtype() from common_fsdp with
torch.accelerator.current_accelerator() to determine the device type, making the test portable across all accelerator backends.

## Changes

- Removed import of get_devtype from common_fsdp
- Replaced device_type = get_devtype().type with torch.accelerator.current_accelerator()-based detection (same pattern used in test_c10d_common.py and test_pg_wrapper.py)


Refs: #174469
cc @wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian