### PR TITLE
Add torch.load-style map_location support to torch.export.load

### DIFF
--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -6,6 +6,7 @@ with test_sym_bool)
 # Owner(s): ["oncall: export"]
 import copy
 import io
+import json
 import math
 import tempfile
 import unittest
@@ -38,7 +39,7 @@ import torch.export._trace
 import torch.utils._pytree as pytree
 from torch._export.db.case import ExportCase, SupportLevel
 from torch._export.db.examples import all_examples
-from torch._export.serde.schema import ArgumentKind
+from torch._export.serde.schema import ArgumentKind, Device, SCHEMA_VERSION
 from torch._export.serde.serialize import (
     _dict_to_dataclass,
     _to_json_bytes,
@@ -47,6 +48,7 @@ from torch._export.serde.serialize import (
     deserialize_torch_artifact,
     ExportedProgramDeserializer,
     ExportedProgramSerializer,
+    GraphModuleDeserializer,
     GraphModuleSerializer,
     serialize,
     SerializeError,
@@ -2388,6 +2390,161 @@ class TestSaveLoad(TestCase):
         loaded_ep = load(buffer)
         self.assertEqual(m(*inp), loaded_ep.module()(*inp))
 
+    @parametrize(
+        "map_location",
+        (
+            "cpu",
+            torch.device("cpu"),
+            {"cuda:0": "cpu"},
+            lambda storage, _location: storage,
+        ),
+        name_fn=lambda map_location: type(map_location).__name__,
+    )
+    def test_load_map_location(self, map_location) -> None:
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = torch.nn.Parameter(torch.randn(4, 4))
+                self.register_buffer("bias", torch.randn(4))
+                self.register_buffer("empty", torch.empty(0))
+                self.constant = torch.randn(4)
+
+            def forward(self, x):
+                out = x @ self.weight + self.bias + self.constant + self.empty.sum()
+                return torch.ops.aten.to.device(
+                    out,
+                    device="cpu",
+                    dtype=torch.float32,
+                )
+
+        def rewrite_cpu_devices_as_cuda(value):
+            if isinstance(value, dict):
+                if value.get("type") == "cpu" and "index" in value:
+                    value["type"] = "cuda"
+                    value["index"] = 0
+                for item in value.values():
+                    rewrite_cpu_devices_as_cuda(item)
+            elif isinstance(value, list):
+                for item in value:
+                    rewrite_cpu_devices_as_cuda(item)
+
+        m = M()
+        inp = (torch.randn(2, 4),)
+        ep = torch.export.export(m, inp)
+        buffer = io.BytesIO()
+        save(ep, buffer)
+        buffer.seek(0)
+
+        cuda_buffer = io.BytesIO()
+        with (
+            zipfile.ZipFile(buffer) as source,
+            zipfile.ZipFile(cuda_buffer, "w") as destination,
+        ):
+            for info in source.infolist():
+                data = source.read(info.filename)
+                if info.filename.endswith(".json"):
+                    json_data = json.loads(data)
+                    rewrite_cpu_devices_as_cuda(json_data)
+                    if info.filename.endswith("models/model.json"):
+                        for node in json_data["graph_module"]["graph"]["nodes"]:
+                            if node["target"] == "torch.ops.aten.to.device":
+                                for node_input in node["inputs"]:
+                                    if "as_device" in node_input["arg"]:
+                                        node_input["arg"]["as_device"]["index"] = None
+                    data = json.dumps(json_data).encode()
+                destination.writestr(info, data)
+        cuda_buffer.seek(0)
+
+        loaded_ep = load(cuda_buffer, map_location=map_location)
+        self.assertEqual(m(*inp), loaded_ep.module()(*inp))
+        self.assertTrue(loaded_ep.constants)
+        self.assertEqual(loaded_ep.state_dict["empty"].numel(), 0)
+
+        for tensor in loaded_ep.state_dict.values():
+            self.assertEqual(tensor.device.type, "cpu")
+        for tensor in loaded_ep.constants.values():
+            if isinstance(tensor, torch.Tensor):
+                self.assertEqual(tensor.device.type, "cpu")
+        for node in loaded_ep.graph.nodes:
+            for value in pytree.tree_leaves(node.meta.get("val")):
+                if isinstance(value, torch.Tensor):
+                    self.assertEqual(value.device.type, "cpu")
+            for value in pytree.tree_leaves((node.args, node.kwargs)):
+                if isinstance(value, torch.device):
+                    self.assertEqual(value.type, "cpu")
+
+    @parametrize(
+        "case,map_location,expected",
+        (
+            (
+                "invalid_source",
+                {"not-a-device": "meta", "cuda:0": "cpu"},
+                torch.device("cpu"),
+            ),
+            (
+                "same_destination",
+                {"cuda:0": "cpu", "cuda:1": "cpu"},
+                torch.device("cpu"),
+            ),
+            (
+                "ambiguous_exact_fallback",
+                {"cuda": "meta", "cuda:0": "cpu"},
+                torch.device("meta"),
+            ),
+        ),
+        name_fn=lambda case, map_location, expected: case,
+    )
+    def test_unindexed_device_map_location(
+        self,
+        case,
+        map_location,
+        expected,
+    ) -> None:
+        deserializer = GraphModuleDeserializer(map_location)
+        self.assertEqual(
+            deserializer._deserialize_device(Device(type="cuda")),
+            expected,
+        )
+
+    @parametrize(
+        "legacy",
+        (False, True),
+        name_fn=lambda legacy: "legacy" if legacy else "pt2",
+    )
+    def test_load_map_location_meta(self, legacy) -> None:
+        ep = export(torch.nn.Linear(4, 4), (torch.randn(2, 4),))
+        buffer = io.BytesIO()
+        if legacy:
+            artifact = serialize(ep)
+            with zipfile.ZipFile(buffer, "w") as archive:
+                archive.writestr("version", ".".join(map(str, SCHEMA_VERSION)))
+                archive.writestr(
+                    "serialized_exported_program.json",
+                    artifact.exported_program,
+                )
+                archive.writestr("serialized_state_dict.pt", artifact.state_dict)
+                archive.writestr("serialized_constants.pt", artifact.constants)
+                archive.writestr(
+                    "serialized_example_inputs.pt",
+                    artifact.example_inputs,
+                )
+        else:
+            save(ep, buffer)
+        buffer.seek(0)
+
+        loaded_ep = load(buffer, map_location="meta")
+        for tensor in loaded_ep.state_dict.values():
+            self.assertEqual(tensor.device.type, "meta")
+        if loaded_ep.example_inputs is None:
+            self.fail("Expected example inputs to be preserved")
+        for value in pytree.tree_leaves(loaded_ep.example_inputs):
+            if isinstance(value, torch.Tensor):
+                self.assertEqual(value.device.type, "meta")
+        for node in loaded_ep.graph.nodes:
+            for value in pytree.tree_leaves(node.meta.get("val")):
+                if isinstance(value, torch.Tensor):
+                    self.assertEqual(value.device.type, "meta")
+
     @unittest.skipIf(not torch.cuda.is_available(), "Requires cuda")
     def test_save_load_cuda_tensor(self) -> None:
         class M(torch.nn.Module):
@@ -2400,6 +2557,7 @@ class TestSaveLoad(TestCase):
 
         m = M().cuda()
         inp = (torch.randn(1, 64, device="cuda"),)
+        expected = m(*inp).cpu()
         ep = torch.export.export(m, inp)
         buffer = io.BytesIO()
         save(ep, buffer)
@@ -2411,6 +2569,21 @@ class TestSaveLoad(TestCase):
                 param.device.type, "cuda", lambda msg: f"{msg}\n{name} not on cuda"
             )
         self.assertEqual(m(*inp), loaded_ep.module()(*inp))
+
+        buffer.seek(0)
+        loaded_cpu_ep = load(buffer, map_location="cpu")
+        for name, param in loaded_cpu_ep.state_dict.items():
+            self.assertEqual(
+                param.device.type, "cpu", lambda msg: f"{msg}\n{name} not on cpu"
+            )
+        example_inputs = loaded_cpu_ep.example_inputs
+        if example_inputs is None:
+            self.fail("Expected example inputs to be preserved")
+        args, kwargs = example_inputs
+        for value in pytree.tree_leaves((args, kwargs)):
+            if isinstance(value, torch.Tensor):
+                self.assertEqual(value.device.type, "cpu")
+        self.assertEqual(expected, loaded_cpu_ep.module()(*args, **kwargs))
 
     def test_from_node_metadata_serialization(self):
         """Test that from_node metadata is properly serialized and deserialized."""
@@ -2464,6 +2637,9 @@ class TestSaveLoad(TestCase):
                         self.assertEqual(
                             node_source_orig.to_dict(), node_source_loaded.to_dict()
                         )
+
+
+instantiate_parametrized_tests(TestSaveLoad)
 
 
 @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo doesn't support")

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -33,6 +33,7 @@ from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
 from torch.fx._symbolic_trace import _ConstantAttributeType
 from torch.fx.experimental import symbolic_shapes
 from torch.fx.traceback import NodeSource
+from torch.serialization import _get_restore_location, MAP_LOCATION
 from torch.utils import _pytree as pytree
 from torch.utils._pytree import treespec_dumps, treespec_loads
 from torch.utils._sympy.numbers import int_oo
@@ -426,6 +427,7 @@ def serialize_torch_artifact(
 
 def deserialize_torch_artifact(
     serialized: dict[str, Any] | tuple[Any, ...] | bytes,
+    map_location: MAP_LOCATION = None,
 ):
     if isinstance(serialized, (dict, tuple)):
         return serialized
@@ -435,10 +437,18 @@ def deserialize_torch_artifact(
     buffer.seek(0)
     # weights_only=False as we want to load custom objects here (e.g. ScriptObject)
     try:
-        artifact = torch.load(buffer, weights_only=True)
+        artifact = torch.load(
+            buffer,
+            map_location=map_location,
+            weights_only=True,
+        )
     except Exception as e:
         buffer.seek(0)
-        artifact = torch.load(buffer, weights_only=False)
+        artifact = torch.load(
+            buffer,
+            map_location=map_location,
+            weights_only=False,
+        )
         log.warning(
             "Fallback to weights_only=False succeeded. "
             "Loaded object of type %s after initial failure: %s",
@@ -2304,11 +2314,35 @@ class GraphModuleDeserializer(metaclass=Final):
         constants: dict[str, _ConstantAttributeType]
         example_inputs: tuple[tuple[torch.Tensor, ...], dict[str, Any]] | None
 
-    def __init__(self) -> None:
+    def __init__(self, map_location: MAP_LOCATION = None) -> None:
         self.serialized_name_to_node: dict[str, torch.fx.Node] = {}
         self.serialized_name_to_meta: LazyMap = LazyMap()  # str -> MetaType
         self.graph = torch.fx.Graph()
         self.module = torch.nn.Module()
+        self.map_location = map_location
+
+    def _deserialize_device(self, device: Device) -> torch.device:
+        deserialized_device = deserialize_device(device)
+        if self.map_location is None:
+            return deserialized_device
+        if isinstance(self.map_location, dict) and deserialized_device.index is None:
+            # Preserve torch.load's exact-key behavior: ignore invalid source tags
+            # and fall through when indexed tags do not imply one destination.
+            mapped_locations: set[str] = set()
+            for location, mapped_location in self.map_location.items():
+                try:
+                    location_device = torch.device(location)
+                except (RuntimeError, ValueError):
+                    continue
+                if location_device.type == deserialized_device.type:
+                    mapped_locations.add(mapped_location)
+            if len(mapped_locations) == 1:
+                return torch.device(mapped_locations.pop())
+        storage = _get_restore_location(self.map_location)(
+            torch.UntypedStorage(0),
+            str(deserialized_device),
+        )
+        return torch.device(storage.device)
 
     @contextmanager
     def save_graph_module(self) -> Iterator[None]:
@@ -2477,7 +2511,7 @@ class GraphModuleDeserializer(metaclass=Final):
                 torch.empty_strided(
                     tuple(self.deserialize_sym_int(val) for val in tensor_meta.sizes),  # type: ignore[misc]
                     tuple(self.deserialize_sym_int(val) for val in tensor_meta.strides),  # type: ignore[misc]
-                    device=deserialize_device(tensor_meta.device),
+                    device=self._deserialize_device(tensor_meta.device),
                     dtype=_SERIALIZE_TO_TORCH_DTYPE[tensor_meta.dtype],
                     requires_grad=tensor_meta.requires_grad,
                 ),
@@ -2950,7 +2984,11 @@ class GraphModuleDeserializer(metaclass=Final):
                 "Identity": torch.utils._sympy.functions.Identity,
             }
             self.symbol_name_to_symbol: dict[str, sympy.Symbol] = {}
-            self.constants = deserialize_torch_artifact(constants)
+            state_dict = deserialize_torch_artifact(
+                serialized_state_dict,
+                self.map_location,
+            )
+            self.constants = deserialize_torch_artifact(constants, self.map_location)
             self.signature = self.deserialize_signature(
                 serialized_graph_module.signature
             )
@@ -2986,7 +3024,10 @@ class GraphModuleDeserializer(metaclass=Final):
                 self.shape_env.unbacked_symint_counter += 1
 
             if example_inputs is not None and len(example_inputs) > 0:
-                self.example_inputs = deserialize_torch_artifact(example_inputs)
+                self.example_inputs = deserialize_torch_artifact(
+                    example_inputs,
+                    self.map_location,
+                )
             else:
                 self.example_inputs = None
             self.deserialize_graph(serialized_graph_module.graph)
@@ -3012,7 +3053,7 @@ class GraphModuleDeserializer(metaclass=Final):
                 signature=self.signature,
                 module_call_graph=module_call_graph,
                 names_to_symbols=self.symbol_name_to_symbol,
-                state_dict=deserialize_torch_artifact(serialized_state_dict),
+                state_dict=state_dict,
                 constants=self.constants,
                 example_inputs=self.example_inputs,
             )
@@ -3117,7 +3158,7 @@ class GraphModuleDeserializer(metaclass=Final):
                 name=value.name,
             )
         elif typ_ == "as_device":
-            return deserialize_device(inp.as_device)
+            return self._deserialize_device(inp.as_device)
         elif typ_ == "as_int":
             return inp.as_int
         elif typ_ == "as_float":
@@ -3574,6 +3615,7 @@ class ExportedProgramDeserializer(metaclass=Final):
         | bytes
         | None = None,
         *,
+        map_location: MAP_LOCATION = None,
         _unsafe_skip_version_check=False,
     ) -> ep.ExportedProgram:
         if not isinstance(exported_program, ExportedProgram):
@@ -3599,7 +3641,7 @@ class ExportedProgramDeserializer(metaclass=Final):
             )
             for k, v in exported_program.range_constraints.items()
         }
-        res = GraphModuleDeserializer().deserialize(
+        res = GraphModuleDeserializer(map_location).deserialize(
             exported_program.graph_module,
             state_dict,
             constants,
@@ -3776,6 +3818,7 @@ def deserialize(
     artifact: SerializedArtifact,
     expected_opset_version: dict[str, int] | None = None,
     *,
+    map_location: MAP_LOCATION = None,
     _unsafe_skip_version_check=False,
 ) -> ep.ExportedProgram:
     if not isinstance(artifact.exported_program, bytes):
@@ -3790,6 +3833,7 @@ def deserialize(
         artifact.state_dict,
         artifact.constants,
         artifact.example_inputs,
+        map_location=map_location,
         _unsafe_skip_version_check=_unsafe_skip_version_check,
     )
 

--- a/torch/export/__init__.py
+++ b/torch/export/__init__.py
@@ -9,6 +9,7 @@ from typing_extensions import deprecated
 import torch
 import torch.utils._pytree as pytree
 from torch.fx.passes.infra.pass_base import PassResult
+from torch.serialization import MAP_LOCATION
 from torch.types import FileLike
 
 
@@ -338,6 +339,7 @@ def load(
     *,
     extra_files: dict[str, Any] | None = None,
     expected_opset_version: dict[str, int] | None = None,
+    map_location: MAP_LOCATION = None,
 ) -> ExportedProgram:
     """
 
@@ -362,6 +364,9 @@ def load(
         expected_opset_version (Optional[Dict[str, int]]): A map of opset names
          to expected opset versions
 
+        map_location: a function, :class:`torch.device`, string or a dict
+         specifying how to remap storage locations.
+
     Returns:
         An :class:`ExportedProgram` object
 
@@ -372,6 +377,9 @@ def load(
 
         # Load ExportedProgram from file
         ep = torch.export.load("exported_program.pt2")
+
+        # Load all tensor state and graph device metadata onto the CPU.
+        ep = torch.export.load("exported_program.pt2", map_location="cpu")
 
         # Load ExportedProgram from io.BytesIO object
         with open("exported_program.pt2", "rb") as f:
@@ -396,6 +404,7 @@ def load(
         pt2_contents = load_pt2(
             f,
             expected_opset_version=expected_opset_version,
+            map_location=map_location,
         )
     except RuntimeError:
         log.warning("Ran into the following error when deserializing", exc_info=True)
@@ -482,7 +491,11 @@ def load(
         )
 
         # Deserialize ExportedProgram
-        ep = deserialize(artifact, expected_opset_version)
+        ep = deserialize(
+            artifact,
+            expected_opset_version,
+            map_location=map_location,
+        )
 
         return ep
 

--- a/torch/export/pt2_archive/_package.py
+++ b/torch/export/pt2_archive/_package.py
@@ -57,6 +57,7 @@ from torch.export.pt2_archive.constants import (
     WEIGHTS_CONFIG_FILENAME_FORMAT,
     WEIGHTS_DIR,
 )
+from torch.serialization import _get_restore_location, MAP_LOCATION
 from torch.types import FileLike
 
 
@@ -796,11 +797,13 @@ def _build_file_map(
     archive_reader: PT2ArchiveReader,
     config: schema.PayloadConfig,
     base_dir: str,
+    map_location: MAP_LOCATION = None,
 ) -> dict[str, torch.Tensor]:
     """
     Build a map from file path to the payload in flat tensor format.
     """
     file_map: dict[str, torch.Tensor] = {}
+    restore_location = _get_restore_location(map_location)
     for payload_meta in config.config.values():
         # skip pickled objects
         if payload_meta.use_pickle:
@@ -819,10 +822,10 @@ def _build_file_map(
         nbytes = archive_reader.archive_file.get_record_size(record_name)
 
         if nbytes == 0:
+            # Match torch.load: materialize on CPU, then apply map_location below.
+            # Allocating on the saved device here would fail before remapping.
             size = deserialize_size(tensor_meta.sizes)
-            tensor = torch.zeros(size, dtype=dtype, device=device)
-            if tensor_meta.requires_grad:
-                tensor.requires_grad_(True)
+            tensor = torch.zeros(size, dtype=dtype)
         else:
             element_size = torch._utils._element_size(dtype)
             if nbytes % element_size != 0:
@@ -838,10 +841,16 @@ def _build_file_map(
             # so we wrap the storage in a proper CPU tensor via set_().
             tensor = torch.empty(0, dtype=dtype)
             tensor.set_(raw.untyped_storage(), 0, (numel,), (1,))
-            if tensor_meta.requires_grad:
-                tensor.requires_grad_(True)
-            if device != torch.device("cpu"):
-                tensor = tensor.to(device)
+
+        restored_storage = restore_location(tensor.untyped_storage(), str(device))
+        tensor = torch.empty(0, dtype=dtype, device=restored_storage.device).set_(
+            restored_storage,
+            tensor.storage_offset(),
+            tensor.size(),
+            tensor.stride(),
+        )
+        if tensor_meta.requires_grad:
+            tensor.requires_grad_(True)
 
         file_map[payload_meta.path_name] = tensor
 
@@ -864,6 +873,7 @@ def _load_payload_config(
 def _load_state_dict(
     archive_reader: PT2ArchiveReader,
     model_name: str,
+    map_location: MAP_LOCATION = None,
 ) -> dict[str, torch.Tensor] | bytes:
     # Make it BC compatible with legacy weight files
     legacy_weights_file = f"{WEIGHTS_DIR}{model_name}.pt"
@@ -880,7 +890,10 @@ def _load_state_dict(
         weights_config = _load_payload_config(archive_reader, weights_config_file)
         # construct the mapping from file name (e.g. weight_0) to flat weight payload
         state_dict_file_map = _build_file_map(
-            archive_reader, weights_config, WEIGHTS_DIR
+            archive_reader,
+            weights_config,
+            WEIGHTS_DIR,
+            map_location,
         )
         # chain the mapping weight FQN -> weight file name -> strided weight payload
         # so that the aliasing of weights is preserved
@@ -891,7 +904,9 @@ def _load_state_dict(
                     os.path.join(WEIGHTS_DIR, payload_meta.path_name)
                 )
                 state_dict[weight_fqn] = torch.load(
-                    io.BytesIO(weight_bytes), weights_only=False
+                    io.BytesIO(weight_bytes),
+                    map_location=map_location,
+                    weights_only=False,
                 )
             else:
                 tensor_meta = payload_meta.tensor_meta
@@ -920,6 +935,7 @@ def _load_state_dict(
 def _load_constants(
     archive_reader: PT2ArchiveReader,
     model_name: str,
+    map_location: MAP_LOCATION = None,
 ) -> dict[str, torch.Tensor] | bytes:
     # Make it BC compatible with legacy constant files
     legacy_constants_file = f"{CONSTANTS_DIR}{model_name}.pt"
@@ -936,7 +952,10 @@ def _load_constants(
         constants_config = _load_payload_config(archive_reader, constants_config_file)
         # construct the mapping from file name (e.g. constant_0) to constant payload
         constant_file_map = _build_file_map(
-            archive_reader, constants_config, CONSTANTS_DIR
+            archive_reader,
+            constants_config,
+            CONSTANTS_DIR,
+            map_location,
         )
         # chain the mapping constant FQN -> constant file name -> strided constant payload
         # so that the aliasing of constants is preserved
@@ -949,7 +968,9 @@ def _load_constants(
                         os.path.join(CONSTANTS_DIR, path_name)
                     )
                     constants[constant_fqn] = torch.load(
-                        io.BytesIO(constant_bytes), weights_only=False
+                        io.BytesIO(constant_bytes),
+                        map_location=map_location,
+                        weights_only=False,
                     )
                 else:
                     tensor_meta = payload_meta.tensor_meta
@@ -989,6 +1010,7 @@ def _load_exported_programs(
     archive_reader: PT2ArchiveReader,
     file_names: list[str],
     expected_opset_version: dict[str, int] | None,
+    map_location: MAP_LOCATION = None,
 ) -> dict[str, ExportedProgram]:
     exported_program_files = [
         file for file in file_names if file.startswith(MODELS_DIR)
@@ -1011,14 +1033,15 @@ def _load_exported_programs(
         serialized_exported_program = _bytes_to_dataclass(
             schema.ExportedProgram, exported_program_bytes
         )
-        state_dict = _load_state_dict(archive_reader, model_name)
-        constants = _load_constants(archive_reader, model_name)
+        state_dict = _load_state_dict(archive_reader, model_name, map_location)
+        constants = _load_constants(archive_reader, model_name, map_location)
 
         ep = ExportedProgramDeserializer(expected_opset_version).deserialize(
             serialized_exported_program,
             state_dict,
             constants,
             serialized_sample_inputs,
+            map_location=map_location,
         )
 
         exported_programs[model_name] = ep
@@ -1083,6 +1106,7 @@ def load_pt2(
     f: FileLike,
     *,
     expected_opset_version: dict[str, int] | None = None,
+    map_location: MAP_LOCATION = None,
     run_single_threaded: bool = False,
     num_runners: int = 1,
     device_index: int = -1,
@@ -1097,6 +1121,9 @@ def load_pt2(
 
         expected_opset_version (Optional[Dict[str, int]]): A map of opset names
          to expected opset versions
+
+        map_location: a function, :class:`torch.device`, string or a dict
+         specifying how to remap storage locations.
 
         num_runners (int): Number of runners to load AOTInductor artifacts
 
@@ -1143,7 +1170,10 @@ def load_pt2(
         file_names = archive_reader.get_file_names()
 
         exported_programs = _load_exported_programs(
-            archive_reader, file_names, expected_opset_version
+            archive_reader,
+            file_names,
+            expected_opset_version,
+            map_location,
         )
         extra_files = _load_extra_files(archive_reader, file_names)
 
@@ -1169,7 +1199,10 @@ def load_pt2(
                     len(WEIGHTS_DIR) :
                 ]  # remove data/weights/ prefix
                 weight_bytes = archive_reader.read_bytes(file)
-                loaded_weight = torch.load(io.BytesIO(weight_bytes))
+                loaded_weight = torch.load(
+                    io.BytesIO(weight_bytes),
+                    map_location=map_location,
+                )
                 weights[weight_file_name] = loaded_weight
 
     if isinstance(f, (io.IOBase, IO)):


### PR DESCRIPTION
Add torch.load-style map_location support to torch.export.load
Tests: test/export/test_serialize.py

example
```python
model = torch.export.load("exported_program.pt2", map_location="cpu")
```