### PR TITLE
Pin Python for uv-based linters

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -37,6 +37,8 @@ exclude_patterns = [
 command = [
     'uv',
     'run',
+    '--python',
+    '3.10',
     '--script',
     'tools/linter/adapters/flake8_linter.py',
     '--',
@@ -410,6 +412,8 @@ include_patterns=['aten/src/ATen/native/native_functions.yaml']
 command = [
     'uv',
     'run',
+    '--python',
+    '3.10',
     '--script',
     'tools/linter/adapters/nativefunctions_linter.py',
     '--native-functions-yml=aten/src/ATen/native/native_functions.yaml',
@@ -422,6 +426,8 @@ include_patterns=['.github/workflows/**/*.yml']
 command = [
     'uv',
     'run',
+    '--python',
+    '3.10',
     '--script',
     'tools/linter/adapters/gha_linter.py',
     '--',
@@ -983,6 +989,8 @@ exclude_patterns = [
 command = [
     'uv',
     'run',
+    '--python',
+    '3.10',
     '--script',
     'tools/linter/adapters/cmake_linter.py',
     '--config=.cmakelintrc',
@@ -1001,6 +1009,8 @@ exclude_patterns = [
 command = [
     'uv',
     'run',
+    '--python',
+    '3.10',
     '--script',
     'tools/linter/adapters/shellcheck_linter.py',
     '--',
@@ -1119,6 +1129,8 @@ exclude_patterns = [
 command = [
     'uv',
     'run',
+    '--python',
+    '3.10',
     '--script',
     'tools/linter/adapters/test_has_main_linter.py',
     '--',
@@ -1205,6 +1217,8 @@ include_patterns = [
 command = [
     'uv',
     'run',
+    '--python',
+    '3.10',
     '--script',
     'tools/linter/adapters/workflow_consistency_linter.py',
     '--',
@@ -1223,6 +1237,8 @@ exclude_patterns = [
 command = [
     'uv',
     'run',
+    '--python',
+    '3.10',
     '--script',
     'tools/linter/adapters/no_workflows_on_fork.py',
     '--',
@@ -1234,6 +1250,8 @@ code = 'CODESPELL'
 command = [
     'uv',
     'run',
+    '--python',
+    '3.10',
     '--script',
     'tools/linter/adapters/codespell_linter.py',
     '--',
@@ -1269,6 +1287,8 @@ include_patterns = [
 command = [
     'uv',
     'run',
+    '--python',
+    '3.10',
     '--script',
     'tools/linter/adapters/pyfmt_linter.py',
     '--',
@@ -1552,6 +1572,8 @@ code = 'PYPROJECT'
 command = [
     'uv',
     'run',
+    '--python',
+    '3.10',
     '--script',
     'tools/linter/adapters/pyproject_linter.py',
     '--',
@@ -1566,6 +1588,8 @@ code = 'CMAKE_MINIMUM_REQUIRED'
 command = [
     'uv',
     'run',
+    '--python',
+    '3.10',
     '--script',
     'tools/linter/adapters/cmake_minimum_required_linter.py',
     '--',
@@ -1650,6 +1674,8 @@ exclude_patterns = [
 command = [
     'uv',
     'run',
+    '--python',
+    '3.10',
     '--script',
     'tools/linter/adapters/ruff_linter.py',
     '--config=pyproject.toml',

--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -11,6 +11,13 @@ import click
 import spin
 
 
+# tomllib is built in on Python 3.11+, and spin depends on tomli for older versions.
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+
+
 CWD = Path(__file__).absolute().parent.parent
 sys.path.insert(0, str(CWD))  # this only affects the current process
 from tools.clean import clean as _clean
@@ -235,6 +242,31 @@ LINTRUNNER_BASE_CMD = [
 ]
 
 
+def _check_linter_python_versions():
+    invalid_linters = []
+
+    with Path(".lintrunner.toml").open("rb") as config_file:
+        config = tomllib.load(config_file)
+    for linter in config["linter"]:
+        command = linter.get("command", [])
+        if command[:2] != ["uv", "run"] or "--script" not in command:
+            continue
+        try:
+            python_index = command.index("--python")
+        except ValueError:
+            python_index = -1
+        if python_index == -1 or command[python_index + 1 : python_index + 2] != [
+            "3.10"
+        ]:
+            invalid_linters.append(linter["code"])
+
+    if invalid_linters:
+        raise click.ClickException(
+            "Linters using `uv run --script` must specify `--python 3.10`: "
+            + ", ".join(invalid_linters)
+        )
+
+
 @click.command()
 def setup_lint():
     """Set up lintrunner with current CI version."""
@@ -243,6 +275,7 @@ def setup_lint():
 
 
 def _check_linters():
+    _check_linter_python_versions()
     cmd = LINTRUNNER_BASE_CMD + ["list"]
     ret = spin.util.run(cmd, output=False, stderr=subprocess.PIPE)
     linters = {l.strip() for l in ret.stdout.decode().strip().split("\n")[1:]}


### PR DESCRIPTION
## Author Notes

Just realized more were unpinned. Hopefully this will improve local vs CI more

## Agent Notes

Pins all remaining PEP 723 lintrunner adapters to Python 3.10 so nested `uv run` invocations use the same interpreter locally and in CI. Extends spin's existing linter configuration preflight to parse `.lintrunner.toml` and reject future `uv run --script` commands that omit the Python 3.10 pin.

Test Plan:

```
spin lint
```

Authored with an AI assistant.
