### PR TITLE
[WIP][inductor] Scalar accumulators for looped Triton reductions

### DIFF
--- a/test/inductor/test_online_softmax.py
+++ b/test/inductor/test_online_softmax.py
@@ -64,6 +64,50 @@ class TestOnlineSoftmax(TestCase):
     def test_prepare_softmax_perf(self):
         self.do_test_acc_and_perf(_prepare_softmax)
 
+    @inductor_config.patch(
+        {
+            "triton.persistent_reductions": False,
+            "split_reductions": False,
+        }
+    )
+    def test_scalar_online_softmax_masked_padding(self):
+        if GPU_TYPE != "cuda" or torch.version.hip is not None:
+            self.skipTest("scalar online-softmax accumulators are CUDA-only")
+
+        def f(x):
+            return _prepare_softmax(x, dim=-1)
+
+        x = torch.full((1, 8193), float("-inf"), dtype=torch.float32, device=GPU_TYPE)
+        with inductor_config.patch("triton.scalar_online_softmax_accumulators", False):
+            vector_result, (vector_code,) = run_and_get_code(torch.compile(f), x)
+
+        with inductor_config.patch("triton.scalar_online_softmax_accumulators", True):
+            scalar_result, (scalar_code,) = run_and_get_code(torch.compile(f), x)
+
+        for scalar, vector in zip(scalar_result, vector_result):
+            torch.testing.assert_close(scalar, vector, equal_nan=True)
+        self.assertTrue(torch.isneginf(scalar_result[0]).all())
+        self.assertNotIn("online_softmax_reduce_scalar_combine", vector_code)
+        self.assertIn("online_softmax_reduce_scalar_combine", scalar_code)
+
+    @inductor_config.patch(
+        {
+            "triton.persistent_reductions": False,
+            "split_reductions": False,
+            "triton.scalar_online_softmax_accumulators": False,
+        }
+    )
+    def test_scalar_online_softmax_disabled(self):
+        if GPU_TYPE != "cuda" or torch.version.hip is not None:
+            self.skipTest("scalar online-softmax accumulators are CUDA-only")
+
+        x = torch.randn(1024, 8192, dtype=torch.float32, device=GPU_TYPE)
+        act, (code,) = run_and_get_code(torch.compile(_prepare_softmax), x, -1)
+
+        self.assertTrue(same(_prepare_softmax(x, -1), act, tol=1e-3))
+        self.assertIn("online_softmax_combine(", code)
+        self.assertNotIn("online_softmax_reduce_scalar_combine", code)
+
     def get_softmax_wrapper(self, V=50304, use_log_softmax=False, device=GPU_TYPE):
         N = 32 * 1024
 
