### PR TITLE
[inductor] Support separate forward/backward inductor configs for invoke_subgraph

### DIFF
--- a/test/dynamo/test_regional_inductor.py
+++ b/test/dynamo/test_regional_inductor.py
@@ -606,7 +606,7 @@ class RegionalInductorInvokeSubgraphTests(torch._inductor.test_case.TestCase):
             )
 
         nested_config = get_invoke_subgraph_compile_options(
-            inductor_config_patches={"post_grad_custom_pre_pass": inner_pass}
+            fw_inductor_config_patches={"post_grad_custom_pre_pass": inner_pass}
         )
 
         @torch.compiler.nested_compile_region(options=nested_config)
@@ -661,7 +661,7 @@ class RegionalInductorInvokeSubgraphTests(torch._inductor.test_case.TestCase):
         # `repeated_subgraph0` and the parent as `call`. fx_graph_cache is off to
         # dodge a triton multi-kernel cache-reload issue unrelated to threading.
         nested_config = get_invoke_subgraph_compile_options(
-            inductor_config_patches={"triton.multi_kernel": True}
+            fw_inductor_config_patches={"triton.multi_kernel": True}
         )
 
         @torch.compiler.nested_compile_region(options=nested_config)
@@ -690,7 +690,7 @@ class RegionalInductorInvokeSubgraphTests(torch._inductor.test_case.TestCase):
         # reduction to be looped (triton_red_*) while the parent keeps its
         # persistent kernel (triton_per_*).
         nested_config = get_invoke_subgraph_compile_options(
-            inductor_config_patches={"triton.persistent_reductions": False}
+            fw_inductor_config_patches={"triton.persistent_reductions": False}
         )
 
         @torch.compiler.nested_compile_region(options=nested_config)
@@ -712,6 +712,36 @@ class RegionalInductorInvokeSubgraphTests(torch._inductor.test_case.TestCase):
         self.assertIn("triton_red_", region_code)
         self.assertNotIn("triton_per_", region_code)
         self.assertIn("triton_per_", parent_code)
+
+    @requires_cuda_and_triton
+    @torch._dynamo.config.patch(inline_single_use_invoke_subgraph=False)
+    def test_nested_region_separate_fw_bw_inductor_config(self):
+        # A region can compile its forward and backward under different inductor
+        # configs. The forward keeps persistent reductions (default) while the
+        # backward is forced to looped reductions via bw_inductor_config_patches.
+        nested_config = get_invoke_subgraph_compile_options(
+            bw_inductor_config_patches={"triton.persistent_reductions": False},
+        )
+
+        @torch.compiler.nested_compile_region(options=nested_config)
+        def g(x):
+            return torch.softmax(x, dim=-1)
+
+        def fn(x):
+            return (g(x) * 3).sum()
+
+        opt_fn = torch.compile(fn, fullgraph=True)
+        x = torch.randn(4096, 256, device="cuda", requires_grad=True)
+        result, codes = run_fw_bw_and_get_code(lambda: opt_fn(x))
+
+        self.assertEqual(result, fn(x))
+        self.assertEqual(len(codes), 2)
+        fw_code, bw_code = codes
+        # Forward region keeps its persistent reduction; the backward region is
+        # looped, so only the backward reflects bw_inductor_config_patches.
+        self.assertIn("triton_per_", fw_code)
+        self.assertIn("triton_red_", bw_code)
+        self.assertNotIn("triton_per_", bw_code)
 
     def test_custom_decomposition(self):
         # Test that custom decompositions are applied to the subgraph.
@@ -1162,7 +1192,7 @@ def forward(self, primals_0, primals_1, primals_2, primals_3, primals_4, primals
         import torch._inductor.config as inductor_config
 
         nested_config = get_invoke_subgraph_compile_options(
-            inductor_config_patches={
+            fw_inductor_config_patches={
                 "max_autotune": True,
                 "triton.cudagraphs": False,
             }
@@ -1227,7 +1257,7 @@ def forward(self, primals_0, primals_1, primals_2, primals_3, primals_4, primals
             "Invalid inductor config key 'invalid_config_key'",
         ):
             get_invoke_subgraph_compile_options(
-                inductor_config_patches={
+                fw_inductor_config_patches={
                     "invalid_config_key": True,
                 }
             )

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -3586,7 +3586,7 @@ class TestFxGraphCacheHashing(TestCase):
 
         gm = torch.fx.GraphModule({}, torch.fx.Graph())
         gm.meta["nested_region_config"] = get_invoke_subgraph_compile_options(
-            inductor_config_patches=patches
+            fw_inductor_config_patches=patches
         )
         return gm
 

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -473,7 +473,7 @@ if HAS_CUDA_AND_TRITON:
             # Region opts in, enclosing graph off, graph_partition globally off:
             # the region becomes its own cudagraph partition, the add stays inline.
             nested_config = get_invoke_subgraph_compile_options(
-                inductor_config_patches={"triton.cudagraphs": True}
+                fw_inductor_config_patches={"triton.cudagraphs": True}
             )
 
             @torch.compiler.nested_compile_region(options=nested_config)
@@ -509,7 +509,7 @@ if HAS_CUDA_AND_TRITON:
             # Region opts out, enclosing graph on, graph_partition globally off:
             # the region is excluded from the cudagraph, the rest is captured.
             nested_config = get_invoke_subgraph_compile_options(
-                inductor_config_patches={"triton.cudagraphs": False}
+                fw_inductor_config_patches={"triton.cudagraphs": False}
             )
 
             @torch.compiler.nested_compile_region(options=nested_config)
@@ -545,7 +545,7 @@ if HAS_CUDA_AND_TRITON:
             # Region opts in but its body has a non-cudagraphable op (a host
             # round-trip), so cudagraphs are skipped for it; result still correct.
             nested_config = get_invoke_subgraph_compile_options(
-                inductor_config_patches={"triton.cudagraphs": True}
+                fw_inductor_config_patches={"triton.cudagraphs": True}
             )
 
             @torch.compiler.nested_compile_region(options=nested_config)

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -857,6 +857,9 @@ def run_joint_graph_passes_on_hops(
     recursive partitioning of nested regions is left to downstream passes.
     """
     from torch._higher_order_ops import invoke_subgraph
+    from torch._higher_order_ops.invoke_subgraph import (
+        get_backward_nested_region_config,
+    )
 
     def num_outputs(mod: torch.fx.GraphModule) -> int:
         return len(mod.graph.find_nodes(op="output")[0].args[0])
@@ -1232,6 +1235,15 @@ def run_joint_graph_passes_on_hops(
             # inputs for the new partitioned backward graph. For the forward
             # graph, it was fine because the input signature remains same.
             new_bw_node.meta.pop("eager_input_vals", None)
+
+            # When the region sets backward-specific inductor config, compile the
+            # partitioned backward under it; the forward keeps its own config.
+            fw_region_config = fw_node.meta.get("custom", {}).get(
+                "nested_region_config"
+            )
+            bw_region_config = get_backward_nested_region_config(fw_region_config)
+            if bw_region_config is not fw_region_config:
+                new_bw_hop_gm.meta["nested_region_config"] = bw_region_config
 
         bw_node.replace_all_uses_with(new_bw_node)
         joint_gm.graph.erase_node(bw_node)

--- a/torch/_higher_order_ops/invoke_subgraph.py
+++ b/torch/_higher_order_ops/invoke_subgraph.py
@@ -7,7 +7,7 @@ import threading
 from collections import defaultdict
 from collections.abc import Callable
 from contextlib import nullcontext
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Any
 
 import torch
@@ -78,8 +78,14 @@ class NestedCompileRegionOptions:
     decompositions: dict[str, Any] | None = None
 
     # Inductor config patches to apply while compiling this nested region through
-    # Inductor's normal invoke_subgraph lowering path.
+    # Inductor's normal invoke_subgraph lowering path. Applies to the backward
+    # too unless bw_inductor_config_patches is set.
     inductor_config_patches: dict[str, Any] | None = None
+
+    # If set, the backward subgraph is compiled under these inductor config
+    # patches instead of inductor_config_patches. If None, the backward reuses
+    # inductor_config_patches.
+    bw_inductor_config_patches: dict[str, Any] | None = None
 
 
 def _extract_nested_region_config(fn):
@@ -102,6 +108,26 @@ def _extract_nested_region_config(fn):
         ):
             return gm_to_compile.meta["nested_region_config"].decompositions
     return None
+
+
+def get_backward_nested_region_config(
+    fw_config: NestedCompileRegionOptions | None,
+) -> NestedCompileRegionOptions | None:
+    """Region config for compiling the backward subgraph.
+
+    When the region sets bw_inductor_config_patches, the backward compiles
+    under those patches (the forward keeps inductor_config_patches). Otherwise
+    the forward config is reused unchanged, so the returned object is identical.
+    """
+    if (
+        isinstance(fw_config, NestedCompileRegionOptions)
+        and fw_config.bw_inductor_config_patches is not None
+    ):
+        return replace(
+            fw_config,
+            inductor_config_patches=fw_config.bw_inductor_config_patches,
+        )
+    return fw_config
 
 
 # Per-call id used by downstream graph passes to pair fw and bw
@@ -1343,32 +1369,48 @@ def invoke_subgraph_inductor_compile(
 
 
 def get_invoke_subgraph_compile_options(
-    inductor_config_patches=None,
+    fw_inductor_config_patches=None,
     decompositions=None,
     partitioner="min_cut_rematerialization_partition",
+    *,
+    bw_inductor_config_patches=None,
 ):
-    if inductor_config_patches is None:
-        inductor_config_patches = {"triton.autotune_at_compile_time": True}
-    inductor_compile = functools.partial(
-        invoke_subgraph_inductor_compile,
-        inductor_config_patches=inductor_config_patches,
+    if fw_inductor_config_patches is None:
+        fw_inductor_config_patches = {"triton.autotune_at_compile_time": True}
+
+    # The backward subgraph uses bw_inductor_config_patches when provided,
+    # otherwise it reuses the forward config.
+    bw_patches = (
+        bw_inductor_config_patches
+        if bw_inductor_config_patches is not None
+        else fw_inductor_config_patches
     )
 
-    if inductor_config_patches:
-        from torch._inductor import config as inductor_config
+    from torch._inductor import config as inductor_config
 
-        # Validate that all config keys exist
-        for key in inductor_config_patches:
+    # Validate that all config keys exist
+    for patches in (fw_inductor_config_patches, bw_inductor_config_patches):
+        for key in patches or {}:
             if not hasattr(inductor_config, key):
                 raise ValueError(
                     f"Invalid inductor config key '{key}' in get_invoke_subgraph_compile_options. "
                     f"Available config keys can be found in torch._inductor.config"
                 )
 
+    fw_compiler = functools.partial(
+        invoke_subgraph_inductor_compile,
+        inductor_config_patches=fw_inductor_config_patches,
+    )
+    bw_compiler = functools.partial(
+        invoke_subgraph_inductor_compile,
+        inductor_config_patches=bw_patches,
+    )
+
     return NestedCompileRegionOptions(
-        fw_compiler=inductor_compile,
-        bw_compiler=inductor_compile,
+        fw_compiler=fw_compiler,
+        bw_compiler=bw_compiler,
         partitioner=partitioner,
         decompositions=decompositions,
-        inductor_config_patches=inductor_config_patches,
+        inductor_config_patches=fw_inductor_config_patches,
+        bw_inductor_config_patches=bw_inductor_config_patches,
     )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189870
* #189321
* #189320

get_invoke_subgraph_compile_options now takes fw_inductor_config_patches (the
forward config, renamed from inductor_config_patches) and a keyword-only
bw_inductor_config_patches. When bw_inductor_config_patches is set, the backward
subgraph of a nested_compile_region compiles under it while the forward uses
fw_inductor_config_patches; when unset, the backward reuses the forward config.

The backward config is applied where the partitioned backward subgraph is created
(run_joint_graph_passes_on_hops), not on the pre-partition backward graph: the
partitioner restitches a fresh backward subgraph module whose meta otherwise
inherits the forward config, so stamping the pre-partition graph is discarded.
get_backward_nested_region_config derives the backward variant from the forward
region config, and it is stamped onto the partitioned backward module only when the
region requested a distinct backward config, leaving the common path unchanged.

This change was authored with the assistance of an AI coding agent.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98