### PR TITLE
[inductor] log when origami GEMM selection is skipped for symbolic shapes

### DIFF
--- a/torch/_inductor/heuristics/template/triton.py
+++ b/torch/_inductor/heuristics/template/triton.py
@@ -2206,6 +2206,8 @@ class MMTemplateConfigMixin(GemmMaxAutotuneTemplateConfigHeuristics):
         # usable selection, so restrict origami to fully static problems and let
         # symbolic shapes fall through to the regular config generator below.
         mnk_static = all(not getattr(x, "free_symbols", None) for x in (m, n, k))
+        if origami is not None and not mnk_static:
+            log.debug("Origami skipped: symbolic m/n/k, using regular config generator")
         # `origami is not None` encodes the module-load gate (see top of file);
         # only DEFAULT search space is supported here.
         if (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #190305

Follow-up to #190024 addressing a post-merge review comment. That PR made the
origami perf model skip symbolic m/n/k by falling through to the regular config
generator, but the skip was silent, unlike every other origami-skip path
(EXHAUSTIVE skip, "Origami returned no configs", "Config lookup failed") which
all log. Add a matching log.debug so anyone debugging why origami did not select
configs for a dynamic-shape matmul has a trace, following the existing
convention.

Test Plan:
Log-only change; no behavior change. Lint only:
```
lintrunner --take PYFMT,RUFF,PYREFLY,CODESPELL,FLAKE8 torch/_inductor/heuristics/template/triton.py
```

Authored with an AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo