### PR TITLE
Fix flaky xfail for test_dtensor_op_db_multinomial_cpu_float32

### DIFF
--- a/test/distributed/tensor/test_dtensor_ops.py
+++ b/test/distributed/tensor/test_dtensor_ops.py
@@ -212,7 +212,9 @@ dtensor_multi_threaded_fails = {
     xfail("nn.functional.dropout2d"),
     xfail("nn.functional.dropout3d"),
     skip("nn.functional.multi_head_attention_forward"),
-    xfail("multinomial"),
+    # Nondeterministic: DTensor vs reference sample from the shared RNG at
+    # different points, so an xfail is flaky (occasional "unexpected success").
+    skip("multinomial"),
     # Flaky in CI: https://github.com/pytorch/pytorch/issues/167252
     skip("full_like"),
     # Flaky in CI: https://github.com/pytorch/pytorch/issues/179779


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #190252

`multinomial` was marked `xfail` in `dtensor_multi_threaded_fails`, but it is
a nondeterministic sampling op. In the multi-threaded DTensor op-db test the
reference output and the DTensor output are drawn from the shared
process-global RNG at different points, so they usually differ (the xfail
passes) but occasionally coincide -- e.g. peaked probability distributions
sample the same indices on both paths. When they coincide the op-db comparison
succeeds, turning the `xfail` into an "unexpected success" and hard-failing the
job. This is the sole residual flake in the "DTensor op-db linalg" CI cluster;
the linalg redness in that cluster was a separate, already-reverted regression
(#185231).

Because the op can be neither a stable pass nor a stable failure, `xfail` is
the wrong marker. Switch it to `skip`, matching how the other nondeterministic
and flaky-in-CI ops in this file are handled. It stays in
`dtensor_multi_threaded_fails` (not the shared `dtensor_fails`) because it only
flakes in the multi-threaded flavor where ranks share the global RNG;
`TestLocalDTensorOps` runs it fine and does not list it.

Test Plan:

Before the fix, ~1 in 6 runs hard-failed with "unexpected successes=1":

```
for i in $(seq 1 8); do
  python test/distributed/tensor/test_dtensor_ops.py \
    -k test_dtensor_op_db_multinomial_cpu_float32
done
```

After the fix, the test consistently skips (9+ consecutive `OK (skipped=1)`),
and the linalg ops from the reverted regression are clean at HEAD:

```
python test/distributed/tensor/test_dtensor_ops.py -k linalg_svd
```

Authored with Claude.