### PR TITLE
[CP] Balance per-document head-tail load balancer with rank-major layout

### DIFF
--- a/test/distributed/tensor/test_attention.py
+++ b/test/distributed/tensor/test_attention.py
@@ -57,7 +57,7 @@ from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
 )
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
-from torch.testing._internal.common_utils import run_tests, skipIfRocm
+from torch.testing._internal.common_utils import run_tests, skipIfRocm, TestCase
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
     DTensorTestBase,
@@ -887,6 +887,45 @@ class TestSharding(DTensorTestBase):
 
     @skip_if_lt_x_gpu(2)
     @with_comms
+    def test_context_parallel_shard_per_document_balance(self) -> None:
+        # End-to-end regression through the real _context_parallel_shard path:
+        # rearrange + shard randomized mixed-length documents and confirm each
+        # rank receives an equal share of causal attention work.
+        # Rank-major balances every rank exactly.
+        # Since a balanced split gives every rank total_work / world_size, each
+        # rank can check its own local shard without cross-rank communication.
+        # NOTE: seed a local RNG so every rank generates identical document
+        # lengths; each length must be a multiple of 2 * world_size.
+        rng = random.Random(1234)
+        doc_lengths = [
+            2 * self.world_size * rng.randint(1, 6) for _ in range(rng.randint(1, 5))
+        ]
+        seq_len = sum(doc_lengths)
+        device_mesh = init_device_mesh(
+            mesh_shape=(self.world_size,),
+            mesh_dim_names=("cp",),
+            device_type=self.device_type,
+        )
+        # cost[t] = causal work of the query at original position t (1..L per doc).
+        cost = []
+        for length in doc_lengths:
+            cost.extend(range(1, length + 1))
+        cost = torch.tensor(cost, device=self.device_type)
+
+        # A token-id buffer so each sharded position maps back to its origin.
+        buffer = torch.arange(seq_len, device=self.device_type).view(1, seq_len)
+        load_balancer = _PerDocumentHeadTailLoadBalancer(
+            [doc_lengths], self.world_size, torch.device(self.device_type)
+        )
+        (sharded,) = _context_parallel_shard(
+            device_mesh, [buffer], [1], load_balancer=load_balancer
+        )
+
+        local_load = int(cost[sharded.reshape(-1).long()].sum())
+        self.assertEqual(local_load, int(cost.sum()) // self.world_size)
+
+    @skip_if_lt_x_gpu(2)
+    @with_comms
     def test_context_parallel_shard_with_positions(self) -> None:
         """Test context parallel sharding with expanded batch dimensions.
 
@@ -1296,7 +1335,77 @@ TestCPCustomOpsWithLocalTensor = create_local_tensor_test_class(
 
 TestShardingWithLocalTensor = create_local_tensor_test_class(
     TestSharding,
+    skipped_tests=[
+        # Uses Python-scalar per-rank load extraction, which does not apply to
+        # the batched local-tensor execution mode.
+        "test_context_parallel_shard_per_document_balance",
+    ],
 )
+
+
+class PerDocumentHeadTailLoadBalancerTest(TestCase):
+    """Non-distributed unit tests for the index layout produced by
+    ``_PerDocumentHeadTailLoadBalancer``. Context-Parallel shards the rearranged
+    sequence into contiguous, equal, per-rank chunks, so the balancer must lay out
+    its indices rank-major (each rank's head+tail chunks of *every* document
+    grouped together) for the contiguous cut to land on rank boundaries."""
+
+    @staticmethod
+    def _causal_cost(doc_lengths: list[int]) -> list[int]:
+        # Under a document-causal mask, the query at within-document position p
+        # attends p + 1 keys, so its cost is 1, 2, ..., L within each document.
+        cost: list[int] = []
+        for length in doc_lengths:
+            cost.extend(range(1, length + 1))
+        return cost
+
+    def _per_rank_causal_load(
+        self, doc_lengths: list[int], world_size: int
+    ) -> list[int]:
+        seq_len = sum(doc_lengths)
+        cost = self._causal_cost(doc_lengths)
+        lb = _PerDocumentHeadTailLoadBalancer([doc_lengths], world_size, "cpu")
+        # Original positions in rearranged order (batch dim removed).
+        rearranged = lb._generate_indices()[0].tolist()
+        # CP shards the rearranged stream into world_size contiguous equal chunks.
+        shard = seq_len // world_size
+        return [
+            sum(cost[t] for t in rearranged[r * shard : (r + 1) * shard])
+            for r in range(world_size)
+        ]
+
+    def test_mixed_length_documents_are_balanced(self) -> None:
+        # Regression test: with mixed-length documents the document-major layout
+        # let the contiguous shard cut fall mid-document, giving loads 26 vs 62
+        # (2.38x imbalance). A rank-major layout balances them exactly.
+        loads = self._per_rank_causal_load([4, 12], world_size=2)
+        self.assertEqual(loads, [44, 44])
+
+    def test_random_documents_are_balanced_across_world_sizes(self) -> None:
+        # The rank-major layout makes every rank's causal load identical for any
+        # set of document lengths (each a multiple of 2 * world_size) and any
+        # world size, since pairing head chunk r with tail chunk (2P-1-r) gives
+        # each rank the same per-document load. Exercise this with randomized,
+        # mixed-length documents across several world sizes > 2.
+        rng = random.Random(2024)
+        for world_size in (2, 3, 4, 8):
+            for _ in range(20):
+                num_docs = rng.randint(1, 6)
+                doc_lengths = [
+                    2 * world_size * rng.randint(1, 5) for _ in range(num_docs)
+                ]
+                loads = self._per_rank_causal_load(doc_lengths, world_size)
+                self.assertEqual(
+                    loads,
+                    [loads[0]] * world_size,
+                    msg=f"world_size={world_size}, doc_lengths={doc_lengths}",
+                )
+
+    def test_restore_indices_invert_rearrange(self) -> None:
+        lb = _PerDocumentHeadTailLoadBalancer([[4, 12]], 2, "cpu")
+        rearranged = lb._generate_indices()[0]
+        restore = lb._generate_indices(restore=True)[0]
+        self.assertEqual(rearranged[restore].tolist(), list(range(16)))
 
 
 if __name__ == "__main__":

--- a/torch/distributed/tensor/experimental/_context_parallel/_load_balancer.py
+++ b/torch/distributed/tensor/experimental/_context_parallel/_load_balancer.py
@@ -72,6 +72,15 @@ class _LoadBalancer(ABC):
             - when `restore == True`, this method returns an indices tensor `restore_idx`
             such that Q[rearrange_idx][restore_idx] == Q, i.e. restoring the rearranged tensor
             back to the original status before rearranging.
+
+        Sharding contract:
+            After rearranging, Context Parallel shards `Q[rearrange_idx]` with
+            `Shard(seq_dim)`, which follows `torch.chunk` semantics: the sequence is
+            split into `world_size` contiguous, equal-sized chunks and chunk `r` is
+            assigned to rank `r`. Implementations must therefore lay out
+            `rearrange_idx` so that each such contiguous chunk is well-balanced --
+            i.e. group each rank's positions together (rank-major), not interleaved
+            by any other axis such as document.
         """
 
 
@@ -255,37 +264,33 @@ class _PerDocumentHeadTailLoadBalancer(_LoadBalancer):
             seq_length % (2 * world_size) == 0 for seq_length in seq_length_per_doc
         ):
             raise AssertionError
