### PR TITLE
[Testcase Refactoring] Refactor FSDP tests for hardware agnosticism

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_comm.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_comm.py
@@ -46,7 +46,7 @@ from torch.distributed.fsdp._fully_shard._fsdp_param_group import FSDPParamGroup
 from torch.distributed.tensor import DTensor
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.distributed.tensor.experimental import implicit_replication
-from torch.testing._internal.common_cuda import SM90OrLater, TEST_MULTIGPU
+from torch.testing._internal.common_cuda import SM90OrLater, TEST_CUDA, TEST_MULTIGPU
 from torch.testing._internal.common_distributed import (
     MultiProcContinuousTest,
     PLATFORM_SUPPORTS_SYMM_MEM,
@@ -1921,9 +1921,10 @@ class TestFullyShardForceSumReduction(FSDPTest):
         super()._run(*args, **kwargs)
 
     # Test reduce-scatter only on plain FSDP on 2 GPUs
+    # This test verifies NCCL debug logs and is CUDA-specific.
     @skip_if_lt_x_gpu(2)
     @unittest.skipIf(
-        TEST_XPU, "Related environment variable is not supported with XCCL"
+        not TEST_CUDA, "This test verifies NCCL debug logs and is CUDA-specific"
     )
     def test_fully_shard_force_sum_reduce_scatter(self):
         torch.manual_seed(42)
@@ -1976,9 +1977,10 @@ class TestFullyShardForceSumReduction(FSDPTest):
         self.assertRegex(logs, reduce_scatter_sum_re)
 
     # Test both reduce-scatter and all-reduce on HSDP (DDP+FSDP) on 4 GPUs
+    # This test verifies NCCL debug logs and is CUDA-specific.
     @skip_if_lt_x_gpu(4)
     @unittest.skipIf(
-        TEST_XPU, "Related environment variable is not supported with XCCL"
+        not TEST_CUDA, "This test verifies NCCL debug logs and is CUDA-specific"
     )
     def test_fully_shard_force_sum_both_reductions(self):
         mesh = init_device_mesh(

--- a/test/distributed/_composable/fsdp/test_fully_shard_dtensor.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_dtensor.py
@@ -57,7 +57,9 @@ def _tp_shard_fn(param):
 class TestFullyShardDTensor(FSDPTest):
     @property
     def world_size(self):
-        return min(4, torch.cuda.device_count())
+        if torch.accelerator.is_available():
+            return min(4, torch.accelerator.device_count())
+        return 0
 
     def _run_train_parity(
         self, model, ref_model, dp_pg, mesh=None, num_iters=5, mlp_dim=16

--- a/test/distributed/_composable/fsdp/test_fully_shard_memory.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_memory.py
@@ -24,7 +24,6 @@ from torch.testing._internal.common_utils import (
     run_tests,
     TEST_CUDA,
     TEST_HPU,
-    TEST_XPU,
 )
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     ModelArgs,
@@ -329,18 +328,17 @@ class TestFullyShardMemory(FSDPTest):
 
     def _get_peak_active_memory_mb(self) -> int:
         mem_stats = torch.get_device_module(device_type).memory_stats()
-
-        if TEST_CUDA or TEST_XPU:
+        # HPU uses different memory stat keys.
+        if not TEST_HPU:
             return round(mem_stats["active_bytes.all.peak"] / 1e6)
-        if TEST_HPU:
-            return round(mem_stats["MaxInUse"] / 1e6)
+        return round(mem_stats["MaxInUse"] / 1e6)
 
     def _get_curr_active_memory_mb(self) -> int:
         mem_stats = torch.get_device_module(device_type).memory_stats()
-        if TEST_CUDA or TEST_XPU:
+        # HPU uses different memory stat keys.
+        if not TEST_HPU:
             return round(mem_stats["active_bytes.all.current"] / 1e6)
-        if TEST_HPU:
-            return round(mem_stats["InUse"] / 1e6)
+        return round(mem_stats["InUse"] / 1e6)
 
     def _register_optim_in_backward(
         self, model: torch.nn.Module, **optim_kwargs
@@ -371,8 +369,9 @@ class TestFullyShardHSDPSyncCorrectness(FSDPTest):
     def world_size(self) -> int:
         return min(4, torch.get_device_module(device_type).device_count())
 
+    # This test is CUDA-specific because it relies on torch.cuda._sleep.
     @skip_if_lt_x_gpu(4)
-    @unittest.skipIf(TEST_HPU or TEST_XPU, "HSDP sync correctness test is CUDA-only")
+    @unittest.skipIf(not TEST_CUDA, "HSDP sync correctness test is CUDA-only")
     def test_ar_buffer_lifetime_mixed_dtype(self):
         """Regression guard for PR #140044 (`[FSDP2] Fix CUDA sync for bf16
         HSDP AR, fp32 params`).

--- a/test/distributed/_composable/fsdp/test_fully_shard_mixed_precision.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_mixed_precision.py
@@ -3,6 +3,7 @@
 import copy
 import dataclasses
 import functools
+import unittest
 from typing import Any, NamedTuple
 
 import torch
@@ -22,6 +23,7 @@ from torch.testing._internal.common_distributed import (
 )
 from torch.testing._internal.common_fsdp import (
     check_sharded_parity,
+    DISTRIBUTED_BACKEND,
     FSDPTest,
     FSDPTestMultiThread,
     get_devtype,
@@ -34,7 +36,8 @@ from torch.testing._internal.common_utils import (
     run_tests,
     skipIfRocmArch,
     skipIfRocmVersionLessThan,
-    TEST_HPU,
+    TEST_CUDA,
+    TEST_XPU,
 )
 from torch.utils.checkpoint import checkpoint
 
@@ -99,6 +102,7 @@ class TestFullyShardMixedPrecisionTraining(FSDPTest):
 
     @skipIfRocmVersionLessThan((7, 0))
     @skip_if_lt_x_gpu(2)
+    @unittest.skipIf(DISTRIBUTED_BACKEND != "nccl", "Requires NCCL backend")
     @requires_nccl_version((2, 10), "Need NCCL 2.10+ for bf16 collectives")
     def test_compute_dtype(self):
         use_shard_placement_fn_vals = (
@@ -179,6 +183,7 @@ class TestFullyShardMixedPrecisionTraining(FSDPTest):
 
     @skipIfRocmVersionLessThan((7, 0))
     @skip_if_lt_x_gpu(2)
+    @unittest.skipIf(DISTRIBUTED_BACKEND != "nccl", "Requires NCCL backend")
     @requires_nccl_version((2, 10), "Need NCCL 2.10+ for bf16 collectives")
     def test_reduce_dtype(self):
         self.run_subtests(
@@ -894,6 +899,7 @@ class TestFullyShardMixedPrecisionCasts(FSDPTestMultiThread):
             )
 
     @skip_if_lt_x_gpu(1)
+    @unittest.skipIf(DISTRIBUTED_BACKEND != "nccl", "Requires NCCL backend")
     @requires_nccl_version((2, 10), "Need NCCL 2.10+ for bf16 collectives")
     def test_norm_modules_bf16(self):
         mp_policy = MixedPrecisionPolicy(param_dtype=torch.bfloat16)
@@ -924,19 +930,21 @@ class TestFullyShardMixedPrecisionCasts(FSDPTestMultiThread):
             fully_shard(module, mp_policy=mp_policy)
         inner(model, torch.randn((4, 32)))
 
-        # Batch norm 2D: error in backward from buffer dtype mismatch
+        # Batch norm 2D: CUDA and XPU raise a dtype mismatch error in backward
+        # from buffer dtype mismatch; other hardware types do not. Preserve the
+        # original semantics for CUDA/XPU and default all other devices to the
+        # no-error path.
         model = nn.Sequential(nn.Conv2d(1, 5, 3), nn.BatchNorm2d(5), nn.Conv2d(5, 4, 3))
         for module in (model[0], model[1], model[2], model):
             fully_shard(module, mp_policy=mp_policy)
-        if TEST_HPU:
-            inner(model, torch.randn((3, 1, 9, 9)))
-        else:
+        if TEST_CUDA or TEST_XPU:
             with self.assertRaisesRegex(
                 RuntimeError,
-                "Expected running_mean to have type",  # Error not seen on HPUs and hence it can be skipped
+                "Expected running_mean to have type",
             ):
-                # Errors in batch norm 2D backward
                 inner(model, torch.randn((3, 1, 9, 9)))
+        else:
+            inner(model, torch.randn((3, 1, 9, 9)))
 
         # Batch norm 2D: cast buffers down to lower precision
         model = nn.Sequential(nn.Conv2d(1, 5, 3), nn.BatchNorm2d(5), nn.Conv2d(5, 4, 3))

--- a/test/distributed/_composable/fsdp/test_fully_shard_overlap.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_overlap.py
@@ -31,7 +31,6 @@ from torch.testing._internal.common_utils import (
     IS_LINUX,
     MI200_ARCH,
     run_tests,
-    TEST_HPU,
 )
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     ModelArgs,
@@ -76,7 +75,10 @@ class TestFullyShardOverlap(FSDPTest):
 
     @skip_if_rocm_arch_multiprocess(MI200_ARCH)
     @skip_if_lt_x_gpu(2)
-    @unittest.skipIf(TEST_HPU, "Sleep is not supported on HPU")
+    @unittest.skipIf(
+        not hasattr(torch.get_device_module(device_type), "_sleep"),
+        "Sleep is not supported on this device",
+    )
     def test_fully_shard_training_overlap(self):
         torch.manual_seed(42)
 
@@ -320,7 +322,10 @@ class TestFullyShardOverlap(FSDPTest):
 
     @unittest.skipIf(IS_LINUX, "https://github.com/pytorch/pytorch/issues/131081")
     @skip_if_lt_x_gpu(2)
-    @unittest.skipIf(TEST_HPU, "Sleep is not supported on HPU")
+    @unittest.skipIf(
+        not hasattr(torch.get_device_module(device_type), "_sleep"),
+        "Sleep is not supported on this device",
+    )
     def test_fully_shard_post_optim_event_overlap(self):
         torch.manual_seed(42)
 
@@ -482,13 +487,19 @@ class TestFullyShardPerParamMeshOverlap(FSDPTest):
 
     @skip_if_rocm_arch_multiprocess(MI200_ARCH)
     @skip_if_lt_x_gpu(4)
-    @unittest.skipIf(TEST_HPU, "Sleep is not supported on HPU")
+    @unittest.skipIf(
+        not hasattr(torch.get_device_module(device_type), "_sleep"),
+        "Sleep is not supported on this device",
+    )
     def test_fully_shard_per_param_mesh_training_overlap(self):
         self._test_per_param_mesh_overlap(simulate_no_grad_input=False)
 
     @skip_if_rocm_arch_multiprocess(MI200_ARCH)
     @skip_if_lt_x_gpu(4)
-    @unittest.skipIf(TEST_HPU, "Sleep is not supported on HPU")
+    @unittest.skipIf(
+        not hasattr(torch.get_device_module(device_type), "_sleep"),
+        "Sleep is not supported on this device",
+    )
     def test_fully_shard_per_param_mesh_no_grad_input_overlap(self):
         self._test_per_param_mesh_overlap(simulate_no_grad_input=True)
 

--- a/test/distributed/_composable/fsdp/test_fully_shard_state_dict.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_state_dict.py
@@ -141,14 +141,14 @@ class TestFullyShardStateDictMultiProcess(FSDPTest):
             )
         else:
             model = model.cpu()
-            model = model.cuda()
+            model = model.to(device_type)
             self.assertTrue(
                 sd["weight"]._local_tensor.untyped_storage().data_ptr()
                 != model.weight._local_tensor.untyped_storage().data_ptr()
             )
 
         torch.manual_seed(42 + self.rank)
-        inp = torch.rand(mlp_dim, mlp_dim, device="cuda")
+        inp = torch.rand(mlp_dim, mlp_dim, device=device_type.type)
         for _ in range(5):
             optim.zero_grad()
             loss = model(inp).sum()

--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -63,7 +63,6 @@ from torch.testing._internal.common_utils import (
     skipIfRocm,
     skipIfTorchInductor,
     TEST_CUDA_GRAPH,
-    TEST_HPU,
     TEST_XPU,
     wrapSwapTensorsTest,
     xfailIf,
@@ -410,7 +409,10 @@ class TestFullyShard1DTrainingCore(FSDPTest):
             self.assertEqual(losses[0], losses[1])
 
     @skip_if_lt_x_gpu(2)
-    @unittest.skipIf(TEST_HPU or TEST_XPU, "Sleep kernel not supported for HPU/XPU")
+    @unittest.skipIf(
+        not hasattr(torch.get_device_module(device_type), "_sleep"),
+        "Sleep is not supported on this device",
+    )
     @compiled_fsdp_test(compile_compute_on_module=Transformer)
     def test_train_parity_multi_group(self):
         """
@@ -434,7 +436,10 @@ class TestFullyShard1DTrainingCore(FSDPTest):
 
     @skipIfTorchInductor(msg="https://github.com/pytorch/pytorch/issues/148901")
     @skip_if_lt_x_gpu(2, allow_cpu=True)
-    @unittest.skipIf(TEST_HPU or TEST_XPU, "sleep kernel not supported on HPU/XPU")
+    @unittest.skipIf(
+        not hasattr(torch.get_device_module(device_type), "_sleep"),
+        "Sleep is not supported on this device",
+    )
     def test_train_parity_multi_group_cpu_offload_eager(self):
         """
         Tests train parity against DDP when using multiple parameter groups for
@@ -458,7 +463,10 @@ class TestFullyShard1DTrainingCore(FSDPTest):
         )
 
     @skip_if_lt_x_gpu(2, allow_cpu=True)
-    @unittest.skipIf(TEST_HPU or TEST_XPU, "sleep kernel not supported on HPU/XPU")
+    @unittest.skipIf(
+        not hasattr(torch.get_device_module(device_type), "_sleep"),
+        "Sleep is not supported on this device",
+    )
     @compiled_fsdp_test(compile_compute_on_module=Transformer)
     def test_train_parity_multi_group_unshard_async_op(self):
         """
@@ -592,7 +600,10 @@ class TestFullyShard1DTrainingCore(FSDPTest):
                 self.assertEqual(losses[0], losses[1])
 
     @skip_if_lt_x_gpu(2, allow_cpu=True)
-    @unittest.skipIf(TEST_XPU, "Sleep is not supported on XPU")
+    @unittest.skipIf(
+        not hasattr(torch.get_device_module(device_type), "_sleep"),
+        "Sleep is not supported on this device",
+    )
     def test_non_root_forward_backward(self):
         """
         Tests running forward/backward through the root and then through a
@@ -723,7 +734,10 @@ class TestFullyShard1DTrainingCore(FSDPTest):
             self.assertEqual(losses[0], losses[1])
 
     @skip_if_lt_x_gpu(2)
-    @unittest.skipIf(TEST_HPU or TEST_XPU, "Sleep is not supported on HPU/XPU")
+    @unittest.skipIf(
+        not hasattr(torch.get_device_module(device_type), "_sleep"),
+        "Sleep is not supported on this device",
+    )
     def test_post_optim_event(self):
         torch.manual_seed(42)
         model_args = ModelArgs(dropout_p=0.0)


### PR DESCRIPTION
## Summary
This PR refactors FSDP distributed tests under `test/distributed/_composable/fsdp/`. Where possible, hard-coded CUDA/HPU/XPU assumptions are generalized via `torch.accelerator` and `torch.get_device_module` APIs. For logic that is genuinely CUDA/NCCL-specific and cannot be safely generalized, the original blacklist-style guards (`skipIf(TEST_HPU)`, `skipIf(TEST_XPU)`, etc.) are replaced with whitelist-style checks (`skipIf(not TEST_CUDA)`, `skipIf(DISTRIBUTED_BACKEND != "nccl")`, or capability-based introspection). This ensures new `PrivateUse1`-based out-of-tree backends either run the test correctly or skip it safely, instead of failing or being routed down the wrong code path.

## Changes

### 1. Generalize hard-coded device logic
Replaced device-specific queries with `torch.accelerator` / `torch.get_device_module` based APIs:
- `test_fully_shard_dtensor.py`: `world_size` now uses `torch.accelerator.device_count()` instead of `torch.cuda.device_count()`.
- `test_fully_shard_state_dict.py`: `model.cuda()` and `device="cuda"` replaced with `.to(device_type)` / `device=device_type.type`.

### 2. Convert blacklist-style guards to whitelist-style
Replaced guards like `skipIf(TEST_HPU)` / `skipIf(TEST_HPU or TEST_XPU)` with positive checks for the device the test actually requires:
- `test_fully_shard_comm.py`: NCCL debug-log tests now use `skipIf(not TEST_CUDA, ...)` because they are CUDA-specific.
- `test_fully_shard_memory.py`: HSDP sync correctness test now uses `skipIf(not TEST_CUDA, ...)` because it relies on `torch.cuda._sleep`.
- clarified BatchNorm 2D behavior: the dtype-mismatch error path is now explicitly gated for CUDA/XPU, while other devices take the no-error path.

### 3. Replace device-name lists with capability checks
For cases where the skip reason is a concrete capability rather than a device brand, use hardware-agnostic introspection:
- `test_fully_shard_overlap.py`: `skipIf(TEST_HPU, "Sleep is not supported on HPU")` changed to `skipIf(not hasattr(torch.get_device_module(device_type), "_sleep"), ...)`.
- `test_fully_shard_training.py`: same `_sleep` capability check applied to multi-group training, CPU offload, unshard async op, non-root forward/backward, and post-optim event tests.

### 4. Strengthen incomplete guards
Added backend checks before NCCL-version requirements so tests do not run on non-NCCL backends:
- `test_fully_shard_mixed_precision.py`: added `skipIf(DISTRIBUTED_BACKEND != "nccl", ...)` before 
- `@requires_nccl_version((2, 10), ...)` for `test_compute_dtype`, `test_reduce_dtype`, and `test_norm_modules_bf16`.


## Motivation
Hard-coding device names like `TEST_CUDA`, `TEST_HPU`, and `TEST_XPU` in distributed tests causes two problems:
1. New accelerator types are silently routed down the wrong code path or skipped entirely.
2. Blacklist-style skips (`skipIf(TEST_HPU)`) implicitly assume everything else behaves like CUDA, which breaks when new hardware is introduced.

By using `torch.accelerator`, capability checks, and whitelist-style guards, the tests become robust to future accelerator types without requiring per-device patches.

## Test Plan
Verified the following files under `test/distributed/_composable/fsdp/`:
- `python test/distributed/_composable/fsdp/test_fully_shard_comm.py`
- `python test/distributed/_composable/fsdp/test_fully_shard_dtensor.py`
- `python test/distributed/_composable/fsdp/test_fully_shard_memory.py`
- `python test/distributed/_composable/fsdp/test_fully_shard_mixed_precision.py`
- `python test/distributed/_composable/fsdp/test_fully_shard_overlap.py`
- `python test/distributed/_composable/fsdp/test_fully_shard_state_dict.py`
- `python test/distributed/_composable/fsdp/test_fully_shard_training.py`