### PR TITLE
Support dataclass comparison in torch.testing assertEqual (#189873)

### DIFF
--- a/test/dynamo/test_reconstruct.py
+++ b/test/dynamo/test_reconstruct.py
@@ -3,7 +3,6 @@
 import collections
 import contextlib
 import dis
-import sys
 import unittest
 
 import torch
@@ -527,10 +526,6 @@ class ReconstructTest(torch._dynamo.test_case.TestCase):
         res = torch.compile(create_tma, backend="eager")(x)
         self.assertEqual(ref[1].desc, res[1].desc)
 
-    @unittest.skipIf(
-        sys.version_info >= (3, 13),
-        "Tensor in TensorDescriptor not comparable in Python 3.13+",
-    )
     @unittest.skipIf(not HAS_GPU, "requires GPU and Triton")
     @unittest.skipIf(
         not has_triton_tensor_descriptor_host_tma(),

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -1259,8 +1259,10 @@ class TestAssertCloseContainer(TestCase):
             t: torch.Tensor
             i: int
 
-        actual = Foo(torch.tensor(1), 0)
-        expected = Foo(torch.tensor(2), 0)
+        # Multi-element tensors force the field-recursion path (scalar tensors
+        # can make dataclass __eq__ return a bool and fall through to ObjectPair).
+        actual = Foo(torch.zeros(2), 0)
+        expected = Foo(torch.ones(2), 0)
 
         with self.assertRaisesRegex(AssertionError, re.escape("item ['t']")):
             torch.testing.assert_close(actual, expected)
@@ -1277,6 +1279,68 @@ class TestAssertCloseContainer(TestCase):
 
         t = torch.ones(3)
         self.assertEqual(Outer(Inner(t), 1), Outer(Inner(t), 1))
+
+    def test_dataclass_custom_eq_respected(self):
+        # eq=False dataclasses with custom __eq__ must not be forced through
+        # field-by-field comparison (which would ignore their semantics).
+        @dataclasses.dataclass(eq=False)
+        class ByShape:
+            t: torch.Tensor
+            tag: str
+
+            def __eq__(self, other: object) -> bool:
+                if not isinstance(other, ByShape):
+                    return NotImplemented
+                return self.t.shape == other.t.shape and self.tag == other.tag
+
+        # Values differ but shape/tag match: custom __eq__ says equal.
+        self.assertEqual(
+            ByShape(torch.zeros(2), "a"),
+            ByShape(torch.ones(2), "a"),
+        )
+        with self.assertRaises(AssertionError):
+            self.assertEqual(
+                ByShape(torch.zeros(2), "a"),
+                ByShape(torch.zeros(3), "a"),
+            )
+
+    def test_dataclass_union_like_getattr_raises(self):
+        # Mimics torch._export.serde.union._Union: unset fields raise on access,
+        # and equality is defined by an active variant only.
+        @dataclasses.dataclass(eq=False, repr=False)
+        class UnionLike:
+            as_int: int | None = None
+            as_tensor: torch.Tensor | None = None
+            _type: str = dataclasses.field(default="", repr=False, compare=False)
+
+            def __post_init__(self) -> None:
+                if self.as_int is not None:
+                    self._type = "as_int"
+                elif self.as_tensor is not None:
+                    self._type = "as_tensor"
+
+            def __getattribute__(self, name: str) -> object:
+                attr = super().__getattribute__(name)
+                field_names = {"as_int", "as_tensor"}
+                if attr is None and name in field_names and name != self._type:
+                    raise AttributeError(f"Field {name} is not set.")
+                return attr
+
+            def __eq__(self, other: object) -> bool:
+                if not isinstance(other, UnionLike):
+                    return False
+                return self._type == other._type and getattr(self, self._type) == getattr(
+                    other, other._type
+                )
+
+            def __repr__(self) -> str:
+                return f"UnionLike({self._type}={getattr(self, self._type)})"
+
+        actual = UnionLike(as_int=1)
+        expected = UnionLike(as_int=1)
+        self.assertEqual(actual, expected)
+        with self.assertRaises(AssertionError):
+            self.assertEqual(UnionLike(as_int=1), UnionLike(as_int=2))
 
 
 class TestAssertCloseSparseCOO(TestCase):

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: tests"]
 
 import collections
+import dataclasses
 import doctest
 import functools
 import importlib
@@ -1223,6 +1224,59 @@ class TestAssertCloseContainer(TestCase):
 
         with self.assertRaisesRegex(AssertionError, re.escape("item ['b']")):
             torch.testing.assert_close(actual, expected)
+
+    def test_dataclass_with_tensor_fields(self):
+        # Python 3.13+ removed the same-object shortcut in dataclass __eq__, so
+        # Foo(t, 1) == Foo(t, 1) raises when t is a multi-element tensor. assertEqual
+        # / assert_close should still succeed by comparing fields directly.
+        @dataclasses.dataclass
+        class Foo:
+            t: torch.Tensor
+            i: int
+
+        t = torch.zeros(2)
+        actual = Foo(t, 1)
+        expected = Foo(t, 1)
+
+        self.assertEqual(actual, expected)
+        for fn in assert_close_with_inputs(actual, expected):
+            fn()
+
+        # Distinct equal tensor values should also compare equal.
+        self.assertEqual(Foo(torch.zeros(2), 1), Foo(torch.zeros(2), 1))
+
+    def test_dataclass_compare_false_fields_ignored(self):
+        @dataclasses.dataclass
+        class Foo:
+            t: torch.Tensor
+            ignored: int = dataclasses.field(compare=False, default=0)
+
+        self.assertEqual(Foo(torch.zeros(2), 1), Foo(torch.zeros(2), 2))
+
+    def test_dataclass_mismatching_tensor_field_msg(self):
+        @dataclasses.dataclass
+        class Foo:
+            t: torch.Tensor
+            i: int
+
+        actual = Foo(torch.tensor(1), 0)
+        expected = Foo(torch.tensor(2), 0)
+
+        with self.assertRaisesRegex(AssertionError, re.escape("item ['t']")):
+            torch.testing.assert_close(actual, expected)
+
+    def test_nested_dataclass_with_tensor_fields(self):
+        @dataclasses.dataclass
+        class Inner:
+            t: torch.Tensor
+
+        @dataclasses.dataclass
+        class Outer:
+            inner: Inner
+            i: int
+
+        t = torch.ones(3)
+        self.assertEqual(Outer(Inner(t), 1), Outer(Inner(t), 1))
 
 
 class TestAssertCloseSparseCOO(TestCase):

--- a/torch/testing/_comparison.py
+++ b/torch/testing/_comparison.py
@@ -28,6 +28,7 @@ _IS_DATACLASS_SKIP_TYPES: tuple[type, ...] = (
     types.GenericAlias,
 )
 if HAS_NUMPY:
+    # pyrefly: ignore [missing-attribute]
     _IS_DATACLASS_SKIP_TYPES = (*_IS_DATACLASS_SKIP_TYPES, np.ndarray, np.generic)
 
 _HAS_DTENSOR = torch.distributed.is_available()

--- a/torch/testing/_comparison.py
+++ b/torch/testing/_comparison.py
@@ -20,6 +20,16 @@ except ModuleNotFoundError:
     HAS_NUMPY = False
     np = None  # type: ignore[assignment]
 
+# Types for which Dynamo can fault if we call dataclasses.is_dataclass on them.
+_IS_DATACLASS_SKIP_TYPES: tuple[type, ...] = (
+    type,
+    torch.Tensor,
+    types.UnionType,
+    types.GenericAlias,
+)
+if HAS_NUMPY:
+    _IS_DATACLASS_SKIP_TYPES = (*_IS_DATACLASS_SKIP_TYPES, np.ndarray, np.generic)
+
 _HAS_DTENSOR = torch.distributed.is_available()
 
 
@@ -1257,14 +1267,10 @@ def originate_pairs(
     # field is the sole compare=True field. Only then recurse field-by-field so
     # tensors use the normal tensor comparison path.
     #
-    # Skip is_dataclass for types Dynamo mishandles (Tensor, UnionType, etc.).
+    # Skip is_dataclass for types Dynamo mishandles (Tensor, ndarray, UnionType, ...).
     elif (
-        not isinstance(
-            actual, (type, torch.Tensor, types.UnionType, types.GenericAlias)
-        )
-        and not isinstance(
-            expected, (type, torch.Tensor, types.UnionType, types.GenericAlias)
-        )
+        not isinstance(actual, _IS_DATACLASS_SKIP_TYPES)
+        and not isinstance(expected, _IS_DATACLASS_SKIP_TYPES)
         and dataclasses.is_dataclass(actual)
         and dataclasses.is_dataclass(expected)
         and type(actual) is type(expected)

--- a/torch/testing/_comparison.py
+++ b/torch/testing/_comparison.py
@@ -3,6 +3,7 @@ import abc
 import cmath
 import collections.abc
 import contextlib
+import dataclasses
 from collections.abc import Callable, Collection, Sequence
 from typing import Any, NoReturn
 from typing_extensions import deprecated
@@ -1155,8 +1156,9 @@ def originate_pairs(
 ) -> list[Pair]:
     """Originates pairs from the individual inputs.
 
-    ``actual`` and ``expected`` can be possibly nested :class:`~collections.abc.Sequence`'s or
-    :class:`~collections.abc.Mapping`'s. In this case the pairs are originated by recursing through them.
+    ``actual`` and ``expected`` can be possibly nested :class:`~collections.abc.Sequence`'s,
+    :class:`~collections.abc.Mapping`'s, or dataclass instances. In this case the pairs are
+    originated by recursing through them.
 
     Args:
         actual (Any): Actual input.
@@ -1242,6 +1244,34 @@ def originate_pairs(
                     sequence_types=sequence_types,
                     mapping_types=mapping_types,
                     id=(*id, key),
+                    **options,
+                )
+            )
+        return pairs
+
+    # Dataclass instances fall through to ObjectPair otherwise, which compares with
+    # ``actual == expected``. Dataclass ``__eq__`` treats each field comparison as a
+    # Python bool, so tensor fields raise on Python 3.13+ (no same-object shortcut).
+    # Recurse field-by-field so tensors use the normal tensor comparison path.
+    elif (
+        dataclasses.is_dataclass(actual)
+        and not isinstance(actual, type)
+        and dataclasses.is_dataclass(expected)
+        and not isinstance(expected, type)
+        and type(actual) is type(expected)
+    ):
+        pairs = []
+        for field in dataclasses.fields(actual):
+            if not field.compare:
+                continue
+            pairs.extend(
+                originate_pairs(
+                    getattr(actual, field.name),
+                    getattr(expected, field.name),
+                    pair_types=pair_types,
+                    sequence_types=sequence_types,
+                    mapping_types=mapping_types,
+                    id=(*id, field.name),
                     **options,
                 )
             )

--- a/torch/testing/_comparison.py
+++ b/torch/testing/_comparison.py
@@ -1255,8 +1255,11 @@ def originate_pairs(
     # raise on Python 3.13+ (no same-object shortcut), or return a Tensor when that
     # field is the sole compare=True field. Only then recurse field-by-field so
     # tensors use the normal tensor comparison path.
+    # Skip Tensors: is_dataclass(tensor) can crash under dynamo_wrapped (sparse PGO).
     elif (
-        dataclasses.is_dataclass(actual)
+        not isinstance(actual, torch.Tensor)
+        and not isinstance(expected, torch.Tensor)
+        and dataclasses.is_dataclass(actual)
         and not isinstance(actual, type)
         and dataclasses.is_dataclass(expected)
         and not isinstance(expected, type)

--- a/torch/testing/_comparison.py
+++ b/torch/testing/_comparison.py
@@ -1249,10 +1249,12 @@ def originate_pairs(
             )
         return pairs
 
-    # Dataclass instances fall through to ObjectPair otherwise, which compares with
-    # ``actual == expected``. Dataclass ``__eq__`` treats each field comparison as a
-    # Python bool, so tensor fields raise on Python 3.13+ (no same-object shortcut).
-    # Recurse field-by-field so tensors use the normal tensor comparison path.
+    # Dataclass instances normally compare via ``==`` / ObjectPair so custom ``__eq__``
+    # (including ``eq=False`` classes) is respected. Generated dataclass ``__eq__``
+    # treats each field comparison as a Python bool, so multi-element tensor fields
+    # raise on Python 3.13+ (no same-object shortcut), or return a Tensor when that
+    # field is the sole compare=True field. Only then recurse field-by-field so
+    # tensors use the normal tensor comparison path.
     elif (
         dataclasses.is_dataclass(actual)
         and not isinstance(actual, type)
@@ -1260,6 +1262,17 @@ def originate_pairs(
         and not isinstance(expected, type)
         and type(actual) is type(expected)
     ):
+        try:
+            equal = actual == expected
+        except RuntimeError as error:
+            if "Boolean value of Tensor" not in str(error):
+                raise
+        else:
+            # Single tensor-field dataclasses can return a Tensor from __eq__
+            # without raising; only a real bool means == is usable as-is.
+            if type(equal) is bool:
+                return [ObjectPair(actual, expected, id=id, **options)]
+
         pairs = []
         for field in dataclasses.fields(actual):
             if not field.compare:

--- a/torch/testing/_comparison.py
+++ b/torch/testing/_comparison.py
@@ -1143,6 +1143,30 @@ class TensorLikePair(Pair):
         )
 
 
+def _is_dataclass_instance_impl(obj: object) -> bool:
+    return dataclasses.is_dataclass(obj) and not isinstance(obj, type)
+
+
+_is_dataclass_instance_check: Callable[[object], bool] | None = None
+
+
+def _is_dataclass_instance(obj: object) -> bool:
+    """True for dataclass instances only.
+
+    Dynamo-safe: tracing ``dataclasses.is_dataclass`` can fault on exotic values
+    (sparse Tensors, typing.Union, ...), so run the check with Dynamo disabled.
+    """
+    global _is_dataclass_instance_check
+    if _is_dataclass_instance_check is None:
+        # Lazy wrap: torch.testing loads before torch._dynamo during startup.
+        import torch._dynamo
+
+        _is_dataclass_instance_check = torch._dynamo.disable(
+            _is_dataclass_instance_impl
+        )
+    return _is_dataclass_instance_check(obj)
+
+
 def originate_pairs(
     actual: Any,
     expected: Any,
@@ -1255,14 +1279,9 @@ def originate_pairs(
     # raise on Python 3.13+ (no same-object shortcut), or return a Tensor when that
     # field is the sole compare=True field. Only then recurse field-by-field so
     # tensors use the normal tensor comparison path.
-    # Skip Tensors: is_dataclass(tensor) can crash under dynamo_wrapped (sparse PGO).
     elif (
-        not isinstance(actual, torch.Tensor)
-        and not isinstance(expected, torch.Tensor)
-        and dataclasses.is_dataclass(actual)
-        and not isinstance(actual, type)
-        and dataclasses.is_dataclass(expected)
-        and not isinstance(expected, type)
+        _is_dataclass_instance(actual)
+        and _is_dataclass_instance(expected)
         and type(actual) is type(expected)
     ):
         try:

--- a/torch/testing/_comparison.py
+++ b/torch/testing/_comparison.py
@@ -4,6 +4,7 @@ import cmath
 import collections.abc
 import contextlib
 import dataclasses
+import types
 from collections.abc import Callable, Collection, Sequence
 from typing import Any, NoReturn
 from typing_extensions import deprecated
@@ -1143,30 +1144,6 @@ class TensorLikePair(Pair):
         )
 
 
-def _is_dataclass_instance_impl(obj: object) -> bool:
-    return dataclasses.is_dataclass(obj) and not isinstance(obj, type)
-
-
-_is_dataclass_instance_check: Callable[[object], bool] | None = None
-
-
-def _is_dataclass_instance(obj: object) -> bool:
-    """True for dataclass instances only.
-
-    Dynamo-safe: tracing ``dataclasses.is_dataclass`` can fault on exotic values
-    (sparse Tensors, typing.Union, ...), so run the check with Dynamo disabled.
-    """
-    global _is_dataclass_instance_check
-    if _is_dataclass_instance_check is None:
-        # Lazy wrap: torch.testing loads before torch._dynamo during startup.
-        import torch._dynamo
-
-        _is_dataclass_instance_check = torch._dynamo.disable(
-            _is_dataclass_instance_impl
-        )
-    return _is_dataclass_instance_check(obj)
-
-
 def originate_pairs(
     actual: Any,
     expected: Any,
@@ -1279,9 +1256,17 @@ def originate_pairs(
     # raise on Python 3.13+ (no same-object shortcut), or return a Tensor when that
     # field is the sole compare=True field. Only then recurse field-by-field so
     # tensors use the normal tensor comparison path.
+    #
+    # Skip is_dataclass for types Dynamo mishandles (Tensor, UnionType, etc.).
     elif (
-        _is_dataclass_instance(actual)
-        and _is_dataclass_instance(expected)
+        not isinstance(
+            actual, (type, torch.Tensor, types.UnionType, types.GenericAlias)
+        )
+        and not isinstance(
+            expected, (type, torch.Tensor, types.UnionType, types.GenericAlias)
+        )
+        and dataclasses.is_dataclass(actual)
+        and dataclasses.is_dataclass(expected)
         and type(actual) is type(expected)
     ):
         try:
@@ -1296,6 +1281,7 @@ def originate_pairs(
                 return [ObjectPair(actual, expected, id=id, **options)]
 
         pairs = []
+        # pyrefly: ignore [bad-argument-type]  # narrowed by is_dataclass above
         for field in dataclasses.fields(actual):
             if not field.compare:
                 continue


### PR DESCRIPTION
## Issue

Fixes #189873

## Summary

On Python 3.13+, dataclass `__eq__` no longer short-circuits same-object field comparisons. For dataclasses that hold multi-element tensors (e.g. Triton's `TensorDescriptor`), `actual == expected` raises:
`RuntimeError: Boolean value of Tensor with more than one value is ambiguous`


This made `self.assertEqual` / `torch.testing.assert_close` fail for those objects, and forced #189712 to skip `test_tma_stable_reconstruct` on 3.13+.

Teach `originate_pairs` to recurse into dataclass fields (honoring `compare=False`), so tensor fields use the normal tensor comparison path instead of falling through to `ObjectPair` / raw `==`. Also remove the Python 3.13 skip on `test_tma_stable_reconstruct`.

## Checklist

- [x] Passes lint (`lintrunner`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98