### PR TITLE
[Test] Add hw_classification to test_c10d_nccl.py with new MULTI_ACCELERATOR enum values

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -67,6 +67,7 @@ from torch.testing._internal.common_distributed import (
     with_nccl_blocking_wait,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     IS_LINUX,
     IS_SANDCASTLE,
@@ -141,6 +142,8 @@ _log_configure(level=logging.INFO, force=True)
 
 
 class RendezvousEnvTest(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     @retry_on_connect_failures
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_CUDA, "No GPUs available, skipping test")
@@ -241,6 +244,8 @@ class RendezvousEnvTest(TestCase):
 
 
 class TimeoutTest(test_c10d_common.AbstractTimeoutTest, TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     @requires_nccl()
     @retry_on_connect_failures
     @skip_but_pass_in_sandcastle_if(not TEST_CUDA, "No GPUs available, skipping test")
@@ -249,6 +254,7 @@ class TimeoutTest(test_c10d_common.AbstractTimeoutTest, TestCase):
 
 
 class ProcessGroupNCCLNoGPUTest(TestCase):
+    hw_classification = HardwareClassification.CUDA
     MAIN_PROCESS_RANK = 0
 
     def setUp(self):
@@ -272,6 +278,7 @@ class ProcessGroupNCCLNoGPUTest(TestCase):
 
 
 class ProcessGroupNCCLInitTest(MultiProcessTestCase):
+    hw_classification = HardwareClassification.MULTI_ACCELERATOR_CUDA
     device_type = "cuda"
 
     def setUp(self):
@@ -323,6 +330,8 @@ class ProcessGroupNCCLInitTest(MultiProcessTestCase):
 
 
 class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
+    hw_classification = HardwareClassification.MULTI_ACCELERATOR_CUDA
+
     def _create_process_group_nccl(self, store, opts, device_id=None):
         # create nccl processgroup with opts
         c10d.init_process_group(
@@ -2106,6 +2115,8 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
 class DistributedDataParallelTest(
     test_c10d_common.CommonDistributedDataParallelTest, MultiProcessTestCase
 ):
+    hw_classification = HardwareClassification.MULTI_ACCELERATOR_CUDA
+
     def setUp(self):
         super().setUp()
         # TORCH_NCCL_BLOCKING_WAIT overrides TORCH_NCCL_ASYNC_ERROR_HANDLING hence tests
@@ -3778,6 +3789,8 @@ class DistributedDataParallelTest(
 
 
 class WorkHookTest(MultiProcessTestCase):
+    hw_classification = HardwareClassification.MULTI_ACCELERATOR_CUDA
+
     @property
     def world_size(self):
         return 2
@@ -3997,6 +4010,8 @@ class WorkHookTest(MultiProcessTestCase):
 
 
 class NcclErrorHandlingTest(MultiProcessTestCase):
+    hw_classification = HardwareClassification.MULTI_ACCELERATOR_CUDA
+
     def setUp(self):
         super().setUp()
         # TORCH_NCCL_BLOCKING_WAIT overrides TORCH_NCCL_ASYNC_ERROR_HANDLING hence tests
@@ -4297,6 +4312,8 @@ class NcclErrorHandlingTest(MultiProcessTestCase):
 
 
 class NcclUserBufferRegistrationTest(MultiProcessTestCase):
+    hw_classification = HardwareClassification.MULTI_ACCELERATOR_CUDA
+
     def setUp(self):
         super().setUp()
         with tempfile.NamedTemporaryFile(delete=False) as nccl_debug_file:
@@ -4429,6 +4446,8 @@ class NcclUserBufferRegistrationTest(MultiProcessTestCase):
 
 
 class CommTest(test_c10d_common.AbstractCommTest, MultiProcessTestCase):
+    hw_classification = HardwareClassification.MULTI_ACCELERATOR_CUDA
+
     @property
     def device(self):
         return f"cuda:{self.rank}"
@@ -5092,6 +5111,8 @@ class SetDeviceMethod(Enum):
 class NcclProcessGroupWithDispatchedCollectivesTests(
     test_c10d_common.ProcessGroupWithDispatchedCollectivesTests
 ):
+    hw_classification = HardwareClassification.MULTI_ACCELERATOR_CUDA
+
     @requires_nccl()
     @skip_if_lt_x_gpu(1)
     def test_collectives(self):
@@ -5150,6 +5171,8 @@ instantiate_parametrized_tests(NcclProcessGroupWithDispatchedCollectivesTests)
 
 
 class LargeCommTest(test_c10d_common.AbstractLargeCommTest, MultiProcessTestCase):
+    hw_classification = HardwareClassification.MULTI_ACCELERATOR_CUDA
+
     def setUp(self):
         super().setUp()
         # TORCH_NCCL_BLOCKING_WAIT overrides TORCH_NCCL_ASYNC_ERROR_HANDLING hence tests
@@ -5603,6 +5626,8 @@ instantiate_parametrized_tests(LargeCommTest)
 
 
 class SparseCollective(MultiProcessTestCase):
+    hw_classification = HardwareClassification.MULTI_ACCELERATOR_CUDA
+
     @property
     def world_size(self):
         return 1
@@ -5677,6 +5702,8 @@ class SparseCollective(MultiProcessTestCase):
 
 
 class ProcessGroupNCCLOneRankTest(MultiProcessTestCase):
+    hw_classification = HardwareClassification.MULTI_ACCELERATOR_CUDA
+
     @property
     def world_size(self):
         return 1
@@ -5841,6 +5868,8 @@ class NCCLTraceTestBase(MultiProcessTestCase):
 
 
 class NCCLTraceTest(NCCLTraceTestBase):
+    hw_classification = HardwareClassification.MULTI_ACCELERATOR_CUDA
+
     def _verify_trace(self, t, include_collectives, timing_enabled, is_json):
         ver = t["version"]
         self.assertEqual(ver, "2.10")
@@ -7241,6 +7270,8 @@ class NCCLTraceTestDumpOnTimeoutBase(NCCLTraceTestBase):
 
 @skip_but_pass_in_sandcastle
 class NCCLTraceTestDumpOnTimeout(NCCLTraceTestDumpOnTimeoutBase):
+    hw_classification = HardwareClassification.MULTI_ACCELERATOR_CUDA
+
     @requires_nccl()
     @skip_if_lt_x_gpu(2)
     @parametrize("timing_enabled", [True, False])
@@ -7293,6 +7324,8 @@ instantiate_parametrized_tests(NCCLTraceTest)
 
 @skip_but_pass_in_sandcastle
 class NCCLTraceTestTimeoutDumpOnStuckRanks(NCCLTraceTestDumpOnTimeoutBase):
+    hw_classification = HardwareClassification.MULTI_ACCELERATOR_CUDA
+
     @check_if_test_is_skipped
     def _check_return_codes(self, fn, elapsed_time):
         # the base test infra assumes processes exit with matching return codes,
@@ -7347,6 +7380,8 @@ class NCCLTraceTestTimeoutDumpOnStuckRanks(NCCLTraceTestDumpOnTimeoutBase):
 
 @skip_but_pass_in_sandcastle
 class NcclErrorDumpTest(NCCLTraceTestBase):
+    hw_classification = HardwareClassification.MULTI_ACCELERATOR_CUDA
+
     def _wait_process(self, rank, timeout):
         try:
             self.processes[rank].join(timeout)
@@ -7403,6 +7438,8 @@ class NcclErrorDumpTest(NCCLTraceTestBase):
 
 # tests that needs to be run with a larger world size
 class ProcessGroupNCCLLargerScaleTest(MultiProcessTestCase):
+    hw_classification = HardwareClassification.MULTI_ACCELERATOR_CUDA
+
     def _create_process_group_nccl(self, store, opts, device_id=None):
         # create nccl processgroup with opts
         c10d.init_process_group(

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -254,7 +254,7 @@ class TimeoutTest(test_c10d_common.AbstractTimeoutTest, TestCase):
 
 
 class ProcessGroupNCCLNoGPUTest(TestCase):
-    hw_classification = HardwareClassification.CUDA
+    hw_classification = HardwareClassification.GENERIC
     MAIN_PROCESS_RANK = 0
 
     def setUp(self):
@@ -278,7 +278,7 @@ class ProcessGroupNCCLNoGPUTest(TestCase):
 
 
 class ProcessGroupNCCLInitTest(MultiProcessTestCase):
-    hw_classification = HardwareClassification.MULTI_ACCELERATOR_CUDA
+    hw_classification = HardwareClassification.CUDA
     device_type = "cuda"
 
     def setUp(self):
@@ -5111,7 +5111,7 @@ class SetDeviceMethod(Enum):
 class NcclProcessGroupWithDispatchedCollectivesTests(
     test_c10d_common.ProcessGroupWithDispatchedCollectivesTests
 ):
-    hw_classification = HardwareClassification.MULTI_ACCELERATOR_CUDA
+    hw_classification = HardwareClassification.CUDA
 
     @requires_nccl()
     @skip_if_lt_x_gpu(1)
@@ -5626,7 +5626,7 @@ instantiate_parametrized_tests(LargeCommTest)
 
 
 class SparseCollective(MultiProcessTestCase):
-    hw_classification = HardwareClassification.MULTI_ACCELERATOR_CUDA
+    hw_classification = HardwareClassification.CUDA
 
     @property
     def world_size(self):
@@ -5702,7 +5702,7 @@ class SparseCollective(MultiProcessTestCase):
 
 
 class ProcessGroupNCCLOneRankTest(MultiProcessTestCase):
-    hw_classification = HardwareClassification.MULTI_ACCELERATOR_CUDA
+    hw_classification = HardwareClassification.CUDA
 
     @property
     def world_size(self):

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -105,7 +105,18 @@ try:
 except ImportError:
     # Temporary fallback for CI jobs that run the PR's test/run_test.py against a
     # previous nightly torch package that doesn't have HardwareClassification yet.
-    _HC_CHOICES = ["GENERIC", "ACCELERATOR", "CPU", "CUDA", "MPS", "XPU"]
+    _HC_CHOICES = [
+        "GENERIC",
+        "ACCELERATOR",
+        "CPU",
+        "CUDA",
+        "MPS",
+        "XPU",
+        "MULTI_ACCELERATOR",
+        "MULTI_ACCELERATOR_CUDA",
+        "MULTI_ACCELERATOR_XPU",
+        "MULTI_ACCELERATOR_MPS",
+    ]
 
 
 # Make sure to remove REPO_ROOT after import is done

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -140,6 +140,18 @@ class HardwareClassification(Enum):
       Use sparingly, and only for device-specific behavior.  These replace
       ``@onlyCPU``, ``@onlyCUDA``, and similar decorators
 
+    * ``MULTI_ACCELERATOR`` – multi-device tests that work across
+      accelerator types (e.g. backend-agnostic distributed API tests).
+      FakePG distributed tests should use ``GENERIC`` instead.
+
+    * ``MULTI_ACCELERATOR_CUDA`` – multi-device tests locked to CUDA
+      (e.g. NCCL collectives, multi-GPU CUDA kernels, NVLink, and
+      peer-to-peer transfers).
+
+    * ``MULTI_ACCELERATOR_XPU`` – multi-device tests locked to XPU.
+
+    * ``MULTI_ACCELERATOR_MPS`` – multi-device tests locked to MPS.
+
     Usage::
 
         class TestFoo(TestCase):
@@ -159,6 +171,10 @@ class HardwareClassification(Enum):
     CUDA = "cuda"
     MPS = "mps"
     XPU = "xpu"
+    MULTI_ACCELERATOR = "multi_accelerator"
+    MULTI_ACCELERATOR_CUDA = "multi_accelerator_cuda"
+    MULTI_ACCELERATOR_XPU = "multi_accelerator_xpu"
+    MULTI_ACCELERATOR_MPS = "multi_accelerator_mps"
 
 
 # Set by parse_cmd_line_args() if called

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -123,7 +123,7 @@ class HardwareClassification(Enum):
     values are executed.  When the flag is not specified, all test discovery
     and execution paths remain unchanged.
 
-    Currently there are three hardware classification categories:
+    Currently there are five hardware classification categories:
 
     * ``GENERIC`` – tests that exercise shared, device-agnostic logic
       (e.g. Dynamo dispatcher, FX passes, and other framework internals
@@ -141,16 +141,20 @@ class HardwareClassification(Enum):
       ``@onlyCPU``, ``@onlyCUDA``, and similar decorators
 
     * ``MULTI_ACCELERATOR`` – multi-device tests that work across
-      accelerator types (e.g. backend-agnostic distributed API tests).
+      accelerator types (e.g. ``ProcessGroup`` tests using
+      ``DistributedTestBase`` with a runtime-determined backend, or
+      backend-agnostic collective API tests).  These test classes typically
+      use :class:`~torch.testing._internal.common_distributed.MultiProcessTestCase`
+      rather than
+      :func:`~torch.testing._internal.common_utils.instantiate_device_type_tests`.
       FakePG distributed tests should use ``GENERIC`` instead.
 
-    * ``MULTI_ACCELERATOR_CUDA`` – multi-device tests locked to CUDA
-      (e.g. NCCL collectives, multi-GPU CUDA kernels, NVLink, and
-      peer-to-peer transfers).
-
-    * ``MULTI_ACCELERATOR_XPU`` – multi-device tests locked to XPU.
-
-    * ``MULTI_ACCELERATOR_MPS`` – multi-device tests locked to MPS.
+    * ``MULTI_ACCELERATOR_CUDA``, ``MULTI_ACCELERATOR_XPU``,
+      ``MULTI_ACCELERATOR_MPS`` – multi-device tests locked to a specific
+      accelerator (e.g. NCCL collectives, NVLink, and peer-to-peer transfers
+      for CUDA; CCL/oneCCL collectives for XPU; or other backend-specific
+      collective libraries).  Use sparingly, and only for backend-specific
+      multi-device behavior.
 
     Usage::
 


### PR DESCRIPTION
Adds `hw_classification` to all 16 concrete test classes in `test/distributed/test_c10d_nccl.py`. The `HardwareClassification` enum and infrastructure were introduced in #186918; this PR extends it with new `MULTI_ACCELERATOR_*` values and applies classification to the NCCL test file.

Follow the [RFC Test class classification](https://github.com/pytorch/pytorch/issues/185142)

### New enum values in `HardwareClassification`

| Value | Meaning |
|---|---|
| `MULTI_ACCELERATOR` | Multi-device tests that work across accelerator types (e.g. `ProcessGroup` tests with a runtime-determined backend). `FakePG` tests → use `GENERIC` instead. |
| `MULTI_ACCELERATOR_CUDA` | Multi-device tests locked to CUDA (NCCL collectives, NVLink, peer-to-peer). |
| `MULTI_ACCELERATOR_XPU` | Multi-device tests locked to XPU (CCL/oneCCL collectives). |
| `MULTI_ACCELERATOR_MPS` | Multi-device tests locked to MPS. |

The `MULTI_ACCELERATOR_*` naming mirrors the existing `ACCELERATOR` single-device value and avoids the ambiguity of `MULTI_DEVICE_*`.

### Classification corrections (from review feedback)

- `ProcessGroupNCCLNoGPUTest` → `GENERIC` (skips when GPUs are present; tests no-GPU error path only)
- `ProcessGroupNCCLInitTest`, `NcclProcessGroupWithDispatchedCollectivesTests`, `SparseCollective`, `ProcessGroupNCCLOneRankTest` → `CUDA` (all have `world_size=1` and `@skip_if_lt_x_gpu(1)` — single GPU is sufficient)

### Files changed

- `torch/testing/_internal/common_utils.py` — new enum values + improved docstrings (count, examples, infrastructure note for `MULTI_ACCELERATOR`)
- `test/distributed/test_c10d_nccl.py` — `hw_classification` on all 16 classes with corrected values
- `test/run_test.py` — fallback `_HC_CHOICES` updated with new values

Authored with an AI assistant.

cc: @mansiag05