### PR TITLE
Fix _scaled_mm dropping scale_result on the fp8 output path

### DIFF
--- a/aten/src/ATen/native/cuda/ScaledBlas.cpp
+++ b/aten/src/ATen/native/cuda/ScaledBlas.cpp
@@ -384,8 +384,9 @@ _scaled_gemm(
           const std::optional<Tensor>& bias,
           const bool use_fast_accum,
           Tensor& out,
-          const std::optional<Tensor>& alpha = std::nullopt) {
-  cublasCommonArgs args(mat1, mat2, out, scale_a, scale_b, std::nullopt, scaling_choice_a, scaling_choice_b);
+          const std::optional<Tensor>& alpha = std::nullopt,
+          const std::optional<Tensor>& scale_result = std::nullopt) {
+  cublasCommonArgs args(mat1, mat2, out, scale_a, scale_b, scale_result, scaling_choice_a, scaling_choice_b);
   const auto out_dtype_ = args.result->scalar_type();
   // H100 only supports row-major x column-major, but all permutaitons are supported on Blackwells
   if (_scaled_mm_allowed_device(true, false)) {
@@ -662,7 +663,7 @@ _scaled_mm_out_cuda(const Tensor& mat1, const Tensor& mat2,
 #endif
   }
 
-  return _scaled_gemm(mat1, mat2, scale_a, scale_b, scaling_choice_a, scaling_choice_b, bias, use_fast_accum, out);
+  return _scaled_gemm(mat1, mat2, scale_a, scale_b, scaling_choice_a, scaling_choice_b, bias, use_fast_accum, out, /*alpha=*/std::nullopt, scale_result);
 }
 
 Tensor

--- a/aten/src/ATen/native/cuda/ScaledBlas.cpp
+++ b/aten/src/ATen/native/cuda/ScaledBlas.cpp
@@ -663,7 +663,13 @@ _scaled_mm_out_cuda(const Tensor& mat1, const Tensor& mat2,
 #endif
   }
 
-  return _scaled_gemm(mat1, mat2, scale_a, scale_b, scaling_choice_a, scaling_choice_b, bias, use_fast_accum, out, /*alpha=*/std::nullopt, scale_result);
+  // scale_result is only utilized when the output is a float8 type; for 16 and
+  // 32-bit outputs it is documented as not applied. Gate the forwarding: recent
+  // cuBLASLt versions reject CUBLASLT_MATMUL_DESC_D_SCALE_POINTER for non-fp8
+  // outputs instead of ignoring it.
+  const std::optional<Tensor> scale_result_fwd =
+      isFloat8Type(out.scalar_type()) ? scale_result : std::optional<Tensor>{};
+  return _scaled_gemm(mat1, mat2, scale_a, scale_b, scaling_choice_a, scaling_choice_b, bias, use_fast_accum, out, /*alpha=*/std::nullopt, scale_result_fwd);
 }
 
 Tensor

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -732,6 +732,30 @@ class TestFP8Matmul(TestCase):
         out_fp8_s = scaled_mm_wrap(x, y, scale_a=scale_a, scale_b=scale_b)
         self.assertEqual(out_fp8, out_fp8_s)
 
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
+    def test_float8_scale_result(self, device) -> None:
+        # scale_result must scale the fp8 output. Regression guard for the v1
+        # _scaled_mm path silently dropping scale_result. Integer operands with
+        # K=16 keep the fp32-accumulated products and their 0.5x scaling exact in
+        # e4m3, so any deviation is a real bug rather than floating point rounding.
+        torch.manual_seed(0)
+        M, K, N = 16, 16, 16
+        x = torch.randint(-1, 2, (M, K), device=device).float().to(e4m3_type)
+        # hipblaslt does not yet support mixed e4m3_type input
+        y_type = e4m3_type if torch.version.hip else e5m2_type
+        y = torch.randint(-1, 2, (N, K), device=device).float().to(y_type).t()
+        one = torch.tensor(1.0, device=device)
+        half = torch.tensor(0.5, device=device)
+        out_unscaled = scaled_mm_wrap(
+            x, y, scale_a=one, scale_b=one, scale_result=one,
+            out_dtype=e4m3_type, wrap_v2=False,
+        )
+        out_scaled = scaled_mm_wrap(
+            x, y, scale_a=one, scale_b=one, scale_result=half,
+            out_dtype=e4m3_type, wrap_v2=False,
+        )
+        self.assertEqual(out_scaled.to(torch.float), 0.5 * out_unscaled.to(torch.float))
+
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_MXFP8_GROUPED_GEMM, mxfp8_grouped_mm_skip_msg)
     @parametrize("G", [1, 4, 16])

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -732,12 +732,15 @@ class TestFP8Matmul(TestCase):
         out_fp8_s = scaled_mm_wrap(x, y, scale_a=scale_a, scale_b=scale_b)
         self.assertEqual(out_fp8, out_fp8_s)
 
+    @onlyCUDA
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
     def test_float8_scale_result(self, device) -> None:
         # scale_result must scale the fp8 output. Regression guard for the v1
         # _scaled_mm path silently dropping scale_result. Integer operands with
         # K=16 keep the fp32-accumulated products and their 0.5x scaling exact in
         # e4m3, so any deviation is a real bug rather than floating point rounding.
+        # CUDA-only: the CPU implementation divides by scale_result instead of
+        # multiplying, a cross-backend divergence tracked in #190449.
         torch.manual_seed(0)
         M, K, N = 16, 16, 16
         x = torch.randint(-1, 2, (M, K), device=device).float().to(e4m3_type)
@@ -755,6 +758,20 @@ class TestFP8Matmul(TestCase):
             out_dtype=e4m3_type, wrap_v2=False,
         )
         self.assertEqual(out_scaled.to(torch.float), 0.5 * out_unscaled.to(torch.float))
+
+        # For 16/32-bit outputs scale_result is documented as not applied: the
+        # call must be accepted (recent cuBLASLt rejects a D-scale on non-fp8
+        # outputs, so forwarding it is the regression this guards) and the
+        # result must match the call without scale_result.
+        out_bf16 = scaled_mm_wrap(
+            x, y, scale_a=one, scale_b=one,
+            out_dtype=torch.bfloat16, wrap_v2=False,
+        )
+        out_bf16_sr = scaled_mm_wrap(
+            x, y, scale_a=one, scale_b=one, scale_result=half,
+            out_dtype=torch.bfloat16, wrap_v2=False,
+        )
+        self.assertEqual(out_bf16_sr, out_bf16)
 
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_MXFP8_GROUPED_GEMM, mxfp8_grouped_mm_skip_msg)


### PR DESCRIPTION
Fixes #190449.

## Summary

The v1 `_scaled_mm` entry point (`_scaled_mm_out_cuda`) validates `scale_result` but never forwards it: it calls `_scaled_gemm` without it, so `CUBLASLT_MATMUL_DESC_D_SCALE_POINTER` is never set and a requested fp8 output scale is silently ignored (implicit scale 1.0). This is a regression from the Blas.cpp to ScaledBlas.cpp refactor; torch 2.9.1 honored the result scale.

The fix threads `scale_result` through `_scaled_gemm` into `cublasCommonArgs`, gated on the output dtype being a float8 type. The gate matters: the documented contract is that `scale_result` "is only utilized if the output is a float8 type", and while CUDA-12-era cuBLASLt silently ignored a D-scale on non-fp8 outputs (which is why 2.9.1's unconditional forwarding worked), the CUDA 13 toolchain rejects it with `CUBLAS_STATUS_INVALID_VALUE`. An earlier revision of this PR forwarded unconditionally and broke `inductor/test_fp8.py::test_scaled_mm_pdl_handles_none_bias`, which passes `scale_result` with a bf16 `out_dtype`.

Only the v1 tensorwise path opts in; the v2 scaling recipes keep their previous behavior.

## Test

`test_float8_scale_result` uses integer operands with K=16 so the fp32-accumulated products and their 0.5x scaling are exact in e4m3: any deviation is a real bug rather than rounding. A second arm asserts that a bf16-output call with `scale_result` is accepted and the scale is not applied. The test is gated to CUDA: the CPU implementation divides by `scale_result` where cuBLASLt multiplies, a cross-backend divergence documented on #190449.

## Verification

On an H100 source build of this branch (CUDA 12.8):

- `test_float8_scale_result` passes.
- fp8 output scales multiplicatively (scale 0.5 gives exactly 0.5x output); bf16 output with `scale_result` is accepted and unchanged.
- Stock torch 2.9.1+cu128 on the same GPU shows identical multiply semantics and identical bf16-ignored behavior, confirming this restores the historical contract.

```
python test/test_scaled_matmul_cuda.py -k test_float8_scale_result
```

*This PR was authored with assistance from Claude; the fix, semantics analysis, and H100 verification were human-reviewed.*
