### PR TITLE
[Tasks][TEST ISSUE] Fix test_structured_trace test_dump_file for pt2_stack_for_internal

### DIFF
--- a/test/dynamo/test_structured_trace.py
+++ b/test/dynamo/test_structured_trace.py
@@ -15,6 +15,7 @@ from contextlib import contextmanager
 import torch
 import torch._dynamo.test_case
 import torch._dynamo.testing
+import torch._environment
 import torch._logging.structured
 import torch.distributed as dist
 import torch.fx as fx
@@ -77,6 +78,11 @@ class StructuredTraceTestingFilter(logging.Filter):
 
     def filter(self, record):
         if "str" in record.metadata:
+            return False
+        if (
+            torch._environment.is_fbcode()
+            and record.metadata.get("artifact", {}).get("name") == "torch_version"
+        ):
             return False
         if self.match_name is not None:
             if "artifact" in record.metadata:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #190030

test_structured_trace.py::StructuredTraceTest::test_dump_file (T260928844) fails only under the internal pt2_stack_for_internal build. In fbcode the global LazyTraceHandler activates and emits an extra structured trace "artifact" record named "torch_version" into the captured buffer ahead of "dynamo_start"; the test's assertExpectedInline golden has no such line, so the comparison fails. OSS never emits this record (the handler disables itself when torch.version.git_version is present), which is why the test passes upstream. This guards StructuredTraceTestingFilter.filter() to drop the fbcode-only torch_version artifact so the captured trace matches the golden in both environments, matching the approach of the earlier abandoned D97883971. Change applied byte-identically to the fbcode and xplat mirrors of the test. Authored with AI assistance.

Differential Revision: [D111961403](https://our.internmc.facebook.com/intern/diff/D111961403/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98