### PR TITLE
[dynamo] preserve dispatch key set across compiled calls via a C++ TLS stack

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -452,6 +452,36 @@ graph():
         self.assertEqual(include, torch._C._dispatch_tls_local_include_set())
         self.assertEqual(exclude, torch._C._dispatch_tls_local_exclude_set())
 
+    def test_dispatch_key_set_stack_balanced_on_fullgraph_error(self):
+        # compile_wrapper pushes the local dispatch key set onto a C++ stack and
+        # must pop it even when the wrapper's own finally raises. The
+        # fullgraph=True "found no compiled frames" error is raised from inside
+        # that finally, so a naive restore-at-end-of-finally would be skipped and
+        # leak a stack entry. Verify the save/restore stack stays balanced.
+        from torch.utils._python_dispatch import TorchDispatchMode
+
+        class YoloMode(TorchDispatchMode):
+            def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+                return torch.ops.aten.mul.Tensor(args[0], args[1])
+
+        x = torch.ones(5)
+        with YoloMode():
+            for _ in range(3):
+                with self.assertRaisesRegex(RuntimeError, "found no compiled frames"):
+                    torch.compile(torch.add, fullgraph=True)(x, x)
+
+        # A normal compiled call after the error loop must still work. This
+        # guards against an over-restore / double-pop regression, which would
+        # leave the stack empty and make the wrapper's own restore raise.
+        cf = torch.compile(lambda t: t + 1, backend="eager")
+        self.assertEqual(cf(x), x + 1)
+
+        # If any push had leaked, the stack would be non-empty here. When
+        # balanced it is empty, so a manual restore raises instead of silently
+        # popping a stale entry.
+        with self.assertRaisesRegex(RuntimeError, "empty stack"):
+            torch._C._dynamo_restore_local_dispatch_key_set()
+
     def test_compile_non_infra_empty_with_disalloed_dispatch_mode(self):
         from torch.utils._python_dispatch import TorchDispatchMode
 

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -1180,12 +1180,17 @@ class _TorchDynamoContext:
 
                 _maybe_set_eval_frame(_callback_from_stance(callback))
 
-                # _PreserveDispatchKeyGuard snapshots the local dispatch key set
-                # on construction and restores it on destruction, entirely in
-                # C++. This avoids materializing the include/exclude
-                # DispatchKeySets as (registered) pybind11 instances on every
-                # compiled call, which showed up as measurable per-call overhead.
-                with torch._C._PreserveDispatchKeyGuard():
+                # Snapshot the local dispatch key set onto a C++ thread-local
+                # stack so it can be restored after the compiled call, matching
+                # the old _ForceDispatchKeyGuard behavior. Keeping the snapshot
+                # in C++ avoids constructing pybind11 DispatchKeySet /
+                # context-manager instances on every compiled call. The restore
+                # runs in the outer finally below (after the inner finally, i.e.
+                # after pop_dynamic_layer_stack) so the save/restore stack stays
+                # balanced even if the inner finally itself raises (e.g. the
+                # fullgraph "found no compiled frames" error).
+                torch._C._dynamo_save_local_dispatch_key_set()
+                try:
                     call_succeeded = False
                     try:
                         result = fn(*args, **kwargs)
@@ -1241,6 +1246,11 @@ class _TorchDynamoContext:
                         )
                         for cleanup in cleanups:
                             cleanup()
+                finally:
+                    # Restore the local dispatch key set snapshotted above. In an
+                    # outer finally so it runs even if the inner finally raised,
+                    # keeping the save/restore stack balanced.
+                    torch._C._dynamo_restore_local_dispatch_key_set()
                 return result
             finally:
                 if fullgraph_count_enabled:

--- a/torch/csrc/utils/python_dispatch.cpp
+++ b/torch/csrc/utils/python_dispatch.cpp
@@ -673,6 +673,15 @@ class SetExcludeDispatchKeyGuard {
   bool old;
 };
 
+// Thread-local stack used to save/restore the local dispatch key set around a
+// torch.compile'd call (see compile_wrapper in eval_frame.py). Keeping the
+// saved keyset in C++ avoids materializing it as a (registered) pybind11
+// instance on every compiled call, and a stack supports nested compiled calls.
+static std::vector<c10::impl::LocalDispatchKeySet>& dynamoDispatchKeySetStack() {
+  static thread_local std::vector<c10::impl::LocalDispatchKeySet> stack;
+  return stack;
+}
+
 void initDispatchBindings(PyObject* module) {
   auto m = py::handle(module).cast<py::module>();
 
@@ -1319,6 +1328,22 @@ void initDispatchBindings(PyObject* module) {
   m.def("_dispatch_keys", [](const at::Tensor& tensor) {
     auto* impl = tensor.unsafeGetTensorImpl();
     return impl->key_set();
+  });
+  // Save the current local dispatch key set onto a C++ thread-local stack, to
+  // be restored by _dynamo_restore_local_dispatch_key_set. Used by
+  // torch.compile's per-call wrapper to preserve dispatch state across the
+  // compiled call without constructing pybind11 DispatchKeySet instances.
+  m.def("_dynamo_save_local_dispatch_key_set", []() {
+    dynamoDispatchKeySetStack().push_back(
+        c10::impl::tls_local_dispatch_key_set());
+  });
+  m.def("_dynamo_restore_local_dispatch_key_set", []() {
+    auto& stack = dynamoDispatchKeySetStack();
+    TORCH_CHECK(
+        !stack.empty(),
+        "_dynamo_restore_local_dispatch_key_set called with an empty stack");
+    c10::impl::_force_tls_local_dispatch_key_set(stack.back());
+    stack.pop_back();
   });
   m.def("_dispatch_tls_local_include_set", []() {
     return c10::impl::tls_local_dispatch_key_set().included_;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #190395
* #190393
* #190392
* __->__ #190391
* #190390

Follow-up to the previous commit. `compile_wrapper` in `_TorchDynamoContext`
still wrapped every compiled call in a pybind11 context manager
(`torch._C._PreserveDispatchKeyGuard`) to snapshot/restore the local dispatch
key set. Constructing that context-manager instance and running its
enter/exit protocol costs ~1.6us per call.

This replaces it with two lightweight bindings,
`_dynamo_save_local_dispatch_key_set` / `_dynamo_restore_local_dispatch_key_set`,
backed by a thread-local `std::vector<LocalDispatchKeySet>` stack in C++. The
save call pushes the current keyset; the restore call force-sets and pops it.
No Python object is materialized (the two calls are arg-less/void, so pybind11
does not register an instance), and the stack supports nested compiled calls.

The save runs immediately before an outer try, and the restore runs in that
outer try's finally -- outside the existing inner try/finally. This matters:
the inner finally itself can raise (e.g. the fullgraph=True "found no compiled
frames" RuntimeError, or pop_dynamic_layer_stack), and a restore placed at the
end of the inner finally would be skipped on that path, leaking a stack entry
and failing to restore dispatch state. The outer finally guarantees the pop
always runs, and runs it after the inner finally (i.e. after
pop_dynamic_layer_stack), preserving the old ordering where the dispatch keyset
is restored last.

Approach note: I first tried moving the save/restore into the C
`dynamo__custom_eval_frame` shim (a stack-local `c10::impl::ForceDispatchKeyGuard`).
That is incorrect: the shim runs per intercepted frame, but a graph break
produces multiple intercepted frames within one `compile_wrapper` call, and the
dispatch/autocast/functorch state must persist across the break. A per-frame
guard reverts each subgraph's state prematurely, which failed
test__enter__exit_autocast_graph_break, test__enter__exit_autocast_non_idempotent,
and test_grad_with_graph_break. The dispatch snapshot is inherently
per-outer-call, so it must stay in `compile_wrapper`; only the mechanism moves
to C++.

The isolated save/restore mechanism drops from 2.87us/call (original: two
DispatchKeySet getters plus a `_ForceDispatchKeyGuard` context manager) to
0.25us/call, with identical per-outer-call semantics.

Test Plan:

```
python test/dynamo/test_misc.py MiscTests.test_dispatch_key_set_stack_balanced_on_fullgraph_error
python test/dynamo/test_ctx_manager.py                                  # 141 passed
python test/dynamo/test_higher_order_ops.py FuncTorchHigherOrderOpTests  # 81 passed
```

The new test exercises the outer-finally guarantee: it runs a fullgraph=True
call that raises "found no compiled frames" from inside the inner finally and
asserts the save/restore stack is left empty (a leaked entry would let a manual
restore silently pop instead of raising "empty stack"). The graph-break tests
above (which failed under the rejected in-shim approach) also pass. Also
verified numerics and functorch.grad-under-compile.

This PR was authored with the assistance of an AI coding assistant.