### PR TITLE
[xpu][fix] Re-enable two XPU inductor disabled tests (#189861, #189963)

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -3381,6 +3381,7 @@ class AOTInductorTestsTemplate:
         torch._export.aot_compile(Model(), example_inputs)
 
     @skipCUDAIf(True, "Test for x86 backend")
+    @skipIfXpu(msg="Test for x86 backend")
     @unittest.skipUnless(IS_X86, "Test for x86 backend")
     @unittest.skipIf(sys.platform == "darwin", "Skip MacOS")
     @unittest.skipIf(IS_FBCODE, "Need newer ideep")

--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -2551,7 +2551,7 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
         eager = fwd(x, targets, W, bias)
         opt = torch.compile(fwd, dynamic=False, fullgraph=True)
         compiled = opt(x, targets, W, bias)
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
         # bf16 matmul + log_sum_exp leaves some slack; loose tol is fine here,
         # the test is about not crashing.
         self.assertTrue(torch.allclose(eager, compiled, atol=1e-2, rtol=1e-2))


### PR DESCRIPTION
Fixes two XPU tests disabled in CI:

## Test 1: `test_buffer_mutation_and_force_mmap_weights` (`AOTInductorTestDualWrapper`) — Fixes #189963

The test exercises an x86-only quantized linear (onednn CPU) path. `@skipCUDAIf(True)` skips CUDA, and `@unittest.skipUnless(IS_X86)` only guards the host architecture (which is x86 on GPU CI hosts), so the XPU-parametrized copy of this test executed on device and failed with:

```
RuntimeError: itensor_view_from_dense expects CPU tensor input
```

Adds `@skipIfXpu` alongside the existing `@skipCUDAIf(True)`, aligning intent and matching the pattern already used elsewhere in this file.

## Test 2: `test_chunked_unrolled_slice_gather_int32_overflow` (`CudaReproTests`) — Fixes #189861

The `CudaReproTests` class is already device-agnostic (`device_type` resolved from `torch.accelerator.current_accelerator()`), but this test hard-coded `torch.cuda.synchronize()`. On XPU, `torch.cuda` is not compiled and the call raises:

```
AssertionError: Torch not compiled with CUDA enabled
```

Switches to `torch.accelerator.synchronize()`, matching the two existing device-agnostic synchronize call sites in the same file.

## Test Plan

```bash
cd test/inductor
python test_aot_inductor.py AOTInductorTestDualWrapper.test_buffer_mutation_and_force_mmap_weights_xpu -v
# -> skipped 'skipIfXpu: Test for x86 backend'  OK
python test_cuda_repro.py CudaReproTests.test_chunked_unrolled_slice_gather_int32_overflow -v
# -> ok  OK
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @fengyuan14 @guangyey @gujinghui @etaf

This PR was authored with the assistance of an AI coding agent.