### PR TITLE
 Reject non-1D batch_norm weight/bias/running stats (#190079)

### DIFF
--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -87,9 +87,19 @@ DEFINE_DISPATCH(batch_norm_cpu_backward_stub);
 DEFINE_DISPATCH(renorm_scale_factor_stub);
 
 namespace {
-  void check_dims_match_num_input_features(const char* arg_name, const SymInt& expected, const SymInt& actual){
-    TORCH_CHECK(actual == expected,
-             arg_name, " should contain ", expected, " elements not ", actual);
+  void check_dims_match_num_input_features(const char* arg_name, const SymInt& expected, const Tensor& actual){
+    // weight/bias/running_mean/running_var are expected to be 1-D tensors of
+    // size [num_features]. Checking element count alone (sym_numel) is not
+    // enough: a multidimensional tensor whose numel happens to match the
+    // channel count would silently pass here and be accepted by some eager
+    // fast paths, while other paths (e.g. the accessor<..., 1> based kernels
+    // exercised under torch.compile) reject it with a cryptic internal error.
+    // Enforce the dimensionality here so eager and compile behave consistently.
+    TORCH_CHECK(actual.dim() == 1,
+             arg_name, " should be a 1-dimensional tensor with ", expected,
+             " elements, but got a ", actual.dim(), "-dimensional tensor");
+    TORCH_CHECK(actual.sym_numel() == expected,
+             arg_name, " should contain ", expected, " elements not ", actual.sym_numel());
   }
 
   inline Tensor repeat_if_defined(const Tensor& t, const SymInt& repeat) {
@@ -590,20 +600,20 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, int64_t> _batch_norm_impl_index(
   }
 
   if (running_mean.defined()) {
-    check_dims_match_num_input_features("running_mean", num_features, running_mean.sym_numel());
+    check_dims_match_num_input_features("running_mean", num_features, running_mean);
   } else if (!training) {
     TORCH_CHECK(false, "running_mean must be defined in evaluation mode");
   }
   if (running_var.defined()) {
-    check_dims_match_num_input_features("running_var", num_features, running_var.sym_numel());
+    check_dims_match_num_input_features("running_var", num_features, running_var);
   } else if (!training) {
     TORCH_CHECK(false, "running_var must be defined in evaluation mode");
   }
   if (weight.defined()) {
-    check_dims_match_num_input_features("weight", num_features, weight.sym_numel());
+    check_dims_match_num_input_features("weight", num_features, weight);
   }
   if (bias.defined()) {
-    check_dims_match_num_input_features("bias", std::move(num_features), bias.sym_numel());
+    check_dims_match_num_input_features("bias", std::move(num_features), bias);
   }
 
   BatchNormBackend backend = _select_batch_norm_backend(input, weight, bias, running_mean, running_var, training, eps);

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4486,6 +4486,35 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             with self.assertRaises(RuntimeError):
                 F.batch_norm(input, running_mean, running_var, bias=Parameter(torch.rand(size)))
 
+    def test_batchnorm_raises_error_if_params_are_not_1d(self):
+        # A multidimensional weight/bias/running_mean/running_var whose numel
+        # matches the channel count used to be silently accepted in eager
+        # (element count was the only thing checked) but failed under
+        # torch.compile with a cryptic "TensorAccessor expected 1 dims but
+        # tensor has N" error. These params must be 1-dimensional, so eager now
+        # rejects them with a clear error too.
+        input = torch.rand(2, 8)
+        running_mean = torch.rand(8)
+        running_var = torch.rand(8)
+        multidim = torch.rand(2, 4)  # numel == 8 == num channels, but 2-D
+
+        # Control: properly-shaped 1-D params of the same numel still work, so
+        # the check below rejects only on rank, not on element count.
+        out = F.batch_norm(
+            input, running_mean, running_var,
+            weight=Parameter(torch.rand(8)), bias=Parameter(torch.rand(8)),
+        )
+        self.assertEqual(out.shape, input.shape)
+
+        with self.assertRaisesRegex(RuntimeError, "running_mean should be a 1-dimensional tensor"):
+            F.batch_norm(input, multidim, running_var)
+        with self.assertRaisesRegex(RuntimeError, "running_var should be a 1-dimensional tensor"):
+            F.batch_norm(input, running_mean, multidim)
+        with self.assertRaisesRegex(RuntimeError, "weight should be a 1-dimensional tensor"):
+            F.batch_norm(input, running_mean, running_var, weight=Parameter(multidim))
+        with self.assertRaisesRegex(RuntimeError, "bias should be a 1-dimensional tensor"):
+            F.batch_norm(input, running_mean, running_var, bias=Parameter(multidim))
+
     def test_batchnorm_raises_error_if_running_var_or_running_mean_have_forward_grad(self):
         args = (
             torch.randn(3, 2, 5),  # input


### PR DESCRIPTION
Summary:
Fixes https://github.com/pytorch/pytorch/issues/188358.

`F.batch_norm` accepted a multidimensional `weight`/`bias`/`running_mean`/`running_var` as long as its element count matched the channel dimension, because `_batch_norm_impl_index` validated these arguments with `check_dims_match_num_input_features`, which only compared `sym_numel()` and never the rank. The documented contract is that each of these is a 1-D tensor of shape `[C]`, and the kernels rely on it: the CPU path asserts `dim() == 1` in `as_nd`, and the CUDA `accessor<..., 1>` kernels require rank 1. As a result a 3-D `bias` with `numel() == C` slipped through the check and then diverged downstream -- eager inference on a contiguous input hit a fast path that read the buffer flat and silently "succeeded", while the same op under `torch.compile` (and some eager paths) hit the `accessor<..., 1>` kernel and failed with the cryptic `RuntimeError: TensorAccessor expected 1 dims but tensor has 3`.

This diff enforces the rank in `check_dims_match_num_input_features`: each defined argument must be a 1-D tensor with `[C]` elements, otherwise we raise a clear error naming the argument. The check lives in `_batch_norm_impl_index`, the CompositeImplicitAutograd path executed both in eager and during AOTAutograd tracing, so eager and every compile backend now reject the malformed input identically instead of silently disagreeing. The existing element-count message is preserved for backward compatibility.

Authored with the assistance of an AI coding assistant.


Test Plan:
Added `test_batchnorm_raises_error_if_params_are_not_1d` covering multidimensional `weight`/`bias`/`running_mean`/`running_var`.

Verified the new test fails without the C++ fix (reverting only Normalization.cpp):
```
Pass 0. Fail 1.
RuntimeError: TensorAccessor expected 1 dims but tensor has 2
AssertionError: "running_mean should be a 1-dimensional tensor" does not match "TensorAccessor expected 1 dims but tensor has 2"
```

With the fix (buck2, CPU host):
```
buck2 test fbcode//mode/dev-nosan fbcode//caffe2/test:nn -- --regex 'test_batchnorm_raises_error_if_params_are_not_1d'   # Pass 1, Fail 0
buck2 test fbcode//mode/dev-nosan fbcode//caffe2/test:nn -- --regex 'batchnorm|instancenorm|InstanceNorm|BatchNorm'      # Pass 45, Fail 0
buck2 test fbcode//mode/dev-nosan fbcode//caffe2/test:others -- --regex 'batch_norm'                                    # Pass 83, Fail 0
buck2 test fbcode//mode/dev-nosan fbcode//caffe2/test:meta -- --regex 'batch_norm'                                      # Pass 61, Fail 0
```

Confirmed the reported reproduction now behaves consistently in eager and torch.compile (aot_eager):
```
[eager]     RuntimeError: bias should be a 1-dimensional tensor with 64 elements, but got a 3-dimensional tensor
[aot_eager] RuntimeError: ... -> bias should be a 1-dimensional tensor with 64 elements, but got a 3-dimensional tensor
```

`arc lint caffe2/aten/src/ATen/native/Normalization.cpp caffe2/test/test_nn.py` reports "ok No lint issues" (lintrunner unavailable on this host).

Differential Revision: D112061367

Pulled By: tanpuresiddhant


