### PR TITLE
[Testcase Refactoring] Decouple test_control_deps.py from CUDA-specific

### DIFF
--- a/test/inductor/test_control_deps.py
+++ b/test/inductor/test_control_deps.py
@@ -7,197 +7,16 @@ from torch._inductor import config
 from torch._inductor.test_case import run_tests, TestCase as InductorTestCase
 from torch._inductor.utils import run_and_get_code
 from torch.testing import FileCheck
-from torch.testing._internal.common_utils import IS_LINUX
-from torch.testing._internal.inductor_utils import (
-    GPU_TYPE,
-    HAS_CUDA_AND_TRITON,
-    HAS_GPU_AND_TRITON,
-    requires_gpu,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification, IS_LINUX
+from torch.testing._internal.inductor_utils import HAS_TRITON
 
 
-requires_cuda_triton = unittest.skipUnless(HAS_CUDA_AND_TRITON, "requires CUDA")
+requires_triton = unittest.skipUnless(HAS_TRITON, "requires triton")
 
 
-class TestControlDeps(InductorTestCase):
-    @config.patch(reorder_for_locality=False)
-    @requires_gpu()
-    def test_control_deps_prevents_fusion(self):
-        def fn(a, b):
-            c = a + 1
-            d = b @ b
-            e = c * 2
-            return d, e
-
-        def add_control_deps(graph):
-            nodes = [n for n in graph.nodes if n.op == "call_function"]
-            if len(nodes) != 3:
-                raise AssertionError(f"Expected 3 nodes, got {len(nodes)}")
-            c_node = nodes[0]
-            d_node = nodes[1]
-            e_node = nodes[2]
-
-            if d_node.target != torch.ops.aten.mm.default:
-                raise AssertionError(f"Expected mm.default, got {d_node.target}")
-
-            from torch.utils._ordered_set import OrderedSet
-
-            deps_map = {d_node: OrderedSet([c_node]), e_node: OrderedSet([d_node])}
-            torch._inductor.fx_passes.control_dependencies.preserve_node_ordering(
-                graph, deps_map
-            )
-            sub_g = graph.find_nodes(
-                op="call_function", target=torch.ops.higher_order.control_deps
-            )
-            if len(sub_g) != 2:
-                raise AssertionError(f"Expected 2 control_deps nodes, got {len(sub_g)}")
-
-            if list(sub_g[0].meta["val"].shape) != [256, 256]:
-                raise AssertionError(
-                    f"Expected shape [256, 256], got {list(sub_g[0].meta['val'].shape)}"
-                )
-            if list(sub_g[1].meta["val"].shape) != [256, 256]:
-                raise AssertionError(
-                    f"Expected shape [256, 256], got {list(sub_g[1].meta['val'].shape)}"
-                )
-
-            for attr in graph.find_nodes(op="get_attr"):
-                for n in getattr(graph.owning_module, attr.target).graph.nodes:
-                    if list(n.meta["val"].shape) != [256, 256]:
-                        raise AssertionError(
-                            f"Expected shape [256, 256], got {list(n.meta['val'].shape)}"
-                        )
-
-            return graph
-
-        with torch._inductor.config.patch(
-            post_grad_custom_post_pass=add_control_deps,
-        ):
-            compiled_fn = torch.compile(fn)
-            a = torch.rand([256, 256], device=GPU_TYPE)
-            b = torch.rand([256, 256], device=GPU_TYPE)
-
-            _, code = run_and_get_code(torch.compile(fn), a, b)
-            result = compiled_fn(a, b)
-
-            FileCheck().check(".run(").check("extern_kernels.mm(").check(".run(").run(
-                code[0]
-            )
-
-            expected = fn(a, b)
-            torch.testing.assert_close(result, expected)
-
-    @config.patch(allow_buffer_reuse=False)
-    @requires_gpu()
-    def test_control_deps_do_not_extend_buffer_lifetime(self):
-        """
-        Control deps should not extend buffer lifetimes - buf0/buf1 should be
-        deleted before the 4th matmul, not kept alive by the control dependency.
-        """
-
-        def fn(a, b):
-            # Chain of 4 matmuls: mm0 -> mm1 -> mm2 -> mm3
-            mm0 = a @ b
-            mm1 = mm0 @ b
-            mm2 = mm1 @ b
-            mm3 = mm2 @ b
-            return mm3
-
-        def add_control_deps(graph):
-            from torch.utils._ordered_set import OrderedSet
-
-            mm_nodes = graph.find_nodes(
-                op="call_function", target=torch.ops.aten.mm.default
-            )
-            if len(mm_nodes) != 4:
-                raise AssertionError(f"Expected 4 mm nodes, got {len(mm_nodes)}")
-
-            # Add control dep: mm3 depends on mm0's output
-            # This should NOT extend mm0's buffer lifetime
-            deps_map = {mm_nodes[3]: OrderedSet([mm_nodes[0]])}
-            torch._inductor.fx_passes.control_dependencies.preserve_node_ordering(
-                graph, deps_map
-            )
-            return graph
-
-        with torch._inductor.config.patch(
-            post_grad_custom_post_pass=add_control_deps,
-        ):
-            a = torch.rand([256, 256], device=GPU_TYPE)
-            b = torch.rand([256, 256], device=GPU_TYPE)
-
-            result, code = run_and_get_code(torch.compile(fn), a, b)
-            torch.testing.assert_close(result, fn(a, b))
-
-            # buf0 should be allocated, passed in out=, used once, then del
-            FileCheck().check("buf0 = ").check_count(
-                "extern_kernels.mm", 2, exactly=True
-            ).check("del buf0").run(code[0])
-
-    @config.patch(reorder_for_locality=False)
-    @requires_gpu()
-    def test_control_deps_with_nested_args(self):
-        """Test control_deps with operations that have nested args (e.g., torch.cat)."""
-
-        def fn(a, b, c):
-            x = a + 1
-            y = b * 2
-            # torch.cat has nested args: (List[Tensor], dim)
-            cat_result = torch.cat([x, y], dim=0)
-            z = cat_result + c
-            return z
-
-        def add_control_deps(graph):
-            from torch.utils._ordered_set import OrderedSet
-
-            # Find the cat node which has nested args
-            cat_nodes = graph.find_nodes(
-                op="call_function", target=torch.ops.aten.cat.default
-            )
-            if len(cat_nodes) != 1:
-                raise AssertionError(f"Expected 1 cat node, got {len(cat_nodes)}")
-            cat_node = cat_nodes[0]
-
-            # Verify it has nested args (list of tensors)
-            if not isinstance(cat_node.args[0], (list, tuple)):
-                raise AssertionError(
-                    f"Expected nested args, got {type(cat_node.args[0])}"
-                )
-
-            # Find a node that comes before cat to use as dependency
-            add_nodes = graph.find_nodes(
-                op="call_function", target=torch.ops.aten.add.Tensor
-            )
-            # Use the first add node (x = a + 1)
-            dep_node = add_nodes[0]
-
-            deps_map = {cat_node: OrderedSet([dep_node])}
-            torch._inductor.fx_passes.control_dependencies.preserve_node_ordering(
-                graph, deps_map
-            )
-
-            # Verify control_deps was created
-            control_deps_nodes = graph.find_nodes(
-                op="call_function", target=torch.ops.higher_order.control_deps
-            )
-            if len(control_deps_nodes) != 1:
-                raise AssertionError(
-                    f"Expected 1 control_deps node, got {len(control_deps_nodes)}"
-                )
-            return graph
-
-        with torch._inductor.config.patch(
-            post_grad_custom_post_pass=add_control_deps,
-        ):
-            a = torch.rand([128, 64], device=GPU_TYPE)
-            b = torch.rand([128, 64], device=GPU_TYPE)
-            c = torch.rand([256, 64], device=GPU_TYPE)
-
-            compiled_fn = torch.compile(fn)
-            result = compiled_fn(a, b, c)
-
-            expected = fn(a, b, c)
-            torch.testing.assert_close(result, expected)
+class TestControlDepsGeneric(InductorTestCase):
+    hw_classification = HardwareClassification.GENERIC
 
     @config.patch(enable_auto_functionalized_v2=True)
     def test_control_deps_with_auto_functionalized_v2(self):
@@ -282,70 +101,6 @@ class TestControlDeps(InductorTestCase):
             expected = fn(eager_x)
             torch.testing.assert_close(result, expected)
             torch.testing.assert_close(compiled_x, eager_x)
-
-    @requires_gpu()
-    def test_control_deps_with_triton_kernel(self):
-        """Test control_deps with triton_kernel_wrapper_mutation."""
-        import triton
-        import triton.language as tl
-
-        @triton.jit
-        def add_kernel(
-            in_ptr0,
-            in_ptr1,
-            out_ptr,
-            n_elements,
-            BLOCK_SIZE: "tl.constexpr",
-        ):
-            pid = tl.program_id(axis=0)
-            block_start = pid * BLOCK_SIZE
-            offsets = block_start + tl.arange(0, BLOCK_SIZE)
-            mask = offsets < n_elements
-            x = tl.load(in_ptr0 + offsets, mask=mask)
-            y = tl.load(in_ptr1 + offsets, mask=mask)
-            tl.store(out_ptr + offsets, x + y, mask=mask)
-
-        def fn(x, y):
-            z = x * 2
-            output = torch.zeros_like(x)
-            n_elements = output.numel()
-            grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)  # noqa: E731
-            add_kernel[grid](x, y, output, n_elements, BLOCK_SIZE=16)
-            return output + z
-
-        def add_control_deps(graph):
-            from torch.utils._ordered_set import OrderedSet
-
-            # Find triton_kernel_wrapper_mutation nodes
-            triton_nodes = graph.find_nodes(
-                op="call_function",
-                target=torch.ops.higher_order.triton_kernel_wrapper_functional,
-            )
-            if not triton_nodes:
-                raise AssertionError("Expected triton_kernel_wrapper_functional nodes")
-            # Find mul node (z = x * 2) to use as dependency
-            mul_nodes = graph.find_nodes(
-                op="call_function", target=torch.ops.aten.mul.Tensor
-            )
-            if not mul_nodes:
-                raise AssertionError("Expected mul.Tensor nodes")
-            deps_map = {triton_nodes[0]: OrderedSet([mul_nodes[0]])}
-            torch._inductor.fx_passes.control_dependencies.preserve_node_ordering(
-                graph, deps_map
-            )
-            return graph
-
-        with torch._inductor.config.patch(
-            post_grad_custom_post_pass=add_control_deps,
-        ):
-            x = torch.rand([256], device=GPU_TYPE)
-            y = torch.rand([256], device=GPU_TYPE)
-
-            compiled_fn = torch.compile(fn)
-            result = compiled_fn(x, y)
-
-            expected = fn(x, y)
-            torch.testing.assert_close(result, expected)
 
     def test_wait_event_threads_record_event_passthroughs(self):
         """wait_event must thread record_event's passthroughs to consumers.
@@ -432,78 +187,6 @@ class TestControlDeps(InductorTestCase):
         self.assertIn(torch.ops.streams.wait_event.default, subgraph_targets)
         self.assertNotIn(torch.ops.streams.record_event.default, subgraph_targets)
 
-    @requires_gpu()
-    def test_control_deps_orders_void_op_across_nested_calls(self):
-        """record_event's void op must be named as an additional_buffer_dep
-        of the subsequent wait_event's operations after Inductor lowering.
-
-        record_event lowers to a NoneLayout (void) op and the overall
-        control_deps call around it returns a tuple/None.  When a later
-        control_deps call (around wait_event) lists the record's control_deps
-        node as an additional dep, the lowered value fails the
-        ``isinstance(dep, IRNode)`` check.  Before the fix, the void op was
-        silently dropped and never referenced in the wait's
-        additional_buffer_deps, so Inductor's cudagraph partitioning and
-        other consumers of additional_buffer_deps could reorder the wait
-        before the record.
-        """
-        from torch._inductor import ir
-        from torch._inductor.virtualized import V
-
-        def fn(x):
-            s1 = torch.Stream(device=GPU_TYPE)
-            s2 = torch.Stream(device=GPU_TYPE)
-            e = torch.Event()
-            with s1:
-                y = x + 1
-                e.record()
-            with s2:
-                a = x * 3
-                e.wait()
-                z = y * a
-            return z
-
-        captured: list[dict] = []
-
-        def capture(nodes):
-            void_names = {
-                op.get_name()
-                for op in V.graph.operations
-                if isinstance(op, ir.Buffer) and isinstance(op.layout, ir.NoneLayout)
-            }
-            referenced: set[str] = set()
-            for deps in V.graph.additional_buffer_deps.values():
-                referenced.update(deps)
-            captured.append({"void_names": void_names, "referenced": referenced})
-            return nodes
-
-        torch._dynamo.reset()
-        with config.patch(_pre_fusion_custom_pass=capture):
-            x = torch.ones(2, 2, device=GPU_TYPE)
-            torch.compile(fn)(x)
-
-        self.assertTrue(captured, "expected at least one Inductor compile")
-
-        void_names: set[str] = set()
-        referenced: set[str] = set()
-        for state in captured:
-            void_names |= state["void_names"]
-            referenced |= state["referenced"]
-
-        self.assertGreater(
-            len(void_names),
-            0,
-            "expected record_event/wait_event to lower to NoneLayout ops",
-        )
-        self.assertTrue(
-            void_names & referenced,
-            lambda msg: f"{msg}\n"
-            + (
-                "no record_event void op appears as an additional_buffer_dep; "
-                f"void_names={void_names}, referenced={referenced}"
-            ),
-        )
-
     def test_reinplace_not_blocked_by_control_deps_ordering_dep(self):
         """Views in control_deps' ordering-only deps should not block reinplacing.
 
@@ -537,8 +220,321 @@ class TestControlDeps(InductorTestCase):
         add = g.call_function(torch.ops.aten.add.Tensor, args=(view, other))
         self.assertFalse(_is_control_deps_ordering_only_use(add, view))
 
-    @requires_gpu()
-    def test_control_deps_passthrough_creates_ordering_barrier(self):
+
+class TestControlDeps(InductorTestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @config.patch(reorder_for_locality=False)
+    def test_control_deps_prevents_fusion(self, device):
+        def fn(a, b):
+            c = a + 1
+            d = b @ b
+            e = c * 2
+            return d, e
+
+        def add_control_deps(graph):
+            nodes = [n for n in graph.nodes if n.op == "call_function"]
+            if len(nodes) != 3:
+                raise AssertionError(f"Expected 3 nodes, got {len(nodes)}")
+            c_node = nodes[0]
+            d_node = nodes[1]
+            e_node = nodes[2]
+
+            if d_node.target != torch.ops.aten.mm.default:
+                raise AssertionError(f"Expected mm.default, got {d_node.target}")
+
+            from torch.utils._ordered_set import OrderedSet
+
+            deps_map = {d_node: OrderedSet([c_node]), e_node: OrderedSet([d_node])}
+            torch._inductor.fx_passes.control_dependencies.preserve_node_ordering(
+                graph, deps_map
+            )
+            sub_g = graph.find_nodes(
+                op="call_function", target=torch.ops.higher_order.control_deps
+            )
+            if len(sub_g) != 2:
+                raise AssertionError(f"Expected 2 control_deps nodes, got {len(sub_g)}")
+
+            if list(sub_g[0].meta["val"].shape) != [256, 256]:
+                raise AssertionError(
+                    f"Expected shape [256, 256], got {list(sub_g[0].meta['val'].shape)}"
+                )
+            if list(sub_g[1].meta["val"].shape) != [256, 256]:
+                raise AssertionError(
+                    f"Expected shape [256, 256], got {list(sub_g[1].meta['val'].shape)}"
+                )
+
+            for attr in graph.find_nodes(op="get_attr"):
+                for n in getattr(graph.owning_module, attr.target).graph.nodes:
+                    if list(n.meta["val"].shape) != [256, 256]:
+                        raise AssertionError(
+                            f"Expected shape [256, 256], got {list(n.meta['val'].shape)}"
+                        )
+
+            return graph
+
+        with torch._inductor.config.patch(
+            post_grad_custom_post_pass=add_control_deps,
+        ):
+            compiled_fn = torch.compile(fn)
+            a = torch.rand([256, 256], device=device)
+            b = torch.rand([256, 256], device=device)
+
+            _, code = run_and_get_code(torch.compile(fn), a, b)
+            result = compiled_fn(a, b)
+
+            FileCheck().check(".run(").check("extern_kernels.mm(").check(".run(").run(
+                code[0]
+            )
+
+            expected = fn(a, b)
+            torch.testing.assert_close(result, expected)
+
+    @config.patch(allow_buffer_reuse=False)
+    def test_control_deps_do_not_extend_buffer_lifetime(self, device):
+        """
+        Control deps should not extend buffer lifetimes - buf0/buf1 should be
+        deleted before the 4th matmul, not kept alive by the control dependency.
+        """
+
+        def fn(a, b):
+            # Chain of 4 matmuls: mm0 -> mm1 -> mm2 -> mm3
+            mm0 = a @ b
+            mm1 = mm0 @ b
+            mm2 = mm1 @ b
+            mm3 = mm2 @ b
+            return mm3
+
+        def add_control_deps(graph):
+            from torch.utils._ordered_set import OrderedSet
+
+            mm_nodes = graph.find_nodes(
+                op="call_function", target=torch.ops.aten.mm.default
+            )
+            if len(mm_nodes) != 4:
+                raise AssertionError(f"Expected 4 mm nodes, got {len(mm_nodes)}")
+
+            # Add control dep: mm3 depends on mm0's output
+            # This should NOT extend mm0's buffer lifetime
+            deps_map = {mm_nodes[3]: OrderedSet([mm_nodes[0]])}
+            torch._inductor.fx_passes.control_dependencies.preserve_node_ordering(
+                graph, deps_map
+            )
+            return graph
+
+        with torch._inductor.config.patch(
+            post_grad_custom_post_pass=add_control_deps,
+        ):
+            a = torch.rand([256, 256], device=device)
+            b = torch.rand([256, 256], device=device)
+
+            result, code = run_and_get_code(torch.compile(fn), a, b)
+            torch.testing.assert_close(result, fn(a, b))
+
+            # buf0 should be allocated, passed in out=, used once, then del
+            FileCheck().check("buf0 = ").check_count(
+                "extern_kernels.mm", 2, exactly=True
+            ).check("del buf0").run(code[0])
+
+    @config.patch(reorder_for_locality=False)
+    def test_control_deps_with_nested_args(self, device):
+        """Test control_deps with operations that have nested args (e.g., torch.cat)."""
+
+        def fn(a, b, c):
+            x = a + 1
+            y = b * 2
+            # torch.cat has nested args: (List[Tensor], dim)
+            cat_result = torch.cat([x, y], dim=0)
+            z = cat_result + c
+            return z
+
+        def add_control_deps(graph):
+            from torch.utils._ordered_set import OrderedSet
+
+            # Find the cat node which has nested args
+            cat_nodes = graph.find_nodes(
+                op="call_function", target=torch.ops.aten.cat.default
+            )
+            if len(cat_nodes) != 1:
+                raise AssertionError(f"Expected 1 cat node, got {len(cat_nodes)}")
+            cat_node = cat_nodes[0]
+
+            # Verify it has nested args (list of tensors)
+            if not isinstance(cat_node.args[0], (list, tuple)):
+                raise AssertionError(
+                    f"Expected nested args, got {type(cat_node.args[0])}"
+                )
+
+            # Find a node that comes before cat to use as dependency
+            add_nodes = graph.find_nodes(
+                op="call_function", target=torch.ops.aten.add.Tensor
+            )
+            # Use the first add node (x = a + 1)
+            dep_node = add_nodes[0]
+
+            deps_map = {cat_node: OrderedSet([dep_node])}
+            torch._inductor.fx_passes.control_dependencies.preserve_node_ordering(
+                graph, deps_map
+            )
+
+            # Verify control_deps was created
+            control_deps_nodes = graph.find_nodes(
+                op="call_function", target=torch.ops.higher_order.control_deps
+            )
+            if len(control_deps_nodes) != 1:
+                raise AssertionError(
+                    f"Expected 1 control_deps node, got {len(control_deps_nodes)}"
+                )
+            return graph
+
+        with torch._inductor.config.patch(
+            post_grad_custom_post_pass=add_control_deps,
+        ):
+            a = torch.rand([128, 64], device=device)
+            b = torch.rand([128, 64], device=device)
+            c = torch.rand([256, 64], device=device)
+
+            compiled_fn = torch.compile(fn)
+            result = compiled_fn(a, b, c)
+
+            expected = fn(a, b, c)
+            torch.testing.assert_close(result, expected)
+
+    def test_control_deps_with_triton_kernel(self, device):
+        """Test control_deps with triton_kernel_wrapper_mutation."""
+        import triton
+        import triton.language as tl
+
+        @triton.jit
+        def add_kernel(
+            in_ptr0,
+            in_ptr1,
+            out_ptr,
+            n_elements,
+            BLOCK_SIZE: "tl.constexpr",
+        ):
+            pid = tl.program_id(axis=0)
+            block_start = pid * BLOCK_SIZE
+            offsets = block_start + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_elements
+            x = tl.load(in_ptr0 + offsets, mask=mask)
+            y = tl.load(in_ptr1 + offsets, mask=mask)
+            tl.store(out_ptr + offsets, x + y, mask=mask)
+
+        def fn(x, y):
+            z = x * 2
+            output = torch.zeros_like(x)
+            n_elements = output.numel()
+            grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)  # noqa: E731
+            add_kernel[grid](x, y, output, n_elements, BLOCK_SIZE=16)
+            return output + z
+
+        def add_control_deps(graph):
+            from torch.utils._ordered_set import OrderedSet
+
+            # Find triton_kernel_wrapper_mutation nodes
+            triton_nodes = graph.find_nodes(
+                op="call_function",
+                target=torch.ops.higher_order.triton_kernel_wrapper_functional,
+            )
+            if not triton_nodes:
+                raise AssertionError("Expected triton_kernel_wrapper_functional nodes")
+            # Find mul node (z = x * 2) to use as dependency
+            mul_nodes = graph.find_nodes(
+                op="call_function", target=torch.ops.aten.mul.Tensor
+            )
+            if not mul_nodes:
+                raise AssertionError("Expected mul.Tensor nodes")
+            deps_map = {triton_nodes[0]: OrderedSet([mul_nodes[0]])}
+            torch._inductor.fx_passes.control_dependencies.preserve_node_ordering(
+                graph, deps_map
+            )
+            return graph
+
+        with torch._inductor.config.patch(
+            post_grad_custom_post_pass=add_control_deps,
+        ):
+            x = torch.rand([256], device=device)
+            y = torch.rand([256], device=device)
+
+            compiled_fn = torch.compile(fn)
+            result = compiled_fn(x, y)
+
+            expected = fn(x, y)
+            torch.testing.assert_close(result, expected)
+
+    def test_control_deps_orders_void_op_across_nested_calls(self, device):
+        """record_event's void op must be named as an additional_buffer_dep
+        of the subsequent wait_event's operations after Inductor lowering.
+
+        record_event lowers to a NoneLayout (void) op and the overall
+        control_deps call around it returns a tuple/None.  When a later
+        control_deps call (around wait_event) lists the record's control_deps
+        node as an additional dep, the lowered value fails the
+        ``isinstance(dep, IRNode)`` check.  Before the fix, the void op was
+        silently dropped and never referenced in the wait's
+        additional_buffer_deps, so Inductor's cudagraph partitioning and
+        other consumers of additional_buffer_deps could reorder the wait
+        before the record.
+        """
+        from torch._inductor import ir
+        from torch._inductor.virtualized import V
+
+        def fn(x):
+            s1 = torch.Stream(device=device)
+            s2 = torch.Stream(device=device)
+            e = torch.Event()
+            with s1:
+                y = x + 1
+                e.record()
+            with s2:
+                a = x * 3
+                e.wait()
+                z = y * a
+            return z
+
+        captured: list[dict] = []
+
+        def capture(nodes):
+            void_names = {
+                op.get_name()
+                for op in V.graph.operations
+                if isinstance(op, ir.Buffer) and isinstance(op.layout, ir.NoneLayout)
+            }
+            referenced: set[str] = set()
+            for deps in V.graph.additional_buffer_deps.values():
+                referenced.update(deps)
+            captured.append({"void_names": void_names, "referenced": referenced})
+            return nodes
+
+        torch._dynamo.reset()
+        with config.patch(_pre_fusion_custom_pass=capture):
+            x = torch.ones(2, 2, device=device)
+            torch.compile(fn)(x)
+
+        self.assertTrue(captured, "expected at least one Inductor compile")
+
+        void_names: set[str] = set()
+        referenced: set[str] = set()
+        for state in captured:
+            void_names |= state["void_names"]
+            referenced |= state["referenced"]
+
+        self.assertGreater(
+            len(void_names),
+            0,
+            "expected record_event/wait_event to lower to NoneLayout ops",
+        )
+        self.assertTrue(
+            void_names & referenced,
+            lambda msg: f"{msg}\n"
+            + (
+                "no record_event void op appears as an additional_buffer_dep; "
+                f"void_names={void_names}, referenced={referenced}"
+            ),
+        )
+
+    def test_control_deps_passthrough_creates_ordering_barrier(self, device):
         """Pass-through values in control_deps create OrderingBarrier nodes.
 
         Verifies that OrderingBarrier:
@@ -566,7 +562,7 @@ class TestControlDeps(InductorTestCase):
             return nodes
 
         def fn(x):
-            s = torch.Stream(device=GPU_TYPE)
+            s = torch.Stream(device=device)
             e = torch.Event()
             with s:
                 y = x + 1
@@ -576,10 +572,10 @@ class TestControlDeps(InductorTestCase):
 
         torch._dynamo.reset()
         with config.patch(_pre_fusion_custom_pass=capture):
-            x = torch.ones(4, device=GPU_TYPE)
+            x = torch.ones(4, device=device)
             result = torch.compile(fn)(x)
 
-        expected = fn(torch.ones(4, device=GPU_TYPE))
+        expected = fn(torch.ones(4, device=device))
         torch.testing.assert_close(result, expected)
 
         self.assertTrue(captured, "expected at least one Inductor compile")
@@ -596,8 +592,7 @@ class TestControlDeps(InductorTestCase):
                     f"barrier source {source_name} should not be in mutated_buffers",
                 )
 
-    @requires_gpu()
-    def test_ordering_barrier_is_nop(self):
+    def test_ordering_barrier_is_nop(self, device):
         """OrderingBarrier must not allocate or generate code.
 
         Verifies should_allocate() and is_no_op() on the actual IR node.
@@ -620,7 +615,7 @@ class TestControlDeps(InductorTestCase):
             return nodes
 
         def fn(x):
-            s = torch.Stream(device=GPU_TYPE)
+            s = torch.Stream(device=device)
             e = torch.Event()
             with s:
                 y = x + 1
@@ -630,10 +625,10 @@ class TestControlDeps(InductorTestCase):
 
         torch._dynamo.reset()
         with config.patch(_pre_fusion_custom_pass=capture):
-            x = torch.ones(4, device=GPU_TYPE)
+            x = torch.ones(4, device=device)
             result = torch.compile(fn)(x)
 
-        expected = fn(torch.ones(4, device=GPU_TYPE))
+        expected = fn(torch.ones(4, device=device))
         torch.testing.assert_close(result, expected)
 
         self.assertTrue(captured, "expected at least one compile")
@@ -652,8 +647,8 @@ class TestControlDeps(InductorTestCase):
                 "OrderingBarrier is_no_op() must be True",
             )
 
-    @requires_cuda_triton
-    def test_bidirectional_stream_sync_correctness(self):
+    @requires_triton
+    def test_bidirectional_stream_sync_correctness(self, device):
         """Regression: passthrough OrderingBarrier must be ordered after all subgraph ops.
 
         Bidirectional stream sync exposes a bug where additional_buffer_deps was
@@ -665,30 +660,34 @@ class TestControlDeps(InductorTestCase):
         from torch._inductor.utils import run_and_get_code
 
         def fn(x):
-            s1 = torch.cuda.Stream()
-            s2 = torch.cuda.Stream()
-            event_s1 = torch.cuda.Event()
-            event_s2 = torch.cuda.Event()
-            with torch.cuda.stream(s1):
+            s1 = torch.get_device_module(device).Stream()
+            s2 = torch.get_device_module(device).Stream()
+            event_s1 = torch.get_device_module(device).Event()
+            event_s2 = torch.get_device_module(device).Event()
+            with torch.get_device_module(device).stream(s1):
                 a = x * 2
                 event_s1.record(s1)
-            with torch.cuda.stream(s2):
+            with torch.get_device_module(device).stream(s2):
                 event_s1.wait(s2)
                 b = a + 1
                 event_s2.record(s2)
-            with torch.cuda.stream(s1):
+            with torch.get_device_module(device).stream(s1):
                 event_s2.wait(s1)
                 c = b * 2
             s1.synchronize()
             s2.synchronize()
             return c
 
-        x = torch.randn(1024, device="cuda")
+        x = torch.randn(1024, device=device)
         expected = fn(x)
         result, _ = run_and_get_code(torch.compile(fn), x)
         self.assertEqual(result, expected)
 
 
+instantiate_device_type_tests(
+    TestControlDeps, globals(), except_for="cpu", allow_xpu=True
+)
+
 if __name__ == "__main__":
-    if IS_LINUX and HAS_GPU_AND_TRITON:
+    if IS_LINUX and HAS_TRITON:
         run_tests(needs="filelock")

--- a/test/inductor/test_control_deps.py
+++ b/test/inductor/test_control_deps.py
@@ -1,25 +1,21 @@
 # Owner(s): ["module: inductor"]
 
-import unittest
-
 import torch
 from torch._inductor import config
 from torch._inductor.test_case import run_tests, TestCase as InductorTestCase
 from torch._inductor.utils import run_and_get_code
 from torch.testing import FileCheck
-from torch.testing._internal.common_utils import IS_LINUX
-from torch.testing._internal.inductor_utils import (
-    GPU_TYPE,
-    HAS_CUDA_AND_TRITON,
-    HAS_GPU_AND_TRITON,
-    requires_gpu,
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    skipIf,
 )
-
-
-requires_cuda_triton = unittest.skipUnless(HAS_CUDA_AND_TRITON, "requires CUDA")
+from torch.testing._internal.common_utils import HardwareClassification, IS_LINUX
+from torch.testing._internal.inductor_utils import HAS_TRITON
 
 
 class TestControlDeps(InductorTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_control_deps_wraps_fallback_op(self):
         def fn(x):
             dependency = x + 1
@@ -52,185 +48,6 @@ class TestControlDeps(InductorTestCase):
             actual = torch.compile(fn)(x)
 
         torch.testing.assert_close(actual, fn(x))
-
-    @config.patch(reorder_for_locality=False)
-    @requires_gpu()
-    def test_control_deps_prevents_fusion(self):
-        def fn(a, b):
-            c = a + 1
-            d = b @ b
-            e = c * 2
-            return d, e
-
-        def add_control_deps(graph):
-            nodes = [n for n in graph.nodes if n.op == "call_function"]
-            if len(nodes) != 3:
-                raise AssertionError(f"Expected 3 nodes, got {len(nodes)}")
-            c_node = nodes[0]
-            d_node = nodes[1]
-            e_node = nodes[2]
-
-            if d_node.target != torch.ops.aten.mm.default:
-                raise AssertionError(f"Expected mm.default, got {d_node.target}")
-
-            from torch.utils._ordered_set import OrderedSet
-
-            deps_map = {d_node: OrderedSet([c_node]), e_node: OrderedSet([d_node])}
-            torch._inductor.fx_passes.control_dependencies.preserve_node_ordering(
-                graph, deps_map
-            )
-            sub_g = graph.find_nodes(
-                op="call_function", target=torch.ops.higher_order.control_deps
-            )
-            if len(sub_g) != 2:
-                raise AssertionError(f"Expected 2 control_deps nodes, got {len(sub_g)}")
-
-            if list(sub_g[0].meta["val"].shape) != [256, 256]:
-                raise AssertionError(
-                    f"Expected shape [256, 256], got {list(sub_g[0].meta['val'].shape)}"
-                )
-            if list(sub_g[1].meta["val"].shape) != [256, 256]:
-                raise AssertionError(
-                    f"Expected shape [256, 256], got {list(sub_g[1].meta['val'].shape)}"
-                )
-
-            for attr in graph.find_nodes(op="get_attr"):
-                for n in getattr(graph.owning_module, attr.target).graph.nodes:
-                    if list(n.meta["val"].shape) != [256, 256]:
-                        raise AssertionError(
-                            f"Expected shape [256, 256], got {list(n.meta['val'].shape)}"
-                        )
-
-            return graph
-
-        with torch._inductor.config.patch(
-            post_grad_custom_post_pass=add_control_deps,
-        ):
-            compiled_fn = torch.compile(fn)
-            a = torch.rand([256, 256], device=GPU_TYPE)
-            b = torch.rand([256, 256], device=GPU_TYPE)
-
-            _, code = run_and_get_code(torch.compile(fn), a, b)
-            result = compiled_fn(a, b)
-
-            FileCheck().check(".run(").check("extern_kernels.mm(").check(".run(").run(
-                code[0]
-            )
-
-            expected = fn(a, b)
-            torch.testing.assert_close(result, expected)
-
-    @config.patch(allow_buffer_reuse=False)
-    @requires_gpu()
-    def test_control_deps_do_not_extend_buffer_lifetime(self):
-        """
-        Control deps should not extend buffer lifetimes - buf0/buf1 should be
-        deleted before the 4th matmul, not kept alive by the control dependency.
-        """
-
-        def fn(a, b):
-            # Chain of 4 matmuls: mm0 -> mm1 -> mm2 -> mm3
-            mm0 = a @ b
-            mm1 = mm0 @ b
-            mm2 = mm1 @ b
-            mm3 = mm2 @ b
-            return mm3
-
-        def add_control_deps(graph):
-            from torch.utils._ordered_set import OrderedSet
-
-            mm_nodes = graph.find_nodes(
-                op="call_function", target=torch.ops.aten.mm.default
-            )
-            if len(mm_nodes) != 4:
-                raise AssertionError(f"Expected 4 mm nodes, got {len(mm_nodes)}")
-
-            # Add control dep: mm3 depends on mm0's output
-            # This should NOT extend mm0's buffer lifetime
-            deps_map = {mm_nodes[3]: OrderedSet([mm_nodes[0]])}
-            torch._inductor.fx_passes.control_dependencies.preserve_node_ordering(
-                graph, deps_map
-            )
-            return graph
-
-        with torch._inductor.config.patch(
-            post_grad_custom_post_pass=add_control_deps,
-        ):
-            a = torch.rand([256, 256], device=GPU_TYPE)
-            b = torch.rand([256, 256], device=GPU_TYPE)
-
-            result, code = run_and_get_code(torch.compile(fn), a, b)
-            torch.testing.assert_close(result, fn(a, b))
-
-            # buf0 should be allocated, passed in out=, used once, then del
-            FileCheck().check("buf0 = ").check_count(
-                "extern_kernels.mm", 2, exactly=True
-            ).check("del buf0").run(code[0])
-
-    @config.patch(reorder_for_locality=False)
-    @requires_gpu()
-    def test_control_deps_with_nested_args(self):
-        """Test control_deps with operations that have nested args (e.g., torch.cat)."""
-
-        def fn(a, b, c):
-            x = a + 1
-            y = b * 2
-            # torch.cat has nested args: (List[Tensor], dim)
-            cat_result = torch.cat([x, y], dim=0)
-            z = cat_result + c
-            return z
-
-        def add_control_deps(graph):
-            from torch.utils._ordered_set import OrderedSet
-
-            # Find the cat node which has nested args
-            cat_nodes = graph.find_nodes(
-                op="call_function", target=torch.ops.aten.cat.default
-            )
-            if len(cat_nodes) != 1:
-                raise AssertionError(f"Expected 1 cat node, got {len(cat_nodes)}")
-            cat_node = cat_nodes[0]
-
-            # Verify it has nested args (list of tensors)
-            if not isinstance(cat_node.args[0], (list, tuple)):
-                raise AssertionError(
-                    f"Expected nested args, got {type(cat_node.args[0])}"
-                )
-
-            # Find a node that comes before cat to use as dependency
-            add_nodes = graph.find_nodes(
-                op="call_function", target=torch.ops.aten.add.Tensor
-            )
-            # Use the first add node (x = a + 1)
-            dep_node = add_nodes[0]
-
-            deps_map = {cat_node: OrderedSet([dep_node])}
-            torch._inductor.fx_passes.control_dependencies.preserve_node_ordering(
-                graph, deps_map
-            )
-
-            # Verify control_deps was created
-            control_deps_nodes = graph.find_nodes(
-                op="call_function", target=torch.ops.higher_order.control_deps
-            )
-            if len(control_deps_nodes) != 1:
-                raise AssertionError(
-                    f"Expected 1 control_deps node, got {len(control_deps_nodes)}"
-                )
-            return graph
-
-        with torch._inductor.config.patch(
-            post_grad_custom_post_pass=add_control_deps,
-        ):
-            a = torch.rand([128, 64], device=GPU_TYPE)
-            b = torch.rand([128, 64], device=GPU_TYPE)
-            c = torch.rand([256, 64], device=GPU_TYPE)
-
-            compiled_fn = torch.compile(fn)
-            result = compiled_fn(a, b, c)
-
-            expected = fn(a, b, c)
-            torch.testing.assert_close(result, expected)
 
     @config.patch(enable_auto_functionalized_v2=True)
     def test_control_deps_with_auto_functionalized_v2(self):
@@ -315,70 +132,6 @@ class TestControlDeps(InductorTestCase):
             expected = fn(eager_x)
             torch.testing.assert_close(result, expected)
             torch.testing.assert_close(compiled_x, eager_x)
-
-    @requires_gpu()
-    def test_control_deps_with_triton_kernel(self):
-        """Test control_deps with triton_kernel_wrapper_mutation."""
-        import triton
-        import triton.language as tl
-
-        @triton.jit
-        def add_kernel(
-            in_ptr0,
-            in_ptr1,
-            out_ptr,
-            n_elements,
-            BLOCK_SIZE: "tl.constexpr",
-        ):
-            pid = tl.program_id(axis=0)
-            block_start = pid * BLOCK_SIZE
-            offsets = block_start + tl.arange(0, BLOCK_SIZE)
-            mask = offsets < n_elements
-            x = tl.load(in_ptr0 + offsets, mask=mask)
-            y = tl.load(in_ptr1 + offsets, mask=mask)
-            tl.store(out_ptr + offsets, x + y, mask=mask)
-
-        def fn(x, y):
-            z = x * 2
-            output = torch.zeros_like(x)
-            n_elements = output.numel()
-            grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)  # noqa: E731
-            add_kernel[grid](x, y, output, n_elements, BLOCK_SIZE=16)
-            return output + z
-
-        def add_control_deps(graph):
-            from torch.utils._ordered_set import OrderedSet
-
-            # Find triton_kernel_wrapper_mutation nodes
-            triton_nodes = graph.find_nodes(
-                op="call_function",
-                target=torch.ops.higher_order.triton_kernel_wrapper_functional,
-            )
-            if not triton_nodes:
-                raise AssertionError("Expected triton_kernel_wrapper_functional nodes")
-            # Find mul node (z = x * 2) to use as dependency
-            mul_nodes = graph.find_nodes(
-                op="call_function", target=torch.ops.aten.mul.Tensor
-            )
-            if not mul_nodes:
-                raise AssertionError("Expected mul.Tensor nodes")
-            deps_map = {triton_nodes[0]: OrderedSet([mul_nodes[0]])}
-            torch._inductor.fx_passes.control_dependencies.preserve_node_ordering(
-                graph, deps_map
-            )
-            return graph
-
-        with torch._inductor.config.patch(
-            post_grad_custom_post_pass=add_control_deps,
-        ):
-            x = torch.rand([256], device=GPU_TYPE)
-            y = torch.rand([256], device=GPU_TYPE)
-
-            compiled_fn = torch.compile(fn)
-            result = compiled_fn(x, y)
-
-            expected = fn(x, y)
-            torch.testing.assert_close(result, expected)
 
     def test_wait_event_threads_record_event_passthroughs(self):
         """wait_event must thread record_event's passthroughs to consumers.
