### PR TITLE
[ROCm] Rewrite bundled-lib NEEDED entries after all libs are copied in

### DIFF
--- a/.ci/manywheel/repair_wheel.py
+++ b/.ci/manywheel/repair_wheel.py
@@ -326,6 +326,31 @@ def replace_needed(unpacked_torch: Path, original: str, replacement: str) -> Non
                 patchelf("--replace-needed", entry, replacement, str(sofile))
 
 
+def check_no_dangling_bundled_needed(torch_lib: Path) -> None:
+    """Fail the build if a lib in torch/lib NEEDs a versioned soname of a
+    bundled lib without a file of that name in the wheel (a missed
+    replace_needed rewrite). Such a reference only resolves against a system
+    ROCm install, so the wheel silently stops being self-contained."""
+    names = {f.name for f in torch_lib.iterdir()}
+    dangling = []
+    for sofile in sorted(torch_lib.glob("*.so*")):
+        if not sofile.is_file():
+            continue
+        try:
+            needed = subprocess.check_output(
+                [PATCHELF, "--print-needed", str(sofile)], text=True
+            ).splitlines()
+        except subprocess.CalledProcessError:
+            continue
+        for entry in needed:
+            stem = entry.split(".so", 1)[0] + ".so"
+            if stem in names and entry not in names:
+                dangling.append(f"{sofile.name} -> {entry}")
+    if dangling:
+        joined = "\n".join(sorted(set(dangling)))
+        sys.exit(f"Dangling NEEDED entries after bundling (missed rewrite?):\n{joined}")
+
+
 def repair_wheel(
     wheel: Path,
     output_dir: Path,
@@ -366,10 +391,7 @@ def repair_wheel(
         # Copy follows symlinks so versioned sonames become real files we can
         # rename to their bare .so form to match what the wheel links against.
         for lib in bundled_libs:
-            dest = torch_lib / lib.dest_name
-            shutil.copy(lib.src, dest)
-            if lib.needed_alias:
-                replace_needed(torch_dir, lib.needed_alias, lib.dest_name)
+            shutil.copy(lib.src, torch_lib / lib.dest_name)
             # Some bundled deps are dlopen'd by their *bare* soname at runtime,
             # not just via NEEDED. In particular rocSHMEM's NUMAWrapper global
             # ctor does dlopen("libnuma.so"). The original build_rocm.sh shipped
@@ -384,6 +406,16 @@ def repair_wheel(
                 bare_path = torch_lib / bare
                 if not bare_path.exists():
                     bare_path.symlink_to(lib.dest_name)
+        # Rewrite NEEDED entries only after every bundled lib has been copied
+        # in: bundled libs reference each other (e.g. libhiprtc.so needs
+        # libamd_comgr.so.3), and replace_needed only visits files present in
+        # the wheel at call time, so rewriting inside the copy loop misses
+        # references from libs bundled after their dependency (#189194).
+        for lib in bundled_libs:
+            if lib.needed_alias:
+                replace_needed(torch_dir, lib.needed_alias, lib.dest_name)
+        if bundled_libs:
+            check_no_dangling_bundled_needed(torch_lib)
 
         # Copy auxiliary content (gfx kernel files, MIOpen db, RCCL algos, ...)
         for aux in aux_files:

--- a/.ci/manywheel/repair_wheel.py
+++ b/.ci/manywheel/repair_wheel.py
@@ -291,6 +291,31 @@ def replace_needed(unpacked_torch: Path, original: str, replacement: str) -> Non
                 patchelf("--replace-needed", entry, replacement, str(sofile))
 
 
+def check_no_dangling_bundled_needed(torch_lib: Path) -> None:
+    """Fail the build if a lib in torch/lib NEEDs a versioned soname of a
+    bundled lib without a file of that name in the wheel (a missed
+    replace_needed rewrite). Such a reference only resolves against a system
+    ROCm install, so the wheel silently stops being self-contained."""
+    names = {f.name for f in torch_lib.iterdir()}
+    dangling = []
+    for sofile in sorted(torch_lib.glob("*.so*")):
+        if not sofile.is_file():
+            continue
+        try:
+            needed = subprocess.check_output(
+                [PATCHELF, "--print-needed", str(sofile)], text=True
+            ).splitlines()
+        except subprocess.CalledProcessError:
+            continue
+        for entry in needed:
+            stem = entry.split(".so", 1)[0] + ".so"
+            if stem in names and entry not in names:
+                dangling.append(f"{sofile.name} -> {entry}")
+    if dangling:
+        joined = "\n".join(sorted(set(dangling)))
+        sys.exit(f"Dangling NEEDED entries after bundling (missed rewrite?):\n{joined}")
+
+
 def repair_wheel(
     wheel: Path,
     output_dir: Path,
@@ -328,10 +353,7 @@ def repair_wheel(
         # Copy follows symlinks so versioned sonames become real files we can
         # rename to their bare .so form to match what the wheel links against.
         for lib in bundled_libs:
-            dest = torch_lib / lib.dest_name
-            shutil.copy(lib.src, dest)
-            if lib.needed_alias:
-                replace_needed(torch_dir, lib.needed_alias, lib.dest_name)
+            shutil.copy(lib.src, torch_lib / lib.dest_name)
             # Some bundled deps are dlopen'd by their *bare* soname at runtime,
             # not just via NEEDED. In particular rocSHMEM's NUMAWrapper global
             # ctor does dlopen("libnuma.so"). The original build_rocm.sh shipped
@@ -346,6 +368,16 @@ def repair_wheel(
                 bare_path = torch_lib / bare
                 if not bare_path.exists():
                     bare_path.symlink_to(lib.dest_name)
+        # Rewrite NEEDED entries only after every bundled lib has been copied
+        # in: bundled libs reference each other (e.g. libhiprtc.so needs
+        # libamd_comgr.so.3), and replace_needed only visits files present in
+        # the wheel at call time, so rewriting inside the copy loop misses
+        # references from libs bundled after their dependency (#189194).
+        for lib in bundled_libs:
+            if lib.needed_alias:
+                replace_needed(torch_dir, lib.needed_alias, lib.dest_name)
+        if bundled_libs:
+            check_no_dangling_bundled_needed(torch_lib)
 
         # Copy auxiliary content (gfx kernel files, MIOpen db, RCCL algos, ...)
         for aux in aux_files:


### PR DESCRIPTION
The ROCm manywheel repair step renames bundled ROCm libs to bare `.so` filenames and rewrites NEEDED references to match. #182696 ported this from build_common.sh to repair_wheel.py and collapsed the shell script's two phases (copy every DEPS_LIST lib into torch/lib, then run replace_needed_sofiles for every soname) into a single per-lib loop that copies a lib and immediately rewrites references to it. `replace_needed` only visits files present in the wheel at call time, so references from a bundled lib to any lib listed earlier in ROCM_SO_FILES are never rewritten: the dependent has not been copied in yet when its dependency's rewrite pass runs. The 2.13.0+rocm7.2 wheel ships 27 such dangling NEEDED entries (`libhiprtc.so -> libamd_comgr.so.3`, `librocblas.so -> libamdhip64.so.7`, `libmagma.so -> libhipblas.so.3`, ...). Most resolve at runtime by luck (the bundled file keeps its versioned SONAME, so a copy already loaded under that SONAME satisfies the ref) or from a system ROCm install via ldconfig, which is why this went unnoticed until the cold dlopen introduced by #183515 hit the `libamd_comgr.so.3` ref on a machine with no ROCm (#189194).

The fix restores the two-phase structure: copy all bundled libs (and their bare-name dlopen symlinks from #189110) first, then run the rewrite passes. A new `check_no_dangling_bundled_needed` pass then fails the build if any lib in torch/lib still references a versioned soname whose stem is bundled but whose exact name is not shipped, so a future ordering or list regression breaks the build instead of shipping a wheel that silently depends on a system ROCm install.

This complements #189900, which makes the inductor VecISA probe recover from such wheels at runtime; this change makes newly built wheels self-contained again.

Validated by running the real `repair_wheel()` from before and after the change on a minimal fake torch wheel bundling actual ROCm libs in the regression order (libhsa-runtime64 listed before libroctracer64, which NEEDs libhsa-runtime64.so.1): the old code ships the stale versioned ref with no error, the new code rewrites it to libhsa-runtime64.so and the new check passes. Aiming `check_no_dangling_bundled_needed` at the torch/lib of the actual torch==2.13.0+rocm7.2 wheel fails the build listing all 27 dangling references, including the `libamd_comgr.so.3` ones from #189194.

This PR was authored with Claude (AI assistant).


cc @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang