### PR TITLE
 Add Barebones Unsigned Integer Support to the Clamp Family

### DIFF
--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -663,14 +663,14 @@ void maximum_kernel(TensorIteratorBase& iter) {
   if (iter.dtype() == ScalarType::Bool) {
     cpu_kernel(iter, [](bool a, bool b) -> bool { return a || b; });
   } else if (isIntegralType(iter.dtype(), /*includeBool=*/false)) {
-    AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "maximum_cpu", [&]() {
+    AT_DISPATCH_V2(iter.dtype(), "maximum_cpu", AT_WRAP([&]() {
       cpu_kernel_vec(
           iter,
           [](scalar_t a, scalar_t b) -> scalar_t { return std::max(a, b); },
           [](Vectorized<scalar_t> a, Vectorized<scalar_t> b) {
             return at::vec::maximum(a, b);
           });
-    });
+    }), AT_EXPAND(AT_INTEGRAL_TYPES_V2));
   } else {
     AT_DISPATCH_FLOATING_TYPES_AND2(
         at::ScalarType::Half,
@@ -698,14 +698,14 @@ void minimum_kernel(TensorIteratorBase& iter) {
   if (iter.dtype() == ScalarType::Bool) {
     cpu_kernel(iter, [](bool a, bool b) -> bool { return a && b; });
   } else if (isIntegralType(iter.dtype(), /*includeBool=*/false)) {
-    AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "minimum_cpu", [&]() {
+    AT_DISPATCH_V2(iter.dtype(), "minimum_cpu", AT_WRAP([&]() {
       cpu_kernel_vec(
           iter,
           [](scalar_t a, scalar_t b) -> scalar_t { return std::min(a, b); },
           [](Vectorized<scalar_t> a, Vectorized<scalar_t> b) {
             return at::vec::minimum(a, b);
           });
-    });
+    }), AT_EXPAND(AT_INTEGRAL_TYPES_V2));
   } else {
     AT_DISPATCH_FLOATING_TYPES_AND2(
         at::ScalarType::Half,

--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -23,6 +23,12 @@ namespace {
 
 using namespace vec;
 
+// The barebones unsigned types have no Vectorized specialization, and gcc-13
+// ICEs auto-vectorizing the vec_base.h emulation for fixed-length SVE.
+template <typename scalar_t>
+constexpr bool use_vectorized_minmax =
+    !isBarebonesUnsignedType(c10::CppTypeToScalarType<scalar_t>::value);
+
 template <
     typename scalar_t,
     typename Op,
@@ -664,12 +670,18 @@ void maximum_kernel(TensorIteratorBase& iter) {
     cpu_kernel(iter, [](bool a, bool b) -> bool { return a || b; });
   } else if (isIntegralType(iter.dtype(), /*includeBool=*/false)) {
     AT_DISPATCH_V2(iter.dtype(), "maximum_cpu", AT_WRAP([&]() {
-      cpu_kernel_vec(
-          iter,
-          [](scalar_t a, scalar_t b) -> scalar_t { return std::max(a, b); },
-          [](Vectorized<scalar_t> a, Vectorized<scalar_t> b) {
-            return at::vec::maximum(a, b);
-          });
+      const auto max_op = [](scalar_t a, scalar_t b) -> scalar_t { return std::max(a, b); };
+
+      if constexpr (use_vectorized_minmax<scalar_t>) {
+        cpu_kernel_vec(
+            iter,
+            max_op,
+            [](Vectorized<scalar_t> a, Vectorized<scalar_t> b) {
+              return at::vec::maximum(a, b);
+            });
+      } else {
+        cpu_kernel(iter, max_op);
+      }
     }), AT_EXPAND(AT_INTEGRAL_TYPES_V2));
   } else {
     AT_DISPATCH_FLOATING_TYPES_AND2(
@@ -699,12 +711,18 @@ void minimum_kernel(TensorIteratorBase& iter) {
     cpu_kernel(iter, [](bool a, bool b) -> bool { return a && b; });
   } else if (isIntegralType(iter.dtype(), /*includeBool=*/false)) {
     AT_DISPATCH_V2(iter.dtype(), "minimum_cpu", AT_WRAP([&]() {
-      cpu_kernel_vec(
-          iter,
-          [](scalar_t a, scalar_t b) -> scalar_t { return std::min(a, b); },
-          [](Vectorized<scalar_t> a, Vectorized<scalar_t> b) {
-            return at::vec::minimum(a, b);
-          });
+      const auto min_op = [](scalar_t a, scalar_t b) -> scalar_t { return std::min(a, b); };
+
+      if constexpr (use_vectorized_minmax<scalar_t>) {
+        cpu_kernel_vec(
+            iter,
+            min_op,
+            [](Vectorized<scalar_t> a, Vectorized<scalar_t> b) {
+              return at::vec::minimum(a, b);
+            });
+      } else {
+        cpu_kernel(iter, min_op);
+      }
     }), AT_EXPAND(AT_INTEGRAL_TYPES_V2));
   } else {
     AT_DISPATCH_FLOATING_TYPES_AND2(

--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -23,12 +23,6 @@ namespace {
 
 using namespace vec;
 
-// The barebones unsigned types have no Vectorized specialization, and gcc-13
-// ICEs auto-vectorizing the vec_base.h emulation for fixed-length SVE.
-template <typename scalar_t>
-constexpr bool use_vectorized_minmax =
-    !isBarebonesUnsignedType(c10::CppTypeToScalarType<scalar_t>::value);
-
 template <
     typename scalar_t,
     typename Op,
@@ -670,18 +664,12 @@ void maximum_kernel(TensorIteratorBase& iter) {
     cpu_kernel(iter, [](bool a, bool b) -> bool { return a || b; });
   } else if (isIntegralType(iter.dtype(), /*includeBool=*/false)) {
     AT_DISPATCH_V2(iter.dtype(), "maximum_cpu", AT_WRAP([&]() {
-      const auto max_op = [](scalar_t a, scalar_t b) -> scalar_t { return std::max(a, b); };
-
-      if constexpr (use_vectorized_minmax<scalar_t>) {
-        cpu_kernel_vec(
-            iter,
-            max_op,
-            [](Vectorized<scalar_t> a, Vectorized<scalar_t> b) {
-              return at::vec::maximum(a, b);
-            });
-      } else {
-        cpu_kernel(iter, max_op);
-      }
+      cpu_kernel_vec(
+          iter,
+          [](scalar_t a, scalar_t b) -> scalar_t { return std::max(a, b); },
+          [](Vectorized<scalar_t> a, Vectorized<scalar_t> b) {
+            return at::vec::maximum(a, b);
+          });
     }), AT_EXPAND(AT_INTEGRAL_TYPES_V2));
   } else {
     AT_DISPATCH_FLOATING_TYPES_AND2(
@@ -711,18 +699,12 @@ void minimum_kernel(TensorIteratorBase& iter) {
     cpu_kernel(iter, [](bool a, bool b) -> bool { return a && b; });
   } else if (isIntegralType(iter.dtype(), /*includeBool=*/false)) {
     AT_DISPATCH_V2(iter.dtype(), "minimum_cpu", AT_WRAP([&]() {
-      const auto min_op = [](scalar_t a, scalar_t b) -> scalar_t { return std::min(a, b); };
-
-      if constexpr (use_vectorized_minmax<scalar_t>) {
-        cpu_kernel_vec(
-            iter,
-            min_op,
-            [](Vectorized<scalar_t> a, Vectorized<scalar_t> b) {
-              return at::vec::minimum(a, b);
-            });
-      } else {
-        cpu_kernel(iter, min_op);
-      }
+      cpu_kernel_vec(
+          iter,
+          [](scalar_t a, scalar_t b) -> scalar_t { return std::min(a, b); },
+          [](Vectorized<scalar_t> a, Vectorized<scalar_t> b) {
+            return at::vec::minimum(a, b);
+          });
     }), AT_EXPAND(AT_INTEGRAL_TYPES_V2));
   } else {
     AT_DISPATCH_FLOATING_TYPES_AND2(

--- a/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
+++ b/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include <ATen/Dispatch.h>
+#include <ATen/Dispatch_v2.h>
 #include <ATen/Parallel.h>
 #include <ATen/NumericUtils.h>
 #include <ATen/TensorIterator.h>
@@ -340,7 +341,7 @@ void isin_default_kernel_cpu(
 }
 
 void clamp_kernel_impl(TensorIteratorBase& iter) {
-  AT_DISPATCH_ALL_TYPES_AND2(kBFloat16, kHalf, iter.common_dtype(), "clamp_cpu", [&]() {
+  AT_DISPATCH_V2(iter.common_dtype(), "clamp_cpu", AT_WRAP([&]() {
     cpu_kernel_vec(iter,
       [](scalar_t a, scalar_t min, scalar_t max) -> scalar_t {
         if (min != min || max != max) {
@@ -352,11 +353,11 @@ void clamp_kernel_impl(TensorIteratorBase& iter) {
       [](Vectorized<scalar_t> a, Vectorized<scalar_t> min, Vectorized<scalar_t> max) {
         return vec::minimum(vec::maximum(a, min), max);
       });
-  });
+  }), AT_EXPAND(AT_ALL_TYPES), AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES), kBFloat16, kHalf);
 }
 
 void clamp_scalar_kernel_impl(TensorIteratorBase& iter, const Scalar& min_, const Scalar& max_) {
-  AT_DISPATCH_ALL_TYPES_AND2(kBFloat16, kHalf, iter.common_dtype(), "clamp_scalar_cpu", [&]() {
+  AT_DISPATCH_V2(iter.common_dtype(), "clamp_scalar_cpu", AT_WRAP([&]() {
     const auto min = min_.to<scalar_t>();
     const auto max = max_.to<scalar_t>();
     const Vectorized<scalar_t> min_vec(min);
@@ -368,11 +369,11 @@ void clamp_scalar_kernel_impl(TensorIteratorBase& iter, const Scalar& min_, cons
         [=](Vectorized<scalar_t> a) {
           return vec::clamp(a, min_vec, max_vec);
         });
-  });
+  }), AT_EXPAND(AT_ALL_TYPES), AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES), kBFloat16, kHalf);
 }
 
 void clamp_max_scalar_kernel_impl(TensorIteratorBase& iter, Scalar max_) {
-  AT_DISPATCH_ALL_TYPES_AND2(kBFloat16, kHalf, iter.common_dtype(), "clamp_max_scalar_cpu", [&]() {
+  AT_DISPATCH_V2(iter.common_dtype(), "clamp_max_scalar_cpu", AT_WRAP([&]() {
     const auto max = max_.to<scalar_t>();
     const Vectorized<scalar_t> max_vec(max);
     cpu_kernel_vec(iter,
@@ -382,11 +383,11 @@ void clamp_max_scalar_kernel_impl(TensorIteratorBase& iter, Scalar max_) {
       [=](Vectorized<scalar_t> a) {
         return vec::clamp_max(a, max_vec);
       });
-  });
+  }), AT_EXPAND(AT_ALL_TYPES), AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES), kBFloat16, kHalf);
 }
 
 void clamp_min_scalar_kernel_impl(TensorIteratorBase& iter, Scalar min_) {
-  AT_DISPATCH_ALL_TYPES_AND2(kBFloat16, kHalf, iter.common_dtype(), "clamp_min_scalar_cpu", [&]() {
+  AT_DISPATCH_V2(iter.common_dtype(), "clamp_min_scalar_cpu", AT_WRAP([&]() {
     const auto min = min_.to<scalar_t>();
     const Vectorized<scalar_t> min_vec(min);
     cpu_kernel_vec(iter,
@@ -396,7 +397,7 @@ void clamp_min_scalar_kernel_impl(TensorIteratorBase& iter, Scalar min_) {
         [=](Vectorized<scalar_t> a) {
           return vec::clamp_min(a, min_vec);
         });
-  });
+  }), AT_EXPAND(AT_ALL_TYPES), AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES), kBFloat16, kHalf);
 }
 
 } // anonymous namespace

--- a/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
+++ b/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
@@ -30,9 +30,9 @@
 
 namespace at::native { namespace {
 
-// gcc-13 ICEs auto-vectorizing the vec_base.h Vectorized<T> emulation under fixed-length SVE. 
+// gcc-13 ICEs auto-vectorizing the vec_base.h Vectorized<T> emulation under fixed-length SVE.
 // The barebones unsigned types have no SVE specialization, so they are the ones that land on that path.
-// Not every 13.x build is affected, so the bound covers the series rather than a point release. 
+// Not every 13.x build is affected, so the bound covers the series rather than a point release.
 // Remove once the aarch64 wheels require gcc-14 or newer.
 #if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 14 && \
     (defined(CPU_CAPABILITY_SVE256) || defined(CPU_CAPABILITY_SVE128))

--- a/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
+++ b/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
@@ -30,6 +30,12 @@
 
 namespace at::native { namespace {
 
+// The barebones unsigned types have no Vectorized specialization, and gcc-13
+// ICEs auto-vectorizing the vec_base.h emulation for fixed-length SVE.
+template <typename scalar_t>
+constexpr bool use_vectorized_clamp =
+    !isBarebonesUnsignedType(c10::CppTypeToScalarType<scalar_t>::value);
+
 template <typename scalar_t, typename scalar_t_2 = int64_t, typename loop1d_t>
 inline void compare_base_kernel_core(
     const Tensor& result1,
@@ -342,17 +348,22 @@ void isin_default_kernel_cpu(
 
 void clamp_kernel_impl(TensorIteratorBase& iter) {
   AT_DISPATCH_V2(iter.common_dtype(), "clamp_cpu", AT_WRAP([&]() {
-    cpu_kernel_vec(iter,
-      [](scalar_t a, scalar_t min, scalar_t max) -> scalar_t {
-        if (min != min || max != max) {
-            return std::numeric_limits<scalar_t>::quiet_NaN();
-        } else {
-            return std::min(std::max(a, min), max);
-        }
-      },
-      [](Vectorized<scalar_t> a, Vectorized<scalar_t> min, Vectorized<scalar_t> max) {
-        return vec::minimum(vec::maximum(a, min), max);
-      });
+    const auto clamp_op = [](scalar_t a, scalar_t min, scalar_t max) -> scalar_t {
+      if (min != min || max != max) {
+          return std::numeric_limits<scalar_t>::quiet_NaN();
+      } else {
+          return std::min(std::max(a, min), max);
+      }
+    };
+
+    if constexpr (use_vectorized_clamp<scalar_t>) {
+      cpu_kernel_vec(iter, clamp_op,
+        [](Vectorized<scalar_t> a, Vectorized<scalar_t> min, Vectorized<scalar_t> max) {
+          return vec::minimum(vec::maximum(a, min), max);
+        });
+    } else {
+      cpu_kernel(iter, clamp_op);
+    }
   }), AT_EXPAND(AT_ALL_TYPES), AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES), kBFloat16, kHalf);
 }
 
@@ -360,43 +371,58 @@ void clamp_scalar_kernel_impl(TensorIteratorBase& iter, const Scalar& min_, cons
   AT_DISPATCH_V2(iter.common_dtype(), "clamp_scalar_cpu", AT_WRAP([&]() {
     const auto min = min_.to<scalar_t>();
     const auto max = max_.to<scalar_t>();
-    const Vectorized<scalar_t> min_vec(min);
-    const Vectorized<scalar_t> max_vec(max);
-      cpu_kernel_vec(iter,
-        [=](scalar_t a) -> scalar_t {
-          return std::min(std::max(a, min), max);
-        },
+    const auto clamp_op = [=](scalar_t a) -> scalar_t {
+      return std::min(std::max(a, min), max);
+    };
+
+    if constexpr (use_vectorized_clamp<scalar_t>) {
+      const Vectorized<scalar_t> min_vec(min);
+      const Vectorized<scalar_t> max_vec(max);
+      cpu_kernel_vec(iter, clamp_op,
         [=](Vectorized<scalar_t> a) {
           return vec::clamp(a, min_vec, max_vec);
         });
+    } else {
+      cpu_kernel(iter, clamp_op);
+    }
   }), AT_EXPAND(AT_ALL_TYPES), AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES), kBFloat16, kHalf);
 }
 
 void clamp_max_scalar_kernel_impl(TensorIteratorBase& iter, Scalar max_) {
   AT_DISPATCH_V2(iter.common_dtype(), "clamp_max_scalar_cpu", AT_WRAP([&]() {
     const auto max = max_.to<scalar_t>();
-    const Vectorized<scalar_t> max_vec(max);
-    cpu_kernel_vec(iter,
-      [=](scalar_t a) -> scalar_t {
-        return std::min(a, max);
-      },
-      [=](Vectorized<scalar_t> a) {
-        return vec::clamp_max(a, max_vec);
-      });
+    const auto clamp_max_op = [=](scalar_t a) -> scalar_t {
+      return std::min(a, max);
+    };
+
+    if constexpr (use_vectorized_clamp<scalar_t>) {
+      const Vectorized<scalar_t> max_vec(max);
+      cpu_kernel_vec(iter, clamp_max_op,
+        [=](Vectorized<scalar_t> a) {
+          return vec::clamp_max(a, max_vec);
+        });
+    } else {
+      cpu_kernel(iter, clamp_max_op);
+    }
   }), AT_EXPAND(AT_ALL_TYPES), AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES), kBFloat16, kHalf);
 }
 
 void clamp_min_scalar_kernel_impl(TensorIteratorBase& iter, Scalar min_) {
   AT_DISPATCH_V2(iter.common_dtype(), "clamp_min_scalar_cpu", AT_WRAP([&]() {
     const auto min = min_.to<scalar_t>();
-    const Vectorized<scalar_t> min_vec(min);
-    cpu_kernel_vec(iter,
-        [=](scalar_t a) -> scalar_t {
-          return std::max(a, min);
-        },
+    const auto clamp_min_op = [=](scalar_t a) -> scalar_t {
+      return std::max(a, min);
+    };
+
+    if constexpr (use_vectorized_clamp<scalar_t>) {
+      const Vectorized<scalar_t> min_vec(min);
+      cpu_kernel_vec(iter, clamp_min_op,
         [=](Vectorized<scalar_t> a) {
           return vec::clamp_min(a, min_vec);
         });
+    } else {
+      cpu_kernel(iter, clamp_min_op);
+    }
   }), AT_EXPAND(AT_ALL_TYPES), AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES), kBFloat16, kHalf);
 }
 

--- a/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
+++ b/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
@@ -30,11 +30,19 @@
 
 namespace at::native { namespace {
 
-// The barebones unsigned types have no Vectorized specialization, and gcc-13
-// ICEs auto-vectorizing the vec_base.h emulation for fixed-length SVE.
+// gcc-13 ICEs auto-vectorizing the vec_base.h Vectorized<T> emulation under fixed-length SVE. 
+// The barebones unsigned types have no SVE specialization, so they are the ones that land on that path.
+// Not every 13.x build is affected, so the bound covers the series rather than a point release. 
+// Remove once the aarch64 wheels require gcc-14 or newer.
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 14 && \
+    (defined(CPU_CAPABILITY_SVE256) || defined(CPU_CAPABILITY_SVE128))
 template <typename scalar_t>
 constexpr bool use_vectorized_clamp =
     !isBarebonesUnsignedType(c10::CppTypeToScalarType<scalar_t>::value);
+#else
+template <typename scalar_t>
+constexpr bool use_vectorized_clamp = true;
+#endif
 
 template <typename scalar_t, typename scalar_t_2 = int64_t, typename loop1d_t>
 inline void compare_base_kernel_core(

--- a/aten/src/ATen/native/cuda/MaxMinElementwiseKernel.cu
+++ b/aten/src/ATen/native/cuda/MaxMinElementwiseKernel.cu
@@ -1,6 +1,7 @@
 #define TORCH_ASSERT_NO_OPERATORS
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
+#include <ATen/Dispatch_v2.h>
 #include <ATen/native/BinaryOps.h>
 #include <ATen/native/DispatchStub.h>
 #include <ATen/native/TensorIterator.h>
@@ -18,12 +19,12 @@ void maximum_kernel_cuda(TensorIteratorBase& iter) {
       return a || b;
     });
   } else if (isIntegralType(iter.common_dtype(), /*includeBool=*/ false)) {
-    AT_DISPATCH_INTEGRAL_TYPES(iter.common_dtype(), "max_elementwise_cuda", [&]() {
+    AT_DISPATCH_V2(iter.common_dtype(), "max_elementwise_cuda", AT_WRAP([&]() {
       opmath_symmetric_gpu_kernel_with_scalars<scalar_t>(
           iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
         return ::max(a, b);
       });
-    });
+    }), AT_EXPAND(AT_INTEGRAL_TYPES_V2));
   } else {
     AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, iter.common_dtype(), "max_elementwise_cuda", [&]() {
       opmath_symmetric_gpu_kernel_with_scalars<scalar_t>(
@@ -46,11 +47,11 @@ void minimum_kernel_cuda(TensorIteratorBase& iter) {
       return a && b;
     });
   } else if (isIntegralType(iter.common_dtype(), /*includeBool=*/ false)) {
-    AT_DISPATCH_INTEGRAL_TYPES(iter.common_dtype(), "minimum_cuda", [&]() {
+    AT_DISPATCH_V2(iter.common_dtype(), "minimum_cuda", AT_WRAP([&]() {
       opmath_symmetric_gpu_kernel_with_scalars<scalar_t>(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
         return ::min(a, b);
       });
-    });
+    }), AT_EXPAND(AT_INTEGRAL_TYPES_V2));
   } else {
     AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, iter.common_dtype(), "min_elementwise_cuda", [&]() {
       opmath_symmetric_gpu_kernel_with_scalars<scalar_t>(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {

--- a/aten/src/ATen/native/cuda/TensorCompare.cu
+++ b/aten/src/ATen/native/cuda/TensorCompare.cu
@@ -42,7 +42,7 @@ void isneginf_kernel_impl(TensorIteratorBase &iter) {
 }
 
 void clamp_kernel_impl(TensorIteratorBase& iter) {
-  AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBFloat16, iter.common_dtype(), "clamp_cuda", [&] {
+  AT_DISPATCH_V2(iter.common_dtype(), "clamp_cuda", AT_WRAP([&] {
     gpu_kernel(iter, []GPU_LAMBDA(scalar_t v, scalar_t lower, scalar_t upper) -> scalar_t {
       scalar_t result = (v < lower) ? lower : v;
       result = (upper < result) ? upper : result;
@@ -55,11 +55,11 @@ void clamp_kernel_impl(TensorIteratorBase& iter) {
 
       return result;
     });
-  });
+  }), AT_EXPAND(AT_ALL_TYPES), AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES), kHalf, kBFloat16);
 }
 
 void inline launch_clamp_scalar(TensorIteratorBase& iter, Scalar lim0, Scalar lim1, at::native::detail::ClampLimits minmax){
-  AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBFloat16, iter.common_dtype(), "clamp_scalar_cuda", [&] {
+  AT_DISPATCH_V2(iter.common_dtype(), "clamp_scalar_cuda", AT_WRAP([&] {
     using opmath_t = at::opmath_type<scalar_t>;
     auto lim0_val = lim0.to<opmath_t>();
     auto lim1_val = lim1.to<opmath_t>();
@@ -85,7 +85,7 @@ void inline launch_clamp_scalar(TensorIteratorBase& iter, Scalar lim0, Scalar li
         return scalar_t((lim1_val < result) ? lim1_val : result);
       }
     });
-  });
+  }), AT_EXPAND(AT_ALL_TYPES), AT_EXPAND(AT_BAREBONES_UNSIGNED_TYPES), kHalf, kBFloat16);
 }
 
 

--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -118,7 +118,7 @@ inline bool isBitsType(ScalarType t) {
       t == ScalarType::Bits16;
 }
 
-inline bool isBarebonesUnsignedType(ScalarType t) {
+constexpr bool isBarebonesUnsignedType(ScalarType t) {
   return t == ScalarType::UInt1 || t == ScalarType::UInt2 ||
       t == ScalarType::UInt3 || t == ScalarType::UInt4 ||
       t == ScalarType::UInt5 || t == ScalarType::UInt6 ||

--- a/test/test_shape_ops.py
+++ b/test/test_shape_ops.py
@@ -300,8 +300,16 @@ class TestShapeOps(TestCase):
         values given the min_vals and/or max_vals.
         If with_nans is provided, then some values are randomly set to nan.
         """
-        X = torch.rand(100, device=device).mul(50).add(-25)  # uniform in [-25, 25]
-        X = X.to(dtype)
+        if dtype in barebones_unsigned_types():
+            info = torch.iinfo(dtype)
+            X = torch.randint(0, 50, (100,), device=device, dtype=torch.int64).to(dtype)
+            # Values above the signed max, which a signed comparison would misorder.
+            top = [info.max, info.max - 1, info.max // 2 + 1, info.max // 2]
+            X[: len(top)] = torch.tensor(top, device=device, dtype=dtype)
+        else:
+            X = torch.rand(100, device=device).mul(50).add(-25)  # uniform in [-25, 25]
+            X = X.to(dtype)
+
         if with_nans:
             mask = torch.randint(0, 2, X.shape, dtype=torch.bool, device=device)
             X[mask] = nan
@@ -319,7 +327,7 @@ class TestShapeOps(TestCase):
         return X, X_clamped
 
     # Tests clamp and its alias, clip
-    @dtypes(torch.int64, torch.float32)
+    @dtypes(torch.int64, torch.float32, *barebones_unsigned_types())
     def test_clamp(self, device, dtype):
         op_list = (
             torch.clamp,
@@ -330,8 +338,16 @@ class TestShapeOps(TestCase):
             torch.Tensor.clip_,
         )
 
-        # min/max argument product
-        args = product((-10, None), (10, None))
+        if dtype in barebones_unsigned_types():
+            # A negative bound would wrap, and a pair straddling the signed max
+            # would promote a Long scalar against a UInt64 one, which is unsupported.
+            info = torch.iinfo(dtype)
+            min_bound, max_bound = info.max // 4, info.max // 2
+        else:
+            min_bound, max_bound = -10, 10
+
+        # min/max argument product; materialized so every op sees every combination
+        args = tuple(product((min_bound, None), (max_bound, None)))
 
         for op in op_list:
             for min_val, max_val in args:
@@ -353,60 +369,14 @@ class TestShapeOps(TestCase):
                     op(X, min=min_val, max=max_val, out=Y_out)
                     self.assertEqual(Y_expected, Y_out)
 
-    # Values above the signed max catch a signed reading of the data. One-sided
-    # tensor bounds lower to maximum/minimum, which do not dispatch these dtypes.
-    @dtypes(*barebones_unsigned_types())
-    def test_clamp_barebones_unsigned(self, device, dtype):
-        info = torch.iinfo(dtype)
-        vals = [0, 1, info.max // 2, info.max - 1, info.max]
-        X = torch.tensor(vals, device=device, dtype=dtype)
-
-        def reference(min_bound, max_bound):
-            clamped = []
-            for v in vals:
-                if min_bound is not None:
-                    v = max(v, min_bound)
-                if max_bound is not None:
-                    v = min(v, max_bound)
-                clamped.append(v)
-            return torch.tensor(clamped, device=device, dtype=dtype)
-
-        op_list = (
-            torch.clamp,
-            torch.Tensor.clamp,
-            torch.Tensor.clamp_,
-            torch.clip,
-            torch.Tensor.clip,
-            torch.Tensor.clip_,
+        # Two-sided tensor bounds dispatch the ternary kernel. One-sided tensor
+        # bounds lower to maximum/minimum, which do not support the unsigned dtypes.
+        min_t = torch.full((100,), min_bound, device=device, dtype=dtype)
+        max_t = torch.full((100,), max_bound, device=device, dtype=dtype)
+        X, Y_expected = self.generate_clamp_baseline(
+            device, dtype, min_vals=min_t, max_vals=max_t, with_nans=False
         )
-
-        # A pair straddling the signed max would promote a Long scalar against a
-        # UInt64 one, which is unsupported.
-        bound_pairs = ((1, info.max // 4), (info.max - 2, info.max - 1))
-
-        for min_val, max_val in bound_pairs:
-            for op in op_list:
-                for min_bound, max_bound in product((min_val, None), (max_val, None)):
-                    if min_bound is None and max_bound is None:
-                        continue
-
-                    Y_expected = reference(min_bound, max_bound)
-
-                    X1 = X.clone()  # So that the in-place ops do not change X
-                    self.assertEqual(Y_expected, op(X1, min_bound, max_bound))
-
-                    # Test op-out behavior (out does not exist for method versions)
-                    if op in (torch.clamp, torch.clip):
-                        Y_out = torch.empty_like(X)
-                        op(X, min=min_bound, max=max_bound, out=Y_out)
-                        self.assertEqual(Y_expected, Y_out)
-
-            self.assertEqual(reference(min_val, None), torch.clamp_min(X, min_val))
-            self.assertEqual(reference(None, max_val), torch.clamp_max(X, max_val))
-
-            min_t = torch.full_like(X, min_val)
-            max_t = torch.full_like(X, max_val)
-            self.assertEqual(reference(min_val, max_val), torch.clamp(X, min_t, max_t))
+        self.assertEqual(Y_expected, torch.clamp(X, min_t, max_t))
 
     def test_clamp_propagates_nans(self, device):
         op_list = (
@@ -418,8 +388,8 @@ class TestShapeOps(TestCase):
             torch.Tensor.clip_,
         )
 
-        # min/max argument product
-        args = product((-10, None), (10, None))
+        # min/max argument product; materialized so every op sees every combination
+        args = tuple(product((-10, None), (10, None)))
 
         for op in op_list:
             for min_val, max_val in args:

--- a/test/test_shape_ops.py
+++ b/test/test_shape_ops.py
@@ -26,6 +26,7 @@ from torch.testing._internal.common_dtype import (
     all_types,
     all_types_and,
     all_types_and_complex_and,
+    barebones_unsigned_types,
 )
 from torch.testing._internal.common_utils import (
     IS_JETSON,
@@ -351,6 +352,61 @@ class TestShapeOps(TestCase):
                     Y_out = torch.empty_like(X)
                     op(X, min=min_val, max=max_val, out=Y_out)
                     self.assertEqual(Y_expected, Y_out)
+
+    # Values above the signed max catch a signed reading of the data. One-sided
+    # tensor bounds lower to maximum/minimum, which do not dispatch these dtypes.
+    @dtypes(*barebones_unsigned_types())
+    def test_clamp_barebones_unsigned(self, device, dtype):
+        info = torch.iinfo(dtype)
+        vals = [0, 1, info.max // 2, info.max - 1, info.max]
+        X = torch.tensor(vals, device=device, dtype=dtype)
+
+        def reference(min_bound, max_bound):
+            clamped = []
+            for v in vals:
+                if min_bound is not None:
+                    v = max(v, min_bound)
+                if max_bound is not None:
+                    v = min(v, max_bound)
+                clamped.append(v)
+            return torch.tensor(clamped, device=device, dtype=dtype)
+
+        op_list = (
+            torch.clamp,
+            torch.Tensor.clamp,
+            torch.Tensor.clamp_,
+            torch.clip,
+            torch.Tensor.clip,
+            torch.Tensor.clip_,
+        )
+
+        # A pair straddling the signed max would promote a Long scalar against a
+        # UInt64 one, which is unsupported.
+        bound_pairs = ((1, info.max // 4), (info.max - 2, info.max - 1))
+
+        for min_val, max_val in bound_pairs:
+            for op in op_list:
+                for min_bound, max_bound in product((min_val, None), (max_val, None)):
+                    if min_bound is None and max_bound is None:
+                        continue
+
+                    Y_expected = reference(min_bound, max_bound)
+
+                    X1 = X.clone()  # So that the in-place ops do not change X
+                    self.assertEqual(Y_expected, op(X1, min_bound, max_bound))
+
+                    # Test op-out behavior (out does not exist for method versions)
+                    if op in (torch.clamp, torch.clip):
+                        Y_out = torch.empty_like(X)
+                        op(X, min=min_bound, max=max_bound, out=Y_out)
+                        self.assertEqual(Y_expected, Y_out)
+
+            self.assertEqual(reference(min_val, None), torch.clamp_min(X, min_val))
+            self.assertEqual(reference(None, max_val), torch.clamp_max(X, max_val))
+
+            min_t = torch.full_like(X, min_val)
+            max_t = torch.full_like(X, max_val)
+            self.assertEqual(reference(min_val, max_val), torch.clamp(X, min_t, max_t))
 
     def test_clamp_propagates_nans(self, device):
         op_list = (

--- a/test/test_shape_ops.py
+++ b/test/test_shape_ops.py
@@ -320,10 +320,14 @@ class TestShapeOps(TestCase):
         if isinstance(max_vals, torch.Tensor):
             max_vals = max_vals.cpu().numpy()
 
-        # Use NumPy implementation as reference
-        X_clamped = torch.tensor(
-            np.clip(X.cpu().numpy(), a_min=min_vals, a_max=max_vals), device=device
-        )
+        # Use NumPy implementation as reference. np.clip against a Python int
+        # bound can widen a uint64 array to the distinct `ulonglong` scalar type,
+        # which torch cannot ingest. Cast back to the input dtype so from_numpy
+        # stays on a supported type.
+        X_np = X.cpu().numpy()
+        X_clamped = torch.from_numpy(
+            np.clip(X_np, a_min=min_vals, a_max=max_vals).astype(X_np.dtype)
+        ).to(device)
         return X, X_clamped
 
     # Tests clamp and its alias, clip
@@ -369,14 +373,13 @@ class TestShapeOps(TestCase):
                     op(X, min=min_val, max=max_val, out=Y_out)
                     self.assertEqual(Y_expected, Y_out)
 
-        # Two-sided tensor bounds dispatch the ternary kernel. One-sided tensor
-        # bounds lower to maximum/minimum, which do not support the unsigned dtypes.
         min_t = torch.full((100,), min_bound, device=device, dtype=dtype)
         max_t = torch.full((100,), max_bound, device=device, dtype=dtype)
-        X, Y_expected = self.generate_clamp_baseline(
-            device, dtype, min_vals=min_t, max_vals=max_t, with_nans=False
-        )
-        self.assertEqual(Y_expected, torch.clamp(X, min_t, max_t))
+        for min_tv, max_tv in ((min_t, max_t), (min_t, None), (None, max_t)):
+            X, Y_expected = self.generate_clamp_baseline(
+                device, dtype, min_vals=min_tv, max_vals=max_tv, with_nans=False
+            )
+            self.assertEqual(Y_expected, torch.clamp(X, min=min_tv, max=max_tv))
 
     def test_clamp_propagates_nans(self, device):
         op_list = (

--- a/torch/testing/_internal/common_dtype.py
+++ b/torch/testing/_internal/common_dtype.py
@@ -161,6 +161,10 @@ def all_types_complex_float8_and(*dtypes):
 _barebones_unsigned_types = _dispatch_dtypes((torch.uint16, torch.uint32, torch.uint64))
 
 
+def barebones_unsigned_types():
+    return _barebones_unsigned_types
+
+
 # Passthru ops (copy, fill, index, gather, scatter, flip, take, put, where, eq, ne)
 # move or select data without dtype-specific arithmetic, so they support the
 # largest common set of dtypes across CPU and CUDA. Mirrors


### PR DESCRIPTION
Adds `uint16`, `uint32`, and `uint64` support to `clamp` functions on CPU and CUDA. These ops previously rejected the barebones unsigned dtypes because their kernels dispatched through `AT_DISPATCH_ALL_TYPES_AND2`, which omits them.

## Relationship to #189872

Unblocks #189872 ("Add Autograd Support for Low-Level Bessel Functions"). That PR restricts the `x > 0` Bessel OpInfos (`special.bessel_y0`, `bessel_y1`, `modified_bessel_k0`, `modified_bessel_k1`) to `domain=(0, None)`, which makes the unary sample generator call `clamp_min` on the sample dtypes. For the barebones unsigned dtypes that call currently raises `NotImplementedError`, so #189872 marks the `uint16/uint32/uint64` forward reference-numerics tests as `expectedFailure`. With clamp supporting these dtypes, those tests pass and the xfails can be removed there.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01