### PR TITLE
[CUDA] Add torch.accelerator.Graph support via an adapter

### DIFF
--- a/aten/src/ATen/cuda/CUDAGraph.cpp
+++ b/aten/src/ATen/cuda/CUDAGraph.cpp
@@ -1,16 +1,18 @@
+#include <ATen/Functions.h>
 #include <ATen/core/CachingHostAllocator.h>
+#include <ATen/core/GraphImplInterface.h>
 #include <ATen/cuda/CUDAContextLight.h>
 #include <ATen/cuda/CUDAGeneratorImpl.h>
 #include <ATen/cuda/CUDAGraph.h>
-#include <ATen/cuda/CUDAGraphsUtils.cuh>
 #include <ATen/cuda/Exceptions.h>
 #include <ATen/cuda/MemPool.h>
-#include <ATen/Functions.h>
 #include <c10/cuda/CUDAAllocatorConfig.h>
 #include <c10/cuda/CUDAFunctions.h>
+#include <ATen/cuda/CUDAGraphsUtils.cuh>
 
 #include <cstddef>
 #include <optional>
+#include <utility>
 
 namespace at::cuda {
 
@@ -401,10 +403,16 @@ void CUDAGraph::reset() {
 #endif
 }
 
-// Returns an id another graph's capture_begin can use to share the same memory pool as this graph.
+// Returns an id another graph's capture_begin can use to share the same memory
+// pool as this graph.
 MempoolId_t CUDAGraph::pool() {
-  TORCH_CHECK(capture_ended_,
-              "Called CUDAGraph::pool() without a preceding successful capture.");
+  return std::as_const(*this).pool();
+}
+
+MempoolId_t CUDAGraph::pool() const {
+  TORCH_CHECK(
+      capture_ended_,
+      "Called CUDAGraph::pool() without a preceding successful capture.");
   return mempool_id_;
 }
 
@@ -680,5 +688,80 @@ std::function<bool(cudaStream_t)> CUDAGraph::create_child_allocate_filter() {
 #endif
 }
 
+namespace {
+
+// Adapt the portable graph interface without changing CUDAGraph's public ABI.
+// CUDA-specific graph extensions remain available through CUDAGraph itself.
+class CUDAAcceleratorGraphImpl final : public GraphImplInterface {
+ public:
+  explicit CUDAAcceleratorGraphImpl(const GraphImplArgs& args)
+      : graph_(args.keep_graph) {}
+
+  void capture_begin(MempoolId_t pool, GraphCaptureMode capture_mode) override {
+    auto cuda_capture_mode = cudaStreamCaptureModeGlobal;
+    switch (capture_mode) {
+      case GraphCaptureMode::Default:
+      case GraphCaptureMode::Global:
+        break;
+      case GraphCaptureMode::ThreadLocal:
+        cuda_capture_mode = cudaStreamCaptureModeThreadLocal;
+        break;
+      case GraphCaptureMode::Relaxed:
+        cuda_capture_mode = cudaStreamCaptureModeRelaxed;
+        break;
+      default:
+        TORCH_CHECK(
+            false,
+            "Invalid GraphCaptureMode value: ",
+            static_cast<int>(capture_mode));
+    }
+    graph_.capture_begin(pool, cuda_capture_mode);
+  }
+
+  void capture_end() override {
+    graph_.capture_end();
+  }
+
+  void instantiate() override {
+    graph_.instantiate();
+  }
+
+  void replay() override {
+    if (!graph_.has_graph_exec()) {
+      graph_.instantiate();
+    }
+    graph_.replay();
+  }
+
+  void reset() override {
+    graph_.reset();
+  }
+
+  MempoolId_t pool() const override {
+    return graph_.pool();
+  }
+
+  void enable_debug_mode() override {
+    TORCH_CHECK_NOT_IMPLEMENTED(
+        false,
+        "torch.accelerator.Graph.enable_debug_mode is not supported for "
+        "CUDA. To dump a CUDA graph, capture it with torch.cuda.CUDAGraph.");
+  }
+
+  void debug_dump(const std::string& /*path*/) override {
+    TORCH_CHECK_NOT_IMPLEMENTED(
+        false,
+        "CUDA graphs captured through torch.accelerator.Graph cannot be "
+        "dumped. Recapture the graph with torch.cuda.CUDAGraph and use "
+        "torch.cuda.CUDAGraph.debug_dump instead.");
+  }
+
+ private:
+  CUDAGraph graph_;
+};
+
+REGISTER_GRAPH_IMPL(CUDA, CUDAAcceleratorGraphImpl)
+
+} // namespace
 
 } // namespace at::cuda

