### PR TITLE
[dynamo] Add polyfill for _io.text_encoding

### DIFF
--- a/test/dynamo/test_polyfills.py
+++ b/test/dynamo/test_polyfills.py
@@ -1,8 +1,22 @@
 # Owner(s): ["module: dynamo"]
 
+import _io
+
 import torch
 import torch._dynamo.testing
 from torch._dynamo.test_case import run_tests, TestCase
+
+
+class TestTextEncoding(TestCase):
+    """Tests for the _io.text_encoding polyfill."""
+
+    def test_text_encoding(self):
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(encoding):
+            return _io.text_encoding(encoding)
+
+        self.assertEqual(fn("utf-8"), "utf-8")
+        self.assertEqual(fn(None), _io.text_encoding(None))
 
 
 class TestGroupTensorsByDeviceAndDtype(TestCase):

--- a/torch/_dynamo/polyfills/__init__.py
+++ b/torch/_dynamo/polyfills/__init__.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
         _collections as _collections,
         builtins as builtins,
         functools as functools,
+        io as io,
         itertools as itertools,
         operator as operator,
         os as os,

--- a/torch/_dynamo/polyfills/io.py
+++ b/torch/_dynamo/polyfills/io.py
@@ -1,0 +1,32 @@
+"""
+Python polyfills for io
+"""
+
+from __future__ import annotations
+
+import _io
+
+import sys
+
+from ..decorators import substitute_in_graph
+
+
+__all__ = ["text_encoding"]
+
+
+# Copied from _pyio.py in the standard library
+# pyrefly: ignore [bad-argument-type]
+@substitute_in_graph(_io.text_encoding, can_constant_fold_through=True)
+def text_encoding(encoding: str | None, stacklevel: int = 2) -> str:
+    if encoding is not None:
+        return encoding
+    encoding = "utf-8" if sys.flags.utf8_mode else "locale"
+    if sys.flags.warn_default_encoding:
+        import warnings
+
+        warnings.warn(
+            "'encoding' argument not specified.",
+            EncodingWarning,
+            stacklevel + 1,
+        )
+    return encoding

--- a/torch/_dynamo/polyfills/loader.py
+++ b/torch/_dynamo/polyfills/loader.py
@@ -19,6 +19,7 @@ POLYFILLED_MODULE_NAMES: tuple[str, ...] = (
     "builtins",
     "copy",
     "functools",
+    "io",
     "itertools",
     "operator",
     "os",


### PR DESCRIPTION
## Issue

Fixes #189925

## Summary

`_io.text_encoding` is a C builtin with no traceable Python implementation, so any call through it (directly, or via stdlib helpers like `tempfile.NamedTemporaryFile` / `pathlib.Path.read_text`/`write_text` that accept `encoding=None`) graph-breaks under `torch.compile`.

Adds a `substitute_in_graph` polyfill in `torch/_dynamo/polyfills/io.py`, ported from CPython's own `_pyio.py` reference implementation, following the same pattern as `os.fspath` / `sys.intern`.

This is also what causes `test/cpython/v3_13/test_bool.py::BoolTest.test_fileclosed` to silently fall back to eager instead of tracing fully under `PYTORCH_TEST_WITH_DYNAMO=1` — that test is decorated with `@torch._dynamo.error_on_graph_break(False)`, so the break didn't fail it, it just printed a `UserWarning` on every run and skipped compiling the file-handling path. This PR does not modify that test; it's cited only as an existing repro for the graph break, and continues to pass unmodified in CI.

`test_polyfills.py` adds a `fullgraph=True` smoke test comparing eager vs compiled output, the same convention used for `os.fspath` (`test/dynamo/test_repros.py::test_os_fspath`) and other `can_constant_fold_through` polyfills in this codebase.

## Test Plan

    python test/dynamo/test_polyfills.py -v

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No.

---
This PR was written with the assistance of Claude (Anthropic).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98
