### PR TITLE
[c10d] Make the sentinal value consistent across new_group, split_group

### DIFF
--- a/test/distributed/test_c10d_common.py
+++ b/test/distributed/test_c10d_common.py
@@ -1574,8 +1574,9 @@ class AbstractLargeCommTest:
         self.assertIn(rank, ranks_in)
         self.assertNotIn(rank, ranks_out)
 
-        self.assertIsNone(
-            dist.new_group(ranks=ranks_out, use_local_synchronization=True)
+        self.assertEqual(
+            dist.new_group(ranks=ranks_out, use_local_synchronization=True),
+            dist.distributed_c10d.GroupMember.NON_GROUP_MEMBER,
         )
 
         new_pg = dist.new_group(ranks=ranks_in, use_local_synchronization=True)

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -1226,6 +1226,29 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
 
     @requires_nccl_version((2, 18), "Need NCCL 2.18+ for ncclCommSplit")
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
+    def test_comm_split_group_non_member_returns_sentinel(self):
+        # A rank left out of every split must get back GroupMember.NON_GROUP_MEMBER,
+        # the same sentinel new_group returns for non-members -- NOT None. Returning
+        # None would be unsafe: downstream collectives treat group=None as the
+        # default/WORLD group, so a non-member passing it in would silently run a
+        # WORLD collective instead of a no-op.
+        store = c10d.FileStore(self.file_name, self.world_size)
+        device = torch.device(f"cuda:{self.rank}")
+        pg = self._create_process_group_nccl(store, self.opts(), device_id=device)
+
+        # Single split containing only rank 0; every other rank is a non-member.
+        ng = c10d.split_group(pg, [[0]])
+        if self.rank == 0:
+            self.assertIsInstance(ng, dist.ProcessGroup)
+            self.assertEqual(dist.get_process_group_ranks(ng), [0])
+        else:
+            self.assertEqual(ng, c10d.GroupMember.NON_GROUP_MEMBER)
+            self.assertIsNotNone(ng)
+
+        dist.destroy_process_group()
+
+    @requires_nccl_version((2, 18), "Need NCCL 2.18+ for ncclCommSplit")
+    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     def test_comm_split_group_mixed_backend(self):
         # Test `ncclCommSplit` for smaller subgroups of the world when
         # we've passed a specific device_id to init_process_group.
@@ -7418,7 +7441,8 @@ class ProcessGroupNCCLLargerScaleTest(MultiProcessTestCase):
             dist.broadcast(tensor2, 7, group=ng2)
             self.assertEqual(tensor2, torch.full((1,), 7))
         else:
-            self.assertEqual(ng2, None)
+            # Non-members get the same sentinel as new_group, not None.
+            self.assertEqual(ng2, c10d.GroupMember.NON_GROUP_MEMBER)
         # a barrier and a cuda sync before destroying all pgs.
         dist.barrier(pg)
         torch.cuda.synchronize()

--- a/test/distributed/test_fake_pg.py
+++ b/test/distributed/test_fake_pg.py
@@ -787,9 +787,10 @@ class TestFakePG(TestCase):
             device_id=torch.device(device_type, 0),
         )
 
-        # Rank 0 is in none of the splits, so it gets None back.
+        # Rank 0 is in none of the splits, so it gets the non-member sentinel
+        # back (the same one new_group returns), not None.
         new_pg = dist.split_group(split_ranks=[[1, 2, 3]])
-        self.assertIsNone(new_pg)
+        self.assertEqual(new_pg, dist.distributed_c10d.GroupMember.NON_GROUP_MEMBER)
 
     @skipIfHpu
     @unittest.skipIf(not HAS_ACCELERATOR, "No accelerator")

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -45,6 +45,7 @@ else:
     from torch.distributed import config as dist_config
     from torch.distributed.distributed_c10d import (
         _get_default_group,
+        _rank_not_in_group,
         _register_process_group_opaque_type,
         _resolve_process_group,
         get_backend,
@@ -569,7 +570,7 @@ else:
                     split_ranks=pg_ranks_by_dim.tolist(),
                     group_desc=group_desc,
                 )
-                if dim_group is None:
+                if _rank_not_in_group(dim_group):
                     return None
                 return dim_group.group_name
 

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -6096,7 +6096,7 @@ def split_group(
     pg_options: Any | None = None,
     group_desc: str | None = None,
     backend: str | Backend | None = None,
-) -> ProcessGroup | None:
+) -> ProcessGroup:
     """
     Create a new process group split from the given parent process group.
 
@@ -6136,7 +6136,9 @@ def split_group(
 
     Returns:
         ProcessGroup if the current rank is within one split/subgroup given by split_ranks,
-        or None if the current rank is not part of any split_ranks`.
+        or ``GroupMember.NON_GROUP_MEMBER`` if the current rank is not part of any
+        ``split_ranks``. Note this matches the sentinel returned by :func:`new_group` for
+        non-members; it is not ``None`` (which downstream APIs treat as the default group).
 
     """
     # check inputs
@@ -6279,7 +6281,9 @@ def split_group(
         device_types=device_types_filter,
     )
     if split_pg is None:
-        return None
+        # Non-member: return the same sentinel as new_group (not None, which
+        # downstream collectives would treat as the default group).
+        return GroupMember.NON_GROUP_MEMBER  # pyrefly: ignore[bad-return]
 
     global_ranks_in_my_group = [parent_group_to_global_ranks[rank] for rank in my_group]
     split_pg.bound_device_id = device_id  # type: ignore[union-attr]
@@ -6604,7 +6608,7 @@ def _new_group_with_tag(
                 "MPI backend doesn't support use_local_synchronization=True"
             )
         if ranks is not None and get_rank() not in ranks:
-            return None
+            return GroupMember.NON_GROUP_MEMBER
 
     # checks the input ranks
     if ranks is not None:


### PR DESCRIPTION
## Summary

The distributed subgroup-creation APIs returned **two different values** to a rank
that is *not* a member of the group being created:

| Call | Non-member return (before) |
|------|----------------------------|
| `new_group(..., use_local_synchronization=False)` (default) | `GroupMember.NON_GROUP_MEMBER` (`-100`) |
| `new_group(..., use_local_synchronization=True)` | `None` |
| `split_group(...)` | `None` |

This PR makes all three consistently return `GroupMember.NON_GROUP_MEMBER`, which is
both the original, documented contract of `new_group` and the *safe* value (see
"Why not `None`" below).

This was surfaced by a user report of the exact inconsistency above; the expectation
was that the three paths agree. 

## Background: the divergent behavior

A rank that calls one of these APIs but is not part of the requested `ranks` /
`split_ranks` is a "non-member". All ranks in the parent group are still required to
call in (the collective contract), so every non-member gets *some* return value back.

Historically that value was `GroupMember.NON_GROUP_MEMBER` — a dedicated sentinel that
the collective wrappers recognize via `_rank_not_in_group()` and turn into a safe
warn-and-no-op. Two newer code paths instead returned `None`, producing the
inconsistency above.

## What led to the divergence (history)

The divergence is not one decision but three independent code paths that never shared
the same non-member return logic:

- **#11405** (original c10d release for PT1) introduced `GroupMember.NON_GROUP_MEMBER`
  as the non-member sentinel for `new_group`. It was deliberately a *distinct* value
  (originally `object()`), because `None` was already reserved across the c10d API to
  mean "the default / WORLD group".
- **#106886** ("Dynamo x FSDP") changed the sentinel's value from `object()` to the
  integer `-100` so it is graph-traceable and picklable. Behavior unchanged — still a
  dedicated sentinel, still not `None`.
- **#99931** ("Scalable PG initiation") added `use_local_synchronization=True`. Because
  its whole purpose is that non-members do *not* join the group barrier, it returns them
  out early — before any process group is constructed — via a new branch that never
  reaches the shared helper (`_new_process_group_helper`) that emits the sentinel. That
  branch returned `None`. This is the first divergence. (Note: at that time the sentinel
  was still an opaque `object()`, which likely made `None` look like the cleaner "nothing
  to return" value from a fast-path early return.)
- **#130507** introduced `split_group` as a brand-new standalone API (not a refactor of
  `new_group`). It returned `None` for non-members from its first commit — even though its
  own docstring described the outcome as "return a non-group member". It inherited the
  `None` convention rather than the older sentinel one.
- **#158488** ("Cleanup split_group logic") reworked `split_group` on top of the new C++
  `splitGroup`, but preserved the `return None`.

Each newer path also shipped with its own test asserting *its own* `None` return, so CI
locked the inconsistency in rather than flagging it.

## What we are changing

Converge the two newer paths back onto the original sentinel.

- `torch/distributed/distributed_c10d.py`
  - `_new_group_with_tag` (the `use_local_synchronization=True` early return): `return None`
    -> `return GroupMember.NON_GROUP_MEMBER`.
  - `split_group`: the non-member return `return None` -> `return GroupMember.NON_GROUP_MEMBER`.
    Its return annotation is narrowed to `ProcessGroup` (the sentinel is documented as the
    non-member exception, matching how the sibling `new_group` helpers are typed), and the
    docstring's "Returns" section is updated.
- `torch/distributed/device_mesh.py`
  - The one internal caller that checked `split_group(...) is None` now uses
    `_rank_not_in_group(dim_group)` so it recognizes the sentinel.
- Tests updated to assert the sentinel instead of `None`, plus one new test:
  - `test/distributed/test_c10d_common.py` — `_test_new_group_local_sync` (local-sync non-member).
  - `test/distributed/test_fake_pg.py` — `test_split_group_non_member` (fake backend; no real
    multi-GPU needed; directly exercises the changed `split_group` line).
  - `test/distributed/test_c10d_nccl.py` — `test_comm_split_group_larger_scale` (real NCCL, 8 GPUs).
  - `test/distributed/test_c10d_nccl.py` — **new** `test_comm_split_group_non_member_returns_sentinel`
    (real NCCL, 2 GPUs — the most common multi-GPU CI config).

## Why `NON_GROUP_MEMBER` and not `None`

The reporter expected `None` everywhere. We are converging on the sentinel instead,
because `None` is the *unsafe* choice: in c10d, `None` is universally overloaded to mean
"the default / WORLD process group". Every collective resolves its `group` argument like
this:

```python
if _rank_not_in_group(group):        # None -> False, NON_GROUP_MEMBER -> True
    _warn_not_in_group(op)
    return                           # safe no-op for a non-member
...
if group is None:
    group = _get_default_group()     # None silently becomes WORLD
```

and:

```python
def _rank_not_in_group(group):
    if group is None:
        return False                 # "None means you ARE in (the default) group"
    return group == GroupMember.NON_GROUP_MEMBER
```

Consequence:

- If a non-member gets `NON_GROUP_MEMBER` back and passes it to a collective, it is a safe
  warn-and-no-op.
- If a non-member gets `None` back and passes it to a collective, the call **silently runs
  on the entire WORLD group** — a hang/deadlock, because the actual members are meanwhile
  collectiving on the subgroup, not on WORLD.

So returning `None` (especially from the widely used default `new_group` path, had we
converged that way instead) would newly expose that footgun. `NON_GROUP_MEMBER` is the
value the rest of the stack already understands, and it matches `new_group`'s
long-documented contract.

Callers that previously checked `if g is None:` for a non-member should switch to
`if g == dist.GroupMember.NON_GROUP_MEMBER:` (or, preferably,
`dist.distributed_c10d._rank_not_in_group(g)`).

## Backward compatibility

- `new_group(use_local_synchronization=False)` — **unchanged** (already returned the sentinel;
  this is the hottest path).
- `new_group(use_local_synchronization=True)` and `split_group(...)` — non-members now receive
  `GroupMember.NON_GROUP_MEMBER` (`-100`) instead of `None`. Code that guarded with `is None`
  must be updated as noted above. Code that already passed the return value straight into a
  collective becomes *safer* (a no-op instead of an accidental WORLD collective).

## Test plan

Run the affected/added tests:

```bash
pytest test/distributed/test_fake_pg.py test/distributed/test_c10d_nccl.py test/distributed/test_c10d_gloo.py \
  -vvs -k "non_member or test_comm_split_group_larger_scale or test_new_group_local_sync"
```

Coverage of the non-member sentinel after this change:

- `split_group`: fake backend (accessible), real NCCL @2 GPUs (new), real NCCL @8 GPUs.
- `new_group(use_local_synchronization=True)`: gloo (CPU) and NCCL, world_size 4.

---

This PR was authored with the assistance of an AI coding assistant.
