### PR TITLE
[inductor] Fix IndexError for 0-D tensors in _other_is_broadcasted_in_dim

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -2198,6 +2198,12 @@ class TestPatternMatcher(TestCase):
         inv_scale = 1 / scale
         self.common(mul_softmax, (x, scale), 1, 3)
         self.common(mul_softmax, (scale, x), 1, 3)
+
+        # 0-D tensor case (regression for #190418)
+        x_0d = torch.randn(())
+        scale_0d = 1e6
+        self.common(mul_softmax, (x_0d, scale_0d), 1, 3)
+        self.common(mul_softmax, (scale_0d, x_0d), 1, 3)
         self.common(div_softmax, (x, inv_scale), 1, 3)
 
         # Test matching with type promotion

--- a/torch/_inductor/fx_passes/joint_graph.py
+++ b/torch/_inductor/fx_passes/joint_graph.py
@@ -1067,6 +1067,8 @@ def _other_is_broadcasted_in_dim(match):
     # Pad other_shape to the same ndim as inp
     other_shape = [1] * (inp_ndim - len(other_shape)) + list(other_shape)
 
+    # A scalar `other` is trivially constant across any reduction dim, 
+    # so the numerically-stable rewrite is valid.
     if len(other_shape) == 0:
         return True
 

--- a/torch/_inductor/fx_passes/joint_graph.py
+++ b/torch/_inductor/fx_passes/joint_graph.py
@@ -1067,7 +1067,7 @@ def _other_is_broadcasted_in_dim(match):
     # Pad other_shape to the same ndim as inp
     other_shape = [1] * (inp_ndim - len(other_shape)) + list(other_shape)
 
-    # A scalar `other` is trivially constant across any reduction dim, 
+    # A scalar `other` is trivially constant across any reduction dim,
     # so the numerically-stable rewrite is valid.
     if len(other_shape) == 0:
         return True

--- a/torch/_inductor/fx_passes/joint_graph.py
+++ b/torch/_inductor/fx_passes/joint_graph.py
@@ -1067,11 +1067,14 @@ def _other_is_broadcasted_in_dim(match):
     # Pad other_shape to the same ndim as inp
     other_shape = [1] * (inp_ndim - len(other_shape)) + list(other_shape)
 
+    if len(other_shape) == 0:
+        return True
+
     dim = match.kwargs["dim"]
     if isinstance(dim, int):
         dim = (dim,)
 
-    if any(d >= len(other_shape) for d in dim):
+    if any(d >= len(other_shape) or d < -len(other_shape) for d in dim):
         return False
 
     return all(statically_known_true(other_shape[d] == 1) for d in dim)


### PR DESCRIPTION
Fixes #190418

### Description
In `torch/_inductor/fx_passes/joint_graph.py`, evaluating `mul_softmax_pattern` on 0-dimensional tensors (scalars) crashes with `IndexError: list index out of range` in `_other_is_broadcasted_in_dim`.

When `inp.ndim == 0`, `other_shape` is correctly padded down to an empty list `[]`. However, PyTorch still allows negative reduction dimensions (like `dim=-1`) on scalars. The bounds checking previously only checked `d >= len(other_shape)`, completely missing negative out-of-bounds indices, which caused the list comprehension to evaluate `other_shape[-1]` on an empty list.

This PR adds an early return for 0-D tensors (since scalars are inherently broadcasted over any reduction operation) and hardens the dimension boundary check to include `d < -len(other_shape)` to prevent any future negative indexing crashes.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo