### PR TITLE
Remove unreachable duplicate CUDA+ROCm check in ATen

### DIFF
--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -580,10 +580,6 @@ else()
   set(all_cpu_cpp ${all_cpu_cpp} ${metal_cpp})
 endif()
 
-if(USE_CUDA AND USE_ROCM)
-  message(FATAL_ERROR "ATen doesn't not currently support simultaneously building with CUDA and ROCM")
-endif()
-
 if(USE_CUDA)
   list(APPEND ATen_CUDA_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/cuda)
   # Next two lines are needed because TunableOp uses third-party/fmt


### PR DESCRIPTION
aten/CMakeLists.txt performs the same USE_CUDA+USE_ROCM FATAL_ERROR (after LoadHIP, on the final USE_ROCM value) before it reaches `add_subdirectory(src/ATen)`, so this inner copy can never fire. Its message also contains a double negative ("doesn't not").

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang