### PR TITLE
[dynamo] Support XPU device properties as constants and generalize test to XPU

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -1423,12 +1423,14 @@ partial_fn = functools.partial(fn, scale=2)
         if x.device.type == "cpu":
             return x + 1
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
+    @unittest.skipIf(not HAS_GPU, "requires gpu")
     @make_test
     def test_get_device_properties_tensor_device(a):
-        x = a.to("cuda")
-        prop = torch.cuda.get_device_properties(x.device)
-        if prop.major == 8:
+        x = a.to(device_type)
+        prop = torch.get_device_module(device_type).get_device_properties(x.device)
+        if device_type == "xpu":
+            return x + prop.max_compute_units
+        if device_type == "cuda" and prop.major == 8:
             return x + prop.multi_processor_count
         return x + prop.max_threads_per_multi_processor
 

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -1430,7 +1430,7 @@ partial_fn = functools.partial(fn, scale=2)
         prop = torch.get_device_module(device_type).get_device_properties(x.device)
         if device_type == "xpu":
             return x + prop.max_compute_units
-        if device_type == "cuda" and prop.major == 8:
+        if prop.major == 8:
             return x + prop.multi_processor_count
         return x + prop.max_threads_per_multi_processor
 

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -1429,7 +1429,7 @@ partial_fn = functools.partial(fn, scale=2)
         x = a.to(device_type)
         prop = torch.get_device_module(device_type).get_device_properties(x.device)
         if device_type == "xpu":
-            return x + prop.max_compute_units
+            return x + prop.gpu_subslice_count
         if prop.major == 8:
             return x + prop.multi_processor_count
         return x + prop.max_threads_per_multi_processor

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -1745,7 +1745,7 @@ partial_fn = functools.partial(fn, scale=2)
         prop = torch.get_device_module(device_type).get_device_properties(x.device)
         if device_type == "xpu":
             return x + prop.max_compute_units
-        if device_type == "cuda" and prop.major == 8:
+        if prop.major == 8:
             return x + prop.multi_processor_count
         return x + prop.max_threads_per_multi_processor
 

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -1744,7 +1744,7 @@ partial_fn = functools.partial(fn, scale=2)
         x = a.to(device_type)
         prop = torch.get_device_module(device_type).get_device_properties(x.device)
         if device_type == "xpu":
-            return x + prop.max_compute_units
+            return x + prop.gpu_subslice_count
         if prop.major == 8:
             return x + prop.multi_processor_count
         return x + prop.max_threads_per_multi_processor

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -1738,12 +1738,14 @@ partial_fn = functools.partial(fn, scale=2)
         if x.device.type == "cpu":
             return x + 1
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
+    @unittest.skipIf(not HAS_GPU, "requires gpu")
     @make_test
     def test_get_device_properties_tensor_device(a):
-        x = a.to("cuda")
-        prop = torch.cuda.get_device_properties(x.device)
-        if prop.major == 8:
+        x = a.to(device_type)
+        prop = torch.get_device_module(device_type).get_device_properties(x.device)
+        if device_type == "xpu":
+            return x + prop.max_compute_units
+        if device_type == "cuda" and prop.major == 8:
             return x + prop.multi_processor_count
         return x + prop.max_threads_per_multi_processor
 

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -2890,6 +2890,7 @@ common_constant_types: set[type] = {
     torch.iinfo,
     torch.nn.attention.SDPBackend,
     torch.cuda._CudaDeviceProperties,
+    torch.xpu._XpuDeviceProperties,
     # Pytree key types (frozen dataclasses used in tree_map_with_path)
     torch.utils._pytree.SequenceKey,
     torch.utils._pytree.MappingKey,

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -2991,6 +2991,7 @@ common_constant_types: set[type] = {
     torch.iinfo,
     torch.nn.attention.SDPBackend,
     torch.cuda._CudaDeviceProperties,
+    torch.xpu._XpuDeviceProperties,
     # Pytree key types (frozen dataclasses used in tree_map_with_path)
     torch.utils._pytree.SequenceKey,
     torch.utils._pytree.MappingKey,


### PR DESCRIPTION
 ## Summary

  Dynamo previously only recognized CUDA device properties (torch.cuda._CudaDeviceProperties) as a constant type. As a result, tracing code that queries XPU device properties via torch.xpu.get_device_properties(...) did not treat the returned object as a constant and the existing test_get_device_properties_tensor_device test was hard-coded to CUDA.

 ### Changes:
  - `torch/_dynamo/utils.py`: add `torch.xpu._XpuDeviceProperties` to
    `common_constant_types`, mirroring the CUDA entry.
  - `test/dynamo/test_functions.py`: switch the test skip guard from
    `torch.cuda.is_available()` to `HAS_GPU`, use `device_type` /
    `torch.get_device_module(device_type)` instead of hardcoded `"cuda"`, and add
    an XPU branch (`prop.max_compute_units`).

 ### Test Plan

  python test/dynamo/test_functions.py -k test_get_device_properties_tensor_device

  Runs on both CUDA and XPU hosts (skipped when no GPU is available).
  Fixes https://github.com/intel/torch-xpu-ops/issues/3595

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98