### PR TITLE
[inductor] masked(): emit explicit where when the load is served from the CSE store cache

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -10233,6 +10233,18 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         y = fn_compiled(x)
         self.assertTrue(y is not x)
 
+    def test_constant_pad_nd_fused_with_split_reduction(self):
+        # https://github.com/pytorch/pytorch/issues/<你的issue号>
+        # The pad's fill value used to be dropped when the pad was fused with
+        # the second stage of a split reduction: the body's load is served
+        # from the CSE store cache (producer fused into the same kernel), so
+        # no tl.load is emitted and the masked-load `other` never applies.
+        def fn(mask):
+            lengths = mask.sum(dim=-1, dtype=torch.int32)
+            return F.pad(torch.cumsum(lengths, dim=0, dtype=torch.int32), (1, 0))
+
+        self.common(fn, (torch.ones(1, 16384, dtype=torch.bool),))
+
     def test_l1_loss(self):
         def fn(a, b):
             return torch.nn.functional.l1_loss(a, b), torch.nn.functional.mse_loss(a, b)

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2534,7 +2534,15 @@ class TritonKernelOverrides(TritonOverrides):
         # operator to save the branching cost.
         for node in nodes:
             for arg in node.args:
-                if arg.target != "load" or should_unwrap_unspec_arg(arg.args[1]):
+                if (
+                    arg.target != "load"
+                    or should_unwrap_unspec_arg(arg.args[1])
+                    # A load whose producer is fused into this kernel is
+                    # served from the CSE store cache and emits no tl.load,
+                    # so the masked-load `other` would be silently dropped;
+                    # fall back to an explicit tl.where.
+                    or arg.args[1] in V.kernel.cse.store_cache
+                ):
                     need_where = True
                     break
 


### PR DESCRIPTION
Fixes #189895

`TritonKernelOverrides.masked()` skips the explicit `tl.where` when the masked body is a plain load, pushing the fill value into `tl.load(..., mask=..., other=...)` instead. However, when the loaded buffer's producer is fused into the same kernel, `CSEProxy.load()` returns the cached CSE variable from `cse.store_cache` and emits no `tl.load` at all — the mask and `other` are silently dropped, and `masked()` returns the unguarded value.

Observable effect: `F.pad(x.sum(...), (1, 0))` with a split reduction returns `[N, N]` instead of `[0, N]`. This is the standard `cu_seqlens` unpad prologue used by HF transformers and flash-attn, so under torch.compile the corrupted offsets make `flash_attn_varlen_func` treat the batch as zero-length and return uninitialized memory (see issue for details and controls).

The fix makes the `need_where` scan treat a load served from the store cache as requiring the explicit `where`. Loads that actually lower to `tl.load` keep the existing masked-load fast path.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo