### PR TITLE
Save result instead of input for inplace hardtanh backward

### DIFF
--- a/aten/src/ATen/native/mps/operations/Activation.mm
+++ b/aten/src/ATen/native/mps/operations/Activation.mm
@@ -588,12 +588,12 @@ Tensor& hardtanh_backward_out_mps(const Tensor& grad_output,
       MPSGraphTensor* maxTensor = [mpsGraph constantWithScalar:max.to<double>()
                                                          shape:@[ @1 ]
                                                       dataType:getMPSDataType(grad_output)];
-      MPSGraphTensor* greaterThanMaxPredicateTensor = [mpsGraph greaterThanWithPrimaryTensor:inputTensor
-                                                                             secondaryTensor:maxTensor
-                                                                                        name:nil];
-      MPSGraphTensor* lesserThanMinPredicateTensor = [mpsGraph lessThanWithPrimaryTensor:inputTensor
-                                                                         secondaryTensor:minTensor
-                                                                                    name:nil];
+      MPSGraphTensor* greaterThanMaxPredicateTensor = [mpsGraph greaterThanOrEqualToWithPrimaryTensor:inputTensor
+                                                                                    secondaryTensor:maxTensor
+                                                                                               name:nil];
+      MPSGraphTensor* lesserThanMinPredicateTensor = [mpsGraph lessThanOrEqualToWithPrimaryTensor:inputTensor
+                                                                                 secondaryTensor:minTensor
+                                                                                            name:nil];
       MPSGraphTensor* greaterThanMaxGradTensor = [mpsGraph selectWithPredicateTensor:greaterThanMaxPredicateTensor
                                                                  truePredicateTensor:zeroTensor
                                                                 falsePredicateTensor:unitTensor

--- a/aten/src/ATen/native/mps/operations/Activation.mm
+++ b/aten/src/ATen/native/mps/operations/Activation.mm
@@ -501,12 +501,12 @@ Tensor& hardtanh_backward_out_mps(const Tensor& grad_output,
       MPSGraphTensor* maxTensor = [mpsGraph constantWithScalar:max.to<double>()
                                                          shape:@[ @1 ]
                                                       dataType:getMPSDataType(grad_output)];
-      MPSGraphTensor* greaterThanMaxPredicateTensor = [mpsGraph greaterThanWithPrimaryTensor:inputTensor
-                                                                             secondaryTensor:maxTensor
-                                                                                        name:nil];
-      MPSGraphTensor* lesserThanMinPredicateTensor = [mpsGraph lessThanWithPrimaryTensor:inputTensor
-                                                                         secondaryTensor:minTensor
-                                                                                    name:nil];
+      MPSGraphTensor* greaterThanMaxPredicateTensor = [mpsGraph greaterThanOrEqualToWithPrimaryTensor:inputTensor
+                                                                                    secondaryTensor:maxTensor
+                                                                                               name:nil];
+      MPSGraphTensor* lesserThanMinPredicateTensor = [mpsGraph lessThanOrEqualToWithPrimaryTensor:inputTensor
+                                                                                 secondaryTensor:minTensor
+                                                                                            name:nil];
       MPSGraphTensor* greaterThanMaxGradTensor = [mpsGraph selectWithPredicateTensor:greaterThanMaxPredicateTensor
                                                                  truePredicateTensor:zeroTensor
                                                                 falsePredicateTensor:unitTensor

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4247,6 +4247,26 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         gradcheck(func, [v])
         gradgradcheck(func, [v])
 
+    def test_hardtanh_inplace_no_input_save(self):
+        x = torch.randn(128, 100, requires_grad=True)
+        cloned = x.clone()
+        F.hardtanh(cloned, inplace=True)
+        saved = [t for t in cloned.grad_fn.saved_tensors]
+        for t in saved:
+            self.assertTrue(
+                t.data_ptr() == cloned.data_ptr(),
+                "Inplace hardtanh should save result, not a copy of input",
+            )
+
+    def test_hardtanh_inplace_correctness(self):
+        x = torch.tensor([-2.0, -1.0, -0.5, 0.0, 0.5, 1.0, 2.0], requires_grad=True)
+        x_ref = x.detach().clone().requires_grad_(True)
+        y = F.hardtanh(x.clone(), inplace=True)
+        y_ref = F.hardtanh(x_ref)
+        y.sum().backward()
+        y_ref.sum().backward()
+        self.assertEqual(x.grad, x_ref.grad)
+
     # test hardtanh backward for large tensor
     def test_hardtanh_backward(self):
         x = torch.randn(128, 10000, requires_grad=True)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3628,6 +3628,26 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         gradcheck(func, [v])
         gradgradcheck(func, [v])
 
+    def test_hardtanh_inplace_no_input_save(self):
+        x = torch.randn(128, 100, requires_grad=True)
+        cloned = x.clone()
+        F.hardtanh(cloned, inplace=True)
+        saved = [t for t in cloned.grad_fn.saved_tensors]
+        for t in saved:
+            self.assertTrue(
+                t.data_ptr() == cloned.data_ptr(),
+                "Inplace hardtanh should save result, not a copy of input",
+            )
+
+    def test_hardtanh_inplace_correctness(self):
+        x = torch.tensor([-2.0, -1.0, -0.5, 0.0, 0.5, 1.0, 2.0], requires_grad=True)
+        x_ref = x.detach().clone().requires_grad_(True)
+        y = F.hardtanh(x.clone(), inplace=True)
+        y_ref = F.hardtanh(x_ref)
+        y.sum().backward()
+        y_ref.sum().backward()
+        self.assertEqual(x.grad, x_ref.grad)
+
     # test hardtanh backward for large tensor
     def test_hardtanh_backward(self):
         x = torch.randn(128, 10000, requires_grad=True)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -2184,6 +2184,10 @@
   self: hardtanh_backward(grad, self, min_val, max_val)
   result: auto_element_wise
 
+- name: hardtanh_(Tensor(a!) self, Scalar min_val=-1, Scalar max_val=1) -> Tensor(a!)
+  self: hardtanh_backward(grad, result, min_val, max_val)
+  result: self_t.copy_(hardtanh_backward(original_self_t.conj(), result, min_val, max_val).conj())
+
 - name: leaky_relu(Tensor self, Scalar negative_slope=0.01) -> Tensor
   self: leaky_relu_backward(grad, self, negative_slope, false)
   result: auto_element_wise

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -2168,6 +2168,10 @@
   self: hardtanh_backward(grad, self, min_val, max_val)
   result: auto_element_wise
 
+- name: hardtanh_(Tensor(a!) self, Scalar min_val=-1, Scalar max_val=1) -> Tensor(a!)
+  self: hardtanh_backward(grad, result, min_val, max_val)
+  result: self_t.copy_(hardtanh_backward(original_self_t.conj(), result, min_val, max_val).conj())
+
 - name: leaky_relu(Tensor self, Scalar negative_slope=0.01) -> Tensor
   self: leaky_relu_backward(grad, self, negative_slope, false)
   result: auto_element_wise


### PR DESCRIPTION
Fixes #95432

## Summary

`hardtanh_` (inplace) saves a copy of the input tensor for backward, negating the memory savings that `inplace=True` should provide. This PR adds a separate `hardtanh_` derivative entry that references `result` instead of `self`, following the `leaky_relu_` pattern. Also fixes MPS boundary comparisons to match CPU/CUDA.

## Changes

1. `tools/autograd/derivatives.yaml`: Add `hardtanh_` inplace entry using `result`
2. `aten/src/ATen/native/mps/operations/Activation.mm`: Fix `>=`/`<=` comparisons
3. `test/test_nn.py`: Add inplace memory and correctness tests

## Context

- Prior PR #101387 was approved by @albanD but closed stale due to an MPS test failure. The MPS bug was that `hardtanh_backward_mps` used strict `>` / `<` comparisons instead of `>=` / `<=`, causing incorrect gradients at boundary values when given the result tensor. This PR fixes the MPS kernel as well.
- Root cause: PR #62329 changed `result` to `self` in the hardtanh derivative to fix XLA, which inadvertently broke inplace memory savings.
- This also fixes `ReLU6(inplace=True)` since `relu6_` dispatches to `hardtanh_`.

cc @albanD @soulitzer