### PR TITLE
Remove always-false CMake blocks caused by typos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1190,10 +1190,8 @@ if(NOT MSVC)
       message(Warning "Applying -Og optimization for aarch64 GCC debug build to workaround ICE")
     endif()
     string(APPEND CMAKE_CXX_FLAGS_DEBUG " -fno-omit-frame-pointer -Og")
-    string(APPEND CMAKE_LINKER_FLAGS_DEBUG " -fno-omit-frame-pointer -Og")
   else()
     string(APPEND CMAKE_CXX_FLAGS_DEBUG " -fno-omit-frame-pointer -O0")
-    string(APPEND CMAKE_LINKER_FLAGS_DEBUG " -fno-omit-frame-pointer -O0")
   endif()
   # aarch64 C++ stack unwinding uses frame-pointer chain walking, so frame
   # pointers must be present in all build types.  The cost is negligible on

--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -204,13 +204,6 @@ file(GLOB flash_attention_hip_hip CONFIGURE_DEPENDS "native/transformers/hip/fla
 if(USE_FLASH_ATTENTION)
   # Now building CK by default
   if(USE_ROCM)
-    if(DEFINED ENV{USE_ROCM_CK_SDPA})
-        if(ENV{USE_ROCM_CK_SDPA} EQUAL 1)
-          caffe2_update_option(USE_ROCM_CK_SDPA ON)
-        endif()
-    elseif(NOT WIN32)
-      caffe2_update_option(USE_ROCM_CK_SDPA ON)
-    endif()
     # CK SDPA only supports gfx942/gfx950. Auto-disable when none of those archs
     # are in PYTORCH_ROCM_ARCH; otherwise the ck_sdpa target ends up with an
     # empty HIP_ARCHITECTURES and CMake errors out.

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1483,13 +1483,6 @@ if(USE_ROCM)
     __HIP_PLATFORM_AMD__
     )
 
-  if(NOT ROCM_SOURCE_DIR)
-    set(ROCM_SOURCE_DIR "$ENV{ROCM_SOURCE_DIR}")
-  endif()
-  if($ROCM_SOURCE_DIR STREQUAL "")
-    set(ROCM_SOURCE_DIR "/opt/rocm")
-  endif()
-  message(INFO "caffe2 ROCM_SOURCE_DIR = ${ROCM_SOURCE_DIR}")
   if(USE_FLASH_ATTENTION)
     target_compile_definitions(torch_hip PRIVATE
         USE_FLASH_ATTENTION

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1256,10 +1256,6 @@ if(USE_GLOO)
       set(ENV{GLOO_ROCM_ARCH} "${PYTORCH_ROCM_ARCH}")
     endif()
     if(NOT USE_SYSTEM_GLOO)
-      if(USE_DISTRIBUED AND USE_TENSORPIPE)
-        get_target_property(_include_dirs uv_a INCLUDE_DIRECTORIES)
-        set_target_properties(uv_a PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${_include_dirs}")
-      endif()
       set(GLOO_USE_CUDA_TOOLKIT ON CACHE BOOL "" FORCE)
 
       # Disable NCCL/RCCL since we don't use Gloo+NCCL, make sure to re-enable it!


### PR DESCRIPTION
Four blocks whose conditions have never been true because of a typo, each with a compensating mechanism that made the breakage invisible:

- **uv_a include workaround** (cmake/Dependencies.cmake, from #77312): the condition misspells `USE_DISTRIBUTED` as `USE_DISTRIBUED`. Gloo gets the vendored libuv headers via the directory-level `include_directories` above it.
- **USE_ROCM_CK_SDPA env override** (aten/src/ATen/CMakeLists.txt, from #178310): `if(ENV{USE_ROCM_CK_SDPA} EQUAL 1)` is missing a `$`. EnvVarForwarding.cmake already forwards the env var into the cache and the `cmake_dependent_option` default is ON; removing the block also stops the `elseif(NOT WIN32)` force-ON from clobbering an explicit `-DUSE_ROCM_CK_SDPA=OFF`.
- **ROCM_SOURCE_DIR fallback** (caffe2/CMakeLists.txt, from #120898): `if($ROCM_SOURCE_DIR STREQUAL "")` is missing braces. The include it fed was removed in #152569; the only remaining consumer was a malformed `message(INFO ...)`.
- **CMAKE_LINKER_FLAGS_DEBUG appends** (CMakeLists.txt): not a real CMake variable (the real ones are `CMAKE_{EXE,SHARED,MODULE}_LINKER_FLAGS_DEBUG`); the flags are codegen flags already applied via the adjacent `CMAKE_CXX_FLAGS_DEBUG` appends.

Deleting rather than fixing the typos preserves shipped behavior instead of activating years-dormant, untested code paths (a fixed CK SDPA condition would force it ON on Windows, defeating #183962).