### PR TITLE
[BE] [MPS] Pass kernel name to exec_unary_kernel_raw as `string_view`

### DIFF
--- a/aten/src/ATen/native/mps/MetalShaderLibrary.h
+++ b/aten/src/ATen/native/mps/MetalShaderLibrary.h
@@ -166,7 +166,7 @@ class MetalShaderLibrary {
   // (copy_identity, copy_conj, copy_neg, copy_conj_neg). offsets are in bytes;
   // numel is the element count to process.
   void exec_unary_kernel_raw(
-      const std::string& name,
+      std::string_view name,
       MTLBuffer_t src_buf,
       uint32_t src_offs_bytes,
       c10::ScalarType src_dtype,

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -1213,7 +1213,7 @@ void MetalShaderLibrary::exec_unary_kernel(TensorIteratorBase& iter,
   }
 }
 
-void MetalShaderLibrary::exec_unary_kernel_raw(const std::string& name,
+void MetalShaderLibrary::exec_unary_kernel_raw(std::string_view name,
                                                MTLBuffer_t src_buf,
                                                uint32_t src_offs_bytes,
                                                c10::ScalarType src_dtype,
@@ -1233,7 +1233,7 @@ void MetalShaderLibrary::exec_unary_kernel_raw(const std::string& name,
     MPSStream* mpsStream = getCurrentMPSStream();
     dispatch_sync(mpsStream->queue(), ^() {
       auto computeEncoder = mpsStream->commandEncoder();
-      getMPSProfiler().beginProfileKernel(cplState, name, /*isGraph=*/false);
+      getMPSProfiler().beginProfileKernel(cplState, kernel_name, /*isGraph=*/false);
       [computeEncoder setComputePipelineState:cplState];
       [computeEncoder setBuffer:dst_buf offset:dst_offs_bytes atIndex:0];
       [computeEncoder setBuffer:src_buf offset:src_offs_bytes atIndex:1];

--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -176,7 +176,7 @@ static at::Tensor& copy_from_mps_(at::Tensor& dst_, const at::Tensor& src_, bool
           : needs_neg                              ? "copy_neg"
           : needs_conj                             ? "copy_conj"
                                                    : "copy_identity";
-      lib.exec_unary_kernel_raw(std::string(name),
+      lib.exec_unary_kernel_raw(name,
                                 sourceBuffer,
                                 static_cast<uint32_t>(storage_byte_offset),
                                 src.scalar_type(),


### PR DESCRIPTION
Matching exec_binary_kernel / exec_ternary_kernel pattern 
Addresses a review comment on #189572.
