### PR TITLE
[functorch] Add experimental stateless RNG layouts

### DIFF
--- a/test/test_stateless_rng.py
+++ b/test/test_stateless_rng.py
@@ -10,6 +10,8 @@ from torch.testing._internal.common_device_type import (
 from torch.testing._internal.common_dtype import floating_types_and
 from torch.testing._internal.common_utils import parametrize, run_tests, TestCase
 from torch.testing._internal.inductor_utils import HAS_TRITON
+from torch.utils import _pytree as pytree
+from torch.utils._python_dispatch import TorchDispatchMode
 
 
 all_floating_dtypes = floating_types_and(torch.half, torch.bfloat16)
@@ -632,7 +634,109 @@ class TestStatelessRNGIndexedDistribution(TestCase):
             )
 
 
+class TestStatelessRNGLayout(TestCase):
+    def _layout(self):
+        return random.RNGLayout(
+            logical_numel=12,
+            blocks=(random.RNGIndexBlock(1, 2, 4, 3),),
+        )
+
+    @parametrize("op", ["normal", "uniform"])
+    @dtypes(*all_floating_dtypes)
+    def test_layout_matches_dense_gather(self, device, dtype, op):
+        key = random.key(42, device=device)
+        layout = self._layout()
+        dense = getattr(random, op)(key, (layout.logical_numel,), dtype=dtype)
+        actual = getattr(random, op)(key, (6,), layout=layout, dtype=dtype)
+        indices = torch.tensor([1, 2, 5, 6, 9, 10], device=device)
+        self.assertEqual(actual, dense[indices])
+
+        inplace = torch.empty(6, device=device, dtype=dtype)
+        returned = getattr(random, f"{op}_")(key, inplace, layout=layout)
+        self.assertIs(returned, inplace)
+        self.assertEqual(inplace, actual)
+
+    @parametrize("op", ["normal", "uniform"])
+    def test_vmap_over_keys_with_shared_layout(self, device, op):
+        keys = random.split(random.key(42, device=device), 3)
+        layout = self._layout()
+        generate = getattr(random, op)
+        actual = torch.vmap(lambda key: generate(key, (6,), layout=layout))(keys)
+        expected = torch.stack(
+            [generate(key, (6,), layout=layout) for key in keys.unbind()]
+        )
+        self.assertEqual(actual, expected)
+
+    @parametrize("op", ["normal", "uniform"])
+    def test_out_of_place_layout_uses_mutable_kernel(self, device, op):
+        class OpRecorder(TorchDispatchMode):
+            def __init__(self):
+                super().__init__()
+                self.ops = []
+
+            def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+                self.ops.append(func)
+                return func(*args, **(kwargs or {}))
+
+        recorder = OpRecorder()
+        with recorder:
+            getattr(random, op)(
+                random.key(42, device=device), (6,), layout=self._layout()
+            )
+
+        inplace_op = getattr(torch.ops.aten, f"_philox_{op}_indexed_").default
+        functional_op = getattr(torch.ops.aten, f"_philox_{op}_indexed").default
+        self.assertIn(inplace_op, recorder.ops)
+        self.assertNotIn(functional_op, recorder.ops)
+
+    def test_layout_is_pytree(self, device):
+        layout = self._layout()
+        leaves, spec = pytree.tree_flatten(layout)
+        rebuilt = pytree.tree_unflatten(leaves, spec)
+        self.assertEqual(rebuilt, layout)
+
+    def test_dense_and_layout_inplace_wrappers_fx_trace(self, device):
+        layout = self._layout()
+
+        def dense(key, output):
+            return random.uniform_(key, output)
+
+        def indexed(key, output):
+            return random.uniform_(key, output, layout=layout)
+
+        dense_graph = torch.fx.symbolic_trace(dense)
+        indexed_graph = torch.fx.symbolic_trace(indexed)
+        self.assertIn("aten._philox_uniform_", dense_graph.code)
+        self.assertIn("aten._philox_uniform_indexed_", indexed_graph.code)
+
+    def test_layout_validation_reaches_native_operator(self, device):
+        key = random.key(42, device=device)
+        bad_layout = random.RNGLayout(
+            8,
+            (
+                random.RNGIndexBlock(0, 2, 2),
+                random.RNGIndexBlock(1, 2, 2),
+            ),
+        )
+        with self.assertRaisesRegex(RuntimeError, "ordered and non-overlapping"):
+            random.uniform(key, (4,), layout=bad_layout)
+        with self.assertRaisesRegex(TypeError, "expected layout to be RNGLayout"):
+            random.uniform(key, (4,), layout=object())  # type: ignore[arg-type]
+
+
 class TestStatelessRNGCompile(TestCase):
+    @parametrize("op", ["normal", "uniform"])
+    def test_layout_fullgraph(self, device, op):
+        key = random.key(42, device=device)
+        layout = random.RNGLayout(12, (random.RNGIndexBlock(1, 2, 4, 3),))
+        generate = getattr(random, op)
+
+        @torch.compile(backend="aot_eager", fullgraph=True)
+        def f(key):
+            return generate(key, (6,), layout=layout)
+
+        self.assertEqual(f(key), generate(key, (6,), layout=layout))
+
     @parametrize("op", ["normal", "uniform"])
     def test_indexed_fullgraph(self, device, op):
         key = random.key(42, device=device)
@@ -759,6 +863,7 @@ instantiate_device_type_tests(
 instantiate_device_type_tests(
     TestStatelessRNGIndexedDistribution, globals(), only_for=("cuda",)
 )
+instantiate_device_type_tests(TestStatelessRNGLayout, globals(), only_for=("cuda",))
 instantiate_device_type_tests(TestStatelessRNGCompile, globals(), only_for=("cuda",))
 
 

--- a/torch/func/_random.py
+++ b/torch/func/_random.py
@@ -5,8 +5,74 @@ Access via ``torch.func._random``.
 """
 
 from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import cast
 
 import torch
+from torch.utils import _pytree as pytree
+
+
+@dataclass(frozen=True)
+class RNGIndexBlock:
+    """A repeated block of logical flat indices in one random draw."""
+
+    start: int | torch.SymInt
+    block_size: int | torch.SymInt
+    block_stride: int | torch.SymInt
+    block_count: int | torch.SymInt = 1
+
+
+@dataclass(frozen=True)
+class RNGLayout:
+    """Map a local flat output to positions in a logical random draw."""
+
+    logical_numel: int | torch.SymInt
+    blocks: tuple[RNGIndexBlock, ...]
+
+
+pytree.register_dataclass(
+    RNGIndexBlock,
+    serialized_type_name="torch.func._random.RNGIndexBlock",
+)
+pytree.register_dataclass(
+    RNGLayout,
+    serialized_type_name="torch.func._random.RNGLayout",
+)
+
+
+def _validate_layout(layout: RNGLayout | None) -> RNGLayout | None:
+    if layout is not None and not isinstance(layout, RNGLayout):
+        raise TypeError(f"expected layout to be RNGLayout, got {type(layout).__name__}")
+    return layout
+
+
+def _layout_args(
+    layout: RNGLayout,
+) -> tuple[
+    int | torch.SymInt,
+    list[int | torch.SymInt],
+    list[int | torch.SymInt],
+    list[int | torch.SymInt],
+    list[int | torch.SymInt],
+]:
+    return (
+        layout.logical_numel,
+        [block.start for block in layout.blocks],
+        [block.block_size for block in layout.blocks],
+        [block.block_stride for block in layout.blocks],
+        [block.block_count for block in layout.blocks],
+    )
+
+
+ShapeArg = int | torch.SymInt | Sequence[int | torch.SymInt]
+
+
+def _normalize_output_shape(
+    shape: tuple[ShapeArg, ...],
+) -> tuple[int | torch.SymInt, ...]:
+    if len(shape) == 1 and isinstance(shape[0], Sequence):
+        return tuple(shape[0])
+    return tuple(cast(int | torch.SymInt, dim) for dim in shape)
 
 
 def key(
@@ -109,6 +175,7 @@ def normal_(
     *,
     mean: float = 0.0,
     std: float = 1.0,
+    layout: RNGLayout | None = None,
 ) -> torch.Tensor:
     r"""Fill ``result`` in-place with normal random values from a PRNG key.
 
@@ -116,9 +183,10 @@ def normal_(
     and ``std``. The output is fully determined by the key, so calling with the
     same key always produces the same result.
 
-    Supports batched keys: if ``key`` has shape ``(*batch, K)``, the leading
-    dimensions of ``result`` must be broadcastable with ``*batch`` and each key
-    independently generates its slice of the output.
+    Without a layout, batched keys are supported: if ``key`` has shape
+    ``(*batch, K)``, the leading dimensions of ``result`` must be broadcastable
+    with ``*batch`` and each key independently generates its output slice.
+    Layout-based in-place generation currently requires one unbatched key.
 
     Args:
         key (Tensor): A PRNG key returned by :func:`key`, :func:`split`, or
@@ -126,6 +194,7 @@ def normal_(
         result (Tensor): The output tensor to fill in-place.
         mean (float): Mean of the normal distribution. Default: ``0.0``.
         std (float): Standard deviation of the normal distribution. Default: ``1.0``.
+        layout (RNGLayout, optional): Logical positions to generate.
 
     Returns:
         ``result``, filled with normal random values.
@@ -136,15 +205,21 @@ def normal_(
         >>> result = torch.empty(1000, device="cuda")  # doctest: +SKIP
         >>> torch.func._random.normal_(key, result)  # doctest: +SKIP
     """
-    return torch.ops.aten._philox_normal_(result, key, mean, std)
+    layout = _validate_layout(layout)
+    if layout is None:
+        return torch.ops.aten._philox_normal_(result, key, mean, std)
+    return torch.ops.aten._philox_normal_indexed_(
+        result, key, *_layout_args(layout), mean, std
+    )
 
 
 def normal(
     key: torch.Tensor,
-    *shape: tuple[int, ...],
+    *shape: ShapeArg,
     mean: float = 0.0,
     std: float = 1.0,
     dtype: torch.dtype | None = None,
+    layout: RNGLayout | None = None,
 ) -> torch.Tensor:
     r"""Generate normally distributed random values from a PRNG key.
 
@@ -153,9 +228,8 @@ def normal(
     determined by the key, so calling with the same key always returns the same
     result. The output is placed on the same device as ``key``.
 
-    Supports batched keys: if ``key`` has shape ``(*batch, K)``, the leading
-    dimensions of ``shape`` must be broadcastable with ``*batch`` and each key
-    independently generates its slice of the output.
+    Without a layout, batched keys are supported directly. With a layout, use
+    :func:`torch.vmap` over unbatched keys sharing one static layout.
 
     Args:
         key (Tensor): A PRNG key returned by :func:`key`, :func:`split`, or
@@ -164,6 +238,7 @@ def normal(
         mean (float): Mean of the normal distribution. Default: ``0.0``.
         std (float): Standard deviation of the normal distribution. Default: ``1.0``.
         dtype (:class:`torch.dtype`, optional): The desired dtype. Default: ``torch.float32``.
+        layout (RNGLayout, optional): Logical positions to generate.
 
     Returns:
         A tensor of the given shape filled with normal random values.
@@ -173,14 +248,17 @@ def normal(
         >>> key = torch.func._random.key(42, device="cuda")  # doctest: +SKIP
         >>> torch.func._random.normal(key, (1000,))  # doctest: +SKIP
     """
-    if len(shape) == 1 and isinstance(shape[0], Sequence):
-        # pyrefly: ignore [bad-argument-type]
-        shape = tuple(shape[0])
+    output_shape = _normalize_output_shape(shape)
     if dtype is None:
         dtype = torch.float32
-    # pyrefly: ignore [no-matching-overload]
-    result = torch.empty(shape, dtype=dtype, device=key.device)
-    return normal_(key, result, mean=mean, std=std)
+    layout = _validate_layout(layout)
+    if layout is None:
+        # pyrefly: ignore [no-matching-overload]
+        result = torch.empty(output_shape, dtype=dtype, device=key.device)
+        return normal_(key, result, mean=mean, std=std)
+    # new_empty propagates a vmap batch level from key to the mutable output.
+    result = key.new_empty(output_shape, dtype=dtype)
+    return normal_(key, result, mean=mean, std=std, layout=layout)
 
 
 def uniform_(
@@ -189,6 +267,7 @@ def uniform_(
     *,
     low: float = 0.0,
     high: float = 1.0,
+    layout: RNGLayout | None = None,
 ) -> torch.Tensor:
     r"""Fill ``result`` in-place with uniform random values from a PRNG key.
 
@@ -196,9 +275,10 @@ def uniform_(
     is fully determined by the key, so calling with the same key always produces
     the same result.
 
-    Supports batched keys: if ``key`` has shape ``(*batch, K)``, the leading
-    dimensions of ``result`` must be broadcastable with ``*batch`` and each key
-    independently generates its slice of the output.
+    Without a layout, batched keys are supported: if ``key`` has shape
+    ``(*batch, K)``, the leading dimensions of ``result`` must be broadcastable
+    with ``*batch`` and each key independently generates its output slice.
+    Layout-based in-place generation currently requires one unbatched key.
 
     Args:
         key (Tensor): A PRNG key returned by :func:`key`, :func:`split`, or
@@ -206,6 +286,7 @@ def uniform_(
         result (Tensor): The output tensor to fill in-place.
         low (float): Lower bound (inclusive) of the uniform distribution. Default: ``0.0``.
         high (float): Upper bound (exclusive) of the uniform distribution. Default: ``1.0``.
+        layout (RNGLayout, optional): Logical positions to generate.
 
     Returns:
         ``result``, filled with uniform random values.
@@ -216,15 +297,21 @@ def uniform_(
         >>> result = torch.empty(1000, device="cuda")  # doctest: +SKIP
         >>> torch.func._random.uniform_(key, result)  # doctest: +SKIP
     """
-    return torch.ops.aten._philox_uniform_(result, key, low, high)
+    layout = _validate_layout(layout)
+    if layout is None:
+        return torch.ops.aten._philox_uniform_(result, key, low, high)
+    return torch.ops.aten._philox_uniform_indexed_(
+        result, key, *_layout_args(layout), low, high
+    )
 
 
 def uniform(
     key: torch.Tensor,
-    *shape: tuple[int, ...],
+    *shape: ShapeArg,
     low: float = 0.0,
     high: float = 1.0,
     dtype: torch.dtype | None = None,
+    layout: RNGLayout | None = None,
 ) -> torch.Tensor:
     r"""Generate uniformly distributed random values from a PRNG key.
 
@@ -233,9 +320,8 @@ def uniform(
     key, so calling with the same key always returns the same result. The output
     is placed on the same device as ``key``.
 
-    Supports batched keys: if ``key`` has shape ``(*batch, K)``, the leading
-    dimensions of ``shape`` must be broadcastable with ``*batch`` and each key
-    independently generates its slice of the output.
+    Without a layout, batched keys are supported directly. With a layout, use
+    :func:`torch.vmap` over unbatched keys sharing one static layout.
 
     Args:
         key (Tensor): A PRNG key returned by :func:`key`, :func:`split`, or
@@ -244,6 +330,7 @@ def uniform(
         low (float): Lower bound (inclusive) of the uniform distribution. Default: ``0.0``.
         high (float): Upper bound (exclusive) of the uniform distribution. Default: ``1.0``.
         dtype (:class:`torch.dtype`, optional): The desired dtype. Default: ``torch.float32``.
+        layout (RNGLayout, optional): Logical positions to generate.
 
     Returns:
         A tensor of the given shape filled with uniform random values.
@@ -253,11 +340,14 @@ def uniform(
         >>> key = torch.func._random.key(42, device="cuda")  # doctest: +SKIP
         >>> torch.func._random.uniform(key, (1000,))  # doctest: +SKIP
     """
-    if len(shape) == 1 and isinstance(shape[0], Sequence):
-        # pyrefly: ignore [bad-argument-type]
-        shape = tuple(shape[0])
+    output_shape = _normalize_output_shape(shape)
     if dtype is None:
         dtype = torch.float32
-    # pyrefly: ignore [no-matching-overload]
-    result = torch.empty(shape, dtype=dtype, device=key.device)
-    return uniform_(key, result, low=low, high=high)
+    layout = _validate_layout(layout)
+    if layout is None:
+        # pyrefly: ignore [no-matching-overload]
+        result = torch.empty(output_shape, dtype=dtype, device=key.device)
+        return uniform_(key, result, low=low, high=high)
+    # new_empty propagates a vmap batch level from key to the mutable output.
+    result = key.new_empty(output_shape, dtype=dtype)
+    return uniform_(key, result, low=low, high=high, layout=layout)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #190447
* __->__ #190446
* #189546
* #190445
* #190444
* #190443
* #190289

Add private immutable RNGIndexBlock and RNGLayout pytrees and accept a static layout in stateless normal and uniform frontends. Layout generation selects logical positions from one portable Philox draw without exposing offset-shifted keys.

Keep dense wrappers unchanged, support vmap over keys via batched output allocation, preserve FX/fullgraph tracing, and avoid the autogenerated functional clone path.