### PR TITLE
[distributed][checkpoint] Bind per-rank devices for all accelerator 

### DIFF
--- a/test/distributed/checkpoint/test_pg_transport.py
+++ b/test/distributed/checkpoint/test_pg_transport.py
@@ -164,8 +164,7 @@ def _test_pg_transport_with_mixed_content(self, device) -> None:
 
 
 def _test_pg_transport_with_sharded_tensor(self, device) -> None:
-    # Set current accelerator device for NCCL/XCCL
-    if device.type == "cuda" or device.type == "xpu":
+    if device.type != "cpu":
         torch.accelerator.set_device_index(device)
 
     state_dict = _create_sharded_tensor_state_dict(self.rank, self.world_size, device)


### PR DESCRIPTION
Bind per-rank devices for all accelerator backends in PGTransport tests

`_test_pg_transport_with_sharded_tensor` only called `torch.accelerator.set_device_index` for CUDA and XPU, leaving any other registered accelerator backend (e.g. NPU/HCCL) without a per-rank current device. Both ranks then defaulted to physical device 0, causing HCCL communicator initialization to fail:

  Communication_Error_Ranktable_Detect(EI0015):
  Rank0 ... has the same physical device ID0 as rank1.

Replace the `cuda or xpu` enumeration with `device.type != "cpu"`, which covers all accelerator backends without naming them and matches the accelerator-generic API style used elsewhere in the file.

Fixes #189989.