### PR TITLE
Fix gaussian_nll_loss eps docstring: it clamps var, not adds

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3323,7 +3323,7 @@ def gaussian_nll_loss(
             in the input (heteroscedastic), or a single one (homoscedastic),
             or a positive scalar value to be used for all expectations.
         full (bool, optional): Whether to include the constant term in the loss calculation. Default: ``False``.
-        eps (float, optional): Value added to var, for stability. Default: 1e-6.
+        eps (float, optional): Value used to clamp ``var`` to a minimum, for stability. Default: 1e-6.
         reduction (str, optional): Specifies the reduction to apply to the output:
             ``'none'`` | ``'mean'`` | ``'sum'``. ``'none'``: no reduction will be applied,
             ``'mean'``: the output is the average of all batch member losses,


### PR DESCRIPTION
### Summary

`torch.nn.functional.gaussian_nll_loss` documents `eps` as:

> eps (float, optional): Value added to var, for stability. Default: 1e-6.

but the implementation clamps the variance to a floor rather than adding `eps`:

```python
var.clamp_(min=eps)   # i.e. max(var, eps)
```

So the loss tracks `max(var, eps)`, not `var + eps`. Quick check on 2.11 (input == target == 0, so `loss == 0.5 * log(effective_var)`):

```
v=4.0,  eps=1.0 -> loss=0.693147  (== 0.5*log(max(4, 1))=0.693147, not 0.5*log(4+1)=0.804719)
v=0.25, eps=1.0 -> loss=0.000000  (== 0.5*log(max(0.25, 1))=0.0,     not 0.5*log(0.25+1)=0.111572)
```

The sibling module `torch.nn.GaussianNLLLoss` already documents this correctly ("value used to clamp `var`"). This updates the functional docstring to match both the code and the module docstring.

### Change

```
-        eps (float, optional): Value added to var, for stability. Default: 1e-6.
+        eps (float, optional): Value used to clamp ``var`` to a minimum, for stability. Default: 1e-6.
```

Documentation only; no functional change.
