### PR TITLE
[Testcase Refactoring] Enable PrivateUse1 tests in test_dtensor_pp_integration

### DIFF
--- a/test/distributed/pipelining/test_dtensor_pp_integration.py
+++ b/test/distributed/pipelining/test_dtensor_pp_integration.py
@@ -137,10 +137,10 @@ def _loss_fn(output: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
     return (output - target).pow(2).mean()
 
 
-def _requires_multi_gpu(func):
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+def _requires_multi_accelerator(func):
+    @requires_accelerator_dist_backend(["nccl", "xccl", "privateuse1"])
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 4+ GPUs"
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 4+ accelerators"
     )
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
@@ -165,8 +165,8 @@ class DTensorPPIntegrationBase(MultiProcContinuousTest):
         return torch.device(device_type, self.rank)
 
     def init_pg(self) -> None:
-        if device_type == "cuda":
-            torch.cuda.set_device(self.device)
+        if torch.accelerator.is_available():
+            torch.accelerator.set_device_index(self.device)
 
     def _make_mesh(self) -> DeviceMesh:
         return init_device_mesh(device_type, (2, 2), mesh_dim_names=("pp", "tp"))
@@ -666,7 +666,7 @@ class DTensorPPIntegrationBase(MultiProcContinuousTest):
 
 
 class TestDTensorPPModes(DTensorPPIntegrationBase):
-    @_requires_multi_gpu
+    @_requires_multi_accelerator
     def test_static_mode_replicate(self):
         self._run_training_correctness(
             Schedule1F1B,
@@ -674,7 +674,7 @@ class TestDTensorPPModes(DTensorPPIntegrationBase):
             [Replicate()],
         )
 
-    @_requires_multi_gpu
+    @_requires_multi_accelerator
     def test_static_mode_none_grad_slots_replicate(self):
         self._run_training_correctness(
             Schedule1F1B,
@@ -683,7 +683,7 @@ class TestDTensorPPModes(DTensorPPIntegrationBase):
             null_boundary_grads=True,
         )
 
-    @_requires_multi_gpu
+    @_requires_multi_accelerator
     def test_static_mode_none_grad_slots_shard(self):
         self._run_training_correctness(
             Schedule1F1B,
@@ -692,7 +692,7 @@ class TestDTensorPPModes(DTensorPPIntegrationBase):
             null_boundary_grads=True,
         )
 
-    @_requires_multi_gpu
+    @_requires_multi_accelerator
     def test_static_mode_shard(self):
         self._run_training_correctness(
             Schedule1F1B,
@@ -700,14 +700,14 @@ class TestDTensorPPModes(DTensorPPIntegrationBase):
             [Shard(1)],
         )
 
-    @_requires_multi_gpu
+    @_requires_multi_accelerator
     def test_dynamic_mode_inference_only_replicate(self):
         self._run_inference_only_equivalence(
             apply_tp_replicate,
             [Replicate()],
         )
 
-    @_requires_multi_gpu
+    @_requires_multi_accelerator
     def test_static_mode_inference_only_replicate(self):
         self._run_inference_only_equivalence(
             apply_tp_replicate,
@@ -715,14 +715,14 @@ class TestDTensorPPModes(DTensorPPIntegrationBase):
             use_static_metadata=True,
         )
 
-    @_requires_multi_gpu
+    @_requires_multi_accelerator
     def test_dynamic_mode_inference_only_shard(self):
         self._run_inference_only_equivalence(
             apply_tp_shard,
             [Shard(1)],
         )
 
-    @_requires_multi_gpu
+    @_requires_multi_accelerator
     def test_static_mode_inference_only_shard(self):
         self._run_inference_only_equivalence(
             apply_tp_shard,
@@ -730,7 +730,7 @@ class TestDTensorPPModes(DTensorPPIntegrationBase):
             use_static_metadata=True,
         )
 
-    @_requires_multi_gpu
+    @_requires_multi_accelerator
     def test_dynamic_mode_replicate(self):
         self._run_training_correctness(
             Schedule1F1B,
@@ -739,7 +739,7 @@ class TestDTensorPPModes(DTensorPPIntegrationBase):
             use_static_metadata=False,
         )
 
-    @_requires_multi_gpu
+    @_requires_multi_accelerator
     def test_dynamic_mode_shard(self):
         self._run_training_correctness(
             Schedule1F1B,
@@ -748,7 +748,7 @@ class TestDTensorPPModes(DTensorPPIntegrationBase):
             use_static_metadata=False,
         )
 
-    @_requires_multi_gpu
+    @_requires_multi_accelerator
     def test_static_mode_interleaved1f1b_replicate(self):
         self._run_training_correctness(
             ScheduleInterleaved1F1B,
@@ -756,7 +756,7 @@ class TestDTensorPPModes(DTensorPPIntegrationBase):
             [Replicate()],
         )
 
-    @_requires_multi_gpu
+    @_requires_multi_accelerator
     def test_static_mode_zbv_zero_bubble_replicate(self):
         self._run_training_correctness(
             ScheduleZBVZeroBubble,
@@ -764,7 +764,7 @@ class TestDTensorPPModes(DTensorPPIntegrationBase):
             [Replicate()],
         )
 
