### PR TITLE
[MPS] Apply inter-layer dropout in LSTM backward and fix dropout=1 NaN

### DIFF
--- a/aten/src/ATen/native/mps/operations/RnnOps.mm
+++ b/aten/src/ATen/native/mps/operations/RnnOps.mm
@@ -146,6 +146,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor, Tensor> _lstm_mps(const Tenso
       NSMutableArray<MPSGraphTensor*>* kernelBiasList = [[NSMutableArray alloc] initWithCapacity:params.size()];
       NSMutableArray<MPSGraphTensor*>* recurrentBiasList = [[NSMutableArray alloc] initWithCapacity:params.size()];
       NSMutableArray<MPSGraphTensor*>* layersOutputsList = [[NSMutableArray alloc] initWithCapacity:num_layers];
+      NSMutableArray<MPSGraphTensor*>* dropoutMasksList = [[NSMutableArray alloc] initWithCapacity:num_layers];
 
       for (const auto i : c10::irange(total_layers)) {
         [kernelWeightsList
@@ -216,11 +217,6 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor, Tensor> _lstm_mps(const Tenso
                                             name:nil];
 
         inputTensor_ = [outputs objectAtIndex:0];
-        // no need to keep the final layer output copy as it is
-        // returned anyway and not used in backprop
-        if (i != num_layers - 1) {
-          [layersOutputsList addObject:[mpsGraph expandDimsOfTensor:inputTensor_ axis:0 name:nil]];
-        }
         if (apply_dropout && (i != num_layers - 1)) {
           // MPSGraph's dropoutTensor:rate:name: has no seed input, so the
           // cached graph reuses the same mask on every forward. This builds
@@ -245,11 +241,21 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor, Tensor> _lstm_mps(const Tenso
                                                                      secondaryTensor:threshold
                                                                                 name:nil];
           MPSGraphTensor* keepMaskCast = [mpsGraph castTensor:keepMask toType:inputDType name:nil];
-          MPSGraphTensor* invKeepProb = [mpsGraph constantWithScalar:(1.0 / (1.0 - dropout_p)) dataType:inputDType];
+          // dropout_p == 1 keeps nothing; 1/(1-p) would be inf and 0*inf NaN.
+          MPSGraphTensor* invKeepProb = [mpsGraph constantWithScalar:(dropout_p >= 1.0 ? 0.0 : 1.0 / (1.0 - dropout_p))
+                                                            dataType:inputDType];
           MPSGraphTensor* scaledMask = [mpsGraph multiplicationWithPrimaryTensor:keepMaskCast
                                                                  secondaryTensor:invKeepProb
                                                                             name:nil];
           inputTensor_ = [mpsGraph multiplicationWithPrimaryTensor:inputTensor_ secondaryTensor:scaledMask name:nil];
+          [dropoutMasksList addObject:[mpsGraph expandDimsOfTensor:scaledMask axis:0 name:nil]];
+        }
+        // Save what the next layer actually consumes (post-dropout); backward
+        // uses it as that layer's source tensor and, with the masks appended
+        // after the outputs below, routes gradients through the dropout. The
+        // final layer's output is returned anyway and not used in backprop.
+        if (i != num_layers - 1) {
+          [layersOutputsList addObject:[mpsGraph expandDimsOfTensor:inputTensor_ axis:0 name:nil]];
         }
 
         if (bidirectional) {
@@ -305,6 +311,11 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor, Tensor> _lstm_mps(const Tenso
       MPSGraphTensor* outputCellStates = [mpsGraph concatTensors:outputCellStateArray dimension:0 name:nil];
       MPSGraphTensor* outputZStates = [mpsGraph concatTensors:outputZStateArray dimension:0 name:nil];
       MPSGraphTensor* outputCellStatesFwd = [mpsGraph concatTensors:outputCellStateFwdArray dimension:0 name:nil];
+      // With dropout, the scaled masks are stacked after the (num_layers - 1)
+      // post-dropout layer outputs; backward slices them back out.
+      if (apply_dropout) {
+        [layersOutputsList addObjectsFromArray:dropoutMasksList];
+      }
       MPSGraphTensor* layersOutputs =
           (num_layers > 1) ? [mpsGraph concatTensors:layersOutputsList dimension:0 name:nil] : nil;
 
@@ -464,10 +475,12 @@ std::tuple<Tensor, std::vector<Tensor>, std::vector<Tensor>> lstm_mps_backward(c
   // Get stream
   MPSStream* stream = getCurrentMPSStream();
   @autoreleasepool {
+    const bool apply_dropout = dropout_p > 0.0 && train && num_layers > 1;
     std::string key = "lstm_backward_" +
         getTensorsStringKey({input, z_state, cell_state_fwd, grad_y, grad_cy, grad_hy}) + getMPSTypeString(input) +
         "_num_layers_" + std::to_string(num_layers) + "_bidirectional_" + std::to_string(bidirectional) +
-        "_has_biases_" + std::to_string(has_biases) + "_batch_first_" + std::to_string(batch_first);
+        "_has_biases_" + std::to_string(has_biases) + "_batch_first_" + std::to_string(batch_first) + "_dropout_" +
+        std::to_string(dropout_p) + "_train_" + std::to_string(train);
     auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
       NSMutableArray<MPSGraphTensor*>* kernelWeightsList = [[NSMutableArray alloc] initWithCapacity:params.size()];
       NSMutableArray<MPSGraphTensor*>* recurrentKernelWeightsList =
@@ -579,14 +592,10 @@ std::tuple<Tensor, std::vector<Tensor>, std::vector<Tensor>> lstm_mps_backward(c
         if (i == 0) {
           iterationInputTensor_ = inputTensor;
         } else {
-          iterationInputTensor_ = [mpsGraph sliceTensor:layersOutputsTensor
-                                              dimension:0
-                                                  // the last element in layersOutputsTensor
-                                                  // contains **inputs** for the **last** layer
-                                                  // and so on
-                                                  start:i - num_layers
-                                                 length:1
-                                                   name:nil];
+          // Entry j holds the (post-dropout) input to layer j + 1; with
+          // dropout, the scaled masks follow after entry num_layers - 2, so
+          // index from the front rather than the end.
+          iterationInputTensor_ = [mpsGraph sliceTensor:layersOutputsTensor dimension:0 start:i - 1 length:1 name:nil];
           if (is_macos_14_4_or_newer) {
             // Prevents shape optimization bug in kernel when num_layers > 2
             iterationInputTensor_ = [mpsGraph identityWithTensor:iterationInputTensor_ name:nil];
@@ -611,6 +620,23 @@ std::tuple<Tensor, std::vector<Tensor>, std::vector<Tensor>> lstm_mps_backward(c
                                                      name:nil];
 
         gradientTensor_ = [outputs objectAtIndex:0];
+        if (apply_dropout && i > 0) {
+          // The gradient just computed is w.r.t. layer i's post-dropout
+          // input; multiply by the scaled mask saved by forward to get the
+          // gradient w.r.t. layer i-1's raw output.
+          MPSGraphTensor* maskTensor = [mpsGraph sliceTensor:layersOutputsTensor
+                                                   dimension:0
+                                                       start:(num_layers - 1) + (i - 1)
+                                                      length:1
+                                                        name:nil];
+          if (is_macos_14_4_or_newer) {
+            maskTensor = [mpsGraph identityWithTensor:maskTensor name:nil];
+          }
+          maskTensor = [mpsGraph squeezeTensor:maskTensor axis:0 name:nil];
+          gradientTensor_ = [mpsGraph multiplicationWithPrimaryTensor:gradientTensor_
+                                                      secondaryTensor:maskTensor
+                                                                 name:nil];
+        }
         if (bidirectional) {
           int outputIter = 1;
           auto gradRecWeightsBidirectional = [outputs objectAtIndex:outputIter++];

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -15036,6 +15036,57 @@ class TestRNNMPS(TestCaseMPS):
             for test_options in self.LSTM_TEST_CASES:
                 self._lstm_helper(num_layers=num_layers, dtype=dtype, device=device, backward=True, **test_options)
 
+    # Regression test for https://github.com/pytorch/pytorch/issues/190057:
+    # dropout=1.0 produced 0 * inf = NaN between layers.
+    def test_lstm_dropout_one(self):
+        torch.manual_seed(0)
+        lstm_cpu = nn.LSTM(4, 4, num_layers=2, dropout=1.0)
+        x = torch.randn(3, 2, 4)
+        out_cpu, _ = lstm_cpu(x)
+        out_mps, _ = copy.deepcopy(lstm_cpu).to("mps")(x.to("mps"))
+        # dropout=1 zeroes the inter-layer input deterministically on both
+        self.assertEqual(out_mps.cpu(), out_cpu)
+
+    # Regression test for https://github.com/pytorch/pytorch/issues/190056:
+    # backward ignored the inter-layer dropout mask. Resetting the device RNG
+    # before every forward pins the mask, making central differences valid.
+    def test_lstm_dropout_backward_matches_finite_differences(self):
+        torch.manual_seed(0)
+        lstm = nn.LSTM(4, 4, num_layers=2, dropout=0.5).to("mps")
+        lstm.train()
+
+        def loss(x):
+            torch.mps.manual_seed(42)
+            out, _ = lstm(x)
+            return out.sum()
+
+        x = torch.randn(3, 2, 4, device="mps", requires_grad=True)
+        loss(x).backward()
+        eps = 1e-2
+
+        for flat_idx in (0, 5, 17):
+            analytic = x.grad.flatten()[flat_idx].item()
+            with torch.no_grad():
+                xp = x.detach().clone()
+                xp.flatten()[flat_idx] += eps
+                xm = x.detach().clone()
+                xm.flatten()[flat_idx] -= eps
+                numeric = ((loss(xp) - loss(xm)) / (2 * eps)).item()
+            self.assertEqual(analytic, numeric, atol=2e-3, rtol=5e-2,
+                             msg=f"input grad mismatch at flat index {flat_idx}")
+
+        # layer-0 weight gradient only reaches the loss through the mask
+        w = lstm.weight_ih_l0
+        analytic_w = w.grad.flatten()[0].item()
+        with torch.no_grad():
+            orig = w.flatten()[0].item()
+            w.flatten()[0] += eps
+            lp = loss(x.detach()).item()
+            w.flatten()[0] = orig - eps
+            lm = loss(x.detach()).item()
+            w.flatten()[0] = orig
+        self.assertEqual(analytic_w, (lp - lm) / (2 * eps), atol=2e-3, rtol=5e-2)
+
     def test_lstm_eval_after_train_same_shape(self):
         # Regression test for https://github.com/pytorch/pytorch/issues/180744
         # The MPS LSTM graph cache key did not include the `train` flag, so a


### PR DESCRIPTION
Forward saved each layer's output *before* applying inter-layer dropout, and backward consumed those unmasked tensors with `mask:nil`, so gradients were computed as if no dropout had happened. Against fixed-RNG central differences (reseeding the device RNG per forward pins the mask), a two-layer `dropout=0.5` LSTM showed 98% relative error on the input gradient, while the `dropout=0` control matched to 0.0%.

Forward now saves the post-dropout tensor (what the next layer actually consumed) and stacks the scaled dropout masks after the layer outputs inside the existing `layersOutputs` tensor, avoiding a schema change; the private forward/backward pair agree on the layout. Backward slices the masks back out and multiplies the inter-layer gradient. The input slices switch from end-relative to front-relative indexing (the tensor's first dimension doubles when dropout is active), and the backward graph key gains dropout/train.

Separately, the dropout scale was built unconditionally as `1/(1-p)`, so `dropout=1.0` produced `0 * inf = NaN` for every output element; the scale is now 0 at p=1, matching the defined zero-inter-layer-input behavior (new test compares against CPU, which is deterministic at p=1).

After the fix the finite-difference check matches to 0.08% relative error. The pre-existing RNN suite passes.

Fixes #190056
Fixes #190057

*This PR was authored with assistance from Claude.*

