### PR TITLE
[lint] Degrade gracefully on shim-linter git timeouts instead of crashing

### DIFF
--- a/tools/linter/adapters/_stable_shim_utils.py
+++ b/tools/linter/adapters/_stable_shim_utils.py
@@ -434,19 +434,6 @@ class PreprocessorTracker:
         return found if found is not None else []
 
 
-def git_output_with_lazy_fetch(cmd: list[str]) -> subprocess.CompletedProcess[str]:
-    """
-    Run a read-only git command whose objects may be missing from a partial
-    clone. 5s is plenty when the objects are already local; if that times out,
-    they are not local yet, so retry and allow the on-demand fetch from the
-    promisor remote to complete.
-    """
-    try:
-        return subprocess.run(cmd, capture_output=True, text=True, timeout=5)
-    except subprocess.TimeoutExpired:
-        return subprocess.run(cmd, capture_output=True, text=True, timeout=600)
-
-
 @functools.cache
 def merge_base_with_main() -> str:
     """

--- a/tools/linter/adapters/_stable_shim_utils.py
+++ b/tools/linter/adapters/_stable_shim_utils.py
@@ -434,6 +434,19 @@ class PreprocessorTracker:
         return found if found is not None else []
 
 
+def git_output_with_lazy_fetch(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    """
+    Run a read-only git command whose objects may be missing from a partial
+    clone. 5s is plenty when the objects are already local; if that times out,
+    they are not local yet, so retry and allow the on-demand fetch from the
+    promisor remote to complete.
+    """
+    try:
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=5)
+    except subprocess.TimeoutExpired:
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=600)
+
+
 @functools.cache
 def merge_base_with_main() -> str:
     """

--- a/tools/linter/adapters/generated_shims_version_linter.py
+++ b/tools/linter/adapters/generated_shims_version_linter.py
@@ -13,7 +13,6 @@ import ast
 import json
 import logging
 import re
-import subprocess
 import sys
 from pathlib import Path
 
@@ -23,6 +22,7 @@ sys.path.insert(0, str(REPO_ROOT))
 
 from tools.linter.adapters._stable_shim_utils import (
     get_current_version,
+    git_output_with_lazy_fetch,
     LintMessage,
     LintSeverity,
     merge_base_with_main,
@@ -118,12 +118,7 @@ def _read_at_merge_base(filename: str) -> str | None:
     # `git show <ref>:<path>` requires <path> relative to the repo root;
     # lintrunner may pass `filename` as an absolute path.
     rel_path = Path(filename).resolve().relative_to(REPO_ROOT).as_posix()
-    result = subprocess.run(
-        ["git", "show", f"{merge_base}:{rel_path}"],
-        capture_output=True,
-        text=True,
-        timeout=5,
-    )
+    result = git_output_with_lazy_fetch(["git", "show", f"{merge_base}:{rel_path}"])
     if result.returncode != 0:
         # File didn't exist at merge-base; treat all current entries as new.
         return None

--- a/tools/linter/adapters/generated_shims_version_linter.py
+++ b/tools/linter/adapters/generated_shims_version_linter.py
@@ -13,6 +13,7 @@ import ast
 import json
 import logging
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -22,7 +23,6 @@ sys.path.insert(0, str(REPO_ROOT))
 
 from tools.linter.adapters._stable_shim_utils import (
     get_current_version,
-    git_output_with_lazy_fetch,
     LintMessage,
     LintSeverity,
     merge_base_with_main,
@@ -118,7 +118,12 @@ def _read_at_merge_base(filename: str) -> str | None:
     # `git show <ref>:<path>` requires <path> relative to the repo root;
     # lintrunner may pass `filename` as an absolute path.
     rel_path = Path(filename).resolve().relative_to(REPO_ROOT).as_posix()
-    result = git_output_with_lazy_fetch(["git", "show", f"{merge_base}:{rel_path}"])
+    result = subprocess.run(
+        ["git", "show", f"{merge_base}:{rel_path}"],
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
     if result.returncode != 0:
         # File didn't exist at merge-base; treat all current entries as new.
         return None
@@ -203,7 +208,14 @@ def _check_one_dict(
 
 def check_file(filename: str) -> list[LintMessage]:
     current_dicts = parse_fallback_ops(Path(filename).read_text())
-    base_src = _read_at_merge_base(filename)
+    try:
+        base_src = _read_at_merge_base(filename)
+    except subprocess.TimeoutExpired:
+        # On a partial-clone CI checkout, reading the base file lazily fetches
+        # its blob from the promisor remote, which can exceed the 5s local-op
+        # budget. Skip rather than crash or treat every op as new: an empty base
+        # would false-positive on all already-versioned ops.
+        return []
     base_dicts = parse_fallback_ops(base_src) if base_src is not None else {}
 
     major, minor, patch = get_current_version()

--- a/tools/linter/adapters/stable_shim_version_linter.py
+++ b/tools/linter/adapters/stable_shim_version_linter.py
@@ -21,7 +21,6 @@ sys.path.insert(0, str(REPO_ROOT))
 
 from tools.linter.adapters._stable_shim_utils import (
     get_current_version,
-    git_output_with_lazy_fetch,
     LintMessage,
     LintSeverity,
     merge_base_with_main,
@@ -44,6 +43,8 @@ def get_added_lines(filename: str) -> set[int]:
     Returns:
         Set of line numbers (1-indexed) that are new additions.
     """
+    import subprocess
+
     added_lines = set()
 
     def parse_diff(diff_output: str) -> set[int]:
@@ -67,14 +68,22 @@ def get_added_lines(filename: str) -> set[int]:
 
     try:
         # Check uncommitted changes (working directory vs HEAD)
-        result = git_output_with_lazy_fetch(["git", "diff", "HEAD", filename])
+        result = subprocess.run(
+            ["git", "diff", "HEAD", filename],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
         if result.returncode == 0:
             added_lines.update(parse_diff(result.stdout))
 
         # Get merge-base with origin/main to check all PR commits
         merge_base = merge_base_with_main()
-        result = git_output_with_lazy_fetch(
-            ["git", "diff", f"{merge_base}..HEAD", filename]
+        result = subprocess.run(
+            ["git", "diff", f"{merge_base}..HEAD", filename],
+            capture_output=True,
+            text=True,
+            timeout=5,
         )
         if result.returncode != 0:
             raise RuntimeError(
@@ -82,6 +91,13 @@ def get_added_lines(filename: str) -> set[int]:
             )
         added_lines.update(parse_diff(result.stdout))
 
+    except subprocess.TimeoutExpired:
+        # On a partial-clone CI checkout, git diff lazily fetches the shim blob
+        # from the promisor remote, which can exceed the 5s local-op budget.
+        # Fall back to no added lines rather than crash: enforcement then only
+        # applies to lines we can confirm are new (safe for the AOTI shim, whose
+        # existing declarations are already exempt when not newly added).
+        return set()
     except Exception as e:
         raise RuntimeError(
             f"Failed to get git diff information for {filename}. Error: {e}"

--- a/tools/linter/adapters/stable_shim_version_linter.py
+++ b/tools/linter/adapters/stable_shim_version_linter.py
@@ -21,6 +21,7 @@ sys.path.insert(0, str(REPO_ROOT))
 
 from tools.linter.adapters._stable_shim_utils import (
     get_current_version,
+    git_output_with_lazy_fetch,
     LintMessage,
     LintSeverity,
     merge_base_with_main,
@@ -43,8 +44,6 @@ def get_added_lines(filename: str) -> set[int]:
     Returns:
         Set of line numbers (1-indexed) that are new additions.
     """
-    import subprocess
-
     added_lines = set()
 
     def parse_diff(diff_output: str) -> set[int]:
@@ -68,22 +67,14 @@ def get_added_lines(filename: str) -> set[int]:
 
     try:
         # Check uncommitted changes (working directory vs HEAD)
-        result = subprocess.run(
-            ["git", "diff", "HEAD", filename],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
+        result = git_output_with_lazy_fetch(["git", "diff", "HEAD", filename])
         if result.returncode == 0:
             added_lines.update(parse_diff(result.stdout))
 
         # Get merge-base with origin/main to check all PR commits
         merge_base = merge_base_with_main()
-        result = subprocess.run(
-            ["git", "diff", f"{merge_base}..HEAD", filename],
-            capture_output=True,
-            text=True,
-            timeout=5,
+        result = git_output_with_lazy_fetch(
+            ["git", "diff", f"{merge_base}..HEAD", filename]
         )
         if result.returncode != 0:
             raise RuntimeError(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #189947

Follows the pattern from #189419: keep the short 5s timeout (plenty when git
objects are local) and, on subprocess.TimeoutExpired, take an explicit graceful
fallback rather than raising the ceiling. A timeout signals the objects are not
present in the partial clone, not that we should wait longer, and bumping the
default only blocks every cold call while hiding that condition.

The two blob-reading call sites are handled per their linter's semantics:

- stable_shim_version_linter.get_added_lines (the two git diff calls): on
  timeout, fall back to an empty added-lines set. Enforcement then only applies
  to lines confirmed new; the AOTI shim's existing declarations are already
  exempt when not newly added, so this cannot false-positive.

- generated_shims_version_linter (the git show base read): on timeout, skip the
  check (return no messages). Crucially this must NOT reuse the "file absent"
  path, which treats every current op as newly added: with the base empty, all
  already-versioned ops (currently 2.10-2.13 against a 2.14 tree) would be
  flagged wrong-version, turning a flaky infra timeout into ~24 false errors.

The git merge-base call is left at 5s untouched: it only walks the commit graph,
which a blobless partial clone has in full, so it never touches the network.

Test Plan: lintrunner on the three adapters passes (STABLE_SHIM_VERSION and
GENERATED_SHIMS_VERSION clean). The partial-clone network timeout is CI-only and
not deterministically reproducible locally.

Authored with Claude.