### PR TITLE
Extend single-GPU distributed test split (#189232) to ROCm

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -2222,11 +2222,11 @@ elif [[ "${BUILD_ENVIRONMENT}" == *libtorch* ]]; then
 elif [[ "$TEST_CONFIG" == distributed ]]; then
   install_torchcomms
   install_spmd_types
-  # On CUDA the single-process (single-GPU) distributed tests are hived off to
-  # the `default` config's 1-GPU runner (see below), so this multi-GPU box only
-  # runs the process-spawning ones. Elsewhere (CPU pull, rocm) there is no such
-  # split, so run the whole suite.
-  if [[ "$BUILD_ENVIRONMENT" == *cuda* ]]; then
+  # On CUDA and ROCm the single-process (single-GPU) distributed tests are hived
+  # off to the `default` config's 1-GPU runner (see below), so this multi-GPU box
+  # only runs the process-spawning ones. Elsewhere (e.g. CPU pull) there is no
+  # such split, so run the whole suite.
+  if [[ "$BUILD_ENVIRONMENT" == *cuda* || "$BUILD_ENVIRONMENT" == *rocm* ]]; then
     test_distributed multigpu
   else
     test_distributed
@@ -2378,7 +2378,7 @@ elif [[ "${BUILD_ENVIRONMENT}" == *rocm* && -n "$TESTS_TO_INCLUDE" ]]; then
 elif [[ "${SHARD_NUMBER}" == 1 && $NUM_TEST_SHARDS -gt 1 ]]; then
   # TODO(temporary): run distributed-single first for faster signal while we
   # validate the split; move to the end once it's proven stable.
-  if [[ "${BUILD_ENVIRONMENT}" == *cuda* ]]; then
+  if [[ "${BUILD_ENVIRONMENT}" == *cuda* || "${BUILD_ENVIRONMENT}" == *rocm* ]]; then
     test_distributed_single_gpu
   fi
   test_lazy_tensor_meta_reference_disabled
@@ -2391,7 +2391,7 @@ elif [[ "${SHARD_NUMBER}" == 1 && $NUM_TEST_SHARDS -gt 1 ]]; then
     test_xpu_bin
   fi
 elif [[ "${SHARD_NUMBER}" == 2 && $NUM_TEST_SHARDS -gt 1 ]]; then
-  if [[ "${BUILD_ENVIRONMENT}" == *cuda* ]]; then
+  if [[ "${BUILD_ENVIRONMENT}" == *cuda* || "${BUILD_ENVIRONMENT}" == *rocm* ]]; then
     test_distributed_single_gpu
   fi
   install_torchvision
@@ -2404,7 +2404,7 @@ elif [[ "${SHARD_NUMBER}" == 2 && $NUM_TEST_SHARDS -gt 1 ]]; then
   test_libtorch_profiler
 elif [[ "${SHARD_NUMBER}" -gt 2 ]]; then
   # Handle arbitrary number of shards
-  if [[ "${BUILD_ENVIRONMENT}" == *cuda* ]]; then
+  if [[ "${BUILD_ENVIRONMENT}" == *cuda* || "${BUILD_ENVIRONMENT}" == *rocm* ]]; then
     test_distributed_single_gpu
   fi
   install_torchvision


### PR DESCRIPTION
## Summary

Follow-up to #189232, which added the `multigpu` pytest marker and, **on CUDA**, moved the single-process (single-GPU) distributed tests out of the multi-GPU `distributed` config onto the `default` config's 1-GPU runner. The routing in `.ci/pytorch/test.sh` was gated to `*cuda*` only — a deliberate, conservative rollout (per the `TODO(temporary) ... while we validate the split` comment) — so **ROCm** still runs the whole distributed suite on its multi-GPU `distributed` box and runs zero distributed tests in `default`.

This PR extends the exact same split to ROCm by flipping the four `*cuda*` gates to also match `*rocm*`:
- `distributed` config → runs only the multi-GPU (process-spawning) tests (`test_distributed multigpu`)
- `default` config's 1-GPU shards → run the single-GPU distributed tests (`test_distributed_single_gpu`)

### Why this is safe/appropriate for ROCm
ROCm's CI topology already mirrors CUDA's:
- `default` configs run on **1-GPU** runners (e.g. `linux.rocm.gpu.gfx942.1`) and, for mi300/mi350/mi200, set no `tests-to-include`, so they already fall through to the same generic shard branches CUDA uses.
- `distributed` configs run on **multi-GPU** runners (`linux.rocm.gpu.gfx942.4`, `linux.rocm.gpu.mi210.2`).
- **navi31** is unaffected: it has no `distributed` config and its `default` job uses `tests-to-include` (the ROCm `TESTS_TO_INCLUDE` branch), so it neither reaches these branches nor changes coverage.

### Motivation
Beyond matching CUDA's cost/throughput win (single-GPU tests off the scarce multi-GPU runners), this also fixes a downstream inconsistency: tooling that compares ROCm vs CUDA test results per `(test, config)` currently sees single-GPU distributed tests under `default` on CUDA but `distributed` on ROCm, producing spurious mismatches. Aligning the split removes that at the source.

## Test plan
- [x] `bash -n .ci/pytorch/test.sh` (syntax)
- [x] `ciflow/rocm` + `ciflow/periodic` — verify on ROCm CI that:
  - the `distributed` config now runs only multigpu tests and stays green on the multi-GPU runners
  - the `default` config's shards pick up the single-GPU distributed tests and stay green on 1-GPU runners

## Related
- Downstream ROCm parity PR that this fixes at the source: ROCm/pytorch#3432. That PR works around the mismatch in the parity tooling by folding `default`↔`distributed` for `distributed.*` files; once this change lands and propagates to ROCm/pytorch, ROCm and CUDA attribute single-GPU distributed tests to the same config, removing the mismatch upstream.

## Verification on ROCm CI (mi350 / gfx950)

Validated end-to-end on this PR's `linux-jammy-rocm-py3.10-mi350` run — all shards green (default 8/8, distributed 3/3, inductor 2/2): https://github.com/pytorch/pytorch/actions/runs/29345176556

**Old vs new — the split is actually exercised:**

Old (merge base `329a5b4`, pre-split) distributed shard ran the whole suite — [job 87124950503](https://github.com/pytorch/pytorch/actions/runs/29342891791/job/87124950503):
```
+ test_distributed
Testing distributed python tests (all)
```

New (this PR) `distributed` shard runs only the multi-GPU tests — [job 87131790315](https://github.com/pytorch/pytorch/actions/runs/29345176556/job/87131790315):
```
+ test_distributed multigpu
Testing distributed python tests (multigpu)
+ python test/run_test.py --distributed-tests --multigpu-filter multigpu --shard 1 3 --verbose
```

New (this PR) `default` shard now runs the single-GPU distributed tests — [job 87131790292](https://github.com/pytorch/pytorch/actions/runs/29345176556/job/87131790292):
```
+ test_distributed_single_gpu
+ test_distributed not-multigpu
Testing distributed python tests (not-multigpu)
+ python test/run_test.py --distributed-tests --multigpu-filter not-multigpu --shard 1 8 --verbose
```

**Downstream parity effect (ROCm vs CUDA)** — parity report for this commit: https://github.com/ethanwee1/pytorch/actions/runs/29370122913 (artifact `parity-results-mi350`, `20260714_all_tests_status_mi350.csv`):
- 0 new ROCm failures; `distributed`-config disagreements dropped to **69** (from ~1,700 before the split), because single-GPU distributed tests now attribute to the same config on both stacks.
- e.g. `distributed/_composable/fsdp/test_fully_shard_autograd::test_post_acc_grad_hook_runs` is now a single `distributed` row `rocm=PASSED / cuda=PASSED`, instead of the previous doubled `default: rocm=MISSED/cuda=PASSED` + `distributed: rocm=PASSED/cuda=MISSED`.

### XML-level evidence: where the single-process distributed tests land

Tracing one single-process (not-multigpu) test — `distributed/test_symmetric_memory::SymmMemSingleProcTest::test_memset32` — through the actual JUnit XML artifacts, before vs after, ROCm vs CUDA:

| stack | before this PR | after this PR |
|---|---|---|
| **ROCm** | `test-distributed` artifact | `test-default` artifact |
| **CUDA** | `test-default` artifact | `test-default` artifact |

**Before — ROCm** ran it in the **distributed** artifact (whole suite on the multi-GPU box) — [run 29342891791 / job 87124950433](https://github.com/pytorch/pytorch/actions/runs/29342891791/job/87124950433):
```xml
<!-- rocm_xml/test-distributed-3-3_87124950433/.../distributed.test_symmetric_memory-*.xml -->
<testcase classname="SymmMemSingleProcTest" name="test_memset32" time="0.095" file="distributed/test_symmetric_memory.py" />
```
**Before — CUDA** already ran it in the **default** artifact (job 87122965489):
```xml
<!-- cuda_xml/test-default-2-5_87122965489/.../distributed.test_symmetric_memory-*.xml -->
<testcase classname="SymmMemSingleProcTest" name="test_memset32" time="0.165" file="distributed/test_symmetric_memory.py" />
```
→ **config mismatch** (ROCm `distributed` vs CUDA `default`) — this is what produced the spurious parity MISSEDs.

**After — ROCm** now runs it in the **default** artifact (moved; 0 remaining in the distributed artifact) — [run 29345176556 / job 87131790292](https://github.com/pytorch/pytorch/actions/runs/29345176556/job/87131790292):
```xml
<!-- rocm_xml/test-default-1-8_87131790292/.../distributed.test_symmetric_memory-*.xml -->
<testcase classname="SymmMemSingleProcTest" name="test_memset32" time="3.214" file="distributed/test_symmetric_memory.py" />
```
**After — CUDA** unchanged, still **default** (job 87132976027):
```xml
<!-- cuda_xml/test-default-1-5_87132976027/.../distributed.test_symmetric_memory-*.xml -->
<testcase classname="SymmMemSingleProcTest" name="test_memset32" time="0.150" file="distributed/test_symmetric_memory.py" />
```
→ **now aligned**: both ROCm and CUDA attribute the single-process test to `default`. The multi-process classes in the same file (e.g. `SymmetricMemoryTest`) correctly stay in the `distributed` artifact on both stacks.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang