### PR TITLE
[DCP] Support CheckpointableTensor in HF safetensors storage

### DIFF
--- a/test/distributed/checkpoint/test_hf_safetensor_e2e.py
+++ b/test/distributed/checkpoint/test_hf_safetensor_e2e.py
@@ -7,6 +7,7 @@ import os
 import torch
 import torch.distributed.checkpoint as dist_cp
 from torch import distributed as dist
+from torch.distributed.checkpoint.metadata import ChunkStorageMetadata
 from torch.distributed.checkpoint.quantized_hf_storage import (
     QuantizedHuggingFaceStorageReader,
 )
@@ -64,6 +65,115 @@ class TestSingleRankSaveLoad(TestCase):
             self.assertTrue(
                 torch.equal(state_dict_to_save[key], state_dict_loaded[key])
             )
+
+    @with_temp_dir
+    def test_save_load_checkpointable_tensor_multiple_shards(self) -> None:
+        if importlib.util.find_spec("safetensors") is None:
+            print("safetensors not installed")
+            return
+
+        CHECKPOINT_DIR = self.temp_dir
+
+        expected = torch.arange(8, dtype=torch.float32)
+        tensor = expected.clone()
+        tensor.global_shape = (16,)
+        tensor.global_offsets = ((0,), (12,))
+        tensor.local_offsets = ((0,), (4,))
+        tensor.local_sizes = ((4,), (4,))
+        state_dict = {"proto": tensor}
+
+        dist_cp.save(
+            state_dict=state_dict,
+            storage_writer=dist_cp.HuggingFaceStorageWriter(path=CHECKPOINT_DIR),
+            no_dist=True,
+        )
+
+        metadata = dist_cp.HuggingFaceStorageReader(path=CHECKPOINT_DIR).read_metadata()
+        tensor_metadata = metadata.state_dict_metadata["proto"]
+        chunks = sorted(tensor_metadata.chunks, key=lambda chunk: tuple(chunk.offsets))
+        self.assertEqual(torch.Size([16]), tensor_metadata.size)
+        self.assertEqual(torch.Size([0]), chunks[0].offsets)
+        self.assertEqual(torch.Size([4]), chunks[0].sizes)
+        self.assertEqual(torch.Size([12]), chunks[1].offsets)
+        self.assertEqual(torch.Size([4]), chunks[1].sizes)
+
+        tensor.fill_(-1)
+        dist_cp.load(
+            state_dict=state_dict,
+            storage_reader=dist_cp.HuggingFaceStorageReader(path=CHECKPOINT_DIR),
+            no_dist=True,
+        )
+
+        self.assertEqual(expected, tensor)
+
+    @with_temp_dir
+    def test_checkpointable_tensor_tail_hole_metadata(self) -> None:
+        if importlib.util.find_spec("safetensors") is None:
+            print("safetensors not installed")
+            return
+
+        expected = torch.arange(4, dtype=torch.float32)
+        tensor = expected.clone()
+        tensor.global_shape = (16,)
+        tensor.global_offsets = ((0,),)
+        tensor.local_offsets = ((0,),)
+        tensor.local_sizes = ((4,),)
+        state_dict = {"proto": tensor}
+
+        dist_cp.save(
+            state_dict=state_dict,
+            storage_writer=dist_cp.HuggingFaceStorageWriter(path=self.temp_dir),
+            no_dist=True,
+        )
+
+        metadata = dist_cp.HuggingFaceStorageReader(path=self.temp_dir).read_metadata()
+        tensor_metadata = metadata.state_dict_metadata["proto"]
+        self.assertEqual(torch.Size([16]), tensor_metadata.size)
+        self.assertEqual(
+            [ChunkStorageMetadata(offsets=torch.Size([0]), sizes=torch.Size([4]))],
+            tensor_metadata.chunks,
+        )
+
+        tensor.fill_(-1)
+        dist_cp.load(
+            state_dict=state_dict,
+            storage_reader=dist_cp.HuggingFaceStorageReader(path=self.temp_dir),
+            no_dist=True,
+        )
+
+        self.assertEqual(expected, tensor)
+
+    @with_temp_dir
+    def test_checkpointable_tensor_tail_hole_consolidation(self) -> None:
+        if importlib.util.find_spec("safetensors") is None:
+            print("safetensors not installed")
+            return
+
+        from safetensors.torch import load_file
+
+        tensor = torch.arange(4, dtype=torch.float32)
+        tensor.global_shape = (16,)
+        tensor.global_offsets = ((0,),)
+        tensor.local_offsets = ((0,),)
+        tensor.local_sizes = ((4,),)
+
+        dist_cp.save(
+            state_dict={"proto": tensor},
+            storage_writer=dist_cp.HuggingFaceStorageWriter(
+                path=self.temp_dir,
+                save_distributed=True,
+                enable_consolidation=True,
+            ),
+            no_dist=True,
+        )
+
+        loaded_dict = load_file(
+            os.path.join(self.temp_dir, "model-00001-of-00001.safetensors")
+        )
+        expected = torch.zeros(16, dtype=torch.float32)
+        expected[:4] = tensor
+        self.assertEqual(loaded_dict.keys(), {"proto"})
+        self.assertEqual(expected, loaded_dict["proto"])
 
     @with_temp_dir
     def test_load(self) -> None:
@@ -275,6 +385,55 @@ class TestSingleRankSaveLoad(TestCase):
 
 
 class TestDistributedHFSafetensorsConsolidation(DTensorTestBase):
+    @with_comms
+    @with_temp_dir
+    @skip_if_lt_x_gpu(2)
+    def test_checkpointable_tensor_consolidate_to_one_file(self) -> None:
+        if importlib.util.find_spec("safetensors") is None:
+            print("safetensors not installed")
+            return
+
+        from safetensors import safe_open
+        from safetensors.torch import load_file
+
+        shard_size = 4
+        global_tensor = torch.arange(
+            self.world_size * shard_size,
+            dtype=torch.float32,
+        )
+        start = self.rank * shard_size
+        local_tensor = (
+            global_tensor[start : start + shard_size].clone().to(self.device_type)
+        )
+        local_tensor.global_shape = tuple(global_tensor.size())
+        local_tensor.global_offsets = ((start,),)
+        local_tensor.local_offsets = ((0,),)
+        local_tensor.local_sizes = ((shard_size,),)
+
+        dist_cp.save(
+            state_dict={"proto": local_tensor},
+            storage_writer=dist_cp.HuggingFaceStorageWriter(
+                path=self.temp_dir,
+                save_distributed=True,
+                enable_consolidation=True,
+            ),
+        )
+        dist.barrier()
+
+        if self.rank == 0:
+            file_path = os.path.join(self.temp_dir, "model-00001-of-00001.safetensors")
+            with safe_open(file_path, framework="pt") as f:
+                self.assertEqual(set(f.keys()), {"proto"})
+                self.assertEqual(
+                    list(global_tensor.size()), f.get_slice("proto").get_shape()
+                )
+
+            loaded_dict = load_file(file_path)
+            self.assertEqual(loaded_dict.keys(), {"proto"})
+            self.assertEqual(global_tensor, loaded_dict["proto"])
+
+        dist.barrier()
+
     @with_comms
     @with_temp_dir
     @skip_if_lt_x_gpu(2)

--- a/torch/distributed/checkpoint/_consolidate_hf_safetensors.py
+++ b/torch/distributed/checkpoint/_consolidate_hf_safetensors.py
@@ -21,6 +21,8 @@ from torch.distributed.checkpoint._hf_utils import (
     DATA_OFFSETS_KEY,
     DEFAULT_EXTRA_METADATA_KEY,
     DTYPE_KEY,
+    GLOBAL_SHAPE_KEY,
+    LOGICAL_FQN_KEY,
     SAVED_OFFSETS_KEY,
     SHAPE_KEY,
     SUFFIX,
@@ -107,18 +109,27 @@ def _parse_input_metadata(
                 "No DCP custom metadata found in safetensors file. The file must be saved with DCP to be consolidated."
             )
 
-        for key, val in safetensors_metadata.items():
-            if key == DEFAULT_EXTRA_METADATA_KEY:
+        for storage_key, val in safetensors_metadata.items():
+            if storage_key == DEFAULT_EXTRA_METADATA_KEY:
                 continue
 
             # Get the shape of this tensor shard and its offset in the full tensor
             sizes = val[SHAPE_KEY]
-            offsets = dcp_sharding_info[key][SAVED_OFFSETS_KEY]
+            shard_info = dcp_sharding_info[storage_key]
+            key = shard_info.get(LOGICAL_FQN_KEY, storage_key)
+            global_shape = shard_info.get(GLOBAL_SHAPE_KEY)
+            offsets = shard_info[SAVED_OFFSETS_KEY]
 
             if key not in fqn_to_size_mapping:
                 # First time seeing this tensor - calculate its full size by adding offsets to dimensions
-                cur_size = [size + offset for size, offset in zip(sizes, offsets)]
+                cur_size = (
+                    list(global_shape)
+                    if global_shape is not None
+                    else [size + offset for size, offset in zip(sizes, offsets)]
+                )
                 fqn_to_size_mapping[key] = (cur_size, val[DTYPE_KEY])
+            elif global_shape is not None:
+                fqn_to_size_mapping[key] = (list(global_shape), val[DTYPE_KEY])
             else:
                 # We've seen this tensor before - update its size if this shard extends beyond current known dimensions
                 cur_size = fqn_to_size_mapping[key][0]
@@ -199,7 +210,7 @@ def _write_metadata(
 
 
 def _read_tensor_data(
-    f,
+    f: Any,
     start_offset: int,
     end_offset: int,
     metadata_size: int,
@@ -245,8 +256,21 @@ def _process_output_file(
 
     file_handles = {}
     dcp_metadata = {}
+    storage_keys_by_logical_fqn: dict[str, dict[str, list[str]]] = {}
     for safetensors_file, file_data in input_files_data.items():
-        dcp_metadata[safetensors_file] = _get_dcp_custom_metadata(file_data.metadata)
+        file_dcp_metadata = _get_dcp_custom_metadata(file_data.metadata)
+        dcp_metadata[safetensors_file] = file_dcp_metadata
+
+        logical_fqn_to_storage_keys: dict[str, list[str]] = {}
+        for storage_key in file_data.metadata:
+            if storage_key == DEFAULT_EXTRA_METADATA_KEY:
+                continue
+
+            # pyrefly: ignore [unsupported-operation]
+            fqn_custom_metadata = file_dcp_metadata[storage_key]  # type: ignore[index]
+            logical_fqn = fqn_custom_metadata.get(LOGICAL_FQN_KEY, storage_key)
+            logical_fqn_to_storage_keys.setdefault(logical_fqn, []).append(storage_key)
+        storage_keys_by_logical_fqn[safetensors_file] = logical_fqn_to_storage_keys
 
     try:
         # Open all input files for reading
@@ -271,37 +295,37 @@ def _process_output_file(
                         safetensors_file
                     ].metadata_size
 
-                    if tensor_fqn not in file_metadata:
-                        continue
+                    file_dcp_metadata = dcp_metadata[safetensors_file]
+                    for storage_key in storage_keys_by_logical_fqn[
+                        safetensors_file
+                    ].get(tensor_fqn, []):
+                        metadata = file_metadata[storage_key]
+                        # pyrefly: ignore [unsupported-operation]
+                        fqn_custom_metadata = file_dcp_metadata[storage_key]  # type: ignore[index]
 
-                    metadata = file_metadata[tensor_fqn]
+                        data_offsets = metadata[DATA_OFFSETS_KEY]
 
-                    data_offsets = metadata[DATA_OFFSETS_KEY]
+                        # Use explicit reads to fetch tensor data efficiently
+                        data_to_write = _read_tensor_data(
+                            file_handles[safetensors_file],
+                            data_offsets[0],
+                            data_offsets[1],
+                            input_metadata_size,
+                        )
 
-                    # Use explicit reads to fetch tensor data efficiently
-                    data_to_write = _read_tensor_data(
-                        file_handles[safetensors_file],
-                        data_offsets[0],
-                        data_offsets[1],
-                        input_metadata_size,
-                    )
+                        offsets_of_tensor_being_read = fqn_custom_metadata[
+                            SAVED_OFFSETS_KEY
+                        ]  # type: ignore[index]
 
-                    # Get the offsets of this tensor shard within the full tensor
-                    # pyrefly: ignore [unsupported-operation]
-                    fqn_custom_metadata = dcp_metadata[safetensors_file][tensor_fqn]  # type: ignore[index]
-                    offsets_of_tensor_being_read = fqn_custom_metadata[
-                        SAVED_OFFSETS_KEY
-                    ]  # type: ignore[index]
-
-                    # Write this tensor shard to the appropriate position in the output file
-                    _write_sub_tensor_to_file_optimized(
-                        full_tensor_mv,
-                        data_to_write,
-                        tensor_fqn_data.dtype_size,  # Size of each element in bytes
-                        tensor_fqn_data.shape_in_file,  # Full tensor shape
-                        offsets_of_tensor_being_read,  # Where this shard belongs in the full tensor
-                        metadata[SHAPE_KEY],  # Shape of this shard
-                    )
+                        # Write this tensor shard to the appropriate position in the output file
+                        _write_sub_tensor_to_file_optimized(
+                            full_tensor_mv,
+                            data_to_write,
+                            tensor_fqn_data.dtype_size,  # Size of each element in bytes
+                            tensor_fqn_data.shape_in_file,  # Full tensor shape
+                            offsets_of_tensor_being_read,  # Where this shard belongs in the full tensor
+                            metadata[SHAPE_KEY],  # Shape of this shard
+                        )
 
                 output_stream.write(full_tensor_mv)
 

--- a/torch/distributed/checkpoint/_hf_utils.py
+++ b/torch/distributed/checkpoint/_hf_utils.py
@@ -16,6 +16,8 @@ SUFFIX = ".safetensors"
 # metadata keys
 CUSTOM_METADATA_KEY = "DCP_SHARDING_INFO"
 DEFAULT_EXTRA_METADATA_KEY = "__metadata__"
+LOGICAL_FQN_KEY = "logical_fqn"
+GLOBAL_SHAPE_KEY = "global_shape"
 SAVED_OFFSETS_KEY = "saved_offsets"
 SHAPE_KEY = "shape"
 DATA_KEY = "data"
@@ -53,6 +55,7 @@ class _HFStorageInfo:
     relative_path: str
     shape: torch.Size
     dtype: torch.dtype
+    storage_key: str | None = None
 
 
 def _gen_file_name(

--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -35,7 +35,10 @@ from torch.distributed.checkpoint._hf_utils import (
     DCP_VERSION_KEY,
     FORMAT_KEY,
     FORMAT_VALUE,
+    GLOBAL_SHAPE_KEY,
     HF_DCP_VERSION,
+    LOGICAL_FQN_KEY,
+    SAVED_OFFSETS_KEY,
 )
 from torch.distributed.checkpoint.metadata import Metadata, STATE_DICT_TYPE, StorageMeta
 from torch.distributed.checkpoint.planner import (
@@ -418,6 +421,28 @@ def _write_files_from_queue(
 
             bytes_w = [wi for wi in write_items if wi.type == WriteItemType.BYTE_IO]
             write_results = []
+            fqn_counts = collections.Counter(wi.index.fqn for wi in tensor_w)
+            fqn_seen: collections.defaultdict[str, int] = collections.defaultdict(int)
+            used_storage_keys: set[str] = set()
+
+            def _safetensors_storage_key(write_item: WriteItem) -> str:
+                logical_fqn = write_item.index.fqn
+                ordinal = fqn_seen[logical_fqn]
+                fqn_seen[logical_fqn] += 1
+
+                if (
+                    fqn_counts[logical_fqn] == 1
+                    and logical_fqn not in used_storage_keys
+                ):
+                    used_storage_keys.add(logical_fqn)
+                    return logical_fqn
+
+                physical_key = f"{logical_fqn}.__dcp_shard_{ordinal}"
+                while physical_key in used_storage_keys:
+                    ordinal += 1
+                    physical_key = f"{logical_fqn}.__dcp_shard_{ordinal}"
+                used_storage_keys.add(physical_key)
+                return physical_key
 
             with create_stream(file_name, "wb") as stream:
                 for write_item in bytes_w:
@@ -435,7 +460,8 @@ def _write_files_from_queue(
 
                 tensor_dict = {}
                 metadata_dict = {}
-                for tensor, write_item in loader.values():
+                for tensor, item in loader.values():
+                    write_item = cast(WriteItem, item)
                     if not tensor.is_cpu:
                         raise AssertionError("Tensor must be on CPU")
                     write_results.append(
@@ -448,9 +474,15 @@ def _write_files_from_queue(
                             serialization_format,
                         )
                     )
-                    tensor_dict[write_item.index.fqn] = tensor  # type: ignore[attr-defined]
-                    metadata_dict[write_item.index.fqn] = {  # type: ignore[attr-defined]
-                        "saved_offsets": write_item.tensor_data.chunk.offsets  # type: ignore[attr-defined]
+                    if write_item.tensor_data is None:
+                        raise AssertionError("Tensor write item must have tensor data")
+                    tensor_storage_key = _safetensors_storage_key(write_item)
+                    chunk_offsets = write_item.tensor_data.chunk.offsets
+                    tensor_dict[tensor_storage_key] = tensor  # type: ignore[attr-defined]
+                    metadata_dict[tensor_storage_key] = {  # type: ignore[attr-defined]
+                        LOGICAL_FQN_KEY: write_item.index.fqn,
+                        GLOBAL_SHAPE_KEY: list(write_item.tensor_data.size),
+                        SAVED_OFFSETS_KEY: list(chunk_offsets),
                     }
 
                 if serialization_format == SerializationFormat.SAFETENSORS:

--- a/torch/distributed/checkpoint/hf_storage.py
+++ b/torch/distributed/checkpoint/hf_storage.py
@@ -16,6 +16,8 @@ from torch.distributed.checkpoint._hf_utils import (
     _HFStorageInfo,
     _metadata_fn,
     CUSTOM_METADATA_KEY,
+    GLOBAL_SHAPE_KEY,
+    LOGICAL_FQN_KEY,
     SAVED_OFFSETS_KEY,
     SHARDED_DIR_NAME,
     SUFFIX,
@@ -88,8 +90,8 @@ class HuggingFaceStorageWriter(FileSystemWriter):
         self.enable_consolidation: bool = enable_consolidation
         self.consolidated_output_path: str | None = None
         if self.enable_consolidation:
-            self.consolidated_output_path = str(self.path)
-            self.path = self.fs.concat_path(self.path, SHARDED_DIR_NAME)
+            self.consolidated_output_path = path
+            self.path = self.fs.concat_path(path, SHARDED_DIR_NAME)
         self.thread_count_consolidation = thread_count_consolidation
 
     def prepare_global_plan(self, plans: list[SavePlan]) -> list[SavePlan]:
@@ -223,7 +225,9 @@ class HuggingFaceStorageReader(FileSystemReader):
             slice(offset, offset + length)
             for offset, length in zip(req.storage_offsets, req.lengths)
         )
-        tensor = f.get_slice(req.storage_index.fqn)[slices]
+        item_md: _HFStorageInfo = self.storage_data[req.storage_index]
+        storage_key = item_md.storage_key or req.storage_index.fqn
+        tensor = f.get_slice(storage_key)[slices]
         target_tensor = planner.resolve_tensor(req).detach()
 
         if target_tensor.size() != tensor.size():
@@ -333,21 +337,31 @@ class HuggingFaceStorageReader(FileSystemReader):
                         extra_metadata.get(CUSTOM_METADATA_KEY)
                     )
 
-                for key in keys:
-                    shape = f.get_slice(key).get_shape()
-                    dtype = f.get_slice(key).get_dtype()
+                for storage_key in keys:
+                    shape = f.get_slice(storage_key).get_shape()
+                    dtype = f.get_slice(storage_key).get_dtype()
                     # construct state_dict_metadata
                     if dcp_sharding_info is not None:
-                        offset = dcp_sharding_info[key][SAVED_OFFSETS_KEY]
+                        shard_info = dcp_sharding_info[storage_key]
+                        key = shard_info.get(LOGICAL_FQN_KEY, storage_key)
+                        global_shape = shard_info.get(GLOBAL_SHAPE_KEY)
+                        offset = shard_info[SAVED_OFFSETS_KEY]
                     else:
+                        key = storage_key
+                        global_shape = None
                         offset = [0] * len(shape)
 
                     if key not in state_dict_metadata:
+                        tensor_size = (
+                            torch.Size(global_shape)
+                            if global_shape is not None
+                            else torch.Size(
+                                [saved + offset for saved, offset in zip(shape, offset)]
+                            )
+                        )
                         state_dict_metadata[key] = TensorStorageMetadata(
                             properties=TensorProperties(dtype=_getdtype(dtype)),
-                            size=torch.Size(
-                                [saved + offset for saved, offset in zip(shape, offset)]
-                            ),
+                            size=tensor_size,
                             chunks=[
                                 ChunkStorageMetadata(
                                     offsets=torch.Size(offset),
@@ -361,22 +375,25 @@ class HuggingFaceStorageReader(FileSystemReader):
                                 torch.Size(offset), sizes=torch.Size(shape)
                             )
                         )
-                        size = list(state_dict_metadata[key].size)
-                        for i in range(len(size)):
-                            size[i] = max(size[i], shape[i] + offset[i])
-                        state_dict_metadata[key].size = torch.Size(size)
+                        if global_shape is not None:
+                            state_dict_metadata[key].size = torch.Size(global_shape)
+                        else:
+                            size = list(state_dict_metadata[key].size)
+                            for i in range(len(size)):
+                                size[i] = max(size[i], shape[i] + offset[i])
+                            state_dict_metadata[key].size = torch.Size(size)
 
                     # construct storage data
                     if dcp_sharding_info is not None:
-                        metadata_index = MetadataIndex(
-                            fqn=key, offset=dcp_sharding_info[key][SAVED_OFFSETS_KEY]
-                        )
+                        metadata_index = MetadataIndex(fqn=key, offset=offset)
                     else:
                         metadata_index = MetadataIndex(fqn=key, offset=[0] * len(shape))
+                    physical_key = storage_key if storage_key != key else None
                     storage_data[metadata_index] = _HFStorageInfo(
                         relative_path=safetensor_file,
                         shape=torch.Size(shape),
                         dtype=_getdtype(dtype),
+                        storage_key=physical_key,
                     )
 
         metadata = Metadata(

--- a/torch/distributed/checkpoint/quantized_hf_storage.py
+++ b/torch/distributed/checkpoint/quantized_hf_storage.py
@@ -123,7 +123,9 @@ class QuantizedHuggingFaceStorageReader(HuggingFaceStorageReader):
                 slice(offset, offset + length)
                 for offset, length in zip(req.storage_offsets, req.lengths)
             )
-            tensor = f.get_slice(tensor_fqn)[slices]
+            item_md = self.storage_data[req.storage_index]
+            storage_key = item_md.storage_key or tensor_fqn
+            tensor = f.get_slice(storage_key)[slices]
 
         target_tensor = planner.resolve_tensor(req).detach()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189945
* #189492

Add DCP safetensors metadata for mapping physical shard keys back to logical FQNs, and store the logical global shape for each shard. The HF reader, quantized HF reader, and consolidation path use that metadata to read shard payloads through their physical safetensors keys while preserving the logical checkpoint tensor metadata.

The tail-hole bug was caused by reconstructing logical tensor size as max(saved_offset + shard_shape). That loses trailing logical extent when no local shard reaches the end of the tensor. Storing `global_shape` in the DCP custom metadata fixes the size reconstruction while keeping a fallback for older checkpoints that only have saved offsets.


Authored with assistance from an AI assistant.
