### PR TITLE
aten TensorRef/OptionalTensorRef: add C10_LIFETIMEBOUND

### DIFF
--- a/aten/src/ATen/core/Tensor.h
+++ b/aten/src/ATen/core/Tensor.h
@@ -13,7 +13,7 @@ class TORCH_API OptionalTensorRef {
     ref_.unsafeReleaseTensorImpl();
   }
 
-  OptionalTensorRef(const TensorBase& src)
+  OptionalTensorRef(const TensorBase& src C10_LIFETIMEBOUND)
       : ref_(Tensor::unsafe_borrow_t{}, src) {
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY(src.defined());
   }
@@ -31,15 +31,15 @@ class TORCH_API OptionalTensorRef {
     return ref_.defined();
   }
 
-  const Tensor& getTensorRef() const & {
+  const Tensor& getTensorRef() const & C10_LIFETIMEBOUND {
     return ref_;
   }
 
-  const Tensor& operator*() const & {
+  const Tensor& operator*() const & C10_LIFETIMEBOUND {
     return ref_;
   }
 
-  const Tensor* operator->() const & {
+  const Tensor* operator->() const & C10_LIFETIMEBOUND {
     return &ref_;
   }
 
@@ -59,14 +59,14 @@ class TORCH_API TensorRef {
     ref_.unsafeReleaseTensorImpl();
   }
 
-  TensorRef(const TensorBase& src)
+  TensorRef(const TensorBase& src C10_LIFETIMEBOUND)
       : ref_(Tensor::unsafe_borrow_t{}, src) {}
   TensorRef(TensorRef&& other) = default;
   TensorRef(const TensorRef&) = default;
   TensorRef& operator=(const TensorRef&) = default;
   TensorRef& operator=(TensorRef&&) = default;
 
-  const Tensor& operator*() const & {
+  const Tensor& operator*() const & C10_LIFETIMEBOUND {
     return ref_;
   }
  private:


### PR DESCRIPTION
Summary:
TensorRef and OptionalTensorRef are non-owning borrows: they adopt the source TensorImpl via unsafe_borrow (no refcount bump) and release it without decref in the destructor, so they are only valid while the borrowed-from Tensor stays alive.

Annotate the src parameter of the borrowing constructors (bind the ref object to src) so Clang catches `TensorRef r = makeTensor();` on a temporary, and the getTensorRef()/operator*()/operator->() accessors (bind to *this) so binding a reference to a temporary ref object is caught. The existing internal use in Tensor::register_hook borrows a named lvalue (grad_base), which is unaffected.

Depends on the C10_LIFETIMEBOUND macro (reachable here via c10/util/Exception.h). Mirrored across the fbcode and xplat copies.

Test Plan: Compile-time only; no-op where the attribute is unavailable. Relies on CI (clang) to surface pre-existing dangling call sites. Local `arc lint` is clean.

Differential Revision: D111955714


