### PR TITLE
[MPS] Reuse unary dispatch stubs for inverse hyperbolic ops

### DIFF
--- a/aten/src/ATen/native/mps/operations/UnaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryOps.mm
@@ -13,11 +13,8 @@
 #else
 #include <ATen/ops/_copy_from_and_resize.h>
 #include <ATen/ops/acos_native.h>
-#include <ATen/ops/acosh_native.h>
 #include <ATen/ops/asin_native.h>
-#include <ATen/ops/asinh_native.h>
 #include <ATen/ops/atan_native.h>
-#include <ATen/ops/atanh_native.h>
 #include <ATen/ops/conj_physical_native.h>
 #include <ATen/ops/cos_native.h>
 #include <ATen/ops/cosh_native.h>
@@ -178,20 +175,12 @@ TORCH_IMPL_FUNC(sign_out_mps)(const Tensor& self, const Tensor& output) {
   }                                                                                                                    \
   REGISTER_DISPATCH(func##_stub, mps_##func##_kernel)
 
+REGISTER_MPS_UNARY_STUB(acosh, acosh);
+REGISTER_MPS_UNARY_STUB(asinh, asinh);
+REGISTER_MPS_UNARY_STUB(atanh, atanh);
 REGISTER_MPS_UNARY_STUB(ceil, ceil);
 REGISTER_MPS_UNARY_STUB(floor, floor);
 REGISTER_MPS_UNARY_STUB(trunc, truncate);
-
-#define CREATE_MPS_STRUCTURED_UNARY_TORCH_IMPL_FUNC(func_out, func_stub)                                         \
-  TORCH_IMPL_FUNC(func_out)(const Tensor& self, const Tensor& output) {                                          \
-    mps::unary_op(self, output, #func_out, ^MPSGraphTensor*(MPSGraph * mpsGraph, MPSGraphTensor * inputTensor) { \
-      return [mpsGraph func_stub##WithTensor:inputTensor name:nil];                                              \
-    });                                                                                                          \
-  }
-
-CREATE_MPS_STRUCTURED_UNARY_TORCH_IMPL_FUNC(asinh_out_mps, asinh)
-CREATE_MPS_STRUCTURED_UNARY_TORCH_IMPL_FUNC(acosh_out_mps, acosh)
-CREATE_MPS_STRUCTURED_UNARY_TORCH_IMPL_FUNC(atanh_out_mps, atanh)
 
 TORCH_IMPL_FUNC(frac_out_mps)(const Tensor& self, const Tensor& output) {
   TORCH_CHECK(isFloatingType(self.scalar_type()), "frac_out_mps is only implemented for floating types");

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -844,8 +844,7 @@
   structured: True
   structured_inherits: TensorIteratorBase
   dispatch:
-    CPU, CUDA, XPU: acosh_out
-    MPS: acosh_out_mps
+    CPU, CUDA, XPU, MPS: acosh_out
   tags: pointwise
 # arccosh, alias for acosh
 
@@ -877,8 +876,7 @@
   structured: True
   structured_inherits: TensorIteratorBase
   dispatch:
-    CPU, CUDA, XPU: asinh_out
-    MPS: asinh_out_mps
+    CPU, CUDA, XPU, MPS: asinh_out
     SparseCPU, SparseCUDA, SparseMPS, SparseXPU: asinh_sparse_out
     SparseCsrCPU, SparseCsrCUDA, SparseCsrMeta, SparseCsrXPU: asinh_sparse_csr_out
   tags: pointwise
@@ -912,8 +910,7 @@
   structured: True
   structured_inherits: TensorIteratorBase
   dispatch:
-    CPU, CUDA, XPU: atanh_out
-    MPS: atanh_out_mps
+    CPU, CUDA, XPU, MPS: atanh_out
     SparseCPU, SparseCUDA, SparseMPS, SparseXPU: atanh_sparse_out
     SparseCsrCPU, SparseCsrCUDA, SparseCsrMeta, SparseCsrXPU: atanh_sparse_csr_out
   tags: pointwise


### PR DESCRIPTION
Route MPS acosh, asinh and atanh through shared unary dispatch stubs. 