### PR TITLE
Fix ternary reference input metadata

### DIFF
--- a/test/functorch/common_utils.py
+++ b/test/functorch/common_utils.py
@@ -135,13 +135,11 @@ def is_valid_inplace_sample_input(sample_input, op, inplace_variant):
     if not isinstance(sample_input.input, torch.Tensor):
         return False
 
-    # In-place variants cannot change the input's shape or dtype.
+    # Check if input's dtype matches the output's dtype
     args = (sample_input.input,) + sample_input.args
     kwargs = sample_input.kwargs
-    output = op(*args, **kwargs)
-    if sample_input.input.shape != output.shape:
-        return False
-    return sample_input.input.dtype == output.dtype
+    output_dtype = op(*args, **kwargs).dtype
+    return sample_input.input.dtype == output_dtype
 
 
 # This is kind of dangerous, please think carefully before using it.

--- a/test/functorch/common_utils.py
+++ b/test/functorch/common_utils.py
@@ -135,11 +135,13 @@ def is_valid_inplace_sample_input(sample_input, op, inplace_variant):
     if not isinstance(sample_input.input, torch.Tensor):
         return False
 
-    # Check if input's dtype matches the output's dtype
+    # In-place variants cannot change the input's shape or dtype.
     args = (sample_input.input,) + sample_input.args
     kwargs = sample_input.kwargs
-    output_dtype = op(*args, **kwargs).dtype
-    return sample_input.input.dtype == output_dtype
+    output = op(*args, **kwargs)
+    if sample_input.input.shape != output.shape:
+        return False
+    return sample_input.input.dtype == output.dtype
 
 
 # This is kind of dangerous, please think carefully before using it.

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -4485,10 +4485,6 @@ class TestVmapOperatorsOpInfo(TestCase):
                 xfail("tril"),  # Exception not raised on error input
                 xfail("triu"),  # Exception not raised on error input
                 xfail("as_strided", "partial_views"),
-                # RuntimeError: output with shape [4, 4] doesn't match the broadcast shape [1, 4, 4]
-                xfail("addcdiv"),
-                xfail("addcmul"),
-                xfail("clamp"),
                 xfail("torch.ops.aten._efficient_attention_forward"),  # outputs ints
                 # TypeError: expected Tensor as element 0 in argument 0, but got float
                 xfail("item"),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -6649,7 +6649,16 @@ def sample_inputs_clamp(op_info, device, dtype, requires_grad, **kwargs):
 def reference_inputs_elementwise_ternary(op, device, dtype, requires_grad, *, sample_inputs_func, supports_scalars=False, **kwargs):
     yield from sample_inputs_func(op, device, dtype, requires_grad, **kwargs)
 
-    make_arg = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)
+    def make_arg(shape, *, requires_grad=requires_grad, **kwargs):
+        return make_tensor(
+            shape,
+            **{
+                "device": device,
+                "dtype": dtype,
+                "requires_grad": requires_grad,
+                **kwargs,
+            },
+        )
     make_scalar_tensor = partial(make_tensor, (), device='cpu', dtype=dtype, requires_grad=requires_grad)
     supported_dtypes = op.supported_dtypes(device)
 
@@ -6666,9 +6675,43 @@ def reference_inputs_elementwise_ternary(op, device, dtype, requires_grad, *, sa
     )
 
     for a, b, c in cases:
-        yield SampleInput(make_arg(a), args=(make_arg(b), make_arg(c)))
-        yield SampleInput(make_arg(a, noncontiguous=True),
-                          args=(make_arg(b).transpose(0, -1), make_arg(c, noncontiguous=True).transpose(0, -1)))
+        input = make_arg(a)
+        output_shape = torch.broadcast_shapes(input.shape, b, c)
+        args = (
+            make_arg(
+                b,
+                requires_grad=requires_grad
+                and (op.name != "clamp" or b == output_shape),
+            ),
+            make_arg(
+                c,
+                requires_grad=requires_grad
+                and (op.name != "clamp" or c == output_shape),
+            ),
+        )
+        yield SampleInput(
+            input,
+            args=args,
+            broadcasts_input=input.shape != output_shape,
+        )
+
+        input = make_arg(a, noncontiguous=True)
+        b = make_arg(b).transpose(0, -1)
+        c = make_arg(c, noncontiguous=True).transpose(0, -1)
+        output_shape = torch.broadcast_shapes(input.shape, b.shape, c.shape)
+        args = (
+            b.detach().requires_grad_(
+                requires_grad and (op.name != "clamp" or b.shape == output_shape)
+            ),
+            c.detach().requires_grad_(
+                requires_grad and (op.name != "clamp" or c.shape == output_shape)
+            ),
+        )
+        yield SampleInput(
+            input,
+            args=args,
+            broadcasts_input=input.shape != output_shape,
+        )
 
     # scalar cases
     if supports_scalars:

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -6666,9 +6666,26 @@ def reference_inputs_elementwise_ternary(op, device, dtype, requires_grad, *, sa
     )
 
     for a, b, c in cases:
-        yield SampleInput(make_arg(a), args=(make_arg(b), make_arg(c)))
-        yield SampleInput(make_arg(a, noncontiguous=True),
-                          args=(make_arg(b).transpose(0, -1), make_arg(c, noncontiguous=True).transpose(0, -1)))
+        input = make_arg(a)
+        args = (make_arg(b), make_arg(c))
+        output_shape = torch.broadcast_shapes(input.shape, *(arg.shape for arg in args))
+        yield SampleInput(
+            input,
+            args=args,
+            broadcasts_input=input.shape != output_shape,
+        )
+
+        input = make_arg(a, noncontiguous=True)
+        args = (
+            make_arg(b).transpose(0, -1),
+            make_arg(c, noncontiguous=True).transpose(0, -1),
+        )
+        output_shape = torch.broadcast_shapes(input.shape, *(arg.shape for arg in args))
+        yield SampleInput(
+            input,
+            args=args,
+            broadcasts_input=input.shape != output_shape,
+        )
 
     # scalar cases
     if supports_scalars:
@@ -6700,7 +6717,12 @@ def reference_inputs_elementwise_ternary(op, device, dtype, requires_grad, *, sa
         )
 
         for a, b, c in cases:
-            yield SampleInput(a, args=(b, c))
+            output_shape = torch.broadcast_shapes(a.shape, b.shape, c.shape)
+            yield SampleInput(
+                a,
+                args=(b, c),
+                broadcasts_input=a.shape != output_shape,
+            )
 
     # NaN propagation
     if dtype.is_floating_point or dtype.is_complex:

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -6649,16 +6649,7 @@ def sample_inputs_clamp(op_info, device, dtype, requires_grad, **kwargs):
 def reference_inputs_elementwise_ternary(op, device, dtype, requires_grad, *, sample_inputs_func, supports_scalars=False, **kwargs):
     yield from sample_inputs_func(op, device, dtype, requires_grad, **kwargs)
 
-    def make_arg(shape, *, requires_grad=requires_grad, **kwargs):
-        return make_tensor(
-            shape,
-            **{
-                "device": device,
-                "dtype": dtype,
-                "requires_grad": requires_grad,
-                **kwargs,
-            },
-        )
+    make_arg = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)
     make_scalar_tensor = partial(make_tensor, (), device='cpu', dtype=dtype, requires_grad=requires_grad)
     supported_dtypes = op.supported_dtypes(device)
 
@@ -6675,43 +6666,9 @@ def reference_inputs_elementwise_ternary(op, device, dtype, requires_grad, *, sa
     )
 
     for a, b, c in cases:
-        input = make_arg(a)
-        output_shape = torch.broadcast_shapes(input.shape, b, c)
-        args = (
-            make_arg(
-                b,
-                requires_grad=requires_grad
-                and (op.name != "clamp" or b == output_shape),
-            ),
-            make_arg(
-                c,
-                requires_grad=requires_grad
-                and (op.name != "clamp" or c == output_shape),
-            ),
-        )
-        yield SampleInput(
-            input,
-            args=args,
-            broadcasts_input=input.shape != output_shape,
-        )
-
-        input = make_arg(a, noncontiguous=True)
-        b = make_arg(b).transpose(0, -1)
-        c = make_arg(c, noncontiguous=True).transpose(0, -1)
-        output_shape = torch.broadcast_shapes(input.shape, b.shape, c.shape)
-        args = (
-            b.detach().requires_grad_(
-                requires_grad and (op.name != "clamp" or b.shape == output_shape)
-            ),
-            c.detach().requires_grad_(
-                requires_grad and (op.name != "clamp" or c.shape == output_shape)
-            ),
-        )
-        yield SampleInput(
-            input,
-            args=args,
-            broadcasts_input=input.shape != output_shape,
-        )
+        yield SampleInput(make_arg(a), args=(make_arg(b), make_arg(c)))
+        yield SampleInput(make_arg(a, noncontiguous=True),
+                          args=(make_arg(b).transpose(0, -1), make_arg(c, noncontiguous=True).transpose(0, -1)))
 
     # scalar cases
     if supports_scalars:


### PR DESCRIPTION
Fixes #189544.

Marks ternary reference samples whose first input is broadcast, so vmap skips invalid in-place variants. For clamp, broadcasted tensor bounds no longer request gradients that cannot be reduced to their original shapes.

Removes the resolved vmap xfails for addcdiv, addcmul, and clamp.

Validation:
- `python3 -m py_compile torch/testing/_internal/common_methods_invocations.py test/functorch/test_vmap.py`
- Targeted operator smoke check covering all generated ternary reference cases and their valid in-place variants`