### PR TITLE
Fix inert typos in top-level CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ set(CMAKE_CXX_STANDARD
     20
     CACHE STRING
           "The C++ standard whose features are requested to build this target.")
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_C_STANDARD
     17
     CACHE STRING
@@ -83,10 +84,6 @@ endif()
 # https://github.com/NVIDIA/cccl/blob/main/docs/libcudacxx/standard_api/numerics_library/complex.rst
 string(APPEND CMAKE_CUDA_FLAGS
        " -DLIBCUDACXX_ENABLE_SIMPLIFIED_COMPLEX_OPERATIONS")
-
-if(LINUX)
-  set(CXX_STANDARD_REQUIRED ON)
-endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_LINK_WHAT_YOU_USE TRUE)
@@ -839,7 +836,7 @@ if("${TORCH_DEFAULT_VERSION} " STREQUAL " ")
   message(WARNING "Could not get version from base 'version.txt'")
   # If we can't get the version from the version file we should probably set it
   # to something non-sensical like 0.0.0
-  set(TORCH_DEFAULT_VERSION, "0.0.0")
+  set(TORCH_DEFAULT_VERSION "0.0.0")
 endif()
 set(TORCH_BUILD_VERSION
     "${TORCH_DEFAULT_VERSION}"
@@ -1187,7 +1184,7 @@ if(NOT MSVC)
   append_cxx_flag_if_supported("-fstandalone-debug" CMAKE_CXX_FLAGS_DEBUG)
   if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64" AND CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     if(CMAKE_BUILD_TYPE MATCHES Debug)
-      message(Warning "Applying -Og optimization for aarch64 GCC debug build to workaround ICE")
+      message(WARNING "Applying -Og optimization for aarch64 GCC debug build to workaround ICE")
     endif()
     string(APPEND CMAKE_CXX_FLAGS_DEBUG " -fno-omit-frame-pointer -Og")
     string(APPEND CMAKE_LINKER_FLAGS_DEBUG " -fno-omit-frame-pointer -Og")
@@ -1256,7 +1253,7 @@ if(USE_CPP_CODE_COVERAGE)
     string(APPEND CMAKE_OBJCXX_FLAGS " -fprofile-instr-generate -fcoverage-mapping")
   else()
     message(
-      ERROR
+      FATAL_ERROR
       "Code coverage for compiler ${CMAKE_CXX_COMPILER_ID} is unsupported")
   endif()
 


### PR DESCRIPTION
Three small fixes, none changing behavior for currently supported configurations:

- `set(CXX_STANDARD_REQUIRED ON)` was missing the `CMAKE_` prefix (and was Linux-only), so it never did anything; now `CMAKE_CXX_STANDARD_REQUIRED ON` sits next to `CMAKE_CXX_STANDARD`. All supported compilers accept `-std=c++20`, so this only turns a hypothetical silent standard fallback into an error.
- `set(TORCH_DEFAULT_VERSION, "0.0.0")` set a variable literally named `TORCH_DEFAULT_VERSION,`; the fallback branch is currently unreachable (version.txt is checked in, and `file(READ)` errors first if it were missing), but now it would actually work.
- `message(Warning ...)` and `message(ERROR ...)` are not valid message modes and printed as NOTICE text. The aarch64 `-Og` note becomes a real WARNING, and requesting `USE_CPP_CODE_COVERAGE` with a compiler that has no coverage support now fails at configure time instead of silently producing an uninstrumented build (GCC and all Clang variants are unaffected).