### PR TITLE
Skip test_backend_simple (failing on main)

### DIFF
--- a/test/test_privateuseone_python_backend.py
+++ b/test/test_privateuseone_python_backend.py
@@ -1,4 +1,6 @@
 # Owner(s): ["module: PrivateUse1"]
+import unittest
+
 import numpy as np
 
 import torch
@@ -138,6 +140,10 @@ class PrivateUse1BackendTest(TestCase):
         # Assert this don't throw:
         _ = a_cpu.is_pinned()
 
+    @unittest.skip(
+        "Disabled due to CI failures; see "
+        "https://github.com/pytorch/pytorch/issues/188688"
+    )
     def test_backend_simple(self):
         a_cpu = torch.randn((2, 2))
         b_cpu = torch.randn((2, 2))

--- a/test/test_privateuseone_python_backend.py
+++ b/test/test_privateuseone_python_backend.py
@@ -142,7 +142,7 @@ class PrivateUse1BackendTest(TestCase):
 
     @unittest.skip(
         "Disabled due to CI failures; see "
-        "https://github.com/pytorch/pytorch/issues/188688"
+        "https://github.com/pytorch/pytorch/issues/190232"
     )
     def test_backend_simple(self):
         a_cpu = torch.randn((2, 2))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #190098

Disables PrivateUse1BackendTest.test_backend_simple, failing in CI and tracked/
disabled via #188688.

Test Plan: test-only; the test is skipped.

Authored with Claude.