### PR TITLE
c10 intrusive_ptr: add [[nodiscard]] to raw::weak_intrusive_ptr helpers

### DIFF
--- a/c10/util/intrusive_ptr.h
+++ b/c10/util/intrusive_ptr.h
@@ -1236,7 +1236,7 @@ inline void decref(weak_intrusive_ptr_target* self) {
 }
 
 template <typename T>
-inline T* lock(T* self) {
+[[nodiscard]] inline T* lock(T* self) {
   auto wptr = c10::weak_intrusive_ptr<T>::reclaim(self);
   auto ptr = wptr.lock();
   wptr.release();
@@ -1244,7 +1244,7 @@ inline T* lock(T* self) {
 }
 
 // This gives the STRONG refcount of a WEAK pointer
-inline uint32_t use_count(weak_intrusive_ptr_target* self) {
+[[nodiscard]] inline uint32_t use_count(weak_intrusive_ptr_target* self) {
   auto wptr = c10::weak_intrusive_ptr<intrusive_ptr_target>::reclaim(self);
   auto r = wptr.use_count();
   wptr.release();


### PR DESCRIPTION
Summary:
Annotate the raw pointer helpers in namespace c10::raw::weak_intrusive_ptr:
- lock returns a raw owning strong pointer; discarding it leaks.
- use_count is a pure query.

incref/decref stay unannotated since they are used for effect.

Mirrored across the fbcode and xplat copies of the header.

Test Plan: [[nodiscard]] is enforced at compile time via -Werror; relies on CI to surface external discarding call sites. Local `arc lint` is clean.

Differential Revision: D111955878


