### PR TITLE
Remove dead USE_ROCM_CK_SDPA env override block

### DIFF
--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -204,13 +204,6 @@ file(GLOB flash_attention_hip_hip CONFIGURE_DEPENDS "native/transformers/hip/fla
 if(USE_FLASH_ATTENTION)
   # Now building CK by default
   if(USE_ROCM)
-    if(DEFINED ENV{USE_ROCM_CK_SDPA})
-        if(ENV{USE_ROCM_CK_SDPA} EQUAL 1)
-          caffe2_update_option(USE_ROCM_CK_SDPA ON)
-        endif()
-    elseif(NOT WIN32)
-      caffe2_update_option(USE_ROCM_CK_SDPA ON)
-    endif()
     # CK SDPA only supports gfx942/gfx950. Auto-disable when none of those archs
     # are in PYTORCH_ROCM_ARCH; otherwise the ck_sdpa target ends up with an
     # empty HIP_ARCHITECTURES and CMake errors out.


### PR DESCRIPTION
The `if(ENV{USE_ROCM_CK_SDPA} EQUAL 1)` condition is missing a `$`, so it compares a literal string and has never been true: whenever the env var is set (to 0 or 1), this block does nothing. It was never missed because the intended semantics are already covered elsewhere — cmake/EnvVarForwarding.cmake forwards `USE_ROCM_CK_SDPA` from the environment into the cache before options are declared, and the `cmake_dependent_option` default is already ON for ROCm non-Windows builds.

Deleting the block rather than fixing the `$` avoids two regressions: a fixed condition would force CK SDPA ON on Windows (the env branch has no WIN32 guard, defeating the exclusion from #183962), and the live `elseif(NOT WIN32)` force-ON silently clobbered an explicit `-DUSE_ROCM_CK_SDPA=OFF`. With the block gone, an explicit opt-out is honored; all other configurations behave as before. The gfx942/gfx950 arch check is kept.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang