### PR TITLE
[CD] Repackage manywheels with auditwheel to fix invalid ZIP64 on >4GB ROCm wheels

### DIFF
--- a/.ci/manywheel/build_install_deps.py
+++ b/.ci/manywheel/build_install_deps.py
@@ -80,6 +80,11 @@ def main() -> None:
         subprocess.run([sys.executable, "setup.py", "clean"], check=True)
     pip_install("-q", "-r", "requirements.txt")
     pip_install("-q", "--pre", f"numpy=={numpy_pin()}")
+    # auditwheel repacks the manywheel with a valid ZIP64 record for >4GB ROCm
+    # wheels (pypa/wheel#692); imported by repair_wheel.py. CD-only, so it is
+    # installed here rather than in requirements.txt, and pinned for
+    # reproducible binary builds.
+    pip_install("-q", "auditwheel==6.4.2")
 
     if "rocm" in os.environ.get("DESIRED_CUDA", ""):
         print(f"Running build_amd.py at {time.strftime('%Y-%m-%d %H:%M:%S')}")

--- a/.ci/manywheel/repair_wheel.py
+++ b/.ci/manywheel/repair_wheel.py
@@ -27,10 +27,21 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-from auditwheel.wheeltools import add_platforms, get_wheel_platforms, InWheelCtx
+from auditwheel.wheeltools import add_platforms, InWheelCtx
 
 
 PATCHELF = "/usr/local/bin/patchelf"
+
+
+def wheel_platform_tags(wheel_name: str) -> list[str]:
+    """Platform tags encoded in a wheel filename.
+
+    The filename is ``{name}-{version}-{python}-{abi}-{platform}.whl``; the
+    platform field is the last ``-``-delimited component and may itself be a
+    ``.``-joined set of tags (e.g. ``linux_x86_64`` or
+    ``manylinux1_x86_64.manylinux_2_17_x86_64``).
+    """
+    return wheel_name.removesuffix(".whl").rsplit("-", 1)[-1].split(".")
 
 
 @dataclass
