### PR TITLE
[xpu][aoti] Skip test_fallback_kernel_with_symexpr_output for DualWrapper on XPU

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -91,7 +91,9 @@ from torch.testing._internal.common_utils import (
     skipIfXpu,
     TEST_MPS,
     TEST_WITH_ROCM,
+    TEST_XPU,
 )
+from torch.testing._internal.common_xpu import PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU
 from torch.testing._internal.custom_tensor import CustomTensorPlainOut
 from torch.testing._internal.inductor_utils import (
     GPU_TYPE,
@@ -2499,6 +2501,10 @@ class AOTInductorTestsTemplate:
 
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Some archs don't support flash SDPA"
+    )
+    @unittest.skipIf(
+        TEST_XPU and not PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU,
+        "XPU Flash Attention is not supported",
     )
     def test_fallback_kernel_with_symexpr_output(self):
         if self.device != GPU_TYPE:

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -97,7 +97,9 @@ from torch.testing._internal.common_utils import (
     skipIfXpu,
     TEST_MPS,
     TEST_WITH_ROCM,
+    TEST_XPU,
 )
+from torch.testing._internal.common_xpu import PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU
 from torch.testing._internal.custom_tensor import CustomTensorPlainOut
 from torch.testing._internal.inductor_utils import (
     GPU_TYPE,
@@ -2699,6 +2701,10 @@ class AOTInductorTestsTemplate:
 
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Some archs don't support flash SDPA"
+    )
+    @unittest.skipIf(
+        TEST_XPU and not PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU,
+        "XPU Flash Attention is not supported",
     )
     def test_fallback_kernel_with_symexpr_output(self):
         if self.device != GPU_TYPE:


### PR DESCRIPTION
## Background

`test_fallback_kernel_with_symexpr_output` was re-enabled for XPU by PR #189009,
which changed `tensor_shape` from (4,32,4,4) to (4,128,4,4) so that head_dim=64
is supported by XPU flash attention (supported: 64, 96, 128, 192).

After the torch-xpu-ops pin was bumped to 2429ff8b (sycltla v0.9), the test started
failing on PVC LTS2 in CI. sycltla v0.9 switched flash attention from JIT to AOT
compilation (intel/sycl-tla#763), which requires Xe2+ (BMG and later) hardware.
PVC (Xe / Gen1) does not support the AOT-compiled flash attention kernel.

## Fix

Add a hardware-aware skip using `PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU`, which
returns `True` only on Xe2+ (BMG and later) and `False` on PVC. This matches the
pattern used in `test_transformers.py` for XPU flash attention tests.

Both `AOTInductorTestABICompatibleGpu` and `AOTInductorTestDualWrapper` variants
skip on PVC (where flash attn is unsupported) and run on Xe2+ hardware.

Note: `TEST_XPU and` prefix is needed so the decorator has no effect on CUDA-only
machines (where `PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU` would be `False` regardless).

Fixes #190295

## Test plan

```
python test/inductor/test_aot_inductor.py     AOTInductorTestABICompatibleGpu.test_fallback_kernel_with_symexpr_output_xpu     AOTInductorTestDualWrapper.test_fallback_kernel_with_symexpr_output_xpu -v
```

Note: This PR was authored with AI assistance (GitHub Copilot / Claude).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo