### PR TITLE
c10 string_view: add [[nodiscard]] to query methods

### DIFF
--- a/c10/util/string_view.h
+++ b/c10/util/string_view.h
@@ -30,7 +30,7 @@ class basic_string_view final : public std::basic_string_view<CharT> {
   // `using Base::Base` does not bring Base's copy/move ctors.
   /* implicit */ constexpr basic_string_view(Base sv) noexcept : Base(sv) {}
 
-  constexpr basic_string_view substr(
+  [[nodiscard]] constexpr basic_string_view substr(
       size_type pos = 0,
       size_type count = Base::npos) const {
 #if !defined(__CUDA_ARCH__)
@@ -42,7 +42,7 @@ class basic_string_view final : public std::basic_string_view<CharT> {
 #endif
   }
 
-  constexpr explicit operator std::basic_string<CharT>() const {
+  [[nodiscard]] constexpr explicit operator std::basic_string<CharT>() const {
     return std::basic_string<CharT>(static_cast<const Base&>(*this));
   }
 };
@@ -58,7 +58,7 @@ using string_view = std::string_view;
 using c10_string_view = basic_string_view<char>;
 
 // NOTE: In C++20, this function should be replaced by string_view.starts_with
-constexpr bool starts_with(
+[[nodiscard]] constexpr bool starts_with(
     const std::string_view s,
     const std::string_view prefix) noexcept {
   return (prefix.size() > s.size()) ? false
@@ -66,14 +66,14 @@ constexpr bool starts_with(
 }
 
 // NOTE: In C++20, this function should be replaced by string_view.starts_with
-constexpr bool starts_with(
+[[nodiscard]] constexpr bool starts_with(
     const std::string_view s,
     const char prefix) noexcept {
   return !s.empty() && prefix == s.front();
 }
 
 // NOTE: In C++20, this function should be replaced by string_view.ends_with
-constexpr bool ends_with(
+[[nodiscard]] constexpr bool ends_with(
     const std::string_view s,
     const std::string_view suffix) noexcept {
   return (suffix.size() > s.size())
@@ -82,7 +82,9 @@ constexpr bool ends_with(
 }
 
 // NOTE: In C++20, this function should be replaced by string_view.ends_with
-constexpr bool ends_with(const std::string_view s, const char prefix) noexcept {
+[[nodiscard]] constexpr bool ends_with(
+    const std::string_view s,
+    const char prefix) noexcept {
   return !s.empty() && prefix == s.back();
 }
 


### PR DESCRIPTION
Summary:
Annotate the pure-query members of c10::basic_string_view (substr and the std::basic_string conversion operator) and the free starts_with / ends_with helpers. These compute and return a value with no side effect.

The common c10::string_view alias is just std::string_view and already carries the standard library's [[nodiscard]] annotations.

Mirrored across the fbcode and xplat copies of the header.

Test Plan: [[nodiscard]] is enforced at compile time via -Werror; relies on CI to surface external discarding call sites. Local `arc lint` is clean.

Differential Revision: D111955871


