### PR TITLE
[inductor] skip libdevice-path compile_worker tests in fbcode

### DIFF
--- a/test/inductor/test_compile_worker.py
+++ b/test/inductor/test_compile_worker.py
@@ -583,11 +583,21 @@ class TestSetTritonLibdevicePath(TestCase):
         """Test eager numerics mode sets libdevice path for CUDA libdevice calls."""
         self._test_libdevice_path_with_compilation()
 
+    @unittest.skipIf(
+        IS_FBCODE,
+        "knobs.nvidia.libdevice_path mismatch in fbcode CI environment; "
+        "matches sibling test_libdevice_path_* disables",
+    )
     @config.patch({"compile_threads": 1, "eager_numerics.use_pytorch_libdevice": True})
     def test_libdevice_path_no_subprocess(self):
         """Test libdevice path is set with compile_threads=1 (no subprocess)."""
         self._test_libdevice_path_with_compilation()
 
+    @unittest.skipIf(
+        IS_FBCODE,
+        "knobs.nvidia.libdevice_path mismatch in fbcode CI environment; "
+        "matches sibling test_libdevice_path_* disables",
+    )
     @config.patch("eager_numerics.use_pytorch_libdevice", True)
     def test_libdevice_path_default_threads(self):
         """Test libdevice path is set with default compile_threads (subprocess)."""


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #190023

`TestSetTritonLibdevicePath._test_libdevice_path_with_compilation` computes `expected = os.path.join(CUDA_HOME, "nvvm", "libdevice", "libdevice.10.bc")` and asserts it equals `triton knobs.nvidia.libdevice_path` after a `torch.compile`. In the fbcode CI environment Triton ships and selects its own bundled bitcode (`.../compile_worker#link-tree/triton/fb/libdevice.10.bc`) rather than the CUDA toolkit copy under `CUDA_HOME` (`/mnt/gvfs/third-party2/cuda/.../nvvm/libdevice/libdevice.10.bc`), so the two paths can never be equal and `test_libdevice_path_no_subprocess` and `test_libdevice_path_default_threads` fail 100% of the time (DISABLED_FAILING, 181 consecutive trunk failures, ~99.7% brokenness). This is a test/environment-assumption issue, not a product regression: pointing the libdevice path at Triton's own bundled copy is correct behavior in fbcode. The sibling `test_emulate_precision_casts_sets_libdevice_path` already carries `@unittest.skipIf(IS_FBCODE, ...)` for exactly this reason, but the guard was only applied to that one method. This change adds the same `@unittest.skipIf(IS_FBCODE, ...)` decorator to both remaining methods, matching the owner's established pattern. `IS_FBCODE` is already imported.

Differential Revision: [D112119016](https://our.internmc.facebook.com/intern/diff/D112119016/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo