### PR TITLE
[Test] Replaced 'torch.cuda.manual_seed_all' with 'torch.get_device_module(device_type).manual_seed_all' in /test/onnx/onnx_test_common.py

### DIFF
--- a/test/onnx/onnx_test_common.py
+++ b/test/onnx/onnx_test_common.py
@@ -95,7 +95,6 @@ class _TestONNXRuntime(pytorch_test_common.ExportTestCase):
         device_type = getattr(torch.accelerator.current_accelerator(), "type", None)
         if device_type:
             torch.get_device_module(device_type).manual_seed_all(0)
-            
         os.environ["ALLOW_RELEASED_ONNX_OPSET_ONLY"] = "0"
         self.is_script_test_enabled = True
 

--- a/test/onnx/onnx_test_common.py
+++ b/test/onnx/onnx_test_common.py
@@ -92,7 +92,9 @@ class _TestONNXRuntime(pytorch_test_common.ExportTestCase):
     def setUp(self):
         super().setUp()
         onnxruntime.set_seed(0)
-        device_type = getattr(torch.accelerator.current_accelerator(check_available=True), "type", None)
+        device_type = getattr(
+            torch.accelerator.current_accelerator(check_available=True), "type", None
+        )
         if device_type:
             torch.get_device_module(device_type).manual_seed_all(0)
         os.environ["ALLOW_RELEASED_ONNX_OPSET_ONLY"] = "0"

--- a/test/onnx/onnx_test_common.py
+++ b/test/onnx/onnx_test_common.py
@@ -92,8 +92,10 @@ class _TestONNXRuntime(pytorch_test_common.ExportTestCase):
     def setUp(self):
         super().setUp()
         onnxruntime.set_seed(0)
-        if torch.cuda.is_available():
-            torch.cuda.manual_seed_all(0)
+        device_type = getattr(torch.accelerator.current_accelerator(), "type", None)
+        if device_type:
+            torch.get_device_module(device_type).manual_seed_all(0)
+            
         os.environ["ALLOW_RELEASED_ONNX_OPSET_ONLY"] = "0"
         self.is_script_test_enabled = True
 

--- a/test/onnx/onnx_test_common.py
+++ b/test/onnx/onnx_test_common.py
@@ -92,7 +92,7 @@ class _TestONNXRuntime(pytorch_test_common.ExportTestCase):
     def setUp(self):
         super().setUp()
         onnxruntime.set_seed(0)
-        device_type = getattr(torch.accelerator.current_accelerator(), "type", None)
+        device_type = getattr(torch.accelerator.current_accelerator(check_available=True), "type", None)
         if device_type:
             torch.get_device_module(device_type).manual_seed_all(0)
         os.environ["ALLOW_RELEASED_ONNX_OPSET_ONLY"] = "0"


### PR DESCRIPTION
## Summary
This PR updates hardware detection and seeding in [onnx_test_common.py] to replace CUDA-specific checks with the generic torch.accelerator.current_accelerator().type API and use the unified device module for seeding. This makes ONNX tests device-agnostic and enables correct behavior on non-NVIDIA accelerators.

## Changes
- Replaced any direct CUDA-specific detection with torch.accelerator.current_accelerator().type in [onnx_test_common.py]
- Migrated seed initialization to use torch.get_device_module(device_type).manual_seed_all(0) when an accelerator type is present.
- Ensures onnxruntime seed and environment toggles remain set while making device handling generic.

## Motivation
The previous CUDA-centric logic limited deterministic seeding and test behavior to NVIDIA GPUs. By using the unified torch.accelerator API and the per-accelerator device module, the ONNX test harness now adapts to any supported accelerator (e.g., NPU, XPU, PrivateUse1) rather than silently skipping or misconfiguring tests on out-of-tree backends.

## Test Plan

CI: run the ONNX test directory, for example:
python -m pytest pytorch/test/onnx -q

Targeted local run:
python -m pytest pytorch/test/onnx/onnx_test_common.py -q -k TestONNXRuntime

- Verified locally that seeding runs for CPU and detected accelerator backends and that ONNX runtime-based tests execute without CUDA-only assumptions.

## Notes
This change is part of the test refactor to make test suites hardware-agnostic (see issue #185590).

@wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian