### PR TITLE
Move libtorch-extract jobs off EC2 onto OSDC

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -89,6 +89,7 @@ self-hosted-runner:
     - linux.google.tpuv7x.4
     # OSDC ARC (multi-tenant) runners
     - mt-l-x86iavx512-2-4
+    - mt-l-x86iavx512-16-128
     - mt-l-x86iavx512-48-384
     - mt-l-x86iavx512-94-768
     - mt-l-x86iamx-8-16

--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -547,6 +547,13 @@ def generate_libtorch_extraction_configs(
                 "gpu_arch_type": gpu_arch_type,
                 "gpu_arch_version": gpu_arch_version,
                 "arch": arch,
+                # Run the extraction in the same builder image the wheel was
+                # built in so the toolchain (binutils for debug-symbol split)
+                # matches; used by the linux template's containerized job.
+                "container_image": source_config.get("container_image", ""),
+                "container_image_tag_prefix": source_config.get(
+                    "container_image_tag_prefix", ""
+                ),
             }
         )
 

--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -468,9 +468,11 @@ jobs:
 
   libtorch-extract:
     name: ${{ matrix.build_name }}-extract
-    if: ${{ github.repository_owner == 'pytorch' }}
-    needs: [manywheel-build]
-    runs-on: "linux.4xlarge"
+    if: !{{ owner_if }}
+    needs: [manywheel-build, get-label-type{%- if pin_docker_image %}, get-docker-tag{%- endif %}]
+    runs-on: "!{{ runner_prefix }}l-x86iavx512-16-128"
+    container:
+      image: pytorch/${{ matrix.container_image }}:${{ matrix.container_image_tag_prefix }}!{{ docker_image_suffix }}
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -484,11 +486,15 @@ jobs:
             libtorch_config: "!{{ lt_config['libtorch_config'] }}"
             source_wheel_build_name: "!{{ lt_config['source_wheel_build_name'] }}"
             build_name: "!{{ lt_config['build_name'] }}"
+            container_image: "!{{ lt_config['container_image'] }}"
+            container_image_tag_prefix: "!{{ lt_config['container_image_tag_prefix'] }}"
         {%- endfor %}
     env:
       DESIRED_CUDA: ${{ matrix.desired_cuda }}
       LIBTORCH_VARIANT: ${{ matrix.libtorch_variant }}
     steps:
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Checkout PyTorch
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -507,10 +507,10 @@ jobs:
       - name: Extract libtorch from wheel
         run: |
           set -eux
-          mkdir -p "${{ runner.temp }}/libtorch_output"
+          mkdir -p "${RUNNER_TEMP}/libtorch_output"
           python3 .ci/libtorch/extract_libtorch_from_wheel.py \
-            --wheel-dir "${{ runner.temp }}/wheel_artifact" \
-            --output-dir "${{ runner.temp }}/libtorch_output" \
+            --wheel-dir "${RUNNER_TEMP}/wheel_artifact" \
+            --output-dir "${RUNNER_TEMP}/libtorch_output" \
             --platform linux \
             --desired-cuda "$DESIRED_CUDA" \
             --libtorch-variant "$LIBTORCH_VARIANT"

--- a/.github/templates/windows_binary_build_workflow.yml.j2
+++ b/.github/templates/windows_binary_build_workflow.yml.j2
@@ -332,12 +332,16 @@ jobs:
     if: ${{ github.repository_owner == 'pytorch' }}
     needs:
       - wheel-build
-    runs-on: "linux.4xlarge"
+    runs-on: "mt-l-x86iavx512-16-128"
+    container:
+      image: python:3.11
     timeout-minutes: 60
     env:
       DESIRED_CUDA: !{{ lt_config["desired_cuda"] }}
       LIBTORCH_VARIANT: !{{ lt_config["libtorch_variant"] }}
     steps:
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Checkout PyTorch
         uses: actions/checkout@v4
         with:

--- a/.github/templates/windows_binary_build_workflow.yml.j2
+++ b/.github/templates/windows_binary_build_workflow.yml.j2
@@ -357,10 +357,10 @@ jobs:
         shell: bash
         run: |
           set -eux
-          mkdir -p "${{ runner.temp }}/libtorch_output"
+          mkdir -p "${RUNNER_TEMP}/libtorch_output"
           python3 .ci/libtorch/extract_libtorch_from_wheel.py \
-            --wheel-dir "${{ runner.temp }}/wheel_artifact" \
-            --output-dir "${{ runner.temp }}/libtorch_output" \
+            --wheel-dir "${RUNNER_TEMP}/wheel_artifact" \
+            --output-dir "${RUNNER_TEMP}/libtorch_output" \
             --platform windows \
             --desired-cuda "$DESIRED_CUDA" \
             --libtorch-variant "$LIBTORCH_VARIANT" \

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -1589,9 +1589,11 @@ jobs:
 
   libtorch-extract:
     name: ${{ matrix.build_name }}-extract
-    if: ${{ github.repository_owner == 'pytorch' }}
-    needs: [manywheel-build]
-    runs-on: "linux.4xlarge"
+    if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
+    needs: [manywheel-build, get-label-type, get-docker-tag]
+    runs-on: "${{ needs.get-label-type.outputs.label-type }}l-x86iavx512-16-128"
+    container:
+      image: pytorch/${{ matrix.container_image }}:${{ matrix.container_image_tag_prefix }}${{ needs.get-docker-tag.outputs.docker_image_suffix }}
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -1604,6 +1606,8 @@ jobs:
             libtorch_config: "release"
             source_wheel_build_name: "manywheel-py3_10-cpu"
             build_name: "libtorch-cpu-shared-with-deps-release"
+            container_image: "manylinux2_28-builder"
+            container_image_tag_prefix: "cpu"
           - desired_cuda: "cu126"
             gpu_arch_type: "cuda"
             gpu_arch_version: "12.6"
@@ -1611,6 +1615,8 @@ jobs:
             libtorch_config: "release"
             source_wheel_build_name: "manywheel-py3_10-cuda12_6"
             build_name: "libtorch-cuda12_6-shared-with-deps-release"
+            container_image: "manylinux2_28-builder"
+            container_image_tag_prefix: "cuda12.6"
           - desired_cuda: "cu130"
             gpu_arch_type: "cuda"
             gpu_arch_version: "13.0"
@@ -1618,6 +1624,8 @@ jobs:
             libtorch_config: "release"
             source_wheel_build_name: "manywheel-py3_10-cuda13_0"
             build_name: "libtorch-cuda13_0-shared-with-deps-release"
+            container_image: "manylinux2_28-builder"
+            container_image_tag_prefix: "cuda13.0"
           - desired_cuda: "cu132"
             gpu_arch_type: "cuda"
             gpu_arch_version: "13.2"
@@ -1625,6 +1633,8 @@ jobs:
             libtorch_config: "release"
             source_wheel_build_name: "manywheel-py3_10-cuda13_2"
             build_name: "libtorch-cuda13_2-shared-with-deps-release"
+            container_image: "manylinux2_28-builder"
+            container_image_tag_prefix: "cuda13.2"
           - desired_cuda: "rocm7.1"
             gpu_arch_type: "rocm"
             gpu_arch_version: "7.1"
@@ -1632,6 +1642,8 @@ jobs:
             libtorch_config: "release"
             source_wheel_build_name: "manywheel-py3_10-rocm7_1"
             build_name: "libtorch-rocm7_1-shared-with-deps-release"
+            container_image: "manylinux2_28-builder"
+            container_image_tag_prefix: "rocm7.1"
           - desired_cuda: "rocm7.2"
             gpu_arch_type: "rocm"
             gpu_arch_version: "7.2"
@@ -1639,10 +1651,14 @@ jobs:
             libtorch_config: "release"
             source_wheel_build_name: "manywheel-py3_10-rocm7_2"
             build_name: "libtorch-rocm7_2-shared-with-deps-release"
+            container_image: "manylinux2_28-builder"
+            container_image_tag_prefix: "rocm7.2"
     env:
       DESIRED_CUDA: ${{ matrix.desired_cuda }}
       LIBTORCH_VARIANT: ${{ matrix.libtorch_variant }}
     steps:
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Checkout PyTorch
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -1661,10 +1661,10 @@ jobs:
       - name: Extract libtorch from wheel
         run: |
           set -eux
-          mkdir -p "${{ runner.temp }}/libtorch_output"
+          mkdir -p "${RUNNER_TEMP}/libtorch_output"
           python3 .ci/libtorch/extract_libtorch_from_wheel.py \
-            --wheel-dir "${{ runner.temp }}/wheel_artifact" \
-            --output-dir "${{ runner.temp }}/libtorch_output" \
+            --wheel-dir "${RUNNER_TEMP}/wheel_artifact" \
+            --output-dir "${RUNNER_TEMP}/libtorch_output" \
             --platform linux \
             --desired-cuda "$DESIRED_CUDA" \
             --libtorch-variant "$LIBTORCH_VARIANT"

--- a/.github/workflows/generated-windows-arm64-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-arm64-binary-wheel-nightly.yml
@@ -258,12 +258,16 @@ jobs:
     if: ${{ github.repository_owner == 'pytorch' }}
     needs:
       - wheel-build
-    runs-on: "linux.4xlarge"
+    runs-on: "mt-l-x86iavx512-16-128"
+    container:
+      image: python:3.11
     timeout-minutes: 60
     env:
       DESIRED_CUDA: cpu
       LIBTORCH_VARIANT: shared-with-deps
     steps:
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Checkout PyTorch
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/generated-windows-arm64-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-arm64-binary-wheel-nightly.yml
@@ -283,10 +283,10 @@ jobs:
         shell: bash
         run: |
           set -eux
-          mkdir -p "${{ runner.temp }}/libtorch_output"
+          mkdir -p "${RUNNER_TEMP}/libtorch_output"
           python3 .ci/libtorch/extract_libtorch_from_wheel.py \
-            --wheel-dir "${{ runner.temp }}/wheel_artifact" \
-            --output-dir "${{ runner.temp }}/libtorch_output" \
+            --wheel-dir "${RUNNER_TEMP}/wheel_artifact" \
+            --output-dir "${RUNNER_TEMP}/libtorch_output" \
             --platform windows \
             --desired-cuda "$DESIRED_CUDA" \
             --libtorch-variant "$LIBTORCH_VARIANT" \

--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -793,12 +793,16 @@ jobs:
     if: ${{ github.repository_owner == 'pytorch' }}
     needs:
       - wheel-build
-    runs-on: "linux.4xlarge"
+    runs-on: "mt-l-x86iavx512-16-128"
+    container:
+      image: python:3.11
     timeout-minutes: 60
     env:
       DESIRED_CUDA: cpu
       LIBTORCH_VARIANT: shared-with-deps
     steps:
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Checkout PyTorch
         uses: actions/checkout@v4
         with:
@@ -853,12 +857,16 @@ jobs:
     if: ${{ github.repository_owner == 'pytorch' }}
     needs:
       - wheel-build
-    runs-on: "linux.4xlarge"
+    runs-on: "mt-l-x86iavx512-16-128"
+    container:
+      image: python:3.11
     timeout-minutes: 60
     env:
       DESIRED_CUDA: cu126
       LIBTORCH_VARIANT: shared-with-deps
     steps:
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Checkout PyTorch
         uses: actions/checkout@v4
         with:
@@ -914,12 +922,16 @@ jobs:
     if: ${{ github.repository_owner == 'pytorch' }}
     needs:
       - wheel-build
-    runs-on: "linux.4xlarge"
+    runs-on: "mt-l-x86iavx512-16-128"
+    container:
+      image: python:3.11
     timeout-minutes: 60
     env:
       DESIRED_CUDA: cu130
       LIBTORCH_VARIANT: shared-with-deps
     steps:
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Checkout PyTorch
         uses: actions/checkout@v4
         with:
@@ -975,12 +987,16 @@ jobs:
     if: ${{ github.repository_owner == 'pytorch' }}
     needs:
       - wheel-build
-    runs-on: "linux.4xlarge"
+    runs-on: "mt-l-x86iavx512-16-128"
+    container:
+      image: python:3.11
     timeout-minutes: 60
     env:
       DESIRED_CUDA: cu132
       LIBTORCH_VARIANT: shared-with-deps
     steps:
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Checkout PyTorch
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -818,10 +818,10 @@ jobs:
         shell: bash
         run: |
           set -eux
