### PR TITLE
implement index read and write for `torch.float4_e2m1fn_x2`

### DIFF
--- a/aten/src/ATen/native/cpu/IndexKernel.cpp
+++ b/aten/src/ATen/native/cpu/IndexKernel.cpp
@@ -37,7 +37,8 @@ void index_kernel(TensorIteratorBase& iter, IntArrayRef index_size, IntArrayRef 
     kBComplex32,
     kHalf,
     kBool,
-    kBFloat16);
+    kBFloat16,
+    kFloat4_e2m1fn_x2);
 }
 
 // Given a linear index, returns the offset of the tensor.
@@ -163,6 +164,33 @@ void take_kernel(
     });
 }
 
+// This is a separate function template (rather than inlined in the dispatch
+// lambda below) so that `if constexpr` discards the `+=` branch for shell
+// dtypes without arithmetic support. Inside AT_DISPATCH, `scalar_t` is a
+// concrete type alias, not a template parameter, so an inline `if constexpr`
+// would still require every branch to compile for every dispatched type.
+template <typename scalar_t>
+void cpu_index_put_accumulate(TensorIterator& iter, IntArrayRef index_size, IntArrayRef index_stride, bool is_deterministic) {
+  if constexpr (std::is_same_v<scalar_t, Float4_e2m1fn_x2>) {
+    // Float4_e2m1fn_x2 is a shell dtype without arithmetic support.
+    TORCH_CHECK(false, "index_put does not support accumulate=true for Float4_e2m1fn_x2");
+  } else {
+    bool use_parallel_for = (!is_deterministic) && (
+      (iter.numel() >= internal::GRAIN_SIZE) && (at::get_num_threads() > 1));
+    if (use_parallel_for && iter.dtype() == ScalarType::Float) {
+      cpu_index_kernel<float>(iter, index_size, index_stride, [](char* dst, char* src, int64_t offset) {
+        cpu_atomic_add_float((float*)(dst + offset), *(float*)src);
+      });
+    } else {
+      // TODO: investigate parallelization of the accumulate kernel. Unlike the non-accumulate case,
+      // this needs to be thread-safe.
+      cpu_index_kernel<scalar_t>(iter, index_size, index_stride, [](char* dst, char* src, int64_t offset) {
+        *(scalar_t*)(dst + offset) += c10::load(reinterpret_cast<scalar_t*>(src));
+      }, /*serial_execution=*/true);
+    }
+  }
+}
+
 void index_put_kernel(TensorIterator& iter, IntArrayRef index_size, IntArrayRef index_stride, bool accumulate) {
   // NOTE: duplicate indices are only supported if accumulate is true.
   AT_DISPATCH_V2(
@@ -174,19 +202,7 @@ void index_put_kernel(TensorIterator& iter, IntArrayRef index_size, IntArrayRef 
       // must enable serial execution if deterministic algorithms are enabled.
       const bool is_deterministic = at::globalContext().deterministicAlgorithms();
       if (accumulate) {
-        bool use_parallel_for = (!is_deterministic) && (
-          (iter.numel() >= internal::GRAIN_SIZE) && (at::get_num_threads() > 1));
-        if (use_parallel_for && iter.dtype() == ScalarType::Float) {
-          cpu_index_kernel<float>(iter, index_size, index_stride, [](char* dst, char* src, int64_t offset) {
-            cpu_atomic_add_float((float*)(dst + offset), *(float*)src);
-          });
-        } else {
-          // TODO: investigate parallelization of the accumulate kernel. Unlike the non-accumulate case,
-          // this needs to be thread-safe.
-          cpu_index_kernel<scalar_t>(iter, index_size, index_stride, [](char* dst, char* src, int64_t offset) {
-            *(scalar_t*)(dst + offset) += c10::load(reinterpret_cast<scalar_t*>(src));
-          }, /*serial_execution=*/true);
-        }
+        cpu_index_put_accumulate<scalar_t>(iter, index_size, index_stride, is_deterministic);
       } else {
         cpu_index_kernel<scalar_t>(iter, index_size, index_stride, [](char* dst, char* src, int64_t offset) {
           *(scalar_t*)(dst + offset) = c10::load(reinterpret_cast<scalar_t*>(src));
@@ -205,7 +221,8 @@ void index_put_kernel(TensorIterator& iter, IntArrayRef index_size, IntArrayRef 
     kBComplex32,
     kHalf,
     kBool,
-    kBFloat16);
+    kBFloat16,
+    kFloat4_e2m1fn_x2);
 }
 
 void index_fill_kernel(

--- a/aten/src/ATen/native/cuda/IndexKernel.cu
+++ b/aten/src/ATen/native/cuda/IndexKernel.cu
@@ -228,7 +228,8 @@ static void index_kernel(
       kBComplex32,
       kHalf,
       kBool,
-      kBFloat16);
+      kBFloat16,
+      kFloat4_e2m1fn_x2);
 }
 
 static void index_fill_kernel(
@@ -281,7 +282,8 @@ static void index_put_kernel(TensorIterator& iter, const IntArrayRef index_size,
     kBComplex32,
     kHalf,
     kBool,
-    kBFloat16);
+    kBFloat16,
+    kFloat4_e2m1fn_x2);
 }
 
 void index_put_kernel_quantized_cuda(TensorIterator& iter, const IntArrayRef index_size, const IntArrayRef index_stride, const bool accumulate, const double scale, const int zero_point) {

--- a/test/quantization/core/experimental/test_floatx.py
+++ b/test/quantization/core/experimental/test_floatx.py
@@ -428,6 +428,31 @@ class TestFloat4Dtype(TestCase):
         # can call contiguous on a dim1 slice (calls `copy_` under the hood)
         x1[:, 0:2048].contiguous()
 
+    def test_float4_e2m1fn_x2_index(self, device):
+        # advanced indexing read (`dst[idx]`) works, calls `index` under the hood
+        src = torch.randint(1, 255, (4, 4), dtype=torch.uint8, device=device).view(
+            torch.float4_e2m1fn_x2
+        )
+        idx = torch.tensor([0, 2], device=device)
+        out = src[idx]
+        self.assertEqual(
+            out.view(torch.uint8), src[0:4:2].view(torch.uint8), atol=0, rtol=0
+        )
+
+    def test_float4_e2m1fn_x2_index_put(self, device):
+        # `dst[idx] = src` works, calls `index_put` under the hood
+        dst = torch.zeros((4, 4), dtype=torch.uint8, device=device).view(
+            torch.float4_e2m1fn_x2
+        )
+        src = torch.randint(1, 255, (2, 4), dtype=torch.uint8, device=device).view(
+            torch.float4_e2m1fn_x2
+        )
+        idx = torch.tensor([0, 1], device=device)
+        dst[idx] = src
+        self.assertEqual(
+            dst[idx].view(torch.uint8), src.view(torch.uint8), atol=0, rtol=0
+        )
+
     def test_f4_save_load(self, device):
         x1 = torch.randint(0, 10, (4, 4), device=device, dtype=torch.uint8).view(
             torch.float4_e2m1fn_x2


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189862

Summary:

This is useful for moving fp4 bytes around.

Claude-assisted

Test Plan:

```python
pytest test/quantization/core/experimental/test_floatx.py -k index -s
```

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01