### PR TITLE
[Testcase Refactoring] Update requires_accelerator_dist_backend to resolve/enable privateuse1 & enable PrivateUse1 tests in test_stage 

### DIFF
--- a/test/distributed/pipelining/test_stage.py
+++ b/test/distributed/pipelining/test_stage.py
@@ -141,9 +141,9 @@ class StageTest(MultiProcContinuousTest):
     def device(self) -> torch.device:
         return torch.device(device_type, self.rank)
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ accelerators"
     )
     @parametrize("ModelClass", [ExampleCode, MultiMLP])
     def test_tracer(self, ModelClass):
@@ -190,9 +190,9 @@ class StageTest(MultiProcContinuousTest):
                 f"Some keys not found in old_keys: {[k for k in submod_keys if k not in old_keys]}"
             )
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ accelerators"
     )
     @parametrize("ModelClass", [ModelWithKwargs])
     def test_tracer_kwargs(self, ModelClass):
@@ -244,9 +244,9 @@ class StageTest(MultiProcContinuousTest):
                 f"Some keys not found in old_keys: {[k for k in submod_keys if k not in old_keys]}"
             )
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ accelerators"
     )
     def test_manual(self):
         full_mod = MultiMLP(d_hid, n_layers=self.world_size)
@@ -278,9 +278,9 @@ class StageTest(MultiProcContinuousTest):
             ref_out = full_mod(x)
             torch.testing.assert_close(out, ref_out)
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ accelerators"
     )
     def test_custom_dw_with_fb_schedule(self):
         """Tests that separate weight grad function 'dw_runner' gets run under a schedule that's only aware of F/B."""
@@ -340,9 +340,9 @@ class StageTest(MultiProcContinuousTest):
             ref_out = full_mod(x)
             torch.testing.assert_close(out, ref_out)
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ accelerators"
     )
     def test_output_chunks_memory_usage(self):
         """Test that output_chunks doesn't store memory for non-first stages."""
@@ -417,9 +417,9 @@ class StageNegativeTest(MultiProcContinuousTest):
     def device(self) -> torch.device:
         return torch.device(device_type, self.rank)
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ accelerators"
     )
     def test_shape_prop_mismatch(self):
         """Tests shape prop errors are raised"""
@@ -466,9 +466,9 @@ class StageNegativeTest(MultiProcContinuousTest):
             with self.assertRaisesRegex(PipeliningMetadataError, "dtype mismatch"):
                 _run_step(x)
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ accelerators"
     )
     def test_custom_dw_errors(self):
         """Tests expected errors are raised"""

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -50,6 +50,8 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_ROCM,
     TEST_WITH_TSAN,
     TEST_XPU,
+    TEST_PRIVATEUSE1,
+    TEST_PRIVATEUSE1_DEVICE_TYPE,
     TestCase,
 )
 from torch.testing._internal.distributed.multi_threaded_pg import (
@@ -549,22 +551,28 @@ def requires_accelerator_dist_backend(backends=None):
     Decorator to skip tests if no accelerator communication backend (NCCL, XCCL, HCCL) is available.
 
     Args:
-        backends (Optional[List[str]]): Specific accelerator backends to check (e.g., ["nccl", "xccl", "hccl"]).
+        backends (Optional[List[str]]): Specific accelerator backends to check (e.g., ["nccl", "xccl", "hccl", "privateuse1"]).
                                        If None, checks all supported accelerator backends (NCCL, XCCL, HCCL).
 
     Returns:
         callable: A decorator that skips the test if no specified accelerator backend is available.
+
+    Note:
+        "privateuse1" is a placeholder resolved to the actual backend name for PrivateUse1 at call time via ``Backend.default_device_backend_map``.
     """
     if backends is None:
         backends = ACCELERATOR_DIST_BACKENDS
+    
+    _resolve = lambda backend: (
+        c10d.Backend.default_device_backend_map.get(TEST_PRIVATEUSE1_DEVICE_TYPE)
+        if backend == "privateuse1" and TEST_PRIVATEUSE1
+        else (None if backend == "privateuse1" else backend)
+    )
 
     backend_available = any(
-        {
-            "nccl": c10d.is_nccl_available,
-            "xccl": c10d.is_xccl_available,
-            "hccl": lambda: TEST_HPU,
-        }.get(backend, lambda: False)()
-        for backend in backends
+        c10d.is_backend_available(backend)
+        for backend in (_resolve(b) for b in backends)
+        if backend is not None
     )
 
     return skip_but_pass_in_sandcastle_if(


### PR DESCRIPTION
## Summary
This PR updates `requires_accelerator_dist_backend` in `common_distributed.py` to dynamically resolve `"privateuse1"` to the actual backend name at call time, and enables the `StageTest`/`StageNegativeTest` tests in `test_stage.py` to run on out-of-tree PrivateUse1 accelerators.

This is a step toward making pipelining distributed tests device-agnostic for PrivateUse1 backends.

## Changes
- **`common_distributed.py`** (Commit 1): Updated `requires_accelerator_dist_backend` to resolve `"privateuse1"` to the actual backend name via `Backend.default_device_backend_map` at call time, then check availability with `c10d.is_backend_available`. Added `TEST_PRIVATEUSE1` and `TEST_PRIVATEUSE1_DEVICE_TYPE` imports. On HPU, `TEST_PRIVATEUSE1` is `False`, so `"privateuse1"` is filtered out and HPU behavior is unchanged.
- **`test_stage.py`** (Commit 2): Changed `@requires_accelerator_dist_backend(["nccl", "xccl"])` to `@requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])` on the 7 `StageTest`/`StageNegativeTest` tests, and updated the skip message "2+ GPUs" -> "2+ accelerators".

## Motivation
`requires_accelerator_dist_backend(["nccl", "xccl"])` excluded PrivateUse1, so the 7 tests were skipped on PrivateUse1 accelerators even when the backend was available. Adding `"privateuse1"` (resolved dynamically to the actual backend name) lets the tests run on PrivateUse1 (and still run on CUDA via nccl, still skip on CPU with no accelerator backend). HPU is unaffected — `"privateuse1"` is not resolved on HPU (`TEST_PRIVATEUSE1` is `False`).

## Notes
- Commit 1 (`common_distributed.py` framework change) is standalone and can be cherry-picked by other PRs that depend on `requires_accelerator_dist_backend`. After it merges, those PRs rebase onto main and can merge directly.
- This is part of the test case refactoring initiative tracked in #185590.
