### PR TITLE
[distributed] fix destroy_process_group hang after partial split_group collectives

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -7486,6 +7486,41 @@ class ProcessGroupNCCLLargerScaleTest(MultiProcessTestCase):
         torch.cuda.synchronize()
         dist.destroy_process_group()
 
+    @requires_nccl_version((2, 18), "Need NCCL 2.18+ for ncclCommSplit")
+    @skip_if_lt_x_gpu(8)
+    def test_split_group_partial_then_2d_teardown(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/190396.
+        # destroy_process_group() used to hang when collectives were run on child
+        # groups created by a partial split_group followed by additional splits.
+        # Root cause: _hash_ranks_to_str used len(_world.pg_names) as the
+        # uniqueness suffix, which diverges across ranks when non-member ranks
+        # don't register a partial split's PG. Co-participants in the same NCCL
+        # communicator then computed different PG names, causing inconsistent
+        # teardown ordering and circular ncclCommFinalize waits.
+        store = c10d.FileStore(self.file_name, self.world_size)
+        device = torch.device(f"cuda:{self.rank}")
+        pg = self._create_process_group_nccl(store, self.opts(), device_id=device)
+
+        # Partial 5-rank group: ranks 5,6,7 are non-members.
+        partial = c10d.split_group(pg, [[0, 1, 2, 3, 4]])
+        if partial is not None:
+            dist.all_reduce(torch.ones(1, device=device), group=partial)
+
+        # 4 rank-pairs, all 8 ranks are members of one subgroup.
+        pairs = c10d.split_group(pg, [[0, 4], [1, 5], [2, 6], [3, 7]])
+        if pairs is not None:
+            dist.all_reduce(torch.ones(1, device=device), group=pairs)
+
+        # 2-D split, all 8 ranks are members of one subgroup.
+        half = c10d.split_group(pg, [[0, 1, 2, 3], [4, 5, 6, 7]])
+        if half is not None:
+            dist.all_reduce(torch.ones(1, device=device), group=half)
+
+        dist.barrier(pg)
+        torch.cuda.synchronize()
+        # This must not hang.
+        dist.destroy_process_group()
+
 
 if __name__ == "__main__":
     if torch.cuda._initialized:

--- a/test/distributed/test_fake_pg.py
+++ b/test/distributed/test_fake_pg.py
@@ -813,6 +813,68 @@ class TestFakePG(TestCase):
         self.assertIsNotNone(new_pg)
         self.assertEqual(new_pg.size(), 2)
 
+    @skipIfHpu
+    @unittest.skipIf(not HAS_ACCELERATOR, "No accelerator")
+    @parametrize("rank", [0, 1, 2, 3])
+    def test_split_group_consistent_naming_after_partial_split(self, rank):
+        # Regression test for https://github.com/pytorch/pytorch/issues/190396.
+        #
+        # _hash_ranks_to_str previously used len(_world.pg_names) as the
+        # uniqueness suffix. Non-member ranks of a partial split don't register
+        # the PG, so their counter stayed lower than member ranks. Subsequent
+        # splits then computed different names for the same communicator on
+        # different ranks, causing inconsistent teardown ordering and (for NCCL)
+        # circular ncclCommFinalize waits that deadlock destroy_process_group.
+        #
+        # The fix uses _world.group_count as the salt. _process_group_name now
+        # increments group_count on BOTH paths so it advances on every rank that
+        # reaches it, including non-members, keeping it collective-consistent.
+        # This test verifies group_count advances consistently even for non-member
+        # ranks and that PG names are computed from it correctly.
+        world_size = 4
+        store = FakeStore()
+        dist.init_process_group(
+            backend="fake",
+            rank=rank,
+            world_size=world_size,
+            store=store,
+            device_id=torch.device(device_type, 0),
+        )
+        import hashlib as _hashlib
+
+        from torch.distributed import distributed_c10d
+
+        # group_count starts at 1 (the default PG consumed count 0).
+        count_after_init = distributed_c10d._world.group_count
+
+        # Partial split: ranks 0,1,2 are members; rank 3 is not.
+        partial = dist.split_group(split_ranks=[[0, 1, 2]])
+
+        # group_count must advance on ALL ranks, including non-member rank 3,
+        # because _process_group_name is called before the member check.
+        self.assertEqual(distributed_c10d._world.group_count, count_after_init + 1)
+        if rank == 3:
+            self.assertNotIsInstance(partial, dist.ProcessGroup)
+        else:
+            self.assertIsInstance(partial, dist.ProcessGroup)
+
+        # Full split: all ranks are members.
+        full = dist.split_group(split_ranks=[[0, 2], [1, 3]])
+        self.assertEqual(distributed_c10d._world.group_count, count_after_init + 2)
+        self.assertIsInstance(full, dist.ProcessGroup)
+
+        # PG name must use count_after_init+1 as the group_count salt
+        # (the value at the time of the second split_group call, before it
+        # was incremented). Co-participants of [0,2] and [1,3] each compute
+        # the same name because group_count is consistent across all ranks.
+        pg_name = distributed_c10d._world.pg_names[full]
+        my_group = [0, 2] if rank in [0, 2] else [1, 3]
+        rank_join = "_".join(map(str, my_group))
+        expected = _hashlib.sha1(
+            f"{rank_join}_{count_after_init + 1}".encode(), usedforsecurity=False
+        ).hexdigest()
+        self.assertEqual(pg_name, expected)
+
 
 instantiate_parametrized_tests(TestFakePG)
 


### PR DESCRIPTION
## Summary

Fixes #190396.

`destroy_process_group()` hangs when collectives are run on child groups created by a partial `split_group` followed by additional splits. The bug surfaces with patterns like `abc` / `bac` (partial split first or second) but not `cba` (partial split last), and only when collectives have been run on the child groups.

**Root cause:** `_hash_ranks_to_str` uses `len(_world.pg_names)` as a uniqueness suffix when computing PG names inside `split_group`. This value is rank-local. After a partial split (e.g. `[[0,1,2,3,4]]` on an 8-rank world), the 5 member ranks register the new PG and advance the counter, while the 3 non-member ranks do not. Every subsequent split whose subgroups span both sets ends up with co-participants computing **different SHA1 names** for the same underlying communicator.

`destroy_process_group` sorts PGs by their hash name to decide teardown order. With inconsistent names, ranks disagree on that order, creating circular waits in `ncclCommFinalize` (which is collective within each communicator):

```
rank 4 → waiting on rank 5 (ncclCommFinalize for C_c_4567)
rank 5 → waiting on rank 1 (ncclCommFinalize for C_b_15)
rank 1 → waiting on rank 4 (ncclCommFinalize for C_a)
```

→ deadlock.

**Fix:** Add `_world.split_count`, a Python-level counter incremented at the start of every `split_group` call, before any rank-local divergence. Since `split_group` is collective (all ranks in the parent group must enter it), every rank increments the counter in lockstep regardless of whether it ends up as a group member. `_hash_ranks_to_str` and `_process_group_name` accept an optional `split_count` parameter; when provided it replaces `len(_world.pg_names)` as the uniqueness suffix, guaranteeing co-participants always compute identical names. This fix is **backend-agnostic** — it does not rely on any NCCL-specific method and corrects the naming inconsistency for all backends that support partial `split_group` calls. `_world.split_count` is reset to 0 alongside `group_count` in both `destroy_process_group` and `_abort_process_group`.

## Test plan

- [ ] End-to-end NCCL deadlock regression test on 8x GPU:

```bash
# previously hung — now completes on all 8 ranks
torchrun --standalone --nproc-per-node=8 repro.py --patterns abc
torchrun --standalone --nproc-per-node=8 repro.py --patterns bac

# was already clean, still clean
torchrun --standalone --nproc-per-node=8 repro.py --patterns cba
```

- [ ] Added `test_split_group_partial_then_2d_teardown` to `ProcessGroupNCCLLargerScaleTest` — covers the `abc` deadlock pattern end-to-end on NCCL.

- [ ] Added `test_split_group_consistent_naming_after_partial_split` to `TestFakePG` — verifies that `_world.split_count` advances for non-member ranks and that PG names are computed consistently for non-NCCL backends (no GPU required).

cc @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab