### PR TITLE
[CUDA] Unwind abandoned graph captures in CUDAGraph so their memory pools are released

### DIFF
--- a/aten/src/ATen/cuda/CUDAGraph.cpp
+++ b/aten/src/ATen/cuda/CUDAGraph.cpp
@@ -167,29 +167,43 @@ void CUDAGraph::capture_begin(MempoolId_t pool/*={0,0}*/, cudaStreamCaptureMode 
     TORCH_INTERNAL_ASSERT(mempool_id_.first > 0);
   }
 
-  // Addendum: beginAllocateStreamToPool is now called before cudaStreamBeginCapture to prevent an
-  // autograd thread's free() call triggering an invalid cudaEventRecord in the caching allocator
-  // due to the capture status being updated _after_ a capture had already started.
-  c10::cuda::CUDACachingAllocator::beginAllocateToPool(
-      capture_dev_, mempool_id_, create_allocate_filter<cudaStream_t>());
-  record_retained_pool(mempool_id_);
+  try {
+    // Addendum: beginAllocateStreamToPool is now called before cudaStreamBeginCapture to prevent an
+    // autograd thread's free() call triggering an invalid cudaEventRecord in the caching allocator
+    // due to the capture status being updated _after_ a capture had already started.
+    c10::cuda::CUDACachingAllocator::beginAllocateToPool(
+        capture_dev_, mempool_id_, create_allocate_filter<cudaStream_t>());
+    record_retained_pool(mempool_id_);
+    dev_pool_routing_active_ = true;
 
-  at::getHostAllocator(at::kCUDA)->begin_allocate_to_pool(mempool_id_, create_allocate_filter<c10::Stream>());
+    at::getHostAllocator(at::kCUDA)->begin_allocate_to_pool(mempool_id_, create_allocate_filter<c10::Stream>());
+    host_pool_routing_active_ = true;
+    host_pool_refed_ = true;
 
-  // cudaStreamCaptureModeGlobal is the most conservative option to
-  // prevent potentially unsafe CUDA API calls during capture.  See
-  // https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__STREAM.html#group__CUDART__STREAM_1g9d0535d93a214cbf126835257b16ba85
-  AT_CUDA_CHECK(cudaStreamBeginCapture(capture_stream_, capture_mode));
-  c10::cuda::CUDACachingAllocator::markCaptureBegin(capture_dev_);
+    // cudaStreamCaptureModeGlobal is the most conservative option to
+    // prevent potentially unsafe CUDA API calls during capture.  See
+    // https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__STREAM.html#group__CUDART__STREAM_1g9d0535d93a214cbf126835257b16ba85
+    AT_CUDA_CHECK(cudaStreamBeginCapture(capture_stream_, capture_mode));
+    stream_capture_active_ = true;
+    c10::cuda::CUDACachingAllocator::markCaptureBegin(capture_dev_);
+    capture_marked_ = true;
 
-  auto capture_id_opt = c10::cuda::captureIdMayInitCtx(stream);
-  TORCH_INTERNAL_ASSERT(capture_id_opt.has_value(),
-      "Stream should be actively capturing after cudaStreamBeginCapture");
-  capture_id_ = capture_id_opt.value();
+    auto capture_id_opt = c10::cuda::captureIdMayInitCtx(stream);
+    TORCH_INTERNAL_ASSERT(capture_id_opt.has_value(),
+        "Stream should be actively capturing after cudaStreamBeginCapture");
+    capture_id_ = capture_id_opt.value();
 
-  {
-    std::lock_guard<std::mutex> lock(_currently_capturing_graphs_mutex);
-    _currently_capturing_graphs.emplace(capture_id_, this);
+    {
+      std::lock_guard<std::mutex> lock(_currently_capturing_graphs_mutex);
+      _currently_capturing_graphs.emplace(capture_id_, this);
+    }
+  } catch (...) {
+    // Close the capture window before propagating so a failed
+    // capture_begin doesn't leave a process-wide capture active until this
+    // graph is destroyed. The pool references stay recorded; reset() (or
+    // the destructor) releases them.
+    unwind_partial_capture();
+    throw;
   }
 }
 
@@ -210,7 +224,16 @@ void CUDAGraph::capture_end_pre() {
   // Clear bookkeeping before propagating the return status so watchdog-side
   // checks cannot observe stale "capture active" state on error paths.
   cudaError_t endCaptureErr = cudaStreamEndCapture(capture_stream_, &graph_);
-  c10::cuda::CUDACachingAllocator::markCaptureEnd(capture_dev_);
+  if (endCaptureErr == cudaSuccess ||
+      endCaptureErr == cudaErrorStreamCaptureInvalidated) {
+    // Any other error (e.g. cudaErrorStreamCaptureWrongThread) means the
+    // capture is still live; leave the flag set so reset() can retry.
+    stream_capture_active_ = false;
+  }
+  if (capture_marked_) {
+    c10::cuda::CUDACachingAllocator::markCaptureEnd(capture_dev_);
+    capture_marked_ = false;
+  }
   {
     std::unique_lock<std::mutex> lock(_currently_capturing_graphs_mutex);
     TORCH_CHECK(
@@ -225,7 +248,9 @@ void CUDAGraph::capture_end_pre() {
   // safe regardless of whether the capture succeeded — they simply
   // remove the pool routing entry added by beginAllocateToPool.
   c10::cuda::CUDACachingAllocator::endAllocateToPool(capture_dev_, mempool_id_);
+  dev_pool_routing_active_ = false;
   at::getHostAllocator(at::kCUDA)->end_allocate_to_pool(mempool_id_);
+  host_pool_routing_active_ = false;
   AT_CUDA_CHECK(endCaptureErr);
 
   TORCH_CHECK(graph_ != nullptr, "Invalid capture.");
@@ -336,6 +361,97 @@ cudaGraphExec_t CUDAGraph::raw_cuda_graph_exec() {
   return graph_exec_;
 }
 
+// Note [Abandoned graph capture]
+// If an exception fires between capture_begin() and a successful
+// capture_end(), the capture is abandoned with some capture-window state
+// still live: the stream may still be capturing, the allocators still
+// routing into the private pool, the device still marked as capturing.
+// Undo the pieces whose teardown in capture_end_pre did not run, each
+// gated on its own flag, so this is idempotent and never over-decrements.
+// Completes #180395, which covered failures once capture_end() is
+// reached. Pool references are NOT dropped here — reset() does that
+// right after this unwind, and only if the window actually closed
+// (gh-188439).
+//
+// Returns false when the capture could not be ended (e.g.
+// cudaErrorStreamCaptureWrongThread: in Global/ThreadLocal capture modes
+// only the capturing thread may end a capture). The remaining state is
+// left in place — a later call from the right thread can still unwind it
+// — and the caller must not release the pool out from under the live
+// capture. Child captures inside conditional nodes are not unwound
+// (pre-existing gap; their extra pool references are also unaccounted).
+bool CUDAGraph::unwind_partial_capture() {
+  if (!stream_capture_active_ && !capture_marked_ &&
+      !dev_pool_routing_active_ && !host_pool_routing_active_) {
+    return true;
+  }
+
+  // The teardown below assumes the capture stream/device are current — in
+  // particular the cudaMallocAsync allocator's endAllocateToPool records
+  // cross-stream dependencies against the current stream.
+  at::cuda::CUDAStreamGuard stream_guard(capture_stream_);
+
+  if (stream_capture_active_) {
+#if !defined(USE_ROCM) && (defined(CUDA_VERSION) && CUDA_VERSION >= 12040)
+    if (!conditional_graph_capture_ids_.empty()) {
+      TORCH_WARN(
+          "CUDAGraph::reset() on a capture abandoned inside a conditional "
+          "node; child capture state is not unwound.");
+    }
+#endif
+    cudaGraph_t abandoned_graph = nullptr;
+    const cudaError_t err =
+        cudaStreamEndCapture(capture_stream_, &abandoned_graph);
+    if (err != cudaSuccess) {
+      (void)cudaGetLastError(); // clear the sticky error
+      // cudaErrorStreamCaptureInvalidated is the expected outcome for a
+      // capture that failed partway; the capture is over either way. Any
+      // other error means the capture may still be live.
+      if (err != cudaErrorStreamCaptureInvalidated) {
+        TORCH_WARN(
+            "CUDAGraph::reset() could not end an in-flight capture (",
+            cudaGetErrorString(err),
+            "); its capture state and memory pool are left in place.");
+        return false;
+      }
+    }
+    if (abandoned_graph != nullptr) {
+      C10_CUDA_CHECK_WARN(cudaGraphDestroy(abandoned_graph));
+    }
+    stream_capture_active_ = false;
+  }
+
+  // reset() runs from the destructor and must not throw; downgrade any
+  // teardown failure to a warning.
+  auto warn_on_throw = [](const char* what, auto&& fn) {
+    try {
+      fn();
+    } catch (const std::exception& e) {
+      TORCH_WARN("CUDAGraph::reset(): ", what, " failed: ", e.what());
+    }
+  };
+  if (capture_marked_) {
+    warn_on_throw("markCaptureEnd", [&] {
+      c10::cuda::CUDACachingAllocator::markCaptureEnd(capture_dev_);
+    });
+    capture_marked_ = false;
+  }
+  if (dev_pool_routing_active_) {
+    warn_on_throw("endAllocateToPool", [&] {
+      c10::cuda::CUDACachingAllocator::endAllocateToPool(
+          capture_dev_, mempool_id_);
+    });
+    dev_pool_routing_active_ = false;
+  }
+  if (host_pool_routing_active_) {
+    warn_on_throw("host end_allocate_to_pool", [&] {
+      at::getHostAllocator(at::kCUDA)->end_allocate_to_pool(mempool_id_);
+    });
+    host_pool_routing_active_ = false;
+  }
+  return true;
+}
+
 void CUDAGraph::reset() {
   // I'd prefer these checks throw exceptions, not print warnings,
   // but the destructor calls reset(), and at least one CI build
@@ -357,6 +473,11 @@ void CUDAGraph::reset() {
   // If the user catches the failure exception in a script, or is running in REPL or (god forbid)
   // a Jupyter notebook, I don't see an easy way for reset() to gracefully fix all such possible error states.
 
+  // Phase 1: close the capture window if capture_end_pre never did.
+  // See Note [Abandoned graph capture] above unwind_partial_capture().
+  const bool capture_window_closed = unwind_partial_capture();
+
+  // Phase 2: generator and capture-registration cleanup.
   // See Note [RNG state tensor lifetime and recordStream] in
   // CUDAGeneratorImpl.cpp — recordStream in setup_for_replay ensures the
   // allocator won't recycle these tensors until in-flight replays finish.
@@ -373,19 +494,32 @@ void CUDAGraph::reset() {
     capture_id_ = 0;
   }
 
-  if (capture_ended_) {
-    // Clean up cuBLAS workspaces allocated on the capture stream, otherwise live allocations prevent
-    // private pool cleanup
-    clearCublasWorkspacesForStream(capture_stream_.stream());
+  // Phase 3: drop the pool references taken during capture. Ownership
+  // records (non-empty retained_mempool_ids_ / host_pool_refed_), NOT
+  // capture_ended_, are the release conditions, so abandoned captures also
+  // drop their references — see Note [Abandoned graph capture]. Skipped if
+  // the capture window could not be closed: a live capture may still be
+  // routing allocations into the pool.
+  if (capture_window_closed) {
+    if (!retained_mempool_ids_.empty()) {
+      // Clean up cuBLAS workspaces allocated on the capture stream, otherwise live allocations prevent
+      // private pool cleanup
+      clearCublasWorkspacesForStream(capture_stream_.stream());
 
-    // notifyCaptureDestroy may throw. How should we handle this?
-    for (const auto& pool : retained_mempool_ids_) {
-      c10::cuda::CUDACachingAllocator::releasePool(capture_dev_, pool);
+      // notifyCaptureDestroy may throw. How should we handle this?
+      for (const auto& pool : retained_mempool_ids_) {
+        c10::cuda::CUDACachingAllocator::releasePool(capture_dev_, pool);
+      }
+      retained_mempool_ids_.clear();
     }
-    retained_mempool_ids_.clear();
-    at::getHostAllocator(at::kCUDA)->release_pool(mempool_id_);
-    capture_ended_ = false;
+    if (host_pool_refed_) {
+      at::getHostAllocator(at::kCUDA)->release_pool(mempool_id_);
+      host_pool_refed_ = false;
+    }
   }
+  capture_ended_ = false;
+
+  // Phase 4: destroy the graph artifacts.
   if (has_graph_) {
     C10_CUDA_CHECK_WARN(cudaGraphDestroy(graph_));
     has_graph_ = false;

--- a/aten/src/ATen/cuda/CUDAGraph.h
+++ b/aten/src/ATen/cuda/CUDAGraph.h
@@ -113,6 +113,9 @@ struct TORCH_CUDA_CPP_API CUDAGraph {
   std::function<bool(cudaStream_t)> create_child_allocate_filter();
   void record_retained_pool(MempoolId_t pool);
   bool has_retained_pool(MempoolId_t pool) const;
+  // Returns false if the capture window could not be closed (the capture
+  // may still be live); see Note [Abandoned graph capture] in CUDAGraph.cpp.
+  bool unwind_partial_capture();
 #if !defined(USE_ROCM) && (defined(CUDA_VERSION) && CUDA_VERSION >= 12040)
   void begin_capture_to_conditional_node(
       const Tensor& scalar_cuda_pred_tensor,
@@ -123,20 +126,54 @@ struct TORCH_CUDA_CPP_API CUDAGraph {
   cudaGraph_t graph_ = nullptr;
   cudaGraphExec_t graph_exec_ = nullptr;
 
-  // internal states so reset() can do its best cleaning up
+  // ---------------------------------------------------------------------
+  // Lifecycle state, in acquisition order. Each field records one thing a
+  // capture acquired and is cleared by the matching teardown; reset()
+  // undoes whatever is still live, so an abandoned capture (exception in
+  // capture_begin, the captured region, or capture_end) unwinds cleanly.
+  // See Note [Abandoned graph capture] in CUDAGraph.cpp.
+  //
+  // Three lifetime classes:
+  //   Capture window — opened by capture_begin, closed by capture_end_pre
+  //     even if cudaStreamEndCapture failed (#180395).
+  //   Pool references — held past capture_end (replay needs the pool);
+  //     dropped only by reset().
+  //   Graph artifacts — created by capture_end_pre / instantiate,
+  //     destroyed by capture_end_post / reset().
+  // ---------------------------------------------------------------------
 
-  // Set to true in capture_end if cudaStreamEndCapture succeeded
-  // Set back to false after instantiate() unless keep_graph=True or
-  // enable_debug_mode() was called on any CUDAGraph instance.
-  bool has_graph_ = false;
-  // Set to true in capture_end if cudaStreamEndCapture succeeded
-  bool capture_ended_ = false;
-  // Set to true in capture_end if cudaGraphInstantiate succeeded
-  bool has_graph_exec_ = false;
-
-  // the ID assigned by cuda during graph capture,
-  // used to identify when a stream is participating in capture
+  // Capture window: device allocator routes allocations into the private
+  // pool (beginAllocateToPool .. endAllocateToPool). The use_count
+  // reference it also takes lives in retained_mempool_ids_.
+  bool dev_pool_routing_active_ = false;
+  // Capture window: host (pinned) allocator routes into the pool
+  // (begin_allocate_to_pool .. end_allocate_to_pool).
+  bool host_pool_routing_active_ = false;
+  // Pool reference: one host-pool use_count ref, taken by the same
+  // begin_allocate_to_pool call.
+  bool host_pool_refed_ = false;
+  // Capture window: stream capture in flight
+  // (cudaStreamBeginCapture .. cudaStreamEndCapture, either outcome).
+  bool stream_capture_active_ = false;
+  // Capture window: counted in the allocator's active-capture count
+  // (markCaptureBegin .. markCaptureEnd).
+  bool capture_marked_ = false;
+  // Capture identity: the ID CUDA assigned to this capture. Nonzero from
+  // capture_begin until reset() — it outlives the capture window (replay()
+  // uses it); keys the entry in _currently_capturing_graphs and the
+  // per-capture RNG generator state.
   CaptureId_t capture_id_ = 0;
+
+  // Phase marker, not a resource: capture_end_pre completed successfully.
+  // Gates pool()/pools()/instantiate(). Deliberately NOT the gate for
+  // releasing pool references — abandoned captures must release those too.
+  bool capture_ended_ = false;
+
+  // Graph artifact: graph_ holds a live cudaGraph_t. capture_end_post
+  // destroys the template unless keep_graph_ (enable_debug_mode() sets it).
+  bool has_graph_ = false;
+  // Graph artifact: graph_exec_ holds a live cudaGraphExec_t.
+  bool has_graph_exec_ = false;
 
   // uuid used to request a particular private mempool from CUDACachingAllocator.
   // By default, this will be set to {id_, 0}.
@@ -151,6 +188,11 @@ struct TORCH_CUDA_CPP_API CUDAGraph {
   // Sharing a mempool across graphs saves memory, and it's safe if you
   // know you'll replay those graphs in the same order you captured them.
   MempoolId_t mempool_id_;
+  // Pool references: device-pool use_count refs this graph owns — one for
+  // mempool_id_ (beginAllocateToPool), plus one per retain_pool() call.
+  // reset() releases one reference per entry. (Conditional-node capture
+  // takes additional increfs that are not recorded here — pre-existing
+  // gap.)
   std::vector<MempoolId_t> retained_mempool_ids_;
 
   // Stream on which capture began

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2949,6 +2949,79 @@ torch.cuda.synchronize()
             after, baseline, "Leaked CUDA/RNG allocations after failed capture test"
         )
 
+    @skipIfRocmVersionLessThan((7, 14))
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    @unittest.skipIf(
+        TEST_CUDAMALLOCASYNC, "memory_snapshot does not track cudaMallocAsync"
+    )
+    def test_graph_failed_capture_releases_pool(self):
+        """A capture that fails partway must not leak its private pool.
+
+        reset() used to release the pool's use_count reference only after a
+        *successful* capture, so an exception during capture left the pool
+        permanently retained and its segments reserved until process exit,
+        poisoning later tests' memory accounting (gh-188439).
+        """
+        if TEST_WITH_ROCM and self.expandable_segments:
+            self.skipTest(
+                "ROCm expandable segments has known issue with graph capture recovery - #179911"
+            )
+        torch.cuda.synchronize()
+        gc.collect()
+        torch.cuda.empty_cache()
+        baseline_pools = {s["segment_pool_id"] for s in torch.cuda.memory_snapshot()}
+
+        # Case 1: exception in the capture body. torch.cuda.graph.__exit__
+        # still calls capture_end(), which re-raises after cudaStreamEndCapture
+        # reports the invalidated capture.
+        g1 = torch.cuda.CUDAGraph()
+        with self.assertRaises(RuntimeError):
+            with torch.cuda.graph(g1):
+                x = torch.ones(2**20, device="cuda")
+                x.sum().item()  # synchronization is illegal during capture
+
+        # Case 2: capture abandoned without ever reaching capture_end()
+        # (manual/C++ path); reset() must abort the live capture itself.
+        # The RNG op registers generator capture state that reset() must
+        # also unwind.
+        g2 = torch.cuda.CUDAGraph()
+        stream = torch.cuda.Stream()
+        with torch.cuda.stream(stream):
+            g2.capture_begin()
+            y = torch.randn(2**20, device="cuda")
+            g2.reset()
+        torch.cuda.current_stream().wait_stream(stream)
+
+        # Case 3: two graphs sharing a pool; the failed capture must drop
+        # only its own reference, leaving the healthy graph replayable.
+        pool = torch.cuda.graph_pool_handle()
+        g_ok = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g_ok, pool=pool):
+            ok_out = torch.ones(64, device="cuda") * 2
+        g_bad = torch.cuda.CUDAGraph()
+        with self.assertRaises(RuntimeError):
+            with torch.cuda.graph(g_bad, pool=pool):
+                z = torch.ones(2**20, device="cuda")
+                z.sum().item()  # synchronization is illegal during capture
+        g_ok.replay()
+        torch.cuda.synchronize()
+        self.assertEqual(ok_out.sum().item(), 128.0)
+
+        del g1, g2, g_ok, g_bad, x, y, z, ok_out
+        gc.collect()
+        torch.cuda.empty_cache()
+        leaked = [
+            s["segment_pool_id"]
+            for s in torch.cuda.memory_snapshot()
+            if s["segment_pool_id"] != (0, 0)
+            and s["segment_pool_id"] not in baseline_pools
+        ]
+        self.assertEqual(leaked, [], "failed captures leaked private-pool segments")
+        # The allocator and the stream must remain usable.
+        torch.randn(8, device="cuda").sum().item()
+
     @unittest.skipIf(
         not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
     )

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2968,7 +2968,10 @@ torch.cuda.synchronize()
             self.skipTest(
                 "ROCm expandable segments has known issue with graph capture recovery - #179911"
             )
-        torch.cuda.synchronize()
+        # Reap earlier tests' garbage first: a cycle-trapped CUDAGraph whose
+        # destructor fired mid-capture below would invalidate our captures,
+        # and freeing already-released pools now keeps cudaFree out of the
+        # capture windows.
         gc.collect()
         torch.cuda.empty_cache()
         baseline_pools = {s["segment_pool_id"] for s in torch.cuda.memory_snapshot()}
@@ -2987,12 +2990,10 @@ torch.cuda.synchronize()
         # The RNG op registers generator capture state that reset() must
         # also unwind.
         g2 = torch.cuda.CUDAGraph()
-        stream = torch.cuda.Stream()
-        with torch.cuda.stream(stream):
+        with torch.cuda.stream(torch.cuda.Stream()):
             g2.capture_begin()
             y = torch.randn(2**20, device="cuda")
             g2.reset()
-        torch.cuda.current_stream().wait_stream(stream)
 
         # Case 3: two graphs sharing a pool; the failed capture must drop
         # only its own reference, leaving the healthy graph replayable.
@@ -3006,7 +3007,6 @@ torch.cuda.synchronize()
                 z = torch.ones(2**20, device="cuda")
                 z.sum().item()  # synchronization is illegal during capture
         g_ok.replay()
-        torch.cuda.synchronize()
         self.assertEqual(ok_out.sum().item(), 128.0)
 
         del g1, g2, g_ok, g_bad, x, y, z, ok_out

--- a/torch/utils/hipify/cuda_to_hip_mappings.py
+++ b/torch/utils/hipify/cuda_to_hip_mappings.py
@@ -459,6 +459,8 @@ CUDA_IDENTIFIER_MAP = collections.OrderedDict([
     ("cudaErrorInvalidResourceHandle", "hipErrorInvalidResourceHandle"),
     ("CUDA_ERROR_NOT_READY", "hipErrorNotReady"),
     ("cudaErrorNotReady", "hipErrorNotReady"),
+    ("CUDA_ERROR_STREAM_CAPTURE_INVALIDATED", "hipErrorStreamCaptureInvalidated"),
+    ("cudaErrorStreamCaptureInvalidated", "hipErrorStreamCaptureInvalidated"),
     ("CUDA_ERROR_ILLEGAL_ADDRESS", "hipErrorIllegalAddress"),
     ("cudaErrorIllegalAddress", "hipErrorIllegalAddress"),
     ("CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES", "hipErrorLaunchOutOfResources"),


### PR DESCRIPTION
### The bug

Every CUDA graph capture reserves a private memory pool. Normally, when the capture ends and the graph is destroyed, the pool is given back. But the cleanup in `CUDAGraph::reset()` only ran for captures that **finished successfully**. If an error interrupted the capture midway, the pool was kept forever: its memory stays reserved, `torch.cuda.empty_cache()` can never free it, and it only goes away when the process exits. 

This is why `test_mempool_ctx_multithread` fails randomly in CI — an earlier test intentionally fails a capture, and the leftover pool memory trips the later test's accounting (#188439).

#180395 fixed cleanup for one failure spot: the capture reaches its normal end step, and the "end capture" CUDA call itself reports an error. It did not cover errors that happen before the end step is ever reached. 

### What this PR changes

- The graph object now remembers each thing a capture sets up, one flag per item: the stream capture is running; the allocator is counting an active capture; the device and pinned-host allocators are redirecting allocations into the pool; the pool references are held.
- `reset()` (which also runs from the destructor) undoes exactly the items still set: it stops a capture that is still running, corrects the active-capture count, and stops the allocation redirection.
- The pool is released whenever the graph still holds a reference to it — not only after a successful capture. Interrupted captures now give their memory back the same way successful ones do.
- Safety on the cleanup path: if the capture cannot be stopped (CUDA only lets the thread that started a capture stop it), we warn and keep the memory rather than free it under a still-running capture; cleanup never throws out of the destructor; and `capture_begin` cleans up after its own failures instead of leaving a half-started capture behind.
- New test `test_graph_failed_capture_releases_pool`: fails captures three different ways (error inside the captured region; a capture abandoned without ever calling the end step; one of two graphs sharing a pool fails while the other must keep working) and checks that no pool memory is left behind.


Known gap: Captures that use conditional nodes take extra pool references that were never released. 

cc @ptrblck @msaroufim @eqy @tinglvv @nWEIdia @mcarilli @ezyang @eellison @penguinwu @BoyuanFeng @galv @MatthiasKohl 

Collaborate with Claude.