### PR TITLE
[cuDNN] Add optional cap on thread-local MHAGraphCache size

### DIFF
--- a/aten/src/ATen/native/cudnn/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/MHA.cpp
@@ -146,6 +146,7 @@ void run_cudnn_SDP_bprop_nestedtensor(
 
 #include <cstdlib>
 #include <iostream>
+#include <list>
 
 namespace at::native {
 
@@ -362,12 +363,17 @@ struct MHACacheKeyWrapper : ParamsWrapper<MHAParams> {
 // see. That is a real, measurable, unbounded memory-growth risk independent
 // of any specific correctness bug.
 //
-// Setting TORCH_CUDNN_SDPA_CACHE_MAX_SIZE to a positive integer bounds the
-// number of entries retained per thread; the default (0, or unset) preserves
-// the historical unbounded behavior so this is strictly opt-in.
-size_t get_mha_graph_cache_max_size() {
-  static size_t size = []() -> size_t {
-    const char* raw = std::getenv("TORCH_CUDNN_SDPA_CACHE_MAX_SIZE");
+// Setting TORCH_CUDNN_SDPA_LRU_CACHE_LIMIT to a positive integer bounds the
+// number of entries retained per thread via true LRU eviction (mirroring the
+// TORCH_CUDNN_V8_API_LRU_CACHE_LIMIT-based BenchmarkCache used for cuDNN
+// convolutions in Conv_v8.cpp): only the single least-recently-used entry is
+// dropped once the cap is reached, so a steady-state working set that fits
+// within the limit keeps its cached plans and avoids repeated cold-start
+// recompiles. The default (0, or unset) preserves the historical unbounded
+// behavior, so this is strictly opt-in.
+size_t getMHAGraphCacheLRULimit() {
+  static size_t limit = []() -> size_t {
+    const char* raw = std::getenv("TORCH_CUDNN_SDPA_LRU_CACHE_LIMIT");
     if (!raw || !*raw) {
       return 0;
     }
@@ -376,13 +382,13 @@ size_t get_mha_graph_cache_max_size() {
       return parsed > 0 ? static_cast<size_t>(parsed) : 0;
     } catch (const std::exception&) {
       TORCH_WARN(
-          "Ignoring unparseable TORCH_CUDNN_SDPA_CACHE_MAX_SIZE='",
+          "Ignoring unparseable TORCH_CUDNN_SDPA_LRU_CACHE_LIMIT='",
           raw,
           "'; expected a positive integer.");
       return 0;
     }
   }();
-  return size;
+  return limit;
 }
 
 struct MHAGraphCache {
@@ -394,9 +400,31 @@ struct MHAGraphCache {
   using const_iterator = typename MapType::const_iterator;
 
   MapType engine_cache;
+  // LRU recency tracking, only populated/consulted when
+  // TORCH_CUDNN_SDPA_LRU_CACHE_LIMIT > 0. lru_order.front() is the
+  // most-recently-used key and lru_order.back() is the next eviction
+  // candidate. lru_positions maps each cached key to its node in lru_order
+  // so find()/try_emplace() can bump recency or evict in O(1). This is kept
+  // as a side structure (rather than folding the list iterator into
+  // MapType's value_type, as Conv_v8.cpp's BenchmarkCache does) so that
+  // engine_cache's iterator/value-type contract -- callers dereference
+  // cache_it->second directly as ValueType -- is unchanged.
+  std::list<KeyType> lru_order;
+  std::unordered_map<
+      KeyType,
+      typename std::list<KeyType>::iterator,
+      ParamsWrapperHash<KeyType>>
+      lru_positions;
   int count = 0;
   int hits = 0;
   int evictions = 0;
+
+  void touch_lru(const KeyType& key) {
+    auto pos_it = lru_positions.find(key);
+    if (pos_it != lru_positions.end()) {
+      lru_order.splice(lru_order.begin(), lru_order, pos_it->second);
+    }
+  }
 
   // no mutexes here as caches are now thread local for v8, can also return a
   // pointer to the Execution Plan if we know it will not be invalidated by
@@ -418,6 +446,9 @@ struct MHAGraphCache {
     auto it = engine_cache.find(key);
     if (it != engine_cache.end()) {
       hits++;
+      if (getMHAGraphCacheLRULimit() > 0) {
+        touch_lru(key);
+      }
     }
     return it;
   }
@@ -428,24 +459,35 @@ struct MHAGraphCache {
 
   template <typename... Args>
   std::pair<iterator, bool> try_emplace(const KeyType& key, Args&&... args) {
-    size_t limit = get_mha_graph_cache_max_size();
-    if (limit > 0 && engine_cache.size() >= limit &&
-        engine_cache.find(key) == engine_cache.end()) {
-      // Bound otherwise-unbounded per-thread growth (see comment above): once
-      // this thread's cache would exceed the configured cap, do a bulk
-      // eviction rather than tracking per-entry recency/LRU order. This is
-      // intentionally simple: it trades a burst of plan-rebuild cost for a
-      // hard ceiling on retained cuDNN plan/workspace-sizing state.
+    size_t limit = getMHAGraphCacheLRULimit();
+    if (limit == 0) {
+      return engine_cache.try_emplace(key, std::forward<Args>(args)...);
+    }
+    auto existing = engine_cache.find(key);
+    if (existing != engine_cache.end()) {
+      touch_lru(key);
+      return {existing, false};
+    }
+    if (engine_cache.size() >= limit) {
+      // True LRU eviction: only the single least-recently-used entry is
+      // dropped, unlike a bulk-clear, so plans for shapes that are still
+      // part of the active working set survive and don't need to be
+      // recompiled from scratch.
+      const KeyType lru_key = lru_order.back();
+      engine_cache.erase(lru_key);
+      lru_positions.erase(lru_key);
+      lru_order.pop_back();
+      evictions++;
       TORCH_WARN_ONCE(
           "cuDNN SDPA plan cache on this thread hit "
-          "TORCH_CUDNN_SDPA_CACHE_MAX_SIZE=",
+          "TORCH_CUDNN_SDPA_LRU_CACHE_LIMIT=",
           limit,
-          " entries; evicting all cached plans on this thread. Increase the "
-          "limit, or leave TORCH_CUDNN_SDPA_CACHE_MAX_SIZE unset (default) "
+          "; evicting the least-recently-used cached plan. Increase the "
+          "limit, or leave TORCH_CUDNN_SDPA_LRU_CACHE_LIMIT unset (default) "
           "to disable this bound.");
-      engine_cache.clear();
-      evictions++;
     }
+    lru_order.emplace_front(key);
+    lru_positions.emplace(key, lru_order.begin());
     return engine_cache.try_emplace(key, std::forward<Args>(args)...);
   }
 };
@@ -455,9 +497,9 @@ struct MHAGraphCache {
 // https://docs.nvidia.com/deeplearning/cudnn/backend/latest/release-notes.html
 // We also leak the caches to workaround potential teardown race issues.
 //
-// The caches are unbounded by default; set TORCH_CUDNN_SDPA_CACHE_MAX_SIZE to
-// cap the number of distinct execution plans retained per thread (see
-// get_mha_graph_cache_max_size above).
+// The caches are unbounded by default; set TORCH_CUDNN_SDPA_LRU_CACHE_LIMIT
+// to cap the number of distinct execution plans retained per thread via LRU
+// eviction (see getMHAGraphCacheLRULimit above).
 
 MHAGraphCache& getMHAGraphCache_() {
   thread_local MHAGraphCache* instance{new MHAGraphCache()};

--- a/aten/src/ATen/native/cudnn/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/MHA.cpp
@@ -382,7 +382,7 @@ size_t getMHAGraphCacheLRULimit() {
       return parsed > 0 ? static_cast<size_t>(parsed) : 0;
     } catch (const std::exception&) {
       TORCH_WARN(
-          "Ignoring unparseable TORCH_CUDNN_SDPA_LRU_CACHE_LIMIT='",
+          "Ignoring unparsable TORCH_CUDNN_SDPA_LRU_CACHE_LIMIT='",
           raw,
           "'; expected a positive integer.");
       return 0;

--- a/aten/src/ATen/native/cudnn/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/MHA.cpp
@@ -144,6 +144,7 @@ void run_cudnn_SDP_bprop_nestedtensor(
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <cudnn.h>
 
+#include <cstdlib>
 #include <iostream>
 
 namespace at::native {
@@ -347,6 +348,43 @@ struct MHACacheKeyWrapper : ParamsWrapper<MHAParams> {
   }
 };
 
+// Optional cap on the number of distinct cuDNN execution plans that a single
+// (thread-local, see getMHAGraphCache_ below) MHAGraphCache will retain.
+//
+// Each cache entry keeps a compiled fe::graph::Graph -- and the cuDNN-side
+// execution-plan/workspace-sizing state that comes with it -- alive for the
+// lifetime of the owning thread, since the cache is never evicted by default.
+// A long-running, multi-threaded server (e.g. one dispatching each request's
+// SDPA calls onto a different worker thread, as Python's
+// `asyncio.to_thread`/ThreadPoolExecutor does) can therefore end up with as
+// many independent, ever-growing caches as it has worker threads, each
+// keyed on every distinct (batch, heads, seqlen, ...) shape it happens to
+// see. That is a real, measurable, unbounded memory-growth risk independent
+// of any specific correctness bug.
+//
+// Setting TORCH_CUDNN_SDPA_CACHE_MAX_SIZE to a positive integer bounds the
+// number of entries retained per thread; the default (0, or unset) preserves
+// the historical unbounded behavior so this is strictly opt-in.
+size_t get_mha_graph_cache_max_size() {
+  static size_t size = []() -> size_t {
+    const char* raw = std::getenv("TORCH_CUDNN_SDPA_CACHE_MAX_SIZE");
+    if (!raw || !*raw) {
+      return 0;
+    }
+    try {
+      long parsed = std::stol(raw);
+      return parsed > 0 ? static_cast<size_t>(parsed) : 0;
+    } catch (const std::exception&) {
+      TORCH_WARN(
+          "Ignoring unparseable TORCH_CUDNN_SDPA_CACHE_MAX_SIZE='",
+          raw,
+          "'; expected a positive integer.");
+      return 0;
+    }
+  }();
+  return size;
+}
+
 struct MHAGraphCache {
   using KeyType = MHACacheKeyWrapper;
   using ValueType = std::unique_ptr<fe::graph::Graph>;
@@ -358,6 +396,7 @@ struct MHAGraphCache {
   MapType engine_cache;
   int count = 0;
   int hits = 0;
+  int evictions = 0;
 
   // no mutexes here as caches are now thread local for v8, can also return a
   // pointer to the Execution Plan if we know it will not be invalidated by
@@ -371,7 +410,9 @@ struct MHAGraphCache {
           count,
           " times. Hit rate: ",
           100 * hits / count,
-          "%");
+          "%. Evictions: ",
+          evictions,
+          ".");
     }
     count++;
     auto it = engine_cache.find(key);
@@ -387,6 +428,24 @@ struct MHAGraphCache {
 
   template <typename... Args>
   std::pair<iterator, bool> try_emplace(const KeyType& key, Args&&... args) {
+    size_t limit = get_mha_graph_cache_max_size();
+    if (limit > 0 && engine_cache.size() >= limit &&
+        engine_cache.find(key) == engine_cache.end()) {
+      // Bound otherwise-unbounded per-thread growth (see comment above): once
+      // this thread's cache would exceed the configured cap, do a bulk
+      // eviction rather than tracking per-entry recency/LRU order. This is
+      // intentionally simple: it trades a burst of plan-rebuild cost for a
+      // hard ceiling on retained cuDNN plan/workspace-sizing state.
+      TORCH_WARN_ONCE(
+          "cuDNN SDPA plan cache on this thread hit "
+          "TORCH_CUDNN_SDPA_CACHE_MAX_SIZE=",
+          limit,
+          " entries; evicting all cached plans on this thread. Increase the "
+          "limit, or leave TORCH_CUDNN_SDPA_CACHE_MAX_SIZE unset (default) "
+          "to disable this bound.");
+      engine_cache.clear();
+      evictions++;
+    }
     return engine_cache.try_emplace(key, std::forward<Args>(args)...);
   }
 };
@@ -395,6 +454,10 @@ struct MHAGraphCache {
 // be thread safe across all engines see Limitations in
 // https://docs.nvidia.com/deeplearning/cudnn/backend/latest/release-notes.html
 // We also leak the caches to workaround potential teardown race issues.
+//
+// The caches are unbounded by default; set TORCH_CUDNN_SDPA_CACHE_MAX_SIZE to
+// cap the number of distinct execution plans retained per thread (see
+// get_mha_graph_cache_max_size above).
 
 MHAGraphCache& getMHAGraphCache_() {
   thread_local MHAGraphCache* instance{new MHAGraphCache()};


### PR DESCRIPTION
## Summary

`MHAGraphCache` (the cache of compiled cuDNN execution plans used by `scaled_dot_product_attention`'s cuDNN backend) is thread-local and unbounded by default. Each entry keeps a compiled `fe::graph::Graph`, along with its associated cuDNN execution-plan/workspace-sizing state, alive for the lifetime of the owning thread.

In a long-running, multi-threaded server that dispatches requests onto a pool of worker threads (e.g. Python's `asyncio.to_thread`/`ThreadPoolExecutor`, as used by frameworks like Ray Serve), this can result in as many independent, ever-growing caches as there are worker threads, each keyed on every distinct `(batch, heads, seqlen, ...)` shape it happens to see. This is a real, measurable source of unbounded memory growth that is independent of any specific correctness bug.

This PR adds an opt-in `TORCH_CUDNN_SDPA_LRU_CACHE_LIMIT` environment variable (named to match the existing `TORCH_CUDNN_V8_API_LRU_CACHE_LIMIT` precedent for cuDNN convolutions). When set to a positive integer, each thread-local `MHAGraphCache` uses true LRU eviction: a side `std::list` tracks recency, and only the single least-recently-used entry is dropped once the configured limit is reached. Left unset (the default), behavior is unchanged: the cache remains unbounded, exactly as before.

Also threads an `evictions` counter into the existing `TORCH_CUDNN_SDPA_CACHE_DEBUG` logging for observability.

**Related knob:** Prefer `TORCH_CUDNN_SDPA_AVOID_RECOMPILE` first where it applies (dense BSHD, no-bias path) — that avoids generating new cache keys per shape entirely. This LRU limit covers the residual/general case (e.g. bias, non-BSHD layouts) where `AVOID_RECOMPILE` cannot help. The two knobs are orthogonal; this one is off by default and does not affect `AVOID_RECOMPILE` users.

## Test plan

Built locally from source (CUDA 12.4, cuDNN 9.24, H200) and verified:
- [x] Default (unset `TORCH_CUDNN_SDPA_LRU_CACHE_LIMIT`) behavior emits no warnings and is unaffected (backward compatible).
- [x] Setting `TORCH_CUDNN_SDPA_LRU_CACHE_LIMIT` triggers single-entry LRU eviction at the configured threshold across repeated distinct-shape SDPA calls, with no crashes.
- [x] Timing check: a hot shape re-touched between insertions stays cache-hit-fast (~0.07ms) while an untouched shape pays recompile (~37ms) only once it becomes the LRU victim.
- [x] `test_transformers.py`'s `cudnn_attention` test suite: 14 passed, 5 xfail, 1 skipped -- no regressions (1 unrelated pre-existing failure due to missing Triton in the test venv, not from this change).
- [x] A 16-thread / 640-call concurrent SDPA stress test mimicking `ThreadPoolExecutor`-style dispatch, with the cap enabled.

Made with [Cursor](https://cursor.com)

cc @csarofeen @ptrblck @eqy @nWEIdia