### PR TITLE
[Dynamo] Support tracing dist.reduce_scatter

### DIFF
--- a/test/distributed/tensor/test_compile_on_one_rank.py
+++ b/test/distributed/tensor/test_compile_on_one_rank.py
@@ -499,6 +499,28 @@ class TestCompileOnOneRankLegacyCollective(TestCase):
             Options(ops_filter=None, node_metadata_key_filter=_drop_distributed_meta),
         )
 
+    @staticmethod
+    def _rs_fn(t, mesh):
+        out = torch.empty_like(t)
+        group = mesh.get_group()
+        dist.reduce_scatter(out, [t, t + 1], op=dist.ReduceOp.MAX, group=group)
+        return out + 1
+
+    @dist_config.patch(compile_on_one_rank=True)
+    def test_legacy_reduce_scatter_serializes_under_coor(self):
+        gm = make_fx(self._rs_fn, tracing_mode="fake")(torch.arange(4.0), self.mesh)
+        targets = _call_targets(gm)
+
+        self.assertIn("_dtensor.mesh_get_process_group.default", targets)
+        self.assertIn("_c10d_functional.reduce_scatter_tensor.default", targets)
+        self.assertNotIn("c10d.reduce_scatter_.default", targets)
+        self.assertEqual(_baked_pg_constants(gm), [])
+
+        GraphPickler.dumps(
+            gm,
+            Options(ops_filter=None, node_metadata_key_filter=_drop_distributed_meta),
+        )
+
     def test_default_path_bakes_pg(self):
         # Without compile_on_one_rank the legacy in-place op is unchanged and bakes
         # the ProcessGroup as a torchbind constant (the gated-against behavior).

--- a/test/distributed/test_inductor_collectives.py
+++ b/test/distributed/test_inductor_collectives.py
@@ -699,6 +699,25 @@ class TestCollectivesMultiProc(DynamoDistributedMultiProcTestCase):
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @skip_if_lt_x_gpu(2)
+    def test_reduce_scatter_list_input(self):
+        def func(output, inputs):
+            torch.distributed.reduce_scatter(output, inputs)
+            return output
+
+        with _dynamo_dist_per_rank_init(self.rank, self.world_size):
+            inputs = [
+                torch.ones(4, 4, device=self.device) * (self.rank + i)
+                for i in range(self.world_size)
+            ]
+            output = torch.empty(4, 4, device=self.device)
+            correct = torch.empty(4, 4, device=self.device)
+            func_compiled = torch.compile(func, fullgraph=True)
+            func_compiled(output, inputs)
+            func(correct, inputs)
+            self.assertTrue(same(output, correct))
+
+    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+    @skip_if_lt_x_gpu(2)
     def test_allgather_contiguous_input(self):
         class Model(torch.nn.Module):
             def __init__(self, *args, **kwargs) -> None:

--- a/test/distributed/test_inductor_collectives.py
+++ b/test/distributed/test_inductor_collectives.py
@@ -1510,7 +1510,7 @@ class TestCollectivesInductor(DynamoDistributedSingleProcTestCase):
             raise AssertionError("Expected outputs to match correct_outputs")
 
     @skipIfXpu  # https://github.com/intel/torch-xpu-ops/issues/1581
-    def test_dynamo_rewrite_dist_reduce_scatter_list_uneven(self):
+    def test_dynamo_rewrite_dist_reduce_scatter_list_size_mismatch(self):
         def func(out, inp_list, *, pg):
             torch.distributed.reduce_scatter(
                 out,
@@ -1522,9 +1522,33 @@ class TestCollectivesInductor(DynamoDistributedSingleProcTestCase):
         outputs = torch.empty([4, 4], device=self.device)
         compiled = torch.compile(func, backend="eager", fullgraph=True)
         with self.assertRaisesRegex(
-            Exception, "Remapping variable size reduce_scatter is not yet supported"
+            Exception,
+            "reduce_scatter requires every input_list element to have the same size as output",
         ):
             compiled(outputs, inputs, pg=GroupMember.WORLD)
+
+    @skipIfXpu  # https://github.com/intel/torch-xpu-ops/issues/1581
+    def test_dynamo_rewrite_dist_reduce_scatter_list_scalar(self):
+        def func(out, inp_list, *, pg):
+            torch.distributed.reduce_scatter(
+                out,
+                inp_list,
+                group=pg,
+            )
+
+        inputs = [torch.ones([], device=self.device)]
+        outputs = torch.empty([], device=self.device)
+        correct_outputs = torch.empty([], device=self.device)
+        counter = CompileCounter()
+        compiled = torch.compile(func, backend=counter, fullgraph=True)
+        compiled(outputs, inputs, pg=GroupMember.WORLD)
+        func(correct_outputs, inputs, pg=GroupMember.WORLD)
+        if counter.frame_count != 1:
+            raise AssertionError(
+                f"Expected frame_count == 1, got {counter.frame_count}"
+            )
+        if not same(outputs, correct_outputs):
+            raise AssertionError("Expected outputs to match correct_outputs")
 
     @parametrize(
         "pg_mode",

--- a/test/distributed/test_inductor_collectives.py
+++ b/test/distributed/test_inductor_collectives.py
@@ -1465,6 +1465,48 @@ class TestCollectivesInductor(DynamoDistributedSingleProcTestCase):
         if not same(outputs, correct_outputs):
             raise AssertionError("Expected outputs to match correct_outputs")
 
+    @skipIfXpu  # https://github.com/intel/torch-xpu-ops/issues/1581
+    def test_dynamo_rewrite_dist_reduce_scatter_list(self):
+        def func(out, inp_list, *, pg):
+            torch.distributed.reduce_scatter(
+                out,
+                inp_list,
+                group=pg,
+            )
+
+        local_size = [4, 4]
+        # single-proc test
+        inputs = [torch.ones(local_size, device=self.device)]
+        outputs = torch.empty(local_size, device=self.device)
+        correct_outputs = torch.empty(local_size, device=self.device)
+        counter = CompileCounter()
+        compiled = torch.compile(func, backend=counter, fullgraph=True)
+        compiled(outputs, inputs, pg=GroupMember.WORLD)
+        func(correct_outputs, inputs, pg=GroupMember.WORLD)
+        if counter.frame_count != 1:
+            raise AssertionError(
+                f"Expected frame_count == 1, got {counter.frame_count}"
+            )
+        if not same(outputs, correct_outputs):
+            raise AssertionError("Expected outputs to match correct_outputs")
+
+    @skipIfXpu  # https://github.com/intel/torch-xpu-ops/issues/1581
+    def test_dynamo_rewrite_dist_reduce_scatter_list_uneven(self):
+        def func(out, inp_list, *, pg):
+            torch.distributed.reduce_scatter(
+                out,
+                inp_list,
+                group=pg,
+            )
+
+        inputs = [torch.ones([8, 4], device=self.device)]
+        outputs = torch.empty([4, 4], device=self.device)
+        compiled = torch.compile(func, backend="eager", fullgraph=True)
+        with self.assertRaisesRegex(
+            Exception, "Remapping variable size reduce_scatter is not yet supported"
+        ):
+            compiled(outputs, inputs, pg=GroupMember.WORLD)
+
     @parametrize(
         "pg_mode",
         [

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -2929,6 +2929,7 @@ class CollectiveFunctionRewriteVariable(UserFunctionVariable):
 
         if self.fn in (
             dist.all_reduce,
+            dist.reduce_scatter,
             dist.reduce_scatter_single,
             # pyrefly: ignore [deprecated]
             dist.reduce_scatter_tensor,

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -1831,7 +1831,7 @@ def reduce_scatter_inplace(
         )
     if not all(t.size() == output.size() for t in input_list):
         raise AssertionError(
-            "Remapping variable size reduce_scatter is not yet supported"
+            "reduce_scatter requires every input_list element to have the same size as output"
         )
 
     group = group or dist.group.WORLD

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -1821,7 +1821,7 @@ def reduce_scatter_inplace(
     output: torch.Tensor,
     input_list: list[torch.Tensor],
     op: str = "sum",
-    group=None,
+    group: dist.ProcessGroup | None = None,
     async_op: bool = False,
     tag: str = "",
 ):
@@ -1838,6 +1838,10 @@ def reduce_scatter_inplace(
     if group is None:
         raise AssertionError("group cannot be None")
 
+    if output.dim() == 0:
+        # scalars have no dim to scatter along; stack into 1-D then reshape back
+        result = reduce_scatter_single(torch.stack(input_list), op, 0, group, tag)
+        return output.copy_(result.reshape(output.shape))
     return output.copy_(reduce_scatter_single(torch.cat(input_list), op, 0, group, tag))
 
 

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -1817,6 +1817,30 @@ def all_gather_inplace(
     return tensor_list
 
 
+def reduce_scatter_inplace(
+    output: torch.Tensor,
+    input_list: list[torch.Tensor],
+    op: str = "sum",
+    group=None,
+    async_op: bool = False,
+    tag: str = "",
+):
+    if async_op:
+        raise AssertionError(
+            "Can't remap async version of inplace op to functional collective"
+        )
+    if not all(t.size() == output.size() for t in input_list):
+        raise AssertionError(
+            "Remapping variable size reduce_scatter is not yet supported"
+        )
+
+    group = group or dist.group.WORLD
+    if group is None:
+        raise AssertionError("group cannot be None")
+
+    return output.copy_(reduce_scatter_single(torch.cat(input_list), op, 0, group, tag))
+
+
 def isend_inplace(
     tensor: torch.Tensor,
     dst: int | None = None,
@@ -1918,6 +1942,7 @@ from torch.distributed.distributed_c10d import (  # pyrefly: ignore  # deprecate
     batch_isend_irecv as legacy_batch_p2p_ops,
     irecv as legacy_irecv,
     isend as legacy_isend,
+    reduce_scatter as legacy_reduce_scatter,
     reduce_scatter_single as legacy_reducescatter_single,
     reduce_scatter_tensor as legacy_reducescatter,
 )
@@ -1967,6 +1992,14 @@ def _remapped_all_gather(*args, **kwargs):
     all_gather_inplace(*args, **kwargs)
 
 
+def _remapped_reduce_scatter(*args, **kwargs):
+    if not _are_we_tracing():
+        raise AssertionError(
+            "_remapped_reduce_scatter should only be called during tracing"
+        )
+    reduce_scatter_inplace(*args, **kwargs)
+
+
 def _remapped_isend(*args, **kwargs):
     if not _are_we_tracing():
         raise AssertionError("_remapped_isend should only be called during tracing")
@@ -1997,6 +2030,7 @@ traceable_collective_remaps = {
     legacy_allreduce: _remapped_allreduce,
     legacy_all_to_all_single: _remapped_all_to_all_single,
     legacy_all_gather: _remapped_all_gather,
+    legacy_reduce_scatter: _remapped_reduce_scatter,
     legacy_reduce_scatter_base: _remapped_reducescatter,
     legacy_all_gather_base: _remapped_allgather,
     legacy_isend: _remapped_isend,

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -2063,6 +2063,7 @@ def _remap_traceable_collective(
     bound = dict(inspect.signature(func).bind(*args, **(kwargs or {})).arguments)
     if func in (
         torch.distributed.all_reduce,
+        torch.distributed.reduce_scatter,
         torch.distributed.reduce_scatter_single,
         torch.distributed.reduce_scatter_tensor,
         torch.distributed._reduce_scatter_base,


### PR DESCRIPTION
## Related Issue

Part of #151204

## Why

`dist.reduce_scatter` is missing from `traceable_collective_remaps`, so Dynamo inlines its eager implementation and fails on the pybind11 `ReduceScatterOptions()` constructor.

## How

- Remap it to a `reduce_scatter_inplace` wrapper (mirroring `all_gather_inplace`): inputs matching `output`'s shape lower to `funcol.reduce_scatter_single`; mismatched sizes raise, matching eager's own check
- Add tests for the equal-size, scalar, and size-mismatch paths

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @d4l3k @pragupta @Lucaskabela
