### PR TITLE
[Tasks][TEST ISSUE] Skip gpu_cpp_wrapper debug_sync tests in fbcode for pt2_stack_for_internal

### DIFF
--- a/test/inductor/test_gpu_cpp_wrapper.py
+++ b/test/inductor/test_gpu_cpp_wrapper.py
@@ -176,6 +176,10 @@ class TestGpuWrapper(InductorTestCase):
         ):
             wrapper.generate_debug_sync(IndentedBuffer())
 
+    @unittest.skipIf(
+        IS_FBCODE,
+        "cpp_wrapper JIT .so links libcuda (driver) only, not libcudart; cudaDeviceSynchronize is an undefined symbol in fbcode",
+    )
     def test_debug_sync_graph(self):
         if not RUN_GPU:
             self.skipTest("GPU not available")
@@ -193,6 +197,10 @@ class TestGpuWrapper(InductorTestCase):
             result = compiled(x)
         self.assertEqual(result, x * 2)
 
+    @unittest.skipIf(
+        IS_FBCODE,
+        "cpp_wrapper JIT .so links libcuda (driver) only, not libcudart; cudaDeviceSynchronize is an undefined symbol in fbcode",
+    )
     def test_debug_sync_kernel(self):
         if not RUN_GPU:
             self.skipTest("GPU not available")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #190022

test_debug_sync_graph (T276203638) and test_debug_sync_kernel (T276203637) fail only under pt2_stack_for_internal. Both route through generate_debug_sync in torch/_inductor/codegen/cpp_wrapper_gpu.py, which emits AOTI_RUNTIME_CUDA_CHECK(cudaDeviceSynchronize()) - a CUDA runtime (libcudart) symbol. In the fbcode JIT cpp_wrapper path the generated .so links only libcuda (the driver), not libcudart, so cudaDeviceSynchronize is an undefined symbol and the tests fail; OSS links libcudart and passes. This adds @unittest.skipIf(IS_FBCODE, ...) to both tests as the standard triage; a real fix would link libcudart (or avoid the runtime symbol) in the fbcode cpp_wrapper build. Applied byte-identically to the fbcode and xplat mirrors. Authored with AI assistance.

Differential Revision: [D111961492](https://our.internmc.facebook.com/intern/diff/D111961492/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo