### PR TITLE
[c10d][torchcomms] Add MCCL backend wrapper example (#190292)

### DIFF
--- a/test/distributed/test_c10d_torchcomms.py
+++ b/test/distributed/test_c10d_torchcomms.py
@@ -708,5 +708,37 @@ class TestC10dTorchCommsNewGroupHelper(TestCase):
         split_src.perform_nocolor_split.assert_called_once_with(torch.device("cuda:0"))
 
 
+class TestC10dTorchCommsBackendConfig(unittest.TestCase):
+    def test_unknown_device_qualified_torchcomms_backend_uses_custom_type(self):
+        backend_name = "tc_test_backend"
+        self.assertNotIn(backend_name, dist.Backend.backend_type_map)
+
+        orig = c10d._use_torchcomms_enabled
+        c10d._use_torchcomms_enabled = lambda: True
+        try:
+            backend_config = dist.BackendConfig(f"cuda:{backend_name}")
+            self.assertEqual(
+                c10d._get_default_backend_type_for_backend_config(backend_config),
+                dist.ProcessGroup.BackendType.CUSTOM,
+            )
+        finally:
+            c10d._use_torchcomms_enabled = orig
+
+    def test_unknown_device_qualified_backend_without_torchcomms_keeps_gloo_type(self):
+        backend_name = "tc_test_backend"
+        self.assertNotIn(backend_name, dist.Backend.backend_type_map)
+
+        orig = c10d._use_torchcomms_enabled
+        c10d._use_torchcomms_enabled = lambda: False
+        try:
+            backend_config = dist.BackendConfig(f"cuda:{backend_name}")
+            self.assertEqual(
+                c10d._get_default_backend_type_for_backend_config(backend_config),
+                dist.ProcessGroup.BackendType.GLOO,
+            )
+        finally:
+            c10d._use_torchcomms_enabled = orig
+
+
 if __name__ == "__main__":
     run_tests()

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -1002,6 +1002,30 @@ def _parse_backend_string(
     return dict.fromkeys(device_types, backend)
 
 
+def _get_default_backend_type_for_backend_config(
+    backend_config: BackendConfig,
+) -> ProcessGroup.BackendType:
+    if Backend.NCCL in backend_config.device_backend_map.values():
+        return ProcessGroup.BackendType.NCCL
+
+    custom_backend = next(
+        (
+            backend
+            for backend in backend_config.device_backend_map.values()
+            if Backend.backend_type_map.get(str(backend))
+            == ProcessGroup.BackendType.CUSTOM
+            or (
+                _use_torchcomms_enabled()
+                and str(backend) not in Backend.backend_type_map
+            )
+        ),
+        None,
+    )
+    if custom_backend is not None:
+        return ProcessGroup.BackendType.CUSTOM
+    return ProcessGroup.BackendType.GLOO
+
+
 class _reduce_op:
     r"""
     Deprecated enum-like class.
@@ -2675,22 +2699,9 @@ def _new_process_group_helper(
     # In order to correctly call pg._has_hooks(), we should set the default backend
     # when multi backend is passed in
     if not pg_backend_set:
-        if Backend.NCCL in backend_config.device_backend_map.values():
-            pg._set_default_backend(ProcessGroup.BackendType.NCCL)
-        else:
-            custom_backend = next(
-                (
-                    backend
-                    for backend in backend_config.device_backend_map.values()
-                    if Backend.backend_type_map.get(str(backend))
-                    == ProcessGroup.BackendType.CUSTOM
-                ),
-                None,
-            )
-            if custom_backend is not None:
-                pg._set_default_backend(ProcessGroup.BackendType.CUSTOM)
-            else:
-                pg._set_default_backend(ProcessGroup.BackendType.GLOO)
+        pg._set_default_backend(
+            _get_default_backend_type_for_backend_config(backend_config)
+        )
 
     if device_id:
         pg.bound_device_id = device_id


### PR DESCRIPTION
Summary:

X-link: https://github.com/meta-pytorch/torchcomms/pull/3163

D111755956 proved the PTD -> TorchComms NCCLX path, but the example had to mutate c10d internals with dist.Backend.backend_type_map.setdefault("ncclx", CUSTOM) before calling dist.init_process_group(backend="cuda:ncclx"). That made the example work, but it pushed c10d bookkeeping onto every user of an otherwise valid TorchComms backend string.

Keep that policy in c10d instead: unknown device-qualified TorchComms backends are treated as CUSTOM when c10d selects the process-group default backend type. This lets backend="cuda:mccl" and backend="cuda:ncclx" initialize through PTD without mutating dist.Backend.backend_type_map in user code.

Refactor the default-backend type decision into a small helper near the backend-string parsing helpers and cover it in test_c10d_torchcomms with a synthetic backend name: TorchComms enabled maps the unknown device-qualified backend to CUSTOM, while TorchComms disabled keeps the existing GLOO fallback.

Remove the old NCCLX AllGatherP example-side backend_type_map workaround now that c10d owns the policy.

Add small straight-line MCCL examples that call dist.init_process_group(backend="cuda:mccl"), verify the PTD backend implementation is a TorchComms _BackendWrapper, and verify the underlying TorchComm backend is mccl / TorchCommMCCL. One example checks ordinary allreduce. The new AllGatherP example allocates through the MCCL TorchComms allocator, calls comm.all_gather_p_init/exec/free through wrapper.get_comm(), and verifies gathered rank chunks.

The multi-backend new_group case is intentionally left for a follow-up diff.

Test Plan:
python3 -m py_compile fbcode/caffe2/torch/distributed/distributed_c10d.py xplat/caffe2/torch/distributed/distributed_c10d.py fbcode/caffe2/test/distributed/test_c10d_torchcomms.py xplat/caffe2/test/distributed/test_c10d_torchcomms.py fbcode/comms/torchcomms/fb/mccl/examples/AllReduceBackendWrapper.py fbcode/comms/torchcomms/fb/mccl/examples/AllGatherPBackendWrapper.py
arc lint --apply-patches fbcode/caffe2/torch/distributed/distributed_c10d.py xplat/caffe2/torch/distributed/distributed_c10d.py fbcode/caffe2/test/distributed/test_c10d_torchcomms.py xplat/caffe2/test/distributed/test_c10d_torchcomms.py fbcode/comms/torchcomms/ncclx/examples/AllGatherPBackendWrapper.py fbcode/comms/torchcomms/fb/mccl/examples/AllReduceBackendWrapper.py fbcode/comms/torchcomms/fb/mccl/examples/AllGatherPBackendWrapper.py fbcode/comms/torchcomms/fb/mccl/examples/BUCK
arc lint fbcode/caffe2/torch/distributed/distributed_c10d.py xplat/caffe2/torch/distributed/distributed_c10d.py fbcode/caffe2/test/distributed/test_c10d_torchcomms.py xplat/caffe2/test/distributed/test_c10d_torchcomms.py fbcode/comms/torchcomms/ncclx/examples/AllGatherPBackendWrapper.py fbcode/comms/torchcomms/fb/mccl/examples/AllReduceBackendWrapper.py fbcode/comms/torchcomms/fb/mccl/examples/AllGatherPBackendWrapper.py fbcode/comms/torchcomms/fb/mccl/examples/BUCK
git -C /tmp/d111994473_export_check apply --check /tmp/d111994473_export_check.patch
buck2 test --local-only --test-executor-stdout=- --test-executor-stderr=- -c comms.hosts=localhost fbcode//comms/torchcomms/fb/mccl/examples:AllReduceMCCLBackendWrapperPy -- --timeout=600 --print-passing-details
buck2 test --local-only --test-executor-stdout=- --test-executor-stderr=- -c comms.hosts=localhost fbcode//comms/torchcomms/fb/mccl/examples:AllGatherPMCCLBackendWrapperPy -- --timeout=600 --print-passing-details

Reviewed By: d4l3k

Differential Revision: D111994473


