### PR TITLE
[Tasks][TEST ISSUE] Skip AOTInductorTestDualWrapper constant-folding tests in fbcode for pt2_stack_for_internal

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -9385,6 +9385,15 @@ copy_tests(
 # Lazy-autotune-mode-specific failures go here. Inherits regular GPU failures.
 GPU_LAZY_AUTOTUNE_TEST_FAILURES = {
     **GPU_TEST_FAILURES,
+    "test_aot_inductor_consts_cpp_build": fail_gpu(("cuda", "xpu"), is_skip=True),
+    "test_constant_folding": fail_gpu(("cuda", "xpu"), is_skip=True),
+    "test_duplicate_constant_folding": fail_gpu(("cuda", "xpu"), is_skip=True),
+    "test_constant_type_propagation": fail_gpu(("cuda", "xpu"), is_skip=True),
+    "test_update_inactive_constant_buffer_with_interleaved_folded_constants": fail_gpu(
+        ("cuda", "xpu"), is_skip=True
+    ),
+    "test_autotune_with_constant_folding": fail_gpu(("cuda", "xpu"), is_skip=True),
+    "test_constant_folding_with_update": fail_gpu(("cuda", "xpu"), is_skip=True),
 }
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #190019

Seven `AOTInductorTestDualWrapper` constant-folding tests (T275764729, T275764731, T275764735, T275764733, T275764728, T275764730, T275764734) fail deterministically under pt2_stack_for_internal. They only fail in the lazy dual-wrapper AOTI path (`autotune_at_compile_time=False`, exercised by `AOTInductorTestDualWrapper`): the constant-folding subgraph JIT variant hard-crashes during compile in `_run_jit_variant_for_autotune`, while the one-pass `ABICompatibleGpu` variant passes. This registers the seven tests in the module `GPU_LAZY_AUTOTUNE_TEST_FAILURES` list with `is_skip=True` (they crash during compile rather than producing a numeric xfail), matching the existing `test_cond_symint_input_disable_one_pass` convention, to unblock the signal while the underlying const-graph lazy-autotune bug is fixed separately in `torch/_inductor`. Applied byte-identically to the fbcode and xplat mirrors. Authored with AI assistance.

Differential Revision: [D111961444](https://our.internmc.facebook.com/intern/diff/D111961444/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo