### PR TITLE
[c10d] Allow CPU device_id in init_process_group

### DIFF
--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -3419,6 +3419,41 @@ class CommTest(test_c10d_common.AbstractCommTest, MultiProcessTestCase):
         for root_rank in ranks:
             self._test_broadcast_coalesced(process_group, device, root_rank)
 
+    @requires_gloo()
+    def test_init_process_group_with_cpu_device_id(self):
+        # https://github.com/pytorch/pytorch/issues/160731
+        store = c10d.FileStore(self.file_name, self.world_size)
+        with self.assertRaisesRegex(ValueError, "must be a device with an index"):
+            c10d.init_process_group(
+                backend="gloo",
+                store=store,
+                rank=self.rank,
+                world_size=self.world_size,
+                device_id=torch.device("cpu"),
+            )
+        c10d.init_process_group(
+            backend="gloo",
+            store=store,
+            rank=self.rank,
+            world_size=self.world_size,
+            device_id=torch.device("cpu", 0),
+        )
+        default_pg = c10d.distributed_c10d._get_default_group()
+        self.assertEqual(default_pg.bound_device_id, torch.device("cpu", 0))
+        t = torch.ones(2)
+        c10d.all_reduce(t)
+        self.assertEqual(t, torch.full((2,), float(self.world_size)))
+        # A cpu-bound default pg must not break subgroup creation on
+        # non-member ranks (new_group used to call the NCCL-only
+        # perform_nocolor_split on gloo).
+        subgroup = c10d.new_group([0])
+        if self.rank == 0:
+            st = torch.ones(2)
+            c10d.all_reduce(st, group=subgroup)
+            self.assertEqual(st, torch.ones(2))
+        c10d.barrier()
+        c10d.destroy_process_group()
+
     @skip_if_lt_x_gpu(2)
     @requires_gloo()
     def test_gloo_warn_not_in_group(self):

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -2474,6 +2474,13 @@ def _get_split_source(pg: ProcessGroup):
     while is_gloo_available() and isinstance(split_from, _ProcessGroupWrapper):
         split_from = split_from.wrapped_pg
 
+    # Non-member ranks split via split_from.perform_nocolor_split(), which
+    # only NCCL-style backends implement; backends such as gloo advertise
+    # supports_splitting for split_group() but cannot serve as a split
+    # source here (their creator functions ignore split_from).
+    if not hasattr(split_from, "perform_nocolor_split"):
+        return None
+
     return split_from
 
 
@@ -2508,9 +2515,9 @@ def _new_process_group_helper(
             "created, please use a different group name"
         )
 
-    if device_id is not None and (device_id.index is None or device_id.type == "cpu"):
+    if device_id is not None and device_id.index is None:
         raise ValueError(
-            "init_process_group device_id parameter must be an accelerator with an index"
+            "init_process_group device_id parameter must be a device with an index"
         )
 
     # Note: _new_process_group_helper is only called from init_process_group, which always provides a timeout value


### PR DESCRIPTION
Fixes `init_process_group(backend="gloo", device_id=torch.device("cpu:0"))` raising `ValueError: init_process_group device_id parameter must be an accelerator with an index`. The check in `_new_process_group_helper` predated CPU `device_id` support and contradicted the docs ("gloo for cpu") and `init_process_group`'s own CPU-exempt sanity check — this relaxes it to require only an index, so a CPU device binds normally. Also guards a latent gloo subgroup-split crash the binding exposed (`_get_split_source` returns `None` for split sources without `perform_nocolor_split`). Adds a 2-rank gloo regression test.

Fixes #160731

cc @kwen2501 @d4l3k @H-Huang