### PR TITLE
[inductor][ci][experiment] Disable Inductor OpInfo comprehensive on CPU

### DIFF
--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -51,7 +51,6 @@ from torch.testing._internal.common_utils import (
 )
 from torch.testing._internal.inductor_utils import (
     GPU_TYPE,
-    HAS_CPU,
     HAS_CUDA_AND_TRITON,
     has_triton,
     HAS_XPU_AND_TRITON,
@@ -1299,7 +1298,7 @@ class TestInductorOpInfo(TestCase):
     @skipXPUIf(
         not HAS_XPU_AND_TRITON, "Skipped! Supported XPU compiler and Triton not found"
     )
-    @skipCPUIf(not HAS_CPU, "Skipped! Supported CPU compiler not found")
+    @skipCPUIf(True, "Skipped! OpInfo CPU coverage disabled to restore CI TTS")
     @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
     @skipIfTorchDynamo("Test uses dynamo already")
     @skipIfCrossRef


### PR DESCRIPTION
Compare effect of running CPU Opinfo on all default targets. Early analysis indicates this consumes 30%+ of default test runs, so we'd like to examine this more closely with a revert to compare side-by-side. 

This change was authored with an AI coding assistant (Claude Code) and reviewed by the commit author.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo