### PR TITLE
[c10d][nccl2] Fix c10d backend contract gaps

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.hpp
@@ -184,13 +184,6 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
     return backendType_;
   }
 
-  inline bool backendSupportsSequenceNumbers(BackendType backendType) {
-    if (backendType == BackendType::GLOO || backendType == BackendType::NCCL ||
-        backendType == BackendType::XCCL || backendType == BackendType::UCC)
-      return true;
-    return false;
-  }
-
   virtual void setTimeout(std::chrono::milliseconds timeout) {
     for (auto& backend : backendTypeToBackend_) {
       backend.second->setTimeout(timeout);
@@ -762,19 +755,7 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
   // in sync. If the returned number is not consistent across the group, it
   // may indicate that there is some sort of collective desynchronization.
   virtual uint64_t getSequenceNumberForGroup() {
-    auto backendType = getBackendType();
-
-    // TODO: HACK for backend name to get sequence number for that backend.
-    if (backendSupportsSequenceNumbers(backendType)) {
-      return getDefaultBackend()->getSequenceNumberForGroup();
-    } else {
-      TORCH_CHECK(
-          false,
-          c10::str(
-              "ProcessGroup ",
-              getBackendName(),
-              " does not yet support sequence numbers."));
-    }
+    return getDefaultBackend()->getSequenceNumberForGroup();
   }
 
   virtual c10::intrusive_ptr<Work> send(

--- a/torch/csrc/distributed/c10d/nccl2/NCCLBootstrap.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/NCCLBootstrap.cpp
@@ -17,9 +17,6 @@
 
 namespace c10d::nccl2 {
 
-// Initialize the static counter
-int NCCLBootstrap::counter_ = 0;
-
 const std::string kUniqueidXchgMethodAuto = "auto";
 const std::string kUniqueidXchgMethodTCPStore = "tcpstore";
 const std::string kUniqueidXchgMethodDefault = kUniqueidXchgMethodAuto;
@@ -29,9 +26,11 @@ NCCLBootstrap::NCCLBootstrap(
     c10::Device device,
     int rank,
     int comm_size,
+    uint64_t generation,
     std::shared_ptr<NcclApi> nccl_api,
     std::chrono::milliseconds timeout)
     : timeout_(timeout),
+      generation_(generation),
       store_(std::move(store)),
       created_internal_store_(false),
       device_(device),
@@ -68,24 +67,10 @@ NCCLBootstrap::NCCLBootstrap(
       c10::cuda::CUDACachingAllocator::get()->allocate(sizeof(float));
 }
 
-std::string NCCLBootstrap::getNCCLStoreKey() {
-  std::string key = fmt::format("{}{}", getNCCLStoreKeyPrefix(), counter_);
-  counter_++;
-  return key;
-}
-
-std::string NCCLBootstrap::getNCCLStoreKeyPrefix() {
-  return "nccl_storekey_";
-};
-
-int NCCLBootstrap::getNCCLStoreKeyCounter() {
-  return counter_;
-}
-
 ncclUniqueId NCCLBootstrap::exchangeUniqueIdStore() {
   ncclUniqueId uniqueId;
 
-  auto key = getNCCLStoreKey();
+  auto key = fmt::format("nccl_storekey_{}", generation_);
   if (rank_ == 0) {
     // Generate unique ID on rank 0
     ncclResult_t ncclErr = nccl_api_->getUniqueId(&uniqueId);
@@ -263,6 +248,7 @@ void populateNcclConfigFromHints(
 ncclComm_t NCCLBootstrap::createNcclComm(
     const std::string& name,
     const std::unordered_map<std::string, std::string>& hints) {
+  c10::cuda::CUDAGuard gpuGuard(device_);
   ncclUniqueId uniqueId;
   ncclComm_t nccl_comm = nullptr;
 

--- a/torch/csrc/distributed/c10d/nccl2/NCCLBootstrap.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/NCCLBootstrap.hpp
@@ -29,6 +29,7 @@ class NCCLBootstrap {
       c10::Device device,
       int rank,
       int comm_size,
+      uint64_t generation,
       std::shared_ptr<NcclApi> nccl_api,
       std::chrono::milliseconds timeout);
 
@@ -41,9 +42,6 @@ class NCCLBootstrap {
   ncclComm_t createNcclComm(
       const std::string& name,
       const std::unordered_map<std::string, std::string>& hints = {});
-  static std::string getNCCLStoreKey();
-  static std::string getNCCLStoreKeyPrefix();
-  static int getNCCLStoreKeyCounter();
 
   int getRank() {
     return rank_;
@@ -64,7 +62,7 @@ class NCCLBootstrap {
 
  private:
   const std::chrono::milliseconds timeout_;
-  static int counter_;
+  const uint64_t generation_;
 
   c10::intrusive_ptr<c10d::Store> store_;
   bool created_internal_store_;

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
@@ -94,6 +94,7 @@ void ProcessGroupNCCL::init(at::Device device) {
         device_,
         getRank(),
         getSize(),
+        bootstrap_generation_++,
         nccl_api_,
         options_c10d_->timeout);
     device_ = bootstrap->getDevice();

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
@@ -23,6 +23,24 @@
 
 namespace c10d::nccl2 {
 
+namespace {
+
+void checkSameDtype(const at::Tensor& reference, const at::Tensor& tensor) {
+  if (reference.scalar_type() != tensor.scalar_type()) {
+    C10_THROW_ERROR(TypeError, "Tensors must have identical type");
+  }
+}
+
+void checkSameDtype(
+    const at::Tensor& reference,
+    const std::vector<at::Tensor>& tensors) {
+  for (const auto& tensor : tensors) {
+    checkSameDtype(reference, tensor);
+  }
+}
+
+} // namespace
+
 ncclResult_t NCCLException::getResult() const noexcept {
   return result_;
 }
@@ -671,6 +689,7 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::all_gather(
 
   checkTensorDevice(tensor);
   checkTensorsDevice(tensor_list);
+  checkSameDtype(tensor, tensor_list);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "all_gather", rank_, tensor_list, {tensor});
@@ -725,6 +744,7 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::allGatherSingleImpl(
   ensureTensorContiguous(input);
   checkTensorDevice(output);
   checkTensorDevice(input);
+  checkSameDtype(input, output);
 
   if (output.numel() != input.numel() * comm_size_) {
     throw std::runtime_error(
@@ -786,6 +806,7 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::reduce_scatter(
 
   checkTensorsDevice(input_list);
   checkTensorDevice(output);
+  checkSameDtype(output, input_list);
 
   TracingGuard tracingGuard(
       name_, comm_size_, "reduce_scatter", rank_, input_list, {output});
@@ -858,6 +879,7 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::reduceScatterSingleImpl(
   ensureTensorContiguous(input);
   checkTensorDevice(output);
   checkTensorDevice(input);
+  checkSameDtype(input, output);
 
   if (input.numel() != output.numel() * comm_size_) {
     throw std::runtime_error(
@@ -908,6 +930,7 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::allToAllSingleImpl(
   ensureTensorContiguous(input);
   checkTensorDevice(output);
   checkTensorDevice(input);
+  checkSameDtype(input, output);
 
   if (input.numel() != output.numel()) {
     throw std::runtime_error(
@@ -1001,6 +1024,7 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::all_to_all_v_single(
   ensureTensorContiguous(input);
   checkTensorDevice(output);
   checkTensorDevice(input);
+  checkSameDtype(input, output);
 
   // Validate split sizes vectors
   if (input_split_sizes.size() != static_cast<size_t>(comm_size_)) {
@@ -1137,6 +1161,8 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::all_to_all(
   for (int i = 0; i < comm_size_; ++i) {
     ensureTensorContiguous(input_tensor_list[i]);
     ensureTensorContiguous(output_tensor_list[i]);
+    checkSameDtype(input_tensor_list[0], input_tensor_list[i]);
+    checkSameDtype(input_tensor_list[0], output_tensor_list[i]);
   }
 
   TracingGuard tracingGuard(
@@ -1254,6 +1280,7 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::scatterImpl(
 
     for (const auto& t : input_tensor_list) {
       ensureTensorContiguous(t);
+      checkSameDtype(output_tensor, t);
       if (t.numel() != output_tensor.numel()) {
         throw std::runtime_error(
             "All input tensors must have same size as output tensor");
@@ -1348,6 +1375,7 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::gatherImpl(
 
     for (const auto& t : output_tensor_list) {
       ensureTensorContiguous(t);
+      checkSameDtype(input_tensor, t);
       if (t.numel() != input_tensor.numel()) {
         throw std::runtime_error(
             "All output tensors must have same size as input tensor");

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
@@ -214,6 +214,9 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
   std::shared_ptr<c10::Allocator> getMemAllocator() override;
   void setTimeout(std::chrono::milliseconds timeout) override;
   void eagerConnectSingleDevice(at::Device device) override;
+  uint64_t getSequenceNumberForGroup() override {
+    return sequence_number_;
+  }
   void shutdown() override;
   void abort() override;
   ::c10d::ErrorType getError() override;
@@ -493,6 +496,8 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
   } init_state_{InitializationState::UNINITIALIZED};
 
   c10::intrusive_ptr<::c10d::Store> store_;
+  uint64_t bootstrap_generation_{0};
+  uint64_t sequence_number_{0};
 
   std::shared_ptr<NcclApi> nccl_api_;
 
@@ -536,6 +541,7 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
   // Active coalescing batch (port of BackendWrapper). Engaged between
   // startCoalescing() and endCoalescing(); send()/recv() append into it.
   std::optional<BatchSendRecv> coalescing_batch_;
+  c10::intrusive_ptr<WorkNCCL> coalesced_work_;
 
   std::unordered_map<
       unsigned long long,

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLBackend.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLBackend.cpp
@@ -14,6 +14,7 @@
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/util/irange.h>
 #include <torch/csrc/cuda/CUDAPluggableAllocator.h>
+#include <torch/csrc/distributed/c10d/Types.hpp>
 
 #include <torch/csrc/distributed/c10d/nccl2/Logging.hpp>
 #include <torch/csrc/distributed/c10d/nccl2/WindowNCCL.hpp>
@@ -224,10 +225,14 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::broadcast(
     std::vector<at::Tensor>& tensors,
     const ::c10d::BroadcastOptions& opts) {
   TORCH_CHECK(tensors.size() == 1, "Only single tensor supported");
-  ensureInitialized(tensors.at(0).device());
+  auto tensor = tensors.at(0);
+  if (tensor.is_complex()) {
+    tensor = at::view_as_real(tensor);
+  }
+  ensureInitialized(tensor.device());
   ++sequence_number_;
   auto work = broadcastImpl(
-      tensors.at(0),
+      tensor,
       static_cast<int>(opts.rootRank),
       opts.asyncOp,
       operationTimeout(opts.timeout));
@@ -239,13 +244,19 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::allreduce(
     std::vector<at::Tensor>& tensors,
     const ::c10d::AllreduceOptions& opts) {
   TORCH_CHECK(tensors.size() == 1, "Only single tensor supported");
-  ensureInitialized(tensors.at(0).device());
+  auto tensor = tensors.at(0);
+  if (tensor.is_complex()) {
+    TORCH_CHECK(
+        ::c10d::isComplexViewAsRealAllowed(opts.reduceOp),
+        "all_reduce does not support",
+        opts.reduceOp,
+        "on complex tensors");
+    tensor = at::view_as_real(tensor);
+  }
+  ensureInitialized(tensor.device());
   ++sequence_number_;
   auto work = all_reduce(
-      tensors.at(0),
-      opts.reduceOp,
-      opts.asyncOp,
-      operationTimeout(opts.timeout));
+      tensor, opts.reduceOp, opts.asyncOp, operationTimeout(opts.timeout));
   work->setOutputs(tensors);
   return work;
 }
@@ -273,10 +284,19 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::reduce(
     std::vector<at::Tensor>& tensors,
     const ::c10d::ReduceOptions& opts) {
   TORCH_CHECK(tensors.size() == 1, "Only single tensor supported");
-  ensureInitialized(tensors.at(0).device());
+  auto tensor = tensors.at(0);
+  if (tensor.is_complex()) {
+    TORCH_CHECK(
+        ::c10d::isComplexViewAsRealAllowed(opts.reduceOp),
+        "reduce does not support",
+        opts.reduceOp,
+        "on complex tensors");
+    tensor = at::view_as_real(tensor);
+  }
+  ensureInitialized(tensor.device());
   ++sequence_number_;
   auto work = reduceImpl(
-      tensors.at(0),
+      tensor,
       static_cast<int>(opts.rootRank),
       opts.reduceOp,
       opts.asyncOp,

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLBackend.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLBackend.cpp
@@ -12,6 +12,7 @@
 
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDAGuard.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/cuda/CUDAPluggableAllocator.h>
 
 #include <torch/csrc/distributed/c10d/nccl2/Logging.hpp>
@@ -54,6 +55,17 @@ class CompletedWork : public ::c10d::Work {
   std::vector<at::Tensor> outputs_;
 };
 
+c10::intrusive_ptr<WorkNCCL> coalesceWorks(
+    std::vector<c10::intrusive_ptr<WorkNCCL>> works,
+    std::vector<at::Tensor> outputs) {
+  TORCH_INTERNAL_ASSERT(!works.empty());
+  auto work = std::move(works.back());
+  works.pop_back();
+  work->setChildren(std::move(works));
+  work->setOutputs(std::move(outputs));
+  return work;
+}
+
 } // namespace
 
 ProcessGroupNCCL::ProcessGroupNCCL(
@@ -64,7 +76,7 @@ ProcessGroupNCCL::ProcessGroupNCCL(
     : Backend(rank, size),
       device_(at::kCUDA),
       store_(std::move(store)),
-      options_c10d_(options ? options : Options::create()) {
+      options_c10d_(options ? std::move(options) : Options::create()) {
   name_ = options_c10d_->group_name.empty() ? std::string(kBackendName)
                                             : options_c10d_->group_name;
 }
@@ -183,7 +195,7 @@ std::shared_ptr<c10::Allocator> ProcessGroupNCCL::getMemAllocator() {
 c10::intrusive_ptr<::c10d::Window> ProcessGroupNCCL::new_window(
     const std::optional<at::Tensor>& tensor) {
   // Trigger the lazy bootstrap: prefer the tensor's device, then the bound
-  // device, then the current CUDA device (same policy as barrier()).
+  // device, then the current CUDA device.
   if (init_state_ != InitializationState::INITIALIZED) {
     at::Device dev = at::Device(at::kCUDA, at::cuda::current_device());
     if (tensor.has_value()) {
@@ -213,6 +225,7 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::broadcast(
     const ::c10d::BroadcastOptions& opts) {
   TORCH_CHECK(tensors.size() == 1, "Only single tensor supported");
   ensureInitialized(tensors.at(0).device());
+  ++sequence_number_;
   auto work = broadcastImpl(
       tensors.at(0),
       static_cast<int>(opts.rootRank),
@@ -227,6 +240,7 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::allreduce(
     const ::c10d::AllreduceOptions& opts) {
   TORCH_CHECK(tensors.size() == 1, "Only single tensor supported");
   ensureInitialized(tensors.at(0).device());
+  ++sequence_number_;
   auto work = all_reduce(
       tensors.at(0),
       opts.reduceOp,
@@ -239,14 +253,19 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::allreduce(
 c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::allreduce_coalesced(
     std::vector<at::Tensor>& tensors,
     const ::c10d::AllreduceCoalescedOptions& opts) {
-  TORCH_CHECK(tensors.size() == 1, "Only single tensor supported");
+  TORCH_CHECK(!tensors.empty(), "Tensor list must be nonempty");
   ensureInitialized(tensors.at(0).device());
-  auto work = all_reduce(
-      tensors.at(0),
-      opts.reduceOp,
-      opts.asyncOp,
-      operationTimeout(opts.timeout));
-  work->setOutputs(tensors);
+  ++sequence_number_;
+  std::vector<c10::intrusive_ptr<WorkNCCL>> works;
+  works.reserve(tensors.size());
+  for (auto& tensor : tensors) {
+    works.push_back(all_reduce(
+        tensor, opts.reduceOp, opts.asyncOp, operationTimeout(opts.timeout)));
+  }
+  auto work = coalesceWorks(std::move(works), tensors);
+  if (coalescing_batch_) {
+    coalesced_work_ = work;
+  }
   return work;
 }
 
@@ -255,6 +274,7 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::reduce(
     const ::c10d::ReduceOptions& opts) {
   TORCH_CHECK(tensors.size() == 1, "Only single tensor supported");
   ensureInitialized(tensors.at(0).device());
+  ++sequence_number_;
   auto work = reduceImpl(
       tensors.at(0),
       static_cast<int>(opts.rootRank),
@@ -273,6 +293,7 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::allgather(
       outputTensors.size() == 1 && inputTensors.size() == 1,
       "Only single tensor / single list supported");
   ensureInitialized(inputTensors.at(0).device());
+  ++sequence_number_;
   const auto& input = inputTensors.at(0);
   auto& outputList = outputTensors.at(0);
   TORCH_CHECK(
@@ -312,15 +333,28 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::allgather_coalesced(
     std::vector<at::Tensor>& inputTensors,
     const ::c10d::AllgatherOptions& opts) {
   TORCH_CHECK(
-      outputTensorLists.size() == 1 && inputTensors.size() == 1,
-      "Only single tensor / single list supported");
+      !inputTensors.empty() && outputTensorLists.size() == inputTensors.size(),
+      "Input and output tensor lists must have the same nonzero size");
   ensureInitialized(inputTensors.at(0).device());
-  auto work = all_gather(
-      outputTensorLists.at(0),
-      inputTensors.at(0),
-      opts.asyncOp,
-      operationTimeout(opts.timeout));
-  work->setOutputs(outputTensorLists.at(0));
+  ++sequence_number_;
+  std::vector<c10::intrusive_ptr<WorkNCCL>> works;
+  std::vector<at::Tensor> outputs;
+  works.reserve(inputTensors.size());
+  for (const auto i : c10::irange(inputTensors.size())) {
+    works.push_back(all_gather(
+        outputTensorLists.at(i),
+        inputTensors.at(i),
+        opts.asyncOp,
+        operationTimeout(opts.timeout)));
+    outputs.insert(
+        outputs.end(),
+        outputTensorLists.at(i).begin(),
+        outputTensorLists.at(i).end());
+  }
+  auto work = coalesceWorks(std::move(works), std::move(outputs));
+  if (coalescing_batch_) {
+    coalesced_work_ = work;
+  }
   return work;
 }
 
@@ -330,15 +364,23 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::
         std::vector<at::Tensor>& inputs,
         const ::c10d::AllgatherOptions& opts) {
   TORCH_CHECK(
-      outputs.size() == 1 && inputs.size() == 1,
-      "Only single tensor supported");
+      !inputs.empty() && outputs.size() == inputs.size(),
+      "Input and output tensor lists must have the same nonzero size");
   ensureInitialized(inputs.at(0).device());
-  auto work = allGatherSingleImpl(
-      outputs.at(0),
-      inputs.at(0),
-      opts.asyncOp,
-      operationTimeout(opts.timeout));
-  work->setOutputs(outputs);
+  ++sequence_number_;
+  std::vector<c10::intrusive_ptr<WorkNCCL>> works;
+  works.reserve(inputs.size());
+  for (const auto i : c10::irange(inputs.size())) {
+    works.push_back(allGatherSingleImpl(
+        outputs.at(i),
+        inputs.at(i),
+        opts.asyncOp,
+        operationTimeout(opts.timeout)));
+  }
+  auto work = coalesceWorks(std::move(works), outputs);
+  if (coalescing_batch_) {
+    coalesced_work_ = work;
+  }
   return work;
 }
 
@@ -347,6 +389,7 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::_allgather_base(
     at::Tensor& inputBuffer,
     const ::c10d::AllgatherOptions& opts) {
   ensureInitialized(inputBuffer.device());
+  ++sequence_number_;
   auto work = allGatherSingleImpl(
       outputBuffer, inputBuffer, opts.asyncOp, operationTimeout(opts.timeout));
   work->setOutputs(std::vector<at::Tensor>{outputBuffer});
@@ -366,6 +409,7 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::gather(
   } else {
     TORCH_CHECK(outputTensors.size() == 1, "Only single output list");
   }
+  ++sequence_number_;
   auto work = gatherImpl(
       outputTensors.at(0),
       inputTensors.at(0),
@@ -388,6 +432,7 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::scatter(
     inputTensors.clear();
     inputTensors.emplace_back();
   }
+  ++sequence_number_;
   auto work = scatterImpl(
       outputTensors.at(0),
       inputTensors.at(0),
@@ -406,6 +451,7 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::reduce_scatter(
       outputTensors.size() == 1 && inputTensors.size() == 1,
       "Only single tensor / single list supported");
   ensureInitialized(outputTensors.at(0).device());
+  ++sequence_number_;
   auto work = reduce_scatter(
       outputTensors.at(0),
       inputTensors.at(0),
@@ -422,16 +468,24 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::
         std::vector<at::Tensor>& inputs,
         const ::c10d::ReduceScatterOptions& opts) {
   TORCH_CHECK(
-      outputs.size() == 1 && inputs.size() == 1,
-      "Only single tensor supported");
+      !outputs.empty() && inputs.size() == outputs.size(),
+      "Input and output tensor lists must have the same nonzero size");
   ensureInitialized(outputs.at(0).device());
-  auto work = reduceScatterSingleImpl(
-      outputs.at(0),
-      inputs.at(0),
-      opts.reduceOp,
-      opts.asyncOp,
-      operationTimeout(opts.timeout));
-  work->setOutputs(outputs);
+  ++sequence_number_;
+  std::vector<c10::intrusive_ptr<WorkNCCL>> works;
+  works.reserve(outputs.size());
+  for (const auto i : c10::irange(outputs.size())) {
+    works.push_back(reduceScatterSingleImpl(
+        outputs.at(i),
+        inputs.at(i),
+        opts.reduceOp,
+        opts.asyncOp,
+        operationTimeout(opts.timeout)));
+  }
+  auto work = coalesceWorks(std::move(works), outputs);
+  if (coalescing_batch_) {
+    coalesced_work_ = work;
+  }
   return work;
 }
 
@@ -440,6 +494,7 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::_reduce_scatter_base(
     at::Tensor& inputBuffer,
     const ::c10d::ReduceScatterOptions& opts) {
   ensureInitialized(outputBuffer.device());
+  ++sequence_number_;
   auto work = reduceScatterSingleImpl(
       outputBuffer,
       inputBuffer,
@@ -457,6 +512,7 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::alltoall_base(
     std::vector<int64_t>& inputSplitSizes,
     const ::c10d::AllToAllOptions& opts) {
   ensureInitialized(outputBuffer.device());
+  ++sequence_number_;
   auto timeout = operationTimeout(opts.timeout);
   if (outputSplitSizes.empty() && inputSplitSizes.empty()) {
     auto work =
@@ -481,6 +537,7 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::alltoall(
     const ::c10d::AllToAllOptions& opts) {
   TORCH_CHECK(!inputTensors.empty(), "alltoall requires input tensors");
   ensureInitialized(inputTensors.at(0).device());
+  ++sequence_number_;
   auto work = all_to_all(
       outputTensors,
       inputTensors,
@@ -493,9 +550,11 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::alltoall(
 c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::barrier(
     const ::c10d::BarrierOptions& opts) {
   // Resolve a device for lazy init: prefer an explicit device id, then the
-  // bound device, then the current CUDA device.
+  // bound device, then the conventional rank-to-device mapping.
   if (init_state_ != InitializationState::INITIALIZED) {
-    at::Device dev = at::Device(at::kCUDA, at::cuda::current_device());
+    const auto device_count = c10::cuda::device_count_ensure_non_zero();
+    at::Device dev = at::Device(
+        at::kCUDA, static_cast<c10::DeviceIndex>(getRank() % device_count));
     if (!opts.device_ids.empty()) {
       dev = at::Device(
           at::kCUDA, static_cast<c10::DeviceIndex>(opts.device_ids[0]));
@@ -504,13 +563,14 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::barrier(
     }
     ensureInitialized(dev);
   }
+  ++sequence_number_;
   return barrierImpl(/*async_op=*/false, operationTimeout(opts.timeout));
 }
 
 c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::send(
     std::vector<at::Tensor>& tensors,
     int dstRank,
-    int /*tag*/) {
+    [[maybe_unused]] int tag) {
   TORCH_CHECK(tensors.size() == 1, "Only single tensor supported");
   ensureInitialized(tensors.at(0).device());
   if (coalescing_batch_.has_value()) {
@@ -526,7 +586,7 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::send(
 c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::recv(
     std::vector<at::Tensor>& tensors,
     int srcRank,
-    int /*tag*/) {
+    [[maybe_unused]] int tag) {
   TORCH_CHECK(tensors.size() == 1, "Only single tensor supported");
   ensureInitialized(tensors.at(0).device());
   if (coalescing_batch_.has_value()) {
@@ -543,6 +603,7 @@ void ProcessGroupNCCL::startCoalescing() {
   TORCH_CHECK(
       !coalescing_batch_.has_value(),
       "startCoalescing called while a batch is already active");
+  coalesced_work_.reset();
   coalescing_batch_.emplace();
 }
 
@@ -553,6 +614,11 @@ c10::intrusive_ptr<::c10d::Work> ProcessGroupNCCL::endCoalescing() {
   auto batch = std::move(*coalescing_batch_);
   coalescing_batch_.reset();
   if (batch.ops.empty()) {
+    if (coalesced_work_) {
+      auto work = std::move(coalesced_work_);
+      coalesced_work_.reset();
+      return work;
+    }
     return c10::make_intrusive<CompletedWork>();
   }
   return batch_op_issue(batch.ops, /*async_op=*/true, options_c10d_->timeout);

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLUtils.cpp
@@ -53,8 +53,19 @@ ncclDataType_t getNcclDataTypeInternal(const at::Tensor& tensor) {
       return ncclInt64;
     case at::ScalarType::Char:
       return ncclInt8;
+#if HAVE_FP8
+    case at::ScalarType::Float8_e5m2:
+      return ncclFloat8e5m2;
+    case at::ScalarType::Float8_e4m3fn:
+      return ncclFloat8e4m3;
+#else
+    case at::ScalarType::Float8_e5m2:
+    case at::ScalarType::Float8_e4m3fn:
+#endif
     case at::ScalarType::Byte:
     case at::ScalarType::Bool:
+    case at::ScalarType::Float8_e4m3fnuz:
+    case at::ScalarType::Float8_e5m2fnuz:
       return ncclUint8;
     default:
       throw std::runtime_error("Unsupported tensor data type for NCCL");
@@ -479,8 +490,8 @@ cudaStream_t ProcessGroupNCCL::getOperationStream(bool async_op) {
 }
 
 void ProcessGroupNCCL::ensureTensorContiguous(const at::Tensor& tensor) {
-  if (!tensor.is_contiguous()) {
-    throw std::runtime_error("Tensor must be contiguous for NCCL operations");
+  if (!tensor.is_contiguous(tensor.suggest_memory_format())) {
+    C10_THROW_ERROR(ValueError, "Tensors must be contiguous");
   }
 }
 

--- a/torch/csrc/distributed/c10d/nccl2/WorkNCCL.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/WorkNCCL.cpp
@@ -8,6 +8,7 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/core/DeviceGuard.h>
 
+#include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
 #include <torch/csrc/distributed/c10d/nccl2/Logging.hpp>
 #include <torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp>
 #include <torch/csrc/distributed/c10d/nccl2/TracingGuard.hpp>
@@ -174,12 +175,16 @@ bool WorkNCCL::wait(std::chrono::milliseconds /*timeout*/) {
   // Unlike c10d's default wait(), this does not block the CPU: for CUDA work it
   // is sufficient (and matches upstream torchcomms) to order the current stream
   // after the collective. The timeout arg is honored by the watchdog, not here.
-  synchronizeInternal();
+  synchronize();
   return true;
 }
 
 void WorkNCCL::synchronize() {
   synchronizeInternal();
+  if (c10d::allow_inflight_collective_as_graph_input()) {
+    c10d::unregister_work(
+        c10::intrusive_ptr<WorkNCCL>::unsafe_reclaim_from_nonowning(this));
+  }
 }
 
 std::vector<at::Tensor> WorkNCCL::result() {
@@ -203,7 +208,7 @@ c10::intrusive_ptr<c10::ivalue::Future> WorkNCCL::getFuture() {
 
   // Order the current stream after the collective before completing the future
   // so consumers observing the future see correct results.
-  synchronizeInternal();
+  synchronize();
 
   if (!outputs_.empty() && !devices.empty()) {
     c10::OptionalDeviceGuard guard(outputs_[0].device());

--- a/torch/csrc/distributed/c10d/nccl2/WorkNCCL.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/WorkNCCL.hpp
@@ -81,6 +81,9 @@ class WorkNCCL : public c10d::Work {
   void setOutputs(std::vector<at::Tensor> outputs) {
     outputs_ = std::move(outputs);
   }
+  void setChildren(std::vector<c10::intrusive_ptr<WorkNCCL>> children) {
+    children_ = std::move(children);
+  }
 
  protected:
   void recordStart(std::string_view coll_name);
@@ -104,6 +107,7 @@ class WorkNCCL : public c10d::Work {
   std::vector<at::Tensor> inputTensors_;
   at::Tensor inputTensor_;
   std::vector<at::Tensor> outputs_;
+  std::vector<c10::intrusive_ptr<WorkNCCL>> children_;
 
   ProcessGroupNCCL* comm_; // non-owning; see class comment
   std::unique_ptr<at::cuda::CUDAEvent> start_event_;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #190133
* __->__ #190138
* #190084
* #189363
* #189362
* #189361

NCCL2's c10d adapter only handled singleton coalesced operations, did not track collective sequence numbers, and left graph-input work registered after wait. Tensorless barriers initialized from the ambient CUDA device, bootstrap store keys came from a process-global counter that could diverge when ranks initialized groups in different orders, complex tensors were forwarded to NCCL without the real-valued view used by ProcessGroupNCCL, and several list and single-tensor collectives allowed mismatched dtypes to reach NCCL.

Implement multi-tensor coalesced collectives, sequence tracking, work-registry cleanup, FP8 type mapping, standard tensor validation, complex broadcast and supported reductions through view_as_real, and rank-based barrier device selection. Always dispatch sequence-number queries to the backend, use per-process-group bootstrap generations, and guard communicator creation with the bootstrap device.

Test Plan:

```bash
BUILD_TEST=0 USE_FBGEMM=0 USE_NNPACK=0 USE_QNNPACK=0 USE_XNNPACK=0 USE_FLASH_ATTENTION=0 USE_MEM_EFF_ATTENTION=0 USE_DISTRIBUTED=1 USE_CUDA=1 MAX_JOBS=144 .venv/bin/pip install -e . -v --no-build-isolation
```

```bash
NCCL_DEBUG=WARN NCCL_SOCKET_IFNAME=eth0 .venv/bin/python test/distributed/test_c10d_collectives.py
NCCL_DEBUG=WARN NCCL_SOCKET_IFNAME=eth0 .venv/bin/python test/distributed/test_c10d_cuda_graphs.py
NCCL_DEBUG=WARN NCCL_SOCKET_IFNAME=eth0 .venv/bin/python test/distributed/test_c10d_p2p.py
NCCL_DEBUG=WARN NCCL_SOCKET_IFNAME=eth0 .venv/bin/python test/distributed/test_c10d_process_group.py
NCCL_DEBUG=WARN NCCL_SOCKET_IFNAME=eth0 .venv/bin/python test/distributed/test_c10d_nccl2.py
```

```bash
spin fixlint
spin quicklint
```

This change was authored with assistance from an AI coding assistant.
