### PR TITLE
[inductor] Exclude inductor_choices_class from save_config codegen

### DIFF
--- a/test/inductor/test_config.py
+++ b/test/inductor/test_config.py
@@ -1,4 +1,5 @@
 # Owner(s): ["module: inductor"]
+import functools
 import math
 import unittest
 
@@ -244,6 +245,16 @@ class TestInductorConfig(TestCase):
         ):
             code = torch._inductor.config.codegen_config()
             self.assertNotIn("post_grad_custom", code)
+
+    def test_codegen_skips_inductor_choices_class(self):
+        # A functools.partial factory has a non-round-trippable repr; it must be
+        # excluded from codegen_config() so extracted repros stay valid Python
+        # (it is cache-serialized separately via _cache_config_factory_keys).
+        with torch._inductor.config.patch(
+            inductor_choices_class=functools.partial(dummy_fn)
+        ):
+            code = torch._inductor.config.codegen_config()
+            self.assertNotIn("inductor_choices_class", code)
 
     def test_select_decomp_table_fallback_embedding_bag_byte_unpack(self):
         """Test that select_decomp_table removes embedding_bag_byte_unpack when fallback is enabled"""

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2950,6 +2950,10 @@ _save_config_ignore: list[str] = [
     # CUDAGraphPolicy objects are not picklable and only affect
     # post_compile wrapping, not compiled code itself.
     "cudagraph_policy",
+    # A custom InductorChoices factory (e.g. a functools.partial) has a
+    # non-round-trippable repr; excluding it keeps codegen_config() valid
+    # Python. It is serialized for caching via _cache_config_factory_keys.
+    "inductor_choices_class",
 ]
 
 _cache_config_ignore_prefix: list[str] = [


### PR DESCRIPTION
Summary: codegen_config() emits inductor_choices_class = functools.partial(<class '...'>), not valid Python → SyntaxError in repro scripts. Fix: add to _save_config_ignore.

Test Plan:
```
buck2 test mode/opt fbcode//caffe2/test/inductor:config
```

Tests finished: Pass 18. Fail 0. Timeout 0. Fatal 0. Skip 0. Omit 0. Infra Failure 0. Build failure 0
New regression test: test_codegen_skips_inductor_choices_class (patches inductor_choices_class to a functools.partial, asserts codegen_config() omits the key).

## Before → After (codegen)

Cluster 2f1ecdb35070 — 80 graphs / 3 model types / 116 failure rows.

Before (without fix): save_config() / codegen_config() serializes inductor_choices_class via repr(); for a functools.partial the emitted config line is non-round-trippable Python, so the extracted repro fails to parse:

    File ".../graph_41_bwd_recompile_1.py", line 63
        torch._inductor.config.inductor_choices_class = functools.partial(<class 'dper_lib.slimper_lib.custom_inductor_choices.SlimperDoNotFuseAddLargeBuffersOrDistantNodes'>, lb=1073741824, ub=10737418240)
                                                                          ^
    SyntaxError: invalid syntax

After (with fix): inductor_choices_class is added to _save_config_ignore, so codegen omits the line entirely; the generated config block is valid Python and recompilation proceeds past it. Verified by test_codegen_skips_inductor_choices_class.

Differential Revision: D110787719




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo