### PR TITLE
[WIP][inductor] Triton finalize kernel for multi-output split-reduction sums

### DIFF
--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -1273,6 +1273,98 @@ class OverFusionTest(TestBase):
 
 
 @inductor_config.patch(
+    {
+        "triton.mix_order_reduction": True,
+        "triton.cooperative_reductions": False,
+        "triton.force_cooperative_reductions": False,
+    }
+)
+class TritonFinalizeSumTest(TestBase):
+    """
+    Tests for the deterministic Triton multi-output-reduction finalize-sum codegen gated by
+    config.triton_finalize_sum.  A multi-output split reduction whose sum
+    finalize is emitted as a column-parallel, single-store Triton kernel
+    (deterministic, no atomics) instead of ATen's generic .sum(dim=0) over the
+    partial-sum workspace.
+    """
+
+    # A multi-output reduction where the dim=0 reduction is large enough to be
+    # split, so its sum finalize goes through the workspace path.
+    def _f(self, x):
+        return x.sum(dim=0), x.sum(dim=1)
+
+    def _make_input(self):
+        return torch.randn(32768, 768, device=GPU_TYPE)
+
+    @inductor_config.patch(triton_finalize_sum=True)
+    def test_finalize_kernel_emitted(self):
+        """(a) flag on: a Triton finalize kernel is emitted for the sum."""
+        if not inductor_config.triton.mix_order_reduction:
+            self.skipTest("Mix order reduction not enabled")
+
+        # Reset so this config variation forces a fresh compile that
+        # run_and_get_code can capture, independent of test ordering.
+        torch._dynamo.reset()
+        x = self._make_input()
+        _, (code,) = utils.run_and_get_code(torch.compile(self._f), x)
+        # The finalize kernel is emitted, and it is the deterministic
+        # single-store form (coalesced tl.store, no atomics).
+        FileCheck().check("triton_mor_finalize_sum").check("tl.store(output_ptr").run(
+            code
+        )
+
+    @inductor_config.patch(triton_finalize_sum=True)
+    def test_no_atomic_add(self):
+        """(b) flag on: the generated code emits no atomic_add op."""
+        if not inductor_config.triton.mix_order_reduction:
+            self.skipTest("Mix order reduction not enabled")
+
+        torch._dynamo.reset()
+        x = self._make_input()
+        _, (code,) = utils.run_and_get_code(torch.compile(self._f), x)
+        self.assertIn("triton_mor_finalize_sum", code)
+        # Match the actual Triton op call, not the "atomic_add_found" key that
+        # appears in every reduction kernel's inductor_meta.
+        self.assertNotIn("tl.atomic_add", code)
+
+    @inductor_config.patch(triton_finalize_sum=False)
+    def test_aten_fallback_when_disabled(self):
+        """(a) flag off: fall back to ATen's .sum(dim=0), no finalize kernel."""
+        if not inductor_config.triton.mix_order_reduction:
+            self.skipTest("Mix order reduction not enabled")
+
+        torch._dynamo.reset()
+        x = self._make_input()
+        _, (code,) = utils.run_and_get_code(torch.compile(self._f), x)
+        self.assertNotIn("triton_mor_finalize_sum", code)
+        FileCheck().check(".sum(dim=0)").run(code)
+
+    @inductor_config.patch(triton_finalize_sum=True)
+    def test_determinism(self):
+        """(c) two runs on identical input are bitwise identical."""
+        if not inductor_config.triton.mix_order_reduction:
+            self.skipTest("Mix order reduction not enabled")
+
+        x = self._make_input()
+        opt_f = torch.compile(self._f)
+        out1 = opt_f(x)
+        out2 = opt_f(x)
+        # The deterministic single-store finalize (unlike atomic_add) sums each
+        # output element in a fixed order, so repeated runs must match exactly.
+        for a, b in zip(out1, out2):
+            self.assertTrue(torch.equal(a, b))
+
+    @inductor_config.patch(triton_finalize_sum=True)
+    def test_numerics(self):
+        """(d) compiled output matches eager."""
+        if not inductor_config.triton.mix_order_reduction:
+            self.skipTest("Mix order reduction not enabled")
+
+        x = self._make_input()
+        self.check_numeric(self._f, (x,))
+
+
+@inductor_config.patch(
     "triton.mix_order_reduction", not inductor_config.triton.mix_order_reduction
 )
 class NoMixOrderReductionTest(MixOrderReductionTest):

