### PR TITLE
Remove dead pre-CUDA-12.1 --source-in-ptx branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1001,12 +1001,6 @@ endif()
 if(DEBUG_CUDA)
   string(APPEND CMAKE_CUDA_FLAGS_DEBUG " -lineinfo")
   string(APPEND CMAKE_CUDA_FLAGS_RELWITHDEBINFO " -lineinfo")
-  # CUDA-12.1 crashes when trying to compile with --source-in-ptx See
-  # https://github.com/pytorch/pytorch/issues/102372#issuecomment-1572526893
-  if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 12.1)
-    string(APPEND CMAKE_CUDA_FLAGS_DEBUG " --source-in-ptx")
-    string(APPEND CMAKE_CUDA_FLAGS_RELWITHDEBINFO " --source-in-ptx")
-  endif()
 endif(DEBUG_CUDA)
 
 if(USE_FBGEMM)


### PR DESCRIPTION
cmake/public/cuda.cmake rejects CUDA < 12.1 with FATAL_ERROR, so the `VERSION_LESS 12.1` condition is always false. Not passing `--source-in-ptx` on 12.1+ is the intended behavior from #102756 (nvcc 12.1 segfaults on the flag, #102372), and whether newer nvcc fixed it is unverified, so the flag is not promoted to unconditional. `-lineinfo` is kept.