### PR TITLE
[RELEASE.md] Add NCCL version to compatibility matrix for releases 2.10-2.12

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -52,9 +52,9 @@ Following is the Release Compatibility Matrix for PyTorch releases:
 | PyTorch version | Python | C++ | Stable CUDA | Experimental CUDA | Stable ROCm |
 | --- | --- | --- | --- | --- | --- |
 | 2.13 | >=3.10, <=(3.15, 3.15t experimental) | C++20 | CUDA 12.6 (CUDNN 9.10.2.21) (NCCL 2.29.3), CUDA 13.0 (CUDNN 9.20.0.48) (NCCL 2.29.7) | CUDA 13.2 (CUDNN 9.20.0.48) (NCCL 2.29.7) | ROCm 7.2 |
-| 2.12 | >=3.10, <=(3.14, 3.14t experimental) | C++17 | CUDA 12.6 (CUDNN 9.10.2.21), CUDA 13.0 (CUDNN 9.20.0.48) | CUDA 13.2 (CUDNN 9.20.0.48) | ROCm 7.2 |
-| 2.11 | >=3.10, <=(3.14, 3.14t experimental) | C++17 | CUDA 12.6 (CUDNN 9.10.2.21), CUDA 12.8 (CUDNN 9.17.1.4), CUDA 13.0 (CUDNN 9.17.1.4) | -- | ROCm 7.2 |
-| 2.10 | >=3.10, <=(3.14, 3.14t experimental) | C++17 | CUDA 12.6 (CUDNN 9.10.2.21), CUDA 12.8 (CUDNN 9.10.2.21) | CUDA 13.0 (CUDNN 9.15.1.9) | ROCm 7.1 |
+| 2.12 | >=3.10, <=(3.14, 3.14t experimental) | C++17 | CUDA 12.6 (CUDNN 9.10.2.21) (NCCL 2.29.3), CUDA 13.0 (CUDNN 9.20.0.48) (NCCL 2.29.7) | CUDA 13.2 (CUDNN 9.20.0.48) (NCCL 2.29.7) | ROCm 7.2 |
+| 2.11 | >=3.10, <=(3.14, 3.14t experimental) | C++17 | CUDA 12.6 (CUDNN 9.10.2.21) (NCCL 2.28.9), CUDA 12.8 (CUDNN 9.17.1.4) (NCCL 2.28.9), CUDA 13.0 (CUDNN 9.17.1.4) (NCCL 2.28.9) | -- | ROCm 7.2 |
+| 2.10 | >=3.10, <=(3.14, 3.14t experimental) | C++17 | CUDA 12.6 (CUDNN 9.10.2.21) (NCCL 2.27.5), CUDA 12.8 (CUDNN 9.10.2.21) (NCCL 2.27.5) | CUDA 13.0 (CUDNN 9.15.1.9) (NCCL 2.28.9) | ROCm 7.1 |
 | 2.9 | >=3.10, <=(3.14, 3.14t experimental) | C++17 | CUDA 12.6 (CUDNN 9.10.2.21), CUDA 12.8 (CUDNN 9.10.2.21) | CUDA 13.0 (CUDNN 9.13.0.50) | ROCm 6.4 |
 | 2.8 | >=3.9, <=3.13, (3.13t experimental) | C++17 | CUDA 12.6 (CUDNN 9.10.2.21), CUDA 12.8 (CUDNN 9.10.2.21) | CUDA 12.9 (CUDNN 9.10.2.21) | ROCm 6.4 |
 | 2.7 | >=3.9, <=3.13, (3.13t experimental) | C++17 | CUDA 11.8 (CUDNN 9.1.0.70), CUDA 12.6 (CUDNN 9.5.1.17) | CUDA 12.8 (CUDNN 9.7.1.26) | ROCm 6.3 |


### PR DESCRIPTION
## Summary

Per @ngimel's request in https://github.com/pytorch/pytorch/pull/186163#issuecomment-4618045817 — when listing the CUDA support matrix we should also mention the NCCL version (alongside CUDNN).

Release 2.13 already lists NCCL; this backfills the NCCL version for **2.10, 2.11, 2.12** in the Release Compatibility Matrix in `RELEASE.md`, using the same `(CUDNN x) (NCCL y)` format.

NCCL versions were extracted from each release branch's `.ci/docker/ci_commit_pins` (`nccl-cu126.txt` / `nccl-cu12.txt` / `nccl-cu13.txt` / `nccl.txt`):

| Release | CUDA → NCCL |
|---|---|
| 2.12 | 12.6 → 2.29.3; 13.0 / 13.2 → 2.29.7 |
| 2.11 | 12.6 / 12.8 / 13.0 → 2.28.9 (single `nccl.txt`) |
| 2.10 | 12.6 / 12.8 → 2.27.5; 13.0 → 2.28.9 |

(Validated against 2.13's existing row: `nccl-cu126.txt` = 2.29.3 and `nccl.txt` = 2.29.7 match what's already published.)

cc @ngimel @atalman