--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -1279,89 +1279,47 @@ class OverFusionTest(TestBase):
         "triton.force_cooperative_reductions": False,
     }
 )
+@instantiate_parametrized_tests
 class TritonFinalizeSumTest(TestBase):
-    """
-    Tests for the deterministic Triton multi-output-reduction finalize-sum codegen gated by
-    config.triton_finalize_sum.  A multi-output split reduction whose sum
-    finalize is emitted as a column-parallel, single-store Triton kernel
-    (deterministic, no atomics) instead of ATen's generic .sum(dim=0) over the
-    partial-sum workspace.
-    """
+    def _f(self, x, keepdim=False):
+        return x.sum(dim=0, keepdim=keepdim), x.sum(dim=1)
 
-    # A multi-output reduction where the dim=0 reduction is large enough to be
-    # split, so its sum finalize goes through the workspace path.
-    def _f(self, x):
-        return x.sum(dim=0), x.sum(dim=1)
+    def _make_input(self, columns=768, dtype=torch.float32):
+        return torch.randn(32768, columns, device=GPU_TYPE, dtype=dtype)
 
-    def _make_input(self):
-        return torch.randn(32768, 768, device=GPU_TYPE)
+    def _require_nvidia(self):
+        if GPU_TYPE != "cuda" or torch.version.hip is not None:
+            self.skipTest("finalize kernel is NVIDIA-only")
 
-    @inductor_config.patch(triton_finalize_sum=True)
-    def test_finalize_kernel_emitted(self):
-        """(a) flag on: a Triton finalize kernel is emitted for the sum."""
-        if not inductor_config.triton.mix_order_reduction:
-            self.skipTest("Mix order reduction not enabled")
-
-        # Reset so this config variation forces a fresh compile that
-        # run_and_get_code can capture, independent of test ordering.
+    @parametrize("enabled", [False, True])
+    def test_codegen(self, enabled):
+        self._require_nvidia()
         torch._dynamo.reset()
         x = self._make_input()
-        _, (code,) = utils.run_and_get_code(torch.compile(self._f), x)
-        # The finalize kernel is emitted, and it is the deterministic
-        # single-store form (coalesced tl.store, no atomics).
-        FileCheck().check("triton_mor_finalize_sum").check("tl.store(output_ptr").run(
-            code
-        )
+        with inductor_config.patch("triton.mix_order_reduction_finalize_sum", enabled):
+            _, (code,) = utils.run_and_get_code(torch.compile(self._f), x, False)
 
-    @inductor_config.patch(triton_finalize_sum=True)
-    def test_no_atomic_add(self):
-        """(b) flag on: the generated code emits no atomic_add op."""
-        if not inductor_config.triton.mix_order_reduction:
-            self.skipTest("Mix order reduction not enabled")
+        if enabled:
+            FileCheck().check("triton_mor_finalize_sum").check(
+                "tl.store(output_ptr"
+            ).check_not("tl.atomic_add").run(code)
+        else:
+            self.assertNotIn("triton_mor_finalize_sum", code)
+            FileCheck().check(".sum(dim=0)").run(code)
 
-        torch._dynamo.reset()
-        x = self._make_input()
-        _, (code,) = utils.run_and_get_code(torch.compile(self._f), x)
-        self.assertIn("triton_mor_finalize_sum", code)
-        # Match the actual Triton op call, not the "atomic_add_found" key that
-        # appears in every reduction kernel's inductor_meta.
-        self.assertNotIn("tl.atomic_add", code)
-
-    @inductor_config.patch(triton_finalize_sum=False)
-    def test_aten_fallback_when_disabled(self):
-        """(a) flag off: fall back to ATen's .sum(dim=0), no finalize kernel."""
-        if not inductor_config.triton.mix_order_reduction:
-            self.skipTest("Mix order reduction not enabled")
-
-        torch._dynamo.reset()
-        x = self._make_input()
-        _, (code,) = utils.run_and_get_code(torch.compile(self._f), x)
-        self.assertNotIn("triton_mor_finalize_sum", code)
-        FileCheck().check(".sum(dim=0)").run(code)
-
-    @inductor_config.patch(triton_finalize_sum=True)
-    def test_determinism(self):
-        """(c) two runs on identical input are bitwise identical."""
-        if not inductor_config.triton.mix_order_reduction:
-            self.skipTest("Mix order reduction not enabled")
-
-        x = self._make_input()
+    @inductor_config.patch("triton.mix_order_reduction_finalize_sum", True)
+    @parametrize("columns", [7, 768])
+    @parametrize("dtype", [torch.bfloat16, torch.float32])
+    @parametrize("keepdim", [False, True])
+    def test_numerics_and_determinism(self, columns, dtype, keepdim):
+        self._require_nvidia()
+        x = self._make_input(columns, dtype)
+        ref = self._f(x, keepdim)
         opt_f = torch.compile(self._f)
-        out1 = opt_f(x)
-        out2 = opt_f(x)
-        # The deterministic single-store finalize (unlike atomic_add) sums each
-        # output element in a fixed order, so repeated runs must match exactly.
-        for a, b in zip(out1, out2):
-            self.assertTrue(torch.equal(a, b))
+        actual = opt_f(x, keepdim)
 
-    @inductor_config.patch(triton_finalize_sum=True)
-    def test_numerics(self):
-        """(d) compiled output matches eager."""
-        if not inductor_config.triton.mix_order_reduction:
-            self.skipTest("Mix order reduction not enabled")
-
-        x = self._make_input()
-        self.check_numeric(self._f, (x,))
+        self.assertEqual(ref, actual, atol=1e-3, rtol=1e-3)
+        self.assertEqual(actual, opt_f(x, keepdim), atol=0, rtol=0)
 
 
 @inductor_config.patch(

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -2577,7 +2577,8 @@ class SIMDScheduling(BaseScheduling):
             # Use a generated Triton finalize kernel for sum reduction
             # to get coalesced memory access instead of ATen's generic reduce.
             use_triton_finalize = (
-                partial_accum.reduction_type == "sum"
+                config.triton_finalize_sum
+                and partial_accum.reduction_type == "sum"
                 and not V.graph.cpp_wrapper
                 and V.graph.device_type == "cuda"
             )

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -2558,9 +2558,8 @@ class SIMDScheduling(BaseScheduling):
                 f"len(kernel.saved_partial_accumulate), got "
                 f"{len(converted_nodes)} and {len(kernel.saved_partial_accumulate)}"
             )
-        nsplit = V.graph.wrapper_code.codegen_python_sizevar(
-            (numel + split_size - 1) // split_size
-        )
+        nsplit_expr = (numel + split_size - 1) // split_size
+        nsplit = V.graph.wrapper_code.codegen_python_sizevar(nsplit_expr)
         for idx, partial_accum in enumerate(kernel.saved_partial_accumulate):
             buffer_name = partial_accum.buffer_name
 
@@ -2574,24 +2573,38 @@ class SIMDScheduling(BaseScheduling):
             opname = reduction_type2op.get(
                 partial_accum.reduction_type, partial_accum.reduction_type
             )
-            final_reduce = f"{buffer_name} = {ws_name}[{start} : {end}].view({nsplit}, {rnumel}).{opname}(dim=0)"
 
-            # Restore the exact original shape via .view() to handle keepdim
-            # and multi-dimensional reductions correctly.
-            buffer = V.graph.get_buffer(buffer_name)
-            if buffer is not None:
-                final_shape = [
-                    V.graph.wrapper_code.codegen_python_sizevar(s)
-                    for s in buffer.get_layout().size
-                ]
-                final_shape_str = f"[{', '.join(final_shape)}]"
-                final_reduce += f".view({final_shape_str})"
+            # Use a generated Triton finalize kernel for sum reduction
+            # to get coalesced memory access instead of ATen's generic reduce.
+            use_triton_finalize = (
+                partial_accum.reduction_type == "sum"
+                and not V.graph.cpp_wrapper
+                and V.graph.device_type == "cuda"
+            )
 
-            # The workspace tensor is in torch.float, need a cast if the buffer is
-            # not.
-            if (buffer_dtype := V.graph.get_dtype(buffer_name)) != torch.float:
-                final_reduce += f".to({buffer_dtype})"
-            V.graph.wrapper_code.writeline(final_reduce)
+            if use_triton_finalize:
+                self._emit_triton_finalize_sum(
+                    buffer_name, ws_name, start, end, nsplit, nsplit_expr, rnumel, idx
+                )
+            else:
+                final_reduce = f"{buffer_name} = {ws_name}[{start} : {end}].view({nsplit}, {rnumel}).{opname}(dim=0)"
+
+                # Restore the exact original shape via .view() to handle keepdim
+                # and multi-dimensional reductions correctly.
+                buffer = V.graph.get_buffer(buffer_name)
+                if buffer is not None:
+                    final_shape = [
+                        V.graph.wrapper_code.codegen_python_sizevar(s)
+                        for s in buffer.get_layout().size
+                    ]
+                    final_shape_str = f"[{', '.join(final_shape)}]"
+                    final_reduce += f".view({final_shape_str})"
+
+                # The workspace tensor is in torch.float, need a cast if the buffer is
+                # not.
+                if (buffer_dtype := V.graph.get_dtype(buffer_name)) != torch.float:
+                    final_reduce += f".to({buffer_dtype})"
+                V.graph.wrapper_code.writeline(final_reduce)
             # mark the buffer as allocated, so we don't try to allocate
             # it again when it's later used
             V.graph.wrapper_code.allocated.add(buffer_name)
@@ -2602,6 +2615,130 @@ class SIMDScheduling(BaseScheduling):
             self._codegen_nodes(node2_epilogue)
 
         self.free_buffers_in_scheduler()
+
+    def _emit_triton_finalize_sum(
+        self, buffer_name, ws_name, start, end, nsplit, nsplit_expr, rnumel, idx
+    ):
+        """
+        Emit a Triton kernel that finalizes multi-output-reduction workspace
+        partial sums.
+
+        Instead of calling ATen's generic .sum(dim=0), this generates a
+        column-parallel Triton kernel (via async_compile): each program owns a
+        tile of BLOCK_C contiguous output columns and loops over the whole split
+        axis in BLOCK_T chunks, accumulating in registers, then does a single
+        non-atomic tl.store per column.  This is deterministic by construction
+        (each output element is summed by exactly one program in a fixed
+        sequential order) and coalesced (contiguous columns), and beats ATen's
+        generic reduce on the affected shapes.
+        """
+        wrapper = V.graph.wrapper_code
+        rnumel_str = V.graph.wrapper_code.codegen_python_sizevar(rnumel)
+
+        # Determine output dtype
+        buffer = V.graph.get_buffer(buffer_name)
+        buffer_dtype = V.graph.get_dtype(buffer_name)
+        needs_cast = buffer_dtype != torch.float
+
+        # Pick block sizes for the column-parallel reduction: a coalesced tile
+        # of BLOCK_C columns, and a BLOCK_T wide enough to consume the split
+        # (tile) axis in one/few loaded blocks -- the register-bounded analogue
+        # of an Inductor reduction sizing RBLOCK to cover the reduced dim.
+        # Sweep-derived (B200): BLOCK_C = min(16, rnumel), BLOCK_T = the smallest
+        # power of two >= nsplit, capped at 512.  A small fixed BLOCK_T (e.g. 64)
+        # leaves most of the win on the table and regresses narrow-column shapes.
+        rnumel_hint = V.graph.sizevars.optimization_hint(rnumel)
+        nsplit_hint = V.graph.sizevars.optimization_hint(nsplit_expr)
+
+        block_c = min(16, max(last_power_of_2(rnumel_hint), 1))
+        block_t = min(max(next_power_of_2(nsplit_hint), 8), 512)
+
+        # Build the kernel source for async_compile.triton()
+        finalize_kernel_name = f"triton_mor_finalize_sum_{wrapper.next_kernel_suffix()}"
+        current_device = V.graph.get_current_device_or_throw()
+        device_props = DeviceProperties.create(current_device)
+
+        kernel_src = textwrap.dedent(f"""\
+            import triton
+            import triton.language as tl
+            from torch._inductor.runtime import triton_helpers, triton_heuristics
+            from torch._inductor.runtime.triton_helpers import libdevice, math as tl_math
+            from torch._inductor.runtime.hints import AutotuneHint, ReductionHint, TileHint, DeviceProperties
+            triton_helpers.set_driver_to_gpu()
+
+            @triton_heuristics.fixed_config(
+                config={{'BLOCK_C': {block_c}, 'BLOCK_T': {block_t}}},
+                filename=__file__,
+                triton_meta={{'signature': {{'workspace_ptr': '*fp32', 'output_ptr': '*fp32', 'N_TILES': 'i32', 'C': 'i32', 'BLOCK_C': 'constexpr', 'BLOCK_T': 'constexpr'}}, 'device': {device_props!r}, 'constants': {{}}, 'configs': [{{}}]}},
+                inductor_meta={{'grid_type': 'FixedGrid', 'fixed_grid': ['_grid_0', '_grid_1', '_grid_2'], 'extra_launcher_args': ['_grid_0', '_grid_1', '_grid_2'], 'kernel_name': '{finalize_kernel_name}', 'mutated_arg_names': ['output_ptr'], 'optimize_mem': True}}
+            )
+            @triton.jit
+            def {finalize_kernel_name}(workspace_ptr, output_ptr, N_TILES, C, BLOCK_C: tl.constexpr, BLOCK_T: tl.constexpr):
+                col_block = tl.program_id(0)
+                cols = col_block * BLOCK_C + tl.arange(0, BLOCK_C)
+                col_mask = cols < C
+                acc = tl.zeros([BLOCK_C], dtype=tl.float32)
+                for t0 in range(0, N_TILES, BLOCK_T):
+                    tiles = t0 + tl.arange(0, BLOCK_T)
+                    tile_mask = tiles < N_TILES
+                    offsets = tiles[:, None] * C + cols[None, :]
+                    mask = tile_mask[:, None] & col_mask[None, :]
+                    vals = tl.load(workspace_ptr + offsets, mask=mask, other=0.0)
+                    acc += tl.sum(vals, axis=0)
+                tl.store(output_ptr + cols, acc, mask=col_mask)
+        """)
+
+        # Define kernel via wrapper's define_kernel (emits async_compile.triton(...))
+        compile_wrapper = IndentedBuffer()
+        compile_wrapper.writeline(f"async_compile.triton('{finalize_kernel_name}', '''")
+        compile_wrapper.splice(kernel_src, strip=True)
+        compile_wrapper.writeline(f"''', device_str='{current_device.type}')")
+        wrapper.define_kernel(
+            finalize_kernel_name,
+            compile_wrapper.getvalue(),
+            metadata=f"# multi-output-reduction finalize sum kernel for {buffer_name}",
+        )
+
+        # Emit the output buffer allocation and kernel call in the body.
+        # Column-parallel 1D grid; the loop over the split axis is internal to
+        # each program, so the tile-dim grid is 1.
+        grid_c = f"(({rnumel_str} + {block_c} - 1) // {block_c})"
+        grid_t = "1"
+
+        # Each output column is written by exactly one program via a single
+        # non-atomic store, so no zero-initialization is required.
+        wrapper.writeline(
+            f"{buffer_name} = empty_strided_cuda(({rnumel_str}, ), (1, ), torch.float32)"
+        )
+
+        # Emit kernel call using .run() with FixedGrid args
+        stream_name = wrapper.write_get_raw_stream(current_device.index, V.graph.name)
+        wrapper.writeline(
+            f"{finalize_kernel_name}.run("
+            f"{ws_name}[{start} : {end}], {buffer_name}, "
+            f"{nsplit}, {rnumel_str}, "
+            f"{grid_c}, {grid_t}, 1, "
+            f"stream={stream_name})"
+        )
+
+        # Reshape if needed
+        if buffer is not None:
+            final_shape = [
+                V.graph.wrapper_code.codegen_python_sizevar(s)
+                for s in buffer.get_layout().size
+            ]
+            final_shape_list = f"[{', '.join(final_shape)}]"
+            # Only reshape if final shape isn't already [rnumel]
+            if len(final_shape) > 1 or (
+                len(final_shape) == 1 and final_shape[0] != rnumel_str
+            ):
+                wrapper.writeline(
+                    f"{buffer_name} = {buffer_name}.view({final_shape_list})"
+                )
+
+        # Cast dtype if needed
+        if needs_cast:
+            wrapper.writeline(f"{buffer_name} = {buffer_name}.to({buffer_dtype})")
 
     def codegen_nested_reduction(self, node):
         """

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -2574,38 +2574,46 @@ class SIMDScheduling(BaseScheduling):
                 partial_accum.reduction_type, partial_accum.reduction_type
             )
 
+            device = V.graph.get_current_device_or_throw()
+            device_props = DeviceProperties.create(device)
+            rnumel_hint = V.graph.sizevars.optimization_hint(rnumel)
             # Use a generated Triton finalize kernel for sum reduction
             # to get coalesced memory access instead of ATen's generic reduce.
             use_triton_finalize = (
-                config.triton_finalize_sum
+                config.triton.mix_order_reduction_finalize_sum
                 and partial_accum.reduction_type == "sum"
                 and not V.graph.cpp_wrapper
-                and V.graph.device_type == "cuda"
+                and device.type == "cuda"
+                and torch.version.hip is None
+                and (
+                    (device_props.major is not None and device_props.major >= 10)
+                    or rnumel_hint >= 128
+                )
             )
 
             if use_triton_finalize:
                 self._emit_triton_finalize_sum(
-                    buffer_name, ws_name, start, end, nsplit, nsplit_expr, rnumel, idx
+                    buffer_name, ws_name, start, end, nsplit, nsplit_expr, rnumel
                 )
             else:
-                final_reduce = f"{buffer_name} = {ws_name}[{start} : {end}].view({nsplit}, {rnumel}).{opname}(dim=0)"
+                V.graph.wrapper_code.writeline(
+                    f"{buffer_name} = {ws_name}[{start} : {end}].view({nsplit}, {rnumel}).{opname}(dim=0)"
+                )
 
-                # Restore the exact original shape via .view() to handle keepdim
-                # and multi-dimensional reductions correctly.
-                buffer = V.graph.get_buffer(buffer_name)
-                if buffer is not None:
-                    final_shape = [
-                        V.graph.wrapper_code.codegen_python_sizevar(s)
-                        for s in buffer.get_layout().size
-                    ]
-                    final_shape_str = f"[{', '.join(final_shape)}]"
-                    final_reduce += f".view({final_shape_str})"
+            buffer = V.graph.get_buffer(buffer_name)
+            if buffer is not None:
+                final_shape = [
+                    V.graph.wrapper_code.codegen_python_sizevar(s)
+                    for s in buffer.get_layout().size
+                ]
+                V.graph.wrapper_code.writeline(
+                    f"{buffer_name} = {buffer_name}.view([{', '.join(final_shape)}])"
+                )
 
-                # The workspace tensor is in torch.float, need a cast if the buffer is
-                # not.
-                if (buffer_dtype := V.graph.get_dtype(buffer_name)) != torch.float:
-                    final_reduce += f".to({buffer_dtype})"
-                V.graph.wrapper_code.writeline(final_reduce)
+            if (buffer_dtype := V.graph.get_dtype(buffer_name)) != torch.float:
+                V.graph.wrapper_code.writeline(
+                    f"{buffer_name} = {buffer_name}.to({buffer_dtype})"
+                )
             # mark the buffer as allocated, so we don't try to allocate
             # it again when it's later used
             V.graph.wrapper_code.allocated.add(buffer_name)
@@ -2618,43 +2626,24 @@ class SIMDScheduling(BaseScheduling):
         self.free_buffers_in_scheduler()
 
     def _emit_triton_finalize_sum(
-        self, buffer_name, ws_name, start, end, nsplit, nsplit_expr, rnumel, idx
-    ):
-        """
-        Emit a Triton kernel that finalizes multi-output-reduction workspace
-        partial sums.
-
-        Instead of calling ATen's generic .sum(dim=0), this generates a
-        column-parallel Triton kernel (via async_compile): each program owns a
-        tile of BLOCK_C contiguous output columns and loops over the whole split
-        axis in BLOCK_T chunks, accumulating in registers, then does a single
-        non-atomic tl.store per column.  This is deterministic by construction
-        (each output element is summed by exactly one program in a fixed
-        sequential order) and coalesced (contiguous columns), and beats ATen's
-        generic reduce on the affected shapes.
-        """
+        self,
+        buffer_name: str,
+        ws_name: str,
+        start: str,
+        end: str,
+        nsplit: str,
+        nsplit_expr: sympy.Expr,
+        rnumel: sympy.Expr,
+    ) -> None:
         wrapper = V.graph.wrapper_code
-        rnumel_str = V.graph.wrapper_code.codegen_python_sizevar(rnumel)
+        rnumel_str = wrapper.codegen_python_sizevar(rnumel)
 
-        # Determine output dtype
-        buffer = V.graph.get_buffer(buffer_name)
-        buffer_dtype = V.graph.get_dtype(buffer_name)
-        needs_cast = buffer_dtype != torch.float
-
-        # Pick block sizes for the column-parallel reduction: a coalesced tile
-        # of BLOCK_C columns, and a BLOCK_T wide enough to consume the split
-        # (tile) axis in one/few loaded blocks -- the register-bounded analogue
-        # of an Inductor reduction sizing RBLOCK to cover the reduced dim.
-        # Sweep-derived (B200): BLOCK_C = min(16, rnumel), BLOCK_T = the smallest
-        # power of two >= nsplit, capped at 512.  A small fixed BLOCK_T (e.g. 64)
-        # leaves most of the win on the table and regresses narrow-column shapes.
         rnumel_hint = V.graph.sizevars.optimization_hint(rnumel)
         nsplit_hint = V.graph.sizevars.optimization_hint(nsplit_expr)
 
         block_c = min(16, max(last_power_of_2(rnumel_hint), 1))
         block_t = min(max(next_power_of_2(nsplit_hint), 8), 512)
 
-        # Build the kernel source for async_compile.triton()
         finalize_kernel_name = f"triton_mor_finalize_sum_{wrapper.next_kernel_suffix()}"
         current_device = V.graph.get_current_device_or_throw()
         device_props = DeviceProperties.create(current_device)
@@ -2663,8 +2652,7 @@ class SIMDScheduling(BaseScheduling):
             import triton
             import triton.language as tl
             from torch._inductor.runtime import triton_helpers, triton_heuristics
-            from torch._inductor.runtime.triton_helpers import libdevice, math as tl_math
-            from torch._inductor.runtime.hints import AutotuneHint, ReductionHint, TileHint, DeviceProperties
+            from torch._inductor.runtime.hints import DeviceProperties
             triton_helpers.set_driver_to_gpu()
 
             @triton_heuristics.fixed_config(
@@ -2679,7 +2667,7 @@ class SIMDScheduling(BaseScheduling):
                 cols = col_block * BLOCK_C + tl.arange(0, BLOCK_C)
                 col_mask = cols < C
                 acc = tl.zeros([BLOCK_C], dtype=tl.float32)
-                for t0 in range(0, N_TILES, BLOCK_T):
+                for t0 in tl.range(0, N_TILES, BLOCK_T):
                     tiles = t0 + tl.arange(0, BLOCK_T)
                     tile_mask = tiles < N_TILES
                     offsets = tiles[:, None] * C + cols[None, :]
@@ -2689,7 +2677,6 @@ class SIMDScheduling(BaseScheduling):
                 tl.store(output_ptr + cols, acc, mask=col_mask)
         """)
 
-        # Define kernel via wrapper's define_kernel (emits async_compile.triton(...))
         compile_wrapper = IndentedBuffer()
         compile_wrapper.writeline(f"async_compile.triton('{finalize_kernel_name}', '''")
         compile_wrapper.splice(kernel_src, strip=True)
@@ -2700,46 +2687,20 @@ class SIMDScheduling(BaseScheduling):
             metadata=f"# multi-output-reduction finalize sum kernel for {buffer_name}",
         )
 
-        # Emit the output buffer allocation and kernel call in the body.
-        # Column-parallel 1D grid; the loop over the split axis is internal to
-        # each program, so the tile-dim grid is 1.
         grid_c = f"(({rnumel_str} + {block_c} - 1) // {block_c})"
-        grid_t = "1"
 
-        # Each output column is written by exactly one program via a single
-        # non-atomic store, so no zero-initialization is required.
         wrapper.writeline(
             f"{buffer_name} = empty_strided_cuda(({rnumel_str}, ), (1, ), torch.float32)"
         )
 
-        # Emit kernel call using .run() with FixedGrid args
         stream_name = wrapper.write_get_raw_stream(current_device.index, V.graph.name)
         wrapper.writeline(
             f"{finalize_kernel_name}.run("
             f"{ws_name}[{start} : {end}], {buffer_name}, "
             f"{nsplit}, {rnumel_str}, "
-            f"{grid_c}, {grid_t}, 1, "
+            f"{grid_c}, 1, 1, "
             f"stream={stream_name})"
         )
-
-        # Reshape if needed
-        if buffer is not None:
-            final_shape = [
-                V.graph.wrapper_code.codegen_python_sizevar(s)
-                for s in buffer.get_layout().size
-            ]
-            final_shape_list = f"[{', '.join(final_shape)}]"
-            # Only reshape if final shape isn't already [rnumel]
-            if len(final_shape) > 1 or (
-                len(final_shape) == 1 and final_shape[0] != rnumel_str
-            ):
-                wrapper.writeline(
-                    f"{buffer_name} = {buffer_name}.view({final_shape_list})"
-                )
-
-        # Cast dtype if needed
-        if needs_cast:
-            wrapper.writeline(f"{buffer_name} = {buffer_name}.to({buffer_dtype})")
 
     def codegen_nested_reduction(self, node):
         """

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1040,6 +1040,12 @@ conv_1x1_as_mm = False
 # enabling both of these will implicitly disable split_reductions
 split_reductions = os.getenv("TORCHINDUCTOR_SPLIT_REDUCTIONS", "1") == "1"
 
+# Finalize multi-output split-reduction sums with a generated column-parallel
+# Triton kernel (coalesced loads, one deterministic non-atomic store per column)
+# instead of ATen's generic .sum(dim=0) over the partial-sum workspace. CUDA
+# python-wrapper only; kill switch for the triton_mor_finalize_sum codegen.
+triton_finalize_sum = os.getenv("TORCHINDUCTOR_TRITON_FINALIZE_SUM", "1") == "1"
+
 # A deterministic mode that skips any on device benchmarking in Inductor
 # if we know they affect numerics.  WARNING: Expect perf hit in this mode.
 deterministic = os.getenv("TORCHINDUCTOR_DETERMINISTIC") == "1"

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1040,12 +1040,6 @@ conv_1x1_as_mm = False
 # enabling both of these will implicitly disable split_reductions
 split_reductions = os.getenv("TORCHINDUCTOR_SPLIT_REDUCTIONS", "1") == "1"
 
-# Finalize multi-output split-reduction sums with a generated column-parallel
-# Triton kernel (coalesced loads, one deterministic non-atomic store per column)
-# instead of ATen's generic .sum(dim=0) over the partial-sum workspace. CUDA
-# python-wrapper only; kill switch for the triton_mor_finalize_sum codegen.
-triton_finalize_sum = os.getenv("TORCHINDUCTOR_TRITON_FINALIZE_SUM", "1") == "1"
-
 # A deterministic mode that skips any on device benchmarking in Inductor
 # if we know they affect numerics.  WARNING: Expect perf hit in this mode.
 deterministic = os.getenv("TORCHINDUCTOR_DETERMINISTIC") == "1"
@@ -2225,6 +2219,9 @@ class triton:
     mix_order_reduction = (
         os.environ.get("TORCHINDUCTOR_MIX_ORDER_REDUCTION", "0" if is_fbcode() else "1")
         == "1"
+    )
+    mix_order_reduction_finalize_sum = (
+        os.environ.get("TORCHINDUCTOR_MIX_ORDER_REDUCTION_FINALIZE_SUM", "1") == "1"
     )
     mix_order_reduction_initial_xblock = 1
 


### PR DESCRIPTION
> **Draft / WIP - agent-submitted and adversarially reviewed.** The implementation has been reviewed for correctness and codebase consistency, but the revised code still needs full CI and refreshed cross-device performance measurements before it is ready for review.

Finalize multi-output split-reduction sums with a deterministic column-parallel Triton kernel instead of ATen's generic `.sum(dim=0)` over the `[nsplit, rnumel]` workspace. Each output column has one non-atomic writer and workspace loads are coalesced across columns.

The review changed the original implementation:

- The path is NVIDIA CUDA and Python-wrapper only. ROCm and other backends retain the ATen fallback.
- H100 measurements showed narrow outputs were neutral or regressive, so pre-Blackwell devices use the custom finalizer only for `rnumel >= 128`; Blackwell retains the original all-width path.
- The kill switch is `config.triton.mix_order_reduction_finalize_sum` / `TORCHINDUCTOR_MIX_ORDER_REDUCTION_FINALIZE_SUM`.
- Output reshape and dtype restoration are shared with the ATen fallback.
- Generated source uses `tl.range`, minimal imports, and no unused grid/index state.
- Tests cover enabled/disabled codegen, no atomics, narrow and standard widths, BF16 and FP32, both `keepdim` forms, numerics, and bitwise repeatability.

The original B200 measurements apply to an earlier revision. Refresh them on the current head, especially around the architecture/width gate, before marking the PR ready.

Test Plan:

```
PYTHONPATH=$PWD python test/inductor/test_mix_order_reduction.py TritonFinalizeSumTest
lintrunner -a -r HEAD --skip PYREFLY --output oneline
python -m compileall -q test/inductor torch/_inductor
git diff --check
```

Full local Pyrefly was unavailable because the isolated worktree lacks its generated API surface; CI Pyrefly is authoritative.

Authored and revised with AI coding assistants at the direction of @eellison.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo