### PR TITLE
[ROCm][CI] Enable scheduled MI200 workflows

### DIFF
--- a/.github/workflows/inductor-rocm-mi200.yml
+++ b/.github/workflows/inductor-rocm-mi200.yml
@@ -2,8 +2,8 @@
 name: inductor-rocm-mi200
 
 on:
-  #schedule:
-    #- cron: 0 0,3,6,9,12,15,18,21 * * * # run every 3 hours for regression coverage
+  schedule:
+    - cron: 0 0,3,6,9,12,15,18,21 * * * # run every 3 hours for regression coverage
   push:
     #branches:
       #- release/*

--- a/.github/workflows/rocm-mi200.yml
+++ b/.github/workflows/rocm-mi200.yml
@@ -8,8 +8,8 @@ on:
     tags:
       - ciflow/rocm-mi200/*
   workflow_dispatch:
-  #schedule:
-    #- cron: 0 0,3,6,9,12,15,18,21 * * * # run every 3 hours for regression coverage
+  schedule:
+    - cron: 0 0,3,6,9,12,15,18,21 * * * # run every 3 hours for regression coverage
 
 
 concurrency:


### PR DESCRIPTION
## Summary

Enable the scheduled `rocm-mi200` and `inductor-rocm-mi200` workflows to run every three hours for regression coverage.

The shard-count expansion originally carried by this PR is now on `main` via #190095, so after rebasing this PR only enables the existing schedule blocks. Existing `ciflow` tags and `workflow_dispatch` triggers remain unchanged.

## Test plan

- Local YAML syntax validation: `python -c "import yaml; [yaml.safe_load(open(f)) for f in ['.github/workflows/rocm-mi200.yml','.github/workflows/inductor-rocm-mi200.yml']]"`
- `git diff --check`
- CI validation via `ciflow/rocm-mi200` and `ciflow/inductor-rocm-mi200`.

## Validation

- `rocm-mi200`: https://github.com/pytorch/pytorch/actions/runs/29948088509
- `inductor-rocm-mi200`: https://github.com/pytorch/pytorch/actions/runs/29948086651
- HUD: https://hud.pytorch.org/pr/190230

# NOTE
Open https://github.com/pytorch/pytorch/issues/169966 and https://github.com/pytorch/pytorch/issues/169965 once this PR is merged, so we can move those workflows to UNSTABLE until we resolve the unit test failures.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang

Made with Cursor