### PR TITLE
[random] Add logical-index stateless Philox generation

### DIFF
--- a/RNG_LAYOUT_PLAN.md
+++ b/RNG_LAYOUT_PLAN.md
@@ -1,0 +1,283 @@
+# Logical RNG Layout Plan
+
+## Status
+
+Draft implementation plan for sharing one logical-index layout representation
+between stateless Philox generation, legacy stateful CUDA generation, and
+distributed tensor initialization.
+
+## Goal
+
+Represent a local output as an explicit selection of positions from one logical
+random draw. Use that representation as the common substrate for:
+
+- Stateless generation from an explicit Philox key.
+- Existing stateful `Generator` APIs without changing their CUDA bitstream.
+- DTensor and other distributed systems that initialize local shards while
+  matching a dense logical initialization.
+- An optional `RNGView` convenience API that does not masquerade as an
+  independent PRNG key.
+
+This project does not replace the default stateful RNG APIs.
+
+## Stack Strategy
+
+This plan stacks new PRs on top of HEAD rather than redesigning HEAD in place.
+
+1. Keep HEAD (`#190289`) as the tested behavioral baseline for logical-index
+   replay and dense `Generator` advancement.
+2. Add the stateless indexed backend and shared layout machinery in follow-up
+   PRs.
+3. Refactor HEAD's generator-backed implementation through the shared core,
+   preserving its values, final generator state, and next draw exactly.
+4. Rebase and rework the current DTensor child (`#189546`) on top of the shared
+   adapter. Do not retain its bypassing custom-handler architecture.
+5. Add experimental frontend conveniences only after backend and DTensor
+   semantics are stable.
+
+An optional pre-landing cleanup may make HEAD's protocol and mode private, but
+the plan does not require an in-place semantic rewrite of HEAD.
+
+## Required Semantic Split
+
+The stateless and legacy stateful streams are not interchangeable.
+
+- `portable_linear_v1` uses an explicit tensor key, fixes Philox subsequence to
+  zero, and maps logical indices directly to counter/lane positions. It is the
+  policy for stateless APIs and should be independent of CUDA launch geometry.
+- `cuda_generator_dense_v1` reproduces the current dense CUDA kernel. It uses
+  dense launch geometry, thread-based subsequences, legacy generator offset
+  units, and legacy uniform/normal transforms.
+
+Both policies share layout validation and local-to-logical index decoding. The
+Generator adapter must not simply convert `Generator` state into today's
+stateless key and invoke `_philox_normal_` or `_philox_uniform_`; doing so would
+change values and generator progression.
+
+## Data Model
+
+Start with private, immutable Python value objects registered as pytrees:
+
+```python
+@dataclass(frozen=True)
+class RNGIndexBlock:
+    start: int | torch.SymInt
+    block_size: int | torch.SymInt
+    block_stride: int | torch.SymInt
+    block_count: int | torch.SymInt = 1
+
+
+@dataclass(frozen=True)
+class RNGLayout:
+    logical_numel: int | torch.SymInt
+    blocks: tuple[RNGIndexBlock, ...]
+
+
+@dataclass(frozen=True)
+class RNGView:
+    key: torch.Tensor
+    layout: RNGLayout
+    event_shape: tuple[int | torch.SymInt, ...]
+```
+
+Expanding one block produces these half-open logical intervals:
+
+```text
+[start + i * block_stride,
+ start + i * block_stride + block_size)
+for i in range(block_count)
+```
+
+Intervals are concatenated in descriptor order. Local flat element `i` must
+equal element `expanded_indices[i]` from dense generation over
+`logical_numel` elements.
+
+The layout is expressed in logical element units, never Philox counter units.
+It contains no key, distribution, dtype, device mesh, generator, tracker, or
+collective state.
+
+## Layout Invariants
+
+- `logical_numel` is nonnegative.
+- Lists have equal lengths after lowering to native operator arguments.
+- Block starts are nonnegative; block sizes and counts are positive.
+- `block_stride >= block_size`.
+- Endpoint and mapped-element calculations use checked 64-bit arithmetic.
+- Every expanded interval ends at or before `logical_numel`.
+- Expanded intervals within one layout are ordered and non-overlapping.
+- The expanded element count equals the local output's `numel`.
+- Empty local output is represented by `blocks=()`.
+- Separate layouts may overlap. This is required for replicated values.
+- Invalid stateful calls fail before reserving generator state.
+
+Keep `RNGLayout` private and opaque initially. The four-value block encoding
+may later need piecewise-affine tiles to avoid descriptor explosion for complex
+multidimensional or ragged layouts.
+
+## PR 1: Freeze Existing Semantics
+
+- Add bitwise golden tests for existing stateless `uniform` and `normal`.
+- Add golden tests for HEAD's values, final generator state, and next draw.
+- Cover all floating dtypes, nonzero generator offsets, empty local shards,
+  multiple blocks, uneven slices, and the dense grid-stride increment boundary.
+- Lock down DTensor tracker-enabled and tracker-disabled behavior.
+- Add a forced-rejection `trunc_normal_` test before claiming generic composite
+  initializer support.
+
+## PR 2: Stateless Indexed Backend
+
+Add private ATen operations conceptually equivalent to:
+
+```text
+_philox_uniform_indexed_(out, key, logical_numel,
+                         starts, sizes, strides, counts, low, high)
+_philox_normal_indexed_(out, key, logical_numel,
+                        starts, sizes, strides, counts, mean, std)
+```
+
+- Use `SymInt logical_numel` and `SymInt[]` descriptors at the schema boundary.
+- Initially require one unbatched CUDA `uint64[2]` key on the output device.
+- Map each logical index to the portable Philox counter and output lane.
+- Share native validation and block decoding between distributions.
+- Add identity-layout and single-block fast paths.
+- Avoid allocating a per-element index tensor.
+- Use checked 64-bit indexing and remove the current `INT_MAX` limitation.
+- Add Meta/FakeTensor registration, functional/out variants, decomposition
+  expectations, fullgraph compilation, export, and dynamic-shape coverage.
+- Refactor current stateless dense generation through the identity fast path
+  without changing its output.
+- Land native schemas before frontend callers and observe the required
+  forward-compatibility window.
+
+## PR 3: Stateful Generator Adapter
+
+Add separate private Generator-backed entry points using the same validator,
+layout decoder, and launcher with the legacy dense sampling policy.
+
+- Compute the full dense execution policy from `logical_numel`.
+- Lock the CUDA generator and reserve its full logical increment exactly once.
+- Preserve `PhiloxCudaState` capture pointers and intragraph offsets.
+- Do not use Python `get_state()`/`set_state()` in the production path.
+- Empty local output with nonempty logical output still reserves the full
+  increment; zero logical output does not advance.
+- Perform capability and argument validation before reservation or fallback.
+- Keep generator reservation outside any loop over layout blocks.
+- Route HEAD's scoped stateful mode through this adapter and prove bitwise
+  equivalence with its golden tests.
+
+Sharing happens at the indexed-kernel layer, not by forcing legacy generator
+state through the portable stateless transform.
+
+## PR 4: Experimental Frontend
+
+Extend private `torch.func._random` APIs with an explicit layout keyword:
+
+```python
+random.uniform(key, local_shape, layout=layout)
+random.uniform_(key, out, layout=layout)
+random.normal(key, local_shape, layout=layout)
+random.normal_(key, out, layout=layout)
+```
+
+- `layout=None` retains current dense behavior.
+- Keep the key and layout as separate concepts.
+- Lower frozen pytree layouts immediately to primitive operator arguments.
+- Reject unsupported layouts rather than silently invoking mutable state.
+- Initially support vmap over keys sharing one static layout.
+- Defer batched or graph-input layouts until there is a tensorized descriptor
+  representation and explicit batching rules.
+
+## PR 5: DTensor Integration
+
+- Construct one local `RNGLayout` from `DTensorSpec` in the common RNG dispatch
+  path.
+- Initially support contiguous CUDA local tensors, `normal_`, `uniform_`, a
+  one-dimensional mesh, `Replicate`, and one `Shard(dim)` placement.
+- Cover uneven and empty shards and ranks outside a submesh.
+- Preserve `distribute_region_enabled` and existing tracker fallback policy.
+- Capability-check before generator reservation so fallback cannot advance
+  twice.
+- Avoid direct custom handlers that bypass tracker policy.
+- Avoid a hidden state broadcast on every RNG operation; synchronization policy
+  belongs above the pure backend.
+- Keep `Partial`, noncontiguous local tensors, unsupported devices, and
+  unsupported placements on the existing fallback initially.
+- Expand later to multidimensional rectangular shards, `_StridedShard`, and
+  piecewise-affine layouts.
+
+Use `#189546` as a bitwise semantic oracle, not as the final dispatch design.
+
+## PR 6: RNGView and Partition Convenience
+
+After explicit layouts are stable, add an optional convenience object:
+
+```python
+draw_key = random.fold_in(root_key, layer_id)
+view = RNGView(draw_key, layout, event_shape)
+local = random.uniform(view)
+```
+
+- `RNGView` is a registered pytree, not a Tensor or Tensor subclass.
+- A view selects positions within one logical draw; it is not an independent
+  random stream.
+- `split(view)` and `fold_in(view)` are errors.
+- Applying overlapping views to one key intentionally reproduces equal values.
+- Production distributed code constructs only its local view.
+- Consider `partition()` or `unbind()` only as sugar returning `RNGView`
+  objects. Do not return offset-shifted ordinary keys.
+- Settle naming only after tensorized layouts and batching rules are available.
+
+## Acceptance Gates
+
+### Correctness
+
+- Reassembling stateless local views is bitwise equal to dense stateless output.
+- Stateful shards match dense values, final generator state, and next draw.
+- Normal generation is correct across odd block starts and pair boundaries.
+- Tests cover every floating dtype, full/empty/uneven/replicated layouts,
+  multiple blocks, overflow, offset wrap, invalid layouts, and repeated calls.
+- Stateless portable output is invariant to physical kernel launch geometry.
+
+### Composability
+
+- Eager, AOT eager, Inductor fullgraph, FakeTensor, export, functionalization,
+  dynamic shapes, and CUDA graph capture/replay agree.
+- vmap over keys with a shared layout works before batched layouts are exposed.
+- No tensor attributes are required to preserve RNG metadata through graph
+  transforms.
+
+### Distributed Behavior
+
+- Default and explicit generators, LocalTensor simulation, submeshes, TP, FSDP,
+  HSDP, and TorchTitan initialization retain their intended behavior.
+- Unsupported cases demonstrate exactly one fallback and no double advancement.
+- No backend operation performs a collective.
+
+### Performance
+
+- Dense identity layouts retain the current stateless fast path.
+- Benchmark dense, one-block shard, repeated-block shard, and many-block cases.
+- Track kernel launches, generator-lock duration, temporary allocations, and
+  layout-construction overhead.
+- Do not regress existing dense APIs to a per-element Philox initialization
+  path.
+
+## Non-Goals
+
+- Replacing default mutation-based RNG APIs.
+- Changing the existing CUDA Generator bitstream.
+- Changing CPU's default Mersenne Twister behavior.
+- Supporting every random distribution in the first stack.
+- Enforcing linear key consumption at runtime.
+- Promoting experimental APIs to public `torch.random` before CPU/CUDA,
+  compile, and distributed semantics are stable.
+
+## Primary Risks
+
+- Confusing stateless counter units with legacy generator offset units.
+- Accidentally changing uniform conversion or Box-Muller output ordering.
+- Breaking CUDA graph capture while extracting generator state.
+- Descriptor explosion for complex placements.
+- Hidden collectives or divergent rank control flow in DTensor integration.
+- Silent semantic discontinuity when falling back to the existing tracker.
+- Metadata loss in composite initializers that allocate temporary tensors.

--- a/aten/src/ATen/native/cuda/PhiloxDistribution.cu
+++ b/aten/src/ATen/native/cuda/PhiloxDistribution.cu
@@ -21,8 +21,10 @@
 #include <ATen/NativeFunctions.h>
 #else
 #include <ATen/ops/_philox_normal_flat_slice_native.h>
+#include <ATen/ops/_philox_normal_indexed_native.h>
 #include <ATen/ops/_philox_normal_native.h>
 #include <ATen/ops/_philox_uniform_flat_slice_native.h>
+#include <ATen/ops/_philox_uniform_indexed_native.h>
 #include <ATen/ops/_philox_uniform_native.h>
 #endif
 
@@ -70,6 +72,236 @@ __device__ __forceinline__ double2 box_muller_double(uint4 r) {
   double s, c;
   ::sincos(TWO_PI * u2, &s, &c);
   return {radius * c, radius * s};
+}
+
+void validate_philox_indexed_args(
+    const char* op_name,
+    const Tensor& self,
+    const Tensor& key,
+    int64_t logical_numel,
+    IntArrayRef start_indices,
+    IntArrayRef block_sizes,
+    IntArrayRef block_strides,
+    IntArrayRef block_counts) {
+  TORCH_CHECK(
+      self.is_floating_point(),
+      op_name,
+      ": self must be a floating point tensor, got ",
+      self.scalar_type());
+  TORCH_CHECK(
+      key.scalar_type() == kUInt64,
+      op_name,
+      ": key must have dtype uint64, got ",
+      key.scalar_type());
+  TORCH_CHECK(
+      self.device() == key.device(),
+      op_name,
+      ": self and key must be on the same device, got ",
+      self.device(),
+      " and ",
+      key.device());
+  TORCH_CHECK(
+      key.dim() == 1 && key.size(0) == 2,
+      op_name,
+      ": key must have shape (2,), got shape ",
+      key.sizes());
+  TORCH_CHECK(
+      logical_numel >= 0,
+      op_name,
+      ": logical_numel must be non-negative, got ",
+      logical_numel);
+  TORCH_CHECK(
+      start_indices.size() == block_sizes.size() &&
+          start_indices.size() == block_strides.size() &&
+          start_indices.size() == block_counts.size(),
+      op_name,
+      ": index block arrays must have the same length");
+  TORCH_CHECK(
+      self.numel() <= logical_numel,
+      op_name,
+      ": output numel ",
+      self.numel(),
+      " exceeds logical_numel ",
+      logical_numel);
+
+  int64_t mapped_numel = 0;
+  int64_t previous_end = 0;
+  for (const auto index : c10::irange(start_indices.size())) {
+    const int64_t start_index = start_indices[index];
+    const int64_t block_size = block_sizes[index];
+    const int64_t block_stride = block_strides[index];
+    const int64_t block_count = block_counts[index];
+    TORCH_CHECK(
+        start_index >= 0,
+        op_name,
+        ": start_index must be non-negative, got ",
+        start_index);
+    TORCH_CHECK(
+        block_size > 0,
+        op_name,
+        ": block_size must be positive, got ",
+        block_size);
+    TORCH_CHECK(
+        block_count > 0,
+        op_name,
+        ": block_count must be positive, got ",
+        block_count);
+    TORCH_CHECK(
+        block_stride >= block_size,
+        op_name,
+        ": block_stride ",
+        block_stride,
+        " must be at least block_size ",
+        block_size);
+    TORCH_CHECK(
+        start_index >= previous_end,
+        op_name,
+        ": index blocks must be ordered and non-overlapping; start_index ",
+        start_index,
+        " is before the previous end ",
+        previous_end);
+    TORCH_CHECK(
+        start_index <= logical_numel,
+        op_name,
+        ": start_index ",
+        start_index,
+        " exceeds logical_numel ",
+        logical_numel);
+    TORCH_CHECK(
+        block_size <= logical_numel - start_index,
+        op_name,
+        ": first block ends beyond logical_numel ",
+        logical_numel);
+
+    const int64_t remaining_after_first =
+        logical_numel - start_index - block_size;
+    TORCH_CHECK(
+        block_count == 1 ||
+            block_count - 1 <= remaining_after_first / block_stride,
+        op_name,
+        ": index blocks end beyond logical_numel ",
+        logical_numel);
+    TORCH_CHECK(
+        block_size <= self.numel() - mapped_numel &&
+            block_count <=
+                (self.numel() - mapped_numel) / block_size,
+        op_name,
+        ": index blocks describe more than output numel ",
+        self.numel());
+
+    const int64_t local_numel = block_size * block_count;
+    const int64_t end_index =
+        start_index + (block_count - 1) * block_stride + block_size;
+    mapped_numel += local_numel;
+    previous_end = end_index;
+  }
+  TORCH_CHECK(
+      mapped_numel == self.numel(),
+      op_name,
+      ": index blocks describe ",
+      mapped_numel,
+      " elements, expected output numel ",
+      self.numel());
+}
+
+template <typename scalar_t, typename sample_t, typename param_t>
+void philox_distribution_kernel(
+    const char* op_name,
+    Tensor& self,
+    const Tensor& key,
+    const sample_t& sample_func,
+    const param_t& param_func);
+
+template <typename scalar_t, typename sample_t, typename param_t>
+__global__ void philox_indexed_distribution_kernel(
+    scalar_t* __restrict__ output,
+    const uint64_t* __restrict__ key,
+    int64_t local_numel,
+    int64_t start_index,
+    int64_t block_size,
+    int64_t block_stride,
+    sample_t sample_func,
+    param_t param_func) {
+  constexpr int epc = elems_per_call<scalar_t>;
+  const uint64_t seed = key[0];
+  const uint64_t offset = key[1];
+  const int64_t local_stride =
+      static_cast<int64_t>(blockDim.x) * gridDim.x;
+  int64_t local_index =
+      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  while (local_index < local_numel) {
+    const int64_t logical_index = block_size == local_numel
+        ? start_index + local_index
+        : start_index + (local_index / block_size) * block_stride +
+            local_index % block_size;
+    const uint64_t counter = static_cast<uint64_t>(logical_index / epc);
+    const int64_t lane = logical_index % epc;
+    auto sample = sample_func(seed, offset + counter);
+    output[local_index] = param_func((&sample.x)[lane]);
+    if (local_numel - local_index <= local_stride) {
+      break;
+    }
+    local_index += local_stride;
+  }
+}
+
+template <typename scalar_t, typename sample_t, typename param_t>
+void philox_indexed_distribution(
+    Tensor& self,
+    const Tensor& key,
+    IntArrayRef start_indices,
+    IntArrayRef block_sizes,
+    IntArrayRef block_strides,
+    IntArrayRef block_counts,
+    const sample_t& sample_func,
+    const param_t& param_func) {
+  if (self.numel() == 0) {
+    return;
+  }
+
+  // Snapshot the key before writing output because callers can construct a
+  // floating-point output that aliases the uint64 key through a dtype view.
+  auto key_snapshot =
+      self.is_alias_of(key) ? key.clone().contiguous() : key.contiguous();
+  if (start_indices.size() == 1 && start_indices[0] == 0 &&
+      block_sizes[0] == self.numel() && block_counts[0] == 1) {
+    philox_distribution_kernel<scalar_t>(
+        "philox_indexed_distribution",
+        self,
+        key_snapshot,
+        sample_func,
+        param_func);
+    return;
+  }
+
+  auto output = self.contiguous();
+  constexpr int threads = 256;
+  constexpr int max_blocks = 65535;
+  int64_t local_start = 0;
+  for (const auto index : c10::irange(start_indices.size())) {
+    const int64_t block_size = block_sizes[index];
+    const int64_t local_numel = block_size * block_counts[index];
+    const int64_t required_blocks =
+        (local_numel - 1) / threads + 1;
+    const int blocks = static_cast<int>(
+        required_blocks < max_blocks ? required_blocks : max_blocks);
+    philox_indexed_distribution_kernel<scalar_t>
+        <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+            output.mutable_data_ptr<scalar_t>() + local_start,
+            key_snapshot.const_data_ptr<uint64_t>(),
+            local_numel,
+            start_indices[index],
+            block_size,
+            block_strides[index],
+            sample_func,
+            param_func);
+    local_start += local_numel;
+  }
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  if (output.data_ptr() != self.data_ptr()) {
+    self.copy_(output);
+  }
 }
 
 template <typename scalar_t, typename sample_t, typename param_t>
@@ -521,6 +753,138 @@ Tensor& _philox_normal_cuda_(
     philox_distribution_kernel<scalar_t>(
         "_philox_normal_", self, key, sample_func, param_func);
   });
+  return self;
+}
+
+Tensor& _philox_uniform_indexed_cuda_(
+    Tensor& self,
+    const Tensor& key,
+    int64_t logical_numel,
+    IntArrayRef start_indices,
+    IntArrayRef block_sizes,
+    IntArrayRef block_strides,
+    IntArrayRef block_counts,
+    double low,
+    double high) {
+  validate_philox_indexed_args(
+      "_philox_uniform_indexed_",
+      self,
+      key,
+      logical_numel,
+      start_indices,
+      block_sizes,
+      block_strides,
+      block_counts);
+  TORCH_CHECK(
+      low <= high,
+      "uniform_ expects to return a [from, to) range, but found from=",
+      low,
+      " > to=",
+      high);
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+      kHalf, kBFloat16, self.scalar_type(), "_philox_uniform_indexed_", [&] {
+        TORCH_CHECK(
+            high - low <= std::numeric_limits<scalar_t>::max(),
+            "uniform_ expects to-from <= std::numeric_limits<",
+            toString(self.scalar_type()),
+            ">, but found to=",
+            high,
+            " and from=",
+            low,
+            " which result in to-from to exceed the limit");
+        auto sample_func = []() {
+          if constexpr (std::is_same_v<scalar_t, double>) {
+            return [] __device__(uint64_t seed, uint64_t offset) {
+              uint4 r = philox_4x32(seed, offset);
+              ulonglong2 packed;
+              packed.x =
+                  (static_cast<unsigned long long>(r.x) << 32) | r.y;
+              packed.y =
+                  (static_cast<unsigned long long>(r.z) << 32) | r.w;
+              return packed;
+            };
+          } else {
+            return [] __device__(uint64_t seed, uint64_t offset) {
+              return philox_4x32(seed, offset);
+            };
+          }
+        }();
+
+        auto lo = static_cast<scalar_t>(low);
+        auto hi = static_cast<scalar_t>(high);
+        auto param_func = [lo, hi] __device__(auto rand) {
+          return static_cast<scalar_t>(
+              at::transformation::uniform_real(rand, lo, hi));
+        };
+
+        philox_indexed_distribution<scalar_t>(
+            self,
+            key,
+            start_indices,
+            block_sizes,
+            block_strides,
+            block_counts,
+            sample_func,
+            param_func);
+      });
+  return self;
+}
+
+Tensor& _philox_normal_indexed_cuda_(
+    Tensor& self,
+    const Tensor& key,
+    int64_t logical_numel,
+    IntArrayRef start_indices,
+    IntArrayRef block_sizes,
+    IntArrayRef block_strides,
+    IntArrayRef block_counts,
+    double mean,
+    double stddev) {
+  validate_philox_indexed_args(
+      "_philox_normal_indexed_",
+      self,
+      key,
+      logical_numel,
+      start_indices,
+      block_sizes,
+      block_strides,
+      block_counts);
+  TORCH_CHECK(
+      stddev >= 0.0,
+      "normal expects std >= 0.0, but found std ",
+      stddev);
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+      kHalf, kBFloat16, self.scalar_type(), "_philox_normal_indexed_", [&] {
+        using compute_t =
+            std::conditional_t<std::is_same_v<scalar_t, double>, double, float>;
+        auto sample_func = []() {
+          if constexpr (std::is_same_v<scalar_t, double>) {
+            return [] __device__(uint64_t seed, uint64_t offset) {
+              return box_muller_double(philox_4x32(seed, offset));
+            };
+          } else {
+            return [] __device__(uint64_t seed, uint64_t offset) {
+              return box_muller_float(philox_4x32(seed, offset));
+            };
+          }
+        }();
+
+        auto mu = static_cast<compute_t>(mean);
+        auto sigma = static_cast<compute_t>(stddev);
+        auto param_func = [mu, sigma] __device__(compute_t rand) {
+          return static_cast<scalar_t>(rand * sigma + mu);
+        };
+
+        philox_indexed_distribution<scalar_t>(
+            self,
+            key,
+            start_indices,
+            block_sizes,
+            block_strides,
+            block_counts,
+            sample_func,
+            param_func);
+      });
   return self;
 }
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -6632,6 +6632,16 @@
     CUDA: _philox_uniform_cuda_
   autogen: _philox_uniform, _philox_uniform.out
 
