### PR TITLE
[TEST][CUDA] `test_out_of_memory_retry`: increase requested memory

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -659,7 +659,7 @@ print(t.is_pinned())
             if TEST_CUDAMALLOCASYNC
             else "Tried to allocate"
         )
-        size = int(available_memory * 0.5)
+        size = int(available_memory * 0.51)
         a = torch.empty(size, dtype=torch.int8, device="cuda")
         with self.assertRaisesRegex(RuntimeError, oom_regex):
             b = torch.empty(size, dtype=torch.int8, device="cuda")


### PR DESCRIPTION
A follow up to my PR #186931 that caused #187045. Basically, the expected `RuntimeError` is not raised, because tensor `b` fits into the memory due to being exactly 50% of available memory in size.

Fixes #187045