### PR TITLE
[BE] Migrate large abs samples from test_mps to OpInfo

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -7500,19 +7500,6 @@ class TestMPS(TestCaseMPS):
 
         helper((2, 8, 4, 5))
 
-    # Regression test for https://github.com/pytorch/pytorch/issues/190052:
-    # integer abs went through float32 and rounded magnitudes above 2**24.
-    def test_abs_large_integers(self):
-        for dtype, vals in [
-            (torch.int32, [-(2**24 + 1), 2**24 + 1, -(2**24 + 3), -(2**31 - 1)]),
-            (torch.int64, [-(2**24 + 1), -(2**33 + 7), -(2**62 + 12345), -(2**63 - 1)]),
-            (torch.int16, [-32767, -128, 0, 127]),
-            (torch.uint8, [0, 1, 255]),
-        ]:
-            with self.subTest(dtype=dtype):
-                a = torch.tensor(vals, dtype=dtype)
-                self.assertEqual(torch.abs(a.to('mps')).cpu(), torch.abs(a))
-
     def test_angle(self):
         def helper(shape, dtype):
             cpu_x = torch.randn(shape, device='cpu', dtype=dtype, requires_grad=False)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -12702,6 +12702,14 @@ def sample_inputs_abs(op_info, device, dtype, requires_grad, op_kwargs=None, **k
             dtype=dtype,
             requires_grad=requires_grad,
         ))
+    # Integer magnitudes above 2**24 lose precision if abs routes through
+    # float32, see https://github.com/pytorch/pytorch/issues/190052
+    large_integer_vals = {
+        torch.int32: [-(2**24 + 1), 2**24 + 1, -(2**24 + 3), -(2**31 - 1)],
+        torch.int64: [-(2**24 + 1), -(2**33 + 7), -(2**62 + 12345), -(2**63 - 1)],
+    }
+    if dtype in large_integer_vals:
+        yield SampleInput(torch.tensor(large_integer_vals[dtype], device=device, dtype=dtype))
 
 # Operator database (sorted alphabetically)
 op_db: list[OpInfo] = [

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -12703,13 +12703,14 @@ def sample_inputs_abs(op_info, device, dtype, requires_grad, op_kwargs=None, **k
             requires_grad=requires_grad,
         ))
     # Integer magnitudes above 2**24 lose precision if abs routes through
-    # float32, see https://github.com/pytorch/pytorch/issues/190052
+    # float32, see https://github.com/pytorch/pytorch/issues/190052. Shaped 2D
+    # so it is also a valid input for the sparse-CSR unary tests.
     large_integer_vals = {
         torch.int32: [-(2**24 + 1), 2**24 + 1, -(2**24 + 3), -(2**31 - 1)],
         torch.int64: [-(2**24 + 1), -(2**33 + 7), -(2**62 + 12345), -(2**63 - 1)],
     }
     if dtype in large_integer_vals:
-        yield SampleInput(torch.tensor(large_integer_vals[dtype], device=device, dtype=dtype))
+        yield SampleInput(torch.tensor([large_integer_vals[dtype]], device=device, dtype=dtype))
 
 # Operator database (sorted alphabetically)
 op_db: list[OpInfo] = [


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #190435

Sort of a review followup from https://github.com/pytorch/pytorch/pull/190053

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>