@@ -465,78 +218,6 @@ class TestControlDeps(InductorTestCase):
         self.assertIn(torch.ops.streams.wait_event.default, subgraph_targets)
         self.assertNotIn(torch.ops.streams.record_event.default, subgraph_targets)
 
-    @requires_gpu()
-    def test_control_deps_orders_void_op_across_nested_calls(self):
-        """record_event's void op must be named as an additional_buffer_dep
-        of the subsequent wait_event's operations after Inductor lowering.
-
-        record_event lowers to a NoneLayout (void) op and the overall
-        control_deps call around it returns a tuple/None.  When a later
-        control_deps call (around wait_event) lists the record's control_deps
-        node as an additional dep, the lowered value fails the
-        ``isinstance(dep, IRNode)`` check.  Before the fix, the void op was
-        silently dropped and never referenced in the wait's
-        additional_buffer_deps, so Inductor's cudagraph partitioning and
-        other consumers of additional_buffer_deps could reorder the wait
-        before the record.
-        """
-        from torch._inductor import ir
-        from torch._inductor.virtualized import V
-
-        def fn(x):
-            s1 = torch.Stream(device=GPU_TYPE)
-            s2 = torch.Stream(device=GPU_TYPE)
-            e = torch.Event()
-            with s1:
-                y = x + 1
-                e.record()
-            with s2:
-                a = x * 3
-                e.wait()
-                z = y * a
-            return z
-
-        captured: list[dict] = []
-
-        def capture(nodes):
-            void_names = {
-                op.get_name()
-                for op in V.graph.operations
-                if isinstance(op, ir.Buffer) and isinstance(op.layout, ir.NoneLayout)
-            }
-            referenced: set[str] = set()
-            for deps in V.graph.additional_buffer_deps.values():
-                referenced.update(deps)
-            captured.append({"void_names": void_names, "referenced": referenced})
-            return nodes
-
-        torch._dynamo.reset()
-        with config.patch(_pre_fusion_custom_pass=capture):
-            x = torch.ones(2, 2, device=GPU_TYPE)
-            torch.compile(fn)(x)
-
-        self.assertTrue(captured, "expected at least one Inductor compile")
-
-        void_names: set[str] = set()
-        referenced: set[str] = set()
-        for state in captured:
-            void_names |= state["void_names"]
-            referenced |= state["referenced"]
-
-        self.assertGreater(
-            len(void_names),
-            0,
-            "expected record_event/wait_event to lower to NoneLayout ops",
-        )
-        self.assertTrue(
-            void_names & referenced,
-            lambda msg: f"{msg}\n"
-            + (
-                "no record_event void op appears as an additional_buffer_dep; "
-                f"void_names={void_names}, referenced={referenced}"
-            ),
-        )
-
     def test_reinplace_not_blocked_by_control_deps_ordering_dep(self):
         """Views in control_deps' ordering-only deps should not block reinplacing.
 
@@ -570,8 +251,327 @@ class TestControlDeps(InductorTestCase):
         add = g.call_function(torch.ops.aten.add.Tensor, args=(view, other))
         self.assertFalse(_is_control_deps_ordering_only_use(add, view))
 
-    @requires_gpu()
-    def test_control_deps_passthrough_creates_ordering_barrier(self):
+
+class TestControlDepsDevice(InductorTestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @skipIf(not HAS_TRITON, "requires triton", device_type=("cuda", "xpu"))
+    @config.patch(reorder_for_locality=False)
+    def test_control_deps_prevents_fusion(self, device):
+        def fn(a, b):
+            c = a + 1
+            d = b @ b
+            e = c * 2
+            return d, e
+
+        def add_control_deps(graph):
+            nodes = [n for n in graph.nodes if n.op == "call_function"]
+            if len(nodes) != 3:
+                raise AssertionError(f"Expected 3 nodes, got {len(nodes)}")
+            c_node = nodes[0]
+            d_node = nodes[1]
+            e_node = nodes[2]
+
+            if d_node.target != torch.ops.aten.mm.default:
+                raise AssertionError(f"Expected mm.default, got {d_node.target}")
+
+            from torch.utils._ordered_set import OrderedSet
+
+            deps_map = {d_node: OrderedSet([c_node]), e_node: OrderedSet([d_node])}
+            torch._inductor.fx_passes.control_dependencies.preserve_node_ordering(
+                graph, deps_map
+            )
+            sub_g = graph.find_nodes(
+                op="call_function", target=torch.ops.higher_order.control_deps
+            )
+            if len(sub_g) != 2:
+                raise AssertionError(f"Expected 2 control_deps nodes, got {len(sub_g)}")
+
+            if list(sub_g[0].meta["val"].shape) != [256, 256]:
+                raise AssertionError(
+                    f"Expected shape [256, 256], got {list(sub_g[0].meta['val'].shape)}"
+                )
+            if list(sub_g[1].meta["val"].shape) != [256, 256]:
+                raise AssertionError(
+                    f"Expected shape [256, 256], got {list(sub_g[1].meta['val'].shape)}"
+                )
+
+            for attr in graph.find_nodes(op="get_attr"):
+                for n in getattr(graph.owning_module, attr.target).graph.nodes:
+                    if list(n.meta["val"].shape) != [256, 256]:
+                        raise AssertionError(
+                            f"Expected shape [256, 256], got {list(n.meta['val'].shape)}"
+                        )
+
+            return graph
+
+        with torch._inductor.config.patch(
+            post_grad_custom_post_pass=add_control_deps,
+        ):
+            compiled_fn = torch.compile(fn)
+            a = torch.rand([256, 256], device=device)
+            b = torch.rand([256, 256], device=device)
+
+            _, code = run_and_get_code(torch.compile(fn), a, b)
+            result = compiled_fn(a, b)
+
+            FileCheck().check(".run(").check("extern_kernels.mm(").check(".run(").run(
+                code[0]
+            )
+
+            expected = fn(a, b)
+            torch.testing.assert_close(result, expected)
+
+    @skipIf(not HAS_TRITON, "requires triton", device_type=("cuda", "xpu"))
+    @config.patch(allow_buffer_reuse=False)
+    def test_control_deps_do_not_extend_buffer_lifetime(self, device):
+        """
+        Control deps should not extend buffer lifetimes - buf0/buf1 should be
+        deleted before the 4th matmul, not kept alive by the control dependency.
+        """
+
+        def fn(a, b):
+            # Chain of 4 matmuls: mm0 -> mm1 -> mm2 -> mm3
+            mm0 = a @ b
+            mm1 = mm0 @ b
+            mm2 = mm1 @ b
+            mm3 = mm2 @ b
+            return mm3
+
+        def add_control_deps(graph):
+            from torch.utils._ordered_set import OrderedSet
+
+            mm_nodes = graph.find_nodes(
+                op="call_function", target=torch.ops.aten.mm.default
+            )
+            if len(mm_nodes) != 4:
+                raise AssertionError(f"Expected 4 mm nodes, got {len(mm_nodes)}")
+
+            # Add control dep: mm3 depends on mm0's output
+            # This should NOT extend mm0's buffer lifetime
+            deps_map = {mm_nodes[3]: OrderedSet([mm_nodes[0]])}
+            torch._inductor.fx_passes.control_dependencies.preserve_node_ordering(
+                graph, deps_map
+            )
+            return graph
+
+        with torch._inductor.config.patch(
+            post_grad_custom_post_pass=add_control_deps,
+        ):
+            a = torch.rand([256, 256], device=device)
+            b = torch.rand([256, 256], device=device)
+
+            result, code = run_and_get_code(torch.compile(fn), a, b)
+            torch.testing.assert_close(result, fn(a, b))
+
+            # buf0 should be allocated, passed in out=, used once, then del
+            FileCheck().check("buf0 = ").check_count(
+                "extern_kernels.mm", 2, exactly=True
+            ).check("del buf0").run(code[0])
+
+    @skipIf(not HAS_TRITON, "requires triton", device_type=("cuda", "xpu"))
+    @config.patch(reorder_for_locality=False)
+    def test_control_deps_with_nested_args(self, device):
+        """Test control_deps with operations that have nested args (e.g., torch.cat)."""
+
+        def fn(a, b, c):
+            x = a + 1
+            y = b * 2
+            # torch.cat has nested args: (List[Tensor], dim)
+            cat_result = torch.cat([x, y], dim=0)
+            z = cat_result + c
+            return z
+
+        def add_control_deps(graph):
+            from torch.utils._ordered_set import OrderedSet
+
+            # Find the cat node which has nested args
+            cat_nodes = graph.find_nodes(
+                op="call_function", target=torch.ops.aten.cat.default
+            )
+            if len(cat_nodes) != 1:
+                raise AssertionError(f"Expected 1 cat node, got {len(cat_nodes)}")
+            cat_node = cat_nodes[0]
+
+            # Verify it has nested args (list of tensors)
+            if not isinstance(cat_node.args[0], (list, tuple)):
+                raise AssertionError(
+                    f"Expected nested args, got {type(cat_node.args[0])}"
+                )
+
+            # Find a node that comes before cat to use as dependency
+            add_nodes = graph.find_nodes(
+                op="call_function", target=torch.ops.aten.add.Tensor
+            )
+            # Use the first add node (x = a + 1)
+            dep_node = add_nodes[0]
+
+            deps_map = {cat_node: OrderedSet([dep_node])}
+            torch._inductor.fx_passes.control_dependencies.preserve_node_ordering(
+                graph, deps_map
+            )
+
+            # Verify control_deps was created
+            control_deps_nodes = graph.find_nodes(
+                op="call_function", target=torch.ops.higher_order.control_deps
+            )
+            if len(control_deps_nodes) != 1:
+                raise AssertionError(
+                    f"Expected 1 control_deps node, got {len(control_deps_nodes)}"
+                )
+            return graph
+
+        with torch._inductor.config.patch(
+            post_grad_custom_post_pass=add_control_deps,
+        ):
+            a = torch.rand([128, 64], device=device)
+            b = torch.rand([128, 64], device=device)
+            c = torch.rand([256, 64], device=device)
+
+            compiled_fn = torch.compile(fn)
+            result = compiled_fn(a, b, c)
+
+            expected = fn(a, b, c)
+            torch.testing.assert_close(result, expected)
+
+    @skipIf(not HAS_TRITON, "requires triton", device_type=("cuda", "xpu"))
+    def test_control_deps_with_triton_kernel(self, device):
+        """Test control_deps with triton_kernel_wrapper_mutation."""
+        import triton
+        import triton.language as tl
+
+        @triton.jit
+        def add_kernel(
+            in_ptr0,
+            in_ptr1,
+            out_ptr,
+            n_elements,
+            BLOCK_SIZE: "tl.constexpr",
+        ):
+            pid = tl.program_id(axis=0)
+            block_start = pid * BLOCK_SIZE
+            offsets = block_start + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_elements
+            x = tl.load(in_ptr0 + offsets, mask=mask)
+            y = tl.load(in_ptr1 + offsets, mask=mask)
+            tl.store(out_ptr + offsets, x + y, mask=mask)
+
+        def fn(x, y):
+            z = x * 2
+            output = torch.zeros_like(x)
+            n_elements = output.numel()
+            grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)  # noqa: E731
+            add_kernel[grid](x, y, output, n_elements, BLOCK_SIZE=16)
+            return output + z
+
+        def add_control_deps(graph):
+            from torch.utils._ordered_set import OrderedSet
+
+            # Find triton_kernel_wrapper_mutation nodes
+            triton_nodes = graph.find_nodes(
+                op="call_function",
+                target=torch.ops.higher_order.triton_kernel_wrapper_functional,
+            )
+            if not triton_nodes:
+                raise AssertionError("Expected triton_kernel_wrapper_functional nodes")
+            # Find mul node (z = x * 2) to use as dependency
+            mul_nodes = graph.find_nodes(
+                op="call_function", target=torch.ops.aten.mul.Tensor
+            )
+            if not mul_nodes:
+                raise AssertionError("Expected mul.Tensor nodes")
+            deps_map = {triton_nodes[0]: OrderedSet([mul_nodes[0]])}
+            torch._inductor.fx_passes.control_dependencies.preserve_node_ordering(
+                graph, deps_map
+            )
+            return graph
+
+        with torch._inductor.config.patch(
+            post_grad_custom_post_pass=add_control_deps,
+        ):
+            x = torch.rand([256], device=device)
+            y = torch.rand([256], device=device)
+
+            compiled_fn = torch.compile(fn)
+            result = compiled_fn(x, y)
+
+            expected = fn(x, y)
+            torch.testing.assert_close(result, expected)
+
+    @skipIf(not HAS_TRITON, "requires triton", device_type=("cuda", "xpu"))
+    def test_control_deps_orders_void_op_across_nested_calls(self, device):
+        """record_event's void op must be named as an additional_buffer_dep
+        of the subsequent wait_event's operations after Inductor lowering.
+
+        record_event lowers to a NoneLayout (void) op and the overall
+        control_deps call around it returns a tuple/None.  When a later
+        control_deps call (around wait_event) lists the record's control_deps
+        node as an additional dep, the lowered value fails the
+        ``isinstance(dep, IRNode)`` check.  Before the fix, the void op was
+        silently dropped and never referenced in the wait's
+        additional_buffer_deps, so Inductor's cudagraph partitioning and
+        other consumers of additional_buffer_deps could reorder the wait
+        before the record.
+        """
+        from torch._inductor import ir
+        from torch._inductor.virtualized import V
+
+        def fn(x):
+            s1 = torch.Stream(device=device)
+            s2 = torch.Stream(device=device)
+            e = torch.Event()
+            with s1:
+                y = x + 1
+                e.record()
+            with s2:
+                a = x * 3
+                e.wait()
+                z = y * a
+            return z
+
+        captured: list[dict] = []
+
+        def capture(nodes):
+            void_names = {
+                op.get_name()
+                for op in V.graph.operations
+                if isinstance(op, ir.Buffer) and isinstance(op.layout, ir.NoneLayout)
+            }
+            referenced: set[str] = set()
+            for deps in V.graph.additional_buffer_deps.values():
+                referenced.update(deps)
+            captured.append({"void_names": void_names, "referenced": referenced})
+            return nodes
+
+        torch._dynamo.reset()
+        with config.patch(_pre_fusion_custom_pass=capture):
+            x = torch.ones(2, 2, device=device)
+            torch.compile(fn)(x)
+
+        self.assertTrue(captured, "expected at least one Inductor compile")
+
+        void_names: set[str] = set()
+        referenced: set[str] = set()
+        for state in captured:
+            void_names |= state["void_names"]
+            referenced |= state["referenced"]
+
+        self.assertGreater(
+            len(void_names),
+            0,
+            "expected record_event/wait_event to lower to NoneLayout ops",
+        )
+        self.assertTrue(
+            void_names & referenced,
+            lambda msg: f"{msg}\n"
+            + (
+                "no record_event void op appears as an additional_buffer_dep; "
+                f"void_names={void_names}, referenced={referenced}"
+            ),
+        )
+
+    @skipIf(not HAS_TRITON, "requires triton", device_type=("cuda", "xpu"))
+    def test_control_deps_passthrough_creates_ordering_barrier(self, device):
         """Pass-through values in control_deps create OrderingBarrier nodes.
 
         Verifies that OrderingBarrier:
@@ -599,7 +599,7 @@ class TestControlDeps(InductorTestCase):
             return nodes
 
         def fn(x):
-            s = torch.Stream(device=GPU_TYPE)
+            s = torch.Stream(device=device)
             e = torch.Event()
             with s:
                 y = x + 1
@@ -609,10 +609,10 @@ class TestControlDeps(InductorTestCase):
 
         torch._dynamo.reset()
         with config.patch(_pre_fusion_custom_pass=capture):
-            x = torch.ones(4, device=GPU_TYPE)
+            x = torch.ones(4, device=device)
             result = torch.compile(fn)(x)
 
-        expected = fn(torch.ones(4, device=GPU_TYPE))
+        expected = fn(torch.ones(4, device=device))
         torch.testing.assert_close(result, expected)
 
         self.assertTrue(captured, "expected at least one Inductor compile")
@@ -629,8 +629,8 @@ class TestControlDeps(InductorTestCase):
                     f"barrier source {source_name} should not be in mutated_buffers",
                 )
 
-    @requires_gpu()
-    def test_ordering_barrier_is_nop(self):
+    @skipIf(not HAS_TRITON, "requires triton", device_type=("cuda", "xpu"))
+    def test_ordering_barrier_is_nop(self, device):
         """OrderingBarrier must not allocate or generate code.
 
         Verifies should_allocate() and is_no_op() on the actual IR node.
@@ -653,7 +653,7 @@ class TestControlDeps(InductorTestCase):
             return nodes
 
         def fn(x):
-            s = torch.Stream(device=GPU_TYPE)
+            s = torch.Stream(device=device)
             e = torch.Event()
             with s:
                 y = x + 1
@@ -663,10 +663,10 @@ class TestControlDeps(InductorTestCase):
 
         torch._dynamo.reset()
         with config.patch(_pre_fusion_custom_pass=capture):
-            x = torch.ones(4, device=GPU_TYPE)
+            x = torch.ones(4, device=device)
             result = torch.compile(fn)(x)
 
-        expected = fn(torch.ones(4, device=GPU_TYPE))
+        expected = fn(torch.ones(4, device=device))
         torch.testing.assert_close(result, expected)
 
         self.assertTrue(captured, "expected at least one compile")
@@ -685,8 +685,8 @@ class TestControlDeps(InductorTestCase):
                 "OrderingBarrier is_no_op() must be True",
             )
 
-    @requires_cuda_triton
-    def test_bidirectional_stream_sync_correctness(self):
+    @skipIf(not HAS_TRITON, "requires triton", device_type="cuda")
+    def test_bidirectional_stream_sync_correctness(self, device):
         """Regression: passthrough OrderingBarrier must be ordered after all subgraph ops.
 
         Bidirectional stream sync exposes a bug where additional_buffer_deps was
