### PR TITLE
fix flamegraph file not found error and test_memory_snapshot

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5483,6 +5483,7 @@ class TestCudaAllocator(TestCase):
                         self.assertTrue("test_cuda.py" in f2.read())
             del unused
             del x
+            torch._C._cuda_clearCublasWorkspaces()
             torch.cuda.empty_cache()
             ss = torch.cuda.memory._snapshot()
             self.assertTrue(

--- a/torch/cuda/_memory_viz.py
+++ b/torch/cuda/_memory_viz.py
@@ -91,10 +91,11 @@ def format_flamegraph(flamegraph_lines, flamegraph_script=None):
     if flamegraph_script is None:
         cache_dir = os.path.expanduser("~/.cache/")
         os.makedirs(cache_dir, exist_ok=True)
-        flamegraph_script = f"{cache_dir}/flamegraph.pl"
+        flamegraph_script = os.path.join(cache_dir, "flamegraph.pl")
     if not os.path.exists(flamegraph_script):
         import tempfile
         import urllib.request
+        import shutil
 
         print(f"Downloading flamegraph.pl to: {flamegraph_script}")
         with tempfile.NamedTemporaryFile(mode="wb", suffix=".pl") as f:
@@ -103,8 +104,8 @@ def format_flamegraph(flamegraph_lines, flamegraph_script=None):
                 f.name,
             )
             try:
-                os.chmod(f.name, 0o755)
-                os.rename(f.name, flamegraph_script)
+                shutil.copyfile(f.name, flamegraph_script)
+                os.chmod(flamegraph_script, 0o755)
             except OSError:
                 # Ok to skip, the file will be removed by tempfile
                 pass


### PR DESCRIPTION
## Summary

Fix `flamegraph.pl` not being found when generating CUDA memory flamegraphs, and stabilize `test_memory_snapshot` teardown by clearing cuBLAS workspaces before asserting segment release.

Fixes https://github.com/pytorch/pytorch/issues/179745

## Problem

In `format_flamegraph()`, when `flamegraph.pl` is missing, the code downloads it to a temporary file in `/tmp` folder and then moves it into `~/.cache/flamegraph.pl` with `os.rename()`.
When `/tmp` and `~/.cache` are on different filesystems/devices, `os.rename()` cannot move the file across devices and raises `OSError: [Errno 18] Invalid cross-device link`. That error is swallowed by the `except OSError: pass`, so nothing is left at the target path. Later, `subprocess.Popen` tries to execute `flamegraph.pl` and fails with "file not found".

`test_memory_snapshot` uses `format_flamegraph()` and also asserts that the last allocator action after cleanup is `segment_free` or `segment_unmap`. cuBLAS workspace allocations on the default stream can keep segments alive and make that assertion flaky.

Docker reproducer (`/tmp` on tmpfs, destination in home dir on a different device):

```bash
# old behavior: fails with 'Invalid cross-device link/
docker run --rm --tmpfs /tmp python:3.12-slim \
  python -c "import os;from pathlib import Path;Path('/tmp/src').touch();os.rename('/tmp/src',os.path.expanduser('~/dest'))"

# new behavior: succeeds
docker run --rm --tmpfs /tmp python:3.12-slim \
  python -c "import os,shutil;from pathlib import Path;Path('/tmp/src').touch();shutil.copyfile('/tmp/src',os.path.expanduser('~/dest'))"
```

## Fix

**`torch/cuda/_memory_viz.py`**
- Build the cache path with `os.path.join(cache_dir, "flamegraph.pl")` instead of an f-string.
- Replace the cross-device `os.rename()` with `shutil.copyfile()` to the cache path, followed by `os.chmod()` on the destination. `shutil.copyfile()` copies bytes and works across filesystems, so the download survives even when the tempfile and cache dir are on different devices.

**`test/test_cuda.py`**
- Call `torch._C._cuda_clearCublasWorkspaces()` before `empty_cache()` in `test_memory_snapshot`, so segment teardown is not blocked by lingering cuBLAS workspace allocations.

## Test plan

```bash
python test/test_cuda.py TestCudaAllocator.test_memory_snapshot
```