### PR TITLE
[xplat] (Re-re-land) Update XNNPACK to github revision f6486e3e1d

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/XnnpackUtils.h
+++ b/aten/src/ATen/native/quantized/cpu/XnnpackUtils.h
@@ -97,7 +97,9 @@ enum xnn_status xnnp_create_convolution2d_nhwc(
         op_min,         /* int8_t output_min                    */
         op_max,         /* int8_t output_max                    */
         flags,          /* uint32_t flags                       */
+#ifndef XNNPACK_NO_CODE_CACHE
         nullptr,        /* xnn_caches_t caches                  */
+#endif
         nullptr,        /* xnn_weights_cache_t weights_cache    */
         op);            /* xnn_operator_t* deconvolution_op_out */
 
@@ -130,7 +132,9 @@ enum xnn_status xnnp_create_convolution2d_nhwc(
         op_min,         /* int8_t output_min                  */
         op_max,         /* int8_t output_max                  */
         flags,          /* uint32_t flags                     */
+#ifndef XNNPACK_NO_CODE_CACHE
         nullptr,        /* xnn_caches_t caches                */
+#endif
         nullptr,        /* xnn_weights_cache_t weights_cache    */
         op);            /* xnn_operator_t* convolution_op_out */
   } else { /* per_channel */
@@ -160,7 +164,9 @@ enum xnn_status xnnp_create_convolution2d_nhwc(
         op_min,         /* int8_t output_min                  */
         op_max,         /* int8_t output_max                  */
         flags,          /* uint32_t flags                     */
+#ifndef XNNPACK_NO_CODE_CACHE
         nullptr,        /* xnn_caches_t caches                */
+#endif
         nullptr,        /* xnn_weights_cache_t weights_cache    */
         op);            /* xnn_operator_t* convolution_op_out */
   }
@@ -195,7 +201,9 @@ enum xnn_status xnnp_reshape_convolution2d_nhwc(
   }
 
   size_t workspace_size = SIZE_MAX;
+#ifndef XNNPACK_NO_CODE_CACHE
   size_t workspace_alignment = SIZE_MAX;
+#endif
 
   if (!per_channel) {
     return xnn_reshape_convolution2d_nhwc_qs8(
@@ -204,7 +212,9 @@ enum xnn_status xnnp_reshape_convolution2d_nhwc(
         in_h,     /* size_t input_height           */
         in_w,     /* size_t input_width            */
         &workspace_size, /* size_t* workspace_size */
+#ifndef XNNPACK_NO_CODE_CACHE
         &workspace_alignment, /* size_t* workspace_alignment */
+#endif
         nullptr,  /* size_t* output_height_out     */
         nullptr,  /* size_t* output_width_out      */
         pt_pool); /* pthreadpool_t threadpool      */
@@ -215,7 +225,9 @@ enum xnn_status xnnp_reshape_convolution2d_nhwc(
         in_h,     /* size_t input_height           */
         in_w,     /* size_t input_width            */
         &workspace_size, /* size_t* workspace_size */
+#ifndef XNNPACK_NO_CODE_CACHE
         &workspace_alignment, /* size_t* workspace_alignment */
+#endif
         nullptr,  /* size_t* output_height_out     */
         nullptr,  /* size_t* output_width_out      */
         pt_pool); /* pthreadpool_t threadpool      */
@@ -298,7 +310,9 @@ enum xnn_status xnnp_create_fully_connected_nc(
       output_min,              /* int8_t output_min                      */
       output_max,              /* int8_t output_max                      */
       flags,                   /* uint32_t flags                         */
+#ifndef XNNPACK_NO_CODE_CACHE
       nullptr,                 /* xnn_caches_t caches                    */
+#endif
       nullptr,                 /* xnn_weights_cache_t                    */
       fully_connected_op_out); /* xnn_operator_t* fully_connected_op_out */
 }

--- a/aten/src/ATen/native/xnnpack/Convolution.cpp
+++ b/aten/src/ATen/native/xnnpack/Convolution.cpp
@@ -25,6 +25,7 @@ namespace {
 // TODO: Decouple and improve error handling and messages.
 bool available(
     const Tensor& weight,
+    // NOLINTNEXTLINE(facebook-hte-ConstantArgumentPassByValue)
     const at::OptionalIntArrayRef bias_sizes_opt,
     const IntArrayRef padding,
     const IntArrayRef stride,
@@ -102,7 +103,7 @@ Tensor create_and_run(
       output_padding,
       stride,
       dilation,
-      groups,
+      static_cast<uint32_t>(groups),
       transposed,
       output_min,
       output_max);
@@ -126,11 +127,10 @@ const Tensor reorder_weights_for_transpose_conv(const Tensor& weight_nhwc,
 
   TORCH_CHECK(weight_nhwc.size(0) % num_groups == 0, "The number of groups cannot be satisfied by the provided weight tensor.");
 
-  // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
-  int input_channels_per_group = weight_nhwc.size(0) / num_groups;
-  int output_channels_per_group = weight_nhwc.size(1);
-  int kernel_width = weight_nhwc.size(3);
-  int kernel_height = weight_nhwc.size(2);
+  int input_channels_per_group = static_cast<int>(weight_nhwc.size(0) / num_groups);
+  int output_channels_per_group = static_cast<int>(weight_nhwc.size(1));
+  int kernel_width = static_cast<int>(weight_nhwc.size(3));
+  int kernel_height = static_cast<int>(weight_nhwc.size(2));
 
   int o_offset = 1;
   int h_offset = output_channels_per_group;
@@ -204,22 +204,22 @@ ContextConv2D create(
   std::array<int64_t, 4> weight_sizes{};
 
   if (transposed) {
-    const Tensor weight_reordered = reorder_weights_for_transpose_conv(weight_nhwc, groups);
+    const Tensor weight_reordered = reorder_weights_for_transpose_conv(weight_nhwc, static_cast<int>(groups));
     for (const auto i : c10::irange(4)) {
       weight_sizes[i] = weight_reordered.size(i);
     }
     create_status = xnn_create_deconvolution2d_nhwc_f32(
-      padding_expanded[Layout::Parameter::height],                    // output_padding_top
-      padding_expanded[Layout::Parameter::width],                     // output_padding_right
-      padding_expanded[Layout::Parameter::height],                    // output_padding_bottom
-      padding_expanded[Layout::Parameter::width],                     // output_padding_left
-      weight_reordered.size(Layout::Filter::height),                  // kernel_height
-      weight_reordered.size(Layout::Filter::width),                   // kernel_width
-      stride_expanded[Layout::Parameter::height],                     // subsampling_height
-      stride_expanded[Layout::Parameter::width],                      // subsampling_width
-      dilation_expanded[Layout::Parameter::height],                   // dilation_height
-      dilation_expanded[Layout::Parameter::width],                    // dilation_width
-      groups,                                                         // groups
+      static_cast<uint32_t>(padding_expanded[Layout::Parameter::height]),                    // output_padding_top
+      static_cast<uint32_t>(padding_expanded[Layout::Parameter::width]),                     // output_padding_right
+      static_cast<uint32_t>(padding_expanded[Layout::Parameter::height]),                    // output_padding_bottom
+      static_cast<uint32_t>(padding_expanded[Layout::Parameter::width]),                     // output_padding_left
+      static_cast<uint32_t>(weight_reordered.size(Layout::Filter::height)),                  // kernel_height
+      static_cast<uint32_t>(weight_reordered.size(Layout::Filter::width)),                   // kernel_width
+      static_cast<uint32_t>(stride_expanded[Layout::Parameter::height]),                     // subsampling_height
+      static_cast<uint32_t>(stride_expanded[Layout::Parameter::width]),                      // subsampling_width
+      static_cast<uint32_t>(dilation_expanded[Layout::Parameter::height]),                   // dilation_height
+      static_cast<uint32_t>(dilation_expanded[Layout::Parameter::width]),                    // dilation_width
+      static_cast<uint32_t>(groups),                                                         // groups
       weight_reordered.size(Layout::Filter::output) / groups,         // group_input_channels
       weight_reordered.size(Layout::Filter::input),                   // group_output_channels
       weight_reordered.size(Layout::Filter::output),                  // input_pixel_stride
@@ -231,7 +231,9 @@ ContextConv2D create(
       output_min,                                                     // output_min
       output_max,                                                     // output_max
       0u,                                                             // flags
+#ifndef XNNPACK_NO_CODE_CACHE
       nullptr,                                                        // xnn_caches_t
+#endif
       nullptr,                                                        // xnn_weights_cache_t
       &convolution_op);                                               // operator
   } else {
@@ -239,17 +241,17 @@ ContextConv2D create(
       weight_sizes[i] = weight_nhwc.size(i);
     }
     create_status = xnn_create_convolution2d_nhwc_f32(
-      padding_expanded[Layout::Parameter::height],                    // input_padding_top
-      padding_expanded[Layout::Parameter::width],                     // input_padding_right
-      padding_expanded[Layout::Parameter::height],                    // input_padding_bottom
-      padding_expanded[Layout::Parameter::width],                     // input_padding_left
-      weight_nhwc.size(Layout::Filter::height),                       // kernel_height
-      weight_nhwc.size(Layout::Filter::width),                        // kernel_width
-      stride_expanded[Layout::Parameter::height],                     // subsampling_height
-      stride_expanded[Layout::Parameter::width],                      // subsampling_width
-      dilation_expanded[Layout::Parameter::height],                   // dilation_height
-      dilation_expanded[Layout::Parameter::width],                    // dilation_width
-      groups,                                                         // groups
+      static_cast<uint32_t>(padding_expanded[Layout::Parameter::height]),                    // input_padding_top
+      static_cast<uint32_t>(padding_expanded[Layout::Parameter::width]),                     // input_padding_right
+      static_cast<uint32_t>(padding_expanded[Layout::Parameter::height]),                    // input_padding_bottom
+      static_cast<uint32_t>(padding_expanded[Layout::Parameter::width]),                     // input_padding_left
+      static_cast<uint32_t>(weight_nhwc.size(Layout::Filter::height)),                       // kernel_height
+      static_cast<uint32_t>(weight_nhwc.size(Layout::Filter::width)),                        // kernel_width
+      static_cast<uint32_t>(stride_expanded[Layout::Parameter::height]),                     // subsampling_height
+      static_cast<uint32_t>(stride_expanded[Layout::Parameter::width]),                      // subsampling_width
+      static_cast<uint32_t>(dilation_expanded[Layout::Parameter::height]),                   // dilation_height
+      static_cast<uint32_t>(dilation_expanded[Layout::Parameter::width]),                    // dilation_width
+      static_cast<uint32_t>(groups),                                                         // groups
       weight_nhwc.size(Layout::Filter::input),                        // group_input_channels
       weight_nhwc.size(Layout::Filter::output) / groups,              // group_output_channels
       weight_nhwc.size(Layout::Filter::input) * groups,               // input_pixel_stride
@@ -261,7 +263,9 @@ ContextConv2D create(
       output_min,                                                     // output_min
       output_max,                                                     // output_max
       0u,                                                             // flags
+#ifndef XNNPACK_NO_CODE_CACHE
       nullptr,                                                        // xnn_caches_t
+#endif
       nullptr,                                                        // xnn_weights_cache_t
       &convolution_op);                                               // operator
   }
@@ -333,13 +337,14 @@ Tensor run(
    */
 
   if (context.transposed_) {
+    // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
     setup_status = xnn_reshape_deconvolution2d_nhwc_f32(
       context.op.get(),
       padded_input_nhwc.size(Layout::Activation4D::batch),   // batch_size
       padded_input_nhwc.size(Layout::Activation4D::height),  // input_height
       padded_input_nhwc.size(Layout::Activation4D::width),   // input_width
-      context.output_padding_[0],                            // adjustment_height
-      context.output_padding_[1],                            // adjustment_width
+      static_cast<uint32_t>(context.output_padding_[0]),                            // adjustment_height
+      static_cast<uint32_t>(context.output_padding_[1]),                            // adjustment_width
       nullptr,                                               // output_height_out
       nullptr,                                               // output_width_out
       caffe2::pthreadpool_());                               // threadpool
@@ -350,15 +355,20 @@ Tensor run(
       output.data_ptr<float>());                             // output
   } else {
     size_t workspace_size = SIZE_MAX;
+#ifndef XNNPACK_NO_CODE_CACHE
     size_t workspace_alignment = SIZE_MAX;
+#endif
 
+    // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
     setup_status = xnn_reshape_convolution2d_nhwc_f32(
       context.op.get(),
       padded_input_nhwc.size(Layout::Activation4D::batch),   // batch_size
       padded_input_nhwc.size(Layout::Activation4D::height),  // input_height
       padded_input_nhwc.size(Layout::Activation4D::width),   // input_width
       &workspace_size,                                       // workspace_size
+#ifndef XNNPACK_NO_CODE_CACHE
       &workspace_alignment,                                  // workspace_alignment
+#endif
       nullptr,                                               // output_height_out
       nullptr,                                               // output_width_out
       caffe2::pthreadpool_());
@@ -462,6 +472,7 @@ Tensor conv2d_transpose_clamp_run(
 bool use_convolution2d(
     const Tensor& input,
     const Tensor& weight,
+    // NOLINTNEXTLINE(facebook-hte-ConstantArgumentPassByValue)
     const at::OptionalIntArrayRef bias_sizes_opt,
     const IntArrayRef padding,
     const IntArrayRef stride,
@@ -497,7 +508,7 @@ Tensor convolution2d(
       {0, 0}, // output_padding
       stride,
       dilation,
-      groups,
+      static_cast<uint32_t>(groups),
       false,  // transposed
       ContextConv2D::kMin,
       ContextConv2D::kMax);

--- a/aten/src/ATen/native/xnnpack/Linear.cpp
+++ b/aten/src/ATen/native/xnnpack/Linear.cpp
@@ -94,7 +94,9 @@ ContextLinear create(
       output_min,                                                     // output_min
       output_max,                                                     // output_max
       0u,                                                             // flags
+#ifndef XNNPACK_NO_CODE_CACHE
       nullptr,                                                        // xnn_caches_t
+#endif
       nullptr,                                                        // xnn_weights_cache_t
       &linear_op);                                                    // operator
 

--- a/third_party/xnnpack.buck.bzl
+++ b/third_party/xnnpack.buck.bzl
@@ -16,7 +16,57 @@ load(
 XNN_COMMON_PREPROCESSOR_FLAGS = [
     "-DXNN_PRIVATE=",
     "-DXNN_INTERNAL=",
-    "-DXNN_LOG_LEVEL=0"
+    "-DXNN_LOG_LEVEL=0",
+] + select({
+    "DEFAULT": ["-Werror=implicit-fallthrough"],
+    "ovr_config//os:windows": [],
+})
+
+# Zip kernels are patched back in internally.
+ZIP_SCALAR_SRCS = [
+    "XNNPACK/src/x8-zip/x8-zip-x2-scalar.c",
+    "XNNPACK/src/x8-zip/x8-zip-x3-scalar.c",
+    "XNNPACK/src/x8-zip/x8-zip-x4-scalar.c",
+    "XNNPACK/src/x8-zip/x8-zip-xm-scalar.c",
+    "XNNPACK/src/x32-zip/x32-zip-x2-scalar.c",
+    "XNNPACK/src/x32-zip/x32-zip-x3-scalar.c",
+    "XNNPACK/src/x32-zip/x32-zip-x4-scalar.c",
+    "XNNPACK/src/x32-zip/x32-zip-xm-scalar.c",
+]
+
+ZIP_NEON_SRCS = [
+    "XNNPACK/src/x8-zip/x8-zip-x2-neon.c",
+    "XNNPACK/src/x8-zip/x8-zip-x3-neon.c",
+    "XNNPACK/src/x8-zip/x8-zip-x4-neon.c",
+    "XNNPACK/src/x8-zip/x8-zip-xm-neon.c",
+    "XNNPACK/src/x32-zip/x32-zip-x2-neon.c",
+    "XNNPACK/src/x32-zip/x32-zip-x3-neon.c",
+    "XNNPACK/src/x32-zip/x32-zip-x4-neon.c",
+    "XNNPACK/src/x32-zip/x32-zip-xm-neon.c",
+]
+
+ZIP_SSE2_SRCS = [
+    "XNNPACK/src/x8-zip/x8-zip-x2-sse2.c",
+    "XNNPACK/src/x8-zip/x8-zip-x3-sse2.c",
+    "XNNPACK/src/x8-zip/x8-zip-x4-sse2.c",
+    "XNNPACK/src/x8-zip/x8-zip-xm-sse2.c",
+    "XNNPACK/src/x32-zip/x32-zip-x2-sse2.c",
+    "XNNPACK/src/x32-zip/x32-zip-x3-sse2.c",
+    "XNNPACK/src/x32-zip/x32-zip-x4-sse2.c",
+    "XNNPACK/src/x32-zip/x32-zip-xm-sse2.c",
+]
+
+AMD64_ASM_COMPILER_FLAGS = [
+    "-mf16c",
+    "-mfma",
+    "-mavx512f",
+    "-mavx512cd",
+    "-mavx512bw",
+    "-mavx512dq",
+    "-mavx512vl",
+    "-mavx512vnni",
+    "-mgfni",
+    "-mavx512bf16",
 ]
 
 # This defines XNNPACK targets for both fbsource BUCK and OSS BUCK
@@ -98,6 +148,7 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             third_party("FP16"),
             third_party("FXdiv"),
             third_party("clog"),
+            third_party("pthreadpool"),
         ],
     )
 
@@ -144,6 +195,42 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         visibility = ["PUBLIC"],
         windows_clang_compiler_flags_override = WINDOWS_FLAGS + WINDOWS_CLANG_COMPILER_FLAGS,
         windows_compiler_flags_override = WINDOWS_FLAGS,
+        deps = XNN_COMMON_MICROKERNEL_EXPORTED_DEPS,
+    )
+
+    fb_xplat_cxx_library(
+        name = "ukernels_zip",
+        srcs = select({
+            "DEFAULT": ZIP_SCALAR_SRCS,
+            "ovr_config//cpu:arm32": ZIP_NEON_SRCS + ZIP_SCALAR_SRCS,
+            "ovr_config//cpu:arm64": ZIP_NEON_SRCS,
+            "ovr_config//cpu:x86_32": ZIP_SSE2_SRCS,
+            "ovr_config//cpu:x86_64": ZIP_SSE2_SRCS,
+            "ovr_config//runtime:wasm-emscripten": ZIP_SCALAR_SRCS,
+        }),
+        headers = get_xnnpack_headers(),
+        header_namespace = "",
+        apple_sdks = (IOS, MACOSX),
+        compiler_flags = [
+            "-O2",
+        ] + select({
+            "DEFAULT": [],
+            "ovr_config//cpu:arm32": [
+                "-marm",
+                "-march=armv7-a",
+                "-mfpu=neon",
+            ],
+            "ovr_config//cpu:x86_32": ["-msse2"],
+            "ovr_config//cpu:x86_64": ["-msse2"],
+        }) + WASM_EMSCRIPTEN_COMPILER_FLAGS,
+        labels = labels,
+        fbandroid_link_whole = True,
+        preferred_linkage = "static",
+        preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
+        visibility = ["PUBLIC"],
+        windows_clang_compiler_flags_override = WINDOWS_FLAGS + WINDOWS_CLANG_COMPILER_FLAGS + ["-msse2"],
+        windows_compiler_flags_override = WINDOWS_FLAGS + ["-msse2"],
+        windows_srcs = ZIP_SSE2_SRCS,
         deps = XNN_COMMON_MICROKERNEL_EXPORTED_DEPS,
     )
 
@@ -741,8 +828,8 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
         visibility = ["PUBLIC"],
-        windows_clang_compiler_flags_override = WINDOWS_FLAGS + WINDOWS_CLANG_COMPILER_FLAGS + ["-mf16c"],
-        windows_compiler_flags_override = WINDOWS_FLAGS + ["-mf16c"],
+        windows_clang_compiler_flags_override = WINDOWS_FLAGS + WINDOWS_CLANG_COMPILER_FLAGS + ["-mf16c", "-DXNN_ENABLE_F16C=1"],
+        windows_compiler_flags_override = WINDOWS_FLAGS + ["-mf16c", "-DXNN_ENABLE_F16C=1"],
         deps = XNN_COMMON_MICROKERNEL_EXPORTED_DEPS,
     )
 
@@ -769,8 +856,8 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         preferred_linkage = "static",
         preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
         visibility = ["PUBLIC"],
-        windows_clang_compiler_flags_override = WINDOWS_FLAGS + WINDOWS_CLANG_COMPILER_FLAGS + ["-mf16c"],
-        windows_compiler_flags_override = WINDOWS_FLAGS + ["-mf16c"],
+        windows_clang_compiler_flags_override = WINDOWS_FLAGS + WINDOWS_CLANG_COMPILER_FLAGS + ["-mf16c", "-DXNN_ENABLE_F16C=1"],
+        windows_compiler_flags_override = WINDOWS_FLAGS + ["-mf16c", "-DXNN_ENABLE_F16C=1"],
         windows_srcs = prod_srcs_for_arch_wrapper("f16c"),
         deps = XNN_COMMON_MICROKERNEL_EXPORTED_DEPS,
     )
@@ -1652,8 +1739,8 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             "ovr_config//cpu:arm32": prod_srcs_for_arch_wrapper("aarch32"),
         }),
         headers = subdir_glob([
-            ("XNNPACK/src", "xnnpack/assembly.h"),
-            ("XNNPACK/src", "**/*.S"),
+            ("XNNPACK", "src/xnnpack/assembly.h"),
+            ("XNNPACK", "src/**/*.S"),
         ]),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX),
@@ -1685,8 +1772,8 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             "ovr_config//cpu:arm64": prod_srcs_for_arch_wrapper("aarch64"),
         }),
         headers = subdir_glob([
-            ("XNNPACK/src", "xnnpack/assembly.h"),
-            ("XNNPACK/src", "**/*.S"),
+            ("XNNPACK", "src/xnnpack/assembly.h"),
+            ("XNNPACK", "src/**/*.S"),
         ]),
         header_namespace = "",
         apple_sdks = (IOS, MACOSX),
@@ -1705,6 +1792,87 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         visibility = ["PUBLIC"],
         windows_clang_compiler_flags_override = WINDOWS_FLAGS + WINDOWS_CLANG_COMPILER_FLAGS,
         windows_compiler_flags_override = WINDOWS_FLAGS,
+        deps = XNN_COMMON_MICROKERNEL_EXPORTED_DEPS,
+    )
+
+    fb_xplat_cxx_library(
+        name = "ukernels_amd64",
+        srcs = select({
+            "DEFAULT": [],
+            "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("amd64"),
+            "ovr_config//runtime:fbcode": prod_srcs_for_arch_wrapper("amd64"),
+        }),
+        headers = subdir_glob([
+            ("XNNPACK", "src/xnnpack/assembly.h"),
+            ("XNNPACK", "src/**/*.S"),
+        ]),
+        header_namespace = "",
+        apple_sdks = (IOS, MACOSX),
+        compiler_flags = [
+            "-O2",
+        ] + select({
+            "DEFAULT": [],
+            "ovr_config//cpu:x86_64": AMD64_ASM_COMPILER_FLAGS,
+            "ovr_config//runtime:fbcode": AMD64_ASM_COMPILER_FLAGS,
+        }),
+        labels = labels,
+        fbandroid_link_whole = True,
+        preferred_linkage = "static",
+        preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
+        visibility = ["PUBLIC"],
+        deps = XNN_COMMON_MICROKERNEL_EXPORTED_DEPS,
+    )
+
+    fb_xplat_cxx_library(
+        name = "ukernels_sse2fma",
+        srcs = select({
+            "DEFAULT": [],
+            "ovr_config//cpu:x86_32": prod_srcs_for_arch_wrapper("sse2fma"),
+            "ovr_config//cpu:x86_64": prod_srcs_for_arch_wrapper("sse2fma"),
+            "ovr_config//runtime:fbcode": prod_srcs_for_arch_wrapper("sse2fma"),
+        }),
+        headers = get_xnnpack_headers(),
+        header_namespace = "",
+        apple_sdks = (IOS, MACOSX),
+        compiler_flags = [
+            "-O2",
+        ] + select({
+            "DEFAULT": [],
+            "ovr_config//cpu:x86_32": ["-msse2"],
+            "ovr_config//cpu:x86_64": ["-msse2"],
+            "ovr_config//runtime:fbcode": ["-msse2"],
+        }),
+        labels = labels,
+        fbandroid_link_whole = True,
+        preferred_linkage = "static",
+        preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
+        visibility = ["PUBLIC"],
+        windows_clang_compiler_flags_override = WINDOWS_FLAGS + WINDOWS_CLANG_COMPILER_FLAGS + ["-msse2"],
+        windows_compiler_flags_override = WINDOWS_FLAGS + ["-msse2"],
+        windows_srcs = prod_srcs_for_arch_wrapper("sse2fma"),
+        deps = XNN_COMMON_MICROKERNEL_EXPORTED_DEPS,
+    )
+
+    fb_xplat_cxx_library(
+        name = "ukernels_sse2fma_ovr_win32",
+        headers = get_xnnpack_headers(),
+        header_namespace = "",
+        apple_sdks = (IOS, MACOSX),
+        compiler_flags = [
+            "-O2",
+        ] + select({
+            "DEFAULT": [],
+            "ovr_config//cpu:x86_32": ["-msse2"],
+            "ovr_config//cpu:x86_64": ["-msse2"],
+        }),
+        labels = labels,
+        fbandroid_link_whole = True,
+        preferred_linkage = "static",
+        preprocessor_flags = XNN_COMMON_PREPROCESSOR_FLAGS,
+        visibility = ["PUBLIC"],
+        windows_clang_compiler_flags_override = WINDOWS_FLAGS + WINDOWS_CLANG_COMPILER_FLAGS + ["-msse2"],
+        windows_compiler_flags_override = WINDOWS_FLAGS + ["-msse2"],
+        windows_srcs = prod_srcs_for_arch_wrapper("sse2fma"),
         deps = XNN_COMMON_MICROKERNEL_EXPORTED_DEPS,
     )
 
@@ -1741,6 +1909,8 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         preferred_linkage = "static",
         visibility = ["PUBLIC"],
         deps = [
+            ":ukernels_amd64",
+            ":ukernels_sse2fma",
             ":ukernels_avx",
             ":ukernels_avx2",
             ":ukernels_avx512",
@@ -1775,14 +1945,12 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             ":ukernels_sse41_ovr_win32",
             ":ukernels_sse_ovr_win32",
             ":ukernels_ssse3_ovr_win32",
+            ":ukernels_sse2fma_ovr_win32",
             ":ukernels_avx512vbmi",
             # ":ukernels_avx512vnni_ovr_win32", # Build crashes on Windows Clang 17.0.3, re-enable when fixed (T199959765)
             # ":ukernels_avx512vnnigfni_ovr_win32",
             # ":ukernels_avxvnni_ovr_win32" Excluding avxvnni microkernels because they fail on older compilers
         ],
-        exported_preprocessor_flags = [
-            "-DXNN_ENABLE_AVX512VNNIGFNI=0"
-        ]
     )
 
     fb_xplat_cxx_library(
@@ -1862,6 +2030,7 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
         deps = [
             ":tables",
             ":prod_ukernels",
+            ":ukernels_zip",
             third_party("cpuinfo"),
             third_party("pthreadpool"),
         ],
@@ -1894,17 +2063,64 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             "-DXNN_ENABLE_CPUINFO",
             "-DXNN_ENABLE_ARM_I8MM=1",
             "-DXNN_ENABLE_ARM_FP16_VECTOR=1",
-            "-DXNN_ENABLE_AVXVNNI=0",
             "-DXNN_ENABLE_ARM_SME=0",
             "-DXNN_ENABLE_ARM_SME2=0",
+            # The hardware-config / gemm-config dispatch code now references every
+            # XNN_ENABLE_<ISA> macro as a C expression (not just #ifdef), so each
+            # must be defined to 0/1. Values mirror the x86 ukernels linked via
+            # :x86_and_x86_64_lib (enabled = 1, the rest = 0).
+            "-DXNN_ENABLE_SSE=1",
+            "-DXNN_ENABLE_SSE2=1",
+            "-DXNN_ENABLE_SSSE3=1",
+            "-DXNN_ENABLE_SSE41=1",
+            "-DXNN_ENABLE_AVX=1",
+            "-DXNN_ENABLE_F16C=1",
+            "-DXNN_ENABLE_FMA3=1",
+            "-DXNN_ENABLE_AVX2=1",
+            "-DXNN_ENABLE_AVX512F=1",
+            "-DXNN_ENABLE_AVX512SKX=1",
+            "-DXNN_ENABLE_AVX512VBMI=1",
+            "-DXNN_ENABLE_AVX512AMX=0",
+            "-DXNN_ENABLE_AVX256SKX=0",
+            "-DXNN_ENABLE_AVX256VNNI=0",
+            "-DXNN_ENABLE_AVX256VNNIGFNI=0",
+            "-DXNN_ENABLE_AVX512FP16=0",
+            "-DXNN_ENABLE_AVX512BF16=0",
+            "-DXNN_ENABLE_AVXVNNI=0",
+            "-DXNN_ENABLE_AVXVNNIINT8=0",
+        ] + (select({
+            "DEFAULT": [
+                "-DXNN_ENABLE_AVX512VNNI=1",
+                "-DXNN_ENABLE_AVX512VNNIGFNI=0",
+            ],
+            # Windows curated lib excludes the avx512vnni/gfni ukernels (T199959765).
+            "ovr_config//os:windows": [
+                "-DXNN_ENABLE_AVX512VNNI=0",
+                "-DXNN_ENABLE_AVX512VNNIGFNI=0",
+            ],
+        }) if XNNPACK_WINDOWS_AVX512F_ENABLED else [
+            "-DXNN_ENABLE_AVX512VNNI=1",
+            "-DXNN_ENABLE_AVX512VNNIGFNI=1",
+        ]),
+        exported_preprocessor_flags = [
+            # XNNPACK dropped the JIT code-cache argument from its xnn_create_*
+            # operator APIs. Signal consumers (e.g. ATen) to use the new
+            # signature; OSS builds against older XNNPACK leave this undefined
+            # and keep passing the code-cache argument.
+            "-DXNNPACK_NO_CODE_CACHE",
         ],
         srcs = XNNPACK_SRCS + LOGGING_SRCS + OPERATOR_SRCS + [
             "XNNPACK/src/init.c",
             "XNNPACK/src/configs/hardware-config.c",
+            "XNNPACK/src/xnnpack/init-once.c",
             "XNNPACK/src/microkernel-utils.c",
+            "XNNPACK/src/operator-delete.c",
             "XNNPACK/src/operator-run.c",
+            "XNNPACK/src/operators/fingerprint_cache.c",
+            "XNNPACK/src/operators/fingerprint_id.c",
+            "XNNPACK/src/xnnpack/fingerprint_check.c",
             "XNNPACK/src/reference/packing.cc",
-            "XNNPACK/src/packw.c",
+            "XNNPACK/src/pack-lh.cc",
             "XNNPACK/src/cache.c",
             "XNNPACK/src/indirection.c",
             "XNNPACK/src/operator-utils.c",

--- a/third_party/xnnpack_buck_shim.bzl
+++ b/third_party/xnnpack_buck_shim.bzl
@@ -4,10 +4,38 @@ load(
     _OPERATOR_SRCS = "OPERATOR_SRCS",
     _SUBGRAPH_SRCS = "SUBGRAPH_SRCS",
     _TABLE_SRCS = "TABLE_SRCS",
-    _XNNPACK_SRCS = "XNNPACK_SRCS",
 )
 load("//xplat/third-party/XNNPACK/XNNPACK/gen:microkernels.bzl", "prod_srcs_for_arch")
 load("//tools/build_defs:glob_defs.bzl", "subdir_glob")
+
+_XNNPACK_SRCS = [
+    "src/configs/argmaxpool-config.c",
+    "src/configs/avgpool-config.c",
+    "src/configs/binary-elementwise-config.c",
+    "src/configs/cmul-config.c",
+    "src/configs/conv-hwc2chw-config.c",
+    "src/configs/dwconv-config.c",
+    "src/configs/dwconv2d-chw-config.c",
+    "src/configs/gemm-config.c",
+    "src/configs/ibilinear-chw-config.c",
+    "src/configs/ibilinear-config.c",
+    "src/configs/lut32norm-config.c",
+    "src/configs/maxpool-config.c",
+    "src/configs/pack-lh-config.c",
+    "src/configs/raddstoreexpminusmax-config.c",
+    "src/configs/reduce-config.c",
+    "src/configs/spmm-config.c",
+    "src/configs/transpose-config.c",
+    "src/configs/unary-elementwise-config.c",
+    "src/configs/unpool-config.c",
+    "src/configs/vmulcaddc-config.c",
+    "src/configs/xx-fill-config.c",
+    "src/configs/xx-pad-config.c",
+    "src/configs/x8-lut-config.c",
+    # Restored to keep the channel-shuffle operator (removed upstream) available
+    # for ATen; see the restored src/x8-zip and src/x32-zip microkernels.
+    "src/configs/zip-config.c",
+]
 
 def define_xnnpack_build_src(xnnpack_build_src):
     return ["XNNPACK/{}".format(src) for src in xnnpack_build_src]
@@ -18,10 +46,13 @@ def prod_srcs_for_arch_wrapper(arch):
 
 def get_xnnpack_headers():
     src_headers = subdir_glob([
-        ("XNNPACK/src", "**/*.h"),
+        ("XNNPACK", "src/**/*.h"),
+        # Microkernel definitions are textually included (.inc) by the
+        # microkernel sources, so they must be visible as headers.
+        ("XNNPACK", "src/**/*.inc"),
     ])
     include_headers = subdir_glob([
-        ("XNNPACK/include", "*.h"),
+        ("XNNPACK", "include/*.h"),
     ])
 
     return src_headers | include_headers


### PR DESCRIPTION
Summary:
Update XNNPACK and update buck build.

allow-large-files

This also involves tweaking a few numerically sensitive tests (see comments). I've aligned with test owners (NGTTS/Llama4) via workchat. Due to the size increase, I also needed to tweak buck builds in a few places to avoid relocation overflows. I followed guidance from https://www.internalfb.com/wiki/Python/Python_and_FBCode/Relocation_Overflow_Errors/.

Test Plan:
Performance testing on 7 models, note that the "w/ old threadpool" tab is the appropriate one for the current state of the stack: https://docs.google.com/spreadsheets/d/1pdCJ2TkNWx0s4D24XUPjYAFXuHaD6OxWQUUC5A1QOHs

Perf is generally positive or within a few percent (noise).

PPL impact is <1% on Gemma3-1b on Wikitext.

Ran fbsource//xplat/cria/benchmark:oneshot_recall_main eval on S25 and had Claude rank outputs:
```
  - Dataset name: evals_e2e_C3_20250918__auto_cleaned__sft__msg_v2 (under recall_gtar_eval)
  - Slice used: all_eval_hive_dump.tsv — the full 568-row / 567-eval set (the 10-row quick slice is the sibling eval_hive_dump.tsv)
```
```
  Rating results: No systemic quality drop

  Aggregate over the 169 differing rows:

  ┌───────────────────────────────────────────────────────┬───────┬───────┐
  │                        Rating                         │ Count │ Share │
  ├───────────────────────────────────────────────────────┼───────┼───────┤
  │ Neutral (paraphrase / both equally good or bad)       │ 96    │ 57%   │
  ├───────────────────────────────────────────────────────┼───────┼───────┤
  │ Better (HEAD more faithful, or fixes a PARENT defect) │ 36    │ 21%   │
  ├───────────────────────────────────────────────────────┼───────┼───────┤
  │ Worse (HEAD introduces a defect PARENT avoided)       │ 37    │ 22%   │
  └───────────────────────────────────────────────────────┴───────┴───────┘
```

Impact is slightly higher on x86.

Reviewed By: digantdesai

Differential Revision: D111504673


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01