### PR TITLE
[fix]: derive is_gpu()/device_need_guard() from DeviceInterface

### DIFF
--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -1478,6 +1478,17 @@ class TestDeviceClassification(TestCase):
             with self.assertLogs("torch._inductor.utils", level="WARNING"):
                 self.assertEqual(get_gpu_type(), "fakegpu")
 
+    def test_in_tree_gpu_types_unchanged(self):
+        # The registry scan replaces a hardcoded GPU_TYPES literal, so pin the
+        # in-tree result: dropping an is_gpu() override would otherwise shift
+        # the classification silently, with no test in the repo failing.
+        known = {"cuda", "xpu", "mtia", "mps", "cpu", "tpu"}
+        self.assertEqual(set(_gpu_types()) & known, {"cuda", "xpu", "mtia", "mps"})
+        # MPS is GPU-class but exposes no Stream, so it takes no stream guard.
+        self.assertFalse(device_need_guard("mps"))
+        self.assertFalse(is_gpu("cpu"))
+        self.assertFalse(is_gpu("cuda:0"))
+
 
 if __name__ == "__main__":
     run_tests()

--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -5,6 +5,7 @@ import importlib.util
 import os
 import sys
 import tempfile
+import types
 import unittest
 from collections.abc import Callable, Iterator
 from pathlib import Path
@@ -13,11 +14,12 @@ from unittest import mock
 from sympy import I, Max, Min, Symbol, sympify
 
 import torch
+from torch._dynamo import device_interface as di
 from torch._dynamo.device_interface import DeviceInterface
 from torch._dynamo.exc import TritonUnavailableError
 from torch._dynamo.testing import AotEagerAndRecordGraphs
 from torch._dynamo.utils import detect_fake_mode
