### PR TITLE
reduce AOTAutograd overhead before invoking compiled_fn

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -136,6 +136,8 @@ torch/testing/_internal/hop_db.py @tugsbayasgalan @zou3519 @ydwu4 @aorenste @boh
 # AOTAutograd
 torch/_functorch/_aot_autograd/*.py @bdhirsh @aorenste
 torch/_functorch/aot_autograd.py @bdhirsh @aorenste
+torch/csrc/functorch/python_aot_autograd.cpp @aorenste
+torch/csrc/functorch/python_aot_autograd.h @aorenste
 
 # FakeTensor
 torch/_subclasses/fake_tensor.py @aorenste

--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -978,6 +978,7 @@ libtorch_python_core_sources = [
     "torch/csrc/dynamo/init.cpp",
     "torch/csrc/dynamo/stackref_bridge.c",
     "torch/csrc/functorch/init.cpp",
+    "torch/csrc/functorch/python_aot_autograd.cpp",
     "torch/csrc/fx/node.cpp",
     "torch/csrc/mps/Module.cpp",
     "torch/csrc/mtia/Module.cpp",

--- a/test/functorch/test_codegen_runtime_wrapper.py
+++ b/test/functorch/test_codegen_runtime_wrapper.py
@@ -28,6 +28,17 @@ class TestCodegenRuntimeWrapper(TestCase):
         super().setUp()
         torch._dynamo.reset()
 
+    def assertCallCompiledFnIsFirstStatement(self, source):
+        # For runtime overhead, everything before the compiled function call must
+        # stay in C++; FlexAttention cares about time to first kernel launch.
+        lines = [line for line in source.splitlines() if line.strip()]
+        self.assertGreaterEqual(len(lines), 2)
+        self.assertEqual(lines[0], "def _runtime_wrapper(_compiled_fn_, args):")
+        self.assertEqual(
+            lines[1],
+            "    orig_inputs, all_outs = _call_compiled_fn_(_call_spec_, _compiled_fn_, args)",
+        )
+
     def test_inference_simple(self):
         """
         Simple inference: no mutations, no aliases. Generated code should
@@ -45,8 +56,10 @@ class TestCodegenRuntimeWrapper(TestCase):
         self.assertEqual(out, x * 2)
         self.assertEqual(len(captured), 1)
         source = captured[0]
-        self.assertIn("orig_inputs = {}", source)
-        self.assertIn("torch._C._set_grad_enabled(False)", source)
+        self.assertCallCompiledFnIsFirstStatement(source)
+        self.assertIn("orig_inputs, all_outs = _call_compiled_fn_", source)
+        self.assertIn("_call_spec_", source)
+        self.assertIn("_call_compiled_fn_", source)
         self.assertNotIn("_force_view_tracking_", source)
         self.assertNotIn("_is_view_replay_enabled", source)
         self.assertNotIn("_set_view_replay_enabled", source)
@@ -54,7 +67,7 @@ class TestCodegenRuntimeWrapper(TestCase):
     def test_training_simple(self):
         """
         Simple training path: no mutations. Generated code should use
-        the training path (enable_grad + view replay tracking).
+        call_compiled_fn to prepare state and invoke the compiled function.
         """
         with capture_codegen_source("runtime_wrapper_orchestration") as captured:
 
@@ -71,16 +84,17 @@ class TestCodegenRuntimeWrapper(TestCase):
 
         self.assertEqual(len(captured), 1)
         source = captured[0]
-        self.assertIn("torch._C._set_view_replay_enabled(True)", source)
-        self.assertIn("if not prev_view_replay_enabled:", source)
-        self.assertIn("torch.enable_grad()", source)
+        self.assertCallCompiledFnIsFirstStatement(source)
+        self.assertIn("_call_spec_", source)
+        self.assertIn("_call_compiled_fn_", source)
+        self.assertNotIn("torch.enable_grad()", source)
 
     def test_training_with_detach_indices(self):
         """
         Training path with a non-leaf input whose gradient is None in
         the backward graph. The input must be detached before calling
-        the joint graph to avoid "backward through graph a second time"
-        errors. Generated code should contain inline detach calls.
+        the joint graph. Generated code should pass args to call_compiled_fn
+        so it can copy and detach selected inputs.
         """
         with capture_codegen_source("runtime_wrapper_orchestration") as captured:
             y_base = torch.randn(4, requires_grad=True)
@@ -98,8 +112,13 @@ class TestCodegenRuntimeWrapper(TestCase):
         self.assertIsNotNone(x.grad)
         self.assertEqual(len(captured), 1)
         source = captured[0]
-        self.assertIn(".detach()", source)
-        self.assertIn("torch._C._set_view_replay_enabled(True)", source)
+        self.assertIn("_call_spec_", source)
+        self.assertIn(
+            "orig_inputs, all_outs = _call_compiled_fn_(_call_spec_, _compiled_fn_, args)",
+            source,
+        )
+        self.assertNotIn("args_", source)
+        self.assertNotIn(".detach()", source)
 
     def test_inference_with_mutation(self):
         """
@@ -123,7 +142,8 @@ class TestCodegenRuntimeWrapper(TestCase):
 
         self.assertEqual(len(captured), 1)
         source = captured[0]
-        self.assertIn("_increment_version_", source)
+        self.assertIn("_call_compiled_fn_", source)
+        self.assertNotIn("_increment_version_", source)
 
     def test_inference_with_output_alias(self):
         """
@@ -145,7 +165,7 @@ class TestCodegenRuntimeWrapper(TestCase):
         self.assertEqual(len(captured), 1)
         source = captured[0]
         self.assertIn("_replay_aliases_", source)
-        self.assertIn("orig_inputs = {0: args[0]}", source)
+        self.assertIn("orig_inputs, all_outs = _call_compiled_fn_", source)
 
     def test_inference_with_mutation_and_alias(self):
         """
@@ -216,7 +236,8 @@ class TestCodegenRuntimeWrapper(TestCase):
 
         self.assertEqual(len(captured), 1)
         source = captured[0]
-        self.assertIn("_increment_version_", source)
+        self.assertIn("_call_compiled_fn_", source)
+        self.assertNotIn("_increment_version_", source)
 
     def test_output_arity_validation_baked(self):
         """
@@ -289,7 +310,7 @@ class TestCodegenRuntimeWrapper(TestCase):
     def test_inference_disable_amp(self):
         """
         Inference path with autocast active at compile time. Generated code
-        should wrap the compiled fn call in _DisableAutocast_.
+        should use the call_compiled_fn path.
         """
         with capture_codegen_source("runtime_wrapper_orchestration") as captured:
 
@@ -302,14 +323,15 @@ class TestCodegenRuntimeWrapper(TestCase):
 
         self.assertEqual(len(captured), 1)
         source = captured[0]
-        self.assertIn("_DisableAutocast_", source)
-        self.assertIn("torch._C._set_grad_enabled(False)", source)
+        self.assertIn("_call_spec_", source)
+        self.assertIn("_call_compiled_fn_", source)
+        self.assertNotIn("_DisableAutocast_", source)
+        self.assertNotIn("torch._C._set_grad_enabled(False)", source)
 
     def test_training_disable_amp(self):
         """
         Training path with autocast active at compile time. Generated code
-        should use _DisableAutocast_ alongside view replay tracking and
-        enable_grad.
+        should use the same call_compiled_fn path as regular training.
         """
         with capture_codegen_source("runtime_wrapper_orchestration") as captured:
 
@@ -325,8 +347,9 @@ class TestCodegenRuntimeWrapper(TestCase):
         self.assertEqual(x.grad, torch.full((4,), 2.0))
         self.assertEqual(len(captured), 1)
         source = captured[0]
-        self.assertIn("_DisableAutocast_", source)
-        self.assertIn("torch._C._set_view_replay_enabled(True)", source)
+        self.assertIn("_call_spec_", source)
+        self.assertIn("_call_compiled_fn_", source)
+        self.assertNotIn("_DisableAutocast_", source)
 
     def test_dynamic_dims(self):
         """
@@ -397,9 +420,8 @@ class TestCodegenRuntimeWrapper(TestCase):
 
         self.assertEqual(len(captured), 1)
         source = captured[0]
-        self.assertIn("_increment_version_", source)
-        for i in range(5):
-            self.assertIn(f"args[{i}]", source)
+        self.assertIn("_call_compiled_fn_", source)
+        self.assertNotIn("_increment_version_", source)
 
     def test_multiple_output_aliases_different_inputs(self):
         """
@@ -424,15 +446,14 @@ class TestCodegenRuntimeWrapper(TestCase):
         self.assertEqual(len(captured), 1)
         source = captured[0]
         self.assertIn("_replay_aliases_", source)
-        self.assertIn("0: args[0]", source)
-        self.assertIn("1: args[1]", source)
+        self.assertIn("orig_inputs, all_outs = _call_compiled_fn_", source)
 
     def test_first_invocation_ctx_threaded_through_codegen(self):
         """
-        The codegen'd wrapper receives _first_ctx_ (a _FirstInvocationContext)
-        as a parameter and wraps compiled fn execution in it. On first call,
-        this activates _AnalyzeCustomOpInputOutputMode which checks custom op
-        aliasing. Verify the mode fires on first call and not on second.
+        runtime_wrapper owns _FirstInvocationContext and wraps the codegen'd
+        wrapper in it on first call. This activates
+        _AnalyzeCustomOpInputOutputMode, which checks custom op aliasing.
+        Verify the mode fires on first call and not on second.
         """
         with torch.library._scoped_library("test_rw", "FRAGMENT") as lib:
             lib.define("alias_op(Tensor x) -> Tensor")
@@ -491,6 +512,65 @@ class TestCodegenRuntimeWrapper(TestCase):
         source = captured[0]
         self.assertIn(".requires_grad", source)
         self.assertIn(".copy_(", source)
+
+
+class TestAOTAutogradCallCompiledFn(TestCase):
+    def test_direct_helper_handles_training_pre_call_work(self):
+        call_compiled_fn = torch._C._aot_autograd_call_compiled_fn
+        call_spec = torch._C._CompiledFnCallSpec((1,), True, False, False, (0,), (0,))
+
+        x = torch.randn(2, requires_grad=True)
+        y_base = torch.randn(2, requires_grad=True)
+        y = y_base * 2
+        args = [x, y]
+
+        prev_view_replay_enabled = torch._C._is_view_replay_enabled()
+        torch._C._set_view_replay_enabled(False)
+        try:
+            x_version = x._version
+            seen = {}
+
+            def compiled_fn(call_args):
+                seen["same_args_list"] = call_args is args
+                self.assertTrue(torch.is_grad_enabled())
+                self.assertTrue(torch._C._is_view_replay_enabled())
+                self.assertIs(call_args[0], x)
+                self.assertIsNot(call_args[1], y)
+                self.assertFalse(call_args[1].requires_grad)
+                self.assertEqual(call_args[1], y)
+                return [call_args[0] + 1]
+
+            with torch.no_grad():
+                orig_inputs, all_outs = call_compiled_fn(call_spec, compiled_fn, args)
+
+            self.assertFalse(seen["same_args_list"])
+            self.assertIs(orig_inputs[0], x)
+            self.assertEqual(all_outs[0], x + 1)
+            self.assertEqual(x._version, x_version + 1)
+            self.assertFalse(torch._C._is_view_replay_enabled())
+        finally:
+            torch._C._set_view_replay_enabled(prev_view_replay_enabled)
+
+    def test_direct_helper_handles_inference_pre_call_work(self):
+        call_compiled_fn = torch._C._aot_autograd_call_compiled_fn
+        call_spec = torch._C._CompiledFnCallSpec((), False, True, False, (), ())
+        x = torch.randn(2)
+
+        def compiled_fn(call_args):
+            self.assertFalse(torch.is_grad_enabled())
+            self.assertFalse(torch.is_autocast_enabled("cpu"))
+            self.assertIs(call_args[0], x)
+            return [call_args[0] + 1]
+
+        with torch.enable_grad(), torch.autocast("cpu", dtype=torch.bfloat16):
+            self.assertTrue(torch.is_grad_enabled())
+            self.assertTrue(torch.is_autocast_enabled("cpu"))
+            orig_inputs, all_outs = call_compiled_fn(call_spec, compiled_fn, [x])
+            self.assertTrue(torch.is_grad_enabled())
+            self.assertTrue(torch.is_autocast_enabled("cpu"))
+
+        self.assertEqual(orig_inputs, {})
+        self.assertEqual(all_outs[0], x + 1)
 
 
 if __name__ == "__main__":

--- a/test/functorch/test_compile_to_python.py
+++ b/test/functorch/test_compile_to_python.py
@@ -442,7 +442,8 @@ class TestAOTCompileToPython(TestCase):
         with torch.autocast("cpu", dtype=torch.bfloat16):
             src, _cache = compile_to_python(gm, pb)
         _assert_composed(self, src)
-        self.assertIn("_DisableAutocast_", src)
+        self.assertIn("_CompiledFnCallSpec((), False, True, True, (), ())", src)
+        self.assertNotIn("_DisableAutocast_", src)
         with torch.no_grad():
             out = _exec(src)(pb)[0]
         with torch.no_grad(), torch.autocast("cpu", dtype=torch.bfloat16):
@@ -479,10 +480,7 @@ class TestAOTCompileToPython(TestCase):
         self.assertIn("return _runtime_wrapper(", src)
         self.assertNotIn("_orchestration", src)  # redundant alias removed
         self.assertNotIn("_exec_wrapper", src)
-        # Pin the deliberate drop of the first-invocation context / profiler prologue:
-        # the orchestration is invoked with contextlib.nullcontext + a no-op in those two
-        # positional slots. A future change re-threading a real context here would fail.
-        self.assertIn(", contextlib.nullcontext, lambda: None,", src)
+        self.assertNotIn("_on_before_call_", src)
         with torch.no_grad():
             self.assertEqual(_exec(src)(_flat_inputs(m, x))[0], m(x))
 
@@ -834,8 +832,7 @@ class TestAOTComposeGuards(TestCase):
     # only fire if AOTAutograd's codegen drifts, so drive them directly with hand-built
     # GeneratedSource objects rather than waiting for an upstream regression.
     _ORCH_SRC = (
-        "def _runtime_wrapper(_compiled_fn_, _first_ctx_, _on_before_call_, args):\n"
-        "    return _compiled_fn_(args)\n"
+        "def _runtime_wrapper(_compiled_fn_, args):\n    return _compiled_fn_(args)\n"
     )
     _CHAIN_SRC = "def inner_fn(args):\n    return compiled_fn(args)\n"
 
@@ -859,13 +856,13 @@ class TestAOTComposeGuards(TestCase):
             )
 
     def test_orchestration_extra_kwonly_param_rejected(self):
-        # The 4 positional params are intact but a keyword-only param is added. The standalone
+        # The positional params are intact but a keyword-only param is added. The standalone
         # call is purely positional, so a kw-only-with-default would be silently dropped; the
         # guard must compare the FULL signature and reject this, not just the positional list.
         kwonly_orch = GeneratedSource(
             "runtime_wrapper_orchestration",
             "_runtime_wrapper",
-            "def _runtime_wrapper(_compiled_fn_, _first_ctx_, _on_before_call_, args, "
+            "def _runtime_wrapper(_compiled_fn_, args, "
             "*, new_flag=None):\n    return _compiled_fn_(args)\n",
             {},
             lambda: None,
@@ -929,8 +926,7 @@ class TestAOTComposeGuards(TestCase):
         orch = GeneratedSource(
             "runtime_wrapper_orchestration",
             "_runtime_wrapper",
-            "def _runtime_wrapper(_compiled_fn_, _first_ctx_, _on_before_call_, args):\n"
-            "    return [_baked]\n",
+            "def _runtime_wrapper(_compiled_fn_, args):\n    return [_baked]\n",
             {"_baked": torch.randn(4)},
             lambda: None,
         )
@@ -949,8 +945,7 @@ class TestAOTComposeGuards(TestCase):
         orch = GeneratedSource(
             "runtime_wrapper_orchestration",
             "_runtime_wrapper",
-            "def _runtime_wrapper(_compiled_fn_, _first_ctx_, _on_before_call_, args):\n"
-            "    return [_baked]\n",
+            "def _runtime_wrapper(_compiled_fn_, args):\n    return [_baked]\n",
             {"_baked": baked},
             lambda: None,
         )

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -498,7 +498,7 @@ class _AnalyzeCustomOpInputOutputMode(TorchDispatchMode):
 
 class _FirstInvocationContext:
     """
-    Context manager that tracks first invocation and conditionally enables _AnalyzeCustomOpInputOutputMode.
+    Tracks first invocation and conditionally enables _AnalyzeCustomOpInputOutputMode.
     This is useful when we have a custom op where we want to analyze its input
     and output during cold start.
     """
@@ -506,9 +506,9 @@ class _FirstInvocationContext:
     def __init__(self) -> None:
         self._is_first = True
 
-    def __call__(self) -> AbstractContextManager[Any]:
+    def __call__(self) -> AbstractContextManager[Any] | None:
         """
-        Returns a context manager: _AnalyzeCustomOpInputOutputMode on first invocation, nullcontext thereafter.
+        Returns _AnalyzeCustomOpInputOutputMode on first invocation, None thereafter.
         Automatically updates state after first use.
         """
         # NB: Don't run the analyzer when you're forcing compile during FX
@@ -521,7 +521,7 @@ class _FirstInvocationContext:
         ):
             self._is_first = False
             return _AnalyzeCustomOpInputOutputMode()
-        return nullcontext()
+        return None
 
 
 # Note [RuntimeWrapper codegen specification methods]
@@ -551,7 +551,7 @@ class _RuntimeCompiledFnInvoker:
     # code from _create_runtime_wrapper(). Keep both in sync.
     # See Note [RuntimeWrapper codegen specification methods]
     def run(self, args: list[Any], *, on_before_call: Callable[[], None]) -> list[Any]:
-        with self.first_invocation_ctx():
+        def run_impl() -> list[Any]:
             if self.trace_joint:
                 args_ = list(args)
                 # See Note [Detaching inputs that never need gradients]
@@ -597,6 +597,12 @@ class _RuntimeCompiledFnInvoker:
             finally:
                 if grad_enabled:
                     torch._C._set_grad_enabled(True)
+
+        first_ctx = self.first_invocation_ctx()
+        if first_ctx is None:
+            return run_impl()
+        with first_ctx:
+            return run_impl()
 
 
 @dataclass
@@ -805,33 +811,6 @@ class _RuntimeForwardEpilogue:
         ]
 
 
-def _codegen_capture_orig_inputs(
-    rw_lines: list[str],
-    epilogue_args_idx: tuple[int, ...],
-) -> None:
-    if epilogue_args_idx:
-        idx_str = ", ".join(f"{i}: args[{i}]" for i in epilogue_args_idx)
-        rw_lines.append(f"    orig_inputs = {{{idx_str}}}")
-    else:
-        rw_lines.append("    orig_inputs = {}")
-
-
-def _codegen_increment_mutation_versions(
-    rw_lines: list[str],
-    rw_globals: dict[str, object],
-    keep_input_mutations: bool,
-    runtime_metadata: ViewAndMutationMeta,
-) -> None:
-    if (
-        keep_input_mutations
-        and runtime_metadata.mutated_graph_handled_indices_seen_by_autograd
-    ):
-        rw_globals["_increment_version_"] = torch.autograd.graph.increment_version
-        mut_idx = tuple(runtime_metadata.mutated_graph_handled_indices_seen_by_autograd)
-        gen_expr = ", ".join(f"args[{i}]" for i in mut_idx)
-        rw_lines.append(f"    _increment_version_(({gen_expr},))")
-
-
 def _codegen_normalize_as_list(
     lines: list[str], var_name: str, *, indent_level: int
 ) -> None:
@@ -840,66 +819,6 @@ def _codegen_normalize_as_list(
     lines.append(f"{indent}    {var_name} = list({var_name})")
     lines.append(f"{indent}elif not isinstance({var_name}, list):")
     lines.append(f"{indent}    {var_name} = [{var_name}]")
-
-
-def _codegen_compiled_fn_invocation(
-    rw_lines: list[str],
-    rw_globals: dict[str, object],
-    trace_joint: bool,
-    indices_of_inps_to_detach: list[int],
-    disable_amp: bool,
-) -> None:
-    rw_lines.append("    with _first_ctx_():")
-    # trace_joint is known at codegen time. Only the joint/training path needs
-    # forced view replay; inference wrappers should not touch this TLS state.
-    if trace_joint:
-        rw_lines.append("        args_ = list(args)")
-        for idx in indices_of_inps_to_detach:
-            rw_lines.append(
-                f"        if isinstance(args_[{idx}], torch.Tensor): "
-                f"args_[{idx}] = args_[{idx}].detach()"
-            )
-        rw_lines.append(
-            "        prev_view_replay_enabled = torch._C._is_view_replay_enabled()"
-        )
-        rw_lines.append("        try:")
-        rw_lines.append("            if not prev_view_replay_enabled:")
-        rw_lines.append("                torch._C._set_view_replay_enabled(True)")
-        rw_lines.append("            with torch.enable_grad():")
-        rw_lines.append("                _on_before_call_()")
-        if disable_amp:
-            rw_globals["_DisableAutocast_"] = torch._C._DisableAutocast
-            rw_lines.append("                with _DisableAutocast_():")
-            rw_lines.append("                    all_outs = _compiled_fn_(args_)")
-            _codegen_normalize_as_list(rw_lines, "all_outs", indent_level=5)
-        else:
-            rw_lines.append("                all_outs = _compiled_fn_(args_)")
-            _codegen_normalize_as_list(rw_lines, "all_outs", indent_level=4)
-        rw_lines.append("        finally:")
-        rw_lines.append(
-            "            if torch._C._is_view_replay_enabled() != prev_view_replay_enabled:"
-        )
-        rw_lines.append(
-            "                torch._C._set_view_replay_enabled(prev_view_replay_enabled)"
-        )
-    else:
-        rw_lines.append("        grad_enabled = torch.is_grad_enabled()")
-        rw_lines.append("        try:")
-        rw_lines.append(
-            "            if grad_enabled: torch._C._set_grad_enabled(False)"
-        )
-        rw_lines.append("            _on_before_call_()")
-        if disable_amp:
-            rw_globals["_DisableAutocast_"] = torch._C._DisableAutocast
-            rw_lines.append("            with _DisableAutocast_():")
-            rw_lines.append("                all_outs = _compiled_fn_(args)")
-            _codegen_normalize_as_list(rw_lines, "all_outs", indent_level=4)
-        else:
-            rw_lines.append("            all_outs = _compiled_fn_(args)")
-            _codegen_normalize_as_list(rw_lines, "all_outs", indent_level=3)
-        rw_lines.append("        finally:")
-        rw_lines.append("            if grad_enabled: torch._C._set_grad_enabled(True)")
-    rw_lines.append("    del args")
 
 
 # signatures mirror the _RuntimeForwardEpilogue reference methods
@@ -1046,24 +965,6 @@ def _create_runtime_wrapper(
 
         codegen_alias_fn = typing.cast(_EpilogueReplayAliasesFn, buf.build())
 
-    def record_runtime_wrapper_prologue_enter() -> AbstractContextManager[None] | None:
-        if (
-            torch.autograd.profiler._is_profiler_enabled
-            and dynamo_config.record_runtime_overhead
-        ):
-            cm = torch._C._profiler._RecordFunctionFast(
-                "AOTDispatcher Runtime Wrapper Prologue"
-            )
-            cm.__enter__()
-            return cm
-        return None
-
-    def record_runtime_wrapper_prologue_exit(
-        cm: AbstractContextManager[None] | None,
-    ) -> None:
-        if cm is not None:
-            cm.__exit__(None, None, None)
-
     # Codegen mutation epilogue: emit straight-line code per mutated input
     # with all branches resolved at compile time.
     if runtime_metadata.num_mutated_inp_runtime_indices > 0:
@@ -1145,20 +1046,39 @@ def _create_runtime_wrapper(
 
     buf = PySourceBuilder(
         "_runtime_wrapper",
-        args="_compiled_fn_, _first_ctx_, _on_before_call_, args",
+        args="_compiled_fn_, args",
         artifact_name="runtime_wrapper_orchestration",
     )
     buf.bind(torch=torch)
     rw_lines = buf.lines
     rw_globals = buf.globals
 
-    _codegen_capture_orig_inputs(rw_lines, epilogue_args_idx)
-    _codegen_increment_mutation_versions(
-        rw_lines, rw_globals, keep_input_mutations, runtime_metadata
+    indices_of_inps_to_increment_version = ()
+    if (
+        keep_input_mutations
+        and runtime_metadata.mutated_graph_handled_indices_seen_by_autograd
+    ):
+        indices_of_inps_to_increment_version = tuple(
+            runtime_metadata.mutated_graph_handled_indices_seen_by_autograd
+        )
+    call_spec_ctor = getattr(torch._C, "_CompiledFnCallSpec")  # noqa: B009
+    call_compiled_fn = getattr(torch._C, "_aot_autograd_call_compiled_fn")  # noqa: B009
+    call_spec = call_spec_ctor(
+        tuple(indices_of_inps_to_detach),
+        trace_joint,
+        disable_amp,
+        dynamo_config.record_runtime_overhead,
+        epilogue_args_idx,
+        indices_of_inps_to_increment_version,
     )
-    _codegen_compiled_fn_invocation(
-        rw_lines, rw_globals, trace_joint, indices_of_inps_to_detach, disable_amp
+    rw_globals["_call_spec_"] = call_spec
+    rw_globals["_call_compiled_fn_"] = call_compiled_fn
+    rw_lines.append(
+        "    orig_inputs, all_outs = _call_compiled_fn_("
+        "_call_spec_, _compiled_fn_, args)"
     )
+    _codegen_normalize_as_list(rw_lines, "all_outs", indent_level=1)
+    rw_lines.append("    del args")
     _codegen_epilogue(
         rw_lines,
         rw_globals,
@@ -1173,27 +1093,21 @@ def _create_runtime_wrapper(
 
     _inner_compiled_fn = compiled_invoker.compiled_fn
     _first_invocation_ctx = compiled_invoker.first_invocation_ctx
+    first_invocation_pending = True
 
     @simple_wraps(_inner_compiled_fn)
     def runtime_wrapper(args: list[Any]) -> Any:
-        cm = record_runtime_wrapper_prologue_enter()
-        prologue_exited = False
+        nonlocal first_invocation_pending
+        first_ctx = None
+        if first_invocation_pending:
+            first_invocation_pending = False
+            first_ctx = _first_invocation_ctx()
 
-        def exit_prologue() -> None:
-            nonlocal prologue_exited
-            if not prologue_exited:
-                record_runtime_wrapper_prologue_exit(cm)
-                prologue_exited = True
-
-        try:
-            result = _codegen_runtime_wrapper(
-                _inner_compiled_fn,
-                _first_invocation_ctx,
-                exit_prologue,
-                args,
-            )
-        finally:
-            exit_prologue()
+        if first_ctx is None:
+            result = _codegen_runtime_wrapper(_inner_compiled_fn, args)
+        else:
+            with first_ctx:
+                result = _codegen_runtime_wrapper(_inner_compiled_fn, args)
         del args
         return result
 

--- a/torch/_functorch/_aot_autograd/to_standalone_python.py
+++ b/torch/_functorch/_aot_autograd/to_standalone_python.py
@@ -106,12 +106,12 @@ _COMPILE_LOCK = threading.RLock()
 #     def _alias_fn(orig_inputs, fw_outs):                     # (3) sibling wrapper
 #         return [gen_alias_from_base(orig_inputs[0], fw_outs[0], False, _vms_0, ...)]
 #     _replay_aliases_ = _alias_fn                             # (3) orchestration's ref
-#     def _runtime_wrapper(_compiled_fn_, _first_ctx_, _on_before_call_, args):
-#         all_outs = _compiled_fn_(args)                       # (2) inner call invoked
+#     def _runtime_wrapper(_compiled_fn_, args):
+#         orig_inputs, all_outs = _call_compiled_fn_(...)      # (2) inner call invoked
 #         return _replay_aliases_(orig_inputs, all_outs)       # (3) sibling invoked
 #     def call(flat_inputs):
 #         return _runtime_wrapper(
-#             _inner_call, contextlib.nullcontext, lambda: None, list(flat_inputs))
+#             _inner_call, list(flat_inputs))
 #
 # We do NOT reimplement any of this. We CAPTURE AOTAutograd's exact codegen'd wrapper
 # source together with the (pre-exec) globals dict each wrapper closed over: a
@@ -357,12 +357,12 @@ def _compose_standalone_module(
     non_orch = [g for g in captured if g is not orch]
 
     # The generated ``call`` invokes the orchestration POSITIONALLY by its own name (see
-    # the bottom of this function): _runtime_wrapper(chain_head, contextlib.nullcontext,
-    # lambda: None, flat_inputs). That mapping is hardcoded to the codegen'd signature in
-    # runtime_wrappers.py (``def _runtime_wrapper(_compiled_fn_, _first_ctx_,
-    # _on_before_call_, args)``). Verify the captured signature still matches so a future
-    # rename/reorder fails loudly here instead of silently passing wrong arguments.
-    expected_orch_params = ["_compiled_fn_", "_first_ctx_", "_on_before_call_", "args"]
+    # the bottom of this function): _runtime_wrapper(chain_head, flat_inputs).
+    # That mapping is hardcoded to the codegen'd signature in
+    # runtime_wrappers.py (``def _runtime_wrapper(_compiled_fn_, args)``). Verify the
+    # captured signature still matches so a future rename/reorder fails loudly here
+    # instead of silently passing wrong arguments.
+    expected_orch_params = ["_compiled_fn_", "args"]
     orch_def = next(
         (
             n
@@ -524,7 +524,6 @@ def _compose_standalone_module(
         "call",
         "_inner_call",
         "_rebuild",
-        "contextlib",
         _ORCH_ENTRY,
     }
 
@@ -613,24 +612,17 @@ def _compose_standalone_module(
     else:
         final_invoke = (
             f"    return {orch.fn_name}(\n"
-            f"        {chain_head}, contextlib.nullcontext, lambda: None, "
-            "list(flat_inputs)\n    )"
+            f"        {chain_head}, list(flat_inputs)\n    )"
         )
 
     # The single-arg adapter over the orchestration (emitted only when outer wrappers
     # wrap it). The outer wrappers call their inner as ``fn(args)``; this adapts the
-    # orchestration's positional (_compiled_fn_, _first_ctx_, _on_before_call_, args)
-    # signature to that. When there are no outer wrappers the orchestration is invoked
-    # directly in ``call`` (see final_invoke).
+    # orchestration's positional (_compiled_fn_, args) signature to that. When there
+    # are no outer wrappers the orchestration is invoked directly in ``call`` (see
+    # final_invoke).
     orch_invoke_comment = [
-        "    # The 2nd/3rd positional args INTENTIONALLY substitute contextlib.nullcontext",
-        "    # for the runtime's first-invocation context (_FirstInvocationContext) and a",
-        "    # no-op for the profiler-prologue exit. This drops two cold-start diagnostics:",
-        "    # the first-call custom-op aliasing analysis (_AnalyzeCustomOpInputOutputMode,",
-        "    # active when check_custom_op_aliasing is set, which can even RAISE under",
-        "    # error_on_custom_op_aliasing) and the profiler prologue. Neither affects",
-        "    # numerics, so this is not a bug -- the standalone artifact deliberately omits",
-        "    # them. (See the positional-mapping note in _compose_standalone_module.)",
+        "    # Standalone source skips runtime_wrapper's first-call custom-op",
+        "    # aliasing analysis; this does not affect numerics.",
     ]
     entry_block: list[str] = []
     if outer_wrappers:
@@ -640,7 +632,7 @@ def _compose_standalone_module(
             "    # orchestration (dedup / synthetic base) can invoke it as ``fn(args)``.",
             *orch_invoke_comment,
             f"    return {orch.fn_name}(",
-            f"        {chain_head}, contextlib.nullcontext, lambda: None, args",
+            f"        {chain_head}, args",
             "    )",
             "",
         ]
@@ -722,7 +714,6 @@ def _compose_standalone_module(
 
     parts = [
         _MODULE_HEADER,
-        "import contextlib",
         *sorted(imports),
         "",
         "",

--- a/torch/csrc/functorch/init.cpp
+++ b/torch/csrc/functorch/init.cpp
@@ -8,6 +8,7 @@
 #include <ATen/WrapDimUtils.h>
 #include <torch/csrc/autograd/python_variable.h>
 #include <torch/csrc/functorch/init.h>
+#include <torch/csrc/functorch/python_aot_autograd.h>
 #include <torch/csrc/utils/object_ptr.h>
 #include <torch/csrc/utils/python_raii.h>
 #include <torch/python.h>
@@ -559,6 +560,10 @@ static PyMethodDef unwrapDeadWrappersDef = {
     nullptr};
 
 void initFuncTorchBindings(PyObject* module) {
+  TORCH_CHECK(
+      InitializeAOTAutogradHelpers(module),
+      "failed to initialize AOTAutograd helper bindings");
+
   auto _C = py::handle(module).cast<py::module>();
   auto m = _C.def_submodule("_functorch");
 

--- a/torch/csrc/functorch/python_aot_autograd.cpp
+++ b/torch/csrc/functorch/python_aot_autograd.cpp
@@ -1,0 +1,399 @@
+#include <torch/csrc/functorch/python_aot_autograd.h>
+
+#include <ATen/record_function.h>
+#include <c10/core/AutogradState.h>
+#include <c10/core/DispatchKeySet.h>
+#include <c10/core/GradMode.h>
+#include <c10/core/impl/LocalDispatchKeySet.h>
+#include <c10/util/irange.h>
+#include <torch/csrc/Exceptions.h>
+#include <torch/csrc/autograd/VariableTypeUtils.h>
+#include <torch/csrc/autograd/python_variable.h>
+#include <torch/csrc/profiler/orchestration/observer.h>
+#include <torch/csrc/utils/object_ptr.h>
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace torch::functorch::impl {
+
+// NOLINTBEGIN(hicpp-exception-baseclass)
+
+namespace {
+
+// Built once by AOTAutograd wrapper codegen. Runtime reads this spec to set TLS
+// state, optionally copy/detach selected args, and restore state after the
+// compiled function returns.
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
+struct CompiledFnCallSpec {
+  PyObject_HEAD
+  std::vector<int64_t> indices_of_inps_to_detach;
+  std::vector<int64_t> epilogue_args_idx;
+  std::vector<int64_t> indices_of_inps_to_increment_version;
+  bool trace_joint;
+  bool disable_amp;
+  bool record_runtime_overhead;
+};
+
+class ViewReplayGuard {
+ public:
+  explicit ViewReplayGuard(bool trace_joint)
+      : restore_(trace_joint),
+        prev_enabled_(
+            c10::AutogradState::get_tls_state().get_view_replay_enabled()) {
+    if (trace_joint && !prev_enabled_) {
+      c10::AutogradState::get_tls_state().set_view_replay_enabled(true);
+    }
+  }
+
+  ~ViewReplayGuard() {
+    if (restore_ &&
+        c10::AutogradState::get_tls_state().get_view_replay_enabled() !=
+            prev_enabled_) {
+      c10::AutogradState::get_tls_state().set_view_replay_enabled(
+          prev_enabled_);
+    }
+  }
+
+ private:
+  bool restore_;
+  bool prev_enabled_;
+};
+
+void CompiledFnCallSpec_dealloc(CompiledFnCallSpec* self) {
+  self->indices_of_inps_to_increment_version.~vector<int64_t>();
+  self->epilogue_args_idx.~vector<int64_t>();
+  self->indices_of_inps_to_detach.~vector<int64_t>();
+  Py_TYPE(self)->tp_free(reinterpret_cast<PyObject*>(self));
+}
+
+PyTypeObject CompiledFnCallSpecType = {
+    PyVarObject_HEAD_INIT(nullptr, 0)
+    "torch._C._CompiledFnCallSpec", /* tp_name */
+    sizeof(CompiledFnCallSpec), /* tp_basicsize */
+    0, /* tp_itemsize */
+    reinterpret_cast<destructor>(CompiledFnCallSpec_dealloc), /* tp_dealloc */
+    0, /* tp_vectorcall_offset */
+    nullptr, /* tp_getattr */
+    nullptr, /* tp_setattr */
+    nullptr, /* tp_as_async */
+    nullptr, /* tp_repr */
+    nullptr, /* tp_as_number */
+    nullptr, /* tp_as_sequence */
+    nullptr, /* tp_as_mapping */
+    nullptr, /* tp_hash */
+    nullptr, /* tp_call */
+    nullptr, /* tp_str */
+    nullptr, /* tp_getattro */
+    nullptr, /* tp_setattro */
+    nullptr, /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT, /* tp_flags */
+    nullptr, /* tp_doc */
+};
+
+[[noreturn]] void raise_python_error() {
+  throw python_error(); // @allow-raw-throw
+}
+
+std::vector<int64_t> read_int_tuple(PyObject* tuple) {
+  TORCH_INTERNAL_ASSERT(PyTuple_CheckExact(tuple));
+  std::vector<int64_t> result;
+  const auto size = PyTuple_GET_SIZE(tuple);
+  result.reserve(size);
+  for (const auto i : c10::irange(size)) {
+    PyObject* item = PyTuple_GET_ITEM(tuple, i);
+    const auto value = PyLong_AsLongLong(item);
+    if (value == -1 && PyErr_Occurred()) {
+      raise_python_error();
+    }
+    TORCH_INTERNAL_ASSERT(value >= 0);
+    result.push_back(value);
+  }
+  return result;
+}
+
+THPObjectPtr make_int_tuple(const std::vector<int64_t>& values) {
+  THPObjectPtr tuple(PyTuple_New(values.size()));
+  if (!tuple) {
+    raise_python_error();
+  }
+  for (const auto i : c10::irange(values.size())) {
+    PyObject* item = PyLong_FromLongLong(values[i]);
+    if (!item) {
+      raise_python_error();
+    }
+    PyTuple_SET_ITEM(tuple.get(), static_cast<Py_ssize_t>(i), item);
+  }
+  return tuple;
+}
+
+PyObject* CompiledFnCallSpec_new(
+    PyTypeObject* type,
+    PyObject* args,
+    PyObject* kwargs) {
+  HANDLE_TH_ERRORS
+  TORCH_INTERNAL_ASSERT(!kwargs || PyDict_GET_SIZE(kwargs) == 0);
+
+  PyObject* detach_indices = nullptr;
+  PyObject* epilogue_args_idx = nullptr;
+  PyObject* increment_version_indices = nullptr;
+  int trace_joint = 0;
+  int disable_amp = 0;
+  int record_runtime_overhead = 0;
+  if (!PyArg_ParseTuple(
+          args,
+          "OpppOO:_CompiledFnCallSpec",
+          &detach_indices,
+          &trace_joint,
+          &disable_amp,
+          &record_runtime_overhead,
+          &epilogue_args_idx,
+          &increment_version_indices)) {
+    raise_python_error();
+  }
+  auto detach_indices_vec = read_int_tuple(detach_indices);
+  auto epilogue_args_idx_vec = read_int_tuple(epilogue_args_idx);
+  auto increment_version_indices_vec =
+      read_int_tuple(increment_version_indices);
+  TORCH_INTERNAL_ASSERT(trace_joint || PyTuple_GET_SIZE(detach_indices) == 0);
+
+  auto* spec = reinterpret_cast<CompiledFnCallSpec*>(type->tp_alloc(type, 0));
+  if (!spec) {
+    raise_python_error();
+  }
+  new (&spec->indices_of_inps_to_detach)
+      std::vector<int64_t>(std::move(detach_indices_vec));
+  new (&spec->epilogue_args_idx)
+      std::vector<int64_t>(std::move(epilogue_args_idx_vec));
+  new (&spec->indices_of_inps_to_increment_version)
+      std::vector<int64_t>(std::move(increment_version_indices_vec));
+  spec->trace_joint = trace_joint != 0;
+  spec->disable_amp = disable_amp != 0;
+  spec->record_runtime_overhead = record_runtime_overhead != 0;
+  return reinterpret_cast<PyObject*>(spec);
+  END_HANDLE_TH_ERRORS
+}
+
+PyObject* CompiledFnCallSpec_reduce(
+    CompiledFnCallSpec* self,
+    PyObject* _unused) {
+  HANDLE_TH_ERRORS
+  // This is required for compile_to_python, which is a debug option to
+  // emits the generated runtime wrapper plus its closed-over
+  // globals as standalone source.
+  //
+  // This __reduce__ lets it reconstruct the closed-over _CompiledFnCallSpec as:
+  //   torch._C._CompiledFnCallSpec(detach, trace_joint, disable_amp,
+  //       record_runtime_overhead, epilogue_args_idx, increment_version_idxs)
+  // Normal runtime uses the live spec object directly; this is not the hot
+  // path.
+  THPObjectPtr detach_indices(make_int_tuple(self->indices_of_inps_to_detach));
+  THPObjectPtr epilogue_args_idx(make_int_tuple(self->epilogue_args_idx));
+  THPObjectPtr increment_version_indices(
+      make_int_tuple(self->indices_of_inps_to_increment_version));
+
+  THPObjectPtr ctor_args(PyTuple_New(6));
+  if (!ctor_args) {
+    raise_python_error();
+  }
+  THPObjectPtr trace_joint(PyBool_FromLong(self->trace_joint));
+  THPObjectPtr disable_amp(PyBool_FromLong(self->disable_amp));
+  THPObjectPtr record_runtime_overhead(
+      PyBool_FromLong(self->record_runtime_overhead));
+  PyTuple_SET_ITEM(ctor_args.get(), 0, detach_indices.release());
+  PyTuple_SET_ITEM(ctor_args.get(), 1, trace_joint.release());
+  PyTuple_SET_ITEM(ctor_args.get(), 2, disable_amp.release());
+  PyTuple_SET_ITEM(ctor_args.get(), 3, record_runtime_overhead.release());
+  PyTuple_SET_ITEM(ctor_args.get(), 4, epilogue_args_idx.release());
+  PyTuple_SET_ITEM(ctor_args.get(), 5, increment_version_indices.release());
+
+  THPObjectPtr result(PyTuple_New(2));
+  if (!result) {
+    raise_python_error();
+  }
+  Py_INCREF(&CompiledFnCallSpecType);
+  PyTuple_SET_ITEM(
+      result.get(), 0, reinterpret_cast<PyObject*>(&CompiledFnCallSpecType));
+  PyTuple_SET_ITEM(result.get(), 1, ctor_args.release());
+  return result.release();
+  END_HANDLE_TH_ERRORS
+}
+
+static PyMethodDef CompiledFnCallSpec_methods[] = {
+    {"__reduce__",
+     reinterpret_cast<PyCFunction>(CompiledFnCallSpec_reduce),
+     METH_NOARGS,
+     nullptr},
+    {nullptr, nullptr, 0, nullptr}};
+
+PyObject* get_inputs_at_indices(
+    PyObject* boxed_args,
+    const std::vector<int64_t>& indices) {
+  // return {idx: boxed_args[arg] for idx in indices}
+  TORCH_INTERNAL_ASSERT(PyList_CheckExact(boxed_args));
+  const auto num_args = PyList_GET_SIZE(boxed_args);
+  THPObjectPtr orig_inputs(PyDict_New());
+  if (!orig_inputs) {
+    raise_python_error();
+  }
+  for (const auto arg_idx : indices) {
+    TORCH_INTERNAL_ASSERT(arg_idx < num_args);
+    PyObject* key = PyLong_FromLongLong(arg_idx);
+    if (!key) {
+      raise_python_error();
+    }
+    PyObject* value =
+        PyList_GET_ITEM(boxed_args, static_cast<Py_ssize_t>(arg_idx));
+    if (PyDict_SetItem(orig_inputs.get(), key, value) < 0) {
+      Py_DECREF(key);
+      raise_python_error();
+    }
+    Py_DECREF(key);
+  }
+  return orig_inputs.release();
+}
+
+void increment_versions_at_indices(
+    PyObject* boxed_args,
+    const std::vector<int64_t>& indices) {
+  TORCH_INTERNAL_ASSERT(PyList_CheckExact(boxed_args));
+  const auto num_args = PyList_GET_SIZE(boxed_args);
+  for (const auto arg_idx : indices) {
+    TORCH_INTERNAL_ASSERT(arg_idx < num_args);
+    PyObject* item =
+        PyList_GET_ITEM(boxed_args, static_cast<Py_ssize_t>(arg_idx));
+    TORCH_INTERNAL_ASSERT(THPVariable_Check(item));
+    auto tensor = THPVariable_Unpack(item);
+    if (!tensor.is_inference()) {
+      torch::autograd::increment_version(tensor);
+    }
+  }
+}
+
+THPObjectPtr maybe_detach_at_indices(
+    PyObject* boxed_args,
+    const std::vector<int64_t>& indices) {
+  // Returns nullptr if nothing to detach, otherwise a new list.
+  if (indices.empty()) {
+    return THPObjectPtr();
+  }
+
+  TORCH_INTERNAL_ASSERT(PyList_CheckExact(boxed_args));
+  const auto num_args = PyList_GET_SIZE(boxed_args);
+  THPObjectPtr call_args(PyList_New(num_args));
+  if (!call_args) {
+    raise_python_error();
+  }
+
+  for (const auto i : c10::irange(num_args)) {
+    PyObject* item = PyList_GET_ITEM(boxed_args, i);
+    Py_INCREF(item);
+    PyList_SET_ITEM(call_args.get(), static_cast<Py_ssize_t>(i), item);
+  }
+
+  for (const auto arg_idx : indices) {
+    TORCH_INTERNAL_ASSERT(arg_idx < num_args);
+    const auto py_idx = static_cast<Py_ssize_t>(arg_idx);
+    PyObject* item = PyList_GET_ITEM(call_args.get(), py_idx);
+    if (!THPVariable_Check(item)) {
+      continue;
+    }
+    PyObject* detached = THPVariable_Wrap(THPVariable_Unpack(item).detach());
+    if (!detached) {
+      raise_python_error();
+    }
+    Py_DECREF(item);
+    PyList_SET_ITEM(call_args.get(), py_idx, detached);
+  }
+
+  return call_args;
+}
+
+PyObject* THPModule_aot_autograd_call_compiled_fn(
+    PyObject* _unused,
+    PyObject* const* args,
+    Py_ssize_t nargs) {
+  HANDLE_TH_ERRORS
+  TORCH_INTERNAL_ASSERT(nargs == 3);
+  TORCH_INTERNAL_ASSERT(Py_IS_TYPE(args[0], &CompiledFnCallSpecType));
+  const auto* spec = reinterpret_cast<CompiledFnCallSpec*>(args[0]);
+  PyObject* compiled_fn = args[1];
+  PyObject* boxed_args = args[2];
+
+  // Begin profiler range if profiler is enabled.
+  std::unique_ptr<at::RecordFunction> record_function;
+  if (spec->record_runtime_overhead &&
+      (torch::profiler::impl::ProfilerStateBase::getGlobal() != nullptr ||
+       torch::profiler::impl::ProfilerStateBase::getTLS() != nullptr)) {
+    record_function =
+        std::make_unique<at::RecordFunction>(at::RecordScope::FUNCTION);
+    record_function->before(
+        std::string_view("AOTDispatcher Runtime Wrapper Prologue"));
+  }
+
+  // Inputs needed by alias and mutation epilogues.
+  THPObjectPtr orig_inputs(
+      get_inputs_at_indices(boxed_args, spec->epilogue_args_idx));
+
+  increment_versions_at_indices(
+      boxed_args, spec->indices_of_inps_to_increment_version);
+
+  THPObjectPtr detached_args =
+      maybe_detach_at_indices(boxed_args, spec->indices_of_inps_to_detach);
+  PyObject* compiled_fn_args = detached_args ? detached_args.get() : boxed_args;
+
+  c10::AutoGradMode grad_mode(spec->trace_joint);
+  ViewReplayGuard view_replay_guard(spec->trace_joint);
+  record_function.reset();
+  std::optional<c10::impl::ExcludeDispatchKeyGuard> autocast_guard;
+  if (spec->disable_amp) {
+    autocast_guard.emplace(c10::autocast_dispatch_keyset);
+  }
+
+  PyObject* vectorcall_args[1] = {compiled_fn_args};
+  THPObjectPtr all_outs(
+      PyObject_Vectorcall(compiled_fn, vectorcall_args, 1, nullptr));
+  if (!all_outs) {
+    raise_python_error();
+  }
+
+  THPObjectPtr result(PyTuple_New(2));
+  if (!result) {
+    raise_python_error();
+  }
+  PyTuple_SET_ITEM(result.get(), 0, orig_inputs.release());
+  PyTuple_SET_ITEM(result.get(), 1, all_outs.release());
+  return result.release();
+  END_HANDLE_TH_ERRORS
+}
+
+static PyMethodDef aot_autograd_methods[] = {
+    {"_aot_autograd_call_compiled_fn",
+     reinterpret_cast<PyCFunction>(
+         reinterpret_cast<void (*)()>(THPModule_aot_autograd_call_compiled_fn)),
+     METH_FASTCALL,
+     nullptr},
+    {nullptr, nullptr, 0, nullptr}};
+
+} // namespace
+
+bool InitializeAOTAutogradHelpers(PyObject* module) {
+  CompiledFnCallSpecType.tp_new = CompiledFnCallSpec_new;
+  CompiledFnCallSpecType.tp_methods = CompiledFnCallSpec_methods;
+
+  if (PyModule_AddType(module, &CompiledFnCallSpecType) < 0) {
+    return false;
+  }
+  if (PyModule_AddFunctions(module, aot_autograd_methods) < 0) {
+    return false;
+  }
+  return true;
+}
+
+// NOLINTEND(hicpp-exception-baseclass)
+
+} // namespace torch::functorch::impl

