### PR TITLE
c10 SmallBuffer: add [[nodiscard]] to observer methods

### DIFF
--- a/c10/util/SmallBuffer.h
+++ b/c10/util/SmallBuffer.h
@@ -55,31 +55,31 @@ class SmallBuffer {
       delete[] data_;
     }
   }
-  T& operator[](size_t idx) {
+  [[nodiscard]] T& operator[](size_t idx) {
     return data()[idx];
   }
-  const T& operator[](size_t idx) const {
+  [[nodiscard]] const T& operator[](size_t idx) const {
     return data()[idx];
   }
-  T* data() {
+  [[nodiscard]] T* data() {
     return data_;
   }
-  const T* data() const {
+  [[nodiscard]] const T* data() const {
     return data_;
   }
-  size_t size() const {
+  [[nodiscard]] size_t size() const {
     return size_;
   }
-  T* begin() {
+  [[nodiscard]] T* begin() {
     return data_;
   }
-  const T* begin() const {
+  [[nodiscard]] const T* begin() const {
     return data_;
   }
-  T* end() {
+  [[nodiscard]] T* end() {
     return data_ + size_;
   }
-  const T* end() const {
+  [[nodiscard]] const T* end() const {
     return data_ + size_;
   }
 };


### PR DESCRIPTION
Summary:
SmallBuffer is a fixed-size SBO array helper. Annotate its observers (operator[], data, size, begin, end, const and non-const overloads); discarding any of them is meaningless, while lvalue uses such as buf[i] = x remain uses.

Mirrored across the fbcode and xplat copies of the header.

Test Plan: [[nodiscard]] is enforced at compile time via -Werror; relies on CI to surface external discarding call sites. Local `arc lint` is clean.

Differential Revision: D111955879


