### PR TITLE
[ATen] Reject non-positive kernel_size in fractional_max_pool

### DIFF
--- a/aten/src/ATen/native/FractionalMaxPool2d.cpp
+++ b/aten/src/ATen/native/FractionalMaxPool2d.cpp
@@ -38,6 +38,10 @@ TORCH_META_FUNC(fractional_max_pool2d) (
   int64_t poolSizeH = pool_size[0];
   int64_t poolSizeW = pool_size[1];
 
+  TORCH_CHECK(poolSizeH > 0 && poolSizeW > 0,
+    "fractional_max_pool2d(): kernel size should be greater than zero, but got ",
+    poolSizeH, "x", poolSizeW);
+
   int64_t ndims = input.ndimension();
   TORCH_CHECK(ndims == 3 || ndims == 4,
               "fractional_max_pool2d(): Expected 3D or 4D tensor, but got: ", input.sizes());

--- a/aten/src/ATen/native/FractionalMaxPool3d.cpp
+++ b/aten/src/ATen/native/FractionalMaxPool3d.cpp
@@ -37,6 +37,10 @@ TORCH_PRECOMPUTE_META_FUNC(fractional_max_pool3d)(
   int64_t poolSizeH = pool_size[1];
   int64_t poolSizeW = pool_size[2];
 
+  TORCH_CHECK(poolSizeT > 0 && poolSizeH > 0 && poolSizeW > 0,
+    "fractional_max_pool3d(): kernel size should be greater than zero, but got ",
+    poolSizeT, "x", poolSizeH, "x", poolSizeW);
+
   int64_t numBatch = 1;
   int64_t planeDim = 0;
   int64_t timeDim = 1;

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -30,6 +30,7 @@ from torch.testing._internal.common_device_type import (
     onlyCPU,
     onlyCUDA,
     onlyMPS,
+    onlyNativeDeviceTypes,
     TEST_WITH_ROCM,
 )
 from torch.testing._internal.common_dtype import floating_types_and
@@ -2065,6 +2066,20 @@ torch.cuda.synchronize()
             torch.ops.aten.fractional_max_pool2d_backward(
                 grad_output, input, kernel_size, output_size, indices
             )
+
+    @onlyNativeDeviceTypes
+    def test_fractional_max_pool_invalid_kernel_size(self, device):
+        x = torch.randn(1, 2, 7, 7, device=device)
+        samples = x.new(1, 2, 2).uniform_()
+        for kernel_size in [(-1, 2), (0, 2)]:
+            with self.assertRaisesRegex(RuntimeError, "greater than zero"):
+                torch.ops.aten.fractional_max_pool2d(x, kernel_size, (3, 3), samples)
+
+        x = torch.randn(1, 2, 7, 7, 7, device=device)
+        samples = x.new(1, 2, 3).uniform_()
+        for kernel_size in [(-1, 2, 2), (0, 2, 2)]:
+            with self.assertRaisesRegex(RuntimeError, "greater than zero"):
+                torch.ops.aten.fractional_max_pool3d(x, kernel_size, (3, 3, 3), samples)
 
     @expectedFailureMPS  # float64
     @expectedFailureMeta  # RuntimeError: Unrecognized tensor type ID: Meta


### PR DESCRIPTION
## Related Issue

Related to #190272, complements #190475

## Why

The C++ structured metas for `fractional_max_pool2d/3d` never validate `kernel_size >= 1`, so direct aten calls in eager silently return `-inf` outputs with out-of-range indices. #190475 adds the check at the Python API and 2d meta layer; this covers the remaining raw-aten paths (2d/3d eager on all backends, and the 3d compile path which has no Python meta).

## How

- Add `TORCH_CHECK(poolSize... > 0)` to the structured metas in `FractionalMaxPool2d.cpp` and `FractionalMaxPool3d.cpp`, matching the `max_pool` "kernel size should be greater than zero" phrasing
- Add a raw-aten regression test in `test/nn/test_pooling.py`

cc @mikaylagawarecki
