### PR TITLE
[Stable C shim] Fix memory leak in StableIValue -> std::string conversion

### DIFF
--- a/test/cpp/shim/test_stable_ivalue.cpp
+++ b/test/cpp/shim/test_stable_ivalue.cpp
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 #include <torch/csrc/stable/c/shim.h>
+#include <torch/csrc/stable/stableivalue_conversions.h>
 #include <limits>
 
 TEST(TorchStableIValue, TestStableIValueUse) {
@@ -41,4 +42,15 @@ TEST(TorchStableIValue, TestStableIValueLargeAmount) {
     ASSERT_EQ(torch_delete_stable_ivalue(v), AOTI_TORCH_SUCCESS);
     v = nullptr;
   }
+}
+
+TEST(TorchStableIValue, TestStringRoundtrip) {
+  // This performs a simple roundtrip from std::string -> StableIValue ->
+  // std::string
+  const std::string our_string = "Hello World!";
+  const StableIValue as_stable_ivalue = torch::stable::detail::from(our_string);
+  const std::string string_back =
+      torch::stable::detail::to<std::string>(as_stable_ivalue);
+
+  ASSERT_EQ(string_back, our_string);
 }

--- a/torch/csrc/stable/stableivalue_conversions.h
+++ b/torch/csrc/stable/stableivalue_conversions.h
@@ -804,7 +804,7 @@ struct ToImpl<torch::stable::Device> {
 };
 
 // Specialization for std::string
-// Returns a new std::string; the string in val is deleted.
+// Returns an std::string; the string in val is deleted.
 template <>
 struct ToImpl<std::string> {
   static std::string call(
@@ -816,11 +816,11 @@ struct ToImpl<std::string> {
     STABLE_TORCH_ERROR_CODE_CHECK(torch_string_length(handle, &length));
     const char* data;
     STABLE_TORCH_ERROR_CODE_CHECK(torch_string_c_str(handle, &data));
-    auto strptr = new std::string(data, length);
+    const auto str = std::string(data, length);
 
     // delete the old string before returning new string
     STABLE_TORCH_ERROR_CODE_CHECK(torch_delete_string(handle));
-    return *strptr;
+    return str;
   }
 };
 

--- a/torch/csrc/stable/stableivalue_conversions.h
+++ b/torch/csrc/stable/stableivalue_conversions.h
@@ -804,7 +804,7 @@ struct ToImpl<torch::stable::Device> {
 };
 
 // Specialization for std::string
-// Returns an std::string; the string in val is deleted.
+// Returns a std::string which owns its memory; the string in val is deleted.
 template <>
 struct ToImpl<std::string> {
   static std::string call(
@@ -818,7 +818,7 @@ struct ToImpl<std::string> {
     STABLE_TORCH_ERROR_CODE_CHECK(torch_string_c_str(handle, &data));
     const auto str = std::string(data, length);
 
-    // delete the old string before returning new string
+    // delete the old string
     STABLE_TORCH_ERROR_CODE_CHECK(torch_delete_string(handle));
     return str;
   }


### PR DESCRIPTION
# Issue
- #174507, minor fix in the same area.
- Introduced in #168370, (66b4cf581fbfff3fb0ef107a36aa0de40d6805fe)  fyi @janeyx99 , @albanD 

# Summary
There's a memory leak in the function that converts StableIValue to std::string. On line 819 there's a heap allocation using a raw pointer stored in `strptr`, the return type is `std::string`, which copies the content by value. The pointer to the heap allocation can never leave the scope and as such is leaked, the returned value itself is correct.

https://github.com/pytorch/pytorch/blob/7a247c9f4626c5bac80d45ed3a6e4c6eeba54941/torch/csrc/stable/stableivalue_conversions.h#L810-L824
 


I've verified the leak by introducing the first commit (09a0deae7266ea05c2e503f5a4e208290046a1b4) that adds a simple roundtrip to the `test_stable_ivalue.cpp` test, using the valgrind runner we created this does indeed show the memory leak:

```
$./test/cpp/shim/run_test.sh ./build/bin/
<snip>
==86539== 32 bytes in 1 blocks are definitely lost in loss record 883 of 3,144
==86539==    at 0x4849013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==86539==    by 0x12E378: TorchStableIValue_TestStringRoundtrip_Test::TestBody() (in /workspace/pytorch/build/bin/test_shim)
==86539==    by 0x1768F0: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (in /workspace/pytorch/build/bin/test_shim)
==86539==    by 0x160334: testing::Test::Run() [clone .part.0] (in /workspace/pytorch/build/bin/test_shim)
==86539==    by 0x160B14: testing::TestInfo::Run() (in /workspace/pytorch/build/bin/test_shim)
==86539==    by 0x161752: testing::TestSuite::Run() [clone .part.0] (in /workspace/pytorch/build/bin/test_shim)
==86539==    by 0x16A725: testing::internal::UnitTestImpl::RunAllTests() (in /workspace/pytorch/build/bin/test_shim)
==86539==    by 0x160FC4: testing::UnitTest::Run() (in /workspace/pytorch/build/bin/test_shim)
==86539==    by 0x12B062: main (in /workspace/pytorch/build/bin/test_shim)
==86539== 
==86539== LEAK SUMMARY:
==86539==    definitely lost: 32 bytes in 1 blocks
==86539==    indirectly lost: 0 bytes in 0 blocks
==86539==      possibly lost: 0 bytes in 0 blocks
==86539==    still reachable: 187,149 bytes in 3,215 blocks
==86539==         suppressed: 0 bytes in 0 blocks
==86539== Reachable blocks (those to which a pointer was found) are not shown.
==86539== To see them, rerun with: --leak-check=full --show-leak-kinds=all
```

The second commit (3c4256a151798918918dcba2354d542900166289) removes the `new` allocation and just puts the string on the stack. Valgrind shows there's no leaks for that commit:

```
==92625== LEAK SUMMARY:
==92625==    definitely lost: 0 bytes in 0 blocks
==92625==    indirectly lost: 0 bytes in 0 blocks
==92625==      possibly lost: 0 bytes in 0 blocks
==92625==    still reachable: 187,149 bytes in 3,215 blocks
==92625==         suppressed: 0 bytes in 0 blocks
```

I discovered this just now while adding the [`div.Tensor_mode`](https://github.com/pytorch/pytorch/blob/v2.13.0/aten/src/ATen/native/native_functions.yaml#L2106-L2112) operation to my [flash_powder](https://github.com/iwanders/flash_powder) bindings. That doesn't actually use this conversion directly, but it is also exercised [here](https://github.com/pytorch/pytorch/blob/7a247c9f4626c5bac80d45ed3a6e4c6eeba54941/torch/csrc/shim_common.cpp#L295-L298) by the `to_ivalue` function that's called by the dispatcher for string arguments. So this leak showed up when I was testing my newly added modulo operation. So a pretty lucky find, and an easy fix :)  
