### PR TITLE
Fix inverted BUILD_LIBTORCHLESS guard in c10/xpu

### DIFF
--- a/c10/xpu/CMakeLists.txt
+++ b/c10/xpu/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 include(../../cmake/public/xpu.cmake)
 
-if(NOT BUILD_LIBTORCHLESS)
+if(BUILD_LIBTORCHLESS)
   find_library(C10_XPU_LIB c10_xpu PATHS $ENV{LIBTORCH_LIB_PATH} NO_DEFAULT_PATH)
 endif()
 


### PR DESCRIPTION
c10/cuda and c10/hip run `find_library` for the prebuilt library when `BUILD_LIBTORCHLESS` is on; the XPU copy inverted the condition, so regular builds run a pointless `find_library` and libtorchless builds never set `C10_XPU_LIB` (currently latent because the XPU test subdirectory is guarded by the same inverted condition). This aligns the guard with cuda/hip. Regular builds lose the no-op `find_library`; libtorchless builds gain a correctly populated `C10_XPU_LIB`. The test subdirectory placement is left as is.