### PR TITLE
CMake/Build Changes for WoA CTK and RTX Spark

### DIFF
--- a/cmake/Modules/FindCUDAToolkit.cmake
+++ b/cmake/Modules/FindCUDAToolkit.cmake
@@ -812,14 +812,19 @@ if(NOT EXISTS "${CUDAToolkit_INCLUDE_DIR}/cublas_v2.h")
   endif()
 endif()
 
+if(WIN32 AND CMAKE_SYSTEM_PROCESSOR STREQUAL "ARM64")
+  set(_CUDAToolkit_ARM64_LIBRARY_SEARCH_SUFFIX lib/arm64)
+  set(_CUDAToolkit_ARM64_STUB_LIBRARY_SEARCH_SUFFIX lib/arm64/stubs)
+endif()
+
 # Find the CUDA Runtime Library libcudart
 find_library(CUDA_CUDART
   NAMES cudart
-  PATH_SUFFIXES lib64 lib/x64
+  PATH_SUFFIXES ${_CUDAToolkit_ARM64_LIBRARY_SEARCH_SUFFIX} lib64 lib/x64
 )
 find_library(CUDA_CUDART
   NAMES cudart
-  PATH_SUFFIXES lib64/stubs lib/x64/stubs
+  PATH_SUFFIXES ${_CUDAToolkit_ARM64_STUB_LIBRARY_SEARCH_SUFFIX} lib64/stubs lib/x64/stubs
 )
 
 if(NOT CUDA_CUDART AND NOT CUDAToolkit_FIND_QUIETLY)
@@ -871,7 +876,7 @@ if(CUDAToolkit_FOUND)
       HINTS ${CUDAToolkit_LIBRARY_DIR}
             ENV CUDA_PATH
             ${arg_EXTRA_HINTS}
-      PATH_SUFFIXES nvidia/current lib64 lib/x64 lib
+      PATH_SUFFIXES nvidia/current ${_CUDAToolkit_ARM64_LIBRARY_SEARCH_SUFFIX} lib64 lib/x64 lib
                     ${arg_EXTRA_PATH_SUFFIXES}
     )
     # Don't try any stub directories until we have exhausted all other
@@ -881,7 +886,7 @@ if(CUDAToolkit_FOUND)
       HINTS ${CUDAToolkit_LIBRARY_DIR}
             ENV CUDA_PATH
             ${arg_EXTRA_HINTS}
-      PATH_SUFFIXES lib64/stubs lib/x64/stubs lib/stubs stubs
+      PATH_SUFFIXES ${_CUDAToolkit_ARM64_STUB_LIBRARY_SEARCH_SUFFIX} lib64/stubs lib/x64/stubs lib/stubs stubs
                     # Support NVHPC splayed math library layout
                     ../../math_libs/${CUDAToolkit_VERSION_MAJOR}.${CUDAToolkit_VERSION_MINOR}/lib64
                     ../../math_libs/lib64

--- a/cmake/Modules_CUDA_fix/upstream/FindCUDA.cmake
+++ b/cmake/Modules_CUDA_fix/upstream/FindCUDA.cmake
@@ -816,6 +816,10 @@ macro(cuda_find_library_local_first_with_path_ext _var _names _doc _path_ext )
     # CUDA 3.2+ on Windows moved the library directories, so we need the new
     # and old paths.
     set(_cuda_64bit_lib_dir "${_path_ext}lib/x64" "${_path_ext}lib64" "${_path_ext}libx64" )
+    # Set library search path for CTK depending on system architecture
+    if(WIN32 AND CMAKE_SYSTEM_PROCESSOR STREQUAL "ARM64")
+      list(PREPEND _cuda_64bit_lib_dir "${_path_ext}lib/arm64")
+    endif()
   endif()
   # CUDA 3.2+ on Windows moved the library directories, so we need to new
   # (lib/Win32) and the old path (lib).

