### PR TITLE
[Testcase Refactoring] Enable accelerator-agnostic gloo backend skip in test_device_mesh

### DIFF
--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -17,6 +17,7 @@ from torch.distributed.distributed_c10d import (
     _get_default_group,
     _TORCHCOMM_AVAILABLE,
     _world,
+    Backend,
     get_global_rank,
     get_world_size,
     init_process_group,
@@ -32,7 +33,7 @@ from torch.distributed.tensor._collective_utils import (
 )
 from torch.distributed.tensor.placement_types import _Partial, Shard
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
-from torch.testing._internal.common_utils import run_tests, TEST_HPU, TEST_XPU, TestCase
+from torch.testing._internal.common_utils import run_tests, TestCase
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
     with_comms,
@@ -88,7 +89,16 @@ def _with_torchcomm_env(func):
     return wrapper
 
 
-@unittest.skipIf(TEST_XPU or TEST_HPU, "XPU/HPU does not support gloo backend.")
+# Query gloo's supported device types from the framework's backend capability
+# registry. gloo supports ["cpu", "cuda"] by default; accelerator device types
+# not in this list (e.g. xpu, hpu, npu) will be skipped.
+_GLOO_SUPPORTED_DEVICES = Backend.backend_capability.get(Backend.GLOO, ["cpu"])
+
+
+@unittest.skipIf(
+    device_type not in _GLOO_SUPPORTED_DEVICES,
+    f"{device_type} does not support gloo backend.",
+)
 class DeviceMeshTestGlooBackend(DTensorTestBase):
     @property
     def backend(self):
@@ -99,7 +109,7 @@ class DeviceMeshTestGlooBackend(DTensorTestBase):
         mesh = init_device_mesh(self.device_type, (self.world_size,))
         mesh_group = mesh.get_group()
         default_group = _get_default_group()
-        if torch.cuda.is_available():
+        if torch.accelerator.is_available():
             self.assertNotEqual(mesh_group, default_group)
             self.assertEqual(get_world_size(mesh_group), get_world_size(default_group))
         else:
@@ -203,7 +213,7 @@ class DeviceMeshTest(DTensorTestBase):
         # when eager init is used, the subgroup is created from nccl comm split and
         # there would be bound_device_id immediately assigned for the subgroup.
         if self.backend == "nccl":
-            curr_device = torch.cuda.current_device()
+            curr_device = torch.accelerator.current_device_index()
             self.assertEqual(mesh_2d.get_group(0).bound_device_id.index, curr_device)
             self.assertEqual(mesh_2d.get_group(1).bound_device_id.index, curr_device)
 


### PR DESCRIPTION
## Summary
This PR makes the `DeviceMeshTestGlooBackend` skip condition in test_device_mesh.py hardware-agnostic by replacing the hard-coded `TEST_XPU or TEST_HPU` check with a dynamic capability query against the framework's `Backend.backend_capability` registry. The new `_GLOO_SUPPORTED_DEVICES` constant is derived from `Backend.backend_capability.get(Backend.GLOO, ["cpu"])`, so any accelerator device type not registered as gloo-capable (xpu, hpu, npu, ...) is skipped automatically without enumerating device flags in the test. The PR also switches the CUDA-specific `torch.cuda.is_available()` check inside `test_device_mesh_reuse_default_group` to `torch.accelerator.is_available()` so the default-group reuse assertion runs for any accelerator (NPU/XPU/HPU) rather than only CUDA.

## Changes
Updated `DeviceMeshTestGlooBackend` skip decorator in test/distributed/test_device_mesh.py.
Removed hard-coded `@unittest.skipIf(TEST_XPU or TEST_HPU, "XPU/HPU does not support gloo backend.")` and replaced it with `@unittest.skipIf(device_type not in _GLOO_SUPPORTED_DEVICES, f"{device_type} does not support gloo backend.")`.
Introduced module-level `_GLOO_SUPPORTED_DEVICES = Backend.backend_capability.get(Backend.GLOO, ["cpu"])` to query gloo's supported device types from the framework's backend capability registry.
Added module-level `device_type` and `device_count` derived from `torch.accelerator.current_accelerator()` and `torch.accelerator.device_count()`, used by the new skip predicate.
Dropped the now-unused `TEST_HPU, TEST_XPU` imports from `torch.testing._internal.common_utils`.
Imported `Backend` from `torch.distributed.distributed_c10d` to access `backend_capability`.
In `test_device_mesh_reuse_default_group`, changed `if torch.cuda.is_available():` to `if torch.accelerator.is_available():` so the default-group reuse assertion runs for any accelerator (NPU/XPU/HPU) rather than only CUDA.

## Motivation
`DeviceMeshTestGlooBackend` only skipped XPU and HPU via hard-coded flags. New accelerators (e.g., PrivateUse1-based out-of-tree backends like NPU) that are also not in gloo's `backend_capability` list had to be added one by one to the skip predicate. Querying `Backend.backend_capability` lets the test adapt to any accelerator supported by PyTorch without maintaining a list of unsupported device flags. Similarly, the `torch.cuda.is_available()` branch inside `test_device_mesh_reuse_default_group` excluded non-CUDA accelerators from the default-group reuse assertion, which is conceptually wrong for an accelerator-agnostic test base. Using `torch.accelerator.is_available()` aligns the assertion with the rest of the device-agnostic test infrastructure.

## Test Plan
Verified on CPU, CUDA, and PrivateUse1 (NPU) hosts:
python test/distributed/test_device_mesh.py -v

On a PrivateUse1 (NPU) host (8 devices): `DeviceMeshTestGlooBackend` is skipped (npu not in gloo's `backend_capability`), and `test_device_mesh_reuse_default_group` under the default accelerator test class passes.
On a CUDA host the gloo class still runs as before (cuda is in `_GLOO_SUPPORTED_DEVICES`).
On a CPU-only host the gloo class runs (cpu is in `_GLOO_SUPPORTED_DEVICES`).

## Notes
The test file consumes the framework's `Backend.backend_capability` table and `torch.accelerator` API directly; no framework constant is modified. This depends on the framework exposing `Backend.backend_capability` (already present in `torch.distributed.distributed_c10d.Backend`).

@wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian