### PR TITLE
MTA now writes the same len of data as prescribed for complex

### DIFF
--- a/aten/src/ATen/native/cuda/MultiTensorApply.cuh
+++ b/aten/src/ATen/native/cuda/MultiTensorApply.cuh
@@ -27,23 +27,23 @@ static constexpr int64_t kBlockSize = 512;
 // TODO: The values for 32KB can very much be optimized further.
 #if defined(CUDART_VERSION) && CUDART_VERSION >= 13000 && !defined(USE_ROCM)
 
-static constexpr int depth_to_max_tensors[5] = {770, 448, 336, 252, 210};
-static constexpr int depth_to_max_blocks[5] = {2240, 2240, 2240, 2240, 2240};
-static constexpr int depth_to_max_tensors_scalarlist[5] =
+static constexpr int32_t depth_to_max_tensors[5] = {770, 448, 336, 252, 210};
+static constexpr int32_t depth_to_max_blocks[5] =
+    {2240, 2240, 2240, 2240, 2240};
+static constexpr int32_t depth_to_max_tensors_scalarlist[5] =
     {672, 448, 336, 252, 210};
-static constexpr int depth_to_max_tensors_scalarlist_of_complex_double[2] = {
-    504,
-    420};
+static constexpr int32_t depth_to_max_tensors_scalarlist_of_complex_double[2] =
+    {504, 420};
 using block_index_t = uint16_t;
 
 #else
 
-static constexpr int depth_to_max_tensors[5] = {110, 64, 48, 36, 30};
-static constexpr int depth_to_max_blocks[5] = {320, 320, 320, 320, 320};
-static constexpr int depth_to_max_tensors_scalarlist[5] = {96, 64, 48, 36, 30};
-static constexpr int depth_to_max_tensors_scalarlist_of_complex_double[2] = {
-    72,
-    60};
+static constexpr int32_t depth_to_max_tensors[5] = {110, 64, 48, 36, 30};
+static constexpr int32_t depth_to_max_blocks[5] = {320, 320, 320, 320, 320};
+static constexpr int32_t depth_to_max_tensors_scalarlist[5] =
+    {96, 64, 48, 36, 30};
+static constexpr int32_t depth_to_max_tensors_scalarlist_of_complex_double[2] =
+    {72, 60};
 using block_index_t = unsigned char;
 
 #endif
