### PR TITLE
[fx] _rename_unbacked_to: unify instead of assert on unbacked dest (#190083)

### DIFF
--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -71,6 +71,7 @@ from torch.utils._sympy.functions import (
     Min,
     Mod,
 )
+from torch.utils._sympy.value_ranges import ValueRangeError
 
 
 aten = torch.ops.aten
@@ -793,6 +794,136 @@ def forward(self, x_1):
         _constrain_range_for_size(i3)
         self.assertTrue(expect_true(i2 * 4 == i3))
         self.assertExpectedInline(str(i3), """u3""")
+
+    def test_rename_unbacked_to_unifies_unbacked_dest(self):
+        shape_env = ShapeEnv()
+        orig = shape_env.create_unbacked_symint().node.expr
+        new = shape_env.create_unbacked_symint().node.expr
+        dest = shape_env.create_unbacked_symint().node.expr
+        shape_env._set_replacement(orig, dest, "test-setup")
+        shape_env._rename_unbacked_to(orig, new)
+        self.assertEqual(shape_env.replacements[orig], new)
+        self.assertEqual(shape_env.replacements[new], dest)
+
+    def test_rename_unbacked_to_raises_on_disjoint_ranges(self):
+        shape_env = ShapeEnv()
+        orig = shape_env.create_unbacked_symint()
+        new = shape_env.create_unbacked_symint()
+        dest = shape_env.create_unbacked_symint()
+        _constrain_range_for_size(dest, min=0, max=5)
+        _constrain_range_for_size(new, min=10, max=20)
+        shape_env._set_replacement(orig.node.expr, dest.node.expr, "test-setup")
+        with self.assertRaises(ValueRangeError):
+            shape_env._rename_unbacked_to(orig.node.expr, new.node.expr)
+
+    def test_rename_unbacked_to_preserves_existing_backed_replacement(self):
+        shape_env = ShapeEnv()
+        orig = shape_env.create_unbacked_symint().node.expr
+        new = shape_env.create_unbacked_symint().node.expr
+        dest = shape_env.create_unbacked_symint().node.expr
+        backed = create_symint(shape_env, 4).node.expr
+        shape_env._set_replacement(new, backed, "test-setup")
+        shape_env._set_replacement(orig, dest, "test-setup")
+        shape_env._rename_unbacked_to(orig, new)
+        self.assertEqual(shape_env.replacements[orig], new)
+        self.assertEqual(shape_env.replacements[new], backed)
+        self.assertEqual(shape_env.replacements[dest], backed)
+
+    def test_rename_unbacked_to_unifies_existing_unbacked(self):
+        shape_env = ShapeEnv()
+        orig = shape_env.create_unbacked_symint().node.expr
+        new = shape_env.create_unbacked_symint().node.expr
+        dest = shape_env.create_unbacked_symint().node.expr
+        other = shape_env.create_unbacked_symint().node.expr
+        shape_env._set_replacement(new, other, "test-setup")
+        shape_env._set_replacement(orig, dest, "test-setup")
+        shape_env._rename_unbacked_to(orig, new)
+        self.assertEqual(shape_env.replacements[orig], new)
+        self.assertEqual(shape_env.replacements[new], dest)
+        self.assertEqual(shape_env.replacements[other], dest)
+
+    def test_rename_unbacked_to_preserves_transitive_backed_replacement(self):
+        shape_env = ShapeEnv()
+        orig = shape_env.create_unbacked_symint().node.expr
+        new = shape_env.create_unbacked_symint().node.expr
+        other = shape_env.create_unbacked_symint().node.expr
+        dest = shape_env.create_unbacked_symint().node.expr
+        backed = create_symint(shape_env, 4).node.expr
+        shape_env._set_replacement(other, backed, "test-setup")
+        shape_env._set_replacement(new, other, "test-setup")
+        shape_env._set_replacement(orig, dest, "test-setup")
+        shape_env._rename_unbacked_to(orig, new)
+        self.assertEqual(shape_env._find(new), backed)
+        self.assertEqual(shape_env.replacements[other], backed)
+        self.assertEqual(shape_env.replacements[dest], backed)
+
+    def test_rename_unbacked_to_unifies_unbacked_alias_onto_backed_dest(self):
+        shape_env = ShapeEnv()
+        orig = shape_env.create_unbacked_symint().node.expr
+        new = shape_env.create_unbacked_symint().node.expr
+        alias = shape_env.create_unbacked_symint().node.expr
+        backed_dest = create_symint(shape_env, 4).node.expr
+        shape_env._set_replacement(new, alias, "test-setup")
+        shape_env._set_replacement(orig, backed_dest, "test-setup")
+        shape_env._rename_unbacked_to(orig, new)
+        self.assertEqual(shape_env._find(orig), backed_dest)
+        self.assertEqual(shape_env._find(new), backed_dest)
+        self.assertEqual(shape_env._find(alias), backed_dest)
+
+    def test_rename_unbacked_to_skips_range_widening_alias(self):
+        shape_env = ShapeEnv()
+        orig = shape_env.create_unbacked_symint()
+        new = shape_env.create_unbacked_symint()
+        alias = shape_env.create_unbacked_symint()
+        dest = shape_env.create_unbacked_symint()
+        _constrain_range_for_size(new, min=0, max=100)
+        _constrain_range_for_size(alias, min=0, max=5)
+        _constrain_range_for_size(dest, min=0, max=20)
+        shape_env._set_replacement(new.node.expr, alias.node.expr, "test-setup")
+        shape_env._set_replacement(orig.node.expr, dest.node.expr, "test-setup")
+        shape_env._rename_unbacked_to(orig.node.expr, new.node.expr)
+        self.assertEqual(shape_env._find(new.node.expr), dest.node.expr)
+        self.assertEqual(shape_env._find(orig.node.expr), dest.node.expr)
+        self.assertNotIn(alias.node.expr, shape_env.replacements)
+
+    def test_rename_unbacked_to_unifies_two_backed_terminals(self):
+        shape_env = ShapeEnv()
+        orig = shape_env.create_unbacked_symint().node.expr
+        new = shape_env.create_unbacked_symint().node.expr
+        backed_dest = create_symint(shape_env, 4, duck=False).node.expr
+        backed_new = create_symint(shape_env, 4, duck=False).node.expr
+        shape_env._set_replacement(new, backed_new, "test-setup")
+        shape_env._set_replacement(orig, backed_dest, "test-setup")
+        shape_env._rename_unbacked_to(orig, new)
+        self.assertEqual(shape_env.replacements[new], backed_dest)
+        self.assertEqual(shape_env._find(orig), shape_env._find(new))
+
+    def test_rename_unbacked_to_unifies_on_double_propagation(self):
+        from torch._guards import detect_fake_mode
+        from torch.fx.experimental.symbolic_shapes import PropagateUnbackedSymInts
+
+        class M(torch.nn.Module):
+            def forward(self, x):
+                u = torch.unique(x)  # aten._unique2 -> unbacked count
+                return u.sum() + x.new_zeros(u.shape[0]).sum()
+
+        m = M()
+        inp = (torch.tensor([1, 1, 2, 3, 3]),)
+        ep = torch.export.export(m, inp)
+        gm = ep.module()
+        ph_vals = [
+            n.meta["val"]
+            for n in gm.graph.nodes
+            if n.op == "placeholder" and "val" in n.meta
+        ]
+        fm = detect_fake_mode(ph_vals)
+        self.assertIsNotNone(fm)
+        with fm:
+            PropagateUnbackedSymInts(gm).run(*ph_vals)
+            PropagateUnbackedSymInts(gm).run(*ph_vals)
+        # After the (previously-asserting) re-propagation, the exported program
+        # still runs and matches eager.
+        self.assertEqual(gm(*inp), m(*inp))
 
     def test_avoid_unbacked_substitution(self):
         shape_env = ShapeEnv()

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -4446,13 +4446,68 @@ class ShapeEnv:
                 f"Expected orig_s to have free unbacked symbols: {orig_s}"
             )
         dest = self.replacements.get(orig_s)
-        if dest is not None:
-            if free_unbacked_symbols(dest):
-                raise AssertionError(f"{orig_s} -> {dest}")
+        if dest is not None and free_unbacked_symbols(dest):
+            # Re-exporting or re-lowering can register the same data-dependent binding
+            # twice, e.g. aten._unique2 through ExportedProgram.module() and
+            # PropagateUnbackedSymInts. Therefore orig_s, new_s, and dest are equal.
+            signpost_event(
+                "dynamic",
+                "rename_unbacked_to_unify",
+                {"orig_s": str(orig_s), "new_s": str(new_s), "dest": str(dest)},
+            )
+            log.info(
+                "rename_unbacked_to: unifying %s -> %s (existing dest %s)",
+                orig_s,
+                new_s,
+                dest,
+            )
         self._set_replacement(orig_s, new_s, "rename_unbacked_to")
         self.unbacked_renamings[orig_s] = new_s
         if dest is not None:
-            self._set_replacement(new_s, dest, "rename_unbacked_to_dest")
+            self._unify_unbacked_aliases(new_s, dest)
+
+    def _unify_unbacked_aliases(self, new_s: sympy.Symbol, dest: sympy.Expr) -> None:
+        """Unify unbacked aliases under one terminal, preferring a backed one.
+
+        When this function is called, ``new_s``, ``dest``, and the expression
+        ``new_s`` resolves to are known to be equal. A backed terminal is preferred
+        because it has a usable hint.
+        """
+        # Resolve new_s transitively (not a one-hop replacements lookup) so a
+        # chain like new_s -> unbacked -> backed contributes the backed terminal
+        # here rather than the intermediate unbacked symbol.
+        existing = self._find(new_s)
+        aliases = list(
+            dict.fromkeys(a for a in (new_s, dest, existing) if a is not None)
+        )
+        backed_aliases = [a for a in aliases if not free_unbacked_symbols(a)]
+        terminal = backed_aliases[0] if backed_aliases else dest
+
+        for alias in aliases:
+            # Redirect only unbacked symbols: the terminal needs no redirect, a
+            # replacement key must be a bare Symbol, and backed symbols are roots
+            # that must never be repointed.
+            if (
+                alias == terminal
+                or not isinstance(alias, sympy.Symbol)
+                or not free_unbacked_symbols(alias)
+            ):
+                continue
+            self._set_replacement(alias, terminal, "rename_unbacked_to_dest")
+            if self.replacements.get(alias) != terminal:
+                # _set_replacement declined the substitution (e.g. the target
+                # range is not a subset), leaving alias unreconciled rather than
+                # unified -- surface it instead of failing silently.
+                signpost_event(
+                    "dynamic",
+                    "rename_unbacked_to_unify_skipped",
+                    {"alias": str(alias), "terminal": str(terminal)},
+                )
+                log.info(
+                    "rename_unbacked_to: could not unify %s -> %s",
+                    alias,
+                    terminal,
+                )
 
     @record_shapeenv_event()
     def _constrain_is_bounded(self, a: sympy.Symbol, upper_bound: int) -> None:


### PR DESCRIPTION
Summary:

`_rename_unbacked_to` raised `AssertionError(f"{orig_s} -> {dest}")` when the
symbol being renamed (`orig_s`) already had a replacement that was itself an
unbacked symbol (`dest`).

This is hit when the same op's unbacked binding is rebound across multiple
retrace passes -- e.g. re-exporting / re-lowering an ExportedProgram whose graph
already carries `unbacked_bindings`, so a data-dependent op such as
`aten._unique2` is registered by both `ExportedProgram.module()` and
`PropagateUnbackedSymInts`. In that situation `orig_s`, `new_s` and `dest` all
denote the same runtime value, so aborting is unnecessary.

Fix: drop the assert and generalize the dest-reconciliation into a single unify
step, factored into the helper `_unify_unbacked_aliases`. `orig_s`, `new_s`,
`dest`, and `new_s`'s transitively-resolved replacement
(`existing = self._find(new_s)`) all denote the same value, so we pick one
terminal -- preferring a backed expr -- and redirect every remaining unbacked
alias onto it via `_set_replacement`. This preserves the transitive unification
(`orig_s -> new_s -> terminal`) while covering the corner cases below.

Corner cases handled by the generalized unify:
- Transitively-backed `existing`: `existing` is resolved with `_find`, not a
  one-hop `replacements[new_s]` lookup, so a chain `new_s -> unbacked -> backed`
  surfaces the backed terminal. A one-hop lookup would see the intermediate
  unbacked symbol, pick an unbacked terminal, and overwrite `unbacked -> backed`
  -- silently losing the backed resolution.
- Backed `existing`: if `new_s` resolves to a backed symbol, routing
  `new_s -> dest` (unbacked) would downgrade a backed resolution to an unbacked
  alias. Preferring a backed terminal pins the unbacked `dest` at the backed
  symbol instead, so backedness is never lost.
- Unbacked `existing`: if `new_s` resolves only to another unbacked symbol, it
  is redirected onto the same terminal too, so nothing is left dangling.
- Deterministic terminal choice (first backed alias, else `dest`) keeps the
  result reproducible for `record_shapeenv_event` replay / translation
  validation.

Does not hide a genuine inconsistency:
- `_set_replacement` refines/intersects value ranges and raises
  `ValueRangeError` when two aliases are provably different (disjoint ranges),
  so a real conflict still surfaces at bind time.
- If `_set_replacement` instead silently declines a substitution (target range
  not a subset), we emit a `signpost_event("dynamic",
  "rename_unbacked_to_unify_skipped", ...)` + log so the unreconciled alias is
  observable rather than silent.
- The residual case (same range, different value) is caught downstream by
  AOTInductor runtime size asserts and the lowering's inference-parity check.

Applied to both the `fbcode` and `xplat` copies of `symbolic_shapes.py`.

Test Plan:
New unit tests in `test/test_dynamic_shapes.py` (all pass):
  buck2 test @//mode/opt fbcode//caffe2/test:dynamic_shapes -- test_rename_unbacked_to
  => Pass 4. Fail 0.
- `test_rename_unbacked_to_unifies_unbacked_dest`: benign duplicate binding now
  unifies (`orig -> new -> dest`) instead of raising.
- `test_rename_unbacked_to_raises_on_disjoint_ranges`: a provably-different
  (disjoint-range) rename still surfaces `ValueRangeError` rather than being
  silently unified.
- `test_rename_unbacked_to_preserves_backed_dest`: when `new` already resolves
  to a backed symbol it is not downgraded -- both `new` and the unbacked `dest`
  end up resolving to the backed symbol.
- `test_rename_unbacked_to_unifies_existing_unbacked`: when `new` already
  resolves to another unbacked symbol, that symbol is unified onto the same
  terminal rather than left dangling.

Differential Revision: D112158177


