### PR TITLE
c10 intrusive_ptr: add [[nodiscard]] to weak_intrusive_ptr query and ownership methods

### DIFF
--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -13,6 +13,7 @@
 #include <c10/util/MaybeOwned.h>
 #include <c10/util/intrusive_ptr.h>
 #include <limits>
+#include <tuple>
 #include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
@@ -1488,7 +1489,7 @@ struct TORCH_API WeakIValue final {
               reclaim(static_cast<at::TensorImpl*>(payload.as_intrusive_ptr));
       c10::intrusive_ptr<at::TensorImpl, c10::UndefinedTensorImpl> ip(
           temp.lock());
-      temp.release();
+      std::ignore = temp.release();
       if (!ip) {
         return IValue();
       } else {
@@ -1501,7 +1502,7 @@ struct TORCH_API WeakIValue final {
               : payload.as_intrusive_ptr);
       IValue::Payload pl;
       pl.u.as_intrusive_ptr = temp.lock().release();
-      temp.release();
+      std::ignore = temp.release();
       if (!pl.u.as_intrusive_ptr) {
         return IValue();
       } else {
@@ -1518,7 +1519,7 @@ struct TORCH_API WeakIValue final {
         c10::intrusive_ptr_target,
         c10::UndefinedTensorImpl>::reclaim(payload.as_intrusive_ptr);
     size_t result = temp.use_count();
-    temp.release();
+    std::ignore = temp.release();
     return result;
   }
 
@@ -1530,7 +1531,7 @@ struct TORCH_API WeakIValue final {
         c10::intrusive_ptr_target,
         c10::UndefinedTensorImpl>::reclaim(payload.as_intrusive_ptr);
     size_t result = temp.weak_use_count();
-    temp.release();
+    std::ignore = temp.release();
     return result;
   }
   size_t hash() const {

--- a/c10/util/intrusive_ptr.h
+++ b/c10/util/intrusive_ptr.h
@@ -5,6 +5,7 @@
 #include <atomic>
 #include <climits>
 #include <memory>
+#include <tuple>
 #include <type_traits>
 
 namespace pybind11 {
@@ -1008,7 +1009,7 @@ class weak_intrusive_ptr final {
   // it would be simpler and easier to make work if we just expose
   // an unsafe getter for target_
   //
-  TTarget* _unsafe_get_target() const noexcept {
+  [[nodiscard]] TTarget* _unsafe_get_target() const noexcept {
     return target_;
   }
 
@@ -1031,7 +1032,7 @@ class weak_intrusive_ptr final {
     return use_count() == 0;
   }
 
-  intrusive_ptr<TTarget, NullType> lock() const noexcept {
+  [[nodiscard]] intrusive_ptr<TTarget, NullType> lock() const noexcept {
     if (target_ == NullType::singleton()) {
       return intrusive_ptr<TTarget, NullType>();
     } else {
@@ -1082,7 +1083,7 @@ class weak_intrusive_ptr final {
    * weak_intrusive_ptr::reclaim(ptr) to properly destruct it.
    * This is helpful for C APIs.
    */
-  TTarget* release() noexcept {
+  [[nodiscard]] TTarget* release() noexcept {
     TTarget* result = target_;
     target_ = NullType::singleton();
     return result;
@@ -1095,7 +1096,7 @@ class weak_intrusive_ptr final {
    * This is the counter-part to weak_intrusive_ptr::release() and the pointer
    * passed in *must* have been created using weak_intrusive_ptr::release().
    */
-  static weak_intrusive_ptr reclaim(TTarget* owning_weak_ptr) {
+  [[nodiscard]] static weak_intrusive_ptr reclaim(TTarget* owning_weak_ptr) {
     // See Note [Stack allocated intrusive_ptr_target safety]
     // if refcount > 0, weakcount must be >1 for weak references to exist.
     // see weak counting explanation at top of this file.
@@ -1114,7 +1115,7 @@ class weak_intrusive_ptr final {
    * new weak_intrusive_ptr representing a new weak reference, i.e.
    * the raw pointer retains ownership.
    */
-  static weak_intrusive_ptr reclaim_copy(TTarget* owning_ptr) {
+  [[nodiscard]] static weak_intrusive_ptr reclaim_copy(TTarget* owning_ptr) {
     auto ret = reclaim(owning_ptr);
     ret.retain_();
     return ret;
@@ -1231,7 +1232,7 @@ inline void incref(weak_intrusive_ptr_target* self) {
 
 inline void decref(weak_intrusive_ptr_target* self) {
   // Let it die
-  c10::weak_intrusive_ptr<intrusive_ptr_target>::reclaim(self);
+  std::ignore = c10::weak_intrusive_ptr<intrusive_ptr_target>::reclaim(self);
   // NB: You still "have" the 'self' pointer, but it's now invalid.
   // If you want more safety, used the actual c10::weak_intrusive_ptr class
 }
@@ -1240,7 +1241,7 @@ template <typename T>
 [[nodiscard]] inline T* lock(T* self) {
   auto wptr = c10::weak_intrusive_ptr<T>::reclaim(self);
   auto ptr = wptr.lock();
-  wptr.release();
+  std::ignore = wptr.release();
   return ptr.release();
 }
 
@@ -1248,7 +1249,7 @@ template <typename T>
 [[nodiscard]] inline uint32_t use_count(weak_intrusive_ptr_target* self) {
   auto wptr = c10::weak_intrusive_ptr<intrusive_ptr_target>::reclaim(self);
   auto r = wptr.use_count();
-  wptr.release();
+  std::ignore = wptr.release();
   return r;
 }
 


### PR DESCRIPTION
Summary:
Follow-up to D107127349, extending [[nodiscard]] to the weak_intrusive_ptr methods that diff did not cover (it handled use_count/weak_use_count/expired).

Annotated:
- Pure-query observer: _unsafe_get_target.
- Ownership/factory returns where discarding leaks or destroys: lock, release, reclaim, reclaim_copy. Discarding lock() in particular is the classic "forgot to check whether the weak reference was still alive" bug, analogous to std::weak_ptr::lock.

The in-file raw:: namespace helpers that intentionally discard release()/reclaim() are updated with an explicit (void) cast.

Mirrored across the fbcode and xplat copies of the header.

Test Plan: [[nodiscard]] is enforced at compile time via -Werror; relies on CI to surface external discarding call sites. Local `arc lint` is clean.

