### PR TITLE
[Tasks][TEST ISSUE] Skip test_disabling_ftz_yields_subnormals in fbcode for pt2_stack_for_internal

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -3158,6 +3158,10 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
         self.assertNotEqual(eager_div, compiled_div)
         self.assertTrue("div_rn" not in code)
 
+    @unittest.skipIf(
+        IS_FBCODE,
+        "fbcode Triton toolchain flushes subnormals to zero despite disable_ftz",
+    )
     @config.patch({"eager_numerics.disable_ftz": True})
     def test_disabling_ftz_yields_subnormals(self):
         from decimal import Decimal


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #190015

test_disabling_ftz_yields_subnormals (T253079891) fails only under pt2_stack_for_internal. The test sets eager_numerics.disable_ftz=True and expects inductor's generated Triton kernel to preserve denormals (via the enable_reflect_ftz=False NVIDIA-backend option), then asserts the output contains subnormal values. The internal Triton 3.5.0+fb toolchain does not honor that option and still flushes subnormals to zero, so the output has none and the assertion fails; the failure is deterministic and specific to the fbcode Triton build. This adds @unittest.skipIf(IS_FBCODE, ...) as the standard triage while the toolchain FTZ behavior is addressed separately. Applied byte-identically to the fbcode and xplat mirrors. Authored with AI assistance.

Differential Revision: [D111961412](https://our.internmc.facebook.com/intern/diff/D111961412/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo