### PR TITLE
[XPU] Skip CUDA event codegen for AOTI cpp_wrapper on XPU

### DIFF
--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -1268,6 +1268,9 @@ class CppWrapperGpu(CppWrapperCpu):
         def _parse_idx(arg: str) -> int:
             return int(arg.rstrip("Ll"))
 
+        if V.graph.device_type == "xpu":
+            # XPU: events are implicit via in-order SYCL queue; skip CUDA event calls
+            return True
         self._ensure_aoti_stream_helpers_emitted()
         event_idx = _parse_idx(args[0])
         if op == "record_event":


### PR DESCRIPTION
## Summary

The D2H non_blocking copy fix in torch-xpu-ops (intel/torch-xpu-ops#4349) now returns sycl::event objects, which triggers the AOTInductor cpp_wrapper_gpu codegen to emit cudaEventRecord/cudaStreamWaitEvent/cudaEventSynchronize when compiling for XPU. On XPU, SYCL in-order queues handle event ordering implicitly — no explicit CUDA events are needed.

## Fix

Skip the CUDA event codegen block in `_emit_stream_op_inline()` when `V.graph.device_type == "xpu"`. This resolves the cudaEvent_t compilation errors in the auto-generated wrapper.cpp.

## Related
- Fix for CI failures on PR #189980
- Depends on intel/torch-xpu-ops#4349

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo