### PR TITLE
Skip `test_pdl_mutation` & `test_pdl_template_and_delay` on CPU

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -18844,6 +18844,7 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         self.assertEqual(eager_result5, compiled_result5)
 
     @requires_cuda_and_triton
+    @skip_if_cpu
     @skipCUDAIf(not SM90OrLater or TEST_WITH_ROCM, "PDL requires NVIDIA sm90+")
     @config.patch({"triton.enable_pdl": True})
     def test_pdl_mutation(self):
@@ -18875,6 +18876,7 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         ).run(code)
 
     @requires_cuda_and_triton
+    @skip_if_cpu
     @skipCUDAIf(not SM90OrLater or TEST_WITH_ROCM, "PDL requires NVIDIA sm90+")
     @config.patch(
         {


### PR DESCRIPTION
test_pdl_mutation and test_pdl_template_and_delay are run on CPU too (but with device tensors) and expect PDL to be used. On e.g. A100 PDL is not supported as indicated by the skip markers. However they only skipped the GPU tests, not the (duplicated) CPU tests.

This might hint to a general issue:
The tests are duplicated for CPU, GPU and possibly others. However some tests do not use `self.device` which means the test executes redundantly wasting time and resources.

One could check if e.g. `requires_cuda_and_triton` can be extended to only test on CUDA devices instead of only checking if CUDA devices are available at all.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo