### PR TITLE
Align local and CI linter partitions

### DIFF
--- a/.github/scripts/lintrunner.sh
+++ b/.github/scripts/lintrunner.sh
@@ -2,6 +2,27 @@
 set -ex
 
 CACHE_DIRECTORY="/tmp/.lintbin"
+CLANG_LINTERS="CLANGTIDY,CLANGTIDY_EXECUTORCH_COMPATIBILITY,CLANGFORMAT"
+PYREFLY_LINTERS="PYREFLY"
+
+case "${LINTER_GROUP:-}" in
+    clang)
+        ADDITIONAL_LINTRUNNER_ARGS="--take ${CLANG_LINTERS} ${CHANGED_FILES}"
+        ;;
+    pyrefly)
+        ADDITIONAL_LINTRUNNER_ARGS="--take ${PYREFLY_LINTERS} --all-files"
+        ;;
+    other)
+        ADDITIONAL_LINTRUNNER_ARGS="--skip ${CLANG_LINTERS},${PYREFLY_LINTERS} ${CHANGED_FILES}"
+        ;;
+    "")
+        ;;
+    *)
+        echo "Unknown linter group: ${LINTER_GROUP}" >&2
+        exit 1
+        ;;
+esac
+
 # Try to recover the cached binaries
 if [[ -d "${CACHE_DIRECTORY}" ]]; then
     # It's ok to fail this as lintrunner init would download these binaries

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -61,10 +61,10 @@ jobs:
       script: |
         CHANGED_FILES="${{ needs.get-changed-files.outputs.changed-files }}"
         if [ "$CHANGED_FILES" = "*" ]; then
-          export ADDITIONAL_LINTRUNNER_ARGS="--take CLANGTIDY,CLANGFORMAT --all-files"
-        else
-          export ADDITIONAL_LINTRUNNER_ARGS="--take CLANGTIDY,CLANGFORMAT $CHANGED_FILES"
+          CHANGED_FILES="--all-files"
         fi
+        export CHANGED_FILES
+        export LINTER_GROUP=clang
         export CLANG=1
         # Cap parallelism to the pod's CPU budget; os.cpu_count() overcounts on k8s and OOMs.
         export MAX_JOBS="$(nproc --ignore=2)"
@@ -88,9 +88,8 @@ jobs:
       runner: mt-l-x86iamx-8-16
       docker-image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/ci-image:pytorch-linux-jammy-linter-${{ needs.get-label-type.outputs.ci-docker-hash }}
       script: |
-        CHANGED_FILES="${{ needs.get-changed-files.outputs.changed-files }}"
         echo "Running pyrefly"
-        ADDITIONAL_LINTRUNNER_ARGS="--take PYREFLY --all-files" .github/scripts/lintrunner.sh
+        LINTER_GROUP=pyrefly .github/scripts/lintrunner.sh
 
   lintrunner-noclang:
     uses: ./.github/workflows/_lint.yml
@@ -105,10 +104,11 @@ jobs:
         # Cap parallelism to the pod's CPU budget; os.cpu_count() overcounts on k8s and OOMs.
         export MAX_JOBS="$(nproc --ignore=2)"
         if [ "$CHANGED_FILES" = '*' ]; then
-          ADDITIONAL_LINTRUNNER_ARGS="--skip CLANGTIDY,CLANGTIDY_EXECUTORCH_COMPATIBILITY,CLANGFORMAT,PYREFLY --all-files" .github/scripts/lintrunner.sh
-        else
-          ADDITIONAL_LINTRUNNER_ARGS="--skip CLANGTIDY,CLANGTIDY_EXECUTORCH_COMPATIBILITY,CLANGFORMAT,PYREFLY ${CHANGED_FILES}" .github/scripts/lintrunner.sh
+          CHANGED_FILES="--all-files"
         fi
+        export CHANGED_FILES
+        export LINTER_GROUP=other
+        .github/scripts/lintrunner.sh
 
   quick-checks:
     if: github.repository_owner == 'pytorch'

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -134,6 +134,8 @@ exclude_patterns = [
 command = [
     'uv',
     'run',
+    '--python',
+    '3.10',
     '--script',
     'tools/linter/adapters/pyrefly_linter.py',
     '--config=pyrefly.toml',

--- a/c10/util/llvmMathExtras.h
+++ b/c10/util/llvmMathExtras.h
@@ -400,6 +400,7 @@ constexpr inline bool isShiftedUInt(uint64_t x) {
       N + S <= 64, "isShiftedUInt<N, S> with N + S > 64 is too wide.");
   // Per the two static_asserts above, S must be strictly less than 64.  So
   // 1 << S is not undefined behavior.
+  // NOLINTNEXTLINE(bugprone-chained-comparison)
   return isUInt<N + S>(x) && (x % (UINT64_C(1) << S) == 0);
 }
 


### PR DESCRIPTION
## Author Notes

Should make local and CI lint match. Also the new structure for clang/other is trying to ensure we don't make this error again when another linter is added.

## Agent Notes

Pins the nested Pyrefly `uv run` to Python 3.10, centralizes the dedicated clang and Pyrefly CI linter groups so the catch-all job skips their exact union, and enables the ExecuTorch C++17 compatibility linter in the clang CI job. It also suppresses the resulting `bugprone-chained-comparison` false positive on a template argument expression.

Test Plan:

```
spin lint -- --take CLANGTIDY_EXECUTORCH_COMPATIBILITY c10/util/llvmMathExtras.h
spin lint
```

Authored with an AI assistant.
