### PR TITLE
[Dynamo] Use isinstance checks in _is_registered_backend

### DIFF
--- a/test/dynamo/test_backends.py
+++ b/test/dynamo/test_backends.py
@@ -507,6 +507,34 @@ class TestCustomBackendAPI(torch._dynamo.test_case.TestCase):
         self.assertEqual(device_from_inputs([NotATensor()]), torch.device("cpu"))
         self.assertEqual(dtype_from_inputs([NotATensor()]), torch.float32)
 
+    def test_is_registered_backend(self):
+        from torch._dynamo.backends.registry import _is_registered_backend
+
+        self.assertTrue(_is_registered_backend(lookup_backend("eager")))
+        self.assertTrue(
+            _is_registered_backend(torch._TorchCompileInductorWrapper(None, None, None))
+        )
+        self.assertTrue(
+            _is_registered_backend(
+                torch._TorchCompileWrapper("eager", None, None, None)
+            )
+        )
+
+        class FakeBackend:
+            compiler_name = "inductor"
+
+        self.assertFalse(_is_registered_backend(FakeBackend()))
+
+        def my_custom_backend(gm, example_inputs):
+            return gm.forward
+
+        self.assertFalse(_is_registered_backend(my_custom_backend))
+        self.assertFalse(
+            _is_registered_backend(
+                torch._TorchCompileWrapper(my_custom_backend, None, None, None)
+            )
+        )
+
     def test_lookup_backend_suggestion(self):
         from torch._dynamo.backends.registry import lookup_backend
         from torch._dynamo.exc import InvalidBackend

--- a/torch/_dynamo/backends/registry.py
+++ b/torch/_dynamo/backends/registry.py
@@ -200,15 +200,11 @@ def _is_registered_backend(compiler_fn: CompilerFn) -> bool:
     if compiler_fn in _COMPILER_FNS.values():
         return True
 
-    # Check for _TorchCompileInductorWrapper or _TorchCompileWrapper
-    # These have a compiler_name attribute that identifies the backend
-    if hasattr(compiler_fn, "compiler_name"):
-        compiler_name = compiler_fn.compiler_name
-        if compiler_name in _BACKENDS or compiler_name in _COMPILER_FNS:
-            return True
+    if isinstance(compiler_fn, torch._TorchCompileInductorWrapper):
+        return True
 
-    # Check if the wrapper has a compiler_fn attribute (e.g., _TorchCompileWrapper)
-    if hasattr(compiler_fn, "compiler_fn"):
+    # _TorchCompileWrapper wraps either a registered backend or a custom callable
+    if isinstance(compiler_fn, torch._TorchCompileWrapper):
         return compiler_fn.compiler_fn in _COMPILER_FNS.values()
 
     return False


### PR DESCRIPTION
## Why

`_is_registered_backend` treats any object whose `compiler_name` attribute names a registered backend as registered, so a custom backend that merely carries `compiler_name = "inductor"` (or a user callable named after a registered backend, once wrapped by `_TorchCompileWrapper`) is misclassified as registered.

## How

- Replace the `hasattr` probes with `isinstance` checks against `_TorchCompileInductorWrapper` / `_TorchCompileWrapper`, resolving the wrapped `compiler_fn` by identity against the registry
- Add a test covering registered backends, both wrappers, an impostor object, and a custom callable

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98