+- func: _philox_normal_indexed_(Tensor(a!) self, Tensor key, SymInt logical_numel, SymInt[] start_indices, SymInt[] block_sizes, SymInt[] block_strides, SymInt[] block_counts, float mean=0, float std=1) -> Tensor(a!)
+  dispatch:
+    CUDA: _philox_normal_indexed_cuda_
+  autogen: _philox_normal_indexed, _philox_normal_indexed.out
+
+- func: _philox_uniform_indexed_(Tensor(a!) self, Tensor key, SymInt logical_numel, SymInt[] start_indices, SymInt[] block_sizes, SymInt[] block_strides, SymInt[] block_counts, float low=0, float high=1) -> Tensor(a!)
+  dispatch:
+    CUDA: _philox_uniform_indexed_cuda_
+  autogen: _philox_uniform_indexed, _philox_uniform_indexed.out
+
 - func: _philox_normal_flat_slice_(Tensor(a!) self, int total_numel, SymInt[] start_indices, SymInt[] block_sizes, SymInt[] block_strides, SymInt[] num_blocks, float mean=0, float std=1, *, Generator? generator=None) -> Tensor(a!)
   tags: nondeterministic_seeded
   dispatch:

--- a/test/test_stateless_rng.py
+++ b/test/test_stateless_rng.py
@@ -486,7 +486,173 @@ class TestStatelessRNGDistribution(TestCase):
         self.assertTrue(result.max().item() <= 5.0)
 
 
+class TestStatelessRNGIndexedDistribution(TestCase):
+    def _layout(self, name):
+        if name == "contiguous":
+            return 37, [5], [17], [17], [1]
+        if name == "strided_blocks":
+            return 37, [2], [3], [7], [5]
+        if name == "multiple_blocks":
+            return 40, [1, 16, 24], [2, 4, 1], [5, 4, 3], [3, 1, 4]
+        raise AssertionError(f"unknown layout {name}")
+
+    def _indices(self, starts, sizes, strides, counts):
+        return [
+            start + block * stride + offset
+            for start, size, stride, count in zip(starts, sizes, strides, counts)
+            for block in range(count)
+            for offset in range(size)
+        ]
+
+    @parametrize("gen_fn_name", ["normal", "uniform"])
+    @parametrize("layout", ["contiguous", "strided_blocks", "multiple_blocks"])
+    @dtypes(*all_floating_dtypes)
+    def test_matches_dense_gather(self, device, dtype, gen_fn_name, layout):
+        logical_numel, starts, sizes, strides, counts = self._layout(layout)
+        indices = self._indices(starts, sizes, strides, counts)
+        key = torch.tensor([1234, 7], dtype=torch.uint64, device=device)
+        result = torch.empty(len(indices), dtype=dtype, device=device)
+        if gen_fn_name == "normal":
+            params = (-1.25, 2.5)
+            dense = random.normal(
+                key,
+                (logical_numel,),
+                mean=params[0],
+                std=params[1],
+                dtype=dtype,
+            )
+        else:
+            params = (-2.0, 3.125)
+            dense = random.uniform(
+                key,
+                (logical_numel,),
+                low=params[0],
+                high=params[1],
+                dtype=dtype,
+            )
+
+        op = getattr(torch.ops.aten, f"_philox_{gen_fn_name}_indexed_")
+        returned = op(
+            result,
+            key,
+            logical_numel,
+            starts,
+            sizes,
+            strides,
+            counts,
+            *params,
+        )
+        self.assertIs(returned, result)
+        self.assertEqual(
+            result, dense[torch.tensor(indices, dtype=torch.int64, device=device)]
+        )
+
+    @parametrize("gen_fn_name", ["normal", "uniform"])
+    def test_noncontiguous_and_empty_output(self, device, gen_fn_name):
+        key = random.key(42, device=device)
+        op = getattr(torch.ops.aten, f"_philox_{gen_fn_name}_indexed_")
+
+        result = torch.empty(20, device=device)[::2]
+        op(result, key, 23, [1], [2], [5], [5])
+        dense = getattr(random, gen_fn_name)(key, (23,))
+        self.assertEqual(
+            result,
+            dense[torch.tensor([1, 2, 6, 7, 11, 12, 16, 17, 21, 22], device=device)],
+        )
+
+        empty = torch.empty(0, device=device)
+        returned = op(empty, key, 23, [], [], [], [])
+        self.assertIs(returned, empty)
+
+    def test_native_validation(self, device):
+        key = random.key(42, device=device)
+        op = torch.ops.aten._philox_uniform_indexed_
+
+        with self.assertRaisesRegex(RuntimeError, "same length"):
+            op(torch.empty(1, device=device), key, 4, [0], [1], [1], [])
+        with self.assertRaisesRegex(RuntimeError, "block_size must be positive"):
+            op(torch.empty(0, device=device), key, 4, [0], [0], [0], [1])
+        with self.assertRaisesRegex(RuntimeError, "ordered and non-overlapping"):
+            op(
+                torch.empty(4, device=device),
+                key,
+                8,
+                [0, 1],
+                [2, 2],
+                [2, 2],
+                [1, 1],
+            )
+        with self.assertRaisesRegex(RuntimeError, "end beyond logical_numel"):
+            op(torch.empty(3, device=device), key, 8, [6], [1], [2], [3])
+        with self.assertRaisesRegex(RuntimeError, "expected output numel"):
+            op(torch.empty(3, device=device), key, 8, [0], [2], [2], [1])
+
+        batched_key = key.expand(2, 2)
+        with self.assertRaisesRegex(RuntimeError, r"key must have shape \(2,\)"):
+            op(torch.empty(1, device=device), batched_key, 1, [0], [1], [1], [1])
+
+        with self.assertRaisesRegex(RuntimeError, "normal expects std >= 0.0"):
+            torch.ops.aten._philox_normal_indexed_(
+                torch.empty(1, device=device), key, 1, [0], [1], [1], [1], 0, -1
+            )
+        with self.assertRaisesRegex(RuntimeError, "found from=1.*> to=0"):
+            op(torch.empty(1, device=device), key, 1, [0], [1], [1], [1], 1, 0)
+
+    def test_key_may_alias_output(self, device):
+        storage = torch.tensor([1234, 7], dtype=torch.uint64, device=device)
+        expected = random.uniform(storage.clone(), (4,))
+        output = storage.view(torch.float32)
+        torch.ops.aten._philox_uniform_indexed_(
+            output,
+            storage,
+            4,
+            [0, 1, 2, 3],
+            [1, 1, 1, 1],
+            [1, 1, 1, 1],
+            [1, 1, 1, 1],
+        )
+        self.assertEqual(output, expected)
+
+    def test_meta(self, device):
+        key = torch.empty(2, dtype=torch.uint64, device="meta")
+        result = torch.empty(6, device="meta")
+        returned = torch.ops.aten._philox_normal_indexed_(
+            result, key, 17, [1, 10], [2, 2], [4, 3], [2, 1]
+        )
+        self.assertIs(returned, result)
+        with self.assertRaisesRegex(RuntimeError, "expected output numel"):
+            torch.ops.aten._philox_normal_indexed_(
+                torch.empty(7, device="meta"),
+                key,
+                17,
+                [1, 10],
+                [2, 2],
+                [4, 3],
+                [2, 1],
+            )
+
+
 class TestStatelessRNGCompile(TestCase):
