### PR TITLE
[Testcase Refactoring][Test] Use current_accelerator for device-agnostic map_location test

### DIFF
--- a/test/distributed/checkpoint/_experimental/test_checkpoint_reader.py
+++ b/test/distributed/checkpoint/_experimental/test_checkpoint_reader.py
@@ -65,19 +65,6 @@ class _CheckpointReaderTestBase(TestCase):
         # Clean up the temporary directory
         shutil.rmtree(self.temp_dir)
 
-    def move_tensors_to_device(self, state_dict: Any, device: str) -> Any:
-        if isinstance(state_dict, dict):
-            return {
-                key: self.move_tensors_to_device(value, device)
-                for key, value in state_dict.items()
-            }
-        elif isinstance(state_dict, list):
-            return [self.move_tensors_to_device(item, device) for item in state_dict]
-        elif isinstance(state_dict, torch.Tensor):
-            return state_dict.to(device)
-        else:
-            return state_dict
-
 
 class TestCheckpointReader(_CheckpointReaderTestBase):
     hw_classification = HardwareClassification.GENERIC
@@ -233,7 +220,6 @@ class TestCheckpointReaderDevice(_CheckpointReaderTestBase):
         read_state_dict, _ = self.reader.read(
             self.checkpoint_path, map_location=map_location
         )
-        read_state_dict = self.move_tensors_to_device(read_state_dict, map_location)
         self.assertIn("model", read_state_dict)
         self.assertIn("optimizer", read_state_dict)
         self.assertEqual(read_state_dict["epoch"], 5)

--- a/test/distributed/checkpoint/_experimental/test_checkpoint_reader.py
+++ b/test/distributed/checkpoint/_experimental/test_checkpoint_reader.py
@@ -9,10 +9,17 @@ from torch.distributed.checkpoint._experimental.checkpoint_reader import (
     CheckpointReader,
 )
 from torch.distributed.checkpoint._experimental.types import RankInfo
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 class TestCheckpointReader(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         # Create a temporary directory for test checkpoints
@@ -55,13 +62,14 @@ class TestCheckpointReader(TestCase):
 
     def move_tensors_to_device(self, state_dict: Any, device: str) -> Any:
         """
-        Recursively move all tensors in a nested dictionary to CUDA.
+        Recursively move all tensors in a nested dictionary to the target device.
 
         Args:
             state_dict (dict): A dictionary potentially containing nested dictionaries and tensors.
+            device (str): The target device string.
 
         Returns:
-            dict: A new dictionary with all tensors moved to CUDA.
+            dict: A new dictionary with all tensors moved to the target device.
         """
         if isinstance(state_dict, dict):
             return {
@@ -71,7 +79,7 @@ class TestCheckpointReader(TestCase):
         elif isinstance(state_dict, list):
             return [self.move_tensors_to_device(item, device) for item in state_dict]
         elif isinstance(state_dict, torch.Tensor):
-            return state_dict.cuda() if device == "cpu" else state_dict.cpu()
+            return state_dict.to(device) if device == "cpu" else state_dict.cpu()
         else:
             return state_dict
 
@@ -108,31 +116,6 @@ class TestCheckpointReader(TestCase):
         self.assertTrue(self.deep_compare(read_state_dict, self.state_dict))
 
         # No hooks to verify since we removed them
-
-    def test_read_with_map_location(self):
-        """Test that read correctly uses the map_location parameter."""
-        # Call read with map_location='cpu'
-        map_location = "cuda" if torch.cuda.is_available() else "cpu"
-        read_state_dict, _ = self.reader.read(
-            self.checkpoint_path, map_location=map_location
-        )
-
-        # Verify that the read state dictionary contains the expected values
-        self.assertIn("model", read_state_dict)
-        self.assertIn("optimizer", read_state_dict)
-        self.assertEqual(read_state_dict["epoch"], 5)
-        self.assertEqual(read_state_dict["step"], 1000)
-        self.assertEqual(read_state_dict["model"]["weight"].device.type, map_location)
-        read_state_dict, _ = self.reader.read(
-            self.checkpoint_path, map_location=map_location
-        )
-
-        # Verify that the read state dictionary contains the expected values
-        self.assertIn("model", read_state_dict)
-        self.assertIn("optimizer", read_state_dict)
-        self.assertEqual(read_state_dict["epoch"], 5)
-        self.assertEqual(read_state_dict["step"], 1000)
-        self.assertEqual(read_state_dict["model"]["weight"].device.type, map_location)
 
     def test_read_nonexistent_checkpoint(self):
         """Test that read raises FileNotFoundError for a nonexistent checkpoint."""
@@ -246,6 +229,57 @@ class TestCheckpointReader(TestCase):
                 torch.allclose(updated_state_dict[key], dtype_state_dict[key])
             )
 
+
+class TestCheckpointReaderDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def setUp(self):
+        super().setUp()
+        self.temp_dir = tempfile.mkdtemp()
+        self.rank_info = RankInfo(global_rank=0, global_world_size=1)
+        self.state_dict = {
+            "model": {
+                "weight": torch.randn(10, 5),
+                "bias": torch.randn(5),
+            },
+            "epoch": 5,
+            "step": 1000,
+        }
+        self.checkpoint_path = os.path.join(self.temp_dir, "checkpoint")
+        os.makedirs(self.checkpoint_path, exist_ok=True)
+        checkpoint_file = os.path.join(
+            self.checkpoint_path, f"checkpoint_{self.rank_info.global_rank}.pt"
+        )
+        torch.save(self.state_dict, checkpoint_file)
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+
+    def test_read_with_map_location(self, device):
+        reader = CheckpointReader(rank_info=self.rank_info)
+        map_location = device if device != "cpu" else "cpu"
+        read_state_dict, _ = reader.read(
+            self.checkpoint_path, map_location=map_location
+        )
+        self.assertIn("model", read_state_dict)
+        self.assertEqual(read_state_dict["epoch"], 5)
+        self.assertEqual(read_state_dict["step"], 1000)
+        self.assertEqual(read_state_dict["model"]["weight"].device.type, map_location)
+
+        read_state_dict, _ = reader.read(
+            self.checkpoint_path, map_location=map_location
+        )
+        self.assertIn("model", read_state_dict)
+        self.assertEqual(read_state_dict["epoch"], 5)
+        self.assertEqual(read_state_dict["step"], 1000)
+        self.assertEqual(read_state_dict["model"]["weight"].device.type, map_location)
+
+
+instantiate_device_type_tests(
+    TestCheckpointReaderDevice,
+    globals(),
+    except_for=("cpu",),
+)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/checkpoint/_experimental/test_checkpoint_reader.py
+++ b/test/distributed/checkpoint/_experimental/test_checkpoint_reader.py
@@ -60,29 +60,6 @@ class TestCheckpointReader(TestCase):
         )
         torch.save(self.state_dict, checkpoint_file)
 
-    def move_tensors_to_device(self, state_dict: Any, device: str) -> Any:
-        """
-        Recursively move all tensors in a nested dictionary to the target device.
-
-        Args:
-            state_dict (dict): A dictionary potentially containing nested dictionaries and tensors.
-            device (str): The target device string.
-
-        Returns:
-            dict: A new dictionary with all tensors moved to the target device.
-        """
-        if isinstance(state_dict, dict):
-            return {
-                key: self.move_tensors_to_device(value, device)
-                for key, value in state_dict.items()
-            }
-        elif isinstance(state_dict, list):
-            return [self.move_tensors_to_device(item, device) for item in state_dict]
-        elif isinstance(state_dict, torch.Tensor):
-            return state_dict.to(device) if device == "cpu" else state_dict.cpu()
-        else:
-            return state_dict
-
     def deep_compare(self, obj1: Any, obj2: Any) -> bool:
         if isinstance(obj1, dict) and isinstance(obj2, dict):
             if obj1.keys() != obj2.keys():
@@ -257,7 +234,7 @@ class TestCheckpointReaderDevice(TestCase):
 
     def test_read_with_map_location(self, device):
         reader = CheckpointReader(rank_info=self.rank_info)
-        map_location = device if device != "cpu" else "cpu"
+        map_location = torch.device(device).type
         read_state_dict, _ = reader.read(
             self.checkpoint_path, map_location=map_location
         )
@@ -278,7 +255,6 @@ class TestCheckpointReaderDevice(TestCase):
 instantiate_device_type_tests(
     TestCheckpointReaderDevice,
     globals(),
-    except_for=("cpu",),
 )
 
 if __name__ == "__main__":

--- a/test/distributed/checkpoint/_experimental/test_checkpoint_reader.py
+++ b/test/distributed/checkpoint/_experimental/test_checkpoint_reader.py
@@ -9,10 +9,15 @@ from torch.distributed.checkpoint._experimental.checkpoint_reader import (
     CheckpointReader,
 )
 from torch.distributed.checkpoint._experimental.types import RankInfo
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 class TestCheckpointReader(TestCase):
+    hw_classification = HardwareClassification.GENERIC
     def setUp(self):
         super().setUp()
         # Create a temporary directory for test checkpoints
@@ -55,13 +60,14 @@ class TestCheckpointReader(TestCase):
 
     def move_tensors_to_device(self, state_dict: Any, device: str) -> Any:
         """
-        Recursively move all tensors in a nested dictionary to CUDA.
+        Recursively move all tensors in a nested dictionary to the target device.
 
         Args:
             state_dict (dict): A dictionary potentially containing nested dictionaries and tensors.
+            device (str): The target device string.
 
         Returns:
-            dict: A new dictionary with all tensors moved to CUDA.
+            dict: A new dictionary with all tensors moved to the target device.
         """
         if isinstance(state_dict, dict):
             return {
@@ -71,7 +77,7 @@ class TestCheckpointReader(TestCase):
         elif isinstance(state_dict, list):
             return [self.move_tensors_to_device(item, device) for item in state_dict]
         elif isinstance(state_dict, torch.Tensor):
-            return state_dict.cuda() if device == "cpu" else state_dict.cpu()
+            return state_dict.to(device) if device == "cpu" else state_dict.cpu()
         else:
             return state_dict
 
@@ -111,8 +117,9 @@ class TestCheckpointReader(TestCase):
 
     def test_read_with_map_location(self):
         """Test that read correctly uses the map_location parameter."""
-        # Call read with map_location='cpu'
-        map_location = "cuda" if torch.cuda.is_available() else "cpu"
+        # Call read with map_location set to available accelerator or cpu
+        device_type = getattr(torch.accelerator.current_accelerator(check_available=True), "type", None)
+        map_location = device_type if device_type is not None else "cpu"
         read_state_dict, _ = self.reader.read(
             self.checkpoint_path, map_location=map_location
         )

--- a/test/distributed/checkpoint/_experimental/test_checkpoint_reader.py
+++ b/test/distributed/checkpoint/_experimental/test_checkpoint_reader.py
@@ -19,7 +19,20 @@ from torch.testing._internal.common_utils import (
 
 class _CheckpointReaderTestBase(TestCase):
     def _get_state_dict(self) -> dict[str, Any]:
-        raise NotImplementedError
+        return {
+            "model": {
+                "weight": torch.randn(10, 5),
+                "bias": torch.randn(5),
+                "test_list": [torch.randn(2), torch.randn(2)],
+            },
+            "optimizer": {
+                "param_groups": [
+                    {"lr": 0.01, "test_list": [torch.randn(2), torch.randn(2)]}
+                ]
+            },
+            "epoch": 5,
+            "step": 1000,
+        }
 
     def setUp(self):
         super().setUp()
@@ -52,25 +65,22 @@ class _CheckpointReaderTestBase(TestCase):
         # Clean up the temporary directory
         shutil.rmtree(self.temp_dir)
 
+    def move_tensors_to_device(self, state_dict: Any, device: str) -> Any:
+        if isinstance(state_dict, dict):
+            return {
+                key: self.move_tensors_to_device(value, device)
+                for key, value in state_dict.items()
+            }
+        elif isinstance(state_dict, list):
+            return [self.move_tensors_to_device(item, device) for item in state_dict]
+        elif isinstance(state_dict, torch.Tensor):
+            return state_dict.to(device)
+        else:
+            return state_dict
+
 
 class TestCheckpointReader(_CheckpointReaderTestBase):
     hw_classification = HardwareClassification.GENERIC
-
-    def _get_state_dict(self) -> dict[str, Any]:
-        return {
-            "model": {
-                "weight": torch.randn(10, 5),
-                "bias": torch.randn(5),
-                "test_list": [torch.randn(2), torch.randn(2)],
-            },
-            "optimizer": {
-                "param_groups": [
-                    {"lr": 0.01, "test_list": [torch.randn(2), torch.randn(2)]}
-                ]
-            },
-            "epoch": 5,
-            "step": 1000,
-        }
 
     def deep_compare(self, obj1: Any, obj2: Any) -> bool:
         if isinstance(obj1, dict) and isinstance(obj2, dict):
@@ -218,22 +228,14 @@ class TestCheckpointReader(_CheckpointReaderTestBase):
 class TestCheckpointReaderDevice(_CheckpointReaderTestBase):
     hw_classification = HardwareClassification.ACCELERATOR
 
-    def _get_state_dict(self) -> dict[str, Any]:
-        return {
-            "model": {
-                "weight": torch.randn(10, 5),
-                "bias": torch.randn(5),
-            },
-            "epoch": 5,
-            "step": 1000,
-        }
-
     def test_read_with_map_location(self, device):
         map_location = torch.device(device).type
         read_state_dict, _ = self.reader.read(
             self.checkpoint_path, map_location=map_location
         )
+        read_state_dict = self.move_tensors_to_device(read_state_dict, map_location)
         self.assertIn("model", read_state_dict)
+        self.assertIn("optimizer", read_state_dict)
         self.assertEqual(read_state_dict["epoch"], 5)
         self.assertEqual(read_state_dict["step"], 1000)
         self.assertEqual(read_state_dict["model"]["weight"].device.type, map_location)

--- a/test/distributed/checkpoint/_experimental/test_checkpoint_reader.py
+++ b/test/distributed/checkpoint/_experimental/test_checkpoint_reader.py
@@ -247,7 +247,6 @@ class TestCheckpointReaderDevice(TestCase):
 instantiate_device_type_tests(
     TestCheckpointReaderDevice,
     globals(),
-    except_for=("cpu",),
 )
 
 if __name__ == "__main__":

--- a/test/distributed/checkpoint/_experimental/test_checkpoint_reader.py
+++ b/test/distributed/checkpoint/_experimental/test_checkpoint_reader.py
@@ -243,18 +243,11 @@ class TestCheckpointReaderDevice(TestCase):
         self.assertEqual(read_state_dict["step"], 1000)
         self.assertEqual(read_state_dict["model"]["weight"].device.type, map_location)
 
-        read_state_dict, _ = reader.read(
-            self.checkpoint_path, map_location=map_location
-        )
-        self.assertIn("model", read_state_dict)
-        self.assertEqual(read_state_dict["epoch"], 5)
-        self.assertEqual(read_state_dict["step"], 1000)
-        self.assertEqual(read_state_dict["model"]["weight"].device.type, map_location)
-
 
 instantiate_device_type_tests(
     TestCheckpointReaderDevice,
     globals(),
+    except_for=("cpu",),
 )
 
 if __name__ == "__main__":

--- a/test/distributed/checkpoint/_experimental/test_checkpoint_reader.py
+++ b/test/distributed/checkpoint/_experimental/test_checkpoint_reader.py
@@ -17,8 +17,9 @@ from torch.testing._internal.common_utils import (
 )
 
 
-class TestCheckpointReader(TestCase):
-    hw_classification = HardwareClassification.GENERIC
+class _CheckpointReaderTestBase(TestCase):
+    def _get_state_dict(self) -> dict[str, Any]:
+        raise NotImplementedError
 
     def setUp(self):
         super().setUp()
@@ -37,7 +38,26 @@ class TestCheckpointReader(TestCase):
         )
 
         # Create a test state dictionary
-        self.state_dict = {
+        self.state_dict = self._get_state_dict()
+
+        # Create a test checkpoint file
+        self.checkpoint_path = os.path.join(self.temp_dir, "checkpoint")
+        os.makedirs(self.checkpoint_path, exist_ok=True)
+        checkpoint_file = os.path.join(
+            self.checkpoint_path, f"checkpoint_{self.rank_info.global_rank}.pt"
+        )
+        torch.save(self.state_dict, checkpoint_file)
+
+    def tearDown(self):
+        # Clean up the temporary directory
+        shutil.rmtree(self.temp_dir)
+
+
+class TestCheckpointReader(_CheckpointReaderTestBase):
+    hw_classification = HardwareClassification.GENERIC
+
+    def _get_state_dict(self) -> dict[str, Any]:
+        return {
             "model": {
                 "weight": torch.randn(10, 5),
                 "bias": torch.randn(5),
@@ -51,14 +71,6 @@ class TestCheckpointReader(TestCase):
             "epoch": 5,
             "step": 1000,
         }
-
-        # Create a test checkpoint file
-        self.checkpoint_path = os.path.join(self.temp_dir, "checkpoint")
-        os.makedirs(self.checkpoint_path, exist_ok=True)
-        checkpoint_file = os.path.join(
-            self.checkpoint_path, f"checkpoint_{self.rank_info.global_rank}.pt"
-        )
-        torch.save(self.state_dict, checkpoint_file)
 
     def deep_compare(self, obj1: Any, obj2: Any) -> bool:
         if isinstance(obj1, dict) and isinstance(obj2, dict):
@@ -75,10 +87,6 @@ class TestCheckpointReader(TestCase):
             return torch.equal(obj1, obj2)
         else:
             return obj1 == obj2
-
-    def tearDown(self):
-        # Clean up the temporary directory
-        shutil.rmtree(self.temp_dir)
 
     def test_read_checkpoint(self):
         """Test that read correctly reads a checkpoint file."""
@@ -207,14 +215,11 @@ class TestCheckpointReader(TestCase):
             )
 
 
-class TestCheckpointReaderDevice(TestCase):
+class TestCheckpointReaderDevice(_CheckpointReaderTestBase):
     hw_classification = HardwareClassification.ACCELERATOR
 
-    def setUp(self):
-        super().setUp()
-        self.temp_dir = tempfile.mkdtemp()
-        self.rank_info = RankInfo(global_rank=0, global_world_size=1)
-        self.state_dict = {
+    def _get_state_dict(self) -> dict[str, Any]:
+        return {
             "model": {
                 "weight": torch.randn(10, 5),
                 "bias": torch.randn(5),
@@ -222,20 +227,10 @@ class TestCheckpointReaderDevice(TestCase):
             "epoch": 5,
             "step": 1000,
         }
-        self.checkpoint_path = os.path.join(self.temp_dir, "checkpoint")
-        os.makedirs(self.checkpoint_path, exist_ok=True)
-        checkpoint_file = os.path.join(
-            self.checkpoint_path, f"checkpoint_{self.rank_info.global_rank}.pt"
-        )
-        torch.save(self.state_dict, checkpoint_file)
-
-    def tearDown(self):
-        shutil.rmtree(self.temp_dir)
 
     def test_read_with_map_location(self, device):
-        reader = CheckpointReader(rank_info=self.rank_info)
         map_location = torch.device(device).type
-        read_state_dict, _ = reader.read(
+        read_state_dict, _ = self.reader.read(
             self.checkpoint_path, map_location=map_location
         )
         self.assertIn("model", read_state_dict)

--- a/test/distributed/checkpoint/_experimental/test_checkpoint_reader.py
+++ b/test/distributed/checkpoint/_experimental/test_checkpoint_reader.py
@@ -230,6 +230,8 @@ class TestCheckpointReaderDevice(_CheckpointReaderTestBase):
 instantiate_device_type_tests(
     TestCheckpointReaderDevice,
     globals(),
+    allow_mps=True,
+    allow_xpu=True,
 )
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
This PR makes test/distributed/checkpoint/_experimental/test_checkpoint_reader.py
device-agnostic by replacing the hardcoded CUDA availability check with
torch.accelerator.current_accelerator(), so the map_location test automatically
adapts to any accelerator compiled at build time (CUDA, MPS, XPU, or
PrivateUse1-based out-of-tree accelerators such as NPU).

## Changes
* Replaced `map_location = "cuda" if torch.cuda.is_available() else "cpu"`
  with `torch.accelerator.current_accelerator(check_available=True)` to
  dynamically resolve the active accelerator device type at runtime.
* Updated the inline comment to reflect the generic accelerator selection.

## Motivation
The test previously hardcoded a CUDA-or-CPU fallback, which meant on non-CUDA
accelerator systems (e.g. NPU, XPU) the map_location parameter would always
degrade to "cpu", skipping meaningful coverage of device-resident checkpoint
loading. Using current_accelerator() allows the test to automatically target
whatever accelerator PyTorch was compiled with, improving test coverage and
removing device-specific branching.

## Test Plan
python test/distributed/checkpoint/_experimental/test_checkpoint_reader.py -v