### PR TITLE
[BE][Ez]: Apply some more missing moves

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
@@ -920,7 +920,7 @@ class QLinearUnpackedDynamicFp16 final {
 
     auto out_channel = weight.sym_sizes().vec()[0];
     auto out_sizes = input.sym_sizes().vec();
-    out_sizes[out_sizes.size() - 1] = out_channel;
+    out_sizes[out_sizes.size() - 1] = std::move(out_channel);
 
     return at::empty_symint(out_sizes, input.options());
   }

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -5884,7 +5884,7 @@ std::tuple<Tensor, Tensor> householder_product_backward(
           at::SymDimVector(input_.sym_sizes().slice(0, input_.dim() - 1));
       zero_grad_shape.push_back(input.sym_size(-1) - k);
       auto zero_grad = at::zeros_symint(zero_grad_shape, input_.options());
-      input_grads[k] = zero_grad;
+      input_grads[k] = std::move(zero_grad);
     }
 
     input_grad = at::cat(input_grads, -1);

--- a/torch/csrc/autograd/cpp_hook.cpp
+++ b/torch/csrc/autograd/cpp_hook.cpp
@@ -43,7 +43,7 @@ variable_list CppFunctionTensorPreHook::operator()(
     value = std::move(res);
   }
   variable_list results(values);
-  results[value_idx_] = value;
+  results[value_idx_] = std::move(value);
   return results;
 }
 


### PR DESCRIPTION
Some more follow up from automated clang-tidy checks. Most of these are about stealing references to avoid atomic refcount updates

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01