### PR TITLE
Avoid specializing FlexAttention dynamic sequence lengths in block mask checks

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -8080,7 +8080,7 @@ BlockMask(shape=(1,s1,s2048,s2048),ssparsity=46.88%,s
                 torch.randn(1, 1, S, 64, dtype=dtype, device=device) for _ in range(3)
             )
             for x in (q, k, v):
-                torch._dynamo.mark_dynamic(x, 2, min=128, max=1024)
+                torch._dynamo.mark_dynamic(x, 2, min=128, max=320)
             return q, k, v
 
         counter = CompileCounterWithBackend("eager")
@@ -8096,6 +8096,19 @@ BlockMask(shape=(1,s1,s2048,s2048),ssparsity=46.88%,s
                 )
 
         self.assertEqual(counter.frame_count, 1)
+
+        def create_plain_inputs(S):
+            return tuple(
+                torch.randn(1, 1, S, 64, dtype=dtype, device=device) for _ in range(3)
+            )
+
+        @torch.compile(fullgraph=True, backend="eager")
+        def flex_attention_plain(q, k, v):
+            return flex_attention(q, k, v, block_mask=block_mask)
+
+        flex_attention_plain(*create_plain_inputs(320))
+        with self.assertRaisesRegex(Exception, "block_mask was created for a smaller length"):
+            flex_attention_plain(*create_plain_inputs(512))
 
     @supported_platform
     @common_utils.parametrize("full_indices", [False, True])

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -8067,7 +8067,7 @@ BlockMask(shape=(1,s1,s2048,s2048),ssparsity=46.88%,s
 
     @supported_platform
     @skip_on_cpu
-    @expected_not_implemented_on_mps
+    @skip_on_mps
     def test_block_mask_check_does_not_specialize_backed_dynamic_length(self, device):
         def mask_mod(b, h, q_idx, kv_idx):
             return q_idx >= kv_idx

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -8116,8 +8116,12 @@ BlockMask(shape=(1,s1,s2048,s2048),ssparsity=46.88%,s
             dynamic_guard_code,
         )
 
-        stale_block_mask = create_block_mask(mask_mod, None, None, 320, 320, device=device)
-        with self.assertRaisesRegex(Exception, "block_mask was created for a smaller length"):
+        stale_block_mask = create_block_mask(
+            mask_mod, None, None, 320, 320, device=device
+        )
+        with self.assertRaisesRegex(
+            Exception, "block_mask was created for a smaller length"
+        ):
             flex_attention_call(*create_inputs(512)[:3], stale_block_mask)
 
     @supported_platform

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -8072,7 +8072,7 @@ BlockMask(shape=(1,s1,s2048,s2048),ssparsity=46.88%,s
         def mask_mod(b, h, q_idx, kv_idx):
             return q_idx >= kv_idx
 
-        dtype = device_configs[device].dtypes_fast[0]
+        dtype = device_configs[torch.device(device).type].dtypes_fast[0]
 
         def create_inputs(S):
             q, k, v = (

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -8066,6 +8066,38 @@ BlockMask(shape=(1,s1,s2048,s2048),ssparsity=46.88%,s
             flex_attention_call(*create_inputs(1024), block_mask=block_mask)
 
     @supported_platform
+    @skip_on_cpu
+    @expected_not_implemented_on_mps
+    def test_block_mask_check_does_not_specialize_backed_dynamic_length(self, device):
+        def mask_mod(b, h, q_idx, kv_idx):
+            return q_idx >= kv_idx
+
+        block_mask = create_block_mask(mask_mod, None, None, 320, 320, device=device)
+        dtype = device_configs[device].dtypes_fast[0]
+
+        def create_inputs(S):
+            q, k, v = (
+                torch.randn(1, 1, S, 64, dtype=dtype, device=device) for _ in range(3)
+            )
+            for x in (q, k, v):
+                torch._dynamo.mark_dynamic(x, 2, min=128, max=1024)
+            return q, k, v
+
+        counter = CompileCounterWithBackend("eager")
+
+        @torch.compile(fullgraph=True, backend=counter)
+        def flex_attention_call(q, k, v):
+            return flex_attention(q, k, v, block_mask=block_mask)
+
+        with torch.no_grad():
+            for S in (320, 256):
+                self.assertEqual(
+                    flex_attention_call(*create_inputs(S)).shape, (1, 1, S, 64)
+                )
+
+        self.assertEqual(counter.frame_count, 1)
+
+    @supported_platform
     @common_utils.parametrize("full_indices", [False, True])
     def test_from_kv_blocks_without_q_computation(self, device, full_indices: bool):
         (

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -8072,43 +8072,53 @@ BlockMask(shape=(1,s1,s2048,s2048),ssparsity=46.88%,s
         def mask_mod(b, h, q_idx, kv_idx):
             return q_idx >= kv_idx
 
-        block_mask = create_block_mask(mask_mod, None, None, 320, 320, device=device)
         dtype = device_configs[device].dtypes_fast[0]
 
         def create_inputs(S):
             q, k, v = (
                 torch.randn(1, 1, S, 64, dtype=dtype, device=device) for _ in range(3)
             )
-            for x in (q, k, v):
-                torch._dynamo.mark_dynamic(x, 2, min=128, max=320)
-            return q, k, v
+            block_mask = create_block_mask(mask_mod, None, None, S, S, device=device)
+            return q, k, v, block_mask
 
         counter = CompileCounterWithBackend("eager")
+        guard_code_parts = []
 
         @torch.compile(fullgraph=True, backend=counter)
-        def flex_attention_call(q, k, v):
+        def flex_attention_call(q, k, v, block_mask):
             return flex_attention(q, k, v, block_mask=block_mask)
 
-        with torch.no_grad():
-            for S in (320, 256):
-                self.assertEqual(
-                    flex_attention_call(*create_inputs(S)).shape, (1, 1, S, 64)
-                )
+        def collect_guard_code_parts(guard_wrapper, f_locals, builder):
+            parts = []
+            for guard in guard_wrapper.root.get_epilogue_lambda_guards():
+                parts.extend(guard.verbose_code_parts())
+            guard_code_parts.append(parts)
 
-        self.assertEqual(counter.frame_count, 1)
+        old_hook = torch._dynamo.guards.guard_manager_testing_hook_fn
+        torch._dynamo.guards.guard_manager_testing_hook_fn = collect_guard_code_parts
+        try:
+            with torch.no_grad():
+                for S in (320, 256, 192):
+                    self.assertEqual(
+                        flex_attention_call(*create_inputs(S)).shape, (1, 1, S, 64)
+                    )
+        finally:
+            torch._dynamo.guards.guard_manager_testing_hook_fn = old_hook
 
-        def create_plain_inputs(S):
-            return tuple(
-                torch.randn(1, 1, S, 64, dtype=dtype, device=device) for _ in range(3)
-            )
+        self.assertEqual(counter.frame_count, 2)
+        dynamic_guard_code = "\n".join(guard_code_parts[-1])
+        self.assertIn(
+            "L['block_mask'].seq_lengths[0] == L['q'].size()[2]",
+            dynamic_guard_code,
+        )
+        self.assertIn(
+            "L['block_mask'].seq_lengths[1] == L['k'].size()[2]",
+            dynamic_guard_code,
+        )
 
-        @torch.compile(fullgraph=True, backend="eager")
-        def flex_attention_plain(q, k, v):
-            return flex_attention(q, k, v, block_mask=block_mask)
-
-        flex_attention_plain(*create_plain_inputs(320))
+        stale_block_mask = create_block_mask(mask_mod, None, None, 320, 320, device=device)
         with self.assertRaisesRegex(Exception, "block_mask was created for a smaller length"):
-            flex_attention_plain(*create_plain_inputs(512))
+            flex_attention_call(*create_inputs(512)[:3], stale_block_mask)
 
     @supported_platform
     @common_utils.parametrize("full_indices", [False, True])

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -20,10 +20,7 @@ import torch
 from torch import Tensor
 from torch._higher_order_ops.flex_attention import flex_attention as flex_attention_hop
 from torch._higher_order_ops.utils import setup_compilation_env
-from torch.fx.experimental.symbolic_shapes import (
-    has_free_unbacked_symbols,
-    statically_known_true,
-)
+from torch.fx.experimental.symbolic_shapes import has_free_unbacked_symbols
 from torch.nn.attention._utils import _validate_sdpa_input
 from torch.utils._pytree import (
     GetAttrKey,
@@ -109,21 +106,20 @@ def _validate_block_mask_shape(
         torch._check(kv_len >= block_mask_kv_len, _BLOCK_MASK_TOO_LARGE_ERROR)
         return
 
-    # Case 2: Dynamo-backed lengths keep upper bounds but avoid equality guards.
-    if torch.compiler.is_dynamo_compiling():
-        torch._check(q_len <= block_mask_q_len, _BLOCK_MASK_TOO_SMALL_ERROR)
-        torch._check(kv_len <= block_mask_kv_len, _BLOCK_MASK_TOO_SMALL_ERROR)
-        return
-
-    # Case 3: eager/non-Dynamo callers still validate statically known mismatches.
-    if statically_known_true(q_len > block_mask_q_len) or statically_known_true(
-        kv_len > block_mask_kv_len
-    ):
+    # Case 2: backed lengths use regular validation so Dynamo can generalize equality.
+    if q_len > block_mask_q_len or kv_len > block_mask_kv_len:
         raise RuntimeError(_BLOCK_MASK_TOO_SMALL_ERROR)
-    if statically_known_true(q_len < block_mask_q_len) or statically_known_true(
-        kv_len < block_mask_kv_len
-    ):
+    if q_len < block_mask_q_len or kv_len < block_mask_kv_len:
         raise RuntimeError(_BLOCK_MASK_TOO_LARGE_ERROR)
+
+    if q_len != block_mask_q_len:
+        raise AssertionError(
+            f"query.size(-2) ({q_len}) != block_mask_q_len ({block_mask_q_len})"
+        )
+    if kv_len != block_mask_kv_len:
+        raise AssertionError(
+            f"key.size(-2) ({kv_len}) != block_mask_kv_len ({block_mask_kv_len})"
+        )
 
 
 __all__ = [

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -109,8 +109,10 @@ def _validate_block_mask_shape(
         torch._check(kv_len >= block_mask_kv_len, _BLOCK_MASK_TOO_LARGE_ERROR)
         return
 
-    # Case 2: Dynamo-backed lengths must not emit checks that force equality guards.
+    # Case 2: Dynamo-backed lengths keep upper bounds but avoid equality guards.
     if torch.compiler.is_dynamo_compiling():
+        torch._check(q_len <= block_mask_q_len, _BLOCK_MASK_TOO_SMALL_ERROR)
+        torch._check(kv_len <= block_mask_kv_len, _BLOCK_MASK_TOO_SMALL_ERROR)
         return
 
     # Case 3: eager/non-Dynamo callers still validate statically known mismatches.

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -20,6 +20,10 @@ import torch
 from torch import Tensor
 from torch._higher_order_ops.flex_attention import flex_attention as flex_attention_hop
 from torch._higher_order_ops.utils import setup_compilation_env
+from torch.fx.experimental.symbolic_shapes import (
+    has_free_unbacked_symbols,
+    statically_known_true,
+)
 from torch.nn.attention._utils import _validate_sdpa_input
 from torch.utils._pytree import (
     GetAttrKey,
@@ -77,6 +81,47 @@ def _warn_once(
         if not torch.compiler.is_compiling():
             warnings.warn(message, category, stacklevel=2)
         _WARNINGS_SHOWN.add(warning_id)
+
+
+def _validate_block_mask_shape(
+    query: Tensor,
+    key: Tensor,
+    q_len: int | torch.SymInt,
+    kv_len: int | torch.SymInt,
+    block_mask_q_len: int | torch.SymInt,
+    block_mask_kv_len: int | torch.SymInt,
+) -> None:
+    """Preserve unbacked checks without specializing regular dynamic lengths."""
+    has_unbacked_input_lengths = has_free_unbacked_symbols(
+        query
+    ) or has_free_unbacked_symbols(key)
+    if not torch.compiler.is_dynamo_compiling():
+        lengths = (q_len, kv_len, block_mask_q_len, block_mask_kv_len)
+        has_unbacked_input_lengths = (
+            has_unbacked_input_lengths or has_free_unbacked_symbols(lengths)
+        )
+
+    # Case 1: unbacked lengths need symbolic checks that can become runtime assertions.
+    if has_unbacked_input_lengths:
+        torch._check(q_len <= block_mask_q_len, _BLOCK_MASK_TOO_SMALL_ERROR)
+        torch._check(kv_len <= block_mask_kv_len, _BLOCK_MASK_TOO_SMALL_ERROR)
+        torch._check(q_len >= block_mask_q_len, _BLOCK_MASK_TOO_LARGE_ERROR)
+        torch._check(kv_len >= block_mask_kv_len, _BLOCK_MASK_TOO_LARGE_ERROR)
+        return
+
+    # Case 2: Dynamo-backed lengths must not emit checks that force equality guards.
+    if torch.compiler.is_dynamo_compiling():
+        return
+
+    # Case 3: eager/non-Dynamo callers still validate statically known mismatches.
+    if statically_known_true(q_len > block_mask_q_len) or statically_known_true(
+        kv_len > block_mask_kv_len
+    ):
+        raise RuntimeError(_BLOCK_MASK_TOO_SMALL_ERROR)
+    if statically_known_true(q_len < block_mask_q_len) or statically_known_true(
+        kv_len < block_mask_kv_len
+    ):
+        raise RuntimeError(_BLOCK_MASK_TOO_LARGE_ERROR)
 
 
 __all__ = [
@@ -2457,23 +2502,8 @@ def flex_attention(
         block_mask_q_len = block_mask.shape[-2]
         block_mask_kv_len = block_mask.shape[-1]
 
-        # Keep these as separate checks: explicit sym_and/sym_or calls become
-        # trace-visible non-Tensor ops under Dynamo.
-        torch._check(
-            q_len <= block_mask_q_len,
-            _BLOCK_MASK_TOO_SMALL_ERROR,
-        )
-        torch._check(
-            kv_len <= block_mask_kv_len,
-            _BLOCK_MASK_TOO_SMALL_ERROR,
-        )
-        torch._check(
-            q_len >= block_mask_q_len,
-            _BLOCK_MASK_TOO_LARGE_ERROR,
-        )
-        torch._check(
-            kv_len >= block_mask_kv_len,
-            _BLOCK_MASK_TOO_LARGE_ERROR,
+        _validate_block_mask_shape(
+            query, key, q_len, kv_len, block_mask_q_len, block_mask_kv_len
         )
 
     if scale is None:


### PR DESCRIPTION
## Human Note
I did a bunch of rounds with codex, i think this mostly closely restores the original behvaior,
 while still adding runtime asserts for unbacked shapes. I dont love this. We basically want torch-check to 
 still allow for backed shapes to not make such a strict guard that auto dyanmic dim still works.

 I assume codex added all the detail from our journey

## Agent Report
# FlexAttention block-mask dynamic length fix

## Summary

FlexAttention's block-mask length validation used four unconditional `torch._check` calls. For regular backed Dynamo dimensions, those checks could pin query/key sequence lengths to the first concrete BlockMask length instead of letting automatic dynamic shapes learn that the query/key lengths equal the recreated BlockMask lengths.

The fix keeps the `torch._check` form only for unbacked symbolic lengths, where Python branches cannot decide the predicate. Backed lengths use the previous Python branch/assert validation shape, preserving exact equality and nice errors while allowing Dynamo's automatic dynamic-dim recompilation to produce a reusable symbolic equality guard.

## Guard behavior before and after

Before `#183838`, backed lengths used Python validation. On the first call, Dynamo compiled a static graph. On the first changed sequence length, automatic dynamic shapes recompiled and made both sides dynamic:

```text
create_symbol s50 = 256 for L['query'].size()[2]
marking L['block_mask'].seq_lengths[0] as dynamic
create_symbol s37 = 256 for L['block_mask'].seq_lengths[0]
eval s50 <= s37 [guard added]
eval s50 >= s37 [guard added]
eval Eq(s50, s37) [guard added]
LAMBDA_GUARD: L['block_mask'].seq_lengths[0] == L['query'].size()[2]
```

That is the useful behavior: the graph is dynamic in sequence length, but still enforces the public equality contract between the query/key lengths and the BlockMask lengths.

After `#183838`, the same equality was expressed as unconditional `torch._check` calls. For backed/hinted symbols, those checks can guard against the current concrete BlockMask length:

```text
eval s50 <= 320 [guard added] torch._check(...)
eval s50 >= 320 [guard added] torch._check(...)
```

Together these force `s50 == 320`, so a dynamic query length is specialized to the first concrete BlockMask length and automatic dynamic shapes cannot produce the desired reusable equality between query length and recreated BlockMask length.

After this fix:

- unbacked lengths keep the full `torch._check` path so checks can become deferred runtime assertions;
- backed lengths use Python validation again, so automatic dynamic shapes can generalize to `block_mask.seq_lengths[0] == query.size()[2]`;
- stale too-small BlockMasks still raise the existing error instead of running an unsafe graph.

## Root cause

The issue was not the equality contract itself. FlexAttention still expects the query/KV sequence lengths to match the BlockMask logical lengths. The issue was representing that equality with unconditional `torch._check` for backed Dynamo symbols. For backed/hinted dimensions, `torch._check` participates in guard production differently from the old Python branch/assert path and can specialize the symbol to the current hint.

## Fix

`torch/nn/attention/flex_attention.py` now routes block-mask shape validation through `_validate_block_mask_shape`:

- query/key tensors with unbacked lengths use the full `torch._check` path;
- regular backed lengths use the pre-existing Python validation shape, preserving exact equality while allowing Dynamo automatic dynamic shapes to generalize equality between query/key lengths and recreated BlockMask lengths.

`test/inductor/test_flex_attention.py` adds a regression that compiles FlexAttention, recreates a matching BlockMask for each changing sequence length, and checks that automatic dynamic dims produce one generalized graph after the first size change. It inspects the generalized graph's guard code and asserts that Dynamo guards `block_mask.seq_lengths[0] == q.size()[2]` and `block_mask.seq_lengths[1] == k.size()[2]`, then verifies that an oversized query with a stale too-small BlockMask still raises the existing “block_mask was created for a smaller length” error.

## PR feedback addressed

- Preserved too-small-mask protection: a stale 320-token BlockMask with a 512-token query still raises.
- Removed the `statically_known_true` path; backed lengths now use the old Python validation structure directly.
- Kept `has_free_unbacked_symbols(query/key)` for the Dynamo path and only inspect the tuple of scalar lengths outside Dynamo, avoiding the unsupported tuple-of-symbols tracing issue.
- Clarified the backed-SymInt behavior: regular tensor sizes are backed symbols, and the fix lets Dynamo relate them to BlockMask metadata dynamically instead of pinning them to a concrete hint.
- Avoided using `torch._check` for backed equality, which sidesteps the symbol-refinement/guarding interaction discussed in review.

## Repro

<details>
<summary>Repro Script</summary>

```python
import os

os.environ.setdefault("TORCHINDUCTOR_COMPILE_THREADS", "1")

import torch
from torch.nn.attention.flex_attention import create_block_mask, flex_attention


def causal_mask(batch, head, query_index, kv_index):
    return query_index >= kv_index


@torch.compile(fullgraph=True)
def attention(query, key, value, block_mask):
    return flex_attention(query, key, value, block_mask=block_mask)


def make_inputs(seq_len):
    tensors = tuple(
        torch.randn(1, 1, seq_len, 64, device="cuda", dtype=torch.float16)
        for _ in range(3)
    )
    block_mask = create_block_mask(
        causal_mask,
        B=None,
        H=None,
        Q_LEN=seq_len,
        KV_LEN=seq_len,
        device="cuda",
        BLOCK_SIZE=64,
    )
    return *tensors, block_mask


def main():
    torch._dynamo.reset()
    torch._dynamo.config.cache_size_limit = 2
    torch._dynamo.config.accumulated_cache_size_limit = 8
    with torch.no_grad():
        for seq_len in (320, 256, 192, 128):
            print(f"running seq_len={seq_len}", flush=True)
            out = attention(*make_inputs(seq_len))
            torch.cuda.synchronize()
            print(tuple(out.shape), flush=True)


if __name__ == "__main__":
    main()
```

Output after the fix:

```text
running seq_len=320
(1, 1, 320, 64)
running seq_len=256
V... [__recompiles] Recompiling function attention ... tensor 'key' size mismatch at index 2. expected 320, actual 256
(1, 1, 256, 64)
running seq_len=192
(1, 1, 192, 64)
running seq_len=128
(1, 1, 128, 64)
```

The single 320-to-256 recompile is Dynamo's normal automatic dynamic-dim generalization point. Before the fix, the `torch._check` structure could specialize the backed sequence dimension to the first concrete BlockMask length instead of producing a reusable symbolic equality.

</details>

## Validation

Behavioral tests:

```bash
cd ~/.ptq_workspace/jobs/20260714-pytorch-189786/pytorch && PYTORCH_TEST_WITH_INDUCTOR=1 INDUCTOR_TEST_DISABLE_FRESH_CACHE=1 TORCHINDUCTOR_COMPILE_THREADS=1 ../.venv/bin/python test/inductor/test_flex_attention.py TestFlexAttentionCUDA.test_block_mask_vs_sequence_lengths_cuda TestFlexAttentionCUDA.test_block_mask_check_does_not_specialize_backed_dynamic_length_cuda
```

```bash
cd ~/.ptq_workspace/jobs/20260714-pytorch-189786/pytorch && PYTORCH_TEST_WITH_INDUCTOR=1 INDUCTOR_TEST_DISABLE_FRESH_CACHE=1 TORCHINDUCTOR_COMPILE_THREADS=1 ../.venv/bin/python test/inductor/test_flex_attention.py TestFlexAttentionCUDA.test_dynamic_shapes_bug_dynamic_batch_cuda
```

Repro check:

```bash
cd ~/.ptq_workspace/jobs/20260714-pytorch-189786 && TORCH_LOGS="recompiles" ./.venv/bin/python repro.py
```

Prerequisite checks:

```bash
cd ~/.ptq_workspace/jobs/20260714-pytorch-189786/pytorch && ../.venv/bin/python -m py_compile torch/nn/attention/flex_attention.py test/inductor/test_flex_attention.py
```

```bash
cd ~/.ptq_workspace/jobs/20260714-pytorch-189786/pytorch && git diff --check
```

`spin quicklint` was run after applying `spin quickfix` to the changed files and passed. After PR CI reported CUDA/ROCm failures in the new test, the test was updated to use `device_configs[torch.device(device).type]` because those jobs can parametrize the device as `cuda:0` while `device_configs` is keyed by accelerator type. After macOS reported that the test unexpectedly passed under `@expected_not_implemented_on_mps`, the decorator was changed to `@skip_on_mps`. Earlier, repo-wide `spin fixlint` applied available patches for configured Python/format lint groups but exited nonzero on unrelated pre-existing shellcheck findings in `.ci/pytorch/test.sh` and `test/run_test.sh`.


Fixes #189786


<details>
<summary>Repro Script</summary>

```python
import os

os.environ.setdefault("TORCHINDUCTOR_COMPILE_THREADS", "1")

import torch
from torch.nn.attention.flex_attention import create_block_mask, flex_attention


def causal_mask(batch, head, query_index, kv_index):
    return query_index >= kv_index


@torch.compile(fullgraph=True)
def attention(query, key, value, block_mask):
    return flex_attention(query, key, value, block_mask=block_mask)


def make_inputs(seq_len):
    tensors = tuple(
        torch.randn(1, 1, seq_len, 64, device="cuda", dtype=torch.float16)
        for _ in range(3)
    )
    block_mask = create_block_mask(
        causal_mask,
        B=None,
        H=None,
        Q_LEN=seq_len,
        KV_LEN=seq_len,
        device="cuda",
        BLOCK_SIZE=64,
    )
    return *tensors, block_mask


def main():
    torch._dynamo.reset()
    torch._dynamo.config.cache_size_limit = 2
    torch._dynamo.config.accumulated_cache_size_limit = 8
    with torch.no_grad():
        for seq_len in (320, 256, 192, 128):
            print(f"running seq_len={seq_len}", flush=True)
            out = attention(*make_inputs(seq_len))
            torch.cuda.synchronize()
            print(tuple(out.shape), flush=True)


if __name__ == "__main__":
    main()
```

</details>


<details>
<summary>Agent Worklog</summary>

## Run 1

### Priming and reproduction

Read `prime.md`, PTQ context, the issue prompt, source `AGENTS.md`, and relevant agent notes. There was no existing `report.md` or upstream `repro.py`.

Created `repro.py` showing that FlexAttention's block-mask `_check` calls specialize a `mark_dynamic` query/key sequence dimension to the first concrete block-mask length. The repro fails during Dynamo guard creation with `ConstraintViolationError` pointing at `torch/nn/attention/flex_attention.py:2470` and `:2474`.

### Fix and validation

Changed FlexAttention block-mask shape validation so unbacked lengths keep the full `torch._check` path, while regular backed lengths use the previous Python branch/assert validation. This preserves exact equality but lets Dynamo automatic dynamic shapes generalize equality between query/key lengths and the recreated BlockMask lengths instead of pinning to the first concrete value.

Added `test_block_mask_check_does_not_specialize_backed_dynamic_length` to cover a compiled FlexAttention call with recreated matching BlockMasks across changing query/key/value sequence lengths. The test also checks that an oversized sequence with a stale too-small BlockMask still raises the existing error.

Validation run:

- `../.venv/bin/python -m py_compile torch/nn/attention/flex_attention.py test/inductor/test_flex_attention.py`
- `PYTORCH_TEST_WITH_INDUCTOR=1 INDUCTOR_TEST_DISABLE_FRESH_CACHE=1 TORCHINDUCTOR_COMPILE_THREADS=1 ../.venv/bin/python test/inductor/test_flex_attention.py TestFlexAttentionCUDA.test_block_mask_vs_sequence_lengths_cuda TestFlexAttentionCUDA.test_block_mask_check_does_not_specialize_backed_dynamic_length_cuda`
- `PYTORCH_TEST_WITH_INDUCTOR=1 INDUCTOR_TEST_DISABLE_FRESH_CACHE=1 TORCHINDUCTOR_COMPILE_THREADS=1 ../.venv/bin/python test/inductor/test_flex_attention.py TestFlexAttentionCUDA.test_dynamic_shapes_bug_dynamic_batch_cuda`
- `TORCH_LOGS="recompiles" ./.venv/bin/python repro.py`

`spin fixlint` applied available patches but exited nonzero on unrelated existing shellcheck findings in `.ci/pytorch/test.sh` and `test/run_test.sh`.

### Guard evidence

Temporarily reversed the local patch and captured old/new `TORCH_LOGS="+dynamic,guards,recompiles"` output under `agent_space/guards/`.

Focused old-style Python branch logs in `agent_space/guards/old_python_checks_blockmask_input.log` show why the pre-`torch._check` structure worked for automatic dynamic dims: the first 320 graph is static; the 256 call triggers PGO, marks both `query.size()[2]` and `block_mask.seq_lengths[0]` dynamic, and emits `L['block_mask'].seq_lengths[0] == L['query'].size()[2]` rather than pinning either one to 320.

The updated repro now recreates a matching BlockMask for every sequence length. It shows one expected 320->256 recompile, then 192 and 128 reuse the generalized graph.

### PR feedback and final guard story

Refetched PR #189952 comments into `agent_space/pr_189952/`. Human review centered on why backed Dynamo shapes should not use unconditional `torch._check`, whether `statically_known_true` guards, why backed SymInts are involved, and whether too-small stale BlockMasks still error.

Final resolution: unbacked query/key lengths keep the `torch._check` path from #183838, while backed lengths use the old Python branch/assert validation. Guard evidence in `agent_space/guards/old_python_checks_blockmask_input.log` shows the pre-`torch._check` backed path recompiled once, made both `query.size()[2]` and `block_mask.seq_lengths[0]` dynamic, and guarded `L['block_mask'].seq_lengths[0] == L['query'].size()[2]` instead of pinning either to 320. The unconditional `torch._check` structure instead emitted concrete guards like `s50 <= 320` and `s50 >= 320`, which specialize to the first BlockMask length.

Updated `report.md` with this before/after guarding summary and PR feedback resolution. Refreshed `fix.diff`.

### Lint follow-up

Checked PR #189952 CI: the only failed completed check was `lintrunner-noclang-partial / lint`, but GitHub logs were unavailable while the workflow was still in progress. Reproduced locally with `spin quicklint`; PYFMT wanted two long lines in `test/inductor/test_flex_attention.py` wrapped. Ran `spin quickfix`, reran `spin quicklint` successfully, reran `TestFlexAttentionCUDA.test_block_mask_check_does_not_specialize_backed_dynamic_length_cuda`, and refreshed `fix.diff`.

### Minimality probe

Tested `has_free_unbacked_symbols` under Dynamo on `x`, `(x,)`, `(x.shape[0],)`, and `(x, x.shape[0])` in `agent_space/guards/probe_has_free_unbacked_tuple.py`. Only the direct tensor call traces; tuple inputs fail with `Unsupported torch.* op returned non-Tensor`. Added a one-line source comment explaining why scalar lengths are inspected only outside Dynamo tracing. Re-ran `spin quicklint`, the focused FlexAttention regression, `git diff --check`, and refreshed `fix.diff`.

Also tested `torch.compiler.config.dynamic_sources` in `agent_space/guards/probe_dynamic_sources_blockmask.py`. With the original `torch._check` equality shape and `mark_dynamic(query, 2)`, the empty config fails by specializing query length to 320, but setting `dynamic_sources` to `L['block_mask'].seq_lengths[0]` or a matching regex makes 320 and 256 compile successfully. This suggests the deeper root fix is to mark BlockMask `seq_lengths` as dynamic sources before the checks when paired with dynamic query/key lengths; FlexAttention Python does not currently have a robust source-name-independent API for doing that locally.

### CI triage

Checked PR #189952. Two jobs were marked failed: CUDA default shard 2/5 and ROCm default shard 1/8. GitHub would not serve raw logs while the workflow was still in progress, but ROCm test artifacts were available. The ROCm failure was our new test:

`TestBlockMaskCUDA.test_block_mask_check_does_not_specialize_backed_dynamic_length_cuda` failed with `KeyError: 'cuda:0...'` at `dtype = device_configs[device].dtypes_fast[0]`. In ROCm CI the parametrized device string is `cuda:0`, while `device_configs` is keyed by accelerator type (`cuda`). Fixed this by normalizing with `torch.device(device).type`.

Validation after device-key fix: `spin quicklint`, focused FlexAttention regression, and `git diff --check` all pass. Refreshed `fix.diff`. CUDA logs later showed the same `KeyError: 'cuda:0'` failure.

A macOS default shard also failed on the new test, but for a different reason: `@expected_not_implemented_on_mps` failed because the test passed on MPS (`AssertionError: expected NotImplementedError on MPS but test passed`). Switched that decorator to `@skip_on_mps` for this guard-inspection regression. Re-ran `spin quicklint`, the focused CUDA regression, and `git diff --check`; all pass. Refreshed `fix.diff`.

Rechecked PR CI after the local fixes. The pasted CUDA failure and the prior ROCm failure are both the same `device_configs['cuda:0']` issue covered by `torch.device(device).type`. Current ROCm default shard failures (5/8 and 8/8) are not this test: artifacts show `inductor/test_flex_attention` passed in ROCm 5/8, and no JUnit failures were found in the downloaded ROCm artifacts. Those jobs appear to be shard timeout/incomplete-test failures rather than regressions from this patch. No AMD-specific skip is indicated for the new test.

### Artifacts

Wrote `report.md`, `pr_title.txt`, and `fix.diff` in the PTQ job directory.

</details>

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*

cc @ezyang @penguinwu @bobrenjc93 @aditvenk @laithsakka @voznesenskym @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo