### PR TITLE
[linalg] Add 32-bit LAPACK limits check on CPU for SVD, QR, Eig, and Lstsq

### DIFF
--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -851,6 +851,36 @@ TORCH_META_FUNC(_linalg_eigh)(const Tensor& A,
   at::native::squareCheckInputs(A, "linalg.eigh");
   at::native::checkUplo(uplo);
 
+  // Early check for 32-bit LAPACK workspace overflow (CPU only)
+  if (A.device().is_cpu() && compute_v) {
+    auto n = A.size(-1);
+    // syevd (real): lwork = 2*n*n + 6*n + 1
+    // heevd (complex): lwork = 2*n*n + 2*n + 1, lrwork = 2*n*n + 5*n + 1
+    // Both overflow int for n >= 32767
+    int64_t lwork_required = A.is_complex()
+        ? (2 * n * n + 2 * n + 1)
+        : (2 * n * n + 6 * n + 1);
+    TORCH_CHECK(
+        lwork_required <= std::numeric_limits<int>::max(),
+        "linalg.eigh: the required LAPACK workspace size (", lwork_required,
+        ") for a ", n, "x", n,
+        " matrix exceeds the 32-bit LAPACK interface limit (",
+        std::numeric_limits<int>::max(),
+        "). Consider using smaller matrices or a LAPACK build with 64-bit "
+        "integer support (ILP64).");
+    if (A.is_complex()) {
+      int64_t lrwork_required = 2 * n * n + 5 * n + 1;
+      TORCH_CHECK(
+          lrwork_required <= std::numeric_limits<int>::max(),
+          "linalg.eigh: the required LAPACK real workspace size (",
+          lrwork_required, ") for a ", n, "x", n,
+          " complex matrix exceeds the 32-bit LAPACK interface limit (",
+          std::numeric_limits<int>::max(),
+          "). Consider using smaller matrices or a LAPACK build with 64-bit "
+          "integer support (ILP64).");
+    }
+  }
+
   auto shape = A.sizes().vec();
   if (compute_v) {
     // eigenvectors

--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -715,6 +715,15 @@ TORCH_META_FUNC(linalg_qr)(const Tensor& A,
   const auto n = A_shape.cend()[-1];
   const auto k = std::min(m, n);
 
+  // Early check for 32-bit LAPACK limit (CPU only)
+  if (A.device().is_cpu()) {
+    TORCH_CHECK(
+        m <= std::numeric_limits<int>::max() && n <= std::numeric_limits<int>::max(),
+        "linalg.qr: The dimensions of the input matrix (", m, "x", n,
+        ") exceed the 32-bit LAPACK interface limit (",
+        std::numeric_limits<int>::max(), ").");
+  }
+
   if (compute_q) {
     auto Q_shape = A_shape;
     Q_shape.end()[-1] = reduced_mode ? k : m;
@@ -770,6 +779,30 @@ TORCH_META_FUNC(_linalg_svd)(const Tensor& A,
   const auto m = sizes.cend()[-2];
   const auto n = sizes.cend()[-1];
   const auto k = std::min(m, n);
+
+  // Early check for 32-bit LAPACK workspace overflow (CPU only)
+  if (A.device().is_cpu()) {
+    TORCH_CHECK(
+        m <= std::numeric_limits<int>::max() && n <= std::numeric_limits<int>::max(),
+        "linalg.svd: The dimensions of the input matrix (", m, "x", n,
+        ") exceed the 32-bit LAPACK interface limit (",
+        std::numeric_limits<int>::max(), ").");
+    if (!A.is_complex()) {
+      TORCH_CHECK(
+          k < 26755,
+          "linalg.svd: the required LAPACK workspace size for a ", m, "x", n,
+          " matrix exceeds the 32-bit LAPACK interface limit. "
+          "Consider using smaller matrices or a LAPACK build with 64-bit "
+          "integer support (ILP64).");
+    } else if (compute_uv) {
+      TORCH_CHECK(
+          k < 46340,
+          "linalg.svd: the required LAPACK workspace size for a ", m, "x", n,
+          " complex matrix exceeds the 32-bit LAPACK interface limit. "
+          "Consider using smaller matrices or a LAPACK build with 64-bit "
+          "integer support (ILP64).");
+    }
+  }
 
   // Prepare sizes for U
   if (compute_uv) {
@@ -2898,6 +2931,16 @@ DEFINE_DISPATCH(linalg_eig_stub);
 static std::tuple<Tensor&, Tensor&> linalg_eig_out_info(const Tensor& input, Tensor& values, Tensor& vectors, Tensor& infos, bool compute_eigenvectors) {
   auto options = input.options();
 
+  // Early check for 32-bit LAPACK limit (CPU only)
+  if (input.device().is_cpu()) {
+    auto n = input.size(-1);
+    TORCH_CHECK(
+        n <= std::numeric_limits<int>::max(),
+        "linalg.eig: The dimensions of the input matrix (", n, "x", n,
+        ") exceed the 32-bit LAPACK interface limit (",
+        std::numeric_limits<int>::max(), ").");
+  }
+
   // These internal asserts make explicit the assumptions in the implementation
   // Error check with the actual error messages are done on the higher level of the hierarchy of calls
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(input.dim() >= 2);
@@ -2998,6 +3041,16 @@ static std::tuple<Tensor&, Tensor&> linalg_eig_out_info(const Tensor& input, Ten
 }
 
 std::tuple<Tensor&, Tensor&> linalg_eig_out(const Tensor& input, Tensor& values, Tensor& vectors) {
+  // Early check for 32-bit LAPACK limit (CPU only)
+  if (input.device().is_cpu()) {
+    auto n = input.size(-1);
+    TORCH_CHECK(
+        n <= std::numeric_limits<int>::max(),
+        "linalg.eig: The dimensions of the input matrix (", n, "x", n,
+        ") exceed the 32-bit LAPACK interface limit (",
+        std::numeric_limits<int>::max(), ").");
+  }
+
   TORCH_CHECK(input.isfinite().all().item<bool>(), "torch.linalg.eig: input tensor should not contain infs or NaNs.");
   squareCheckInputs(input, "linalg.eig");
 
@@ -3364,6 +3417,17 @@ static void linalg_lstsq_out_info(
     const Tensor& other,
     double rcond,
     std::string& driver) {
+  // Early check for 32-bit LAPACK limit (CPU only)
+  if (input.device().is_cpu()) {
+    auto m = input.size(-2);
+    auto n = input.size(-1);
+    TORCH_CHECK(
+        m <= std::numeric_limits<int>::max() && n <= std::numeric_limits<int>::max(),
+        "linalg.lstsq: The dimensions of the input matrix (", m, "x", n,
+        ") exceed the 32-bit LAPACK interface limit (",
+        std::numeric_limits<int>::max(), ").");
+  }
+
   // These internal asserts make explicit the assumptions in the implementation
   // Error check with the actual error messages are done on the higher level of
   // the hierarchy of calls

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1048,6 +1048,21 @@ class TestLinalg(TestCase):
                 torch.linalg.eigh(a, out=(out_w, out_v))
 
     @skipCPUIfNoLapack
+    @onlyCPU
+    @dtypes(torch.float, torch.double, torch.cfloat, torch.cdouble)
+    def test_eigh_large_matrix_error(self, device, dtype):
+        # n=33000 needs lwork = 2*33000^2 + 6*33000 + 1 > INT32_MAX for real,
+        # and similar large workspace size for complex.
+        # Use expand (zero-stride) to create a large logical shape without
+        # allocating O(n^2) memory.
+        small = torch.zeros(1, 1, device=device, dtype=dtype)
+        large = small.expand(33000, 33000)
+        with self.assertRaisesRegex(
+            RuntimeError, "exceeds the 32-bit LAPACK interface limit"
+        ):
+            torch.linalg.eigh(large)
+
+    @skipCPUIfNoLapack
     @dtypes(torch.float, torch.double)
     def test_eigh_svd_illcondition_matrix_input_should_not_crash(self, device, dtype):
         # See https://github.com/pytorch/pytorch/issues/94772, https://github.com/pytorch/pytorch/issues/105359

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -29,7 +29,7 @@ from torch.testing._internal.common_utils import \
      freeze_rng_state, IS_ARM64, IS_SANDCASTLE, TEST_OPT_EINSUM, isRocmArchAnyOf, parametrize, skipIfTorchDynamo,
      skipIfRocmArch, setBlasBackendsToDefaultFinally, setLinalgBackendsToDefaultFinally, serialTest, skipIfRocm,
      runOnRocmArch, MI200_ARCH, MI300_ARCH, MI350_ARCH, NAVI_ARCH, TEST_CUDA,
-     skipIfNoNvmath)
+     skipIfNoNvmath, skipIfCrossRef)
 from torch.testing._internal.common_device_type import \
     (instantiate_device_type_tests, dtypes, has_cusolver, onlyCPU, skipCPUIfNoLapack, precisionOverride,
      skipCUDAIf,
@@ -1061,6 +1061,44 @@ class TestLinalg(TestCase):
             RuntimeError, "exceeds the 32-bit LAPACK interface limit"
         ):
             torch.linalg.eigh(large)
+
+    @skipCPUIfNoLapack
+    @onlyCPU
+    @skipIfCrossRef
+    @dtypes(torch.float, torch.double, torch.cfloat, torch.cdouble)
+    def test_svd_large_matrix_error(self, device, dtype):
+        # n=47000 guarantees early overflow checks for both real SVD (min(m, n) < 26755)
+        # and complex SVD (min(m, n) < 46340) to prevent huge workspace allocation.
+        small = torch.zeros(1, 1, device=device, dtype=dtype)
+        large = small.expand(47000, 47000)
+        with self.assertRaisesRegex(
+            RuntimeError, "exceed.*the 32-bit LAPACK interface limit"
+        ):
+            torch.linalg.svd(large)
+
+    @skipCPUIfNoLapack
+    @onlyCPU
+    @skipIfCrossRef
+    @dtypes(torch.float)
+    def test_linalg_ops_dimension_overflow_error(self, device, dtype):
+        small = torch.zeros(1, 1, device=device, dtype=dtype)
+        large_qr = small.expand(2147483648, 10)
+        with self.assertRaisesRegex(
+            RuntimeError, "exceed.*the 32-bit LAPACK interface limit"
+        ):
+            torch.linalg.qr(large_qr)
+
+        large_eig = small.expand(2147483648, 2147483648)
+        with self.assertRaisesRegex(
+            RuntimeError, "exceed.*the 32-bit LAPACK interface limit"
+        ):
+            torch.linalg.eig(large_eig)
+
+        large_lstsq = small.expand(2147483648, 10)
+        with self.assertRaisesRegex(
+            RuntimeError, "exceed.*the 32-bit LAPACK interface limit"
+        ):
+            torch.linalg.lstsq(large_lstsq, small.expand(2147483648, 1))
 
     @skipCPUIfNoLapack
     @dtypes(torch.float, torch.double)


### PR DESCRIPTION
Add 32-bit LAPACK limits check on CPU for linalg.svd, linalg.qr, linalg.eig, and linalg.lstsq

Fixes #190509

This commit introduces validation checks to prevent integer overflow in 32-bit LAPACK calls on CPU.

Root Cause:
LAPACK dimensions and workspace requirements are represented as 32-bit signed integers. When calling linalg.svd, linalg.qr, linalg.eig, or linalg.lstsq on very large matrices, the required workspace sizes or the matrix dimensions can exceed std::numeric_limits<int>::max(), leading to integer overflow and undefined behavior/crashes.

Fix:
- Added early checking of matrix dimensions (m and n) against INT_MAX on CPU for svd, qr, eig, and lstsq.
- Added early checking of workspace thresholds on CPU for real SVD (min(m, n) < 26755) and complex SVD (min(m, n) < 46340).
- Added early dimension checks in linalg_eig_out before evaluating input.isfinite().all() to prevent allocator errors on large logical views.

Test Plan:
Run PyTorch unit tests:
```bash
PYTHONPATH=test python test/test_linalg.py -k "test_svd_large_matrix_error"
PYTHONPATH=test python test/test_linalg.py -k "test_linalg_ops_dimension_overflow_error"
```
