### PR TITLE
c10 intrusive_ptr: add [[nodiscard]] to weak_intrusive_ptr comparison operators

### DIFF
--- a/c10/util/intrusive_ptr.h
+++ b/c10/util/intrusive_ptr.h
@@ -1138,21 +1138,21 @@ inline void swap(
 
 // To allow weak_intrusive_ptr inside std::map or std::set, we need operator<
 template <class TTarget1, class NullType1, class TTarget2, class NullType2>
-inline bool operator<(
+[[nodiscard]] inline bool operator<(
     const weak_intrusive_ptr<TTarget1, NullType1>& lhs,
     const weak_intrusive_ptr<TTarget2, NullType2>& rhs) noexcept {
   return lhs.target_ < rhs.target_;
 }
 
 template <class TTarget1, class NullType1, class TTarget2, class NullType2>
-inline bool operator==(
+[[nodiscard]] inline bool operator==(
     const weak_intrusive_ptr<TTarget1, NullType1>& lhs,
     const weak_intrusive_ptr<TTarget2, NullType2>& rhs) noexcept {
   return lhs.target_ == rhs.target_;
 }
 
 template <class TTarget1, class NullType1, class TTarget2, class NullType2>
-inline bool operator!=(
+[[nodiscard]] inline bool operator!=(
     const weak_intrusive_ptr<TTarget1, NullType1>& lhs,
     const weak_intrusive_ptr<TTarget2, NullType2>& rhs) noexcept {
   return !operator==(lhs, rhs);


### PR DESCRIPTION
Summary:
Add [[nodiscard]] to the free comparison operators for weak_intrusive_ptr (operator<, operator==, operator!=). These are pure queries whose result must be used.

Mirrored across the fbcode and xplat copies of the header.

Test Plan: [[nodiscard]] is enforced at compile time via -Werror; relies on CI to surface external discarding call sites. Local `arc lint` is clean.

Differential Revision: D111955860


