### PR TITLE
Add handling for empty batch dimensions in FFT operations

### DIFF
--- a/aten/src/ATen/native/SpectralOps.cpp
+++ b/aten/src/ATen/native/SpectralOps.cpp
@@ -246,6 +246,8 @@ Tensor fft_r2c(std::string_view function_name,
               " expects a real input tensor, but got ", input.scalar_type());
   TORCH_CHECK(!out.defined() || out.is_complex(), function_name,
               " expects a complex output tensor, but got ", out.scalar_type());
+  TORCH_CHECK(!out.defined() || out.device() == input.device(), function_name,
+              " expects out tensor on device ", input.device(), " but got ", out.device());
   input = promote_tensor_fft(input);
   const auto input_dim = input.dim();
   const auto dim = maybe_wrap_dim(unwrapped_dim, input_dim, /*wrap_scalar=*/false);

--- a/aten/src/ATen/native/cuda/SpectralOps.cpp
+++ b/aten/src/ATen/native/cuda/SpectralOps.cpp
@@ -167,6 +167,13 @@ bool has_large_prime_factor(int64_t n) {
 // Execute a general fft operation (can be c2c, onesided r2c or onesided c2r)
 const Tensor& _exec_fft(Tensor& out, const Tensor& self, IntArrayRef out_sizes,
                          IntArrayRef dim, bool forward) {
+  // cuFFT rejects zero-element batches with CUFFT_INVALID_SIZE. An empty batch
+  // has nothing to transform, so skip planning/execution and return the output
+  // in its expected (empty) shape.
+  if (out.numel() == 0) {
+    out.resize_(out_sizes, MemoryFormat::Contiguous);
+    return out;
+  }
   const auto ndim = self.dim();
   const int64_t signal_ndim = dim.size();
   const auto batch_dims = ndim - signal_ndim;

--- a/aten/src/ATen/native/mkl/SpectralOps.cpp
+++ b/aten/src/ATen/native/mkl/SpectralOps.cpp
@@ -425,6 +425,13 @@ static DftiDescriptor _plan_mkl_fft(
 // Execute a general fft operation (can be c2c, onesided r2c or onesided c2r)
 static Tensor& _exec_fft(Tensor& out, const Tensor& self, IntArrayRef out_sizes,
                          IntArrayRef dim, int64_t normalization, bool forward) {
+  // MKL DFTI rejects zero-element batches ("Inconsistent configuration
+  // parameters"). An empty batch has nothing to transform, so skip planning and
+  // execution and return the output in its expected (empty) shape.
+  if (out.numel() == 0) {
+    out.resize_(out_sizes, MemoryFormat::Contiguous);
+    return out;
+  }
   const auto ndim = self.dim();
   const int64_t signal_ndim = dim.size();
   const auto batch_dims = ndim - signal_ndim;

--- a/aten/src/ATen/native/mps/operations/FastFourierTransform.mm
+++ b/aten/src/ATen/native/mps/operations/FastFourierTransform.mm
@@ -124,6 +124,7 @@ using namespace mps;
 Tensor& _fft_r2c_mps_out(const Tensor& self, IntArrayRef dim, int64_t normalization, bool onesided, Tensor& out) {
   TORCH_CHECK(self.scalar_type() == kFloat || self.scalar_type() == kHalf, "Only float and half dtypes are supported");
   TORCH_CHECK(out.scalar_type() == c10::toComplexType(self.scalar_type()));
+  TORCH_CHECK(out.device() == self.device(), "Expected out tensor on ", self.device(), " but got ", out.device());
   const auto input_sizes = self.sym_sizes();
   SymDimVector out_sizes(input_sizes.begin(), input_sizes.end());
   auto last_dim = dim.back();
@@ -181,6 +182,7 @@ Tensor& _fft_c2r_mps_out(const Tensor& self,
                          Tensor& out) {
   TORCH_CHECK(self.is_complex(), "Input must be complex");
   TORCH_CHECK(out.scalar_type() == c10::toRealValueType(self.scalar_type()), "Unexpected output type");
+  TORCH_CHECK(out.device() == self.device(), "Expected out tensor on ", self.device(), " but got ", out.device());
   const auto in_sizes = self.sym_sizes();
   SymDimVector out_sizes(in_sizes.begin(), in_sizes.end());
   out_sizes[dim.back()] = last_dim_size;
@@ -218,6 +220,7 @@ Tensor& _fft_c2r_mps_out(const Tensor& self,
 
 Tensor& _fft_c2c_mps_out(const Tensor& self, IntArrayRef dim, int64_t normalization, bool forward, Tensor& out) {
   TORCH_CHECK(self.is_complex());
+  TORCH_CHECK(out.device() == self.device(), "Expected out tensor on ", self.device(), " but got ", out.device());
   at::native::resize_output_symint(out, self.sym_sizes());
   if (out.numel() == 0) {
     return out;

--- a/aten/src/ATen/native/mps/operations/FastFourierTransform.mm
+++ b/aten/src/ATen/native/mps/operations/FastFourierTransform.mm
@@ -132,6 +132,9 @@ Tensor& _fft_r2c_mps_out(const Tensor& self, IntArrayRef dim, int64_t normalizat
     out_sizes[last_dim] = last_dim_halfsize;
   }
   at::native::resize_output_symint(out, out_sizes);
+  if (out.numel() == 0) {
+    return out;
+  }
 
   auto key = __func__ + getTensorsStringKey({self, out}) + ":" + getArrayRefString(dim) + ":" +
       std::to_string(normalization) + ":" + std::to_string(onesided);
@@ -182,6 +185,10 @@ Tensor& _fft_c2r_mps_out(const Tensor& self,
   SymDimVector out_sizes(in_sizes.begin(), in_sizes.end());
   out_sizes[dim.back()] = last_dim_size;
   at::native::resize_output_symint(out, out_sizes);
+  if (out.numel() == 0) {
+    return out;
+  }
+
   auto key = __func__ + getTensorsStringKey({self}) + ":" + getArrayRefString(dim) + ":" +
       std::to_string(normalization) + ":" + std::to_string(last_dim_size);
   @autoreleasepool {
@@ -210,6 +217,12 @@ Tensor& _fft_c2r_mps_out(const Tensor& self,
 }
 
 Tensor& _fft_c2c_mps_out(const Tensor& self, IntArrayRef dim, int64_t normalization, bool forward, Tensor& out) {
+  TORCH_CHECK(self.is_complex());
+  at::native::resize_output_symint(out, self.sym_sizes());
+  if (out.numel() == 0) {
+    return out;
+  }
+
   auto key = __func__ + getTensorsStringKey({self}) + ":" + getArrayRefString(dim) + ":" +
       std::to_string(normalization) + ":" + std::to_string(forward);
   @autoreleasepool {

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -2914,6 +2914,37 @@ class TestMPS(TestCaseMPS):
         # Expecting the inverted to yield the original signal
         self.assertEqual(ifft_result, signal)
 
+    _EMPTY_BATCH_FFT_CASES = {
+        "c2c": (torch.fft.fft, (0, 3, 7), torch.complex64, {}, (0, 3, 7), torch.complex64),
+        "r2c_full": (torch.fft.fft, (0, 3, 7), torch.float32, {}, (0, 3, 7), torch.complex64),
+        "r2c_onesided": (torch.fft.rfft, (0, 3, 7), torch.float32, {}, (0, 3, 4), torch.complex64),
+        "c2r": (torch.fft.irfft, (0, 3, 4), torch.complex64, {"n": 7}, (0, 3, 7), torch.float32),
+    }
+
+    @parametrize("case", tuple(_EMPTY_BATCH_FFT_CASES))
+    def test_empty_batch_fft(self, case):
+        # Regression test for https://github.com/pytorch/pytorch/issues/190011: MPS FFTs must handle empty batch dimensions.
+        op, input_shape, input_dtype, kwargs, output_shape, output_dtype = self._EMPTY_BATCH_FFT_CASES[case]
+        input = torch.empty(input_shape, device="mps", dtype=input_dtype, requires_grad=True)
+
+        result = op(input, **kwargs)
+
+        self.assertEqual(result, torch.empty(output_shape, device="mps", dtype=output_dtype))
+        (result.real if result.is_complex() else result).sum().backward()
+        self.assertEqual(input.grad, torch.empty_like(input))
+
+    @parametrize("case", tuple(_EMPTY_BATCH_FFT_CASES))
+    def test_empty_batch_fft_out(self, case):
+        # Regression test for https://github.com/pytorch/pytorch/issues/190011 (out= path)
+        op, input_shape, input_dtype, kwargs, output_shape, output_dtype = self._EMPTY_BATCH_FFT_CASES[case]
+        input = torch.empty(input_shape, device="mps", dtype=input_dtype)
+        out = torch.empty(0, device="mps", dtype=output_dtype)
+
+        result = op(input, out=out, **kwargs)
+
+        self.assertIs(result, out)
+        self.assertEqual(result, torch.empty(output_shape, device="mps", dtype=output_dtype))
+
     def test_fftfreq(self):
         # Regression test for https://github.com/pytorch/pytorch/issues/135223
         freq_cpu = torch.fft.fftfreq(10**4, device='cpu')

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -2914,37 +2914,6 @@ class TestMPS(TestCaseMPS):
         # Expecting the inverted to yield the original signal
         self.assertEqual(ifft_result, signal)
 
-    _EMPTY_BATCH_FFT_CASES = {
-        "c2c": (torch.fft.fft, (0, 3, 7), torch.complex64, {}, (0, 3, 7), torch.complex64),
-        "r2c_full": (torch.fft.fft, (0, 3, 7), torch.float32, {}, (0, 3, 7), torch.complex64),
-        "r2c_onesided": (torch.fft.rfft, (0, 3, 7), torch.float32, {}, (0, 3, 4), torch.complex64),
-        "c2r": (torch.fft.irfft, (0, 3, 4), torch.complex64, {"n": 7}, (0, 3, 7), torch.float32),
-    }
-
-    @parametrize("case", tuple(_EMPTY_BATCH_FFT_CASES))
-    def test_empty_batch_fft(self, case):
-        # Regression test for https://github.com/pytorch/pytorch/issues/190011: MPS FFTs must handle empty batch dimensions.
-        op, input_shape, input_dtype, kwargs, output_shape, output_dtype = self._EMPTY_BATCH_FFT_CASES[case]
-        input = torch.empty(input_shape, device="mps", dtype=input_dtype, requires_grad=True)
-
-        result = op(input, **kwargs)
-
-        self.assertEqual(result, torch.empty(output_shape, device="mps", dtype=output_dtype))
-        (result.real if result.is_complex() else result).sum().backward()
-        self.assertEqual(input.grad, torch.empty_like(input))
-
-    @parametrize("case", tuple(_EMPTY_BATCH_FFT_CASES))
-    def test_empty_batch_fft_out(self, case):
-        # Regression test for https://github.com/pytorch/pytorch/issues/190011 (out= path)
-        op, input_shape, input_dtype, kwargs, output_shape, output_dtype = self._EMPTY_BATCH_FFT_CASES[case]
-        input = torch.empty(input_shape, device="mps", dtype=input_dtype)
-        out = torch.empty(0, device="mps", dtype=output_dtype)
-
-        result = op(input, out=out, **kwargs)
-
-        self.assertIs(result, out)
-        self.assertEqual(result, torch.empty(output_shape, device="mps", dtype=output_dtype))
-
     def test_fftfreq(self):
         # Regression test for https://github.com/pytorch/pytorch/issues/135223
         freq_cpu = torch.fft.fftfreq(10**4, device='cpu')

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -302,6 +302,13 @@ def logcumsumexp(self, dim):
 # Although the actual FFT launch is different, all the permuting code appears
 # to be the same
 def _exec_fft(out, self, out_sizes, dim, *, forward):
+    # Empty batches are short-circuited by the eager kernels (cuFFT/MKL/MPS all
+    # reject zero-element transforms); mirror that here so tracing does not call
+    # resize_ on a functionalized tensor.
+    from torch.fx.experimental.symbolic_shapes import guard_or_false
+
+    if guard_or_false(out.numel() == 0):
+        return out.new_empty(out_sizes)
     ndim = self.ndim
     signal_ndim = len(dim)
     batch_dims = ndim - signal_ndim

--- a/torch/testing/_internal/opinfo/definitions/fft.py
+++ b/torch/testing/_internal/opinfo/definitions/fft.py
@@ -12,7 +12,11 @@ from torch.testing._internal.common_dtype import (
     all_types_and,
     all_types_and_complex_and,
 )
-from torch.testing._internal.common_utils import TEST_SCIPY, TEST_WITH_ROCM
+from torch.testing._internal.common_utils import (
+    MACOS_VERSION,
+    TEST_SCIPY,
+    TEST_WITH_ROCM,
+)
 from torch.testing._internal.opinfo.core import (
     DecorateInfo,
     ErrorInput,
@@ -103,6 +107,17 @@ def sample_inputs_fft_with_min(
     a = make_tensor(min_size, dtype=dtype, device=device, requires_grad=requires_grad)
     yield SampleInput(a)
 
+    # Empty batch dimension with non-empty transform dims
+    # https://github.com/pytorch/pytorch/issues/190011
+    min_shape = min_size if isinstance(min_size, tuple) else (min_size,)
+    empty = make_tensor(
+        (0, *min_shape), dtype=dtype, device=device, requires_grad=requires_grad
+    )
+    if op_info.ndimensional == SpectralFuncType.OneD:
+        yield SampleInput(empty, dim=-1)
+    else:
+        yield SampleInput(empty, dim=tuple(range(-len(min_shape), 0)))
+
 
 def sample_inputs_fftshift(op_info, device, dtype, requires_grad, **kwargs):
     def mt(shape, **kwargs):
@@ -169,11 +184,13 @@ op_db: list[OpInfo] = [
                 active_if=TEST_WITH_ROCM,
             ),
             # RuntimeError: [srcBuf length] > 0 INTERNAL ASSERT FAILED
+            # Fixed on macOS 15+ by empty-batch handling in the MPS FFT out= path.
             DecorateInfo(
                 unittest.expectedFailure,
                 "TestCommon",
                 "test_out",
                 device_type="mps",
+                active_if=MACOS_VERSION < 15.0,
             ),
             # AssertionError: The values for attribute 'shape' do not match: torch.Size([5, 3, 10]) != torch.Size([5, 3, 11]).
             DecorateInfo(
@@ -181,6 +198,7 @@ op_db: list[OpInfo] = [
                 "TestCommon",
                 "test_out_warning",
                 device_type="mps",
+                active_if=MACOS_VERSION < 15.0,
             ),
         ),
     ),
@@ -209,11 +227,13 @@ op_db: list[OpInfo] = [
         decorators=[precisionOverride({torch.float: 1e-4, torch.cfloat: 1e-4})],
         skips=(
             # RuntimeError: [srcBuf length] > 0 INTERNAL ASSERT FAILED
+            # Fixed on macOS 15+ by empty-batch handling in the MPS FFT out= path.
             DecorateInfo(
                 unittest.expectedFailure,
                 "TestCommon",
                 "test_out",
                 device_type="mps",
+                active_if=MACOS_VERSION < 15.0,
             ),
             # AssertionError: The values for attribute 'shape' do not match: torch.Size([5, 3, 10]) != torch.Size([5, 3, 11]).
             DecorateInfo(
@@ -221,6 +241,7 @@ op_db: list[OpInfo] = [
                 "TestCommon",
                 "test_out_warning",
                 device_type="mps",
+                active_if=MACOS_VERSION < 15.0,
             ),
         ),
     ),
@@ -447,11 +468,13 @@ op_db: list[OpInfo] = [
         ],
         skips=(
             # RuntimeError: [srcBuf length] > 0 INTERNAL ASSERT FAILED
+            # Fixed on macOS 15+ by empty-batch handling in the MPS FFT out= path.
             DecorateInfo(
                 unittest.expectedFailure,
                 "TestCommon",
                 "test_out",
                 device_type="mps",
+                active_if=MACOS_VERSION < 15.0,
             ),
             # AssertionError: The values for attribute 'shape' do not match: torch.Size([5, 3, 10]) != torch.Size([5, 3, 11]).
             DecorateInfo(
@@ -459,6 +482,7 @@ op_db: list[OpInfo] = [
                 "TestCommon",
                 "test_out_warning",
                 device_type="mps",
+                active_if=MACOS_VERSION < 15.0,
             ),
         ),
     ),
@@ -493,8 +517,13 @@ op_db: list[OpInfo] = [
         ],
         skips=(
             # RuntimeError: [srcBuf length] > 0 INTERNAL ASSERT FAILED
+            # Fixed on macOS 15+ by empty-batch handling in the MPS FFT out= path.
             DecorateInfo(
-                unittest.expectedFailure, "TestCommon", "test_out", device_type="mps"
+                unittest.expectedFailure,
+                "TestCommon",
+                "test_out",
+                device_type="mps",
+                active_if=MACOS_VERSION < 15.0,
             ),
             # AssertionError: The values for attribute 'shape' do not match: torch.Size([5, 3, 10]) != torch.Size([5, 3, 11]).
             DecorateInfo(
@@ -502,6 +531,7 @@ op_db: list[OpInfo] = [
                 "TestCommon",
                 "test_out_warning",
                 device_type="mps",
+                active_if=MACOS_VERSION < 15.0,
             ),
         ),
     ),


### PR DESCRIPTION
On MPS/CUDA/x86 CPU, FFT operations failed for tensors with an empty batch
dimension: no backend can plan/execute a transform over a zero-element tensor,
and shape inference under tracing tripped over the empty output as well.

- **MPSGraph** rejects empty tensor placeholders :
  ```
  RuntimeError: [srcBuf length] > 0 INTERNAL ASSERT FAILED at "aten/src/ATen/native/mps/OperationUtils.mm":536, please report a bug to PyTorch. Placeholder tensor is empty!
  ```
- **cuFFT** could not plan over an empty tensor:
  ```
  RuntimeError: cuFFT error: CUFFT_INVALID_SIZE
  # Exception raised from CUFFT_CHECK at aten/src/ATen/native/cuda/CuFFTUtils.h:71, in _fft_c2c_cufft
  ```
- **MKL** (oneMKL DFTI) could not build a descriptor over an empty tensor:
  ```
  RuntimeError: MKL FFT error: Intel oneMKL DFTI ERROR: Inconsistent configuration parameters
  ```
- **Meta** registration could not compute the empty output: under fake/proxy
  tracing the shared `_exec_fft` resizes the functionalized output in place,
  which is rejected for a zero-element (numel-preserving) resize:
  ```
  RuntimeError: tried to directly modify sizes for customized tensor
  # failed while attempting to run meta for aten._fft_c2r.default -> _fft_c2c -> _exec_fft -> out.resize_(...)
  ```

Fixed by short-circuiting empty transforms: the eager kernels (MPS `out=` paths, CUDA/MKL `_exec_fft`) and the Python meta `_exec_fft` resize the output to its expected shape and return early when it has no elements.
The MPS `out=` paths also gained an explicit device check, since the early return skips the device validation that graph execution used to implicitly provide.
Empty-batch coverage is added as a `SampleInput` in the shared FFT OpInfo. 

Fixes https://github.com/pytorch/pytorch/issues/190011
