### PR TITLE
Gate triton/vllm wheel builds to release runners only on release refs

### DIFF
--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -62,19 +62,19 @@ jobs:
         include:
           - device: "rocm"
             rocm_version: "7.2"
-            runs_on: "${{ needs.get-label-type.outputs.label-type }}rel-l-x86iavx512-44-340"
+            runs_on: "${{ needs.get-label-type.outputs.label-type }}${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-x86iavx512-44-340' || 'l-x86iavx512-48-384' }}"
             docker_image: "pytorch/manylinux2_28-builder:rocm7.2"
           - device: "cuda"
             rocm_version: ""
-            runs_on: "${{ needs.get-label-type.outputs.label-type }}rel-l-x86iavx512-44-340"
+            runs_on: "${{ needs.get-label-type.outputs.label-type }}${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-x86iavx512-44-340' || 'l-x86iavx512-48-384' }}"
             docker_image: "pytorch/manylinux2_28-builder:cpu"
           - device: "xpu"
             rocm_version: ""
-            runs_on: "${{ needs.get-label-type.outputs.label-type }}rel-l-x86iavx512-44-340"
+            runs_on: "${{ needs.get-label-type.outputs.label-type }}${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-x86iavx512-44-340' || 'l-x86iavx512-48-384' }}"
             docker_image: "pytorch/manylinux2_28-builder:cpu"
           - device: "aarch64"
             rocm_version: ""
-            runs_on: "${{ needs.get-label-type.outputs.label-type }}rel-l-arm64g3-44-340"
+            runs_on: "${{ needs.get-label-type.outputs.label-type }}${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-arm64g3-44-340' || 'l-arm64g3-61-463' }}"
             docker_image: "pytorch/manylinux2_28_aarch64-builder:cpu-aarch64"
     timeout-minutes: 40
     env:

--- a/.github/workflows/build-vllm-wheel.yml
+++ b/.github/workflows/build-vllm-wheel.yml
@@ -33,19 +33,19 @@ jobs:
           - platform: manylinux_2_28_x86_64
             device: cu130
             manylinux-image: 'pytorch/manylinux2_28-builder:cuda13.0'
-            runner: mt-rel-l-x86iavx512-44-340
+            runner: "mt-${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-x86iavx512-44-340' || 'l-x86iavx512-48-384' }}"
           - platform: manylinux_2_28_x86_64
             device: cu132
             manylinux-image: 'pytorch/manylinux2_28-builder:cuda13.2'
-            runner: mt-rel-l-x86iavx512-44-340
+            runner: "mt-${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-x86iavx512-44-340' || 'l-x86iavx512-48-384' }}"
           - platform: manylinux_2_28_aarch64
             device: cu130
             manylinux-image: 'pytorch/manylinuxaarch64-builder:cuda13.0'
-            runner: mt-rel-l-arm64g3-44-340
+            runner: "mt-${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-arm64g3-44-340' || 'l-arm64g3-61-463' }}"
           - platform: manylinux_2_28_aarch64
             device: cu132
             manylinux-image: 'pytorch/manylinuxaarch64-builder:cuda13.2'
-            runner: mt-rel-l-arm64g3-44-340
+            runner: "mt-${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-arm64g3-44-340' || 'l-arm64g3-61-463' }}"
     name: "Build ${{ matrix.device }} vLLM wheel on ${{ matrix.platform }}"
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 480


### PR DESCRIPTION
`build-triton-wheel` and `build-vllm-wheel` requested the release-isolated `rel-l-*` runners on **every** ref, so their PR / ciflow runs hang against the now-locked release runner group (its access is restricted to protected refs).

Gate the release runners to release refs (`main` / `nightly` / `release/*` / `v*` tags) and fall back to the regular multi-tenant OSDC pool (`l-x86iavx512-48-384` / `l-arm64g3-61-463`) on other refs — matching the `generated-linux-*-binary-manywheel-nightly` workflows.

Authored with the assistance of Claude Code.