@@ -122,6 +166,368 @@ class TestOnlineSoftmax(TestCase):
         """
         wrapper_code = self.get_softmax_wrapper(1024)
         self.assertEqual(wrapper_code.count("for r0_offset in"), 0)
+
+    @inductor_config.patch(
+        {
+            "triton.persistent_reductions": False,
+            "split_reductions": False,
+            "triton.scalar_online_softmax_accumulators": True,
+        }
+    )
+    def test_scalar_online_softmax_skips_plain_sum(self):
+        if GPU_TYPE != "cuda" or torch.version.hip is not None:
+            self.skipTest("scalar online-softmax accumulators are CUDA-only")
+
+        def f(x):
+            return x.sum(dim=-1)
+
+        x = torch.randn(1024, 8192, dtype=torch.float32, device=GPU_TYPE)
+        act, (code,) = run_and_get_code(torch.compile(f), x)
+
+        self.assertTrue(same(f(x), act, tol=1e-3))
+        self.assertEqual(code.count("for r0_offset in"), 1)
+        self.assertIn("tl.full([XBLOCK, R0_BLOCK]", code)
+        self.assertIn("tl.sum(_tmp", code)
+
+    @inductor_config.patch(
+        {
+            "triton.persistent_reductions": False,
+            "split_reductions": False,
+            "triton.scalar_online_softmax_accumulators": True,
+        }
+    )
+    def test_scalar_online_softmax_skips_50k_reduction_bucket(self):
+        if GPU_TYPE != "cuda" or torch.version.hip is not None:
+            self.skipTest("scalar online-softmax accumulators are CUDA-only")
+
+        x = torch.randn(4, 50005, dtype=torch.float32, device=GPU_TYPE)
+        act, (code,) = run_and_get_code(torch.compile(_prepare_softmax), x, -1)
+
+        self.assertTrue(same(_prepare_softmax(x, -1), act, tol=1e-3))
+        self.assertIn("online_softmax_combine(", code)
+        self.assertNotIn("online_softmax_reduce_scalar_combine", code)
+
+    @inductor_config.patch(
+        {
+            "triton.persistent_reductions": False,
+            "split_reductions": False,
+            "triton.scalar_online_softmax_accumulators": True,
+        }
+    )
+    def test_scalar_online_softmax_skips_small_reduction(self):
+        if GPU_TYPE != "cuda" or torch.version.hip is not None:
+            self.skipTest("scalar online-softmax accumulators are CUDA-only")
+
+        def f(a, b):
+            return _prepare_softmax(a + b, -1)
+
+        args = [
+            torch.randn(128, 1024, dtype=torch.float32, device=GPU_TYPE)
+            for _ in range(2)
+        ]
+        act, (code,) = run_and_get_code(torch.compile(f), *args)
+
+        ref = f(*args)
+        for expected, actual in zip(ref, act):
+            torch.testing.assert_close(expected, actual, rtol=1e-3, atol=1e-3)
+        self.assertIn("online_softmax_combine(", code)
+        self.assertNotIn("online_softmax_reduce_scalar_combine", code)
+
+    @inductor_config.patch(
+        {
+            "triton.persistent_reductions": False,
+            "split_reductions": False,
+            "triton.scalar_online_softmax_accumulators": True,
+        }
+    )
+    def test_scalar_online_softmax_skips_outer_reduction(self):
+        if GPU_TYPE != "cuda" or torch.version.hip is not None:
+            self.skipTest("scalar online-softmax accumulators are CUDA-only")
+
+        def f(x):
+            return _prepare_softmax(x, 0)
+
+        x = torch.randn(8192, 128, dtype=torch.float32, device=GPU_TYPE)
+        act, (code,) = run_and_get_code(torch.compile(f), x)
+
+        ref = f(x)
+        for expected, actual in zip(ref, act):
+            torch.testing.assert_close(expected, actual, rtol=1e-3, atol=1e-3)
+        self.assertIn("online_softmax_combine(", code)
+        self.assertNotIn("online_softmax_reduce_scalar_combine", code)
+
+    @inductor_config.patch(
+        {
+            "triton.persistent_reductions": False,
+            "split_reductions": False,
+            "triton.scalar_online_softmax_accumulators": True,
+        }
+    )
+    def test_scalar_online_softmax_allows_three_read_buffers(self):
+        if GPU_TYPE != "cuda" or torch.version.hip is not None:
+            self.skipTest("scalar online-softmax accumulators are CUDA-only")
+
+        def f(a, b, c):
+            return _prepare_softmax(a + b + c, -1)
+
+        args = [
+            torch.randn(128, 8192, dtype=torch.float32, device=GPU_TYPE)
+            for _ in range(3)
+        ]
+        act, (code,) = run_and_get_code(torch.compile(f), *args)
+
+        ref = f(*args)
+        for expected, actual in zip(ref, act):
+            torch.testing.assert_close(expected, actual, rtol=1e-3, atol=1e-3)
+        self.assertIn("online_softmax_reduce_scalar_combine", code)
+
+    @inductor_config.patch(
+        {
+            "triton.persistent_reductions": False,
+            "split_reductions": False,
+            "triton.scalar_online_softmax_accumulators": True,
+        }
+    )
+    def test_scalar_online_softmax_skips_many_read_buffers(self):
+        if GPU_TYPE != "cuda" or torch.version.hip is not None:
+            self.skipTest("scalar online-softmax accumulators are CUDA-only")
+
+        def f(a, b, c, d):
+            return _prepare_softmax(a + b + c + d, -1)
+
+        args = [
+            torch.randn(128, 8192, dtype=torch.float32, device=GPU_TYPE)
+            for _ in range(4)
+        ]
+        act, (code,) = run_and_get_code(torch.compile(f), *args)
+
+        ref = f(*args)
+        for expected, actual in zip(ref, act):
+            torch.testing.assert_close(expected, actual, rtol=1e-3, atol=1e-3)
+        self.assertIn("online_softmax_combine(", code)
+        self.assertNotIn("online_softmax_reduce_scalar_combine", code)
+
+    @inductor_config.patch(
+        {
+            "triton.persistent_reductions": False,
+            "split_reductions": False,
+            "triton.scalar_online_softmax_accumulators": True,
+        }
+    )
+    def test_scalar_online_softmax_allows_fused_gather(self):
+        if GPU_TYPE != "cuda" or torch.version.hip is not None:
+            self.skipTest("scalar online-softmax accumulators are CUDA-only")
+
+        def f(logits, target):
+            xmax, xsum = _prepare_softmax(logits, -1)
+            target_logit = logits.gather(-1, target[:, None])
+            return (xmax + xsum.log() - target_logit).squeeze(-1)
+
+        logits = torch.randn(128, 8192, dtype=torch.float32, device=GPU_TYPE)
+        target = torch.randint(0, 8192, (128,), dtype=torch.int64, device=GPU_TYPE)
+        act, (code,) = run_and_get_code(torch.compile(f), logits, target)
+
+        torch.testing.assert_close(f(logits, target), act, rtol=1e-3, atol=1e-3)
+        self.assertIn("online_softmax_reduce_scalar_combine", code)
+
+    @inductor_config.patch(
+        {
+            "triton.persistent_reductions": False,
+            "split_reductions": False,
+            "triton.scalar_online_softmax_accumulators": True,
+        }
+    )
+    def test_scalar_online_softmax_skips_materialized_reduction_outputs(self):
+        if GPU_TYPE != "cuda" or torch.version.hip is not None:
+            self.skipTest("scalar online-softmax accumulators are CUDA-only")
+
+        def f(x, bias):
+            logits = (x + bias).to(torch.bfloat16)
+            xmax, xsum = _prepare_softmax(logits.float(), -1)
+            log_probs = (logits.float() - xmax - xsum.log()).to(torch.bfloat16)
+            return logits, log_probs
+
+        x = torch.randn(128, 8192, dtype=torch.bfloat16, device=GPU_TYPE)
+        bias = torch.randn(8192, dtype=torch.float32, device=GPU_TYPE)
+        act, (code,) = run_and_get_code(torch.compile(f), x, bias)
+
+        ref = f(x, bias)
+        for expected, actual in zip(ref, act):
+            torch.testing.assert_close(expected, actual, rtol=1e-2, atol=1e-2)
+        self.assertIn("tl.full([XBLOCK, R0_BLOCK]", code)
+        self.assertNotIn("online_softmax_reduce_scalar_combine", code)
+
+    @inductor_config.patch(
+        {
+            "triton.persistent_reductions": False,
+            "split_reductions": False,
+            "triton.scalar_online_softmax_accumulators": True,
+        }
+    )
+    def test_scalar_online_softmax_skips_dynamic_materialized_reduction_outputs(self):
+        if GPU_TYPE != "cuda" or torch.version.hip is not None:
+            self.skipTest("scalar online-softmax accumulators are CUDA-only")
+
+        def f(x, bias):
+            logits = (x + bias).to(torch.bfloat16)
+            xmax, xsum = _prepare_softmax(logits.float(), -1)
+            log_probs = (logits.float() - xmax - xsum.log()).to(torch.bfloat16)
+            return logits, log_probs
+
+        x = torch.randn(128, 8192, dtype=torch.bfloat16, device=GPU_TYPE)
+        bias = torch.randn(8192, dtype=torch.float32, device=GPU_TYPE)
+        act, (code,) = run_and_get_code(torch.compile(f, dynamic=True), x, bias)
+
+        ref = f(x, bias)
+        for expected, actual in zip(ref, act):
+            torch.testing.assert_close(expected, actual, rtol=1e-2, atol=1e-2)
+        self.assertIn("tl.full([XBLOCK, R0_BLOCK]", code)
+        self.assertNotIn("online_softmax_reduce_scalar_combine", code)
+
+    @inductor_config.patch(
+        {
+            "triton.persistent_reductions": False,
+            "split_reductions": False,
+            "triton.scalar_online_softmax_accumulators": True,
+        }
+    )
+    def test_scalar_online_softmax_skips_tiny_reduction(self):
+        if GPU_TYPE != "cuda" or torch.version.hip is not None:
+            self.skipTest("scalar online-softmax accumulators are CUDA-only")
+
+        x = torch.randn(128, 2, dtype=torch.float32, device=GPU_TYPE)
+        act, (code,) = run_and_get_code(torch.compile(_prepare_softmax), x, -1)
+
+        self.assertTrue(same(_prepare_softmax(x, -1), act, tol=1e-3))
+        self.assertIn("prepare_softmax_online", code)
+        self.assertNotIn("online_softmax_reduce_scalar_combine", code)
+
+    @inductor_config.patch(
+        {
+            "triton.persistent_reductions": False,
+            "split_reductions": False,
+            "triton.scalar_online_softmax_accumulators": True,
+        }
+    )
+    def test_scalar_online_softmax_skips_dynamic_50k_reduction_bucket(self):
+        if GPU_TYPE != "cuda" or torch.version.hip is not None:
+            self.skipTest("scalar online-softmax accumulators are CUDA-only")
+
+        opt_f = torch.compile(_prepare_softmax, dynamic=True)
+        x = torch.randn(4, 50005, dtype=torch.float32, device=GPU_TYPE)
+        act, (code,) = run_and_get_code(opt_f, x, -1)
+
+        self.assertTrue(same(_prepare_softmax(x, -1), act, tol=1e-3))
+        self.assertIn("prepare_softmax_online", code)
+        self.assertNotIn("online_softmax_reduce_scalar_combine", code)
+
+        # Dynamic scalar accumulation is deliberately disabled. Confirm that a
+        # graph first compiled in an otherwise eligible bucket remains safe
+        # when reused in the excluded 50k bucket.
+        torch._dynamo.reset()
+        compile_counter = torch._dynamo.testing.CompileCounterWithBackend("inductor")
+        opt_f = torch.compile(
+            _prepare_softmax, backend=compile_counter, dynamic=True
+        )
+        x = torch.randn(4, 8192, dtype=torch.float32, device=GPU_TYPE)
+        act, (code,) = run_and_get_code(opt_f, x, -1)
+        self.assertTrue(same(_prepare_softmax(x, -1), act, tol=1e-3))
+        self.assertNotIn("online_softmax_reduce_scalar_combine", code)
+        self.assertEqual(compile_counter.frame_count, 1)
+
+        x = torch.randn(4, 50005, dtype=torch.float32, device=GPU_TYPE)
+        act = opt_f(x, -1)
+        self.assertTrue(same(_prepare_softmax(x, -1), act, tol=1e-3))
+        self.assertEqual(compile_counter.frame_count, 1)
+
+    @inductor_config.patch(
+        {
+            "triton.persistent_reductions": False,
+            "split_reductions": False,
+            "triton.scalar_online_softmax_accumulators": True,
+        }
+    )
+    def test_scalar_online_softmax_supports_large_reductions(self):
+        if GPU_TYPE != "cuda" or torch.version.hip is not None:
+            self.skipTest("scalar online-softmax accumulators are CUDA-only")
+
+        x = torch.randn(4, 2**20 + 13, dtype=torch.float32, device=GPU_TYPE)
+        act, (code,) = run_and_get_code(torch.compile(_prepare_softmax), x, -1)
+
+        self.assertTrue(same(_prepare_softmax(x, -1), act, tol=1e-3))
+        self.assertIn("online_softmax_reduce_scalar_combine", code)
+
+    @inductor_config.patch(
+        {
+            "triton.persistent_reductions": False,
+            "split_reductions": False,
+            "triton.scalar_online_softmax_accumulators": True,
+        }
+    )
+    def test_scalar_online_softmax_skips_extra_reductions(self):
+        if GPU_TYPE != "cuda" or torch.version.hip is not None:
+            self.skipTest("scalar online-softmax accumulators are CUDA-only")
+
+        def f(x):
+            xmax, xsum = _prepare_softmax(x, -1)
+            return xmax, xsum, (x - xmax).sum(dim=-1, keepdim=True)
+
+        x = torch.randn(128, 8192, dtype=torch.float32, device=GPU_TYPE)
+        act, (code,) = run_and_get_code(torch.compile(f), x)
+
+        ref = f(x)
+        for expected, actual in zip(ref, act):
+            torch.testing.assert_close(expected, actual, rtol=1e-3, atol=1e-3)
+        self.assertIn("online_softmax_combine(", code)
+        self.assertNotIn("online_softmax_reduce_scalar_combine", code)
+
+    @inductor_config.patch(
+        {
+            "triton.persistent_reductions": False,
+            "split_reductions": False,
+            "triton.scalar_online_softmax_accumulators": True,
+        }
+    )
+    @parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32, torch.float64])
+    def test_scalar_online_softmax_native_max(self, dtype):
+        if GPU_TYPE != "cuda" or torch.version.hip is not None:
+            self.skipTest("scalar online-softmax fast combine is CUDA-only")
+
+        rows, cols = 7, 8193
+        x = torch.randn(rows, cols, device=GPU_TYPE, dtype=dtype)
+        x[0, 0] = float("nan")
+        x[1, cols // 2] = float("nan")
+        x[2, cols - 1] = float("nan")
+        x[3].fill_(float("-inf"))
+        x[4].fill_(float("-inf"))
+        x[4, 0] = float("inf")
+        x[5].fill_(float("-inf"))
+        x[5, cols // 2] = 2.0
+
+        ref = _prepare_softmax(x, -1)
+        act, (code,) = run_and_get_code(torch.compile(_prepare_softmax), x, dim=-1)
+
+        self.assertIn("online_softmax_reduce_scalar_combine", code)
+        self.assertIn("other=0.0", code)
+        self.assertIn("tl.where(r0_mask", code)
+        eager_rows = torch.tensor([0, 1, 2, 4, 5, 6], device=GPU_TYPE)
+        for expected, actual in zip(ref, act):
+            torch.testing.assert_close(
+                expected.index_select(0, eager_rows),
+                actual.index_select(0, eager_rows),
+                equal_nan=True,
+            )
+        for row in (0, 1, 2):
+            self.assertTrue(ref[0][row].isnan().all())
+            self.assertTrue(act[0][row].isnan().all())
+            self.assertTrue(ref[1][row].isnan().all())
+            self.assertTrue(act[1][row].isnan().all())
+        self.assertTrue(act[0][3].isneginf().all())
+        self.assertEqual(act[1][3], torch.full_like(act[1][3], cols))
+        self.assertTrue(act[0][4].isposinf().all())
+        self.assertTrue(act[1][4].isnan().all())
+        self.assertEqual(act[0][5].item(), 2.0)
+        self.assertEqual(act[1][5].item(), 1.0)
 
     @inductor_config.patch("triton.persistent_reductions", False)
     def test_sdpa(self):
@@ -284,6 +690,7 @@ class TestOnlineSoftmax(TestCase):
             current["saved_activation_bytes"],
         )
 
+    @inductor_config.patch("triton.persistent_reductions", False)
     def test_split_reduction(self):
         """
         Split online_softmax_reduce into partial max/sum tuples and combine

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -49,6 +49,7 @@ from .. import config, ir, metrics, utils
 from ..async_compile import AsyncCompile
 from ..codecache import code_hash, get_path, PyCodeCache, write_atomic
 from ..debug import set_kernel_post_grad_provenance_tracing
+from ..dependencies import MemoryDep
 from ..ops_handler import DefaultHandler
 from ..runtime import triton_heuristics
 from ..runtime.benchmarking import benchmarker
@@ -1548,8 +1549,7 @@ class TritonOverrides(OpOverrides):
         """
         if config.use_fast_math:
             return f"tl_math.exp({x})"
-        else:
-            return f"libdevice.exp({x})"
+        return f"libdevice.exp({x})"
 
     @staticmethod
     @maybe_upcast_float32()
@@ -3300,6 +3300,8 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         self.has_load_with_contiguous_rdim = False
         # We track the store name since a store can be canceled later
         self.stores_with_contiguous_rdim: list[str] = []
+        self.has_scalar_online_softmax_reduction = False
+        self.has_non_scalar_reduction = False
 
     def triton_tensor_ndim(self) -> int:
         return sum(int(tree.tensor_dim is not None) for tree in self.range_trees)
@@ -5248,6 +5250,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             return TritonKernelOverrides.where(cond, tval, fval)
 
         if self.persistent_reduction:
+            self.has_non_scalar_reduction = True
             default = ir.Reduction.default_value(reduction_type, src_dtype)
 
             def update_constant_dtype(constant, src_dtype, dst_dtype):
@@ -5386,6 +5389,74 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 if reduction_type in arg_with_value_reduction_types
                 else result_var
             )
+            num_reduction_ops = self.features.op_counts().get("reduction", 0)
+            reduction_numel = self.features.reduction_numel
+            sizevars = V.graph.sizevars
+            reduction_numel_hint_unrounded = int(
+                sizevars.optimization_hint(reduction_numel)
+            )
+            reduction_numel_hint = next_power_of_2(reduction_numel_hint_unrounded)
+            reduction_hint = self.features.get_reduction_hint(self.tiling_scores)
+
+            def materialized_reduction_output_count() -> int:
+                names: OrderedSet[str] = OrderedSet()
+                scheduler_nodes = OrderedSet(self.features.scheduler_nodes())
+                materialized_numel = int(
+                    sizevars.optimization_hint(self.features.numel)
+                )
+                materialized_numel *= reduction_numel_hint_unrounded
+                for node in self.features.scheduler_nodes():
+                    for dep in node.read_writes.writes:
+                        if (
+                            not isinstance(dep, MemoryDep)
+                            or dep.name in V.graph.removed_buffers
+                            or dep.numel_hint() < materialized_numel
+                        ):
+                            continue
+                        scheduler_buf = node.scheduler.name_to_buf.get(dep.name)
+                        if scheduler_buf is not None and all(
+                            user.node in scheduler_nodes for user in scheduler_buf.users
+                        ):
+                            continue
+                        names.add(dep.name)
+                return len(names)
+
+            # Small reductions are already cheap on the vector path, and the
+            # 65536 hint bucket covers vocab-sized softmax reductions where
+            # scalar accumulation is slower than the vector path.
+            skip_scalar_online_softmax = (
+                reduction_numel_hint < 8192 or reduction_numel_hint == 65536
+            )
+            use_scalar_online_softmax = (
+                config.triton.scalar_online_softmax_accumulators
+                and reduction_type == "online_softmax_reduce"
+                and not isinstance(value, tuple)
+                # Use emitted loads, not scheduler dependency count: fused
+                # CE-style gather kernels can have a wider dependency set but
+                # only two actual in-loop loads.
+                and self.num_load <= 3
+                and self.num_reduction_dims == 1
+                and reduction_hint == ReductionHint.INNER
+                and num_reduction_ops <= 2
+                and not skip_scalar_online_softmax
+            )
+            if use_scalar_online_softmax:
+                device = next(iter(self.features.scheduler_nodes())).get_device()
+                use_scalar_online_softmax = (
+                    device is not None
+                    and device.type == "cuda"
+                    and torch.version.hip is None
+                )
+            if use_scalar_online_softmax:
+                # Scalar accumulation trades vector accumulator state for an
+                # in-loop block reduction. That loses when the fused kernel
+                # still has to materialize multiple full reduction-axis outputs.
+                use_scalar_online_softmax = materialized_reduction_output_count() < 2
+            self.has_scalar_online_softmax_reduction |= use_scalar_online_softmax
+            self.has_non_scalar_reduction |= not use_scalar_online_softmax
+
+            scalar_acc_shape = tuple(self.dense_size_list()[:dim])
+            scalar_acc_size = f"[{', '.join(scalar_acc_shape)}]"
             accumulator = self.cse.namedvar(
                 f"_{result_prefix}",
                 dtype=torch_acc_type,
@@ -5452,59 +5523,94 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 accumulator_max = f"_{result_var}_max"
                 accumulator_sum = f"_{result_var}_sum"
 
-                # setup accumulator
-                self.body.writeline(
-                    f"{accumulator_max} = tl.full({self.dense_size_str()}, float('-inf'), {acc_type})"
-                )
-                self.body.writeline(
-                    f"{accumulator_sum} = tl.zeros({self.dense_size_str()}, {acc_type})"
-                )
+                if use_scalar_online_softmax:
+                    self.body.writeline(
+                        f"{accumulator_max} = tl.full({scalar_acc_size}, float('-inf'), {acc_type})"
+                    )
+                    self.body.writeline(
+                        f"{accumulator_sum} = tl.full({scalar_acc_size}, 0.0, {acc_type})"
+                    )
 
-                # combine
-                # Note, we pass config.use_fast_math to the JITFunction
-                # since a triton kernel can not access a config.
-                if isinstance(value, tuple):
-                    value_max, value_sum = value
+                    if cond:
+                        masked_val = f"tl.where({cond}, {value}, float('-inf'))"
+                        valid_mask = cond
+                    else:
+                        masked_val = str(value)
+                        valid_mask = "True"
+
                     self.compute.splice(
                         f"""
