### PR TITLE
[MPS] Fix torch.nextafter for bfloat16

### DIFF
--- a/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
@@ -264,36 +264,25 @@ struct nextafter_functor {
     return static_cast<T>(::metal::nextafter(a, b));
   }
 
+  // Metal has no bfloat nextafter overload, so open-code the musl algorithm
+  // over the sign-magnitude bit pattern.
   inline bfloat operator()(const bfloat from, const bfloat to) {
-    ushort ufrom = as_type<ushort>(from);
-    ushort uto = as_type<ushort>(to);
-    ushort sign_mask = ushort(1) << 15;
-
     if (from != from || to != to) {
       return from + to;
     }
-
-    if (ufrom == uto) {
-      return from;
+    if (from == to) {
+      return to;
     }
-
-    ushort abs_from = ufrom & ~sign_mask;
-    ushort abs_to = uto & ~sign_mask;
-
-    if (abs_from == 0) {
-      if (abs_to == 0) {
-        return to;
-      }
-      ufrom = (uto & sign_mask) | ushort(1);
-      return as_type<bfloat>(ufrom);
+    ushort ufrom = as_type<ushort>(from);
+    if (from == 0) {
+      ushort r = (as_type<ushort>(to) & (ushort(1) << 15)) | ushort(1);
+      return as_type<bfloat>(r);
     }
-
-    if (abs_from > abs_to || ((ufrom ^ uto) & sign_mask)) {
-      ufrom--;
-    } else {
+    if ((from < to) == (from > 0)) {
       ufrom++;
+    } else {
+      ufrom--;
     }
-
     return as_type<bfloat>(ufrom);
   }
 };

--- a/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
@@ -263,6 +263,39 @@ struct nextafter_functor {
   inline T operator()(const T a, const T b) {
     return static_cast<T>(::metal::nextafter(a, b));
   }
+
+  inline bfloat operator()(const bfloat from, const bfloat to) {
+    ushort ufrom = as_type<ushort>(from);
+    ushort uto = as_type<ushort>(to);
+    ushort sign_mask = ushort(1) << 15;
+
+    if (from != from || to != to) {
+      return from + to;
+    }
+
+    if (ufrom == uto) {
+      return from;
+    }
+
+    ushort abs_from = ufrom & ~sign_mask;
+    ushort abs_to = uto & ~sign_mask;
+
+    if (abs_from == 0) {
+      if (abs_to == 0) {
+        return to;
+      }
+      ufrom = (uto & sign_mask) | ushort(1);
+      return as_type<bfloat>(ufrom);
+    }
+
+    if (abs_from > abs_to || ((ufrom ^ uto) & sign_mask)) {
+      ufrom--;
+    } else {
+      ufrom++;
+    }
+
+    return as_type<bfloat>(ufrom);
+  }
 };
 
 struct hypot_functor {

--- a/scripts/write_metallib_headers.py
+++ b/scripts/write_metallib_headers.py
@@ -11,9 +11,7 @@ from _cpp_embed_headers import embed_headers
 def write_metallib_headers(metal_filename: str, output_filename: str):
     embedded_headers = embed_headers(metal_filename)
 
-    out_path = Path(output_filename)
-    out_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(out_path, "w") as out:
+    with open(output_filename, "w") as out:
         out.writelines(
             [
                 "#include <ATen/native/mps/OperationUtils.h>\n",

--- a/scripts/write_metallib_headers.py
+++ b/scripts/write_metallib_headers.py
@@ -11,7 +11,9 @@ from _cpp_embed_headers import embed_headers
 def write_metallib_headers(metal_filename: str, output_filename: str):
     embedded_headers = embed_headers(metal_filename)
 
-    with open(output_filename, "w") as out:
+    out_path = Path(output_filename)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w") as out:
         out.writelines(
             [
                 "#include <ATen/native/mps/OperationUtils.h>\n",

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -15098,7 +15098,7 @@ class TestAdvancedIndexing(TestCaseMPS):
         self.assertEqual(out, torch.zeros(2, device=device), atol=0, rtol=0)
 
     def test_nextafter(self, device="mps"):
-        for dtype in [torch.float16, torch.float32]:
+        for dtype in [torch.float16, torch.bfloat16, torch.float32]:
             x = torch.tensor([1, -1, 0, 0, 2, -2], device=device, dtype=dtype)
             y = torch.tensor([2, -2, -1, 1, -3, 3], device=device, dtype=dtype)
             na = torch.nextafter(x, y)
@@ -15107,6 +15107,7 @@ class TestAdvancedIndexing(TestCaseMPS):
             # greater is broken on MPS, see https://github.com/pytorch/pytorch/issues/125051
             na_ge_x_cpu = na_cpu > x.cpu()
             self.assertEqual(na_ge_x_mps, na_ge_x_cpu)
+            self.assertEqual(na, na_cpu)
 
 
 class TestRNNMPS(TestCaseMPS):


### PR DESCRIPTION
On MPS, `torch.nextafter` was returning its input unchanged for `bfloat16`, because  `nextafter_functor` in `BinaryKernel.metal` called `::metal::nextafter`, which does not have a `bfloat` overload.
This caused the arguments to be promoted to `float`, stepped by one fp32 ULP, and then cast back to `bfloat`, which rounded the step away.

Fixed by implementing a bitwise manual stepping overload for `bfloat` inside `nextafter_functor` in `BinaryKernel.metal` using its `ushort` representation, closely mirroring the CPU implementation in `c10/util/BFloat16-math.h` and extend nextafter unit test to cover bfloat as well


Fixes https://github.com/pytorch/pytorch/pull/190476 
