### PR TITLE
[inductor] Type the V global accessors and add a KernelLike protocol in virtualized.py

### DIFF
--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -2179,7 +2179,9 @@ class CSE(Generic[CSEVariableType, AugmentedKeyT]):
         shape: BlockShapeType = None,
     ) -> CSEVariableType:
         var_name = f"{self.name_prefix}{next(self.iter_buffer_ids)}"
-        var = V.kernel.create_cse_var(var_name, bounds, dtype, shape)
+        var = cast(
+            "CSEVariableType", V.kernel.create_cse_var(var_name, bounds, dtype, shape)
+        )
         self.varname_map[var_name] = var
         return var
 
@@ -2193,7 +2195,9 @@ class CSE(Generic[CSEVariableType, AugmentedKeyT]):
         torch._check_value(
             name not in self.varname_map, lambda: f"duplicate name: {name}"
         )
-        var = V.kernel.create_cse_var(name, bounds, dtype, shape)
+        var = cast(
+            "CSEVariableType", V.kernel.create_cse_var(name, bounds, dtype, shape)
+        )
         self.varname_map[name] = var
         return var
 
@@ -2798,6 +2802,7 @@ class CSEProxy(DefaultHandler):
                 V.kernel.compute,
                 v,
                 bounds=bounds,
+                # pyrefly: ignore[bad-argument-type]
                 dtype=output_dtype,
                 shape=output_shape,
             )

--- a/torch/_inductor/codegen/pallas.py
+++ b/torch/_inductor/codegen/pallas.py
@@ -818,6 +818,7 @@ class PallasKernelOverrides(OpOverrides):
     def load_seed(name: str, offset: str) -> str:
         """Load the random seed value from a buffer."""
         # Load the seed from the buffer and add offset for uniqueness
+        # pyrefly: ignore[bad-argument-type]
         seed_offset = V.kernel.args.seed_offset("load_seed_offset", offset)
         return f"({V.kernel.args.input(name)}[0] + {seed_offset})"
 

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -632,7 +632,9 @@ class BlockDescriptorOptions:
 
     def has_rindex(self) -> bool:
         return any(
-            TritonSymbols.has_reduction_index_symbol(V.kernel, expr)
+            TritonSymbols.has_reduction_index_symbol(
+                cast("TritonKernel", V.kernel), expr
+            )
             for expr in self.block_shape
         )
 
@@ -1253,7 +1255,9 @@ class TritonCSEVariable(CSEVariable):
                 # however, when index vars are used to compute indices for indirect reads
                 # those reads should subsequently be masked,
                 if (
-                    mask_name := TritonSymbols.mask_name_for_symbol(V.kernel, arg)
+                    mask_name := TritonSymbols.mask_name_for_symbol(
+                        cast("TritonKernel", V.kernel), arg
+                    )
                 ) is not None:
                     self.mask_vars.add(mask_name)
 
@@ -4484,6 +4488,8 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         def matching_dep(dep):
             if prev_node is None:
                 raise AssertionError("prev_node must not be None")
+            if current_node is None:
+                raise AssertionError("current_node must not be None")
             prev_deps = prev_node.read_writes.writes
             if consider_reads:
                 prev_deps = itertools.chain(prev_deps, prev_node.read_writes.reads)

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -2274,6 +2274,7 @@ class GraphLowering(torch.fx.Interpreter):
         # symbol is likely to hit lots of GuardOnDataDependent errors that
         # we already know facts for.
         renamed_unbacked_bindings = OrderedSet(
+            # unbacked_renamings is not declared on every ShapeEnv path
             # pyrefly: ignore[missing-attribute]
             V.fake_mode.shape_env.unbacked_renamings.get(s, s)
             for s in unbacked_bindings

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -2274,6 +2274,7 @@ class GraphLowering(torch.fx.Interpreter):
         # symbol is likely to hit lots of GuardOnDataDependent errors that
         # we already know facts for.
         renamed_unbacked_bindings = OrderedSet(
+            # pyrefly: ignore[missing-attribute]
             V.fake_mode.shape_env.unbacked_renamings.get(s, s)
             for s in unbacked_bindings
         )

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -2573,6 +2573,7 @@ class GraphLowering(torch.fx.Interpreter):
                         if param is not None
                     ]
                     real_inputs = [
+                        # pyrefly: ignore[bad-argument-type]
                         materialize(x)
                         for x in itertools.chain(params_flat, V.real_inputs)
                     ]

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -7302,6 +7302,7 @@ class ExternKernel(InputsKernel):
             ctx: AbstractContextManager[None] = nullcontext()
             if V.current_node.target is torch._higher_order_ops.effects.with_effects:
                 # remove the first effect token in meta["val"] and meta["unbacked_bindings"]
