### PR TITLE
[dynamo] add polyfill for _io.text_encoding to prevent graph break

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -6512,10 +6512,14 @@ def forward(self, L_x_ : torch.Tensor, s77 : torch.SymInt, s27 : torch.SymInt):
 
         @torch.compile(backend="eager", fullgraph=True)
         def fn(x):
-            _io.text_encoding("utf-8")
-            return torch.sin(x)
+            enc_explicit = _io.text_encoding("utf-8")
+            enc_default = _io.text_encoding(None)
+            return torch.sin(x), enc_explicit, enc_default
 
-        fn(torch.randn(4))
+        x = torch.randn(4)
+        _, enc_explicit, enc_default = fn(x)
+        self.assertEqual(enc_explicit, _io.text_encoding("utf-8"))
+        self.assertEqual(enc_default, _io.text_encoding(None))
 
     # https://github.com/pytorch/pytorch/issues/88813
     def test_return_value_duplication_tensor(self) -> None:

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -6506,6 +6506,17 @@ def forward(self, L_x_ : torch.Tensor, s77 : torch.SymInt, s27 : torch.SymInt):
 
         fn(torch.randn(4))
 
+    # https://github.com/pytorch/pytorch/issues/189925
+    def test_io_text_encoding(self):
+        import _io
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(x):
+            _io.text_encoding("utf-8")
+            return torch.sin(x)
+
+        fn(torch.randn(4))
+
     # https://github.com/pytorch/pytorch/issues/88813
     def test_return_value_duplication_tensor(self) -> None:
         def fn(val: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:

--- a/torch/_dynamo/polyfills/__init__.py
+++ b/torch/_dynamo/polyfills/__init__.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
         _collections as _collections,
         builtins as builtins,
         functools as functools,
+        io as io,
         itertools as itertools,
         operator as operator,
         os as os,

--- a/torch/_dynamo/polyfills/io.py
+++ b/torch/_dynamo/polyfills/io.py
@@ -5,6 +5,7 @@ Python polyfills for _io
 from __future__ import annotations
 
 import _io
+
 import sys
 import warnings
 
@@ -15,6 +16,7 @@ __all__ = ["text_encoding"]
 
 
 # Copied from Lib/_pyio.py in the standard library
+# pyrefly: ignore [bad-argument-type]
 @substitute_in_graph(_io.text_encoding, can_constant_fold_through=True)
 def text_encoding(encoding: str | None, stacklevel: int = 2, /) -> str:
     if encoding is None:
@@ -23,6 +25,6 @@ def text_encoding(encoding: str | None, stacklevel: int = 2, /) -> str:
             warnings.warn(
                 "'encoding' argument not specified.",
                 EncodingWarning,
-                stacklevel + 2,
+                stacklevel + 1,
             )
     return encoding

--- a/torch/_dynamo/polyfills/io.py
+++ b/torch/_dynamo/polyfills/io.py
@@ -1,0 +1,28 @@
+"""
+Python polyfills for _io
+"""
+
+from __future__ import annotations
+
+import _io
+import sys
+import warnings
+
+from ..decorators import substitute_in_graph
+
+
+__all__ = ["text_encoding"]
+
+
+# Copied from Lib/_pyio.py in the standard library
+@substitute_in_graph(_io.text_encoding, can_constant_fold_through=True)
+def text_encoding(encoding: str | None, stacklevel: int = 2, /) -> str:
+    if encoding is None:
+        encoding = "utf-8" if sys.flags.utf8_mode else "locale"
+        if sys.flags.warn_default_encoding:
+            warnings.warn(
+                "'encoding' argument not specified.",
+                EncodingWarning,
+                stacklevel + 2,
+            )
+    return encoding

--- a/torch/_dynamo/polyfills/loader.py
+++ b/torch/_dynamo/polyfills/loader.py
@@ -19,6 +19,7 @@ POLYFILLED_MODULE_NAMES: tuple[str, ...] = (
     "builtins",
     "copy",
     "functools",
+    "io",
     "itertools",
     "operator",
     "os",


### PR DESCRIPTION
## Summary

`_io.text_encoding` is a C builtin with no traceable Python body, so `torch.compile(fullgraph=True)` raises an `Unsupported` graph break whenever compiled code calls it — which happens implicitly through `open()`, `pathlib.Path.read_text()`, `pathlib.Path.write_text()`, and `tempfile.NamedTemporaryFile` when `encoding=None`.

This PR adds a `substitute_in_graph` polyfill for `_io.text_encoding`, following the same pattern as the existing `os.fspath`, `sys.intern`, etc. polyfills. The pure-Python implementation mirrors CPython's `Lib/_pyio.py`.

Fixes #189925

## Changes

- `torch/_dynamo/polyfills/io.py` — new polyfill module with `text_encoding`
- `torch/_dynamo/polyfills/loader.py` — register `io` in `POLYFILLED_MODULE_NAMES`
- `torch/_dynamo/polyfills/__init__.py` — add `io` to the `TYPE_CHECKING` import block
- `test/dynamo/test_repros.py` — regression test asserting no graph break

## Test Plan

```
python test/dynamo/test_repros.py ReproTests.test_io_text_encoding
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98