### PR TITLE
[TEST] Refactor test_functional_api.py with hw_classification and instantiate_parametrized_tests

### DIFF
--- a/test/distributed/test_functional_api.py
+++ b/test/distributed/test_functional_api.py
@@ -27,50 +27,13 @@ from torch.testing._internal.common_distributed import (
     TEST_SKIPS,
 )
 from torch.testing._internal.common_utils import (
-    instantiate_parametrized_tests,
+    HardwareClassification,
     IS_LINUX,
-    parametrize,
     run_tests,
     skipIfHpu,
-    TEST_CUDA,
-    TEST_HPU,
     TEST_WITH_ROCM,
-    TEST_XPU,
     TestCase,
 )
-
-
-# NOTE: Instructions for adding new device types to this test file
-#
-# This test file contains two types of tests:
-# 1. Tests that run on both CPUs and accelerators
-# 2. Tests that run only on accelerators
-#
-# We use two variables to manage device types:
-# - `devices`: A list containing device types for both CPU and accelerator tests
-# - `DEVICE`: A string containing only the accelerator type for accelerator-only tests
-#
-# To add a new device type:
-# 1. Add a new `elif` statement in the if-else ladder below
-# 2. Check for the presence of your device (e.g., TEST_NEW_DEVICE)
-# 3. Append your device type to the `devices` list
-# 4. Assign your device type string to `DEVICE`
-#
-# Example:
-# elif TEST_NEW_DEVICE:
-#     devices.append("new_device")
-#     DEVICE = "new_device"
-
-DEVICE = "cuda"
-devices = ["cpu"]
-if TEST_HPU:
-    devices.append("hpu")
-    DEVICE = "hpu"
-elif TEST_XPU:
-    devices.append("xpu")
-    DEVICE = "xpu"
-elif TEST_CUDA:
-    devices.append("cuda")
 
 
 def new_subgroups(group_size: int, pg_tag=None):
@@ -97,6 +60,8 @@ def new_subgroups(group_size: int, pg_tag=None):
 
 @skipIfHpu
 class TestExpand(MultiThreadedTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @property
     def world_size(self):
         return 4
@@ -187,6 +152,8 @@ class TestExpand(MultiThreadedTestCase):
 
 @skipIfHpu
 class TestPgTag(MultiThreadedTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @property
     def world_size(self):
         return 4
@@ -264,9 +231,10 @@ class TestPgTag(MultiThreadedTestCase):
         self.assertEqual(dist.group.WORLD, pg)
 
 
-@instantiate_parametrized_tests
 @skipIfHpu
 class TestTraceableCollectives(MultiThreadedTestCase):
+    hw_classification = HardwareClassification.MULTI_ACCELERATOR
+
     @property
     def world_size(self):
         return 4
@@ -275,7 +243,6 @@ class TestTraceableCollectives(MultiThreadedTestCase):
         super().setUp()
         self._spawn_threads()
 
-    @parametrize("device", devices)
     def test_broadcast(self, device):
         if device != "cpu":
             if torch.accelerator.device_count() < self.world_size:
@@ -291,7 +258,6 @@ class TestTraceableCollectives(MultiThreadedTestCase):
         res = ft_c.broadcast(tensor, 0, mesh)
         self.assertEqual(res, torch.ones([4], device=device))
 
-    @parametrize("device", devices)
     def test_all_reduce_eager(self, device):
         if device != "cpu":
             if torch.accelerator.device_count() < self.world_size:
@@ -308,7 +274,6 @@ class TestTraceableCollectives(MultiThreadedTestCase):
         res2 = ft_c.all_reduce(tensor, "sum", (mesh, 1))
         self.assertEqual(res2, torch.tensor([2, 2, 2, 2], dtype=torch.float))
 
-    @parametrize("device", devices)
     def test_all_reduce_coalesced_eager(self, device):
         if device != "cpu":
             if torch.accelerator.device_count() < self.world_size:
@@ -323,7 +288,6 @@ class TestTraceableCollectives(MultiThreadedTestCase):
         self.assertEqual(res[0], t0 * 4)
         self.assertEqual(res[1], t1 * 4)
 
-    @parametrize("device", devices)
     def test_all_gather_tensor(self, device):
         if device != "cpu":
             if torch.accelerator.device_count() < self.world_size:
@@ -345,7 +309,6 @@ class TestTraceableCollectives(MultiThreadedTestCase):
                 )
                 self.assertEqual(gathered_tensor, torch.ones(output_size))
 
-    @parametrize("device", devices)
     def test_all_gather_into_tensor_coalesced(self, device):
         if device != "cpu":
             if torch.accelerator.device_count() < self.world_size:
@@ -362,7 +325,6 @@ class TestTraceableCollectives(MultiThreadedTestCase):
             torch.ones([4 * dist.get_world_size()], device=device) + 1, res[1]
         )
 
-    @parametrize("device", devices)
     def test_reduce_scatter_tensor(self, device):
         if device != "cpu":
             if torch.accelerator.device_count() < self.world_size:
@@ -386,7 +348,6 @@ class TestTraceableCollectives(MultiThreadedTestCase):
                 )
                 self.assertEqual(rs_tensor, torch.ones(input_size) * res_num)
 
-    @parametrize("device", devices)
     def test_reduce_scatter_into_tensor_coalesced(self, device):
         if device != "cpu":
             if torch.accelerator.device_count() < self.world_size:
@@ -405,6 +366,8 @@ class TestTraceableCollectives(MultiThreadedTestCase):
 
 
 class TestMetaCollectives(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_all_reduce(self):
         x = torch.rand((2, 3, 4), device="meta")
         out = ft_c.all_reduce(x, "sum", "0")
@@ -413,6 +376,8 @@ class TestMetaCollectives(TestCase):
 
 @skipIfHpu
 class TestGradCollectives(MultiThreadedTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @property
     def world_size(self):
         return 2
@@ -430,6 +395,8 @@ class TestGradCollectives(MultiThreadedTestCase):
 
 
 class TestMakeFx(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         # make_fx is not thread-safe due to patching nd mutating global states
@@ -477,6 +444,8 @@ class TestAllGatherViewOptimization(TestCase):
     """Validate that all_gather_tensor delays wait() when the view optimization
     applies and calls wait() early when the fallback path is needed."""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self.world_size = 4
@@ -510,21 +479,7 @@ class TestAllGatherViewOptimization(TestCase):
         self.assertNotIsInstance(res, ft_c.AsyncCollectiveTensor)
 
 
-BACKEND = dist.Backend.NCCL if torch.cuda.is_available() else dist.Backend.GLOO
-
-# Adding support for HCCL backend
-# To add a different backend
-# add an elif to the same chain with a conditional checking for the device type (along the lines of TEST_HPU or TEST_CUDA)
-# And then set the BACKEND variable appropriately.
-if TEST_HPU:
-    BACKEND = dist.Backend.HCCL
-elif TEST_XPU:
-    BACKEND = dist.Backend.XCCL
-
-
-# allows you to check for multiple accelerator irrespective of device type
-# to add new device types to this check simply follow the same format
-# and append an elif with the conditional and appropriate device count function for your new device
+# Allows checking for multiple accelerators irrespective of device type.
 def exit_if_lt_x_accelerators(x):
     if torch.accelerator.is_available():
         if torch.accelerator.device_count() < x:
@@ -537,13 +492,15 @@ def with_comms(func=None):
 
     @wraps(func)
     def wrapper(self, *args, **kwargs):
+        device = self.device_type
+        backend = self.backend(device)
         if (
-            BACKEND == dist.Backend.NCCL or BACKEND == dist.Backend.XCCL
+            "nccl" in backend or "xccl" in backend
         ) and torch.accelerator.device_count() < self.world_size:
             sys.exit(TEST_SKIPS[f"multi-gpu-{self.world_size}"].exit_code)
 
-        kwargs["device"] = DEVICE
-        self.pg = self.create_pg(device=DEVICE)
+        kwargs["device"] = device
+        self.pg = self.create_pg(device=device)
         try:
             return func(self, *args, **kwargs)
         finally:
@@ -553,6 +510,8 @@ def with_comms(func=None):
 
 
 class TestCollectivesWithDistributedBackend(DistributedTestBase):
+    hw_classification = HardwareClassification.MULTI_ACCELERATOR
+
     @with_comms()
     def test_all_gather_into_tensor_coalesced(self, device):
         exit_if_lt_x_accelerators(self.world_size)
@@ -627,7 +586,7 @@ class TestCollectivesWithDistributedBackend(DistributedTestBase):
         compiled_allreduce(torch.randn(8, device=device), self.pg)
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
-    def test_tracing_with_fakepg(self, device=DEVICE):
+    def test_tracing_with_fakepg(self, device):
         exit_if_lt_x_accelerators(self.world_size)
 
         def allreduce(t, pg):
@@ -666,6 +625,8 @@ class TestCollectivesWithDistributedBackend(DistributedTestBase):
 class TestDistributedBackendCollectivesWithWorldSize4(
     TestCollectivesWithDistributedBackend
 ):
+    hw_classification = HardwareClassification.MULTI_ACCELERATOR
+
     @property
     def world_size(self):
         return 4
@@ -700,6 +661,8 @@ class TestDistributedBackendCollectivesWithWorldSize4(
 
 
 class TestFunctionalAutograd(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self.world_size = 2
@@ -795,6 +758,8 @@ class TestFunctionalAutograd(TestCase):
 
 
 class TestFunctionalAutogradWithDistributedBackend(DistributedTestBase):
+    hw_classification = HardwareClassification.MULTI_ACCELERATOR
+
     @with_comms()
     def test_all_to_all_single(self, device) -> None:
         group = self.pg
@@ -814,21 +779,18 @@ class TestFunctionalAutogradWithDistributedBackend(DistributedTestBase):
         self.assertEqual(t.grad, torch.full_like(t, 2.0))
 
 
-# Update the supported devices in DEVICE
+instantiate_device_type_tests(TestTraceableCollectives, globals())
 instantiate_device_type_tests(
-    TestCollectivesWithDistributedBackend, globals(), only_for=DEVICE, allow_xpu=True
-)
-instantiate_device_type_tests(
-    TestDistributedBackendCollectivesWithWorldSize4,
+    TestCollectivesWithDistributedBackend,
     globals(),
-    only_for=DEVICE,
+    except_for="cpu",
     allow_xpu=True,
 )
 instantiate_device_type_tests(
-    TestFunctionalAutogradWithDistributedBackend,
-    globals(),
-    only_for=DEVICE,
-    allow_xpu=True,
+    TestDistributedBackendCollectivesWithWorldSize4, globals(), except_for="cpu"
+)
+instantiate_device_type_tests(
+    TestFunctionalAutogradWithDistributedBackend, globals(), except_for="cpu"
 )
 
 if __name__ == "__main__":

--- a/test/distributed/test_multi_threaded_pg.py
+++ b/test/distributed/test_multi_threaded_pg.py
@@ -17,20 +17,26 @@ if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)
     sys.exit(0)
 
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import (
     MultiThreadedTestCase,
     skip_if_lt_x_gpu,
     spawn_threads_and_init_comms,
 )
-from torch.testing._internal.common_utils import IS_SANDCASTLE, run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    IS_SANDCASTLE,
+    run_tests,
+    TestCase,
+)
 
-
-device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
 
 DEFAULT_WORLD_SIZE = 4
 
 
 class TestCollectivesWithWrapper(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @spawn_threads_and_init_comms(world_size=4)
     def test_broadcast_object_list(self):
         val = 99 if dist.get_rank() == 0 else None
@@ -135,7 +141,9 @@ class TestCollectivesWithWrapper(TestCase):
         self.assertEqual(out.tolist(), list(zip(range(world_size), range(world_size))))
 
 
-class TestCollectivesWithBaseClass(MultiThreadedTestCase):
+class TestCollectivesWithBaseClassGeneric(MultiThreadedTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @property
     def world_size(self):
         return 4
@@ -301,6 +309,23 @@ class TestCollectivesWithBaseClass(MultiThreadedTestCase):
         self.assertEqual(t0, torch.ones(3, 3) * res_num)
         self.assertEqual(t1, torch.ones(3, 3) * (res_num * 2))
 
+
+class TestCollectivesWithBaseClassMultiAccelerator(MultiThreadedTestCase):
+    hw_classification = HardwareClassification.MULTI_ACCELERATOR
+
+    @property
+    def world_size(self):
+        return 4
+
+    def setUp(self):
+        os.environ["TORCH_DIST_INIT_BARRIER"] = "1"
+        super().setUp()
+        self._spawn_threads()
+
+    def tearDown(self):
+        super().tearDown()
+        os.environ["TORCH_DIST_INIT_BARRIER"] = "0"
+
     @skip_if_lt_x_gpu(1)
     def test_bwd_sees_fwd_pg(self):
         fwd_tid = threading.current_thread().ident
@@ -335,10 +360,22 @@ class TestCollectivesWithBaseClass(MultiThreadedTestCase):
                 return grad_output * result
 
         x = torch.tensor(
-            [dist.get_rank()], dtype=torch.float, device=device_type, requires_grad=True
+            [dist.get_rank()],
+            dtype=torch.float,
+            device=self.device_type,
+            requires_grad=True,
         )
         x = MyFunc.apply(x)
         x.sum().backward()
+
+
+instantiate_device_type_tests(
+    TestCollectivesWithBaseClassMultiAccelerator,
+    globals(),
+    except_for="cpu",
+    allow_mps=True,
+    allow_xpu=True,
+)
 
 
 if __name__ == "__main__":

--- a/test/distributed/test_multi_threaded_pg.py
+++ b/test/distributed/test_multi_threaded_pg.py
@@ -17,26 +17,20 @@ if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)
     sys.exit(0)
 
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import (
     MultiThreadedTestCase,
     skip_if_lt_x_gpu,
     spawn_threads_and_init_comms,
 )
-from torch.testing._internal.common_utils import (
-    HardwareClassification,
-    IS_SANDCASTLE,
-    run_tests,
-    TestCase,
-)
+from torch.testing._internal.common_utils import IS_SANDCASTLE, run_tests, TestCase
 
+
+device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
 
 DEFAULT_WORLD_SIZE = 4
 
 
 class TestCollectivesWithWrapper(TestCase):
-    hw_classification = HardwareClassification.GENERIC
-
     @spawn_threads_and_init_comms(world_size=4)
     def test_broadcast_object_list(self):
         val = 99 if dist.get_rank() == 0 else None
@@ -141,9 +135,7 @@ class TestCollectivesWithWrapper(TestCase):
         self.assertEqual(out.tolist(), list(zip(range(world_size), range(world_size))))
 
 
-class TestCollectivesWithBaseClassGeneric(MultiThreadedTestCase):
-    hw_classification = HardwareClassification.GENERIC
-
+class TestCollectivesWithBaseClass(MultiThreadedTestCase):
     @property
     def world_size(self):
         return 4
@@ -309,23 +301,6 @@ class TestCollectivesWithBaseClassGeneric(MultiThreadedTestCase):
         self.assertEqual(t0, torch.ones(3, 3) * res_num)
         self.assertEqual(t1, torch.ones(3, 3) * (res_num * 2))
 
-
-class TestCollectivesWithBaseClassMultiAccelerator(MultiThreadedTestCase):
-    hw_classification = HardwareClassification.MULTI_ACCELERATOR
-
-    @property
-    def world_size(self):
-        return 4
-
-    def setUp(self):
-        os.environ["TORCH_DIST_INIT_BARRIER"] = "1"
-        super().setUp()
-        self._spawn_threads()
-
-    def tearDown(self):
-        super().tearDown()
-        os.environ["TORCH_DIST_INIT_BARRIER"] = "0"
-
     @skip_if_lt_x_gpu(1)
     def test_bwd_sees_fwd_pg(self):
         fwd_tid = threading.current_thread().ident
@@ -360,22 +335,10 @@ class TestCollectivesWithBaseClassMultiAccelerator(MultiThreadedTestCase):
                 return grad_output * result
 
         x = torch.tensor(
-            [dist.get_rank()],
-            dtype=torch.float,
-            device=self.device_type,
-            requires_grad=True,
+            [dist.get_rank()], dtype=torch.float, device=device_type, requires_grad=True
         )
         x = MyFunc.apply(x)
         x.sum().backward()
-
-
-instantiate_device_type_tests(
-    TestCollectivesWithBaseClassMultiAccelerator,
-    globals(),
-    except_for="cpu",
-    allow_mps=True,
-    allow_xpu=True,
-)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Depends on [#190082](https://github.com/pytorch/pytorch/pull/190082).

Tagged the functional collective tests with `hw_classification`, and moved the device-portable multi-rank cases off the old `DEVICE`/`devices` ladder onto `instantiate_device_type_tests` / `self.device_type`.

### Classification

* **GENERIC** — FakePG / meta / threaded bookkeeping, no real accelerator collectives:
  * `TestExpand`, `TestPgTag`, `TestMetaCollectives`, `TestGradCollectives`, `TestMakeFx`, `TestAllGatherViewOptimization`, `TestFunctionalAutograd`
* **MULTI_ACCELERATOR** — real multi-rank collectives on device tensors:
  * `TestTraceableCollectives`
  * `TestCollectivesWithDistributedBackend`
  * `TestDistributedBackendCollectivesWithWorldSize4`
  * `TestFunctionalAutogradWithDistributedBackend`

### Changes

* Added `hw_classification` on every test class.
* `TestTraceableCollectives` no longer uses `@parametrize("device", devices)` / `instantiate_parametrized_tests`. It goes through `instantiate_device_type_tests` now (CPU + accelerators), still with the same `device` parameter.
* `@with_comms` now pulls `self.device_type` and `self.backend(device)` instead of the module-level `DEVICE` / `BACKEND`.
* Removed the unused `DEVICE`/`devices` ladder and `BACKEND` block.
* Distributed-backend classes use `instantiate_device_type_tests(..., except_for="cpu", allow_xpu=True)` instead of `only_for=DEVICE`. Kept `allow_xpu=True` since XPU was already covered when `DEVICE` was `"xpu"`.

### Test plan
```bash
python test/distributed/test_functional_api.py -v
python test/distributed/test_functional_api.py --hw-classification GENERIC -v
python test/distributed/test_functional_api.py --hw-classification MULTI_ACCELERATOR -v
```

CC: @mansiag05, @vishalgoyal316, @RiyaP2508  