### PR TITLE
Fix cusparselt.cpp build when neither USE_CUSPARSELT nor USE_HIPSPARSELT is defined

### DIFF
--- a/torch/csrc/cuda/shared/cusparselt.cpp
+++ b/torch/csrc/cuda/shared/cusparselt.cpp
@@ -1,5 +1,6 @@
 #include <torch/csrc/utils/pybind.h>
 
+#if defined(USE_CUSPARSELT) || defined(USE_HIPSPARSELT)
 #include <ATen/native/sparse/cuda/cuSPARSELtOps.h>
 #ifdef USE_HIPSPARSELT
 #include <hipsparselt/hipsparselt-version.h>
@@ -58,3 +59,4 @@ void initCusparseltBindings(PyObject* module) {
 }
 
 } // namespace torch::cuda::shared
+#endif


### PR DESCRIPTION
#178737 removed the file-level `#ifdef USE_CUSPARSELT` guard around `torch/csrc/cuda/shared/cusparselt.cpp` and only gates the `getVersionInt()` definition. The `cusparselt.def("getVersionInt", getVersionInt)` registration is now compiled unconditionally, so building the translation unit with neither macro defined fails:

```
cusparselt.cpp:56:35: error: use of undeclared identifier 'getVersionInt'
```

This restores a file-level `#if defined(USE_CUSPARSELT) || defined(USE_HIPSPARSELT)` guard around the file body, matching the source-gating condition in `torch/CMakeLists.txt`. The file compiles to an empty TU when neither macro is set, preserving the intended behavior.