### PR TITLE
[Testcase Refactoring] Enable PrivateUse1 tests in test_backward

### DIFF
--- a/test/distributed/pipelining/test_backward.py
+++ b/test/distributed/pipelining/test_backward.py
@@ -324,10 +324,7 @@ class StageBackwardTests(TestCase):
             torch.testing.assert_close(p.grad, ref_p.grad)
 
 
-devices = ["cpu", "cuda", "hpu", "xpu"]
-instantiate_device_type_tests(
-    StageBackwardTests, globals(), only_for=devices, allow_xpu=True
-)
+instantiate_device_type_tests(StageBackwardTests, globals(), allow_xpu=True)
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary
This PR enables `test_backward.py` to run on out-of-tree PrivateUse1 accelerators by removing the `only_for=["cpu", "cuda", "hpu", "xpu"]` argument from `instantiate_device_type_tests`, letting the framework auto-discover the PrivateUse1 device-type test base and auto-generate the PrivateUse1 variants of `StageBackwardTests`.

This is a step toward making pipelining device-type tests device-agnostic for PrivateUse1 backends.

## Changes
- Removed the `devices = ["cpu", "cuda", "hpu", "xpu"]` list and the `only_for=devices` argument from `instantiate_device_type_tests` in `test_backward.py`.
  - `get_desired_device_type_test_bases` already auto-registers `PrivateUse1TestBase` when `_is_privateuse1_backend_available()`, and unconditionally adds HPU on `TEST_HPU`.
  - Kept `allow_xpu=True` so XPU remains opted in (it is not auto-added without this flag).

## Motivation
The explicit `only_for` list excluded PrivateUse1, so the `StageBackwardTests` variants were never generated for PrivateUse1 accelerators even when one was available — the PrivateUse1 variants were silently skipped. Removing `only_for` lets the tests run on PrivateUse1 with no loss of existing coverage (CPU/CUDA/HPU/XPU all still run when available); the only addition is the PrivateUse1 variant.