### PR TITLE
Fix test_nvshmem import crash on GPU-less CUDA builds

### DIFF
--- a/test/distributed/test_nvshmem.py
+++ b/test/distributed/test_nvshmem.py
@@ -34,7 +34,7 @@ def requires_nvshmem():
 
 
 def has_nvls_support():
-    if not symm_mem.is_nvshmem_available():
+    if not torch.cuda.is_available() or not symm_mem.is_nvshmem_available():
         return False
 
     if os.environ.get("NVSHMEM_DISABLE_NVLS", "0") == "1":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #190442
* #190441

**Impact:** CI only
**Risk:** low

## What
`test_nvshmem.py`'s `has_nvls_support()` helper runs at import time -- the
`@requires_nvls()` method decorators are evaluated during class-body execution. It called
into `_SymmetricMemory.has_multicast_support(...)`, which touches the CUDA driver and
aborts with `RuntimeError: ... Can't find cuDeviceGet` when no driver/GPU is present. The
fix adds a `torch.cuda.is_available()` short-circuit as the first check in
`has_nvls_support()`, so the driver is never touched on a GPU-less box.

## Why
Like the distributed main-guard crash below it in this stack, this is exposed by #189232
routing distributed tests onto the periodic nogpu shards (CUDA build, no GPU). The file
died at import there, before any test ran.

`torch.cuda.is_available()` is the established guard: the in-tree
`requires_multicast_support()` helper in `torch/testing/_internal/common_distributed.py`
gates the same `has_multicast_support` call the same way. Guarding inside
`has_nvls_support()` -- rather than skipping the whole module at import -- lets the file
import normally and skip its tests at runtime, matching how the other nogpu-shard
distributed files behave. On a real GPU `torch.cuda.is_available()` is `True` and the
`or` falls through to the original check, so behavior is unchanged.

## Test Plan
Lint:
```
lintrunner test/distributed/test_nvshmem.py
```
Confirmed the short-circuit triggers on a GPU-less box:
```
python -c "import torch; print(torch.cuda.is_available())"   # -> False
```
With `torch.cuda.is_available()` False, `has_nvls_support()` returns early before the
`cuDeviceGet` driver call. End-to-end validation on the CUDA nogpu shards runs in CI on
this PR.