### PR TITLE
Support CheckpointableTensor in DCP format utils

### DIFF
--- a/test/distributed/checkpoint/test_format_utils.py
+++ b/test/distributed/checkpoint/test_format_utils.py
@@ -1,5 +1,7 @@
 # Owner(s): ["oncall: distributed"]
 
+from unittest.mock import patch
+
 import torch
 import torch.distributed as dist
 import torch.distributed.checkpoint as dcp
@@ -10,6 +12,10 @@ from torch.distributed.checkpoint.format_utils import (
     dcp_to_torch_save,
     DynamicMetaLoadPlanner,
     torch_save_to_dcp,
+)
+from torch.distributed.checkpoint.metadata import (
+    ChunkStorageMetadata,
+    TensorStorageMetadata,
 )
 from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
@@ -71,6 +77,51 @@ class TestFormatUtils(DTensorTestBase):
         dcp.load({"model": model}, checkpoint_id=self.temp_dir)
 
         self.assertEqual({"model": model.state_dict()}, sd)
+
+    def test_broadcasting_torch_save_reader_checkpointable_tensor(self) -> None:
+        tensor = torch.full((8,), -1.0)
+        tensor.global_shape = (16,)
+        tensor.global_offsets = ((0,), (12,))
+        tensor.local_offsets = ((0,), (4,))
+        tensor.local_sizes = ((4,), (4,))
+
+        planner = DynamicMetaLoadPlanner()
+        planner.set_up_planner({"proto": tensor}, metadata=None, is_coordinator=False)
+        plan = planner.create_local_plan()
+
+        tensor_metadata = planner.metadata.state_dict_metadata["proto"]
+        self.assertIsInstance(tensor_metadata, TensorStorageMetadata)
+        self.assertEqual(torch.Size([16]), tensor_metadata.size)
+        self.assertEqual(
+            [
+                ChunkStorageMetadata(
+                    offsets=torch.Size([0]),
+                    sizes=torch.Size([16]),
+                )
+            ],
+            tensor_metadata.chunks,
+        )
+        self.assertEqual(2, len(plan.items))
+        self.assertEqual(torch.Size([0]), plan.items[0].storage_offsets)
+        self.assertEqual(torch.Size([12]), plan.items[1].storage_offsets)
+
+        reader = BroadcastingTorchSaveReader()
+        reader.is_coordinator = False
+
+        def mock_broadcast(tensor_to_broadcast, src, async_op=False):
+            self.assertEqual(torch.Size([16]), tensor_to_broadcast.size())
+            tensor_to_broadcast.copy_(torch.arange(16, dtype=tensor.dtype))
+
+        with patch(
+            "torch.distributed.checkpoint.format_utils.dist.broadcast",
+            mock_broadcast,
+        ):
+            reader.read_data(plan, planner)
+
+        self.assertEqual(
+            torch.tensor([0, 1, 2, 3, 12, 13, 14, 15], dtype=tensor.dtype),
+            tensor,
+        )
 
     @with_comms
     @with_temp_dir

--- a/torch/distributed/checkpoint/format_utils.py
+++ b/torch/distributed/checkpoint/format_utils.py
@@ -14,6 +14,7 @@ from torch.distributed.checkpoint.default_planner import (
     DefaultLoadPlanner,
 )
 from torch.distributed.checkpoint.metadata import (
+    ChunkStorageMetadata,
     Metadata,
     STATE_DICT_TYPE,
     STORAGE_TYPES,
@@ -22,6 +23,7 @@ from torch.distributed.checkpoint.metadata import (
 )
 from torch.distributed.checkpoint.planner import LoadItemType, LoadPlan, LoadPlanner
 from torch.distributed.checkpoint.planner_helpers import _create_chunk_list
+from torch.distributed.checkpoint.protocol import _is_checkpointable_tensor
 from torch.distributed.checkpoint.state_dict_loader import _load_state_dict
 from torch.distributed.checkpoint.state_dict_saver import _save_state_dict
 from torch.distributed.checkpoint.storage import StorageReader
@@ -107,7 +109,18 @@ class BroadcastingTorchSaveReader(StorageReader):
                 # pyrefly: ignore [unsupported-operation]
                 tensor = torch_state_dict[req.storage_index.fqn].to(pg_device)
             else:
-                tensor = torch.empty_like(planner.state_dict[req.storage_index.fqn])
+                target = planner.state_dict[req.storage_index.fqn]
+                if _is_checkpointable_tensor(target):
+                    if planner.metadata is None:
+                        raise AssertionError(
+                            "planner metadata must be set before reading data"
+                        )
+                    md = planner.metadata.state_dict_metadata[req.storage_index.fqn]
+                    if not isinstance(md, TensorStorageMetadata):
+                        raise AssertionError("expected TensorStorageMetadata")
+                    tensor = cast(torch.Tensor, target).new_empty(md.size)
+                else:
+                    tensor = torch.empty_like(target)
 
             dist.broadcast(tensor, src=self.coordinator_rank, async_op=False)
 
@@ -197,10 +210,22 @@ class DynamicMetaLoadPlanner(DefaultLoadPlanner):
                     f"At this time {type(self).__name__} only supports loading Tensors."
                 )
 
+            if _is_checkpointable_tensor(tensor):
+                tensor_size = torch.Size(tensor.global_shape)
+                chunks = [
+                    ChunkStorageMetadata(
+                        offsets=torch.Size([0] * len(tensor_size)),
+                        sizes=tensor_size,
+                    )
+                ]
+            else:
+                tensor_size = tensor.size()
+                chunks = _create_chunk_list(tensor)
+
             state_dict_metadata[key] = TensorStorageMetadata(
                 TensorProperties(dtype=tensor.dtype),
-                tensor.size(),
-                _create_chunk_list(tensor),
+                tensor_size,
+                chunks,
             )
         self.metadata = Metadata(state_dict_metadata=state_dict_metadata)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #189945
* __->__ #189944
* #189492

Teach DynamicMetaLoadPlanner to describe CheckpointableTensor values by their logical global shape, and teach BroadcastingTorchSaveReader to allocate the full broadcast buffer before slicing into local shards.

This keeps torch-save conversion support aligned with the core CheckpointableTensor planner contract introduced by the previous commit.

Test Plan:
```bash
python test/distributed/checkpoint/test_format_utils.py TestFormatUtils.test_broadcasting_torch_save_reader_checkpointable_tensor
```

```bash
python -m py_compile test/distributed/checkpoint/test_format_utils.py
```

```bash
git diff --check
```

```bash
lintrunner -a
```

Authored with assistance from an AI assistant.