### PR TITLE
Realign remaining rocm dynamo-benchmark baselines to current status

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamic_inductor_huggingface_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamic_inductor_huggingface_inference.csv
@@ -22,7 +22,7 @@ BlenderbotForCausalLM,pass_due_to_skip,0
 
 
 
-DebertaV2ForMaskedLM,eager_fail_to_run,0
+DebertaV2ForMaskedLM,pass_due_to_skip,0
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamic_inductor_timm_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamic_inductor_timm_training.csv
@@ -10,7 +10,7 @@ beit_base_patch16_224,pass,7
 
 
 
-convnextv2_nano.fcmae_ft_in22k_in1k,pass,7
+convnextv2_nano.fcmae_ft_in22k_in1k,fail_accuracy,7
 
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189904

Two rocm periodic dynamo-benchmark shards are red on trunk because their
expected-accuracy baselines no longer match observed behavior:

- dynamic_inductor_timm: convnextv2_nano.fcmae_ft_in22k_in1k now reports
  fail_accuracy (was pass). This is a genuine rocm numerical regression;
  baselining it to fail_accuracy quarantines the known failure so the rest
  of the timm shard regains signal. It should have a tracking issue for the
  underlying accuracy drift rather than staying silently masked.
- dynamic_inductor_huggingface: DebertaV2ForMaskedLM is now skipped
  (pass_due_to_skip) rather than eager_fail_to_run. This is the skip churn
  tracked in #188851.

Note mobilenetv2_100 on the rocm dynamic_inductor_timm shard is handled
separately by #189766.

Test Plan: Baseline-only change. The rocm-periodic dynamic_inductor_timm
and dynamic_inductor_huggingface shards should stop reporting these two
models as regressed once the expected status matches.

Authored with Claude.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @azahed98