### PR TITLE
Treat cancelled jobs as no-signal, not failures, in HUD analysis

### DIFF
--- a/scripts/hud/analyze_failing_jobs.py
+++ b/scripts/hud/analyze_failing_jobs.py
@@ -47,7 +47,17 @@ PER_PAGE = 100
 # treated as no-data rather than breaking a streak -- otherwise an in-flight
 # rerun, or a runner-queue backlog at the tip, would look like a failure streak
 # for a job that is actually green (queue-backlogged jobs report "queued").
-SKIPPED_CONCLUSIONS = {"neutral", "skipped", "pending", "queued", "in_progress"}
+# "cancelled" is a superseded/aborted run (e.g. a concurrency cancel-in-progress
+# when a newer commit lands), not a real result -- counting it as a failure
+# makes jobs that are otherwise skipped/green look like they are failing.
+SKIPPED_CONCLUSIONS = {
+    "neutral",
+    "skipped",
+    "pending",
+    "queued",
+    "in_progress",
+    "cancelled",
+}
 # Two failures whose captured error text is at least this similar are treated
 # as the same underlying failure.
 SIMILARITY_THRESHOLD = 0.75


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #190218

Follow-up to #190069. analyze_failing_jobs.py still counted "cancelled" as a
failure: is_skipped() did not recognize it, and is_failure() flags any
conclusion that is not "success"/skipped. But a cancelled run is a
superseded/aborted run (e.g. the workflow's concurrency cancel-in-progress when
a newer commit lands), not a real result.

The concrete symptom: `Create Release / Upload source code to S3 for release
tags` is skipped on every real run (it only runs on rc tags), so its only
non-skipped datapoints were cancelled runs -- which produced a phantom failure
streak with no captured error text ("unclassified"). Adding "cancelled" to
SKIPPED_CONCLUSIONS makes such runs no-data, matching the existing handling of
queued/in_progress.

Test Plan:

```
lintrunner scripts/hud/analyze_failing_jobs.py   # ok, no lint issues
```

Authored with assistance from Claude.