### PR TITLE
[Docs] add NUMA binding documentation to torchrun docs

### DIFF
--- a/docs/source/elastic/run.md
+++ b/docs/source/elastic/run.md
@@ -18,3 +18,17 @@
    run
    run_script_path
 ```
+
+## NUMA Binding
+
+NUMA (Non-Uniform Memory Access) is a memory architecture in which different CPU memory nodes have different access latencies. On NUMA-enabled multi-GPU servers, `--numa-binding` can bind worker processes to CPU cores that are closest to their assigned GPUs to improve locality and potentially improve performance.
+
+This feature is intended for NUMA-enabled multi-GPU servers and may not provide a benefit on typical desktop or laptop systems.
+
+Example:
+
+```bash
+torchrun --numa-binding=node --nproc-per-node=8 train.py
+```
+
+For more information about the available NUMA binding modes and configuration options, see the {doc}`NUMA Binding <numa>` documentation.


### PR DESCRIPTION
## Summary

Adds documentation for the `--numa-binding` option to the `torchrun` documentation (`docs/source/elastic/run.md`).

### Changes

- Added a new **NUMA Binding** section.
- Explained what NUMA is and when the feature is useful.
- Documented the `--numa-binding` CLI option.
- Added a basic `torchrun` usage example.

Fixes #158775