### PR TITLE
Migrate docker-release (Build Official Docker Images) to OSDC

### DIFF
--- a/.github/scripts/generate_docker_release_matrix.py
+++ b/.github/scripts/generate_docker_release_matrix.py
@@ -12,6 +12,7 @@ Will output a condensed version of the matrix. Will include fllowing:
 """
 
 import json
+import os
 
 import generate_binary_build_matrix
 
@@ -20,6 +21,11 @@ DOCKER_IMAGE_TYPES = ["runtime", "devel"]
 
 
 def generate_docker_matrix() -> dict[str, list[dict[str, str]]]:
+    # OSDC runner per platform; the workflow ref-gates these (release-isolated
+    # on protected refs, regular otherwise) and passes them in.
+    x86_runner = os.environ.get("RUNNER_X86", "mt-l-x86iavx512-48-384")
+    arm64_runner = os.environ.get("RUNNER_ARM64", "mt-l-arm64g3-61-463")
+
     ret: list[dict[str, str]] = []
     # CUDA amd64 Docker images are available as both runtime and devel while
     # CPU arm64 image is only available as runtime.
@@ -34,6 +40,7 @@ def generate_docker_matrix() -> dict[str, list[dict[str, str]]]:
                     ],
                     "image_type": image,
                     "platform": "linux/amd64",
+                    "runner": x86_runner,
                 }
             )
     ret.append(
@@ -43,6 +50,7 @@ def generate_docker_matrix() -> dict[str, list[dict[str, str]]]:
             "cudnn_version": "",
             "image_type": "runtime",
             "platform": "linux/arm64",
+            "runner": arm64_runner,
         }
     )
 

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -38,7 +38,7 @@ permissions: read-all
 jobs:
   generate-matrix:
     if: github.repository_owner == 'pytorch'
-    runs-on: "linux.large"
+    runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
     steps:
@@ -50,15 +50,30 @@ jobs:
       - name: Get docker release matrix
         id: generate-matrix
         run: |
+          # Release-isolated OSDC runners on protected refs, regular otherwise.
+          if [[ "${GITHUB_REF}" == refs/heads/main || "${GITHUB_REF}" == refs/heads/nightly || "${GITHUB_REF}" == refs/heads/release/* || "${GITHUB_REF}" == refs/tags/v* ]]; then
+            export RUNNER_X86="mt-rel-l-x86iavx512-44-340"
+            export RUNNER_ARM64="mt-rel-l-arm64g3-44-340"
+          else
+            export RUNNER_X86="mt-l-x86iavx512-48-384"
+            export RUNNER_ARM64="mt-l-arm64g3-61-463"
+          fi
           MATRIX_BLOB="$(python3 .github/scripts/generate_docker_release_matrix.py)"
           echo "${MATRIX_BLOB}"
           echo "matrix=${MATRIX_BLOB}" >> "${GITHUB_OUTPUT}"
 
   build:
     if: ${{ github.repository == 'pytorch/pytorch' }}
-    runs-on: "linux.2xlarge"
+    runs-on: ${{ matrix.runner }}
+    container:
+      image: ghcr.io/actions/actions-runner:latest
     environment: ${{ (github.ref == 'refs/heads/nightly' || startsWith(github.event.ref, 'refs/tags/v')) && 'docker-build' || '' }}
     timeout-minutes: 240
+    # The actions-runner container defaults `run:` to sh; force bash for the
+    # build/tag scripts (set -o pipefail, [[ ]], PIPESTATUS).
+    defaults:
+      run:
+        shell: bash
     needs:
       - generate-matrix
     strategy:
@@ -71,19 +86,16 @@ jobs:
       CUDA_VERSION_SHORT: ${{ matrix.cuda }}
       CUDNN_VERSION: ${{ matrix.cudnn_version }}
     steps:
-      - name: Setup SSH (Click me for login details)
-        uses: pytorch/test-infra/.github/actions/setup-ssh@main
-        with:
-          github-secret: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Setup Linux
-        uses: pytorch/pytorch/.github/actions/setup-linux@main
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Checkout PyTorch
+        uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
         with:
           submodules: 'false'
-
-      - name: Login to ECR
-        uses: ./.github/actions/ecr-login
-
+      - name: Setup UV
+        uses: pytorch/test-infra/.github/actions/setup-uv@main
+      - name: Install make
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends make
       - name: Login to GitHub Container Registry
         if: ${{ env.WITH_PUSH == 'true' }}
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
@@ -91,26 +103,20 @@ jobs:
           registry: ghcr.io
           username: pytorch
           password: ${{ secrets.GHCR_PAT }}
-      # Setup multi-arch image builds
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
-        env:
-          QEMU_BINARY_PATH: ${{ runner.temp }}/bin
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
-        with:
-          version: latest
-          driver-opts: image=moby/buildkit:v0.19.0
+      # OSDC/ARC pods have no host docker daemon; build on a remote BuildKit pod
+      # (native per-arch, so no QEMU emulation needed).
+      - name: Set up Docker Buildx (remote)
+        run: |
+          set -ex
+          case "$(uname -m)" in
+            aarch64|arm64) buildkit_addr="tcp://buildkitd-arm64.buildkit:1234" ;;
+            *)             buildkit_addr="tcp://buildkitd-amd64.buildkit:1234" ;;
+          esac
+          docker buildx create --name remote-buildkit --driver remote --use "${buildkit_addr}"
       - name: Setup job specific variables
         run: |
-          set -eou pipefail
-          # To get QEMU binaries in our PATH
-          echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
-          # Generate PyTorch version to use
-          {
-            echo "PYTORCH_VERSION=$(python3 .github/scripts/generate_pytorch_version.py --no-build-suffix)";
-            echo "STABLE_CUDA_VERSION=$(python3 .github/scripts/get_ci_variable.py --cuda-stable-version)"
-          } >> "${GITHUB_ENV}"
+          echo "PYTORCH_VERSION=$(python3 .github/scripts/generate_pytorch_version.py --no-build-suffix)" >> "${GITHUB_ENV}"
+          echo "STABLE_CUDA_VERSION=$(python3 .github/scripts/get_ci_variable.py --cuda-stable-version)" >> "${GITHUB_ENV}"
       - name: Setup test specific variables
         if: ${{ startsWith(github.event.ref, 'refs/tags/v') }}
         run: |
@@ -130,32 +136,76 @@ jobs:
             echo "TRITON_VERSION=$(cut -f 1 .ci/docker/triton_version.txt)+$(cut -c -10 .ci/docker/ci_commit_pins/triton.txt)";
           } >> "${GITHUB_ENV}"
       - name: Run docker build / push
-        # WITH_PUSH is used here to determine whether or not to add the --push flag
+        # docker.Makefile drives the buildx build; the remote BuildKit builder
+        # set up above is the current buildx builder, so it runs there.
         run: |
-          make -f docker.Makefile "${BUILD_IMAGE_TYPE}-image"
+          set -eo pipefail
+
+          run_build() {
+            make -f docker.Makefile "${BUILD_IMAGE_TYPE}-image"
+          }
+
+          # The autoscaled BuildKit pool may be cold / at capacity at start, where
+          # buildx's connect fails before scale-up. Retry connection failures (not
+          # build errors) so a capacity-limited build waits for a free pod.
+          attempts="${REMOTE_BUILDKIT_CONNECT_ATTEMPTS:-360}"
+          delay="${REMOTE_BUILDKIT_CONNECT_DELAY:-15}"
+          for attempt in $(seq 1 "${attempts}"); do
+            build_log="$(mktemp)"
+            set +e
+            run_build 2>&1 | tee "${build_log}"
+            rc="${PIPESTATUS[0]}"
+            set -e
+            if [[ "${rc}" -eq 0 ]]; then
+              rm -f "${build_log}"
+              break
+            fi
+            if [[ "${attempt}" -lt "${attempts}" ]] && grep -qiE \
+              "waiting for connection|context deadline exceeded|server preface|failed to (dial|list workers)|connection (refused|reset)|no such host|transport: Error|i/o timeout|use of closed network connection|EOF" \
+              "${build_log}"; then
+              echo "Remote BuildKit not ready yet (attempt ${attempt}/${attempts}); retrying in ${delay}s..." >&2
+              rm -f "${build_log}"
+              sleep "${delay}"
+              continue
+            fi
+            rm -f "${build_log}"
+            exit "${rc}"
+          done
       - name: Push nightly tags
+        # Daemon-less: ARC has no docker daemon. Read git_version out of the
+        # pushed image via a one-file BuildKit stage, then create the alias
+        # tags registry-side with imagetools.
         if: ${{ github.event.ref == 'refs/heads/nightly' && matrix.image_type == 'runtime' && matrix.platform == 'linux/amd64' }}
         run: |
+          set -eo pipefail
+          PREFIX="ghcr.io/pytorch/pytorch-nightly"
           PYTORCH_DOCKER_TAG="${PYTORCH_VERSION}-cuda${CUDA_VERSION_SHORT}-cudnn${CUDNN_VERSION}-runtime"
           CUDA_SUFFIX="-cu${CUDA_VERSION}"
-          PYTORCH_NIGHTLY_COMMIT=$(docker run ghcr.io/pytorch/pytorch-nightly:"${PYTORCH_DOCKER_TAG}" \
-                                          python -c 'import torch; print(torch.version.git_version[:7],end="")')
 
-          docker tag ghcr.io/pytorch/pytorch-nightly:"${PYTORCH_DOCKER_TAG}" \
-                 ghcr.io/pytorch/pytorch-nightly:"${PYTORCH_NIGHTLY_COMMIT}${CUDA_SUFFIX}"
+          out="$(mktemp -d)"
+          cat > "${out}/Dockerfile" <<'DOCKERFILE'
+          ARG SRC_IMAGE
+          FROM ${SRC_IMAGE} AS src
+          RUN python -c 'import torch; print(torch.version.git_version[:7], end="")' > /commit
+          FROM scratch AS out
+          COPY --from=src /commit /commit
+          DOCKERFILE
+          docker buildx build --builder remote-buildkit \
+            --build-arg SRC_IMAGE="${PREFIX}:${PYTORCH_DOCKER_TAG}" \
+            --target out --output "type=local,dest=${out}/export" \
+            -f "${out}/Dockerfile" "${out}"
+          PYTORCH_NIGHTLY_COMMIT="$(cat "${out}/export/commit")"
 
-          docker push ghcr.io/pytorch/pytorch-nightly:"${PYTORCH_NIGHTLY_COMMIT}${CUDA_SUFFIX}"
+          docker buildx imagetools create \
+            -t "${PREFIX}:${PYTORCH_NIGHTLY_COMMIT}${CUDA_SUFFIX}" \
+            "${PREFIX}:${PYTORCH_DOCKER_TAG}"
 
-          # Please note, here we need to pin specific version of CUDA as with latest label
-          if [[ ${CUDA_VERSION_SHORT} == "${STABLE_CUDA_VERSION}" ]]; then
-            docker tag ghcr.io/pytorch/pytorch-nightly:"${PYTORCH_NIGHTLY_COMMIT}${CUDA_SUFFIX}" \
-                    ghcr.io/pytorch/pytorch-nightly:latest
-            docker push ghcr.io/pytorch/pytorch-nightly:latest
+          # Pin latest to the stable-CUDA build, as before.
+          if [[ "${CUDA_VERSION_SHORT}" == "${STABLE_CUDA_VERSION}" ]]; then
+            docker buildx imagetools create \
+              -t "${PREFIX}:latest" \
+              "${PREFIX}:${PYTORCH_NIGHTLY_COMMIT}${CUDA_SUFFIX}"
           fi
-
-      - name: Teardown Linux
-        uses: pytorch/test-infra/.github/actions/teardown-linux@main
-        if: always()
 
   validate:
     needs: build


### PR DESCRIPTION
Migrates docker-release (Build Official Docker Images) off the EC2 `linux.2xlarge` runner onto OSDC + remote BuildKit, mirroring `build-manywheel-images`.

- **generate-matrix** (`ubuntu-24.04`): ref-gates the build runner — release-isolated `rel-l-*` on `main`/`release/*`/`v*`, regular `l-*` otherwise — and bakes a per-platform `runner` into each matrix entry.
- **build** (OSDC `actions-runner` container → remote BuildKit `tcp://buildkitd-{amd64,arm64}`): still builds via `make -f docker.Makefile` (`USE_BUILDX=1`, so its buildx targets the remote builder); `make`/Python come from `apt` + `setup-uv`. Each single-platform build is native to its runner arch, so QEMU is dropped.
- **Push nightly tags**: unchanged behavior, run daemon-less — reads `torch.version.git_version` from the pushed image via a one-file BuildKit `--output` build, then creates the `<commit>-cu<cuda>` / `latest` aliases with `docker buildx imagetools create`.
- Dropped host-only steps (ARC has no docker daemon): setup-ssh / setup-linux / teardown / QEMU / ecr-login (base is public `ubuntu:24.04`).

**DONE:** add `docker-release.yml@refs/heads/nightly` and `@refs/tags/v*` to the release runner group's selected-workflows allowlist, or protected-ref builds hang queued.

Authored with assistance from Claude Code.