### PR TITLE
[MPS] Support mixed-dtype affine params in layer_norm forward and backward

### DIFF
--- a/aten/src/ATen/native/mps/operations/Normalization.mm
+++ b/aten/src/ATen/native/mps/operations/Normalization.mm
@@ -948,12 +948,19 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_mps(const Tensor& input,
   const Tensor& weight = *weight_maybe_owned;
   c10::MaybeOwned<Tensor> bias_maybe_owned = at::borrow_from_optional_tensor(bias_opt);
   const Tensor& bias = *bias_maybe_owned;
-  auto bias_contig = bias.expect_contiguous();
 
   auto M_N = _check_layer_norm_inputs(input, normalized_shape, weight, bias);
   auto M = M_N.first;
   auto X = input.expect_contiguous();
-  auto gamma = weight.expect_contiguous();
+  // The Metal kernels bind gamma/beta at the input dtype, so mixed-dtype
+  // affine params (e.g. fp32 gamma/beta with an fp16 input, the
+  // keep-LayerNorm-in-fp32 recipe) must be cast, not reinterpreted.
+  const Tensor weight_cast =
+      weight.defined() && weight.scalar_type() != input.scalar_type() ? weight.to(input.scalar_type()) : weight;
+  const Tensor bias_cast =
+      bias.defined() && bias.scalar_type() != input.scalar_type() ? bias.to(input.scalar_type()) : bias;
+  auto bias_contig = bias_cast.expect_contiguous();
+  auto gamma = weight_cast.expect_contiguous();
   auto mean = at::empty(batch_shape, input.options(), MemoryFormat::Contiguous);
   auto rstd = at::empty(batch_shape, input.options(), MemoryFormat::Contiguous);
 
@@ -1139,18 +1146,24 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_backward_mps(const Tensor& grad_ou
       for (const auto i : c10::irange(num_normalized_dims))
         bn_gamma_shape[i + 2] = input_shape[i + num_channel_dims];
 
-      std::string key = fmt::format("layer_norm_backward_mps:{}:{}:{}:{}:{}",
+      std::string key = fmt::format("layer_norm_backward_mps:{}:{}:{}:{}:{}:{}:{}",
                                     has_weight,
                                     getArrayRefString(normalized_shape),
                                     getArrayRefString((*X).sizes()),
                                     c10::Join(",", grad_input_mask),
-                                    getMPSTypeString(*X));
+                                    getMPSTypeString(*X),
+                                    has_weight ? getMPSTypeString(*gamma) : "",
+                                    bias.defined() ? getMPSTypeString(*beta) : "");
       auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
         MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, *X);
         MPSGraphTensor* gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, *dOut);
         MPSGraphTensor* weightTensor = nil;
         if (has_weight)
           weightTensor = mpsGraphRankedPlaceHolder(mpsGraph, *gamma);
+        // Compute in the input dtype; MPSGraph rejects mixed-dtype arithmetic
+        // (fp32 gamma with an fp16 input asserts inside the MLIR verifier).
+        MPSGraphTensor* weightComputeTensor =
+            has_weight ? castMPSTensor(mpsGraph, weightTensor, getMPSDataType(*X)) : nil;
 
         // Mean and inv std tensors to be saved and returned
         MPSGraphTensor* meanTensor = mpsGraphRankedPlaceHolder(mpsGraph, mean);
@@ -1184,7 +1197,9 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_backward_mps(const Tensor& grad_ou
           MPSGraphTensor* bnGradOutputTensor = [mpsGraph reshapeTensor:gradOutputTensor withShape:bn_shape name:nil];
           // Do this at the end
           if (has_weight) {
-            MPSGraphTensor* bnGammaTensor = [mpsGraph reshapeTensor:weightTensor withShape:bn_gamma_shape name:nil];
+            MPSGraphTensor* bnGammaTensor = [mpsGraph reshapeTensor:weightComputeTensor
+                                                          withShape:bn_gamma_shape
+                                                               name:nil];
             bnGradOutputTensor = [mpsGraph multiplicationWithPrimaryTensor:bnGradOutputTensor
                                                            secondaryTensor:bnGammaTensor
                                                                       name:nil];
@@ -1256,11 +1271,17 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_backward_mps(const Tensor& grad_ou
           gradInputTensor = [mpsGraph reshapeTensor:gradient withShape:input_shape name:nil];
         }
 
+        // Gradients are computed in the input dtype; return them in the
+        // affine params' dtype like CPU does.
         if (grad_input_mask[1]) {
-          gradWeightTensor = [mpsGraph reshapeTensor:gradWeightTensor withShape:gamma_shape name:nil];
+          gradWeightTensor = [mpsGraph reshapeTensor:castMPSTensor(mpsGraph, gradWeightTensor, getMPSDataType(*gamma))
+                                           withShape:gamma_shape
+                                                name:nil];
         }
         if (grad_input_mask[2]) {
-          gradBiasTensor = [mpsGraph reshapeTensor:gradBiasTensor withShape:gamma_shape name:nil];
+          gradBiasTensor = [mpsGraph reshapeTensor:castMPSTensor(mpsGraph, gradBiasTensor, getMPSDataType(*beta))
+                                         withShape:gamma_shape
+                                              name:nil];
         }
 
         newCachedGraph->gradOutputTensor_ = gradOutputTensor;

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -2306,6 +2306,29 @@ class TestMPS(TestCaseMPS):
         self.assertEqual(mps_w.cpu(), cpu_w)
         self.assertEqual(mps_b.cpu(), cpu_b)
 
+    # Regression test for https://github.com/pytorch/pytorch/issues/190054:
+    # fp32 gamma/beta with an fp16/bf16 input was reinterpreted at the input
+    # dtype in forward, and backward aborted in the MPSGraph verifier.
+    def test_layer_norm_mixed_dtype_affine(self):
+        for in_dtype in (torch.float16, torch.bfloat16):
+            with self.subTest(dtype=in_dtype):
+                x_cpu = torch.randn(4, 8, dtype=in_dtype, requires_grad=True)
+                w_cpu = torch.randn(8, dtype=torch.float32, requires_grad=True)
+                b_cpu = torch.randn(8, dtype=torch.float32, requires_grad=True)
+                out_cpu = torch.nn.functional.layer_norm(x_cpu, (8,), w_cpu, b_cpu)
+                out_cpu.backward(torch.ones_like(out_cpu))
+
+                x = x_cpu.detach().clone().to('mps').requires_grad_()
+                w = w_cpu.detach().clone().to('mps').requires_grad_()
+                b = b_cpu.detach().clone().to('mps').requires_grad_()
+                out = torch.nn.functional.layer_norm(x, (8,), w, b)
+                out.backward(torch.ones_like(out))
+
+                self.assertEqual(out.cpu(), out_cpu, atol=2e-2, rtol=2e-2)
+                self.assertEqual(x.grad.cpu(), x_cpu.grad, atol=2e-2, rtol=2e-2)
+                self.assertEqual(w.grad.cpu(), w_cpu.grad, atol=2e-2, rtol=2e-2)
+                self.assertEqual(b.grad.cpu(), b_cpu.grad, atol=2e-2, rtol=2e-2)
+
     def test_norm(self):
         a = torch.arange(9, dtype=torch.float, device="mps") - 4
         b = a.reshape((3, 3))


### PR DESCRIPTION
The forward Metal kernels bind gamma/beta at the input dtype, so fp32 affine params with an fp16/bf16 input were reinterpreted bitwise, producing garbage (max err `inf` for fp16, ~1e31 for bf16). For backward, MPSGraph rejects the mixed-dtype multiply and its MLIR verifier assertion **aborts the process**. CPU and CUDA both support this combination natively (the `is_mixed_type` handling in `layer_norm.cpp`).

Scope note: autocast is not affected, since `KERNEL_MPS(layer_norm, fp32)` upcasts the input first, and a fully-half model is not affected either (uniform dtypes). The mixed call happens in manual mixed-precision flows that keep norm affine params in fp32 while the model runs in bf16/fp16 (e.g. HF `_keep_in_fp32_modules`), the same path the native CPU/CUDA mixed-dtype support exists for.

Cast gamma/beta to the input dtype before binding in forward, and in backward cast the weight placeholder for compute and the weight/bias gradients back to the params' dtype, mirroring what the batch_norm paths in the same file already do with `castMPSTensor`. The backward graph cache key gains the affine dtypes, since the casts are baked into the graph; without that, a mixed call and a uniform call at the same shapes would share a cached graph.

The new test runs forward and backward for fp16 and bf16 inputs with fp32 affine params and compares outputs and all three gradients against CPU. The 15 pre-existing layer_norm tests and the broader norm suite (132) pass.

Fixes #190054

*This PR was authored with assistance from Claude.*
