### PR TITLE
c10 IntrusiveList: add [[nodiscard]] to observer methods

### DIFF
--- a/c10/util/IntrusiveList.h
+++ b/c10/util/IntrusiveList.h
@@ -46,7 +46,7 @@ class IntrusiveListHook {
     }
   }
 
-  bool is_linked() const {
+  [[nodiscard]] bool is_linked() const {
     return next_ != this;
   }
 };
@@ -88,16 +88,16 @@ class ListIterator {
   }
 
   template <typename Q>
-  bool operator==(const ListIterator<Q, T>& other) const {
+  [[nodiscard]] bool operator==(const ListIterator<Q, T>& other) const {
     return ptr_ == other.ptr_;
   }
 
   template <typename Q>
-  bool operator!=(const ListIterator<Q, T>& other) const {
+  [[nodiscard]] bool operator!=(const ListIterator<Q, T>& other) const {
     return !(*this == other);
   }
 
-  auto& operator*() const {
+  [[nodiscard]] auto& operator*() const {
     return static_cast<reference>(*ptr_);
   }
 
@@ -113,7 +113,7 @@ class ListIterator {
     return *this;
   }
 
-  auto* operator->() const {
+  [[nodiscard]] auto* operator->() const {
     return static_cast<pointer>(ptr_);
   }
 };
@@ -142,43 +142,43 @@ class IntrusiveList {
   using iterator = ListIterator<IntrusiveListHook, T>;
   using const_iterator = ListIterator<const IntrusiveListHook, T>;
 
-  auto begin() const {
+  [[nodiscard]] auto begin() const {
     return ++const_iterator{&head_};
   }
 
-  auto begin() {
+  [[nodiscard]] auto begin() {
     return ++iterator{&head_};
   }
 
-  auto end() const {
+  [[nodiscard]] auto end() const {
     return const_iterator{&head_};
   }
 
-  auto end() {
+  [[nodiscard]] auto end() {
     return iterator{&head_};
   }
 
-  auto rbegin() const {
+  [[nodiscard]] auto rbegin() const {
     return std::reverse_iterator{end()};
   }
 
-  auto rbegin() {
+  [[nodiscard]] auto rbegin() {
     return std::reverse_iterator{end()};
   }
 
-  auto rend() const {
+  [[nodiscard]] auto rend() const {
     return std::reverse_iterator{begin()};
   }
 
-  auto rend() {
+  [[nodiscard]] auto rend() {
     return std::reverse_iterator{begin()};
   }
 
-  auto iterator_to(const T& n) const {
+  [[nodiscard]] auto iterator_to(const T& n) const {
     return const_iterator{&n};
   }
 
-  auto iterator_to(T& n) {
+  [[nodiscard]] auto iterator_to(T& n) {
     return iterator{&n};
   }
 
@@ -187,7 +187,7 @@ class IntrusiveList {
     return iterator{&n};
   }
 
-  size_t size() const {
+  [[nodiscard]] size_t size() const {
     size_t ret = 0;
     for ([[maybe_unused]] auto& _ : *this) {
       ret++;
@@ -195,7 +195,7 @@ class IntrusiveList {
     return ret;
   }
 
-  bool empty() const {
+  [[nodiscard]] bool empty() const {
     return !head_.is_linked();
   }
 


### PR DESCRIPTION
Summary:
Annotate the pure-query methods of IntrusiveListHook (is_linked), ListIterator (operator==, operator!=, operator*, operator->) and IntrusiveList (begin/end, rbegin/rend, iterator_to, size, empty). insert() keeps no annotation since discarding its returned iterator is a common and valid use of its linking side effect.

Mirrored across the fbcode and xplat copies of the header.

Test Plan: [[nodiscard]] is enforced at compile time via -Werror; relies on CI to surface external discarding call sites. Local `arc lint` is clean.

Differential Revision: D111955863


