### PR TITLE
[CI][sharding] Revert MIN_TEST_FILE_TIMES OpInfo sharding floor

### DIFF
--- a/tools/test/test_test_selections.py
+++ b/tools/test/test_test_selections.py
@@ -6,7 +6,6 @@ import sys
 import unittest
 from collections import defaultdict
 from pathlib import Path
-from unittest import mock
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -431,57 +430,6 @@ class TestCalculateShards(unittest.TestCase):
                 test_times,
                 gen_class_times(test_times),
             ),
-        )
-
-    def test_opinfo_uses_min_duration_for_pytest_sharding(self) -> None:
-        opinfo = "inductor/test_torchinductor_opinfo"
-        with mock.patch(
-            "tools.testing.test_selections.BUILD_ENVIRONMENT",
-            "linux-jammy-py3.10-gcc11",
-        ):
-            shards = calculate_shards(
-                1,
-                [TestRun(opinfo), TestRun("normal_test")],
-                {opinfo: 1, "normal_test": 2},
-                None,
-            )
-        self.assertEqual(THRESHOLD * 56 + 2, shards[0][0])
-
-        opinfo_shards = [test for test in shards[0][1] if test.name == opinfo]
-        self.assertEqual(56, len(opinfo_shards))
-        self.assertEqual(list(range(1, 57)), [test.shard for test in opinfo_shards])
-        self.assertTrue(
-            all(
-                test.num_shards == 56 and test.time == THRESHOLD
-                for test in opinfo_shards
-            )
-        )
-        self.assertIn(
-            ShardedTest(test="normal_test", shard=1, num_shards=1, time=2),
-            shards[0][1],
-        )
-
-    def test_opinfo_does_not_use_min_duration_on_windows(self) -> None:
-        opinfo = "inductor/test_torchinductor_opinfo"
-        with mock.patch(
-            "tools.testing.test_selections.BUILD_ENVIRONMENT",
-            "win-vs2022-cpu-py3",
-        ):
-            shards = calculate_shards(
-                1,
-                [TestRun(opinfo), TestRun("normal_test")],
-                {opinfo: 1, "normal_test": 2},
-                None,
-            )
-
-        self.assertEqual(3, shards[0][0])
-        self.assertIn(
-            ShardedTest(test=opinfo, shard=1, num_shards=1, time=1),
-            shards[0][1],
-        )
-        self.assertIn(
-            ShardedTest(test="normal_test", shard=1, num_shards=1, time=2),
-            shards[0][1],
         )
 
     def test_zero_tests(self) -> None:

--- a/tools/testing/test_selections.py
+++ b/tools/testing/test_selections.py
@@ -37,14 +37,6 @@ NUM_PROCS = 1 if IS_MEM_LEAK_CHECK else 3 if not TEST_CUDA or SM80OrLater else 2
 NUM_PROCS_FOR_SHARDING_CALC = NUM_PROCS if not IS_ROCM or IS_MEM_LEAK_CHECK else 2
 THRESHOLD = 60 * 10  # 10 minutes
 
-MIN_TEST_FILE_TIMES = {
-    # Generated stats can record a fully skipped CPU Inductor OpInfo run.
-    # Keep enough pytest shards to stay under per-test timeouts when that
-    # near-zero runtime is stale. Windows CI intentionally skips this file, so
-    # do not inflate Windows shard estimates with no-op pytest shards.
-    "inductor/test_torchinductor_opinfo": THRESHOLD * 56,
-}
-
 # See Note [ROCm parallel CI testing]
 # Special logic for ROCm GHA runners to query number of GPUs available.
 # torch.version.hip was not available to check if this was a ROCm self-hosted runner.
@@ -116,11 +108,6 @@ def get_duration(
     test_class_times.  Returns None if the time is unknown."""
     file_duration = test_file_times.get(test.test_file, None)
     if test.is_full_file():
-        min_duration = None
-        if not BUILD_ENVIRONMENT.startswith(("win-", "windows-")):
-            min_duration = MIN_TEST_FILE_TIMES.get(test.test_file)
-        if min_duration is not None:
-            return max(file_duration or 0, min_duration)
         return file_duration
 
     def get_duration_for_classes(


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/184048 introduced `MIN_TEST_FILE_TIMES` to bootstrap sharding for inductor/test_torchinductor_opinfo since its recorded time in test-times.json was a stale ~4s. That timing is now accurate (~375min+) as of https://github.com/pytorch/test-infra/actions/runs/29458417984/job/87496607917 and available at https://raw.githubusercontent.com/pytorch/test-infra/generated-stats/stats/test-times.json, so the file should shard correctly on its own. Removing it also stops the floor from manufacturing phantom shards in configs that skip the file (e.g. crossref). Keeps #184048's OpInfo coverage; removes only the floor and its two tests.

Removing the floor is also done to see if shards balance correctly again. By examining https://hud.pytorch.org/pytorch/pytorch/commit/53e958ddf88a76eae49437a1a7acc5b7418ac1de, it looks like crossref shards that shouldn't be affected by the changes are thrown out of balance, and extending overall pull time performance. 

<img width="976" height="427" alt="Screenshot 2026-07-15 at 4 44 16 PM" src="https://github.com/user-attachments/assets/556fe4e8-9fc9-4ed3-aae9-b4a893212d1c" />
- It's typically uncommon for one shard to be greater than 40% longer than siblings

Test Plan:
```
python tools/test/test_test_selections.py
```

(Claude inspection of times)
  **Current `test-times.json` for `inductor/test_torchinductor_opinfo`** — 37 configs run it, all with real times (32–486 min):

  | config | min |
  |---|---:|
  | linux-jammy-py3.14t-clang18 / default | 486 |
  | linux-jammy-py3.10-clang18 / default | 435 |
  | linux-jammy-aarch64-py3.10 / default | 401 |
  | unit-test / inductor-cpu-test / inductor_amx | 375 |
  | periodic-inductor-benchmarks-cpu-test / inductor_avx2 | 364 |
  | unit-test / inductor-test / default | 203 |
  | default / default | 191 |
  | linux-jammy-cuda13.0-py3.10-gcc11 / default | 131 |
  | linux-jammy-rocm-py3.10-mi350 / default | 90 |
  | _…28 more, 32–486 min_ | |

  The only `≤1 min` entries are configs that **skip** opinfo (`@skipIf(TEST_WITH_ASAN)`, empty-config orphan keys) plus one dead-config key (`unit-test /
  inductor-cpu-test / inductor_avx2`, 0 rows) — none of them shards opinfo, so they're harmless.

Authored with assistance from Claude (Claude Code).