### PR TITLE
[ROCm] Retry VecISA dlopen probe with import torch on cold load failure

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -5272,6 +5272,58 @@ class TestVecISACheckBuild(TestCase):
             msg=lambda msg: f"{msg}\nLD_LIBRARY_PATH should be prepended with {torch_lib!r}, got {value!r}",
         )
 
+    @unittest.skipUnless(sys.platform == "linux", "Linux loader semantics")
+    def test_avx_py_load_falls_back_to_import_torch(self):
+        # Wheels whose native deps only resolve once `import torch` has run
+        # (e.g. ROCm wheels with DT_NEEDED refs on sonames that exist only as
+        # already-loaded renamed bundles, see #189194) fail the cold dlopen,
+        # so the probe child must retry after importing torch. Simulate that:
+        # a probe .so that DT_NEEDEDs libc10.so with no rpath and no
+        # LD_LIBRARY_PATH fails to load cold, and resolves only once
+        # `import torch` maps libc10 into the child process.
+        from torch._inductor import cpu_vec_isa
+
+        compiler = shutil.which("cc") or shutil.which("gcc") or shutil.which("clang")
+        if compiler is None:
+            raise unittest.SkipTest("no C compiler available")
+        torch_lib = os.path.join(os.path.dirname(torch.__file__), "lib")
+        if not os.path.isfile(os.path.join(torch_lib, "libc10.so")):
+            raise unittest.SkipTest("libc10.so not found in torch lib dir")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            src = os.path.join(tmp, "probe.c")
+            with open(src, "w") as f:
+                f.write("void __vec_isa_probe_dummy(void) {}\n")
+            lib_path = os.path.join(tmp, "libvec_isa_probe_needs_c10.so")
+            # --no-as-needed: the probe references no c10 symbol, so without it
+            # the linker would drop the DT_NEEDED entry this test relies on
+            cmd = [
+                compiler,
+                "-shared",
+                "-fPIC",
+                src,
+                "-o",
+                lib_path,
+                "-Wl,--no-as-needed",
+                f"-L{torch_lib}",
+                "-lc10",
+            ]
+            subprocess.run(cmd, check=True)
+
+            env = {k: v for k, v in os.environ.items() if k != "LD_LIBRARY_PATH"}
+            cold_load = f'from ctypes import cdll; cdll.LoadLibrary("{lib_path}")'
+            cold = subprocess.run(
+                [sys.executable, "-c", cold_load], env=env, stderr=subprocess.DEVNULL
+            )
+            if cold.returncode == 0:
+                raise unittest.SkipTest("loader resolves libc10.so without torch")
+
+            script = cpu_vec_isa.VecISA._avx_py_load.replace("__lib_path__", lib_path)
+            probe = subprocess.run(
+                [sys.executable, "-c", script], env=env, stderr=subprocess.PIPE
+            )
+            self.assertEqual(probe.returncode, 0, msg=probe.stderr.decode())
+
 
 class TestCompilationEventLogging(TestCase):
     def reset(self):

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -5175,6 +5175,58 @@ class TestVecISACheckBuild(TestCase):
             msg=lambda msg: f"{msg}\nLD_LIBRARY_PATH should be prepended with {torch_lib!r}, got {value!r}",
         )
 
+    @unittest.skipUnless(sys.platform == "linux", "Linux loader semantics")
+    def test_avx_py_load_falls_back_to_import_torch(self):
+        # Wheels whose native deps only resolve once `import torch` has run
+        # (e.g. ROCm wheels with DT_NEEDED refs on sonames that exist only as
+        # already-loaded renamed bundles, see #189194) fail the cold dlopen,
+        # so the probe child must retry after importing torch. Simulate that:
+        # a probe .so that DT_NEEDEDs libc10.so with no rpath and no
+        # LD_LIBRARY_PATH fails to load cold, and resolves only once
+        # `import torch` maps libc10 into the child process.
+        from torch._inductor import cpu_vec_isa
+
+        compiler = shutil.which("cc") or shutil.which("gcc") or shutil.which("clang")
+        if compiler is None:
+            raise unittest.SkipTest("no C compiler available")
+        torch_lib = os.path.join(os.path.dirname(torch.__file__), "lib")
+        if not os.path.isfile(os.path.join(torch_lib, "libc10.so")):
+            raise unittest.SkipTest("libc10.so not found in torch lib dir")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            src = os.path.join(tmp, "probe.c")
+            with open(src, "w") as f:
+                f.write("void __vec_isa_probe_dummy(void) {}\n")
+            lib_path = os.path.join(tmp, "libvec_isa_probe_needs_c10.so")
+            # --no-as-needed: the probe references no c10 symbol, so without it
+            # the linker would drop the DT_NEEDED entry this test relies on
+            cmd = [
+                compiler,
+                "-shared",
+                "-fPIC",
+                src,
+                "-o",
+                lib_path,
+                "-Wl,--no-as-needed",
+                f"-L{torch_lib}",
+                "-lc10",
+            ]
+            subprocess.run(cmd, check=True)
+
+            env = {k: v for k, v in os.environ.items() if k != "LD_LIBRARY_PATH"}
+            cold_load = f'from ctypes import cdll; cdll.LoadLibrary("{lib_path}")'
+            cold = subprocess.run(
+                [sys.executable, "-c", cold_load], env=env, stderr=subprocess.DEVNULL
+            )
+            if cold.returncode == 0:
+                raise unittest.SkipTest("loader resolves libc10.so without torch")
+
+            script = cpu_vec_isa.VecISA._avx_py_load.replace("__lib_path__", lib_path)
+            probe = subprocess.run(
+                [sys.executable, "-c", script], env=env, stderr=subprocess.PIPE
+            )
+            self.assertEqual(probe.returncode, 0, msg=probe.stderr.decode())
+
 
 class TestCompilationEventLogging(TestCase):
     def reset(self):

