### PR TITLE
[DO NOT LAND] Test revert of #189533 to check a100 unbacked-parity hardening

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -937,27 +937,7 @@ class TestPatternMatcher(TestCase):
             x = torch.full([10, 10], True, dtype=torch.int32)
             return torch.cumsum(x, 1)
 
-        def fn7():
-            ones = torch.full([2, 4, 4], True, dtype=torch.bool)
-            return torch.cumsum(ones, 1, dtype=torch.bfloat16)
-
-        def fn8():
-            x = torch.full([10, 10], 2, dtype=torch.int32)
-            return torch.cumsum(x, 1, dtype=torch.float64)
-
-        def fn9():
-            x = torch.full([100], 0.1, dtype=torch.float32)
-            return torch.cumsum(x, 0, dtype=torch.float64)
-
-        def fn10():
-            x = torch.full([5000], 1.0, dtype=torch.float16)
-            return torch.cumsum(x, 0, dtype=torch.float32)
-
-        def fn11():
-            x = torch.full([10], 2.5, dtype=torch.float32)
-            return torch.cumsum(x, 0, dtype=torch.int64)
-
-        for fn in (fn1, fn2, fn3, fn4, fn5, fn6, fn7, fn8, fn9, fn10, fn11):
+        for fn in (fn1, fn2, fn3, fn4, fn5, fn6):
             result, (code,) = run_and_get_code(torch.compile(fn, fullgraph=True))
             self.assertNotIn("aten.cumsum", code)
             self.assertEqual(result, fn())

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -1016,26 +1016,16 @@ def pointless_cumsum_replacement(match: Match, shape, fill_value, device, dtype,
     """Based on a pattern in OPTForCausalLM"""
 
     if is_integer_dtype(dtype) or is_boolean_dtype(dtype):
-        # match full()'s fill_value cast
-        fill_value = int(bool(fill_value) if is_boolean_dtype(dtype) else fill_value)
         # cumsum promotes all integral types to int64
         dtype = torch.int64
 
-    out_dtype = match.output_node().kwargs.get("dtype") or dtype
-    bool_out = is_boolean_dtype(out_dtype)  # pyrefly: ignore[bad-argument-type]
-    # pyrefly: ignore[bad-argument-type]
-    integral_out = bool_out or is_integer_dtype(out_dtype)
-    if integral_out:
-        fill_value = int(bool(fill_value) if bool_out else fill_value)
-    acc_dtype = torch.int64 if integral_out else torch.float64
-
     def repl(*shape):
         dim_size = shape[dim]
-        idx = torch.arange(1, dim_size + 1, device=device, dtype=acc_dtype)
+        idx = torch.arange(1, dim_size + 1, device=device, dtype=dtype)
 
         inter_shape = [1] * len(shape)
         inter_shape[dim] = dim_size
-        return (idx * fill_value).view(inter_shape).expand(shape).to(out_dtype)
+        return (idx * fill_value).view(inter_shape).expand(shape)
 
     # only replace the output node, not all nodes
     match.nodes = [match.output_node()]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189927

Experimental revert to test whether #189533 ("[Inductor] Honor cumsum dtype
in pointless_cumsum pattern") is what tipped the inductor_huggingface_unbacked_parity
a100 config from flaky/borderline to consistently red around 2026-07-12. It is
the boundary commit (first solid-red run) but only a weak suspect, and the a100
margin cannot be reproduced locally (this fleet is h100). This draft exists solely
to run the periodic a100 job on reverted code and compare backed-vs-unbacked diffs.

Not intended to land.

Test Plan: Push with ciflow/inductor-periodic and inspect the
inductor_huggingface_unbacked_parity (a100) job's backed/unbacked diffs vs main.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo