### PR TITLE
Mark convnextv2_nano flaky on rocm to stop accuracy flapping

### DIFF
--- a/benchmarks/dynamo/check_accuracy.py
+++ b/benchmarks/dynamo/check_accuracy.py
@@ -76,6 +76,9 @@ def check_accuracy(actual_csv, expected_csv, expected_filename):
                 # Discovered on gfx950 CI after ROCm 7.2 upgrade, eager mode non determinism
                 "alexnet",
                 "demucs",
+                # Flip-flops pass <-> fail_accuracy on gfx950; tolerate both
+                # rather than pinning a status. See #190086 discussion / #189904.
+                "convnextv2_nano.fcmae_ft_in22k_in1k",
             }
         )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #190219

convnextv2_nano.fcmae_ft_in22k_in1k is nondeterministic in accuracy on gfx950:
it flip-flops between pass and fail_accuracy across runs. #189904 pinned it to
fail_accuracy, which fixed the failing case but then flags the passing case as
an "improvement" (accuracy=pass, expected=fail_accuracy), so the periodic rocm
dynamic_inductor_timm job stays red either way.

Add it to the rocm flaky_models set so both outcomes are tolerated
(PASS_BUT_FLAKY / FAIL_BUT_FLAKY) instead of pinning a single status. The
existing fail_accuracy baseline entry is left as-is; flaky_models makes the
specific value moot (XFAIL when it fails, PASS_BUT_FLAKY when it passes). Can
revert the baseline to pass as follow-up cleanup if preferred.

Test Plan: rocm dynamic_inductor_timm (and inductor_timm) training jobs should
stop reporting convnextv2_nano as regressed/improved regardless of which way it
lands.

Authored with Claude.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @azahed98