### PR TITLE
Make tf32_off thread-safe for multithreaded test runners

### DIFF
--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -3,6 +3,7 @@
 r"""This file is allowed to initialize CUDA context when imported."""
 
 import functools
+import threading
 import torch
 import torch.cuda
 from torch.testing._internal.common_utils import LazyVal, TEST_NUMBA, TEST_WITH_ROCM, TEST_CUDA, IS_WINDOWS, IS_MACOS, TEST_XPU
@@ -315,18 +316,40 @@ def initialize_cuda_context_rng():
         __cuda_ctx_rng_initialized = True
 
 
+_tf32_off_lock = threading.Lock()
+_tf32_off_depth = 0
+_tf32_off_saved_precision = None
+_tf32_off_cudnn_ctx = None
+
+
 @contextlib.contextmanager
 def tf32_off():
-    # Snapshot fp32_precision (a string), not allow_tf32 (a bool): writing
-    # allow_tf32 back can't reproduce the "none" default (it yields "ieee"),
-    # which the TestCase precision-leak detector would flag on ROCm.
-    old_fp32_precision = torch.backends.cuda.matmul.fp32_precision
+    # First-in saves state and disables tf32; last-out restores. Multithreaded
+    # test runners (e.g. MultiThreadedTestCase) enter this context once per
+    # rank thread over the same process-global flags, so per-entry
+    # save/restore can interleave and leak a modified state past the last
+    # exit, which the TestCase fp32 precision leak detector then flags.
+    global _tf32_off_depth, _tf32_off_saved_precision, _tf32_off_cudnn_ctx
+    with _tf32_off_lock:
+        if _tf32_off_depth == 0:
+            # Snapshot fp32_precision (a string), not allow_tf32 (a bool):
+            # writing allow_tf32 back can't reproduce the "none" default (it
+            # yields "ieee"), which the leak detector would flag on ROCm.
+            _tf32_off_saved_precision = torch.backends.cuda.matmul.fp32_precision
+            torch.backends.cuda.matmul.allow_tf32 = False
+            _tf32_off_cudnn_ctx = torch.backends.cudnn.flags(enabled=None, benchmark=None, deterministic=None, allow_tf32=False)
+            _tf32_off_cudnn_ctx.__enter__()
+        _tf32_off_depth += 1
     try:
-        torch.backends.cuda.matmul.allow_tf32 = False
-        with torch.backends.cudnn.flags(enabled=None, benchmark=None, deterministic=None, allow_tf32=False):
-            yield
+        yield
     finally:
-        torch.backends.cuda.matmul.fp32_precision = old_fp32_precision
+        with _tf32_off_lock:
+            _tf32_off_depth -= 1
+            if _tf32_off_depth == 0:
+                _tf32_off_cudnn_ctx.__exit__(None, None, None)
+                _tf32_off_cudnn_ctx = None
+                torch.backends.cuda.matmul.fp32_precision = _tf32_off_saved_precision
+                _tf32_off_saved_precision = None
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
The `tf32_off` context manager mutates process-global TF32 state (`torch.backends.cuda.matmul` plus the cudnn flags) with a per-entry save/restore. Multithreaded test runners such as `MultiThreadedTestCase` execute the decorated test body once per rank thread, so linalg OpInfo tests carrying `with_tf32_off` enter `tf32_off` concurrently: a thread can snapshot already-modified state and restore it last, leaking modified flags past the final exit. The fp32 precision leak detector added in #185236 now catches this in the distributed dtensor CPU shards (`cuda.matmul` fp32_precision "none" -> "ieee", cudnn conv/rnn "tf32" -> "none", the exact signature of the interleaved `cudnn.flags` entry write surviving).

The fix makes `tf32_off` first-in/last-out: a refcount guarded by a lock so only the first concurrent entry saves state and applies the writes, and only the last exit restores. The lock is held only around the bookkeeping, never across the yield, so rank threads still run concurrently and dtensor collectives cannot deadlock. The writes themselves are unchanged, and the `cudnn.flags` context manager is kept (entered and exited manually so the exit can run at last-out) because it handles the frozen-flags machinery test suites enable. `tf32_on` is untouched since it is only reachable through the already device-gated `tf32_on_and_off`, which multithreaded runners do not use.

An alternative was a thread-local implementation via `at::NoTF32Guard`, which already exists and is consulted in the cuBLAS handle pool, but it has no Python binding, no cudnn coverage, and is invisible to compiled-code paths that read the global flag at compile time; that remains a possible follow-up.

Authored with an AI assistant (Claude Code).
