### PR TITLE
[rfc] Add RADAR: AI risk-based auto-approval for low-risk maintainer PRs

### DIFF
--- a/.github/scripts/radar.py
+++ b/.github/scripts/radar.py
@@ -1,0 +1,598 @@
+#!/usr/bin/env python3
+
+"""RADAR: AI risk-based auto-approval for low-risk maintainer PRs.
+
+RADAR runs an AI risk assessment on a PR. When the assessed risk is low enough,
+every changed file is inside a conservative allowlist, and the PR author has
+write access, it posts an approval comment carrying a machine-readable marker
+bound to the head commit SHA and signed with an HMAC, and adds the
+``radar-approved`` label. ``trymerge`` treats a valid marker as satisfying the
+human-approval requirement, so a maintainer can land the PR with
+``@pytorchbot merge`` without a separate human review.
+
+The trust anchor is the HMAC signature, not the comment author: the marker is
+signed over ``(repo, pr, sha, score, tier)`` with a secret shared only by the
+RADAR workflow and ``trymerge`` (``RADAR_HMAC_KEY``). A regular user -- even one
+who can induce another workflow to reflect attacker-controlled text into a bot
+comment -- cannot produce a valid signature, so a RADAR approval cannot be
+forged. The marker is bound to the head SHA, so pushing any new commit
+invalidates the approval and re-runs RADAR. When no key is configured, signing
+and verification both fail closed.
+
+This module is imported by ``trymerge`` for the parsing/detection helpers and
+run as a CLI by the RADAR workflow to post approvals.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import hashlib
+import hmac
+import json
+import os
+import re
+from argparse import ArgumentParser
+from typing import NamedTuple
+
+from github_utils import gh_delete_comment, gh_fetch_json_list, gh_post_pr_comment
+from label_utils import gh_add_labels, gh_remove_label
+
+
+RADAR_APPROVED_LABEL = "radar-approved"
+
+# Identity used in the commit-message "Approved by:" trailer whenever a RADAR
+# approval authorized the merge. Deliberately a distinct, greppable pseudo-login
+# (NOT the unrelated real pytorch-bot account) so RADAR landings are auditable via
+# `git log --grep "Approved by:.*pytorch-auto-radar"`. It is attributed whenever a
+# valid RADAR approval was applied at merge time (alongside any human reviewers),
+# which is a conservative superset of RADAR-only landings: it never misses a
+# human-review-bypassing merge, and at worst also tags the rare case where a
+# qualifying human approval was independently present. It is not a metamates
+# member, so update_metamates_rule.py silently drops it and it can never leak into
+# merge_rules.yaml.
+RADAR_APPROVAL_LOGIN = "pytorch-auto-radar"
+
+# Login(s) whose comments RADAR trusts. RADAR posts under the default
+# GITHUB_TOKEN identity (github-actions[bot]), so keep this set as tight as the
+# posting identity. This login check is only a cheap prefilter: the HMAC
+# signature below is the real trust anchor, since another workflow could reflect
+# attacker text into a comment under the same shared login.
+RADAR_BOT_LOGINS = {"github-actions"}
+
+# GitHub repo-permission levels that count as write access for RADAR purposes.
+WRITE_ACCESS_PERMISSIONS = {"write", "admin", "maintain"}
+
+# SIGNER/VERIFIER CONTRACT: the score/tier thresholds and the file allow/deny
+# policy below are re-checked by trymerge, which imports is_low_risk /
+# files_allowlisted from THIS module, so both sides evaluate byte-identical
+# policy. The score ceiling and approved tiers are deliberately NOT
+# env-overridable: a per-workflow override could let RADAR sign an approval that
+# trymerge then rejects (or vice versa). Change policy only by editing these
+# constants; both sides pick it up on next import. The only env-configured values
+# RADAR shares with trymerge are the secret RADAR_HMAC_KEY and the tighten-only
+# RADAR_DENYLIST_GLOBS (see below), both of which fail closed under divergence.
+RADAR_APPROVED_TIERS = {"trivial"}
+RADAR_MAX_SCORE = 10
+
+# Signer-side only: additions+deletions ceiling. A change this large cannot be
+# "trivial", and the count comes from `gh pr view --json additions,deletions`,
+# which is never truncated (unlike the byte-capped diff shown to the AI). This is
+# deliberately NOT re-checked in trymerge: adding fields to GH_GET_PR_INFO_QUERY
+# would rekey every recorded gql_mocks fixture. It needs no verifier mirror
+# because an oversized diff never gets a signed marker in the first place, and the
+# marker is SHA-bound so any later change to the PR invalidates it.
+RADAR_MAX_DIFF_LINES = 2000
+
+# The same secret must be available to the RADAR workflow (to sign) and to
+# trymerge (to verify). Absent key => fail closed on both sides.
+RADAR_HMAC_KEY_ENV = "RADAR_HMAC_KEY"
+
+# RADAR only auto-approves when *every* changed file matches one of these globs.
+# This is a deterministic guardrail on top of the AI score that cannot be
+# steered by prompt injection in the diff, and it keeps domain-specific reviewer
+# requirements (FFT, Sparse, MPS, dispatch, ...) in force for any real source
+# change. Keep this to genuinely low-blast-radius paths only: e.g. "*.pyi.in" is
+# intentionally excluded because it would admit torch/_C/__init__.pyi.in, the
+# core C-extension type surface gated by domain reviewers. fnmatch '*' spans '/',
+# so "test/*" matches at any depth under test/. This list is a hardcoded constant
+# (not env-overridable) so the RADAR signer and the trymerge verifier evaluate the
+# same allowlist.
+DEFAULT_ALLOWLIST_GLOBS = (
+    "test/*",
+    "docs/*",
+    "benchmarks/*",
+    "*.md",
+)
+
+# Files that sit under an allowlisted prefix but EXECUTE in CI, so their blast
+# radius is far larger than a single test or doc page: pytest collection hooks,
+# the test runner, global pytest config, the Sphinx docs-build config (conf.py
+# is imported and run on every docs build), and Makefiles (they drive the build).
+# RADAR must never auto-approve these even under test/ or docs/. Patterns are
+# basename-anchored (e.g. conftest.py + */conftest.py) so nested files at any
+# depth are caught without over-matching legitimate files like test/my_conftest.py.
+DEFAULT_DENYLIST_GLOBS = (
+    "conftest.py",
+    "*/conftest.py",
+    "run_test.py",
+    "*/run_test.py",
+    "pytest.ini",
+    "*/pytest.ini",
+    "conf.py",
+    "*/conf.py",
+    "Makefile",
+    "*/Makefile",
+)
+
+# The marker is VISIBLE text, not an HTML comment: trymerge detects it from the
+# GitHub GraphQL bodyText, which is rendered to plain text and strips HTML
+# comments -- an invisible marker would never be seen. It carries the approved
+# head SHA, the score/tier, and an HMAC over all of them so none can be tampered
+# with after signing. Revealing the marker is safe: without RADAR_HMAC_KEY the
+# signature cannot be forged for any other PR/SHA.
+RADAR_MARKER_RE = re.compile(
+    r"RADAR-APPROVED\s+sha=(?P<sha>[0-9a-f]{40})\s+"
+    r"score=(?P<score>\d+)\s+tier=(?P<tier>[a-z]+)\s+"
+    r"sig=(?P<sig>[0-9a-f]{64})"
+)
+
+# Signed revocation of a prior approval, bound to a head SHA. When RADAR re-runs
+# on an UNCHANGED SHA and the new verdict no longer qualifies, deleting the old
+# approval comment is best-effort and can fail. Posting a signed revocation makes
+# withdrawal a POSITIVE, fail-closed signal instead: trymerge honors the newest
+# RADAR decision for the current head, so a revocation invalidates an approval it
+# could not delete. Like the approval marker, the HMAC (not the text) is the trust
+# anchor, so reflected/forged revocation text cannot deny or grant anything.
+RADAR_REVOKED_MARKER_RE = re.compile(
+    r"RADAR-REVOKED\s+sha=(?P<sha>[0-9a-f]{40})\s+sig=(?P<sig>[0-9a-f]{64})"
+)
+
+
+class RadarMarker(NamedTuple):
+    sha: str
+    score: int
+    tier: str
+    sig: str
+
+
+class RadarRevocation(NamedTuple):
+    sha: str
+    sig: str
+
+
+def get_hmac_key() -> bytes | None:
+    key = os.environ.get(RADAR_HMAC_KEY_ENV, "")
+    return key.encode() if key else None
+
+
+def compute_marker_sig(
+    key: bytes,
+    org: str,
+    project: str,
+    pr_num: int,
+    sha: str,
+    score: int,
+    tier: str,
+) -> str:
+    # Canonical payload. Every field trymerge trusts must be covered here so it
+    # cannot be altered after signing.
+    payload = f"{org}/{project}#{pr_num}@{sha}:score={score}:tier={tier}".encode()
+    return hmac.new(key, payload, hashlib.sha256).hexdigest()
+
+
+def compute_revoked_sig(
+    key: bytes, org: str, project: str, pr_num: int, sha: str
+) -> str:
+    # Distinct payload namespace (":REVOKED") so an approval signature can never
+    # be replayed as a revocation or vice versa.
+    payload = f"{org}/{project}#{pr_num}@{sha}:REVOKED".encode()
+    return hmac.new(key, payload, hashlib.sha256).hexdigest()
+
+
+def render_marker(marker: RadarMarker) -> str:
+    # Plain visible text (no HTML comment) so it survives GitHub's bodyText
+    # rendering; see RADAR_MARKER_RE.
+    return (
+        f"RADAR-APPROVED sha={marker.sha} score={marker.score} "
+        f"tier={marker.tier} sig={marker.sig}"
+    )
+
+
+def render_revoked_marker(rev: RadarRevocation) -> str:
+    return f"RADAR-REVOKED sha={rev.sha} sig={rev.sig}"
+
+
+def _marker_from_match(m: re.Match[str]) -> RadarMarker:
+    return RadarMarker(
+        sha=m.group("sha"),
+        score=int(m.group("score")),
+        tier=m.group("tier"),
+        sig=m.group("sig"),
+    )
+
+
+def parse_radar_marker(body: str) -> RadarMarker | None:
+    m = RADAR_MARKER_RE.search(body)
+    return _marker_from_match(m) if m is not None else None
+
+
+def iter_radar_markers(body: str) -> list[RadarMarker]:
+    # Return every marker in the body, not just the first: an approval comment
+    # also contains AI-authored summary/reasoning text, and a marker-shaped
+    # string there must not shadow the genuine (signed) marker at merge time.
+    return [_marker_from_match(m) for m in RADAR_MARKER_RE.finditer(body)]
+
+
+def iter_revoked_markers(body: str) -> list[RadarRevocation]:
+    return [
+        RadarRevocation(sha=m.group("sha"), sig=m.group("sig"))
+        for m in RADAR_REVOKED_MARKER_RE.finditer(body)
+    ]
+
+
+def verify_marker_sig(marker: RadarMarker, org: str, project: str, pr_num: int) -> bool:
+    key = get_hmac_key()
+    if key is None:
+        # No configured secret: an unsigned deployment must never honor a marker.
+        return False
+    expected = compute_marker_sig(
+        key, org, project, pr_num, marker.sha, marker.score, marker.tier
+    )
+    return hmac.compare_digest(expected, marker.sig)
+
+
+def verify_revoked_sig(
+    rev: RadarRevocation, org: str, project: str, pr_num: int
+) -> bool:
+    key = get_hmac_key()
+    if key is None:
+        return False
+    expected = compute_revoked_sig(key, org, project, pr_num, rev.sha)
+    return hmac.compare_digest(expected, rev.sig)
+
+
+def is_trusted_radar_login(login: str) -> bool:
+    # GraphQL returns app logins with or without the "[bot]" suffix depending on
+    # the surface, so normalize before comparing against the trusted set.
+    return login.removesuffix("[bot]").lower() in RADAR_BOT_LOGINS
+
+
+def is_low_risk(tier: str, score: int) -> bool:
+    return tier.lower() in RADAR_APPROVED_TIERS and score <= RADAR_MAX_SCORE
+
+
+def has_write_access(permission: str) -> bool:
+    return permission.lower() in WRITE_ACCESS_PERMISSIONS
+
+
+def _denylist_globs() -> tuple[str, ...]:
+    # TIGHTEN-ONLY: RADAR_DENYLIST_GLOBS can only ADD to the hardcoded floor,
+    # never remove from it. This keeps the policy fail-safe even if the RADAR
+    # signer and the trymerge verifier are configured with different denylist
+    # envs: a denylist set on only one side always makes that side stricter,
+    # never more permissive.
+    raw = os.environ.get("RADAR_DENYLIST_GLOBS", "").strip()
+    extra = tuple(g.strip() for g in raw.split(",") if g.strip()) if raw else ()
+    return DEFAULT_DENYLIST_GLOBS + extra
+
+
+def files_allowlisted(files: list[str]) -> bool:
+    # Empty file list fails closed: with nothing to reason about there is no
+    # approval. Every file must match an allowlist glob AND no file may match a
+    # denylist glob (denylist wins). The allowlist is a hardcoded constant (not
+    # env-overridable) so the signer and verifier stay provably in sync; only the
+    # tighten-only denylist is env-adjustable. fnmatch '*' spans '/'.
+    if not files:
+        return False
+    deny = _denylist_globs()
+    for f in files:
+        if any(fnmatch.fnmatch(f, g) for g in deny):
+            return False
+        if not any(fnmatch.fnmatch(f, g) for g in DEFAULT_ALLOWLIST_GLOBS):
+            return False
+    return True
+
+
+def build_approval_comment(
+    marker: RadarMarker, summary: str, reasoning: str, run_url: str | None
+) -> str:
+    lines = [
+        "## :radioactive: RADAR approves this PR",
+        "",
+        (
+            f"RADAR assessed this change as **{marker.tier}** risk "
+            f"(score {marker.score}/100, auto-approve threshold {RADAR_MAX_SCORE}), "
+            "every changed file is in the RADAR allowlist, and the author has "
+            "write access, so a human approval is not required to land it."
+        ),
+        "",
+        f"> {summary}",
+        "",
+        "<details><summary>RADAR risk reasoning</summary>",
+        "",
+        reasoning,
+        "",
+        "</details>",
+        "",
+        (
+            "A maintainer can now land this with `@pytorchbot merge`. Mandatory CI "
+            "checks are still enforced, and pushing any new commit re-runs RADAR "
+            "and invalidates this approval."
+        ),
+        "",
+        # Machine-readable marker (see RADAR_MARKER_RE). Emitted as a plain
+        # visible line -- not an HTML comment and not wrapped in markdown -- so it
+        # survives GitHub's bodyText rendering verbatim. Visible on purpose; the
+        # HMAC signature is what makes it unforgeable, not its invisibility.
+        render_marker(marker),
+    ]
+    if run_url:
+        lines += ["", f"<sub>Generated by [RADAR]({run_url}).</sub>"]
+    return "\n".join(lines)
+
+
+def _list_pr_comments(org: str, project: str, pr_num: int) -> list[dict]:
+    # Paginate the full comment list (busy PyTorch PRs routinely exceed one page).
+    # Best-effort; a listing failure never blocks the current decision.
+    url = f"https://api.github.com/repos/{org}/{project}/issues/{pr_num}/comments"
+    comments: list[dict] = []
+    for page in range(1, 101):  # cap at 10k comments, mirroring get_comments
+        try:
+            batch = gh_fetch_json_list(url, params={"per_page": 100, "page": page})
+        except Exception as e:
+            print(f"Could not list comments page {page} (ok): {e}")
+            break
+        comments.extend(batch)
+        if len(batch) < 100:
+            break
+    return comments
+
+
+def _radar_comment_state(
+    comments: list[dict], org: str, project: str, pr_num: int, head_sha: str
+) -> tuple[bool, bool]:
+    # Scan (no mutation) for whether a prior RADAR APPROVAL exists and whether a
+    # valid signed revocation for the CURRENT head already stands. The caller uses
+    # these to decide whether a fresh revocation must be posted before pruning, so
+    # a standing withdrawal is guaranteed to exist at every instant (no window
+    # where a stale approval is the only signal).
+    had_approval = False
+    has_head_revocation = False
+    for c in comments:
+        if not is_trusted_radar_login((c.get("user") or {}).get("login", "")):
+            continue
+        body = c.get("body", "") or ""
+        if parse_radar_marker(body) is not None:
+            had_approval = True
+        if any(
+            rev.sha == head_sha and verify_revoked_sig(rev, org, project, pr_num)
+            for rev in iter_revoked_markers(body)
+        ):
+            has_head_revocation = True
+    return had_approval, has_head_revocation
+
+
+def _delete_radar_comments(
+    comments: list[dict],
+    org: str,
+    project: str,
+    pr_num: int,
+    head_sha: str,
+    keep_head_revocation: bool,
+    dry_run: bool,
+) -> None:
+    # Remove superseded RADAR banners so the PR does not accumulate one per push.
+    # When keep_head_revocation is set, a standing signed revocation for the
+    # current head is preserved (it is the fail-closed withdrawal); everything
+    # else -- approval banners and revocations for other SHAs -- is pruned.
+    # Best-effort: delete failures never block the current decision.
+    for c in comments:
+        if not is_trusted_radar_login((c.get("user") or {}).get("login", "")):
+            continue
+        body = c.get("body", "") or ""
+        has_approval = parse_radar_marker(body) is not None
+        revs = iter_revoked_markers(body)
+        if not (has_approval or revs):
+            continue
+        is_head_revocation = any(
+            rev.sha == head_sha and verify_revoked_sig(rev, org, project, pr_num)
+            for rev in revs
+        )
+        if keep_head_revocation and is_head_revocation and not has_approval:
+            continue
+        cid = c.get("id")
+        if cid is None:
+            continue
+        if dry_run:
+            print(f"Dryrun: would delete prior RADAR comment {cid}")
+            continue
+        try:
+            gh_delete_comment(org, project, int(cid))
+        except Exception as e:
+            print(f"Could not delete prior RADAR comment {cid} (ok): {e}")
+
+
+def _post_revocation(
+    org: str, project: str, pr_num: int, sha: str, dry_run: bool
+) -> None:
+    # Post a signed revocation bound to the current head SHA. Callers guarantee a
+    # key is present; without one no approval could ever have validated anyway.
+    key = get_hmac_key()
+    if key is None:
+        return
+    sig = compute_revoked_sig(key, org, project, pr_num, sha)
+    marker = render_revoked_marker(RadarRevocation(sha=sha, sig=sig))
+    body = "\n".join(
+        [
+            "## :radioactive: RADAR approval revoked",
+            "",
+            (
+                "A previous RADAR auto-approval no longer applies to this PR: the "
+                "current assessment does not qualify for auto-approval, so a human "
+                "review is required to land it."
+            ),
+            "",
+            marker,
+        ]
+    )
+    gh_post_pr_comment(org, project, pr_num, body, dry_run=dry_run)
+
+
+def _clear_stale_label(org: str, project: str, pr_num: int, dry_run: bool) -> None:
+    # A previously-approved PR whose new head is riskier must lose the label.
+    # gh_remove_label 404s when the label is absent, which is fine here.
+    try:
+        gh_remove_label(org, project, pr_num, RADAR_APPROVED_LABEL, dry_run)
+    except Exception as e:
+        print(f"Could not remove stale {RADAR_APPROVED_LABEL} label (ok): {e}")
+
+
+def main() -> None:
+    parser = ArgumentParser("RADAR risk-based auto-approval")
+    parser.add_argument("--pr-num", type=int, required=True)
+    parser.add_argument("--sha", type=str, required=True, help="full head commit SHA")
+    parser.add_argument("--org", type=str, default="pytorch")
+    parser.add_argument("--project", type=str, default="pytorch")
+    parser.add_argument(
+        "--verdict-file",
+        type=str,
+        required=True,
+        help="path to the AI structured-output JSON (risk_score, risk_tier, ...)",
+    )
+    parser.add_argument(
+        "--meta-file",
+        type=str,
+        required=True,
+        help="path to `gh pr view --json ...files` metadata; used for the "
+        "changed-files allowlist check",
+    )
+    parser.add_argument(
+        "--author-permission",
+        type=str,
+        default="none",
+        help="the PR author's repo permission (admin/maintain/write/read/none)",
+    )
+    parser.add_argument("--run-url", type=str, default=None)
+    parser.add_argument(
+        "--diff-truncated",
+        action="store_true",
+        help="set by the workflow when the diff shown to the AI was "
+        "byte-truncated; forces non-approval regardless of the AI score",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    with open(args.verdict_file) as f:
+        verdict = json.load(f)
+    score = int(verdict["risk_score"])
+    tier = str(verdict["risk_tier"]).lower()
+    summary = str(verdict.get("summary", ""))
+    reasoning = str(verdict.get("reasoning", ""))
+
+    with open(args.meta_file) as f:
+        meta = json.load(f)
+    files = [str(x["path"]) for x in meta.get("files", [])]
+    # Fail closed if the line counts are absent: without them we cannot bound the
+    # change size, so treat it as too large to auto-approve rather than defaulting
+    # to zero (which would silently disable the size backstop).
+    if meta.get("additions") is None or meta.get("deletions") is None:
+        additions, deletions = RADAR_MAX_DIFF_LINES + 1, 0
+    else:
+        additions = int(meta["additions"])
+        deletions = int(meta["deletions"])
+    # `gh pr view --json files` caps its list at 100 entries, so on a >100-file PR
+    # a non-allowlisted file could sit past the cap and the list would look fully
+    # allowlisted. Fail closed unless GitHub's own changedFiles count (never
+    # truncated) matches the list we actually see. trymerge re-checks the fully
+    # paginated list, but this stops RADAR from POSTING a misleading approval.
+    changed_total = meta.get("changedFiles")
+    files_complete = changed_total is not None and len(files) == int(changed_total)
+
+    low_risk = is_low_risk(tier, score)
+    write_ok = has_write_access(args.author_permission)
+    allowlist_ok = files_allowlisted(files)
+    key_present = get_hmac_key() is not None
+    # A truncated diff means the AI never saw the whole change, and an oversized
+    # diff cannot be trivial; either forces non-approval regardless of the score.
+    # The line count comes from meta.json, which is never truncated.
+    size_ok = (not args.diff_truncated) and (
+        additions + deletions
+    ) <= RADAR_MAX_DIFF_LINES
+    print(
+        f"RADAR PR #{args.pr_num} @ {args.sha}: tier={tier} score={score} "
+        f"low_risk={low_risk} author_permission={args.author_permission} "
+        f"write_ok={write_ok} allowlist_ok={allowlist_ok} ({len(files)} files) "
+        f"files_complete={files_complete} (changedFiles={changed_total}) "
+        f"hmac_key_present={key_present} size_ok={size_ok} "
+        f"diff_lines={additions + deletions} truncated={args.diff_truncated}"
+    )
+
+    if not (
+        low_risk
+        and write_ok
+        and allowlist_ok
+        and key_present
+        and size_ok
+        and files_complete
+    ):
+        print("RADAR does not approve; revoking any prior approval and clearing label.")
+        comments = _list_pr_comments(args.org, args.project, args.pr_num)
+        had_prior_approval, has_head_revocation = _radar_comment_state(
+            comments, args.org, args.project, args.pr_num, args.sha
+        )
+        # Post a signed revocation for the current head BEFORE pruning, and only
+        # when a prior approval exists but no standing revocation does yet. Posting
+        # first (and keeping any current-head revocation during the prune below)
+        # guarantees a fail-closed withdrawal is present at every instant, so
+        # trymerge -- which honors the newest RADAR decision -- never sees a stale
+        # approval unopposed even if the old approval comment fails to delete. A
+        # write-access actor deleting the bot's revocation could still resurrect a
+        # not-yet-deleted approval, but that is inherent to trusting write access
+        # (they can already merge), and the SHA binding remains the primary guard.
+        if had_prior_approval and not has_head_revocation and key_present:
+            _post_revocation(
+                args.org, args.project, args.pr_num, args.sha, args.dry_run
+            )
+        _delete_radar_comments(
+            comments,
+            args.org,
+            args.project,
+            args.pr_num,
+            args.sha,
+            keep_head_revocation=True,
+            dry_run=args.dry_run,
+        )
+        _clear_stale_label(args.org, args.project, args.pr_num, args.dry_run)
+        return
+
+    key = get_hmac_key()
+    assert key is not None  # guarded by key_present above
+    sig = compute_marker_sig(
+        key, args.org, args.project, args.pr_num, args.sha, score, tier
+    )
+    marker = RadarMarker(sha=args.sha, score=score, tier=tier, sig=sig)
+    comment = build_approval_comment(marker, summary, reasoning, args.run_url)
+    # Drop every prior RADAR banner (approvals and any revocation) so the fresh
+    # approval is the sole, newest decision. The brief gap before the post below
+    # is fail-closed (no signal -> trymerge denies), so the approval path needs no
+    # keep-revocation handling.
+    _delete_radar_comments(
+        _list_pr_comments(args.org, args.project, args.pr_num),
+        args.org,
+        args.project,
+        args.pr_num,
+        args.sha,
+        keep_head_revocation=False,
+        dry_run=args.dry_run,
+    )
+    gh_post_pr_comment(
+        args.org, args.project, args.pr_num, comment, dry_run=args.dry_run
+    )
+    gh_add_labels(
+        args.org, args.project, args.pr_num, [RADAR_APPROVED_LABEL], args.dry_run
+    )
+    print("RADAR approved and posted.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_radar.py
+++ b/.github/scripts/test_radar.py
@@ -1,0 +1,638 @@
+#!/usr/bin/env python3
+# Owner(s): ["module: ci"]
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import sys
+import tempfile
+from typing import Any
+from unittest import main, mock, TestCase
+
+
+# RADAR helpers read the HMAC key from the environment at call time; set it
+# unconditionally before importing so module-level constants and every helper
+# see a non-empty key regardless of the ambient environment.
+os.environ["RADAR_HMAC_KEY"] = "radar-unit-test-key"
+
+import radar
+from github_utils import GitHubComment
+from trymerge import has_valid_radar_approval, radar_merger_has_write
+
+
+ORG = "pytorch"
+PROJECT = "pytorch"
+PR_NUM = 1
+HEAD_SHA = "a" * 40
+OTHER_SHA = "b" * 40
+ALLOWLISTED_FILES = ["test/test_radar_feature.py"]
+NON_ALLOWLISTED_FILES = ["torch/csrc/foo.cpp"]
+
+
+def _sig(sha: str, score: int, tier: str) -> str:
+    key = radar.get_hmac_key()
+    assert key is not None
+    return radar.compute_marker_sig(key, ORG, PROJECT, PR_NUM, sha, score, tier)
+
+
+def _marker(sha: str, score: int = 5, tier: str = "trivial") -> str:
+    m = radar.RadarMarker(sha=sha, score=score, tier=tier, sig=_sig(sha, score, tier))
+    return radar.render_marker(m) + "\napproved"
+
+
+def _revoked(sha: str) -> str:
+    key = radar.get_hmac_key()
+    assert key is not None
+    sig = radar.compute_revoked_sig(key, ORG, PROJECT, PR_NUM, sha)
+    return radar.render_revoked_marker(radar.RadarRevocation(sha=sha, sig=sig))
+
+
+def _comment(
+    body: str,
+    login: str = "github-actions",
+    association: str = "MEMBER",
+    editor: str | None = None,
+) -> GitHubComment:
+    # The RADAR marker is plain visible text, so it survives GitHub's bodyText
+    # rendering; detection reads body_text, matching production.
+    return GitHubComment(
+        body_text=body,
+        created_at="",
+        author_login=login,
+        author_url=None,
+        author_association=association,
+        editor_login=editor,
+        database_id=1,
+        url="",
+    )
+
+
+class FakePR:
+    def __init__(
+        self,
+        comments: list[GitHubComment],
+        head_sha: str = HEAD_SHA,
+        changed_files: list[str] | None = None,
+    ) -> None:
+        self._comments = comments
+        self._head_sha = head_sha
+        self._changed_files = (
+            list(ALLOWLISTED_FILES) if changed_files is None else changed_files
+        )
+        self.org = ORG
+        self.project = PROJECT
+        self.pr_num = PR_NUM
+
+    def last_commit_sha(self, default: str | None = None) -> str:
+        return self._head_sha
+
+    def get_comments(self) -> list[GitHubComment]:
+        return self._comments
+
+    def get_comment_by_id(self, database_id: int) -> GitHubComment:
+        return self._comments[-1]
+
+    def get_changed_files(self) -> list[str]:
+        return self._changed_files
+
+    def is_base_repo_private(self) -> bool:
+        return False
+
+
+class TestRadarPure(TestCase):
+    def test_parse_marker_roundtrip(self) -> None:
+        m = radar.parse_radar_marker(_marker(HEAD_SHA, 7, "trivial"))
+        assert m is not None
+        self.assertEqual(m.sha, HEAD_SHA)
+        self.assertEqual(m.score, 7)
+        self.assertEqual(m.tier, "trivial")
+        self.assertEqual(m.sig, _sig(HEAD_SHA, 7, "trivial"))
+
+    def test_parse_marker_absent(self) -> None:
+        self.assertIsNone(radar.parse_radar_marker("no marker here"))
+
+    def test_parse_marker_requires_signature(self) -> None:
+        # A marker with no sig=... must not parse, so unsigned/forged markers can
+        # never be honored.
+        unsigned = f"RADAR-APPROVED sha={HEAD_SHA} score=5 tier=trivial"
+        self.assertIsNone(radar.parse_radar_marker(unsigned))
+
+    def test_verify_good_signature(self) -> None:
+        m = radar.parse_radar_marker(_marker(HEAD_SHA))
+        assert m is not None
+        self.assertTrue(radar.verify_marker_sig(m, ORG, PROJECT, PR_NUM))
+
+    def test_verify_rejects_tampered_fields(self) -> None:
+        m = radar.parse_radar_marker(_marker(HEAD_SHA, 5, "trivial"))
+        assert m is not None
+        # Same signature but a bumped score / different pr must not verify.
+        tampered_score = m._replace(score=99)
+        self.assertFalse(radar.verify_marker_sig(tampered_score, ORG, PROJECT, PR_NUM))
+        self.assertFalse(radar.verify_marker_sig(m, ORG, PROJECT, 999))
+
+    def test_verify_fails_closed_without_key(self) -> None:
+        m = radar.parse_radar_marker(_marker(HEAD_SHA))
+        assert m is not None
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("RADAR_HMAC_KEY", None)
+            self.assertIsNone(radar.get_hmac_key())
+            self.assertFalse(radar.verify_marker_sig(m, ORG, PROJECT, PR_NUM))
+
+    def test_trusted_login_normalizes_bot_suffix(self) -> None:
+        self.assertTrue(radar.is_trusted_radar_login("github-actions[bot]"))
+        self.assertTrue(radar.is_trusted_radar_login("github-actions"))
+        self.assertFalse(radar.is_trusted_radar_login("some-random-user"))
+
+    def test_low_risk_requires_tier_and_score(self) -> None:
+        self.assertTrue(radar.is_low_risk("trivial", radar.RADAR_MAX_SCORE))
+        self.assertFalse(radar.is_low_risk("low", 0))
+        self.assertFalse(radar.is_low_risk("trivial", radar.RADAR_MAX_SCORE + 1))
+
+    def test_write_access(self) -> None:
+        for perm in ("write", "admin", "maintain"):
+            self.assertTrue(radar.has_write_access(perm))
+        for perm in ("read", "none", "triage"):
+            self.assertFalse(radar.has_write_access(perm))
+
+    def test_files_allowlisted(self) -> None:
+        self.assertTrue(radar.files_allowlisted(["test/test_x.py"]))
+        self.assertTrue(radar.files_allowlisted(["docs/source/foo.rst", "README.md"]))
+        # .pyi.in is deliberately NOT allowlisted: it would admit the core
+        # torch/_C/__init__.pyi.in and bypass its domain reviewers.
+        self.assertFalse(radar.files_allowlisted(["torch/_C/__init__.pyi.in"]))
+        # A single non-allowlisted file taints the whole set.
+        self.assertFalse(
+            radar.files_allowlisted(["test/test_x.py", "torch/csrc/foo.cpp"])
+        )
+        self.assertFalse(radar.files_allowlisted(["aten/src/ATen/native/foo.cpp"]))
+        # Empty list fails closed.
+        self.assertFalse(radar.files_allowlisted([]))
+        # Denylist: CI-executing harness files are rejected even under test/.
+        self.assertFalse(radar.files_allowlisted(["test/conftest.py"]))
+        self.assertFalse(radar.files_allowlisted(["test/run_test.py"]))
+        self.assertFalse(radar.files_allowlisted(["test/inductor/conftest.py"]))
+        # Docs build config / Makefiles execute in CI: denied even under docs/.
+        self.assertFalse(radar.files_allowlisted(["docs/source/conf.py"]))
+        self.assertFalse(radar.files_allowlisted(["docs/Makefile"]))
+        self.assertFalse(radar.files_allowlisted(["docs/conf.py"]))
+        # One denied file taints the whole set.
+        self.assertFalse(
+            radar.files_allowlisted(["test/test_x.py", "test/conftest.py"])
+        )
+        # Basename-anchored globs must NOT over-match legitimate files.
+        self.assertTrue(radar.files_allowlisted(["test/my_conftest.py"]))
+        self.assertTrue(radar.files_allowlisted(["test/test_run_test.py"]))
+        # RADAR_DENYLIST_GLOBS is tighten-only: it ADDS to the floor.
+        with mock.patch.dict(os.environ, {"RADAR_DENYLIST_GLOBS": "*.md"}):
+            self.assertFalse(radar.files_allowlisted(["README.md"]))
+            self.assertFalse(radar.files_allowlisted(["test/conftest.py"]))
+
+    def test_revoked_sign_verify_roundtrip(self) -> None:
+        markers = radar.iter_revoked_markers(_revoked(HEAD_SHA))
+        self.assertEqual(len(markers), 1)
+        self.assertEqual(markers[0].sha, HEAD_SHA)
+        self.assertTrue(radar.verify_revoked_sig(markers[0], ORG, PROJECT, PR_NUM))
+
+    def test_revoked_rejects_tampered_and_wrong_pr(self) -> None:
+        rev = radar.iter_revoked_markers(_revoked(HEAD_SHA))[0]
+        self.assertFalse(
+            radar.verify_revoked_sig(rev._replace(sig="0" * 64), ORG, PROJECT, PR_NUM)
+        )
+        self.assertFalse(radar.verify_revoked_sig(rev, ORG, PROJECT, 999))
+
+    def test_revoked_fails_closed_without_key(self) -> None:
+        rev = radar.iter_revoked_markers(_revoked(HEAD_SHA))[0]
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("RADAR_HMAC_KEY", None)
+            self.assertFalse(radar.verify_revoked_sig(rev, ORG, PROJECT, PR_NUM))
+
+    def test_approval_sig_is_not_a_valid_revocation(self) -> None:
+        # The ":REVOKED" payload namespace means an approval signature can never
+        # be replayed as a revocation for the same SHA.
+        approval_sig = _sig(HEAD_SHA, 5, "trivial")
+        rev = radar.RadarRevocation(sha=HEAD_SHA, sig=approval_sig)
+        self.assertFalse(radar.verify_revoked_sig(rev, ORG, PROJECT, PR_NUM))
+
+    def test_max_score_is_constant_not_env(self) -> None:
+        # The score ceiling is a hardcoded constant, not an env read, so the
+        # signer and the trymerge verifier cannot diverge. Reloading the module
+        # under a bogus RADAR_MAX_SCORE env must NOT change it; this would fail
+        # against a regression back to int(os.environ.get("RADAR_MAX_SCORE", ...)).
+        self.assertEqual(radar.RADAR_MAX_SCORE, 10)
+        reloaded = None
+        try:
+            with mock.patch.dict(os.environ, {"RADAR_MAX_SCORE": "999"}):
+                importlib.reload(radar)
+                reloaded = radar.RADAR_MAX_SCORE
+        finally:
+            # Restore the module under the ambient (unpatched) environment so
+            # other tests see the normal constant regardless of the outcome above.
+            importlib.reload(radar)
+        self.assertEqual(reloaded, 10)
+        self.assertEqual(radar.RADAR_MAX_SCORE, 10)
+
+
+class TestRadarDetection(TestCase):
+    def _valid(self, pr: Any) -> bool:
+        return has_valid_radar_approval(pr)
+
+    def test_valid_bot_approval_current_sha(self) -> None:
+        pr = FakePR([_comment(_marker(HEAD_SHA))])
+        self.assertTrue(self._valid(pr))
+
+    def test_marker_is_visible_text_not_html_comment(self) -> None:
+        # GitHub's bodyText (which detection reads) strips HTML comments, so the
+        # marker must be plain visible text. Guards against regressing to an
+        # HTML-comment marker that would silently never be detected.
+        rendered = radar.render_marker(
+            radar.RadarMarker(HEAD_SHA, 5, "trivial", _sig(HEAD_SHA, 5, "trivial"))
+        )
+        self.assertNotIn("<!--", rendered)
+        self.assertIsNotNone(radar.parse_radar_marker(rendered))
+
+    def test_stale_sha_rejected(self) -> None:
+        pr = FakePR([_comment(_marker(OTHER_SHA))])
+        self.assertFalse(self._valid(pr))
+
+    def test_non_bot_author_rejected(self) -> None:
+        pr = FakePR([_comment(_marker(HEAD_SHA), login="attacker")])
+        self.assertFalse(self._valid(pr))
+
+    def test_edited_comment_rejected(self) -> None:
+        pr = FakePR([_comment(_marker(HEAD_SHA), editor="attacker")])
+        self.assertFalse(self._valid(pr))
+
+    def test_no_marker_rejected(self) -> None:
+        pr = FakePR([_comment("just a normal bot comment")])
+        self.assertFalse(self._valid(pr))
+
+    def test_bad_signature_rejected(self) -> None:
+        # Correctly-shaped marker whose signature does not match its fields
+        # (e.g. reflected attacker text) must not validate.
+        forged = radar.RadarMarker(sha=HEAD_SHA, score=1, tier="trivial", sig="0" * 64)
+        body = radar.render_marker(forged)
+        pr = FakePR([_comment(body)])
+        self.assertFalse(self._valid(pr))
+
+    def test_score_over_threshold_rejected(self) -> None:
+        # Even a properly-signed marker is rejected at merge time if its score /
+        # tier are above the auto-approve threshold.
+        pr = FakePR([_comment(_marker(HEAD_SHA, 99, "high"))])
+        self.assertFalse(self._valid(pr))
+
+    def test_non_allowlisted_files_rejected(self) -> None:
+        # A valid, signed, current-SHA marker is still rejected when the PR
+        # touches files outside the allowlist.
+        pr = FakePR(
+            [_comment(_marker(HEAD_SHA))], changed_files=list(NON_ALLOWLISTED_FILES)
+        )
+        self.assertFalse(self._valid(pr))
+
+    def test_fails_closed_without_key(self) -> None:
+        pr = FakePR([_comment(_marker(HEAD_SHA))])
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("RADAR_HMAC_KEY", None)
+            self.assertFalse(self._valid(pr))
+
+    def test_latest_valid_marker_wins(self) -> None:
+        pr = FakePR([_comment(_marker(OTHER_SHA)), _comment(_marker(HEAD_SHA))])
+        self.assertTrue(self._valid(pr))
+
+    def test_shadow_marker_before_real_is_ignored(self) -> None:
+        # A bogus marker-shaped string (bad sig) preceding the genuine marker in
+        # the same comment must not shadow it: all markers are scanned.
+        bogus = f"RADAR-APPROVED sha={HEAD_SHA} score=5 tier=trivial sig={'0' * 64}"
+        body = bogus + "\n\n" + _marker(HEAD_SHA)
+        self.assertTrue(self._valid(FakePR([_comment(body)])))
+
+    def test_revocation_invalidates_prior_approval(self) -> None:
+        # A signed revocation for the head SHA, newer than the approval, wins even
+        # though the approval comment was not deleted (delete is best-effort).
+        pr = FakePR([_comment(_marker(HEAD_SHA)), _comment(_revoked(HEAD_SHA))])
+        self.assertFalse(self._valid(pr))
+
+    def test_revocation_for_other_sha_ignored(self) -> None:
+        # A revocation bound to a different SHA must not invalidate the current
+        # head's approval.
+        pr = FakePR([_comment(_marker(HEAD_SHA)), _comment(_revoked(OTHER_SHA))])
+        self.assertTrue(self._valid(pr))
+
+    def test_forged_revocation_sig_does_not_invalidate(self) -> None:
+        # A revocation-shaped string with a bad signature cannot deny a genuine
+        # approval (forgery is impossible in either direction).
+        bogus = f"RADAR-REVOKED sha={HEAD_SHA} sig={'0' * 64}"
+        pr = FakePR([_comment(_marker(HEAD_SHA)), _comment(bogus)])
+        self.assertTrue(self._valid(pr))
+
+    def test_reapproval_after_revocation_wins(self) -> None:
+        # Newest decision wins: an approval posted after a revocation re-validates.
+        pr = FakePR(
+            [
+                _comment(_marker(HEAD_SHA)),
+                _comment(_revoked(HEAD_SHA)),
+                _comment(_marker(HEAD_SHA)),
+            ]
+        )
+        self.assertTrue(self._valid(pr))
+
+    def test_revocation_from_untrusted_login_ignored(self) -> None:
+        # Only a revocation under the trusted RADAR login counts; an attacker
+        # cannot deny an approval from a non-bot comment.
+        pr = FakePR(
+            [
+                _comment(_marker(HEAD_SHA)),
+                _comment(_revoked(HEAD_SHA), login="attacker"),
+            ]
+        )
+        self.assertTrue(self._valid(pr))
+
+    def test_edited_revocation_still_revokes(self) -> None:
+        # A revocation is deny-only and HMAC-signed, so it is honored even from an
+        # EDITED comment. This closes the fail-open where editing the bot's
+        # revocation comment would otherwise resurrect a lingering approval.
+        pr = FakePR(
+            [_comment(_marker(HEAD_SHA)), _comment(_revoked(HEAD_SHA), editor="x")]
+        )
+        self.assertFalse(self._valid(pr))
+
+    def test_edited_approval_still_rejected(self) -> None:
+        # The edited-comment skip still applies to approvals: an edited approval
+        # marker must not authorize a merge.
+        pr = FakePR([_comment(_marker(HEAD_SHA), editor="x")])
+        self.assertFalse(self._valid(pr))
+
+
+class TestRadarMergerHasWrite(TestCase):
+    # The person half of authorization, reused per-PR across a ghstack. It gates
+    # on the commenter's REAL repo permission, not their author_association.
+    @mock.patch("trymerge._radar_commenter_repo_permission", return_value="write")
+    def test_write_access_unedited(self, _perm: mock.MagicMock) -> None:
+        pr = FakePR([_comment(_marker(HEAD_SHA))])
+        self.assertTrue(radar_merger_has_write(pr, comment_id=1))
+
+    @mock.patch("trymerge._radar_commenter_repo_permission", return_value="read")
+    def test_read_only_rejected(self, _perm: mock.MagicMock) -> None:
+        # An org MEMBER/COLLABORATOR association is not enough: read-only fails.
+        pr = FakePR([_comment(_marker(HEAD_SHA), association="MEMBER")])
+        self.assertFalse(radar_merger_has_write(pr, comment_id=1))
+
+    @mock.patch("trymerge._radar_commenter_repo_permission", return_value="none")
+    def test_no_permission_rejected(self, _perm: mock.MagicMock) -> None:
+        pr = FakePR([_comment(_marker(HEAD_SHA), association="MEMBER")])
+        self.assertFalse(radar_merger_has_write(pr, comment_id=1))
+
+    @mock.patch("trymerge._radar_commenter_repo_permission", return_value="write")
+    def test_edited_merge_comment_rejected(self, _perm: mock.MagicMock) -> None:
+        pr = FakePR([_comment(_marker(HEAD_SHA), editor="x")])
+        self.assertFalse(radar_merger_has_write(pr, comment_id=1))
+
+    @mock.patch("trymerge._radar_commenter_repo_permission", return_value="write")
+    def test_no_comment_id_rejected(self, _perm: mock.MagicMock) -> None:
+        pr = FakePR([_comment(_marker(HEAD_SHA))])
+        self.assertFalse(radar_merger_has_write(pr, comment_id=None))
+
+    @mock.patch("trymerge.gh_fetch_json_dict", side_effect=RuntimeError("404"))
+    def test_permission_fetch_failure_fails_closed(
+        self, _fetch: mock.MagicMock
+    ) -> None:
+        # A failed/absent permission lookup (e.g. non-collaborator 404) must be
+        # treated as no write access, not silently allowed.
+        from trymerge import _radar_commenter_repo_permission
+
+        pr = FakePR([_comment(_marker(HEAD_SHA))])
+        self.assertEqual(_radar_commenter_repo_permission(pr, "someone"), "none")
+        self.assertFalse(radar_merger_has_write(pr, comment_id=1))
+
+
+class TestRadarMain(TestCase):
+    # Exercises the composed approval DECISION in radar.main(): it posts an
+    # approval + adds the label only when the change is low-risk, allowlisted,
+    # authored by a write-access user, small/untruncated, and a signing key is
+    # present; otherwise it prunes any stale approval and clears the label.
+    def _run(
+        self,
+        tier: str,
+        score: int,
+        files: list[str],
+        perm: str,
+        additions: int = 3,
+        deletions: int = 1,
+        extra: tuple[str, ...] = (),
+        include_line_counts: bool = True,
+        changed_files_count: int | None = None,
+        include_changed_files: bool = True,
+        prior_comments: list[dict[str, Any]] | None = None,
+    ) -> tuple[mock.MagicMock, mock.MagicMock, mock.MagicMock, mock.MagicMock]:
+        d = tempfile.mkdtemp()
+        vf, mf = os.path.join(d, "v.json"), os.path.join(d, "m.json")
+        with open(vf, "w") as f:
+            json.dump(
+                {
+                    "risk_score": score,
+                    "risk_tier": tier,
+                    "summary": "s",
+                    "reasoning": "r",
+                },
+                f,
+            )
+        meta: dict[str, Any] = {"files": [{"path": p} for p in files]}
+        if include_line_counts:
+            meta["additions"] = additions
+            meta["deletions"] = deletions
+        if include_changed_files:
+            meta["changedFiles"] = (
+                len(files) if changed_files_count is None else changed_files_count
+            )
+        with open(mf, "w") as f:
+            json.dump(meta, f)
+        argv = [
+            "radar.py",
+            "--pr-num",
+            str(PR_NUM),
+            "--sha",
+            HEAD_SHA,
+            "--org",
+            ORG,
+            "--project",
+            PROJECT,
+            "--verdict-file",
+            vf,
+            "--meta-file",
+            mf,
+            "--author-permission",
+            perm,
+            *extra,
+        ]
+        with (
+            mock.patch.object(sys, "argv", argv),
+            mock.patch("radar.gh_fetch_json_list", return_value=prior_comments or []),
+            mock.patch("radar.gh_delete_comment") as dele,
+            mock.patch("radar.gh_post_pr_comment") as post,
+            mock.patch("radar.gh_add_labels") as addl,
+            mock.patch("radar.gh_remove_label") as reml,
+        ):
+            radar.main()
+        return post, addl, reml, dele
+
+    def test_approves_low_risk(self) -> None:
+        post, addl, reml, _ = self._run("trivial", 5, ["test/test_x.py"], "write")
+        post.assert_called_once()
+        addl.assert_called_once()
+        reml.assert_not_called()
+        # The posted comment must carry a marker whose signature verifies.
+        body = post.call_args[0][3]
+        mk = radar.parse_radar_marker(body)
+        assert mk is not None
+        self.assertTrue(radar.verify_marker_sig(mk, ORG, PROJECT, PR_NUM))
+
+    def test_rejects_high_score(self) -> None:
+        post, addl, reml, _ = self._run("medium", 50, ["test/test_x.py"], "write")
+        post.assert_not_called()
+        addl.assert_not_called()
+        reml.assert_called_once()
+
+    def test_rejects_no_write(self) -> None:
+        post, addl, _, _ = self._run("trivial", 5, ["test/test_x.py"], "read")
+        post.assert_not_called()
+        addl.assert_not_called()
+
+    def test_rejects_non_allowlisted(self) -> None:
+        post, addl, _, _ = self._run("trivial", 5, ["torch/csrc/foo.cpp"], "write")
+        post.assert_not_called()
+        addl.assert_not_called()
+
+    def test_rejects_denylisted(self) -> None:
+        post, addl, _, _ = self._run("trivial", 5, ["test/conftest.py"], "write")
+        post.assert_not_called()
+        addl.assert_not_called()
+
+    def test_rejects_truncated_diff(self) -> None:
+        post, addl, _, _ = self._run(
+            "trivial", 5, ["test/test_x.py"], "write", extra=("--diff-truncated",)
+        )
+        post.assert_not_called()
+        addl.assert_not_called()
+
+    def test_rejects_huge_diff(self) -> None:
+        post, addl, _, _ = self._run(
+            "trivial", 5, ["test/test_x.py"], "write", additions=5000, deletions=0
+        )
+        post.assert_not_called()
+        addl.assert_not_called()
+
+    def test_rejects_missing_line_counts(self) -> None:
+        # Absent additions/deletions must fail closed (treated as oversized).
+        post, addl, _, _ = self._run(
+            "trivial", 5, ["test/test_x.py"], "write", include_line_counts=False
+        )
+        post.assert_not_called()
+        addl.assert_not_called()
+
+    def test_rejects_no_key(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("RADAR_HMAC_KEY", None)
+            post, addl, _, _ = self._run("trivial", 5, ["test/test_x.py"], "write")
+        post.assert_not_called()
+        addl.assert_not_called()
+
+    def test_rejects_truncated_file_list(self) -> None:
+        # changedFiles > the (100-capped) files list means the list may hide a
+        # non-allowlisted file, so RADAR must fail closed even if every visible
+        # file is allowlisted.
+        post, addl, _, _ = self._run(
+            "trivial", 5, ["test/test_x.py"], "write", changed_files_count=150
+        )
+        post.assert_not_called()
+        addl.assert_not_called()
+
+    def test_rejects_missing_changed_files_count(self) -> None:
+        # Absent changedFiles must fail closed: we cannot prove the list is whole.
+        post, addl, _, _ = self._run(
+            "trivial", 5, ["test/test_x.py"], "write", include_changed_files=False
+        )
+        post.assert_not_called()
+        addl.assert_not_called()
+
+    def _prior_approval_comment(self) -> dict[str, Any]:
+        return {
+            "user": {"login": "github-actions[bot]"},
+            "body": _marker(HEAD_SHA),
+            "id": 42,
+        }
+
+    def test_posts_signed_revocation_when_prior_approval_exists(self) -> None:
+        # A PR that previously earned an approval but no longer qualifies must get
+        # a SIGNED revocation bound to the head SHA, so withdrawal does not depend
+        # on the prior approval comment being deleted.
+        post, addl, reml, _ = self._run(
+            "medium",
+            50,
+            ["test/test_x.py"],
+            "write",
+            prior_comments=[self._prior_approval_comment()],
+        )
+        post.assert_called_once()
+        addl.assert_not_called()
+        reml.assert_called_once()
+        body = post.call_args[0][3]
+        revs = radar.iter_revoked_markers(body)
+        self.assertEqual(len(revs), 1)
+        self.assertEqual(revs[0].sha, HEAD_SHA)
+        self.assertTrue(radar.verify_revoked_sig(revs[0], ORG, PROJECT, PR_NUM))
+
+    def test_no_revocation_when_no_prior_approval(self) -> None:
+        # An ordinary non-qualifying PR that was never approved must not be spammed
+        # with a revocation comment.
+        post, _, reml, _ = self._run("medium", 50, ["test/test_x.py"], "write")
+        post.assert_not_called()
+        reml.assert_called_once()
+
+    def _prior_revocation_comment(self) -> dict[str, Any]:
+        return {
+            "user": {"login": "github-actions[bot]"},
+            "body": _revoked(HEAD_SHA),
+            "id": 43,
+        }
+
+    def test_no_double_revocation_when_head_revocation_exists(self) -> None:
+        # A standing signed revocation for the head already provides the
+        # fail-closed withdrawal, so a re-run must not post a duplicate.
+        post, _, _, dele = self._run(
+            "medium",
+            50,
+            ["test/test_x.py"],
+            "write",
+            prior_comments=[
+                self._prior_approval_comment(),
+                self._prior_revocation_comment(),
+            ],
+        )
+        post.assert_not_called()
+        # The stale approval (42) is pruned; the standing head revocation (43) is
+        # KEPT so the fail-closed withdrawal survives the prune.
+        deleted = [c.args[2] for c in dele.call_args_list]
+        self.assertIn(42, deleted)
+        self.assertNotIn(43, deleted)
+
+    def test_approval_posts_even_with_prior_revocation(self) -> None:
+        # When a previously-revoked PR now qualifies again, the approval path posts
+        # a fresh approval marker (newest decision wins).
+        post, addl, _, dele = self._run(
+            "trivial",
+            5,
+            ["test/test_x.py"],
+            "write",
+            prior_comments=[self._prior_revocation_comment()],
+        )
+        post.assert_called_once()
+        addl.assert_called_once()
+        self.assertIsNotNone(radar.parse_radar_marker(post.call_args[0][3]))
+        # The approval path drops every prior banner, including the old revocation
+        # (43), so the fresh approval is the sole, newest decision.
+        self.assertIn(43, [c.args[2] for c in dele.call_args_list])
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -35,6 +35,7 @@ from trymerge import (
     JobCheckState,
     main as trymerge_main,
     MandatoryChecksMissingError,
+    merge,
     MergeRule,
     MergeRuleFailedError,
     PostCommentError,
@@ -190,6 +191,23 @@ def mocked_read_merge_rules_NE(repo: Any, org: str, project: str) -> list[MergeR
             patterns=["*"],
             approved_by=[],
             mandatory_checks_name=["Lint", "Facebook CLA Check", "nonexistent"],
+            ignore_flaky_failures=True,
+        ),
+    ]
+
+
+def mocked_read_merge_rules_approver_and_pending(
+    repo: Any, org: str, project: str
+) -> list[MergeRule]:
+    # Requires an approver (so radar_approved must bypass the approval gate) AND a
+    # check that never exists (so it stays pending). This makes radar_approved
+    # load-bearing for reaching the pending-check branch.
+    return [
+        MergeRule(
+            name="needs approver with pending check",
+            patterns=["*"],
+            approved_by=["1", "2"],
+            mandatory_checks_name=["nonexistent"],
             ignore_flaky_failures=True,
         ),
     ]
@@ -996,6 +1014,64 @@ class TestBypassFailures(TestCase):
 
 @mock.patch("trymerge.gh_graphql", side_effect=mocked_gh_graphql)
 @mock.patch("trymerge.gh_fetch_merge_base", return_value="")
+@mock.patch(
+    "trymerge.get_drci_classifications", side_effect=mocked_drci_classifications
+)
+@mock.patch.object(GitHubPR, "get_approved_by", return_value=[])
+class TestRadarMergeRuleBypass(TestCase):
+    # get_approved_by is stripped to [] so a valid radar_approved is the ONLY
+    # thing that can carry a PR past the human-approval gate; the mandatory-check
+    # logic is still exercised by the real recorded check state, proving RADAR
+    # bypasses ONLY the approval requirement, never mandatory CI.
+    @mock.patch(
+        "trymerge.read_merge_rules", side_effect=mocked_read_merge_rules_approvers
+    )
+    def test_radar_bypasses_approver_gate_when_checks_green(self, *args: Any) -> None:
+        pr = GitHubPR("pytorch", "pytorch", 115495)
+        repo = DummyGitRepo()
+        self.assertRaisesRegex(
+            MergeRuleFailedError,
+            "has not been reviewed yet",
+            lambda: find_matching_merge_rule(pr, repo, radar_approved=False),
+        )
+        self.assertIsNotNone(find_matching_merge_rule(pr, repo, radar_approved=True))
+
+    @mock.patch("trymerge.read_merge_rules", side_effect=xla_merge_rules)
+    def test_radar_still_enforces_failed_checks(self, *args: Any) -> None:
+        pr = GitHubPR("pytorch", "pytorch", 105312)
+        repo = DummyGitRepo()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            with self.assertRaises(MergeRuleFailedError) as cm:
+                find_matching_merge_rule(pr, repo, radar_approved=True)
+        self.assertIn("mandatory check(s) failed", str(cm.exception))
+        # A genuine failure, not the pending subclass.
+        self.assertNotIsInstance(cm.exception, MandatoryChecksMissingError)
+
+    @mock.patch(
+        "trymerge.read_merge_rules",
+        side_effect=mocked_read_merge_rules_approver_and_pending,
+    )
+    def test_radar_still_enforces_pending_checks(self, *args: Any) -> None:
+        pr = GitHubPR("pytorch", "pytorch", 76118)
+        repo = DummyGitRepo()
+        # radar_approved is load-bearing here: the rule requires an approver, so
+        # without it the approval gate rejects first; with it we reach the
+        # pending-check branch, proving RADAR does not bypass mandatory checks.
+        self.assertRaisesRegex(
+            MergeRuleFailedError,
+            "has not been reviewed yet",
+            lambda: find_matching_merge_rule(pr, repo, radar_approved=False),
+        )
+        self.assertRaisesRegex(
+            MandatoryChecksMissingError,
+            "pending/not yet run",
+            lambda: find_matching_merge_rule(pr, repo, radar_approved=True),
+        )
+
+
+@mock.patch("trymerge.gh_graphql", side_effect=mocked_gh_graphql)
+@mock.patch("trymerge.gh_fetch_merge_base", return_value="")
 @mock.patch("trymerge.get_drci_classifications", return_value={})
 class TestBypassFailuresOnSandCastle(TestCase):
     def test_get_classifications(self, *args: Any) -> None:
@@ -1101,6 +1177,35 @@ class TestGitHubPRGhstackDependencies(TestCase):
             "Approved by: https://github.com/ezyang, https://github.com/fegin\n"
             "ghstack dependencies: #106032, #106033, #106034\n",
         )
+
+    @mock.patch.object(GitHubPR, "get_approved_by", return_value=[])
+    def test_radar_approval_attribution_no_human(self, *args: Any) -> None:
+        # radar_approved with no human reviewer: the trailer is attributed to the
+        # greppable RADAR pseudo-login, not the real pytorch-bot account.
+        pr = GitHubPR("pytorch", "pytorch", 106068)
+        msg = pr.gen_commit_message(filter_ghstack=True, radar_approved=True)
+        self.assertIn("Approved by: https://github.com/pytorch-auto-radar", msg)
+        self.assertNotIn("pytorch-bot", msg)
+
+    def test_radar_attribution_when_nonqualifying_human_present(
+        self, *args: Any
+    ) -> None:
+        # The gap the fix closes: RADAR can authorize a merge even when a
+        # non-qualifying human review exists. get_approved_by is non-empty here,
+        # but because RADAR was the authorizing factor the trailer must still
+        # record pytorch-auto-radar (alongside the human) so the landing stays
+        # greppable as a RADAR auto-approval.
+        pr = GitHubPR("pytorch", "pytorch", 106068)
+        msg = pr.gen_commit_message(filter_ghstack=True, radar_approved=True)
+        self.assertIn("https://github.com/pytorch-auto-radar", msg)
+        self.assertIn("https://github.com/ezyang", msg)
+
+    @mock.patch.object(GitHubPR, "get_approved_by", return_value=[])
+    def test_no_radar_attribution_when_not_radar_approved(self, *args: Any) -> None:
+        # Without a RADAR authorization, RADAR must not appear in the trailer.
+        pr = GitHubPR("pytorch", "pytorch", 106068)
+        msg = pr.gen_commit_message(filter_ghstack=True, radar_approved=False)
+        self.assertNotIn("pytorch-auto-radar", msg)
 
     @skip(
         reason="This test is run against a mutable PR that has changed, so it no longer works. The test should be changed"
@@ -1238,6 +1343,188 @@ class TestGitHubPRGhstackDependencies(TestCase):
             top_pr.merge_ghstack_into(mock_repo, True)
 
         self.assertIn("#106034", str(cm.exception))
+
+    @mock.patch.object(GitHubPR, "is_closed", return_value=False)
+    @mock.patch("trymerge.radar_merger_has_write", return_value=True)
+    @mock.patch("trymerge.has_valid_radar_approval")
+    @mock.patch("trymerge.find_matching_merge_rule")
+    @mock.patch("trymerge.GitRepo")
+    @mock.patch("trymerge.get_ghstack_prs")
+    def test_merge_ghstack_into_radar_is_per_pr(
+        self,
+        mock_get_ghstack_prs: mock.MagicMock,
+        mock_repo: mock.MagicMock,
+        mock_find_matching_merge_rule: mock.MagicMock,
+        mock_has_valid_radar_approval: mock.MagicMock,
+        _mock_merger_has_write: mock.MagicMock,
+        _mock_is_closed: mock.MagicMock,
+        *args: Any,
+    ) -> None:
+        """RADAR authorization must be evaluated per stacked PR, not computed once
+        for the top PR and reused: only the PR with its own valid marker may ride
+        RADAR. Guards against a regression to has_valid_radar_approval(self)."""
+        parent_pr = GitHubPR("pytorch", "pytorch", 106034)
+        top_pr = GitHubPR("pytorch", "pytorch", 106068)
+        mock_get_ghstack_prs.return_value = [
+            (parent_pr, "rev_parent"),
+            (top_pr, "rev_top"),
+        ]
+        # Only the top PR carries a valid RADAR marker.
+        mock_has_valid_radar_approval.side_effect = lambda pr: pr.pr_num == 106068
+
+        top_pr.merge_ghstack_into(mock_repo, True)
+
+        # The rule check runs only for the non-top stacked PR (the parent), and it
+        # must receive the PARENT's own radar decision (False), not the top's.
+        self.assertEqual(mock_find_matching_merge_rule.call_count, 1)
+        self.assertFalse(
+            mock_find_matching_merge_rule.call_args.kwargs["radar_approved"]
+        )
+        # Attribution follows the same per-PR decision: the top PR's message is
+        # RADAR-attributed, the parent's is not.
+        messages = [c.args[0] for c in mock_repo.amend_commit_message.call_args_list]
+        parent_msg = next(m for m in messages if "#106034" in m)
+        top_msg = next(m for m in messages if "#106068" in m)
+        self.assertNotIn("pytorch-auto-radar", parent_msg)
+        self.assertIn("pytorch-auto-radar", top_msg)
+
+    @mock.patch.object(GitHubPR, "is_closed", return_value=False)
+    @mock.patch("trymerge.radar_merger_has_write", return_value=False)
+    @mock.patch("trymerge.has_valid_radar_approval", return_value=True)
+    @mock.patch("trymerge.find_matching_merge_rule")
+    @mock.patch("trymerge.GitRepo")
+    @mock.patch("trymerge.get_ghstack_prs")
+    def test_merge_ghstack_into_read_only_commenter_gets_no_radar(
+        self,
+        mock_get_ghstack_prs: mock.MagicMock,
+        mock_repo: mock.MagicMock,
+        mock_find_matching_merge_rule: mock.MagicMock,
+        _mock_has_valid_radar_approval: mock.MagicMock,
+        _mock_merger_has_write: mock.MagicMock,
+        _mock_is_closed: mock.MagicMock,
+        *args: Any,
+    ) -> None:
+        """The person half is load-bearing: even if EVERY stacked PR carries a
+        valid marker, a merge commenter without write access yields no RADAR
+        authorization on any PR (both the rule check and the attribution)."""
+        parent_pr = GitHubPR("pytorch", "pytorch", 106034)
+        top_pr = GitHubPR("pytorch", "pytorch", 106068)
+        mock_get_ghstack_prs.return_value = [
+            (parent_pr, "rev_parent"),
+            (top_pr, "rev_top"),
+        ]
+
+        top_pr.merge_ghstack_into(mock_repo, True)
+
+        self.assertEqual(mock_find_matching_merge_rule.call_count, 1)
+        self.assertFalse(
+            mock_find_matching_merge_rule.call_args.kwargs["radar_approved"]
+        )
+        messages = [c.args[0] for c in mock_repo.amend_commit_message.call_args_list]
+        self.assertTrue(all("pytorch-auto-radar" not in m for m in messages))
+
+    @mock.patch.object(GitHubPR, "is_ghstack_pr", return_value=False)
+    def test_single_pr_threads_radar_approved_to_commit_message(
+        self, _mock_is_ghstack: mock.MagicMock, *args: Any
+    ) -> None:
+        # The non-ghstack path must forward radar_approved from merge_into ->
+        # merge_changes_locally -> gen_commit_message. gen_commit_message is the
+        # first thing merge_changes_locally does for a single PR, so intercept it
+        # to assert the flag is threaded (guards against a refactor dropping it).
+        pr = GitHubPR("pytorch", "pytorch", 106068)
+        repo = mock.MagicMock()
+
+        class _Stop(Exception):
+            pass
+
+        with mock.patch.object(pr, "gen_commit_message", side_effect=_Stop) as mock_gen:
+            with self.assertRaises(_Stop):
+                pr.merge_changes_locally(repo, comment_id=1, radar_approved=True)
+        mock_gen.assert_called_once_with(radar_approved=True)
+
+    def test_merge_into_forwards_radar_approved(self, *args: Any) -> None:
+        # merge_into must pass radar_approved to BOTH find_matching_merge_rule
+        # (the gate) and merge_changes_locally (the commit-message attribution).
+        pr = GitHubPR("pytorch", "pytorch", 106068)
+        repo = mock.MagicMock()
+        rule = MergeRule(
+            "r", patterns=["*"], approved_by=[], mandatory_checks_name=None
+        )
+        with (
+            mock.patch(
+                "trymerge.find_matching_merge_rule",
+                return_value=(rule, [], [], {}),
+            ) as mock_fmmr,
+            mock.patch.object(pr, "merge_changes_locally", return_value=[]) as mock_mcl,
+            mock.patch("trymerge.can_skip_internal_checks", return_value=False),
+            mock.patch("trymerge.save_merge_record"),
+            mock.patch("trymerge.manually_close_merged_pr"),
+            mock.patch("trymerge.time.sleep"),
+        ):
+            pr.merge_into(repo, comment_id=1, dry_run=True, radar_approved=True)
+        self.assertTrue(mock_fmmr.call_args.kwargs["radar_approved"])
+        self.assertTrue(mock_mcl.call_args.kwargs["radar_approved"])
+
+
+@mock.patch("trymerge.gh_graphql", side_effect=mocked_gh_graphql)
+@mock.patch("trymerge.gh_fetch_merge_base", return_value="")
+@mock.patch(
+    "trymerge.get_drci_classifications", side_effect=mocked_drci_classifications
+)
+class TestRadarMergeLoop(TestCase):
+    # Exercises the real trymerge.merge() wait loop to prove RADAR authorization
+    # is RE-EVALUATED every iteration, so an approval withdrawn mid-merge (on an
+    # unchanged head SHA) aborts the merge instead of landing.
+    @mock.patch("trymerge.gh_add_labels")
+    @mock.patch("trymerge.post_starting_merge_comment")
+    @mock.patch("trymerge.has_required_labels", return_value=True)
+    @mock.patch("trymerge.check_for_sev")
+    @mock.patch.object(GitHubPR, "merge_into")
+    @mock.patch.object(GitHubPR, "is_ghstack_pr", return_value=False)
+    @mock.patch.object(GitHubPR, "get_labels", return_value=["merging"])
+    @mock.patch("trymerge.find_matching_merge_rule")
+    @mock.patch("trymerge.has_valid_radar_approval")
+    @mock.patch("trymerge.radar_merger_has_write", return_value=True)
+    def test_merge_aborts_when_radar_revoked_mid_wait(
+        self,
+        mock_merger_write: mock.MagicMock,
+        mock_has_approval: mock.MagicMock,
+        mock_fmmr: mock.MagicMock,
+        _mock_get_labels: mock.MagicMock,
+        _mock_is_ghstack: mock.MagicMock,
+        mock_merge_into: mock.MagicMock,
+        _mock_check_for_sev: mock.MagicMock,
+        _mock_has_required_labels: mock.MagicMock,
+        _mock_post_starting: mock.MagicMock,
+        _mock_add_labels: mock.MagicMock,
+        *args: Any,
+    ) -> None:
+        # Approval valid pre-loop then withdrawn (revoked) inside the loop on an
+        # unchanged SHA. The commenter write access is resolved ONCE; only the
+        # approval is re-read each iteration.
+        mock_has_approval.side_effect = [True, False]
+        rule = MergeRule(
+            "r", patterns=["*"], approved_by=[], mandatory_checks_name=None
+        )
+
+        def fmmr(pr: Any, repo: Any, **kwargs: Any) -> Any:
+            if not kwargs.get("radar_approved", False):
+                raise MergeRuleFailedError(f"PR #{pr.pr_num} has not been reviewed yet")
+            return (rule, [], [], {})
+
+        mock_fmmr.side_effect = fmmr
+        pr = GitHubPR("pytorch", "pytorch", 115495)
+        repo = DummyGitRepo()
+
+        with self.assertRaisesRegex(MergeRuleFailedError, "has not been reviewed yet"):
+            merge(pr, repo, comment_id=1, dry_run=True)
+
+        # The approval was re-read in the loop (2 calls) and once it went False the
+        # merge aborted; the commenter permission was fetched ONCE (not per
+        # iteration), so a transient permission blip cannot abort a valid merge.
+        self.assertEqual(mock_has_approval.call_count, 2)
+        self.assertEqual(mock_merger_write.call_count, 1)
+        mock_merge_into.assert_not_called()
 
 
 @mock.patch("trymerge.gh_graphql", side_effect=mocked_gh_graphql)

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -19,6 +19,7 @@ from warnings import warn
 import yaml
 from github_utils import (
     gh_close_pr,
+    gh_fetch_json_dict,
     gh_fetch_json_list,
     gh_fetch_merge_base,
     gh_fetch_url,
@@ -26,6 +27,7 @@ from github_utils import (
     gh_post_commit_comment,
     gh_post_pr_comment,
     gh_update_pr_state,
+    GITHUB_API_URL,
     GitHubComment,
 )
 from gitutils import (
@@ -41,6 +43,17 @@ from label_utils import (
     gh_remove_label,
     has_required_labels,
     LABEL_ERR_MSG,
+)
+from radar import (
+    files_allowlisted,
+    has_write_access,
+    is_low_risk,
+    is_trusted_radar_login,
+    iter_radar_markers,
+    iter_revoked_markers,
+    RADAR_APPROVAL_LOGIN,
+    verify_marker_sig,
+    verify_revoked_sig,
 )
 from trymerge_explainer import get_revert_message, TryMergeExplainer
 
@@ -1189,14 +1202,24 @@ class GitHubPR:
         ghstack_prs = get_ghstack_prs(
             repo, self, open_only=False
         )  # raises error if out of sync
+        # The merge command lives on the top PR, so establish the commenter's
+        # write access once and combine it with each stacked PR's own RADAR
+        # approval below.
+        merger_has_write = radar_merger_has_write(self, comment_id)
         pr_dependencies = []
         for pr, rev in ghstack_prs:
             if pr.is_closed():
                 pr_dependencies.append(pr)
                 continue
 
+            # Each stacked PR carries its own RADAR approval; combine it with the
+            # commenter's write access so both the rule check and the commit-message
+            # attribution reflect this PR's actual authorization.
+            pr_radar_approved = merger_has_write and has_valid_radar_approval(pr)
             commit_msg = pr.gen_commit_message(
-                filter_ghstack=True, ghstack_deps=pr_dependencies
+                filter_ghstack=True,
+                ghstack_deps=pr_dependencies,
+                radar_approved=pr_radar_approved,
             )
             if pr.pr_num != self.pr_num and not skip_all_rule_checks:
                 try:
@@ -1205,6 +1228,7 @@ class GitHubPR:
                         repo,
                         skip_mandatory_checks=skip_mandatory_checks,
                         skip_internal_checks=can_skip_internal_checks(self, comment_id),
+                        radar_approved=pr_radar_approved,
                     )
                 except MergeRuleFailedError as ex:
                     raise type(ex)(
@@ -1220,13 +1244,23 @@ class GitHubPR:
         self,
         filter_ghstack: bool = False,
         ghstack_deps: list[GitHubPR] | None = None,
+        radar_approved: bool = False,
     ) -> str:
         """Fetches title and body from PR description
         adds reviewed by, pull request resolved and optionally
         filters out ghstack info"""
         # Adding the url here makes it clickable within the Github UI
+        approvers = self.get_approved_by()
+        if radar_approved and RADAR_APPROVAL_LOGIN not in approvers:
+            # A valid RADAR approval was applied to this merge: record it (in
+            # addition to any human reviewers) so the landing stays greppable as a
+            # RADAR auto-approval. This intentionally over-reports -- it also tags
+            # the rare case where a qualifying human review was independently
+            # present -- which is the safe direction: it never omits a merge whose
+            # human-approval gate was actually satisfied by RADAR.
+            approvers = [*approvers, RADAR_APPROVAL_LOGIN]
         approved_by_urls = ", ".join(
-            prefix_with_github_url(login) for login in self.get_approved_by()
+            prefix_with_github_url(login) for login in approvers
         )
         # Remove "cc: " line from the message body
         msg_body = re.sub(RE_PR_CC_LINE, "", self.get_body())
@@ -1272,6 +1306,7 @@ class GitHubPR:
         dry_run: bool = False,
         comment_id: int,
         ignore_current_checks: list[str] | None = None,
+        radar_approved: bool = False,
     ) -> None:
         # Raises exception if matching rule is not found
         (
@@ -1285,9 +1320,10 @@ class GitHubPR:
             skip_mandatory_checks=skip_mandatory_checks,
             skip_internal_checks=can_skip_internal_checks(self, comment_id),
             ignore_current_checks=ignore_current_checks,
+            radar_approved=radar_approved,
         )
         additional_merged_prs = self.merge_changes_locally(
-            repo, skip_mandatory_checks, comment_id
+            repo, skip_mandatory_checks, comment_id, radar_approved=radar_approved
         )
 
         repo.push(self.default_branch(), dry_run)
@@ -1343,6 +1379,7 @@ class GitHubPR:
         comment_id: int | None = None,
         branch: str | None = None,
         skip_all_rule_checks: bool = False,
+        radar_approved: bool = False,
     ) -> list[GitHubPR]:
         """
         :param skip_all_rule_checks: If true, skips all rule checks on ghstack PRs, useful for dry-running merge locally
@@ -1352,7 +1389,9 @@ class GitHubPR:
             repo.checkout(branch_to_merge_into)
 
         # It's okay to skip the commit SHA check for ghstack PRs since
-        # authoring requires write access to the repo.
+        # authoring requires write access to the repo. The ghstack path computes
+        # each stacked PR's own RADAR attribution, so radar_approved (the top
+        # PR's decision) is only used for the single-PR commit message below.
         if self.is_ghstack_pr():
             return self.merge_ghstack_into(
                 repo,
@@ -1361,7 +1400,7 @@ class GitHubPR:
                 skip_all_rule_checks=skip_all_rule_checks,
             )
 
-        msg = self.gen_commit_message()
+        msg = self.gen_commit_message(radar_approved=radar_approved)
         pr_branch_name = f"__pull-request-{self.pr_num}__init__"
 
         # Determine which commit SHA to merge
@@ -1480,12 +1519,108 @@ def _find_non_matching_files(patterns: list[str], files: list[str]) -> list[str]
     ]
 
 
+def has_valid_radar_approval(pr: GitHubPR) -> bool:
+    """Return whether this PR carries a valid RADAR auto-approval.
+
+    A valid approval is a comment carrying a RADAR marker that (1) is authored
+    by a trusted RADAR bot login and unedited, (2) has a valid HMAC signature
+    over (repo, pr, head sha, score, tier), (3) matches the current head commit,
+    and (4) is still within the auto-approve risk threshold. The HMAC -- not the
+    login or the label -- is the trust anchor: it cannot be forged without the
+    shared secret, so reflected attacker text under a bot login does not
+    validate. The SHA binding prevents a stale approval from applying after a
+    new push.
+
+    The NEWEST trusted RADAR decision for the current head wins: a signed
+    revocation (RADAR-REVOKED) for the head SHA invalidates an older approval.
+    This makes withdrawal fail-closed even when deleting the prior approval
+    comment failed (deletion is best-effort), and forgery is impossible either
+    direction because both markers are HMAC-signed. A revocation is honored even
+    from an EDITED comment: it is deny-only, so trusting an edited revocation can
+    only fail closed (never grant), which closes the hole where editing the
+    revocation comment would otherwise resurrect a stale approval. An approval,
+    by contrast, must come from an unedited comment.
+
+    As defense in depth against a leaked key or a radar.py bug, this also
+    re-enforces the changed-files allowlist here, so RADAR can never substitute
+    for review on a file outside the allowlist (which keeps domain-specific
+    reviewer requirements in force for real source changes).
+    """
+    if not files_allowlisted(pr.get_changed_files()):
+        return False
+    head_sha = pr.last_commit_sha()
+    for comment in reversed(pr.get_comments()):
+        if not is_trusted_radar_login(comment.author_login):
+            continue
+        body = comment.body_text
+        # Revocation is checked BEFORE the edited-comment skip: it is HMAC-signed
+        # and deny-only, so honoring it even when edited stays fail-safe.
+        if any(
+            rev.sha == head_sha
+            and verify_revoked_sig(rev, pr.org, pr.project, pr.pr_num)
+            for rev in iter_revoked_markers(body)
+        ):
+            return False
+        # An approval, unlike a revocation, must come from an unedited comment.
+        if comment.editor_login is not None:
+            continue
+        # Scan every marker in the comment: a marker-shaped string in the
+        # AI-authored summary/reasoning must not shadow the genuine signed one.
+        for marker in iter_radar_markers(body):
+            if marker.sha != head_sha:
+                continue
+            if not verify_marker_sig(marker, pr.org, pr.project, pr.pr_num):
+                continue
+            if not is_low_risk(marker.tier, marker.score):
+                continue
+            return True
+    return False
+
+
+def _radar_commenter_repo_permission(pr: GitHubPR, login: str) -> str:
+    # The commenter's REAL repository permission (admin/write/read/none/...), the
+    # same source claude-radar.yml uses to gate the PR author, so the verifier's
+    # person-gate is exactly as strong as the signer's author-gate. Fails closed
+    # to "none" on any error (unknown collaborator 404s, API failure).
+    try:
+        resp = gh_fetch_json_dict(
+            f"{GITHUB_API_URL}/repos/{pr.org}/{pr.project}/collaborators/{login}/permission"
+        )
+    except Exception as e:
+        print(f"Could not fetch repo permission for {login} (treating as none): {e}")
+        return "none"
+    return str(resp.get("permission", "none"))
+
+
+def radar_merger_has_write(pr: GitHubPR, comment_id: int | None) -> bool:
+    """Return whether the `@pytorchbot merge` commenter has repo WRITE access.
+
+    This is the person half of RADAR authorization, kept separate from the
+    per-PR approval so it can be reused across a ghstack (the merge command
+    lives on the top PR, but each stacked PR needs its own RADAR approval).
+
+    It resolves the commenter's actual repository permission via the same
+    collaborators-permission API that claude-radar.yml uses to gate the PR
+    author, so the person-gate that substitutes for human review is exactly as
+    strong as the signer's author-gate -- not merely an org-membership/author
+    -association check (a MEMBER or COLLABORATOR can be read/triage-only). Fails
+    closed on a missing comment id, an edited comment, or a non-write permission.
+    """
+    if comment_id is None:
+        return False
+    comment = pr.get_comment_by_id(comment_id)
+    if comment.editor_login is not None:
+        return False
+    return has_write_access(_radar_commenter_repo_permission(pr, comment.author_login))
+
+
 def find_matching_merge_rule(
     pr: GitHubPR,
     repo: GitRepo | None = None,
     skip_mandatory_checks: bool = False,
     skip_internal_checks: bool = False,
     ignore_current_checks: list[str] | None = None,
+    radar_approved: bool = False,
 ) -> tuple[
     MergeRule,
     list[tuple[str, str | None, int | None]],
@@ -1554,8 +1689,10 @@ def find_matching_merge_rule(
                 )
             continue
 
-        # If rule needs approvers but PR has not been reviewed, skip it
-        if len(rule.approved_by) > 0 and len(approved_by) == 0:
+        # If rule needs approvers but PR has not been reviewed, skip it.
+        # A valid RADAR auto-approval substitutes for the human review here;
+        # mandatory checks below are still enforced.
+        if len(rule.approved_by) > 0 and len(approved_by) == 0 and not radar_approved:
             if reject_reason_score < 10000:
                 reject_reason_score = 10000
                 reject_reason = f"PR #{pr.pr_num} has not been reviewed yet"
@@ -1571,7 +1708,11 @@ def find_matching_merge_rule(
                 rule_approvers.add(approver)
         approvers_intersection = approved_by.intersection(rule_approvers)
         # If rule requires approvers but they aren't the ones that reviewed PR
-        if len(approvers_intersection) == 0 and len(rule_approvers) > 0:
+        if (
+            len(approvers_intersection) == 0
+            and len(rule_approvers) > 0
+            and not radar_approved
+        ):
             # Less than or equal is intentionally used here to gather all potential
             # approvers
             if reject_reason_score <= 10000:
@@ -2412,8 +2553,21 @@ def merge(
             comment_id=comment_id,
         )
 
+    # A valid RADAR auto-approval, combined with the merge command coming from a
+    # user with write access, lets a low-risk PR skip the human-approval gate. The
+    # commenter's write access does not change during the merge, so resolve it ONCE
+    # (a network call) and reuse it below; only the network-free RADAR approval is
+    # re-read each iteration, so a transient permission-API blip can never
+    # spuriously abort a valid RADAR merge with a misleading "not reviewed" reason.
+    radar_merger_write = radar_merger_has_write(pr, comment_id)
+    radar_approved = radar_merger_write and has_valid_radar_approval(pr)
+    if radar_approved:
+        print(f"RADAR auto-approval accepted for PR #{pr.pr_num}")
+
     # Check for approvals
-    find_matching_merge_rule(pr, repo, skip_mandatory_checks=True)
+    find_matching_merge_rule(
+        pr, repo, skip_mandatory_checks=True, radar_approved=radar_approved
+    )
 
     if not has_required_labels(pr):
         raise RuntimeError(LABEL_ERR_MSG.lstrip(" #"))
@@ -2453,13 +2607,26 @@ def merge(
             raise RuntimeError(
                 "New commits were pushed while merging. Please rerun the merge command."
             )
+        # Re-read the RADAR approval on the refetched PR each iteration (reusing
+        # the once-resolved commenter write access), mirroring how human approvals
+        # are re-read inside find_matching_merge_rule. A RADAR approval can be
+        # withdrawn on an unchanged head SHA (a re-run of the RADAR workflow posts a
+        # signed RADAR-REVOKED marker, which has_valid_radar_approval honors as the
+        # newest decision), which the new-commits guard above would not catch;
+        # recomputing here stops an in-flight merge whose approval was withdrawn
+        # mid-wait. trymerge never reads the radar-approved label -- only the signed
+        # markers.
+        radar_approved = radar_merger_write and has_valid_radar_approval(pr)
         try:
             required_checks = []
             failed_rule_message = None
             ignore_flaky_failures = True
             try:
                 find_matching_merge_rule(
-                    pr, repo, ignore_current_checks=ignore_current_checks
+                    pr,
+                    repo,
+                    ignore_current_checks=ignore_current_checks,
+                    radar_approved=radar_approved,
                 )
             except MandatoryChecksMissingError as ex:
                 if ex.rule is not None:
@@ -2513,6 +2680,7 @@ def merge(
                 skip_mandatory_checks=skip_mandatory_checks,
                 comment_id=comment_id,
                 ignore_current_checks=ignore_current_checks,
+                radar_approved=radar_approved,
             )
         except MandatoryChecksMissingError as ex:
             last_exception = str(ex)

--- a/.github/workflows/claude-radar.yml
+++ b/.github/workflows/claude-radar.yml
@@ -1,0 +1,269 @@
+# Owner(s): ["module: ci"]
+name: Claude RADAR
+
+# RADAR runs an AI risk assessment on a PR. When the change is low-risk and the
+# author has write access, it posts an approval comment carrying a marker bound
+# to the head SHA (see .github/scripts/radar.py), which lets a maintainer land
+# the PR with `@pytorchbot merge` without a separate human review.
+#
+# This runs as pull_request_target so it can comment on fork PRs, but it never
+# checks out or executes head code: it only checks out the trusted base for
+# context and reasons over the PR diff passed as text. The AI is limited to
+# read-only tools (no Bash / no network) for that reason.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to assess"
+        required: true
+        type: string
+
+concurrency:
+  group: claude-radar-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  assess:
+    if: github.repository == 'pytorch/pytorch'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    environment: bedrock
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+
+    steps:
+      - name: Resolve PR metadata
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Pass event data via env, never interpolated into the script, so a
+          # crafted workflow_dispatch input cannot inject shell.
+          EVENT_NAME: ${{ github.event_name }}
+          REPO: ${{ github.repository }}
+          DISPATCH_PR_NUMBER: ${{ github.event.inputs.pr_number }}
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT_SHA: ${{ github.event.pull_request.head.sha }}
+          EVENT_AUTHOR: ${{ github.event.pull_request.user.login }}
+          EVENT_DRAFT: ${{ github.event.pull_request.draft }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            PR_NUM="$DISPATCH_PR_NUMBER"
+            # Reject anything that is not a bare PR number before it reaches gh.
+            if ! [[ "$PR_NUM" =~ ^[0-9]+$ ]]; then
+              echo "Invalid pr_number input: $PR_NUM" >&2
+              exit 1
+            fi
+            META=$(gh pr view "$PR_NUM" --repo "$REPO" \
+              --json headRefOid,author,isDraft)
+            SHA=$(echo "$META" | jq -r '.headRefOid')
+            AUTHOR=$(echo "$META" | jq -r '.author.login')
+            DRAFT=$(echo "$META" | jq -r '.isDraft')
+          else
+            PR_NUM="$EVENT_PR_NUMBER"
+            SHA="$EVENT_SHA"
+            AUTHOR="$EVENT_AUTHOR"
+            DRAFT="$EVENT_DRAFT"
+          fi
+          {
+            echo "pr_num=$PR_NUM"
+            echo "sha=$SHA"
+            echo "author=$AUTHOR"
+            echo "draft=$DRAFT"
+          } >> "$GITHUB_OUTPUT"
+          echo "Resolved PR #$PR_NUM sha=$SHA author=$AUTHOR draft=$DRAFT"
+
+      - name: Check author write access
+        id: perm
+        if: steps.pr.outputs.draft != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          AUTHOR: ${{ steps.pr.outputs.author }}
+        run: |
+          set -euo pipefail
+          # RADAR only assesses maintainer-authored PRs, which bounds AI cost and
+          # matches the "maintainers can land low-risk PRs" goal.
+          PERM=$(gh api \
+            "repos/${REPO}/collaborators/${AUTHOR}/permission" \
+            --jq '.permission' 2>/dev/null || echo "none")
+          echo "permission=$PERM" >> "$GITHUB_OUTPUT"
+          case "$PERM" in
+            admin|maintain|write) echo "has_write=true" >> "$GITHUB_OUTPUT" ;;
+            *) echo "has_write=false" >> "$GITHUB_OUTPUT" ;;
+          esac
+          echo "Author ${AUTHOR} permission: $PERM"
+
+      - name: Checkout base for context
+        if: steps.perm.outputs.has_write == 'true'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.base.sha || 'main' }}
+          fetch-depth: 1
+
+      - name: Collect PR diff and metadata
+        id: collect
+        if: steps.perm.outputs.has_write == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUM: ${{ steps.pr.outputs.pr_num }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/radar
+          # changedFiles is the authoritative (never-truncated) file count; radar.py
+          # fails closed unless it matches the `files` list, which `gh pr view`
+          # caps at 100 entries. Without it a >100-file PR could hide a
+          # non-allowlisted file past the cap.
+          gh pr view "$PR_NUM" --repo "$REPO" \
+            --json title,body,files,changedFiles,additions,deletions,labels \
+            > /tmp/radar/meta.json
+          # Cap the diff so an enormous PR cannot blow the prompt budget. Write
+          # the full diff to a file first, then `head -c` the file (do NOT pipe gh
+          # into head: head closes the pipe early and gh dies with SIGPIPE). No
+          # `|| true` here: a real `gh pr diff` failure must abort the step so that
+          # (via the has_write step guard) the decision step is skipped, i.e. RADAR
+          # fails closed rather than scoring a diff the AI never saw. When the diff
+          # is truncated the AI is not seeing the whole change, so append a visible
+          # sentinel banner and mark truncated=true; radar.py independently refuses
+          # to approve a truncated diff via --diff-truncated, so correctness does
+          # not depend on the model heeding the banner.
+          CAP=200000
+          gh pr diff "$PR_NUM" --repo "$REPO" > /tmp/radar/diff.full
+          FULL_BYTES=$(wc -c < /tmp/radar/diff.full)
+          head -c "$CAP" /tmp/radar/diff.full > /tmp/radar/diff.patch
+          rm -f /tmp/radar/diff.full
+          # A change with reported line edits but an empty diff means the fetch
+          # produced nothing usable; treat that as truncated (fail closed) too.
+          CHANGED_LINES=$(jq -r '(.additions // 0) + (.deletions // 0)' /tmp/radar/meta.json)
+          if [ "$FULL_BYTES" -gt "$CAP" ] || { [ "$FULL_BYTES" -eq 0 ] && [ "$CHANGED_LINES" -gt 0 ]; }; then
+            {
+              printf '\n\n=== RADAR NOTICE: DIFF TRUNCATED OR UNAVAILABLE ===\n'
+              printf 'Only %s of %s bytes are shown. You are NOT seeing the whole\n' "$CAP" "$FULL_BYTES"
+              printf 'change; a change you cannot fully review is never trivial.\n'
+              printf 'Score it medium or higher.\n'
+              printf '=== END RADAR NOTICE ===\n'
+            } >> /tmp/radar/diff.patch
+            echo "truncated=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "truncated=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Collected $(wc -c < /tmp/radar/diff.patch) bytes of diff (full=${FULL_BYTES}, cap=${CAP})"
+
+      - name: Configure AWS credentials via OIDC
+        if: steps.perm.outputs.has_write == 'true'
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_claude_code
+          aws-region: us-east-1
+
+      - name: Run RADAR risk assessment
+        id: claude
+        if: steps.perm.outputs.has_write == 'true'
+        uses: anthropics/claude-code-action@6e2bd52842c65e914eba5c8badd17560bd26b5de # v1.0.89
+        with:
+          use_bedrock: "true"
+          claude_args: |
+            --model global.anthropic.claude-opus-4-6-v1
+            --allowedTools "Read,Grep,Glob"
+            --json-schema '{"type":"object","required":["risk_score","risk_tier","summary","reasoning"],"properties":{"risk_score":{"type":"integer","minimum":0,"maximum":100,"description":"0 = trivially safe, 100 = extremely risky"},"risk_tier":{"type":"string","enum":["trivial","low","medium","high"]},"summary":{"type":"string","description":"1-2 sentence summary of the change and its risk"},"reasoning":{"type":"string","description":"Detailed risk reasoning: what could break, blast radius, test coverage"}}}'
+          settings: '{"alwaysThinkingEnabled": true}'
+          prompt: |
+            You are RADAR, a strict risk assessor for PyTorch pull requests. Your
+            job is to score how risky it would be to land this PR WITHOUT any
+            human review. Be conservative: when in doubt, score higher.
+
+            You may Read/Grep/Glob the checked-out base repository for context.
+            You do NOT have Bash or network access.
+
+            The PR metadata (title, body, changed files, line counts, labels) is
+            in /tmp/radar/meta.json and the full diff is in /tmp/radar/diff.patch.
+            Read both files first, then reason over them.
+
+            ## Scoring rubric
+
+            - **trivial (score 0-10)**: mechanical, self-contained, low blast
+              radius. Examples: typo/comment/docstring fixes, test-only changes,
+              adding a filter to a test, tightening a type annotation, a small
+              obviously-correct one-liner in a well-covered path. The change is
+              easy to fully understand from the diff alone and hard to get wrong.
+            - **low (11-30)**: small, localized logic change in a well-tested
+              area with clear intent.
+            - **medium (31-70)**: non-trivial logic, touches shared code paths,
+              public API, build/CI config, or has meaningful blast radius.
+            - **high (71-100)**: risky or wide-reaching: core dispatch, autograd,
+              memory/threading, security-sensitive code, codegen, ABI, anything
+              you cannot fully reason about from the diff, or anything lacking
+              test coverage for the changed behavior.
+
+            ## Rules
+
+            - Only assign **trivial** when you are confident the change is safe to
+              land unreviewed. Any uncertainty, missing test coverage for changed
+              behavior, or non-local blast radius means at least **medium**.
+            - Changes to core runtime (aten/, c10/, torch/csrc/, autograd,
+              dispatcher), build system, CI workflows, or anything touching
+              serialization/ABI/security should never be **trivial**.
+            - A large diff, or one you cannot fully understand from the patch, is
+              never **trivial**.
+            - The line counts in meta.json (`additions`, `deletions`) are
+              authoritative and never truncated. If their sum is more than a few
+              hundred lines, or /tmp/radar/diff.patch ends with a "RADAR NOTICE:
+              DIFF TRUNCATED" banner, you are NOT seeing the whole change and must
+              never score it trivial (medium or higher).
+            - Score the change on its own merits; do not consider who the author
+              is or what happens with your score.
+
+            Read /tmp/radar/meta.json and /tmp/radar/diff.patch, investigate the
+            base repo as needed, then return your structured verdict.
+
+      - name: Save verdict
+        id: verdict
+        if: steps.perm.outputs.has_write == 'true' && steps.claude.outputs.structured_output != ''
+        env:
+          VERDICT_JSON: ${{ steps.claude.outputs.structured_output }}
+        run: |
+          set -euo pipefail
+          printf '%s' "$VERDICT_JSON" > /tmp/radar/verdict.json
+          cat /tmp/radar/verdict.json
+          echo "written=true" >> "$GITHUB_OUTPUT"
+
+      - name: Evaluate and post RADAR decision
+        if: steps.verdict.outputs.written == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Shared secret used to sign the approval marker; the same secret must
+          # be configured for the mergebot environment so trymerge can verify.
+          # When absent, radar.py refuses to approve (fail closed). The score
+          # ceiling, approved tiers, and the file allow/deny policy are hardcoded
+          # constants in radar.py (imported by trymerge), so nothing else needs
+          # mirroring between the signer and verifier.
+          RADAR_HMAC_KEY: ${{ secrets.RADAR_HMAC_KEY }}
+        run: |
+          set -euo pipefail
+          # Pass --diff-truncated via a bash array so the flag is cleanly absent
+          # (not an empty positional arg) when the diff was not truncated.
+          EXTRA=()
+          if [ "${{ steps.collect.outputs.truncated }}" = "true" ]; then
+            EXTRA+=(--diff-truncated)
+          fi
+          python3 .github/scripts/radar.py \
+            --pr-num "${{ steps.pr.outputs.pr_num }}" \
+            --sha "${{ steps.pr.outputs.sha }}" \
+            --org "${{ github.repository_owner }}" \
+            --project "${{ github.event.repository.name }}" \
+            --verdict-file /tmp/radar/verdict.json \
+            --meta-file /tmp/radar/meta.json \
+            --author-permission "${{ steps.perm.outputs.permission }}" \
+            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            "${EXTRA[@]}"
+
+      - name: Upload usage metrics
+        if: always()
+        uses: pytorch/test-infra/.github/actions/upload-claude-usage@main

--- a/.github/workflows/trymerge.yml
+++ b/.github/workflows/trymerge.yml
@@ -47,6 +47,13 @@ jobs:
           DRCI_BOT_KEY: ${{ secrets.DRCI_BOT_KEY }}
           GITHUB_RUN_ID: ${{ github.run_id }}
           HUD_API_TOKEN: ${{ secrets.HUD_API_TOKEN }}
+          # Shared secret used to verify RADAR approval-marker signatures. Must
+          # match the key the RADAR (bedrock) workflow signs with. When absent,
+          # trymerge treats every RADAR marker as invalid (fail closed). Only the
+          # HMAC secret is mirrored here: the score ceiling, tiers, and file
+          # allow/deny policy are hardcoded in radar.py (imported by trymerge), so
+          # they cannot drift from the RADAR signer workflow.
+          RADAR_HMAC_KEY: ${{ secrets.RADAR_HMAC_KEY }}
         run: |
           set -x
           if [ -n "${REBASE}" ]; then


### PR DESCRIPTION
## Summary

[human note] putting this up for review/discussion. This is the first time I've made CI related changes, so if anyone can point me to canary/testing runbooks, please do!

RADAR lets a maintainer land a sufficiently **low-risk** PR with `@pytorchbot merge` **without a separate human approval**. An AI assesses the change's risk; if it is low enough, **every changed file is inside a conservative path allowlist** (and none executes in CI), **the change is small and fully visible to the assessor**, **and both the PR author and the `@pytorchbot merge` commenter have repository write access**, a bot posts a **signed** approval comment and the merge bot treats that as satisfying the human-review requirement. **Mandatory CI checks are still fully enforced.**

The intent is to remove the human round-trip on changes that are genuinely trivial to review (test-only tweaks, typo/docstring fixes), while keeping the bar strict. A change auto-approves only when **all** of these hold:

- the AI verdict is the `trivial` tier with score <= 10;
- every changed file is under `test/`, `docs/`, or `benchmarks/`, or is a Markdown (`*.md`) file, **and** none is a file that executes in CI (`conftest.py`, `run_test.py`, `pytest.ini`, the Sphinx `conf.py`, or a `Makefile`) — these run across the whole trunk/nightly suite or drive the docs build and have far larger blast radius than a single test or doc page;
- the total additions + deletions is <= 2000, the diff shown to the AI was not truncated, **and** the changed-file list returned by the GitHub API was not truncated (it caps at 100 files); and
- the PR author has repository write access.

## ⚠️ Manual next steps (required — RADAR is inert until these are done)

These cannot be done in-repo and must be performed manually before RADAR can approve anything:

1. **Provision the `RADAR_HMAC_KEY` secret in BOTH GitHub environments:**
   - `bedrock` (used by `claude-radar.yml`, which **signs** the approval/revocation markers)
   - `mergebot` (used by `trymerge.yml`, which **verifies** the signature)

   Use the same random high-entropy value in both (e.g. `openssl rand -hex 32`). This secret is the trust anchor for the whole feature. Until it exists in **both** environments, both sides **fail closed** — RADAR simply never approves, and `trymerge` never honors a marker. (An asymmetric setup — key in only one — also fails closed.)

2. **(Optional) Decide pilot rollout scope.** As written, RADAR runs on every maintainer-authored PR on open/update. To limit AI cost during a pilot, gate the workflow behind a label. The strictness knobs (`RADAR_MAX_SCORE`, `RADAR_APPROVED_TIERS`, the allow/deny globs, `RADAR_MAX_DIFF_LINES`) are **hardcoded constants** in `radar.py` — deliberately not env-overridable — so the signer and the `trymerge` verifier (which imports them) evaluate byte-identical policy. Change policy by editing those constants; only the `RADAR_HMAC_KEY` secret and a tighten-only `RADAR_DENYLIST_GLOBS` are env-configured.

3. **Drop the `[rfc]` prefix** from the PR title when we're ready to actually enable it.

## How it works, end to end

1. **`.github/scripts/radar.py`** is the decision brain and the shared marker format. When the verdict is low-risk, every changed file is allowlisted (and none denylisted), the change is within the size cap, the diff and file list are complete, the author has write access, and a signing key is present, it posts an approval comment carrying a machine-readable, **HMAC-signed**, head-SHA-bound marker (`RADAR-APPROVED sha=<head-sha> score=N tier=T sig=<hmac>`) and adds a `radar-approved` label. Otherwise it **withdraws** any prior approval: it posts a signed `RADAR-REVOKED` marker bound to the head SHA (so withdrawal is fail-closed even if deleting the stale approval comment fails) and clears the label.

2. **`.github/scripts/trymerge.py`** detects a valid RADAR approval and, combined with the `@pytorchbot merge` commenter having repository write access, bypasses **only** the human-approval gate in `find_matching_merge_rule`. All other gating (file-pattern matching, mandatory checks, internal-changes checks) is unchanged. `has_valid_radar_approval` honors the **newest** trusted RADAR decision for the current head (a signed revocation invalidates an older approval), and re-validates on every merge-wait iteration, so an approval withdrawn mid-merge (on an unchanged head SHA) stops the merge, exactly as a dismissed human review would.

3. **`.github/workflows/claude-radar.yml`** runs on `pull_request_target`. It early-exits unless the PR author has write access, then runs an AI risk assessment on Bedrock via `claude-code-action` with a JSON schema, mirroring `claude-autorevert-advisor.yml`. It **never checks out or executes head code**: it checks out only the trusted base for context and passes the diff as text, and the model is restricted to read-only tools (`Read`/`Grep`/`Glob`). If the diff exceeds the prompt cap it is truncated with a visible sentinel banner and the run is flagged so it cannot auto-approve.

## Security model

- **The trust anchor is an HMAC signature over the marker fields**, not the comment author or the label. Without the shared `RADAR_HMAC_KEY` a marker cannot be forged for any PR/SHA, so even reflected attacker text under a bot login does not validate. Both the approval marker (over `repo, pr, head sha, score, tier`) and the revocation marker (over `repo, pr, head sha`, in a distinct namespace) are signed, so forgery is impossible in either direction; a revocation can only ever **deny**, never grant. `trymerge` independently re-checks the signature, the score/tier threshold, and the file allow/deny list (defense in depth against a leaked key or a `radar.py` bug).
- **Signer and verifier are provably in sync.** The score ceiling, approved tiers, and the file allow/deny globs are hardcoded constants in `radar.py`, which `trymerge` imports — there is no env-driven divergence. The only env values are the `RADAR_HMAC_KEY` secret and a **tighten-only** `RADAR_DENYLIST_GLOBS` (it can only add to the hardcoded denylist floor), both of which fail closed under any single-side divergence.
- **The marker is bound to the head SHA**, so pushing any new commit invalidates the approval and re-runs RADAR.
- **The person-gate is as strong as the author-gate.** `trymerge` resolves the `@pytorchbot merge` commenter's **real repository permission** via the same collaborators-permission API the workflow uses to gate the author — not merely an org-membership/author-association check (a `MEMBER` or `COLLABORATOR` can be read/triage-only) — and fails closed on any error.
- **The allow/deny list keeps domain-specific reviewers in force.** RADAR can only substitute for review on low-blast-radius paths; it never bypasses the FFT/Sparse/MPS/dispatch/etc. reviewer requirements for real source changes. `*.pyi.in` is excluded (it would admit the core `torch/_C/__init__.pyi.in` type surface), and files that execute in CI (e.g. `conftest.py`, `conf.py`, `Makefile`) are denylisted even under an allowlisted prefix.

## Attribution

A RADAR-authorized landing records `Approved by: https://github.com/pytorch-auto-radar` in the squashed commit trailer — a distinct, greppable pseudo-login (not the real `pytorch-bot` account), so RADAR landings are auditable via `git log --grep "Approved by:.*pytorch-auto-radar"`. It is threaded per-PR through both the single-PR and ghstack merge paths.

## Two design decisions worth calling out

- **The marker is plain visible text, not an HTML comment.** `trymerge` detects it from the GitHub GraphQL `bodyText`, which strips HTML comments — an invisible marker would never be seen (an earlier iteration hit exactly this). Revealing the marker is safe because the HMAC, not its invisibility, is what makes it unforgeable. This also avoids changing the comment GraphQL query, which would invalidate the recorded `gql_mocks` fixtures.
- **Detection scans every marker in a comment, not just the first**, so a marker-shaped string in the AI-authored summary/reasoning cannot shadow the genuine signed marker.

## Suggested review order

`radar.py` (marker + revocation format, signing, allow/deny list, size and file-completeness guards, approval/revocation decision) -> the `trymerge.py` hook (`has_valid_radar_approval` newest-decision-wins, `radar_merger_has_write` real-permission gate, the `radar_approved` threading through `find_matching_merge_rule` / `merge` / `merge_into` / `merge_ghstack_into`, and the commit-message attribution) -> the workflows -> the tests.

## ghstack

A multi-PR stack lands only if each un-landed PR carries its own valid RADAR approval (the workflow produces one per PR); `merge_ghstack_into` evaluates each stacked PR independently, combining the top-PR commenter's write access with each PR's own approval. A single PR works directly.

## Test Plan

Unit tests for marker/revocation parse-sign-verify, the allow/deny list (incl. CI-executing files under `docs/`), the size/truncation/file-completeness guards, the trust/staleness/spoofing/shadowing checks, the newest-decision-wins revocation logic (including honoring an edited revocation but not an edited approval), the real-permission merger gate (read/none/edited/404 fail-closed), the `find_matching_merge_rule` bypass (approval gate bypassed but mandatory checks still enforced for both failing and pending checks), the `radar.py` decision matrix, the `merge()` wait-loop mid-merge revocation abort (commenter permission fetched once, approval re-read each iteration), per-PR ghstack authorization, and the commit-message attribution:

```
cd .github/scripts
python -m pytest test_radar.py -q --noconftest
python -m pytest test_trymerge.py -q --noconftest
```

`radar.py` CLI exercised in dry-run (approves only when trivial + allowlisted + not denylisted + within the size cap + untruncated + complete file list + write access + a signing key is present):

```
echo '{"risk_score":5,"risk_tier":"trivial","summary":"Test-only.","reasoning":"No runtime."}' \
  > /tmp/v.json
echo '{"files":[{"path":"test/test_foo.py"}],"changedFiles":1,"additions":10,"deletions":2}' \
  > /tmp/m.json
RADAR_HMAC_KEY=demo-key python3 .github/scripts/radar.py --pr-num 189883 \
  --sha cccccccccccccccccccccccccccccccccccccccc \
  --verdict-file /tmp/v.json --meta-file /tmp/m.json \
  --author-permission write --dry-run
```

Workflows linted with actionlint:

```
lintrunner --take ACTIONLINT .github/workflows/claude-radar.yml .github/workflows/trymerge.yml
```

Authored with an AI assistant.
