### PR TITLE
[xpu] Fix OneDNN SDPA with GQA + broadcasted mask

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/detail/Attention.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Attention.cpp
@@ -102,11 +102,11 @@ struct SDPALogicalParams {
       // [batch_size, num_head_q / num_head_kv, num_head_kv, seq_len_q,
       // head_dim_qk]. Please refer to
       // https://uxlfoundation.github.io/oneDNN/dev_guide_graph_gqa.html#gqa-pattern
-      reshaped_query = query_.view(
+      reshaped_query = reshaped_query.view(
           {batch_size, group_num, group_size, seq_len_q, head_dim_qk});
-      reshaped_key = key_.unsqueeze(2);
-      reshaped_value = value_.unsqueeze(2);
-      reshaped_attention = attention_.view(
+      reshaped_key = reshaped_key.unsqueeze(2);
+      reshaped_value = reshaped_value.unsqueeze(2);
+      reshaped_attention = reshaped_attention.view(
           {batch_size, group_num, group_size, seq_len_q, head_dim_v});
       if (attn_mask_.has_value() && attn_mask_.value().dim() == 4) {
         reshaped_attn_mask = reshaped_attn_mask.unsqueeze(2);

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Attention.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Attention.cpp
@@ -109,7 +109,7 @@ struct SDPALogicalParams {
       reshaped_attention = attention_.view(
           {batch_size, group_num, group_size, seq_len_q, head_dim_v});
       if (attn_mask_.has_value() && attn_mask_.value().dim() == 4) {
-        reshaped_attn_mask = attn_mask_.value().unsqueeze(2);
+        reshaped_attn_mask = reshaped_attn_mask.unsqueeze(2);
       }
     }
 

--- a/test/xpu/test_transformers.py
+++ b/test/xpu/test_transformers.py
@@ -115,6 +115,79 @@ class TestSDPAXpuOnly(NNTestCase):
             self.assertEqual(grad_k_actual, grad_k_ref, atol=tol.atol, rtol=tol.rtol)
             self.assertEqual(grad_v_actual, grad_v_ref, atol=tol.atol, rtol=tol.rtol)
 
+    @parametrize("dtype", [torch.half, torch.bfloat16])
+    def test_onednn_attention_broadcast_mask_gqa(self, device, dtype):
+        """Verify SDPA with GQA (grouped query attention) and a broadcast
+        attn_mask works correctly.
+
+        The attn_mask is broadcast across batch and head dimensions via
+        as_strided, which is a common pattern in real models. Combined with
+        GQA (query_heads > key_value_heads), this exercises the broadcast +
+        GQA code path in the OneDNN backend.
+        """
+        tol = Tolerances(1e-2, 1e-2)
+        if dtype is torch.bfloat16:
+            tol = Tolerances(5e-2, 5e-2)
+
+        batch_size = 1
+        query_heads = 2
+        key_value_heads = 1
+        seq_len = 128
+        head_dim = 128
+
+        torch.manual_seed(0)
+        query = torch.randn(
+            batch_size, query_heads, seq_len, head_dim, device=device, dtype=dtype
+        )
+        key = torch.randn(
+            batch_size, key_value_heads, seq_len, head_dim, device=device, dtype=dtype
+        )
+        value = torch.randn(
+            batch_size, key_value_heads, seq_len, head_dim, device=device, dtype=dtype
+        )
+        # Broadcast mask: base shape (seq_len,) expanded to (B, H, S, S) via stride (0,0,0,1)
+        attn_mask_base = torch.linspace(
+            0.1766357421875, 0.73828125, seq_len, device=device, dtype=dtype
+        )
+        attn_mask = torch.as_strided(
+            attn_mask_base,
+            (batch_size, query_heads, seq_len, seq_len),
+            (0, 0, 0, 1),
+        )
+        scale = head_dim**-0.5
+
+        with sdpa_kernel(backends=[SDPBackend.OVERRIDEABLE]):
+            actual = F.scaled_dot_product_attention(
+                query,
+                key,
+                value,
+                attn_mask=attn_mask,
+                dropout_p=0.0,
+                is_causal=False,
+                scale=scale,
+                enable_gqa=True,
+            )
+
+        # Math reference: expand K/V to match query heads for manual computation
+        key_expanded = key.expand(batch_size, query_heads, seq_len, head_dim)
+        value_expanded = value.expand(batch_size, query_heads, seq_len, head_dim)
+        attn_mask_contig = attn_mask.expand(
+            batch_size, query_heads, seq_len, seq_len
+        ).contiguous()
+
+        with sdpa_kernel(backends=[SDPBackend.MATH]):
+            expected = F.scaled_dot_product_attention(
+                query.contiguous(),
+                key_expanded.contiguous(),
+                value_expanded.contiguous(),
+                attn_mask=attn_mask_contig,
+                dropout_p=0.0,
+                is_causal=False,
+                scale=scale,
+            )
+
+        self.assertEqual(actual, expected, atol=tol.atol, rtol=tol.rtol)
+
 
 instantiate_device_type_tests(
     TestSDPAXpuOnly, globals(), only_for="xpu", allow_xpu=True


### PR DESCRIPTION
Fix https://github.com/intel/torch-xpu-ops/issues/4369 which run into OneDNN SDPA GQA + broadcasted mask path.

where the `attn_mask_.unsqueeze(2)` should be replaced with `undo_broadcast(reshaped_attn_mask)`
```
if (attn_mask_.has_value() &&
        at::native::onednn::is_broadcast(reshaped_attn_mask)) {
      at::native::onednn::undo_broadcast(reshaped_attn_mask);
    }

    if (num_head_q != num_head_kv) { // Check whether the attention is a
                                     // Grouped-Query Attention (GQA)
      int group_num = num_head_kv;
      int group_size = num_head_q / num_head_kv;
      // oneDNN requires the shape of the query tensor to be represented as
      // [batch_size, num_head_q / num_head_kv, num_head_kv, seq_len_q,
      // head_dim_qk]. Please refer to
      // https://uxlfoundation.github.io/oneDNN/dev_guide_graph_gqa.html#gqa-pattern
      reshaped_query = query_.view(
          {batch_size, group_num, group_size, seq_len_q, head_dim_qk});
      reshaped_key = key_.unsqueeze(2);
      reshaped_value = value_.unsqueeze(2);
      reshaped_attention = attention_.view(
          {batch_size, group_num, group_size, seq_len_q, head_dim_v});
      if (attn_mask_.has_value() && attn_mask_.value().dim() == 4) {
        reshaped_attn_mask = attn_mask_.unsqueeze(2);
      }
    }
```

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01