### PR TITLE
Allocate autograd.Function ctx directly

### DIFF
--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -1382,6 +1382,16 @@ THPObjectPtr call_forward_with_ctx(
       nullptr));
 }
 
+THPObjectPtr create_ctx_instance(PyObject* backward_cls) {
+  if (!PyType_Check(backward_cls) ||
+      !PyType_IsSubtype(
+          reinterpret_cast<PyTypeObject*>(backward_cls), &THPFunctionType)) {
+    return THPObjectPtr(PyObject_CallNoArgs(backward_cls));
+  }
+  return THPObjectPtr(THPFunction_new(
+      reinterpret_cast<PyTypeObject*>(backward_cls), nullptr, nullptr));
+}
+
 THPObjectPtr make_ctx_input_output_tuple(
     THPFunction* ctx,
     UnpackedInput& unpacked_input,
@@ -1626,7 +1636,7 @@ PyObject* THPFunction_apply(PyObject* cls, PyObject* args, PyObject* kwargs) {
   THPObjectPtr backward_cls(PyObject_GetAttrString(cls, "_backward_cls"));
   if (!backward_cls)
     return nullptr;
-  THPObjectPtr ctx_obj(PyObject_CallFunctionObjArgs(backward_cls, nullptr));
+  THPObjectPtr ctx_obj(create_ctx_instance(backward_cls));
   if (!ctx_obj)
     return nullptr;
   auto* ctx = reinterpret_cast<THPFunction*>(ctx_obj.get());


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189898
* #189897
* #189866
* #189865
* #189824
* #189822
* #189810
* #189800
* #189788

The generated backward class used as the Python custom Function ctx is normally a _FunctionBase subtype whose allocation is handled by THPFunction_new. Calling it through the Python type-call path does extra dispatch before reaching the same object allocation path.

When _backward_cls is a THPFunctionType subtype, call THPFunction_new directly. Keep the generic no-arg Python call for unexpected classes.

On the local one-apply 13-in-2-out instruction-count benchmark, this moved the requires-grad case from 45,626 to 45,274 instructions. The no-requires-grad variant moved from 32,217 to 32,515 instructions.

Test Plan:

```bash
MAX_JOBS=96 USE_FBGEMM=0 BUILD_TEST=0 BUILD_IGNORE_SVE_UNAVAILABLE=1 pip install -e . -v --no-build-isolation
```

```bash
python test/test_autograd.py TestAutograd.test_function TestAutograd.test_custom_function_apply_kwargs_setup_context
```

```bash
python test/inductor/test_compiled_autograd.py TestCompiledAutograd.test_custom_fn_saved_tensors TestCompiledAutograd.test_custom_fn_non_variable_input
```

```bash
python - <<'PY'
import torch
import torch._C._instruction_counter as i_counter

OUT = (torch.empty((0,), device="cuda"), torch.empty((0,), device="cuda"))

class F(torch.autograd.Function):
    @staticmethod
    def forward(ctx, *args):
        return OUT

    @staticmethod
    def backward(ctx, *grad_outputs):
        raise RuntimeError

args = tuple(torch.empty((0,), device="cuda", requires_grad=True) for _ in range(13))
for _ in range(10000):
    F.apply(*args)
torch.cuda.synchronize()
counts = []
for i in range(10):
    counter = i_counter.start()
    F.apply(*args)
    count = i_counter.end(counter)
    torch.cuda.synchronize()
    counts.append(count)
print(min(counts))
PY
```

```bash
lintrunner -a
```

`lintrunner -a` fails on pre-existing clang-tidy hicpp-exception-baseclass warnings for python_error in torch/csrc/autograd/python_function.cpp.

Authored with assistance from an AI assistant.