### PR TITLE
[c10d][nccl2] Fix ROCm <7.0 build by guarding hipEventRecordWithFlags

### DIFF
--- a/torch/csrc/distributed/c10d/nccl2/CudaApi.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/CudaApi.cpp
@@ -196,7 +196,14 @@ cudaError_t DefaultCudaApi::eventRecordWithFlags(
     cudaEvent_t event,
     cudaStream_t stream,
     unsigned int flags) {
+#if !defined(USE_ROCM) || ROCM_VERSION >= 70000
   return cudaEventRecordWithFlags(event, stream, flags);
+#else
+  // hipEventRecordWithFlags is unavailable before ROCm 7.0; the flags variant
+  // has no equivalent, so fall back to the plain record.
+  (void)flags;
+  return cudaEventRecord(event, stream);
+#endif
 }
 
 cudaError_t DefaultCudaApi::eventQuery(cudaEvent_t event) {


### PR DESCRIPTION
Summary: Adds a version guard for `cudaEventRecordWithFlags` to fix build failures on ROCm versions before 7.0. The `hipEventRecordWithFlags` API is unavailable in older ROCm releases, so we fall back to the plain `cudaEventRecord` call for compatibility.

Test Plan: Verified the build failure was resolved in the CI link provided. The change maintains backward compatibility while allowing newer ROCm versions to use the flags variant.

Differential Revision: D112035112




cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang