### PR TITLE
[Test] Add NPU device support in test_backends.py

### DIFF
--- a/test/distributed/test_backends.py
+++ b/test/distributed/test_backends.py
@@ -6,6 +6,8 @@ import torch.distributed as dist
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import run_tests, TestCase
 
+import torch_npu
+
 
 """
 common backend API tests
@@ -37,6 +39,11 @@ class TestMiscCollectiveUtils(TestCase):
                 raise AssertionError(
                     f"Expected xccl, got {dist.get_default_backend_for_device(device)}"
                 )
+        elif "npu" in device:
+            if dist.get_default_backend_for_device(device) != "hccl":
+                raise AssertionError(
+                    f"Expected hccl, got {dist.get_default_backend_for_device(device)}"
+                )
         else:
             with self.assertRaises(ValueError):
                 dist.get_default_backend_for_device(device)
@@ -54,12 +61,16 @@ class TestMiscCollectiveUtils(TestCase):
         )
         pg = dist.distributed_c10d._get_default_group()
         backend_pg = pg._get_backend_name()
-        if backend_pg != backend:
-            raise AssertionError(f"Expected {backend}, got {backend_pg}")
+        if "npu" in device:
+            if backend_pg != "custom":
+                raise AssertionError(f"Expected custom for NPU, got {backend_pg}")
+        else:
+            if backend_pg != backend:
+                raise AssertionError(f"Expected {backend}, got {backend_pg}")
         dist.destroy_process_group()
 
 
-devices = ["cpu", "cuda", "mps", "xpu"]
+devices = ["cpu", "cuda", "mps", "xpu", "npu"]
 instantiate_device_type_tests(
     TestMiscCollectiveUtils, globals(), only_for=devices, allow_mps=True, allow_xpu=True
 )


### PR DESCRIPTION
## Summary
This PR adds NPU device support to test/distributed/test_backends.py by registering NPU in the device-type test matrix and handling its backend assertions correctly.
NPU is a PrivateUse1-based out-of-tree accelerator. Its distributed tests should run alongside CUDA/HPU/XPU in TestMiscCollectiveUtils.
## Changes
* Added import torch_npu to register the NPU backend.
* Added "npu" to the devices list in instantiate_device_type_tests, so TestMiscCollectiveUtils is parametrized over NPU.
* Added an "npu" branch in test_device_to_backend_mapping asserting that get_default_backend_for_device("npu") returns "hccl" (NPU uses the HCCL collective communication library).
* Added NPU-specific handling in test_create_pg: NPU process groups report "custom" as the backend name (via the PrivateUse1 pathway) instead of "hccl", so the assertion is branched accordingly.
## Motivation
TestMiscCollectiveUtils already covers cpu, cuda, and hpu, but NPU was omitted. Without this change, NPU backend tests are skipped, missing coverage for device-to-backend mapping and process group creation on NPU.
## Test Plan

python test/distributed/test_backends.py -v