-        chunk_length_per_doc = [
-            seq_length // (2 * world_size) for seq_length in seq_length_per_doc
-        ]
 
-        indices = []
+        # For each document, split it into 2 * world_size equal chunks and pair
+        # chunk r with chunk (2 * world_size - 1 - r), so row r holds rank r's
+        # head+tail chunks (the same strategy as _HeadTailLoadBalancer). Stacking
+        # the per-document rows rank-wise (dim=1) and flattening lays the indices
+        # out rank-major, so a contiguous per-rank shard gives each rank a
+        # head+tail slice of every document. A document-major layout would instead
+        # let the cut fall mid-document, imbalancing work for mixed-length docs.
+        head_idx = torch.arange(world_size, device=device)
+        tail_idx = 2 * world_size - 1 - head_idx
+        per_doc_rank_chunks = []
         document_start_idx = 0
-        for seq_length, chunk_length in zip(seq_length_per_doc, chunk_length_per_doc):
-            # Generate the indices for the current document
-            for rank in range(world_size):
-                head_chunk_start_idx = document_start_idx + chunk_length * rank
-                tail_chunk_end_idx = document_start_idx + chunk_length * (
-                    2 * world_size - rank
-                )
-                indices.append(
-                    torch.arange(
-                        head_chunk_start_idx,
-                        head_chunk_start_idx + chunk_length,
-                        device=device,
-                    )
-                )
-                indices.append(
-                    torch.arange(
-                        tail_chunk_end_idx - chunk_length,
-                        tail_chunk_end_idx,
-                        device=device,
-                    )
-                )
-
+        for seq_length in seq_length_per_doc:
+            chunk_length = seq_length // (2 * world_size)
+            chunks = torch.arange(
+                document_start_idx,
+                document_start_idx + seq_length,
+                device=device,
+            ).view(2 * world_size, chunk_length)
+            # (world_size, 2, chunk_length) -> (world_size, 2 * chunk_length):
+            # row r is rank r's head chunk followed by its tail chunk.
+            paired = torch.stack([chunks[head_idx], chunks[tail_idx]], dim=1)
+            per_doc_rank_chunks.append(paired.reshape(world_size, -1))
             document_start_idx += seq_length
 
-        indices_tensor = torch.cat(indices)
+        # (world_size, seq_len / world_size) flattened rank-major.
+        indices_tensor = torch.cat(per_doc_rank_chunks, dim=1).reshape(-1)
         if restore:
             indices_tensor = torch.argsort(indices_tensor)
 


### PR DESCRIPTION
## Summary

`_PerDocumentHeadTailLoadBalancer` (used for Context Parallel with packed,
variable-length documents) produced **imbalanced** attention work across ranks on
mixed-length documents.

CP shards the rearranged sequence by handing each rank a **contiguous** chunk
(`_context_parallel_shard` -> `distribute_tensor(..., [Shard(seq_dim)])`, i.e.
`torch.chunk` semantics). The balancer, however, laid out its rearrange indices
**document-major** (all of doc0's per-rank head/tail chunks, then all of doc1's,
...). With mixed lengths, the contiguous cut then falls in the *middle* of a
document's block, so some ranks inherit a document's entire expensive causal tail.

Outputs stay numerically correct (it is still a valid permutation), which is why
the existing correctness tests never caught it — the bug is purely a load
imbalance.

### Concrete example (`q_len == kv_len == 16`, `cp_world_size == 2`)

Packed documents of length **4** and **12** (doc0 = KV 0-3, doc1 = KV 4-15). Each
row is a query's document-causal mask; `-> N` is that query's workload (number of
attended keys); the per-rank `sum` is the work landing on that rank after the
contiguous Q-shard.

**Before (document-major): the cut splits doc1, rank1 gets its whole tail**

```
[1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]  ->  1   (q0)
[1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]  ->  4   (q3)
[1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]  ->  2   (q1)
[1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]  ->  3   (q2)
[0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]  ->  1   (q4)
[0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]  ->  2   (q5)
[0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0]  ->  3   (q6)
[0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0]  -> 10   (q13)  rank0 sum=26
------------------------------------------------------------
[0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0]  -> 11   (q14)
[0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]  -> 12   (q15)
[0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0]  ->  4   (q7)
[0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0]  ->  5   (q8)
[0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0]  ->  6   (q9)
[0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0]  ->  7   (q10)
[0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0]  ->  8   (q11)
[0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0]  ->  9   (q12)  rank1 sum=62
                                                              (imbalance 2.38x)
```

**After (rank-major): each rank gets head+tail of every document**

```
[1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]  ->  1   (q0)
[1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]  ->  4   (q3)
[0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]  ->  1   (q4)
[0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]  ->  2   (q5)
[0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0]  ->  3   (q6)
[0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0]  -> 10   (q13)
[0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0]  -> 11   (q14)
[0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]  -> 12   (q15)  rank0 sum=44
------------------------------------------------------------
[1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]  ->  2   (q1)
[1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]  ->  3   (q2)
[0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0]  ->  4   (q7)
[0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0]  ->  5   (q8)
[0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0]  ->  6   (q9)
[0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0]  ->  7   (q10)
[0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0]  ->  8   (q11)
[0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0]  ->  9   (q12)  rank1 sum=44
                                                              (imbalance 1.00x)
```

The only change is the loop nesting: document-major (document outer, rank inner)
vs **rank-major** (rank outer, document inner). Both feed the identical CP shard
(permute + contiguous halve); only the rank-major layout makes the halves equal.

### The code did not match its own docstring (`[4, 8, 4]`)

`_PerDocumentHeadTailLoadBalancer._generate_indices`'s docstring illustrates the
"after load-balancing on 2 devices" result for documents `[4, 8, 4]` (doc0 =
KV 0-3, doc1 = KV 4-11, doc2 = KV 12-15). That documented diagram is actually the
**rank-major** layout — rank0 owns `{0, 3, 4, 5, 10, 11, 12, 15}`:

```
[1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]  ->  1   (q0)
[1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]  ->  4   (q3)
[0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]  ->  1   (q4)
[0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]  ->  2   (q5)
[0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0]  ->  7   (q10)
[0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0]  ->  8   (q11)
[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0]  ->  1   (q12)
[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1]  ->  4   (q15)  rank0 sum=28
------------------------------------------------------------
... rank1 = {1, 2, 6, 7, 8, 9, 13, 14}                          rank1 sum=28
```

But the actual (pre-fix) **document-major** code produced a *different*
assignment — rank0 owns `{0, 1, 2, 3, 4, 5, 10, 11}`:

```
[1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]  ->  1   (q0)
[1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]  ->  2   (q1)
[1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]  ->  3   (q2)
[1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]  ->  4   (q3)
[0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]  ->  1   (q4)
[0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]  ->  2   (q5)
[0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0]  ->  7   (q10)
[0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0]  ->  8   (q11)  rank0 sum=28
------------------------------------------------------------
... rank1 = {6, 7, 8, 9, 12, 13, 14, 15}                        rank1 sum=28
```

Because the lengths are symmetric (doc0 + doc2 = doc1), the contiguous cut still
happens to land on a rank boundary, so **both layouts sum to 28/28**. The totals
matched even though the actual per-rank assignment did not match the documented
diagram — so the symmetric example "looked fine" and hid the mixed-length bug
shown above. After this fix, the code produces exactly the assignment its
docstring already illustrates.

## The fix

Lay out the rearrange indices **rank-major** so a contiguous per-rank shard gives
each rank a head+tail slice of every document. Because head chunk `r` is paired
with tail chunk `2W-1-r`, each rank's per-document load is
`c*(2W-1) + c*(c+1)` — **independent of the rank** — so the split is *exactly*
balanced for any document lengths and world size. The single-sequence
`_HeadTailLoadBalancer` already used this rank-major layout; this makes the
per-document variant consistent with it (and with its own docstring diagram).

The implementation is also vectorized to mirror `_HeadTailLoadBalancer`. The
contiguous-shard requirement the layout must satisfy is now documented on the
base `_LoadBalancer._generate_indices` interface.

## Test plan

New tests in `test/distributed/tensor/test_attention.py`:

- `PerDocumentHeadTailLoadBalancerTest` (CPU, non-distributed): exact per-rank
  balance on the `[4, 12]` regression and on randomized mixed-length documents
  across world sizes 2/3/4/8, plus a restore-inverts-rearrange check.
- `TestSharding.test_context_parallel_shard_per_document_balance` (2-GPU):
  verifies balance end-to-end through the real `_context_parallel_shard` path.

```
python -m pytest test/distributed/tensor/test_attention.py \
  -k "PerDocumentHeadTailLoadBalancerTest or test_context_parallel_shard_per_document_balance"
# => 4 passed, 1 skipped

python -m pytest test/distributed/tensor/test_attention.py \
  -k test_cp_flex_attention_document_mask   # existing correctness test, no regression
# => 1 passed, 1 skipped
```

The before/after numbers above were reproduced through the real
`_context_parallel_shard` path on a gloo CPU mesh (26/62 -> 44/44 for `[4, 12]`).
`lintrunner` on both changed files reports no issues.
