### PR TITLE
[inductor] Treat MTIA as a GPU in TorchInductor test utils (#190339)

### DIFF
--- a/torch/testing/_internal/inductor_utils.py
+++ b/torch/testing/_internal/inductor_utils.py
@@ -84,11 +84,13 @@ else:
 
 HAS_CUDA_AND_TRITON = torch.cuda.is_available() and HAS_TRITON
 
+HAS_MTIA_AND_TRITON = torch.mtia.is_available() and HAS_TRITON
+
 HAS_XPU_AND_TRITON = torch.xpu.is_available() and HAS_TRITON
 
 HAS_MPS = torch.mps.is_available()
 
-HAS_GPU = HAS_CUDA_AND_TRITON or HAS_XPU_AND_TRITON
+HAS_GPU = HAS_CUDA_AND_TRITON or HAS_XPU_AND_TRITON or HAS_MTIA_AND_TRITON
 HAS_GPU_AND_TRITON = HAS_GPU
 
 GPU_TYPE = get_gpu_type()


### PR DESCRIPTION
Summary:

This diff modifies the TorchInductor test utilities to treat MTIA (Meta Training and Inference Accelerator) as a GPU. The change is made by adding `HAS_MTIA_AND_TRITON` checks to the `HAS_GPU` and `HAS_GPU_AND_TRITON` variables in the `inductor_utils.py` files.

**Key Changes**

*   Added `HAS_MTIA_AND_TRITON` checks to `inductor_utils.py`.
*   Updated `HAS_GPU` to include `HAS_MTIA_AND_TRITON` in its conditions.
*   No functional changes are expected, as this diff only modifies test utilities.

**Impact**

This change allows MTIA to be treated as a GPU in TorchInductor tests, enabling more comprehensive testing on MTIA devices. The updated test utilities will now recognize MTIA as a valid GPU, ensuring that tests are run on MTIA devices when necessary.
`, `RUN_GPU`, `requires_gpu`, and the stamping of the device-generic `GPUTests`) -- only recognized CUDA and XPU. On an MTIA host this made the inductor test infrastructure behave as if the machine had no accelerator: `HAS_GPU`/`RUN_GPU` stayed `False`, `requires_gpu` tests were skipped, and no MTIA `GPUTests` were generated.

This diff adds `HAS_MTIA_AND_TRITON = torch.mtia.is_available() and HAS_TRITON` and folds it into `HAS_GPU`, mirroring the existing `HAS_CUDA_AND_TRITON` / `HAS_XPU_AND_TRITON` treatment. On a host where both MTIA and Triton are available, `HAS_GPU` becomes `True`, so the existing GPU-oriented TorchInductor tests and utilities recognize MTIA as a device. `HAS_GPU_AND_TRITON` stays `= HAS_GPU` because every disjunct already requires Triton.

The change is intentionally additive and behavior-neutral on non-MTIA hosts: `torch.mtia.is_available()` is `False` there, so `HAS_MTIA_AND_TRITON` is `False` and all derived symbols are unchanged.

Test Plan:
Low-risk and behavior-neutral off MTIA; sanity checks:

- **Symbol invariance on non-MTIA machines**
  - Verify that, with and without this change, the following flags remain identical on a host without MTIA:
    - `HAS_GPU`
    - `HAS_GPU_AND_TRITON`
    - `RUN_GPU`
    - `GPU_TYPE`
  - On a CPU-only machine, confirm the GPU/Triton detection remains a no-op:
    - `has_triton() == False`
    - `cuda/xpu/mtia/mps == False`
    - `HAS_GPU == False`
    - This should hold both **before and after** the change, indicating the added MTIA check does not alter behavior when MTIA is unavailable.

- **Import sanity**
  - Confirm importing the relevant test utilities succeeds (i.e., no import-time side effects or missing-symbol errors introduced by the new MTIA availability probe).
  - Ensure the added `torch.mtia.is_available()` call is safe at module import time and is consistent with existing import-time availability checks for other backends (e.g., `torch.cuda.is_available()`, `torch.xpu.is_available()`, `torch.mps.is_available()`).

- **Existing test suite unaffected off MTIA**
  - Run the OSS-equivalent unit/integration tests for the affected area and confirm:
    - The same tests are discovered/collected with and without the change.
    - Skip counts are unchanged (or differ only due to environment/hardware availability).
    - Any outcome variance across runs is attributable to environment noise (e.g., timeouts), not systematic behavior changes from the patch.

- **Style and static checks**
  - Run formatting and linting on the modified file(s) and confirm they are clean (e.g., `ruff`/`flake8`, `black`, `mypy` as applicable for the repository).

- **Positive coverage on MTIA + Triton hardware**
  - On a host where MTIA and Triton are available, verify the change enables the intended GPU-gated coverage:
    - `HAS_GPU` becomes `True`
    - `get_gpu_type() == "mtia"`
  - Confirm that GPU-gated inductor tests are now eligible to run under MTIA (i.e., they are no longer incorrectly skipped solely due to missing MTIA detection).

Reviewed By: blaine-rister, egienvalue

Differential Revision: D112355729


