### PR TITLE
[TEST] Add hw_classification to test_common_rules.py (DTensor)

### DIFF
--- a/test/distributed/tensor/test_common_rules.py
+++ b/test/distributed/tensor/test_common_rules.py
@@ -6,7 +6,8 @@ from torch.distributed.tensor import DeviceMesh
 from torch.distributed.tensor._dtensor_spec import DTensorSpec, TensorMeta
 from torch.distributed.tensor._op_schema import OpSchema
 from torch.distributed.tensor._ops._common_rules import einop_rule, pointwise_rule
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorContinuousTestBase,
 )
@@ -16,6 +17,8 @@ aten = torch.ops.aten
 
 
 class CommonRulesTest(DTensorContinuousTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     # hard code world size to 4 as we need to test
     # at least with 2d mesh
     world_size = 4
@@ -399,6 +402,8 @@ class CommonRulesTest(DTensorContinuousTestBase):
         self.assertEqual(schema_suggestion.args_schema[0].dim_map, mat1)
         self.assertEqual(schema_suggestion.args_schema[1].dim_map, mat1)
 
+
+instantiate_device_type_tests(CommonRulesTest, globals(), except_for="cpu")
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary
- Classify `CommonRulesTest` as `ACCELERATOR` with `instantiate_device_type_tests`
- Add `except_for="cpu"` to avoid doubling CI runtime per reviewer feedback
- All 10 tests use `DTensorContinuousTestBase` with `self.device_type`

Follows [RFC Test class classification](https://github.com/pytorch/pytorch/issues/185142).

## Test Plan
```
python test/distributed/tensor/test_common_rules.py -v
Ran 10 tests in 11.860s -- OK
```

cc @vishalgoyal316