### PR TITLE
Skip test_polar_matches_svd when cuSOLVER lacks Xpolar

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4264,6 +4264,13 @@ class TestLinalg(TestCase):
         if torch.device(device).type != "cuda":
             self.skipTest("cuSOLVER Xpolar path is CUDA-only")
         from torch._native.ops.polar import nvmath_impl as nv
+        from torch._native.ops.polar.impl import _check_nvmath
+
+        # The test invokes the Xpolar kernel directly, bypassing the override's
+        # runtime gate/fallback, so skip when the loaded cuSOLVER does not expose
+        # Xpolar (e.g. a CUDA runtime older than the version that added it).
+        if not _check_nvmath():
+            self.skipTest("cuSOLVER runtime does not expose Xpolar")
 
         make_fullrank = make_fullrank_matrices_with_distinct_singular_values
         A = make_fullrank(32, 16, device=device, dtype=dtype)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189875

test_polar_matches_svd invokes the cuSOLVER Xpolar (QDWH) kernel directly via
torch._native.ops.polar.nvmath_impl.polar_xpolar, deliberately bypassing the
linalg_polar override's runtime gate and SVD fallback so it exercises Xpolar
specifically. But cusolverDnXpolar was only added in cuSOLVER 12.2 (CUDA 13.1),
and nvmath resolves the symbol lazily, so on an older CUDA runtime the direct
call raises FunctionNotFoundError instead of falling back. This reds the H100
smoke job (CUDA 13.0):

    test_linalg.py::TestLinalgCUDA::test_polar_matches_svd_cuda_float32
    nvmath.bindings._internal.utils.FunctionNotFoundError:
      function cusolverDnXpolar_bufferSize is not found

@skipIfNoNvmath only checks that nvmath is installed, not that the loaded
cuSOLVER exposes Xpolar. Gate the test on the polar override's own
_check_nvmath() (which requires cusolver_version() >= 12.2 and a NVIDIA build)
and skip when the fast path is unavailable -- the same criterion the override
uses to decide whether to run Xpolar at all.

Note: production is unaffected; the override's cond/_run_xpolar already gate and
fall back to the aten SVD kernel. This only fixes the test's direct call.

Test Plan:
```
lintrunner test/test_linalg.py
python -m py_compile test/test_linalg.py
```
Full run needs a CUDA runtime and is left to CI: on the H100 smoke image
(cuSOLVER < 12.2) the test now skips; on runtimes with Xpolar it still runs.

Authored with Claude.