### PR TITLE
[CI] Run only gradcheck files in slow-gradcheck (allowlist)

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -453,27 +453,43 @@ TESTS_REQUIRING_LAPACK = [
     "distributions/test_distributions",
 ]
 
-# These are just the slowest ones, this isn't an exhaustive list.
-TESTS_NOT_USING_GRADCHECK = [
-    # Note that you should use skipIfSlowGradcheckEnv if you do not wish to
-    # skip all the tests in that file, e.g. test_mps
-    "doctests",
-    "test_meta",
-    "test_hub",
-    "test_fx",
-    "test_decomp",
-    "test_cpp_extensions_jit",
-    "test_jit",
-    "test_matmul_cuda",
-    "test_ops",
-    "test_ops_jit",
-    "dynamo/test_recompile_ux",
-    "inductor/test_compiled_optimizers",
-    "inductor/test_cutlass_backend",
-    "inductor/test_max_autotune",
-    "inductor/test_select_algorithm",
-    "inductor/test_smoke",
-    "test_quantization",
+# Allowlist of the test files that actually exercise gradcheck -- either via the
+# OpInfo/ModuleInfo gradient sweeps or the internal common_utils.gradcheck
+# wrapper (which is what flips fast_mode off under slow gradcheck). In slow
+# gradcheck mode we run ONLY these: every other file gains nothing from
+# fast_mode=False and just burns the per-shard time budget, and the full suite
+# is ~2x too large to fit the shards' timeout otherwise.
+#
+# This is an allowlist, so a NEW file that adds gradcheck coverage must be added
+# here or it will silently not run in slow gradcheck. Files that call
+# torch.autograd.gradcheck directly (rather than the common_utils wrapper) are
+# intentionally omitted: they run identically in normal CI and slow mode adds
+# nothing. Use skipIfSlowGradcheckEnv to opt out individual tests within a file.
+TESTS_USING_GRADCHECK = [
+    # OpInfo / ModuleInfo gradient sweeps -- the core of slow gradcheck
+    "test_ops_gradients",
+    "test_ops_fwd_gradients",
+    "test_modules",
+    # Core autograd + nn
+    "test_autograd",
+    "autograd/test_functional",
+    "autograd/test_complex",
+    "test_nn",
+    "nn/test_convolution",
+    "nn/test_pooling",
+    "nn/test_parametrization",
+    # Domain-specific autograd coverage
+    "test_linalg",
+    "test_sparse",
+    "test_sparse_csr",
+    "test_nestedtensor",
+    "test_foreach",
+    "test_view_ops",
+    "test_segment_reductions",
+    "test_transformers",
+    "test_mkldnn",
+    "distributions/test_distributions",
+    "optim/test_optim",
 ]
 
 
@@ -1933,12 +1949,10 @@ def get_selected_tests(options) -> list[str]:
         )
 
     if TEST_WITH_SLOW_GRADCHECK:
-        selected_tests = exclude_tests(
-            TESTS_NOT_USING_GRADCHECK,
-            selected_tests,
-            "Running in slow gradcheck mode, skipping tests that don't use gradcheck.",
-            exact_match=True,
-        )
+        # Avoid running files that don't use gradcheck. See TESTS_USING_GRADCHECK.
+        selected_tests = [
+            test for test in selected_tests if test in TESTS_USING_GRADCHECK
+        ]
 
     selected_tests = [parse_test_module(x) for x in selected_tests]
     return selected_tests


### PR DESCRIPTION
Human notes:
- slowgradcheck tests have been timing out since forever
- previously we had a blocklist but this requires a lot of periodic updating 
- only a few select files actually run gradcheck and this list doesn't change (if necessary we can periodically grep for new gradcheck callsites)

AI notes:

The cuda13.0 slow-gradcheck job has been red since it first appeared. Two
distinct problems, both rooted in the job running far more than it should:

1. Non-gradcheck tests were tripping the job. slow-gradcheck runs the suite
   under PYTORCH_TEST_CUDA_MEM_LEAK_CHECK=1 with fast_mode=False, and files
   that don't use gradcheck at all (test_dataloader's CUDA-IPC sparse leak,
   dynamo/test_misc, test_autocast, etc.) were failing/leaking and reddening a
   job that has nothing to do with them.

2. The suite does not fit the shards' timeout. The full slow-gradcheck suite
   is ~4231 min of test time; at 8 shards that is ~529 min/shard against a
   270-min (JOB_TIMEOUT 300 - 30) budget -- ~2x over. So even once the failures
   are fixed, a clean run would time out.

Root cause of both: most of what runs in slow-gradcheck does not use gradcheck
and gains nothing from fast_mode=False. functorch (~456 min) validates
vjp/jvp/vmap against an autograd reference, not gradcheck; the inductor opinfo
and attention tests (~730 min) don't gradcheck; the elementwise ufunc files
(~444 min) have diagonal Jacobians and only 1-3 trivial gradcheck calls
(sinc, pow) that fast-mode CI already covers.

Fix: flip TESTS_NOT_USING_GRADCHECK (a non-exhaustive blocklist) to
TESTS_USING_GRADCHECK, an allowlist of the files that actually exercise
gradcheck -- the OpInfo/ModuleInfo gradient sweeps plus files calling the
internal common_utils.gradcheck wrapper (which is what flips fast_mode under
the slow flag). This drops the job to ~1274 min, ~159 min/shard at 8 shards,
comfortably under budget with no shard-count change. Files that call
torch.autograd.gradcheck directly (e.g. inductor/test_flex_attention) are
omitted because they run identically in normal CI; test_transformers is kept
because its SDP gradcheck uses the internal wrapper.

The two OpInfo sweeps (test_ops_gradients, test_ops_fwd_gradients) dominate the
remaining time, and second-order checks (gradgrad, fwgrad_bwgrad) are ~80% of
their cost -- a natural target if further trimming is ever needed.

Caveats: (1) as an allowlist, a new file that adds gradcheck coverage must be
added here or it silently won't run in slow gradcheck; a follow-up guard test
that greps for gradcheck( in non-allowlisted files would prevent erosion.
(2) locally, `-i <file>` with PYTORCH_TEST_WITH_SLOW_GRADCHECK=1 now only runs
allowlisted files.

Test Plan:

Reproduced the original leaks on an H100 box built against CUDA 13.0, and
derived the per-file/per-op slow-gradcheck times from CI stats to size the
allowlist:

```
CUDA_VISIBLE_DEVICES=0 PYTORCH_TEST_CUDA_MEM_LEAK_CHECK=1 \
  PYTORCH_TEST_WITH_SLOW_GRADCHECK=1 \
  python test/test_dataloader.py \
  TestDataLoaderDeviceTypeCUDA.test_sparse_tensor_multiprocessing_context_forkserver_cuda
```

Verifying via ciflow/periodic + ciflow/slow on this PR that the slow-gradcheck
shards pass and stay under the timeout.

This PR was authored with the assistance of an AI coding agent.