### PR TITLE
Zero fully-masked rows in fastpath masked_softmax to match SDPA

### DIFF
--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -126,7 +126,19 @@ Tensor masked_softmax(
     attn_mask = attn_mask->to(at::kBool);
   }
   if (attn_mask) {
-    return _masked_softmax(attn_scores, *attn_mask, attn_scores.dim() - 1, mask_type);
+    auto out =
+        _masked_softmax(attn_scores, *attn_mask, attn_scores.dim() - 1, mask_type);
+    // A row whose every key is masked softmaxes over the empty set: _masked_softmax
+    // yields NaN there, while the SDPA fallback (_safe_softmax) yields 0 -- so the
+    // same module silently diverges between the native fast path and the SDPA path.
+    // Adopt the safe-softmax convention: fully-masked rows attend to nothing.
+    auto mask = *attn_mask;
+    if (mask_type == 1 && mask.dim() == 2) {
+      // key_padding_mask [B, S] broadcasts over heads and query rows, as the
+      // _masked_softmax kernels do internally.
+      mask = mask.view({mask.size(0), 1, 1, mask.size(1)});
+    }
+    return out.masked_fill_(mask.all(-1, /*keepdim=*/true), 0.0);
   } else {
     return _softmax_out(attn_scores, attn_scores, attn_scores.dim() - 1, false);
   }

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -399,9 +399,34 @@ class TestTransformers(NNTestCase):
             out, _ = mha(X, X, X, attn_mask=attn_mask, key_padding_mask=key_padding_mask, need_weights=False)
             mha.eval()  # enable fast path
             out_fp, _ = mha(X, X, X, attn_mask=attn_mask, key_padding_mask=key_padding_mask, need_weights=False)
-            # The FP kernel will return NaNs while the sdpa kernel which is ran when the fast path is turned off returns 0 instead
-            # of NaNs for fully masked rows
-            self.assertEqual(out, out_fp.nan_to_num())
+            self.assertEqual(out, out_fp)
+
+    def test_transformerencoder_fastpath_fully_masked_rows_match_sdpa(self, device):
+        # A bool banded mask + key padding deeper than the band leaves rows with
+        # every key masked: the fast path yielded NaN there while SDPA zero-fills.
+        previous_fastpath = torch.backends.mha.get_fastpath_enabled()
+        try:
+            torch.manual_seed(0)
+            seqlen, window, pad = 16, 4, 12
+            encoder = nn.TransformerEncoder(
+                nn.TransformerEncoderLayer(
+                    32, 4, 64, batch_first=True, norm_first=True, device=device),
+                1, enable_nested_tensor=False).eval()
+            x = torch.randn(1, seqlen, 32, device=device)
+            i = torch.arange(seqlen, device=device)[:, None]
+            j = torch.arange(seqlen, device=device)[None, :]
+            mask = ~((i - j >= 0) & (i - j < window))
+            key_padding_mask = torch.zeros(1, seqlen, dtype=torch.bool, device=device)
+            key_padding_mask[:, -pad:] = True
+            with torch.no_grad():
+                torch.backends.mha.set_fastpath_enabled(True)
+                fast = encoder(x, mask=mask, src_key_padding_mask=key_padding_mask)
+                torch.backends.mha.set_fastpath_enabled(False)
+                ref = encoder(x, mask=mask, src_key_padding_mask=key_padding_mask)
+            self.assertTrue(torch.isfinite(fast).all())
+            self.assertEqual(fast, ref)
+        finally:
+            torch.backends.mha.set_fastpath_enabled(previous_fastpath)
 
     @onlyCUDA
     def test_multiheadattention_fastpath_fp16_head_dim_alignment(self, device):


### PR DESCRIPTION
Fixes a silent divergence between the native transformer fast path and the SDPA fallback for rows whose every key is masked.

### Problem

`nn.TransformerEncoder` / `nn.MultiheadAttention` in eval: when a bool `attn_mask` combines with `src_key_padding_mask` such that some rows end up with all keys masked (e.g. tail padding deeper than a banded causal mask), the two execution paths disagree:

- **Native fast path** (`_transformer_encoder_layer_fwd` → `native_multi_head_attention_*` → `masked_softmax`): those rows come out **NaN** (softmax over the empty set).
- **SDPA fallback** (`F.multi_head_attention_forward` → `scaled_dot_product_attention` → `_safe_softmax`): the same rows are **zero-filled**.

Same module, same inputs, no warning — outputs differ between CPU/CUDA (fast path) and MPS (always falls back), and flip with `torch.backends.mha.set_fastpath_enabled`. The existing `test_multiheadattention_fastpath_attn_mask` acknowledges the mismatch and works around it with `.nan_to_num()`.

Minimal repro:

```python
import torch, torch.nn as nn

torch.manual_seed(0)
S, WINDOW, PAD = 16, 4, 12          # pad depth > band width => fully-masked rows
enc = nn.TransformerEncoder(
    nn.TransformerEncoderLayer(32, 4, 64, batch_first=True, norm_first=True),
    1, enable_nested_tensor=False).eval()
x = torch.randn(1, S, 32)
i, j = torch.arange(S)[:, None], torch.arange(S)[None, :]
banded = ~((i - j >= 0) & (i - j < WINDOW))
kpm = torch.zeros(1, S, dtype=torch.bool)
kpm[:, -PAD:] = True
out = enc(x, mask=banded, src_key_padding_mask=kpm)
print(out[:, -PAD:].isnan().any())   # True on the fast path, False with fastpath disabled / on MPS
```

### Fix

Adopt the `_safe_softmax` convention at the single site shared by the CPU and CUDA fast paths — the `masked_softmax` wrapper in `aten/src/ATen/native/transformers/attention.cpp`: after `_masked_softmax`, zero the rows whose mask is all-True along the key dim. The kpm `[B, S]` layout (`mask_type == 1`) is viewed to `[B, 1, 1, S]` exactly as the kernels broadcast it; `[L, S]` and 4-D masks broadcast as-is through `all(-1, keepdim=True)`.

Zeroing the softmax row reproduces the SDPA path's semantics: zero attention probabilities → zero context row from the following bmm → identical out-proj/residual downstream. Verified empirically: with the patch, fast path == fastpath-disabled to machine precision on the repro, and CPU == MPS.

An alternative — fixing inside each `_masked_softmax` kernel (CPU `SoftMax.cpp` + CUDA) — avoids the extra mask reduction but triples the surface; the wrapper reduction is O(mask) next to the attention matmuls.

### Tests

- New `test_transformerencoder_fastpath_fully_masked_rows_match_sdpa`: banded bool mask + deep key padding, asserts the fast path output is finite and equal to the fastpath-disabled reference.
- `test_multiheadattention_fastpath_attn_mask`: the `.nan_to_num()` workaround is now dead and removed — the test asserts direct equality.
- `pytest test/test_transformers.py`: 3322 passed, 105 skipped, 1 failure (`test_transformer_encoder_layer_fwd_fake_cpu`) that is environmental on my machine — inductor's runtime C++ compile fails on `omp.h` missing from Apple clang, unrelated to this change.