+                # pyrefly: ignore[unsupported-operation]
                 node_meta_val = node_meta_val[1]
                 ctx = _remove_effect_token_unbacked_bindings(V.current_node)
 

--- a/torch/_inductor/virtualized.py
+++ b/torch/_inductor/virtualized.py
@@ -75,18 +75,48 @@ from .ops_handler import (  # noqa: F401
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Sequence
+    from typing import Protocol
 
     import torch
     from torch._inductor.choices import InductorChoices
+    from torch._inductor.codegen.common import CSE, CSEVariable, KernelArgs
     from torch._inductor.codegen.cpp_utils import LocalBufferContext
     from torch._inductor.debug import DebugContext
     from torch._inductor.graph import GraphLowering
     from torch._inductor.ir import ExternKernelNode
     from torch._inductor.loop_body import InterpreterShim
+    from torch._inductor.scheduler import SchedulerNode
     from torch._subclasses import FakeTensorMode
 
     from .distributed_autotune import _DistributedAutotuneState
+    from .utils import IndentedBuffer, InputType
+
+    class KernelLike(Protocol):
+        """
+        Structural type for ``V.kernel``.  Its backing handler ranges from the
+        ``NullKernelHandler`` sentinel (installed while codegening the wrapper,
+        before any kernel exists) to a concrete ``Kernel`` subclass during
+        kernel codegen, so callers duck-type against this common surface rather
+        than a single class.  The members declared explicitly below are the
+        common surface relied on regardless of backend; the ``__getattr__``
+        fallback keeps backend-specific members (e.g. Triton/CPP tiling state)
+        accessible as ``Any`` without forcing every kernel class to enumerate
+        them here.
+        """
+
+        removed_buffers: OrderedSet[str]
+        inplaced_to_remove: OrderedSet[str]
+        index_dtype: str
+        cse: CSE[Any, Any]
+        compute: IndentedBuffer
+        current_node: SchedulerNode | None
+        args: KernelArgs
+
+        def create_cse_var(self, *args: Any, **kwargs: Any) -> CSEVariable: ...
+        def __getattr__(self, name: str) -> Any: ...
+        def __setattr__(self, name: str, value: Any) -> None: ...
+
 
 threadlocal = local()
 
@@ -191,11 +221,9 @@ _graph: Virtualized[GraphLowering] = Virtualized("graph", NullHandler)
 _extern_kernel_nodes: Virtualized[list[ExternKernelNode]] = Virtualized(
     "extern_kernel_nodes", NullHandler
 )
-_real_inputs: Virtualized[list[torch.Tensor]] = Virtualized("real_inputs", NullHandler)
+_real_inputs: Virtualized[Sequence[InputType]] = Virtualized("real_inputs", NullHandler)
 _fake_mode: Virtualized[FakeTensorMode] = Virtualized("fake_mode", NullHandler)
-_kernel: Virtualized[NullKernelHandler] = Virtualized(
-    "kernel", NullKernelHandler
-)  # TODO: improve type
+_kernel: Virtualized[KernelLike] = Virtualized("kernel", NullKernelHandler)
 _debug: Virtualized[DebugContext] = Virtualized("debug", NullHandler)
 _interpreter: Virtualized[InterpreterShim] = Virtualized("interpreter", NullHandler)
 _aot_compilation: Virtualized[bool] = Virtualized("aot_compilation", NullHandler)
@@ -370,33 +398,59 @@ class _V:
         _ops._set_handler
     )
     get_ops_handler: Callable[[], OpsHandler[Any]] = _ops._get_handler
