### PR TITLE
c10 MaybeOwned: add C10_LIFETIMEBOUND to borrow entry points

### DIFF
--- a/c10/util/MaybeOwned.h
+++ b/c10/util/MaybeOwned.h
@@ -17,7 +17,7 @@ struct MaybeOwnedTraitsGenericImpl {
   using owned_type = T;
   using borrow_type = const T*;
 
-  static borrow_type createBorrow(const owned_type& from) {
+  static borrow_type createBorrow(const owned_type& from C10_LIFETIMEBOUND) {
     return &from;
   }
 
@@ -73,7 +73,7 @@ class MaybeOwned final {
   };
 
   /// Don't use this; use borrowed() instead.
-  explicit MaybeOwned(const owned_type& t)
+  explicit MaybeOwned(const owned_type& t C10_LIFETIMEBOUND)
       : isBorrowed_(true), borrow_(MaybeOwnedTraits<T>::createBorrow(t)) {}
 
   /// Don't use this; use owned() instead.
@@ -167,7 +167,7 @@ class MaybeOwned final {
     return *this;
   }
 
-  static MaybeOwned borrowed(const T& t) {
+  static MaybeOwned borrowed(const T& t C10_LIFETIMEBOUND) {
     return MaybeOwned(t);
   }
 


### PR DESCRIPTION
Summary:
MaybeOwned is a borrow-or-own smart pointer whose docs already warn that a borrowed-from argument must outlive it. Annotate the borrowing paths so Clang enforces that: the borrowing constructor MaybeOwned(const T&), the public borrowed(const T&) factory, and MaybeOwnedTraitsGenericImpl::createBorrow(const owned_type&), which returns &from. Catches `auto m = MaybeOwned<Tensor>::borrowed(makeTensor());`.

The operator*/operator-> accessors are intentionally left unannotated: in the borrowed case they point at an external referent, so binding them to *this would be over-restrictive.

Depends on the C10_LIFETIMEBOUND macro. Mirrored across the fbcode and xplat copies.

Test Plan: Compile-time only; no-op where the attribute is unavailable. Relies on CI (clang) to surface pre-existing dangling call sites. Local `arc lint` is clean.

Differential Revision: D111955722


