### PR TITLE
Fix avg all_reduce backward

### DIFF
--- a/test/distributed/test_functional_differentials.py
+++ b/test/distributed/test_functional_differentials.py
@@ -266,32 +266,36 @@ class TestFunctionalDifferentials(MultiThreadedTestCase):
     # ============================================================
 
     @parametrize("device", devices)
-    def test_all_reduce_backward(self, device):
+    @parametrize("reduce_op", ["sum", "avg"])
+    def test_all_reduce_backward(self, device, reduce_op):
         """Test all_reduce backward does all_reduce.
 
         Both tensor AND gradients are VARYING (different across ranks).
-        Backward aggregates gradients via all_reduce(sum).
+        Backward aggregates gradients using the forward reduction operation.
         """
         group_name = dist.group.WORLD.group_name
 
         input_tensor = torch.randn(3, 3, requires_grad=True, device=device)
-        output = fcols.all_reduce(input_tensor, "sum", group=group_name)
+        output = fcols.all_reduce(input_tensor, reduce_op, group=group_name)
 
         # Backward with ones
         output.sum().backward()
 
-        # Gradient should be aggregated (backward is all_reduce)
+        # Gradient should be aggregated using the forward reduction operation
+        expected_value = self.world_size if reduce_op == "sum" else 1
         expected_grad = torch.full(
-            (3, 3), fill_value=float(self.world_size), device=device
+            (3, 3), fill_value=float(expected_value), device=device
         )
         self.assertEqual(input_tensor.grad, expected_grad)
 
-        # Backward is all_reduce (sum)
+        # Backward uses the same all_reduce operation as forward
         grad_outputs = torch.rand_like(output, device=device)
         (grad_input,) = torch.autograd.grad(
             output, input_tensor, grad_outputs=grad_outputs
         )
-        expected_grad_input = fcols.all_reduce(grad_outputs, "sum", group=group_name)
+        expected_grad_input = fcols.all_reduce(
+            grad_outputs, reduce_op, group=group_name
+        )
         self.assertEqual(grad_input, expected_grad_input)
 
     @parametrize("device", devices)

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -658,9 +658,10 @@ def all_reduce_backward(ctx, grad_output: torch.Tensor):
     group_name = ctx.group_name
     reduce_op = ctx.reduce_op
 
-    if reduce_op != "sum":
+    if reduce_op not in ("sum", "avg"):
         raise RuntimeError(
-            f"all_reduce backward only supports 'sum' reduction, got '{reduce_op}'"
+            "all_reduce backward only supports 'sum' and 'avg' reductions, "
+            f"got '{reduce_op}'"
         )
 
     # Backward does all_reduce with the same reduce_op


### PR DESCRIPTION
## Summary

Fixes #190007.

`all_reduce_backward` rejected the `avg` reduction even though its backward can use the same all-reduce operation as its forward. This change permits `avg` alongside `sum` and parameterizes the existing differential test to cover both operations.

## Test plan

- Passed a two-process Gloo test against a PyTorch nightly binary and the local `_functional_collectives.py`, covering `sum` and `avg` forward results and gradients.
- `python -m py_compile torch/distributed/_functional_collectives.py test/distributed/test_functional_differentials.py`
- `git diff --check`
- The repository test was collected successfully for both `sum` and `avg`, but could not execute on the Windows nightly because that wheel does not provide `torch.distributed.HashStore`.
- The official lintrunner bootstrap was attempted, but reports `Unsupported platform: Windows/Windows-AMD64`.

## AI assistance

This change was developed with assistance from OpenAI Codex. I reviewed the resulting implementation, tests, and diff and take responsibility for the contribution.
