### PR TITLE
c10 intrusive_ptr: add [[nodiscard]] to raw::intrusive_ptr helpers

### DIFF
--- a/c10/util/intrusive_ptr.h
+++ b/c10/util/intrusive_ptr.h
@@ -1205,7 +1205,7 @@ inline void decref(intrusive_ptr_target* self) {
 }
 
 template <typename T>
-inline T* make_weak(T* self) {
+[[nodiscard]] inline T* make_weak(T* self) {
   // NB: 'this' is a strong pointer, but we return a weak pointer
   auto ptr = c10::intrusive_ptr<T>::reclaim(self);
   c10::weak_intrusive_ptr<T> wptr(ptr);
@@ -1213,7 +1213,7 @@ inline T* make_weak(T* self) {
   return wptr.release();
 }
 
-inline uint32_t use_count(intrusive_ptr_target* self) {
+[[nodiscard]] inline uint32_t use_count(intrusive_ptr_target* self) {
   auto ptr = c10::intrusive_ptr<intrusive_ptr_target>::reclaim(self);
   auto r = ptr.use_count();
   ptr.release();


### PR DESCRIPTION
Summary:
Annotate the raw pointer helpers in namespace c10::raw::intrusive_ptr:
- make_weak returns a raw owning weak pointer; discarding it leaks.
- use_count is a pure query.

incref/decref stay unannotated since they are used for effect.

Mirrored across the fbcode and xplat copies of the header.

Test Plan: [[nodiscard]] is enforced at compile time via -Werror; relies on CI to surface external discarding call sites. Local `arc lint` is clean.

Differential Revision: D111955873


