### PR TITLE
c10 OptionalTensorRef: declare special members explicitly

### DIFF
--- a/aten/src/ATen/core/Tensor.h
+++ b/aten/src/ATen/core/Tensor.h
@@ -4,7 +4,6 @@
 #include <c10/util/Exception.h>
 
 namespace at {
-// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions)
 class TORCH_API OptionalTensorRef {
  public:
   OptionalTensorRef() = default;
@@ -18,12 +17,24 @@ class TORCH_API OptionalTensorRef {
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY(src.defined());
   }
 
+  // ref_ is a non-owning borrow, so copies re-borrow instead of bumping the
+  // refcount and assignment must avoid Tensor's refcount-adjusting operator=.
+  // Copy-and-swap keeps every path refcount-neutral: the swapped-out value is
+  // released via unsafeReleaseTensorImpl() by the temporary's destructor.
   OptionalTensorRef(const OptionalTensorRef& rhs)
       : ref_(Tensor::unsafe_borrow_t{}, rhs.ref_) {}
 
   OptionalTensorRef(OptionalTensorRef&& rhs) = default;
-  OptionalTensorRef& operator=(OptionalTensorRef rhs) {
-    std::swap(ref_, rhs.ref_);
+
+  OptionalTensorRef& operator=(const OptionalTensorRef& rhs) {
+    OptionalTensorRef tmp(rhs);
+    std::swap(ref_, tmp.ref_);
+    return *this;
+  }
+
+  OptionalTensorRef& operator=(OptionalTensorRef&& rhs) noexcept {
+    OptionalTensorRef tmp(std::move(rhs));
+    std::swap(ref_, tmp.ref_);
     return *this;
   }
 


### PR DESCRIPTION
`OptionalTensorRef` used a by-value copy-and-swap assignment operator
(`operator=(OptionalTensorRef)`). Because a by-value `operator=` is itself the
copy-assignment operator, the move-assignment operator was never declared, so
the rule-of-five set was incomplete and clang-tidy's
`cppcoreguidelines-special-member-functions` fired -- previously silenced with a
`NOLINT`.

This declares the full set explicitly instead of suppressing the check: an
explicit copy-assignment and move-assignment, each preserving the existing
refcount-neutral borrow semantics. `ref_` holds a borrowed `TensorImpl` (built
via `Tensor::unsafe_borrow_t` and released with `unsafeReleaseTensorImpl()`,
i.e. no decref), so a defaulted `Tensor` assignment must never run on it or it
would decref an impl we do not own. Copy-and-swap via a temporary keeps both
paths refcount-neutral, exactly as the prior by-value operator did, so behavior
is unchanged.

Split out of #190074 per review feedback.

## Test Plan
Build-only refactor with identical runtime behavior:

```
pip install -e . -v --no-build-isolation
```

Authored with the assistance of an AI coding agent.