### PR TITLE
[Testcase Refactoring] Enable PrivateUse1 tests in test_unflatten

### DIFF
--- a/test/distributed/pipelining/test_unflatten.py
+++ b/test/distributed/pipelining/test_unflatten.py
@@ -125,10 +125,7 @@ class UnflattenPlaceholderOrderingTests(TestCase):
         )
 
 
-devices = ["cpu", "cuda", "hpu", "xpu"]
-instantiate_device_type_tests(
-    UnflattenTests, globals(), only_for=devices, allow_xpu=True
-)
+instantiate_device_type_tests(UnflattenTests, globals(), allow_xpu=True)
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary
This PR enables `test_unflatten.py` to run on out-of-tree PrivateUse1 accelerators by removing the `only_for=["cpu", "cuda", "hpu", "xpu"]` argument from `instantiate_device_type_tests`, letting the framework auto-discover the PrivateUse1 device-type test base and auto-generate the PrivateUse1 variant of `test_unflatten`.

This is a step toward making pipelining device-type tests device-agnostic for PrivateUse1 backends.

## Changes
- Removed the `devices = ["cpu", "cuda", "hpu", "xpu"]` list and the `only_for=devices` argument from `instantiate_device_type_tests` in `test_unflatten.py`.
  - `get_desired_device_type_test_bases` already auto-registers `PrivateUse1TestBase` when `_is_privateuse1_backend_available()`, and unconditionally adds HPU on `TEST_HPU`.
  - Kept `allow_xpu=True` so XPU remains opted in (it is not auto-added without this flag).

## Motivation
The explicit `only_for` list excluded PrivateUse1, so `test_unflatten` was never generated for PrivateUse1 accelerators even when one was available — the PrivateUse1 variant was silently skipped. Removing `only_for` lets the test run on PrivateUse1 with no loss of existing coverage (CPU/CUDA/HPU/XPU all still run when available); the only addition is the PrivateUse1 variant.

## Notes
- `UnflattenPlaceholderOrderingTests` (regression tests for #162898) are plain `TestCase`, not device-parameterized, so they are unaffected by this change and continue to run as-is.