### PR TITLE
Compile the full-API smoke-test probe at C++20

### DIFF
--- a/.ci/pytorch/smoke_test/check_binary_symbols.py
+++ b/.ci/pytorch/smoke_test/check_binary_symbols.py
@@ -182,7 +182,12 @@ int main() { return 0; }
 
     base_compile_flags = [
         "g++",
-        "-std=c++17",
+        # The full torch C++ API (torch/all.h, ATen/ATen.h) enforces a C++20
+        # minimum via header guards; compile at C++20 to match. The other
+        # checks below stay at C++17 on purpose -- they exercise the stable /
+        # header-only / C-shim surface, which must remain buildable under the
+        # older standard.
+        "-std=c++20",
         f"-I{include_dir}",
         f"-I{include_dir}/torch/csrc/api/include",
         "-c",  # Compile only, don't link


### PR DESCRIPTION
check_binary_symbols.py's check_stable_only_symbols() compiles a probe that includes torch/all.h and ATen/ATen.h, but pins the compile at -std=c++17. Since #178150 ("[12/12] Enforce C++20 minimum in header guards") those two headers hard-error under a pre-C++20 compiler, so the probe now fails to compile with:

  torch/all.h:5:2: error: #error C++20 or later compatible compiler is
  required to use PyTorch.

which trips every manywheel-*-test job (the smoke test aborts on the first failing check). Bump only this probe to -std=c++20 to match the standard the full API now requires.

The stable / header-only / C-shim checks below deliberately stay at -std=c++17: they exercise the portable ABI surface, which does not pull in the C++20-guarded headers and must remain buildable under the older standard, so their flag is left unchanged.

Fixes #190527.

## Test plan

- [x] Only the full-API probe's flag changed; the other four checks still compile at C++17: ``` grep -n 'std=c++' .ci/pytorch/smoke_test/check_binary_symbols.py ```
- [ ] manywheel-*-test jobs (which run check_binary_symbols.py) go green on CI.

Authored with assistance from Claude Code.