### PR TITLE
Revert "Hoist invariant gather prologue loads in mm templates (#184301)"

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -4545,10 +4545,7 @@ class TestPrologueFusion(TestCase):
             # upcast preserves zero mask
             FileCheck().check("a =").check_not("tl.where").check("tl.dot").run(code[0])
 
-    @unittest.skipIf(
-        config.triton.native_matmul,
-        "generated code is different in native matmul",
-    )
+    @unittest.skip("Triton bug in compilation")
     def test_gather_fusion(self):
         M, K, N = (64, 128, 256)
         x = torch.rand([M, K], dtype=torch.float16, device=GPU_TYPE)
@@ -4571,96 +4568,6 @@ class TestPrologueFusion(TestCase):
             .check("dot")
             .run(code[0])
         )
-        (
-            FileCheck()
-            .check("tl.load(in_ptr1 + (_loop_invariant_idx_m)")
-            .check("for k_idx")
-            .check_not("tl.load(in_ptr1")
-            .check("tl.dot")
-            .run(code[0])
-        )
-        self.assertEqual(
-            len(re.findall(r"_loop_invariant_A_tmp\d+ = tl\.load", code[0])), 1
-        )
-
-    @unittest.skipIf(
-        config.triton.native_matmul,
-        "generated code is different in native matmul",
-    )
-    def test_gather_fusion_hoists_both_inputs(self):
-        M, K, N = (64, 128, 256)
-        x = torch.rand([M, K], dtype=torch.float16, device=GPU_TYPE)
-        y = torch.rand([K, N], dtype=torch.float16, device=GPU_TYPE)
-        idx_m = torch.randperm(M, device=GPU_TYPE)
-        idx_n = torch.randperm(N, device=GPU_TYPE)
-
-        def foo(x, y, idx_m, idx_n):
-            return x[idx_m] @ y[:, idx_n]
-
-        out, code = run_and_get_code(torch.compile(foo), x, y, idx_m, idx_n)
-        self.assertEqual(out, foo(x, y, idx_m, idx_n), atol=0.05, rtol=0.05)
-
-        kernel_code = code[0]
-        loop_start = kernel_code.index("for k_idx")
-        dot_start = kernel_code.index("tl.dot", loop_start)
-        pre_loop = kernel_code[:loop_start]
-        loop_body = kernel_code[loop_start:dot_start]
-
-        self.assertRegex(
-            pre_loop,
-            r"_loop_invariant_A_tmp\d+ = tl\.load\(in_ptr\d+ \+ \(_loop_invariant_idx_m\)",
-        )
-        self.assertRegex(
-            pre_loop,
-            r"_loop_invariant_B_tmp\d+ = tl\.load\(in_ptr\d+ \+ \(_loop_invariant_idx_n\)",
-        )
-        self.assertNotRegex(loop_body, r"tl\.load\(in_ptr\d+ \+ \(idx_[mn]\)")
-        self.assertRegex(loop_body, r"_loop_invariant_A_tmp\d+")
-        self.assertRegex(loop_body, r"_loop_invariant_B_tmp\d+")
-        self.assertEqual(
-            len(re.findall(r"_loop_invariant_A_tmp\d+ = tl\.load", kernel_code)), 1
-        )
-        self.assertEqual(
-            len(re.findall(r"_loop_invariant_B_tmp\d+ = tl\.load", kernel_code)), 1
-        )
-
-    @unittest.skipIf(
-        config.triton.native_matmul,
-        "generated code is different in native matmul",
-    )
-    def test_gather_fusion_hoists_even_k_false(self):
-        M, K, N = (64, 130, 256)
-        x = torch.rand([M, K], dtype=torch.float16, device=GPU_TYPE)
-        y = torch.rand([K, N], dtype=torch.float16, device=GPU_TYPE)
-        idx_m = torch.randperm(M, device=GPU_TYPE)
-        idx_n = torch.randperm(N, device=GPU_TYPE)
-
-        def foo(x, y, idx_m, idx_n):
-            return x[idx_m] @ y[:, idx_n]
-
-        out, code = run_and_get_code(torch.compile(foo), x, y, idx_m, idx_n)
-        self.assertEqual(out, foo(x, y, idx_m, idx_n), atol=0.05, rtol=0.05)
-
-        kernel_code = code[0]
-        self.assertIn("EVEN_K : tl.constexpr = False", kernel_code)
-        loop_start = kernel_code.index("for k_idx")
-        dot_start = kernel_code.index("tl.dot", loop_start)
-        pre_loop = kernel_code[:loop_start]
-        loop_body = kernel_code[loop_start:dot_start]
-
-        self.assertRegex(
-            pre_loop,
-            r"_loop_invariant_A_tmp\d+ = tl\.load\(in_ptr\d+ \+ \(_loop_invariant_idx_m\), None",
-        )
-        self.assertRegex(
-            pre_loop,
-            r"_loop_invariant_B_tmp\d+ = tl\.load\(in_ptr\d+ \+ \(_loop_invariant_idx_n\), None",
-        )
-        self.assertNotRegex(loop_body, r"tl\.load\(in_ptr\d+ \+ \(idx_[mn]\)")
-        self.assertIn("a_mask =", loop_body)
-        self.assertIn("b_mask =", loop_body)
-        self.assertIn(", a_mask", loop_body)
-        self.assertIn(", b_mask", loop_body)
 
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FP8,

--- a/torch/_inductor/kernel/templates/triton_mm.py.jinja
+++ b/torch/_inductor/kernel/templates/triton_mm.py.jinja
@@ -36,10 +36,6 @@
         offs_b_n = rn % N
     offs_k = tl.arange(0, BLOCK_K).to(INDEX_DTYPE)
     acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=ACC_TYPE)
-    {{load_input_loop_invariant_code(
-        idx_m="offs_a_m[:, None]",
-        idx_n="offs_b_n[None, :]",
-    )}}
 
     for k_idx in range(0, tl.cdiv(K, BLOCK_K)):
         {% if not EVEN_K %}
@@ -52,14 +48,12 @@
         idx_m = offs_a_m[:, None]
         idx_n = a_k_idx_vals
         {{load_input("A", "a", ("idx_m", "idx_n"), mask=None if EVEN_K else "a_mask",
-                     indent_width=8, index_shape=("BLOCK_M", "BLOCK_K"),
-                     loop_varying_indices=("idx_n", "a_mask"))}}
+                     indent_width=8, index_shape=("BLOCK_M", "BLOCK_K"))}}
 
         idx_m = b_k_idx_vals
         idx_n = offs_b_n[None, :]
         {{load_input("B", "b", ("idx_m", "idx_n"), mask=None if EVEN_K else "b_mask",
-                     indent_width=8, index_shape=("BLOCK_K", "BLOCK_N"),
-                     loop_varying_indices=("idx_m", "b_mask"))}}
+                     indent_width=8, index_shape=("BLOCK_K", "BLOCK_N"))}}
 
         {% if USE_FAST_ACCUM %}
         acc = tl.dot(a, b, acc, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE)

--- a/torch/_inductor/kernel/templates/triton_mm_rocm.py.jinja
+++ b/torch/_inductor/kernel/templates/triton_mm_rocm.py.jinja
@@ -36,10 +36,6 @@
         offs_b_n = rn % N
     offs_k = tl.arange(0, BLOCK_K).to(INDEX_DTYPE)
     acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=ACC_TYPE)
-    {{load_input_loop_invariant_code(
-        idx_m="offs_a_m[:, None]",
-        idx_n="offs_b_n[None, :]",
-    )}}
 
     for k_idx in range(0, tl.cdiv(K, BLOCK_K)):
         {% if not EVEN_K %}
@@ -52,14 +48,12 @@
         idx_m = offs_a_m[:, None]
         idx_n = a_k_idx_vals
         {{load_input("A", "a", ("idx_m", "idx_n"), mask=None if EVEN_K else "a_mask",
-                     indent_width=8, index_shape=("BLOCK_M", "BLOCK_K"),
-                     loop_varying_indices=("idx_n", "a_mask"))}}
+                     indent_width=8, index_shape=("BLOCK_M", "BLOCK_K"))}}
 
         idx_m = b_k_idx_vals
         idx_n = offs_b_n[None, :]
         {{load_input("B", "b", ("idx_m", "idx_n"), mask=None if EVEN_K else "b_mask",
-                     indent_width=8, index_shape=("BLOCK_K", "BLOCK_N"),
-                     loop_varying_indices=("idx_m", "b_mask"))}}
+                     indent_width=8, index_shape=("BLOCK_K", "BLOCK_N"))}}
         {% if USE_FAST_ACCUM %}
         acc = tl.dot(a, b, acc, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE)
         {% else %}

--- a/torch/_inductor/kernel/templates/triton_persistent_mm.py.jinja
+++ b/torch/_inductor/kernel/templates/triton_persistent_mm.py.jinja
@@ -39,10 +39,6 @@
             offs_b_n = rn % N
         offs_k = tl.arange(0, BLOCK_K)
         acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=ACC_TYPE)
-        {{load_input_loop_invariant_code(
-            idx_m="offs_a_m[:, None]",
-            idx_n="offs_b_n[None, :]",
-        )}}
 
         for k_idx in range(0, tl.cdiv(K, BLOCK_K)):
             {% if not EVEN_K %}
@@ -55,14 +51,12 @@
             idx_m = offs_a_m[:, None]
             idx_n = a_k_idx_vals
             {{load_input("A", "a", ("idx_m", "idx_n"), mask=None if EVEN_K else "a_mask",
-                         indent_width=12, index_shape=("BLOCK_M", "BLOCK_K"),
-                         loop_varying_indices=("idx_n", "a_mask"))}}
+                         indent_width=12, index_shape=("BLOCK_M", "BLOCK_K"))}}
 
             idx_m = b_k_idx_vals
             idx_n = offs_b_n[None, :]
             {{load_input("B", "b", ("idx_m", "idx_n"), mask=None if EVEN_K else "b_mask",
-                         indent_width=12, index_shape=("BLOCK_K", "BLOCK_N"),
-                         loop_varying_indices=("idx_m", "b_mask"))}}
+                         indent_width=12, index_shape=("BLOCK_K", "BLOCK_N"))}}
 
             {% if USE_FAST_ACCUM %}
             acc = tl.dot(a, b, acc, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE)

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -1,5 +1,4 @@
 # mypy: allow-untyped-defs
-import ast
 import contextlib
 import dataclasses
 import functools
@@ -688,9 +687,6 @@ class TritonTemplateKernel(TritonKernel):
         # When prologue_loads_all_inputs is true, prologue_supported_inputs is populated during def_kernel
         # by adding all inputs.
         self.prologue_loads_all_inputs = prologue_loads_all_inputs
-        self._load_input_loop_invariant_code = IndentedBuffer()
-        self._load_input_loop_invariant_index_replacements: dict[str, str] = {}
-        self._load_input_loop_invariant_enabled = False
 
         # When always_freeze_layout is True, get_stride_and_maybe_freeze_layout will
         # always freeze the layout immediately, bypassing layout constraints.
@@ -1215,7 +1211,6 @@ class TritonTemplateKernel(TritonKernel):
         other: float | int | None = 0.0,
         indent_width: int = 4,
         index_shape: tuple[str] | None = None,
-        loop_varying_indices: Sequence[str] | None = None,
     ):
         """Loads an input and applies any necessary preprocessing or masking.
 
@@ -1226,9 +1221,6 @@ class TritonTemplateKernel(TritonKernel):
             mask (Optional[str]): An optional mask to use for the load operation.
             other (Optional[Union[float, int]]): The value to use for masked elements. Default is 0.0.
             indent_width (int): The number of spaces to use for indentation.
-            loop_varying_indices (Optional[Sequence[str]]): Template index names
-                that vary across the surrounding template loop.  Used to hoist
-                prologue loads that only depend on loop-invariant indices.
         """
 
         input_node = self.named_input_nodes[input_name]
@@ -1249,7 +1241,6 @@ class TritonTemplateKernel(TritonKernel):
             no_x_dim=False,
         )
         load_code = None
-        original_indices = tuple(indices)
 
         with self.create_subgraph_body(f"<LOAD_INPUT_{input_name}>"):
             if not isinstance(indices, (list, tuple)):
@@ -1386,209 +1377,11 @@ class TritonTemplateKernel(TritonKernel):
                     self.body.writeline(load_code)
 
                 result = self.body.getvalue()
-                if input_node.get_name() in self.prologue_fused_inputs:
-                    result = self._hoist_loop_invariant_load_input_code(
-                        input_name,
-                        result,
-                        original_indices,
-                        index_shape,
-                        loop_varying_indices,
-                    )
                 if indent_width:
                     result = textwrap.indent(result, " " * indent_width)
                 return result.strip()
 
         return self._register_hook(hook_key, hook)
-
-    def load_input_loop_invariant_code(self, **index_replacements: str):
-        """Hook point for loop-invariant prologue loads.
-
-        ``load_input`` hooks are finalized before this hook, so they can append
-        loads that are safe to compute before the template's inner loop.
-        """
-        if not all(
-            isinstance(name, str) and isinstance(expr, str)
-            for name, expr in index_replacements.items()
-        ):
-            raise AssertionError("index replacements must be string pairs")
-        hook_key = "<LOAD_INPUT_LOOP_INVARIANT>"
-        self._load_input_loop_invariant_enabled = True
-        self._load_input_loop_invariant_index_replacements = {
-            name: f"_loop_invariant_{name}" for name in index_replacements
-        }
-        preamble_lines = tuple(
-            f"{self._load_input_loop_invariant_index_replacements[name]} = {expr}"
-            for name, expr in index_replacements.items()
-        )
-        self._load_input_loop_invariant_code = IndentedBuffer()
-
-        def hook():
-            hoisted_code = self._load_input_loop_invariant_code.getvalue().rstrip()
-            self._load_input_loop_invariant_code = IndentedBuffer()
-            self._load_input_loop_invariant_enabled = False
-            self._load_input_loop_invariant_index_replacements = {}
-            if not hoisted_code:
-                return ""
-            if not preamble_lines:
-                return hoisted_code
-            return "\n".join(preamble_lines) + ("\n" + hoisted_code)
-
-        return self._register_hook(hook_key, hook)
-
-    @staticmethod
-    def _assignment_lhs_and_rhs_names(line: str) -> tuple[str | None, OrderedSet[str]]:
-        # This parser only sees assignment lines emitted by Inductor's own
-        # Triton codegen for prologue subgraphs.  Any line outside that narrow
-        # shape is treated as non-hoistable.
-        try:
-            parsed = ast.parse(line.strip())
-        except SyntaxError:
-            return None, OrderedSet()
-
-        if len(parsed.body) != 1 or not isinstance(parsed.body[0], ast.Assign):
-            return None, OrderedSet()
-
-        node = parsed.body[0]
-        if len(node.targets) != 1 or not isinstance(node.targets[0], ast.Name):
-            return None, OrderedSet()
-
-        rhs_names = OrderedSet(
-            name.id for name in ast.walk(node.value) if isinstance(name, ast.Name)
-        )
-        return node.targets[0].id, rhs_names
-
-    @staticmethod
-    def _is_generated_prologue_temp(name: str) -> bool:
-        # Keep this in sync with temporary names emitted by prologue pointwise
-        # codegen.  Unknown assigned temps still block hoisting via
-        # assigned_names, but recognizing the common forms keeps this helper
-        # conservative if a temp is referenced without a local assignment.
-        return (
-            re.fullmatch(r"tmp\d+", name) is not None
-            or re.fullmatch(r"_tmp_var\d+", name) is not None
-            or name in {"xindex", "xmask"}
-        )
-
-    @staticmethod
-    def _remove_loop_invariant_broadcast(
-        line: str,
-        invariant_indices: Sequence[str],
-        index_shape: tuple[str] | None,
-        index_replacements: dict[str, str],
-    ) -> str:
-        if not index_shape:
-            return line
-
-        shape_pattern = (
-            r"\[\s*" + r"\s*,\s*".join(re.escape(dim) for dim in index_shape) + r"\s*\]"
-        )
-        for index in invariant_indices:
-            index_pattern = re.escape(index)
-            replacement = index_replacements.get(index, index)
-            line = re.sub(
-                rf"tl\.broadcast_to\(\s*\(?\s*{index_pattern}\s*\)?\s*,\s*{shape_pattern}\s*\)",
-                replacement,
-                line,
-            )
-        return line
-
-    @staticmethod
-    def _rename_code_names(line: str, renames: dict[str, str]) -> str:
-        if not renames:
-            return line
-
-        pattern = re.compile(
-            r"\b(" + "|".join(re.escape(name) for name in renames) + r")\b"
-        )
-        return pattern.sub(lambda match: renames[match.group(0)], line)
-
-    def _hoist_loop_invariant_load_input_code(
-        self,
-        input_name: str,
-        code: str,
-        indices: Sequence[str],
-        index_shape: tuple[str] | None,
-        loop_varying_indices: Sequence[str] | None,
-    ) -> str:
-        if not (
-            self._load_input_loop_invariant_enabled
-            and loop_varying_indices
-            and code.strip()
-        ):
-            return code
-
-        loop_dependent_names = OrderedSet(["k_idx", "k", *loop_varying_indices])
-        index_names = OrderedSet(index for index in indices if isinstance(index, str))
-        removable_loop_masks = OrderedSet(loop_varying_indices) - index_names
-        invariant_indices = [
-            index
-            for index in indices
-            if isinstance(index, str) and index not in loop_dependent_names
-        ]
-        if not invariant_indices:
-            return code
-
-        lines = code.splitlines()
-        parsed_assignments = [
-            self._assignment_lhs_and_rhs_names(line) for line in lines
-        ]
-        assigned_names = OrderedSet(
-            lhs for lhs, _ in parsed_assignments if lhs is not None
-        )
-        assignment_counts: defaultdict[str, int] = defaultdict(int)
-        for lhs, _ in parsed_assignments:
-            if lhs is not None:
-                assignment_counts[lhs] += 1
-
-        kept_lines: list[str] = []
-        hoisted_lines: list[str] = []
-        renames: dict[str, str] = {}
-
-        for line, (lhs, rhs_names) in zip(lines, parsed_assignments):
-            loop_deps_in_rhs = rhs_names & loop_dependent_names
-            generated_temp_deps = OrderedSet(
-                name for name in rhs_names if self._is_generated_prologue_temp(name)
-            )
-            # Keep this intentionally narrow: only direct tl.load assignments
-            # whose RHS does not mention a symbol assigned in this generated
-            # prologue body are hoisted.  Loads needing an invariant temp stay
-            # in place rather than moving before their dependency.  K-tail
-            # masks are dropped only for otherwise-invariant loads; the data
-            # loads that actually depend on the K index remain masked in-loop.
-            should_hoist = (
-                lhs is not None
-                and assignment_counts[lhs] == 1
-                and "tl.load(" in line
-                and loop_deps_in_rhs <= removable_loop_masks
-                and not (rhs_names & assigned_names)
-                and not generated_temp_deps
-            )
-            if should_hoist:
-                new_lhs = f"_loop_invariant_{input_name}_{lhs}"
-                renames[lhs] = new_lhs
-                hoisted_line = self._remove_loop_invariant_broadcast(
-                    line.strip(),
-                    invariant_indices,
-                    index_shape,
-                    self._load_input_loop_invariant_index_replacements,
-                )
-                hoisted_line = self._rename_code_names(
-                    hoisted_line,
-                    self._load_input_loop_invariant_index_replacements,
-                )
-                hoisted_line = self._rename_code_names(
-                    hoisted_line,
-                    dict.fromkeys(loop_deps_in_rhs, "None"),
-                )
-                hoisted_line = self._rename_code_names(hoisted_line, {lhs: new_lhs})
-                hoisted_lines.append(hoisted_line)
-            else:
-                kept_lines.append(self._rename_code_names(line, renames))
-
-        for line in hoisted_lines:
-            self._load_input_loop_invariant_code.writeline(line)
-
-        return "\n".join(kept_lines)
 
     def _generate_index_from_tma_index(
         self,
@@ -1960,7 +1753,6 @@ class TritonTemplateKernel(TritonKernel):
                 self.stride,
                 self.store_output,
                 self.load_input,
-                self.load_input_loop_invariant_code,
                 self.make_load,
                 self.modification,
                 self.gen_argdefs,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #190121

This reverts #184301 (relanded 2026-07-05 as 8db8ac05181).

It breaks the "Limited CI on H100" smoke job: the inductor/test_max_autotune
caching tests fail consistently on trunk --
  - TestMaxAutotune.test_triton_template_generated_code_caching
  - TestMaxAutotuneRemoteCache.test_max_autotune_remote_caching_dynamic_False
The remote-cache stats double (num_put / num_get_miss go 2 -> 4). The H100
smoke job was already red on #184301's own PR CI and has been failing on
trunk since the reland.

Confirmed by this revert: with #184301 reverted, the H100 smoke job is green
(inductor/test_max_autotune 2/3 and 3/3 successful,
test_triton_template_generated_code_caching PASSED).

Likely mechanism: the two tests #184301 added
(test_gather_fusion_hoists_both_inputs / test_gather_fusion_hoists_even_k_false)
leak autotune remote-cache state into the shared stats, so a later test in the
same shard observes doubled counts.

@jansel -- reverting to green the H100 smoke; happy to take a forward-fix
(test isolation for the new gather-fusion tests) instead if you prefer.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo