### PR TITLE
[benchmarks/dynamo] Guard DistillGPT2 fallback_random override to ROCm only

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1169,12 +1169,7 @@ test_inductor_torchbench_smoketest_perf() {
   done
 
   # Perform some "warm-start" runs for a few huggingface models.
-  # NB: DistillGPT2 is excluded here because it has a known A100-specific inductor
-  # accuracy divergence (RMSE ~0.19 vs ~0.008 eager) that fails only on sm80; it
-  # still passes and is covered by the inductor_huggingface accuracy job on other
-  # runners. See pytorch/pytorch#187401. A one-off warm-start accuracy miss should
-  # not fail the whole smoke job. Re-add once the sm80 divergence is fixed.
-  for test in AllenaiLongformerBase DistilBertForMaskedLM GoogleFnet YituTechConvBert; do
+  for test in AllenaiLongformerBase DistilBertForMaskedLM DistillGPT2 GoogleFnet YituTechConvBert; do
     python benchmarks/dynamo/huggingface.py --accuracy --training --amp --inductor --device cuda --warm-start-latency \
       --only $test --output "$TEST_REPORTS_DIR/inductor_warm_start_smoketest_$test.csv"
     python benchmarks/dynamo/check_accuracy.py \

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -4351,7 +4351,8 @@ def run(runner, args, original_dir=None):
             torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = False
 
         if (
-            args.training
+            torch.version.hip is not None
+            and args.training
             and args.only is not None
             and args.only
             in {
@@ -4360,13 +4361,14 @@ def run(runner, args, original_dir=None):
         ):
             # With the harness-wide fallback_random=True, inductor falls back
             # to ATen rng for the dropout decomposition. That fallback Philox
-            # path indexes randoms by flat element offset, whereas eager CUDA
+            # path indexes randoms by flat element offset, whereas eager ROCm
             # rng indexes by (thread_id, intra_thread_iter), so the two produce
             # different dropout masks for the same seed and trip DistillGPT2's
-            # tight accuracy tolerance (observed on gfx942). Setting
+            # tight accuracy tolerance (observed on ROCm/gfx942). Setting
             # fallback_random=False re-enables inductor's replace_random passes,
-            # which align the masks with eager. This is correct/harmless on
-            # other backends since it only changes how inductor lowers rng.
+            # which align the masks with eager on that backend. Leave CUDA on
+            # the default fallback path; the Triton RNG path is not
+            # eager-equivalent there and regresses A100 DistillGPT2 accuracy.
             inductor_config.fallback_random = False
 
         # Some models e.g. yolov3 assert batch size on n_gpus


### PR DESCRIPTION
# Summary
https://github.com/pytorch/pytorch/issues/188835 flagged an A100 `DistillGPT2` AMP training accuracy failure. 

We bisected this issue to https://github.com/pytorch/pytorch/pull/186623/changes as the first failing commit. That commit attempts to fix accuracy error on ROCm/gfx942 by disabling `inductor_config.fallback_random`. This was only validated on gfx942, but on A100 it causes accuracy regression for this benchmark

In this PR we guard the change to ROCm only and also remove the change from https://github.com/pytorch/pytorch/pull/188750 which was added to temporarily patch the issue

Fixes https://github.com/pytorch/pytorch/issues/188835

# Validation
Validated this change on both A100 and MI300x and confirmed the accuracy failure goes away. CI also shows the failing test is fixed https://github.com/pytorch/pytorch/actions/runs/29646406986/job/88107424644?pr=190306

A100/sm80, PyTorch `2.14.0.dev20260625+cu130`
(`8dad44fdd9595ad80658b0ea49e3f322c978b139`), Triton source
`3.7.1+gitf797708c`:

```bash
python pytorch-src/benchmarks/dynamo/huggingface.py \
  --accuracy --training --amp --inductor --device cuda \
  --warm-start-latency --only DistillGPT2 \
  --output /data/users/warrdeng/triton-pin/investigation_188835/a100_distillgpt2_guard.csv

python pytorch-src/benchmarks/dynamo/check_accuracy.py \
  --actual /data/users/warrdeng/triton-pin/investigation_188835/a100_distillgpt2_guard.csv \
  --expected pytorch-src/benchmarks/dynamo/ci_expected_accuracy/inductor_huggingface_training.csv
```

Result:

```text
cuda,DistillGPT2,1,pass,540,5,8,5,0,0,0,11.792233
DistillGPT2                         PASS
```

Bisect evidence:

```text
bc977b3d830f6838a460d16e4638e83904d63f9d: pass
63aad77ebd19313e1cf0df82bb554dbf65b3430e: fail_accuracy
```

Triton boundary evidence:

```text
f797708c0626e5f9840ca5b0a98790e2c7cb09ad: STATUS FAIL
483327f0336aac7feb02a0eed45c2a6e2207ca00: STATUS FAIL
```



cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @azahed98