### PR TITLE
[inductor] Type custom_op autotuning and precompiled-pattern registry surfaces

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -1796,13 +1796,7 @@ class TestPatternMatcher(TestCase):
         joint_graph.lazy_init()
 
         with torch._subclasses.FakeTensorMode() as mode:
-            for (
-                search_fn,
-                example_inputs,
-                trace_fn,
-                scalar_workaround,
-                search_fn_pattern,
-            ) in _known_precompiled_patterns:
+            for precompiled in _known_precompiled_patterns:
                 # Because the example_inputs were saved as fake tensors in a
                 # different FakeTensorMode we need to update them to our
                 # FakeTensorMode().
@@ -1811,24 +1805,29 @@ class TestPatternMatcher(TestCase):
                         return torch._subclasses.FakeTensor.from_tensor(x, mode)
                     return x
 
-                example_inputs = pytree.tree_map(remap_fake_tensor, example_inputs)
+                example_inputs = pytree.tree_map(
+                    remap_fake_tensor, precompiled.example_inputs
+                )
 
                 pattern = gen_pattern(
-                    search_fn, example_inputs, trace_fn, scalar_workaround
+                    precompiled.search_fn,
+                    example_inputs,
+                    precompiled.trace_fn,
+                    precompiled.scalar_workaround,
                 )
                 pattern_pp = PatternPrettyPrinter.run(pattern)
 
                 self.assertEqual(
                     pattern_pp,
-                    PatternPrettyPrinter.run(search_fn_pattern),
-                    msg=lambda msg: f"{msg}\nFound mismatched pattern {search_fn.__name__}. Run torchgen/fuse/gen_patterns.py",
+                    PatternPrettyPrinter.run(precompiled.search_fn_pattern),
+                    msg=lambda msg: f"{msg}\nFound mismatched pattern {precompiled.search_fn.__name__}. Run torchgen/fuse/gen_patterns.py",
                 )
 
                 # Since we've already checked that the serialized patterns match
                 # lets verify the serializer by ensuring the generated patterns
                 # also match (since search_fn_pattern is the serialized version
                 # of search_fn).
