### PR TITLE
Remove dead ROCM_SOURCE_DIR block in caffe2

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1483,13 +1483,6 @@ if(USE_ROCM)
     __HIP_PLATFORM_AMD__
     )
 
-  if(NOT ROCM_SOURCE_DIR)
-    set(ROCM_SOURCE_DIR "$ENV{ROCM_SOURCE_DIR}")
-  endif()
-  if($ROCM_SOURCE_DIR STREQUAL "")
-    set(ROCM_SOURCE_DIR "/opt/rocm")
-  endif()
-  message(INFO "caffe2 ROCM_SOURCE_DIR = ${ROCM_SOURCE_DIR}")
   if(USE_FLASH_ATTENTION)
     target_compile_definitions(torch_hip PRIVATE
         USE_FLASH_ATTENTION


### PR DESCRIPTION
`if($ROCM_SOURCE_DIR STREQUAL "")` is missing braces, so it compares a literal token and is always false: the `/opt/rocm` fallback has never applied. The `target_include_directories` this variable used to feed was removed in #152569, leaving a malformed `message(INFO ...)` (INFO is not a message mode) as the only consumer. Kineto receives `ROCM_SOURCE_DIR` independently via cmake/Dependencies.cmake, so the whole block can go.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang