### PR TITLE
[MPS] Add MPS stream pool and Python bindings

### DIFF
--- a/aten/src/ATen/mps/MPSAllocator.h
+++ b/aten/src/ATen/mps/MPSAllocator.h
@@ -78,6 +78,8 @@ struct BufferBlock {
   static uint64_t buffer_counter;
   // Metal events used to sync GPU/CPU operations on the shared-storage buffers
   MPSEventPtr event;
+  // Stream for which this buffer was allocated.
+  MPSStream* stream = nullptr;
 
   BufferBlock(size_t Size, size_t RequestedSize = 0, const id<MTLBuffer> Buffer = nullptr, HeapBlock* Heap = nullptr)
       : buffer(Buffer), size(Size), requested_size(RequestedSize), heap(Heap), buf_id(Buffer ? ++buffer_counter : 0) {}
@@ -260,6 +262,11 @@ struct BufferPool {
   std::set<HeapBlock*, HeapComparison> heaps;
   // list of only "available" buffers in the pool (i.e., buffers not in-use)
   std::set<BufferBlock*, BufferComparison> available_buffers;
+  // List of available buffers partitioned by which stream allocated them.
+  // Buffers can only be reused by the same stream. Allowing buffers to be used
+  // by a different stream would require an expensive cross-stream
+  // synchronization.
+  ska::flat_hash_map<MPSStream*, std::set<BufferBlock*, BufferComparison>> available_buffers_by_stream;
   // list of buffers that are in a state of "limbo" where they've already been freed
   // from PyTorch-side, but were not returned to pool due to still being
   // in-use by command buffers with retainCount > 1. In this state, the buffer is
@@ -423,6 +430,12 @@ class MPSHeapAllocatorImpl {
   void free_buffer(BufferBlock* buffer_block);
   // returns true if the container heap is also released
   bool release_buffer(BufferBlock* buffer_block, bool remove_empty_heap = true);
+  // adds/removes a buffer in both `pool.available_buffers` and
+  // `pool.available_buffers_by_stream[buffer_block->stream]`, so the two stay
+  // in sync. `insert_available_buffer` returns whether the buffer was newly
+  // inserted.
+  bool insert_available_buffer(BufferPool& pool, BufferBlock* buffer_block);
+  void erase_available_buffer(BufferPool& pool, BufferBlock* buffer_block);
   void release_buffers(BufferPool& pool);
   bool release_available_cached_buffers(AllocParams& params);
   bool release_cached_buffers();

--- a/aten/src/ATen/mps/MPSAllocator.mm
+++ b/aten/src/ATen/mps/MPSAllocator.mm
@@ -174,6 +174,7 @@ bool MPSHeapAllocatorImpl::alloc_buffer(AllocParams& params) {
   // insert heap after a buffer was created on it to update the order of heap's set
   pool.heaps.insert(heap);
   params.buffer_block = new BufferBlock(params.size(), params.requested_size, buffer, heap);
+  params.buffer_block->stream = getCurrentMPSStream();
   m_allocated_buffers[params.buffer_block->buffer] = params.buffer_block;
   pool.allocated_size += params.size();
   pool.n_buffers++;
@@ -203,37 +204,45 @@ bool MPSHeapAllocatorImpl::get_free_buffer(AllocParams& params) {
       ++b->gc_count;
     }
   }
-  auto it = pool.available_buffers.lower_bound(&params.search_key);
+  auto no_larger_it = pool.available_buffers.lower_bound(&params.search_key);
   // No cached buffer is >= the request size when this is true; used below to
   // detect a buffer that grows by a small amount on every step.
-  const bool no_larger_buffer = (it == pool.available_buffers.end());
-  if (it != pool.available_buffers.end()) {
-    BufferBlock* buffer_block = *it;
+  const bool no_larger_buffer = (no_larger_it == pool.available_buffers.end());
 
-    // the logic in here is simple: keep reusing existing heaps capacity as long as possible (by splitting
-    // or releasing oversize buffers, if required), and avoid 'new' heap allocations as much as possible.
-    if (buffer_block->size <= params.size() + kLargeHeap) {
-      // return the existing buffer if it already fits the requested size (i.e., not oversize)
-      params.buffer_block = buffer_block;
-    } else {
-      HeapBlock search_key(params.size());
-      // if there's an 'existing' heap with enough capacity, then don't
-      // return the oversize buffer and sub-allocate from that existing heap.
-      if (pool.heaps.lower_bound(&search_key) != pool.heaps.end()) {
-        params.buffer_block = nullptr;
-      } else if (buffer_block->retainCount() <= 1) {
-        // otherwise if buffer is releasable immediately, we make room by releasing the
-        // buffer and reuse the new space within its heap container for the new smaller buffer allocation
-        release_buffer(buffer_block, false);
-        // this will skip unnecessary garbage collection as we'll reuse the newly released space
-        params.has_memory_pressure = false;
-      } else if (params.has_memory_pressure) {
-        // the oversized buffer is busy and not reusable at the moment. So release it (and potentially its heap
-        // container) in allocator, and ARC will later free up its backing memory when the busy command buffer finishes.
-        release_buffer(buffer_block, true);
-      } else {
-        // only if there's no memory pressure, we'll reuse the oversized buffer
+  MPSStream* current_stream = getCurrentMPSStream();
+  auto stream_pool_it = pool.available_buffers_by_stream.find(current_stream);
+  if (stream_pool_it != pool.available_buffers_by_stream.end()) {
+    auto& stream_buffers = stream_pool_it->second;
+    auto it = stream_buffers.lower_bound(&params.search_key);
+    if (it != stream_buffers.end()) {
+      BufferBlock* buffer_block = *it;
+
+      // the logic in here is simple: keep reusing existing heaps capacity as long as possible (by splitting
+      // or releasing oversize buffers, if required), and avoid 'new' heap allocations as much as possible.
+      if (buffer_block->size <= params.size() + kLargeHeap) {
+        // return the existing buffer if it already fits the requested size (i.e., not oversize)
         params.buffer_block = buffer_block;
+      } else {
+        HeapBlock search_key(params.size());
+        // if there's an 'existing' heap with enough capacity, then don't
+        // return the oversize buffer and sub-allocate from that existing heap.
+        if (pool.heaps.lower_bound(&search_key) != pool.heaps.end()) {
+          params.buffer_block = nullptr;
+        } else if (buffer_block->retainCount() <= 1) {
+          // otherwise if buffer is releasable immediately, we make room by releasing the
+          // buffer and reuse the new space within its heap container for the new smaller buffer allocation
+          release_buffer(buffer_block, false);
+          // this will skip unnecessary garbage collection as we'll reuse the newly released space
+          params.has_memory_pressure = false;
+        } else if (params.has_memory_pressure) {
+          // the oversized buffer is busy and not reusable at the moment. So release it (and potentially its heap
+          // container) in allocator, and ARC will later free up its backing memory when the busy command buffer
+          // finishes.
+          release_buffer(buffer_block, true);
+        } else {
+          // only if there's no memory pressure, we'll reuse the oversized buffer
+          params.buffer_block = buffer_block;
+        }
       }
     }
   }
@@ -253,7 +262,7 @@ bool MPSHeapAllocatorImpl::get_free_buffer(AllocParams& params) {
     }
     return false; // this will make allocator to allocate a new buffer
   }
-  pool.available_buffers.erase(params.buffer_block);
+  erase_available_buffer(pool, params.buffer_block);
   params.buffer_block->requested_size = params.requested_size;
   params.buffer_block->gc_count = 0;
   pool.available_size -= params.buffer_block->size;
@@ -342,12 +351,32 @@ BufferBlock* MPSHeapAllocatorImpl::alloc_buffer_block(size_t size, uint32_t usag
   return buffer_block;
 }
 
+bool MPSHeapAllocatorImpl::insert_available_buffer(BufferPool& pool, BufferBlock* buffer_block) {
+  bool inserted = pool.available_buffers.insert(buffer_block).second;
+  auto it = pool.available_buffers_by_stream.find(buffer_block->stream);
+  if (it == pool.available_buffers_by_stream.end()) {
+    it = pool.available_buffers_by_stream
+             .emplace(buffer_block->stream, std::set<BufferBlock*, BufferComparison>(BufferBlock::Comparator))
+             .first;
+  }
+  it->second.insert(buffer_block);
+  return inserted;
+}
+
+void MPSHeapAllocatorImpl::erase_available_buffer(BufferPool& pool, BufferBlock* buffer_block) {
+  pool.available_buffers.erase(buffer_block);
+  auto it = pool.available_buffers_by_stream.find(buffer_block->stream);
+  if (it != pool.available_buffers_by_stream.end()) {
+    it->second.erase(buffer_block);
+  }
+}
+
 void MPSHeapAllocatorImpl::free_buffer(BufferBlock* buffer_block) {
   TORCH_INTERNAL_ASSERT(buffer_block->in_use);
 
   BufferPool& pool = *buffer_block->heap->pool;
   // Makes sure the BufferBlock* isn't already present in the pool we're freeing it back into.
-  TORCH_INTERNAL_ASSERT(pool.available_buffers.insert(buffer_block).second);
+  TORCH_INTERNAL_ASSERT(insert_available_buffer(pool, buffer_block));
   pool.available_size += buffer_block->size;
   buffer_block->shape.clear(); // reset shape
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(m_current_allocated_memory.current >= static_cast<int64_t>(buffer_block->size));
@@ -373,7 +402,7 @@ bool MPSHeapAllocatorImpl::release_buffer(BufferBlock* buffer_block, bool remove
   pool.allocated_size -= buffer_block->size;
   pool.available_size -= buffer_block->size;
   m_allocated_buffers.erase(buffer_block->buffer);
-  pool.available_buffers.erase(buffer_block);
+  erase_available_buffer(pool, buffer_block);
   pool.n_buffers--;
   // will re-insert later to keep the heaps list sorted based on heap's new available size (if heap not empty)
   pool.heaps.erase(heap_block);

--- a/aten/src/ATen/mps/MPSAllocator.mm
+++ b/aten/src/ATen/mps/MPSAllocator.mm
@@ -204,16 +204,18 @@ bool MPSHeapAllocatorImpl::get_free_buffer(AllocParams& params) {
       ++b->gc_count;
     }
   }
-  auto no_larger_it = pool.available_buffers.lower_bound(&params.search_key);
-  // No cached buffer is >= the request size when this is true; used below to
-  // detect a buffer that grows by a small amount on every step.
-  const bool no_larger_buffer = (no_larger_it == pool.available_buffers.end());
-
   MPSStream* current_stream = getCurrentMPSStream();
   auto stream_pool_it = pool.available_buffers_by_stream.find(current_stream);
+  bool no_larger_buffer = true;
+
   if (stream_pool_it != pool.available_buffers_by_stream.end()) {
     auto& stream_buffers = stream_pool_it->second;
     auto it = stream_buffers.lower_bound(&params.search_key);
+
+    // No cached buffer is >= the request size when this is true; used below to
+    // detect a buffer that grows by a small amount on every step.
+    no_larger_buffer = (it == stream_buffers.end());
+
     if (it != stream_buffers.end()) {
       BufferBlock* buffer_block = *it;
 
@@ -253,9 +255,10 @@ bool MPSHeapAllocatorImpl::get_free_buffer(AllocParams& params) {
     // buffers. Release the largest one within kNearFitReuseDenom (1/8) of the
     // request to free its heap. The tolerance is kept wider than a bucket so the
     // stranded near-fit is caught anywhere in the power-of-two band.
-    if (no_larger_buffer && !(pool.usage & UsageFlags::SMALL) && !pool.available_buffers.empty()) {
+    if (no_larger_buffer && !(pool.usage & UsageFlags::SMALL) &&
+        stream_pool_it != pool.available_buffers_by_stream.end() && !stream_pool_it->second.empty()) {
       constexpr size_t kNearFitReuseDenom = 8;
-      BufferBlock* nearest = *pool.available_buffers.rbegin();
+      BufferBlock* nearest = *stream_pool_it->second.rbegin();
       if (nearest->size >= params.size() - params.size() / kNearFitReuseDenom && nearest->retainCount() <= 1) {
         release_buffer(nearest, /*remove_empty_heap=*/true);
       }

--- a/aten/src/ATen/mps/MPSStream.h
+++ b/aten/src/ATen/mps/MPSStream.h
@@ -139,14 +139,29 @@ class TORCH_API MPSStream {
 };
 
 /**
- * Get the current MPS stream
+ * Get the current MPS stream for this thread. Returns the default stream if no
+ * other stream has been set with `setCurrentMPSStream()`.
  */
 TORCH_API MPSStream* getCurrentMPSStream();
+
+/**
+ * Set the current MPS stream for this thread. Kernels that call
+ * `getCurrentMPSStream()` will enqueue their work onto this stream. Passing
+ * nullptr sets to the default stream.
+ */
+TORCH_API void setCurrentMPSStream(MPSStream* stream);
 
 /**
  * Get the default MPS stream
  */
 TORCH_API MPSStream* getDefaultMPSStream();
+
+/**
+ * Get a stream from the pool. There are 32 streams in the pool which live for
+ * the lifetime of a process. The stream returned by this function is chosen
+ * in round-robin order. Note: The default stream is not in the pool.
+ */
+TORCH_API MPSStream* getStreamFromPool();
 
 //-----------------------------------------------------------------
 //  MPSStreamImpl

--- a/aten/src/ATen/mps/MPSStream.mm
+++ b/aten/src/ATen/mps/MPSStream.mm
@@ -4,6 +4,11 @@
 #include <ATen/mps/MPSProfiler.h>
 #include <ATen/mps/MPSStream.h>
 #include <c10/metal/error.h>
+#include <c10/util/CallOnce.h>
+#include <c10/util/irange.h>
+
+#include <array>
+#include <atomic>
 
 @interface MPSGraphExecutionDescriptor ()
 @property(readwrite, atomic) BOOL enableCommitAndContinue;
@@ -280,12 +285,44 @@ MPSStream* MPSStreamImpl::getInstance() {
 
 MPSStreamImpl::MPSStreamImpl() {}
 
+namespace {
+thread_local MPSStream* current_stream = nullptr;
+} // namespace
+
 MPSStream* getCurrentMPSStream() {
-  return getDefaultMPSStream();
+  return current_stream ? current_stream : getDefaultMPSStream();
+}
+
+void setCurrentMPSStream(MPSStream* stream) {
+  current_stream = stream;
 }
 
 MPSStream* getDefaultMPSStream() {
   return MPSStreamImpl::getInstance();
+}
+
+//-----------------------------------------------------------------
+//  MPS stream pool
+//-----------------------------------------------------------------
+
+namespace {
+constexpr int kMPSStreamsPerPool = 32;
+
+std::array<MPSStream*, kMPSStreamsPerPool> stream_pool{};
+c10::once_flag stream_pool_flag;
+std::atomic<uint32_t> stream_pool_counter{0};
+
+void initStreamPool() {
+  // Pool ids start at 1; id 0 is reserved for the default stream.
+  for (const auto i : c10::irange(kMPSStreamsPerPool)) {
+    stream_pool[i] = new MPSStream(Stream(Stream::UNSAFE, c10::Device(DeviceType::MPS, 0), i + 1));
+  }
+}
+} // namespace
+
+MPSStream* getStreamFromPool() {
+  c10::call_once(stream_pool_flag, initStreamPool);
+  return stream_pool[stream_pool_counter++ % kMPSStreamsPerPool];
 }
 
 // Helper methods

--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -982,6 +982,7 @@ libtorch_python_core_sources = [
     "torch/csrc/functorch/init.cpp",
     "torch/csrc/fx/node.cpp",
     "torch/csrc/mps/Module.cpp",
+    "torch/csrc/mps/Stream.cpp",
     "torch/csrc/mtia/Module.cpp",
     "torch/csrc/export/pybind.cpp",
     "torch/csrc/export/upgrader.cpp",

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -908,6 +908,49 @@ class TestMPS(TestCaseMPS):
         kl_div = F.kl_div(q.log(), p, reduction='sum').item()
         self.assertLess(kl_div, 0.03)
 
+    def test_stream_base(self):
+        s1 = torch._C._MPSStreamBase()
+        s2 = torch._C._MPSStreamBase()
+        self.assertNotEqual(s1, s2)
+        self.assertNotEqual(s2.stream_id, s1.stream_id)
+        self.assertEqual(s1.device.type, 'mps')
+        self.assertEqual(s2.device.type, 'mps')
+
+        def concurrent_sine_loop(a1, a2, s1=None, s2=None, n=100):
+            r1 = a1
+            r2 = a2
+
+            for _ in range(n):
+                torch._C._mps_setStream(s1)
+                r1 = torch.sin(r1)
+                torch._C._mps_setStream(s2)
+                r2 = torch.sin(r2)
+
+            return r1, r2
+
+        try:
+            torch._C._mps_setStream(None)
+            a1 = torch.randn(100, device='mps')
+            a2 = torch.randn(100, device='mps')
+            torch.mps.synchronize()
+
+            r1, r2 = concurrent_sine_loop(a1, a2, s1, s2)
+            s1.synchronize()
+            s2.synchronize()
+            torch._C._mps_setStream(None)
+            r1_check, r2_check = concurrent_sine_loop(a1, a2, s1=None, s2=None)
+            torch.mps.synchronize()
+
+            self.assertEqual(r1, r1_check)
+            self.assertEqual(r2, r2_check)
+
+        finally:
+            torch._C._mps_setStream(None)
+            torch.mps.synchronize()
+            s1.synchronize()
+            s2.synchronize()
+            torch.mps.empty_cache()
+
     def test_exp(self, device="mps", dtype=torch.float):
         for v in (2, -2) + ((1j, 1 + 1j) if dtype.is_complex else ()):
             b = torch.arange(18, dtype=dtype, device=device) / 3 * math.pi

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -951,6 +951,36 @@ class TestMPS(TestCaseMPS):
             s2.synchronize()
             torch.mps.empty_cache()
 
+    def test_buffer_reuse_per_stream(self):
+        def make_and_free_get_ptr(stream):
+            torch._C._mps_setStream(stream)
+            t = torch.randn(1 << 16, device='mps')
+            stream.synchronize()
+            ptr = t.data_ptr()
+            del t
+            stream.synchronize()
+            return ptr
+
+        s1 = torch._C._MPSStreamBase()
+        s2 = torch._C._MPSStreamBase()
+
+        try:
+            # Same stream: the exact same buffer should be reused
+            ptr_s1_first = make_and_free_get_ptr(s1)
+            ptr_s1_second = make_and_free_get_ptr(s1)
+            self.assertEqual(ptr_s1_second, ptr_s1_first)
+
+            # Different stream: must not reuse s1's freed buffer
+            ptr_s2 = make_and_free_get_ptr(s2)
+            self.assertNotEqual(ptr_s2, ptr_s1_second)
+
+        finally:
+            torch._C._mps_setStream(None)
+            torch.mps.synchronize()
+            s1.synchronize()
+            s2.synchronize()
+            torch.mps.empty_cache()
+
     def test_exp(self, device="mps", dtype=torch.float):
         for v in (2, -2) + ((1j, 1 + 1j) if dtype.is_complex else ()):
             b = torch.arange(18, dtype=dtype, device=device) / 3 * math.pi

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -2409,7 +2409,7 @@ void initModule(PyObject* module);
 
 #ifdef USE_MPS
 // NOLINTNEXTLINE(misc-use-internal-linkage)
-void THMPStream_init(PyObject* module);
+void THPMPSStream_init(PyObject* module);
 #endif
 
 static std::vector<PyMethodDef> methods;
@@ -2609,7 +2609,7 @@ PyObject* initModule() {
 #endif
 #ifdef USE_MPS
   torch::mps::initModule(module);
-  THMPStream_init(module);
+  THPMPSStream_init(module);
 #endif
 #ifdef USE_XPU
   torch::xpu::initModule(module);

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -2407,6 +2407,11 @@ void initModule(PyObject* module);
 } // namespace torch::xpu
 #endif
 
+#ifdef USE_MPS
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+void THMPStream_init(PyObject* module);
+#endif
+
 static std::vector<PyMethodDef> methods;
 
 static void LogAPIUsageMetadataFromPython(
@@ -2604,6 +2609,7 @@ PyObject* initModule() {
 #endif
 #ifdef USE_MPS
   torch::mps::initModule(module);
+  THMPStream_init(module);
 #endif
 #ifdef USE_XPU
   torch::xpu::initModule(module);

--- a/torch/csrc/mps/Module.cpp
+++ b/torch/csrc/mps/Module.cpp
@@ -229,18 +229,20 @@ static PyObject* MPSModule_elapsedTimeOfEvents(
   END_HANDLE_TH_ERRORS
 }
 
+#ifdef USE_MPS
 static PyObject* MPSModule_setStream(PyObject* _unused, PyObject* stream) {
   HANDLE_TH_ERRORS
   at::mps::MPSStream* mps_stream = nullptr;
   if (stream != Py_None) {
     TORCH_CHECK(
-        THMPStream_Check(stream), "invalid stream argument to setStream");
-    mps_stream = reinterpret_cast<THMPStream*>(stream)->mps_stream;
+        THPMPSStream_Check(stream), "invalid stream argument to setStream");
+    mps_stream = reinterpret_cast<THPMPSStream*>(stream)->mps_stream;
   }
   at::mps::setCurrentMPSStream(mps_stream);
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }
+#endif /* USE_MPS */
 
 // NOLINTNEXTLINE(*-c-arrays, *-global-variables)
 static struct PyMethodDef _MPSModule_methods[] = {
@@ -291,7 +293,9 @@ static struct PyMethodDef _MPSModule_methods[] = {
      MPSModule_elapsedTimeOfEvents,
      METH_VARARGS,
      nullptr},
+#ifdef USE_MPS
     {"_mps_setStream", MPSModule_setStream, METH_O, nullptr},
+#endif /* USE_MPS */
     {nullptr}};
 
 PyMethodDef* python_functions() {

--- a/torch/csrc/mps/Module.cpp
+++ b/torch/csrc/mps/Module.cpp
@@ -16,6 +16,7 @@
 #include <ATen/mps/MPSAllocatorInterface.h>
 #include <ATen/mps/MPSProfiler.h>
 #include <ATen/native/mps/MetalShaderLibrary.h>
+#include <torch/csrc/mps/Stream.h>
 #endif
 
 namespace torch::mps {
@@ -228,6 +229,19 @@ static PyObject* MPSModule_elapsedTimeOfEvents(
   END_HANDLE_TH_ERRORS
 }
 
+static PyObject* MPSModule_setStream(PyObject* _unused, PyObject* stream) {
+  HANDLE_TH_ERRORS
+  at::mps::MPSStream* mps_stream = nullptr;
+  if (stream != Py_None) {
+    TORCH_CHECK(
+        THMPStream_Check(stream), "invalid stream argument to setStream");
+    mps_stream = reinterpret_cast<THMPStream*>(stream)->mps_stream;
+  }
+  at::mps::setCurrentMPSStream(mps_stream);
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+
 // NOLINTNEXTLINE(*-c-arrays, *-global-variables)
 static struct PyMethodDef _MPSModule_methods[] = {
     {"_mps_deviceSynchronize",
@@ -277,6 +291,7 @@ static struct PyMethodDef _MPSModule_methods[] = {
      MPSModule_elapsedTimeOfEvents,
      METH_VARARGS,
      nullptr},
+    {"_mps_setStream", MPSModule_setStream, METH_O, nullptr},
     {nullptr}};
 
 PyMethodDef* python_functions() {

--- a/torch/csrc/mps/Stream.cpp
+++ b/torch/csrc/mps/Stream.cpp
@@ -2,14 +2,13 @@
 #include <torch/csrc/mps/Stream.h>
 
 #ifdef USE_MPS
-// #include <torch/csrc/Device.h>
 #include <torch/csrc/utils/pybind.h>
 
 #include <structmember.h>
 
-PyObject* THMPStreamClass = nullptr;
+PyObject* THPMPSStreamClass = nullptr;
 
-static PyObject* THMPStream_pynew(
+static PyObject* THPMPSStream_pynew(
     PyTypeObject* type,
     PyObject* args,
     PyObject* kwargs) {
@@ -34,7 +33,7 @@ static PyObject* THMPStream_pynew(
   at::mps::MPSStream* stream = at::mps::getStreamFromPool();
   c10::Stream unwrapped = stream->unwrap();
 
-  THMPStream* self = (THMPStream*)ptr.get();
+  THPMPSStream* self = (THPMPSStream*)ptr.get();
   self->stream_id = static_cast<int64_t>(unwrapped.id());
   // NOLINTNEXTLINE(bugprone-signed-char-misuse)
   self->device_index = static_cast<int64_t>(unwrapped.device_index());
@@ -45,16 +44,16 @@ static PyObject* THMPStream_pynew(
   END_HANDLE_TH_ERRORS
 }
 
-static void THMPStream_dealloc(THMPStream* self) {
+static void THPMPSStream_dealloc(THPMPSStream* self) {
   // Only the Python object needs to be deleted, not `self->mps_stream`, the
   // underlying MPSStream, since that is kept alive in the pool.
   THPStream_dealloc_common(reinterpret_cast<THPStream*>(self));
 }
 
-static PyObject* THMPStream_synchronize(PyObject* _self, PyObject* noargs) {
+static PyObject* THPMPSStream_synchronize(PyObject* _self, PyObject* noargs) {
   HANDLE_TH_ERRORS {
     pybind11::gil_scoped_release no_gil;
-    auto self = (THMPStream*)_self;
+    auto self = (THPMPSStream*)_self;
     self->mps_stream->synchronize(at::mps::SyncType::COMMIT_AND_WAIT);
   }
   Py_RETURN_NONE;
@@ -62,22 +61,22 @@ static PyObject* THMPStream_synchronize(PyObject* _self, PyObject* noargs) {
 }
 
 // NOLINTNEXTLINE(*-c-arrays*, *-global-variables)
-static struct PyMemberDef THMPStream_members[] = {{nullptr}};
+static struct PyMemberDef THPMPSStream_members[] = {{nullptr}};
 
 // NOLINTNEXTLINE(*-c-arrays*, *-global-variables)
-static struct PyGetSetDef THMPStream_properties[] = {{nullptr}};
+static struct PyGetSetDef THPMPSStream_properties[] = {{nullptr}};
 
 // NOLINTNEXTLINE(*-c-arrays*, *-global-variables)
-static PyMethodDef THMPStream_methods[] = {
-    {"synchronize", THMPStream_synchronize, METH_NOARGS, nullptr},
+static PyMethodDef THPMPSStream_methods[] = {
+    {"synchronize", THPMPSStream_synchronize, METH_NOARGS, nullptr},
     {nullptr}};
 
-PyTypeObject THMPStreamType = {
+PyTypeObject THPMPSStreamType = {
     PyVarObject_HEAD_INIT(nullptr, 0)
     "torch._C._MPSStreamBase", /* tp_name */
-    sizeof(THMPStream), /* tp_basicsize */
+    sizeof(THPMPSStream), /* tp_basicsize */
     0, /* tp_itemsize */
-    (destructor)THMPStream_dealloc, /* tp_dealloc */
+    (destructor)THPMPSStream_dealloc, /* tp_dealloc */
     0, /* tp_vectorcall_offset */
     nullptr, /* tp_getattr */
     nullptr, /* tp_setattr */
@@ -100,9 +99,9 @@ PyTypeObject THMPStreamType = {
     0, /* tp_weaklistoffset (inherited from THPStreamType via tp_base) */
     nullptr, /* tp_iter */
     nullptr, /* tp_iternext */
-    THMPStream_methods, /* tp_methods */
-    THMPStream_members, /* tp_members */
-    THMPStream_properties, /* tp_getset */
+    THPMPSStream_methods, /* tp_methods */
+    THPMPSStream_members, /* tp_members */
+    THPMPSStream_properties, /* tp_getset */
     nullptr, /* tp_base */
     nullptr, /* tp_dict */
     nullptr, /* tp_descr_get */
@@ -110,19 +109,19 @@ PyTypeObject THMPStreamType = {
     0, /* tp_dictoffset */
     nullptr, /* tp_init */
     nullptr, /* tp_alloc */
-    THMPStream_pynew, /* tp_new */
+    THPMPSStream_pynew, /* tp_new */
 };
 
-void THMPStream_init(PyObject* module) {
+void THPMPSStream_init(PyObject* module) {
   Py_INCREF(THPStreamClass);
-  THMPStreamType.tp_base = THPStreamClass;
-  THMPStreamClass = (PyObject*)&THMPStreamType;
-  if (PyType_Ready(&THMPStreamType) < 0) {
+  THPMPSStreamType.tp_base = THPStreamClass;
+  THPMPSStreamClass = (PyObject*)&THPMPSStreamType;
+  if (PyType_Ready(&THPMPSStreamType) < 0) {
     throw python_error(); // @allow-raw-throw
   }
-  Py_INCREF(&THMPStreamType);
-  if (PyModule_AddObject(module, "_MPSStreamBase", (PyObject*)&THMPStreamType) <
-      0) {
+  Py_INCREF(&THPMPSStreamType);
+  if (PyModule_AddObject(
+          module, "_MPSStreamBase", (PyObject*)&THPMPSStreamType) < 0) {
     throw python_error(); // @allow-raw-throw
   }
 }

--- a/torch/csrc/mps/Stream.cpp
+++ b/torch/csrc/mps/Stream.cpp
@@ -2,6 +2,7 @@
 #include <torch/csrc/mps/Stream.h>
 
 #ifdef USE_MPS
+#include <ATen/mps/MPSStream.h>
 #include <torch/csrc/utils/pybind.h>
 
 #include <structmember.h>

--- a/torch/csrc/mps/Stream.cpp
+++ b/torch/csrc/mps/Stream.cpp
@@ -1,0 +1,130 @@
+#include <torch/csrc/THP.h>
+#include <torch/csrc/mps/Stream.h>
+
+#ifdef USE_MPS
+// #include <torch/csrc/Device.h>
+#include <torch/csrc/utils/pybind.h>
+
+#include <structmember.h>
+
+PyObject* THMPStreamClass = nullptr;
+
+static PyObject* THMPStream_pynew(
+    PyTypeObject* type,
+    PyObject* args,
+    PyObject* kwargs) {
+  HANDLE_TH_ERRORS
+
+  // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
+  constexpr const char* kwlist[] = {nullptr};
+  if (!PyArg_ParseTupleAndKeywords(
+          args,
+          kwargs,
+          "",
+          // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+          const_cast<char**>(kwlist))) {
+    return nullptr;
+  }
+
+  THPObjectPtr ptr(type->tp_alloc(type, 0));
+  if (!ptr) {
+    return nullptr;
+  }
+
+  at::mps::MPSStream* stream = at::mps::getStreamFromPool();
+  c10::Stream unwrapped = stream->unwrap();
+
+  THMPStream* self = (THMPStream*)ptr.get();
+  self->stream_id = static_cast<int64_t>(unwrapped.id());
+  // NOLINTNEXTLINE(bugprone-signed-char-misuse)
+  self->device_index = static_cast<int64_t>(unwrapped.device_index());
+  self->device_type = static_cast<int64_t>(unwrapped.device_type());
+  self->mps_stream = stream;
+
+  return (PyObject*)ptr.release();
+  END_HANDLE_TH_ERRORS
+}
+
+static void THMPStream_dealloc(THMPStream* self) {
+  // Only the Python object needs to be deleted, not `self->mps_stream`, the
+  // underlying MPSStream, since that is kept alive in the pool.
+  THPStream_dealloc_common(reinterpret_cast<THPStream*>(self));
+}
+
+static PyObject* THMPStream_synchronize(PyObject* _self, PyObject* noargs) {
+  HANDLE_TH_ERRORS {
+    pybind11::gil_scoped_release no_gil;
+    auto self = (THMPStream*)_self;
+    self->mps_stream->synchronize(at::mps::SyncType::COMMIT_AND_WAIT);
+  }
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+
+// NOLINTNEXTLINE(*-c-arrays*, *-global-variables)
+static struct PyMemberDef THMPStream_members[] = {{nullptr}};
+
+// NOLINTNEXTLINE(*-c-arrays*, *-global-variables)
+static struct PyGetSetDef THMPStream_properties[] = {{nullptr}};
+
+// NOLINTNEXTLINE(*-c-arrays*, *-global-variables)
+static PyMethodDef THMPStream_methods[] = {
+    {"synchronize", THMPStream_synchronize, METH_NOARGS, nullptr},
+    {nullptr}};
+
+PyTypeObject THMPStreamType = {
+    PyVarObject_HEAD_INIT(nullptr, 0)
+    "torch._C._MPSStreamBase", /* tp_name */
+    sizeof(THMPStream), /* tp_basicsize */
+    0, /* tp_itemsize */
+    (destructor)THMPStream_dealloc, /* tp_dealloc */
+    0, /* tp_vectorcall_offset */
+    nullptr, /* tp_getattr */
+    nullptr, /* tp_setattr */
+    nullptr, /* tp_reserved */
+    nullptr, /* tp_repr */
+    nullptr, /* tp_as_number */
+    nullptr, /* tp_as_sequence */
+    nullptr, /* tp_as_mapping */
+    nullptr, /* tp_hash  */
+    nullptr, /* tp_call */
+    nullptr, /* tp_str */
+    nullptr, /* tp_getattro */
+    nullptr, /* tp_setattro */
+    nullptr, /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /* tp_flags */
+    nullptr, /* tp_doc */
+    nullptr, /* tp_traverse */
+    nullptr, /* tp_clear */
+    nullptr, /* tp_richcompare */
+    0, /* tp_weaklistoffset (inherited from THPStreamType via tp_base) */
+    nullptr, /* tp_iter */
+    nullptr, /* tp_iternext */
+    THMPStream_methods, /* tp_methods */
+    THMPStream_members, /* tp_members */
+    THMPStream_properties, /* tp_getset */
+    nullptr, /* tp_base */
+    nullptr, /* tp_dict */
+    nullptr, /* tp_descr_get */
+    nullptr, /* tp_descr_set */
+    0, /* tp_dictoffset */
+    nullptr, /* tp_init */
+    nullptr, /* tp_alloc */
+    THMPStream_pynew, /* tp_new */
+};
+
+void THMPStream_init(PyObject* module) {
+  Py_INCREF(THPStreamClass);
+  THMPStreamType.tp_base = THPStreamClass;
+  THMPStreamClass = (PyObject*)&THMPStreamType;
+  if (PyType_Ready(&THMPStreamType) < 0) {
+    throw python_error(); // @allow-raw-throw
+  }
+  Py_INCREF(&THMPStreamType);
+  if (PyModule_AddObject(module, "_MPSStreamBase", (PyObject*)&THMPStreamType) <
+      0) {
+    throw python_error(); // @allow-raw-throw
+  }
+}
+
+#endif // USE_MPS

--- a/torch/csrc/mps/Stream.h
+++ b/torch/csrc/mps/Stream.h
@@ -1,8 +1,11 @@
 #pragma once
 
-#include <ATen/mps/MPSStream.h>
 #include <torch/csrc/Stream.h>
 #include <torch/csrc/python_headers.h>
+
+namespace at::mps {
+class MPSStream;
+} // namespace at::mps
 
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 struct THPMPSStream : THPStream {

--- a/torch/csrc/mps/Stream.h
+++ b/torch/csrc/mps/Stream.h
@@ -5,14 +5,14 @@
 #include <torch/csrc/python_headers.h>
 
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
-struct THMPStream : THPStream {
+struct THPMPSStream : THPStream {
   // Non-owning pointer to one of the streams in the MPS stream pool
   at::mps::MPSStream* mps_stream;
 };
-extern PyObject* THMPStreamClass;
+extern PyObject* THPMPSStreamClass;
 
-void THMPStream_init(PyObject* module);
+void THPMPSStream_init(PyObject* module);
 
-inline bool THMPStream_Check(PyObject* obj) {
-  return THMPStreamClass && PyObject_IsInstance(obj, THMPStreamClass);
+inline bool THPMPSStream_Check(PyObject* obj) {
+  return THPMPSStreamClass && PyObject_IsInstance(obj, THPMPSStreamClass);
 }

--- a/torch/csrc/mps/Stream.h
+++ b/torch/csrc/mps/Stream.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <ATen/mps/MPSStream.h>
+#include <torch/csrc/Stream.h>
+#include <torch/csrc/python_headers.h>
+
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
+struct THMPStream : THPStream {
+  // Non-owning pointer to one of the streams in the MPS stream pool
+  at::mps::MPSStream* mps_stream;
+};
+extern PyObject* THMPStreamClass;
+
+void THMPStream_init(PyObject* module);
+
+inline bool THMPStream_Check(PyObject* obj) {
+  return THMPStreamClass && PyObject_IsInstance(obj, THMPStreamClass);
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #190375

This PR adds a pool of 32 MPS streams that remain alive through the whole process, similar to CUDA's stream pool, to avoid the overhead of repeatedly creating and destroying streams.

Python bindings are added to obtain a stream from the pool, set the current stream for kernels to be executed on, and synchronize streams.

MPSAllocator's buffer reuse code is modified so that buffers can only be reused by the stream that initially allocated them, to avoid data races between streams. The CUDA allocator does this as well. If a buffer could be reused by a different stream, an expensive sync would be required to ensure that the previous stream has actually finished executing any kernels that used that buffer.

This PR does not add the python frontend APIs like `torch.mps.Stream`. That will be done in a follow-up PR.

Co-authored with Claude