### PR TITLE
[CI] Remove unused scaffolding jobs from the unstable workflow

### DIFF
--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -36,21 +36,3 @@ jobs:
           echo
           echo "Once the jobs are deemed stable enough (% red signal < 5% and TTS < 3h),"
           echo " they can graduate and move back to pull or trunk."
-
-  target-determination:
-    if: github.repository_owner == 'pytorch'
-    name: before-test
-    uses: ./.github/workflows/target_determination.yml
-    permissions:
-      id-token: write
-      contents: read
-
-  get-label-type:
-    name: get-label-type
-    uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
-    if: ${{ (github.event_name != 'schedule' || github.repository == 'pytorch/pytorch') && github.repository_owner == 'pytorch' }}
-    with:
-      triggering_actor: ${{ github.triggering_actor }}
-      issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
-      curr_branch: ${{ github.head_ref || github.ref_name }}
-      curr_ref_type: ${{ github.ref_type }}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189881

The `unstable` workflow currently hosts no unstable jobs -- it is an empty
shell. Its `target-determination` (before-test) and `get-label-type` /
runner-determinator jobs are pre-test scaffolding meant to feed unstable
*test* jobs via `needs:`, but there are none, and nothing references them
(the workflow has no `needs:` at all). They run on every push to `main` and
on every `ciflow/unstable` trigger, producing outputs nothing consumes and
adding noise to the `unstable` HUD column.

Remove both. Keep `introduction`: a workflow must have at least one job, and
it documents the purpose of the unstable workflow. When a real unstable job
is next added, its `get-label-type` / `target-determination` dependencies
come back alongside it.

`unstable-periodic.yml` already contains only `introduction`, so no change is
needed there.

Test Plan:

```
lintrunner .github/workflows/unstable.yml   # actionlint: ok, no lint issues
```

Also confirmed the workflow has no `needs:` referencing the removed jobs, so
nothing consumed their outputs.

Authored with assistance from Claude.