+    @parametrize("op", ["normal", "uniform"])
+    def test_indexed_fullgraph(self, device, op):
+        key = random.key(42, device=device)
+        indexed_op = getattr(torch.ops.aten, f"_philox_{op}_indexed_")
+
+        def f(key):
+            result = torch.empty(6, device=key.device)
+            return indexed_op(
+                result,
+                key,
+                17,
+                [1, 10],
+                [2, 2],
+                [4, 3],
+                [2, 1],
+            )
+
+        compiled = torch.compile(f, backend="aot_eager", fullgraph=True)
+        self.assertEqual(compiled(key), f(key))
+
     def test_split_fullgraph(self, device):
         key = random.key(42, device=device)
 
@@ -589,6 +755,9 @@ instantiate_device_type_tests(TestStatelessRNGKeySplit, globals(), only_for=("cu
 instantiate_device_type_tests(TestStatelessRNGKeyFoldIn, globals(), only_for=("cuda",))
 instantiate_device_type_tests(
     TestStatelessRNGDistribution, globals(), only_for=("cuda",)
+)
+instantiate_device_type_tests(
+    TestStatelessRNGIndexedDistribution, globals(), only_for=("cuda",)
 )
 instantiate_device_type_tests(TestStatelessRNGCompile, globals(), only_for=("cuda",))
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -637,6 +637,176 @@ def meta_philox_uniform_(self, key, low=0.0, high=1.0):
     return self
 
 
+def _check_philox_indexed_distribution_args(
+    op_name,
+    self,
+    key,
+    logical_numel,
+    start_indices,
+    block_sizes,
+    block_strides,
+    block_counts,
+):
+    torch._check(
+        self.dtype.is_floating_point,
+        lambda: f"{op_name}: self must be a floating point tensor, got {self.dtype}",
+    )
+    torch._check(
+        key.dtype == torch.uint64,
+        lambda: f"{op_name}: key must have dtype uint64, got {key.dtype}",
+    )
+    torch._check(
+        self.device == key.device,
+        lambda: (
+            f"{op_name}: self and key must be on the same device, "
+            f"got {self.device} and {key.device}"
+        ),
+    )
+    torch._check(
+        key.dim() == 1,
+        lambda: f"{op_name}: key must have shape (2,), got shape {key.shape}",
+    )
+    torch._check(
+        key.shape[0] == 2,
+        lambda: f"{op_name}: key must have shape (2,), got shape {key.shape}",
+    )
+    torch._check(
+        logical_numel >= 0,
+        lambda: (f"{op_name}: logical_numel must be non-negative, got {logical_numel}"),
+    )
+    torch._check(
+        len(start_indices)
+        == len(block_sizes)
+        == len(block_strides)
+        == len(block_counts),
+        lambda: f"{op_name}: index block arrays must have the same length",
+    )
+    torch._check(
+        self.numel() <= logical_numel,
+        lambda: (
+            f"{op_name}: output numel {self.numel()} exceeds logical_numel "
+            f"{logical_numel}"
+        ),
+    )
+
+    mapped_numel = 0
+    previous_end = 0
+    for start_index, block_size, block_stride, block_count in zip(
+        start_indices, block_sizes, block_strides, block_counts
+    ):
+        torch._check(
+            start_index >= 0,
+            lambda: (f"{op_name}: start_index must be non-negative, got {start_index}"),
+        )
+        torch._check(
+            block_size > 0,
+            lambda: f"{op_name}: block_size must be positive, got {block_size}",
+        )
+        torch._check(
+            block_count > 0,
+            lambda: f"{op_name}: block_count must be positive, got {block_count}",
+        )
+        torch._check(
+            block_stride >= block_size,
+            lambda: (
+                f"{op_name}: block_stride {block_stride} must be at least "
+                f"block_size {block_size}"
+            ),
+        )
+        torch._check(
+            start_index >= previous_end,
+            lambda: (
+                f"{op_name}: index blocks must be ordered and non-overlapping; "
+                f"start_index {start_index} is before the previous end {previous_end}"
+            ),
+        )
+        end_index = start_index + (block_count - 1) * block_stride + block_size
+        torch._check(
+            end_index <= logical_numel,
+            lambda: (
+                f"{op_name}: index blocks end beyond logical_numel {logical_numel}"
+            ),
+        )
+        mapped_numel += block_size * block_count
+        previous_end = end_index
+
+    torch._check(
+        mapped_numel == self.numel(),
+        lambda: (
+            f"{op_name}: index blocks describe {mapped_numel} elements, "
+            f"expected output numel {self.numel()}"
+        ),
+    )
+
+
+@register_meta(aten._philox_normal_indexed_.default)
+def meta_philox_normal_indexed_(
+    self,
+    key,
+    logical_numel,
+    start_indices,
+    block_sizes,
+    block_strides,
+    block_counts,
+    mean=0.0,
+    std=1.0,
+):
+    _check_philox_indexed_distribution_args(
+        "_philox_normal_indexed_",
+        self,
+        key,
+        logical_numel,
+        start_indices,
+        block_sizes,
+        block_strides,
+        block_counts,
+    )
+    torch._check(
+        std >= 0.0,
+        lambda: f"normal expects std >= 0.0, but found std {std}",
+    )
+    return self
+
+
+@register_meta(aten._philox_uniform_indexed_.default)
+def meta_philox_uniform_indexed_(
+    self,
+    key,
+    logical_numel,
+    start_indices,
+    block_sizes,
+    block_strides,
+    block_counts,
+    low=0.0,
+    high=1.0,
+):
+    _check_philox_indexed_distribution_args(
+        "_philox_uniform_indexed_",
+        self,
+        key,
+        logical_numel,
+        start_indices,
+        block_sizes,
+        block_strides,
+        block_counts,
+    )
+    torch._check(
+        low <= high,
+        lambda: (
+            "uniform_ expects to return a [from, to) range, but found "
+            f"from={low} > to={high}"
+        ),
+    )
+    torch._check(
+        high - low <= torch.finfo(self.dtype).max,
+        lambda: (
+            f"uniform_ expects to-from <= {torch.finfo(self.dtype).max}, "
+            f"but found to={high} and from={low}"
+        ),
+    )
+    return self
+
+
 @register_meta([aten._fft_c2r.default, aten._fft_c2r.out])
 @out_wrapper()
 def meta_fft_c2r(self: Tensor, dim: list[int], normalization: int, lastdim: int):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #190447
* #190446
* #189546
* #190445
* #190444
* __->__ #190443
* #190289

Add private indexed uniform and normal operators that map compact block descriptors to positions in one logical stateless Philox draw. Preserve the existing dense APIs, validate layouts in native and Meta paths, and provide compile coverage.

Document the follow-up architecture for sharing logical RNG layouts with the legacy Generator adapter and DTensor without changing existing stateful streams.

Test Plan:
- ninja -C build install
- python test/test_stateless_rng.py
- python test/distributed/test_stateful_rng.py
- python test/test_public_bindings.py -k test_no_new_bindings
- python test/test_public_bindings.py -k test_correct_module_names
- lintrunner on changed files