### PR TITLE
Add c10::safe_conv (strict, integer-only) and c10::unsafe_wrapping_convert (#190092)

### DIFF
--- a/c10/test/util/TypeSafeSignMath_test.cpp
+++ b/c10/test/util/TypeSafeSignMath_test.cpp
@@ -1,0 +1,138 @@
+#include <c10/util/TypeSafeSignMath.h>
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <limits>
+#include <typeinfo>
+#include <utility>
+
+// These tests pin the invariant that c10::safe_conv relies on: for
+// integer->integer, the TypeSafeSignMath range check
+//   !less_than_lowest<To>(f) && !greater_than_max<To>(f)
+// is exactly equivalent to std::in_range<To>(f) (the C++20 ground truth). This
+// guards against regressions in the hand-written sign-aware comparisons that
+// safe_conv uses in place of std::in_range (see c10/util/safe_conv.h).
+
+namespace c10 {
+namespace {
+
+template <typename To, typename From>
+bool tsm_representable(From f) {
+  return !c10::less_than_lowest<To>(f) && !c10::greater_than_max<To>(f);
+}
+
+template <typename To, typename From>
+void checkOne(From f) {
+  EXPECT_EQ(tsm_representable<To>(f), std::in_range<To>(f))
+      << "To=" << typeid(To).name() << " From=" << typeid(From).name()
+      << " f=" << static_cast<long long>(f);
+}
+
+// Every target integer type, for a single source value.
+template <typename From>
+void checkAllTargets(From f) {
+  checkOne<int8_t>(f);
+  checkOne<uint8_t>(f);
+  checkOne<int16_t>(f);
+  checkOne<uint16_t>(f);
+  checkOne<int32_t>(f);
+  checkOne<uint32_t>(f);
+  checkOne<int64_t>(f);
+  checkOne<uint64_t>(f);
+}
+
+// Boundary seeds spanning every integer type's limits (+/-1 around them). Cast
+// to the source type (integer static_cast is always well-defined) so each
+// source type is exercised right where representability flips.
+template <typename From>
+void checkBoundarySeeds() {
+  constexpr int64_t s[] = {
+      0,
+      1,
+      2,
+      -1,
+      -2,
+      126,
+      127,
+      128,
+      254,
+      255,
+      256,
+      -127,
+      -128,
+      -129,
+      32766,
+      32767,
+      32768,
+      65535,
+      65536,
+      -32768,
+      -32769,
+      2147483646LL,
+      2147483647LL,
+      2147483648LL,
+      4294967295LL,
+      4294967296LL,
+      -2147483648LL,
+      -2147483649LL,
+      9223372036854775806LL,
+      9223372036854775807LL,
+      std::numeric_limits<int64_t>::min()};
+  for (int64_t v : s) {
+    checkAllTargets<From>(static_cast<From>(v));
+  }
+  constexpr uint64_t u[] = {
+      9223372036854775808ULL, 18446744073709551614ULL, 18446744073709551615ULL};
+  for (uint64_t v : u) {
+    checkAllTargets<From>(static_cast<From>(v));
+  }
+  checkAllTargets<From>(std::numeric_limits<From>::min());
+  checkAllTargets<From>(std::numeric_limits<From>::max());
+}
+
+TEST(TypeSafeSignMathTest, ExhaustiveEightAndSixteenBitSources) {
+  for (int v = 0; v <= 255; ++v) {
+    checkAllTargets<uint8_t>(static_cast<uint8_t>(v));
+  }
+  for (int v = -128; v <= 127; ++v) {
+    checkAllTargets<int8_t>(static_cast<int8_t>(v));
+  }
+  for (int v = 0; v <= 65535; ++v) {
+    checkAllTargets<uint16_t>(static_cast<uint16_t>(v));
+  }
+  for (int v = -32768; v <= 32767; ++v) {
+    checkAllTargets<int16_t>(static_cast<int16_t>(v));
+  }
+}
+
+TEST(TypeSafeSignMathTest, BoundarySeedsWideSources) {
+  checkBoundarySeeds<int32_t>();
+  checkBoundarySeeds<uint32_t>();
+  checkBoundarySeeds<int64_t>();
+  checkBoundarySeeds<uint64_t>();
+}
+
+// The behaviors safe_conv depends on, pinned explicitly so the critical rows
+// are protected even if the oracle above ever changes.
+TEST(TypeSafeSignMathTest, CriticalRows) {
+  // negative -> unsigned is out of range (no two's-complement wrap)
+  EXPECT_FALSE(tsm_representable<uint32_t>(int64_t{-1}));
+  EXPECT_FALSE(tsm_representable<uint8_t>(int32_t{-5}));
+  EXPECT_FALSE(tsm_representable<uint64_t>(int64_t{-1}));
+  // exact-fit boundaries
+  EXPECT_TRUE(tsm_representable<int32_t>(int64_t{2147483647}));
+  EXPECT_FALSE(tsm_representable<int32_t>(int64_t{2147483648}));
+  EXPECT_TRUE(tsm_representable<uint32_t>(int64_t{4294967295}));
+  EXPECT_FALSE(tsm_representable<uint32_t>(int64_t{4294967296}));
+  EXPECT_TRUE(tsm_representable<int64_t>(uint64_t{9223372036854775807ULL}));
+  EXPECT_FALSE(tsm_representable<int64_t>(uint64_t{9223372036854775808ULL}));
+  EXPECT_TRUE(tsm_representable<uint64_t>(uint64_t{18446744073709551615ULL}));
+  // same-type is always representable
+  EXPECT_TRUE(
+      tsm_representable<uint64_t>(std::numeric_limits<uint64_t>::max()));
+  EXPECT_TRUE(tsm_representable<int8_t>(int8_t{-128}));
+}
+
+} // namespace
+} // namespace c10

--- a/c10/test/util/safe_conv_test.cpp
+++ b/c10/test/util/safe_conv_test.cpp
@@ -1,0 +1,76 @@
+#include <c10/util/safe_conv.h>
+
+#include <c10/util/TypeCast.h>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+
+namespace c10 {
+namespace {
+
+TEST(safeConvTest, InRangePassesThrough) {
+  EXPECT_EQ(safe_conv<int32_t>(int64_t{5}), 5);
+  EXPECT_EQ(
+      safe_conv<int32_t>(int64_t{std::numeric_limits<int32_t>::max()}),
+      std::numeric_limits<int32_t>::max());
+  EXPECT_EQ(
+      safe_conv<int32_t>(int64_t{std::numeric_limits<int32_t>::min()}),
+      std::numeric_limits<int32_t>::min());
+}
+
+TEST(safeConvTest, SameTypeIsNoOp) {
+  EXPECT_EQ(safe_conv<int32_t>(int32_t{42}), 42);
+  EXPECT_EQ(
+      safe_conv<uint64_t>(std::numeric_limits<uint64_t>::max()),
+      std::numeric_limits<uint64_t>::max());
+}
+
+TEST(safeConvTest, OverflowHighThrows) {
+  constexpr int64_t tooBig = int64_t{std::numeric_limits<int32_t>::max()} + 1;
+  EXPECT_THROW(safe_conv<int32_t>(tooBig), std::runtime_error);
+}
+
+TEST(safeConvTest, OverflowLowThrows) {
+  constexpr int64_t tooSmall = int64_t{std::numeric_limits<int32_t>::min()} - 1;
+  EXPECT_THROW(safe_conv<int32_t>(tooSmall), std::runtime_error);
+}
+
+// The key differentiator from unsafe_wrapping_convert: a negative value
+// converted to an unsigned type is REJECTED, never wrapped to a large positive
+// value.
+TEST(safeConvTest, NegativeToUnsignedThrows) {
+  EXPECT_THROW(safe_conv<uint8_t>(int32_t{-1}), std::runtime_error);
+  EXPECT_THROW(safe_conv<uint32_t>(int64_t{-1}), std::runtime_error);
+}
+
+TEST(safeConvTest, UnsignedToUnsignedBoundary) {
+  EXPECT_EQ(safe_conv<uint32_t>(int64_t{0}), 0u);
+  EXPECT_EQ(
+      safe_conv<uint32_t>(int64_t{std::numeric_limits<uint32_t>::max()}),
+      std::numeric_limits<uint32_t>::max());
+  constexpr int64_t tooBig = int64_t{std::numeric_limits<uint32_t>::max()} + 1;
+  EXPECT_THROW(safe_conv<uint32_t>(tooBig), std::runtime_error);
+}
+
+TEST(safeConvTest, UnsignedToSignedOverflowThrows) {
+  EXPECT_EQ(safe_conv<int8_t>(uint32_t{100}), 100);
+  EXPECT_THROW(safe_conv<int8_t>(uint32_t{200}), std::runtime_error);
+}
+
+// unsafe_wrapping_convert preserves the historical signed->unsigned
+// two's-complement wrap that safe_conv rejects.
+TEST(safeConvTest, UnsafeWrappingConvertPreservesWrap) {
+  EXPECT_EQ(unsafe_wrapping_convert<uint8_t>(int64_t{-1}, "uint8_t"), 255);
+  EXPECT_EQ(unsafe_wrapping_convert<uint16_t>(int64_t{-1}, "uint16_t"), 65535);
+  EXPECT_EQ(
+      unsafe_wrapping_convert<uint32_t>(int64_t{-1}, "uint32_t"), 4294967295u);
+  // Wrap applies only to unsigned targets; signed targets still range-check.
+  constexpr int64_t tooBig = int64_t{std::numeric_limits<int32_t>::max()} + 1;
+  EXPECT_THROW(
+      unsafe_wrapping_convert<int32_t>(tooBig, "int32_t"), std::runtime_error);
+}
+
+} // namespace
+} // namespace c10

--- a/c10/util/TypeCast.h
+++ b/c10/util/TypeCast.h
@@ -9,6 +9,7 @@
 #include <c10/util/Half.h>
 #include <c10/util/complex.h>
 #include <c10/util/overflows.h>
+#include <c10/util/safe_conv.h>
 
 #include <type_traits>
 
@@ -328,6 +329,20 @@ C10_HOST_DEVICE To convert(From f) {
 
 template <typename To, typename From>
 To checked_convert(From f, const char* name) {
+  // Converting to bool can't overflow so we exclude this case from checking.
+  if (!std::is_same_v<To, bool> && overflows<To, From>(f)) {
+    report_overflow(name);
+  }
+  return convert<To, From>(f);
+}
+
+// Range-checked conversion that PERMITS signed->unsigned two's-complement
+// wraparound (via overflows() with its default strict_unsigned=false). Retained
+// only to preserve the historical behavior of the few call sites that relied on
+// the wrap. DO NOT use in new code: use c10::safe_conv (strict integer
+// narrowing, c10/util/safe_conv.h) or c10::checked_convert (general, above).
+template <typename To, typename From>
+To unsafe_wrapping_convert(From f, const char* name) {
   // Converting to bool can't overflow so we exclude this case from checking.
   if (!std::is_same_v<To, bool> && overflows<To, From>(f)) {
     report_overflow(name);

--- a/c10/util/safe_conv.cpp
+++ b/c10/util/safe_conv.cpp
@@ -1,0 +1,18 @@
+#include <c10/util/safe_conv.h>
+
+#include <sstream>
+#include <stdexcept>
+#include <utility>
+
+namespace c10::detail {
+
+[[noreturn]] void report_narrowing_overflow(const char* name) {
+  std::ostringstream oss;
+  oss << "value cannot be safely converted without overflow";
+  if (name != nullptr) {
+    oss << ": " << name;
+  }
+  throw std::runtime_error(std::move(oss).str());
+}
+
+} // namespace c10::detail

--- a/c10/util/safe_conv.h
+++ b/c10/util/safe_conv.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <c10/macros/Macros.h>
+#include <c10/util/TypeSafeSignMath.h>
+
+#include <type_traits>
+
+// c10::safe_conv is the deliberately lightweight, INTEGER-ONLY, strict
+// narrowing conversion. This header intentionally avoids <c10/util/TypeCast.h>
+// (and its Half/BFloat16/Float8/complex machinery) so it stays cheap to include
+// in ubiquitous low-level headers and, especially, in CUDA/HIP kernels.
+//
+// For general conversions -- floating-point or complex sources, or any case
+// where a lossy-but-in-range cast is acceptable -- use c10::checked_convert
+// (c10/util/TypeCast.h) instead. If you deliberately want signed->unsigned
+// two's-complement wraparound, use c10::unsafe_wrapping_convert.
+
+namespace c10 {
+
+namespace detail {
+// Defined out-of-line in safe_conv.cpp (part of //c10/util:base) so the throw
+// is not inlined at every call site (avoids code-size bloat), and so this
+// header stays lightweight.
+[[noreturn]] C10_API void report_narrowing_overflow(const char* name);
+
+#if defined(__cpp_concepts)
+template <typename T>
+concept SafeConvIntegral = std::is_integral_v<T> && !std::is_same_v<T, bool>;
+#endif
+} // namespace detail
+
+// Strict, range-checked INTEGER narrowing conversion.
+//
+// Rejects ANY value not representable in To -- in particular there is NO
+// signed->unsigned two's-complement wraparound (a negative source converted to
+// an unsigned type is rejected, not wrapped). Use this wherever a narrowing
+// truncation would be a bug.
+//
+// For floating-point/complex sources or general conversions, use
+// c10::checked_convert (c10/util/TypeCast.h). For intentional modular wrap, use
+// c10::unsafe_wrapping_convert.
+//
+// Usable in both host and device code: on host it throws via
+// report_narrowing_overflow; in CUDA/HIP device code (which cannot throw) it
+// traps via CUDA_KERNEL_ASSERT_PRINTF, printing name if one is provided.
+#if defined(__cpp_concepts)
+template <detail::SafeConvIntegral To, detail::SafeConvIntegral From>
+#else
+template <typename To, typename From>
+#endif
+C10_HOST_DEVICE To safe_conv(From f, const char* name = nullptr) {
+#if !defined(__cpp_concepts)
+  // The integer-only restriction is load-bearing for correctness, not just
+  // ergonomics: the TypeSafeSignMath range check below is exact for
+  // integer->integer, but its digits-based logic is silently wrong for
+  // floating-point sources. Route float/complex through c10::checked_convert.
+  static_assert(
+      std::is_integral_v<To> && !std::is_same_v<To, bool>,
+      "safe_conv requires an integral, non-bool destination type");
+  static_assert(
+      std::is_integral_v<From> && !std::is_same_v<From, bool>,
+      "safe_conv requires an integral, non-bool source type");
+#endif
+  // Exact for integer->integer and device-safe (plain constexpr comparisons).
+  // TODO: Use std::in_range after ExecuTorch moves to C++20.
+  const bool representable =
+      !c10::less_than_lowest<To>(f) && !c10::greater_than_max<To>(f);
+  if (!representable) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    // Device code cannot throw; trap on overflow instead, printing name if set.
+    CUDA_KERNEL_ASSERT_PRINTF(
+        false,
+        "value cannot be safely converted without overflow: %s",
+        name != nullptr ? name : "<unknown>");
+#else
+    detail::report_narrowing_overflow(name);
+#endif
+  }
+  return static_cast<To>(f);
+}
+
+} // namespace c10


### PR DESCRIPTION
Summary:

Additive, backwards-compatible groundwork for splitting narrowing-conversion intent. This PR only ADDS new API; it changes no existing behavior or function signature. A follow-up PR (#191234) migrates callers and makes `c10::checked_convert` strict for integers (the BC-affecting part).

- Add `c10::safe_conv<To>(From)` in a new lightweight header `c10/util/safe_conv.h`: a STRICT, integer-only range-checked narrowing usable in host and device code (throws on host via an out-of-line reporter; traps via `CUDA_KERNEL_ASSERT_PRINTF` on CUDA/HIP). The range check uses `c10::less_than_lowest`/`greater_than_max` (exact for integer->integer and device-safe as plain constexpr comparisons); a TODO notes switching to `std::in_range` once the ExecuTorch header mirror is C++20. The header avoids `TypeCast.h` (Half/BFloat16/Float8/complex) so it is cheap to include in ubiquitous headers and CUDA kernels.
- Add `c10::unsafe_wrapping_convert` (a copy of the current `checked_convert` body) so a later PR can route the few call sites that deliberately rely on signed->unsigned two's-complement wrap through an explicitly-named function.
- `c10::checked_convert` is UNCHANGED: same signature, same wrapping behavior. No caller is migrated in this PR.

Adds `c10/test/util/TypeSafeSignMath_test.cpp` pinning the invariant `safe_conv` relies on: `!less_than_lowest<To> && !greater_than_max<To>` equals `std::in_range<To>` for integer->integer, checked exhaustively over 8/16-bit sources against all integer targets plus boundary sweeps for 32/64-bit, with explicit critical-row assertions. Adds `c10/test/util/safe_conv_test.cpp` covering `safe_conv` (strict; negative->unsigned rejected) and `unsafe_wrapping_convert` (wrap preserved).

Note: `TypeSafeSignMath` cannot be made meaningfully lighter -- its cost is `<type_traits>` + `<limits>`, both required; the `Macros.h` chain is negligible.

Test Plan:
Verified the `TypeSafeSignMath == std::in_range` equivalence standalone (`g++ -std=c++20`): 1,053,824 checks across all integer To/From pairs, 0 mismatches. `lintrunner -a` is clean on all touched files. Relies on CI to build and run `c10_TypeSafeSignMath_test` and `c10_safe_conv_test` (internally, `util_base_tests`).

Authored with the assistance of Claude Code.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01
