### PR TITLE
Fix: allow both linear reductions ("sum" and "avg") through the guard

### DIFF
--- a/test/distributed/test_functional_differentials.py
+++ b/test/distributed/test_functional_differentials.py
@@ -295,6 +295,31 @@ class TestFunctionalDifferentials(MultiThreadedTestCase):
         self.assertEqual(grad_input, expected_grad_input)
 
     @parametrize("device", devices)
+    def test_all_reduce_avg_backward(self, device):
+        """Test all_reduce backward with the 'avg' reduction.
+
+        Both tensor AND gradients are VARYING (different across ranks).
+        Backward aggregates gradients via all_reduce(avg).
+        """
+        group_name = dist.group.WORLD.group_name
+
+        input_tensor = torch.randn(3, 3, requires_grad=True, device=device)
+        output = fcols.all_reduce(input_tensor, "avg", group=group_name)
+
+        # Backward with ones: avg of ones across ranks is ones.
+        output.sum().backward()
+        expected_grad = torch.ones(3, 3, device=device)
+        self.assertEqual(input_tensor.grad, expected_grad)
+
+        # Backward is all_reduce (avg) of the incoming gradients.
+        grad_outputs = torch.rand_like(output, device=device)
+        (grad_input,) = torch.autograd.grad(
+            output, input_tensor, grad_outputs=grad_outputs
+        )
+        expected_grad_input = fcols.all_reduce(grad_outputs, "avg", group=group_name)
+        self.assertEqual(grad_input, expected_grad_input)
+
+    @parametrize("device", devices)
     @parametrize("gather_dim", [0, 1, 2])
     def test_all_gather_tensor_backward(self, device, gather_dim):
         """Test all_gather_tensor backward does reduce_scatter.

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -658,9 +658,13 @@ def all_reduce_backward(ctx, grad_output: torch.Tensor):
     group_name = ctx.group_name
     reduce_op = ctx.reduce_op
 
-    if reduce_op != "sum":
+    # Only linear reductions have a well-defined all_reduce backward: for both
+    # 'sum' and 'avg' the gradient is an all_reduce of grad_output with the same
+    # op (grad wrt each rank's input is the same reduction of the per-rank
+    # grad_outputs). Nonlinear ops (min/max/product/premul_sum) do not.
+    if reduce_op not in ("sum", "avg"):
         raise RuntimeError(
-            f"all_reduce backward only supports 'sum' reduction, got '{reduce_op}'"
+            f"all_reduce backward only supports 'sum' and 'avg' reductions, got '{reduce_op}'"
         )
 
     # Backward does all_reduce with the same reduce_op


### PR DESCRIPTION
 Title: Support 'avg' reduction in all_reduce autograd backward

 Fixes #190007

 What
The autograd backward for torch.distributed._functional_collectives.all_reduce rejected every reduction except "sum". Because the forward accepts any op, migrating from the deprecated torch.distributed.nn.functional.all_reduce(op=ReduceOp.AVG) to the recommended functional API silently broke .backward() — forward returned the correct mean, then backward raised RuntimeError: all_reduce backward only supports 'sum' reduction, got 'avg'.

Why it was wrong
The backward already computes all_reduce(grad_output, reduce_op, group_name) — the same op re-applied to the gradient. avg is a linear reduction, so that expression is the correct gradient (grad_input = all_reduce(grad_output, "avg"), since ∂((1/N)Σx_j)/∂x_r = 1/N). The guard was more restrictive than the math required. This matches the legacy _AllReduce.backward, which re-applies the same op and has always supported AVG.

Change
Permit both linear reductions ("sum" and "avge to reject nonlinear ops(min/max/product/premul_sum), which do not have a same-op all-reduce gradient. Added test_all_reduce_avg_backward mirroring the existing sum-backward test.

Testing
python test/distributed/test_functional_differentials.py -k test_all_reduce_avg_backward
 lintrunner -a