### PR TITLE
docker-builds: move image builds to regular OSDC runners

### DIFF
--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -77,17 +77,12 @@ jobs:
         include:
           - docker-image-name: pytorch-linux-jammy-aarch64-py3.10-gcc13
             buildkit_addr: "tcp://buildkitd-arm64.buildkit:1234"
-            runner_label: mt-rel-l-arm64g4-16-62
+            runner_label: mt-l-arm64g4-16-62
           - docker-image-name: pytorch-linux-jammy-aarch64-py3.10-gcc13-inductor-benchmarks
             buildkit_addr: "tcp://buildkitd-arm64.buildkit:1234"
             timeout-minutes: 600
-            runner_label: mt-rel-l-arm64g4-16-62
-    # Use the mt-rel-* release runner labels: their nodes carry
-    # osdc.io/runner-class=release, which exempts them from the cache-enforcer
-    # DaemonSet's iptables block on outbound ghcr.io traffic so the "Mirror image
-    # to GHCR" step can succeed. The regular mt-l-* pool blocks ghcr.io egress at
-    # the host iptables layer.
-    runs-on: ${{ matrix.runner_label || 'mt-rel-l-x86iavx512-8-64' }}
+            runner_label: mt-l-arm64g4-16-62
+    runs-on: ${{ matrix.runner_label || 'mt-l-x86iavx512-8-64' }}
     container:
       image: ghcr.io/actions/actions-runner:latest
     steps:


### PR DESCRIPTION
`docker-builds.yml` ran its image builds on the `mt-rel-*` release runners for ghcr.io egress exemption. That's no longer needed or valid:
- the cache-enforcer DaemonSet that blocked ghcr egress on the regular `mt-l-*` pool is no longer deployed, so the exemption is moot; and
- the specific `mt-rel-l-x86iavx512-8-64` / `mt-rel-l-arm64g4-16-62` labels were **deleted** by pytorch/ci-infra#888, so these jobs currently point at runners that no longer exist.

Move to the equivalent regular OSDC runners (`mt-l-x86iavx512-8-64` / `mt-l-arm64g4-16-62`) and drop the stale egress-exemption comment. This also frees the release runners for actual release builds.

Authored with the assistance of Claude Code.