### PR TITLE
Fix distributed test main-guard AttributeError on GPU-less CUDA builds

### DIFF
--- a/test/distributed/test_c10d_common.py
+++ b/test/distributed/test_c10d_common.py
@@ -2890,7 +2890,7 @@ class ThreadLocalSafetyLintTest(TestCase):
 
 if __name__ == "__main__":
     if device_type != "cpu":
-        if torch.get_device_module()._initialized:
+        if getattr(torch.get_device_module(device_type), "_initialized", False):
             raise AssertionError(
                 f"test_distributed must not have initialized {device_type} context on main process"
             )

--- a/test/distributed/test_store.py
+++ b/test/distributed/test_store.py
@@ -1220,7 +1220,7 @@ class TestClientProtocol(TestCase):
 
 if __name__ == "__main__":
     if device_type != "cpu":
-        if torch.get_device_module()._initialized:
+        if getattr(torch.get_device_module(device_type), "_initialized", False):
             raise AssertionError(
                 f"test_distributed must not have initialized {device_type} context on main process"
             )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #190442
* __->__ #190441

**Impact:** CI only
**Risk:** low

## What
The `if __name__ == "__main__"` guard in `test_store.py` and `test_c10d_common.py`
called `torch.get_device_module()` with no argument. The no-arg form resolves to the
*runtime*-available device -- `torch.cpu` on a machine with no GPU -- while `device_type`
in the same guard comes from `torch.accelerator.current_accelerator()`, a *compile-time*
check that returns `"cuda"` on any CUDA build. `torch.cpu` has no `_initialized`
attribute, so the guard raised
`AttributeError: module 'torch.cpu' has no attribute '_initialized'` at import, before
any test ran. The fix passes `device_type` explicitly so the lookup returns the
compile-time accelerator module, and reads the attribute via
`getattr(..., "_initialized", False)`.

## Why
#189232 (landed Jul 9) started routing single-GPU distributed tests onto the periodic
workflow's `nogpu_AVX512` / `nogpu_NO_AVX2` shards, which run a CUDA build of torch on
GPU-less runners. That exposed the guard's compile-time/runtime device mismatch and every
affected shard has been red at import since Jul 10.

The robust `getattr` form was chosen over the minimal
`get_device_module(device_type)._initialized`: the minimal form still raises on
accelerator modules that have no `_initialized` global (e.g. `torch.mps`, which is what
`current_accelerator()` returns when running these files directly on a Mac), whereas
`getattr(..., False)` degrades to a no-op there. On real CUDA/XPU/MTIA runs the module
always defines `_initialized`, so guard behavior is unchanged.
`getattr(get_device_module(...), "_initialized", False)` is the same idiom already used
in `torch/utils/checkpoint.py`.

## Test Plan
Lint:
```
lintrunner test/distributed/test_store.py test/distributed/test_c10d_common.py
```
Reproduced the crash class and confirmed the fix locally on an MPS box, where
`device_type` is `"mps"` and `torch.mps` also lacks `_initialized` (same failure mode as
`torch.cpu` on the CUDA nogpu shard):
```
python -c "import torch; dt = acc.type if (acc := torch.accelerator.current_accelerator()) else 'cpu'; print(getattr(torch.get_device_module(dt), '_initialized', False))"
```
The old no-arg expression raised `AttributeError`; the new expression prints `False`.
End-to-end validation on the CUDA nogpu shards runs in CI on this PR.