### PR TITLE
[c10d] Promote getError() capability check to Backend

### DIFF
--- a/test/distributed/test_c10d_fault_tolerance.py
+++ b/test/distributed/test_c10d_fault_tolerance.py
@@ -229,12 +229,10 @@ class AbstractFaultToleranceTest:
         # reconfigure() with a fresh uuid.
         self._create_reconfigured_pg("ft_abort", 1200)
         self.backend.abort()
-        try:
+        if self.backend.supports_error_tracking:
             from torch._C._distributed_c10d import ErrorType
 
             self.assertEqual(self.backend.get_error(), ErrorType.COMM_ERROR)
-        except RuntimeError:
-            pass
 
         handles = self._collect_handles("ft_abort_recover")
         self._reconfigure(1201, handles)

--- a/torch/csrc/distributed/c10d/Backend.hpp
+++ b/torch/csrc/distributed/c10d/Backend.hpp
@@ -650,6 +650,10 @@ class TORCH_API Backend : public torch::CustomClassHolder {
     bound_device_id_ = device;
   }
 
+  virtual bool supportsErrorTracking() const {
+    return false;
+  }
+
   virtual ErrorType getError() {
     TORCH_CHECK(
         false,

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -986,6 +986,10 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   // If all comms on this PG are fully initialized, return true.
   bool isInitialized();
 
+  bool supportsErrorTracking() const override {
+    return true;
+  }
+
   ErrorType getError() override;
 
   bool supportsShrinking() const override {

--- a/torch/csrc/distributed/c10d/ProcessGroupWrapper.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupWrapper.hpp
@@ -169,6 +169,10 @@ class TORCH_API ProcessGroupWrapper : public Backend {
   void resume() override;
   std::unordered_map<std::string, uint64_t> getMemoryStats() override;
 
+  bool supportsErrorTracking() const override {
+    return backend_->supportsErrorTracking();
+  }
+
   ErrorType getError() override;
   void eagerConnectSingleDevice(at::Device device) override;
 

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -3024,6 +3024,10 @@ Arguments:
               "supports_reconfigure",
               &::c10d::Backend::supportsReconfigure,
               "(test whether the backend supports reconfigure for fault tolerance)")
+          .def_property_readonly(
+              "supports_error_tracking",
+              &::c10d::Backend::supportsErrorTracking,
+              "(test whether the backend supports error tracking)")
           .def(
               "set_timeout",
               &::c10d::Backend::setTimeout,

--- a/torch/csrc/distributed/c10d/lazy/LazyBackend.hpp
+++ b/torch/csrc/distributed/c10d/lazy/LazyBackend.hpp
@@ -248,6 +248,9 @@ class LazyBackend : public Backend {
       channel->abort();
     }
   }
+  bool supportsErrorTracking() const override {
+    return primary_->supportsErrorTracking();
+  }
   ErrorType getError() override {
     return primary_->getError();
   }

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
@@ -215,6 +215,10 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
   void eagerConnectSingleDevice(at::Device device) override;
   void shutdown() override;
   void abort() override;
+  bool supportsErrorTracking() const override {
+    return true;
+  }
+
   ::c10d::ErrorType getError() override;
 
   // Memory offload API (see Backend.hpp): suspend() releases NCCL's dynamic

--- a/torch/csrc/distributed/c10d/py/PyBackend.hpp
+++ b/torch/csrc/distributed/c10d/py/PyBackend.hpp
@@ -371,6 +371,11 @@ class PyBackend : public Backend {
     return getPropertyOverride("supports_window", Backend::supportsWindow());
   }
 
+  bool supportsErrorTracking() const override {
+    return getPropertyOverride(
+        "supports_error_tracking", Backend::supportsErrorTracking());
+  }
+
   bool supportsTensorAlloc(c10::DeviceIndex deviceIdx) override {
     pybind11::gil_scoped_acquire gil;
     pybind11::function override = pybind11::get_override(


### PR DESCRIPTION
### Summary

#189817 added `get_error` to the base Backend pybind binding, which made `hasattr(backend, "get_error")` return True for all backends. The merged fix used a try/except RuntimeError as a band-aid.
This replaces that with a proper capability check on the Backend interface (default false), overridden to true by NCCL backends that implement getError(). `ProcessGroupWrapper` and `LazyBackend` delegate to their underlying backend. `PyBackend` supports python-side property override via getPropertyOverride. 

### Test Plan
```
python -m pip install -e . 
python -m pytest test/distributed/test_c10d_fault_tolerance.py
python -m pytest test/distributed/test_c10d_pybackend.py
```
Authored with the help of an AI assistant

