### PR TITLE
c10 Bitset: add [[nodiscard]] to query methods

### DIFF
--- a/c10/util/Bitset.h
+++ b/c10/util/Bitset.h
@@ -26,7 +26,7 @@ struct bitset final {
   using bitset_type = long long int;
 #endif
  public:
-  static constexpr size_t NUM_BITS() {
+  [[nodiscard]] static constexpr size_t NUM_BITS() {
     return 8 * sizeof(bitset_type);
   }
 
@@ -47,11 +47,11 @@ struct bitset final {
     bitset_ &= ~(static_cast<long long int>(1) << index);
   }
 
-  constexpr bool get(size_t index) const noexcept {
+  [[nodiscard]] constexpr bool get(size_t index) const noexcept {
     return bitset_ & (static_cast<long long int>(1) << index);
   }
 
-  constexpr bool is_entirely_unset() const noexcept {
+  [[nodiscard]] constexpr bool is_entirely_unset() const noexcept {
     return 0 == bitset_;
   }
 
@@ -104,14 +104,14 @@ struct bitset final {
 #endif
   }
 
-  friend bool operator==(bitset lhs, bitset rhs) noexcept {
+  [[nodiscard]] friend bool operator==(bitset lhs, bitset rhs) noexcept {
     return lhs.bitset_ == rhs.bitset_;
   }
 
   bitset_type bitset_{0};
 };
 
-inline bool operator!=(bitset lhs, bitset rhs) noexcept {
+[[nodiscard]] inline bool operator!=(bitset lhs, bitset rhs) noexcept {
   return !(lhs == rhs);
 }
 


### PR DESCRIPTION
Summary:
Annotate the pure-query methods of c10::utils::bitset: NUM_BITS, get, is_entirely_unset, and the operator==/operator!= comparisons. Mutators (set, unset) and the functor-invoking for_each_set_bit are left untouched.

Mirrored across the fbcode and xplat copies of the header.

Test Plan: [[nodiscard]] is enforced at compile time via -Werror; relies on CI to surface external discarding call sites. Local `arc lint` is clean.

Differential Revision: D111955862


