### PR TITLE
[cuda] Remove host sync from masked_fill_ with a device value tensor

### DIFF
--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -1770,6 +1770,19 @@ void masked_fill_kernel(TensorIterator& iter, const Scalar& value) {
       });
 }
 
+void masked_fill_kernel_tensor(TensorIterator& iter) {
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND5(
+      kBool, kHalf, kBFloat16, kComplexHalf, kBComplex32, iter.common_dtype(), "masked_fill_", [&]() {
+        gpu_kernel(
+            iter, [] GPU_LAMBDA(scalar_t self, bool mask, scalar_t value) -> scalar_t {
+              if (mask) {
+                return value;
+              }
+              return self;
+            });
+      });
+}
+
 template <typename scalar_t>
 void cuda_masked_fill_kernel_quantized(TensorIterator& iter, scalar_t quantized_val) {
     gpu_kernel(
@@ -1833,7 +1846,41 @@ Tensor & masked_fill__cuda(Tensor& self, const Tensor & mask, const Tensor & val
   // `mask` to be CPU tensor. Check for `self` and `mask` being on same device
   // exists in `masked_fill__cuda` (Scalar version).
   TORCH_CHECK(!self.device().is_cpu(), "masked_fill_: Expected inputs to be on same device")
-  return masked_fill__cuda(self, mask, value.item());
+  // A host-side value carries no device sync, so keep the cheap Scalar path.
+  if (value.device().is_cpu()) {
+    return masked_fill__cuda(self, mask, value.item());
+  }
+  TORCH_CHECK(self.device() == mask.device(), "expected self and mask to be on the same device, but got mask on ",
+    mask.device(), " and self on ", self.device());
+  TORCH_CHECK(mask.scalar_type() == kBool,
+    "masked_fill only supports boolean masks, but got dtype ", mask.scalar_type());
+  if (at::has_internal_overlap(self) == MemOverlap::Yes) {
+    TORCH_WARN(
+      "Use of masked_fill_ on expanded tensors is deprecated. "
+      "Please clone() the tensor before performing this operation. "
+      "This also applies to advanced indexing e.g. tensor[mask] = scalar");
+  }
+  at::assert_no_partial_overlap(self, mask);
+
+  // A device value used to go through value.item(), forcing a blocking
+  // device-to-host sync on every call and breaking CUDA graph capture. Read it
+  // on-device instead: a 0-dim value is broadcast by the iterator; keep it in
+  // self's dtype so the numerics match the Scalar overload.
+  c10::MaybeOwned<Tensor> b_mask = expand_inplace(self, mask, "masked_fill_");
+  Tensor value_ = value.to(self.options());
+
+  auto iter = TensorIteratorConfig()
+      .set_check_mem_overlap(false)
+      .check_all_same_dtype(false)
+      .resize_outputs(false)
+      .add_output(self)
+      .add_const_input(self)
+      .add_const_input(*b_mask)
+      .add_const_input(value_)
+      .build();
+
+  masked_fill_kernel_tensor(iter);
+  return self;
 }
 
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3964,6 +3964,19 @@ class TestTorchDeviceType(TestCase):
         self.assertEqual(out_cpu_val, ref, atol=0, rtol=0)
 
     @onlyCUDA
+    def test_masked_fill_tensor_value_no_host_sync(self, device):
+        dst = torch.arange(10, dtype=torch.float, device=device)
+        mask = (dst % 2 == 0)
+        val = torch.tensor(3.5, device=device)
+        ref = dst.clone().masked_fill_(mask, 3.5)
+        out = dst.clone()
+
+        with CudaSyncGuard("error"):
+            out.masked_fill_(mask, val)
+
+        self.assertEqual(out, ref, atol=0, rtol=0)
+
+    @onlyCUDA
     def test_masked_fill_tensor_value_cuda_graph(self, device):
         # A device value used to go through value.item(), whose device-to-host
         # sync is illegal during CUDA graph capture. Reading the value

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3950,6 +3950,42 @@ class TestTorchDeviceType(TestCase):
         dst = dst.masked_fill(mask, False)
         self.assertEqual(dst, torch.tensor([True, False, True], device=device))
 
+    def test_masked_fill_tensor_value(self, device):
+        # A 0-dim value tensor on the same device must match the Scalar overload.
+        dst = torch.arange(10, dtype=torch.float, device=device)
+        mask = (dst % 2 == 0)
+        ref = dst.clone().masked_fill_(mask, 3.5)
+        val = torch.tensor(3.5, device=device)
+        out = dst.clone().masked_fill_(mask, val)
+        self.assertEqual(out, ref, atol=0, rtol=0)
+
+        # A host-side value tensor keeps working too.
+        out_cpu_val = dst.clone().masked_fill_(mask, torch.tensor(3.5))
+        self.assertEqual(out_cpu_val, ref, atol=0, rtol=0)
+
+    @onlyCUDA
+    def test_masked_fill_tensor_value_cuda_graph(self, device):
+        # A device value used to go through value.item(), whose device-to-host
+        # sync is illegal during CUDA graph capture. Reading the value
+        # on-device must let capture and replay succeed.
+        dst = torch.zeros(128, device=device)
+        mask = torch.randint(2, (128,), device=device).bool()
+        val = torch.tensor(7.0, device=device)
+
+        s = torch.cuda.Stream()
+        s.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(s):
+            dst.clone().masked_fill_(mask, val)
+        torch.cuda.current_stream().wait_stream(s)
+
+        g = torch.cuda.CUDAGraph()
+        work = dst.clone()
+        with torch.cuda.graph(g):
+            work.masked_fill_(mask, val)
+        g.replay()
+        torch.cuda.synchronize()
+        self.assertEqual(work, torch.where(mask, val, torch.zeros_like(work)))
+
     def test_tensor_shape_empty(self, device):
         x = torch.randn((0, 1, 3, 0), device=device)
         # flatten


### PR DESCRIPTION
## Summary

`masked_fill_` with a value that lives on the GPU is slower than it needs to be, and it cannot be captured into a CUDA graph.

The CUDA overload reads the fill value with `value.item()`:

```cpp
return masked_fill__cuda(self, mask, value.item());
```

`value.item()` copies one element from the GPU back to the host and blocks the calling thread until the copy lands. So every call with a device value stalls the host. The copy is also illegal during CUDA graph capture, so the op cannot be captured, and it forces a break in `torch.compile` cudagraph regions. You hit this when the fill value came from an earlier GPU computation, for example `x.masked_fill_(mask, scale)` where `scale` is a reduction result still on the device.

This PR reads the value on the GPU instead. For a device value it builds a `TensorIterator` over `self`, the broadcast mask, and the 0-dim value, and a small kernel selects the value where the mask is set. The 0-dim value broadcasts over the output, so there is no host round-trip and the op can be captured.

A CPU value never needed a sync, since `value.item()` there just reads host memory. So a CPU value keeps the old, cheaper path. Only a device value takes the new path, which is the case that used to stall.

The value is cast with `value.to(self.options())` before the kernel runs, so the result matches the existing scalar overload across the supported dtypes. The device, dtype, and overlap checks are preserved.

This follows recent host-sync removals in the CUDA backend, for example #186595 and #189305.

## Test Plan

```
python test/test_torch.py -k test_masked_fill_tensor_value
python test/test_torch.py -k test_masked_fill_tensor_value_cuda_graph
```

I also checked the change on an NVIDIA RTX A4000 (CUDA 12.1). I compiled the exact device-value path as an extension and compared it against the stock op:

- the device-value result matches the scalar overload for float32, float64, float16, bfloat16, and int64
- the stock `masked_fill_(mask, device_value)` fails inside `torch.cuda.graph` capture, while the on-device path captures and replays with the correct result

`lintrunner` is clean on the changed files.

This change was written with help from an AI assistant. I have read the diff and can explain every line.
