### PR TITLE
[inductor][retry] fix torch.randperm for slice_shape node in fx_passes

### DIFF
--- a/test/inductor/pallas_expected_failures/CpuTests.test_randperm_index_slice_range_cpu
+++ b/test/inductor/pallas_expected_failures/CpuTests.test_randperm_index_slice_range_cpu
@@ -1,0 +1,3 @@
+ERROR
+TypeError: add got incompatible shapes for broadcasting
+cannot reshape array of shape (4, 64) (size 256) into shape (8, 1, 64) (size 512)

--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -776,6 +776,67 @@ class TestPatternMatcher(TestCase):
     # called in test_gpu_cpp_wrapper
     test_cat_slice_cat_xpu = test_cat_slice_cat_cuda
 
+    @parametrize("n", (8, 64))
+    def test_randperm_index(self, n):
+        def fn(x):
+            idx = torch.randperm(x.shape[0], device=x.device)
+            return x[idx]
+
+        x = torch.randn(n, 64, device=GPU_TYPE)
+        rand_opt = torch.compile(fn, backend="inductor")
+
+        torch.manual_seed(42)
+        expect = fn(x)
+
+        torch._dynamo.reset()
+        counters.clear()
+        torch.manual_seed(42)
+        actual = rand_opt(x)
+
+        self.assertEqual(expect, actual)
+        self.assertGreaterEqual(counters["inductor"]["pattern_matcher_count"], 1)
+
+    @parametrize("case", ((8, 42), (64, 42), (64, 8), (128, 64)))
+    def test_randperm_index_with_slice(self, case):
+        def fn(x, slice_shape):
+            idx = torch.randperm(x.shape[0], device=x.device)[:slice_shape]
+            return x[idx]
+
+        n, s = case
+        x = torch.randn(n, 64, device=GPU_TYPE)
+        rand_opt = torch.compile(fn, backend="inductor")
+
+        torch.manual_seed(42)
+        expect = fn(x, s)
+
+        torch._dynamo.reset()
+        counters.clear()
+        torch.manual_seed(42)
+        actual = rand_opt(x, s)
+
+        self.assertEqual(expect, actual)
+        self.assertGreaterEqual(counters["inductor"]["pattern_matcher_count"], 1)
+
+    @parametrize("n", (8, 64))
+    def test_randperm_index_2d(self, n):
+        def fn(x):
+            idx = torch.randperm(x.shape[0], device=x.device)
+            return x[idx, :]
+
+        x = torch.randn(n, 64, device=GPU_TYPE)
+        rand_opt = torch.compile(fn, backend="inductor")
+
+        torch.manual_seed(42)
+        expect = fn(x)
+
+        torch._dynamo.reset()
+        counters.clear()
+        torch.manual_seed(42)
+        actual = rand_opt(x)
+
+        self.assertEqual(expect, actual)
+        self.assertGreaterEqual(counters["inductor"]["pattern_matcher_count"], 1)
+
     def test_pointless_view_pair(self):
         def f(x):
             x = aten.view.default(x, [3, 5, 7])

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -2203,6 +2203,14 @@ class CommonTemplate:
         actual = _run_and_assert_no_indirect_indexing(self, flip_opt, x)
         self.assertEqual(expect, actual)
 
+    def test_randperm_index_slice_range(self):
+        def fn(x):
+            idx = torch.randperm(x.shape[0], device=x.device)
+            return x[idx[2:6]]
+
+        for n in (8, 64):
+            self.common(fn, (torch.randn(n, 64, device=self.device),))
+
     def test__unsafe_masked_index(self):
         def fn(a, mask, idx):
             return aten._unsafe_masked_index(a, mask, idx, 1)

--- a/torch/_inductor/fx_passes/misc_patterns.py
+++ b/torch/_inductor/fx_passes/misc_patterns.py
@@ -94,13 +94,37 @@ def _misc_patterns_init(input_device: torch.device | None = None):
         randperm_index_pattern,
         # pyrefly: ignore [bad-argument-type]
         randperm_index_replacement,
-        [torch.empty(4, 8, device=device)],
+        # x.shape[0] must exceed scalar_workaround['slice_shape'] (42)
+        # so applySlice's length<=stop fast path doesn't elide
+        # the slice during pattern tracing
+        [torch.empty(64, 8, device=device)],
         # pyrefly: ignore [bad-argument-type]
         fwd_only,
         # pyrefly: ignore [bad-argument-type]
         [post_grad_patterns, joint_graph_patterns],
         # Keep this smaller than the example input dim so tracing preserves the slice.
         scalar_workaround={"slice_shape": 2},
+        skip_duplicates=True,
+    )
+
+    def randperm_index_only_pattern(x):
+        index = torch.randperm(x.shape[0], device=x.device)
+        return torch.ops.aten.index(x, (index,))
+
+    def randperm_index_only_replacement(x):
+        index = torch.randperm(x.shape[0], device=x.device)
+        return torch.ops.aten._unsafe_index(x, (index,))
+
+    register_replacement(
+        # pyrefly: ignore [bad-argument-type]
+        randperm_index_only_pattern,
+        # pyrefly: ignore [bad-argument-type]
+        randperm_index_only_replacement,
+        [torch.empty(4, 8, device=device)],
+        # pyrefly: ignore [bad-argument-type]
+        fwd_only,
+        # pyrefly: ignore [bad-argument-type]
+        [post_grad_patterns, joint_graph_patterns],
         skip_duplicates=True,
     )
 


### PR DESCRIPTION
Fixes: #183988

```python
In [1]: import torch
   ...: 
   ...: def fn(x):
   ...:     idx = torch.randperm(x.shape[0], device=x.device)
   ...:     return x[idx]
   ...: 
   ...: x = torch.randn(8, 64, device="cuda")
   ...: 
   ...: # Eager: OK
   ...: print(fn(x).shape)
   ...: 
   ...: # aot_eager: OK
   ...: torch._dynamo.reset()
   ...: print(torch.compile(fn, backend="aot_eager")(x).shape)  # torch.Size([8, 64])
   ...: 
   ...: # Inductor: WORKS FINE
   ...: torch._dynamo.reset()
   ...: print(torch.compile(fn, backend="inductor")(x).shape)
torch.Size([8, 64])
torch.Size([8, 64])
torch.Size([8, 64])

In [2]: 
```

I checked Inductor traces to verify whether the optimized kernel is being generated. Check #184276 on description.

This PR contains the same changes as my previous PR #184276.

Sorry for the duplicate PR.

That PR was approved and was attempted to be merged multiple times (thanks, @jansel). However, merge attempts failed due to unrelated issues, including:
```
Reason: [Errno 7] Argument list too long: 'git'
```

I'm not sure what caused the issue. It may have been related to the branch history or it may have been unrelated merge infrastructure. Since the previous PR could not be merged successfully, I'm opening a fresh PR with the same changes.

Thank you @jansel, @aorenste, and @eellison for reviewing the previous PR!

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo