### PR TITLE
c10 Lazy: add [[nodiscard]] to LazyValue::get

### DIFF
--- a/c10/util/Lazy.h
+++ b/c10/util/Lazy.h
@@ -80,7 +80,7 @@ class LazyValue {
  public:
   virtual ~LazyValue() = default;
 
-  virtual const T& get() const = 0;
+  [[nodiscard]] virtual const T& get() const = 0;
 };
 
 /**
@@ -90,7 +90,7 @@ class LazyValue {
 template <class T>
 class OptimisticLazyValue : public LazyValue<T> {
  public:
-  const T& get() const override {
+  [[nodiscard]] const T& get() const override {
     return value_.ensure([this] { return compute(); });
   }
 
@@ -109,7 +109,7 @@ class PrecomputedLazyValue : public LazyValue<T> {
  public:
   PrecomputedLazyValue(T value) : value_(std::move(value)) {}
 
-  const T& get() const override {
+  [[nodiscard]] const T& get() const override {
     return value_;
   }
 


### PR DESCRIPTION
Summary:
Annotate the get() accessor on LazyValue and its OptimisticLazyValue / PrecomputedLazyValue implementations; it is a pure accessor whose returned reference is the only point of the call.

OptimisticLazy::ensure is intentionally left unannotated: unlike get(), it has a caching side effect and can legitimately be called to prime the value while discarding the returned reference.

Mirrored across the fbcode and xplat copies of the header.

Test Plan: [[nodiscard]] is enforced at compile time via -Werror; relies on CI to surface external discarding call sites. Local `arc lint` is clean.

Differential Revision: D111955870


