### PR TITLE
[Test] Replaced 'torch.cuda.manual_seed_all' with 'torch.get_device_module(device_type).manual_seed_all' in /test/onnx/pytorch_test_common.py

### DIFF
--- a/test/onnx/pytorch_test_common.py
+++ b/test/onnx/pytorch_test_common.py
@@ -408,6 +408,8 @@ class ExportTestCase(common_utils.TestCase):
         super().setUp()
         # TODO(#88264): Flaky test failures after changing seed.
         set_rng_seed(0)
-        device_type = getattr(torch.accelerator.current_accelerator(check_available=True), "type", None)
+        device_type = getattr(
+            torch.accelerator.current_accelerator(check_available=True), "type", None
+        )
         if device_type:
             torch.get_device_module(device_type).manual_seed_all(0)

--- a/test/onnx/pytorch_test_common.py
+++ b/test/onnx/pytorch_test_common.py
@@ -408,5 +408,6 @@ class ExportTestCase(common_utils.TestCase):
         super().setUp()
         # TODO(#88264): Flaky test failures after changing seed.
         set_rng_seed(0)
-        if torch.cuda.is_available():
-            torch.cuda.manual_seed_all(0)
+        device_type = getattr(torch.accelerator.current_accelerator(), "type", None)
+        if device_type:
+            torch.get_device_module(device_type).manual_seed_all(0)

--- a/test/onnx/pytorch_test_common.py
+++ b/test/onnx/pytorch_test_common.py
@@ -408,6 +408,6 @@ class ExportTestCase(common_utils.TestCase):
         super().setUp()
         # TODO(#88264): Flaky test failures after changing seed.
         set_rng_seed(0)
-        device_type = getattr(torch.accelerator.current_accelerator(), "type", None)
+        device_type = getattr(torch.accelerator.current_accelerator(check_available=True), "type", None)
         if device_type:
             torch.get_device_module(device_type).manual_seed_all(0)


### PR DESCRIPTION
## Summary
This PR updates hardware detection and test guards in [pytorch_test_common.py] to replace CUDA-specific checks with the generic torch.accelerator.current_accelerator().type API and to use the per-accelerator device module for seeding and capability checks. This change makes ONNX test utilities device-agnostic and compatible with non-NVIDIA backends.

## Changes
Replaced any direct CUDA-specific detection with torch.accelerator.current_accelerator().type in [pytorch_test_common.py]
Migrated seed initialization to use torch.get_device_module(device_type).manual_seed_all(0) when an accelerator type is present.
Ensures onnxruntime seed and environment toggles remain set while making device handling generic.

## Motivation
Hard-coded CUDA checks force test behavior to NVIDIA GPUs and can cause silent skips or incorrect assumptions on out-of-tree or non-NVIDIA backends. Migrating to torch.accelerator and the per-accelerator device module ensures tests adapt dynamically to any supported hardware (e.g., NPU, XPU, PrivateUse1), improving test coverage and preventing hidden failures.

## Test Plan
CI: run ONNX test suite:
python test/onnx/test_models_onnxruntime.py

Local targeted runs:
Verify that seeding capability checks run correctly on CPU and detected accelerator backends.

## Notes
Part of the test refactor to make test infra hardware-agnostic (see issue #185590).
@wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian