### PR TITLE
[MPS] Bounds-check indices in index_copy_, index_fill_, and index_reduce_

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Indexing.metal
+++ b/aten/src/ATen/native/mps/kernels/Indexing.metal
@@ -320,9 +320,9 @@ kernel void index_reduce(
       // separately by the index_check_bounds pass, which invalidates the
       // result. The wrapping uint32 cast keeps the math 32-bit: any negative
       // or too-large index still lands in [0, self_size - 1].
-      uint32_t idx = min(
-          static_cast<uint32_t>(index[dim_idx * params.index_stride]),
-          params.self_sizes[dim] - 1);
+      uint32_t idx =
+          min(static_cast<uint32_t>(index[dim_idx * params.index_stride]),
+              params.self_sizes[dim] - 1);
       self_offset += idx * params.self_strides[dim];
     } else {
       self_offset += dim_idx * params.self_strides[dim];
@@ -389,9 +389,9 @@ kernel void index_add(
       // separately by the index_check_bounds pass, which invalidates the
       // result. The wrapping uint32 cast keeps the math 32-bit: any negative
       // or too-large index still lands in [0, self_size - 1].
-      uint32_t idx = min(
-          static_cast<uint32_t>(index[dim_idx * params.index_stride]),
-          params.self_sizes[dim] - 1);
+      uint32_t idx =
+          min(static_cast<uint32_t>(index[dim_idx * params.index_stride]),
+              params.self_sizes[dim] - 1);
       self_offset += idx * params.self_strides[dim];
     } else {
       self_offset += dim_idx * params.self_strides[dim];
@@ -496,9 +496,9 @@ kernel void index_select_dim(
       // out-of-range index and invalidates the result. The wrapping uint32
       // cast keeps the math 32-bit: any negative or too-large index still
       // lands in [0, self_size - 1].
-      uint32_t idx = min(
-          static_cast<uint32_t>(index[dim_idx * params.index_stride]),
-          params.self_sizes[dim] - 1);
+      uint32_t idx =
+          min(static_cast<uint32_t>(index[dim_idx * params.index_stride]),
+              params.self_sizes[dim] - 1);
       input_offset += idx * params.self_strides[dim];
     } else {
       input_offset += dim_idx * params.self_strides[dim];
@@ -539,10 +539,11 @@ kernel void index_select_dim_dense(
     uint3 tid [[thread_position_in_grid]]) {
   // Clamp keeps the read in bounds; index_check_bounds reports any out-of-range
   // index and invalidates the result. The wrapping uint32 cast keeps the
-  // clamp 32-bit; any negative or too-large index lands in [0, in_dim_size - 1].
-  uint32_t in_row = min(
-      static_cast<uint32_t>(index[tid.y * params.index_stride]),
-      params.in_dim_size - 1);
+  // clamp 32-bit; any negative or too-large index lands in [0, in_dim_size -
+  // 1].
+  uint32_t in_row =
+      min(static_cast<uint32_t>(index[tid.y * params.index_stride]),
+          params.in_dim_size - 1);
   long out_off =
       (static_cast<long>(tid.z) * params.out_dim_size + tid.y) * params.inner +
       tid.x;

--- a/aten/src/ATen/native/mps/kernels/Indexing.metal
+++ b/aten/src/ATen/native/mps/kernels/Indexing.metal
@@ -318,12 +318,12 @@ kernel void index_reduce(
     if (dim == params.reduce_dim) {
       // Clamp keeps the access in bounds; out-of-range indices are reported
       // separately by the index_check_bounds pass, which invalidates the
-      // result.
-      long idx = clamp(
-          long(index[dim_idx * params.index_stride]),
-          0L,
-          long(params.self_sizes[dim]) - 1);
-      self_offset += static_cast<uint32_t>(idx) * params.self_strides[dim];
+      // result. The wrapping uint32 cast keeps the math 32-bit: any negative
+      // or too-large index still lands in [0, self_size - 1].
+      uint32_t idx = min(
+          static_cast<uint32_t>(index[dim_idx * params.index_stride]),
+          params.self_sizes[dim] - 1);
+      self_offset += idx * params.self_strides[dim];
     } else {
       self_offset += dim_idx * params.self_strides[dim];
     }
@@ -387,12 +387,12 @@ kernel void index_add(
     if (dim == params.reduce_dim) {
       // Clamp keeps the access in bounds; out-of-range indices are reported
       // separately by the index_check_bounds pass, which invalidates the
-      // result.
-      long idx = clamp(
-          long(index[dim_idx * params.index_stride]),
-          0L,
-          long(params.self_sizes[dim]) - 1);
-      self_offset += static_cast<uint32_t>(idx) * params.self_strides[dim];
+      // result. The wrapping uint32 cast keeps the math 32-bit: any negative
+      // or too-large index still lands in [0, self_size - 1].
+      uint32_t idx = min(
+          static_cast<uint32_t>(index[dim_idx * params.index_stride]),
+          params.self_sizes[dim] - 1);
+      self_offset += idx * params.self_strides[dim];
     } else {
       self_offset += dim_idx * params.self_strides[dim];
     }
@@ -493,12 +493,13 @@ kernel void index_select_dim(
 
     if (dim == params.reduce_dim) {
       // Clamp keeps the access in bounds; index_check_bounds reports any
-      // out-of-range index and invalidates the result.
-      long idx = clamp(
-          long(index[dim_idx * params.index_stride]),
-          0L,
-          long(params.self_sizes[dim]) - 1);
-      input_offset += static_cast<uint32_t>(idx) * params.self_strides[dim];
+      // out-of-range index and invalidates the result. The wrapping uint32
+      // cast keeps the math 32-bit: any negative or too-large index still
+      // lands in [0, self_size - 1].
+      uint32_t idx = min(
+          static_cast<uint32_t>(index[dim_idx * params.index_stride]),
+          params.self_sizes[dim] - 1);
+      input_offset += idx * params.self_strides[dim];
     } else {
       input_offset += dim_idx * params.self_strides[dim];
     }
@@ -537,11 +538,11 @@ kernel void index_select_dim_dense(
     constant IndexSelectParams& params [[buffer(3)]],
     uint3 tid [[thread_position_in_grid]]) {
   // Clamp keeps the read in bounds; index_check_bounds reports any out-of-range
-  // index and invalidates the result.
-  long in_row = clamp(
-      long(index[tid.y * params.index_stride]),
-      0L,
-      long(params.in_dim_size) - 1);
+  // index and invalidates the result. The wrapping uint32 cast keeps the
+  // clamp 32-bit; any negative or too-large index lands in [0, in_dim_size - 1].
+  uint32_t in_row = min(
+      static_cast<uint32_t>(index[tid.y * params.index_stride]),
+      params.in_dim_size - 1);
   long out_off =
       (static_cast<long>(tid.z) * params.out_dim_size + tid.y) * params.inner +
       tid.x;
@@ -657,7 +658,8 @@ kernel void index_copy_dense(
   OffsetT before = gid.z;
   // Clamp keeps the access in bounds; out-of-range indices are reported
   // separately by the index_check_bounds pass, which invalidates the result.
-  OffsetT idx = OffsetT(clamp(long(indices[i]), 0L, long(dim_size) - 1));
+  // Clamping in OffsetT keeps the 32-bit kernel variant free of long math.
+  OffsetT idx = clamp(OffsetT(indices[i]), OffsetT(0), OffsetT(dim_size - 1));
   output[(before * OffsetT(dim_size) + idx) * OffsetT(inner) + after] =
       source[(before * OffsetT(indices_numel) + i) * OffsetT(inner) + after];
 }
@@ -682,8 +684,11 @@ kernel void index_copy_strided(
   // Clamp keeps the access in bounds; out-of-range indices (including
   // negative ones, which index_copy_ rejects) are reported separately by the
   // index_check_bounds pass, which invalidates the result.
-  OffsetT idx = OffsetT(clamp(
-      long(indices[i * OffsetT(indices_stride)]), 0L, long(dim_size) - 1));
+  // Clamping in OffsetT keeps the 32-bit kernel variant free of long math.
+  OffsetT idx = clamp(
+      OffsetT(indices[i * OffsetT(indices_stride)]),
+      OffsetT(0),
+      OffsetT(dim_size - 1));
   OffsetT slice_pos[max_ndim];
   pos_from_thread_index(j, slice_pos, slice_sizes, slice_ndim);
   OffsetT out_offset =

--- a/aten/src/ATen/native/mps/kernels/Indexing.metal
+++ b/aten/src/ATen/native/mps/kernels/Indexing.metal
@@ -316,9 +316,14 @@ kernel void index_reduce(
     source_offset += dim_idx * params.source_strides[dim];
 
     if (dim == params.reduce_dim) {
-      uint32_t self_dim_idx =
-          static_cast<uint32_t>(index[dim_idx * params.index_stride]);
-      self_offset += self_dim_idx * params.self_strides[dim];
+      // Clamp keeps the access in bounds; out-of-range indices are reported
+      // separately by the index_check_bounds pass, which invalidates the
+      // result.
+      long idx = clamp(
+          long(index[dim_idx * params.index_stride]),
+          0L,
+          long(params.self_sizes[dim]) - 1);
+      self_offset += static_cast<uint32_t>(idx) * params.self_strides[dim];
     } else {
       self_offset += dim_idx * params.self_strides[dim];
     }
@@ -437,10 +442,11 @@ kernel void index_check_bounds(
     device IT* index [[buffer(0)]],
     constant uint& index_stride [[buffer(1)]],
     constant long& dim_size [[buffer(2)]],
-    device ErrorMessages* error_buf [[buffer(3)]],
+    constant long& lower_bound [[buffer(3)]],
+    device ErrorMessages* error_buf [[buffer(4)]],
     uint tid [[thread_position_in_grid]]) {
   long idx = index[tid * index_stride];
-  if (idx < 0 || idx >= dim_size) {
+  if (idx < lower_bound || idx >= dim_size) {
     TORCH_REPORT_ERROR(
         error_buf,
         "index ",
@@ -455,12 +461,14 @@ template [[host_name("index_check_bounds_int")]] kernel void index_check_bounds<
     device int*,
     constant uint&,
     constant long&,
+    constant long&,
     device ErrorMessages*,
     uint);
 template [[host_name("index_check_bounds_long")]] kernel void index_check_bounds<
     long>(
     device long*,
     constant uint&,
+    constant long&,
     constant long&,
     device ErrorMessages*,
     uint);
@@ -647,7 +655,9 @@ kernel void index_copy_dense(
   OffsetT after = gid.x;
   OffsetT i = gid.y;
   OffsetT before = gid.z;
-  OffsetT idx = indices[i];
+  // Clamp keeps the access in bounds; out-of-range indices are reported
+  // separately by the index_check_bounds pass, which invalidates the result.
+  OffsetT idx = OffsetT(clamp(long(indices[i]), 0L, long(dim_size) - 1));
   output[(before * OffsetT(dim_size) + idx) * OffsetT(inner) + after] =
       source[(before * OffsetT(indices_numel) + i) * OffsetT(inner) + after];
 }
@@ -669,10 +679,11 @@ kernel void index_copy_strided(
     uint thread_index [[thread_position_in_grid]]) {
   OffsetT j = OffsetT(thread_index) % OffsetT(slice_numel);
   OffsetT i = OffsetT(thread_index) / OffsetT(slice_numel);
-  OffsetT idx = indices[i * OffsetT(indices_stride)];
-  if (idx < 0) {
-    idx += OffsetT(dim_size);
-  }
+  // Clamp keeps the access in bounds; out-of-range indices (including
+  // negative ones, which index_copy_ rejects) are reported separately by the
+  // index_check_bounds pass, which invalidates the result.
+  OffsetT idx = OffsetT(clamp(
+      long(indices[i * OffsetT(indices_stride)]), 0L, long(dim_size) - 1));
   OffsetT slice_pos[max_ndim];
   pos_from_thread_index(j, slice_pos, slice_sizes, slice_ndim);
   OffsetT out_offset =
@@ -705,6 +716,10 @@ kernel void index_fill_dense(
   if (idx < 0) {
     idx += dim_size;
   }
+  // Clamp keeps the access in bounds; indices outside [-dim_size, dim_size)
+  // are reported separately by the index_check_bounds pass, which invalidates
+  // the result.
+  idx = clamp(idx, 0L, dim_size - 1);
   long before = j / dim_stride;
   long after = j % dim_stride;
   output[before * (dim_size * dim_stride) + idx * dim_stride + after] =
@@ -733,6 +748,10 @@ kernel void index_fill_strided(
   if (idx < 0) {
     idx += dim_size;
   }
+  // Clamp keeps the access in bounds; indices outside [-dim_size, dim_size)
+  // are reported separately by the index_check_bounds pass, which invalidates
+  // the result.
+  idx = clamp(idx, 0L, dim_size - 1);
   int slice_pos[max_ndim];
   pos_from_thread_index(int(j), slice_pos, slice_sizes, slice_ndim);
   long out_offset = offset_from_coord(slice_pos, slice_out_strides, slice_ndim);
@@ -762,6 +781,10 @@ kernel void index_fill_set_mask(
   long idx = indices[thread_index * indices_stride];
   if (idx < 0)
     idx += dim_size;
+  // Clamp keeps the mask write in bounds; indices outside
+  // [-dim_size, dim_size) are reported separately by the index_check_bounds
+  // pass, which invalidates the result.
+  idx = clamp(idx, 0L, dim_size - 1);
   mask[idx] = true;
 }
 

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -221,6 +221,25 @@ static void index_put_kernel_mps(TensorIterator& iter,
 }
 } // namespace mps
 
+// Validate index in [lower, dim_size) once (one thread per index) on the
+// given encoder, so the following gather/scatter kernel can clamp instead of
+// branch-and-report per element. lower is 0, or -dim_size for ops like
+// index_fill_ that accept wrapped negative indices. Out-of-bounds surfaces as
+// an async AcceleratorError on the next stream sync.
+static void encodeIndexBoundsCheck(id<MTLComputeCommandEncoder> encoder,
+                                   at::mps::MPSStream* stream,
+                                   const Tensor& index,
+                                   int64_t dim_size,
+                                   bool allow_negative_wrap = false) {
+  using namespace mps;
+  auto pso = lib.getPipelineStateForFunc(fmt::format("index_check_bounds_{}", scalarToMetalTypeString(index)));
+  const int64_t lower_bound = allow_negative_wrap ? -dim_size : 0;
+  [encoder setComputePipelineState:pso];
+  mtl_setArgs(encoder, index);
+  mtl_setArgs<1>(encoder, static_cast<uint32_t>(index.stride(0)), dim_size, lower_bound, stream->getErrorBuffer());
+  mtl_dispatch1DJob(encoder, pso, index.numel());
+}
+
 TORCH_IMPL_FUNC(index_copy_out_mps)(const Tensor& self,
                                     int64_t dim,
                                     const Tensor& index,
@@ -306,6 +325,7 @@ TORCH_IMPL_FUNC(index_copy_out_mps)(const Tensor& self,
   dispatch_sync_with_rethrow(stream->queue(), ^() {
     @autoreleasepool {
       auto computeEncoder = stream->commandEncoder();
+      encodeIndexBoundsCheck(computeEncoder, stream, index, dim_size);
       [computeEncoder setComputePipelineState:indexCopyPSO];
       mtl_setArgs(computeEncoder, result, source, index);
       if (is_dense) {
@@ -534,22 +554,6 @@ Tensor flip_mps(const Tensor& self, IntArrayRef dims) {
   }
 
   return result;
-}
-
-// Validate index in [0, dim_size) once (one thread per index) on the given
-// encoder, so the following gather/scatter kernel can clamp instead of
-// branch-and-report per element. Out-of-bounds surfaces as an async
-// AcceleratorError on the next stream sync.
-static void encodeIndexBoundsCheck(id<MTLComputeCommandEncoder> encoder,
-                                   at::mps::MPSStream* stream,
-                                   const Tensor& index,
-                                   int64_t dim_size) {
-  using namespace mps;
-  auto pso = lib.getPipelineStateForFunc(fmt::format("index_check_bounds_{}", scalarToMetalTypeString(index)));
-  [encoder setComputePipelineState:pso];
-  mtl_setArgs(encoder, index);
-  mtl_setArgs<1>(encoder, static_cast<uint32_t>(index.stride(0)), dim_size, stream->getErrorBuffer());
-  mtl_dispatch1DJob(encoder, pso, index.numel());
 }
 
 TORCH_IMPL_FUNC(index_add_mps_out)
@@ -891,10 +895,13 @@ TORCH_IMPL_FUNC(index_reduce_mps_out)
   MPSStream* stream = getCurrentMPSStream();
 
   auto num_threads = source.numel();
+  // For a 0-dim result the only valid index is 0.
+  const int64_t index_bound = result.dim() > 0 ? result.size(dim) : 1;
 
   dispatch_sync_with_rethrow(stream->queue(), ^() {
     @autoreleasepool {
       id<MTLComputeCommandEncoder> compute_encoder = stream->commandEncoder();
+      encodeIndexBoundsCheck(compute_encoder, stream, index, index_bound);
       auto pipeline_state = mps::lib.getPipelineStateForFunc(fmt::format(
           "index_reduce_{}_{}_{}", reduce, mps::scalarToMetalTypeString(result), mps::scalarToMetalTypeString(index)));
       getMPSProfiler().beginProfileKernel(pipeline_state, "index_reduce", {result, index, source});
@@ -1091,6 +1098,7 @@ static void index_fill_mps_kernel(TensorIterator& iter,
     dispatch_sync_with_rethrow(stream->queue(), ^() {
       @autoreleasepool {
         auto computeEncoder = stream->commandEncoder();
+        encodeIndexBoundsCheck(computeEncoder, stream, index, dim_size, /*allow_negative_wrap=*/true);
         auto mpsScalar = getMPSScalar(source, self.scalar_type());
         long indices_stride = index.stride(0);
 
@@ -1154,6 +1162,7 @@ static void index_fill_mps_kernel(TensorIterator& iter,
     dispatch_sync_with_rethrow(stream->queue(), ^() {
       @autoreleasepool {
         auto computeEncoder = stream->commandEncoder();
+        encodeIndexBoundsCheck(computeEncoder, stream, index, dim_size, /*allow_negative_wrap=*/true);
         auto mpsScalar = getMPSScalar(source, self.scalar_type());
         [computeEncoder setComputePipelineState:indexFillPSO];
         mtl_setArgs(computeEncoder, self, index);

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -8565,6 +8565,43 @@ class TestMPS(TestCaseMPS):
         for args in test_cases:
             helper(*args)
 
+    # Regression test for https://github.com/pytorch/pytorch/issues/189968,
+    # https://github.com/pytorch/pytorch/issues/189969, and
+    # https://github.com/pytorch/pytorch/issues/189970: these ops skipped
+    # index validation and wrote out of bounds. Like index_add_/index_select,
+    # invalid indices are reported asynchronously and surface at the next sync.
+    def test_indexed_write_ops_reject_out_of_bounds_indices(self):
+        def run(op, t, index):
+            if op == "index_copy":
+                t.index_copy_(0, index, torch.ones(index.numel(), 4, device="mps"))
+            elif op == "index_fill":
+                t.index_fill_(0, index, 7.0)
+            elif op == "index_reduce":
+                t.index_reduce_(0, index, torch.ones(index.numel(), 4, device="mps"), "amax")
+            torch.mps.synchronize()
+
+        for op in ("index_copy", "index_fill", "index_reduce"):
+            # index_fill_ wraps negative indices in [-size, -1]; the others
+            # reject all negatives like CPU.
+            bad_indices = (32, 100, -33) if op == "index_fill" else (32, 100, -1)
+            for strided in (False, True):
+                for bad in bad_indices:
+                    with self.subTest(op=op, strided=strided, bad=bad):
+                        t = torch.zeros(4, 64, device="mps").t()[:32, :] if strided \
+                            else torch.zeros(32, 4, device="mps")
+                        with self.assertRaisesRegex(torch.AcceleratorError, "out of bounds"):
+                            run(op, t, torch.tensor([bad], device="mps"))
+
+        # valid negative indices for index_fill_ keep wrapping
+        t = torch.zeros(32, device="mps")
+        t.index_fill_(0, torch.tensor([-1], device="mps"), 3.0)
+        self.assertEqual(t[-1].item(), 3.0)
+
+        # the mask-based index_fill_ path (high fill rate) must also report
+        with self.assertRaisesRegex(torch.AcceleratorError, "out of bounds"):
+            torch.zeros(5, device="mps").index_fill_(0, torch.tensor([8], device="mps"), 7.0)
+            torch.mps.synchronize()
+
     def test_index_select_scalar(self):
         def helper(value, dim, index, idx_dtype=torch.int32):
             cpu_x = torch.tensor(value, device='cpu', dtype=torch.float, requires_grad=False)


### PR DESCRIPTION
These three ops dispatched their kernels without the shared `index_check_bounds` pass that `index_add_` and `index_select` already encode, so an out-of-range index silently read or wrote out of bounds: past or before the tensor view for `index_copy_` and `index_fill_`'s scatter path, past the internal mask allocation for `index_fill_`'s mask path, and via an unchecked uint32 cast (negative indices become huge offsets) for `index_reduce_`'s atomic writes. CPU raises `IndexError` for all of these; the repros in the linked issues show corruption of sibling storage and of separately allocated tensors.

Encode the shared bounds check before each kernel and clamp the index in the kernels, matching the existing check-then-clamp pattern. The checker gains a `lower_bound` argument because `index_fill_` accepts negative indices in `[-size, -1]` (which continue to wrap), while `index_copy_` and `index_reduce_` reject all negatives like CPU — `index_copy_`'s strided kernel previously wrapped negatives once instead. Errors surface as an async `AcceleratorError` at the next sync, same as `index_add_`.

The new test covers dense and strided variants of all three ops with too-large and invalid-negative indices, `index_fill_`'s valid negative wrapping, and both of its kernel paths. The pre-existing index suite passes, except `test_output_match_index_reduce_{mean,prod}_mps_bfloat16` which alternate pass/fail on unmodified main as well (non-associative atomic accumulation; the op already calls `alertNotDeterministic`).

Fixes #189968
Fixes #189969
Fixes #189970

*This PR was authored with assistance from Claude.*
