### PR TITLE
[Inductor] Use Sleef expm1 in CPU vec codegen

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -3348,6 +3348,19 @@ class CPUReproTests(TestCase):
 
     @requires_vectorization
     @patch("torch.cuda.is_available", lambda: False)
+    def test_vec_expm1_small_values(self):
+        def fn(x):
+            return torch.expm1(x)
+
+        x = torch.linspace(-1e-6, 1e-6, 1024)
+        with config.patch({"cpp.simdlen": None}):
+            torch._dynamo.reset()
+            metrics.reset()
+            self.common(fn, (x,), atol=1e-9, rtol=1e-6)
+            check_metrics_vec_kernel_count(1)
+
+    @requires_vectorization
+    @patch("torch.cuda.is_available", lambda: False)
     def test_vec_cpu_only_for_all_available_isa(self):
         def fn(x):
             return torch.sin(torch.cos(torch.erf(x)))

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -1335,9 +1335,7 @@ class CppVecOverrides(CppOverrides):
 
     @staticmethod
     def expm1(x):
-        # decompose for a better performance
-        vec_one = f"decltype({x})(1)"
-        return f"{x}.exp() - {vec_one}"
+        return f"{x}.expm1()"
 
     @staticmethod
     def erf(x):


### PR DESCRIPTION
Fixes #189803

## Why

- The CPU vectorized codegen lowers `expm1(x)` to `exp(x) - 1`, introduced in #92289 to match ATen's then-current implementation
- ATen's vectorized `elu` has since moved to `Vectorized::expm1` (Sleef), so the rewrite loses precision for small `|x|` (catastrophic cancellation) and drifts ~1 ulp from eager
- In `reciprocal(elu(x) + exp(elu(x)))` the denominator crosses zero, amplifying that drift into errors on the order of 100 versus eager

## How

- Emits `Vectorized::expm1` instead of `exp() - 1` in the cpp vec overrides, matching eager bitwise (the issue's repro goes from max diff ~215 to 0)
- Adds a vectorized small-value `expm1` test with tolerances tight enough to catch the cancellation


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo
