### PR TITLE
[Test] Detect registered accelerator backends in distributed helpers

### DIFF
--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -150,7 +150,12 @@ logger.setLevel(logging.INFO)
 
 ACCELERATOR_DIST_BACKENDS = ["nccl", "xccl", "hccl"]
 DDP_RANK_DEVICES = ["cuda", "xpu"]
-HAS_ACCELERATOR = TEST_CUDA or TEST_HPU or TEST_XPU
+HAS_ACCELERATOR = (
+    TEST_CUDA
+    or TEST_HPU
+    or TEST_XPU
+    or torch.accelerator.is_available()
+)
 
 
 class TestSkip(NamedTuple):
@@ -562,7 +567,7 @@ def requires_accelerator_dist_backend(backends=None):
         {
             "nccl": c10d.is_nccl_available,
             "xccl": c10d.is_xccl_available,
-            "hccl": lambda: TEST_HPU,
+            "hccl": lambda: TEST_HPU or c10d.is_backend_available("hccl"),
         }.get(backend, lambda: False)()
         for backend in backends
     )


### PR DESCRIPTION
## Issue

Related to #185590 and #174469.

## Summary

Make the distributed test infrastructure recognize a runtime-available
`torch.accelerator` and a communication backend registered at runtime.

## Changes

- Extend `HAS_ACCELERATOR` with `torch.accelerator.is_available()`.
- Treat HCCL as available when `dist.is_backend_available("hccl")` is true.

## Motivation

The existing checks enumerate built-in device flags, so an out-of-tree
accelerator and its registered communication backend can be reported as
unavailable and the tests are skipped.

## Test Plan

- `python test/distributed/checkpoint/test_pg_transport.py -v`

## Notes

Related to #178463. This PR is a narrower change limited to accelerator and
registered-backend availability detection.