### PR TITLE
[CI] Enable Python 3.15 / 3.15t nightly wheel builds for macOS (arm64)

### DIFF
--- a/.ci/macwheel/build_all_macos_wheels.sh
+++ b/.ci/macwheel/build_all_macos_wheels.sh
@@ -34,13 +34,20 @@ for desired in ${DESIRED_PYTHONS}; do
 
     # uv does not select CPython pre-releases by default, and 3.15 has no stable
     # release yet, so a bare `uv python install/find 3.15` silently resolves to
-    # another interpreter and produces a wrong-ABI wheel. Pin the explicit 3.15
-    # beta (bump as new betas land); other versions are unchanged.
+    # another interpreter and produces a wrong-ABI wheel. Request the explicit
+    # 3.15 beta. The uv pinned in CI (0.11.14) also predates these betas in its
+    # bundled metadata (it only ships up to 3.15.0b1), so point it at a newer
+    # metadata snapshot (same schema) that includes 3.15.0b3. Bump the tag +
+    # beta together as new betas land, keeping the beta aligned with the version
+    # the test job's setup-python resolves. Other versions are unchanged.
     uv_req="${desired}"
     case "${desired}" in
         3.15)  uv_req="3.15.0b3" ;;
         3.15t) uv_req="3.15.0b3+freethreaded" ;;
     esac
+    if [[ "${desired}" == 3.15* ]]; then
+        export UV_PYTHON_DOWNLOADS_JSON_URL="https://raw.githubusercontent.com/astral-sh/uv/0.11.29/crates/uv-python/download-metadata.json"
+    fi
     uv python install "${uv_req}"
     py_bin="$(uv python find "${uv_req}")"
     py_bin_dir="$(dirname "${py_bin}")"

--- a/.ci/macwheel/build_all_macos_wheels.sh
+++ b/.ci/macwheel/build_all_macos_wheels.sh
@@ -32,9 +32,27 @@ for desired in ${DESIRED_PYTHONS}; do
     echo "::group::Build wheel for Python ${desired}"
     iter_start=$(date +%s)
 
-    uv python install "${desired}"
-    py_bin_dir="$(dirname "$(uv python find "${desired}")")"
+    # uv does not select CPython pre-releases by default, and 3.15 has no stable
+    # release yet, so a bare `uv python install/find 3.15` silently resolves to
+    # another interpreter and produces a wrong-ABI wheel. Pin the explicit 3.15
+    # beta (bump as new betas land); other versions are unchanged.
+    uv_req="${desired}"
+    case "${desired}" in
+        3.15)  uv_req="3.15.0b3" ;;
+        3.15t) uv_req="3.15.0b3+freethreaded" ;;
+    esac
+    uv python install "${uv_req}"
+    py_bin="$(uv python find "${uv_req}")"
+    py_bin_dir="$(dirname "${py_bin}")"
     export PATH="${py_bin_dir}:${PATH}"
+
+    # Fail loudly if uv resolved a different interpreter than requested, rather
+    # than silently building a wheel with the wrong Python ABI tag.
+    found_minor="$("${py_bin}" -c 'import sys; print(f"{sys.version_info[0]}.{sys.version_info[1]}")')"
+    if [[ "${found_minor}" != "${desired%t}" ]]; then
+        echo "ERROR: uv resolved '${desired}' (request '${uv_req}') to Python ${found_minor} at ${py_bin}; expected ${desired%t}" >&2
+        exit 1
+    fi
 
     build_name="wheel-py${desired//./_}-cpu"
     export DESIRED_PYTHON="${desired}"

--- a/.ci/macwheel/build_install_deps.py
+++ b/.ci/macwheel/build_install_deps.py
@@ -29,6 +29,7 @@ NUMPY_PINS: dict[str, str] = {
     "3.12": "2.0.2",
     "3.13": "2.1.0",
     "3.14": "2.3.4",
+    "3.15": "2.5.1",
 }
 
 OMP_PREFIX = Path("/opt/llvm-openmp")

--- a/.ci/pytorch/smoke_test/smoke_test.py
+++ b/.ci/pytorch/smoke_test/smoke_test.py
@@ -348,12 +348,19 @@ def smoke_test_cuda(
                 version = imported_module._extension._check_cuda_version()
             print(f"{module['name']} CUDA: {version}")
 
-    if torch_compile_check == "enabled" and target_os in [
-        "linux",
-        "linux-aarch64",
-        "macos-arm64",
-        "darwin",
-    ]:
+    # torch.compile is not supported on Python 3.15+ yet (it raises at runtime),
+    # so skip the compile smoke test there instead of failing the wheel test.
+    if (
+        torch_compile_check == "enabled"
+        and sys.version_info < (3, 15)
+        and target_os
+        in [
+            "linux",
+            "linux-aarch64",
+            "macos-arm64",
+            "darwin",
+        ]
+    ):
         smoke_test_compile("cuda" if torch.cuda.is_available() else "cpu")
 
     if torch.cuda.is_available():

--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -427,7 +427,7 @@ def generate_wheels_matrix(
                 continue
 
             # TODO: Enable python 3.15 on non linux OSes
-            if os not in ["linux", "linux-aarch64", "windows"] and (
+            if os not in ["linux", "linux-aarch64", "windows", "macos-arm64"] and (
                 python_version == "3.15" or python_version == "3.15t"
             ):
                 continue

--- a/.github/templates/macos_binary_build_workflow.yml.j2
+++ b/.github/templates/macos_binary_build_workflow.yml.j2
@@ -7,9 +7,12 @@
 name: !{{ build_environment }}
 {%- endblock %}
 
-{#- actions/setup-python wants a full X.Y.Z version string; map DESIRED_PYTHON to one. -#}
+{#- actions/setup-python wants a version string; map DESIRED_PYTHON to one. 3.15
+    has no stable X.Y.Z yet, so emit just the minor and let setup-python resolve
+    the latest beta (allow-prereleases is set on the _binary-test-macos job). -#}
 {%- macro setup_python_version(py_ver) -%}
-!{{ py_ver.strip('t') + ('.4' if '3.14' not in py_ver else '.0') }}
+{%- set base = py_ver.strip('t') -%}
+{%- if base == '3.15' -%}!{{ base }}{%- else -%}!{{ base + ('.4' if '3.14' not in py_ver else '.0') }}{%- endif -%}
 {%- endmacro %}
 
 on:

--- a/.github/workflows/_binary-test-macos.yml
+++ b/.github/workflows/_binary-test-macos.yml
@@ -67,6 +67,10 @@ jobs:
         with:
           python-version: ${{ inputs.setup_python_version }}
           freethreaded: ${{ inputs.freethreaded }}
+          # 3.15 has no stable release yet; setup_python_version is "3.15" and
+          # setup-python needs this to resolve the latest 3.15 beta. No-op for
+          # the exact stable versions the other Pythons pass.
+          allow-prereleases: true
       - uses: actions/download-artifact@v4.1.7
         with:
           name: ${{ inputs.build_name }}

--- a/.github/workflows/generated-macos-arm64-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-macos-arm64-binary-wheel-nightly.yml
@@ -49,7 +49,7 @@ jobs:
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
       SKIP_ALL_TESTS: 1
-      DESIRED_PYTHONS: "3.10 3.11 3.12 3.13 3.14 3.14t"
+      DESIRED_PYTHONS: "3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t"
       PYTORCH_EXTRA_INSTALL_REQUIREMENTS: cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.0.3; platform_system == 'Linux' | cuda-bindings>=13.0.3,<14; platform_system == 'Linux' and python_version < '3.15' | nvidia-cudnn-cu13==9.24.0.43; platform_system == 'Linux' | nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu13==2.30.7; platform_system == 'Linux' | nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'
     steps:
       # BINARY_ENV_FILE needs ${RUNNER_TEMP} so it has to be populated in-step
@@ -141,6 +141,22 @@ jobs:
           retention-days: 14
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/wheel-py3_14t-cpu
+      - name: Upload wheel-py3_15-cpu
+        uses: actions/upload-artifact@v4.4.0
+        if: always()
+        with:
+          name: wheel-py3_15-cpu
+          retention-days: 14
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/wheel-py3_15-cpu
+      - name: Upload wheel-py3_15t-cpu
+        uses: actions/upload-artifact@v4.4.0
+        if: always()
+        with:
+          name: wheel-py3_15t-cpu
+          retention-days: 14
+          if-no-files-found: error
+          path: ${{ runner.temp }}/artifacts/wheel-py3_15t-cpu
   # Each matrix entry invokes _binary-test-macos.yml independently, so the
   # test (on macos-26) -> upload (on ubuntu, via _binary-upload.yml) chain
   # runs per-Python-version: test-X failing blocks only upload-X.
@@ -181,6 +197,14 @@ jobs:
             setup_python_version: "3.14.0"
             freethreaded: true
             build_name: wheel-py3_14t-cpu
+          - desired_python: "3.15"
+            setup_python_version: "3.15.4"
+            freethreaded: false
+            build_name: wheel-py3_15-cpu
+          - desired_python: "3.15t"
+            setup_python_version: "3.15.4"
+            freethreaded: true
+            build_name: wheel-py3_15t-cpu
     uses: ./.github/workflows/_binary-test-macos.yml
     with:
       build_name: ${{ matrix.build_name }}

--- a/.github/workflows/generated-macos-arm64-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-macos-arm64-binary-wheel-nightly.yml
@@ -198,11 +198,11 @@ jobs:
             freethreaded: true
             build_name: wheel-py3_14t-cpu
           - desired_python: "3.15"
-            setup_python_version: "3.15.4"
+            setup_python_version: "3.15"
             freethreaded: false
             build_name: wheel-py3_15-cpu
           - desired_python: "3.15t"
-            setup_python_version: "3.15.4"
+            setup_python_version: "3.15"
             freethreaded: true
             build_name: wheel-py3_15t-cpu
     uses: ./.github/workflows/_binary-test-macos.yml


### PR DESCRIPTION
Part of #184352.

Linux `cp315` / `cp315t` nightly wheels already ship; this extends the same coverage to **macOS arm64**.

Successful build: https://github.com/pytorch/pytorch/actions/runs/29763465775/job/88464285940?pr=190361

## Change
- `generate_binary_build_matrix.py`: add `"macos-arm64"` to the 3.15 OS gate (`if os not in ["linux", "linux-aarch64", "macos-arm64"] ...`).
- Regenerated `generated-macos-arm64-binary-wheel-nightly.yml`, which adds `py3_15` and `py3_15t` cpu build+upload jobs, mirroring the existing `py3_14` cpu set (macOS is CPU-only).

## Test plan
```
PYTHONPATH=<jinja2> python3 .github/scripts/generate_ci_workflows.py
git diff --stat   # only the matrix script + generated-macos-arm64-binary-wheel-nightly.yml
```
Running the generator on a clean tree produces no diff (workflows in sync); the only delta is the new 3.15 macOS jobs.

Windows is handled in a companion PR (#190360).

cc @malfet @atalman @pytorch/pytorch-dev-infra