### PR TITLE
Fix flaky test_block_table_kv_cache "no compiled frames" error

### DIFF
--- a/test/test_varlen_attention.py
+++ b/test/test_varlen_attention.py
@@ -1144,6 +1144,15 @@ class TestVarlenAttention(NNTestCase):
         if backend == "fa2" and page_size % 256 != 0:
             self.skipTest("FA2 paged KV requires page_size divisible by 256")
 
+        # varlen_attn lives in a Dynamo skipfile, so torch.compile wraps it onto
+        # the process-global wrap_inline "inner" frame - the same code object the
+        # fa3/fa4 aten-op compile below uses. Compiling this whole matrix in one
+        # process accumulates recompiles on that shared cache until it hits
+        # recompile_limit; the non-fullgraph aten-op compile then pins "inner" to
+        # RUN_ONLY, and a later fullgraph compile silently finds no compiled
+        # frames. Reset per parametrization so each stays independent.
+        torch._dynamo.reset()
+
         torch.manual_seed(42)
 
         batch_size = 4


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #190266

test_block_table_kv_cache in test_varlen_attention flakily failed with
"torch.compile with fullgraph=True found no compiled frames" on the
page_size_256/compile_True/fa2 params (observed on the B200 smoke config).

Root cause: varlen_attn lives in torch/nn/attention/varlen.py, which is a
Dynamo skipfile, so torch.compile(varlen_attn, fullgraph=True) is wrapped by
external_utils.wrap_inline and the frame Dynamo actually compiles is the
process-global shared "inner" code object -- the same one used by the fa3/fa4
torch.compile(aten_op) call. The test compiles this whole parametrized matrix
in one process with no torch._dynamo.reset() (NNTestCase does not reset), so
recompiles accumulate on that single shared cache until it hits
recompile_limit (8). The compile that trips the limit is the non-fullgraph
aten-op compile, which does not raise but instead pins "inner" to a persistent
RUN_ONLY frame execution strategy. After that, the next fullgraph varlen_attn
compile whose input signature is not already cached gets a cache miss under
RUN_ONLY, runs eager without ever invoking Dynamo, leaves the fullgraph frame
count at 0, and raises the "found no compiled frames" error. It presents as
flaky because the counter is shard/process-global, so dynamic sharding shifts
where the limit is first tripped; the B200 config is simply where fa4 is
enabled and supplies the extra compiles that push the shared counter past 8.

Fix: reset Dynamo at the start of each test_block_table_kv_cache
parametrization so each param's compiles stay independent and cannot exhaust
the shared "inner" recompile limit. Preferred over disabling the test or
extending the skip; adding varlen.py to the Dynamo inline list was rejected
because it would change public-API tracing behavior and only move the
exhaustion onto varlen_attn's own recompile counter.

Test Plan:

Ran the affected test on an A100 (fa2 only on this arch); the previously
failing param now passes:

```
python test/test_varlen_attention.py TestVarlenAttentionCUDA \
    -k test_block_table_kv_cache -v
# Ran 80 tests ... OK (skipped=60)
```

Reproduced the exact failure and confirmed the fix with the real varlen_attn
on an A100 by pre-exhausting the shared wrap_inline "inner" recompile counter
(as the fa4 aten-op path does on B200), then compiling varlen_attn fullgraph:
without a reset it raises "found no compiled frames"; with torch._dynamo.reset()
it succeeds.

Authored with Claude.