### PR TITLE
[Testcase Refactoring] Decouple hardcoded device types in distributed test infrastructure

### DIFF
--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -821,8 +821,8 @@ class DTensorTestBase(DTensorTestMixin, MultiProcessTestCase):
             raise RuntimeError(f"Backend {backend} not supported!")
 
         device_id = None
-        if "nccl" in backend or "xccl" in backend:
-            # set device for nccl pg for collectives
+        if requires_gpu:
+            # set device for accelerator pg for collectives (nccl/xccl/hccl)
             # TODO: if users want to enable testing across hosts, we may need
             # to change this part.
             torch.accelerator.set_device_index(self.rank)


### PR DESCRIPTION
## Summary
Remove hardcoded CUDA/XPU device type checks in distributed test
infrastructure to initialize process groups and run FSDP checkpoint
conversion tests on non CUDA/XPU devices.

## Changes
  1. `torch/testing/_internal/distributed/_tensor/common_dtensor.py`: In `DTensorTestBase.init_pg()`, replaced the hardcoded backend check `if "nccl" in backend or "xccl" in backend:` with `if requires_gpu:`. The `requires_gpu` variable is already computed earlier in the same function from `ACCELERATOR_DIST_BACKENDS = ["nccl", "xccl", "hccl"]`, so the new condition is functionally equivalent for CUDA/XPU while extending device binding to HCCL (NPU). This ensures `torch.accelerator.set_device_index(self.rank)` is called for every accelerator backend, so each rank binds to a distinct physical device before `dist.init_process_group`.

## Motivation
`DTensorTestBase.init_pg()` excluded the HCCL backend from the
  device-setting branch. On  NPU, all ranks remained 
  on device 0, and HCCL communicator initialization fails.

  An alternative would have been to add `"hccl" in backend` to the
  existing `or` condition. We chose `requires_gpu` instead because it
  is already used for the device-count check a few lines above, avoiding
  a second hardcoded backend list that must be kept in sync with
  `ACCELERATOR_DIST_BACKENDS`.

## Test Plan
`python test/distributed/checkpoint/test_fsdp_tp_checkpoint_conversion.py`

No behavioral change on CUDA and XPU - `requires_gpu` evaluates identically to 
the previous `or` condition when the backend is nccl or xccl.

## Notes
- This PR references the hardware decoupling RFC proposed in #185590 .