### PR TITLE
[MPS] Reject embedding_bag index equal to num_weights

### DIFF
--- a/aten/src/ATen/native/mps/kernels/EmbeddingBag.metal
+++ b/aten/src/ATen/native/mps/kernels/EmbeddingBag.metal
@@ -183,7 +183,7 @@ void embedding_bag_impl(
   for (uint32_t indices_idx = indices_start; indices_idx < indices_end;
        indices_idx++) {
     I weight_idx = indices[indices_idx];
-    if (weight_idx < 0 || static_cast<uint32_t>(weight_idx) > num_weights) {
+    if (weight_idx < 0 || static_cast<uint32_t>(weight_idx) >= num_weights) {
       TORCH_REPORT_ERROR(
           error_buf,
           "Index ",

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -16019,6 +16019,12 @@ class TestErrorInputs(TestCase):
         with self.assertRaisesRegex(torch.AcceleratorError, "Index 2 is out of bounds: 6, range 0 to 4"):
             torch.nn.functional.embedding_bag(inputs, weight, offsets)
             torch.mps.synchronize()
+        # Regression for https://github.com/pytorch/pytorch/issues/189971: an index equal to
+        # num_weights (the exact upper boundary) was accepted and read one row past the table.
+        boundary = torch.tensor([0, 1, 4], device=device)  # Note: 4 == num_weights for size 4
+        with self.assertRaisesRegex(torch.AcceleratorError, "Index 2 is out of bounds: 4, range 0 to 4"):
+            torch.nn.functional.embedding_bag(boundary, weight, offsets)
+            torch.mps.synchronize()
 
     def test_scatter_out_of_bounds(self, device):
         with self.assertRaisesRegex(torch.AcceleratorError, "out of bounds"):


### PR DESCRIPTION
Fixes #189971.

## Root cause
The MPS `embedding_bag` forward bounds check in `aten/src/ATen/native/mps/kernels/EmbeddingBag.metal` used `static_cast<uint32_t>(weight_idx) > num_weights`. Valid weight indices are `0 .. num_weights - 1`, so an index exactly equal to `num_weights` passed the check and the kernel read one row past the weight table. The backward path applies the same index as an out-of-range gradient write.

## Fix
Change the comparison to `>= num_weights` so the exact upper boundary is rejected like any other out-of-range index. This matches CPU and CUDA, which reject `index == num_weights`. The forward gate is sufficient because the backward accumulation only runs for indices the forward already validated.

## Test
Extended `test_embedding_bag_out_of_bounds` in `test/test_mps.py` with a boundary case where the index equals `num_weights`; it now raises instead of silently reading out of bounds.

```
python test/test_mps.py -k test_embedding_bag_out_of_bounds
```