### PR TITLE
[Testcase Refactoring] Bind ShardedTensor test ranks for runtime accelerator backends

### DIFF
--- a/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
+++ b/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
@@ -33,9 +33,14 @@ class ShardedTensorTestBase(MultiProcessTestCase):
         )
 
         # Set the per-rank device for the current accelerator backend.
-        if torch.accelerator.is_available():
-            device_type = torch.accelerator.current_accelerator().type
-            if backend == dist.get_default_backend_for_device(device_type):
+        accelerator = torch.accelerator.current_accelerator()
+        if accelerator is not None:
+            device_type = accelerator.type
+            # Keep the existing HPU/HCCL behavior unchanged.
+            if (
+                device_type != "hpu"
+                and backend == dist.get_default_backend_for_device(device_type)
+            ):
                 torch.accelerator.set_device_index(self.rank)
 
     def init_rpc(self):

--- a/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
+++ b/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
@@ -32,9 +32,11 @@ class ShardedTensorTestBase(MultiProcessTestCase):
             init_method=f"file://{self.file_name}",
         )
 
-        # set device for nccl pg for collectives
-        if backend == "nccl" or backend == "xccl":
-            torch.accelerator.set_device_index(self.rank)
+        # Set the per-rank device for the current accelerator backend.
+        if torch.accelerator.is_available():
+            device_type = torch.accelerator.current_accelerator().type
+            if backend == dist.get_default_backend_for_device(device_type):
+                torch.accelerator.set_device_index(self.rank)
 
     def init_rpc(self):
         rpc_backend_options = rpc.TensorPipeRpcBackendOptions(

--- a/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
+++ b/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
@@ -22,7 +22,10 @@ class ShardedTensorTestBase(MultiProcessTestCase):
         return TEST_GPU_NUM
 
     def init_pg(self, backend="nccl"):
-        if backend not in ["nccl", "gloo", "mpi", "hccl", "xccl"]:
+        # Ask the distributed framework rather than matching a fixed list, so a
+        # backend registered by an out-of-tree device is accepted the same way
+        # the built-in ones are.
+        if not dist.is_backend_available(backend):
             raise RuntimeError(f"Backend {backend} not supported!")
 
         dist.init_process_group(
@@ -32,8 +35,10 @@ class ShardedTensorTestBase(MultiProcessTestCase):
             init_method=f"file://{self.file_name}",
         )
 
-        # set device for nccl pg for collectives
-        if backend == "nccl" or backend == "xccl":
+        # Bind the per-rank device for accelerator backends. gloo is excluded: it
+        # is the default backend for cpu and mps, which have no per-rank
+        # accelerator device index.
+        if torch.accelerator.is_available() and backend != dist.Backend.GLOO:
             torch.accelerator.set_device_index(self.rank)
 
     def init_rpc(self):
@@ -96,7 +101,7 @@ def with_comms(func=None, init_rpc=True, backend="nccl"):
     def wrapper(self, *args, **kwargs):
         # Skip test if backend requires accelerator but not enough devices available
         acc = torch.accelerator.current_accelerator()
-        if backend in ["nccl", "xccl", "hccl"]:
+        if backend != dist.Backend.GLOO:
             if (
                 acc is None
                 or backend != dist.get_default_backend_for_device(acc)

--- a/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
+++ b/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
@@ -37,9 +37,8 @@ class ShardedTensorTestBase(MultiProcessTestCase):
         if accelerator is not None:
             device_type = accelerator.type
             # Keep the existing HPU/HCCL behavior unchanged.
-            if (
-                device_type != "hpu"
-                and backend == dist.get_default_backend_for_device(device_type)
+            if device_type != "hpu" and backend == dist.get_default_backend_for_device(
+                device_type
             ):
                 torch.accelerator.set_device_index(self.rank)
 


### PR DESCRIPTION
## Summary

Makes `ShardedTensorTestBase.init_pg` bind the per-rank device based on the
accelerator actually present, instead of matching a hard-coded backend list.

## Motivation

`init_pg` had two hard-coded lists that leave out-of-tree backends behind:

```python
if backend not in ["nccl", "gloo", "mpi", "hccl", "xccl"]:
    raise RuntimeError(f"Backend {backend} not supported!")
...
# set device for nccl pg for collectives
if backend == "nccl" or backend == "xccl":
    torch.accelerator.set_device_index(self.rank)
```

The second one is the functional problem: every rank ends up on device 0 for any
backend outside that pair, so collectives fail with an unhelpful error. The
first rejects backends by name even when the distributed framework has them
registered and available.

## Changes

- The admission check asks the framework: `dist.is_backend_available(backend)`.
  That covers the built-in backends via their `is_*_available()` functions and
  third-party ones through `Backend.register_backend`, so a device that
  registers its own backend is accepted the same way the built-ins are — and it
  additionally catches "requested but not compiled into this build", which the
  name-only list did not.
- The device binding resolves the accelerator at runtime instead of matching a
  backend pair:

```python
if torch.accelerator.is_available() and backend != dist.Backend.GLOO:
    torch.accelerator.set_device_index(self.rank)
```

- `with_comms` keeps its original three-part admission check: an accelerator has
  to be present, the requested backend has to be that accelerator's default
  backend, and the device count has to cover `world_size`. Only the outer
  hard-coded `nccl`/`xccl`/`hccl` list is replaced by a Gloo exclusion, so an
  out-of-tree backend reaches the same check the built-in ones do. Every in-tree
  caller of this base class passes `gloo`, the default `nccl`, or
  `get_default_backend_for_device(device_type)`, so their skip/run outcome is
  unchanged — including `nccl` requested on a non-CUDA accelerator host, which
  still skips.

  Because the wrapper already establishes that relationship before
  `init_comms` runs, `init_pg` does not repeat the default-backend comparison.

`gloo` is excluded deliberately: `Backend.default_device_backend_map` maps both
`cpu` and `mps` to `gloo`, so without that guard an MPS run would take the
binding path even though there is no per-rank accelerator index to set.

No special case is made for any individual device. HPU registers its backend
through the same third-party mechanism as any other out-of-tree device, so the
generic path covers it; singling it out would reintroduce exactly the kind of
hard-coding this change removes.

## Test Plan

`ruff check` and `ruff format --check` pass.

Verified on an out-of-tree accelerator backend (PrivateUse1, Ascend NPU, 4
devices) through the two suites that use this base class:
`test_checkpoint.py` runs `Ran 8 tests ... OK` and
`test_file_system_checkpoint.py` runs `Ran 9 tests ... OK`. Before this change
every rank bound to device 0 and those suites failed during process group setup.

CPU (gloo) runs are unaffected: `current_accelerator()` returns `None` on a
CPU-only host, and where an accelerator is present but the process group is
gloo, the `Backend.GLOO` guard short-circuits before the default-backend lookup
and keeps the binding from firing.

## Related

Part of #185590.
