### PR TITLE
[inductor] Skip configs that raise CompilationError in _precompile_worker

### DIFF
--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -46,6 +46,7 @@ from torch._inductor.runtime.hints import (
     TRITON_MAX_BLOCK,
     TRITON_MAX_TENSOR_NUMEL,
 )
+from torch._inductor.runtime.triton_compat import CompilationError
 from torch._inductor.runtime.triton_helpers import math as tl_math
 from torch._inductor.runtime.triton_heuristics import (
     _check_max_grid_x,
@@ -60,6 +61,7 @@ from torch._inductor.runtime.triton_heuristics import (
     check_autotune_cache,
     DEFER,
     make_matmul_triton_config,
+    NoTritonConfigsError,
     template,
     triton_config,
 )
@@ -407,6 +409,25 @@ class TestTritonHeuristics(TestCase):
             CachingAutotuner(**args)
 
     @skipUnless(HAS_GPU_AND_TRITON, "requires gpu and triton")
+    def test_precompile_worker_catches_compilation_error(self):
+        # https://github.com/pytorch/pytorch/issues/190002: a config whose
+        # generated Triton fails to compile raised CompilationError out of
+        # _precompile_worker (crashing cold AOT precompile) instead of being
+        # skipped like OutOfResources/PTXASError. With every config failing, the
+        # worker should surface the regular NoTritonConfigsError rather than the
+        # raw CompilationError.
+        args = self._get_cos_kernel_caching_autotuner_args()
+        autotuner = CachingAutotuner(**args)
+
+        def raise_compilation_error(self, cfg):
+            raise CompilationError("shape mismatch in generated triton")
+
+        with patch.object(
+            CachingAutotuner, "_precompile_config", raise_compilation_error
+        ):
+            with self.assertRaises(NoTritonConfigsError):
+                autotuner._precompile_worker()
+
     def test_autotune_hints_to_configs(self):
         device_props = DeviceProperties.create(torch.device(GPU_TYPE))
         device_props = device_props._replace(warp_size=8)

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, patch, PropertyMock
 
 import torch
 from torch._dynamo.testing import rand_strided
-from torch._inductor.runtime.triton_compat import HAS_WARP_SPEC
+from torch._inductor.runtime.triton_compat import CompilationError, HAS_WARP_SPEC
 from torch._inductor.utils import clone_preserve_strides
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
@@ -46,7 +46,6 @@ from torch._inductor.runtime.hints import (
     TRITON_MAX_BLOCK,
     TRITON_MAX_TENSOR_NUMEL,
 )
-from torch._inductor.runtime.triton_compat import CompilationError
 from torch._inductor.runtime.triton_helpers import math as tl_math
 from torch._inductor.runtime.triton_heuristics import (
     _check_max_grid_x,
@@ -427,6 +426,26 @@ class TestTritonHeuristics(TestCase):
         ):
             with self.assertRaises(NoTritonConfigsError):
                 autotuner._precompile_worker()
+
+    @skipUnless(HAS_GPU_AND_TRITON, "requires gpu and triton")
+    def test_precompile_worker_skips_bad_config_keeps_good(self):
+        # A CompilationError on one config must not sink the others: the
+        # regression in #190002 is that the *first* invalid config aborted the
+        # whole precompile even though a later config was perfectly fine.
+        args = self._get_cos_kernel_caching_autotuner_args()
+        autotuner = CachingAutotuner(**args)
+        bad_config = args["configs"][0]
+        good_result = MagicMock()
+
+        def precompile_config(self, cfg):
+            if cfg is bad_config:
+                raise CompilationError("shape mismatch in generated triton")
+            return good_result
+
+        with patch.object(CachingAutotuner, "_precompile_config", precompile_config):
+            autotuner._precompile_worker()
+
+        self.assertEqual(autotuner.compile_results, [good_result])
 
     def test_autotune_hints_to_configs(self):
         device_props = DeviceProperties.create(torch.device(GPU_TYPE))

--- a/torch/_inductor/runtime/triton_compat.py
+++ b/torch/_inductor/runtime/triton_compat.py
@@ -98,6 +98,13 @@ if triton is not None:
         class IntelGPUError(Exception):  # type: ignore[no-redef]
             pass
 
+    try:
+        from triton.compiler.errors import CompilationError
+    except ImportError:
+
+        class CompilationError(Exception):  # type: ignore[no-redef]
+            pass
+
     builtins_use_semantic_kwarg = (
         "_semantic" in inspect.signature(triton.language.core.view).parameters
     )
@@ -114,6 +121,9 @@ else:
         pass
 
     class IntelGPUError(Exception):  # type: ignore[no-redef]
+        pass
+
+    class CompilationError(Exception):  # type: ignore[no-redef]
         pass
 
     Config = object
@@ -163,6 +173,7 @@ __all__ = [
     "KernelInterface",
     "PTXASError",
     "IntelGPUError",
+    "CompilationError",
     "ASTSource",
     "GPUTarget",
     "tl",

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -88,6 +88,7 @@ from .static_triton_launcher import (
 from .triton_compat import (
     ASTSource,
     autograd_profiler,
+    CompilationError,
     CompiledKernel,
     Config,
     GPUTarget,
@@ -810,7 +811,7 @@ class CachingAutotuner(KernelInterface):
         for c in self.configs:
             try:
                 compile_results.append(self._precompile_config(c))
-            except (OutOfResources, PTXASError, IntelGPUError) as e:
+            except (OutOfResources, PTXASError, IntelGPUError, CompilationError) as e:
                 exc = e
         if len(compile_results) == 0:
             raise NoTritonConfigsError(

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -816,7 +816,7 @@ class CachingAutotuner(KernelInterface):
         if len(compile_results) == 0:
             raise NoTritonConfigsError(
                 f"No valid triton configs. {type(exc).__name__}: {exc}"
-            )
+            ) from exc
         self.compile_results = compile_results
         self.configs = None
 


### PR DESCRIPTION
Fixes #190002.

## Root cause
`_precompile_worker` (`torch/_inductor/runtime/triton_heuristics.py`) compiles every autotuning config ahead of time. Its per-config `except` caught `(OutOfResources, PTXASError, IntelGPUError)` but not Triton's `CompilationError`, so a config whose generated Triton is structurally invalid (e.g. a persistent-reduction/combo config with a `[XBLOCK, 1]` vs `[1, RBLOCK]` shape mismatch) propagated out and aborted the whole precompile.

During a normal `torch.compile` run a working config is selected and the bad one is only compiled lazily, so it never surfaces; on cold import of AOT-serialized code every config is compiled up front and the first invalid one crashes the load.

## Fix
Export `CompilationError` from `triton_compat` (imported from `triton.compiler.errors` with a fallback stub, mirroring `PTXASError`/`IntelGPUError`) and add it to the caught tuple. A bad config is then skipped and the existing "no valid configs" handling only raises `NoTritonConfigsError` when *all* configs fail.

## Test
Added `test_precompile_worker_catches_compilation_error`, which patches `_precompile_config` to raise `CompilationError` for every config and asserts `_precompile_worker` surfaces `NoTritonConfigsError` rather than the raw error.

```
python test/inductor/test_triton_heuristics.py -k test_precompile_worker_catches_compilation_error
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo