### PR TITLE
c10 intrusive_ptr: add [[nodiscard]] to intrusive_ptr comparison operators

### DIFF
--- a/c10/util/intrusive_ptr.h
+++ b/c10/util/intrusive_ptr.h
@@ -766,49 +766,49 @@ inline void swap(
 
 // To allow intrusive_ptr inside std::map or std::set, we need operator<
 template <class TTarget1, class NullType1, class TTarget2, class NullType2>
-inline bool operator<(
+[[nodiscard]] inline bool operator<(
     const intrusive_ptr<TTarget1, NullType1>& lhs,
     const intrusive_ptr<TTarget2, NullType2>& rhs) noexcept {
   return lhs.get() < rhs.get();
 }
 
 template <class TTarget1, class NullType1, class TTarget2, class NullType2>
-inline bool operator==(
+[[nodiscard]] inline bool operator==(
     const intrusive_ptr<TTarget1, NullType1>& lhs,
     const intrusive_ptr<TTarget2, NullType2>& rhs) noexcept {
   return lhs.get() == rhs.get();
 }
 
 template <class TTarget1, class NullType1>
-inline bool operator==(
+[[nodiscard]] inline bool operator==(
     const intrusive_ptr<TTarget1, NullType1>& lhs,
     std::nullptr_t) noexcept {
   return lhs.get() == nullptr;
 }
 
 template <class TTarget2, class NullType2>
-inline bool operator==(
+[[nodiscard]] inline bool operator==(
     std::nullptr_t,
     const intrusive_ptr<TTarget2, NullType2>& rhs) noexcept {
   return nullptr == rhs.get();
 }
 
 template <class TTarget1, class NullType1, class TTarget2, class NullType2>
-inline bool operator!=(
+[[nodiscard]] inline bool operator!=(
     const intrusive_ptr<TTarget1, NullType1>& lhs,
     const intrusive_ptr<TTarget2, NullType2>& rhs) noexcept {
   return !operator==(lhs, rhs);
 }
 
 template <class TTarget1, class NullType1>
-inline bool operator!=(
+[[nodiscard]] inline bool operator!=(
     const intrusive_ptr<TTarget1, NullType1>& lhs,
     std::nullptr_t) noexcept {
   return !operator==(lhs, nullptr);
 }
 
 template <class TTarget2, class NullType2>
-inline bool operator!=(
+[[nodiscard]] inline bool operator!=(
     std::nullptr_t,
     const intrusive_ptr<TTarget2, NullType2>& rhs) noexcept {
   return !operator==(nullptr, rhs);


### PR DESCRIPTION
Summary:
Add [[nodiscard]] to the free comparison operators for intrusive_ptr (operator<, operator== and operator!= including the nullptr_t overloads). These are pure queries; computing a comparison and discarding the result is always a mistake, and [[nodiscard]] on comparison operators is idiomatic.

Mirrored across the fbcode and xplat copies of the header.

Test Plan: [[nodiscard]] is enforced at compile time via -Werror; relies on CI to surface external discarding call sites. Local `arc lint` is clean.

Differential Revision: D111955875


