### PR TITLE
[Testcase Refactoring]Migrate test_tensorpipe_agent.py to torch.accelerator and add hw_classification label

### DIFF
--- a/test/distributed/rpc/test_tensorpipe_agent.py
+++ b/test/distributed/rpc/test_tensorpipe_agent.py
@@ -11,7 +11,11 @@ if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)
     sys.exit(0)
 
-from torch.testing._internal.common_utils import IS_CI, run_tests
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    IS_CI,
+    run_tests,
+)
 from torch.testing._internal.distributed.rpc.tensorpipe_rpc_agent_test_fixture import (
     TensorPipeRpcAgentTestFixture,
 )
@@ -24,15 +28,16 @@ from torch.testing._internal.distributed.rpc_utils import (
 
 # On CircleCI these tests are already run on CPU jobs, thus to save resources do
 # not run them on GPU jobs, since they wouldn't provide additional test signal.
-if not (IS_CI and torch.cuda.is_available()):
-    globals().update(
-        generate_tests(
-            "TensorPipe",
-            TensorPipeRpcAgentTestFixture,
-            GENERIC_TESTS + TENSORPIPE_TESTS,
-            __name__,
-        )
+if not (IS_CI and torch.accelerator.is_available()):
+    _generated_tests = generate_tests(
+        "TensorPipe",
+        TensorPipeRpcAgentTestFixture,
+        GENERIC_TESTS + TENSORPIPE_TESTS,
+        __name__,
     )
+    for _cls in _generated_tests.values():
+        _cls.hw_classification = HardwareClassification.CPU
+    globals().update(_generated_tests)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# [Testcase Refactoring] Migrate test_tensorpipe_agent.py to torch.accelerator and add hw_classification label
## Summary
This PR makes two changes to `test/distributed/rpc/test_tensorpipe_agent.py`: migrates the CI skip guard from `torch.cuda.is_available()` to `torch.accelerator.is_available()`, and adds `hw_classification = HardwareClassification.CPU` to the test classes generated by `generate_tests`.
## Changes
- `torch.cuda.is_available()` → `torch.accelerator.is_available()` in the CI skip guard.
- Imported `HardwareClassification` from `torch.testing._internal.common_utils`.
- Captured the return value of `generate_tests(...)` and set `hw_classification = HardwareClassification.CPU` on each generated class before registering them in `globals()`.
## Motivation
### CI skip guard migration
`torch.cuda.is_available()` is a CUDA-specific API. The CI skip guard in this file is intended to skip these CPU-logic RPC tests on accelerator CI jobs where they would not provide additional test signal since they are already covered on CPU CI. However, with the CUDA-specific check the skip only applied to CUDA CI; on other accelerator CI jobs (e.g. XPU, MPS) the tests would still run, contradicting the intent of the existing comment: "On CircleCI these tests are already run on CPU jobs, thus to save resources do not run them on GPU jobs, since they wouldn't provide additional test signal." By routing through `torch.accelerator.is_available()`, the skip applies to whichever accelerator CI job is active, consistent with the comment's intent. `is_available()` is a Category A (same-name accelerator equivalent) API, making this a direct replacement. Local execution behavior is unchanged, as `IS_CI` short-circuits the guard to `False`.
### hw_classification label
`HardwareClassification` is the community-standard mechanism (defined in `torch/testing/_internal/common_utils.py`) for declaring the kind of hardware a test class requires. When `--hw-classification` is passed on the CLI, only tests whose classification matches are executed; when the flag is not specified, all test discovery and execution paths remain unchanged. These RPC test classes exercise pure inter-process communication logic (`share_memory_()` is a no-op on CUDA tensors per `torch/_tensor.py`), so they are labeled `CPU`.
## Test Plan
- CI: `python test/distributed/rpc/test_tensorpipe_agent.py`
- Verified that on a CUDA host the CI skip behavior is unchanged: when `IS_CI` is `True` and an accelerator is available, the tests are skipped.
- Verified that local execution (`IS_CI=False`) is unchanged: the tests run regardless of accelerator availability.
- Verified that without `--hw-classification`, test discovery and execution are unchanged (the label is pure metadata).
## Notes
- This is part of the test case refactoring initiative tracked in #185590.
- Only `test/distributed/rpc/test_tensorpipe_agent.py` is changed in this PR.