### PR TITLE
[inductor] Prototype: partial/regional AOTI (#190100)

### DIFF
--- a/test/inductor/test_regional_aoti.py
+++ b/test/inductor/test_regional_aoti.py
@@ -1,0 +1,393 @@
+# Owner(s): ["module: inductor"]
+"""Tests for the prototype torch._inductor.regional_aoti API.
+
+Compile/runtime tests are device-generic (via instantiate_device_type_tests) so
+they run on CPU and, on the GPU target, CUDA. No ``only_for`` is passed, so under
+the ASAN CPU target (where CUDA cannot init) only CPU variants are generated.
+"""
+
+from unittest import mock
+
+import torch
+import torch.nn as nn
+from torch._inductor import regional_aoti
+from torch._inductor.regional_aoti import (
+    AOTIRegionConfig,
+    AOTIRegionExportError,
+    CompiledAOTIRegion,
+)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+# ---------------------------------------------------------------------------
+# Test modules
+# ---------------------------------------------------------------------------
+class GoodBlock(nn.Module):
+    """A cleanly exportable region (marked on the class)."""
+
+    def __init__(self, dim=8):
+        super().__init__()
+        self.lin1 = nn.Linear(dim, dim)
+        self.lin2 = nn.Linear(dim, dim)
+
+    def forward(self, x):
+        return self.lin2(torch.relu(self.lin1(x)))
+
+
+regional_aoti.region()(GoodBlock)  # class-level marking
+
+
+class MethodMarkedBlock(nn.Module):
+    def __init__(self, dim=8):
+        super().__init__()
+        self.lin = nn.Linear(dim, dim)
+
+    @regional_aoti.region()
+    def forward(self, x):
+        return torch.relu(self.lin(x))
+
+
+class PlainBlock(nn.Module):
+    def __init__(self, dim=8):
+        super().__init__()
+        self.lin = nn.Linear(dim, dim)
+
+    def forward(self, x):
+        return self.lin(x)
+
+
+class BadBlock(nn.Module):
+    """A region that cannot be exported (numpy round-trip breaks under export)."""
+
+    def __init__(self, dim=8):
+        super().__init__()
+        self.lin = nn.Linear(dim, dim)
+
+    @regional_aoti.region()
+    def forward(self, x):
+        y = self.lin(x)
+        arr = y.detach().cpu().numpy()  # not traceable by export
+        return torch.from_numpy(arr).to(x.device) * 2.0
+
+
+class OuterNested(nn.Module):
+    """Marked outer region containing a marked inner region."""
+
+    def __init__(self, dim=8):
+        super().__init__()
+        self.inner = GoodBlock(dim)  # also marked
+
+    @regional_aoti.region()
+    def forward(self, x):
+        return self.inner(x)
+
+
+class ConditionalModel(nn.Module):
+    """The marked region is only reached when ``use_region`` is True."""
+
+    def __init__(self, dim=8):
+        super().__init__()
+        self.region = GoodBlock(dim)
+        self.fallback_lin = nn.Linear(dim, dim)
+
+    def forward(self, x, use_region: bool):
+        if use_region:
+            return self.region(x)
+        return self.fallback_lin(x)
+
+
+class TwoRegionModel(nn.Module):
+    """One good + one bad region wrapped in an eager outer model."""
+
+    def __init__(self, dim=8):
+        super().__init__()
+        self.pre = nn.Linear(dim, dim)  # eager, not marked
+        self.good = GoodBlock(dim)
+        self.bad = BadBlock(dim)
+
+    def forward(self, x):
+        x = torch.relu(self.pre(x))
+        x = self.good(x)
+        x = self.bad(x)
+        return x
+
+
+class SingleGoodModel(nn.Module):
+    def __init__(self, dim=8):
+        super().__init__()
+        self.pre = nn.Linear(dim, dim)
+        self.good = GoodBlock(dim)
+
+    def forward(self, x):
+        return self.good(torch.relu(self.pre(x)))
+
+
+# ---------------------------------------------------------------------------
+# Discovery (device-agnostic: no compilation)
+# ---------------------------------------------------------------------------
+class RegionDiscoveryTest(TestCase):
+    def test_class_decorated_region_discovered(self):
+        model = SingleGoodModel()
+        regions = regional_aoti.discover_regions(model)
+        self.assertEqual([r.name for r in regions], ["good"])
+
+    def test_method_decorated_region_discovered(self):
+        model = MethodMarkedBlock()
+        regions = regional_aoti.discover_regions(model)
+        self.assertEqual([r.name for r in regions], [""])
+
+    def test_programmatic_mark_region(self):
+        model = PlainBlock()
+        self.assertEqual(regional_aoti.discover_regions(model), [])
+        regional_aoti.mark_region(model)
+        regions = regional_aoti.discover_regions(model)
+        self.assertEqual([r.name for r in regions], [""])
+
+    def test_mark_region_on_submodule_instance(self):
+        # mark_region() on a plain submodule *instance* is discovered too.
+        model = SingleGoodModel()
+        regional_aoti.mark_region(model.pre)
+        names = {r.name for r in regional_aoti.discover_regions(model)}
+        self.assertIn("pre", names)
+
+    def test_nested_regions_returns_top_level_only(self):
+        model = OuterNested()
+        regions = regional_aoti.discover_regions(model)
+        # Only the outer region; the nested "inner" is skipped.
+        self.assertEqual([r.name for r in regions], [""])
+
+    def test_config_carried_through(self):
+        dim_spec = {"x": {0: torch.export.Dim("batch")}}
+
+        class M(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.lin = nn.Linear(4, 4)
+
+            @regional_aoti.region(dynamic_shapes=dim_spec)
+            def forward(self, x):
+                return self.lin(x)
+
+        regions = regional_aoti.discover_regions(M())
+        self.assertEqual(len(regions), 1)
+        self.assertIsInstance(regions[0].config, AOTIRegionConfig)
+        self.assertEqual(regions[0].config.dynamic_shapes, dim_spec)
+
+
+# ---------------------------------------------------------------------------
+# Capture (device-agnostic: eager forward only)
+# ---------------------------------------------------------------------------
+class RegionCaptureTest(TestCase):
+    def test_capture_positional_args(self):
+        model = SingleGoodModel()
+        x = torch.randn(3, 8)
+        regions = regional_aoti.discover_regions(model)
+        regional_aoti.capture_region_inputs(model, regions, (x,))
+        (r,) = regions
+        self.assertEqual(r.status, "captured")
+        self.assertEqual(len(r.captured_args), 1)
+        self.assertEqual(r.captured_args[0].shape, torch.Size([3, 8]))
+
+    def test_capture_kwargs(self):
+        class KwModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.good = GoodBlock(8)
+
+            def forward(self, x):
+                return self.good(x=x)
+
+        model = KwModel()
+        regions = regional_aoti.discover_regions(model)
+        regional_aoti.capture_region_inputs(model, regions, (torch.randn(2, 8),))
+        (r,) = regions
+        self.assertEqual(r.status, "captured")
+        self.assertIn("x", r.captured_kwargs)
+
+    def test_region_not_reached_reported(self):
+        model = ConditionalModel()
+        regions = regional_aoti.discover_regions(model)
+        regional_aoti.capture_region_inputs(
+            model, regions, (torch.randn(2, 8),), {"use_region": False}
+        )
+        (r,) = regions
+        self.assertEqual(r.status, "not_reached")
+
+
+# ---------------------------------------------------------------------------
+# Export + compile + fallback (device-generic: CPU + GPU)
+# ---------------------------------------------------------------------------
+class RegionCompileTest(TestCase):
+    def test_single_region_compiles_with_parity(self, device):
+        model = SingleGoodModel().to(device)
+        x = torch.randn(3, 8, device=device)
+        with torch.no_grad():
+            expected = model(x)
+        compiled = regional_aoti.compile_regions(
+            model, (x,), fallback="error", check_parity=True
+        )
+        result = compiled._regional_aoti_result
+        self.assertEqual([r.name for r in result.compiled()], ["good"])
+        self.assertIsInstance(compiled.good, CompiledAOTIRegion)
+        with torch.no_grad():
+            got = compiled(x)
+        self.assertEqual(got, expected, rtol=1e-3, atol=1e-3)
+
+    def test_region_in_modulelist_is_replaced(self, device):
+        # A region inside an nn.ModuleList must be swapped in-place (container
+        # elements are index-addressed, not plain attributes).
+        class Stacked(nn.Module):
+            def __init__(self, dim=8):
+                super().__init__()
+                self.blocks = nn.ModuleList([GoodBlock(dim)])
+
+            def forward(self, x):
+                return self.blocks[0](x)
+
+        model = Stacked().to(device)
+        x = torch.randn(3, 8, device=device)
+        with torch.no_grad():
+            expected = model(x)
+        compiled = regional_aoti.compile_regions(
+            model, (x,), fallback="error", check_parity=True
+        )
+        result = compiled._regional_aoti_result
+        self.assertEqual([r.name for r in result.compiled()], ["blocks.0"])
+        self.assertIsInstance(compiled.blocks[0], CompiledAOTIRegion)
+        with torch.no_grad():
+            got = compiled(x)
+        self.assertEqual(got, expected, rtol=1e-3, atol=1e-3)
+
+    def test_parity_failure_falls_back_eager(self, device):
+        # A parity mismatch under fallback="eager" keeps the region eager instead
+        # of escaping as an uncaught AssertionError.
+        x = torch.randn(3, 8, device=device)
+        err = regional_aoti.AOTIRegionParityError("forced mismatch")
+        with (
+            mock.patch.object(
+                regional_aoti, "_compile_region", return_value="unused.pt2"
+            ),
+            mock.patch.object(regional_aoti, "_check_parity", side_effect=err),
+        ):
+            compiled = regional_aoti.compile_regions(
+                SingleGoodModel().to(device), (x,), fallback="eager", check_parity=True
+            )
+        result = compiled._regional_aoti_result
+        self.assertEqual([r.name for r in result.fallback()], ["good"])
+        self.assertNotIsInstance(compiled.good, CompiledAOTIRegion)
+
+    def test_parity_failure_raises_under_error(self, device):
+        x = torch.randn(3, 8, device=device)
+        err = regional_aoti.AOTIRegionParityError("forced mismatch")
+        with (
+            mock.patch.object(
+                regional_aoti, "_compile_region", return_value="unused.pt2"
+            ),
+            mock.patch.object(regional_aoti, "_check_parity", side_effect=err),
+        ):
+            with self.assertRaises(regional_aoti.AOTIRegionParityError):
+                regional_aoti.compile_regions(
+                    SingleGoodModel().to(device),
+                    (x,),
+                    fallback="error",
+                    check_parity=True,
+                )
+
+    def test_fallback_eager_keeps_bad_region_eager(self, device):
+        model = TwoRegionModel().to(device)
+        x = torch.randn(3, 8, device=device)
+        with torch.no_grad():
+            expected = model(x)
+        compiled = regional_aoti.compile_regions(model, (x,), fallback="eager")
+        result = compiled._regional_aoti_result
+        self.assertEqual([r.name for r in result.compiled()], ["good"])
+        self.assertEqual([r.name for r in result.fallback()], ["bad"])
+        # Good region is compiled; bad region stays the original eager module.
+        self.assertIsInstance(compiled.good, CompiledAOTIRegion)
+        self.assertNotIsInstance(compiled.bad, CompiledAOTIRegion)
+        with torch.no_grad():
+            got = compiled(x)
+        self.assertEqual(got, expected, rtol=1e-3, atol=1e-3)
+
+    def test_fallback_error_raises_on_bad_region(self, device):
+        # Only a non-exportable region is marked, so compile_regions raises
+        # immediately without paying for an unrelated (good-region) compile.
+        class OnlyBad(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.bad = BadBlock()
+
+            def forward(self, x):
+                return self.bad(x)
+
+        model = OnlyBad().to(device)
+        x = torch.randn(3, 8, device=device)
+        with self.assertRaises(AOTIRegionExportError):
+            regional_aoti.compile_regions(model, (x,), fallback="error")
+
+
+# ---------------------------------------------------------------------------
+# Runtime wrapper + state ownership (device-generic: CPU + GPU)
+# ---------------------------------------------------------------------------
+class RegionStateTest(TestCase):
+    def test_state_dict_keys_preserved(self, device):
+        model = SingleGoodModel().to(device)
+        x = torch.randn(2, 8, device=device)
+        before_keys = set(model.state_dict().keys())
+        compiled = regional_aoti.compile_regions(model, (x,), fallback="error")
+        after_keys = set(compiled.state_dict().keys())
+        self.assertEqual(before_keys, after_keys)
+
+    def test_runtime_fallback_paths(self, device):
+        # A compiled region that throws at runtime: runtime_fallback="error"
+        # surfaces AOTIRegionRuntimeError; "eager" falls back to the eager module.
+        model = SingleGoodModel().to(device)
+        x = torch.randn(2, 8, device=device)
+        with torch.no_grad():
+            expected = model(x)
+        compiled = regional_aoti.compile_regions(model, (x,), fallback="error")
+        region = compiled.good
+        self.assertIsInstance(region, CompiledAOTIRegion)
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("boom")
+
+        region._compiled = boom  # inject a failing compiled artifact
+
+        region._runtime_fallback = "error"
+        with self.assertRaises(regional_aoti.AOTIRegionRuntimeError):
+            compiled(x)
+
+        region._runtime_fallback = "eager"
+        with torch.no_grad():
+            got = compiled(x)
+        self.assertEqual(got, expected, rtol=1e-3, atol=1e-3)
+
+    def test_load_state_dict_changes_output(self, device):
+        model = SingleGoodModel().to(device)
+        x = torch.randn(2, 8, device=device)
+        compiled = regional_aoti.compile_regions(model, (x,), fallback="error")
+        with torch.no_grad():
+            out1 = compiled(x)
+
+        # Load clearly-distinct weights so the "output changed" check can't flake.
+        new_model = SingleGoodModel().to(device)
+        new_sd = {k: torch.full_like(v, 0.5) for k, v in model.state_dict().items()}
+        new_model.load_state_dict(new_sd)
+        compiled.load_state_dict(new_sd)
+        with torch.no_grad():
+            out2 = compiled(x)
+            expected = new_model(x)
+        self.assertFalse(torch.allclose(out1, out2, rtol=1e-3, atol=1e-3))
+        self.assertEqual(out2, expected, rtol=1e-3, atol=1e-3)
+
+
+# Generate CPU (always) and CUDA (when available) variants. No ``only_for`` so
+# the ASAN CPU target -- where CUDA cannot init -- yields CPU-only variants.
+instantiate_device_type_tests(RegionCompileTest, globals())
+instantiate_device_type_tests(RegionStateTest, globals())
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_inductor/regional_aoti.py
+++ b/torch/_inductor/regional_aoti.py
@@ -1,0 +1,687 @@
+# mypy: allow-untyped-defs
+"""
+Prototype: Partial / Regional AOTInductor for inference.
+
+This is an **experimental** API exposed as ``torch._inductor.regional_aoti``.
+It lets users compile selected hot submodules of a model with AOTInductor while
+keeping the rest of the model eager. Incompatible regions gracefully fall back to
+eager execution instead of failing the whole model.
+
+The implementation is a thin orchestration layer over existing PyTorch APIs:
+
+- ``torch.func.functional_call`` to make params/buffers explicit runtime inputs,
+- ``torch.export.export`` to capture each region independently,
+- ``torch._inductor.aoti_compile_and_package`` / ``aoti_load_package`` to compile
+  and load AOTI artifacts.
+
+It intentionally does NOT depend on any Meta-internal serving system.
+
+Public (experimental) entry points: ``mark_region`` + ``compile_regions``.
+The returned model carries a ``RegionCompileResult`` and its regions are
+``CompiledAOTIRegion`` instances; export/compile failures raise
+``AOTIRegionExportError`` / ``AOTIRegionCompileError``.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import inspect
+import logging
+import os
+import tempfile
+from typing import Any
+
+import torch
+import torch.nn as nn
+import torch.utils._pytree as pytree
+from torch.utils._ordered_set import OrderedSet
+
+
+log = logging.getLogger(__name__)
+
+# Stable attribute used to tag a class / forward method / instance as an AOTI region.
+_REGION_CONFIG_ATTR = "_torch_aoti_region_config"
+
+# Attribute stashed on a model returned by ``compile_regions`` for later inspection.
+_RESULT_ATTR = "_regional_aoti_result"
+
+# Public (experimental) API. Supporting types (``region``, ``discover_regions``,
+# ``CompiledAOTIRegion``, the ``RegionInfo`` / ``RegionCompileResult`` /
+# ``AOTIRegionConfig`` dataclasses, and the ``AOTIRegion*Error`` classes) remain
+# importable but are intentionally not advertised yet.
+__all__ = [
+    "mark_region",
+    "compile_regions",
+]
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+class AOTIRegionError(RuntimeError):
+    """Base class for all regional AOTI errors."""
+
+
+class AOTIRegionExportError(AOTIRegionError):
+    """Raised when ``torch.export.export`` fails for a region."""
+
+
+class AOTIRegionCompileError(AOTIRegionError):
+    """Raised when AOTInductor compilation fails for a region."""
+
+
+class AOTIRegionParityError(AOTIRegionError):
+    """Raised when a compiled region fails the numerical parity check."""
+
+
+class AOTIRegionLoadError(AOTIRegionError):
+    """Raised when a compiled region artifact cannot be loaded."""
+
+
+class AOTIRegionRuntimeError(AOTIRegionError):
+    """Raised when a compiled region fails at runtime (e.g. schema mismatch)."""
+
+
+# ---------------------------------------------------------------------------
+# Config / info dataclasses
+# ---------------------------------------------------------------------------
+@dataclasses.dataclass
+class AOTIRegionConfig:
+    """Per-region export / fallback configuration.
+
+    Args:
+        dynamic_shapes: Mapping from the region ``forward`` parameter name to an
+            export dynamic-shape spec (e.g. ``{"x": {0: torch.export.Dim("batch")}}``).
+            Params/buffers are always kept static.
+        fallback: Optional per-region override of the global compile-time fallback
+            policy (``"eager"`` or ``"error"``).
+    """
+
+    dynamic_shapes: dict[str, Any] | None = None
+    fallback: str | None = None
+
+
+@dataclasses.dataclass
+class RegionInfo:
+    """State tracked for a single discovered region."""
+
+    name: str
+    module: nn.Module = dataclasses.field(repr=False)
+    config: AOTIRegionConfig = dataclasses.field(repr=False)
+    # One of: discovered, captured, not_reached, exported, compiled, fallback.
+    status: str = "discovered"
+    fallback_reason: str | None = None
+    package_path: str | None = None
+    captured_args: tuple[Any, ...] | None = dataclasses.field(default=None, repr=False)
+    captured_kwargs: dict[str, Any] | None = dataclasses.field(default=None, repr=False)
+
+
+@dataclasses.dataclass
+class RegionCompileResult:
+    """Result of :func:`compile_regions`."""
+
+    regions: list[RegionInfo]
+
+    def compiled(self) -> list[RegionInfo]:
+        return [r for r in self.regions if r.status == "compiled"]
+
+    def fallback(self) -> list[RegionInfo]:
+        return [r for r in self.regions if r.status == "fallback"]
+
+    def not_reached(self) -> list[RegionInfo]:
+        return [r for r in self.regions if r.status == "not_reached"]
+
+    def report(self) -> str:
+        lines = ["Regional AOTI report:"]
+        for r in self.regions:
+            name = r.name or "<root>"
+            line = f"  [{r.status:>10}] {name}"
+            if r.fallback_reason:
+                line += f"  (reason: {r.fallback_reason})"
+            lines.append(line)
+        return "\n".join(lines)
+
+    def __str__(self) -> str:
+        return self.report()
+
+
+# ---------------------------------------------------------------------------
+# Marking / discovery
+# ---------------------------------------------------------------------------
+_FALLBACK_CHOICES = ("eager", "error")
+
+
+def _validate_fallback(fallback, argname: str = "fallback") -> None:
+    """Reject an unrecognized fallback policy. ``None`` means "unset" and is allowed."""
+    if fallback is not None and fallback not in _FALLBACK_CHOICES:
+        raise ValueError(f"{argname} must be 'eager' or 'error', got {fallback!r}")
+
+
+def region(_obj=None, *, dynamic_shapes=None, fallback=None):
+    """Mark an ``nn.Module`` class or its ``forward`` method as an AOTI region.
+
+    Can be used with or without arguments::
+
+        class Attention(nn.Module):
+            @region(dynamic_shapes={"x": {0: torch.export.Dim("batch")}})
+            def forward(self, x, mask=None): ...
+
+
+        @region()
+        class Block(nn.Module): ...
+    """
+    config = AOTIRegionConfig(
+        dynamic_shapes=dynamic_shapes,
+        fallback=fallback,
+    )
+
+    def deco(obj):
+        setattr(obj, _REGION_CONFIG_ATTR, config)
+        return obj
+
+    if _obj is not None:
+        # Used as a bare decorator: @region
+        return deco(_obj)
+    return deco
+
+
+def mark_region(
+    module: nn.Module,
+    config: AOTIRegionConfig | None = None,
+    *,
+    dynamic_shapes=None,
+    fallback=None,
+) -> nn.Module:
+    """Programmatically mark a module *instance* as an AOTI region."""
+    if not isinstance(module, nn.Module):
+        raise TypeError(f"mark_region expects an nn.Module, got {type(module)!r}")
+    if config is None:
+        config = AOTIRegionConfig(
+            dynamic_shapes=dynamic_shapes,
+            fallback=fallback,
+        )
+    # Instance attribute (goes into __dict__, takes priority over class markers).
+    module.__dict__[_REGION_CONFIG_ATTR] = config
+    return module
+
+
+def _get_region_config(module: nn.Module) -> AOTIRegionConfig | None:
+    """Return the region config for a module, or None if it is not a region."""
+    # 1. Instance-level (programmatic) marking wins.
+    cfg = module.__dict__.get(_REGION_CONFIG_ATTR)
+    if isinstance(cfg, AOTIRegionConfig):
+        return cfg
+    cls = type(module)
+    # 2. Class-level decorator. Walk the MRO so a subclass of a decorated class
+    #    is still recognized, consistent with the forward-method lookup below.
+    for klass in cls.__mro__:
+        cfg = klass.__dict__.get(_REGION_CONFIG_ATTR)
+        if isinstance(cfg, AOTIRegionConfig):
+            return cfg
+    # 3. forward-method decorator.
+    fwd = getattr(cls, "forward", None)
+    cfg = getattr(fwd, _REGION_CONFIG_ATTR, None)
+    if isinstance(cfg, AOTIRegionConfig):
+        return cfg
+    return None
+
+
+def _is_nested_under(name: str, ancestors: list[str]) -> bool:
+    """True if ``name`` is a strict descendant of any name in ``ancestors``."""
+    for other in ancestors:
+        if other == name:
+            continue
+        if other == "":
+            # Root is an ancestor of every non-root module.
+            return True
+        if name.startswith(other + "."):
+            return True
+    return False
+
+
+def discover_regions(model: nn.Module) -> list[RegionInfo]:
+    """Walk ``model.named_modules()`` and return only top-level marked regions.
+
+    Nested marked regions are skipped in favor of their marked ancestor so each
+    tensor is compiled at most once.
+    """
+    marked: list[tuple[str, nn.Module, AOTIRegionConfig]] = []
+    seen_ids: OrderedSet[int] = OrderedSet()
+    for name, mod in model.named_modules():
+        cfg = _get_region_config(mod)
+        # A single instance mounted under multiple attribute paths must be
+        # compiled once (under its first name); otherwise it would export
+        # repeatedly and only one path would end up pointing at the wrapper.
+        if cfg is not None and id(mod) not in seen_ids:
+            seen_ids.add(id(mod))
+            marked.append((name, mod, cfg))
+
+    all_names = [n for n, _, _ in marked]
+    regions: list[RegionInfo] = []
+    for name, mod, cfg in marked:
+        if _is_nested_under(name, all_names):
+            continue
+        regions.append(RegionInfo(name=name, module=mod, config=cfg))
+    return regions
+
+
+# ---------------------------------------------------------------------------
+# Input capture
+# ---------------------------------------------------------------------------
+def _detach_inputs(obj, clone: bool):
+    def f(x):
+        if isinstance(x, torch.Tensor):
+            y = x.detach()
+            return y.clone() if clone else y
+        return x
+
+    return pytree.tree_map(f, obj)
+
+
+def capture_region_inputs(
+    model: nn.Module,
+    regions: list[RegionInfo],
+    example_inputs,
+    example_kwargs=None,
+    *,
+    clone_inputs: bool = False,
+) -> list[RegionInfo]:
+    """Run one eager forward, capturing (args, kwargs) into each reached region.
+
+    The outer model behavior is unchanged: this only observes inputs via
+    forward pre-hooks and runs under ``torch.no_grad()``.
+    """
+    example_inputs = tuple(example_inputs) if example_inputs is not None else ()
+    example_kwargs = dict(example_kwargs) if example_kwargs else {}
+
+    captures: dict[int, tuple] = {}
+    handles = []
+
+    def make_hook():
+        def hook(module, args, kwargs):
+            captures[id(module)] = (
+                _detach_inputs(args, clone_inputs),
+                _detach_inputs(kwargs, clone_inputs),
+            )
+
+        return hook
+
+    for r in regions:
+        handles.append(
+            r.module.register_forward_pre_hook(make_hook(), with_kwargs=True)
+        )
+
+    try:
+        with torch.no_grad():
+            model(*example_inputs, **example_kwargs)
+    finally:
+        for h in handles:
+            h.remove()
+
+    for r in regions:
+        if id(r.module) in captures:
+            r.captured_args, r.captured_kwargs = captures[id(r.module)]
+            r.status = "captured"
+        elif r.status == "discovered":
+            r.status = "not_reached"
+    return regions
+
+
+# ---------------------------------------------------------------------------
+# Functionalized export
+# ---------------------------------------------------------------------------
+class _FunctionalizedRegion(nn.Module):
+    """Wrap a region so params/buffers are explicit runtime inputs.
+
+    The original module is stored inside a plain Python list so it is NOT
+    registered as a submodule; otherwise its parameters would be re-lifted as
+    state instead of being passed in explicitly.
+    """
+
+    def __init__(self, module: nn.Module) -> None:
+        super().__init__()
+        self._region = [module]
+
+    def forward(self, params, buffers, args, kwargs):
+        return torch.func.functional_call(
+            self._region[0], {**params, **buffers}, tuple(args), dict(kwargs)
+        )
+
+
+def _positional_param_names(fn) -> list[str]:
+    names = []
+    for p in inspect.signature(fn).parameters.values():
+        if p.name == "self":
+            continue
+        if p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD):
+            names.append(p.name)
+    return names
+
+
+def _spec_for(value, user_spec):
+    """Translate a user dynamic-shape spec for a single input value.
+
+    Non-tensor values and unspecified tensors are static (``None``). A user
+    spec (dict/list of Dims) is passed through unchanged.
+    """
+    if not isinstance(value, torch.Tensor):
+        return None
+    if user_spec is None:
+        return None
+    return user_spec
+
+
+def _build_dynamic_shapes(orig_module, params, buffers, args, kwargs, config):
+    """Build the ``dynamic_shapes`` tuple for the functionalized signature.
+
+    Signature is ``forward(params, buffers, args, kwargs)`` so the returned tuple
+    is always length 4: ``(params_static, buffers_static, args_specs, kwargs_specs)``.
+    Params/buffers are marked fully static.
+    """
+    user = (config.dynamic_shapes or {}) if config is not None else {}
+
+    params_spec = dict.fromkeys(params, None)
+    buffers_spec = dict.fromkeys(buffers, None)
+
+    pos_names = _positional_param_names(orig_module.forward)
+    args_specs = []
+    for i, val in enumerate(args):
+        nm = pos_names[i] if i < len(pos_names) else None
+        args_specs.append(_spec_for(val, user.get(nm) if nm is not None else None))
+
+    kwargs_specs = {k: _spec_for(v, user.get(k)) for k, v in kwargs.items()}
+
+    return (params_spec, buffers_spec, tuple(args_specs), kwargs_specs)
+
+
+def _export_region(rinfo: RegionInfo):
+    module = rinfo.module
+    params = {n: p.detach() for n, p in module.named_parameters()}
+    buffers = {n: b.detach() for n, b in module.named_buffers()}
+
+    args = tuple(rinfo.captured_args or ())
+    kwargs = dict(rinfo.captured_kwargs or {})
+
+    func_mod = _FunctionalizedRegion(module)
+    export_inputs = (params, buffers, args, kwargs)
+    dynamic_shapes = _build_dynamic_shapes(
+        module, params, buffers, args, kwargs, rinfo.config
+    )
+
+    try:
+        ep = torch.export.export(
+            func_mod,
+            export_inputs,
+            dynamic_shapes=dynamic_shapes,
+            strict=False,
+        )
+    except Exception as e:
+        raise AOTIRegionExportError(
+            f"Failed to export region {rinfo.name or '<root>'!r}: {e}"
+        ) from e
+    rinfo.status = "exported"
+    return ep
+
+
+# ---------------------------------------------------------------------------
+# Compile
+# ---------------------------------------------------------------------------
+def _sanitize(name: str) -> str:
+    return name.replace(".", "_").replace("/", "_") if name else "__root__"
+
+
+def _compile_region(rinfo: RegionInfo, ep, cache_dir: str | None) -> str:
+    if cache_dir is not None:
+        os.makedirs(cache_dir, exist_ok=True)
+        pkg_path = os.path.join(cache_dir, _sanitize(rinfo.name) + ".pt2")
+    else:
+        fd, pkg_path = tempfile.mkstemp(suffix=".pt2")
+        os.close(fd)
+
+    try:
+        path = torch._inductor.aoti_compile_and_package(ep, package_path=pkg_path)
+    except Exception as e:
+        if cache_dir is None:
+            # Remove the orphaned temp artifact so failures don't leak .pt2 files.
+            try:
+                os.unlink(pkg_path)
+            except OSError:
+                pass
+        raise AOTIRegionCompileError(
+            f"Failed to AOTI-compile region {rinfo.name or '<root>'!r}: {e}"
+        ) from e
+    rinfo.package_path = path
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Runtime wrapper
+# ---------------------------------------------------------------------------
+class CompiledAOTIRegion(nn.Module):
+    """Runtime wrapper that routes a region through its compiled AOTI artifact.
+
+    The original module is kept as a child (named ``region``) so it continues to
+    own its params/buffers. State-dict hooks make the extra ``region.`` prefix
+    transparent, so ``state_dict()`` / ``load_state_dict()`` keep working with
+    the original key names.
+    """
+
+    def __init__(
+        self,
+        original_module: nn.Module,
+        package_path: str,
+        *,
+        runtime_fallback: str = "error",
+        region_name: str = "",
+    ) -> None:
+        super().__init__()
+        self.region = original_module
+        self._package_path = package_path
+        self._runtime_fallback = runtime_fallback
+        self._region_name = region_name
+        self._compiled = None  # lazily loaded AOTICompiledModel
+
+        # Make the "region." infix transparent in state_dict / load_state_dict.
+        self._register_state_dict_hook(_strip_region_prefix_hook)
+        self._register_load_state_dict_pre_hook(
+            _add_region_prefix_hook, with_module=True
+        )
+
+    def _load(self):
+        if self._compiled is None:
+            try:
+                self._compiled = torch._inductor.aoti_load_package(self._package_path)
+            except Exception as e:
+                raise AOTIRegionLoadError(
+                    f"Failed to load compiled region from {self._package_path!r}: {e}"
+                ) from e
+        return self._compiled
+
+    def forward(self, *args, **kwargs):
+        # Gather *current* params/buffers so load_state_dict updates take effect.
+        params = dict(self.region.named_parameters())
+        buffers = dict(self.region.named_buffers())
+        try:
+            compiled = self._load()
+            return compiled(params, buffers, tuple(args), dict(kwargs))
+        except AOTIRegionLoadError:
+            raise
+        except Exception as e:
+            if self._runtime_fallback == "eager":
+                log.warning(
+                    "Regional AOTI: runtime fallback to eager for region %r: %s",
+                    self._region_name or "<region>",
+                    e,
+                )
+                return self.region(*args, **kwargs)
+            raise AOTIRegionRuntimeError(
+                f"Compiled region failed at runtime: {e}"
+            ) from e
+
+
+def _strip_region_prefix_hook(module, state_dict, prefix, local_metadata):
+    region_prefix = prefix + "region."
+    for key in list(state_dict.keys()):
+        if key.startswith(region_prefix):
+            new_key = prefix + key[len(region_prefix) :]
+            state_dict[new_key] = state_dict.pop(key)
+    return state_dict
+
+
+def _add_region_prefix_hook(
+    module,
+    state_dict,
+    prefix,
+    local_metadata,
+    strict,
+    missing_keys,
+    unexpected_keys,
+    error_msgs,
+):
+    # Only re-prefix keys that correspond to this region's own state; leave
+    # unrelated keys (e.g. extras passed under strict=False) untouched. This
+    # matters for the root wrapper where prefix is empty.
+    region_prefix = prefix + "region."
+    own_keys = OrderedSet(module.region.state_dict().keys())
+    for key in list(state_dict.keys()):
+        if not key.startswith(prefix):
+            continue
+        suffix = key[len(prefix) :]
+        if suffix in own_keys:
+            state_dict[region_prefix + suffix] = state_dict.pop(key)
+
+
+def _replace_submodule(model: nn.Module, name: str, new_module: nn.Module) -> None:
+    parent_name, _, child = name.rpartition(".")
+    parent = model.get_submodule(parent_name) if parent_name else model
+    if child.isdigit() and isinstance(parent, (nn.ModuleList, nn.Sequential)):
+        # Ordered containers address children by position; assign through
+        # __setitem__ so the container's internal _modules is updated.
+        parent[int(child)] = new_module
+    else:
+        setattr(parent, child, new_module)
+
+
+# ---------------------------------------------------------------------------
+# Parity
+# ---------------------------------------------------------------------------
+def _check_parity(rinfo: RegionInfo, wrapper: CompiledAOTIRegion, rtol, atol) -> None:
+    args = tuple(rinfo.captured_args or ())
+    kwargs = dict(rinfo.captured_kwargs or {})
+    # Force the compiled path while measuring parity. If the wrapper is left on
+    # runtime_fallback="eager", a broken artifact would silently return eager
+    # output and the check would compare eager-vs-eager and trivially pass.
+    saved_fallback = wrapper._runtime_fallback
+    wrapper._runtime_fallback = "error"
+    try:
+        with torch.no_grad():
+            eager_out = rinfo.module(*args, **kwargs)
+            comp_out = wrapper(*args, **kwargs)
+    finally:
+        wrapper._runtime_fallback = saved_fallback
+    try:
+        torch.testing.assert_close(comp_out, eager_out, rtol=rtol, atol=atol)
+    except AssertionError as e:
+        raise AOTIRegionParityError(
+            f"Region {rinfo.name or '<root>'!r} failed parity check: {e}"
+        ) from e
+
+
+# ---------------------------------------------------------------------------
+# Top-level orchestration
+# ---------------------------------------------------------------------------
+def compile_regions(
+    model: nn.Module,
+    example_inputs,
+    example_kwargs=None,
+    *,
+    cache_dir: str | None = None,
+    fallback: str = "eager",
+    runtime_fallback: str = "error",
+    check_parity: bool = False,
+    parity_rtol: float = 1e-3,
+    parity_atol: float = 1e-3,
+) -> nn.Module:
+    """Compile marked regions of ``model`` with AOTInductor.
+
+    Returns a model that routes successfully-compiled regions through their AOTI
+    artifacts while keeping every other part (and any failed region under
+    ``fallback="eager"``) eager. The returned object carries a
+    :class:`RegionCompileResult` (see ``report()``).
+    """
+    if fallback not in ("eager", "error"):
+        raise ValueError(f"fallback must be 'eager' or 'error', got {fallback!r}")
+    if runtime_fallback not in ("eager", "error"):
+        raise ValueError(
+            f"runtime_fallback must be 'eager' or 'error', got {runtime_fallback!r}"
+        )
+
+    regions = discover_regions(model)
+    if not regions:
+        log.warning(
+            "Regional AOTI: no marked regions found on %s", type(model).__name__
+        )
+
+    capture_region_inputs(model, regions, example_inputs, example_kwargs)
+
+    root_wrapper: nn.Module | None = None
+
+    for r in regions:
+        eff_fallback = r.config.fallback or fallback
+
+        if r.status == "not_reached":
+            reason = "region was not reached during example-input capture"
+            if eff_fallback == "error":
+                # Not an export failure: export never ran for an unreached region.
+                raise AOTIRegionError(f"Region {r.name or '<root>'!r}: {reason}")
+            r.status = "not_reached"
+            r.fallback_reason = reason
+            log.warning("Regional AOTI: %s (%s)", reason, r.name or "<root>")
+            continue
+
+        path: str | None = None
+        try:
+            ep = _export_region(r)
+            path = _compile_region(r, ep, cache_dir)
+            wrapper = CompiledAOTIRegion(
+                r.module,
+                path,
+                runtime_fallback=runtime_fallback,
+                region_name=r.name,
+            )
+            if check_parity:
+                _check_parity(r, wrapper, parity_rtol, parity_atol)
+            if r.name == "":
+                root_wrapper = wrapper
+            else:
+                _replace_submodule(model, r.name, wrapper)
+            r.status = "compiled"
+        except (
+            AOTIRegionExportError,
+            AOTIRegionCompileError,
+            AOTIRegionParityError,
+            AOTIRegionLoadError,
+            AOTIRegionRuntimeError,
+        ) as e:
+            if eff_fallback == "error":
+                raise
+            # A downstream step (e.g. parity) can fail after _compile_region
+            # already wrote the artifact. For temp artifacts (no cache_dir)
+            # that would otherwise leak, unlink the orphaned .pt2 file.
+            if path is not None and cache_dir is None:
+                try:
+                    os.unlink(path)
+                except OSError:
+                    pass
+            r.status = "fallback"
+            r.fallback_reason = str(e)
+            log.warning(
+                "Regional AOTI: region %r fell back to eager: %s",
+                r.name or "<root>",
+                e,
+            )
+
+    result = RegionCompileResult(regions=regions)
+    out_model = root_wrapper if root_wrapper is not None else model
+    setattr(out_model, _RESULT_ATTR, result)
+    return out_model


### PR DESCRIPTION
Summary:

# Regional AOTI: incremental AOTInductor for parts of a model

## What this is

An experimental `torch._inductor.regional_aoti` API for partial AOTInductor adoption. You mark the hot submodules of a model, and this compiles just those with AOTInductor while everything else stays eager. Regions that can't be compiled fall back to eager (or raise, your choice), so you can adopt AOTI incrementally instead of all-or-nothing.

It is a thin orchestration layer over existing PyTorch APIs with no dependency on Meta-internal serving systems:

- `torch.func.functional_call` makes params/buffers explicit runtime inputs
- `torch.export.export` captures each region independently
- `torch._inductor.aoti_compile_and_package` / `aoti_load_package` compile and load each region

## For MLEs: use this to check if a submodule is export / AOTI-friendly

A handy use of this API is a diff-time unit test that gates a submodule on AOTI compatibility. Mark the submodule, call `compile_regions(..., fallback="error")`, and it raises if that region can't be exported or compiled. Pass `check_parity=True` to also verify the compiled output matches eager. This runs in a plain CPU `buck2 test` (no serving deps).

```python
import torch
import torch.nn as nn
from torch._inductor import regional_aoti
from torch._inductor.regional_aoti import CompiledAOTIRegion

model = MyModel().eval()
x = torch.randn(3, 8)

# Mark ONLY the submodule instance you care about; the rest of the model stays eager.
regional_aoti.mark_region(model.hot)

# fallback="error" raises AOTIRegionExportError / AOTIRegionCompileError if `hot`
# cannot be exported / AOTI-compiled. check_parity verifies outputs match eager.
compiled = regional_aoti.compile_regions(model, (x,), fallback="error", check_parity=True)

result = compiled._regional_aoti_result             # a RegionCompileResult
assert [r.name for r in result.compiled()] == ["hot"]  # region name = attribute path
assert isinstance(compiled.hot, CompiledAOTIRegion)
print(result.report())                              # per-region status + fallback reasons
```

Notes for adapting it:

- Region name is the submodule's attribute path from the model root (e.g. `"hot"`, `"blocks.0"`), so assert on that.
- The example inputs must actually reach the region. Under `fallback="error"`, a not-reached region also raises.
- Whole-model check: mark the model itself with `regional_aoti.mark_region(model)`, then `compile_regions(model, (x,), fallback="error")`.
- Export vs compile failures are distinct classes (`AOTIRegionExportError` vs `AOTIRegionCompileError`), so you can isolate the stage you care about.

## Public (experimental) API

The advertised entry points are just `mark_region` and `compile_regions`. Supporting types stay importable but are intentionally not advertised yet: `region`, `discover_regions`, `capture_region_inputs`, `CompiledAOTIRegion`, the `AOTIRegionConfig` / `RegionInfo` / `RegionCompileResult` dataclasses, and the `AOTIRegion*Error` hierarchy. 

## Behavior details

- Regions are explicit nn.Modules, marked via a class/method decorator or `mark_region`; discovery returns top-level regions only.
- Eager inputs are captured via forward pre-hooks; regions never reached during capture are reported.
- Per-region export is functionalized (params/buffers become runtime inputs), so `load_state_dict()` after compile still drives the compiled regions.
- Per-region AOTI compile with compile-time `fallback="eager"|"error"`.
- `CompiledAOTIRegion` is the runtime wrapper; state_dict / load_state_dict keep the original key names via state-dict hooks; `runtime_fallback="error"` by default.

Test Plan:
Single test file (`test_regional_aoti.py`), device-generic via `instantiate_device_type_tests` (no `only_for`), registered "tested in both" -> targets `regional_aoti_cpu` (CPU) and `regional_aoti` (GPU remote-execution). This follows the inductor convention (cf. `test_unbacked_symints.py`); GPU test infra is not imported in a way that forces CUDA, so under the ASAN CPU target only CPU variants are generated.

CPU (verified):
```
buck2 test fbcode//caffe2/test/inductor:regional_aoti_cpu
```
18 tests pass: https://www.internalfb.com/intern/testinfra/testrun/1688850240446757
- Discovery (6) + Capture (3): device-agnostic.
- Compile + fallback (6): incl. a region inside an nn.ModuleList is swapped in place; single-region compile with parity; parity mismatch falls back under `fallback="eager"` and raises `AOTIRegionParityError` under `fallback="error"`; good/bad two-region fallback.
- Runtime wrapper + state (3): state-dict key preservation; runtime fallback (`AOTIRegionRuntimeError` vs eager); `load_state_dict()` drives the compiled region.

GPU (CI-validated):
```
buck2 test fbcode//caffe2/test/inductor:regional_aoti
```
The compile + state tests run as `_cuda` variants on the GPU remote-execution target. NOT run locally: the devserver default build mode is ASAN, under which CUDA cannot initialize. Validated via Sandcastle/CI.

Differential Revision: D110820441




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo