### PR TITLE
Fix stale get_ci_variable.py flag in docker-release

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -109,7 +109,7 @@ jobs:
           # Generate PyTorch version to use
           {
             echo "PYTORCH_VERSION=$(python3 .github/scripts/generate_pytorch_version.py --no-build-suffix)";
-            echo "STABLE_CUDA_VERSION=$(python3 .github/scripts/get_ci_variable.py --stable-cuda-version)"
+            echo "STABLE_CUDA_VERSION=$(python3 .github/scripts/get_ci_variable.py --cuda-stable-version)"
           } >> "${GITHUB_ENV}"
       - name: Setup test specific variables
         if: ${{ startsWith(github.event.ref, 'refs/tags/v') }}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #190291

docker-release's build job computes STABLE_CUDA_VERSION with
`get_ci_variable.py --stable-cuda-version`, but the script's flag is
`--cuda-stable-version`. The stale flag makes the command error out, so
STABLE_CUDA_VERSION resolves to empty and the nightly `latest` tag pin
(gated on `CUDA_VERSION_SHORT == STABLE_CUDA_VERSION`) never matches --
`ghcr.io/pytorch/pytorch-nightly:latest` is never published.

Test Plan:
```
python3 .github/scripts/get_ci_variable.py --cuda-stable-version  # prints e.g. 13.0
python3 .github/scripts/get_ci_variable.py --stable-cuda-version  # error: unrecognized arguments
```

Example failure https://github.com/pytorch/pytorch/actions/runs/29482952236/job/87692503320#step:9:31

Authored with assistance from Claude Code.