### PR TITLE
[ROCm] Remove system python3-devel (3.6) from the manylinux image (root-cause fix for cp315 numpy build)

### DIFF
--- a/.ci/docker/manywheel/Dockerfile_2_28
+++ b/.ci/docker/manywheel/Dockerfile_2_28
@@ -171,6 +171,18 @@ RUN bash ./install_rocSHMEM.sh ${ROCM_VERSION} && rm install_rocSHMEM.sh
 ADD ./common/install_miopen.sh install_miopen.sh
 RUN bash ./install_miopen.sh ${ROCM_VERSION} && rm install_miopen.sh
 
+# The ROCm base image (rocm/dev-almalinux-8) ships the distro's system
+# python3-devel (Python 3.6). Its python3.pc sits on pkg-config's default search
+# path and its python3.6m headers on the default include path. cp315 has no
+# numpy wheel, so numpy is built from source, and meson's Cython check resolves
+# `pkg-config python3` to that 3.6 .pc and fails with "Cython requires Python
+# 3.8+". We never install this package ourselves and never build against the
+# system interpreter (all wheels target /opt/python/cp*), so remove it outright
+# rather than leaving it to hijack the from-source build. CUDA/XPU/CPU images
+# don't ship it. This removes the need for the in-tree pkg-config redirect /
+# numpy skips in .ci/manywheel and .ci/pytorch.
+RUN yum remove -y python3-devel
+
 FROM cpu_final as xpu_final
 # XPU CD use rolling driver
 ENV XPU_DRIVER_TYPE ROLLING


### PR DESCRIPTION
## Summary

Root-cause fix for the ROCm Python 3.15 manywheel numpy failure.

**Where the offending package comes from:** the ROCm manylinux builder is `FROM rocm/dev-almalinux-8:${ROCM}-complete` (AMD's ROCm dev image; see `.ci/docker/manywheel/build.sh`). That base ships the distro's system **`python3-devel` (Python 3.6)** — nothing in `.ci/docker/` installs it. Its `/usr/lib64/pkgconfig/python3.pc` is on pkg-config's default search path and its `python3.6m` headers on the default include path.

cp315 has **no numpy wheel** on any index, so numpy is built **from source**, and meson's Cython sanity check resolves `pkg-config python3` to that **3.6** `.pc`:

```
`pkg-config --cflags python3` -> -I/usr/include/python3.6m
Run-time dependency python3 found: YES 3.6
sanity_check_for_cython.c:23:6: error: #error Cython requires Python 3.8+.
```

CUDA / XPU / CPU manylinux images don't ship `python3-devel`, so their from-source numpy build resolves the correct interpreter and passes. Only ROCm is affected.

## Fix

We never install `python3-devel` ourselves and never build against the system interpreter (every wheel targets `/opt/python/cp*`). So instead of leaving the stray `.pc` to hijack the build, **remove the package outright** in the `rocm_final` stage:

```dockerfile
RUN yum remove -y python3-devel
```

This drops the `python3.pc` *and* the `python3.6m` headers, eliminating the whole class of "accidentally resolves to 3.6" problems. Triggers a rebuild of the ROCm manylinux builder image.

## Validation

A `.ci/docker/**` change is not exercised by a PR's binary builds (they pull the published image), but the **`build-manywheel-images` job on this PR does rebuild the ROCm image** — so that job validates `yum remove -y python3-devel` doesn't cascade into or break the remaining ROCm image build steps (magma / rocSHMEM / MIOpen). End-to-end proof that the *removal* fixes the numpy build is carried by the runtime-shim PR #190016 (applies the equivalent removal at runtime through a real ROCm build+test).

## Follow-up

Once this lands, drop the in-tree workarounds:
- `prefer_target_python_pkgconfig()` in `.ci/manywheel/build_install_deps.py`, and
- the cp315 numpy handling in `.ci/pytorch/binary_linux_test.sh`

(added in #189722; mirrored at runtime in #190016).

## Test plan

```
# after the image rebuilds, inside the ROCm builder:
rpm -q python3-devel                                   # -> not installed
pkg-config --exists python3 && echo present || echo absent   # -> absent
/opt/python/cp315-cp315t/bin/pip install numpy         # builds from source, resolves 3.15
```

cc @jeffdaily @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @pragupta @jerrymannil @malfet @atalman