### PR TITLE
Increase ROCm MI200 CI test shard counts

### DIFF
--- a/.github/workflows/inductor-rocm-mi200.yml
+++ b/.github/workflows/inductor-rocm-mi200.yml
@@ -43,8 +43,10 @@ jobs:
       docker-image-name: ci-image:pytorch-linux-jammy-rocm-n-py3
       test-matrix: |
         { include: [
-          { config: "inductor", shard: 1, num_shards: 2, runner: "linux.rocm.gpu.mi210.1" },
-          { config: "inductor", shard: 2, num_shards: 2, runner: "linux.rocm.gpu.mi210.1" },
+          { config: "inductor", shard: 1, num_shards: 4, runner: "linux.rocm.gpu.mi210.1" },
+          { config: "inductor", shard: 2, num_shards: 4, runner: "linux.rocm.gpu.mi210.1" },
+          { config: "inductor", shard: 3, num_shards: 4, runner: "linux.rocm.gpu.mi210.1" },
+          { config: "inductor", shard: 4, num_shards: 4, runner: "linux.rocm.gpu.mi210.1" },
         ]}
     secrets: inherit
 

--- a/.github/workflows/rocm-mi200.yml
+++ b/.github/workflows/rocm-mi200.yml
@@ -53,12 +53,16 @@ jobs:
       sync-tag: rocm-build
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 6, runner: "linux.rocm.gpu.mi210.1" },
-          { config: "default", shard: 2, num_shards: 6, runner: "linux.rocm.gpu.mi210.1" },
-          { config: "default", shard: 3, num_shards: 6, runner: "linux.rocm.gpu.mi210.1" },
-          { config: "default", shard: 4, num_shards: 6, runner: "linux.rocm.gpu.mi210.1" },
-          { config: "default", shard: 5, num_shards: 6, runner: "linux.rocm.gpu.mi210.1" },
-          { config: "default", shard: 6, num_shards: 6, runner: "linux.rocm.gpu.mi210.1" },
+          { config: "default", shard: 1, num_shards: 10, runner: "linux.rocm.gpu.mi210.1" },
+          { config: "default", shard: 2, num_shards: 10, runner: "linux.rocm.gpu.mi210.1" },
+          { config: "default", shard: 3, num_shards: 10, runner: "linux.rocm.gpu.mi210.1" },
+          { config: "default", shard: 4, num_shards: 10, runner: "linux.rocm.gpu.mi210.1" },
+          { config: "default", shard: 5, num_shards: 10, runner: "linux.rocm.gpu.mi210.1" },
+          { config: "default", shard: 6, num_shards: 10, runner: "linux.rocm.gpu.mi210.1" },
+          { config: "default", shard: 7, num_shards: 10, runner: "linux.rocm.gpu.mi210.1" },
+          { config: "default", shard: 8, num_shards: 10, runner: "linux.rocm.gpu.mi210.1" },
+          { config: "default", shard: 9, num_shards: 10, runner: "linux.rocm.gpu.mi210.1" },
+          { config: "default", shard: 10, num_shards: 10, runner: "linux.rocm.gpu.mi210.1" },
         ]}
     secrets: inherit
 


### PR DESCRIPTION
## Summary

Increase test shard counts for ROCm MI200 CI workflows to reduce per-shard runtime and improve parallelism:

- `rocm-mi200.yml`: 6 -> 10 shards for the default test config
- `inductor-rocm-mi200.yml`: 2 -> 4 shards for the inductor test config

These shard counts match what is already configured in `trunk-rocm-sandbox.yml`.

## Test plan

- [ ] Trigger `rocm-mi200` and `inductor-rocm-mi200` workflows and confirm all shards are spawned
- [ ] Verify per-shard runtime is reduced compared to current shard counts

Authored with assistance from Cursor

Made with [Cursor](https://cursor.com)

cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang