### PR TITLE
Increase tolerance for `test_vmap_autograd_grad_nn_functional_conv2d_cpu_float32`

### DIFF
--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -2366,7 +2366,6 @@ class TestOperators(TestCase):
             tol1(
                 "nn.functional.conv2d",
                 {torch.float32: tol(atol=5e-05, rtol=5e-05)},
-                device_type="cuda",
             ),
             tol1("svd_lowrank", {torch.float32: tol(atol=5e-05, rtol=5e-05)}),
             tol1("pca_lowrank", {torch.float32: tol(atol=5e-05, rtol=5e-05)}),


### PR DESCRIPTION
`PYTORCH_OPINFO_SAMPLE_INPUT_INDEX=16 python functorch/test_ops.py TestOperatorsCPU.test_vmap_autograd_grad_nn_functional_conv2d_cpu_float32` fails with
> Greatest absolute difference: 1.1444091796875e-05 at index (0, 4, 0, 0, 2) (up to 1e-05 allowed)
> Greatest relative difference: 2.064850013994146e-05 at index (0, 4, 0, 0, 2) (up to 1.3e-06 allowed)

So use the same tolerance used for CUDA unconditionally.

Fixes #151113