### PR TITLE
Fix typos in comments and docstrings across torch

### DIFF
--- a/torch/_library/fake_class_registry.py
+++ b/torch/_library/fake_class_registry.py
@@ -406,11 +406,11 @@ def register_fake_class(qualname, fake_class: HasStaticMethodFromReal | None = N
             def size(self):
                 return len(self.queue)
 
-    In this example, the original TensorQeue need to add a __obj_flatten__ method
+    In this example, the original TensorQueue need to add a __obj_flatten__ method
     to the class TensorQueue and the flattened result is passed into FakeTensorQueue's
     __obj_unflatten__ as inputs to create a fake class. This protocol allows pytorch to look
     at the contents of the script object and properly handle them in the subsystems
-    like dynamo, aot_aotugrad or more.
+    like dynamo, aot_autograd or more.
     """
 
     def inner(fake_class: HasStaticMethodFromReal):

--- a/torch/_prims_common/__init__.py
+++ b/torch/_prims_common/__init__.py
@@ -1850,7 +1850,7 @@ def make_channels_last_1d_strides_for(
     multiplier: _IntLikeT | int = 1
     strides: list[_IntLikeT | int] = [0] * 3
     for idx in (1, -1, 0):
-        # NOTE: intentionally divergence from make_contiguous_strides_for
+        # NOTE: intentional divergence from make_contiguous_strides_for
         # This is consistent with eager
         strides[idx] = multiplier
         multiplier *= shape[idx]
@@ -1870,7 +1870,7 @@ def make_channels_last_2d_strides_for(
     multiplier: _IntLikeT | int = 1
     strides: list[_IntLikeT | int] = [0] * 4
     for idx in (1, -1, -2, 0):
-        # NOTE: intentionally divergence from make_contiguous_strides_for
+        # NOTE: intentional divergence from make_contiguous_strides_for
         # This is consistent with eager
         strides[idx] = multiplier
         multiplier *= shape[idx]
@@ -1889,7 +1889,7 @@ def make_channels_last_3d_strides_for(
     multiplier: _IntLikeT | int = 1
     strides: list[_IntLikeT | int] = [0] * 5
     for idx in (1, -1, -2, -3, 0):
-        # NOTE: intentionally divergence from make_contiguous_strides_for
+        # NOTE: intentional divergence from make_contiguous_strides_for
         # This is consistent with eager
         strides[idx] = multiplier
         multiplier *= shape[idx]

--- a/torch/_vmap_internals.py
+++ b/torch/_vmap_internals.py
@@ -113,7 +113,7 @@ def _create_batched_inputs(
     return tree_unflatten(batched_inputs, args_spec), batch_size
 
 
-# Undos the batching (and any batch dimensions) associated with the `vmap_level`.
+# Undoes the batching (and any batch dimensions) associated with the `vmap_level`.
 def _unwrap_batched(
     batched_outputs: Tensor | tuple[Tensor, ...],
     out_dims: out_dims_t,

--- a/torch/backends/_nnapi/serializer.py
+++ b/torch/backends/_nnapi/serializer.py
@@ -1253,7 +1253,7 @@ class _NnapiSerializer:
         )
         inputs[4] = self.add_immediate_int_scalar(0)  # begin mask
         inputs[5] = self.add_immediate_int_scalar(end_mask)
-        inputs[6] = self.add_immediate_int_scalar(0)  # shrink axis mas
+        inputs[6] = self.add_immediate_int_scalar(0)  # shrink axis mask
 
         outputs = [None] * 1
         outputs[0] = out_id

--- a/torch/backends/xeon/run_cpu.py
+++ b/torch/backends/xeon/run_cpu.py
@@ -236,7 +236,7 @@ class _CPUinfo:
         Check whether all cores in core_list are in the same NUMA node.
 
         Cross NUMA will reduce performance.
-        We strongly advice to not use cores on different nodes.
+        We strongly advise to not use cores on different nodes.
         """
         cores_numa_map = self.logical_core_node_map
         numa_ids = []

--- a/torch/compiler/_cache.py
+++ b/torch/compiler/_cache.py
@@ -207,7 +207,7 @@ class CacheArtifactManager:
 
     # Protected by the compile_lock
     _new_cache_artifacts: CacheArtifactsResult = defaultdict(list)
-    # Keep a separate seen artifacts list to make avoid unnecessary duplicates
+    # Keep a separate seen artifacts list to avoid unnecessary duplicates
     # This list will not be cleared between serialize() calls
     _seen_artifacts: OrderedSet[CacheArtifact] = OrderedSet()
     # When serialize() is called, artifacts are transferred from _cache_artifacts to

--- a/torch/compiler/config.py
+++ b/torch/compiler/config.py
@@ -65,7 +65,7 @@ they remember it is dynamic.  This profile information, however, is sensitive
 to what workload you are running, so we require you to tell us that two jobs
 are *related* (i.e., are the same workload) before we are willing to reuse
 this information.  Notably, PGO does nothing (even if explicitly enabled)
-unless a valid ``job_id`` is available.  In some situations, PyTorch can
+unless a valid ``job_id`` is available.  In some situations, PyTorch can be
 configured to automatically compute a ``job_id`` based on the environment it
 is running in.
 

--- a/torch/csrc/autograd/engine.h
+++ b/torch/csrc/autograd/engine.h
@@ -161,7 +161,7 @@ struct TORCH_API Engine {
   // for the graph.
   //
   // NB: This API should only be used by internal autograd specific
-  // machinery and shouldn't be exposed to users in anyway.
+  // machinery and shouldn't be exposed to users in any way.
   virtual c10::intrusive_ptr<at::ivalue::Future> execute_with_graph_task(
       const std::shared_ptr<GraphTask>& graph_task,
       c10::intrusive_ptr<Node> graph_root,

--- a/torch/csrc/cuda/nccl.h
+++ b/torch/csrc/cuda/nccl.h
@@ -28,7 +28,7 @@ namespace torch::cuda::nccl {
 typedef void* ncclComm_t;
 
 /** redefine nccl unique ID in torch scope. this should be identical to native
- * nccl impp. */
+ * nccl impl. */
 #define NCCL_UNIQUE_ID_BYTES 128
 typedef struct {
   // NOLINTNEXTLINE(*array*)

--- a/torch/csrc/distributed/rpc/rpc_agent.h
+++ b/torch/csrc/distributed/rpc/rpc_agent.h
@@ -222,7 +222,7 @@ class TORCH_API RpcAgent {
   void shutdown();
 
   // Derived classes must override this function to start accepting requests.
-  // THis is used to clean up any backend-specific state. Users must call
+  // This is used to clean up any backend-specific state. Users must call
   // shutdown, not shutdownImpl, to shutdown the RPC Agent.
   virtual void shutdownImpl() = 0;
 

--- a/torch/csrc/lazy/ts_backend/ops/device_data.h
+++ b/torch/csrc/lazy/ts_backend/ops/device_data.h
@@ -36,7 +36,7 @@ class TORCH_API DeviceData : public TsNode {
   static const DeviceData* Cast(const Node* node);
 
   // To reuse IR nodes, use this method to create DeviceData nodes
-  // instead of calling the constructor directconst ly.
+  // instead of calling the constructor directly.
   static NodePtr Create(const std::shared_ptr<BackendData>& data);
 
   TSOpVector Lower(

--- a/torch/csrc/profiler/data_flow.h
+++ b/torch/csrc/profiler/data_flow.h
@@ -9,7 +9,7 @@
 
 namespace torch::profiler::impl {
 
-// Identity is a complex concept in PyTorch. A Tensor might not have a
+// Identity is a complex concept in PyTorch. A Tensor might not have
 // an associated storage, multiple Tensors might share the same underlying
 // storage, the storage of a Tensor might change over time, etc.
 //

--- a/torch/csrc/utils/pybind.h
+++ b/torch/csrc/utils/pybind.h
@@ -398,7 +398,7 @@ namespace torch::impl {
 //
 // Attaching the GIL release logic to the holder pointer rather than the
 // actual destructor of T is helpful when T is Python-agnostic and
-// shouldn't refer to the PYthon API.
+// shouldn't refer to the Python API.
 //
 // Note there are limitations to the correctness of code that makes use of this.
 // In particular, if a shared_ptr is constructed from C++ code without this

--- a/torch/distributed/_shard/sharded_tensor/reshard.py
+++ b/torch/distributed/_shard/sharded_tensor/reshard.py
@@ -55,7 +55,7 @@ def build_reshard_metadata(
         world_size (int): number of ranks.
 
     Returns:
-        A Tuple of the followings:
+        A Tuple of the following:
             A List[`ShardMetadata`] which contains the metadata for the shard, including
                 offsets, lengths and device placement.
             A List[int] which contains the ranks in the order of placement.
@@ -105,7 +105,7 @@ def reshuffle_local_shard(
         pg (ProcessGroup): The process group to aggregate on.
 
     Returns:
-        A Tuple of the followings:
+        A Tuple of the following:
             A List[`Shard`] which contains the local tensor and its metadata.
             A List[`ShardMetadata`] which contains the metadata for the shard, including
                 offsets, lengths and device placement.
@@ -174,7 +174,7 @@ def reshard_local_shard(
         pg (ProcessGroup): The process group to aggregate on.
 
     Returns:
-        A Tuple of the followings:
+        A Tuple of the following:
             A List[`Shard`] which contains the local tensor and its metadata.
             A List[`ShardMetadata`] which contains the metadata for the shard, including
                 offsets, lengths and device placement.

--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -509,7 +509,7 @@ class OpDispatcher:
 
         if output_sharding.output_spec is None:
             if op_call == aten.equal.default:
-                # The output of the equal op is a bool, by converting it into a
+                # The output of the equal op is a bool, by converting it into
                 # a single value tensor, we can use all-reduce with min reduce op
                 # to simulate logical and.
                 if not (local_results is None or isinstance(local_results, bool)):

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -361,7 +361,7 @@ class TransformerEncoder(Module):
         self.layers = _get_clones(encoder_layer, num_layers)
         self.num_layers = num_layers
         self.norm = norm
-        # this attribute saves the value providedat object construction
+        # this attribute saves the value provided at object construction
         self.enable_nested_tensor = enable_nested_tensor
         # this attribute controls whether nested tensors are used
         self.use_nested_tensor = enable_nested_tensor


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #190249

Correct spelling and grammar mistakes in code comments and docstrings throughout the torch package. These are documentation-only changes with no functional impact, covering typos such as "TensorQeue" to "TensorQueue", "Undos" to "Undoes", "followings" to "following", and similar fixes across autograd, distributed, nn, compiler, and other modules.