### PR TITLE
[MPS] Gather non-dense equal-strided views in MPS-to-CPU copy

### DIFF
--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -133,12 +133,19 @@ static at::Tensor& copy_from_mps_(at::Tensor& dst_, const at::Tensor& src_, bool
   Tensor dst = dst_;
   Tensor src = src_;
 
-  if (dst_.strides() != src_.strides()) {
+  // Equal strides alone don't make the flat blit/castout below valid: both
+  // sides must also map a contiguous storage segment. Views like x[::2] share
+  // strides yet have holes, so a flat copy reads/writes the wrong bytes and
+  // clobbers out-of-view storage (the CPU-to-MPS direction already guards
+  // this with is_dense_in_storage). Gather/scatter through contiguous
+  // temporaries in that case.
+  const bool direct_copy = dst_.strides() == src_.strides() && is_dense_in_storage(src_);
+  if (!direct_copy) {
     dst = at::empty_like(dst_, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
   }
 
   auto storage_byte_offset = src_.storage_offset() * src_.itemsize();
-  if (dst_.strides() != src_.strides()) {
+  if (!direct_copy) {
     Tensor emptyShell = Tensor();
     src = gatherViewTensor(src_, emptyShell);
     if (src.has_storage()) {

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -7716,6 +7716,33 @@ class TestMPS(TestCaseMPS):
         self.assertEqual(output, input_cpu.to(torch.half))
         self.assertTrue(torch.equal(input_mps.cpu(), input_cpu))
 
+    # Regression test for https://github.com/pytorch/pytorch/issues/189961
+    def test_copy_equal_strided_non_dense_mps_to_cpu(self):
+        parent = torch.zeros(20)
+        dst = parent[::2]
+        src = torch.arange(20., device="mps")[::2]
+        dst.copy_(src)
+        expected_parent = torch.zeros(20)
+        expected_parent[::2] = torch.arange(0., 20., 2.)
+        self.assertEqual(dst, torch.arange(0., 20., 2.))
+        # out-of-view slots of the destination's storage must stay untouched
+        self.assertEqual(parent, expected_parent)
+
+        # column view into a preallocated CPU matrix
+        mcpu = torch.zeros(4, 4)
+        mmps = torch.arange(16., device="mps").reshape(4, 4)
+        mcpu[:, 0].copy_(mmps[:, 0])
+        expected = torch.zeros(4, 4)
+        expected[:, 0] = torch.arange(0., 16., 4.)
+        self.assertEqual(mcpu, expected)
+
+        # dtype-converting variant exercises the castout path
+        half_parent = torch.zeros(20, dtype=torch.half)
+        half_dst = half_parent[::2]
+        half_dst.copy_(src)
+        self.assertEqual(half_dst, torch.arange(0., 20., 2., dtype=torch.half))
+        self.assertEqual(half_parent[1::2], torch.zeros(10, dtype=torch.half))
+
     def test_cast_mps_to_mps(self):
         def helper(src_dtype, dst_dtype):
             input_cpu = torch.rand((1, 3, 128, 128), dtype=src_dtype)


### PR DESCRIPTION
`copy_from_mps_` gated its gather/materialization path solely on `dst_.strides() != src_.strides()`. When source and destination are views with identical but non-dense strides (e.g. `x[::2]`, or matching column views of preallocated matrices), it fell through to a flat copy of `numel * itemsize` contiguous storage bytes: the destination view received the wrong elements, the tail of the view was never written, and storage slots between the view's elements were clobbered. The dtype-converting castout path had the same hole.

Require `is_dense_in_storage(src_)` for the direct path, mirroring the guard the reverse CPU-to-MPS direction already has; equal strides plus equal sizes make source and destination density coincide. Non-dense views now gather on device and scatter through the existing contiguous-temporary epilogue.

The regression test covers the 1-D gappy view (values plus hole preservation in the destination's backing storage), the column-copy case, and a dtype-converting gappy copy through the castout path. The pre-existing D2H copy/cast suite (`-k "copy or cast or neg_bit"`, 1183 tests) passes unchanged.

Fixes #189961

*This PR was authored with assistance from Claude.*
