### PR TITLE
[MPS] F.linear fix for [B,1,K] (seq=1 decode) 8.5x regression on bf16/fp16

### DIFF
--- a/aten/src/ATen/native/mps/operations/Linear.mm
+++ b/aten/src/ATen/native/mps/operations/Linear.mm
@@ -138,7 +138,7 @@ Tensor _mps_linear(const Tensor& input, const Tensor& weight_arg, const std::opt
         !is_macos_at_least(MacOSVersion::MACOS_27_0);
     const bool add_bias_after = is_bias_defined && decompose_bias;
     const Tensor kernel_bias = add_bias_after ? Tensor() : bias;
-    if (needs_nd_workaround(input) && (!kernel_bias.defined() || kernel_bias.dim() <= 1)) {
+    if (input.dim() > 2 && (!kernel_bias.defined() || kernel_bias.dim() <= 1)) {
       auto input2d = input.flatten(0, -2);
       auto output2d = output.flatten(0, -2);
       _mps_linear_nograph(input2d, weight, kernel_bias, output2d);


### PR DESCRIPTION
## [MPS] F.linear fix for [B,1,K] (seq=1 decode) 8.5x regression on bf16/fp16

> Authored by @radimurban, fixes #189847.

On Apple Silicon MPS, `torch.nn.functional.linear` applied to a 3D input of decode shape `[B, 1, K]` is up to ~8.5x slower than the mathematically identical 2D op `[B, K]`, and than `torch.matmul(x, w.t())` on the same 3D tensor. The cost ramps ~linearly with `B` and then snaps back to GEMM once `B` crosses a threshold (~16). It directly throttles on-device LLM token generation

It is specific to
 - MPS
- `F.linear` (which on MPS routes to `_mps_linear`)
- half precision (fp32 is unaffected)
- 3D half input with small non-batch dims (`M == 1` is the worst/most-persistent case)

## Environment

```
PyTorch : 2.14.0a0 (source build; also present on 2.10.x)
OS      : macOS 26.4 (25E246)
Device  : Apple M4 Pro (MPS)
dtype   : bfloat16 (fp16 identical; fp32 unaffected)
```

## Minimal reproduction

```python
import time, torch
import torch.nn.functional as F
dev, dt = "mps", torch.bfloat16
K, N = 5120, 17408                              # Qwen3-14B gate: [.,K] @ [K,N]
W = torch.randn(N, K, device=dev, dtype=dt)     # nn.Linear weight [out, in]

def timed(fn, warmup=10, iters=30):
    for _ in range(warmup): fn()
    torch.mps.synchronize(); ts=[]
    for _ in range(iters):
        torch.mps.synchronize(); t=time.perf_counter()
        fn(); torch.mps.synchronize(); ts.append((time.perf_counter()-t)*1e3)
    return sorted(ts)[len(ts)//2]

print(f"{'B':>4} {'F.linear_3d':>12} {'F.linear_2d':>12} {'matmul_3d':>10} {'3d/2d':>6}")
for B in (1,4,8,14,16,32,64):
    x3 = torch.randn(B,1,K,device=dev,dtype=dt)  # [B,1,K] decode shape
    x2 = x3.squeeze(1)                            # [B,K] (zero-copy view)
    l3 = timed(lambda: F.linear(x3, W))
    l2 = timed(lambda: F.linear(x2, W))
    m3 = timed(lambda: torch.matmul(x3, W.t()))
    print(f"{B:>4} {l3:>12.2f} {l2:>12.2f} {m3:>10.2f} {l3/l2:>5.1f}x")
```

Output (M4 Pro, macOS 26.4, bf16):

```
   B  F.linear_3d  F.linear_2d   matmul_3d  3d/2d
   1         0.89         0.91        0.93   1.0x
   4         3.00         0.97        0.97   3.1x
   8         5.76         0.94        0.93   6.1x
  14         9.91         1.17        1.18   8.5x
  16         1.15         1.14        1.15   1.0x
  32         1.28         1.29        1.30   1.0x
  64         1.97         1.95        1.96   1.0x
```

- **Expected:** `F.linear([B,1,K])` costs ~the same as `F.linear([B,K])` and
  `matmul([B,1,K], w.t())` — a `[B,1]×N` output is a trivial reshape from a
  `[B]×N` GEMM.
- **Actual:** `F.linear([B,1,K])` ramps ~linearly in `B` (each batch element run
  as an independent GEMV) and only snaps to GEMM performance past a width-
  dependent `B` threshold. `matmul` and 2D `F.linear` stay flat.


## Analysis


<img width="3552" height="2648" alt="Image" src="https://github.com/user-attachments/assets/0c1f7825-043e-446b-b400-c0245b2b1d25" />

1. **`F.linear` only.** `torch.matmul`, `torch.mm`, `torch.addmm` on the same logical op do **not** show the linear-per-batch ramp.
2. **3D half input with small non-batch dims.** `M == 1` (`[B,1,K]`) is the worst and most persistent case, but `[B,2,K]` also ramps at low `B` and snaps earlier (~B=5); `[B,8,K]` tracks the efficient GEMM sooner. A leading singleton `[1,B,K]` (middle dim `= B`) is flat. The pathology is the small-leading-dims 3D layout staying below the `N`-dependent GEMM threshold; seq=1 decode (`M==1`) sits in it for the widest `B` range.
3. **Half precision only.** At `B=8` gate: bf16 = 6.1x, fp16 = 6.0x, fp32 = 1.0x (no cliff).
4. **Threshold scales with output width `N`.** Snap-back `B` is `None` only for  `N = 512`; ~16 for `N ∈ [1024, 17408]`; ~10 for `N ≥ 32768`. So the per-layer snap differs by width (MLP `N=17408` ~16, `lm_head` `N=151936` ~10), and a full decode step's summed
   cost peaks around batch 8–14 before the widest ops flip to GEMM.

## Source localization

`aten::linear` on MPS maps to `_mps_linear` (`native_functions.yaml` → `aten/src/ATen/native/mps/operations/Linear.mm`)

For the decode case (macOS 15+, contiguous, non-complex, half) `_mps_linear` takes the **nograph fast path** `_mps_linear_nograph`, which hands the raw 3D `[B,1,K]` NDArray to `MPSNDArrayMatrixMultiplication` (weight transposed, broadcast over the leading batch dim) → per-batch GEMV.

A flatten-to-2D perf workaround for exactly this 3D case already exists, but only in the graph branch of `_mps_linear` (reached on macOS < 15):

```cpp
// graph branch -- the perf workaround exists here:
bool doReshape = input.dim() > 4;
if (!doReshape && is_bias_defined) {
  // workaround to improve the performance with 3D+ inputs
  doReshape = input_size.size() > 2 && input_size[0] > 1 &&
              input_size[1] >= 1 && input_size[1] <= 32 && bias.dim() <= 1;
}
```

The `nograph` fast path has no equivalent perf flatten. Its only flatten, `needs_nd_workaround(input)`, is a non-determinism fix gated to the Apple10 (M5+) GPU family (#180776) — it does not fire on M4 and is unrelated to this GEMV perf issue. So on M4 / macOS 26 a contiguous half `[B,1,K]` reaches `_mps_linear_nograph` with no flatten → the per-batch GEMV cliff.

## Proposed fix

The `nograph` fast path already has a flatten-to-2D branch, it is just gated to the M5+ non-determinism case (`needs_nd_workaround`). Broadening that gate to any `>2D` input fixes the GEMV cliff and subsumes the existing workaround. One-line change in `_mps_linear`:

```diff
-    if (needs_nd_workaround(input) && (!kernel_bias.defined() || kernel_bias.dim() <= 1)) {
+    if (input.dim() > 2 && (!kernel_bias.defined() || kernel_bias.dim() <= 1)) {
       auto input2d = input.flatten(0, -2);    // [B,1,K] -> [B,K]  (zero-copy view)
       auto output2d = output.flatten(0, -2);  // [B,1,N] -> [B,N]
       _mps_linear_nograph(input2d, weight, kernel_bias, output2d);
     } else {
       _mps_linear_nograph(input, weight, kernel_bias, output);
     }
```

`flatten(0, -2)` on a contiguous input is a zero-copy view.

## Verification

**(a) Related PR #184631 (drop `strides()` in `_mps_linear_nograph`) does not fix this.** A canonically-strided `[B,1,K]` never takes the strided NDArray path that PR targets, so the cliff is unchanged: `F.linear_3d` still 6.2x at B=8, 8.5x at B=14, snapping at 16. (That PR fixes a *different* problem — non-canonically strided contiguous inputs, e.g. a B=1 transpose in `MultiheadAttention`, #181725.)

**(b) The flatten fix above eliminates it.** With the gate broadened, `F.linear` on `[B,1,K]` matches 2D and `torch.matmul` at every batch, with no large-batch regression (M4 Pro, bf16, ms):

```
   B | F.linear_3d | F.linear_2d | matmul_3d | 3d/2d
   1 |        0.94 |        0.94 |      0.97 | 1.0x
   8 |        0.93 |        0.93 |      0.92 | 1.0x    (was 5.8 ms / 6.2x)
  14 |        1.16 |        1.16 |      1.18 | 1.0x    (was 9.9 ms / 8.5x)
  16 |        1.17 |        1.17 |      1.18 | 1.0x
  32 |        1.29 |        1.29 |      1.31 | 1.0x
  64 |        1.97 |        1.96 |      1.97 | 1.0x
```

Output is bit-identical (`torch.allclose` / `torch.equal`), since the flatten is a pure reshape.

## Related Issues

- #186541 (open, "Port all MPSGraph matmuls to Metal") — benchmark table shows MPSGraph matmul slow on GEMV (M==1) / small-batch bmm.
- #184631 (open, "Skip strided NDArray path in `_mps_linear_nograph` when inputs are contiguous") — same function, but a *different* cause (non-canonical
  strides). **Tested: does not fix this GEMV cliff** (see Verification).
- #181725 (open) — `nn.MultiheadAttention` ~9x slower at B=1; the case #184631 fixes (B=1 strided `F.linear`), distinct from this M=1 GEMV cliff.
- #188728 (open) — `F.linear` ignores `PYTORCH_MPS_PREFER_METAL`.
- #117837 (merged) — origin of the graph-branch `input_size[1] <= 32` flatten workaround. #180776 (closed) / #181466 (merged) — the M5+ >2D half `linear` non-determinism flatten this fix generalizes.

---

CC: @jhavukainen , @jerryzh168 , @versi379 , @kulinseth , @malfet , @DenisVieriu97 , @aditvenk 
