### PR TITLE
[xpu][fix] Skip test_emulate_precision_casts_preserves_explicit_precision_cast_float16 on XPU

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -1699,6 +1699,16 @@ class CudaReproTests(TestCase):
     def test_emulate_precision_casts_preserves_explicit_precision_cast(
         self, lowp_dtype
     ):
+        if TEST_XPU and lowp_dtype is torch.float16:
+            # To be enabled once triton-xpu emits a constrained fptrunc for
+            # `arith.truncf f32 -> f16`, so the fp32 -> fp16 -> fp32 barrier
+            # survives SPIR-V/IGC lowering (currently folded to identity).
+            # Upstream triton bug: intel/intel-xpu-backend-for-triton#7491.
+            # Tracker: intel/torch-xpu-ops#4358.
+            raise unittest.SkipTest(
+                "XPU: to be enabled after triton-xpu fix "
+                "(intel/intel-xpu-backend-for-triton#7491)"
+            )
         torch.manual_seed(0)
         torch.cuda.manual_seed_all(0) if TEST_CUDA else torch.xpu.manual_seed_all(0)
         lowp_name = str(lowp_dtype).removeprefix("torch.")


### PR DESCRIPTION
## Summary

Skip `test_emulate_precision_casts_preserves_explicit_precision_cast_float16`
on XPU. The `float16` parametrization fails on XPU because the triton-xpu
backend folds the `fp32 -> fp16 -> fp32` precision barrier to identity,
defeating `emulate_precision_casts`.

Only the `float16` case is skipped; `bfloat16` continues to run so any
future regression is still visible.

## Root cause

Inductor's codegen is correct: TTIR / TTGIR / LLIR all retain the
`arith.truncf` + `arith.extf` pair (LLVM `fptrunc float, half` +
`fpext half, float`). The bug is in triton-xpu's `TruncFOpConversion`
which lowers `arith.truncf f32 -> f16` to a plain `LLVM::FPTruncOp`;
without a constrained intrinsic the downstream SPIR-V / IGC lowering
folds it against the following `fpext` as identity.

The same file already provides the correct lowering for `tt.fp_to_fp`
via `FpToFpOpConversion::convertFp32ToFp16`, which uses
`LLVM::ConstrainedFPTruncIntr` (constrained intrinsic with explicit
rounding mode). The two paths must be aligned; that is out of scope for
this PR and tracked upstream at
[intel/intel-xpu-backend-for-triton#7491](https://github.com/intel/intel-xpu-backend-for-triton/issues/7491).

## Isolation

| variant | max abs diff on XPU |
| --- | --- |
| matmul only | 0.0 |
| matmul + sigmoid + sum, no fp16 cast | 1.5e-5 |
| `.to(fp16).float()` alone (cast round-trip) | **7.7e-3** |
| `.to(bf16).float()` alone (cast round-trip) | **0.0** |
| full UT (fp16) | **0.018** (FAIL) |
| full UT (bf16) | 7.6e-6 (from downstream sigmoid/reduce order, not the cast; PASS) |

Environment: `torch 2.14.0.dev20260713+xpu`, `triton-xpu 3.7.2+git5fcc14d9`,
Intel(R) Data Center GPU Max 1100.

## Why only float16 is skipped

The `bfloat16` path in triton-xpu's `TruncFOpConversion` goes through
`intel::convertFp32ToBf16` (either the `__spirv_ConvertFToBF16INTEL`
intrinsic or a hand-written RTNE bit-manipulation sequence), which never
emits an LLVM `fptrunc`. The "unconstrained `fptrunc`+`fpext` folded away
as identity" root cause simply does not apply to bf16. Isolating the cast
alone confirms this: `matmul(x, w).to(bf16).float()` produces a bit-exact
match against eager on XPU today (diff = 0.0).

The ~7.6e-6 residual on the full bf16 UT comes from downstream ops
(sigmoid / `sum(dim=1)` reduction order), i.e. ordinary floating-point
reordering variance between compiled and eager execution, unrelated to
`emulate_precision_casts`. `assertEqual`'s default fp32 tolerance
correctly absorbs it, and bf16's pass is a genuine pass. The upstream
triton-xpu fix should only touch the `f32 -> f16` branch of
`TruncFOpConversion`.

## Why source-level skip instead of the DISABLED issue

`pytorch/pytorch#190157` uses the bot-managed dynamic DISABLED mechanism.
That mechanism does not surface the reason in the test source, so someone
running the test locally sees a bare skip with no context. A source-level
`SkipTest` guard whose message links to the canonical tracking issue in
`intel/torch-xpu-ops` makes the reason visible in the file, and the tracking
issue owns the closure conditions (upstream triton-xpu fix -> PyTorch pin bump
-> remove this skip).

## Test plan

```
$ cd test
$ pytest inductor/test_cuda_repro.py -v \
    -k test_emulate_precision_casts_preserves_explicit_precision_cast
inductor/test_cuda_repro.py::CudaReproTests::test_emulate_precision_casts_preserves_explicit_precision_cast_bfloat16 PASSED
inductor/test_cuda_repro.py::CudaReproTests::test_emulate_precision_casts_preserves_explicit_precision_cast_float16 SKIPPED
```

Fixes #190157

Upstream triton bug (removal condition): intel/intel-xpu-backend-for-triton#7491.
Tracking: intel/torch-xpu-ops#4358 (contains the reproducer, isolation,
root cause, and the closure checklist).

---

This PR was authored with AI assistance.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo

