### PR TITLE
[Tasks][TEST ISSUE] Skip conv_transpose2d_forward_triton (128ch groups=1 NHWC) in fbcode for pt2_stack_for_internal

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6278,6 +6278,20 @@ for dtype in (torch.int32, torch.int64):
         if torch._inductor.compile_fx.fx_compile_mode == FxCompileMode.SUBPROCESS:
             self.skipTest("Expected failure under subprocess compile mode")
 
+        if (
+            IS_FBCODE
+            and nhwc
+            and in_channels == 128
+            and out_channels == 128
+            and groups == 1
+            and kernel == 3
+            and stride == 1
+        ):
+            self.skipTest(
+                "Triton max-autotune conv backend gives out-of-tolerance results for "
+                "128ch groups=1 NHWC transposed conv in fbcode (T275754523)"
+            )
+
         def fn(x, weight):
             return torch.ops.aten.convolution(
                 x,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #190020

The four tracked test_conv_transpose2d_forward_triton variants with in_channels=128, out_channels=128, groups=1, nhwc=True, kernel=3, stride=1 (dilation 1/2 x padding 0/1) fail deterministically (100% of continuous runs, all retries) under pt2_stack_for_internal (T275754523, T275754516, T275754514, T275754520). The Triton max-autotune conv backend (the convolution2d_bwd_input template used to implement transposed-conv forward) compiles and benchmarks successfully but produces out-of-tolerance results for this specific 128-channel groups=1 NHWC configuration in the internal Triton 3.5.0+fb / H100 environment; the failure does not reproduce in OSS and there is no upstream skip. Pending a real fix in the conv template, this adds a narrow in-body skip that targets exactly this config in fbcode and leaves the ~124 other parametrized variants running, so coverage is preserved. Applied byte-identically to the fbcode and xplat mirrors. Authored with AI assistance.

Differential Revision: [D111961391](https://our.internmc.facebook.com/intern/diff/D111961391/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo