### PR TITLE
c10 TensorAccessor: add C10_LIFETIMEBOUND to borrowed sizes_/strides_

### DIFF
--- a/torch/headeronly/core/TensorAccessor.h
+++ b/torch/headeronly/core/TensorAccessor.h
@@ -54,8 +54,8 @@ class TensorAccessorBase {
 
   C10_HOST_DEVICE TensorAccessorBase(
       PtrType data_,
-      const index_t* sizes_,
-      const index_t* strides_)
+      const index_t* sizes_ C10_LIFETIMEBOUND,
+      const index_t* strides_ C10_LIFETIMEBOUND)
       : data_(data_), sizes_(sizes_), strides_(strides_) {}
   C10_HOST ArrayRefCls sizes() const {
     return ArrayRefCls(sizes_, N);
@@ -99,8 +99,8 @@ class TensorAccessor
 
   C10_HOST_DEVICE TensorAccessor(
       PtrType data_,
-      const index_t* sizes_,
-      const index_t* strides_)
+      const index_t* sizes_ C10_LIFETIMEBOUND,
+      const index_t* strides_ C10_LIFETIMEBOUND)
       : TensorAccessorBase<ArrayRefCls, T, N, PtrTraits, index_t>(
             data_,
             sizes_,
@@ -140,8 +140,8 @@ class TensorAccessor<ArrayRefCls, T, 1, PtrTraits, index_t>
 
   C10_HOST_DEVICE TensorAccessor(
       PtrType data_,
-      const index_t* sizes_,
-      const index_t* strides_)
+      const index_t* sizes_ C10_LIFETIMEBOUND,
+      const index_t* strides_ C10_LIFETIMEBOUND)
       : TensorAccessorBase<ArrayRefCls, T, 1, PtrTraits, index_t>(
             data_,
             sizes_,


### PR DESCRIPTION
Summary:
TensorAccessorBase and the N-dim / 1-dim TensorAccessor specializations store sizes_ and strides_ as raw pointers (they do not copy). Marking those constructor parameters C10_LIFETIMEBOUND lets Clang diagnose an accessor that outlives the sizes/strides arrays it borrows, e.g. building an accessor from a temporary tensor's shape.

The GenericPackedTensorAccessor* constructors are deliberately left unannotated: they std::copy sizes/strides into inline arrays, so there is no borrow to dangle. data_ is also left unmarked since it points into the owning tensor storage, matching existing accessor usage.

C10_LIFETIMEBOUND expands to nothing under compilers without the attribute (including nvcc device compilation), so this is inert for CUDA device code. Depends on the C10_LIFETIMEBOUND macro. Mirrored across the fbcode and xplat copies.

Test Plan: Compile-time only; no-op where the attribute is unavailable. Relies on CI (clang CPU + CUDA) to surface pre-existing dangling call sites. Local `arc lint` is clean.

Differential Revision: D111955715


