### PR TITLE
Update rocm aot_inductor_torchbench baseline: microbench_unbacked_tolist_sum now passes

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/rocm/aot_inductor_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/rocm/aot_inductor_torchbench_inference.csv
@@ -122,7 +122,7 @@ maml_omniglot,pass,0
 
 
 
-microbench_unbacked_tolist_sum,fail_to_run,0
+microbench_unbacked_tolist_sum,pass,0
 
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189905

microbench_unbacked_tolist_sum now runs and passes on the rocm
aot_inductor_torchbench inference job, but the expected-accuracy baseline
still lists it as fail_to_run, so check_accuracy.py flags it as an
improvement and the periodic rocm shard stays red.

This is the rocm counterpart to #189764, which updates the same model in
the non-rocm aot_inductor_torchbench_inference.csv.

Test Plan: Baseline-only change; the rocm-periodic-dynamo-benchmarks
aot_inductor_torchbench shard should stop reporting the microbench
improvement once the expected status matches.

Authored with Claude.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @azahed98