### PR TITLE
[inductor] make compile_worker libdevice-path tests environment-agnostic

### DIFF
--- a/test/inductor/test_compile_worker.py
+++ b/test/inductor/test_compile_worker.py
@@ -22,7 +22,7 @@ from torch._inductor.compile_worker.subproc_pool import (
 )
 from torch._inductor.compile_worker.timer import Timer
 from torch._inductor.test_case import TestCase
-from torch.testing._internal.common_utils import IS_FBCODE, IS_LINUX, skipIfWindows
+from torch.testing._internal.common_utils import IS_LINUX, skipIfWindows
 from torch.testing._internal.inductor_utils import HAS_CPU, HAS_TRITON
 
 
@@ -573,11 +573,6 @@ class TestTimer(TestCase):
 
 
 class TestSetTritonLibdevicePath(TestCase):
-    @unittest.skipIf(
-        IS_FBCODE,
-        "knobs.nvidia.libdevice_path mismatch in fbcode CI environment; "
-        "matches sibling test_libdevice_path_* disables",
-    )
     @config.patch({"compile_threads": 1, "emulate_precision_casts": True})
     def test_emulate_precision_casts_sets_libdevice_path(self):
         """Test eager numerics mode sets libdevice path for CUDA libdevice calls."""
@@ -679,10 +674,15 @@ class TestSetTritonLibdevicePath(TestCase):
         x = torch.randn(10, device="cuda", dtype=torch.float32)
         fn(x)
 
-        # Verify libdevice path was set
+        # Verify libdevice path was set. The exact path is environment-specific
+        # (OSS uses the CUDA_HOME toolkit copy; fbcode uses Triton's bundled
+        # copy), so verify a libdevice bitcode path was set rather than pinning
+        # it to the CUDA_HOME location.
         from triton import knobs
 
-        self.assertEqual(knobs.nvidia.libdevice_path, expected)
+        actual = knobs.nvidia.libdevice_path
+        self.assertTrue(actual, "libdevice path was not set")
+        self.assertTrue(actual.endswith("libdevice.10.bc"))
 
 
 class TestTritonCompileWorker(TestCase):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #190032

The `TestSetTritonLibdevicePath` tests asserted that `knobs.nvidia.libdevice_path` exactly equals the CUDA_HOME toolkit copy (`$CUDA_HOME/nvvm/libdevice/libdevice.10.bc`). That holds in OSS, but in fbcode Triton uses its own bundled libdevice, so the assertion failed deterministically (a sibling test was already `@skipIf(IS_FBCODE)` for this reason). Rather than skip, fix the shared helper `_test_libdevice_path_with_compilation` to verify the production code's actual intent — that a valid libdevice bitcode path was set — by asserting the path is non-empty and ends with `libdevice.10.bc`, instead of pinning it to the CUDA_HOME location. This re-enables all three tests (`test_emulate_precision_casts_sets_libdevice_path`, `test_libdevice_path_no_subprocess`, `test_libdevice_path_default_threads`) in both OSS and fbcode; the now-unused `IS_FBCODE` import and the `skipIf(IS_FBCODE)` decorators are removed.

**Failure scope:** Internal (fbcode) only — the production helper `_set_triton_libdevice_path_impl` early-returns when `knobs.nvidia.libdevice_path` is already set, which fbcode Triton does with its own bundled libdevice, so the exact-path assertion against `$CUDA_HOME/nvvm/libdevice/libdevice.10.bc` fails only in fbcode; on OSS the path resolves to the CUDA_HOME copy and the test passed.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo

---
**Re-enables the following disabled test(s)** (owner: `pt2_stack_for_internal`):
- `caffe2/test/inductor:compile_worker` — `TestSetTritonLibdevicePath.test_emulate_precision_casts_sets_libdevice_path`
- `caffe2/test/inductor:compile_worker` — `TestSetTritonLibdevicePath.test_libdevice_path_no_subprocess`
- `caffe2/test/inductor:compile_worker` — `TestSetTritonLibdevicePath.test_libdevice_path_default_threads`
