### PR TITLE
Add 32-bit indexed kernel for CUDA FFT conjugate-symmetry fill

### DIFF
--- a/aten/src/ATen/native/cuda/SpectralOps.cu
+++ b/aten/src/ATen/native/cuda/SpectralOps.cu
@@ -9,6 +9,8 @@
 
 #include <array>
 #include <cmath>
+#include <cstdlib>
+#include <limits>
 
 
 namespace at::native {
@@ -17,11 +19,15 @@ namespace at::native {
 // In mirrored dims, maps linear index i to (n - i) % n
 template <typename index_t>
 struct HermitianSymmetryOffsetCalculator {
-  using offset_type = std::array<index_t, 1>;
+  // Strides may be negative (the last transformed dim is mirrored with a
+  // negative stride), so the stride/offset type must stay signed even when the
+  // divmod index type is unsigned for faster division.
+  using stride_t = std::make_signed_t<index_t>;
+  using offset_type = std::array<stride_t, 1>;
   using dim_type = std::remove_cv_t<decltype(MAX_DIMS)>;
   dim_type dims;
   at::cuda::detail::IntDivider<index_t> sizes_[MAX_DIMS];
-  index_t strides_[MAX_DIMS];
+  stride_t strides_[MAX_DIMS];
   uint32_t mirror_dim_;  // bit mask
   static_assert(MAX_DIMS < 32, "Need a bigger mask type");
 
@@ -50,16 +56,16 @@ struct HermitianSymmetryOffsetCalculator {
   }
 
   C10_HOST_DEVICE offset_type get(index_t linear_idx) const {
-    index_t offset = 0;
+    stride_t offset = 0;
 
     for (dim_type dim = 0; dim < dims; ++dim) {
       auto divmod = sizes_[dim].divmod(linear_idx);
       linear_idx = divmod.div;
 
       if ((mirror_dim_ & (uint32_t{1} << dim)) == 0) {
-        offset += divmod.mod * strides_[dim];
+        offset += static_cast<stride_t>(divmod.mod) * strides_[dim];
       } else if (divmod.mod != 0) {
-        offset += (sizes_[dim].divisor - divmod.mod) * strides_[dim];
+        offset += static_cast<stride_t>(sizes_[dim].divisor - divmod.mod) * strides_[dim];
       }
     }
     offset_type offsets;
@@ -70,16 +76,45 @@ struct HermitianSymmetryOffsetCalculator {
 
 
 // out[:] = conj(in[:]) where in and out ordering is generalized by offset calculators
-template <typename scalar_t, typename inp_calc_t, typename out_calc_t>
+template <typename scalar_t, typename index_t, typename inp_calc_t, typename out_calc_t>
 C10_LAUNCH_BOUNDS_1(cuda::detail::CUDA_NUM_THREADS)
 __global__ void _fft_conjugate_copy_kernel(
     int64_t numel, scalar_t * out_data, const scalar_t * in_data,
     inp_calc_t ic, out_calc_t oc) {
-  CUDA_KERNEL_LOOP_TYPE(index, numel, int64_t) {
+  CUDA_KERNEL_LOOP_TYPE(index, numel, index_t) {
     auto in_offset = ic.get(index)[0];
     auto out_offset = oc.get(index)[0];
     out_data[out_offset] = std::conj(in_data[in_offset]);
   }
+}
+
+template <typename index_t>
+static void _fft_fill_with_conjugate_symmetry_launch(
+    ScalarType dtype, IntArrayRef mirror_dims, IntArrayRef signal_half_sizes,
+    IntArrayRef in_strides, const void * in_data,
+    IntArrayRef out_strides, void * out_data,
+    int64_t element_size, int64_t numel) {
+  auto* in_strides_ptr = in_strides.data();
+  const int ndim = in_strides.size();
+  // signed_strides matches the signed offset type in the output calculator: the
+  // divmod index type stays unsigned (fast IntDivider) while strides/offsets
+  // remain signed, so a negative input stride cannot wrap in the 32-bit path.
+  OffsetCalculator<1, index_t, /*signed_strides=*/true> input_offset_calculator(
+      ndim, signal_half_sizes.data(), &in_strides_ptr, &element_size);
+  HermitianSymmetryOffsetCalculator<index_t> output_offset_calculator(
+      signal_half_sizes, out_strides, mirror_dims, element_size);
+
+  AT_DISPATCH_COMPLEX_TYPES_AND(kComplexHalf, dtype, "_fft_fill_with_conjugate_symmetry", [&] {
+      using namespace cuda::detail;
+      _fft_conjugate_copy_kernel<scalar_t, index_t><<<
+        GET_BLOCKS(numel), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+            numel,
+            static_cast<scalar_t*>(out_data),
+            static_cast<const scalar_t*>(in_data),
+            input_offset_calculator,
+            output_offset_calculator);
+      C10_CUDA_KERNEL_LAUNCH_CHECK();
+    });
 }
 
 // In real-to-complex transform, cuFFT only fills half of the values due to
@@ -95,28 +130,35 @@ void _fft_fill_with_conjugate_symmetry_cuda_(
     ScalarType dtype, IntArrayRef mirror_dims, IntArrayRef signal_half_sizes,
     IntArrayRef in_strides, const void * in_data,
     IntArrayRef out_strides, void * out_data) {
-  // Do the actual conjugate mirroring.
-  // TODO: consider adding a 32bit indexed kernel for improved performance
-  auto* in_strides_ptr = in_strides.data();
   const int ndim = in_strides.size();
   const int64_t element_size = scalarTypeToTypeMeta(dtype).itemsize();
-  OffsetCalculator<1, int64_t> input_offset_calculator(
-      ndim, signal_half_sizes.data(), &in_strides_ptr, &element_size);
-  HermitianSymmetryOffsetCalculator<int64_t> output_offset_calculator(
-      signal_half_sizes, out_strides, mirror_dims, element_size);
-
   const auto numel = c10::multiply_integers(signal_half_sizes);
-  AT_DISPATCH_COMPLEX_TYPES_AND(kComplexHalf, dtype, "_fft_fill_with_conjugate_symmetry", [&] {
-      using namespace cuda::detail;
-      _fft_conjugate_copy_kernel<<<
-        GET_BLOCKS(numel), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
-            numel,
-            static_cast<scalar_t*>(out_data),
-            static_cast<const scalar_t*>(in_data),
-            input_offset_calculator,
-            output_offset_calculator);
-      C10_CUDA_KERNEL_LAUNCH_CHECK();
-    });
+
+  // Prefer 32-bit index math when the element count and every element offset
+  // fit in int32. The offset calculators then use magic-number division rather
+  // than full 64-bit integer divmod, which dominates this offset-bound kernel.
+  bool use_32bit_indexing = numel <= std::numeric_limits<int32_t>::max();
+  if (use_32bit_indexing) {
+    int64_t max_in_offset = 0;
+    int64_t max_out_offset = 0;
+    for (const auto i : c10::irange(ndim)) {
+      const auto extent = signal_half_sizes[i] - 1;
+      max_in_offset += extent * std::abs(in_strides[i] / element_size);
+      max_out_offset += extent * std::abs(out_strides[i] / element_size);
+    }
+    use_32bit_indexing = max_in_offset <= std::numeric_limits<int32_t>::max() &&
+        max_out_offset <= std::numeric_limits<int32_t>::max();
+  }
+
+  if (use_32bit_indexing) {
+    _fft_fill_with_conjugate_symmetry_launch<uint32_t>(
+        dtype, mirror_dims, signal_half_sizes, in_strides, in_data,
+        out_strides, out_data, element_size, numel);
+  } else {
+    _fft_fill_with_conjugate_symmetry_launch<int64_t>(
+        dtype, mirror_dims, signal_half_sizes, in_strides, in_data,
+        out_strides, out_data, element_size, numel);
+  }
 }
 
 REGISTER_DISPATCH(fft_fill_with_conjugate_symmetry_stub, &_fft_fill_with_conjugate_symmetry_cuda_)

--- a/test/test_spectral_ops.py
+++ b/test/test_spectral_ops.py
@@ -15,7 +15,8 @@ from torch.testing._internal.common_utils import \
      make_tensor, skipIfTorchDynamo)
 from torch.testing._internal.common_device_type import \
     (instantiate_device_type_tests, ops, dtypes, onlyNativeDeviceTypes,
-     skipCPUIfNoFFT, deviceCountAtLeast, onlyCUDA, onlyOn, OpDTypes, toleranceOverride, tol)
+     skipCPUIfNoFFT, deviceCountAtLeast, onlyCUDA, onlyOn, OpDTypes, toleranceOverride, tol,
+     largeTensorTest)
 from torch.testing._internal.common_methods_invocations import (
     spectral_funcs, SpectralFuncType)
 from torch._prims_common import corresponding_complex_dtype
@@ -944,6 +945,20 @@ class TestFFT(TestCase):
 
         self.assertTrue((x.grad - dx).abs().max() == 0)
         self.assertFalse((x.grad - x).abs().max() == 0)
+
+    @onlyCUDA
+    @largeTensorTest("18GB")
+    def test_fft_conjugate_symmetry_fill_int64_indexing(self, device):
+        # The CUDA conjugate-symmetry fill uses 32-bit index math when numel and
+        # every element offset fit in int32, else a 64-bit fallback. Space the
+        # output rows 2**31 elements apart so max_out_offset exceeds INT32_MAX and
+        # the 64-bit path is taken, while the filled region itself stays tiny.
+        rows, cols, stride = 2, 8, 2 ** 31
+        x = torch.randn(rows, cols, device=device)
+        buf = torch.empty((rows - 1) * stride + cols, dtype=torch.complex64, device=device)
+        out = buf.as_strided((rows, cols), (stride, 1))
+        torch.fft.fft(x, dim=-1, out=out)
+        self.assertEqual(out, torch.fft.fft(x, dim=-1))
 
     # passes on ROCm w/ python 2.7, fails w/ python 3.6
     @skipIfTorchDynamo("cannot set WRITEABLE flag to True of this array")


### PR DESCRIPTION

The CUDA `_fft_fill_with_conjugate_symmetry_` kernel fills the redundant half of
a real-to-complex transform when `onesided=False` (reached by `torch.fft.fft` /
`fftn` on real inputs and by `irfftn`). It computed every input and output
offset with 64-bit index math, so the offset calculators used full 64-bit
integer divmod, which dominates this offset-bound copy kernel. This resolves the
long-standing `// TODO: consider adding a 32bit indexed kernel for improved
performance` in `SpectralOps.cu`.

Profiling on an RTX 3080 shows the fill is **25-58% of total FFT device time**
for 2D/3D real inputs, so this is a meaningful fraction of the op.

### Change

Adds a 32-bit indexed fast path, selected when the element count and every
element offset fit in `int32` (matching the `canUse32BitIndexMath` pattern used
elsewhere in `native/cuda`); the calculators then use magic-number division
instead of 64-bit divmod. Tensors whose offsets do not fit `int32` fall back to
the original 64-bit path unchanged.

One subtlety drove the type choice: the last transformed dimension is mirrored
with a **negative stride**, so the stride/offset type must stay signed (an
unsigned offset wraps and reads out of bounds). But `IntDivider`'s fast
magic-number path is specialized only for `unsigned int`. The fast path
therefore uses an unsigned `uint32` divider for the (always non-negative) sizes
together with `std::make_signed_t` strides/offsets, rather than a single signed
`int32` type (which would not hit the specialized divider).

### Performance (RTX 3080, sm_86)

Fill kernel device time, before -> after (`torch.profiler`):

| Input (real) | fill before | fill after | kernel speedup | end-to-end |
|---|---|---|---|---|
| 2D 2048x2048 | 67.6 us | 52.8 us | 1.28x | ~1.07x |
| 2D 4096x4096 | 254.0 us | 201.8 us | 1.26x | ~1.13x |
| 3D 256x256x256 | 254.7 us | 198.7 us | 1.28x | ~1.10x |
| 1D 4,000,000 | 64.6 us | 48.9 us | 1.32x | ~1.0x (cuFFT-bound) |

Output is numerically unchanged.

### Test plan

Verified locally on an RTX 3080 (CUDA 12.6). Existing CUDA FFT correctness suite
passes (311 tests):

```
python test/test_spectral_ops.py TestFFTCUDA
```

Fill correctness checked by comparing the r2c+fill path against the c2c path
(which does not use the fill) on the same device, across float32/float64 and
1D/2D/3D shapes including the non-power-of-two and non-contiguous cases;
identical up to floating point. Performance measured with `torch.profiler` as
above. The 64-bit fallback path is the original code and is unchanged.

CI will confirm on the full matrix of GPUs/dtypes.



---

_This PR description was formatted with AI assistance for readability._
