### PR TITLE
Fix max_unpool2d channels-last stride mismatch on XPU

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -5935,9 +5935,11 @@ for dtype in (torch.int32, torch.int64):
         x3d = torch.randn(1, 1, 1, 1, 1, device=self.device)
         self.common(Unpool3d().to(self.device), (x3d, x3d.long()))
 
-    def test_max_unpool2d_channels_last_stride_cpu(self):
-        if self.device != "cpu":
-            raise unittest.SkipTest("CPU max_unpool2d preserves channels-last layout")
+    def test_max_unpool2d_channels_last_stride(self):
+        if self.device not in ("cpu", "xpu"):
+            raise unittest.SkipTest(
+                "only CPU and XPU max_unpool2d preserve channels-last layout"
+            )
 
         def fn(x, indices):
             return F.max_unpool2d(x, indices, kernel_size=2, stride=2)

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -3191,11 +3191,12 @@ def _max_unpoolnd(
             ),
         )
 
-    # The native CPU kernel preserves the input's memory format
-    # (aten/src/ATen/native/MaxUnpooling.cpp uses suggest_memory_format),
-    # while the CUDA kernel and the 3d kernels always return contiguous output.
+    # The native CPU kernel (aten/src/ATen/native/MaxUnpooling.cpp) and the XPU
+    # kernel (torch-xpu-ops MaxUnpoolingKernels.cpp) preserve the input's memory
+    # format via suggest_memory_format, while the CUDA kernel and the 3d kernels
+    # always return contiguous output.
     def _restride(t: TensorLike) -> TensorLike:
-        if dim == 2 and self.device.type == "cpu":
+        if dim == 2 and self.device.type in ("cpu", "xpu"):
             return t.contiguous(memory_format=utils.suggest_memory_format(self))
         return t
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -3659,60 +3659,6 @@ def _adaptive_pool_empty_output_check(grad_output: Tensor, arg_name: str):
         )
 
 
-@register_meta(aten.max_unpool2d)
-@out_wrapper()
-def meta_max_unpool2d(self, indices, output_size):
-    torch._check(
-        indices.dtype == torch.int64,
-        lambda: f"elements in indices should be type int64 but got: {indices.dtype}",
-    )
-    torch._check(
-        len(output_size) == 2,
-        lambda: (
-            f"There should be exactly two elements (height, width) in output_size, "
-            f"but got {len(output_size)} elements."
-        ),
-    )
-    torch._check(
-        self.ndim in (3, 4),
-        lambda: (
-            f"Input to max_unpooling2d should be a 3d or 4d Tensor, "
-            f"but got a tensor with {self.ndim} dimensions."
-        ),
-    )
-    torch._check(
-        self.shape == indices.shape,
-        lambda: (
-            f"Expected shape of indices to be same as that of the input tensor ({self.shape}) "
-            f"but got indices tensor with shape: {indices.shape}"
-        ),
-    )
-    for i in range(1, self.ndim):
-        torch._check(
-            self.size(i) > 0,
-            lambda i=i: (
-                f"max_unpooling2d(): "
-                f"Expected input to have non-zero size for non-batch dimensions, "
-                f"but got {self.shape} with dimension {i} being empty."
-            ),
-        )
-
-    output_shape = (*self.shape[:-2], *output_size)
-    result = self.new_empty(output_shape)
-
-    # Match each backend's eager max_unpool2d layout so FakeTensor strides
-    # agree with the real device kernel:
-    #   - CPU (aten/src/ATen/native/MaxUnpooling.cpp) and XPU
-    #     (torch-xpu-ops MaxUnpoolingKernels.cpp) resize the 4D output with
-    #     self.suggest_memory_format(), preserving channels-last.
-    #   - CUDA (aten/src/ATen/native/cuda/MaxUnpooling.cu) always makes the
-    #     input contiguous, so the output is contiguous.
-    if self.ndim == 4 and device_hint(self) in ("cpu", "xpu"):
-        result = result.to(memory_format=utils.suggest_memory_format(self))
-
-    return result
-
-
 @register_meta(aten.adaptive_max_pool2d)
 @out_wrapper("out", "indices")
 def meta_adaptive_max_pool2d(input, output_size):

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -3659,6 +3659,60 @@ def _adaptive_pool_empty_output_check(grad_output: Tensor, arg_name: str):
         )
 
 
+@register_meta(aten.max_unpool2d)
+@out_wrapper()
+def meta_max_unpool2d(self, indices, output_size):
+    torch._check(
+        indices.dtype == torch.int64,
+        lambda: f"elements in indices should be type int64 but got: {indices.dtype}",
+    )
+    torch._check(
+        len(output_size) == 2,
+        lambda: (
+            f"There should be exactly two elements (height, width) in output_size, "
+            f"but got {len(output_size)} elements."
+        ),
+    )
+    torch._check(
+        self.ndim in (3, 4),
+        lambda: (
+            f"Input to max_unpooling2d should be a 3d or 4d Tensor, "
+            f"but got a tensor with {self.ndim} dimensions."
+        ),
+    )
+    torch._check(
+        self.shape == indices.shape,
+        lambda: (
+            f"Expected shape of indices to be same as that of the input tensor ({self.shape}) "
+            f"but got indices tensor with shape: {indices.shape}"
+        ),
+    )
+    for i in range(1, self.ndim):
+        torch._check(
+            self.size(i) > 0,
+            lambda i=i: (
+                f"max_unpooling2d(): "
+                f"Expected input to have non-zero size for non-batch dimensions, "
+                f"but got {self.shape} with dimension {i} being empty."
+            ),
+        )
+
+    output_shape = (*self.shape[:-2], *output_size)
+    result = self.new_empty(output_shape)
+
+    # Match each backend's eager max_unpool2d layout so FakeTensor strides
+    # agree with the real device kernel:
+    #   - CPU (aten/src/ATen/native/MaxUnpooling.cpp) and XPU
+    #     (torch-xpu-ops MaxUnpoolingKernels.cpp) resize the 4D output with
+    #     self.suggest_memory_format(), preserving channels-last.
+    #   - CUDA (aten/src/ATen/native/cuda/MaxUnpooling.cu) always makes the
+    #     input contiguous, so the output is contiguous.
+    if self.ndim == 4 and device_hint(self) in ("cpu", "xpu"):
+        result = result.to(memory_format=utils.suggest_memory_format(self))
+
+    return result
+
+
 @register_meta(aten.adaptive_max_pool2d)
 @out_wrapper("out", "indices")
 def meta_adaptive_max_pool2d(input, output_size):


### PR DESCRIPTION
'max_unpool2d' had no explicit meta kernel, so FakeTensor/meta ran the '_max_unpool1nd' decomposition, whose '_restride' preserved channels-last only for 'device.type=="cpu"'. The XPU kernel (torch-xpu-ops 'maxUnpoolingKernel.cpp') preserves the input's memory format via 'suggest_memory_format', so for a channels-last 4D input the XPU eager output was channels-last while meta reported contiguous: 'MetadataMismatchError: Stride mismatch!'

Fix:
Extend '_max_unpoolnd._restride' in torch/_decompo/decompositions.py to preserve channels-last for both cpu and xpu, matching the real device kernels:
- CPU and XPU - resize the 4D output with suggest_memory_format, preserving channels-last
- CUDA and the 3d kernels - always contigous

Fixes: https://github.com/intel/torch-xpu-ops/issues/3599

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo