### PR TITLE
Fixes #189392

### DIFF
--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -6873,7 +6873,7 @@ Example::
 
     >>> csr = torch.eye(5,5).to_sparse_csr()
     >>> csr.crow_indices()
-    tensor([0, 1, 2, 3, 4, 5], dtype=torch.int32)
+    tensor([0, 1, 2, 3, 4, 5])
 
 """,
 )
@@ -6894,7 +6894,7 @@ Example::
 
     >>> csr = torch.eye(5,5).to_sparse_csr()
     >>> csr.col_indices()
-    tensor([0, 1, 2, 3, 4], dtype=torch.int32)
+    tensor([0, 1, 2, 3, 4])
 
 """,
 )


### PR DESCRIPTION
This PR updates the docstring examples for `torch.Tensor.crow_indices`
  and `torch.Tensor.col_indices`.

    The examples previously showed the output containing `dtype=torch.int32`.
  However, `to_sparse_csr()` produces `int64` indices by default, which was
  confusing users. The `dtype=torch.int32` annotation has been removed to
  accurately reflect the true output.

    ### Checklist
    - [x] I have read the `CONTRIBUTING.md` file.
