### PR TITLE
[Testcase Refactoring] Generalize `HAS_ACCELERATOR` flag to support out-of-tree backends

### DIFF
--- a/test/distributed/checkpoint/test_state_dict_stager.py
+++ b/test/distributed/checkpoint/test_state_dict_stager.py
@@ -22,6 +22,7 @@ from torch.distributed.checkpoint._state_dict_stager import StateDictStager
 from torch.distributed.checkpoint.staging import _ReplicationStager
 from torch.distributed.checkpoint.state_dict_saver import async_save
 from torch.distributed.tensor import DeviceMesh, distribute_tensor
+from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_distributed import (
     HAS_ACCELERATOR,
     requires_accelerator_dist_backend,
@@ -209,7 +210,9 @@ class FrozenDataClass:
 
 
 class TestStateDictStager(TestCase):
-    @unittest.skipIf(not HAS_ACCELERATOR, "No accelerator")
+    @unittest.skipIf(
+        not TEST_CUDA, "This test verifies CUDA-only feature pin_memory"
+    )
     def test_views(self):
         test_configs = [
             (False, False),  # pin_memory=False, share_memory=False,
@@ -923,7 +926,12 @@ class TestReplicationStager(DTensorTestBase):
 
     @property
     def backend(self) -> str:
-        return "cpu:gloo,cuda:nccl"
+        # Device-agnostic composed backend matching the allow-list entry in
+        # common_dtensor.DTensorTestBase.init_pg:
+        #   f"cpu:gloo,{self.device_type}:{curr_backend}"
+        # where curr_backend = dist.get_default_backend_for_device(self.device_type).
+        curr_backend = dist.get_default_backend_for_device(self.device_type)
+        return f"cpu:gloo,{self.device_type}:{curr_backend}"
 
     def _create_simple_state_dict(self, rank: int) -> dict:
         """

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -83,7 +83,9 @@ logger.setLevel(logging.INFO)
 
 ACCELERATOR_DIST_BACKENDS = ["nccl", "xccl", "hccl"]
 DDP_RANK_DEVICES = ["cuda", "xpu"]
-HAS_ACCELERATOR = TEST_CUDA or TEST_HPU or TEST_XPU
+# HAS_ACCELERATOR should check all supported accelerators, including out-of-tree backends,
+# hence replace TEST_CUDA, TEST_HPU and TEST_XPU with is_available call instead.
+HAS_ACCELERATOR = torch.accelerator.is_available()
 
 
 class TestSkip(NamedTuple):


### PR DESCRIPTION
## Summary

This PR generalizes the `HAS_ACCELERATOR` flag in `torch/testing/_internal/common_distributed.py` so it no longer enumerates the built-in device backends (`TEST_CUDA`, `TEST_HPU`, `TEST_XPU`) and instead delegates to `torch.accelerator.is_available()`. This makes the flag correctly report the presence of any registered accelerator — including out-of-tree (OOT) backends.

## Changes

- `torch/testing/_internal/common_distributed.py`: Replace `HAS_ACCELERATOR = TEST_CUDA or TEST_HPU or TEST_XPU` with `HAS_ACCELERATOR = torch.accelerator.is_available()`, which delegates to the current accelerator — including out-of-tree backends.

## Motivation

Out-of-tree (OOT) backends — `PrivateUse1`-based devices — are not covered by `TEST_CUDA`, `TEST_HPU`, or `TEST_XPU`. As a result, the existing `HAS_ACCELERATOR` definition evaluated to `False` on an OOT backend even though `torch.accelerator.is_available()` reported an accelerator present.

Routing `HAS_ACCELERATOR` through `torch.accelerator.is_available()` makes the flag backend-agnostic: any accelerator that correctly registers with `torch.accelerator` (built-in or OOT) is recognized, which is part of the broader objective of making distributed tests device-agnostic.

## Test Plan

- Run a representative distributed checkpoint test that is gated behind `requires_accelerator_dist_backend()` / `HAS_ACCELERATOR` to confirm it is no longer skipped on an OOT accelerator:
  ```bash
  python test/distributed/checkpoint/test_state_dict.py
  python test/distributed/checkpoint/test_state_dict_stager.py
  ```
- Verify no regression on stock CUDA: `HAS_ACCELERATOR` remains `True` and the same tests run as before.

## Notes

- This is part of the test case refactoring initiative tracked in https://github.com/pytorch/pytorch/issues/185590.

@wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian