### PR TITLE
Remove broken guard around BUNDLE_PTXAS copy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1461,11 +1461,9 @@ endif()
 
 # Bundle PTXAS if needed
 if(BUILD_BUNDLE_PTXAS AND USE_CUDA)
-  if(NOT EXISTS "${PROJECT_SOURCE_DIR}/build/bin/ptxas")
-    message(STATUS "Copying PTXAS into the bin folder")
-    file(COPY "${CUDAToolkit_BIN_DIR}/ptxas"
-         DESTINATION "${PROJECT_BINARY_DIR}")
-  endif()
+  message(STATUS "Copying PTXAS into the bin folder")
+  file(COPY "${CUDAToolkit_BIN_DIR}/ptxas"
+       DESTINATION "${PROJECT_BINARY_DIR}")
   install(PROGRAMS "${PROJECT_BINARY_DIR}/ptxas"
           DESTINATION "${CMAKE_INSTALL_BINDIR}")
 endif()


### PR DESCRIPTION
The guard checks `${PROJECT_SOURCE_DIR}/build/bin/ptxas`, a path this code never produces (the copy lands at `${PROJECT_BINARY_DIR}/ptxas`), so it has been always-true since #119750. `file(COPY)` already skips the copy when the destination exists with the same timestamp, so the guard is unnecessary rather than worth repairing.