### PR TITLE
[speculative] Re-enable baddbmm case in test_scalar_arg_0d_tensor to get CI signal

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -7272,7 +7272,7 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
             "addcmul_positional",
             "addcdiv",
             "addcdiv_positional",
-            subtest("baddbmm", decorators=[expectedFailureDynamic]),
+            "baddbmm",
         ],
     )
     def test_scalar_arg_0d_tensor(self, op):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #190220

This is a speculative re-enable to obtain a CI signal and should be abandoned if CI is red.

The `baddbmm` parametrization of `test_scalar_arg_0d_tensor` in `test/dynamo/test_misc.py` was marked `expectedFailureDynamic` because Z3 translation validation did not support the unbacked symbols produced by `baddbmm`'s scalar (`alpha`/`beta`) args (https://github.com/pytorch/pytorch/issues/162287, raised a `Z3Exception` across shards). Upstream changes may have since fixed this, so this diff removes the `expectedFailureDynamic` decorator on the `baddbmm` subtest so the case runs again and CI (including ROCm GPU) can tell us whether the `Z3Exception` still reproduces. If CI is red, abandon this diff.

Differential Revision: [D112356009](https://our.internmc.facebook.com/intern/diff/D112356009/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98