### PR TITLE
Gate nccl2 backend behind USE_C10D_NCCL

### DIFF
--- a/torch/csrc/distributed/c10d/nccl2/Batch.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/Batch.hpp
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#ifdef USE_C10D_NCCL
+
 #include <ATen/ATen.h>
 #include <vector>
 
@@ -39,3 +41,5 @@ class BatchSendRecv {
 };
 
 } // namespace c10d::nccl2
+
+#endif // USE_C10D_NCCL

--- a/torch/csrc/distributed/c10d/nccl2/CudaApi.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/CudaApi.cpp
@@ -1,5 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#ifdef USE_C10D_NCCL
+
 #include <ATen/cuda/CUDAContext.h>
 #include <torch/csrc/distributed/c10d/nccl2/CudaApi.hpp>
 
@@ -208,3 +210,5 @@ const char* DefaultCudaApi::getErrorString(cudaError_t error) {
 }
 
 } // namespace c10d::nccl2
+
+#endif // USE_C10D_NCCL

--- a/torch/csrc/distributed/c10d/nccl2/CudaApi.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/CudaApi.hpp
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#ifdef USE_C10D_NCCL
+
 #include <c10/util/Logging.h>
 #include <cuda_runtime.h>
 
@@ -247,3 +249,5 @@ class DefaultCudaApi : public CudaApi {
 };
 
 } // namespace c10d::nccl2
+
+#endif // USE_C10D_NCCL

--- a/torch/csrc/distributed/c10d/nccl2/Logging.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/Logging.hpp
@@ -1,6 +1,8 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 #pragma once
 
+#ifdef USE_C10D_NCCL
+
 #include <c10/util/Logging.h>
 #include <fmt/format.h>
 
@@ -49,3 +51,5 @@ inline std::string getRankPrefix(Comm* comm) {
       ##__VA_ARGS__,                           \
       TC_LOG_WITH_PREFIX_BUILDER(__VA_ARGS__), \
       TC_LOG_PLAIN(__VA_ARGS__))
+
+#endif // USE_C10D_NCCL

--- a/torch/csrc/distributed/c10d/nccl2/NCCLBootstrap.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/NCCLBootstrap.cpp
@@ -1,5 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#ifdef USE_C10D_NCCL
+
 #include <ATen/cuda/CUDAContext.h>
 #include <fmt/core.h>
 #include <nccl.h>
@@ -318,3 +320,5 @@ ncclComm_t NCCLBootstrap::createNcclComm(
 }
 
 } // namespace c10d::nccl2
+
+#endif // USE_C10D_NCCL

--- a/torch/csrc/distributed/c10d/nccl2/NCCLBootstrap.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/NCCLBootstrap.hpp
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#ifdef USE_C10D_NCCL
+
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -86,3 +88,5 @@ void populateNcclConfigFromHints(
     const std::string& name);
 
 } // namespace c10d::nccl2
+
+#endif // USE_C10D_NCCL

--- a/torch/csrc/distributed/c10d/nccl2/NcclApi.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/NcclApi.cpp
@@ -1,5 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#ifdef USE_C10D_NCCL
+
 #include <fmt/core.h>
 #include <torch/csrc/distributed/c10d/nccl2/Logging.hpp>
 #include <torch/csrc/distributed/c10d/nccl2/NcclApi.hpp>
@@ -460,3 +462,5 @@ ncclResult_t DefaultNcclApi::waitSignal(
 }
 
 } // namespace c10d::nccl2
+
+#endif // USE_C10D_NCCL

--- a/torch/csrc/distributed/c10d/nccl2/NcclApi.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/NcclApi.hpp
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#ifdef USE_C10D_NCCL
+
 #include <mutex>
 #include <string>
 #include <string_view>
@@ -475,3 +477,5 @@ class DefaultNcclApi : public NcclApi {
 };
 
 } // namespace c10d::nccl2
+
+#endif // USE_C10D_NCCL

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
@@ -1,5 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#ifdef USE_C10D_NCCL
+
 #include <torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp>
 
 #include <cstdlib>
@@ -1477,3 +1479,5 @@ const char* NCCLException::what() const noexcept {
 }
 
 } // namespace c10d::nccl2
+
+#endif // USE_C10D_NCCL

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLUtils.cpp
@@ -1,5 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#ifdef USE_C10D_NCCL
+
 #include <torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp>
 
 #include <nccl.h>
@@ -698,3 +700,5 @@ ncclResult_t ProcessGroupNCCL::ensureSegmentWindow(const void* ptr) {
 }
 
 } // namespace c10d::nccl2
+
+#endif // USE_C10D_NCCL

--- a/torch/csrc/distributed/c10d/nccl2/StoreManager.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/StoreManager.cpp
@@ -1,4 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifdef USE_C10D_NCCL
+
 #include <torch/csrc/distributed/c10d/nccl2/StoreManager.hpp>
 
 #include <torch/csrc/distributed/c10d/PrefixStore.hpp>
@@ -80,3 +83,5 @@ c10::intrusive_ptr<c10d::Store> dupPrefixStore(
 }
 
 } // namespace c10d::nccl2
+
+#endif // USE_C10D_NCCL

--- a/torch/csrc/distributed/c10d/nccl2/StoreManager.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/StoreManager.hpp
@@ -1,6 +1,8 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 #pragma once
 
+#ifdef USE_C10D_NCCL
+
 #include <torch/csrc/distributed/c10d/Store.hpp>
 #include <string>
 
@@ -25,3 +27,5 @@ c10::intrusive_ptr<c10d::Store> dupPrefixStore(
     std::chrono::milliseconds timeout);
 
 } // namespace c10d::nccl2
+
+#endif // USE_C10D_NCCL

--- a/torch/csrc/distributed/c10d/nccl2/TracingGuard.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/TracingGuard.cpp
@@ -1,5 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#ifdef USE_C10D_NCCL
+
 #include <torch/csrc/distributed/c10d/nccl2/TracingGuard.hpp>
 
 #include <string>
@@ -193,3 +195,5 @@ TracingGuard::TracingGuard(
 }
 
 } // namespace c10d::nccl2
+
+#endif // USE_C10D_NCCL

--- a/torch/csrc/distributed/c10d/nccl2/TracingGuard.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/TracingGuard.hpp
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#ifdef USE_C10D_NCCL
+
 #include <ATen/core/ivalue.h>
 #include <string_view>
 #include <vector>
@@ -79,3 +81,5 @@ class TracingGuard {
 };
 
 } // namespace c10d::nccl2
+
+#endif // USE_C10D_NCCL

--- a/torch/csrc/distributed/c10d/nccl2/Utils.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/Utils.cpp
@@ -1,5 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#ifdef USE_C10D_NCCL
+
 #include <torch/csrc/distributed/c10d/nccl2/Utils.hpp>
 #include <algorithm>
 #include <sstream>
@@ -216,3 +218,5 @@ std::pair<int, int> query_ranksize() {
 }
 
 } // namespace c10d::nccl2
+
+#endif // USE_C10D_NCCL

--- a/torch/csrc/distributed/c10d/nccl2/Utils.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/Utils.hpp
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#ifdef USE_C10D_NCCL
+
 #include <cstdint>
 #include <string>
 #include <string_view>
@@ -18,3 +20,5 @@ T env_to_value(std::string_view env_key, const T& default_value);
 std::pair<int, int> query_ranksize();
 
 } // namespace c10d::nccl2
+
+#endif // USE_C10D_NCCL

--- a/torch/csrc/distributed/c10d/nccl2/WorkNCCLQueue.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/WorkNCCLQueue.cpp
@@ -1,5 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#ifdef USE_C10D_NCCL
+
 #include <torch/csrc/distributed/c10d/nccl2/WorkNCCL.hpp>
 
 namespace c10d::nccl2 {
@@ -95,3 +97,5 @@ void WorkNCCLQueue::enqueueWork(
 }
 
 } // namespace c10d::nccl2
+
+#endif // USE_C10D_NCCL


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189938

The in-tree nccl2 c10d backend (torch/csrc/distributed/c10d/nccl2/) is added to torch_cuda whenever CUDA and distributed are enabled, independent of whether NCCL is available. Some of its files were already wrapped in #ifdef USE_C10D_NCCL but many were not, so a non-NCCL-compliant backend such as libtorch_mtia_simt -- which defines no USE_C10D_NCCL -- fails to compile. Two distinct failures appear in sequence:

  torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLUtils.cpp:5:10: fatal error: 'nccl.h' file not found
  torch/csrc/distributed/c10d/nccl2/CudaApi.hpp:75:7: error: unknown type name 'cudaUserObject_t'

The first comes from the files that #include <nccl.h> or use NCCL types. The second comes from CudaApi, an NCCL-free CUDA wrapper that uses CUDA-graph APIs (cudaUserObject_t) not present on the mtia_simt CUDA surface. Because the whole nccl2 backend is only usable with NCCL -- its C++ registration in init.cpp and its Python entry point are both gated on NCCL availability -- the entire directory is gated rather than cherry-picking individual files.

This wraps every nccl2 source and header in #ifdef USE_C10D_NCCL / #endif, so the backend compiles to empty translation units when NCCL is not built. Files that already carried the guard are unchanged.

Test Plan:

Non-NCCL backend (the original failure): building libtorch_mtia_simt now succeeds and the previously broken tests pass:

```
buck2 test fbcode//mtia/cutedsl/tests/python:test_dlpack-mtia_simt fbcode//mtia/cutedsl/tests/python:test_cute_tensor-mtia_simt
# Tests finished: Pass 190. Fail 0. Timeout 0. Fatal 0. Skip 0. Omit 0. Infra Failure 0. Build failure 0
```

With USE_C10D_NCCL defined (normal CUDA build), the nccl2 objects compile unchanged.

With USE_C10D_NCCL undefined, every nccl2 file preprocesses to an empty translation unit.

lintrunner on the changed files reports no issues.

Differential Revision: [D111984293](https://our.internmc.facebook.com/intern/diff/D111984293)