-          mkdir -p "${{ runner.temp }}/libtorch_output"
+          mkdir -p "${RUNNER_TEMP}/libtorch_output"
           python3 .ci/libtorch/extract_libtorch_from_wheel.py \
-            --wheel-dir "${{ runner.temp }}/wheel_artifact" \
-            --output-dir "${{ runner.temp }}/libtorch_output" \
+            --wheel-dir "${RUNNER_TEMP}/wheel_artifact" \
+            --output-dir "${RUNNER_TEMP}/libtorch_output" \
             --platform windows \
             --desired-cuda "$DESIRED_CUDA" \
             --libtorch-variant "$LIBTORCH_VARIANT" \
@@ -882,10 +882,10 @@ jobs:
         shell: bash
         run: |
           set -eux
-          mkdir -p "${{ runner.temp }}/libtorch_output"
+          mkdir -p "${RUNNER_TEMP}/libtorch_output"
           python3 .ci/libtorch/extract_libtorch_from_wheel.py \
-            --wheel-dir "${{ runner.temp }}/wheel_artifact" \
-            --output-dir "${{ runner.temp }}/libtorch_output" \
+            --wheel-dir "${RUNNER_TEMP}/wheel_artifact" \
+            --output-dir "${RUNNER_TEMP}/libtorch_output" \
             --platform windows \
             --desired-cuda "$DESIRED_CUDA" \
             --libtorch-variant "$LIBTORCH_VARIANT" \
@@ -947,10 +947,10 @@ jobs:
         shell: bash
         run: |
           set -eux
-          mkdir -p "${{ runner.temp }}/libtorch_output"
+          mkdir -p "${RUNNER_TEMP}/libtorch_output"
           python3 .ci/libtorch/extract_libtorch_from_wheel.py \
-            --wheel-dir "${{ runner.temp }}/wheel_artifact" \
-            --output-dir "${{ runner.temp }}/libtorch_output" \
+            --wheel-dir "${RUNNER_TEMP}/wheel_artifact" \
+            --output-dir "${RUNNER_TEMP}/libtorch_output" \
             --platform windows \
             --desired-cuda "$DESIRED_CUDA" \
             --libtorch-variant "$LIBTORCH_VARIANT" \
@@ -1012,10 +1012,10 @@ jobs:
         shell: bash
         run: |
           set -eux
-          mkdir -p "${{ runner.temp }}/libtorch_output"
+          mkdir -p "${RUNNER_TEMP}/libtorch_output"
           python3 .ci/libtorch/extract_libtorch_from_wheel.py \
-            --wheel-dir "${{ runner.temp }}/wheel_artifact" \
-            --output-dir "${{ runner.temp }}/libtorch_output" \
+            --wheel-dir "${RUNNER_TEMP}/wheel_artifact" \
+            --output-dir "${RUNNER_TEMP}/libtorch_output" \
             --platform windows \
             --desired-cuda "$DESIRED_CUDA" \
             --libtorch-variant "$LIBTORCH_VARIANT" \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #190229
* __->__ #190227

The libtorch extraction jobs in the Linux manywheel and Windows wheel
binary workflows still ran on the EC2 `linux.4xlarge` label. Standalone
jobs like these bypass the arc-enabled reusable workflows, so arc.yaml
does not remap them to OSDC -- they land on EC2. Run them on OSDC
directly instead.

The Linux extraction splits debug symbols (strip/objcopy), so it needs a
toolchain image: it now runs in the same manylinux builder image its
source wheel was built in (threaded through the extraction config) on
l-x86iavx512-16-128, matching the build job's image tag exactly so the
image is guaranteed to exist. The Windows extraction only unpacks a
wheel with the Python stdlib (--platform windows skips debug-symbol
splitting), so it runs in python:3.11 on the same runner.

Test Plan:
Regenerated and confirmed only the intended workflows changed:

```
python3 .github/scripts/generate_ci_workflows.py
git status --short .github/workflows/generated-*.yml
```

Verified the Linux extract container tag matches the build job's image
tag for each config (e.g. pytorch/manylinux2_28-builder:cpu...).

Authored with assistance from Claude Code.