### PR TITLE
[MPS] Fall back to castout kernel for unaligned MPS-to-CPU copy offsets

### DIFF
--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -14,6 +14,8 @@
 #include <ATen/ops/zeros_like.h>
 #include <fmt/format.h>
 
+#include <limits>
+
 namespace at::native {
 #ifndef PYTORCH_JIT_COMPILE_SHADERS
 static auto& lib = mps::MetalShaderLibrary::getBundledLibrary();
@@ -172,20 +174,27 @@ static at::Tensor& copy_from_mps_(at::Tensor& dst_, const at::Tensor& src_, bool
 
   @autoreleasepool {
     auto [destBuffer, destOffset] = buffer_with_offset_from_tensor(dst, dst_tensor_nbytes, non_blocking);
-    // 4 bytes alignment required on macos for blits.
-    TORCH_INTERNAL_ASSERT(destOffset % 4 == 0, "Unaligned blit request");
 
     id<MTLBuffer> blitSourceBuffer = sourceBuffer;
     Tensor blitSource = src;
     NSUInteger blitSourceOffset = storage_byte_offset;
+    // Blit offsets must be 4-byte aligned on macOS. Sub-4-byte dtypes at odd
+    // element offsets (e.g. a bool slice, #119367) take the castout kernel
+    // below instead, which only needs element-size alignment. The castout API
+    // takes 32-bit offsets/numel, so unaligned sources beyond 4GB stay on the
+    // blit, matching prior behavior.
+    const bool blit_alignment_ok = destOffset % 4 == 0 && storage_byte_offset % 4 == 0;
+    const bool castout_fits = storage_byte_offset <= std::numeric_limits<uint32_t>::max() &&
+        src.numel() <= std::numeric_limits<uint32_t>::max();
     bool needsBlit = true;
-    if (src_.dtype() != dst.dtype()) {
+    if (src_.dtype() != dst.dtype() || (!blit_alignment_ok && castout_fits)) {
       // Unified memory: cast straight from the MPS source into the CPU-wrapped
       // destination buffer at the requested offsets. This avoids the temporary
       // that used to alias the live source buffer and blitting from it (see
       // #189563). src and dst are dense with identical strides here, so a linear
       // castout of numel elements from the source offset to the dest offset is a
-      // faithful conversion.
+      // faithful conversion. Same-dtype unaligned copies use the identity
+      // functor, so the castout is a plain offset-tolerant copy.
       needsBlit = false;
       const bool needs_conj = src.is_conj() != dst.is_conj();
       const bool needs_neg = src.is_neg() != dst.is_neg();
@@ -209,6 +218,9 @@ static at::Tensor& copy_from_mps_(at::Tensor& dst_, const at::Tensor& src_, bool
     }
 
     if (needsBlit) {
+      // Reachable with an unaligned dest only for >4GB unaligned source
+      // offsets, which the castout fallback cannot address.
+      TORCH_INTERNAL_ASSERT(destOffset % 4 == 0, "Unaligned blit request");
       const size_t size_to_copy = (src.nbytes() / src.element_size()) * dst.element_size();
 
       // If there's anything wrong with source, we shouldn't return dst_ silently and must error out.

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -4770,6 +4770,20 @@ class TestMPS(TestCaseMPS):
         x_cpu[2:4] = update_mps  # implicit device moving and copy
         self.assertEqual(x_cpu, x_mps)
 
+    # Regression test for https://github.com/pytorch/pytorch/issues/119367
+    def test_copy_unaligned_offsets_mps_to_cpu(self):
+        for dtype in [torch.bool, torch.uint8, torch.float16]:
+            for src_off, dst_off in [(0, 1), (1, 0), (1, 1), (3, 2), (0, 2)]:
+                with self.subTest(dtype=dtype, src_off=src_off, dst_off=dst_off):
+                    n = 8
+                    src_cpu = (torch.arange(n) % 3 != 0).to(dtype)
+                    src = src_cpu.to("mps")
+                    backing = torch.zeros(n + dst_off, dtype=dtype)
+                    dst = backing[dst_off:dst_off + n - src_off]
+                    dst.copy_(src[src_off:])
+                    self.assertEqual(dst, src_cpu[src_off:])
+                    self.assertEqual(backing[:dst_off], torch.zeros(dst_off, dtype=dtype))
+
     def test_copy_broadcasting(self):
         def helper(src_shape, dst_shape, src_dtype, dst_dtype):
             cpu_src = torch.randint(0, 127, src_shape).to(src_dtype)


### PR DESCRIPTION
`copy_from_mps_` asserted `destOffset % 4 == 0` before choosing how to copy, so any same-dtype D2H copy into a CPU view at a sub-4-byte offset (a bool or uint8 slice at odd offset, an fp16 slice at odd element offset) failed with `INTERNAL ASSERT FAILED ... Unaligned blit request`. The 4-byte requirement is real, but only for the blit encoder; the castout compute kernel that already serves dtype-converting copies indexes buffers at element-size alignment and handles these fine.

Route copies with unaligned source or destination byte offsets through the castout (identity) kernel instead of asserting, when the offsets fit the castout API's 32-bit arguments. The unaligned *source* offset case never even reached the old assert — it blitted out of spec (it happens to work on current macOS, but Metal's alignment contract covers both offsets). Sources with unaligned storage offsets beyond 4GB keep the legacy blit, matching prior behavior — `test_64bit_index_copy`'s `.item()` at a ~2^32 odd byte offset exercises exactly that path. The dest-alignment assert moves into the blit branch, now reachable only for that corner. Widening the castout API to 64-bit offsets would remove the remaining corner and is left as a follow-up.

The regression test parametrizes bool/uint8/fp16 over unaligned source/destination offset combinations, including the exact shape from #119367. The pre-existing copy/cast suite (1183 tests) passes unchanged.

Note: #189966 also touches `copy_from_mps_`; the two changes are textually independent, but this one should land second so the castout fallback only ever sees dense views.

Fixes #119367

*This PR was authored with assistance from Claude.*
