### PR TITLE
c10 Array: add [[nodiscard]] to array_of

### DIFF
--- a/c10/util/Array.h
+++ b/c10/util/Array.h
@@ -11,7 +11,8 @@ namespace c10 {
 //
 // See also https://stackoverflow.com/a/26351760/23845
 template <typename V, typename... T>
-inline constexpr auto array_of(T&&... t) -> std::array<V, sizeof...(T)> {
+[[nodiscard]] inline constexpr auto array_of(T&&... t)
+    -> std::array<V, sizeof...(T)> {
   return {{std::forward<T>(t)...}};
 }
 


### PR DESCRIPTION
Summary:
array_of is a constexpr factory that builds and returns a std::array; discarding the result is pointless, so mark it [[nodiscard]].

Mirrored across the fbcode and xplat copies of the header.

Test Plan: [[nodiscard]] is enforced at compile time via -Werror; relies on CI to surface external discarding call sites. Local `arc lint` is clean.

Differential Revision: D111955866


