### PR TITLE
[skip ci] [docs] fix a typo in DeviceMesh._unflatten method

### DIFF
--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -1386,7 +1386,7 @@ else:
             Its length must match the length of mesh_sizes.
 
             For example, if we have a 1D mesh DeviceMesh([0, 1, 2, 3, 4, 5, 6, 7], mesh_dim_names=("world")),
-            calling mesh_1d._unflatten(0, (2, 2, 4), ["dp", "pp", "tp"]) will create a 3D mesh
+            calling mesh_1d._unflatten(0, (2, 2, 2), ["dp", "pp", "tp"]) will create a 3D mesh
             DeviceMesh([[[0, 1], [2, 3]], [[4, 5], [6, 7]]], mesh_dim_names=("dp", "cp", "tp")).
 
             Note that after calling the unflatten, there is no access to the unflattened dimension in mesh_1d, one can only


### PR DESCRIPTION
In the DeviceMesh._unflatten() method's description, thers is a typo. It is clear that the mesh_sizes should be (2, 2, 2) from the context. This PR is trying to fix it.

This PR is just docs-related, and can be merged without running CI.