### PR TITLE
[TEST] Add hw_classification to test_nvshmem.py

### DIFF
--- a/test/distributed/test_nvshmem.py
+++ b/test/distributed/test_nvshmem.py
@@ -16,6 +16,7 @@ from torch.testing._internal.common_distributed import (
     skip_if_lt_x_gpu,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     requires_cuda_p2p_access,
@@ -64,6 +65,8 @@ device_module = torch.get_device_module(device_type)
 @requires_nvshmem()
 @requires_cuda_p2p_access()
 class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+
     def _init_device(self) -> None:
         # TODO: relieve this (seems to hang if without)
         device_module.set_device(self.device)
@@ -372,6 +375,8 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
 @requires_nvshmem()
 @requires_cuda_p2p_access()
 class NVSHMEMAll2AllTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+
     def _init_device(self) -> None:
         # TODO: relieve this (seems to hang if without)
         device_module.set_device(self.device)
@@ -773,6 +778,8 @@ def dispatch_then_combine(device, align: int, group) -> None:
 @requires_nvshmem()
 @requires_cuda_p2p_access()
 class DispatchCombineTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+
     def _init_device(self) -> None:
         # TODO: relieve this (seems to hang if without)
         device_module.set_device(self.device)
@@ -797,6 +804,8 @@ class DispatchCombineTest(MultiProcContinuousTest):
 @requires_nvshmem()
 @requires_cuda_p2p_access()
 class DispatchCombineInSubgroups(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+
     def _init_device(self) -> None:
         # TODO: relieve this (seems to hang if without)
         device_module.set_device(self.device)
@@ -828,6 +837,8 @@ class DispatchCombineInSubgroups(MultiProcContinuousTest):
 @requires_nvshmem()
 @requires_cuda_p2p_access()
 class NVSHMEMTileCommTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.CUDA
+
     def _init_device(self) -> None:
         # TODO: relieve this (seems to hang if without)
         device_module.set_device(self.device)


### PR DESCRIPTION
## Summary
- Classify all 5 test classes as `CUDA`
- All require NVSHMEM backend, CUDA P2P access, and symmetric memory — inherently CUDA locked

Follows [RFC Test class classification](https://github.com/pytorch/pytorch/issues/185142).

cc @vishalgoyal316