### PR TITLE
Simplify c10 TypeSafeSignMath tag-dispatch with if constexpr

### DIFF
--- a/torch/headeronly/util/TypeSafeSignMath.h
+++ b/torch/headeronly/util/TypeSafeSignMath.h
@@ -14,20 +14,6 @@ C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-int-float-conversion")
 
 namespace c10 {
 
-/// Returns false since we cannot have x < 0 if x is unsigned.
-template <typename T>
-inline constexpr bool is_negative(
-    const T& /*x*/,
-    std::true_type /*is_unsigned*/) {
-  return false;
-}
-
-/// Returns true if a signed variable x < 0
-template <typename T>
-inline constexpr bool is_negative(const T& x, std::false_type /*is_unsigned*/) {
-  return x < T(0);
-}
-
 /// Returns true if x < 0
 /// NOTE: Will fail on an unsigned custom type
 ///       For the most part it's possible to fix this if
@@ -35,19 +21,12 @@ inline constexpr bool is_negative(const T& x, std::false_type /*is_unsigned*/) {
 ///       However, notably, c10::Half does not :-(
 template <typename T>
 inline constexpr bool is_negative(const T& x) {
-  return is_negative(x, std::is_unsigned<T>());
-}
-
-/// Returns the sign of an unsigned variable x as 0, 1
-template <typename T>
-inline constexpr int signum(const T& x, std::true_type /*is_unsigned*/) {
-  return T(0) < x;
-}
-
-/// Returns the sign of a signed variable x as -1, 0, 1
-template <typename T>
-inline constexpr int signum(const T& x, std::false_type /*is_unsigned*/) {
-  return (T(0) < x) - (x < T(0));
+  if constexpr (std::is_unsigned_v<T>) {
+    // An unsigned value can never be less than zero.
+    return false;
+  } else {
+    return x < T(0);
+  }
 }
 
 /// Returns the sign of x as -1, 0, 1
@@ -57,7 +36,11 @@ inline constexpr int signum(const T& x, std::false_type /*is_unsigned*/) {
 ///       However, notably, c10::Half does not :-(
 template <typename T>
 inline constexpr int signum(const T& x) {
-  return signum(x, std::is_unsigned<T>());
+  if constexpr (std::is_unsigned_v<T>) {
+    return T(0) < x;
+  } else {
+    return (T(0) < x) - (x < T(0));
+  }
 }
 
 /// Returns true if a and b are not both negative
@@ -86,53 +69,22 @@ inline constexpr bool greater_than_max(const T& x) {
 #pragma GCC diagnostic pop
 #endif
 
-/// Returns true if x < lowest(Limit). Standard comparison
-template <typename Limit, typename T>
-inline constexpr bool less_than_lowest(
-    const T& x,
-    std::false_type /*limit_is_unsigned*/,
-    std::false_type /*x_is_unsigned*/) {
-  return x < std::numeric_limits<Limit>::lowest();
-}
-
-/// Returns false since all the limit is signed and therefore includes
-/// negative values but x cannot be negative because it is unsigned
-template <typename Limit, typename T>
-inline constexpr bool less_than_lowest(
-    const T& /*x*/,
-    std::false_type /*limit_is_unsigned*/,
-    std::true_type /*x_is_unsigned*/) {
-  return false;
-}
-
-/// Returns true if x < 0, where 0 is constructed from T.
-/// Limit is not signed, so its lower value is zero
-template <typename Limit, typename T>
-inline constexpr bool less_than_lowest(
-    const T& x,
-    std::true_type /*limit_is_unsigned*/,
-    std::false_type /*x_is_unsigned*/) {
-  return x < T(0);
-}
-
-/// Returns false sign both types are unsigned
-template <typename Limit, typename T>
-inline constexpr bool less_than_lowest(
-    const T& /*x*/,
-    std::true_type /*limit_is_unsigned*/,
-    std::true_type /*x_is_unsigned*/) {
-  return false;
-}
-
-/// Returns true if x is less than the lowest value of type T
+/// Returns true if x is less than the lowest value of type Limit
 /// NOTE: Will fail on an unsigned custom type
 ///       For the most part it's possible to fix this if
 ///       the custom type has a constexpr constructor.
 ///       However, notably, c10::Half does not :
 template <typename Limit, typename T>
 inline constexpr bool less_than_lowest(const T& x) {
-  return less_than_lowest<Limit>(
-      x, std::is_unsigned<Limit>(), std::is_unsigned<T>());
+  if constexpr (std::is_unsigned_v<T>) {
+    // x is unsigned, so it can never be below the lowest value of any type.
+    return false;
+  } else if constexpr (std::is_unsigned_v<Limit>) {
+    // Limit is unsigned, so its lowest value is zero.
+    return x < T(0);
+  } else {
+    return x < std::numeric_limits<Limit>::lowest();
+  }
 }
 
 } // namespace c10


### PR DESCRIPTION
Summary:
`TypeSafeSignMath.h` implemented `is_negative`, `signum`, and `less_than_lowest` using the pre-C++17 `std::true_type`/`std::false_type` tag-dispatch idiom, with a public forwarding overload calling into private helper overloads selected by `std::is_unsigned<T>()`. This collapses each of those into a single function that branches on `if constexpr (std::is_unsigned_v<T>)`, cutting ~130 lines to ~75 with no behavior change for any signedness combination.

`greater_than_max` and `signs_differ` were already single functions and are left untouched (including the existing `-Wsign-compare` GCC pragma around `greater_than_max`).

I deliberately did not adopt the C++20 `<utility>` safe-integer comparisons (`std::cmp_less`/`std::cmp_greater`/`std::in_range`). This header is part of the c10 header set mirrored to ExecuTorch and is compiled under C++17 by `caffe2/c10/test/util/cpp17_header_build_check.cpp`; those facilities are C++20-only. Additionally, several call sites (e.g. `sign_kernel`, `signum`, and the float branch of `signs_differ`) instantiate these helpers with `float`/`c10::Half`/`BFloat16`, which the integral-only std comparisons reject. `if constexpr` and `std::is_unsigned_v` are both C++17, so the mirror stays green.

This diff was authored with the assistance of an AI coding assistant (Claude Code).

Test Plan:
Lint is clean:
```
arc lint caffe2/torch/headeronly/util/TypeSafeSignMath.h
```
The C++17 header-build check (which includes this header via both `c10/util/TypeSafeSignMath.h` and `torch/headeronly/util/TypeSafeSignMath.h`) compiles:
```
buck2 build fbcode//caffe2/c10/test:util_base_tests
```




