### PR TITLE
[Testcase Refactoring] Enable PrivateUse1 tests in test_schedule

### DIFF
--- a/test/distributed/pipelining/test_schedule.py
+++ b/test/distributed/pipelining/test_schedule.py
@@ -1428,7 +1428,7 @@ class TestScheduleLowering(TestCase):
         # print(_format_pipeline_order(simulated_schedule))
         self.assertEqual(num_steps, 113)
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
     def test_grad_with_v_schedule(self):
         """
         We have a special case for V schedules where 2 adjacent stages are on the same rank.
@@ -1546,7 +1546,7 @@ class TestScheduleLowering(TestCase):
 
         torch.distributed.destroy_process_group()
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
     def test_grad_with_split_b_w(self):
         """
         Ensure that separate dInput and dWeight computations are correctly executed.

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -50,6 +50,8 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_ROCM,
     TEST_WITH_TSAN,
     TEST_XPU,
+    TEST_PRIVATEUSE1,
+    TEST_PRIVATEUSE1_DEVICE_TYPE,
     TestCase,
 )
 from torch.testing._internal.distributed.multi_threaded_pg import (
@@ -549,22 +551,28 @@ def requires_accelerator_dist_backend(backends=None):
     Decorator to skip tests if no accelerator communication backend (NCCL, XCCL, HCCL) is available.
 
     Args:
-        backends (Optional[List[str]]): Specific accelerator backends to check (e.g., ["nccl", "xccl", "hccl"]).
+        backends (Optional[List[str]]): Specific accelerator backends to check (e.g., ["nccl", "xccl", "hccl", "privateuse1"]).
                                        If None, checks all supported accelerator backends (NCCL, XCCL, HCCL).
 
     Returns:
         callable: A decorator that skips the test if no specified accelerator backend is available.
+
+    Note:
+        "privateuse1" is a placeholder resolved to the actual backend name for PrivateUse1 at call time via ``Backend.default_device_backend_map``.
     """
     if backends is None:
         backends = ACCELERATOR_DIST_BACKENDS
+    
+    _resolve = lambda backend: (
+        c10d.Backend.default_device_backend_map.get(TEST_PRIVATEUSE1_DEVICE_TYPE)
+        if backend == "privateuse1" and TEST_PRIVATEUSE1
+        else (None if backend == "privateuse1" else backend)
+    )
 
     backend_available = any(
-        {
-            "nccl": c10d.is_nccl_available,
-            "xccl": c10d.is_xccl_available,
-            "hccl": lambda: TEST_HPU,
-        }.get(backend, lambda: False)()
-        for backend in backends
+        c10d.is_backend_available(backend)
+        for backend in (_resolve(b) for b in backends)
+        if backend is not None
     )
 
     return skip_but_pass_in_sandcastle_if(


### PR DESCRIPTION
## Summary
The `test_grad_with_v_schedule` and `test_grad_with_split_b_w` tests
were skipped on out-of-tree PrivateUse1 accelerators because
`@requires_accelerator_dist_backend(["nccl", "xccl"])` omits PrivateUse1.

## Changes
Two commits:

1. Framework (cherry-picked from #190153): update
   `requires_accelerator_dist_backend` in `common_distributed.py` to
   resolve the PrivateUse1 entry in the backends list to the host's
   actual communication backend for the PrivateUse1 device type at call
   time via `Backend.default_device_backend_map`, then check availability
   with `c10d.is_backend_available`. On HPU, `TEST_PRIVATEUSE1` is False,
   so the PrivateUse1 entry is filtered out and behavior is unchanged.

2. Test file (`test_schedule.py`): change
   `@requires_accelerator_dist_backend(["nccl", "xccl"])` to
   `@requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])`
   on the two gated tests. 

## Motivation
Part of decoupling pipelining tests from hard-coded CUDA/NCCL dependencies
so they can execute on any PrivateUse1 accelerator with an out-of-tree
communication backend.

## Notes
- Depends on #190153 for the framework change; this PR cherry-picks that
  commit. Once #190153 merges, the cherry-pick can be dropped and only
  the test-file diff is rebased on top.
- This is part of the test case refactoring initiative tracked in #185590.

## Test Plan
```
python test/distributed/pipelining/test_schedule.py -v
```
Verified on a PrivateUse1 host (8 devices): all 56 tests pass,
including the 2 gated tests (previously skipped). On a CPU-only host
the 2 gated tests are skipped.
