### PR TITLE
Remove stale Caffe2 references from docs

### DIFF
--- a/aten/src/ATen/core/op_registration/README.md
+++ b/aten/src/ATen/core/op_registration/README.md
@@ -1,4 +1,4 @@
-# Howto: Writing PyTorch & Caffe2 Operators
+# Howto: Writing PyTorch Operators
 
 So you want to write a new operator or a new kernel for an existing operator. How do you do that and what API should you use? So glad you asked.
 
@@ -224,33 +224,4 @@ This is useful to define the interface of an operator when you don't know a kern
 
 ## Calling custom operators
 
-### From PyTorch/JIT
-
 All registered operators are automatically available to PyTorch and JIT under `torch.ops.XXX`. If your operator was `my_namespace::my_op`, you can call it from python or JIT using `torch.ops.my_namespace.my_op(a, b)`.
-
-### From caffe2
-
-Custom operators are not available to the caffe2 frontend by default, but there's a simple macro you can add if you want to make it available. To expose a CPU kernel:
-
-```
-// Expose "my_namespace::my_op" custom operator to caffe2.
-// In caffe2, the operator will be called "MyCaffe2OperatorName".
-C10_EXPORT_C10_OP_TO_CAFFE2_CPU(
-    MyCaffe2OperatorName, "my_namespace::my_op")
-```
-
-And to expose a CUDA kernel:
-
-```
-C10_EXPORT_C10_OP_TO_CAFFE2_CUDA(
-    MyCaffe2OperatorName, "my_namespace::my_op")
-```
-
-Note that this doesn't autogenerate a caffe2 operator schema for you (yet). If there's need, we might consider adding that in future, but for now you have to write the caffe2 `OPERATOR_SCHEMA` macro manually if you need it.
-
-Also, there's some requirements on the operator schema for it to be callable from caffe2. Some of these restrictions are just because the functionality isn't implemented. If you have a use case that is blocked by them, please reach out to Sebastian Messmer.
-
-* There must be either one or more arguments of type `Tensor`, or one argument of type `Tensor[]`. You cannot have both `Tensor` and `Tensor[]`.
-* Except for `Tensor` or `Tensor[]`, only arguments of type `int`, `double` and `bool` are supported. These can be in any position in the argument list and will be read from the caffe2 operator arguments, based on the argument name in the operator schema.
-* We do not support lists (`int[]`, `double[]` or `bool[]`) or optionals (`int?`, `double?`, `bool?`) yet.
-* The operator must return a single `Tensor` or multiple tensors as in `(Tensor, Tensor, Tensor)`. It cannot return a list `Tensor[]`, optional `Tensor?` or any primitive types.

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/README.md
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/README.md
@@ -1,7 +1,7 @@
 # QNNPACK
 QNNPACK (Quantized Neural Networks PACKage) is a mobile-optimized library for low-precision high-performance neural network inference. QNNPACK provides implementation of common neural network operators on quantized 8-bit tensors.
 
-QNNPACK is not intended to be directly used by machine learning researchers; instead it provides low-level performance primitives for high-level deep learning frameworks. As of today, QNNPACK is integrated in [PyTorch 1.0](https://github.com/pytorch/pytorch) with Caffe2 graph representation.
+QNNPACK is not intended to be directly used by machine learning researchers; instead it provides low-level performance primitives for high-level deep learning frameworks. As of today, QNNPACK is integrated in [PyTorch](https://github.com/pytorch/pytorch).
 
 ## Operator Coverage
 
@@ -57,128 +57,6 @@ To cross-compile for iOS, clone [ios-cmake](https://github.com/leetal/ios-cmake)
 | arm64e       | `scripts/build-ios-arm64e.sh` | iPhone XS/XR              |
 | i386         | `scripts/build-ios-i386.sh`   | iPhone Simulator (32-bit) |
 | x86_64       | `scripts/build-ios-x86_64.sh` | iPhone Simulator (64-bit) |
-
-## End-to-End Benchmarking
-
-Caffe2 backend of PyTorch 1.0 natively integrates QNNPACK, and provides a [pre-trained quantized MobileNet v2 model](https://github.com/caffe2/models/tree/master/mobilenet_v2_quantized). Below are instructions for benchmarking this model end-to-end with QNNPACK.
-
-### Raspberry Pi 2 or 3
-
-```bash
-# Clone PyTorch 1.0 repo
-git clone --recursive https://github.com/pytorch/pytorch.git
-cd pytorch
-
-# Optional: update QNNPACK submodule to latest revision
-git submodule update --remote third_party/QNNPACK
-
-# Build Caffe2 (including binaries) for the host system
-# Use only 1 thread for build to avoid out-of-memory failures
-MAX_JOBS=1 scripts/build_local.sh -DBUILD_BINARY=ON -DBUILD_PYTHON=OFF \
-    -DUSE_OBSERVERS=OFF -DUSE_DISTRIBUTED=OFF
-
-# Download model weights
-wget https://s3.amazonaws.com/download.caffe2.ai/models/mobilenet_v2_1.0_224_quant/init_net.pb  # @lint-ignore
-
-# Download model graph
-wget https://s3.amazonaws.com/download.caffe2.ai/models/mobilenet_v2_1.0_224_quant/predict_net.pb  # @lint-ignore
-
-# Run speed benchmark with 50 warm-up iterations and 10 measurement iterations
-build/bin/speed_benchmark --net predict_net.pb --init_net init_net.pb \
-    --input data --input_dims 1,3,224,224 --input_type float \
-    --warmup 50 --iter 10
-```
-
-### ARMv7 (32-bit) Android
-
-```bash
-# Clone PyTorch 1.0 repo
-git clone --recursive https://github.com/pytorch/pytorch.git
-cd pytorch
-
-# Optional: update QNNPACK submodule to latest revision
-git submodule update --remote third_party/QNNPACK
-
-# Build Caffe2 (including binaries) for Android, and push to device
-scripts/build_android.sh -DANDROID_TOOLCHAIN=clang -DBUILD_BINARY=ON
-adb push build_android/bin/speed_benchmark /data/local/tmp/speed_benchmark
-
-# Download model weights and copy them to Android device
-wget https://s3.amazonaws.com/download.caffe2.ai/models/mobilenet_v2_1.0_224_quant/init_net.pb  # @lint-ignore
-adb push init_net.pb /data/local/tmp/init_net.pb
-
-# Download model graph and copy it to Android device
-wget https://s3.amazonaws.com/download.caffe2.ai/models/mobilenet_v2_1.0_224_quant/predict_net.pb  # @lint-ignore
-adb push predict_net.pb /data/local/tmp/predict_net.pb
-
-# Run speed benchmark with 50 warm-up iterations and 10 measurement iterations
-adb shell /data/local/tmp/speed_benchmark \
-    --net /data/local/tmp/predict_net.pb \
-    --init_net /data/local/tmp/init_net.pb \
-    --input data --input_dims 1,3,224,224 --input_type float \
-    --warmup 50 --iter 10
-```
-
-### ARM64 (64-bit) Android
-
-```bash
-# Clone PyTorch 1.0 repo
-git clone --recursive https://github.com/pytorch/pytorch.git
-cd pytorch
-
-# Optional: update QNNPACK submodule to latest revision
-git submodule update --remote third_party/QNNPACK
-
-# Build Caffe2 (including binaries) for Android, and push to device
-scripts/build_android.sh -DANDROID_ABI=arm64-v8a -DANDROID_TOOLCHAIN=clang -DBUILD_BINARY=ON
-adb push build_android/bin/speed_benchmark /data/local/tmp/speed_benchmark
-
-# Download model weights and copy them to Android device
-wget https://s3.amazonaws.com/download.caffe2.ai/models/mobilenet_v2_1.0_224_quant/init_net.pb  # @lint-ignore
-adb push init_net.pb /data/local/tmp/init_net.pb
-
-# Download model graph and copy it to Android device
-wget https://s3.amazonaws.com/download.caffe2.ai/models/mobilenet_v2_1.0_224_quant/predict_net.pb  # @lint-ignore
-adb push predict_net.pb /data/local/tmp/predict_net.pb
-
-# Run speed benchmark with 50 warm-up iterations and 10 measurement iterations
-adb shell /data/local/tmp/speed_benchmark \
-    --net /data/local/tmp/predict_net.pb \
-    --init_net /data/local/tmp/init_net.pb \
-    --input data --input_dims 1,3,224,224 --input_type float \
-    --warmup 50 --iter 10
-```
-
-### PEP (Performance Evaluation Platform) Method
-
-[Facebook AI Performance Evaluation Platform](https://github.com/facebook/FAI-PEP) is a framework and backend agnostic benchmarking platform to compare machine learning inferencing runtime metrics on a set of models and a variety of backends.
-
-We use PEP to produce the results we have in our [blog](https://code.fb.com/ml-applications/qnnpack/)
-
-With an ARMv7 device connected:
-
-```bash
-# Clone PyTorch 1.0 repo
-mkdir ~/Code && cd ~/Code
-git clone --recursive https://github.com/pytorch/pytorch.git
-cd pytorch
-
-# Optional: update QNNPACK submodule to latest revision
-git submodule update --remote third_party/QNNPACK
-
-# Clone PEP repo
-cd ~/Code
-git clone --recursive https://github.com/facebook/FAI-PEP.git aibench
-cd aibench
-
-# Run PEP benchmark with cool specifications. Try changing that cmd with more specifications!
-# First time compile could take 20+ minutes
-./benchmarking/run_bench.py \
-  --platform android \
-  -b ~/Code/aibench/specifications/models/caffe2/mobilenet_v2/mobilenet_v2_quant.json \
-  --platform android --repo_dir ~/Code/pytorch \
-  --frameworks_dir ~/Code/aibench/specifications/frameworks --framework caffe2
-```
 
 ## Acknowledgements
 

--- a/docs/source/tensorboard.md
+++ b/docs/source/tensorboard.md
@@ -10,7 +10,7 @@ Before going further, more details on TensorBoard can be found at
 Once you've installed TensorBoard, these utilities let you log PyTorch models
 and metrics into a directory for visualization within the TensorBoard UI.
 Scalars, images, histograms, graphs, and embedding visualizations are all
-supported for PyTorch models and tensors as well as Caffe2 nets and blobs.
+supported for PyTorch models and tensors.
 
 The SummaryWriter class is your main entry to log data for consumption
 and visualization by TensorBoard. For example:


### PR DESCRIPTION
Remove documentation for functionality that no longer exists:

- qnnpack README: Caffe2 benchmarking instructions (removed Caffe2 backend, dead caffe2.ai and download.caffe2.ai links)
- op_registration README: the `C10_EXPORT_C10_OP_TO_CAFFE2_*` macros were removed from the codebase
- tensorboard docs: Caffe2 nets/blobs support was removed from `torch.utils.tensorboard`

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01