### PR TITLE
[CUDA] Use 64-bit sample offsets in NLLLoss2d backward

### DIFF
--- a/aten/src/ATen/native/cuda/NLLLoss2d.cu
+++ b/aten/src/ATen/native/cuda/NLLLoss2d.cu
@@ -165,7 +165,7 @@ __global__ void nll_loss2d_backward_no_reduce_kernel(
   }
 }
 
-template <typename scalar_t>
+template <typename scalar_t, typename index_t>
 C10_LAUNCH_BOUNDS_1(CUDA_NUM_THREADS)
 __global__ void nll_loss2d_backward_kernel(
   scalar_t* grad_input,
@@ -174,24 +174,27 @@ __global__ void nll_loss2d_backward_kernel(
   const scalar_t* weights,
   const scalar_t* total_weight,
   bool size_average,
-  int n_classes,
-  int map_nelem,
+  index_t n_classes,
+  index_t map_nelem,
   int blocks_per_sample,
   int64_t ignore_index
 ) {
   const auto grad = -(size_average ? *grad_output / *total_weight
                                    : *grad_output);
 
-  const int sample = blockIdx.x / blocks_per_sample;
-  const int step = blockDim.x * blocks_per_sample;
+  const index_t sample = blockIdx.x / blocks_per_sample;
+  const index_t step =
+      static_cast<index_t>(blockDim.x) * blocks_per_sample;
 
-  const int toffset = sample * map_nelem;
+  const index_t toffset = sample * map_nelem;
   const auto* const target_thread = target + toffset;
 
-  const int ioffset = sample * map_nelem * n_classes;
+  const index_t ioffset = sample * map_nelem * n_classes;
   auto* const grad_input_thread = grad_input + ioffset;
 
-  for (int i = (blockIdx.x % blocks_per_sample) * blockDim.x + threadIdx.x;
+  for (index_t i =
+           static_cast<index_t>(blockIdx.x % blocks_per_sample) * blockDim.x +
+           threadIdx.x;
        i < map_nelem;
        i += step) {
     const int64_t t = target_thread[i];
@@ -449,22 +452,29 @@ void nll_loss2d_backward_out_cuda_template(
         input.scalar_type(),
         "nll_loss2d_backward_kernel",
         [&] {
-          nll_loss2d_backward_kernel<scalar_t>
-              <<<total_blocks,
-                CUDA_NUM_THREADS,
-                0,
-                at::cuda::getCurrentCUDAStream()>>>(
-                  grad_input.mutable_data_ptr<scalar_t>(),
-                  grad_output.const_data_ptr<scalar_t>(),
-                  target_.const_data_ptr<int64_t>(),
-                  optional_data<scalar_t>(weight_),
-                  total_weight.const_data_ptr<scalar_t>(),
-                  reduction == at::Reduction::Mean,
-                  input.size(1),
-                  map_nelem,
-                  blocks_per_sample,
-                  ignore_index);
-          C10_CUDA_KERNEL_LAUNCH_CHECK();
+          AT_DISPATCH_INDEX_TYPES(
+              at::native::canUse32BitIndexMath(input, INT_MAX)
+                  ? ScalarType::Int
+                  : ScalarType::Long,
+              "nll_loss2d_backward_launcher",
+              [&] {
+                nll_loss2d_backward_kernel<scalar_t, index_t>
+                    <<<total_blocks,
+                      CUDA_NUM_THREADS,
+                      0,
+                      at::cuda::getCurrentCUDAStream()>>>(
+                        grad_input.mutable_data_ptr<scalar_t>(),
+                        grad_output.const_data_ptr<scalar_t>(),
+                        target_.const_data_ptr<int64_t>(),
+                        optional_data<scalar_t>(weight_),
+                        total_weight.const_data_ptr<scalar_t>(),
+                        reduction == at::Reduction::Mean,
+                        input.size(1),
+                        map_nelem,
+                        blocks_per_sample,
+                        ignore_index);
+                C10_CUDA_KERNEL_LAUNCH_CHECK();
+              });
         });
   }
 }

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -12418,6 +12418,43 @@ class TestNNDeviceType(NNTestCase):
         print(logits.numel(), labels.numel(), loss.numel())
         self.assertTrue(torch.allclose(loss_cpu, loss.cpu(), rtol=1e-4, atol=1e-4))
 
+    # Ref: https://github.com/pytorch/pytorch/issues/190139
+    @onlyCUDA
+    @largeTensorTest("5GB", "cuda")
+    def test_nll_loss2d_backward_large_sample_offset(self, device):
+        batch_size = 2**16 + 1
+        num_classes = 2**15
+        ignore_index = -100
+
+        # Reduced backward only uses input metadata. Expanding a scalar avoids
+        # materializing another four-GiB tensor.
+        input = torch.empty(
+            (),
+            device=device,
+            dtype=torch.float16,
+        ).expand(batch_size, num_classes, 1, 1)
+        target = torch.full(
+            (batch_size, 1, 1),
+            ignore_index,
+            dtype=torch.int64,
+            device=device,
+        )
+        target[-1] = 0
+        one = torch.ones((), dtype=torch.float16, device=device)
+
+        grad_input = torch.ops.aten.nll_loss2d_backward.default(
+            one,
+            input,
+            target,
+            None,
+            F._Reduction.get_enum("sum"),
+            ignore_index,
+            one,
+        )
+
+        torch.cuda.synchronize()
+        self.assertEqual(grad_input[-1, 0, 0, 0], -1)
+
     def _nll_loss_helper(self, input_size, reduction, expected, device, dtype):
         input = torch.rand(input_size, requires_grad=True, device=device, dtype=dtype)
         num_channels = input_size[1]


### PR DESCRIPTION
Fixes #190139

## Summary

- select 32-bit or 64-bit indexing for reduced CUDA NLLLoss2d backward
- use the selected index type for sample, target, and gradient offsets
- add a gated large-tensor regression test at the `2**31` element boundary

## Context

Reduced NLLLoss2d backward computed each sample's gradient offset in signed
32-bit arithmetic. Valid tensors with more than `INT_MAX` elements could wrap
the pointer and cause an illegal GPU memory access. The forward kernel already
selects its index type with `canUse32BitIndexMath`; this change applies the same
strategy to reduced backward.

The regression test uses an expanded scalar for the input because backward only
needs its metadata. The contiguous gradient remains just over 4 GiB and exercises
the real failing address while keeping the test's memory requirement near 5 GiB.

For transformer logits, `F.cross_entropy(logits.transpose(1, 2), labels)`
reaches this implementation.

## Testing

- `git diff --check`
- `lintrunner test/test_nn.py --take FLAKE8`
- `python -m py_compile test/test_nn.py`
- small CPU execution of the direct `aten.nll_loss2d_backward` test pattern
- unpatched CUDA reproduction on an A100-SXM4-80GB, which reported an illegal
  memory access

A CUDA source build was not available locally. The new gated CUDA regression test
is included for CI verification.

*This pull request was prepared with AI assistance and reviewed by the author.*
