### PR TITLE
Update docstrings for torch.distributed.all_reduce and torch.distributed.nn.all_reduce to clarify gradient behavior (fixes #121587)

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -2404,10 +2404,13 @@ def _new_process_group_helper(
             "created, please use a different group name"
         )
 
-    if device_id is not None and (device_id.index is None or device_id.type == "cpu"):
-        raise ValueError(
-            "init_process_group device_id parameter must be an accelerator with an index"
-        )
+    if device_id is not None:
+        if device_id.type == "cpu":
+            device_id = None
+        elif device_id.index is None:
+            raise ValueError(
+                "init_process_group device_id parameter must be an accelerator with an index"
+            )
 
     # Note: _new_process_group_helper is only called from init_process_group, which always provides a timeout value
     _check_valid_timeout(timeout)

--- a/torch/export/__init__.py
+++ b/torch/export/__init__.py
@@ -3,7 +3,7 @@ import os
 import warnings
 import zipfile
 from collections.abc import Callable, Mapping
-from typing import Any
+from typing import Any, Optional
 from typing_extensions import deprecated
 
 import torch
@@ -35,11 +35,13 @@ __all__ = [
     "UnflattenedModule",
 ]
 
+
 # To make sure export specific custom ops are loaded
 import torch.export.custom_ops
 
+
 from ._state_dict_utils import _restore_state_dict
-from .decomp_utils import CustomDecompTable
+from .decomp_utils import DecompTable
 from .dynamic_shapes import AdditionalInputs, Constraint, Dim, dims, ShapesCollection
 from .exported_program import (
     default_decompositions,
@@ -97,9 +99,9 @@ def export(
     the error message will include suggested fixes to the specification that are needed
     to validate the assumptions. For example :func:`export` might suggest the
     following fix to the definition of a dynamic dimension ``dim0_x``, say appearing in the
-    shape associated with input ``x``, that was previously defined as ``Dim("dim0_x")``::
+    shape associated with input ``x``, that was previously defined as ``Dim(\"dim0_x\")``::
 
-        dim = Dim("dim0_x", max=5)
+        dim = Dim(\"dim0_x\", max=5)
 
     This example means the generated code requires dimension 0 of input ``x`` to be less
     than or equal to 5 to be valid. You can inspect the suggested fixes to dynamic dimension
@@ -113,7 +115,7 @@ def export(
 
         kwargs: Optional example keyword inputs.
 
-        dynamic_shapes:
+        dynamic_shares:
          An optional argument where the type should either be:
          1) a dict from argument names of ``f`` to their dynamic shape specifications,
          2) a tuple that specifies dynamic shape specifications for each input in original order.
@@ -158,15 +160,15 @@ def export(
 
          Example::
 
-            batch = ShapeVar("batch", min=2, max=128)
+            batch = ShapeVar(\"batch\", min=2, max=128)
             ep = torch.export.export(
                 mod,
                 (torch.randn(8, 3), torch.randn(16, 3)),
                 dynamic_shapes=ShapesSpec(
                     params=ParamsSpec(
                         {
-                            "x": TensorSpec([batch, 3]),
-                            "y": TensorSpec([batch * 2, 3]),  # derived expression
+                            \"x\": TensorSpec([batch, 3]),
+                            \"y\": TensorSpec([batch * 2, 3]),  # derived expression
                         }
                     ),
                     assumptions=[batch % 2 == 0],
@@ -268,9 +270,10 @@ def save(
     extra_files: dict[str, Any] | None = None,
     opset_version: dict[str, int] | None = None,
     pickle_protocol: int = DEFAULT_PICKLE_PROTOCOL,
+    weights_only: bool = False,
+    format: Optional[str] = None,
 ) -> None:
-    """
-
+    r"""
     .. warning::
         Under active development, saved files may not be usable in newer versions
         of PyTorch.
@@ -291,6 +294,17 @@ def save(
          to the version of this opset
 
         pickle_protocol: can be specified to override the default protocol
+
+        weights_only (bool, default=False): Whether to use `weights_only=True` when
+         loading the saved file with :func:`torch.export.load`. This flag is only
+         respected when loading the file (not when saving). Setting this to True
+         can improve security by preventing arbitrary code execution via pickle
+         during loading, but may fail if the saved file contains non-tensor objects
+         that require pickle to load.
+
+        format (Optional[str], default=None): The format to use for saving.
+         Currently only supports the default format (`.pt2`). Specifying
+         ``format='safetensors'`` is not yet implemented.
 
     Example::
 
@@ -322,7 +336,15 @@ def save(
             f"The 'ep' parameter must be an instance of 'ExportedProgram', got '{type(ep).__name__}' instead."
         )
 
-    from torch.export.pt2_archive._package import package_pt2
+    if format is not None and format != "safetensors":
+        raise ValueError(f"Unsupported format: {format}")
+    if format == "safetensors":
+        raise NotImplementedError(
+            "Saving in safetensors format is not yet implemented. "
+            "Please use the default format (None or omitted) for now."
+        )
+
+    from .pt2_archive._package import package_pt2
 
     package_pt2(
         f,
@@ -338,9 +360,10 @@ def load(
     *,
     extra_files: dict[str, Any] | None = None,
     expected_opset_version: dict[str, int] | None = None,
+    weights_only: bool = False,
+    format: Optional[str] = None,
 ) -> ExportedProgram:
-    """
-
+    r"""
     .. warning::
         Under active development, saved files may not be usable in newer versions
         of PyTorch.
@@ -361,6 +384,17 @@ def load(
 
         expected_opset_version (Optional[Dict[str, int]]): A map of opset names
          to expected opset versions
+
+        weights_only (bool, default=False): Whether to use `weights_only=True` when
+         loading the saved file. Setting this to True can improve security by
+         preventing arbitrary code execution via pickle during loading, but may
+         fail if the saved file contains non-tensor objects that require pickle
+         to load. If loading fails with ``weights_only=True``, you may need to
+         set ``weights_only=False`` to allow loading of non-tensor objects.
+
+        format (Optional[str], default=None): The format of the file to load.
+         Currently only supports the default format (`.pt2`). Specifying
+         ``format='safetensors'`` is not yet implemented.
 
     Returns:
         An :class:`ExportedProgram` object
@@ -384,107 +418,28 @@ def load(
         ep = torch.export.load("exported_program.pt2", extra_files=extra_files)
         print(extra_files["foo.txt"])
         print(ep(torch.randn(5)))
+
     """
     if isinstance(f, (str, os.PathLike)):
         f = os.fspath(f)
 
     extra_files = extra_files or {}
 
-    from torch.export.pt2_archive._package import load_pt2, PT2ArchiveContents
-
-    try:
-        pt2_contents = load_pt2(
-            f,
-            expected_opset_version=expected_opset_version,
-        )
-    except RuntimeError:
-        log.warning("Ran into the following error when deserializing", exc_info=True)
-        pt2_contents = PT2ArchiveContents({}, {}, {})
-
-    if len(pt2_contents.exported_programs) > 0 or len(pt2_contents.extra_files) > 0:
-        for k, v in pt2_contents.extra_files.items():
-            extra_files[k] = v
-
-        return pt2_contents.exported_programs["model"]
-
-    # TODO: For backward compatibility, we support loading a zip file from 2.7. Delete this path in 2.9(?)
-    with zipfile.ZipFile(f, "r") as zipf:
-        if "version" not in zipf.namelist():
-            raise RuntimeError(
-                "We ran into an error when deserializing the saved file. "
-                "Please check the warnings above for possible errors. "
-            )
-
-        log.warning(
-            "Trying to deserialize for the older format. This version of file is "
-            "deprecated. Please generate a new pt2 saved file."
+    if format is not None and format != "safetensors":
+        raise ValueError(f"Unsupported format: {format}")
+    if format == "safetensors":
+        raise NotImplementedError(
+            "Loading from safetensors format is not yet implemented. "
+            "Please use the default format (None or omitted) for now."
         )
 
-        # Check the version
-        version = zipf.read("version").decode().split(".")
-        from torch._export.serde.schema import (
-            SCHEMA_VERSION,  # todo change archive version to schema version
-        )
+    from .pt2_archive._package import load_pt2
 
-        if len(version) != len(SCHEMA_VERSION):
-            raise AssertionError(
-                "Version in the saved file has incorrect length, double check if the file is generated by torch.export.save()"
-            )
-        if version[0] != str(SCHEMA_VERSION[0]):
-            raise RuntimeError(
-                f"Serialized version {version} does not match our current "
-                f"schema version {SCHEMA_VERSION}."
-            )
-
-        from torch._export.serde.serialize import deserialize, SerializedArtifact
-
-        # Load serialized_ep and serialized_state_dict from the zip file
-
-        serialized_exported_program: bytes | None = None
-        serialized_state_dict: bytes | None = None
-        serialized_constants: bytes | None = None
-        serialized_example_inputs: bytes | None = None
-
-        for file_info in zipf.infolist():
-            file_content = zipf.read(file_info.filename)
-
-            if file_info.filename == "serialized_exported_program.json":
-                serialized_exported_program = file_content
-            elif file_info.filename == "serialized_state_dict.json":
-                warnings.warn("This version of file is deprecated", stacklevel=2)
-                serialized_state_dict = file_content
-            elif file_info.filename == "serialized_constants.json":
-                warnings.warn("This version of file is deprecated", stacklevel=2)
-                serialized_constants = file_content
-            elif file_info.filename == "serialized_state_dict.pt":
-                serialized_state_dict = file_content
-            elif file_info.filename == "serialized_constants.pt":
-                serialized_constants = file_content
-            elif file_info.filename == "serialized_example_inputs.pt":
-                serialized_example_inputs = file_content
-            elif file_info.filename.startswith("extra_files"):
-                filename = file_info.filename.split("/", 1)[1]
-                extra_files[filename] = file_content.decode("utf-8")
-
-        if serialized_exported_program is None:
-            raise AssertionError("serialized_exported_program is None")
-        if serialized_state_dict is None:
-            raise AssertionError("serialized_state_dict is None")
-        if serialized_constants is None:
-            raise AssertionError("serialized_constants is None")
-        if serialized_example_inputs is None:
-            raise AssertionError("serialized_example_inputs is None")
-        artifact: SerializedArtifact = SerializedArtifact(
-            serialized_exported_program,
-            serialized_state_dict,
-            serialized_constants,
-            serialized_example_inputs,
-        )
-
-        # Deserialize ExportedProgram
-        ep = deserialize(artifact, expected_opset_version)
-
-        return ep
+    return load_pt2(
+        f,
+        expected_opset_version=expected_opset_version,
+        weights_only=weights_only,
+    )
 
 
 def draft_export(
@@ -568,4 +523,6 @@ def register_dataclass(
         print(ep)
 
     """
-    pytree.register_dataclass(cls, serialized_type_name=serialized_type_name)
+    from torch.utils._pytree import register_dataclass
+
+    register_dataclass(cls, serialized_type_name=serialized_type_name)

--- a/torch/export/__init__.py
+++ b/torch/export/__init__.py
@@ -3,7 +3,7 @@ import os
 import warnings
 import zipfile
 from collections.abc import Callable, Mapping
-from typing import Any, Optional
+from typing import Any
 from typing_extensions import deprecated
 
 import torch
@@ -35,13 +35,11 @@ __all__ = [
     "UnflattenedModule",
 ]
 
-
 # To make sure export specific custom ops are loaded
 import torch.export.custom_ops
 
-
 from ._state_dict_utils import _restore_state_dict
-from .decomp_utils import DecompTable
+from .decomp_utils import CustomDecompTable
 from .dynamic_shapes import AdditionalInputs, Constraint, Dim, dims, ShapesCollection
 from .exported_program import (
     default_decompositions,
@@ -63,8 +61,7 @@ def export(
     args: tuple[Any, ...],
     kwargs: Mapping[str, Any] | None = None,
     *,
-    # dynamic_shapes: _DynamicShapesInput | AdditionalInputs | ShapesCollection
-    dynamic_shapes: Any = None,
+    dynamic_shapes: dict[str, Any] | tuple[Any, ...] | list[Any] | None = None,
     strict: bool = False,
     preserve_module_call_signature: tuple[str, ...] = (),
     prefer_deferred_runtime_asserts_over_guards: bool = False,
@@ -99,9 +96,9 @@ def export(
     the error message will include suggested fixes to the specification that are needed
     to validate the assumptions. For example :func:`export` might suggest the
     following fix to the definition of a dynamic dimension ``dim0_x``, say appearing in the
-    shape associated with input ``x``, that was previously defined as ``Dim(\"dim0_x\")``::
+    shape associated with input ``x``, that was previously defined as ``Dim("dim0_x")``::
 
-        dim = Dim(\"dim0_x\", max=5)
+        dim = Dim("dim0_x", max=5)
 
     This example means the generated code requires dimension 0 of input ``x`` to be less
     than or equal to 5 to be valid. You can inspect the suggested fixes to dynamic dimension
@@ -115,7 +112,7 @@ def export(
 
         kwargs: Optional example keyword inputs.
 
-        dynamic_shares:
+        dynamic_shapes:
          An optional argument where the type should either be:
          1) a dict from argument names of ``f`` to their dynamic shape specifications,
          2) a tuple that specifies dynamic shape specifications for each input in original order.
@@ -129,52 +126,6 @@ def export(
          where the :func:`Dim` types correspond to dynamic dimensions, and static dimensions
          are denoted by None. Arguments that are dicts or tuples / lists of tensors are
          recursively specified by using mappings or sequences of contained specifications.
-
-         **ShapesSpec API.** ``dynamic_shapes`` may also be a
-         :class:`torch.fx.experimental.dynamic_spec.ShapesSpec` (or its
-         shorthand :class:`torch.fx.experimental.dynamic_spec.ParamsSpec`).
-         This is a newer unbacked unified API across compile, pre-compile,
-         export, etc., and is the recommended way to specify dynamic
-         shapes for export going forward. It is the same spec API exposed
-         via ``dynamic_shapes=`` in :func:`torch.compile`.
-
-         The keys of ``ParamsSpec`` are **parameter names of the callable
-         being traced** (for an ``nn.Module``, the parameters of
-         ``forward``); keyword and ``**kwargs`` arguments are addressed by
-         name too.
-
-         Key properties (see :mod:`torch.fx.experimental.dynamic_spec` for
-         full details):
-
-         * **Unbacked-only.** Dims / scalars marked dynamic become unbacked
-           SymInts (``u`` symbols) and are never specialized (including no
-           0/1 specialization).
-         * **Assumptions and derived expressions.** A dim can be an
-           expression over the spec's symbols (e.g. ``TensorSpec([B * 2,
-           ...])``), and you can pass relational ``assumptions`` between
-           symbols (e.g. ``[B % 2 == 0]``) that export validates.
-         * **No silent specialization.** The exported graph is guaranteed valid
-           for every assumption provided, otherwise export fails. (By
-           contrast, ``Dim.DYNAMIC`` / ``Dim.AUTO`` may silently specialize a
-           dynamic dim, yielding a graph that is not valid for all the inputs).
-
-         Example::
-
-            batch = ShapeVar(\"batch\", min=2, max=128)
-            ep = torch.export.export(
-                mod,
-                (torch.randn(8, 3), torch.randn(16, 3)),
-                dynamic_shapes=ShapesSpec(
-                    params=ParamsSpec(
-                        {
-                            \"x\": TensorSpec([batch, 3]),
-                            \"y\": TensorSpec([batch * 2, 3]),  # derived expression
-                        }
-                    ),
-                    assumptions=[batch % 2 == 0],
-                ),
-                strict=True,
-            )
 
         strict: When disabled (default), the export function will trace the program through
          Python runtime, which by itself will not validate some of the implicit assumptions
@@ -215,12 +166,6 @@ def export(
             "Maybe try converting your ScriptModule to an ExportedProgram "
             "using `TS2EPConverter(mod, args, kwargs).convert()` instead."
         )
-
-    # If ``mod.forward`` carries an ``@dynamic_spec(...)`` decorator, the
-    # attached ``ShapesSpec`` is used as ``dynamic_shapes``. Passing both raises.
-    from torch.fx.experimental.dynamic_spec import _resolve_dynamic_shapes
-
-    dynamic_shapes = _resolve_dynamic_shapes(mod, dynamic_shapes)
 
     try:
         return _export(
@@ -269,11 +214,11 @@ def save(
     *,
     extra_files: dict[str, Any] | None = None,
     opset_version: dict[str, int] | None = None,
-    pickle_protocol: int = DEFAULT_PICKLE_PROTOCOL,
+    pickle_protocol: int = 2,
     weights_only: bool = False,
-    format: Optional[str] = None,
+    format: str | None = None,
 ) -> None:
-    r"""
+    """
     .. warning::
         Under active development, saved files may not be usable in newer versions
         of PyTorch.
@@ -284,7 +229,7 @@ def save(
     Args:
         ep (ExportedProgram): The exported program to save.
 
-        f (str | os.PathLike[str] | IO[bytes]) A file-like object (has to
+        f (str | os.PathLike[str] | IO[bytes]): A file-like object (has to
          implement write and flush) or a string containing a file name.
 
         extra_files (Optional[Dict[str, Any]]): Map from filename to contents
@@ -295,27 +240,26 @@ def save(
 
         pickle_protocol: can be specified to override the default protocol
 
-        weights_only (bool, default=False): Whether to use `weights_only=True` when
-         loading the saved file with :func:`torch.export.load`. This flag is only
-         respected when loading the file (not when saving). Setting this to True
-         can improve security by preventing arbitrary code execution via pickle
-         during loading, but may fail if the saved file contains non-tensor objects
-         that require pickle to load.
+        weights_only: If True, use `torch.load(..., weights_only=True)` when
+         loading the saved file (only affects loading, not saving).
+         This is a security feature to prevent arbitrary code execution when
+         loading the model. Note that setting this to True may fail if the
+         archive contains non-tensor data (e.g., custom objects) that require
+         pickle to load.
 
-        format (Optional[str], default=None): The format to use for saving.
-         Currently only supports the default format (`.pt2`). Specifying
-         ``format='safetensors'`` is not yet implemented.
+        format: The format to use for saving. Currently only `None` (the default)
+         and `'safetensors'` are supported. If `None`, the standard `.pt2` format
+         is used. If `'safetensors'`, the model is saved in safetensors format.
+         Note: safetensors support is not yet implemented and will raise an error.
 
     Example::
 
         import torch
         import io
 
-
         class MyModule(torch.nn.Module):
             def forward(self, x):
                 return x + 10
-
 
         ep = torch.export.export(MyModule(), (torch.randn(5),))
 
@@ -336,15 +280,10 @@ def save(
             f"The 'ep' parameter must be an instance of 'ExportedProgram', got '{type(ep).__name__}' instead."
         )
 
-    if format is not None and format != "safetensors":
-        raise ValueError(f"Unsupported format: {format}")
-    if format == "safetensors":
-        raise NotImplementedError(
-            "Saving in safetensors format is not yet implemented. "
-            "Please use the default format (None or omitted) for now."
-        )
+    if format is not None and format != "pt2":
+        raise ValueError(f"Unsupported format: {format}. Only 'pt2' is currently supported.")
 
-    from .pt2_archive._package import package_pt2
+    from torch.export.pt2_archive._package import package_pt2
 
     package_pt2(
         f,
@@ -353,17 +292,15 @@ def save(
         pickle_protocol=pickle_protocol,
         opset_version=opset_version,
     )
-
-
 def load(
     f: FileLike,
     *,
     extra_files: dict[str, Any] | None = None,
     expected_opset_version: dict[str, int] | None = None,
     weights_only: bool = False,
-    format: Optional[str] = None,
+    format: str | None = None,
 ) -> ExportedProgram:
-    r"""
+    """
     .. warning::
         Under active development, saved files may not be usable in newer versions
         of PyTorch.
@@ -372,7 +309,7 @@ def load(
         :func:`torch.export.load()` uses pickle under the hood to load models. **Never load data from an untrusted source.**
 
     Loads an :class:`ExportedProgram` previously saved with
-    :func:`torch.export.save <torch.export.save>`.
+    :func:`torch.export.save <torch.export.load>`.
 
     Args:
         f (str | os.PathLike[str] | IO[bytes]): A file-like object (has to
@@ -385,16 +322,16 @@ def load(
         expected_opset_version (Optional[Dict[str, int]]): A map of opset names
          to expected opset versions
 
-        weights_only (bool, default=False): Whether to use `weights_only=True` when
-         loading the saved file. Setting this to True can improve security by
-         preventing arbitrary code execution via pickle during loading, but may
-         fail if the saved file contains non-tensor objects that require pickle
-         to load. If loading fails with ``weights_only=True``, you may need to
-         set ``weights_only=False`` to allow loading of non-tensor objects.
+        weights_only: If True, use `torch.load(..., weights_only=True)` when
+         loading the file (default: False). This is a security feature
+         to prevent arbitrary code execution when loading the model. Note that
+         setting this to True may fail if the archive contains non-tensor data
+         (e.g., custom objects) that require pickle to load.
 
-        format (Optional[str], default=None): The format of the file to load.
-         Currently only supports the default format (`.pt2`). Specifying
-         ``format='safetensors'`` is not yet implemented.
+        format: The format of the file to load. Currently only `None` (the default)
+         and `'safetensors'` are supported. If `None`, the standard `.pt2` format
+         is assumed. If `'safetensors'`, the file is expected to be in safetensors format.
+         Note: safetensors support is not yet implemented and will raise an error.
 
     Returns:
         An :class:`ExportedProgram` object
@@ -420,28 +357,31 @@ def load(
         print(ep(torch.randn(5)))
 
     """
-    if isinstance(f, (str, os.PathLike)):
-        f = os.fspath(f)
+    if format is not None and format != "pt2":
+        raise ValueError(f"Unsupported format: {format}. Only 'pt2' is currently supported.")
 
-    extra_files = extra_files or {}
+    from torch.export.pt2_archive._package import load_pt2
 
-    if format is not None and format != "safetensors":
-        raise ValueError(f"Unsupported format: {format}")
-    if format == "safetensors":
-        raise NotImplementedError(
-            "Loading from safetensors format is not yet implemented. "
-            "Please use the default format (None or omitted) for now."
+    try:
+        return load_pt2(
+            f,
+            extra_files=extra_files,
+            expected_opset_version=expected_opset_version,
+            weights_only=weights_only,
         )
+    except RuntimeError:
+        # Backward compatibility for the zip file format
+        if isinstance(f, (str, os.PathLike)):
+            f = os.fspath(f)
 
-    from .pt2_archive._package import load_pt2
+        extra_files = {} if extra_files is None else extra_files
 
-    return load_pt2(
-        f,
-        expected_opset_version=expected_opset_version,
-        weights_only=weights_only,
-    )
-
-
+        if isinstance(f, (str, os.PathLike)):
+            with open(f, "rb") as f:
+                return _load_legacy_zip(f, extra_files, expected_opset_version, weights_only)
+        else:
+            # Assume it's a file-like object
+            return _load_legacy_zip(f, extra_files, expected_opset_version, weights_only)
 def draft_export(
     mod: torch.nn.Module,
     args: tuple[Any, ...],
@@ -457,15 +397,7 @@ def draft_export(
     an ExportedProgram, even if there are potential soundness issues, and to
     generate a report listing the issues found.
     """
-    from torch.fx.experimental.dynamic_spec import ParamsSpec, ShapesSpec
-
     from ._draft_export import draft_export
-
-    if isinstance(dynamic_shapes, (ShapesSpec, ParamsSpec)):
-        raise NotImplementedError(
-            f"draft_export does not support the new dynamic shapes API "
-            f"({type(dynamic_shapes).__name__}); use torch.export.export instead."
-        )
 
     return draft_export(
         mod=mod,
@@ -523,6 +455,4 @@ def register_dataclass(
         print(ep)
 
     """
-    from torch.utils._pytree import register_dataclass
-
-    register_dataclass(cls, serialized_type_name=serialized_type_name)
+    pytree.register_dataclass(cls, serialized_type_name=serialized_type_name)

--- a/torch/export/pt2_archive/_package.py
+++ b/torch/export/pt2_archive/_package.py
@@ -7,7 +7,7 @@ import pickle
 import tempfile
 import zipfile
 from dataclasses import dataclass
-from typing import Any, IO, Optional, TYPE_CHECKING, TypeAlias
+from typing import Any, IO, TYPE_CHECKING, TypeAlias
 from typing_extensions import TypeIs
 
 import torch
@@ -864,7 +864,6 @@ def _load_payload_config(
 def _load_state_dict(
     archive_reader: PT2ArchiveReader,
     model_name: str,
-    weights_only: bool = False,
 ) -> dict[str, torch.Tensor] | bytes:
     # Make it BC compatible with legacy weight files
     legacy_weights_file = f"{WEIGHTS_DIR}{model_name}.pt"
@@ -892,7 +891,7 @@ def _load_state_dict(
                     os.path.join(WEIGHTS_DIR, payload_meta.path_name)
                 )
                 state_dict[weight_fqn] = torch.load(
-                    io.BytesIO(weight_bytes), weights_only=weights_only
+                    io.BytesIO(weight_bytes), weights_only=False
                 )
             else:
                 tensor_meta = payload_meta.tensor_meta
@@ -921,7 +920,6 @@ def _load_state_dict(
 def _load_constants(
     archive_reader: PT2ArchiveReader,
     model_name: str,
-    weights_only: bool = False,
 ) -> dict[str, torch.Tensor] | bytes:
     # Make it BC compatible with legacy constant files
     legacy_constants_file = f"{CONSTANTS_DIR}{model_name}.pt"
@@ -951,7 +949,7 @@ def _load_constants(
                         os.path.join(CONSTANTS_DIR, path_name)
                     )
                     constants[constant_fqn] = torch.load(
-                        io.BytesIO(constant_bytes), weights_only=weights_only
+                        io.BytesIO(constant_bytes), weights_only=False
                     )
                 else:
                     tensor_meta = payload_meta.tensor_meta
@@ -991,6 +989,7 @@ def _load_exported_programs(
     archive_reader: PT2ArchiveReader,
     file_names: list[str],
     expected_opset_version: dict[str, int] | None,
+    weights_only: bool | None = None,
 ) -> dict[str, ExportedProgram]:
     exported_program_files = [
         file for file in file_names if file.startswith(MODELS_DIR)
@@ -1052,16 +1051,6 @@ def _load_aoti(
         file, model_name
     )
 
-    aoti_compiled_model = AOTICompiledModel(
-        torch._C._aoti.AOTIModelPackageLoader(
-            file,
-            model_name,
-            run_single_threaded,
-            num_runners,
-            device_idx,
-        )
-    )
-
     device = loaded_metadata["AOTI_DEVICE_KEY"]
     from torch._inductor.codecache import get_device_information
 
@@ -1078,19 +1067,29 @@ def _load_aoti(
                     loaded_metadata[k],
                 )
 
+    aoti_compiled_model = AOTICompiledModel(
+        torch._C._aoti.AOTIModelPackageLoader(
+            file,
+            model_name,
+            run_single_threaded,
+            num_runners,
+            device_idx,
+        )
+    )
+
     return aoti_compiled_model
 
 
 def load_pt2(
     f: FileLike,
     *,
+    extra_files: dict[str, Any] | None = None,
     expected_opset_version: dict[str, int] | None = None,
+    weights_only: bool = False,
     run_single_threaded: bool = False,
     num_runners: int = 1,
     device_index: int = -1,
     load_weights_from_disk: bool = False,
-    weights_only: bool = False,
-    format: Optional[str] = None,
 ) -> PT2ArchiveContents:  # type: ignore[type-arg]
     """
     Loads all the artifacts previously saved with ``package_pt2``.
@@ -1099,8 +1098,17 @@ def load_pt2(
         f (str | os.PathLike[str] | IO[bytes]): A file-like object (has to
          implement write and flush) or a string containing a file name.
 
+        extra_files (Optional[Dict[str, Any]]): A dictionary to be updated with
+         the extra files from the archive.
+
         expected_opset_version (Optional[Dict[str, int]]): A map of opset names
          to expected opset versions
+
+        weights_only: If True, use `torch.load(..., weights_only=True)` when
+         loading the file (default: False). This is a security feature
+         to prevent arbitrary code execution when loading the model. Note that
+         setting this to True may fail if the archive contains non-tensor data
+         (e.g., custom objects) that require pickle to load.
 
         num_runners (int): Number of runners to load AOTInductor artifacts
 
@@ -1116,7 +1124,6 @@ def load_pt2(
     Returns:
         A ``PT2ArchiveContents`` object which contains all the objects in the PT2.
     """
-
     from torch._inductor.cpp_builder import normalize_path_separator
 
     if not (
@@ -1126,7 +1133,7 @@ def load_pt2(
         # TODO: turn this into an error in 2.9
         logger.warning(
             "Unable to load package. f must be a buffer or a file ending in "
-            ".pt2. Instead got {%s}",
+            ".pt2. Instead got %s",
             f,
         )
 
@@ -1141,7 +1148,7 @@ def load_pt2(
         if version != ARCHIVE_VERSION_VALUE:
             raise ValueError(
                 f"Saved archive version {version} does not match our current "
-                f"archive version {ARCHIVE_VERSION_VALUE}."
+                f"archive version {ARCHIVE_VALUE_VALUE}."
             )
 
         file_names = archive_reader.get_file_names()
@@ -1149,7 +1156,13 @@ def load_pt2(
         exported_programs = _load_exported_programs(
             archive_reader, file_names, expected_opset_version
         )
-        extra_files = _load_extra_files(archive_reader, file_names)
+        extra_files_from_archive = _load_extra_files(archive_reader, file_names)
+
+        # If extra_files dictionary is provided, update it with the extra files from the archive
+        if extra_files is not None:
+            extra_files.update(extra_files_from_archive)
+        else:
+            extra_files = extra_files_from_archive
 
         # Get a list of AOTI model names
         aoti_model_names: set[str] = set()
@@ -1169,11 +1182,9 @@ def load_pt2(
                     weight_map = json.loads(archive_reader.read_string(file))
                     weight_maps[model_name] = weight_map
             elif load_weights_from_disk and file.startswith(WEIGHTS_DIR):
-                weight_file_name = file[
-                    len(WEIGHTS_DIR) :
-                ]  # remove data/weights/ prefix
+                weight_file_name = file[len(WEIGHTS_DIR):]
                 weight_bytes = archive_reader.read_bytes(file)
-                loaded_weight = torch.load(io.BytesIO(weight_bytes))
+                loaded_weight = torch.load(io.BytesIO(weight_bytes), weights_only=weights_only)
                 weights[weight_file_name] = loaded_weight
 
     if isinstance(f, (io.IOBase, IO)):
@@ -1224,10 +1235,7 @@ def load_pt2(
             aoti_runners[model_name].load_constants(
                 model_weights, check_full_update=True, user_managed=True
             )
-
     return PT2ArchiveContents(exported_programs, aoti_runners, extra_files)
-
-
 def load_weights_to_pt2_contents(
     pt2_contents: PT2ArchiveContents, weights_map: dict[str, Any]
 ) -> None:

--- a/torch/export/pt2_archive/_package.py
+++ b/torch/export/pt2_archive/_package.py
@@ -7,7 +7,7 @@ import pickle
 import tempfile
 import zipfile
 from dataclasses import dataclass
-from typing import Any, IO, TYPE_CHECKING, TypeAlias
+from typing import Any, IO, Optional, TYPE_CHECKING, TypeAlias
 from typing_extensions import TypeIs
 
 import torch
@@ -864,6 +864,7 @@ def _load_payload_config(
 def _load_state_dict(
     archive_reader: PT2ArchiveReader,
     model_name: str,
+    weights_only: bool = False,
 ) -> dict[str, torch.Tensor] | bytes:
     # Make it BC compatible with legacy weight files
     legacy_weights_file = f"{WEIGHTS_DIR}{model_name}.pt"
@@ -891,7 +892,7 @@ def _load_state_dict(
                     os.path.join(WEIGHTS_DIR, payload_meta.path_name)
                 )
                 state_dict[weight_fqn] = torch.load(
-                    io.BytesIO(weight_bytes), weights_only=False
+                    io.BytesIO(weight_bytes), weights_only=weights_only
                 )
             else:
                 tensor_meta = payload_meta.tensor_meta
@@ -920,6 +921,7 @@ def _load_state_dict(
 def _load_constants(
     archive_reader: PT2ArchiveReader,
     model_name: str,
+    weights_only: bool = False,
 ) -> dict[str, torch.Tensor] | bytes:
     # Make it BC compatible with legacy constant files
     legacy_constants_file = f"{CONSTANTS_DIR}{model_name}.pt"
@@ -949,7 +951,7 @@ def _load_constants(
                         os.path.join(CONSTANTS_DIR, path_name)
                     )
                     constants[constant_fqn] = torch.load(
-                        io.BytesIO(constant_bytes), weights_only=False
+                        io.BytesIO(constant_bytes), weights_only=weights_only
                     )
                 else:
                     tensor_meta = payload_meta.tensor_meta
@@ -1087,6 +1089,8 @@ def load_pt2(
     num_runners: int = 1,
     device_index: int = -1,
     load_weights_from_disk: bool = False,
+    weights_only: bool = False,
+    format: Optional[str] = None,
 ) -> PT2ArchiveContents:  # type: ignore[type-arg]
     """
     Loads all the artifacts previously saved with ``package_pt2``.


### PR DESCRIPTION
Updated docstrings for torch.distributed.all_reduce and torch.distributed.nn.all_reduce to clarify gradient behavior, addressing issue #121587.