### PR TITLE
[dynamo] Skips due to TorchDispatchMode should not be permanent

### DIFF
--- a/test/dynamo/test_modes.py
+++ b/test/dynamo/test_modes.py
@@ -131,12 +131,34 @@ class TorchDispatchModeTests(torch._dynamo.test_case.TestCase):
         cnt = torch._dynamo.testing.CompileCounter()
 
         x = torch.tensor([3.0])
+        compiled_fn = torch.compile(fn, backend=cnt)
         with RewriteAddToMul():
             eager_res = fn(x)
-            compiled_res = torch.compile(fn, backend=cnt)(x)
+            compiled_res = compiled_fn(x)
 
         self.assertEqual(eager_res, compiled_res)
         self.assertEqual(cnt.frame_count, 0)
+
+        self.assertEqual(compiled_fn(x), fn(x))
+        self.assertEqual(cnt.frame_count, 1)
+
+    def test_flop_counter_mode_compile_skip_is_transient(self):
+        from torch.utils.flop_counter import FlopCounterMode
+
+        def fn(x, y):
+            return (x @ y).sin()
+
+        cnt = torch._dynamo.testing.CompileCounter()
+        x = torch.randn(4, 4)
+        y = torch.randn(4, 4)
+
+        with FlopCounterMode(display=False):
+            compiled_fn = torch.compile(fn, backend=cnt)
+            self.assertEqual(compiled_fn(x, y), fn(x, y))
+
+        self.assertEqual(cnt.frame_count, 0)
+        self.assertEqual(compiled_fn(x, y), fn(x, y))
+        self.assertEqual(cnt.frame_count, 1)
 
     def test_get_current_dispatch_mode_stack_no_graph_break(self):
         from torch.utils._python_dispatch import _get_current_dispatch_mode_stack

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -2570,6 +2570,7 @@ class CatchErrorsWrapper:
                 and not getattr(self._torchdynamo_orig_backend, "_export", False)
             )
         ):
+            apply_to_code = True
             if has_started_execution:
                 skip_reason = "frame has already started executing"
             elif is_skipfile:
@@ -2581,7 +2582,13 @@ class CatchErrorsWrapper:
                     "non-infra torch dispatch mode present, this is not"
                     " supported today in torch.compile"
                 )
-            return self._handle_skip(ConvertFrameReturn(skip_reason=skip_reason), frame)
+                apply_to_code = False
+            return self._handle_skip(
+                ConvertFrameReturn(
+                    apply_to_code=apply_to_code, skip_reason=skip_reason
+                ),
+                frame,
+            )
 
         if (
             frame.f_code.co_filename == "<string>" and frame.f_code.co_name == "__new__"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #190287

Fixes https://github.com/pytorch/pytorch/issues/190286

Dynamo skips compilation for a frame when a TorchDispatchMode is active.
Then, it permanently skips it for the code object, even when the code is
called not under a TorchDispatchMode. The permanent skip thing is useful
as a caching thing for things that should actually be permanently
skipped (like if the function is in skipfiles), but it shouldn't apply
to code being run under a TorchDispatchMode.

Test Plan:

```
python test/dynamo/test_modes.py TorchDispatchModeTests.test_skip_torch_dispatch_modes TorchDispatchModeTests.test_flop_counter_mode_compile_skip_is_transient
python test/dynamo/test_logging.py -k test_skip_reason_logging_dispatch_mode
```

Authored with the help of an AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98