### PR TITLE
[Testcase Refactoring] Decouple test_collective_autotuning.py from CUDA-specific

### DIFF
--- a/test/inductor/test_collective_autotuning.py
+++ b/test/inductor/test_collective_autotuning.py
@@ -6,7 +6,14 @@ import torch
 import torch.distributed as dist
 
 
-if not dist.is_available() or not dist.is_nccl_available():
+accel = torch.accelerator.current_accelerator()
+if accel is not None:
+    backend_str = dist.get_default_backend_for_device(accel.type)
+else:
+    backend_str = "nccl"
+device_type = getattr(accel, "type", None)
+
+if not dist.is_available() or not dist.is_backend_available(backend_str):
     print("c10d NCCL not available, skipping tests", file=sys.stderr)
     sys.exit(0)
 
@@ -14,11 +21,13 @@ from torch.testing._internal.common_distributed import (
     MultiProcessTestCase,
     skip_if_lt_x_gpu,
 )
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 
 
 class TestCollectiveAutotuning2Ranks(MultiProcessTestCase):
     """Test collective autotuning with 2 ranks"""
+
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @property
     def world_size(self):
@@ -37,7 +46,7 @@ class TestCollectiveAutotuning2Ranks(MultiProcessTestCase):
         Strategy 2: avg all_reduce * world_size
         """
         dist.init_process_group(
-            backend="nccl",
+            backend=backend_str,
             init_method=f"file:///tmp/test_equiv_allreduce_{self.id()}",
             world_size=self.world_size,
             rank=self.rank,
@@ -46,7 +55,7 @@ class TestCollectiveAutotuning2Ranks(MultiProcessTestCase):
         dist.barrier()
 
         rank = dist.get_rank()
-        device = f"cuda:{rank}"
+        device = f"{device_type}:{rank}"
 
         from torch._C._distributed_c10d import _register_process_group
 
@@ -102,6 +111,8 @@ class TestCollectiveAutotuning2Ranks(MultiProcessTestCase):
 class TestCollectiveAutotuning4Ranks(MultiProcessTestCase):
     """Test collective autotuning with 4 ranks"""
 
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self):
         return 4
@@ -119,7 +130,7 @@ class TestCollectiveAutotuning4Ranks(MultiProcessTestCase):
         Two implementations simulate vLLM's registered=False mode vs standard NCCL.
         """
         dist.init_process_group(
-            backend="nccl",
+            backend=backend_str,
             init_method=f"file:///tmp/test_vllm_allreduce_{self.id()}",
             world_size=self.world_size,
             rank=self.rank,
@@ -128,7 +139,7 @@ class TestCollectiveAutotuning4Ranks(MultiProcessTestCase):
         dist.barrier()
 
         rank = dist.get_rank()
-        device = f"cuda:{rank}"
+        device = f"{device_type}:{rank}"
 
         from torch._C._distributed_c10d import _register_process_group
 

--- a/test/inductor/test_collective_autotuning.py
+++ b/test/inductor/test_collective_autotuning.py
@@ -6,7 +6,13 @@ import torch
 import torch.distributed as dist
 
 
-if not dist.is_available() or not dist.is_nccl_available():
+accel = torch.accelerator.current_accelerator()
+if accel is not None:
+    backend_str = dist.get_default_backend_for_device(accel.type)
+else:
+    backend_str = "gloo"
+
+if not dist.is_available() or not dist.is_backend_available(backend_str):
     print("c10d NCCL not available, skipping tests", file=sys.stderr)
     sys.exit(0)
 
@@ -14,11 +20,14 @@ from torch.testing._internal.common_distributed import (
     MultiProcessTestCase,
     skip_if_lt_x_gpu,
 )
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 
 
 class TestCollectiveAutotuning2Ranks(MultiProcessTestCase):
     """Test collective autotuning with 2 ranks"""
+
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @property
     def world_size(self):
@@ -29,7 +38,7 @@ class TestCollectiveAutotuning2Ranks(MultiProcessTestCase):
         self._spawn_processes()
 
     @skip_if_lt_x_gpu(2)
-    def test_equivalent_allreduce_strategies(self):
+    def test_equivalent_allreduce_strategies(self, device):
         """
         Test autotuning between mathematically equivalent all_reduce strategies.
 
@@ -37,7 +46,7 @@ class TestCollectiveAutotuning2Ranks(MultiProcessTestCase):
         Strategy 2: avg all_reduce * world_size
         """
         dist.init_process_group(
-            backend="nccl",
+            backend=backend_str,
             init_method=f"file:///tmp/test_equiv_allreduce_{self.id()}",
             world_size=self.world_size,
             rank=self.rank,
@@ -46,7 +55,7 @@ class TestCollectiveAutotuning2Ranks(MultiProcessTestCase):
         dist.barrier()
 
         rank = dist.get_rank()
-        device = f"cuda:{rank}"
+        device_rank = f"{torch.device(device).type}:{rank}"
 
         from torch._C._distributed_c10d import _register_process_group
 
@@ -87,10 +96,10 @@ class TestCollectiveAutotuning2Ranks(MultiProcessTestCase):
             def forward(self, x):
                 return equiv_ar(x)
 
-        model = torch.compile(EquivAllReduceModel()).to(device)
+        model = torch.compile(EquivAllReduceModel()).to(device_rank)
 
         torch.manual_seed(42)
-        x = torch.randn(128, 128, device=device)
+        x = torch.randn(128, 128, device=device_rank)
         dist.broadcast(x, src=0)
 
         _ = model(x)
@@ -102,6 +111,8 @@ class TestCollectiveAutotuning2Ranks(MultiProcessTestCase):
 class TestCollectiveAutotuning4Ranks(MultiProcessTestCase):
     """Test collective autotuning with 4 ranks"""
 
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self):
         return 4
@@ -111,7 +122,7 @@ class TestCollectiveAutotuning4Ranks(MultiProcessTestCase):
         self._spawn_processes()
 
     @skip_if_lt_x_gpu(4)
-    def test_vllm_style_allreduce(self):
+    def test_vllm_style_allreduce(self, device):
         """
         Test vLLM-style custom allreduce with buffer copy pattern.
 
@@ -119,7 +130,7 @@ class TestCollectiveAutotuning4Ranks(MultiProcessTestCase):
         Two implementations simulate vLLM's registered=False mode vs standard NCCL.
         """
         dist.init_process_group(
-            backend="nccl",
+            backend=backend_str,
             init_method=f"file:///tmp/test_vllm_allreduce_{self.id()}",
             world_size=self.world_size,
             rank=self.rank,
@@ -128,7 +139,7 @@ class TestCollectiveAutotuning4Ranks(MultiProcessTestCase):
         dist.barrier()
 
         rank = dist.get_rank()
-        device = f"cuda:{rank}"
+        device_rank = f"{torch.device(device).type}:{rank}"
 
         from torch._C._distributed_c10d import _register_process_group
 
@@ -182,16 +193,19 @@ class TestCollectiveAutotuning4Ranks(MultiProcessTestCase):
             def forward(self, x):
                 return vllm_allreduce(x)
 
-        model = torch.compile(VLLMAllReduceModel()).to(device)
+        model = torch.compile(VLLMAllReduceModel()).to(device_rank)
 
         torch.manual_seed(42 + rank)
-        x = torch.randn(128, 256, device=device)
+        x = torch.randn(128, 256, device=device_rank)
 
         y = model(x)
         self.assertEqual(y.shape, x.shape)
         dist.barrier()
         dist.destroy_process_group()
 
+
+instantiate_device_type_tests(TestCollectiveAutotuning2Ranks, globals(), except_for="cpu")
+instantiate_device_type_tests(TestCollectiveAutotuning4Ranks, globals(), except_for="cpu")
 
 if __name__ == "__main__":
     run_tests()

--- a/test/inductor/test_collective_autotuning.py
+++ b/test/inductor/test_collective_autotuning.py
@@ -1,30 +1,18 @@
 # Owner(s): ["module: inductor"]
 
-import sys
+import unittest
 
 import torch
 import torch.distributed as dist
-
-
-accel = torch.accelerator.current_accelerator()
-if accel is not None:
-    backend_str = dist.get_default_backend_for_device(accel.type)
-else:
-    backend_str = "gloo"
-
-if not dist.is_available() or not dist.is_backend_available(backend_str):
-    print("c10d NCCL not available, skipping tests", file=sys.stderr)
-    sys.exit(0)
-
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import (
-    MultiProcessTestCase,
+    DistributedTestBase,
     skip_if_lt_x_gpu,
 )
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import HardwareClassification, run_tests
 
 
-class TestCollectiveAutotuning2Ranks(MultiProcessTestCase):
+class TestCollectiveAutotuning2Ranks(DistributedTestBase):
     """Test collective autotuning with 2 ranks"""
 
     hw_classification = HardwareClassification.ACCELERATOR
@@ -33,9 +21,12 @@ class TestCollectiveAutotuning2Ranks(MultiProcessTestCase):
     def world_size(self):
         return 2
 
-    def setUp(self):
-        super().setUp()
-        self._spawn_processes()
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        backend_str = dist.get_default_backend_for_device(cls.device_type)
+        if not dist.is_available() or not dist.is_backend_available(backend_str):
+            raise unittest.SkipTest("c10d NCCL not available, skipping tests")
 
     @skip_if_lt_x_gpu(2)
     def test_equivalent_allreduce_strategies(self, device):
@@ -46,7 +37,7 @@ class TestCollectiveAutotuning2Ranks(MultiProcessTestCase):
         Strategy 2: avg all_reduce * world_size
         """
         dist.init_process_group(
-            backend=backend_str,
+            backend=self.backend(device),
             init_method=f"file:///tmp/test_equiv_allreduce_{self.id()}",
             world_size=self.world_size,
             rank=self.rank,
@@ -108,7 +99,7 @@ class TestCollectiveAutotuning2Ranks(MultiProcessTestCase):
         dist.destroy_process_group()
 
 
-class TestCollectiveAutotuning4Ranks(MultiProcessTestCase):
+class TestCollectiveAutotuning4Ranks(DistributedTestBase):
     """Test collective autotuning with 4 ranks"""
 
     hw_classification = HardwareClassification.ACCELERATOR
@@ -117,9 +108,12 @@ class TestCollectiveAutotuning4Ranks(MultiProcessTestCase):
     def world_size(self):
         return 4
 
-    def setUp(self):
-        super().setUp()
-        self._spawn_processes()
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        backend_str = dist.get_default_backend_for_device(cls.device_type)
+        if not dist.is_available() or not dist.is_backend_available(backend_str):
+            raise unittest.SkipTest("c10d NCCL not available, skipping tests")
 
     @skip_if_lt_x_gpu(4)
     def test_vllm_style_allreduce(self, device):
@@ -130,7 +124,7 @@ class TestCollectiveAutotuning4Ranks(MultiProcessTestCase):
         Two implementations simulate vLLM's registered=False mode vs standard NCCL.
         """
         dist.init_process_group(
-            backend=backend_str,
+            backend=self.backend(device),
             init_method=f"file:///tmp/test_vllm_allreduce_{self.id()}",
             world_size=self.world_size,
             rank=self.rank,
@@ -204,8 +198,12 @@ class TestCollectiveAutotuning4Ranks(MultiProcessTestCase):
         dist.destroy_process_group()
 
 
-instantiate_device_type_tests(TestCollectiveAutotuning2Ranks, globals(), except_for="cpu")
-instantiate_device_type_tests(TestCollectiveAutotuning4Ranks, globals(), except_for="cpu")
+instantiate_device_type_tests(
+    TestCollectiveAutotuning2Ranks, globals(), except_for="cpu"
+)
+instantiate_device_type_tests(
+    TestCollectiveAutotuning4Ranks, globals(), except_for="cpu"
+)
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary
This PR replaces hardcoded CUDA references with device-agnostic equivalents so out-of-tree accelerator backends can run these tests.

## Changes
- Replace hardcoded `cuda` device with device-agnostic `torch.accelerator.current_accelerator()` detect current accelerator type.
- Uses `get_default_backend_for_device` to get distributed backend.
- Instantiate device-agnostic test templates as device-specific test classes for multiple differrent device backends.
- Add `hw_classification = HardwareClassification.GENERIC|ACCELERATOR` to tests class.

## Motivation
"cuda" device is hardcoded CUDA-specific. New accelerators (e.g., `PrivateUse1`-based out-of-tree backends) are silently skipped even when enough devices are available. A generic decorator lets inductor tests adapt to any accelerator supported by `torch.accelerator`.

## Test Plan
- CI: `python test_collective_autotuning.py --hw-classification ACCELERATOR`
- Verified locally that test cases correctly on GPU.

## Notes
- This is part of the test case refactoring initiative tracked in #185590.
- Make CUDA/XPU device-generic in #189138.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo