### PR TITLE
[Docs] Clarify norm docs for complex inputs

### DIFF
--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -1409,9 +1409,8 @@ Args:
 
 Keyword args:
     out (Tensor, optional): output tensor. Ignored if `None`. Default: `None`.
-    dtype (:class:`torch.dtype`, optional): If specified, the input tensor is cast to
-        :attr:`dtype` before performing the operation, and the returned tensor's type
-        will be :attr:`dtype`. Default: `None`
+    dtype (:class:`torch.dtype`, optional): If specified :attr:`x` is cast to
+        :attr:`dtype` prior to doing the accumulation. Default: `None`
 
 Returns:
     A real-valued tensor, even when :attr:`input` is complex.
@@ -1544,11 +1543,8 @@ Args:
 
 Keyword args:
     out (Tensor, optional): output tensor. Ignored if `None`. Default: `None`.
-    dtype (:class:`torch.dtype`, optional): type used to perform the accumulation and the return.
-        If specified, :attr:`x` is cast to :attr:`dtype` before performing the operation,
-        and the returned tensor's type will be :attr:`dtype` if real and of its real counterpart if complex.
-        :attr:`dtype` may be complex if :attr:`x` is complex, otherwise it must be real.
-        :attr:`x` should be convertible without narrowing to :attr:`dtype`. Default: None
+    dtype (:class:`torch.dtype`, optional): If specified :attr:`x` is cast to
+        :attr:`dtype` prior to doing the accumulation. Default: `None`
 
 Returns:
     A real-valued tensor, even when :attr:`x` is complex.
@@ -1613,9 +1609,8 @@ Args:
 
 Keyword args:
     out (Tensor, optional): output tensor. Ignored if `None`. Default: `None`.
-    dtype (:class:`torch.dtype`, optional): If specified, the input tensor is cast to
-        :attr:`dtype` before performing the operation, and the returned tensor's type
-        will be :attr:`dtype`. Default: `None`
+    dtype (:class:`torch.dtype`, optional): If specified :attr:`x` is cast to
+        :attr:`dtype` prior to doing the accumulation. Default: `None`
 
 Returns:
     A real-valued tensor, even when :attr:`A` is complex.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #190381

fixes: #136452

docstrings for `linalg.norm` and `linalg.matrix_norm`
contain a confusing contradiction between the `dtype` kwarg and the
return for complex dtypes. This is clarified by simply stating that the
input is cast. The output dtype is already implied by the definitions of
the operations.

All three of `norm`, `vector_norm`, and `matrix_norm` are now
consistent. They no longer state that the return type will be guaranteed
to be the same.

* `torch.linalg.norm` flows to either `torch.linalg.vector_norm` or
  `torch.linalg.matrix_norm` depending on the conditions documented.
* All of  `norm`, `vector_norm` and `matrix_norm` indicate that the
  return value will be real if input is complex.
* Both of `vector_norm` and `matrix_norm` indicate that for complex
  input the norm of `A.abs()` or `x.abs()` is computed instead.

`vector_norm` did not contain a contradiction but the description for
`dtype` was also far less clear.

IMO saying less with respect to dtype is more clear here.