### PR TITLE
[Dynamo] Only infer input device and dtype from tensors

### DIFF
--- a/test/dynamo/test_backends.py
+++ b/test/dynamo/test_backends.py
@@ -449,6 +449,19 @@ class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
         opt_f(torch.randn(3, 3))
         self.assertTrue(backend_run)
 
+    def test_device_and_dtype_from_inputs(self):
+        from torch._dynamo.backends.common import device_from_inputs, dtype_from_inputs
+
+        class NotATensor:
+            device = "not-a-device"
+            dtype = "not-a-dtype"
+
+        tensor = torch.randn(3, dtype=torch.float64)
+        self.assertEqual(device_from_inputs([NotATensor(), tensor]), tensor.device)
+        self.assertEqual(dtype_from_inputs([NotATensor(), tensor]), torch.float64)
+        self.assertEqual(device_from_inputs([NotATensor()]), torch.device("cpu"))
+        self.assertEqual(dtype_from_inputs([NotATensor()]), torch.float32)
+
     def test_lookup_backend_suggestion(self):
         from torch._dynamo.backends.registry import lookup_backend
         from torch._dynamo.exc import InvalidBackend

--- a/torch/_dynamo/backends/common.py
+++ b/torch/_dynamo/backends/common.py
@@ -204,13 +204,13 @@ def fake_tensor_unsupported(fn: Callable[[Any, list[Any], Any], R]) -> Any:
 
 def device_from_inputs(example_inputs: Iterable[Any]) -> torch.device:
     for x in example_inputs:
-        if hasattr(x, "device"):
+        if isinstance(x, torch.Tensor):
             return x.device
     return torch.device("cpu")  # Default fallback
 
 
 def dtype_from_inputs(example_inputs: Iterable[Any]) -> torch.dtype:
     for x in example_inputs:
-        if hasattr(x, "dtype"):
+        if isinstance(x, torch.Tensor):
             return x.dtype
     return torch.float32  # Default fallback


### PR DESCRIPTION
## Why

`device_from_inputs` / `dtype_from_inputs` return the first input that has a `.device` / `.dtype` attribute, so any non-tensor object carrying such an attribute wins over an actual tensor, and the returned value need not even be a `torch.device` / `torch.dtype`. The current behavior is only correct because `SymInt` happens to lack these attributes.

## How

- Match `isinstance(x, torch.Tensor)` instead of probing with `hasattr`
- Pin the behavior with a test covering non-tensor inputs and the empty-input fallback

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98