--- a/torch/csrc/functorch/python_aot_autograd.h
+++ b/torch/csrc/functorch/python_aot_autograd.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <torch/csrc/python_headers.h>
+
+namespace torch::functorch::impl {
+
+bool InitializeAOTAutogradHelpers(PyObject* module);
+
+} // namespace torch::functorch::impl


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #190049

Move the AOTAutograd runtime-wrapper work before compiled_fn,
plus the compiled_fn call itself, into THPModule_aot_autograd_call_compiled_fn.
AOTAutograd builds a _CompiledFnCallSpec during wrapper codegen and passes the
closed-over spec to the helper at runtime.

This PR also changes first invocation handling: after the first invocation,
runtime_wrapper avoids constructing nullcontext.

This optimizes the FlexAttention hot path. On the repro, measuring from outer
runtime_wrapper entry to compiled_fn entry dropped from 6.336us / 35,822 instructions
to 2.272us / 20,512 instructions median. The 6.3/2.2 us are timing
in a hot loop.

In my non-hot-loop experiment where I use torch.profiler to look at
FlexAttention overhead e2e, the AOTAutograd time for this portion
goes from 40 -> 20us. I don't think the profiler is distorting the
timing so much, so I think we are actually saving more times than the
6->2us hot loop experiment would imply.

After this PR, the main overhead in AOTAutograd runtime for the
time-to-first-kernel benchmark is just autograd.Function overhead.

Authored with the assistance of an AI assistant.