### PR TITLE
[Tasks][TEST ISSUE] Enable graph_partition for cudagraph_trees graph-partition tests in fbcode for pt2_stack_for_internal

### DIFF
--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -3334,6 +3334,7 @@ if HAS_CUDA_AND_TRITON:
 
         @torch._dynamo.config.patch("capture_dynamic_output_shape_ops", True)
         @torch._inductor.config.patch("cpp_wrapper", True)
+        @torch._inductor.config.patch("graph_partition", True)
         def test_skip_cpp_wrapper(self):
             def foo(x):
                 return x + 1
@@ -4065,6 +4066,7 @@ if HAS_CUDA_AND_TRITON:
             # matching the forward-only count of the enable variant above.
             self.assertEqual(self.get_manager().new_graph_id().id, 2)
 
+        @torch._inductor.config.patch("graph_partition", True)
         def test_cudagraph_min_partition_size_skip_small(self):
             """Partitions with fewer kernels than the threshold are skipped."""
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #190031

test_skip_cpp_wrapper (T264469002) and test_cudagraph_min_partition_size_skip_small (T259394717) fail only under pt2_stack_for_internal because config.graph_partition defaults to False in fbcode (it is True in OSS). Both tests exercise graph-partition-only code paths: test_skip_cpp_wrapper asserts a skip message that get_cpp_wrapper_config() emits only when cudagraphs and graph_partition are both on, and test_cudagraph_min_partition_size_skip_small relies on the cudagraph_min_partition_size threshold that is applied only inside the partition builder. With graph_partition off, neither path executes and both assertions fail. This enables graph_partition for the two tests via @torch._inductor.config.patch("graph_partition", True) so they exercise the intended code path in both OSS and fbcode, matching the approach of the earlier abandoned D99364853. Applied byte-identically to the fbcode and xplat mirrors. Authored with AI assistance.

Differential Revision: [D111961524](https://our.internmc.facebook.com/intern/diff/D111961524/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo