### PR TITLE
Fuse Half->Float upcast into softmax and reductions on XPU

### DIFF
--- a/aten/src/ATen/native/ReduceOpsUtils.h
+++ b/aten/src/ATen/native/ReduceOpsUtils.h
@@ -253,8 +253,9 @@ inline TensorIterator make_reduction(
   // efficiency.
   // We don't generalize this to common mismatched input/output types to avoid cross
   // product of templated kernel launches.
-  if (self.scalar_type() == dtype1 ||
-      (self.is_cuda() && self.scalar_type() == kHalf && dtype1 == kFloat)) {
+  const bool gpu_f16_to_f32 =
+      (self.is_cuda() || self.is_xpu()) && self.scalar_type() == kHalf && dtype1 == kFloat;
+  if (self.scalar_type() == dtype1 || gpu_f16_to_f32) {
     return TensorIterator::reduce_op(viewed_result1, viewed_result2, self);
   }
   return TensorIterator::reduce_op(viewed_result1, viewed_result2, self.to(dtype1));
@@ -432,8 +433,9 @@ inline TensorIterator make_reduction(
   // special case for type promotion in mixed precision, improves computational efficiency.
   // We don't generalize this to common mismatched input/output types to avoid cross product
   // of templated kernel launches.
-  if (self.scalar_type() == dtype1 ||
-      (self.is_cuda() && self.scalar_type() == kHalf && dtype1 == kFloat)) {
+  const bool gpu_f16_to_f32 =
+      (self.is_cuda() || self.is_xpu()) && self.scalar_type() == kHalf && dtype1 == kFloat;
+  if (self.scalar_type() == dtype1 || gpu_f16_to_f32) {
     return TensorIterator::reduce_op(viewed_result1, viewed_result2, self);
   }
   return TensorIterator::reduce_op(viewed_result1, viewed_result2, self.to(dtype1));
@@ -450,7 +452,7 @@ inline TensorIterator make_reduction(
   // not generalize this to common mismatched input/output types to avoid cross
   // product of templated kernel launches.
   const bool gpu_lowp_to_f32 =
-      (self.is_cuda() &&
+      ((self.is_cuda() || self.is_xpu()) &&
        (self.scalar_type() == kHalf || self.scalar_type() == kBFloat16) &&
        out_dtype == kFloat);
   auto in_dtype = gpu_lowp_to_f32 ? self.scalar_type() : out_dtype;

--- a/aten/src/ATen/native/SoftMax.cpp
+++ b/aten/src/ATen/native/SoftMax.cpp
@@ -409,7 +409,7 @@ TORCH_IMPL_FUNC(log_softmax_backward_cpu_out) (
 
 Tensor softmax(const Tensor& input_, const int64_t dim_, std::optional<ScalarType> dtype) {
   auto result = [&]() {
-    if (input_.is_cuda() && input_.scalar_type() == ScalarType::Half && dtype == ScalarType::Float){
+    if ((input_.is_cuda() || input_.is_xpu()) && input_.scalar_type() == ScalarType::Half && dtype == ScalarType::Float){
         return at::_softmax(input_, dim_, true);
     } else {
         Tensor converted = dtype.has_value() ? input_.toType(dtype.value()) : input_;
@@ -425,7 +425,7 @@ Tensor& softmax_out(
     std::optional<ScalarType> dtype,
     Tensor& output_) {
   Tensor output_temp;
-  if (input_.is_cuda() && input_.scalar_type() == ScalarType::Half &&
+  if ((input_.is_cuda() || input_.is_xpu()) && input_.scalar_type() == ScalarType::Half &&
       dtype == ScalarType::Float) {
     if (!output_.is_contiguous()) {
       auto options =
@@ -463,7 +463,7 @@ Tensor special_softmax(const Tensor& input_, const int64_t dim_, std::optional<S
 
 Tensor log_softmax(const Tensor& input_, const int64_t dim_, std::optional<ScalarType> dtype) {
   auto result = [&]() {
-    if (input_.is_cuda() && input_.scalar_type() == ScalarType::Half && dtype == ScalarType::Float){
+    if ((input_.is_cuda() || input_.is_xpu()) && input_.scalar_type() == ScalarType::Half && dtype == ScalarType::Float){
         return at::_log_softmax(input_, dim_, true);
     } else {
         Tensor converted = dtype.has_value()? input_.toType(dtype.value()) : input_;
@@ -479,7 +479,7 @@ Tensor& log_softmax_out(
     std::optional<ScalarType> dtype,
     Tensor& output_) {
   Tensor output_temp;
-  if (input_.is_cuda() && input_.scalar_type() == ScalarType::Half &&
+  if ((input_.is_cuda() || input_.is_xpu()) && input_.scalar_type() == ScalarType::Half &&
       dtype == ScalarType::Float) {
     if (!output_.is_contiguous()) {
       auto options =


### PR DESCRIPTION
On CUDA, `softmax(half, dtype=float)` and mixed-precision reductions skip the explicit `Half->Float` conversion and let the kernel upcast on the fly (`half_to_float=true` in `_softmax`/`_log_softmax`, and reducing directly on the Half input in `make_reduction`). XPU kernels support the same fused upcast, but these fast paths were gated on `is_cuda()`, so XPU paid for an extra conversion kernel and a full-size Float temporary.

Extend the gates to `is_cuda() || is_xpu()` in `softmax`/`log_softmax` (and their `_out` variants) and in the three `make_reduction` overloads.