### PR TITLE
[distributed][docs] Fix undefined ProcessGroupOptions type in docstrings

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -2195,7 +2195,7 @@ def init_process_group(
             When TORCH_NCCL_BLOCKING_WAIT is set, the process will block and wait for this timeout.
 
         group_name (str, optional, deprecated): Group name. This argument is ignored
-        pg_options (ProcessGroupOptions, optional): process group options
+        pg_options (Backend.Options, optional): process group options
             specifying what additional options need to be passed in during
             the construction of specific process groups. As of now, the only
             options we support is ``ProcessGroupNCCL.Options`` for the ``nccl``
@@ -6011,7 +6011,7 @@ def split_group(
             list determines the group rank in the new group. All ranks must pass
             the same ordering.
         timeout (timedelta, optional): see `init_process_group` for details and default value.
-        pg_options (ProcessGroupOptions, optional): Additional options need to be passed in during
+        pg_options (Backend.Options, optional): Additional options need to be passed in during
             the construction of specific process groups. i.e.``is_high_priority_stream``
             can be specified so that process group can pick up high priority cuda streams.
         group_desc (str, optional): a string to describe the process group.
@@ -6262,7 +6262,7 @@ def new_group(
             ``Backend.GLOO``). If ``None`` is passed in, the backend
             corresponding to the default process group will be used. Default is
             ``None``.
-        pg_options (ProcessGroupOptions, optional): process group options
+        pg_options (Backend.Options, optional): process group options
             specifying what additional options need to be passed in during
             the construction of specific process groups. i.e. for the ``nccl``
             backend, ``is_high_priority_stream`` can be specified so that
@@ -6655,7 +6655,7 @@ def new_subgroups(
             ``Backend.GLOO``). If ``None`` is passed in, the backend
             corresponding to the default process group will be used. Default is
             ``None``.
-        pg_options (ProcessGroupOptions, optional): process group options
+        pg_options (Backend.Options, optional): process group options
             specifying what additional options need to be passed in during
             the construction of specific process groups. i.e. for the ``nccl``
             backend, ``is_high_priority_stream`` can be specified so that
@@ -6749,7 +6749,7 @@ def new_subgroups_by_enumeration(
              ``Backend.GLOO``). If ``None`` is passed in, the backend
              corresponding to the default process group will be used. Default is
              ``None``.
-        pg_options (ProcessGroupOptions, optional): process group options
+        pg_options (Backend.Options, optional): process group options
             specifying what additional options need to be passed in during
             the construction of specific process groups. i.e. for the ``nccl``
             backend, ``is_high_priority_stream`` can be specified so that
@@ -6893,7 +6893,7 @@ def shrink_group(
             ``SHRINK_ABORT`` will attempt to terminate ongoing operations
             in the parent communicator before shrinking.
             Defaults to ``SHRINK_DEFAULT``.
-        pg_options (ProcessGroupOptions, optional): Backend-specific options to apply
+        pg_options (Backend.Options, optional): Backend-specific options to apply
             to the shrunken process group. If provided, the backend will use
             these options when creating the new group. If omitted, the new group
             inherits defaults from the parent.


### PR DESCRIPTION
Fixes #130958.

## Summary

The `pg_options` parameter docstrings across `init_process_group`, `split_group`, `new_group`, `new_subgroups`, `new_subgroups_by_enumeration`, and `shrink_group` all describe its type as `ProcessGroupOptions`. That type has never existed anywhere in the codebase. The actual base type is `Backend.Options`, defined in `torch/csrc/distributed/c10d/Backend.hpp` and exposed via the pybind stub as `torch._C._distributed_c10d.Backend.Options` (see `torch/_C/_distributed_c10d.pyi`), which `ProcessGroupNCCL.Options`, `ProcessGroupGloo.Options`, etc. all subclass. `Backend.Options` is already the reference used for this exact type elsewhere in the codebase (`device_mesh.py`'s `C10dBackend.Options`, and the `opts: Backend.Options | None` parameter on `ProcessGroup.split_group` in the same `.pyi`).

This replaces all six occurrences of `ProcessGroupOptions` with `Backend.Options`.

## Disclosure

This change was prepared with the help of an AI assistant, which located the six affected docstrings, verified against `torch/_C/_distributed_c10d.pyi` that `Backend.Options` is the correct underlying type, and checked that `Backend.Options` isn't itself an attribute of the Python-level `Backend(str)` enum in `distributed_c10d.py` (a distinct class from the C++ `Backend`, imported elsewhere in this same file under the alias `C10DBackend` specifically to avoid that collision) so as not to swap one broken reference for another.

## Test Plan

Documentation-only change (docstring text), no functional code path is affected. Verified via a sparse checkout of `torch/distributed` and `torch/_C` that:
- No remaining occurrences of `ProcessGroupOptions` exist in `torch/distributed/distributed_c10d.py`.
- `Backend.Options` is defined at `torch/_C/_distributed_c10d.pyi:389`, nested under `class Backend:`, and `ProcessGroupNCCL.Options`/`ProcessGroupGloo.Options` both declare `class Options(Backend.Options)`.
- The replacement matches the existing convention used for this type elsewhere in the tree.

A full `pip install -e . -v --no-build-isolation` build was not run, since this change only touches docstring text with no build-time or runtime code path affected.
