### PR TITLE
refactor getSequenceNumberForGroup in ProcessGroup

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.hpp
@@ -184,13 +184,6 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
     return backendType_;
   }
 
-  inline bool backendSupportsSequenceNumbers(BackendType backendType) {
-    if (backendType == BackendType::GLOO || backendType == BackendType::NCCL ||
-        backendType == BackendType::XCCL || backendType == BackendType::UCC)
-      return true;
-    return false;
-  }
-
   virtual void setTimeout(std::chrono::milliseconds timeout) {
     for (auto& backend : backendTypeToBackend_) {
       backend.second->setTimeout(timeout);
@@ -762,19 +755,8 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
   // in sync. If the returned number is not consistent across the group, it
   // may indicate that there is some sort of collective desynchronization.
   virtual uint64_t getSequenceNumberForGroup() {
-    auto backendType = getBackendType();
-
-    // TODO: HACK for backend name to get sequence number for that backend.
-    if (backendSupportsSequenceNumbers(backendType)) {
-      return getDefaultBackend()->getSequenceNumberForGroup();
-    } else {
-      TORCH_CHECK(
-          false,
-          c10::str(
-              "ProcessGroup ",
-              getBackendName(),
-              " does not yet support sequence numbers."));
-    }
+    // For backends that do not support sequence numbers, the default method in the Backend class is called
+    return getDefaultBackend()->getSequenceNumberForGroup();
   }
 
   virtual c10::intrusive_ptr<Work> send(


### PR DESCRIPTION
## Motivation

The `getSequenceNumberForGroup()` methods in the `ProcessGroup` class restrict backend types through hardcoded logic, currently only supporting four backends: NCCL, GLOO, UCC, and XCCL. For third-party backend implementations, the logic of `getSequenceNumberForGroup` cannot be reached.

Therefore, we propose refactoring the implementation of these two methods to flexibly support different backends.

## Implementation Plan

### 1. Refactoring `ProcessGroup::getSequenceNumberForGroup()`

The original code of this method in PyTorch's `ProcessGroup` class:

```cpp
  inline bool backendSupportsSequenceNumbers(BackendType backendType) {
    if (backendType == BackendType::GLOO || backendType == BackendType::NCCL ||
        backendType == BackendType::XCCL || backendType == BackendType::UCC)
      return true;
    return false;
  }

  virtual uint64_t getSequenceNumberForGroup() {
    auto backendType = getBackendType();

    // TODO: HACK for backend name to get sequence number for that backend.
    if (backendSupportsSequenceNumbers(backendType)) {
      return getDefaultBackend()->getSequenceNumberForGroup();
    } else {
      TORCH_CHECK(
          false,
          c10::str(
              "ProcessGroup ",
              getBackendName(),
              " does not yet support sequence numbers."));
    }
  }
```

The main functionality of this method is:

1. For backends that support sequence numbers (NCCL, GLOO, UCC, XCCL), call the corresponding backend's `getSequenceNumberForGroup()` method.
2. For backends that do not support sequence numbers, throw an exception.

PyTorch's built-in backends are NCCL, GLOO, UCC, and MPI. The MPI backend does not implement the `getSequenceNumberForGroup()` method, so when this method is called, the parent class `Backend`'s method is called, which throws an exception. The implementation in the `Backend` class is as follows:

```cpp
  virtual uint64_t getSequenceNumberForGroup() {
    auto backendName = getBackendName();
    TORCH_CHECK(
        false,
        c10::str(
            "Backend ",
            backendName,
            " does not yet support sequence numbers."));
  }
```

As can be seen, the exception message thrown in the `Backend` class is consistent with the exception message thrown in the `ProcessGroup` class's `getSequenceNumberForGroup` method.

Therefore, for the `getSequenceNumberForGroup` method in the `ProcessGroup` class, we propose simplifying its implementation logic:

```cpp
  virtual void getSequenceNumberForGroup() {
    // For backends that do not support sequence numbers, the default method in the Backend class is called
    return getDefaultBackend()->getSequenceNumberForGroup();
  }
```

In general, the principle of refactoring is to keep the original behavior and functionality of the method, while support new backends.


