### PR TITLE
[AI Codemod][PerfAICT-General] Add bias-add fast path to PackedLinearWeightFp16::apply_dynamic_impl

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
@@ -443,7 +443,27 @@ at::Tensor& PackedLinearWeightFp16::apply_dynamic_impl(
   // Add bias term
   if (bias_.has_value()) {
     TORCH_CHECK(bias_->dim() == 1);
-    output.add_(*bias_);
+    const auto& bias = *bias_;
+    // Fast path for a contiguous float32 bias vector of length N: add it
+    // directly over the row-major output. Otherwise fall back to add_, which
+    // handles dtype promotion and size-1 broadcasting.
+    if (bias.scalar_type() == at::kFloat && bias.numel() == N &&
+        bias.is_contiguous()) {
+      const float* bias_data = bias.const_data_ptr<float>();
+      constexpr int64_t kGrainElems = 32768;
+      const int64_t grain_size =
+          std::max<int64_t>(1, kGrainElems / std::max<int64_t>(1, N));
+      at::parallel_for(0, M, grain_size, [&](int64_t begin, int64_t end) {
+        for (const auto row : c10::irange(begin, end)) {
+          float* out_row = output_data + row * N;
+          for (const auto col : c10::irange(N)) {
+            out_row[col] += bias_data[col];
+          }
+        }
+      });
+    } else {
+      output.add_(bias);
+    }
   }
 
   return output;


### PR DESCRIPTION
This function was detected as a hotspot in performance data, and this is an AI generated change to improve performance. It was reviewed and iterated on by a human:
This diff optimizes bias addition in `PackedLinearWeightFp16::apply_dynamic_impl` by directly broadcasting a contiguous float bias over the known contiguous MxN output. Unsupported dtypes, layouts, and broadcast patterns retain the existing `output.add_ fallback`.
Microbenchmarks with representative production shapes show the bias-add step improving by 90–98% (10–49× faster). Profile attribution suggests this corresponds to approximately a 5% reduction in overall CPU cost in our setup.

Reviewed By: kunalspathak

Differential Revision: D111854215

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01