### PR TITLE
[MPS] Compute integer abs exactly instead of through float32

### DIFF
--- a/aten/src/ATen/native/mps/kernels/UnaryKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/UnaryKernel.metal
@@ -101,16 +101,19 @@ struct sigmoid_functor {
 };
 
 struct abs_functor {
+  // precise:: has only float candidates, so bfloat converts unambiguously
+  // (unqualified abs is ambiguous for bfloat: float vs half), and abs is
+  // exact under the round trip. Integers must not take this path: the float
+  // conversion rounds above 2^24.
   template <
       typename T,
       enable_if_t<!is_complex_v<T> && !is_scalar_integral_v<T>, bool> = true>
   inline T operator()(const T x) {
     return static_cast<T>(precise::abs(x));
   }
-  // precise::abs is float-only; going through it rounds integers above 2^24.
   template <typename T, enable_if_t<is_scalar_integral_v<T>, bool> = true>
   inline T operator()(const T x) {
-    return x < 0 ? static_cast<T>(-x) : x;
+    return ::metal::abs(x);
   }
   template <typename T, enable_if_t<is_complex_v<T>, bool> = true>
   inline T operator()(const T x) {

--- a/aten/src/ATen/native/mps/kernels/UnaryKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/UnaryKernel.metal
@@ -101,9 +101,16 @@ struct sigmoid_functor {
 };
 
 struct abs_functor {
-  template <typename T, enable_if_t<!is_complex_v<T>, bool> = true>
+  template <
+      typename T,
+      enable_if_t<!is_complex_v<T> && !is_scalar_integral_v<T>, bool> = true>
   inline T operator()(const T x) {
     return static_cast<T>(precise::abs(x));
+  }
+  // precise::abs is float-only; going through it rounds integers above 2^24.
+  template <typename T, enable_if_t<is_scalar_integral_v<T>, bool> = true>
+  inline T operator()(const T x) {
+    return x < 0 ? static_cast<T>(-x) : x;
   }
   template <typename T, enable_if_t<is_complex_v<T>, bool> = true>
   inline T operator()(const T x) {

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -7326,6 +7326,19 @@ class TestMPS(TestCaseMPS):
 
         helper((2, 8, 4, 5))
 
+    # Regression test for https://github.com/pytorch/pytorch/issues/190052:
+    # integer abs went through float32 and rounded magnitudes above 2**24.
+    def test_abs_large_integers(self):
+        for dtype, vals in [
+            (torch.int32, [-(2**24 + 1), 2**24 + 1, -(2**24 + 3), -(2**31 - 1)]),
+            (torch.int64, [-(2**24 + 1), -(2**33 + 7), -(2**62 + 12345), -(2**63 - 1)]),
+            (torch.int16, [-32767, -128, 0, 127]),
+            (torch.uint8, [0, 1, 255]),
+        ]:
+            with self.subTest(dtype=dtype):
+                a = torch.tensor(vals, dtype=dtype)
+                self.assertEqual(torch.abs(a.to('mps')).cpu(), torch.abs(a))
+
     def test_angle(self):
         def helper(shape, dtype):
             cpu_x = torch.randn(shape, device='cpu', dtype=dtype, requires_grad=False)


### PR DESCRIPTION
The abs functor applied Metal's float-only `precise::abs` to every non-complex dtype, implicitly converting integers to float32 and back. Any magnitude above 2^24 silently rounded: int32 broke immediately above 16,777,216 (including `abs(x) != x` for positive x), and int64 corruption grew with magnitude, up to `abs(-(2^63 - 1))` returning `-2^63`. Add an integral overload that negates directly.

The new `test_abs_large_integers` covers int32/int64 values above the 2^24 boundary (including INT64_MAX magnitude), int16, and uint8 against CPU. All abs tests pass.

Fixes #190052

*This PR was authored with assistance from Claude.*