-                self.assertTrue(pattern.pattern_eq(search_fn_pattern))
+                self.assertTrue(pattern.pattern_eq(precompiled.search_fn_pattern))
 
     @xfailIfSM89
     @inductor_config.patch(

--- a/torch/_inductor/kernel/custom_op.py
+++ b/torch/_inductor/kernel/custom_op.py
@@ -493,7 +493,7 @@ def autotune_custom_op(
                            and return real tensors for performance measurement.
 
     Returns:
-        Tuple of (IR node representing the optimized operation result, winning ChoiceCaller)
+        Tuple of (IR node representing the optimized operation result, winning choice)
 
     Raises:
         TypeError: If decompositions is not a list/tuple

--- a/torch/_inductor/kernel/custom_op.py
+++ b/torch/_inductor/kernel/custom_op.py
@@ -5,16 +5,17 @@ import functools
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, cast, Protocol
+from typing_extensions import NotRequired, TypedDict
 
 import torch
 from torch._dynamo.utils import counters
 from torch._inductor.codegen.subgraph import SubgraphTemplate
 from torch._inductor.ir import (
     Buffer,
-    ChoiceCaller,
     FixedLayout,
     ir_node_to_tensor,
+    Layout,
     StorageBox,
     TensorBox,
 )
@@ -30,6 +31,31 @@ from torch._inductor.virtualized import V
 log = logging.getLogger(__name__)
 
 DEFAULT_RANGE_UPPER_BOUND = 65536
+
+
+class DispatchOnConfig(TypedDict):
+    """Range-based dispatch spec for register_custom_op_autotuning(dispatch_on=...)."""
+
+    tensor_name: str
+    dim: int
+    range_upper_bound: NotRequired[int]
+
+
+class _AutotuneChoice(Protocol):
+    """Winning-choice surface consumed after autotuning.
+
+    Structurally satisfied by ChoiceCaller and its SubgraphChoiceCaller subclass;
+    lets callers read choice metadata without getattr fallbacks.
+    """
+
+    name: str
+    gm: torch.fx.GraphModule | None
+    config_patches: dict[str, Any]
+    decomposition: Callable[..., Any] | None
+    decomposition_kwargs: dict[str, Any]
+    layout: Layout
+
+    def output_node(self) -> TensorBox: ...
 
 
 @dataclass(frozen=True)
@@ -446,7 +472,7 @@ def autotune_custom_op(
     config_patches_list: list[dict[str, Any]] | None = None,
     min_speedup_threshold: float = 1.0,
     benchmark_with_cudagraphs: bool = False,
-) -> tuple[TensorBox, ChoiceCaller]:
+) -> tuple[TensorBox, _AutotuneChoice]:
     """Autotune custom operations by comparing multiple decomposition implementations.
 
     Currently supports SINGLE OUTPUT custom ops only.
@@ -537,8 +563,9 @@ def autotune_custom_op(
 
     is_collective = _detect_collective_ops(choices)
 
-    # Run autotuning and get both result and winning choice
-    selected_result, winning_choice = autotune_select_algorithm(
+    # Run autotuning and get both result and winning choice. The selector returns
+    # the base ChoiceCaller type, so cast to the structural winning-choice surface.
+    selected_result, winning_choice_base = autotune_select_algorithm(
         name=name,
         choices=choices,
         input_nodes=list(inputs),
@@ -548,6 +575,7 @@ def autotune_custom_op(
         min_speedup_threshold=min_speedup_threshold,
         benchmark_with_cudagraphs=benchmark_with_cudagraphs,
     )
+    winning_choice: _AutotuneChoice = cast(_AutotuneChoice, winning_choice_base)
 
     # Test mode: force specific choice to win
     force_choice = config.test_configs.force_custom_op_decomposition
@@ -557,7 +585,7 @@ def autotune_custom_op(
             if choice.gm is not None:
                 log.info(
                     "Test mode: forcing decomposition %s over fallback",
-                    getattr(choice, "name", type(choice).__name__),
+                    choice.name,
                 )
                 winning_choice = choice
                 selected_result = choice.output_node()
@@ -568,7 +596,7 @@ def autotune_custom_op(
             if choice.gm is None:
                 log.info(
                     "Test mode: forcing fallback %s over decomposition",
-                    getattr(choice, "name", type(choice).__name__),
+                    choice.name,
                 )
                 winning_choice = choice
                 selected_result = choice.output_node()
@@ -578,7 +606,7 @@ def autotune_custom_op(
     if winning_choice.gm is not None:
         log.debug(
             "Inlining winning choice: %s (name=%s)",
-            getattr(winning_choice, "name", type(winning_choice).__name__),
+            winning_choice.name,
             name,
         )
         from torch._inductor.codegen.subgraph import inline_subgraph_to_ir_nodes
@@ -596,7 +624,7 @@ def autotune_custom_op(
 
     log.debug(
         "Winning choice does not support inlining: %s (name=%s)",
-        getattr(winning_choice, "name", type(winning_choice).__name__),
+        winning_choice.name,
         name,
     )
     return selected_result, winning_choice
@@ -1120,7 +1148,7 @@ def register_custom_op_autotuning(
     | None = None,
     name: str | None = None,
     input_gen_fns: dict[str, Callable[[torch.Tensor], torch.Tensor]] | None = None,
-    dispatch_on: dict[str, Any] | None = None,
+    dispatch_on: DispatchOnConfig | None = None,
     split_points: list[int] | None = None,
     min_speedup_threshold: float = 1.0,
     benchmark_with_cudagraphs: bool = False,

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -2135,18 +2135,20 @@ def _serialize_pattern(
 
 SERIALIZED_PATTERN_PATH = Path(__file__).parent / "fx_passes" / "serialized_patterns"
 
+
 # This is the set of serialized patterns that we've registered.  Used by
 # test_serialized_patterns_up_to_date() to ensure the patterns are up
 # to date.
-_known_precompiled_patterns: list[
-    tuple[
-        Any,
-        Iterable[Any],
-        Callable[[Callable[..., Any], Iterable[Any]], torch.fx.GraphModule],
-        Any,
-        PatternExpr,
-    ]
-] = []
+@dataclasses.dataclass
+class _PrecompiledPattern:
+    search_fn: SearchFn
+    example_inputs: Sequence[Any]
+    trace_fn: TraceFn
+    scalar_workaround: dict[str, float | int] | None
+    search_fn_pattern: PatternExpr
+
+
+_known_precompiled_patterns: list[_PrecompiledPattern] = []
 
 
 def gen_register_replacement(
@@ -2191,7 +2193,7 @@ def gen_register_replacement(
             arg.constant = None
 
     _known_precompiled_patterns.append(
-        (search_fn, example_inputs, trace_fn, scalar_workaround, pat)
+        _PrecompiledPattern(search_fn, example_inputs, trace_fn, scalar_workaround, pat)
     )
     register_replacement(
         search_fn,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #190223

Replaces three loosely-typed shapes in the inductor autotune/pattern-matcher
paths with precise types, dropping getattr fallbacks and a 5-tuple with three
Any slots.

kernel/custom_op.py gets two new types: a DispatchOnConfig TypedDict for the
register_custom_op_autotuning(dispatch_on=...) argument (keys tensor_name: str,
dim: int, range_upper_bound: NotRequired[int], matching the documented shape),
and an _AutotuneChoice Protocol capturing the winning-choice surface consumed
after autotuning (name, gm, config_patches, decomposition, decomposition_kwargs,
layout, output_node()). The Protocol is structurally satisfied by the base
ChoiceCaller and its SubgraphChoiceCaller subclass, so autotune_custom_op now
returns tuple[TensorBox, _AutotuneChoice] and the getattr(choice, "name", ...)
fallbacks collapse to choice.name. autotune_select_algorithm returns the base
type untyped, so the winning choice is cast to _AutotuneChoice at that boundary.

pattern_matcher.py replaces the _known_precompiled_patterns 5-tuple with a
_PrecompiledPattern dataclass reusing the existing SearchFn/TraceFn Protocols;
the one positional-unpack consumer in test_pattern_matcher.py is updated to
attribute access.

This PR was authored with the assistance of an AI coding assistant.

Test Plan:

```
lintrunner --take PYFMT,RUFF,PYREFLY,CODESPELL,FLAKE8 \
  torch/_inductor/kernel/custom_op.py \
  torch/_inductor/pattern_matcher.py \
  test/inductor/test_pattern_matcher.py
```

```
python test/inductor/test_pattern_matcher.py -k test_serialized_patterns_up_to_date
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo