### PR TITLE
[dynamo] route _disable_dynamo hot path through call_with_disable

### DIFF
--- a/benchmarks/dynamo/pr_time_benchmarks/benchmarks/disable_overhead.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/benchmarks/disable_overhead.py
@@ -82,10 +82,52 @@ class BenchmarkCallWithDisable(BenchmarkBase):
         self._call_with_disable(self._f, self.a)
 
 
+class BenchmarkDisableDynamo(BenchmarkBase):
+    # torch._compile._disable_dynamo is the torch-internal disable used on hot
+    # paths like torch.library.custom_op and torch.optim. It routes fully
+    # recursive, non-export calls through call_with_disable.
+    def __init__(self):
+        super().__init__(
+            category="disable_dynamo_overhead",
+            device="cpu",
+        )
+
+    def name(self):
+        return self.category()
+
+    def description(self):
+        return "per-call overhead of torch._compile._disable_dynamo"
+
+    def _prepare_once(self):
+        from torch._compile import _disable_dynamo
+
+        torch._dynamo.reset()
+
+        @_disable_dynamo
+        def f(x):
+            return x
+
+        self._fn = f
+        self.a = torch.ones(1)
+
+        # warm up (also resolves the cached fast-path hooks)
+        for _ in range(10):
+            self._work()
+
+    def _prepare(self):
+        pass
+
+    def _work(self):
+        self._fn(self.a)
+
+
 def main():
     result_path = sys.argv[1]
     Benchmark().enable_instruction_count().collect_all().append_results(result_path)
     BenchmarkCallWithDisable().enable_instruction_count().collect_all().append_results(
+        result_path
+    )
+    BenchmarkDisableDynamo().enable_instruction_count().collect_all().append_results(
         result_path
     )
 

--- a/test/dynamo/test_decorators.py
+++ b/test/dynamo/test_decorators.py
@@ -162,6 +162,62 @@ class DecoratorTests(PytreeRegisteringTestCase):
         with self.assertRaises(TypeError):
             call_with_disable()
 
+    def test_disable_dynamo_fast_path(self):
+        # torch._compile._disable_dynamo routes fully-recursive, non-export calls
+        # through call_with_disable. Verify results are correct and Dynamo still
+        # treats the callee as disabled (graph break, not traced into), and that
+        # recursive=False still works via the DisableContext fallback.
+        from torch._compile import _disable_dynamo
+
+        @_disable_dynamo
+        def inner(x):
+            return x + 1
+
+        def fn(x):
+            return torch.cos(inner(torch.sin(x)))
+
+        x = torch.randn(3)
+        ref = fn(x)
+        cnts = torch._dynamo.testing.CompileCounter()
+        self.assertEqual(torch.compile(fn, backend=cnts)(x), ref)
+        # inner is disabled -> graph break around it -> two compiled frames.
+        self.assertEqual(cnts.frame_count, 2)
+
+        @_disable_dynamo(recursive=False)
+        def inner_nonrecursive(x):
+            return x + 1
+
+        self.assertEqual(inner_nonrecursive(x), x + 1)
+
+        # recursive=False takes the DisableContext fallback (not the fast path);
+        # it must also work under torch.compile.
+        def fn_nr(x):
+            return torch.cos(inner_nonrecursive(torch.sin(x)))
+
+        cnts_nr = torch._dynamo.testing.CompileCounter()
+        self.assertEqual(torch.compile(fn_nr, backend=cnts_nr)(x), fn_nr(x))
+
+    def test_disable_dynamo_under_export(self):
+        # Under export, _disable_dynamo takes the DisableContext fallback (the
+        # fast path is guarded by `not is_exporting()`); verify a disabled helper
+        # still produces correct results in the exported program. (The
+        # fx_traceback disable annotation itself is covered by test_export.py's
+        # test_uplift_common_custom_meta_with_multiple_calls, which exercises the
+        # custom_op dispatch path where the annotation surfaces.)
+        from torch._compile import _disable_dynamo
+
+        @_disable_dynamo
+        def helper(x):
+            return x + 1
+
+        class M(torch.nn.Module):
+            def forward(self, x):
+                return helper(x) * 2
+
+        x = torch.randn(3)
+        ep = torch.export.export(M(), (x,))
+        self.assertEqual(ep.module()(x), (x + 1) * 2)
+
     def test_disable_ignores_outer_wraps(self):
         def orig_inner():
             pass

--- a/torch/_compile.py
+++ b/torch/_compile.py
@@ -12,6 +12,10 @@ from typing_extensions import ParamSpec
 _T = TypeVar("_T")
 _P = ParamSpec("_P")
 
+# (call_with_disable, is_exporting), resolved lazily on the first disabled call
+# to avoid importing torch at module load (see module docstring).
+_fast_disable_hooks: tuple[Callable[..., object], Callable[[], bool]] | None = None
+
 
 @overload
 def _disable_dynamo(
@@ -41,6 +45,26 @@ def _disable_dynamo(
 
         @functools.wraps(fn)
         def inner(*args: _P.args, **kwargs: _P.kwargs) -> _T:
+            # Fast path: a fully-recursive disable outside of export is just
+            # "run fn with the eval-frame handler off", which call_with_disable
+            # does entirely in C (forwarding args via vectorcall), avoiding the
+            # DisableContext wrapper. Export needs the DisableContext wrapper for
+            # its fx_traceback annotation, and recursive=False needs its
+            # non-recursive skip semantics, so both fall through below. The C
+            # entry point and is_exporting are resolved once and cached to keep
+            # this path cheap without importing torch at module load time.
+            global _fast_disable_hooks
+            if _fast_disable_hooks is None:
+                import torch
+
+                _fast_disable_hooks = (
+                    torch._C._dynamo.eval_frame.call_with_disable,
+                    torch.compiler.is_exporting,
+                )
+            call_with_disable, is_exporting = _fast_disable_hooks
+            if recursive and not is_exporting():
+                return call_with_disable(fn, *args, **kwargs)
+
             # cache this on the first invocation to avoid adding too much overhead.
             disable_fn = getattr(fn, "__dynamo_disable", None)
             if disable_fn is None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #190409
* __->__ #190395
* #190393
* #190392
* #190390
* #190391

Applies the call_with_disable C-API (previous commit) to the torch-internal
disable wrapper so real callsites benefit -- this is the payoff zou3519 asked
for in #188077 (comments 1 and 2). torch._compile._disable_dynamo backs the
hot disable callsites across the codebase (torch.library.custom_op backend
wrappers, torch.optim.*, prims wrappers, higher-order-op utils, ...).

Its per-call `inner` wrapper resolved a cached DisableContext and invoked it,
paying for that wrapper's own prologue/epilogue on every call. Route the common
case -- fully recursive disable outside of export -- straight through
call_with_disable instead, which toggles the eval-frame handler and forwards
args via vectorcall in C. Two cases fall through to the existing DisableContext
path, which is required for their semantics:

- recursive=False (e.g. torch.nn.parallel.distributed): needs non-recursive
  skip semantics, which call_with_disable does not provide.
- torch.compiler.is_exporting(): needs the fx_traceback annotation that
  DisableContext emits.

The call_with_disable entry point and is_exporting are resolved once and cached
in a module global so the fast path stays cheap and _compile.py still avoids
importing torch at module load.

disable_dynamo_overhead benchmark (deterministic instruction count): 5051 ->
4260 per call (~16%); the custom-op disable path (its @_disable_dynamo wrapper)
is down ~44% from its pre-#188077 baseline once combined with the earlier
commits. Dynamo's handling of a disabled callee under torch.compile is
unchanged -- frame_count / op_count are identical with and without this change,
so no new graph breaks are introduced.

Coverage also asserts the two fallback paths: recursive=False under
torch.compile, and a _disable_dynamo helper producing correct results under
torch.export (which takes the is_exporting() fallback). The disable
fx_traceback annotation itself stays covered by test_export.py's
test_uplift_common_custom_meta_with_multiple_calls (the annotation surfaces in
the custom_op dispatch context, not for arbitrary user functions).

Test Plan:

```
python test/dynamo/test_decorators.py DecoratorTests.test_disable_dynamo_fast_path
python test/dynamo/test_decorators.py DecoratorTests.test_disable_dynamo_under_export
python test/dynamo/test_decorators.py -k disable
python test/test_custom_ops.py -k compile                 # 9 passed
python test/export/test_export.py -k test_uplift_common_custom_meta_with_multiple_calls
python benchmarks/dynamo/pr_time_benchmarks/benchmarks/disable_overhead.py /tmp/out.csv
```

Also smoke-tested torch.optim.AdamW under torch.compile (optim uses
_disable_dynamo) and confirmed the compiled graph-break count is unchanged.

This PR was authored with the assistance of an AI coding assistant.