### PR TITLE
[lint] Bump remaining shim-linter git timeouts to 60s

### DIFF
--- a/tools/linter/adapters/_stable_shim_utils.py
+++ b/tools/linter/adapters/_stable_shim_utils.py
@@ -488,7 +488,7 @@ def merge_base_with_main() -> str:
         ["git", "merge-base", "HEAD", main_sha],
         capture_output=True,
         text=True,
-        timeout=5,
+        timeout=60,
     )
     if result.returncode != 0:
         raise RuntimeError(

--- a/tools/linter/adapters/generated_shims_version_linter.py
+++ b/tools/linter/adapters/generated_shims_version_linter.py
@@ -122,7 +122,7 @@ def _read_at_merge_base(filename: str) -> str | None:
         ["git", "show", f"{merge_base}:{rel_path}"],
         capture_output=True,
         text=True,
-        timeout=5,
+        timeout=60,
     )
     if result.returncode != 0:
         # File didn't exist at merge-base; treat all current entries as new.

--- a/tools/linter/adapters/stable_shim_version_linter.py
+++ b/tools/linter/adapters/stable_shim_version_linter.py
@@ -72,7 +72,7 @@ def get_added_lines(filename: str) -> set[int]:
             ["git", "diff", "HEAD", filename],
             capture_output=True,
             text=True,
-            timeout=5,
+            timeout=60,
         )
         if result.returncode == 0:
             added_lines.update(parse_diff(result.stdout))
@@ -83,7 +83,7 @@ def get_added_lines(filename: str) -> set[int]:
             ["git", "diff", f"{merge_base}..HEAD", filename],
             capture_output=True,
             text=True,
-            timeout=5,
+            timeout=60,
         )
         if result.returncode != 0:
             raise RuntimeError(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189937

#189444 bumped the git cat-file timeout in merge_base_with_main but left four
sibling git calls in the shim linters at timeout=5: the git diff calls in
stable_shim_version_linter.get_added_lines, the git show in
generated_shims_version_linter._read_at_merge_base, and the git merge-base in
_stable_shim_utils. On a partial-clone CI checkout these lazily fetch blobs from
the remote and intermittently exceed 5s, crashing the STABLE_SHIM_VERSION and
GENERATED_SHIMS_VERSION linters with TimeoutExpired. Bump them all to 60s to
match the calls #189444 already fixed.

Test Plan: Ran lintrunner on the three adapters locally; the STABLE_SHIM_VERSION
and GENERATED_SHIMS_VERSION linters pass. The flake is a CI-only partial-clone
network timeout that cannot be reproduced deterministically locally.

Authored with Claude.