### PR TITLE
Bump cublasLt grouped GEMM version requirement to 13.3

### DIFF
--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -224,7 +224,7 @@ using detail::CuBlasLtMatmulDescriptor;
 using detail::CuBlasLtMatrixLayout;
 using detail::CuBlasLtMatmulPreference;
 using detail::CublasLtWorkspace;
-#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13020
+#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13030
 using detail::CuBlasLtGroupedMatrixLayout;
 #endif
 
@@ -2224,7 +2224,7 @@ void grouped_gemm(
     const void *lddArrayDev,
     int batchCount,
     bool use_int64_dims) {
-#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13020
+#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13030
   cudaDeviceProp* prop = at::cuda::getCurrentDeviceProperties();
   const bool sm90 = prop->major == 9;
   TORCH_CHECK(prop->major >= 9 && prop->major < 12, "grouped cublasLtMatmul requires SM 9.0-11.0");
@@ -2309,8 +2309,8 @@ void grouped_gemm(
       " when calling grouped cublasLtMatmul");
   return;
 #else
-  TORCH_CHECK(false, "grouped cublasLtMatmul requires CUDA >= 13.2 and is not supported on ROCm. Current build does not meet these requirements.");
-#endif // !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13020
+  TORCH_CHECK(false, "grouped cublasLtMatmul requires CUDA >= 13.3 and is not supported on ROCm. Current build does not meet these requirements.");
+#endif // !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13030
 }
 
 template <>

--- a/aten/src/ATen/cuda/detail/CublasLtUtils.h
+++ b/aten/src/ATen/cuda/detail/CublasLtUtils.h
@@ -81,7 +81,7 @@ class CuBlasLtMatrixLayout : public CuBlasLtDescriptor<
   }
 };
 
-#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13020
+#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13030
 class CuBlasLtGroupedMatrixLayout : public CuBlasLtDescriptor<
                                         cublasLtMatrixLayoutOpaque_t,
                                         &cublasLtMatrixLayoutDestroy> {
@@ -120,7 +120,7 @@ class CuBlasLtGroupedMatrixLayout : public CuBlasLtDescriptor<
         descriptor(), attr, &value, sizeof(T)));
   }
 };
-#endif // !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13020
+#endif // !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13030
 
 class CuBlasLtMatmulPreference : public CuBlasLtDescriptor<
                                      cublasLtMatmulPreferenceOpaque_t,

--- a/aten/src/ATen/native/cuda/CublasGroupedArgs.cu
+++ b/aten/src/ATen/native/cuda/CublasGroupedArgs.cu
@@ -13,7 +13,7 @@
 
 namespace at::native {
 
-#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13020
+#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13030
 
 namespace {
 
@@ -323,6 +323,6 @@ cublasGroupedArgs::cublasGroupedArgs(
       stream);
 }
 
-#endif // !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13020
+#endif // !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13030
 
 } // namespace at::native

--- a/aten/src/ATen/native/cuda/CublasGroupedArgs.h
+++ b/aten/src/ATen/native/cuda/CublasGroupedArgs.h
@@ -10,7 +10,7 @@
 
 namespace at::native {
 
-#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13020
+#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13030
 struct cublasGroupedArgs {
   cublasGroupedArgs(
       const Tensor& mat1,
@@ -48,6 +48,6 @@ struct cublasGroupedArgs {
   float* alphaScalar;
   float* betaScalar;
 };
-#endif // !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13020
+#endif // !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13030
 
 } // namespace at::native

--- a/aten/src/ATen/native/cuda/GroupedBlas.cpp
+++ b/aten/src/ATen/native/cuda/GroupedBlas.cpp
@@ -104,7 +104,7 @@ bool should_use_cublaslt_grouped_gemm(
     const std::optional<Tensor>& offs,
     std::optional<c10::ScalarType> out_dtype) {
   const auto dprops = at::cuda::getCurrentDeviceProperties();
-  const bool valid_sm = 
+  const bool valid_sm =
       dprops->major >= 9 && dprops->major <= 11;
   if (!valid_sm) {
     return false;

--- a/aten/src/ATen/native/cuda/GroupedBlas.cpp
+++ b/aten/src/ATen/native/cuda/GroupedBlas.cpp
@@ -19,7 +19,7 @@
 #include <ATen/native/Resize.h>
 #include <c10/util/MaybeOwned.h>
 #include <ATen/native/GroupedMMUtils.h>
-#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13020
+#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13030
 #include <ATen/cuda/detail/CublasLtUtils.h>
 #include <ATen/native/cuda/CublasGroupedArgs.h>
 #endif
@@ -97,21 +97,18 @@ bool _scaled_mm_allowed_device(bool sm90_only=false, bool sm100_only=false) {
 #endif
 }
 
-#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13020
+#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13030
 bool should_use_cublaslt_grouped_gemm(
     const Tensor& mat_a,
     const Tensor& mat_b,
     const std::optional<Tensor>& offs,
     std::optional<c10::ScalarType> out_dtype) {
   const auto dprops = at::cuda::getCurrentDeviceProperties();
-  const bool sm90 = dprops->major == 9;
-  const bool sm10_or_sm11 =
-      dprops->major == 10 || dprops->major == 11;
-#if CUDA_VERSION >= 13030
-  const bool sm90_cublaslt_grouped_gemm_supported = sm90;
-#else
-  constexpr bool sm90_cublaslt_grouped_gemm_supported = false;
-#endif
+  const bool valid_sm = 
+      dprops->major >= 9 && dprops->major <= 11;
+  if (!valid_sm) {
+    return false;
+  }
   const bool fp16_grouped_gemm =
       mat_a.dtype() == at::kHalf && mat_b.dtype() == at::kHalf &&
       out_dtype.value_or(at::kHalf) == at::kHalf;
@@ -130,20 +127,10 @@ bool should_use_cublaslt_grouped_gemm(
     return false;
   }
 
-  const bool use_fp16_by_default =
-      sm10_or_sm11 || sm90_cublaslt_grouped_gemm_supported;
-  if (use_fp16_by_default && fp16_grouped_gemm) {
+  if (fp16_grouped_gemm) {
     return true;
   }
-  if (sm90) {
-    if (!sm90_cublaslt_grouped_gemm_supported) {
-      return false;
-    }
-    return bf16_grouped_gemm && at::globalContext().preferCublasltGroupedGemm();
-  }
-  // Only SM 9.0-11.0 are supported; on any other arch fall back so we don't
-  // dispatch to a kernel that hard-errors on the device check.
-  return sm10_or_sm11 && bf16_grouped_gemm &&
+  return bf16_grouped_gemm &&
       at::globalContext().preferCublasltGroupedGemm();
 }
 #endif
@@ -474,7 +461,7 @@ static Tensor grouped_mm_cublaslt(const Tensor& mat_a, const Tensor& mat_b,
 const std::optional<at::Tensor>& offs,
 const std::optional<at::Tensor>& bias,
 std::optional<c10::ScalarType> out_dtype) {
-#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13020
+#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13030
   TORCH_CHECK(
       mat_a.dtype() == at::kBFloat16 || mat_a.dtype() == at::kHalf,
       "cublasLt grouped GEMM requires BFloat16 or Float16 input, got ", mat_a.scalar_type());
@@ -521,8 +508,8 @@ std::optional<c10::ScalarType> out_dtype) {
                                args.batchCount, args.use_int64);
   return out;
 #else
-  TORCH_CHECK(false, "cublasLt grouped GEMM requires CUDA >= 13.2 and is not supported on ROCm. Current build does not meet these requirements.");
-#endif // !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13020
+  TORCH_CHECK(false, "cublasLt grouped GEMM requires CUDA >= 13.3 and is not supported on ROCm. Current build does not meet these requirements.");
+#endif // !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13030
 }
 
 Tensor
@@ -796,7 +783,7 @@ const std::optional<at::Tensor>& offs,
 const std::optional<at::Tensor>& bias,
 std::optional<c10::ScalarType> out_dtype) {
   _grouped_mm_validate_inputs(mat_a, mat_b, offs, bias, out_dtype);
-#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13020
+#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 13030
   if (should_use_cublaslt_grouped_gemm(mat_a, mat_b, offs, out_dtype)) {
     return grouped_mm_cublaslt(mat_a, mat_b, offs, bias, out_dtype);
   }

--- a/test/distributed/tensor/test_matrix_ops.py
+++ b/test/distributed/tensor/test_matrix_ops.py
@@ -1046,15 +1046,11 @@ class DistMatrixOpsTest(DTensorTestBase):
     )
     def test_grouped_mm(self, backend, kwargs):
         if backend == "cublaslt":
-            if _get_torch_cuda_version() < (13, 2):
-                self.skipTest("cublaslt grouped gemm requires CUDA Toolkit >= 13.2")
+            if _get_torch_cuda_version() < (13, 3):
+                self.skipTest("cublaslt grouped gemm requires CUDA Toolkit >= 13.3")
             sm_major = torch.cuda.get_device_capability()[0]
             if sm_major < 9 or sm_major >= 12:
                 self.skipTest("cublaslt grouped gemm requires SM 9.0-11.0")
-            if sm_major == 9 and _get_torch_cuda_version() < (13, 3):
-                self.skipTest(
-                    "cublaslt grouped gemm on SM 9.0 requires CUDA Toolkit >= 13.3"
-                )
         # TODO: torch.nn.functional.grouped_mm can take inputs of dimension (2D, 3D) x (2D, 3D)
         # More tests need to be added.
         device_mesh = self.build_device_mesh()

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -19623,15 +19623,11 @@ if RUN_GPU:
         @parametrize("backend", ["cublaslt", "cutlass"])
         def test_grouped_mm(self, backend):
             if backend == "cublaslt":
-                if _get_torch_cuda_version() < (13, 2):
-                    self.skipTest("cublaslt grouped gemm requires CUDA Toolkit >= 13.2")
+                if _get_torch_cuda_version() < (13, 3):
+                    self.skipTest("cublaslt grouped gemm requires CUDA Toolkit >= 13.3")
                 sm_major = torch.cuda.get_device_capability()[0]
                 if sm_major < 9 or sm_major >= 12:
                     self.skipTest("cublaslt grouped gemm requires SM 9.0-11.0")
-                if sm_major == 9 and _get_torch_cuda_version() < (13, 3):
-                    self.skipTest(
-                        "cublaslt grouped gemm on SM 9.0 requires CUDA Toolkit >= 13.3"
-                    )
             prev = torch.backends.cuda.matmul.prefer_cublaslt_grouped_gemm
             torch.backends.cuda.matmul.prefer_cublaslt_grouped_gemm = (
                 backend == "cublaslt"

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -1009,10 +1009,8 @@ class TestMatmulCuda(InductorTestCase):
         raise AssertionError(f"Invalid op: {op}")
 
     @unittest.skipIf(TEST_WITH_ROCM, "ROCm doesn't support cuBLASLt grouped GEMM")
-    @unittest.skipIf(TEST_CUDA and _get_torch_cuda_version() < (13, 2), "cublaslt grouped gemm requires CUDA Toolkit >= 13.2")
+    @unittest.skipIf(TEST_CUDA and _get_torch_cuda_version() < (13, 3), "cublaslt grouped gemm requires CUDA Toolkit >= 13.3")
     @unittest.skipIf(not SM90OrLater or SM120OrLater, "cublaslt grouped gemm requires SM 9.0-11.0")
-    @unittest.skipIf(SM90OrLater and not SM100OrLater and _get_torch_cuda_version() < (13, 3),
-                     "cublaslt grouped gemm on SM 9.0 requires CUDA Toolkit >= 13.3")
     @parametrize("op", ["2d/2d", "2d/3d", "3d/2d", "3d/3d"])
     @parametrize("jagged_size", [31, 32])
     @parametrize("a_row_major", [False, True])
@@ -1039,10 +1037,8 @@ class TestMatmulCuda(InductorTestCase):
         self.assertEqual(C, C_ref)
 
     @unittest.skipIf(TEST_WITH_ROCM, "ROCm doesn't support cuBLASLt grouped GEMM")
-    @unittest.skipIf(TEST_CUDA and _get_torch_cuda_version() < (13, 2), "cublaslt grouped gemm requires CUDA Toolkit >= 13.2")
+    @unittest.skipIf(TEST_CUDA and _get_torch_cuda_version() < (13, 3), "cublaslt grouped gemm requires CUDA Toolkit >= 13.3")
     @unittest.skipIf(not SM90OrLater or SM120OrLater, "cublaslt grouped gemm requires SM 9.0-11.0")
-    @unittest.skipIf(SM90OrLater and not SM100OrLater and _get_torch_cuda_version() < (13, 3),
-                     "cublaslt grouped gemm on SM 9.0 requires CUDA Toolkit >= 13.3")
     @parametrize("op", ["2d/2d", "2d/3d", "3d/2d", "3d/3d"])
     @parametrize("jagged_size", [31, 32])
     @parametrize("a_row_major", [False, True])
@@ -1085,10 +1081,8 @@ class TestMatmulCuda(InductorTestCase):
             torch._grouped_mm(A, B, offs=offs)
 
     @unittest.skipIf(TEST_WITH_ROCM, "ROCm doesn't support cuBLASLt grouped GEMM")
-    @unittest.skipIf(TEST_CUDA and _get_torch_cuda_version() < (13, 2), "cublaslt grouped gemm requires CUDA Toolkit >= 13.2")
+    @unittest.skipIf(TEST_CUDA and _get_torch_cuda_version() < (13, 3), "cublaslt grouped gemm requires CUDA Toolkit >= 13.3")
     @unittest.skipIf(not SM90OrLater or SM120OrLater, "cublaslt grouped gemm requires SM 9.0-11.0")
-    @unittest.skipIf(SM90OrLater and not SM100OrLater and _get_torch_cuda_version() < (13, 3),
-                     "cublaslt grouped gemm on SM 9.0 requires CUDA Toolkit >= 13.3")
     @parametrize("op", ["2d/2d", "2d/3d", "3d/3d"])
     def test_grouped_gemm_cublaslt_int64_indexing(self, op):
         # Verify that the int64 indexing path works correctly when a

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -8632,10 +8632,8 @@ def _grouped_mm_fp16_cublaslt_supported(
     if torch.version.cuda:
         parts = torch.version.cuda.split(".")
         cuda_version = (int(parts[0]), int(parts[1]))
-    if device_capability[0] == 9:
-        return cuda_version >= (13, 3)
-    return cuda_version >= (13, 2) and (
-        device_capability[0] == 10 or device_capability == (11, 0)
+    return cuda_version >= (13, 3) and (
+        device_capability[0] >= 9 and device_capability[0] <= 11
     )
 
 


### PR DESCRIPTION
Row-major layouts are not working with cublasLt grouped GEMM prior to CTK 13.3, so this PR bumps the version requirement to 13.3+.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @eqy