### PR TITLE
Don't mutate the input in unpad_sequence (fixes #98499)

### DIFF
--- a/test/nn/test_packed_sequence.py
+++ b/test/nn/test_packed_sequence.py
@@ -264,10 +264,13 @@ class PackedSequenceTest(TestCase):
             padded_sequences = rnn_utils.pad_sequence(
                 sequences, batch_first=batch_first
             )
+            padded_before = padded_sequences.clone()
             unpadded_sequences = rnn_utils.unpad_sequence(
                 padded_sequences, lengths, batch_first=batch_first
             )
             self.assertEqual(sequences, unpadded_sequences)
+            # unpad_sequence must not modify its input in place (gh-98499)
+            self.assertEqual(padded_sequences, padded_before)
 
         # more dimensions
         maxlen = 9

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -506,7 +506,7 @@ def unpad_sequence(
     unpadded_sequences = []
 
     if not batch_first:
-        padded_sequences.transpose_(0, 1)
+        padded_sequences = padded_sequences.transpose(0, 1)
 
     max_length = padded_sequences.shape[1]
     idx = torch.arange(max_length, device=lengths.device)


### PR DESCRIPTION
Fixes #98499.

### Summary

`torch.nn.utils.rnn.unpad_sequence` transposes its input **in place** when `batch_first=False` (the default):

```python
    if not batch_first:
        padded_sequences.transpose_(0, 1)
```

`transpose_` mutates the caller's tensor, so after the call the padded input comes back transposed:

```python
>>> import torch
>>> from torch.nn.utils.rnn import pad_sequence, unpad_sequence
>>> padded = pad_sequence([torch.tensor([1., 2., 3.]), torch.tensor([4., 5.])])
>>> padded.shape
torch.Size([3, 2])
>>> _ = unpad_sequence(padded, torch.tensor([3, 2]))
>>> padded.shape
torch.Size([2, 3])   # caller's tensor was transposed in place
```

This is a surprising side effect (and stateful across repeated calls on the same tensor). `unpad_sequence` should not modify its argument.

### Fix

Use the out-of-place `transpose` and rebind the local variable:

```python
    if not batch_first:
        padded_sequences = padded_sequences.transpose(0, 1)
```

The subsequent logic reads `padded_sequences.shape[1]` and iterates over it, so rebinding the local is sufficient and the output is unchanged.

### Test

Extended `test/nn/test_packed_sequence.py::test_unpad_sequence` to clone the padded input and assert it is unchanged after `unpad_sequence` (for both `batch_first` values). It fails before this change (the `batch_first=False` case transposes the input) and passes after.
