### PR TITLE
[ATen] Add reduction tag to missing base reduction ops (re-land of #188902)

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3970,9 +3970,11 @@
 - func: nanmean(Tensor self, int[1]? dim=None, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor
   device_check: NoCheck   # Composite
   variants: function, method
+  tags: reduction
 
 - func: nanmean.out(Tensor self, int[1]? dim=None, bool keepdim=False, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # Composite
+  tags: reduction
 
 - func: median(Tensor self) -> Tensor
   variants: function, method
@@ -3982,11 +3984,13 @@
     MPS: median_mps
     XPU: median_xpu
   autogen: median.out
+  tags: reduction
 
 - func: median.dim(Tensor self, int dim, bool keepdim=False) -> (Tensor values, Tensor indices)
   variants: function, method
   dispatch:
     CompositeExplicitAutograd: median
+  tags: reduction
 
 - func: median.dim_values(Tensor self, int dim, bool keepdim=False, *, Tensor(a!) values, Tensor(b!) indices) -> (Tensor(a!) values, Tensor(b!) indices)
   dispatch:
@@ -3994,6 +3998,7 @@
     CUDA: median_out_cuda
     MPS: median_out_mps
     XPU: median_out_xpu
+  tags: reduction
 
 - func: nanmedian(Tensor self) -> Tensor
   variants: function, method
@@ -4003,11 +4008,13 @@
     MPS: nanmedian_mps
     XPU: nanmedian_xpu
   autogen: nanmedian.out
+  tags: reduction
 
 - func: nanmedian.dim(Tensor self, int dim, bool keepdim=False) -> (Tensor values, Tensor indices)
   variants: function, method
   dispatch:
     CompositeExplicitAutograd: nanmedian
+  tags: reduction
 
 - func: nanmedian.dim_values(Tensor self, int dim, bool keepdim=False, *, Tensor(a!) values, Tensor(b!) indices) -> (Tensor(a!) values, Tensor(b!) indices)
   dispatch:
@@ -4015,6 +4022,7 @@
     CUDA: nanmedian_out_cuda
     MPS: nanmedian_out_mps
     XPU: nanmedian_out_xpu
+  tags: reduction
 
 - func: min.dim(Tensor self, int dim, bool keepdim=False) -> (Tensor values, Tensor indices)
   device_check: NoCheck   # TensorIterator
@@ -4239,10 +4247,12 @@
   variants: function, method
   dispatch:
     CPU, CUDA, XPU: mode
+  tags: reduction
 
 - func: mode.values(Tensor self, int dim=-1, bool keepdim=False, *, Tensor(a!) values, Tensor(b!) indices) -> (Tensor(a!) values, Tensor(b!) indices)
   dispatch:
     CompositeExplicitAutograd: mode_out
+  tags: reduction
 
 - func: mul.Tensor(Tensor self, Tensor other) -> Tensor
   device_check: NoCheck   # TensorIterator
@@ -8893,6 +8903,7 @@
     MPS: trace_mps
     XPU: trace_xpu
   autogen: trace.out
+  tags: reduction
 
 - func: trace_backward(Tensor grad, SymInt[] sizes) -> Tensor
   variants: function
@@ -9710,6 +9721,7 @@
   dispatch:
     CompositeExplicitAutograd: dist
   autogen: dist.out
+  tags: reduction
 
 - func: atan2.out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
@@ -13886,9 +13898,11 @@
 - func: special_logsumexp(Tensor self, int[1] dim, bool keepdim=False) -> Tensor
   python_module: special
   variants: function
+  tags: reduction
 
 - func: special_logsumexp.out(Tensor self, int[1] dim, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
   python_module: special
+  tags: reduction
 
 - func: special_expit(Tensor self) -> Tensor
   python_module: special

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3968,9 +3968,11 @@
 - func: nanmean(Tensor self, int[1]? dim=None, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor
   device_check: NoCheck   # Composite
   variants: function, method
+  tags: reduction
 
 - func: nanmean.out(Tensor self, int[1]? dim=None, bool keepdim=False, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # Composite
+  tags: reduction
 
 - func: median(Tensor self) -> Tensor
   variants: function, method
@@ -3980,11 +3982,13 @@
     MPS: median_mps
     XPU: median_xpu
   autogen: median.out
+  tags: reduction
 
 - func: median.dim(Tensor self, int dim, bool keepdim=False) -> (Tensor values, Tensor indices)
   variants: function, method
   dispatch:
     CompositeExplicitAutograd: median
+  tags: reduction
 
 - func: median.dim_values(Tensor self, int dim, bool keepdim=False, *, Tensor(a!) values, Tensor(b!) indices) -> (Tensor(a!) values, Tensor(b!) indices)
   dispatch:
@@ -3992,6 +3996,7 @@
     CUDA: median_out_cuda
     MPS: median_out_mps
     XPU: median_out_xpu
+  tags: reduction
 
 - func: nanmedian(Tensor self) -> Tensor
   variants: function, method
@@ -4001,11 +4006,13 @@
     MPS: nanmedian_mps
     XPU: nanmedian_xpu
   autogen: nanmedian.out
+  tags: reduction
 
 - func: nanmedian.dim(Tensor self, int dim, bool keepdim=False) -> (Tensor values, Tensor indices)
   variants: function, method
   dispatch:
     CompositeExplicitAutograd: nanmedian
+  tags: reduction
 
 - func: nanmedian.dim_values(Tensor self, int dim, bool keepdim=False, *, Tensor(a!) values, Tensor(b!) indices) -> (Tensor(a!) values, Tensor(b!) indices)
   dispatch:
@@ -4013,6 +4020,7 @@
     CUDA: nanmedian_out_cuda
     MPS: nanmedian_out_mps
     XPU: nanmedian_out_xpu
+  tags: reduction
 
 - func: min.dim(Tensor self, int dim, bool keepdim=False) -> (Tensor values, Tensor indices)
   device_check: NoCheck   # TensorIterator
@@ -4239,10 +4247,12 @@
   variants: function, method
   dispatch:
     CPU, CUDA, XPU: mode
+  tags: reduction
 
 - func: mode.values(Tensor self, int dim=-1, bool keepdim=False, *, Tensor(a!) values, Tensor(b!) indices) -> (Tensor(a!) values, Tensor(b!) indices)
   dispatch:
     CompositeExplicitAutograd: mode_out
+  tags: reduction
 
 - func: mul.Tensor(Tensor self, Tensor other) -> Tensor
   device_check: NoCheck   # TensorIterator
@@ -8908,6 +8918,7 @@
     MPS: trace_mps
     XPU: trace_xpu
   autogen: trace.out
+  tags: reduction
 
 - func: trace_backward(Tensor grad, SymInt[] sizes) -> Tensor
   variants: function
@@ -9725,6 +9736,7 @@
   dispatch:
     CompositeExplicitAutograd: dist
   autogen: dist.out
+  tags: reduction
 
 - func: atan2.out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
@@ -13898,9 +13910,11 @@
 - func: special_logsumexp(Tensor self, int[1] dim, bool keepdim=False) -> Tensor
   python_module: special
   variants: function
+  tags: reduction
 
 - func: special_logsumexp.out(Tensor self, int[1] dim, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
   python_module: special
+  tags: reduction
 
 - func: special_expit(Tensor self) -> Tensor
   python_module: special

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -5659,20 +5659,24 @@ def sample_inputs__unsafe_masked_index_put_accumulate(op_info, device, dtype, re
 
 
 def sample_inputs_mode(op_info, device, dtype, requires_grad, **kwargs):
-    args = (
-        ((S, S, S), (),),
-        ((S, S, S), (1, ),),
-        ((S, S, S), (1, True, ),),
-        ((), (),),
-        ((), (0,),),
-        ((), (0, True,),),
-        # Non-fused mode kernel on CUDA
-        ((3000,), ()),
-    )
     make_arg = partial(make_tensor, dtype=dtype, device=device,
                        requires_grad=requires_grad, low=None, high=None)
-    return (SampleInput(make_arg(input_tensor), *args)
-            for input_tensor, args in args)
+    # `dim` / `keepdim` are passed via kwargs so that test_ops.test_reduction_ops_reduce
+    # (which gates on `"dim" in sample.kwargs`) actually exercises the op instead
+    # of skipping every sample and trivially passing.
+    cases = (
+        # (input_shape, kwargs)
+        ((S, S, S), {}),
+        ((S, S, S), {'dim': 1}),
+        ((S, S, S), {'dim': 1, 'keepdim': True}),
+        ((), {}),
+        ((), {'dim': 0}),
+        ((), {'dim': 0, 'keepdim': True}),
+        # Non-fused mode kernel on CUDA
+        ((3000,), {}),
+    )
+    for input_shape, kw in cases:
+        yield SampleInput(make_arg(input_shape), **kw)
 
 # Missing to test the nondeterminism of the operation
 # https://github.com/pytorch/pytorch/issues/53352

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -5728,20 +5728,24 @@ def sample_inputs__unsafe_masked_index_put_accumulate(op_info, device, dtype, re
 
 
 def sample_inputs_mode(op_info, device, dtype, requires_grad, **kwargs):
-    args = (
-        ((S, S, S), (),),
-        ((S, S, S), (1, ),),
-        ((S, S, S), (1, True, ),),
-        ((), (),),
-        ((), (0,),),
-        ((), (0, True,),),
-        # Non-fused mode kernel on CUDA
-        ((3000,), ()),
-    )
     make_arg = partial(make_tensor, dtype=dtype, device=device,
                        requires_grad=requires_grad, low=None, high=None)
-    return (SampleInput(make_arg(input_tensor), *args)
-            for input_tensor, args in args)
+    # `dim` / `keepdim` are passed via kwargs so that test_ops.test_reduction_ops_reduce
+    # (which gates on `"dim" in sample.kwargs`) actually exercises the op instead
+    # of skipping every sample and trivially passing.
+    cases = (
+        # (input_shape, kwargs)
+        ((S, S, S), {}),
+        ((S, S, S), {'dim': 1}),
+        ((S, S, S), {'dim': 1, 'keepdim': True}),
+        ((), {}),
+        ((), {'dim': 0}),
+        ((), {'dim': 0, 'keepdim': True}),
+        # Non-fused mode kernel on CUDA
+        ((3000,), {}),
+    )
+    for input_shape, kw in cases:
+        yield SampleInput(make_arg(input_shape), **kw)
 
 # Missing to test the nondeterminism of the operation
 # https://github.com/pytorch/pytorch/issues/53352


### PR DESCRIPTION
Re-land of #188902 with the fix for the MPS `mode` OpInfo interaction that caused the original PR to be auto-reverted.

### What was reverted

#188902 added the `reduction` tag to 14 `native_functions.yaml` entries. That caused `test/test_ops.py::test_reduction_ops_reduce` to be generated for the `mode` op for the first time. The new test `test_reduction_ops_reduce_mode_mps` failed with `Unexpected success` on trunk, triggering the auto-revert.

### Root cause

1. `test_reduction_ops_reduce` is parametrized over ops with `torch.Tag.reduction`
2. Before #188902, `mode` had no tag, so the test was never generated for it
3. After the tag was added, `test_reduction_ops_reduce_mode_mps` is created
4. `mode`'s OpInfo carries a blanket `TestCommon` `expectedFailure` on MPS, because `aten::mode` dispatches to `CPU, CUDA, XPU` only
5. The test's per-sample loop does `if "dim" not in sample.kwargs: continue`, and `sample_inputs_mode` passed `dim` **positionally** — so every sample was skipped and `aten::mode` was never invoked
6. Trivial pass + `expectedFailure` = `Unexpected success` = red trunk

Nothing was wrong with the tag additions themselves. The failure came entirely from the interaction between the `mode` OpInfo's blanket decorator and the newly-generated test.

### Fix

`sample_inputs_mode` now passes `dim` and `keepdim` as **kwargs** instead of positionally. No new decorators are added and no existing ones are touched.

With this change `test_reduction_ops_reduce` actually invokes `aten::mode`:

- On CPU/CUDA/XPU, `torch.mode(x, dim=k)` returns a `(values, indices)` namedtuple. The test's `isinstance(result, torch.Tensor)` guard skips the numel assertion for those samples, as intended.
- On MPS, `aten::mode` raises `NotImplementedError`, which the existing blanket `expectedFailure` catches as an expected failure.
- If MPS support is added later, that xfail will fire `Unexpected success` and prompt its removal — preserving the maintenance signal @Skylion007 asked for, rather than silencing it with a skip.

Fixing this at the sample-inputs level addresses the cause rather than suppressing the symptom.

### Newly tagged ops

- `nanmean`, `nanmean.out` (mirrors `mean.*`)
- `median`, `median.dim`, `median.dim_values`
- `nanmedian`, `nanmedian.dim`, `nanmedian.dim_values` (mirror `min.dim` / `max.dim`)
- `mode`, `mode.values` (dim-reduced like `min.dim`)
- `trace` (sum over diagonal -> scalar)
- `dist` (`norm(a - b)` -> scalar)
- `special_logsumexp`, `special_logsumexp.out` (mirrors `logsumexp.*`)

### Audit of the other tagged ops

Confirmed none share the MPS blanket-xfail interaction that `mode` had:

| Op | OpInfo state on MPS |
| --- | --- |
| `nanmean` | No blanket xfail |
| `median` | `dtypesIfMPS` set -> supported |
| `nanmedian` | `dtypesIfMPS` set -> supported |
| `trace` | `dtypesIfMPS` set -> supported |
| `dist` | No blanket xfail |
| `special_logsumexp` (via `logsumexp`) | No blanket xfail |

### Diff summary

- `aten/src/ATen/native/native_functions.yaml`: +14 (unchanged from #188902)
- `torch/testing/_internal/common_methods_invocations.py`: +16 / -12 (`sample_inputs_mode`)

Total: 2 files, +30 / -12.

### Context

Follow-up to #129020, per @eellison's invitation on #169944 ("if there are any missing ops, please submit a pr to add them").

cc @eellison @drisspg