### PR TITLE
[Testcase Refactoring] Decouple test_multi_threaded_pg from GPU-specific skip

### DIFF
--- a/test/distributed/test_multi_threaded_pg.py
+++ b/test/distributed/test_multi_threaded_pg.py
@@ -19,7 +19,7 @@ if not dist.is_available():
 
 from torch.testing._internal.common_distributed import (
     MultiThreadedTestCase,
-    skip_if_lt_x_gpu,
+    skip_if_lt_x_devices,
     spawn_threads_and_init_comms,
 )
 from torch.testing._internal.common_utils import IS_SANDCASTLE, run_tests, TestCase
@@ -301,7 +301,7 @@ class TestCollectivesWithBaseClass(MultiThreadedTestCase):
         self.assertEqual(t0, torch.ones(3, 3) * res_num)
         self.assertEqual(t1, torch.ones(3, 3) * (res_num * 2))
 
-    @skip_if_lt_x_gpu(1)
+    @skip_if_lt_x_devices(1)
     def test_bwd_sees_fwd_pg(self):
         fwd_tid = threading.current_thread().ident
 

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -334,6 +334,38 @@ def skip_if_lt_x_gpu(x, *, allow_cpu=False):
 
     return decorator
 
+def skip_if_lt_x_devices(x, *, allow_cpu=False):
+    """Skip if fewer than x devices available for the current accelerator.
+
+    Unlike @skip_if_lt_x_gpu, this does not hard-code cuda/hpu/xpu.
+    It uses torch.accelerator.current_accelerator() to determine the device type.
+    """
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            acc = torch.accelerator.current_accelerator()
+            if acc is not None:
+                device_type = acc.type
+                device_module = torch.get_device_module(device_type)
+                if device_module.is_available() and device_module.device_count() >= x:
+                    return func(*args, **kwargs)
+
+            # CPU path: allow running a degenerate version if explicitly requested
+            if allow_cpu and acc is None:
+                return func(*args, **kwargs)
+
+            # NOTE: TEST_SKIPS uses "multi-gpu-{x}" naming for historical/
+            # backward-compatibility reasons only. The skip logic itself is
+            # hardware-agnostic and does not assume CUDA/GPU.
+            test_skip = TEST_SKIPS[f"multi-gpu-{x}"]
+            # NOTE: _maybe_handle_skip_if_lt_x_gpu retains "gpu" in its name
+            # for backward compatibility; it is hardware-agnostic.
+            if not _maybe_handle_skip_if_lt_x_gpu(args, test_skip.message):
+                sys.exit(test_skip.exit_code)
+        return wrapper
+
+    return decorator
 
 def requires_world_size(n: int):
     """


### PR DESCRIPTION
## Summary

This PR migrates `test/distributed/test_multi_threaded_pg.py` from the CUDA-specific `@skip_if_lt_x_gpu(1)` decorator to the generic `@skip_if_lt_x_devices(1)` decorator, making the test compatible with `PrivateUse1`-based out-of-tree backends (e.g., NPU/Ascend).

## Changes

- **`test/distributed/test_multi_threaded_pg.py`**: Replaced `@skip_if_lt_x_gpu(1)` with `@skip_if_lt_x_devices(1)` and updated the corresponding import.

## Motivation

`@skip_if_lt_x_gpu` only recognizes CUDA, HPU, and XPU. New accelerators (e.g., `PrivateUse1`-based out-of-tree backends) are silently skipped even when enough devices are available. A generic decorator allows distributed tests to adapt to any accelerator supported by `torch.accelerator`.

## Test Plan

- Verified on accelerator: all 22 tests pass, and `test_bwd_sees_fwd_pg` is no longer incorrectly skipped.
- `@skip_if_lt_x_devices(1)` correctly skips on machines with fewer than 1 accelerator device.

## Notes

- The skip_if_lt_x_devices implementation comes from https://github.com/pytorch/pytorch/pull/187650. When that PR merges, this branch should rebase to remove the duplicate implementation.
- This is part of the test case refactoring initiative tracked in https://github.com/pytorch/pytorch/issues/185590.
- Additional distributed tests will be migrated in follow-up PRs.