### PR TITLE
[benchmarks] Fix incorrect usage of `Timer.adaptive_autorange` in benchmark_core.py

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -387,7 +387,8 @@ class BenchmarkRunner:
             },
         )
         result = timer.adaptive_autorange(min_run_time=0.0001)
-        return result.median * iters
+        # result.median is the time for ONE call to func(iters, ...)
+        return result.median
 
     def _launch_backward(self, test_case, iters, print_per_iter=False):
         """This function runs forward path of an op to get an output. Then the backward path is executed
@@ -408,7 +409,8 @@ class BenchmarkRunner:
             },
         )
         result = timer.adaptive_autorange(min_run_time=0.0001)
-        return result.median * iters
+        # result.median is the time for ONE call to run_backward(iters, ...)
+        return result.median
 
     def _measure_metrics(self, launch_test, test_case, iters, print_per_iter):
         """


### PR DESCRIPTION
In `benchmarks/operator_benchmark/benchmark_core.py` the `_launch_forward` and `_launch_backward` paths use `torch.utils.benchmark.Timer.adaptive_autorange` to time a function `func(iters, ...)`. Internally, `adaptive_autorange` repeats the passed callable until it has either 3 iterations or exceeds the minimum run time (hence the "adaptive" in the name). Then, we get a result that includes an unspecified number of iterations, so we take `result.median`.

However, the called function `func` loops `iters` times, so one execution of `func(iters, ...)` includes the total time for all `iters` passes. Existing code is assuming that `results.median` is taking the median of `iters` repetitions, when it is not.  This PR fixes that by changing the return value from 
```
timer = Timer(
    stmt="func(iters, print_per_iter, gpu_sync)",
    globals={
        "func": func,
        "iters": iters,
        "print_per_iter": print_per_iter,
        "gpu_sync": gpu_sync,
    },)
result = timer.adaptive_autorange(min_run_time=0.0001)
return result.median * iters
```
to 
``` 
return result.median
```
This matches the expected calling code below in `BenchmarkRunner._measure_metrics`:
```python
run_time_sec = launch_test(test_case, iters, print_per_iter)
...

report_run_time = 1e6 * run_time_sec / iters
```
 
## Impact
For forward measurements, this incorrect code has been in use since Sept 2025 (https://github.com/pytorch/pytorch/pull/162530) so existing CI benchmark results will need to be updated (see https://github.com/pytorch/pytorch/pull/189079) @frgossen 

https://github.com/pytorch/pytorch/issues/189279, https://github.com/pytorch/pytorch/issues/189280, https://github.com/pytorch/pytorch/issues/189281, https://github.com/pytorch/pytorch/issues/189282, https://github.com/pytorch/pytorch/issues/189283

Fixes https://github.com/pytorch/pytorch/issues/189279, https://github.com/pytorch/pytorch/issues/189280, https://github.com/pytorch/pytorch/issues/189281, https://github.com/pytorch/pytorch/issues/189282, https://github.com/pytorch/pytorch/issues/189283, once CI benchmark results are updated


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10