### PR TITLE
[Testcase Refactoring] Make ComposabilityTest backend resolution hardware-agnostic in…

### DIFF
--- a/test/distributed/test_composability.py
+++ b/test/distributed/test_composability.py
@@ -21,22 +21,23 @@ from torch.distributed.pipelining.schedules import (
 )
 from torch.distributed.tensor import DTensor
 from torch.nn.parallel import DistributedDataParallel as DDP
-from torch.testing._internal.common_cuda import TEST_MULTIGPU
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
+)
 from torch.testing._internal.common_distributed import (
-    MultiProcContinuousTest,
-    requires_nccl,
+    MultiProcContinuousForInstantiateTest,
     skip_if_lt_x_gpu,
 )
 from torch.testing._internal.common_utils import (
-    instantiate_parametrized_tests,
+    HardwareClassification,
     parametrize,
     run_tests,
     skip_but_pass_in_sandcastle_if,
+    TEST_MULTIACCELERATOR,
     TEST_WITH_ROCM,
 )
-
-
-device_type = "cuda"
 
 
 # MLP Layer
@@ -95,19 +96,12 @@ def loss_fn(y, target, scale=1e-4):
     return torch.nn.functional.cross_entropy(y, target) * scale
 
 
-class ComposabilityTest(MultiProcContinuousTest):
-    @classmethod
-    def backend_str(cls) -> str:
-        # Testing with NCCL backend
-        return "nccl"
-
-    @property
-    def device(self) -> torch.device:
-        return torch.device(device_type, self.rank)
+class ComposabilityTest(MultiProcContinuousForInstantiateTest):
+    hw_classification = HardwareClassification.ACCELERATOR
 
     def _rand_microbatches(self, dp_mesh, num_microbatches, dim, dtype=torch.float32):
         full = [
-            torch.rand((num_microbatches, dim), device=self.device, dtype=dtype)
+            torch.rand((num_microbatches, dim), device=self.current_device, dtype=dtype)
             for _ in range(dp_mesh.size())
         ]
         local = full[dp_mesh.get_local_rank()]
@@ -130,13 +124,13 @@ class ComposabilityTest(MultiProcContinuousTest):
         partial_model = nn.Sequential(
             *full_model[offset : (stage_idx + 1) * layers_per_stage]
         )
-        partial_model.to(self.device)
+        partial_model.to(self.current_device)
         dp_model = apply_dp(partial_model)
         stage = PipelineStage(
             dp_model,
             stage_idx,
             num_stages,
-            self.device,
+            self.current_device,
             group=pp_group,
         )
         return stage, offset
@@ -195,9 +189,9 @@ class ComposabilityTest(MultiProcContinuousTest):
             )
         return pipeline_schedule, partial_models, offsets
 
-    @requires_nccl()
+    @requires_capabilities(Capability.distributed.backend)
     @skip_if_lt_x_gpu(4)
-    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "Test requires 4+ GPUs")
+    @skip_but_pass_in_sandcastle_if(not TEST_MULTIACCELERATOR, "Test requires 4+ GPUs")
     @parametrize(
         "ScheduleClass",
         [
@@ -206,17 +200,17 @@ class ComposabilityTest(MultiProcContinuousTest):
             ScheduleInterleavedZeroBubble,
         ],
     )
-    def test_pp_ddp(self, ScheduleClass):
+    def test_pp_ddp(self, ScheduleClass, device):
         if ScheduleClass == ScheduleInterleavedZeroBubble:
             # TODO: DDP + InterleavedZeroBubble is not currently supported due to issue with DDP reducer not triggering
             # https://github.com/pytorch/pytorch/issues/144530
             return
 
-        torch.get_device_module(device_type).set_device(self.device)
+        torch.get_device_module(self.device_type).set_device(self.current_device)
         mesh_shape = (self.world_size // 2, 2)
         mesh_dim_names = ("dp", "pp")
         device_mesh = init_device_mesh(
-            "cuda", mesh_shape=mesh_shape, mesh_dim_names=mesh_dim_names
+            self.device_type, mesh_shape=mesh_shape, mesh_dim_names=mesh_dim_names
         )
         pp_group = device_mesh["pp"].get_group()
         dp_mesh = device_mesh["dp"]
@@ -227,7 +221,7 @@ class ComposabilityTest(MultiProcContinuousTest):
         dim = 10
         full_model = nn.ModuleList([MLPModule(dim) for _ in range(total_layers)])
         ref_model = nn.Sequential(*copy.deepcopy(full_model))
-        ref_model.to(self.device)
+        ref_model.to(self.current_device)
 
         # Prepare inputs
         inputs, input_local, _ = self._rand_microbatches(dp_mesh, num_microbatches, dim)
@@ -276,9 +270,9 @@ class ComposabilityTest(MultiProcContinuousTest):
                 ref_p = ref_parameters[name]
                 torch.testing.assert_close(p.grad, ref_p.grad)
 
-    @requires_nccl()
+    @requires_capabilities(Capability.distributed.backend)
     @skip_if_lt_x_gpu(4)
-    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "Test requires 4+ GPUs")
+    @skip_but_pass_in_sandcastle_if(not TEST_MULTIACCELERATOR, "Test requires 4+ GPUs")
     @parametrize("dp_type", ["FSDP", "FSDP_MP"])
     @parametrize(
         "ScheduleClass",
@@ -289,15 +283,15 @@ class ComposabilityTest(MultiProcContinuousTest):
             ScheduleInterleavedZeroBubble,
         ],
     )
-    def test_pp_fsdp(self, dp_type, ScheduleClass):
+    def test_pp_fsdp(self, dp_type, ScheduleClass, device):
         if TEST_WITH_ROCM:
             return
 
-        torch.get_device_module(device_type).set_device(self.device)
+        torch.get_device_module(self.device_type).set_device(self.current_device)
         mesh_shape = (self.world_size // 2, 2)
         mesh_dim_names = ("dp", "pp")
         device_mesh = init_device_mesh(
-            "cuda", mesh_shape=mesh_shape, mesh_dim_names=mesh_dim_names
+            self.device_type, mesh_shape=mesh_shape, mesh_dim_names=mesh_dim_names
         )
         pp_group = device_mesh["pp"].get_group()
         dp_mesh = device_mesh["dp"]
@@ -311,7 +305,7 @@ class ComposabilityTest(MultiProcContinuousTest):
         dim = 10
         full_model = nn.ModuleList([MLPModule(dim) for _ in range(total_layers)])
         ref_model = nn.Sequential(*copy.deepcopy(full_model))
-        ref_model.to(self.device)
+        ref_model.to(self.current_device)
         if dp_type == "FSDP_MP":
             ref_model.to(dtype=mp_dtype)
 
@@ -387,20 +381,20 @@ class ComposabilityTest(MultiProcContinuousTest):
                     p.grad.full_tensor(), ref_p.grad, atol=5e-5, rtol=2e-2
                 )
 
-    @requires_nccl()
+    @requires_capabilities(Capability.distributed.backend)
     @skip_if_lt_x_gpu(4)
-    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "Test requires 4+ GPUs")
+    @skip_but_pass_in_sandcastle_if(not TEST_MULTIACCELERATOR, "Test requires 4+ GPUs")
     @parametrize("dp_type", ["FSDP", "FSDP_MP"])
-    def test_pp_fsdp_unshard_reshard_runtime(self, dp_type):
+    def test_pp_fsdp_unshard_reshard_runtime(self, dp_type, device):
         """Test FSDP UNSHARD/RESHARD functionality using _PipelineScheduleRuntime with custom schedules."""
         if TEST_WITH_ROCM:
             return
 
-        torch.get_device_module(device_type).set_device(self.device)
+        torch.get_device_module(self.device_type).set_device(self.current_device)
         mesh_shape = (self.world_size, 1)
         mesh_dim_names = ("dp", "pp")
         device_mesh = init_device_mesh(
-            "cuda", mesh_shape=mesh_shape, mesh_dim_names=mesh_dim_names
+            self.device_type, mesh_shape=mesh_shape, mesh_dim_names=mesh_dim_names
         )
         pp_group = device_mesh["pp"].get_group()
         dp_mesh = device_mesh["dp"]
@@ -434,7 +428,7 @@ class ComposabilityTest(MultiProcContinuousTest):
         partial_model = nn.Sequential(
             *full_model[offset : (stage_idx + 1) * layers_per_stage]
         )
-        partial_model.to(self.device)
+        partial_model.to(self.current_device)
         fsdp_model = apply_dp(partial_model)
         distributed_state = fully_shard.state(fsdp_model)
         distributed_state._lazy_init()
@@ -443,7 +437,7 @@ class ComposabilityTest(MultiProcContinuousTest):
             fsdp_model,
             stage_idx,
             num_stages,
-            self.device,
+            self.current_device,
             group=pp_group,
         )
 
@@ -521,7 +515,7 @@ class ComposabilityTest(MultiProcContinuousTest):
             [stage], n_microbatches=1, loss_fn=None, scale_grads=False
         )
         runtime.pipeline_order_with_comms = unshard_reshard_schedule
-        dummy_input = torch.randn(1, dim, device=self.device, dtype=mp_dtype)
+        dummy_input = torch.randn(1, dim, device=self.current_device, dtype=mp_dtype)
         runtime.step(dummy_input)
 
         # Verify parameters are now sharded again
@@ -535,6 +529,9 @@ class ComposabilityTest(MultiProcContinuousTest):
         check_fsdp_unsharded_state(stage.submod, expected_unsharded=False)
 
 
-instantiate_parametrized_tests(ComposabilityTest)
+instantiate_device_type_tests(
+    ComposabilityTest, globals(), except_for="cpu", allow_xpu=True
+)
+
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/test_composability.py
+++ b/test/distributed/test_composability.py
@@ -21,22 +21,27 @@ from torch.distributed.pipelining.schedules import (
 )
 from torch.distributed.tensor import DTensor
 from torch.nn.parallel import DistributedDataParallel as DDP
-from torch.testing._internal.common_cuda import TEST_MULTIGPU
 from torch.testing._internal.common_distributed import (
     MultiProcContinuousTest,
-    requires_nccl,
+    requires_accelerator_dist_backend,
     skip_if_lt_x_gpu,
 )
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
-    instantiate_parametrized_tests,
+    HardwareClassification,
     parametrize,
     run_tests,
     skip_but_pass_in_sandcastle_if,
+    TEST_MULTIACCELERATOR,
     TEST_WITH_ROCM,
 )
 
 
-device_type = "cuda"
+device_type = (
+    acc.type
+    if (acc := torch.accelerator.current_accelerator(check_available=True))
+    else "cpu"
+)
 
 
 # MLP Layer
@@ -96,10 +101,11 @@ def loss_fn(y, target, scale=1e-4):
 
 
 class ComposabilityTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @classmethod
     def backend_str(cls) -> str:
-        # Testing with NCCL backend
-        return "nccl"
+        return torch.distributed.get_default_backend_for_device(device_type)
 
     @property
     def device(self) -> torch.device:
@@ -195,9 +201,9 @@ class ComposabilityTest(MultiProcContinuousTest):
             )
         return pipeline_schedule, partial_models, offsets
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(4)
-    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "Test requires 4+ GPUs")
+    @skip_but_pass_in_sandcastle_if(not TEST_MULTIACCELERATOR, "Test requires 4+ GPUs")
     @parametrize(
         "ScheduleClass",
         [
@@ -216,7 +222,7 @@ class ComposabilityTest(MultiProcContinuousTest):
         mesh_shape = (self.world_size // 2, 2)
         mesh_dim_names = ("dp", "pp")
         device_mesh = init_device_mesh(
-            "cuda", mesh_shape=mesh_shape, mesh_dim_names=mesh_dim_names
+            device_type, mesh_shape=mesh_shape, mesh_dim_names=mesh_dim_names
         )
         pp_group = device_mesh["pp"].get_group()
         dp_mesh = device_mesh["dp"]
@@ -276,9 +282,9 @@ class ComposabilityTest(MultiProcContinuousTest):
                 ref_p = ref_parameters[name]
                 torch.testing.assert_close(p.grad, ref_p.grad)
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(4)
-    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "Test requires 4+ GPUs")
+    @skip_but_pass_in_sandcastle_if(not TEST_MULTIACCELERATOR, "Test requires 4+ GPUs")
     @parametrize("dp_type", ["FSDP", "FSDP_MP"])
     @parametrize(
         "ScheduleClass",
@@ -297,7 +303,7 @@ class ComposabilityTest(MultiProcContinuousTest):
         mesh_shape = (self.world_size // 2, 2)
         mesh_dim_names = ("dp", "pp")
         device_mesh = init_device_mesh(
-            "cuda", mesh_shape=mesh_shape, mesh_dim_names=mesh_dim_names
+            device_type, mesh_shape=mesh_shape, mesh_dim_names=mesh_dim_names
         )
         pp_group = device_mesh["pp"].get_group()
         dp_mesh = device_mesh["dp"]
@@ -387,9 +393,9 @@ class ComposabilityTest(MultiProcContinuousTest):
                     p.grad.full_tensor(), ref_p.grad, atol=5e-5, rtol=2e-2
                 )
 
-    @requires_nccl()
+    @requires_accelerator_dist_backend()
     @skip_if_lt_x_gpu(4)
-    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "Test requires 4+ GPUs")
+    @skip_but_pass_in_sandcastle_if(not TEST_MULTIACCELERATOR, "Test requires 4+ GPUs")
     @parametrize("dp_type", ["FSDP", "FSDP_MP"])
     def test_pp_fsdp_unshard_reshard_runtime(self, dp_type):
         """Test FSDP UNSHARD/RESHARD functionality using _PipelineScheduleRuntime with custom schedules."""
@@ -400,7 +406,7 @@ class ComposabilityTest(MultiProcContinuousTest):
         mesh_shape = (self.world_size, 1)
         mesh_dim_names = ("dp", "pp")
         device_mesh = init_device_mesh(
-            "cuda", mesh_shape=mesh_shape, mesh_dim_names=mesh_dim_names
+            device_type, mesh_shape=mesh_shape, mesh_dim_names=mesh_dim_names
         )
         pp_group = device_mesh["pp"].get_group()
         dp_mesh = device_mesh["dp"]
@@ -535,6 +541,9 @@ class ComposabilityTest(MultiProcContinuousTest):
         check_fsdp_unsharded_state(stage.submod, expected_unsharded=False)
 
 
-instantiate_parametrized_tests(ComposabilityTest)
+instantiate_device_type_tests(
+    ComposabilityTest, globals(), except_for="cpu", allow_xpu=True
+)
+
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Summary
This PR makes `ComposabilityTest` in `test/distributed/test_composability.py` hardware-agnostic by replacing the hard-coded `"nccl"` backend string with `torch.distributed.get_default_backend_for_device(device_type)`, and by replacing `@requires_nccl()` decorators with `@requires_accelerator_dist_backend()`. The test now adapts to any accelerator supported by `torch.accelerator` (including PrivateUse1-based out-of-tree backends such as NPU) instead of forcing NCCL.

## Changes
Updated `ComposabilityTest` in `test/distributed/test_composability.py`:
- Replaced the hard-coded `return "nccl"` in `ComposabilityTest.backend_str()` with `return torch.distributed.get_default_backend_for_device(device_type)`, so the backend string is resolved dynamically from the framework's device→backend map.
- Replaced the import of `requires_nccl` from `torch.testing._internal.common_distributed` with `requires_accelerator_dist_backend`. Dropped the `requires_nccl` reference entirely.
- Changed the three `@requires_nccl()` decorators on `ComposabilityTest` test methods (lines 201, 282, 393) to `@requires_accelerator_dist_backend()`, so the tests are gated on whether the current accelerator has a registered distributed backend rather than on NCCL specifically.
- Introduced a module-level `device_type` constant derived from `torch.accelerator.current_accelerator(check_available=True)` (falling back to `"cpu"`), used both by `backend_str()` and the `device` property (`torch.device(device_type, self.rank)`) so tensor allocation targets the current accelerator instead of assuming CUDA.

## Motivation
`ComposabilityTest` hard-coded `"nccl"` as the distributed backend and used `@requires_nccl()` to gate execution. On accelerators whose default backend is not NCCL (e.g., NPU uses HCCL, XPU uses XCCL), the test was either skipped or failed at process-group initialization because the framework could not bind NCCL to a non-CUDA device. Using `torch.distributed.get_default_backend_for_device()` and `requires_accelerator_dist_backend()` lets the test pick up the correct backend for any accelerator registered with `torch.accelerator` without introducing a new test class.

## Test Plan
Verified on CPU and across multiple accelerator types:
```
python test/distributed/test_composability.py -v
```
On a PrivateUse1 (NPU) host (8 devices): the three `@requires_accelerator_dist_backend()`-decorated tests execute with `backend_str()` returning `"hccl"` (resolved via `default_device_backend_map["npu"]`), and tensors are allocated on `torch.device("npu", rank)` instead of `cuda`.
On a CPU-only host all three are skipped, because `requires_accelerator_dist_backend()` returns False when no accelerator is available.
On a CUDA host the decorator still runs the tests, with `backend_str()` returning `"nccl"` and tensors allocated on `cuda:rank`, matching the previous behavior.

## Notes
- This change depends on [PR 191919](https://github.com/pytorch/pytorch/pull/191919) ， [PR 193080](https://github.com/pytorch/pytorch/pull/193080) and [PR 195000](https://github.com/pytorch/pytorch/pull/195000)


@wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian