### PR TITLE
[Testcase Refactoring]Add hw_classification label to test_tensorpipe_agent.py (cuda)

### DIFF
--- a/test/distributed/rpc/cuda/test_tensorpipe_agent.py
+++ b/test/distributed/rpc/cuda/test_tensorpipe_agent.py
@@ -11,7 +11,10 @@ if not dist.is_available():
     sys.exit(0)
 
 import torch
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+)
 from torch.testing._internal.distributed.rpc.tensorpipe_rpc_agent_test_fixture import (
     TensorPipeRpcAgentTestFixture,
 )
@@ -25,14 +28,15 @@ from torch.testing._internal.distributed.rpc_utils import (
 if torch.cuda.is_available():
     torch.cuda.memory._set_allocator_settings("expandable_segments:False")
 
-globals().update(
-    generate_tests(
-        "TensorPipe",
-        TensorPipeRpcAgentTestFixture,
-        GENERIC_CUDA_TESTS + TENSORPIPE_CUDA_TESTS,
-        __name__,
-    )
+_generated_tests = generate_tests(
+    "TensorPipe",
+    TensorPipeRpcAgentTestFixture,
+    GENERIC_CUDA_TESTS + TENSORPIPE_CUDA_TESTS,
+    __name__,
 )
+for _cls in _generated_tests.values():
+    _cls.hw_classification = HardwareClassification.CUDA
+globals().update(_generated_tests)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# [Testcase Refactoring] Add hw_classification label to test_tensorpipe_agent.py (cuda)

## Summary
This PR adds a `hw_classification = HardwareClassification.CUDA` label to the test classes generated by `generate_tests` in `test/distributed/rpc/cuda/test_tensorpipe_agent.py`.

## Changes
- Imported `HardwareClassification` from `torch.testing._internal.common_utils`.
- Captured the return value of `generate_tests(...)` and set `hw_classification = HardwareClassification.CUDA` on each generated class before registering them in `globals()`.

## Motivation
`HardwareClassification` is the community-standard mechanism (defined in `torch/testing/_internal/common_utils.py`) for declaring the kind of hardware a test class requires. When `--hw-classification` is passed on the CLI, only tests whose classification matches are executed; when the flag is not specified, all test discovery and execution paths remain unchanged. These CUDA RPC test classes (built from `GENERIC_CUDA_TESTS + TENSORPIPE_CUDA_TESTS`) exercise CUDA-specific behavior (e.g. `device="cuda:0"`, `torch.cuda.Stream`), so they are labeled `CUDA`.

## Test Plan
- CI: `python test/distributed/rpc/cuda/test_tensorpipe_agent.py`
- Verified that without `--hw-classification`, test discovery and execution are unchanged (the label is pure metadata).
- Verified that `--hw-classification CUDA` correctly selects these tests.

## Notes
- The allocator-settings guard (`if torch.cuda.is_available(): torch.cuda.memory._set_allocator_settings(...)`) is intentionally left unchanged. `_set_allocator_settings` is currently a CUDA-only entry point (not present on `torch.xpu.memory` or `torch.mps`), and this file is a CUDA-specific test file under `test/distributed/rpc/cuda/`, so the CUDA-specific guard is consistent with the file's context.
- This is part of the test case refactoring initiative tracked in #185590.
