### PR TITLE
[c10d][torchcomms] Add NCCLX and MCCL backend group example

### DIFF
--- a/test/distributed/test_c10d_common.py
+++ b/test/distributed/test_c10d_common.py
@@ -319,6 +319,36 @@ class BackendEntryPointTest(TestCase):
         self.assertIn("nccl", looked_up)
         self.assertEqual(str(backend_config), "cpu:gloo,cuda:nccl")
 
+    def test_unknown_device_qualified_torchcomms_backend_uses_custom_type(self):
+        backend_name = "tc_test_backend"
+        self.assertNotIn(backend_name, dist.Backend.backend_type_map)
+
+        orig = c10d._use_torchcomms_enabled
+        c10d._use_torchcomms_enabled = lambda: True
+        try:
+            backend_config = dist.BackendConfig(f"cuda:{backend_name}")
+            self.assertEqual(
+                c10d._get_default_backend_type_for_backend_config(backend_config),
+                dist.ProcessGroup.BackendType.CUSTOM,
+            )
+        finally:
+            c10d._use_torchcomms_enabled = orig
+
+    def test_unknown_device_qualified_backend_without_torchcomms_keeps_gloo_type(self):
+        backend_name = "tc_test_backend"
+        self.assertNotIn(backend_name, dist.Backend.backend_type_map)
+
+        orig = c10d._use_torchcomms_enabled
+        c10d._use_torchcomms_enabled = lambda: False
+        try:
+            backend_config = dist.BackendConfig(f"cuda:{backend_name}")
+            self.assertEqual(
+                c10d._get_default_backend_type_for_backend_config(backend_config),
+                dist.ProcessGroup.BackendType.GLOO,
+            )
+        finally:
+            c10d._use_torchcomms_enabled = orig
+
 
 class Net(nn.Module):
     def __init__(self) -> None:

--- a/test/distributed/test_fake_backend_new_group.py
+++ b/test/distributed/test_fake_backend_new_group.py
@@ -15,8 +15,7 @@ FakeProcessGroup directly and still produces a hashed name.
 These tests use a real (gloo) parent on a single CPU process: no GPU needed.
 """
 
-import os
-
+import torch
 import torch.distributed as dist
 import torch.distributed.distributed_c10d as c10d
 from torch.testing._internal.common_utils import run_tests, TestCase
@@ -24,10 +23,10 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 
 class FakeBackendNewGroupTest(TestCase):
     def setUp(self):
-        os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
-        os.environ.setdefault("MASTER_PORT", "29517")
         # Real (non-fake) parent so a fake child differs from the parent backend.
-        dist.init_process_group(backend="gloo", rank=0, world_size=1)
+        dist.init_process_group(
+            backend="gloo", rank=0, world_size=1, store=dist.HashStore()
+        )
 
     def tearDown(self):
         if dist.is_initialized():
@@ -75,6 +74,28 @@ class FakeBackendNewGroupTest(TestCase):
             self._check_fake_subgroup()
         finally:
             dist_config.use_torchcomms = prev
+
+    def test_torchcomms_new_group_split_predicate_for_same_and_different_backend(self):
+        """Different requested backend should use fresh new_group, not split."""
+
+        class _DummyDefaultGroup:
+            _device_types = [torch.device("cuda")]
+
+        dummy_default_pg = _DummyDefaultGroup()
+        orig_get_default_group = c10d._get_default_group
+        c10d._get_default_group = lambda: dummy_default_pg
+        c10d._world.pg_map[dummy_default_pg] = ("cuda:ncclx", None)
+        try:
+            self.assertTrue(c10d._torchcomms_new_group_can_split(None))
+            self.assertTrue(c10d._torchcomms_new_group_can_split("ncclx"))
+            self.assertTrue(c10d._torchcomms_new_group_can_split("cuda:ncclx"))
+
+            self.assertFalse(c10d._torchcomms_new_group_can_split("mccl"))
+            self.assertFalse(c10d._torchcomms_new_group_can_split("cuda:mccl"))
+            self.assertFalse(c10d._torchcomms_new_group_can_split("fake"))
+        finally:
+            c10d._world.pg_map.pop(dummy_default_pg, None)
+            c10d._get_default_group = orig_get_default_group
 
 
 if __name__ == "__main__":

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -5987,6 +5987,41 @@ def _is_safe_to_split() -> bool:
     return _get_default_group().bound_device_id is not None
 
 
+def _torchcomms_new_group_can_split(backend: str | Backend | None) -> bool:
+    if backend is None:
+        return True
+
+    default_pg = _get_default_group()
+    parent_backend, _ = _world.pg_map[default_pg]
+    requested_backend = str(backend).lower()
+    parent_backend_str = str(parent_backend).lower()
+    if requested_backend == parent_backend_str:
+        return True
+
+    parent_devices = {device.type for device in default_pg._device_types}
+    try:
+        parent_device_backends = _parse_backend_string(
+            parent_backend_str,
+            available_devices=parent_devices,
+        )
+    except ValueError:
+        return False
+    if ":" not in requested_backend:
+        return requested_backend in parent_device_backends.values()
+
+    try:
+        requested_device_backends = _parse_backend_string(
+            requested_backend,
+            available_devices=parent_devices,
+        )
+    except ValueError:
+        return False
+    return all(
+        parent_device_backends.get(device_type) == requested_be
+        for device_type, requested_be in requested_device_backends.items()
+    )
+
+
 @_time_logger
 def split_group(
     parent_pg: ProcessGroup | None = None,
@@ -6304,29 +6339,22 @@ def new_group(
     same global creation order.
 
     N.B. When TorchComms is enabled (``torch.distributed.config.use_torchcomms``
-    / ``TORCH_DISTRIBUTED_USE_TORCHCOMMS=1``), this function delegates to
-    :func:`split_group` so subgroup creation goes through the TorchComms path.
-    The delegation raises ``NotImplementedError`` for arguments that
-    :func:`split_group` cannot honor (e.g. ``use_local_synchronization=True``,
-    or an explicit ``device_id`` that diverges from the default group's bound
+    / ``TORCH_DISTRIBUTED_USE_TORCHCOMMS=1``), same-backend groups delegate to
+    :func:`split_group` so subgroup creation goes through the TorchComms split
+    path. Different-backend groups are created through the normal fresh process
+    group path since splitting cannot change the parent communicator's backend.
+    Split delegation raises ``NotImplementedError`` for arguments that
+    :func:`split_group` cannot honor (e.g. ``use_local_synchronization=True`` or
+    an explicit ``device_id`` that diverges from the default group's bound
     device).
     """
     if _use_torchcomms_enabled():
         # split_group can only split the parent's existing communicator, so it
-        # cannot produce a child whose backend differs from the parent's. A
-        # "fake" subgroup of a real parent -- how DeviceMesh creates disabled /
-        # unflattened dims, with use_local_synchronization for hashed names -- is
-        # exactly that case: route it through the normal path, which builds the
-        # FakeProcessGroup directly (see ``_new_group_with_tag``). When the
-        # requested backend matches the parent (including a fake parent), split
-        # delegation is fine.
-        parent_backend, _ = _world.pg_map[_get_default_group()]
-        is_fake_subgroup = (
-            backend is not None
-            and str(backend).lower() == "fake"
-            and str(backend).lower() != str(parent_backend).lower()
-        )
-        if not is_fake_subgroup:
+        # cannot produce a child whose backend differs from the parent's. Route
+        # different-backend requests through the normal path, which creates a
+        # fresh process group and lets TorchComms instantiate the requested
+        # backend directly.
+        if _torchcomms_new_group_can_split(backend):
             return _new_group_via_split_group(
                 ranks=ranks,
                 timeout=timeout,

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -2477,6 +2477,27 @@ def _get_split_source(pg: ProcessGroup):
     return split_from
 
 
+def _get_default_backend_type_for_backend_config(
+    backend_config: BackendConfig,
+) -> ProcessGroup.BackendType:
+    if Backend.NCCL in backend_config.device_backend_map.values():
+        return ProcessGroup.BackendType.NCCL
+
+    custom_backend = next(
+        (
+            backend
+            for backend in backend_config.device_backend_map.values()
+            if Backend.backend_type_map.get(str(backend))
+            == ProcessGroup.BackendType.CUSTOM
+            or (_use_torchcomms_enabled() and str(backend) not in Backend.backend_type_map)
+        ),
+        None,
+    )
+    if custom_backend is not None:
+        return ProcessGroup.BackendType.CUSTOM
+    return ProcessGroup.BackendType.GLOO
+
+
 def _new_process_group_helper(
     group_size,
     group_rank,
@@ -2575,22 +2596,9 @@ def _new_process_group_helper(
     # In order to correctly call pg._has_hooks(), we should set the default backend
     # when multi backend is passed in
     if not pg_backend_set:
-        if Backend.NCCL in backend_config.device_backend_map.values():
-            pg._set_default_backend(ProcessGroup.BackendType.NCCL)
-        else:
-            custom_backend = next(
-                (
-                    backend
-                    for backend in backend_config.device_backend_map.values()
-                    if Backend.backend_type_map.get(str(backend))
-                    == ProcessGroup.BackendType.CUSTOM
-                ),
-                None,
-            )
-            if custom_backend is not None:
-                pg._set_default_backend(ProcessGroup.BackendType.CUSTOM)
-            else:
-                pg._set_default_backend(ProcessGroup.BackendType.GLOO)
+        pg._set_default_backend(
+            _get_default_backend_type_for_backend_config(backend_config)
+        )
 
     if device_id:
         pg.bound_device_id = device_id


### PR DESCRIPTION
Summary:
Enable TorchComms-backed new_group to create a fresh process group when the requested backend differs from the default process group backend. Splitting is still used for same-backend groups, but a default cuda:ncclx group can now create a separate cuda:mccl group. This is needed because splitting an existing communicator cannot change the communicator backend.

Add CPU regression coverage for the routing decision: cuda:ncclx can split for ncclx/cuda:ncclx, while mccl/cuda:mccl/fake fall through to fresh process-group creation. Keep the existing fake-backend regression covered as well, since DeviceMesh uses fake subgroups with local synchronization and must not route those through TorchComms split_group.

Add a simple PTD example that initializes a default cuda:ncclx group and a secondary cuda:mccl group, verifies both groups are backed by TorchComms _BackendWrapper instances, verifies the underlying implementations are TorchCommNCCLX and TorchCommMCCL, and runs all_reduce on each.

Test Plan:
python3 -m py_compile fbcode/caffe2/test/distributed/test_fake_backend_new_group.py xplat/caffe2/test/distributed/test_fake_backend_new_group.py
arc lint --apply-patches fbcode/caffe2/torch/distributed/distributed_c10d.py xplat/caffe2/torch/distributed/distributed_c10d.py fbcode/caffe2/test/distributed/BUCK xplat/caffe2/test/distributed/BUCK fbcode/caffe2/test/distributed/test_fake_backend_new_group.py xplat/caffe2/test/distributed/test_fake_backend_new_group.py fbcode/comms/torchcomms/fb/mccl/examples/AllReduceTwoBackendWrappers.py fbcode/comms/torchcomms/fb/mccl/examples/BUCK
arc lint fbcode/caffe2/torch/distributed/distributed_c10d.py xplat/caffe2/torch/distributed/distributed_c10d.py fbcode/caffe2/test/distributed/BUCK xplat/caffe2/test/distributed/BUCK fbcode/caffe2/test/distributed/test_fake_backend_new_group.py xplat/caffe2/test/distributed/test_fake_backend_new_group.py fbcode/comms/torchcomms/fb/mccl/examples/AllReduceTwoBackendWrappers.py fbcode/comms/torchcomms/fb/mccl/examples/BUCK
buck2 test --local-only --test-executor-stdout=- --test-executor-stderr=- -c comms.hosts=localhost -c hpc_comms.use_ncclx=stable fbcode//comms/torchcomms/fb/mccl/examples:AllReduceNCCLXMCCLBackendWrappersPy -- --timeout=600 --print-passing-details
buck2 test --local-only --test-executor-stdout=- --test-executor-stderr=- -c comms.hosts=localhost fbcode//caffe2/test/distributed:fake_backend_new_group -- --timeout=600 --print-passing-details (attempted locally; no target result emitted, interrupted after prolonged silent build/setup)

Differential Revision: D112405733


