### PR TITLE
[inductor] Select CPU cpp wrapper from current allow_stack_allocation, not frozen registration

### DIFF
--- a/test/inductor/test_aot_inductor_arrayref.py
+++ b/test/inductor/test_aot_inductor_arrayref.py
@@ -359,6 +359,37 @@ if IS_FBCODE:
         CPU_TEST_FAILURES,
     )
 
+
+class TestCppWrapperCpuSelection(TestCase):
+    def test_cpu_cpp_wrapper_follows_current_stack_allocation_config(self):
+        # Regression test: the CPU cpp wrapper class (CppWrapperCpu vs
+        # CppWrapperCpuArrayRef) must track the current allow_stack_allocation
+        # config at each compile. It used to be frozen at the process's first
+        # backend registration, so whichever config was active for the first
+        # compile decided the wrapper for the whole process -- making tests that
+        # toggle the config order-dependent and flaky.
+        from torch._inductor.codegen.common import (
+            get_wrapper_codegen_for_device,
+            init_backend_registration,
+        )
+        from torch._inductor.codegen.cpp_wrapper_cpu import CppWrapperCpu
+        from torch._inductor.codegen.cpp_wrapper_cpu_array_ref import (
+            CppWrapperCpuArrayRef,
+        )
+
+        init_backend_registration()
+        with config.patch({"aot_inductor.allow_stack_allocation": True}):
+            self.assertIs(
+                get_wrapper_codegen_for_device("cpu", cpp_wrapper=True),
+                CppWrapperCpuArrayRef,
+            )
+        with config.patch({"aot_inductor.allow_stack_allocation": False}):
+            self.assertIs(
+                get_wrapper_codegen_for_device("cpu", cpp_wrapper=True),
+                CppWrapperCpu,
+            )
+
+
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests
 

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -488,7 +488,17 @@ def get_wrapper_codegen_for_device(
         if fx_wrapper:
             return wrapper_codegen_obj.fx_wrapper_codegen
         elif cpp_wrapper:
-            return wrapper_codegen_obj.cpp_wrapper_codegen
+            cpp_wrapper_codegen = wrapper_codegen_obj.cpp_wrapper_codegen
+            # allow_stack_allocation is a per-compile config, so the arrayref CPU
+            # wrapper must follow the current config value rather than whatever it
+            # happened to be at first registration (see init_backend_registration).
+            if device == "cpu" and config.aot_inductor.allow_stack_allocation:
+                from .cpp_wrapper_cpu import CppWrapperCpu
+                from .cpp_wrapper_cpu_array_ref import CppWrapperCpuArrayRef
+
+                if cpp_wrapper_codegen is CppWrapperCpu:
+                    return CppWrapperCpuArrayRef
+            return cpp_wrapper_codegen
         else:
             return wrapper_codegen_obj.wrapper_codegen
     return None
@@ -510,7 +520,6 @@ def init_backend_registration() -> None:
     """
     from .cpp import CppScheduling
     from .cpp_wrapper_cpu import CppWrapperCpu
-    from .cpp_wrapper_cpu_array_ref import CppWrapperCpuArrayRef
     from .cpp_wrapper_gpu import CppWrapperGpu
     from .cpp_wrapper_mps import CppWrapperMps
     from .cuda_combined_scheduling import CUDACombinedScheduling
@@ -534,9 +543,11 @@ def init_backend_registration() -> None:
             "cpu",
             lambda scheduling: cpu_backends[config.cpu_backend](scheduling),
             PythonWrapperCodegen,
-            CppWrapperCpuArrayRef
-            if config.aot_inductor.allow_stack_allocation
-            else CppWrapperCpu,
+            # allow_stack_allocation selects CppWrapperCpuArrayRef, but that is a
+            # per-compile config; the choice is made dynamically in
+            # get_wrapper_codegen_for_device rather than frozen here at the
+            # process's first registration.
+            CppWrapperCpu,
             WrapperFxCodegen,
         )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #190160
* __->__ #190151

The CPU C++ wrapper class (CppWrapperCpu vs CppWrapperCpuArrayRef) was chosen
from config.aot_inductor.allow_stack_allocation exactly once per process, at the
first init_backend_registration() call, and cached in device_codegens["cpu"].
init_backend_registration is @functools.cache'd and additionally guarded by
`if get_scheduling_for_device("cpu") is None`, and nothing ever resets it, so
every later compile reused whichever wrapper the first CPU compile happened to
register. Per-test config.patch({"aot_inductor.allow_stack_allocation": ...})
therefore had no effect on wrapper selection, and which wrapper a test got
depended on test ordering within the shard process.

This made AOTInductor tests order-dependent and flaky:
- test_assert_size_stride_guarded_by_env_check does not patch the config and
  expects the plain wrapper's env-guarded assert_size_stride. It failed whenever
  an earlier stack-allocation compile had frozen the arrayref wrapper, which
  omits the assert (and includes array_ref.h instead of cpu.h).
- test_while_loop_with_mixed_device_dynamic_{True,False} and
  test_while_loop_with_pytree_inputs are marked expectedFailure under stack
  allocation. They reported unexpected success (a CI failure) whenever the plain
  wrapper had frozen first and compiled the loop fine.
Isolated reruns passed because the rerun's own compile is first and freezes the
matching wrapper.

The fix registers CppWrapperCpu unconditionally for CPU and moves the arrayref
choice into get_wrapper_codegen_for_device, which now returns
CppWrapperCpuArrayRef when config.aot_inductor.allow_stack_allocation is set at
call time. get_wrapper_codegen_for_device is the single reader of the registered
cpp wrapper slot, so routing the decision through it keeps the compile path
(graph.py) and the caching-support probe (compile_fx.py) consistent with the
current config; both previously read the same frozen slot, so they agreed but
could disagree with the config. The header-path helper (_get_cpp_wrapper_header)
and the FX wrapper already read the config dynamically and are unchanged.

A test-level fix (forcing a config in the test body) was considered and rejected:
the wrapper is already frozen by the time the test runs, so config.patch there is
ignored. Honoring the current config in the selection is the smallest change that
makes per-test config behave as intended and removes the order dependence.

Test Plan:

New regression test (fails before the fix, passes after):

```
python test/inductor/test_aot_inductor_arrayref.py \
  TestCppWrapperCpuSelection.test_cpu_cpp_wrapper_follows_current_stack_allocation_config
```

Previously-flaky tests, now deterministic:

```
python -m pytest "test/inductor/test_aot_inductor_arrayref.py::AOTInductorTestABICompatibleCpuWithStackAllocation" \
  -k "test_while_loop_with_mixed_device or test_while_loop_with_pytree_inputs" -q
# -> 3 xfailed
```

Regression sample across op categories (no new failures):

```
python -m pytest "test/inductor/test_aot_inductor_arrayref.py::AOTInductorTestABICompatibleCpuWithStackAllocation" \
  -k "test_simple or test_addmm or test_reuse or test_zero or test_conv or test_linear or test_view or test_return or test_cat or test_repeat_interleave or test_amp" -q
# -> passed/skipped, no failures
```

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo