### PR TITLE
Remove no-op MKLDNN_ENABLE_CONCURRENT_EXEC and dead sparselt stores

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,7 +352,6 @@ cmake_dependent_option(
 cmake_dependent_option(
   USE_MKLDNN_ACL "Use Compute Library for the Arm architecture." OFF
   "USE_MKLDNN AND CPU_AARCH64" OFF)
-set(MKLDNN_ENABLE_CONCURRENT_EXEC ${USE_MKLDNN})
 option(USE_STATIC_MKL "Prefer to link with MKL statically (Unix only)" OFF)
 cmake_dependent_option(
   USE_MPI "Use MPI for Caffe2. Only available if USE_DISTRIBUTED is on." ON

--- a/aten/CMakeLists.txt
+++ b/aten/CMakeLists.txt
@@ -86,19 +86,6 @@ else()
   set(AT_NNPACK_ENABLED 1)
 endif()
 
-if(NOT USE_CUSPARSELT)
-  set(AT_CUSPARSELT_ENABLED 0)
-else()
-  set(AT_CUSPARSELT_ENABLED 1)
-endif()
-
-# Add hipSPARSELt support flag if the package is available.
-if(USE_ROCM AND hipsparselt_FOUND)
-  set(AT_HIPSPARSELT_ENABLED 1)
-else()
-  set(AT_HIPSPARSELT_ENABLED 0)
-endif()
-
 list(APPEND ATen_CPU_INCLUDE
   ${CMAKE_CURRENT_SOURCE_DIR}/src)
 add_subdirectory(src/ATen)


### PR DESCRIPTION
- `MKLDNN_ENABLE_CONCURRENT_EXEC`: a no-op since the DNNL v1.2 upgrade (#32422) dropped the old option name. Deleting rather than renaming to `DNNL_ENABLE_CONCURRENT_EXEC` preserves the behavior PyTorch has shipped since 2020.
- `AT_CUSPARSELT_ENABLED`/`AT_HIPSPARSELT_ENABLED` sets in aten/CMakeLists.txt: dead stores since their introduction (#103700, #150578) — aten/src/ATen/CMakeLists.txt recomputes both via `set_bool()` before the only consumer, the CUDAConfig.h.in `configure_file`.