### PR TITLE
Revert #189444: restore shim-linter cat-file timeout to 5s

### DIFF
--- a/tools/linter/adapters/_stable_shim_utils.py
+++ b/tools/linter/adapters/_stable_shim_utils.py
@@ -462,7 +462,7 @@ def merge_base_with_main() -> str:
             subprocess.run(
                 ["git", "cat-file", "-e", f"{main_sha}^{{commit}}"],
                 capture_output=True,
-                timeout=60,
+                timeout=5,
             ).returncode
             != 0
         )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189946

#189444 bumped the git cat-file timeout in merge_base_with_main() from 5s to
60s. That defeats the design introduced in #189419, which deliberately keeps a
short 5s timeout and catches subprocess.TimeoutExpired to fall back to the
slower git fetch: a timeout is the signal that the object is not present in the
partial clone, not something to wait out. Bumping to 60s just makes every cold
call block and masks that condition. Restore the 5s timeout so the graceful
fallback triggers promptly as intended.

Test Plan: lintrunner on _stable_shim_utils.py passes. The STABLE_SHIM_VERSION /
GENERATED_SHIMS_VERSION linters continue to resolve the merge base via the
try/except fallback on partial-clone CI checkouts.

Authored with Claude.