-from torch._inductor import config as inductor_config
+from torch._inductor import config as inductor_config, utils as inductor_utils
 from torch._inductor.compile_fx import _get_subgraph_names
 from torch._inductor.fx_utils import (
     _is_fake_tensor_same,
@@ -27,7 +29,11 @@ from torch._inductor.fx_utils import (
     get_fake,
 )
 from torch._inductor.utils import (
+    _gpu_types,
+    device_need_guard,
     get_device_tflops,
+    get_gpu_type,
+    is_gpu,
     load_template,
     python_subprocess_env,
     sympy_str,
@@ -1259,6 +1265,218 @@ class TestHasTriton(TestCase):
         # if the ordering regresses, _GPUTooOldForTriton escapes instead of False.
         iface = _make_triton_interface(capable=False, raise_exc=_GPUTooOldForTriton())
         self.assertFalse(self._run([("fake", iface)]))
+
+
+class _GpuWithStream(DeviceInterface):
+    class Stream:  # overrides the base sentinel Stream -> exposes_streams() True
+        pass
+
+    @staticmethod
+    def is_gpu() -> bool:
+        return True
+
+    @staticmethod
+    def is_available() -> bool:
+        return True
+
+
+class _GpuNoStream(DeviceInterface):
+    # deliberately does NOT define Stream: inherits the base sentinel (mps-like)
+    @staticmethod
+    def is_gpu() -> bool:
+        return True
+
+    @staticmethod
+    def is_available() -> bool:
+        return True
+
+
+class _GpuUnavailable(DeviceInterface):
+    @staticmethod
+    def is_gpu() -> bool:
+        return True
+
+    @staticmethod
+    def is_available() -> bool:
+        return False
+
+
+class _NonGpu(DeviceInterface):
+    # is_gpu() NOT overridden: inherits the base default of False
+    @staticmethod
+    def is_available() -> bool:
+        return True
+
+
+class _GpuOnlyClassified(DeviceInterface):
+    # Overrides nothing but is_gpu(): a partially-implemented out-of-tree
+    # interface whose other base-class methods (is_available, device_count,
+    # ...) raise NotImplementedError. Registry-driven consumers must treat
+    # it as unavailable rather than propagate the error.
+    @staticmethod
+    def is_gpu() -> bool:
+        return True
+
+
+class TestDeviceClassification(TestCase):
+    def setUp(self):
+        super().setUp()
+        self._registered = []
+        get_gpu_type.cache_clear()
+
+    def tearDown(self):
+        # GPU_TYPES is an import-time snapshot and never refreshes, so tests
+        # patch it rather than mutate it; only get_gpu_type() caches at all.
+        for name in self._registered:
+            di.device_interfaces.pop(name, None)
+        get_gpu_type.cache_clear()
+        super().tearDown()
+
+    def _register(self, name, iface):
+        di.register_interface_for_device(name, iface)
+        self._registered.append(name)
+
+    # ---- is_gpu() default on the base class ----
+    def test_base_is_gpu_defaults_false(self):
+        self.assertFalse(DeviceInterface.is_gpu())
+        self.assertFalse(_NonGpu.is_gpu())
+        self.assertTrue(_GpuWithStream.is_gpu())
+
+    # ---- exposes_streams(): sentinel comparison, NOT None ----
+    def test_exposes_streams_true_when_stream_overridden(self):
+        self.assertTrue(_GpuWithStream.exposes_streams())
+
+    def test_exposes_streams_false_via_base_sentinel_not_none(self):
+        # _GpuNoStream.Stream IS the base sentinel (same object, not None).
+        # exposes_streams() must compare against the sentinel, not None;
+        # otherwise this card would be wrongly reported as stream-capable.
+        self.assertIs(_GpuNoStream.Stream, DeviceInterface.Stream)
+        self.assertIsNotNone(_GpuNoStream.Stream)
+        self.assertFalse(_GpuNoStream.exposes_streams())
+
+    # ---- is_gpu(device) ----
+    def test_is_gpu_none_returns_false(self):
+        self.assertFalse(is_gpu(None))
+
+    def test_is_gpu_unregistered_returns_false(self):
+        self.assertFalse(is_gpu("definitely_not_a_device"))
+
+    def test_is_gpu_registered(self):
+        self._register("fakegpu", _GpuWithStream)
+        self._register("fakecpu", _NonGpu)
+        # GPU_TYPES snapshots at inductor import; patch it with a fresh scan
+        # so is_gpu() sees the fixtures.
+        with mock.patch.object(inductor_utils, "GPU_TYPES", _gpu_types()):
+            self.assertTrue(is_gpu("fakegpu"))
+            self.assertFalse(is_gpu("fakecpu"))
+
+    # ---- device_need_guard(device) ----
+    def test_device_need_guard(self):
+        self._register("fakegpu", _GpuWithStream)
+        self._register("fakemps", _GpuNoStream)
+        self._register("fakecpu", _NonGpu)
+        with mock.patch.object(inductor_utils, "GPU_TYPES", _gpu_types()):
+            self.assertTrue(device_need_guard("fakegpu"))
+            self.assertFalse(device_need_guard("fakemps"))  # gpu but no stream
+            self.assertFalse(device_need_guard("fakecpu"))
+            self.assertFalse(device_need_guard("definitely_not_a_device"))
+
+    # ---- _gpu_types() ----
+    def test_gpu_types_filters_indexed_and_non_gpu(self):
+        self._register("fakegpu", _GpuWithStream)
+        self._register("fakegpu:0", _GpuWithStream)
+        self._register("fakecpu", _NonGpu)
+        result = _gpu_types()
+        self.assertIn("fakegpu", result)
+        self.assertNotIn("fakegpu:0", result)
+        self.assertNotIn("fakecpu", result)
+
+    def test_gpu_types_is_an_import_time_snapshot(self):
+        # GPU_TYPES is scanned exactly once, when inductor is imported;
+        # registering afterwards is documented as unsupported and must not be
+        # reflected (see register_interface_for_device).
+        first = get_gpu_type()
+        self._register("acc", _GpuWithStream)
+        self.assertIn("acc", _gpu_types())  # a fresh scan does see it
+        self.assertNotIn("acc", inductor_utils.GPU_TYPES)  # the snapshot does not
+        self.assertFalse(is_gpu("acc"))
+        # Clear the cache so this re-evaluates over the frozen snapshot rather
+        # than trivially hitting functools.cache.
+        get_gpu_type.cache_clear()
+        self.assertEqual(get_gpu_type(), first)
+
+    def test_gpu_types_consumer_resolves_out_of_tree_via_registry(self):
+        # A third-party PrivateUse1 backend (here "acc") registers a GPU-class
+        # DeviceInterface but exposes no torch.acc submodule, so GPU_TYPES
+        # consumers must resolve through the registry, not getattr(torch, name).
+        # Drive the real consumers so reverting their fixes fails this test.
+        import torch._inductor.fx_passes.freezing_patterns as freezing_patterns
+        from torch._inductor.fx_passes.freezing_patterns import _addmm_pattern_device
+        from torch.testing._internal.inductor_utils import _is_multigpu
+
+        self._register("acc", _GpuWithStream)
+        self.assertFalse(hasattr(torch, "acc"))
+        self.assertIn("acc", _gpu_types())  # the registry scan resolves it
+        # Each consumer module holds its own binding of the GPU_TYPES snapshot,
+        # so patch the consumer's binding directly.
+        with mock.patch.object(freezing_patterns, "GPU_TYPES", ["acc"]):
+            self.assertEqual(_addmm_pattern_device(), "acc")
+        # The fake interface has no device_count: must be False, not raise.
+        self.assertFalse(_is_multigpu("acc"))
+
+    def test_is_multigpu_tolerates_unimplemented_is_available(self):
+        from torch.testing._internal.inductor_utils import _is_multigpu
+
+        # is_available() itself is unimplemented (base raises): _is_multigpu
+        # feeds HAS_MULTIGPU at module import, so it must return False, not
+        # raise (or importing the test-support module dies).
+        self._register("fakeraw", _GpuOnlyClassified)
+        self.assertFalse(_is_multigpu("fakeraw"))
+
+    # ---- get_gpu_type() ----
+    def test_get_gpu_type_single_available(self):
+        self._register("fakegpu", _GpuWithStream)
+        with mock.patch.object(inductor_utils, "GPU_TYPES", ["fakegpu"]):
+            self.assertEqual(get_gpu_type(), "fakegpu")
+
+    def test_get_gpu_type_none_available_falls_back_to_cuda(self):
+        # No available GPU type: falls back to "cuda" before ever consulting
+        # the current accelerator.
+        self._register("fakegpu", _GpuUnavailable)
+        with mock.patch.object(inductor_utils, "GPU_TYPES", ["fakegpu"]):
+            self.assertEqual(get_gpu_type(), "cuda")
+
+    def test_get_gpu_type_multiple_disambiguates_without_assert(self):
+        # Old code asserted len(avail) <= 1; this test would crash there.
+        # New code uses current_accelerator() to disambiguate instead.
+        self._register("fakegpu", _GpuWithStream)
+        self._register("fakegpu2", _GpuWithStream)
+        acc = types.SimpleNamespace(type="fakegpu2")
+        with (
+            mock.patch.object(inductor_utils, "GPU_TYPES", ["fakegpu", "fakegpu2"]),
+            mock.patch("torch.accelerator.current_accelerator", return_value=acc),
+        ):
+            self.assertEqual(get_gpu_type(), "fakegpu2")
+
+    def test_get_gpu_type_skips_unimplemented_is_available(self):
+        # A partially-implemented interface must be skipped, not crash the
+        # availability scan.
+        self._register("fakeraw", _GpuOnlyClassified)
+        with mock.patch.object(inductor_utils, "GPU_TYPES", ["fakeraw"]):
+            self.assertEqual(get_gpu_type(), "cuda")
+
+    def test_get_gpu_type_stable_fallback_when_accelerator_disagrees(self):
+        # >1 available and current_accelerator() names none of them: the pick
+        # must be stable (sorted), not positional registry order.
+        self._register("fakegpu", _GpuWithStream)
+        self._register("fakegpu2", _GpuWithStream)
+        acc = types.SimpleNamespace(type="unrelated")
+        with (
+            mock.patch.object(inductor_utils, "GPU_TYPES", ["fakegpu2", "fakegpu"]),
+            mock.patch("torch.accelerator.current_accelerator", return_value=acc),
+        ):
+            with self.assertLogs("torch._inductor.utils", level="WARNING"):
+                self.assertEqual(get_gpu_type(), "fakegpu")
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -5,6 +5,7 @@ import importlib.util
 import os
 import sys
 import tempfile
+import types
 import unittest
 from collections.abc import Callable, Iterator
 from pathlib import Path
@@ -13,8 +14,11 @@ from unittest import mock
 from sympy import I, Max, Min, Symbol, sympify
 
 import torch
+from torch._dynamo import device_interface as di
+from torch._dynamo.device_interface import DeviceInterface
 from torch._dynamo.testing import AotEagerAndRecordGraphs
 from torch._dynamo.utils import detect_fake_mode
+from torch._inductor import utils as inductor_utils
 from torch._inductor.compile_fx import _get_subgraph_names
 from torch._inductor.fx_utils import (
     _is_fake_tensor_same,
@@ -24,7 +28,11 @@ from torch._inductor.fx_utils import (
     get_fake,
 )
 from torch._inductor.utils import (
+    _gpu_types,
+    device_need_guard,
     get_device_tflops,
+    get_gpu_type,
+    is_gpu,
     load_template,
     python_subprocess_env,
     sympy_str,
@@ -42,6 +50,7 @@ from torch.testing._internal.common_utils import (
     TestCase,
     xfailIfNoAcceleratorTriton,
 )
+from torch.utils import _triton as triton_utils
 from torch.utils._sympy.functions import Identity
 
 
@@ -1144,6 +1153,150 @@ class TestFakeTensorUpdater(TestCase):
 
         self.assertEqual(tuple(neg_replacement.meta["val"].shape), (4, 5))
         self.assertEqual(tuple(lowered.meta["val"].shape), (2, 3))
+
+
+class _GpuWithStream(DeviceInterface):
+    class Stream:  # overrides the base sentinel Stream -> exposes_streams() True
+        pass
+
+    @staticmethod
+    def is_gpu() -> bool:
+        return True
+
+    @staticmethod
+    def is_available() -> bool:
+        return True
+
+
+class _GpuNoStream(DeviceInterface):
+    # deliberately does NOT define Stream: inherits the base sentinel (mps-like)
+    @staticmethod
+    def is_gpu() -> bool:
+        return True
+
+    @staticmethod
+    def is_available() -> bool:
+        return True
+
+
+class _GpuUnavailable(DeviceInterface):
+    @staticmethod
+    def is_gpu() -> bool:
+        return True
+
+    @staticmethod
+    def is_available() -> bool:
+        return False
+
+
+class _NonGpu(DeviceInterface):
+    # is_gpu() NOT overridden: inherits the base default of False
+    @staticmethod
+    def is_available() -> bool:
+        return True
+
+
+class TestDeviceClassification(TestCase):
+    def setUp(self):
+        super().setUp()
+        self._registered = []
+        get_gpu_type.cache_clear()
+
+    def tearDown(self):
+        for name in self._registered:
+            di.device_interfaces.pop(name, None)
+        get_gpu_type.cache_clear()
+        super().tearDown()
+
+    def _register(self, name, iface):
+        di.register_interface_for_device(name, iface)
+        self._registered.append(name)
+
+    # ---- is_gpu() default on the base class ----
+    def test_base_is_gpu_defaults_false(self):
+        self.assertFalse(DeviceInterface.is_gpu())
+        self.assertFalse(_NonGpu.is_gpu())
+        self.assertTrue(_GpuWithStream.is_gpu())
+
+    # ---- exposes_streams(): sentinel comparison, NOT None ----
+    def test_exposes_streams_true_when_stream_overridden(self):
+        self.assertTrue(_GpuWithStream.exposes_streams())
+
+    def test_exposes_streams_false_via_base_sentinel_not_none(self):
+        # _GpuNoStream.Stream IS the base sentinel (same object, not None).
+        # exposes_streams() must compare against the sentinel, not None;
+        # otherwise this card would be wrongly reported as stream-capable.
+        self.assertIs(_GpuNoStream.Stream, DeviceInterface.Stream)
+        self.assertIsNotNone(_GpuNoStream.Stream)
+        self.assertFalse(_GpuNoStream.exposes_streams())
+
+    # ---- is_gpu(device) ----
+    def test_is_gpu_none_returns_false(self):
+        self.assertFalse(is_gpu(None))
+
+    def test_is_gpu_unregistered_returns_false(self):
+        self.assertFalse(is_gpu("definitely_not_a_device"))
+
+    def test_is_gpu_registered(self):
+        self._register("fakegpu", _GpuWithStream)
+        self._register("fakecpu", _NonGpu)
+        self.assertTrue(is_gpu("fakegpu"))
+        self.assertFalse(is_gpu("fakecpu"))
+
+    # ---- device_need_guard(device) ----
+    def test_device_need_guard(self):
+        self._register("fakegpu", _GpuWithStream)
+        self._register("fakemps", _GpuNoStream)
+        self._register("fakecpu", _NonGpu)
+        self.assertTrue(device_need_guard("fakegpu"))
+        self.assertFalse(device_need_guard("fakemps"))  # gpu but no stream
+        self.assertFalse(device_need_guard("fakecpu"))
+        self.assertFalse(device_need_guard("definitely_not_a_device"))
+
+    # ---- _gpu_types() ----
+    def test_gpu_types_filters_indexed_and_non_gpu(self):
+        self._register("fakegpu", _GpuWithStream)
+        self._register("fakegpu:0", _GpuWithStream)
+        self._register("fakecpu", _NonGpu)
+        result = _gpu_types()
+        self.assertIn("fakegpu", result)
+        self.assertNotIn("fakegpu:0", result)
+        self.assertNotIn("fakecpu", result)
+
+    # ---- get_gpu_type() ----
+    def test_get_gpu_type_single_available(self):
+        self._register("fakegpu", _GpuWithStream)
+        with mock.patch.object(
+            inductor_utils, "_gpu_types", return_value=["fakegpu"]
+        ):
+            get_gpu_type.cache_clear()
+            self.assertEqual(get_gpu_type(), "fakegpu")
+
+    def test_get_gpu_type_none_available_falls_back_to_cuda(self):
+        self._register("fakegpu", _GpuUnavailable)
+        with (
+            mock.patch.object(
+                inductor_utils, "_gpu_types", return_value=["fakegpu"]
+            ),
+            mock.patch("torch.accelerator.current_accelerator", return_value=None),
+        ):
+            get_gpu_type.cache_clear()
+            self.assertEqual(get_gpu_type(), "cuda")
+
+    def test_get_gpu_type_multiple_disambiguates_without_assert(self):
+        # Old code asserted len(avail) <= 1; this test would crash there.
+        # New code uses current_accelerator() to disambiguate instead.
+        self._register("fakegpu", _GpuWithStream)
+        self._register("fakegpu2", _GpuWithStream)
+        acc = types.SimpleNamespace(type="fakegpu2")
+        with (
+            mock.patch.object(
+                inductor_utils, "_gpu_types", return_value=["fakegpu", "fakegpu2"]
+            ),
+            mock.patch("torch.accelerator.current_accelerator", return_value=acc),
+        ):
+            get_gpu_type.cache_clear()
+            self.assertEqual(get_gpu_type(), "fakegpu2")
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -1195,19 +1195,27 @@ class _NonGpu(DeviceInterface):
         return True
 
 
+class _GpuOnlyClassified(DeviceInterface):
+    # Overrides nothing but is_gpu(): a partially-implemented out-of-tree
+    # interface whose other base-class methods (is_available, device_count,
+    # ...) raise NotImplementedError. Registry-driven consumers must treat
+    # it as unavailable rather than propagate the error.
+    @staticmethod
+    def is_gpu() -> bool:
+        return True
+
+
 class TestDeviceClassification(TestCase):
     def setUp(self):
         super().setUp()
         self._registered = []
-        inductor_utils._gpu_types.cache_clear()
         get_gpu_type.cache_clear()
 
     def tearDown(self):
-        # pop() bypasses register_interface_for_device's cache invalidation,
-        # so clear the registry-derived caches manually.
+        # GPU_TYPES is an import-time snapshot and never refreshes, so tests
+        # patch it rather than mutate it; only get_gpu_type() caches at all.
         for name in self._registered:
             di.device_interfaces.pop(name, None)
-        inductor_utils._gpu_types.cache_clear()
         get_gpu_type.cache_clear()
         super().tearDown()
 
@@ -1243,18 +1251,22 @@ class TestDeviceClassification(TestCase):
     def test_is_gpu_registered(self):
         self._register("fakegpu", _GpuWithStream)
         self._register("fakecpu", _NonGpu)
-        self.assertTrue(is_gpu("fakegpu"))
-        self.assertFalse(is_gpu("fakecpu"))
+        # GPU_TYPES snapshots at inductor import; patch it with a fresh scan
+        # so is_gpu() sees the fixtures.
+        with mock.patch.object(inductor_utils, "GPU_TYPES", _gpu_types()):
+            self.assertTrue(is_gpu("fakegpu"))
+            self.assertFalse(is_gpu("fakecpu"))
 
     # ---- device_need_guard(device) ----
     def test_device_need_guard(self):
         self._register("fakegpu", _GpuWithStream)
         self._register("fakemps", _GpuNoStream)
         self._register("fakecpu", _NonGpu)
-        self.assertTrue(device_need_guard("fakegpu"))
-        self.assertFalse(device_need_guard("fakemps"))  # gpu but no stream
-        self.assertFalse(device_need_guard("fakecpu"))
-        self.assertFalse(device_need_guard("definitely_not_a_device"))
+        with mock.patch.object(inductor_utils, "GPU_TYPES", _gpu_types()):
+            self.assertTrue(device_need_guard("fakegpu"))
+            self.assertFalse(device_need_guard("fakemps"))  # gpu but no stream
+            self.assertFalse(device_need_guard("fakecpu"))
+            self.assertFalse(device_need_guard("definitely_not_a_device"))
 
     # ---- _gpu_types() ----
     def test_gpu_types_filters_indexed_and_non_gpu(self):
@@ -1266,34 +1278,59 @@ class TestDeviceClassification(TestCase):
         self.assertNotIn("fakegpu:0", result)
         self.assertNotIn("fakecpu", result)
 
+    def test_gpu_types_is_an_import_time_snapshot(self):
+        # GPU_TYPES is scanned exactly once, when inductor is imported;
+        # registering afterwards is documented as unsupported and must not be
+        # reflected (see register_interface_for_device).
+        first = get_gpu_type()
+        self._register("acc", _GpuWithStream)
+        self.assertIn("acc", _gpu_types())  # a fresh scan does see it
+        self.assertNotIn("acc", inductor_utils.GPU_TYPES)  # the snapshot does not
+        self.assertFalse(is_gpu("acc"))
+        # Clear the cache so this re-evaluates over the frozen snapshot rather
+        # than trivially hitting functools.cache.
+        get_gpu_type.cache_clear()
+        self.assertEqual(get_gpu_type(), first)
+
     def test_gpu_types_consumer_resolves_out_of_tree_via_registry(self):
         # A third-party PrivateUse1 backend (here "acc") registers a GPU-class
         # DeviceInterface but exposes no torch.acc submodule, so GPU_TYPES
         # consumers must resolve through the registry, not getattr(torch, name).
         # Drive the real consumers so reverting their fixes fails this test.
+        import torch._inductor.fx_passes.freezing_patterns as freezing_patterns
         from torch._inductor.fx_passes.freezing_patterns import _addmm_pattern_device
         from torch.testing._internal.inductor_utils import _is_multigpu
 
         self._register("acc", _GpuWithStream)
         self.assertFalse(hasattr(torch, "acc"))
-        with mock.patch.object(inductor_utils, "_gpu_types", return_value=["acc"]):
-            self.assertIn("acc", inductor_utils.GPU_TYPES)
+        self.assertIn("acc", _gpu_types())  # the registry scan resolves it
+        # Each consumer module holds its own binding of the GPU_TYPES snapshot,
+        # so patch the consumer's binding directly.
+        with mock.patch.object(freezing_patterns, "GPU_TYPES", ["acc"]):
             self.assertEqual(_addmm_pattern_device(), "acc")
-            # The fake interface has no device_count: must be False, not raise.
-            self.assertFalse(_is_multigpu("acc"))
+        # The fake interface has no device_count: must be False, not raise.
+        self.assertFalse(_is_multigpu("acc"))
+
+    def test_is_multigpu_tolerates_unimplemented_is_available(self):
+        from torch.testing._internal.inductor_utils import _is_multigpu
+
+        # is_available() itself is unimplemented (base raises): _is_multigpu
+        # feeds HAS_MULTIGPU at module import, so it must return False, not
+        # raise (or importing the test-support module dies).
+        self._register("fakeraw", _GpuOnlyClassified)
+        self.assertFalse(_is_multigpu("fakeraw"))
 
     # ---- get_gpu_type() ----
     def test_get_gpu_type_single_available(self):
         self._register("fakegpu", _GpuWithStream)
-        with mock.patch.object(inductor_utils, "_gpu_types", return_value=["fakegpu"]):
+        with mock.patch.object(inductor_utils, "GPU_TYPES", ["fakegpu"]):
             self.assertEqual(get_gpu_type(), "fakegpu")
 
     def test_get_gpu_type_none_available_falls_back_to_cuda(self):
+        # No available GPU type: falls back to "cuda" before ever consulting
+        # the current accelerator.
         self._register("fakegpu", _GpuUnavailable)
-        with (
-            mock.patch.object(inductor_utils, "_gpu_types", return_value=["fakegpu"]),
-            mock.patch("torch.accelerator.current_accelerator", return_value=None),
-        ):
+        with mock.patch.object(inductor_utils, "GPU_TYPES", ["fakegpu"]):
             self.assertEqual(get_gpu_type(), "cuda")
 
     def test_get_gpu_type_multiple_disambiguates_without_assert(self):
@@ -1303,12 +1340,30 @@ class TestDeviceClassification(TestCase):
         self._register("fakegpu2", _GpuWithStream)
         acc = types.SimpleNamespace(type="fakegpu2")
         with (
-            mock.patch.object(
-                inductor_utils, "_gpu_types", return_value=["fakegpu", "fakegpu2"]
-            ),
+            mock.patch.object(inductor_utils, "GPU_TYPES", ["fakegpu", "fakegpu2"]),
             mock.patch("torch.accelerator.current_accelerator", return_value=acc),
         ):
             self.assertEqual(get_gpu_type(), "fakegpu2")
+
+    def test_get_gpu_type_skips_unimplemented_is_available(self):
+        # A partially-implemented interface must be skipped, not crash the
+        # availability scan.
+        self._register("fakeraw", _GpuOnlyClassified)
+        with mock.patch.object(inductor_utils, "GPU_TYPES", ["fakeraw"]):
+            self.assertEqual(get_gpu_type(), "cuda")
+
+    def test_get_gpu_type_stable_fallback_when_accelerator_disagrees(self):
+        # >1 available and current_accelerator() names none of them: the pick
+        # must be stable (sorted), not positional registry order.
+        self._register("fakegpu", _GpuWithStream)
+        self._register("fakegpu2", _GpuWithStream)
+        acc = types.SimpleNamespace(type="unrelated")
+        with (
+            mock.patch.object(inductor_utils, "GPU_TYPES", ["fakegpu2", "fakegpu"]),
+            mock.patch("torch.accelerator.current_accelerator", return_value=acc),
+        ):
+            with self.assertLogs("torch._inductor.utils", level="WARNING"):
+                self.assertEqual(get_gpu_type(), "fakegpu")
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -1199,11 +1199,15 @@ class TestDeviceClassification(TestCase):
     def setUp(self):
         super().setUp()
         self._registered = []
+        inductor_utils._gpu_types.cache_clear()
         get_gpu_type.cache_clear()
 
     def tearDown(self):
+        # pop() bypasses register_interface_for_device's cache invalidation,
+        # so clear the registry-derived caches manually.
         for name in self._registered:
             di.device_interfaces.pop(name, None)
+        inductor_utils._gpu_types.cache_clear()
         get_gpu_type.cache_clear()
         super().tearDown()
 
@@ -1264,29 +1268,24 @@ class TestDeviceClassification(TestCase):
 
     def test_gpu_types_consumer_resolves_out_of_tree_via_registry(self):
         # A third-party PrivateUse1 backend (here "acc") registers a GPU-class
-        # DeviceInterface but exposes no torch.acc submodule. Consumers that
-        # iterate GPU_TYPES must resolve availability through the interface
-        # registry; getattr(torch, name) would raise AttributeError here.
+        # DeviceInterface but exposes no torch.acc submodule, so GPU_TYPES
+        # consumers must resolve through the registry, not getattr(torch, name).
+        # Drive the real consumers so reverting their fixes fails this test.
+        from torch._inductor.fx_passes.freezing_patterns import _addmm_pattern_device
+        from torch.testing._internal.inductor_utils import _is_multigpu
+
         self._register("acc", _GpuWithStream)
         self.assertFalse(hasattr(torch, "acc"))
         with mock.patch.object(inductor_utils, "_gpu_types", return_value=["acc"]):
             self.assertIn("acc", inductor_utils.GPU_TYPES)
-            # Mirrors freezing_patterns.addmm_patterns_init()'s device pick.
-            device = next(
-                (
-                    gpu
-                    for gpu in inductor_utils.GPU_TYPES
-                    if di.get_interface_for_device(gpu).is_available()
-                ),
-                "cpu",
-            )
-        self.assertEqual(device, "acc")
+            self.assertEqual(_addmm_pattern_device(), "acc")
+            # The fake interface has no device_count: must be False, not raise.
+            self.assertFalse(_is_multigpu("acc"))
 
     # ---- get_gpu_type() ----
     def test_get_gpu_type_single_available(self):
         self._register("fakegpu", _GpuWithStream)
         with mock.patch.object(inductor_utils, "_gpu_types", return_value=["fakegpu"]):
-            get_gpu_type.cache_clear()
             self.assertEqual(get_gpu_type(), "fakegpu")
 
     def test_get_gpu_type_none_available_falls_back_to_cuda(self):
@@ -1295,7 +1294,6 @@ class TestDeviceClassification(TestCase):
             mock.patch.object(inductor_utils, "_gpu_types", return_value=["fakegpu"]),
             mock.patch("torch.accelerator.current_accelerator", return_value=None),
         ):
-            get_gpu_type.cache_clear()
             self.assertEqual(get_gpu_type(), "cuda")
 
     def test_get_gpu_type_multiple_disambiguates_without_assert(self):
@@ -1310,7 +1308,6 @@ class TestDeviceClassification(TestCase):
             ),
             mock.patch("torch.accelerator.current_accelerator", return_value=acc),
         ):
-            get_gpu_type.cache_clear()
             self.assertEqual(get_gpu_type(), "fakegpu2")
 
 

--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -1265,18 +1265,14 @@ class TestDeviceClassification(TestCase):
     # ---- get_gpu_type() ----
     def test_get_gpu_type_single_available(self):
         self._register("fakegpu", _GpuWithStream)
-        with mock.patch.object(
-            inductor_utils, "_gpu_types", return_value=["fakegpu"]
-        ):
+        with mock.patch.object(inductor_utils, "_gpu_types", return_value=["fakegpu"]):
             get_gpu_type.cache_clear()
             self.assertEqual(get_gpu_type(), "fakegpu")
 
     def test_get_gpu_type_none_available_falls_back_to_cuda(self):
         self._register("fakegpu", _GpuUnavailable)
         with (
-            mock.patch.object(
-                inductor_utils, "_gpu_types", return_value=["fakegpu"]
-            ),
+            mock.patch.object(inductor_utils, "_gpu_types", return_value=["fakegpu"]),
             mock.patch("torch.accelerator.current_accelerator", return_value=None),
         ):
             get_gpu_type.cache_clear()

--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -50,7 +50,6 @@ from torch.testing._internal.common_utils import (
     TestCase,
     xfailIfNoAcceleratorTriton,
 )
-from torch.utils import _triton as triton_utils
 from torch.utils._sympy.functions import Identity
 
 

--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -1262,6 +1262,26 @@ class TestDeviceClassification(TestCase):
         self.assertNotIn("fakegpu:0", result)
         self.assertNotIn("fakecpu", result)
 
+    def test_gpu_types_consumer_resolves_out_of_tree_via_registry(self):
+        # A third-party PrivateUse1 backend (here "acc") registers a GPU-class
+        # DeviceInterface but exposes no torch.acc submodule. Consumers that
+        # iterate GPU_TYPES must resolve availability through the interface
+        # registry; getattr(torch, name) would raise AttributeError here.
+        self._register("acc", _GpuWithStream)
+        self.assertFalse(hasattr(torch, "acc"))
+        with mock.patch.object(inductor_utils, "_gpu_types", return_value=["acc"]):
+            self.assertIn("acc", inductor_utils.GPU_TYPES)
+            # Mirrors freezing_patterns.addmm_patterns_init()'s device pick.
+            device = next(
+                (
+                    gpu
+                    for gpu in inductor_utils.GPU_TYPES
+                    if di.get_interface_for_device(gpu).is_available()
+                ),
+                "cpu",
+            )
+        self.assertEqual(device, "acc")
+
     # ---- get_gpu_type() ----
     def test_get_gpu_type_single_available(self):
         self._register("fakegpu", _GpuWithStream)

--- a/test/test_cpp_extensions_mtia_backend.py
+++ b/test/test_cpp_extensions_mtia_backend.py
@@ -52,6 +52,17 @@ class TestCppExtensionMTIABackend(common.TestCase):
     @classmethod
     def setUpClass(cls):
         torch.testing._internal.common_utils.remove_cpp_extensions_build_root()
+        # Regression test for the ordering bug that caused PR #190326 to be
+        # reverted: importing torch._inductor.utils used to eagerly call
+        # torch.mtia.device_count(), which latches an empty MTIAHooksInterface
+        # into a process-lifetime static before this class's real hooks
+        # extension registers below, permanently breaking every MTIA call.
+        # Force that import here so it always precedes the extension load.
+        # (aliased, not "import torch._inductor.utils": a bare import would
+        # bind the local name "torch" and shadow the module-level import
+        # used above.)
+        from torch._inductor import utils as _unused_inductor_utils  # noqa: F401
+
         build_dir = tempfile.mkdtemp()
         # Load the fake device guard impl.
         cls.module = torch.utils.cpp_extension.load(

--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -796,19 +796,8 @@ def get_registered_device_interfaces() -> Iterable[tuple[str, type[DeviceInterfa
 def init_device_reg() -> None:
     global _device_initialized
     register_interface_for_device("cuda", CudaInterface)
-    for i in range(torch.cuda.device_count()):
-        register_interface_for_device(f"cuda:{i}", CudaInterface)
-
     register_interface_for_device("xpu", XpuInterface)
-    for i in range(torch.xpu.device_count()):
-        register_interface_for_device(f"xpu:{i}", XpuInterface)
-
     register_interface_for_device("mtia", MtiaInterface)
-    # MtiaInterface.device_count() reports 0 until an MTIAHooks impl is
-    # registered, so this enumeration cannot latch the fallback hooks.
-    for i in range(MtiaInterface.device_count()):
-        register_interface_for_device(f"mtia:{i}", MtiaInterface)
-
     register_interface_for_device("cpu", CpuInterface)
     register_interface_for_device("mps", MpsInterface)
     register_interface_for_device("tpu", TpuInterface)

--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -210,7 +210,10 @@ class DeviceInterface:
 
         Overriding the Stream slot is the contract for stream support: it is
         what opts a GPU-class device into stream guards (device_need_guard),
-        so stream-capable backends must override it.
+        so stream-capable backends must override it. The override must be a
+        real, instantiable torch.Stream subclass: a placeholder that raises on
+        construction is still reported as stream-capable here and fails later,
+        at guard time.
         """
         return cls.Stream is not DeviceInterface.Stream
 
@@ -437,7 +440,19 @@ class MtiaInterface(DeviceInterface):
 
     current_device = staticmethod(torch.mtia.current_device)
     set_device = staticmethod(torch.mtia.set_device)  # type: ignore[assignment]
-    device_count = staticmethod(torch.mtia.device_count)
+
+    # Unlike torch.cuda/torch.xpu, torch.mtia.device_count() has no
+    # _is_compiled() guard: it goes straight to at::detail::getMTIAHooks(),
+    # which latches a process-lifetime static on first call and would
+    # permanently shadow an MTIAHooks impl that registers later (e.g. a
+    # JIT-built extension loaded in a test's setUpClass). Report 0 until the
+    # registry has one, so no registry-driven consumer can latch the fallback.
+    @staticmethod
+    def device_count() -> int:
+        if not torch.mtia._is_compiled():
+            return 0
+        return torch.mtia.device_count()
+
     stream = staticmethod(torch.mtia.stream)  # type: ignore[assignment]
     current_stream = staticmethod(torch.mtia.current_stream)
     set_stream = staticmethod(torch.mtia.set_stream)  # type: ignore[assignment]
@@ -789,13 +804,10 @@ def init_device_reg() -> None:
         register_interface_for_device(f"xpu:{i}", XpuInterface)
 
     register_interface_for_device("mtia", MtiaInterface)
-    # device_count() latches at::detail::getMTIAHooks() into a process-lifetime
-    # static on first call. Skip it when no MTIAHooks impl is registered yet
-    # (e.g. a JIT-built extension registers later, in a test's setUpClass) so
-    # that later registration is not permanently shadowed by the fallback hooks.
-    if torch.mtia._is_compiled():
-        for i in range(torch.mtia.device_count()):
-            register_interface_for_device(f"mtia:{i}", MtiaInterface)
+    # MtiaInterface.device_count() reports 0 until an MTIAHooks impl is
+    # registered, so this enumeration cannot latch the fallback hooks.
+    for i in range(MtiaInterface.device_count()):
+        register_interface_for_device(f"mtia:{i}", MtiaInterface)
 
     register_interface_for_device("cpu", CpuInterface)
     register_interface_for_device("mps", MpsInterface)

--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -789,8 +789,13 @@ def init_device_reg() -> None:
         register_interface_for_device(f"xpu:{i}", XpuInterface)
 
     register_interface_for_device("mtia", MtiaInterface)
-    for i in range(torch.mtia.device_count()):
-        register_interface_for_device(f"mtia:{i}", MtiaInterface)
+    # device_count() latches at::detail::getMTIAHooks() into a process-lifetime
+    # static on first call. Skip it when no MTIAHooks impl is registered yet
+    # (e.g. a JIT-built extension registers later, in a test's setUpClass) so
+    # that later registration is not permanently shadowed by the fallback hooks.
+    if torch.mtia._is_compiled():
+        for i in range(torch.mtia.device_count()):
+            register_interface_for_device(f"mtia:{i}", MtiaInterface)
 
     register_interface_for_device("cpu", CpuInterface)
     register_interface_for_device("mps", MpsInterface)

--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -193,6 +193,27 @@ class DeviceInterface:
         """
         return False
 
+    @staticmethod
+    def is_gpu() -> bool:
+        """
+        Returns True if Inductor should treat this device as a GPU-class
+        accelerator (device guards, GPU codegen/fusion, cudagraph eligibility).
+        Defaults to False so unknown backends stay conservative until they opt in.
+        """
+        return False
+
+    @classmethod
+    def exposes_streams(cls) -> bool:
+        """
+        True when a subclass provides its own Stream. The base Stream is a
+        raising sentinel, so compare against it rather than None.
+
+        Overriding the Stream slot is the contract for stream support: it is
+        what opts a GPU-class device into stream guards (device_need_guard),
+        so stream-capable backends must override it.
+        """
+        return cls.Stream is not DeviceInterface.Stream
+
     @classmethod
     def get_multi_processor_count(cls, device: torch.types.Device = None) -> int:
         """Return the number of compute units, used for occupancy /
@@ -266,6 +287,10 @@ class CudaInterface(DeviceInterface):
     # make sure Event and Stream are implemented and inherited from the torch.Event and torch.Stream
     Event = torch.cuda.Event  # type: ignore[assignment]
     Stream = torch.cuda.Stream  # type: ignore[assignment]
+
+    @staticmethod
+    def is_gpu() -> bool:
+        return True
 
     # pyrefly: ignore [bad-override]
     class Worker:
@@ -371,6 +396,10 @@ class MtiaInterface(DeviceInterface):
     Event = torch.mtia.Event  # type: ignore[assignment]
     Stream = torch.mtia.Stream  # type: ignore[assignment]
 
+    @staticmethod
+    def is_gpu() -> bool:
+        return True
+
     # pyrefly: ignore [bad-override]
     class Worker:
         @staticmethod
@@ -465,6 +494,10 @@ class XpuInterface(DeviceInterface):
     device = torch.xpu.device  # type: ignore[assignment]
     Event = torch.xpu.Event  # type: ignore[assignment]
     Stream = torch.xpu.Stream  # type: ignore[assignment]
+
+    @staticmethod
+    def is_gpu() -> bool:
+        return True
 
     # pyrefly: ignore [bad-override]
     class Worker:
@@ -616,6 +649,10 @@ class CpuInterface(DeviceInterface):
 
 class MpsInterface(DeviceInterface):
     @staticmethod
+    def is_gpu() -> bool:
+        return True
+
+    @staticmethod
     def is_bf16_supported(including_emulation: bool = False) -> bool:
         return True
 
@@ -705,6 +742,18 @@ _device_initialized = False
 def register_interface_for_device(
     device: str | torch.device, device_interface: type[DeviceInterface]
 ) -> None:
+    """Register a DeviceInterface for a device type.
+
+    Registration must happen before ``torch._inductor.utils`` is imported:
+    the registry-derived GPU classification (GPU_TYPES / is_gpu() /
+    get_gpu_type()) is scanned exactly once, at that import. In-tree backends
+    satisfy this by construction (init_device_reg() runs inside the scan
+    itself). Out-of-tree backends register at package import, either
+    autoloaded during ``import torch`` (TORCH_DEVICE_BACKEND_AUTOLOAD) or via
+    an explicit ``import torch_npu``-style import, both of which precede any
+    import of inductor. Registering later is not supported and will not be
+    reflected in the snapshot.
+    """
     if isinstance(device, torch.device):
         device = device.type
     device_interfaces[device] = device_interface

--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -157,6 +157,21 @@ class DeviceInterface:
         """
         return False
 
+    @staticmethod
+    def is_gpu() -> bool:
+        """
+        Returns True if Inductor should treat this device as a GPU-class
+        accelerator (device guards, GPU codegen/fusion, cudagraph eligibility).
+        Defaults to False so unknown backends stay conservative until they opt in.
+        """
+        return False
+
+    @classmethod
+    def exposes_streams(cls) -> bool:
+        # True when a subclass provides its own Stream. The base Stream is a
+        # sentinel that raises, so compare against it rather than None.
+        return cls.Stream is not DeviceInterface.Stream
+
     @classmethod
     def raise_if_triton_unavailable(cls, device: torch.types.Device = None) -> None:
         """
@@ -205,6 +220,10 @@ class CudaInterface(DeviceInterface):
     # make sure Event and Stream are implemented and inherited from the torch.Event and torch.Stream
     Event = torch.cuda.Event  # type: ignore[assignment]
     Stream = torch.cuda.Stream  # type: ignore[assignment]
+
+    @staticmethod
+    def is_gpu() -> bool:
+        return True
 
     # pyrefly: ignore [bad-override]
     class Worker:
@@ -305,6 +324,10 @@ class MtiaInterface(DeviceInterface):
     Event = torch.mtia.Event  # type: ignore[assignment]
     Stream = torch.mtia.Stream  # type: ignore[assignment]
 
+    @staticmethod
+    def is_gpu() -> bool:
+        return True
+
     # pyrefly: ignore [bad-override]
     class Worker:
         @staticmethod
@@ -389,6 +412,10 @@ class XpuInterface(DeviceInterface):
     device = torch.xpu.device  # type: ignore[assignment]
     Event = torch.xpu.Event  # type: ignore[assignment]
     Stream = torch.xpu.Stream  # type: ignore[assignment]
+
+    @staticmethod
+    def is_gpu() -> bool:
+        return True
 
     # pyrefly: ignore [bad-override]
     class Worker:
@@ -530,6 +557,10 @@ class CpuInterface(DeviceInterface):
 
 
 class MpsInterface(DeviceInterface):
+    @staticmethod
+    def is_gpu() -> bool:
+        return True
+
     @staticmethod
     def is_bf16_supported(including_emulation: bool = False) -> bool:
         return True

--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -16,6 +16,7 @@ specialized implementations for each hardware backend's unique features.
 """
 
 import inspect
+import sys
 import time
 from collections import namedtuple
 from collections.abc import Callable, Iterable
@@ -168,8 +169,14 @@ class DeviceInterface:
 
     @classmethod
     def exposes_streams(cls) -> bool:
-        # True when a subclass provides its own Stream. The base Stream is a
-        # sentinel that raises, so compare against it rather than None.
+        """
+        True when a subclass provides its own Stream. The base Stream is a
+        raising sentinel, so compare against it rather than None.
+
+        Overriding the Stream slot is the contract for stream support: it is
+        what opts a GPU-class device into stream guards (device_need_guard),
+        so stream-capable backends must override it.
+        """
         return cls.Stream is not DeviceInterface.Stream
 
     @classmethod
@@ -654,6 +661,14 @@ def register_interface_for_device(
     if isinstance(device, torch.device):
         device = device.type
     device_interfaces[device] = device_interface
+    # Late registration must refresh inductor's registry-derived GPU-type
+    # caches. sys.modules avoids importing inductor from dynamo.
+    inductor_utils = sys.modules.get("torch._inductor.utils")
+    if inductor_utils is not None:
+        for cached in ("_gpu_types", "get_gpu_type"):
+            fn = getattr(inductor_utils, cached, None)
+            if fn is not None:
+                fn.cache_clear()
 
 
 def get_interface_for_device(device: str | torch.device) -> type[DeviceInterface]:

--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -16,7 +16,6 @@ specialized implementations for each hardware backend's unique features.
 """
 
 import inspect
-import sys
 import time
 from collections import namedtuple
 from collections.abc import Callable, Iterable
@@ -658,17 +657,21 @@ _device_initialized = False
 def register_interface_for_device(
     device: str | torch.device, device_interface: type[DeviceInterface]
 ) -> None:
+    """Register a DeviceInterface for a device type.
+
+    Registration must happen before ``torch._inductor.utils`` is imported:
+    the registry-derived GPU classification (GPU_TYPES / is_gpu() /
+    get_gpu_type()) is scanned exactly once, at that import. In-tree backends
+    satisfy this by construction (init_device_reg() runs inside the scan
+    itself). Out-of-tree backends register at package import, either
+    autoloaded during ``import torch`` (TORCH_DEVICE_BACKEND_AUTOLOAD) or via
+    an explicit ``import torch_npu``-style import, both of which precede any
+    import of inductor. Registering later is not supported and will not be
+    reflected in the snapshot.
+    """
     if isinstance(device, torch.device):
         device = device.type
     device_interfaces[device] = device_interface
-    # Late registration must refresh inductor's registry-derived GPU-type
-    # caches. sys.modules avoids importing inductor from dynamo.
-    inductor_utils = sys.modules.get("torch._inductor.utils")
-    if inductor_utils is not None:
-        for cached in ("_gpu_types", "get_gpu_type"):
-            fn = getattr(inductor_utils, cached, None)
-            if fn is not None:
-                fn.cache_clear()
 
 
 def get_interface_for_device(device: str | torch.device) -> type[DeviceInterface]:

--- a/torch/_inductor/fx_passes/freezing_patterns.py
+++ b/torch/_inductor/fx_passes/freezing_patterns.py
@@ -3,7 +3,7 @@ import functools
 
 import torch
 from torch._inductor.compile_fx import fake_tensor_prop
-from torch._inductor.utils import GPU_TYPES
+from torch._inductor.utils import _device_is_available, GPU_TYPES
 
 from ..._dynamo.utils import counters
 from .. import config
@@ -121,15 +121,20 @@ def register_binary_folding_pattern(pattern, extra_check=_return_true):
     )
 
 
+def _addmm_pattern_device() -> str:
+    # Resolve availability through the DeviceInterface registry rather than
+    # getattr(torch, gpu): GPU_TYPES may include out-of-tree PrivateUse1
+    # backends that register an interface but expose no torch.<name> module.
+    return next((gpu for gpu in GPU_TYPES if _device_is_available(gpu)), "cpu")
+
+
 @functools.cache
 def addmm_patterns_init():
     """
     addmm related patterns.
     To avoid duplication, also includes int8 WoQ GEMM pattern without bias.
     """
-    device = next(
-        (gpu for gpu in GPU_TYPES if getattr(torch, gpu).is_available()), "cpu"
-    )
+    device = _addmm_pattern_device()
     val = functools.partial(torch.empty, (10, 10), device=device, requires_grad=False)
     scale = functools.partial(torch.empty, (10,), device=device, requires_grad=False)
 

--- a/torch/_inductor/fx_passes/freezing_patterns.py
+++ b/torch/_inductor/fx_passes/freezing_patterns.py
@@ -121,18 +121,25 @@ def register_binary_folding_pattern(pattern, extra_check=_return_true):
     )
 
 
+def _addmm_pattern_device() -> str:
+    from torch._dynamo.device_interface import get_interface_for_device
+
+    # Resolve availability through the DeviceInterface registry rather than
+    # getattr(torch, gpu): GPU_TYPES may include out-of-tree PrivateUse1
+    # backends that register an interface but expose no torch.<name> module.
+    return next(
+        (gpu for gpu in GPU_TYPES if get_interface_for_device(gpu).is_available()),
+        "cpu",
+    )
+
+
 @functools.cache
 def addmm_patterns_init():
     """
     addmm related patterns.
     To avoid duplication, also includes int8 WoQ GEMM pattern without bias.
     """
-    from torch._dynamo.device_interface import get_interface_for_device
-
-    device = next(
-        (gpu for gpu in GPU_TYPES if get_interface_for_device(gpu).is_available()),
-        "cpu",
-    )
+    device = _addmm_pattern_device()
     val = functools.partial(torch.empty, (10, 10), device=device, requires_grad=False)
     scale = functools.partial(torch.empty, (10,), device=device, requires_grad=False)
 

--- a/torch/_inductor/fx_passes/freezing_patterns.py
+++ b/torch/_inductor/fx_passes/freezing_patterns.py
@@ -127,8 +127,11 @@ def addmm_patterns_init():
     addmm related patterns.
     To avoid duplication, also includes int8 WoQ GEMM pattern without bias.
     """
+    from torch._dynamo.device_interface import get_interface_for_device
+
     device = next(
-        (gpu for gpu in GPU_TYPES if getattr(torch, gpu).is_available()), "cpu"
+        (gpu for gpu in GPU_TYPES if get_interface_for_device(gpu).is_available()),
+        "cpu",
     )
     val = functools.partial(torch.empty, (10, 10), device=device, requires_grad=False)
     scale = functools.partial(torch.empty, (10,), device=device, requires_grad=False)

--- a/torch/_inductor/fx_passes/freezing_patterns.py
+++ b/torch/_inductor/fx_passes/freezing_patterns.py
@@ -3,7 +3,7 @@ import functools
 
 import torch
 from torch._inductor.compile_fx import fake_tensor_prop
-from torch._inductor.utils import GPU_TYPES
+from torch._inductor.utils import _device_is_available, GPU_TYPES
 
 from ..._dynamo.utils import counters
 from .. import config
@@ -122,15 +122,10 @@ def register_binary_folding_pattern(pattern, extra_check=_return_true):
 
 
 def _addmm_pattern_device() -> str:
-    from torch._dynamo.device_interface import get_interface_for_device
-
     # Resolve availability through the DeviceInterface registry rather than
     # getattr(torch, gpu): GPU_TYPES may include out-of-tree PrivateUse1
     # backends that register an interface but expose no torch.<name> module.
-    return next(
-        (gpu for gpu in GPU_TYPES if get_interface_for_device(gpu).is_available()),
-        "cpu",
-    )
+    return next((gpu for gpu in GPU_TYPES if _device_is_available(gpu)), "cpu")
 
 
 @functools.cache

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -108,21 +108,67 @@ if TYPE_CHECKING:
     from .scheduler import BaseSchedulerNode, SchedulerBuffer
 
 
-GPU_TYPES = ["cuda", "mps", "xpu", "mtia"]
 T = TypeVar("T")
 
 
-# defines here before import torch._dynamo is for avoiding circular import
-# when get_gpu_type is imported from dynamo
+# Defined before the torch._dynamo import below to avoid a circular import
+# when pulled in from dynamo; hence the lazy registry imports in the bodies.
+def _gpu_types() -> list[str]:
+    """Freshly scan the DeviceInterface registry for GPU-class device types,
+    skipping indexed aliases such as "cuda:0". Production code should use the
+    GPU_TYPES snapshot below; this scan exists to compute it and for tests.
+    """
+    from torch._dynamo.device_interface import get_registered_device_interfaces
+
+    return [
+        name
+        for name, device_interface in get_registered_device_interfaces()
+        if ":" not in name and device_interface.is_gpu()
+    ]
+
+
+def _device_is_available(device: str) -> bool:
+    """Whether a registered DeviceInterface reports the device available.
+
+    Tolerates partially-implemented out-of-tree interfaces: the base-class
+    is_available() raises NotImplementedError, which must not propagate out
+    of registry-driven consumers (some run at module import time). Device
+    types with no registered interface are likewise treated as unavailable.
+    """
+    from torch._dynamo.device_interface import get_interface_for_device
+
+    try:
+        return get_interface_for_device(device).is_available()
+    except NotImplementedError:
+        return False
+
+
 @functools.cache
 def get_gpu_type() -> str:
-    avail_gpus = [x for x in GPU_TYPES if getattr(torch, x).is_available()]
-    if not len(avail_gpus) <= 1:
-        raise AssertionError(
-            f"Expected at most 1 available GPU type, got {len(avail_gpus)}: {avail_gpus}"
-        )
-    gpu_type = "cuda" if len(avail_gpus) == 0 else avail_gpus.pop()
-    return gpu_type
+    avail_gpus = [gpu for gpu in GPU_TYPES if _device_is_available(gpu)]
+
+    if not avail_gpus:
+        return "cuda"
+    if len(avail_gpus) == 1:
+        return avail_gpus[0]
+
+    # >1 GPU type available: disambiguate via the current accelerator.
+    acc = torch.accelerator.current_accelerator()
+    if acc is not None and acc.type in avail_gpus:
+        return acc.type
+    # Registry order is insertion order and may differ between processes
+    # (out-of-tree backends register at import time), so fall back to a
+    # stable choice rather than a positional one.
+    chosen = "cuda" if "cuda" in avail_gpus else sorted(avail_gpus)[0]
+    log.warning(
+        "Multiple GPU types %s are available but the current accelerator (%s) "
+        "is not one of them; defaulting to %r. Codegen may target the wrong "
+        "device.",
+        avail_gpus,
+        acc,
+        chosen,
+    )
+    return chosen
 
 
 from torch._dynamo.device_interface import get_interface_for_device
@@ -149,6 +195,15 @@ from .runtime.runtime_utils import ceildiv as runtime_ceildiv
 _IS_WINDOWS = sys.platform == "win32"
 
 log = logging.getLogger(__name__)
+
+# Scanned exactly once, when this module is imported. Safe because both
+# registration paths precede any import of inductor: autoloaded out-of-tree
+# backends register during `import torch` (TORCH_DEVICE_BACKEND_AUTOLOAD, end
+# of torch/__init__.py) and explicit ones at their package import (e.g.
+# `import torch_npu`), while in-tree backends are registered by
+# init_device_reg() inside the scan itself. Registering after this module is
+# imported is not supported (see register_interface_for_device).
+GPU_TYPES: list[str] = _gpu_types()
 
 
 _DO_BENCH_PROFILE_EVENT_NAME = "inductor_do_bench_using_profiling"
@@ -3841,7 +3896,11 @@ def is_triton_fp8_dtype_supported(
 
 
 def device_need_guard(device: str) -> bool:
-    return device != "mps" and is_gpu(device)  # TODO: MPS does not expose streams now
+    if not is_gpu(device):
+        return False
+    # A GPU-class device still only needs stream guards if it exposes streams;
+    # e.g. MPS is a GPU but does not, so it must be excluded here.
+    return get_interface_for_device(device).exposes_streams()
 
 
 def needs_fallback_due_to_atomic_add_limitations(dtype: torch.dtype) -> bool:

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -120,16 +120,11 @@ def _gpu_types() -> list[str]:
     """
     from torch._dynamo.device_interface import get_registered_device_interfaces
 
-    gpu_types = []
-    for name, device_interface in get_registered_device_interfaces():
-        if ":" in name:
-            continue
-        try:
-            if device_interface.is_gpu():
-                gpu_types.append(name)
-        except NotImplementedError:
-            continue
-    return gpu_types
+    return [
+        name
+        for name, device_interface in get_registered_device_interfaces()
+        if ":" not in name and device_interface.is_gpu()
+    ]
 
 
 class _GpuTypes:
@@ -145,12 +140,6 @@ class _GpuTypes:
 
     def __contains__(self, item: object) -> bool:
         return item in _gpu_types()
-
-    def __len__(self) -> int:
-        return len(_gpu_types())
-
-    def __getitem__(self, index: Any) -> Any:
-        return _gpu_types()[index]
 
     def __repr__(self) -> str:
         return repr(_gpu_types())

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -104,21 +104,85 @@ if TYPE_CHECKING:
     from .scheduler import BaseSchedulerNode, SchedulerBuffer
 
 
-GPU_TYPES = ["cuda", "mps", "xpu", "mtia"]
 T = TypeVar("T")
 
 
-# defines here before import torch._dynamo is for avoiding circular import
-# when get_gpu_type is imported from dynamo
+# _gpu_types()/get_gpu_type()/GPU_TYPES are defined before the torch._dynamo
+# import below to avoid a circular import when they are pulled in from dynamo;
+# hence the lazy imports of the device-interface registry inside the bodies.
+def _gpu_types() -> list[str]:
+    """GPU-class device types, derived from the registered DeviceInterfaces.
+
+    This is intentionally not a hardcoded list: any backend (including
+    out-of-tree ones such as NPU) that registers a DeviceInterface whose
+    is_gpu() returns True is picked up automatically. Indexed aliases such as
+    "cuda:0" are skipped so only base device types are returned.
+    """
+    from torch._dynamo.device_interface import get_registered_device_interfaces
+
+    gpu_types = []
+    for name, device_interface in get_registered_device_interfaces():
+        if ":" in name:
+            continue
+        try:
+            if device_interface.is_gpu():
+                gpu_types.append(name)
+        except NotImplementedError:
+            continue
+    return gpu_types
+
+
+class _GpuTypes:
+    """Live, registry-derived view of the GPU-class device types.
+
+    Behaves like the old GPU_TYPES list for iteration and membership, but
+    reflects backends that register their DeviceInterface late (e.g. NPU),
+    instead of freezing a hardcoded list at import time.
+    """
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(_gpu_types())
+
+    def __contains__(self, item: object) -> bool:
+        return item in _gpu_types()
+
+    def __len__(self) -> int:
+        return len(_gpu_types())
+
+    def __getitem__(self, index: Any) -> Any:
+        return _gpu_types()[index]
+
+    def __repr__(self) -> str:
+        return repr(_gpu_types())
+
+
+GPU_TYPES = _GpuTypes()
+
+
 @functools.cache
 def get_gpu_type() -> str:
-    avail_gpus = [x for x in GPU_TYPES if getattr(torch, x).is_available()]
-    if not len(avail_gpus) <= 1:
-        raise AssertionError(
-            f"Expected at most 1 available GPU type, got {len(avail_gpus)}: {avail_gpus}"
-        )
-    gpu_type = "cuda" if len(avail_gpus) == 0 else avail_gpus.pop()
-    return gpu_type
+    from torch._dynamo.device_interface import get_interface_for_device
+
+    avail_gpus = []
+    for gpu_type in _gpu_types():
+        try:
+            if get_interface_for_device(gpu_type).is_available():
+                avail_gpus.append(gpu_type)
+        except NotImplementedError:
+            continue
+
+    if not avail_gpus:
+        return "cuda"
+    if len(avail_gpus) == 1:
+        return avail_gpus[0]
+
+    # More than one GPU type is available (e.g. cuda + an out-of-tree backend).
+    # Disambiguate via the process-wide current accelerator rather than
+    # asserting there can only be one.
+    acc = torch.accelerator.current_accelerator()
+    if acc is not None and acc.type in avail_gpus:
+        return acc.type
+    return avail_gpus[0]
 
 
 from torch._dynamo.device_interface import get_interface_for_device
@@ -3516,7 +3580,13 @@ def is_triton_fp8_dtype_supported(
 
 
 def device_need_guard(device: str) -> bool:
-    return device != "mps" and is_gpu(device)  # TODO: MPS does not expose streams now
+    if not is_gpu(device):
+        return False
+    # A GPU-class device still only needs stream guards if it exposes streams;
+    # e.g. MPS is a GPU but does not, so it must be excluded here.
+    from torch._dynamo.device_interface import get_interface_for_device
+
+    return get_interface_for_device(device).exposes_streams()
 
 
 def needs_fallback_due_to_atomic_add_limitations(dtype: torch.dtype) -> bool:

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -107,16 +107,14 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 
-# _gpu_types()/get_gpu_type()/GPU_TYPES are defined before the torch._dynamo
-# import below to avoid a circular import when they are pulled in from dynamo;
-# hence the lazy imports of the device-interface registry inside the bodies.
+# Defined before the torch._dynamo import below to avoid a circular import
+# when pulled in from dynamo; hence the lazy registry imports in the bodies.
+@functools.cache
 def _gpu_types() -> list[str]:
-    """GPU-class device types, derived from the registered DeviceInterfaces.
-
-    This is intentionally not a hardcoded list: any backend (including
-    out-of-tree ones such as NPU) that registers a DeviceInterface whose
-    is_gpu() returns True is picked up automatically. Indexed aliases such as
-    "cuda:0" are skipped so only base device types are returned.
+    """GPU-class device types from the registered DeviceInterfaces, skipping
+    indexed aliases such as "cuda:0". Memoized so the hot is_gpu() path is
+    constant-time; register_interface_for_device() invalidates it when a
+    backend registers late.
     """
     from torch._dynamo.device_interface import get_registered_device_interfaces
 
@@ -128,18 +126,21 @@ def _gpu_types() -> list[str]:
 
 
 class _GpuTypes:
-    """Live, registry-derived view of the GPU-class device types.
-
-    Behaves like the old GPU_TYPES list for iteration and membership, but
-    reflects backends that register their DeviceInterface late (e.g. NPU),
-    instead of freezing a hardcoded list at import time.
-    """
+    """Registry-derived, list-like replacement for the old hardcoded GPU_TYPES."""
 
     def __iter__(self) -> Iterator[str]:
         return iter(_gpu_types())
 
     def __contains__(self, item: object) -> bool:
         return item in _gpu_types()
+
+    def __len__(self) -> int:
+        return len(_gpu_types())
+
+    def __eq__(self, other: object) -> bool:
+        return _gpu_types() == other
+
+    __hash__ = None  # type: ignore[assignment]
 
     def __repr__(self) -> str:
         return repr(_gpu_types())
@@ -165,13 +166,14 @@ def get_gpu_type() -> str:
     if len(avail_gpus) == 1:
         return avail_gpus[0]
 
-    # More than one GPU type is available (e.g. cuda + an out-of-tree backend).
-    # Disambiguate via the process-wide current accelerator rather than
-    # asserting there can only be one.
+    # >1 GPU type available: disambiguate via the current accelerator.
     acc = torch.accelerator.current_accelerator()
     if acc is not None and acc.type in avail_gpus:
         return acc.type
-    return avail_gpus[0]
+    # Registry order is insertion order and may differ between processes
+    # (out-of-tree backends register at import time), so fall back to a
+    # stable choice rather than a positional one.
+    return "cuda" if "cuda" in avail_gpus else sorted(avail_gpus)[0]
 
 
 from torch._dynamo.device_interface import get_interface_for_device

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -109,12 +109,10 @@ T = TypeVar("T")
 
 # Defined before the torch._dynamo import below to avoid a circular import
 # when pulled in from dynamo; hence the lazy registry imports in the bodies.
-@functools.cache
 def _gpu_types() -> list[str]:
-    """GPU-class device types from the registered DeviceInterfaces, skipping
-    indexed aliases such as "cuda:0". Memoized so the hot is_gpu() path is
-    constant-time; register_interface_for_device() invalidates it when a
-    backend registers late.
+    """Freshly scan the DeviceInterface registry for GPU-class device types,
+    skipping indexed aliases such as "cuda:0". Production code should use the
+    GPU_TYPES snapshot below; this scan exists to compute it and for tests.
     """
     from torch._dynamo.device_interface import get_registered_device_interfaces
 
@@ -125,41 +123,25 @@ def _gpu_types() -> list[str]:
     ]
 
 
-class _GpuTypes:
-    """Registry-derived, list-like replacement for the old hardcoded GPU_TYPES."""
+def _device_is_available(device: str) -> bool:
+    """Whether a registered DeviceInterface reports the device available.
 
-    def __iter__(self) -> Iterator[str]:
-        return iter(_gpu_types())
+    Tolerates partially-implemented out-of-tree interfaces: the base-class
+    is_available() raises NotImplementedError, which must not propagate out
+    of registry-driven consumers (some run at module import time). Device
+    types with no registered interface are likewise treated as unavailable.
+    """
+    from torch._dynamo.device_interface import get_interface_for_device
 
-    def __contains__(self, item: object) -> bool:
-        return item in _gpu_types()
-
-    def __len__(self) -> int:
-        return len(_gpu_types())
-
-    def __eq__(self, other: object) -> bool:
-        return _gpu_types() == other
-
-    __hash__ = None  # type: ignore[assignment]
-
-    def __repr__(self) -> str:
-        return repr(_gpu_types())
-
-
-GPU_TYPES = _GpuTypes()
+    try:
+        return get_interface_for_device(device).is_available()
+    except NotImplementedError:
+        return False
 
 
 @functools.cache
 def get_gpu_type() -> str:
-    from torch._dynamo.device_interface import get_interface_for_device
-
-    avail_gpus = []
-    for gpu_type in _gpu_types():
-        try:
-            if get_interface_for_device(gpu_type).is_available():
-                avail_gpus.append(gpu_type)
-        except NotImplementedError:
-            continue
+    avail_gpus = [gpu for gpu in GPU_TYPES if _device_is_available(gpu)]
 
     if not avail_gpus:
         return "cuda"
@@ -173,7 +155,16 @@ def get_gpu_type() -> str:
     # Registry order is insertion order and may differ between processes
     # (out-of-tree backends register at import time), so fall back to a
     # stable choice rather than a positional one.
-    return "cuda" if "cuda" in avail_gpus else sorted(avail_gpus)[0]
+    chosen = "cuda" if "cuda" in avail_gpus else sorted(avail_gpus)[0]
+    log.warning(
+        "Multiple GPU types %s are available but the current accelerator (%s) "
+        "is not one of them; defaulting to %r. Codegen may target the wrong "
+        "device.",
+        avail_gpus,
+        acc,
+        chosen,
+    )
+    return chosen
 
 
 from torch._dynamo.device_interface import get_interface_for_device
@@ -200,6 +191,15 @@ from .runtime.runtime_utils import ceildiv as runtime_ceildiv
 _IS_WINDOWS = sys.platform == "win32"
 
 log = logging.getLogger(__name__)
+
+# Scanned exactly once, when this module is imported. Safe because both
+# registration paths precede any import of inductor: autoloaded out-of-tree
+# backends register during `import torch` (TORCH_DEVICE_BACKEND_AUTOLOAD, end
+# of torch/__init__.py) and explicit ones at their package import (e.g.
+# `import torch_npu`), while in-tree backends are registered by
+# init_device_reg() inside the scan itself. Registering after this module is
+# imported is not supported (see register_interface_for_device).
+GPU_TYPES: list[str] = _gpu_types()
 
 
 _DO_BENCH_PROFILE_EVENT_NAME = "inductor_do_bench_using_profiling"
@@ -3575,8 +3575,6 @@ def device_need_guard(device: str) -> bool:
         return False
     # A GPU-class device still only needs stream guards if it exposes streams;
     # e.g. MPS is a GPU but does not, so it must be excluded here.
-    from torch._dynamo.device_interface import get_interface_for_device
-
     return get_interface_for_device(device).exposes_streams()
 
 

--- a/torch/testing/_internal/inductor_utils.py
+++ b/torch/testing/_internal/inductor_utils.py
@@ -12,8 +12,10 @@ from subprocess import CalledProcessError
 import torch
 import torch._inductor.config as config
 
+from torch._dynamo.device_interface import get_interface_for_device
 from torch._inductor import compile_fx  # noqa: F401
 from torch._inductor.utils import (
+    _device_is_available,
     get_gpu_shared_memory,
     get_gpu_type,
     GPU_TYPES,
@@ -82,10 +84,21 @@ HAS_GPU_AND_TRITON = HAS_GPU
 
 GPU_TYPE = get_gpu_type()
 
-HAS_MULTIGPU = any(
-    getattr(torch, gpu).is_available() and getattr(torch, gpu).device_count() >= 2
-    for gpu in GPU_TYPES
-)
+
+def _is_multigpu(gpu: str) -> bool:
+    # Resolve through the DeviceInterface registry: GPU_TYPES may include
+    # out-of-tree backends with no torch.<gpu> module (getattr would raise)
+    # or with partially-implemented interfaces (base methods raise
+    # NotImplementedError).
+    if not _device_is_available(gpu):
+        return False
+    try:
+        return get_interface_for_device(gpu).device_count() >= 2
+    except NotImplementedError:
+        return False
+
+
+HAS_MULTIGPU = any(_is_multigpu(gpu) for gpu in GPU_TYPES)
 
 _desired_test_bases = get_desired_device_type_test_bases(allow_xpu=True)
 RUN_GPU = HAS_GPU and any(

--- a/torch/testing/_internal/inductor_utils.py
+++ b/torch/testing/_internal/inductor_utils.py
@@ -13,9 +13,11 @@ from subprocess import CalledProcessError
 
 import torch
 import torch._inductor.config as config
+
 from torch._dynamo.device_interface import get_interface_for_device
 from torch._inductor import compile_fx  # noqa: F401
 from torch._inductor.utils import (
+    _device_is_available,
     get_gpu_shared_memory,
     get_gpu_type,
     GPU_TYPES,
@@ -82,12 +84,13 @@ GPU_TYPE = get_gpu_type()
 
 def _is_multigpu(gpu: str) -> bool:
     # Resolve through the DeviceInterface registry: GPU_TYPES may include
-    # out-of-tree backends with no torch.<gpu> module (getattr would raise).
-    interface = get_interface_for_device(gpu)
-    if not interface.is_available():
+    # out-of-tree backends with no torch.<gpu> module (getattr would raise)
+    # or with partially-implemented interfaces (base methods raise
+    # NotImplementedError).
+    if not _device_is_available(gpu):
         return False
     try:
-        return interface.device_count() >= 2
+        return get_interface_for_device(gpu).device_count() >= 2
     except NotImplementedError:
         return False
 

--- a/torch/testing/_internal/inductor_utils.py
+++ b/torch/testing/_internal/inductor_utils.py
@@ -7,11 +7,13 @@ import os
 import re
 import sys
 import unittest
+
+from collections.abc import Callable
 from subprocess import CalledProcessError
 
 import torch
 import torch._inductor.config as config
-
+from torch._dynamo.device_interface import get_interface_for_device
 from torch._inductor import compile_fx  # noqa: F401
 from torch._inductor.utils import (
     get_gpu_shared_memory,
@@ -21,21 +23,14 @@ from torch._inductor.utils import (
     is_gpu,
     OrderedSet,
 )
-from torch.utils._helion import has_helion
-from torch.utils._pallas import has_pallas_package, has_tpu_pallas
-from torch.utils._triton import has_triton
-from torch.utils._config_module import ConfigModule
 from torch.testing._internal.common_device_type import (
     get_desired_device_type_test_bases,
 )
-from torch.testing._internal.common_utils import (
-    IS_CI,
-    IS_WINDOWS,
-    LazyVal,
-    TestCase,
-)
-
-from collections.abc import Callable
+from torch.testing._internal.common_utils import IS_CI, IS_WINDOWS, LazyVal, TestCase
+from torch.utils._config_module import ConfigModule
+from torch.utils._helion import has_helion
+from torch.utils._pallas import has_pallas_package, has_tpu_pallas
+from torch.utils._triton import has_triton
 
 log: logging.Logger = logging.getLogger(__name__)
 
@@ -84,10 +79,20 @@ HAS_GPU_AND_TRITON = HAS_GPU
 
 GPU_TYPE = get_gpu_type()
 
-HAS_MULTIGPU = any(
-    getattr(torch, gpu).is_available() and getattr(torch, gpu).device_count() >= 2
-    for gpu in GPU_TYPES
-)
+
+def _is_multigpu(gpu: str) -> bool:
+    # Resolve through the DeviceInterface registry: GPU_TYPES may include
+    # out-of-tree backends with no torch.<gpu> module (getattr would raise).
+    interface = get_interface_for_device(gpu)
+    if not interface.is_available():
+        return False
+    try:
+        return interface.device_count() >= 2
+    except NotImplementedError:
+        return False
+
+
+HAS_MULTIGPU = any(_is_multigpu(gpu) for gpu in GPU_TYPES)
 
 _desired_test_bases = get_desired_device_type_test_bases(allow_xpu=True)
 RUN_GPU = HAS_GPU and any(
@@ -478,7 +483,10 @@ def patch_inductor_backend(
             original_custom_backend_config,
         )
 
-def patch_custom_fallback_pass(predicate: Callable[[torch.fx.Node], bool]) -> contextlib.ContextDecorator:
+
+def patch_custom_fallback_pass(
+    predicate: Callable[[torch.fx.Node], bool],
+) -> contextlib.ContextDecorator:
     """
     Create a custom pass which falls back based on the provided predicate. For example,
     we could provide a predicate which returns True for all aten.add.default nodes.
@@ -494,6 +502,5 @@ def patch_custom_fallback_pass(predicate: Callable[[torch.fx.Node], bool]) -> co
 
         def uuid(self):
             return None
-
 
     return config.patch(post_grad_custom_pre_pass=Pass())


### PR DESCRIPTION
  ## Summary

  Route Inductor's device classification through the `DeviceInterface` contract so
  out-of-tree PrivateUse1 accelerator backends (e.g. NPU) are recognized as GPUs
  (for device guards, GPU-type enumeration and disambiguation) without
  monkeypatching module-level lists.

  ## Changes

  **`torch/_dynamo/device_interface.py`**

  - Add two capability bits to `DeviceInterface`: `is_gpu()` (staticmethod, default
    `False`) and `exposes_streams()` (classmethod, `True` iff a subclass overrides
    the base `Stream` sentinel slot).
  - Declare `is_gpu() = True` on `CudaInterface`, `MtiaInterface`, `XpuInterface`
    and `MpsInterface` (`Cpu`/`Tpu` inherit `False`).
  - Document the registration-ordering contract on
    `register_interface_for_device()` (see Notes).

  **`torch/_inductor/utils.py`**

  - Replace the hardcoded `GPU_TYPES = ["cuda", "mps", "xpu", "mtia"]` with a
    registry-derived snapshot: `_gpu_types()` enumerates the registered
    `DeviceInterface`s whose `is_gpu()` is `True` (skipping indexed aliases such
    as `cuda:0`), and `GPU_TYPES: list[str] = _gpu_types()` is computed exactly
    once, when this module is imported. `GPU_TYPES` stays a plain `list[str]`,
    so `is_gpu(device)` (`device in GPU_TYPES`) and every other consumer keep the
    same type, read cost and access patterns as with the old literal; only the
    contents now come from the registry.
  - Add `_device_is_available(device)`: a tolerant availability probe shared by
    the three consumers below. Partially-implemented out-of-tree interfaces
    (base-class methods raise `NotImplementedError`) and unregistered device
    types count as unavailable instead of propagating an exception out of
    registry-driven code, some of which runs at module import time.
  - Rewrite `get_gpu_type()`: probe availability through the helper; with more
    than one GPU type available, disambiguate via
    `torch.accelerator.current_accelerator()` and otherwise fall back to a
    stable pick (prefer `cuda`, else lexicographically smallest) with a warning,
    instead of asserting at most one GPU type can exist.
  - Rewrite `device_need_guard()` to
    `is_gpu(device) and get_interface_for_device(device).exposes_streams()`,
    removing the hardcoded `!= "mps"` special case.

  **`torch/_inductor/fx_passes/freezing_patterns.py`**

  - Extract `_addmm_pattern_device()` and resolve availability through
    `_device_is_available()` instead of `getattr(torch, gpu).is_available()`,
    which raises `AttributeError` for backends that register an interface but
    expose no `torch.<name>` module - the exact case this PR enables.

  **`torch/testing/_internal/inductor_utils.py`**

  - Compute `HAS_MULTIGPU` via a new `_is_multigpu()` that resolves through the
    registry, fixing the same `getattr(torch, gpu)` crash at module scope and
    tolerating partially-implemented interfaces. (The import reordering and
    reformatting in this file are enforced by ruff-format/usort on any PR that
    touches it.)

  ## Motivation

  `is_gpu()` tested membership in a hardcoded
  `GPU_TYPES = ["cuda","mps","xpu","mtia"]`, `get_gpu_type()` enumerated the same
  frozen list and asserted at most one GPU type could ever be available, and
  `device_need_guard()` special-cased the string `"mps"`. An out-of-tree backend
  that registers a full `DeviceInterface` (e.g. a PrivateUse1 `"npu"`) was still
  classified as non-GPU / no-guard and was absent from GPU-type enumeration, and
  could only work around it by mutating upstream module-level state at import
  time. Routing these predicates through the existing contract lets any
  registered backend opt in via its own `DeviceInterface`, provided it registers
  before inductor is imported (which holds by construction; see Notes).

  ## Test Plan

  - CI: `python test/inductor/test_utils.py TestDeviceClassification`
  - Added `TestDeviceClassification` (16 cases) to `test/inductor/test_utils.py`.
    Tests register throwaway fake `DeviceInterface` subclasses - no GPU or
    compilation required. Coverage:
    - `is_gpu()` safe default on the base class, and `exposes_streams()` sentinel
      comparison (the base `Stream` is a sentinel class, not `None`; comparing
      against `None` would wrongly classify MPS-style backends as
      stream-capable).
    - `is_gpu(device)` for `None` / unregistered / registered devices.
    - `device_need_guard` derivation for GPU+stream / GPU-no-stream / non-GPU /
      unknown device.
    - `_gpu_types` filtering of indexed (`cuda:0`) and non-GPU entries.
    - The snapshot contract itself: registering after `GPU_TYPES` is computed is
      not reflected (negative test; a fresh `_gpu_types()` scan does see the new
      backend, the snapshot and `get_gpu_type()` - re-evaluated after
      `cache_clear()` - do not).
    - Real-consumer regression tests: `_addmm_pattern_device()` and
      `_is_multigpu()` driven against a fake out-of-tree backend with no
      `torch.<name>` module, including a fixture that omits `is_available()`
      entirely (base raises `NotImplementedError`).
    - `get_gpu_type` single-available / none-available (falls back to `cuda`
      before consulting the accelerator) / multi-GPU disambiguation via
      `current_accelerator()` / partially-implemented interface skipped / stable
      sorted fallback when the accelerator names none of the candidates (fed in
      reverse order to prove the pick is sorted, not positional; warning pinned
      with `assertLogs`).

  ## Notes

  - **`GPU_TYPES` is scanned exactly once, at `torch._inductor.utils` import.**
    An earlier iteration made it a live view that re-derived the list on every
    read, which then required caching, invalidation hooks and concurrency
    handling. Scanning once is sound because registration always precedes that
    import: in-tree backends are registered by `init_device_reg()` inside the
    scan itself, and out-of-tree backends register at package import - either
    autoloaded at the end of `import torch` (`TORCH_DEVICE_BACKEND_AUTOLOAD`,
    on by default) or via an explicit `import torch_npu`-style import - both of
    which precede any import of inductor, in the main process and in spawned
    workers alike. Registering later is unsupported, documented on
    `register_interface_for_device()`, and pinned by a negative test.
  - Preserves in-tree behavior: the derived list contains exactly
    `cuda/xpu/mtia/mps` (`cpu`/`tpu` stay non-GPU), and `MpsInterface` is a GPU
    but exposes no `Stream`, so `device_need_guard("mps")` stays `False` -
    reproducing the removed `!= "mps"` case via the real reason (no stream)
    rather than a device name.
  - **Behavior change (relaxation):** with more than one GPU type available,
    `get_gpu_type()` no longer raises `AssertionError`; it disambiguates via the
    current accelerator and otherwise makes a stable pick and logs a warning.
    Single-GPU and no-GPU results are unchanged.
  - Importing `torch._inductor.utils` now triggers `init_device_reg()`
    (lightweight `device_count()` probes) at import; previously this happened on
    the first registry access.
  - Related RFC: `DeviceInterface` registry support for PrivateUse1 backends in
    `torch.compile`.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98