### PR TITLE
[MPS] Implement true adaptive max pooling

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Pooling.h
+++ b/aten/src/ATen/native/mps/kernels/Pooling.h
@@ -59,3 +59,14 @@ struct MaxUnpoolingParams {
   ::c10::metal::array<idx_type_t, N> output_strides;
   ::c10::metal::array<idx_type_t, N> indices_strides;
 };
+
+// Both sides are contiguous NCHW; the host copies through contiguous
+// temporaries otherwise.
+template <typename idx_type_t = int32_t>
+struct AdaptiveMaxPoolParams {
+  idx_type_t plane_count; // N * C
+  idx_type_t input_h;
+  idx_type_t input_w;
+  idx_type_t output_h;
+  idx_type_t output_w;
+};

--- a/aten/src/ATen/native/mps/kernels/Pooling.metal
+++ b/aten/src/ATen/native/mps/kernels/Pooling.metal
@@ -763,6 +763,95 @@ kernel void avg_pool_backward(
       params.divisor_override);
 }
 
+// Adaptive max pooling: one thread per output element. The window for output
+// position o along a dim of input size I and output size O is
+// [floor(o * I / O), ceil((o + 1) * I / O)), so windows vary in size and may
+// overlap for non-divisible geometry. Indices are flattened over the input
+// plane, like max_pool2d. Input offsets use 64-bit math: the input can exceed
+// 2^31 elements even when the output is small.
+template <typename T>
+kernel void adaptive_max_pool2d(
+    constant T* input [[buffer(0)]],
+    device T* output [[buffer(1)]],
+    device int64_t* indices [[buffer(2)]],
+    constant AdaptiveMaxPoolParams<>& params [[buffer(3)]],
+    uint tid [[thread_position_in_grid]]) {
+  const auto input_h = params.input_h;
+  const auto input_w = params.input_w;
+  const auto output_h = params.output_h;
+  const auto output_w = params.output_w;
+
+  const auto out_plane_area = int64_t(output_h) * output_w;
+  const auto plane = int64_t(tid) / out_plane_area;
+  const auto rem = int32_t(int64_t(tid) % out_plane_area);
+  const int32_t oh = rem / output_w;
+  const int32_t ow = rem % output_w;
+
+  const auto h0 = int32_t((int64_t(oh) * input_h) / output_h);
+  const auto h1 =
+      int32_t(((int64_t(oh) + 1) * input_h + output_h - 1) / output_h);
+  const auto w0 = int32_t((int64_t(ow) * input_w) / output_w);
+  const auto w1 =
+      int32_t(((int64_t(ow) + 1) * input_w + output_w - 1) / output_w);
+
+  constant T* input_plane = input + plane * (int64_t(input_h) * input_w);
+  auto max_val = input_plane[int64_t(h0) * input_w + w0];
+  auto max_index = int64_t(h0) * input_w + w0;
+
+  for (auto h = h0; h < h1; h++) {
+    for (auto w = w0; w < w1; w++) {
+      const auto index = int64_t(h) * input_w + w;
+      const T val = input_plane[index];
+      // NaN propagates and the first NaN encountered wins, matching CPU.
+      if (!isnan(static_cast<float>(max_val)) &&
+          (isnan(static_cast<float>(val)) || val > max_val)) {
+        max_val = val;
+        max_index = index;
+      }
+    }
+  }
+
+  output[tid] = max_val;
+  indices[tid] = max_index;
+}
+
+// One thread per grad_output element; windows can overlap, so different
+// output positions may route into the same input element.
+template <typename T>
+kernel void adaptive_max_pool2d_backward(
+    device AtomicType_t<T>* grad_input [[buffer(0)]],
+    constant T* grad_output [[buffer(1)]],
+    constant int64_t* indices [[buffer(2)]],
+    constant AdaptiveMaxPoolParams<>& params [[buffer(3)]],
+    uint tid [[thread_position_in_grid]]) {
+  const auto out_plane_area = int64_t(params.output_h) * params.output_w;
+  const auto plane = int64_t(tid) / out_plane_area;
+  const auto input_offset =
+      plane * (int64_t(params.input_h) * params.input_w) + indices[tid];
+  AtomicType<T>::atomic_add(grad_input, input_offset, grad_output[tid]);
+}
+
+#define REGISTER_ADAPTIVE_MAX_POOL_OP(DTYPE)                     \
+  template [[host_name("adaptive_max_pool2d_" #DTYPE)]]          \
+  kernel void adaptive_max_pool2d<DTYPE>(                        \
+      constant DTYPE * input [[buffer(0)]],                      \
+      device DTYPE * output [[buffer(1)]],                       \
+      device int64_t* indices [[buffer(2)]],                     \
+      constant AdaptiveMaxPoolParams<>& params [[buffer(3)]],    \
+      uint tid [[thread_position_in_grid]]);                     \
+                                                                 \
+  template [[host_name("adaptive_max_pool2d_backward_" #DTYPE)]] \
+  kernel void adaptive_max_pool2d_backward<DTYPE>(               \
+      device AtomicType_t<DTYPE> * grad_input [[buffer(0)]],     \
+      constant DTYPE * grad_output [[buffer(1)]],                \
+      constant int64_t* indices [[buffer(2)]],                   \
+      constant AdaptiveMaxPoolParams<>& params [[buffer(3)]],    \
+      uint tid [[thread_position_in_grid]]);
+
+REGISTER_ADAPTIVE_MAX_POOL_OP(float);
+REGISTER_ADAPTIVE_MAX_POOL_OP(half);
+REGISTER_ADAPTIVE_MAX_POOL_OP(bfloat);
+
 #define REGISTER_POOL_OP(DTYPE)                                               \
   template [[host_name("max_pool_" #DTYPE)]] kernel void max_pool<DTYPE>(     \
       constant DTYPE * input [[buffer(0)]],                                   \

--- a/aten/src/ATen/native/mps/operations/AdaptivePooling.mm
+++ b/aten/src/ATen/native/mps/operations/AdaptivePooling.mm
@@ -11,12 +11,8 @@
 #include <ATen/ops/_adaptive_avg_pool2d_native.h>
 #include <ATen/ops/adaptive_avg_pool2d.h>
 #include <ATen/ops/adaptive_avg_pool2d_native.h>
-#include <ATen/ops/adaptive_max_pool2d_backward_native.h>
-#include <ATen/ops/adaptive_max_pool2d_native.h>
 #include <ATen/ops/avg_pool2d.h>
 #include <ATen/ops/avg_pool2d_backward.h>
-#include <ATen/ops/max_pool2d_with_indices.h>
-#include <ATen/ops/max_pool2d_with_indices_backward.h>
 #include <ATen/ops/mul.h>
 #include <ATen/ops/ones_like.h>
 #endif
@@ -178,61 +174,6 @@ Tensor adaptive_avg_pool2d_backward_mps(const Tensor& gradOutput, const Tensor& 
   return gradInput;
 }
 
-// Adaptive max pooling
-TORCH_IMPL_FUNC(adaptive_max_pool2d_out_mps)
-(const Tensor& input, IntArrayRef output_size, const Tensor& output, const Tensor& indices) {
-  for (int64_t i = 1; i < input.ndimension(); i++) {
-    TORCH_CHECK(input.size(i) > 0,
-                "adaptive_max_pool2d(): Expected input to have non-zero size for non-batch dimensions, "
-                "but input has sizes ",
-                input.sizes(),
-                " with dimension ",
-                i,
-                " being "
-                "empty");
-  }
-
-  int64_t isizeH = input.size(-2);
-  int64_t isizeW = input.size(-1);
-  int64_t osizeH = output_size[0];
-  int64_t osizeW = output_size[1];
-
-  int64_t strideH = 0, strideW = 0;
-  int64_t kernel_sizeH = 0, kernel_sizeW = 0;
-
-  mps::set_kernel_params(isizeH, isizeW, osizeH, osizeW, strideH, strideW, kernel_sizeH, kernel_sizeW);
-
-  at::max_pool2d_with_indices_out(const_cast<Tensor&>(output),
-                                  const_cast<Tensor&>(indices),
-                                  input,
-                                  IntArrayRef({kernel_sizeH, kernel_sizeW}),
-                                  IntArrayRef({strideH, strideW}),
-                                  IntArrayRef({0, 0}),
-                                  IntArrayRef({1, 1}),
-                                  false);
-}
-
-TORCH_IMPL_FUNC(adaptive_max_pool2d_backward_out_mps)
-(const Tensor& gradOutput, const Tensor& input, const Tensor& indices, const Tensor& gradInput) {
-  int64_t isizeH = input.size(-2);
-  int64_t isizeW = input.size(-1);
-  int64_t osizeH = gradOutput.size(-2);
-  int64_t osizeW = gradOutput.size(-1);
-
-  int64_t strideH = 0, strideW = 0;
-  int64_t kernel_sizeH = 0, kernel_sizeW = 0;
-
-  mps::set_kernel_params(isizeH, isizeW, osizeH, osizeW, strideH, strideW, kernel_sizeH, kernel_sizeW);
-
-  at::max_pool2d_with_indices_backward_out(const_cast<Tensor&>(gradInput),
-                                           gradOutput,
-                                           input,
-                                           IntArrayRef({kernel_sizeH, kernel_sizeW}),
-                                           IntArrayRef({strideH, strideW}),
-                                           IntArrayRef({0, 0}),
-                                           IntArrayRef({1, 1}),
-                                           false,
-                                           indices);
-}
+// Adaptive max pooling lives in Pooling.mm, next to its Metal kernels.
 
 } // namespace at::native

--- a/aten/src/ATen/native/mps/operations/Pooling.mm
+++ b/aten/src/ATen/native/mps/operations/Pooling.mm
@@ -9,6 +9,8 @@
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
 #else
+#include <ATen/ops/adaptive_max_pool2d_backward_native.h>
+#include <ATen/ops/adaptive_max_pool2d_native.h>
 #include <ATen/ops/aminmax.h>
 #include <ATen/ops/avg_pool2d.h>
 #include <ATen/ops/avg_pool2d_backward.h>
@@ -1316,6 +1318,92 @@ TORCH_IMPL_FUNC(avg_pool3d_backward_out_mps)(const Tensor& grad_output,
                                           divisor_override,
                                           /*pooling_dims=*/3,
                                           "avg_pool3d_backward");
+}
+
+TORCH_IMPL_FUNC(adaptive_max_pool2d_out_mps)
+(const Tensor& input, IntArrayRef output_size, const Tensor& output, const Tensor& indices) {
+  using namespace mps;
+  for (int64_t i = 1; i < input.ndimension(); i++) {
+    TORCH_CHECK(input.size(i) > 0,
+                "adaptive_max_pool2d(): Expected input to have non-zero size for non-batch dimensions, "
+                "but input has sizes ",
+                input.sizes(),
+                " with dimension ",
+                i,
+                " being empty");
+  }
+  if (output.numel() == 0) {
+    return;
+  }
+
+  auto input_c = input.contiguous();
+  AdaptiveMaxPoolParams<> params;
+  params.input_h = safe_downcast<int32_t, int64_t>(input.size(-2));
+  params.input_w = safe_downcast<int32_t, int64_t>(input.size(-1));
+  params.output_h = safe_downcast<int32_t, int64_t>(output_size[0]);
+  params.output_w = safe_downcast<int32_t, int64_t>(output_size[1]);
+  params.plane_count = safe_downcast<int32_t, int64_t>(input.numel() / (input.size(-2) * input.size(-1)));
+
+  const bool out_contig = output.is_contiguous();
+  const bool idx_contig = indices.is_contiguous();
+  Tensor out_c = out_contig ? output : at::empty_like(output, MemoryFormat::Contiguous);
+  Tensor idx_c = idx_contig ? indices : at::empty_like(indices, MemoryFormat::Contiguous);
+
+  MPSStream* stream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      auto computeEncoder = stream->commandEncoder();
+      auto pso = lib.getPipelineStateForFunc("adaptive_max_pool2d_" + scalarToMetalTypeString(input));
+      getMPSProfiler().beginProfileKernel(pso, "adaptive_max_pool2d", {input});
+      [computeEncoder setComputePipelineState:pso];
+      mtl_setArgs(computeEncoder, input_c, out_c, idx_c, params);
+      mtl_dispatch1DJob(computeEncoder, pso, out_c.numel());
+      getMPSProfiler().endProfileKernel(pso);
+    }
+  });
+  if (!out_contig) {
+    output.copy_(out_c);
+  }
+  if (!idx_contig) {
+    indices.copy_(idx_c);
+  }
+}
+
+TORCH_IMPL_FUNC(adaptive_max_pool2d_backward_out_mps)
+(const Tensor& gradOutput, const Tensor& input, const Tensor& indices, const Tensor& gradInput) {
+  using namespace mps;
+  if (gradInput.numel() == 0) {
+    return;
+  }
+
+  auto grad_output_c = gradOutput.contiguous();
+  auto indices_c = indices.contiguous();
+  AdaptiveMaxPoolParams<> params;
+  params.input_h = safe_downcast<int32_t, int64_t>(input.size(-2));
+  params.input_w = safe_downcast<int32_t, int64_t>(input.size(-1));
+  params.output_h = safe_downcast<int32_t, int64_t>(gradOutput.size(-2));
+  params.output_w = safe_downcast<int32_t, int64_t>(gradOutput.size(-1));
+  params.plane_count = safe_downcast<int32_t, int64_t>(input.numel() / (input.size(-2) * input.size(-1)));
+
+  const bool gi_contig = gradInput.is_contiguous();
+  Tensor gi_c = gi_contig ? gradInput : at::empty_like(gradInput, MemoryFormat::Contiguous);
+  gi_c.zero_();
+
+  MPSStream* stream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      auto computeEncoder = stream->commandEncoder();
+      auto pso = lib.getPipelineStateForFunc("adaptive_max_pool2d_backward_" + scalarToMetalTypeString(gradOutput));
+      getMPSProfiler().beginProfileKernel(pso, "adaptive_max_pool2d_backward", {gradOutput, indices});
+      [computeEncoder setComputePipelineState:pso];
+      mtl_setArgs(computeEncoder, gi_c, grad_output_c, indices_c, params);
+      mtl_dispatch1DJob(computeEncoder, pso, grad_output_c.numel());
+      getMPSProfiler().endProfileKernel(pso);
+    }
+  });
+  if (!gi_contig) {
+    gradInput.copy_(gi_c);
+  }
 }
 
 } // namespace at::native

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -7829,6 +7829,25 @@ class TestMPS(TestCaseMPS):
                 helper((2, 2, 16, 16), (2, 2), return_indices, dtype)
                 helper((2, 2, 16, 16), (2, 16), return_indices, dtype)
                 helper((2, 16, 16), (4, 4), return_indices, dtype)
+                # Non-divisible geometry: windows vary in size and overlap.
+                # Regression test for
+                # https://github.com/pytorch/pytorch/issues/190064
+                helper((1, 1, 5, 5), (3, 3), return_indices, dtype)
+                helper((2, 3, 7, 5), (4, 3), return_indices, dtype)
+                helper((3, 10, 9), (7, 7), return_indices, dtype)
+                helper((2, 3, 7, 5), (4, 3), return_indices, dtype, channels_last=True)
+                # Upsampling geometry previously returned the wrong shape.
+                helper((1, 2, 2, 2), (4, 4), return_indices, dtype)
+                helper((1, 2, 2, 3), (3, 7), return_indices, dtype)
+
+    # NaN must propagate and take the index of the first NaN in the window,
+    # matching CPU.
+    def test_adaptive_max_pool2d_nan_propagation(self):
+        x = torch.tensor([[[[1.0, float('nan')], [2.0, 3.0]]]])
+        ref, ref_idx = torch.nn.functional.adaptive_max_pool2d(x, (1, 1), return_indices=True)
+        out, idx = torch.nn.functional.adaptive_max_pool2d(x.to('mps'), (1, 1), return_indices=True)
+        self.assertEqual(out.cpu(), ref, equal_nan=True)
+        self.assertEqual(idx.cpu(), ref_idx)
 
     def test_gelu_simple(self):
         def helper(shape, dtype=torch.float, contiguous=True):


### PR DESCRIPTION
`adaptive_max_pool2d` was implemented as a single ordinary max-pool with one derived kernel/stride pair, without requiring divisibility. True adaptive pooling uses windows `[floor(o*I/O), ceil((o+1)*I/O))` that vary in size and overlap for non-divisible geometry, so values and indices were silently wrong (5×5 → 3×3 returned `[12,13,14,...]` where CPU returns `[6,8,9,...]`), upsampling geometry returned the wrong output shape entirely (2×2 → 4×4 produced 1×1), and backward inherited the bad indices.

This adds dedicated Metal kernels: forward computes one output element per thread with the adaptive window bounds, propagating NaN with first-NaN-wins index semantics like CPU; backward atomically routes grad_output through the saved indices (windows overlap, so multiple outputs can hit one input element). Input offsets use 64-bit math since the input can exceed 2^31 elements even when the output is small. The host impls move to `Pooling.mm` next to the kernels' metallib; non-contiguous tensors go through contiguous temporaries.

`test_adaptive_max_pool2d_simple` gains non-divisible, channels-last, and upsampling geometries (values, indices, and gradients against CPU), plus a new NaN-propagation test. All 20 adaptive and 117 pool tests pass.

**Alternatives considered**

- *Raise for non-divisible sizes, like `adaptive_avg_pool2d` does (~3 lines):* stops the silent corruption but turns the op's core use case (arbitrary input sizes) into an error; the avg-pool version of that error is itself a long-standing complaint (#96056). Defensible only as a stopgap.
- *Compose from existing ops:* adaptive window starts follow `floor(o*I/O)`, an irregular pattern with two window sizes that can overlap, so no fixed (kernel, stride, padding, dilation) reproduces them. A host-side loop over output cells needs O(H_out*W_out) dispatches and still has to build the flattened indices tensor for autograd.
- *Custom forward, reusing `max_pool2d_with_indices_backward`:* the MPS graph path of that backward recomputes the argmax from the supplied kernel geometry instead of using the saved indices, so fabricated geometry would reintroduce the same bug class.

Hence dedicated forward/backward kernels.

Fixes #190064

*This PR was authored with assistance from Claude.*
