### PR TITLE
[fix]:has_triton(): query registered DeviceInterfaces,not a hardcoded dict

### DIFF
--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -13,6 +13,7 @@ from unittest import mock
 from sympy import I, Max, Min, Symbol, sympify
 
 import torch
+from torch._dynamo.device_interface import DeviceInterface
 from torch._dynamo.testing import AotEagerAndRecordGraphs
 from torch._dynamo.utils import detect_fake_mode
 from torch._inductor.compile_fx import _get_subgraph_names
@@ -42,6 +43,7 @@ from torch.testing._internal.common_utils import (
     TestCase,
     xfailIfNoAcceleratorTriton,
 )
+from torch.utils import _triton as triton_utils
 from torch.utils._sympy.functions import Identity
 
 
@@ -1144,6 +1146,100 @@ class TestFakeTensorUpdater(TestCase):
 
         self.assertEqual(tuple(neg_replacement.meta["val"].shape), (4, 5))
         self.assertEqual(tuple(lowered.meta["val"].shape), (2, 3))
+
+
+# A non-RuntimeError exception mirroring CUDA's GPUTooOldForTriton. The
+# has_triton() loop must never let this escape for a sub-capable device.
+class _GPUTooOldForTriton(Exception):
+    pass
+
+
+def _make_triton_interface(*, available=True, capable=True, raise_exc=None):
+    class _FakeInterface(DeviceInterface):
+        @staticmethod
+        def is_available() -> bool:
+            return available
+
+        @staticmethod
+        def is_triton_capable(device=None) -> bool:
+            return capable
+
+        @classmethod
+        def raise_if_triton_unavailable(cls, device=None) -> None:
+            if raise_exc is not None:
+                raise raise_exc
+
+    return _FakeInterface
+
+
+class TestHasTriton(TestCase):
+    def setUp(self):
+        super().setUp()
+        triton_utils.has_triton.cache_clear()
+
+    def tearDown(self):
+        triton_utils.has_triton.cache_clear()
+        super().tearDown()
+
+    def _run(self, registered, *, has_package=True, detection_disabled=False):
+        with (
+            mock.patch.object(
+                triton_utils, "has_triton_package", return_value=has_package
+            ),
+            mock.patch(
+                "torch._inductor.config.triton_disable_device_detection",
+                detection_disabled,
+            ),
+            mock.patch(
+                "torch._dynamo.device_interface.get_registered_device_interfaces",
+                return_value=registered,
+            ),
+        ):
+            triton_utils.has_triton.cache_clear()
+            return triton_utils.has_triton()
+
+    def test_no_triton_package(self):
+        result = self._run([("fake", _make_triton_interface())], has_package=False)
+        self.assertFalse(result)
+
+    def test_detection_disabled(self):
+        result = self._run(
+            [("fake", _make_triton_interface())], detection_disabled=True
+        )
+        self.assertFalse(result)
+
+    def test_capable_available_backend_built(self):
+        self.assertTrue(self._run([("fake", _make_triton_interface())]))
+
+    def test_device_not_available(self):
+        self.assertFalse(
+            self._run([("fake", _make_triton_interface(available=False))])
+        )
+
+    def test_device_not_triton_capable(self):
+        self.assertFalse(self._run([("fake", _make_triton_interface(capable=False))]))
+
+    def test_backend_missing_raises_runtime_error(self):
+        iface = _make_triton_interface(raise_exc=RuntimeError("backend not built"))
+        self.assertFalse(self._run([("fake", iface)]))
+
+    def test_indexed_device_name_skipped(self):
+        # "fake:0" is available+capable but must be skipped as an indexed alias.
+        self.assertFalse(self._run([("fake:0", _make_triton_interface())]))
+
+    def test_first_working_device_wins(self):
+        registered = [
+            ("bad", _make_triton_interface(capable=False)),
+            ("good", _make_triton_interface()),
+        ]
+        self.assertTrue(self._run(registered))
+
+    def test_capability_gate_precedes_backend_probe(self):
+        # A sub-capable device whose backend probe would throw a NON-RuntimeError.
+        # The capability gate must short-circuit before the probe is ever called;
+        # if the ordering regresses, _GPUTooOldForTriton escapes instead of False.
+        iface = _make_triton_interface(capable=False, raise_exc=_GPUTooOldForTriton())
+        self.assertFalse(self._run([("fake", iface)]))
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -1212,9 +1212,7 @@ class TestHasTriton(TestCase):
         self.assertTrue(self._run([("fake", _make_triton_interface())]))
 
     def test_device_not_available(self):
-        self.assertFalse(
-            self._run([("fake", _make_triton_interface(available=False))])
-        )
+        self.assertFalse(self._run([("fake", _make_triton_interface(available=False))]))
 
     def test_device_not_triton_capable(self):
         self.assertFalse(self._run([("fake", _make_triton_interface(capable=False))]))

--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -13,7 +13,8 @@ from unittest import mock
 from sympy import I, Max, Min, Symbol, sympify
 
 import torch
-from torch._dynamo.device_interface import DeviceInterface, TritonUnavailableError
+from torch._dynamo.device_interface import DeviceInterface
+from torch._dynamo.exc import TritonUnavailableError
 from torch._dynamo.testing import AotEagerAndRecordGraphs
 from torch._dynamo.utils import detect_fake_mode
 from torch._inductor.compile_fx import _get_subgraph_names
@@ -1173,10 +1174,6 @@ def _make_triton_interface(*, available=True, capable=True, raise_exc=None):
 
 
 class TestHasTriton(TestCase):
-    def setUp(self):
-        super().setUp()
-        triton_utils.has_triton.cache_clear()
-
     def tearDown(self):
         triton_utils.has_triton.cache_clear()
         super().tearDown()
@@ -1227,7 +1224,7 @@ class TestHasTriton(TestCase):
         # A generic RuntimeError is NOT the "no triton backend" signal, so it
         # must surface instead of being silently treated as "no triton".
         iface = _make_triton_interface(raise_exc=RuntimeError("something else broke"))
-        with self.assertRaises(RuntimeError):
+        with self.assertRaisesRegex(RuntimeError, "something else broke"):
             self._run([("fake", iface)])
 
     def test_indexed_device_name_skipped(self):

--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -17,6 +17,7 @@ from torch._dynamo.device_interface import DeviceInterface
 from torch._dynamo.exc import TritonUnavailableError
 from torch._dynamo.testing import AotEagerAndRecordGraphs
 from torch._dynamo.utils import detect_fake_mode
+from torch._inductor import config as inductor_config
 from torch._inductor.compile_fx import _get_subgraph_names
 from torch._inductor.fx_utils import (
     _is_fake_tensor_same,
@@ -1149,8 +1150,10 @@ class TestFakeTensorUpdater(TestCase):
         self.assertEqual(tuple(lowered.meta["val"].shape), (2, 3))
 
 
-# A non-RuntimeError exception mirroring CUDA's GPUTooOldForTriton. The
-# has_triton() loop must never let this escape for a sub-capable device.
+# Stand-in for any exception that is not TritonUnavailableError and must not
+# escape has_triton() for a sub-capable device. (The real GPUTooOldForTriton
+# is a RuntimeError subclass; this one deliberately is not, so an escape
+# cannot be mistaken for anything has_triton() legitimately catches.)
 class _GPUTooOldForTriton(Exception):
     pass
 
@@ -1183,10 +1186,7 @@ class TestHasTriton(TestCase):
             mock.patch.object(
                 triton_utils, "has_triton_package", return_value=has_package
             ),
-            mock.patch(
-                "torch._inductor.config.triton_disable_device_detection",
-                detection_disabled,
-            ),
+            inductor_config.patch(triton_disable_device_detection=detection_disabled),
             mock.patch(
                 "torch._dynamo.device_interface.get_registered_device_interfaces",
                 return_value=registered,

--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -13,7 +13,7 @@ from unittest import mock
 from sympy import I, Max, Min, Symbol, sympify
 
 import torch
-from torch._dynamo.device_interface import DeviceInterface
+from torch._dynamo.device_interface import DeviceInterface, TritonUnavailableError
 from torch._dynamo.testing import AotEagerAndRecordGraphs
 from torch._dynamo.utils import detect_fake_mode
 from torch._inductor.compile_fx import _get_subgraph_names
@@ -1219,9 +1219,18 @@ class TestHasTriton(TestCase):
     def test_device_not_triton_capable(self):
         self.assertFalse(self._run([("fake", _make_triton_interface(capable=False))]))
 
-    def test_backend_missing_raises_runtime_error(self):
-        iface = _make_triton_interface(raise_exc=RuntimeError("backend not built"))
+    def test_backend_missing_is_swallowed(self):
+        iface = _make_triton_interface(
+            raise_exc=TritonUnavailableError("backend not built")
+        )
         self.assertFalse(self._run([("fake", iface)]))
+
+    def test_unexpected_runtime_error_propagates(self):
+        # A generic RuntimeError is NOT the "no triton backend" signal, so it
+        # must surface instead of being silently treated as "no triton".
+        iface = _make_triton_interface(raise_exc=RuntimeError("something else broke"))
+        with self.assertRaises(RuntimeError):
+            self._run([("fake", iface)])
 
     def test_indexed_device_name_skipped(self):
         # "fake:0" is available+capable but must be skipped as an indexed alias.

--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -37,6 +37,18 @@ caching_worker_device_properties: dict[str, Any] = {}
 caching_worker_current_devices: dict[str, int] = {}
 
 
+class TritonUnavailableError(RuntimeError):
+    """
+    Raised by DeviceInterface.raise_if_triton_unavailable to signal that a
+    device cannot run Triton (e.g. no Triton backend was built for it).
+
+    Subclasses RuntimeError so existing callers that catch RuntimeError keep
+    working, while callers that only want to react to Triton unavailability -
+    such as has_triton() - can catch this specific type instead of swallowing
+    every RuntimeError, which would hide unrelated bugs.
+    """
+
+
 class DeviceInterface:
     """
     This is a simple device runtime interface for Inductor. It enables custom
@@ -160,15 +172,17 @@ class DeviceInterface:
     @classmethod
     def raise_if_triton_unavailable(cls, device: torch.types.Device = None) -> None:
         """
-        Raises a `RuntimeError` with the appropriate human-readable instructions
-        to resolve the issue if Triton is not available for the given device, or
-        the default device if `device` is `None`.
+        Raises a `TritonUnavailableError` with the appropriate human-readable
+        instructions to resolve the issue if Triton is not available for the
+        given device, or the default device if `device` is `None`.
 
         The caller should ensure the presence of the 'triton' package before
         calling this method.
         """
         if not cls.is_triton_capable():
-            raise RuntimeError("This device is not capable of supporting Triton")
+            raise TritonUnavailableError(
+                "This device is not capable of supporting Triton"
+            )
 
 
 class DeviceGuard:
@@ -288,9 +302,9 @@ class CudaInterface(DeviceInterface):
 
         if torch.version.hip is not None:
             if "amd" not in triton.backends.backends:
-                raise RuntimeError("triton not built with the 'amd' backend")
+                raise TritonUnavailableError("triton not built with the 'amd' backend")
         elif "nvidia" not in triton.backends.backends:
-            raise RuntimeError("triton not built with the 'nvidia' backend")
+            raise TritonUnavailableError("triton not built with the 'nvidia' backend")
 
 
 get_mtia_stream: Callable[[int], int] | None
@@ -375,7 +389,7 @@ class MtiaInterface(DeviceInterface):
         import triton.backends
 
         if "mtia" not in triton.backends.backends:
-            raise RuntimeError("triton not built with the 'mtia' backend")
+            raise TritonUnavailableError("triton not built with the 'mtia' backend")
 
 
 get_xpu_stream: Callable[[int], int] | None
@@ -462,7 +476,7 @@ class XpuInterface(DeviceInterface):
         import triton.backends
 
         if "intel" not in triton.backends.backends:
-            raise RuntimeError("triton not built with the 'intel' backend")
+            raise TritonUnavailableError("triton not built with the 'intel' backend")
 
 
 @dataclass
@@ -526,7 +540,7 @@ class CpuInterface(DeviceInterface):
         import triton.backends
 
         if "cpu" not in triton.backends.backends:
-            raise RuntimeError("triton not built with the 'cpu' backend")
+            raise TritonUnavailableError("triton not built with the 'cpu' backend")
 
 
 class MpsInterface(DeviceInterface):

--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -160,9 +160,13 @@ class DeviceInterface:
     @classmethod
     def raise_if_triton_unavailable(cls, device: torch.types.Device = None) -> None:
         """
-        Raises a `TritonUnavailableError` with the appropriate human-readable
-        instructions to resolve the issue if Triton is not available for the
-        given device, or the default device if `device` is `None`.
+        Raises a `TritonUnavailableError` with human-readable instructions if
+        the Triton backend for the given device (or the default device if
+        `device` is `None`) is not built. Implementations may raise a
+        different, more specific error when the device itself is not
+        Triton-capable (e.g. CUDA raises `GPUTooOldForTriton`), so callers
+        that only want an availability answer should check
+        `is_triton_capable()` first.
 
         The caller should ensure the presence of the 'triton' package before
         calling this method.
@@ -381,9 +385,9 @@ class MtiaInterface(DeviceInterface):
 
     @staticmethod
     def raise_if_triton_unavailable(device: torch.types.Device = None) -> None:
-        from torch._dynamo.exc import TritonUnavailableError
-
         import triton.backends
+
+        from torch._dynamo.exc import TritonUnavailableError
 
         if "mtia" not in triton.backends.backends:
             raise TritonUnavailableError("triton not built with the 'mtia' backend")
@@ -470,9 +474,9 @@ class XpuInterface(DeviceInterface):
 
     @staticmethod
     def raise_if_triton_unavailable(device: torch.types.Device = None) -> None:
-        from torch._dynamo.exc import TritonUnavailableError
-
         import triton.backends
+
+        from torch._dynamo.exc import TritonUnavailableError
 
         if "intel" not in triton.backends.backends:
             raise TritonUnavailableError("triton not built with the 'intel' backend")
@@ -536,9 +540,9 @@ class CpuInterface(DeviceInterface):
 
     @staticmethod
     def raise_if_triton_unavailable(device: torch.types.Device = None) -> None:
-        from torch._dynamo.exc import TritonUnavailableError
-
         import triton.backends
+
+        from torch._dynamo.exc import TritonUnavailableError
 
         if "cpu" not in triton.backends.backends:
             raise TritonUnavailableError("triton not built with the 'cpu' backend")

--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -23,7 +23,6 @@ from dataclasses import dataclass
 from typing import Any, Literal
 
 import torch
-from torch._dynamo.exc import TritonUnavailableError
 from torch.utils._pallas import has_torch_tpu
 
 
@@ -168,6 +167,8 @@ class DeviceInterface:
         The caller should ensure the presence of the 'triton' package before
         calling this method.
         """
+        from torch._dynamo.exc import TritonUnavailableError
+
         if not cls.is_triton_capable():
             raise TritonUnavailableError(
                 "This device is not capable of supporting Triton"
@@ -285,6 +286,7 @@ class CudaInterface(DeviceInterface):
 
     @staticmethod
     def raise_if_triton_unavailable(device: torch.types.Device = None) -> None:
+        from torch._dynamo.exc import TritonUnavailableError
         from torch._inductor.exc import GPUTooOldForTriton
 
         if not CudaInterface.is_triton_capable(device):
@@ -379,6 +381,8 @@ class MtiaInterface(DeviceInterface):
 
     @staticmethod
     def raise_if_triton_unavailable(device: torch.types.Device = None) -> None:
+        from torch._dynamo.exc import TritonUnavailableError
+
         import triton.backends
 
         if "mtia" not in triton.backends.backends:
@@ -466,6 +470,8 @@ class XpuInterface(DeviceInterface):
 
     @staticmethod
     def raise_if_triton_unavailable(device: torch.types.Device = None) -> None:
+        from torch._dynamo.exc import TritonUnavailableError
+
         import triton.backends
 
         if "intel" not in triton.backends.backends:
@@ -530,6 +536,8 @@ class CpuInterface(DeviceInterface):
 
     @staticmethod
     def raise_if_triton_unavailable(device: torch.types.Device = None) -> None:
+        from torch._dynamo.exc import TritonUnavailableError
+
         import triton.backends
 
         if "cpu" not in triton.backends.backends:

--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -23,6 +23,7 @@ from dataclasses import dataclass
 from typing import Any, Literal
 
 import torch
+from torch._dynamo.exc import TritonUnavailableError
 from torch.utils._pallas import has_torch_tpu
 
 
@@ -35,18 +36,6 @@ else:
 # Recording the device properties in the main process but used in worker process.
 caching_worker_device_properties: dict[str, Any] = {}
 caching_worker_current_devices: dict[str, int] = {}
-
-
-class TritonUnavailableError(RuntimeError):
-    """
-    Raised by DeviceInterface.raise_if_triton_unavailable to signal that a
-    device cannot run Triton (e.g. no Triton backend was built for it).
-
-    Subclasses RuntimeError so existing callers that catch RuntimeError keep
-    working, while callers that only want to react to Triton unavailability -
-    such as has_triton() - can catch this specific type instead of swallowing
-    every RuntimeError, which would hide unrelated bugs.
-    """
 
 
 class DeviceInterface:
@@ -285,9 +274,13 @@ class CudaInterface(DeviceInterface):
 
     @staticmethod
     def is_triton_capable(device: torch.types.Device = None) -> bool:
+        # Use the Worker API (device properties cached in the main process
+        # before fork) instead of torch.cuda.get_device_properties directly, so
+        # the capability check stays safe when called from spawn-based compile
+        # workers.
         return (
             torch.version.hip is not None
-            or torch.cuda.get_device_properties(device).major >= 7
+            or CudaInterface.Worker.get_device_properties(device).major >= 7
         )
 
     @staticmethod

--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -140,6 +140,18 @@ def _reconstruct_torch_dynamo_exception(
     return exc
 
 
+class TritonUnavailableError(RuntimeError):
+    """
+    Raised by DeviceInterface.raise_if_triton_unavailable to signal that a
+    device cannot run Triton (e.g. no Triton backend was built for it).
+
+    Subclasses RuntimeError so existing callers that catch RuntimeError keep
+    working, while callers that only want to react to Triton unavailability -
+    such as has_triton() - can catch this specific type instead of swallowing
+    every RuntimeError, which would hide unrelated bugs.
+    """
+
+
 class TorchDynamoException(RuntimeError):
     """Base exception class for all TorchDynamo-specific exceptions.
 

--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -140,18 +140,6 @@ def _reconstruct_torch_dynamo_exception(
     return exc
 
 
-class TritonUnavailableError(RuntimeError):
-    """
-    Raised by DeviceInterface.raise_if_triton_unavailable to signal that a
-    device cannot run Triton (e.g. no Triton backend was built for it).
-
-    Subclasses RuntimeError so existing callers that catch RuntimeError keep
-    working, while callers that only want to react to Triton unavailability -
-    such as has_triton() - can catch this specific type instead of swallowing
-    every RuntimeError, which would hide unrelated bugs.
-    """
-
-
 class TorchDynamoException(RuntimeError):
     """Base exception class for all TorchDynamo-specific exceptions.
 
@@ -531,6 +519,18 @@ class UnhandledDescriptorError(NotImplementedError):
     graph-break fallback) still work, but callers that want to
     distinguish unhandled descriptors from other NotImplementedErrors can
     catch this specifically.
+    """
+
+
+class TritonUnavailableError(RuntimeError):
+    """
+    Raised by DeviceInterface.raise_if_triton_unavailable to signal that a
+    device cannot run Triton (e.g. no Triton backend was built for it).
+
+    Subclasses RuntimeError so existing callers that catch RuntimeError keep
+    working, while callers that only want to react to Triton unavailability -
+    such as has_triton() - can catch this specific type instead of swallowing
+    every RuntimeError, which would hide unrelated bugs.
     """
 
 

--- a/torch/utils/_triton.py
+++ b/torch/utils/_triton.py
@@ -202,12 +202,17 @@ def has_triton() -> bool:
     if triton_disable_device_detection:
         return False
 
-    from torch._dynamo.device_interface import get_registered_device_interfaces
+    from torch._dynamo.device_interface import (
+        get_registered_device_interfaces,
+        TritonUnavailableError,
+    )
 
     # A device supports Triton if it is available, reports Triton capability, and
     # its Triton backend is actually built. Capability is gated first so that
-    # raise_if_triton_unavailable() only surfaces missing-backend RuntimeErrors
-    # (and not, e.g., CUDA's GPUTooOldForTriton for sub-capable devices).
+    # raise_if_triton_unavailable() only surfaces missing-backend errors (and
+    # not, e.g., CUDA's GPUTooOldForTriton for sub-capable devices). We catch the
+    # specific TritonUnavailableError rather than RuntimeError so unexpected
+    # errors are not silently swallowed.
     for name, device_interface in get_registered_device_interfaces():
         if ":" in name:
             continue
@@ -217,7 +222,7 @@ def has_triton() -> bool:
             continue
         try:
             device_interface.raise_if_triton_unavailable()
-        except RuntimeError:
+        except TritonUnavailableError:
             continue
         return True
     return False

--- a/torch/utils/_triton.py
+++ b/torch/utils/_triton.py
@@ -202,34 +202,25 @@ def has_triton() -> bool:
     if triton_disable_device_detection:
         return False
 
-    from torch._dynamo.device_interface import get_interface_for_device
+    from torch._dynamo.device_interface import get_registered_device_interfaces
 
-    def cuda_extra_check(device_interface: Any) -> bool:
-        return device_interface.Worker.get_device_properties().major >= 7
-
-    def cpu_extra_check(device_interface: Any) -> bool:
-        import triton.backends
-
-        return "cpu" in triton.backends.backends
-
-    def _return_true(device_interface: Any) -> bool:
+    # A device supports Triton if it is available, reports Triton capability, and
+    # its Triton backend is actually built. Capability is gated first so that
+    # raise_if_triton_unavailable() only surfaces missing-backend RuntimeErrors
+    # (and not, e.g., CUDA's GPUTooOldForTriton for sub-capable devices).
+    for name, device_interface in get_registered_device_interfaces():
+        if ":" in name:
+            continue
+        if not (
+            device_interface.is_available() and device_interface.is_triton_capable()
+        ):
+            continue
+        try:
+            device_interface.raise_if_triton_unavailable()
+        except RuntimeError:
+            continue
         return True
-
-    triton_supported_devices = {
-        "cuda": cuda_extra_check,
-        "xpu": _return_true,
-        "cpu": cpu_extra_check,
-        "mtia": _return_true,
-    }
-
-    def is_device_compatible_with_triton() -> bool:
-        for device, extra_check in triton_supported_devices.items():
-            device_interface = get_interface_for_device(device)
-            if device_interface.is_available() and extra_check(device_interface):
-                return True
-        return False
-
-    return is_device_compatible_with_triton()
+    return False
 
 
 @functools.cache

--- a/torch/utils/_triton.py
+++ b/torch/utils/_triton.py
@@ -202,10 +202,8 @@ def has_triton() -> bool:
     if triton_disable_device_detection:
         return False
 
-    from torch._dynamo.device_interface import (
-        get_registered_device_interfaces,
-        TritonUnavailableError,
-    )
+    from torch._dynamo.device_interface import get_registered_device_interfaces
+    from torch._dynamo.exc import TritonUnavailableError
 
     # A device supports Triton if it is available, reports Triton capability, and
     # its Triton backend is actually built. Capability is gated first so that


### PR DESCRIPTION
## Summary
Make `has_triton()` decide Triton availability by querying the registered
DeviceInterfaces instead of a hardcoded device dict, so out-of-tree PrivateUse1
accelerator backends are recognized without monkeypatching `has_triton` at import.

## Changes
- Replace the hardcoded `triton_supported_devices` dict (cuda/xpu/cpu/mtia) and
  its per-device `extra_check` closures with a loop over
  `get_registered_device_interfaces()`.
- A device provides Triton when it is available, reports `is_triton_capable()`,
  and its Triton backend is actually built (`raise_if_triton_unavailable()` does
  not raise). Indexed entries like "cuda:0" are skipped.
- Gate on `is_triton_capable()` before calling `raise_if_triton_unavailable()`
  so only missing-backend `RuntimeError`s are caught and CUDA's
  `GPUTooOldForTriton` is never leaked for sub-capable devices.

## Motivation
`has_triton()` walked a hardcoded dict of device names, so an out-of-tree
PrivateUse1 backend that registers a full DeviceInterface (already exposing
`is_triton_capable()` / `raise_if_triton_unavailable()`) was invisible and had to
monkeypatch `has_triton` at import time. Iterating the registry lets any
registered backend participate through the existing contract.

## Test Plan
- CI: `python test/inductor/test_utils.py TestHasTriton`
- Added `TestHasTriton` (9 cases) to `test/inductor/test_utils.py`. Tests use
  fake `DeviceInterface` subclasses and mock all three external inputs
  (`has_triton_package`, `triton_disable_device_detection`, and the registry) —
  no GPU or Triton install required. Coverage: two early-exit gates, indexed-name
  skip, available/capable filter, missing-backend `RuntimeError` path,
  first-working-device-wins, and the capability-gate-before-probe ordering that
  prevents `GPUTooOldForTriton` from escaping for sub-capable devices.

## Notes
- Related RFC: DeviceInterface registry support for PrivateUse1 backends in torch.compile.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98