### PR TITLE
Reuse autograd.Function input tuple

### DIFF
--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -997,8 +997,9 @@ static std::unordered_set<at::TensorImpl*> _parse_non_differentiable(
 
 struct UnpackedInput {
   THPObjectPtr input_tuple;
-  // Borrowed from Tensor arguments kept alive by input_tuple. Avoids copying
-  // at::Tensor handles on the common apply path.
+  // Borrowed from Tensor arguments kept alive by input_tuple. This may be the
+  // original argument tuple; avoid copying at::Tensor handles on the common
+  // apply path.
   c10::SmallVector<const Variable*, 24> input_vars;
   // record_function_inputs is for RECORD_FUNCTION only
   std::vector<c10::IValue> record_function_inputs;
@@ -1028,7 +1029,7 @@ std::pair<UnpackedInput, InputFlags> unpack_input(
   InputFlags flags;
 
   auto num_args = PyTuple_GET_SIZE(args);
-  unpacked.input_tuple = PyTuple_New(num_args);
+  unpacked.input_tuple = Py_NewRef(args);
   flags.needs_input_grad.reserve(num_args);
   unpacked.input_vars.reserve(num_args);
   flags.is_variable_input.reserve(num_args);
@@ -1065,8 +1066,6 @@ std::pair<UnpackedInput, InputFlags> unpack_input(
         unpacked.record_function_inputs.emplace_back(tensor);
       }
     }
-    Py_INCREF(arg);
-    PyTuple_SET_ITEM(unpacked.input_tuple.get(), i, arg);
   }
 
   flags.is_executable = GradMode::is_enabled() && any_requires_grad;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189901
* #189897
* #189866
* #189865
* #189810

THPFunction_apply keeps borrowed Variable pointers for input tensors in UnpackedInput. The old code allocated a second Python tuple and copied every argument into it just to keep those borrowed tensor objects alive.

Keep a new reference to the existing resolved args tuple instead. It provides the same lifetime guarantee while avoiding the duplicate tuple allocation and per-argument incref/store work on the apply path.

On the local one-apply 13-in-2-out no-save instruction-count benchmark, this moved from 47,687 to 45,949 instructions.

Authored with assistance from an AI assistant.