### PR TITLE
[mtia][inductor][fx_wrapper] Guard unbacked-symbol codegen against empty bindings (#190255)

### DIFF
--- a/test/inductor/test_fxir_backend.py
+++ b/test/inductor/test_fxir_backend.py
@@ -7,6 +7,7 @@ import itertools
 import operator
 import unittest
 from collections.abc import Callable
+from unittest.mock import MagicMock
 
 import sympy
 
@@ -23,7 +24,7 @@ from torch._inductor import config
 from torch._inductor.async_compile import AsyncCompile, shutdown_compile_workers
 from torch._inductor.codegen.cpp import CppScheduling
 from torch._inductor.codegen.triton import TritonScheduling
-from torch._inductor.codegen.wrapper import PythonWrapperCodegen
+from torch._inductor.codegen.wrapper import PythonWrapperCodegen, UnbackedSymbolDefsLine
 from torch._inductor.codegen.wrapper_fxir import (
     FxConverter,
     replace_floor_div,
@@ -1497,6 +1498,24 @@ class TestReplaceFloorDiv(InductorTestCase):
         x, y = sympy.symbols("x y")
         expr = sympy.floor(-FloorDiv(x * y, 2) / FloorDiv(-x * y, 131070))
         self._check(expr)
+
+
+class TestUnbackedSymbolDefs(InductorTestCase):
+    """Tests for FxConverter._generate_unbacked_symbol_defs."""
+
+    def test_empty_bindings_returns_before_buffer_lookup(self):
+        # A line with no unbacked symbols must return before the output-buffer
+        # lookup: such kernels are not recorded in buffer_to_node, so the lookup
+        # would KeyError. Fails without the early-return guard, passes with it.
+        conv = MagicMock(spec=FxConverter)
+        conv.gm = MagicMock()
+        conv.buffer_to_node = {}
+        line = MagicMock(spec=UnbackedSymbolDefsLine)
+        # output_name is set so that, absent the guard, the buffer_to_node lookup
+        # is actually reached and raises KeyError (its documented failure mode).
+        line.output_name = "buf0"
+        line.unbacked_bindings = {}
+        self.assertIsNone(FxConverter._generate_unbacked_symbol_defs(conv, line))
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/codegen/wrapper_fxir.py
+++ b/torch/_inductor/codegen/wrapper_fxir.py
@@ -1339,10 +1339,15 @@ class FxConverter:
             else:
                 raise NotImplementedError(f"Unrecognized entry type: {type(entry)}")
 
-        root_node = self.buffer_to_node[line.output_name]
         unbacked_bindings = line.unbacked_bindings
         if unbacked_bindings is None:
             raise AssertionError("line.unbacked_bindings must not be None")
+        # Kernels with no unbacked symbols aren't recorded in buffer_to_node, so
+        # return before the output-buffer lookup to avoid a KeyError. Mirrors
+        # the non-FX wrapper's early return.
+        if not unbacked_bindings:
+            return
+        root_node = self.buffer_to_node[line.output_name]
         for s, keypath in unbacked_bindings.items():
             # Check if we already generated this symbol.
             if s.name in self.buffer_to_node:


### PR DESCRIPTION
Summary:

mirror from:

https://www.internalfb.com/code/fbsource/[1a3446ddb32b]/fbcode/caffe2/torch/_inductor/codegen/wrapper.py?lines=4391-4392

Full inductor lowering crashed with a KeyError in the FX wrapper while
generating unbacked-symbol definitions. This shows up for in-place (aliased)
ops, and this diff explains and fixes why.

An in-place op that mutates a buffer and returns nothing -- like the KV-cache
update -- is functionalized into an `auto_functionalized` higher-order op, and
export (as well as inductor internal) backfills a phantom empty tensor as its output, instead of a standard empty_stride. When inductor lowers this
as a fallback, the output slot aliases the buffer the op mutates instead of
getting a fresh allocation, so the FX wrapper never records that buffer in its
buffer-to-node map -- only real allocations and reuses are recorded there.

Separately, the fallback codegen always emits an unbacked-symbol-defs line for
its output, even when that output has no unbacked symbols (empty bindings). The
FX wrapper looked up the output buffer in the map before checking whether there
were any bindings. For an aliased output that was never recorded, the lookup
missed and raised KeyError, so lowering aborted.

Fix: return early when there are no unbacked bindings, before the buffer lookup,
matching what the non-FX (Python/C++) wrapper already does. Ordinary ops are
unaffected because their outputs are recorded; only the empty-binding aliased
case -- which never needed the lookup -- is now skipped, so lowering proceeds.

Test Plan:
Unit test (CPU):
```
buck2 test fbcode//caffe2/test/inductor:fxir_backend -- TestUnbackedSymbolDefs
```
Feeds a codegen line with no unbacked bindings and asserts it returns before the
output-buffer lookup; without the guard the lookup raises KeyError.

Buck UI: https://www.internalfb.com/buck2/daab7e3a-05f1-465a-9178-df5a33154ae1
Test session: https://www.internalfb.com/intern/testinfra/testrun/27021597794433832
Result: Pass 2, Fail 0.

Reviewed By: blaine-rister

Differential Revision: D112373081




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo