### PR TITLE
[inductor] Clamp num_warps<=4 for Triton conv bwd/transposed templates (triton#1254)

### DIFF
--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -748,7 +748,10 @@ def convolution(
                 GROUPS=groups,
                 ALLOW_TF32=torch.backends.cudnn.fp32_precision == "tf32",
                 num_stages=cfg.num_stages,
-                num_warps=cfg.num_warps,
+                # The non-unrolled loop in this template triggers triton#1254
+                # with 8 warps, producing incorrect results; clamp to 4 warps
+                # to work around this, matching the forward conv path.
+                num_warps=min(cfg.num_warps, 4),
                 **cfg.kwargs,
             )
 
@@ -1136,7 +1139,10 @@ def convolution_backward_lowering(
                         GROUPS=groups,
                         ALLOW_TF32=torch.backends.cudnn.allow_tf32,
                         num_stages=cfg.num_stages,
-                        num_warps=cfg.num_warps,
+                        # The non-unrolled loop in this template triggers triton#1254
+                        # with 8 warps, producing incorrect results; clamp to 4 warps
+                        # to work around this, matching the forward conv path.
+                        num_warps=min(cfg.num_warps, 4),
                         **cfg.kwargs,
                     )
 
@@ -1192,7 +1198,10 @@ def convolution_backward_lowering(
                         GROUPS=groups,
                         ALLOW_TF32=torch.backends.cudnn.allow_tf32,
                         num_stages=cfg.num_stages,
-                        num_warps=cfg.num_warps,
+                        # The non-unrolled loop in this template triggers triton#1254
+                        # with 8 warps, producing incorrect results; clamp to 4 warps
+                        # to work around this, matching the forward conv path.
+                        num_warps=min(cfg.num_warps, 4),
                         **cfg.kwargs,
                     )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #190114

The four test_conv_transpose2d_forward_triton variants (in_channels=128, out_channels=128, groups=1, nhwc=True, kernel=3, stride=1; dilation 1/2 x padding 0/1) produced out-of-tolerance results under pt2_stack_for_internal. Root cause: the Triton conv bwd-input template (reused for transposed-conv forward) emits a non-unrolled K-loop that triton#1254 miscompiles at num_warps=8, and the transposed/bwd template invocations in kernel/conv.py did not apply the num_warps<=4 clamp that the forward conv path already uses to work around triton#1254. This applies that clamp to the transposed-forward, bwd-input, and bwd-weight template invocations, fixing the miscompile at the source instead of skipping the test. Fixes T275754523, T275754516, T275754514, T275754520. Authored with AI assistance.

Differential Revision: [D111961391](https://our.internmc.facebook.com/intern/diff/D111961391/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo