### PR TITLE
[speculative] Empty fbcode opinfo numerical xfail overrides to probe CI

### DIFF
--- a/test/inductor/test_torchinductor_opinfo_properties.py
+++ b/test/inductor/test_torchinductor_opinfo_properties.py
@@ -508,40 +508,11 @@ ROCM_XFAIL_DICTS = {
 # fbcode ships a different Triton fork (triton+fb) and cuBLAS/CUDA/GPU stack than
 # OSS CI (e.g. A100 vs L4), which changes compiled-path numerics. These combos pass
 # in OSS but not in fbcode, so they are merged in only when IS_FBCODE (CUDA).
-FBCODE_BATCH_INVARIANCE_XFAILS = {
-    "aot_eager_decomp_partition": {
-        "bmm": {fp32},
-    },
-    "inductor_default": {
-        "bmm": {fp32},
-    },
-    "inductor_numerics": {
-        "bmm": {fp32},
-    },
-}
+FBCODE_BATCH_INVARIANCE_XFAILS = {}
 
-FBCODE_UNARY_NUMERICAL_XFAILS = {
-    "inductor_default": {
-        "sqrt": {bf16, fp32},
-    },
-    "inductor_numerics": {
-        "exp2": {bf16, fp32},
-        "expm1": {bf16, fp32},
-        "log1p": {fp32},
-        "reciprocal": {bf16, fp32},
-        "rsqrt": {bf16, fp32},
-        "sin": {fp32},
-        "sqrt": {bf16, fp32},
-        "tan": {bf16, fp32},
-        "tanh": {fp32},
-    },
-}
+FBCODE_UNARY_NUMERICAL_XFAILS = {}
 
-FBCODE_BINARY_NUMERICAL_XFAILS = {
-    "inductor_numerics": {
-        "fmod": {bf16, fp32},
-    },
-}
+FBCODE_BINARY_NUMERICAL_XFAILS = {}
 
 FBCODE_XFAIL_DICTS = {
     "batch_invariance": FBCODE_BATCH_INVARIANCE_XFAILS,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #190222

This is a speculative re-enable to obtain a CI signal and should be abandoned if CI is red.

`caffe2/test/inductor/test_torchinductor_opinfo_properties.py` maintains per-environment expected-failure dictionaries. On top of the base xfail dicts (`EAGER_EQUIV_XFAILS`, `BATCH_INVARIANCE_XFAILS`, `UNARY_NUMERICAL_XFAILS`, `BINARY_NUMERICAL_XFAILS`), it defines fbcode-only overrides that `is_expected_failure` unions in when `IS_FBCODE and torch.version.hip is None`. These overrides mark a cluster of compiled-vs-eager numerical and batch-invariance cases as expected-failures only in fbcode (due to the `triton+fb` fork and the internal cuBLAS/CUDA/GPU stack).

This change speculatively empties the three fbcode override dicts so those cases are no longer treated as expected-failures in fbcode runs, letting CI (including ROCm GPU CI) reveal which now pass, since the underlying numerics may have been fixed since the entries were added. This is a broad speculative probe.

Emptied dicts (each set to `{}`):
- `FBCODE_BATCH_INVARIANCE_XFAILS` (was `bmm` fp32 across `aot_eager_decomp_partition`, `inductor_default`, `inductor_numerics`)
- `FBCODE_UNARY_NUMERICAL_XFAILS` (was `sqrt`, `exp2`, `expm1`, `log1p`, `reciprocal`, `rsqrt`, `sin`, `tan`, `tanh` across `inductor_default`/`inductor_numerics`)
- `FBCODE_BINARY_NUMERICAL_XFAILS` (was `fmod` bf16/fp32 under `inductor_numerics`)

The base (non-fbcode) and ROCm xfail dicts are left untouched. Applied to both the fbcode and xplat mirrors.

Differential Revision: [D112356048](https://our.internmc.facebook.com/intern/diff/D112356048/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo