### PR TITLE
[Inductor] deterministic_ops config for fine-grained deterministic mode control

### DIFF
--- a/test/inductor/test_autoheuristic.py
+++ b/test/inductor/test_autoheuristic.py
@@ -206,6 +206,36 @@ class AutoHeuristicTest(TestCase):
         # because AutoHeuristics makes the decision without benchmarking
         self.assertEqual(counters["inductor"]["pad_mm_bench"], 0)
 
+    @skipIfXpu(msg="AutoHeuristic doesn't currently work on the XPU stack")
+    @unittest.skipIf(not IS_H100 and not IS_A100, "heuristic only run on H100")
+    @inductor_config.patch("deterministic_ops.pad_mm", True)
+    @inductor_config.patch("autoheuristic_use.pad_mm", True)
+    def test_pad_mm_autoheuristic_enabled_via_deterministic_ops(self):
+        """Test that pad_mm AutoHeuristics works in deterministic mode."""
+        from torch._dynamo.utils import counters
+
+        counters.clear()
+
+        def f(a, b):
+            return torch.mm(a, b)
+
+        cf = torch.compile(f)
+        # Use shapes that would normally trigger padding but aren't well-aligned
+        a = torch.randn(2047, 2048, device=GPU_TYPE, dtype=torch.float16)
+        b = torch.randn(2048, 2049, device=GPU_TYPE, dtype=torch.float16)
+
+        # Run the compiled function
+        result = cf(a, b)
+
+        # Verify correctness with tolerance for potential padding differences
+        expected = torch.mm(a, b)
+        torch.testing.assert_close(result, expected, atol=0.1, rtol=0.05)
+
+        # In deterministic mode with AutoHeuristics enabled,
+        # we should not do any benchmarking (pad_mm_bench should stay 0)
+        # because AutoHeuristics makes the decision without benchmarking
+        self.assertEqual(counters["inductor"]["pad_mm_bench"], 0)
+
     @inductor_config.patch(deterministic=True)
     def test_use_autoheuristic_pad_mm_enabled_in_deterministic_mode(self):
         inductor_config.autoheuristic_use.pad_mm = None

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1044,6 +1044,17 @@ split_reductions = os.getenv("TORCHINDUCTOR_SPLIT_REDUCTIONS", "1") == "1"
 # if we know they affect numerics.  WARNING: Expect perf hit in this mode.
 deterministic = os.getenv("TORCHINDUCTOR_DETERMINISTIC") == "1"
 
+
+def _parse_deterministic_ops_env():
+    use_env = os.environ.get("TORCHINDUCTOR_DETERMINISTIC_OPS", "").split(",")
+    return use_env
+
+
+# fine-grained deterministic mode flag
+class deterministic_ops:
+    pad_mm = True if "pad_mm" in _parse_deterministic_ops_env() else None
+
+
 # Batch-invariant mode: stable per-sample compiled kernel across batch sizes. Implies deterministic.
 batch_invariant = os.getenv("TORCHINDUCTOR_BATCH_INVARIANT") == "1"
 

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1052,7 +1052,7 @@ def _parse_deterministic_ops_env():
 
 # fine-grained deterministic mode flag
 class deterministic_ops:
-    pad_mm = True if "pad_mm" in _parse_deterministic_ops_env() else None
+    pad_mm = "pad_mm" in _parse_deterministic_ops_env()
 
 
 # Batch-invariant mode: stable per-sample compiled kernel across batch sizes. Implies deterministic.

--- a/torch/_inductor/fx_passes/pad_mm.py
+++ b/torch/_inductor/fx_passes/pad_mm.py
@@ -93,6 +93,13 @@ def hint_symbols(
     return [optimization_hint(d) for d in ds]
 
 
+def _uses_deterministic_pad_mm() -> bool:
+    return (
+        torch._inductor.config.deterministic
+        or torch._inductor.config.deterministic_ops.pad_mm
+    )
+
+
 def can_pad(
     mat1: Tensor,
     mat2: Tensor,
@@ -161,7 +168,7 @@ def can_pad(
     # In deterministic mode, we can't safely benchmark - disallow padding
     # Check this after other basic checks so force_shape_pad/autoheuristic can override
     if (
-        torch._inductor.config.deterministic
+        _uses_deterministic_pad_mm()
         and not torch._inductor.config.force_shape_pad
         and not torch._inductor.config.use_autoheuristic("pad_mm")
     ):
@@ -674,7 +681,7 @@ def _should_pad(
                 return ah_should_pad
 
         # AH didn't make a decision, so if we're in deterministic mode, we should return false
-        if torch._inductor.config.deterministic:
+        if _uses_deterministic_pad_mm():
             return False
 
         if ori_time is None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #190265

Providing a mechanism to enable deterministic mode only for specific ops

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo