### PR TITLE
[Profiler] Pass typed NCCL metadata to Kineto

### DIFF
--- a/test/cpp/profiler/comms_id.cpp
+++ b/test/cpp/profiler/comms_id.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include <limits>
+
 #include <c10/util/ThreadLocalDebugInfo.h>
 #include <torch/csrc/distributed/c10d/ParamCommsUtils.hpp>
 #include <torch/csrc/profiler/util.h>
@@ -49,6 +51,39 @@ std::string getCommsIdViaSaveNcclMeta(
 }
 
 } // namespace
+
+TEST(CommsIdTest, SaveNcclMetaTypedPreservesTypes) {
+  auto debugInfo =
+      makeDebugInfo("pg_uid", "custom_pg", 2, "allreduce", 4, 42, false, 4, 2);
+  c10::DebugInfoGuard guard(c10::DebugInfoKind::PARAM_COMMS_INFO, debugInfo);
+  at::RecordFunction fn(at::RecordScope::USER_SCOPE);
+  auto metadata = saveNcclMetaTyped(fn);
+
+  EXPECT_EQ(metadata.at(kCommsName).toStringRef(), "allreduce");
+  EXPECT_EQ(metadata.at(kDtype).toStringRef(), "Float");
+  EXPECT_EQ(metadata.at(kInMsgNelems).toInt(), 1024);
+  EXPECT_EQ(metadata.at(kGroupRanks).toStringRef(), "[4, 6, 8, 10]");
+  EXPECT_TRUE(metadata.at(kCommsId).isUnsigned());
+  EXPECT_TRUE(metadata.at(kIsAsynchronizedOp).toBool());
+}
+
+TEST(CommsIdTest, NcclMetaStringMapFormatsValues) {
+  collective_meta_t metadata;
+  metadata.emplace(kCommsName, "allreduce");
+  metadata.emplace(kDtype, "Float");
+  metadata.emplace(kInMsgNelems, int64_t{1024});
+  metadata.emplace(kIsAsynchronizedOp, false);
+  metadata.emplace(kCommsId, std::numeric_limits<uint64_t>::max());
+  metadata.emplace(kInSplit, "[1, 2]");
+
+  auto formatted = ncclMetaToStringMap(metadata);
+  EXPECT_EQ(formatted.at(kCommsName), "\"allreduce\"");
+  EXPECT_EQ(formatted.at(kDtype), "\"Float\"");
+  EXPECT_EQ(formatted.at(kInMsgNelems), "1024");
+  EXPECT_EQ(formatted.at(kIsAsynchronizedOp), "false");
+  EXPECT_EQ(formatted.at(kCommsId), "18446744073709551615");
+  EXPECT_EQ(formatted.at(kInSplit), "\"[1, 2]\"");
+}
 
 TEST(CommsIdTest, ParamCommsDebugInfoStoresSeqNumberAndIsP2P) {
   auto info =

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -443,13 +443,12 @@ void onFunctionExitImpl(
   kineto_ctx_ptr->event_->basic_fields_.end_tid_ =
       at::RecordFunction::currentThreadId();
   if (fn.isNcclMeta()) {
-    auto& extra_meta = *(kineto_ctx_ptr->event_->extra_nccl_meta_);
-    // Record only the outputs in this exit callback of the record function
-    torch::profiler::impl::SaveNcclMetaConfig ncclMetaConfig{
+    auto& metadata = *kineto_ctx_ptr->event_->collective_meta_;
+    torch::profiler::impl::SaveNcclMetaConfig nccl_meta_config{
         true, false, false, true};
-    auto additional_nccl_meta =
-        torch::profiler::impl::saveNcclMeta(fn, ncclMetaConfig);
-    extra_meta.insert(additional_nccl_meta.begin(), additional_nccl_meta.end());
+    auto output_metadata =
+        torch::profiler::impl::saveNcclMetaTyped(fn, nccl_meta_config);
+    metadata.insert(output_metadata.begin(), output_metadata.end());
   }
   if (config.state == ProfilerState::KINETO_GPU_FALLBACK) {
     try {
@@ -1273,7 +1272,9 @@ TYPED_ATTR(TorchOp, isAsync, e.is_async_)
 extra_meta_t KinetoEvent::extraMeta() const {
   extra_meta_t out;
   result_->visit(c10::overloaded(
-      [&](const ExtraFields<EventType::TorchOp>& e) { out = e.extra_meta_; },
+      [&](const ExtraFields<EventType::TorchOp>& e) {
+        out = torch::profiler::impl::ncclMetaToStringMap(e.collective_meta_);
+      },
       [&](const ExtraFields<EventType::Kineto>& e) { out = e.extra_meta_; },
       [](const auto&) {}));
   return out;

--- a/torch/csrc/profiler/collection.cpp
+++ b/torch/csrc/profiler/collection.cpp
@@ -446,15 +446,12 @@ std::unique_ptr<KinetoObserverContext> ThreadLocalSubqueue::begin_op(
   auto out = std::make_unique<KinetoObserverContext>(event);
   out->pushed_correlation_id_ = pushed_correlation_id;
   if (fn.isNcclMeta()) {
-    // Record NCCL metadata for specific CPU ops, switch off output
-    // introspection in this begin_op callback, we will do that in exit callback
-    // if needed.
-    torch::profiler::impl::SaveNcclMetaConfig ncclMetaConfig{
+    torch::profiler::impl::SaveNcclMetaConfig nccl_meta_config{
         true, true, true, false};
-    out->event_->extra_nccl_meta_ = torch_ops_.extra_meta_.emplace_back(
-        torch::profiler::impl::saveNcclMeta(fn, ncclMetaConfig));
+    out->event_->collective_meta_ = torch_ops_.collective_meta_.emplace_back(
+        torch::profiler::impl::saveNcclMetaTyped(fn, nccl_meta_config));
   } else {
-    out->event_->extra_nccl_meta_ = torch_ops_.extra_meta_.emplace_back();
+    out->event_->collective_meta_ = torch_ops_.collective_meta_.emplace_back();
   }
 
   if (config_.state == ProfilerState::KINETO_GPU_FALLBACK) {
@@ -557,7 +554,7 @@ void ThreadLocalSubqueue::TorchOpStorage::materialize(
   auto jit_stack = StealOrDefault(jit_stack_);
   auto jit_module = StealOrDefault(jit_modules_);
   auto extra_args = StealOrDefault(extra_args_);
-  auto extra_meta = StealOrDefault(extra_meta_);
+  auto collective_meta = StealOrDefault(collective_meta_);
   auto kwinputs = StealOrDefault(kwinputs_);
   auto gpu_fallback = StealOrDefault(device_fallback_);
 
@@ -571,7 +568,7 @@ void ThreadLocalSubqueue::TorchOpStorage::materialize(
         jit_stack(),
         jit_module(),
         extra_args(),
-        extra_meta(),
+        collective_meta(),
         kwinputs(),
         gpu_fallback(),
         event->allow_tf32_cublas_,

--- a/torch/csrc/profiler/collection.h
+++ b/torch/csrc/profiler/collection.h
@@ -171,7 +171,7 @@ struct ExtraFields<EventType::TorchOp> : TorchOpBasicFields {
       jit_stack_t&& jit_stack,
       jit_modules_t&& jit_modules,
       extra_args_t&& extra_args,
-      extra_meta_t&& extra_meta,
+      collective_meta_t&& collective_meta,
       kwinputs_t&& kwinputs,
       FallbackPair&& device_fallback,
       bool allow_tf32_cublas,
@@ -184,7 +184,7 @@ struct ExtraFields<EventType::TorchOp> : TorchOpBasicFields {
         jit_stack_{std::move(jit_stack)},
         jit_modules_{std::move(jit_modules)},
         extra_args_{std::move(extra_args)},
-        extra_meta_{std::move(extra_meta)},
+        collective_meta_{std::move(collective_meta)},
         kwinputs_{std::move(kwinputs)},
         device_fallback_{std::move(device_fallback)},
         allow_tf32_cublas_{allow_tf32_cublas},
@@ -196,7 +196,7 @@ struct ExtraFields<EventType::TorchOp> : TorchOpBasicFields {
   jit_stack_t jit_stack_;
   jit_modules_t jit_modules_;
   extra_args_t extra_args_;
-  extra_meta_t extra_meta_;
+  collective_meta_t collective_meta_;
   kwinputs_t kwinputs_;
   FallbackPair device_fallback_;
   bool allow_tf32_cublas_;
@@ -478,7 +478,7 @@ struct KinetoObserverContext : public at::ObserverContext {
 
     bool allow_tf32_cublas_;
     std::unique_ptr<perf_counters_t> counters_;
-    extra_meta_t* extra_nccl_meta_{};
+    collective_meta_t* collective_meta_{};
   };
 
   explicit KinetoObserverContext(Event* event) : event_{event} {}
@@ -654,8 +654,8 @@ class TORCH_API ThreadLocalSubqueue {
     // with_flops
     AppendOnlyList<extra_args_t, BlockSize> extra_args_;
 
-    // report extra metadata, i.e. collective communication meta
-    AppendOnlyList<extra_meta_t, BlockSize> extra_meta_;
+    // report collective communication metadata
+    AppendOnlyList<collective_meta_t, BlockSize> collective_meta_;
 
     // report kwinputs
     AppendOnlyList<kwinputs_t, BlockSize> kwinputs_;

--- a/torch/csrc/profiler/kineto_metadata.cpp
+++ b/torch/csrc/profiler/kineto_metadata.cpp
@@ -38,8 +38,12 @@ using torch::profiler::impl::variantShapesTruncated;
 #ifdef USE_KINETO
 
 namespace fields = libkineto::GenericMetadataFields;
+namespace collective_fields = libkineto::CollectiveMetadataFields;
 
 namespace {
+
+template <typename>
+inline constexpr bool always_false_v = false;
 
 struct MetadataBase {
   /* implicit */ MetadataBase(const std::shared_ptr<Result>& result)
@@ -85,6 +89,27 @@ struct MetadataBase {
       }
     }
     mutableActivity()->addMetadata(field, value);
+  }
+
+  template <typename T>
+  void addCollectiveMetadata(
+      const libkineto::MetadataField<T>& field,
+      const torch::profiler::impl::collective_meta_t& metadata) {
+    const auto it = metadata.find(std::string{field.name});
+    if (it == metadata.end()) {
+      return;
+    }
+    if constexpr (std::is_same_v<T, std::string>) {
+      addMetadata(field, it->second.toStringRef());
+    } else if constexpr (std::is_same_v<T, int64_t>) {
+      addMetadata(field, it->second.toInt());
+    } else if constexpr (std::is_same_v<T, uint64_t>) {
+      addMetadata(field, it->second.toUInt());
+    } else if constexpr (std::is_same_v<T, bool>) {
+      addMetadata(field, it->second.toBool());
+    } else {
+      static_assert(always_false_v<T>, "Unsupported collective metadata type");
+    }
   }
 
   bool hasKinetoActivity() const {
@@ -221,9 +246,32 @@ struct AddGenericMetadata : public MetadataBase {
         addMetadata(key, ivalueToStr(val, isString));
       }
     }
-    // Add extra metadata if any
-    for (const auto& [key, val] : op_event.extra_meta_) {
-      addMetadata(key, val);
+    const auto& metadata = op_event.collective_meta_;
+    if (!metadata.empty()) {
+      addCollectiveMetadata(collective_fields::kCollectiveName, metadata);
+      addCollectiveMetadata(collective_fields::kDtype, metadata);
+      // These are manually set for now because Kineto uses getMetadataValue to
+      // fetch metadata by key. Adding by key enforces that the MetadataField
+      // key matches. Soon NCCL metadata should be written by a visitor
+      // pattern and we can remove this.
+      addCollectiveMetadata(collective_fields::kInMsgNelems, metadata);
+      addCollectiveMetadata(collective_fields::kOutMsgNelems, metadata);
+      addCollectiveMetadata(collective_fields::kInSplit, metadata);
+      addCollectiveMetadata(collective_fields::kOutSplit, metadata);
+      addCollectiveMetadata(collective_fields::kGlobalRankStart, metadata);
+      addCollectiveMetadata(collective_fields::kGlobalRankStride, metadata);
+      addCollectiveMetadata(collective_fields::kGroupSize, metadata);
+      addCollectiveMetadata(collective_fields::kProcessGroupName, metadata);
+      addCollectiveMetadata(collective_fields::kProcessGroupDesc, metadata);
+      addCollectiveMetadata(collective_fields::kGroupRanks, metadata);
+      addCollectiveMetadata(collective_fields::kRank, metadata);
+      addCollectiveMetadata(collective_fields::kP2pSrc, metadata);
+      addCollectiveMetadata(collective_fields::kP2pDst, metadata);
+      addCollectiveMetadata(collective_fields::kSeqNum, metadata);
+      addCollectiveMetadata(collective_fields::kInTensorsStart, metadata);
+      addCollectiveMetadata(collective_fields::kOutTensorsStart, metadata);
+      addCollectiveMetadata(collective_fields::kIsAsynchronizedOp, metadata);
+      addCollectiveMetadata(collective_fields::kCommsId, metadata);
     }
 
     if (config_ && !config_->experimental_config.performance_events.empty()) {

--- a/torch/csrc/profiler/util.cpp
+++ b/torch/csrc/profiler/util.cpp
@@ -645,11 +645,9 @@ std::unordered_map<std::string, std::string> ncclMetaToStringMap(
     // @lint-ignore CLANGTIDY
     const collective_meta_t& metadata) {
   std::unordered_map<std::string, std::string> map;
-#ifdef USE_DISTRIBUTED
   for (const auto& [key, value] : metadata) {
     map.emplace(key, ivalueToStr(value, value.isString()));
   }
-#endif // USE_DISTRIBUTED
   return map;
 }
 

--- a/torch/csrc/profiler/util.cpp
+++ b/torch/csrc/profiler/util.cpp
@@ -503,12 +503,12 @@ std::pair<bool, std::variant<int, std::vector<int>>> findStartAddrForTensors(
   }
 }
 
-std::unordered_map<std::string, std::string> saveNcclMeta(
+collective_meta_t saveNcclMetaTyped(
     // @lint-ignore CLANGTIDY
     const at::RecordFunction& fn,
     // @lint-ignore CLANGTIDY
     const SaveNcclMetaConfig& config) {
-  std::unordered_map<std::string, std::string> map;
+  collective_meta_t metadata;
 #ifdef USE_DISTRIBUTED
   auto debugInfo = dynamic_cast<ParamCommsDebugInfo*>(
       c10::ThreadLocalDebugInfo::get(c10::DebugInfoKind::PARAM_COMMS_INFO));
@@ -517,72 +517,71 @@ std::unordered_map<std::string, std::string> saveNcclMeta(
     if (debugInfo == nullptr) {
       LOG(WARNING) << "ParamCommsDebugInfo not available for function: "
                    << fn.name();
-      return map;
+      return metadata;
     }
     auto& collective_name = debugInfo->getCollectiveName();
-    map.emplace(kCommsName, fmt::format("\"{}\"", collective_name));
-    map.emplace(
-        kDtype, fmt::format("\"{}\"", c10::toString(debugInfo->getDType())));
-    map.emplace(kInMsgNelems, std::to_string(debugInfo->getInMessageNelems()));
-    map.emplace(
-        kOutMsgNelems, std::to_string(debugInfo->getOutMessageNelems()));
+    metadata.emplace(kCommsName, collective_name);
+    metadata.emplace(kDtype, std::string(c10::toString(debugInfo->getDType())));
+    metadata.emplace(kInMsgNelems, debugInfo->getInMessageNelems());
+    metadata.emplace(kOutMsgNelems, debugInfo->getOutMessageNelems());
 
     auto& inSplitSizes = debugInfo->getInputSplitSizes();
-    map.emplace(kInSplit, format_list(inSplitSizes, config.truncate));
+    metadata.emplace(
+        kInSplit, format_list(inSplitSizes, config.truncate, false));
 
     auto& outSplitSizes = debugInfo->getOutputSplitSizes();
-    map.emplace(kOutSplit, format_list(outSplitSizes, config.truncate));
+    metadata.emplace(
+        kOutSplit, format_list(outSplitSizes, config.truncate, false));
 
     auto globalRankStart = debugInfo->getGlobalRankStart();
     if (globalRankStart >= 0) {
-      map.emplace(kGlobalRankStart, std::to_string(globalRankStart));
+      metadata.emplace(kGlobalRankStart, globalRankStart);
     }
     auto globalRankStride = debugInfo->getGlobalRankStride();
     if (globalRankStride > 0) {
-      map.emplace(kGlobalRankStride, std::to_string(globalRankStride));
+      metadata.emplace(kGlobalRankStride, globalRankStride);
     }
-    map.emplace(kGroupSize, std::to_string(debugInfo->getWorldSize()));
+    metadata.emplace(kGroupSize, debugInfo->getWorldSize());
     auto& group_name = debugInfo->getProcessGroupName();
     if (!group_name.empty()) {
-      map.emplace(kProcessGroupName, fmt::format("\"{}\"", group_name));
+      metadata.emplace(kProcessGroupName, group_name);
     }
     auto& group_desc = debugInfo->getProcessGroupDesc();
     if (!group_desc.empty()) {
-      map.emplace(kProcessGroupDesc, fmt::format("\"{}\"", group_desc));
+      metadata.emplace(kProcessGroupDesc, group_desc);
     }
     auto& groupRanks = debugInfo->getGroupRanks();
-    map.emplace(kGroupRanks, format_list(groupRanks, config.truncate));
+    metadata.emplace(
+        kGroupRanks, format_list(groupRanks, config.truncate, false));
 
     auto rank = debugInfo->getRank();
-    map.emplace(kRank, std::to_string(rank));
+    metadata.emplace(kRank, rank);
     int nRanks = static_cast<int>(groupRanks.size());
     if (collective_name == "send") {
       if (rank >= 0 && rank < nRanks) {
-        map.emplace(kP2pDst, std::to_string(groupRanks[rank]));
+        metadata.emplace(kP2pDst, groupRanks[rank]);
       }
     } else if (collective_name == "recv") {
       if (rank >= 0 && rank < nRanks) {
-        map.emplace(kP2pSrc, std::to_string(groupRanks[rank]));
+        metadata.emplace(kP2pSrc, groupRanks[rank]);
       }
     }
 
     auto seqNum = debugInfo->getSequenceNumber();
     if (seqNum >= 0) {
-      map.emplace(kSeqNum, std::to_string(seqNum));
+      metadata.emplace(kSeqNum, seqNum);
 
-      size_t comms_id = c10::get_hash(
+      uint64_t comms_id = static_cast<uint64_t>(c10::get_hash(
           debugInfo->getProcessGroupName(),
           seqNum,
           debugInfo->getIsP2P(),
           globalRankStart,
           globalRankStride,
-          debugInfo->getWorldSize());
-      map.emplace(kCommsId, std::to_string(comms_id));
+          debugInfo->getWorldSize()));
+      metadata.emplace(kCommsId, comms_id);
     }
   }
-
-  map.emplace(
-      kIsAsynchronizedOp, std::to_string(debugInfo->isAsynchronizedOp()));
+  metadata.emplace(kIsAsynchronizedOp, debugInfo->isAsynchronizedOp());
 
   if (get_record_tensor_addrs_enabled()) {
     std::vector<std::string> addressList;
@@ -609,7 +608,8 @@ std::unordered_map<std::string, std::string> saveNcclMeta(
           // break out of the loop here.
           break;
         }
-        map.emplace(kInTensorsStart, format_list(addressList, false));
+        metadata.emplace(
+            kInTensorsStart, format_list(addressList, false, false));
         addressList.clear();
       }
     }
@@ -631,13 +631,32 @@ std::unordered_map<std::string, std::string> saveNcclMeta(
             addressList.push_back(std::to_string(scalar_result));
           }
         }
-        map.emplace(kOutTensorsStart, format_list(addressList, false));
+        metadata.emplace(
+            kOutTensorsStart, format_list(addressList, false, false));
         addressList.clear();
       }
     }
   }
 #endif // USE_DISTRIBUTED
+  return metadata;
+}
+
+std::unordered_map<std::string, std::string> ncclMetaToStringMap(
+    // @lint-ignore CLANGTIDY
+    const collective_meta_t& metadata) {
+  std::unordered_map<std::string, std::string> map;
+#ifdef USE_DISTRIBUTED
+  for (const auto& [key, value] : metadata) {
+    map.emplace(key, ivalueToStr(value, value.isString()));
+  }
+#endif // USE_DISTRIBUTED
   return map;
+}
+
+std::unordered_map<std::string, std::string> saveNcclMeta(
+    const at::RecordFunction& fn,
+    const SaveNcclMetaConfig& config) {
+  return ncclMetaToStringMap(saveNcclMetaTyped(fn, config));
 }
 
 // ----------------------------------------------------------------------------

--- a/torch/csrc/profiler/util.h
+++ b/torch/csrc/profiler/util.h
@@ -102,6 +102,10 @@ struct TORCH_API SaveNcclMetaConfig {
         introspectOutputs(introspectOutputs) {}
 };
 
+// List-shaped values stay as opaque, preformatted strings because truncation
+// can insert "...". Do not parse or restructure them.
+using collective_meta_t = std::unordered_map<std::string, c10::IValue>;
+
 TORCH_API std::vector<FileLineFunc> prepareCallstack(
     const std::vector<jit::StackEntry>& cs);
 TORCH_API std::vector<std::string> callstackStr(
@@ -133,6 +137,11 @@ TORCH_API std::vector<std::string> inputTypes(const at::RecordFunction& fn);
 
 std::unordered_map<std::string, c10::IValue> TORCH_API
 saveExtraArgs(const at::RecordFunction& fn);
+TORCH_API collective_meta_t saveNcclMetaTyped(
+    const at::RecordFunction& fn,
+    const SaveNcclMetaConfig& config = SaveNcclMetaConfig());
+TORCH_API std::unordered_map<std::string, std::string> ncclMetaToStringMap(
+    const collective_meta_t& metadata);
 std::unordered_map<std::string, std::string> TORCH_API saveNcclMeta(
     const at::RecordFunction& fn,
     const SaveNcclMetaConfig& config = SaveNcclMetaConfig());


### PR DESCRIPTION
Currently, all NCCL metadata gets cast to string before being sent to Kineto to write to the final output. This is super inefficient because this metadata is directly written to JSON, and from that JSON we re-parse from string to populate other output formats. We have been doing a lot of work to add support for dealing with typed metadata directly -- including in `GenericTraceActivity` -- so that we can skip the JSON roundtrip.

To support this for NCCL metadata we add `saveNcclMetaTyped(`), which mirrors the existing NCCL metadata collection logic but stores values as `IValue` instead of string. As before, core and input metadata are captured when the op starts and output metadata is merged into the same record when it finishes, but TorchOp stores this separately from generic `extra_meta_`. We also continue to pass the metadata back to Kineto by adding them to `GenericTraceActivity`, but now we use the NCCL `MetadataField`s we recently added.

We only convert the typed map back to the legacy string map for compatibility paths such as `KinetoEvent.extraMeta()`. saveNcclMeta() remains as a compatibility wrapper around the typed implementation. Rank lists, split-size lists, and tensor-start diagnostics remain strings because their existing representation may contain truncation markers or pre-formatted JSON (i.e. ["a", "b", "c", "...", "d"].

Note that using `MetadataField` is only a requirement if Kineto needs to fetch the field by value (which it needs to do for all NCCL metadata in output_json.cpp right now). In the future, we'd like to align NCCL metadata so it's similar to other activities and doesn't need to be fetched by value -- at that point, you can send the metadata back via `addTypedMetadata` and then the visitor class will automatically add it to the various output formats. This would allow you to add new metadata on the PyTorch side without waiting for a new `MetadataField` to land in Kineto. 