### PR TITLE
[inductor][ROCm] Relax tolerance in test_reduction_comprehensive_padding_stride to fix MI200 failure

### DIFF
--- a/test/inductor/test_padding.py
+++ b/test/inductor/test_padding.py
@@ -977,11 +977,8 @@ class PaddingTest(TestCaseBase):
             compiled = torch.compile(program, backend="inductor")(x.clone())
 
         # This reduction sums ~100k fp32 values, so eager and inductor differ
-        # only by floating-point accumulation order. On some backends (e.g. ROCm
-        # MI200) that difference slightly exceeds the default fp32 tolerance, so
-        # use a tolerance appropriate for a large fp32 reduction. The regression
-        # being guarded here is a stride mismatch during compilation, not the
-        # last-ULP numerics.
+        # only by floating-point accumulation order. Relaxed tolerance to account
+        # for potential differences
         self.assertEqual(eager, compiled, atol=1e-3, rtol=1e-4)
 
 

--- a/test/inductor/test_padding.py
+++ b/test/inductor/test_padding.py
@@ -976,7 +976,13 @@ class PaddingTest(TestCaseBase):
         with config.patch({"comprehensive_padding": True}):
             compiled = torch.compile(program, backend="inductor")(x.clone())
 
-        self.assertEqual(eager, compiled)
+        # This reduction sums ~100k fp32 values, so eager and inductor differ
+        # only by floating-point accumulation order. On some backends (e.g. ROCm
+        # MI200) that difference slightly exceeds the default fp32 tolerance, so
+        # use a tolerance appropriate for a large fp32 reduction. The regression
+        # being guarded here is a stride mismatch during compilation, not the
+        # last-ULP numerics.
+        self.assertEqual(eager, compiled, atol=1e-3, rtol=1e-4)
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_padding.py
+++ b/test/inductor/test_padding.py
@@ -977,8 +977,10 @@ class PaddingTest(TestCaseBase):
             compiled = torch.compile(program, backend="inductor")(x.clone())
 
         # This reduction sums ~100k fp32 values, so eager and inductor differ
-        # only by floating-point accumulation order. Relaxed tolerance to account
-        # for potential differences
+        # only by floating-point accumulation order, which slightly exceeds the
+        # default fp32 tolerance on some backends (e.g. ROCm MI200). The
+        # regression guarded here is a stride mismatch during compilation, not
+        # the last-ULP numerics, so a relaxed tolerance is appropriate.
         self.assertEqual(eager, compiled, atol=1e-3, rtol=1e-4)
 
 


### PR DESCRIPTION
`test/inductor/test_padding.py::PaddingTest::test_reduction_comprehensive_padding_stride` (added in #180197) fails consistently on ROCm MI200 (gfx90a):
```
AssertionError: Tensor-likes are not close!
Mismatched elements: 1 / 4 (25.0%)
Greatest absolute difference: 0.00011444091796875 at index (3,) (up to 1e-05 allowed)
Greatest relative difference: 1.9748501927097095e-06 at index (3,) (up to 1.3e-06 allowed)
```

The test sums ~100k fp32 values (adaptive_avg_pool2d(x, 7).flatten(1).sum(dim=-1) on a (4, 2049, 8, 8) input) and compares the eager and Inductor outputs with assertEqual's strict default fp32 tolerance (rtol=1.3e-6). Eager and Inductor accumulate the reduction in different orders, so their results differ at the last ULP — slightly above the default bound on MI200. It fails deterministically because the harness uses a fixed RNG seed.It's MI200-only because accumulation order (and thus the eager-vs-compiled gap) is backend-specific, and only MI200 lands over the threshold for this fixed seed. This PR relaxes the comparison to atol=1e-3, rtol=1e-4, appropriate for a large fp32 reduction.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben