### PR TITLE
Fix int32 offset overflow in NLLLoss2d reduce backward kernel

### DIFF
--- a/aten/src/ATen/native/cuda/NLLLoss2d.cu
+++ b/aten/src/ATen/native/cuda/NLLLoss2d.cu
@@ -182,13 +182,13 @@ __global__ void nll_loss2d_backward_kernel(
   const auto grad = -(size_average ? *grad_output / *total_weight
                                    : *grad_output);
 
-  const int sample = blockIdx.x / blocks_per_sample;
+  const int64_t sample = blockIdx.x / blocks_per_sample;
   const int step = blockDim.x * blocks_per_sample;
 
-  const int toffset = sample * map_nelem;
+  const int64_t toffset = sample * map_nelem;
   const auto* const target_thread = target + toffset;
 
-  const int ioffset = sample * map_nelem * n_classes;
+  const int64_t ioffset = sample * map_nelem * n_classes;
   auto* const grad_input_thread = grad_input + ioffset;
 
   for (int i = (blockIdx.x % blocks_per_sample) * blockDim.x + threadIdx.x;

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -12418,6 +12418,21 @@ class TestNNDeviceType(NNTestCase):
         print(logits.numel(), labels.numel(), loss.numel())
         self.assertTrue(torch.allclose(loss_cpu, loss.cpu(), rtol=1e-4, atol=1e-4))
 
+    # Ref: https://github.com/pytorch/pytorch/issues/190139
+    @onlyCUDA
+    @largeTensorTest("18GB", "cuda")
+    def test_nll_loss2d_backward_64bit_offsets(self, device):
+        # The reduce backward kernel computed per-sample offsets in 32-bit int,
+        # so grad_input with more than INT_MAX elements wrapped the base pointer
+        # and caused an illegal memory access. The spatial (N, C, d1, ...) shape
+        # routes cross_entropy's backward through nll_loss2d_backward_kernel.
+        n, c = 2 ** 16 + 1, 2 ** 15
+        logits = torch.zeros((n, c, 1, 1), dtype=torch.float16, device=device, requires_grad=True)
+        target = torch.zeros((n, 1, 1), dtype=torch.long, device=device)
+        F.cross_entropy(logits, target).backward()
+        torch.cuda.synchronize()
+        self.assertEqual(logits.grad.shape, logits.shape)
+
     def _nll_loss_helper(self, input_size, reduction, expected, device, dtype):
         input = torch.rand(input_size, requires_grad=True, device=device, dtype=dtype)
         num_channels = input_size[1]


### PR DESCRIPTION
Fixes #190139.

## Root cause
`nll_loss2d_backward_kernel` (`aten/src/ATen/native/cuda/NLLLoss2d.cu`) computes the per-sample base offsets `sample`, `toffset` and `ioffset` as 32-bit `int`:

```cpp
const int ioffset = sample * map_nelem * n_classes;
auto* const grad_input_thread = grad_input + ioffset;
```

`sample * map_nelem * n_classes` wraps once `grad_input` has more than `INT_MAX` elements, so `grad_input_thread` points outside the allocation and the store issues an illegal memory access. This path is reached by `cross_entropy` on `(batch, classes, d1, ...)` logits (e.g. `F.cross_entropy(logits.transpose(1, 2), labels)`), so it affects ordinary large-batch spatial losses, not only a synthetic case.

## Fix
Widen the three offset locals to `int64_t` so the products are computed in 64-bit. The forward and no-reduce kernels already carry the same offsets in the templated `index_t`; this brings the reduce backward kernel in line.

## Test
Added `test_nll_loss2d_backward_64bit_offsets`, a `@largeTensorTest` that runs the spatial `cross_entropy` backward with `grad_input` numel above `INT_MAX` and asserts it completes (before the fix it hit an illegal memory access).

```
python test/test_nn.py -k test_nll_loss2d_backward_64bit_offsets
```