--- a/torch/_inductor/cpu_vec_isa.py
+++ b/torch/_inductor/cpu_vec_isa.py
@@ -85,6 +85,13 @@ extern "C" void __avx_chk_kernel() {
     # only: the parent puts torch's lib dir on LD_LIBRARY_PATH so the linker
     # resolves libtorch_cpu for the test .so on its own. macOS can't do this --
     # SIP strips DYLD_LIBRARY_PATH from the child -- so it falls back to import.
+    # Some wheels only resolve their native deps once `import torch` has run.
+    # ROCm wheels bundle ROCm libs under unversioned names but keep some
+    # DT_NEEDED refs on the versioned soname (e.g. libamd_comgr.so.3), which
+    # only resolves against the copy torch has already loaded; TheRock-based
+    # wheels preload ROCm libs from separate rocm-sdk packages with no rpath.
+    # So a cold dlopen can fail even though the ISA is fine; retry after
+    # importing torch before giving up (#189194).
     # TODO: extend the no-import path to Windows once its CI build is green
     # enough to validate it.
     _avx_py_load = """
@@ -92,7 +99,13 @@ import sys
 if sys.platform != "linux":
     import torch  # noqa: F401
 from ctypes import cdll
-cdll.LoadLibrary("__lib_path__")
+try:
+    cdll.LoadLibrary("__lib_path__")
+except OSError:
+    if sys.platform != "linux":
+        raise
+    import torch  # noqa: F401
+    cdll.LoadLibrary("__lib_path__")
 """
 
     def bit_width(self) -> int:


### PR DESCRIPTION
Fixes #189194

The ROCm manywheel build bundles the ROCm runtime into torch/lib under unversioned filenames (libamd_comgr.so, libamdhip64.so, ...) and rewrites consumers' DT_NEEDED entries to match, but some entries are missed: in the 2.13.0+rocm7.2 wheel, libhiprtc.so, librocprofiler-sdk.so, and librocroller.so still reference libamd_comgr.so.3, a filename that does not exist in the wheel. After `import torch` this is harmless: the bundled libamd_comgr.so is already loaded and registered under its unchanged SONAME libamd_comgr.so.3, so those references resolve against the in-process copy. A cold dlopen has no such copy, so on a machine without a system ROCm install the load fails (a ROCm docker image masks the bug because /opt/rocm provides libamd_comgr.so.3 via ldconfig). #183515 changed the VecISA dlopen probe child from `import torch` + dlopen to a cold dlopen with `LD_LIBRARY_PATH=<torch>/lib`, so on such a machine every `check_build` fails and inductor reports "Can't detect vectorized ISA for CPU". Thanks to @karthickai and @atalman for bisecting to #183515 on the issue.

The fix keeps the fast no-import path but retries after `import torch` if the cold dlopen raises OSError, so whatever loading semantics the wheel relies on are in effect before the second attempt. This also covers the same class of failure for TheRock-based ROCm wheels (ROCm libs preloaded from separate rocm-sdk packages with no rpath) and the latent CUDA case where torch and the nvidia wheels land in different site-packages roots and the `$ORIGIN`-relative rpaths dangle. The 60s probe timeout from #183515 still bounds the child either way, so the CI hang that change addressed stays fixed. The missed DT_NEEDED rewrites are arguably a wheel packaging bug worth fixing at the source, but the probe fallback repairs wheels already shipped and does not hardcode packaging layout into inductor.

Reproduced and validated with the actual 2.13.0+rocm7.2 test wheel in a venv, using the glibc loader's `--inhibit-cache` to emulate a machine with no system ROCm: the pre-fix probe script fails with `OSError: libamd_comgr.so.3: cannot open shared object file` and the fixed script succeeds. The new regression test simulates the layout without needing a ROCm wheel:

```
python test/inductor/test_codecache.py TestVecISACheckBuild
```

This PR was authored with Claude (AI assistant).


cc @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben