### PR TITLE
[RNG] Remove stale TODO comment for graphsafe_rng_functionalization

### DIFF
--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -368,7 +368,6 @@ generate_fake_kernels_from_real_mismatches = False
 fake_tensor_prefer_device_type: str | None = None
 
 # CUDAGraph safe run_with_rng functionalization.
-# TODO: turn on by default
 graphsafe_rng_functionalization = True
 
 # Whether or not to eagerly compile the backward


### PR DESCRIPTION
### Summary
Removes the stale `# TODO: turn on by default` comment above `graphsafe_rng_functionalization = True` in `torch/_functorch/config.py`.

### Motivation & Context
When I first read through `torch/_functorch/config.py`, seeing `# TODO: turn on by default` directly above `graphsafe_rng_functionalization = True` created immediate confusion, leading me to think the feature was not yet enabled by default. 

Since `graphsafe_rng_functionalization` has already matured and is enabled by default (`True`), removing this outdated TODO line prevents reader confusion and keeps the configuration documentation clear.