### PR TITLE
c10 macros: add C10_LIFETIMEBOUND

### DIFF
--- a/torch/headeronly/macros/Macros.h
+++ b/torch/headeronly/macros/Macros.h
@@ -123,6 +123,15 @@
 #define C10_HAS_CPP_ATTRIBUTE(x) (0)
 #endif
 
+/// Bind a returned reference/pointer's lifetime to a parameter (or *this) so
+/// Clang can warn when it would dangle. Expands to nothing on compilers that
+/// lack the attribute (e.g. non-clang, older nvcc).
+#if C10_HAS_CPP_ATTRIBUTE(clang::lifetimebound)
+#define C10_LIFETIMEBOUND [[clang::lifetimebound]]
+#else
+#define C10_LIFETIMEBOUND
+#endif
+
 #ifndef FBCODE_CAFFE2
 /// DEPRECATED: Warn if a type or return value is discarded.
 #define C10_NODISCARD [[nodiscard]]


### PR DESCRIPTION
Summary:
Add a C10_LIFETIMEBOUND macro that expands to [[clang::lifetimebound]] when the compiler supports it and to nothing otherwise (via C10_HAS_CPP_ATTRIBUTE). This lets c10/ATen headers - including headeronly and CUDA-device headers compiled by nvcc - annotate borrowing constructors and container accessors so Clang can diagnose dangling references at compile time, without breaking non-clang or older toolchains.

This is the base commit for a series that applies the annotation to the c10 view/borrow types (ArrayRef, OptionalArrayRef, MaybeOwned, TensorAccessor, TensorRef) and owning containers (SmallVector, SmallBuffer, ExclusivelyOwned).

Mirrored across the fbcode and xplat copies of the header.

Test Plan: Macro-only change; no behavior change on its own. Compiles as a no-op where the attribute is unavailable. Subsequent commits exercise it; local `arc lint` is clean.

Differential Revision: D111955729


