### PR TITLE
[linalg] Improve linalg.eigh error message for large CPU matrices

### DIFF
--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -851,6 +851,36 @@ TORCH_META_FUNC(_linalg_eigh)(const Tensor& A,
   at::native::squareCheckInputs(A, "linalg.eigh");
   at::native::checkUplo(uplo);
 
+  // Early check for 32-bit LAPACK workspace overflow (CPU only)
+  if (A.device().is_cpu() && compute_v) {
+    auto n = A.size(-1);
+    // syevd (real): lwork = 2*n*n + 6*n + 1
+    // heevd (complex): lwork = 2*n*n + 2*n + 1, lrwork = 2*n*n + 5*n + 1
+    // Both overflow int for n >= 32767
+    int64_t lwork_required = A.is_complex()
+        ? (2 * n * n + 2 * n + 1)
+        : (2 * n * n + 6 * n + 1);
+    TORCH_CHECK(
+        lwork_required <= std::numeric_limits<int>::max(),
+        "linalg.eigh: the required LAPACK workspace size (", lwork_required,
+        ") for a ", n, "x", n,
+        " matrix exceeds the 32-bit LAPACK interface limit (",
+        std::numeric_limits<int>::max(),
+        "). Consider using smaller matrices or a LAPACK build with 64-bit "
+        "integer support (ILP64).");
+    if (A.is_complex()) {
+      int64_t lrwork_required = 2 * n * n + 5 * n + 1;
+      TORCH_CHECK(
+          lrwork_required <= std::numeric_limits<int>::max(),
+          "linalg.eigh: the required LAPACK real workspace size (",
+          lrwork_required, ") for a ", n, "x", n,
+          " complex matrix exceeds the 32-bit LAPACK interface limit (",
+          std::numeric_limits<int>::max(),
+          "). Consider using smaller matrices or a LAPACK build with 64-bit "
+          "integer support (ILP64).");
+    }
+  }
+
   auto shape = A.sizes().vec();
   if (compute_v) {
     // eigenvectors

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1048,6 +1048,21 @@ class TestLinalg(TestCase):
                 torch.linalg.eigh(a, out=(out_w, out_v))
 
     @skipCPUIfNoLapack
+    @onlyCPU
+    @dtypes(torch.float, torch.double, torch.cfloat, torch.cdouble)
+    def test_eigh_large_matrix_error(self, device, dtype):
+        # n=33000 needs lwork = 2*33000^2 + 6*33000 + 1 > INT32_MAX for real,
+        # and similar large workspace size for complex.
+        # Use expand (zero-stride) to create a large logical shape without
+        # allocating O(n^2) memory.
+        small = torch.zeros(1, 1, device=device, dtype=dtype)
+        large = small.expand(33000, 33000)
+        with self.assertRaisesRegex(
+            RuntimeError, "exceeds the 32-bit LAPACK interface limit"
+        ):
+            torch.linalg.eigh(large)
+
+    @skipCPUIfNoLapack
     @dtypes(torch.float, torch.double)
     def test_eigh_svd_illcondition_matrix_input_should_not_crash(self, device, dtype):
         # See https://github.com/pytorch/pytorch/issues/94772, https://github.com/pytorch/pytorch/issues/105359


### PR DESCRIPTION
[linalg] Improve linalg.eigh error message for large CPU matrices

Fixes #92141

### Root Cause
When calling `linalg.eigh` on CPU with large matrices, the required workspace sizes (e.g. `lwork = 2*n^2 + 6*n + 1` for `syevd`) can exceed 32-bit integer limits (`INT32_MAX`). Since PyTorch is compiled against a 32-bit LAPACK interface, passing these values leads to silent integer overflows. As a result, LAPACK returns `info = -8`, which PyTorch raises as a confusing internal assertion error stating "Most certainly there is a bug in the implementation calling the backend library."

### Fix
Added an early CPU-only validation check inside `TORCH_META_FUNC(_linalg_eigh)` to confirm that the required LAPACK workspaces (`lwork` and `lrwork` for complex dtypes) do not exceed `std::numeric_limits<int>::max()`. If they do, a clear `RuntimeError` is raised explaining the 32-bit LAPACK limit.

This validation is placed inside the meta function so it catches the overflow before any memory allocations or backend dispatch calls occur.

### Test Plan
We added `test_eigh_large_matrix_error` under `test/test_linalg.py` that utilizes a zero-stride logical expansion (`small.expand(33000, 33000)`) to trigger the error on CPU for float, double, cfloat, and cdouble types without allocating massive amounts of physical memory.

Literal commands run:
```bash
# Run the specific new error-path tests
.venv/bin/python test/test_linalg.py -k "test_eigh_large_matrix_error"

# Verify all eigh tests pass successfully
.venv/bin/python test/test_linalg.py -k "test_eigh"
```
