### PR TITLE
Fix broken conditions and typos in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ set(CMAKE_CXX_STANDARD
     20
     CACHE STRING
           "The C++ standard whose features are requested to build this target.")
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_C_STANDARD
     17
     CACHE STRING
@@ -83,10 +84,6 @@ endif()
 # https://github.com/NVIDIA/cccl/blob/main/docs/libcudacxx/standard_api/numerics_library/complex.rst
 string(APPEND CMAKE_CUDA_FLAGS
        " -DLIBCUDACXX_ENABLE_SIMPLIFIED_COMPLEX_OPERATIONS")
-
-if(LINUX)
-  set(CXX_STANDARD_REQUIRED ON)
-endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_LINK_WHAT_YOU_USE TRUE)
@@ -839,7 +836,7 @@ if("${TORCH_DEFAULT_VERSION} " STREQUAL " ")
   message(WARNING "Could not get version from base 'version.txt'")
   # If we can't get the version from the version file we should probably set it
   # to something non-sensical like 0.0.0
-  set(TORCH_DEFAULT_VERSION, "0.0.0")
+  set(TORCH_DEFAULT_VERSION "0.0.0")
 endif()
 set(TORCH_BUILD_VERSION
     "${TORCH_DEFAULT_VERSION}"
@@ -1187,7 +1184,7 @@ if(NOT MSVC)
   append_cxx_flag_if_supported("-fstandalone-debug" CMAKE_CXX_FLAGS_DEBUG)
   if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64" AND CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     if(CMAKE_BUILD_TYPE MATCHES Debug)
-      message(Warning "Applying -Og optimization for aarch64 GCC debug build to workaround ICE")
+      message(WARNING "Applying -Og optimization for aarch64 GCC debug build to workaround ICE")
     endif()
     string(APPEND CMAKE_CXX_FLAGS_DEBUG " -fno-omit-frame-pointer -Og")
     string(APPEND CMAKE_LINKER_FLAGS_DEBUG " -fno-omit-frame-pointer -Og")
@@ -1256,7 +1253,7 @@ if(USE_CPP_CODE_COVERAGE)
     string(APPEND CMAKE_OBJCXX_FLAGS " -fprofile-instr-generate -fcoverage-mapping")
   else()
     message(
-      ERROR
+      FATAL_ERROR
       "Code coverage for compiler ${CMAKE_CXX_COMPILER_ID} is unsupported")
   endif()
 
@@ -1461,11 +1458,9 @@ endif()
 
 # Bundle PTXAS if needed
 if(BUILD_BUNDLE_PTXAS AND USE_CUDA)
-  if(NOT EXISTS "${PROJECT_SOURCE_DIR}/build/bin/ptxas")
-    message(STATUS "Copying PTXAS into the bin folder")
-    file(COPY "${CUDAToolkit_BIN_DIR}/ptxas"
-         DESTINATION "${PROJECT_BINARY_DIR}")
-  endif()
+  message(STATUS "Copying PTXAS into the bin folder")
+  file(COPY "${CUDAToolkit_BIN_DIR}/ptxas"
+       DESTINATION "${PROJECT_BINARY_DIR}")
   install(PROGRAMS "${PROJECT_BINARY_DIR}/ptxas"
           DESTINATION "${CMAKE_INSTALL_BINDIR}")
 endif()

--- a/c10/xpu/CMakeLists.txt
+++ b/c10/xpu/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 include(../../cmake/public/xpu.cmake)
 
-if(NOT BUILD_LIBTORCHLESS)
+if(BUILD_LIBTORCHLESS)
   find_library(C10_XPU_LIB c10_xpu PATHS $ENV{LIBTORCH_LIB_PATH} NO_DEFAULT_PATH)
 endif()
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -275,7 +275,7 @@ elseif(BLAS STREQUAL "APL")
   set(BLAS_CHECK_F2C 1)
 elseif(BLAS STREQUAL "Generic")
   # On Debian family, the CBLAS ABIs have been merged into libblas.so
-  if(ENV{GENERIC_BLAS_LIBRARIES} STREQUAL "")
+  if("$ENV{GENERIC_BLAS_LIBRARIES}" STREQUAL "")
     set(GENERIC_BLAS "blas")
   else()
     set(GENERIC_BLAS $ENV{GENERIC_BLAS_LIBRARIES})


### PR DESCRIPTION
Small fixes to conditions and settings that were silently doing nothing:

- **`BLAS=Generic` env check** (cmake/Dependencies.cmake): `if(ENV{GENERIC_BLAS_LIBRARIES} STREQUAL "")` is missing the `$` and always took the else branch, so `BLAS=Generic` without the env var gave `find_library` no candidates and failed at generate time. Fixing it restores the pre-#74269 default of looking for `libblas`; the Spack use case that sets the env var is unaffected.
- **`CMAKE_CXX_STANDARD_REQUIRED`** (CMakeLists.txt): was set without the `CMAKE_` prefix (and only on Linux), i.e. never took effect; now declared next to `CMAKE_CXX_STANDARD`. All supported compilers accept `-std=c++20`, so this only turns a hypothetical silent standard fallback into an error.
- **`TORCH_DEFAULT_VERSION` fallback** (CMakeLists.txt): `set(TORCH_DEFAULT_VERSION, "0.0.0")` set a variable literally named with a trailing comma; the branch is currently unreachable but now works as intended.
- **message modes** (CMakeLists.txt): `message(Warning ...)` and `message(ERROR ...)` are not valid modes and printed as NOTICE text. The aarch64 `-Og` note becomes a real WARNING; requesting `USE_CPP_CODE_COVERAGE` with a compiler lacking coverage support now fails at configure time instead of silently producing an uninstrumented build (GCC and all Clang variants unaffected).
- **BUNDLE_PTXAS guard** (CMakeLists.txt): checked a path the code never produces, so it was always true; `file(COPY)` is already incremental, the guard is dropped.
- **c10/xpu `BUILD_LIBTORCHLESS` guard**: inverted relative to c10/cuda and c10/hip; regular builds ran a pointless `find_library` while libtorchless builds never set `C10_XPU_LIB`. Aligned with the cuda/hip pattern.