### PR TITLE
[inductor] Race scaled block variants for stitched combo kernels

### DIFF
--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -2045,6 +2045,41 @@ class ComboKernelCompileTimeAutotuneTests(TestCase):
         # Sorts stay fused in the combo: tuned normally, no carve-out fallbacks.
         self.assertEqual(counters["inductor"]["combo_subkernel_autotune_fallback"], 0)
 
+    def test_stitched_launch_candidates_include_scaled_blocks(self):
+        """The combo-level autotune must race down-scaled variants of the
+        stitched blocks: each subkernel's standalone winner can be too large
+        for the fused body (union of register footprints), and with only the
+        stitched candidate the runtime autotune cannot correct it.
+
+        Scaled variants are optional: they may violate backend minimums
+        (e.g. TMA descriptor width), so precompile must skip a failing
+        optional candidate instead of erroring.
+        """
+        from torch._inductor.runtime.triton_heuristics import (
+            _handle_combo_kernel_per_subkernel_blocks,
+        )
+
+        combo_meta = {
+            "num_kernels": 2,
+            "heuristic_0": "persistent_reduction",
+            "heuristic_1": "persistent_reduction",
+            "size_hints_0": {"x": 16384, "r0_": 128},
+            "size_hints_1": {"x": 8192, "r0_": 128},
+            "stitched_launch_candidates": [({}, 2, 1)],
+            "default_config": {"XBLOCK_0": 8, "XBLOCK_1": 8},
+        }
+        inductor_meta = {"combo_grid_meta": combo_meta}
+        configs = _handle_combo_kernel_per_subkernel_blocks(
+            {"x": 16384, "r0_": 128}, inductor_meta, {}
+        )
+        kwargs = [cfg.kwargs for cfg in configs]
+        self.assertIn({"XBLOCK_0": 8, "XBLOCK_1": 8}, kwargs)  # stitched winner
+        self.assertIn({"XBLOCK_0": 4, "XBLOCK_1": 4}, kwargs)  # /2 variant
+        self.assertIn({"XBLOCK_0": 2, "XBLOCK_1": 2}, kwargs)  # /4 variant
+        # only the scaled variants are optional (skippable on compile failure)
+        optional = [getattr(cfg, "optional_candidate", False) for cfg in configs]
+        self.assertEqual(optional, [False, True, True])
+
     @requires_gpu_and_triton
     def test_compile_time_autotune_excludes_indirect_indexing(self):
         def fn(a, b, c, idx):

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -761,6 +761,12 @@ class CachingAutotuner(KernelInterface):
                 compile_results.append(self._precompile_config(c))
             except (OutOfResources, PTXASError, IntelGPUError) as e:
                 exc = e
+            except Exception as e:
+                # Optional candidates (e.g. down-scaled stitched combo blocks) may
+                # violate backend constraints; skip them instead of failing.
+                if not getattr(c, "optional_candidate", False):
+                    raise
+                exc = e
         if len(compile_results) == 0:
             raise NoTritonConfigsError(
                 f"No valid triton configs. {type(exc).__name__}: {exc}"
@@ -4093,10 +4099,27 @@ def _handle_combo_kernel_per_subkernel_blocks(
             field_order, field_limits = _combo_coordesc_meta(combo_meta, block_config)
             inductor_meta["combo_coordesc_field_order"] = field_order
             inductor_meta["combo_coordesc_field_limits"] = field_limits
-            return [
+            configs = [
                 triton.Config({**block_config, **kwargs}, num_warps=nw, num_stages=ns)
                 for kwargs, nw, ns in launch_candidates
             ]
+            # The stitched blocks are each subkernel's standalone winner, but the
+            # combo body unions the subkernels' register pressure, which can shift
+            # the occupancy optimum toward smaller blocks. Race halved/quartered
+            # variants so the combo-level autotune can correct the bias. Smaller
+            # blocks can violate backend minimums (e.g. TMA descriptor width), so
+            # mark them optional: precompile skips them on compile failure.
+            for scale in (2, 4):
+                scaled = {k: max(1, v // scale) for k, v in block_config.items()}
+                if scaled == block_config:
+                    break
+                for kwargs, nw, ns in launch_candidates:
+                    cfg = triton.Config(
+                        {**scaled, **kwargs}, num_warps=nw, num_stages=ns
+                    )
+                    cfg.optional_candidate = True
+                    configs.append(cfg)
+            return configs
         return [
             triton.Config(
                 combo_meta["stitched_backend_kwargs"],


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #188119
* __->__ #190384
* #190383
* #189724
* #189003
* #189002
* #189001
* #188203
* #189677
* #184955
* #182577
* #187961

Compile-time per-subkernel autotuning benchmarks each combo sub-kernel
standalone and stitches the winning block sizes into the fused kernel
(XBLOCK_0, XBLOCK_1, ...). The runtime combo autotune then races only
that single stitched candidate, so a block choice that is optimal for a
sub-kernel alone but wrong for the fused body can never be corrected.

The bias is systematic: the fused body contains every sub-kernel's code,
so the compiler allocates registers for the union, and higher register
pressure shifts the occupancy optimum toward smaller blocks. On
Qwen3-0.6B inference the fused q-norm/k-norm RMSNorm pair
(triton_per_fused_2, two persistent reductions x=16000/x=8000, r0=128)
compiled at 48 regs/thread vs 32 for each standalone; the stitched
XBLOCK=8 winner ran the fused kernel at 5586us over 280 launches vs
4018us for the two kernels it replaced (+39%), a +5.7% model latency
regression. Coordinate descent, when enabled, refined XBLOCK 8 -> 2 and
beat the baseline pair (3019us), confirming the block choice as the
cause -- but CDT is off by default, so default users kept the regressed
config.

Fix: _handle_combo_kernel_per_subkernel_blocks also emits /2 and /4
scaled variants of the stitched block config (cross product with the
winner launch candidates), so the standard runtime autotune race can
correct the fused-body bias. This is deliberately unconditional rather
than gated on the fused kernel's n_regs: registers are a compiler output
that does not exist at config-generation time, gating post-compile would
serialize the extra compiles in the parent process (see the TODO in
_iter_rblock_scale_candidates), register pressure is not the only thing
fusion shifts (shared memory, grid shape), and the race itself is the
measurement -- if the stitched winner is still best it simply wins.
Down-scaling per-subkernel uniformly preserves the block ratios the
per-subkernel tuning discovered; asymmetric per-field refinement remains
CDT's job, which starts from the race winner via
combo_coordesc_field_order.

Scaled variants can violate backend minimums. Concretely, on stitched
combos using host-side TMA (tl.make_tensor_descriptor, exercised by
test_combo_kernel_tma_descriptor_block_name: two reduction sub-kernels
with r0=128/r0=256 fp32 rows), quartering produced a descriptor block of
4 fp32 elements = 8 bytes in the innermost dimension, below the TMA
requirement that a descriptor block load/store at least 16 bytes (see
[Note: TMA API Restrictions] in config.py), and Triton raised
CompilationError: "Descriptor block shape must have at least 16 bytes",
failing the whole compile. Such minimums are backend- and dtype-
dependent and not knowable at candidate-generation time, so scaled
variants are marked optional_candidate and _precompile_worker skips an
optional candidate whose compile fails instead of raising; the stitched
winner is always a mandatory candidate, so a valid config always
remains.

Benchmarks (B200, locked clocks, combo_kernels=True,
combo_kernel_per_subkernel_blocks=True, combo_kernel_compile_time_autotune=True):

  model                        latency     before      after
  Qwen3-0.6B infer                         +5.7%       -6.4%
  BlenderbotForCondGen train               +2.3%       -2.7%

triton_per_fused_2 on Qwen3: 5586us -> 3395us x280 launches (race picked
XBLOCK_0=4, XBLOCK_1=4), now faster than the unfused baseline pair.
Wall-clock compile time measured unchanged (extra candidates compile in
the async worker pool off the critical path; cold-cache A/B on Qwen3:
19.4s single-candidate vs 17.5s with variants, within run noise).

Test Plan:

New test ComboKernelCompileTimeAutotuneTests.
test_stitched_launch_candidates_include_scaled_blocks: feeds a stitched
combo meta (two persistent-reduction sub-kernels, stitched XBLOCK 8/8)
through _handle_combo_kernel_per_subkernel_blocks and asserts the
candidate set contains the stitched winner plus the /2 and /4 variants,
and that only the scaled variants carry optional_candidate (the stitched
winner must stay mandatory so compile failures still surface).

The TMA interaction is covered by the existing
ComboKernelTestsPerSubkernelBlocks.test_combo_kernel_tma_descriptor_block_name,
which failed with the descriptor-width CompilationError before the
optional_candidate skip and passes with it.

```
python test/inductor/test_combo_kernels.py ComboKernelCompileTimeAutotuneTests.test_stitched_launch_candidates_include_scaled_blocks
python test/inductor/test_combo_kernels.py ComboKernelTestsPerSubkernelBlocks.test_combo_kernel_tma_descriptor_block_name
python test/inductor/test_combo_kernels.py
```

Full suite: 213 tests OK on B200.

Authored with assistance from an AI coding assistant (Claude Code).