### PR TITLE
perf(dynamo): port historical fast plan to 2.10

### DIFF
--- a/benchmarks/dynamo/microbenchmarks/dynamo_guard_lookup_stats.py
+++ b/benchmarks/dynamo/microbenchmarks/dynamo_guard_lookup_stats.py
@@ -1,0 +1,224 @@
+import argparse
+import json
+import os
+import statistics
+import subprocess
+import sys
+import time
+
+
+def fn(x, y, scale: int):
+    return (x + y) * scale
+
+
+def avg_ns(stats, key):
+    count = max(int(stats["lookup_count"]), 1)
+    return int(stats.get(key, 0)) / count
+
+
+def child_main(args):
+    import torch
+    from torch._C._dynamo import guards
+
+    opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+    x = torch.randn(4)
+    y = torch.randn(4)
+
+    for _ in range(args.warmup):
+        opt_fn(x, y, 3)
+
+    guards.reset_guard_lookup_stats()
+    start_ns = time.perf_counter_ns()
+    for _ in range(args.iters):
+        opt_fn(x, y, 3)
+    elapsed_ns = time.perf_counter_ns() - start_ns
+
+    stats = guards.get_guard_lookup_stats()
+    accessor_type_stats = {
+        str(name): dict(value)
+        for name, value in stats["root_guard_accessor_type_stats"].items()
+    }
+    accessor_detail_topk = {
+        str(name): dict(value)
+        for name, value in stats["root_guard_accessor_detail_topk"].items()
+    }
+    payload = {
+        "iters": args.iters,
+        "call_avg_ns": elapsed_ns / args.iters,
+        "lookup_count": stats["lookup_count"],
+        "lookup_avg_ns": avg_ns(stats, "lookup_total_ns"),
+        "backend_match_avg_ns": avg_ns(stats, "backend_match_ns"),
+        "slow_guard_avg_ns": avg_ns(stats, "slow_guard_ns"),
+        "move_to_front_avg_ns": avg_ns(stats, "move_to_front_ns"),
+        "root_guard_avg_ns": avg_ns(stats, "root_guard_total_ns"),
+        "root_guard_lock_avg_ns": avg_ns(stats, "root_guard_lock_ns"),
+        "root_guard_local_state_avg_ns": avg_ns(
+            stats, "root_guard_local_state_ns"
+        ),
+        "root_guard_leaf_avg_ns": avg_ns(stats, "root_guard_leaf_ns"),
+        "root_guard_accessor_avg_ns": avg_ns(stats, "root_guard_accessor_ns"),
+        "root_guard_tls_avg_ns": avg_ns(stats, "root_guard_tls_ns"),
+        "root_guard_count": stats["root_guard_count"],
+        "cache_entry_count_sum": stats["cache_entry_count_sum"],
+        "cache_entry_hit_index_sum": stats["cache_entry_hit_index_sum"],
+        "root_guard_accessor_type_stats": accessor_type_stats,
+        "root_guard_accessor_detail_topk": accessor_detail_topk,
+        "unsafe_mock_guard_bypass_enabled": bool(
+            stats["unsafe_mock_guard_bypass_enabled"]
+        ),
+        "unsafe_mock_guard_bypass_count": stats["unsafe_mock_guard_bypass_count"],
+        "unsafe_mock_guard_bypass_hit_index_sum": stats[
+            "unsafe_mock_guard_bypass_hit_index_sum"
+        ],
+    }
+    print(json.dumps(payload, sort_keys=True))
+
+
+def run_once(iters, warmup):
+    env = os.environ.copy()
+    env["TORCHDYNAMO_GUARD_LOOKUP_STATS"] = "1"
+    if os.environ.get("TORCHDYNAMO_UNSAFE_MOCK_GUARD_BYPASS") == "1":
+        env["TORCHDYNAMO_UNSAFE_MOCK_GUARD_BYPASS"] = "1"
+    output = subprocess.check_output(
+        [
+            sys.executable,
+            __file__,
+            "--child",
+            "--iters",
+            str(iters),
+            "--warmup",
+            str(warmup),
+        ],
+        env=env,
+        text=True,
+    )
+    return json.loads(output.splitlines()[-1])
+
+
+def median(rows, key):
+    return statistics.median(float(row[key]) for row in rows)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--iters", type=int, default=10000)
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--repeats", type=int, default=5)
+    parser.add_argument("--child", action="store_true")
+    args = parser.parse_args()
+
+    if args.child:
+        child_main(args)
+        return
+
+    rows = [run_once(args.iters, args.warmup) for _ in range(args.repeats)]
+
+    columns = [
+        "call_us",
+        "lookup_us",
+        "backend_us",
+        "slow_guard_us",
+        "move_to_front_us",
+        "root_guard_us",
+        "root_lock_us",
+        "root_local_state_us",
+        "root_leaf_us",
+        "root_accessor_us",
+        "root_tls_us",
+        "lookup_count",
+        "root_guard_count",
+        "mock_bypass_count",
+    ]
+    values = [
+        f"{median(rows, 'call_avg_ns') / 1000:.3f}",
+        f"{median(rows, 'lookup_avg_ns') / 1000:.3f}",
+        f"{median(rows, 'backend_match_avg_ns') / 1000:.3f}",
+        f"{median(rows, 'slow_guard_avg_ns') / 1000:.3f}",
+        f"{median(rows, 'move_to_front_avg_ns') / 1000:.3f}",
+        f"{median(rows, 'root_guard_avg_ns') / 1000:.3f}",
+        f"{median(rows, 'root_guard_lock_avg_ns') / 1000:.3f}",
+        f"{median(rows, 'root_guard_local_state_avg_ns') / 1000:.3f}",
+        f"{median(rows, 'root_guard_leaf_avg_ns') / 1000:.3f}",
+        f"{median(rows, 'root_guard_accessor_avg_ns') / 1000:.3f}",
+        f"{median(rows, 'root_guard_tls_avg_ns') / 1000:.3f}",
+        str(int(median(rows, "lookup_count"))),
+        str(int(median(rows, "root_guard_count"))),
+        str(int(median(rows, "unsafe_mock_guard_bypass_count"))),
+    ]
+    print(" ".join(columns))
+    print(" ".join(values))
+    accessor_totals = {}
+    for row in rows:
+        for name, item in row["root_guard_accessor_type_stats"].items():
+            total = accessor_totals.setdefault(
+                name, {"count": 0, "fail_count": 0, "inclusive_ns": 0}
+            )
+            total["count"] += int(item["count"])
+            total["fail_count"] += int(item["fail_count"])
+            total["inclusive_ns"] += int(item["inclusive_ns"])
+
+    print("\naccessor_type_stats:")
+    print("name count fail_count inclusive_us avg_inclusive_us")
+    for name, item in sorted(
+        accessor_totals.items(),
+        key=lambda pair: pair[1]["inclusive_ns"],
+        reverse=True,
+    ):
+        count = max(item["count"], 1)
+        print(
+            " ".join(
+                [
+                    name,
+                    str(item["count"]),
+                    str(item["fail_count"]),
+                    f"{item['inclusive_ns'] / 1000:.3f}",
+                    f"{item['inclusive_ns'] / count / 1000:.3f}",
+                ]
+            )
+        )
+    print("\naccessor_detail_topk:")
+    print("name count fail_count self_us child_us inclusive_us avg_inclusive_us")
+    detail_totals = {}
+    for row in rows:
+        for name, item in row["root_guard_accessor_detail_topk"].items():
+            total = detail_totals.setdefault(
+                name,
+                {
+                    "count": 0,
+                    "fail_count": 0,
+                    "self_ns": 0,
+                    "child_ns": 0,
+                    "inclusive_ns": 0,
+                },
+            )
+            total["count"] += int(item["count"])
+            total["fail_count"] += int(item["fail_count"])
+            total["self_ns"] += int(item["self_ns"])
+            total["child_ns"] += int(item["child_ns"])
+            total["inclusive_ns"] += int(item["inclusive_ns"])
+    for name, item in sorted(
+        detail_totals.items(),
+        key=lambda pair: pair[1]["inclusive_ns"],
+        reverse=True,
+    ):
+        count = max(item["count"], 1)
+        print(
+            " ".join(
+                [
+                    name,
+                    str(item["count"]),
+                    str(item["fail_count"]),
+                    f"{item['self_ns'] / 1000:.3f}",
+                    f"{item['child_ns'] / 1000:.3f}",
+                    f"{item['inclusive_ns'] / 1000:.3f}",
+                    f"{item['inclusive_ns'] / count / 1000:.3f}",
+                ]
+            )
+        )
+
+    print("\nraw_json:")
+    print(json.dumps(rows, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/superpowers/plans/2026-07-15-pytorch-2.10-fast-plan-9163-port.md
+++ b/docs/superpowers/plans/2026-07-15-pytorch-2.10-fast-plan-9163-port.md
@@ -1,0 +1,791 @@
+# PyTorch 2.10 Fast Plan `9163ffc` Port Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Recreate the Fast Plan behavior of tree `9163ffc` on exact PyTorch
+2.10 base `449b176` without importing any post-`9163ffc` hardening.
+
+**Architecture:** Preserve the 2.10 Guard Manager, precompile lookup, LRU,
+root-aware leaf guards, immutable/tag-safe state, and accessor behavior. Add
+the historical statistics, receipt recorder, token matcher, nested Fast Plan,
+and root last-success actual-partial state through the six files changed by the
+exact feature range. Use a read-only manual-base merge tree only as a
+mechanical six-file scaffold, then resolve every conflict with an explicit
+2.10-native rule.
+
+**Tech Stack:** C++17, CPython/pybind11, PyTorch Dynamo Guard Manager, Python
+`unittest`, PowerShell, Git, Linux/AArch64 Release build, JSON microbenchmark.
+
+---
+
+## File Structure
+
+- Modify `torch/csrc/dynamo/guards.cpp`: private statistics, receipt/token
+  model, cold training, nested/root matchers, leaf/accessor instrumentation,
+  bindings, and C++ bridge implementation.
+- Modify `torch/csrc/dynamo/guards.h`: ExtraState bridge declarations and
+  read-only tensor metadata accessors.
+- Modify `torch/csrc/dynamo/extra_state.cpp`: lookup timing, mock bypass,
+  last-success invocation, receipt reset, and 2.10 LRU-compatible accounting.
+- Modify `torch/csrc/dynamo/extra_state.h`: opaque receipt ownership.
+- Modify `test/dynamo/test_guard_manager.py`: the 36 final `9163ffc` behavior
+  contracts merged with all existing 2.10 tests.
+- Create
+  `benchmarks/dynamo/microbenchmarks/dynamo_guard_lookup_stats.py`: historical
+  lookup statistics and timing runner.
+- Modify
+  `docs/superpowers/specs/2026-07-15-pytorch-2.10-fast-plan-9163-port-design.md`:
+  record written approval and the exact six-file surface.
+- Create this implementation plan.
+
+No other tracked file is in scope unless a matching 2.10 compile error proves
+a concrete compatibility dependency.
+
+## Fixed References
+
+```text
+2.10 base       449b1768410104d3ed79d3bcfe4ba1d65c7f22c0
+feature base    9ebc62ec6becf4f78606a668d4783269b7592f40
+semantic tree   9163ffcaa12e2efa6d19869fb9a25616b4c36961
+merge scaffold  cbda19bab053ce494ee8a6e51705b8f536c7ac22
+target branch   codex/2.10-9163ffc
+```
+
+The scaffold is reproducible with:
+
+```powershell
+git merge-tree --write-tree `
+  --merge-base=9ebc62ec6becf4f78606a668d4783269b7592f40 `
+  449b1768410104d3ed79d3bcfe4ba1d65c7f22c0 `
+  9163ffcaa12e2efa6d19869fb9a25616b4c36961
+```
+
+Expected: exit 1 because selected files contain conflicts, with the first
+output line equal to `cbda19b...`. Never checkout the whole tree; it contains
+unrelated historical upstream drift.
+
+### Task 1: Commit the approved specification and executable plan
+
+**Files:**
+
+- Modify:
+  `docs/superpowers/specs/2026-07-15-pytorch-2.10-fast-plan-9163-port-design.md`
+- Create:
+  `docs/superpowers/plans/2026-07-15-pytorch-2.10-fast-plan-9163-port.md`
+
+- [ ] **Step 1: Verify the design correction**
+
+Run:
+
+```powershell
+rg -n 'Written-spec review|guards\.h|extra_state|test_guard_manager|dynamo_guard_lookup_stats' `
+  docs/superpowers/specs/2026-07-15-pytorch-2.10-fast-plan-9163-port-design.md
+```
+
+Expected: written approval plus exactly the six historical feature files; no
+`torch/_dynamo/guards.py` primary edit.
+
+- [ ] **Step 2: Self-review the plan and specification**
+
+Run:
+
+```powershell
+rg -n 'T[B]D|T[O]DO|F[I]XME|X[X]X|i[m]plement later|f[i]ll in details' `
+  docs/superpowers/specs/2026-07-15-pytorch-2.10-fast-plan-9163-port-design.md `
+  docs/superpowers/plans/2026-07-15-pytorch-2.10-fast-plan-9163-port.md
+git diff --check
+git diff --stat
+```
+
+Expected: no placeholder matches, no whitespace errors, and only the two
+documentation files changed.
+
+- [ ] **Step 3: Commit documentation**
+
+```powershell
+git add -- `
+  docs/superpowers/specs/2026-07-15-pytorch-2.10-fast-plan-9163-port-design.md `
+  docs/superpowers/plans/2026-07-15-pytorch-2.10-fast-plan-9163-port.md
+$message = @'
+docs(dynamo): plan 2.10 fast plan port
+
+Record the approved semantic boundary and the executable TDD sequence for
+porting the historical Fast Plan behavior onto the exact 2.10 base.
+'@
+git commit -m $message
+```
+
+Expected: a conventional documentation commit whose parent is `f1c8d19e`.
+
+### Task 2: Install the historical behavior contracts before product code
+
+**Files:**
+
+- Modify: `test/dynamo/test_guard_manager.py`
+- Create:
+  `benchmarks/dynamo/microbenchmarks/dynamo_guard_lookup_stats.py`
+
+- [ ] **Step 1: Apply only the test and benchmark scaffold**
+
+Run this bulk mechanical merge; do not include product files yet:
+
+```powershell
+git diff 449b1768410104d3ed79d3bcfe4ba1d65c7f22c0 `
+  cbda19bab053ce494ee8a6e51705b8f536c7ac22 -- `
+  test/dynamo/test_guard_manager.py `
+  benchmarks/dynamo/microbenchmarks/dynamo_guard_lookup_stats.py |
+  git apply --whitespace=nowarn -
+```
+
+Expected: the test file contains one import conflict and the benchmark has no
+conflict.
+
+- [ ] **Step 2: Resolve the single import conflict**
+
+Retain the combined import block:
+
+```python
+import abc
+import functools
+import inspect
+import json
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+import weakref
+```
+
+Remove all `<<<<<<<`, `=======`, and `>>>>>>>` lines.
+
+- [ ] **Step 3: Verify all 36 historical contracts are present**
+
+The exact added method names are:
+
+```text
+test_guard_lookup_stats_api_records_cache_hits
+test_guard_lookup_stats_records_accessor_types
+test_guard_lookup_stats_records_leaf_guards
+test_unsafe_mock_guard_bypass_skips_slow_guard
+test_unsafe_mock_guard_bypass_does_not_require_stats_collection
+test_guard_subtree_probe_is_off_by_default
+test_reset_guard_lookup_stats_does_not_force_collect_perf_counters
+test_guard_subtree_probe_requires_fast_plan
+test_guard_subtree_probe_summary_records_shadow_entries
+test_guard_subtree_probe_detail_is_pruned_to_summary
+test_guard_fast_plan_skips_top_modules
+test_guard_fast_plan_skips_top_module_disabled_reasons
+test_guard_fast_plan_nested_modules_records_hits
+test_guard_fast_plan_blocked_sibling_does_not_disable_clean_nested
+test_guard_fast_plan_partial_hit_checks_unsupported_child
+test_guard_fast_plan_tensor_match_token_hits_and_checks_metadata
+test_guard_fast_plan_tensor_match_token_skips_attr_sources
+test_guard_fast_plan_tensor_match_token_supports_cached_tensor_attr
+test_guard_fast_plan_tensor_match_token_supports_scale_attr
+test_guard_fast_plan_supports_no_tensor_aliasing_token
+test_guard_fast_plan_supports_object_aliasing_token
+test_guard_last_success_shadow_records_lookup_attempts
+test_guard_last_success_full_actual_stays_disabled
+test_guard_last_success_partial_self_hits_with_unstable_global
+test_guard_last_success_partial_does_not_claim_bound_method_token
+test_guard_last_success_partial_shadow_full_is_pruned
+test_guard_last_success_full_actual_disabled_with_stable_global_dict
+test_guard_last_success_respects_global_tensor_replacement
+test_guard_last_success_respects_module_buffer_replacement
+test_guard_last_success_dynamic_shape_inputs_keep_working
+test_guard_last_success_global_dict_ignores_unrelated_version
+test_guard_last_success_supports_default_device_token
+test_guard_last_success_supports_global_state_token
+test_guard_last_success_supports_torch_function_mode_stack_token
+test_guard_fast_plan_subtree_memo_miss_disables_and_falls_back
+test_guard_fast_plan_subtree_memo_detects_list_item_change
+```
+
+Run:
+
+```powershell
+python -m py_compile test/dynamo/test_guard_manager.py `
+  benchmarks/dynamo/microbenchmarks/dynamo_guard_lookup_stats.py
+rg -n '^<<<<<<< |^=======|^>>>>>>> ' `
+  test/dynamo/test_guard_manager.py `
+  benchmarks/dynamo/microbenchmarks/dynamo_guard_lookup_stats.py
+```
+
+Expected: Python compilation succeeds and the marker scan has no matches.
+
+- [ ] **Step 4: Commit the RED contracts**
+
+```powershell
+git add -- test/dynamo/test_guard_manager.py `
+  benchmarks/dynamo/microbenchmarks/dynamo_guard_lookup_stats.py
+$message = @'
+test(dynamo): define fast plan port contracts
+
+Carry the final historical behavior matrix onto the untouched 2.10 tree so
+the matching source build can establish a real RED baseline before product
+code changes.
+'@
+git commit -m $message
+```
+
+Expected: test-only/benchmark commit; no product C++ change.
+
+### Task 3: Build the untouched 2.10 runtime and prove real RED
+
+**Files:** No tracked source changes.
+
+- [ ] **Step 1: Package the branch for the existing AArch64 build host**
+
+Run locally:
+
+```powershell
+New-Item -ItemType Directory -Force C:\work\build-artifacts
+git bundle create C:\work\build-artifacts\pytorch-210-9163.bundle `
+  codex/2.10-9163ffc
+scp C:\work\build-artifacts\pytorch-210-9163.bundle `
+  root@192.168.41.97:/root/pytorch-210-9163.bundle
+```
+
+Expected: the bundle contains the test commit and exact 2.10 ancestry. If the
+host is unavailable, use the already configured AArch64 host with the largest
+free disk and record the substituted hostname; do not use the installed local
+2.7 binary.
+
+- [ ] **Step 2: Create an isolated remote checkout**
+
+Run remotely:
+
+```bash
+git clone -b codex/2.10-9163ffc \
+  /root/pytorch-210-9163.bundle /root/pytorch_210_9163_run_20260715
+cd /root/pytorch_210_9163_run_20260715
+git rev-parse HEAD^
+```
+
+Expected: checkout is isolated and ancestry contains exact `449b176`.
+
+- [ ] **Step 3: Initialize pinned dependencies and build Release CPU Torch**
+
+Run remotely:
+
+```bash
+git submodule sync --recursive
+git submodule update --init --recursive --jobs 16
+python3 -m venv --system-site-packages /root/venvs/pytorch-210-9163
+. /root/venvs/pytorch-210-9163/bin/activate
+python -m pip install -U pip wheel setuptools cmake ninja expecttest hypothesis
+export CMAKE_BUILD_TYPE=Release
+export MAX_JOBS=48
+export USE_CUDA=0
+export USE_ROCM=0
+export USE_NCCL=0
+export USE_DISTRIBUTED=0
+export USE_KINETO=0
+python setup.py develop
+```
+
+Expected: Release build and editable install succeed. Diagnose dependency or
+toolchain failures before changing tracked product code.
+
+- [ ] **Step 4: Execute a representative contract and record RED**
+
+Run remotely from the source root:
+
+```bash
+. /root/venvs/pytorch-210-9163/bin/activate
+python test/dynamo/test_guard_manager.py \
+  -k test_guard_fast_plan_nested_modules_records_hits -v
+```
+
+Expected: the test is discovered and fails because the matching 2.10 binary
+lacks `reset_guard_lookup_stats`, `get_guard_lookup_stats`, or equivalent Fast
+Plan behavior. Import/dependency/build failures are not accepted as RED.
+
+### Task 4: Port the 2.10 bridge and ExtraState ownership
+
+**Files:**
+
+- Modify: `torch/csrc/dynamo/guards.h`
+- Modify: `torch/csrc/dynamo/extra_state.h`
+- Modify: `torch/csrc/dynamo/extra_state.cpp`
+
+- [ ] **Step 1: Apply the selected mechanical scaffold**
+
+```powershell
+git diff 449b1768410104d3ed79d3bcfe4ba1d65c7f22c0 `
+  cbda19bab053ce494ee8a6e51705b8f536c7ac22 -- `
+  torch/csrc/dynamo/guards.h `
+  torch/csrc/dynamo/extra_state.h `
+  torch/csrc/dynamo/extra_state.cpp |
+  git apply --whitespace=nowarn -
+```
+
+Expected: headers are conflict-free; `extra_state.cpp` has exactly three
+conflicts.
+
+- [ ] **Step 2: Resolve backend timing against the 2.10 backend holder**
+
+Use the 2.10 pointer access while adding historical timing:
+
+```cpp
+const uint64_t backend_match_start_ns =
+    collect_stats ? torch::dynamo::guard_lookup_time_ns() : 0;
+bool valid = backend == Py_False ||
+    backend_match(cache_entry.backend.ptr(), backend);
+if (collect_stats) {
+  backend_match_ns +=
+      torch::dynamo::guard_lookup_time_ns() - backend_match_start_ns;
+}
+```
+
+- [ ] **Step 3: Resolve optional LRU movement and stats**
+
+Only move and charge movement time when 2.10 LRU is enabled. Always emit the
+historical lookup aggregate:
+
+```cpp
+if (use_lru) {
+  const uint64_t move_start_ns =
+      collect_stats ? torch::dynamo::guard_lookup_time_ns() : 0;
+  extra_state->move_to_front(found);
+  if (collect_stats) {
+    move_to_front_ns +=
+        torch::dynamo::guard_lookup_time_ns() - move_start_ns;
+  }
+}
+if (collect_stats) {
+  torch::dynamo::record_guard_lookup_stats(
+      torch::dynamo::guard_lookup_time_ns() - lookup_start_ns,
+      backend_match_ns,
+      slow_guard_ns,
+      move_to_front_ns,
+      extra_state->cache_entry_list.size(),
+      index);
+}
+```
+
+- [ ] **Step 4: Resolve receipt reset with both insertion modes**
+
+```cpp
+torch::dynamo::reset_guard_last_success_receipt(
+    extra_state->last_success_receipt);
+std::list<CacheEntry>::iterator new_iter;
+if (use_lru) {
+  extra_state->cache_entry_list.emplace_front(guarded_code, backend);
+  new_iter = extra_state->cache_entry_list.begin();
+} else {
+  extra_state->cache_entry_list.emplace_back(guarded_code, backend);
+  new_iter = std::prev(extra_state->cache_entry_list.end());
+}
+```
+
+Keep the 2.10 precompile-entry loop unchanged. Insert invalidation reset inside
+the existing `orig_code` INCREF/DECREF lifetime window.
+
+- [ ] **Step 5: Verify the bridge diff**
+
+```powershell
+rg -n '^<<<<<<< |^=======|^>>>>>>> ' `
+  torch/csrc/dynamo/guards.h `
+  torch/csrc/dynamo/extra_state.h `
+  torch/csrc/dynamo/extra_state.cpp
+git diff --check
+```
+
+Expected: no markers or whitespace errors.
+
+### Task 5: Port final `9163ffc` statistics, tokens, and plan state
+
+**Files:**
+
+- Modify: `torch/csrc/dynamo/guards.cpp`
+
+- [ ] **Step 1: Apply only the final guards scaffold**
+
+```powershell
+git diff 449b1768410104d3ed79d3bcfe4ba1d65c7f22c0 `
+  cbda19bab053ce494ee8a6e51705b8f536c7ac22 -- `
+  torch/csrc/dynamo/guards.cpp |
+  git apply --whitespace=nowarn -
+```
+
+Expected: exactly 22 conflicts.
+
+- [ ] **Step 2: Resolve includes and namespace infrastructure**
+
+Keep both 2.10 and feature includes:
+
+```cpp
+#include <c10/util/Exception.h>
+#include <c10/util/env.h>
+
+#ifdef USE_MTIA
+#include <ATen/native/mtia/EmptyTensor.h>
+#endif
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+```
+
+Retain the complete historical anonymous-namespace statistics/token block and
+retain the 2.10
+`tls_is_in_mode_without_ignore_compile_internals` definitions immediately
+after it.
+
+- [ ] **Step 3: Resolve root-aware leaf constructors**
+
+For every conflicting leaf class, retain its 2.10 constructor and add the
+historical statistics name declaration. The repeated pattern is:
+
+```cpp
+class LENGTH_CHECK : public LeafGuard {
+ public:
+  LEAF_GUARD_STATS_NAME(LENGTH_CHECK)
+
+  LENGTH_CHECK(
+      RootGuardManager* root_guard_manager,
+      py::object value,
+      py::object verbose_code_parts)
+      : LeafGuard(root_guard_manager, std::move(verbose_code_parts)),
+        _expected_length(py::cast<Py_ssize_t>(value)) {}
+};
+```
+
+Apply the same combined form to `LAMBDA_GUARD`, `EQUALS_MATCH`,
+`DICT_LENGTH`, `NOT_NONE`, `MAPPING_KEYS_MATCH`, `DEFAULT_DEVICE`,
+`GLOBAL_STATE`, `NO_HASATTR`, `DICT_CONTAINS`, `RelationalGuard`,
+`OBJECT_ALIASING`, `DYNAMIC_INDICES`, and `DICT_VERSION`. Preserve all other
+2.10 root-aware constructor signatures.
+
+- [ ] **Step 4: Resolve GlobalState token recording**
+
+Retain 2.10's `GlobalStateGuard* _guard` ownership and add the historical
+`append_subtree_memo_token_template`/token-stat methods. Token construction
+uses the existing `_guard` pointer and must not replace it with the historical
+`unique_ptr` representation.
+
+- [ ] **Step 5: Resolve GuardManager state composition**
+
+Both normal and clone constructors retain `_is_immutable` and initialize the
+historical candidate kind:
+
+```cpp
+_fastplan_candidate_kind =
+    compute_guard_fastplan_candidate_kind(_source);
+```
+
+The class fields retain all 2.10 recursive-dict-tag, tag-safe, immutable, and
+root fields, then add only:
+
+```cpp
+GuardSubtreeProbeState _subtree_probe_state;
+GuardFastPlanCandidateKind _fastplan_candidate_kind{
+    GuardFastPlanCandidateKind::None};
+```
+
+- [ ] **Step 6: Resolve GenericGetAttr without dropping 2.10 semantics**
+
+Keep the historical Stats-OFF direct `PyObject_GenericGetDict` path and its
+Stats-ON detailed path, while retaining 2.10 error clearing, borrowed/new
+reference discipline, and child-manager invocation. Do not add cached-owner
+proofs or later fail-closed accessor checks.
+
+- [ ] **Step 7: Verify all merge markers and final-9163 core symbols**
+
+This check also locks the historical publication threshold at three stable
+training passes; it must not inherit a later admission policy.
+
+```powershell
+rg -n '^<<<<<<< |^=======|^>>>>>>> ' torch/csrc/dynamo/guards.cpp
+rg -n 'GuardLookupStats|GuardSubtreeEntryToken|GuardLastSuccessReceipt|check_nopybind_with_fastplan|run_root_guard_manager_with_last_success_receipt|reset_guard_lookup_stats|get_guard_lookup_stats|shadow_passes >= 3' `
+  torch/csrc/dynamo/guards.cpp
+git diff --check
+```
+
+Expected: no markers; all listed historical symbols present.
+
+- [ ] **Step 8: Audit forbidden post-9163 mechanisms**
+
+```powershell
+rg -n 'owner_proof|strict_owner|relation_sidecar|cross_slice|free_thread|proof_publication|actual_partial_alias_operand_outside_self|GuardLastSuccessCrossRelation' `
+  torch/csrc/dynamo/guards.cpp `
+  torch/csrc/dynamo/guards.h `
+  torch/csrc/dynamo/extra_state.cpp `
+  torch/csrc/dynamo/extra_state.h
+```
+
+Expected: no matches.
+
+### Task 6: Compile, diagnose compatibility gaps, and turn RED GREEN
+
+**Files:** Modify only the five product files when a matching compiler or
+runtime failure proves a 2.10 compatibility issue.
+
+- [ ] **Step 1: Transfer the product tree to the isolated build host**
+
+Stream the four uncommitted product-file changes into the isolated remote
+checkout. The remote starts clean at the same test commit:
+
+```powershell
+git diff --binary HEAD -- `
+  torch/csrc/dynamo/guards.cpp `
+  torch/csrc/dynamo/guards.h `
+  torch/csrc/dynamo/extra_state.cpp `
+  torch/csrc/dynamo/extra_state.h |
+  ssh root@192.168.41.97 `
+    'cd /root/pytorch_210_9163_run_20260715 && git apply --whitespace=nowarn -'
+```
+
+Expected: remote `git diff --stat` matches the local four-file product diff
+while build artifacts and initialized submodules remain available. If a later
+compatibility edit is needed, first reverse the remote product diff with
+`git diff --binary | git apply -R -`, then stream the complete current local
+diff again.
+
+- [ ] **Step 2: Run the matching incremental Release build**
+
+```bash
+. /root/venvs/pytorch-210-9163/bin/activate
+export CMAKE_BUILD_TYPE=Release MAX_JOBS=48
+export USE_CUDA=0 USE_ROCM=0 USE_NCCL=0 USE_DISTRIBUTED=0 USE_KINETO=0
+python setup.py develop
+```
+
+Expected: compilation and linking succeed. For each compiler error, map the
+historical operation to the 2.10 type/API at the exact call site; do not import
+later hardening or change public behavior.
+
+- [ ] **Step 3: Run the focused 36-contract group**
+
+```bash
+. /root/venvs/pytorch-210-9163/bin/activate
+python test/dynamo/test_guard_manager.py -k guard_fast_plan -v
+python test/dynamo/test_guard_manager.py -k guard_last_success -v
+python test/dynamo/test_guard_manager.py -k guard_lookup_stats -v
+python test/dynamo/test_guard_manager.py -k unsafe_mock_guard_bypass -v
+python test/dynamo/test_guard_manager.py -k guard_subtree_probe -v
+```
+
+Expected: all 36 historical contracts pass.
+
+- [ ] **Step 4: Run the full guard-manager suite**
+
+```bash
+. /root/venvs/pytorch-210-9163/bin/activate
+python test/dynamo/test_guard_manager.py -v
+```
+
+Expected: all CPU-applicable tests pass; accelerator-only skips are reported
+separately and no failure is hidden.
+
+- [ ] **Step 5: Commit the native implementation**
+
+After local source parity with the verified remote tree:
+
+```powershell
+git add -- `
+  torch/csrc/dynamo/guards.cpp `
+  torch/csrc/dynamo/guards.h `
+  torch/csrc/dynamo/extra_state.cpp `
+  torch/csrc/dynamo/extra_state.h
+$message = @'
+perf(dynamo): port historical fast plan to 2.10
+
+Recreate the final 9163ffc statistics, nested Fast Plan, and root
+last-success actual-partial behavior on the 2.10 Guard Manager while
+preserving its precompile, LRU, root-aware leaf, and tag-safe changes.
+
+Post-9163 owner, alias, lifetime, and concurrency hardening is intentionally
+excluded to keep the requested historical semantic point.
+'@
+git commit -m $message
+```
+
+Expected: one product commit containing no test, docs, or unrelated file.
+
+### Task 7: Verify default-off parity, schema, fallback, and performance
+
+**Files:** No additional tracked changes unless a test exposes a compatibility
+defect.
+
+- [ ] **Step 1: Verify feature-off parity**
+
+Run the existing 2.10 tests with both Fast Plan and lookup stats removed from
+the environment:
+
+```bash
+env -u TORCHDYNAMO_GUARD_FAST_PLAN \
+    -u TORCHDYNAMO_GUARD_LOOKUP_STATS \
+    python test/dynamo/test_guard_manager.py -v
+```
+
+Expected: the same full-suite pass/skip result as Task 6.
+
+- [ ] **Step 2: Verify the exact statistics schema and reset behavior**
+
+Run the migrated API/accessor/leaf tests together:
+
+```bash
+python test/dynamo/test_guard_manager.py -k guard_lookup_stats -v
+python test/dynamo/test_guard_manager.py \
+  -k reset_guard_lookup_stats_does_not_force_collect_perf_counters -v
+```
+
+Expected: all selected tests pass and default reset does not force collection.
+
+- [ ] **Step 3: Verify real miss fallback and exact-list mutation**
+
+```bash
+python test/dynamo/test_guard_manager.py \
+  -k guard_fast_plan_subtree_memo_miss_disables_and_falls_back -v
+python test/dynamo/test_guard_manager.py \
+  -k guard_fast_plan_subtree_memo_detects_list_item_change -v
+```
+
+Expected: pre-mutation hits, mutation miss, full-guard fallback, and historical
+disable counters all pass.
+
+- [ ] **Step 4: Run Stats-ON diagnostic benchmark**
+
+```bash
+python benchmarks/dynamo/microbenchmarks/dynamo_guard_lookup_stats.py \
+  --iters 1000 --warmup 20 --runs 5
+```
+
+Expected: five valid JSON samples, nonzero lookup count, and internally
+consistent lookup timing/counter fields.
+
+- [ ] **Step 5: Run same-build Stats-OFF Fast Plan A/B**
+
+Run this exact workload in separate processes with Fast Plan OFF and ON, with
+`TORCHDYNAMO_GUARD_LOOKUP_STATS` absent in both:
+
+```bash
+run_fastplan_ab() {
+python - <<'PY'
+import json
+import statistics
+import time
+
+import torch
+
+
+class Block(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = torch.nn.Linear(1, 1)
+
+    def forward(self, x):
+        return self.linear(x)
+
+
+class Model(torch.nn.Module):
+    def __init__(self, depth=256):
+        super().__init__()
+        self.layers = torch.nn.ModuleList(Block() for _ in range(depth))
+
+    def forward(self, x):
+        for layer in self.layers:
+            x = layer(x)
+        return x
+
+
+model = torch.compile(Model().eval(), backend="eager", fullgraph=True)
+x = torch.ones(1, 1)
+for _ in range(8):
+    model(x)
+samples = []
+for _ in range(60):
+    start = time.perf_counter_ns()
+    model(x)
+    samples.append((time.perf_counter_ns() - start) / 1_000_000)
+ordered = sorted(samples)
+print(json.dumps({
+    "median_ms": statistics.median(samples),
+    "p95_ms": ordered[int(len(ordered) * 0.95) - 1],
+}))
+PY
+}
+unset TORCHDYNAMO_GUARD_FAST_PLAN TORCHDYNAMO_GUARD_LOOKUP_STATS
+run_fastplan_ab
+export TORCHDYNAMO_GUARD_FAST_PLAN=1
+unset TORCHDYNAMO_GUARD_LOOKUP_STATS
+run_fastplan_ab
+```
+
+Record median and p95 call time plus actual Fast Plan hit evidence from a
+separate Stats-ON census test.
+
+Expected: ON produces genuine nested/root hits and no gross regression versus
+OFF. Do not claim QianChuan/NPU equivalence from this synthetic A/B.
+
+### Task 8: Final audit, commits, and GitHub publication
+
+**Files:** No new tracked files.
+
+- [ ] **Step 1: Verify ancestry and exact changed-file scope**
+
+```powershell
+git merge-base HEAD 449b1768410104d3ed79d3bcfe4ba1d65c7f22c0
+git diff --name-only 449b1768410104d3ed79d3bcfe4ba1d65c7f22c0..HEAD
+git diff --check 449b1768410104d3ed79d3bcfe4ba1d65c7f22c0..HEAD
+git status --short
+```
+
+Expected: exact base merge-base, only design/plan plus six feature files,
+clean whitespace, and clean worktree.
+
+- [ ] **Step 2: Compare public contracts with exact `9163ffc`**
+
+Confirm the two environment variables, two binding functions, 36 test names,
+1,024-token cap, nested-only candidate return, three-pass enable threshold,
+and representative stats keys in both source trees:
+
+```powershell
+rg -n 'TORCHDYNAMO_GUARD_FAST_PLAN|TORCHDYNAMO_GUARD_LOOKUP_STATS|reset_guard_lookup_stats|get_guard_lookup_stats|kGuardFastPlanMaxTokens|return GuardFastPlanCandidateKind::NestedModules|shadow_passes >= 3' `
+  torch/csrc/dynamo/guards.cpp
+git show 9163ffcaa12e2efa6d19869fb9a25616b4c36961:torch/csrc/dynamo/guards.cpp |
+  rg -n 'TORCHDYNAMO_GUARD_FAST_PLAN|TORCHDYNAMO_GUARD_LOOKUP_STATS|reset_guard_lookup_stats|get_guard_lookup_stats|kGuardFastPlanMaxTokens|return GuardFastPlanCandidateKind::NestedModules|shadow_passes >= 3'
+```
+
+Expected: contract parity; private 2.10 adaptations are documented.
+
+- [ ] **Step 3: Re-run the forbidden-hardening audit**
+
+Use the Task 5 scan and inspect `git log --oneline 9163ffc..6bfeb52` only as
+an exclusion reference.
+
+Expected: no post-9163 owner/alias/lifetime/concurrency hardening appears in
+the target product diff.
+
+- [ ] **Step 4: Push the target branch to the GitHub fork**
+
+Push `codex/2.10-9163ffc` to `113xiaoji/pytorch` using the connected GitHub
+identity. Do not change `main` or `release/2.10` and do not create a pull
+request.
+
+- [ ] **Step 5: Verify the remote ref**
+
+Verify through the GitHub connector that:
+
+```text
+repository: 113xiaoji/pytorch
+branch:     codex/2.10-9163ffc
+merge-base: 449b1768410104d3ed79d3bcfe4ba1d65c7f22c0
+tip:        exact local HEAD
+```
+
+Expected: remote branch exists at the exact verified local commit and the
+fork's `main` and `release/2.10` refs are unchanged.
+
+## Execution Mode
+
+Execute inline in this session with `superpowers:executing-plans`. The user
+requested uninterrupted plan, implementation, and testing and did not
+authorize subagent delegation. Report only after all gates complete or after
+an exhausted external blocker prevents meaningful progress.

--- a/docs/superpowers/specs/2026-07-15-pytorch-2.10-fast-plan-9163-port-design.md
+++ b/docs/superpowers/specs/2026-07-15-pytorch-2.10-fast-plan-9163-port-design.md
@@ -3,7 +3,7 @@
 ## Status
 
 - Conversation design: approved on 2026-07-15
-- Written-spec review: pending
+- Written-spec review: approved on 2026-07-15
 - Implementation: not started
 
 ## Coordinates
@@ -75,8 +75,11 @@ These omissions are deliberate compatibility choices, not oversights.
 The primary implementation surface is:
 
 - `torch/csrc/dynamo/guards.cpp`
-- `torch/_dynamo/guards.py`
+- `torch/csrc/dynamo/guards.h`
+- `torch/csrc/dynamo/extra_state.cpp`
+- `torch/csrc/dynamo/extra_state.h`
 - `test/dynamo/test_guard_manager.py`
+- `benchmarks/dynamo/microbenchmarks/dynamo_guard_lookup_stats.py`
 
 Additional files may change only when a concrete 2.10 build, binding, or test
 integration dependency requires it. Every expansion must be justified in the

--- a/docs/superpowers/specs/2026-07-15-pytorch-2.10-fast-plan-9163-port-design.md
+++ b/docs/superpowers/specs/2026-07-15-pytorch-2.10-fast-plan-9163-port-design.md
@@ -1,0 +1,291 @@
+# PyTorch 2.10 Fast Plan `9163ffc` Semantic Port Design
+
+## Status
+
+- Conversation design: approved on 2026-07-15
+- Written-spec review: pending
+- Implementation: not started
+
+## Coordinates
+
+- Upstream base: `449b1768410104d3ed79d3bcfe4ba1d65c7f22c0`
+- Historical semantic reference:
+  `9163ffcaa12e2efa6d19869fb9a25616b4c36961`
+- Target branch: `codex/2.10-9163ffc`
+- Target fork: `113xiaoji/pytorch`
+
+The target branch must remain a descendant of the exact upstream base. The
+fork's `main` and `release/2.10` refs are not modified by this work.
+
+## Problem
+
+PyTorch 2.10 does not contain the Fast Plan implementation represented by the
+historical `9163ffc` tree. The `9163ffc` commit itself primarily aligns tests;
+the requested behavior is the cumulative Fast Plan implementation present in
+that complete tree, not merely the final commit's textual diff.
+
+The old implementation was built against an earlier Guard Manager layout.
+Applying its patch directly to 2.10 fails because the required state,
+statistics, recorder, token, and test infrastructure is absent or has moved.
+
+## Decision
+
+Implement a minimal, PyTorch-2.10-native semantic port. Recreate the final
+observable behavior of the `9163ffc` tree on the 2.10 Guard Manager instead of
+replaying its intermediate commits or replacing complete 2.10 files.
+
+This decision preserves current upstream code wherever it is unrelated to the
+feature and makes each imported behavior independently reviewable.
+
+## Semantic Boundary
+
+Functional equivalence means preserving the following `9163ffc` contracts:
+
+- Environment controls and their default-off behavior.
+- Guard lookup statistics API, key schema, reset behavior, and counters.
+- Nested-module candidate eligibility and top-module pruning.
+- Stable shadow-training and plan-publication transitions.
+- Token kinds, token matching, duplicate handling, and the 1,024-token cap.
+- Nested full/partial Fast Plan hit, miss, disable, and fallback behavior.
+- Root last-success full/actual-partial training, hit, miss, and fallback.
+- Test-visible result and counter behavior.
+- Stats-OFF hot-path intent and performance characteristics.
+
+The port may change private representation only when the 2.10 API or object
+layout requires it. Such adaptation must not change the contracts above.
+
+## Explicit Non-goals
+
+Do not port or independently recreate hardening added after `9163ffc`,
+including:
+
+- Owner or accessor proof systems.
+- Alias-completeness gates or relation sidecars.
+- Raw-object lifetime or proof-publication hardening.
+- Free-threaded or additional concurrency disable policies.
+- Hardened residual relation evaluation.
+- Coverage-audit schema-v2 observability.
+- Later fail-closed candidate policies.
+- Unrelated guard refactors or performance work.
+
+These omissions are deliberate compatibility choices, not oversights.
+
+## Expected Edit Surface
+
+The primary implementation surface is:
+
+- `torch/csrc/dynamo/guards.cpp`
+- `torch/_dynamo/guards.py`
+- `test/dynamo/test_guard_manager.py`
+
+Additional files may change only when a concrete 2.10 build, binding, or test
+integration dependency requires it. Every expansion must be justified in the
+implementation plan and reviewed as a compatibility adapter, not new feature
+scope.
+
+## Architecture
+
+### 1. External contract and observability
+
+Restore the historical feature controls:
+
+- `TORCHDYNAMO_GUARD_FAST_PLAN`
+- `TORCHDYNAMO_GUARD_LOOKUP_STATS`
+
+Restore the public guard bindings and their historical behavior:
+
+- `reset_guard_lookup_stats(force_enable)`
+- `get_guard_lookup_stats()`
+
+The returned dictionary must use the exact `9163ffc` key set and value types,
+including the Fast Plan, token, disabled-path, tensor-token, and root
+last-success groups. Stats remain disabled unless their historical environment
+or force-enable path enables them.
+
+### 2. Cold receipt recording and training
+
+Adapt receipt recording to the 2.10 Guard Manager nodes and accessors. A normal
+full guard lookup remains the source of truth while the recorder observes the
+checks needed to construct a plan.
+
+Candidate selection retains the historical scope:
+
+- Nested module paths may train.
+- Pruned top-module-only paths do not regain eligibility.
+- Unsupported paths remain unsupported for the same historical reasons.
+
+A candidate must complete the historical three stable shadow passes before a
+plan is published. Unstable receipts reset or disable according to the
+historical state transition. Plans containing more than 1,024 tokens follow
+the historical token-cap disable path.
+
+### 3. Token representation and matcher
+
+Map the historical token set to the corresponding 2.10 guard/accessor data:
+
+- Object-only
+- Exact dict
+- Exact list
+- Exact tuple
+- Tensor match
+- Default device
+- Global state
+- Torch function mode stack
+- No-tensor-aliasing
+- Object aliasing
+- Bound method
+- Frame globals
+
+The matcher preserves the old comparison order, duplicate behavior, timing
+boundaries, miss classification, and counter transitions. It must not add
+owner, alias-completeness, lifetime, or concurrency checks.
+
+### 4. Nested Fast Plan execution
+
+When a nested plan is published, subsequent eligible lookups execute its token
+matcher first. A complete match follows the historical full or partial success
+path. A mismatch records the historical miss and falls back to the complete
+Guard Manager lookup.
+
+The fallback remains authoritative and supplies later training observations.
+No new retry state or fail-closed demotion state is introduced.
+
+### 5. Root last-success execution
+
+Adapt the historical root last-success state to the 2.10 lookup owner. The
+most recently successful Guard Manager may train and publish its historical
+actual or actual-partial token plan. Hits, misses, disabled paths, shadow
+comparisons, partial token accounting, and fallback follow the `9163ffc`
+state machine.
+
+Later root ownership and cross-slice alias protections are explicitly absent.
+
+## Runtime Data Flow
+
+1. At process initialization, read the historical environment controls.
+2. If Fast Plan is disabled, run the unmodified 2.10 lookup path.
+3. If enabled and no plan is published, run the full guard lookup while
+   recording an eligible receipt.
+4. Compare stable training receipts using the historical rules.
+5. Publish a nested or root plan only after the historical training gate.
+6. On a later lookup, execute the published token matcher.
+7. On a hit, use the historical full or residual/partial continuation.
+8. On a mismatch, record the old miss classification and run full lookup.
+9. Update training and last-success state exactly as the historical outcome
+   requires.
+
+Stats-OFF execution bypasses statistics-only timing and aggregation work.
+
+## PyTorch 2.10 Compatibility Rules
+
+Allowed compatibility work includes:
+
+- Mapping renamed or reorganized Guard Manager classes.
+- Mapping 2.10 accessor ownership and traversal APIs.
+- Mapping tensor metadata to the current tensor guard representation.
+- Updating binding declarations to current pybind organization.
+- Updating test helpers to current subprocess and Dynamo test conventions.
+- Resolving compile-only API and type differences.
+
+Compatibility work must not:
+
+- Add a new token or candidate kind.
+- Tighten or widen eligibility beyond the historical behavior.
+- Add a new safety proof, disable reason, or state transition.
+- Change public statistics keys or counter meaning.
+- Substitute a post-`9163ffc` implementation because it is newer.
+
+If a required historical operation has no 2.10 equivalent, implementation
+stops on that path and records a specific compatibility gap for review. It is
+not replaced with a later hardened policy without a new user decision.
+
+## Failure and Fallback Behavior
+
+Unsupported accessors, unstable training, token-cap overflow, token mismatch,
+and incomplete plans use the historical disable, miss, and full-lookup
+fallback behavior. Full guard lookup remains the semantic authority.
+
+The port must not swallow new 2.10 exceptions or convert unrelated upstream
+errors into Fast Plan misses. API adaptation errors are implementation defects
+and must fail tests or compilation rather than silently changing the state
+machine.
+
+## Verification Design
+
+### Equivalence oracle
+
+Use evidence in this priority order:
+
+1. Exact source and tests from the `9163ffc` tree.
+2. Exact statistics schema and state-transition observations from that tree.
+3. Historical matching-build profiles for performance context.
+4. PyTorch 2.10 feature-off behavior for upstream regression protection.
+
+Post-`9163ffc` hardening commits and tests are evidence of accepted historical
+risk only. They are not the functional oracle for this branch.
+
+### TDD sequence
+
+Before product code changes, migrate the smallest representative contracts to
+the untouched 2.10 base and obtain real RED results from a matching source
+build. A missing dependency, source-tree import failure, or unrelated installed
+Torch binary does not count as RED.
+
+Implementation proceeds in independently verifiable stages:
+
+1. Environment, statistics schema, reset, and binding contracts.
+2. Nested candidate and stable-training contracts.
+3. Token-kind hit and miss contracts.
+4. Nested full/partial execution and fallback contracts.
+5. Root last-success actual/actual-partial contracts.
+6. Token-cap, disabled-path, and Stats-OFF contracts.
+
+Each stage requires a RED-to-GREEN transition on the matching 2.10 build.
+
+### Required acceptance gates
+
+- Branch parent/ancestry verifies the exact `449b176` base.
+- Migrated `9163ffc` focused contracts pass.
+- Relevant 2.10 `test_guard_manager.py` tests pass.
+- A Release C++ build completes successfully.
+- Feature-off results match the untouched 2.10 baseline.
+- Stats key set, types, reset semantics, and representative transition counts
+  match the historical contract.
+- Nested and root partial paths produce real hits and correct miss fallback.
+- Stats-OFF A/B uses the same 2.10 build and shows the intended hot path.
+- Final source/diff audit finds none of the explicitly excluded post-9163
+  hardening mechanisms.
+- Final branch status is clean and its remote ref resolves to the verified
+  local commit.
+
+### Performance evidence
+
+Use a same-host, same-build Stats-OFF comparison between Fast Plan ON and OFF.
+A synthetic deep-module topology is sufficient to detect gross hot-path
+regression and prove that real hits occur.
+
+The historical QianChuan/NPU workload is a separate external validation gate.
+If that environment is unavailable, report it as unavailable; do not present a
+synthetic benchmark as equivalent customer-workload evidence.
+
+## Accepted Historical Risks
+
+The `9163ffc` tree predates later fixes for owner completeness, alias closure,
+object lifetime, free-threaded concurrency, proof publication, inherited
+accessor permissiveness, and portions of the historical test harness. The
+target branch intentionally preserves that semantic point.
+
+This design therefore claims functional equivalence to `9163ffc`, not the
+safety properties of later branches. The implementation report must retain
+this distinction explicitly.
+
+## Delivery
+
+1. Commit this approved design on `codex/2.10-9163ffc`.
+2. Obtain written-spec review approval.
+3. Write and approve a file-level TDD implementation plan.
+4. Implement in focused commits on the isolated worktree.
+5. Run the required acceptance gates.
+6. Push the branch to `113xiaoji/pytorch` and verify the remote base and tip.
+
+No pull request is created unless separately requested.

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -2,6 +2,11 @@
 import abc
 import functools
 import inspect
+import json
+import os
+import subprocess
+import sys
+import textwrap
 import unittest
 import weakref
 
@@ -66,6 +71,19 @@ def less_match(x, expected):
 
 def less_match_verbose_code_parts(expected):
     return [f"expected < {expected}"]
+
+
+def run_guard_manager_script(script, *, env_updates=None):
+    env = os.environ.copy()
+    if env_updates:
+        env.update(env_updates)
+    output = subprocess.check_output(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        cwd=os.getcwd(),
+        env=env,
+        text=True,
+    )
+    return json.loads(output.splitlines()[-1])
 
 
 class GuardManagerTests(torch._dynamo.test_case.TestCase):
@@ -899,6 +917,2521 @@ num_guards_executed=0)
 
             foo = (10.0, 11)
             opt_fn(x, foo, bar)
+
+    def test_guard_lookup_stats_api_records_cache_hits(self):
+        def fn(x, y, scale: int):
+            return (x + y) * scale
+
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+        x = torch.randn(4)
+        y = torch.randn(4)
+
+        opt_fn(x, y, 3)
+        guards.reset_guard_lookup_stats(True)
+        before = guards.get_guard_lookup_stats()
+        self.assertEqual(before["lookup_count"], 0)
+
+        opt_fn(x, y, 3)
+
+        after = guards.get_guard_lookup_stats()
+        self.assertGreater(after["lookup_count"], 0)
+        self.assertGreater(after["lookup_total_ns"], 0)
+        self.assertGreater(after["slow_guard_ns"], 0)
+        self.assertGreater(after["root_guard_count"], 0)
+        self.assertGreater(after["root_guard_total_ns"], 0)
+        self.assertFalse(after["unsafe_mock_guard_bypass_enabled"])
+        self.assertEqual(after["unsafe_mock_guard_bypass_count"], 0)
+
+    def test_guard_lookup_stats_records_accessor_types(self):
+        class Foo:
+            def __init__(self, x):
+                self.x = x
+
+        foo = Foo(1)
+
+        guards.reset_guard_lookup_stats(True)
+
+        attr_root = RootGuardManager()
+        attr_root.getattr_manager("x", "x", 1, default_mgr_enum).add_lambda_guard(
+            functools.partial(equals_match, expected=1),
+            equals_match_verbose_code_parts(1),
+        )
+        self.assertTrue(attr_root.check(foo))
+
+        item_root = RootGuardManager()
+        item_root.getitem_manager(0, "", 1, default_mgr_enum).add_lambda_guard(
+            functools.partial(equals_match, expected=1),
+            equals_match_verbose_code_parts(1),
+        )
+        self.assertTrue(item_root.check([1]))
+
+        type_root = RootGuardManager()
+        type_root.getitem_manager("foo", "", foo, default_mgr_enum).type_manager(
+            "", type(foo), default_mgr_enum
+        ).add_lambda_guard(lambda x: x is type(foo), ["type(foo)"])
+        self.assertTrue(type_root.check({"foo": foo}))
+
+        generic_dict_root = RootGuardManager()
+        generic_dict_root.get_generic_dict_manager(
+            "foo.__dict__", foo.__dict__, default_mgr_enum
+        ).add_lambda_guard(lambda x: x["x"] == 1, ["foo.__dict__['x'] == 1"])
+        self.assertTrue(generic_dict_root.check(foo))
+
+        dict_getitem_root = RootGuardManager()
+        dict_getitem_root.dict_getitem_manager(
+            "foo", "D['foo']", foo, default_mgr_enum
+        ).add_lambda_guard(lambda x: x is foo, ["D['foo'] is foo"])
+        self.assertTrue(dict_getitem_root.check({"foo": foo}))
+
+        dict_root = RootGuardManager()
+        f_locals = {"d": {"a": 1}}
+        dict_mgr = dict_root.getitem_manager(
+            "d",
+            "",
+            f_locals["d"],
+            torch._dynamo.guards.GuardManagerType.DICT_GUARD_MANAGER,
+        )
+        dict_mgr.get_key_manager(0, "", "a", default_mgr_enum).add_equals_match_guard(
+            "a",
+            ["dict.keys()[0] == a"],
+        )
+        dict_mgr.get_value_manager(0, "", 1, default_mgr_enum).add_equals_match_guard(
+            1,
+            ["d[0] == 1"],
+        )
+        self.assertTrue(dict_root.check(f_locals))
+
+        accessor_stats = guards.get_guard_lookup_stats()[
+            "root_guard_accessor_type_stats"
+        ]
+        for name in (
+            "GetAttrGuardAccessor",
+            "GetItemGuardAccessor",
+            "TypeGuardAccessor",
+            "DictGetItemGuardAccessor",
+        ):
+            self.assertIn(name, accessor_stats)
+            self.assertGreater(accessor_stats[name]["count"], 0)
+            self.assertGreater(accessor_stats[name]["inclusive_ns"], 0)
+
+        detail_stats = guards.get_guard_lookup_stats()[
+            "root_guard_accessor_detail_topk"
+        ]
+        for name in (
+            "GetItemGuardAccessor",
+            "GetGenericDictGuardAccessor",
+            "DictGetItemGuardAccessor",
+        ):
+            matches = [
+                stats
+                for key, stats in detail_stats.items()
+                if key.startswith(f"{name}:")
+            ]
+            self.assertTrue(
+                matches, f"missing {name}: {sorted(detail_stats)}"
+            )
+            self.assertGreater(matches[0]["count"], 0)
+            self.assertGreater(matches[0]["inclusive_ns"], 0)
+            self.assertIn("self_ns", matches[0])
+            self.assertIn("child_ns", matches[0])
+
+    def test_guard_lookup_stats_records_leaf_guards(self):
+        guards.reset_guard_lookup_stats(True)
+
+        root = RootGuardManager()
+        root.add_type_match_guard(id_type([1, 2]), ["type(x) == list"])
+        root.add_length_check_guard(2, ["len(x) == 2"])
+
+        for _ in range(16):
+            self.assertTrue(root.check([1, 2]))
+            self.assertFalse(root.check((1, 2)))
+
+        stats = guards.get_guard_lookup_stats()
+        leaf_type_stats = stats["root_guard_leaf_type_stats"]
+        for name in ("TYPE_MATCH", "LENGTH_CHECK"):
+            self.assertIn(name, leaf_type_stats)
+            self.assertGreater(leaf_type_stats[name]["count"], 0)
+            self.assertGreater(leaf_type_stats[name]["inclusive_ns"], 0)
+        self.assertGreater(leaf_type_stats["TYPE_MATCH"]["fail_count"], 0)
+
+        leaf_detail_stats = stats["root_guard_leaf_detail_topk"]
+        self.assertTrue(
+            any(
+                key.startswith("TYPE_MATCH:") and item["fail_count"] > 0
+                for key, item in leaf_detail_stats.items()
+            )
+        )
+
+    def test_unsafe_mock_guard_bypass_skips_slow_guard(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+
+SCALE = 3
+
+def fn(x, y):
+    return (x + y) * SCALE
+
+opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+x = torch.randn(4)
+y = torch.randn(4)
+
+expected = fn(x, y)
+assert torch.equal(opt_fn(x, y), expected)
+
+SCALE = 5
+out = opt_fn(x, y)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "unsafe_mock_guard_bypass_enabled": stats[
+        "unsafe_mock_guard_bypass_enabled"
+    ],
+    "stale_cached_result": torch.equal(out, expected),
+    "fresh_result": torch.equal(out, fn(x, y)),
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_UNSAFE_MOCK_GUARD_BYPASS"] = "1"
+        env.pop("TORCHDYNAMO_GUARD_LOOKUP_STATS", None)
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertTrue(stats["unsafe_mock_guard_bypass_enabled"])
+        self.assertTrue(stats["stale_cached_result"])
+        self.assertFalse(stats["fresh_result"])
+
+    def test_unsafe_mock_guard_bypass_does_not_require_stats_collection(self):
+        script = r"""
+import json
+from torch._C._dynamo import guards
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "unsafe_mock_guard_bypass_enabled": stats[
+        "unsafe_mock_guard_bypass_enabled"
+    ],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_UNSAFE_MOCK_GUARD_BYPASS"] = "1"
+        env.pop("TORCHDYNAMO_GUARD_LOOKUP_STATS", None)
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertTrue(stats["unsafe_mock_guard_bypass_enabled"])
+
+    def test_guard_subtree_probe_is_off_by_default(self):
+        guards.reset_guard_lookup_stats()
+        stats = guards.get_guard_lookup_stats()
+
+        self.assertEqual(stats["guard_subtree_probe_mode"], "off")
+        self.assertEqual(stats["guard_subtree_probe_attempt"], 0)
+        self.assertEqual(stats["guard_subtree_probe_entry_match"], 0)
+        self.assertNotIn("guard_subtree_probe_top_paths", stats)
+
+    def test_reset_guard_lookup_stats_does_not_force_collect_perf_counters(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+
+def fn(x):
+    return x + 1
+
+x = torch.randn(4)
+opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+opt_fn(x)
+guards.reset_guard_lookup_stats()
+opt_fn(x)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "lookup_count": stats["lookup_count"],
+    "lookup_total_ns": stats["lookup_total_ns"],
+    "slow_guard_ns": stats["slow_guard_ns"],
+    "root_guard_count": stats["root_guard_count"],
+    "root_guard_total_ns": stats["root_guard_total_ns"],
+    "actual_partial_token_check_ns": stats[
+        "guard_last_success_actual_partial_token_check_ns"
+    ],
+    "probe_attempt": stats["guard_subtree_probe_attempt"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        env.pop("TORCHDYNAMO_GUARD_LOOKUP_STATS", None)
+        env.pop("TORCHDYNAMO_GUARD_SUBTREE_PROBE", None)
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertEqual(stats["lookup_count"], 0)
+        self.assertEqual(stats["lookup_total_ns"], 0)
+        self.assertEqual(stats["slow_guard_ns"], 0)
+        self.assertEqual(stats["root_guard_count"], 0)
+        self.assertEqual(stats["root_guard_total_ns"], 0)
+        self.assertEqual(stats["actual_partial_token_check_ns"], 0)
+        self.assertEqual(stats["probe_attempt"], 0)
+
+    def test_guard_subtree_probe_requires_fast_plan(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+
+class Mod(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.seq = torch.nn.Sequential(torch.nn.Linear(4, 4), torch.nn.ReLU())
+
+    def forward(self, x):
+        return self.seq(x)
+
+model = Mod()
+opt_model = torch.compile(model, backend="eager", fullgraph=True)
+x = torch.randn(2, 4)
+
+opt_model(x)
+guards.reset_guard_lookup_stats()
+for _ in range(3):
+    opt_model(x)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "mode": stats["guard_subtree_probe_mode"],
+    "enabled": stats["guard_fastplan_enabled"],
+    "attempt": stats["guard_subtree_probe_attempt"],
+    "entry_match": stats["guard_subtree_probe_entry_match"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_SUBTREE_PROBE"] = "summary"
+        env.pop("TORCHDYNAMO_GUARD_FAST_PLAN", None)
+        env.pop("TORCHDYNAMO_GUARD_LOOKUP_STATS", None)
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertEqual(stats["mode"], "summary")
+        self.assertFalse(stats["enabled"])
+        self.assertEqual(stats["attempt"], 0)
+        self.assertEqual(stats["entry_match"], 0)
+
+    def test_guard_subtree_probe_summary_records_shadow_entries(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+
+class Mod(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.seq = torch.nn.Sequential(torch.nn.Linear(4, 4), torch.nn.ReLU())
+
+    def forward(self, x):
+        return self.seq(x)
+
+model = Mod()
+opt_model = torch.compile(model, backend="eager", fullgraph=True)
+x = torch.randn(2, 4)
+
+opt_model(x)
+guards.reset_guard_lookup_stats()
+for _ in range(3):
+    opt_model(x)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "mode": stats["guard_subtree_probe_mode"],
+    "attempt": stats["guard_subtree_probe_attempt"],
+    "entry_match": stats["guard_subtree_probe_entry_match"],
+    "shadow_ok": stats["guard_subtree_probe_shadow_ok"],
+    "child_check_ns": stats["guard_subtree_probe_child_check_ns"],
+    "has_top_paths": "guard_subtree_probe_top_paths" in stats,
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        env["TORCHDYNAMO_GUARD_SUBTREE_PROBE"] = "summary"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertEqual(stats["mode"], "summary")
+        self.assertGreater(stats["attempt"], 0)
+        self.assertGreater(stats["entry_match"], 0)
+        self.assertGreater(stats["shadow_ok"], 0)
+        self.assertGreater(stats["child_check_ns"], 0)
+        self.assertFalse(stats["has_top_paths"])
+
+    def test_guard_subtree_probe_detail_is_pruned_to_summary(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+
+class Mod(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.seq = torch.nn.Sequential(torch.nn.Linear(4, 4), torch.nn.ReLU())
+
+    def forward(self, x):
+        return self.seq(x)
+
+model = Mod()
+opt_model = torch.compile(model, backend="eager", fullgraph=True)
+x = torch.randn(2, 4)
+
+opt_model(x)
+guards.reset_guard_lookup_stats()
+for _ in range(3):
+    opt_model(x)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "mode": stats["guard_subtree_probe_mode"],
+    "attempt": stats["guard_subtree_probe_attempt"],
+    "entry_match": stats["guard_subtree_probe_entry_match"],
+    "shadow_ok": stats["guard_subtree_probe_shadow_ok"],
+    "has_top_paths": "guard_subtree_probe_top_paths" in stats,
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        env["TORCHDYNAMO_GUARD_SUBTREE_PROBE"] = "detail"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertEqual(stats["mode"], "summary")
+        self.assertGreater(stats["attempt"], 0)
+        self.assertGreater(stats["entry_match"], 0)
+        self.assertGreater(stats["shadow_ok"], 0)
+        self.assertFalse(stats["has_top_paths"])
+
+    def test_guard_fast_plan_skips_top_modules(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+from torch._C._dynamo.guards import RootGuardManager
+from torch._dynamo.guards import GuardManagerType
+
+class Mod(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.seq = torch.nn.Sequential(torch.nn.Linear(4, 4), torch.nn.ReLU())
+
+model = Mod()
+root = RootGuardManager()
+self_mgr = root.getitem_manager(
+    "self", "L['self']", model, GuardManagerType.GUARD_MANAGER
+)
+dict_mgr = self_mgr.get_generic_dict_manager(
+    "L['self'].__dict__", model.__dict__, GuardManagerType.GUARD_MANAGER
+)
+modules_mgr = dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules",
+    model._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+modules_mgr.add_dict_length_check_guard(
+    len(model._modules), ["len(L['self']._modules) == 1"]
+)
+
+f_locals = {"self": model}
+guards.reset_guard_lookup_stats()
+for _ in range(6):
+    assert root.check(f_locals)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "enabled": stats["guard_fastplan_enabled"],
+    "candidate": stats["guard_fastplan_candidate"],
+    "shadow_pass": stats["guard_fastplan_shadow_pass"],
+    "enable": stats["guard_fastplan_enable"],
+    "hit": stats["guard_fastplan_hit"],
+    "miss": stats["guard_fastplan_miss"],
+    "disabled": stats["guard_fastplan_disabled"],
+    "token_count_sum": stats["guard_fastplan_token_count_sum"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        env["TORCHDYNAMO_GUARD_LOOKUP_STATS"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertTrue(stats["enabled"])
+        self.assertEqual(stats["candidate"], 0)
+        self.assertEqual(stats["shadow_pass"], 0)
+        self.assertEqual(stats["enable"], 0)
+        self.assertEqual(stats["hit"], 0)
+        self.assertEqual(stats["miss"], 0)
+        self.assertEqual(stats["disabled"], 0)
+        self.assertEqual(stats["token_count_sum"], 0)
+
+    def test_guard_fast_plan_skips_top_module_disabled_reasons(self):
+        script = r"""
+import functools
+import json
+import torch
+from torch._C._dynamo import guards
+from torch._C._dynamo.guards import RootGuardManager
+from torch._dynamo.guards import GuardManagerType
+
+def equals_match(x, expected):
+    return x == expected
+
+class Mod(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.seq = torch.nn.Sequential(torch.nn.Linear(4, 4), torch.nn.ReLU())
+
+model = Mod()
+root = RootGuardManager()
+self_mgr = root.getitem_manager(
+    "self", "L['self']", model, GuardManagerType.GUARD_MANAGER
+)
+dict_mgr = self_mgr.get_generic_dict_manager(
+    "L['self'].__dict__", model.__dict__, GuardManagerType.GUARD_MANAGER
+)
+modules_mgr = dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules",
+    model._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+modules_mgr.add_lambda_guard(
+    functools.partial(equals_match, expected=model._modules),
+    ["L['self']._modules == original"],
+)
+
+f_locals = {"self": model}
+guards.reset_guard_lookup_stats()
+assert root.check(f_locals)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "enabled": stats["guard_fastplan_enabled"],
+    "candidate": stats["guard_fastplan_candidate"],
+    "disabled": stats["guard_fastplan_disabled"],
+    "reasons": stats["guard_fastplan_disabled_reasons"],
+    "top_paths": stats["guard_fastplan_disabled_top_paths"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        env["TORCHDYNAMO_GUARD_LOOKUP_STATS"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertTrue(stats["enabled"])
+        self.assertEqual(stats["candidate"], 0)
+        self.assertEqual(stats["disabled"], 0)
+        self.assertEqual(stats["reasons"], {})
+        self.assertEqual(stats["top_paths"], {})
+
+    def test_guard_fast_plan_nested_modules_records_hits(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+from torch._C._dynamo.guards import RootGuardManager
+from torch._dynamo.guards import GuardManagerType
+
+class Child(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.seq = torch.nn.Sequential(torch.nn.Linear(4, 4), torch.nn.ReLU())
+
+class Mod(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.clean = Child()
+
+model = Mod()
+root = RootGuardManager()
+self_mgr = root.getitem_manager(
+    "self", "L['self']", model, GuardManagerType.GUARD_MANAGER
+)
+self_dict_mgr = self_mgr.get_generic_dict_manager(
+    "L['self'].__dict__", model.__dict__, GuardManagerType.GUARD_MANAGER
+)
+modules_mgr = self_dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules",
+    model._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+clean_mgr = modules_mgr.getitem_manager(
+    "clean",
+    "L['self']._modules['clean']",
+    model.clean,
+    GuardManagerType.GUARD_MANAGER,
+)
+clean_dict_mgr = clean_mgr.get_generic_dict_manager(
+    "L['self']._modules['clean'].__dict__",
+    model.clean.__dict__,
+    GuardManagerType.GUARD_MANAGER,
+)
+clean_modules_mgr = clean_dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules['clean']._modules",
+    model.clean._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+clean_modules_mgr.add_dict_length_check_guard(
+    len(model.clean._modules),
+    ["len(L['self']._modules['clean']._modules) == 1"],
+)
+
+f_locals = {"self": model}
+guards.reset_guard_lookup_stats()
+for _ in range(6):
+    assert root.check(f_locals)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "enabled": stats["guard_fastplan_enabled"],
+    "candidate_nested": stats["guard_fastplan_candidate_nested"],
+    "shadow_pass_nested": stats["guard_fastplan_shadow_pass_nested"],
+    "enable_nested": stats["guard_fastplan_enable_nested"],
+    "hit_nested": stats["guard_fastplan_hit_nested"],
+    "miss": stats["guard_fastplan_miss"],
+    "disabled_nested": stats["guard_fastplan_disabled_nested"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        env["TORCHDYNAMO_GUARD_LOOKUP_STATS"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertTrue(stats["enabled"])
+        self.assertGreater(stats["candidate_nested"], 0)
+        self.assertGreater(stats["shadow_pass_nested"], 0)
+        self.assertGreater(stats["enable_nested"], 0)
+        self.assertGreater(stats["hit_nested"], 0)
+        self.assertEqual(stats["miss"], 0)
+        self.assertEqual(stats["disabled_nested"], 0)
+
+    def test_guard_fast_plan_blocked_sibling_does_not_disable_clean_nested(self):
+        script = r"""
+import functools
+import json
+import torch
+from torch._C._dynamo import guards
+from torch._C._dynamo.guards import RootGuardManager
+from torch._dynamo.guards import GuardManagerType
+
+def equals_match(x, expected):
+    return x == expected
+
+class Child(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.seq = torch.nn.Sequential(torch.nn.Linear(4, 4), torch.nn.ReLU())
+
+class Mod(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.clean = Child()
+        self.blocked = Child()
+
+model = Mod()
+root = RootGuardManager()
+self_mgr = root.getitem_manager(
+    "self", "L['self']", model, GuardManagerType.GUARD_MANAGER
+)
+self_dict_mgr = self_mgr.get_generic_dict_manager(
+    "L['self'].__dict__", model.__dict__, GuardManagerType.GUARD_MANAGER
+)
+modules_mgr = self_dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules",
+    model._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+clean_mgr = modules_mgr.getitem_manager(
+    "clean",
+    "L['self']._modules['clean']",
+    model.clean,
+    GuardManagerType.GUARD_MANAGER,
+)
+clean_dict_mgr = clean_mgr.get_generic_dict_manager(
+    "L['self']._modules['clean'].__dict__",
+    model.clean.__dict__,
+    GuardManagerType.GUARD_MANAGER,
+)
+clean_modules_mgr = clean_dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules['clean']._modules",
+    model.clean._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+clean_modules_mgr.add_dict_length_check_guard(
+    len(model.clean._modules),
+    ["len(L['self']._modules['clean']._modules) == 1"],
+)
+
+blocked_mgr = modules_mgr.getitem_manager(
+    "blocked",
+    "L['self']._modules['blocked']",
+    model.blocked,
+    GuardManagerType.GUARD_MANAGER,
+)
+blocked_dict_mgr = blocked_mgr.get_generic_dict_manager(
+    "L['self']._modules['blocked'].__dict__",
+    model.blocked.__dict__,
+    GuardManagerType.GUARD_MANAGER,
+)
+blocked_modules_mgr = blocked_dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules['blocked']._modules",
+    model.blocked._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+blocked_modules_mgr.add_lambda_guard(
+    functools.partial(equals_match, expected=model.blocked._modules),
+    ["L['self']._modules['blocked']._modules == original"],
+)
+
+f_locals = {"self": model}
+guards.reset_guard_lookup_stats()
+for _ in range(6):
+    assert root.check(f_locals)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "enabled": stats["guard_fastplan_enabled"],
+    "candidate_top": stats["guard_fastplan_candidate_top"],
+    "candidate_nested": stats["guard_fastplan_candidate_nested"],
+    "enable_nested": stats["guard_fastplan_enable_nested"],
+    "hit_nested": stats["guard_fastplan_hit_nested"],
+    "disabled": stats["guard_fastplan_disabled"],
+    "disabled_nested": stats["guard_fastplan_disabled_nested"],
+    "reasons": stats["guard_fastplan_disabled_reasons"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        env["TORCHDYNAMO_GUARD_LOOKUP_STATS"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertTrue(stats["enabled"])
+        self.assertEqual(stats["candidate_top"], 0)
+        self.assertGreater(stats["candidate_nested"], 0)
+        self.assertGreater(stats["enable_nested"], 0)
+        self.assertGreater(stats["hit_nested"], 0)
+        self.assertGreater(stats["disabled"], 0)
+        self.assertGreater(stats["disabled_nested"], 0)
+        self.assertGreaterEqual(
+            stats["reasons"].get("unsupported_leaf:LAMBDA_GUARD", 0), 1
+        )
+
+    def test_guard_fast_plan_partial_hit_checks_unsupported_child(self):
+        script = r"""
+import functools
+import json
+import torch
+from torch._C._dynamo import guards
+from torch._C._dynamo.guards import RootGuardManager
+from torch._dynamo.guards import GuardManagerType
+
+def is_original_dict(x, expected):
+    return x is expected
+
+class Child(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.seq = torch.nn.Sequential(torch.nn.Linear(4, 4), torch.nn.ReLU())
+
+class Parent(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.clean = Child()
+        self.blocked = Child()
+
+class Mod(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.parent = Parent()
+
+model = Mod()
+root = RootGuardManager()
+self_mgr = root.getitem_manager(
+    "self", "L['self']", model, GuardManagerType.GUARD_MANAGER
+)
+self_dict_mgr = self_mgr.get_generic_dict_manager(
+    "L['self'].__dict__", model.__dict__, GuardManagerType.GUARD_MANAGER
+)
+modules_mgr = self_dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules",
+    model._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+parent_mgr = modules_mgr.getitem_manager(
+    "parent",
+    "L['self']._modules['parent']",
+    model.parent,
+    GuardManagerType.GUARD_MANAGER,
+)
+parent_dict_mgr = parent_mgr.get_generic_dict_manager(
+    "L['self']._modules['parent'].__dict__",
+    model.parent.__dict__,
+    GuardManagerType.GUARD_MANAGER,
+)
+parent_modules_mgr = parent_dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules['parent']._modules",
+    model.parent._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+
+clean_mgr = parent_modules_mgr.getitem_manager(
+    "clean",
+    "L['self']._modules['parent']._modules['clean']",
+    model.parent.clean,
+    GuardManagerType.GUARD_MANAGER,
+)
+clean_dict_mgr = clean_mgr.get_generic_dict_manager(
+    "L['self']._modules['parent']._modules['clean'].__dict__",
+    model.parent.clean.__dict__,
+    GuardManagerType.GUARD_MANAGER,
+)
+clean_modules_mgr = clean_dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules['parent']._modules['clean']._modules",
+    model.parent.clean._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+clean_modules_mgr.add_dict_length_check_guard(
+    len(model.parent.clean._modules),
+    ["len(L['self']._modules['parent']._modules['clean']._modules) == 1"],
+)
+
+blocked_mgr = parent_modules_mgr.getitem_manager(
+    "blocked",
+    "L['self']._modules['parent']._modules['blocked']",
+    model.parent.blocked,
+    GuardManagerType.GUARD_MANAGER,
+)
+blocked_dict_mgr = blocked_mgr.get_generic_dict_manager(
+    "L['self']._modules['parent']._modules['blocked'].__dict__",
+    model.parent.blocked.__dict__,
+    GuardManagerType.GUARD_MANAGER,
+)
+blocked_modules_mgr = blocked_dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules['parent']._modules['blocked']._modules",
+    model.parent.blocked._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+blocked_modules_mgr.add_lambda_guard(
+    functools.partial(is_original_dict, expected=model.parent.blocked._modules),
+    ["blocked._modules is original"],
+)
+
+f_locals = {"self": model}
+guards.reset_guard_lookup_stats()
+for _ in range(6):
+    assert root.check(f_locals)
+
+model.parent.blocked._modules = {}
+assert not root.check(f_locals)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "partial_enable": stats["guard_fastplan_partial_enable"],
+    "partial_hit": stats["guard_fastplan_partial_hit"],
+    "miss": stats["guard_fastplan_miss"],
+    "reasons": stats["guard_fastplan_disabled_reasons"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        env["TORCHDYNAMO_GUARD_LOOKUP_STATS"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertGreater(stats["partial_enable"], 0)
+        self.assertGreater(stats["partial_hit"], 0)
+        self.assertEqual(stats["miss"], 0)
+        self.assertGreaterEqual(
+            stats["reasons"].get("unsupported_leaf:LAMBDA_GUARD", 0), 1
+        )
+
+    def test_guard_fast_plan_tensor_match_token_hits_and_checks_metadata(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+from torch._C._dynamo.guards import RootGuardManager
+from torch._dynamo.guards import GuardManagerType
+
+model = torch.nn.Sequential(torch.nn.Linear(4, 4))
+container = torch.nn.Module()
+container.child = model
+root = RootGuardManager()
+self_mgr = root.getitem_manager(
+    "self", "L['self']", container, GuardManagerType.GUARD_MANAGER
+)
+self_dict_mgr = self_mgr.get_generic_dict_manager(
+    "L['self'].__dict__", container.__dict__, GuardManagerType.GUARD_MANAGER
+)
+modules_mgr = self_dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules",
+    container._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+child_mgr = modules_mgr.getitem_manager(
+    "child",
+    "L['self']._modules['child']",
+    model,
+    GuardManagerType.GUARD_MANAGER,
+)
+child_dict_mgr = child_mgr.get_generic_dict_manager(
+    "L['self']._modules['child'].__dict__",
+    model.__dict__,
+    GuardManagerType.GUARD_MANAGER,
+)
+child_modules_mgr = child_dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules['child']._modules",
+    model._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+linear_mgr = child_modules_mgr.getitem_manager(
+    "0",
+    "L['self']._modules['child']._modules['0']",
+    model[0],
+    GuardManagerType.GUARD_MANAGER,
+)
+linear_dict_mgr = linear_mgr.get_generic_dict_manager(
+    "L['self']._modules['child']._modules['0'].__dict__",
+    model[0].__dict__,
+    GuardManagerType.GUARD_MANAGER,
+)
+parameters_mgr = linear_dict_mgr.getitem_manager(
+    "_parameters",
+    "L['self']._modules['child']._modules['0']._parameters",
+    model[0]._parameters,
+    GuardManagerType.GUARD_MANAGER,
+)
+weight_mgr = parameters_mgr.getitem_manager(
+    "weight",
+    "L['self']._modules['child']._modules['0']._parameters['weight']",
+    model[0].weight,
+    GuardManagerType.GUARD_MANAGER,
+)
+weight_mgr.add_tensor_match_guard(
+    model[0].weight,
+    list(model[0].weight.size()),
+    list(model[0].weight.stride()),
+    "L['self']._modules['child']._modules['0']._parameters['weight']",
+    ["check_tensor(weight)"],
+)
+
+f_locals = {"self": container}
+guards.reset_guard_lookup_stats()
+for _ in range(6):
+    assert root.check(f_locals)
+
+with torch.no_grad():
+    model[0].weight.add_(1)
+assert root.check(f_locals)
+
+model[0].weight.requires_grad_(False)
+assert not root.check(f_locals)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "tensor_shadow": stats["guard_fastplan_tensor_token_shadow"],
+    "tensor_hit": stats["guard_fastplan_tensor_token_hit"],
+    "tensor_miss": stats["guard_fastplan_tensor_token_miss"],
+    "miss_reasons": stats["guard_fastplan_tensor_token_miss_reasons"],
+    "fastplan_miss": stats["guard_fastplan_miss"],
+    "disabled_reasons": stats["guard_fastplan_disabled_reasons"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        env["TORCHDYNAMO_GUARD_LOOKUP_STATS"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertGreater(stats["tensor_shadow"], 0)
+        self.assertGreater(stats["tensor_hit"], 0)
+        self.assertGreater(stats["tensor_miss"], 0)
+        self.assertGreater(stats["fastplan_miss"], 0)
+        self.assertGreater(
+            stats["miss_reasons"].get("requires_grad", 0), 0
+        )
+        self.assertEqual(
+            stats["disabled_reasons"].get("unsupported_leaf:TENSOR_MATCH", 0),
+            0,
+        )
+
+    def test_guard_fast_plan_tensor_match_token_skips_attr_sources(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+from torch._C._dynamo.guards import RootGuardManager
+from torch._dynamo.guards import GuardManagerType
+
+class Mod(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.other_tensor = torch.ones(2)
+
+model = Mod()
+parent = torch.nn.Module()
+parent.leaf = model
+container = torch.nn.Module()
+container.child = parent
+root = RootGuardManager()
+self_mgr = root.getitem_manager(
+    "self", "L['self']", container, GuardManagerType.GUARD_MANAGER
+)
+self_dict_mgr = self_mgr.get_generic_dict_manager(
+    "L['self'].__dict__", container.__dict__, GuardManagerType.GUARD_MANAGER
+)
+modules_mgr = self_dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules",
+    container._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+child_mgr = modules_mgr.getitem_manager(
+    "child",
+    "L['self']._modules['child']",
+    parent,
+    GuardManagerType.GUARD_MANAGER,
+)
+child_dict_mgr = child_mgr.get_generic_dict_manager(
+    "L['self']._modules['child'].__dict__",
+    parent.__dict__,
+    GuardManagerType.GUARD_MANAGER,
+)
+child_modules_mgr = child_dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules['child']._modules",
+    parent._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+leaf_mgr = child_modules_mgr.getitem_manager(
+    "leaf",
+    "L['self']._modules['child']._modules['leaf']",
+    model,
+    GuardManagerType.GUARD_MANAGER,
+)
+cached_mgr = leaf_mgr.getattr_manager(
+    "other_tensor",
+    "L['self']._modules['child']._modules['leaf'].other_tensor",
+    model.other_tensor,
+    GuardManagerType.GUARD_MANAGER,
+)
+cached_mgr.add_tensor_match_guard(
+    model.other_tensor,
+    list(model.other_tensor.size()),
+    list(model.other_tensor.stride()),
+    "L['self']._modules['child']._modules['leaf'].other_tensor",
+    ["check_tensor(cached)"],
+)
+
+f_locals = {"self": container}
+guards.reset_guard_lookup_stats()
+for _ in range(4):
+    assert root.check(f_locals)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "tensor_shadow": stats["guard_fastplan_tensor_token_shadow"],
+    "disabled_reasons": stats["guard_fastplan_disabled_reasons"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        env["TORCHDYNAMO_GUARD_LOOKUP_STATS"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertEqual(stats["tensor_shadow"], 0)
+        self.assertGreater(
+            stats["disabled_reasons"].get("unsupported_leaf:TENSOR_MATCH", 0),
+            0,
+        )
+
+    def test_guard_fast_plan_tensor_match_token_supports_cached_tensor_attr(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+from torch._C._dynamo.guards import RootGuardManager
+from torch._dynamo.guards import GuardManagerType
+
+class Mod(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self._cached_tensor = torch.ones(2)
+
+model = Mod()
+parent = torch.nn.Module()
+parent.leaf = model
+container = torch.nn.Module()
+container.child = parent
+root = RootGuardManager()
+self_mgr = root.getitem_manager(
+    "self", "L['self']", container, GuardManagerType.GUARD_MANAGER
+)
+self_dict_mgr = self_mgr.get_generic_dict_manager(
+    "L['self'].__dict__", container.__dict__, GuardManagerType.GUARD_MANAGER
+)
+modules_mgr = self_dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules",
+    container._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+child_mgr = modules_mgr.getitem_manager(
+    "child",
+    "L['self']._modules['child']",
+    parent,
+    GuardManagerType.GUARD_MANAGER,
+)
+child_dict_mgr = child_mgr.get_generic_dict_manager(
+    "L['self']._modules['child'].__dict__",
+    parent.__dict__,
+    GuardManagerType.GUARD_MANAGER,
+)
+child_modules_mgr = child_dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules['child']._modules",
+    parent._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+leaf_mgr = child_modules_mgr.getitem_manager(
+    "leaf",
+    "L['self']._modules['child']._modules['leaf']",
+    model,
+    GuardManagerType.GUARD_MANAGER,
+)
+cached_mgr = leaf_mgr.getattr_manager(
+    "_cached_tensor",
+    "L['self']._modules['child']._modules['leaf']._cached_tensor",
+    model._cached_tensor,
+    GuardManagerType.GUARD_MANAGER,
+)
+cached_mgr.add_tensor_match_guard(
+    model._cached_tensor,
+    list(model._cached_tensor.size()),
+    list(model._cached_tensor.stride()),
+    "L['self']._modules['child']._modules['leaf']._cached_tensor",
+    ["check_tensor(cached)"],
+)
+
+f_locals = {"self": container}
+guards.reset_guard_lookup_stats()
+for _ in range(6):
+    assert root.check(f_locals)
+
+model._cached_tensor.resize_(3)
+assert not root.check(f_locals)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "tensor_shadow": stats["guard_fastplan_tensor_token_shadow"],
+    "tensor_hit": stats["guard_fastplan_tensor_token_hit"],
+    "tensor_miss": stats["guard_fastplan_tensor_token_miss"],
+    "miss_reasons": stats["guard_fastplan_tensor_token_miss_reasons"],
+    "fastplan_miss": stats["guard_fastplan_miss"],
+    "disabled_reasons": stats["guard_fastplan_disabled_reasons"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        env["TORCHDYNAMO_GUARD_LOOKUP_STATS"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertGreater(stats["tensor_shadow"], 0)
+        self.assertGreater(stats["tensor_hit"], 0)
+        self.assertGreater(stats["tensor_miss"], 0)
+        self.assertGreater(stats["fastplan_miss"], 0)
+        self.assertGreater(stats["miss_reasons"].get("size", 0), 0)
+        self.assertEqual(
+            stats["disabled_reasons"].get("unsupported_leaf:TENSOR_MATCH", 0),
+            0,
+        )
+
+    def test_guard_fast_plan_tensor_match_token_supports_scale_attr(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+from torch._C._dynamo.guards import RootGuardManager
+from torch._dynamo.guards import GuardManagerType
+
+class Mod(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.scale = torch.ones(2)
+
+model = Mod()
+parent = torch.nn.Module()
+parent.leaf = model
+container = torch.nn.Module()
+container.child = parent
+root = RootGuardManager()
+self_mgr = root.getitem_manager(
+    "self", "L['self']", container, GuardManagerType.GUARD_MANAGER
+)
+self_dict_mgr = self_mgr.get_generic_dict_manager(
+    "L['self'].__dict__", container.__dict__, GuardManagerType.GUARD_MANAGER
+)
+modules_mgr = self_dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules",
+    container._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+child_mgr = modules_mgr.getitem_manager(
+    "child",
+    "L['self']._modules['child']",
+    parent,
+    GuardManagerType.GUARD_MANAGER,
+)
+child_dict_mgr = child_mgr.get_generic_dict_manager(
+    "L['self']._modules['child'].__dict__",
+    parent.__dict__,
+    GuardManagerType.GUARD_MANAGER,
+)
+child_modules_mgr = child_dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules['child']._modules",
+    parent._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+leaf_mgr = child_modules_mgr.getitem_manager(
+    "leaf",
+    "L['self']._modules['child']._modules['leaf']",
+    model,
+    GuardManagerType.GUARD_MANAGER,
+)
+scale_mgr = leaf_mgr.getattr_manager(
+    "scale",
+    "L['self']._modules['child']._modules['leaf'].scale",
+    model.scale,
+    GuardManagerType.GUARD_MANAGER,
+)
+scale_mgr.add_tensor_match_guard(
+    model.scale,
+    list(model.scale.size()),
+    list(model.scale.stride()),
+    "L['self']._modules['child']._modules['leaf'].scale",
+    ["check_tensor(scale)"],
+)
+
+f_locals = {"self": container}
+guards.reset_guard_lookup_stats()
+for _ in range(6):
+    assert root.check(f_locals)
+
+model.scale.resize_(3)
+assert not root.check(f_locals)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "tensor_shadow": stats["guard_fastplan_tensor_token_shadow"],
+    "tensor_hit": stats["guard_fastplan_tensor_token_hit"],
+    "tensor_miss": stats["guard_fastplan_tensor_token_miss"],
+    "miss_reasons": stats["guard_fastplan_tensor_token_miss_reasons"],
+    "fastplan_miss": stats["guard_fastplan_miss"],
+    "disabled_reasons": stats["guard_fastplan_disabled_reasons"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        env["TORCHDYNAMO_GUARD_LOOKUP_STATS"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertGreater(stats["tensor_shadow"], 0)
+        self.assertGreater(stats["tensor_hit"], 0)
+        self.assertGreater(stats["tensor_miss"], 0)
+        self.assertGreater(stats["fastplan_miss"], 0)
+        self.assertGreater(stats["miss_reasons"].get("size", 0), 0)
+        self.assertEqual(
+            stats["disabled_reasons"].get("unsupported_leaf:TENSOR_MATCH", 0),
+            0,
+        )
+
+    def test_guard_fast_plan_supports_no_tensor_aliasing_token(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+from torch._C._dynamo.guards import RootGuardManager
+from torch._dynamo.guards import GuardManagerType
+
+class Leaf(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.register_buffer("a", torch.ones(2))
+        self.register_buffer("b", torch.zeros(2))
+
+class Child(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.leaf = Leaf()
+
+container = torch.nn.Module()
+container.child = Child()
+root = RootGuardManager()
+self_mgr = root.getitem_manager(
+    "self", "L['self']", container, GuardManagerType.GUARD_MANAGER
+)
+self_dict_mgr = self_mgr.get_generic_dict_manager(
+    "L['self'].__dict__", container.__dict__, GuardManagerType.GUARD_MANAGER
+)
+modules_mgr = self_dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules",
+    container._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+child_mgr = modules_mgr.getitem_manager(
+    "child",
+    "L['self']._modules['child']",
+    container.child,
+    GuardManagerType.GUARD_MANAGER,
+)
+child_dict_mgr = child_mgr.get_generic_dict_manager(
+    "L['self']._modules['child'].__dict__",
+    container.child.__dict__,
+    GuardManagerType.GUARD_MANAGER,
+)
+child_modules_mgr = child_dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules['child']._modules",
+    container.child._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+leaf_mgr = child_modules_mgr.getitem_manager(
+    "leaf",
+    "L['self']._modules['child']._modules['leaf']",
+    container.child.leaf,
+    GuardManagerType.GUARD_MANAGER,
+)
+leaf_dict_mgr = leaf_mgr.get_generic_dict_manager(
+    "L['self']._modules['child']._modules['leaf'].__dict__",
+    container.child.leaf.__dict__,
+    GuardManagerType.GUARD_MANAGER,
+)
+leaf_buffers_mgr = leaf_dict_mgr.getitem_manager(
+    "_buffers",
+    "L['self']._modules['child']._modules['leaf']._buffers",
+    container.child.leaf._buffers,
+    GuardManagerType.GUARD_MANAGER,
+)
+a_mgr = leaf_buffers_mgr.getitem_manager(
+    "a",
+    "L['self']._modules['child']._modules['leaf']._buffers['a']",
+    container.child.leaf.a,
+    GuardManagerType.GUARD_MANAGER,
+)
+b_mgr = leaf_buffers_mgr.getitem_manager(
+    "b",
+    "L['self']._modules['child']._modules['leaf']._buffers['b']",
+    container.child.leaf.b,
+    GuardManagerType.GUARD_MANAGER,
+)
+guards.install_no_tensor_aliasing_guard(
+    [a_mgr, b_mgr],
+    ["a", "b"],
+    ["no_aliasing(a, b)"],
+)
+
+f_locals = {"self": container}
+guards.reset_guard_lookup_stats()
+for _ in range(6):
+    assert root.check(f_locals)
+
+container.child.leaf.b = container.child.leaf.a
+assert not root.check(f_locals)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "candidate_nested": stats["guard_fastplan_candidate_nested"],
+    "fastplan_hit": stats["guard_fastplan_hit"],
+    "fastplan_miss": stats["guard_fastplan_miss"],
+    "disabled_reasons": stats["guard_fastplan_disabled_reasons"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        env["TORCHDYNAMO_GUARD_LOOKUP_STATS"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertGreater(stats["candidate_nested"], 0)
+        self.assertGreater(stats["fastplan_hit"], 0)
+        self.assertGreater(stats["fastplan_miss"], 0)
+        self.assertEqual(
+            stats["disabled_reasons"].get(
+                "unsupported_leaf:NO_TENSOR_ALIASING", 0
+            ),
+            0,
+        )
+
+    def test_guard_fast_plan_supports_object_aliasing_token(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+from torch._C._dynamo.guards import RootGuardManager
+from torch._dynamo.guards import GuardManagerType
+
+class Leaf(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.register_buffer("a", torch.ones(2))
+        self.register_buffer("b", self.a)
+
+class Child(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.leaf = Leaf()
+
+container = torch.nn.Module()
+container.child = Child()
+root = RootGuardManager()
+self_mgr = root.getitem_manager(
+    "self", "L['self']", container, GuardManagerType.GUARD_MANAGER
+)
+self_dict_mgr = self_mgr.get_generic_dict_manager(
+    "L['self'].__dict__", container.__dict__, GuardManagerType.GUARD_MANAGER
+)
+modules_mgr = self_dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules",
+    container._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+child_mgr = modules_mgr.getitem_manager(
+    "child",
+    "L['self']._modules['child']",
+    container.child,
+    GuardManagerType.GUARD_MANAGER,
+)
+child_dict_mgr = child_mgr.get_generic_dict_manager(
+    "L['self']._modules['child'].__dict__",
+    container.child.__dict__,
+    GuardManagerType.GUARD_MANAGER,
+)
+child_modules_mgr = child_dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules['child']._modules",
+    container.child._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+leaf_mgr = child_modules_mgr.getitem_manager(
+    "leaf",
+    "L['self']._modules['child']._modules['leaf']",
+    container.child.leaf,
+    GuardManagerType.GUARD_MANAGER,
+)
+leaf_dict_mgr = leaf_mgr.get_generic_dict_manager(
+    "L['self']._modules['child']._modules['leaf'].__dict__",
+    container.child.leaf.__dict__,
+    GuardManagerType.GUARD_MANAGER,
+)
+leaf_buffers_mgr = leaf_dict_mgr.getitem_manager(
+    "_buffers",
+    "L['self']._modules['child']._modules['leaf']._buffers",
+    container.child.leaf._buffers,
+    GuardManagerType.GUARD_MANAGER,
+)
+a_mgr = leaf_buffers_mgr.getitem_manager(
+    "a",
+    "L['self']._modules['child']._modules['leaf']._buffers['a']",
+    container.child.leaf.a,
+    GuardManagerType.GUARD_MANAGER,
+)
+b_mgr = leaf_buffers_mgr.getitem_manager(
+    "b",
+    "L['self']._modules['child']._modules['leaf']._buffers['b']",
+    container.child.leaf.b,
+    GuardManagerType.GUARD_MANAGER,
+)
+guards.install_object_aliasing_guard(
+    a_mgr,
+    b_mgr,
+    ["aliasing(a, b)"],
+)
+
+f_locals = {"self": container}
+guards.reset_guard_lookup_stats()
+for _ in range(6):
+    assert root.check(f_locals)
+
+container.child.leaf.b = torch.zeros(2)
+assert not root.check(f_locals)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "candidate_nested": stats["guard_fastplan_candidate_nested"],
+    "fastplan_hit": stats["guard_fastplan_hit"],
+    "fastplan_miss": stats["guard_fastplan_miss"],
+    "disabled_reasons": stats["guard_fastplan_disabled_reasons"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        env["TORCHDYNAMO_GUARD_LOOKUP_STATS"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertGreater(stats["candidate_nested"], 0)
+        self.assertGreater(stats["fastplan_hit"], 0)
+        self.assertGreater(stats["fastplan_miss"], 0)
+        self.assertEqual(
+            stats["disabled_reasons"].get(
+                "unsupported_leaf:OBJECT_ALIASING", 0
+            ),
+            0,
+        )
+
+    def test_guard_last_success_shadow_records_lookup_attempts(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+
+def fn(x):
+    return x + 1
+
+compiled = torch.compile(fn, backend="eager")
+x = torch.ones(4)
+guards.reset_guard_lookup_stats()
+for _ in range(5):
+    out = compiled(x)
+    assert torch.equal(out, x + 1)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "lookup_count": stats["lookup_count"],
+    "attempt": stats["guard_last_success_shadow_attempt"],
+    "success": stats["guard_last_success_shadow_success"],
+    "incomplete": stats["guard_last_success_shadow_incomplete"],
+    "support_check_ns": stats["guard_last_success_support_check_ns"],
+    "token_cap_count_sum": stats["guard_last_success_token_cap_count_sum"],
+    "token_cap_count_max": stats["guard_last_success_token_cap_count_max"],
+    "compare_mismatch": stats["guard_last_success_compare_mismatch"],
+    "mismatch_reasons": stats["guard_last_success_mismatch_reasons"],
+    "mismatch_token_kinds": stats["guard_last_success_mismatch_token_kinds"],
+    "mismatch_top_paths": stats["guard_last_success_mismatch_top_paths"],
+    "disabled_reasons": stats["guard_last_success_disabled_reasons"],
+    "actual_attempt": stats["guard_last_success_actual_attempt"],
+    "actual_hit": stats["guard_last_success_actual_hit"],
+    "actual_miss": stats["guard_last_success_actual_miss"],
+    "actual_enable": stats["guard_last_success_actual_enable"],
+    "actual_disabled": stats["guard_last_success_actual_disabled"],
+    "actual_token_check_ns": stats["guard_last_success_actual_token_check_ns"],
+    "actual_train_ns": stats["guard_last_success_actual_train_ns"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        env["TORCHDYNAMO_GUARD_LOOKUP_STATS"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertGreater(stats["lookup_count"], 0)
+        self.assertGreater(stats["attempt"], 0)
+        self.assertGreater(stats["incomplete"] + stats["success"], 0)
+        self.assertGreaterEqual(stats["support_check_ns"], 0)
+        self.assertGreaterEqual(stats["token_cap_count_sum"], 0)
+        self.assertGreaterEqual(stats["token_cap_count_max"], 0)
+        self.assertGreaterEqual(stats["compare_mismatch"], 0)
+        self.assertIsInstance(stats["mismatch_reasons"], dict)
+        self.assertIsInstance(stats["mismatch_token_kinds"], dict)
+        self.assertIsInstance(stats["mismatch_top_paths"], dict)
+        self.assertGreaterEqual(stats["actual_attempt"], 0)
+        self.assertGreaterEqual(stats["actual_hit"], 0)
+        self.assertGreaterEqual(stats["actual_miss"], 0)
+        self.assertGreaterEqual(stats["actual_enable"], 0)
+        self.assertGreaterEqual(stats["actual_disabled"], 0)
+        self.assertGreaterEqual(stats["actual_token_check_ns"], 0)
+        self.assertGreaterEqual(stats["actual_train_ns"], 0)
+
+    def test_guard_last_success_full_actual_stays_disabled(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+
+class Mod(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.register_buffer("bias", torch.ones(4))
+
+    def forward(self):
+        return self.bias + 1
+
+m = Mod()
+compiled = torch.compile(m, backend="eager")
+expected = m.bias + 1
+assert torch.equal(compiled(), expected)
+
+guards.reset_guard_lookup_stats()
+for _ in range(8):
+    out = compiled()
+    assert torch.equal(out, expected)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "actual_attempt": stats["guard_last_success_actual_attempt"],
+    "actual_enable": stats["guard_last_success_actual_enable"],
+    "actual_hit": stats["guard_last_success_actual_hit"],
+    "actual_miss": stats["guard_last_success_actual_miss"],
+    "actual_disabled": stats["guard_last_success_actual_disabled"],
+    "disabled_reasons": stats["guard_last_success_disabled_reasons"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        env["TORCHDYNAMO_GUARD_LOOKUP_STATS"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertEqual(stats["actual_attempt"], 0)
+        self.assertEqual(stats["actual_enable"], 0)
+        self.assertEqual(stats["actual_hit"], 0)
+        self.assertEqual(stats["actual_miss"], 0)
+        self.assertEqual(stats["actual_disabled"], 0, stats["disabled_reasons"])
+
+    def test_guard_last_success_partial_self_hits_with_unstable_global(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+
+GLOBAL_DICT = {"used": 1, "noise": [0]}
+
+class Mod(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.register_buffer("bias", torch.ones(4))
+
+    def forward(self):
+        return self.bias + GLOBAL_DICT["used"]
+
+m = Mod()
+compiled = torch.compile(m, backend="eager")
+expected = m.bias + 1
+assert torch.equal(compiled(), expected)
+
+guards.reset_guard_lookup_stats()
+for _ in range(8):
+    GLOBAL_DICT["noise"] = [1]
+    out = compiled()
+    assert torch.equal(out, expected)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "partial_attempt": stats["guard_last_success_actual_partial_attempt"],
+    "partial_enable": stats["guard_last_success_actual_partial_enable"],
+    "partial_hit": stats["guard_last_success_actual_partial_hit"],
+    "partial_miss": stats["guard_last_success_actual_partial_miss"],
+    "partial_disabled": stats["guard_last_success_actual_partial_disabled"],
+    "partial_hot_tokens": stats[
+        "guard_last_success_actual_partial_hot_token_count_sum"
+    ],
+    "partial_hot_token_unique": stats[
+        "guard_last_success_actual_partial_hot_token_unique_count_sum"
+    ],
+    "partial_hot_token_duplicate": stats[
+        "guard_last_success_actual_partial_hot_token_duplicate_count_sum"
+    ],
+    "partial_hot_token_kinds": stats[
+        "guard_last_success_actual_partial_hot_token_kind_counts"
+    ],
+    "partial_hot_token_duplicate_kinds": stats[
+        "guard_last_success_actual_partial_hot_token_duplicate_kind_counts"
+    ],
+    "partial_residual_fail": stats[
+        "guard_last_success_actual_partial_residual_fail"
+    ],
+    "partial_shadow_full_pass": stats[
+        "guard_last_success_actual_partial_shadow_full_pass"
+    ],
+    "partial_shadow_full_fail": stats[
+        "guard_last_success_actual_partial_shadow_full_fail"
+    ],
+    "partial_shadow_full_ns": stats[
+        "guard_last_success_actual_partial_shadow_full_ns"
+    ],
+    "partial_shadow_fail_reasons": stats[
+        "guard_last_success_actual_partial_shadow_fail_reasons"
+    ],
+    "partial_shadow_fail_top_paths": stats[
+        "guard_last_success_actual_partial_shadow_fail_top_paths"
+    ],
+    "mismatch_top_paths": stats["guard_last_success_mismatch_top_paths"],
+}))
+"""
+        stats = run_guard_manager_script(
+            script,
+            env_updates={
+                "TORCHDYNAMO_GUARD_FAST_PLAN": "1",
+                "TORCHDYNAMO_GUARD_LOOKUP_STATS": "1",
+            },
+        )
+
+        self.assertGreater(stats["partial_attempt"], 0)
+        self.assertGreater(stats["partial_enable"], 0)
+        self.assertGreater(stats["partial_hit"], 0)
+        self.assertEqual(stats["partial_miss"], 0)
+        self.assertEqual(stats["partial_disabled"], 0)
+        self.assertEqual(stats["partial_residual_fail"], 0)
+        self.assertEqual(stats["partial_shadow_full_pass"], 0)
+        self.assertEqual(stats["partial_shadow_full_fail"], 0)
+        self.assertEqual(stats["partial_shadow_full_ns"], 0)
+        self.assertEqual(stats["partial_shadow_fail_reasons"], {})
+        self.assertEqual(stats["partial_shadow_fail_top_paths"], {})
+        self.assertGreater(stats["partial_hot_tokens"], 0)
+        self.assertGreater(stats["partial_hot_token_unique"], 0)
+        self.assertLessEqual(
+            stats["partial_hot_token_unique"], stats["partial_hot_tokens"]
+        )
+        self.assertEqual(
+            stats["partial_hot_token_unique"] + stats["partial_hot_token_duplicate"],
+            stats["partial_hot_tokens"],
+        )
+        self.assertIsInstance(stats["partial_hot_token_kinds"], dict)
+        for unused_kind in (
+            "BoundMethod",
+            "DefaultDevice",
+            "FrameGlobals",
+            "GlobalState",
+            "TorchFunctionModeStack",
+        ):
+            self.assertEqual(stats["partial_hot_token_kinds"][unused_kind], 0)
+        self.assertEqual(
+            sum(stats["partial_hot_token_kinds"].values()),
+            stats["partial_hot_tokens"],
+        )
+        self.assertIsInstance(stats["partial_hot_token_duplicate_kinds"], dict)
+
+    def test_guard_last_success_partial_does_not_claim_bound_method_token(self):
+        script = r"""
+import json
+import torch
+import torch._dynamo
+from torch._C._dynamo import guards
+
+GLOBAL_DICT = {"used": 1, "noise": [0]}
+
+class PlainMod(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.register_buffer("bias", torch.ones(4))
+
+    def forward(self, x):
+        return x + self.bias + GLOBAL_DICT["used"]
+
+class BoundMethodMod(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.register_buffer("bias", torch.ones(4))
+        self.bound = self.helper
+
+    def helper(self, x):
+        return x + self.bias
+
+    def forward(self, x):
+        return self.bound(x) + GLOBAL_DICT["used"]
+
+def run(cls):
+    torch._dynamo.reset()
+    GLOBAL_DICT["noise"] = [0]
+    m = cls()
+    compiled = torch.compile(m, backend="eager")
+    x = torch.ones(4)
+    expected = m(x)
+    assert torch.equal(compiled(x), expected)
+
+    guards.reset_guard_lookup_stats()
+    for i in range(8):
+        GLOBAL_DICT["noise"] = [i + 1]
+        out = compiled(x)
+        assert torch.equal(out, expected)
+
+    stats = guards.get_guard_lookup_stats()
+    return {
+        "partial_attempt": stats["guard_last_success_actual_partial_attempt"],
+        "partial_enable": stats["guard_last_success_actual_partial_enable"],
+        "partial_hit": stats["guard_last_success_actual_partial_hit"],
+        "partial_disabled": stats["guard_last_success_actual_partial_disabled"],
+        "partial_hot_token_kinds": stats[
+            "guard_last_success_actual_partial_hot_token_kind_counts"
+        ],
+    }
+
+print(json.dumps({
+    "plain": run(PlainMod),
+    "bound": run(BoundMethodMod),
+}))
+"""
+        stats = run_guard_manager_script(
+            script,
+            env_updates={
+                "TORCHDYNAMO_GUARD_FAST_PLAN": "1",
+                "TORCHDYNAMO_GUARD_LOOKUP_STATS": "1",
+            },
+        )
+
+        self.assertGreater(stats["plain"]["partial_attempt"], 0)
+        self.assertGreater(stats["plain"]["partial_enable"], 0)
+        self.assertGreater(stats["plain"]["partial_hit"], 0)
+        self.assertEqual(stats["plain"]["partial_disabled"], 0)
+
+        self.assertGreater(stats["bound"]["partial_attempt"], 0)
+        self.assertGreater(stats["bound"]["partial_enable"], 0)
+        self.assertGreater(stats["bound"]["partial_hit"], 0)
+        self.assertEqual(stats["bound"]["partial_disabled"], 0)
+        self.assertEqual(
+            stats["bound"]["partial_hot_token_kinds"]["BoundMethod"], 0
+        )
+
+    def test_guard_last_success_partial_shadow_full_is_pruned(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+
+GLOBAL_DICT = {"used": 1, "noise": [0]}
+
+class Mod(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.register_buffer("bias", torch.ones(4))
+
+    def forward(self):
+        return self.bias + GLOBAL_DICT["used"]
+
+m = Mod()
+compiled = torch.compile(m, backend="eager")
+expected = m.bias + 1
+assert torch.equal(compiled(), expected)
+
+guards.reset_guard_lookup_stats()
+for _ in range(8):
+    GLOBAL_DICT["noise"] = [1]
+    out = compiled()
+    assert torch.equal(out, expected)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "partial_hit": stats["guard_last_success_actual_partial_hit"],
+    "partial_shadow_full_pass": stats[
+        "guard_last_success_actual_partial_shadow_full_pass"
+    ],
+    "partial_shadow_full_fail": stats[
+        "guard_last_success_actual_partial_shadow_full_fail"
+    ],
+    "partial_shadow_full_ns": stats[
+        "guard_last_success_actual_partial_shadow_full_ns"
+    ],
+    "partial_shadow_fail_reasons": stats[
+        "guard_last_success_actual_partial_shadow_fail_reasons"
+    ],
+    "partial_shadow_fail_top_paths": stats[
+        "guard_last_success_actual_partial_shadow_fail_top_paths"
+    ],
+}))
+"""
+        stats = run_guard_manager_script(
+            script,
+            env_updates={
+                "TORCHDYNAMO_GUARD_FAST_PLAN": "1",
+                "TORCHDYNAMO_GUARD_LOOKUP_STATS": "1",
+                "TORCHDYNAMO_GUARD_LAST_SUCCESS_SHADOW_FULL": "1",
+            },
+        )
+
+        self.assertGreater(stats["partial_hit"], 0)
+        self.assertEqual(stats["partial_shadow_full_pass"], 0)
+        self.assertEqual(stats["partial_shadow_full_fail"], 0)
+        self.assertEqual(stats["partial_shadow_full_ns"], 0)
+        self.assertIsInstance(stats["partial_shadow_fail_reasons"], dict)
+        self.assertIsInstance(stats["partial_shadow_fail_top_paths"], dict)
+
+    def test_guard_last_success_full_actual_disabled_with_stable_global_dict(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+
+GLOBAL_DICT = {"used": 1}
+
+class Mod(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.register_buffer("bias", torch.ones(4))
+
+    def forward(self):
+        return self.bias + GLOBAL_DICT["used"]
+
+m = Mod()
+compiled = torch.compile(m, backend="eager")
+expected = m.bias + GLOBAL_DICT["used"]
+assert torch.equal(compiled(), expected)
+
+guards.reset_guard_lookup_stats()
+for _ in range(8):
+    out = compiled()
+    assert torch.equal(out, expected)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "actual_attempt": stats["guard_last_success_actual_attempt"],
+    "actual_enable": stats["guard_last_success_actual_enable"],
+    "actual_hit": stats["guard_last_success_actual_hit"],
+    "actual_miss": stats["guard_last_success_actual_miss"],
+    "actual_disabled": stats["guard_last_success_actual_disabled"],
+    "actual_hot_token_count_sum": stats[
+        "guard_last_success_actual_hot_token_count_sum"
+    ],
+    "partial_hit": stats["guard_last_success_actual_partial_hit"],
+    "disabled_reasons": stats["guard_last_success_disabled_reasons"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        env["TORCHDYNAMO_GUARD_LOOKUP_STATS"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertEqual(stats["actual_attempt"], 0)
+        self.assertEqual(stats["actual_enable"], 0)
+        self.assertEqual(stats["actual_hit"], 0)
+        self.assertEqual(stats["actual_miss"], 0)
+        self.assertEqual(stats["actual_disabled"], 0, stats["disabled_reasons"])
+        self.assertEqual(stats["actual_hot_token_count_sum"], 0)
+        self.assertGreaterEqual(stats["partial_hit"], 0)
+
+    def test_guard_last_success_respects_global_tensor_replacement(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+
+GLOBAL_TENSOR = torch.ones(4)
+
+def fn(x):
+    return x + GLOBAL_TENSOR
+
+compiled = torch.compile(fn, backend="eager")
+x = torch.zeros(4)
+assert torch.equal(compiled(x), torch.ones(4))
+
+guards.reset_guard_lookup_stats()
+for value in (2.0, 3.0, 4.0):
+    GLOBAL_TENSOR = torch.full((4,), value)
+    out = compiled(x)
+    assert torch.equal(out, torch.full((4,), value)), out
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "actual_hit": stats["guard_last_success_actual_hit"],
+    "actual_miss": stats["guard_last_success_actual_miss"],
+    "partial_hit": stats["guard_last_success_actual_partial_hit"],
+    "partial_residual_fail": stats[
+        "guard_last_success_actual_partial_residual_fail"
+    ],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        env["TORCHDYNAMO_GUARD_LOOKUP_STATS"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertGreaterEqual(stats["actual_hit"], 0)
+        self.assertGreaterEqual(stats["actual_miss"], 0)
+        self.assertGreaterEqual(stats["partial_hit"], 0)
+        self.assertEqual(stats["partial_residual_fail"], 0)
+
+    def test_guard_last_success_respects_module_buffer_replacement(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+
+class Mod(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.register_buffer("bias", torch.ones(4))
+
+    def forward(self, x):
+        return x + self.bias
+
+m = Mod()
+compiled = torch.compile(m, backend="eager")
+x = torch.zeros(4)
+assert torch.equal(compiled(x), torch.ones(4))
+
+guards.reset_guard_lookup_stats()
+for value in (2.0, 3.0, 4.0):
+    m.bias = torch.full((4,), value)
+    out = compiled(x)
+    assert torch.equal(out, torch.full((4,), value)), out
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "actual_hit": stats["guard_last_success_actual_hit"],
+    "actual_miss": stats["guard_last_success_actual_miss"],
+    "partial_hit": stats["guard_last_success_actual_partial_hit"],
+    "partial_residual_fail": stats[
+        "guard_last_success_actual_partial_residual_fail"
+    ],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        env["TORCHDYNAMO_GUARD_LOOKUP_STATS"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertGreaterEqual(stats["actual_hit"], 0)
+        self.assertGreaterEqual(stats["actual_miss"], 0)
+        self.assertGreaterEqual(stats["partial_hit"], 0)
+        self.assertEqual(stats["partial_residual_fail"], 0)
+
+    def test_guard_last_success_dynamic_shape_inputs_keep_working(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+
+def fn(x):
+    return x.sin() + 1
+
+compiled = torch.compile(fn, backend="eager", dynamic=True)
+guards.reset_guard_lookup_stats()
+for batch in (2, 5, 3, 7):
+    x = torch.randn(batch, 4)
+    out = compiled(x)
+    expected = fn(x)
+    assert out.shape == (batch, 4)
+    assert torch.allclose(out, expected)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "actual_hit": stats["guard_last_success_actual_hit"],
+    "actual_miss": stats["guard_last_success_actual_miss"],
+    "partial_hit": stats["guard_last_success_actual_partial_hit"],
+    "tensor_miss_reasons": stats["guard_fastplan_tensor_token_miss_reasons"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        env["TORCHDYNAMO_GUARD_LOOKUP_STATS"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertGreaterEqual(stats["actual_hit"], 0)
+        self.assertGreaterEqual(stats["actual_miss"], 0)
+        self.assertGreaterEqual(stats["partial_hit"], 0)
+        self.assertIsInstance(stats["tensor_miss_reasons"], dict)
+
+    def test_guard_last_success_global_dict_ignores_unrelated_version(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+
+GLOBAL_DICT = {"used": 1, "noise": 0}
+
+def fn(x):
+    return x + GLOBAL_DICT["used"]
+
+compiled = torch.compile(fn, backend="eager")
+x = torch.ones(4)
+assert torch.equal(compiled(x), x + GLOBAL_DICT["used"])
+
+guards.reset_guard_lookup_stats()
+for i in range(5):
+    GLOBAL_DICT["noise"] = i
+    out = compiled(x)
+    assert torch.equal(out, x + GLOBAL_DICT["used"])
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "success": stats["guard_last_success_shadow_success"],
+    "stable": stats["guard_last_success_shadow_stable"],
+    "reset": stats["guard_last_success_shadow_reset"],
+    "mismatch_top_paths": stats["guard_last_success_mismatch_top_paths"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        env["TORCHDYNAMO_GUARD_LOOKUP_STATS"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertGreater(stats["success"], 0)
+        self.assertGreater(stats["stable"], 0)
+        for path, item in stats["mismatch_top_paths"].items():
+            self.assertFalse(path.startswith("G") and item.get("reason") == "version")
+
+    def test_guard_last_success_supports_default_device_token(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+
+def fn(x):
+    return x + 1
+
+compiled = torch.compile(fn, backend="eager")
+x = torch.ones(4)
+guards.reset_guard_lookup_stats()
+for _ in range(5):
+    out = compiled(x)
+    assert torch.equal(out, x + 1)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "attempt": stats["guard_last_success_shadow_attempt"],
+    "success": stats["guard_last_success_shadow_success"],
+    "disabled_reasons": stats["guard_last_success_disabled_reasons"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        env["TORCHDYNAMO_GUARD_LOOKUP_STATS"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertGreater(stats["attempt"], 0)
+        self.assertGreaterEqual(stats["success"], 0)
+        self.assertEqual(
+            stats["disabled_reasons"].get("unsupported_leaf:DEFAULT_DEVICE", 0),
+            0,
+        )
+
+    def test_guard_last_success_supports_global_state_token(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+
+def fn(x):
+    return x + 1
+
+compiled = torch.compile(fn, backend="eager")
+x = torch.ones(4)
+guards.reset_guard_lookup_stats()
+for _ in range(5):
+    out = compiled(x)
+    assert torch.equal(out, x + 1)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "attempt": stats["guard_last_success_shadow_attempt"],
+    "success": stats["guard_last_success_shadow_success"],
+    "disabled_reasons": stats["guard_last_success_disabled_reasons"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        env["TORCHDYNAMO_GUARD_LOOKUP_STATS"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertGreater(stats["attempt"], 0)
+        self.assertGreaterEqual(stats["success"], 0)
+        self.assertEqual(
+            stats["disabled_reasons"].get("unsupported_leaf:GLOBAL_STATE", 0),
+            0,
+        )
+
+    def test_guard_last_success_supports_torch_function_mode_stack_token(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+
+def fn(x):
+    return x + 1
+
+compiled = torch.compile(fn, backend="eager")
+x = torch.ones(4)
+guards.reset_guard_lookup_stats()
+for _ in range(5):
+    out = compiled(x)
+    assert torch.equal(out, x + 1)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "attempt": stats["guard_last_success_shadow_attempt"],
+    "success": stats["guard_last_success_shadow_success"],
+    "disabled_reasons": stats["guard_last_success_disabled_reasons"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        env["TORCHDYNAMO_GUARD_LOOKUP_STATS"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertGreater(stats["attempt"], 0)
+        self.assertGreaterEqual(stats["success"], 0)
+        self.assertEqual(
+            stats["disabled_reasons"].get(
+                "unsupported_leaf:TORCH_FUNCTION_MODE_STACK", 0
+            ),
+            0,
+        )
+
+    def test_guard_fast_plan_subtree_memo_miss_disables_and_falls_back(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+from torch._C._dynamo.guards import RootGuardManager
+from torch._dynamo.guards import GuardManagerType
+
+class Mod(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.seq = torch.nn.Sequential(torch.nn.Linear(4, 4), torch.nn.ReLU())
+
+model = Mod()
+container = torch.nn.Module()
+container.child = model
+root = RootGuardManager()
+self_mgr = root.getitem_manager(
+    "self", "L['self']", container, GuardManagerType.GUARD_MANAGER
+)
+dict_mgr = self_mgr.get_generic_dict_manager(
+    "L['self'].__dict__", container.__dict__, GuardManagerType.GUARD_MANAGER
+)
+modules_mgr = dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules",
+    container._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+child_mgr = modules_mgr.getitem_manager(
+    "child",
+    "L['self']._modules['child']",
+    model,
+    GuardManagerType.GUARD_MANAGER,
+)
+child_dict_mgr = child_mgr.get_generic_dict_manager(
+    "L['self']._modules['child'].__dict__",
+    model.__dict__,
+    GuardManagerType.GUARD_MANAGER,
+)
+child_modules_mgr = child_dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules['child']._modules",
+    model._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+child_modules_mgr.add_dict_length_check_guard(
+    len(model._modules),
+    ["len(L['self']._modules['child']._modules) == 1"],
+)
+
+f_locals = {"self": container}
+guards.reset_guard_lookup_stats()
+for _ in range(6):
+    assert root.check(f_locals)
+
+model.extra = torch.nn.ReLU()
+assert not root.check(f_locals)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "enabled": stats["guard_fastplan_enabled"],
+    "hit": stats["guard_fastplan_hit"],
+    "miss": stats["guard_fastplan_miss"],
+    "disabled": stats["guard_fastplan_disabled"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        env["TORCHDYNAMO_GUARD_LOOKUP_STATS"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertTrue(stats["enabled"])
+        self.assertGreater(stats["hit"], 0)
+        self.assertGreater(stats["miss"], 0)
+        self.assertGreater(stats["disabled"], 0)
+
+    def test_guard_fast_plan_subtree_memo_detects_list_item_change(self):
+        script = r"""
+import json
+import torch
+from torch._C._dynamo import guards
+from torch._C._dynamo.guards import RootGuardManager
+from torch._dynamo.guards import GuardManagerType
+
+class Leaf(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.items = [1]
+
+class Child(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.leaf = Leaf()
+
+class Mod(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.child = Child()
+
+model = Mod()
+root = RootGuardManager()
+self_mgr = root.getitem_manager(
+    "self", "L['self']", model, GuardManagerType.GUARD_MANAGER
+)
+self_dict_mgr = self_mgr.get_generic_dict_manager(
+    "L['self'].__dict__", model.__dict__, GuardManagerType.GUARD_MANAGER
+)
+modules_mgr = self_dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules",
+    model._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+child_mgr = modules_mgr.getitem_manager(
+    "child",
+    "L['self']._modules['child']",
+    model.child,
+    GuardManagerType.GUARD_MANAGER,
+)
+child_dict_mgr = child_mgr.get_generic_dict_manager(
+    "L['self']._modules['child'].__dict__",
+    model.child.__dict__,
+    GuardManagerType.GUARD_MANAGER,
+)
+child_modules_mgr = child_dict_mgr.getitem_manager(
+    "_modules",
+    "L['self']._modules['child']._modules",
+    model.child._modules,
+    GuardManagerType.GUARD_MANAGER,
+)
+leaf_mgr = child_modules_mgr.getitem_manager(
+    "leaf",
+    "L['self']._modules['child']._modules['leaf']",
+    model.child.leaf,
+    GuardManagerType.GUARD_MANAGER,
+)
+leaf_dict_mgr = leaf_mgr.get_generic_dict_manager(
+    "L['self']._modules['child']._modules['leaf'].__dict__",
+    model.child.leaf.__dict__,
+    GuardManagerType.GUARD_MANAGER,
+)
+items_mgr = leaf_dict_mgr.getitem_manager(
+    "items",
+    "L['self']._modules['child']._modules['leaf'].items",
+    model.child.leaf.items,
+    GuardManagerType.GUARD_MANAGER,
+)
+item_mgr = items_mgr.getitem_manager(
+    0,
+    "L['self']._modules['child']._modules['leaf'].items[0]",
+    model.child.leaf.items[0],
+    GuardManagerType.GUARD_MANAGER,
+)
+item_mgr.add_equals_match_guard(
+    model.child.leaf.items[0],
+    ["L['self']._modules['child']._modules['leaf'].items[0] == 1"],
+)
+
+f_locals = {"self": model}
+guards.reset_guard_lookup_stats()
+for _ in range(6):
+    assert root.check(f_locals)
+
+model.child.leaf.items[0] = 2
+assert not root.check(f_locals)
+
+stats = guards.get_guard_lookup_stats()
+print(json.dumps({
+    "enabled": stats["guard_fastplan_enabled"],
+    "hit": stats["guard_fastplan_hit"],
+    "miss": stats["guard_fastplan_miss"],
+    "disabled": stats["guard_fastplan_disabled"],
+}))
+"""
+        env = os.environ.copy()
+        env["TORCHDYNAMO_GUARD_FAST_PLAN"] = "1"
+        env["TORCHDYNAMO_GUARD_LOOKUP_STATS"] = "1"
+        out = subprocess.check_output(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+        )
+        stats = json.loads(out.splitlines()[-1])
+
+        self.assertTrue(stats["enabled"])
+        self.assertGreater(stats["hit"], 0)
+        self.assertGreater(stats["miss"], 0)
+        self.assertGreater(stats["disabled"], 0)
 
 
 class TypePropagationTests(torch._dynamo.test_case.TestCase):

--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -1888,6 +1888,8 @@ weight_mgr.add_tensor_match_guard(
     list(model[0].weight.stride()),
     "L['self']._modules['child']._modules['0']._parameters['weight']",
     ["check_tensor(weight)"],
+    type(model[0].weight),
+    torch._C._dispatch_keys(model[0].weight),
 )
 
 f_locals = {"self": container}
@@ -2001,6 +2003,8 @@ cached_mgr.add_tensor_match_guard(
     list(model.other_tensor.stride()),
     "L['self']._modules['child']._modules['leaf'].other_tensor",
     ["check_tensor(cached)"],
+    type(model.other_tensor),
+    torch._C._dispatch_keys(model.other_tensor),
 )
 
 f_locals = {"self": container}
@@ -2097,6 +2101,8 @@ cached_mgr.add_tensor_match_guard(
     list(model._cached_tensor.stride()),
     "L['self']._modules['child']._modules['leaf']._cached_tensor",
     ["check_tensor(cached)"],
+    type(model._cached_tensor),
+    torch._C._dispatch_keys(model._cached_tensor),
 )
 
 f_locals = {"self": container}
@@ -2204,6 +2210,8 @@ scale_mgr.add_tensor_match_guard(
     list(model.scale.stride()),
     "L['self']._modules['child']._modules['leaf'].scale",
     ["check_tensor(scale)"],
+    type(model.scale),
+    torch._C._dispatch_keys(model.scale),
 )
 
 f_locals = {"self": container}

--- a/torch/csrc/dynamo/extra_state.cpp
+++ b/torch/csrc/dynamo/extra_state.cpp
@@ -27,7 +27,13 @@ CacheEntry* ExtraState::get_first_entry() {
 }
 
 ExtraState::ExtraState(PyCodeObject* orig_code_arg)
-    : orig_code(orig_code_arg) {}
+    : orig_code(orig_code_arg),
+      last_success_receipt(
+          torch::dynamo::create_guard_last_success_receipt()) {}
+
+ExtraState::~ExtraState() {
+  torch::dynamo::destroy_guard_last_success_receipt(last_success_receipt);
+}
 
 void ExtraState::move_to_front(CacheEntry* cache_entry) {
   CHECK(cache_entry->_owner == this);
@@ -63,6 +69,7 @@ void ExtraState::invalidate(
   CHECK(cache_entry->_owner == this);
   CHECK(!this->cache_entry_list.empty());
   CHECK(cache_entry == &*cache_entry->_owner_loc);
+  torch::dynamo::reset_guard_last_success_receipt(last_success_receipt);
   cache_entry->invalidate(std::move(deleted_guard_manager));
   // Move the cache entry to the end of the list because these will always
   // return False.
@@ -144,6 +151,15 @@ void lookup(
     PyObject** maybe_cached_code,
     const char** trace_annotation,
     bool is_skip_guard_eval_unsafe) {
+  const bool collect_stats = torch::dynamo::guard_lookup_stats_enabled();
+  const bool unsafe_mock_guard_bypass =
+      torch::dynamo::unsafe_mock_guard_bypass_enabled() &&
+      !is_skip_guard_eval_unsafe;
+  const uint64_t lookup_start_ns =
+      collect_stats ? torch::dynamo::guard_lookup_time_ns() : 0;
+  uint64_t backend_match_ns = 0;
+  uint64_t slow_guard_ns = 0;
+  uint64_t move_to_front_ns = 0;
   size_t index = 0;
   CacheEntry* found = nullptr;
 
@@ -157,17 +173,42 @@ void lookup(
   for (CacheEntry& cache_entry : extra_state->cache_entry_list) {
     // Check backend. Py_False means run only mode.
 
+    const uint64_t backend_match_start_ns =
+        collect_stats ? torch::dynamo::guard_lookup_time_ns() : 0;
     bool valid = backend == Py_False ||
         backend_match(cache_entry.backend.ptr(), backend);
+    if (collect_stats) {
+      backend_match_ns +=
+          torch::dynamo::guard_lookup_time_ns() - backend_match_start_ns;
+    }
 
     if (valid) {
       try {
-        if (is_skip_guard_eval_unsafe) {
-          valid = torch::dynamo::run_root_guard_manager(
-              cache_entry.diff_guard_root_mgr, f_locals);
+        if (unsafe_mock_guard_bypass) {
+          torch::dynamo::record_unsafe_mock_guard_bypass_stats(index);
+          valid = true;
         } else {
-          valid = torch::dynamo::run_root_guard_manager(
-              cache_entry.root_mgr, f_locals);
+          auto run_slow_guard = [&](void* root_mgr) {
+            const uint64_t slow_guard_start_ns =
+                collect_stats ? torch::dynamo::guard_lookup_time_ns() : 0;
+            const bool slow_guard_result =
+                torch::dynamo::run_root_guard_manager_with_last_success_receipt(
+                    extra_state->last_success_receipt,
+                    &cache_entry,
+                    root_mgr,
+                    f_locals,
+                    is_skip_guard_eval_unsafe);
+            if (collect_stats) {
+              slow_guard_ns +=
+                  torch::dynamo::guard_lookup_time_ns() - slow_guard_start_ns;
+            }
+            return slow_guard_result;
+          };
+          if (is_skip_guard_eval_unsafe) {
+            valid = run_slow_guard(cache_entry.diff_guard_root_mgr);
+          } else {
+            valid = run_slow_guard(cache_entry.root_mgr);
+          }
         }
       } catch (py::error_already_set& e) {
         if (guard_error_hook) {
@@ -195,11 +236,35 @@ void lookup(
   }
   if (found) {
     if (use_lru) {
+      const uint64_t move_to_front_start_ns =
+          collect_stats ? torch::dynamo::guard_lookup_time_ns() : 0;
       extra_state->move_to_front(found);
+      if (collect_stats) {
+        move_to_front_ns =
+            torch::dynamo::guard_lookup_time_ns() - move_to_front_start_ns;
+      }
+    }
+    if (collect_stats) {
+      torch::dynamo::record_guard_lookup_stats(
+          torch::dynamo::guard_lookup_time_ns() - lookup_start_ns,
+          backend_match_ns,
+          slow_guard_ns,
+          move_to_front_ns,
+          extra_state->cache_entry_list.size(),
+          index);
     }
     *maybe_cached_code = found->code.ptr();
     *trace_annotation = found->trace_annotation.c_str();
     return;
+  }
+  if (collect_stats) {
+    torch::dynamo::record_guard_lookup_stats(
+        torch::dynamo::guard_lookup_time_ns() - lookup_start_ns,
+        backend_match_ns,
+        slow_guard_ns,
+        move_to_front_ns,
+        extra_state->cache_entry_list.size(),
+        extra_state->cache_entry_list.size());
   }
   *maybe_cached_code = py::none().ptr();
 }
@@ -208,6 +273,8 @@ CacheEntry* create_cache_entry(
     ExtraState* extra_state,
     PyObject* guarded_code,
     PyObject* backend) {
+  torch::dynamo::reset_guard_last_success_receipt(
+      extra_state->last_success_receipt);
   std::list<CacheEntry>::iterator new_iter;
   if (use_lru) {
     extra_state->cache_entry_list.emplace_front(guarded_code, backend);

--- a/torch/csrc/dynamo/extra_state.h
+++ b/torch/csrc/dynamo/extra_state.h
@@ -66,8 +66,11 @@ typedef struct VISIBILITY_HIDDEN ExtraState {
   py::dict frame_state;
   // Actions to apply to all frames with this code object
   FrameExecStrategy strategy{DEFAULT, DEFAULT};
+  // Opaque guard receipt used by Dynamo guard shadow diagnostics.
+  void* last_success_receipt{nullptr};
 
   ExtraState(PyCodeObject* orig_code_arg);
+  ~ExtraState();
   CacheEntry* get_first_entry();
   void move_to_front(CacheEntry* cache_entry);
   void move_to_back(CacheEntry* cache_entry);

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -3,12 +3,14 @@
 #include <c10/core/SafePyObject.h>
 #include <c10/core/impl/PyInterpreter.h>
 #include <c10/util/Exception.h>
+#include <c10/util/env.h>
 #define PY_SSIZE_T_CLEAN
 #include <ATen/EmptyTensor.h>
 #include <ATen/SparseCsrTensorUtils.h>
 #include <c10/util/flat_hash_map.h>
 #include <fmt/format.h>
 #include <torch/csrc/autograd/grad_mode.h>
+#include <torch/csrc/autograd/python_variable.h>
 #include <torch/csrc/autograd/utils/wrap_outputs.h>
 #include <torch/csrc/dynamo/guards.h>
 #include <torch/csrc/inductor/inductor_ops.h>
@@ -37,10 +39,19 @@
 #include <ATen/native/mtia/EmptyTensor.h>
 #endif
 
+#include <algorithm>
+#include <array>
+#include <atomic>
 #include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <mutex>
+#include <optional>
 #include <sstream>
 #include <tuple>
+#include <unordered_map>
 #include <utility>
+#include <vector>
 
 // Uncomment next line to count instructions for guard eval.
 // #define GUARD_INSTRUCTION_COUNT
@@ -122,6 +133,2274 @@ typedef struct {
 
 namespace torch::dynamo {
 
+namespace {
+
+struct GuardLookupStats {
+  std::atomic<uint64_t> lookup_count{0};
+  std::atomic<uint64_t> lookup_total_ns{0};
+  std::atomic<uint64_t> backend_match_ns{0};
+  std::atomic<uint64_t> slow_guard_ns{0};
+  std::atomic<uint64_t> move_to_front_ns{0};
+  std::atomic<uint64_t> cache_entry_count_sum{0};
+  std::atomic<uint64_t> cache_entry_hit_index_sum{0};
+
+  std::atomic<uint64_t> root_guard_count{0};
+  std::atomic<uint64_t> root_guard_total_ns{0};
+  std::atomic<uint64_t> root_guard_lock_ns{0};
+  std::atomic<uint64_t> root_guard_local_state_ns{0};
+  std::atomic<uint64_t> root_guard_leaf_ns{0};
+  std::atomic<uint64_t> root_guard_accessor_ns{0};
+  std::atomic<uint64_t> root_guard_epilogue_ns{0};
+  std::atomic<uint64_t> root_guard_tls_ns{0};
+
+  std::atomic<uint64_t> unsafe_mock_guard_bypass_count{0};
+  std::atomic<uint64_t> unsafe_mock_guard_bypass_hit_index_sum{0};
+};
+
+enum class GuardSubtreeProbeMode {
+  Off,
+  Summary,
+  Detail,
+};
+
+enum class GuardSubtreeProbeTokenKind : uint8_t {
+  ObjectOnly,
+  ExactDict,
+  ExactList,
+  ExactTuple,
+  TensorMatch,
+  DefaultDevice,
+  GlobalState,
+  TorchFunctionModeStack,
+  NoTensorAliasing,
+  ObjectAliasing,
+  BoundMethod,
+  FrameGlobals,
+};
+
+constexpr size_t kGuardSubtreeProbeTokenKindCount = 12;
+
+enum class GuardFastPlanCandidateKind : uint8_t {
+  Unknown,
+  None,
+  TopModules,
+  NestedModules,
+};
+
+enum class GuardFastPlanTensorTokenMissReason : uint8_t {
+  None,
+  MissingLocalState,
+  Object,
+  Type,
+  NotTensor,
+  DispatchKey,
+  DType,
+  Device,
+  RequiresGrad,
+  Dim,
+  Size,
+  Stride,
+};
+
+enum class GuardLastSuccessCompareMismatchReason : uint8_t {
+  EntryKey,
+  RootKey,
+  EmptyPrevious,
+  Size,
+  Kind,
+  Object,
+  Type,
+  TensorMeta,
+  DefaultDevice,
+  GlobalState,
+  TorchFunctionModeStack,
+  NoTensorAliasing,
+  ObjectAliasing,
+  BoundMethod,
+  Version,
+  DictSize,
+  ListItems,
+  Unknown,
+};
+
+struct GuardSubtreeProbeStats {
+  std::atomic<uint64_t> attempt{0};
+  std::atomic<uint64_t> entry_match{0};
+  std::atomic<uint64_t> entry_miss{0};
+  std::atomic<uint64_t> shadow_ok{0};
+  std::atomic<uint64_t> mismatch{0};
+  std::atomic<uint64_t> disabled{0};
+  std::atomic<uint64_t> entry_check_ns{0};
+  std::atomic<uint64_t> child_check_ns{0};
+  std::atomic<uint64_t> token_object_only{0};
+  std::atomic<uint64_t> token_exact_dict{0};
+  std::atomic<uint64_t> token_exact_list{0};
+  std::atomic<uint64_t> token_exact_tuple{0};
+  std::atomic<uint64_t> token_tensor_match{0};
+  std::atomic<uint64_t> token_default_device{0};
+  std::atomic<uint64_t> token_global_state{0};
+  std::atomic<uint64_t> token_torch_function_mode_stack{0};
+  std::atomic<uint64_t> token_no_tensor_aliasing{0};
+  std::atomic<uint64_t> token_object_aliasing{0};
+  std::atomic<uint64_t> token_bound_method{0};
+  std::atomic<uint64_t> token_frame_globals{0};
+};
+
+struct GuardFastPlanStats {
+  std::atomic<uint64_t> candidate{0};
+  std::atomic<uint64_t> candidate_top{0};
+  std::atomic<uint64_t> candidate_nested{0};
+  std::atomic<uint64_t> shadow_pass{0};
+  std::atomic<uint64_t> shadow_pass_top{0};
+  std::atomic<uint64_t> shadow_pass_nested{0};
+  std::atomic<uint64_t> partial_shadow_pass{0};
+  std::atomic<uint64_t> enable{0};
+  std::atomic<uint64_t> enable_top{0};
+  std::atomic<uint64_t> enable_nested{0};
+  std::atomic<uint64_t> partial_enable{0};
+  std::atomic<uint64_t> hit{0};
+  std::atomic<uint64_t> hit_top{0};
+  std::atomic<uint64_t> hit_nested{0};
+  std::atomic<uint64_t> partial_hit{0};
+  std::atomic<uint64_t> miss{0};
+  std::atomic<uint64_t> miss_top{0};
+  std::atomic<uint64_t> miss_nested{0};
+  std::atomic<uint64_t> disabled{0};
+  std::atomic<uint64_t> disabled_top{0};
+  std::atomic<uint64_t> disabled_nested{0};
+  std::atomic<uint64_t> token_count_sum{0};
+  std::atomic<uint64_t> token_check_ns{0};
+  std::atomic<uint64_t> slow_check_ns{0};
+  std::atomic<uint64_t> token_cap_disabled{0};
+  std::atomic<uint64_t> tensor_token_shadow{0};
+  std::atomic<uint64_t> tensor_token_hit{0};
+  std::atomic<uint64_t> tensor_token_miss{0};
+  std::atomic<uint64_t> tensor_token_check_ns{0};
+  std::atomic<uint64_t> tensor_token_count_sum{0};
+  std::atomic<uint64_t> tensor_token_miss_missing_local_state{0};
+  std::atomic<uint64_t> tensor_token_miss_object{0};
+  std::atomic<uint64_t> tensor_token_miss_type{0};
+  std::atomic<uint64_t> tensor_token_miss_not_tensor{0};
+  std::atomic<uint64_t> tensor_token_miss_dispatch_key{0};
+  std::atomic<uint64_t> tensor_token_miss_dtype{0};
+  std::atomic<uint64_t> tensor_token_miss_device{0};
+  std::atomic<uint64_t> tensor_token_miss_requires_grad{0};
+  std::atomic<uint64_t> tensor_token_miss_dim{0};
+  std::atomic<uint64_t> tensor_token_miss_size{0};
+  std::atomic<uint64_t> tensor_token_miss_stride{0};
+};
+
+struct GuardLastSuccessStats {
+  std::atomic<uint64_t> shadow_attempt{0};
+  std::atomic<uint64_t> shadow_success{0};
+  std::atomic<uint64_t> shadow_incomplete{0};
+  std::atomic<uint64_t> shadow_stable{0};
+  std::atomic<uint64_t> shadow_reset{0};
+  std::atomic<uint64_t> shadow_max_passes{0};
+  std::atomic<uint64_t> token_count_sum{0};
+  std::atomic<uint64_t> token_cap_disabled{0};
+  std::atomic<uint64_t> token_cap_count_sum{0};
+  std::atomic<uint64_t> token_cap_count_max{0};
+  std::atomic<uint64_t> support_check_ns{0};
+  std::atomic<uint64_t> receipt_update_ns{0};
+  std::atomic<uint64_t> receipt_compare_ns{0};
+  std::atomic<uint64_t> compare_mismatch{0};
+  std::atomic<uint64_t> compare_mismatch_index_sum{0};
+  std::atomic<uint64_t> compare_mismatch_index_max{0};
+  std::atomic<uint64_t> actual_attempt{0};
+  std::atomic<uint64_t> actual_hit{0};
+  std::atomic<uint64_t> actual_miss{0};
+  std::atomic<uint64_t> actual_enable{0};
+  std::atomic<uint64_t> actual_disabled{0};
+  std::atomic<uint64_t> actual_hot_token_count_sum{0};
+  std::atomic<uint64_t> actual_token_check_ns{0};
+  std::atomic<uint64_t> actual_train_ns{0};
+  std::atomic<uint64_t> actual_partial_attempt{0};
+  std::atomic<uint64_t> actual_partial_hit{0};
+  std::atomic<uint64_t> actual_partial_miss{0};
+  std::atomic<uint64_t> actual_partial_enable{0};
+  std::atomic<uint64_t> actual_partial_disabled{0};
+  std::atomic<uint64_t> actual_partial_residual_fail{0};
+  std::atomic<uint64_t> actual_partial_hot_token_count_sum{0};
+  std::atomic<uint64_t> actual_partial_hot_token_unique_count_sum{0};
+  std::atomic<uint64_t> actual_partial_hot_token_duplicate_count_sum{0};
+  std::atomic<uint64_t> actual_partial_hot_token_object_only{0};
+  std::atomic<uint64_t> actual_partial_hot_token_exact_dict{0};
+  std::atomic<uint64_t> actual_partial_hot_token_exact_list{0};
+  std::atomic<uint64_t> actual_partial_hot_token_exact_tuple{0};
+  std::atomic<uint64_t> actual_partial_hot_token_tensor_match{0};
+  std::atomic<uint64_t> actual_partial_hot_token_default_device{0};
+  std::atomic<uint64_t> actual_partial_hot_token_global_state{0};
+  std::atomic<uint64_t> actual_partial_hot_token_torch_function_mode_stack{0};
+  std::atomic<uint64_t> actual_partial_hot_token_no_tensor_aliasing{0};
+  std::atomic<uint64_t> actual_partial_hot_token_object_aliasing{0};
+  std::atomic<uint64_t> actual_partial_hot_token_bound_method{0};
+  std::atomic<uint64_t> actual_partial_hot_token_frame_globals{0};
+  std::atomic<uint64_t> actual_partial_hot_token_duplicate_object_only{0};
+  std::atomic<uint64_t> actual_partial_hot_token_duplicate_exact_dict{0};
+  std::atomic<uint64_t> actual_partial_hot_token_duplicate_exact_list{0};
+  std::atomic<uint64_t> actual_partial_hot_token_duplicate_exact_tuple{0};
+  std::atomic<uint64_t> actual_partial_hot_token_duplicate_tensor_match{0};
+  std::atomic<uint64_t> actual_partial_hot_token_duplicate_default_device{0};
+  std::atomic<uint64_t> actual_partial_hot_token_duplicate_global_state{0};
+  std::atomic<uint64_t>
+      actual_partial_hot_token_duplicate_torch_function_mode_stack{0};
+  std::atomic<uint64_t> actual_partial_hot_token_duplicate_no_tensor_aliasing{0};
+  std::atomic<uint64_t> actual_partial_hot_token_duplicate_object_aliasing{0};
+  std::atomic<uint64_t> actual_partial_hot_token_duplicate_bound_method{0};
+  std::atomic<uint64_t> actual_partial_hot_token_duplicate_frame_globals{0};
+  std::atomic<uint64_t> actual_partial_token_check_ns{0};
+  std::atomic<uint64_t> actual_partial_residual_ns{0};
+  std::atomic<uint64_t> actual_partial_shadow_full_pass{0};
+  std::atomic<uint64_t> actual_partial_shadow_full_fail{0};
+  std::atomic<uint64_t> actual_partial_shadow_full_ns{0};
+  std::atomic<uint64_t> actual_partial_train_ns{0};
+};
+
+struct GuardFastPlanDisabledPathStats {
+  uint64_t count{0};
+  std::string reason;
+  bool has_mismatch_detail{false};
+  std::string old_kind;
+  std::string new_kind;
+  std::string old_type;
+  std::string new_type;
+  uint64_t old_object_id{0};
+  uint64_t new_object_id{0};
+  uint64_t old_version{0};
+  uint64_t new_version{0};
+  Py_ssize_t old_size{0};
+  Py_ssize_t new_size{0};
+};
+
+struct GuardAccessorTypeStats {
+  uint64_t count{0};
+  uint64_t fail_count{0};
+  uint64_t inclusive_ns{0};
+};
+
+struct GuardAccessorDetailStats {
+  uint64_t count{0};
+  uint64_t fail_count{0};
+  uint64_t self_ns{0};
+  uint64_t child_ns{0};
+  uint64_t inclusive_ns{0};
+};
+
+struct GuardLeafStats {
+  uint64_t count{0};
+  uint64_t fail_count{0};
+  uint64_t inclusive_ns{0};
+};
+
+struct GuardSubtreeProbePathStats {
+  uint64_t attempt{0};
+  uint64_t entry_match{0};
+  uint64_t entry_miss{0};
+  uint64_t shadow_ok{0};
+  uint64_t mismatch{0};
+  uint64_t disabled{0};
+  uint64_t entry_check_ns{0};
+  uint64_t child_check_ns{0};
+  uint64_t token_object_only{0};
+  uint64_t token_exact_dict{0};
+  uint64_t token_exact_list{0};
+  uint64_t token_exact_tuple{0};
+  uint64_t token_tensor_match{0};
+  uint64_t token_default_device{0};
+  uint64_t token_global_state{0};
+  uint64_t token_torch_function_mode_stack{0};
+  uint64_t token_no_tensor_aliasing{0};
+  uint64_t token_object_aliasing{0};
+  uint64_t token_bound_method{0};
+  uint64_t token_frame_globals{0};
+};
+
+constexpr size_t kGuardAccessorDetailStatsTopK = 64;
+constexpr size_t kGuardLeafDetailStatsTopK = 64;
+constexpr size_t kGuardSubtreeProbeTopK = 64;
+constexpr size_t kGuardFastPlanDisabledTopK = 64;
+constexpr size_t kGuardFastPlanMaxTokens = 1024;
+constexpr size_t kGuardLastSuccessShadowMaxTokens = 65536;
+constexpr size_t kGuardLastSuccessActualMaxTokens = 65536;
+constexpr uint64_t kGuardLastSuccessActualStablePasses = 3;
+constexpr size_t kGuardSubtreeMemoSupportAnalysisMaxItems = 1024;
+
+struct GuardSubtreeMemoSupportAnalysis {
+  std::string reason;
+  std::string path;
+  bool collect_all{false};
+  std::vector<std::pair<std::string, std::string>> unsupported;
+
+  void set_if_empty(const char* new_reason, const std::string& new_path) {
+    const std::string resolved_reason =
+        new_reason == nullptr ? "unsupported:unknown" : new_reason;
+    if (collect_all &&
+        unsupported.size() < kGuardSubtreeMemoSupportAnalysisMaxItems) {
+      unsupported.emplace_back(resolved_reason, new_path);
+    }
+    if (!reason.empty()) {
+      return;
+    }
+    reason = resolved_reason;
+    path = new_path;
+  }
+};
+
+GuardLookupStats& guard_lookup_stats() {
+  static GuardLookupStats stats;
+  return stats;
+}
+
+GuardSubtreeProbeStats& guard_subtree_probe_stats() {
+  static GuardSubtreeProbeStats stats;
+  return stats;
+}
+
+GuardFastPlanStats& guard_fastplan_stats() {
+  static GuardFastPlanStats stats;
+  return stats;
+}
+
+GuardLastSuccessStats& guard_last_success_stats() {
+  static GuardLastSuccessStats stats;
+  return stats;
+}
+
+std::atomic<bool>& guard_lookup_stats_force_enabled() {
+  static std::atomic<bool> enabled{false};
+  return enabled;
+}
+
+void store_zero(std::atomic<uint64_t>& value) {
+  value.store(0, std::memory_order_relaxed);
+}
+
+uint64_t load_relaxed(const std::atomic<uint64_t>& value) {
+  return value.load(std::memory_order_relaxed);
+}
+
+void add_relaxed(std::atomic<uint64_t>& value, uint64_t delta) {
+  value.fetch_add(delta, std::memory_order_relaxed);
+}
+
+void max_relaxed(std::atomic<uint64_t>& value, uint64_t candidate) {
+  uint64_t current = value.load(std::memory_order_relaxed);
+  while (candidate > current &&
+         !value.compare_exchange_weak(
+             current,
+             candidate,
+             std::memory_order_relaxed,
+             std::memory_order_relaxed)) {
+  }
+}
+
+std::mutex& guard_accessor_type_stats_mutex() {
+  static std::mutex mutex;
+  return mutex;
+}
+
+std::unordered_map<std::string, GuardAccessorTypeStats>&
+guard_accessor_type_stats() {
+  static std::unordered_map<std::string, GuardAccessorTypeStats> stats;
+  return stats;
+}
+
+std::mutex& guard_accessor_detail_stats_mutex() {
+  static std::mutex mutex;
+  return mutex;
+}
+
+std::unordered_map<std::string, GuardAccessorDetailStats>&
+guard_accessor_detail_stats() {
+  static std::unordered_map<std::string, GuardAccessorDetailStats> stats;
+  return stats;
+}
+
+std::mutex& guard_leaf_type_stats_mutex() {
+  static std::mutex mutex;
+  return mutex;
+}
+
+std::unordered_map<std::string, GuardLeafStats>& guard_leaf_type_stats() {
+  static std::unordered_map<std::string, GuardLeafStats> stats;
+  return stats;
+}
+
+std::mutex& guard_leaf_detail_stats_mutex() {
+  static std::mutex mutex;
+  return mutex;
+}
+
+std::unordered_map<std::string, GuardLeafStats>& guard_leaf_detail_stats() {
+  static std::unordered_map<std::string, GuardLeafStats> stats;
+  return stats;
+}
+
+std::mutex& guard_subtree_probe_path_stats_mutex() {
+  static std::mutex mutex;
+  return mutex;
+}
+
+std::unordered_map<std::string, GuardSubtreeProbePathStats>&
+guard_subtree_probe_path_stats() {
+  static std::unordered_map<std::string, GuardSubtreeProbePathStats> stats;
+  return stats;
+}
+
+std::mutex& guard_fastplan_disabled_stats_mutex() {
+  static std::mutex mutex;
+  return mutex;
+}
+
+std::unordered_map<std::string, uint64_t>&
+guard_fastplan_disabled_reason_stats() {
+  static std::unordered_map<std::string, uint64_t> stats;
+  return stats;
+}
+
+std::unordered_map<std::string, GuardFastPlanDisabledPathStats>&
+guard_fastplan_disabled_path_stats() {
+  static std::unordered_map<std::string, GuardFastPlanDisabledPathStats> stats;
+  return stats;
+}
+
+std::mutex& guard_last_success_disabled_stats_mutex() {
+  static std::mutex mutex;
+  return mutex;
+}
+
+std::unordered_map<std::string, uint64_t>&
+guard_last_success_disabled_reason_stats() {
+  static std::unordered_map<std::string, uint64_t> stats;
+  return stats;
+}
+
+std::unordered_map<std::string, GuardFastPlanDisabledPathStats>&
+guard_last_success_disabled_path_stats() {
+  static std::unordered_map<std::string, GuardFastPlanDisabledPathStats> stats;
+  return stats;
+}
+
+std::mutex& guard_last_success_mismatch_stats_mutex() {
+  static std::mutex mutex;
+  return mutex;
+}
+
+std::unordered_map<std::string, uint64_t>&
+guard_last_success_mismatch_reason_stats() {
+  static std::unordered_map<std::string, uint64_t> stats;
+  return stats;
+}
+
+std::unordered_map<std::string, uint64_t>&
+guard_last_success_mismatch_kind_stats() {
+  static std::unordered_map<std::string, uint64_t> stats;
+  return stats;
+}
+
+std::unordered_map<std::string, GuardFastPlanDisabledPathStats>&
+guard_last_success_mismatch_path_stats() {
+  static std::unordered_map<std::string, GuardFastPlanDisabledPathStats> stats;
+  return stats;
+}
+
+std::mutex& guard_last_success_partial_shadow_stats_mutex() {
+  static std::mutex mutex;
+  return mutex;
+}
+
+std::unordered_map<std::string, uint64_t>&
+guard_last_success_partial_shadow_fail_reason_stats() {
+  static std::unordered_map<std::string, uint64_t> stats;
+  return stats;
+}
+
+std::unordered_map<std::string, GuardFastPlanDisabledPathStats>&
+guard_last_success_partial_shadow_fail_path_stats() {
+  static std::unordered_map<std::string, GuardFastPlanDisabledPathStats> stats;
+  return stats;
+}
+
+} // namespace
+
+bool guard_lookup_stats_enabled() {
+  static const bool env_enabled =
+      c10::utils::check_env("TORCHDYNAMO_GUARD_LOOKUP_STATS") == true;
+  const bool force_enabled =
+      guard_lookup_stats_force_enabled().load(std::memory_order_relaxed);
+  return C10_UNLIKELY(env_enabled) || C10_UNLIKELY(force_enabled);
+}
+
+static GuardSubtreeProbeMode guard_subtree_probe_mode() {
+  static const GuardSubtreeProbeMode mode = [] {
+    const auto env = c10::utils::get_env("TORCHDYNAMO_GUARD_SUBTREE_PROBE");
+    const std::string value = env.value_or("");
+    if (value.empty() || value == "0" || value == "false" ||
+        value == "False" || value == "off") {
+      return GuardSubtreeProbeMode::Off;
+    }
+    if (value == "detail") {
+      // Keep the environment value accepted, but collapse detail into summary
+      // on the hot-core branch to avoid path-name aggregation overhead.
+      return GuardSubtreeProbeMode::Summary;
+    }
+    if (value == "summary" || value == "1" || value == "true" ||
+        value == "True") {
+      return GuardSubtreeProbeMode::Summary;
+    }
+    return GuardSubtreeProbeMode::Off;
+  }();
+  return mode;
+}
+
+static const char* guard_subtree_probe_mode_name() {
+  switch (guard_subtree_probe_mode()) {
+    case GuardSubtreeProbeMode::Summary:
+      return "summary";
+    case GuardSubtreeProbeMode::Detail:
+      return "detail";
+    case GuardSubtreeProbeMode::Off:
+      return "off";
+  }
+  return "off";
+}
+
+static bool guard_fast_plan_enabled() {
+  static const bool env_enabled =
+      c10::utils::check_env("TORCHDYNAMO_GUARD_FAST_PLAN") == true;
+  return C10_UNLIKELY(env_enabled);
+}
+
+static bool guard_subtree_probe_enabled() {
+  static const bool enabled = guard_fast_plan_enabled() &&
+      guard_subtree_probe_mode() != GuardSubtreeProbeMode::Off;
+  return C10_UNLIKELY(enabled);
+}
+
+static bool guard_subtree_probe_detail_enabled() {
+  static const bool detail_enabled = guard_subtree_probe_enabled() &&
+      guard_subtree_probe_mode() == GuardSubtreeProbeMode::Detail;
+  return C10_UNLIKELY(detail_enabled);
+}
+
+bool unsafe_mock_guard_bypass_enabled() {
+  static const bool env_enabled =
+      c10::utils::check_env("TORCHDYNAMO_UNSAFE_MOCK_GUARD_BYPASS") == true;
+  return C10_UNLIKELY(env_enabled);
+}
+
+uint64_t guard_lookup_time_ns() {
+  return static_cast<uint64_t>(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(
+          std::chrono::steady_clock::now().time_since_epoch())
+          .count());
+}
+
+void reset_guard_lookup_stats(bool force_enable) {
+  auto& stats = guard_lookup_stats();
+  auto& subtree_stats = guard_subtree_probe_stats();
+  auto& fastplan_stats = guard_fastplan_stats();
+  auto& last_success_stats = guard_last_success_stats();
+  store_zero(stats.lookup_count);
+  store_zero(stats.lookup_total_ns);
+  store_zero(stats.backend_match_ns);
+  store_zero(stats.slow_guard_ns);
+  store_zero(stats.move_to_front_ns);
+  store_zero(stats.cache_entry_count_sum);
+  store_zero(stats.cache_entry_hit_index_sum);
+  store_zero(stats.root_guard_count);
+  store_zero(stats.root_guard_total_ns);
+  store_zero(stats.root_guard_lock_ns);
+  store_zero(stats.root_guard_local_state_ns);
+  store_zero(stats.root_guard_leaf_ns);
+  store_zero(stats.root_guard_accessor_ns);
+  store_zero(stats.root_guard_epilogue_ns);
+  store_zero(stats.root_guard_tls_ns);
+  store_zero(stats.unsafe_mock_guard_bypass_count);
+  store_zero(stats.unsafe_mock_guard_bypass_hit_index_sum);
+  store_zero(subtree_stats.attempt);
+  store_zero(subtree_stats.entry_match);
+  store_zero(subtree_stats.entry_miss);
+  store_zero(subtree_stats.shadow_ok);
+  store_zero(subtree_stats.mismatch);
+  store_zero(subtree_stats.disabled);
+  store_zero(subtree_stats.entry_check_ns);
+  store_zero(subtree_stats.child_check_ns);
+  store_zero(subtree_stats.token_object_only);
+  store_zero(subtree_stats.token_exact_dict);
+  store_zero(subtree_stats.token_exact_list);
+  store_zero(subtree_stats.token_exact_tuple);
+  store_zero(subtree_stats.token_tensor_match);
+  store_zero(subtree_stats.token_default_device);
+  store_zero(subtree_stats.token_global_state);
+  store_zero(subtree_stats.token_torch_function_mode_stack);
+  store_zero(subtree_stats.token_no_tensor_aliasing);
+  store_zero(subtree_stats.token_object_aliasing);
+  store_zero(subtree_stats.token_bound_method);
+  store_zero(subtree_stats.token_frame_globals);
+  store_zero(fastplan_stats.candidate);
+  store_zero(fastplan_stats.candidate_top);
+  store_zero(fastplan_stats.candidate_nested);
+  store_zero(fastplan_stats.shadow_pass);
+  store_zero(fastplan_stats.shadow_pass_top);
+  store_zero(fastplan_stats.shadow_pass_nested);
+  store_zero(fastplan_stats.partial_shadow_pass);
+  store_zero(fastplan_stats.enable);
+  store_zero(fastplan_stats.enable_top);
+  store_zero(fastplan_stats.enable_nested);
+  store_zero(fastplan_stats.partial_enable);
+  store_zero(fastplan_stats.hit);
+  store_zero(fastplan_stats.hit_top);
+  store_zero(fastplan_stats.hit_nested);
+  store_zero(fastplan_stats.partial_hit);
+  store_zero(fastplan_stats.miss);
+  store_zero(fastplan_stats.miss_top);
+  store_zero(fastplan_stats.miss_nested);
+  store_zero(fastplan_stats.disabled);
+  store_zero(fastplan_stats.disabled_top);
+  store_zero(fastplan_stats.disabled_nested);
+  store_zero(fastplan_stats.token_count_sum);
+  store_zero(fastplan_stats.token_check_ns);
+  store_zero(fastplan_stats.slow_check_ns);
+  store_zero(fastplan_stats.token_cap_disabled);
+  store_zero(fastplan_stats.tensor_token_shadow);
+  store_zero(fastplan_stats.tensor_token_hit);
+  store_zero(fastplan_stats.tensor_token_miss);
+  store_zero(fastplan_stats.tensor_token_check_ns);
+  store_zero(fastplan_stats.tensor_token_count_sum);
+  store_zero(fastplan_stats.tensor_token_miss_missing_local_state);
+  store_zero(fastplan_stats.tensor_token_miss_object);
+  store_zero(fastplan_stats.tensor_token_miss_type);
+  store_zero(fastplan_stats.tensor_token_miss_not_tensor);
+  store_zero(fastplan_stats.tensor_token_miss_dispatch_key);
+  store_zero(fastplan_stats.tensor_token_miss_dtype);
+  store_zero(fastplan_stats.tensor_token_miss_device);
+  store_zero(fastplan_stats.tensor_token_miss_requires_grad);
+  store_zero(fastplan_stats.tensor_token_miss_dim);
+  store_zero(fastplan_stats.tensor_token_miss_size);
+  store_zero(fastplan_stats.tensor_token_miss_stride);
+  store_zero(last_success_stats.shadow_attempt);
+  store_zero(last_success_stats.shadow_success);
+  store_zero(last_success_stats.shadow_incomplete);
+  store_zero(last_success_stats.shadow_stable);
+  store_zero(last_success_stats.shadow_reset);
+  store_zero(last_success_stats.shadow_max_passes);
+  store_zero(last_success_stats.token_count_sum);
+  store_zero(last_success_stats.token_cap_disabled);
+  store_zero(last_success_stats.token_cap_count_sum);
+  store_zero(last_success_stats.token_cap_count_max);
+  store_zero(last_success_stats.support_check_ns);
+  store_zero(last_success_stats.receipt_update_ns);
+  store_zero(last_success_stats.receipt_compare_ns);
+  store_zero(last_success_stats.compare_mismatch);
+  store_zero(last_success_stats.compare_mismatch_index_sum);
+  store_zero(last_success_stats.compare_mismatch_index_max);
+  store_zero(last_success_stats.actual_attempt);
+  store_zero(last_success_stats.actual_hit);
+  store_zero(last_success_stats.actual_miss);
+  store_zero(last_success_stats.actual_enable);
+  store_zero(last_success_stats.actual_disabled);
+  store_zero(last_success_stats.actual_hot_token_count_sum);
+  store_zero(last_success_stats.actual_token_check_ns);
+  store_zero(last_success_stats.actual_train_ns);
+  store_zero(last_success_stats.actual_partial_attempt);
+  store_zero(last_success_stats.actual_partial_hit);
+  store_zero(last_success_stats.actual_partial_miss);
+  store_zero(last_success_stats.actual_partial_enable);
+  store_zero(last_success_stats.actual_partial_disabled);
+  store_zero(last_success_stats.actual_partial_residual_fail);
+  store_zero(last_success_stats.actual_partial_hot_token_count_sum);
+  store_zero(last_success_stats.actual_partial_hot_token_unique_count_sum);
+  store_zero(last_success_stats.actual_partial_hot_token_duplicate_count_sum);
+  store_zero(last_success_stats.actual_partial_hot_token_object_only);
+  store_zero(last_success_stats.actual_partial_hot_token_exact_dict);
+  store_zero(last_success_stats.actual_partial_hot_token_exact_list);
+  store_zero(last_success_stats.actual_partial_hot_token_exact_tuple);
+  store_zero(last_success_stats.actual_partial_hot_token_tensor_match);
+  store_zero(last_success_stats.actual_partial_hot_token_default_device);
+  store_zero(last_success_stats.actual_partial_hot_token_global_state);
+  store_zero(
+      last_success_stats.actual_partial_hot_token_torch_function_mode_stack);
+  store_zero(last_success_stats.actual_partial_hot_token_no_tensor_aliasing);
+  store_zero(last_success_stats.actual_partial_hot_token_object_aliasing);
+  store_zero(last_success_stats.actual_partial_hot_token_bound_method);
+  store_zero(last_success_stats.actual_partial_hot_token_frame_globals);
+  store_zero(last_success_stats.actual_partial_hot_token_duplicate_object_only);
+  store_zero(last_success_stats.actual_partial_hot_token_duplicate_exact_dict);
+  store_zero(last_success_stats.actual_partial_hot_token_duplicate_exact_list);
+  store_zero(last_success_stats.actual_partial_hot_token_duplicate_exact_tuple);
+  store_zero(last_success_stats.actual_partial_hot_token_duplicate_tensor_match);
+  store_zero(
+      last_success_stats.actual_partial_hot_token_duplicate_default_device);
+  store_zero(last_success_stats.actual_partial_hot_token_duplicate_global_state);
+  store_zero(
+      last_success_stats
+          .actual_partial_hot_token_duplicate_torch_function_mode_stack);
+  store_zero(
+      last_success_stats.actual_partial_hot_token_duplicate_no_tensor_aliasing);
+  store_zero(
+      last_success_stats.actual_partial_hot_token_duplicate_object_aliasing);
+  store_zero(last_success_stats.actual_partial_hot_token_duplicate_bound_method);
+  store_zero(last_success_stats.actual_partial_hot_token_duplicate_frame_globals);
+  store_zero(last_success_stats.actual_partial_token_check_ns);
+  store_zero(last_success_stats.actual_partial_residual_ns);
+  store_zero(last_success_stats.actual_partial_shadow_full_pass);
+  store_zero(last_success_stats.actual_partial_shadow_full_fail);
+  store_zero(last_success_stats.actual_partial_shadow_full_ns);
+  store_zero(last_success_stats.actual_partial_train_ns);
+  {
+    std::lock_guard<std::mutex> lock(guard_accessor_type_stats_mutex());
+    guard_accessor_type_stats().clear();
+  }
+  {
+    std::lock_guard<std::mutex> lock(guard_accessor_detail_stats_mutex());
+    guard_accessor_detail_stats().clear();
+  }
+  {
+    std::lock_guard<std::mutex> lock(guard_leaf_type_stats_mutex());
+    guard_leaf_type_stats().clear();
+  }
+  {
+    std::lock_guard<std::mutex> lock(guard_leaf_detail_stats_mutex());
+    guard_leaf_detail_stats().clear();
+  }
+  {
+    std::lock_guard<std::mutex> lock(guard_subtree_probe_path_stats_mutex());
+    guard_subtree_probe_path_stats().clear();
+  }
+  {
+    std::lock_guard<std::mutex> lock(guard_fastplan_disabled_stats_mutex());
+    guard_fastplan_disabled_reason_stats().clear();
+    guard_fastplan_disabled_path_stats().clear();
+  }
+  {
+    std::lock_guard<std::mutex> lock(
+        guard_last_success_disabled_stats_mutex());
+    guard_last_success_disabled_reason_stats().clear();
+    guard_last_success_disabled_path_stats().clear();
+  }
+  {
+    std::lock_guard<std::mutex> lock(
+        guard_last_success_mismatch_stats_mutex());
+    guard_last_success_mismatch_reason_stats().clear();
+    guard_last_success_mismatch_kind_stats().clear();
+    guard_last_success_mismatch_path_stats().clear();
+  }
+  {
+    std::lock_guard<std::mutex> lock(
+        guard_last_success_partial_shadow_stats_mutex());
+    guard_last_success_partial_shadow_fail_reason_stats().clear();
+    guard_last_success_partial_shadow_fail_path_stats().clear();
+  }
+  guard_lookup_stats_force_enabled().store(
+      force_enable, std::memory_order_relaxed);
+}
+
+py::dict get_guard_lookup_stats() {
+  auto& stats = guard_lookup_stats();
+  py::dict result;
+  result["lookup_count"] = load_relaxed(stats.lookup_count);
+  result["lookup_total_ns"] = load_relaxed(stats.lookup_total_ns);
+  result["backend_match_ns"] = load_relaxed(stats.backend_match_ns);
+  result["slow_guard_ns"] = load_relaxed(stats.slow_guard_ns);
+  result["move_to_front_ns"] = load_relaxed(stats.move_to_front_ns);
+  result["cache_entry_count_sum"] = load_relaxed(stats.cache_entry_count_sum);
+  result["cache_entry_hit_index_sum"] =
+      load_relaxed(stats.cache_entry_hit_index_sum);
+  result["root_guard_count"] = load_relaxed(stats.root_guard_count);
+  result["root_guard_total_ns"] = load_relaxed(stats.root_guard_total_ns);
+  result["root_guard_lock_ns"] = load_relaxed(stats.root_guard_lock_ns);
+  result["root_guard_local_state_ns"] =
+      load_relaxed(stats.root_guard_local_state_ns);
+  result["root_guard_leaf_ns"] = load_relaxed(stats.root_guard_leaf_ns);
+  result["root_guard_accessor_ns"] = load_relaxed(stats.root_guard_accessor_ns);
+  result["root_guard_epilogue_ns"] = load_relaxed(stats.root_guard_epilogue_ns);
+  result["root_guard_tls_ns"] = load_relaxed(stats.root_guard_tls_ns);
+  result["unsafe_mock_guard_bypass_enabled"] =
+      unsafe_mock_guard_bypass_enabled();
+  result["unsafe_mock_guard_bypass_count"] =
+      load_relaxed(stats.unsafe_mock_guard_bypass_count);
+  result["unsafe_mock_guard_bypass_hit_index_sum"] =
+      load_relaxed(stats.unsafe_mock_guard_bypass_hit_index_sum);
+  auto& subtree_stats = guard_subtree_probe_stats();
+  result["guard_subtree_probe_mode"] = guard_subtree_probe_mode_name();
+  result["guard_subtree_probe_attempt"] =
+      load_relaxed(subtree_stats.attempt);
+  result["guard_subtree_probe_entry_match"] =
+      load_relaxed(subtree_stats.entry_match);
+  result["guard_subtree_probe_entry_miss"] =
+      load_relaxed(subtree_stats.entry_miss);
+  result["guard_subtree_probe_shadow_ok"] =
+      load_relaxed(subtree_stats.shadow_ok);
+  result["guard_subtree_probe_mismatch"] =
+      load_relaxed(subtree_stats.mismatch);
+  result["guard_subtree_probe_disabled"] =
+      load_relaxed(subtree_stats.disabled);
+  result["guard_subtree_probe_entry_check_ns"] =
+      load_relaxed(subtree_stats.entry_check_ns);
+  result["guard_subtree_probe_child_check_ns"] =
+      load_relaxed(subtree_stats.child_check_ns);
+  py::dict subtree_token_kind_counts;
+  subtree_token_kind_counts["ObjectOnly"] =
+      load_relaxed(subtree_stats.token_object_only);
+  subtree_token_kind_counts["ExactDict"] =
+      load_relaxed(subtree_stats.token_exact_dict);
+  subtree_token_kind_counts["ExactList"] =
+      load_relaxed(subtree_stats.token_exact_list);
+  subtree_token_kind_counts["ExactTuple"] =
+      load_relaxed(subtree_stats.token_exact_tuple);
+  subtree_token_kind_counts["TensorMatch"] =
+      load_relaxed(subtree_stats.token_tensor_match);
+  subtree_token_kind_counts["DefaultDevice"] =
+      load_relaxed(subtree_stats.token_default_device);
+  subtree_token_kind_counts["GlobalState"] =
+      load_relaxed(subtree_stats.token_global_state);
+  subtree_token_kind_counts["TorchFunctionModeStack"] =
+      load_relaxed(subtree_stats.token_torch_function_mode_stack);
+  subtree_token_kind_counts["NoTensorAliasing"] =
+      load_relaxed(subtree_stats.token_no_tensor_aliasing);
+  subtree_token_kind_counts["ObjectAliasing"] =
+      load_relaxed(subtree_stats.token_object_aliasing);
+  subtree_token_kind_counts["BoundMethod"] =
+      load_relaxed(subtree_stats.token_bound_method);
+  subtree_token_kind_counts["FrameGlobals"] =
+      load_relaxed(subtree_stats.token_frame_globals);
+  result["guard_subtree_probe_token_kind_counts"] =
+      subtree_token_kind_counts;
+  auto& fastplan_stats = guard_fastplan_stats();
+  result["guard_fastplan_enabled"] = guard_fast_plan_enabled();
+  result["guard_fastplan_candidate"] =
+      load_relaxed(fastplan_stats.candidate);
+  result["guard_fastplan_candidate_top"] =
+      load_relaxed(fastplan_stats.candidate_top);
+  result["guard_fastplan_candidate_nested"] =
+      load_relaxed(fastplan_stats.candidate_nested);
+  result["guard_fastplan_shadow_pass"] =
+      load_relaxed(fastplan_stats.shadow_pass);
+  result["guard_fastplan_shadow_pass_top"] =
+      load_relaxed(fastplan_stats.shadow_pass_top);
+  result["guard_fastplan_shadow_pass_nested"] =
+      load_relaxed(fastplan_stats.shadow_pass_nested);
+  result["guard_fastplan_partial_shadow_pass"] =
+      load_relaxed(fastplan_stats.partial_shadow_pass);
+  result["guard_fastplan_enable"] = load_relaxed(fastplan_stats.enable);
+  result["guard_fastplan_enable_top"] =
+      load_relaxed(fastplan_stats.enable_top);
+  result["guard_fastplan_enable_nested"] =
+      load_relaxed(fastplan_stats.enable_nested);
+  result["guard_fastplan_partial_enable"] =
+      load_relaxed(fastplan_stats.partial_enable);
+  result["guard_fastplan_hit"] = load_relaxed(fastplan_stats.hit);
+  result["guard_fastplan_hit_top"] = load_relaxed(fastplan_stats.hit_top);
+  result["guard_fastplan_hit_nested"] =
+      load_relaxed(fastplan_stats.hit_nested);
+  result["guard_fastplan_partial_hit"] =
+      load_relaxed(fastplan_stats.partial_hit);
+  result["guard_fastplan_miss"] = load_relaxed(fastplan_stats.miss);
+  result["guard_fastplan_miss_top"] = load_relaxed(fastplan_stats.miss_top);
+  result["guard_fastplan_miss_nested"] =
+      load_relaxed(fastplan_stats.miss_nested);
+  result["guard_fastplan_disabled"] =
+      load_relaxed(fastplan_stats.disabled);
+  result["guard_fastplan_disabled_top"] =
+      load_relaxed(fastplan_stats.disabled_top);
+  result["guard_fastplan_disabled_nested"] =
+      load_relaxed(fastplan_stats.disabled_nested);
+  result["guard_fastplan_token_count_sum"] =
+      load_relaxed(fastplan_stats.token_count_sum);
+  result["guard_fastplan_token_check_ns"] =
+      load_relaxed(fastplan_stats.token_check_ns);
+  result["guard_fastplan_slow_check_ns"] =
+      load_relaxed(fastplan_stats.slow_check_ns);
+  result["guard_fastplan_token_cap_disabled"] =
+      load_relaxed(fastplan_stats.token_cap_disabled);
+  result["guard_fastplan_tensor_token_shadow"] =
+      load_relaxed(fastplan_stats.tensor_token_shadow);
+  result["guard_fastplan_tensor_token_hit"] =
+      load_relaxed(fastplan_stats.tensor_token_hit);
+  result["guard_fastplan_tensor_token_miss"] =
+      load_relaxed(fastplan_stats.tensor_token_miss);
+  result["guard_fastplan_tensor_token_check_ns"] =
+      load_relaxed(fastplan_stats.tensor_token_check_ns);
+  result["guard_fastplan_tensor_token_count_sum"] =
+      load_relaxed(fastplan_stats.tensor_token_count_sum);
+  py::dict tensor_token_miss_reasons;
+  tensor_token_miss_reasons["missing_local_state"] =
+      load_relaxed(fastplan_stats.tensor_token_miss_missing_local_state);
+  tensor_token_miss_reasons["object"] =
+      load_relaxed(fastplan_stats.tensor_token_miss_object);
+  tensor_token_miss_reasons["type"] =
+      load_relaxed(fastplan_stats.tensor_token_miss_type);
+  tensor_token_miss_reasons["not_tensor"] =
+      load_relaxed(fastplan_stats.tensor_token_miss_not_tensor);
+  tensor_token_miss_reasons["dispatch_key"] =
+      load_relaxed(fastplan_stats.tensor_token_miss_dispatch_key);
+  tensor_token_miss_reasons["dtype"] =
+      load_relaxed(fastplan_stats.tensor_token_miss_dtype);
+  tensor_token_miss_reasons["device"] =
+      load_relaxed(fastplan_stats.tensor_token_miss_device);
+  tensor_token_miss_reasons["requires_grad"] =
+      load_relaxed(fastplan_stats.tensor_token_miss_requires_grad);
+  tensor_token_miss_reasons["dim"] =
+      load_relaxed(fastplan_stats.tensor_token_miss_dim);
+  tensor_token_miss_reasons["size"] =
+      load_relaxed(fastplan_stats.tensor_token_miss_size);
+  tensor_token_miss_reasons["stride"] =
+      load_relaxed(fastplan_stats.tensor_token_miss_stride);
+  result["guard_fastplan_tensor_token_miss_reasons"] =
+      tensor_token_miss_reasons;
+  py::dict fastplan_disabled_reasons;
+  py::dict fastplan_disabled_top_paths;
+  {
+    std::vector<std::pair<std::string, GuardFastPlanDisabledPathStats>>
+        path_items;
+    {
+      std::lock_guard<std::mutex> lock(guard_fastplan_disabled_stats_mutex());
+      for (const auto& item : guard_fastplan_disabled_reason_stats()) {
+        fastplan_disabled_reasons[py::str(item.first)] = item.second;
+      }
+      path_items.reserve(guard_fastplan_disabled_path_stats().size());
+      for (const auto& item : guard_fastplan_disabled_path_stats()) {
+        path_items.emplace_back(item.first, item.second);
+      }
+    }
+    std::sort(
+        path_items.begin(),
+        path_items.end(),
+        [](const auto& a, const auto& b) {
+          return a.second.count > b.second.count;
+        });
+    const size_t limit =
+        std::min(path_items.size(), kGuardFastPlanDisabledTopK);
+    for (size_t i = 0; i < limit; ++i) {
+      py::dict item_stats;
+      item_stats["count"] = path_items[i].second.count;
+      item_stats["reason"] = path_items[i].second.reason;
+      fastplan_disabled_top_paths[py::str(path_items[i].first)] = item_stats;
+    }
+  }
+  result["guard_fastplan_disabled_reasons"] = fastplan_disabled_reasons;
+  result["guard_fastplan_disabled_top_paths"] = fastplan_disabled_top_paths;
+  auto& last_success_stats = guard_last_success_stats();
+  result["guard_last_success_shadow_attempt"] =
+      load_relaxed(last_success_stats.shadow_attempt);
+  result["guard_last_success_shadow_success"] =
+      load_relaxed(last_success_stats.shadow_success);
+  result["guard_last_success_shadow_incomplete"] =
+      load_relaxed(last_success_stats.shadow_incomplete);
+  result["guard_last_success_shadow_stable"] =
+      load_relaxed(last_success_stats.shadow_stable);
+  result["guard_last_success_shadow_reset"] =
+      load_relaxed(last_success_stats.shadow_reset);
+  result["guard_last_success_shadow_max_passes"] =
+      load_relaxed(last_success_stats.shadow_max_passes);
+  result["guard_last_success_token_count_sum"] =
+      load_relaxed(last_success_stats.token_count_sum);
+  result["guard_last_success_token_cap_disabled"] =
+      load_relaxed(last_success_stats.token_cap_disabled);
+  result["guard_last_success_token_cap_count_sum"] =
+      load_relaxed(last_success_stats.token_cap_count_sum);
+  result["guard_last_success_token_cap_count_max"] =
+      load_relaxed(last_success_stats.token_cap_count_max);
+  result["guard_last_success_support_check_ns"] =
+      load_relaxed(last_success_stats.support_check_ns);
+  result["guard_last_success_receipt_update_ns"] =
+      load_relaxed(last_success_stats.receipt_update_ns);
+  result["guard_last_success_receipt_compare_ns"] =
+      load_relaxed(last_success_stats.receipt_compare_ns);
+  result["guard_last_success_compare_mismatch"] =
+      load_relaxed(last_success_stats.compare_mismatch);
+  result["guard_last_success_compare_mismatch_index_sum"] =
+      load_relaxed(last_success_stats.compare_mismatch_index_sum);
+  result["guard_last_success_compare_mismatch_index_max"] =
+      load_relaxed(last_success_stats.compare_mismatch_index_max);
+  result["guard_last_success_actual_attempt"] =
+      load_relaxed(last_success_stats.actual_attempt);
+  result["guard_last_success_actual_hit"] =
+      load_relaxed(last_success_stats.actual_hit);
+  result["guard_last_success_actual_miss"] =
+      load_relaxed(last_success_stats.actual_miss);
+  result["guard_last_success_actual_enable"] =
+      load_relaxed(last_success_stats.actual_enable);
+  result["guard_last_success_actual_disabled"] =
+      load_relaxed(last_success_stats.actual_disabled);
+  result["guard_last_success_actual_hot_token_count_sum"] =
+      load_relaxed(last_success_stats.actual_hot_token_count_sum);
+  result["guard_last_success_actual_token_check_ns"] =
+      load_relaxed(last_success_stats.actual_token_check_ns);
+  result["guard_last_success_actual_train_ns"] =
+      load_relaxed(last_success_stats.actual_train_ns);
+  result["guard_last_success_actual_partial_attempt"] =
+      load_relaxed(last_success_stats.actual_partial_attempt);
+  result["guard_last_success_actual_partial_hit"] =
+      load_relaxed(last_success_stats.actual_partial_hit);
+  result["guard_last_success_actual_partial_miss"] =
+      load_relaxed(last_success_stats.actual_partial_miss);
+  result["guard_last_success_actual_partial_enable"] =
+      load_relaxed(last_success_stats.actual_partial_enable);
+  result["guard_last_success_actual_partial_disabled"] =
+      load_relaxed(last_success_stats.actual_partial_disabled);
+  result["guard_last_success_actual_partial_residual_fail"] =
+      load_relaxed(last_success_stats.actual_partial_residual_fail);
+  result["guard_last_success_actual_partial_hot_token_count_sum"] =
+      load_relaxed(last_success_stats.actual_partial_hot_token_count_sum);
+  result["guard_last_success_actual_partial_hot_token_unique_count_sum"] =
+      load_relaxed(
+          last_success_stats.actual_partial_hot_token_unique_count_sum);
+  result["guard_last_success_actual_partial_hot_token_duplicate_count_sum"] =
+      load_relaxed(
+          last_success_stats.actual_partial_hot_token_duplicate_count_sum);
+  py::dict actual_partial_kind_counts;
+  actual_partial_kind_counts["ObjectOnly"] =
+      load_relaxed(last_success_stats.actual_partial_hot_token_object_only);
+  actual_partial_kind_counts["ExactDict"] =
+      load_relaxed(last_success_stats.actual_partial_hot_token_exact_dict);
+  actual_partial_kind_counts["ExactList"] =
+      load_relaxed(last_success_stats.actual_partial_hot_token_exact_list);
+  actual_partial_kind_counts["ExactTuple"] =
+      load_relaxed(last_success_stats.actual_partial_hot_token_exact_tuple);
+  actual_partial_kind_counts["TensorMatch"] =
+      load_relaxed(last_success_stats.actual_partial_hot_token_tensor_match);
+  actual_partial_kind_counts["DefaultDevice"] =
+      load_relaxed(last_success_stats.actual_partial_hot_token_default_device);
+  actual_partial_kind_counts["GlobalState"] =
+      load_relaxed(last_success_stats.actual_partial_hot_token_global_state);
+  actual_partial_kind_counts["TorchFunctionModeStack"] = load_relaxed(
+      last_success_stats.actual_partial_hot_token_torch_function_mode_stack);
+  actual_partial_kind_counts["NoTensorAliasing"] = load_relaxed(
+      last_success_stats.actual_partial_hot_token_no_tensor_aliasing);
+  actual_partial_kind_counts["ObjectAliasing"] =
+      load_relaxed(last_success_stats.actual_partial_hot_token_object_aliasing);
+  actual_partial_kind_counts["BoundMethod"] =
+      load_relaxed(last_success_stats.actual_partial_hot_token_bound_method);
+  actual_partial_kind_counts["FrameGlobals"] =
+      load_relaxed(last_success_stats.actual_partial_hot_token_frame_globals);
+  result["guard_last_success_actual_partial_hot_token_kind_counts"] =
+      actual_partial_kind_counts;
+  py::dict actual_partial_duplicate_kind_counts;
+  actual_partial_duplicate_kind_counts["ObjectOnly"] = load_relaxed(
+      last_success_stats.actual_partial_hot_token_duplicate_object_only);
+  actual_partial_duplicate_kind_counts["ExactDict"] = load_relaxed(
+      last_success_stats.actual_partial_hot_token_duplicate_exact_dict);
+  actual_partial_duplicate_kind_counts["ExactList"] = load_relaxed(
+      last_success_stats.actual_partial_hot_token_duplicate_exact_list);
+  actual_partial_duplicate_kind_counts["ExactTuple"] = load_relaxed(
+      last_success_stats.actual_partial_hot_token_duplicate_exact_tuple);
+  actual_partial_duplicate_kind_counts["TensorMatch"] = load_relaxed(
+      last_success_stats.actual_partial_hot_token_duplicate_tensor_match);
+  actual_partial_duplicate_kind_counts["DefaultDevice"] = load_relaxed(
+      last_success_stats.actual_partial_hot_token_duplicate_default_device);
+  actual_partial_duplicate_kind_counts["GlobalState"] = load_relaxed(
+      last_success_stats.actual_partial_hot_token_duplicate_global_state);
+  actual_partial_duplicate_kind_counts["TorchFunctionModeStack"] = load_relaxed(
+      last_success_stats
+          .actual_partial_hot_token_duplicate_torch_function_mode_stack);
+  actual_partial_duplicate_kind_counts["NoTensorAliasing"] = load_relaxed(
+      last_success_stats.actual_partial_hot_token_duplicate_no_tensor_aliasing);
+  actual_partial_duplicate_kind_counts["ObjectAliasing"] = load_relaxed(
+      last_success_stats.actual_partial_hot_token_duplicate_object_aliasing);
+  actual_partial_duplicate_kind_counts["BoundMethod"] = load_relaxed(
+      last_success_stats.actual_partial_hot_token_duplicate_bound_method);
+  actual_partial_duplicate_kind_counts["FrameGlobals"] = load_relaxed(
+      last_success_stats.actual_partial_hot_token_duplicate_frame_globals);
+  result
+      ["guard_last_success_actual_partial_hot_token_duplicate_kind_counts"] =
+          actual_partial_duplicate_kind_counts;
+  result["guard_last_success_actual_partial_token_check_ns"] =
+      load_relaxed(last_success_stats.actual_partial_token_check_ns);
+  result["guard_last_success_actual_partial_residual_ns"] =
+      load_relaxed(last_success_stats.actual_partial_residual_ns);
+  result["guard_last_success_actual_partial_shadow_full_pass"] =
+      load_relaxed(last_success_stats.actual_partial_shadow_full_pass);
+  result["guard_last_success_actual_partial_shadow_full_fail"] =
+      load_relaxed(last_success_stats.actual_partial_shadow_full_fail);
+  result["guard_last_success_actual_partial_shadow_full_ns"] =
+      load_relaxed(last_success_stats.actual_partial_shadow_full_ns);
+  py::dict last_success_partial_shadow_fail_reasons;
+  py::dict last_success_partial_shadow_fail_top_paths;
+  {
+    std::vector<std::pair<std::string, GuardFastPlanDisabledPathStats>>
+        path_items;
+    {
+      std::lock_guard<std::mutex> lock(
+          guard_last_success_partial_shadow_stats_mutex());
+      for (const auto& item :
+           guard_last_success_partial_shadow_fail_reason_stats()) {
+        last_success_partial_shadow_fail_reasons[py::str(item.first)] =
+            item.second;
+      }
+      path_items.reserve(
+          guard_last_success_partial_shadow_fail_path_stats().size());
+      for (const auto& item :
+           guard_last_success_partial_shadow_fail_path_stats()) {
+        path_items.emplace_back(item.first, item.second);
+      }
+    }
+    std::sort(
+        path_items.begin(),
+        path_items.end(),
+        [](const auto& a, const auto& b) {
+          return a.second.count > b.second.count;
+        });
+    const size_t limit =
+        std::min(path_items.size(), kGuardFastPlanDisabledTopK);
+    for (size_t i = 0; i < limit; ++i) {
+      py::dict item_stats;
+      item_stats["count"] = path_items[i].second.count;
+      item_stats["reason"] = path_items[i].second.reason;
+      last_success_partial_shadow_fail_top_paths[py::str(path_items[i].first)] =
+          item_stats;
+    }
+  }
+  result["guard_last_success_actual_partial_shadow_fail_reasons"] =
+      last_success_partial_shadow_fail_reasons;
+  result["guard_last_success_actual_partial_shadow_fail_top_paths"] =
+      last_success_partial_shadow_fail_top_paths;
+  result["guard_last_success_actual_partial_train_ns"] =
+      load_relaxed(last_success_stats.actual_partial_train_ns);
+  py::dict last_success_disabled_reasons;
+  py::dict last_success_disabled_top_paths;
+  {
+    std::vector<std::pair<std::string, GuardFastPlanDisabledPathStats>>
+        path_items;
+    {
+      std::lock_guard<std::mutex> lock(
+          guard_last_success_disabled_stats_mutex());
+      for (const auto& item : guard_last_success_disabled_reason_stats()) {
+        last_success_disabled_reasons[py::str(item.first)] = item.second;
+      }
+      path_items.reserve(guard_last_success_disabled_path_stats().size());
+      for (const auto& item : guard_last_success_disabled_path_stats()) {
+        path_items.emplace_back(item.first, item.second);
+      }
+    }
+    std::sort(
+        path_items.begin(),
+        path_items.end(),
+        [](const auto& a, const auto& b) {
+          return a.second.count > b.second.count;
+        });
+    const size_t limit =
+        std::min(path_items.size(), kGuardFastPlanDisabledTopK);
+    for (size_t i = 0; i < limit; ++i) {
+      py::dict item_stats;
+      item_stats["count"] = path_items[i].second.count;
+      item_stats["reason"] = path_items[i].second.reason;
+      last_success_disabled_top_paths[py::str(path_items[i].first)] =
+          item_stats;
+    }
+  }
+  result["guard_last_success_disabled_reasons"] =
+      last_success_disabled_reasons;
+  result["guard_last_success_disabled_top_paths"] =
+      last_success_disabled_top_paths;
+  py::dict last_success_mismatch_reasons;
+  py::dict last_success_mismatch_token_kinds;
+  py::dict last_success_mismatch_top_paths;
+  {
+    std::lock_guard<std::mutex> lock(
+        guard_last_success_mismatch_stats_mutex());
+    for (const auto& item : guard_last_success_mismatch_reason_stats()) {
+      last_success_mismatch_reasons[py::str(item.first)] = item.second;
+    }
+    for (const auto& item : guard_last_success_mismatch_kind_stats()) {
+      last_success_mismatch_token_kinds[py::str(item.first)] = item.second;
+    }
+    std::vector<std::pair<std::string, GuardFastPlanDisabledPathStats>>
+        path_items;
+    path_items.reserve(guard_last_success_mismatch_path_stats().size());
+    for (const auto& item : guard_last_success_mismatch_path_stats()) {
+      path_items.emplace_back(item.first, item.second);
+    }
+    std::sort(
+        path_items.begin(),
+        path_items.end(),
+        [](const auto& a, const auto& b) {
+          return a.second.count > b.second.count;
+        });
+    const size_t limit =
+        std::min(path_items.size(), kGuardFastPlanDisabledTopK);
+    for (size_t i = 0; i < limit; ++i) {
+      py::dict item_stats;
+      item_stats["count"] = path_items[i].second.count;
+      item_stats["reason"] = path_items[i].second.reason;
+      if (path_items[i].second.has_mismatch_detail) {
+        item_stats["old_kind"] = path_items[i].second.old_kind;
+        item_stats["new_kind"] = path_items[i].second.new_kind;
+        item_stats["old_type"] = path_items[i].second.old_type;
+        item_stats["new_type"] = path_items[i].second.new_type;
+        item_stats["old_object_id"] = path_items[i].second.old_object_id;
+        item_stats["new_object_id"] = path_items[i].second.new_object_id;
+        item_stats["old_version"] = path_items[i].second.old_version;
+        item_stats["new_version"] = path_items[i].second.new_version;
+        item_stats["old_size"] = path_items[i].second.old_size;
+        item_stats["new_size"] = path_items[i].second.new_size;
+      }
+      last_success_mismatch_top_paths[py::str(path_items[i].first)] =
+          item_stats;
+    }
+  }
+  result["guard_last_success_mismatch_reasons"] =
+      last_success_mismatch_reasons;
+  result["guard_last_success_mismatch_token_kinds"] =
+      last_success_mismatch_token_kinds;
+  result["guard_last_success_mismatch_top_paths"] =
+      last_success_mismatch_top_paths;
+  if (guard_subtree_probe_detail_enabled()) {
+    py::dict path_stats;
+    std::vector<std::pair<std::string, GuardSubtreeProbePathStats>> items;
+    {
+      std::lock_guard<std::mutex> lock(guard_subtree_probe_path_stats_mutex());
+      items.reserve(guard_subtree_probe_path_stats().size());
+      for (const auto& item : guard_subtree_probe_path_stats()) {
+        items.emplace_back(item.first, item.second);
+      }
+    }
+    std::sort(
+        items.begin(),
+        items.end(),
+        [](const auto& a, const auto& b) {
+          return a.second.child_check_ns > b.second.child_check_ns;
+        });
+    const size_t limit = std::min(items.size(), kGuardSubtreeProbeTopK);
+    for (size_t i = 0; i < limit; ++i) {
+      py::dict item_stats;
+      item_stats["attempt"] = items[i].second.attempt;
+      item_stats["entry_match"] = items[i].second.entry_match;
+      item_stats["entry_miss"] = items[i].second.entry_miss;
+      item_stats["shadow_ok"] = items[i].second.shadow_ok;
+      item_stats["mismatch"] = items[i].second.mismatch;
+      item_stats["disabled"] = items[i].second.disabled;
+      item_stats["entry_check_ns"] = items[i].second.entry_check_ns;
+      item_stats["child_check_ns"] = items[i].second.child_check_ns;
+      py::dict token_counts;
+      token_counts["ObjectOnly"] = items[i].second.token_object_only;
+      token_counts["ExactDict"] = items[i].second.token_exact_dict;
+      token_counts["ExactList"] = items[i].second.token_exact_list;
+      token_counts["ExactTuple"] = items[i].second.token_exact_tuple;
+      token_counts["TensorMatch"] = items[i].second.token_tensor_match;
+      token_counts["DefaultDevice"] = items[i].second.token_default_device;
+      token_counts["GlobalState"] = items[i].second.token_global_state;
+      token_counts["TorchFunctionModeStack"] =
+          items[i].second.token_torch_function_mode_stack;
+      token_counts["NoTensorAliasing"] =
+          items[i].second.token_no_tensor_aliasing;
+      token_counts["ObjectAliasing"] = items[i].second.token_object_aliasing;
+      token_counts["BoundMethod"] = items[i].second.token_bound_method;
+      token_counts["FrameGlobals"] = items[i].second.token_frame_globals;
+      item_stats["token_kind_counts"] = token_counts;
+      path_stats[py::str(items[i].first)] = item_stats;
+    }
+    result["guard_subtree_probe_top_paths"] = path_stats;
+  }
+  py::dict accessor_type_stats;
+  {
+    std::lock_guard<std::mutex> lock(guard_accessor_type_stats_mutex());
+    for (const auto& item : guard_accessor_type_stats()) {
+      py::dict item_stats;
+      item_stats["count"] = item.second.count;
+      item_stats["fail_count"] = item.second.fail_count;
+      item_stats["inclusive_ns"] = item.second.inclusive_ns;
+      accessor_type_stats[py::str(item.first)] = item_stats;
+    }
+  }
+  result["root_guard_accessor_type_stats"] = accessor_type_stats;
+  py::dict accessor_detail_stats;
+  {
+    std::vector<std::pair<std::string, GuardAccessorDetailStats>> items;
+    {
+      std::lock_guard<std::mutex> lock(guard_accessor_detail_stats_mutex());
+      items.reserve(guard_accessor_detail_stats().size());
+      for (const auto& item : guard_accessor_detail_stats()) {
+        items.emplace_back(item.first, item.second);
+      }
+    }
+    std::sort(
+        items.begin(),
+        items.end(),
+        [](const auto& a, const auto& b) {
+          return a.second.inclusive_ns > b.second.inclusive_ns;
+        });
+    const size_t limit =
+        std::min(items.size(), kGuardAccessorDetailStatsTopK);
+    for (size_t i = 0; i < limit; ++i) {
+      py::dict item_stats;
+      item_stats["count"] = items[i].second.count;
+      item_stats["fail_count"] = items[i].second.fail_count;
+      item_stats["self_ns"] = items[i].second.self_ns;
+      item_stats["child_ns"] = items[i].second.child_ns;
+      item_stats["inclusive_ns"] = items[i].second.inclusive_ns;
+      accessor_detail_stats[py::str(items[i].first)] = item_stats;
+    }
+  }
+  result["root_guard_accessor_detail_topk"] = accessor_detail_stats;
+  py::dict leaf_type_stats;
+  {
+    std::lock_guard<std::mutex> lock(guard_leaf_type_stats_mutex());
+    for (const auto& item : guard_leaf_type_stats()) {
+      py::dict item_stats;
+      item_stats["count"] = item.second.count;
+      item_stats["fail_count"] = item.second.fail_count;
+      item_stats["inclusive_ns"] = item.second.inclusive_ns;
+      leaf_type_stats[py::str(item.first)] = item_stats;
+    }
+  }
+  result["root_guard_leaf_type_stats"] = leaf_type_stats;
+  py::dict leaf_detail_stats;
+  {
+    std::vector<std::pair<std::string, GuardLeafStats>> items;
+    {
+      std::lock_guard<std::mutex> lock(guard_leaf_detail_stats_mutex());
+      items.reserve(guard_leaf_detail_stats().size());
+      for (const auto& item : guard_leaf_detail_stats()) {
+        items.emplace_back(item.first, item.second);
+      }
+    }
+    std::sort(
+        items.begin(),
+        items.end(),
+        [](const auto& a, const auto& b) {
+          return a.second.inclusive_ns > b.second.inclusive_ns;
+        });
+    const size_t limit = std::min(items.size(), kGuardLeafDetailStatsTopK);
+    for (size_t i = 0; i < limit; ++i) {
+      py::dict item_stats;
+      item_stats["count"] = items[i].second.count;
+      item_stats["fail_count"] = items[i].second.fail_count;
+      item_stats["inclusive_ns"] = items[i].second.inclusive_ns;
+      leaf_detail_stats[py::str(items[i].first)] = item_stats;
+    }
+  }
+  result["root_guard_leaf_detail_topk"] = leaf_detail_stats;
+  return result;
+}
+
+void record_guard_lookup_stats(
+    uint64_t total_ns,
+    uint64_t backend_match_ns,
+    uint64_t slow_guard_ns,
+    uint64_t move_to_front_ns,
+    uint64_t cache_entry_count,
+    uint64_t cache_entry_hit_index) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  auto& stats = guard_lookup_stats();
+  add_relaxed(stats.lookup_count, 1);
+  add_relaxed(stats.lookup_total_ns, total_ns);
+  add_relaxed(stats.backend_match_ns, backend_match_ns);
+  add_relaxed(stats.slow_guard_ns, slow_guard_ns);
+  add_relaxed(stats.move_to_front_ns, move_to_front_ns);
+  add_relaxed(stats.cache_entry_count_sum, cache_entry_count);
+  add_relaxed(stats.cache_entry_hit_index_sum, cache_entry_hit_index);
+}
+
+void record_root_guard_stats(
+    uint64_t total_ns,
+    uint64_t lock_ns,
+    uint64_t local_state_ns,
+    uint64_t leaf_ns,
+    uint64_t accessor_ns,
+    uint64_t epilogue_ns,
+    uint64_t tls_ns) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  auto& stats = guard_lookup_stats();
+  add_relaxed(stats.root_guard_count, 1);
+  add_relaxed(stats.root_guard_total_ns, total_ns);
+  add_relaxed(stats.root_guard_lock_ns, lock_ns);
+  add_relaxed(stats.root_guard_local_state_ns, local_state_ns);
+  add_relaxed(stats.root_guard_leaf_ns, leaf_ns);
+  add_relaxed(stats.root_guard_accessor_ns, accessor_ns);
+  add_relaxed(stats.root_guard_epilogue_ns, epilogue_ns);
+  add_relaxed(stats.root_guard_tls_ns, tls_ns);
+}
+
+void record_unsafe_mock_guard_bypass_stats(uint64_t cache_entry_hit_index) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  auto& stats = guard_lookup_stats();
+  add_relaxed(stats.unsafe_mock_guard_bypass_count, 1);
+  add_relaxed(
+      stats.unsafe_mock_guard_bypass_hit_index_sum, cache_entry_hit_index);
+}
+
+static const char* guard_subtree_token_kind_name(
+    GuardSubtreeProbeTokenKind token_kind) {
+  switch (token_kind) {
+    case GuardSubtreeProbeTokenKind::ObjectOnly:
+      return "ObjectOnly";
+    case GuardSubtreeProbeTokenKind::ExactDict:
+      return "ExactDict";
+    case GuardSubtreeProbeTokenKind::ExactList:
+      return "ExactList";
+    case GuardSubtreeProbeTokenKind::ExactTuple:
+      return "ExactTuple";
+    case GuardSubtreeProbeTokenKind::TensorMatch:
+      return "TensorMatch";
+    case GuardSubtreeProbeTokenKind::DefaultDevice:
+      return "DefaultDevice";
+    case GuardSubtreeProbeTokenKind::GlobalState:
+      return "GlobalState";
+    case GuardSubtreeProbeTokenKind::TorchFunctionModeStack:
+      return "TorchFunctionModeStack";
+    case GuardSubtreeProbeTokenKind::NoTensorAliasing:
+      return "NoTensorAliasing";
+    case GuardSubtreeProbeTokenKind::ObjectAliasing:
+      return "ObjectAliasing";
+    case GuardSubtreeProbeTokenKind::BoundMethod:
+      return "BoundMethod";
+    case GuardSubtreeProbeTokenKind::FrameGlobals:
+      return "FrameGlobals";
+  }
+  return "Unknown";
+}
+
+static const char* guard_last_success_mismatch_reason_name(
+    GuardLastSuccessCompareMismatchReason reason) {
+  switch (reason) {
+    case GuardLastSuccessCompareMismatchReason::EntryKey:
+      return "entry_key";
+    case GuardLastSuccessCompareMismatchReason::RootKey:
+      return "root_key";
+    case GuardLastSuccessCompareMismatchReason::EmptyPrevious:
+      return "empty_previous";
+    case GuardLastSuccessCompareMismatchReason::Size:
+      return "size";
+    case GuardLastSuccessCompareMismatchReason::Kind:
+      return "kind";
+    case GuardLastSuccessCompareMismatchReason::Object:
+      return "object";
+    case GuardLastSuccessCompareMismatchReason::Type:
+      return "type";
+    case GuardLastSuccessCompareMismatchReason::TensorMeta:
+      return "tensor_meta";
+    case GuardLastSuccessCompareMismatchReason::DefaultDevice:
+      return "default_device";
+    case GuardLastSuccessCompareMismatchReason::GlobalState:
+      return "global_state";
+    case GuardLastSuccessCompareMismatchReason::TorchFunctionModeStack:
+      return "torch_function_mode_stack";
+    case GuardLastSuccessCompareMismatchReason::NoTensorAliasing:
+      return "no_tensor_aliasing";
+    case GuardLastSuccessCompareMismatchReason::ObjectAliasing:
+      return "object_aliasing";
+    case GuardLastSuccessCompareMismatchReason::BoundMethod:
+      return "bound_method";
+    case GuardLastSuccessCompareMismatchReason::Version:
+      return "version";
+    case GuardLastSuccessCompareMismatchReason::DictSize:
+      return "dict_size";
+    case GuardLastSuccessCompareMismatchReason::ListItems:
+      return "list_items";
+    case GuardLastSuccessCompareMismatchReason::Unknown:
+      return "unknown";
+  }
+  return "unknown";
+}
+
+void record_guard_accessor_type_stats(
+    const std::string& name,
+    uint64_t inclusive_ns,
+    bool failed) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  std::lock_guard<std::mutex> lock(guard_accessor_type_stats_mutex());
+  auto& stats = guard_accessor_type_stats()[name];
+  stats.count += 1;
+  stats.inclusive_ns += inclusive_ns;
+  if (failed) {
+    stats.fail_count += 1;
+  }
+}
+
+void record_guard_accessor_detail_stats(
+    const std::string& name,
+    uint64_t self_ns,
+    uint64_t child_ns,
+    uint64_t inclusive_ns,
+    bool failed) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  std::lock_guard<std::mutex> lock(guard_accessor_detail_stats_mutex());
+  auto& stats = guard_accessor_detail_stats()[name];
+  stats.count += 1;
+  stats.self_ns += self_ns;
+  stats.child_ns += child_ns;
+  stats.inclusive_ns += inclusive_ns;
+  if (failed) {
+    stats.fail_count += 1;
+  }
+}
+
+void record_guard_leaf_stats(
+    const char* guard_name,
+    const std::string& source,
+    uint64_t inclusive_ns,
+    bool failed) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  const std::string name = guard_name == nullptr ? "LeafGuard" : guard_name;
+  {
+    std::lock_guard<std::mutex> lock(guard_leaf_type_stats_mutex());
+    auto& stats = guard_leaf_type_stats()[name];
+    stats.count += 1;
+    stats.inclusive_ns += inclusive_ns;
+    if (failed) {
+      stats.fail_count += 1;
+    }
+  }
+  {
+    std::lock_guard<std::mutex> lock(guard_leaf_detail_stats_mutex());
+    const std::string detail_name =
+        name + ":" + (source.empty() ? std::string("<root>") : source);
+    auto& stats = guard_leaf_detail_stats()[detail_name];
+    stats.count += 1;
+    stats.inclusive_ns += inclusive_ns;
+    if (failed) {
+      stats.fail_count += 1;
+    }
+  }
+}
+
+static void add_guard_subtree_probe_token_kind(
+    GuardSubtreeProbeStats& stats,
+    GuardSubtreeProbeTokenKind token_kind) {
+  switch (token_kind) {
+    case GuardSubtreeProbeTokenKind::ExactDict:
+      add_relaxed(stats.token_exact_dict, 1);
+      break;
+    case GuardSubtreeProbeTokenKind::ExactList:
+      add_relaxed(stats.token_exact_list, 1);
+      break;
+    case GuardSubtreeProbeTokenKind::ExactTuple:
+      add_relaxed(stats.token_exact_tuple, 1);
+      break;
+    case GuardSubtreeProbeTokenKind::TensorMatch:
+      add_relaxed(stats.token_tensor_match, 1);
+      break;
+    case GuardSubtreeProbeTokenKind::DefaultDevice:
+      add_relaxed(stats.token_default_device, 1);
+      break;
+    case GuardSubtreeProbeTokenKind::GlobalState:
+      add_relaxed(stats.token_global_state, 1);
+      break;
+    case GuardSubtreeProbeTokenKind::TorchFunctionModeStack:
+      add_relaxed(stats.token_torch_function_mode_stack, 1);
+      break;
+    case GuardSubtreeProbeTokenKind::NoTensorAliasing:
+      add_relaxed(stats.token_no_tensor_aliasing, 1);
+      break;
+    case GuardSubtreeProbeTokenKind::ObjectAliasing:
+      add_relaxed(stats.token_object_aliasing, 1);
+      break;
+    case GuardSubtreeProbeTokenKind::BoundMethod:
+      add_relaxed(stats.token_bound_method, 1);
+      break;
+    case GuardSubtreeProbeTokenKind::FrameGlobals:
+      add_relaxed(stats.token_frame_globals, 1);
+      break;
+    case GuardSubtreeProbeTokenKind::ObjectOnly:
+      add_relaxed(stats.token_object_only, 1);
+      break;
+  }
+}
+
+static void add_guard_subtree_probe_token_kind(
+    GuardSubtreeProbePathStats& stats,
+    GuardSubtreeProbeTokenKind token_kind) {
+  switch (token_kind) {
+    case GuardSubtreeProbeTokenKind::ExactDict:
+      stats.token_exact_dict += 1;
+      break;
+    case GuardSubtreeProbeTokenKind::ExactList:
+      stats.token_exact_list += 1;
+      break;
+    case GuardSubtreeProbeTokenKind::ExactTuple:
+      stats.token_exact_tuple += 1;
+      break;
+    case GuardSubtreeProbeTokenKind::TensorMatch:
+      stats.token_tensor_match += 1;
+      break;
+    case GuardSubtreeProbeTokenKind::DefaultDevice:
+      stats.token_default_device += 1;
+      break;
+    case GuardSubtreeProbeTokenKind::GlobalState:
+      stats.token_global_state += 1;
+      break;
+    case GuardSubtreeProbeTokenKind::TorchFunctionModeStack:
+      stats.token_torch_function_mode_stack += 1;
+      break;
+    case GuardSubtreeProbeTokenKind::NoTensorAliasing:
+      stats.token_no_tensor_aliasing += 1;
+      break;
+    case GuardSubtreeProbeTokenKind::ObjectAliasing:
+      stats.token_object_aliasing += 1;
+      break;
+    case GuardSubtreeProbeTokenKind::BoundMethod:
+      stats.token_bound_method += 1;
+      break;
+    case GuardSubtreeProbeTokenKind::FrameGlobals:
+      stats.token_frame_globals += 1;
+      break;
+    case GuardSubtreeProbeTokenKind::ObjectOnly:
+      stats.token_object_only += 1;
+      break;
+  }
+}
+
+static void record_guard_subtree_probe_stats(
+    const std::string& path,
+    bool entry_match,
+    bool child_result,
+    bool disabled_now,
+    uint64_t entry_check_ns,
+    uint64_t child_check_ns,
+    GuardSubtreeProbeTokenKind token_kind) {
+  if (!guard_subtree_probe_enabled()) {
+    return;
+  }
+  auto& stats = guard_subtree_probe_stats();
+  add_relaxed(stats.attempt, 1);
+  add_relaxed(stats.entry_check_ns, entry_check_ns);
+  add_relaxed(stats.child_check_ns, child_check_ns);
+  add_guard_subtree_probe_token_kind(stats, token_kind);
+  if (entry_match) {
+    add_relaxed(stats.entry_match, 1);
+    if (child_result) {
+      add_relaxed(stats.shadow_ok, 1);
+    } else {
+      add_relaxed(stats.mismatch, 1);
+    }
+  } else {
+    add_relaxed(stats.entry_miss, 1);
+  }
+  if (disabled_now) {
+    add_relaxed(stats.disabled, 1);
+  }
+
+  if (!guard_subtree_probe_detail_enabled()) {
+    return;
+  }
+  std::lock_guard<std::mutex> lock(guard_subtree_probe_path_stats_mutex());
+  auto& path_stats = guard_subtree_probe_path_stats()[path];
+  path_stats.attempt += 1;
+  path_stats.entry_check_ns += entry_check_ns;
+  path_stats.child_check_ns += child_check_ns;
+  add_guard_subtree_probe_token_kind(path_stats, token_kind);
+  if (entry_match) {
+    path_stats.entry_match += 1;
+    if (child_result) {
+      path_stats.shadow_ok += 1;
+    } else {
+      path_stats.mismatch += 1;
+    }
+  } else {
+    path_stats.entry_miss += 1;
+  }
+  if (disabled_now) {
+    path_stats.disabled += 1;
+  }
+}
+
+static void add_guard_fastplan_kind_count(
+    std::atomic<uint64_t>& top,
+    std::atomic<uint64_t>& nested,
+    GuardFastPlanCandidateKind kind) {
+  switch (kind) {
+    case GuardFastPlanCandidateKind::TopModules:
+      add_relaxed(top, 1);
+      break;
+    case GuardFastPlanCandidateKind::NestedModules:
+      add_relaxed(nested, 1);
+      break;
+    case GuardFastPlanCandidateKind::Unknown:
+    case GuardFastPlanCandidateKind::None:
+      break;
+  }
+}
+
+static void record_guard_fastplan_candidate(
+    GuardFastPlanCandidateKind kind) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  auto& stats = guard_fastplan_stats();
+  add_relaxed(stats.candidate, 1);
+  add_guard_fastplan_kind_count(
+      stats.candidate_top, stats.candidate_nested, kind);
+}
+
+static void record_guard_fastplan_shadow_pass(
+    GuardFastPlanCandidateKind kind,
+    bool partial,
+    size_t token_count,
+    uint64_t slow_check_ns) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  auto& stats = guard_fastplan_stats();
+  add_relaxed(stats.shadow_pass, 1);
+  add_guard_fastplan_kind_count(
+      stats.shadow_pass_top, stats.shadow_pass_nested, kind);
+  if (partial) {
+    add_relaxed(stats.partial_shadow_pass, 1);
+  }
+  add_relaxed(stats.token_count_sum, token_count);
+  add_relaxed(stats.slow_check_ns, slow_check_ns);
+}
+
+static void record_guard_fastplan_enable(
+    GuardFastPlanCandidateKind kind,
+    bool partial) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  auto& stats = guard_fastplan_stats();
+  add_relaxed(stats.enable, 1);
+  add_guard_fastplan_kind_count(stats.enable_top, stats.enable_nested, kind);
+  if (partial) {
+    add_relaxed(stats.partial_enable, 1);
+  }
+}
+
+static void record_guard_fastplan_disabled(
+    GuardFastPlanCandidateKind kind,
+    const GuardSubtreeMemoSupportAnalysis& analysis) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  auto& stats = guard_fastplan_stats();
+  add_relaxed(stats.disabled, 1);
+  add_guard_fastplan_kind_count(
+      stats.disabled_top, stats.disabled_nested, kind);
+  if (analysis.reason.empty()) {
+    return;
+  }
+
+  std::lock_guard<std::mutex> lock(guard_fastplan_disabled_stats_mutex());
+  guard_fastplan_disabled_reason_stats()[analysis.reason] += 1;
+  if (!analysis.path.empty()) {
+    auto& path_stats = guard_fastplan_disabled_path_stats()[analysis.path];
+    path_stats.count += 1;
+    if (path_stats.reason.empty()) {
+      path_stats.reason = analysis.reason;
+    }
+  }
+}
+
+static void record_guard_fastplan_hit(
+    GuardFastPlanCandidateKind kind,
+    bool partial,
+    size_t token_count,
+    uint64_t token_check_ns) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  auto& stats = guard_fastplan_stats();
+  add_relaxed(stats.hit, 1);
+  add_guard_fastplan_kind_count(stats.hit_top, stats.hit_nested, kind);
+  if (partial) {
+    add_relaxed(stats.partial_hit, 1);
+  }
+  add_relaxed(stats.token_count_sum, token_count);
+  add_relaxed(stats.token_check_ns, token_check_ns);
+}
+
+static void record_guard_fastplan_miss(
+    GuardFastPlanCandidateKind kind,
+    size_t token_count,
+    uint64_t token_check_ns,
+    uint64_t slow_check_ns,
+    bool disabled_now) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  auto& stats = guard_fastplan_stats();
+  add_relaxed(stats.miss, 1);
+  add_guard_fastplan_kind_count(stats.miss_top, stats.miss_nested, kind);
+  add_relaxed(stats.token_count_sum, token_count);
+  add_relaxed(stats.token_check_ns, token_check_ns);
+  add_relaxed(stats.slow_check_ns, slow_check_ns);
+  if (disabled_now) {
+    add_relaxed(stats.disabled, 1);
+    add_guard_fastplan_kind_count(
+        stats.disabled_top, stats.disabled_nested, kind);
+  }
+}
+
+static void record_guard_fastplan_token_cap_disabled() {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  add_relaxed(guard_fastplan_stats().token_cap_disabled, 1);
+}
+
+static void record_guard_last_success_shadow_attempt() {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  add_relaxed(guard_last_success_stats().shadow_attempt, 1);
+}
+
+static void record_guard_last_success_shadow_success(
+    size_t token_count,
+    uint64_t update_ns,
+    uint64_t compare_ns,
+    uint64_t shadow_passes) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  auto& stats = guard_last_success_stats();
+  add_relaxed(stats.shadow_success, 1);
+  add_relaxed(stats.token_count_sum, token_count);
+  add_relaxed(stats.receipt_update_ns, update_ns);
+  add_relaxed(stats.receipt_compare_ns, compare_ns);
+  max_relaxed(stats.shadow_max_passes, shadow_passes);
+}
+
+static void record_guard_last_success_shadow_stable() {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  add_relaxed(guard_last_success_stats().shadow_stable, 1);
+}
+
+static void record_guard_last_success_shadow_reset() {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  add_relaxed(guard_last_success_stats().shadow_reset, 1);
+}
+
+static void record_guard_last_success_compare_mismatch(
+    GuardLastSuccessCompareMismatchReason reason,
+    GuardSubtreeProbeTokenKind token_kind,
+    size_t index,
+    const std::string& path) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  auto& stats = guard_last_success_stats();
+  add_relaxed(stats.compare_mismatch, 1);
+  add_relaxed(stats.compare_mismatch_index_sum, index);
+  max_relaxed(stats.compare_mismatch_index_max, index);
+  std::lock_guard<std::mutex> lock(
+      guard_last_success_mismatch_stats_mutex());
+  guard_last_success_mismatch_reason_stats()
+      [guard_last_success_mismatch_reason_name(reason)] += 1;
+  guard_last_success_mismatch_kind_stats()
+      [guard_subtree_token_kind_name(token_kind)] += 1;
+  if (!path.empty()) {
+    auto& path_stats = guard_last_success_mismatch_path_stats()[path];
+    path_stats.count += 1;
+    if (path_stats.reason.empty()) {
+      path_stats.reason = guard_last_success_mismatch_reason_name(reason);
+    }
+  }
+}
+
+static void record_guard_last_success_actual_partial_attempt() {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  add_relaxed(guard_last_success_stats().actual_partial_attempt, 1);
+}
+
+static void record_guard_last_success_actual_partial_hit(
+    uint64_t token_check_ns,
+    uint64_t residual_ns) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  auto& stats = guard_last_success_stats();
+  add_relaxed(stats.actual_partial_hit, 1);
+  add_relaxed(stats.actual_partial_token_check_ns, token_check_ns);
+  add_relaxed(stats.actual_partial_residual_ns, residual_ns);
+}
+
+static void record_guard_last_success_actual_partial_miss(
+    uint64_t token_check_ns) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  auto& stats = guard_last_success_stats();
+  add_relaxed(stats.actual_partial_miss, 1);
+  add_relaxed(stats.actual_partial_token_check_ns, token_check_ns);
+}
+
+static void record_guard_last_success_actual_partial_enable() {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  add_relaxed(guard_last_success_stats().actual_partial_enable, 1);
+}
+
+static void record_guard_last_success_actual_partial_disabled() {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  add_relaxed(guard_last_success_stats().actual_partial_disabled, 1);
+}
+
+static void record_guard_last_success_actual_partial_hot_tokens(
+    size_t token_count) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  add_relaxed(
+      guard_last_success_stats().actual_partial_hot_token_count_sum,
+      token_count);
+}
+
+static void add_guard_last_success_actual_partial_kind_count(
+    GuardLastSuccessStats& stats,
+    GuardSubtreeProbeTokenKind kind,
+    uint64_t count) {
+  switch (kind) {
+    case GuardSubtreeProbeTokenKind::ObjectOnly:
+      add_relaxed(stats.actual_partial_hot_token_object_only, count);
+      break;
+    case GuardSubtreeProbeTokenKind::ExactDict:
+      add_relaxed(stats.actual_partial_hot_token_exact_dict, count);
+      break;
+    case GuardSubtreeProbeTokenKind::ExactList:
+      add_relaxed(stats.actual_partial_hot_token_exact_list, count);
+      break;
+    case GuardSubtreeProbeTokenKind::ExactTuple:
+      add_relaxed(stats.actual_partial_hot_token_exact_tuple, count);
+      break;
+    case GuardSubtreeProbeTokenKind::TensorMatch:
+      add_relaxed(stats.actual_partial_hot_token_tensor_match, count);
+      break;
+    case GuardSubtreeProbeTokenKind::DefaultDevice:
+      add_relaxed(stats.actual_partial_hot_token_default_device, count);
+      break;
+    case GuardSubtreeProbeTokenKind::GlobalState:
+      add_relaxed(stats.actual_partial_hot_token_global_state, count);
+      break;
+    case GuardSubtreeProbeTokenKind::TorchFunctionModeStack:
+      add_relaxed(
+          stats.actual_partial_hot_token_torch_function_mode_stack, count);
+      break;
+    case GuardSubtreeProbeTokenKind::NoTensorAliasing:
+      add_relaxed(stats.actual_partial_hot_token_no_tensor_aliasing, count);
+      break;
+    case GuardSubtreeProbeTokenKind::ObjectAliasing:
+      add_relaxed(stats.actual_partial_hot_token_object_aliasing, count);
+      break;
+    case GuardSubtreeProbeTokenKind::BoundMethod:
+      add_relaxed(stats.actual_partial_hot_token_bound_method, count);
+      break;
+    case GuardSubtreeProbeTokenKind::FrameGlobals:
+      add_relaxed(stats.actual_partial_hot_token_frame_globals, count);
+      break;
+  }
+}
+
+static void add_guard_last_success_actual_partial_duplicate_kind_count(
+    GuardLastSuccessStats& stats,
+    GuardSubtreeProbeTokenKind kind,
+    uint64_t count) {
+  switch (kind) {
+    case GuardSubtreeProbeTokenKind::ObjectOnly:
+      add_relaxed(
+          stats.actual_partial_hot_token_duplicate_object_only, count);
+      break;
+    case GuardSubtreeProbeTokenKind::ExactDict:
+      add_relaxed(stats.actual_partial_hot_token_duplicate_exact_dict, count);
+      break;
+    case GuardSubtreeProbeTokenKind::ExactList:
+      add_relaxed(stats.actual_partial_hot_token_duplicate_exact_list, count);
+      break;
+    case GuardSubtreeProbeTokenKind::ExactTuple:
+      add_relaxed(stats.actual_partial_hot_token_duplicate_exact_tuple, count);
+      break;
+    case GuardSubtreeProbeTokenKind::TensorMatch:
+      add_relaxed(stats.actual_partial_hot_token_duplicate_tensor_match, count);
+      break;
+    case GuardSubtreeProbeTokenKind::DefaultDevice:
+      add_relaxed(
+          stats.actual_partial_hot_token_duplicate_default_device, count);
+      break;
+    case GuardSubtreeProbeTokenKind::GlobalState:
+      add_relaxed(stats.actual_partial_hot_token_duplicate_global_state, count);
+      break;
+    case GuardSubtreeProbeTokenKind::TorchFunctionModeStack:
+      add_relaxed(
+          stats
+              .actual_partial_hot_token_duplicate_torch_function_mode_stack,
+          count);
+      break;
+    case GuardSubtreeProbeTokenKind::NoTensorAliasing:
+      add_relaxed(
+          stats.actual_partial_hot_token_duplicate_no_tensor_aliasing, count);
+      break;
+    case GuardSubtreeProbeTokenKind::ObjectAliasing:
+      add_relaxed(
+          stats.actual_partial_hot_token_duplicate_object_aliasing, count);
+      break;
+    case GuardSubtreeProbeTokenKind::BoundMethod:
+      add_relaxed(stats.actual_partial_hot_token_duplicate_bound_method, count);
+      break;
+    case GuardSubtreeProbeTokenKind::FrameGlobals:
+      add_relaxed(stats.actual_partial_hot_token_duplicate_frame_globals, count);
+      break;
+  }
+}
+
+static void record_guard_last_success_actual_partial_hot_token_duplicates(
+    size_t unique_count,
+    size_t duplicate_count,
+    const std::array<uint64_t, kGuardSubtreeProbeTokenKindCount>& kind_counts,
+    const std::array<uint64_t, kGuardSubtreeProbeTokenKindCount>&
+        duplicate_kind_counts) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  auto& stats = guard_last_success_stats();
+  add_relaxed(
+      stats.actual_partial_hot_token_unique_count_sum, unique_count);
+  add_relaxed(
+      stats.actual_partial_hot_token_duplicate_count_sum, duplicate_count);
+  for (size_t i = 0; i < kind_counts.size(); ++i) {
+    if (kind_counts[i] == 0) {
+      continue;
+    }
+    add_guard_last_success_actual_partial_kind_count(
+        stats, static_cast<GuardSubtreeProbeTokenKind>(i), kind_counts[i]);
+  }
+  for (size_t i = 0; i < duplicate_kind_counts.size(); ++i) {
+    if (duplicate_kind_counts[i] == 0) {
+      continue;
+    }
+    add_guard_last_success_actual_partial_duplicate_kind_count(
+        stats,
+        static_cast<GuardSubtreeProbeTokenKind>(i),
+        duplicate_kind_counts[i]);
+  }
+}
+
+static void record_guard_last_success_actual_partial_residual_fail(
+    uint64_t token_check_ns,
+    uint64_t residual_ns) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  auto& stats = guard_last_success_stats();
+  add_relaxed(stats.actual_partial_residual_fail, 1);
+  add_relaxed(stats.actual_partial_token_check_ns, token_check_ns);
+  add_relaxed(stats.actual_partial_residual_ns, residual_ns);
+}
+
+static void record_guard_last_success_actual_partial_train(uint64_t train_ns) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  add_relaxed(guard_last_success_stats().actual_partial_train_ns, train_ns);
+}
+
+static void record_guard_last_success_disabled_item_locked(
+    const char* reason,
+    const std::string& path) {
+  if (reason == nullptr) {
+    reason = "unsupported:unknown";
+  }
+  guard_last_success_disabled_reason_stats()[reason] += 1;
+  if (!path.empty()) {
+    auto& path_stats = guard_last_success_disabled_path_stats()[path];
+    path_stats.count += 1;
+    if (path_stats.reason.empty()) {
+      path_stats.reason = reason;
+    }
+  }
+}
+
+static void record_guard_last_success_incomplete(
+    const char* reason,
+    const std::string& path = "",
+    size_t token_count = 0) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  if (reason == nullptr) {
+    reason = "unsupported:unknown";
+  }
+  auto& stats = guard_last_success_stats();
+  add_relaxed(stats.shadow_incomplete, 1);
+  if (std::strcmp(reason, "token_cap_exceeded") == 0) {
+    add_relaxed(stats.token_cap_disabled, 1);
+    add_relaxed(stats.token_cap_count_sum, token_count);
+    max_relaxed(stats.token_cap_count_max, token_count);
+  }
+  std::lock_guard<std::mutex> lock(
+      guard_last_success_disabled_stats_mutex());
+  record_guard_last_success_disabled_item_locked(reason, path);
+}
+
+static void record_guard_last_success_incomplete(
+    const GuardSubtreeMemoSupportAnalysis& analysis) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  auto& stats = guard_last_success_stats();
+  add_relaxed(stats.shadow_incomplete, 1);
+  std::lock_guard<std::mutex> lock(
+      guard_last_success_disabled_stats_mutex());
+  if (analysis.unsupported.empty()) {
+    record_guard_last_success_disabled_item_locked(
+        analysis.reason.empty() ? "unsupported:unknown" : analysis.reason.c_str(),
+        analysis.path);
+    return;
+  }
+  for (const auto& item : analysis.unsupported) {
+    record_guard_last_success_disabled_item_locked(
+        item.first.c_str(), item.second);
+  }
+}
+
+static void record_guard_fastplan_tensor_token_shadow() {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  auto& stats = guard_fastplan_stats();
+  add_relaxed(stats.tensor_token_shadow, 1);
+  add_relaxed(stats.tensor_token_count_sum, 1);
+}
+
+static void record_guard_fastplan_tensor_token_hit(uint64_t check_ns) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  auto& stats = guard_fastplan_stats();
+  add_relaxed(stats.tensor_token_hit, 1);
+  add_relaxed(stats.tensor_token_check_ns, check_ns);
+  add_relaxed(stats.tensor_token_count_sum, 1);
+}
+
+static void record_guard_fastplan_tensor_token_miss(
+    GuardFastPlanTensorTokenMissReason reason,
+    uint64_t check_ns) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  auto& stats = guard_fastplan_stats();
+  add_relaxed(stats.tensor_token_miss, 1);
+  add_relaxed(stats.tensor_token_check_ns, check_ns);
+  add_relaxed(stats.tensor_token_count_sum, 1);
+  switch (reason) {
+    case GuardFastPlanTensorTokenMissReason::MissingLocalState:
+      add_relaxed(stats.tensor_token_miss_missing_local_state, 1);
+      break;
+    case GuardFastPlanTensorTokenMissReason::Object:
+      add_relaxed(stats.tensor_token_miss_object, 1);
+      break;
+    case GuardFastPlanTensorTokenMissReason::Type:
+      add_relaxed(stats.tensor_token_miss_type, 1);
+      break;
+    case GuardFastPlanTensorTokenMissReason::NotTensor:
+      add_relaxed(stats.tensor_token_miss_not_tensor, 1);
+      break;
+    case GuardFastPlanTensorTokenMissReason::DispatchKey:
+      add_relaxed(stats.tensor_token_miss_dispatch_key, 1);
+      break;
+    case GuardFastPlanTensorTokenMissReason::DType:
+      add_relaxed(stats.tensor_token_miss_dtype, 1);
+      break;
+    case GuardFastPlanTensorTokenMissReason::Device:
+      add_relaxed(stats.tensor_token_miss_device, 1);
+      break;
+    case GuardFastPlanTensorTokenMissReason::RequiresGrad:
+      add_relaxed(stats.tensor_token_miss_requires_grad, 1);
+      break;
+    case GuardFastPlanTensorTokenMissReason::Dim:
+      add_relaxed(stats.tensor_token_miss_dim, 1);
+      break;
+    case GuardFastPlanTensorTokenMissReason::Size:
+      add_relaxed(stats.tensor_token_miss_size, 1);
+      break;
+    case GuardFastPlanTensorTokenMissReason::Stride:
+      add_relaxed(stats.tensor_token_miss_stride, 1);
+      break;
+    case GuardFastPlanTensorTokenMissReason::None:
+      break;
+  }
+}
+
+static GuardFastPlanCandidateKind compute_guard_fastplan_candidate_kind(
+    const std::string& source) {
+  static constexpr const char* kModulesSuffix = "._modules";
+  static constexpr const char* kSelfModules = "L['self']._modules";
+  const size_t suffix_len = std::strlen(kModulesSuffix);
+  if (source.size() < suffix_len ||
+      source.compare(source.size() - suffix_len, suffix_len, kModulesSuffix) !=
+          0) {
+    return GuardFastPlanCandidateKind::None;
+  }
+  if (source.find(kSelfModules) == std::string::npos) {
+    return GuardFastPlanCandidateKind::None;
+  }
+  if (source.find("._modules[") == std::string::npos) {
+    return GuardFastPlanCandidateKind::None;
+  }
+  return GuardFastPlanCandidateKind::NestedModules;
+}
+
+static bool source_ends_with(
+    const std::string& source,
+    const char* suffix) {
+  const size_t suffix_len = std::strlen(suffix);
+  return source.size() >= suffix_len &&
+      source.compare(source.size() - suffix_len, suffix_len, suffix) == 0;
+}
+
+static bool tensor_match_source_supports_subtree_memo(
+    const std::string& source) {
+  return source.find("._parameters[") != std::string::npos ||
+      source.find("._buffers[") != std::string::npos ||
+      source_ends_with(source, "._cached_tensor") ||
+      (source.find("L['self']._modules[") != std::string::npos &&
+       source_ends_with(source, ".scale"));
+}
+
+std::string guard_accessor_stats_key(PyObject* key) {
+  if (key == nullptr) {
+    return "<unknown>";
+  }
+  if (key == Py_None) {
+    return "None";
+  }
+  if (key == Py_True) {
+    return "True";
+  }
+  if (key == Py_False) {
+    return "False";
+  }
+  if (PyUnicode_CheckExact(key)) {
+    const char* value = PyUnicode_AsUTF8(key);
+    if (value == nullptr) {
+      PyErr_Clear();
+      return "<str>";
+    }
+    return std::string("'") + value + "'";
+  }
+  if (PyLong_CheckExact(key)) {
+    long long value = PyLong_AsLongLong(key);
+    if (PyErr_Occurred()) {
+      PyErr_Clear();
+      return "<int>";
+    }
+    return std::to_string(value);
+  }
+  return "<unknown>";
+}
+
 thread_local bool tls_is_in_mode_without_ignore_compile_internals = false;
 
 void set_is_in_mode_without_ignore_compile_internals(bool value) {
@@ -138,6 +2417,16 @@ bool get_is_in_mode_without_ignore_compile_internals() {
     return;                                 \
   }                                         \
   self.insert_leaf_guard(name);
+
+#define GUARD_ACCESSOR_STATS_NAME(name) \
+  const char* stats_name() const override { \
+    return #name;                           \
+  }
+
+#define LEAF_GUARD_STATS_NAME(name)     \
+  const char* stats_name() const override { \
+    return #name;                       \
+  }
 
 TensorCheck::TensorCheck(
     const LocalState& state,
@@ -889,6 +3178,1327 @@ static uint64_t get_dict_version_unchecked(PyObject* dict) {
   return ((PyDictObject*)dict)->ma_version_tag;
 
 #endif
+}
+
+static bool tensor_layout_does_not_support_stride(const at::Tensor& tensor) {
+  return tensor.layout() == c10::kSparseCsr ||
+      tensor.layout() == c10::kSparseCsc ||
+      tensor.layout() == c10::kSparseBsc ||
+      tensor.layout() == c10::kSparseBsr;
+}
+
+static bool tensor_strides_match_guard_check(
+    const at::Tensor& tensor,
+    const std::vector<int64_t>& stride_indices,
+    const std::vector<c10::SymInt>& stride_values) {
+  if (stride_indices.size() != stride_values.size()) {
+    return false;
+  }
+  if (tensor_layout_does_not_support_stride(tensor)) {
+    const int64_t ndim = tensor.ndimension();
+    const c10::SymInt unsupported_stride(static_cast<int64_t>(-1));
+    for (auto i : c10::irange(stride_indices.size())) {
+      const int64_t index = stride_indices[i];
+      if (index < 0 || index >= ndim ||
+          stride_values[i] != unsupported_stride) {
+        return false;
+      }
+    }
+    return true;
+  }
+  const auto current_strides = tensor.sym_strides();
+  for (auto i : c10::irange(stride_indices.size())) {
+    const int64_t index = stride_indices[i];
+    if (index < 0 || index >= static_cast<int64_t>(current_strides.size()) ||
+        stride_values[i] != current_strides[index]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+static PyObject* current_device_key() {
+  static PyObject* key = PyUnicode_InternFromString("CURRENT_DEVICE");
+  return key;
+}
+
+static bool default_device_matches(
+    PyObject* utils_device_dict,
+    PyObject* expected) {
+  if (utils_device_dict == nullptr || expected == nullptr) {
+    return false;
+  }
+  PyObject* key = current_device_key();
+  if (key == nullptr) {
+    PyErr_Clear();
+    return false;
+  }
+  PyObject* device = PyDict_GetItem(utils_device_dict, key);
+  if (device == nullptr) {
+    PyErr_Clear();
+    return false;
+  }
+  if (device == expected) {
+    return true;
+  }
+  const int result = PyObject_RichCompareBool(device, expected, Py_EQ);
+  if (result == -1) {
+    PyErr_Clear();
+    return false;
+  }
+  return result == 1;
+}
+
+static bool torch_function_mode_stack_guard_matches(const void* guard);
+
+static bool is_global_source_path(const std::string& source) {
+  return source == "G" ||
+      (source.size() > 1 && source[0] == 'G' &&
+       (source[1] == '[' || source[1] == '.'));
+}
+
+struct GuardSubtreeEntryToken {
+  PyObject* object{nullptr};
+  PyTypeObject* type{nullptr};
+  GuardSubtreeProbeTokenKind kind{GuardSubtreeProbeTokenKind::ObjectOnly};
+  uint64_t version{0};
+  Py_ssize_t size{0};
+  std::vector<PyObject*> list_items;
+  uint64_t tensor_dispatch_key{0};
+  at::ScalarType tensor_dtype{at::ScalarType::Undefined};
+  c10::DeviceIndex tensor_device_index{-1};
+  bool tensor_requires_grad{false};
+  int64_t tensor_dim{0};
+  std::vector<int64_t> tensor_size_indices;
+  std::vector<c10::SymInt> tensor_size_values;
+  std::vector<int64_t> tensor_stride_indices;
+  std::vector<c10::SymInt> tensor_stride_values;
+  PyObject* default_device_dict{nullptr};
+  PyObject* default_device{nullptr};
+  GlobalStateGuard* global_state_guard{nullptr};
+  const void* torch_function_mode_stack_guard{nullptr};
+  const void* no_tensor_aliasing_guard{nullptr};
+  const void* object_aliasing_guard{nullptr};
+  PyObject* bound_method_self{nullptr};
+  PyObject* bound_method_func{nullptr};
+  PyCFunction bound_c_method_func{nullptr};
+  PyTypeObject* bound_c_method_class{nullptr};
+  int bound_c_method_flags{0};
+
+  static GuardSubtreeEntryToken make(PyObject* obj) {
+    GuardSubtreeEntryToken token;
+    token.object = obj;
+    token.type = Py_TYPE(obj);
+    if (PyMethod_Check(obj)) {
+      token.kind = GuardSubtreeProbeTokenKind::BoundMethod;
+      token.bound_method_self = PyMethod_GET_SELF(obj);
+      token.bound_method_func = PyMethod_GET_FUNCTION(obj);
+    } else if (PyCFunction_Check(obj)) {
+      token.kind = GuardSubtreeProbeTokenKind::BoundMethod;
+      token.bound_method_self = PyCFunction_GET_SELF(obj);
+      token.bound_c_method_func = PyCFunction_GET_FUNCTION(obj);
+      token.bound_c_method_flags = PyCFunction_GET_FLAGS(obj);
+#ifdef PyCFunction_GET_CLASS
+      token.bound_c_method_class = PyCFunction_GET_CLASS(obj);
+#endif
+    } else if (PyDict_CheckExact(obj)) {
+      token.kind = GuardSubtreeProbeTokenKind::ExactDict;
+      token.version = get_dict_version_unchecked(obj);
+      token.size = PyDict_GET_SIZE(obj);
+    } else if (PyList_CheckExact(obj)) {
+      token.kind = GuardSubtreeProbeTokenKind::ExactList;
+      token.size = PyList_GET_SIZE(obj);
+      token.list_items.reserve(static_cast<size_t>(token.size));
+      for (Py_ssize_t i = 0; i < token.size; ++i) {
+        token.list_items.push_back(PyList_GET_ITEM(obj, i));
+      }
+    } else if (PyTuple_CheckExact(obj)) {
+      token.kind = GuardSubtreeProbeTokenKind::ExactTuple;
+      token.size = PyTuple_GET_SIZE(obj);
+    }
+    return token;
+  }
+
+  static GuardSubtreeEntryToken make_for_source(
+      PyObject* obj,
+      const std::string& source) {
+    if (is_global_source_path(source) && PyDict_CheckExact(obj)) {
+      GuardSubtreeEntryToken token;
+      token.object = obj;
+      token.type = Py_TYPE(obj);
+      token.kind = GuardSubtreeProbeTokenKind::FrameGlobals;
+      return token;
+    }
+    return make(obj);
+  }
+
+  static bool make_tensor_match(
+      PyObject* obj,
+      TensorCheck& tensor_check,
+      const LocalState& state,
+      GuardSubtreeEntryToken* token) {
+    if (Py_TYPE(obj) != tensor_check.pytype) {
+      return false;
+    }
+    if (!THPVariable_CheckExact(obj) && !THPVariable_Check(obj)) {
+      return false;
+    }
+
+    const at::Tensor tensor = THPVariable_Unpack(obj);
+    if (!tensor_check.check(state, tensor)) {
+      return false;
+    }
+
+    token->object = obj;
+    token->type = Py_TYPE(obj);
+    token->kind = GuardSubtreeProbeTokenKind::TensorMatch;
+    token->tensor_dispatch_key = state.apply(tensor.key_set()).raw_repr();
+    token->tensor_dtype = tensor.dtype().toScalarType();
+    token->tensor_device_index = tensor.device().index();
+    token->tensor_requires_grad = tensor.requires_grad();
+    token->tensor_dim = tensor.ndimension();
+
+    const auto& expected_sizes = tensor_check.sizes();
+    token->tensor_size_indices.reserve(expected_sizes.size());
+    token->tensor_size_values.reserve(expected_sizes.size());
+    for (auto i : c10::irange(expected_sizes.size())) {
+      const auto& expected_size = expected_sizes[i];
+      if (expected_size.has_value()) {
+        // Dynamic dimensions are represented as nullopt by TensorCheck and are
+        // deliberately not tokenized. Fast-path tensor tokens must not make a
+        // dynamic dimension more static than the original guard.
+        token->tensor_size_indices.push_back(static_cast<int64_t>(i));
+        token->tensor_size_values.push_back(expected_size.value());
+      }
+    }
+
+    const auto& expected_strides = tensor_check.strides();
+    token->tensor_stride_indices.reserve(expected_strides.size());
+    token->tensor_stride_values.reserve(expected_strides.size());
+    for (auto i : c10::irange(expected_strides.size())) {
+      const auto& expected_stride = expected_strides[i];
+      if (expected_stride.has_value()) {
+        // Same rule as sizes: only original static stride guards become token
+        // checks; dynamic stride entries stay unchecked here.
+        token->tensor_stride_indices.push_back(static_cast<int64_t>(i));
+        token->tensor_stride_values.push_back(expected_stride.value());
+      }
+    }
+    return true;
+  }
+
+  static GuardSubtreeEntryToken make_default_device(
+      PyObject* utils_device_dict,
+      PyObject* device) {
+    GuardSubtreeEntryToken token;
+    token.object = utils_device_dict;
+    token.type = Py_TYPE(utils_device_dict);
+    token.kind = GuardSubtreeProbeTokenKind::DefaultDevice;
+    token.default_device_dict = utils_device_dict;
+    token.default_device = device;
+    return token;
+  }
+
+  static GuardSubtreeEntryToken make_global_state(GlobalStateGuard* guard) {
+    GuardSubtreeEntryToken token;
+    token.kind = GuardSubtreeProbeTokenKind::GlobalState;
+    token.global_state_guard = guard;
+    return token;
+  }
+
+  static GuardSubtreeEntryToken make_torch_function_mode_stack(
+      const void* guard) {
+    GuardSubtreeEntryToken token;
+    token.kind = GuardSubtreeProbeTokenKind::TorchFunctionModeStack;
+    token.torch_function_mode_stack_guard = guard;
+    return token;
+  }
+
+  static GuardSubtreeEntryToken make_no_tensor_aliasing(
+      PyObject* obj,
+      const void* guard) {
+    GuardSubtreeEntryToken token;
+    token.object = obj;
+    token.type = Py_TYPE(obj);
+    token.kind = GuardSubtreeProbeTokenKind::NoTensorAliasing;
+    token.no_tensor_aliasing_guard = guard;
+    return token;
+  }
+
+  static GuardSubtreeEntryToken make_object_aliasing(
+      PyObject* obj,
+      const void* guard) {
+    GuardSubtreeEntryToken token;
+    token.object = obj;
+    token.type = Py_TYPE(obj);
+    token.kind = GuardSubtreeProbeTokenKind::ObjectAliasing;
+    token.object_aliasing_guard = guard;
+    return token;
+  }
+
+  bool matches_tensor_current(
+      const LocalState* state,
+      GuardFastPlanTensorTokenMissReason& reason) const {
+    reason = GuardFastPlanTensorTokenMissReason::None;
+    if (state == nullptr) {
+      reason = GuardFastPlanTensorTokenMissReason::MissingLocalState;
+      return false;
+    }
+    if (object == nullptr) {
+      reason = GuardFastPlanTensorTokenMissReason::Object;
+      return false;
+    }
+    if (Py_TYPE(object) != type) {
+      reason = GuardFastPlanTensorTokenMissReason::Type;
+      return false;
+    }
+    if (!THPVariable_CheckExact(object) && !THPVariable_Check(object)) {
+      reason = GuardFastPlanTensorTokenMissReason::NotTensor;
+      return false;
+    }
+
+    const at::Tensor tensor = THPVariable_Unpack(object);
+    if (state->apply(tensor.key_set()).raw_repr() != tensor_dispatch_key) {
+      reason = GuardFastPlanTensorTokenMissReason::DispatchKey;
+      return false;
+    }
+    if (tensor.dtype().toScalarType() != tensor_dtype) {
+      reason = GuardFastPlanTensorTokenMissReason::DType;
+      return false;
+    }
+    if (tensor.device().index() != tensor_device_index) {
+      reason = GuardFastPlanTensorTokenMissReason::Device;
+      return false;
+    }
+    if (tensor.requires_grad() != tensor_requires_grad) {
+      reason = GuardFastPlanTensorTokenMissReason::RequiresGrad;
+      return false;
+    }
+    if (tensor.ndimension() != tensor_dim) {
+      reason = GuardFastPlanTensorTokenMissReason::Dim;
+      return false;
+    }
+
+    const auto current_sizes = tensor.sym_sizes();
+    for (auto i : c10::irange(tensor_size_indices.size())) {
+      const int64_t index = tensor_size_indices[i];
+      if (index < 0 || index >= static_cast<int64_t>(current_sizes.size()) ||
+          tensor_size_values[i] != current_sizes[index]) {
+        reason = GuardFastPlanTensorTokenMissReason::Size;
+        return false;
+      }
+    }
+
+    if (!tensor_strides_match_guard_check(
+            tensor, tensor_stride_indices, tensor_stride_values)) {
+      reason = GuardFastPlanTensorTokenMissReason::Stride;
+      return false;
+    }
+    return true;
+  }
+
+  bool matches_default_device_current() const {
+    return default_device_matches(default_device_dict, default_device);
+  }
+
+  bool matches_global_state_current() const {
+    return global_state_guard != nullptr && global_state_guard->check();
+  }
+
+  bool matches(const GuardSubtreeEntryToken& other) const {
+    if (kind != other.kind || type != other.type) {
+      return false;
+    }
+    if (kind == GuardSubtreeProbeTokenKind::BoundMethod) {
+      return bound_method_self == other.bound_method_self &&
+          bound_method_func == other.bound_method_func &&
+          bound_c_method_func == other.bound_c_method_func &&
+          bound_c_method_class == other.bound_c_method_class &&
+          bound_c_method_flags == other.bound_c_method_flags;
+    }
+    if (object != other.object) {
+      return false;
+    }
+    if (kind == GuardSubtreeProbeTokenKind::FrameGlobals) {
+      return true;
+    }
+    if (kind == GuardSubtreeProbeTokenKind::TensorMatch) {
+      return tensor_dispatch_key == other.tensor_dispatch_key &&
+          tensor_dtype == other.tensor_dtype &&
+          tensor_device_index == other.tensor_device_index &&
+          tensor_requires_grad == other.tensor_requires_grad &&
+          tensor_dim == other.tensor_dim &&
+          tensor_size_indices == other.tensor_size_indices &&
+          tensor_size_values == other.tensor_size_values &&
+          tensor_stride_indices == other.tensor_stride_indices &&
+          tensor_stride_values == other.tensor_stride_values;
+    }
+    if (kind == GuardSubtreeProbeTokenKind::DefaultDevice) {
+      return default_device_dict == other.default_device_dict &&
+          default_device == other.default_device;
+    }
+    if (kind == GuardSubtreeProbeTokenKind::GlobalState) {
+      return global_state_guard == other.global_state_guard;
+    }
+    if (kind == GuardSubtreeProbeTokenKind::TorchFunctionModeStack) {
+      return torch_function_mode_stack_guard ==
+          other.torch_function_mode_stack_guard;
+    }
+    if (kind == GuardSubtreeProbeTokenKind::NoTensorAliasing) {
+      return no_tensor_aliasing_guard == other.no_tensor_aliasing_guard;
+    }
+    if (kind == GuardSubtreeProbeTokenKind::ObjectAliasing) {
+      return object_aliasing_guard == other.object_aliasing_guard;
+    }
+    return version == other.version && size == other.size &&
+        list_items == other.list_items;
+  }
+};
+
+static GuardLastSuccessCompareMismatchReason
+guard_subtree_token_mismatch_reason(
+    const GuardSubtreeEntryToken& lhs,
+    const GuardSubtreeEntryToken& rhs) {
+  if (lhs.kind != rhs.kind) {
+    return GuardLastSuccessCompareMismatchReason::Kind;
+  }
+  if (lhs.type != rhs.type) {
+    return GuardLastSuccessCompareMismatchReason::Type;
+  }
+  if (lhs.kind == GuardSubtreeProbeTokenKind::BoundMethod) {
+    if (lhs.bound_method_self != rhs.bound_method_self ||
+        lhs.bound_method_func != rhs.bound_method_func ||
+        lhs.bound_c_method_func != rhs.bound_c_method_func ||
+        lhs.bound_c_method_class != rhs.bound_c_method_class ||
+        lhs.bound_c_method_flags != rhs.bound_c_method_flags) {
+      return GuardLastSuccessCompareMismatchReason::BoundMethod;
+    }
+    return GuardLastSuccessCompareMismatchReason::Unknown;
+  }
+  if (lhs.object != rhs.object) {
+    return GuardLastSuccessCompareMismatchReason::Object;
+  }
+  if (lhs.kind == GuardSubtreeProbeTokenKind::TensorMatch) {
+    if (lhs.tensor_dispatch_key != rhs.tensor_dispatch_key ||
+        lhs.tensor_dtype != rhs.tensor_dtype ||
+        lhs.tensor_device_index != rhs.tensor_device_index ||
+        lhs.tensor_requires_grad != rhs.tensor_requires_grad ||
+        lhs.tensor_dim != rhs.tensor_dim ||
+        lhs.tensor_size_indices != rhs.tensor_size_indices ||
+        lhs.tensor_size_values != rhs.tensor_size_values ||
+        lhs.tensor_stride_indices != rhs.tensor_stride_indices ||
+        lhs.tensor_stride_values != rhs.tensor_stride_values) {
+      return GuardLastSuccessCompareMismatchReason::TensorMeta;
+    }
+    return GuardLastSuccessCompareMismatchReason::Unknown;
+  }
+  if (lhs.kind == GuardSubtreeProbeTokenKind::DefaultDevice) {
+    if (lhs.default_device_dict != rhs.default_device_dict ||
+        lhs.default_device != rhs.default_device) {
+      return GuardLastSuccessCompareMismatchReason::DefaultDevice;
+    }
+    return GuardLastSuccessCompareMismatchReason::Unknown;
+  }
+  if (lhs.kind == GuardSubtreeProbeTokenKind::GlobalState) {
+    return lhs.global_state_guard == rhs.global_state_guard
+        ? GuardLastSuccessCompareMismatchReason::Unknown
+        : GuardLastSuccessCompareMismatchReason::GlobalState;
+  }
+  if (lhs.kind == GuardSubtreeProbeTokenKind::TorchFunctionModeStack) {
+    return lhs.torch_function_mode_stack_guard ==
+            rhs.torch_function_mode_stack_guard
+        ? GuardLastSuccessCompareMismatchReason::Unknown
+        : GuardLastSuccessCompareMismatchReason::TorchFunctionModeStack;
+  }
+  if (lhs.kind == GuardSubtreeProbeTokenKind::NoTensorAliasing) {
+    return lhs.no_tensor_aliasing_guard == rhs.no_tensor_aliasing_guard
+        ? GuardLastSuccessCompareMismatchReason::Unknown
+        : GuardLastSuccessCompareMismatchReason::NoTensorAliasing;
+  }
+  if (lhs.kind == GuardSubtreeProbeTokenKind::ObjectAliasing) {
+    return lhs.object_aliasing_guard == rhs.object_aliasing_guard
+        ? GuardLastSuccessCompareMismatchReason::Unknown
+        : GuardLastSuccessCompareMismatchReason::ObjectAliasing;
+  }
+  if (lhs.version != rhs.version) {
+    return GuardLastSuccessCompareMismatchReason::Version;
+  }
+  if (lhs.size != rhs.size) {
+    return GuardLastSuccessCompareMismatchReason::DictSize;
+  }
+  if (lhs.list_items != rhs.list_items) {
+    return GuardLastSuccessCompareMismatchReason::ListItems;
+  }
+  return GuardLastSuccessCompareMismatchReason::Unknown;
+}
+
+static bool guard_subtree_token_vectors_match(
+    const std::vector<GuardSubtreeEntryToken>& lhs,
+    const std::vector<GuardSubtreeEntryToken>& rhs) {
+  if (lhs.size() != rhs.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < lhs.size(); ++i) {
+    if (!lhs[i].matches(rhs[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+enum class GuardLastSuccessPartialTokenDecision : uint8_t {
+  Keep,
+  DropReachabilityOnly,
+  UnsupportedBail,
+};
+
+static GuardLastSuccessPartialTokenDecision
+guard_last_success_partial_token_decision(
+    const GuardSubtreeEntryToken& token,
+    size_t index) {
+  if (index == 0) {
+    return GuardLastSuccessPartialTokenDecision::Keep;
+  }
+  switch (token.kind) {
+    case GuardSubtreeProbeTokenKind::ObjectOnly:
+      // Parent container tokens prove whether this object is still reachable.
+      // Dropping this token is safe only for reachability-only objects: any
+      // semantic guard attached to the object must emit its own token or force
+      // the partial plan to bail.
+      return GuardLastSuccessPartialTokenDecision::DropReachabilityOnly;
+    case GuardSubtreeProbeTokenKind::BoundMethod:
+      // Keep bound methods as hot tokens. A stored bound method is protected by
+      // its parent structural token; the runtime matcher validates the bound
+      // target payload without dereferencing the possibly short-lived method
+      // wrapper.
+      return GuardLastSuccessPartialTokenDecision::Keep;
+    case GuardSubtreeProbeTokenKind::DefaultDevice:
+    case GuardSubtreeProbeTokenKind::GlobalState:
+    case GuardSubtreeProbeTokenKind::TorchFunctionModeStack:
+    case GuardSubtreeProbeTokenKind::FrameGlobals:
+      // These tokens are valid in the full slow receipt, but the partial fast
+      // path has no local proof that dropping them preserves guard semantics.
+      // Conservatively disable the partial plan instead of silently filtering
+      // them out and later reporting a fast hit.
+      return GuardLastSuccessPartialTokenDecision::UnsupportedBail;
+    case GuardSubtreeProbeTokenKind::NoTensorAliasing:
+    case GuardSubtreeProbeTokenKind::ObjectAliasing:
+      // Relational guard tokens are part of the measured hot path. They are
+      // safe only if kept as hot tokens: dropping them would silently skip the
+      // relation, while keeping them lets container tokens prove rebinding did
+      // not happen and the token matcher verify the guarded objects/types.
+      return GuardLastSuccessPartialTokenDecision::Keep;
+    default:
+      return GuardLastSuccessPartialTokenDecision::Keep;
+  }
+}
+
+static bool guard_last_success_make_partial_hot_tokens(
+    const std::vector<GuardSubtreeEntryToken>& tokens,
+    const std::vector<std::string>& debug_paths,
+    std::vector<GuardSubtreeEntryToken>& hot_tokens,
+    std::string& disabled_reason,
+    std::string& disabled_path) {
+  hot_tokens.clear();
+  hot_tokens.reserve(tokens.size());
+  for (size_t i = 0; i < tokens.size(); ++i) {
+    switch (guard_last_success_partial_token_decision(tokens[i], i)) {
+      case GuardLastSuccessPartialTokenDecision::Keep:
+        hot_tokens.push_back(tokens[i]);
+        break;
+      case GuardLastSuccessPartialTokenDecision::DropReachabilityOnly:
+        break;
+      case GuardLastSuccessPartialTokenDecision::UnsupportedBail:
+        disabled_reason = std::string("actual_partial_unsupported_hot_token:") +
+            guard_subtree_token_kind_name(tokens[i].kind);
+        disabled_path = i < debug_paths.size() ? debug_paths[i] : "L['self']";
+        return false;
+    }
+  }
+  return true;
+}
+
+static void record_guard_last_success_actual_partial_hot_token_duplicate_stats(
+    const std::vector<GuardSubtreeEntryToken>& tokens) {
+  if (!guard_lookup_stats_enabled()) {
+    return;
+  }
+  std::array<uint64_t, kGuardSubtreeProbeTokenKindCount> kind_counts{};
+  std::array<uint64_t, kGuardSubtreeProbeTokenKindCount>
+      duplicate_kind_counts{};
+  for (const auto& token : tokens) {
+    kind_counts[static_cast<size_t>(token.kind)] += 1;
+  }
+  record_guard_last_success_actual_partial_hot_token_duplicates(
+      tokens.size(), 0, kind_counts, duplicate_kind_counts);
+}
+
+static bool guard_subtree_token_vectors_match(
+    const std::vector<GuardSubtreeEntryToken>& lhs,
+    const std::vector<GuardSubtreeEntryToken>& rhs,
+    GuardLastSuccessCompareMismatchReason& reason,
+    GuardSubtreeProbeTokenKind& token_kind,
+    size_t& index) {
+  reason = GuardLastSuccessCompareMismatchReason::Unknown;
+  token_kind = GuardSubtreeProbeTokenKind::ObjectOnly;
+  index = 0;
+  if (lhs.size() != rhs.size()) {
+    reason = GuardLastSuccessCompareMismatchReason::Size;
+    index = std::min(lhs.size(), rhs.size());
+    return false;
+  }
+  for (size_t i = 0; i < lhs.size(); ++i) {
+    if (!lhs[i].matches(rhs[i])) {
+      reason = guard_subtree_token_mismatch_reason(lhs[i], rhs[i]);
+      token_kind = lhs[i].kind == rhs[i].kind ? lhs[i].kind
+                                              : GuardSubtreeProbeTokenKind::ObjectOnly;
+      index = i;
+      return false;
+    }
+  }
+  return true;
+}
+
+extern thread_local const LocalState* active_guard_local_state;
+
+template <bool CollectStats>
+static bool guard_subtree_tensor_token_matches_current(
+    const GuardSubtreeEntryToken& token) {
+  const uint64_t tensor_start_ns =
+      CollectStats ? guard_lookup_time_ns() : 0;
+  GuardFastPlanTensorTokenMissReason reason =
+      GuardFastPlanTensorTokenMissReason::None;
+  const bool matches =
+      token.matches_tensor_current(active_guard_local_state, reason);
+  if constexpr (CollectStats) {
+    const uint64_t check_ns = guard_lookup_time_ns() - tensor_start_ns;
+    if (matches) {
+      record_guard_fastplan_tensor_token_hit(check_ns);
+    } else {
+      record_guard_fastplan_tensor_token_miss(reason, check_ns);
+    }
+  }
+  return matches;
+}
+
+static bool guard_subtree_special_token_matches_current(
+    const GuardSubtreeEntryToken& token) {
+  switch (token.kind) {
+    case GuardSubtreeProbeTokenKind::DefaultDevice:
+      return token.matches_default_device_current();
+    case GuardSubtreeProbeTokenKind::GlobalState:
+      return token.matches_global_state_current();
+    case GuardSubtreeProbeTokenKind::TorchFunctionModeStack:
+      return torch_function_mode_stack_guard_matches(
+          token.torch_function_mode_stack_guard);
+    default:
+      return false;
+  }
+}
+
+static bool guard_subtree_token_is_aliasing_guard(
+    GuardSubtreeProbeTokenKind kind) {
+  return kind == GuardSubtreeProbeTokenKind::NoTensorAliasing ||
+      kind == GuardSubtreeProbeTokenKind::ObjectAliasing;
+}
+
+static bool guard_subtree_token_proves_child_reachability(
+    const GuardSubtreeEntryToken& token) {
+  switch (token.kind) {
+    case GuardSubtreeProbeTokenKind::TensorMatch:
+    case GuardSubtreeProbeTokenKind::ExactDict:
+    case GuardSubtreeProbeTokenKind::ExactList:
+    case GuardSubtreeProbeTokenKind::ExactTuple:
+      return token.object != nullptr;
+    default:
+      return false;
+  }
+}
+
+static bool guard_subtree_aliasing_tokens_have_reachability_proof(
+    const std::vector<GuardSubtreeEntryToken>& tokens,
+    const std::vector<std::string>& debug_paths,
+    std::string& disabled_reason,
+    std::string& disabled_path) {
+  bool saw_reachability_proof = false;
+  for (size_t i = 0; i < tokens.size(); ++i) {
+    const auto& token = tokens[i];
+    if (guard_subtree_token_proves_child_reachability(token)) {
+      saw_reachability_proof = true;
+    }
+    if (!guard_subtree_token_is_aliasing_guard(token.kind)) {
+      continue;
+    }
+    if (!saw_reachability_proof || token.object == nullptr ||
+        token.type == nullptr) {
+      disabled_reason =
+          std::string("actual_partial_alias_unproven_reachability:") +
+          guard_subtree_token_kind_name(token.kind);
+      disabled_path = i < debug_paths.size() ? debug_paths[i] : "L['self']";
+      return false;
+    }
+  }
+  return true;
+}
+
+static bool guard_last_success_build_partial_plan_tokens(
+    const std::vector<GuardSubtreeEntryToken>& partial_tokens,
+    const std::vector<std::string>& partial_debug_paths,
+    std::vector<GuardSubtreeEntryToken>& stability_tokens,
+    std::vector<GuardSubtreeEntryToken>& hot_tokens,
+    std::string& disabled_reason,
+    std::string& disabled_path) {
+  stability_tokens = partial_tokens;
+  if (!guard_subtree_aliasing_tokens_have_reachability_proof(
+          partial_tokens,
+          partial_debug_paths,
+          disabled_reason,
+          disabled_path)) {
+    return false;
+  }
+  return guard_last_success_make_partial_hot_tokens(
+      partial_tokens,
+      partial_debug_paths,
+      hot_tokens,
+      disabled_reason,
+      disabled_path);
+}
+
+static bool guard_subtree_aliasing_token_matches_current(
+    const GuardSubtreeEntryToken& token) {
+  // Relational guards are fully evaluated during the slow receipt pass before
+  // a partial plan is trained. Rechecking the recorded relation among immutable
+  // receipt tokens would be tautological; the live runtime check here is that
+  // the recorded alias operand is still the same object/type. Actual-partial
+  // plan construction applies an additional conservative reachability gate
+  // before these tokens are admitted; nested memo plans do not currently have
+  // that gate.
+  return token.object != nullptr && token.type != nullptr &&
+      Py_TYPE(token.object) == token.type;
+}
+
+static bool guard_subtree_bound_method_token_matches_current(
+    const GuardSubtreeEntryToken& token) {
+  if (token.type == nullptr) {
+    return false;
+  }
+  if (token.bound_method_func != nullptr) {
+    return token.bound_method_self != nullptr;
+  }
+  return token.bound_c_method_func != nullptr;
+}
+
+static bool guard_subtree_token_is_reachability_only(
+    const GuardSubtreeEntryToken& token,
+    size_t index) {
+  return index != 0 && token.kind == GuardSubtreeProbeTokenKind::ObjectOnly;
+}
+
+static std::string guard_subtree_token_type_name(
+    const GuardSubtreeEntryToken* token) {
+  if (token == nullptr || token->type == nullptr) {
+    return std::string();
+  }
+  return token->type->tp_name == nullptr ? std::string()
+                                         : std::string(token->type->tp_name);
+}
+
+static uint64_t guard_subtree_token_object_id(
+    const GuardSubtreeEntryToken* token) {
+  if (token == nullptr || token->object == nullptr) {
+    return 0;
+  }
+  return static_cast<uint64_t>(reinterpret_cast<uintptr_t>(token->object));
+}
+
+static void record_guard_last_success_compare_mismatch_detail(
+    const std::string& path,
+    const GuardSubtreeEntryToken* old_token,
+    const GuardSubtreeEntryToken* new_token) {
+  if (!guard_lookup_stats_enabled() || path.empty()) {
+    return;
+  }
+  std::lock_guard<std::mutex> lock(
+      guard_last_success_mismatch_stats_mutex());
+  auto& path_stats = guard_last_success_mismatch_path_stats()[path];
+  path_stats.has_mismatch_detail = true;
+  path_stats.old_kind = old_token == nullptr
+      ? std::string()
+      : guard_subtree_token_kind_name(old_token->kind);
+  path_stats.new_kind = new_token == nullptr
+      ? std::string()
+      : guard_subtree_token_kind_name(new_token->kind);
+  path_stats.old_type = guard_subtree_token_type_name(old_token);
+  path_stats.new_type = guard_subtree_token_type_name(new_token);
+  path_stats.old_object_id = guard_subtree_token_object_id(old_token);
+  path_stats.new_object_id = guard_subtree_token_object_id(new_token);
+  path_stats.old_version = old_token == nullptr ? 0 : old_token->version;
+  path_stats.new_version = new_token == nullptr ? 0 : new_token->version;
+  path_stats.old_size = old_token == nullptr ? 0 : old_token->size;
+  path_stats.new_size = new_token == nullptr ? 0 : new_token->size;
+}
+
+enum class GuardLastSuccessPartialPlanState : uint8_t {
+  Empty,
+  Training,
+  Enabled,
+  Disabled,
+};
+
+struct GuardLastSuccessPartialPlan {
+  void reset() {
+    state = GuardLastSuccessPartialPlanState::Empty;
+    entry_key = nullptr;
+    root_key = nullptr;
+    shadow_passes = 0;
+    self_object = nullptr;
+    self_type = nullptr;
+    self_framelocals_index = -1;
+    stability_tokens.clear();
+    tokens.clear();
+  }
+
+  void disable() {
+    reset();
+    state = GuardLastSuccessPartialPlanState::Disabled;
+  }
+
+  bool is_enabled_for(void* current_entry_key, void* current_root_key) const {
+    return state == GuardLastSuccessPartialPlanState::Enabled &&
+        entry_key == current_entry_key && root_key == current_root_key;
+  }
+
+  bool should_train() const {
+    return state != GuardLastSuccessPartialPlanState::Disabled;
+  }
+
+  bool observe_successful_training_pass(
+      void* new_entry_key,
+      void* new_root_key,
+      std::vector<GuardSubtreeEntryToken>&& new_stability_tokens,
+      std::vector<GuardSubtreeEntryToken>&& new_tokens) {
+    const bool stable = entry_key == new_entry_key &&
+        root_key == new_root_key && !stability_tokens.empty() &&
+        guard_subtree_token_vectors_match(
+            new_stability_tokens, stability_tokens);
+    if (stable) {
+      shadow_passes += 1;
+    } else {
+      entry_key = new_entry_key;
+      root_key = new_root_key;
+      stability_tokens = std::move(new_stability_tokens);
+      tokens = std::move(new_tokens);
+      shadow_passes = 1;
+      state = GuardLastSuccessPartialPlanState::Training;
+    }
+    if (state != GuardLastSuccessPartialPlanState::Enabled &&
+        shadow_passes >= kGuardLastSuccessActualStablePasses) {
+      state = GuardLastSuccessPartialPlanState::Enabled;
+      return true;
+    }
+    return false;
+  }
+
+  GuardLastSuccessPartialPlanState state{
+      GuardLastSuccessPartialPlanState::Empty};
+  void* entry_key{nullptr};
+  void* root_key{nullptr};
+  uint64_t shadow_passes{0};
+  PyObject* self_object{nullptr};
+  PyTypeObject* self_type{nullptr};
+  int self_framelocals_index{-1};
+  std::vector<GuardSubtreeEntryToken> stability_tokens;
+  std::vector<GuardSubtreeEntryToken> tokens;
+};
+
+struct GuardLastSuccessReceipt {
+  void reset() {
+    entry_key = nullptr;
+    root_key = nullptr;
+    shadow_passes = 0;
+    tokens.clear();
+    debug_paths.clear();
+    reset_actual();
+    actual_partial.reset();
+  }
+
+  void reset_actual() {
+    actual_entry_key = nullptr;
+    actual_root_key = nullptr;
+    actual_shadow_passes = 0;
+    actual_enabled = false;
+    actual_disabled = false;
+    actual_requires_self = false;
+    actual_self_object = nullptr;
+    actual_self_type = nullptr;
+    actual_stability_tokens.clear();
+    actual_tokens.clear();
+  }
+
+  uint64_t update(
+      void* new_entry_key,
+      void* new_root_key,
+      std::vector<GuardSubtreeEntryToken>&& new_tokens,
+      std::vector<std::string>&& new_debug_paths,
+      bool& stable,
+      bool& reset_state,
+      uint64_t& compare_ns) {
+    const uint64_t compare_start_ns = guard_lookup_time_ns();
+    GuardLastSuccessCompareMismatchReason mismatch_reason =
+        GuardLastSuccessCompareMismatchReason::Unknown;
+    GuardSubtreeProbeTokenKind mismatch_kind =
+        GuardSubtreeProbeTokenKind::ObjectOnly;
+    size_t mismatch_index = 0;
+    if (entry_key != new_entry_key) {
+      stable = false;
+      mismatch_reason = GuardLastSuccessCompareMismatchReason::EntryKey;
+    } else if (root_key != new_root_key) {
+      stable = false;
+      mismatch_reason = GuardLastSuccessCompareMismatchReason::RootKey;
+    } else if (tokens.empty()) {
+      stable = false;
+      mismatch_reason = GuardLastSuccessCompareMismatchReason::EmptyPrevious;
+    } else {
+      stable = guard_subtree_token_vectors_match(
+          tokens, new_tokens, mismatch_reason, mismatch_kind, mismatch_index);
+    }
+    compare_ns = guard_lookup_time_ns() - compare_start_ns;
+    reset_state = !stable && !tokens.empty();
+    if (!stable) {
+      const std::string* mismatch_path = nullptr;
+      if (mismatch_index < new_debug_paths.size()) {
+        mismatch_path = &new_debug_paths[mismatch_index];
+      } else if (mismatch_index < debug_paths.size()) {
+        mismatch_path = &debug_paths[mismatch_index];
+      }
+      record_guard_last_success_compare_mismatch(
+          mismatch_reason,
+          mismatch_kind,
+          mismatch_index,
+          mismatch_path == nullptr ? std::string() : *mismatch_path);
+      if (mismatch_path != nullptr) {
+        const GuardSubtreeEntryToken* old_token =
+            mismatch_index < tokens.size() ? &tokens[mismatch_index] : nullptr;
+        const GuardSubtreeEntryToken* new_token =
+            mismatch_index < new_tokens.size() ? &new_tokens[mismatch_index]
+                                               : nullptr;
+        record_guard_last_success_compare_mismatch_detail(
+            *mismatch_path, old_token, new_token);
+      }
+    }
+
+    if (stable) {
+      shadow_passes += 1;
+    } else {
+      entry_key = new_entry_key;
+      root_key = new_root_key;
+      tokens = std::move(new_tokens);
+      debug_paths = std::move(new_debug_paths);
+      shadow_passes = 1;
+    }
+    return shadow_passes;
+  }
+
+  void* entry_key{nullptr};
+  void* root_key{nullptr};
+  uint64_t shadow_passes{0};
+  std::vector<GuardSubtreeEntryToken> tokens;
+  std::vector<std::string> debug_paths;
+
+  void* actual_entry_key{nullptr};
+  void* actual_root_key{nullptr};
+  uint64_t actual_shadow_passes{0};
+  bool actual_enabled{false};
+  bool actual_disabled{false};
+  bool actual_requires_self{false};
+  PyObject* actual_self_object{nullptr};
+  PyTypeObject* actual_self_type{nullptr};
+  // Full token vector used only to prove consecutive slow-guard receipts are
+  // stable enough to enable the fast path.
+  std::vector<GuardSubtreeEntryToken> actual_stability_tokens;
+  // Compacted token vector used by the runtime fast path after stability is
+  // proven. This may omit tokens that are redundant for hot matching.
+  std::vector<GuardSubtreeEntryToken> actual_tokens;
+
+  GuardLastSuccessPartialPlan actual_partial;
+};
+
+struct GuardLocalStateScope {
+  explicit GuardLocalStateScope(const LocalState* state)
+      : previous(active_guard_local_state) {
+    active_guard_local_state = state;
+  }
+
+  ~GuardLocalStateScope() {
+    active_guard_local_state = previous;
+  }
+
+  const LocalState* previous{nullptr};
+};
+
+static bool guard_subtree_exact_list_token_matches_current(
+    const GuardSubtreeEntryToken& token,
+    PyObject* current_object) {
+  if (current_object == nullptr || current_object != token.object ||
+      Py_TYPE(current_object) != token.type ||
+      !PyList_CheckExact(current_object) || token.version != 0) {
+    return false;
+  }
+  const Py_ssize_t size = PyList_GET_SIZE(current_object);
+  if (size != token.size ||
+      static_cast<size_t>(size) != token.list_items.size()) {
+    return false;
+  }
+  for (Py_ssize_t i = 0; i < size; ++i) {
+    if (PyList_GET_ITEM(current_object, i) !=
+        token.list_items[static_cast<size_t>(i)]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+template <bool CollectStats>
+static bool guard_subtree_memo_tokens_match_impl(
+    const std::vector<GuardSubtreeEntryToken>& tokens,
+    PyObject* root_value) {
+  for (size_t i = 0; i < tokens.size(); ++i) {
+    const auto& token = tokens[i];
+    if (token.kind == GuardSubtreeProbeTokenKind::TensorMatch) {
+      if (!guard_subtree_tensor_token_matches_current<CollectStats>(token)) {
+        return false;
+      }
+      continue;
+    }
+    if (token.kind == GuardSubtreeProbeTokenKind::DefaultDevice ||
+        token.kind == GuardSubtreeProbeTokenKind::GlobalState ||
+        token.kind == GuardSubtreeProbeTokenKind::TorchFunctionModeStack) {
+      if (!guard_subtree_special_token_matches_current(token)) {
+        return false;
+      }
+      continue;
+    }
+    if (guard_subtree_token_is_aliasing_guard(token.kind)) {
+      // Keep the hot path O(1). The original relation was checked by the slow
+      // receipt pass; here we only prove the recorded alias operand is still
+      // live with the same type.
+      if (!guard_subtree_aliasing_token_matches_current(token)) {
+        return false;
+      }
+      continue;
+    }
+    if (token.kind == GuardSubtreeProbeTokenKind::BoundMethod) {
+      if (!guard_subtree_bound_method_token_matches_current(token)) {
+        return false;
+      }
+      continue;
+    }
+    if (guard_subtree_token_is_reachability_only(token, i)) {
+      // Parent tokens prove whether this non-root object is still reachable.
+      continue;
+    }
+    if (token.kind == GuardSubtreeProbeTokenKind::FrameGlobals) {
+      // FrameGlobals is only safe for full slow-guard receipt comparison,
+      // where every run records a fresh child token vector. Existing hot
+      // memo checks rely on exact parent container tokens to prove non-root
+      // ObjectOnly tokens are still reachable.
+      return false;
+    }
+    PyObject* current_object = i == 0 ? root_value : token.object;
+    if (token.kind == GuardSubtreeProbeTokenKind::ExactList) {
+      if (!guard_subtree_exact_list_token_matches_current(
+              token, current_object)) {
+        return false;
+      }
+      continue;
+    }
+    GuardSubtreeEntryToken current =
+        GuardSubtreeEntryToken::make(current_object);
+    if (!current.matches(token)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+static bool guard_subtree_memo_tokens_match(
+    const std::vector<GuardSubtreeEntryToken>& tokens,
+    PyObject* root_value,
+    bool collect_stats) {
+  if (C10_UNLIKELY(collect_stats)) {
+    return guard_subtree_memo_tokens_match_impl<true>(tokens, root_value);
+  }
+  return guard_subtree_memo_tokens_match_impl<false>(tokens, root_value);
+}
+
+static bool source_starts_with(
+    const std::string& source,
+    const char* prefix) {
+  const size_t prefix_len = std::strlen(prefix);
+  return source.size() >= prefix_len &&
+      source.compare(0, prefix_len, prefix) == 0;
+}
+
+static bool is_self_local_source_path(const std::string& source) {
+  static constexpr const char* kSelf = "L['self']";
+  if (!source_starts_with(source, kSelf)) {
+    return false;
+  }
+  return source.size() == std::strlen(kSelf) ||
+      source[std::strlen(kSelf)] == '.' ||
+      source[std::strlen(kSelf)] == '[';
+}
+
+static bool is_local_source_path(const std::string& source) {
+  return source_starts_with(source, "L[");
+}
+
+static PyObject* guard_last_success_self_key() {
+  static PyObject* key = PyUnicode_InternFromString("self");
+  return key;
+}
+
+static PyObject* guard_last_success_get_self(
+    FrameLocalsMapping* f_locals,
+    int framelocals_index,
+    bool* missing_key) {
+  if (missing_key != nullptr) {
+    *missing_key = false;
+  }
+  if (framelocals_index >= 0) {
+    PyObject* current_self = f_locals->get(framelocals_index);
+    if (current_self != nullptr) {
+      return current_self;
+    }
+  }
+  PyObject* key = guard_last_success_self_key();
+  if (key == nullptr) {
+    PyErr_Clear();
+    if (missing_key != nullptr) {
+      *missing_key = true;
+    }
+    return nullptr;
+  }
+  return PyDict_GetItem((PyObject*)f_locals->to_dict(), key);
+}
+
+static std::vector<GuardSubtreeEntryToken>
+guard_last_success_make_diagnostic_tokens(
+    const std::vector<GuardSubtreeEntryToken>& tokens,
+    const std::vector<std::string>& debug_paths) {
+  std::vector<GuardSubtreeEntryToken> diagnostic_tokens = tokens;
+  if (diagnostic_tokens.size() != debug_paths.size()) {
+    return diagnostic_tokens;
+  }
+  for (size_t i = 0; i < diagnostic_tokens.size(); ++i) {
+    auto& token = diagnostic_tokens[i];
+    if (is_global_source_path(debug_paths[i]) &&
+        token.object != nullptr && PyDict_CheckExact(token.object)) {
+      token.kind = GuardSubtreeProbeTokenKind::FrameGlobals;
+      token.version = 0;
+      token.size = 0;
+      token.list_items.clear();
+    }
+  }
+  return diagnostic_tokens;
+}
+
+static bool guard_last_success_extract_self_partial_tokens(
+    const std::vector<GuardSubtreeEntryToken>& tokens,
+    const std::vector<std::string>& debug_paths,
+    std::vector<GuardSubtreeEntryToken>& partial_tokens,
+    std::vector<std::string>& partial_debug_paths,
+    std::string& disabled_reason,
+    std::string& disabled_path) {
+  partial_tokens.clear();
+  partial_debug_paths.clear();
+  if (tokens.empty()) {
+    disabled_reason = "actual_partial_empty_receipt";
+    return false;
+  }
+  if (tokens.size() != debug_paths.size()) {
+    disabled_reason = "actual_partial_missing_debug_paths";
+    return false;
+  }
+
+  size_t start = tokens.size();
+  for (size_t i = 0; i < debug_paths.size(); ++i) {
+    if (debug_paths[i] == "L['self']") {
+      start = i;
+      break;
+    }
+  }
+  if (start == tokens.size()) {
+    disabled_reason = "actual_partial_missing_self";
+    disabled_path = "L['self']";
+    return false;
+  }
+
+  size_t end = tokens.size();
+  for (size_t i = start + 1; i < debug_paths.size(); ++i) {
+    const auto& path = debug_paths[i];
+    if (is_global_source_path(path) ||
+        (is_local_source_path(path) && !is_self_local_source_path(path))) {
+      end = i;
+      break;
+    }
+  }
+  if (end <= start) {
+    disabled_reason = "actual_partial_empty_self";
+    disabled_path = "L['self']";
+    return false;
+  }
+
+  partial_tokens.assign(tokens.begin() + start, tokens.begin() + end);
+  partial_debug_paths.assign(
+      debug_paths.begin() + start, debug_paths.begin() + end);
+  return true;
+}
+
+struct GuardLastSuccessPartialPlanBuild {
+  std::vector<GuardSubtreeEntryToken> stability_tokens;
+  std::vector<GuardSubtreeEntryToken> hot_tokens;
+  std::string disabled_reason;
+  std::string disabled_path;
+};
+
+static bool guard_last_success_prepare_actual_partial(
+    GuardLastSuccessPartialPlan* plan,
+    FrameLocalsMapping* f_locals,
+    int self_framelocals_index,
+    const std::vector<GuardSubtreeEntryToken>& tokens,
+    const std::vector<std::string>& debug_paths,
+    GuardLastSuccessPartialPlanBuild& build) {
+  std::vector<GuardSubtreeEntryToken> partial_tokens;
+  std::vector<std::string> partial_debug_paths;
+  if (!guard_last_success_extract_self_partial_tokens(
+          tokens,
+          debug_paths,
+          partial_tokens,
+          partial_debug_paths,
+          build.disabled_reason,
+          build.disabled_path)) {
+    return false;
+  }
+  if (partial_tokens.size() > kGuardLastSuccessActualMaxTokens) {
+    build.disabled_reason = "actual_partial_token_cap_exceeded";
+    build.disabled_path = "L['self']";
+    return false;
+  }
+  if (partial_tokens.empty() ||
+      partial_tokens[0].kind == GuardSubtreeProbeTokenKind::FrameGlobals) {
+    build.disabled_reason = "actual_partial_invalid_self_token";
+    build.disabled_path = "L['self']";
+    return false;
+  }
+
+  bool missing_self_key = false;
+  PyObject* current_self = guard_last_success_get_self(
+      f_locals, self_framelocals_index, &missing_self_key);
+  if (missing_self_key) {
+    build.disabled_reason = "actual_partial_missing_self_key";
+    return false;
+  }
+  if (current_self == nullptr) {
+    build.disabled_reason = "actual_partial_missing_self";
+    build.disabled_path = "L['self']";
+    return false;
+  }
+  if (partial_tokens[0].object != current_self) {
+    build.disabled_reason = "actual_partial_self_object_mismatch";
+    build.disabled_path = "L['self']";
+    return false;
+  }
+  plan->self_object = current_self;
+  plan->self_type = Py_TYPE(current_self);
+  plan->self_framelocals_index = self_framelocals_index;
+
+  return guard_last_success_build_partial_plan_tokens(
+      partial_tokens,
+      partial_debug_paths,
+      build.stability_tokens,
+      build.hot_tokens,
+      build.disabled_reason,
+      build.disabled_path);
+}
+
+static bool guard_last_success_actual_partial_tokens_match(
+    const GuardLastSuccessPartialPlan& plan,
+    FrameLocalsMapping* f_locals,
+    bool collect_stats) {
+  if (plan.tokens.empty()) {
+    return false;
+  }
+  PyObject* current_self = guard_last_success_get_self(
+      f_locals, plan.self_framelocals_index, nullptr);
+  if (current_self == nullptr ||
+      current_self != plan.self_object ||
+      Py_TYPE(current_self) != plan.self_type) {
+    return false;
+  }
+  LocalState state;
+  GuardLocalStateScope local_state_scope(&state);
+  return guard_subtree_memo_tokens_match(
+      plan.tokens, plan.tokens[0].object, collect_stats);
+}
+
+struct GuardSubtreeMemoState {
+  bool enabled{false};
+  bool disabled{false};
+  bool partial{false};
+  uint8_t shadow_passes{0};
+  std::vector<GuardSubtreeEntryToken> tokens;
+  std::vector<size_t> slow_accessor_indices;
+};
+
+struct GuardSubtreeProbeState {
+  bool has_last_token{false};
+  bool disabled{false};
+  GuardSubtreeEntryToken last_token;
+  GuardSubtreeMemoState memo;
+};
+
+thread_local std::vector<GuardSubtreeEntryToken>*
+    active_guard_subtree_memo_recorder = nullptr;
+thread_local std::vector<std::string>*
+    active_guard_subtree_memo_debug_paths = nullptr;
+thread_local bool active_guard_subtree_memo_relax_global_dicts = false;
+thread_local const LocalState* active_guard_local_state = nullptr;
+
+struct GuardSubtreeMemoRecorderScope {
+  explicit GuardSubtreeMemoRecorderScope(
+      std::vector<GuardSubtreeEntryToken>* tokens,
+      std::vector<std::string>* debug_paths = nullptr,
+      bool relax_global_dicts = false)
+      : previous(active_guard_subtree_memo_recorder),
+        previous_debug_paths(active_guard_subtree_memo_debug_paths),
+        previous_relax_global_dicts(
+            active_guard_subtree_memo_relax_global_dicts) {
+    active_guard_subtree_memo_recorder = tokens;
+    active_guard_subtree_memo_debug_paths = debug_paths;
+    active_guard_subtree_memo_relax_global_dicts = relax_global_dicts;
+  }
+
+  ~GuardSubtreeMemoRecorderScope() {
+    active_guard_subtree_memo_recorder = previous;
+    active_guard_subtree_memo_debug_paths = previous_debug_paths;
+    active_guard_subtree_memo_relax_global_dicts =
+        previous_relax_global_dicts;
+  }
+
+  std::vector<GuardSubtreeEntryToken>* previous{nullptr};
+  std::vector<std::string>* previous_debug_paths{nullptr};
+  bool previous_relax_global_dicts{false};
+};
+
+static void append_guard_subtree_memo_token(
+    std::vector<GuardSubtreeEntryToken>* tokens,
+    GuardSubtreeEntryToken&& token,
+    const std::string& debug_path) {
+  tokens->emplace_back(std::move(token));
+  if (active_guard_subtree_memo_debug_paths != nullptr) {
+    active_guard_subtree_memo_debug_paths->push_back(debug_path);
+  }
 }
 
 static PyObject* dict_version(PyObject* dummy, PyObject* args) {
@@ -1651,6 +5261,31 @@ class LeafGuard {
     // Could fallback to running check on the Python dict (lazily constructed)
     return check_nopybind((PyObject*)map->to_dict());
   }
+  virtual bool supports_subtree_memo() const {
+    return true;
+  }
+  virtual const char* subtree_memo_unsupported_reason() const {
+    return "unsupported_leaf:LeafGuard";
+  }
+  virtual const char* stats_name() const {
+    return "LeafGuard";
+  }
+  virtual bool emits_subtree_memo_token() const {
+    return false;
+  }
+  virtual bool emits_subtree_memo_token_for_frame_locals() const {
+    return false;
+  }
+  virtual bool append_subtree_memo_token(
+      PyObject* value,
+      std::vector<GuardSubtreeEntryToken>* /*tokens*/) {
+    return check_nopybind(value);
+  }
+  virtual bool append_subtree_memo_token(
+      FrameLocalsMapping* value,
+      std::vector<GuardSubtreeEntryToken>* /*tokens*/) {
+    return check_nopybind(value);
+  }
 
   virtual ~LeafGuard() = default;
 
@@ -1677,6 +5312,8 @@ class LeafGuard {
  */
 class LAMBDA_GUARD : public LeafGuard {
  public:
+  LEAF_GUARD_STATS_NAME(LAMBDA_GUARD)
+
   LAMBDA_GUARD(
       RootGuardManager* root_guard_manager,
       py::object guard_check_fn,
@@ -1718,6 +5355,13 @@ class LAMBDA_GUARD : public LeafGuard {
     return GuardDebugInfo(false, verbose_code_parts(), 0);
   }
 
+  bool supports_subtree_memo() const override {
+    return false;
+  }
+  const char* subtree_memo_unsupported_reason() const override {
+    return "unsupported_leaf:LAMBDA_GUARD";
+  }
+
  private:
   // The user provided lambda function for check_fn.
   py::function _guard_check_fn;
@@ -1725,6 +5369,8 @@ class LAMBDA_GUARD : public LeafGuard {
 
 class TYPE_MATCH : public LeafGuard {
  public:
+  LEAF_GUARD_STATS_NAME(TYPE_MATCH)
+
   // type_id = id(type(obj))
   TYPE_MATCH(
       RootGuardManager* root_guard_manager,
@@ -1745,6 +5391,8 @@ class TYPE_MATCH : public LeafGuard {
 
 class ID_MATCH : public LeafGuard {
  public:
+  LEAF_GUARD_STATS_NAME(ID_MATCH)
+
   // obj_id = id(obj)
   ID_MATCH(
       RootGuardManager* root_guard_manager,
@@ -1801,6 +5449,8 @@ class FALSE_MATCH : public LeafGuard {
 
 class EQUALS_MATCH : public LeafGuard {
  public:
+  LEAF_GUARD_STATS_NAME(EQUALS_MATCH)
+
   EQUALS_MATCH(
       RootGuardManager* root_guard_manager,
       py::object value,
@@ -1841,6 +5491,8 @@ class EQUALS_MATCH : public LeafGuard {
 
 class RANGE_ITERATOR_MATCH : public LeafGuard {
  public:
+  LEAF_GUARD_STATS_NAME(RANGE_ITERATOR_MATCH)
+
   RANGE_ITERATOR_MATCH(
       RootGuardManager* root_guard_manager,
       py::object start,
@@ -1888,6 +5540,8 @@ class RANGE_ITERATOR_MATCH : public LeafGuard {
 
 class TUPLE_ITERATOR_LEN : public LeafGuard {
  public:
+  LEAF_GUARD_STATS_NAME(TUPLE_ITERATOR_LEN)
+
   TUPLE_ITERATOR_LEN(
       RootGuardManager* root_guard_manager,
       py::object length,
@@ -1918,6 +5572,8 @@ class TUPLE_ITERATOR_LEN : public LeafGuard {
 
 class LENGTH_CHECK : public LeafGuard {
  public:
+  LEAF_GUARD_STATS_NAME(LENGTH_CHECK)
+
   LENGTH_CHECK(
       RootGuardManager* root_guard_manager,
       py::object value,
@@ -1938,6 +5594,8 @@ class LENGTH_CHECK : public LeafGuard {
 
 class DICT_LENGTH : public LeafGuard {
  public:
+  LEAF_GUARD_STATS_NAME(DICT_LENGTH)
+
   DICT_LENGTH(
       RootGuardManager* root_guard_manager,
       py::object value,
@@ -1956,6 +5614,8 @@ class DICT_LENGTH : public LeafGuard {
 
 class NOT_NONE : public LeafGuard {
  public:
+  LEAF_GUARD_STATS_NAME(NOT_NONE)
+
   NOT_NONE(RootGuardManager* root_guard_manager, py::object verbose_code_parts)
       : LeafGuard(root_guard_manager, std::move(verbose_code_parts)) {}
 
@@ -1966,6 +5626,8 @@ class NOT_NONE : public LeafGuard {
 
 class MAPPING_KEYS_MATCH : public LeafGuard {
  public:
+  LEAF_GUARD_STATS_NAME(MAPPING_KEYS_MATCH)
+
   MAPPING_KEYS_MATCH(
       RootGuardManager* root_guard_manager,
       py::object value,
@@ -1990,6 +5652,8 @@ class MAPPING_KEYS_MATCH : public LeafGuard {
 
 class DEFAULT_DEVICE : public LeafGuard {
  public:
+  LEAF_GUARD_STATS_NAME(DEFAULT_DEVICE)
+
   DEFAULT_DEVICE(
       RootGuardManager* root_guard_manager,
       py::object verbose_code_parts)
@@ -2002,23 +5666,7 @@ class DEFAULT_DEVICE : public LeafGuard {
 
   template <typename T>
   bool check_nopybind_template(T* value) { // borrowed ref
-    // Create a static interned string. Interned string is faster than creating
-    // a new string every time. Even though its a new reference, we don't dec
-    // ref it. Interned strings are used for things like variable names and are
-    // leaked by design.
-    static PyObject* current_device_str =
-        PyUnicode_InternFromString("CURRENT_DEVICE");
-    PyObject* device = PyDict_GetItem(
-        _utils_device_dict.ptr(), current_device_str); // borrowed ref
-    if (device != _device.ptr()) {
-      int result = PyObject_RichCompareBool(device, _device.ptr(), Py_EQ);
-      if (result == -1) {
-        PyErr_Clear();
-        return false;
-      }
-      return result;
-    }
-    return true;
+    return default_device_matches(_utils_device_dict.ptr(), _device.ptr());
   }
 
   bool check_nopybind(PyObject* value) override {
@@ -2029,7 +5677,45 @@ class DEFAULT_DEVICE : public LeafGuard {
     return check_nopybind_template(value);
   }
 
+  bool supports_subtree_memo() const override {
+    return true;
+  }
+  const char* subtree_memo_unsupported_reason() const override {
+    return "unsupported_leaf:DEFAULT_DEVICE";
+  }
+  bool emits_subtree_memo_token() const override {
+    return true;
+  }
+  bool emits_subtree_memo_token_for_frame_locals() const override {
+    return true;
+  }
+  bool append_subtree_memo_token(
+      PyObject* value,
+      std::vector<GuardSubtreeEntryToken>* tokens) override {
+    return append_subtree_memo_token_template(value, tokens);
+  }
+  bool append_subtree_memo_token(
+      FrameLocalsMapping* value,
+      std::vector<GuardSubtreeEntryToken>* tokens) override {
+    return append_subtree_memo_token_template(value, tokens);
+  }
+
  private:
+  template <typename T>
+  bool append_subtree_memo_token_template(
+      T* value,
+      std::vector<GuardSubtreeEntryToken>* tokens) {
+    if (!check_nopybind_template(value)) {
+      return false;
+    }
+    append_guard_subtree_memo_token(
+        tokens,
+        GuardSubtreeEntryToken::make_default_device(
+            _utils_device_dict.ptr(), _device.ptr()),
+        "<DEFAULT_DEVICE>");
+    return true;
+  }
+
   // Save the current device and the module dict during the guard construction.
   py::object _utils_device_dict;
   py::object _device;
@@ -2037,6 +5723,8 @@ class DEFAULT_DEVICE : public LeafGuard {
 
 class GLOBAL_STATE : public LeafGuard {
  public:
+  LEAF_GUARD_STATS_NAME(GLOBAL_STATE)
+
   GLOBAL_STATE(
       RootGuardManager* root_guard_manager,
       py::object verbose_code_parts)
@@ -2076,7 +5764,44 @@ class GLOBAL_STATE : public LeafGuard {
     return GuardDebugInfo(true, 1);
   }
 
+  bool supports_subtree_memo() const override {
+    return true;
+  }
+  const char* subtree_memo_unsupported_reason() const override {
+    return "unsupported_leaf:GLOBAL_STATE";
+  }
+  bool emits_subtree_memo_token() const override {
+    return true;
+  }
+  bool emits_subtree_memo_token_for_frame_locals() const override {
+    return true;
+  }
+  bool append_subtree_memo_token(
+      PyObject* value,
+      std::vector<GuardSubtreeEntryToken>* tokens) override {
+    return append_subtree_memo_token_template(value, tokens);
+  }
+  bool append_subtree_memo_token(
+      FrameLocalsMapping* value,
+      std::vector<GuardSubtreeEntryToken>* tokens) override {
+    return append_subtree_memo_token_template(value, tokens);
+  }
+
  private:
+  template <typename T>
+  bool append_subtree_memo_token_template(
+      T* value,
+      std::vector<GuardSubtreeEntryToken>* tokens) {
+    if (!check_nopybind(value)) {
+      return false;
+    }
+    append_guard_subtree_memo_token(
+        tokens,
+        GuardSubtreeEntryToken::make_global_state(_guard),
+        "<GLOBAL_STATE>");
+    return true;
+  }
+
   py::object owner_;
   GlobalStateGuard* _guard;
 };
@@ -2086,6 +5811,8 @@ class GLOBAL_STATE : public LeafGuard {
 // HASATTR guard.
 class NO_HASATTR : public LeafGuard {
  public:
+  LEAF_GUARD_STATS_NAME(NO_HASATTR)
+
   NO_HASATTR(
       RootGuardManager* root_guard_manager,
       py::object attr_name,
@@ -2108,6 +5835,8 @@ class NO_HASATTR : public LeafGuard {
 // being faster.
 class DICT_CONTAINS : public LeafGuard {
  public:
+  LEAF_GUARD_STATS_NAME(DICT_CONTAINS)
+
   DICT_CONTAINS(
       RootGuardManager* root_guard_manager,
       bool contains,
@@ -2253,10 +5982,19 @@ class DUAL_LEVEL_MATCH : public LeafGuard {
  */
 class RelationalGuard : public LeafGuard {
  public:
+  LEAF_GUARD_STATS_NAME(RelationalGuard)
+
   RelationalGuard(
       RootGuardManager* root_guard_manager,
       py::object verbose_code_parts)
       : LeafGuard(root_guard_manager, std::move(verbose_code_parts)) {}
+
+  bool supports_subtree_memo() const override {
+    return false;
+  }
+  const char* subtree_memo_unsupported_reason() const override {
+    return "unsupported_leaf:RelationalGuard";
+  }
 
   // reset the relational guard state on guard failure. This is called by the
   // guard manager.
@@ -2268,6 +6006,8 @@ class RelationalGuard : public LeafGuard {
  */
 class OBJECT_ALIASING : public RelationalGuard {
  public:
+  LEAF_GUARD_STATS_NAME(OBJECT_ALIASING)
+
   OBJECT_ALIASING(
       RootGuardManager* root_guard_manager,
       py::object verbose_code_parts)
@@ -2286,6 +6026,29 @@ class OBJECT_ALIASING : public RelationalGuard {
     _is_first_call = true;
   }
 
+  bool supports_subtree_memo() const override {
+    return true;
+  }
+  const char* subtree_memo_unsupported_reason() const override {
+    return "unsupported_leaf:OBJECT_ALIASING";
+  }
+  bool emits_subtree_memo_token() const override {
+    return true;
+  }
+  bool append_subtree_memo_token(
+      PyObject* value,
+      std::vector<GuardSubtreeEntryToken>* tokens) override {
+    if (!check_nopybind(value)) {
+      return false;
+    }
+    append_guard_subtree_memo_token(
+        tokens,
+        GuardSubtreeEntryToken::make_object_aliasing(
+            value, static_cast<const void*>(this)),
+        "<OBJECT_ALIASING>");
+    return true;
+  }
+
  private:
   bool _is_first_call{true};
   PyObject* _first_tensor{nullptr};
@@ -2296,6 +6059,8 @@ class OBJECT_ALIASING : public RelationalGuard {
  */
 class NO_TENSOR_ALIASING : public RelationalGuard {
  public:
+  LEAF_GUARD_STATS_NAME(NO_TENSOR_ALIASING)
+
   NO_TENSOR_ALIASING(
       RootGuardManager* root_guard_manager,
       const py::list& tensor_names,
@@ -2329,6 +6094,29 @@ class NO_TENSOR_ALIASING : public RelationalGuard {
     _unique_tensors.clear();
   }
 
+  bool supports_subtree_memo() const override {
+    return true;
+  }
+  const char* subtree_memo_unsupported_reason() const override {
+    return "unsupported_leaf:NO_TENSOR_ALIASING";
+  }
+  bool emits_subtree_memo_token() const override {
+    return true;
+  }
+  bool append_subtree_memo_token(
+      PyObject* value,
+      std::vector<GuardSubtreeEntryToken>* tokens) override {
+    if (!check_nopybind(value)) {
+      return false;
+    }
+    append_guard_subtree_memo_token(
+        tokens,
+        GuardSubtreeEntryToken::make_no_tensor_aliasing(
+            value, static_cast<const void*>(this)),
+        "<NO_TENSOR_ALIASING>");
+    return true;
+  }
+
  private:
   py::list _tensor_names;
   ska::flat_hash_map<PyObject*, std::nullptr_t> _unique_tensors;
@@ -2347,6 +6135,8 @@ class NO_TENSOR_ALIASING : public RelationalGuard {
  */
 class STORAGE_OVERLAPPING : public RelationalGuard {
  public:
+  LEAF_GUARD_STATS_NAME(STORAGE_OVERLAPPING)
+
   STORAGE_OVERLAPPING(
       RootGuardManager* root_guard_manager,
       bool overlapping,
@@ -2365,6 +6155,10 @@ class STORAGE_OVERLAPPING : public RelationalGuard {
     _checker->reset(_overlapping);
   }
 
+  const char* subtree_memo_unsupported_reason() const override {
+    return "unsupported_leaf:STORAGE_OVERLAPPING";
+  }
+
  private:
   // Flag that indicates which kind of tensor this guard is collecting:
   //   1. Possibly overlapping tensors; or
@@ -2379,6 +6173,8 @@ class STORAGE_OVERLAPPING : public RelationalGuard {
  */
 class SYMBOLIC_SHAPE_GUARD : public RelationalGuard {
  public:
+  LEAF_GUARD_STATS_NAME(SYMBOLIC_SHAPE_GUARD)
+
   SYMBOLIC_SHAPE_GUARD(
       RootGuardManager* root_guard_manager,
       py::int_ nargs_int,
@@ -2480,6 +6276,10 @@ class SYMBOLIC_SHAPE_GUARD : public RelationalGuard {
     _args_seen = 0;
   }
 
+  const char* subtree_memo_unsupported_reason() const override {
+    return "unsupported_leaf:SYMBOLIC_SHAPE_GUARD";
+  }
+
  private:
   py::object _py_addr_keep_alive;
   size_t _args_seen{0}, _nargs_float, _nargs_int, _nargs;
@@ -2495,6 +6295,8 @@ class DYNAMIC_INDICES : public LeafGuard {
   //      if hasattr({tensor_name}, '_dynamo_dynamic_indices') else True)"  #
   //      noqa: B950
  public:
+  LEAF_GUARD_STATS_NAME(DYNAMIC_INDICES)
+
   DYNAMIC_INDICES(
       RootGuardManager* root_guard_manager,
       py::set dynamic_indices,
@@ -2523,12 +6325,21 @@ class DYNAMIC_INDICES : public LeafGuard {
     return result;
   }
 
+  bool supports_subtree_memo() const override {
+    return false;
+  }
+  const char* subtree_memo_unsupported_reason() const override {
+    return "unsupported_leaf:DYNAMIC_INDICES";
+  }
+
  private:
   py::set _dynamic_indices;
 };
 
 class DICT_VERSION : public LeafGuard {
  public:
+  LEAF_GUARD_STATS_NAME(DICT_VERSION)
+
   DICT_VERSION(
       RootGuardManager* root_guard_manager,
       py::object value,
@@ -2618,12 +6429,20 @@ class GuardAccessor {
     return _guard_manager;
   }
 
+  const std::unique_ptr<GuardManager>& get_guard_manager() const {
+    return _guard_manager;
+  }
+
   bool matches_key(const py::handle& key) const {
     return _accessor_key.equal(key);
   }
 
-  std::string get_source() {
+  const std::string& get_source() const {
     return _source;
+  }
+
+  virtual int framelocals_index() const {
+    return -1;
   }
 
   // matches_dict_tag is used by the DictGetItemGuardAccessor to skip the guard
@@ -2633,6 +6452,42 @@ class GuardAccessor {
     // throw std::runtime_error("fallback to python");
     // Could fallback to running check on the Python dict (lazily constructed)
     return check_nopybind((PyObject*)map->to_dict(), matches_dict_tag);
+  }
+  bool check_child_manager_nopybind(PyObject* obj);
+  virtual bool supports_subtree_memo() const {
+    return true;
+  }
+  virtual const char* subtree_memo_unsupported_reason() const {
+    return "unsupported_accessor:GuardAccessor";
+  }
+  virtual const char* stats_name() const {
+    return "GuardAccessor";
+  }
+  const std::string& stats_detail_name() {
+    if (_stats_detail_name.empty()) {
+      _stats_detail_name = stats_name();
+      _stats_detail_name += ":";
+      if (_source.empty()) {
+        _stats_detail_name += "key=";
+        _stats_detail_name += guard_accessor_stats_key(_accessor_key.ptr());
+      } else {
+        _stats_detail_name += _source;
+        const std::string key = guard_accessor_stats_key(_accessor_key.ptr());
+        if (key != "<unknown>") {
+          _stats_detail_name += "|key=";
+          _stats_detail_name += key;
+        }
+      }
+    }
+    return _stats_detail_name;
+  }
+  void record_detail_stats(
+      uint64_t self_ns,
+      uint64_t child_ns,
+      uint64_t inclusive_ns,
+      bool failed) {
+    record_guard_accessor_detail_stats(
+        stats_detail_name(), self_ns, child_ns, inclusive_ns, failed);
   }
   virtual GuardDebugInfo check_verbose_nopybind(PyObject* obj) = 0;
   virtual std::string repr() const = 0;
@@ -2677,6 +6532,9 @@ class GuardAccessor {
   // A string that can be eval'd on f_locals or f_globals to access the variable
   // value. Only used for debugging.
   std::string _source;
+
+  // Lazily initialized only while guard lookup stats are enabled.
+  std::string _stats_detail_name;
 };
 
 /**
@@ -2730,7 +6588,11 @@ class GuardManager {
  public:
   GuardManager() = delete;
   GuardManager(RootGuardManager* root, std::string source)
-      : _root(root), _source(std::move(source)), _is_dict(false) {}
+      : _root(root),
+        _source(std::move(source)),
+        _is_dict(false),
+        _fastplan_candidate_kind(
+            compute_guard_fastplan_candidate_kind(_source)) {}
 
   GuardManager(
       RootGuardManager* root,
@@ -2740,6 +6602,7 @@ class GuardManager {
         _source(std::move(source)),
         _is_dict(py::isinstance<py::dict>(example_value)),
         _is_immutable(is_immutable_object(example_value)) {
+    _fastplan_candidate_kind = compute_guard_fastplan_candidate_kind(_source);
     if (_is_dict) {
       _dict_tag = get_dict_version_unchecked(example_value.ptr());
     }
@@ -2874,7 +6737,9 @@ class GuardManager {
         _source(std::move(source)),
         _is_dict(is_dict),
         _is_immutable(is_immutable),
-        _weak_type(weak_type) {}
+        _weak_type(weak_type) {
+    _fastplan_candidate_kind = compute_guard_fastplan_candidate_kind(_source);
+  }
 
   void clone_common(
       RootGuardManager* cloned_root,
@@ -2959,6 +6824,16 @@ class GuardManager {
   // the code here.
   template <typename T>
   bool check_nopybind_template(T* value) { // borrowed ref
+    if constexpr (std::is_same_v<T, PyObject>) {
+      if (C10_UNLIKELY(active_guard_subtree_memo_recorder != nullptr)) {
+        append_guard_subtree_memo_token(
+            active_guard_subtree_memo_recorder,
+            active_guard_subtree_memo_relax_global_dicts
+                ? GuardSubtreeEntryToken::make_for_source(value, _source)
+                : GuardSubtreeEntryToken::make(value),
+            _source);
+      }
+    }
 
     if (!this->check_leaf_guards_nopybind(value)) {
       return false;
@@ -3057,19 +6932,24 @@ class GuardManager {
       if (_is_tag_safe_root) {
         // Check if the `value` object was recorded earlier
         if (_dict_pointers.find(value) != _dict_pointers.end()) {
-          // Check for fast path
-          // if (is_weakref_valid(value) && check_dict_pointer_tags(value)) {
-          if (check_dict_pointer_tags(value)) {
-            if (check_no_tensor_aliasing_guards_fast(value)) {
-              return true;
-            } else {
-              _disable_dict_tag_matching = true;
-              return false;
+          // A receipt recorder must observe the full subtree. The recursive
+          // dict-tag shortcut is a 2.10 optimization that postdates the
+          // historical Fast Plan and would otherwise omit its self tokens.
+          if (active_guard_subtree_memo_recorder == nullptr) {
+            // Check for fast path
+            // if (is_weakref_valid(value) && check_dict_pointer_tags(value)) {
+            if (check_dict_pointer_tags(value)) {
+              if (check_no_tensor_aliasing_guards_fast(value)) {
+                return true;
+              } else {
+                _disable_dict_tag_matching = true;
+                return false;
+              }
             }
+            // Something changed, very likely the dict tag checking will fail
+            // in future. So disable the recursive tag matching.
+            _disable_dict_tag_matching = true;
           }
-          // Something changed, very likely the dict tag checking will fail in
-          // future. So disable the recursive tag matching.
-          _disable_dict_tag_matching = true;
         } else if (
             _dict_pointers.size() ==
             _max_saved_pointers_for_recursive_dict_tags_check) {
@@ -3250,6 +7130,412 @@ class GuardManager {
 #endif
   }
 
+  GuardFastPlanCandidateKind guard_fastplan_candidate_kind() const {
+    return _fastplan_candidate_kind;
+  }
+
+  bool is_guard_fastplan_candidate() const {
+    return guard_fastplan_candidate_kind() != GuardFastPlanCandidateKind::None;
+  }
+
+  virtual bool supports_subtree_memo_recursive(
+      GuardSubtreeMemoSupportAnalysis* analysis = nullptr) const {
+    bool supported = true;
+    const bool collect_all = analysis != nullptr && analysis->collect_all;
+    for (const auto& guard : _leaf_guards) {
+      if (!guard->supports_subtree_memo()) {
+        if (analysis != nullptr) {
+          analysis->set_if_empty(
+              guard->subtree_memo_unsupported_reason(), _source);
+        }
+        supported = false;
+        if (!collect_all) {
+          return false;
+        }
+      }
+    }
+    for (const auto& accessor : _accessors) {
+      if (!accessor->supports_subtree_memo()) {
+        if (analysis != nullptr) {
+          analysis->set_if_empty(
+              accessor->subtree_memo_unsupported_reason(),
+              accessor->get_source());
+        }
+        supported = false;
+        if (!collect_all) {
+          return false;
+        }
+        continue;
+      }
+      if (!accessor->get_guard_manager()->supports_subtree_memo_recursive(
+              analysis)) {
+        if (analysis != nullptr && analysis->path.empty()) {
+          analysis->path = accessor->get_source();
+        }
+        supported = false;
+        if (!collect_all) {
+          return false;
+        }
+      }
+    }
+    return supported;
+  }
+
+  bool supports_accessor_subtree_memo_recursive(
+      const std::string& source,
+      GuardSubtreeMemoSupportAnalysis* analysis = nullptr,
+      int* framelocals_index = nullptr) const {
+    if (framelocals_index != nullptr) {
+      *framelocals_index = -1;
+    }
+    for (const auto& accessor : _accessors) {
+      if (accessor->get_source() != source) {
+        continue;
+      }
+      if (!accessor->supports_subtree_memo()) {
+        if (analysis != nullptr) {
+          analysis->set_if_empty(
+              accessor->subtree_memo_unsupported_reason(),
+              accessor->get_source());
+        }
+        return false;
+      }
+      if (!accessor->get_guard_manager()->supports_subtree_memo_recursive(
+              analysis)) {
+        if (analysis != nullptr && analysis->path.empty()) {
+          analysis->path = accessor->get_source();
+        }
+        return false;
+      }
+      if (framelocals_index != nullptr) {
+        *framelocals_index = accessor->framelocals_index();
+      }
+      return true;
+    }
+    if (analysis != nullptr) {
+      analysis->set_if_empty("partial_missing_accessor", source);
+    }
+    return false;
+  }
+
+  bool prepare_partial_subtree_memo(
+      GuardSubtreeMemoState& memo,
+      GuardSubtreeMemoSupportAnalysis* analysis) const {
+    memo.partial = false;
+    memo.slow_accessor_indices.clear();
+
+    bool has_supported_accessor = false;
+    bool has_slow_work = false;
+    for (const auto& guard : _leaf_guards) {
+      if (!guard->supports_subtree_memo()) {
+        has_slow_work = true;
+        if (analysis != nullptr) {
+          analysis->set_if_empty(
+              guard->subtree_memo_unsupported_reason(), _source);
+        }
+      }
+    }
+
+    for (size_t i = 0; i < _accessors.size(); ++i) {
+      const auto& accessor = _accessors[i];
+      GuardSubtreeMemoSupportAnalysis child_analysis;
+      GuardSubtreeMemoSupportAnalysis* child_analysis_ptr =
+          analysis == nullptr ? nullptr : &child_analysis;
+      const bool accessor_supported = accessor->supports_subtree_memo() &&
+          accessor->get_guard_manager()->supports_subtree_memo_recursive(
+              child_analysis_ptr);
+      if (accessor_supported) {
+        has_supported_accessor = true;
+        continue;
+      }
+
+      has_slow_work = true;
+      memo.slow_accessor_indices.push_back(i);
+      if (analysis != nullptr) {
+        if (!accessor->supports_subtree_memo()) {
+          analysis->set_if_empty(
+              accessor->subtree_memo_unsupported_reason(),
+              accessor->get_source());
+        } else {
+          analysis->set_if_empty(
+              child_analysis.reason.empty() ? "unsupported:unknown"
+                                            : child_analysis.reason.c_str(),
+              child_analysis.path.empty() ? accessor->get_source()
+                                          : child_analysis.path);
+        }
+      }
+    }
+
+    if (!has_supported_accessor || !has_slow_work) {
+      memo.slow_accessor_indices.clear();
+      return false;
+    }
+    memo.partial = true;
+    return true;
+  }
+
+  bool is_partial_slow_accessor(
+      const GuardSubtreeMemoState& memo,
+      size_t accessor_index) const {
+    return std::find(
+               memo.slow_accessor_indices.begin(),
+               memo.slow_accessor_indices.end(),
+               accessor_index) != memo.slow_accessor_indices.end();
+  }
+
+  void get_dict_tag_match_for_accessors(
+      PyObject* value,
+      bool& matches_dict_tag,
+      uint64_t& new_tag) {
+    matches_dict_tag = false;
+    new_tag = 0;
+    if (_is_dict) {
+      new_tag = get_dict_version_unchecked(value);
+      matches_dict_tag = (new_tag == _dict_tag);
+    }
+  }
+
+  void maybe_update_dict_tag_after_accessors(bool result, uint64_t new_tag) {
+    if (_is_dict && result) {
+      _dict_tag = new_tag;
+    }
+  }
+
+  bool check_accessor_nopybind_with_stats(
+      const std::unique_ptr<GuardAccessor>& accessor,
+      PyObject* value,
+      bool matches_dict_tag) {
+    const bool collect_stats = guard_lookup_stats_enabled();
+    const uint64_t accessor_start_ns =
+        collect_stats ? guard_lookup_time_ns() : 0;
+    const bool accessor_result =
+        accessor->check_nopybind(value, matches_dict_tag);
+    if (collect_stats) {
+      record_guard_accessor_type_stats(
+          accessor->stats_name(),
+          guard_lookup_time_ns() - accessor_start_ns,
+          !accessor_result);
+    }
+    return accessor_result;
+  }
+
+  bool check_partial_shadow_nopybind(
+      PyObject* value,
+      const GuardSubtreeMemoState& memo,
+      std::vector<GuardSubtreeEntryToken>* tokens) {
+    append_guard_subtree_memo_token(
+        tokens,
+        GuardSubtreeEntryToken::make(value),
+        _source);
+    if (!this->check_leaf_guards_nopybind(value)) {
+      return false;
+    }
+
+    bool matches_dict_tag = false;
+    uint64_t new_tag = 0;
+    get_dict_tag_match_for_accessors(value, matches_dict_tag, new_tag);
+    for (size_t i = 0; i < _accessors.size(); ++i) {
+      const auto& accessor = _accessors[i];
+      bool accessor_result = false;
+      if (is_partial_slow_accessor(memo, i)) {
+        accessor_result = check_accessor_nopybind_with_stats(
+            accessor, value, matches_dict_tag);
+      } else {
+        GuardSubtreeMemoRecorderScope recorder(tokens);
+        accessor_result = check_accessor_nopybind_with_stats(
+            accessor, value, matches_dict_tag);
+      }
+      if (!accessor_result) {
+        _fail_count += 1;
+        return false;
+      }
+    }
+
+    maybe_update_dict_tag_after_accessors(true, new_tag);
+    return true;
+  }
+
+  bool check_partial_slow_accessors_nopybind(
+      PyObject* value,
+      const GuardSubtreeMemoState& memo) {
+    if (!this->check_leaf_guards_nopybind(value)) {
+      return false;
+    }
+
+    bool matches_dict_tag = false;
+    uint64_t new_tag = 0;
+    get_dict_tag_match_for_accessors(value, matches_dict_tag, new_tag);
+    for (const size_t accessor_index : memo.slow_accessor_indices) {
+      if (accessor_index >= _accessors.size()) {
+        return false;
+      }
+      if (!check_accessor_nopybind_with_stats(
+              _accessors[accessor_index], value, matches_dict_tag)) {
+        _fail_count += 1;
+        return false;
+      }
+    }
+
+    maybe_update_dict_tag_after_accessors(true, new_tag);
+    return true;
+  }
+
+  bool check_nopybind_with_fastplan(PyObject* value) {
+    GuardSubtreeMemoState& memo = _subtree_probe_state.memo;
+    const GuardFastPlanCandidateKind candidate_kind =
+        guard_fastplan_candidate_kind();
+    if (!guard_fast_plan_enabled() || memo.disabled ||
+        candidate_kind == GuardFastPlanCandidateKind::None) {
+      return check_nopybind(value);
+    }
+
+    const bool collect_stats = guard_lookup_stats_enabled();
+    if (collect_stats) {
+      record_guard_fastplan_candidate(candidate_kind);
+    }
+    GuardSubtreeMemoSupportAnalysis analysis;
+    GuardSubtreeMemoSupportAnalysis* analysis_ptr =
+        collect_stats ? &analysis : nullptr;
+    if (memo.tokens.empty() &&
+        !supports_subtree_memo_recursive(analysis_ptr)) {
+      if (!prepare_partial_subtree_memo(memo, analysis_ptr)) {
+        memo.disabled = true;
+        if (collect_stats) {
+          record_guard_fastplan_disabled(candidate_kind, analysis);
+        }
+        return check_nopybind(value);
+      }
+    }
+
+    if (memo.enabled) {
+      const uint64_t token_start_ns =
+          collect_stats ? guard_lookup_time_ns() : 0;
+      const bool token_match = guard_subtree_memo_tokens_match(
+          memo.tokens, value, collect_stats);
+      const uint64_t token_check_ns =
+          collect_stats ? guard_lookup_time_ns() - token_start_ns : 0;
+      if (token_match) {
+        if (collect_stats) {
+          record_guard_fastplan_hit(
+              candidate_kind, memo.partial, memo.tokens.size(), token_check_ns);
+        }
+        if (memo.partial) {
+          return check_partial_slow_accessors_nopybind(value, memo);
+        }
+        return true;
+      }
+
+      memo.disabled = true;
+      memo.partial = false;
+      const uint64_t slow_start_ns =
+          collect_stats ? guard_lookup_time_ns() : 0;
+      const bool result = check_nopybind(value);
+      const uint64_t slow_check_ns =
+          collect_stats ? guard_lookup_time_ns() - slow_start_ns : 0;
+      if (collect_stats) {
+        record_guard_fastplan_miss(
+            candidate_kind,
+            memo.tokens.size(),
+            token_check_ns,
+            slow_check_ns,
+            true);
+      }
+      return result;
+    }
+
+    std::vector<GuardSubtreeEntryToken> tokens;
+    const uint64_t slow_start_ns =
+        collect_stats ? guard_lookup_time_ns() : 0;
+    bool result = false;
+    if (memo.partial) {
+      result = check_partial_shadow_nopybind(value, memo, &tokens);
+    } else {
+      GuardSubtreeMemoRecorderScope recorder(&tokens);
+      result = check_nopybind(value);
+    }
+    const uint64_t slow_check_ns =
+        collect_stats ? guard_lookup_time_ns() - slow_start_ns : 0;
+
+    if (!result) {
+      memo.shadow_passes = 0;
+      memo.tokens.clear();
+      return false;
+    }
+
+    if (tokens.size() > kGuardFastPlanMaxTokens) {
+      memo.disabled = true;
+      memo.partial = false;
+      memo.shadow_passes = 0;
+      memo.tokens.clear();
+      record_guard_fastplan_token_cap_disabled();
+      return true;
+    }
+
+    if (!memo.tokens.empty() &&
+        guard_subtree_token_vectors_match(tokens, memo.tokens)) {
+      memo.shadow_passes += 1;
+    } else {
+      memo.tokens = std::move(tokens);
+      memo.shadow_passes = 1;
+    }
+
+    if (collect_stats) {
+      record_guard_fastplan_shadow_pass(
+          candidate_kind, memo.partial, memo.tokens.size(), slow_check_ns);
+    }
+    if (memo.shadow_passes >= 3) {
+      memo.enabled = true;
+      if (collect_stats) {
+        record_guard_fastplan_enable(candidate_kind, memo.partial);
+      }
+    }
+    return true;
+  }
+
+  bool check_nopybind_with_subtree_probe(
+      PyObject* value,
+      const std::string& path) {
+    if (guard_fast_plan_enabled() &&
+        active_guard_subtree_memo_recorder == nullptr &&
+        is_guard_fastplan_candidate()) {
+      return check_nopybind_with_fastplan(value);
+    }
+    if (!guard_subtree_probe_enabled() || _subtree_probe_state.disabled) {
+      return check_nopybind(value);
+    }
+
+    const uint64_t entry_start_ns = guard_lookup_time_ns();
+    GuardSubtreeEntryToken token = GuardSubtreeEntryToken::make(value);
+    const bool entry_match = _subtree_probe_state.has_last_token &&
+        token.matches(_subtree_probe_state.last_token);
+    const uint64_t entry_check_ns = guard_lookup_time_ns() - entry_start_ns;
+
+    const uint64_t child_start_ns = guard_lookup_time_ns();
+    const bool child_result = check_nopybind(value);
+    const uint64_t child_check_ns = guard_lookup_time_ns() - child_start_ns;
+
+    bool disabled_now = false;
+    if (entry_match && !child_result) {
+      _subtree_probe_state.disabled = true;
+      disabled_now = true;
+    }
+    if (child_result) {
+      _subtree_probe_state.last_token = std::move(token);
+      _subtree_probe_state.has_last_token = true;
+    }
+    record_guard_subtree_probe_stats(
+        path,
+        entry_match,
+        child_result,
+        disabled_now,
+        entry_check_ns,
+        child_check_ns,
+        _subtree_probe_state.has_last_token
+            ? _subtree_probe_state.last_token.kind
+            : token.kind);
+    return child_result;
+  }
+
   virtual bool check_nopybind(FrameLocalsMapping* value) {
     return check_nopybind_template(value);
   }
@@ -3257,8 +7543,36 @@ class GuardManager {
   template <typename T>
   bool check_leaf_guards_nopybind(T* value) {
     // Iterate over leaf guards
+    const bool collect_stats = guard_lookup_stats_enabled();
     for (const auto& guard : _leaf_guards) {
-      if (!guard->check_nopybind(value)) { // early exit
+      bool result = false;
+      const uint64_t guard_start_ns =
+          collect_stats ? guard_lookup_time_ns() : 0;
+      if (C10_UNLIKELY(active_guard_subtree_memo_recorder != nullptr)) {
+        bool emit_subtree_memo_token = false;
+        if constexpr (std::is_same_v<T, PyObject>) {
+          emit_subtree_memo_token = guard->emits_subtree_memo_token();
+        } else {
+          emit_subtree_memo_token =
+              guard->emits_subtree_memo_token_for_frame_locals();
+        }
+        if (emit_subtree_memo_token) {
+          result = guard->append_subtree_memo_token(
+              value, active_guard_subtree_memo_recorder);
+        } else {
+          result = guard->check_nopybind(value);
+        }
+      } else {
+        result = guard->check_nopybind(value);
+      }
+      if (collect_stats) {
+        record_guard_leaf_stats(
+            guard->stats_name(),
+            _source,
+            guard_lookup_time_ns() - guard_start_ns,
+            !result);
+      }
+      if (!result) { // early exit
         _fail_count += 1;
         // no need of sorting, just return.
         return false;
@@ -3286,10 +7600,21 @@ class GuardManager {
     }
 
     // Iterate over accessors.
+    const bool collect_stats = guard_lookup_stats_enabled();
     bool result = true;
     bool failed_on_first = true;
     for (const auto& accessor : _accessors) {
-      if (!accessor->check_nopybind(value, matches_dict_tag)) { // early exit
+      const uint64_t accessor_start_ns =
+          collect_stats ? guard_lookup_time_ns() : 0;
+      const bool accessor_result =
+          accessor->check_nopybind(value, matches_dict_tag);
+      if (collect_stats) {
+        record_guard_accessor_type_stats(
+            accessor->stats_name(),
+            guard_lookup_time_ns() - accessor_start_ns,
+            !accessor_result);
+      }
+      if (!accessor_result) { // early exit
         _fail_count += 1;
         result = false;
         // need to sort, so break the loop.
@@ -3325,6 +7650,63 @@ class GuardManager {
       // If result is true, reset the _dict_tag. This is useful if there is a
       // mutation on the dict but it does not change the attr values (like
       // swapping).
+      _dict_tag = new_tag;
+    }
+
+    return result;
+  }
+
+  template <typename T>
+  bool check_accessors_nopybind_skipping_source(
+      T* value,
+      const std::string& skip_source) {
+    bool matches_dict_tag = false;
+    uint64_t new_tag = 0;
+    if constexpr (std::is_same_v<T, PyObject>) {
+      if (_is_dict) {
+        new_tag = get_dict_version_unchecked(value);
+        matches_dict_tag = (new_tag == _dict_tag);
+      }
+    }
+
+    const bool collect_stats = guard_lookup_stats_enabled();
+    bool result = true;
+    bool failed_on_first = true;
+    for (const auto& accessor : _accessors) {
+      if (accessor->get_source() == skip_source) {
+        failed_on_first = false;
+        continue;
+      }
+      const uint64_t accessor_start_ns =
+          collect_stats ? guard_lookup_time_ns() : 0;
+      const bool accessor_result =
+          accessor->check_nopybind(value, matches_dict_tag);
+      if (collect_stats) {
+        record_guard_accessor_type_stats(
+            accessor->stats_name(),
+            guard_lookup_time_ns() - accessor_start_ns,
+            !accessor_result);
+      }
+      if (!accessor_result) {
+        _fail_count += 1;
+        result = false;
+        break;
+      }
+      failed_on_first = false;
+    }
+
+    if (!result && !failed_on_first) {
+      std::sort(
+          _accessors.begin(),
+          _accessors.end(),
+          [](const std::unique_ptr<GuardAccessor>& a,
+             const std::unique_ptr<GuardAccessor>& b) {
+            return a->get_guard_manager()->fail_count() >
+                b->get_guard_manager()->fail_count();
+          });
+    }
+
+    if (_is_dict && result) {
       _dict_tag = new_tag;
     }
 
@@ -3492,6 +7874,10 @@ class GuardManager {
   // 3.12+ related helper
   bool _dict_callback_installed = false;
 
+  GuardSubtreeProbeState _subtree_probe_state;
+  GuardFastPlanCandidateKind _fastplan_candidate_kind{
+      GuardFastPlanCandidateKind::None};
+
  protected:
   // weakref to the type of guarded value
   // protected because it is used for cloning by DictGuardManager
@@ -3513,6 +7899,19 @@ GuardAccessor::GuardAccessor(
 GuardAccessor::GuardAccessor(GuardManager* guard_manager, GuardAccessor* from)
     : _guard_manager(std::unique_ptr<GuardManager>(guard_manager)) {
   from->clone_visitor(this);
+}
+
+inline bool GuardAccessor::check_child_manager_nopybind(PyObject* obj) {
+  if (C10_LIKELY(
+          !guard_subtree_probe_enabled() && !guard_fast_plan_enabled())) {
+    return _guard_manager->check_nopybind(obj);
+  }
+  static const std::string empty_path = "";
+  if (!guard_subtree_probe_detail_enabled()) {
+    return _guard_manager->check_nopybind_with_subtree_probe(obj, empty_path);
+  }
+  return _guard_manager->check_nopybind_with_subtree_probe(
+      obj, stats_detail_name());
 }
 
 /**
@@ -3571,55 +7970,139 @@ class RootGuardManager : public GuardManager {
 
   // Fast check function.
   template <typename T>
-  bool check_nopybind_template(T* value) { // borrowed ref
+  bool check_nopybind_template(
+      T* value,
+      const std::string* skip_accessor_source = nullptr) { // borrowed ref
+    const bool collect_stats = guard_lookup_stats_enabled();
+    const uint64_t total_start_ns =
+        collect_stats ? guard_lookup_time_ns() : 0;
+    uint64_t lock_ns = 0;
+    uint64_t local_state_ns = 0;
+    uint64_t leaf_ns = 0;
+    uint64_t accessor_ns = 0;
+    uint64_t epilogue_ns = 0;
+    uint64_t tls_ns = 0;
+    auto record_and_return = [&](bool result) {
+      if (collect_stats) {
+        record_root_guard_stats(
+            guard_lookup_time_ns() - total_start_ns,
+            lock_ns,
+            local_state_ns,
+            leaf_ns,
+            accessor_ns,
+            epilogue_ns,
+            tls_ns);
+      }
+      return result;
+    };
+
     // Check [Note on GIL interaction with mutex lock] for details on why we
     // need mutex and its interactions with GIL.
     PyThreadState* _save = nullptr;
+    const uint64_t lock_start_ns =
+        collect_stats ? guard_lookup_time_ns() : 0;
     Py_UNBLOCK_THREADS; // ; is added to avoid clang-formatting
     std::lock_guard<std::mutex> lock_guard(_lock);
     Py_BLOCK_THREADS; // ; is added to avoid clang-formatting
+    if (collect_stats) {
+      lock_ns += guard_lookup_time_ns() - lock_start_ns;
+    }
 
     // Clean up dict pointer recording for tag safe roots
     reset_dict_tag_recording_variables();
 
     // Get the local state. This will be used for TENSOR_MATCH guards.
+    const uint64_t local_state_start_ns =
+        collect_stats ? guard_lookup_time_ns() : 0;
     if (_init_local_state) {
       LocalState state;
       _local_state = state;
     }
+    if (collect_stats) {
+      local_state_ns += guard_lookup_time_ns() - local_state_start_ns;
+    }
+    GuardLocalStateScope local_state_scope(&_local_state);
 
+    const uint64_t leaf_start_ns =
+        collect_stats ? guard_lookup_time_ns() : 0;
     if (!GuardManager::check_leaf_guards_nopybind(value)) {
+      if (collect_stats) {
+        leaf_ns += guard_lookup_time_ns() - leaf_start_ns;
+      }
       _reset_relational_guard_state();
-      return false;
+      return record_and_return(false);
+    }
+    if (collect_stats) {
+      leaf_ns += guard_lookup_time_ns() - leaf_start_ns;
     }
 
     // Run accessor guards without TorchFunction enabled
     // Dynamo should only be adding guards on values without
     // torch function at this point, because if there
     // was a torch function, we should've traced through it
+    const uint64_t tls_disable_start_ns =
+        collect_stats ? guard_lookup_time_ns() : 0;
     const at::impl::TorchFunctionDisabledState old_state =
         at::impl::PythonTorchFunctionTLS::get_disabled_state();
     at::impl::PythonTorchFunctionTLS::set_disabled_state(
         at::impl::TorchFunctionDisabledState::ALL_DISABLED);
+    if (collect_stats) {
+      tls_ns += guard_lookup_time_ns() - tls_disable_start_ns;
+    }
 
-    if (!GuardManager::check_accessors_nopybind(value)) {
+    const uint64_t accessor_start_ns =
+        collect_stats ? guard_lookup_time_ns() : 0;
+    const bool accessor_result = skip_accessor_source == nullptr
+        ? GuardManager::check_accessors_nopybind(value)
+        : GuardManager::check_accessors_nopybind_skipping_source(
+              value, *skip_accessor_source);
+    if (!accessor_result) {
+      if (collect_stats) {
+        accessor_ns += guard_lookup_time_ns() - accessor_start_ns;
+      }
+      const uint64_t tls_restore_start_ns =
+          collect_stats ? guard_lookup_time_ns() : 0;
       at::impl::PythonTorchFunctionTLS::set_disabled_state(old_state);
+      if (collect_stats) {
+        tls_ns += guard_lookup_time_ns() - tls_restore_start_ns;
+      }
       _reset_relational_guard_state();
-      return false;
+      return record_and_return(false);
+    }
+    if (collect_stats) {
+      accessor_ns += guard_lookup_time_ns() - accessor_start_ns;
     }
 
     // Iterate over epilogue leaf guards.
     for (const auto& guard : _epilogue_lambda_guards) {
+      const uint64_t epilogue_start_ns =
+          collect_stats ? guard_lookup_time_ns() : 0;
       if (!guard->check_nopybind(value)) { // early exit
+        if (collect_stats) {
+          epilogue_ns += guard_lookup_time_ns() - epilogue_start_ns;
+        }
+        const uint64_t tls_restore_start_ns =
+            collect_stats ? guard_lookup_time_ns() : 0;
         at::impl::PythonTorchFunctionTLS::set_disabled_state(old_state);
+        if (collect_stats) {
+          tls_ns += guard_lookup_time_ns() - tls_restore_start_ns;
+        }
         _reset_relational_guard_state();
-        return false;
+        return record_and_return(false);
+      }
+      if (collect_stats) {
+        epilogue_ns += guard_lookup_time_ns() - epilogue_start_ns;
       }
     }
 
+    const uint64_t tls_restore_start_ns =
+        collect_stats ? guard_lookup_time_ns() : 0;
     at::impl::PythonTorchFunctionTLS::set_disabled_state(old_state);
+    if (collect_stats) {
+      tls_ns += guard_lookup_time_ns() - tls_restore_start_ns;
+    }
     _reset_relational_guard_state();
-    return true;
+    return record_and_return(true);
   }
 
   bool check_nopybind(PyObject* value) override {
@@ -3628,6 +8111,34 @@ class RootGuardManager : public GuardManager {
 
   bool check_nopybind(FrameLocalsMapping* value) override {
     return check_nopybind_template(value);
+  }
+
+  bool check_nopybind_skipping_source(
+      FrameLocalsMapping* value,
+      const std::string& skip_accessor_source) {
+    return check_nopybind_template(value, &skip_accessor_source);
+  }
+
+  bool supports_subtree_memo_recursive(
+      GuardSubtreeMemoSupportAnalysis* analysis = nullptr) const override {
+    bool supported = GuardManager::supports_subtree_memo_recursive(analysis);
+    const bool collect_all = analysis != nullptr && analysis->collect_all;
+    if (!supported && !collect_all) {
+      return false;
+    }
+    for (const auto& guard : _epilogue_lambda_guards) {
+      if (!guard->supports_subtree_memo()) {
+        if (analysis != nullptr) {
+          analysis->set_if_empty(
+              guard->subtree_memo_unsupported_reason(), "L");
+        }
+        supported = false;
+        if (!collect_all) {
+          return false;
+        }
+      }
+    }
+    return supported;
   }
 
   // Fast check_verbose function.
@@ -4060,6 +8571,37 @@ class DictGuardManager : public GuardManager {
     return _is_exact_dict_type;
   }
 
+  bool supports_subtree_memo_recursive(
+      GuardSubtreeMemoSupportAnalysis* analysis = nullptr) const override {
+    bool supported = true;
+    const bool collect_all = analysis != nullptr && analysis->collect_all;
+    if (!GuardManager::supports_subtree_memo_recursive(analysis)) {
+      supported = false;
+      if (!collect_all) {
+        return false;
+      }
+    }
+    for (const auto& item : _key_value_managers) {
+      const auto& key_manager = item.second.first;
+      if (key_manager && !key_manager->supports_subtree_memo_recursive(
+                             analysis)) {
+        supported = false;
+        if (!collect_all) {
+          return false;
+        }
+      }
+      const auto& value_manager = item.second.second;
+      if (value_manager && !value_manager->supports_subtree_memo_recursive(
+                                analysis)) {
+        supported = false;
+        if (!collect_all) {
+          return false;
+        }
+      }
+    }
+    return supported;
+  }
+
  public: // cloning functions
   DictGuardManager(
       RootGuardManager* cloned_root,
@@ -4282,6 +8824,8 @@ std::shared_ptr<RelationalGuard> get_no_tensor_aliasing_guard(
 
 class TORCH_FUNCTION_MODE_STACK : public LeafGuard {
  public:
+  LEAF_GUARD_STATS_NAME(TORCH_FUNCTION_MODE_STACK)
+
   TORCH_FUNCTION_MODE_STACK(
       RootGuardManager* root_guard_manager,
       const py::list& initial_stack,
@@ -4296,7 +8840,7 @@ class TORCH_FUNCTION_MODE_STACK : public LeafGuard {
   }
 
   template <typename T>
-  bool check_nopybind_template(T* value) {
+  bool check_nopybind_template(T* value) const {
     // Ignore value arg, only used to satisfy the interface
     const size_t len = (size_t)at::impl::PythonTorchFunctionTLS::stack_len();
     const size_t ref_stack_size = this->_ref_stack.size();
@@ -4326,12 +8870,58 @@ class TORCH_FUNCTION_MODE_STACK : public LeafGuard {
     return check_nopybind_template(value);
   }
 
+  bool supports_subtree_memo() const override {
+    return true;
+  }
+  const char* subtree_memo_unsupported_reason() const override {
+    return "unsupported_leaf:TORCH_FUNCTION_MODE_STACK";
+  }
+  bool emits_subtree_memo_token() const override {
+    return true;
+  }
+  bool emits_subtree_memo_token_for_frame_locals() const override {
+    return true;
+  }
+  bool append_subtree_memo_token(
+      PyObject* value,
+      std::vector<GuardSubtreeEntryToken>* tokens) override {
+    return append_subtree_memo_token_template(value, tokens);
+  }
+  bool append_subtree_memo_token(
+      FrameLocalsMapping* value,
+      std::vector<GuardSubtreeEntryToken>* tokens) override {
+    return append_subtree_memo_token_template(value, tokens);
+  }
+
  private:
+  template <typename T>
+  bool append_subtree_memo_token_template(
+      T* value,
+      std::vector<GuardSubtreeEntryToken>* tokens) {
+    if (!check_nopybind_template(value)) {
+      return false;
+    }
+    append_guard_subtree_memo_token(
+        tokens,
+        GuardSubtreeEntryToken::make_torch_function_mode_stack(
+            static_cast<const void*>(this)),
+        "<TORCH_FUNCTION_MODE_STACK>");
+    return true;
+  }
+
   std::vector<PyTypeObject*> _ref_stack;
 };
 
+static bool torch_function_mode_stack_guard_matches(const void* guard) {
+  return guard != nullptr &&
+      static_cast<const TORCH_FUNCTION_MODE_STACK*>(guard)
+          ->check_nopybind_template(static_cast<PyObject*>(nullptr));
+}
+
 class DISPATCH_KEY_SET_MATCH : public LeafGuard {
  public:
+  LEAF_GUARD_STATS_NAME(DISPATCH_KEY_SET_MATCH)
+
   DISPATCH_KEY_SET_MATCH(
       RootGuardManager* root_guard_manager,
       py::object value,
@@ -4349,12 +8939,21 @@ class DISPATCH_KEY_SET_MATCH : public LeafGuard {
         _root_guard_manager->_local_state.apply(value_).raw_repr();
   }
 
+  bool supports_subtree_memo() const override {
+    return false;
+  }
+  const char* subtree_memo_unsupported_reason() const override {
+    return "unsupported_leaf:DISPATCH_KEY_SET_MATCH";
+  }
+
  private:
   uint64_t raw_repr;
 };
 
 class TENSOR_MATCH : public LeafGuard {
  public:
+  LEAF_GUARD_STATS_NAME(TENSOR_MATCH)
+
   TENSOR_MATCH(
       RootGuardManager* root_guard_manager,
       py::object value,
@@ -4365,7 +8964,9 @@ class TENSOR_MATCH : public LeafGuard {
       py::object pytype,
       py::object dispatch_keys)
       : LeafGuard(root_guard_manager, std::move(verbose_code_parts)),
-        _tensor_name(py::cast<std::string>(std::move(tensor_name))) {
+        _tensor_name(py::cast<std::string>(std::move(tensor_name))),
+        _supports_subtree_memo_token(
+            tensor_match_source_supports_subtree_memo(_tensor_name)) {
     root_guard_manager->set_init_local_state_flag();
     PyObject* item = value.ptr();
     if (!THPVariable_CheckExact(item) && !THPVariable_Check(item)) {
@@ -4440,8 +9041,32 @@ class TENSOR_MATCH : public LeafGuard {
     return GuardDebugInfo(true, 1);
   }
 
+  bool supports_subtree_memo() const override {
+    return _supports_subtree_memo_token;
+  }
+  const char* subtree_memo_unsupported_reason() const override {
+    return "unsupported_leaf:TENSOR_MATCH";
+  }
+  bool emits_subtree_memo_token() const override {
+    return _supports_subtree_memo_token;
+  }
+  bool append_subtree_memo_token(
+      PyObject* value,
+      std::vector<GuardSubtreeEntryToken>* tokens) override {
+    GuardSubtreeEntryToken token;
+    if (!GuardSubtreeEntryToken::make_tensor_match(
+            value, *_tensor_check, _root_guard_manager->_local_state, &token)) {
+      return false;
+    }
+    append_guard_subtree_memo_token(
+        tokens, std::move(token), _tensor_name);
+    record_guard_fastplan_tensor_token_shadow();
+    return true;
+  }
+
  private:
   std::string _tensor_name;
+  bool _supports_subtree_memo_token;
   std::unique_ptr<TensorCheck> _tensor_check;
 };
 
@@ -4450,6 +9075,8 @@ class TENSOR_MATCH : public LeafGuard {
  */
 class GetAttrGuardAccessor : public GuardAccessor {
  public:
+  GUARD_ACCESSOR_STATS_NAME(GetAttrGuardAccessor)
+
   GetAttrGuardAccessor(
       RootGuardManager* root,
       py::str name,
@@ -4474,7 +9101,7 @@ class GetAttrGuardAccessor : public GuardAccessor {
       PyErr_Clear();
       return false;
     }
-    bool result = _guard_manager->check_nopybind(x);
+    bool result = check_child_manager_nopybind(x);
     Py_DECREF(x);
     return result;
   }
@@ -4530,6 +9157,8 @@ class GetAttrGuardAccessor : public GuardAccessor {
  */
 class GenericGetAttrGuardAccessor : public GuardAccessor {
  public:
+  GUARD_ACCESSOR_STATS_NAME(GenericGetAttrGuardAccessor)
+
   GenericGetAttrGuardAccessor(
       RootGuardManager* root,
       py::str name,
@@ -4554,7 +9183,7 @@ class GenericGetAttrGuardAccessor : public GuardAccessor {
       PyErr_Clear();
       return false;
     }
-    bool result = _guard_manager->check_nopybind(x);
+    bool result = check_child_manager_nopybind(x);
     Py_DECREF(x);
     return result;
   }
@@ -4609,6 +9238,8 @@ class GenericGetAttrGuardAccessor : public GuardAccessor {
  */
 class GetGenericDictGuardAccessor : public GuardAccessor {
  public:
+  GUARD_ACCESSOR_STATS_NAME(GetGenericDictGuardAccessor)
+
   GetGenericDictGuardAccessor(
       RootGuardManager* root,
       py::str name,
@@ -4633,14 +9264,35 @@ class GetGenericDictGuardAccessor : public GuardAccessor {
     // 1) Once __dict__ is generated, accessing it the second time is fast.
     // 2) Getting the object from weakref, from 3.13 onwards, requires
     // Py_DECREF, which further eats into the benefit.
+    const bool collect_stats = guard_lookup_stats_enabled();
+    if (!collect_stats) {
+      PyObject* x = PyObject_GenericGetDict(obj, nullptr); // new ref
+      if (x == nullptr) {
+        // Attribute absent, clear the exception and return false.
+        PyErr_Clear();
+        return false;
+      }
+      bool result = check_child_manager_nopybind(x);
+      Py_DECREF(x);
+      return result;
+    }
+
+    const uint64_t total_start_ns = guard_lookup_time_ns();
     PyObject* x = PyObject_GenericGetDict(obj, nullptr); // new ref
+    const uint64_t self_ns = guard_lookup_time_ns() - total_start_ns;
     if (x == nullptr) {
       // Attribute absent, clear the exception and return false.
       PyErr_Clear();
+      record_detail_stats(
+          self_ns, 0, guard_lookup_time_ns() - total_start_ns, true);
       return false;
     }
-    bool result = _guard_manager->check_nopybind(x);
+    const uint64_t child_start_ns = guard_lookup_time_ns();
+    bool result = check_child_manager_nopybind(x);
+    const uint64_t child_ns = guard_lookup_time_ns() - child_start_ns;
     Py_DECREF(x);
+    record_detail_stats(
+        self_ns, child_ns, guard_lookup_time_ns() - total_start_ns, !result);
     return result;
   }
 
@@ -4684,6 +9336,8 @@ class GetGenericDictGuardAccessor : public GuardAccessor {
  */
 class GetItemGuardAccessor : public GuardAccessor {
  public:
+  GUARD_ACCESSOR_STATS_NAME(GetItemGuardAccessor)
+
   GetItemGuardAccessor(
       RootGuardManager* root,
       py::object name,
@@ -4702,13 +9356,33 @@ class GetItemGuardAccessor : public GuardAccessor {
   // check_verbose_nopybind.
   bool check_nopybind(PyObject* obj, bool matches_dict_tag = false)
       override { // borrowed ref
+    const bool collect_stats = guard_lookup_stats_enabled();
+    if (!collect_stats) {
+      PyObject* x = PyObject_GetItem(obj, _attr_name); // new ref
+      if (x == nullptr) {
+        PyErr_Clear();
+        return false;
+      }
+      bool result = check_child_manager_nopybind(x);
+      Py_DECREF(x);
+      return result;
+    }
+
+    const uint64_t total_start_ns = guard_lookup_time_ns();
     PyObject* x = PyObject_GetItem(obj, _attr_name); // new ref
+    const uint64_t self_ns = guard_lookup_time_ns() - total_start_ns;
     if (x == nullptr) {
       PyErr_Clear();
+      record_detail_stats(
+          self_ns, 0, guard_lookup_time_ns() - total_start_ns, true);
       return false;
     }
-    bool result = _guard_manager->check_nopybind(x);
+    const uint64_t child_start_ns = guard_lookup_time_ns();
+    bool result = check_child_manager_nopybind(x);
+    const uint64_t child_ns = guard_lookup_time_ns() - child_start_ns;
     Py_DECREF(x);
+    record_detail_stats(
+        self_ns, child_ns, guard_lookup_time_ns() - total_start_ns, !result);
     return result;
   }
 
@@ -4760,6 +9434,8 @@ class GetItemGuardAccessor : public GuardAccessor {
  */
 class FrameLocalsGuardAccessor : public GuardAccessor {
  public:
+  GUARD_ACCESSOR_STATS_NAME(FrameLocalsGuardAccessor)
+
   FrameLocalsGuardAccessor(
       RootGuardManager* root,
       const py::tuple& key,
@@ -4776,23 +9452,49 @@ class FrameLocalsGuardAccessor : public GuardAccessor {
         _framelocals_idx(key[1].cast<int>()),
         _is_immutable_object(is_immutable_object(example_value)) {}
 
+  int framelocals_index() const override {
+    return _framelocals_idx;
+  }
+
   // Run as a result of calling run_root_guard_manager/check_nopybind
   // NB: Intentional duplication between check_nopybind and
   // check_verbose_nopybind.
   bool check_nopybind(
       FrameLocalsMapping* obj,
       bool matches_dict_tag = false) override { // borrowed ref
+    const bool collect_stats = guard_lookup_stats_enabled();
     if (matches_dict_tag && _is_immutable_object) {
       // immutable object and dict tag matches, we can skip the guard subtree.
+      if (collect_stats) {
+        record_detail_stats(0, 0, 0, false);
+      }
       return true;
     }
 
+    if (!collect_stats) {
+      PyObject* x = obj->get(_framelocals_idx);
+      if (x == nullptr) {
+        PyErr_Clear();
+        return false;
+      }
+      return check_child_manager_nopybind(x);
+    }
+
+    const uint64_t total_start_ns = guard_lookup_time_ns();
     PyObject* x = obj->get(_framelocals_idx);
+    const uint64_t self_ns = guard_lookup_time_ns() - total_start_ns;
     if (x == nullptr) {
       PyErr_Clear();
+      record_detail_stats(
+          self_ns, 0, guard_lookup_time_ns() - total_start_ns, true);
       return false;
     }
-    return _guard_manager->check_nopybind(x);
+    const uint64_t child_start_ns = guard_lookup_time_ns();
+    bool result = check_child_manager_nopybind(x);
+    const uint64_t child_ns = guard_lookup_time_ns() - child_start_ns;
+    record_detail_stats(
+        self_ns, child_ns, guard_lookup_time_ns() - total_start_ns, !result);
+    return result;
   }
 
   // Run as a result of calling check(), e.g. from Python
@@ -4806,17 +9508,39 @@ class FrameLocalsGuardAccessor : public GuardAccessor {
         PyDict_Check(obj),
         "FrameLocalsGuardAccessor check expected dict() input");
 
+    const bool collect_stats = guard_lookup_stats_enabled();
     if (matches_dict_tag && _is_immutable_object) {
       // immutable object and dict tag matches, we can skip the guard subtree.
+      if (collect_stats) {
+        record_detail_stats(0, 0, 0, false);
+      }
       return true;
     }
 
+    if (!collect_stats) {
+      PyObject* x = PyDict_GetItem(obj, _key); // borrowed ref
+      if (x == nullptr) {
+        PyErr_Clear();
+        return false;
+      }
+      bool result = check_child_manager_nopybind(x);
+      return result;
+    }
+
+    const uint64_t total_start_ns = guard_lookup_time_ns();
     PyObject* x = PyDict_GetItem(obj, _key); // borrowed ref
+    const uint64_t self_ns = guard_lookup_time_ns() - total_start_ns;
     if (x == nullptr) {
       PyErr_Clear();
+      record_detail_stats(
+          self_ns, 0, guard_lookup_time_ns() - total_start_ns, true);
       return false;
     }
-    bool result = _guard_manager->check_nopybind(x);
+    const uint64_t child_start_ns = guard_lookup_time_ns();
+    bool result = check_child_manager_nopybind(x);
+    const uint64_t child_ns = guard_lookup_time_ns() - child_start_ns;
+    record_detail_stats(
+        self_ns, child_ns, guard_lookup_time_ns() - total_start_ns, !result);
     return result;
   }
 
@@ -4882,6 +9606,8 @@ class FrameLocalsGuardAccessor : public GuardAccessor {
  */
 class DictGetItemGuardAccessor : public GuardAccessor {
  public:
+  GUARD_ACCESSOR_STATS_NAME(DictGetItemGuardAccessor)
+
   DictGetItemGuardAccessor(
       RootGuardManager* root,
       py::object key,
@@ -4900,6 +9626,7 @@ class DictGetItemGuardAccessor : public GuardAccessor {
   // NB: Intentional duplication between check_nopybind and
   // check_verbose_nopybind.
   bool check_nopybind(PyObject* obj, bool matches_dict_tag = false) override {
+    const bool collect_stats = guard_lookup_stats_enabled();
     if (matches_dict_tag && _is_immutable_object &&
         !is_recording_dict_pointers(get_guard_manager()->get_root()) &&
         _guard_manager->has_no_accessors()) {
@@ -4907,15 +9634,36 @@ class DictGetItemGuardAccessor : public GuardAccessor {
       // NB: We only skip the subtree if there are no accessors in the subtree.
       // This is specifically for tensors which are used in symbolic shape C++
       // guards, and therefore have accessors on the tensor GuardManager itself.
+      if (collect_stats) {
+        record_detail_stats(0, 0, 0, false);
+      }
       return true;
     }
 
+    if (!collect_stats) {
+      PyObject* x = PyDict_GetItem(obj, _key); // borrowed ref
+      if (x == nullptr) {
+        PyErr_Clear();
+        return false;
+      }
+      bool result = check_child_manager_nopybind(x);
+      return result;
+    }
+
+    const uint64_t total_start_ns = guard_lookup_time_ns();
     PyObject* x = PyDict_GetItem(obj, _key); // borrowed ref
+    const uint64_t self_ns = guard_lookup_time_ns() - total_start_ns;
     if (x == nullptr) {
       PyErr_Clear();
+      record_detail_stats(
+          self_ns, 0, guard_lookup_time_ns() - total_start_ns, true);
       return false;
     }
-    bool result = _guard_manager->check_nopybind(x);
+    const uint64_t child_start_ns = guard_lookup_time_ns();
+    bool result = check_child_manager_nopybind(x);
+    const uint64_t child_ns = guard_lookup_time_ns() - child_start_ns;
+    record_detail_stats(
+        self_ns, child_ns, guard_lookup_time_ns() - total_start_ns, !result);
     return result;
   }
 
@@ -4969,6 +9717,8 @@ class DictGetItemGuardAccessor : public GuardAccessor {
  */
 class ListGetItemGuardAccessor : public GuardAccessor {
  public:
+  GUARD_ACCESSOR_STATS_NAME(ListGetItemGuardAccessor)
+
   ListGetItemGuardAccessor(
       RootGuardManager* root,
       const py::object& index,
@@ -4987,12 +9737,31 @@ class ListGetItemGuardAccessor : public GuardAccessor {
   // check_verbose_nopybind.
   bool check_nopybind(PyObject* obj, bool matches_dict_tag = false)
       override { // borrowed ref
+    const bool collect_stats = guard_lookup_stats_enabled();
+    if (!collect_stats) {
+      PyObject* x = PyList_GetItem(obj, _index); // borrowed ref
+      if (x == nullptr) {
+        PyErr_Clear();
+        return false;
+      }
+      bool result = check_child_manager_nopybind(x);
+      return result;
+    }
+
+    const uint64_t total_start_ns = guard_lookup_time_ns();
     PyObject* x = PyList_GetItem(obj, _index); // borrowed ref
+    const uint64_t self_ns = guard_lookup_time_ns() - total_start_ns;
     if (x == nullptr) {
       PyErr_Clear();
+      record_detail_stats(
+          self_ns, 0, guard_lookup_time_ns() - total_start_ns, true);
       return false;
     }
-    bool result = _guard_manager->check_nopybind(x);
+    const uint64_t child_start_ns = guard_lookup_time_ns();
+    bool result = check_child_manager_nopybind(x);
+    const uint64_t child_ns = guard_lookup_time_ns() - child_start_ns;
+    record_detail_stats(
+        self_ns, child_ns, guard_lookup_time_ns() - total_start_ns, !result);
     return result;
   }
 
@@ -5116,6 +9885,8 @@ class SetGetItemGuardAccessor : public GuardAccessor {
  */
 class TupleGetItemGuardAccessor : public GuardAccessor {
  public:
+  GUARD_ACCESSOR_STATS_NAME(TupleGetItemGuardAccessor)
+
   TupleGetItemGuardAccessor(
       RootGuardManager* root,
       const py::object& index,
@@ -5134,12 +9905,31 @@ class TupleGetItemGuardAccessor : public GuardAccessor {
   // check_verbose_nopybind.
   bool check_nopybind(PyObject* obj, bool matches_dict_tag = false)
       override { // borrowed ref
+    const bool collect_stats = guard_lookup_stats_enabled();
+    if (!collect_stats) {
+      PyObject* x = PyTuple_GetItem(obj, _index); // borrowed ref
+      if (x == nullptr) {
+        PyErr_Clear();
+        return false;
+      }
+      bool result = check_child_manager_nopybind(x);
+      return result;
+    }
+
+    const uint64_t total_start_ns = guard_lookup_time_ns();
     PyObject* x = PyTuple_GetItem(obj, _index); // borrowed ref
+    const uint64_t self_ns = guard_lookup_time_ns() - total_start_ns;
     if (x == nullptr) {
       PyErr_Clear();
+      record_detail_stats(
+          self_ns, 0, guard_lookup_time_ns() - total_start_ns, true);
       return false;
     }
-    bool result = _guard_manager->check_nopybind(x);
+    const uint64_t child_start_ns = guard_lookup_time_ns();
+    bool result = check_child_manager_nopybind(x);
+    const uint64_t child_ns = guard_lookup_time_ns() - child_start_ns;
+    record_detail_stats(
+        self_ns, child_ns, guard_lookup_time_ns() - total_start_ns, !result);
     return result;
   }
 
@@ -5207,6 +9997,8 @@ std::string to_string(TensorProperty prop) {
 template <TensorProperty _prop>
 class TensorPropertyGuardAccessor : public GuardAccessor {
  public:
+  GUARD_ACCESSOR_STATS_NAME(TensorPropertyGuardAccessor)
+
   TensorPropertyGuardAccessor(
       RootGuardManager* root,
       const py::object& index,
@@ -5259,7 +10051,7 @@ class TensorPropertyGuardAccessor : public GuardAccessor {
 
     PyObject* py_value =
         PyLong_FromLongLong(opt_value.value()); // New reference
-    bool result = _guard_manager->check_nopybind(py_value);
+    bool result = check_child_manager_nopybind(py_value);
     Py_DECREF(py_value);
     return result;
   }
@@ -5334,6 +10126,8 @@ class TensorPropertyGuardAccessor : public GuardAccessor {
  */
 class IndexedGuardAccessor : public GuardAccessor {
  public:
+  GUARD_ACCESSOR_STATS_NAME(IndexedGuardAccessor)
+
   IndexedGuardAccessor(
       RootGuardManager* root,
       py::int_ index,
@@ -5352,7 +10146,7 @@ class IndexedGuardAccessor : public GuardAccessor {
   bool check_nopybind(PyObject* obj, bool matches_dict_tag = false)
       override { // borrowed ref
     PyObject* tuple = PyTuple_Pack(2, _index.ptr(), obj); // New reference
-    bool result = _guard_manager->check_nopybind(tuple);
+    bool result = check_child_manager_nopybind(tuple);
     Py_DECREF(tuple);
     return result;
   }
@@ -5396,6 +10190,8 @@ class IndexedGuardAccessor : public GuardAccessor {
  */
 class GradGuardAccessor : public GuardAccessor {
  public:
+  GUARD_ACCESSOR_STATS_NAME(GradGuardAccessor)
+
   GradGuardAccessor(
       RootGuardManager* root,
       py::str name,
@@ -5419,7 +10215,7 @@ class GradGuardAccessor : public GuardAccessor {
     }
     PyObject* grad =
         THPVariable_Wrap(THPVariable_Unpack(obj).grad()); // New reference
-    bool result = _guard_manager->check_nopybind(grad);
+    bool result = check_child_manager_nopybind(grad);
     // For undefined tensor, THPVariable_Wrap returns Py_RETURN_NONE. So, no
     // need of Py_XDECREF.
     Py_DECREF(grad);
@@ -5465,6 +10261,8 @@ class GradGuardAccessor : public GuardAccessor {
  */
 class FuncDefaultsGuardAccessor : public GuardAccessor {
  public:
+  GUARD_ACCESSOR_STATS_NAME(FuncDefaultsGuardAccessor)
+
   FuncDefaultsGuardAccessor(
       RootGuardManager* root,
       py::object name,
@@ -5493,7 +10291,7 @@ class FuncDefaultsGuardAccessor : public GuardAccessor {
       PyErr_Clear();
       return false;
     }
-    return _guard_manager->check_nopybind(x);
+    return check_child_manager_nopybind(x);
   }
 
   GuardDebugInfo check_verbose_nopybind(
@@ -5540,6 +10338,8 @@ class FuncDefaultsGuardAccessor : public GuardAccessor {
  */
 class FuncKwDefaultsGuardAccessor : public GuardAccessor {
  public:
+  GUARD_ACCESSOR_STATS_NAME(FuncKwDefaultsGuardAccessor)
+
   FuncKwDefaultsGuardAccessor(
       RootGuardManager* root,
       py::object name,
@@ -5568,7 +10368,7 @@ class FuncKwDefaultsGuardAccessor : public GuardAccessor {
       PyErr_Clear();
       return false;
     }
-    return _guard_manager->check_nopybind(x);
+    return check_child_manager_nopybind(x);
   }
 
   GuardDebugInfo check_verbose_nopybind(
@@ -5617,6 +10417,8 @@ class FuncKwDefaultsGuardAccessor : public GuardAccessor {
  */
 class GlobalsGuardAccessor : public GuardAccessor {
  public:
+  GUARD_ACCESSOR_STATS_NAME(GlobalsGuardAccessor)
+
   GlobalsGuardAccessor(
       RootGuardManager* root,
       py::dict globals_dict,
@@ -5637,7 +10439,7 @@ class GlobalsGuardAccessor : public GuardAccessor {
       override { // borrowed ref
     // Ignore the obj arg. This is required to satisfy the function signature.
     // Just pass on the globals dict to the child manager.
-    return _guard_manager->check_nopybind(_globals_dict);
+    return check_child_manager_nopybind(_globals_dict);
   }
 
   GuardDebugInfo check_verbose_nopybind(
@@ -5683,6 +10485,8 @@ class GlobalsGuardAccessor : public GuardAccessor {
  */
 class TypeGuardAccessor : public GuardAccessor {
  public:
+  GUARD_ACCESSOR_STATS_NAME(TypeGuardAccessor)
+
   // name = __type_accessor__, a unique string used as attribute name.
   TypeGuardAccessor(
       RootGuardManager* root,
@@ -5702,7 +10506,7 @@ class TypeGuardAccessor : public GuardAccessor {
   bool check_nopybind(PyObject* obj, bool matches_dict_tag = false)
       override { // borrowed ref
     PyObject* x = (PyObject*)Py_TYPE(obj); // borrowed ref
-    return _guard_manager->check_nopybind(x);
+    return check_child_manager_nopybind(x);
   }
 
   GuardDebugInfo check_verbose_nopybind(
@@ -5847,6 +10651,8 @@ class TypeMROGuardAccessor : public GuardAccessor {
  */
 class TupleIteratorGetItemAccessor : public GuardAccessor {
  public:
+  GUARD_ACCESSOR_STATS_NAME(TupleIteratorGetItemAccessor)
+
   TupleIteratorGetItemAccessor(
       RootGuardManager* root,
       py::object index,
@@ -5873,7 +10679,7 @@ class TupleIteratorGetItemAccessor : public GuardAccessor {
       PyErr_Clear();
       return false;
     }
-    bool result = _guard_manager->check_nopybind(x);
+    bool result = check_child_manager_nopybind(x);
     return result;
   }
 
@@ -5926,6 +10732,8 @@ class TupleIteratorGetItemAccessor : public GuardAccessor {
  */
 class GlobalWeakRefGuardAccessor : public GuardAccessor {
  public:
+  GUARD_ACCESSOR_STATS_NAME(GlobalWeakRefGuardAccessor)
+
   GlobalWeakRefGuardAccessor(
       RootGuardManager* root,
       py::object global_name,
@@ -5967,7 +10775,7 @@ class GlobalWeakRefGuardAccessor : public GuardAccessor {
       // weakref is dead
       x = Py_NewRef(Py_None);
     }
-    bool result = _guard_manager->check_nopybind(x);
+    bool result = check_child_manager_nopybind(x);
     Py_DECREF(x);
     return result;
   }
@@ -6037,6 +10845,8 @@ class GlobalWeakRefGuardAccessor : public GuardAccessor {
  */
 class WeakRefCallGuardAccessor : public GuardAccessor {
  public:
+  GUARD_ACCESSOR_STATS_NAME(WeakRefCallGuardAccessor)
+
   WeakRefCallGuardAccessor(
       RootGuardManager* root,
       py::str name,
@@ -6068,7 +10878,7 @@ class WeakRefCallGuardAccessor : public GuardAccessor {
       // weakref is dead
       x = Py_NewRef(Py_None);
     }
-    bool result = _guard_manager->check_nopybind(x);
+    bool result = check_child_manager_nopybind(x);
     Py_DECREF(x);
     return result;
   }
@@ -6274,6 +11084,8 @@ class ClosureGuardAccessor : public GuardAccessor {
  */
 class CallFunctionNoArgsGuardAccessor : public GuardAccessor {
  public:
+  GUARD_ACCESSOR_STATS_NAME(CallFunctionNoArgsGuardAccessor)
+
   CallFunctionNoArgsGuardAccessor(
       RootGuardManager* root,
       py::str name,
@@ -6302,7 +11114,7 @@ class CallFunctionNoArgsGuardAccessor : public GuardAccessor {
       return false;
     }
 
-    bool result = _guard_manager->check_nopybind(x);
+    bool result = check_child_manager_nopybind(x);
     Py_DECREF(x);
     return result;
   }
@@ -6331,6 +11143,13 @@ class CallFunctionNoArgsGuardAccessor : public GuardAccessor {
     return "CallFunctionNoArgsGuardAccessor()";
   }
 
+  bool supports_subtree_memo() const override {
+    return false;
+  }
+  const char* subtree_memo_unsupported_reason() const override {
+    return "unsupported_accessor:CallFunctionNoArgsGuardAccessor";
+  }
+
  public: // cloning functions
   CallFunctionNoArgsGuardAccessor(
       GuardManager* guard_manager,
@@ -6355,6 +11174,8 @@ class CallFunctionNoArgsGuardAccessor : public GuardAccessor {
  */
 class PythonLambdaGuardAccessor : public GuardAccessor {
  public:
+  GUARD_ACCESSOR_STATS_NAME(PythonLambdaGuardAccessor)
+
   PythonLambdaGuardAccessor(
       RootGuardManager* root,
       py::function accessor_fn,
@@ -6379,7 +11200,7 @@ class PythonLambdaGuardAccessor : public GuardAccessor {
       PyErr_Clear();
       return false;
     }
-    bool result = _guard_manager->check_nopybind(x);
+    bool result = check_child_manager_nopybind(x);
     Py_DECREF(x);
     return result;
   }
@@ -6400,6 +11221,13 @@ class PythonLambdaGuardAccessor : public GuardAccessor {
 
   std::string repr() const override {
     return "PythonLambdaGuardAccessor";
+  }
+
+  bool supports_subtree_memo() const override {
+    return false;
+  }
+  const char* subtree_memo_unsupported_reason() const override {
+    return "unsupported_accessor:PythonLambdaGuardAccessor";
   }
 
  public: // cloning functions
@@ -6621,6 +11449,217 @@ bool run_root_guard_manager(void* root, FrameLocalsMapping* f_locals) {
 #endif
 
   return ((RootGuardManager*)root)->check_nopybind(f_locals);
+}
+
+void* create_guard_last_success_receipt() {
+  return new GuardLastSuccessReceipt();
+}
+
+void destroy_guard_last_success_receipt(void* receipt) {
+  delete static_cast<GuardLastSuccessReceipt*>(receipt);
+}
+
+void reset_guard_last_success_receipt(void* receipt) {
+  if (receipt == nullptr) {
+    return;
+  }
+  static_cast<GuardLastSuccessReceipt*>(receipt)->reset();
+}
+
+static bool guard_last_success_shadow_enabled() {
+  return C10_UNLIKELY(guard_fast_plan_enabled()) &&
+      C10_UNLIKELY(guard_lookup_stats_enabled());
+}
+
+static bool guard_last_success_actual_enabled() {
+  return C10_UNLIKELY(guard_fast_plan_enabled());
+}
+
+bool run_root_guard_manager_with_last_success_receipt(
+    void* receipt,
+    void* entry_key,
+    void* root,
+    FrameLocalsMapping* f_locals,
+    bool is_skip_guard_eval_unsafe) {
+  if (!guard_last_success_actual_enabled() || receipt == nullptr) {
+    return run_root_guard_manager(root, f_locals);
+  }
+
+  record_guard_last_success_shadow_attempt();
+  GuardLastSuccessReceipt* state =
+      static_cast<GuardLastSuccessReceipt*>(receipt);
+  if (is_skip_guard_eval_unsafe) {
+    record_guard_last_success_incomplete("skip_guard_eval_unsafe");
+    state->reset();
+    return run_root_guard_manager(root, f_locals);
+  }
+  if (root == nullptr) {
+    record_guard_last_success_incomplete("null_root");
+    state->reset();
+    return run_root_guard_manager(root, f_locals);
+  }
+
+  RootGuardManager* root_mgr = static_cast<RootGuardManager*>(root);
+  static const std::string self_source = "L['self']";
+
+  record_guard_last_success_actual_partial_attempt();
+  if (state->actual_partial.is_enabled_for(entry_key, root)) {
+    const bool collect_stats = guard_lookup_stats_enabled();
+    const uint64_t token_start_ns =
+        collect_stats ? guard_lookup_time_ns() : 0;
+    const bool partial_match = guard_last_success_actual_partial_tokens_match(
+        state->actual_partial, f_locals, collect_stats);
+    const uint64_t token_check_ns =
+        collect_stats ? guard_lookup_time_ns() - token_start_ns : 0;
+    if (partial_match) {
+      const uint64_t residual_start_ns =
+          collect_stats ? guard_lookup_time_ns() : 0;
+      const bool residual_result =
+          root_mgr->check_nopybind_skipping_source(f_locals, self_source);
+      const uint64_t residual_ns =
+          collect_stats ? guard_lookup_time_ns() - residual_start_ns : 0;
+      if (residual_result) {
+        record_guard_last_success_actual_partial_hit(
+            token_check_ns, residual_ns);
+      } else {
+        record_guard_last_success_actual_partial_residual_fail(
+            token_check_ns, residual_ns);
+      }
+      return residual_result;
+    }
+    record_guard_last_success_actual_partial_miss(token_check_ns);
+    state->actual_partial.reset();
+  }
+
+  if (!state->actual_partial.should_train() &&
+      !guard_last_success_shadow_enabled()) {
+    return run_root_guard_manager(root, f_locals);
+  }
+
+  GuardSubtreeMemoSupportAnalysis partial_analysis;
+  partial_analysis.collect_all = guard_lookup_stats_enabled();
+  const bool should_train_partial = state->actual_partial.should_train();
+  int self_framelocals_index = -1;
+  const bool partial_supported = should_train_partial &&
+      root_mgr->supports_accessor_subtree_memo_recursive(
+          self_source, &partial_analysis, &self_framelocals_index);
+  if (!partial_supported && should_train_partial) {
+    state->actual_partial.disable();
+    record_guard_last_success_actual_partial_disabled();
+    if (guard_lookup_stats_enabled()) {
+      std::lock_guard<std::mutex> lock(
+          guard_last_success_disabled_stats_mutex());
+      record_guard_last_success_disabled_item_locked(
+          partial_analysis.reason.empty()
+              ? "actual_partial_unsupported"
+              : partial_analysis.reason.c_str(),
+          partial_analysis.path.empty() ? self_source : partial_analysis.path);
+    }
+  }
+
+  if (!partial_supported && !guard_last_success_shadow_enabled()) {
+    return run_root_guard_manager(root, f_locals);
+  }
+
+  std::vector<GuardSubtreeEntryToken> tokens;
+  std::vector<std::string> debug_paths;
+  {
+    // The recorder deliberately disables nested manager fastplan so it can
+    // observe the full guard tree. Actual fast path uses the strict tokens;
+    // diagnostics derive a relaxed copy below.
+    GuardSubtreeMemoRecorderScope recorder(&tokens, &debug_paths);
+    const bool result = run_root_guard_manager(root, f_locals);
+    if (!result) {
+      state->reset();
+      return false;
+    }
+  }
+  if (debug_paths.size() != tokens.size()) {
+    debug_paths.clear();
+  }
+
+  if (tokens.empty()) {
+    record_guard_last_success_incomplete("empty_receipt");
+    state->reset();
+    return true;
+  }
+  if (tokens.size() > kGuardLastSuccessShadowMaxTokens) {
+    record_guard_last_success_incomplete(
+        "token_cap_exceeded", "L", tokens.size());
+    state->reset();
+    return true;
+  }
+
+  const uint64_t partial_train_start_ns =
+      guard_lookup_stats_enabled() ? guard_lookup_time_ns() : 0;
+  GuardLastSuccessPartialPlanBuild partial_build;
+  bool partial_disabled_now = false;
+  const bool actual_partial_supported = should_train_partial &&
+      partial_supported &&
+      guard_last_success_prepare_actual_partial(
+          &state->actual_partial,
+          f_locals,
+          self_framelocals_index,
+          tokens,
+          debug_paths,
+          partial_build);
+  if (actual_partial_supported) {
+    record_guard_last_success_actual_partial_hot_token_duplicate_stats(
+        partial_build.hot_tokens);
+    record_guard_last_success_actual_partial_hot_tokens(
+        partial_build.hot_tokens.size());
+    if (state->actual_partial.observe_successful_training_pass(
+            entry_key,
+            root,
+            std::move(partial_build.stability_tokens),
+            std::move(partial_build.hot_tokens))) {
+      record_guard_last_success_actual_partial_enable();
+    }
+  } else if (should_train_partial && partial_supported) {
+    state->actual_partial.disable();
+    partial_disabled_now = true;
+    record_guard_last_success_actual_partial_disabled();
+  }
+  record_guard_last_success_actual_partial_train(
+      guard_lookup_stats_enabled()
+          ? guard_lookup_time_ns() - partial_train_start_ns
+          : 0);
+
+  if (guard_last_success_shadow_enabled()) {
+    std::vector<GuardSubtreeEntryToken> diagnostic_tokens =
+        guard_last_success_make_diagnostic_tokens(tokens, debug_paths);
+    const uint64_t update_start_ns = guard_lookup_time_ns();
+    bool stable = false;
+    bool reset_state = false;
+    uint64_t compare_ns = 0;
+    const uint64_t shadow_passes = state->update(
+        entry_key,
+        root,
+        std::move(diagnostic_tokens),
+        std::move(debug_paths),
+        stable,
+        reset_state,
+        compare_ns);
+    const uint64_t update_ns = guard_lookup_time_ns() - update_start_ns;
+    if (stable) {
+      record_guard_last_success_shadow_stable();
+    }
+    if (reset_state) {
+      record_guard_last_success_shadow_reset();
+    }
+    record_guard_last_success_shadow_success(
+        state->tokens.size(), update_ns, compare_ns, shadow_passes);
+  }
+  if (partial_disabled_now && guard_lookup_stats_enabled()) {
+    std::lock_guard<std::mutex> lock(
+        guard_last_success_disabled_stats_mutex());
+    record_guard_last_success_disabled_item_locked(
+        partial_build.disabled_reason.empty()
+            ? "actual_partial_unsupported"
+            : partial_build.disabled_reason.c_str(),
+        partial_build.disabled_path);
+  }
+  return true;
 }
 
 PyObject* torch_c_dynamo_guards_init() {
@@ -7824,6 +12863,11 @@ PyObject* torch_c_dynamo_guards_init() {
       py::arg("symbolic") = true);
   py_m.def("install_symbolic_shape_guard", install_symbolic_shape_guard);
   py_m.def("profile_guard_manager", profile_guard_manager);
+  py_m.def(
+      "reset_guard_lookup_stats",
+      &reset_guard_lookup_stats,
+      py::arg("force_enable") = false);
+  py_m.def("get_guard_lookup_stats", get_guard_lookup_stats);
 
 // initialize dict_version_map watcher for 3.12
 #if IS_PYTHON_3_12_PLUS

--- a/torch/csrc/dynamo/guards.h
+++ b/torch/csrc/dynamo/guards.h
@@ -4,6 +4,8 @@
 #include <torch/csrc/python_headers.h>
 #include <torch/csrc/utils/pybind.h>
 
+#include <cstdint>
+
 namespace torch::dynamo {
 
 PyObject* torch_c_dynamo_guards_init();
@@ -12,6 +14,37 @@ PyObject* torch_c_dynamo_guards_init();
 // not visible there.
 void* convert_to_root_guard_manager(py::object root);
 bool run_root_guard_manager(void* root, FrameLocalsMapping* f_locals);
+bool run_root_guard_manager_with_last_success_receipt(
+    void* receipt,
+    void* entry_key,
+    void* root,
+    FrameLocalsMapping* f_locals,
+    bool is_skip_guard_eval_unsafe);
+
+bool guard_lookup_stats_enabled();
+bool unsafe_mock_guard_bypass_enabled();
+uint64_t guard_lookup_time_ns();
+void reset_guard_lookup_stats(bool force_enable = false);
+py::dict get_guard_lookup_stats();
+void record_guard_lookup_stats(
+    uint64_t total_ns,
+    uint64_t backend_match_ns,
+    uint64_t slow_guard_ns,
+    uint64_t move_to_front_ns,
+    uint64_t cache_entry_count,
+    uint64_t cache_entry_hit_index);
+void record_root_guard_stats(
+    uint64_t total_ns,
+    uint64_t lock_ns,
+    uint64_t local_state_ns,
+    uint64_t leaf_ns,
+    uint64_t accessor_ns,
+    uint64_t epilogue_ns,
+    uint64_t tls_ns);
+void record_unsafe_mock_guard_bypass_stats(uint64_t cache_entry_hit_index);
+void* create_guard_last_success_receipt();
+void destroy_guard_last_success_receipt(void* receipt);
+void reset_guard_last_success_receipt(void* receipt);
 
 extern thread_local bool tls_is_in_mode_without_ignore_compile_internals;
 
@@ -93,6 +126,14 @@ class TensorCheck {
       const LocalState& state,
       const at::Tensor& v,
       const std::string& tensor_name);
+
+  const std::vector<std::optional<c10::SymInt>>& sizes() const {
+    return sizes_;
+  }
+
+  const std::vector<std::optional<c10::SymInt>>& strides() const {
+    return strides_;
+  }
 
   PyTypeObject* pytype;
 


### PR DESCRIPTION
## Summary

Port the historical guard Fast Plan behavior from `9163ffcaa12e2efa6d19869fb9a25616b4c36961` onto the PyTorch 2.10 guard manager.

The port preserves the requested 9163ffc functional point—lookup statistics, last-success receipt training, nested-module planning, tensor token checks, and slow-guard fallback—while intentionally excluding post-9163 hardening.

## Changes

- add optional guard lookup/root timing statistics and a JSON microbenchmark
- cache the last successful guard receipt and execute trained nested Fast Plans with full-guard fallback
- adapt tensor/accessor token validation and ExtraState lifecycle handling to the 2.10 APIs
- add focused positive, negative, fallback, feature-off, and statistics-schema coverage

## Test Plan

- AArch64 CPU-only Release build
- focused historical contract groups: 36/36 passed
- full `test/dynamo/test_guard_manager.py` with Fast Plan and lookup stats unset: 74 passed, 1 expected CUDA skip
- same-build Stats-OFF Fast Plan A/B: 20/20 actual-partial hits and zero misses
- `git diff --check 449b1768410104d3ed79d3bcfe4ba1d65c7f22c0..HEAD`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98