### PR TITLE
[Docs] Fix Python comments in profiler example

### DIFF
--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -606,13 +606,16 @@ class _KinetoProfile:
             ) as p:
                 code_to_profile_0()
                 # turn off collection of all CUDA activity
-                p.toggle_collection_dynamic(False, [torch.profiler.ProfilerActivity.CUDA])
+                p.toggle_collection_dynamic(
+                    False, [torch.profiler.ProfilerActivity.CUDA]
+                )
                 code_to_profile_1()
                 # turn on collection of all CUDA activity
-                p.toggle_collection_dynamic(True, [torch.profiler.ProfilerActivity.CUDA])
+                p.toggle_collection_dynamic(
+                    True, [torch.profiler.ProfilerActivity.CUDA]
+                )
                 code_to_profile_2()
-            print(p.key_averages().table(
-                sort_by="self_cuda_time_total", row_limit=-1))
+            print(p.key_averages().table(sort_by="self_cuda_time_total", row_limit=-1))
         """
         if self.profiler is None:
             return

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -605,10 +605,10 @@ class _KinetoProfile:
                 ]
             ) as p:
                 code_to_profile_0()
-                // turn off collection of all CUDA activity
+                # turn off collection of all CUDA activity
                 p.toggle_collection_dynamic(False, [torch.profiler.ProfilerActivity.CUDA])
                 code_to_profile_1()
-                // turn on collection of all CUDA activity
+                # turn on collection of all CUDA activity
                 p.toggle_collection_dynamic(True, [torch.profiler.ProfilerActivity.CUDA])
                 code_to_profile_2()
             print(p.key_averages().table(

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -535,10 +535,10 @@ class _KinetoProfile:
                 ]
             ) as p:
                 code_to_profile_0()
-                // turn off collection of all CUDA activity
+                # turn off collection of all CUDA activity
                 p.toggle_collection_dynamic(False, [torch.profiler.ProfilerActivity.CUDA])
                 code_to_profile_1()
-                // turn on collection of all CUDA activity
+                # turn on collection of all CUDA activity
                 p.toggle_collection_dynamic(True, [torch.profiler.ProfilerActivity.CUDA])
                 code_to_profile_2()
             print(p.key_averages().table(

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -536,13 +536,16 @@ class _KinetoProfile:
             ) as p:
                 code_to_profile_0()
                 # turn off collection of all CUDA activity
-                p.toggle_collection_dynamic(False, [torch.profiler.ProfilerActivity.CUDA])
+                p.toggle_collection_dynamic(
+                    False, [torch.profiler.ProfilerActivity.CUDA]
+                )
                 code_to_profile_1()
                 # turn on collection of all CUDA activity
-                p.toggle_collection_dynamic(True, [torch.profiler.ProfilerActivity.CUDA])
+                p.toggle_collection_dynamic(
+                    True, [torch.profiler.ProfilerActivity.CUDA]
+                )
                 code_to_profile_2()
-            print(p.key_averages().table(
-                sort_by="self_cuda_time_total", row_limit=-1))
+            print(p.key_averages().table(sort_by="self_cuda_time_total", row_limit=-1))
         """
         if self.profiler is None:
             return


### PR DESCRIPTION
Fixes #190202

## summary

The toggle_collection_dynamic example is using C++ style comments, which will cause a syntax error in python. Changed to use Python comment syntax instead.

## Test Plan

Docs-only change; no functional change.