@@ -698,32 +698,32 @@ class TestControlDeps(InductorTestCase):
         from torch._inductor.utils import run_and_get_code
 
         def fn(x):
-            s1 = torch.cuda.Stream()
-            s2 = torch.cuda.Stream()
-            event_s1 = torch.cuda.Event()
-            event_s2 = torch.cuda.Event()
-            with torch.cuda.stream(s1):
+            s1 = torch.Stream(device=device)
+            s2 = torch.Stream(device=device)
+            event_s1 = torch.Event(device=device)
+            event_s2 = torch.Event(device=device)
+            with s1:
                 a = x * 2
                 event_s1.record(s1)
-            with torch.cuda.stream(s2):
+            with s2:
                 event_s1.wait(s2)
                 b = a + 1
                 event_s2.record(s2)
-            with torch.cuda.stream(s1):
+            with s1:
                 event_s2.wait(s1)
                 c = b * 2
             s1.synchronize()
             s2.synchronize()
             return c
 
-        x = torch.randn(1024, device="cuda")
+        x = torch.randn(1024, device=device)
         expected = fn(x)
         result, _ = run_and_get_code(torch.compile(fn), x)
         self.assertEqual(result, expected)
 
+    @skipIf(not HAS_TRITON, "requires triton", device_type=("cuda", "xpu"))
     @config.patch(reorder_for_locality=False)
