### PR TITLE
[Test][1/N] Add proper `hw_classification` attribute to test classes

### DIFF
--- a/test/test_as_strided.py
+++ b/test/test_as_strided.py
@@ -3,7 +3,11 @@
 from collections import deque
 
 import torch
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 def get_state(t: torch.Tensor) -> tuple[tuple[int, ...], tuple[int, ...]]:
@@ -84,6 +88,8 @@ def enumerate_reachable_states(
 
 
 class TestAsStrided(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_size_10_exhaustive(self) -> None:
         """Test that size 10 produces exactly the expected 54 states."""
         expected_states = {

--- a/test/test_autocast.py
+++ b/test/test_autocast.py
@@ -11,11 +11,18 @@ from torch.testing._internal.common_device_type import (
     onlyAccelerator,
     onlyMPS,
 )
-from torch.testing._internal.common_utils import run_tests, skipIfTorchDynamo, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    skipIfTorchDynamo,
+    TestCase,
+)
 from torch.utils._python_dispatch import TorchDispatchMode
 
 
 class TestAutocastCPU(TestAutocast):
+    hw_classification = HardwareClassification.CPU
+
     def setUp(self):
         super().setUp()
         self.autocast_lists = AutocastCPUTestLists(torch.device("cpu"))
@@ -233,6 +240,8 @@ class WeightDTypeCastCounterMode(TorchDispatchMode):
 
 
 class TestAutocastDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @onlyAccelerator
     def test_cast_cache_is_global(self, device):
         """
@@ -319,6 +328,8 @@ class TestAutocastDevice(TestCase):
 
 
 class TestTorchAutocast(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_autocast_fast_dtype(self):
         gpu_fast_dtype = torch.get_autocast_dtype(device_type="cuda")
         cpu_fast_dtype = torch.get_autocast_dtype(device_type="cpu")
@@ -351,6 +362,8 @@ class TestTorchAutocast(TestCase):
 
 
 class TestTorchAutocastDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def test_autocast_nograd_caching_issue_158232(self, device):
         dtype = torch.get_autocast_dtype(device_type=device)
         model = torch.nn.Linear(2, 2).to(device)

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -59,6 +59,7 @@ from torch.testing._internal.common_methods_invocations import (
 )
 from torch.testing._internal.common_utils import (
     gradcheck,
+    HardwareClassification,
     instantiate_parametrized_tests,
     iter_indices,
     numpy_to_torch_dtype_dict,
@@ -90,6 +91,8 @@ _unsigned_int_types = (torch.uint16, torch.uint32, torch.uint64)
 
 @instantiate_parametrized_tests
 class TestBinaryUfuncs(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _test_cop(self, torchfn, mathfn, dtype):
         def reference_implementation(res2):
             for i, j in iter_indices(sm1):
@@ -282,6 +285,8 @@ class TestBinaryUfuncs(TestCase):
 
 
 class TestBinaryUfuncsDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     # Generic tests for elementwise binary (AKA binary universal (u) functions (funcs))
     # TODO: below contiguous tensor results are compared with a variety of noncontiguous results.
     #   It would be interesting to have the lhs and rhs have different discontinuities.
@@ -4660,6 +4665,8 @@ class TestBinaryUfuncsDevice(TestCase):
 
 
 class TestChebyshevNanPropagation(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def test_chebyshev_nan_noncontiguous(self, device):
         if self.device_type not in ("cpu", "cuda"):
             self.skipTest("NaN uninitialized return is only fixed for CPU and CUDA")
@@ -4693,6 +4700,8 @@ class TestChebyshevNanPropagation(TestCase):
 
 
 class TestBinaryUfuncsCUDA(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     @dtypes(torch.float16, torch.bfloat16)
     def test_copysign_nan_sign(self, device, dtype):
         # Regression test for https://github.com/pytorch/pytorch/issues/181804

--- a/test/test_function_schema.py
+++ b/test/test_function_schema.py
@@ -2,10 +2,12 @@
 
 import torch
 from torch._C import parse_schema
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import run_tests, TestCase, HardwareClassification
 
 
 class TestFunctionSchema(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_serialize_and_deserialize(self):
         schemas = torch._C._jit_get_all_schemas()
         # so far we have around 1700 registered schemas

--- a/test/test_namedtuple_return_api.py
+++ b/test/test_namedtuple_return_api.py
@@ -6,7 +6,7 @@ import yaml
 import textwrap
 import torch
 
-from torch.testing._internal.common_utils import TestCase, run_tests
+from torch.testing._internal.common_utils import TestCase, run_tests, HardwareClassification
 from collections import namedtuple
 
 
@@ -35,6 +35,7 @@ all_operators_with_namedtuple_return_skip_list = {
 
 
 class TestNamedTupleAPI(TestCase):
+    hw_classification = HardwareClassification.GENERIC
 
     def test_import_return_types(self):
         import torch.return_types  # noqa: F401

--- a/test/test_native_functions.py
+++ b/test/test_native_functions.py
@@ -1,7 +1,7 @@
 # Owner(s): ["module: unknown"]
 
 import torch
-from torch.testing._internal.common_utils import TestCase, run_tests, skipIfTorchDynamo
+from torch.testing._internal.common_utils import TestCase, run_tests, skipIfTorchDynamo, HardwareClassification
 
 # End-to-end tests of features in native_functions.yaml
 
@@ -17,6 +17,7 @@ class IntListWrapperModule(torch.nn.Module):
 
 
 class TestNativeFunctions(TestCase):
+    hw_classification = HardwareClassification.GENERIC
 
     def _lists_with_str(self):
         return [

--- a/test/test_segment_reductions.py
+++ b/test/test_segment_reductions.py
@@ -10,6 +10,7 @@ from torch.testing._internal.common_device_type import (
     dtypes,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     TestCase,
     run_tests,
     gradcheck,
@@ -36,6 +37,8 @@ def get_default_value(initial_value, reduction):
 
 
 class TestSegmentReductions(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _test_common(
         self,
         reduction,

--- a/test/test_type_info.py
+++ b/test/test_type_info.py
@@ -2,6 +2,7 @@
 # Owner(s): ["module: typing"]
 
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     load_tests,
     run_tests,
     set_default_dtype,
@@ -25,6 +26,8 @@ if TEST_NUMPY:
 
 
 class TestDTypeInfo(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_invalid_input(self):
         for dtype in [
             torch.float16,

--- a/test/test_type_promotion.py
+++ b/test/test_type_promotion.py
@@ -8,7 +8,7 @@ import torch
 
 from torch.testing._internal.common_utils import (TestCase, run_tests, load_tests, make_tensor,
                                                   TEST_NUMPY, set_default_dtype, torch_to_numpy_dtype_dict,
-                                                  numpy_to_torch_dtype_dict, skipIfTorchDynamo)
+                                                  numpy_to_torch_dtype_dict, skipIfTorchDynamo, HardwareClassification)
 from torch.testing._internal.common_device_type import (instantiate_device_type_tests,
                                                         dtypes, onlyCPU, expectedFailureMeta, skipMeta)
 from torch.testing._internal.common_dtype import (
@@ -38,6 +38,7 @@ def float_double_default_dtype(fn):
     return wrapped_fn
 
 class TestTypePromotion(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
 
     # In-place operations don't promote.
     # `int+float -> float` but `int.add_(float)` is rejected as an error.
@@ -1160,6 +1161,7 @@ class TestTypePromotion(TestCase):
 
 class TestTypePromotionCPU(TestCase):
     """Pure dtype-algebra tests that don't require any accelerator."""
+    hw_classification = HardwareClassification.CPU
 
     @float_double_default_dtype
     def test_can_cast(self):


### PR DESCRIPTION
Add `hw_classification` (PR: https://github.com/pytorch/pytorch/pull/186918) attribute to a batch of refatored test files.


cc @mruberry @mcarilli @ptrblck @leslie-fang-intel @jgong5