### PR TITLE
[OSS][PyTorch][Inductor] Include HAS_MTIA_AND_TRITON in requires_gpu_and_triton

### DIFF
--- a/torch/testing/_internal/inductor_utils.py
+++ b/torch/testing/_internal/inductor_utils.py
@@ -84,11 +84,13 @@ else:
 
 HAS_CUDA_AND_TRITON = torch.cuda.is_available() and HAS_TRITON
 
+HAS_MTIA_AND_TRITON = torch.mtia.is_available() and HAS_TRITON
+
 HAS_XPU_AND_TRITON = torch.xpu.is_available() and HAS_TRITON
 
 HAS_MPS = torch.mps.is_available()
 
-HAS_GPU = HAS_CUDA_AND_TRITON or HAS_XPU_AND_TRITON
+HAS_GPU = HAS_CUDA_AND_TRITON or HAS_XPU_AND_TRITON or HAS_MTIA_AND_TRITON
 HAS_GPU_AND_TRITON = HAS_GPU
 
 GPU_TYPE = get_gpu_type()

--- a/torch/testing/_internal/triton_utils.py
+++ b/torch/testing/_internal/triton_utils.py
@@ -5,6 +5,7 @@ import unittest
 from torch.testing._internal.inductor_utils import (
     HAS_CUDA_AND_TRITON,
     HAS_GPU,
+    HAS_MTIA_AND_TRITON,
     HAS_XPU_AND_TRITON,
 )
 from torch.utils._triton import has_triton
@@ -17,7 +18,8 @@ requires_xpu_and_triton = unittest.skipUnless(
     HAS_XPU_AND_TRITON, "requires xpu and triton"
 )
 requires_gpu_and_triton = unittest.skipUnless(
-    HAS_XPU_AND_TRITON or HAS_CUDA_AND_TRITON, "requires gpu and triton"
+    HAS_XPU_AND_TRITON or HAS_CUDA_AND_TRITON or HAS_MTIA_AND_TRITON,
+    "requires gpu and triton",
 )
 requires_gpu = unittest.skipUnless(HAS_GPU, "requires gpu")
 


### PR DESCRIPTION
Summary: requires_gpu_and_triton gated on CUDA and XPU but omitted HAS_MTIA_AND_TRITON, even though HAS_GPU already includes it. This aligns the decorator with HAS_GPU so the gate is consistent across accelerator types. Behavior-neutral where MTIA+Triton is unavailable (HAS_MTIA_AND_TRITON is False), so CUDA/XPU/CPU are unaffected.

Test Plan: N/A

Differential Revision: D112639337