--- a/aten/src/ATen/cuda/CUDAGraph.h
+++ b/aten/src/ATen/cuda/CUDAGraph.h
@@ -91,6 +91,7 @@ struct TORCH_CUDA_CPP_API CUDAGraph {
   void replay();
   void reset();
   MempoolId_t pool();
+  MempoolId_t pool() const;
   std::vector<MempoolId_t> pools();
   void retain_pool(MempoolId_t pool);
   void enable_debug_mode();

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2712,6 +2712,76 @@ torch.cuda.synchronize()
     @unittest.skipIf(
         not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
     )
+    @parametrize("capture_error_mode", ["default", "global", "thread_local", "relaxed"])
+    def test_accelerator_graph_capture_modes(self, capture_error_mode):
+        stream = torch.Stream()
+        value = torch.zeros((), device="cuda")
+        graph = torch.accelerator.Graph(
+            capture_error_mode=capture_error_mode,
+        )
+
+        with stream, graph:
+            value.add_(1)
+        torch.accelerator.current_stream().wait_stream(stream)
+
+        value.zero_()
+        graph.replay()
+        self.assertEqual(value, 1)
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    def test_accelerator_graph_keep_graph_pool_reset(self):
+        stream = torch.Stream()
+        value = torch.zeros((), device="cuda")
+
+        first = torch.accelerator.Graph()
+        with stream, first:
+            value.add_(1)
+
+        pool = first.pool()
+        self.assertNotEqual(pool, (0, 0))
+
+        second = torch.accelerator.Graph(keep_graph=True, pool=pool)
+        with stream, second:
+            value.add_(2)
+        torch.accelerator.current_stream().wait_stream(stream)
+
+        self.assertEqual(second.pool(), pool)
+
+        value.zero_()
+        first.replay()
+        second.replay()
+        self.assertEqual(value, 3)
+
+        second.reset()
+        value.zero_()
+        with stream, second:
+            value.add_(4)
+        torch.accelerator.current_stream().wait_stream(stream)
+
+        self.assertEqual(second.pool(), pool)
+        second.instantiate()
+
+        value.zero_()
+        second.replay()
+        self.assertEqual(value, 4)
+
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            "torch.accelerator.Graph.enable_debug_mode is not supported for CUDA",
+        ):
+            second.enable_debug_mode()
+
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            "CUDA graphs captured through torch.accelerator.Graph cannot be dumped",
+        ):
+            second.debug_dump("unused.dot")
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
     def test_graph_capture_stale_default_stream_error(self):
         """Default-stream warmup + side-stream capture raises a clear error
         (not an opaque CUDA crash) when override is not enabled."""

--- a/torch/csrc/cuda/Graph.cpp
+++ b/torch/csrc/cuda/Graph.cpp
@@ -85,7 +85,8 @@ void THCPGraph_init(PyObject* module) {
           torch::wrap_pybind_function_no_gil(&at::cuda::CUDAGraph::reset))
       .def(
           "pool",
-          torch::wrap_pybind_function_no_gil(&at::cuda::CUDAGraph::pool))
+          torch::wrap_pybind_function_no_gil(
+              py::overload_cast<>(&at::cuda::CUDAGraph::pool)))
       .def(
           "pools",
           torch::wrap_pybind_function_no_gil(&at::cuda::CUDAGraph::pools))


### PR DESCRIPTION
## Motivation

The graph generalization RFC in #158827 introduced `GraphImplInterface` as the portable backend contract. In practice, other accelerator backends already have their own CUDAGraph-like implementations, such as `XPUGraph` and `MTIAGraph`.

A previous CUDA implementation in #171313 used a shared PIMPL-style implementation. The review raised concerns about additional indirection and whether `torch.accelerator.Graph` and `CUDAGraph` should be required to evolve together.

This PR explores a smaller alternative: keep the existing `CUDAGraph` implementation and public object layout intact, and implement `torch.accelerator.Graph` through a private adapter that composes `CUDAGraph`.

For backends that already have a mature graph implementation, should `torch.accelerator.Graph` support be added through a private adapter, rather than requiring the existing graph class to inherit from or be refactored around `GraphImplInterface`?

Could this be the recommended integration pattern for both in-tree and out-of-tree accelerators?

## Implementation

- Adds and registers a private CUDA `GraphImplInterface` adapter.
- Maps portable capture modes to CUDA capture modes.
- Reuses `CUDAGraph` for capture, replay, reset, instantiation, and graph pools.
- Preserves lazy instantiation with `keep_graph=True`.
- Adds CUDA tests for capture modes, replay, pool sharing, reset, and instantiation.

## Open design issues

### Cross-API lifetime

During capture, the adapter-owned `CUDAGraph` can be exposed through `torch.cuda.CUDAGraph.get_currently_capturing_graph()` as a non-owning reference. If that reference outlives the outer `torch.accelerator.Graph`, it becomes dangling.

We need to decide whether the generic and backend-specific graph APIs should be non-mixable, whether an ownership-safe bridge is needed, or whether composition is the wrong model.

### Debug APIs

`GraphImplInterface` includes `enable_debug_mode()` and `debug_dump()`, but CUDA graph dumping was moved from C++ to the Python layer in #187749. The adapter therefore cannot fully forward the C++ debug interface and currently reports these operations as unsupported.

We need to decide whether debug APIs belong in the portable interface or should remain optional, backend-specific capabilities.
