### PR TITLE
Reduce hot binary footprint in BoxedKernelWrapper and structured set_output codegen

### DIFF
--- a/aten/src/ATen/core/boxing/KernelFunction.cpp
+++ b/aten/src/ATen/core/boxing/KernelFunction.cpp
@@ -1,7 +1,6 @@
 #include <ATen/core/boxing/KernelFunction.h>
 #include <ATen/core/dispatch/Dispatcher.h>
 
-#include <memory>
 #include <sstream>
 
 namespace c10 {
@@ -56,18 +55,12 @@ bool KernelFunction::_equalsBoxedAndUnboxed(const KernelFunction& other) const {
 
 namespace impl {
 
-torch::jit::Stack boxedBufferToStack(IValue* begin, IValue*& end) {
+torch::jit::Stack boxedBufferToStack(IValue* begin, IValue* end) {
   torch::jit::Stack stack;
   stack.reserve(static_cast<size_t>(end - begin));
-  // Everything from here on is noexcept (push_back into reserved capacity
-  // uses IValue's noexcept move constructor), so the caller's BoxedBuffer
-  // cleanup can never observe a partially drained range: either reserve
-  // throws with the buffer untouched, or end is reset after a full drain.
   for (IValue* it = begin; it != end; ++it) {
     stack.push_back(std::move(*it));
-    std::destroy_at(it);
   }
-  end = begin;
   return stack;
 }
 

--- a/aten/src/ATen/core/boxing/KernelFunction.cpp
+++ b/aten/src/ATen/core/boxing/KernelFunction.cpp
@@ -62,8 +62,10 @@ torch::jit::Stack boxedBufferToStack(IValue* begin, IValue* end) {
       std::make_move_iterator(begin), std::make_move_iterator(end));
 }
 
-// Intentionally out of line; see the declaration in boxing.h.
-void destroyBoxedBuffer(IValue* begin, IValue* end) noexcept {
+// Intentionally out of line; see the declaration in boxing.h. C10_NOINLINE
+// keeps it that way under LTO, where the definition would otherwise be
+// visible to callers in other translation units.
+C10_NOINLINE void destroyBoxedBuffer(IValue* begin, IValue* end) noexcept {
   std::destroy(begin, end);
 }
 

--- a/aten/src/ATen/core/boxing/KernelFunction.cpp
+++ b/aten/src/ATen/core/boxing/KernelFunction.cpp
@@ -53,4 +53,21 @@ bool KernelFunction::_equalsBoxedAndUnboxed(const KernelFunction& other) const {
          unboxed_kernel_func_ == other.unboxed_kernel_func_;
 }
 
+namespace impl {
+
+torch::jit::Stack boxedBufferToStack(IValue* begin, IValue* end) {
+  torch::jit::Stack stack;
+  stack.reserve(static_cast<size_t>(end - begin));
+  for (IValue* it = begin; it != end; ++it) {
+    // push_back into reserved capacity is noexcept (IValue's move
+    // constructor is noexcept), so a partially drained buffer is not
+    // observable by the caller's cleanup guard.
+    stack.push_back(std::move(*it));
+    it->~IValue();
+  }
+  return stack;
+}
+
+} // namespace impl
+
 } // namespace c10

--- a/aten/src/ATen/core/boxing/KernelFunction.cpp
+++ b/aten/src/ATen/core/boxing/KernelFunction.cpp
@@ -1,6 +1,8 @@
 #include <ATen/core/boxing/KernelFunction.h>
 #include <ATen/core/dispatch/Dispatcher.h>
 
+#include <iterator>
+#include <memory>
 #include <sstream>
 
 namespace c10 {
@@ -56,12 +58,12 @@ bool KernelFunction::_equalsBoxedAndUnboxed(const KernelFunction& other) const {
 namespace impl {
 
 torch::jit::Stack boxedBufferToStack(IValue* begin, IValue* end) {
-  torch::jit::Stack stack;
-  stack.reserve(static_cast<size_t>(end - begin));
-  for (IValue* it = begin; it != end; ++it) {
-    stack.push_back(std::move(*it));
-  }
-  return stack;
+  return torch::jit::Stack(
+      std::make_move_iterator(begin), std::make_move_iterator(end));
+}
+
+void destroyBoxedBuffer(IValue* begin, IValue* end) noexcept {
+  std::destroy(begin, end);
 }
 
 } // namespace impl

--- a/aten/src/ATen/core/boxing/KernelFunction.cpp
+++ b/aten/src/ATen/core/boxing/KernelFunction.cpp
@@ -1,6 +1,7 @@
 #include <ATen/core/boxing/KernelFunction.h>
 #include <ATen/core/dispatch/Dispatcher.h>
 
+#include <memory>
 #include <sstream>
 
 namespace c10 {
@@ -55,16 +56,18 @@ bool KernelFunction::_equalsBoxedAndUnboxed(const KernelFunction& other) const {
 
 namespace impl {
 
-torch::jit::Stack boxedBufferToStack(IValue* begin, IValue* end) {
+torch::jit::Stack boxedBufferToStack(IValue* begin, IValue*& end) {
   torch::jit::Stack stack;
   stack.reserve(static_cast<size_t>(end - begin));
+  // Everything from here on is noexcept (push_back into reserved capacity
+  // uses IValue's noexcept move constructor), so the caller's BoxedBuffer
+  // cleanup can never observe a partially drained range: either reserve
+  // throws with the buffer untouched, or end is reset after a full drain.
   for (IValue* it = begin; it != end; ++it) {
-    // push_back into reserved capacity is noexcept (IValue's move
-    // constructor is noexcept), so a partially drained buffer is not
-    // observable by the caller's cleanup guard.
     stack.push_back(std::move(*it));
-    it->~IValue();
+    std::destroy_at(it);
   }
+  end = begin;
   return stack;
 }
 

--- a/aten/src/ATen/core/boxing/KernelFunction.cpp
+++ b/aten/src/ATen/core/boxing/KernelFunction.cpp
@@ -62,6 +62,7 @@ torch::jit::Stack boxedBufferToStack(IValue* begin, IValue* end) {
       std::make_move_iterator(begin), std::make_move_iterator(end));
 }
 
+// Intentionally out of line; see the declaration in boxing.h.
 void destroyBoxedBuffer(IValue* begin, IValue* end) noexcept {
   std::destroy(begin, end);
 }

--- a/aten/src/ATen/core/boxing/impl/boxing.h
+++ b/aten/src/ATen/core/boxing/impl/boxing.h
@@ -10,7 +10,9 @@
 #include <ATen/core/boxing/BoxedKernel.h>
 
 #include <c10/util/Metaprogramming.h>
+#include <cstddef>
 #include <type_traits>
+#include <utility>
 
 namespace c10::impl {
 
@@ -76,18 +78,6 @@ using can_unbox = std::conjunction<
         std::is_same<void, T>>,
     std::negation<std::is_lvalue_reference<T>>>;
 
-//
-// boxArgs - utility for pushing unboxed args onto IValue stack
-//
-template <class... Args>
-torch::jit::Stack boxArgs(Args... args) {
-  // TODO Reuse stack vector instead of allocating?
-  torch::jit::Stack stack;
-  stack.reserve(sizeof...(Args));
-  torch::jit::push(stack, std::forward<Args>(args)...);
-  return stack;
-}
-
 template <class T>
 inline constexpr size_t boxed_size_one() {
   static_assert(
@@ -117,9 +107,13 @@ static inline constexpr size_t boxed_size() {
   return BoxedSize<Args...>::value;
 }
 
-template <typename T>
-C10_ALWAYS_INLINE_UNLESS_MOBILE void boxToStack(IValue*& dest, T& arg) {
-  new (dest++) IValue(arg);
+template <
+    typename T,
+    std::enable_if_t<
+        !std::is_same_v<std::decay_t<T>, c10::TensorOptions>,
+        int> = 0>
+C10_ALWAYS_INLINE_UNLESS_MOBILE void boxToStack(IValue*& dest, T&& arg) {
+  new (dest++) IValue(std::forward<T>(arg));
 }
 
 C10_ALWAYS_INLINE_UNLESS_MOBILE void boxToStack(
@@ -136,10 +130,56 @@ inline void boxArgsToStack(IValue*& /*unused*/) {}
 template <typename T, typename... Args>
 C10_ALWAYS_INLINE_UNLESS_MOBILE void boxArgsToStack(
     IValue*& dest,
-    T& arg,
-    Args&... args) {
-  boxToStack(dest, arg);
-  boxArgsToStack(dest, args...);
+    T&& arg,
+    Args&&... args) {
+  boxToStack(dest, std::forward<T>(arg));
+  boxArgsToStack(dest, std::forward<Args>(args)...);
+}
+
+//
+// boxArgs - utility for boxing unboxed args into an IValue stack
+//
+// The args are boxed into a stack-local buffer and moved into the returned
+// vector by a shared non-template helper, so each instantiation only emits
+// the type-dependent IValue constructions. This keeps the per-signature
+// code size of BoxedKernelWrapper instantiations small (there are hundreds
+// of them in libtorch).
+//
+
+// Moves [begin, end) into a freshly allocated Stack and destroys the moved
+// IValues. On exception (allocation failure) the buffer is left untouched.
+TORCH_API torch::jit::Stack boxedBufferToStack(IValue* begin, IValue* end);
+
+namespace detail {
+// Destroys [begin, cur) on unwind if boxing an argument throws.
+struct BoxedBufferGuard final {
+  IValue* begin;
+  IValue* cur;
+  ~BoxedBufferGuard() {
+    while (cur != begin) {
+      (--cur)->~IValue();
+    }
+  }
+};
+} // namespace detail
+
+template <class... Args>
+torch::jit::Stack boxArgs(Args... args) {
+  constexpr size_t num_boxed = boxed_size<Args...>();
+  if constexpr (num_boxed == 0) {
+    return torch::jit::Stack();
+  } else {
+    // See Dispatcher::callWithDispatchKeySlowPath for why this is not an
+    // std::array<IValue, num_boxed>.
+    // NOLINTNEXTLINE(*array*)
+    alignas(IValue) std::byte buffer[num_boxed * sizeof(IValue)];
+    IValue* const buffer_begin = reinterpret_cast<IValue*>(buffer);
+    detail::BoxedBufferGuard guard{buffer_begin, buffer_begin};
+    boxArgsToStack(guard.cur, std::forward<Args>(args)...);
+    torch::jit::Stack stack = boxedBufferToStack(guard.begin, guard.cur);
+    guard.cur = guard.begin;
+    return stack;
+  }
 }
 
 //

--- a/aten/src/ATen/core/boxing/impl/boxing.h
+++ b/aten/src/ATen/core/boxing/impl/boxing.h
@@ -93,47 +93,36 @@ inline constexpr size_t boxed_size_one<c10::TensorOptions>() {
   return 4;
 }
 
-// NOTE: this could probably be simplified with C++17 fold expressions.
-template <typename...>
-struct BoxedSize : std::integral_constant<size_t, 0> {};
-template <class T, class... Args>
-struct BoxedSize<T, Args...>
-    : std::integral_constant<
-          size_t,
-          boxed_size_one<T>() + BoxedSize<Args...>::value> {};
-
 template <class... Args>
-static inline constexpr size_t boxed_size() {
-  return BoxedSize<Args...>::value;
+consteval size_t boxed_size() {
+  return (size_t{0} + ... + boxed_size_one<Args>());
 }
 
-template <
-    typename T,
-    std::enable_if_t<
-        !std::is_same_v<std::decay_t<T>, c10::TensorOptions>,
-        int> = 0>
+// dest is only incremented after an IValue is fully constructed, so that
+// cleanup code (e.g. detail::BoxedBufferGuard) never destroys an
+// unconstructed slot if a constructor throws.
+template <typename T>
 C10_ALWAYS_INLINE_UNLESS_MOBILE void boxToStack(IValue*& dest, T&& arg) {
-  new (dest++) IValue(std::forward<T>(arg));
+  if constexpr (std::is_same_v<std::decay_t<T>, c10::TensorOptions>) {
+    new (dest) IValue(c10::typeMetaToScalarType(arg.dtype()));
+    ++dest;
+    new (dest) IValue(arg.layout());
+    ++dest;
+    new (dest) IValue(arg.device());
+    ++dest;
+    new (dest) IValue(arg.pinned_memory());
+    ++dest;
+  } else {
+    new (dest) IValue(std::forward<T>(arg));
+    ++dest;
+  }
 }
 
-C10_ALWAYS_INLINE_UNLESS_MOBILE void boxToStack(
-    IValue*& dest,
-    c10::TensorOptions options) {
-  new (dest++) IValue(c10::typeMetaToScalarType(options.dtype()));
-  new (dest++) IValue(options.layout());
-  new (dest++) IValue(options.device());
-  new (dest++) IValue(options.pinned_memory());
-}
-
-inline void boxArgsToStack(IValue*& /*unused*/) {}
-
-template <typename T, typename... Args>
+template <typename... Args>
 C10_ALWAYS_INLINE_UNLESS_MOBILE void boxArgsToStack(
     IValue*& dest,
-    T&& arg,
     Args&&... args) {
-  boxToStack(dest, std::forward<T>(arg));
-  boxArgsToStack(dest, std::forward<Args>(args)...);
+  (boxToStack(dest, std::forward<Args>(args)), ...);
 }
 
 //
@@ -164,7 +153,7 @@ struct BoxedBufferGuard final {
 } // namespace detail
 
 template <class... Args>
-torch::jit::Stack boxArgs(Args... args) {
+torch::jit::Stack boxArgs(Args&&... args) {
   constexpr size_t num_boxed = boxed_size<Args...>();
   if constexpr (num_boxed == 0) {
     return torch::jit::Stack();

--- a/aten/src/ATen/core/boxing/impl/boxing.h
+++ b/aten/src/ATen/core/boxing/impl/boxing.h
@@ -136,9 +136,10 @@ C10_ALWAYS_INLINE_UNLESS_MOBILE void boxArgsToStack(
 // (then moved-from) IValues is left to the caller's BoxedBuffer.
 TORCH_API torch::jit::Stack boxedBufferToStack(IValue* begin, IValue* end);
 
-// Destroys [begin, end). Out of line so that each boxArgs instantiation
-// emits a single call instead of its own unrolled sequence of inlined
-// IValue destructors.
+// Destroys [begin, end). Out of line, and marked C10_NOINLINE at the
+// definition, so that each boxArgs instantiation emits a single call
+// instead of its own unrolled sequence of inlined IValue destructors
+// even in builds that could otherwise inline across translation units.
 TORCH_API void destroyBoxedBuffer(IValue* begin, IValue* end) noexcept;
 
 namespace detail {

--- a/aten/src/ATen/core/boxing/impl/boxing.h
+++ b/aten/src/ATen/core/boxing/impl/boxing.h
@@ -136,6 +136,11 @@ C10_ALWAYS_INLINE_UNLESS_MOBILE void boxArgsToStack(
 // (then moved-from) IValues is left to the caller's BoxedBuffer.
 TORCH_API torch::jit::Stack boxedBufferToStack(IValue* begin, IValue* end);
 
+// Destroys [begin, end). Out of line so that each boxArgs instantiation
+// emits a single call instead of its own unrolled sequence of inlined
+// IValue destructors.
+TORCH_API void destroyBoxedBuffer(IValue* begin, IValue* end) noexcept;
+
 namespace detail {
 // Uninitialized storage for N boxed IValues. The destructor destroys
 // [begin, end): cheap moved-from IValues after a successful
@@ -154,7 +159,7 @@ struct BoxedBuffer final {
   BoxedBuffer(const BoxedBuffer&) = delete;
   BoxedBuffer& operator=(const BoxedBuffer&) = delete;
   ~BoxedBuffer() {
-    std::destroy(begin, end);
+    destroyBoxedBuffer(begin, end);
   }
 };
 } // namespace detail

--- a/aten/src/ATen/core/boxing/impl/boxing.h
+++ b/aten/src/ATen/core/boxing/impl/boxing.h
@@ -132,16 +132,15 @@ C10_ALWAYS_INLINE_UNLESS_MOBILE void boxArgsToStack(
 // of them in libtorch).
 //
 
-// Moves [begin, end) into a freshly allocated Stack, destroying the drained
-// IValues and resetting end to begin. On exception (Stack allocation
-// failure) the buffer is left untouched.
-TORCH_API torch::jit::Stack boxedBufferToStack(IValue* begin, IValue*& end);
+// Moves [begin, end) into a freshly allocated Stack. Destroying the
+// (then moved-from) IValues is left to the caller's BoxedBuffer.
+TORCH_API torch::jit::Stack boxedBufferToStack(IValue* begin, IValue* end);
 
 namespace detail {
-// Uninitialized storage for N boxed IValues. Destroys the constructed
-// prefix [begin, end) on destruction; a successful boxedBufferToStack
-// empties the range, so the destructor only does work when boxing or the
-// Stack allocation threw.
+// Uninitialized storage for N boxed IValues. The destructor destroys
+// [begin, end): cheap moved-from IValues after a successful
+// boxedBufferToStack, or the constructed prefix if boxing or the Stack
+// allocation threw.
 template <size_t N>
 struct BoxedBuffer final {
   // See Dispatcher::callWithDispatchKeySlowPath for why this is not an

--- a/aten/src/ATen/core/boxing/impl/boxing.h
+++ b/aten/src/ATen/core/boxing/impl/boxing.h
@@ -11,6 +11,7 @@
 
 #include <c10/util/Metaprogramming.h>
 #include <cstddef>
+#include <memory>
 #include <type_traits>
 #include <utility>
 
@@ -98,22 +99,18 @@ consteval size_t boxed_size() {
   return (size_t{0} + ... + boxed_size_one<Args>());
 }
 
-// dest is only incremented after an IValue is fully constructed, so that
-// cleanup code (e.g. detail::BoxedBufferGuard) never destroys an
+// dest is only advanced past a slot once its IValue is fully constructed,
+// so cleanup code (e.g. detail::BoxedBuffer) never destroys an
 // unconstructed slot if a constructor throws.
 template <typename T>
 C10_ALWAYS_INLINE_UNLESS_MOBILE void boxToStack(IValue*& dest, T&& arg) {
   if constexpr (std::is_same_v<std::decay_t<T>, c10::TensorOptions>) {
-    new (dest) IValue(c10::typeMetaToScalarType(arg.dtype()));
-    ++dest;
-    new (dest) IValue(arg.layout());
-    ++dest;
-    new (dest) IValue(arg.device());
-    ++dest;
-    new (dest) IValue(arg.pinned_memory());
-    ++dest;
+    boxToStack(dest, c10::typeMetaToScalarType(arg.dtype()));
+    boxToStack(dest, arg.layout());
+    boxToStack(dest, arg.device());
+    boxToStack(dest, arg.pinned_memory());
   } else {
-    new (dest) IValue(std::forward<T>(arg));
+    std::construct_at(dest, std::forward<T>(arg));
     ++dest;
   }
 }
@@ -135,19 +132,30 @@ C10_ALWAYS_INLINE_UNLESS_MOBILE void boxArgsToStack(
 // of them in libtorch).
 //
 
-// Moves [begin, end) into a freshly allocated Stack and destroys the moved
-// IValues. On exception (allocation failure) the buffer is left untouched.
-TORCH_API torch::jit::Stack boxedBufferToStack(IValue* begin, IValue* end);
+// Moves [begin, end) into a freshly allocated Stack, destroying the drained
+// IValues and resetting end to begin. On exception (Stack allocation
+// failure) the buffer is left untouched.
+TORCH_API torch::jit::Stack boxedBufferToStack(IValue* begin, IValue*& end);
 
 namespace detail {
-// Destroys [begin, cur) on unwind if boxing an argument throws.
-struct BoxedBufferGuard final {
+// Uninitialized storage for N boxed IValues. Destroys the constructed
+// prefix [begin, end) on destruction; a successful boxedBufferToStack
+// empties the range, so the destructor only does work when boxing or the
+// Stack allocation threw.
+template <size_t N>
+struct BoxedBuffer final {
+  // See Dispatcher::callWithDispatchKeySlowPath for why this is not an
+  // std::array<IValue, N>.
+  // NOLINTNEXTLINE(*array*)
+  alignas(IValue) std::byte storage[N * sizeof(IValue)];
   IValue* begin;
-  IValue* cur;
-  ~BoxedBufferGuard() {
-    while (cur != begin) {
-      (--cur)->~IValue();
-    }
+  IValue* end;
+
+  BoxedBuffer() : begin(reinterpret_cast<IValue*>(storage)), end(begin) {}
+  BoxedBuffer(const BoxedBuffer&) = delete;
+  BoxedBuffer& operator=(const BoxedBuffer&) = delete;
+  ~BoxedBuffer() {
+    std::destroy(begin, end);
   }
 };
 } // namespace detail
@@ -158,16 +166,9 @@ torch::jit::Stack boxArgs(Args&&... args) {
   if constexpr (num_boxed == 0) {
     return torch::jit::Stack();
   } else {
-    // See Dispatcher::callWithDispatchKeySlowPath for why this is not an
-    // std::array<IValue, num_boxed>.
-    // NOLINTNEXTLINE(*array*)
-    alignas(IValue) std::byte buffer[num_boxed * sizeof(IValue)];
-    IValue* const buffer_begin = reinterpret_cast<IValue*>(buffer);
-    detail::BoxedBufferGuard guard{buffer_begin, buffer_begin};
-    boxArgsToStack(guard.cur, std::forward<Args>(args)...);
-    torch::jit::Stack stack = boxedBufferToStack(guard.begin, guard.cur);
-    guard.cur = guard.begin;
-    return stack;
+    detail::BoxedBuffer<num_boxed> buffer;
+    boxArgsToStack(buffer.end, std::forward<Args>(args)...);
+    return boxedBufferToStack(buffer.begin, buffer.end);
   }
 }
 

--- a/aten/src/ATen/core/boxing/impl/boxing.h
+++ b/aten/src/ATen/core/boxing/impl/boxing.h
@@ -94,41 +94,35 @@ inline constexpr size_t boxed_size_one<c10::TensorOptions>() {
 }
 
 template <class... Args>
-struct BoxedSize
-    : std::integral_constant<size_t, (boxed_size_one<Args>() + ... + 0)> {};
-
-template <class... Args>
-static inline constexpr size_t boxed_size() {
-  return BoxedSize<Args...>::value;
+consteval size_t boxed_size() {
+  return (size_t{0} + ... + boxed_size_one<Args>());
 }
 
-template <
-    typename T,
-    std::enable_if_t<
-        !std::is_same_v<std::decay_t<T>, c10::TensorOptions>,
-        int> = 0>
+// dest is only incremented after an IValue is fully constructed, so that
+// cleanup code (e.g. detail::BoxedBufferGuard) never destroys an
+// unconstructed slot if a constructor throws.
+template <typename T>
 C10_ALWAYS_INLINE_UNLESS_MOBILE void boxToStack(IValue*& dest, T&& arg) {
-  new (dest++) IValue(std::forward<T>(arg));
+  if constexpr (std::is_same_v<std::decay_t<T>, c10::TensorOptions>) {
+    new (dest) IValue(c10::typeMetaToScalarType(arg.dtype()));
+    ++dest;
+    new (dest) IValue(arg.layout());
+    ++dest;
+    new (dest) IValue(arg.device());
+    ++dest;
+    new (dest) IValue(arg.pinned_memory());
+    ++dest;
+  } else {
+    new (dest) IValue(std::forward<T>(arg));
+    ++dest;
+  }
 }
 
-C10_ALWAYS_INLINE_UNLESS_MOBILE void boxToStack(
-    IValue*& dest,
-    c10::TensorOptions options) {
-  new (dest++) IValue(c10::typeMetaToScalarType(options.dtype()));
-  new (dest++) IValue(options.layout());
-  new (dest++) IValue(options.device());
-  new (dest++) IValue(options.pinned_memory());
-}
-
-inline void boxArgsToStack(IValue*& /*unused*/) {}
-
-template <typename T, typename... Args>
+template <typename... Args>
 C10_ALWAYS_INLINE_UNLESS_MOBILE void boxArgsToStack(
     IValue*& dest,
-    T&& arg,
     Args&&... args) {
-  boxToStack(dest, std::forward<T>(arg));
-  boxArgsToStack(dest, std::forward<Args>(args)...);
+  (boxToStack(dest, std::forward<Args>(args)), ...);
 }
 
 //
@@ -159,7 +153,7 @@ struct BoxedBufferGuard final {
 } // namespace detail
 
 template <class... Args>
-torch::jit::Stack boxArgs(Args... args) {
+torch::jit::Stack boxArgs(Args&&... args) {
   constexpr size_t num_boxed = boxed_size<Args...>();
   if constexpr (num_boxed == 0) {
     return torch::jit::Stack();

--- a/aten/src/ATen/core/boxing/impl/boxing.h
+++ b/aten/src/ATen/core/boxing/impl/boxing.h
@@ -10,7 +10,9 @@
 #include <ATen/core/boxing/BoxedKernel.h>
 
 #include <c10/util/Metaprogramming.h>
+#include <cstddef>
 #include <type_traits>
+#include <utility>
 
 namespace c10::impl {
 
@@ -76,18 +78,6 @@ using can_unbox = std::conjunction<
         std::is_same<void, T>>,
     std::negation<std::is_lvalue_reference<T>>>;
 
-//
-// boxArgs - utility for pushing unboxed args onto IValue stack
-//
-template <class... Args>
-torch::jit::Stack boxArgs(Args... args) {
-  // TODO Reuse stack vector instead of allocating?
-  torch::jit::Stack stack;
-  stack.reserve(sizeof...(Args));
-  torch::jit::push(stack, std::forward<Args>(args)...);
-  return stack;
-}
-
 template <class T>
 inline constexpr size_t boxed_size_one() {
   static_assert(
@@ -112,9 +102,13 @@ static inline constexpr size_t boxed_size() {
   return BoxedSize<Args...>::value;
 }
 
-template <typename T>
-C10_ALWAYS_INLINE_UNLESS_MOBILE void boxToStack(IValue*& dest, T& arg) {
-  new (dest++) IValue(arg);
+template <
+    typename T,
+    std::enable_if_t<
+        !std::is_same_v<std::decay_t<T>, c10::TensorOptions>,
+        int> = 0>
+C10_ALWAYS_INLINE_UNLESS_MOBILE void boxToStack(IValue*& dest, T&& arg) {
+  new (dest++) IValue(std::forward<T>(arg));
 }
 
 C10_ALWAYS_INLINE_UNLESS_MOBILE void boxToStack(
@@ -131,10 +125,56 @@ inline void boxArgsToStack(IValue*& /*unused*/) {}
 template <typename T, typename... Args>
 C10_ALWAYS_INLINE_UNLESS_MOBILE void boxArgsToStack(
     IValue*& dest,
-    T& arg,
-    Args&... args) {
-  boxToStack(dest, arg);
-  boxArgsToStack(dest, args...);
+    T&& arg,
+    Args&&... args) {
+  boxToStack(dest, std::forward<T>(arg));
+  boxArgsToStack(dest, std::forward<Args>(args)...);
+}
+
+//
+// boxArgs - utility for boxing unboxed args into an IValue stack
+//
+// The args are boxed into a stack-local buffer and moved into the returned
+// vector by a shared non-template helper, so each instantiation only emits
+// the type-dependent IValue constructions. This keeps the per-signature
+// code size of BoxedKernelWrapper instantiations small (there are hundreds
+// of them in libtorch).
+//
+
+// Moves [begin, end) into a freshly allocated Stack and destroys the moved
+// IValues. On exception (allocation failure) the buffer is left untouched.
+TORCH_API torch::jit::Stack boxedBufferToStack(IValue* begin, IValue* end);
+
+namespace detail {
+// Destroys [begin, cur) on unwind if boxing an argument throws.
+struct BoxedBufferGuard final {
+  IValue* begin;
+  IValue* cur;
+  ~BoxedBufferGuard() {
+    while (cur != begin) {
+      (--cur)->~IValue();
+    }
+  }
+};
+} // namespace detail
+
+template <class... Args>
+torch::jit::Stack boxArgs(Args... args) {
+  constexpr size_t num_boxed = boxed_size<Args...>();
+  if constexpr (num_boxed == 0) {
+    return torch::jit::Stack();
+  } else {
+    // See Dispatcher::callWithDispatchKeySlowPath for why this is not an
+    // std::array<IValue, num_boxed>.
+    // NOLINTNEXTLINE(*array*)
+    alignas(IValue) std::byte buffer[num_boxed * sizeof(IValue)];
+    IValue* const buffer_begin = reinterpret_cast<IValue*>(buffer);
+    detail::BoxedBufferGuard guard{buffer_begin, buffer_begin};
+    boxArgsToStack(guard.cur, std::forward<Args>(args)...);
+    torch::jit::Stack stack = boxedBufferToStack(guard.begin, guard.cur);
+    guard.cur = guard.begin;
+    return stack;
+  }
 }
 
 //

--- a/aten/src/ATen/core/boxing/impl/boxing.h
+++ b/aten/src/ATen/core/boxing/impl/boxing.h
@@ -119,6 +119,11 @@ template <typename... Args>
 C10_ALWAYS_INLINE_UNLESS_MOBILE void boxArgsToStack(
     IValue*& dest,
     Args&&... args) {
+  // Argument order matters here: each boxToStack advances dest, so the
+  // arguments have to be boxed into consecutive slots left to right. The
+  // built-in comma operator sequences its left operand before its right,
+  // so this fold evaluates the calls strictly in pack order. (boxToStack
+  // returns void, so no overloaded operator, can be selected instead.)
   (boxToStack(dest, std::forward<Args>(args)), ...);
 }
 

--- a/torchgen/dest/register_dispatch_key.py
+++ b/torchgen/dest/register_dispatch_key.py
@@ -204,6 +204,88 @@ void check_inplace(const Tensor &self, IntArrayRef sizes, const TensorOptions &o
     ]
 
 
+# Dispatch keys whose structured wrappers manage a device guard in their
+# set_output functions (see maybe_set_guard in gen_class_set_output_body).
+GUARDED_SET_OUTPUT_KEYS = (
+    DispatchKey.CUDA,
+    DispatchKey.MPS,
+    DispatchKey.XPU,
+    DispatchKey.CompositeExplicitAutogradNonFunctional,
+)
+
+
+def structured_set_output_guard_type(backend_index: BackendIndex) -> str | None:
+    if backend_index.dispatch_key not in GUARDED_SET_OUTPUT_KEYS:
+        return None
+    if backend_index.dispatch_key == DispatchKey.CUDA:
+        return "c10::cuda::OptionalCUDAGuard"
+    # TODO: MPS should move to OptionalMPSGuard.
+    return "c10::OptionalDeviceGuard"
+
+
+# The set_output_strided/set_output_raw_strided overrides generated for every
+# structured operator only differ in the final super call; the rest of the
+# body is hoisted into these per-file helpers so it is emitted once per
+# Register file instead of once per operator (BOLT profiling showed thousands
+# of byte-identical copies of these bodies in libtorch).
+def gen_structured_set_output_helpers(backend_index: BackendIndex) -> list[str]:
+    if not gen_create_out_helper(backend_index):
+        return []
+
+    guard_type = structured_set_output_guard_type(backend_index)
+    if guard_type is not None:
+        guard_param = f"{guard_type}& guard_, "
+        maybe_set_guard = """\
+  auto current_device = guard_.current_device();
+  if (C10_UNLIKELY(current_device.has_value())) {
+    TORCH_INTERNAL_ASSERT(*current_device == options.device(),
+      "structured kernels don't support multi-device outputs");
+  } else {
+    guard_.reset_device(options.device());
+  }
+"""
+    else:
+        guard_param = ""
+        maybe_set_guard = ""
+
+    create_proxy = """\
+  if (maybe_proxy != nullptr) {
+    auto proxy = maybe_create_proxy(out, sizes, strides, options);
+    if (C10_UNLIKELY(proxy.has_value())) {
+      *maybe_proxy = std::move(proxy).value();
+    }
+  }
+"""
+
+    helpers = [
+        f"""
+void set_output_functional(
+    {guard_param}Tensor& output,
+    IntArrayRef sizes, IntArrayRef strides, const TensorOptions& options) {{
+{maybe_set_guard}  output = create_out(sizes, strides, options);
+}}
+""",
+        f"""
+void set_output_inplace(
+    {guard_param}const Tensor& out, std::optional<Tensor>* maybe_proxy,
+    IntArrayRef sizes, IntArrayRef strides, const TensorOptions& options) {{
+{maybe_set_guard}  check_inplace(out, sizes, options);
+{create_proxy}}}
+""",
+    ]
+    if gen_resize_out_helper(backend_index):
+        helpers.append(
+            f"""
+void set_output_out(
+    {guard_param}const Tensor& out, std::optional<Tensor>* maybe_proxy,
+    IntArrayRef sizes, IntArrayRef strides, const TensorOptions& options) {{
+{maybe_set_guard}  resize_out(out, sizes, strides, options);
+{create_proxy}}}
+"""
+        )
+    return helpers
+
+
 def gen_registration_helpers(backend_index: BackendIndex) -> list[str]:
     return [
         'C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wunused-function")',
@@ -211,6 +293,7 @@ def gen_registration_helpers(backend_index: BackendIndex) -> list[str]:
         *gen_resize_out_helper(backend_index),
         *gen_check_inplace_helper(backend_index),
         *gen_maybe_create_proxy_helper(backend_index),
+        *gen_structured_set_output_helpers(backend_index),
         "C10_DIAGNOSTIC_POP()",
     ]
 
@@ -615,34 +698,12 @@ void set_output_{name}(
 """
 
     def gen_class_set_output_body(self, k: SchemaKind, maybe_create_proxy: bool) -> str:
-        if self.backend_index.dispatch_key in [
-            DispatchKey.CUDA,
-            DispatchKey.MPS,
-            DispatchKey.XPU,
-            DispatchKey.CompositeExplicitAutogradNonFunctional,
-        ]:
-            maybe_set_guard = """
-auto current_device = guard_.current_device();
-if (C10_UNLIKELY(current_device.has_value())) {
-  TORCH_INTERNAL_ASSERT(*current_device == options.device(),
-    "structured kernels don't support multi-device outputs");
-} else {
-  guard_.reset_device(options.device());
-}
-"""
-            maybe_set_guard_line = maybe_set_guard + "\n"
-        else:
-            maybe_set_guard_line = maybe_set_guard = ""
-
-        if maybe_create_proxy:
-            create_proxy = """
-auto maybe_proxy = maybe_create_proxy(out, sizes, strides, options);
-if (C10_UNLIKELY(maybe_proxy.has_value())) {
-    proxy_outputs_[output_idx] = std::move(maybe_proxy).value();
-}
-"""
-        else:
-            create_proxy = ""
+        guard_arg = (
+            "guard_, "
+            if structured_set_output_guard_type(self.backend_index) is not None
+            else ""
+        )
+        proxy_arg = "&proxy_outputs_[output_idx]" if maybe_create_proxy else "nullptr"
 
         if k is SchemaKind.functional:
             if self.backend_index.dispatch_key not in (
@@ -658,18 +719,11 @@ if (C10_UNLIKELY(maybe_proxy.has_value())) {
                     f"Unexpected dispatch key {self.backend_index.dispatch_key} "
                     "for functional schema"
                 )
-            return f"""{maybe_set_guard_line}
-outputs_[output_idx] = create_out(sizes, strides, options);"""
+            return f"set_output_functional({guard_arg}outputs_[output_idx], sizes, strides, options);"
         elif k is SchemaKind.inplace:
-            return f"""{maybe_set_guard_line}
-const auto& out = outputs_[output_idx].get();
-check_inplace(out, sizes, options);
-{create_proxy}"""
+            return f"set_output_inplace({guard_arg}outputs_[output_idx].get(), {proxy_arg}, sizes, strides, options);"
         elif k is SchemaKind.out:
-            return f"""{maybe_set_guard_line}
-const auto& out = outputs_[output_idx].get();
-resize_out(out, sizes, strides, options);
-{create_proxy}"""
+            return f"set_output_out({guard_arg}outputs_[output_idx].get(), {proxy_arg}, sizes, strides, options);"
         elif k is SchemaKind.mutable or k is SchemaKind.scratch:
             raise AssertionError(
                 f"{k} structured operators are currently not supported"
@@ -716,22 +770,8 @@ resize_out(out, sizes, strides, options);
         else:
             raise RuntimeError(f"Unsupported SchemaKind {k}")
 
-        if self.backend_index.dispatch_key == DispatchKey.CUDA:
-            guard_field = "c10::cuda::OptionalCUDAGuard guard_;"
-        elif (
-            self.backend_index.dispatch_key
-            == DispatchKey.CompositeExplicitAutogradNonFunctional
-        ):
-            guard_field = "c10::OptionalDeviceGuard guard_;"
-        elif self.backend_index.dispatch_key == DispatchKey.MPS:
-            # TODO: Move to OptionalMPSGuard.
-            guard_field = "c10::OptionalDeviceGuard guard_;"
-        elif self.backend_index.dispatch_key == DispatchKey.XPU:
-            guard_field = "c10::OptionalDeviceGuard guard_;"
-        elif self.backend_index.dispatch_key == DispatchKey.MTIA:
-            guard_field = "c10::OptionalDeviceGuard guard_;"
-        else:
-            guard_field = ""
+        guard_type = structured_set_output_guard_type(self.backend_index)
+        guard_field = f"{guard_type} guard_;" if guard_type is not None else ""
 
         indent = " " * 4
         class_ctor_str = self.gen_class_ctor(k, class_name, len(f.func.returns))

--- a/torchgen/dest/register_dispatch_key.py
+++ b/torchgen/dest/register_dispatch_key.py
@@ -211,6 +211,88 @@ void check_inplace(const Tensor &self, IntArrayRef sizes, const TensorOptions &o
     ]
 
 
+# Dispatch keys whose structured wrappers manage a device guard in their
+# set_output functions (see maybe_set_guard in gen_class_set_output_body).
+GUARDED_SET_OUTPUT_KEYS = (
+    DispatchKey.CUDA,
+    DispatchKey.MPS,
+    DispatchKey.XPU,
+    DispatchKey.CompositeExplicitAutogradNonFunctional,
+)
+
+
+def structured_set_output_guard_type(backend_index: BackendIndex) -> str | None:
+    if backend_index.dispatch_key not in GUARDED_SET_OUTPUT_KEYS:
+        return None
+    if backend_index.dispatch_key == DispatchKey.CUDA:
+        return "c10::cuda::OptionalCUDAGuard"
+    # TODO: MPS should move to OptionalMPSGuard.
+    return "c10::OptionalDeviceGuard"
+
+
+# The set_output_strided/set_output_raw_strided overrides generated for every
+# structured operator only differ in the final super call; the rest of the
+# body is hoisted into these per-file helpers so it is emitted once per
+# Register file instead of once per operator (BOLT profiling showed thousands
+# of byte-identical copies of these bodies in libtorch).
+def gen_structured_set_output_helpers(backend_index: BackendIndex) -> list[str]:
+    if not gen_create_out_helper(backend_index):
+        return []
+
+    guard_type = structured_set_output_guard_type(backend_index)
+    if guard_type is not None:
+        guard_param = f"{guard_type}& guard_, "
+        maybe_set_guard = """\
+  auto current_device = guard_.current_device();
+  if (C10_UNLIKELY(current_device.has_value())) {
+    TORCH_INTERNAL_ASSERT(*current_device == options.device(),
+      "structured kernels don't support multi-device outputs");
+  } else {
+    guard_.reset_device(options.device());
+  }
+"""
+    else:
+        guard_param = ""
+        maybe_set_guard = ""
+
+    create_proxy = """\
+  if (maybe_proxy != nullptr) {
+    auto proxy = maybe_create_proxy(out, sizes, strides, options);
+    if (C10_UNLIKELY(proxy.has_value())) {
+      *maybe_proxy = std::move(proxy).value();
+    }
+  }
+"""
+
+    helpers = [
+        f"""
+void set_output_functional(
+    {guard_param}Tensor& output,
+    IntArrayRef sizes, IntArrayRef strides, const TensorOptions& options) {{
+{maybe_set_guard}  output = create_out(sizes, strides, options);
+}}
+""",
+        f"""
+void set_output_inplace(
+    {guard_param}const Tensor& out, std::optional<Tensor>* maybe_proxy,
+    IntArrayRef sizes, IntArrayRef strides, const TensorOptions& options) {{
+{maybe_set_guard}  check_inplace(out, sizes, options);
+{create_proxy}}}
+""",
+    ]
+    if gen_resize_out_helper(backend_index):
+        helpers.append(
+            f"""
+void set_output_out(
+    {guard_param}const Tensor& out, std::optional<Tensor>* maybe_proxy,
+    IntArrayRef sizes, IntArrayRef strides, const TensorOptions& options) {{
+{maybe_set_guard}  resize_out(out, sizes, strides, options);
+{create_proxy}}}
+"""
+        )
+    return helpers
+
+
 def gen_registration_helpers(backend_index: BackendIndex) -> list[str]:
     return [
         'C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wunused-function")',
@@ -218,6 +300,7 @@ def gen_registration_helpers(backend_index: BackendIndex) -> list[str]:
         *gen_resize_out_helper(backend_index),
         *gen_check_inplace_helper(backend_index),
         *gen_maybe_create_proxy_helper(backend_index),
+        *gen_structured_set_output_helpers(backend_index),
         "C10_DIAGNOSTIC_POP()",
     ]
 
@@ -629,34 +712,12 @@ void set_output_{name}(
 """
 
     def gen_class_set_output_body(self, k: SchemaKind, maybe_create_proxy: bool) -> str:
-        if self.backend_index.dispatch_key in [
-            DispatchKey.CUDA,
-            DispatchKey.MPS,
-            DispatchKey.XPU,
-            DispatchKey.CompositeExplicitAutogradNonFunctional,
-        ]:
-            maybe_set_guard = """
-auto current_device = guard_.current_device();
-if (C10_UNLIKELY(current_device.has_value())) {
-  TORCH_INTERNAL_ASSERT(*current_device == options.device(),
-    "structured kernels don't support multi-device outputs");
-} else {
-  guard_.reset_device(options.device());
-}
-"""
-            maybe_set_guard_line = maybe_set_guard + "\n"
-        else:
-            maybe_set_guard_line = maybe_set_guard = ""
-
-        if maybe_create_proxy:
-            create_proxy = """
-auto maybe_proxy = maybe_create_proxy(out, sizes, strides, options);
-if (C10_UNLIKELY(maybe_proxy.has_value())) {
-    proxy_outputs_[output_idx] = std::move(maybe_proxy).value();
-}
-"""
-        else:
-            create_proxy = ""
+        guard_arg = (
+            "guard_, "
+            if structured_set_output_guard_type(self.backend_index) is not None
+            else ""
+        )
+        proxy_arg = "&proxy_outputs_[output_idx]" if maybe_create_proxy else "nullptr"
 
         if k is SchemaKind.functional:
             if self.backend_index.dispatch_key not in (
@@ -672,18 +733,11 @@ if (C10_UNLIKELY(maybe_proxy.has_value())) {
                     f"Unexpected dispatch key {self.backend_index.dispatch_key} "
                     "for functional schema"
                 )
-            return f"""{maybe_set_guard_line}
-outputs_[output_idx] = create_out(sizes, strides, options);"""
+            return f"set_output_functional({guard_arg}outputs_[output_idx], sizes, strides, options);"
         elif k is SchemaKind.inplace:
-            return f"""{maybe_set_guard_line}
-const auto& out = outputs_[output_idx].get();
-check_inplace(out, sizes, options);
-{create_proxy}"""
+            return f"set_output_inplace({guard_arg}outputs_[output_idx].get(), {proxy_arg}, sizes, strides, options);"
         elif k is SchemaKind.out:
-            return f"""{maybe_set_guard_line}
-const auto& out = outputs_[output_idx].get();
-resize_out(out, sizes, strides, options);
-{create_proxy}"""
+            return f"set_output_out({guard_arg}outputs_[output_idx].get(), {proxy_arg}, sizes, strides, options);"
         elif k is SchemaKind.mutable or k is SchemaKind.scratch:
             raise AssertionError(
                 f"{k} structured operators are currently not supported"
@@ -730,22 +784,8 @@ resize_out(out, sizes, strides, options);
         else:
             raise RuntimeError(f"Unsupported SchemaKind {k}")
 
-        if self.backend_index.dispatch_key == DispatchKey.CUDA:
-            guard_field = "c10::cuda::OptionalCUDAGuard guard_;"
-        elif (
-            self.backend_index.dispatch_key
-            == DispatchKey.CompositeExplicitAutogradNonFunctional
-        ):
-            guard_field = "c10::OptionalDeviceGuard guard_;"
-        elif self.backend_index.dispatch_key == DispatchKey.MPS:
-            # TODO: Move to OptionalMPSGuard.
-            guard_field = "c10::OptionalDeviceGuard guard_;"
-        elif self.backend_index.dispatch_key == DispatchKey.XPU:
-            guard_field = "c10::OptionalDeviceGuard guard_;"
-        elif self.backend_index.dispatch_key == DispatchKey.MTIA:
-            guard_field = "c10::OptionalDeviceGuard guard_;"
-        else:
-            guard_field = ""
+        guard_type = structured_set_output_guard_type(self.backend_index)
+        guard_field = f"{guard_type} guard_;" if guard_type is not None else ""
 
         indent = " " * 4
         class_ctor_str = self.gen_class_ctor(k, class_name, len(f.func.returns))


### PR DESCRIPTION
## Summary

Two targeted reductions of hot binary footprint in libtorch, motivated by
BOLT profiling (see pytorch/pytorch#186245).

### 1. Shrink per-signature code emitted by `boxArgs` / `BoxedKernelWrapper`

`BoxedKernelWrapper::call` instantiations are one of the largest sources of
duplicated machine code in libtorch: 76 profiled instantiations averaging
~700 instructions each, with the hottest (`Tensor(const Tensor&)`) reaching
~12.8k instructions. Most of that code is type-independent — constructing the
IValue stack vector inlines the `reserve`/`emplace_back` capacity checks, the
vector reallocation slow path, and unwind cleanup separately into every
instantiation.

`boxArgs` now boxes arguments into an exact-size stack buffer using the same
`boxed_size`/`boxArgsToStack` machinery the dispatcher already uses for
`RecordFunction` inputs, then hands the buffer to a shared non-template helper
(`boxedBufferToStack`) that performs the single allocation and type-erased
moves into the vector. Each instantiation is left with only the
type-dependent IValue constructions plus one call.

`boxToStack`/`boxArgsToStack` switch from lvalue-reference parameters to
constrained forwarding references so `boxArgs` can forward by-value arguments
as rvalues, matching the move semantics `torch::jit::push` previously
provided. The `TensorOptions` overload still wins overload resolution via the
`enable_if` exclusion.

### 2. Hoist structured `set_output` bodies into per-file codegen helpers

Every structured operator's generated `RegisterCPU.cpp`, `RegisterCUDA.cpp`,
etc. carries two `set_output_strided`/`set_output_raw_strided` overrides
whose bodies are identical across operators: the optional device-guard block,
`create_out`/`check_inplace`/`resize_out`, and proxy-output handling. Only
the trailing `super` call differs per operator.

The bodies now live in three per-file helpers (`set_output_functional`,
`set_output_inplace`, `set_output_out`) generated next to the existing
`create_out`/`resize_out` helpers; each per-operator override reduces to a
single helper call plus the super call. This removes ~22k lines from the
generated Register files for CPU/CUDA/Meta/CENF and deduplicates the
corresponding machine code at the source level — benefiting both
ICF-capable linkers and BOLT.

## Testing

Built and ran successfully across >100 workload configurations on an
aarch64 / GB200 system using NVIDIA's 26.05 and 26.06 build of libtorch.

BOLT perf comparison (~42 BOLTed workloads, modified vs. unmodified baseline):
geomean **+0.13 %**; tacotron2 +4.9 %, deepseek +2.0 %, nemotron-h +1.2 %,
no regressions outside noise. Full CI (test_dispatch, test_ops) is still
needed before merge.

## AI Disclosure

These changes were developed with AI assistance (Claude Fable 5,
`Co-Authored-By` in each commit). The implementation has been read,
understood, built, and validated end-to-end by the author.