-    @_requires_multi_gpu
+    @_requires_multi_accelerator
     def test_static_mode_dualpipev_replicate(self):
         self._run_training_correctness(
             ScheduleDualPipeV,
@@ -772,7 +772,7 @@ class TestDTensorPPModes(DTensorPPIntegrationBase):
             [Replicate()],
         )
 
-    @_requires_multi_gpu
+    @_requires_multi_accelerator
     def test_dynamic_mode_interleaved1f1b_shard(self):
         self._run_training_correctness(
             ScheduleInterleaved1F1B,
@@ -781,7 +781,7 @@ class TestDTensorPPModes(DTensorPPIntegrationBase):
             use_static_metadata=False,
         )
 
-    @_requires_multi_gpu
+    @_requires_multi_accelerator
     def test_dynamic_mode_zbv_zero_bubble_shard(self):
         self._run_training_correctness(
             ScheduleZBVZeroBubble,
@@ -790,7 +790,7 @@ class TestDTensorPPModes(DTensorPPIntegrationBase):
             use_static_metadata=False,
         )
 
-    @_requires_multi_gpu
+    @_requires_multi_accelerator
     def test_dynamic_mode_dualpipev_shard(self):
         self._run_training_correctness(
             ScheduleDualPipeV,

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -50,6 +50,8 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_ROCM,
     TEST_WITH_TSAN,
     TEST_XPU,
+    TEST_PRIVATEUSE1,
+    TEST_PRIVATEUSE1_DEVICE_TYPE,
     TestCase,
 )
 from torch.testing._internal.distributed.multi_threaded_pg import (
@@ -549,22 +551,28 @@ def requires_accelerator_dist_backend(backends=None):
     Decorator to skip tests if no accelerator communication backend (NCCL, XCCL, HCCL) is available.
 
     Args:
-        backends (Optional[List[str]]): Specific accelerator backends to check (e.g., ["nccl", "xccl", "hccl"]).
+        backends (Optional[List[str]]): Specific accelerator backends to check (e.g., ["nccl", "xccl", "hccl", "privateuse1"]).
                                        If None, checks all supported accelerator backends (NCCL, XCCL, HCCL).
 
     Returns:
         callable: A decorator that skips the test if no specified accelerator backend is available.
+
+    Note:
+        "privateuse1" is a placeholder resolved to the actual backend name for PrivateUse1 at call time via ``Backend.default_device_backend_map``.
     """
     if backends is None:
         backends = ACCELERATOR_DIST_BACKENDS
+    
+    _resolve = lambda backend: (
+        c10d.Backend.default_device_backend_map.get(TEST_PRIVATEUSE1_DEVICE_TYPE)
+        if backend == "privateuse1" and TEST_PRIVATEUSE1
+        else (None if backend == "privateuse1" else backend)
+    )
 
     backend_available = any(
-        {
-            "nccl": c10d.is_nccl_available,
-            "xccl": c10d.is_xccl_available,
-            "hccl": lambda: TEST_HPU,
-        }.get(backend, lambda: False)()
-        for backend in backends
+        c10d.is_backend_available(backend)
+        for backend in (_resolve(b) for b in backends)
+        if backend is not None
     )
 
     return skip_but_pass_in_sandcastle_if(


### PR DESCRIPTION
## Summary
Enable the multi-process DTensor pipeline-integration tests to run on
out-of-tree PrivateUse1 accelerators. The `_requires_multi_accelerator`
helper was gated to a hardcoded vendor backend and used CUDA-specific
device setup, so the tests were skipped on PrivateUse1 hosts.

## Changes
Two commits:

1. Framework (cherry-picked from #190153): update
   `requires_accelerator_dist_backend` in `common_distributed.py` to
   resolve the PrivateUse1 entry in the backends list to the host's actual
   communication backend for the PrivateUse1 device type at call time via
   `Backend.default_device_backend_map`, then check availability with
   `c10d.is_backend_available`.

2. Test file (`test_dtensor_pp_integration.py`):
   - In the `_requires_multi_accelerator` helper, change the
     `@requires_accelerator_dist_backend` backend list to
     `["nccl", "xccl", "privateuse1"]`.
   - `init_pg`: `if device_type == "cuda": torch.cuda.set_device(...)`
     -> `if torch.accelerator.is_available(): torch.accelerator.set_device_index(...)`.
   - Rename `_requires_multi_gpu` -> `_requires_multi_accelerator` and the
     skip message `"4+ GPUs"` -> `"4+ accelerators"`.

## Motivation
Part of decoupling pipelining tests from hard-coded CUDA/NCCL dependencies
so they can execute on any PrivateUse1 accelerator with an out-of-tree
communication backend.

## Notes
- Depends on #190153 for the framework change; this PR cherry-picks that
  commit. Once #190153 merges, the cherry-pick can be dropped and only
  the test-file diff is rebased on top.
- This is part of the test case refactoring initiative tracked in #185590.

## Test Plan
```
python test/distributed/pipelining/test_dtensor_pp_integration.py -v
```
On a CPU-only host all tests are skipped.
