### PR TITLE
[inductor] assert libdevice path exists in compile_worker tests

### DIFF
--- a/test/inductor/test_compile_worker.py
+++ b/test/inductor/test_compile_worker.py
@@ -1024,7 +1024,10 @@ class TestSetTritonLibdevicePath(TestCase):
 
         actual = knobs.nvidia.libdevice_path
         self.assertTrue(actual, "libdevice path was not set")
-        self.assertTrue(actual.endswith("libdevice.10.bc"))
+        self.assertTrue(
+            actual.endswith("libdevice.10.bc") and os.path.isfile(actual),
+            f"expected a valid libdevice path, got {actual!r}",
+        )
 
 
 class TestTritonCompileWorker(TestCase):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* (to be filled)

Follow-up to #190032 addressing a post-merge review comment. The prior assertion
used only endswith("libdevice.10.bc"), which passes for any string with that
suffix, including a stale or non-existent path. Since the intent is to confirm a
valid libdevice bitcode path was set, also assert os.path.isfile(actual) and echo
the path on failure. The set path points to a real bitcode in both OSS
(CUDA_HOME toolkit copy) and fbcode (Triton's bundled copy), so this does not
reintroduce the environment-specific failure the original PR fixed.

Test Plan:
Test-only assertion strengthening. The affected tests
(test_emulate_precision_casts_sets_libdevice_path, test_libdevice_path_no_subprocess,
test_libdevice_path_default_threads) require a CUDA build; they run in CI
(inductor). The local build could not exercise them because main's new bcomplex32
dtype left the installed binary stale, so verification is via CI.

Authored with an AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo