### PR TITLE
Docs: Clarify deterministic ordering of module.parameters() to Fixes #188389

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -2667,6 +2667,10 @@ class Module:
     def parameters(self, recurse: bool = True) -> Iterator[Parameter]:
         r"""Return an iterator over module parameters.
 
+        The exact order of the returned parameters is unspecified, but repeated
+        calls to the ``parameters()`` method of an unchanged module return the
+        parameters in the same order.
+
         This is typically passed to an optimizer.
 
         Args:


### PR DESCRIPTION
This PR updates the docstring for `torch.nn.Module.parameters()` to
  explicitly state that the exact order of returned parameters is
  deterministic (i.e. repeated calls on an unchanged module return the
  parameters in the same order). 

    This clarification was requested by users building custom AI optimizers
  who rely on parameter batching.
