### PR TITLE
c10 OptionalArrayRef: add C10_LIFETIMEBOUND to borrowing constructors

### DIFF
--- a/c10/util/OptionalArrayRef.h
+++ b/c10/util/OptionalArrayRef.h
@@ -39,7 +39,7 @@ class OptionalArrayRef final {
   constexpr OptionalArrayRef(std::optional<ArrayRef<T>>&& other) noexcept
       : wrapped_opt_array_ref(std::move(other)) {}
 
-  constexpr OptionalArrayRef(const T& value) noexcept
+  constexpr OptionalArrayRef(const T& value C10_LIFETIMEBOUND) noexcept
       : wrapped_opt_array_ref(value) {}
 
   template <
@@ -52,7 +52,7 @@ class OptionalArrayRef final {
               std::is_convertible_v<U&&, ArrayRef<T>> &&
               !std::is_convertible_v<U&&, T>,
           bool> = false>
-  constexpr OptionalArrayRef(U&& value) noexcept(
+  constexpr OptionalArrayRef(U&& value C10_LIFETIMEBOUND) noexcept(
       std::is_nothrow_constructible_v<ArrayRef<T>, U&&>)
       : wrapped_opt_array_ref(std::forward<U>(value)) {}
 
@@ -65,7 +65,7 @@ class OptionalArrayRef final {
               std::is_constructible_v<ArrayRef<T>, U&&> &&
               !std::is_convertible_v<U&&, ArrayRef<T>>,
           bool> = false>
-  constexpr explicit OptionalArrayRef(U&& value) noexcept(
+  constexpr explicit OptionalArrayRef(U&& value C10_LIFETIMEBOUND) noexcept(
       std::is_nothrow_constructible_v<ArrayRef<T>, U&&>)
       : wrapped_opt_array_ref(std::forward<U>(value)) {}
 
@@ -82,7 +82,8 @@ class OptionalArrayRef final {
       Args&&... args)
       : wrapped_opt_array_ref(ip, il, std::forward<Args>(args)...) {}
 
-  constexpr OptionalArrayRef(const std::initializer_list<T>& Vec)
+  constexpr OptionalArrayRef(
+      const std::initializer_list<T>& Vec C10_LIFETIMEBOUND)
       : wrapped_opt_array_ref(ArrayRef<T>(Vec)) {}
 
   // Destructor

--- a/torch/csrc/inductor/aoti_torch/utils.h
+++ b/torch/csrc/inductor/aoti_torch/utils.h
@@ -269,7 +269,13 @@ struct OwnedOptionalArrayRef {
   std::optional<std::vector<T>> storage;
 
   /* implicit */ operator c10::OptionalArrayRef<T>() const {
-    return storage ? c10::OptionalArrayRef<T>(c10::ArrayRef<T>(*storage))
+    // Build the OptionalArrayRef from a std::optional<ArrayRef<T>> (whose
+    // constructor is not lifetimebound) rather than from a temporary ArrayRef:
+    // the view points into the owned `storage` vector, which outlives the
+    // wrapper's enclosing call, so binding it to the temporary ArrayRef would
+    // be a spurious -Wreturn-stack-address error under C10_LIFETIMEBOUND.
+    return storage ? c10::OptionalArrayRef<T>(
+                         std::make_optional(c10::ArrayRef<T>(*storage)))
                    : c10::OptionalArrayRef<T>(std::nullopt);
   }
   /* implicit */ operator std::optional<c10::ArrayRef<T>>() const {


### PR DESCRIPTION
Summary:
OptionalArrayRef exists specifically to fix a dangling-pointer bug in its converting constructor (pytorch#63645); C10_LIFETIMEBOUND hardens it further by letting Clang diagnose the dangle at compile time. Annotate the value parameter of the single-element constructor, both forwarding (U&&) converting constructors, and the initializer_list constructor - each ultimately builds an ArrayRef view that borrows from the argument. Catches `OptionalIntArrayRef o = std::vector<int64_t>{...};`.

The std::optional<ArrayRef<T>> and in_place constructors are left unannotated (they do not introduce a new borrow of a temporary buffer).

Depends on the C10_LIFETIMEBOUND macro. Mirrored across the fbcode and xplat copies.

Test Plan: Compile-time only; no-op where the attribute is unavailable. Relies on CI (clang) to surface pre-existing dangling call sites. Local `arc lint` is clean.



