### PR TITLE
CUDAGraph releases memory after capture error

### DIFF
--- a/aten/src/ATen/cuda/CUDAGraph.cpp
+++ b/aten/src/ATen/cuda/CUDAGraph.cpp
@@ -176,6 +176,11 @@ void CUDAGraph::capture_begin(MempoolId_t pool/*={0,0}*/, cudaStreamCaptureMode 
 
   at::getHostAllocator(at::kCUDA)->begin_allocate_to_pool(mempool_id_, create_allocate_filter<c10::Stream>());
 
+  // The pool is now acquired and being recorded to. Track this so reset() can
+  // release it even if the capture fails before capture_end() completes.
+  allocated_pool_ = true;
+  capturing_to_pool_ = true;
+
   // cudaStreamCaptureModeGlobal is the most conservative option to
   // prevent potentially unsafe CUDA API calls during capture.  See
   // https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__STREAM.html#group__CUDART__STREAM_1g9d0535d93a214cbf126835257b16ba85
@@ -226,6 +231,9 @@ void CUDAGraph::capture_end_pre() {
   // remove the pool routing entry added by beginAllocateToPool.
   c10::cuda::CUDACachingAllocator::endAllocateToPool(capture_dev_, mempool_id_);
   at::getHostAllocator(at::kCUDA)->end_allocate_to_pool(mempool_id_);
+  // Allocation recording has stopped (even if endCaptureErr is a failure), so
+  // reset() must not end the pool again.
+  capturing_to_pool_ = false;
   AT_CUDA_CHECK(endCaptureErr);
 
   TORCH_CHECK(graph_ != nullptr, "Invalid capture.");
@@ -373,7 +381,16 @@ void CUDAGraph::reset() {
     capture_id_ = 0;
   }
 
-  if (capture_ended_) {
+  if (allocated_pool_) {
+    if (capturing_to_pool_) {
+      // Capture was abandoned before capture_end() ran, so the allocator is
+      // still routing allocations to this pool. Stop that before releasing so
+      // the pool is left in a consistent, freeable state.
+      c10::cuda::CUDACachingAllocator::endAllocateToPool(capture_dev_, mempool_id_);
+      at::getHostAllocator(at::kCUDA)->end_allocate_to_pool(mempool_id_);
+      capturing_to_pool_ = false;
+    }
+
     // Clean up cuBLAS workspaces allocated on the capture stream, otherwise live allocations prevent
     // private pool cleanup
     clearCublasWorkspacesForStream(capture_stream_.stream());
@@ -385,6 +402,7 @@ void CUDAGraph::reset() {
     retained_mempool_ids_.clear();
     at::getHostAllocator(at::kCUDA)->release_pool(mempool_id_);
     capture_ended_ = false;
+    allocated_pool_ = false;
   }
   if (has_graph_) {
     C10_CUDA_CHECK_WARN(cudaGraphDestroy(graph_));

--- a/aten/src/ATen/cuda/CUDAGraph.h
+++ b/aten/src/ATen/cuda/CUDAGraph.h
@@ -134,6 +134,18 @@ struct TORCH_CUDA_CPP_API CUDAGraph {
   // Set to true in capture_end if cudaGraphInstantiate succeeded
   bool has_graph_exec_ = false;
 
+  // Set to true in capture_begin once a private pool has been acquired
+  // (beginAllocateToPool). Tells reset() it must release the pool, even if the
+  // capture failed before capture_end() completed. Otherwise a failed capture
+  // leaks the pool: its use_count never returns to zero, so empty_cache can
+  // never reclaim its segments for the rest of the process.
+  bool allocated_pool_ = false;
+  // Set to true in capture_begin after beginAllocateToPool and cleared in
+  // capture_end after endAllocateToPool. Tells reset() whether the allocator is
+  // still routing allocations to the pool (capture abandoned before capture_end
+  // ran) and must be ended before the pool can be released.
+  bool capturing_to_pool_ = false;
+
   // the ID assigned by cuda during graph capture,
   // used to identify when a stream is participating in capture
   CaptureId_t capture_id_ = 0;

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2949,6 +2949,43 @@ torch.cuda.synchronize()
             after, baseline, "Leaked CUDA/RNG allocations after failed capture test"
         )
 
+    @skipIfRocmVersionLessThan((7, 14))
+    @xfailCUDAIfSM89OrLaterOnWindows
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    def test_graph_capture_error_releases_reserved_segments(self):
+        # A failed capture (capture_end raises) must still release the graph's
+        # private mempool on reset(); otherwise its reserved segments leak for
+        # the rest of the process. Unlike test_graph_rng_after_failed_capture,
+        # which asserts on active.all.current (no leaked live allocations), this
+        # checks memory_reserved(): a leaked pool can show zero active bytes yet
+        # still hold reserved segments, so only this assertion catches the leak.
+        torch.cuda.synchronize()
+        torch.cuda.empty_cache()
+        reserved_before = torch.cuda.memory_reserved()
+
+        s = torch.cuda.Stream()
+        s.wait_stream(torch.cuda.current_stream())
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.stream(s):
+            g.capture_begin()
+            x = torch.empty(8 * 1024 * 1024, device="cuda")
+            # A synchronizing op during capture invalidates it, but we must
+            # still call capture_end() so the stream's capture is ended (with an
+            # error); otherwise the stream is left mid-capture and teardown fails.
+            with self.assertRaises(RuntimeError):
+                torch.cuda.synchronize()
+            with self.assertRaises(RuntimeError):
+                g.capture_end()
+
+        del x
+        g.reset()
+        del g
+        torch.cuda.synchronize()
+        torch.cuda.empty_cache()
+        self.assertEqual(torch.cuda.memory_reserved(), reserved_before)
+
     @unittest.skipIf(
         not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
     )


### PR DESCRIPTION
## Summary

Fix a memory leak when CUDA graph capture fails: `CUDAGraph::reset()` now releases the graph's private mempool even if capture never completed successfully. Previously, a failed capture could leave the pool's use count elevated for the rest of the process, so `empty_cache()` could not reclaim its reserved segments.

## Problem

`capture_begin()` acquires a private mempool and routes allocations to it via `beginAllocateToPool()`. On a successful capture, `capture_end()` ends pool routing, sets `capture_ended_ = true`, and `reset()` releases the pool.

If capture fails, `capture_end()` may still call `endAllocateToPool()` (that happens before the capture error is propagated), but `capture_ended_` is only set on success. `reset()` gated pool release on `capture_ended_`, so after a failed capture it skipped releasing the pool entirely. The pool's use count never returned to zero, and its reserved segments leaked until process exit - even with no live allocations (`active.all.current == 0`).

Because the leaked segments persist for the rest of the process, this also causes spurious failures in later, unrelated tests that assume a clean allocator after `empty_cache()` (e.g. `test_memory_snapshot_*`) that start from empty memory and assert on the exact set of reserved segments. When such a test runs in the same process after a failed-capture test, the leaked pool pollutes `memory_reserved()` / `_snapshot()`. This fix removes that cross-test contamination.

`test_graph_rng_after_failed_capture` covered stream/RNG recovery and live allocation leaks, but not this reserved-segment leak.

## Fix

Track two new flags on `CUDAGraph`:

- `allocated_pool_` - set in `capture_begin()` once the private pool is acquired; tells `reset()` it must release the pool regardless of capture success.
- `capturing_to_pool_` - set in `capture_begin()` and cleared in `capture_end()` after `endAllocateToPool()`; tells `reset()` whether pool routing is still active and must be ended before release (e.g. capture abandoned before `capture_end()` ran).

`reset()` now keys pool cleanup off `allocated_pool_` instead of `capture_ended_`.

## Test plan

- [x] Added `test_graph_capture_error_releases_reserved_segments`: triggers a failed capture via `torch.cuda.synchronize()` during capture, calls `reset()`, and asserts `memory_reserved()` returns to baseline after `empty_cache()`.
- [x] New test comment explains how it complements `test_graph_rng_after_failed_capture` (reserved segments vs. live allocations).

```bash
python test/test_cuda.py TestCuda.test_graph_capture_error_releases_reserved_segments
```
output without fix:
```
test_graph_capture_error_releases_reserved_segments (__main__.TestCuda.test_graph_capture_error_releases_reserved_segments) ... FAIL
Expected 0 but got 33554432.
```
output with fix:
```
test_graph_capture_error_releases_reserved_segments (__main__.TestCuda.test_graph_capture_error_releases_reserved_segments) ... ok
```