### PR TITLE
Fix always-false env check in BLAS=Generic branch

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -275,7 +275,7 @@ elseif(BLAS STREQUAL "APL")
   set(BLAS_CHECK_F2C 1)
 elseif(BLAS STREQUAL "Generic")
   # On Debian family, the CBLAS ABIs have been merged into libblas.so
-  if(ENV{GENERIC_BLAS_LIBRARIES} STREQUAL "")
+  if("$ENV{GENERIC_BLAS_LIBRARIES}" STREQUAL "")
     set(GENERIC_BLAS "blas")
   else()
     set(GENERIC_BLAS $ENV{GENERIC_BLAS_LIBRARIES})


### PR DESCRIPTION
`if(ENV{GENERIC_BLAS_LIBRARIES} STREQUAL "")` is missing the `$`, so it compares a literal string and always takes the else branch. With the env var unset, `GENERIC_BLAS` ends up empty and `find_library(BLAS_LIBRARIES NAMES)` has no candidates, so `BLAS=Generic` without `GENERIC_BLAS_LIBRARIES` fails at generate time with a NOTFOUND error. Fixing the check restores the pre-#74269 default of looking for `libblas`. Users who do set the env var (the Spack use case #74269 was added for) are unaffected.