### PR TITLE
Add shared compute_range_size helper and route CPU/CUDA/MPS through it

### DIFF
--- a/aten/src/ATen/native/RangeFactories.cpp
+++ b/aten/src/ATen/native/RangeFactories.cpp
@@ -154,12 +154,9 @@ Tensor& range_out(const Scalar& start, const Scalar& end, const Scalar& step, Te
   AT_DISPATCH_ALL_TYPES_AND2(kBFloat16, kHalf, result.scalar_type(), "range_cpu", [&]() {
     using accscalar_t = at::acc_type<scalar_t, false>;
     auto xstart = start.to<accscalar_t>();
-    auto xend = end.to<accscalar_t>();
     auto xstep = step.to<accscalar_t>();
 
-    arange_check_bounds(start, end, step);
-
-    int64_t size = static_cast<int64_t>(((xend - xstart) / xstep) + 1);
+    int64_t size = compute_range_size<scalar_t>(start, end, step);
     if (result.numel() != size) {
       result.resize_({size});
     }

--- a/aten/src/ATen/native/RangeUtils.h
+++ b/aten/src/ATen/native/RangeUtils.h
@@ -63,4 +63,33 @@ int64_t compute_arange_size(const Scalar& start, const Scalar& end, const Scalar
   return static_cast<int64_t>(size_d);
 }
 
+template <typename scalar_t>
+int64_t compute_range_size(const Scalar& start, const Scalar& end, const Scalar& step) {
+  arange_check_bounds(start, end, step);
+
+  // range is the closed-interval sibling of arange: size = (end - start) / step + 1.
+  // Same precision rationale as compute_arange_size: use double for cross-device
+  // consistency, with an int64_t accumulator fallback for integer args of int64
+  // dtype where double's 53-bit mantissa is insufficient.
+  double size_d;
+  if constexpr (std::is_same_v<scalar_t, int64_t>) {
+    if (start.isIntegral(false) && end.isIntegral(false) && step.isIntegral(false)) {
+      using accscalar_t = at::acc_type<scalar_t, false>;
+      auto xstart = start.to<accscalar_t>();
+      auto xend = end.to<accscalar_t>();
+      auto xstep = step.to<accscalar_t>();
+      size_d = static_cast<double>((xend - xstart) / xstep) + 1;
+    } else {
+      size_d = (end.to<double>() - start.to<double>()) / step.to<double>() + 1;
+    }
+  } else {
+    size_d = (end.to<double>() - start.to<double>()) / step.to<double>() + 1;
+  }
+
+  TORCH_CHECK(size_d >= 0 && size_d <= static_cast<double>(std::numeric_limits<int64_t>::max()),
+            "invalid size, possible overflow?");
+
+  return static_cast<int64_t>(size_d);
+}
+
 } // namespace at::native

--- a/aten/src/ATen/native/cuda/RangeFactories.cu
+++ b/aten/src/ATen/native/cuda/RangeFactories.cu
@@ -220,12 +220,9 @@ Tensor& range_cuda_out(const Scalar& start, const Scalar& end, const Scalar& ste
   AT_DISPATCH_ALL_TYPES_AND(at::ScalarType::Half, result.scalar_type(), "range_cuda", [&]() {
     using accscalar_t = at::acc_type<scalar_t, true>;
     auto xstart = start.to<accscalar_t>();
-    auto xend = end.to<accscalar_t>();
     auto xstep = step.to<accscalar_t>();
 
-    arange_check_bounds(start, end, step);
-
-    int64_t size = static_cast<int64_t>(((xend - xstart) / xstep) + 1);
+    int64_t size = compute_range_size<scalar_t>(start, end, step);
 
     if (result.numel() != size) {
       result.resize_({size});

--- a/aten/src/ATen/native/mps/operations/RangeFactories.mm
+++ b/aten/src/ATen/native/mps/operations/RangeFactories.mm
@@ -107,26 +107,7 @@ Tensor& arange_mps_out(const Scalar& start, const Scalar& end, const Scalar& ste
 
 Tensor& range_mps_out(const Scalar& start, const Scalar& end, const Scalar& step, Tensor& result) {
   AT_DISPATCH_MPS_TYPES(result.scalar_type(), "arange_mps", [&]() {
-    using accscalar_t = at::acc_type_device<scalar_t, kMPS>;
-    auto xstart = start.to<accscalar_t>();
-    auto xend = end.to<accscalar_t>();
-    auto xstep = step.to<accscalar_t>();
-
-    // double size_d = ((xend - xstart) / xstep) + 1;
-    double size_d;
-    if constexpr (std::is_same_v<scalar_t, int64_t>) {
-      size_d = static_cast<double>(end.to<accscalar_t>() - start.to<accscalar_t>()) / step.to<accscalar_t>() + 1;
-    } else {
-      size_d = static_cast<double>(end.to<double>() - start.to<double>()) / step.to<double>() + 1;
-    }
-
-    arange_check_bounds(start, end, step);
-
-    TORCH_CHECK(size_d >= 0 && size_d <= static_cast<double>(std::numeric_limits<int64_t>::max()),
-                "invalid size, possible overflow?");
-
-    int64_t size = static_cast<int64_t>(size_d);
-
+    int64_t size = compute_range_size<scalar_t>(start, end, step);
     int64_t numel = result.numel();
 
     if (numel != size) {


### PR DESCRIPTION
Add shared compute_range_size helper and route CPU/CUDA/MPS through it

Follow-up to the review on intel/torch-xpu-ops#4331: 
`range_cuda_out` / `range_xpu_out` should share the same helper pattern
that #185812 introduced for arange. `range` and `arange` have different
size formulas (closed vs. half-open interval), so `compute_arange_size`
cannot be reused directly. Instead, add a sibling helper
`compute_range_size<scalar_t>` in aten/src/ATen/native/RangeUtils.h that
encodes range's closed-interval size formula `(end - start) / step + 1`,
mirroring `compute_arange_size`'s precision handling:

- use double as the accumulator by default so CPU, CUDA, and MPS agree
  on output size regardless of the on-device accumulator type (this
  matches the same-PR rationale of #185812 for arange),
- fall back to `at::acc_type<int64_t, false>` (i.e. int64_t) only when
  the output dtype is int64 AND all three Scalar args are integral, so
  that exact int64 ranges above 2^53 keep their precision but fractional
  Scalar args still take the double path instead of being truncated,
- delegate bounds validation to the existing `arange_check_bounds` so
  the error message set is identical across the two entry points.

CPU `range_out`, CUDA `range_cuda_out`, and MPS `range_mps_out` are then
switched to call `compute_range_size`, replacing three separate inlined
size-and-check blocks. The MPS variant had the largest inlined block
(size computation, arange_check_bounds, and the overflow TORCH_CHECK all
separate) and shrinks the most.

An XPU-side follow-up in torch-xpu-ops will call the same helper from
`range_xpu_out` once this lands and the pin is updated.

Test Plan

Verified on d84328bd347 with USE_XPU=1 USE_CUDA=0 build.

```
python -m pytest -sv test/test_tensor_creation_ops.py -k "test_range or test_arange"
# 8 passed, 5 skipped, 667 deselected

python -m pytest -sv test/test_tensor_creation_ops.py::TestTensorCreationCPU::test_range_warning_cpu
# 1 passed
```

Cross-device parity check (14 range cases: float32, float16, int64
integral, int64 fractional dtype-cast, negative step, single-element,
empty step-sign) -- CPU and XPU produce identical shapes and values.
Precision corner cases:

- `torch.range(2**53 + 10, 2**53 + 15, 1, dtype=int64, device='cpu')`
  returns exact int64 values (int64 accumulator path).
- `torch.range(0.5, 5.5, 1.0, dtype=int64)` matches CPU and XPU
  (double path, no int64 truncation of fractional args).



This PR was authored with AI assistance.
