### PR TITLE
[Testcase Refactoring] Migrate test_dependencies.py to use "meta" device

### DIFF
--- a/test/inductor/test_dependencies.py
+++ b/test/inductor/test_dependencies.py
@@ -15,16 +15,19 @@ from torch._inductor.ir import (
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import sympy_index_symbol
 from torch._inductor.virtualized import ops, V
-from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_CPU, HAS_GPU
+from torch.testing._internal.common_utils import HardwareClassification
+from torch.testing._internal.inductor_utils import HAS_CPU
 from torch.utils._sympy.functions import FloorDiv, ModularIndexing
 from torch.utils._sympy.value_ranges import ValueRanges
 
 
 class TestDependencies(InductorTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _create_buffer(self, name, shape, dtype=torch.float32):
         return Buffer(
             name=name,
-            layout=FixedLayout(torch.device(GPU_TYPE), dtype=dtype, size=shape),
+            layout=FixedLayout(torch.device("meta"), dtype=dtype, size=shape),
         )
 
     def setUp(self):
@@ -63,7 +66,7 @@ class TestDependencies(InductorTestCase):
             )
 
         pointwise = Pointwise.create(
-            device=torch.device(GPU_TYPE),
+            device=torch.device("meta"),
             dtype=torch.int32,
             inner_fn=inner_fn,
             ranges=[1024 * 4],
@@ -96,7 +99,7 @@ class TestDependencies(InductorTestCase):
             )
 
         pointwise = Pointwise.create(
-            device=torch.device(GPU_TYPE),
+            device=torch.device("meta"),
             dtype=torch.int32,
             inner_fn=inner_fn,
             ranges=[1024 * 4],
@@ -243,5 +246,5 @@ class TestDependencies(InductorTestCase):
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests
 
-    if HAS_CPU and HAS_GPU:
+    if HAS_CPU:
         run_tests("sympy")

--- a/test/inductor/test_dependencies.py
+++ b/test/inductor/test_dependencies.py
@@ -15,11 +15,14 @@ from torch._inductor.ir import (
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import sympy_index_symbol
 from torch._inductor.virtualized import ops, V
+from torch.testing._internal.common_utils import HardwareClassification
 from torch.testing._internal.inductor_utils import HAS_CPU
 from torch.utils._sympy.value_ranges import ValueRanges
 
 
 class TestDependencies(InductorTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _create_buffer(self, name, shape, dtype=torch.float32):
         return Buffer(
             name=name,

--- a/test/inductor/test_dependencies.py
+++ b/test/inductor/test_dependencies.py
@@ -15,7 +15,7 @@ from torch._inductor.ir import (
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import sympy_index_symbol
 from torch._inductor.virtualized import ops, V
-from torch.testing._internal.inductor_utils import  HAS_CPU
+from torch.testing._internal.inductor_utils import HAS_CPU
 from torch.utils._sympy.value_ranges import ValueRanges
 
 

--- a/test/inductor/test_dependencies.py
+++ b/test/inductor/test_dependencies.py
@@ -15,7 +15,7 @@ from torch._inductor.ir import (
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import sympy_index_symbol
 from torch._inductor.virtualized import ops, V
-from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_CPU, HAS_GPU
+from torch.testing._internal.inductor_utils import  HAS_CPU
 from torch.utils._sympy.value_ranges import ValueRanges
 
 
@@ -23,7 +23,7 @@ class TestDependencies(InductorTestCase):
     def _create_buffer(self, name, shape, dtype=torch.float32):
         return Buffer(
             name=name,
-            layout=FixedLayout(torch.device(GPU_TYPE), dtype=dtype, size=shape),
+            layout=FixedLayout(torch.device("meta"), dtype=dtype, size=shape),
         )
 
     def setUp(self):
@@ -62,7 +62,7 @@ class TestDependencies(InductorTestCase):
             )
 
         pointwise = Pointwise.create(
-            device=torch.device(GPU_TYPE),
+            device=torch.device("meta"),
             dtype=torch.int32,
             inner_fn=inner_fn,
             ranges=[1024 * 4],
@@ -95,7 +95,7 @@ class TestDependencies(InductorTestCase):
             )
 
         pointwise = Pointwise.create(
-            device=torch.device(GPU_TYPE),
+            device=torch.device("meta"),
             dtype=torch.int32,
             inner_fn=inner_fn,
             ranges=[1024 * 4],
@@ -206,5 +206,5 @@ class TestDependencies(InductorTestCase):
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests
 
-    if HAS_CPU and HAS_GPU:
+    if HAS_CPU:
         run_tests("sympy")


### PR DESCRIPTION
[Testcase Refactoring] Migrate test_dependencies.py to "meta" device and add hw_classification

### Summary

Migrated test/inductor/test_dependencies.py from GPU_TYPE to "meta" device for symbolic dependency tracking tests, and added HardwareClassification.GENERIC label to TestDependencies class. No class splitting needed as all 7 test methods are device-agnostic.

### Changes

- Replaced GPU_TYPE with "meta" device in _create_buffer, Pointwise.create calls
- Removed GPU_TYPE and HAS_GPU imports from torch.testing._internal.inductor_utils
- Changed run condition from "HAS_CPU and HAS_GPU" to "HAS_CPU" only
- Added import: from torch.testing._internal.common_utils import HardwareClassification
- Added class attribute: hw_classification = HardwareClassification.GENERIC to TestDependencies

### Motivation

The original code hardcoded GPU_TYPE, which excluded accelerator backends from running these tests. Since all test methods operate on IR objects with "meta" device and perform no real device computation (sympy-based dependency tracking, MemoryDep offset/normalization, CppCSEVariable itervar tracking), they are inherently device-agnostic. Migrating to "meta" device and adding the GENERIC classification aligns the file with the multi-backend test classification framework, allowing these tests to run on any hardware.

### Test Plan

## Test Plan
- CI: `python test/inductor/test_dependencies.py`

@wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo