### PR TITLE
[Inductor] Replace empty-output ops with empty_strided

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -810,6 +810,19 @@ class TestPatternMatcher(TestCase):
         joint_graph.joint_graph_passes(gm)
         self.assertEqual(count_calls(gm.graph), 0)
 
+    def test_replace_empty_tensor_ops(self):
+        def f(x, y):
+            return torch.add(x, y)
+
+        x = torch.randn(3, 0, dtype=torch.complex64)
+        y = torch.randn(3, 0, dtype=torch.complex64)
+        gm = make_fx(f)(x, y)
+        joint_graph.joint_graph_passes(gm)
+        targets = [n.target for n in gm.graph.nodes if n.op == "call_function"]
+        self.assertNotIn(aten.add.Tensor, targets)
+        self.assertIn(aten.empty_strided.default, targets)
+        self.assertEqual(gm(x, y), f(x, y))
+
     def test_pointless_view_pair_dynamic_shapes(self):
         def f(x):
             s1, s2 = x.shape

--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -811,6 +811,19 @@ class TestPatternMatcher(TestCase):
         joint_graph.joint_graph_passes(gm)
         self.assertEqual(count_calls(gm.graph), 0)
 
+    def test_replace_empty_tensor_ops(self):
+        def f(x, y):
+            return torch.add(x, y)
+
+        x = torch.randn(3, 0, dtype=torch.complex64)
+        y = torch.randn(3, 0, dtype=torch.complex64)
+        gm = make_fx(f)(x, y)
+        joint_graph.joint_graph_passes(gm)
+        targets = [n.target for n in gm.graph.nodes if n.op == "call_function"]
+        self.assertNotIn(aten.add.Tensor, targets)
+        self.assertIn(aten.empty_strided.default, targets)
+        self.assertEqual(gm(x, y), f(x, y))
+
     def test_pointless_view_pair_dynamic_shapes(self):
         def f(x):
             s1, s2 = x.shape

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -1793,6 +1793,14 @@ class CommonTemplate:
         y = torch.rand((), dtype=torch.complex64, device=self.device)
         self.common(fn, (x, y, 2))
 
+    def test_add_complex11(self):
+        def fn(a, b, alpha):
+            return torch.add(a, b, alpha=alpha)
+
+        x = torch.randn(3, 0, dtype=torch.complex64, device=self.device)
+        y = torch.randn(3, 0, dtype=torch.complex64, device=self.device)
+        self.common(fn, (x, y, 2))
+
     def test_concat_add_inplace(self):
         def fn(x, y, z):
             return torch.cat([x, y], dim=1).add_(z)

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -2060,6 +2060,14 @@ class CommonTemplate:
         y = torch.rand((), dtype=torch.complex64, device=self.device)
         self.common(fn, (x, y, 2))
 
+    def test_add_complex11(self):
+        def fn(a, b, alpha):
+            return torch.add(a, b, alpha=alpha)
+
+        x = torch.randn(3, 0, dtype=torch.complex64, device=self.device)
+        y = torch.randn(3, 0, dtype=torch.complex64, device=self.device)
+        self.common(fn, (x, y, 2))
+
     def test_concat_add_inplace(self):
         def fn(x, y, z):
             return torch.cat([x, y], dim=1).add_(z)

--- a/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
@@ -326,6 +326,7 @@ test_failures = {
     "test_add_complex7_dynamic_shapes": TestFailure(("cpu",), is_skip=True),
     "test_add_complex8_dynamic_shapes": TestFailure(("cpu",), is_skip=True),
     "test_add_complex9_dynamic_shapes": TestFailure(("cpu",), is_skip=True),
+    "test_add_complex11_dynamic_shapes": TestFailure(("cpu",), is_skip=True),
     "test_randn_generator_dynamic_shapes": TestFailure(("cpu",)),
     "test_randn_like_empty_dynamic_shapes": TestFailure(("cpu", "cuda", "xpu")),
     "test_single_elem_dynamic_shapes": TestFailure(("cpu",)),

--- a/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
@@ -352,6 +352,7 @@ test_failures = {
     "test_add_complex7_dynamic_shapes": TestFailure(("cpu",), is_skip=True),
     "test_add_complex8_dynamic_shapes": TestFailure(("cpu",), is_skip=True),
     "test_add_complex9_dynamic_shapes": TestFailure(("cpu",), is_skip=True),
+    "test_add_complex11_dynamic_shapes": TestFailure(("cpu",), is_skip=True),
     "test_randn_generator_dynamic_shapes": TestFailure(("cpu",)),
     "test_randn_like_empty_dynamic_shapes": TestFailure(("cpu", "cuda", "xpu")),
     "test_single_elem_dynamic_shapes": TestFailure(("cpu",)),

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -647,6 +647,8 @@ def add(
     def _requires_fallback(tensor: torch.Tensor) -> bool:
         if tensor.ndim == 0:
             return False
+        if tensor.numel() == 0:
+            return True
         # Viewing complex tensors as their real dtype requires the last stride to be 1.
         return tensor.stride()[-1] != 1
 

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -689,6 +689,8 @@ def add(
     def _requires_fallback(tensor: torch.Tensor) -> bool:
         if tensor.ndim == 0:
             return False
+        if tensor.numel() == 0:
+            return True
         # Viewing complex tensors as their real dtype requires the last stride to be 1.
         return tensor.stride()[-1] != 1
 

--- a/torch/_inductor/fx_passes/joint_graph.py
+++ b/torch/_inductor/fx_passes/joint_graph.py
@@ -498,6 +498,49 @@ def _has_self_referential_shape(
     return False
 
 
+def replace_empty_tensor_ops(gm: torch.fx.GraphModule):
+    """Replace functional ops whose output is statically known to be empty
+    with empty_strided, so their lowerings and fallbacks never run."""
+    graph = gm.graph
+    replaced = False
+    for node in list(graph.nodes):
+        if node.op != "call_function":
+            continue
+        target = node.target
+        if not isinstance(target, torch._ops.OpOverload) or target.namespace != "aten":
+            continue
+        if target in (aten.empty_strided.default, aten.empty.memory_format):
+            continue
+        if torch.Tag.nondeterministic_seeded in target.tags:
+            continue
+        schema = target._schema
+        if schema.is_mutable or any(r.alias_info for r in schema.returns):
+            continue
+        val = node.meta.get("val")
+        if not isinstance(val, torch.Tensor) or val.layout is not torch.strided:
+            continue
+        if val.is_conj() or val.is_neg():
+            continue
+        if not statically_known_true(val.numel() == 0):
+            continue
+        sizes, strides = list(val.size()), list(val.stride())
+        if any(isinstance(x, torch.SymInt) for x in sizes + strides):
+            continue
+        with graph.inserting_after(node):
+            new_node = graph.call_function(
+                aten.empty_strided.default,
+                args=(sizes, strides),
+                kwargs={"dtype": val.dtype, "device": val.device},
+            )
+        new_node.meta.update(node.meta)
+        node.replace_all_uses_with(new_node)
+        graph.erase_node(node)
+        counters["inductor"]["replace_empty_tensor_ops"] += 1
+        replaced = True
+    if replaced:
+        graph.eliminate_dead_code()
+
+
 def constant_fold_uniform_value(gm: torch.fx.GraphModule):
     """Runs constant folding and replaces constants which can be constructed with a single `full` call. Calls into remove_no_ops."""
     with torch.utils._python_dispatch._disable_current_modes():
@@ -725,6 +768,9 @@ def joint_graph_passes(
     GraphTransformObserver(graph, "remove_noop_ops").apply_graph_pass(remove_noop_ops)
 
     if config.joint_graph_constant_folding:
+        GraphTransformObserver(graph, "replace_empty_tensor_ops").apply_gm_pass(
+            replace_empty_tensor_ops
+        )
         GraphTransformObserver(graph, "constant_fold_uniform_value").apply_gm_pass(
             constant_fold_uniform_value
         )

--- a/torch/_inductor/fx_passes/joint_graph.py
+++ b/torch/_inductor/fx_passes/joint_graph.py
@@ -554,6 +554,49 @@ def _has_self_referential_shape(
     return False
 
 
+def replace_empty_tensor_ops(gm: torch.fx.GraphModule):
+    """Replace functional ops whose output is statically known to be empty
+    with empty_strided, so their lowerings and fallbacks never run."""
+    graph = gm.graph
+    replaced = False
+    for node in list(graph.nodes):
+        if node.op != "call_function":
+            continue
+        target = node.target
+        if not isinstance(target, torch._ops.OpOverload) or target.namespace != "aten":
+            continue
+        if target in (aten.empty_strided.default, aten.empty.memory_format):
+            continue
+        if torch.Tag.nondeterministic_seeded in target.tags:
+            continue
+        schema = target._schema
+        if schema.is_mutable or any(r.alias_info for r in schema.returns):
+            continue
+        val = node.meta.get("val")
+        if not isinstance(val, torch.Tensor) or val.layout is not torch.strided:
+            continue
+        if val.is_conj() or val.is_neg():
+            continue
+        if not statically_known_true(val.numel() == 0):
+            continue
+        sizes, strides = list(val.size()), list(val.stride())
+        if any(isinstance(x, torch.SymInt) for x in sizes + strides):
+            continue
+        with graph.inserting_after(node):
+            new_node = graph.call_function(
+                aten.empty_strided.default,
+                args=(sizes, strides),
+                kwargs={"dtype": val.dtype, "device": val.device},
+            )
+        new_node.meta.update(node.meta)
+        node.replace_all_uses_with(new_node)
+        graph.erase_node(node)
+        counters["inductor"]["replace_empty_tensor_ops"] += 1
+        replaced = True
+    if replaced:
+        graph.eliminate_dead_code()
+
+
 def constant_fold_uniform_value(gm: torch.fx.GraphModule):
     """Runs constant folding and replaces constants which can be constructed with a single `full` call. Calls into remove_no_ops."""
     with torch.utils._python_dispatch._disable_current_modes():
@@ -781,6 +824,9 @@ def joint_graph_passes(
     GraphTransformObserver(graph, "remove_noop_ops").apply_graph_pass(remove_noop_ops)
 
     if config.joint_graph_constant_folding:
+        GraphTransformObserver(graph, "replace_empty_tensor_ops").apply_gm_pass(
+            replace_empty_tensor_ops
+        )
         GraphTransformObserver(graph, "constant_fold_uniform_value").apply_gm_pass(
             constant_fold_uniform_value
         )


### PR DESCRIPTION
## Related Issue

Fixes #190274

## Why

- The complex `add` decomposition fails a real-to-complex `view` stride check on zero-element tensors, so compile crashes while eager works
- Ops whose outputs are statically known to be empty never need to run, so this can be handled generically instead of per-op

## How

- Adds a `replace_empty_tensor_ops` joint graph pass that replaces functional ops with statically empty outputs by `empty_strided`
- Keeps the decomposition fallback for empty inputs, since the crash happens during aot capture, before joint graph passes run


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo
