### PR TITLE
c10 ExclusivelyOwned: add [[nodiscard]] to query and ownership methods

### DIFF
--- a/c10/util/ExclusivelyOwned.h
+++ b/c10/util/ExclusivelyOwned.h
@@ -101,38 +101,39 @@ class ExclusivelyOwned {
   // undefined Tensor as its null state.
   explicit operator bool() const noexcept = delete;
 
-  operator T() && {
+  [[nodiscard]] operator T() && {
     return take();
   }
 
   // NOTE: the equivalent operation on MaybeOwned is a moving
   // operator*. For ExclusivelyOwned, take() and operator*() may well
   // have different return types, so they are different functions.
-  T take() && {
+  [[nodiscard]] T take() && {
     return EOT::take(repr_);
   }
 
-  typename EOT::const_pointer_type operator->() const {
+  [[nodiscard]] typename EOT::const_pointer_type operator->() const {
     return get();
   }
 
-  typename EOT::const_pointer_type get() const {
+  [[nodiscard]] typename EOT::const_pointer_type get() const {
     return EOT::getImpl(repr_);
   }
 
-  typename EOT::pointer_type operator->() {
+  [[nodiscard]] typename EOT::pointer_type operator->() {
     return get();
   }
 
-  typename EOT::pointer_type get() {
+  [[nodiscard]] typename EOT::pointer_type get() {
     return EOT::getImpl(repr_);
   }
 
-  std::remove_pointer_t<typename EOT::const_pointer_type>& operator*() const {
+  [[nodiscard]] std::remove_pointer_t<typename EOT::const_pointer_type>&
+  operator*() const {
     return *get();
   }
 
-  std::remove_pointer_t<typename EOT::pointer_type>& operator*() {
+  [[nodiscard]] std::remove_pointer_t<typename EOT::pointer_type>& operator*() {
     return *get();
   }
 };


### PR DESCRIPTION
Summary:
ExclusivelyOwned is a smart-pointer-like wrapper around an exclusively-owned T. Annotate:
- Pure-query observers: get(), operator->(), operator* (const and non-const overloads).
- Ownership-transfer: take() && and operator T() &&, which move the owned value out; discarding the result destroys the moved-out value.

operator bool is =delete and left untouched.

Mirrored across the fbcode and xplat copies of the header.

Test Plan: [[nodiscard]] is enforced at compile time via -Werror; relies on CI to surface external discarding call sites. Local `arc lint` is clean.

Differential Revision: D111955869


