### PR TITLE
Stop recording ordinary Function output_info eagerly

### DIFF
--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -512,6 +512,10 @@ PyObject* PyNode::to_py_args(
     pybind11::gil_scoped_release gil;
     return variable.zeros(dg);
   };
+  auto metadata_zeros_without_gil = [](const InputMetadata& metadata) {
+    pybind11::gil_scoped_release gil;
+    return metadata.zeros_like();
+  };
 
   auto num_inputs = inputs.size();
   THPObjectPtr pyInputs(PyTuple_New(static_cast<Py_ssize_t>(num_inputs)));
@@ -524,6 +528,13 @@ PyObject* PyNode::to_py_args(
         (input_metadata(i).was_default_constructed() &&
          !py_fn->materialize_non_diff_grads)) {
       input = THPVariable_Wrap(inputs[i]);
+    } else if (
+        output_info[i].is_empty &&
+        !input_metadata(i).was_default_constructed()) {
+      // The empty output_info entry is a placeholder for an ordinary
+      // differentiable output. The node's InputMetadata has the same
+      // shape/options data we need to materialize an undefined grad output.
+      input = THPVariable_Wrap(metadata_zeros_without_gil(input_metadata(i)));
     } else {
       input =
           THPVariable_Wrap(zeros_without_gil(output_info[i], *device_guard));
@@ -833,7 +844,15 @@ static void _wrap_outputs(
              isDifferentiableType(wrapped_output->scalar_type()));
         bool use_zeros_like =
             is_differentiable && num_outputs > 1 && wrapped_output->is_nested();
-        self->output_info.emplace_back(wrapped_output.value(), use_zeros_like);
+        if (is_differentiable && !use_zeros_like) {
+          // This slot is still positional, but for ordinary differentiable
+          // outputs we can use the node's InputMetadata later instead of
+          // copying duplicate VariableInfo here.
+          self->output_info.emplace_back();
+        } else {
+          self->output_info.emplace_back(
+              wrapped_output.value(), use_zeros_like);
+        }
       }
       PyTuple_SetItem(
           outputs, i, THPVariable_Wrap(std::move(wrapped_output.value())));


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189911
* #189901
* #189897
* #189866
* #189865
* #189810
* #189800
* #189788

Python custom Function apply recorded VariableInfo for every ordinary differentiable output, even though the node already records equivalent InputMetadata for those outputs. That copied metadata is only needed later if backward has to materialize a missing grad output.

Store an empty output_info entry for ordinary differentiable outputs and materialize missing backward grads from InputMetadata when needed. Keep the existing VariableInfo path for nested outputs, which still require zeros_like behavior.

On the local one-apply 13-in-2-out no-save instruction-count benchmark, this moved from 45,949 to 45,138 instructions. At the top of the stack, the compact 13-in-2-out benchmark measured 11.774 us mean / 11.648 us median for no-save and 13.595 us mean / 13.472 us median for save13; direct_zero was 3.229 us mean / 3.200 us median.

Authored with assistance from an AI assistant.