@@ -65,46 +65,56 @@ __device__ __forceinline__ void load_store(
 
 template <int n>
 struct TensorListMetadata {
-  const void* addresses[n][depth_to_max_tensors[n - 1]];
-  int64_t numel_for_tensor[depth_to_max_tensors[n - 1]];
-  block_index_t block_to_tensor[depth_to_max_blocks[n - 1]];
-  int block_to_chunk[depth_to_max_blocks[n - 1]];
-  int start_tensor_this_launch;
+  // Capacities of the per-tensor and per-block arrays below. multi_tensor_apply
+  // must launch before exceeding either, or it overflows the struct.
+  static constexpr int32_t max_tensors_per_launch = depth_to_max_tensors[n - 1];
+  static constexpr int32_t max_blocks_per_launch = depth_to_max_blocks[n - 1];
+  const void* addresses[n][max_tensors_per_launch];
+  int64_t numel_for_tensor[max_tensors_per_launch];
+  block_index_t block_to_tensor[max_blocks_per_launch];
+  int32_t block_to_chunk[max_blocks_per_launch];
+  int32_t start_tensor_this_launch;
 };
 
 template <typename scalar_vals_t, int n>
 struct TensorListScalarListMetadata {
-  const void* addresses[n][depth_to_max_tensors_scalarlist[n - 1]];
-  int64_t numel_for_tensor[depth_to_max_tensors_scalarlist[n - 1]];
-  scalar_vals_t scalar_vals[depth_to_max_tensors_scalarlist[n - 1]];
-  block_index_t block_to_tensor[depth_to_max_blocks[n - 1]];
-  int block_to_chunk[depth_to_max_blocks[n - 1]];
+  // Capacities of the per-tensor and per-block arrays below. multi_tensor_apply
+  // must launch before exceeding either, or it overflows the struct.
+  static constexpr int32_t max_tensors_per_launch =
+      depth_to_max_tensors_scalarlist[n - 1];
+  static constexpr int32_t max_blocks_per_launch = depth_to_max_blocks[n - 1];
+  const void* addresses[n][max_tensors_per_launch];
+  int64_t numel_for_tensor[max_tensors_per_launch];
+  scalar_vals_t scalar_vals[max_tensors_per_launch];
+  block_index_t block_to_tensor[max_blocks_per_launch];
+  int32_t block_to_chunk[max_blocks_per_launch];
 };
 
 // note(mkozuki): `n` of 1&2 violate the limit of cuda kernel argument size
-// with `c10::complex<double>`
+// with `c10::complex<double>`, so these specializations use the smaller
+// depth_to_max_tensors_scalarlist_of_complex_double capacity.
 template <>
 struct TensorListScalarListMetadata<c10::complex<double>, 1> {
-  const void* addresses[1]
-                       [depth_to_max_tensors_scalarlist_of_complex_double[0]];
-  int64_t
-      numel_for_tensor[depth_to_max_tensors_scalarlist_of_complex_double[0]];
-  c10::complex<double>
-      scalar_vals[depth_to_max_tensors_scalarlist_of_complex_double[0]];
-  block_index_t block_to_tensor[depth_to_max_blocks[1 - 1]];
-  int block_to_chunk[depth_to_max_blocks[1 - 1]];
+  static constexpr int32_t max_tensors_per_launch =
+      depth_to_max_tensors_scalarlist_of_complex_double[0];
+  static constexpr int32_t max_blocks_per_launch = depth_to_max_blocks[0];
+  const void* addresses[1][max_tensors_per_launch];
+  int64_t numel_for_tensor[max_tensors_per_launch];
+  c10::complex<double> scalar_vals[max_tensors_per_launch];
+  block_index_t block_to_tensor[max_blocks_per_launch];
+  int32_t block_to_chunk[max_blocks_per_launch];
 };
 
 template <>
 struct TensorListScalarListMetadata<c10::complex<double>, 2> {
-  const void* addresses[2]
-                       [depth_to_max_tensors_scalarlist_of_complex_double[1]];
-  int64_t
-      numel_for_tensor[depth_to_max_tensors_scalarlist_of_complex_double[1]];
-  c10::complex<double>
-      scalar_vals[depth_to_max_tensors_scalarlist_of_complex_double[1]];
-  block_index_t block_to_tensor[depth_to_max_blocks[2 - 1]];
-  int block_to_chunk[depth_to_max_blocks[2 - 1]];
+  static constexpr int32_t max_tensors_per_launch =
+      depth_to_max_tensors_scalarlist_of_complex_double[1];
+  static constexpr int32_t max_blocks_per_launch = depth_to_max_blocks[1];
+  const void* addresses[2][max_tensors_per_launch];
+  int64_t numel_for_tensor[max_tensors_per_launch];
+  c10::complex<double> scalar_vals[max_tensors_per_launch];
+  block_index_t block_to_tensor[max_blocks_per_launch];
+  int32_t block_to_chunk[max_blocks_per_launch];
 };
 
 // NOTE(crcrpar): This is a conservative resolution to handle `state_steps`
@@ -115,12 +125,16 @@ struct TensorListScalarListMetadata<c10::complex<double>, 2> {
 // concern (yet).
 template <int n>
 struct FusedOptimizerTensorListMetadata {
-  const void* addresses[n][depth_to_max_tensors[n - 1]];
-  int64_t numel_for_tensor[depth_to_max_tensors[n - 1]];
-  const void* state_steps_addresses[depth_to_max_tensors[n - 1]];
-  block_index_t block_to_tensor[depth_to_max_blocks[n - 1]];
-  int block_to_chunk[depth_to_max_blocks[n - 1]];
-  int start_tensor_this_launch;
+  // Capacities of the per-tensor and per-block arrays below. multi_tensor_apply
+  // must launch before exceeding either, or it overflows the struct.
+  static constexpr int32_t max_tensors_per_launch = depth_to_max_tensors[n - 1];
+  static constexpr int32_t max_blocks_per_launch = depth_to_max_blocks[n - 1];
+  const void* addresses[n][max_tensors_per_launch];
+  int64_t numel_for_tensor[max_tensors_per_launch];
+  const void* state_steps_addresses[max_tensors_per_launch];
+  block_index_t block_to_tensor[max_blocks_per_launch];
+  int32_t block_to_chunk[max_blocks_per_launch];
+  int32_t start_tensor_this_launch;
 };
 
 template <typename T, typename U, typename... ArgTypes>
@@ -167,7 +181,8 @@ void multi_tensor_apply(
       "Number of tensor lists has to match the depth.");
   const size_t n_tensors = tensor_lists[0].size();
   using scalar_vals_t = typename T::opmath_t;
-  TensorListScalarListMetadata<scalar_vals_t, depth> tensorListMeta;
+  using metadata_t = TensorListScalarListMetadata<scalar_vals_t, depth>;
+  metadata_t tensorListMeta;
 
   int loc_block_info = 0;
   int loc_tensor_info = 0;
@@ -199,12 +214,14 @@ void multi_tensor_apply(
       loc_block_info++;
 
       // a tensor is not considered full unless all its chunks have been
-      // processed
+      // processed. Use the metadata struct's own capacities: the
+      // c10::complex<double> specializations hold fewer tensors than
+      // depth_to_max_tensors_scalarlist to stay within the kernel arg limit.
       const bool tensors_full =
-          (loc_tensor_info == depth_to_max_tensors_scalarlist[depth - 1] &&
+          (loc_tensor_info == metadata_t::max_tensors_per_launch &&
            chunk == chunks - 1);
       const bool blocks_full =
-          (loc_block_info == depth_to_max_blocks[depth - 1]);
+          (loc_block_info == metadata_t::max_blocks_per_launch);
 
       if (tensors_full || blocks_full) {
         record_foreach_mta_launch();
@@ -259,7 +276,8 @@ void multi_tensor_apply(
       tensor_lists.size() == depth,
       "Number of tensor lists has to match the depth.");
   const size_t n_tensors = tensor_lists[0].size();
-  TensorListMetadata<depth> tensorListMeta;
+  using metadata_t = TensorListMetadata<depth>;
+  metadata_t tensorListMeta;
   tensorListMeta.start_tensor_this_launch = 0;
 
   int loc_block_info = 0;
@@ -289,10 +307,10 @@ void multi_tensor_apply(
       loc_block_info++;
 
       const bool tensors_full =
-          (loc_tensor_info == depth_to_max_tensors[depth - 1] &&
+          (loc_tensor_info == metadata_t::max_tensors_per_launch &&
            chunk == chunks - 1);
       const bool blocks_full =
-          (loc_block_info == depth_to_max_blocks[depth - 1]);
+          (loc_block_info == metadata_t::max_blocks_per_launch);
 
       if (tensors_full || blocks_full) {
         record_foreach_mta_launch();
@@ -345,7 +363,8 @@ void multi_tensor_apply_for_fused_optimizer(
       tensor_lists.size() == depth,
       "Number of tensor lists has to match the depth");
   const auto num_tensors = tensor_lists[0].size();
-  FusedOptimizerTensorListMetadata<depth> tensorListMeta;
+  using metadata_t = FusedOptimizerTensorListMetadata<depth>;
+  metadata_t tensorListMeta;
 
   int loc_block_info = 0;
   int loc_tensor_info = 0;
@@ -374,9 +393,10 @@ void multi_tensor_apply_for_fused_optimizer(
       loc_block_info++;
 
       const auto tensor_full =
-          (loc_tensor_info == depth_to_max_tensors[depth - 1] &&
+          (loc_tensor_info == metadata_t::max_tensors_per_launch &&
            chunk == chunks - 1);
-      const auto blocks_full = loc_block_info == depth_to_max_blocks[depth - 1];
+      const auto blocks_full =
+          loc_block_info == metadata_t::max_blocks_per_launch;
 
       if (tensor_full || blocks_full) {
         record_foreach_mta_launch();

--- a/aten/src/ATen/native/cuda/MultiTensorApply.cuh
+++ b/aten/src/ATen/native/cuda/MultiTensorApply.cuh
@@ -65,8 +65,6 @@ __device__ __forceinline__ void load_store(
 
 template <int n>
 struct TensorListMetadata {
-  // Capacities of the per-tensor and per-block arrays below. multi_tensor_apply
-  // must launch before exceeding either, or it overflows the struct.
   static constexpr int32_t max_tensors_per_launch = depth_to_max_tensors[n - 1];
   static constexpr int32_t max_blocks_per_launch = depth_to_max_blocks[n - 1];
   const void* addresses[n][max_tensors_per_launch];
@@ -78,8 +76,6 @@ struct TensorListMetadata {
 
 template <typename scalar_vals_t, int n>
 struct TensorListScalarListMetadata {
-  // Capacities of the per-tensor and per-block arrays below. multi_tensor_apply
-  // must launch before exceeding either, or it overflows the struct.
   static constexpr int32_t max_tensors_per_launch =
       depth_to_max_tensors_scalarlist[n - 1];
   static constexpr int32_t max_blocks_per_launch = depth_to_max_blocks[n - 1];
@@ -91,8 +87,7 @@ struct TensorListScalarListMetadata {
 };
 
 // note(mkozuki): `n` of 1&2 violate the limit of cuda kernel argument size
-// with `c10::complex<double>`, so these specializations use the smaller
-// depth_to_max_tensors_scalarlist_of_complex_double capacity.
+// with `c10::complex<double>`
 template <>
 struct TensorListScalarListMetadata<c10::complex<double>, 1> {
   static constexpr int32_t max_tensors_per_launch =
@@ -125,8 +120,6 @@ struct TensorListScalarListMetadata<c10::complex<double>, 2> {
 // concern (yet).
 template <int n>
 struct FusedOptimizerTensorListMetadata {
-  // Capacities of the per-tensor and per-block arrays below. multi_tensor_apply
-  // must launch before exceeding either, or it overflows the struct.
   static constexpr int32_t max_tensors_per_launch = depth_to_max_tensors[n - 1];
   static constexpr int32_t max_blocks_per_launch = depth_to_max_blocks[n - 1];
   const void* addresses[n][max_tensors_per_launch];

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -20,6 +20,7 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     largeTensorTest,
     onlyAccelerator,
+    onlyCUDA,
     OpDTypes,
     ops,
     skipXPU,
@@ -1122,6 +1123,29 @@ class TestForeach(TestCase):
             expect = ref_fn(inputs=[tensorlist], **kwargs)
 
             self.assertEqual(expect, actual, equal_nan=True)
+
+    @onlyCUDA
+    @dtypes(torch.complex128)
+    def test_foreach_scalarlist_complex_double_many_tensors(self, device, dtype):
+        # Prevent regressions for complex double MTA chunking, see #189827
+        N = 600
+        scalars = [i + 2.0 for i in range(N)]
+
+        def make_tensors():
+            return [
+                torch.full((1, 1, 1), i + 1, dtype=dtype, device=device)
+                for i in range(N)
+            ]
+
+        # out-of-place: depth 2
+        tensors = make_tensors()
+        expect = [t / s for t, s in zip(tensors, scalars)]
+        self.assertEqual(torch._foreach_div(tensors, scalars), expect)
+
+        # in-place: depth 1
+        tensors = make_tensors()
+        torch._foreach_div_(tensors, scalars)
+        self.assertEqual(tensors, expect)
 
     @onlyAccelerator
     @ops(foreach_reduce_op_db)


### PR DESCRIPTION
Fixes #189827 

I did also take the time to explicitize int -> int32.

Test plan:
1. Run the repro in the issue and ensured no more compute sanitizer errors.
2. Added an one-off unit test (testing foreach_div is sufficient, no need to test this for every TensorList/ScalarList op) similar to test_big_num_tensor and it passed locally
3. CI should be green

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #189915

