### PR TITLE
[Testcase Refactoring] Decouple test_auto_chunker.py from CUDA-specific

### DIFF
--- a/test/inductor/test_auto_chunker.py
+++ b/test/inductor/test_auto_chunker.py
@@ -8,6 +8,7 @@ from torch._inductor import config, metrics
 from torch._inductor.test_case import TestCase
 from torch.testing._internal.common_device_type import largeTensorTest
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
 )
@@ -33,6 +34,8 @@ class LinearAndCEL(nn.Module):
 @config.patch("auto_chunker.enable", True)
 @instantiate_parametrized_tests
 class AutoChunkerTest(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def setUp(self):
         super().setUp()
         metrics.reset()
@@ -72,7 +75,7 @@ class AutoChunkerTest(TestCase):
         weight.grad = None
         bias.grad = None
 
-        torch.cuda.reset_peak_memory_stats()
+        torch.accelerator.reset_peak_memory_stats()
         opt_f = torch.compile(f, dynamic=dynamic_shape)
         actual = (
             opt_f(_input, weight, bias),
@@ -80,7 +83,7 @@ class AutoChunkerTest(TestCase):
             weight.grad,
             bias.grad if use_bias else None,
         )
-        peak_memory = torch.cuda.max_memory_allocated()
+        peak_memory = torch.accelerator.max_memory_allocated()
 
         print(f"Peak memory {peak_memory / 10**9:.6f} GB")
 
@@ -133,7 +136,7 @@ class AutoChunkerTest(TestCase):
 
         dtype = torch.bfloat16
 
-        mod = LinearAndCEL(C, V).cuda().to(dtype)
+        mod = LinearAndCEL(C, V).to(device=GPU_TYPE, dtype=dtype)
 
         def f(x, y):
             x.grad = None
@@ -147,13 +150,13 @@ class AutoChunkerTest(TestCase):
 
         opt_f = torch.compile(f)
 
-        x = torch.randn(B, T, C, dtype=dtype, requires_grad=True, device="cuda")
-        y = torch.randint(0, V, (B, T)).cuda()
+        x = torch.randn(B, T, C, dtype=dtype, requires_grad=True, device=GPU_TYPE)
+        y = torch.randint(0, V, (B, T)).to(GPU_TYPE)
 
         expect = (f(x, y), x.grad, mod.linear.weight.grad, mod.linear.bias.grad)
-        torch.cuda.reset_peak_memory_stats()
+        torch.accelerator.reset_peak_memory_stats()
         actual = (opt_f(x, y), x.grad, mod.linear.weight.grad, mod.linear.bias.grad)
-        peak_memory = torch.cuda.max_memory_allocated()
+        peak_memory = torch.accelerator.max_memory_allocated()
         print(f"Peak memory {peak_memory / 10**9:.6f} GB")
 
         self.assertTrue(
@@ -195,7 +198,7 @@ class AutoChunkerTest(TestCase):
 
         dtype = torch.bfloat16
 
-        mod = LinearAndCEL(C, V).cuda().to(dtype)
+        mod = LinearAndCEL(C, V).to(device=GPU_TYPE, dtype=dtype)
 
         def f(x, y):
             x.grad = None
@@ -218,11 +221,11 @@ class AutoChunkerTest(TestCase):
         opt_f = torch.compile(f)
 
         xs = [
-            torch.randn(B, T, C, dtype=dtype, requires_grad=True, device="cuda")
+            torch.randn(B, T, C, dtype=dtype, requires_grad=True, device=GPU_TYPE)
             for _ in range(gradient_accumulation_steps)
         ]
         ys = [
-            torch.randint(0, V, (B, T)).cuda()
+            torch.randint(0, V, (B, T)).to(GPU_TYPE)
             for _ in range(gradient_accumulation_steps)
         ]
 
@@ -232,14 +235,14 @@ class AutoChunkerTest(TestCase):
             mod.linear.weight.grad,
             mod.linear.bias.grad,
         )
-        torch.cuda.reset_peak_memory_stats()
+        torch.accelerator.reset_peak_memory_stats()
         actual = (
             step(opt_f, xs, ys),
             *[x.grad for x in xs],
             mod.linear.weight.grad,
             mod.linear.bias.grad,
         )
-        peak_memory = torch.cuda.max_memory_allocated()
+        peak_memory = torch.accelerator.max_memory_allocated()
         print(f"Peak memory {peak_memory / 10**9:.6f} GB")
 
         self.assertTrue(
@@ -394,9 +397,11 @@ class AutoChunkerTest(TestCase):
             "auto_chunker.num_chunk": 16,
             "auto_chunker.amplify_ratio_threshold": 10,
         }
-        mod = torch.compile(LinearAndCEL(C, V).cuda().to(dtype), options=options)
-        x = torch.randn(B, T, C, dtype=dtype, requires_grad=True, device="cuda")
-        y = torch.randint(0, V, (B, T)).cuda()
+        mod = torch.compile(
+            LinearAndCEL(C, V).to(device=GPU_TYPE, dtype=dtype), options=options
+        )
+        x = torch.randn(B, T, C, dtype=dtype, requires_grad=True, device=GPU_TYPE)
+        y = torch.randint(0, V, (B, T)).to(GPU_TYPE)
         mod(x, y).backward()
         self.assertEqual(metrics.num_auto_chunking, 1)
 


### PR DESCRIPTION
## Summary
This PR replaces hardcoded CUDA references with device-agnostic equivalents so out-of-tree accelerator backends can run these tests.

## Changes
- Replace hardcoded `device="cuda"` and `.cuda()` with device-generic `GPU_TYPE`.
- Replace hardcoded CUDA references `torch.cuda.xxx` with device-agnostic `torch.accelerator` APIs or equivalents.
- Instantiate device-agnostic test templates as device-specific test classes for multiple differrent device backends.
- Add `hw_classification = HardwareClassification.GENERIC|ACCELERATOR` to tests class.

## Motivation
`torch.cuda` only recognizes CUDA, `device="cuda"` and `.cuda()` are hardcoded CUDA-specific. New accelerators (e.g., `PrivateUse1`-based out-of-tree backends) are silently skipped even when enough devices are available. A generic decorator lets inductor tests adapt to any accelerator supported by `torch.accelerator`.

## Test Plan
- CI: `python test/inductor/test_auto_chunker.py --hw-classification GENERIC ACCELERATOR CUDA CPU XXX`
- Verified test cases correctly on CPU, GPU, and XPU.

## Notes
- This is part of the test case refactoring initiative tracked in #185590.
- Make CUDA/XPU device-generic in #189138.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo