### PR TITLE
[inductor] pin graph_partition=True in cudagraph_trees tests that require it (#189886)

### DIFF
--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -3333,7 +3333,7 @@ if HAS_CUDA_AND_TRITON:
             self.assertEqual(counters["inductor"]["cudagraph_skips"], 1)
 
         @torch._dynamo.config.patch("capture_dynamic_output_shape_ops", True)
-        @torch._inductor.config.patch("cpp_wrapper", True)
+        @torch._inductor.config.patch({"cpp_wrapper": True, "graph_partition": True})
         def test_skip_cpp_wrapper(self):
             def foo(x):
                 return x + 1
@@ -4076,7 +4076,7 @@ if HAS_CUDA_AND_TRITON:
 
             # Set threshold high enough to skip this simple function
             with torch._inductor.config.patch(
-                {"triton.cudagraph_min_partition_size": 10}
+                {"triton.cudagraph_min_partition_size": 10, "graph_partition": True}
             ):
                 fn_compiled = torch.compile(fn, mode="reduce-overhead")
                 for _ in range(3):


### PR DESCRIPTION
Summary:
`graph_partition` defaults to `True` in OSS but to `False` in fbcode (`torch/_inductor/config.py` gates the default on `is_fbcode()`). Two tests in `CudaGraphTreeTests` in `test_cudagraph_trees.py` assume `graph_partition` is enabled and therefore fail under the fbcode default: `test_skip_cpp_wrapper` and `test_cudagraph_min_partition_size_skip_small`. The fix pins `graph_partition` to `True` for exactly these two tests -- `test_skip_cpp_wrapper` now patches `{"cpp_wrapper": True, "graph_partition": True}` on its `torch._inductor.config.patch` decorator, and `test_cudagraph_min_partition_size_skip_small` adds `"graph_partition": True` to its existing `torch._inductor.config.patch({"triton.cudagraph_min_partition_size": 10})` context manager. This makes both tests pass in fbcode while leaving OSS behavior unchanged. The same two tests under the `:cudagraph_trees_expandable_segments` target (same file) are fixed as well.

ghstack-source-id: 402987622

Test Plan: buck2 test fbcode//mode/opt fbcode//caffe2/test/inductor:cudagraph_trees -- --regex 'test_skip_cpp_wrapper|test_cudagraph_min_partition_size_skip_small' --run-disabled

Reviewed By: aorenste

Differential Revision: D111930019




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo