### PR TITLE
[ROCm] Validate cp315 numpy python3-devel fix at runtime (build + test)

### DIFF
--- a/.ci/manywheel/build_install_deps.py
+++ b/.ci/manywheel/build_install_deps.py
@@ -18,10 +18,28 @@ from pathlib import Path
 # NumPy build-time pin selected by Python version.
 # Keep in sync with .ci/manywheel/build_common.sh.
 NUMPY_PINS: list[tuple[str, str]] = [
+    ("cp315", "2.5.1"),
     ("cp314", "2.3.4"),
     ("cp31", "2.1.0"),
 ]
 DEFAULT_NUMPY = "2.0.2"
+
+
+def remove_system_python3_devel() -> None:
+    """Runtime equivalent of the ROCm manylinux image fix (#190013).
+
+    cp315 has no numpy wheel, so numpy is built from source. The ROCm image's
+    base (rocm/dev-almalinux-8) ships the distro's system python3-devel (Python
+    3.6), whose python3.pc is on pkg-config's default search path and hijacks
+    numpy's meson Cython check ("Cython requires Python 3.8+"). We never install
+    it and never build against the system interpreter (wheels target
+    /opt/python/cp*), so remove the package -- exactly what #190013 does in the
+    image, applied here at runtime so it is validated through a normal binary
+    build. Once #190013 lands this can be dropped. No-op on non-ROCm images.
+    """
+    if "rocm" not in os.environ.get("DESIRED_CUDA", ""):
+        return
+    subprocess.run(["yum", "remove", "-y", "python3-devel"], check=False)
 
 
 def retry(cmd: list[str], delays: tuple[int, ...] = (1, 2, 4, 8)) -> None:
@@ -55,6 +73,7 @@ def main() -> None:
     args = parser.parse_args()
 
     os.chdir(args.package_dir)
+    remove_system_python3_devel()
     pip_install("-qU", "-r", "requirements-build.txt")
     # The CUPTI field-id codegen (tools/gen_cupti_stubs.py) parses cupti_activity.h with
     # libclang's python bindings. Install libclang only when a sufficiently-new CUPTI header

--- a/.ci/pytorch/binary_linux_test.sh
+++ b/.ci/pytorch/binary_linux_test.sh
@@ -51,6 +51,16 @@ if [[ "$PACKAGE_TYPE" != libtorch ]]; then
   if [[ "\$BUILD_ENVIRONMENT" != *s390x* ]]; then
     pip install "\$pkg" --index-url "https://download.pytorch.org/whl/\${CHANNEL}/${DESIRED_CUDA}"
 
+    # Runtime equivalent of the ROCm image fix (#190013): cp315 has no numpy
+    # wheel, so numpy is built from source, and the ROCm image's system 3.6
+    # python3-devel (python3.pc) hijacks meson's Cython check. Remove the package
+    # so the source build resolves the interpreter being tested. Validates the
+    # image fix through a normal binary build; drop once #190013 lands. No-op on
+    # non-ROCm.
+    if [[ "${DESIRED_CUDA}" == *rocm* ]]; then
+      yum remove -y python3-devel || true
+    fi
+
     # numpy tests:
     # We test 1 version no numpy. 1 version with numpy 1.x and rest with numpy 2.x
     if [[ "\$python_nodot" = *311* ]]; then


### PR DESCRIPTION
## Purpose

Validation PR for #190013. It applies that Docker image fix **at runtime** so it is exercised end-to-end through this PR's normal ROCm binary build+test. If ROCm cp315 goes green here, #190013 is proven and can be accepted; these runtime shims are then dropped.

## Why a runtime shim

#190013 runs `yum remove -y python3-devel` in `Dockerfile_2_28`'s `rocm_final` stage. But a `.ci/docker/**` change is **not exercised by a PR's binary builds**: those pull the already-published `pytorch/manylinux2_28-builder:rocm*` image, and `build-manywheel-images` only pushes on `push` to main (not on PRs). So a green binary build on #190013 proves nothing on its own. Applying the identical removal at runtime, just before numpy is installed, lets the real ROCm build+test validate the fix against the published image.

## Root cause

cp315 has no numpy wheel on any index, so numpy is built **from source**. The ROCm manylinux base (`rocm/dev-almalinux-8`) ships the distro's system `python3-devel` (Python 3.6), whose `/usr/lib64/pkgconfig/python3.pc` is on pkg-config's default search path; numpy's meson build resolves `pkg-config python3` to it and fails:

```
`pkg-config --cflags python3` -> -I/usr/include/python3.6m
Run-time dependency python3 found: YES 3.6
sanity_check_for_cython.c:23:6: error: #error Cython requires Python 3.8+.
```

CUDA / XPU / CPU images (`FROM amd64/almalinux:8`) never install `python3-devel`, so only ROCm cp315 is affected.

## Changes

- **`.ci/manywheel/build_install_deps.py`** (build phase): `remove_system_python3_devel()` runs `yum remove -y python3-devel` for ROCm before installing build reqs. Also fixes `numpy_pin()`: `"cp315".startswith("cp31")` wrongly bucketed 3.15 to `numpy==2.1.0` (unbuildable on 3.15); cp315 now pins `2.5.1`.
- **`.ci/pytorch/binary_linux_test.sh`** (test phase): same `yum remove -y python3-devel` for ROCm before the numpy smoke-test install. numpy still builds from source, so a green run proves the fix (it is not skipped).

Both are no-ops on non-ROCm images. No Docker rebuild (the published image is used as-is).

## Test plan

```
python3 -m py_compile .ci/manywheel/build_install_deps.py
bash -n .ci/pytorch/binary_linux_test.sh
```

via `ciflow/binaries`: ROCm `manywheel-py3_15-rocm*` / `py3_15t-rocm*` build **and** test complete, with numpy built from source resolving the cp315 interpreter.

Related: #190013 (image fix, `yum remove -y python3-devel`, to be accepted once this is green), #189722 (interim in-tree workaround).

cc @jeffdaily @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @pragupta @jerrymannil @malfet @atalman