### PR TITLE
[inductor] Preserve `tma_min_block_sizes` when only a TMA store (no TMA load) is emitted

### DIFF
--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -1753,6 +1753,57 @@ class TritonTensorDescriptorTestCUDA(BlockDescriptorTestBase):
         inp = torch.zeros(16, dtype=torch.bool, device=GPU_TYPE)
         self._run_and_compare(fn, inp, expected_num_block_pointers=0)
 
+    @config.patch({"split_reductions": True})
+    def test_split_reduction_tma_store_strided_input(self):
+        """
+        Regression test: split reduction emits a TMA descriptor store for the
+        partial-sum output.  When the input is strided (no TMA load), this was
+        the only TMA path in the kernel.  Previously _emitted_device_tma was not
+        set, causing tma_min_block_sizes to be stripped and XBLOCK=1 to reach
+        Triton (which requires >= 16 bytes in the innermost descriptor dim).
+        """
+
+        def fn(a):
+            return torch.sum(a, dim=-1)
+
+        n = 1 << 20
+        base = torch.randn((1, 2 * n), device=GPU_TYPE)
+        # stride-2 on reduction dim prevents TMA load
+        a = torch.as_strided(base, (1, n), (2 * n, 2))
+
+        compiled = torch.compile(fn, backend="inductor", fullgraph=True)
+        result = compiled(a)
+        expected = fn(a)
+        torch.testing.assert_close(result, expected)
+
+    @config.patch(
+        {
+            "split_reductions": False,
+            "triton.cooperative_reductions": True,
+            "triton.force_cooperative_reductions": True,
+        }
+    )
+    def test_cooperative_reduction_tma_store_strided_input(self):
+        """
+        Same as the split reduction variant but using cooperative (grid)
+        reduction.  The store_reduction path is shared; xnumel > 1 is needed
+        so the output is multi-element and TMA-eligible.
+        """
+
+        def fn(a):
+            return torch.sum(a, dim=-1)
+
+        n = 1 << 20
+        base = torch.randn((4, 2 * n), device=GPU_TYPE)
+        # stride-2 on reduction dim prevents TMA load; 4 output rows
+        a = torch.as_strided(base, (4, n), (2 * n, 2))
+
+        compiled = torch.compile(fn, backend="inductor", fullgraph=True)
+        result = compiled(a)
+        expected = fn(a)
+        # Cooperative reduction changes summation order; allow small tolerance
+        torch.testing.assert_close(result, expected, rtol=1e-4, atol=1e-3)
+
 
 test_torchinductor.copy_tests(
     CommonTemplate,

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -5895,6 +5895,8 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         self._handle_pdl_before_access(self.post_loop_store, var)
 
         if isinstance(indexing, (BlockPtrOptions, TensorDescriptorOptions)):
+            if isinstance(indexing, TensorDescriptorOptions):
+                self._emitted_device_tma = True
             self.post_loop_store.writeline(
                 DeferredLine(
                     name,


### PR DESCRIPTION
**Issue:** https://github.com/pytorch/pytorch/issues/190363

`store_reduction()` emits a device-side TMA tensor descriptor store via `codegen_block_ptr_store_line()`, but never calls `codegen_block_ptr()` which is the only path that sets `_emitted_device_tma = True`. The cleanup guard in `codegen_kernel()` then strips `tma_min_block_sizes` from the metadata, **allowing illegal configs (e.g. XBLOCK=1) to pass through** — Triton rejects them because the innermost block is only 1*4=4 bytes (needs >= 16).

**Fix:** set `_emitted_device_tma = True` when store_reduction detects a `TensorDescriptorOptions` indexing, mirroring what codegen_block_ptr does for regular stores and loads.

Co-Authored-By: Claude Opus 4.8 (1M context)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo