### PR TITLE
[sdpa] Avoid key/value replication in math backend GQA

### DIFF
--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -904,9 +904,49 @@ std::tuple<Tensor, Tensor> _scaled_dot_product_attention_math(
     }
 
 
-    // MQA/GQA handling
-    auto [key_expanded, value_expanded] = pre_process_group_query_attention_input(query, key_acc, value_acc, enable_gqa);
-    auto attn = at::matmul(query, key_expanded.transpose(-2, -1) * scaling_factor);
+    // MQA/GQA handling. When query has more heads than key/value, the math
+    // reference historically materialized repeated key/value with
+    // repeat_interleave. Instead, split the query heads into (kv_heads, group)
+    // and broadcast key/value over the group dimension, so the repeated
+    // key/value tensors are never allocated. Softmax/masking still run on the
+    // [..., q_heads, L, S] shape. Nested inputs keep the repeat path since the
+    // grouped view/broadcast semantics don't apply to them.
+    const bool gqa_broadcast = enable_gqa && !query.is_nested() &&
+        !key_acc.is_nested() && !value_acc.is_nested() &&
+        (query.sym_size(-3) != key_acc.sym_size(-3) ||
+         query.sym_size(-3) != value_acc.sym_size(-3));
+
+    // Broadcast a's query heads against v's kv heads: reshape a to
+    // (..., kv_heads, group, *, *) and unsqueeze v to (..., kv_heads, 1, *, *).
+    auto grouped_matmul = [](const at::Tensor& a, const at::Tensor& v) {
+      const auto a_heads = a.sym_size(-3);
+      const auto v_heads = v.sym_size(-3);
+      return at::matmul(
+                 a.unflatten_symint(-3, {v_heads, a_heads / v_heads}),
+                 v.unsqueeze(-3))
+          .flatten(-4, -3);
+    };
+
+    at::Tensor attn;
+    at::Tensor key_expanded, value_expanded;
+    if (gqa_broadcast) {
+      const auto q_num_heads = query.sym_size(-3);
+      const auto k_num_heads = key_acc.sym_size(-3);
+      const auto v_num_heads = value_acc.sym_size(-3);
+      TORCH_CHECK(
+          q_num_heads % k_num_heads == 0 && q_num_heads % v_num_heads == 0,
+          "Number of heads in key and value must divide the number of heads in query");
+      auto scaled_key_t =
+          (key_acc.transpose(-2, -1) * scaling_factor).unsqueeze(-3);
+      auto query_grouped =
+          query.unflatten_symint(-3, {k_num_heads, q_num_heads / k_num_heads});
+      attn = at::matmul(query_grouped, scaled_key_t).flatten(-4, -3);
+    } else {
+      std::tie(key_expanded, value_expanded) =
+          pre_process_group_query_attention_input(
+              query, key_acc, value_acc, enable_gqa);
+      attn = at::matmul(query, key_expanded.transpose(-2, -1) * scaling_factor);
+    }
     if (attn_mask.has_value()) {
       if (at::areAnyTensorSubclassLike({attn, *attn_mask})) {
         attn = attn.add(*attn_mask);
@@ -922,13 +962,18 @@ std::tuple<Tensor, Tensor> _scaled_dot_product_attention_math(
         TORCH_WARN_ONCE("Dropout mask should only be used for testing purposes.");
         attn = attn.masked_fill(dropout_mask->logical_not(), 0.0);
         auto dropout_scaling = 1.0 / (1 - dropout_p);
-        return std::make_tuple(at::matmul(attn, value_expanded * dropout_scaling).to(origin_dtype), attn.to(origin_dtype));
+        auto out = gqa_broadcast
+            ? grouped_matmul(attn, value_acc * dropout_scaling)
+            : at::matmul(attn, value_expanded * dropout_scaling);
+        return std::make_tuple(out.to(origin_dtype), attn.to(origin_dtype));
       } else {
         attn = at::dropout(attn, dropout_p, true);
       }
     }
 
-    return std::make_tuple(at::matmul(attn, value_expanded).to(origin_dtype), attn.to(origin_dtype));
+    auto out = gqa_broadcast ? grouped_matmul(attn, value_acc)
+                             : at::matmul(attn, value_expanded);
+    return std::make_tuple(out.to(origin_dtype), attn.to(origin_dtype));
 }
 
 std::tuple<at::Tensor, at::Tensor>

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2481,6 +2481,40 @@ class TestSDPA(NNTestCase):
         # Should not crash during export with unbacked symbolic mask batch dim
         torch.export.export(model, args=(x,))
 
+    @parametrize("dtype", [torch.float64, torch.float32, torch.float16, torch.bfloat16])
+    @parametrize("kv_heads", [1, 2])
+    @parametrize("variant", ["plain", "mask", "causal", "dropout_mask"])
+    def test_math_gqa_broadcast_matches_repeat(self, device, dtype, kv_heads, variant):
+        # The math backend computes GQA by broadcasting key/value over grouped
+        # query heads. Check that matches the historical behavior of repeating
+        # key/value with repeat_interleave and running attention with equal heads.
+        torch.manual_seed(0)
+        batch, q_heads, q_len, kv_len, head_dim = 2, 8, 7, 11, 16
+        group = q_heads // kv_heads
+        q = torch.randn(batch, q_heads, q_len, head_dim, dtype=dtype, device=device)
+        k = torch.randn(batch, kv_heads, kv_len, head_dim, dtype=dtype, device=device)
+        v = torch.randn(batch, kv_heads, kv_len, head_dim, dtype=dtype, device=device)
+        k_rep = k.repeat_interleave(group, dim=-3)
+        v_rep = v.repeat_interleave(group, dim=-3)
+
+        attn_mask = None
+        is_causal = False
+        dropout_mask = None
+        dropout_p = 0.0
+        if variant == "mask":
+            attn_mask = torch.randn(batch, q_heads, q_len, kv_len, dtype=dtype, device=device)
+        elif variant == "causal":
+            is_causal = True
+        elif variant == "dropout_mask":
+            dropout_p = 0.3
+            dropout_mask = torch.rand(batch, q_heads, q_len, kv_len, device=device) > dropout_p
+
+        broadcast_out = torch.ops.aten._scaled_dot_product_attention_math(
+            q, k, v, attn_mask, dropout_p, is_causal, dropout_mask, enable_gqa=True)[0]
+        repeat_out = torch.ops.aten._scaled_dot_product_attention_math(
+            q, k_rep, v_rep, attn_mask, dropout_p, is_causal, dropout_mask, enable_gqa=False)[0]
+        self.assertEqual(broadcast_out, repeat_out)
+
 class TestSDPACpuOnly(NNTestCase):
     """ Used to test CPU only functionality of scaled_dot_product_attention """
 

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2485,6 +2485,8 @@ class TestSDPA(NNTestCase):
     @parametrize("kv_heads", [1, 2])
     @parametrize("variant", ["plain", "mask", "causal", "dropout_mask"])
     def test_math_gqa_broadcast_matches_repeat(self, device, dtype, kv_heads, variant):
+        if dtype == torch.float64 and torch.device(device).type == "mps":
+            self.skipTest("float64 is not supported on MPS")
         # The math backend computes GQA by broadcasting key/value over grouped
         # query heads. Check that matches the historical behavior of repeating
         # key/value with repeat_interleave and running attention with equal heads.


### PR DESCRIPTION
## Summary

`scaled_dot_product_attention`'s math backend supports grouped-query attention
(GQA / MQA), where the key and value have fewer heads than the query. It handled
this by repeating the key and value up to the query's head count with
`repeat_interleave` before the matmuls:

```cpp
key_repeated   = key.repeat_interleave_symint(q_heads / k_heads, -3);
value_repeated = value.repeat_interleave_symint(q_heads / v_heads, -3);
```

That physically allocates and copies the larger key/value. For a Llama-3-8B
shaped call (query heads 32, kv heads 8, kv length 4096) it is about 134 MB of
extra fp32 allocation and copy on every call.

This PR keeps the key/value at their original head count and instead splits the
query heads into `(kv_heads, group)` and broadcasts the key/value over the group
dimension inside the two matmuls. The repeated tensors are never allocated.
Softmax, masking, dropout and the causal path still operate on the
`[..., q_heads, L, S]` attention tensor, so that logic is untouched. Nested
tensors keep the old `repeat_interleave` path, since the grouped view/broadcast
does not apply to them.

The result is identical to the old path -- it is the same math, just batched
differently rather than materialized.

## Benchmark

CPU, fp32, query heads 32 / kv heads 8 / q len 512 / kv len 4096 / head dim 128:

| path | time/call | extra alloc/call |
|---|---:|---:|
| repeat_interleave (old) | 6267 ms | 134 MB |
| broadcast (this PR) | 2234 ms | 0 |

2.81x faster on this shape, and the 134 MB key/value replication is gone.

## Test Plan

```
python test/test_transformers.py -k test_math_gqa_broadcast_matches_repeat
python test/test_transformers.py -k test_scaled_dot_product_fused_attention_gqa_vs_math_cpu
```

The new device-generic test compares the broadcast path (`enable_gqa=True`)
against explicitly `repeat_interleave`-d key/value (`enable_gqa=False`) across
fp64/fp32/fp16/bf16, kv heads in {1, 2}, and the plain / attn_mask / causal /
dropout_mask variants.

`lintrunner` is clean on the changed files.

This change was authored with the help of an AI assistant. I have read the diff
and can explain every line.
