### PR TITLE
Fix 32-bit shift in Bitfield<uint64_t> non-PTX path

### DIFF
--- a/aten/src/ATen/cuda/AsmUtils.cuh
+++ b/aten/src/ATen/cuda/AsmUtils.cuh
@@ -54,7 +54,7 @@ struct Bitfield<uint64_t> {
     pos &= 0xff;
     len &= 0xff;
 
-    uint64_t m = (uint64_t(1) << len) - 1;
+    uint64_t m = (static_cast<uint64_t>(1) << len) - 1;
     return (val >> pos) & m;
 #else
     uint64_t ret;
@@ -69,7 +69,7 @@ struct Bitfield<uint64_t> {
     pos &= 0xff;
     len &= 0xff;
 
-    uint64_t m = (uint64_t(1) << len) - 1;
+    uint64_t m = (static_cast<uint64_t>(1) << len) - 1;
     toInsert &= m;
     toInsert <<= pos;
     m <<= pos;

--- a/aten/src/ATen/cuda/AsmUtils.cuh
+++ b/aten/src/ATen/cuda/AsmUtils.cuh
@@ -54,7 +54,7 @@ struct Bitfield<uint64_t> {
     pos &= 0xff;
     len &= 0xff;
 
-    uint64_t m = (1u << len) - 1u;
+    uint64_t m = (uint64_t(1) << len) - 1;
     return (val >> pos) & m;
 #else
     uint64_t ret;
@@ -69,7 +69,7 @@ struct Bitfield<uint64_t> {
     pos &= 0xff;
     len &= 0xff;
 
-    uint64_t m = (1u << len) - 1u;
+    uint64_t m = (uint64_t(1) << len) - 1;
     toInsert &= m;
     toInsert <<= pos;
     m <<= pos;


### PR DESCRIPTION
`(1u << len) - 1u` truncates the mask for `len >= 32`. The non-PTX branch is not just the host fallback: it is the device implementation on ROCm, where this is latent UB. No behavior change today since all callers pass `len <= 4` (`RADIX_BITS`).