--- a/cmake/Modules_CUDA_fix/upstream/FindCUDA.cmake
+++ b/cmake/Modules_CUDA_fix/upstream/FindCUDA.cmake
@@ -817,7 +817,7 @@ macro(cuda_find_library_local_first_with_path_ext _var _names _doc _path_ext )
     # and old paths.
     set(_cuda_64bit_lib_dir "${_path_ext}lib/x64" "${_path_ext}lib64" "${_path_ext}libx64" )
     # Set library search path for CTK depending on system architecture
-    if(WIN32 AND CMAKE_SYSTEM_PROCESSOR STREQUAL "ARM64")
+    if(CMAKE_SYSTEM_PROCESSOR STREQUAL "ARM64")
       list(PREPEND _cuda_64bit_lib_dir "${_path_ext}lib/arm64")
     endif()
   endif()

--- a/cmake/Modules_CUDA_fix/upstream/FindCUDA.cmake
+++ b/cmake/Modules_CUDA_fix/upstream/FindCUDA.cmake
@@ -817,7 +817,7 @@ macro(cuda_find_library_local_first_with_path_ext _var _names _doc _path_ext )
     # and old paths.
     set(_cuda_64bit_lib_dir "${_path_ext}lib/x64" "${_path_ext}lib64" "${_path_ext}libx64" )
     # Set library search path for CTK depending on system architecture
-    if(CMAKE_SYSTEM_PROCESSOR STREQUAL "ARM64")
+    if(WIN32 AND CMAKE_SYSTEM_PROCESSOR STREQUAL "ARM64")
       list(PREPEND _cuda_64bit_lib_dir "${_path_ext}lib/arm64")
     endif()
   endif()

--- a/cmake/PostBuildSteps.cmake
+++ b/cmake/PostBuildSteps.cmake
@@ -84,7 +84,7 @@ if(WIN32 AND BUILD_PYTHON)
   # CUDA runtime DLLs - only for CUDA builds.
   if(USE_CUDA AND CUDA_TOOLKIT_ROOT_DIR)
     # CUDA 13+ moves DLLs to an architecture-specific bin directory.
-    if(WIN32 AND CMAKE_SYSTEM_PROCESSOR STREQUAL "ARM64")
+    if (CMAKE_SYSTEM_PROCESSOR STREQUAL "ARM64")
       set(_cuda_windows_arch "arm64")
     else()
       set(_cuda_windows_arch "x64")
@@ -94,18 +94,6 @@ if(WIN32 AND BUILD_PYTHON)
       set(_cuda_bin "${CUDA_TOOLKIT_ROOT_DIR}/bin/${_cuda_windows_arch}")
     else()
       set(_cuda_bin "${CUDA_TOOLKIT_ROOT_DIR}/bin")
-    endif()
-
-    # CUDA 13.4+ uses extras/CUPTI/lib/<arch>, while older Windows x64
-    # toolkits use extras/CUPTI/lib64. Never use lib64 for ARM64 because
-    # that legacy directory contains x64 binaries.
-    if(IS_DIRECTORY "${CUDA_TOOLKIT_ROOT_DIR}/extras/CUPTI/lib/${_cuda_windows_arch}")
-      set(_cupti_bin
-        "${CUDA_TOOLKIT_ROOT_DIR}/extras/CUPTI/lib/${_cuda_windows_arch}")
-    elseif(IS_DIRECTORY "${CUDA_TOOLKIT_ROOT_DIR}/extras/CUPTI/lib64")
-      set(_cupti_bin "${CUDA_TOOLKIT_ROOT_DIR}/extras/CUPTI/lib64")
-    else()
-      unset(_cupti_bin)
     endif()
 
     set(_cuda_dll_patterns
@@ -118,12 +106,11 @@ if(WIN32 AND BUILD_PYTHON)
       "${_cuda_bin}/nvrtc*64_*.dll"
       "${_cuda_bin}/nvJitLink_*.dll"
       "${CUDA_TOOLKIT_ROOT_DIR}/bin/cudnn*64_*.dll"
+      "${CUDA_TOOLKIT_ROOT_DIR}/extras/CUPTI/lib/${_cuda_windows_arch}/cupti64_*.dll"
+      "${CUDA_TOOLKIT_ROOT_DIR}/extras/CUPTI/lib/${_cuda_windows_arch}/nvperf_host*.dll"
+      "${CUDA_TOOLKIT_ROOT_DIR}/extras/CUPTI/lib64/cupti64_*.dll"
+      "${CUDA_TOOLKIT_ROOT_DIR}/extras/CUPTI/lib64/nvperf_host*.dll"
     )
-    if(_cupti_bin)
-      list(APPEND _cuda_dll_patterns
-        "${_cupti_bin}/cupti64_*.dll"
-        "${_cupti_bin}/nvperf_host*.dll")
-    endif()
     foreach(_pattern ${_cuda_dll_patterns})
       file(GLOB _dlls "${_pattern}")
       if(_dlls)
@@ -132,7 +119,7 @@ if(WIN32 AND BUILD_PYTHON)
     endforeach()
 
     # NvToolsExt (legacy, may not exist on all systems).
-    set(_nvtoolsext "C:/Program Files/NVIDIA Corporation/NvToolsExt/bin/${_cuda_windows_arch}/nvToolsExt64_1.dll")
+    set(_nvtoolsext "C:/Program Files/NVIDIA Corporation/NvToolsExt/bin/x64/nvToolsExt64_1.dll")
     if(EXISTS "${_nvtoolsext}")
       install(FILES "${_nvtoolsext}" DESTINATION "${TORCH_INSTALL_LIB_DIR}")
     endif()

--- a/cmake/PostBuildSteps.cmake
+++ b/cmake/PostBuildSteps.cmake
@@ -83,12 +83,31 @@ if(WIN32 AND BUILD_PYTHON)
 
   # CUDA runtime DLLs - only for CUDA builds.
   if(USE_CUDA AND CUDA_TOOLKIT_ROOT_DIR)
-    # CUDA 13+ moves DLLs to bin/x64.
-    if(IS_DIRECTORY "${CUDA_TOOLKIT_ROOT_DIR}/bin/x64")
-      set(_cuda_bin "${CUDA_TOOLKIT_ROOT_DIR}/bin/x64")
+    # CUDA 13+ moves DLLs to an architecture-specific bin directory.
+    if(WIN32 AND CMAKE_SYSTEM_PROCESSOR STREQUAL "ARM64")
+      set(_cuda_windows_arch "arm64")
+    else()
+      set(_cuda_windows_arch "x64")
+    endif()
+
+    if(IS_DIRECTORY "${CUDA_TOOLKIT_ROOT_DIR}/bin/${_cuda_windows_arch}")
+      set(_cuda_bin "${CUDA_TOOLKIT_ROOT_DIR}/bin/${_cuda_windows_arch}")
     else()
       set(_cuda_bin "${CUDA_TOOLKIT_ROOT_DIR}/bin")
     endif()
+
+    # CUDA 13.4+ uses extras/CUPTI/lib/<arch>, while older Windows x64
+    # toolkits use extras/CUPTI/lib64. Never use lib64 for ARM64 because
+    # that legacy directory contains x64 binaries.
+    if(IS_DIRECTORY "${CUDA_TOOLKIT_ROOT_DIR}/extras/CUPTI/lib/${_cuda_windows_arch}")
+      set(_cupti_bin
+        "${CUDA_TOOLKIT_ROOT_DIR}/extras/CUPTI/lib/${_cuda_windows_arch}")
+    elseif(IS_DIRECTORY "${CUDA_TOOLKIT_ROOT_DIR}/extras/CUPTI/lib64")
+      set(_cupti_bin "${CUDA_TOOLKIT_ROOT_DIR}/extras/CUPTI/lib64")
+    else()
+      unset(_cupti_bin)
+    endif()
+
     set(_cuda_dll_patterns
       "${_cuda_bin}/cusparse*64_*.dll"
       "${_cuda_bin}/cublas*64_*.dll"
@@ -99,9 +118,12 @@ if(WIN32 AND BUILD_PYTHON)
       "${_cuda_bin}/nvrtc*64_*.dll"
       "${_cuda_bin}/nvJitLink_*.dll"
       "${CUDA_TOOLKIT_ROOT_DIR}/bin/cudnn*64_*.dll"
-      "${CUDA_TOOLKIT_ROOT_DIR}/extras/CUPTI/lib64/cupti64_*.dll"
-      "${CUDA_TOOLKIT_ROOT_DIR}/extras/CUPTI/lib64/nvperf_host*.dll"
     )