@@ -361,7 +372,7 @@ def repair_wheel(
         # metadata. add_platforms updates ctx.out_wheel to the new name; RECORD
         # regeneration and repacking happen when the context exits.
         add_platforms(
-            ctx, [platform_tag], remove_platforms=get_wheel_platforms(wheel.name)
+            ctx, [platform_tag], remove_platforms=wheel_platform_tags(wheel.name)
         )
 
 

--- a/.ci/manywheel/repair_wheel.py
+++ b/.ci/manywheel/repair_wheel.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python3
 """Repair a PyTorch wheel: bundle libgomp + GPU libs, set RPATHs, retag platform.
 
-Uses the `wheel` Python package for unpack/pack/tags (not zip).
+Uses auditwheel for unpack/repack (not the `wheel` CLI). `wheel pack`/`wheel tags`
+emit an invalid ZIP64 header for archives over 4GB (pypa/wheel#692), which makes
+large ROCm wheels fail to install under strict zip parsers such as uv
+(pytorch#189748). auditwheel repacks via the stdlib `zipfile`, which writes a
+correct ZIP64 record.
 
 Usage: repair_wheel.py <input_dir> <output_dir>
 
@@ -20,9 +24,10 @@ import platform
 import shutil
 import subprocess
 import sys
-import tempfile
 from dataclasses import dataclass
 from pathlib import Path
+
+from auditwheel.wheeltools import add_platforms, get_wheel_platforms, InWheelCtx
 
 
 PATCHELF = "/usr/local/bin/patchelf"
@@ -263,18 +268,6 @@ def set_rpath(sofile: Path, rpath: str, force_rpath: bool) -> None:
     patchelf(*cmd)
 
 
-def unpack_wheel(wheel: Path, work: Path) -> Path:
-    subprocess.run(["wheel", "unpack", str(wheel), "-d", str(work)], check=True)
-    unpacked = next(work.glob("torch-*"), None)
-    if unpacked is None:
-        raise RuntimeError(f"wheel unpack produced no torch-* dir in {work}")
-    return unpacked
-
-
-def pack_wheel(unpacked: Path, output_dir: Path) -> None:
-    subprocess.run(["wheel", "pack", str(unpacked), "-d", str(output_dir)], check=True)
-
-
 def replace_needed(unpacked_torch: Path, original: str, replacement: str) -> None:
     """Rewrite NEEDED entries that match `original*` to `replacement` across the wheel."""
     for sofile in unpacked_torch.rglob("*.so*"):
@@ -294,6 +287,7 @@ def replace_needed(unpacked_torch: Path, original: str, replacement: str) -> Non
 def repair_wheel(
     wheel: Path,
     output_dir: Path,
+    platform_tag: str,
     libgomp_path: Path,
     aarch64_deps: list[Path],
     bundled_libs: list[BundledLib],
@@ -302,10 +296,12 @@ def repair_wheel(
     lib_so_rpath: str,
     force_rpath: bool,
 ) -> None:
-    with tempfile.TemporaryDirectory() as tmp:
-        work = Path(tmp)
-        unpacked = unpack_wheel(wheel, work)
-        torch_dir = unpacked / "torch"
+    # InWheelCtx unpacks via auditwheel's zip2dir on enter and, once out_wheel is
+    # set, regenerates RECORD and repacks via dir2zip on exit. dir2zip uses the
+    # stdlib zipfile (correct ZIP64), unlike `wheel pack`/`wheel tags` which
+    # corrupt >4GB ROCm wheels (pypa/wheel#692, pytorch#189748).
+    with InWheelCtx(wheel, output_dir / wheel.name) as ctx:
+        torch_dir = ctx.path / "torch"
         torch_lib = torch_dir / "lib"
 
         # Bundle libgomp and rewrite NEEDED entries to point at our copy
@@ -361,14 +357,11 @@ def repair_wheel(
             if sofile.is_file():
                 set_rpath(sofile, lib_so_rpath, force_rpath)
 
-        pack_wheel(unpacked, output_dir)
-
-
-def retag_wheels(output_dir: Path, platform_tag: str) -> None:
-    for whl in output_dir.glob("*.whl"):
-        subprocess.run(
-            ["wheel", "tags", "--platform-tag", platform_tag, "--remove", str(whl)],
-            check=True,
+        # Retag linux_* -> manylinux_2_28_* in both the filename and the WHEEL
+        # metadata. add_platforms updates ctx.out_wheel to the new name; RECORD
+        # regeneration and repacking happen when the context exits.
+        add_platforms(
+            ctx, [platform_tag], remove_platforms=get_wheel_platforms(wheel.name)
         )
 
 
@@ -420,10 +413,12 @@ def main() -> None:
     if not wheels:
         sys.exit(f"No wheels found in {args.input_dir}")
 
+    platform_tag = f"manylinux_2_28_{arch}"
     for whl in wheels:
         repair_wheel(
             whl,
             args.output_dir,
+            platform_tag,
             libgomp_path,
             aarch64_deps,
             bundled_libs,
@@ -433,7 +428,6 @@ def main() -> None:
             force_rpath,
         )
 
-    retag_wheels(args.output_dir, f"manylinux_2_28_{arch}")
     repaired = list(args.output_dir.glob("*.whl"))
     print(f"Repaired {len(repaired)} wheel(s) in {args.output_dir}")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@
 --requirement requirements-build.txt
 
 # Install / Development extra requirements
-auditwheel ; sys_platform == "linux"  # repackages manywheels with valid ZIP64 (>4GB); see .ci/manywheel/repair_wheel.py
 build[uv]  # for building sdist and wheel
 expecttest>=0.3.0
 filelock

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@
 --requirement requirements-build.txt
 
 # Install / Development extra requirements
+auditwheel ; sys_platform == "linux"  # repackages manywheels with valid ZIP64 (>4GB); see .ci/manywheel/repair_wheel.py
 build[uv]  # for building sdist and wheel
 expecttest>=0.3.0
 filelock


### PR DESCRIPTION
## Summary

`.ci/manywheel/repair_wheel.py` repackaged manywheels through the `wheel` CLI (`wheel unpack`/`pack`/`tags`). `wheel pack` and `wheel tags` emit an **invalid ZIP64 extended-information field for archives larger than 4GB** ([pypa/wheel#692](https://github.com/pypa/wheel/issues/692)). ROCm wheels bundle the full ROCm runtime and exceed 4GB, so the produced nightlies carry a malformed ZIP64 record. Lenient unzippers tolerate it, but uv's stricter zip validation rejects it, so `uv pip install` of recent ROCm 7.2 nightlies fails to unzip and silently falls back to the last good build (#189748).

## Fix

Repackage with **auditwheel** instead of the `wheel` CLI:

- `repair_wheel()` now uses `auditwheel.wheeltools.InWheelCtx`, which unpacks via `zip2dir` on enter and, once `out_wheel` is set, regenerates `RECORD` and repacks via `dir2zip` on exit. `dir2zip` writes with the stdlib `zipfile`, which produces a correct ZIP64 record. 
- The `linux_* -> manylinux_2_28_*` retag (filename **and** `WHEEL` metadata) now goes through `auditwheel.wheeltools.add_platforms`, folded into the single unpack/repack cycle instead of a separate post-pass.
- All patchelf / lib-bundling logic is unchanged (including the rocSHMEM bare-soname symlink from #189110).
- `auditwheel` added to `requirements.txt` (Linux only); installed into the build interpreter by `build_install_deps.py`.

This switches the whole manywheel repack (cpu/cuda/xpu/rocm, x86_64 and aarch64) to one correct path; ROCm is the variant that was actually breaking.

Fixes #189748. Works around pypa/wheel#692.

## Test Plan

- `python -m py_compile .ci/manywheel/repair_wheel.py`
- Verified `packaging.parse_wheel_filename` accepts PyTorch local-version wheel names (e.g. `torch-...+rocm7.2-...-linux_x86_64.whl`), which auditwheel's `add_platforms` relies on.
- CI: manywheel ROCm build; confirm the produced wheel installs via `uv pip install` (unzips under uv's strict validation).
- Test was done on repackaging wheels for release 2.13 using:  https://github.com/pytorch/test-infra/pull/8256/changes 

*This PR was authored with the assistance of an AI coding agent.*


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang