### PR TITLE
[release/2.13] Keep static kernel owner alive in fast launcher

### DIFF
--- a/test/inductor/test_static_triton_launcher.py
+++ b/test/inductor/test_static_triton_launcher.py
@@ -81,6 +81,59 @@ class TestStaticTritonLauncherUnit(TestCase):
         self.assertIsNone(launcher.function)
         self.assertIsNone(launcher.module)
 
+    def test_fast_launcher_keeps_kernel_owner_alive(self):
+        """
+        _build_fast_launcher bakes kernel.function into a _FastCudaLauncher and
+        replaces the "runner" global, dropping the launcher's only reference to
+        the owning kernel. It must retain the owner so the kernel (and its
+        loaded module) cannot be collected/unloaded while the fast launcher is
+        still callable.
+        """
+        import types
+
+        class FakeFastLauncher:
+            def __init__(self, func, num_warps, shared, arg_tys, n_scratch):
+                self.func = func
+
+        kernel = object.__new__(StaticallyLaunchedCudaKernel)
+        kernel.function = 0xF00D
+        kernel.num_warps = 4
+        kernel.shared = 0
+        kernel.arg_tys = "O"
+        kernel.has_global_scratch = False
+        kernel.has_profile_scratch = False
+
+        launcher_globals = {"runner": kernel.run}
+
+        def _launcher_body(grid_0, grid_1, grid_2, stream, *args):
+            runner(grid_0, grid_1, grid_2, stream, *args)  # noqa: F821
+
+        launcher = types.FunctionType(
+            _launcher_body.__code__, launcher_globals, "launcher"
+        )
+        launcher._is_static = True
+
+        autotuner = object.__new__(CachingAutotuner)
+        autotuner.inductor_meta = {"use_fast_triton_launcher": True}
+        autotuner.device_props = SimpleNamespace(type="cuda")
+
+        with mock.patch("torch._C._FastCudaLauncher", FakeFastLauncher, create=True):
+            fast_launcher = autotuner._build_fast_launcher(launcher)
+
+        self.assertIsNotNone(fast_launcher)
+        self.assertIs(fast_launcher._static_kernel_owner, kernel)
+        self.assertNotIn(kernel.run, fast_launcher.__globals__.values())
+
+        owner_ref = weakref.ref(kernel)
+        del kernel, launcher, launcher_globals
+        gc.collect()
+        # Only fast_launcher._static_kernel_owner keeps the kernel alive now.
+        self.assertIsNotNone(owner_ref())
+
+        del fast_launcher
+        gc.collect()
+        self.assertIsNone(owner_ref())
+
     @staticmethod
     def _autotuner_with_static_cubin(cubin_raw):
         autotuner = object.__new__(CachingAutotuner)

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2293,6 +2293,15 @@ class CachingAutotuner(KernelInterface):
                 val = getattr(launcher, attr, None)
                 if val is not None:
                     setattr(new_launcher, attr, val)
+            # _FastCudaLauncher bakes kernel.function (a raw CUfunction pointer)
+            # into a C object and never re-reads it, and replacing the "runner"
+            # global drops this launcher's only reference to the owning static
+            # kernel. Without an explicit reference the kernel can be collected or
+            # closed while this launcher is still cached and callable; its
+            # close()/__del__ then unloads the module and leaves the baked pointer
+            # dangling, producing a CUDA "misaligned address" error on the next
+            # launch. Keep the owner alive for as long as the fast launcher is.
+            new_launcher._static_kernel_owner = kernel  # type: ignore[attr-defined]
             return new_launcher
         except (AttributeError, TypeError, KeyError, ValueError):
             # Expected failures - silent fallback is OK.


### PR DESCRIPTION
Summary
Backport the static-launcher lifetime fix from upstream PR #188607 (0e67836a0c42c228e44e070267e2eb7472523fdf) to release/2.13.

_FastCudaLauncher stores a raw CUfunction, but _build_fast_launcher() replaces the bound runner and otherwise drops the only reference to the static kernel that owns the loaded CUDA module. The kernel can then be collected, its destructor unloads the module, and the cached launcher calls a dangling function pointer.

Keep the static kernel as _static_kernel_owner on the fast launcher and add a focused owner-lifetime regression test.

Impact
This fixes TorchInductor hard crashes observed after upgrading from Torch 2.11 to 2.13, including xdist workers terminating with CUDA illegal-instruction or segmentation-fault signals on an R575 B200 compatibility lane. No public API changes.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo