### PR TITLE
[dynamo] Fix flaky test_compiled_autograd_id by resetting raw log after dynamo reset

### DIFF
--- a/test/dynamo/test_structured_trace.py
+++ b/test/dynamo/test_structured_trace.py
@@ -1084,9 +1084,19 @@ def forward(self, x_1: "f32[2][1]cpu"):
         fn_opt = torch._dynamo.optimize("inductor")(fn)
         fn_opt(x)
         torch._dynamo.reset()
+        # Reset raw log so assertParses only validates the cache-hit compilation.
+        # Without this, the raw log contains two compilations with identical
+        # compiled_autograd_id=0 (reset() restarts COMPILE_COUNTER from zero),
+        # which tlparse --strict rejects as duplicate compiled_autograd_id.
+        trace_log.removeHandler(self.raw_handler)
+        self.raw_file.close()
+        self.raw_file = tempfile.NamedTemporaryFile(mode="w", delete=True)  # noqa: SIM115
+        self.raw_handler = logging.StreamHandler(self.raw_file)
+        self.raw_handler.setFormatter(TorchLogsFormatter(trace=True))
+        trace_log.addHandler(self.raw_handler)
         # Trigger a cache hit
         fn_opt(x)
-        # Should print twice, including inductor_output_code
+        # Verify the cache-hit trace (including inductor_output_code) parses cleanly
         self.assertParses()
         chromium_events = [
             (


### PR DESCRIPTION
Fixes #190498.

## Root cause

`test_compiled_autograd_id` calls `torch._dynamo.reset()` mid-test to trigger an Inductor FX graph cache hit on the second compilation. `reset()` restarts `FRAME_COUNTER` and `COMPILE_COUNTER` from zero, so both compilations emit events with the same `frame_id=0` and `compiled_autograd_id=0` into the shared raw trace log. When `tlparse --strict` validates that log it sees duplicate compile IDs and fails non-deterministically (302 failures / 151 successes across 151 CI runs).

## Fix

Reset the raw log handler immediately after `torch._dynamo.reset()`, so `assertParses()` only inspects the second compilation's (cache-hit) events, which form a clean, duplicate-free trace. The `self.buffer` check on chromium events is unaffected because that handler spans both compilations.

An alternative would be to clear logging state inside `torch._dynamo.reset()`, but that is explicitly out of scope per the comment there: `NB: this does NOT reset logging state`.

## Test Plan

```
python test/dynamo/test_structured_trace.py StructuredTraceTest.test_compiled_autograd_id
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98