-    set_graph_handler: Callable[[GraphLowering], Any] = _graph._set_handler
-    set_extern_kernel_nodes: Callable[[list[ExternKernelNode]], Any] = (
-        _extern_kernel_nodes._set_handler
+    set_graph_handler: Callable[[GraphLowering], AbstractContextManager[None]] = (
+        _graph._set_handler
     )
-    set_real_inputs: Callable[[Any], Any] = _real_inputs._set_handler
-    get_real_inputs: Callable[[], Any] = _real_inputs._get_handler
-    set_fake_mode: Callable[[Any], Any] = _fake_mode._set_handler
-    get_fake_mode: Callable[[], Any] = _fake_mode._get_handler
-    set_kernel_handler: Callable[[Any], Any] = _kernel._set_handler
-    set_debug_handler: Callable[[Any], Any] = _debug._set_handler
-    set_interpreter_handler: Callable[[Any], Any] = _interpreter._set_handler
-    set_aot_compilation: Callable[[bool], Any] = _aot_compilation._set_handler
-    get_aot_compilation: Callable[[], Any] = _aot_compilation._get_handler
-    set_current_node: Callable[[Any], Any] = _current_node._set_handler
-    get_current_node: Callable[[], Any] = _current_node._get_handler
-    set_local_buffer_context: Callable[[Any], Any] = _local_buffer_context._set_handler
-    get_local_buffer_context: Callable[[], Any] = _local_buffer_context._get_handler
-    set_choices_handler: Callable[[Any], Any] = _choices._set_handler
-    set_distributed_autotune_state: Callable[[Any], Any] = (
+    set_extern_kernel_nodes: Callable[
+        [list[ExternKernelNode]], AbstractContextManager[None]
+    ] = _extern_kernel_nodes._set_handler
+    set_real_inputs: Callable[[Sequence[InputType]], AbstractContextManager[None]] = (
+        _real_inputs._set_handler
+    )
+    get_real_inputs: Callable[[], Sequence[InputType]] = _real_inputs._get_handler
+    # Broad param: fake_mode may be installed as None (see compile_fx); the
+    # getter still narrows to FakeTensorMode for the common set-then-read path.
+    set_fake_mode: Callable[[Any], AbstractContextManager[None]] = (
+        _fake_mode._set_handler
+    )
+    get_fake_mode: Callable[[], FakeTensorMode] = _fake_mode._get_handler
+    set_kernel_handler: Callable[[Any], AbstractContextManager[None]] = (
+        _kernel._set_handler
+    )
+    set_debug_handler: Callable[[DebugContext], AbstractContextManager[None]] = (
+        _debug._set_handler
+    )
+    set_interpreter_handler: Callable[
+        [InterpreterShim], AbstractContextManager[None]
+    ] = _interpreter._set_handler
+    set_aot_compilation: Callable[[bool], AbstractContextManager[None]] = (
+        _aot_compilation._set_handler
+    )
+    get_aot_compilation: Callable[[], bool] = _aot_compilation._get_handler
+    set_current_node: Callable[[torch.fx.Node], AbstractContextManager[None]] = (
+        _current_node._set_handler
+    )
+    get_current_node: Callable[[], torch.fx.Node] = _current_node._get_handler
+    set_local_buffer_context: Callable[
+        [LocalBufferContext], AbstractContextManager[None]
+    ] = _local_buffer_context._set_handler
+    get_local_buffer_context: Callable[[], LocalBufferContext] = (
+        _local_buffer_context._get_handler
+    )
+    set_choices_handler: Callable[[InductorChoices], AbstractContextManager[None]] = (
+        _choices._set_handler
+    )
+    # Broad param: the state is reset by installing a NullHandler (see
+    # distributed_autotune.graph_context); the getter narrows on the read path.
+    set_distributed_autotune_state: Callable[[Any], AbstractContextManager[None]] = (
         _distributed_autotune_state._set_handler
     )
-    get_distributed_autotune_state: Callable[[], Any] = (
+    get_distributed_autotune_state: Callable[[], _DistributedAutotuneState] = (
         _distributed_autotune_state._get_handler
     )
-    set_active_user_lowering_ops: Callable[[Any], Any] = (
-        _active_user_lowering_ops._set_handler
-    )
+    set_active_user_lowering_ops: Callable[
+        [OrderedSet[Any]], AbstractContextManager[None]
+    ] = _active_user_lowering_ops._set_handler
     get_active_user_lowering_ops: Callable[[], OrderedSet[Any]] = (
         _active_user_lowering_ops._get_handler
     )
@@ -421,20 +475,24 @@ class _V:
         return _extern_kernel_nodes._get_handler()
 
     @property
-    def real_inputs(self):
+    def real_inputs(self) -> Sequence[InputType]:
         """non-fake example inputs"""
         return _real_inputs._get_handler()
 
     @property
-    def fake_mode(self):
+    def fake_mode(self) -> FakeTensorMode:
         """The graph currently being generated"""
         return _fake_mode._get_handler()
 
     @property
-    def kernel(self):
+    def kernel(self) -> KernelLike:
         """The kernel currently being generated"""
         return _kernel._get_handler()
 
+    # debug and interpreter intentionally keep an inferred (dynamic) return
+    # type: DebugContext dispatches via __getattr__ and InterpreterShim carries
+    # an Optional current_node, so pinning the concrete class here surfaces
+    # spurious callable/None errors at unrelated call sites.
     @property
     def debug(self):
         return _debug._get_handler()
@@ -444,15 +502,15 @@ class _V:
         return _interpreter._get_handler()
 
     @property
-    def aot_compilation(self):
+    def aot_compilation(self) -> bool:
         return _aot_compilation._get_handler() is True
 
     @property
-    def current_node(self):
+    def current_node(self) -> torch.fx.Node:
         return _current_node._get_handler()
 
     @property
-    def local_buffer_context(self):
+    def local_buffer_context(self) -> LocalBufferContext:
         return _local_buffer_context._get_handler()
 
     @property
@@ -460,7 +518,7 @@ class _V:
         return _choices._get_handler()
 
     @property
-    def distributed_autotune_state(self):
+    def distributed_autotune_state(self) -> _DistributedAutotuneState:
         return _distributed_autotune_state._get_handler()
 
     @property

--- a/torch/_inductor/virtualized.py
+++ b/torch/_inductor/virtualized.py
@@ -489,10 +489,10 @@ class _V:
         """The kernel currently being generated"""
         return _kernel._get_handler()
 
-    # debug and interpreter intentionally keep an inferred (dynamic) return
-    # type: DebugContext dispatches via __getattr__ and InterpreterShim carries
-    # an Optional current_node, so pinning the concrete class here surfaces
-    # spurious callable/None errors at unrelated call sites.
+    # debug and interpreter intentionally keep an inferred (dynamic) return type.
+    # DebugContext dispatches via __getattr__ and InterpreterShim carries an
+    # Optional current_node, so pinning the concrete class here surfaces spurious
+    # callable/None errors at unrelated call sites.
     @property
     def debug(self):
         return _debug._get_handler()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #189954

The `_V` accessor surface in `virtualized.py` was almost entirely
`Callable[[Any], Any]` / untyped properties even though each backing
`Virtualized[X]` slot already declares its concrete handler type one screen
up. This retypes the setters/getters and property returns to those known
types (`GraphLowering`, `FakeTensorMode`, `torch.fx.Node`, `InductorChoices`,
`LocalBufferContext`, `_DistributedAutotuneState`, `Sequence[InputType]`, ...)
and introduces a `KernelLike` protocol for `V.kernel`.

The one real judgment call is `V.kernel`. It is a genuinely duck-typed slot:
the backing handler ranges from the `NullKernelHandler` sentinel to any of the
backend `Kernel` subclasses (Triton/CPP/CUTLASS/ROCm/CuteDSL), and callers read
~70 distinct members off it, most of them backend-specific. A protocol that
enumerated every member would both couple `virtualized.py` to backend internals
and still fail to be satisfiable by the null sentinel. Instead `KernelLike`
declares only the common surface relied on regardless of backend
(`removed_buffers`, `inplaced_to_remove`, `index_dtype`, `cse`, `compute`,
`current_node`, `args`, `create_cse_var`) and adds `__getattr__`/`__setattr__`
fallbacks so backend-specific reads/writes remain `Any`. This gives precise
types for the common surface while keeping the ~80 polymorphic call sites
type-checking exactly as they did when `V.kernel` was `Any`.

A few other deliberate choices:
- `debug` and `interpreter` keep an inferred (dynamic) return type: the former
  dispatches via `DebugContext.__getattr__` (making real methods look Optional)
  and the latter carries an Optional `current_node`, so pinning the concrete
  class surfaces spurious errors at unrelated call sites.
- `set_fake_mode` / `set_distributed_autotune_state` keep a broad param type
  because those slots are legitimately installed with `None` / a reset
  `NullHandler`; the getters still narrow on the read path.

Tightening the accessors surfaces a handful of latent Optional/subtype
assumptions at call sites; each is addressed locally with a cast (where the
concrete subtype is known), an `AssertionError` guard (where an invariant
holds), or a targeted `pyrefly: ignore` (where the checker cannot prove a
runtime invariant).

Test Plan:

Verified there are zero net-new pyrefly errors across every file that uses the
retyped accessors (110 files), by diffing the checker output against
`origin/viable/strict`:

```
mapfile -t AFF < affected_files.txt   # all files using the retyped V accessors
pyrefly check "${AFF[@]}" | sort > new.txt
git stash && pyrefly check "${AFF[@]}" | sort > base.txt && git stash pop
comm -13 base.txt new.txt   # only line-shifted pre-existing errors, count unchanged (55 == 55)
```

```
lintrunner --take PYFMT,RUFF,PYREFLY,CODESPELL,FLAKE8 -a <changed files>
```

This PR was authored with the assistance of an AI coding agent.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo