### PR TITLE
Fix embedding_bag CPU scale_grad_by_freq using wrong index count

### DIFF
--- a/aten/src/ATen/native/EmbeddingBag.cpp
+++ b/aten/src/ATen/native/EmbeddingBag.cpp
@@ -1570,7 +1570,7 @@ static void _embedding_bag_dense_backward_cpu_sum_mean(
               scale = per_sample_weights_data[*per_sample_weights_stride * j];
             }
             if (scale_grad_by_freq) {
-              scale /= counts[indices_data[i]];
+              scale /= counts[index];
             }
             if (mode == EmbeddingBagMode::MEAN) {
               auto bag_size = bag_size_data[source];

--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -986,6 +986,29 @@ class TestEmbeddingNNDeviceType(NNTestCase):
 
         torch.testing.assert_close(torch.ones(dim, device=device), grad_at_r(dtype))
 
+    # https://github.com/pytorch/pytorch/issues/190063
+    @onlyNativeDeviceTypes
+    @dtypes(torch.float32, torch.float64)
+    def test_embedding_bag_scale_grad_by_freq_mixed_counts(self, device, dtype):
+        # scale_grad_by_freq must divide each index's gradient by that index's
+        # own occurrence count. Use mixed counts (index 1 twice, index 3 once)
+        # so a once-occurring index sorts after a repeated one: this is the case
+        # where indexing the counts array by loop position rather than by index
+        # value produces the wrong scale.
+        # sum: grad row = occurrences / count. mean: additionally / bag_size (3).
+        expected_grads = {"sum": (1.0, 1.0), "mean": (1.0 / 3, 1.0 / 3)}
+        for mode, (row1, row3) in expected_grads.items():
+            weight = torch.ones(4, 3, device=device, dtype=dtype, requires_grad=True)
+            indices = torch.tensor([1, 1, 3], device=device)
+            offsets = torch.tensor([0], device=device)
+            F.embedding_bag(
+                indices, weight, offsets, mode=mode, scale_grad_by_freq=True
+            ).sum().backward()
+            expected = torch.zeros(4, 3, device=device, dtype=dtype)
+            expected[1] = row1  # index 1: 2 occurrences, count 2
+            expected[3] = row3  # index 3: 1 occurrence, count 1
+            self.assertEqual(weight.grad, expected)
+
     # Check correctness of torch.nn.functional.embedding_bag forward and
     # backward functions with padding_idx, given a 2D indices input. Compare
     # against torch.nn.functional.embedding followed by a reduction.


### PR DESCRIPTION
Fixes #190063.

### Root cause

In `_embedding_bag_dense_backward_cpu_sum_mean`, the `scale_grad_by_freq` divisor was `counts[indices_data[i]]`, where `i` is the outer loop counter that steps once per *unique* index (`next_unique_index_idx`), not the position of the current element. `indices_data[i]` therefore reads an unrelated slot of the sorted indices array rather than the current group's index value.

The current group's index value is already computed as `index` (`indices_data[indices_start]`), and `counts` is keyed by index value (`compute_counts` does `counts[indices_data[i]]++`). The correct divisor is `counts[index]`. This matches the non-bagged path in `Embedding.cpp` (`counts[k]`) and the CUDA/MPS backends, which were already correct; the CPU `embedding_bag` path was the lone outlier.

### Symptom

A once-occurring index that sorts after a repeated index gets divided by the repeated index's count. For indices `[1, 1, 3]` with `mode="sum"`, row 3 of the gradient was `0.5` (divided by count 2) instead of `1.0` (count 1).

This was discovered by @bogatyy while implementing the corresponding MPS scaling (#190062); the MPS backend divides by the true frequency, so CPU and MPS diverged on this input. This PR fixes the CPU side.

### Test plan

Reproducer from the issue now returns the correct gradient:

```python
import torch
w = torch.ones(4, 3, requires_grad=True)
torch.nn.functional.embedding_bag(torch.tensor([1,1,3]), w, torch.tensor([0]),
    mode='sum', scale_grad_by_freq=True).sum().backward()
print(w.grad[:,0].tolist())  # [0.0, 1.0, 0.0, 1.0]
```

New device-generic regression test (sum and mean modes, mixed-count indices):

```
python test/nn/test_embedding.py -k scale_grad_by_freq_mixed_counts -v
```

The test discriminates: rebuilt against the pre-fix code it fails (row 3 off by 0.5 on CPU) while CUDA passes; with the fix it passes on both. Broader sweep shows no regressions:

```
python test/nn/test_embedding.py -k embedding_bag -v   # 158 passed, 28 skipped
```
This PR description was formatted with AI assistance for readability.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01