### PR TITLE
Fix CUDA IPC dataset cleanup in DataLoader workers

### DIFF
--- a/torch/utils/data/_utils/worker.py
+++ b/torch/utils/data/_utils/worker.py
@@ -243,7 +243,7 @@ def _generate_state(base_seed, worker_id):
 
 def _worker_loop(
     dataset_kind,
-    dataset,
+    dataset_holder,
     index_queue,
     data_queue,
     done_event,
@@ -259,6 +259,7 @@ def _worker_loop(
 ) -> None:
     # See NOTE [ Data Loader Multiprocessing Shutdown Logic ] for details on the
     # logic of this function.
+    dataset = dataset_holder.pop()
 
     try:
         # Initialize C side signal handlers for SIGBUS and SIGSEGV. Python signal
@@ -394,6 +395,8 @@ def _worker_loop(
     except KeyboardInterrupt:
         # Main process will raise KeyboardInterrupt anyways.
         pass
+    finally:
+        _worker_info = None
     if done_event.is_set():
         data_queue.cancel_join_thread()
         data_queue.close()

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -1144,11 +1144,13 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
             # Need to `cancel_join_thread` here!
             # See sections (2) and (3b) above.
             index_queue.cancel_join_thread()
+            # The worker consumes the holder so its Process does not retain the dataset.
+            dataset_holder = [self._dataset]
             w = multiprocessing_context.Process(
                 target=_utils.worker._worker_loop,
                 args=(
                     self._dataset_kind,
-                    self._dataset,
+                    dataset_holder,
                     index_queue,
                     self._worker_result_queue,
                     self._workers_done_event,


### PR DESCRIPTION
## Author Notes

Fix for https://github.com/pytorch/pytorch/issues/190268 , I think that's the simplest one even though we have to change the calling convention

## Agent Notes

DataLoader worker processes retain their launch arguments until process exit, while `get_worker_info()` also holds the dataset globally. For CUDA datasets received over IPC, multiprocessing exits without running the storage deleters, leaving producer-side CUDA IPC reference counts elevated and allocations in limbo. This change passes the dataset through a mutable holder consumed at worker startup and clears the global worker info on worker-loop exit, releasing CUDA IPC storage while cleanup remains operational without relying on private multiprocessing fields.

Test plan:

```bash
PYTORCH_TEST_CUDA_MEM_LEAK_CHECK=1 PYTORCH_TEST_WITH_SLOW_GRADCHECK=1 python test/test_dataloader.py TestDataLoaderDeviceTypeCUDA.test_sparse_tensor_multiprocessing_context_forkserver_cuda
```

The reproducer passes. Focused DataLoader lint checks pass; full `spin lint` reports unrelated pre-existing Pyrefly failures in `torch/_dynamo/symbolic_convert.py` and `torch/_dynamo/variables/constant.py`.

This PR was authored with an AI assistant.