### PR TITLE
[xpu][fix] Restore @skipIfXpu on test_unused_cpu_input_cudagraphs

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -2395,6 +2395,7 @@ class CudaReproTests(TestCase):
         idxs = remove_unaligned_input_idxs(inputs, [0, 2])
         self.assertEqual(idxs, [0])
 
+    @skipIfXpu(msg="cudagraph is not supported on xpu")
     @skipIfCachingAllocatorDisabled
     @config.patch("triton.cudagraphs", True)
     def test_unused_cpu_input_cudagraphs(self):


### PR DESCRIPTION
## Summary

Restores the `@skipIfXpu(msg="cudagraph is not supported on xpu")` decorator on `test_unused_cpu_input_cudagraphs` in `test/inductor/test_cuda_repro.py`. This decorator was removed in #186915 on the premise that cudagraphs are now supported on XPU, but that is not yet true for this test.

Fixes #189815

## Root cause

The test currently fails on XPU with:

```
AssertionError: None mismatch: skipping cudagraphs due to multiple devices:
device(type='xpu', index=0) is not None
```

at `test/inductor/test_cuda_repro.py:2409` (`self.assertEqual(graph.disable_cudagraphs_reason, None)`).

Two independent reasons this test cannot pass on XPU today:

1. `torch/_inductor/cudagraph_utils.py::check_multiple_devices_or_any_cpu_nodes` explicitly whitelists only ``\"cuda\"`` when a single non-cpu device remains:

   ```python
   if (
       len(device_node_mapping) == 1
       and next(iter(device_node_mapping.keys())).type == "cuda"
   ):
       return None
   ```

   For XPU the single-remaining device is ``\"xpu\"``, so it falls through to the ``\"multiple devices\"`` branch and sets `disable_cudagraphs_reason`, which the test asserts is `None`.

2. `torch/_inductor/cudagraph_trees.py` (the inductor runtime that actually captures/replays cudagraphs) has zero XPU references. Even if the check above were extended to accept ``\"xpu\"``, the runtime path `compiled_fn(*inp)` would not work end-to-end.

The sibling `test_cpu_index` still carries the same `@skipIfXpu(msg="cudagraph is not supported on xpu")`, consistent with this reality. Restoring the skip here matches that.

## Why not fix the underlying issue instead

Enabling XPU cudagraphs in inductor is a larger piece of work spanning both `cudagraph_utils.py` (device whitelisting) and `cudagraph_trees.py` (runtime integration). Doing the surface-level `cudagraph_utils` patch alone would only push the failure downstream into cudagraph replay. The correct order is to enable the runtime first, then remove the skip — tracked in intel/torch-xpu-ops#4345. This PR restores the skip so nightly CI is unblocked.

## Test Plan

```bash
source /opt/intel/oneapi/setvars.sh
python test/inductor/test_cuda_repro.py -k test_unused_cpu_input_cudagraphs -v
```

Before this change:

```
FAILED (failures=1)
AssertionError: None mismatch: skipping cudagraphs due to multiple devices:
device(type='xpu', index=0) is not None
```

After this change:

```
test_unused_cpu_input_cudagraphs ... skipped 'skipIfXpu: cudagraph is not supported on xpu'
OK (skipped=1)
```

Verified against latest XPU nightly wheel `torch 2.14.0.dev20260713+xpu` on Intel Data Center GPU Max 1100.

Note: This PR was authored with AI assistance.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo
