### PR TITLE
[dynamo] Filter torch_version artifact in structured trace tests

### DIFF
--- a/test/dynamo/test_structured_trace.py
+++ b/test/dynamo/test_structured_trace.py
@@ -78,6 +78,15 @@ class StructuredTraceTestingFilter(logging.Filter):
     def filter(self, record):
         if "str" in record.metadata:
             return False
+        # torch_version is a global artifact emitted once per process the first
+        # time the trace handler initializes. Its presence (and commit-hash
+        # payload) depends on run context and test ordering, so drop it here to
+        # keep each test's expected inline output deterministic.
+        if (
+            "artifact" in record.metadata
+            and record.metadata["artifact"].get("name") == "torch_version"
+        ):
+            return False
         if self.match_name is not None:
             if "artifact" in record.metadata:
                 if self.match_name != record.metadata["artifact"]["name"]:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189883

_log_torch_version() (added in #178024) emits a global
{"artifact": {"name": "torch_version", ...}} record once per process the
first time the trace handler initializes. This record propagates to the
StructuredTraceTest buffer handler. In OSS unittest runs the lazy trace
handler is not active so it never fires, but internally trace logging is
enabled and each test runs in isolation, so whichever test runs first
picks up a torch_version line its expected inline output does not have.
This left test_dump_file permanently failing and disabled.

Filter the torch_version artifact out in StructuredTraceTestingFilter,
alongside the existing "str" drop, so the once-per-process artifact never
pollutes any test's golden output regardless of run context or ordering.

Differential Revision: [D111928737](https://our.internmc.facebook.com/intern/diff/D111928737/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98