### PR TITLE
Fix OOB read in batch_norm_gather_stats with inconsistent invstd

### DIFF
--- a/aten/src/ATen/native/cuda/Normalization.cu
+++ b/aten/src/ATen/native/cuda/Normalization.cu
@@ -704,6 +704,10 @@ std::tuple<Tensor, Tensor> batch_norm_gather_stats_cuda(const Tensor& self, cons
   const Tensor& running_mean = *running_mean_maybe_owned;
   const Tensor& running_var = running_var_opt.value_or(Tensor());
 
+  TORCH_CHECK(mean.dim() == 2,
+      "batch_norm_gather_stats: expected mean to be 2-dimensional (world_size, num_features), but got mean of sizes ",
+      mean.sizes());
+
   std::vector<int64_t> counts(mean.size(0), count);
   Tensor counts_ = at::from_blob((void*)counts.data(), {(int64_t)counts.size()}, self.options().dtype(at::kLong).device(at::kCPU));
   counts_ = counts_.to(self.device()).to(running_mean.defined() ? running_mean.dtype() : self.dtype());
@@ -718,6 +722,17 @@ std::tuple<Tensor, Tensor> batch_norm_gather_stats_with_counts_cuda(
   const Tensor& running_mean = *running_mean_maybe_owned;
   const Tensor& running_var = running_var_opt.value_or(Tensor());
 
+  // batch_norm_reduce_statistics_kernel derives both of its loop bounds from mean alone, then
+  // indexes invstd and counts with them, so any disagreement is an out-of-bounds read.
+  TORCH_CHECK(mean.dim() == 2,
+      "batch_norm_gather_stats_with_counts: expected mean to be 2-dimensional (world_size, num_features), but got mean of sizes ",
+      mean.sizes());
+  TORCH_CHECK(invstd.sizes() == mean.sizes(),
+      "batch_norm_gather_stats_with_counts: expected invstd to have the same shape as mean (",
+      mean.sizes(), "), but got invstd of sizes ", invstd.sizes());
+  TORCH_CHECK(counts.numel() >= mean.size(0),
+      "batch_norm_gather_stats_with_counts: expected counts to have at least one element per entry in mean's first dimension (",
+      mean.size(0), "), but got ", counts.numel(), " elements");
 
   auto scalar_type = running_mean.defined() ? running_mean.scalar_type() : self.scalar_type();
   return AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, scalar_type, "batch_norm_update_stats_cuda", [&] {

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7365,6 +7365,34 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         _batch_norm_stats(torch.randn(1, 96, 112, 112, dtype=torch.float, device='cuda'), torch.channels_last, (0, 2, 3))
         _batch_norm_stats(torch.randn(1, 96, 112, 112, 112, dtype=torch.float, device='cuda'), torch.channels_last_3d, (0, 2, 3, 4))
 
+    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
+    def test_batch_norm_gather_stats_invalid_shapes_cuda(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/189828.
+        # batch_norm_reduce_statistics_kernel takes both of its loop bounds from mean, then
+        # indexes invstd and counts with them, so an invstd that disagrees with mean used to
+        # be read out of bounds. The op must validate the shapes instead.
+        input = torch.full((1, 3, 3, 0), 1.0, dtype=torch.float32, device='cuda')
+        mean = torch.full((2, 3), 1.15215e+25, dtype=torch.float32, device='cuda')
+        invstd = torch.full((2, 0), 1.0, dtype=torch.float32, device='cuda')
+        with self.assertRaisesRegex(RuntimeError, "invstd to have the same shape as mean"):
+            torch.batch_norm_gather_stats(input, mean, invstd, None, None, float('-inf'), float('-inf'),
+                                          -9223372036854775808)
+
+        # mean must be (world_size, num_features); a 1-D mean would index past its dims
+        with self.assertRaisesRegex(RuntimeError, "expected mean to be 2-dimensional"):
+            torch.batch_norm_gather_stats(input, torch.ones(3, device='cuda'), torch.ones(3, device='cuda'),
+                                          None, None, 0.1, 1e-5, 2)
+
+        # counts is indexed up to mean.size(0), so it must have at least that many elements
+        with self.assertRaisesRegex(RuntimeError, "counts to have at least one element"):
+            torch.batch_norm_gather_stats_with_counts(
+                torch.randn(1, 3, 3, 3, device='cuda'),
+                torch.ones(2, 3, device='cuda'),
+                torch.ones(2, 3, device='cuda'),
+                None, None, 0.1, 1e-5,
+                torch.ones(1, device='cuda'),
+            )
+
     def test_flatten(self):
         tensor_input = torch.randn(2, 1, 2, 3)
 


### PR DESCRIPTION
Fixes #189828

`batch_norm_reduce_statistics_kernel` derives **both** of its loop bounds from `vec_mean` alone — `feature_size` from `vec_mean.size(1)`, `world_size` from `vec_mean.size(0)` — and then indexes `vec_invstd[j][i]` and `counts[j]` with them, without ever consulting those tensors' own extents. When `invstd` disagrees with `mean`, the kernel reads out of bounds.

## Root cause

The reported repro passes `mean` of shape `(2, 3)` with `invstd` of shape `(2, 0)`:

- A zero-numel `invstd` gets a **null data pointer** from the caching allocator.
- Its strides are still clamped to 1 (strides can't be 0 even when sizes are), so the accessor computes `nullptr + (j + i)`.
- The first thread dereferences address `0x0`.

The launch config is **not** involved: `features = 3` yields an ordinary `<<<1, 32>>>` launch, and the grid-stride loop maps threads to features correctly.

## The fix

Three metadata-only `TORCH_CHECK`s before the launch:

| Check | Why |
|---|---|
| `mean.dim() == 2` | The kernel treats `mean` as `(world_size, num_features)`; anything else indexes past its dims. |
| `invstd.sizes() == mean.sizes()` | `vec_invstd[j][i]` is indexed with bounds taken from `mean`. |
| `counts.numel() >= mean.size(0)` | `counts[j]` is read for `j < mean.size(0)`. |

Both public entry points reach the kernel through `batch_norm_gather_stats_with_counts_cuda`, so the shape validation goes there and covers both. `batch_norm_gather_stats_cuda` additionally reads `mean.size(0)` before delegating — to size the `counts` vector it synthesizes — so it gets its own dimension guard first.

`counts` is checked with `>=` rather than `==` deliberately: the kernel reads `counts[j]` only for `j < mean.size(0)`, so that is exactly the memory-safety boundary. The counts synthesized by `batch_norm_gather_stats_cuda` always satisfy it; a `counts` tensor passed directly to `batch_norm_gather_stats_with_counts` is unchecked today and is indexed on the same unvalidated assumption.

## Why `count = INT64_MIN` is left alone

The `count = INT64_MIN` in the repro is **not** what causes the invalid read — it only fills a `std::vector` and is then used arithmetically in the kernel, never as an index. Validating it would be a behavior change rather than a memory-safety fix, and a value check on the `counts` **tensor** would force a device-to-host sync.

## Compatibility

This cannot regress legitimate callers: the only in-tree caller is `SyncBatchNorm`, which builds `mean` and `invstd` from a single `torch.split` of one gathered tensor, so they are shape-consistent by construction.

## Test plan

**Reproducer from the issue under `compute-sanitizer`** — before the change:

```
compute-sanitizer --tool memcheck --error-exitcode 99 python poc_189828.py gather_stats
========= Invalid __global__ read of size 4 bytes
=========     at void at::native::batch_norm_reduce_statistics_kernel<float, float, int>(...)
=========     Address 0x0 is out of bounds
========= ERROR SUMMARY: 9 errors
```

After the change, the same reproducer raises cleanly and the sanitizer is quiet:

```
compute-sanitizer --tool memcheck --error-exitcode 99 python poc_189828.py gather_stats
RuntimeError: batch_norm_gather_stats_with_counts: expected invstd to have the same
shape as mean ([2, 3]), but got invstd of sizes [2, 0]
========= ERROR SUMMARY: 0 errors
```

**New regression test:**

```
python test/test_nn.py -k test_batch_norm_gather_stats_invalid_shapes_cuda
test_batch_norm_gather_stats_invalid_shapes_cuda ... ok
Ran 1 test in 0.061s
OK
```

**Valid usage is unaffected** — the happy path from `test_cuda.py`'s `test_batch_norm_gather_stats` (`mean (2, 3)`, `invstd (2, 3)`, `count=2`) returns `ones(3)`/`ones(3)` and reports 0 sanitizer errors.
