### PR TITLE
Remove dead uv_a include workaround

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1256,10 +1256,6 @@ if(USE_GLOO)
       set(ENV{GLOO_ROCM_ARCH} "${PYTORCH_ROCM_ARCH}")
     endif()
     if(NOT USE_SYSTEM_GLOO)
-      if(USE_DISTRIBUED AND USE_TENSORPIPE)
-        get_target_property(_include_dirs uv_a INCLUDE_DIRECTORIES)
-        set_target_properties(uv_a PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${_include_dirs}")
-      endif()
       set(GLOO_USE_CUDA_TOOLKIT ON CACHE BOOL "" FORCE)
 
       # Disable NCCL/RCCL since we don't use Gloo+NCCL, make sure to re-enable it!


### PR DESCRIPTION
This block from #77312 has never executed: the condition misspells `USE_DISTRIBUTED` as `USE_DISTRIBUED`, which is never set. Gloo has always gotten the vendored libuv headers through the directory-level `include_directories(BEFORE SYSTEM .../tensorpipe/third_party/libuv/include)` a few lines above, so the workaround is redundant. Deleting the block (rather than fixing the typo) preserves shipped behavior instead of activating a four-year-dormant property overwrite.