### PR TITLE
nightly: fix update-metamates-rule by reading the team with pytorchbot token

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -94,7 +94,9 @@ jobs:
         run: pip install pyyaml==6.0.2
       - name: Update metamates rule
         env:
-          GH_TOKEN: ${{ secrets.UPDATEBOT_TOKEN }}
+          # Reading the closed pytorch/metamates team needs an org-member token;
+          # pytorchupdatebot is not an org member, so use pytorchbot here.
+          GH_TOKEN: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
         run: |
           python .github/scripts/update_metamates_rule.py
       - name: Create or update PR


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/189032

The `update-metamates-rule` job has failed on every scheduled run since it was added in #176303. It reads the `closed` pytorch/metamates team, but `UPDATEBOT_TOKEN` belongs to pytorchupdatebot, which is not a pytorch org member and so cannot enumerate the team's members (GitHub reports it as needing `admin:org`).

Fix: read the team with `GH_PYTORCHBOT_TOKEN` (pytorchbot is an org member); keep `UPDATEBOT_TOKEN` for checkout and the PR.

### Testing

* Example failure https://github.com/pytorch/pytorch/actions/runs/29382038881/job/87247646479
* Successful run with the right token https://github.com/pytorch/pytorch/actions/runs/29382692304/job/87249529930