### PR TITLE
Skip autograd.Function forward AD input checks when no level exists

### DIFF
--- a/torch/csrc/autograd/custom_function.cpp
+++ b/torch/csrc/autograd/custom_function.cpp
@@ -1,7 +1,9 @@
+#include <c10/core/AutogradState.h>
 #include <c10/util/irange.h>
 #include <torch/csrc/autograd/VariableTypeUtils.h>
 #include <torch/csrc/autograd/autograd.h>
 #include <torch/csrc/autograd/custom_function.h>
+#include <torch/csrc/autograd/forward_grad.h>
 #include <torch/csrc/autograd/functions/accumulate_grad.h>
 
 #include <utility>
@@ -35,6 +37,11 @@ static variable_list call_jvp(
     owned.emplace_back(*input);
   }
   return jvp_user_function(std::move(owned), std::move(input_grads));
+}
+
+static bool is_forward_ad_active() {
+  return c10::AutogradState::get_tls_state().get_fw_grad_mode() &&
+      ForwardADLevel::has_any_level();
 }
 
 // This function has two main goals:
@@ -517,14 +524,16 @@ static optional_variable_list _wrap_outputs_impl(
 
   // This must happen after the backward processing as we expect the
   // computations happening here to track backward mode gradients.
-  _process_forward_mode_AD(
-      input_vars,
-      std::move(inputs_mapping),
-      raw_outputs,
-      outputs,
-      non_differentiable,
-      dirty_inputs,
-      jvp_user_function);
+  if (is_forward_ad_active()) {
+    _process_forward_mode_AD(
+        input_vars,
+        std::move(inputs_mapping),
+        raw_outputs,
+        outputs,
+        non_differentiable,
+        dirty_inputs,
+        jvp_user_function);
+  }
 
   return outputs;
 }
@@ -606,6 +615,7 @@ void check_variable_result(
       "' has changed the size of value");
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 AutogradContext::AutogradContext(PackedArgs& packed_args) {
   saved_data = packed_args.unpack_saved_data();
   saved_variables_override_ = packed_args.unpack<variable_list>();

--- a/torch/csrc/autograd/forward_grad.cpp
+++ b/torch/csrc/autograd/forward_grad.cpp
@@ -1,5 +1,7 @@
 #include <torch/csrc/autograd/forward_grad.h>
 
+#include <atomic>
+
 namespace torch::autograd {
 
 namespace {
@@ -8,6 +10,9 @@ namespace {
 
 std::mutex all_forward_levels_mutex_;
 std::vector<std::shared_ptr<ForwardADLevel>> all_forward_levels_;
+// Fast path for checking whether any forward AD level exists without grabbing
+// all_forward_levels_mutex_.
+std::atomic<uint64_t> active_forward_levels_{0};
 
 const static at::Tensor singleton_undefined_tensor;
 } // namespace
@@ -18,6 +23,8 @@ uint64_t ForwardADLevel::get_next_idx() {
   TORCH_CHECK(
       next_idx == 0, "Nested forward mode AD is not supported at the moment");
   all_forward_levels_.push_back(std::make_shared<ForwardADLevel>(next_idx));
+  active_forward_levels_.store(
+      all_forward_levels_.size(), std::memory_order_release);
   return next_idx;
 }
 
@@ -32,7 +39,13 @@ void ForwardADLevel::release_idx(uint64_t idx) {
   // Keep the level alive until we have released the lock
   auto lvl = std::move(all_forward_levels_.back());
   all_forward_levels_.pop_back();
+  active_forward_levels_.store(
+      all_forward_levels_.size(), std::memory_order_release);
   lock.unlock();
+}
+
+bool ForwardADLevel::has_any_level() {
+  return active_forward_levels_.load(std::memory_order_acquire) != 0;
 }
 
 std::shared_ptr<ForwardADLevel> ForwardADLevel::get_by_idx(uint64_t idx) {

--- a/torch/csrc/autograd/forward_grad.h
+++ b/torch/csrc/autograd/forward_grad.h
@@ -100,6 +100,7 @@ struct ForwardGrad;
 #define EXPECTED_MAX_LEVEL 2
 
 struct TORCH_API ForwardADLevel {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   ForwardADLevel(uint64_t idx) : idx_(idx) {}
   ~ForwardADLevel();
 
@@ -107,6 +108,7 @@ struct TORCH_API ForwardADLevel {
   static void release_idx(uint64_t idx);
   static std::shared_ptr<ForwardADLevel> get_by_idx(uint64_t idx);
   static std::shared_ptr<ForwardADLevel> try_get_by_idx(uint64_t idx);
+  static bool has_any_level();
 
   void erase(const std::shared_ptr<ForwardGrad>& grad) {
     std::lock_guard<std::mutex> lock(mutex_);
@@ -124,6 +126,7 @@ struct TORCH_API ForwardADLevel {
   uint64_t idx_;
 };
 
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 struct TORCH_API ForwardGrad : std::enable_shared_from_this<ForwardGrad> {
   ForwardGrad() = default;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #189901
* #189897
* __->__ #189866
* #189865
* #189810

autograd.Function output wrapping scanned every input for a forward AD tangent before deciding whether to call jvp. Skip that scan when forward grad mode is off or no process-wide forward AD level exists.

Track the active forward AD level count with an atomic so the hot path can avoid taking all_forward_levels_mutex_ just to discover that there are no levels.

For the 13-in-2-out benchmark from https://gist.github.com/zou3519/dc02adbe58ad35c804475486f905dde3, this reduced the local instruction-count minimum from 42,054 to 39,727 for no_save and from 51,902 to 50,138 for save13.

Authored with an AI assistant.

On the local one-apply 13-in-2-out no-save instruction-count benchmark, this moved from 49,440 to 48,840 instructions.