### PR TITLE
[inductor] Add barrier before reading back a buffer stored in a reduction loop

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -19606,6 +19606,29 @@ if RUN_GPU:
 
             self.assertEqual(fn_opt(*inps), fn(*inps))
 
+        def test_barrier_on_reduction_loop_readback(self):
+            # A buffer stored in a reduction loop and read back after it needs
+            # a barrier, or one warp may read what another wrote.
+            def fn(a, b, w, bias):
+                y = a + b
+                mean = y.mean(-1, keepdim=True)
+                var = y.var(-1, keepdim=True, unbiased=False)
+                normed = (y - mean) * torch.rsqrt(var + 1e-6) * w + bias
+                return y, normed
+
+            N = 4096
+            inps = [
+                torch.randn(64, N, device=GPU_TYPE),
+                torch.randn(64, N, device=GPU_TYPE),
+                torch.randn(N, device=GPU_TYPE),
+                torch.randn(N, device=GPU_TYPE),
+            ]
+            fn_opt = torch.compile(fn, backend="inductor")
+            code = run_and_get_triton_code(fn_opt, *inps)
+            self.assertTrue("tl.debug_barrier()" in code)
+
+            self.assertEqual(fn_opt(*inps), fn(*inps))
+
         def test_index_expr_pure_indexing_no_int64(self):
             def fn(x: torch.Tensor) -> torch.Tensor:
                 idx = torch.arange(0, 128, device=GPU_TYPE, dtype=torch.int64)

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -4741,6 +4741,12 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 dtype = torch.bool
 
         load_buffer = self.get_load_buffer(indexing)
+        # Read-after-write companion to the #1615 guard in store(). If we read
+        # back a buffer we stored in a reduction loop, coalescing can put the
+        # store and load on different warps, so a warp may read before another
+        # warp's write is visible. Barrier first to make the writes visible.
+        if name in self.cse.invalidated_stores:
+            load_buffer.writeline(DeferredLine(name, "tl.debug_barrier()"))
         self._handle_pdl_before_access(load_buffer, name)
         result_var = self.cse.generate(
             load_buffer, make_line(line), dtype=dtype, shape=shape

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -4745,7 +4745,10 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         # back a buffer we stored in a reduction loop, coalescing can put the
         # store and load on different warps, so a warp may read before another
         # warp's write is visible. Barrier first to make the writes visible.
-        if name in self.cse.invalidated_stores:
+        if (
+            name in self.cse.invalidated_stores
+            and V.graph.get_current_device_or_throw().type != "cpu"
+        ):
             load_buffer.writeline(DeferredLine(name, "tl.debug_barrier()"))
         self._handle_pdl_before_access(load_buffer, name)
         result_var = self.cse.generate(


### PR DESCRIPTION
Fixes #190517

If a kernel stores a buffer and then reads it back in a reduction loop, the
store and the read-back can land on different warps, so a warp may read the
value before another warp's write is visible.

This is the read-after-write side of the write-after-read guard already in
`store()` (triton #1615). `self.cse.invalidated_stores` already tracks the
"stored, then reloaded across a reduction-loop boundary" set, so we add a
`tl.debug_barrier()` before such a load.

pit_b_224 (timm, XPU, AMP fp16 inference) now passes.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo