### PR TITLE
bugfix: check_linker_flag cache-variable reuse

### DIFF
--- a/cmake/public/utils.cmake
+++ b/cmake/public/utils.cmake
@@ -496,7 +496,7 @@ include(CheckCCompilerFlag)
 include(CheckLinkerFlag)
 
 ##############################################################################
-# CHeck if given flag is supported and append it to provided outputvar
+# Check if given flag is supported and append it to provided outputvar
 # Also define HAS_UPPER_CASE_FLAG_NAME variable
 # Usage:
 #   append_cxx_flag_if_supported("-Werror" CMAKE_CXX_FLAGS)
@@ -543,9 +543,14 @@ function(target_compile_options_if_supported target flag)
 endfunction()
 
 # Check if a global link option is supported
+# Also defines HAS_LINKER_UPPER_CASE_FLAG_NAME
+# Usage:
+#   add_link_options_if_supported("--emit-relocs")
 function(add_link_options_if_supported flag)
-  check_linker_flag(C "LINKER:${flag}" _supported)
-  if("${_supported}")
+  string(TOUPPER "HAS_LINKER${flag}" _FLAG_NAME)
+  string(REGEX REPLACE "[=,-]" "_" _FLAG_NAME "${_FLAG_NAME}")
+  check_linker_flag(C "LINKER:${flag}" ${_FLAG_NAME})
+  if(${_FLAG_NAME})
     add_link_options("LINKER:${flag}")
   else()
     message(WARNING "Attempted to use unsupported link option : ${flag}.")
@@ -553,8 +558,10 @@ function(add_link_options_if_supported flag)
 endfunction()
 
 function(target_link_options_if_supported tgt flag)
-  check_linker_flag(C "LINKER:${flag}" _supported)
-  if("${_supported}")
+  string(TOUPPER "HAS_LINKER${flag}" _FLAG_NAME)
+  string(REGEX REPLACE "[=,-]" "_" _FLAG_NAME "${_FLAG_NAME}")
+  check_linker_flag(C "LINKER:${flag}" ${_FLAG_NAME})
+  if(${_FLAG_NAME})
     target_link_options("${tgt}" PRIVATE "LINKER:${flag}")
   else()
     message(WARNING "Attempted to use unsupported link option : ${flag}.")


### PR DESCRIPTION
`check_linker_flag(LANG FLAGS VAR)` stores its result in `VAR` as a cache variable (see [CheckLinkerFlag][1]). On any later call where VAR already exists in the cache, CMake short-circuits and skips the actual linker probe, reusing the previous verdict.

I discovered this while trying to use LLD linker on AArch64. It kept failing on `--stub-group-size=0x2000000` which if the logic worked properly shouldn't have been applied by CMake to the linker command. It was applied because the `_supported` var was cached from the previous call to `check_linker_flag`.

This commit changes the `add_link_options_if_supported` (which calls `check_linker_flag`) to generate a unique cache variable name just like `append_cxx_flag_if_supported` does.

CMake now prints this when it encounters an unsupported flag:

```
-- Performing Test HAS_LINKER_Z_MAX_PAGE_SIZE_0X10000
-- Performing Test HAS_LINKER_Z_MAX_PAGE_SIZE_0X10000 - Success
-- Performing Test HAS_LINKER__STUB_GROUP_SIZE_0X2000000
-- Performing Test HAS_LINKER__STUB_GROUP_SIZE_0X2000000 - Failed
CMake Warning at cmake/public/utils.cmake:556 (message):
  Attempted to use unsupported link option : --stub-group-size=0x2000000.
```

[1]: https://cmake.org/cmake/help/latest/module/CheckLinkerFlag.html