+    if(_cupti_bin)
+      list(APPEND _cuda_dll_patterns
+        "${_cupti_bin}/cupti64_*.dll"
+        "${_cupti_bin}/nvperf_host*.dll")
+    endif()
     foreach(_pattern ${_cuda_dll_patterns})
       file(GLOB _dlls "${_pattern}")
       if(_dlls)
@@ -110,7 +132,7 @@ if(WIN32 AND BUILD_PYTHON)
     endforeach()
 
     # NvToolsExt (legacy, may not exist on all systems).
-    set(_nvtoolsext "C:/Program Files/NVIDIA Corporation/NvToolsExt/bin/x64/nvToolsExt64_1.dll")
+    set(_nvtoolsext "C:/Program Files/NVIDIA Corporation/NvToolsExt/bin/${_cuda_windows_arch}/nvToolsExt64_1.dll")
     if(EXISTS "${_nvtoolsext}")
       install(FILES "${_nvtoolsext}" DESTINATION "${TORCH_INSTALL_LIB_DIR}")
     endif()


### PR DESCRIPTION
## Motivation

Windows Arm64 CUDA builds currently fail or require local patching because PyTorch’s build logic assumes Windows CUDA Toolkit libraries live under `lib/x64`.

## Summary

This PR adds Windows Arm64 CUDA Toolkit library layout support to PyTorch’s CUDA discovery and CUDA extension build paths (used by audio/vision etc).

The Windows Arm64 CUDA Toolkit uses architecture-specific library directories such as `lib/arm64`, while PyTorch currently assumes the existing Windows x64 layout, primarily `lib/x64`. This breaks CUDA Toolkit library discovery during PyTorch configuration and downstream CUDA extension builds against an installed PyTorch wheel.

This PR updates:

- PyTorch’s bundled `FindCUDAToolkit.cmake` to search `lib/arm64` and `lib/arm64/stubs` on Windows Arm64.
- PyTorch’s bundled legacy `FindCUDA.cmake` fallback to include `lib/arm64` for completeness.
- PyTorch's bundled `PostBuildSteps.cmake` to copy from correct CTK directories
- ~~`torch.utils.cpp_extension` so `CUDAExtension`, JIT extensions, torchvision, torchaudio, and other extension builds use `CUDA_HOME/lib/arm64` on native Windows Arm64.~~ -- moved to [191656](https://github.com/pytorch/pytorch/pull/191656)
- ~~`torch.utils.cpp_extension` Visual Studio environment selection to recognize `win-arm64`.~~ -- moved to [191656](https://github.com/pytorch/pytorch/pull/191656)
- ~~CUDA extension arch parsing for `10.3f`, `12.0f` and `12.1f`.~~

References:

- Windows Arm64 CUDA Toolkit Dev Preview: [WoA CTK Download](https://developer.nvidia.com/cuda-13-4-0-download-archive?target_os=Windows&target_arch=arm64)

This install has updated layout:

```
└── v13.4\
     └── bin
        ├── x64\
        └── arm64\
    └── lib
        ├── x64\
        └── arm64\
    └── extras\CUPTI\lib
        ├── x64\
        └── arm64\
        
```

## Details

For CMake discovery, the new Arm64 suffixes are prepended only when:

```cmake
WIN32 AND CMAKE_SYSTEM_PROCESSOR STREQUAL "ARM64"
```

## Testing

Validated locally with a Windows Arm64 PyTorch CUDA wheel build using the new CUDA Toolkit layout.

Also validated that CUDA extension library paths resolve to the Arm64 CUDA Toolkit directory when building against the resulting torch installation.

Existing Windows x64 behavior remains unchanged because `lib/x64` remains the default unless the Python platform and/or CMAKE_SYSTEM_PROCESSOR is Arm64.