### PR TITLE
Let deprecated-declarations warn (not error) in c10/ATen/torch builds

### DIFF
--- a/cmake/public/utils.cmake
+++ b/cmake/public/utils.cmake
@@ -414,6 +414,9 @@ function(torch_compile_options libname)
         -Werror=pedantic
         -Werror=unused
         -Wno-error=unused-parameter
+        # Deprecated APIs (e.g. c10::checked_convert) must warn, not break the
+        # build, so they can be retired while external/BC callers migrate.
+        -Wno-error=deprecated-declarations
       )
       if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
         list(APPEND private_compile_options -Werror=unused-but-set-variable -Werror=cpp)

--- a/defs.bzl
+++ b/defs.bzl
@@ -16,6 +16,9 @@ default_compiler_flags = [
     "-Wno-unused-function",
     "-Wno-unused-parameter",
     "-Wno-error=strict-aliasing",
+    # Deprecated APIs (e.g. c10::checked_convert) must warn, not break the build,
+    # so they can be retired while external/BC callers migrate.
+    "-Wno-error=deprecated-declarations",
     "-Wno-shadow-compatible-local",
     "-Wno-maybe-uninitialized",  # aten is built with gcc as part of HHVM
     "-Wno-unknown-pragmas",


### PR DESCRIPTION
Summary:
To retire `c10::checked_convert` (and enable future API deprecations) without breaking `-Werror` builds, add `-Wno-error=deprecated-declarations` to the canonical warning-flag lists: `C10_COMPILER_FLAGS` (c10, the only fbcode list that sets `-Werror`), `default_compiler_flags` (ATen), `compiler_flags_cpu` (libtorch), and the `WERROR` block in `cmake/public/utils.cmake` (OSS). This makes `[[deprecated]]` APIs emit warnings while callers migrate.

This is the bottom of a stack that introduces `c10::safe_conv`/`c10::wrapping_convert`, deprecates `checked_convert`, migrates callers, and enables `-Wshorten-64-to-32` as an error for FBGEMM's HIP build.

Test Plan:
Relied on by the rest of the stack; `buck2 build fbcode//caffe2/c10/...`, `//caffe2:_ATen-cpu`, and `//caffe2:_ATen-cu` build green with the deprecated `checked_convert` alias present.

Authored with the assistance of Claude Code.

Differential Revision: D112008234
