### PR TITLE
[BE] the proper python version to target is 3.10 for extensions 2.10+

### DIFF
--- a/test/cpp_extensions/libtorch_agn_2_10_extension/setup.py
+++ b/test/cpp_extensions/libtorch_agn_2_10_extension/setup.py
@@ -97,5 +97,5 @@ setup(
         "build_ext": BuildExtension.with_options(no_python_abi_suffix=True),
         "clean": clean,
     },
-    options={"bdist_wheel": {"py_limited_api": "cp39"}},
+    options={"bdist_wheel": {"py_limited_api": "cp310"}},
 )

--- a/test/cpp_extensions/libtorch_agn_2_11_extension/setup.py
+++ b/test/cpp_extensions/libtorch_agn_2_11_extension/setup.py
@@ -98,5 +98,5 @@ setup(
         "build_ext": BuildExtension.with_options(no_python_abi_suffix=True),
         "clean": clean,
     },
-    options={"bdist_wheel": {"py_limited_api": "cp39"}},
+    options={"bdist_wheel": {"py_limited_api": "cp310"}},
 )

--- a/test/cpp_extensions/libtorch_agn_2_12_extension/setup.py
+++ b/test/cpp_extensions/libtorch_agn_2_12_extension/setup.py
@@ -99,5 +99,5 @@ setup(
         "build_ext": BuildExtension.with_options(no_python_abi_suffix=True),
         "clean": clean,
     },
-    options={"bdist_wheel": {"py_limited_api": "cp39"}},
+    options={"bdist_wheel": {"py_limited_api": "cp310"}},
 )

--- a/test/cpp_extensions/libtorch_agn_2_13_extension/setup.py
+++ b/test/cpp_extensions/libtorch_agn_2_13_extension/setup.py
@@ -100,5 +100,5 @@ setup(
         "build_ext": BuildExtension.with_options(no_python_abi_suffix=True),
         "clean": clean,
     },
-    options={"bdist_wheel": {"py_limited_api": "cp39"}},
+    options={"bdist_wheel": {"py_limited_api": "cp310"}},
 )

--- a/test/cpp_extensions/libtorch_agn_2_14_extension/setup.py
+++ b/test/cpp_extensions/libtorch_agn_2_14_extension/setup.py
@@ -101,5 +101,5 @@ setup(
         "build_ext": BuildExtension.with_options(no_python_abi_suffix=True),
         "clean": clean,
     },
-    options={"bdist_wheel": {"py_limited_api": "cp39"}},
+    options={"bdist_wheel": {"py_limited_api": "cp310"}},
 )


### PR DESCRIPTION
This change just updates the tests to target the right minimum python version. Very minor, but if anyone were copying our code, we should give them the right pattern.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #189882
* #189877

