### PR TITLE
[inductor] Simplify nested modular indexing

### DIFF
--- a/test/inductor/test_indexing.py
+++ b/test/inductor/test_indexing.py
@@ -214,7 +214,10 @@ class TestIndexingSimplification(InductorTestCase):
         # Nested modular indexing is correctly simplified
         var_ranges = {i1: 13, i2: 121}
         expr = ModularIndexing(ModularIndexing(121 * i1 + i2, 1, 784), 1, 28)
-        self.assertEqual(sizevars.simplify_with_ranges(expr, var_ranges), expr)
+        self.assertEqual(
+            sizevars.simplify_with_ranges(expr, var_ranges),
+            ModularIndexing(121 * i1 + i2, 1, 28),
+        )
         expr = ModularIndexing(ModularIndexing(121 * i1 + i2, 1, 784) + 1, 1, 28)
         self.assertEqual(sizevars.simplify_with_ranges(expr, var_ranges), expr)
         var_ranges = {i2: 784}
@@ -225,6 +228,33 @@ class TestIndexingSimplification(InductorTestCase):
         self.assertEqual(sizevars.simplify_with_ranges(expr, var_ranges), expected)
         expr = ModularIndexing(ModularIndexing(i2, 1, 28) + 1, 7, 4)
         self.assertEqual(sizevars.simplify_with_ranges(expr, var_ranges), expr)
+
+        var_ranges = {i0: 4096, r3: 256}
+        p = r3 + 256 * i0
+        expr = (
+            32768 * FloorDiv(p, 32768)
+            + 4 * FloorDiv(ModularIndexing(p, 1, 32768), 8192)
+            + 16 * ModularIndexing(ModularIndexing(p, 1, 32768), 256, 32)
+            + 512
+            * ModularIndexing(
+                ModularIndexing(ModularIndexing(p, 1, 32768), 1, 8192),
+                4,
+                64,
+            )
+            + ModularIndexing(
+                ModularIndexing(ModularIndexing(p, 1, 32768), 1, 8192),
+                1,
+                4,
+            )
+        )
+        expected = (
+            512 * FloorDiv(r3, 4)
+            + 32768 * FloorDiv(i0, 128)
+            + ModularIndexing(r3, 1, 4)
+            + 16 * ModularIndexing(i0, 1, 32)
+            + 4 * ModularIndexing(i0, 32, 4)
+        )
+        self.assertEqual(sizevars.simplify_with_ranges(expr, var_ranges), expected)
 
     def test_floordiv_modularindexing_simplification(self):
         sizevars = SizeVarAllocator()

--- a/test/inductor/test_indexing.py
+++ b/test/inductor/test_indexing.py
@@ -220,6 +220,10 @@ class TestIndexingSimplification(InductorTestCase):
         )
         expr = ModularIndexing(ModularIndexing(121 * i1 + i2, 1, 784) + 1, 1, 28)
         self.assertEqual(sizevars.simplify_with_ranges(expr, var_ranges), expr)
+        expr = ModularIndexing(ModularIndexing(i2, 1, 29), 7, 4)
+        self.assertEqual(sizevars.simplify_with_ranges(expr, {}), expr)
+        expr = ModularIndexing(ModularIndexing(i2, -3, 12), -3, 4)
+        self.assertEqual(sizevars.simplify_with_ranges(expr, {}), expr)
         var_ranges = {i2: 784}
         expr = ModularIndexing(ModularIndexing(i2, 1, 28), 7, 4)
         # FloorDiv(ModularIndexing(b, d1, m), d2) simplifies to

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -408,7 +408,11 @@ class SizeVarAllocator:
             if isinstance(base, ModularIndexing):
                 inner_base, inner_divisor, inner_modulus = base.args
                 period = divisor * modulus
-                if self.statically_known_multiple_of(inner_modulus, period):
+                # Target use cases have constant indices; avoid symbolic compile-time analysis.
+                if all(
+                    isinstance(value, sympy.Integer) and value > 0
+                    for value in (inner_modulus, divisor, modulus)
+                ) and self.statically_known_multiple_of(inner_modulus, period):
                     return ModularIndexing(inner_base, inner_divisor * divisor, modulus)
 
             can_remove_mod = statically_known(base >= 0) and statically_known(

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -405,6 +405,12 @@ class SizeVarAllocator:
         def visit_modular_indexing(base, divisor, modulus):
             base = remove_zero_terms(base, divisor)
 
+            if isinstance(base, ModularIndexing):
+                inner_base, inner_divisor, inner_modulus = base.args
+                period = divisor * modulus
+                if self.statically_known_multiple_of(inner_modulus, period):
+                    return ModularIndexing(inner_base, inner_divisor * divisor, modulus)
+
             can_remove_mod = statically_known(base >= 0) and statically_known(
                 base < modulus * divisor
             )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #190596
* #190595
* #190594
* #190593
* #190404
* #190403
* #190402
* #190401
* __->__ #190400

Teach simplify_with_ranges to collapse nested ModularIndexing when the inner modulus covers an integer number of outer periods. This keeps generated inverse-index expressions cleaner without changing cases where an intervening offset makes the rewrite invalid.

Authored by Codex.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo