### PR TITLE
[DCP] Add strict=False support to distributed checkpoint loading (#190389)

### DIFF
--- a/test/distributed/checkpoint/test_planner.py
+++ b/test/distributed/checkpoint/test_planner.py
@@ -760,6 +760,79 @@ class TestLoadPlanner(TestCase):
             )
 
     @with_temp_dir
+    def test_load_strict_true_default_raises(self):
+        # strict defaults to True, so a key present in the state_dict but absent
+        # from the checkpoint must still raise, preserving historical behavior.
+        original_module = nn.Linear(2, 2)
+        dcp.save(state_dict={"module": original_module}, checkpoint_id=self.temp_dir)
+
+        new_module = nn.Linear(2, 2)
+        new_module.extra_param = nn.Parameter(torch.randn(2, 2))
+        with self.assertRaisesRegex(CheckpointException, "Missing key in checkpoint"):
+            dcp.load(
+                state_dict={"module": new_module},
+                checkpoint_id=self.temp_dir,
+            )
+
+    @with_temp_dir
+    def test_load_strict_false_reports_missing_keys(self):
+        # A key in the state_dict but not in the checkpoint is reported as a
+        # missing key and left untouched instead of raising.
+        original_module = nn.Linear(2, 2)
+        dcp.save(state_dict={"module": original_module}, checkpoint_id=self.temp_dir)
+
+        new_module = nn.Linear(2, 2)
+        new_module.extra_param = nn.Parameter(torch.randn(2, 2))
+        result = dcp.load(
+            state_dict={"module": new_module},
+            checkpoint_id=self.temp_dir,
+            strict=False,
+        )
+
+        self.assertEqual(result.missing_keys, ["module.extra_param"])
+        self.assertEqual(result.unexpected_keys, [])
+        # The overlapping parameters are still loaded.
+        self.assertEqual(new_module.weight, original_module.weight)
+        self.assertEqual(new_module.bias, original_module.bias)
+
+    @with_temp_dir
+    def test_load_strict_false_reports_unexpected_keys(self):
+        # A key in the checkpoint but not in the state_dict is reported as an
+        # unexpected key and silently ignored.
+        original_module = nn.Linear(2, 2)
+        original_module.extra_param = nn.Parameter(torch.randn(2, 2))
+        dcp.save(state_dict={"module": original_module}, checkpoint_id=self.temp_dir)
+
+        new_module = nn.Linear(2, 2)
+        result = dcp.load(
+            state_dict={"module": new_module},
+            checkpoint_id=self.temp_dir,
+            strict=False,
+        )
+
+        self.assertEqual(result.missing_keys, [])
+        self.assertEqual(result.unexpected_keys, ["module.extra_param"])
+        self.assertEqual(new_module.weight, original_module.weight)
+        self.assertEqual(new_module.bias, original_module.bias)
+
+    @with_temp_dir
+    def test_load_returns_empty_incompatible_keys_on_exact_match(self):
+        # When state_dict and checkpoint match exactly, both lists are empty
+        # regardless of the strict flag.
+        original_module = nn.Linear(2, 2)
+        dcp.save(state_dict={"module": original_module}, checkpoint_id=self.temp_dir)
+
+        for strict in (True, False):
+            new_module = nn.Linear(2, 2)
+            result = dcp.load(
+                state_dict={"module": new_module},
+                checkpoint_id=self.temp_dir,
+                strict=strict,
+            )
+            self.assertEqual(result.missing_keys, [])
+            self.assertEqual(result.unexpected_keys, [])
+
+    @with_temp_dir
     def test_load_different_sizes_throws(self):
         original_module = nn.Linear(2, 2)
         dcp.save(state_dict={"module": original_module}, checkpoint_id=self.temp_dir)

--- a/torch/distributed/checkpoint/default_planner.py
+++ b/torch/distributed/checkpoint/default_planner.py
@@ -314,6 +314,12 @@ class DefaultLoadPlanner(LoadPlanner):
         self.original_state_dict = {}
         self.mappings = {}
         self.allow_partial_load = allow_partial_load
+        # Populated by create_local_plan. missing_keys are keys present in the
+        # state_dict being loaded into but absent from the checkpoint;
+        # unexpected_keys are keys present in the checkpoint but absent from the
+        # state_dict. Mirrors torch.nn.Module.load_state_dict semantics.
+        self.missing_keys: list[str] = []
+        self.unexpected_keys: list[str] = []
 
     def set_up_planner(
         self,
@@ -369,6 +375,11 @@ class DefaultLoadPlanner(LoadPlanner):
                 # _derived_version is only used by flatten_state_dict now.
                 # Set it back to None so that later we can save to a new version.
                 _version._derived_version = None
+
+        current_keys = set(self.state_dict.keys())
+        checkpoint_keys = set(self.metadata.state_dict_metadata.keys())
+        self.missing_keys = sorted(current_keys - checkpoint_keys)
+        self.unexpected_keys = sorted(checkpoint_keys - current_keys)
 
         return create_default_local_load_plan(
             self.state_dict, self.metadata, not self.allow_partial_load

--- a/torch/distributed/checkpoint/state_dict_loader.py
+++ b/torch/distributed/checkpoint/state_dict_loader.py
@@ -12,6 +12,7 @@ import torch.distributed as dist
 from torch.distributed.checkpoint.default_planner import _EmptyStateDictLoadPlanner
 from torch.distributed.checkpoint.logger import _dcp_method_logger
 from torch.distributed.checkpoint.stateful import Stateful
+from torch.nn.modules.module import _IncompatibleKeys
 
 from ._storage_utils import _storage_setup
 from .default_planner import DefaultLoadPlanner
@@ -65,7 +66,8 @@ def load(
     planner: LoadPlanner | None = None,
     process_group: dist.ProcessGroup | None = None,
     no_dist: bool = False,
-) -> None:
+    strict: bool = True,
+) -> _IncompatibleKeys:
     """
     Load a checkpoint into a distributed state dict in SPMD style.
 
@@ -124,8 +126,21 @@ def load(
             (Default: ``None``)
         no_dist (bool): If ``True``, this function will assume the intent is to load
             a checkpoint without using cross-rank synchronization. (Default: ``False``)
+        strict (bool): If ``True`` (the default), raise a ``RuntimeError`` when a key
+            present in ``state_dict`` is missing from the checkpoint, preserving the
+            historical behavior. If ``False``, keys that are missing from the checkpoint
+            are skipped (left untouched in ``state_dict``) and keys present in the
+            checkpoint but absent from ``state_dict`` are ignored, mirroring
+            ``torch.nn.Module.load_state_dict(strict=False)``. (Default: ``True``)
     Returns:
-        None.
+        ``NamedTuple`` with ``missing_keys`` and ``unexpected_keys`` fields, matching
+        the return value of ``torch.nn.Module.load_state_dict``:
+            * **missing_keys** is a list of str containing the keys in ``state_dict``
+              that were not found in the checkpoint.
+            * **unexpected_keys** is a list of str containing the keys in the
+              checkpoint that are not present in ``state_dict``.
+        When a custom ``planner`` that does not track these keys is supplied, both
+        lists are empty.
 
     Examples
         >>> # xdoctest: +SKIP
@@ -180,12 +195,13 @@ def load(
             elem = state_dict[key]
             stateful_sd[key] = elem.state_dict() if isinstance(elem, Stateful) else elem
 
-        _load_state_dict(
+        result = _load_state_dict(
             state_dict=stateful_sd,
             storage_reader=storage_reader,
             process_group=process_group,
             no_dist=no_dist,
             planner=planner,
+            strict=strict,
         )
         for key in keys:
             if key not in state_dict:
@@ -199,6 +215,8 @@ def load(
                 # Otherwise, replace the state_dict with the loaded state_dict.
                 state_dict[key] = stateful_sd[key]
 
+        return result
+
 
 def _load_state_dict(
     state_dict: dict[str, Any],
@@ -207,12 +225,17 @@ def _load_state_dict(
     coordinator_rank: int = 0,
     no_dist: bool = False,
     planner: LoadPlanner | None = None,
-) -> None:
+    strict: bool = True,
+) -> _IncompatibleKeys:
     torch._C._log_api_usage_once("torch.distributed.checkpoint.load_state_dict")
 
     distW = _DistWrapper(process_group, not no_dist, coordinator_rank)
     if planner is None:
-        planner = DefaultLoadPlanner()
+        planner = DefaultLoadPlanner(allow_partial_load=not strict)
+    elif not strict and hasattr(planner, "allow_partial_load"):
+        # Honor strict=False for planners (e.g. DefaultLoadPlanner subclasses)
+        # that gate the missing-key check on allow_partial_load.
+        planner.allow_partial_load = True
 
     ckpt_kwargs = {}
     if (ckpt_id := getattr(storage_reader, "checkpoint_id", None)) is not None:
@@ -315,6 +338,13 @@ def _load_state_dict(
     else:
         read_data()
         distW.barrier()
+
+    # missing_keys / unexpected_keys are computed identically on every rank
+    # (all ranks share the same keys and metadata), so no collective is needed.
+    return _IncompatibleKeys(
+        list(getattr(planner, "missing_keys", [])),
+        list(getattr(planner, "unexpected_keys", [])),
+    )
 
 
 def _load_state_dict_from_keys(


### PR DESCRIPTION
Summary:

`torch.distributed.checkpoint.load` (DCP) historically raised a `RuntimeError` whenever the `state_dict` being loaded into contained a key that was absent from the checkpoint, with no equivalent of the `strict=False` escape hatch that `torch.nn.Module.load_state_dict` offers. This made it awkward to load a checkpoint into a model whose structure has drifted (extra or missing parameters), which is a common case during fine-tuning, architecture changes, and partial restores.

This diff adds a `strict: bool = True` parameter to `load`:
- When `strict=True` (the default) behavior is unchanged: a key present in `state_dict` but missing from the checkpoint still raises, preserving backward compatibility.
- When `strict=False`, missing keys are skipped (left untouched in `state_dict`) and keys present in the checkpoint but absent from `state_dict` are ignored.

`load` now always returns a `NamedTuple` with `missing_keys` and `unexpected_keys` fields, matching the return contract of `torch.nn.Module.load_state_dict`. `missing_keys` are keys in `state_dict` not found in the checkpoint; `unexpected_keys` are keys in the checkpoint not present in `state_dict`. The previous return value was `None`, so returning a value is backward compatible for callers that ignore it.

Implementation: the internal `strict` flag is plumbed through `load` -> `_load_state_dict`. When no planner is supplied, DCP constructs `DefaultLoadPlanner(allow_partial_load=not strict)`; the missing-key check already keyed off `allow_partial_load`, so this reuses existing machinery rather than duplicating it. `DefaultLoadPlanner.create_local_plan` now records `missing_keys`/`unexpected_keys` by diffing the flattened `state_dict` keys against `metadata.state_dict_metadata`, and `_load_state_dict` reads them back to build the returned `NamedTuple`. The keys are identical on every rank (all ranks share the same keys and metadata), so no extra collective is required.

Addresses https://github.com/pytorch/pytorch/issues/148252.

This diff was authored with the assistance of an AI coding agent.

Test Plan:
Added unit tests in `test/distributed/checkpoint/test_planner.py::TestLoadPlanner` covering: default `strict=True` still raises on a missing key; `strict=False` reports `missing_keys` and still loads overlapping params; `strict=False` reports `unexpected_keys` for extra checkpoint keys; and an exact-match load returns empty `missing_keys`/`unexpected_keys` for both `strict` values.

```
buck2 test //caffe2/test/distributed/checkpoint:test_planner -- TestLoadPlanner
```

(Note: this environment has no built PyTorch, so the tests were authored against the existing `test_strict` patterns and validated for syntax/lint; they should be run in CI before publishing.)

Differential Revision: D110684683
