### PR TITLE
[Testcase Refactoring] Fix _LocalOffsetBasedRNGTracker device state lookup for non-cuda/xpu devices

### DIFF
--- a/torch/distributed/_local_tensor/__init__.py
+++ b/torch/distributed/_local_tensor/__init__.py
@@ -794,18 +794,14 @@ class _LocalOffsetBasedRNGTracker:
         if self.distribute_region_enabled:
             # sync to rank 0's state if no explicit generator
             if generator is None:
-                any_rank_state = lm._any_local_rng_state()
-                any_rank_cpu, any_rank_cuda = any_rank_state
-
-                if self._device.type in {"cuda", "xpu"}:
-                    if self._device.index not in any_rank_cuda:
-                        raise AssertionError
-                    any_rank_device_state = any_rank_cuda[self._device.index]
-                else:
-                    any_rank_device_state = any_rank_cpu
-
                 from torch.distributed.tensor._random import _PhiloxState
 
+                # Get the device RNG state directly from the base_state_tensor
+                # (already fetched via the device handle at line above).
+                # This is device-agnostic and works for any accelerator
+                # (cuda, xpu, npu, etc.) without relying on torch.accelerator registration.
+                first_rank = next(iter(lm.ranks))
+                any_rank_device_state = base_state_tensor._local_tensors[first_rank]
                 any_rank_philox = _PhiloxState(any_rank_device_state)
                 state.seed = int(any_rank_philox.seed.item())
                 state.offset = int(any_rank_philox.offset.item())

--- a/torch/distributed/_local_tensor/__init__.py
+++ b/torch/distributed/_local_tensor/__init__.py
@@ -794,14 +794,18 @@ class _LocalOffsetBasedRNGTracker:
         if self.distribute_region_enabled:
             # sync to rank 0's state if no explicit generator
             if generator is None:
+                any_rank_state = lm._any_local_rng_state()
+                any_rank_cpu, any_rank_cuda = any_rank_state
+
+                if torch.accelerator.is_available():
+                    if self._device.index not in any_rank_cuda:
+                        raise AssertionError
+                    any_rank_device_state = any_rank_cuda[self._device.index]
+                else:
+                    any_rank_device_state = any_rank_cpu
+
                 from torch.distributed.tensor._random import _PhiloxState
 
-                # Get the device RNG state directly from the base_state_tensor
-                # (already fetched via the device handle at line above).
-                # This is device-agnostic and works for any accelerator
-                # (cuda, xpu, npu, etc.) without relying on torch.accelerator registration.
-                first_rank = next(iter(lm.ranks))
-                any_rank_device_state = base_state_tensor._local_tensors[first_rank]
                 any_rank_philox = _PhiloxState(any_rank_device_state)
                 state.seed = int(any_rank_philox.seed.item())
                 state.offset = int(any_rank_philox.offset.item())


### PR DESCRIPTION
## Summary:
The `_distribute_region` method hardcoded `{"cuda", "xpu"}` to select whether to use the accelerator RNG state or the CPU state. Instead of routing through the (cpu_state, accelerator_states) tuple from `lm._any_local_rng_state()` - which requires both a hardcoded device-type set and torch.accelerator registration — use `base_state_tensor._local_tensors[first_rank]` directly.

## Test Plan
- CI: `python test/distributed/tensor/parallel/test_tp_style.py TensorParallelStyleTestWithLocalTensor.test_sequence_parallel_style`

Refs #185590 