### PR TITLE
Make test_functional_api device-generic

### DIFF
--- a/test/distributed/test_functional_api.py
+++ b/test/distributed/test_functional_api.py
@@ -34,6 +34,8 @@ from torch.testing._internal.common_utils import (
     skipIfHpu,
     TEST_CUDA,
     TEST_HPU,
+    TEST_PRIVATEUSE1,
+    TEST_PRIVATEUSE1_DEVICE_TYPE,
     TEST_WITH_ROCM,
     TEST_XPU,
     TestCase,
@@ -71,6 +73,9 @@ elif TEST_XPU:
     DEVICE = "xpu"
 elif TEST_CUDA:
     devices.append("cuda")
+elif TEST_PRIVATEUSE1:
+    devices.append(TEST_PRIVATEUSE1_DEVICE_TYPE)
+    DEVICE = TEST_PRIVATEUSE1_DEVICE_TYPE
 
 
 def new_subgroups(group_size: int, pg_tag=None):
@@ -520,6 +525,10 @@ if TEST_HPU:
     BACKEND = dist.Backend.HCCL
 elif TEST_XPU:
     BACKEND = dist.Backend.XCCL
+elif TEST_PRIVATEUSE1:
+    BACKEND = dist.Backend.default_device_backend_map.get(
+        TEST_PRIVATEUSE1_DEVICE_TYPE, dist.Backend.GLOO
+    )
 
 
 # allows you to check for multiple accelerator irrespective of device type
@@ -538,7 +547,7 @@ def with_comms(func=None):
     @wraps(func)
     def wrapper(self, *args, **kwargs):
         if (
-            BACKEND == dist.Backend.NCCL or BACKEND == dist.Backend.XCCL
+            BACKEND != dist.Backend.GLOO
         ) and torch.accelerator.device_count() < self.world_size:
             sys.exit(TEST_SKIPS[f"multi-gpu-{self.world_size}"].exit_code)
 
@@ -617,7 +626,7 @@ class TestCollectivesWithDistributedBackend(DistributedTestBase):
         self.assertEqual(y, expected)
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend()
     @with_comms()
     def test_tracing(self, device):
         def allreduce(t, pg):
@@ -643,7 +652,7 @@ class TestCollectivesWithDistributedBackend(DistributedTestBase):
         dist.destroy_process_group()
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend()
     @with_comms()
     def test_tracing_with_dce_code(self, device):
         if self.world_size > 2:

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -558,12 +558,11 @@ def requires_accelerator_dist_backend(backends=None):
     if backends is None:
         backends = ACCELERATOR_DIST_BACKENDS
 
+    # Use the is_<backend>_available() naming convention via reflection so
+    # that any registered accelerator backend is discovered automatically,
+    # without hardcoding a device-to-backend mapping here.
     backend_available = any(
-        {
-            "nccl": c10d.is_nccl_available,
-            "xccl": c10d.is_xccl_available,
-            "hccl": lambda: TEST_HPU,
-        }.get(backend, lambda: False)()
+        getattr(c10d, f"is_{backend}_available", lambda: False)()
         for backend in backends
     )
 
@@ -1286,14 +1285,7 @@ class DistributedTestBase(MultiProcessTestCase):
             pass
 
     def backend(self, device) -> str:
-        if "cuda" in device:
-            return "nccl"
-        elif "hpu" in device:  # intel gaudi
-            return "hccl"
-        elif "xpu" in device:
-            return "xccl"
-        else:
-            return "gloo"
+        return c10d.get_default_backend_for_device(device)
 
     def create_pg(self, device, world_size=None):
         if world_size is None:
@@ -1306,7 +1298,7 @@ class DistributedTestBase(MultiProcessTestCase):
             rank=self.rank,
             store=store,
         )
-        if "nccl" in self.backend(device) or "xccl" in self.backend(device):
+        if self.backend(device) != "gloo":
             accelerator = torch.accelerator.current_accelerator()
             if accelerator:
                 device_type = accelerator.type


### PR DESCRIPTION
## Summary

The device/backend ladders and decorators in test_functional_api.py hardcoded CUDA/HPU/XPU and omitted the PrivateUse1 extension point, silently excluding third-party accelerator backends. This commit adds PrivateUse1 coverage at every selection point using upstream generic APIs (default_device_backend_map, get_default_backend_for_device, is_<backend>_available reflection) so no device-specific branch is introduced.

## Changes

test/distributed/test_functional_api.py
- Added elif TEST_PRIVATEUSE1 to the DEVICE and BACKEND ladders.
- Changed with_comms gate from `BACKEND == NCCL or BACKEND == XCCL` to `BACKEND != GLOO`.
- Dropped the ["nccl", "xccl"] whitelist from the two @requires_accelerator_dist_backend decorators.

torch/testing/_internal/common_distributed.py
- Replaced the hardcoded if-elif ladder in DistributedTestBase.backend() with c10d.get_default_backend_for_device(device).
- Changed the create_pg() accelerator guard to `backend != "gloo"`.
- Refactored requires_accelerator_dist_backend() to use reflection (getattr c10d, "is_<backend>_available") instead of a hardcoded dict that mapped "hccl" to lambda: TEST_HPU.

Refs: #174469
cc @wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian