### PR TITLE
Enable Meta-internal Clang warnings for PyTorch OSS build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1133,7 +1133,57 @@ if(NOT MSVC)
                                CMAKE_CXX_FLAGS)
   append_cxx_flag_if_supported("-Winconsistent-missing-destructor-override"
                                CMAKE_CXX_FLAGS)
+  # Match Meta-internal flags. These mirror the Clang warning set Meta enables
+  # internally, so only apply them under Clang; GCC diagnoses several of them
+  # (e.g. unused-const-variable on header constexprs) far more aggressively.
   if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+  foreach(
+    flag
+    "-Werror=address-of-packed-member"
+    "-Werror=address"
+    "-Werror=ambiguous-reversed-operator"
+    "-Werror=bitwise-instead-of-logical"
+    "-Werror=dangling"
+    "-Werror=deprecated-copy-with-user-provided-copy"
+    "-Werror=deprecated-dynamic-exception-spec"
+    "-Werror=deprecated-implementations"
+    "-Werror=deprecated-redundant-constexpr-static-def"
+    "-Werror=deprecated-this-capture"
+    "-Werror=enum-compare"
+    "-Werror=gcc-compat"
+    "-Werror=header-hygiene"
+    "-Werror=implicit-fallthrough"
+    "-Werror=implicitly-unsigned-literal"
+    "-Werror=import-preprocessor-directive-pedantic"
+    "-Werror=incompatible-function-pointer-types"
+    "-Werror=infinite-recursion"
+    "-Werror=misleading-indentation"
+    "-Werror=mismatched-tags"
+    "-Werror=missing-braces"
+    "-Werror=move"
+    "-Werror=null-conversion"
+    "-Werror=packed-non-pod"
+    "-Werror=parentheses"
+    "-Werror=pessimizing-move"
+    "-Werror=self-assign"
+    "-Werror=semicolon-before-method-body"
+    "-Werror=shift-sign-overflow"
+    "-Werror=string-conversion"
+    "-Werror=thread-safety"
+    "-Werror=undefined-var-template"
+    "-Werror=uninitialized-const-reference"
+    "-Werror=uninitialized"
+    "-Werror=unreachable-code-fallthrough"
+    "-Werror=unused-but-set-variable"
+    "-Werror=unused-const-variable"
+    "-Werror=unused-exception-parameter"
+    "-Werror=unused-label"
+    "-Werror=unused-local-typedef"
+    "-Werror=unused-value"
+    "-Werror=unused-variable"
+    "-Werror=vexing-parse")
+    append_cxx_flag_if_supported("${flag}" CMAKE_CXX_FLAGS)
+  endforeach()
     string(APPEND CMAKE_CXX_FLAGS " -Wno-pass-failed")
   endif()
   if(CMAKE_COMPILER_IS_GNUCXX)

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -1008,7 +1008,7 @@ Tensor& masked_scatter__mps(Tensor& self, const Tensor& mask, const Tensor& sour
   // next broadcast all index tensors together
   try {
     indices = at::expand_outplace(indices);
-  } catch (std::exception& e) {
+  } catch (std::exception&) {
     TORCH_CHECK_INDEX(false, "shape mismatch: indexing tensors could not be broadcast together");
   }
 

--- a/test/cpp/jit/torch_python_test.cpp
+++ b/test/cpp/jit/torch_python_test.cpp
@@ -70,7 +70,7 @@ void testTorchSaveError() {
   try {
     torch::jit::load("eager_value.pt");
     passed = false;
-  } catch (const std::exception& c) {
+  } catch (const std::exception&) {
   }
   // Ensure torch::jit::load did not run
   AT_ASSERT(passed);

--- a/torch/csrc/jit/runtime/interpreter.cpp
+++ b/torch/csrc/jit/runtime/interpreter.cpp
@@ -866,8 +866,8 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
         push(stack, IValue());
         try {
           f.run(stack);
-        } catch (std::exception& _) {
-          // TODO(T98048876): Handle `_` correctly.
+        } catch (std::exception&) {
+          // TODO(T98048876): Handle the caught exception correctly.
         }
       }
       if (FLAGS_torch_jit_enable_rethrow_caught_exception) {


### PR DESCRIPTION
Summary: Meta has a number of warning flags enabled internally which apply to PyTorch. Here, we enable them in PyTorch externally to prevent bugs and increase dev velocity.

Test Plan:
- `arc f fbcode/caffe2/CMakeLists.txt` reports no formatting changes needed.
- Inspected the generated flag list against `_COMMON_CLANG_FLAGS_WARNINGS_TO_ENABLE` to confirm all 43 flags are present and none conflict with existing `-Wno-` suppressions in the file.

Authored with the assistance of an AI coding agent.

Reviewed By: ezyang

Differential Revision: D112164154


