### PR TITLE
Avoid dirty-output set when mark_dirty is unused

### DIFF
--- a/torch/csrc/autograd/custom_function.cpp
+++ b/torch/csrc/autograd/custom_function.cpp
@@ -382,7 +382,10 @@ static optional_variable_list _process_backward_mode_ad(
   };
 
   optional_variable_list outputs;
-  std::unordered_set<at::TensorImpl*> outputs_impl; // For dirty_inputs check
+  std::optional<std::unordered_set<at::TensorImpl*>> outputs_impl;
+  if (!dirty_inputs.empty()) {
+    outputs_impl.emplace();
+  }
   outputs.reserve(num_outputs);
   int num_diff_outputs = 0;
 
@@ -443,7 +446,9 @@ static optional_variable_list _process_backward_mode_ad(
       ++num_diff_outputs;
     }
 
-    outputs_impl.insert(out_tensor_impl);
+    if (outputs_impl) {
+      outputs_impl->insert(out_tensor_impl);
+    }
     outputs.emplace_back(var);
   }
 
@@ -462,11 +467,13 @@ static optional_variable_list _process_backward_mode_ad(
 
   // All the modified Tensors must be returned as is for the rewrite to be
   // valid.
-  for (auto& dirty_input : dirty_inputs) {
-    TORCH_CHECK(
-        outputs_impl.count(dirty_input) > 0,
-        "Some elements marked as dirty during the forward method were not returned as output. The"
-        " inputs that are modified inplace must all be outputs of the Function.");
+  if (outputs_impl) {
+    for (auto& dirty_input : dirty_inputs) {
+      TORCH_CHECK(
+          outputs_impl->count(dirty_input) > 0,
+          "Some elements marked as dirty during the forward method were not returned as output. The"
+          " inputs that are modified inplace must all be outputs of the Function.");
+    }
   }
 
   return outputs;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #189901
* #189897
* #189866
* __->__ #189865
* #189810

Autograd Function output wrapping always built an output TensorImpl set for the ctx.mark_dirty validation, even when no inputs were marked dirty. Make that set lazy so the common path only pays for it after ctx.mark_dirty is used.

For the 13-in-2-out benchmark from https://gist.github.com/zou3519/dc02adbe58ad35c804475486f905dde3, this reduced the local instruction-count minimum from 43,558 to 42,054 for no_save and from 53,269 to 51,902 for save13.

Authored with an AI assistant.

On the local one-apply 13-in-2-out no-save instruction-count benchmark, this moved from 50,614 to 49,440 instructions.