### PR TITLE
[Testcase Refactoring] Refactor test_python_dispatcher.py for test cases classification and device generalization

### DIFF
--- a/test/dynamo/test_python_dispatcher.py
+++ b/test/dynamo/test_python_dispatcher.py
@@ -1,19 +1,14 @@
 # Owner(s): ["module: dynamo"]
-import unittest
-
 import torch
 import torch._dynamo.test_case
 from torch._dynamo.testing import CompileCounter, EagerAndRecordGraphs, normalize_gm
-from torch.testing._internal.common_cuda import TEST_CUDA
-from torch.testing._internal.common_utils import TEST_XPU
-
-
-device_type = (
-    acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 class PythonDispatcherTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_dispatch_key1(self):
         @torch.compile(backend="aot_eager", fullgraph=True)
         def fn(x):
@@ -80,34 +75,6 @@ class GraphModule(torch.nn.Module):
 """,
         )
 
-    @unittest.skipIf(not TEST_CUDA and not TEST_XPU, "requires cuda or xpu")
-    def test_dispatch_key_set_guard(self):
-        counter = CompileCounter()
-
-        @torch.compile(backend=counter, fullgraph=True)
-        def fn(x, dks):
-            if dks.has("CPU"):
-                return torch.sin(x + 1)
-            else:
-                return torch.sin(x - 1)
-
-        x1 = torch.randn(2, 3)
-        dks1 = torch._C._dispatch_keys(x1)
-        self.assertEqual(fn(x1, dks1), torch.sin(x1 + 1))
-        self.assertEqual(counter.frame_count, 1)
-
-        x2 = torch.randn(2, 3)
-        dks2 = torch._C._dispatch_keys(x2)
-        self.assertEqual(fn(x2, dks2), torch.sin(x2 + 1))
-        # No recompile since the dispatch key set is the same though the tensor is different.
-        self.assertEqual(counter.frame_count, 1)
-
-        x3 = torch.randn(2, 3, device=device_type)
-        dks3 = torch._C._dispatch_keys(x3)
-        self.assertEqual(fn(x3, dks3), torch.sin(x3 - 1))
-        # Re-compile since the dispatch key set is different.
-        self.assertEqual(counter.frame_count, 2)
-
     def test_functorch_interpreter(self):
         counter = CompileCounter()
 
@@ -164,6 +131,42 @@ class GraphModule(torch.nn.Module):
             torch._C._dispatch_tls_set_dispatch_key_included(
                 torch._C.DispatchKey.PythonTLSSnapshot, saved_python_tls_snapshot
             )
+
+
+class PythonDispatcherTestsDevice(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def test_dispatch_key_set_guard(self, device):
+        counter = CompileCounter()
+
+        @torch.compile(backend=counter, fullgraph=True)
+        def fn(x, dks):
+            if dks.has("CPU"):
+                return torch.sin(x + 1)
+            else:
+                return torch.sin(x - 1)
+
+        x1 = torch.randn(2, 3)
+        dks1 = torch._C._dispatch_keys(x1)
+        self.assertEqual(fn(x1, dks1), torch.sin(x1 + 1))
+        self.assertEqual(counter.frame_count, 1)
+
+        x2 = torch.randn(2, 3)
+        dks2 = torch._C._dispatch_keys(x2)
+        self.assertEqual(fn(x2, dks2), torch.sin(x2 + 1))
+        # No recompile since the dispatch key set is the same though the tensor is different.
+        self.assertEqual(counter.frame_count, 1)
+
+        x3 = torch.randn(2, 3, device=device)
+        dks3 = torch._C._dispatch_keys(x3)
+        self.assertEqual(fn(x3, dks3), torch.sin(x3 - 1))
+        # Re-compile since the dispatch key set is different.
+        self.assertEqual(counter.frame_count, 2)
+
+
+instantiate_device_type_tests(
+    PythonDispatcherTestsDevice, globals(), except_for="cpu", allow_xpu=True
+)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR refactors `test/dynamo/test_python_dispatcher.py` by separating device-generic tests from accelerator-only tests, replacing manual device detection with PyTorch's standard device-type test infrastructure (`instantiate_device_type_tests`).

## Changes

- Removed manual `device_type` detection via `torch.accelerator.current_accelerator()` and replaced it with the `device` parameter from `instantiate_device_type_tests`.
- Extracted `test_dispatch_key_set_guard` into a dedicated `PythonDispatcherTestsDevice` class with `hw_classification = HardwareClassification.ACCELERATOR`.
- Deleted `@unittest.skipIf(not TEST_CUDA and not TEST_XPU, ...)` on `test_dispatch_key_set_guard`.
- Added `instantiate_device_type_tests(PythonDispatcherTestsDevice, globals(), except_for="cpu", allow_xpu=True)` for device-type parametrization.
- Set `hw_classification = HardwareClassification.GENERIC` on `PythonDispatcherTests` so generic tests run on all devices.
- Cleaned up unused imports: `unittest`, `TEST_CUDA`, `TEST_XPU`.

## Test Plan

 `python test/dynamo/test_python_dispatcher.py --hw-classification GENERIC -v`
<img width="565" height="118" alt="图片1" src="https://github.com/user-attachments/assets/b3457132-66c0-4a63-9a45-2b1467334649" />
<img width="692" height="149" alt="图片2" src="https://github.com/user-attachments/assets/2e5d398b-dd74-4c56-a8ca-c1398c5c8546" />

`python test/dynamo/test_python_dispatcher.py --hw-classification ACCELERATOR -v`
<img width="865" height="133" alt="image" src="https://github.com/user-attachments/assets/25a20460-d96c-4316-aa64-a6884d74ff15" />
<img width="865" height="113" alt="image" src="https://github.com/user-attachments/assets/97a6267d-2433-4bce-99a2-22d47a48535b" />
● Verified locally that all cases correctly on CPU and NPU.

● Verified that `PythonDispatcherTestsDevice` is correctly skipped when no accelerator is available (CPU-only).

## Notes
This is part of the test case refactoring initiative tracked in [Test] PyTorch Test Case Refactoring and Track [https://github.com/pytorch/pytorch/issues/185590](https://github.com/pytorch/pytorch/issues/185590)
@wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98