### PR TITLE
Fix typos in comments and docstrings across torch modules

### DIFF
--- a/torch/_dynamo/create_parameter_op.py
+++ b/torch/_dynamo/create_parameter_op.py
@@ -48,7 +48,7 @@ def new_parameter_placeholder(
         torch.empty(size, dtype=dtype, device=device), requires_grad=requires_grad
     )
     # TODO(jansel): alloc followed by free is inefficient, need a way to allocate an unbacked tensor.
-    # Allocating a zero tensor would causes assert failures in autograd.
+    # Allocating a zero tensor would cause assert failures in autograd.
     result.untyped_storage().resize_(0)
     return result
 

--- a/torch/_export/passes/replace_quantized_ops_with_standard_ops_pass.py
+++ b/torch/_export/passes/replace_quantized_ops_with_standard_ops_pass.py
@@ -644,7 +644,7 @@ def replace_quantized_ops_with_standard_ops(gm: torch.fx.GraphModule):
                 else:
                     last_quantized_node = node
 
-    # Post-processing again to remove legacy ScriptObjects and quantizated tensors
+    # Post-processing again to remove legacy ScriptObjects and quantized tensors
     # stored as attributes or in the buffer. This is used to clean up the GraphModule
     # to not trigger tracing errors like missing __obj_flatten__ functions.
     def _clean_attr(mod: torch.nn.Module):

--- a/torch/_functorch/_aot_autograd/schemas.py
+++ b/torch/_functorch/_aot_autograd/schemas.py
@@ -1246,7 +1246,7 @@ class AOTState:
 
     # Whether or not we need to handle autograd when doing graph capture and
     # compilation.  Although the calling convention for non-autograd graph
-    # capture in AOTAutograd is simple and can be relied upon, the autograph
+    # capture in AOTAutograd is simple and can be relied upon, the autograd
     # capture calling convention is quite complicated and in general you are
     # only expected to pass to aot_stage2_compile to process.
     needs_autograd: bool

--- a/torch/_functorch/eager_transforms.py
+++ b/torch/_functorch/eager_transforms.py
@@ -591,7 +591,7 @@ def jacrev(
         >>> assert torch.allclose(hessian, torch.diag(-x.sin()))
 
     By default, :func:`jacrev` computes the Jacobian with respect to the first
-    input. However, it can compute the Jacboian with respect to a different
+    input. However, it can compute the Jacobian with respect to a different
     argument by using ``argnums``:
 
         >>> from torch.func import jacrev
@@ -1335,7 +1335,7 @@ def jacfwd(
         >>> assert torch.allclose(hessian, torch.diag(-x.sin()))
 
     By default, :func:`jacfwd` computes the Jacobian with respect to the first
-    input. However, it can compute the Jacboian with respect to a different
+    input. However, it can compute the Jacobian with respect to a different
     argument by using ``argnums``:
 
         >>> from torch.func import jacfwd

--- a/torch/_functorch/vmap.py
+++ b/torch/_functorch/vmap.py
@@ -204,7 +204,7 @@ def _maybe_remove_batch_dim(
     return _remove_batch_dim(batched_output, vmap_level, batch_size, out_dim)
 
 
-# Undos the batching (and any batch dimensions) associated with the `vmap_level`.
+# Undoes the batching (and any batch dimensions) associated with the `vmap_level`.
 def _unwrap_batched(
     batched_outputs: Tensor | tuple[Tensor, ...],
     out_dims: out_dims_t,

--- a/torch/ao/nn/intrinsic/quantized/dynamic/modules/linear_relu.py
+++ b/torch/ao/nn/intrinsic/quantized/dynamic/modules/linear_relu.py
@@ -44,7 +44,7 @@ class LinearReLU(nnqd.Linear):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         if self._packed_params.dtype == torch.qint8:
-            # TODO check if we should set reduce_rage = True by default here
+            # TODO check if we should set reduce_range = True by default here
             Y = torch.ops.quantized.linear_relu_dynamic(
                 x, self._packed_params._packed_params, reduce_range=True
             )

--- a/torch/ao/nn/quantized/modules/utils.py
+++ b/torch/ao/nn/quantized/modules/utils.py
@@ -13,7 +13,7 @@ __all__ = [
 
 
 class WeightedQuantizedModule(torch.nn.Module, metaclass=abc.ABCMeta):
-    """Wrapper for quantized modules than can be lowered from reference modules."""
+    """Wrapper for quantized modules that can be lowered from reference modules."""
 
     @classmethod
     @abc.abstractmethod

--- a/torch/distributed/_mesh_layout.py
+++ b/torch/distributed/_mesh_layout.py
@@ -156,10 +156,10 @@ class _FlatLayout:
 
     def all_ranks_from_zero(self) -> list[int]:
         """
-        This function computes the all ranks specified by the layout staring from zero.
+        This function computes the all ranks specified by the layout starting from zero.
 
         How it works:
-        1. we enumerates every possible coordinate (like a nested for-loop).
+        1. we enumerate every possible coordinate (like a nested for-loop).
         If sizes = (2, 3), we get the following coordinates:
             (0,0), (0,1), (0,2), (1,0), (1,1), (1,2)
 

--- a/torch/distributed/_shard/sharded_tensor/_ops/tensor_ops.py
+++ b/torch/distributed/_shard/sharded_tensor/_ops/tensor_ops.py
@@ -34,7 +34,7 @@ _register_default_op(torch.Tensor.grad_fn.__get__, _sharded_op_impl)  # type: ig
 _register_default_op(torch.Tensor.is_leaf.__get__, _sharded_op_impl)  # type: ignore[attr-defined]
 
 
-# device property is ambiguous as from a global prospective,
+# device property is ambiguous as from a global perspective,
 # ShardedTensor.device consists of multiple devices (might even across hosts)
 # We choose to return the current device of the local tensor to represent
 # the device property on each rank

--- a/torch/distributed/checkpoint/_fsspec_filesystem.py
+++ b/torch/distributed/checkpoint/_fsspec_filesystem.py
@@ -95,7 +95,7 @@ class FileSystem(FileSystemBase):
 # TODO: add the dcp.async_save mixin
 class FsspecWriter(FileSystemWriter):
     """
-    Basic implementation of StorageWriter using FFspec.
+    Basic implementation of StorageWriter using fsspec.
 
     This implementation makes the following assumptions and simplifications:
 

--- a/torch/distributed/elastic/rendezvous/etcd_server.py
+++ b/torch/distributed/elastic/rendezvous/etcd_server.py
@@ -152,7 +152,7 @@ class EtcdServer:
         stderr: int | TextIO | None = None,
     ) -> None:
         """
-        Start the server, and waits for it to be ready. When this function returns the sever is ready to take requests.
+        Start the server, and waits for it to be ready. When this function returns the server is ready to take requests.
 
         Args:
             timeout: time (in seconds) to wait for the server to be ready

--- a/torch/distributed/tensor/experimental/_context_parallel/_load_balancer.py
+++ b/torch/distributed/tensor/experimental/_context_parallel/_load_balancer.py
@@ -391,7 +391,7 @@ class _PTRRLoadBalancer(_LoadBalancer):
             (i.e. `self.block_mask` must have shape (B, 1, seq_len, seq_len) or (1, 1, seq_len, seq_len)).
 
         Example:
-            Here is the document causal mask for attention whereq_len == kv_len == 16 * BLOCK_SIZE
+            Here is the document causal mask for attention where q_len == kv_len == 16 * BLOCK_SIZE
             (each entry is a block):
                                         KV_index
                     [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]  -> row value = 1

--- a/torch/export/dynamic_shapes.py
+++ b/torch/export/dynamic_shapes.py
@@ -117,7 +117,7 @@ class Dim:
     ``Dim("name", min=1, max=2)``).
 
     Dim hints provide the lowest barrier to exportability, with the user only
-    needing to specify if a dimension if dynamic, static, or left for the
+    needing to specify if a dimension is dynamic, static, or left for the
     compiler to decide (``Dim.AUTO``). The export process will automatically
     infer the remaining constraints on min/max ranges and relationships between
     dimensions.

--- a/torch/jit/_state.py
+++ b/torch/jit/_state.py
@@ -3,7 +3,7 @@
 
 This module stores various pieces of Python-global state relating to the JIT.
 
-This is not intended to be imported directly; please the exposed
+This is not intended to be imported directly; please use the exposed
 functionalities in `torch.jit`.
 """
 

--- a/torch/nn/attention/__init__.py
+++ b/torch/nn/attention/__init__.py
@@ -29,7 +29,7 @@ __all__: list[str] = [
 
 # Note: [SDPA warnings]
 # TODO: Consider using this for sdpa regardless of subclasses
-# This only effects users of bias subclasses
+# This only affects users of bias subclasses
 # If this is set to True, we will warn the user if they are not using the fused kernels
 # As well, it will raise warnings for all the reasons why the fused kernels can't be run.
 # To set this to True, run

--- a/torch/nn/utils/_expanded_weights/instance_norm_expanded_weights.py
+++ b/torch/nn/utils/_expanded_weights/instance_norm_expanded_weights.py
@@ -64,7 +64,7 @@ class InstanceNormPerSampleGrad(torch.autograd.Function):
             )
             rstd = torch.rsqrt(var + eps)
 
-            # must use native batch norm since it supports all inputs. This may have used cuda or openmi during the forward but
+            # must use native batch norm since it supports all inputs. This may have used cuda or openmp during the forward but
             # it didn't save the metadata, so we don't know during the backward
             res = torch.ops.aten.native_batch_norm_backward(
                 grad_output_reshaped,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #190477

Correct spelling and grammar mistakes in comments and docstrings
spanning dynamo, export, functorch, ao, distributed, jit, and nn
modules. These are documentation-only changes with no functional impact.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98