### PR TITLE
[Test] Remove HardwareClassification nightly fallbacks

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -116,13 +116,8 @@ class HardwareClassificationPytestPlugin:
     def _resolve_hw_classification(hw_classification):
         if hw_classification is None:
             return None
-        # Temporary workaround needed until HardwareClassification makes it into a
-        # nightly because main / PR's tests are sometimes run against the previous
-        # day's nightly which won't have this class.
-        try:
-            from torch.testing._internal.common_utils import HardwareClassification
-        except ImportError:
-            return None
+        from torch.testing._internal.common_utils import HardwareClassification
+
         return {HardwareClassification[name] for name in hw_classification}
 
     def pytest_collection_modifyitems(self, items):

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -98,14 +98,10 @@ except ImportError:
         pass
 
 
-try:
-    from torch.testing._internal.common_utils import HardwareClassification
+from torch.testing._internal.common_utils import HardwareClassification
 
-    _HC_CHOICES = [e.name for e in HardwareClassification]
-except ImportError:
-    # Temporary fallback for CI jobs that run the PR's test/run_test.py against a
-    # previous nightly torch package that doesn't have HardwareClassification yet.
-    _HC_CHOICES = ["GENERIC", "ACCELERATOR", "CPU", "CUDA", "MPS", "XPU"]
+
+_HC_CHOICES = [e.name for e in HardwareClassification]
 
 
 # Make sure to remove REPO_ROOT after import is done


### PR DESCRIPTION
## Summary

[HardwareClassification](https://github.com/pytorch/pytorch/pull/186918) has landed in a nightly, so the temporary import workarounds are no longer needed.

## Changes
- test/conftest.py: remove try/except in `_resolve_hw_classification`
- test/run_test.py: remove try/except with hardcoded `_HC_CHOICES` fallback