-                        {accumulator_max}_next, {accumulator_sum}_next = triton_helpers.online_softmax_combine_with_sum(
-                            {accumulator_max}, {accumulator_sum}, {value_max}, {value_sum}, {config.use_fast_math}
+                        {accumulator_max}, {accumulator_sum} = triton_helpers.online_softmax_reduce_scalar_combine(
+                            {accumulator_max}, {accumulator_sum}, {masked_val}, {valid_mask}, {dim},
+                            {config.use_fast_math}
                         )
                         """
                     )
+
+                    result_max = cast(CSEVariable, result_var)
+                    result_sum = self.cse.newvar(dtype=dtype, shape=result_max.shape)
+                    self.post_loop_combine.splice(
+                        f"""
+                        {result_max} = {self.reduction_resize(f"{accumulator_max}")}
+                        {result_sum} = {self.reduction_resize(f"{accumulator_sum}")}
+                        """
+                    )
+                    result_var = result_max, result_sum
                 else:
+                    # Original vector accumulator path
+                    # setup accumulator
+                    self.body.writeline(
+                        f"{accumulator_max} = tl.full({self.dense_size_str()}, float('-inf'), {acc_type})"
+                    )
+                    self.body.writeline(
+                        f"{accumulator_sum} = tl.zeros({self.dense_size_str()}, {acc_type})"
+                    )
+
+                    # combine
+                    # Note, we pass config.use_fast_math to the JITFunction
+                    # since a triton kernel can not access a config.
+                    if isinstance(value, tuple):
+                        value_max, value_sum = value
+                        self.compute.splice(
+                            f"""
+                            {accumulator_max}_next, {accumulator_sum}_next = triton_helpers.online_softmax_combine_with_sum(
+                                {accumulator_max}, {accumulator_sum}, {value_max}, {value_sum}, {config.use_fast_math}
+                            )
+                            """
+                        )
+                    else:
+                        self.compute.splice(
+                            f"""
+                            {accumulator_max}_next, {accumulator_sum}_next = triton_helpers.online_softmax_combine(
+                                {accumulator_max}, {accumulator_sum}, {value}, {config.use_fast_math}
+                            )
+                            """
+                        )
+
+                    # mask
                     self.compute.splice(
                         f"""
-                        {accumulator_max}_next, {accumulator_sum}_next = triton_helpers.online_softmax_combine(
-                            {accumulator_max}, {accumulator_sum}, {value}, {config.use_fast_math}
-                        )
+                        {accumulator_max} = {where_cond(f"{accumulator_max}_next", accumulator_max)}
+                        {accumulator_sum} = {where_cond(f"{accumulator_sum}_next", accumulator_sum)}
                         """
                     )
 
-                # mask
-                self.compute.splice(
-                    f"""
-                    {accumulator_max} = {where_cond(f"{accumulator_max}_next", accumulator_max)}
-                    {accumulator_sum} = {where_cond(f"{accumulator_sum}_next", accumulator_sum)}
-                    """
-                )
+                    # reduce. Similar to the final reduction for coopereative
+                    # reduction
+                    result_max = result_var
+                    result_sum = self.cse.newvar(
+                        dtype=dtype, shape=cast(Any, result_max).shape
+                    )
 
-                # reduce. Similar to the final reduction for coopereative
-                # reduction
-                result_max = result_var
-                result_sum = self.cse.newvar(
-                    dtype=dtype, shape=cast(Any, result_max).shape
-                )
-
-                result_var = self.online_softmax_reduce_final_reduction(
-                    self.post_loop_combine,
-                    result_max,
-                    result_sum,
-                    accumulator_max,
-                    accumulator_sum,
-                    dim,
-                    dtype,
-                )
+                    result_var = self.online_softmax_reduce_final_reduction(
+                        self.post_loop_combine,
+                        result_max,
+                        result_sum,
+                        accumulator_max,
+                        accumulator_sum,
+                        dim,
+                        dtype,
+                    )
             else:
                 combine_fn = ir.get_reduction_combine_fn(reduction_type, src_dtype)
                 updated = combine_fn(accumulator, value)
@@ -6772,6 +6878,11 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             out["min_xblock"] = self.min_xblock
         if self.min_rblock is not None:
             out["min_rblock"] = self.min_rblock
+        if (
+            self.has_scalar_online_softmax_reduction
+            and not self.has_non_scalar_reduction
+        ):
+            out["has_scalar_online_softmax_reduction"] = True
         if self.cooperative_reduction:
             out["persistent_reduction"] = self.persistent_reduction
         if (rblock := self._get_native_matmul_persistent_rblock()) is not None:

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2138,6 +2138,12 @@ class triton:
     # We should revisit this once we understand more of the source of register spills.
     spill_threshold: int = 32 if torch.version.hip else 16
 
+    # Use scalar accumulators for online softmax in non-persistent CUDA
+    # reduction loops.
+    scalar_online_softmax_accumulators = (
+        os.environ.get("TORCHINDUCTOR_SCALAR_ONLINE_SOFTMAX_ACCUMULATORS", "1") == "1"
+    )
+
     # Generate code containing the newer tl.make_block_ptr() API for loads/store
     use_block_ptr = False
 

--- a/torch/_inductor/heuristics/triton_codegen/reduction.py
+++ b/torch/_inductor/heuristics/triton_codegen/reduction.py
@@ -14,7 +14,10 @@ from torch._inductor.heuristics.registry import (
     CodegenConfigHeuristics,
     register_codegen_heuristic,
 )
-from torch._inductor.runtime.hints import ReductionHint, TRITON_MAX_BLOCK
+from torch._inductor.runtime.hints import (
+    ReductionHint,
+    TRITON_MAX_BLOCK,
+)
 from torch._inductor.runtime.runtime_utils import next_power_of_2
 from torch._inductor.utils import prefix_is_reduction
 from torch.utils._ordered_set import OrderedSet
@@ -210,7 +213,17 @@ class ReductionHeuristic(CodegenConfigHeuristics):
 
         device_major = triton_meta["device"].major
         warp_size = triton_meta["device"].warp_size_or_default
-        MAX_R0_BLOCK = 1024 if device_major is not None and device_major >= 10 else 2048
+
+        has_scalar_online_softmax_reduction = inductor_meta.get(
+            "has_scalar_online_softmax_reduction", False
+        )
+        if has_scalar_online_softmax_reduction and 8192 <= rnumel:
+            MAX_R0_BLOCK = 4096
+        elif device_major is not None and device_major >= 10:
+            # Prefer smaller MAX_R0_BLOCK for Blackwell by default
+            MAX_R0_BLOCK = 1024
+        else:
+            MAX_R0_BLOCK = 2048
         if size_hints["x"] >= 1024 and loads_and_red >= 10:
             MAX_R0_BLOCK = 1024
             register_intensive = True
@@ -290,6 +303,19 @@ class ReductionHeuristic(CodegenConfigHeuristics):
             register_intensive,
         )
 
+        # Scalar online-softmax accumulators make larger R0_BLOCK candidates
+        # viable without coordinate-descent tuning.
+        scalar_acc_configs: list[Config] = []
+        if (
+            has_scalar_online_softmax_reduction
+            and 8192 <= rnumel
+            and "y" not in size_hints
+        ):
+            scalar_acc_configs = [
+                make_config(1, min(rnumel, 8192), num_warps=4),
+                make_config(1, min(rnumel, 16384), num_warps=8),
+            ]
+
         configs: list[Config] = []
 
         if inductor_meta.get("add_persistent_rblock") and loads_and_red <= 8:
@@ -308,20 +334,24 @@ class ReductionHeuristic(CodegenConfigHeuristics):
         elif max_autotune_enabled:
             pass
         elif reduction_hint == ReductionHint.INNER:
-            return configs + [contiguous_config]
+            return configs + [contiguous_config] + scalar_acc_configs
         elif reduction_hint == ReductionHint.OUTER:
             return configs + [outer_config]
         elif reduction_hint == ReductionHint.OUTER_TINY:
             return configs + [tiny_config]
 
-        result_configs = configs + [
-            contiguous_config,
-            outer_config,
-            tiny_config,
-            make_config(64, 64),
-            make_config(8, 512),
-            make_config(64, 4, num_warps=8),
-        ]
+        result_configs = (
+            configs
+            + [
+                contiguous_config,
+                outer_config,
+                tiny_config,
+                make_config(64, 64),
+                make_config(8, 512),
+                make_config(64, 4, num_warps=8),
+            ]
+            + scalar_acc_configs
+        )
 
         return self._finalize_configs(
             result_configs, make_config, size_hints, inductor_meta

--- a/torch/_inductor/runtime/hints.py
+++ b/torch/_inductor/runtime/hints.py
@@ -324,6 +324,7 @@ class InductorMeta(typing.TypedDict, total=False):
     tiling_scores: typing.Any
     min_xblock: int
     min_rblock: int
+    has_scalar_online_softmax_reduction: bool
     persistent_reduction: bool
     native_matmul_persistent_rblock: int
     add_persistent_rblock: bool

--- a/torch/_inductor/runtime/triton_helpers.py
+++ b/torch/_inductor/runtime/triton_helpers.py
@@ -272,6 +272,17 @@ def fmax2(a, dim):
 
 
 @triton.jit
+def _online_softmax_maximum(a, b):
+    return tl.maximum(a, b, propagate_nan=tl.PropagateNan.ALL)
+
+
+@triton.jit
+def online_softmax_max2(a, dim):
+    # Softmax normalization does not observe the sign of a zero maximum.
+    return tl.reduce(a, dim, _online_softmax_maximum)
+
+
+@triton.jit
 def minimum_with_index(a_value, a_index, b_value, b_index):
     mask = a_value < b_value
     equal = a_value == b_value
@@ -351,6 +362,31 @@ def online_softmax_combine(lhs_max, lhs_sum, rhs_max, use_fast_math: tl.constexp
     #   out_sum = lhs_sum * lhs_scale + rhs_sum * rhs_scale
     # but since rhs_sum is all 1, we can simplify it.
     out_sum = lhs_sum * lhs_scale + rhs_scale
+    return out_max, out_sum
+
+
+@triton.jit
+def online_softmax_reduce_scalar_combine(
+    lhs_max,
+    lhs_sum,
+    rhs_max,
+    valid_mask,
+    dim,
+    use_fast_math: tl.constexpr,
+):
+    block_max = online_softmax_max2(rhs_max, dim)
+    out_max = maximum(lhs_max, block_max)
+    lhs_scale = tl.where(
+        out_max == float("-inf"), 1.0, exp(lhs_max - out_max, use_fast_math)
+    )
+    out_max_keepdim = tl.expand_dims(out_max, dim)
+    rhs_scale = tl.where(
+        out_max_keepdim == float("-inf"),
+        1.0,
+        exp(rhs_max - out_max_keepdim, use_fast_math),
+    )
+    rhs_scale = tl.where(valid_mask, rhs_scale, 0.0)
+    out_sum = lhs_sum * lhs_scale + tl.sum(rhs_scale, dim)
     return out_max, out_sum
 
 

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -4025,6 +4025,7 @@ def _subkernel_fingerprint(combo_meta: dict[str, Any], i: int) -> tuple[Any, ...
         tuple(sorted(sub_meta.get("autotune_hints") or [], key=str)),
         sub_meta.get("atomic_add_found"),
         sub_meta.get("no_x_dim"),
+        sub_meta.get("has_scalar_online_softmax_reduction", False),
         combo_meta.get(f"reduction_hint_{i}"),
         combo_meta.get(f"tile_hint_{i}"),
         sub_meta.get("add_persistent_rblock", False),


### PR DESCRIPTION
> **Draft / WIP - agent-submitted and adversarially reviewed.** The implementation has been reviewed for correctness and codebase consistency, but the revised code still needs fresh performance measurements and full CI before it is ready for review.

Use scalar accumulator state for supported non-persistent Triton reductions, avoiding an `[XBLOCK, R0_BLOCK]` accumulator across loop iterations. Scalar-only kernels also receive larger `R0_BLOCK` autotuning candidates without requiring coordinate-descent tuning.

The review tightened the original implementation:

- Scalar codegen is limited to NVIDIA CUDA, one reduction dimension, supported dtypes/reduction types, and kernels with at most three distinct read buffers.
- Tuple, multi-axis, load-heavy, persistent, ROCm, and mixed scalar/vector kernels retain the existing vector path.
- Launch metadata is emitted only when every unique generated reduction uses scalar accumulation, so fused vector reductions cannot receive scalar-only configs.
- The online-softmax update uses a shared helper, preserves all-negative-infinity handling, and honors `config.use_fast_math`.
- A second overlapping config gate and an unrelated kernel-wide fast-exp override were removed.

The original B200 numbers were collected before these correctness changes and should not be used for landing decisions. Rebenchmark the current head before marking the PR ready.

Test Plan:

```
PYTHONPATH=$PWD python test/inductor/test_online_softmax.py -k scalar_acc_reduction
lintrunner -a -r HEAD --skip PYREFLY --output oneline
python -m compileall -q test/inductor torch/_inductor
git diff --check
```

Full local Pyrefly was unavailable because the isolated worktree lacks its generated API surface; CI Pyrefly is authoritative.

Authored and revised with AI coding assistants at the direction of @eellison.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo