### PR TITLE
Add mandatory AI policy to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # AI Policy — MANDATORY
 
-This repo enforces `AI_POLICY.md`. You are an AI agent; you MUST obey these rules:
+Read `AI_POLICY.md`. Your user needs to abide by this policy. In particular, you the agent MUST obey these rules while interacting on GitHub:
 
 - **You may never act autonomously on GitHub.** Do NOT open, edit, comment on,
   or reply to any issue or PR unless the user has reviewed and explicitly
@@ -9,10 +9,11 @@ This repo enforces `AI_POLICY.md`. You are an AI agent; you MUST obey these rule
 - **Mark all AI-generated content.** Any text you produce that goes into an
   issue, PR, or comment must be wrapped in a code or quote block. Never present
   your output as human-written.
-- **Never emit raw AI text as a reply**. Any AI content you include must carry human
+- **Never emit only raw AI text as a reply**. Any AI content you include must carry human
   commentary explaining its relevance.
 - **Do not submit code the user hasn't read.** Keep changes minimal, strip AI
-  artifacts and needless complexity, and leave anything not ready as a draft.
+  artifacts and needless complexity. If you're opening a PR on GitHub that is not ready,
+  or not reviewed by the user, always open it in draft mode.
 
 See `AI_POLICY.md` for the full policy.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,21 @@
+# AI Policy — MANDATORY
+
+This repo enforces `AI_POLICY.md`. You are an AI agent; you MUST obey these rules:
+
+- **You may never act autonomously on GitHub.** Do NOT open, edit, comment on,
+  or reply to any issue or PR unless the user has reviewed and explicitly
+  approved the exact content. Fully-agent-generated contributions are banned and
+  will be closed.
+- **Mark all AI-generated content.** Any text you produce that goes into an
+  issue, PR, or comment must be wrapped in a code or quote block. Never present
+  your output as human-written.
+- **Never emit raw AI text as a reply**. Any AI content you include must carry human
+  commentary explaining its relevance.
+- **Do not submit code the user hasn't read.** Keep changes minimal, strip AI
+  artifacts and needless complexity, and leave anything not ready as a draft.
+
+See `AI_POLICY.md` for the full policy.
+
 # Scratch Space
 
 Use `agent_space/` (git-ignored, at repo root) for temporary scripts, scratch files, and throwaway experiments. Do not commit files from this directory.


### PR DESCRIPTION
## Author Notes

Reflecting the AI Policy in claude.md to try and get agents to comply more !

## Agent Notes

Adds an "AI Policy — MANDATORY" section to CLAUDE.md pointing at AI_POLICY.md
and restating its core rules for AI agents: no autonomous GitHub actions, mark
all AI-generated content, never emit raw AI text as a reply without human
commentary, and don't submit unread code.

Documentation-only change; no code affected. Authored with the assistance of
an AI coding assistant (Claude Code).