### PR TITLE
[MPS] Fix native_layer_norm for small-variance rows via two-pass kernel

### DIFF
--- a/aten/src/ATen/native/mps/kernels/LayerNorm.metal
+++ b/aten/src/ATen/native/mps/kernels/LayerNorm.metal
@@ -5,13 +5,13 @@
 using namespace metal;
 using namespace c10::metal;
 
-template <typename T>
+template <typename T, typename idx_t>
 kernel void layer_norm_single_row(
     device T* input [[buffer(0)]],
     device T* output [[buffer(1)]],
     device T* meanOut [[buffer(2)]],
     device T* rstdTensor [[buffer(3)]],
-    constant ulong& axis_size [[buffer(4)]],
+    constant idx_t& axis_size [[buffer(4)]],
     constant float& epsilon [[buffer(5)]],
     constant int& use_weight [[buffer(6)]],
     constant int& use_bias [[buffer(7)]],
@@ -26,7 +26,7 @@ kernel void layer_norm_single_row(
   // Each threadgroup handles one full row of length axis_size, and each thread
   // owns exactly its N_READS-element slice. The slice is loaded once and reused
   // for the variance pass and the write-back
-  size_t row_offset = tg_id * size_t(axis_size);
+  idx_t row_offset = idx_t(tg_id) * axis_size;
   device T* x = input + row_offset + tid * N_READS;
   device T* out = output + row_offset + tid * N_READS;
 
@@ -80,13 +80,13 @@ kernel void layer_norm_single_row(
   }
 }
 
-template <typename T>
+template <typename T, typename idx_t>
 kernel void layer_norm_looped(
     device T* input [[buffer(0)]],
     device T* output [[buffer(1)]],
     device T* meanOut [[buffer(2)]],
     device T* rstdTensor [[buffer(3)]],
-    constant ulong& axis_size [[buffer(4)]],
+    constant idx_t& axis_size [[buffer(4)]],
     constant float& epsilon [[buffer(5)]],
     constant int& use_weight [[buffer(6)]],
     constant int& use_bias [[buffer(7)]],
@@ -98,7 +98,7 @@ kernel void layer_norm_looped(
     uint simd_lane_id [[thread_index_in_simdgroup]]) {
   constexpr int N_READS = 4;
 
-  size_t row_offset = tg_id * size_t(axis_size);
+  idx_t row_offset = idx_t(tg_id) * axis_size;
   device T* x = input + row_offset;
   device T* out = output + row_offset;
 
@@ -109,8 +109,8 @@ kernel void layer_norm_looped(
   threadgroup float local_sum_sq[simdgroup_size];
 
   float partial_sum = 0.0f;
-  for (ulong r = 0; r < axis_size; r += lsize * N_READS) {
-    ulong base = r + tid * N_READS;
+  for (idx_t r = 0; r < axis_size; r += lsize * N_READS) {
+    idx_t base = r + tid * N_READS;
     if (base + N_READS <= axis_size) {
       float4 v4 = float4(x[base], x[base + 1], x[base + 2], x[base + 3]);
       partial_sum += v4.x + v4.y + v4.z + v4.w;
@@ -127,8 +127,8 @@ kernel void layer_norm_looped(
       threadgroup_sum(local_sum, partial_sum, tid, lsize) / float(axis_size);
 
   float partial_sum_sq = 0.0f;
-  for (ulong r = 0; r < axis_size; r += lsize * N_READS) {
-    ulong base = r + tid * N_READS;
+  for (idx_t r = 0; r < axis_size; r += lsize * N_READS) {
+    idx_t base = r + tid * N_READS;
     if (base + N_READS <= axis_size) {
       float4 d4 = float4(x[base], x[base + 1], x[base + 2], x[base + 3]) - mean;
       partial_sum_sq += dot(d4, d4);
@@ -146,8 +146,8 @@ kernel void layer_norm_looped(
       float(axis_size);
   float inv_std = metal::precise::rsqrt(var + epsilon);
 
-  for (ulong r = 0; r < axis_size; r += lsize * N_READS) {
-    ulong base = r + tid * N_READS;
+  for (idx_t r = 0; r < axis_size; r += lsize * N_READS) {
+    idx_t base = r + tid * N_READS;
     if (base + N_READS <= axis_size) {
 #pragma unroll
       for (int i = 0; i < N_READS; i++) {
@@ -181,44 +181,49 @@ kernel void layer_norm_looped(
   }
 }
 
-#define instantiate_layer_norm_single_row(DTYPE)                          \
-  template [[host_name("layer_norm_single_row_" #DTYPE)]] [[kernel]] void \
-  layer_norm_single_row<DTYPE>(                                           \
-      device DTYPE * input [[buffer(0)]],                                 \
-      device DTYPE * output [[buffer(1)]],                                \
-      device DTYPE * meanOut [[buffer(2)]],                               \
-      device DTYPE * rstdTensor [[buffer(3)]],                            \
-      constant ulong & axis_size [[buffer(4)]],                           \
-      constant float& epsilon [[buffer(5)]],                              \
-      constant int& use_weight [[buffer(6)]],                             \
-      constant int& use_bias [[buffer(7)]],                               \
-      device DTYPE* weight [[buffer(8)]],                                 \
-      device DTYPE* bias [[buffer(9)]],                                   \
-      uint tg_id [[threadgroup_position_in_grid]],                        \
-      uint tid [[thread_position_in_threadgroup]],                        \
-      uint lsize [[threads_per_threadgroup]],                             \
+#define instantiate_layer_norm_single_row(DTYPE, IDX_T, IDXNAME) \
+  template [[host_name("layer_norm_single_row_" IDXNAME          \
+                       "_" #DTYPE)]] [[kernel]] void             \
+  layer_norm_single_row<DTYPE, IDX_T>(                           \
+      device DTYPE * input [[buffer(0)]],                        \
+      device DTYPE * output [[buffer(1)]],                       \
+      device DTYPE * meanOut [[buffer(2)]],                      \
+      device DTYPE * rstdTensor [[buffer(3)]],                   \
+      constant IDX_T & axis_size [[buffer(4)]],                  \
+      constant float& epsilon [[buffer(5)]],                     \
+      constant int& use_weight [[buffer(6)]],                    \
+      constant int& use_bias [[buffer(7)]],                      \
+      device DTYPE* weight [[buffer(8)]],                        \
+      device DTYPE* bias [[buffer(9)]],                          \
+      uint tg_id [[threadgroup_position_in_grid]],               \
+      uint tid [[thread_position_in_threadgroup]],               \
+      uint lsize [[threads_per_threadgroup]],                    \
       uint simd_lane_id [[thread_index_in_simdgroup]]);
 
-#define instantiate_layer_norm_looped(DTYPE)                          \
-  template [[host_name("layer_norm_looped_" #DTYPE)]] [[kernel]] void \
-  layer_norm_looped<DTYPE>(                                           \
-      device DTYPE * input [[buffer(0)]],                             \
-      device DTYPE * output [[buffer(1)]],                            \
-      device DTYPE * meanOut [[buffer(2)]],                           \
-      device DTYPE * rstdTensor [[buffer(3)]],                        \
-      constant ulong & axis_size [[buffer(4)]],                       \
-      constant float& epsilon [[buffer(5)]],                          \
-      constant int& use_weight [[buffer(6)]],                         \
-      constant int& use_bias [[buffer(7)]],                           \
-      device DTYPE* weight [[buffer(8)]],                             \
-      device DTYPE* bias [[buffer(9)]],                               \
-      uint tg_id [[threadgroup_position_in_grid]],                    \
-      uint tid [[thread_position_in_threadgroup]],                    \
-      uint lsize [[threads_per_threadgroup]],                         \
-      uint simd_lane_id [[thread_index_in_simdgroup]]);
+#define instantiate_layer_norm_looped(DTYPE, IDX_T, IDXNAME)                 \
+  template                                                                   \
+      [[host_name("layer_norm_looped_" IDXNAME "_" #DTYPE)]] [[kernel]] void \
+      layer_norm_looped<DTYPE, IDX_T>(                                       \
+          device DTYPE * input [[buffer(0)]],                                \
+          device DTYPE * output [[buffer(1)]],                               \
+          device DTYPE * meanOut [[buffer(2)]],                              \
+          device DTYPE * rstdTensor [[buffer(3)]],                           \
+          constant IDX_T & axis_size [[buffer(4)]],                          \
+          constant float& epsilon [[buffer(5)]],                             \
+          constant int& use_weight [[buffer(6)]],                            \
+          constant int& use_bias [[buffer(7)]],                              \
+          device DTYPE* weight [[buffer(8)]],                                \
+          device DTYPE* bias [[buffer(9)]],                                  \
+          uint tg_id [[threadgroup_position_in_grid]],                       \
+          uint tid [[thread_position_in_threadgroup]],                       \
+          uint lsize [[threads_per_threadgroup]],                            \
+          uint simd_lane_id [[thread_index_in_simdgroup]]);
 
-#define instantiate_layer_norm(DTYPE) \
-  instantiate_layer_norm_single_row(DTYPE) instantiate_layer_norm_looped(DTYPE)
+#define instantiate_layer_norm(DTYPE)                        \
+  instantiate_layer_norm_single_row(DTYPE, uint, "i32")      \
+      instantiate_layer_norm_single_row(DTYPE, ulong, "i64") \
+          instantiate_layer_norm_looped(DTYPE, uint, "i32")  \
+              instantiate_layer_norm_looped(DTYPE, ulong, "i64")
 
 instantiate_layer_norm(float);
 instantiate_layer_norm(half);

--- a/aten/src/ATen/native/mps/kernels/LayerNorm.metal
+++ b/aten/src/ATen/native/mps/kernels/LayerNorm.metal
@@ -1,8 +1,9 @@
 #include <c10/metal/common.h>
+#include <c10/metal/reduction_utils.h>
 #include <metal_simdgroup>
 #include <metal_stdlib>
 using namespace metal;
-using c10::metal::simdgroup_size;
+using namespace c10::metal;
 
 template <typename T>
 kernel void layer_norm_single_row(
@@ -10,7 +11,7 @@ kernel void layer_norm_single_row(
     device T* output [[buffer(1)]],
     device T* meanOut [[buffer(2)]],
     device T* rstdTensor [[buffer(3)]],
-    constant uint& axis_size [[buffer(4)]],
+    constant ulong& axis_size [[buffer(4)]],
     constant float& epsilon [[buffer(5)]],
     constant int& use_weight [[buffer(6)]],
     constant int& use_bias [[buffer(7)]],
@@ -18,105 +19,58 @@ kernel void layer_norm_single_row(
     device T* bias [[buffer(9)]],
     uint tg_id [[threadgroup_position_in_grid]],
     uint tid [[thread_position_in_threadgroup]],
-    uint simd_lane_id [[thread_index_in_simdgroup]],
-    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+    uint lsize [[threads_per_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]]) {
   constexpr int N_READS = 4;
 
-  // each threadgroup handles one full “row” of length axis_size
-  uint row_offset = tg_id * axis_size;
+  // Each threadgroup handles one full row of length axis_size, and each thread
+  // owns exactly its N_READS-element slice. The slice is loaded once and reused
+  // for the variance pass and the write-back
+  size_t row_offset = tg_id * size_t(axis_size);
   device T* x = input + row_offset + tid * N_READS;
   device T* out = output + row_offset + tid * N_READS;
 
-  // partial sums for calculating mean & variance
-  float partial_sum = 0.0f;
-  float partial_sum_sq = 0.0f;
   uint base_lane = tid * N_READS;
-  if (base_lane + N_READS <= axis_size) {
-    float4 v4 = float4(x[0], x[1], x[2], x[3]);
-    partial_sum = v4.x + v4.y + v4.z + v4.w;
-    partial_sum_sq = dot(v4, v4);
-  } else {
-    int remaining = axis_size - base_lane;
-    if (remaining >= 3) {
-      float3 v3 = float3(x[0], x[1], x[2]);
-      partial_sum = v3.x + v3.y + v3.z;
-      partial_sum_sq = dot(v3, v3);
-    } else if (remaining >= 2) {
-      float2 v2 = float2(x[0], x[1]);
-      partial_sum = v2.x + v2.y;
-      partial_sum_sq = dot(v2, v2);
-    } else if (remaining >= 1) {
-      float v = x[0];
-      partial_sum = v;
-      partial_sum_sq = fma(v, v, partial_sum_sq);
-    }
-  }
-
-  // threadgroup‐wide reduction
-  threadgroup float local_sums[simdgroup_size];
-  threadgroup float local_sums_sq[simdgroup_size];
-  threadgroup float tg_mean[1];
-  threadgroup float tg_inv_std[1];
-
-  if (simdgroup_id == 0) {
-    local_sums[simd_lane_id] = 0.0f;
-    local_sums_sq[simd_lane_id] = 0.0f;
-  }
-  threadgroup_barrier(mem_flags::mem_threadgroup);
-
-  // each simdgroup writes its partial
-  float group_partial_sum = simd_sum(partial_sum);
-  float group_partial_sum_sq = simd_sum(partial_sum_sq);
-  if (simd_lane_id == 0) {
-    local_sums[simdgroup_id] = group_partial_sum;
-    local_sums_sq[simdgroup_id] = group_partial_sum_sq;
-  }
-  threadgroup_barrier(mem_flags::mem_threadgroup);
-
-  // warp 0 reduces those 32 values
-  if (simdgroup_id == 0) {
-    float sum = simd_sum(local_sums[simd_lane_id]);
-    float sum_sq = simd_sum(local_sums_sq[simd_lane_id]);
-    if (simd_lane_id == 0) {
-      float mean = sum / float(axis_size);
-      float var = sum_sq / float(axis_size) - mean * mean;
-      var = var < 1e-6 ? 0.0f : var; // for rsqrt precision
-      float inv_std = metal::precise::rsqrt(var + epsilon);
-      tg_mean[0] = mean;
-      tg_inv_std[0] = inv_std;
-    }
-  }
-  threadgroup_barrier(mem_flags::mem_threadgroup);
-
-  float mean = tg_mean[0];
-  float inv_std = tg_inv_std[0];
-
-  // normalize and optional scale & shift
-  if (base_lane + N_READS <= axis_size) {
+  int count = min((int)N_READS, max(0, (int)axis_size - (int)base_lane));
+  float vals[N_READS];
 #pragma unroll
-    for (int i = 0; i < N_READS; i++) {
-      float v = float(x[i]);
-      float norm = (v - mean) * inv_std;
+  for (int i = 0; i < N_READS; i++) {
+    vals[i] = (i < count) ? float(x[i]) : 0.0f;
+  }
+
+  threadgroup float local_sum[simdgroup_size];
+  threadgroup float local_sum_sq[simdgroup_size];
+
+  float partial_sum = 0.0f;
+#pragma unroll
+  for (int i = 0; i < N_READS; i++) {
+    partial_sum += vals[i];
+  }
+  float mean =
+      threadgroup_sum(local_sum, partial_sum, tid, lsize) / float(axis_size);
+
+  // Two-pass variance from the centered values avoids the catastrophic
+  // cancellation of E[x^2]-E[x]^2 for small variances.
+  float partial_sum_sq = 0.0f;
+#pragma unroll
+  for (int i = 0; i < N_READS; i++) {
+    float d = (i < count) ? (vals[i] - mean) : 0.0f;
+    partial_sum_sq += d * d;
+  }
+  float var = threadgroup_sum(local_sum_sq, partial_sum_sq, tid, lsize) /
+      float(axis_size);
+  float inv_std = metal::precise::rsqrt(var + epsilon);
+
+#pragma unroll
+  for (int i = 0; i < N_READS; i++) {
+    if (i < count) {
+      float norm = (vals[i] - mean) * inv_std;
       uint lane_idx = base_lane + i;
       if (use_weight)
         norm *= float(weight[lane_idx]);
       if (use_bias)
         norm += float(bias[lane_idx]);
       out[i] = static_cast<T>(norm);
-    }
-  } else {
-#pragma unroll
-    for (int i = 0; i < N_READS; i++) {
-      uint lane_idx = base_lane + i;
-      if (lane_idx < axis_size) {
-        float v = float(x[i]);
-        float norm = (v - mean) * inv_std;
-        if (use_weight)
-          norm *= float(weight[lane_idx]);
-        if (use_bias)
-          norm += float(bias[lane_idx]);
-        out[i] = static_cast<T>(norm);
-      }
     }
   }
 
@@ -132,7 +86,7 @@ kernel void layer_norm_looped(
     device T* output [[buffer(1)]],
     device T* meanOut [[buffer(2)]],
     device T* rstdTensor [[buffer(3)]],
-    constant uint& axis_size [[buffer(4)]],
+    constant ulong& axis_size [[buffer(4)]],
     constant float& epsilon [[buffer(5)]],
     constant int& use_weight [[buffer(6)]],
     constant int& use_bias [[buffer(7)]],
@@ -141,80 +95,59 @@ kernel void layer_norm_looped(
     uint tg_id [[threadgroup_position_in_grid]],
     uint tid [[thread_position_in_threadgroup]],
     uint lsize [[threads_per_threadgroup]],
-    uint simd_lane_id [[thread_index_in_simdgroup]],
-    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+    uint simd_lane_id [[thread_index_in_simdgroup]]) {
   constexpr int N_READS = 4;
 
-  uint row_offset = tg_id * axis_size;
+  size_t row_offset = tg_id * size_t(axis_size);
   device T* x = input + row_offset;
   device T* out = output + row_offset;
 
+  // This kernel is used when axis_size > 1024 * N_READS, so the row cannot be
+  // cached in registers. The mean and variance passes each read it from global
+  // memory. Two passes keep it accurate for small variances
+  threadgroup float local_sum[simdgroup_size];
+  threadgroup float local_sum_sq[simdgroup_size];
+
   float partial_sum = 0.0f;
-  float partial_sum_sq = 0.0f;
-  for (uint r = 0; r < axis_size; r += lsize * N_READS) {
-    uint base = r + tid * N_READS;
+  for (ulong r = 0; r < axis_size; r += lsize * N_READS) {
+    ulong base = r + tid * N_READS;
     if (base + N_READS <= axis_size) {
-      float4 xi4 = float4(x[base], x[base + 1], x[base + 2], x[base + 3]);
-      partial_sum += xi4.x + xi4.y + xi4.z + xi4.w;
-      partial_sum_sq += dot(xi4, xi4);
+      float4 v4 = float4(x[base], x[base + 1], x[base + 2], x[base + 3]);
+      partial_sum += v4.x + v4.y + v4.z + v4.w;
     } else {
-      int remaining = axis_size - base;
-      if (remaining >= 3) {
-        float3 v3 = float3(x[base], x[base + 1], x[base + 2]);
-        partial_sum += v3.x + v3.y + v3.z;
-        partial_sum_sq += dot(v3, v3);
-      } else if (remaining >= 2) {
-        float2 v2 = float2(x[base], x[base + 1]);
-        partial_sum += v2.x + v2.y;
-        partial_sum_sq += dot(v2, v2);
-      } else if (remaining >= 1) {
-        float v = x[base];
-        partial_sum += v;
-        partial_sum_sq = fma(v, v, partial_sum_sq);
+#pragma unroll
+      for (int i = 0; i < N_READS; i++) {
+        if (base + i < axis_size) {
+          partial_sum += float(x[base + i]);
+        }
       }
     }
   }
+  float mean =
+      threadgroup_sum(local_sum, partial_sum, tid, lsize) / float(axis_size);
 
-  partial_sum = simd_sum(partial_sum);
-  partial_sum_sq = simd_sum(partial_sum_sq);
-
-  threadgroup float local_sums[simdgroup_size];
-  threadgroup float local_sums_sq[simdgroup_size];
-  threadgroup float tg_mean[1];
-  threadgroup float tg_inv_std[1];
-
-  if (simd_lane_id == 0) {
-    local_sums[simdgroup_id] = 0.0f;
-    local_sums_sq[simdgroup_id] = 0.0f;
-  }
-  threadgroup_barrier(mem_flags::mem_threadgroup);
-
-  if (simd_lane_id == 0) {
-    local_sums[simdgroup_id] = partial_sum;
-    local_sums_sq[simdgroup_id] = partial_sum_sq;
-  }
-  threadgroup_barrier(mem_flags::mem_threadgroup);
-
-  if (simdgroup_id == 0) {
-    float s = simd_sum(local_sums[simd_lane_id]);
-    float ss = simd_sum(local_sums_sq[simd_lane_id]);
-    if (simd_lane_id == 0) {
-      float mean = s / float(axis_size);
-      float var = ss / float(axis_size) - mean * mean;
-      var = var < 1e-6 ? 0.0f : var; // for rsqrt precision
-      float inv_std = metal::precise::rsqrt(var + epsilon);
-      tg_mean[0] = mean;
-      tg_inv_std[0] = inv_std;
+  float partial_sum_sq = 0.0f;
+  for (ulong r = 0; r < axis_size; r += lsize * N_READS) {
+    ulong base = r + tid * N_READS;
+    if (base + N_READS <= axis_size) {
+      float4 d4 = float4(x[base], x[base + 1], x[base + 2], x[base + 3]) - mean;
+      partial_sum_sq += dot(d4, d4);
+    } else {
+#pragma unroll
+      for (int i = 0; i < N_READS; i++) {
+        if (base + i < axis_size) {
+          float d = float(x[base + i]) - mean;
+          partial_sum_sq += d * d;
+        }
+      }
     }
   }
-  threadgroup_barrier(mem_flags::mem_threadgroup);
+  float var = threadgroup_sum(local_sum_sq, partial_sum_sq, tid, lsize) /
+      float(axis_size);
+  float inv_std = metal::precise::rsqrt(var + epsilon);
 
-  float mean = tg_mean[0];
-  float inv_std = tg_inv_std[0];
-
-  // write back normalized + scale/shift if needed
-  for (uint r = 0; r < axis_size; r += lsize * N_READS) {
-    uint base = r + tid * N_READS;
+  for (ulong r = 0; r < axis_size; r += lsize * N_READS) {
+    ulong base = r + tid * N_READS;
     if (base + N_READS <= axis_size) {
 #pragma unroll
       for (int i = 0; i < N_READS; i++) {
@@ -255,7 +188,7 @@ kernel void layer_norm_looped(
       device DTYPE * output [[buffer(1)]],                                \
       device DTYPE * meanOut [[buffer(2)]],                               \
       device DTYPE * rstdTensor [[buffer(3)]],                            \
-      constant uint & axis_size [[buffer(4)]],                            \
+      constant ulong & axis_size [[buffer(4)]],                           \
       constant float& epsilon [[buffer(5)]],                              \
       constant int& use_weight [[buffer(6)]],                             \
       constant int& use_bias [[buffer(7)]],                               \
@@ -263,8 +196,8 @@ kernel void layer_norm_looped(
       device DTYPE* bias [[buffer(9)]],                                   \
       uint tg_id [[threadgroup_position_in_grid]],                        \
       uint tid [[thread_position_in_threadgroup]],                        \
-      uint simd_lane_id [[thread_index_in_simdgroup]],                    \
-      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+      uint lsize [[threads_per_threadgroup]],                             \
+      uint simd_lane_id [[thread_index_in_simdgroup]]);
 
 #define instantiate_layer_norm_looped(DTYPE)                          \
   template [[host_name("layer_norm_looped_" #DTYPE)]] [[kernel]] void \
@@ -273,7 +206,7 @@ kernel void layer_norm_looped(
       device DTYPE * output [[buffer(1)]],                            \
       device DTYPE * meanOut [[buffer(2)]],                           \
       device DTYPE * rstdTensor [[buffer(3)]],                        \
-      constant uint & axis_size [[buffer(4)]],                        \
+      constant ulong & axis_size [[buffer(4)]],                       \
       constant float& epsilon [[buffer(5)]],                          \
       constant int& use_weight [[buffer(6)]],                         \
       constant int& use_bias [[buffer(7)]],                           \
@@ -282,8 +215,7 @@ kernel void layer_norm_looped(
       uint tg_id [[threadgroup_position_in_grid]],                    \
       uint tid [[thread_position_in_threadgroup]],                    \
       uint lsize [[threads_per_threadgroup]],                         \
-      uint simd_lane_id [[thread_index_in_simdgroup]],                \
-      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+      uint simd_lane_id [[thread_index_in_simdgroup]]);
 
 #define instantiate_layer_norm(DTYPE) \
   instantiate_layer_norm_single_row(DTYPE) instantiate_layer_norm_looped(DTYPE)

--- a/aten/src/ATen/native/mps/operations/Normalization.mm
+++ b/aten/src/ATen/native/mps/operations/Normalization.mm
@@ -958,7 +958,7 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_mps(const Tensor& input,
   auto rstd = at::empty(batch_shape, input.options(), MemoryFormat::Contiguous);
 
   auto input_shape = input.sizes();
-  int axis_size = static_cast<int>(N);
+  uint64_t axis_size = static_cast<uint64_t>(N);
   float epsilon_buf = static_cast<float>(eps);
   int use_weight_buf = weight.defined() ? 1 : 0;
   int use_bias_buf = bias.defined() ? 1 : 0;
@@ -991,7 +991,7 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_mps(const Tensor& input,
       } else if (use_bias_buf) {
         mps::mtl_setArgs<9>(computeEncoder, *bias_contig);
       }
-      MTLSize numThreads = MTLSizeMake(std::min((axis_size + N_READS - 1) / N_READS, 1024), 1, 1);
+      MTLSize numThreads = MTLSizeMake(std::min<uint64_t>((axis_size + N_READS - 1) / N_READS, 1024), 1, 1);
       MTLSize numThreadgroups = MTLSizeMake(M, 1, 1);
       [computeEncoder dispatchThreadgroups:numThreadgroups threadsPerThreadgroup:numThreads];
     });

--- a/aten/src/ATen/native/mps/operations/Normalization.mm
+++ b/aten/src/ATen/native/mps/operations/Normalization.mm
@@ -972,7 +972,6 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_mps(const Tensor& input,
   TORCH_CHECK_NOT_IMPLEMENTED(input.scalar_type() != kLong, "Not implemented for long on MPS");
   @autoreleasepool {
     dispatch_sync_with_rethrow(stream->queue(), ^() {
-      // which kernel variant to use based on the normalized axis N size
       const int N_READS = 4;
       auto metalType = mps::scalarToMetalTypeString(input);
       // Use 32-bit index math unless the tensor is too large for it.

--- a/aten/src/ATen/native/mps/operations/Normalization.mm
+++ b/aten/src/ATen/native/mps/operations/Normalization.mm
@@ -2,6 +2,7 @@
 
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/TensorUtils.h>
+#include <ATen/native/CanUse32BitIndexMath.h>
 #include <ATen/native/Pool.h>
 #include <ATen/native/layer_norm.h>
 #include <ATen/native/mps/OperationUtils.h>
@@ -974,22 +975,38 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_mps(const Tensor& input,
       // which kernel variant to use based on the normalized axis N size
       const int N_READS = 4;
       auto metalType = mps::scalarToMetalTypeString(input);
-      id<MTLComputePipelineState> layerNormKernel = nil;
-      if (axis_size <= 1024 * N_READS) {
-        layerNormKernel = mps::lib.getPipelineStateForFunc("layer_norm_single_row_" + metalType);
-      } else {
-        layerNormKernel = mps::lib.getPipelineStateForFunc("layer_norm_looped_" + metalType);
-      }
+      // Use 32-bit index math unless the tensor is too large for it.
+      const bool use32 = at::native::canUse32BitIndexMath(*X) && at::native::canUse32BitIndexMath(out);
+      const char* idx_str = use32 ? "i32" : "i64";
+      const char* variant = axis_size <= 1024 * N_READS ? "single_row" : "looped";
+      id<MTLComputePipelineState> layerNormKernel =
+          mps::lib.getPipelineStateForFunc(fmt::format("layer_norm_{}_{}_{}", variant, idx_str, metalType));
       id<MTLComputeCommandEncoder> computeEncoder = stream->commandEncoder();
       [computeEncoder setComputePipelineState:layerNormKernel];
 
-      mps::mtl_setArgs(computeEncoder, *X, out, mean, rstd, axis_size, epsilon_buf, use_weight_buf, use_bias_buf);
-      if (use_weight_and_bias_buf) {
-        mps::mtl_setArgs<8>(computeEncoder, *gamma, *bias_contig);
-      } else if (use_weight_buf) {
-        mps::mtl_setArgs<8>(computeEncoder, *gamma);
-      } else if (use_bias_buf) {
-        mps::mtl_setArgs<9>(computeEncoder, *bias_contig);
+      auto setLayerNormArgs = [&](auto idx_tag) {
+        using IDX_T = decltype(idx_tag);
+        mps::mtl_setArgs(computeEncoder,
+                         *X,
+                         out,
+                         mean,
+                         rstd,
+                         static_cast<IDX_T>(axis_size),
+                         epsilon_buf,
+                         use_weight_buf,
+                         use_bias_buf);
+        if (use_weight_and_bias_buf) {
+          mps::mtl_setArgs<8>(computeEncoder, *gamma, *bias_contig);
+        } else if (use_weight_buf) {
+          mps::mtl_setArgs<8>(computeEncoder, *gamma);
+        } else if (use_bias_buf) {
+          mps::mtl_setArgs<9>(computeEncoder, *bias_contig);
+        }
+      };
+      if (use32) {
+        setLayerNormArgs(uint32_t{});
+      } else {
+        setLayerNormArgs(uint64_t{});
       }
       MTLSize numThreads = MTLSizeMake(std::min<uint64_t>((axis_size + N_READS - 1) / N_READS, 1024), 1, 1);
       MTLSize numThreadgroups = MTLSizeMake(M, 1, 1);

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -2836,6 +2836,33 @@ class TestMPS(TestCaseMPS):
         # Regression test for https://github.com/pytorch/pytorch/issues/96113
         torch.nn.LayerNorm((16,), elementwise_affine=True).to("mps")(torch.randn(1, 2, 16).to("mps", dtype=torch.float16))
 
+    # Regression test for https://github.com/pytorch/pytorch/issues/190491: small
+    # per-row variance with small eps used to collapse rstd to rsqrt(eps) on MPS.
+    @parametrize("axis_size", [8, 8192])
+    def test_layer_norm_small_variance(self, axis_size):
+        a, eps = 1e-4, 1e-9  # var = a^2 = 1e-8, far below the old 1e-6 clamp
+        row = torch.tensor([a, -a] * (axis_size // 2), dtype=torch.float32)
+        cpu_x = row.repeat(4, 1)
+        weight = torch.rand(axis_size)
+        bias = torch.rand(axis_size)
+        cpu_y = F.layer_norm(cpu_x, (axis_size,), weight, bias, eps)
+        mps_y = F.layer_norm(
+            cpu_x.to('mps'), (axis_size,), weight.to('mps'), bias.to('mps'), eps)
+        self.assertEqual(mps_y, cpu_y)
+
+    # The row base offset (tg_id * axis_size) overflows 32 bits for tensors with
+    # more than 2**32 elements; check a row past that boundary still normalizes.
+    @largeTensorTest("18GB", device="mps")
+    def test_layer_norm_large_tensor_indexing(self):
+        axis_size = 8192  # > 1024 * N_READS, exercises the looped kernel
+        M = 2**32 // axis_size + 1  # last row starts at element offset >= 2**32
+        x = torch.randn(M, axis_size, dtype=torch.bfloat16, device="mps")
+        mps_y = F.layer_norm(x, (axis_size,))
+        # layer_norm is row-independent, so validate just the last row (whose
+        # offset overflows uint32) against CPU without a full-tensor CPU pass.
+        cpu_last = F.layer_norm(x[-1].float().cpu(), (axis_size,))
+        self.assertEqual(mps_y[-1].float().cpu(), cpu_last, atol=1e-2, rtol=1e-2)
+
     def test_ifft(self):
         # See: https://github.com/pytorch/pytorch/issues/124096
         device = torch.device("mps")

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -2853,10 +2853,10 @@ class TestMPS(TestCaseMPS):
     # The row base offset (tg_id * axis_size) overflows 32 bits for tensors with
     # more than 2**32 elements; check a row past that boundary still normalizes.
     @serialTest()
-    def test_layer_norm_large_tensor_indexing(self):
+    @parametrize("axis_size", [4096, 8192])  # 4096 -> single_row, 8192 -> looped
+    def test_layer_norm_large_tensor_indexing(self, axis_size):
         if torch.mps.recommended_max_memory() < 18_000_000_000:
             raise unittest.SkipTest("Needs at least 18GB of RAM")
-        axis_size = 8192  # > 1024 * N_READS, exercises the looped kernel
         M = 2**32 // axis_size + 1  # last row starts at element offset >= 2**32
         x = torch.randn(M, axis_size, dtype=torch.bfloat16, device="mps")
         mps_y = F.layer_norm(x, (axis_size,))

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -42,7 +42,7 @@ from torch.testing._internal.common_methods_invocations import (
     SpectralFuncInfo,
     BinaryUfuncInfo,
 )
-from torch.testing._internal.common_device_type import ops, dtypes, instantiate_device_type_tests, OpDTypes
+from torch.testing._internal.common_device_type import ops, dtypes, instantiate_device_type_tests, OpDTypes, largeTensorTest
 from torch.testing._internal.common_nn import NNTestCase
 from torch.testing._internal.common_quantization import _group_quantize_tensor, _dynamically_quantize_per_channel
 import numpy as np
@@ -2853,10 +2853,9 @@ class TestMPS(TestCaseMPS):
     # The row base offset (tg_id * axis_size) overflows 32 bits for tensors with
     # more than 2**32 elements; check a row past that boundary still normalizes.
     @serialTest()
+    @largeTensorTest("18GB", device="mps")
     @parametrize("axis_size", [4096, 8192])  # 4096 -> single_row, 8192 -> looped
     def test_layer_norm_large_tensor_indexing(self, axis_size):
-        if torch.mps.recommended_max_memory() < 18_000_000_000:
-            raise unittest.SkipTest("Needs at least 18GB of RAM")
         M = 2**32 // axis_size + 1  # last row starts at element offset >= 2**32
         x = torch.randn(M, axis_size, dtype=torch.bfloat16, device="mps")
         mps_y = F.layer_norm(x, (axis_size,))

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -42,7 +42,7 @@ from torch.testing._internal.common_methods_invocations import (
     SpectralFuncInfo,
     BinaryUfuncInfo,
 )
-from torch.testing._internal.common_device_type import ops, dtypes, instantiate_device_type_tests, OpDTypes, largeTensorTest
+from torch.testing._internal.common_device_type import ops, dtypes, instantiate_device_type_tests, OpDTypes
 from torch.testing._internal.common_nn import NNTestCase
 from torch.testing._internal.common_quantization import _group_quantize_tensor, _dynamically_quantize_per_channel
 import numpy as np
@@ -2852,8 +2852,10 @@ class TestMPS(TestCaseMPS):
 
     # The row base offset (tg_id * axis_size) overflows 32 bits for tensors with
     # more than 2**32 elements; check a row past that boundary still normalizes.
-    @largeTensorTest("18GB", device="mps")
+    @serialTest()
     def test_layer_norm_large_tensor_indexing(self):
+        if torch.mps.recommended_max_memory() < 18_000_000_000:
+            raise unittest.SkipTest("Needs at least 18GB of RAM")
         axis_size = 8192  # > 1024 * N_READS, exercises the looped kernel
         M = 2**32 // axis_size + 1  # last row starts at element offset >= 2**32
         x = torch.randn(M, axis_size, dtype=torch.bfloat16, device="mps")

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -25768,8 +25768,6 @@ python_ref_db = [
                          device_type="cpu", dtypes=(torch.float32,)),
             DecorateInfo(unittest.skip("Skipped!"), "TestCommon", "test_python_ref_torch_fallback",
                          device_type="cpu", dtypes=(torch.float32,)),
-            # TypeError: Cannot convert a MPS Tensor to float64 dtype as the MPS framework doesn't support float64
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref', device_type='mps', dtypes=(torch.float32,)),
             # Exception: Dtypes torch.float32 and torch.float16 are not equal!
             DecorateInfo(
                 unittest.expectedFailure, 'TestCommon', 'test_python_ref',


### PR DESCRIPTION
Fixes: https://github.com/pytorch/pytorch/issues/190491

Addresses the cancellation issue from one-pass kernel computing variance as E[x²] − E[x]² with the numerically stable two-pass version E[(x−μ)²]. The case where per-thread row slices can be cached in thread memory avoids doing the read twice has its own single row kernel and the looped kernel exists for the general case.

Benchmarked on an M2 Max, macOS27 beta.
```
  ┌───────────────┬────────────┬───────────────┬─────────────────┬───────┐
  │ shape (M × N) │   kernel   │ baseline (µs) │ fix, ulong (µs) │   Δ   │
  ├───────────────┼────────────┼───────────────┼─────────────────┼───────┤
  │ 50432 × 1024  │ single_row │ 1362          │ 1169            │ −14%  │
  ├───────────────┼────────────┼───────────────┼─────────────────┼───────┤
  │ 16384 × 4096  │ single_row │ 2126          │ 1896            │ −11%  │
  ├───────────────┼────────────┼───────────────┼─────────────────┼───────┤
  │ 8192 × 8192   │ looped     │ 2163          │ 2272            │ +5.0% │
  ├───────────────┼────────────┼───────────────┼─────────────────┼───────┤
  │ 4096 × 16384  │ looped     │ 2189          │ 2370            │ +8.3% │
  ├───────────────┼────────────┼───────────────┼─────────────────┼───────┤
  │ 4096 × 32768  │ looped     │ 4390          │ 4595            │ +4.7% │
  └───────────────┴────────────┴───────────────┴─────────────────┴───────┘

```

Adds support for 64-bit indexing while we are here. Avoids the silent overflow.

Two test cases, one addressing the cancellation issue and one for the new indexing.