### PR TITLE
Fix update-pip-graph job: use short-form -r for requirements-build.txt include

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Python dependencies required for development
 
 # Build System requirements
---requirement requirements-build.txt
+-r requirements-build.txt
 
 # Install / Development extra requirements
 build[uv]  # for building sdist and wheel


### PR DESCRIPTION
The scheduled update-pip-graph job (GitHub's server-side Dependabot dependency-graph scanner) fails on the root requirements.txt with:

```
  dependency_file_not_evaluatable
  InstallationError: Could not open requirements file:
  'dependabot_tmp_dir/requirements-build.txt'
```

ex: https://github.com/pytorch/pytorch/actions/runs/29583765385/job/87895528997

Root cause: dependabot-core [#15521](https://github.com/dependabot/dependabot-core/pull/15521) (v0.386.0) changed the graph scanner to split a requirements directory into per-layer groups and stage only a subset of files per group. Its file-staging regexes match only the short include forms:

  CHILD_REQUIREMENT_REGEX = /^-r\s?(?<path>.*\.(?:txt|in))/
  CONSTRAINT_REGEX        = /^-c\s?(?<path>.*\.(?:txt|in))/

requirements.txt used the long form "--requirement requirements-build.txt", which these regexes never match, so requirements-build.txt was not staged next to requirements.txt and pip could not open it. The upstream fix ([#15581](https://github.com/dependabot/dependabot-core/pull/15581), v0.387.0) only covers pip-compile .in/.txt layouts, not the long-form include, so it does not resolve this case.

Switch to the short form "-r requirements-build.txt". pip treats -r and --requirement as identical, so this is behavior-identical for every consumer (CI build scripts, Dockerfile, dev setup, lintrunner cache key), keeps requirements-build.txt a separate file, and keeps the root manifest in the dependency graph.