### PR TITLE
Remove appends to nonexistent CMAKE_LINKER_FLAGS_DEBUG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1190,10 +1190,8 @@ if(NOT MSVC)
       message(Warning "Applying -Og optimization for aarch64 GCC debug build to workaround ICE")
     endif()
     string(APPEND CMAKE_CXX_FLAGS_DEBUG " -fno-omit-frame-pointer -Og")
-    string(APPEND CMAKE_LINKER_FLAGS_DEBUG " -fno-omit-frame-pointer -Og")
   else()
     string(APPEND CMAKE_CXX_FLAGS_DEBUG " -fno-omit-frame-pointer -O0")
-    string(APPEND CMAKE_LINKER_FLAGS_DEBUG " -fno-omit-frame-pointer -O0")
   endif()
   # aarch64 C++ stack unwinding uses frame-pointer chain walking, so frame
   # pointers must be present in all build types.  The cost is negligible on


### PR DESCRIPTION
`CMAKE_LINKER_FLAGS_DEBUG` is not a CMake variable (the real ones are `CMAKE_{EXE,SHARED,MODULE}_LINKER_FLAGS_DEBUG`), so these appends have never reached the linker. Nothing is lost: `-fno-omit-frame-pointer` and `-Og`/`-O0` are code-generation flags that non-LTO link invocations ignore anyway, and the compile side is already covered by the adjacent `CMAKE_CXX_FLAGS_DEBUG` appends. Deleting rather than renaming avoids changing link-time codegen in untested Debug+LTO configurations.