### PR TITLE
[MPS] TCCL - Thunderbolt Collective Communication Library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -389,6 +389,14 @@ cmake_dependent_option(
     USE_C10D_XCCL "USE C10D XCCL" ON "USE_DISTRIBUTED;USE_XCCL" OFF)
 cmake_dependent_option(
     USE_C10D_MPI "USE C10D MPI" ON "USE_DISTRIBUTED;USE_MPI" OFF)
+# TCCL (Thunderbolt Collective Communications Library): RDMA backend for MPS
+# over Apple Silicon Thunderbolt 5. macOS-only and off by default. Enable with
+# -DUSE_TCCL=ON on macOS 26.2+ with librdma.dylib present.
+cmake_dependent_option(
+    USE_TCCL "Use TCCL (Thunderbolt RDMA) backend for MPS." OFF
+    "USE_DISTRIBUTED;APPLE" OFF)
+cmake_dependent_option(
+    USE_C10D_TCCL "USE C10D TCCL" ON "USE_DISTRIBUTED;USE_TCCL" OFF)
 cmake_dependent_option(
     USE_TENSORPIPE "Use TensorPipe. Only available if USE_DISTRIBUTED is on." ON
     "USE_DISTRIBUTED AND NOT WIN32" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -498,6 +498,14 @@ cmake_dependent_option(
     USE_C10D_XCCL "USE C10D XCCL" ON "USE_DISTRIBUTED;USE_XCCL" OFF)
 cmake_dependent_option(
     USE_C10D_MPI "USE C10D MPI" ON "USE_DISTRIBUTED;USE_MPI" OFF)
+# TCCL (Thunderbolt Collective Communications Library): RDMA backend for MPS
+# over Apple Silicon Thunderbolt 5. macOS-only and off by default. Enable with
+# -DUSE_TCCL=ON on macOS 26.2+ with librdma.dylib present.
+cmake_dependent_option(
+    USE_TCCL "Use TCCL (Thunderbolt RDMA) backend for MPS." OFF
+    "USE_DISTRIBUTED;APPLE" OFF)
+cmake_dependent_option(
+    USE_C10D_TCCL "USE C10D TCCL" ON "USE_DISTRIBUTED;USE_TCCL" OFF)
 cmake_dependent_option(
     USE_TENSORPIPE "Use TensorPipe. Only available if USE_DISTRIBUTED is on." ON
     "USE_DISTRIBUTED AND NOT WIN32" OFF)

--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -532,6 +532,8 @@ libtorch_distributed_base_sources = [
     "torch/csrc/distributed/c10d/ProcessGroup.cpp",
     "torch/csrc/distributed/c10d/ProcessGroupGloo.cpp",
     "torch/csrc/distributed/c10d/ProcessGroupMPI.cpp",
+    "torch/csrc/distributed/c10d/ProcessGroupTCCL.cpp",
+    "torch/csrc/distributed/c10d/TCCLUtils.cpp",
     "torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp",
     "torch/csrc/distributed/c10d/Store.cpp",
     "torch/csrc/distributed/c10d/TCPStore.cpp",

--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -526,6 +526,8 @@ libtorch_distributed_base_sources = [
     "torch/csrc/distributed/c10d/ProcessGroup.cpp",
     "torch/csrc/distributed/c10d/ProcessGroupGloo.cpp",
     "torch/csrc/distributed/c10d/ProcessGroupMPI.cpp",
+    "torch/csrc/distributed/c10d/ProcessGroupTCCL.cpp",
+    "torch/csrc/distributed/c10d/TCCLUtils.cpp",
     "torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp",
     "torch/csrc/distributed/c10d/Store.cpp",
     "torch/csrc/distributed/c10d/TCPStore.cpp",

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1668,6 +1668,11 @@ if(USE_DISTRIBUTED)
     endif()
     target_compile_definitions(torch_cpu PUBLIC USE_C10D_MPI)
   endif()
+  if(USE_TCCL AND USE_C10D_TCCL)
+    target_compile_definitions(torch_cpu PUBLIC USE_C10D_TCCL)
+    target_include_directories(torch_cpu PRIVATE ${LIBRDMA_INCLUDE_DIR})
+    target_link_libraries(torch_cpu PRIVATE ${LIBRDMA_LIBRARY})
+  endif()
   # Pass USE_RPC in order to reduce use of
   # #if defined(USE_DISTRIBUTED) && !defined(_WIN32)
   # need to be removed when RPC is supported

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1572,6 +1572,11 @@ if(USE_DISTRIBUTED)
     endif()
     target_compile_definitions(torch_cpu PUBLIC USE_C10D_MPI)
   endif()
+  if(USE_TCCL AND USE_C10D_TCCL)
+    target_compile_definitions(torch_cpu PUBLIC USE_C10D_TCCL)
+    target_include_directories(torch_cpu PRIVATE ${LIBRDMA_INCLUDE_DIR})
+    target_link_libraries(torch_cpu PRIVATE ${LIBRDMA_LIBRARY})
+  endif()
   # Pass USE_RPC in order to reduce use of
   # #if defined(USE_DISTRIBUTED) && !defined(_WIN32)
   # need to be removed when RPC is supported

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -958,6 +958,26 @@ if(USE_MPI)
   endif()
 endif()
 
+# ---[ TCCL (Thunderbolt RDMA over macOS librdma)
+# Only probed when the user explicitly opts in with -DUSE_TCCL=ON. Gated on
+# APPLE at the top-level option definition; here we verify that librdma.dylib
+# and <infiniband/verbs.h> are actually reachable on this system. If the probe
+# fails, USE_TCCL is turned off (with a warning) so Dependencies.cmake doesn't
+# carry the flag into the caffe2 source lists.
+if(USE_TCCL)
+  find_library(LIBRDMA_LIBRARY rdma)
+  find_path(LIBRDMA_INCLUDE_DIR infiniband/verbs.h)
+  if(LIBRDMA_LIBRARY AND LIBRDMA_INCLUDE_DIR)
+    message(STATUS "TCCL: found librdma at ${LIBRDMA_LIBRARY}")
+    message(STATUS "TCCL: verbs.h in ${LIBRDMA_INCLUDE_DIR}")
+  else()
+    message(WARNING
+      "USE_TCCL was requested but librdma.dylib or <infiniband/verbs.h> was "
+      "not found. Requires macOS 26.2+. Disabling TCCL.")
+    caffe2_update_option(USE_TCCL OFF)
+  endif()
+endif()
+
 # ---[ OpenMP
 if(USE_OPENMP AND NOT TARGET caffe2::openmp)
   include(${CMAKE_CURRENT_LIST_DIR}/Modules/FindOpenMP.cmake)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -931,6 +931,26 @@ if(USE_MPI)
   endif()
 endif()
 
+# ---[ TCCL (Thunderbolt RDMA over macOS librdma)
+# Only probed when the user explicitly opts in with -DUSE_TCCL=ON. Gated on
+# APPLE at the top-level option definition; here we verify that librdma.dylib
+# and <infiniband/verbs.h> are actually reachable on this system. If the probe
+# fails, USE_TCCL is turned off (with a warning) so Dependencies.cmake doesn't
+# carry the flag into the caffe2 source lists.
+if(USE_TCCL)
+  find_library(LIBRDMA_LIBRARY rdma)
+  find_path(LIBRDMA_INCLUDE_DIR infiniband/verbs.h)
+  if(LIBRDMA_LIBRARY AND LIBRDMA_INCLUDE_DIR)
+    message(STATUS "TCCL: found librdma at ${LIBRDMA_LIBRARY}")
+    message(STATUS "TCCL: verbs.h in ${LIBRDMA_INCLUDE_DIR}")
+  else()
+    message(WARNING
+      "USE_TCCL was requested but librdma.dylib or <infiniband/verbs.h> was "
+      "not found. Requires macOS 26.2+. Disabling TCCL.")
+    caffe2_update_option(USE_TCCL OFF)
+  endif()
+endif()
+
 # ---[ OpenMP
 if(USE_OPENMP AND NOT TARGET caffe2::openmp)
   include(${CMAKE_CURRENT_LIST_DIR}/Modules/FindOpenMP.cmake)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -396,6 +396,7 @@ nccl2 = "torch.distributed.distributed_c10d:_register_builtin_nccl2_backend"
 "nccl-lazy" = "torch.distributed.distributed_c10d:_register_builtin_nccl_lazy_backend"
 ucc = "torch.distributed.distributed_c10d:_register_builtin_ucc_backend"
 xccl = "torch.distributed.distributed_c10d:_register_builtin_xccl_backend"
+tccl = "torch.distributed.distributed_c10d:_register_builtin_tccl_backend"
 
 [project.urls]
 Homepage = "https://pytorch.org"

--- a/setup.py
+++ b/setup.py
@@ -1127,6 +1127,7 @@ def configure_extension_build() -> tuple[
         "nccl = torch.distributed.distributed_c10d:_register_builtin_nccl_backend",
         "ucc = torch.distributed.distributed_c10d:_register_builtin_ucc_backend",
         "xccl = torch.distributed.distributed_c10d:_register_builtin_xccl_backend",
+        "tccl = torch.distributed.distributed_c10d:_register_builtin_tccl_backend",
     ]
     return ext_modules, cmdclass, packages, entry_points, extra_install_requires
 

--- a/test/distributed/test_c10d_tccl.py
+++ b/test/distributed/test_c10d_tccl.py
@@ -1,0 +1,738 @@
+# Owner(s): ["oncall: distributed"]
+#
+# Correctness tests for the TCCL c10d backend (RDMA-over-Thunderbolt for Apple
+# Silicon MPS tensors).
+#
+# LAUNCH MODEL — read this before adding tests.
+# TCCL is a genuinely MULTI-NODE backend: it moves data over RDMA between
+# *physical* Macs linked by Thunderbolt, so — unlike Gloo/NCCL, which exercise a
+# backend with multiple processes (or GPUs) on a single host — it cannot be
+# driven by the single-host spawn model of MultiProcessTestCase /
+# MultiProcContinuousTest (both spawn local processes + rendezvous via a shared
+# FileStore, neither of which crosses machines). Instead these tests are
+# ENV-LAUNCHED: one rank per machine, each process runs this file with
+# RANK / WORLD_SIZE / MASTER_ADDR / MASTER_PORT (and the per-rank
+# TCCL_PEER_DEVICES the backend reads) provided by the TCCL multi-node launcher
+# (scripts/tccl_launch.py). Rendezvous is a TCPStore over the mesh; the
+# collectives run in lockstep because every rank executes the identical,
+# deterministically-ordered set of test methods.
+#
+# Consequence: a plain ``python test_c10d_tccl.py`` or pytest invocation on a
+# single host (no launcher env) SKIPS the whole suite — TCCL needs the fabric.
+# This is the same "collected but hardware-gated, skips without the hardware"
+# property NCCL tests have for GPUs; how CI should drive a multi-host backend is
+# an open item for the upstream RFC.
+#
+# To run on a configured cluster (rank 0 = master), e.g.:
+#   python scripts/tccl_launch.py --hostfile ~/tccl_hostfile.json --nodes 4 \
+#       --port 29500 -- test_c10d_tccl.py
+# (the launcher sets RANK/WORLD_SIZE/MASTER_ADDR/MASTER_PORT/TCCL_PEER_DEVICES
+# per rank and runs this file on each node).
+
+import os
+import contextlib
+import math
+import sys
+import unittest
+from datetime import timedelta
+
+import torch
+import torch.distributed as c10d
+import torch.nn as nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+# TCCL needs the multi-node launcher env. Without it (e.g. generic CI / a bare
+# pytest run) there is no fabric to talk to, so skip the module cleanly.
+
+if not c10d.is_available():
+    print("c10d not available, skipping tests", file=sys.stderr)
+    sys.exit(0)
+
+from torch.testing._internal.common_distributed import requires_tccl
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    skip_but_pass_in_sandcastle_if,
+    TestCase,
+)
+
+
+# ---- dtype / reduce-op tables under test ----
+REDUCE_DTYPES = [
+    torch.float32, torch.float16, torch.bfloat16,
+    torch.int64, torch.int32, torch.int16, torch.int8, torch.uint8, torch.bool,
+]
+COPY_DTYPES = REDUCE_DTYPES + [torch.complex64]
+FLOAT_DTYPES = [torch.float32, torch.float16, torch.bfloat16]
+
+
+def _fill_value(rank, dtype):
+    if dtype == torch.bool:
+        return bool(rank % 2 == 0)
+    if dtype == torch.complex64:
+        return complex(rank + 1, rank + 1)
+    return rank + 1
+
+
+def _tol(dtype):
+    # tiny integer sums are exact in fp16/bf16 too; keep a small cushion for them.
+    if dtype in (torch.float16, torch.bfloat16):
+        return dict(rtol=1e-2, atol=1e-2)
+    return dict(rtol=0, atol=0)
+
+
+def _launcher_env():
+    """(rank, world_size, master_addr, master_port) from the launcher, or None.
+
+    Read from the explicit CLI args the launcher passes (--rank/--world-size/
+    --master-addr/--port), falling back to the RANK/WORLD_SIZE/MASTER_ADDR/
+    MASTER_PORT env vars. The CLI args are the source of truth: a cluster login
+    shell can carry a stale MASTER_PORT in the environment (a duplicate that
+    resolves to the wrong port for ssh-launched ranks), which would desync
+    rank 0 (launched locally, no login shell) from the other ranks."""
+    import argparse
+
+    def _ei(k):
+        v = os.environ.get(k)
+        return int(v) if v is not None else None
+
+    p = argparse.ArgumentParser(add_help=False)
+    p.add_argument("--rank", type=int)
+    p.add_argument("--world-size", type=int)
+    p.add_argument("--master-addr")
+    p.add_argument("--port", type=int)
+    a, _ = p.parse_known_args()
+    rank = a.rank if a.rank is not None else _ei("RANK")
+    ws = a.world_size if a.world_size is not None else _ei("WORLD_SIZE")
+    addr = a.master_addr or os.environ.get("MASTER_ADDR")
+    port = a.port if a.port is not None else _ei("MASTER_PORT")
+    if rank is None or ws is None or addr is None or port is None:
+        return None
+    return (rank, ws, addr, port)
+
+
+# Captured at import — BEFORE the __main__ block strips these flags from argv.
+_LAUNCH = _launcher_env()
+
+
+# Integration-smoke model dims + a seeded RNG helper (CPU-generated then moved to
+# MPS so every rank produces identical/deterministic tensors from a given seed).
+_IN, _HID, _OUT, _BATCH = 64, 128, 64, 8
+
+
+def _randn(shape, seed, dtype, device):
+    g = torch.Generator().manual_seed(seed)
+    return torch.randn(*shape, generator=g).to(dtype).to(device)
+
+
+def _ring_topology():
+    """True when the launcher brought the group up as a ring (sparse cabling):
+    TCCL_TOPOLOGY=ring. Ring drops the two mesh-only capabilities (uneven
+    alltoall, non-neighbor p2p), so those tests invert to rejection tests."""
+    return os.environ.get("TCCL_TOPOLOGY", "mesh").lower() == "ring"
+
+
+@contextlib.contextmanager
+def _force_algo(algo):
+    """Force the TCCL ring/mesh algorithm for the enclosed collective(s). Every
+    rank runs the identical parametrized test, so all ranks set the same algo (a
+    ring/mesh mix across ranks would deadlock). At world_size <= 2 ring silently
+    falls back to mesh (still correct)."""
+    prev = os.environ.get("TCCL_FORCE_ALGO")
+    os.environ["TCCL_FORCE_ALGO"] = algo
+    try:
+        yield
+    finally:
+        if prev is None:
+            os.environ.pop("TCCL_FORCE_ALGO", None)
+        else:
+            os.environ["TCCL_FORCE_ALGO"] = prev
+
+
+class TcclTestBase(TestCase):
+    """Env-launched base: one rank per machine. Inits a single TCCL process group
+    for the whole class (rendezvous via TCPStore from the launcher env) and tears
+    it down at the end. A barrier between tests keeps the ranks in lockstep."""
+
+    timeout = timedelta(seconds=120)
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        env = _LAUNCH
+        if env is None:
+            raise unittest.SkipTest(
+                "TCCL is multi-node; launch via the TCCL launcher (sets RANK/"
+                "WORLD_SIZE/MASTER_ADDR/MASTER_PORT). Skipping single-host run.")
+        if sys.platform != "darwin" or not c10d.is_tccl_available():
+            raise unittest.SkipTest("TCCL requires macOS with the TCCL backend built in")
+        if not torch.backends.mps.is_available():
+            raise unittest.SkipTest("TCCL requires an available MPS device")
+
+        cls.rank, cls.world_size, master_addr, master_port = env
+        cls.device = torch.device("mps", 0)  # one MPS device per machine (not mps:rank)
+        store = c10d.TCPStore(
+            host_name=master_addr, port=master_port, world_size=cls.world_size,
+            is_master=(cls.rank == 0), timeout=cls.timeout)
+        c10d.init_process_group(
+            backend="tccl", store=store, rank=cls.rank, world_size=cls.world_size,
+            device_id=cls.device, timeout=cls.timeout)
+
+    @classmethod
+    def tearDownClass(cls):
+        if c10d.is_initialized():
+            c10d.destroy_process_group()
+        super().tearDownClass()
+
+    def tearDown(self):
+        # Resync ranks between tests so a per-test mismatch can't desync the next
+        # (mirrors the inter-cell barrier in the external dtype-matrix harness).
+        if c10d.is_initialized():
+            c10d.barrier()
+        super().tearDown()
+
+    # ---- helpers --------------------------------------------------------------
+    def _full(self, dtype, n=4096):
+        return torch.full((n,), _fill_value(self.rank, dtype), dtype=dtype,
+                          device=self.device)
+
+    def _assert(self, actual, expected_scalar, dtype):
+        exp = torch.full_like(actual, expected_scalar)
+        self.assertEqual(actual, exp, **_tol(dtype))
+
+
+@requires_tccl()
+class ProcessGroupTcclCorrectnessTest(TcclTestBase):
+    """Per-collective numerical correctness over the supported dtype/op contract."""
+
+    # ---- allreduce ------------------------------------------------------------
+    @parametrize("dtype", REDUCE_DTYPES)
+    def test_allreduce_sum(self, dtype):
+        t = self._full(dtype)
+        c10d.all_reduce(t, op=c10d.ReduceOp.SUM)
+        ws = self.world_size
+        if dtype == torch.bool:
+            self._assert(t, True, dtype)  # SUM == OR; any rank0 True -> True
+        else:
+            self._assert(t, ws * (ws + 1) // 2, dtype)
+
+    @parametrize("dtype", REDUCE_DTYPES)
+    @parametrize("op", ["MIN", "MAX"])
+    def test_allreduce_minmax(self, dtype, op):
+        t = self._full(dtype)
+        c10d.all_reduce(t, op=getattr(c10d.ReduceOp, op))
+        if dtype == torch.bool:
+            self._assert(t, (op == "MAX"), dtype)  # MIN=AND=False, MAX=OR=True
+        else:
+            self._assert(t, 1 if op == "MIN" else self.world_size, dtype)
+
+    @parametrize("dtype", FLOAT_DTYPES)
+    def test_allreduce_avg(self, dtype):
+        t = self._full(dtype)
+        c10d.all_reduce(t, op=c10d.ReduceOp.AVG)
+        self._assert(t, (self.world_size + 1) / 2.0, dtype)
+
+    @parametrize("dtype", REDUCE_DTYPES)
+    def test_allreduce_product(self, dtype):
+        t = self._full(dtype)
+        c10d.all_reduce(t, op=c10d.ReduceOp.PRODUCT)
+        if dtype == torch.bool:
+            self._assert(t, False, dtype)  # PRODUCT == AND; even ranks True, odd False
+        else:
+            # prod over ranks of (rank+1) = world_size! (fits int8 for ws <= 5)
+            self._assert(t, math.factorial(self.world_size), dtype)
+
+    # ---- broadcast (byte-copy, any dtype) -------------------------------------
+    @parametrize("dtype", COPY_DTYPES)
+    def test_broadcast(self, dtype):
+        t = self._full(dtype)
+        c10d.broadcast(t, src=0)
+        self._assert(t, _fill_value(0, dtype), dtype)
+
+    # ---- allgather (byte-copy) ------------------------------------------------
+    @parametrize("dtype", COPY_DTYPES)
+    def test_allgather_base(self, dtype):
+        ws = self.world_size
+        inp = self._full(dtype, n=1024)
+        out = torch.empty(1024 * ws, dtype=dtype, device=self.device)
+        c10d.all_gather_into_tensor(out, inp)
+        for r in range(ws):
+            exp = torch.full((1024,), _fill_value(r, dtype), dtype=dtype, device=self.device)
+            self.assertEqual(out[r * 1024:(r + 1) * 1024], exp, **_tol(dtype))
+
+    # ---- reduce_scatter (coalesced; TP sequence-parallel / DTensor path) ------
+    @parametrize("dtype", REDUCE_DTYPES)
+    @parametrize("op", ["SUM", "MIN", "MAX"])
+    def test_reduce_scatter_sum_minmax(self, dtype, op):
+        import torch.distributed._functional_collectives as funcol
+        ws = self.world_size
+        inp = self._full(dtype, n=1024 * ws)
+        out = funcol.reduce_scatter_tensor(inp, op.lower(), scatter_dim=0,
+                                           group=c10d.distributed_c10d._get_default_group())
+        out = out.wait() if hasattr(out, "wait") else out
+        if dtype == torch.bool:
+            want = True if op in ("SUM", "MAX") else False
+            self._assert(out, want, dtype)
+        else:
+            want = {"SUM": ws * (ws + 1) // 2, "MIN": 1, "MAX": ws}[op]
+            self._assert(out, want, dtype)
+
+    @parametrize("dtype", FLOAT_DTYPES)
+    def test_reduce_scatter_avg(self, dtype):
+        import torch.distributed._functional_collectives as funcol
+        ws = self.world_size
+        inp = self._full(dtype, n=1024 * ws)
+        out = funcol.reduce_scatter_tensor(inp, "avg", scatter_dim=0,
+                                           group=c10d.distributed_c10d._get_default_group())
+        out = out.wait() if hasattr(out, "wait") else out
+        self._assert(out, (ws + 1) / 2.0, dtype)
+
+    @parametrize("dtype", REDUCE_DTYPES)
+    def test_reduce_scatter_product(self, dtype):
+        import torch.distributed._functional_collectives as funcol
+        ws = self.world_size
+        inp = self._full(dtype, n=1024 * ws)
+        out = funcol.reduce_scatter_tensor(inp, "product", scatter_dim=0,
+                                           group=c10d.distributed_c10d._get_default_group())
+        out = out.wait() if hasattr(out, "wait") else out
+        if dtype == torch.bool:
+            self._assert(out, False, dtype)
+        else:
+            self._assert(out, math.factorial(ws), dtype)
+
+    # ---- barrier --------------------------------------------------------------
+    def test_barrier(self):
+        c10d.barrier()  # no data; should not raise
+
+    # ---- reduce_scatter, tensor form (FSDP reduce_scatter_tensor ->
+    #      _reduce_scatter_base). Forces BOTH ring and mesh; world_size <= 2 makes
+    #      ring fall back to mesh (still correct). Same fill -> same expected value
+    #      as the coalesced path: out[k] = reduction over ranks of (rank+1).
+    @parametrize("dtype", REDUCE_DTYPES)
+    @parametrize("op", ["SUM", "MIN", "MAX"])
+    @parametrize("algo", ["ring", "mesh"])
+    def test_reduce_scatter_base_sum_minmax(self, dtype, op, algo):
+        with _force_algo(algo):
+            ws = self.world_size
+            inp = self._full(dtype, n=1024 * ws)
+            out = torch.empty(1024, dtype=dtype, device=self.device)
+            c10d.reduce_scatter_tensor(out, inp, op=getattr(c10d.ReduceOp, op))
+            if dtype == torch.bool:
+                self._assert(out, op in ("SUM", "MAX"), dtype)  # SUM/MAX=OR, MIN=AND
+            else:
+                self._assert(out, {"SUM": ws * (ws + 1) // 2, "MIN": 1, "MAX": ws}[op], dtype)
+
+    @parametrize("dtype", FLOAT_DTYPES)
+    @parametrize("algo", ["ring", "mesh"])
+    def test_reduce_scatter_base_avg(self, dtype, algo):
+        with _force_algo(algo):
+            ws = self.world_size
+            inp = self._full(dtype, n=1024 * ws)
+            out = torch.empty(1024, dtype=dtype, device=self.device)
+            c10d.reduce_scatter_tensor(out, inp, op=c10d.ReduceOp.AVG)
+            self._assert(out, (ws + 1) / 2.0, dtype)
+
+    @parametrize("dtype", REDUCE_DTYPES)
+    @parametrize("algo", ["ring", "mesh"])
+    def test_reduce_scatter_base_product(self, dtype, algo):
+        with _force_algo(algo):
+            ws = self.world_size
+            inp = self._full(dtype, n=1024 * ws)
+            out = torch.empty(1024, dtype=dtype, device=self.device)
+            c10d.reduce_scatter_tensor(out, inp, op=c10d.ReduceOp.PRODUCT)
+            if dtype == torch.bool:
+                self._assert(out, False, dtype)
+            else:
+                self._assert(out, math.factorial(ws), dtype)
+
+    # ---- reduce_scatter, list form (dist.reduce_scatter -> the `reduce_scatter`
+    #      virtual). out (on rank r) = reduction over ranks of in_list[r]; every
+    #      rank fills each in_list[j] = rank+1, so out = reduction over ranks of
+    #      (rank+1) — same expected value. Exercises the zero-copy per-rank-pointer
+    #      path. Both ring and mesh.
+    @parametrize("dtype", REDUCE_DTYPES)
+    @parametrize("op", ["SUM", "MIN", "MAX"])
+    @parametrize("algo", ["ring", "mesh"])
+    def test_reduce_scatter_list(self, dtype, op, algo):
+        with _force_algo(algo):
+            ws = self.world_size
+            out = torch.empty(1024, dtype=dtype, device=self.device)
+            in_list = [self._full(dtype, n=1024) for _ in range(ws)]
+            c10d.reduce_scatter(out, in_list, op=getattr(c10d.ReduceOp, op))
+            if dtype == torch.bool:
+                self._assert(out, op in ("SUM", "MAX"), dtype)
+            else:
+                self._assert(out, {"SUM": ws * (ws + 1) // 2, "MIN": 1, "MAX": ws}[op], dtype)
+
+    @parametrize("dtype", FLOAT_DTYPES)
+    @parametrize("algo", ["ring", "mesh"])
+    def test_reduce_scatter_list_avg(self, dtype, algo):
+        with _force_algo(algo):
+            ws = self.world_size
+            out = torch.empty(1024, dtype=dtype, device=self.device)
+            in_list = [self._full(dtype, n=1024) for _ in range(ws)]
+            c10d.reduce_scatter(out, in_list, op=c10d.ReduceOp.AVG)
+            self._assert(out, (ws + 1) / 2.0, dtype)
+
+    @parametrize("dtype", REDUCE_DTYPES)
+    @parametrize("algo", ["ring", "mesh"])
+    def test_reduce_scatter_list_product(self, dtype, algo):
+        with _force_algo(algo):
+            ws = self.world_size
+            out = torch.empty(1024, dtype=dtype, device=self.device)
+            in_list = [self._full(dtype, n=1024) for _ in range(ws)]
+            c10d.reduce_scatter(out, in_list, op=c10d.ReduceOp.PRODUCT)
+            if dtype == torch.bool:
+                self._assert(out, False, dtype)
+            else:
+                self._assert(out, math.factorial(ws), dtype)
+
+    # ---- send / recv (point-to-point over the per-peer UC QP) -----------------
+    # Byte-copy, any dtype. TCCL's single worker thread serializes ops, so a rank
+    # never has a send and a recv in flight at once; these use directed/sequential
+    # patterns. Concurrent bidirectional P2P (e.g. naive batch_isend_irecv both
+    # ways) would serialize on the worker — a pipeline-framework concern, out of
+    # scope here. No recv-before-send handshake: the ctor RTS barrier brings the
+    # QPs up and the sender's stage-copy gives the receiver a head start to post
+    # its recv.
+    def test_send_recv_chain(self):
+        # Sequential pipeline 0->1->...->(ws-1): rank i sends float(i) to i+1;
+        # rank i+1 verifies it got float(i). No cycle -> deadlock-free, any ws>=2.
+        ws, r, dev = self.world_size, self.rank, self.device
+        if ws < 2:
+            self.skipTest("send/recv needs world_size >= 2")
+        n = 2048
+        if r > 0:
+            t = torch.empty(n, dtype=torch.float32, device=dev)
+            c10d.recv(t, src=r - 1)
+            self.assertEqual(t, torch.full((n,), float(r - 1), device=dev))
+        if r < ws - 1:
+            c10d.send(torch.full((n,), float(r), dtype=torch.float32, device=dev), dst=r + 1)
+
+    @parametrize("dtype", [torch.float32, torch.bfloat16, torch.int64])
+    def test_send_recv_pair_dtypes(self, dtype):
+        # Directed rank 0 -> rank 1 (other ranks idle). Byte-copy across dtypes.
+        ws, r, dev = self.world_size, self.rank, self.device
+        if ws < 2:
+            self.skipTest("send/recv needs world_size >= 2")
+        n = 512
+        if r == 0:
+            c10d.send(torch.full((n,), _fill_value(7, dtype), dtype=dtype, device=dev), dst=1)
+        elif r == 1:
+            t = torch.empty(n, dtype=dtype, device=dev)
+            c10d.recv(t, src=0)
+            self._assert(t, _fill_value(7, dtype), dtype)
+
+    def test_send_recv_large_multichunk(self):
+        # 1 MB fp32 (> the 512 KB chunk) rank 0 -> rank 1: exercises the chunk loop.
+        ws, r, dev = self.world_size, self.rank, self.device
+        if ws < 2:
+            self.skipTest("send/recv needs world_size >= 2")
+        n = 256 * 1024  # 1 MB fp32 -> 2 chunks
+        if r == 0:
+            c10d.send(torch.full((n,), 3.0, dtype=torch.float32, device=dev), dst=1)
+        elif r == 1:
+            t = torch.empty(n, dtype=torch.float32, device=dev)
+            c10d.recv(t, src=0)
+            self.assertEqual(t, torch.full((n,), 3.0, device=dev))
+
+    def test_send_recv_nonadjacent(self):
+        # rank 0 -> rank (ws-1) directly: any pair has a usable QP (full mesh),
+        # not just neighbours.
+        if _ring_topology():
+            self.skipTest("non-neighbor p2p is mesh-only; ring rejects it "
+                          "(see ProcessGroupTcclRingRejectTest)")
+        ws, r, dev = self.world_size, self.rank, self.device
+        if ws < 3:
+            self.skipTest("non-adjacent needs world_size >= 3")
+        n = 1024
+        if r == 0:
+            c10d.send(torch.full((n,), 5.0, dtype=torch.float32, device=dev), dst=ws - 1)
+        elif r == ws - 1:
+            t = torch.empty(n, dtype=torch.float32, device=dev)
+            c10d.recv(t, src=0)
+            self.assertEqual(t, torch.full((n,), 5.0, device=dev))
+
+    # ---- alltoall_base (MoE / sequence-parallel) ------------------------------
+    # Equal split: rank r fills its whole input with fill(r); each output block i
+    # (received from rank i) must be fill(i). Byte-copy -> a few dtypes; both ring
+    # and mesh (ring needs ws>2, else falls back to mesh — still correct).
+    @parametrize("dtype", [torch.float32, torch.bfloat16, torch.int32])
+    @parametrize("algo", ["ring", "mesh"])
+    def test_alltoall_equal(self, dtype, algo):
+        with _force_algo(algo):
+            ws, r, dev = self.world_size, self.rank, self.device
+            seg = 256
+            inp = torch.full((seg * ws,), _fill_value(r, dtype), dtype=dtype, device=dev)
+            out = torch.empty(seg * ws, dtype=dtype, device=dev)
+            c10d.all_to_all_single(out, inp)
+            for i in range(ws):
+                exp = torch.full((seg,), _fill_value(i, dtype), dtype=dtype, device=dev)
+                self.assertEqual(out[i * seg:(i + 1) * seg], exp, **_tol(dtype))
+
+    def test_alltoall_uneven(self):
+        # alltoallv (variable splits -> mesh). rank r sends (j+1) rows to rank j and
+        # fills its input with (r+1); so rank r receives (r+1) rows from each src,
+        # each block valued (src+1). Splits are consistent across ranks.
+        if _ring_topology():
+            self.skipTest("uneven alltoall is mesh-only; ring rejects it "
+                          "(see ProcessGroupTcclRingRejectTest)")
+        ws, r, dev = self.world_size, self.rank, self.device
+        in_splits = [j + 1 for j in range(ws)]
+        out_splits = [r + 1 for _ in range(ws)]
+        inp = torch.full((sum(in_splits),), float(r + 1), dtype=torch.float32, device=dev)
+        out = torch.empty(sum(out_splits), dtype=torch.float32, device=dev)
+        c10d.all_to_all_single(out, inp, out_splits, in_splits)
+        off = 0
+        for src in range(ws):
+            self.assertEqual(out[off:off + (r + 1)],
+                             torch.full((r + 1,), float(src + 1), device=dev))
+            off += r + 1
+
+    @parametrize("algo", ["ring", "mesh"])
+    def test_alltoall_large_multichunk(self, algo):
+        # Equal split, 1 MB fp32 per segment (> the 512 KB chunk) -> chunk loop.
+        with _force_algo(algo):
+            ws, r, dev = self.world_size, self.rank, self.device
+            seg = 256 * 1024
+            inp = torch.full((seg * ws,), float(r + 1), dtype=torch.float32, device=dev)
+            out = torch.empty(seg * ws, dtype=torch.float32, device=dev)
+            c10d.all_to_all_single(out, inp)
+            for i in range(ws):
+                self.assertEqual(out[i * seg:(i + 1) * seg],
+                                 torch.full((seg,), float(i + 1), device=dev))
+
+    # ---- allgather, list form (dist.all_gather -> the `allgather` virtual) -----
+    # The byte-copy paths are dtype-agnostic (proven across dtypes via the _base
+    # form above); here we just exercise the separate list-form code path DDP
+    # construction uses. fp32 is representative.
+    def test_allgather_list(self):
+        ws = self.world_size
+        inp = self._full(torch.float32, n=1024)
+        outs = [torch.empty(1024, dtype=torch.float32, device=self.device) for _ in range(ws)]
+        c10d.all_gather(outs, inp)
+        for r in range(ws):
+            self.assertEqual(outs[r], torch.full((1024,), float(r + 1), device=self.device))
+
+    # ---- allgather coalesced (funcol -> allgather_into_tensor_coalesced) -------
+    # The DTensor/TP entry point, distinct from _base (eager) above.
+    def test_allgather_coalesced(self):
+        import torch.distributed._functional_collectives as funcol
+        ws = self.world_size
+        inp = self._full(torch.float32, n=1024)
+        out = funcol.all_gather_tensor(inp, gather_dim=0,
+                                       group=c10d.distributed_c10d._get_default_group())
+        out = out.wait() if hasattr(out, "wait") else out
+        for r in range(ws):
+            self.assertEqual(out[r * 1024:(r + 1) * 1024],
+                             torch.full((1024,), float(r + 1), device=self.device))
+
+    # ---- large allreduce: crosses the 512 KB mesh chunk boundary + (ws>2) the ring
+    #      auto-switch (fp32 >=8 MB). Tiny dtype-matrix cells never reach either. -----
+    def test_allreduce_large_fp32(self):
+        n = 3 * 1024 * 1024  # 12 MB fp32 -> ring at ws>2, many 512 KB chunks
+        t = torch.full((n,), float(self.rank + 1), dtype=torch.float32, device=self.device)
+        c10d.all_reduce(t, op=c10d.ReduceOp.SUM)
+        ws = self.world_size
+        self.assertEqual(t, torch.full((n,), float(ws * (ws + 1) // 2), device=self.device))
+
+    # ---- TCCL_FORCE_ALGO knob: both ring and mesh produce correct results ------
+    # (correctness holds regardless of the algo actually chosen; at ws<=2 ring
+    # silently falls back to mesh, which is still correct).
+    def test_force_algo(self):
+        ws = self.world_size
+        prev = os.environ.get("TCCL_FORCE_ALGO")
+        try:
+            for algo, dtype in (("ring", torch.float32), ("mesh", torch.bfloat16)):
+                os.environ["TCCL_FORCE_ALGO"] = algo
+                t = self._full(dtype)
+                c10d.all_reduce(t, op=c10d.ReduceOp.SUM)
+                self._assert(t, ws * (ws + 1) // 2, dtype)
+        finally:
+            if prev is None:
+                os.environ.pop("TCCL_FORCE_ALGO", None)
+            else:
+                os.environ["TCCL_FORCE_ALGO"] = prev
+
+    # ---- process-group identity -----------------------------------------------
+    def test_rank_world_size(self):
+        self.assertEqual(c10d.get_rank(), self.rank)
+        self.assertEqual(c10d.get_world_size(), self.world_size)
+
+
+@requires_tccl()
+class ProcessGroupTcclIntegrationTest(TcclTestBase):
+    """End-to-end smokes: real DDP backward and Megatron tensor-parallel forward
+    over TCCL, each diffed against a LOCAL single-process baseline (non-circular —
+    the baseline uses no collectives)."""
+
+    def _mlp(self):
+        return nn.Sequential(nn.Linear(_IN, _HID), nn.ReLU(), nn.Linear(_HID, _OUT))
+
+    @parametrize("dtype", [torch.float32, torch.bfloat16])
+    def test_ddp_backward(self, dtype):
+        # DDP all-reduce-averages per-rank grads; for a mean-MSE loss with equal
+        # per-rank batches that equals the single-process grad over the concatenated
+        # batch (computed locally from the same init weights). Exercises DDP ctor
+        # (broadcast params + allgather metadata) + backward allreduce over TCCL.
+        rank, ws = self.rank, self.world_size
+        dev = self.device
+        torch.manual_seed(0)                       # identical init on every rank
+        model = self._mlp().to(dev).to(dtype)
+        init_sd = {k: v.detach().clone() for k, v in model.state_dict().items()}
+
+        ddp = DDP(model)
+        x = _randn((_BATCH, _IN), 100 + rank, dtype, dev)
+        y = _randn((_BATCH, _OUT), 200 + rank, dtype, dev)
+        ((ddp(x) - y) ** 2).mean().backward()
+        torch.mps.synchronize()
+        ddp_grads = [p.grad.detach().float().cpu() for p in model.parameters()]
+
+        ref = self._mlp().to(dev).to(dtype)
+        ref.load_state_dict(init_sd)
+        xs = torch.cat([_randn((_BATCH, _IN), 100 + r, dtype, dev) for r in range(ws)], 0)
+        ys = torch.cat([_randn((_BATCH, _OUT), 200 + r, dtype, dev) for r in range(ws)], 0)
+        ((ref(xs) - ys) ** 2).mean().backward()
+        torch.mps.synchronize()
+        ref_grads = [p.grad.detach().float().cpu() for p in ref.parameters()]
+
+        worst = max((dg - rg).abs().max().item() for dg, rg in zip(ddp_grads, ref_grads))
+        tol = 2e-2 if dtype == torch.bfloat16 else 1e-4
+        self.assertLess(worst, tol, f"DDP grads diverge from single-process baseline: {worst:.3e}")
+
+    @parametrize("dtype", [torch.float32, torch.bfloat16])
+    def test_tp_megatron_forward(self, dtype):
+        # Megatron MLP: fc1 column-parallel (no comm), fc2 row-parallel
+        # (all_reduce-SUM of partials). Reduced output == full single-process MLP.
+        rank, ws = self.rank, self.world_size
+        dev = self.device
+        if _HID % ws != 0:
+            self.skipTest(f"hidden dim {_HID} not divisible by world_size {ws}")
+        W1 = _randn((_IN, _HID), 1, dtype, dev)    # full weights, identical per rank
+        W2 = _randn((_HID, _OUT), 2, dtype, dev)
+        x = _randn((_BATCH, _IN), 3, dtype, dev)
+        full = torch.relu(x @ W1) @ W2             # single-process reference (no comm)
+
+        hp = _HID // ws
+        z = torch.relu(x @ W1[:, rank * hp:(rank + 1) * hp]) @ W2[rank * hp:(rank + 1) * hp, :]
+        c10d.all_reduce(z, op=c10d.ReduceOp.SUM)   # sum partials -> full output
+        torch.mps.synchronize()
+
+        ref = full.float().cpu()
+        abs_err = (z.float().cpu() - ref).abs().max().item()
+        # TP activations are large-magnitude; one bf16 ulp at that scale ~1.0, so
+        # compare RELATIVE error against the reference scale.
+        scale = max(1.0, ref.abs().max().item())
+        rtol = 3e-2 if dtype == torch.bfloat16 else 1e-5
+        self.assertLess(abs_err / scale, rtol,
+                        f"TP forward diverges from single-process baseline: rel={abs_err/scale:.3e}")
+
+
+@requires_tccl()
+class ProcessGroupTcclContractTest(TcclTestBase):
+    """Negative/contract tests: the unsupported (op, dtype) cells must reject
+    cleanly (raise), not crash or silently corrupt."""
+
+    def test_avg_integer_rejects(self):
+        # AVG is float-only (matches NCCL); integer AVG must raise.
+        t = self._full(torch.int32)
+        with self.assertRaises(Exception):
+            c10d.all_reduce(t, op=c10d.ReduceOp.AVG)
+
+    def test_uint16_reduce_rejects(self):
+        # uint16/32/64 have no MPS add kernel -> reduce must reject.
+        t = self._full(torch.uint16)
+        with self.assertRaises(Exception):
+            c10d.all_reduce(t, op=c10d.ReduceOp.SUM)
+
+    def test_complex_minmax_rejects(self):
+        # complex MIN/MAX is undefined; the PyTorch frontend deny-lists it.
+        t = torch.full((128,), complex(self.rank + 1, 1), dtype=torch.complex64,
+                       device=self.device)
+        with self.assertRaises(Exception):
+            c10d.all_reduce(t, op=c10d.ReduceOp.MAX)
+
+    def test_complex_product_rejects(self):
+        # complex PRODUCT is undefined via the real-view; the frontend deny-lists it.
+        t = torch.full((128,), complex(self.rank + 1, 1), dtype=torch.complex64,
+                       device=self.device)
+        with self.assertRaises(Exception):
+            c10d.all_reduce(t, op=c10d.ReduceOp.PRODUCT)
+
+    def test_noncontiguous_rejects(self):
+        # TCCL requires contiguous tensors; a non-contiguous view must reject.
+        t = torch.full((64, 64), float(self.rank + 1), device=self.device).t()  # transpose -> non-contiguous
+        self.assertFalse(t.is_contiguous())
+        with self.assertRaises(Exception):
+            c10d.all_reduce(t, op=c10d.ReduceOp.SUM)
+
+    def test_stubbed_collectives_raise(self):
+        # Out-of-scope collectives (reduce/scatter — not on the DDP/TP/FSDP/PP/MoE
+        # path) must raise a clean NotImplemented-style error, not crash. The stubs
+        # raise at dispatch before any communication, so every rank calling them
+        # symmetrically is safe.
+        t = torch.ones(8, device=self.device)
+        with self.assertRaises(Exception):
+            c10d.reduce(t, dst=0, op=c10d.ReduceOp.SUM)
+        with self.assertRaises(Exception):
+            c10d.scatter(t, scatter_list=None, src=0)
+
+    # ---- ring topology: the two mesh-only capabilities must reject cleanly -----
+    # These run only when the launcher brought the group up as a ring (sparse
+    # cabling). Each reject is a synchronous TORCH_CHECK in the collective's
+    # dispatch (before any RDMA), so every rank raises symmetrically -> no
+    # rendezvous, no deadlock, and tearDown's barrier still lines the ranks up.
+    def test_ring_uneven_alltoall_rejects(self):
+        if not _ring_topology():
+            self.skipTest("ring-only: uneven alltoall is valid on a mesh")
+        ws, r, dev = self.world_size, self.rank, self.device
+        if ws <= 2:
+            self.skipTest("ring uneven-alltoall reject needs world_size > 2")
+        in_splits = [j + 1 for j in range(ws)]
+        out_splits = [r + 1 for _ in range(ws)]
+        inp = torch.full((sum(in_splits),), float(r + 1), dtype=torch.float32, device=dev)
+        out = torch.empty(sum(out_splits), dtype=torch.float32, device=dev)
+        with self.assertRaises(Exception):
+            c10d.all_to_all_single(out, inp, out_splits, in_splits)
+
+    def test_ring_nonneighbor_send_rejects(self):
+        if not _ring_topology():
+            self.skipTest("ring-only: non-neighbor send is valid on a mesh")
+        ws, r, dev = self.world_size, self.rank, self.device
+        if ws < 4:
+            self.skipTest("a non-neighbor only exists at world_size >= 4 "
+                          "(ws=3 ring is a fully-connected triangle)")
+        dst = (r + 2) % ws  # two hops away -> never a ring neighbor for ws >= 4
+        with self.assertRaises(Exception):
+            c10d.send(torch.ones(64, device=dev), dst=dst)
+
+    def test_ring_nonneighbor_recv_rejects(self):
+        if not _ring_topology():
+            self.skipTest("ring-only: non-neighbor recv is valid on a mesh")
+        ws, r, dev = self.world_size, self.rank, self.device
+        if ws < 4:
+            self.skipTest("a non-neighbor only exists at world_size >= 4 "
+                          "(ws=3 ring is a fully-connected triangle)")
+        src = (r + 2) % ws
+        with self.assertRaises(Exception):
+            c10d.recv(torch.empty(64, device=dev), src=src)
+
+
+instantiate_parametrized_tests(ProcessGroupTcclCorrectnessTest)
+instantiate_parametrized_tests(ProcessGroupTcclIntegrationTest)
+
+if __name__ == "__main__":
+    # The TCCL multi-node launcher appends --rank/--world-size/--master-addr/--port
+    # for the legacy script convention; this suite reads them from the environment
+    # instead (RANK/WORLD_SIZE/MASTER_ADDR/MASTER_PORT). Strip them so run_tests()'s
+    # own argparse doesn't reject them.
+    _strip = {"--rank", "--world-size", "--master-addr", "--port"}
+    _argv, _it = [], iter(sys.argv[1:])
+    for _a in _it:
+        if _a in _strip:
+            next(_it, None)  # also drop its value
+            continue
+        _argv.append(_a)
+    sys.argv = [sys.argv[0]] + _argv
+    run_tests()

--- a/test/distributed/test_c10d_tccl.py
+++ b/test/distributed/test_c10d_tccl.py
@@ -305,6 +305,103 @@ class ProcessGroupTcclCorrectnessTest(TcclTestBase):
     def test_barrier(self):
         c10d.barrier()  # no data; should not raise
 
+    # ---- reduce (rooted reduction) --------------------------------------------
+    # Reduce lands on every rank (all-reduce), but only the root is guaranteed -
+    # assert there. fill -> SUM = ws(ws+1)/2, MAX = ws.
+    @parametrize("dtype", [torch.float32, torch.bfloat16, torch.int64, torch.bool])
+    @parametrize("op", ["SUM", "MAX"])
+    def test_reduce_to_root(self, dtype, op):
+        root = self.world_size - 1
+        t = self._full(dtype)
+        c10d.reduce(t, dst=root, op=getattr(c10d.ReduceOp, op))
+        if self.rank == root:
+            if dtype == torch.bool:
+                # SUM/MAX = OR -> True
+                self._assert(t, True, dtype)
+            else:
+                ws = self.world_size
+                self._assert(t, ws * (ws + 1) // 2 if op == "SUM" else ws, dtype)
+
+    @parametrize("dtype", FLOAT_DTYPES)
+    def test_reduce_avg(self, dtype):
+        t = self._full(dtype)
+        c10d.reduce(t, dst=0, op=c10d.ReduceOp.AVG)
+        if self.rank == 0:
+            self._assert(t, (self.world_size + 1) / 2.0, dtype)
+
+    @parametrize("dtype", [torch.float32, torch.int64])
+    def test_reduce_product(self, dtype):
+        root = self.world_size - 1
+        t = self._full(dtype)
+        c10d.reduce(t, dst=root, op=c10d.ReduceOp.PRODUCT)
+        if self.rank == root:
+            expected = 1
+            for k in range(1, self.world_size + 1):
+                expected *= k
+            self._assert(t, expected, dtype)
+
+    # ---- gather (root collects every rank's tensor) ---------------------------
+    # Byte-copy -> any dtype. Root slot k == fill(k). Mesh-only; ring rejects it.
+    @parametrize("dtype", [torch.float32, torch.bfloat16, torch.int64, torch.complex64])
+    def test_gather(self, dtype):
+        if _ring_topology():
+            self.skipTest("gather is mesh-only; ring rejects it "
+                          "(see ProcessGroupTcclContractTest)")
+        ws, r, dev, n = self.world_size, self.rank, self.device, 1024
+        inp = self._full(dtype, n=n)
+        if r == 0:
+            out = [torch.empty(n, dtype=dtype, device=dev) for _ in range(ws)]
+            c10d.gather(inp, gather_list=out, dst=0)
+            for k in range(ws):
+                exp = torch.full((n,), _fill_value(k, dtype), dtype=dtype, device=dev)
+                self.assertEqual(out[k], exp, **_tol(dtype))
+        else:
+            c10d.gather(inp, gather_list=None, dst=0)
+
+    def test_gather_nonzero_root(self):
+        if _ring_topology():
+            self.skipTest("gather is mesh-only; ring rejects it")
+        ws, r, dev, n = self.world_size, self.rank, self.device, 1024
+        root = ws - 1
+        inp = self._full(torch.float32, n=n)
+        if r == root:
+            out = [torch.empty(n, dtype=torch.float32, device=dev) for _ in range(ws)]
+            c10d.gather(inp, gather_list=out, dst=root)
+            for k in range(ws):
+                self.assertEqual(out[k], torch.full((n,), float(k + 1), device=dev))
+        else:
+            c10d.gather(inp, gather_list=None, dst=root)
+
+    # ---- scatter (root distributes a per-rank slice) --------------------------
+    @parametrize("dtype", [torch.float32, torch.bfloat16, torch.int64, torch.complex64])
+    def test_scatter(self, dtype):
+        if _ring_topology():
+            self.skipTest("scatter is mesh-only; ring rejects it "
+                          "(see ProcessGroupTcclContractTest)")
+        ws, r, dev, n = self.world_size, self.rank, self.device, 1024
+        out = torch.empty(n, dtype=dtype, device=dev)
+        if r == 0:
+            sl = [torch.full((n,), _fill_value(k, dtype), dtype=dtype, device=dev)
+                  for k in range(ws)]
+            c10d.scatter(out, scatter_list=sl, src=0)
+        else:
+            c10d.scatter(out, scatter_list=None, src=0)
+        self._assert(out, _fill_value(r, dtype), dtype)
+
+    def test_scatter_nonzero_root(self):
+        if _ring_topology():
+            self.skipTest("scatter is mesh-only; ring rejects it")
+        ws, r, dev, n = self.world_size, self.rank, self.device, 1024
+        root = ws - 1
+        out = torch.empty(n, dtype=torch.float32, device=dev)
+        if r == root:
+            sl = [torch.full((n,), float(k + 1), dtype=torch.float32, device=dev)
+                  for k in range(ws)]
+            c10d.scatter(out, scatter_list=sl, src=root)
+        else:
+            c10d.scatter(out, scatter_list=None, src=root)
+        self.assertEqual(out, torch.full((n,), float(r + 1), device=dev))
+
     # ---- reduce_scatter, tensor form (FSDP reduce_scatter_tensor ->
     #      _reduce_scatter_base). Forces BOTH ring and mesh; world_size <= 2 makes
     #      ring fall back to mesh (still correct). Same fill -> same expected value
@@ -529,13 +626,85 @@ class ProcessGroupTcclCorrectnessTest(TcclTestBase):
                              torch.full((1024,), float(r + 1), device=self.device))
 
     # ---- large allreduce: crosses the 512 KB mesh chunk boundary + (ws>2) the ring
-    #      auto-switch (fp32 >=8 MB). Tiny dtype-matrix cells never reach either. -----
+    #      auto-switch (fp32 >=1 MB). Tiny dtype-matrix cells never reach either. -----
     def test_allreduce_large_fp32(self):
         n = 3 * 1024 * 1024  # 12 MB fp32 -> ring at ws>2, many 512 KB chunks
         t = torch.full((n,), float(self.rank + 1), dtype=torch.float32, device=self.device)
         c10d.all_reduce(t, op=c10d.ReduceOp.SUM)
         ws = self.world_size
         self.assertEqual(t, torch.full((n,), float(ws * (ws + 1) // 2), device=self.device))
+
+    # ---- ragged / chunk-boundary sizes on the RING path ----
+    # N full 512 KB chunks + a 1-elem ODD tail: exercises the double-ring A/B
+    # half-split and the ragged last chunk. Ring is FORCED (ws<=2 falls back to
+    # mesh, still correct). fill = rank+1 -> SUM = ws(ws+1)/2, MAX = ws.
+    # 128*1024 fp32 elems = one 512 KB chunk.
+    @parametrize("dtype", [torch.float32, torch.bfloat16])
+    def test_allreduce_ring_ragged(self, dtype):
+        # bf16 also drives the native __bf16 reduce.
+        with _force_algo("ring"):
+            n = 6 * 128 * 1024 + 1
+            t = torch.full((n,), float(self.rank + 1), dtype=dtype, device=self.device)
+            c10d.all_reduce(t, op=c10d.ReduceOp.SUM)
+            self._assert(t, self.world_size * (self.world_size + 1) // 2, dtype)
+
+    def test_allreduce_ring_chunk_plus_one(self):
+        # Exactly one full 512 KB chunk + a 1-element second chunk: the depth-2
+        # pipeline must fill/drain a piece far smaller than kChunkSize.
+        with _force_algo("ring"):
+            n = 128 * 1024 + 1
+            t = torch.full((n,), float(self.rank + 1), dtype=torch.float32, device=self.device)
+            c10d.all_reduce(t, op=c10d.ReduceOp.SUM)
+            ws = self.world_size
+            self.assertEqual(t, torch.full((n,), float(ws * (ws + 1) // 2), device=self.device))
+
+    @parametrize("op", ["SUM", "MAX"])
+    def test_reduce_scatter_ring_ragged(self, op):
+        # bidir ring_reduce_scatter with an odd, non-chunk-aligned per-rank chunk.
+        with _force_algo("ring"):
+            ws = self.world_size
+            n = 3 * 128 * 1024 + 1
+            inp = torch.full((n * ws,), float(self.rank + 1), dtype=torch.float32, device=self.device)
+            out = torch.empty(n, dtype=torch.float32, device=self.device)
+            c10d.reduce_scatter_tensor(out, inp, op=getattr(c10d.ReduceOp, op))
+            want = ws * (ws + 1) // 2 if op == "SUM" else ws
+            self.assertEqual(out, torch.full((n,), float(want), device=self.device))
+
+    def test_allgather_ring_ragged(self):
+        # bidir ring_all_gather with an odd, non-chunk-aligned per-rank shard.
+        with _force_algo("ring"):
+            ws = self.world_size
+            n = 3 * 128 * 1024 + 1
+            inp = torch.full((n,), float(self.rank + 1), dtype=torch.float32, device=self.device)
+            out = torch.empty(n * ws, dtype=torch.float32, device=self.device)
+            c10d.all_gather_into_tensor(out, inp)
+            for r in range(ws):
+                self.assertEqual(out[r * n:(r + 1) * n],
+                                 torch.full((n,), float(r + 1), device=self.device))
+
+    def test_send_recv_ragged_multichunk(self):
+        # depth-2 pipelined p2p over an odd, non-chunk-aligned payload (rank 0 -> 1).
+        ws, r, dev = self.world_size, self.rank, self.device
+        if ws < 2:
+            self.skipTest("send/recv needs world_size >= 2")
+        n = 3 * 128 * 1024 + 1
+        if r == 0:
+            c10d.send(torch.full((n,), 3.0, dtype=torch.float32, device=dev), dst=1)
+        elif r == 1:
+            t = torch.empty(n, dtype=torch.float32, device=dev)
+            c10d.recv(t, src=0)
+            self.assertEqual(t, torch.full((n,), 3.0, device=dev))
+
+    def test_ring_mesh_agree_ragged(self):
+        # Cross-check: ragged all_reduce under ring and mesh must agree and equal
+        # the analytic SUM - guards the bidir-ring result against the mesh path.
+        ws, n = self.world_size, 3 * 128 * 1024 + 1
+        exp = torch.full((n,), float(ws * (ws + 1) // 2), device=self.device)
+        for algo in ("ring", "mesh"):
+            with _force_algo(algo):
+                t = torch.full((n,), float(self.rank + 1), dtype=torch.float32, device=self.device)
+                c10d.all_reduce(t, op=c10d.ReduceOp.SUM)
+                self.assertEqual(t, exp, msg=f"algo={algo}")
 
     # ---- TCCL_FORCE_ALGO knob: both ring and mesh produce correct results ------
     # (correctness holds regardless of the algo actually chosen; at ws<=2 ring
@@ -668,21 +837,15 @@ class ProcessGroupTcclContractTest(TcclTestBase):
             c10d.all_reduce(t, op=c10d.ReduceOp.SUM)
 
     def test_stubbed_collectives_raise(self):
-        # Out-of-scope collectives (reduce/scatter — not on the DDP/TP/FSDP/PP/MoE
-        # path) must raise a clean NotImplemented-style error, not crash. The stubs
-        # raise at dispatch before any communication, so every rank calling them
-        # symmetrically is safe.
+        # allreduce_coalesced is unimplemented and must raise a clean error at
+        # dispatch, not crash. Every rank raises symmetrically.
         t = torch.ones(8, device=self.device)
         with self.assertRaises(Exception):
-            c10d.reduce(t, dst=0, op=c10d.ReduceOp.SUM)
-        with self.assertRaises(Exception):
-            c10d.scatter(t, scatter_list=None, src=0)
+            c10d.all_reduce_coalesced([t], op=c10d.ReduceOp.SUM)
 
     # ---- ring topology: the two mesh-only capabilities must reject cleanly -----
-    # These run only when the launcher brought the group up as a ring (sparse
-    # cabling). Each reject is a synchronous TORCH_CHECK in the collective's
-    # dispatch (before any RDMA), so every rank raises symmetrically -> no
-    # rendezvous, no deadlock, and tearDown's barrier still lines the ranks up.
+    # Only when the group came up as a ring. Each reject is a synchronous
+    # TORCH_CHECK at dispatch (before any RDMA), so every rank raises symmetrically.
     def test_ring_uneven_alltoall_rejects(self):
         if not _ring_topology():
             self.skipTest("ring-only: uneven alltoall is valid on a mesh")
@@ -717,6 +880,30 @@ class ProcessGroupTcclContractTest(TcclTestBase):
         src = (r + 2) % ws
         with self.assertRaises(Exception):
             c10d.recv(torch.empty(64, device=dev), src=src)
+
+    # gather / scatter are mesh-only; a ring rejects them synchronously at dispatch.
+    def test_ring_gather_rejects(self):
+        if not _ring_topology():
+            self.skipTest("ring-only: gather is valid on a mesh")
+        ws, r, dev, n = self.world_size, self.rank, self.device, 256
+        inp = torch.full((n,), float(r + 1), device=dev)
+        with self.assertRaises(Exception):
+            if r == 0:
+                c10d.gather(inp, gather_list=[torch.empty(n, device=dev) for _ in range(ws)], dst=0)
+            else:
+                c10d.gather(inp, gather_list=None, dst=0)
+
+    def test_ring_scatter_rejects(self):
+        if not _ring_topology():
+            self.skipTest("ring-only: scatter is valid on a mesh")
+        ws, r, dev, n = self.world_size, self.rank, self.device, 256
+        out = torch.empty(n, device=dev)
+        with self.assertRaises(Exception):
+            if r == 0:
+                c10d.scatter(out, scatter_list=[torch.full((n,), float(k + 1), device=dev)
+                                                for k in range(ws)], src=0)
+            else:
+                c10d.scatter(out, scatter_list=None, src=0)
 
 
 instantiate_parametrized_tests(ProcessGroupTcclCorrectnessTest)

--- a/torch/csrc/distributed/c10d/Ops.cpp
+++ b/torch/csrc/distributed/c10d/Ops.cpp
@@ -92,6 +92,7 @@ namespace {
 IMPL_SEND(CPU)
 IMPL_SEND(CUDA)
 IMPL_SEND(PrivateUse1)
+IMPL_SEND(MPS)
 
 #define IMPL_RECV(DEV)                                                         \
   c10::intrusive_ptr<Work> recv_##DEV(                                         \
@@ -118,6 +119,7 @@ IMPL_SEND(PrivateUse1)
 IMPL_RECV(CPU)
 IMPL_RECV(CUDA)
 IMPL_RECV(PrivateUse1)
+IMPL_RECV(MPS)
 
 #define IMPL_RECV_ANY_SOURCE(DEV)                                       \
   c10::intrusive_ptr<Work> recv_any_source_##DEV(                       \
@@ -141,6 +143,7 @@ IMPL_RECV(PrivateUse1)
 IMPL_RECV_ANY_SOURCE(CPU)
 IMPL_RECV_ANY_SOURCE(CUDA)
 IMPL_RECV_ANY_SOURCE(PrivateUse1)
+IMPL_RECV_ANY_SOURCE(MPS)
 
 #define IMPL_REDUCE(DEV)                                        \
   c10::intrusive_ptr<Work> reduce_##DEV(                        \
@@ -171,6 +174,7 @@ IMPL_RECV_ANY_SOURCE(PrivateUse1)
 IMPL_REDUCE(CPU)
 IMPL_REDUCE(CUDA)
 IMPL_REDUCE(PrivateUse1)
+IMPL_REDUCE(MPS)
 
 #define IMPL_BROADCAST(DEV)                                               \
   std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>>           \
@@ -201,6 +205,7 @@ IMPL_REDUCE(PrivateUse1)
 IMPL_BROADCAST(CPU)
 IMPL_BROADCAST(CUDA)
 IMPL_BROADCAST(PrivateUse1)
+IMPL_BROADCAST(MPS)
 
 // Return input tensors as output tensors to make inplace allreduce look like
 // a functional API, so that make_fx can correctly build the dependencies in
@@ -233,6 +238,7 @@ IMPL_BROADCAST(PrivateUse1)
 IMPL_ALLREDUCE(CPU)
 IMPL_ALLREDUCE(CUDA)
 IMPL_ALLREDUCE(PrivateUse1)
+IMPL_ALLREDUCE(MPS)
 
 #define IMPL_ALLREDUCE_COALESCED(DEV)                             \
   c10::intrusive_ptr<Work> allreduce_coalesced_##DEV(             \
@@ -258,6 +264,7 @@ IMPL_ALLREDUCE(PrivateUse1)
 IMPL_ALLREDUCE_COALESCED(CPU)
 IMPL_ALLREDUCE_COALESCED(CUDA)
 IMPL_ALLREDUCE_COALESCED(PrivateUse1)
+IMPL_ALLREDUCE_COALESCED(MPS)
 
 // Copy output tensors (not storage) so that this can be used in a functional
 // manner
@@ -294,6 +301,7 @@ IMPL_ALLREDUCE_COALESCED(PrivateUse1)
 IMPL_ALLGATHER(CPU)
 IMPL_ALLGATHER(CUDA)
 IMPL_ALLGATHER(PrivateUse1)
+IMPL_ALLGATHER(MPS)
 
 #define IMPL__ALLGATHER_BASE(DEV)                                          \
   std::tuple<at::Tensor, c10::intrusive_ptr<Work>> _allgather_base_##DEV(  \
@@ -319,6 +327,7 @@ IMPL_ALLGATHER(PrivateUse1)
 IMPL__ALLGATHER_BASE(CPU)
 IMPL__ALLGATHER_BASE(CUDA)
 IMPL__ALLGATHER_BASE(PrivateUse1)
+IMPL__ALLGATHER_BASE(MPS)
 
 #define IMPL_ALLGATHER_COALESCED(DEV)                                      \
   c10::intrusive_ptr<Work> allgather_coalesced_##DEV(                      \
@@ -345,6 +354,7 @@ IMPL__ALLGATHER_BASE(PrivateUse1)
 IMPL_ALLGATHER_COALESCED(CPU)
 IMPL_ALLGATHER_COALESCED(CUDA)
 IMPL_ALLGATHER_COALESCED(PrivateUse1)
+IMPL_ALLGATHER_COALESCED(MPS)
 
 #define IMPL_ALLGATHER_INTO_TENSOR_COALESCED(DEV)                       \
   c10::intrusive_ptr<c10d::Work> allgather_into_tensor_coalesced_##DEV( \
@@ -369,6 +379,7 @@ IMPL_ALLGATHER_COALESCED(PrivateUse1)
 IMPL_ALLGATHER_INTO_TENSOR_COALESCED(CPU)
 IMPL_ALLGATHER_INTO_TENSOR_COALESCED(CUDA)
 IMPL_ALLGATHER_INTO_TENSOR_COALESCED(PrivateUse1)
+IMPL_ALLGATHER_INTO_TENSOR_COALESCED(MPS)
 
 #define IMPL_REDUCE_SCATTER(DEV)                                           \
   std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>>            \
@@ -404,6 +415,7 @@ IMPL_ALLGATHER_INTO_TENSOR_COALESCED(PrivateUse1)
 IMPL_REDUCE_SCATTER(CPU)
 IMPL_REDUCE_SCATTER(CUDA)
 IMPL_REDUCE_SCATTER(PrivateUse1)
+IMPL_REDUCE_SCATTER(MPS)
 
 #define IMPL__REDUCE_SCATTER_BASE(DEV)                                         \
   std::tuple<at::Tensor, c10::intrusive_ptr<Work>> _reduce_scatter_base_##DEV( \
@@ -432,6 +444,7 @@ IMPL_REDUCE_SCATTER(PrivateUse1)
 IMPL__REDUCE_SCATTER_BASE(CPU)
 IMPL__REDUCE_SCATTER_BASE(CUDA)
 IMPL__REDUCE_SCATTER_BASE(PrivateUse1)
+IMPL__REDUCE_SCATTER_BASE(MPS)
 
 #define IMPL_REDUCE_SCATTER_TENSOR_COALESCED(DEV)                        \
   c10::intrusive_ptr<c10d::Work> reduce_scatter_tensor_coalesced_##DEV(  \
@@ -461,6 +474,7 @@ IMPL__REDUCE_SCATTER_BASE(PrivateUse1)
 IMPL_REDUCE_SCATTER_TENSOR_COALESCED(CPU)
 IMPL_REDUCE_SCATTER_TENSOR_COALESCED(CUDA)
 IMPL_REDUCE_SCATTER_TENSOR_COALESCED(PrivateUse1)
+IMPL_REDUCE_SCATTER_TENSOR_COALESCED(MPS)
 
 #define IMPL_GATHER(DEV)                                                      \
   c10::intrusive_ptr<Work> gather_##DEV(                                      \
@@ -493,6 +507,7 @@ IMPL_REDUCE_SCATTER_TENSOR_COALESCED(PrivateUse1)
 IMPL_GATHER(CPU)
 IMPL_GATHER(CUDA)
 IMPL_GATHER(PrivateUse1)
+IMPL_GATHER(MPS)
 
 #define IMPL_SCATTER(DEV)                                                      \
   std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>> scatter_##DEV( \
@@ -526,6 +541,7 @@ IMPL_GATHER(PrivateUse1)
 IMPL_SCATTER(CPU)
 IMPL_SCATTER(CUDA)
 IMPL_SCATTER(PrivateUse1)
+IMPL_SCATTER(MPS)
 
 #define IMPL_ALLTOALL(DEV)                                                     \
   std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>>                \
@@ -558,6 +574,7 @@ IMPL_SCATTER(PrivateUse1)
 IMPL_ALLTOALL(CPU)
 IMPL_ALLTOALL(CUDA)
 IMPL_ALLTOALL(PrivateUse1)
+IMPL_ALLTOALL(MPS)
 
 #define IMPL_ALLTOALL_BASE(DEV)                                                \
   c10::intrusive_ptr<Work> alltoall_base_##DEV(                                \
@@ -586,6 +603,7 @@ IMPL_ALLTOALL(PrivateUse1)
 IMPL_ALLTOALL_BASE(CPU)
 IMPL_ALLTOALL_BASE(CUDA)
 IMPL_ALLTOALL_BASE(PrivateUse1)
+IMPL_ALLTOALL_BASE(MPS)
 
 // NOLINTBEGIN(performance-unnecessary-value-param)
 #define IMPL_BARRIER(DEV)                                               \
@@ -611,6 +629,7 @@ IMPL_ALLTOALL_BASE(PrivateUse1)
 IMPL_BARRIER(CPU)
 IMPL_BARRIER(CUDA)
 IMPL_BARRIER(PrivateUse1)
+IMPL_BARRIER(MPS)
 // NOLINTEND(performance-unnecessary-value-param)
 // NOLINTEND(cppcoreguidelines-pro-type-const-cast)
 
@@ -670,7 +689,8 @@ namespace {
 #define REGISTER_C10D_OP(FUNC)  \
   REGISTER_C10D_OP1(FUNC, CPU)  \
   REGISTER_C10D_OP1(FUNC, CUDA) \
-  REGISTER_C10D_OP1(FUNC, PrivateUse1)
+  REGISTER_C10D_OP1(FUNC, PrivateUse1) \
+  REGISTER_C10D_OP1(FUNC, MPS)
 
 // Now we start to register ops with the three device keys
 

--- a/torch/csrc/distributed/c10d/Ops.cpp
+++ b/torch/csrc/distributed/c10d/Ops.cpp
@@ -94,6 +94,7 @@ namespace {
 IMPL_SEND(CPU)
 IMPL_SEND(CUDA)
 IMPL_SEND(PrivateUse1)
+IMPL_SEND(MPS)
 
 #define IMPL_RECV(DEV)                                                         \
   c10::intrusive_ptr<Work> recv_##DEV(                                         \
@@ -120,6 +121,7 @@ IMPL_SEND(PrivateUse1)
 IMPL_RECV(CPU)
 IMPL_RECV(CUDA)
 IMPL_RECV(PrivateUse1)
+IMPL_RECV(MPS)
 
 #define IMPL_RECV_ANY_SOURCE(DEV)                                       \
   c10::intrusive_ptr<Work> recv_any_source_##DEV(                       \
@@ -143,6 +145,7 @@ IMPL_RECV(PrivateUse1)
 IMPL_RECV_ANY_SOURCE(CPU)
 IMPL_RECV_ANY_SOURCE(CUDA)
 IMPL_RECV_ANY_SOURCE(PrivateUse1)
+IMPL_RECV_ANY_SOURCE(MPS)
 
 #define IMPL_REDUCE(DEV)                                        \
   c10::intrusive_ptr<Work> reduce_##DEV(                        \
@@ -173,6 +176,7 @@ IMPL_RECV_ANY_SOURCE(PrivateUse1)
 IMPL_REDUCE(CPU)
 IMPL_REDUCE(CUDA)
 IMPL_REDUCE(PrivateUse1)
+IMPL_REDUCE(MPS)
 
 #define IMPL_BROADCAST(DEV)                                               \
   std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>>           \
@@ -203,6 +207,7 @@ IMPL_REDUCE(PrivateUse1)
 IMPL_BROADCAST(CPU)
 IMPL_BROADCAST(CUDA)
 IMPL_BROADCAST(PrivateUse1)
+IMPL_BROADCAST(MPS)
 
 // Return input tensors as output tensors to make inplace allreduce look like
 // a functional API, so that make_fx can correctly build the dependencies in
@@ -235,6 +240,7 @@ IMPL_BROADCAST(PrivateUse1)
 IMPL_ALLREDUCE(CPU)
 IMPL_ALLREDUCE(CUDA)
 IMPL_ALLREDUCE(PrivateUse1)
+IMPL_ALLREDUCE(MPS)
 
 #define IMPL_ALLREDUCE_COALESCED(DEV)                                \
   c10::intrusive_ptr<Work> allreduce_coalesced_##DEV(                \
@@ -260,6 +266,7 @@ IMPL_ALLREDUCE(PrivateUse1)
 IMPL_ALLREDUCE_COALESCED(CPU)
 IMPL_ALLREDUCE_COALESCED(CUDA)
 IMPL_ALLREDUCE_COALESCED(PrivateUse1)
+IMPL_ALLREDUCE_COALESCED(MPS)
 
 // Copy output tensors (not storage) so that this can be used in a functional
 // manner
@@ -296,6 +303,7 @@ IMPL_ALLREDUCE_COALESCED(PrivateUse1)
 IMPL_ALLGATHER(CPU)
 IMPL_ALLGATHER(CUDA)
 IMPL_ALLGATHER(PrivateUse1)
+IMPL_ALLGATHER(MPS)
 
 #define IMPL__ALLGATHER_BASE(DEV)                                              \
   std::tuple<at::Tensor, c10::intrusive_ptr<Work>> _allgather_base_##DEV(      \
@@ -321,6 +329,7 @@ IMPL_ALLGATHER(PrivateUse1)
 IMPL__ALLGATHER_BASE(CPU)
 IMPL__ALLGATHER_BASE(CUDA)
 IMPL__ALLGATHER_BASE(PrivateUse1)
+IMPL__ALLGATHER_BASE(MPS)
 
 #define IMPL_ALLGATHER_COALESCED(DEV)                                      \
   c10::intrusive_ptr<Work> allgather_coalesced_##DEV(                      \
@@ -351,6 +360,7 @@ IMPL__ALLGATHER_BASE(PrivateUse1)
 IMPL_ALLGATHER_COALESCED(CPU)
 IMPL_ALLGATHER_COALESCED(CUDA)
 IMPL_ALLGATHER_COALESCED(PrivateUse1)
+IMPL_ALLGATHER_COALESCED(MPS)
 
 #define IMPL_ALLGATHER_INTO_TENSOR_COALESCED(DEV)                       \
   c10::intrusive_ptr<c10d::Work> allgather_into_tensor_coalesced_##DEV( \
@@ -382,6 +392,7 @@ IMPL_ALLGATHER_COALESCED(PrivateUse1)
 IMPL_ALLGATHER_INTO_TENSOR_COALESCED(CPU)
 IMPL_ALLGATHER_INTO_TENSOR_COALESCED(CUDA)
 IMPL_ALLGATHER_INTO_TENSOR_COALESCED(PrivateUse1)
+IMPL_ALLGATHER_INTO_TENSOR_COALESCED(MPS)
 
 #define IMPL_REDUCE_SCATTER(DEV)                                           \
   std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>>            \
@@ -417,6 +428,7 @@ IMPL_ALLGATHER_INTO_TENSOR_COALESCED(PrivateUse1)
 IMPL_REDUCE_SCATTER(CPU)
 IMPL_REDUCE_SCATTER(CUDA)
 IMPL_REDUCE_SCATTER(PrivateUse1)
+IMPL_REDUCE_SCATTER(MPS)
 
 #define IMPL__REDUCE_SCATTER_BASE(DEV)                                         \
   std::tuple<at::Tensor, c10::intrusive_ptr<Work>> _reduce_scatter_base_##DEV( \
@@ -449,6 +461,7 @@ IMPL_REDUCE_SCATTER(PrivateUse1)
 IMPL__REDUCE_SCATTER_BASE(CPU)
 IMPL__REDUCE_SCATTER_BASE(CUDA)
 IMPL__REDUCE_SCATTER_BASE(PrivateUse1)
+IMPL__REDUCE_SCATTER_BASE(MPS)
 
 #define IMPL_REDUCE_SCATTER_TENSOR_COALESCED(DEV)                       \
   c10::intrusive_ptr<c10d::Work> reduce_scatter_tensor_coalesced_##DEV( \
@@ -485,6 +498,7 @@ IMPL__REDUCE_SCATTER_BASE(PrivateUse1)
 IMPL_REDUCE_SCATTER_TENSOR_COALESCED(CPU)
 IMPL_REDUCE_SCATTER_TENSOR_COALESCED(CUDA)
 IMPL_REDUCE_SCATTER_TENSOR_COALESCED(PrivateUse1)
+IMPL_REDUCE_SCATTER_TENSOR_COALESCED(MPS)
 
 #define IMPL_GATHER(DEV)                                                      \
   c10::intrusive_ptr<Work> gather_##DEV(                                      \
@@ -517,6 +531,7 @@ IMPL_REDUCE_SCATTER_TENSOR_COALESCED(PrivateUse1)
 IMPL_GATHER(CPU)
 IMPL_GATHER(CUDA)
 IMPL_GATHER(PrivateUse1)
+IMPL_GATHER(MPS)
 
 #define IMPL_GATHER_INTO_TENSOR(DEV)                                          \
   std::tuple<at::Tensor, c10::intrusive_ptr<Work>> gather_into_tensor_##DEV(  \
@@ -577,6 +592,7 @@ IMPL_GATHER_INTO_TENSOR(PrivateUse1)
 IMPL_SCATTER(CPU)
 IMPL_SCATTER(CUDA)
 IMPL_SCATTER(PrivateUse1)
+IMPL_SCATTER(MPS)
 
 #define IMPL_ALLTOALL(DEV)                                                     \
   std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>>                \
@@ -609,6 +625,7 @@ IMPL_SCATTER(PrivateUse1)
 IMPL_ALLTOALL(CPU)
 IMPL_ALLTOALL(CUDA)
 IMPL_ALLTOALL(PrivateUse1)
+IMPL_ALLTOALL(MPS)
 
 #define IMPL_ALLTOALL_BASE(DEV)                                                \
   c10::intrusive_ptr<Work> alltoall_base_##DEV(                                \
@@ -637,6 +654,7 @@ IMPL_ALLTOALL(PrivateUse1)
 IMPL_ALLTOALL_BASE(CPU)
 IMPL_ALLTOALL_BASE(CUDA)
 IMPL_ALLTOALL_BASE(PrivateUse1)
+IMPL_ALLTOALL_BASE(MPS)
 
 // NOLINTBEGIN(performance-unnecessary-value-param)
 #define IMPL_BARRIER(DEV)                                               \
@@ -662,6 +680,7 @@ IMPL_ALLTOALL_BASE(PrivateUse1)
 IMPL_BARRIER(CPU)
 IMPL_BARRIER(CUDA)
 IMPL_BARRIER(PrivateUse1)
+IMPL_BARRIER(MPS)
 // NOLINTEND(performance-unnecessary-value-param)
 // NOLINTEND(cppcoreguidelines-pro-type-const-cast)
 
@@ -721,7 +740,8 @@ namespace {
 #define REGISTER_C10D_OP(FUNC)  \
   REGISTER_C10D_OP1(FUNC, CPU)  \
   REGISTER_C10D_OP1(FUNC, CUDA) \
-  REGISTER_C10D_OP1(FUNC, PrivateUse1)
+  REGISTER_C10D_OP1(FUNC, PrivateUse1) \
+  REGISTER_C10D_OP1(FUNC, MPS)
 
 // Now we start to register ops with the three device keys
 

--- a/torch/csrc/distributed/c10d/ProcessGroupTCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupTCCL.cpp
@@ -43,7 +43,8 @@ namespace {
 at::Tensor mpsSharedCpuView(const at::Tensor& mpsTensor) {
   auto* allocator = at::mps::getIMPSAllocator();
   const void* storage_ptr = mpsTensor.storage().data_ptr().get();
-  auto [cpu_ptr, retain_count] = allocator->getSharedBufferPtr(storage_ptr);
+  // Pair is {cpu_ptr, retain_count}; only the pointer is used here.
+  const void* cpu_ptr = allocator->getSharedBufferPtr(storage_ptr).first;
   TORCH_INTERNAL_ASSERT(
       cpu_ptr != nullptr,
       "MPS tensor does not have a shared (unified memory) backing buffer. ",
@@ -320,10 +321,14 @@ ProcessGroupTCCL::Options::Options(std::chrono::milliseconds timeout)
 ProcessGroupTCCL::TCCLWork::TCCLWork(
     OpType opType, uint64_t seq, std::vector<at::Tensor> outputs)
     : Work(/*rank=*/-1, opType), seq_(seq), outputs_(std::move(outputs)) {
-  // Build the result Future (mirrors ProcessGroupGloo::createFutureAsOutput):
-  // carries a List[Tensor]; its device list is the outputs' non-CPU devices so
-  // device-aware consumers (DDP's reducer) chain correctly.
-
+  // Build the result Future carrying a List[Tensor]. Intentionally NO device
+  // list (unlike ProcessGroupGloo::createFutureAsOutput): a Future's device
+  // list only exists to order the callback against pending async GPU work on
+  // those devices' streams. Here there is nothing to order -- MPS is
+  // single-queue and the collective runs to completion on a CPU worker thread,
+  // so when the Future fires the data is already in place. DDP's reducer still
+  // chains correctly. A device list added ~140 us/op of pure overhead that
+  // synchronizes nothing, so we omit it.
   future_ = c10::make_intrusive<c10::ivalue::Future>(
       c10::ListType::create(c10::TensorType::get()));
 }

--- a/torch/csrc/distributed/c10d/ProcessGroupTCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupTCCL.cpp
@@ -1,0 +1,1318 @@
+#ifdef USE_C10D_TCCL
+
+#include <torch/csrc/distributed/c10d/ProcessGroupTCCL.hpp>
+#include <torch/csrc/distributed/c10d/ProcessGroupTCCLDetail.hpp>
+#include <torch/csrc/distributed/c10d/TCCLUtils.hpp>
+
+#include <c10/util/Exception.h>
+#include <c10/util/thread_name.h>
+
+#include <ATen/core/jit_type.h>
+#include <ATen/Context.h>
+#include <ATen/mps/MPSAllocatorInterface.h>
+#include <ATen/detail/MPSHooksInterface.h>
+
+#include <cstddef>
+#include <cstdlib>
+#include <cstdint>
+#include <exception>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+#include <vector>
+
+namespace c10d {
+
+namespace {
+
+// MPS staging helpers.
+
+// These let the collective run on a worker thread while the GPU keeps
+// computing: the main thread records a non-blocking MPS event
+// (mpsEventRecord), the worker blocks on it (mpsEventWait) so we neither drain
+// nor block the GPU, then reads/writes the tensor via a zero-copy CPU view
+// (mpsSharedCpuView) over the same unified-memory storage.
+
+// Zero-copy CPU view over an MPS tensor's unified shared memory. With
+// MTLStorageModeShared the allocator exposes a CPU pointer via
+// getSharedBufferPtr; from_blob wraps it as a CPU tensor over the same bytes.
+// Uses the storage base pointer (not data_ptr()) because on MPS data_ptr()
+// folds storage_offset into id<MTLBuffer> arithmetic, yielding an address the
+// allocator can't map; views/chunks (e.g. _allgather_base) have non-zero
+// storage_offset, so a raw data_ptr() lookup would fail there.
+at::Tensor mpsSharedCpuView(const at::Tensor& mpsTensor) {
+  auto* allocator = at::mps::getIMPSAllocator();
+  const void* storage_ptr = mpsTensor.storage().data_ptr().get();
+  auto [cpu_ptr, retain_count] = allocator->getSharedBufferPtr(storage_ptr);
+  TORCH_INTERNAL_ASSERT(
+      cpu_ptr != nullptr,
+      "MPS tensor does not have a shared (unified memory) backing buffer. ",
+      "storage_ptr=",
+      storage_ptr,
+      " data_ptr=",
+      mpsTensor.data_ptr(),
+      " size=",
+      mpsTensor.nbytes(),
+      " storage_offset=",
+      mpsTensor.storage_offset(),
+      " device=",
+      mpsTensor.device());
+  void* offset_ptr = static_cast<char*>(const_cast<void*>(cpu_ptr)) +
+      mpsTensor.storage_offset() * mpsTensor.itemsize();
+  return at::from_blob(
+      offset_ptr,
+      mpsTensor.sizes(),
+      mpsTensor.strides(),
+      at::TensorOptions().dtype(mpsTensor.dtype()).device(at::kCPU));
+}
+
+// Non-blocking: encode a signal into the MPS command buffer and commit via
+// commitAndContinue. Returns an event id the worker can synchronize on. Does
+// NOT drain the GPU or hold the MPS serial queue beyond the encode.
+uint32_t mpsEventRecord() {
+  auto& hooks = at::detail::getMPSHooks();
+  uint32_t eid = hooks.acquireEvent(false);
+  hooks.recordEvent(eid);
+  return eid;
+}
+
+// Block the calling thread until the GPU reaches the signal recorded by
+// mpsEventRecord() (MTLSharedEvent listener + condition_variable). Returns
+// immediately if the GPU already passed it; releases the event to the pool.
+void mpsEventWait(uint32_t eid) {
+  auto& hooks = at::detail::getMPSHooks();
+  hooks.synchronizeEvent(eid);
+  hooks.releaseEvent(eid);
+}
+
+constexpr const char* kNotImplementedHint =
+    "is not implemented for the TCCL backend. Implemented collectives: "
+    "allreduce, broadcast, allgather, _allgather_base, "
+    "allgather_into_tensor_coalesced, reduce_scatter, _reduce_scatter_base, "
+    "reduce_scatter_tensor_coalesced, alltoall_base, send, recv, and barrier "
+    "(reductions: SUM/MIN/MAX/PRODUCT for float32/float16/bfloat16 + "
+    "int8/16/32/64/uint8/bool, AVG float-only; broadcast/allgather/alltoall/send/"
+    "recv are byte-copy, any dtype).";
+
+// SUM-capable reduce dtypes
+inline bool isSupportedReduceDtype(at::ScalarType st) {
+  return st == at::kFloat || st == at::kHalf || st == at::kBFloat16 ||
+      st == at::kChar || st == at::kShort || st == at::kInt ||
+      st == at::kLong || st == at::kByte || st == at::kBool;
+}
+
+// AVG (= SUM then ×1/world_size)
+// AVG is gated to the float dtypes
+inline bool isFloatReduceDtype(at::ScalarType st) {
+  return st == at::kFloat || st == at::kHalf || st == at::kBFloat16;
+}
+
+// Typed mesh allreduce + AVG post-scale. Instantiated for float/Half/BFloat16;
+// Ring-vs-mesh selection for all_reduce (N>2):
+//   bf16       -> ring at ANY size
+//   fp32/fp16  -> ring only >=8MB
+// TCCL_FORCE_ALGO=ring|mesh overrides per-call (mainly benchmarking reasons).
+inline bool tcclUseRing(
+    int worldSize, bool autoEnable, bool isBf16, std::size_t count,
+    std::size_t elemBytes, bool forceRing = false) {
+
+  if (worldSize <= 2) {
+    return false;
+  }
+  if (forceRing) {
+    return true;
+  }
+  // autoEnable: size/dtype threshold and all_reduce
+  // TCCL_FORCE_ALGO, e.g. for reliability or a ring-cabled cluster).
+  bool useRing = autoEnable &&
+      (isBf16 || count * elemBytes >= 8u * 1024u * 1024u);
+  if (const char* f = std::getenv("TCCL_FORCE_ALGO")) {
+    // TCCL_FORCE_ALGO=ring|mesh overrides the auto-heuristic above
+    const std::string forced(f);
+    if (forced == "ring") {
+      useRing = true;
+    } else if (forced == "mesh") {
+      useRing = false;
+    }
+  }
+  return useRing;
+}
+
+// Run an allreduce with a specific reduce-op functor, picking ring vs mesh.
+template <typename T, typename Op>
+void tcclAllreduceWith(
+    TCCLEngine& mesh, T* data, std::size_t count, int worldSize, bool useRing) {
+  if (useRing) {
+    mesh.ring_all_reduce<T, Op>(data, count, Op{});
+  } else {
+    mesh.all_reduce<T, Op>(data, count, Op{});
+  }
+}
+
+// Typed mesh allreduce. `op` selects the reduce op (SUM/MIN/MAX/AVG)
+template <typename T>
+void runMeshAllreduce(
+    TCCLEngine& mesh, at::Tensor& view, ReduceOp::RedOpType op, int worldSize) {
+  T* data = view.data_ptr<T>();
+  const std::size_t count = static_cast<std::size_t>(view.numel());
+  const bool useRing =
+      tcclUseRing(worldSize, /*autoEnable=*/true, std::is_same_v<T, at::BFloat16>, count, sizeof(T), mesh.ringTopology());
+  switch (op) {
+    case ReduceOp::MIN:
+      tcclAllreduceWith<T, TCCLMinOp<T>>(mesh, data, count, worldSize, useRing);
+      break;
+    case ReduceOp::MAX:
+      tcclAllreduceWith<T, TCCLMaxOp<T>>(mesh, data, count, worldSize, useRing);
+      break;
+    case ReduceOp::PRODUCT:
+      tcclAllreduceWith<T, TCCLProdOp<T>>(mesh, data, count, worldSize, useRing);
+      break;
+    default:  // SUM or AVG
+      tcclAllreduceWith<T, TCCLSumOp<T>>(mesh, data, count, worldSize, useRing);
+      break;
+  }
+  if (op == ReduceOp::AVG) {
+    const float inv = 1.0f / static_cast<float>(worldSize);
+    for (std::size_t i = 0; i < count; ++i) {
+      data[i] = static_cast<T>(static_cast<float>(data[i]) * inv);
+    }
+  }
+}
+
+// Typed reduce-scatter core over per-rank input-chunk pointers: in_chunks[p] is
+// this rank's contribution for peer p (count_per_rank elements). Picks
+// ring vs mesh, applies the reduce functor (SUM/MIN/MAX/AVG), and writes
+// count_per_rank elements to `out`.
+template <typename T>
+void runReduceScatterChunks(
+    TCCLEngine& mesh,
+    const std::vector<const T*>& in_chunks,
+    T* out,
+    std::size_t count_per_rank,
+    ReduceOp::RedOpType op,
+    int worldSize) {
+  const bool useRing = tcclUseRing(
+      worldSize, /*autoEnable=*/false, std::is_same_v<T, at::BFloat16>,
+      count_per_rank * static_cast<std::size_t>(worldSize), sizeof(T), mesh.ringTopology());
+  switch (op) {
+    case ReduceOp::MIN:
+      if (useRing)
+        mesh.ring_reduce_scatter<T, TCCLMinOp<T>>(in_chunks, out, count_per_rank, TCCLMinOp<T>{});
+      else
+        mesh.reduce_scatter<T, TCCLMinOp<T>>(in_chunks, out, count_per_rank, TCCLMinOp<T>{});
+      break;
+    case ReduceOp::MAX:
+      if (useRing)
+        mesh.ring_reduce_scatter<T, TCCLMaxOp<T>>(in_chunks, out, count_per_rank, TCCLMaxOp<T>{});
+      else
+        mesh.reduce_scatter<T, TCCLMaxOp<T>>(in_chunks, out, count_per_rank, TCCLMaxOp<T>{});
+      break;
+    case ReduceOp::PRODUCT:
+      if (useRing)
+        mesh.ring_reduce_scatter<T, TCCLProdOp<T>>(in_chunks, out, count_per_rank, TCCLProdOp<T>{});
+      else
+        mesh.reduce_scatter<T, TCCLProdOp<T>>(in_chunks, out, count_per_rank, TCCLProdOp<T>{});
+      break;
+    default:  // SUM or AVG
+      if (useRing)
+        mesh.ring_reduce_scatter<T, TCCLSumOp<T>>(in_chunks, out, count_per_rank, TCCLSumOp<T>{});
+      else
+        mesh.reduce_scatter<T, TCCLSumOp<T>>(in_chunks, out, count_per_rank, TCCLSumOp<T>{});
+      break;
+  }
+  if (op == ReduceOp::AVG) {
+    const float inv = 1.0f / static_cast<float>(worldSize);
+    for (std::size_t k = 0; k < count_per_rank; ++k) {
+      out[k] = static_cast<T>(static_cast<float>(out[k]) * inv);
+    }
+  }
+}
+
+// Contiguous reduce-scatter: `inView` holds worldSize contiguous chunks of
+// count_per_rank elements (chunk p destined for peer p). Builds the per-rank
+// chunk pointers and runs the core.
+template <typename T>
+void runMeshReduceScatter(
+    TCCLEngine& mesh,
+    at::Tensor& inView,
+    at::Tensor& outView,
+    ReduceOp::RedOpType op,
+    int worldSize) {
+  const std::size_t count_per_rank = static_cast<std::size_t>(outView.numel());
+  const T* in = inView.data_ptr<T>();
+  std::vector<const T*> in_chunks(static_cast<std::size_t>(worldSize));
+  for (int r = 0; r < worldSize; ++r) {
+    in_chunks[r] = in + static_cast<std::size_t>(r) * count_per_rank;
+  }
+  runReduceScatterChunks<T>(
+      mesh, in_chunks, outView.data_ptr<T>(), count_per_rank, op, worldSize);
+}
+
+// List-form reduce-scatter: inChunkViews[p] is this rank's CPU view of the
+// contribution destined for peer p.
+template <typename T>
+void runMeshReduceScatterList(
+    TCCLEngine& mesh,
+    std::vector<at::Tensor>& inChunkViews,
+    at::Tensor& outView,
+    ReduceOp::RedOpType op,
+    int worldSize) {
+  const std::size_t count_per_rank = static_cast<std::size_t>(outView.numel());
+  std::vector<const T*> in_chunks(static_cast<std::size_t>(worldSize));
+  for (int r = 0; r < worldSize; ++r) {
+    in_chunks[r] = inChunkViews[r].data_ptr<T>();
+  }
+  runReduceScatterChunks<T>(
+      mesh, in_chunks, outView.data_ptr<T>(), count_per_rank, op, worldSize);
+}
+
+// Runtime-dtype dispatch for contiguous reduce-scatter
+void dispatchReduceScatter(
+    TCCLEngine& mesh,
+    at::Tensor& inView,
+    at::Tensor& outView,
+    ReduceOp::RedOpType op,
+    int worldSize) {
+  switch (inView.scalar_type()) {
+    case at::kFloat: runMeshReduceScatter<float>(mesh, inView, outView, op, worldSize); break;
+    case at::kHalf: runMeshReduceScatter<at::Half>(mesh, inView, outView, op, worldSize); break;
+    case at::kBFloat16: runMeshReduceScatter<at::BFloat16>(mesh, inView, outView, op, worldSize); break;
+    case at::kChar: runMeshReduceScatter<int8_t>(mesh, inView, outView, op, worldSize); break;
+    case at::kShort: runMeshReduceScatter<int16_t>(mesh, inView, outView, op, worldSize); break;
+    case at::kInt: runMeshReduceScatter<int32_t>(mesh, inView, outView, op, worldSize); break;
+    case at::kLong: runMeshReduceScatter<int64_t>(mesh, inView, outView, op, worldSize); break;
+    case at::kByte: runMeshReduceScatter<uint8_t>(mesh, inView, outView, op, worldSize); break;
+    case at::kBool: runMeshReduceScatter<bool>(mesh, inView, outView, op, worldSize); break;
+    default: break;  // unreachable — validated by caller
+  }
+}
+
+// Runtime-dtype dispatch for list-form reduce-scatter (worldSize separate input
+// views, one per destination rank).
+void dispatchReduceScatterList(
+    TCCLEngine& mesh,
+    std::vector<at::Tensor>& inChunkViews,
+    at::Tensor& outView,
+    ReduceOp::RedOpType op,
+    int worldSize) {
+  switch (outView.scalar_type()) {
+    case at::kFloat: runMeshReduceScatterList<float>(mesh, inChunkViews, outView, op, worldSize); break;
+    case at::kHalf: runMeshReduceScatterList<at::Half>(mesh, inChunkViews, outView, op, worldSize); break;
+    case at::kBFloat16: runMeshReduceScatterList<at::BFloat16>(mesh, inChunkViews, outView, op, worldSize); break;
+    case at::kChar: runMeshReduceScatterList<int8_t>(mesh, inChunkViews, outView, op, worldSize); break;
+    case at::kShort: runMeshReduceScatterList<int16_t>(mesh, inChunkViews, outView, op, worldSize); break;
+    case at::kInt: runMeshReduceScatterList<int32_t>(mesh, inChunkViews, outView, op, worldSize); break;
+    case at::kLong: runMeshReduceScatterList<int64_t>(mesh, inChunkViews, outView, op, worldSize); break;
+    case at::kByte: runMeshReduceScatterList<uint8_t>(mesh, inChunkViews, outView, op, worldSize); break;
+    case at::kBool: runMeshReduceScatterList<bool>(mesh, inChunkViews, outView, op, worldSize); break;
+    default: break;  // unreachable — validated by caller
+  }
+}
+} // namespace
+
+// ---- Options --------------------------------------------------------------
+
+ProcessGroupTCCL::Options::Options(std::chrono::milliseconds timeout)
+    : Backend::Options(TCCL_BACKEND_NAME, timeout) {}
+
+// ---- TCCLWork -------------------------------------------------------------
+
+ProcessGroupTCCL::TCCLWork::TCCLWork(
+    OpType opType, uint64_t seq, std::vector<at::Tensor> outputs)
+    : Work(/*rank=*/-1, opType), seq_(seq), outputs_(std::move(outputs)) {
+  // Build the result Future (mirrors ProcessGroupGloo::createFutureAsOutput):
+  // carries a List[Tensor]; its device list is the outputs' non-CPU devices so
+  // device-aware consumers (DDP's reducer) chain correctly.
+
+  future_ = c10::make_intrusive<c10::ivalue::Future>(
+      c10::ListType::create(c10::TensorType::get()));
+}
+
+// ---- ProcessGroupTCCL -----------------------------------------------------
+
+ProcessGroupTCCL::ProcessGroupTCCL(
+    const c10::intrusive_ptr<Store>& store,
+    int rank,
+    int size,
+    c10::intrusive_ptr<Options> options)
+    : Backend(rank, size),
+      store_(store),
+      options_(std::move(options)) {
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      store_ != nullptr,
+      "ProcessGroupTCCL: store must not be null.");
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      size > 0 && rank >= 0 && rank < size,
+      "ProcessGroupTCCL: invalid (rank=",
+      rank,
+      ", size=",
+      size,
+      ").");
+
+  // 0. Resolve topology: Options field, overridden by env TCCL_TOPOLOGY=ring|mesh.
+  topology_ = options_->topology;
+  if (const char* t = std::getenv("TCCL_TOPOLOGY")) {
+    const std::string ts(t);
+    if (ts == "ring") {
+      topology_ = Topology::Ring;
+    } else if (ts == "mesh") {
+      topology_ = Topology::Mesh;
+    } else {
+      TORCH_CHECK_WITH(
+          DistBackendError,
+          false,
+          "ProcessGroupTCCL: TCCL_TOPOLOGY must be 'ring' or 'mesh', got '",
+          ts,
+          "'.");
+    }
+  }
+  const bool ringTopology = (topology_ == Topology::Ring);
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      !ringTopology || size > 2,
+      "ProcessGroupTCCL: ring topology requires world size > 2 (got ",
+      size,
+      "); use mesh for <=2 ranks.");
+
+  // 1. Resolve the per-peer RDMA device list.
+  const std::vector<std::string> peerDevices =
+      resolveTcclPeerDevices(rank, size, options_->device_name, ringTopology);
+
+  // 2. num_wires sanity
+  const int num_wires = options_->num_wires;
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      num_wires >= 1,
+      "ProcessGroupTCCL: num_wires must be >= 1, got ",
+      num_wires);
+
+  // 3. Per-device validation.
+  std::unordered_map<std::string, int> peersPerDevice;
+  for (int peer = 0; peer < size; peer++) {
+    if (peer != rank && !peerDevices[peer].empty()) {
+      peersPerDevice[peerDevices[peer]]++;
+    }
+  }
+  for (const auto& [dev, peers] : peersPerDevice) {
+    checkLinkLayer(dev);
+    const int qps = num_wires * peers;
+    TORCH_CHECK_WITH(
+        DistBackendError,
+        qps <= 10,
+        "ProcessGroupTCCL: device '",
+        dev,
+        "' would host num_wires=",
+        num_wires,
+        " * ",
+        peers,
+        " peer(s) = ",
+        qps,
+        " QPs, exceeding the 10-UC-QP-per-device Thunderbolt limit "
+        "(TN3205 §12.1). Spread peers across more devices (full mesh) or "
+        "reduce num_wires.");
+  }
+
+  // 4. Reserve a unique init-sequence number from the Store. The keys we
+  //    use for destination exchange are prefixed with this number.
+  const int64_t initSeq = tcclInitSequence(*store_, rank, options_->timeout);
+  const std::string keyPrefix =
+      "tccl_dest_s" + std::to_string(initSeq) + "_";
+
+  // 5. Construct one TCCLConnection per (peer, wire). Each constructor opens its
+  //    own device context, allocates PD/CQ/QP, transitions the QP to INIT,
+  //    and populates its localDestination.
+  connections_.resize(static_cast<size_t>(size) * num_wires);
+  std::vector<TCCLDestination> localDests(connections_.size());
+  for (int peer = 0; peer < size; peer++) {
+    if (peer == rank || peerDevices[peer].empty()) {
+      continue;  // self, or a non-neighbor in ring topology (no connection)
+    }
+    for (int wire = 0; wire < num_wires; wire++) {
+      const size_t idx = static_cast<size_t>(peer) * num_wires + wire;
+      connections_[idx] = std::make_unique<TCCLConnection>(peerDevices[peer]);
+      localDests[idx] = connections_[idx]->localDestination();
+    }
+  }
+
+  // 6. Allocate + register per-peer send/recv buffers
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      num_wires == 1,
+      "ProcessGroupTCCL: num_wires must be 1 (multi-wire is not yet "
+      "supported). Got num_wires=",
+      num_wires);
+
+  sendBuffers_.resize(static_cast<size_t>(size));
+  recvBuffers_.resize(static_cast<size_t>(size));
+  for (int peer = 0; peer < size; peer++) {
+    if (peer == rank || peerDevices[peer].empty()) {
+      continue;  // self, or a non-neighbor in ring topology
+    }
+    sendBuffers_[peer] = TCCLSharedBuffer(TCCLEngine::kChunkSize);
+    recvBuffers_[peer] = TCCLSharedBuffer(TCCLEngine::kChunkSize);
+    auto* pd = connections_[peer]->protectionDomain();
+    sendBuffers_[peer].registerToPD(pd);
+    recvBuffers_[peer].registerToPD(pd);
+  }
+
+  // 7. All-to-all destination exchange via Store. Each rank publishes its
+  //    full (size * num_wires) destination list.
+  std::vector<std::vector<TCCLDestination>> remoteDests;
+  allgatherDestinationsViaStore(
+      *store_,
+      rank,
+      size,
+      localDests,
+      remoteDests,
+      keyPrefix,
+      options_->timeout);
+
+  // 8. Transition each connection INIT -> RTR -> RTS. To find peer p's
+  //    destination FOR ME on wire w, we read p's published list at the
+  //    slot p.
+  for (int peer = 0; peer < size; peer++) {
+    if (peer == rank || peerDevices[peer].empty()) {
+      continue;  // self, or a non-neighbor in ring topology
+    }
+    for (int wire = 0; wire < num_wires; wire++) {
+      const size_t myConn =
+          static_cast<size_t>(peer) * num_wires + wire;
+      const size_t peerSlotForMe =
+          static_cast<size_t>(rank) * num_wires + wire;
+      const TCCLDestination& remote =
+          remoteDests[peer][peerSlotForMe];
+      connections_[myConn]->transitionToRTR(remote);
+      connections_[myConn]->transitionToRTS();
+    }
+  }
+
+  // 9. Final sync — every rank reaches RTS before any rank may post a send.
+  tcclRtsBarrier(
+      *store_,
+      size,
+      keyPrefix + "rts_ready",
+      options_->timeout);
+
+  // 10. Construct the collective engine (holds refs into our connection + buffer vectors).
+  engine_ = std::make_unique<TCCLEngine>(
+      rank, size, connections_, sendBuffers_, recvBuffers_, options_->timeout,
+      /*ring_topology=*/ringTopology);
+
+  // 11. Spawn the worker thread.
+  workerThread_ = std::thread(&ProcessGroupTCCL::runLoop, this);
+}
+
+ProcessGroupTCCL::~ProcessGroupTCCL() {
+  stop_.store(true);
+  workCV_.notify_all();
+  if (workerThread_.joinable()) {
+    workerThread_.join();
+  }
+}
+
+// ---- Worker thread --------------------------------------------------------
+
+void ProcessGroupTCCL::runLoop() {
+  c10::setThreadName("pt_tccl_runloop");
+  std::unique_lock<std::mutex> lock(workMutex_);
+  while (!stop_.load()) {
+    workCV_.wait(lock, [this] {
+      return stop_.load() || !workQueue_.empty();
+    });
+    if (stop_.load()) {
+      return;
+    }
+    auto task = std::move(workQueue_.front());
+    workQueue_.pop_front();
+    lock.unlock();
+    // Run without holding the queue mutex so the main thread can keep
+    // enqueuing follow-on work for the next collective.
+    task();
+    lock.lock();
+  }
+}
+
+// ---- enqueueCollective ----------------------------------------------------
+//
+// Shared async scaffold. Mirrors the original allreduce flow: record the MPS
+// event on the calling thread (non-blocking commitAndContinue keeps the serial
+// queue free so autograd / DDP can keep dispatching GPU work in parallel with
+// our RDMA transfer), enqueue a lambda that waits for that event on the worker
+// and runs `fn`, and hand back a TCCLWork the caller blocks on via wait().
+c10::intrusive_ptr<Work> ProcessGroupTCCL::enqueueCollective(
+    OpType opType,
+    std::vector<at::Tensor> outputs,
+    std::function<void()> fn) {
+  const uint32_t mpsEventId = mpsEventRecord();
+  const uint64_t mySeq = ++seq_;
+  auto work = c10::make_intrusive<TCCLWork>(opType, mySeq, std::move(outputs));
+  {
+    std::lock_guard<std::mutex> lock(workMutex_);
+    workQueue_.push_back(
+        [mpsEventId, fn = std::move(fn), work]() mutable {
+          std::exception_ptr ep;
+          try {
+            // Block only this worker thread until the GPU finishes pending
+            // writes to the input tensors; releases the event to the pool.
+            mpsEventWait(mpsEventId);
+            fn();
+          } catch (...) {
+            ep = std::current_exception();
+          }
+          // Store any exception and wake threads blocked on Work::wait().
+          work->finishWork(ep);
+        });
+  }
+  workCV_.notify_one();
+  return work;
+}
+
+// ---- allreduce ------------------------------------------------------------
+
+c10::intrusive_ptr<Work> ProcessGroupTCCL::allreduce(
+    std::vector<at::Tensor>& tensors,
+    const AllreduceOptions& opts) {
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      tensors.size() == 1,
+      "TCCL allreduce: expected exactly one tensor, got ",
+      tensors.size());
+  auto& tensor = tensors[0];
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      tensor.device().is_mps(),
+      "TCCL allreduce: tensor must be on MPS device, got ",
+      tensor.device());
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      isSupportedReduceDtype(tensor.scalar_type()),
+      "TCCL allreduce: unsupported dtype. Supported: float32/float16/bfloat16 "
+      "and int8/int16/int32/int64/uint8/bool (SUM); uint16/32/64 have no MPS add "
+      "and are unsupported. ",
+      kNotImplementedHint,
+      " Got dtype=",
+      tensor.scalar_type());
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      opts.reduceOp == ReduceOp::SUM || opts.reduceOp == ReduceOp::AVG ||
+          opts.reduceOp == ReduceOp::MIN || opts.reduceOp == ReduceOp::MAX ||
+          opts.reduceOp == ReduceOp::PRODUCT,
+      "TCCL allreduce: only SUM, AVG (= SUM / world_size), MIN, MAX and "
+      "PRODUCT are supported. ",
+      kNotImplementedHint);
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      opts.reduceOp != ReduceOp::AVG || isFloatReduceDtype(tensor.scalar_type()),
+      "TCCL allreduce: AVG is only supported for float32/float16/bfloat16 "
+      "(integer/bool AVG is undefined; matches NCCL). Use SUM for integer dtypes. ",
+      " Got dtype=",
+      tensor.scalar_type());
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      tensor.is_contiguous(),
+      "TCCL allreduce: non-contiguous tensors are not supported. "
+      "Call .contiguous() before allreduce.");
+
+  const ReduceOp::RedOpType op = opts.reduceOp;
+  const int worldSize = size_;
+  const at::ScalarType st = tensor.scalar_type();
+  return enqueueCollective(
+      OpType::ALLREDUCE,
+      std::vector<at::Tensor>{tensor},
+      [this, tensor, op, worldSize, st]() mutable {
+        at::Tensor cpuView = mpsSharedCpuView(tensor);
+        switch (st) {
+          case at::kFloat:
+            runMeshAllreduce<float>(*engine_, cpuView, op, worldSize);
+            break;
+          case at::kHalf:
+            runMeshAllreduce<at::Half>(*engine_, cpuView, op, worldSize);
+            break;
+          case at::kBFloat16:
+            runMeshAllreduce<at::BFloat16>(*engine_, cpuView, op, worldSize);
+            break;
+          // Integer/bool: SUM (native add / OR) and MIN/MAX (std::min/max).
+          // AVG is gated to floats above, so op is never AVG here.
+          case at::kChar:
+            runMeshAllreduce<int8_t>(*engine_, cpuView, op, worldSize);
+            break;
+          case at::kShort:
+            runMeshAllreduce<int16_t>(*engine_, cpuView, op, worldSize);
+            break;
+          case at::kInt:
+            runMeshAllreduce<int32_t>(*engine_, cpuView, op, worldSize);
+            break;
+          case at::kLong:
+            runMeshAllreduce<int64_t>(*engine_, cpuView, op, worldSize);
+            break;
+          case at::kByte:
+            runMeshAllreduce<uint8_t>(*engine_, cpuView, op, worldSize);
+            break;
+          case at::kBool:
+            runMeshAllreduce<bool>(*engine_, cpuView, op, worldSize);
+            break;
+          default:
+            break;  // unreachable — validated above
+        }
+      });
+}
+
+// ---- broadcast ------------------------------------------------------------
+
+c10::intrusive_ptr<Work> ProcessGroupTCCL::broadcast(
+    std::vector<at::Tensor>& tensors,
+    const BroadcastOptions& opts) {
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      tensors.size() == 1,
+      "TCCL broadcast: expected exactly one tensor, got ",
+      tensors.size());
+  auto& tensor = tensors[0];
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      tensor.device().is_mps(),
+      "TCCL broadcast: tensor must be on MPS device, got ",
+      tensor.device());
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      tensor.is_contiguous(),
+      "TCCL broadcast: non-contiguous tensors are not supported. "
+      "Call .contiguous() first.");
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      opts.rootRank >= 0 && opts.rootRank < size_,
+      "TCCL broadcast: invalid rootRank ",
+      opts.rootRank,
+      " for world size ",
+      size_);
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      opts.rootTensor == 0,
+      "TCCL broadcast: rootTensor must be 0 (one tensor per rank), got ",
+      opts.rootTensor);
+
+  // Byte-copy collective — any dtype. DDP construction broadcasts int32/int64
+  // metadata tensors through this path.
+  const int root = opts.rootRank;
+  return enqueueCollective(
+      OpType::BROADCAST,
+      std::vector<at::Tensor>{tensor},
+      [this, tensor, root]() mutable {
+        at::Tensor view = mpsSharedCpuView(tensor);
+        const std::size_t nbytes = static_cast<std::size_t>(view.nbytes());
+        if (tcclUseRing(size_, /*autoEnable=*/false, /*isBf16=*/false, nbytes, 1,
+                        engine_->ringTopology())) {
+          engine_->ring_broadcast(view.data_ptr(), nbytes, root);
+        } else {
+          engine_->broadcast(view.data_ptr(), nbytes, root);
+        }
+      });
+}
+
+c10::intrusive_ptr<Work> ProcessGroupTCCL::allreduce_coalesced(
+    std::vector<at::Tensor>& /*tensors*/,
+    const AllreduceCoalescedOptions& /*opts*/) {
+  TORCH_CHECK(
+      false, "ProcessGroupTCCL::allreduce_coalesced ", kNotImplementedHint);
+}
+
+c10::intrusive_ptr<Work> ProcessGroupTCCL::reduce(
+    std::vector<at::Tensor>& /*tensors*/,
+    const ReduceOptions& /*opts*/) {
+  TORCH_CHECK(false, "ProcessGroupTCCL::reduce ", kNotImplementedHint);
+}
+
+// ---- allgather (list form) ------------------------------------------------
+
+c10::intrusive_ptr<Work> ProcessGroupTCCL::allgather(
+    std::vector<std::vector<at::Tensor>>& outputTensors,
+    std::vector<at::Tensor>& inputTensors,
+    const AllgatherOptions& /*opts*/) {
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      inputTensors.size() == 1,
+      "TCCL allgather: expected exactly one input tensor, got ",
+      inputTensors.size());
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      outputTensors.size() == 1,
+      "TCCL allgather: expected exactly one output list, got ",
+      outputTensors.size());
+  auto& input = inputTensors[0];
+  auto& outList = outputTensors[0];
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      static_cast<int>(outList.size()) == size_,
+      "TCCL allgather: output list must have world_size (",
+      size_,
+      ") tensors, got ",
+      outList.size());
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      input.device().is_mps() && input.is_contiguous(),
+      "TCCL allgather: input must be a contiguous MPS tensor.");
+  for (const auto& o : outList) {
+    TORCH_CHECK_WITH(
+        DistBackendError,
+        o.device().is_mps() && o.is_contiguous() &&
+            o.numel() == input.numel() &&
+            o.scalar_type() == input.scalar_type(),
+        "TCCL allgather: every output slot must be a contiguous MPS tensor "
+        "matching the input shape and dtype.");
+  }
+
+  // Byte-copy collective - any dtype (DDP construction allgathers kLong
+  // param-size vectors).
+  return enqueueCollective(
+      OpType::ALLGATHER,
+      outList,
+      [this, input, outList]() mutable {
+        at::Tensor inView = mpsSharedCpuView(input);
+        const std::size_t per_rank_bytes =
+            static_cast<std::size_t>(inView.nbytes());
+
+        // Hold the per-slot CPU views alive for the duration of the gather;
+        // out_ptrs points into their (unified-memory) storage.
+        std::vector<at::Tensor> outViews;
+        std::vector<void*> outPtrs;
+        outViews.reserve(outList.size());
+        outPtrs.reserve(outList.size());
+        for (auto& o : outList) {
+          outViews.push_back(mpsSharedCpuView(o));
+          outPtrs.push_back(outViews.back().data_ptr());
+        }
+
+        if (tcclUseRing(size_, /*autoEnable=*/false, /*isBf16=*/false,
+                        per_rank_bytes * static_cast<std::size_t>(size_), 1,
+                        engine_->ringTopology())) {
+          engine_->ring_all_gather(inView.data_ptr(), outPtrs, per_rank_bytes);
+        } else {
+          engine_->all_gather(inView.data_ptr(), outPtrs, per_rank_bytes);
+        }
+      });
+}
+
+// ---- _allgather_base ------------------------------------------------------
+
+c10::intrusive_ptr<Work> ProcessGroupTCCL::_allgather_base(
+    at::Tensor& outputBuffer,
+    at::Tensor& inputBuffer,
+    const AllgatherOptions& /*opts*/) {
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      inputBuffer.device().is_mps() && inputBuffer.is_contiguous() &&
+          outputBuffer.device().is_mps() && outputBuffer.is_contiguous(),
+      "TCCL _allgather_base: input and output must be contiguous MPS tensors.");
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      outputBuffer.scalar_type() == inputBuffer.scalar_type(),
+      "TCCL _allgather_base: output/input dtype mismatch.");
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      outputBuffer.numel() == inputBuffer.numel() * size_,
+      "TCCL _allgather_base: output numel (",
+      outputBuffer.numel(),
+      ") must equal input numel (",
+      inputBuffer.numel(),
+      ") * world_size (",
+      size_,
+      ").");
+
+  // Byte-copy, any dtype. Output is one contiguous rank-major buffer.
+  return enqueueCollective(
+      OpType::_ALLGATHER_BASE,
+      std::vector<at::Tensor>{outputBuffer},
+      [this, inputBuffer, outputBuffer]() mutable {
+        at::Tensor inView = mpsSharedCpuView(inputBuffer);
+        at::Tensor outView = mpsSharedCpuView(outputBuffer);
+        const std::size_t per_rank_bytes =
+            static_cast<std::size_t>(inView.nbytes());
+
+        std::vector<void*> outPtrs(static_cast<std::size_t>(size_));
+        char* ob = reinterpret_cast<char*>(outView.data_ptr());
+        for (int r = 0; r < size_; ++r) {
+          outPtrs[r] = ob + static_cast<std::size_t>(r) * per_rank_bytes;
+        }
+
+        if (tcclUseRing(size_, /*autoEnable=*/false, /*isBf16=*/false,
+                        per_rank_bytes * static_cast<std::size_t>(size_), 1,
+                        engine_->ringTopology())) {
+          engine_->ring_all_gather(inView.data_ptr(), outPtrs, per_rank_bytes);
+        } else {
+          engine_->all_gather(inView.data_ptr(), outPtrs, per_rank_bytes);
+        }
+      });
+}
+
+// ---- allgather_into_tensor_coalesced (TP all-gather) ----------------------
+
+c10::intrusive_ptr<Work> ProcessGroupTCCL::allgather_into_tensor_coalesced(
+    std::vector<at::Tensor>& outputs,
+    std::vector<at::Tensor>& inputs,
+    const AllgatherOptions& /*opts*/) {
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      outputs.size() == inputs.size(),
+      "TCCL allgather_into_tensor_coalesced: outputs/inputs size mismatch (",
+      outputs.size(),
+      " vs ",
+      inputs.size(),
+      ").");
+  for (size_t i = 0; i < inputs.size(); ++i) {
+    TORCH_CHECK_WITH(
+        DistBackendError,
+        inputs[i].device().is_mps() && inputs[i].is_contiguous() &&
+            outputs[i].device().is_mps() && outputs[i].is_contiguous() &&
+            outputs[i].scalar_type() == inputs[i].scalar_type() &&
+            outputs[i].numel() == inputs[i].numel() * size_,
+        "TCCL allgather_into_tensor_coalesced: each (output, input) pair must "
+        "be contiguous MPS, same dtype, with output numel = input numel * "
+        "world_size.");
+  }
+
+  return enqueueCollective(
+      OpType::ALLGATHER_COALESCED,
+      outputs,
+      [this, inputs, outputs]() mutable {
+        for (size_t i = 0; i < inputs.size(); ++i) {
+          at::Tensor inView = mpsSharedCpuView(inputs[i]);
+          at::Tensor outView = mpsSharedCpuView(outputs[i]);
+          const std::size_t per_rank_bytes =
+              static_cast<std::size_t>(inView.nbytes());
+
+          std::vector<void*> outPtrs(static_cast<std::size_t>(size_));
+          char* ob = reinterpret_cast<char*>(outView.data_ptr());
+          for (int r = 0; r < size_; ++r) {
+            outPtrs[r] = ob + static_cast<std::size_t>(r) * per_rank_bytes;
+          }
+
+          if (tcclUseRing(size_, /*autoEnable=*/false, /*isBf16=*/false,
+                          per_rank_bytes * static_cast<std::size_t>(size_), 1,
+                          engine_->ringTopology())) {
+            engine_->ring_all_gather(inView.data_ptr(), outPtrs, per_rank_bytes);
+          } else {
+            engine_->all_gather(inView.data_ptr(), outPtrs, per_rank_bytes);
+          }
+        }
+      });
+}
+
+c10::intrusive_ptr<Work> ProcessGroupTCCL::gather(
+    std::vector<std::vector<at::Tensor>>& /*outputTensors*/,
+    std::vector<at::Tensor>& /*inputTensors*/,
+    const GatherOptions& /*opts*/) {
+  TORCH_CHECK(false, "ProcessGroupTCCL::gather ", kNotImplementedHint);
+}
+
+c10::intrusive_ptr<Work> ProcessGroupTCCL::scatter(
+    std::vector<at::Tensor>& /*outputTensors*/,
+    std::vector<std::vector<at::Tensor>>& /*inputTensors*/,
+    const ScatterOptions& /*opts*/) {
+  TORCH_CHECK(false, "ProcessGroupTCCL::scatter ", kNotImplementedHint);
+}
+
+// ---- reduce_scatter (list form) -------------------------------------------
+//
+// outputTensors[i] (on this rank) receives the element-wise reduction across
+// ranks of inputTensors[i][rank_]; inputTensors[i] is this rank's world_size
+// contributions (chunk p destined for peer p). The separate input tensors feed
+// the engine directly as per-rank chunk pointers — no pre-gather copy.
+
+c10::intrusive_ptr<Work> ProcessGroupTCCL::reduce_scatter(
+    std::vector<at::Tensor>& outputTensors,
+    std::vector<std::vector<at::Tensor>>& inputTensors,
+    const ReduceScatterOptions& opts) {
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      outputTensors.size() == inputTensors.size(),
+      "TCCL reduce_scatter: outputs/inputs size mismatch (",
+      outputTensors.size(),
+      " vs ",
+      inputTensors.size(),
+      ").");
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      opts.reduceOp == ReduceOp::SUM || opts.reduceOp == ReduceOp::AVG ||
+          opts.reduceOp == ReduceOp::MIN || opts.reduceOp == ReduceOp::MAX ||
+          opts.reduceOp == ReduceOp::PRODUCT,
+      "TCCL reduce_scatter: only SUM, AVG, MIN, MAX and PRODUCT are supported. ",
+      kNotImplementedHint);
+  for (size_t i = 0; i < outputTensors.size(); ++i) {
+    auto& out = outputTensors[i];
+    auto& inList = inputTensors[i];
+    TORCH_CHECK_WITH(
+        DistBackendError,
+        static_cast<int>(inList.size()) == size_,
+        "TCCL reduce_scatter: input list ",
+        i,
+        " must have world_size (",
+        size_,
+        ") tensors, got ",
+        inList.size());
+    TORCH_CHECK_WITH(
+        DistBackendError,
+        out.device().is_mps() && out.is_contiguous() &&
+            isSupportedReduceDtype(out.scalar_type()),
+        "TCCL reduce_scatter: each output must be a contiguous MPS tensor of a "
+        "supported dtype (float32/float16/bfloat16, int8/16/32/64, uint8, bool). ",
+        kNotImplementedHint);
+    TORCH_CHECK_WITH(
+        DistBackendError,
+        opts.reduceOp != ReduceOp::AVG || isFloatReduceDtype(out.scalar_type()),
+        "TCCL reduce_scatter: AVG is only supported for float32/float16/bfloat16 "
+        "(integer/bool AVG is undefined; matches NCCL). Use SUM for integer "
+        "dtypes.");
+    for (const auto& chunk : inList) {
+      TORCH_CHECK_WITH(
+          DistBackendError,
+          chunk.device().is_mps() && chunk.is_contiguous() &&
+              chunk.scalar_type() == out.scalar_type() &&
+              chunk.numel() == out.numel(),
+          "TCCL reduce_scatter: every input chunk must be a contiguous MPS "
+          "tensor matching the output dtype and numel.");
+    }
+  }
+
+  const ReduceOp::RedOpType op = opts.reduceOp;
+  const int worldSize = size_;
+  return enqueueCollective(
+      OpType::REDUCE_SCATTER,
+      outputTensors,
+      [this, inputTensors, outputTensors, op, worldSize]() mutable {
+        for (size_t i = 0; i < outputTensors.size(); ++i) {
+          at::Tensor outView = mpsSharedCpuView(outputTensors[i]);
+          // Hold the per-chunk CPU views alive for the duration of the call;
+          // dispatchReduceScatterList reads their (unified-memory) storage.
+          std::vector<at::Tensor> inChunkViews;
+          inChunkViews.reserve(inputTensors[i].size());
+          for (auto& chunk : inputTensors[i]) {
+            inChunkViews.push_back(mpsSharedCpuView(chunk));
+          }
+          dispatchReduceScatterList(*engine_, inChunkViews, outView, op, worldSize);
+        }
+      });
+}
+
+// ---- _reduce_scatter_base (FSDP reduce_scatter_tensor) --------------------
+
+c10::intrusive_ptr<Work> ProcessGroupTCCL::_reduce_scatter_base(
+    at::Tensor& outputBuffer,
+    at::Tensor& inputBuffer,
+    const ReduceScatterOptions& opts) {
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      opts.reduceOp == ReduceOp::SUM || opts.reduceOp == ReduceOp::AVG ||
+          opts.reduceOp == ReduceOp::MIN || opts.reduceOp == ReduceOp::MAX ||
+          opts.reduceOp == ReduceOp::PRODUCT,
+      "TCCL _reduce_scatter_base: only SUM, AVG, MIN, MAX and PRODUCT are supported. ",
+      kNotImplementedHint);
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      inputBuffer.device().is_mps() && inputBuffer.is_contiguous() &&
+          outputBuffer.device().is_mps() && outputBuffer.is_contiguous() &&
+          isSupportedReduceDtype(inputBuffer.scalar_type()) &&
+          outputBuffer.scalar_type() == inputBuffer.scalar_type(),
+      "TCCL _reduce_scatter_base: unsupported dtype or layout. Supported: "
+      "float32/float16/bfloat16 and int8/int16/int32/int64/uint8/bool (SUM); "
+      "in/out dtype must match; contiguous MPS. ",
+      kNotImplementedHint);
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      opts.reduceOp != ReduceOp::AVG ||
+          isFloatReduceDtype(inputBuffer.scalar_type()),
+      "TCCL _reduce_scatter_base: AVG is only supported for "
+      "float32/float16/bfloat16 (integer/bool AVG is undefined; matches NCCL). "
+      "Use SUM for integer dtypes.");
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      inputBuffer.numel() == outputBuffer.numel() * size_,
+      "TCCL _reduce_scatter_base: input numel (",
+      inputBuffer.numel(),
+      ") must equal output numel (",
+      outputBuffer.numel(),
+      ") * world_size (",
+      size_,
+      ").");
+
+  const ReduceOp::RedOpType op = opts.reduceOp;
+  const int worldSize = size_;
+  return enqueueCollective(
+      OpType::_REDUCE_SCATTER_BASE,
+      std::vector<at::Tensor>{outputBuffer},
+      [this, inputBuffer, outputBuffer, op, worldSize]() mutable {
+        at::Tensor inView = mpsSharedCpuView(inputBuffer);
+        at::Tensor outView = mpsSharedCpuView(outputBuffer);
+        dispatchReduceScatter(*engine_, inView, outView, op, worldSize);
+      });
+}
+
+// ---- reduce_scatter_tensor_coalesced (TP / sequence-parallel) -------------
+
+c10::intrusive_ptr<Work> ProcessGroupTCCL::reduce_scatter_tensor_coalesced(
+    std::vector<at::Tensor>& outputs,
+    std::vector<at::Tensor>& inputs,
+    const ReduceScatterOptions& opts) {
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      outputs.size() == inputs.size(),
+      "TCCL reduce_scatter_tensor_coalesced: outputs/inputs size mismatch (",
+      outputs.size(),
+      " vs ",
+      inputs.size(),
+      ").");
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      opts.reduceOp == ReduceOp::SUM || opts.reduceOp == ReduceOp::AVG ||
+          opts.reduceOp == ReduceOp::MIN || opts.reduceOp == ReduceOp::MAX ||
+          opts.reduceOp == ReduceOp::PRODUCT,
+      "TCCL reduce_scatter_tensor_coalesced: only SUM, AVG, MIN, MAX and "
+      "PRODUCT are supported. ",
+      kNotImplementedHint);
+  for (size_t i = 0; i < inputs.size(); ++i) {
+    TORCH_CHECK_WITH(
+        DistBackendError,
+        inputs[i].device().is_mps() && inputs[i].is_contiguous() &&
+            outputs[i].device().is_mps() && outputs[i].is_contiguous() &&
+            isSupportedReduceDtype(inputs[i].scalar_type()) &&
+            outputs[i].scalar_type() == inputs[i].scalar_type(),
+        "TCCL reduce_scatter_tensor_coalesced: unsupported dtype. Supported: "
+        "float32/float16/bfloat16 and int8/int16/int32/int64/uint8/bool (SUM); "
+        "in/out dtype must match; contiguous MPS. ",
+        kNotImplementedHint);
+    TORCH_CHECK_WITH(
+        DistBackendError,
+        opts.reduceOp != ReduceOp::AVG ||
+            isFloatReduceDtype(inputs[i].scalar_type()),
+        "TCCL reduce_scatter_tensor_coalesced: AVG is only supported for "
+        "float32/float16/bfloat16 (integer/bool AVG is undefined; matches NCCL). "
+        "Use SUM for integer dtypes.");
+    TORCH_CHECK_WITH(
+        DistBackendError,
+        inputs[i].numel() == outputs[i].numel() * size_,
+        "TCCL reduce_scatter_tensor_coalesced: input numel (",
+        inputs[i].numel(),
+        ") must equal output numel (",
+        outputs[i].numel(),
+        ") * world_size (",
+        size_,
+        ").");
+  }
+
+  const ReduceOp::RedOpType op = opts.reduceOp;
+  const int worldSize = size_;
+  return enqueueCollective(
+      OpType::REDUCE_SCATTER_TENSOR_COALESCED,
+      outputs,
+      [this, inputs, outputs, op, worldSize]() mutable {
+        for (size_t i = 0; i < inputs.size(); ++i) {
+          at::Tensor inView = mpsSharedCpuView(inputs[i]);
+          at::Tensor outView = mpsSharedCpuView(outputs[i]);
+          dispatchReduceScatter(*engine_, inView, outView, op, worldSize);
+        }
+      });
+}
+
+c10::intrusive_ptr<Work> ProcessGroupTCCL::alltoall_base(
+    at::Tensor& outputBuffer,
+    at::Tensor& inputBuffer,
+    std::vector<int64_t>& outputSplitSizes,
+    std::vector<int64_t>& inputSplitSizes,
+    const AllToAllOptions& /*opts*/) {
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      inputBuffer.device().is_mps() && inputBuffer.is_contiguous() &&
+          outputBuffer.device().is_mps() && outputBuffer.is_contiguous() &&
+          inputBuffer.dim() >= 1 && outputBuffer.dim() >= 1,
+      "TCCL alltoall_base: input/output must be contiguous MPS tensors with dim >= 1.");
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      outputBuffer.scalar_type() == inputBuffer.scalar_type(),
+      "TCCL alltoall_base: input/output dtype mismatch.");
+
+  const int ws = size_;
+  // Split is along dim 0; a "row" is the trailing-dims slab. in/out row bytes
+  // match (same dtype + trailing dims for a valid all-to-all).
+  const int64_t inDim0 = inputBuffer.size(0);
+  const int64_t outDim0 = outputBuffer.size(0);
+  const std::size_t inRow =
+      inDim0 > 0 ? static_cast<std::size_t>(inputBuffer.nbytes()) / inDim0 : 0;
+  const std::size_t outRow =
+      outDim0 > 0 ? static_cast<std::size_t>(outputBuffer.nbytes()) / outDim0 : 0;
+
+  const bool equal = inputSplitSizes.empty() && outputSplitSizes.empty();
+  std::vector<std::size_t> sOff(ws), sBytes(ws), rOff(ws), rBytes(ws);
+  if (equal) {
+    TORCH_CHECK_WITH(
+        DistBackendError,
+        inDim0 % ws == 0 && outDim0 % ws == 0,
+        "TCCL alltoall_base: equal split requires dim-0 (", inDim0, "/", outDim0,
+        ") divisible by world_size ", ws, ".");
+    const std::size_t sb = static_cast<std::size_t>(inDim0 / ws) * inRow;
+    const std::size_t rb = static_cast<std::size_t>(outDim0 / ws) * outRow;
+    for (int p = 0; p < ws; ++p) {
+      sOff[p] = static_cast<std::size_t>(p) * sb;
+      sBytes[p] = sb;
+      rOff[p] = static_cast<std::size_t>(p) * rb;
+      rBytes[p] = rb;
+    }
+  } else {
+    TORCH_CHECK_WITH(
+        DistBackendError,
+        static_cast<int>(inputSplitSizes.size()) == ws &&
+            static_cast<int>(outputSplitSizes.size()) == ws,
+        "TCCL alltoall_base: split-size vectors must have world_size entries.");
+    std::size_t so = 0, ro = 0;
+    for (int p = 0; p < ws; ++p) {
+      sOff[p] = so;
+      sBytes[p] = static_cast<std::size_t>(inputSplitSizes[p]) * inRow;
+      so += sBytes[p];
+      rOff[p] = ro;
+      rBytes[p] = static_cast<std::size_t>(outputSplitSizes[p]) * outRow;
+      ro += rBytes[p];
+    }
+    TORCH_CHECK_WITH(
+        DistBackendError,
+        so == static_cast<std::size_t>(inputBuffer.nbytes()) &&
+            ro == static_cast<std::size_t>(outputBuffer.nbytes()),
+        "TCCL alltoall_base: split sizes do not sum to the buffer sizes.");
+  }
+
+  // Ring requires equal (uniform) segments + ws > 2; tcclUseRing only returns
+  // true under TCCL_FORCE_ALGO=ring or ring topology. Everything else (the
+  // default, and all uneven splits) uses the mesh/direct form, which handles
+  // variable per-peer sizes.
+  const bool ringTop = engine_->ringTopology();
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      !ringTop || (equal && sBytes[0] == rBytes[0]),
+      "TCCL alltoall_base: ring topology supports only uniform (equal-split) "
+      "all-to-all; uneven splits require the full mesh (non-neighbor peers are "
+      "not connected on a ring).");
+  const bool ringOk = equal && sBytes[0] == rBytes[0] &&
+      tcclUseRing(ws, /*autoEnable=*/false, /*isBf16=*/false,
+                  sBytes[0] * static_cast<std::size_t>(ws), 1, ringTop);
+  const std::size_t segBytes = equal ? sBytes[0] : 0;
+
+  return enqueueCollective(
+      OpType::ALLTOALL_BASE,
+      std::vector<at::Tensor>{outputBuffer},
+      [this, inputBuffer, outputBuffer, sOff, sBytes, rOff, rBytes, ringOk,
+       segBytes]() mutable {
+        at::Tensor inView = mpsSharedCpuView(inputBuffer);
+        at::Tensor outView = mpsSharedCpuView(outputBuffer);
+        const char* sb = reinterpret_cast<const char*>(inView.data_ptr());
+        char* rb = reinterpret_cast<char*>(outView.data_ptr());
+        if (ringOk) {
+          engine_->ring_all_to_all(sb, rb, segBytes);
+        } else {
+          engine_->all_to_all(sb, rb, sOff, sBytes, rOff, rBytes);
+        }
+      });
+}
+
+c10::intrusive_ptr<Work> ProcessGroupTCCL::send(
+    std::vector<at::Tensor>& tensors,
+    int dstRank,
+    int /*tag*/) {
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      tensors.size() == 1,
+      "TCCL send: expected exactly one tensor, got ", tensors.size());
+  auto& tensor = tensors[0];
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      tensor.device().is_mps() && tensor.is_contiguous(),
+      "TCCL send: tensor must be a contiguous MPS tensor.");
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      dstRank >= 0 && dstRank < size_ && dstRank != rank_,
+      "TCCL send: invalid dstRank ", dstRank, " for rank ", rank_,
+      " (world size ", size_, ").");
+  // Ring topology only connects the two neighbors ((rank±1)%world); a send to
+  // any other rank has a null connection slot.
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      !engine_->ringTopology() ||
+          dstRank == (rank_ + 1) % size_ ||
+          dstRank == (rank_ - 1 + size_) % size_,
+      "TCCL send: ring topology only permits sends to a ring neighbor "
+      "((rank±1)%world); dstRank ", dstRank, " is not a neighbor of rank ",
+      rank_, ".");
+  // Byte movement - any dtype. tag is accepted but not hardware-matched (UC has
+  // no tag matching); ordering is the per-peer FIFO of matched send/recv pairs.
+  return enqueueCollective(
+      OpType::SEND,
+      std::vector<at::Tensor>{},
+      [this, tensor, dstRank]() mutable {
+        at::Tensor view = mpsSharedCpuView(tensor);
+        engine_->p2p_send(
+            dstRank,
+            reinterpret_cast<const char*>(view.data_ptr()),
+            static_cast<std::size_t>(view.nbytes()));
+      });
+}
+
+c10::intrusive_ptr<Work> ProcessGroupTCCL::recv(
+    std::vector<at::Tensor>& tensors,
+    int srcRank,
+    int /*tag*/) {
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      tensors.size() == 1,
+      "TCCL recv: expected exactly one tensor, got ", tensors.size());
+  auto& tensor = tensors[0];
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      tensor.device().is_mps() && tensor.is_contiguous(),
+      "TCCL recv: tensor must be a contiguous MPS tensor.");
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      srcRank >= 0 && srcRank < size_ && srcRank != rank_,
+      "TCCL recv: invalid srcRank ", srcRank, " for rank ", rank_,
+      " (world size ", size_, ").");
+  // Ring topology only connects the two neighbors ((rank±1)%world); a recv from
+  // any other rank has a null connection slot.
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      !engine_->ringTopology() ||
+          srcRank == (rank_ + 1) % size_ ||
+          srcRank == (rank_ - 1 + size_) % size_,
+      "TCCL recv: ring topology only permits recvs from a ring neighbor "
+      "((rank±1)%world); srcRank ", srcRank, " is not a neighbor of rank ",
+      rank_, ".");
+  return enqueueCollective(
+      OpType::RECV,
+      std::vector<at::Tensor>{tensor},
+      [this, tensor, srcRank]() mutable {
+        at::Tensor view = mpsSharedCpuView(tensor);
+        engine_->p2p_recv(
+            srcRank,
+            reinterpret_cast<char*>(view.data_ptr()),
+            static_cast<std::size_t>(view.nbytes()));
+      });
+}
+
+// ---- barrier --------------------------------------------------------------
+
+c10::intrusive_ptr<Work> ProcessGroupTCCL::barrier(
+    const BarrierOptions& /*opts*/) {
+  // No data path — Store::barrier is the optimized server-side primitive.
+  // Each call uses a fresh sequence number so
+  // rapid-fire barriers don't collide on the same key.
+  const uint64_t mySeq = ++barrierSeq_;
+  const std::string key = "tccl_barrier_" + std::to_string(mySeq);
+
+  // Run the barrier synchronously on the calling thread, then return a
+  // pre-completed Work.
+  tcclRtsBarrier(*store_, size_, key, options_->timeout);
+
+  auto work = c10::make_intrusive<TCCLWork>(OpType::BARRIER, mySeq);
+  work->finishWork();
+  return work;
+}
+
+} // namespace c10d
+
+#endif // USE_C10D_TCCL

--- a/torch/csrc/distributed/c10d/ProcessGroupTCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupTCCL.cpp
@@ -26,20 +26,16 @@ namespace c10d {
 namespace {
 
 // MPS staging helpers.
+//
+// Run the collective on a worker thread while the GPU keeps computing: main
+// thread records a non-blocking MPS event (mpsEventRecord), worker blocks on it
+// (mpsEventWait) - neither drains nor blocks the GPU - then reads/writes the
+// tensor via a zero-copy CPU view (mpsSharedCpuView) over unified memory.
 
-// These let the collective run on a worker thread while the GPU keeps
-// computing: the main thread records a non-blocking MPS event
-// (mpsEventRecord), the worker blocks on it (mpsEventWait) so we neither drain
-// nor block the GPU, then reads/writes the tensor via a zero-copy CPU view
-// (mpsSharedCpuView) over the same unified-memory storage.
-
-// Zero-copy CPU view over an MPS tensor's unified shared memory. With
-// MTLStorageModeShared the allocator exposes a CPU pointer via
-// getSharedBufferPtr; from_blob wraps it as a CPU tensor over the same bytes.
-// Uses the storage base pointer (not data_ptr()) because on MPS data_ptr()
-// folds storage_offset into id<MTLBuffer> arithmetic, yielding an address the
-// allocator can't map; views/chunks (e.g. _allgather_base) have non-zero
-// storage_offset, so a raw data_ptr() lookup would fail there.
+// Zero-copy CPU view over an MPS tensor's unified memory: getSharedBufferPtr
+// gives the shared CPU pointer, from_blob wraps it. Uses the storage base
+// pointer, NOT data_ptr() - on MPS data_ptr() folds storage_offset into
+// MTLBuffer arithmetic, unmappable for offset views (e.g. _allgather_base).
 at::Tensor mpsSharedCpuView(const at::Tensor& mpsTensor) {
   auto* allocator = at::mps::getIMPSAllocator();
   const void* storage_ptr = mpsTensor.storage().data_ptr().get();
@@ -67,9 +63,8 @@ at::Tensor mpsSharedCpuView(const at::Tensor& mpsTensor) {
       at::TensorOptions().dtype(mpsTensor.dtype()).device(at::kCPU));
 }
 
-// Non-blocking: encode a signal into the MPS command buffer and commit via
-// commitAndContinue. Returns an event id the worker can synchronize on. Does
-// NOT drain the GPU or hold the MPS serial queue beyond the encode.
+// Non-blocking: encode a signal via commitAndContinue, return an event id.
+// Does NOT drain the GPU or hold the serial queue beyond the encode.
 uint32_t mpsEventRecord() {
   auto& hooks = at::detail::getMPSHooks();
   uint32_t eid = hooks.acquireEvent(false);
@@ -77,9 +72,8 @@ uint32_t mpsEventRecord() {
   return eid;
 }
 
-// Block the calling thread until the GPU reaches the signal recorded by
-// mpsEventRecord() (MTLSharedEvent listener + condition_variable). Returns
-// immediately if the GPU already passed it; releases the event to the pool.
+// Block the calling thread until the GPU reaches the recorded signal, then
+// release the event. Returns immediately if the GPU already passed it.
 void mpsEventWait(uint32_t eid) {
   auto& hooks = at::detail::getMPSHooks();
   hooks.synchronizeEvent(eid);
@@ -102,17 +96,14 @@ inline bool isSupportedReduceDtype(at::ScalarType st) {
       st == at::kLong || st == at::kByte || st == at::kBool;
 }
 
-// AVG (= SUM then ×1/world_size)
+// AVG (= SUM then x 1/world_size)
 // AVG is gated to the float dtypes
 inline bool isFloatReduceDtype(at::ScalarType st) {
   return st == at::kFloat || st == at::kHalf || st == at::kBFloat16;
 }
 
-// Typed mesh allreduce + AVG post-scale. Instantiated for float/Half/BFloat16;
-// Ring-vs-mesh selection for all_reduce (N>2):
-//   bf16       -> ring at ANY size
-//   fp32/fp16  -> ring only >=8MB
-// TCCL_FORCE_ALGO=ring|mesh overrides per-call (mainly benchmarking reasons).
+// Ring-vs-mesh selection for all_reduce (N>2): bf16 -> ring at any size,
+// fp32/fp16 -> ring only >=8MB. TCCL_FORCE_ALGO=ring|mesh overrides per-call.
 inline bool tcclUseRing(
     int worldSize, bool autoEnable, bool isBf16, std::size_t count,
     std::size_t elemBytes, bool forceRing = false) {
@@ -123,12 +114,10 @@ inline bool tcclUseRing(
   if (forceRing) {
     return true;
   }
-  // autoEnable: size/dtype threshold and all_reduce
-  // TCCL_FORCE_ALGO, e.g. for reliability or a ring-cabled cluster).
+  // Auto-heuristic: bf16 any size, else >=8MB
   bool useRing = autoEnable &&
       (isBf16 || count * elemBytes >= 8u * 1024u * 1024u);
   if (const char* f = std::getenv("TCCL_FORCE_ALGO")) {
-    // TCCL_FORCE_ALGO=ring|mesh overrides the auto-heuristic above
     const std::string forced(f);
     if (forced == "ring") {
       useRing = true;
@@ -168,7 +157,8 @@ void runMeshAllreduce(
     case ReduceOp::PRODUCT:
       tcclAllreduceWith<T, TCCLProdOp<T>>(mesh, data, count, worldSize, useRing);
       break;
-    default:  // SUM or AVG
+    // SUM or AVG
+    default:
       tcclAllreduceWith<T, TCCLSumOp<T>>(mesh, data, count, worldSize, useRing);
       break;
   }
@@ -180,10 +170,9 @@ void runMeshAllreduce(
   }
 }
 
-// Typed reduce-scatter core over per-rank input-chunk pointers: in_chunks[p] is
-// this rank's contribution for peer p (count_per_rank elements). Picks
-// ring vs mesh, applies the reduce functor (SUM/MIN/MAX/AVG), and writes
-// count_per_rank elements to `out`.
+// Typed reduce-scatter core: in_chunks[p] is this rank's contribution for peer
+// p (count_per_rank elements). Picks ring vs mesh, applies the reduce functor,
+// writes count_per_rank elements to `out`.
 template <typename T>
 void runReduceScatterChunks(
     TCCLEngine& mesh,
@@ -214,7 +203,8 @@ void runReduceScatterChunks(
       else
         mesh.reduce_scatter<T, TCCLProdOp<T>>(in_chunks, out, count_per_rank, TCCLProdOp<T>{});
       break;
-    default:  // SUM or AVG
+    // SUM or AVG
+    default:
       if (useRing)
         mesh.ring_reduce_scatter<T, TCCLSumOp<T>>(in_chunks, out, count_per_rank, TCCLSumOp<T>{});
       else
@@ -284,7 +274,8 @@ void dispatchReduceScatter(
     case at::kLong: runMeshReduceScatter<int64_t>(mesh, inView, outView, op, worldSize); break;
     case at::kByte: runMeshReduceScatter<uint8_t>(mesh, inView, outView, op, worldSize); break;
     case at::kBool: runMeshReduceScatter<bool>(mesh, inView, outView, op, worldSize); break;
-    default: break;  // unreachable — validated by caller
+    // Unreachable - validated by caller
+    default: break;
   }
 }
 
@@ -306,34 +297,30 @@ void dispatchReduceScatterList(
     case at::kLong: runMeshReduceScatterList<int64_t>(mesh, inChunkViews, outView, op, worldSize); break;
     case at::kByte: runMeshReduceScatterList<uint8_t>(mesh, inChunkViews, outView, op, worldSize); break;
     case at::kBool: runMeshReduceScatterList<bool>(mesh, inChunkViews, outView, op, worldSize); break;
-    default: break;  // unreachable — validated by caller
+    // Unreachable - validated by caller
+    default: break;
   }
 }
 } // namespace
 
-// ---- Options --------------------------------------------------------------
+// Options
 
 ProcessGroupTCCL::Options::Options(std::chrono::milliseconds timeout)
     : Backend::Options(TCCL_BACKEND_NAME, timeout) {}
 
-// ---- TCCLWork -------------------------------------------------------------
+// TCCLWork
 
 ProcessGroupTCCL::TCCLWork::TCCLWork(
     OpType opType, uint64_t seq, std::vector<at::Tensor> outputs)
     : Work(/*rank=*/-1, opType), seq_(seq), outputs_(std::move(outputs)) {
-  // Build the result Future carrying a List[Tensor]. Intentionally NO device
-  // list (unlike ProcessGroupGloo::createFutureAsOutput): a Future's device
-  // list only exists to order the callback against pending async GPU work on
-  // those devices' streams. Here there is nothing to order -- MPS is
-  // single-queue and the collective runs to completion on a CPU worker thread,
-  // so when the Future fires the data is already in place. DDP's reducer still
-  // chains correctly. A device list added ~140 us/op of pure overhead that
-  // synchronizes nothing, so we omit it.
+  // No device list: nothing to order (MPS single-queue, collective completes on
+  // the CPU worker before the Future fires). DDP chaining unaffected. A device
+  // list cost ~140 us/op for zero synchronization.
   future_ = c10::make_intrusive<c10::ivalue::Future>(
       c10::ListType::create(c10::TensorType::get()));
 }
 
-// ---- ProcessGroupTCCL -----------------------------------------------------
+// ProcessGroupTCCL
 
 ProcessGroupTCCL::ProcessGroupTCCL(
     const c10::intrusive_ptr<Store>& store,
@@ -415,7 +402,7 @@ ProcessGroupTCCL::ProcessGroupTCCL(
         " peer(s) = ",
         qps,
         " QPs, exceeding the 10-UC-QP-per-device Thunderbolt limit "
-        "(TN3205 §12.1). Spread peers across more devices (full mesh) or "
+        "(TN3205 sec. 12.1). Spread peers across more devices (full mesh) or "
         "reduce num_wires.");
   }
 
@@ -432,7 +419,8 @@ ProcessGroupTCCL::ProcessGroupTCCL(
   std::vector<TCCLDestination> localDests(connections_.size());
   for (int peer = 0; peer < size; peer++) {
     if (peer == rank || peerDevices[peer].empty()) {
-      continue;  // self, or a non-neighbor in ring topology (no connection)
+      // Self, or a non-neighbor in ring topology - no connection
+      continue;
     }
     for (int wire = 0; wire < num_wires; wire++) {
       const size_t idx = static_cast<size_t>(peer) * num_wires + wire;
@@ -453,7 +441,8 @@ ProcessGroupTCCL::ProcessGroupTCCL(
   recvBuffers_.resize(static_cast<size_t>(size));
   for (int peer = 0; peer < size; peer++) {
     if (peer == rank || peerDevices[peer].empty()) {
-      continue;  // self, or a non-neighbor in ring topology
+      // Self, or a non-neighbor in ring topology
+      continue;
     }
     sendBuffers_[peer] = TCCLSharedBuffer(TCCLEngine::kChunkSize);
     recvBuffers_[peer] = TCCLSharedBuffer(TCCLEngine::kChunkSize);
@@ -479,7 +468,8 @@ ProcessGroupTCCL::ProcessGroupTCCL(
   //    slot p.
   for (int peer = 0; peer < size; peer++) {
     if (peer == rank || peerDevices[peer].empty()) {
-      continue;  // self, or a non-neighbor in ring topology
+      // Self, or a non-neighbor in ring topology
+      continue;
     }
     for (int wire = 0; wire < num_wires; wire++) {
       const size_t myConn =
@@ -493,7 +483,7 @@ ProcessGroupTCCL::ProcessGroupTCCL(
     }
   }
 
-  // 9. Final sync — every rank reaches RTS before any rank may post a send.
+  // 9. Final sync - every rank reaches RTS before any rank may post a send.
   tcclRtsBarrier(
       *store_,
       size,
@@ -517,7 +507,7 @@ ProcessGroupTCCL::~ProcessGroupTCCL() {
   }
 }
 
-// ---- Worker thread --------------------------------------------------------
+// Worker thread
 
 void ProcessGroupTCCL::runLoop() {
   c10::setThreadName("pt_tccl_runloop");
@@ -539,13 +529,12 @@ void ProcessGroupTCCL::runLoop() {
   }
 }
 
-// ---- enqueueCollective ----------------------------------------------------
+// enqueueCollective
 //
-// Shared async scaffold. Mirrors the original allreduce flow: record the MPS
-// event on the calling thread (non-blocking commitAndContinue keeps the serial
-// queue free so autograd / DDP can keep dispatching GPU work in parallel with
-// our RDMA transfer), enqueue a lambda that waits for that event on the worker
-// and runs `fn`, and hand back a TCCLWork the caller blocks on via wait().
+// Shared async scaffold. Record the MPS event on the calling thread
+// (non-blocking commitAndContinue keeps the serial queue free so autograd / DDP
+// overlap the RDMA transfer), enqueue a lambda that waits the event and runs
+// `fn` on the worker, return a TCCLWork the caller blocks on via wait().
 c10::intrusive_ptr<Work> ProcessGroupTCCL::enqueueCollective(
     OpType opType,
     std::vector<at::Tensor> outputs,
@@ -559,8 +548,7 @@ c10::intrusive_ptr<Work> ProcessGroupTCCL::enqueueCollective(
         [mpsEventId, fn = std::move(fn), work]() mutable {
           std::exception_ptr ep;
           try {
-            // Block only this worker thread until the GPU finishes pending
-            // writes to the input tensors; releases the event to the pool.
+            // Block only this worker until the GPU flushes writes to the inputs
             mpsEventWait(mpsEventId);
             fn();
           } catch (...) {
@@ -574,7 +562,7 @@ c10::intrusive_ptr<Work> ProcessGroupTCCL::enqueueCollective(
   return work;
 }
 
-// ---- allreduce ------------------------------------------------------------
+// allreduce
 
 c10::intrusive_ptr<Work> ProcessGroupTCCL::allreduce(
     std::vector<at::Tensor>& tensors,
@@ -659,12 +647,13 @@ c10::intrusive_ptr<Work> ProcessGroupTCCL::allreduce(
             runMeshAllreduce<bool>(*engine_, cpuView, op, worldSize);
             break;
           default:
-            break;  // unreachable — validated above
+            // Unreachable - validated above
+            break;
         }
       });
 }
 
-// ---- broadcast ------------------------------------------------------------
+// broadcast
 
 c10::intrusive_ptr<Work> ProcessGroupTCCL::broadcast(
     std::vector<at::Tensor>& tensors,
@@ -698,7 +687,7 @@ c10::intrusive_ptr<Work> ProcessGroupTCCL::broadcast(
       "TCCL broadcast: rootTensor must be 0 (one tensor per rank), got ",
       opts.rootTensor);
 
-  // Byte-copy collective — any dtype. DDP construction broadcasts int32/int64
+  // Byte-copy collective - any dtype. DDP construction broadcasts int32/int64
   // metadata tensors through this path.
   const int root = opts.rootRank;
   return enqueueCollective(
@@ -729,7 +718,7 @@ c10::intrusive_ptr<Work> ProcessGroupTCCL::reduce(
   TORCH_CHECK(false, "ProcessGroupTCCL::reduce ", kNotImplementedHint);
 }
 
-// ---- allgather (list form) ------------------------------------------------
+// allgather (list form)
 
 c10::intrusive_ptr<Work> ProcessGroupTCCL::allgather(
     std::vector<std::vector<at::Tensor>>& outputTensors,
@@ -799,7 +788,7 @@ c10::intrusive_ptr<Work> ProcessGroupTCCL::allgather(
       });
 }
 
-// ---- _allgather_base ------------------------------------------------------
+// _allgather_base
 
 c10::intrusive_ptr<Work> ProcessGroupTCCL::_allgather_base(
     at::Tensor& outputBuffer,
@@ -851,7 +840,7 @@ c10::intrusive_ptr<Work> ProcessGroupTCCL::_allgather_base(
       });
 }
 
-// ---- allgather_into_tensor_coalesced (TP all-gather) ----------------------
+// allgather_into_tensor_coalesced (TP all-gather)
 
 c10::intrusive_ptr<Work> ProcessGroupTCCL::allgather_into_tensor_coalesced(
     std::vector<at::Tensor>& outputs,
@@ -918,12 +907,12 @@ c10::intrusive_ptr<Work> ProcessGroupTCCL::scatter(
   TORCH_CHECK(false, "ProcessGroupTCCL::scatter ", kNotImplementedHint);
 }
 
-// ---- reduce_scatter (list form) -------------------------------------------
+// reduce_scatter (list form)
 //
-// outputTensors[i] (on this rank) receives the element-wise reduction across
-// ranks of inputTensors[i][rank_]; inputTensors[i] is this rank's world_size
-// contributions (chunk p destined for peer p). The separate input tensors feed
-// the engine directly as per-rank chunk pointers — no pre-gather copy.
+// outputTensors[i] receives the element-wise reduction across ranks of
+// inputTensors[i][rank_]; inputTensors[i] is this rank's world_size
+// contributions (chunk p destined for peer p), fed to the engine directly as
+// per-rank chunk pointers - no pre-gather copy.
 
 c10::intrusive_ptr<Work> ProcessGroupTCCL::reduce_scatter(
     std::vector<at::Tensor>& outputTensors,
@@ -1000,7 +989,7 @@ c10::intrusive_ptr<Work> ProcessGroupTCCL::reduce_scatter(
       });
 }
 
-// ---- _reduce_scatter_base (FSDP reduce_scatter_tensor) --------------------
+// _reduce_scatter_base (FSDP reduce_scatter_tensor)
 
 c10::intrusive_ptr<Work> ProcessGroupTCCL::_reduce_scatter_base(
     at::Tensor& outputBuffer,
@@ -1053,7 +1042,7 @@ c10::intrusive_ptr<Work> ProcessGroupTCCL::_reduce_scatter_base(
       });
 }
 
-// ---- reduce_scatter_tensor_coalesced (TP / sequence-parallel) -------------
+// reduce_scatter_tensor_coalesced (TP / sequence-parallel)
 
 c10::intrusive_ptr<Work> ProcessGroupTCCL::reduce_scatter_tensor_coalesced(
     std::vector<at::Tensor>& outputs,
@@ -1235,7 +1224,7 @@ c10::intrusive_ptr<Work> ProcessGroupTCCL::send(
       dstRank >= 0 && dstRank < size_ && dstRank != rank_,
       "TCCL send: invalid dstRank ", dstRank, " for rank ", rank_,
       " (world size ", size_, ").");
-  // Ring topology only connects the two neighbors ((rank±1)%world); a send to
+  // Ring topology only connects the two neighbors ((rank+/-1)%world); a send to
   // any other rank has a null connection slot.
   TORCH_CHECK_WITH(
       DistBackendError,
@@ -1243,7 +1232,7 @@ c10::intrusive_ptr<Work> ProcessGroupTCCL::send(
           dstRank == (rank_ + 1) % size_ ||
           dstRank == (rank_ - 1 + size_) % size_,
       "TCCL send: ring topology only permits sends to a ring neighbor "
-      "((rank±1)%world); dstRank ", dstRank, " is not a neighbor of rank ",
+      "((rank+/-1)%world); dstRank ", dstRank, " is not a neighbor of rank ",
       rank_, ".");
   // Byte movement - any dtype. tag is accepted but not hardware-matched (UC has
   // no tag matching); ordering is the per-peer FIFO of matched send/recv pairs.
@@ -1277,7 +1266,7 @@ c10::intrusive_ptr<Work> ProcessGroupTCCL::recv(
       srcRank >= 0 && srcRank < size_ && srcRank != rank_,
       "TCCL recv: invalid srcRank ", srcRank, " for rank ", rank_,
       " (world size ", size_, ").");
-  // Ring topology only connects the two neighbors ((rank±1)%world); a recv from
+  // Ring topology only connects the two neighbors ((rank+/-1)%world); a recv from
   // any other rank has a null connection slot.
   TORCH_CHECK_WITH(
       DistBackendError,
@@ -1285,7 +1274,7 @@ c10::intrusive_ptr<Work> ProcessGroupTCCL::recv(
           srcRank == (rank_ + 1) % size_ ||
           srcRank == (rank_ - 1 + size_) % size_,
       "TCCL recv: ring topology only permits recvs from a ring neighbor "
-      "((rank±1)%world); srcRank ", srcRank, " is not a neighbor of rank ",
+      "((rank+/-1)%world); srcRank ", srcRank, " is not a neighbor of rank ",
       rank_, ".");
   return enqueueCollective(
       OpType::RECV,
@@ -1299,13 +1288,12 @@ c10::intrusive_ptr<Work> ProcessGroupTCCL::recv(
       });
 }
 
-// ---- barrier --------------------------------------------------------------
+// barrier
 
 c10::intrusive_ptr<Work> ProcessGroupTCCL::barrier(
     const BarrierOptions& /*opts*/) {
-  // No data path — Store::barrier is the optimized server-side primitive.
-  // Each call uses a fresh sequence number so
-  // rapid-fire barriers don't collide on the same key.
+  // No data path - Store::barrier is the optimized server-side primitive.
+  // Fresh sequence number per call so rapid-fire barriers don't collide.
   const uint64_t mySeq = ++barrierSeq_;
   const std::string key = "tccl_barrier_" + std::to_string(mySeq);
 

--- a/torch/csrc/distributed/c10d/ProcessGroupTCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupTCCL.cpp
@@ -114,9 +114,9 @@ inline bool tcclUseRing(
   if (forceRing) {
     return true;
   }
-  // Auto-heuristic: bf16 any size, else >=8MB
+  // Auto-heuristic: bf16 any size, else >=1MB
   bool useRing = autoEnable &&
-      (isBf16 || count * elemBytes >= 8u * 1024u * 1024u);
+      (isBf16 || count * elemBytes >= 1u * 1024u * 1024u);
   if (const char* f = std::getenv("TCCL_FORCE_ALGO")) {
     const std::string forced(f);
     if (forced == "ring") {
@@ -439,6 +439,8 @@ ProcessGroupTCCL::ProcessGroupTCCL(
 
   sendBuffers_.resize(static_cast<size_t>(size));
   recvBuffers_.resize(static_cast<size_t>(size));
+  pipeSendBuffers_.resize(static_cast<size_t>(size) * TCCLEngine::kPipelineDepth);
+  pipeRecvBuffers_.resize(static_cast<size_t>(size) * TCCLEngine::kPipelineDepth);
   for (int peer = 0; peer < size; peer++) {
     if (peer == rank || peerDevices[peer].empty()) {
       // Self, or a non-neighbor in ring topology
@@ -449,6 +451,15 @@ ProcessGroupTCCL::ProcessGroupTCCL(
     auto* pd = connections_[peer]->protectionDomain();
     sendBuffers_[peer].registerToPD(pd);
     recvBuffers_[peer].registerToPD(pd);
+    // Depth-indexed staging pool for the pipelined bidirectional ring.
+    for (int slot = 0; slot < TCCLEngine::kPipelineDepth; slot++) {
+      const size_t idx =
+          static_cast<size_t>(peer) * TCCLEngine::kPipelineDepth + slot;
+      pipeSendBuffers_[idx] = TCCLSharedBuffer(TCCLEngine::kChunkSize);
+      pipeRecvBuffers_[idx] = TCCLSharedBuffer(TCCLEngine::kChunkSize);
+      pipeSendBuffers_[idx].registerToPD(pd);
+      pipeRecvBuffers_[idx].registerToPD(pd);
+    }
   }
 
   // 7. All-to-all destination exchange via Store. Each rank publishes its
@@ -492,7 +503,8 @@ ProcessGroupTCCL::ProcessGroupTCCL(
 
   // 10. Construct the collective engine (holds refs into our connection + buffer vectors).
   engine_ = std::make_unique<TCCLEngine>(
-      rank, size, connections_, sendBuffers_, recvBuffers_, options_->timeout,
+      rank, size, connections_, sendBuffers_, recvBuffers_, pipeSendBuffers_,
+      pipeRecvBuffers_, options_->timeout,
       /*ring_topology=*/ringTopology);
 
   // 11. Spawn the worker thread.
@@ -713,9 +725,81 @@ c10::intrusive_ptr<Work> ProcessGroupTCCL::allreduce_coalesced(
 }
 
 c10::intrusive_ptr<Work> ProcessGroupTCCL::reduce(
-    std::vector<at::Tensor>& /*tensors*/,
-    const ReduceOptions& /*opts*/) {
-  TORCH_CHECK(false, "ProcessGroupTCCL::reduce ", kNotImplementedHint);
+    std::vector<at::Tensor>& tensors,
+    const ReduceOptions& opts) {
+  TORCH_CHECK_WITH(
+      DistBackendError, tensors.size() == 1,
+      "TCCL reduce: expected exactly one tensor, got ", tensors.size());
+  auto& tensor = tensors[0];
+  TORCH_CHECK_WITH(
+      DistBackendError, tensor.device().is_mps(),
+      "TCCL reduce: tensor must be on MPS device, got ", tensor.device());
+  TORCH_CHECK_WITH(
+      DistBackendError, opts.rootRank >= 0 && opts.rootRank < size_,
+      "TCCL reduce: invalid rootRank ", opts.rootRank, " (world size ", size_, ").");
+  TORCH_CHECK_WITH(
+      DistBackendError, isSupportedReduceDtype(tensor.scalar_type()),
+      "TCCL reduce: unsupported dtype. Supported: float32/float16/bfloat16 and "
+      "int8/int16/int32/int64/uint8/bool. ", kNotImplementedHint,
+      " Got dtype=", tensor.scalar_type());
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      opts.reduceOp == ReduceOp::SUM || opts.reduceOp == ReduceOp::AVG ||
+          opts.reduceOp == ReduceOp::MIN || opts.reduceOp == ReduceOp::MAX ||
+          opts.reduceOp == ReduceOp::PRODUCT,
+      "TCCL reduce: only SUM, AVG, MIN, MAX and PRODUCT are supported. ",
+      kNotImplementedHint);
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      opts.reduceOp != ReduceOp::AVG || isFloatReduceDtype(tensor.scalar_type()),
+      "TCCL reduce: AVG is only supported for float32/float16/bfloat16. Got dtype=",
+      tensor.scalar_type());
+  TORCH_CHECK_WITH(
+      DistBackendError, tensor.is_contiguous(),
+      "TCCL reduce: non-contiguous tensors are not supported. Call .contiguous().");
+  // Runs as all-reduce - reduced value on every rank (reduce guarantees only the
+  // root). rootRank is validated, not used in the reduction.
+  const ReduceOp::RedOpType op = opts.reduceOp;
+  const int worldSize = size_;
+  const at::ScalarType st = tensor.scalar_type();
+  return enqueueCollective(
+      OpType::REDUCE,
+      std::vector<at::Tensor>{tensor},
+      [this, tensor, op, worldSize, st]() mutable {
+        at::Tensor cpuView = mpsSharedCpuView(tensor);
+        switch (st) {
+          case at::kFloat:
+            runMeshAllreduce<float>(*engine_, cpuView, op, worldSize);
+            break;
+          case at::kHalf:
+            runMeshAllreduce<at::Half>(*engine_, cpuView, op, worldSize);
+            break;
+          case at::kBFloat16:
+            runMeshAllreduce<at::BFloat16>(*engine_, cpuView, op, worldSize);
+            break;
+          case at::kChar:
+            runMeshAllreduce<int8_t>(*engine_, cpuView, op, worldSize);
+            break;
+          case at::kShort:
+            runMeshAllreduce<int16_t>(*engine_, cpuView, op, worldSize);
+            break;
+          case at::kInt:
+            runMeshAllreduce<int32_t>(*engine_, cpuView, op, worldSize);
+            break;
+          case at::kLong:
+            runMeshAllreduce<int64_t>(*engine_, cpuView, op, worldSize);
+            break;
+          case at::kByte:
+            runMeshAllreduce<uint8_t>(*engine_, cpuView, op, worldSize);
+            break;
+          case at::kBool:
+            runMeshAllreduce<bool>(*engine_, cpuView, op, worldSize);
+            break;
+          default:
+            // Unreachable - validated above
+            break;
+        }
+      });
 }
 
 // allgather (list form)
@@ -894,17 +978,127 @@ c10::intrusive_ptr<Work> ProcessGroupTCCL::allgather_into_tensor_coalesced(
 }
 
 c10::intrusive_ptr<Work> ProcessGroupTCCL::gather(
-    std::vector<std::vector<at::Tensor>>& /*outputTensors*/,
-    std::vector<at::Tensor>& /*inputTensors*/,
-    const GatherOptions& /*opts*/) {
-  TORCH_CHECK(false, "ProcessGroupTCCL::gather ", kNotImplementedHint);
+    std::vector<std::vector<at::Tensor>>& outputTensors,
+    std::vector<at::Tensor>& inputTensors,
+    const GatherOptions& opts) {
+  TORCH_CHECK_WITH(
+      DistBackendError, inputTensors.size() == 1,
+      "TCCL gather: expected exactly one input tensor, got ", inputTensors.size());
+  auto& input = inputTensors[0];
+  const int root = opts.rootRank;
+  TORCH_CHECK_WITH(
+      DistBackendError, root >= 0 && root < size_,
+      "TCCL gather: invalid rootRank ", root, " (world size ", size_, ").");
+  TORCH_CHECK_WITH(
+      DistBackendError, input.device().is_mps() && input.is_contiguous(),
+      "TCCL gather: input must be a contiguous MPS tensor.");
+  // Root needs a QP to every rank - mesh-only (ring has no non-neighbor link).
+  TORCH_CHECK_WITH(
+      DistBackendError, !engine_->ringTopology(),
+      "TCCL gather: not supported on a ring topology (the root needs a QP to "
+      "every rank); use a full-mesh cluster.");
+  const bool isRoot = (rank_ == root);
+  std::vector<at::Tensor> outList;
+  if (isRoot) {
+    TORCH_CHECK_WITH(
+        DistBackendError,
+        outputTensors.size() == 1 &&
+            static_cast<int>(outputTensors[0].size()) == size_,
+        "TCCL gather: the root must supply one output list of world_size (",
+        size_, ") tensors.");
+    outList = outputTensors[0];
+    for (const auto& o : outList) {
+      TORCH_CHECK_WITH(
+          DistBackendError,
+          o.device().is_mps() && o.is_contiguous() &&
+              o.numel() == input.numel() &&
+              o.scalar_type() == input.scalar_type(),
+          "TCCL gather: every output slot must be a contiguous MPS tensor "
+          "matching the input shape and dtype.");
+    }
+  }
+  // Byte-copy - any dtype.
+  return enqueueCollective(
+      OpType::GATHER,
+      isRoot ? outList : std::vector<at::Tensor>{},
+      [this, input, outList, isRoot, root]() mutable {
+        at::Tensor inView = mpsSharedCpuView(input);
+        const std::size_t nbytes = static_cast<std::size_t>(inView.nbytes());
+        // Keep the CPU views alive - out_ptrs alias their memory (root only).
+        std::vector<at::Tensor> outViews;
+        std::vector<void*> outPtrs;
+        if (isRoot) {
+          outViews.reserve(outList.size());
+          outPtrs.reserve(outList.size());
+          for (auto& o : outList) {
+            outViews.push_back(mpsSharedCpuView(o));
+            outPtrs.push_back(outViews.back().data_ptr());
+          }
+        }
+        engine_->gather(inView.data_ptr(), outPtrs, nbytes, root);
+      });
 }
 
 c10::intrusive_ptr<Work> ProcessGroupTCCL::scatter(
-    std::vector<at::Tensor>& /*outputTensors*/,
-    std::vector<std::vector<at::Tensor>>& /*inputTensors*/,
-    const ScatterOptions& /*opts*/) {
-  TORCH_CHECK(false, "ProcessGroupTCCL::scatter ", kNotImplementedHint);
+    std::vector<at::Tensor>& outputTensors,
+    std::vector<std::vector<at::Tensor>>& inputTensors,
+    const ScatterOptions& opts) {
+  TORCH_CHECK_WITH(
+      DistBackendError, outputTensors.size() == 1,
+      "TCCL scatter: expected exactly one output tensor, got ",
+      outputTensors.size());
+  auto& output = outputTensors[0];
+  const int root = opts.rootRank;
+  TORCH_CHECK_WITH(
+      DistBackendError, root >= 0 && root < size_,
+      "TCCL scatter: invalid rootRank ", root, " (world size ", size_, ").");
+  TORCH_CHECK_WITH(
+      DistBackendError, output.device().is_mps() && output.is_contiguous(),
+      "TCCL scatter: output must be a contiguous MPS tensor.");
+  TORCH_CHECK_WITH(
+      DistBackendError, !engine_->ringTopology(),
+      "TCCL scatter: not supported on a ring topology (the root needs a QP to "
+      "every rank); use a full-mesh cluster.");
+  const bool isRoot = (rank_ == root);
+  std::vector<at::Tensor> inList;
+  if (isRoot) {
+    TORCH_CHECK_WITH(
+        DistBackendError,
+        inputTensors.size() == 1 &&
+            static_cast<int>(inputTensors[0].size()) == size_,
+        "TCCL scatter: the root must supply one input list of world_size (",
+        size_, ") tensors.");
+    inList = inputTensors[0];
+    for (const auto& in : inList) {
+      TORCH_CHECK_WITH(
+          DistBackendError,
+          in.device().is_mps() && in.is_contiguous() &&
+              in.numel() == output.numel() &&
+              in.scalar_type() == output.scalar_type(),
+          "TCCL scatter: every input slot must be a contiguous MPS tensor "
+          "matching the output shape and dtype.");
+    }
+  }
+  // Byte-copy - any dtype.
+  return enqueueCollective(
+      OpType::SCATTER,
+      std::vector<at::Tensor>{output},
+      [this, output, inList, isRoot, root]() mutable {
+        at::Tensor outView = mpsSharedCpuView(output);
+        const std::size_t nbytes = static_cast<std::size_t>(outView.nbytes());
+        // Keep the CPU views alive - in_ptrs alias their memory (root only).
+        std::vector<at::Tensor> inViews;
+        std::vector<const void*> inPtrs;
+        if (isRoot) {
+          inViews.reserve(inList.size());
+          inPtrs.reserve(inList.size());
+          for (auto& in : inList) {
+            inViews.push_back(mpsSharedCpuView(in));
+            inPtrs.push_back(inViews.back().data_ptr());
+          }
+        }
+        engine_->scatter(inPtrs, outView.data_ptr(), nbytes, root);
+      });
 }
 
 // reduce_scatter (list form)

--- a/torch/csrc/distributed/c10d/ProcessGroupTCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupTCCL.hpp
@@ -1,0 +1,239 @@
+#pragma once
+
+#ifdef USE_C10D_TCCL
+
+#include <chrono>
+#include <condition_variable>
+#include <deque>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <ATen/ATen.h>
+#include <ATen/core/ivalue.h>
+#include <c10/macros/Macros.h>
+
+#include <torch/csrc/distributed/c10d/Backend.hpp>
+#include <torch/csrc/distributed/c10d/Store.hpp>
+#include <torch/csrc/distributed/c10d/Types.hpp>
+#include <torch/csrc/distributed/c10d/Work.hpp>
+
+namespace c10d {
+
+constexpr const char* TCCL_BACKEND_NAME = "tccl";
+
+// Forward declaration — definition in TCCLUtils.hpp (transport layer).
+class TCCLConnection;
+class TCCLSharedBuffer;
+class TCCLEngine;
+
+class TORCH_API ProcessGroupTCCL : public Backend {
+ public:
+  // Thin Work subclass. Completion state (mutex_, cv_, completed_,
+  // exception_) is owned by the Work base class. Use finishWork(eptr) to
+  // signal completion.
+  class TORCH_API TCCLWork : public Work {
+   public:
+    TCCLWork(OpType opType, uint64_t seq, std::vector<at::Tensor> outputs = {});
+
+    uint64_t seq() const noexcept {
+      return seq_;
+    }
+
+    c10::intrusive_ptr<c10::ivalue::Future> getFuture() override {
+      return future_;
+    }
+
+    // Public completion entry point (the worker lambda calls this).
+    void finishWork(std::exception_ptr exception = nullptr) {
+      if (exception) {
+        future_->setError(exception);
+      } else {
+        future_->markCompleted(c10::IValue(outputs_));
+      }
+      finish(std::move(exception));
+    }
+
+   private:
+    const uint64_t seq_;
+    std::vector<at::Tensor> outputs_;
+    c10::intrusive_ptr<c10::ivalue::Future> future_;
+  };
+
+  enum class Topology { Mesh, Ring };
+
+  struct TORCH_API Options : Backend::Options {
+    explicit Options(
+        std::chrono::milliseconds timeout = kBackendDefaultTimeout);
+
+    static c10::intrusive_ptr<Options> create(
+        std::chrono::milliseconds timeout = kBackendDefaultTimeout) {
+      return c10::make_intrusive<Options>(timeout);
+    }
+
+    // Name of the RDMA device as exposed by librdma (e.g. "rdma_en2").
+    std::string device_name;
+
+    // (multi-wire is not yet supported).
+    int num_wires{1};
+    Topology topology{Topology::Mesh};
+  };
+
+  explicit ProcessGroupTCCL(
+      const c10::intrusive_ptr<Store>& store,
+      int rank,
+      int size,
+      c10::intrusive_ptr<Options> options = Options::create());
+
+  ~ProcessGroupTCCL() override;
+
+  const std::string getBackendName() const override {
+    return std::string(TCCL_BACKEND_NAME);
+  }
+
+  c10::intrusive_ptr<Options> getOptions() {
+    return options_;
+  }
+
+  c10::intrusive_ptr<Backend::Options> getBackendOptions() override {
+    return c10::static_intrusive_pointer_cast<Backend::Options>(options_);
+  }
+
+  void setTimeout(std::chrono::milliseconds timeout) override {
+    options_->timeout = timeout;
+  }
+
+  // Collective overrides
+  c10::intrusive_ptr<Work> broadcast(
+      std::vector<at::Tensor>& tensors,
+      const BroadcastOptions& opts = BroadcastOptions()) override;
+
+  c10::intrusive_ptr<Work> allreduce(
+      std::vector<at::Tensor>& tensors,
+      const AllreduceOptions& opts = AllreduceOptions()) override;
+
+  c10::intrusive_ptr<Work> allreduce_coalesced(
+      std::vector<at::Tensor>& tensors,
+      const AllreduceCoalescedOptions& opts =
+          AllreduceCoalescedOptions()) override;
+
+  c10::intrusive_ptr<Work> reduce(
+      std::vector<at::Tensor>& tensors,
+      const ReduceOptions& opts = ReduceOptions()) override;
+
+  c10::intrusive_ptr<Work> allgather(
+      std::vector<std::vector<at::Tensor>>& outputTensors,
+      std::vector<at::Tensor>& inputTensors,
+      const AllgatherOptions& opts = AllgatherOptions()) override;
+
+  c10::intrusive_ptr<Work> _allgather_base(
+      at::Tensor& outputBuffer,
+      at::Tensor& inputBuffer,
+      const AllgatherOptions& opts = AllgatherOptions()) override;
+
+  // Coalesced all-gather-into-tensor. This is the virtual that DTensor /
+  // Tensor-Parallel reach via _functional_collectives (all_gather_into_tensor
+  // -> Functional.cpp -> group->allgather_into_tensor_coalesced), NOT
+  // _allgather_base.
+  c10::intrusive_ptr<Work> allgather_into_tensor_coalesced(
+      std::vector<at::Tensor>& outputs,
+      std::vector<at::Tensor>& inputs,
+      const AllgatherOptions& opts = AllgatherOptions()) override;
+
+  c10::intrusive_ptr<Work> gather(
+      std::vector<std::vector<at::Tensor>>& outputTensors,
+      std::vector<at::Tensor>& inputTensors,
+      const GatherOptions& opts = GatherOptions()) override;
+
+  c10::intrusive_ptr<Work> scatter(
+      std::vector<at::Tensor>& outputTensors,
+      std::vector<std::vector<at::Tensor>>& inputTensors,
+      const ScatterOptions& opts = ScatterOptions()) override;
+
+  c10::intrusive_ptr<Work> reduce_scatter(
+      std::vector<at::Tensor>& outputTensors,
+      std::vector<std::vector<at::Tensor>>& inputTensors,
+      const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
+
+  c10::intrusive_ptr<Work> _reduce_scatter_base(
+      at::Tensor& outputBuffer,
+      at::Tensor& inputBuffer,
+      const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
+
+  // Coalesced reduce-scatter-tensor. The virtual DTensor / sequence-parallel
+  // reach via _functional_collectives (reduce_scatter_tensor -> Functional.cpp
+  // -> group->reduce_scatter_tensor_coalesced).
+  c10::intrusive_ptr<Work> reduce_scatter_tensor_coalesced(
+      std::vector<at::Tensor>& outputs,
+      std::vector<at::Tensor>& inputs,
+      const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
+
+  c10::intrusive_ptr<Work> alltoall_base(
+      at::Tensor& outputBuffer,
+      at::Tensor& inputBuffer,
+      std::vector<int64_t>& outputSplitSizes,
+      std::vector<int64_t>& inputSplitSizes,
+      const AllToAllOptions& opts = AllToAllOptions()) override;
+
+  c10::intrusive_ptr<Work> send(
+      std::vector<at::Tensor>& tensors,
+      int dstRank,
+      int tag) override;
+
+  c10::intrusive_ptr<Work> recv(
+      std::vector<at::Tensor>& tensors,
+      int srcRank,
+      int tag) override;
+
+  c10::intrusive_ptr<Work> barrier(
+      const BarrierOptions& opts = BarrierOptions()) override;
+
+ protected:
+  c10::intrusive_ptr<Store> store_;
+  c10::intrusive_ptr<Options> options_;
+  Topology topology_{Topology::Mesh};  // resolved in ctor (options_ + TCCL_TOPOLOGY)
+  uint64_t seq_{0};
+  uint64_t barrierSeq_{0};
+
+  // One TCCLConnection per (peer_rank, wire) — one UC queue pair each. Index
+  // = peer_rank * num_wires + wire. Slots at peer_rank == rank_ stay null.
+  // Total size = size_ * options_->num_wires.
+  std::vector<std::unique_ptr<TCCLConnection>> connections_;
+
+  // One send buffer + one recv buffer per peer. Both vectors are sized to
+  // `size_`; self-slot stays empty (TCCLSharedBuffer with data_=nullptr).
+  std::vector<TCCLSharedBuffer> sendBuffers_;
+  std::vector<TCCLSharedBuffer> recvBuffers_;
+
+  // RDMA collective engine. Constructed after buffers are. Holds references
+  // into connections_/sendBuffers_/recvBuffers_;
+  std::unique_ptr<TCCLEngine> engine_;
+
+  // Worker thread model. Spawned at the end of the constructor
+  // (after the RTS barrier) and joined in the destructor.
+  std::thread workerThread_;
+  std::deque<std::function<void()>> workQueue_;
+  std::mutex workMutex_;
+  std::condition_variable workCV_;
+  std::atomic<bool> stop_{false};
+
+  // Shared async scaffold for collectives. Records an MPS event on the
+  // calling (main) thread so the worker waits for the GPU to flush writes to
+  // the input tensors, enqueues `fn` onto the worker, and returns a TCCLWork
+  // whose Future completes with `outputs` when `fn` returns. `fn` captures the
+  // tensors it needs and does the mpsSharedCpuView + engine_-> call; `outputs`
+  // are the tensors the Future should carry (for DDP's getFuture() chaining).
+  c10::intrusive_ptr<Work> enqueueCollective(
+      OpType opType,
+      std::vector<at::Tensor> outputs,
+      std::function<void()> fn);
+
+  void runLoop();
+};
+
+} // namespace c10d
+
+#endif // USE_C10D_TCCL

--- a/torch/csrc/distributed/c10d/ProcessGroupTCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupTCCL.hpp
@@ -25,7 +25,7 @@ namespace c10d {
 
 constexpr const char* TCCL_BACKEND_NAME = "tccl";
 
-// Forward declaration — definition in TCCLUtils.hpp (transport layer).
+// Forward declaration - definition in TCCLUtils.hpp (transport layer).
 class TCCLConnection;
 class TCCLSharedBuffer;
 class TCCLEngine;
@@ -134,10 +134,8 @@ class TORCH_API ProcessGroupTCCL : public Backend {
       at::Tensor& inputBuffer,
       const AllgatherOptions& opts = AllgatherOptions()) override;
 
-  // Coalesced all-gather-into-tensor. This is the virtual that DTensor /
-  // Tensor-Parallel reach via _functional_collectives (all_gather_into_tensor
-  // -> Functional.cpp -> group->allgather_into_tensor_coalesced), NOT
-  // _allgather_base.
+  // Coalesced all-gather-into-tensor. The virtual DTensor / TP reach via
+  // _functional_collectives (all_gather_into_tensor), NOT _allgather_base.
   c10::intrusive_ptr<Work> allgather_into_tensor_coalesced(
       std::vector<at::Tensor>& outputs,
       std::vector<at::Tensor>& inputs,
@@ -164,8 +162,8 @@ class TORCH_API ProcessGroupTCCL : public Backend {
       const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
 
   // Coalesced reduce-scatter-tensor. The virtual DTensor / sequence-parallel
-  // reach via _functional_collectives (reduce_scatter_tensor -> Functional.cpp
-  // -> group->reduce_scatter_tensor_coalesced).
+  // reach via _functional_collectives (reduce_scatter_tensor), NOT
+  // _reduce_scatter_base.
   c10::intrusive_ptr<Work> reduce_scatter_tensor_coalesced(
       std::vector<at::Tensor>& outputs,
       std::vector<at::Tensor>& inputs,
@@ -194,11 +192,12 @@ class TORCH_API ProcessGroupTCCL : public Backend {
  protected:
   c10::intrusive_ptr<Store> store_;
   c10::intrusive_ptr<Options> options_;
-  Topology topology_{Topology::Mesh};  // resolved in ctor (options_ + TCCL_TOPOLOGY)
+  // Resolved in ctor from options_ + TCCL_TOPOLOGY
+  Topology topology_{Topology::Mesh};
   uint64_t seq_{0};
   uint64_t barrierSeq_{0};
 
-  // One TCCLConnection per (peer_rank, wire) — one UC queue pair each. Index
+  // One TCCLConnection per (peer_rank, wire) - one UC queue pair each. Index
   // = peer_rank * num_wires + wire. Slots at peer_rank == rank_ stay null.
   // Total size = size_ * options_->num_wires.
   std::vector<std::unique_ptr<TCCLConnection>> connections_;
@@ -220,12 +219,11 @@ class TORCH_API ProcessGroupTCCL : public Backend {
   std::condition_variable workCV_;
   std::atomic<bool> stop_{false};
 
-  // Shared async scaffold for collectives. Records an MPS event on the
-  // calling (main) thread so the worker waits for the GPU to flush writes to
-  // the input tensors, enqueues `fn` onto the worker, and returns a TCCLWork
-  // whose Future completes with `outputs` when `fn` returns. `fn` captures the
-  // tensors it needs and does the mpsSharedCpuView + engine_-> call; `outputs`
-  // are the tensors the Future should carry (for DDP's getFuture() chaining).
+  // Shared async scaffold. Records an MPS event so the worker waits for the GPU
+  // to flush writes to the inputs, enqueues `fn`, and returns a TCCLWork whose
+  // Future completes with `outputs` when `fn` returns. `fn` does the
+  // mpsSharedCpuView + engine_ call; `outputs` are what the Future carries (DDP
+  // getFuture() chaining).
   c10::intrusive_ptr<Work> enqueueCollective(
       OpType opType,
       std::vector<at::Tensor> outputs,

--- a/torch/csrc/distributed/c10d/ProcessGroupTCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupTCCL.hpp
@@ -207,6 +207,12 @@ class TORCH_API ProcessGroupTCCL : public Backend {
   std::vector<TCCLSharedBuffer> sendBuffers_;
   std::vector<TCCLSharedBuffer> recvBuffers_;
 
+  // Depth-indexed staging pools for the pipelined bidirectional ring, flat
+  // [peer * kPipelineDepth + slot]. Sized size_ * kPipelineDepth; non-neighbor
+  // and self slots stay empty under ring topology.
+  std::vector<TCCLSharedBuffer> pipeSendBuffers_;
+  std::vector<TCCLSharedBuffer> pipeRecvBuffers_;
+
   // RDMA collective engine. Constructed after buffers are. Holds references
   // into connections_/sendBuffers_/recvBuffers_;
   std::unique_ptr<TCCLEngine> engine_;

--- a/torch/csrc/distributed/c10d/ProcessGroupTCCLDetail.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupTCCLDetail.hpp
@@ -1,0 +1,369 @@
+#pragma once
+
+#ifdef USE_C10D_TCCL
+
+// TCCL collective-algorithm engine and reduction-op templates
+
+#include <algorithm>
+#include <chrono>
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+#include <c10/util/BFloat16.h>
+#include <c10/util/Half.h>
+
+namespace c10d {
+
+class TCCLConnection;
+class TCCLSharedBuffer;
+
+// ---- Reduction op templates ------------------------------------------------
+
+
+
+template <typename T>
+struct TCCLSumOp {
+  void operator()(const T* input, T* output, std::size_t n) const;
+};
+
+template <typename T>
+struct TCCLMaxOp {
+  void operator()(const T* input, T* output, std::size_t n) const;
+};
+
+template <typename T>
+struct TCCLMinOp {
+  void operator()(const T* input, T* output, std::size_t n) const;
+};
+
+template <typename T>
+struct TCCLProdOp {
+  void operator()(const T* input, T* output, std::size_t n) const;
+};
+
+// Float32 SUM
+template <>
+inline void TCCLSumOp<float>::operator()(
+    const float* input,
+    float* output,
+    std::size_t n) const {
+  for (std::size_t i = 0; i < n; ++i) {
+    output[i] += input[i];
+  }
+}
+
+// float16 / bfloat16 SUM — accumulate in float32 then round back, matching
+// PyTorch's reduction semantics for low-precision floats (the dtypes DDP/TP
+// reduce most).
+template <>
+inline void TCCLSumOp<c10::Half>::operator()(
+    const c10::Half* input,
+    c10::Half* output,
+    std::size_t n) const {
+  for (std::size_t i = 0; i < n; ++i) {
+    output[i] = static_cast<c10::Half>(
+        static_cast<float>(output[i]) + static_cast<float>(input[i]));
+  }
+}
+
+template <>
+inline void TCCLSumOp<c10::BFloat16>::operator()(
+    const c10::BFloat16* input,
+    c10::BFloat16* output,
+    std::size_t n) const {
+  for (std::size_t i = 0; i < n; ++i) {
+    output[i] = static_cast<c10::BFloat16>(
+        static_cast<float>(output[i]) + static_cast<float>(input[i]));
+  }
+}
+
+// Integer SUM
+#define TCCL_DEFINE_INT_SUM(TYPE)                       \
+  template <>                                           \
+  inline void TCCLSumOp<TYPE>::operator()(              \
+      const TYPE* input, TYPE* output, std::size_t n)   \
+      const {                                           \
+    for (std::size_t i = 0; i < n; ++i) {               \
+      output[i] += input[i];                            \
+    }                                                   \
+  }
+TCCL_DEFINE_INT_SUM(int8_t)
+TCCL_DEFINE_INT_SUM(int16_t)
+TCCL_DEFINE_INT_SUM(int32_t)
+TCCL_DEFINE_INT_SUM(int64_t)
+TCCL_DEFINE_INT_SUM(uint8_t)
+#undef TCCL_DEFINE_INT_SUM
+
+// bool SUM = logical OR
+template <>
+inline void TCCLSumOp<bool>::operator()(
+    const bool* input,
+    bool* output,
+    std::size_t n) const {
+  for (std::size_t i = 0; i < n; ++i) {
+    output[i] = output[i] || input[i];
+  }
+}
+
+// PRODUCT  mirroring SUM: float32-accumulate for
+// fp16/bf16, native in-dtype for the integer dtypes (wraparound), logical AND
+// for bool.
+template <>
+inline void TCCLProdOp<float>::operator()(
+    const float* input, float* output, std::size_t n) const {
+  for (std::size_t i = 0; i < n; ++i) {
+    output[i] *= input[i];
+  }
+}
+template <>
+inline void TCCLProdOp<c10::Half>::operator()(
+    const c10::Half* input, c10::Half* output, std::size_t n) const {
+  for (std::size_t i = 0; i < n; ++i) {
+    output[i] = static_cast<c10::Half>(
+        static_cast<float>(output[i]) * static_cast<float>(input[i]));
+  }
+}
+template <>
+inline void TCCLProdOp<c10::BFloat16>::operator()(
+    const c10::BFloat16* input, c10::BFloat16* output, std::size_t n) const {
+  for (std::size_t i = 0; i < n; ++i) {
+    output[i] = static_cast<c10::BFloat16>(
+        static_cast<float>(output[i]) * static_cast<float>(input[i]));
+  }
+}
+#define TCCL_DEFINE_INT_PROD(TYPE)                              \
+  template <>                                                   \
+  inline void TCCLProdOp<TYPE>::operator()(                     \
+      const TYPE* input, TYPE* output, std::size_t n) const {   \
+    for (std::size_t i = 0; i < n; ++i)                         \
+      output[i] = static_cast<TYPE>(output[i] * input[i]);      \
+  }
+TCCL_DEFINE_INT_PROD(int8_t)
+TCCL_DEFINE_INT_PROD(int16_t)
+TCCL_DEFINE_INT_PROD(int32_t)
+TCCL_DEFINE_INT_PROD(int64_t)
+TCCL_DEFINE_INT_PROD(uint8_t)
+#undef TCCL_DEFINE_INT_PROD
+template <>
+inline void TCCLProdOp<bool>::operator()(
+    const bool* input, bool* output, std::size_t n) const {
+  for (std::size_t i = 0; i < n; ++i) {
+    output[i] = output[i] && input[i];
+  }
+}
+
+// MIN/MAX
+#define TCCL_DEFINE_MINMAX(TYPE)                                            \
+  template <>                                                               \
+  inline void TCCLMaxOp<TYPE>::operator()(                                  \
+      const TYPE* input, TYPE* output, std::size_t n) const {              \
+    for (std::size_t i = 0; i < n; ++i)                                     \
+      output[i] = std::max(output[i], input[i]);                            \
+  }                                                                         \
+  template <>                                                               \
+  inline void TCCLMinOp<TYPE>::operator()(                                  \
+      const TYPE* input, TYPE* output, std::size_t n) const {              \
+    for (std::size_t i = 0; i < n; ++i)                                     \
+      output[i] = std::min(output[i], input[i]);                            \
+  }
+TCCL_DEFINE_MINMAX(float)
+TCCL_DEFINE_MINMAX(int8_t)
+TCCL_DEFINE_MINMAX(int16_t)
+TCCL_DEFINE_MINMAX(int32_t)
+TCCL_DEFINE_MINMAX(int64_t)
+TCCL_DEFINE_MINMAX(uint8_t)
+TCCL_DEFINE_MINMAX(bool)
+#undef TCCL_DEFINE_MINMAX
+
+#define TCCL_DEFINE_MINMAX_VIA_FLOAT(TYPE)                                  \
+  template <>                                                               \
+  inline void TCCLMaxOp<TYPE>::operator()(                                  \
+      const TYPE* input, TYPE* output, std::size_t n) const {              \
+    for (std::size_t i = 0; i < n; ++i)                                     \
+      output[i] = static_cast<TYPE>(std::max(                               \
+          static_cast<float>(output[i]), static_cast<float>(input[i])));    \
+  }                                                                         \
+  template <>                                                               \
+  inline void TCCLMinOp<TYPE>::operator()(                                  \
+      const TYPE* input, TYPE* output, std::size_t n) const {              \
+    for (std::size_t i = 0; i < n; ++i)                                     \
+      output[i] = static_cast<TYPE>(std::min(                               \
+          static_cast<float>(output[i]), static_cast<float>(input[i])));    \
+  }
+TCCL_DEFINE_MINMAX_VIA_FLOAT(c10::Half)
+TCCL_DEFINE_MINMAX_VIA_FLOAT(c10::BFloat16)
+#undef TCCL_DEFINE_MINMAX_VIA_FLOAT
+
+
+// ---- TCCLEngine ----------------------------------------------------------
+
+class TCCLEngine {
+ public:
+  // Size of each per-peer staging buffer (hence its registered MR) and the
+  // max bytes per ibv_post_send; larger messages split into a chunk loop and
+  // reduce incrementally. Capped at 512 KB.
+  static constexpr size_t kChunkSize = 512 * 1024;
+
+  TCCLEngine(
+      int rank,
+      int size,
+      std::vector<std::unique_ptr<TCCLConnection>>& connections,
+      std::vector<TCCLSharedBuffer>& send_buffers,
+      std::vector<TCCLSharedBuffer>& recv_buffers,
+      const std::chrono::milliseconds& timeout,
+      bool ring_topology = false)
+      : rank_(rank),
+        size_(size),
+        connections_(connections),
+        send_buffers_(send_buffers),
+        recv_buffers_(recv_buffers),
+        timeout_(timeout),
+        ring_topology_(ring_topology) {}
+
+  // True when this PG was brought up as a ring (sparse connections). Dispatch
+  // reads it to force the ring path for every collective (see tcclUseRing).
+  bool ringTopology() const {
+    return ring_topology_;
+  }
+
+  template <typename T, typename ReduceOp>
+  void all_reduce(T* data, std::size_t count, ReduceOp reduce_op);
+
+  // In-place RING allreduce: reduce-scatter (size_-1 steps) + all-gather
+  // (size_-1 steps), each step sending to the right neighbor and receiving from
+  // the left.
+  template <typename T, typename ReduceOp>
+  void ring_all_reduce(T* data, std::size_t count, ReduceOp reduce_op);
+
+  // RING reduce_scatter: in_chunks[p] points at this rank's contribution
+  // destined for peer p (count_per_rank elements); on exit `out` holds the
+  // element-wise reduction across ranks of chunk number rank_.
+  template <typename T, typename ReduceOp>
+  void ring_reduce_scatter(
+      const std::vector<const T*>& in_chunks,
+      T* out,
+      std::size_t count_per_rank,
+      ReduceOp reduce_op);
+
+  // RING all_gather: `in` is this rank's shard (per_rank_bytes); on exit
+  // out_ptrs[r] holds rank r's shard. N-1 ring steps (send right / recv left)
+  // circulating shards; pure byte movement. out_ptrs.size() must equal size_.
+  // Requires size_ > 2.
+  void ring_all_gather(
+      const void* in,
+      const std::vector<void*>& out_ptrs,
+      std::size_t per_rank_bytes);
+
+  // In-place broadcast of `total_bytes` bytes at `data` from rank `root` to
+  // every rank.
+  void broadcast(void* data, std::size_t total_bytes, int root);
+
+  // RING broadcast: pipelined store-and-forward of total_bytes from `root` along
+  // the ring (root -> right -> ... -> root's left neighbour). Enables broadcast
+  // on a ring-cabled cluster; on a full mesh the dispatch defaults to mesh broadcast.
+  void ring_broadcast(void* data, std::size_t total_bytes, int root);
+
+  // Mesh all-gather. `in` is this rank's contiguous shard of `per_rank_bytes`
+  // bytes; on exit out_ptrs[r] receives rank r's shard (per_rank_bytes bytes).
+  void all_gather(
+      const void* in,
+      const std::vector<void*>& out_ptrs,
+      std::size_t per_rank_bytes);
+
+  // Mesh reduce-scatter. in_chunks[p] points at this rank's contribution
+  // destined for peer p (count_per_rank elements); on exit `out` holds the
+  // element-wise reduction across ranks of chunk number rank_. Reduces straight
+  // into `out` (no scratch).
+  template <typename T, typename ReduceOp>
+  void reduce_scatter(
+      const std::vector<const T*>& in_chunks,
+      T* out,
+      std::size_t count_per_rank,
+      ReduceOp reduce_op);
+
+  // Point-to-point send: stream `nbytes` from `in` to peer `dst` over its UC QP,
+  // chunked at kChunkSize through the per-peer send buffer (PIPELINE=1, one chunk
+  // in flight).
+  void p2p_send(int dst, const char* in, std::size_t nbytes);
+
+  // Point-to-point recv: receive `nbytes` from peer `src` into `out`, chunked
+  // through the per-peer recv buffer (PIPELINE=1). Posts the recv before polling.
+  void p2p_recv(int src, char* out, std::size_t nbytes);
+
+  // Mesh (direct) all-to-all. This rank's slab destined for peer p is
+  // [send_base + send_off[p], +send_bytes[p]); the slab received from peer p lands
+  // at [recv_base + recv_off[p], +recv_bytes[p]). Handles equal AND uneven
+  // (alltoallv) splits — sizes are per-peer. The self slot (p == rank_) is a local
+  // memcpy. Every peer is served simultaneously (recv+send in flight per peer,
+  // chunked at kChunkSize, PIPELINE=1), polling each peer's CQ; recv posted before
+  // send (UC discipline).
+  void all_to_all(
+      const char* send_base,
+      char* recv_base,
+      const std::vector<std::size_t>& send_off,
+      const std::vector<std::size_t>& send_bytes,
+      const std::vector<std::size_t>& recv_off,
+      const std::vector<std::size_t>& recv_bytes);
+
+  // RING all-to-all (neighbours only, store-and-forward), EQUAL splits: send_base
+  // holds size_ segments of seg_bytes each (segment j destined for rank j); on exit
+  // recv_base holds size_ segments (segment i received from rank i).
+  void ring_all_to_all(
+      const char* send_base, char* recv_base, std::size_t seg_bytes);
+
+ private:
+  // Core mesh primitive shared by all collectives above. Exchanges up to
+  // `total_bytes` bytes with every non-self peer in kChunkSize chunks. Per
+  // chunk [off, off+chunk_bytes):
+  //   - for each peer with want_recv(peer) == true: pre-post a recv (UC needs
+  //     the recv posted before the matching send arrives, Apple TN3205 §12.3);
+  //   - for each peer where send_src(peer, off) != nullptr: memcpy that source
+  //     region into the peer's send buffer and post a send;
+  //   - busy-poll (PG-timeout watchdog) until every posted WR completes,
+  //     calling on_recv(peer, recv_buf, off, chunk_bytes) once per recv
+  //     completion.
+  // The per-peer send_src lets reduce_scatter hand each peer a different slab;
+  // want_recv + a nullable send_src let broadcast post an asymmetric
+  // (root-sends / leaf-receives) WR set.
+  template <typename SendSrc, typename WantRecv, typename OnRecv>
+  void mesh_exchange(
+      std::size_t total_bytes,
+      SendSrc send_src,
+      WantRecv want_recv,
+      OnRecv on_recv);
+
+  // One ring step shared by reduce-scatter and all-gather: send `send_bytes`
+  // from `send_base` to the right neighbor `send_peer` AND receive `recv_bytes`
+  // from the left neighbor `recv_peer`, both in kChunkSize pieces (PIPELINE=1,
+  // one piece in flight per direction). recv posted before send (UC discipline);
+  // per-completion wc.status check + a timeout_ watchdog. on_recv(recv_offset,
+  // src, n_bytes) reduces/copies each received piece into the destination chunk.
+  // The two directions carry independent byte counts (the ragged last chunk
+  // differs per direction).
+  template <typename OnRecv>
+  void ring_step(
+      int send_peer,
+      const char* send_base,
+      std::size_t send_bytes,
+      int recv_peer,
+      std::size_t recv_bytes,
+      OnRecv on_recv);
+
+  int rank_;
+  int size_;
+  std::vector<std::unique_ptr<TCCLConnection>>& connections_;
+  std::vector<TCCLSharedBuffer>& send_buffers_;
+  std::vector<TCCLSharedBuffer>& recv_buffers_;
+  const std::chrono::milliseconds& timeout_;
+  const bool ring_topology_{false};  // true => mesh_exchange must never be reached
+};
+
+} // namespace c10d
+
+// Template implementations. Separated for readability; included at the end
+// of this header so consumers get the full definitions without a separate
+// include.
+#include <torch/csrc/distributed/c10d/ProcessGroupTCCLDetail.ipp>
+
+#endif // USE_C10D_TCCL

--- a/torch/csrc/distributed/c10d/ProcessGroupTCCLDetail.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupTCCLDetail.hpp
@@ -18,7 +18,7 @@ namespace c10d {
 class TCCLConnection;
 class TCCLSharedBuffer;
 
-// ---- Reduction op templates ------------------------------------------------
+// Reduction op templates
 
 
 
@@ -53,7 +53,7 @@ inline void TCCLSumOp<float>::operator()(
   }
 }
 
-// float16 / bfloat16 SUM — accumulate in float32 then round back, matching
+// float16 / bfloat16 SUM - accumulate in float32 then round back, matching
 // PyTorch's reduction semantics for low-precision floats (the dtypes DDP/TP
 // reduce most).
 template <>
@@ -196,13 +196,12 @@ TCCL_DEFINE_MINMAX_VIA_FLOAT(c10::BFloat16)
 #undef TCCL_DEFINE_MINMAX_VIA_FLOAT
 
 
-// ---- TCCLEngine ----------------------------------------------------------
+// TCCLEngine
 
 class TCCLEngine {
  public:
-  // Size of each per-peer staging buffer (hence its registered MR) and the
-  // max bytes per ibv_post_send; larger messages split into a chunk loop and
-  // reduce incrementally. Capped at 512 KB.
+  // Per-peer staging buffer size (hence its MR) and max bytes per ibv_post_send.
+  // Larger messages split into a chunk loop and reduce incrementally.
   static constexpr size_t kChunkSize = 512 * 1024;
 
   TCCLEngine(
@@ -291,13 +290,11 @@ class TCCLEngine {
   // through the per-peer recv buffer (PIPELINE=1). Posts the recv before polling.
   void p2p_recv(int src, char* out, std::size_t nbytes);
 
-  // Mesh (direct) all-to-all. This rank's slab destined for peer p is
-  // [send_base + send_off[p], +send_bytes[p]); the slab received from peer p lands
-  // at [recv_base + recv_off[p], +recv_bytes[p]). Handles equal AND uneven
-  // (alltoallv) splits — sizes are per-peer. The self slot (p == rank_) is a local
-  // memcpy. Every peer is served simultaneously (recv+send in flight per peer,
-  // chunked at kChunkSize, PIPELINE=1), polling each peer's CQ; recv posted before
-  // send (UC discipline).
+  // Mesh (direct) all-to-all. Slab destined for peer p is [send_base +
+  // send_off[p], +send_bytes[p]); slab from peer p lands at [recv_base +
+  // recv_off[p], +recv_bytes[p]). Handles equal AND uneven (alltoallv) splits.
+  // Self slot is a local memcpy. Every peer served simultaneously (recv+send in
+  // flight per peer, kChunkSize, PIPELINE=1), recv before send (UC discipline).
   void all_to_all(
       const char* send_base,
       char* recv_base,
@@ -313,19 +310,15 @@ class TCCLEngine {
       const char* send_base, char* recv_base, std::size_t seg_bytes);
 
  private:
-  // Core mesh primitive shared by all collectives above. Exchanges up to
-  // `total_bytes` bytes with every non-self peer in kChunkSize chunks. Per
-  // chunk [off, off+chunk_bytes):
-  //   - for each peer with want_recv(peer) == true: pre-post a recv (UC needs
-  //     the recv posted before the matching send arrives, Apple TN3205 §12.3);
-  //   - for each peer where send_src(peer, off) != nullptr: memcpy that source
-  //     region into the peer's send buffer and post a send;
-  //   - busy-poll (PG-timeout watchdog) until every posted WR completes,
-  //     calling on_recv(peer, recv_buf, off, chunk_bytes) once per recv
-  //     completion.
-  // The per-peer send_src lets reduce_scatter hand each peer a different slab;
-  // want_recv + a nullable send_src let broadcast post an asymmetric
-  // (root-sends / leaf-receives) WR set.
+  // Core mesh primitive shared by the mesh collectives. Exchanges up to
+  // `total_bytes` with every non-self peer in kChunkSize chunks. Per chunk:
+  //   - want_recv(peer): pre-post a recv (UC needs recv before the matching
+  //     send, Apple TN3205 sec. 12.3)
+  //   - send_src(peer, off) != nullptr: memcpy into the send buffer, post a send
+  //   - busy-poll (timeout watchdog) until all WRs complete, firing
+  //     on_recv(peer, recv_buf, off, chunk_bytes) per recv
+  // Per-peer send_src lets reduce_scatter send each peer a different slab;
+  // want_recv + nullable send_src let broadcast post an asymmetric WR set.
   template <typename SendSrc, typename WantRecv, typename OnRecv>
   void mesh_exchange(
       std::size_t total_bytes,
@@ -334,13 +327,11 @@ class TCCLEngine {
       OnRecv on_recv);
 
   // One ring step shared by reduce-scatter and all-gather: send `send_bytes`
-  // from `send_base` to the right neighbor `send_peer` AND receive `recv_bytes`
-  // from the left neighbor `recv_peer`, both in kChunkSize pieces (PIPELINE=1,
-  // one piece in flight per direction). recv posted before send (UC discipline);
-  // per-completion wc.status check + a timeout_ watchdog. on_recv(recv_offset,
-  // src, n_bytes) reduces/copies each received piece into the destination chunk.
-  // The two directions carry independent byte counts (the ragged last chunk
-  // differs per direction).
+  // from `send_base` to right neighbor `send_peer` AND receive `recv_bytes` from
+  // left neighbor `recv_peer`, in kChunkSize pieces (PIPELINE=1, one in flight
+  // per direction). Recv before send (UC discipline), per-completion wc.status
+  // check + timeout_ watchdog. on_recv reduces/copies each received piece. The
+  // two directions carry independent byte counts (ragged last chunk differs).
   template <typename OnRecv>
   void ring_step(
       int send_peer,
@@ -356,7 +347,8 @@ class TCCLEngine {
   std::vector<TCCLSharedBuffer>& send_buffers_;
   std::vector<TCCLSharedBuffer>& recv_buffers_;
   const std::chrono::milliseconds& timeout_;
-  const bool ring_topology_{false};  // true => mesh_exchange must never be reached
+  // True => mesh_exchange must never be reached
+  const bool ring_topology_{false};
 };
 
 } // namespace c10d

--- a/torch/csrc/distributed/c10d/ProcessGroupTCCLDetail.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupTCCLDetail.hpp
@@ -7,8 +7,13 @@
 #include <algorithm>
 #include <chrono>
 #include <cstddef>
+#include <cstdlib>
 #include <memory>
 #include <vector>
+
+#if defined(__aarch64__) && defined(__APPLE__)
+#include <sys/sysctl.h>
+#endif
 
 #include <c10/util/BFloat16.h>
 #include <c10/util/Half.h>
@@ -67,11 +72,60 @@ inline void TCCLSumOp<c10::Half>::operator()(
   }
 }
 
+// bfloat16 SUM. On FEAT_BF16 hardware (all Apple Silicon with bf16) this reduces
+// with native __bf16 arithmetic (armv8.6-a); set TCCL_NATIVE_BF16=0 to force the
+// float32-accumulate fallback. On Apple aarch64 there is no scalar bf16 FADD, so
+// __bf16 addition lowers to fcvt -> fp32 add -> fcvt: a correctly-rounded single
+// add, bitwise-identical to the fp32-accumulate path (verified), so this is a
+// pure speedup with no change to reduction semantics. The native path avoids the
+// explicit per-element convert loop, which is the bf16 all-reduce cost vs JACCL.
+
+#if defined(__aarch64__) && defined(__APPLE__)
+
+inline bool tcclNativeBf16Enabled() {
+  static bool enabled = []() {
+    int value = 0;
+    std::size_t value_size = sizeof(value);
+    bool hw = sysctlbyname(
+                  "hw.optional.arm.FEAT_BF16",
+                  &value,
+                  &value_size,
+                  nullptr,
+                  0) == 0 &&
+        value != 0;
+    if (!hw) {
+      return false;
+    }
+    const char* e = std::getenv("TCCL_NATIVE_BF16");
+    return e == nullptr || std::atoi(e) != 0;
+  }();
+  return enabled;
+}
+
+__attribute__((target("arch=armv8.6-a"))) inline void tcclNativeBf16Sum(
+    const c10::BFloat16* input,
+    c10::BFloat16* output,
+    std::size_t n) {
+  auto in = reinterpret_cast<const __bf16*>(input);
+  auto out = reinterpret_cast<__bf16*>(output);
+  for (std::size_t i = 0; i < n; ++i) {
+    out[i] = out[i] + in[i];
+  }
+}
+
+#endif // defined(__aarch64__) && defined(__APPLE__)
+
 template <>
 inline void TCCLSumOp<c10::BFloat16>::operator()(
     const c10::BFloat16* input,
     c10::BFloat16* output,
     std::size_t n) const {
+#if defined(__aarch64__) && defined(__APPLE__)
+  if (tcclNativeBf16Enabled()) {
+    tcclNativeBf16Sum(input, output, n);
+    return;
+  }
+#endif
   for (std::size_t i = 0; i < n; ++i) {
     output[i] = static_cast<c10::BFloat16>(
         static_cast<float>(output[i]) + static_cast<float>(input[i]));
@@ -204,12 +258,18 @@ class TCCLEngine {
   // Larger messages split into a chunk loop and reduce incrementally.
   static constexpr size_t kChunkSize = 512 * 1024;
 
+  // Pipeline depth for the bidirectional ring: pieces in flight per stream, with
+  // an equal number of double-buffered staging slots. 2 matches JACCL's PIPELINE.
+  static constexpr int kPipelineDepth = 2;
+
   TCCLEngine(
       int rank,
       int size,
       std::vector<std::unique_ptr<TCCLConnection>>& connections,
       std::vector<TCCLSharedBuffer>& send_buffers,
       std::vector<TCCLSharedBuffer>& recv_buffers,
+      std::vector<TCCLSharedBuffer>& pipe_send_buffers,
+      std::vector<TCCLSharedBuffer>& pipe_recv_buffers,
       const std::chrono::milliseconds& timeout,
       bool ring_topology = false)
       : rank_(rank),
@@ -217,6 +277,8 @@ class TCCLEngine {
         connections_(connections),
         send_buffers_(send_buffers),
         recv_buffers_(recv_buffers),
+        pipe_send_buffers_(pipe_send_buffers),
+        pipe_recv_buffers_(pipe_recv_buffers),
         timeout_(timeout),
         ring_topology_(ring_topology) {}
 
@@ -270,6 +332,24 @@ class TCCLEngine {
       const std::vector<void*>& out_ptrs,
       std::size_t per_rank_bytes);
 
+  // Mesh gather (rooted): the root collects rank r's `per_rank_bytes` shard into
+  // out_ptrs[r]; every non-root rank sends `in`. out_ptrs is root-only (size_
+  // entries); pass empty elsewhere.
+  void gather(
+      const void* in,
+      const std::vector<void*>& out_ptrs,
+      std::size_t per_rank_bytes,
+      int root);
+
+  // Mesh scatter (rooted): the root sends in_ptrs[r] (`per_rank_bytes`) to rank r;
+  // every non-root rank receives its slice into `out`. in_ptrs is root-only
+  // (size_ entries).
+  void scatter(
+      const std::vector<const void*>& in_ptrs,
+      void* out,
+      std::size_t per_rank_bytes,
+      int root);
+
   // Mesh reduce-scatter. in_chunks[p] points at this rank's contribution
   // destined for peer p (count_per_rank elements); on exit `out` holds the
   // element-wise reduction across ranks of chunk number rank_. Reduces straight
@@ -319,7 +399,11 @@ class TCCLEngine {
   //     on_recv(peer, recv_buf, off, chunk_bytes) per recv
   // Per-peer send_src lets reduce_scatter send each peer a different slab;
   // want_recv + nullable send_src let broadcast post an asymmetric WR set.
-  template <typename SendSrc, typename WantRecv, typename OnRecv>
+  // Pipeline=true drives a depth-kPipelineDepth per-peer pipeline at size_>=3;
+  // safe ONLY when on_recv is cheap (a byte copy, e.g. all_gather) - a slow
+  // on_recv (reduce) held over a recv buffer starves the all-to-all under UC drop
+  // and deadlocks, so reduce collectives keep the default depth-1 path.
+  template <bool Pipeline = false, typename SendSrc, typename WantRecv, typename OnRecv>
   void mesh_exchange(
       std::size_t total_bytes,
       SendSrc send_src,
@@ -341,11 +425,40 @@ class TCCLEngine {
       std::size_t recv_bytes,
       OnRecv on_recv);
 
+  // Bidirectional ring step: two counter-rotating rings concurrently over the two
+  // neighbor links, so both links carry traffic in both directions (~2x the
+  // unidirectional ring bandwidth; JACCL all_reduce<MAX_DIR=2> equivalent).
+  //   ring A (clockwise): send sendA_bytes from sendA_base to `right`, recv
+  //     recvA_bytes from `left`, firing on_recv_A per received piece.
+  //   ring B (counter-clockwise): send sendB_bytes from sendB_base to `left`, recv
+  //     recvB_bytes from `right`, firing on_recv_B per received piece.
+  // Four independent streams (A_send/A_recv/B_send/B_recv), kChunkSize pieces,
+  // PIPELINE=1 per stream. Completions demuxed by the (isSend, peer) wr_id: a
+  // connection's CQ carries one send stream and one recv stream (different rings).
+  // Recv posted before send (UC discipline), per-WR wc.status check, timeout_ watchdog.
+  template <typename OnRecvA, typename OnRecvB>
+  void bidir_ring_step(
+      int right,
+      int left,
+      const char* sendA_base,
+      std::size_t sendA_bytes,
+      std::size_t recvA_bytes,
+      OnRecvA on_recv_A,
+      const char* sendB_base,
+      std::size_t sendB_bytes,
+      std::size_t recvB_bytes,
+      OnRecvB on_recv_B);
+
   int rank_;
   int size_;
   std::vector<std::unique_ptr<TCCLConnection>>& connections_;
   std::vector<TCCLSharedBuffer>& send_buffers_;
   std::vector<TCCLSharedBuffer>& recv_buffers_;
+  // Depth-indexed staging pools for the pipelined bidirectional ring, flat
+  // [peer * kPipelineDepth + slot]. Separate from send_buffers_/recv_buffers_
+  // (which stay one-per-peer for the PIPELINE=1 mesh/p2p/broadcast paths).
+  std::vector<TCCLSharedBuffer>& pipe_send_buffers_;
+  std::vector<TCCLSharedBuffer>& pipe_recv_buffers_;
   const std::chrono::milliseconds& timeout_;
   // True => mesh_exchange must never be reached
   const bool ring_topology_{false};

--- a/torch/csrc/distributed/c10d/ProcessGroupTCCLDetail.ipp
+++ b/torch/csrc/distributed/c10d/ProcessGroupTCCLDetail.ipp
@@ -1,0 +1,990 @@
+#pragma once
+
+// Template implementations for ProcessGroupTCCLDetail.hpp. Pulled in via
+// the trailing include in that header — do not include directly.
+
+#ifdef USE_C10D_TCCL
+
+#include <algorithm>
+#include <chrono>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include <c10/util/Exception.h>
+
+#include <torch/csrc/distributed/c10d/TCCLUtils.hpp>
+#include <torch/csrc/distributed/c10d/exception.h>
+
+#include <infiniband/verbs.h>  // for ibv_wc, IBV_WC_SUCCESS
+
+namespace c10d {
+
+// Work-request id encoding for completion-event demultiplexing.
+//   bit 63          : 1 = send, 0 = recv
+//   bits 62..32     : reserved
+//   bits 31..0      : peer rank
+//
+// Every collective posts WRs through mesh_exchange using this scheme so
+// completion polling can identify which (peer, direction) a completion is
+// for. At PIPELINE=1 there is one in-flight chunk per (peer, direction), so
+// (direction, peer) fully identifies a completion; the reserved bits leave room
+// to encode extra fields if that changes.
+namespace tccl_wr {
+
+constexpr uint64_t kSendBit = 1ULL << 63;
+
+inline uint64_t makeSend(int peer) {
+  return kSendBit | static_cast<uint64_t>(peer);
+}
+
+inline uint64_t makeRecv(int peer) {
+  return static_cast<uint64_t>(peer);
+}
+
+inline bool isSend(uint64_t wr_id) {
+  return (wr_id & kSendBit) != 0;
+}
+
+inline int peer(uint64_t wr_id) {
+  return static_cast<int>(wr_id & 0xFFFFFFFFULL);
+}
+
+} // namespace tccl_wr
+
+// ---- mesh_exchange ---------------------------------------------------------
+//
+// The one place the UC-ordering discipline (recv posted before send) and the
+// WC-status / duplicate-completion / PG-timeout-watchdog checks live. All four
+// collectives below are thin adapters over this. See the declaration in
+// ProcessGroupTCCLDetail.hpp for the contract.
+template <typename SendSrc, typename WantRecv, typename OnRecv>
+void TCCLEngine::mesh_exchange(
+    std::size_t total_bytes,
+    SendSrc send_src,
+    WantRecv want_recv,
+    OnRecv on_recv) {
+  // Ring topology has null connection slots for all non-neighbor peers;
+  // mesh_exchange indexes every peer, so reaching it here would null-deref.
+  // Dispatch must force the ring path in ring mode — fail loud if it didn't.
+  TORCH_CHECK(
+      !ring_topology_,
+      "TCCL: mesh_exchange invoked under ring topology — a collective's "
+      "dispatch failed to select its ring variant (internal error).");
+  if (size_ <= 1) {
+    return;
+  }
+
+  // Pre-allocated scratch for completion events; a few peers' worth per poll.
+  std::vector<ibv_wc> wcs(8);
+
+  std::size_t offset = 0;
+  while (offset < total_bytes) {
+    const std::size_t chunk_bytes =
+        std::min(kChunkSize, total_bytes - offset);
+
+    // Per-peer participation for this chunk.
+    std::vector<char> want_send(size_, 0);
+    std::vector<char> will_recv(size_, 0);
+    int expected_completions = 0;
+
+    // Step 1: pre-post recvs FIRST. UC requires the recv posted before the
+    // matching send arrives (Apple TN3205 §12.3 credit-based flow control);
+    // post every recv before any send.
+    for (int peer = 0; peer < size_; ++peer) {
+      if (peer == rank_) continue;
+      if (want_recv(peer)) {
+        connections_[peer]->postRecv(
+            recv_buffers_[peer], chunk_bytes, tccl_wr::makeRecv(peer));
+        will_recv[peer] = 1;
+        ++expected_completions;
+      }
+    }
+
+    // Step 2: for every peer with a non-null source, copy this chunk into the
+    // peer's send buffer and post a send. send_src is per-peer so
+    // reduce_scatter can hand each peer a different slab of `in`; a null
+    // source means "no send to this peer" (broadcast on a non-root rank).
+    for (int peer = 0; peer < size_; ++peer) {
+      if (peer == rank_) continue;
+      const void* src = send_src(peer, offset);
+      if (src == nullptr) continue;
+      std::memcpy(send_buffers_[peer].data(), src, chunk_bytes);
+      connections_[peer]->postSend(
+          send_buffers_[peer], chunk_bytes, tccl_wr::makeSend(peer));
+      want_send[peer] = 1;
+      ++expected_completions;
+    }
+
+    // Step 3: busy-poll each participating peer's CQ until every posted WR
+    // completes. on_recv fires once per recv completion (the recv buffer is
+    // safe to read at that point).
+    std::vector<char> send_done(size_, 0);
+    std::vector<char> recv_done(size_, 0);
+    int completions_seen = 0;
+
+    auto deadline =
+        std::chrono::steady_clock::now() + timeout_;
+
+    while (completions_seen < expected_completions) {
+      bool made_progress = false;
+      for (int peer = 0; peer < size_; ++peer) {
+        if (peer == rank_) continue;
+        const bool send_pending = want_send[peer] && !send_done[peer];
+        const bool recv_pending = will_recv[peer] && !recv_done[peer];
+        if (!send_pending && !recv_pending) continue;
+
+        int n = connections_[peer]->pollCq(
+            static_cast<int>(wcs.size()), wcs.data());
+        if (n == 0) continue;
+        made_progress = true;
+
+        for (int i = 0; i < n; ++i) {
+          const ibv_wc& wc = wcs[i];
+          TORCH_CHECK_WITH(
+              DistBackendError,
+              wc.status == IBV_WC_SUCCESS,
+              "TCCL mesh: WC failed status=",
+              static_cast<int>(wc.status),
+              " (peer=",
+              peer,
+              ", wr_id=",
+              wc.wr_id,
+              ")");
+
+          const int wc_peer = tccl_wr::peer(wc.wr_id);
+          TORCH_INTERNAL_ASSERT(
+              wc_peer == peer,
+              "TCCL mesh: completion peer mismatch ",
+              wc_peer,
+              " vs ",
+              peer);
+
+          if (tccl_wr::isSend(wc.wr_id)) {
+            TORCH_CHECK_WITH(
+                DistBackendError,
+                want_send[peer] && !send_done[peer],
+                "TCCL mesh: unexpected or duplicate send completion for peer ",
+                peer);
+            send_done[peer] = 1;
+          } else {
+            TORCH_CHECK_WITH(
+                DistBackendError,
+                will_recv[peer] && !recv_done[peer],
+                "TCCL mesh: unexpected or duplicate recv completion for peer ",
+                peer);
+            recv_done[peer] = 1;
+            // Recv complete — the peer's chunk is in recv_buffers_[peer].
+            on_recv(peer, recv_buffers_[peer].data(), offset, chunk_bytes);
+          }
+          ++completions_seen;
+        }
+      }
+
+      if (!made_progress &&
+          std::chrono::steady_clock::now() > deadline) {
+        std::string outstanding;
+        for (int p = 0; p < size_; ++p) {
+          if (p == rank_) continue;
+          if (want_send[p] && !send_done[p])
+            outstanding += " send->" + std::to_string(p);
+          if (will_recv[p] && !recv_done[p])
+            outstanding += " recv<-" + std::to_string(p);
+        }
+        TORCH_CHECK_WITH(
+            DistBackendError,
+            false,
+            "TCCL mesh: timed out after ",
+            timeout_.count(),
+            " ms waiting for completions at offset ",
+            offset,
+            " (total_bytes=",
+            total_bytes,
+            ", chunk_bytes=",
+            chunk_bytes,
+            "). Saw ",
+            completions_seen,
+            "/",
+            expected_completions,
+            " completions; outstanding WRs:",
+            outstanding,
+            ". The poll bound is the process-group timeout "
+            "(init_process_group(timeout=) / set_timeout); a persistent stall "
+            "here indicates a dropped UC packet (no hardware retransmission).");
+      }
+    }
+
+    offset += chunk_bytes;
+  }
+}
+
+// ---- all_reduce ------------------------------------------------------------
+template <typename T, typename ReduceOp>
+void TCCLEngine::all_reduce(
+    T* data,
+    std::size_t count,
+    ReduceOp reduce_op) {
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      data != nullptr,
+      "TCCL mesh: all_reduce called with null data pointer.");
+  if (size_ <= 1) {
+    return;
+  }
+
+  char* base = reinterpret_cast<char*>(data);
+  mesh_exchange(
+      count * sizeof(T),
+      // Send every peer this rank's chunk at `offset`.
+      [&](int /*peer*/, std::size_t offset) -> const void* {
+        return base + offset;
+      },
+      // Receive from every peer.
+      [](int /*peer*/) { return true; },
+      // Reduce the peer's chunk into our output in place.
+      [&](int /*peer*/,
+          const void* recv_ptr,
+          std::size_t offset,
+          std::size_t chunk_bytes) {
+        reduce_op(
+            static_cast<const T*>(recv_ptr),
+            reinterpret_cast<T*>(base + offset),
+            chunk_bytes / sizeof(T));
+      });
+}
+
+// ---- ring_step -------------------------------------------------------------
+//
+// One step of a ring collective: stream `send_bytes` from `send_base` to the
+// right neighbor while streaming `recv_bytes` from the left neighbor, both in
+// kChunkSize pieces with one piece in flight per direction (PIPELINE=1). The
+// recv is posted before the send (UC credit-flow discipline), every completion
+// is status-checked, and a timeout_ watchdog bounds the wait. on_recv handles
+// each received piece (reduce or copy).
+template <typename OnRecv>
+void TCCLEngine::ring_step(
+    int send_peer,
+    const char* send_base,
+    std::size_t send_bytes,
+    int recv_peer,
+    std::size_t recv_bytes,
+    OnRecv on_recv) {
+  std::vector<ibv_wc> wcs(8);
+  std::size_t send_off = 0;       // bytes acknowledged sent
+  std::size_t recv_off = 0;       // bytes received and handled
+  std::size_t send_inflight = 0;  // size of the in-flight send piece (0 = none)
+  std::size_t recv_inflight = 0;  // size of the in-flight recv piece (0 = none)
+
+  auto post_recv_piece = [&]() {
+    if (recv_inflight == 0 && recv_off < recv_bytes) {
+      recv_inflight = std::min(kChunkSize, recv_bytes - recv_off);
+      connections_[recv_peer]->postRecv(
+          recv_buffers_[recv_peer], recv_inflight, tccl_wr::makeRecv(recv_peer));
+    }
+  };
+  auto post_send_piece = [&]() {
+    if (send_inflight == 0 && send_off < send_bytes) {
+      send_inflight = std::min(kChunkSize, send_bytes - send_off);
+      std::memcpy(
+          send_buffers_[send_peer].data(), send_base + send_off, send_inflight);
+      connections_[send_peer]->postSend(
+          send_buffers_[send_peer], send_inflight, tccl_wr::makeSend(send_peer));
+    }
+  };
+
+  // UC discipline: recv posted before the matching send can arrive.
+  post_recv_piece();
+  post_send_piece();
+
+  auto deadline = std::chrono::steady_clock::now() + timeout_;
+  while (recv_off < recv_bytes || send_off < send_bytes) {
+    bool made_progress = false;
+    // For a ring (size_ > 2) recv_peer != send_peer, so each peer's CQ carries
+    // exactly one direction; poll the one(s) with work outstanding.
+    for (int peer : {recv_peer, send_peer}) {
+      const bool pending =
+          (peer == recv_peer ? recv_inflight : send_inflight) != 0;
+      if (!pending) continue;
+      int n = connections_[peer]->pollCq(static_cast<int>(wcs.size()), wcs.data());
+      if (n == 0) continue;
+      made_progress = true;
+      for (int i = 0; i < n; ++i) {
+        const ibv_wc& wc = wcs[i];
+        TORCH_CHECK_WITH(
+            DistBackendError,
+            wc.status == IBV_WC_SUCCESS,
+            "TCCL ring: WC failed status=",
+            static_cast<int>(wc.status),
+            " (peer=",
+            peer,
+            ", wr_id=",
+            wc.wr_id,
+            ")");
+        if (tccl_wr::isSend(wc.wr_id)) {
+          send_off += send_inflight;
+          send_inflight = 0;
+          post_send_piece();
+        } else {
+          on_recv(recv_off, recv_buffers_[recv_peer].data(), recv_inflight);
+          recv_off += recv_inflight;
+          recv_inflight = 0;
+          post_recv_piece();
+        }
+      }
+    }
+    if (!made_progress && std::chrono::steady_clock::now() > deadline) {
+      TORCH_CHECK_WITH(
+          DistBackendError,
+          false,
+          "TCCL ring: timed out after ",
+          timeout_.count(),
+          " ms. send ",
+          send_off,
+          "/",
+          send_bytes,
+          " to peer ",
+          send_peer,
+          ", recv ",
+          recv_off,
+          "/",
+          recv_bytes,
+          " from peer ",
+          recv_peer,
+          ". The poll bound is the process-group timeout "
+          "(init_process_group(timeout=) / set_timeout); a persistent stall "
+          "here indicates a dropped UC packet (no hardware retransmission).");
+    }
+  }
+}
+
+// ---- ring_all_reduce -------------------------------------------------------
+//
+// Bandwidth-optimal ring: reduce-scatter (size_-1 steps) then all-gather
+// (size_-1 steps). At step s the rank sends chunk (rank-s) to the right and
+// receives chunk (rank-s-1) from the left — the chunk it just reduced — so each
+// step depends on the previous (synchronous, no cross-step pipelining yet).
+// Traffic is bounded to the two ring neighbors (the avoidance strategy for
+// large/bf16 messages).
+template <typename T, typename ReduceOp>
+void TCCLEngine::ring_all_reduce(
+    T* data,
+    std::size_t count,
+    ReduceOp reduce_op) {
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      data != nullptr,
+      "TCCL ring: all_reduce called with null data pointer.");
+  if (size_ <= 1) {
+    return;
+  }
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      size_ > 2,
+      "TCCL ring_all_reduce requires size_ > 2 (dispatch uses mesh for <=2).");
+
+  const int N = size_;
+  const int right = (rank_ + 1) % N;
+  const int left = (rank_ + N - 1) % N;
+  char* base = reinterpret_cast<char*>(data);
+
+  // Split `count` elements into N contiguous chunks of `chunk` elements (the
+  // last chunk may be short or empty). Chunk c is elements [c*chunk, end_c).
+  const std::size_t chunk = (count + static_cast<std::size_t>(N) - 1) / N;
+  auto lo = [&](int c) {
+    return std::min<std::size_t>(static_cast<std::size_t>(c) * chunk, count);
+  };
+  auto hi = [&](int c) {
+    return std::min<std::size_t>((static_cast<std::size_t>(c) + 1) * chunk, count);
+  };
+  auto chunk_nbytes = [&](int c) { return (hi(c) - lo(c)) * sizeof(T); };
+  auto chunk_ptr = [&](int c) { return base + lo(c) * sizeof(T); };
+
+  // Reduce-scatter: send chunk (rank-s) right, recv+reduce chunk (rank-s-1) left.
+  for (int s = 0; s < N - 1; ++s) {
+    const int send_c = ((rank_ - s) % N + N) % N;
+    const int recv_c = (send_c - 1 + N) % N;
+    char* recv_dst = chunk_ptr(recv_c);
+    ring_step(
+        right,
+        chunk_ptr(send_c),
+        chunk_nbytes(send_c),
+        left,
+        chunk_nbytes(recv_c),
+        [&](std::size_t off, const void* src, std::size_t nbytes) {
+          reduce_op(
+              static_cast<const T*>(src),
+              reinterpret_cast<T*>(recv_dst + off),
+              nbytes / sizeof(T));
+        });
+  }
+
+  // All-gather: send chunk (rank-s+1) right, recv+overwrite chunk (rank-s) left.
+  for (int s = 0; s < N - 1; ++s) {
+    const int send_c = ((rank_ - s + 1) % N + N) % N;
+    const int recv_c = (send_c - 1 + N) % N;
+    char* recv_dst = chunk_ptr(recv_c);
+    ring_step(
+        right,
+        chunk_ptr(send_c),
+        chunk_nbytes(send_c),
+        left,
+        chunk_nbytes(recv_c),
+        [&](std::size_t off, const void* src, std::size_t nbytes) {
+          std::memcpy(recv_dst + off, src, nbytes);
+        });
+  }
+}
+
+// ---- ring_all_gather -------------------------------------------------------
+inline void TCCLEngine::ring_all_gather(
+    const void* in,
+    const std::vector<void*>& out_ptrs,
+    std::size_t per_rank_bytes) {
+  TORCH_CHECK_WITH(
+      DistBackendError, in != nullptr,
+      "TCCL ring: all_gather called with null input pointer.");
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      static_cast<int>(out_ptrs.size()) == size_,
+      "TCCL ring all_gather expects ",
+      size_,
+      " output pointers, got ",
+      out_ptrs.size());
+  // Self-placement: our own shard goes into our slot.
+  std::memcpy(out_ptrs[rank_], in, per_rank_bytes);
+  if (size_ <= 1) {
+    return;
+  }
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      size_ > 2,
+      "TCCL ring_all_gather requires size_ > 2 (dispatch uses mesh for <=2).");
+
+  const int N = size_;
+  const int right = (rank_ + 1) % N;
+  const int left = (rank_ + N - 1) % N;
+  // Step k: send shard (rank-k) to the right, receive shard (rank-k-1) from the
+  // left (the shard we just received / our own at k=0), copy it into its slot.
+  for (int k = 0; k < N - 1; ++k) {
+    const int send_c = ((rank_ - k) % N + N) % N;
+    const int recv_c = (send_c - 1 + N) % N;
+    char* recv_dst = reinterpret_cast<char*>(out_ptrs[recv_c]);
+    ring_step(
+        right,
+        reinterpret_cast<const char*>(out_ptrs[send_c]),
+        per_rank_bytes,
+        left,
+        per_rank_bytes,
+        [&](std::size_t off, const void* src, std::size_t nbytes) {
+          std::memcpy(recv_dst + off, src, nbytes);
+        });
+  }
+}
+
+// ---- ring_reduce_scatter ---------------------------------------------------
+template <typename T, typename ReduceOp>
+void TCCLEngine::ring_reduce_scatter(
+    const std::vector<const T*>& in_chunks,
+    T* out,
+    std::size_t count_per_rank,
+    ReduceOp reduce_op) {
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      static_cast<int>(in_chunks.size()) == size_ && out != nullptr,
+      "TCCL ring: reduce_scatter expects size_ input-chunk pointers and a "
+      "non-null output.");
+  const int N = size_;
+  const std::size_t chunk_bytes = count_per_rank * sizeof(T);
+  if (N <= 1) {
+    std::memcpy(out, in_chunks[0], chunk_bytes);
+    return;
+  }
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      N > 2,
+      "TCCL ring_reduce_scatter requires size_ > 2 (dispatch uses mesh for <=2).");
+
+  // Ring reduce-scatter accumulates partials in place, so it needs a mutable
+  // copy of all N input chunks, gathered here from the per-rank pointers (mesh
+  // reduce_scatter reduces straight into `out` and needs no scratch — a fair
+  // cost difference to keep in mind for the bench).
+  std::vector<char> work(static_cast<std::size_t>(N) * chunk_bytes);
+  for (int c = 0; c < N; ++c) {
+    std::memcpy(
+        work.data() + static_cast<std::size_t>(c) * chunk_bytes,
+        in_chunks[c],
+        chunk_bytes);
+  }
+  const int right = (rank_ + 1) % N;
+  const int left = (rank_ + N - 1) % N;
+  auto chunk = [&](int c) {
+    return work.data() + static_cast<std::size_t>(c) * chunk_bytes;
+  };
+  // Step s: send chunk (rank-s-1) right, recv+reduce chunk (rank-s-2) from left
+  // (carry-forward: what we send at s is what we reduced at s-1). This lands the
+  // full reduction of chunk rank_ at work[rank_] after N-1 steps. (Indexing is
+  // validated against mesh reduce_scatter by the correctness test.)
+  for (int s = 0; s < N - 1; ++s) {
+    const int send_c = ((rank_ - s - 1) % N + N) % N;
+    const int recv_c = ((send_c - 1) % N + N) % N;
+    char* recv_chunk = chunk(recv_c);
+    ring_step(
+        right,
+        chunk(send_c),
+        chunk_bytes,
+        left,
+        chunk_bytes,
+        [&](std::size_t off, const void* src, std::size_t nbytes) {
+          reduce_op(
+              static_cast<const T*>(src),
+              reinterpret_cast<T*>(recv_chunk + off),
+              nbytes / sizeof(T));
+        });
+  }
+  std::memcpy(out, chunk(rank_), chunk_bytes);
+}
+
+// ---- ring_broadcast --------------------------------------------------------
+//
+// Store-and-forward along the ring: chunk by chunk, the root sends to its right;
+// each non-root rank receives a chunk from its left, writes it to the output, and
+// (unless it is the chain tail = root's left neighbour) forwards it to its right.
+// RDMA does not relay, so forwarding is explicit. Per-chunk synchronous, with the
+// recv posted before the matching send (UC credit-flow), a wc.status check, and
+// the PG-timeout watchdog.
+inline void TCCLEngine::ring_broadcast(
+    void* data, std::size_t total_bytes, int root) {
+  if (size_ <= 1) {
+    return;
+  }
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      size_ > 2,
+      "TCCL ring_broadcast requires size_ > 2 (dispatch uses mesh for <=2).");
+  const int N = size_;
+  const int pos = ((rank_ - root) % N + N) % N;  // 0 = root ... N-1 = chain tail
+  const bool is_root = (pos == 0);
+  const bool is_tail = (pos == N - 1);
+  const int right = (rank_ + 1) % N;
+  const int left = (rank_ + N - 1) % N;
+  char* base = reinterpret_cast<char*>(data);
+  std::vector<ibv_wc> wcs(8);
+
+  auto poll_one = [&](int peer, bool want_send) {
+    auto deadline = std::chrono::steady_clock::now() + timeout_;
+    while (true) {
+      int n = connections_[peer]->pollCq(static_cast<int>(wcs.size()), wcs.data());
+      for (int i = 0; i < n; ++i) {
+        TORCH_CHECK_WITH(
+            DistBackendError,
+            wcs[i].status == IBV_WC_SUCCESS,
+            "TCCL ring_broadcast: WC failed status=",
+            static_cast<int>(wcs[i].status),
+            " (peer=", peer, ")");
+        if (tccl_wr::isSend(wcs[i].wr_id) == want_send) {
+          return;
+        }
+      }
+      if (n == 0 && std::chrono::steady_clock::now() > deadline) {
+        TORCH_CHECK_WITH(
+            DistBackendError, false,
+            "TCCL ring_broadcast: timed out after ", timeout_.count(),
+            " ms (root=", root, ", pos=", pos, "). The poll bound is the process-"
+            "group timeout (init_process_group(timeout=) / set_timeout).");
+      }
+    }
+  };
+
+  std::size_t off = 0;
+  while (off < total_bytes) {
+    const std::size_t n = std::min(kChunkSize, total_bytes - off);
+    if (!is_root) {  // receive this chunk from the left, write to output
+      connections_[left]->postRecv(recv_buffers_[left], n, tccl_wr::makeRecv(left));
+      poll_one(left, /*want_send=*/false);
+      std::memcpy(base + off, recv_buffers_[left].data(), n);
+    }
+    if (!is_tail) {  // forward (root: from data; others: the just-received chunk)
+      std::memcpy(send_buffers_[right].data(), base + off, n);
+      connections_[right]->postSend(send_buffers_[right], n, tccl_wr::makeSend(right));
+      poll_one(right, /*want_send=*/true);
+    }
+    off += n;
+  }
+}
+
+// ---- broadcast -------------------------------------------------------------
+inline void TCCLEngine::broadcast(
+    void* data,
+    std::size_t total_bytes,
+    int root) {
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      data != nullptr,
+      "TCCL mesh: broadcast called with null data pointer.");
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      root >= 0 && root < size_,
+      "TCCL mesh: broadcast root ",
+      root,
+      " out of range [0, ",
+      size_,
+      ").");
+  if (size_ <= 1) {
+    return;
+  }
+
+  const bool is_root = (rank_ == root);
+  char* base = reinterpret_cast<char*>(data);
+  mesh_exchange(
+      total_bytes,
+      // Root sends its data to every peer; non-root sends nothing.
+      [&](int /*peer*/, std::size_t offset) -> const void* {
+        return is_root ? (base + offset) : nullptr;
+      },
+      // Only a non-root rank receives, and only from the root.
+      [&](int peer) { return !is_root && peer == root; },
+      // Copy the received chunk into our buffer (non-root path only).
+      [&](int /*peer*/,
+          const void* recv_ptr,
+          std::size_t offset,
+          std::size_t chunk_bytes) {
+        std::memcpy(base + offset, recv_ptr, chunk_bytes);
+      });
+}
+
+// ---- all_gather ------------------------------------------------------------
+inline void TCCLEngine::all_gather(
+    const void* in,
+    const std::vector<void*>& out_ptrs,
+    std::size_t per_rank_bytes) {
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      in != nullptr,
+      "TCCL mesh: all_gather called with null input pointer.");
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      static_cast<int>(out_ptrs.size()) == size_,
+      "TCCL mesh: all_gather expects ",
+      size_,
+      " output pointers, got ",
+      out_ptrs.size());
+
+  const char* in_base = reinterpret_cast<const char*>(in);
+
+  // Self-placement: our own shard goes into our slot.
+  std::memcpy(out_ptrs[rank_], in_base, per_rank_bytes);
+  if (size_ <= 1) {
+    return;
+  }
+
+  mesh_exchange(
+      per_rank_bytes,
+      // Send every peer our whole shard at `offset`.
+      [&](int /*peer*/, std::size_t offset) -> const void* {
+        return in_base + offset;
+      },
+      // Receive from every peer.
+      [](int /*peer*/) { return true; },
+      // Place the peer's shard at its destination slot.
+      [&](int peer,
+          const void* recv_ptr,
+          std::size_t offset,
+          std::size_t chunk_bytes) {
+        std::memcpy(
+            reinterpret_cast<char*>(out_ptrs[peer]) + offset,
+            recv_ptr,
+            chunk_bytes);
+      });
+}
+
+// ---- reduce_scatter --------------------------------------------------------
+template <typename T, typename ReduceOp>
+void TCCLEngine::reduce_scatter(
+    const std::vector<const T*>& in_chunks,
+    T* out,
+    std::size_t count_per_rank,
+    ReduceOp reduce_op) {
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      static_cast<int>(in_chunks.size()) == size_ && out != nullptr,
+      "TCCL mesh: reduce_scatter expects size_ input-chunk pointers and a "
+      "non-null output.");
+
+  // Seed our output with our own contribution — our chunk destined for rank_.
+  // (Out-of-place, so we cannot rely on `out` already holding it the way an
+  // in-place ring reduce-scatter would.)
+  std::memcpy(
+      out, in_chunks[rank_], count_per_rank * sizeof(T));
+  if (size_ <= 1) {
+    return;
+  }
+
+  const std::size_t per_rank_bytes = count_per_rank * sizeof(T);
+
+  mesh_exchange(
+      per_rank_bytes,
+      // Send peer p the chunk of our input destined for it: in_chunks[p].
+      [&](int peer, std::size_t offset) -> const void* {
+        return reinterpret_cast<const char*>(in_chunks[peer]) + offset;
+      },
+      // Receive from every peer.
+      [](int /*peer*/) { return true; },
+      // Reduce the peer's contribution (their chunk destined for rank_) into
+      // our output in place.
+      [&](int /*peer*/,
+          const void* recv_ptr,
+          std::size_t offset,
+          std::size_t chunk_bytes) {
+        reduce_op(
+            static_cast<const T*>(recv_ptr),
+            reinterpret_cast<T*>(reinterpret_cast<char*>(out) + offset),
+            chunk_bytes / sizeof(T));
+      });
+}
+
+// ---- point-to-point send / recv -------------------------------------------
+inline void TCCLEngine::p2p_send(
+    int dst, const char* in, std::size_t nbytes) {
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      dst >= 0 && dst < size_ && dst != rank_,
+      "TCCL p2p_send: invalid dst ", dst, " (rank ", rank_, ", size ", size_, ").");
+  std::vector<ibv_wc> wcs(8);
+  std::size_t off = 0;        // bytes acknowledged sent
+  std::size_t inflight = 0;   // size of the in-flight chunk (0 = none)
+  auto post = [&]() {
+    if (inflight == 0 && off < nbytes) {
+      inflight = std::min(kChunkSize, nbytes - off);
+      std::memcpy(send_buffers_[dst].data(), in + off, inflight);
+      connections_[dst]->postSend(
+          send_buffers_[dst], inflight, tccl_wr::makeSend(dst));
+    }
+  };
+  post();
+  auto deadline = std::chrono::steady_clock::now() + timeout_;
+  while (off < nbytes) {
+    int n = connections_[dst]->pollCq(static_cast<int>(wcs.size()), wcs.data());
+    if (n == 0) {
+      TORCH_CHECK_WITH(
+          DistBackendError,
+          std::chrono::steady_clock::now() <= deadline,
+          "TCCL p2p_send: timed out after ", timeout_.count(), " ms sending ",
+          off, "/", nbytes, " bytes to peer ", dst,
+          ". The poll bound is the process-group timeout; a persistent stall here "
+          "indicates a dropped UC packet (no hardware retransmission).");
+      continue;
+    }
+    for (int i = 0; i < n; ++i) {
+      TORCH_CHECK_WITH(
+          DistBackendError,
+          wcs[i].status == IBV_WC_SUCCESS,
+          "TCCL p2p_send: WC failed status=", static_cast<int>(wcs[i].status),
+          " (peer=", dst, ").");
+      off += inflight;
+      inflight = 0;
+      post();
+    }
+    deadline = std::chrono::steady_clock::now() + timeout_;  // progress -> reset
+  }
+}
+
+inline void TCCLEngine::p2p_recv(
+    int src, char* out, std::size_t nbytes) {
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      src >= 0 && src < size_ && src != rank_,
+      "TCCL p2p_recv: invalid src ", src, " (rank ", rank_, ", size ", size_, ").");
+  std::vector<ibv_wc> wcs(8);
+  std::size_t off = 0;        // bytes received and handled
+  std::size_t inflight = 0;   // size of the in-flight chunk (0 = none)
+  auto post = [&]() {
+    if (inflight == 0 && off < nbytes) {
+      inflight = std::min(kChunkSize, nbytes - off);
+      connections_[src]->postRecv(
+          recv_buffers_[src], inflight, tccl_wr::makeRecv(src));
+    }
+  };
+  post();
+  auto deadline = std::chrono::steady_clock::now() + timeout_;
+  while (off < nbytes) {
+    int n = connections_[src]->pollCq(static_cast<int>(wcs.size()), wcs.data());
+    if (n == 0) {
+      TORCH_CHECK_WITH(
+          DistBackendError,
+          std::chrono::steady_clock::now() <= deadline,
+          "TCCL p2p_recv: timed out after ", timeout_.count(), " ms receiving ",
+          off, "/", nbytes, " bytes from peer ", src,
+          ". The poll bound is the process-group timeout; a persistent stall here "
+          "indicates a dropped UC packet (no hardware retransmission).");
+      continue;
+    }
+    for (int i = 0; i < n; ++i) {
+      TORCH_CHECK_WITH(
+          DistBackendError,
+          wcs[i].status == IBV_WC_SUCCESS,
+          "TCCL p2p_recv: WC failed status=", static_cast<int>(wcs[i].status),
+          " (peer=", src, ").");
+      std::memcpy(out + off, recv_buffers_[src].data(), inflight);
+      off += inflight;
+      inflight = 0;
+      post();
+    }
+    deadline = std::chrono::steady_clock::now() + timeout_;  // progress -> reset
+  }
+}
+
+// ---- all-to-all (mesh / direct) -------------------------------------------
+inline void TCCLEngine::all_to_all(
+    const char* send_base,
+    char* recv_base,
+    const std::vector<std::size_t>& send_off,
+    const std::vector<std::size_t>& send_bytes,
+    const std::vector<std::size_t>& recv_off,
+    const std::vector<std::size_t>& recv_bytes) {
+  // Self slot: local copy (no wire).
+  if (send_bytes[rank_] > 0) {
+    std::memcpy(
+        recv_base + recv_off[rank_], send_base + send_off[rank_],
+        send_bytes[rank_]);
+  }
+  if (size_ <= 1) {
+    return;
+  }
+
+  std::vector<std::size_t> s_done(size_, 0), r_done(size_, 0);
+  std::vector<std::size_t> s_inflight(size_, 0), r_inflight(size_, 0);
+  std::vector<ibv_wc> wcs(8);
+
+  auto post_recv = [&](int p) {
+    if (p != rank_ && r_inflight[p] == 0 && r_done[p] < recv_bytes[p]) {
+      r_inflight[p] = std::min(kChunkSize, recv_bytes[p] - r_done[p]);
+      connections_[p]->postRecv(
+          recv_buffers_[p], r_inflight[p], tccl_wr::makeRecv(p));
+    }
+  };
+  auto post_send = [&](int p) {
+    if (p != rank_ && s_inflight[p] == 0 && s_done[p] < send_bytes[p]) {
+      s_inflight[p] = std::min(kChunkSize, send_bytes[p] - s_done[p]);
+      std::memcpy(
+          send_buffers_[p].data(), send_base + send_off[p] + s_done[p],
+          s_inflight[p]);
+      connections_[p]->postSend(
+          send_buffers_[p], s_inflight[p], tccl_wr::makeSend(p));
+    }
+  };
+
+  // UC discipline: recv posted before the matching send, for every peer.
+  for (int p = 0; p < size_; ++p) {
+    if (p == rank_) continue;
+    post_recv(p);
+    post_send(p);
+  }
+
+  auto remaining = [&]() {
+    for (int p = 0; p < size_; ++p) {
+      if (p == rank_) continue;
+      if (s_done[p] < send_bytes[p] || r_done[p] < recv_bytes[p]) return true;
+    }
+    return false;
+  };
+
+  auto deadline = std::chrono::steady_clock::now() + timeout_;
+  while (remaining()) {
+    bool progress = false;
+    for (int p = 0; p < size_; ++p) {
+      if (p == rank_) continue;
+      if (s_inflight[p] == 0 && r_inflight[p] == 0) continue;
+      int n = connections_[p]->pollCq(static_cast<int>(wcs.size()), wcs.data());
+      if (n == 0) continue;
+      progress = true;
+      for (int i = 0; i < n; ++i) {
+        TORCH_CHECK_WITH(
+            DistBackendError,
+            wcs[i].status == IBV_WC_SUCCESS,
+            "TCCL alltoall(mesh): WC failed status=",
+            static_cast<int>(wcs[i].status), " (peer=", p, ").");
+        if (tccl_wr::isSend(wcs[i].wr_id)) {
+          s_done[p] += s_inflight[p];
+          s_inflight[p] = 0;
+          post_send(p);
+        } else {
+          std::memcpy(
+              recv_base + recv_off[p] + r_done[p],
+              recv_buffers_[p].data(), r_inflight[p]);
+          r_done[p] += r_inflight[p];
+          r_inflight[p] = 0;
+          post_recv(p);
+        }
+      }
+    }
+    if (progress) {
+      deadline = std::chrono::steady_clock::now() + timeout_;
+    } else {
+      TORCH_CHECK_WITH(
+          DistBackendError,
+          std::chrono::steady_clock::now() <= deadline,
+          "TCCL alltoall(mesh): timed out after ", timeout_.count(),
+          " ms. The poll bound is the process-group timeout; a persistent stall "
+          "indicates a dropped UC packet (no hardware retransmission).");
+    }
+  }
+}
+
+// ---- all-to-all (ring / store-and-forward, equal splits) ------------------
+inline void TCCLEngine::ring_all_to_all(
+    const char* send_base, char* recv_base, std::size_t seg_bytes) {
+  const int N = size_;
+  // Self segment: local copy.
+  std::memcpy(
+      recv_base + static_cast<std::size_t>(rank_) * seg_bytes,
+      send_base + static_cast<std::size_t>(rank_) * seg_bytes, seg_bytes);
+  if (N <= 1) {
+    return;
+  }
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      N > 2,
+      "TCCL ring_all_to_all requires size_ > 2 (dispatch uses mesh for <=2).");
+
+  const int right = (rank_ + 1) % N;
+  const int left = (rank_ - 1 + N) % N;
+
+  // Forward block, furthest-destination first: segment for (rank+N-1), (rank+N-2),
+  // ..., (rank+1). The receiver peels the LAST segment (its immediate-dst hop) and
+  // forwards the front; ordering stays furthest-first at each hop.
+  std::vector<char> work(static_cast<std::size_t>(N - 1) * seg_bytes);
+  for (int h = N - 1; h >= 1; --h) {
+    const int dst = (rank_ + h) % N;
+    std::memcpy(
+        work.data() + static_cast<std::size_t>(N - 1 - h) * seg_bytes,
+        send_base + static_cast<std::size_t>(dst) * seg_bytes, seg_bytes);
+  }
+  std::vector<char> recv_work(static_cast<std::size_t>(N - 1) * seg_bytes);
+
+  for (int k = 1; k <= N - 1; ++k) {
+    const std::size_t block = static_cast<std::size_t>(N - k) * seg_bytes;
+    char* rw = recv_work.data();
+    ring_step(
+        right, work.data(), block, left, block,
+        [&](std::size_t off, const void* src, std::size_t nbytes) {
+          std::memcpy(rw + off, src, nbytes);
+        });
+    // Peel the last segment of the received block — destined for this rank,
+    // originated (k hops left) by rank (rank_ - k).
+    const int origin = (rank_ - k + N) % N;
+    std::memcpy(
+        recv_base + static_cast<std::size_t>(origin) * seg_bytes,
+        recv_work.data() + static_cast<std::size_t>(N - k - 1) * seg_bytes,
+        seg_bytes);
+    // Forward the front (N-k-1) segments next step.
+    if (N - k - 1 > 0) {
+      std::memcpy(
+          work.data(), recv_work.data(),
+          static_cast<std::size_t>(N - k - 1) * seg_bytes);
+    }
+  }
+}
+
+} // namespace c10d
+
+#endif // USE_C10D_TCCL

--- a/torch/csrc/distributed/c10d/ProcessGroupTCCLDetail.ipp
+++ b/torch/csrc/distributed/c10d/ProcessGroupTCCLDetail.ipp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstdio>
 #include <cstring>
 #include <string>
 #include <vector>
@@ -22,22 +23,28 @@ namespace c10d {
 
 // Work-request id encoding for completion-event demultiplexing.
 //   bit 63          : 1 = send, 0 = recv
-//   bits 62..32     : reserved
+//   bits 40..33     : pipeline slot (0..kPipelineDepth-1)
+//   bits 62..41, 32 : reserved
 //   bits 31..0      : peer rank
 //
-// At PIPELINE=1 there is one in-flight chunk per (peer, direction), so
-// (direction, peer) fully identifies a completion; reserved bits leave room to
-// grow.
+// PIPELINE=1 callers omit the slot (defaults 0), so (direction, peer) still
+// fully identifies their single in-flight chunk. The pipelined bidirectional
+// ring keeps up to kPipelineDepth pieces in flight per (peer, direction) and
+// uses the slot field to tell which staging buffer a completion refers to.
 namespace tccl_wr {
 
 constexpr uint64_t kSendBit = 1ULL << 63;
+constexpr uint64_t kSlotShift = 33;
+constexpr uint64_t kSlotMask = 0xFFULL;
 
-inline uint64_t makeSend(int peer) {
-  return kSendBit | static_cast<uint64_t>(peer);
+inline uint64_t makeSend(int peer, int slot = 0) {
+  return kSendBit | (static_cast<uint64_t>(slot) << kSlotShift) |
+      static_cast<uint64_t>(peer);
 }
 
-inline uint64_t makeRecv(int peer) {
-  return static_cast<uint64_t>(peer);
+inline uint64_t makeRecv(int peer, int slot = 0) {
+  return (static_cast<uint64_t>(slot) << kSlotShift) |
+      static_cast<uint64_t>(peer);
 }
 
 inline bool isSend(uint64_t wr_id) {
@@ -48,6 +55,10 @@ inline int peer(uint64_t wr_id) {
   return static_cast<int>(wr_id & 0xFFFFFFFFULL);
 }
 
+inline int slot(uint64_t wr_id) {
+  return static_cast<int>((wr_id >> kSlotShift) & kSlotMask);
+}
+
 } // namespace tccl_wr
 
 // mesh_exchange
@@ -55,7 +66,7 @@ inline int peer(uint64_t wr_id) {
 // The one place the UC-ordering discipline (recv before send) and the WC-status
 // / duplicate-completion / timeout-watchdog checks live. The mesh collectives
 // are thin adapters over this; contract in the header.
-template <typename SendSrc, typename WantRecv, typename OnRecv>
+template <bool Pipeline, typename SendSrc, typename WantRecv, typename OnRecv>
 void TCCLEngine::mesh_exchange(
     std::size_t total_bytes,
     SendSrc send_src,
@@ -69,6 +80,212 @@ void TCCLEngine::mesh_exchange(
       "TCCL: mesh_exchange invoked under ring topology - a collective's "
       "dispatch failed to select its ring variant (internal error).");
   if (size_ <= 1) {
+    return;
+  }
+
+  // 2-node fast path: depth-kPipelineDepth pipeline over the single peer, so the
+  // per-piece memcpy/reduce overlaps the wire (the PIPELINE=1 general path below
+  // ran them serially - worst at N=2 where mesh is the only option and the reduce
+  // sat on the critical path). Restricted to size_==2: with one peer there is no
+  // round-robin, so a recv buffer briefly held by the reduce cannot starve other
+  // peers' recvs. At size_>=3 that starvation deadlocks under UC drop semantics,
+  // so the general path keeps its synchronized one-chunk-per-round discipline.
+  if (size_ == 2) {
+    const int peer = 1 - rank_;
+    const bool do_send = (send_src(peer, 0) != nullptr);
+    const bool do_recv = want_recv(peer);
+    constexpr int D = kPipelineDepth;
+    std::vector<ibv_wc> wcs(2 * D + 2);
+    std::size_t send_off = 0, recv_off = 0, send_done = 0, recv_done = 0;
+    int send_if = 0, recv_if = 0;
+    std::size_t slen[D] = {0}, roff[D] = {0}, rlen[D] = {0};
+    auto fill_recv = [&]() {
+      if (!do_recv) return;
+      for (int s = 0; s < D; ++s) {
+        const std::size_t idx = static_cast<std::size_t>(peer) * D + s;
+        if (rlen[s] == 0 && recv_off < total_bytes) {
+          const std::size_t L = std::min(kChunkSize, total_bytes - recv_off);
+          roff[s] = recv_off;
+          rlen[s] = L;
+          connections_[peer]->postRecv(
+              pipe_recv_buffers_[idx], L, tccl_wr::makeRecv(peer, s));
+          recv_off += L;
+          ++recv_if;
+        }
+      }
+    };
+    auto fill_send = [&]() {
+      if (!do_send) return;
+      for (int s = 0; s < D; ++s) {
+        const std::size_t idx = static_cast<std::size_t>(peer) * D + s;
+        if (slen[s] == 0 && send_off < total_bytes) {
+          const std::size_t L = std::min(kChunkSize, total_bytes - send_off);
+          const void* src = send_src(peer, send_off);
+          std::memcpy(pipe_send_buffers_[idx].data(), src, L);
+          slen[s] = L;
+          connections_[peer]->postSend(
+              pipe_send_buffers_[idx], L, tccl_wr::makeSend(peer, s));
+          send_off += L;
+          ++send_if;
+        }
+      }
+    };
+    fill_recv();
+    fill_send();
+    auto deadline = std::chrono::steady_clock::now() + timeout_;
+    while ((do_send && send_done < total_bytes) ||
+           (do_recv && recv_done < total_bytes)) {
+      int n = connections_[peer]->pollCq(
+          static_cast<int>(wcs.size()), wcs.data());
+      if (n == 0) {
+        TORCH_CHECK_WITH(
+            DistBackendError,
+            std::chrono::steady_clock::now() <= deadline,
+            "TCCL mesh(2-node): timed out after ", timeout_.count(),
+            " ms (send ", send_done, "/", do_send ? total_bytes : 0,
+            ", recv ", recv_done, "/", do_recv ? total_bytes : 0, " peer ", peer,
+            "). The poll bound is the process-group timeout; a persistent stall "
+            "here indicates a dropped UC packet (no hardware retransmission).");
+        continue;
+      }
+      for (int i = 0; i < n; ++i) {
+        TORCH_CHECK_WITH(
+            DistBackendError,
+            wcs[i].status == IBV_WC_SUCCESS,
+            "TCCL mesh(2-node): WC failed status=",
+            static_cast<int>(wcs[i].status), " (peer=", peer, ").");
+        const int s = tccl_wr::slot(wcs[i].wr_id);
+        const std::size_t idx = static_cast<std::size_t>(peer) * D + s;
+        if (tccl_wr::isSend(wcs[i].wr_id)) {
+          send_done += slen[s];
+          slen[s] = 0;
+          --send_if;
+          fill_send();
+        } else {
+          on_recv(peer, pipe_recv_buffers_[idx].data(), roff[s], rlen[s]);
+          recv_done += rlen[s];
+          rlen[s] = 0;
+          --recv_if;
+          fill_recv();
+        }
+      }
+      deadline = std::chrono::steady_clock::now() + timeout_;
+    }
+    return;
+  }
+
+  // Pipelined multi-peer path (Pipeline=true, size_>=3): depth-kPipelineDepth per
+  // peer over the full mesh, so all N-1 links stay busy and the per-piece copy
+  // overlaps the wire. Only enabled for copy-based collectives (all_gather): the
+  // on_recv is a fast memcpy that frees the recv buffer promptly, so a peer cannot
+  // starve while another is serviced. A slow on_recv (reduce) would deadlock here,
+  // which is why reduce collectives use the depth-1 path below.
+  if (Pipeline && size_ > 2) {
+    constexpr int D = kPipelineDepth;
+    std::vector<ibv_wc> wcs(2 * D + 2);
+    std::vector<char> sends_to(size_, 0), recvs_from(size_, 0);
+    for (int p = 0; p < size_; ++p) {
+      if (p == rank_) continue;
+      sends_to[p] = (send_src(p, 0) != nullptr) ? 1 : 0;
+      recvs_from[p] = want_recv(p) ? 1 : 0;
+    }
+    std::vector<std::size_t> send_off(size_, 0), recv_off(size_, 0);
+    std::vector<std::size_t> send_done(size_, 0), recv_done(size_, 0);
+    std::vector<int> send_if(size_, 0), recv_if(size_, 0);
+    const std::size_t NS = static_cast<std::size_t>(size_) * D;
+    std::vector<std::size_t> slen(NS, 0), roff(NS, 0), rlen(NS, 0);
+    auto fill_recv = [&](int p) {
+      if (!recvs_from[p]) return;
+      for (int s = 0; s < D; ++s) {
+        const std::size_t idx = static_cast<std::size_t>(p) * D + s;
+        if (rlen[idx] == 0 && recv_off[p] < total_bytes) {
+          const std::size_t L = std::min(kChunkSize, total_bytes - recv_off[p]);
+          roff[idx] = recv_off[p];
+          rlen[idx] = L;
+          connections_[p]->postRecv(
+              pipe_recv_buffers_[idx], L, tccl_wr::makeRecv(p, s));
+          recv_off[p] += L;
+          ++recv_if[p];
+        }
+      }
+    };
+    auto fill_send = [&](int p) {
+      if (!sends_to[p]) return;
+      for (int s = 0; s < D; ++s) {
+        const std::size_t idx = static_cast<std::size_t>(p) * D + s;
+        if (slen[idx] == 0 && send_off[p] < total_bytes) {
+          const std::size_t L = std::min(kChunkSize, total_bytes - send_off[p]);
+          const void* src = send_src(p, send_off[p]);
+          std::memcpy(pipe_send_buffers_[idx].data(), src, L);
+          slen[idx] = L;
+          connections_[p]->postSend(
+              pipe_send_buffers_[idx], L, tccl_wr::makeSend(p, s));
+          send_off[p] += L;
+          ++send_if[p];
+        }
+      }
+    };
+    for (int p = 0; p < size_; ++p)
+      if (p != rank_) fill_recv(p);
+    for (int p = 0; p < size_; ++p)
+      if (p != rank_) fill_send(p);
+    auto all_done = [&]() {
+      for (int p = 0; p < size_; ++p) {
+        if (p == rank_) continue;
+        if (recvs_from[p] && recv_done[p] < total_bytes) return false;
+        if (sends_to[p] && send_done[p] < total_bytes) return false;
+      }
+      return true;
+    };
+    auto deadline = std::chrono::steady_clock::now() + timeout_;
+    while (!all_done()) {
+      bool made_progress = false;
+      for (int p = 0; p < size_; ++p) {
+        if (p == rank_) continue;
+        if (send_if[p] == 0 && recv_if[p] == 0) continue;
+        int n = connections_[p]->pollCq(static_cast<int>(wcs.size()), wcs.data());
+        if (n == 0) continue;
+        made_progress = true;
+        for (int i = 0; i < n; ++i) {
+          const ibv_wc& wc = wcs[i];
+          TORCH_CHECK_WITH(
+              DistBackendError, wc.status == IBV_WC_SUCCESS,
+              "TCCL mesh(pipe): WC failed status=", static_cast<int>(wc.status),
+              " (peer=", p, ", wr_id=", wc.wr_id, ")");
+          const int s = tccl_wr::slot(wc.wr_id);
+          const std::size_t idx = static_cast<std::size_t>(p) * D + s;
+          if (tccl_wr::isSend(wc.wr_id)) {
+            send_done[p] += slen[idx];
+            slen[idx] = 0;
+            --send_if[p];
+            fill_send(p);
+          } else {
+            on_recv(p, pipe_recv_buffers_[idx].data(), roff[idx], rlen[idx]);
+            recv_done[p] += rlen[idx];
+            rlen[idx] = 0;
+            --recv_if[p];
+            fill_recv(p);
+          }
+        }
+      }
+      if (made_progress) {
+        deadline = std::chrono::steady_clock::now() + timeout_;
+      } else if (std::chrono::steady_clock::now() > deadline) {
+        std::string outstanding;
+        for (int p = 0; p < size_; ++p) {
+          if (p == rank_) continue;
+          if (sends_to[p] && send_done[p] < total_bytes)
+            outstanding += " send->" + std::to_string(p);
+          if (recvs_from[p] && recv_done[p] < total_bytes)
+            outstanding += " recv<-" + std::to_string(p);
+        }
+        TORCH_CHECK_WITH(
+            DistBackendError, false,
+            "TCCL mesh(pipe): timed out after ", timeout_.count(),
+            " ms (total_bytes=", total_bytes, "). outstanding:", outstanding,
+            ". A persistent stall here indicates a dropped UC packet.");
+      }
+    }
     return;
   }
 
@@ -331,26 +548,232 @@ void TCCLEngine::ring_step(
         }
       }
     }
-    if (!made_progress && std::chrono::steady_clock::now() > deadline) {
+    if (!made_progress) {
+      if (std::chrono::steady_clock::now() > deadline) {
+        TORCH_CHECK_WITH(
+            DistBackendError,
+            false,
+            "TCCL ring: timed out after ",
+            timeout_.count(),
+            " ms. send ",
+            send_off,
+            "/",
+            send_bytes,
+            " to peer ",
+            send_peer,
+            ", recv ",
+            recv_off,
+            "/",
+            recv_bytes,
+            " from peer ",
+            recv_peer,
+            ". The poll bound is the process-group timeout "
+            "(init_process_group(timeout=) / set_timeout); a persistent stall "
+            "here indicates a dropped UC packet (no hardware retransmission).");
+      }
+    }
+  }
+}
+
+// bidir_ring_step (contract in the header)
+//
+// Four independent piece-streams over the two neighbor connections. conn[right]
+// carries A_send (send completions) + B_recv (recv completions); conn[left]
+// carries B_send + A_recv. Each stream keeps up to kPipelineDepth pieces in
+// flight with an equal number of double-buffered staging slots, so a piece's
+// memcpy/reduce overlaps the wire transfer of another piece (JACCL PIPELINE=2).
+// Completions are demuxed by (isSend, slot) from the wr_id. Recv posted before
+// send (UC), per-WR wc.status check, timeout_ watchdog.
+template <typename OnRecvA, typename OnRecvB>
+void TCCLEngine::bidir_ring_step(
+    int right,
+    int left,
+    const char* sendA_base,
+    std::size_t sendA_bytes,
+    std::size_t recvA_bytes,
+    OnRecvA on_recv_A,
+    const char* sendB_base,
+    std::size_t sendB_bytes,
+    std::size_t recvB_bytes,
+    OnRecvB on_recv_B) {
+  constexpr int D = kPipelineDepth;
+  std::vector<ibv_wc> wcs(2 * D + 2);
+
+  // Per-stream state: next byte to post, bytes completed, in-flight slot count,
+  // and per-slot (offset, length) so a completion knows which piece it was
+  // (length 0 = slot free). Send buffers indexed by destination peer, recv by
+  // source peer, both in the depth pool [peer * D + slot].
+  std::size_t asend_next = 0, asend_done = 0;
+  std::size_t bsend_next = 0, bsend_done = 0;
+  std::size_t arecv_next = 0, arecv_done = 0;
+  std::size_t brecv_next = 0, brecv_done = 0;
+  int asend_if = 0, bsend_if = 0, arecv_if = 0, brecv_if = 0;
+  std::size_t asoff[D] = {0}, aslen[D] = {0}; // A send -> right
+  std::size_t bsoff[D] = {0}, bslen[D] = {0}; // B send -> left
+  std::size_t aroff[D] = {0}, arlen[D] = {0}; // A recv <- left
+  std::size_t broff[D] = {0}, brlen[D] = {0}; // B recv <- right
+
+  auto fill_send = [&](int peer,
+                       const char* base,
+                       std::size_t total,
+                       std::size_t& next_off,
+                       int& inflight,
+                       std::size_t* soff,
+                       std::size_t* slen) {
+    for (int s = 0; s < D; ++s) {
+      if (slen[s] == 0 && next_off < total) {
+        const std::size_t L = std::min(kChunkSize, total - next_off);
+        auto& buf =
+            pipe_send_buffers_[static_cast<std::size_t>(peer) * D + s];
+        std::memcpy(buf.data(), base + next_off, L);
+        soff[s] = next_off;
+        slen[s] = L;
+        connections_[peer]->postSend(buf, L, tccl_wr::makeSend(peer, s));
+        next_off += L;
+        ++inflight;
+      }
+    }
+  };
+  auto fill_recv = [&](int peer,
+                       std::size_t total,
+                       std::size_t& next_off,
+                       int& inflight,
+                       std::size_t* soff,
+                       std::size_t* slen) {
+    for (int s = 0; s < D; ++s) {
+      if (slen[s] == 0 && next_off < total) {
+        const std::size_t L = std::min(kChunkSize, total - next_off);
+        auto& buf =
+            pipe_recv_buffers_[static_cast<std::size_t>(peer) * D + s];
+        soff[s] = next_off;
+        slen[s] = L;
+        connections_[peer]->postRecv(buf, L, tccl_wr::makeRecv(peer, s));
+        next_off += L;
+        ++inflight;
+      }
+    }
+  };
+
+  // UC discipline: post recvs before sends.
+  fill_recv(left, recvA_bytes, arecv_next, arecv_if, aroff, arlen);
+  fill_recv(right, recvB_bytes, brecv_next, brecv_if, broff, brlen);
+  fill_send(right, sendA_base, sendA_bytes, asend_next, asend_if, asoff, aslen);
+  fill_send(left, sendB_base, sendB_bytes, bsend_next, bsend_if, bsoff, bslen);
+
+  auto done = [&]() {
+    return asend_done >= sendA_bytes && arecv_done >= recvA_bytes &&
+        bsend_done >= sendB_bytes && brecv_done >= recvB_bytes;
+  };
+
+  auto deadline = std::chrono::steady_clock::now() + timeout_;
+  while (!done()) {
+    bool made_progress = false;
+
+    if (asend_if != 0 || brecv_if != 0) {
+      int n = connections_[right]->pollCq(
+          static_cast<int>(wcs.size()), wcs.data());
+      for (int i = 0; i < n; ++i) {
+        const ibv_wc& wc = wcs[i];
+        TORCH_CHECK_WITH(
+            DistBackendError,
+            wc.status == IBV_WC_SUCCESS,
+            "TCCL bidir-ring: WC failed status=",
+            static_cast<int>(wc.status),
+            " (peer=",
+            right,
+            ", wr_id=",
+            wc.wr_id,
+            ")");
+        made_progress = true;
+        const int s = tccl_wr::slot(wc.wr_id);
+        if (tccl_wr::isSend(wc.wr_id)) {
+          asend_done += aslen[s];
+          aslen[s] = 0;
+          --asend_if;
+          fill_send(
+              right, sendA_base, sendA_bytes, asend_next, asend_if, asoff, aslen);
+        } else {
+          on_recv_B(
+              broff[s],
+              pipe_recv_buffers_[static_cast<std::size_t>(right) * D + s].data(),
+              brlen[s]);
+          brecv_done += brlen[s];
+          brlen[s] = 0;
+          --brecv_if;
+          fill_recv(right, recvB_bytes, brecv_next, brecv_if, broff, brlen);
+        }
+      }
+    }
+
+    if (bsend_if != 0 || arecv_if != 0) {
+      int n = connections_[left]->pollCq(
+          static_cast<int>(wcs.size()), wcs.data());
+      for (int i = 0; i < n; ++i) {
+        const ibv_wc& wc = wcs[i];
+        TORCH_CHECK_WITH(
+            DistBackendError,
+            wc.status == IBV_WC_SUCCESS,
+            "TCCL bidir-ring: WC failed status=",
+            static_cast<int>(wc.status),
+            " (peer=",
+            left,
+            ", wr_id=",
+            wc.wr_id,
+            ")");
+        made_progress = true;
+        const int s = tccl_wr::slot(wc.wr_id);
+        if (tccl_wr::isSend(wc.wr_id)) {
+          bsend_done += bslen[s];
+          bslen[s] = 0;
+          --bsend_if;
+          fill_send(
+              left, sendB_base, sendB_bytes, bsend_next, bsend_if, bsoff, bslen);
+        } else {
+          on_recv_A(
+              aroff[s],
+              pipe_recv_buffers_[static_cast<std::size_t>(left) * D + s].data(),
+              arlen[s]);
+          arecv_done += arlen[s];
+          arlen[s] = 0;
+          --arecv_if;
+          fill_recv(left, recvA_bytes, arecv_next, arecv_if, aroff, arlen);
+        }
+      }
+    }
+
+    if (made_progress) {
+      deadline = std::chrono::steady_clock::now() + timeout_;
+    } else if (std::chrono::steady_clock::now() > deadline) {
       TORCH_CHECK_WITH(
           DistBackendError,
           false,
-          "TCCL ring: timed out after ",
+          "TCCL bidir-ring: timed out after ",
           timeout_.count(),
-          " ms. send ",
-          send_off,
+          " ms. A send ",
+          asend_done,
           "/",
-          send_bytes,
-          " to peer ",
-          send_peer,
-          ", recv ",
-          recv_off,
+          sendA_bytes,
+          "->",
+          right,
+          ", A recv ",
+          arecv_done,
           "/",
-          recv_bytes,
-          " from peer ",
-          recv_peer,
-          ". The poll bound is the process-group timeout "
-          "(init_process_group(timeout=) / set_timeout); a persistent stall "
+          recvA_bytes,
+          "<-",
+          left,
+          ", B send ",
+          bsend_done,
+          "/",
+          sendB_bytes,
+          "->",
+          left,
+          ", B recv ",
+          brecv_done,
+          "/",
+          recvB_bytes,
+          "<-",
+          right,
+          ". The poll bound is the process-group timeout; a persistent stall "
           "here indicates a dropped UC packet (no hardware retransmission).");
     }
   }
@@ -358,10 +781,13 @@ void TCCLEngine::ring_step(
 
 // ring_all_reduce
 //
-// Bandwidth-optimal ring: reduce-scatter (size_-1 steps) then all-gather
-// (size_-1 steps). Each step depends on the previous (synchronous, no
-// cross-step pipelining yet). Traffic bounded to the two ring neighbors - the
-// avoidance strategy for large/bf16 messages.
+// Bidirectional (double) ring: two counter-rotating rings over disjoint halves
+// of `data`, in place. Ring A (clockwise, d=+1) reduces the first half; ring B
+// (counter-clockwise, d=-1) reduces the second half. Both run their reduce-
+// scatter (size_-1 steps) + all-gather (size_-1 steps) driven IN LOCKSTEP by
+// bidir_ring_step, so both neighbor links carry traffic in both directions
+// (~2x the unidirectional ring bandwidth). d=+1 reproduces the classic single-
+// ring index math; d=-1 is the same algorithm on the reversed ring.
 template <typename T, typename ReduceOp>
 void TCCLEngine::ring_all_reduce(
     T* data,
@@ -382,52 +808,94 @@ void TCCLEngine::ring_all_reduce(
   const int N = size_;
   const int right = (rank_ + 1) % N;
   const int left = (rank_ + N - 1) % N;
-  char* base = reinterpret_cast<char*>(data);
 
-  // Split `count` elements into N contiguous chunks of `chunk` elements (the
-  // last chunk may be short or empty). Chunk c is elements [c*chunk, end_c).
-  const std::size_t chunk = (count + static_cast<std::size_t>(N) - 1) / N;
-  auto lo = [&](int c) {
-    return std::min<std::size_t>(static_cast<std::size_t>(c) * chunk, count);
-  };
-  auto hi = [&](int c) {
-    return std::min<std::size_t>((static_cast<std::size_t>(c) + 1) * chunk, count);
-  };
-  auto chunk_nbytes = [&](int c) { return (hi(c) - lo(c)) * sizeof(T); };
-  auto chunk_ptr = [&](int c) { return base + lo(c) * sizeof(T); };
+  // Two halves on the same buffer: ring A = [0, countA), ring B = [countA, count).
+  const std::size_t countA = count / 2;
+  const std::size_t countB = count - countA;
+  T* dataA = data;
+  T* dataB = data + countA;
 
-  // Reduce-scatter: send chunk (rank-s) right, recv+reduce chunk (rank-s-1) left.
+  // Per-half chunking into N pieces (ragged/empty last piece via the clamps).
+  const std::size_t chunkA = (countA + static_cast<std::size_t>(N) - 1) / N;
+  const std::size_t chunkB = (countB + static_cast<std::size_t>(N) - 1) / N;
+  auto ptrA = [&](int c) {
+    return reinterpret_cast<char*>(dataA) +
+        std::min<std::size_t>(static_cast<std::size_t>(c) * chunkA, countA) *
+        sizeof(T);
+  };
+  auto nbA = [&](int c) {
+    const std::size_t lo =
+        std::min<std::size_t>(static_cast<std::size_t>(c) * chunkA, countA);
+    const std::size_t hi = std::min<std::size_t>(
+        (static_cast<std::size_t>(c) + 1) * chunkA, countA);
+    return (hi - lo) * sizeof(T);
+  };
+  auto ptrB = [&](int c) {
+    return reinterpret_cast<char*>(dataB) +
+        std::min<std::size_t>(static_cast<std::size_t>(c) * chunkB, countB) *
+        sizeof(T);
+  };
+  auto nbB = [&](int c) {
+    const std::size_t lo =
+        std::min<std::size_t>(static_cast<std::size_t>(c) * chunkB, countB);
+    const std::size_t hi = std::min<std::size_t>(
+        (static_cast<std::size_t>(c) + 1) * chunkB, countB);
+    return (hi - lo) * sizeof(T);
+  };
+
+  // Reduce-scatter: A clockwise, B counter-clockwise.
   for (int s = 0; s < N - 1; ++s) {
-    const int send_c = ((rank_ - s) % N + N) % N;
-    const int recv_c = (send_c - 1 + N) % N;
-    char* recv_dst = chunk_ptr(recv_c);
-    ring_step(
+    const int aSend = ((rank_ - s) % N + N) % N;
+    const int aRecv = ((aSend - 1) % N + N) % N;
+    const int bSend = ((rank_ + s) % N + N) % N;
+    const int bRecv = ((bSend + 1) % N + N) % N;
+    char* aRecvDst = ptrA(aRecv);
+    char* bRecvDst = ptrB(bRecv);
+    bidir_ring_step(
         right,
-        chunk_ptr(send_c),
-        chunk_nbytes(send_c),
         left,
-        chunk_nbytes(recv_c),
+        ptrA(aSend),
+        nbA(aSend),
+        nbA(aRecv),
         [&](std::size_t off, const void* src, std::size_t nbytes) {
           reduce_op(
               static_cast<const T*>(src),
-              reinterpret_cast<T*>(recv_dst + off),
+              reinterpret_cast<T*>(aRecvDst + off),
+              nbytes / sizeof(T));
+        },
+        ptrB(bSend),
+        nbB(bSend),
+        nbB(bRecv),
+        [&](std::size_t off, const void* src, std::size_t nbytes) {
+          reduce_op(
+              static_cast<const T*>(src),
+              reinterpret_cast<T*>(bRecvDst + off),
               nbytes / sizeof(T));
         });
   }
 
-  // All-gather: send chunk (rank-s+1) right, recv+overwrite chunk (rank-s) left.
+  // All-gather: A clockwise, B counter-clockwise.
   for (int s = 0; s < N - 1; ++s) {
-    const int send_c = ((rank_ - s + 1) % N + N) % N;
-    const int recv_c = (send_c - 1 + N) % N;
-    char* recv_dst = chunk_ptr(recv_c);
-    ring_step(
+    const int aSend = ((rank_ - s + 1) % N + N) % N;
+    const int aRecv = ((aSend - 1) % N + N) % N;
+    const int bSend = ((rank_ + s - 1) % N + N) % N;
+    const int bRecv = ((bSend + 1) % N + N) % N;
+    char* aRecvDst = ptrA(aRecv);
+    char* bRecvDst = ptrB(bRecv);
+    bidir_ring_step(
         right,
-        chunk_ptr(send_c),
-        chunk_nbytes(send_c),
         left,
-        chunk_nbytes(recv_c),
+        ptrA(aSend),
+        nbA(aSend),
+        nbA(aRecv),
         [&](std::size_t off, const void* src, std::size_t nbytes) {
-          std::memcpy(recv_dst + off, src, nbytes);
+          std::memcpy(aRecvDst + off, src, nbytes);
+        },
+        ptrB(bSend),
+        nbB(bSend),
+        nbB(bRecv),
+        [&](std::size_t off, const void* src, std::size_t nbytes) {
+          std::memcpy(bRecvDst + off, src, nbytes);
         });
   }
 }
@@ -460,20 +928,34 @@ inline void TCCLEngine::ring_all_gather(
   const int N = size_;
   const int right = (rank_ + 1) % N;
   const int left = (rank_ + N - 1) % N;
-  // Step k: send shard (rank-k) to the right, receive shard (rank-k-1) from the
-  // left (the shard we just received / our own at k=0), copy it into its slot.
+  // Bidirectional: split each shard's bytes in half. Ring A circulates half A of
+  // every shard clockwise (send shard (rank-k) right, recv shard (rank-k-1) left);
+  // ring B circulates half B counter-clockwise (send shard (rank+k) left, recv
+  // shard (rank+k+1) right). Both cover all N-1 other shards, so out_ptrs[r] gets
+  // its half A via ring A and half B via ring B.
+  const std::size_t halfA = per_rank_bytes / 2;
+  const std::size_t halfB = per_rank_bytes - halfA;
   for (int k = 0; k < N - 1; ++k) {
-    const int send_c = ((rank_ - k) % N + N) % N;
-    const int recv_c = (send_c - 1 + N) % N;
-    char* recv_dst = reinterpret_cast<char*>(out_ptrs[recv_c]);
-    ring_step(
+    const int aSend = ((rank_ - k) % N + N) % N;
+    const int aRecv = ((aSend - 1) % N + N) % N;
+    const int bSend = ((rank_ + k) % N + N) % N;
+    const int bRecv = ((bSend + 1) % N + N) % N;
+    char* aRecvDst = reinterpret_cast<char*>(out_ptrs[aRecv]);
+    char* bRecvDst = reinterpret_cast<char*>(out_ptrs[bRecv]) + halfA;
+    bidir_ring_step(
         right,
-        reinterpret_cast<const char*>(out_ptrs[send_c]),
-        per_rank_bytes,
         left,
-        per_rank_bytes,
+        reinterpret_cast<const char*>(out_ptrs[aSend]),
+        halfA,
+        halfA,
         [&](std::size_t off, const void* src, std::size_t nbytes) {
-          std::memcpy(recv_dst + off, src, nbytes);
+          std::memcpy(aRecvDst + off, src, nbytes);
+        },
+        reinterpret_cast<const char*>(out_ptrs[bSend]) + halfA,
+        halfB,
+        halfB,
+        [&](std::size_t off, const void* src, std::size_t nbytes) {
+          std::memcpy(bRecvDst + off, src, nbytes);
         });
   }
 }
@@ -503,7 +985,10 @@ void TCCLEngine::ring_reduce_scatter(
 
   // Ring reduce-scatter accumulates partials in place, so it needs a mutable
   // copy of all N input chunks (mesh reduce_scatter reduces straight into `out`
-  // with no scratch).
+  // with no scratch). Bidirectional: split each chunk in half - ring A reduce-
+  // scatters half A clockwise (d=+1), ring B half B counter-clockwise (d=-1),
+  // driven in lockstep by bidir_ring_step so both neighbor links carry traffic
+  // both ways (~2x the unidirectional bandwidth, mirroring ring_all_gather).
   std::vector<char> work(static_cast<std::size_t>(N) * chunk_bytes);
   for (int c = 0; c < N; ++c) {
     std::memcpy(
@@ -516,24 +1001,37 @@ void TCCLEngine::ring_reduce_scatter(
   auto chunk = [&](int c) {
     return work.data() + static_cast<std::size_t>(c) * chunk_bytes;
   };
-  // Step s: send chunk (rank-s-1) right, recv+reduce chunk (rank-s-2) from left
-  // (carry-forward: what we send at s is what we reduced at s-1). This lands the
-  // full reduction of chunk rank_ at work[rank_] after N-1 steps. (Indexing is
-  // validated against mesh reduce_scatter by the correctness test.)
+  const std::size_t abytes = (count_per_rank / 2) * sizeof(T);  // half A
+  const std::size_t bbytes = chunk_bytes - abytes;              // half B
+  // Ring A (d=+1): send chunk (rank-s-1) right, recv+reduce (rank-s-2) from left.
+  // Ring B (d=-1): the mirror - send chunk (rank+s+1) left, recv+reduce (rank+s+2)
+  // from right. Each lands work[rank_]'s half fully reduced after N-1 steps.
   for (int s = 0; s < N - 1; ++s) {
-    const int send_c = ((rank_ - s - 1) % N + N) % N;
-    const int recv_c = ((send_c - 1) % N + N) % N;
-    char* recv_chunk = chunk(recv_c);
-    ring_step(
+    const int aSend = ((rank_ - s - 1) % N + N) % N;
+    const int aRecv = ((aSend - 1) % N + N) % N;
+    const int bSend = ((rank_ + s + 1) % N + N) % N;
+    const int bRecv = ((bSend + 1) % N + N) % N;
+    char* aRecvHalf = chunk(aRecv);
+    char* bRecvHalf = chunk(bRecv) + abytes;
+    bidir_ring_step(
         right,
-        chunk(send_c),
-        chunk_bytes,
         left,
-        chunk_bytes,
+        chunk(aSend),
+        abytes,
+        abytes,
         [&](std::size_t off, const void* src, std::size_t nbytes) {
           reduce_op(
               static_cast<const T*>(src),
-              reinterpret_cast<T*>(recv_chunk + off),
+              reinterpret_cast<T*>(aRecvHalf + off),
+              nbytes / sizeof(T));
+        },
+        chunk(bSend) + abytes,
+        bbytes,
+        bbytes,
+        [&](std::size_t off, const void* src, std::size_t nbytes) {
+          reduce_op(
+              static_cast<const T*>(src),
+              reinterpret_cast<T*>(bRecvHalf + off),
               nbytes / sizeof(T));
         });
   }
@@ -674,7 +1172,7 @@ inline void TCCLEngine::all_gather(
     return;
   }
 
-  mesh_exchange(
+  mesh_exchange<true>(
       per_rank_bytes,
       // Send every peer our whole shard at `offset`.
       [&](int /*peer*/, std::size_t offset) -> const void* {
@@ -691,6 +1189,93 @@ inline void TCCLEngine::all_gather(
             reinterpret_cast<char*>(out_ptrs[peer]) + offset,
             recv_ptr,
             chunk_bytes);
+      });
+}
+
+// gather (rooted): root collects each shard; non-root sends to root.
+inline void TCCLEngine::gather(
+    const void* in,
+    const std::vector<void*>& out_ptrs,
+    std::size_t per_rank_bytes,
+    int root) {
+  TORCH_CHECK_WITH(
+      DistBackendError, in != nullptr,
+      "TCCL mesh: gather called with null input pointer.");
+  TORCH_CHECK_WITH(
+      DistBackendError, root >= 0 && root < size_,
+      "TCCL mesh: gather root ", root, " out of range [0, ", size_, ").");
+  const bool is_root = (rank_ == root);
+  const char* in_base = reinterpret_cast<const char*>(in);
+  if (is_root) {
+    TORCH_CHECK_WITH(
+        DistBackendError, static_cast<int>(out_ptrs.size()) == size_,
+        "TCCL mesh: gather expects ", size_, " output pointers on the root.");
+    // Root's own shard.
+    std::memcpy(out_ptrs[rank_], in_base, per_rank_bytes);
+  }
+  if (size_ <= 1) {
+    return;
+  }
+  mesh_exchange<true>(
+      per_rank_bytes,
+      // Non-root sends its shard to root.
+      [&](int peer, std::size_t offset) -> const void* {
+        return (!is_root && peer == root) ? (in_base + offset) : nullptr;
+      },
+      // Only root receives.
+      [&](int /*peer*/) { return is_root; },
+      // Place each peer's shard.
+      [&](int peer,
+          const void* recv_ptr,
+          std::size_t offset,
+          std::size_t chunk_bytes) {
+        std::memcpy(
+            reinterpret_cast<char*>(out_ptrs[peer]) + offset,
+            recv_ptr,
+            chunk_bytes);
+      });
+}
+
+// scatter (rooted): root sends each slice; non-root receives from root.
+inline void TCCLEngine::scatter(
+    const std::vector<const void*>& in_ptrs,
+    void* out,
+    std::size_t per_rank_bytes,
+    int root) {
+  TORCH_CHECK_WITH(
+      DistBackendError, out != nullptr,
+      "TCCL mesh: scatter called with null output pointer.");
+  TORCH_CHECK_WITH(
+      DistBackendError, root >= 0 && root < size_,
+      "TCCL mesh: scatter root ", root, " out of range [0, ", size_, ").");
+  const bool is_root = (rank_ == root);
+  char* out_base = reinterpret_cast<char*>(out);
+  if (is_root) {
+    TORCH_CHECK_WITH(
+        DistBackendError, static_cast<int>(in_ptrs.size()) == size_,
+        "TCCL mesh: scatter expects ", size_, " input pointers on the root.");
+    // Root's own slice.
+    std::memcpy(out_base, in_ptrs[rank_], per_rank_bytes);
+  }
+  if (size_ <= 1) {
+    return;
+  }
+  mesh_exchange<true>(
+      per_rank_bytes,
+      // Root sends each peer its slice.
+      [&](int peer, std::size_t offset) -> const void* {
+        return is_root
+            ? (reinterpret_cast<const char*>(in_ptrs[peer]) + offset)
+            : nullptr;
+      },
+      // Only non-root receives, from root.
+      [&](int peer) { return !is_root && peer == root; },
+      // Store the received slice.
+      [&](int /*peer*/,
+          const void* recv_ptr,
+          std::size_t offset,
+          std::size_t chunk_bytes) {
+        std::memcpy(out_base + offset, recv_ptr, chunk_bytes);
       });
 }
 
@@ -746,29 +1331,36 @@ inline void TCCLEngine::p2p_send(
       DistBackendError,
       dst >= 0 && dst < size_ && dst != rank_,
       "TCCL p2p_send: invalid dst ", dst, " (rank ", rank_, ", size ", size_, ").");
-  std::vector<ibv_wc> wcs(8);
-  // Bytes acknowledged sent
-  std::size_t off = 0;
-  // In-flight chunk size - 0 = none
-  std::size_t inflight = 0;
-  auto post = [&]() {
-    if (inflight == 0 && off < nbytes) {
-      inflight = std::min(kChunkSize, nbytes - off);
-      std::memcpy(send_buffers_[dst].data(), in + off, inflight);
-      connections_[dst]->postSend(
-          send_buffers_[dst], inflight, tccl_wr::makeSend(dst));
+  constexpr int D = kPipelineDepth;
+  std::vector<ibv_wc> wcs(D + 2);
+  // Depth-D pipeline: up to D pieces in flight, double-buffered staging, so the
+  // per-piece memcpy overlaps the wire (PIPELINE=1 ran them serially).
+  std::size_t next_off = 0, done = 0;
+  int inflight = 0;
+  std::size_t slen[D] = {0};
+  auto fill = [&]() {
+    for (int s = 0; s < D; ++s) {
+      if (slen[s] == 0 && next_off < nbytes) {
+        const std::size_t L = std::min(kChunkSize, nbytes - next_off);
+        auto& buf = pipe_send_buffers_[static_cast<std::size_t>(dst) * D + s];
+        std::memcpy(buf.data(), in + next_off, L);
+        slen[s] = L;
+        connections_[dst]->postSend(buf, L, tccl_wr::makeSend(dst, s));
+        next_off += L;
+        ++inflight;
+      }
     }
   };
-  post();
+  fill();
   auto deadline = std::chrono::steady_clock::now() + timeout_;
-  while (off < nbytes) {
+  while (done < nbytes) {
     int n = connections_[dst]->pollCq(static_cast<int>(wcs.size()), wcs.data());
     if (n == 0) {
       TORCH_CHECK_WITH(
           DistBackendError,
           std::chrono::steady_clock::now() <= deadline,
           "TCCL p2p_send: timed out after ", timeout_.count(), " ms sending ",
-          off, "/", nbytes, " bytes to peer ", dst,
+          done, "/", nbytes, " bytes to peer ", dst,
           ". The poll bound is the process-group timeout; a persistent stall here "
           "indicates a dropped UC packet (no hardware retransmission).");
       continue;
@@ -779,11 +1371,12 @@ inline void TCCLEngine::p2p_send(
           wcs[i].status == IBV_WC_SUCCESS,
           "TCCL p2p_send: WC failed status=", static_cast<int>(wcs[i].status),
           " (peer=", dst, ").");
-      off += inflight;
-      inflight = 0;
-      post();
+      const int s = tccl_wr::slot(wcs[i].wr_id);
+      done += slen[s];
+      slen[s] = 0;
+      --inflight;
     }
-    // Progress -> reset
+    fill();
     deadline = std::chrono::steady_clock::now() + timeout_;
   }
 }
@@ -794,28 +1387,37 @@ inline void TCCLEngine::p2p_recv(
       DistBackendError,
       src >= 0 && src < size_ && src != rank_,
       "TCCL p2p_recv: invalid src ", src, " (rank ", rank_, ", size ", size_, ").");
-  std::vector<ibv_wc> wcs(8);
-  // Bytes received and handled
-  std::size_t off = 0;
-  // In-flight chunk size - 0 = none
-  std::size_t inflight = 0;
-  auto post = [&]() {
-    if (inflight == 0 && off < nbytes) {
-      inflight = std::min(kChunkSize, nbytes - off);
-      connections_[src]->postRecv(
-          recv_buffers_[src], inflight, tccl_wr::makeRecv(src));
+  constexpr int D = kPipelineDepth;
+  std::vector<ibv_wc> wcs(D + 2);
+  // Depth-D pipeline: up to D recvs in flight; the copy-out of one piece overlaps
+  // the wire arrival of the next. Per-slot offset recorded so completions (which a
+  // single QP delivers in post order) copy to the right place regardless.
+  std::size_t next_off = 0, done = 0;
+  int inflight = 0;
+  std::size_t soff[D] = {0}, slen[D] = {0};
+  auto fill = [&]() {
+    for (int s = 0; s < D; ++s) {
+      if (slen[s] == 0 && next_off < nbytes) {
+        const std::size_t L = std::min(kChunkSize, nbytes - next_off);
+        auto& buf = pipe_recv_buffers_[static_cast<std::size_t>(src) * D + s];
+        soff[s] = next_off;
+        slen[s] = L;
+        connections_[src]->postRecv(buf, L, tccl_wr::makeRecv(src, s));
+        next_off += L;
+        ++inflight;
+      }
     }
   };
-  post();
+  fill();
   auto deadline = std::chrono::steady_clock::now() + timeout_;
-  while (off < nbytes) {
+  while (done < nbytes) {
     int n = connections_[src]->pollCq(static_cast<int>(wcs.size()), wcs.data());
     if (n == 0) {
       TORCH_CHECK_WITH(
           DistBackendError,
           std::chrono::steady_clock::now() <= deadline,
           "TCCL p2p_recv: timed out after ", timeout_.count(), " ms receiving ",
-          off, "/", nbytes, " bytes from peer ", src,
+          done, "/", nbytes, " bytes from peer ", src,
           ". The poll bound is the process-group timeout; a persistent stall here "
           "indicates a dropped UC packet (no hardware retransmission).");
       continue;
@@ -826,12 +1428,16 @@ inline void TCCLEngine::p2p_recv(
           wcs[i].status == IBV_WC_SUCCESS,
           "TCCL p2p_recv: WC failed status=", static_cast<int>(wcs[i].status),
           " (peer=", src, ").");
-      std::memcpy(out + off, recv_buffers_[src].data(), inflight);
-      off += inflight;
-      inflight = 0;
-      post();
+      const int s = tccl_wr::slot(wcs[i].wr_id);
+      std::memcpy(
+          out + soff[s],
+          pipe_recv_buffers_[static_cast<std::size_t>(src) * D + s].data(),
+          slen[s]);
+      done += slen[s];
+      slen[s] = 0;
+      --inflight;
     }
-    // Progress -> reset
+    fill();
     deadline = std::chrono::steady_clock::now() + timeout_;
   }
 }

--- a/torch/csrc/distributed/c10d/ProcessGroupTCCLDetail.ipp
+++ b/torch/csrc/distributed/c10d/ProcessGroupTCCLDetail.ipp
@@ -1,7 +1,6 @@
 #pragma once
 
-// Template implementations for ProcessGroupTCCLDetail.hpp. Pulled in via
-// the trailing include in that header — do not include directly.
+// Template implementations for ProcessGroupTCCLDetail.hpp.
 
 #ifdef USE_C10D_TCCL
 
@@ -16,7 +15,8 @@
 #include <torch/csrc/distributed/c10d/TCCLUtils.hpp>
 #include <torch/csrc/distributed/c10d/exception.h>
 
-#include <infiniband/verbs.h>  // for ibv_wc, IBV_WC_SUCCESS
+// For ibv_wc, IBV_WC_SUCCESS
+#include <infiniband/verbs.h>
 
 namespace c10d {
 
@@ -25,11 +25,9 @@ namespace c10d {
 //   bits 62..32     : reserved
 //   bits 31..0      : peer rank
 //
-// Every collective posts WRs through mesh_exchange using this scheme so
-// completion polling can identify which (peer, direction) a completion is
-// for. At PIPELINE=1 there is one in-flight chunk per (peer, direction), so
-// (direction, peer) fully identifies a completion; the reserved bits leave room
-// to encode extra fields if that changes.
+// At PIPELINE=1 there is one in-flight chunk per (peer, direction), so
+// (direction, peer) fully identifies a completion; reserved bits leave room to
+// grow.
 namespace tccl_wr {
 
 constexpr uint64_t kSendBit = 1ULL << 63;
@@ -52,12 +50,11 @@ inline int peer(uint64_t wr_id) {
 
 } // namespace tccl_wr
 
-// ---- mesh_exchange ---------------------------------------------------------
+// mesh_exchange
 //
-// The one place the UC-ordering discipline (recv posted before send) and the
-// WC-status / duplicate-completion / PG-timeout-watchdog checks live. All four
-// collectives below are thin adapters over this. See the declaration in
-// ProcessGroupTCCLDetail.hpp for the contract.
+// The one place the UC-ordering discipline (recv before send) and the WC-status
+// / duplicate-completion / timeout-watchdog checks live. The mesh collectives
+// are thin adapters over this; contract in the header.
 template <typename SendSrc, typename WantRecv, typename OnRecv>
 void TCCLEngine::mesh_exchange(
     std::size_t total_bytes,
@@ -66,10 +63,10 @@ void TCCLEngine::mesh_exchange(
     OnRecv on_recv) {
   // Ring topology has null connection slots for all non-neighbor peers;
   // mesh_exchange indexes every peer, so reaching it here would null-deref.
-  // Dispatch must force the ring path in ring mode — fail loud if it didn't.
+  // Dispatch must force the ring path in ring mode - fail loud if it didn't.
   TORCH_CHECK(
       !ring_topology_,
-      "TCCL: mesh_exchange invoked under ring topology — a collective's "
+      "TCCL: mesh_exchange invoked under ring topology - a collective's "
       "dispatch failed to select its ring variant (internal error).");
   if (size_ <= 1) {
     return;
@@ -89,7 +86,7 @@ void TCCLEngine::mesh_exchange(
     int expected_completions = 0;
 
     // Step 1: pre-post recvs FIRST. UC requires the recv posted before the
-    // matching send arrives (Apple TN3205 §12.3 credit-based flow control);
+    // matching send arrives (Apple TN3205 sec. 12.3 credit-based flow control);
     // post every recv before any send.
     for (int peer = 0; peer < size_; ++peer) {
       if (peer == rank_) continue;
@@ -174,7 +171,7 @@ void TCCLEngine::mesh_exchange(
                 "TCCL mesh: unexpected or duplicate recv completion for peer ",
                 peer);
             recv_done[peer] = 1;
-            // Recv complete — the peer's chunk is in recv_buffers_[peer].
+            // Recv complete - the peer's chunk is in recv_buffers_[peer].
             on_recv(peer, recv_buffers_[peer].data(), offset, chunk_bytes);
           }
           ++completions_seen;
@@ -218,7 +215,7 @@ void TCCLEngine::mesh_exchange(
   }
 }
 
-// ---- all_reduce ------------------------------------------------------------
+// all_reduce
 template <typename T, typename ReduceOp>
 void TCCLEngine::all_reduce(
     T* data,
@@ -253,14 +250,12 @@ void TCCLEngine::all_reduce(
       });
 }
 
-// ---- ring_step -------------------------------------------------------------
+// ring_step
 //
-// One step of a ring collective: stream `send_bytes` from `send_base` to the
-// right neighbor while streaming `recv_bytes` from the left neighbor, both in
-// kChunkSize pieces with one piece in flight per direction (PIPELINE=1). The
-// recv is posted before the send (UC credit-flow discipline), every completion
-// is status-checked, and a timeout_ watchdog bounds the wait. on_recv handles
-// each received piece (reduce or copy).
+// One ring step: stream `send_bytes` to the right neighbor while streaming
+// `recv_bytes` from the left, in kChunkSize pieces, one in flight per direction
+// (PIPELINE=1). Recv before send (UC credit-flow), every completion
+// status-checked, timeout_ watchdog. on_recv handles each piece (reduce or copy).
 template <typename OnRecv>
 void TCCLEngine::ring_step(
     int send_peer,
@@ -270,10 +265,14 @@ void TCCLEngine::ring_step(
     std::size_t recv_bytes,
     OnRecv on_recv) {
   std::vector<ibv_wc> wcs(8);
-  std::size_t send_off = 0;       // bytes acknowledged sent
-  std::size_t recv_off = 0;       // bytes received and handled
-  std::size_t send_inflight = 0;  // size of the in-flight send piece (0 = none)
-  std::size_t recv_inflight = 0;  // size of the in-flight recv piece (0 = none)
+  // Bytes acknowledged sent
+  std::size_t send_off = 0;
+  // Bytes received and handled
+  std::size_t recv_off = 0;
+  // In-flight send piece size - 0 = none
+  std::size_t send_inflight = 0;
+  // In-flight recv piece size - 0 = none
+  std::size_t recv_inflight = 0;
 
   auto post_recv_piece = [&]() {
     if (recv_inflight == 0 && recv_off < recv_bytes) {
@@ -357,14 +356,12 @@ void TCCLEngine::ring_step(
   }
 }
 
-// ---- ring_all_reduce -------------------------------------------------------
+// ring_all_reduce
 //
 // Bandwidth-optimal ring: reduce-scatter (size_-1 steps) then all-gather
-// (size_-1 steps). At step s the rank sends chunk (rank-s) to the right and
-// receives chunk (rank-s-1) from the left — the chunk it just reduced — so each
-// step depends on the previous (synchronous, no cross-step pipelining yet).
-// Traffic is bounded to the two ring neighbors (the avoidance strategy for
-// large/bf16 messages).
+// (size_-1 steps). Each step depends on the previous (synchronous, no
+// cross-step pipelining yet). Traffic bounded to the two ring neighbors - the
+// avoidance strategy for large/bf16 messages.
 template <typename T, typename ReduceOp>
 void TCCLEngine::ring_all_reduce(
     T* data,
@@ -435,7 +432,7 @@ void TCCLEngine::ring_all_reduce(
   }
 }
 
-// ---- ring_all_gather -------------------------------------------------------
+// ring_all_gather
 inline void TCCLEngine::ring_all_gather(
     const void* in,
     const std::vector<void*>& out_ptrs,
@@ -481,7 +478,7 @@ inline void TCCLEngine::ring_all_gather(
   }
 }
 
-// ---- ring_reduce_scatter ---------------------------------------------------
+// ring_reduce_scatter
 template <typename T, typename ReduceOp>
 void TCCLEngine::ring_reduce_scatter(
     const std::vector<const T*>& in_chunks,
@@ -505,9 +502,8 @@ void TCCLEngine::ring_reduce_scatter(
       "TCCL ring_reduce_scatter requires size_ > 2 (dispatch uses mesh for <=2).");
 
   // Ring reduce-scatter accumulates partials in place, so it needs a mutable
-  // copy of all N input chunks, gathered here from the per-rank pointers (mesh
-  // reduce_scatter reduces straight into `out` and needs no scratch — a fair
-  // cost difference to keep in mind for the bench).
+  // copy of all N input chunks (mesh reduce_scatter reduces straight into `out`
+  // with no scratch).
   std::vector<char> work(static_cast<std::size_t>(N) * chunk_bytes);
   for (int c = 0; c < N; ++c) {
     std::memcpy(
@@ -544,14 +540,12 @@ void TCCLEngine::ring_reduce_scatter(
   std::memcpy(out, chunk(rank_), chunk_bytes);
 }
 
-// ---- ring_broadcast --------------------------------------------------------
+// ring_broadcast
 //
-// Store-and-forward along the ring: chunk by chunk, the root sends to its right;
-// each non-root rank receives a chunk from its left, writes it to the output, and
-// (unless it is the chain tail = root's left neighbour) forwards it to its right.
-// RDMA does not relay, so forwarding is explicit. Per-chunk synchronous, with the
-// recv posted before the matching send (UC credit-flow), a wc.status check, and
-// the PG-timeout watchdog.
+// Store-and-forward along the ring: each non-root rank receives a chunk from its
+// left, writes it, and (unless it is the chain tail = root's left neighbor)
+// forwards it right. RDMA does not relay, so forwarding is explicit. Per-chunk
+// synchronous, recv before send (UC credit-flow), wc.status check, timeout watchdog.
 inline void TCCLEngine::ring_broadcast(
     void* data, std::size_t total_bytes, int root) {
   if (size_ <= 1) {
@@ -562,7 +556,8 @@ inline void TCCLEngine::ring_broadcast(
       size_ > 2,
       "TCCL ring_broadcast requires size_ > 2 (dispatch uses mesh for <=2).");
   const int N = size_;
-  const int pos = ((rank_ - root) % N + N) % N;  // 0 = root ... N-1 = chain tail
+  // 0 = root ... N-1 = chain tail
+  const int pos = ((rank_ - root) % N + N) % N;
   const bool is_root = (pos == 0);
   const bool is_tail = (pos == N - 1);
   const int right = (rank_ + 1) % N;
@@ -598,12 +593,14 @@ inline void TCCLEngine::ring_broadcast(
   std::size_t off = 0;
   while (off < total_bytes) {
     const std::size_t n = std::min(kChunkSize, total_bytes - off);
-    if (!is_root) {  // receive this chunk from the left, write to output
+    // Receive this chunk from the left, write to output
+    if (!is_root) {
       connections_[left]->postRecv(recv_buffers_[left], n, tccl_wr::makeRecv(left));
       poll_one(left, /*want_send=*/false);
       std::memcpy(base + off, recv_buffers_[left].data(), n);
     }
-    if (!is_tail) {  // forward (root: from data; others: the just-received chunk)
+    // Forward - root sends from data, others the just-received chunk
+    if (!is_tail) {
       std::memcpy(send_buffers_[right].data(), base + off, n);
       connections_[right]->postSend(send_buffers_[right], n, tccl_wr::makeSend(right));
       poll_one(right, /*want_send=*/true);
@@ -612,7 +609,7 @@ inline void TCCLEngine::ring_broadcast(
   }
 }
 
-// ---- broadcast -------------------------------------------------------------
+// broadcast
 inline void TCCLEngine::broadcast(
     void* data,
     std::size_t total_bytes,
@@ -652,7 +649,7 @@ inline void TCCLEngine::broadcast(
       });
 }
 
-// ---- all_gather ------------------------------------------------------------
+// all_gather
 inline void TCCLEngine::all_gather(
     const void* in,
     const std::vector<void*>& out_ptrs,
@@ -697,7 +694,7 @@ inline void TCCLEngine::all_gather(
       });
 }
 
-// ---- reduce_scatter --------------------------------------------------------
+// reduce_scatter
 template <typename T, typename ReduceOp>
 void TCCLEngine::reduce_scatter(
     const std::vector<const T*>& in_chunks,
@@ -710,7 +707,7 @@ void TCCLEngine::reduce_scatter(
       "TCCL mesh: reduce_scatter expects size_ input-chunk pointers and a "
       "non-null output.");
 
-  // Seed our output with our own contribution — our chunk destined for rank_.
+  // Seed our output with our own contribution - our chunk destined for rank_.
   // (Out-of-place, so we cannot rely on `out` already holding it the way an
   // in-place ring reduce-scatter would.)
   std::memcpy(
@@ -742,7 +739,7 @@ void TCCLEngine::reduce_scatter(
       });
 }
 
-// ---- point-to-point send / recv -------------------------------------------
+// point-to-point send / recv
 inline void TCCLEngine::p2p_send(
     int dst, const char* in, std::size_t nbytes) {
   TORCH_CHECK_WITH(
@@ -750,8 +747,10 @@ inline void TCCLEngine::p2p_send(
       dst >= 0 && dst < size_ && dst != rank_,
       "TCCL p2p_send: invalid dst ", dst, " (rank ", rank_, ", size ", size_, ").");
   std::vector<ibv_wc> wcs(8);
-  std::size_t off = 0;        // bytes acknowledged sent
-  std::size_t inflight = 0;   // size of the in-flight chunk (0 = none)
+  // Bytes acknowledged sent
+  std::size_t off = 0;
+  // In-flight chunk size - 0 = none
+  std::size_t inflight = 0;
   auto post = [&]() {
     if (inflight == 0 && off < nbytes) {
       inflight = std::min(kChunkSize, nbytes - off);
@@ -784,7 +783,8 @@ inline void TCCLEngine::p2p_send(
       inflight = 0;
       post();
     }
-    deadline = std::chrono::steady_clock::now() + timeout_;  // progress -> reset
+    // Progress -> reset
+    deadline = std::chrono::steady_clock::now() + timeout_;
   }
 }
 
@@ -795,8 +795,10 @@ inline void TCCLEngine::p2p_recv(
       src >= 0 && src < size_ && src != rank_,
       "TCCL p2p_recv: invalid src ", src, " (rank ", rank_, ", size ", size_, ").");
   std::vector<ibv_wc> wcs(8);
-  std::size_t off = 0;        // bytes received and handled
-  std::size_t inflight = 0;   // size of the in-flight chunk (0 = none)
+  // Bytes received and handled
+  std::size_t off = 0;
+  // In-flight chunk size - 0 = none
+  std::size_t inflight = 0;
   auto post = [&]() {
     if (inflight == 0 && off < nbytes) {
       inflight = std::min(kChunkSize, nbytes - off);
@@ -829,11 +831,12 @@ inline void TCCLEngine::p2p_recv(
       inflight = 0;
       post();
     }
-    deadline = std::chrono::steady_clock::now() + timeout_;  // progress -> reset
+    // Progress -> reset
+    deadline = std::chrono::steady_clock::now() + timeout_;
   }
 }
 
-// ---- all-to-all (mesh / direct) -------------------------------------------
+// all-to-all (mesh / direct)
 inline void TCCLEngine::all_to_all(
     const char* send_base,
     char* recv_base,
@@ -930,7 +933,7 @@ inline void TCCLEngine::all_to_all(
   }
 }
 
-// ---- all-to-all (ring / store-and-forward, equal splits) ------------------
+// all-to-all (ring / store-and-forward, equal splits)
 inline void TCCLEngine::ring_all_to_all(
     const char* send_base, char* recv_base, std::size_t seg_bytes) {
   const int N = size_;
@@ -969,7 +972,7 @@ inline void TCCLEngine::ring_all_to_all(
         [&](std::size_t off, const void* src, std::size_t nbytes) {
           std::memcpy(rw + off, src, nbytes);
         });
-    // Peel the last segment of the received block — destined for this rank,
+    // Peel the last segment of the received block - destined for this rank,
     // originated (k hops left) by rank (rank_ - k).
     const int origin = (rank_ - k + N) % N;
     std::memcpy(

--- a/torch/csrc/distributed/c10d/TCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/TCCLUtils.cpp
@@ -1,0 +1,971 @@
+#ifdef USE_C10D_TCCL
+
+#include <torch/csrc/distributed/c10d/TCCLUtils.hpp>
+
+#include <cstdlib>
+#include <cstring>
+#include <dlfcn.h>
+#include <ifaddrs.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+
+#include <infiniband/verbs.h>
+
+#include <c10/util/Exception.h>
+#include <c10/util/StringUtil.h>
+#include <torch/csrc/distributed/c10d/Store.hpp>
+#include <torch/csrc/distributed/c10d/exception.h>
+
+namespace c10d {
+
+// Compile-time check that the layout assumption used by the Store wire
+// format holds. ibv_gid is a 16-byte union (per the standard infiniband
+// header), so TCCLDestination::gid[16] is the right size and our
+// memcpy-based conversion at the verbs boundary is well-defined.
+static_assert(
+    sizeof(ibv_gid) == 16,
+    "ibv_gid is expected to be 16 bytes; TCCLDestination::gid[16] depends "
+    "on this for the memcpy bridge.");
+
+
+// 32-byte layout asserted at compile time. Serialization is reinterpret_cast
+// (POD memcpy) so this MUST hold. Catches struct-padding surprises on any
+// future platform before bytes go on the wire.
+static_assert(
+    sizeof(TCCLDestination) == 32,
+    "TCCLDestination must be 32 bytes for POD serialization compatibility "
+    "across peers. If you changed the struct, also bump the wire format "
+    "(see allgatherDestinationsViaStore).");
+
+namespace {
+
+constexpr const char* kInitCounterKey = "tccl_init_counter";
+constexpr const char* kInitSeqBroadcastKey = "tccl_init_seq";
+constexpr int kQpMaxSendWr = 32;
+constexpr int kQpMaxRecvWr = 32;
+constexpr int kQpMaxSge = 1;
+constexpr int kCqCapacity = 64;
+constexpr int kQpPort = 1;
+constexpr int kGidIndex = 1;
+constexpr int kPsn = 7;  // initial packet sequence number
+constexpr int kQpAccessFlags =
+    IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_WRITE;
+
+// Bridge between our portable TCCLDestination::gid[16] and the verbs-native
+// ibv_gid union. Both are 16 bytes (static_assert above guards this).
+void gidToBytes(const ibv_gid& src, uint8_t (&dst)[16]) {
+  std::memcpy(dst, &src, sizeof(ibv_gid));
+}
+
+ibv_gid bytesToGid(const uint8_t (&src)[16]) {
+  ibv_gid g{};
+  std::memcpy(&g, src, sizeof(ibv_gid));
+  return g;
+}
+
+// Walk getifaddrs for a BSD interface and return true iff it has at least
+// one AF_INET address that is NOT in the 169.254/16 link-local block.
+
+bool ifaceHasStaticIPv4(const std::string& bsd_iface) {
+  struct ifaddrs* ifaddr = nullptr;
+  if (getifaddrs(&ifaddr) != 0) {
+    // Treat as "not found" — the caller will throw with a clear message.
+    return false;
+  }
+  bool found = false;
+  for (auto* ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next) {
+    if (ifa->ifa_name == nullptr || ifa->ifa_addr == nullptr) {
+      continue;
+    }
+    if (bsd_iface != ifa->ifa_name) {
+      continue;
+    }
+    if (ifa->ifa_addr->sa_family != AF_INET) {
+      continue;
+    }
+    auto* sin = reinterpret_cast<sockaddr_in*>(ifa->ifa_addr);
+    uint32_t host_addr = ntohl(sin->sin_addr.s_addr);
+    // 169.254.0.0/16 — RFC 3927 link-local autoconf. The Thunderbolt RDMA
+    // stack hands these out when no static IP is configured; RTR fails with
+    // them as the source GID.
+    if ((host_addr & 0xFFFF0000u) == 0xA9FE0000u) {
+      continue;
+    }
+    found = true;
+    break;
+  }
+  freeifaddrs(ifaddr);
+  return found;
+}
+
+} // namespace
+
+// =============================================================================
+// TCCLIBVWrapper
+// =============================================================================
+
+TCCLIBVWrapper::TCCLIBVWrapper() {
+  // RTLD_NOW: resolve all symbols at dlopen time so we fail fast if the
+  // library is missing or incompatible.
+  // RTLD_GLOBAL: makes librdma symbols available to subsequently dlopen'd
+  // libraries
+  handle_ = dlopen("librdma.dylib", RTLD_NOW | RTLD_GLOBAL);
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      handle_ != nullptr,
+      "TCCL: failed to load librdma.dylib via dlopen: ",
+      dlerror(),
+      ". Requires macOS 26.2 or later with Thunderbolt RDMA enabled.");
+
+  // Resolve each symbol; complain with the symbol name on failure rather
+  // than the generic dlerror text alone.
+#define TCCL_LOAD_SYM(var, name)                                              \
+  do {                                                                        \
+    (var) = reinterpret_cast<decltype(var)>(dlsym(handle_, name));            \
+    TORCH_CHECK_WITH(                                                         \
+        DistBackendError,                                                     \
+        (var) != nullptr,                                                     \
+        "TCCL: dlsym(\"",                                                     \
+        name,                                                                 \
+        "\") returned null: ",                                                \
+        dlerror());                                                           \
+  } while (0)
+
+  TCCL_LOAD_SYM(get_device_list, "ibv_get_device_list");
+  TCCL_LOAD_SYM(get_device_name, "ibv_get_device_name");
+  TCCL_LOAD_SYM(open_device, "ibv_open_device");
+  TCCL_LOAD_SYM(free_device_list, "ibv_free_device_list");
+  TCCL_LOAD_SYM(close_device, "ibv_close_device");
+  TCCL_LOAD_SYM(alloc_pd, "ibv_alloc_pd");
+  TCCL_LOAD_SYM(create_cq, "ibv_create_cq");
+  TCCL_LOAD_SYM(create_qp, "ibv_create_qp");
+  TCCL_LOAD_SYM(destroy_qp, "ibv_destroy_qp");
+  TCCL_LOAD_SYM(destroy_cq, "ibv_destroy_cq");
+  TCCL_LOAD_SYM(dealloc_pd, "ibv_dealloc_pd");
+  TCCL_LOAD_SYM(query_port, "ibv_query_port");
+  TCCL_LOAD_SYM(query_gid, "ibv_query_gid");
+  TCCL_LOAD_SYM(modify_qp, "ibv_modify_qp");
+  TCCL_LOAD_SYM(reg_mr, "ibv_reg_mr");
+  TCCL_LOAD_SYM(dereg_mr, "ibv_dereg_mr");
+
+#undef TCCL_LOAD_SYM
+}
+
+TCCLIBVWrapper& TCCLIBVWrapper::instance() {
+  // Lives for the process lifetime; we deliberately do not dlclose — the
+  // function pointers we hold would dangle if the library unmapped.
+  static TCCLIBVWrapper inst;
+  return inst;
+}
+
+// =============================================================================
+// listRdmaDevices
+// =============================================================================
+
+std::vector<std::string> listRdmaDevices() {
+  auto& ibv = TCCLIBVWrapper::instance();
+  int num_devices = 0;
+  ibv_device** devices = ibv.get_device_list(&num_devices);
+  if (devices == nullptr || num_devices == 0) {
+    if (devices != nullptr) {
+      ibv.free_device_list(devices);
+    }
+    return {};
+  }
+  std::vector<std::string> names;
+  names.reserve(num_devices);
+  for (int i = 0; i < num_devices; i++) {
+    const char* name = ibv.get_device_name(devices[i]);
+    names.emplace_back(name ? name : "");
+  }
+  ibv.free_device_list(devices);
+  return names;
+}
+
+std::string resolveTcclDeviceName(const std::string& explicit_name) {
+  // Precedence 1: explicit Options::device_name. Trust the caller.
+  if (!explicit_name.empty()) {
+    return explicit_name;
+  }
+  // Precedence 2: TCCL_DEVICE env var. Convenient per-rank override for
+  // launch scripts that share a single Python entry point but bind each
+  // rank to a different device.
+  if (const char* env = std::getenv("TCCL_DEVICE");
+      env != nullptr && *env != '\0') {
+    return std::string(env);
+  }
+  // Precedence 3: auto-detect. Succeeds iff exactly one device is visible
+  // — the common case on Macs with a single Thunderbolt RDMA fabric.
+  auto devices = listRdmaDevices();
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      !devices.empty(),
+      "TCCL: no RDMA devices visible. Check that macOS is >= 26.2, RDMA "
+      "is enabled, and Thunderbolt is unbridged (`sudo tbtrdmactl unbridge`). Run "
+      "torch.distributed.list_tccl_devices() for a standalone diagnostic.");
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      devices.size() == 1,
+      "TCCL: multiple RDMA devices visible (",
+      c10::Join(", ", devices),
+      "); cannot auto-select. Set the device explicitly via the "
+      "TCCL_DEVICE environment variable or Options.device_name.");
+  return devices[0];
+}
+
+std::vector<std::string> resolveTcclPeerDevices(
+    int rank,
+    int size,
+    const std::string& explicit_name,
+    bool ring_topology) {
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      size > 0 && rank >= 0 && rank < size,
+      "TCCL: resolveTcclPeerDevices invalid (rank=",
+      rank,
+      ", size=",
+      size,
+      ").");
+
+  const int left = (rank - 1 + size) % size;
+  const int right = (rank + 1) % size;
+  // Which peers this rank is physically cabled to. Mesh: every non-self peer.
+  // Ring: only the two neighbors ((rank±1)%size) — every other slot (incl. self)
+  // must be empty, so the sparse row round-trips to null connection slots.
+  const auto isConnectedPeer = [&](int p) {
+    if (p == rank) {
+      return false;
+    }
+    return ring_topology ? (p == left || p == right) : true;
+  };
+
+  std::vector<std::string> devices(static_cast<size_t>(size));
+
+  // Precedence 1: TCCL_PEER_DEVICES — the rank's row of the device matrix.
+  // Comma-separated, exactly `size` fields, self-slot empty. The launcher
+  // derives it from the auto-discovered hostfile so each peer maps to the
+  // physical port (rdma_enX) that is cabled to it. Ring rows are sparse:
+  // only the two neighbor fields are non-empty.
+  if (const char* env = std::getenv("TCCL_PEER_DEVICES");
+      env != nullptr && *env != '\0') {
+    const std::string s(env);
+    std::vector<std::string> parts;
+    size_t start = 0;
+    while (true) {
+      const size_t comma = s.find(',', start);
+      parts.push_back(
+          s.substr(start, comma == std::string::npos ? comma : comma - start));
+      if (comma == std::string::npos) {
+        break;
+      }
+      start = comma + 1;
+    }
+    TORCH_CHECK_WITH(
+        DistBackendError,
+        static_cast<int>(parts.size()) == size,
+        "TCCL: TCCL_PEER_DEVICES has ",
+        parts.size(),
+        " comma-separated entries; expected world_size=",
+        size,
+        " (self-slot empty). Value: '",
+        s,
+        "'.");
+    for (int p = 0; p < size; p++) {
+      if (isConnectedPeer(p)) {
+        TORCH_CHECK_WITH(
+            DistBackendError,
+            !parts[p].empty(),
+            "TCCL: TCCL_PEER_DEVICES entry for peer ",
+            p,
+            " is empty; this peer must name a device (",
+            ring_topology ? "ring neighbor" : "mesh peer",
+            "). Value: '",
+            s,
+            "'.");
+      } else {
+        TORCH_CHECK_WITH(
+            DistBackendError,
+            parts[p].empty(),
+            "TCCL: TCCL_PEER_DEVICES entry for peer ",
+            p,
+            " must be empty (",
+            p == rank ? "self-slot" : "non-neighbor under ring topology",
+            "), got '",
+            parts[p],
+            "'.");
+      }
+      devices[static_cast<size_t>(p)] = parts[p];
+    }
+    return devices;
+  }
+
+  // Precedence 2: a single device for every connected peer — the single-link
+  // case. resolveTcclDeviceName applies its own explicit/env/auto precedence.
+  // Under ring topology only the two neighbor slots are filled.
+  const std::string one = resolveTcclDeviceName(explicit_name);
+  for (int p = 0; p < size; p++) {
+    devices[static_cast<size_t>(p)] =
+        isConnectedPeer(p) ? one : std::string();
+  }
+  return devices;
+}
+
+// =============================================================================
+// TCCLConnection
+// =============================================================================
+
+namespace {
+
+// Open the device matching device_name. Returns nullptr if not found.
+// Caller owns the returned context (must close_device on it).
+ibv_context* openDeviceByName(const std::string& device_name) {
+  auto& ibv = TCCLIBVWrapper::instance();
+  int num_devices = 0;
+  ibv_device** devices = ibv.get_device_list(&num_devices);
+  if (devices == nullptr) {
+    return nullptr;
+  }
+  ibv_context* ctx = nullptr;
+  for (int i = 0; i < num_devices; i++) {
+    const char* name = ibv.get_device_name(devices[i]);
+    if (name != nullptr && device_name == name) {
+      ctx = ibv.open_device(devices[i]);
+      break;
+    }
+  }
+  ibv.free_device_list(devices);
+  return ctx;
+}
+
+} // namespace
+
+TCCLConnection::TCCLConnection(const std::string& device_name) {
+  auto& ibv = TCCLIBVWrapper::instance();
+
+  ctx_ = openDeviceByName(device_name);
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      ctx_ != nullptr,
+      "TCCL: failed to open RDMA device '",
+      device_name,
+      "'. Available devices: see torch.distributed.list_tccl_devices(). ",
+      "If empty, Thunderbolt may be bridged — run `sudo tbtrdmactl unbridge`.");
+
+  // PD/CQ/QP allocation: any failure here means we partially constructed —
+  // call destroy() to free what we did get before rethrowing.
+  try {
+    pd_ = ibv.alloc_pd(ctx_);
+    TORCH_CHECK_WITH(
+        DistBackendError, pd_ != nullptr, "TCCL: ibv_alloc_pd failed.");
+
+    cq_ = ibv.create_cq(
+        ctx_,
+        kCqCapacity,
+        /*cq_context=*/nullptr,
+        /*channel=*/nullptr,
+        /*comp_vector=*/0);
+    TORCH_CHECK_WITH(
+        DistBackendError, cq_ != nullptr, "TCCL: ibv_create_cq failed.");
+
+    ibv_qp_init_attr qp_init{};
+    qp_init.qp_context = ctx_;
+    qp_init.send_cq = cq_;
+    qp_init.recv_cq = cq_;
+    qp_init.srq = nullptr;
+    qp_init.qp_type = IBV_QPT_UC;
+    qp_init.cap.max_send_wr = kQpMaxSendWr;
+    qp_init.cap.max_recv_wr = kQpMaxRecvWr;
+    qp_init.cap.max_send_sge = kQpMaxSge;
+    qp_init.cap.max_recv_sge = kQpMaxSge;
+    qp_init.cap.max_inline_data = 0;
+    qp_init.sq_sig_all = 0;  // Only explicitly-signaled sends get a CQE.
+
+    qp_ = ibv.create_qp(pd_, &qp_init);
+    TORCH_CHECK_WITH(
+        DistBackendError,
+        qp_ != nullptr,
+        "TCCL: ibv_create_qp(UC) failed. Most common cause on Thunderbolt: "
+        "the device's 10-QP-per-context limit is exhausted (Apple TN3205 §12.1). "
+        "Spread peers across more devices or reduce num_wires.");
+
+    // QP -> INIT (the first transition; INIT->RTR happens once the peer's
+    // destination has been exchanged via Store).
+    {
+      ibv_qp_attr attr{};
+      attr.qp_state = IBV_QPS_INIT;
+      attr.port_num = kQpPort;
+      attr.pkey_index = 0;
+      attr.qp_access_flags = kQpAccessFlags;
+      int mask = IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT |
+          IBV_QP_ACCESS_FLAGS;
+      int ret = ibv.modify_qp(qp_, &attr, mask);
+      TORCH_CHECK_WITH(
+          DistBackendError,
+          ret == 0,
+          "TCCL: ibv_modify_qp(QP -> INIT) failed with errno=",
+          ret);
+    }
+
+    // Populate local routing info now so the caller can publish it via Store
+    // immediately after construction. ibv_query_port reports link state
+    // (must be ACTIVE) and LID; ibv_query_gid at index 1 returns the
+    // IPv4-mapped GID that Thunderbolt uses for addressing.
+    ibv_port_attr port_attr{};
+    int qp_ret = ibv.query_port(ctx_, kQpPort, &port_attr);
+    TORCH_CHECK_WITH(
+        DistBackendError,
+        qp_ret == 0,
+        "TCCL: ibv_query_port(port=",
+        kQpPort,
+        ") failed with errno=",
+        qp_ret);
+    TORCH_CHECK_WITH(
+        DistBackendError,
+        port_attr.state == IBV_PORT_ACTIVE,
+        "TCCL: port ",
+        kQpPort,
+        " on device '",
+        device_name,
+        "' is not ACTIVE (state=",
+        static_cast<int>(port_attr.state),
+        "). Check that the Thunderbolt cable is connected and the BSD "
+        "interface is up.");
+
+    ibv_gid gid{};
+    int gid_ret = ibv.query_gid(ctx_, kQpPort, kGidIndex, &gid);
+    TORCH_CHECK_WITH(
+        DistBackendError,
+        gid_ret == 0,
+        "TCCL: ibv_query_gid(port=",
+        kQpPort,
+        ", index=",
+        kGidIndex,
+        ") failed with errno=",
+        gid_ret);
+
+    local_destination_.lid = port_attr.lid;
+    local_destination_.qp_num = qp_->qp_num;
+    local_destination_.psn = kPsn;
+    local_destination_._pad = 0;
+    gidToBytes(gid, local_destination_.gid);
+  } catch (...) {
+    destroy();
+    throw;
+  }
+}
+
+TCCLConnection::~TCCLConnection() {
+  destroy();
+}
+
+TCCLConnection::TCCLConnection(TCCLConnection&& other) noexcept {
+  swap(other);
+}
+
+TCCLConnection& TCCLConnection::operator=(TCCLConnection&& other) noexcept {
+  if (this != &other) {
+    destroy();
+    swap(other);
+  }
+  return *this;
+}
+
+void TCCLConnection::swap(TCCLConnection& other) noexcept {
+  std::swap(ctx_, other.ctx_);
+  std::swap(pd_, other.pd_);
+  std::swap(cq_, other.cq_);
+  std::swap(qp_, other.qp_);
+  std::swap(local_destination_, other.local_destination_);
+}
+
+void TCCLConnection::destroy() noexcept {
+  // Teardown order: QP -> CQ -> PD -> context. Each tier depends on the
+  // ones below it, so we unwind in reverse-allocation order. Errors are
+  // intentionally ignored — there's nothing useful we can do on a teardown
+  // failure in a destructor, and throwing from noexcept would call std::terminate.
+  auto& ibv = TCCLIBVWrapper::instance();
+  if (qp_ != nullptr) {
+    ibv.destroy_qp(qp_);
+    qp_ = nullptr;
+  }
+  if (cq_ != nullptr) {
+    ibv.destroy_cq(cq_);
+    cq_ = nullptr;
+  }
+  if (pd_ != nullptr) {
+    ibv.dealloc_pd(pd_);
+    pd_ = nullptr;
+  }
+  if (ctx_ != nullptr) {
+    ibv.close_device(ctx_);
+    ctx_ = nullptr;
+  }
+  local_destination_ = TCCLDestination{};
+}
+
+void TCCLConnection::transitionToRTR(const TCCLDestination& remote) {
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      qp_ != nullptr,
+      "TCCL: transitionToRTR called on a moved-from / destroyed Connection.");
+
+  ibv_qp_attr attr{};
+  attr.qp_state = IBV_QPS_RTR;
+  // IBV_MTU_1024 — TN3205 recommends 4096 but it consistently caused RTR
+  // timeouts on the Thunderbolt RDMA stack; the hardware appears to negotiate
+  // 1024 as the supported MTU.
+  attr.path_mtu = IBV_MTU_1024;
+  attr.rq_psn = remote.psn;
+  attr.dest_qp_num = remote.qp_num;
+  attr.ah_attr.dlid = remote.lid;
+  attr.ah_attr.sl = 0;
+  attr.ah_attr.src_path_bits = 0;
+  attr.ah_attr.port_num = kQpPort;
+  attr.ah_attr.is_global = 0;
+
+  // Bridge our portable byte array back to ibv_gid for the address-handle.
+  ibv_gid remote_gid = bytesToGid(remote.gid);
+  // Only set GRH (global routing header) when the remote GID's interface_id
+  // is non-zero. On link-local addresses interface_id is 0 and setting GRH
+  // confuses the hardware.
+  if (remote_gid.global.interface_id != 0) {
+    attr.ah_attr.is_global = 1;
+    attr.ah_attr.grh.hop_limit = 1;
+    attr.ah_attr.grh.dgid = remote_gid;
+    attr.ah_attr.grh.sgid_index = kGidIndex;
+  }
+
+  int mask = IBV_QP_STATE | IBV_QP_AV | IBV_QP_PATH_MTU | IBV_QP_DEST_QPN |
+      IBV_QP_RQ_PSN;
+  auto& ibv = TCCLIBVWrapper::instance();
+  int ret = ibv.modify_qp(qp_, &attr, mask);
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      ret == 0,
+      "TCCL: ibv_modify_qp(QP -> RTR) failed with errno=",
+      ret,
+      ". remote: lid=",
+      remote.lid,
+      ", qp_num=",
+      remote.qp_num,
+      ", psn=",
+      remote.psn,
+      ". errno=60 (ETIMEDOUT) usually means the link-layer subnet is not "
+      "configured — call check_tccl_link_layer() before init, or configure a "
+      "static /30 on the Thunderbolt interface.");
+}
+
+void TCCLConnection::transitionToRTS() {
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      qp_ != nullptr,
+      "TCCL: transitionToRTS called on a moved-from / destroyed Connection.");
+
+  ibv_qp_attr attr{};
+  attr.qp_state = IBV_QPS_RTS;
+  attr.sq_psn = local_destination_.psn;
+  int mask = IBV_QP_STATE | IBV_QP_SQ_PSN;
+  auto& ibv = TCCLIBVWrapper::instance();
+  int ret = ibv.modify_qp(qp_, &attr, mask);
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      ret == 0,
+      "TCCL: ibv_modify_qp(QP -> RTS) failed with errno=",
+      ret);
+}
+
+// ---- TCCLConnection data-path methods --------------------------------------
+
+void TCCLConnection::postSend(
+    const TCCLSharedBuffer& buf,
+    uint64_t length,
+    uint64_t wr_id) {
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      qp_ != nullptr,
+      "TCCL: postSend on a moved-from / destroyed Connection.");
+
+  ibv_sge sge = buf.toSge(pd_, length);
+
+  ibv_send_wr wr{};
+  wr.wr_id = wr_id;
+  wr.sg_list = &sge;
+  wr.num_sge = 1;
+  wr.opcode = IBV_WR_SEND;
+  wr.send_flags = IBV_SEND_SIGNALED;
+  wr.next = nullptr;
+
+  ibv_send_wr* bad = nullptr;
+  // ibv_post_send is inline in <infiniband/verbs.h> — calls through
+  // qp->context->ops, no syscall (Apple TN3205 §12.5).
+  int rc = ibv_post_send(qp_, &wr, &bad);
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      rc == 0,
+      "TCCL: ibv_post_send returned ",
+      rc,
+      " (length=",
+      length,
+      ", wr_id=",
+      wr_id,
+      ").");
+}
+
+void TCCLConnection::postRecv(
+    TCCLSharedBuffer& buf,
+    uint64_t length,
+    uint64_t wr_id) {
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      qp_ != nullptr,
+      "TCCL: postRecv on a moved-from / destroyed Connection.");
+
+  ibv_sge sge = buf.toSge(pd_, length);
+
+  ibv_recv_wr wr{};
+  wr.wr_id = wr_id;
+  wr.sg_list = &sge;
+  wr.num_sge = 1;
+  wr.next = nullptr;
+
+  ibv_recv_wr* bad = nullptr;
+  int rc = ibv_post_recv(qp_, &wr, &bad);
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      rc == 0,
+      "TCCL: ibv_post_recv returned ",
+      rc,
+      " (length=",
+      length,
+      ", wr_id=",
+      wr_id,
+      ").");
+}
+
+int TCCLConnection::pollCq(int max_completions, ibv_wc* wcs) {
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      cq_ != nullptr,
+      "TCCL: pollCq on a moved-from / destroyed Connection.");
+  // ibv_poll_cq is inline; non-blocking; returns -errno on failure.
+  int n = ibv_poll_cq(cq_, max_completions, wcs);
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      n >= 0,
+      "TCCL: ibv_poll_cq returned errno=",
+      -n);
+  return n;
+}
+
+// ---- TCCLSharedBuffer ------------------------------------------------------
+
+TCCLSharedBuffer::TCCLSharedBuffer(size_t num_bytes) : size_(num_bytes) {
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      num_bytes > 0,
+      "TCCL: TCCLSharedBuffer(size=0) is invalid; use the default ctor for "
+      "an empty placeholder.");
+  long page_size = sysconf(_SC_PAGESIZE);
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      page_size > 0,
+      "TCCL: sysconf(_SC_PAGESIZE) returned ",
+      page_size);
+  int rc = posix_memalign(&data_, static_cast<size_t>(page_size), num_bytes);
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      rc == 0 && data_ != nullptr,
+      "TCCL: posix_memalign(align=",
+      page_size,
+      ", size=",
+      num_bytes,
+      ") returned ",
+      rc);
+  std::memset(data_, 0, num_bytes);
+}
+
+TCCLSharedBuffer::~TCCLSharedBuffer() {
+  destroy();
+}
+
+TCCLSharedBuffer::TCCLSharedBuffer(TCCLSharedBuffer&& other) noexcept {
+  swap(other);
+}
+
+TCCLSharedBuffer& TCCLSharedBuffer::operator=(
+    TCCLSharedBuffer&& other) noexcept {
+  if (this != &other) {
+    destroy();
+    swap(other);
+  }
+  return *this;
+}
+
+void TCCLSharedBuffer::swap(TCCLSharedBuffer& other) noexcept {
+  std::swap(data_, other.data_);
+  std::swap(size_, other.size_);
+  mrs_.swap(other.mrs_);
+}
+
+void TCCLSharedBuffer::destroy() noexcept {
+  // Deregister all MRs before freeing the underlying memory.
+  if (!mrs_.empty()) {
+    auto& ibv = TCCLIBVWrapper::instance();
+    for (auto& kv : mrs_) {
+      if (kv.second != nullptr) {
+        ibv.dereg_mr(kv.second);
+      }
+    }
+    mrs_.clear();
+  }
+  if (data_ != nullptr) {
+    free(data_);
+    data_ = nullptr;
+  }
+  size_ = 0;
+}
+
+void TCCLSharedBuffer::registerToPD(ibv_pd* pd) {
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      data_ != nullptr,
+      "TCCL: registerToPD on an empty TCCLSharedBuffer.");
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      pd != nullptr,
+      "TCCL: registerToPD called with null pd.");
+  // Access flag set (LOCAL_WRITE | REMOTE_READ | REMOTE_WRITE). TN3205 §12.2
+  // notes LOCAL_WRITE alone is enough for 2-sided UC; the broader set is also
+  // valid and is what this backend uses.
+  auto& ibv = TCCLIBVWrapper::instance();
+  ibv_mr* mr = ibv.reg_mr(
+      pd,
+      data_,
+      size_,
+      IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ |
+          IBV_ACCESS_REMOTE_WRITE);
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      mr != nullptr,
+      "TCCL: ibv_reg_mr(size=",
+      size_,
+      ") returned null.");
+  auto [it, inserted] = mrs_.emplace(pd, mr);
+  if (!inserted) {
+    // Already had an MR for this pd — that's a programming error in our
+    // caller. Free the new MR and throw.
+    ibv.dereg_mr(mr);
+    TORCH_CHECK_WITH(
+        DistBackendError,
+        false,
+        "TCCL: TCCLSharedBuffer is already registered to this protection "
+        "domain. Call sites must register exactly once per (buffer, pd) "
+        "pair at init time.");
+  }
+}
+
+ibv_sge TCCLSharedBuffer::toSge(ibv_pd* pd, uint64_t length) const {
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      data_ != nullptr,
+      "TCCL: toSge on an empty TCCLSharedBuffer.");
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      length > 0 && length <= size_,
+      "TCCL: toSge length=",
+      length,
+      " out of range for buffer size=",
+      size_);
+  auto it = mrs_.find(pd);
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      it != mrs_.end(),
+      "TCCL: TCCLSharedBuffer is not registered to the requested "
+      "protection domain. Call registerToPD(pd) first.");
+  ibv_sge sge{};
+  sge.addr = reinterpret_cast<uintptr_t>(data_);
+  sge.length = static_cast<uint32_t>(length);
+  sge.lkey = it->second->lkey;
+  return sge;
+}
+
+void checkLinkLayer(const std::string& rdma_device) {
+  // The Thunderbolt RDMA device naming convention is "rdma_" + BSD interface
+  // name (rdma_en2, rdma_en4, ...). Strip the prefix to derive the BSD
+  // interface we should inspect with getifaddrs.
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      rdma_device.rfind("rdma_", 0) == 0,
+      "TCCL: device_name must start with 'rdma_' (e.g. 'rdma_en2'), got '",
+      rdma_device,
+      "'.");
+  std::string bsd_iface = rdma_device.substr(5);
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      !bsd_iface.empty(),
+      "TCCL: device_name '",
+      rdma_device,
+      "' has no BSD interface suffix after 'rdma_'.");
+
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      ifaceHasStaticIPv4(bsd_iface),
+      "TCCL: interface '",
+      bsd_iface,
+      "' has no non-link-local IPv4 address. Thunderbolt RDMA requires a "
+      "static /30 subnet on this interface or ibv_modify_qp(QP -> RTR) "
+      "will time out with errno=60 (ETIMEDOUT). Run on each node "
+      "(one-time per boot, requires sudo):\n"
+      "  sudo ifconfig bridge0 down\n"
+      "  sudo ifconfig ",
+      bsd_iface,
+      " inet 192.168.0.X netmask 255.255.255.252\n"
+      "  sudo route change 192.168.0.Y -interface ",
+      bsd_iface,
+      "\nwhere X is this node's address (e.g. 1) and Y is the peer's "
+      "(e.g. 2). The /30 is only on the TB cable and does not affect LAN "
+      "routing.");
+}
+
+int64_t tcclInitSequence(
+    Store& store,
+    int rank,
+    std::chrono::milliseconds timeout) {
+  // All ranks must agree on ONE sequence number for this PG instance. Only
+  // rank 0 reserves it via Store::add (a server-side atomic on TCPStore,
+  // fresh on every (re)creation) and broadcasts it via
+  // the Store; every other rank reads rank 0's value. A per-rank Store::add
+  // would return a different post-increment value to each caller, so the
+  // ranks would build different key prefixes and never find each other's
+  // destinations. Mirrors ProcessGroupNCCL's unique-id broadcast.
+  if (rank == 0) {
+    const int64_t seq = store.add(kInitCounterKey, 1);
+    const std::string s = std::to_string(seq);
+    store.set(
+        kInitSeqBroadcastKey, std::vector<uint8_t>(s.begin(), s.end()));
+    return seq;
+  }
+  // Non-root ranks block here until rank 0 publishes the number. Bound by the
+  // backend timeout instead of the Store's default.
+  StoreTimeoutGuard guard(store, timeout);
+  const std::vector<uint8_t> bytes = store.get(kInitSeqBroadcastKey);
+  return std::stoll(std::string(bytes.begin(), bytes.end()));
+}
+
+void allgatherDestinationsViaStore(
+    Store& store,
+    int rank,
+    int size,
+    const std::vector<TCCLDestination>& local,
+    std::vector<std::vector<TCCLDestination>>& remote,
+    const std::string& keyPrefix,
+    std::chrono::milliseconds timeout) {
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      rank >= 0 && rank < size,
+      "TCCL: rank=",
+      rank,
+      " out of range for size=",
+      size);
+  TORCH_CHECK_WITH(
+      DistBackendError,
+      !local.empty(),
+      "TCCL: local destinations vector is empty; expected num_wires >= 1.");
+
+  const size_t bytes_per_rank = local.size() * sizeof(TCCLDestination);
+
+  // Reinterpret_cast to bytes — same pattern as ProcessGroupNCCL.cpp:
+  // 2916-2918 for ncclUniqueId. POD, well-defined, single-platform (macOS
+  // arm64) on both sides.
+  std::vector<uint8_t> myBytes(
+      reinterpret_cast<const uint8_t*>(local.data()),
+      reinterpret_cast<const uint8_t*>(local.data()) + bytes_per_rank);
+
+  std::vector<std::string> keys;
+  keys.reserve(size);
+  for (int r = 0; r < size; r++) {
+    keys.push_back(keyPrefix + std::to_string(r));
+  }
+
+  // Publish OUR destinations before reading peers'. If every rank read
+  // before writing, multiGet would block forever on every rank.
+  store.set(keys[rank], myBytes);
+
+  // multiGet blocks until all listed keys exist. Single batched round-trip on
+  // TCPStore. Use StoreTimeoutGuard to apply our backend timeout instead of the
+  // Store's default.
+  std::vector<std::vector<uint8_t>> results;
+  {
+    StoreTimeoutGuard guard(store, timeout);
+    try {
+      results = store.multiGet(keys);
+    } catch (const std::exception& e) {
+      // Identify which peers failed to publish so the error message can
+      // point at the real culprit. Store::check is non-blocking.
+      std::vector<std::string> missing;
+      for (int r = 0; r < size; r++) {
+        if (r == rank) {
+          continue;
+        }
+        try {
+          if (!store.check({keys[r]})) {
+            missing.push_back(std::to_string(r));
+          }
+        } catch (...) {
+          // Best-effort diagnostic; ignore secondary failures.
+        }
+      }
+      std::string missingStr =
+          missing.empty() ? std::string("(none, store reported error)")
+                          : c10::Join(",", missing);
+      C10D_THROW_ERROR(
+          DistStoreError,
+          c10::str(
+              "TCCL: timed out waiting for destinations from peers: [",
+              missingStr,
+              "]. Most likely those peers crashed before reaching the "
+              "TCCL bootstrap. Original store error: ",
+              e.what()));
+    }
+  }
+
+  remote.assign(size, {});
+  for (int r = 0; r < size; r++) {
+    if (r == rank) {
+      continue;
+    }
+    TORCH_CHECK_WITH(
+        DistBackendError,
+        results[r].size() == bytes_per_rank,
+        "TCCL: peer rank ",
+        r,
+        " published ",
+        results[r].size(),
+        " bytes; expected ",
+        bytes_per_rank,
+        " (",
+        local.size(),
+        " destinations * ",
+        sizeof(TCCLDestination),
+        " bytes). Most likely a num_wires mismatch between ranks or a "
+        "TCCLDestination ABI mismatch between builds.");
+    remote[r].assign(local.size(), TCCLDestination{});
+    std::memcpy(remote[r].data(), results[r].data(), bytes_per_rank);
+  }
+}
+
+void tcclRtsBarrier(
+    Store& store,
+    int size,
+    const std::string& key,
+    std::chrono::milliseconds timeout) {
+  // Store::barrier is the optimized server-side primitive: it combines
+  // increment + wait into a single round-trip per rank, and is implemented by
+  // every concrete Store (TCPStore, FileStore, HashStore).
+  store.barrier(key, static_cast<int64_t>(size), timeout);
+}
+
+} // namespace c10d
+
+#endif // USE_C10D_TCCL

--- a/torch/csrc/distributed/c10d/TCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/TCCLUtils.cpp
@@ -502,10 +502,22 @@ void TCCLConnection::transitionToRTR(const TCCLDestination& remote) {
 
   ibv_qp_attr attr{};
   attr.qp_state = IBV_QPS_RTR;
-  // IBV_MTU_1024 - TN3205 recommends 4096 but it consistently caused RTR
-  // timeouts on the Thunderbolt RDMA stack; the hardware appears to negotiate
-  // 1024 as the supported MTU.
+  // MTU. TN3205 recommends IBV_MTU_4096. We keep 1024 as the default (all campaign
+  // results were validated on it); TCCL_PATH_MTU lets you select another value.
+  // Measured 2026-08-21: 4096 negotiates cleanly (the old "RTR timeout" was a subnet
+  // issue, not the MTU) and is perf-NEUTRAL - per-link BW 9.32 vs 9.33 GB/s, allreduce
+  // within noise. The TB controller segments on fixed 4KB frames regardless of
+  // path_mtu, so this attribute does not affect bandwidth on this stack.
   attr.path_mtu = IBV_MTU_1024;
+  if (const char* m = std::getenv("TCCL_PATH_MTU")) {
+    if (std::strcmp(m, "4096") == 0) {
+      attr.path_mtu = IBV_MTU_4096;
+    } else if (std::strcmp(m, "2048") == 0) {
+      attr.path_mtu = IBV_MTU_2048;
+    } else if (std::strcmp(m, "512") == 0) {
+      attr.path_mtu = IBV_MTU_512;
+    }
+  }
   attr.rq_psn = remote.psn;
   attr.dest_qp_num = remote.qp_num;
   attr.ah_attr.dlid = remote.lid;

--- a/torch/csrc/distributed/c10d/TCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/TCCLUtils.cpp
@@ -19,10 +19,8 @@
 
 namespace c10d {
 
-// Compile-time check that the layout assumption used by the Store wire
-// format holds. ibv_gid is a 16-byte union (per the standard infiniband
-// header), so TCCLDestination::gid[16] is the right size and our
-// memcpy-based conversion at the verbs boundary is well-defined.
+// Guards the Store wire-format layout: ibv_gid is a 16-byte union, so
+// TCCLDestination::gid[16] matches and the memcpy bridge is well-defined.
 static_assert(
     sizeof(ibv_gid) == 16,
     "ibv_gid is expected to be 16 bytes; TCCLDestination::gid[16] depends "
@@ -48,7 +46,8 @@ constexpr int kQpMaxSge = 1;
 constexpr int kCqCapacity = 64;
 constexpr int kQpPort = 1;
 constexpr int kGidIndex = 1;
-constexpr int kPsn = 7;  // initial packet sequence number
+// Initial packet sequence number
+constexpr int kPsn = 7;
 constexpr int kQpAccessFlags =
     IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_WRITE;
 
@@ -70,7 +69,7 @@ ibv_gid bytesToGid(const uint8_t (&src)[16]) {
 bool ifaceHasStaticIPv4(const std::string& bsd_iface) {
   struct ifaddrs* ifaddr = nullptr;
   if (getifaddrs(&ifaddr) != 0) {
-    // Treat as "not found" — the caller will throw with a clear message.
+    // Treat as "not found" - the caller will throw with a clear message.
     return false;
   }
   bool found = false;
@@ -86,7 +85,7 @@ bool ifaceHasStaticIPv4(const std::string& bsd_iface) {
     }
     auto* sin = reinterpret_cast<sockaddr_in*>(ifa->ifa_addr);
     uint32_t host_addr = ntohl(sin->sin_addr.s_addr);
-    // 169.254.0.0/16 — RFC 3927 link-local autoconf. The Thunderbolt RDMA
+    // 169.254.0.0/16 - RFC 3927 link-local autoconf. The Thunderbolt RDMA
     // stack hands these out when no static IP is configured; RTR fails with
     // them as the source GID.
     if ((host_addr & 0xFFFF0000u) == 0xA9FE0000u) {
@@ -101,15 +100,11 @@ bool ifaceHasStaticIPv4(const std::string& bsd_iface) {
 
 } // namespace
 
-// =============================================================================
 // TCCLIBVWrapper
-// =============================================================================
 
 TCCLIBVWrapper::TCCLIBVWrapper() {
-  // RTLD_NOW: resolve all symbols at dlopen time so we fail fast if the
-  // library is missing or incompatible.
-  // RTLD_GLOBAL: makes librdma symbols available to subsequently dlopen'd
-  // libraries
+  // RTLD_NOW: resolve all symbols now, fail fast if the library is bad.
+  // RTLD_GLOBAL: expose librdma symbols to later dlopen'd libraries.
   handle_ = dlopen("librdma.dylib", RTLD_NOW | RTLD_GLOBAL);
   TORCH_CHECK_WITH(
       DistBackendError,
@@ -153,15 +148,13 @@ TCCLIBVWrapper::TCCLIBVWrapper() {
 }
 
 TCCLIBVWrapper& TCCLIBVWrapper::instance() {
-  // Lives for the process lifetime; we deliberately do not dlclose — the
+  // Lives for the process lifetime; we deliberately do not dlclose - the
   // function pointers we hold would dangle if the library unmapped.
   static TCCLIBVWrapper inst;
   return inst;
 }
 
-// =============================================================================
 // listRdmaDevices
-// =============================================================================
 
 std::vector<std::string> listRdmaDevices() {
   auto& ibv = TCCLIBVWrapper::instance();
@@ -196,7 +189,7 @@ std::string resolveTcclDeviceName(const std::string& explicit_name) {
     return std::string(env);
   }
   // Precedence 3: auto-detect. Succeeds iff exactly one device is visible
-  // — the common case on Macs with a single Thunderbolt RDMA fabric.
+  // - the common case on Macs with a single Thunderbolt RDMA fabric.
   auto devices = listRdmaDevices();
   TORCH_CHECK_WITH(
       DistBackendError,
@@ -231,7 +224,7 @@ std::vector<std::string> resolveTcclPeerDevices(
   const int left = (rank - 1 + size) % size;
   const int right = (rank + 1) % size;
   // Which peers this rank is physically cabled to. Mesh: every non-self peer.
-  // Ring: only the two neighbors ((rank±1)%size) — every other slot (incl. self)
+  // Ring: only the two neighbors ((rank+/-1)%size) - every other slot (incl. self)
   // must be empty, so the sparse row round-trips to null connection slots.
   const auto isConnectedPeer = [&](int p) {
     if (p == rank) {
@@ -242,7 +235,7 @@ std::vector<std::string> resolveTcclPeerDevices(
 
   std::vector<std::string> devices(static_cast<size_t>(size));
 
-  // Precedence 1: TCCL_PEER_DEVICES — the rank's row of the device matrix.
+  // Precedence 1: TCCL_PEER_DEVICES - the rank's row of the device matrix.
   // Comma-separated, exactly `size` fields, self-slot empty. The launcher
   // derives it from the auto-discovered hostfile so each peer maps to the
   // physical port (rdma_enX) that is cabled to it. Ring rows are sparse:
@@ -300,7 +293,7 @@ std::vector<std::string> resolveTcclPeerDevices(
     return devices;
   }
 
-  // Precedence 2: a single device for every connected peer — the single-link
+  // Precedence 2: a single device for every connected peer - the single-link
   // case. resolveTcclDeviceName applies its own explicit/env/auto precedence.
   // Under ring topology only the two neighbor slots are filled.
   const std::string one = resolveTcclDeviceName(explicit_name);
@@ -311,9 +304,7 @@ std::vector<std::string> resolveTcclPeerDevices(
   return devices;
 }
 
-// =============================================================================
 // TCCLConnection
-// =============================================================================
 
 namespace {
 
@@ -350,9 +341,9 @@ TCCLConnection::TCCLConnection(const std::string& device_name) {
       "TCCL: failed to open RDMA device '",
       device_name,
       "'. Available devices: see torch.distributed.list_tccl_devices(). ",
-      "If empty, Thunderbolt may be bridged — run `sudo tbtrdmactl unbridge`.");
+      "If empty, Thunderbolt may be bridged - run `sudo tbtrdmactl unbridge`.");
 
-  // PD/CQ/QP allocation: any failure here means we partially constructed —
+  // PD/CQ/QP allocation: any failure here means we partially constructed -
   // call destroy() to free what we did get before rethrowing.
   try {
     pd_ = ibv.alloc_pd(ctx_);
@@ -379,14 +370,15 @@ TCCLConnection::TCCLConnection(const std::string& device_name) {
     qp_init.cap.max_send_sge = kQpMaxSge;
     qp_init.cap.max_recv_sge = kQpMaxSge;
     qp_init.cap.max_inline_data = 0;
-    qp_init.sq_sig_all = 0;  // Only explicitly-signaled sends get a CQE.
+    // Only explicitly-signaled sends get a CQE
+    qp_init.sq_sig_all = 0;
 
     qp_ = ibv.create_qp(pd_, &qp_init);
     TORCH_CHECK_WITH(
         DistBackendError,
         qp_ != nullptr,
         "TCCL: ibv_create_qp(UC) failed. Most common cause on Thunderbolt: "
-        "the device's 10-QP-per-context limit is exhausted (Apple TN3205 §12.1). "
+        "the device's 10-QP-per-context limit is exhausted (Apple TN3205 sec. 12.1). "
         "Spread peers across more devices or reduce num_wires.");
 
     // QP -> INIT (the first transition; INIT->RTR happens once the peer's
@@ -407,10 +399,9 @@ TCCLConnection::TCCLConnection(const std::string& device_name) {
           ret);
     }
 
-    // Populate local routing info now so the caller can publish it via Store
-    // immediately after construction. ibv_query_port reports link state
-    // (must be ACTIVE) and LID; ibv_query_gid at index 1 returns the
-    // IPv4-mapped GID that Thunderbolt uses for addressing.
+    // Populate local routing info for the caller to publish via Store.
+    // ibv_query_port gives link state (must be ACTIVE) and LID; ibv_query_gid at
+    // index 1 gives the IPv4-mapped GID Thunderbolt addresses with.
     ibv_port_attr port_attr{};
     int qp_ret = ibv.query_port(ctx_, kQpPort, &port_attr);
     TORCH_CHECK_WITH(
@@ -480,10 +471,9 @@ void TCCLConnection::swap(TCCLConnection& other) noexcept {
 }
 
 void TCCLConnection::destroy() noexcept {
-  // Teardown order: QP -> CQ -> PD -> context. Each tier depends on the
-  // ones below it, so we unwind in reverse-allocation order. Errors are
-  // intentionally ignored — there's nothing useful we can do on a teardown
-  // failure in a destructor, and throwing from noexcept would call std::terminate.
+  // Teardown QP -> CQ -> PD -> context (reverse-allocation order). Errors are
+  // ignored - nothing useful to do on teardown, and throwing from noexcept
+  // would call std::terminate.
   auto& ibv = TCCLIBVWrapper::instance();
   if (qp_ != nullptr) {
     ibv.destroy_qp(qp_);
@@ -512,7 +502,7 @@ void TCCLConnection::transitionToRTR(const TCCLDestination& remote) {
 
   ibv_qp_attr attr{};
   attr.qp_state = IBV_QPS_RTR;
-  // IBV_MTU_1024 — TN3205 recommends 4096 but it consistently caused RTR
+  // IBV_MTU_1024 - TN3205 recommends 4096 but it consistently caused RTR
   // timeouts on the Thunderbolt RDMA stack; the hardware appears to negotiate
   // 1024 as the supported MTU.
   attr.path_mtu = IBV_MTU_1024;
@@ -552,7 +542,7 @@ void TCCLConnection::transitionToRTR(const TCCLDestination& remote) {
       ", psn=",
       remote.psn,
       ". errno=60 (ETIMEDOUT) usually means the link-layer subnet is not "
-      "configured — call check_tccl_link_layer() before init, or configure a "
+      "configured - call check_tccl_link_layer() before init, or configure a "
       "static /30 on the Thunderbolt interface.");
 }
 
@@ -575,7 +565,7 @@ void TCCLConnection::transitionToRTS() {
       ret);
 }
 
-// ---- TCCLConnection data-path methods --------------------------------------
+// TCCLConnection data-path methods
 
 void TCCLConnection::postSend(
     const TCCLSharedBuffer& buf,
@@ -597,8 +587,8 @@ void TCCLConnection::postSend(
   wr.next = nullptr;
 
   ibv_send_wr* bad = nullptr;
-  // ibv_post_send is inline in <infiniband/verbs.h> — calls through
-  // qp->context->ops, no syscall (Apple TN3205 §12.5).
+  // ibv_post_send is inline in <infiniband/verbs.h> - calls through
+  // qp->context->ops, no syscall (Apple TN3205 sec. 12.5).
   int rc = ibv_post_send(qp_, &wr, &bad);
   TORCH_CHECK_WITH(
       DistBackendError,
@@ -658,7 +648,7 @@ int TCCLConnection::pollCq(int max_completions, ibv_wc* wcs) {
   return n;
 }
 
-// ---- TCCLSharedBuffer ------------------------------------------------------
+// TCCLSharedBuffer
 
 TCCLSharedBuffer::TCCLSharedBuffer(size_t num_bytes) : size_(num_bytes) {
   TORCH_CHECK_WITH(
@@ -735,7 +725,7 @@ void TCCLSharedBuffer::registerToPD(ibv_pd* pd) {
       DistBackendError,
       pd != nullptr,
       "TCCL: registerToPD called with null pd.");
-  // Access flag set (LOCAL_WRITE | REMOTE_READ | REMOTE_WRITE). TN3205 §12.2
+  // Access flag set (LOCAL_WRITE | REMOTE_READ | REMOTE_WRITE). TN3205 sec. 12.2
   // notes LOCAL_WRITE alone is enough for 2-sided UC; the broader set is also
   // valid and is what this backend uses.
   auto& ibv = TCCLIBVWrapper::instance();
@@ -753,7 +743,7 @@ void TCCLSharedBuffer::registerToPD(ibv_pd* pd) {
       ") returned null.");
   auto [it, inserted] = mrs_.emplace(pd, mr);
   if (!inserted) {
-    // Already had an MR for this pd — that's a programming error in our
+    // Already had an MR for this pd - that's a programming error in our
     // caller. Free the new MR and throw.
     ibv.dereg_mr(mr);
     TORCH_CHECK_WITH(
@@ -832,13 +822,11 @@ int64_t tcclInitSequence(
     Store& store,
     int rank,
     std::chrono::milliseconds timeout) {
-  // All ranks must agree on ONE sequence number for this PG instance. Only
-  // rank 0 reserves it via Store::add (a server-side atomic on TCPStore,
-  // fresh on every (re)creation) and broadcasts it via
-  // the Store; every other rank reads rank 0's value. A per-rank Store::add
-  // would return a different post-increment value to each caller, so the
-  // ranks would build different key prefixes and never find each other's
-  // destinations. Mirrors ProcessGroupNCCL's unique-id broadcast.
+  // All ranks must agree on ONE sequence number for this PG instance. Only rank
+  // 0 reserves it (Store::add, a server-side atomic) and broadcasts it; others
+  // read rank 0's value. A per-rank Store::add would hand each caller a
+  // different value, so key prefixes would diverge and ranks never find each
+  // other. Mirrors ProcessGroupNCCL's unique-id broadcast.
   if (rank == 0) {
     const int64_t seq = store.add(kInitCounterKey, 1);
     const std::string s = std::to_string(seq);
@@ -875,9 +863,9 @@ void allgatherDestinationsViaStore(
 
   const size_t bytes_per_rank = local.size() * sizeof(TCCLDestination);
 
-  // Reinterpret_cast to bytes — same pattern as ProcessGroupNCCL.cpp:
-  // 2916-2918 for ncclUniqueId. POD, well-defined, single-platform (macOS
-  // arm64) on both sides.
+  // Reinterpret_cast to bytes - same pattern as ProcessGroupNCCL's
+  // allgatherUniqueNCCLIDs for ncclUniqueId. POD, well-defined, single-platform
+  // (macOS arm64) on both sides.
   std::vector<uint8_t> myBytes(
       reinterpret_cast<const uint8_t*>(local.data()),
       reinterpret_cast<const uint8_t*>(local.data()) + bytes_per_rank);

--- a/torch/csrc/distributed/c10d/TCCLUtils.hpp
+++ b/torch/csrc/distributed/c10d/TCCLUtils.hpp
@@ -1,0 +1,352 @@
+#pragma once
+
+#ifdef USE_C10D_TCCL
+
+// TCCL transport-layer types and free-function helpers used by ProcessGroupTCCL.
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <c10/macros/Macros.h>
+#include <c10/util/intrusive_ptr.h>
+
+struct ibv_context;
+struct ibv_pd;
+struct ibv_cq;
+struct ibv_qp;
+struct ibv_mr;
+struct ibv_device;
+struct ibv_qp_init_attr;
+struct ibv_qp_attr;
+struct ibv_port_attr;
+struct ibv_comp_channel;
+struct ibv_sge;
+struct ibv_wc;
+union ibv_gid;
+
+namespace c10d {
+
+class Store;
+
+class TCCLRegisteredMPSTensor;
+
+// POD routing info exchanged between peers during QP setup. Serialized by
+// reinterpret_cast to bytes.
+//
+// 32 bytes on macOS arm64: 3 * int (12 bytes, 4-byte aligned) + ibv_gid
+// (16 bytes union). The static_assert in TCCLUtils.cpp catches any platform
+// where this assumption breaks before we send corrupt bytes over the wire.
+struct TCCLDestination {
+  int32_t lid;
+  int32_t qp_num;
+  int32_t psn;
+  int32_t _pad;       // align gid to 16 bytes; ibv_gid is a 16-byte union
+  uint8_t gid[16];    // raw GID bytes
+
+};
+
+// =============================================================================
+// IBV wrapper - singleton dlopen of librdma.dylib
+// =============================================================================
+
+// Process-wide singleton owning the dlopen handle and dlsym'd function
+// pointers for all librdma.dylib control-path symbols. Data-path symbols
+// (ibv_post_send, ibv_post_recv, ibv_poll_cq) are NOT dlsym'd - they are
+// inline in <infiniband/verbs.h> and call through ctx->ops.
+
+class TORCH_API TCCLIBVWrapper {
+ public:
+  static TCCLIBVWrapper& instance();
+
+  // Disable copy and move - singleton.
+  TCCLIBVWrapper(const TCCLIBVWrapper&) = delete;
+  TCCLIBVWrapper& operator=(const TCCLIBVWrapper&) = delete;
+  TCCLIBVWrapper(TCCLIBVWrapper&&) = delete;
+  TCCLIBVWrapper& operator=(TCCLIBVWrapper&&) = delete;
+
+  // Control-path verbs entry points, resolved via dlsym in the constructor.
+  // Signatures mirror <infiniband/verbs.h> using forward-declared struct
+  // types so this header does not depend on librdma headers.
+  ibv_device** (*get_device_list)(int*) = nullptr;
+  const char*  (*get_device_name)(ibv_device*) = nullptr;
+  ibv_context* (*open_device)(ibv_device*) = nullptr;
+  void         (*free_device_list)(ibv_device**) = nullptr;
+  int          (*close_device)(ibv_context*) = nullptr;
+  ibv_pd*      (*alloc_pd)(ibv_context*) = nullptr;
+  ibv_cq*      (*create_cq)(
+      ibv_context*,
+      int cqe,
+      void* cq_context,
+      ibv_comp_channel*,
+      int comp_vector) = nullptr;
+  ibv_qp*      (*create_qp)(ibv_pd*, ibv_qp_init_attr*) = nullptr;
+  int          (*destroy_qp)(ibv_qp*) = nullptr;
+  int          (*destroy_cq)(ibv_cq*) = nullptr;
+  int          (*dealloc_pd)(ibv_pd*) = nullptr;
+  int          (*query_port)(ibv_context*, uint8_t, ibv_port_attr*) = nullptr;
+  int          (*query_gid)(ibv_context*, uint8_t, int, ibv_gid*) = nullptr;
+  int          (*modify_qp)(ibv_qp*, ibv_qp_attr*, int) = nullptr;
+  ibv_mr*      (*reg_mr)(ibv_pd*, void*, size_t, int) = nullptr;
+  int          (*dereg_mr)(ibv_mr*) = nullptr;
+
+ private:
+  // Constructor performs dlopen + 16 dlsym in one shot.
+  TCCLIBVWrapper();
+  ~TCCLIBVWrapper() = default;
+
+  void* handle_ = nullptr;
+};
+
+// =============================================================================
+// Connection - owns one QP plus its supporting context/PD/CQ
+// =============================================================================
+
+// One Connection corresponds to one UC queue pair to one peer-wire. Each
+// instance opens its own ibv_context, allocates its own PD/CQ, and creates
+// one QP.
+
+// Lifecycle:
+//   ctor              opens device, allocates PD/CQ, creates QP, transitions
+//                     QP to INIT, populates local_destination_.
+//   transitionToRTR   feeds the peer's TCCLDestination to ibv_modify_qp(RTR).
+//   transitionToRTS   transitions to RTS using local PSN.
+//   dtor              tears down QP -> CQ -> PD -> ctx in that order.
+
+class TORCH_API TCCLConnection {
+ public:
+  // Opens device_name (e.g. "rdma_en2") and runs through INIT-state
+  // initialization. After construction, localDestination() returns valid
+  // QP routing info ready to publish via Store.
+  explicit TCCLConnection(const std::string& device_name);
+
+  ~TCCLConnection();
+
+  TCCLConnection(const TCCLConnection&) = delete;
+  TCCLConnection& operator=(const TCCLConnection&) = delete;
+
+  TCCLConnection(TCCLConnection&& other) noexcept;
+  TCCLConnection& operator=(TCCLConnection&& other) noexcept;
+
+  // Transition our QP to RTR using the peer's published routing info.
+  // Throws DistBackendError on ibv_modify_qp failure.
+  void transitionToRTR(const TCCLDestination& remote);
+
+  // Transition our QP to RTS using our locally chosen PSN.
+  void transitionToRTS();
+
+  // ===== Data-path methods =====
+  // Post a send WR referencing `length` bytes of `buf`'s storage. Caller is
+  // responsible for buf having been registered to this Connection's PD via
+  // TCCLSharedBuffer::registerToPD(protectionDomain()) at init time.
+  // wr_id is opaque to verbs - the algorithm layer encodes (type, slot, peer)
+  // into it for completion-event demultiplexing (see TCCLEngine).
+  // Throws DistBackendError if ibv_post_send returns non-zero.
+  void postSend(
+      const class TCCLSharedBuffer& buf,
+      uint64_t length,
+      uint64_t wr_id);
+
+  // Post a recv WR referencing `length` bytes of `buf`'s storage. Same
+  // registration precondition as postSend. UC requires the recv to be
+  // posted BEFORE the matching send arrives (Apple TN3205 §12.3: credit-based
+  // flow control stalls the sender otherwise).
+  void postRecv(
+      class TCCLSharedBuffer& buf,
+      uint64_t length,
+      uint64_t wr_id);
+
+  // Non-blocking. Polls up to `max_completions` work completion events
+  // from this Connection's CQ into `wcs`. Returns the number actually
+  // dequeued (0 if CQ empty, never negative - verbs errors throw).
+  // Caller is the algorithm layer which busy-polls until all expected
+  // completions arrive.
+  int pollCq(int max_completions, ibv_wc* wcs);
+
+  // Local routing info this rank publishes to peers via Store.
+  const TCCLDestination& localDestination() const noexcept {
+    return local_destination_;
+  }
+
+  // Accessors for the algorithm/buffer layer. Returned pointers are owned by
+  // this Connection - do not free.
+  ibv_context* context() const noexcept { return ctx_; }
+  ibv_pd* protectionDomain() const noexcept { return pd_; }
+  ibv_cq* completionQueue() const noexcept { return cq_; }
+  ibv_qp* queuePair() const noexcept { return qp_; }
+
+ private:
+  void swap(TCCLConnection& other) noexcept;
+  void destroy() noexcept;
+
+  ibv_context* ctx_ = nullptr;
+  ibv_pd* pd_ = nullptr;
+  ibv_cq* cq_ = nullptr;
+  ibv_qp* qp_ = nullptr;
+  TCCLDestination local_destination_{};
+};
+
+// =============================================================================
+// SharedBuffer - page-aligned RDMA-registerable storage
+// =============================================================================
+
+// A fixed-size, page-aligned chunk of host memory that can be registered to
+// one or more protection domains via ibv_reg_mr.
+//
+// One of these is used per (peer, direction): every rank holds (size_-1) send
+// buffers and (size_-1) recv buffers, each registered to the corresponding
+// peer's PD.
+//
+// Move-only because the underlying allocation and the MR map cannot be
+// safely copied. Default-constructible as an empty buffer (data_=nullptr,
+// size_=0) so vectors of SharedBuffers can be sized first and assigned later.
+class TORCH_API TCCLSharedBuffer {
+ public:
+  // Empty buffer. Useful as a placeholder for the self-slot in
+  // peer-indexed vectors.
+  TCCLSharedBuffer() noexcept = default;
+
+  // Allocate `num_bytes` of page-aligned storage via posix_memalign and
+  // zero-initialize. Throws DistBackendError on allocation failure.
+  explicit TCCLSharedBuffer(size_t num_bytes);
+
+  ~TCCLSharedBuffer();
+
+  TCCLSharedBuffer(const TCCLSharedBuffer&) = delete;
+  TCCLSharedBuffer& operator=(const TCCLSharedBuffer&) = delete;
+
+  TCCLSharedBuffer(TCCLSharedBuffer&& other) noexcept;
+  TCCLSharedBuffer& operator=(TCCLSharedBuffer&& other) noexcept;
+
+  // Register the underlying storage with a protection domain. The MR is
+  // owned by this object and freed in the destructor. Throws
+  // DistBackendError if `pd` is already registered - buffers register to each
+  // peer's PD exactly once at init.
+  void registerToPD(ibv_pd* pd);
+
+  // Build an ibv_sge describing `length` bytes at offset 0 of this buffer's
+  // storage, using the lkey from the MR registered to `pd`. `pd` must have
+  // been passed to registerToPD; otherwise throws DistBackendError.
+  // `length` must be <= size().
+  ibv_sge toSge(ibv_pd* pd, uint64_t length) const;
+
+  // Raw access for memcpy in/out of the buffer. Pointer is page-aligned.
+  void* data() noexcept { return data_; }
+  const void* data() const noexcept { return data_; }
+
+  size_t size() const noexcept { return size_; }
+  bool empty() const noexcept { return data_ == nullptr; }
+
+ private:
+  void destroy() noexcept;
+  void swap(TCCLSharedBuffer& other) noexcept;
+
+  void* data_ = nullptr;
+  size_t size_ = 0;
+  std::unordered_map<ibv_pd*, ibv_mr*> mrs_;
+};
+
+// =============================================================================
+// Free helpers
+// =============================================================================
+
+// Lists the names of RDMA devices visible to librdma on this host.
+// Loads the singleton TCCLIBVWrapper if not already loaded. Returns an empty
+// vector if the library loads but the device list is empty (e.g.
+// Thunderbolt is bridged - user must run `sudo tbtrdmactl unbridge`).
+// Throws DistBackendError if librdma cannot be loaded.
+TORCH_API std::vector<std::string> listRdmaDevices();
+
+// Resolve which RDMA device the backend should bind to.
+//
+// Precedence:
+//   1. `explicit_name` if non-empty (passed via Options::device_name).
+//   2. `TCCL_DEVICE` environment variable.
+//   3. Auto-detect via listRdmaDevices() - succeeds iff exactly one
+//      device is visible (the common case on a single-Thunderbolt-port Mac).
+//
+// Throws DistBackendError with an actionable message when no device is
+// found OR when multiple devices are found and no explicit selection was
+// provided.
+TORCH_API std::string resolveTcclDeviceName(const std::string& explicit_name);
+
+// Resolve the per-peer RDMA device list for this rank. Returns a vector of
+// size `size`; entry [peer] is the device this rank uses to reach `peer`, with
+// the self-slot ([rank]) left empty. In a full Thunderbolt mesh each peer is on
+// a different physical port (different rdma_enX), so a single device cannot
+// drive the group.
+//
+// Precedence:
+//   1. TCCL_PEER_DEVICES env - comma-separated list of exactly `size` device
+//      names, self-slot empty (e.g. "rdma_en2,,rdma_en3,rdma_en4" for rank 1 of
+//      4). This is the rank's row of the auto-discovered device matrix, set by
+//      the launcher from the hostfile. Enables the full-mesh topology.
+//   2. Fallback - a single device (resolveTcclDeviceName(explicit_name)) for
+//      ALL peers (the single-Thunderbolt-link case).
+//
+// Throws DistBackendError if TCCL_PEER_DEVICES is set but malformed (wrong
+// count, non-empty self-slot, or empty peer slot). Under ring_topology the row
+// is sparse: only the two neighbor slots ((rank±1)%size) may be non-empty and
+// all other slots (incl. self) must be empty - the inverse is enforced too.
+TORCH_API std::vector<std::string> resolveTcclPeerDevices(
+    int rank,
+    int size,
+    const std::string& explicit_name,
+    bool ring_topology = false);
+
+// Verify the underlying BSD interface for the requested RDMA device has a
+// non-link-local static IPv4 address. Throws DistBackendError with the exact
+// sudo commands to run if the prerequisite isn't met.
+TORCH_API void checkLinkLayer(const std::string& rdma_device);
+
+// Reserve a unique init sequence number that ALL ranks of this PG instance
+// agree on. Used as a key prefix for destination exchange so PG re-init under
+// the same group_name cannot accidentally read stale destinations from a
+// prior incarnation.
+//
+// Only rank 0 reserves the number (Store::add - a server-side atomic on
+// TCPStore, fresh on every (re)creation) and broadcasts it via the Store;
+// every other rank reads rank 0's value. A per-rank
+// Store::add would hand each rank a different post-increment value, so the
+// ranks would build different key prefixes and never find each other. Mirrors
+// NCCL's unique-id broadcast. Returns the agreed counter value (1-indexed).
+TORCH_API int64_t tcclInitSequence(
+    Store& store,
+    int rank,
+    std::chrono::milliseconds timeout);
+
+// All-to-all destination exchange. Each rank publishes its
+// num_wires-sized vector of TCCLDestinations under keyPrefix + std::to_string(rank),
+// then blocks on Store::multiGet until every peer has done the same.
+//
+// On length mismatch (e.g. peer compiled with different num_wires), throws
+// DistBackendError with the offending peer's rank and byte counts.
+TORCH_API void allgatherDestinationsViaStore(
+    Store& store,
+    int rank,
+    int size,
+    const std::vector<TCCLDestination>& local,
+    std::vector<std::vector<TCCLDestination>>& remote,
+    const std::string& keyPrefix,
+    std::chrono::milliseconds timeout);
+
+// Global RTS barrier - every rank reaches this point after locally
+// transitioning all of its QPs to RTS, before any rank is allowed to post
+// a send. Otherwise UC drops on the receiver side if its QP isn't yet RTS.
+//
+// Wraps Store::barrier. Optimized server-side increment+wait - single round
+// trip per rank.
+TORCH_API void tcclRtsBarrier(
+    Store& store,
+    int size,
+    const std::string& key,
+    std::chrono::milliseconds timeout);
+
+} // namespace c10d
+
+#endif // USE_C10D_TCCL
+

--- a/torch/csrc/distributed/c10d/TCCLUtils.hpp
+++ b/torch/csrc/distributed/c10d/TCCLUtils.hpp
@@ -38,21 +38,20 @@ class TCCLRegisteredMPSTensor;
 // POD routing info exchanged between peers during QP setup. Serialized by
 // reinterpret_cast to bytes.
 //
-// 32 bytes on macOS arm64: 3 * int (12 bytes, 4-byte aligned) + ibv_gid
-// (16 bytes union). The static_assert in TCCLUtils.cpp catches any platform
-// where this assumption breaks before we send corrupt bytes over the wire.
+// 32 bytes on macOS arm64: 4 * int32 (16 bytes) + uint8[16] (16 bytes). The
+// static_assert in TCCLUtils.cpp catches any platform where this assumption
+// breaks before we send corrupt bytes over the wire.
 struct TCCLDestination {
   int32_t lid;
   int32_t qp_num;
   int32_t psn;
-  int32_t _pad;       // align gid to 16 bytes; ibv_gid is a 16-byte union
-  uint8_t gid[16];    // raw GID bytes
+  // Align gid to 16 bytes - ibv_gid is a 16-byte union
+  int32_t _pad;
+  uint8_t gid[16];
 
 };
 
-// =============================================================================
 // IBV wrapper - singleton dlopen of librdma.dylib
-// =============================================================================
 
 // Process-wide singleton owning the dlopen handle and dlsym'd function
 // pointers for all librdma.dylib control-path symbols. Data-path symbols
@@ -102,9 +101,7 @@ class TORCH_API TCCLIBVWrapper {
   void* handle_ = nullptr;
 };
 
-// =============================================================================
 // Connection - owns one QP plus its supporting context/PD/CQ
-// =============================================================================
 
 // One Connection corresponds to one UC queue pair to one peer-wire. Each
 // instance opens its own ibv_context, allocates its own PD/CQ, and creates
@@ -139,7 +136,7 @@ class TORCH_API TCCLConnection {
   // Transition our QP to RTS using our locally chosen PSN.
   void transitionToRTS();
 
-  // ===== Data-path methods =====
+  // Data-path methods
   // Post a send WR referencing `length` bytes of `buf`'s storage. Caller is
   // responsible for buf having been registered to this Connection's PD via
   // TCCLSharedBuffer::registerToPD(protectionDomain()) at init time.
@@ -153,7 +150,7 @@ class TORCH_API TCCLConnection {
 
   // Post a recv WR referencing `length` bytes of `buf`'s storage. Same
   // registration precondition as postSend. UC requires the recv to be
-  // posted BEFORE the matching send arrives (Apple TN3205 §12.3: credit-based
+  // posted BEFORE the matching send arrives (Apple TN3205 sec. 12.3: credit-based
   // flow control stalls the sender otherwise).
   void postRecv(
       class TCCLSharedBuffer& buf,
@@ -190,20 +187,14 @@ class TORCH_API TCCLConnection {
   TCCLDestination local_destination_{};
 };
 
-// =============================================================================
 // SharedBuffer - page-aligned RDMA-registerable storage
-// =============================================================================
 
-// A fixed-size, page-aligned chunk of host memory that can be registered to
-// one or more protection domains via ibv_reg_mr.
+// A fixed-size, page-aligned host buffer registerable to one or more protection
+// domains via ibv_reg_mr. One per (peer, direction): each rank holds (size_-1)
+// send and (size_-1) recv buffers, each registered to the matching peer's PD.
 //
-// One of these is used per (peer, direction): every rank holds (size_-1) send
-// buffers and (size_-1) recv buffers, each registered to the corresponding
-// peer's PD.
-//
-// Move-only because the underlying allocation and the MR map cannot be
-// safely copied. Default-constructible as an empty buffer (data_=nullptr,
-// size_=0) so vectors of SharedBuffers can be sized first and assigned later.
+// Move-only (allocation + MR map cannot be copied). Default-constructible as an
+// empty buffer so vectors can be sized first and assigned later.
 class TORCH_API TCCLSharedBuffer {
  public:
   // Empty buffer. Useful as a placeholder for the self-slot in
@@ -250,9 +241,7 @@ class TORCH_API TCCLSharedBuffer {
   std::unordered_map<ibv_pd*, ibv_mr*> mrs_;
 };
 
-// =============================================================================
 // Free helpers
-// =============================================================================
 
 // Lists the names of RDMA devices visible to librdma on this host.
 // Loads the singleton TCCLIBVWrapper if not already loaded. Returns an empty
@@ -274,11 +263,10 @@ TORCH_API std::vector<std::string> listRdmaDevices();
 // provided.
 TORCH_API std::string resolveTcclDeviceName(const std::string& explicit_name);
 
-// Resolve the per-peer RDMA device list for this rank. Returns a vector of
-// size `size`; entry [peer] is the device this rank uses to reach `peer`, with
-// the self-slot ([rank]) left empty. In a full Thunderbolt mesh each peer is on
-// a different physical port (different rdma_enX), so a single device cannot
-// drive the group.
+// Resolve the per-peer RDMA device list for this rank. Returns a size-`size`
+// vector; entry [peer] is the device reaching `peer`, self-slot ([rank]) empty.
+// In a full Thunderbolt mesh each peer is on a different port, so one device
+// cannot drive the group.
 //
 // Precedence:
 //   1. TCCL_PEER_DEVICES env - comma-separated list of exactly `size` device
@@ -290,7 +278,7 @@ TORCH_API std::string resolveTcclDeviceName(const std::string& explicit_name);
 //
 // Throws DistBackendError if TCCL_PEER_DEVICES is set but malformed (wrong
 // count, non-empty self-slot, or empty peer slot). Under ring_topology the row
-// is sparse: only the two neighbor slots ((rank±1)%size) may be non-empty and
+// is sparse: only the two neighbor slots ((rank+/-1)%size) may be non-empty and
 // all other slots (incl. self) must be empty - the inverse is enforced too.
 TORCH_API std::vector<std::string> resolveTcclPeerDevices(
     int rank,
@@ -305,15 +293,9 @@ TORCH_API void checkLinkLayer(const std::string& rdma_device);
 
 // Reserve a unique init sequence number that ALL ranks of this PG instance
 // agree on. Used as a key prefix for destination exchange so PG re-init under
-// the same group_name cannot accidentally read stale destinations from a
-// prior incarnation.
-//
-// Only rank 0 reserves the number (Store::add - a server-side atomic on
-// TCPStore, fresh on every (re)creation) and broadcasts it via the Store;
-// every other rank reads rank 0's value. A per-rank
-// Store::add would hand each rank a different post-increment value, so the
-// ranks would build different key prefixes and never find each other. Mirrors
-// NCCL's unique-id broadcast. Returns the agreed counter value (1-indexed).
+// the same group_name cannot read stale destinations from a prior incarnation.
+// Only rank 0 reserves (Store::add) and broadcasts; others read it. Returns the
+// agreed counter value (1-indexed).
 TORCH_API int64_t tcclInitSequence(
     Store& store,
     int rank,

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -52,6 +52,11 @@
 #include <torch/csrc/distributed/c10d/ProcessGroupUCC.hpp>
 #endif
 
+#ifdef USE_C10D_TCCL
+#include <torch/csrc/distributed/c10d/ProcessGroupTCCL.hpp>
+#include <torch/csrc/distributed/c10d/TCCLUtils.hpp>
+#endif
+
 #include <fmt/format.h>
 #include <pybind11/chrono.h>
 #include <pybind11/functional.h>
@@ -3873,6 +3878,104 @@ options :class:`~torch.distributed.ProcessGroupNCCL.Options`).
               "get_error",
               &::c10d::ProcessGroupWrapper::getError,
               py::call_guard<py::gil_scoped_release>());
+#endif
+
+#ifdef USE_C10D_TCCL
+  auto processGroupTCCL =
+      intrusive_ptr_no_gil_destructor_class_<::c10d::ProcessGroupTCCL>(
+          module, "ProcessGroupTCCL", backend);
+
+  py::enum_<::c10d::ProcessGroupTCCL::Topology>(processGroupTCCL, "Topology")
+      .value("MESH", ::c10d::ProcessGroupTCCL::Topology::Mesh)
+      .value("RING", ::c10d::ProcessGroupTCCL::Topology::Ring);
+
+  intrusive_ptr_class_<::c10d::ProcessGroupTCCL::Options>(
+      processGroupTCCL, "_Options", backendOptions)
+      .def(py::init<std::chrono::milliseconds>(), py::arg("timeout"))
+      .def_readwrite(
+          "_device_name", &::c10d::ProcessGroupTCCL::Options::device_name)
+      .def_readwrite(
+          "_num_wires", &::c10d::ProcessGroupTCCL::Options::num_wires)
+      .def_readwrite(
+          "_topology", &::c10d::ProcessGroupTCCL::Options::topology);
+
+  processGroupTCCL
+      .def(
+          py::init(
+              [](const c10::intrusive_ptr<::c10d::Store>& store,
+                 int rank,
+                 int size,
+                 const c10::intrusive_ptr<::c10d::ProcessGroupTCCL::Options>&
+                     options) {
+                py::gil_scoped_release nogil{};
+                return c10::make_intrusive<::c10d::ProcessGroupTCCL>(
+                    store, rank, size, options);
+              }),
+          py::arg("store"),
+          py::arg("rank"),
+          py::arg("size"),
+          py::arg("options"),
+          R"(Create a new ProcessGroupTCCL instance.)")
+      .def(
+          py::init([](const c10::intrusive_ptr<::c10d::Store>& store,
+                      int rank,
+                      int size,
+                      std::chrono::milliseconds timeout) {
+            py::gil_scoped_release nogil{};
+            return c10::make_intrusive<::c10d::ProcessGroupTCCL>(
+                store,
+                rank,
+                size,
+                ::c10d::ProcessGroupTCCL::Options::create(timeout));
+          }),
+          py::arg("store"),
+          py::arg("rank"),
+          py::arg("size"),
+          py::arg("timeout") = kProcessGroupDefaultTimeout,
+          R"(Create a new ProcessGroupTCCL instance.)")
+      .def(
+          "_set_default_timeout",
+          &::c10d::ProcessGroupTCCL::setTimeout,
+          py::arg("timeout"),
+          py::call_guard<py::gil_scoped_release>())
+      .def_property_readonly(
+          "options",
+          &::c10d::ProcessGroupTCCL::getOptions,
+          R"(Return the options used to create this ProcessGroupTCCL instance.)");
+
+  // Diagnostic: verify the BSD interface backing the requested rdma_enX
+  // device has a non-link-local IPv4 address. Throws DistBackendError with
+  // the exact sudo commands to run if the prerequisite isn't met. Exposed
+  // here so users can call it before init_process_group to validate setup
+  // independently of constructing a ProcessGroup.
+  module.def(
+      "_tccl_check_link_layer",
+      &::c10d::checkLinkLayer,
+      py::arg("device_name"),
+      py::call_guard<py::gil_scoped_release>(),
+      R"(Check the link-layer prerequisite for TCCL on a given RDMA device.
+
+Throws RuntimeError if the BSD interface corresponding to ``device_name``
+(e.g. ``rdma_en2`` → ``en2``) lacks a non-link-local static IPv4 address.
+The error message includes the exact ``ifconfig`` / ``route`` commands
+required.)");
+
+  // Diagnostic: enumerate RDMA devices visible to librdma on this host.
+  // Loads librdma.dylib via dlopen on first call (singleton). Returns an
+  // empty list when the library loads but no devices are present (most
+  // likely Thunderbolt is bridged — user should run `sudo tbtrdmactl
+  // unbridge`). Throws RuntimeError when librdma itself can't be loaded.
+  module.def(
+      "_tccl_list_devices",
+      &::c10d::listRdmaDevices,
+      py::call_guard<py::gil_scoped_release>(),
+      R"(Enumerate RDMA devices visible to TCCL on this host.
+
+Returns a list of device names (e.g. ``["rdma_en2"]``). Returns an empty
+list if Thunderbolt RDMA is enabled but no devices appear — most likely
+the Thunderbolt fabric is bridged and needs ``sudo tbtrdmactl unbridge``.
+Raises RuntimeError if ``librdma.dylib`` cannot be loaded (e.g. macOS
+< 26.2 or RDMA not enabled via ``bputil``).)");
 #endif
 
 #ifdef USE_C10D_NCCL

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -44,6 +44,11 @@
 #include <torch/csrc/distributed/c10d/ProcessGroupUCC.hpp>
 #endif
 
+#ifdef USE_C10D_TCCL
+#include <torch/csrc/distributed/c10d/ProcessGroupTCCL.hpp>
+#include <torch/csrc/distributed/c10d/TCCLUtils.hpp>
+#endif
+
 #include <fmt/format.h>
 #include <pybind11/chrono.h>
 #include <pybind11/functional.h>
@@ -3570,6 +3575,104 @@ options :class:`~torch.distributed.ProcessGroupNCCL.Options`).
               "get_error",
               &::c10d::ProcessGroupWrapper::getError,
               py::call_guard<py::gil_scoped_release>());
+#endif
+
+#ifdef USE_C10D_TCCL
+  auto processGroupTCCL =
+      intrusive_ptr_no_gil_destructor_class_<::c10d::ProcessGroupTCCL>(
+          module, "ProcessGroupTCCL", backend);
+
+  py::enum_<::c10d::ProcessGroupTCCL::Topology>(processGroupTCCL, "Topology")
+      .value("MESH", ::c10d::ProcessGroupTCCL::Topology::Mesh)
+      .value("RING", ::c10d::ProcessGroupTCCL::Topology::Ring);
+
+  intrusive_ptr_class_<::c10d::ProcessGroupTCCL::Options>(
+      processGroupTCCL, "_Options", backendOptions)
+      .def(py::init<std::chrono::milliseconds>(), py::arg("timeout"))
+      .def_readwrite(
+          "_device_name", &::c10d::ProcessGroupTCCL::Options::device_name)
+      .def_readwrite(
+          "_num_wires", &::c10d::ProcessGroupTCCL::Options::num_wires)
+      .def_readwrite(
+          "_topology", &::c10d::ProcessGroupTCCL::Options::topology);
+
+  processGroupTCCL
+      .def(
+          py::init(
+              [](const c10::intrusive_ptr<::c10d::Store>& store,
+                 int rank,
+                 int size,
+                 const c10::intrusive_ptr<::c10d::ProcessGroupTCCL::Options>&
+                     options) {
+                py::gil_scoped_release nogil{};
+                return c10::make_intrusive<::c10d::ProcessGroupTCCL>(
+                    store, rank, size, options);
+              }),
+          py::arg("store"),
+          py::arg("rank"),
+          py::arg("size"),
+          py::arg("options"),
+          R"(Create a new ProcessGroupTCCL instance.)")
+      .def(
+          py::init([](const c10::intrusive_ptr<::c10d::Store>& store,
+                      int rank,
+                      int size,
+                      std::chrono::milliseconds timeout) {
+            py::gil_scoped_release nogil{};
+            return c10::make_intrusive<::c10d::ProcessGroupTCCL>(
+                store,
+                rank,
+                size,
+                ::c10d::ProcessGroupTCCL::Options::create(timeout));
+          }),
+          py::arg("store"),
+          py::arg("rank"),
+          py::arg("size"),
+          py::arg("timeout") = kProcessGroupDefaultTimeout,
+          R"(Create a new ProcessGroupTCCL instance.)")
+      .def(
+          "_set_default_timeout",
+          &::c10d::ProcessGroupTCCL::setTimeout,
+          py::arg("timeout"),
+          py::call_guard<py::gil_scoped_release>())
+      .def_property_readonly(
+          "options",
+          &::c10d::ProcessGroupTCCL::getOptions,
+          R"(Return the options used to create this ProcessGroupTCCL instance.)");
+
+  // Diagnostic: verify the BSD interface backing the requested rdma_enX
+  // device has a non-link-local IPv4 address. Throws DistBackendError with
+  // the exact sudo commands to run if the prerequisite isn't met. Exposed
+  // here so users can call it before init_process_group to validate setup
+  // independently of constructing a ProcessGroup.
+  module.def(
+      "_tccl_check_link_layer",
+      &::c10d::checkLinkLayer,
+      py::arg("device_name"),
+      py::call_guard<py::gil_scoped_release>(),
+      R"(Check the link-layer prerequisite for TCCL on a given RDMA device.
+
+Throws RuntimeError if the BSD interface corresponding to ``device_name``
+(e.g. ``rdma_en2`` → ``en2``) lacks a non-link-local static IPv4 address.
+The error message includes the exact ``ifconfig`` / ``route`` commands
+required.)");
+
+  // Diagnostic: enumerate RDMA devices visible to librdma on this host.
+  // Loads librdma.dylib via dlopen on first call (singleton). Returns an
+  // empty list when the library loads but no devices are present (most
+  // likely Thunderbolt is bridged — user should run `sudo tbtrdmactl
+  // unbridge`). Throws RuntimeError when librdma itself can't be loaded.
+  module.def(
+      "_tccl_list_devices",
+      &::c10d::listRdmaDevices,
+      py::call_guard<py::gil_scoped_release>(),
+      R"(Enumerate RDMA devices visible to TCCL on this host.
+
+Returns a list of device names (e.g. ``["rdma_en2"]``). Returns an empty
+list if Thunderbolt RDMA is enabled but no devices appear — most likely
+the Thunderbolt fabric is bridged and needs ``sudo tbtrdmactl unbridge``.
+Raises RuntimeError if ``librdma.dylib`` cannot be loaded (e.g. macOS
+< 26.2 or RDMA not enabled via ``bputil``).)");
 #endif
 
 #ifdef USE_C10D_NCCL

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -390,10 +390,10 @@ class Backend(str):  # noqa: SLOT000
         "cpu": GLOO,
         "cuda": NCCL,
         "xpu": XCCL,
-        # TCCL (Thunderbolt RDMA) is the MPS backend when torch is built with
-        # USE_C10D_TCCL. Without it (_TCCL_AVAILABLE == False) this maps to Gloo,
-        # which will raise on MPS tensors.
-        "mps": TCCL if _TCCL_AVAILABLE else GLOO,
+        # TCCL (Thunderbolt RDMA) is the MPS backend; requires USE_C10D_TCCL.
+        # If torch was built without it, backend creation raises a clear
+        # "rebuild with USE_TCCL=1" error (see _create_tccl_process_group).
+        "mps": TCCL,
     }
 
     backend_capability: dict[str, list[str]] = {

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -123,6 +123,9 @@ __all__ = [
     "is_torchelastic_launched",
     "is_ucc_available",
     "is_xccl_available",
+    "is_tccl_available",
+    "check_tccl_link_layer",
+    "list_tccl_devices",
     "isend",
     "monitored_barrier",
     "new_group",
@@ -173,6 +176,7 @@ _NCCL_AVAILABLE = True
 _GLOO_AVAILABLE = True
 _UCC_AVAILABLE = True
 _XCCL_AVAILABLE = True
+_TCCL_AVAILABLE = True
 
 try:
     try:
@@ -300,6 +304,14 @@ try:
 except ImportError:
     _XCCL_AVAILABLE = False
 
+try:
+    from torch._C._distributed_c10d import ProcessGroupTCCL
+
+    ProcessGroupTCCL.__module__ = "torch.distributed.distributed_c10d"
+    __all__ += ["ProcessGroupTCCL"]
+except ImportError:
+    _TCCL_AVAILABLE = False
+
 
 if TYPE_CHECKING:
     from torch._C._distributed_c10d import (  # noqa: TC004
@@ -362,6 +374,7 @@ class Backend(str):  # noqa: SLOT000
     UCC = "ucc"
     MPI = "mpi"
     XCCL = "xccl"
+    TCCL = "tccl"
     FAKE = "fake"
 
     class _BackendPlugin(NamedTuple):
@@ -370,14 +383,17 @@ class Backend(str):  # noqa: SLOT000
 
     _plugins: dict[str, _BackendPlugin] = {}
 
-    backend_list = [UNDEFINED, GLOO, NCCL, XCCL, UCC, MPI, FAKE]
+    backend_list = [UNDEFINED, GLOO, NCCL, XCCL, UCC, MPI, FAKE, TCCL]
 
     # 3rd-party devices can register the default backend support here
     default_device_backend_map: dict[str, str] = {
         "cpu": GLOO,
         "cuda": NCCL,
         "xpu": XCCL,
-        "mps": GLOO,
+        # TCCL (Thunderbolt RDMA) is the MPS backend when torch is built with
+        # USE_C10D_TCCL. Without it (_TCCL_AVAILABLE == False) this maps to Gloo,
+        # which will raise on MPS tensors.
+        "mps": TCCL if _TCCL_AVAILABLE else GLOO,
     }
 
     backend_capability: dict[str, list[str]] = {
@@ -387,6 +403,7 @@ class Backend(str):  # noqa: SLOT000
         UCC: ["cpu", "cuda"],
         MPI: ["cpu", "cuda"],
         FAKE: ["cpu", "cuda", "hpu", "xpu"],
+        TCCL: ["mps"],
     }
 
     backend_type_map: dict[str, ProcessGroup.BackendType] = {
@@ -397,6 +414,7 @@ class Backend(str):  # noqa: SLOT000
         UCC: ProcessGroup.BackendType.UCC,
         MPI: ProcessGroup.BackendType.MPI,
         FAKE: ProcessGroup.BackendType.CUSTOM,
+        TCCL: ProcessGroup.BackendType.CUSTOM,
     }
 
     def __new__(cls, name: str):
@@ -666,6 +684,36 @@ def _register_builtin_xccl_backend() -> None:
         extended_api=True,
         devices=Backend.backend_capability[Backend.XCCL],
         _backend_type=ProcessGroup.BackendType.XCCL,
+    )
+
+
+def _create_tccl_process_group(
+    opts: _DistributedBackendOptions, backend_options: Any | None
+) -> C10DBackend:
+    if not is_tccl_available():
+        raise RuntimeError(
+            "Distributed package doesn't have TCCL built in. "
+            "Rebuild with USE_TCCL=1 on macOS 26.2+ with librdma.dylib."
+        )
+    backend_class = ProcessGroupTCCL(
+        opts.store,
+        opts.group_rank,
+        opts.group_size,
+        # pyrefly: ignore [bad-argument-type]
+        timeout=opts.timeout,
+    )
+    backend_class.options.global_ranks_in_group = opts.global_ranks_in_group
+    backend_class.options.group_name = opts.group_id
+    return backend_class
+
+
+def _register_builtin_tccl_backend() -> None:
+    Backend.register_backend(
+        Backend.TCCL,
+        _create_tccl_process_group,
+        extended_api=True,
+        devices=Backend.backend_capability[Backend.TCCL],
+        _backend_type=ProcessGroup.BackendType.CUSTOM,
     )
 
 
@@ -1640,6 +1688,63 @@ def is_ucc_available() -> bool:
 def is_xccl_available() -> bool:
     """Check if the XCCL backend is available."""
     return _XCCL_AVAILABLE
+
+
+def is_tccl_available() -> bool:
+    """Check if the TCCL (Thunderbolt RDMA) backend is available."""
+    return _TCCL_AVAILABLE
+
+
+def check_tccl_link_layer(device_name: str) -> None:
+    """Verify the link-layer prerequisite for TCCL on a given RDMA device.
+
+    Thunderbolt RDMA requires that the BSD interface underlying ``device_name``
+    (e.g. ``rdma_en2`` -> ``en2``) has a non-link-local static IPv4 address.
+    Without it, ``ibv_modify_qp(QP -> RTR)`` silently times out with
+    ``errno=60`` and ``init_process_group(backend="tccl")`` hangs.
+
+    This helper runs the same check that ``ProcessGroupTCCL``'s constructor
+    runs, but standalone -- useful for validating cluster setup before any
+    PyTorch distributed call.
+
+    Raises:
+        RuntimeError: if the interface is missing or has only a link-local
+            (169.254/16) address. The message contains the exact ``ifconfig``
+            and ``route`` commands to run.
+    """
+    if not is_tccl_available():
+        raise RuntimeError(
+            "Distributed package doesn't have TCCL built in. "
+            "Rebuild with USE_TCCL=1 on macOS 26.2+ with librdma.dylib."
+        )
+    from torch._C._distributed_c10d import _tccl_check_link_layer
+
+    _tccl_check_link_layer(device_name)
+
+
+def list_tccl_devices() -> list[str]:
+    """Enumerate RDMA devices visible to TCCL on this host.
+
+    Loads ``librdma.dylib`` on first call (process-wide singleton).
+
+    Returns:
+        list[str]: Device names (e.g. ``["rdma_en2"]``). Empty if the library
+        loads but no devices appear -- most likely the Thunderbolt fabric is
+        bridged. Run ``sudo tbtrdmactl unbridge`` and try again.
+
+    Raises:
+        RuntimeError: if ``librdma.dylib`` cannot be loaded (e.g. macOS
+            < 26.2 or RDMA not enabled via ``bputil -enable rdma`` in
+            Recovery Mode).
+    """
+    if not is_tccl_available():
+        raise RuntimeError(
+            "Distributed package doesn't have TCCL built in. "
+            "Rebuild with USE_TCCL=1 on macOS 26.2+ with librdma.dylib."
+        )
+    from torch._C._distributed_c10d import _tccl_list_devices
+
+    return _tccl_list_devices()
 
 
 def _check_single_backend_availability(backend_name: str) -> bool:

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -141,6 +141,9 @@ __all__ = [
     "is_torchelastic_launched",
     "is_ucc_available",
     "is_xccl_available",
+    "is_tccl_available",
+    "check_tccl_link_layer",
+    "list_tccl_devices",
     "isend",
     "monitored_barrier",
     "new_group",
@@ -191,6 +194,7 @@ _NCCL_AVAILABLE = True
 _GLOO_AVAILABLE = True
 _UCC_AVAILABLE = True
 _XCCL_AVAILABLE = True
+_TCCL_AVAILABLE = True
 
 try:
     try:
@@ -406,6 +410,14 @@ try:
 except ImportError:
     _XCCL_AVAILABLE = False
 
+try:
+    from torch._C._distributed_c10d import ProcessGroupTCCL
+
+    ProcessGroupTCCL.__module__ = "torch.distributed.distributed_c10d"
+    __all__ += ["ProcessGroupTCCL"]
+except ImportError:
+    _TCCL_AVAILABLE = False
+
 
 if TYPE_CHECKING:
     from torch._C._distributed_c10d import (  # noqa: TC004
@@ -495,6 +507,7 @@ class Backend(str):  # noqa: SLOT000
     UCC = "ucc"
     MPI = "mpi"
     XCCL = "xccl"
+    TCCL = "tccl"
     FAKE = "fake"
 
     class _BackendPlugin(NamedTuple):
@@ -503,14 +516,17 @@ class Backend(str):  # noqa: SLOT000
 
     _plugins: dict[str, _BackendPlugin] = {}
 
-    backend_list = [UNDEFINED, GLOO, NCCL, XCCL, UCC, MPI, FAKE]
+    backend_list = [UNDEFINED, GLOO, NCCL, XCCL, UCC, MPI, FAKE, TCCL]
 
     # 3rd-party devices can register the default backend support here
     default_device_backend_map: dict[str, str] = {
         "cpu": GLOO,
         "cuda": NCCL,
         "xpu": XCCL,
-        "mps": GLOO,
+        # TCCL (Thunderbolt RDMA) is the MPS backend when torch is built with
+        # USE_C10D_TCCL. Without it (_TCCL_AVAILABLE == False) this maps to Gloo,
+        # which will raise on MPS tensors.
+        "mps": TCCL if _TCCL_AVAILABLE else GLOO,
     }
 
     backend_capability: dict[str, list[str]] = {
@@ -520,6 +536,7 @@ class Backend(str):  # noqa: SLOT000
         UCC: ["cpu", "cuda"],
         MPI: ["cpu", "cuda"],
         FAKE: ["cpu", "cuda", "hpu", "xpu"],
+        TCCL: ["mps"],
     }
 
     backend_type_map: dict[str, ProcessGroup.BackendType] = {
@@ -530,6 +547,7 @@ class Backend(str):  # noqa: SLOT000
         UCC: ProcessGroup.BackendType.UCC,
         MPI: ProcessGroup.BackendType.MPI,
         FAKE: ProcessGroup.BackendType.CUSTOM,
+        TCCL: ProcessGroup.BackendType.CUSTOM,
     }
 
     def __new__(cls, name: str) -> str:
@@ -956,6 +974,36 @@ def _register_builtin_xccl_backend() -> None:
         extended_api=True,
         devices=Backend.backend_capability[Backend.XCCL],
         _backend_type=ProcessGroup.BackendType.XCCL,
+    )
+
+
+def _create_tccl_process_group(
+    opts: _DistributedBackendOptions, backend_options: Any | None
+) -> C10DBackend:
+    if not is_tccl_available():
+        raise RuntimeError(
+            "Distributed package doesn't have TCCL built in. "
+            "Rebuild with USE_TCCL=1 on macOS 26.2+ with librdma.dylib."
+        )
+    backend_class = ProcessGroupTCCL(
+        opts.store,
+        opts.group_rank,
+        opts.group_size,
+        # pyrefly: ignore [bad-argument-type]
+        timeout=opts.timeout,
+    )
+    backend_class.options.global_ranks_in_group = opts.global_ranks_in_group
+    backend_class.options.group_name = opts.group_id
+    return backend_class
+
+
+def _register_builtin_tccl_backend() -> None:
+    Backend.register_backend(
+        Backend.TCCL,
+        _create_tccl_process_group,
+        extended_api=True,
+        devices=Backend.backend_capability[Backend.TCCL],
+        _backend_type=ProcessGroup.BackendType.CUSTOM,
     )
 
 
@@ -1989,6 +2037,63 @@ def is_ucc_available() -> bool:
 def is_xccl_available() -> bool:
     """Check if the XCCL backend is available."""
     return _XCCL_AVAILABLE
+
+
+def is_tccl_available() -> bool:
+    """Check if the TCCL (Thunderbolt RDMA) backend is available."""
+    return _TCCL_AVAILABLE
+
+
+def check_tccl_link_layer(device_name: str) -> None:
+    """Verify the link-layer prerequisite for TCCL on a given RDMA device.
+
+    Thunderbolt RDMA requires that the BSD interface underlying ``device_name``
+    (e.g. ``rdma_en2`` -> ``en2``) has a non-link-local static IPv4 address.
+    Without it, ``ibv_modify_qp(QP -> RTR)`` silently times out with
+    ``errno=60`` and ``init_process_group(backend="tccl")`` hangs.
+
+    This helper runs the same check that ``ProcessGroupTCCL``'s constructor
+    runs, but standalone -- useful for validating cluster setup before any
+    PyTorch distributed call.
+
+    Raises:
+        RuntimeError: if the interface is missing or has only a link-local
+            (169.254/16) address. The message contains the exact ``ifconfig``
+            and ``route`` commands to run.
+    """
+    if not is_tccl_available():
+        raise RuntimeError(
+            "Distributed package doesn't have TCCL built in. "
+            "Rebuild with USE_TCCL=1 on macOS 26.2+ with librdma.dylib."
+        )
+    from torch._C._distributed_c10d import _tccl_check_link_layer
+
+    _tccl_check_link_layer(device_name)
+
+
+def list_tccl_devices() -> list[str]:
+    """Enumerate RDMA devices visible to TCCL on this host.
+
+    Loads ``librdma.dylib`` on first call (process-wide singleton).
+
+    Returns:
+        list[str]: Device names (e.g. ``["rdma_en2"]``). Empty if the library
+        loads but no devices appear -- most likely the Thunderbolt fabric is
+        bridged. Run ``sudo tbtrdmactl unbridge`` and try again.
+
+    Raises:
+        RuntimeError: if ``librdma.dylib`` cannot be loaded (e.g. macOS
+            < 26.2 or RDMA not enabled via ``bputil -enable rdma`` in
+            Recovery Mode).
+    """
+    if not is_tccl_available():
+        raise RuntimeError(
+            "Distributed package doesn't have TCCL built in. "
+            "Rebuild with USE_TCCL=1 on macOS 26.2+ with librdma.dylib."
+        )
+    from torch._C._distributed_c10d import _tccl_list_devices
+
+    return _tccl_list_devices()
 
 
 def _check_single_backend_availability(backend_name: str) -> bool:

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -523,10 +523,10 @@ class Backend(str):  # noqa: SLOT000
         "cpu": GLOO,
         "cuda": NCCL,
         "xpu": XCCL,
-        # TCCL (Thunderbolt RDMA) is the MPS backend when torch is built with
-        # USE_C10D_TCCL. Without it (_TCCL_AVAILABLE == False) this maps to Gloo,
-        # which will raise on MPS tensors.
-        "mps": TCCL if _TCCL_AVAILABLE else GLOO,
+        # TCCL (Thunderbolt RDMA) is the MPS backend; requires USE_C10D_TCCL.
+        # If torch was built without it, backend creation raises a clear
+        # "rebuild with USE_TCCL=1" error (see _create_tccl_process_group).
+        "mps": TCCL,
     }
 
     backend_capability: dict[str, list[str]] = {

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -495,6 +495,13 @@ def requires_gloo():
     )
 
 
+def requires_tccl():
+    return skip_but_pass_in_sandcastle_if(
+        not c10d.is_tccl_available(),
+        "c10d was not compiled with the TCCL backend",
+    )
+
+
 def requires_nccl_version(version, msg):
     if not TEST_CUDA:
         return lambda f: f

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -484,6 +484,13 @@ def requires_gloo():
     )
 
 
+def requires_tccl():
+    return skip_but_pass_in_sandcastle_if(
+        not c10d.is_tccl_available(),
+        "c10d was not compiled with the TCCL backend",
+    )
+
+
 def requires_nccl_version(version, msg):
     if not TEST_CUDA:
         return lambda f: f


### PR DESCRIPTION
# TCCL - Thunderbolt Collective Communication Library

> Authored by @radimurban, implements #189853.

As of now, PyTorch has no MPS-native communication backend, so `torch.distributed` collectives do not run on Apple Silicon. We introduce TCCL to fill that gap: a low-latency communication backend (`c10d::Backend`) that runs collectives on MPS tensors over RDMA on Thunderbolt 5. It implements all necessary collectives to enable parallelism strategies available on the front-end.

<p align="center">
<img height="200" src="https://github.com/user-attachments/assets/3cc13e9a-7529-4397-848e-faa904c600bd">
</p>


**Requirements.** macOS 26.2 and Thunderbolt 5 hardware.
## Design

TCCL is an in-tree `c10d::Backend`, functionally inspired by JACCL and structurally modelled around NCCL for PyTorch integration.

The transport layer utilizes RDMA (Remote Direct Memory Access). RDMA bypasses the OS kernel - up to an order of magnitude lower latency and higher bandwidth than TCP.

<img width="3084" height="796" alt="rdma_vs_tcp_stack" src="https://github.com/user-attachments/assets/1193e965-1515-40b1-921f-bf4e410f212f" />

On fp32, TCCL cuts small-message latency ~56× and reaches ~7.6 GB/s per rank of effective bandwidth.

<img width="3854" height="1618" alt="bench_collectives_pub" src="https://github.com/user-attachments/assets/13ce8081-e0e6-4080-90c6-ede888a98e51" />

### Implementation

TCCL is implemented in 3 main files. A few more files wire the distributed-on-MPS path. Tests are covered below.

|             Main files             | Responsibility |
| :--------------------------------: | :------------- |
|    `ProcessGroupTCCL.{hpp,cpp}`    | `c10d::Backend` subclass (`Options`, `TCCLWork`); 12-step RDMA bootstrap ctor, worker `runLoop`, `enqueueCollective` async scaffold, all collective overrides, and the reduce-op / dtype / mesh-vs-ring dispatch. |
|       `TCCLUtils.{hpp,cpp}`        | Transport layer: `dlopen` librdma + dlsym (`TCCLIBVWrapper`), UC queue-pair lifecycle (INIT→RTR→RTS, post/poll) (`TCCLConnection`), registered staging buffers (`TCCLSharedBuffer`), `TCCLDestination`, link-layer subnet check, Store bootstrap. |
| `ProcessGroupTCCLDetail.{hpp,ipp}` | Algorithm layer: reduction-op templates (SUM/PROD/MIN/MAX over float/int/bool, native `__bf16` add); `kChunkSize`; the shared `mesh_exchange`, `ring_step`, and `bidir_ring_step` primitives (depth-2 pipelined); every mesh + ring collective; `wr_id` encoding. |

### Collectives

The full set for every exposed parallelism strategy. Most run in ring and mesh. `gather` and `scatter` are mesh-only.

| Collective                        | Description                                                       | Ring | Mesh |
| --------------------------------- | ---------------------------------------------------------------- | ---- | ---- |
| `allreduce`                       | reductions SUM / AVG / MIN / MAX / PRODUCT (AVG float-only)      | Yes  | Yes  |
| `reduce`                          | rooted reduction, same ops; runs as all-reduce (result on all)   | Yes  | Yes  |
| `broadcast`                       | root → all, byte-copy (any dtype)                                | Yes  | Yes  |
| `allgather` (list)                | gather each rank's shard into separate output tensors, byte-copy | Yes  | Yes  |
| `_allgather_base`                 | single contiguous rank-major output, byte-copy                   | Yes  | Yes  |
| `allgather_into_tensor_coalesced` | the TP / DTensor all-gather virtual                              | Yes  | Yes  |
| `gather`                          | root collects each rank's tensor, byte-copy                      | No   | Yes  |
| `scatter`                         | root sends each rank its slice, byte-copy                        | No   | Yes  |
| `reduce_scatter` (list)           | reduce per-peer input tensors, scatter the result                | Yes  | Yes  |
| `_reduce_scatter_base`            | FSDP eager reduce-scatter (contiguous in/out)                    | Yes  | Yes  |
| `reduce_scatter_tensor_coalesced` | the TP / sequence-parallel reduce-scatter virtual                | Yes  | Yes  |
| `alltoall_base`                   | all-to-all with split sizes (ring: equal split)                  | Yes  | Yes  |
| `send` / `recv`                   | point-to-point                                                   | /    | /    |
| `barrier`                         | Store-based synchronization, no data path                        | /    | /    |

### Algorithm selection

Selection is dynamic, by node count and payload. Benchmarks show allreduce wins with ring even on a mesh at N={3,4}.

<img width="7234" height="2499" alt="collectives_decision_map_poster" src="https://github.com/user-attachments/assets/515d0eab-19ea-4cbf-88c8-eee61c79e22b" />

- Rule: allreduce goes to ring for bf16 or payload ≥ 1 MB, mesh otherwise. World size ≤ 2 always uses mesh.
- Macs cannot mesh all-to-all beyond N=4, so ring is a complete alternative, not just a large-message optimization.

### Compute-communication overlap

RDMA is a kernel-bypass, CPU-side API. Each collective runs on a dedicated CPU worker: it drives the RDMA, polls completions, and reduces, while the NIC DMAs the payload over Thunderbolt 5.

- The NIC transfers from a small staging buffer, registered once at init and reused every collective.
- Each chunk is memcpy'd into it from the tensor.
- That memcpy's CPU-side source is a zero-copy view over the same unified-memory storage, so the only real copy is the stage.

Overlap comes from the offload. PyTorch MPS Backend exposes a single serial stream, so a collective cannot hide behind compute on a second GPU stream - but the CPU worker runs it while the GPU stays busy. The hand-off is an `MTLSharedEvent`: the main thread records a signal (non-blocking, via commit-and-continue), the worker waits on it. The GPU is never drained.

<img width="3620" height="1042" alt="cc_overlap" src="https://github.com/user-attachments/assets/f1a12f3f-9fc2-4f55-b0a6-5ce246e08850" />


- DDP: real overlap. The all-reduce runs on gradient buckets already computed while the GPU proceeds to later buckets - off the critical path.
- TP: each layer's all-reduce feeds the next matmul, so it sits on the critical path. Hiding it needs chunked/async TP, which PyTorch currently gates to CUDA/symmetric-memory. Noted as future work - default TP already brings significant uplift.

## Evaluation

Measured on 4× Mac mini M4 Pro (48/48/64/64 GB), clustered all-to-all over Thunderbolt 5. N<4 and ring runs use a subset of the machines and connections.

### Correctness

319 in-tree cases across three test classes:

| Axis            | Spans |
| --------------- | ----- |
| **Collectives** | `allreduce`; `reduce` (rooted, non-zero root); `broadcast`; `allgather` (list, `_allgather_base`, DTensor/TP coalesced); `gather` / `scatter` (rooted, non-zero root, mesh-only reject on ring); `reduce_scatter` (list, `_reduce_scatter_base` / FSDP, coalesced); `alltoall_base` (equal, uneven `alltoallv`, multi-chunk); `send`/`recv` (chain, directed pair, multi-chunk, non-adjacent); `barrier`. |
| **Reduce ops**  | SUM, AVG, MIN, MAX, PRODUCT |
| **Dtypes**      | float32 / float16 / bfloat16, int8 / int16 / int32 / int64 / uint8, bool (reductions); complex64 (byte-copy collectives) |
| **Algorithms**  | allreduce, all reduce-scatter forms, and alltoall in mesh and ring; broadcast and allgather ring paths via auto-selection |
| **Sizes**       | small tensors plus large payloads across the 512 KB chunk boundary - a 1 MB multi-chunk `send`/`recv`, a 12 MB `allreduce` that trips the ≥ 1 MB ring auto-switch, and ragged odd sizes (N full chunks + 1 element) forced onto the ring |

An out-of-tree superset (which we used for development) adds a full shape sweep, a memory-layout axis (contiguous, sliced, transposed, narrowed, reshaped, chunk-output views with non-zero storage offset), float64, and broader campaigns - ring-vs-mesh sweeps, UC sustained-load stress, raw-RDMA and collective microbenchmarks, and LLM TP/PP scaling on real models.

### Example workloads

FLUX.1-dev, 4 nodes vs one - DDP LoRA fine-tune (training throughput) and TP inference (denoising latency).

<img width="3854" height="1596" alt="flux_speedup" src="https://github.com/user-attachments/assets/2cb7ae1f-7a87-4cc5-99a2-b4120c441f2e" />

- DDP is communication-light (all-reduce once per step, overlapped with compute), so it scales near-linearly: ~3.8× on 4 nodes, flat across batch size and LoRA rank.
- TP is latency-bound and shards compute, so its win grows with work per step: 1.19× at 512 to 3.04× at 1280 (avg 2.21×). TP also lifts the memory ceiling - 1920 OOMs on one node, runs on four. Note chart is a log scale.

TCCL is otherwise use-case-agnostic - any `torch.distributed` workload with front-end MPS support runs over it. We have run LLMs (Qwen, Llama, ...) in TP and PP inference; TP=4 reaches ~2.3× decode throughput at large batch.

<img width="3403" height="1383" alt="single_vs_tp_linear" src="https://github.com/user-attachments/assets/3c58548a-a64b-4a3f-9529-a7034400db28" />

The broader point is enablement: sharding runs models that exceed a single node's memory directly in PyTorch on Apple Silicon - previously not an option.

## Running TCCL

TCCL needs three things:

1. RDMA enabled on each Mac
2. a static IP on each Thunderbolt link
3. a few environment variables at launch

The backend reads everything from env vars plus the standard rendezvous.

<details>
<summary><h3>Spelled-out setup for 2-/4-node</h3></summary>

### 1. One-time per node

Enable RDMA on every node (Recovery Mode, then reboot): https://developer.apple.com/documentation/technotes/tn3205-low-latency-communication-with-rdma-over-thunderbolt

### 2. Per boot / node

```
sudo tbtrdmactl unbridge          # makes rdma_enX devices appear
sudo ifconfig bridge0 destroy     # once per node
```

Give each Thunderbolt cable a static IP. Every cable is its own `/30` subnet, and the two ends get different addresses (conventionally `.1` and `.2` - not always `.1`). The only hard rule: both ends of a cable share a non-link-local `/30`. These IPs just bring the RDMA link up; data never leaves the cable.

A node has one interface (and one `/30`) per cable - a 2-node setup has one, a 4-node full mesh has three per node. Which `enX` reaches which peer is just how the cables are plugged in.

### 3. Launch

**Example A - 2 nodes** (`amadeus` = rank 0, `ludwig` = rank 1, cabled `en2`↔`en2`):

```bash
# on amadeus (rank 0):
sudo ifconfig en2 inet 192.168.0.1 netmask 255.255.255.252
MASTER_ADDR=192.168.0.1 MASTER_PORT=29500 RANK=0 WORLD_SIZE=2 \
  TCCL_DEVICE=rdma_en2  python train.py

# on ludwig (rank 1):
sudo ifconfig en2 inet 192.168.0.2 netmask 255.255.255.252    # .2, the other end
MASTER_ADDR=192.168.0.1 MASTER_PORT=29500 RANK=1 WORLD_SIZE=2 \
  TCCL_DEVICE=rdma_en2  python train.py
```

`TCCL_DEVICE` names the RDMA device (omit it if the node exposes exactly one).

**Example B - 4 nodes, full mesh** (`amadeus`, `ludwig`, `johann`, `joseph`). Each Mac's 3 Thunderbolt ports connect it to every other node, so each configures 3 cables (each its own `/30`) and sets `TCCL_PEER_DEVICES` instead of `TCCL_DEVICE`: a comma-separated list of length `WORLD_SIZE` giving the device this rank uses to reach each peer, own slot empty. `MASTER_ADDR` is rank 0's IP on the caller's cable (rank 0's store binds all interfaces).

```bash
# rank 0 - amadeus:  cabled to ludwig/johann/joseph via en2/en3/en4
sudo ifconfig en2 inet 192.168.12.1 netmask 255.255.255.252   # ↔ ludwig
sudo ifconfig en3 inet 192.168.13.1 netmask 255.255.255.252   # ↔ johann
sudo ifconfig en4 inet 192.168.14.1 netmask 255.255.255.252   # ↔ joseph
MASTER_ADDR=192.168.12.1 MASTER_PORT=29500 RANK=0 WORLD_SIZE=4 \
  TCCL_PEER_DEVICES=",rdma_en2,rdma_en3,rdma_en4"  python train.py

# rank 1 - ludwig:
sudo ifconfig en2 inet 192.168.12.2 netmask 255.255.255.252   # ↔ amadeus
sudo ifconfig en4 inet 192.168.23.1 netmask 255.255.255.252   # ↔ johann
sudo ifconfig en3 inet 192.168.24.1 netmask 255.255.255.252   # ↔ joseph
MASTER_ADDR=192.168.12.1 MASTER_PORT=29500 RANK=1 WORLD_SIZE=4 \
  TCCL_PEER_DEVICES="rdma_en2,,rdma_en4,rdma_en3"  python train.py

# rank 2 - johann:
sudo ifconfig en4 inet 192.168.13.2 netmask 255.255.255.252   # ↔ amadeus
sudo ifconfig en2 inet 192.168.23.2 netmask 255.255.255.252   # ↔ ludwig
sudo ifconfig en3 inet 192.168.34.1 netmask 255.255.255.252   # ↔ joseph
MASTER_ADDR=192.168.13.1 MASTER_PORT=29500 RANK=2 WORLD_SIZE=4 \
  TCCL_PEER_DEVICES="rdma_en4,rdma_en2,,rdma_en3"  python train.py

# rank 3 - joseph:
sudo ifconfig en2 inet 192.168.14.2 netmask 255.255.255.252   # ↔ amadeus
sudo ifconfig en4 inet 192.168.24.2 netmask 255.255.255.252   # ↔ ludwig
sudo ifconfig en3 inet 192.168.34.2 netmask 255.255.255.252   # ↔ johann
MASTER_ADDR=192.168.14.1 MASTER_PORT=29500 RANK=3 WORLD_SIZE=4 \
  TCCL_PEER_DEVICES="rdma_en2,rdma_en4,rdma_en3,"  python train.py
```

`MASTER_ADDR` differs per rank - rank 2 reaches rank 0 over the `192.168.13.x` cable, rank 3 over `192.168.14.x`. If the nodes also share a routable network (LAN/IPv6), use one shared `MASTER_ADDR` for all ranks; the per-cable IPs above are what make it work Thunderbolt-only / offline.

### 4. In your PyTorch script

```python
import torch, torch.distributed as dist
dist.init_process_group(backend="tccl", device_id=torch.device("mps", 0))
# then use dist.all_reduce / DDP / TP exactly as with any backend
```

Addressing and the `enX` mapping are per-cable and come from how things are plugged in - a discovery script can generate both the subnet setup and the `TCCL_PEER_DEVICES` rows, but the backend only needs the env vars above.

### 5. Check setup before launching

```python
import torch.distributed as dist
dist.is_tccl_available()                 # built with USE_TCCL=1?
dist.list_tccl_devices()                 # -> ['rdma_en2', 'rdma_en3', 'rdma_en4']
dist.check_tccl_link_layer('rdma_en2')   # raises with the exact fix if the /30 IP is missing
```
</details>

## Future work

- [ ] Multi-wire - split each transfer across N parallel QPs per peer
- [ ] Many frameworks assume distributed PyTorch on MPS is impossible; we hope TCCL changes that and the community builds on it
