### PR TITLE
c10 HeaderOnlyArrayRef: add C10_LIFETIMEBOUND to borrowing constructors (#190078)

### DIFF
--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -4203,7 +4203,7 @@ TEST_F(VulkanAPITest, repeat_invalid_inputs_outputs_exceptions) {
   {
     const auto in_cpu =
         at::rand({3, 9, 11, 7, 3}, at::device(at::kCPU).dtype(at::kFloat));
-    const at::IntArrayRef repeats = {5, 7, 3, 9, 2};
+    const std::vector<int64_t> repeats = {5, 7, 3, 9, 2};
 
     // Act
     EXPECT_THROW(
@@ -4216,7 +4216,7 @@ TEST_F(VulkanAPITest, repeat_invalid_inputs_outputs_exceptions) {
   {
     const auto in_cpu =
         at::rand({3, 5, 11, 13}, at::device(at::kCPU).dtype(at::kFloat));
-    const at::IntArrayRef repeats = {5, 7};
+    const std::vector<int64_t> repeats = {5, 7};
 
     // Act
     EXPECT_THROW(
@@ -4228,7 +4228,7 @@ TEST_F(VulkanAPITest, repeat_invalid_inputs_outputs_exceptions) {
   {
     const auto in_cpu =
         at::rand({3, 9, 11, 7}, at::device(at::kCPU).dtype(at::kFloat));
-    const at::IntArrayRef repeats = {5, 7, 3, 9, 2};
+    const std::vector<int64_t> repeats = {5, 7, 3, 9, 2};
 
     // Act
     EXPECT_THROW(
@@ -7014,7 +7014,7 @@ TEST_F(VulkanAPITest, tile_invalid_inputs_exceptions) {
   {
     const auto in_cpu =
         at::rand({3, 9, 5, 7, 3}, at::device(at::kCPU).dtype(at::kFloat));
-    const at::IntArrayRef repeats = {7, 3, 9, 2};
+    const std::vector<int64_t> repeats = {7, 3, 9, 2};
 
     // Act
     EXPECT_THROW(
@@ -7028,7 +7028,7 @@ TEST_F(VulkanAPITest, tile_invalid_outpus_exceptions) {
   {
     const auto in_cpu =
         at::rand({3, 9, 5, 13}, at::device(at::kCPU).dtype(at::kFloat));
-    const at::IntArrayRef repeats = {5, 7, 3, 9, 2};
+    const std::vector<int64_t> repeats = {5, 7, 3, 9, 2};
 
     // Act
     EXPECT_THROW(

--- a/test/cpp/aoti_abi_check/test_headeronlyarrayref.cpp
+++ b/test/cpp/aoti_abi_check/test_headeronlyarrayref.cpp
@@ -35,7 +35,8 @@ TEST(TestHeaderOnlyArrayRef, TestAPIs) {
 
 TEST(TestHeaderOnlyArrayRef, TestFromInitializerList) {
   std::vector<int> vec = {1, 2, 3, 4, 5, 6, 7};
-  HeaderOnlyArrayRef<int> arr({1, 2, 3, 4, 5, 6, 7});
+  std::initializer_list<int> il = {1, 2, 3, 4, 5, 6, 7};
+  HeaderOnlyArrayRef<int> arr(il);
   auto res_vec = arr.vec();
   for (size_t i = 0; i < vec.size(); i++) {
     EXPECT_EQ(vec[i], res_vec[i]);

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -217,7 +217,8 @@ TensorCheck::TensorCheck(
 // Logic parallel to here must be maintained in python
 bool TensorCheck::check(const LocalState& state, const at::Tensor& v) {
   // In terms of a sparse_csr tensor, it does not support strides information
-  c10::SymIntArrayRef sym_strides(std::vector<SymInt>(v.ndimension(), -1));
+  std::vector<SymInt> sym_strides_storage(v.ndimension(), -1);
+  c10::SymIntArrayRef sym_strides(sym_strides_storage);
   bool does_not_support_stride = v.layout() == c10::kSparseCsr ||
       v.layout() == c10::kSparseCsc || v.layout() == c10::kSparseBsc ||
       v.layout() == c10::kSparseBsr;

--- a/torch/headeronly/util/HeaderOnlyArrayRef.h
+++ b/torch/headeronly/util/HeaderOnlyArrayRef.h
@@ -54,14 +54,17 @@ class HeaderOnlyArrayRef {
 
   /// Construct a HeaderOnlyArrayRef from a single element.
   // TODO Make this explicit
-  constexpr HeaderOnlyArrayRef(const T& OneElt) : Data(&OneElt), Length(1) {}
+  constexpr HeaderOnlyArrayRef(const T& OneElt C10_LIFETIMEBOUND)
+      : Data(&OneElt), Length(1) {}
 
   /// Construct a HeaderOnlyArrayRef from a pointer and length.
-  constexpr HeaderOnlyArrayRef(const T* data, size_t length)
+  constexpr HeaderOnlyArrayRef(const T* data C10_LIFETIMEBOUND, size_t length)
       : Data(data), Length(length) {}
 
   /// Construct a HeaderOnlyArrayRef from a range.
-  constexpr HeaderOnlyArrayRef(const T* begin, const T* end)
+  constexpr HeaderOnlyArrayRef(
+      const T* begin C10_LIFETIMEBOUND,
+      const T* end C10_LIFETIMEBOUND)
       : Data(begin), Length(end - begin) {}
 
   template <
@@ -70,7 +73,8 @@ class HeaderOnlyArrayRef {
       // NOLINTNEXTLINE(modernize-use-constraints)
       typename = std::enable_if_t<
           (std::is_same_v<U, T*> || std::is_same_v<U, T const*>)>>
-  /* implicit */ HeaderOnlyArrayRef(const Container& container)
+  /* implicit */ HeaderOnlyArrayRef(
+      const Container& container C10_LIFETIMEBOUND)
       : Data(container.data()), Length(container.size()) {}
 
   /// Construct a HeaderOnlyArrayRef from a std::vector.
@@ -78,7 +82,8 @@ class HeaderOnlyArrayRef {
   // std::vector<bool>, because ArrayRef can't work on a std::vector<bool>
   // bitfield.
   template <typename A>
-  /* implicit */ HeaderOnlyArrayRef(const std::vector<T, A>& Vec)
+  /* implicit */ HeaderOnlyArrayRef(
+      const std::vector<T, A>& Vec C10_LIFETIMEBOUND)
       : Data(Vec.data()), Length(Vec.size()) {
     static_assert(
         !std::is_same_v<T, bool>,
@@ -87,18 +92,20 @@ class HeaderOnlyArrayRef {
 
   /// Construct a HeaderOnlyArrayRef from a std::array
   template <size_t N>
-  /* implicit */ constexpr HeaderOnlyArrayRef(const std::array<T, N>& Arr)
+  /* implicit */ constexpr HeaderOnlyArrayRef(
+      const std::array<T, N>& Arr C10_LIFETIMEBOUND)
       : Data(Arr.data()), Length(N) {}
 
   /// Construct a HeaderOnlyArrayRef from a C array.
   template <size_t N>
-  // NOLINTNEXTLINE(*c-arrays*)
-  /* implicit */ constexpr HeaderOnlyArrayRef(const T (&Arr)[N])
+  /* implicit */ constexpr HeaderOnlyArrayRef(
+      // NOLINTNEXTLINE(*c-arrays*)
+      const T (&Arr C10_LIFETIMEBOUND)[N])
       : Data(Arr), Length(N) {}
 
   /// Construct a HeaderOnlyArrayRef from a std::initializer_list.
   /* implicit */ constexpr HeaderOnlyArrayRef(
-      const std::initializer_list<T>& Vec)
+      const std::initializer_list<T>& Vec C10_LIFETIMEBOUND)
       : Data(
             std::begin(Vec) == std::end(Vec) ? static_cast<T*>(nullptr)
                                              : std::begin(Vec)),


### PR DESCRIPTION
Summary:

HeaderOnlyArrayRef is a non-owning view (ArrayRef/IntArrayRef inherit these constructors). Marking the source parameter C10_LIFETIMEBOUND lets Clang diagnose the canonical dangling bug where the view outlives the buffer it points into, e.g. `ArrayRef<int> r = std::vector<int>{...};` or `ArrayRef r = makeVec();`.

Annotated the single-element, pointer, range, generic-container, std::vector, std::array, C-array and initializer_list constructors. The attribute goes on the constructor parameter (bind view -> source), NOT on the accessors: front()/data()/operator[] return pointers into the external buffer, not into the view object, so binding those to *this would reject safe code.

Depends on the C10_LIFETIMEBOUND macro. Mirrored across the fbcode and xplat copies.

Test Plan: Compile-time only; no-op where the attribute is unavailable. Relies on CI (clang) to surface any pre-existing dangling call sites this newly diagnoses. Local `arc lint` is clean.





cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98