### PR TITLE
c10 intrusive_ptr: add [[nodiscard]] to make_intrusive

### DIFF
--- a/c10/util/intrusive_ptr.h
+++ b/c10/util/intrusive_ptr.h
@@ -753,7 +753,8 @@ template <
     class TTarget,
     class NullType = detail::intrusive_target_default_null_type<TTarget>,
     class... Args>
-inline intrusive_ptr<TTarget, NullType> make_intrusive(Args&&... args) {
+[[nodiscard]] inline intrusive_ptr<TTarget, NullType> make_intrusive(
+    Args&&... args) {
   return intrusive_ptr<TTarget, NullType>::make(std::forward<Args>(args)...);
 }
 


### PR DESCRIPTION
Summary:
make_intrusive allocates a new object and returns an owning intrusive_ptr. Discarding the result allocates and then immediately frees the object, which is never intended, so mark it [[nodiscard]].

Mirrored across the fbcode and xplat copies of the header.

Test Plan: [[nodiscard]] is enforced at compile time via -Werror; relies on CI to surface external discarding call sites. Local `arc lint` is clean.

Differential Revision: D111955864


