### PR TITLE
Treat queued/in_progress jobs as in-flight, not failures, in HUD analysis

### DIFF
--- a/scripts/hud/analyze_failing_jobs.py
+++ b/scripts/hud/analyze_failing_jobs.py
@@ -42,11 +42,12 @@ HUD_API = "https://hud.pytorch.org/api/hud/pytorch/pytorch"
 # we fetch whole pages and trim to the exact commit count requested.
 PER_PAGE = 100
 
-# Conclusions without a completed signal for a commit/job pair. "pending" is an
-# in-progress run (no result yet), so it is treated as no-data rather than
-# breaking a streak -- otherwise an in-flight rerun at the tip would reset the
-# streak of a job that is otherwise consistently failing.
-SKIPPED_CONCLUSIONS = {"neutral", "skipped", "pending"}
+# Conclusions without a completed signal for a commit/job pair. "pending",
+# "queued" and "in_progress" are in-flight runs (no result yet), so they are
+# treated as no-data rather than breaking a streak -- otherwise an in-flight
+# rerun, or a runner-queue backlog at the tip, would look like a failure streak
+# for a job that is actually green (queue-backlogged jobs report "queued").
+SKIPPED_CONCLUSIONS = {"neutral", "skipped", "pending", "queued", "in_progress"}
 # Two failures whose captured error text is at least this similar are treated
 # as the same underlying failure.
 SIMILARITY_THRESHOLD = 0.75
@@ -58,7 +59,7 @@ def is_skipped(job: dict[str, Any]) -> bool:
 
 def is_failure(job: dict[str, Any]) -> bool:
     conclusion = job.get("conclusion")
-    return conclusion is not None and conclusion not in ("success", "pending")
+    return conclusion is not None and conclusion != "success" and not is_skipped(job)
 
 
 def transpose_grid(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #190069

analyze_failing_jobs.py counted any conclusion that was not "success"/"pending"
as a failure. The HUD reports runner-queue-backlogged jobs with conclusion
"queued", which fell through that gap: is_skipped() only recognized "pending" as
in-flight, so a queued run was classified as a failure. A job stuck in the
runner queue (e.g. trunk / macos-py3-arm64 / build with ~19 commits queued on a
backed-up arm64 pool) then looked like a long failure streak even though every
completed run was green.

Add "queued" and "in_progress" to SKIPPED_CONCLUSIONS and derive is_failure()
from is_skipped() so the two helpers share a single source of truth and cannot
drift apart again.

Test Plan:
```
# Previously reported as failing; now correctly empty:
python scripts/hud/analyze_failing_jobs.py main --commits 100 \
  --filter-job-name "trunk / macos-py3-arm64 / build"
# -> Found 0 continuously failing jobs

# Genuine failures are still detected:
python scripts/hud/analyze_failing_jobs.py main --commits 100 \
  --filter-job-name ".*backwards_compat.*"
# -> still reports the broken backwards_compat jobs
```

Authored with Claude.