-    @requires_gpu()
-    def test_subgraph_placeholders_need_not_be_contiguous(self):
+    def test_subgraph_placeholders_need_not_be_contiguous(self, device):
         """Placeholders need not be a contiguous prefix of the subgraph.
 
         fx allows a placeholder to appear after other nodes, and lowering a
@@ -784,13 +784,13 @@ class TestControlDeps(InductorTestCase):
             return graph
 
         with torch._inductor.config.patch(post_grad_custom_post_pass=add_control_deps):
-            a = torch.rand([128, 64], device=GPU_TYPE)
-            b = torch.rand([128, 64], device=GPU_TYPE)
+            a = torch.rand([128, 64], device=device)
+            b = torch.rand([128, 64], device=device)
             result = torch.compile(fn)(a, b)
             torch.testing.assert_close(result, fn(a, b))
 
-    @requires_cuda_triton
-    def test_host_to_device_transfer_between_sync_passthroughs(self):
+    @skipIf(not HAS_TRITON, "requires triton", device_type="cuda")
+    def test_host_to_device_transfer_between_sync_passthroughs(self, device):
         """The interleaving above, arrived at without touching the graph.
 
         A CPU tensor and a CUDA tensor are both live across a stream sync, so
@@ -802,22 +802,26 @@ class TestControlDeps(InductorTestCase):
         def fn(x, w):
             meta = torch.tensor(x.shape[-2], dtype=torch.long)
             residual = x.sin()
-            s = torch.cuda.Stream()
-            with torch.cuda.stream(s):
+            s = torch.Stream(device=device)
+            with s:
                 out = x @ w
             s.synchronize()
             extra = meta.to(device=out.device, dtype=out.dtype)
             return torch.cat((out, extra.expand(*out.shape[:-1], 1), residual), dim=-1)
 
-        x = torch.randn(8, 128, device="cuda", dtype=torch.bfloat16)
-        w = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16)
+        x = torch.randn(8, 128, device=device, dtype=torch.bfloat16)
+        w = torch.randn(128, 128, device=device, dtype=torch.bfloat16)
         expected = fn(x, w)
         with torch.no_grad():
             result = torch.compile(fn, mode="reduce-overhead")(x, w)
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
         torch.testing.assert_close(result, expected)
 
 
+instantiate_device_type_tests(
+    TestControlDepsDevice, globals(), allow_xpu=True, allow_mps=True, except_for="cpu"
+)
+
 if __name__ == "__main__":
-    if IS_LINUX and HAS_GPU_AND_TRITON:
+    if IS_LINUX:
         run_tests(needs="filelock")


### PR DESCRIPTION
## Summary
This PR replaces hardcoded CUDA references with device-agnostic equivalents so out-of-tree accelerator backends can run these tests.

## Changes
- Replace `device="cuda"` and `.cuda()` with torch.accelerator APIs.
- Replace hardcoded CUDA references with device-agnostic equivalents.
- Instantiate device-agnostic test templates as device-specific test classes for multiple differrent device backends.
- Add `hw_classification = HardwareClassification.GENERIC|ACCELERATOR` to tests class.
- Split generic tests of class TestControlDeps into class TestControlDepsGeneric.

## Motivation
`torch.cuda` only recognizes CUDA, `device="cuda"` and `.cuda()` are hardcoded CUDA-specific. New accelerators (e.g., `PrivateUse1`-based out-of-tree backends) are silently skipped even when enough devices are available. A generic decorator lets inductor tests adapt to any accelerator supported by `torch.accelerator`.

## Test Plan
- CI: `python test/inductor/test_control_deps.py --hw-classification GENERIC ACCELERATOR`
- Verified test cases correctly on CPU, GPU, and XPU.

## Notes
- This is part of the test case refactoring initiative tracked in #185590.
- Make CUDA/XPU device-generic in #189138.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo