### PR TITLE
[dynamo] default _guards TLS attrs so compiled-call try_get() avoids getattr-miss

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -482,6 +482,41 @@ graph():
         with self.assertRaisesRegex(RuntimeError, "empty stack"):
             torch._C._dynamo_restore_local_dispatch_key_set()
 
+    def test_tracing_context_tls_defaults_present(self):
+        # The _guards thread-local defaults tracing_context/compile_context to
+        # None per thread, so the hot-path try_get() calls (once per compiled
+        # call) hit a present attribute instead of a slow getattr-miss on a
+        # thread that never ran compilation itself (e.g. a worker thread running
+        # code compiled on another thread).
+        import threading
+
+        from torch._guards import _TLS, CompileContext, TracingContext
+
+        result = {}
+
+        def worker():
+            result["tc_present"] = "tracing_context" in _TLS.__dict__
+            result["cc_present"] = "compile_context" in _TLS.__dict__
+            result["tc"] = TracingContext.try_get()
+            result["cc"] = CompileContext.try_get()
+            # Off-context (compile_context defaulted to None), get() still raises
+            # -- the default makes this the "not set" AssertionError rather than
+            # an AttributeError, on every thread regardless of history.
+            try:
+                CompileContext.get()
+                result["get_raised"] = None
+            except AssertionError:
+                result["get_raised"] = "AssertionError"
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join()
+        self.assertTrue(result["tc_present"])
+        self.assertTrue(result["cc_present"])
+        self.assertIsNone(result["tc"])
+        self.assertIsNone(result["cc"])
+        self.assertEqual(result["get_raised"], "AssertionError")
+
     def test_compile_non_infra_empty_with_disalloed_dispatch_mode(self):
         from torch.utils._python_dispatch import TorchDispatchMode
 

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -1004,7 +1004,19 @@ class HopDispatchSetCache:
         return self.hop_cache_map[op]  # type: ignore[index]
 
 
-_TLS = threading.local()
+class _TLSStorage(threading.local):
+    # Default the hot-path attributes to None per thread so that
+    # TracingContext.try_get() / CompileContext.try_get() -- called on every
+    # torch.compile'd call -- hit a present attribute instead of paying for an
+    # AttributeError raise+catch inside getattr(). Without this, a thread that
+    # never ran compilation itself (e.g. a worker thread executing compiled code
+    # compiled on another thread) takes the slow getattr-miss path on every call.
+    def __init__(self) -> None:
+        self.tracing_context: TracingContext | None = None
+        self.compile_context: CompileContext | None = None
+
+
+_TLS = _TLSStorage()
 
 """
 TracingContext is the source of truth for all currently accumulated information


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #190409
* #190395
* #190393
* #190392
* #190390
* #190391

compile_wrapper calls TracingContext.try_get() (and the machinery reads
CompileContext) on every torch.compile'd call. These are
`getattr(_TLS, "tracing_context", None)` on a threading.local. On a thread that
has itself run compilation, the tracing_context_manager leaves the attribute set
(to None on exit), so the getattr hits. But on a thread that only *executes*
compiled code -- e.g. a worker thread running a module compiled on another
thread -- the attribute is absent, and every call pays ~450ns for an
AttributeError raised-and-caught inside getattr() (measured: ~610ns miss vs
~160ns hit on a threading.local).

Make _TLS a threading.local subclass whose per-thread __init__ defaults
tracing_context and compile_context to None, so the attribute is always present
and the hot-path try_get() takes the fast path on every thread. Behavior is
unchanged (a missing attribute and an attribute set to None both mean "no
context"); this only removes the getattr-miss.

One incidental, harmless consequence: CompileContext.get() called off-context
on a thread that never compiled used to raise AttributeError (the attribute was
absent); now the attribute is present as None, so it raises the more informative
AssertionError("compile_context is not set") -- the same error a thread that had
already compiled always hit. No caller catches AttributeError here (the sole
non-test caller runs under an active compile_context), so this only affects
misuse. The new test pins it.

Test Plan:

```
python test/dynamo/test_misc.py MiscTests.test_tracing_context_tls_defaults_present
python test/dynamo/test_ctx_manager.py   # 141 passed (exercises tracing/compile context)
```

This PR was authored with the assistance of an AI coding assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98