### PR TITLE
docs: clarify torch.distributed collectives are not autograd-aware

### DIFF
--- a/docs/source/distributed.md
+++ b/docs/source/distributed.md
@@ -610,6 +610,32 @@ if rank == 0:
     print(output)
 ```
 
+## Autograd and gradients
+
+:::{warning}
+Collective communication APIs under {mod}`torch.distributed` (for example
+{func}`torch.distributed.all_reduce`) are **not** autograd-aware. They update
+tensors in place and are **not** recorded in the autograd graph, so gradients
+do **not** flow through them. Using these APIs inside a model forward pass
+without an autograd-aware alternative can silently produce incorrect gradients.
+:::
+
+If you need collectives that participate in autograd:
+
+- Prefer {mod}`torch.distributed.tensor` (DTensor), which transparently inserts
+  the appropriate collectives while preserving single-device semantics for
+  backward.
+- Or use the functional collectives in
+  {mod}`torch.distributed._functional_collectives`, which have autograd support
+  for common ops (for example ``all_reduce`` with ``sum``).
+
+:::{note}
+{mod}`torch.distributed.nn` historically provided autograd wrappers around some
+collectives (for example ``torch.distributed.nn.functional.all_reduce``).
+Those APIs are deprecated in favor of functional collectives / DTensor and
+should not be used in new code.
+:::
+
 ## Collective functions
 
 ```{eval-rst}

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -3576,6 +3576,14 @@ def all_reduce(tensor, op=ReduceOp.SUM, group=None, async_op: bool = False):
 
     Complex tensors are supported.
 
+    .. warning::
+        This collective is **not** autograd-aware. It operates in-place and does
+        not participate in the autograd graph, so gradients do not flow through it.
+        For autograd-aware collectives, prefer
+        :mod:`torch.distributed.tensor` (DTensor) or
+        :mod:`torch.distributed._functional_collectives`.
+        The older :mod:`torch.distributed.nn` wrappers are deprecated.
+
     Args:
         tensor (Tensor): Input and output of the collective. The function
             operates in-place.

--- a/torch/distributed/nn/functional.py
+++ b/torch/distributed/nn/functional.py
@@ -271,6 +271,11 @@ def all_reduce(tensor, op=ReduceOp.SUM, group=group.WORLD):
     After the call the returned tensor is going to be bitwise
     identical in all processes.
 
+    Unlike :func:`torch.distributed.all_reduce`, this wrapper is an autograd
+    ``Function`` so gradients can flow through the collective. This API is
+    deprecated; prefer :mod:`torch.distributed._functional_collectives` or
+    :mod:`torch.distributed.tensor` (DTensor) in new code.
+
     Arguments:
         tensor (Tensor): Input of the collective.
         op (optional): One of the values from


### PR DESCRIPTION
Fixes #121587