### PR TITLE
[Testcase Refactoring][Test] Use default device backend in TestNoCPU instead of hardcoding …

### DIFF
--- a/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
+++ b/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
@@ -266,7 +266,9 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
         dist_model, dist_optim = self._create_model(device, compile, model_type)
         _, original_train_state = _train(dist_model, dist_optim, train_steps=2)
 
-        original_stateful_obj = TestStatefulObj(torch.rand(10, 10, device=self.device_type))  # tests arbitrary saving/loading
+        original_stateful_obj = TestStatefulObj(
+            torch.rand(10, 10, device=self.device_type)
+        )  # tests arbitrary saving/loading
         sd = {
             "model": dist_model,
             "optimizer": dist_optim,
@@ -294,9 +296,7 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
                 sd,
                 storage_writer=writer,
                 async_checkpointer_type=(
-                    async_checkpointer_type
-                    if async_checkpointer_type
-                    else AsyncCheckpointerType.THREAD
+                    async_checkpointer_type or AsyncCheckpointerType.THREAD
                 ),
                 async_stager=stager,
             )
@@ -318,7 +318,9 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
         else:
             DCP.save(sd, checkpoint_id=self.temp_dir)
 
-        loaded_stateful_obj = TestStatefulObj(torch.rand(10, 10, device=self.device_type))
+        loaded_stateful_obj = TestStatefulObj(
+            torch.rand(10, 10, device=self.device_type)
+        )
         loaded_train_state = TestTrainState()
         dist_model, dist_optim = self._create_model(device, compile, model_type)
 
@@ -345,7 +347,6 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
 
         self._verify_msd(model_sd, dist_msd)
         self._verify_osd_by_load(model, optim, self._optim(model), dist_osd)
-
 
     @skip_if_lt_x_gpu(4)
     @with_comms
@@ -400,12 +401,13 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
         DCP.save(sd, checkpoint_id=self.temp_dir)
         DCP.load(sd, checkpoint_id=self.temp_dir)
 
-
     @skip_if_lt_x_gpu(4)
     @with_comms
     @with_temp_dir
     def test_partial_load(self, device):
-        model, optim = self._create_model(device, compile=False, model_type=ModelType.NONE)
+        model, optim = self._create_model(
+            device, compile=False, model_type=ModelType.NONE
+        )
         _train(model, optim, train_steps=2)
 
         dist_model, dist_optim = self._create_model(
@@ -417,7 +419,9 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
             {"model": dist_model, "optimizer": dist_optim}, checkpoint_id=self.temp_dir
         )
 
-        dist_model, _ = self._create_model(device, compile=False, model_type=ModelType.FSDP)
+        dist_model, _ = self._create_model(
+            device, compile=False, model_type=ModelType.FSDP
+        )
         DCP.load({"model": dist_model}, checkpoint_id=self.temp_dir)
 
         dist_msd = get_model_state_dict(dist_model)
@@ -439,7 +443,6 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
                 self._compare_tensor(
                     loaded_optim_state[k][optim_key], v[optim_key], offload_to_cpu=True
                 )
-
 
 
 class TestNoCPU(DTensorTestBase):
@@ -500,6 +503,7 @@ class TestInitStateDict(DTensorTestBase):
         self.assertEqual(msd, get_model_state_dict(model_2))
         self.assertEqual(osd, get_optimizer_state_dict(model_2, optim_2))
         self.assertEqual(optim_2.param_groups[0]["lr"], 0.1)
+
     @with_temp_dir
     def test_stateful_and_non_stateful_loads(self) -> None:
         class StateDict(dict):
@@ -550,6 +554,8 @@ class TestInitStateDict(DTensorTestBase):
         DCP.save({}, checkpoint_id=self.temp_dir)
         DCP.load({}, checkpoint_id=self.temp_dir)
 
+    @skip_if_lt_x_gpu(4)
+    @with_comms
     @with_temp_dir
     def test_overwrite(self):
         t1, t2 = torch.randn(10), torch.randn(10)
@@ -571,7 +577,6 @@ class TestInitStateDict(DTensorTestBase):
                 {"random": t2},
                 storage_writer=DCP.FileSystemWriter(self.temp_dir, overwrite=False),
             )
-
 
 
 instantiate_device_type_tests(

--- a/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
+++ b/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
@@ -77,8 +77,8 @@ class TestDummyModel(torch.nn.Module):
 
 
 class TestStatefulObj:
-    def __init__(self) -> None:
-        self.data = torch.rand(10, 10)
+    def __init__(self, data) -> None:
+        self.data = data
 
     def state_dict(self):
         return {"data": self.data}
@@ -266,7 +266,7 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
         dist_model, dist_optim = self._create_model(device, compile, model_type)
         _, original_train_state = _train(dist_model, dist_optim, train_steps=2)
 
-        original_stateful_obj = TestStatefulObj()  # tests arbitrary saving/loading
+        original_stateful_obj = TestStatefulObj(torch.rand(10, 10, device=device))  # tests arbitrary saving/loading
         sd = {
             "model": dist_model,
             "optimizer": dist_optim,
@@ -318,7 +318,7 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
         else:
             DCP.save(sd, checkpoint_id=self.temp_dir)
 
-        loaded_stateful_obj = TestStatefulObj()
+        loaded_stateful_obj = TestStatefulObj(torch.rand(10, 10, device=device))
         loaded_train_state = TestTrainState()
         dist_model, dist_optim = self._create_model(device, compile, model_type)
 
@@ -346,48 +346,6 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
         self._verify_msd(model_sd, dist_msd)
         self._verify_osd_by_load(model, optim, self._optim(model), dist_osd)
 
-    @with_temp_dir
-    def test_stateful_and_non_stateful_loads(self, device) -> None:
-        class StateDict(dict):
-            def __init__(self):
-                self.set_sd_item_called = False
-
-            def __setitem__(self, item, value):
-                self.set_sd_item_called = True
-                super().__setitem__(item, value)
-
-        class Foo(Stateful):
-            def __init__(self):
-                self.load_state_dict_called = False
-
-            def state_dict(self):
-                return {}
-
-            def load_state_dict(self, state_dict):
-                self.load_state_dict_called = True
-
-        stateful_foo = Foo()
-        sd = StateDict()
-        sd["foo"] = stateful_foo
-        sd.set_sd_item_called = False
-
-        DCP.save(sd, checkpoint_id=self.temp_dir)
-        DCP.load(sd, checkpoint_id=self.temp_dir)
-
-        # Validate that the stateful object was loaded in-place
-        self.assertTrue(stateful_foo.load_state_dict_called)
-        # Validate that the stateful object was NOT replaced in the state dict
-        self.assertFalse(sd.set_sd_item_called)
-
-        sd = StateDict()
-        sd["foo"] = {"replicated": torch.rand(10, 10), "bytes": [1, 2, 3, 4]}
-        sd.set_sd_item_called = False
-
-        DCP.save(sd, checkpoint_id=self.temp_dir)
-        DCP.load(sd, checkpoint_id=self.temp_dir)
-
-        # Validate that the non-stateful state dict was replaced with the loaded state dict
-        self.assertTrue(sd.set_sd_item_called)
 
     @skip_if_lt_x_gpu(4)
     @with_comms
@@ -398,7 +356,6 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
         """
 
         world_size = self.world_size
-        device_type = torch.device(device).type
 
         class Foo:
             def state_dict(self):
@@ -406,11 +363,11 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
 
             def load_state_dict(self, state_dict):
                 tl = [
-                    torch.ones(2, dtype=torch.int64, device=device_type)
+                    torch.ones(2, dtype=torch.int64, device=device)
                     for _ in range(world_size)
                 ]
                 t = (
-                    torch.arange(2, dtype=torch.int64, device=device_type)
+                    torch.arange(2, dtype=torch.int64, device=device)
                     + 1
                     + 2 * dist.get_rank()
                 )
@@ -422,7 +379,7 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
 
             def load_state_dict(self, state_dict):
                 tensor = (
-                    torch.arange(2, dtype=torch.int64, device=device_type)
+                    torch.arange(2, dtype=torch.int64, device=device)
                     + 1
                     + 2 * dist.get_rank()
                 )
@@ -442,12 +399,6 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
         DCP.save(sd, checkpoint_id=self.temp_dir)
         DCP.load(sd, checkpoint_id=self.temp_dir)
 
-    @with_temp_dir
-    def test_no_dist(self, device):
-        # since comm's are not initialized in this method, `no_dist`
-        # is assumed False
-        DCP.save({}, checkpoint_id=self.temp_dir)
-        DCP.load({}, checkpoint_id=self.temp_dir)
 
     @skip_if_lt_x_gpu(4)
     @with_comms
@@ -488,38 +439,17 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
                     loaded_optim_state[k][optim_key], v[optim_key], offload_to_cpu=True
                 )
 
-    @skip_if_lt_x_gpu(4)
-    @with_comms
-    @with_temp_dir
-    def test_overwrite(self, device):
-        t1, t2 = torch.randn(10), torch.randn(10)
-        DCP.save({"random": t1}, checkpoint_id=self.temp_dir)
-        DCP.save(
-            {"random": t2},
-            storage_writer=DCP.FileSystemWriter(self.temp_dir, overwrite=True),
-        )
-
-        sd = {"random": torch.zeros(10)}
-        DCP.load(sd, checkpoint_id=self.temp_dir)
-
-        self.assertTrue(torch.allclose(sd["random"], t2))
-
-        with self.assertRaisesRegex(
-            CheckpointException, ".*Checkpoint already exists.*"
-        ):
-            DCP.save(
-                {"random": t2},
-                storage_writer=DCP.FileSystemWriter(self.temp_dir, overwrite=False),
-            )
 
 
 class TestNoCPU(DTensorTestBase):
-    hw_classification = HardwareClassification.ACCELERATOR
+    hw_classification = HardwareClassification.GENERIC
+
+    @property
+    def backend(self):
+        return "nccl"
 
     @with_comms
-    def test_no_cpu(self, device):
-        if torch.device(device).type == "cpu":
-            self.skipTest("test_no_cpu requires a non-CPU device")
+    def test_no_cpu(self):
         with self.assertRaisesRegex(
             AssertionError, r"A CPU backend must be enabled for async save;.*?"
         ):
@@ -569,18 +499,83 @@ class TestInitStateDict(DTensorTestBase):
         self.assertEqual(msd, get_model_state_dict(model_2))
         self.assertEqual(osd, get_optimizer_state_dict(model_2, optim_2))
         self.assertEqual(optim_2.param_groups[0]["lr"], 0.1)
+    @with_temp_dir
+    def test_stateful_and_non_stateful_loads(self) -> None:
+        class StateDict(dict):
+            def __init__(self):
+                self.set_sd_item_called = False
+
+            def __setitem__(self, item, value):
+                self.set_sd_item_called = True
+                super().__setitem__(item, value)
+
+        class Foo(Stateful):
+            def __init__(self):
+                self.load_state_dict_called = False
+
+            def state_dict(self):
+                return {}
+
+            def load_state_dict(self, state_dict):
+                self.load_state_dict_called = True
+
+        stateful_foo = Foo()
+        sd = StateDict()
+        sd["foo"] = stateful_foo
+        sd.set_sd_item_called = False
+
+        DCP.save(sd, checkpoint_id=self.temp_dir)
+        DCP.load(sd, checkpoint_id=self.temp_dir)
+
+        # Validate that the stateful object was loaded in-place
+        self.assertTrue(stateful_foo.load_state_dict_called)
+        # Validate that the stateful object was NOT replaced in the state dict
+        self.assertFalse(sd.set_sd_item_called)
+
+        sd = StateDict()
+        sd["foo"] = {"replicated": torch.rand(10, 10), "bytes": [1, 2, 3, 4]}
+        sd.set_sd_item_called = False
+
+        DCP.save(sd, checkpoint_id=self.temp_dir)
+        DCP.load(sd, checkpoint_id=self.temp_dir)
+
+        # Validate that the non-stateful state dict was replaced with the loaded state dict
+        self.assertTrue(sd.set_sd_item_called)
+
+    @with_temp_dir
+    def test_no_dist(self):
+        # since comm's are not initialized in this method, `no_dist`
+        # is assumed False
+        DCP.save({}, checkpoint_id=self.temp_dir)
+        DCP.load({}, checkpoint_id=self.temp_dir)
+
+    @with_temp_dir
+    def test_overwrite(self):
+        t1, t2 = torch.randn(10), torch.randn(10)
+        DCP.save({"random": t1}, checkpoint_id=self.temp_dir)
+        DCP.save(
+            {"random": t2},
+            storage_writer=DCP.FileSystemWriter(self.temp_dir, overwrite=True),
+        )
+
+        sd = {"random": torch.zeros(10)}
+        DCP.load(sd, checkpoint_id=self.temp_dir)
+
+        self.assertTrue(torch.allclose(sd["random"], t2))
+
+        with self.assertRaisesRegex(
+            CheckpointException, ".*Checkpoint already exists.*"
+        ):
+            DCP.save(
+                {"random": t2},
+                storage_writer=DCP.FileSystemWriter(self.temp_dir, overwrite=False),
+            )
 
 
-instantiate_device_type_tests(
-    TestNoCPU,
-    globals(),
-    except_for=("cpu",),
-)
 
 instantiate_device_type_tests(
     TestE2ESaveAndLoad,
     globals(),
-    except_for=("cpu",),
 )
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
+++ b/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
@@ -578,6 +578,7 @@ instantiate_device_type_tests(
     TestE2ESaveAndLoad,
     globals(),
     except_for=("cpu",),
+    allow_xpu=True,
 )
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
+++ b/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
@@ -443,11 +443,11 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
 
 
 class TestNoCPU(DTensorTestBase):
-    hw_classification = HardwareClassification.ACCELERATOR
+    hw_classification = HardwareClassification.GENERIC
 
     @property
     def backend(self):
-        return dist.get_default_backend_for_device(self.device_type)
+        return "nccl"
 
     @with_comms
     def test_no_cpu(self):

--- a/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
+++ b/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
@@ -356,6 +356,7 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
         """
 
         world_size = self.world_size
+        device_type = self.device_type
 
         class Foo:
             def state_dict(self):
@@ -363,11 +364,11 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
 
             def load_state_dict(self, state_dict):
                 tl = [
-                    torch.ones(2, dtype=torch.int64, device=self.device_type)
+                    torch.ones(2, dtype=torch.int64, device=device_type)
                     for _ in range(world_size)
                 ]
                 t = (
-                    torch.arange(2, dtype=torch.int64, device=self.device_type)
+                    torch.arange(2, dtype=torch.int64, device=device_type)
                     + 1
                     + 2 * dist.get_rank()
                 )
@@ -379,7 +380,7 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
 
             def load_state_dict(self, state_dict):
                 tensor = (
-                    torch.arange(2, dtype=torch.int64, device=self.device_type)
+                    torch.arange(2, dtype=torch.int64, device=device_type)
                     + 1
                     + 2 * dist.get_rank()
                 )
@@ -442,11 +443,11 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
 
 
 class TestNoCPU(DTensorTestBase):
-    hw_classification = HardwareClassification.GENERIC
+    hw_classification = HardwareClassification.ACCELERATOR
 
     @property
     def backend(self):
-        return "nccl"
+        return dist.get_default_backend_for_device(self.device_type)
 
     @with_comms
     def test_no_cpu(self):
@@ -576,6 +577,7 @@ class TestInitStateDict(DTensorTestBase):
 instantiate_device_type_tests(
     TestE2ESaveAndLoad,
     globals(),
+    except_for=("cpu",),
 )
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
+++ b/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
@@ -40,8 +40,6 @@ from torch.distributed.tensor.parallel import (
     RowwiseParallel,
 )
 from torch.nn.parallel import DistributedDataParallel
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
-from torch.testing._internal.common_distributed import MultiProcContinuousTest
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     instantiate_parametrized_tests,
@@ -514,33 +512,22 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
             )
 
 
-class TestNoCPU(MultiProcContinuousTest):
+class TestNoCPU(DTensorTestBase):
     hw_classification = HardwareClassification.ACCELERATOR
 
-    @classmethod
-    def backend_str(cls) -> str:
-        return dist.get_default_backend_for_device(cls.device_type)
-
     @property
-    def device(self) -> torch.device:
-        return self._dev
+    def backend(self):
+        return dist.get_default_backend_for_device(self.device_type)
 
-    def test_no_cpu(self, device):
-        self._dev = torch.device(device)
-        if device == "cpu":
+    @with_comms
+    def test_no_cpu(self):
+        if self.device_type == "cpu":
             self.skipTest("test_no_cpu requires a non-CPU device")
         with self.assertRaisesRegex(
             AssertionError, r"A CPU backend must be enabled for async save;.*?"
         ):
             f = saver.async_save({})
             f.result()
-
-
-instantiate_device_type_tests(
-    TestNoCPU,
-    globals(),
-    except_for=("cpu",),
-)
 
 
 class TestInitStateDict(DTensorTestBase):

--- a/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
+++ b/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
@@ -40,14 +40,16 @@ from torch.distributed.tensor.parallel import (
     RowwiseParallel,
 )
 from torch.nn.parallel import DistributedDataParallel
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     HardwareClassification,
-    instantiate_parametrized_tests,
     parametrize,
     run_tests,
 )
 from torch.testing._internal.distributed._tensor.common_dtensor import (
+    DTensorContinuousTestBase,
     DTensorTestBase,
+    NUM_DEVICES,
     skip_if_lt_x_gpu,
     with_comms,
 )
@@ -152,13 +154,12 @@ def _train(model, optim, train_steps=1):
     return loss, train_state
 
 
-class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
+class TestE2ESaveAndLoad(DTensorContinuousTestBase, VerifyStateDictMixin):
     hw_classification = HardwareClassification.ACCELERATOR
 
     @property
-    def backend(self):
-        curr_backend = dist.get_default_backend_for_device(self.device_type)
-        return f"cpu:gloo,{self.device_type}:{curr_backend}"
+    def world_size(self) -> int:
+        return NUM_DEVICES
 
     def _create_model(self, compile, model_type, state_dict_options=None):
         dummy_model = TestDummyModel().to(self.device_type)
@@ -512,22 +513,24 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
             )
 
 
-class TestNoCPU(DTensorTestBase):
+class TestNoCPU(DTensorContinuousTestBase):
     hw_classification = HardwareClassification.ACCELERATOR
 
-    @property
-    def backend(self):
-        return dist.get_default_backend_for_device(self.device_type)
-
-    @with_comms
-    def test_no_cpu(self):
-        if self.device_type == "cpu":
+    def test_no_cpu(self, device):
+        if device == "cpu":
             self.skipTest("test_no_cpu requires a non-CPU device")
         with self.assertRaisesRegex(
             AssertionError, r"A CPU backend must be enabled for async save;.*?"
         ):
             f = saver.async_save({})
             f.result()
+
+
+instantiate_device_type_tests(
+    TestNoCPU,
+    globals(),
+    except_for=("cpu",),
+)
 
 
 class TestInitStateDict(DTensorTestBase):
@@ -574,6 +577,10 @@ class TestInitStateDict(DTensorTestBase):
         self.assertEqual(optim_2.param_groups[0]["lr"], 0.1)
 
 
-instantiate_parametrized_tests(TestE2ESaveAndLoad)
+instantiate_device_type_tests(
+    TestE2ESaveAndLoad,
+    globals(),
+    except_for=("cpu",),
+)
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
+++ b/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
@@ -516,10 +516,6 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
 class TestNoCPU(DTensorTestBase):
     hw_classification = HardwareClassification.ACCELERATOR
 
-    @property
-    def backend(self):
-        return dist.get_default_backend_for_device(self.device_type)
-
     @with_comms
     def test_no_cpu(self, device):
         if torch.device(device).type == "cpu":

--- a/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
+++ b/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
@@ -363,11 +363,11 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
 
             def load_state_dict(self, state_dict):
                 tl = [
-                    torch.ones(2, dtype=torch.int64, device=device)
+                    torch.ones(2, dtype=torch.int64, device=self.device_type)
                     for _ in range(world_size)
                 ]
                 t = (
-                    torch.arange(2, dtype=torch.int64, device=device)
+                    torch.arange(2, dtype=torch.int64, device=self.device_type)
                     + 1
                     + 2 * dist.get_rank()
                 )
@@ -379,7 +379,7 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
 
             def load_state_dict(self, state_dict):
                 tensor = (
-                    torch.arange(2, dtype=torch.int64, device=device)
+                    torch.arange(2, dtype=torch.int64, device=self.device_type)
                     + 1
                     + 2 * dist.get_rank()
                 )

--- a/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
+++ b/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
@@ -41,6 +41,7 @@ from torch.distributed.tensor.parallel import (
 )
 from torch.nn.parallel import DistributedDataParallel
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
@@ -152,6 +153,8 @@ def _train(model, optim, train_steps=1):
 
 
 class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def backend(self):
         curr_backend = dist.get_default_backend_for_device(self.device_type)
@@ -510,12 +513,16 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
 
 
 class TestNoCPU(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def backend(self):
-        return "nccl"
+        return dist.get_default_backend_for_device(self.device_type)
 
     @with_comms
     def test_no_cpu(self):
+        if self.device_type == "cpu":
+            self.skipTest("test_no_cpu requires a non-CPU device")
         with self.assertRaisesRegex(
             AssertionError, r"A CPU backend must be enabled for async save;.*?"
         ):
@@ -524,6 +531,8 @@ class TestNoCPU(DTensorTestBase):
 
 
 class TestInitStateDict(DTensorTestBase):
+    hw_classification = HardwareClassification.GENERIC
+
     @with_temp_dir
     def test_init_state_dict(self):
         temp_dir = self.temp_dir

--- a/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
+++ b/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
@@ -41,13 +41,14 @@ from torch.distributed.tensor.parallel import (
 )
 from torch.nn.parallel import DistributedDataParallel
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
+    skip_but_pass_in_sandcastle_if,
 )
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
-    skip_if_lt_x_gpu,
     with_comms,
 )
 from torch.testing._internal.distributed.checkpoint_utils import with_temp_dir
@@ -152,6 +153,8 @@ def _train(model, optim, train_steps=1):
 
 
 class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def backend(self):
         curr_backend = dist.get_default_backend_for_device(self.device_type)
@@ -212,7 +215,10 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
     def _optim(self, model):
         return torch.optim.Adam(model.parameters(), lr=0.1)
 
-    @skip_if_lt_x_gpu(4)
+    @skip_but_pass_in_sandcastle_if(
+        torch.accelerator.device_count() < 4,
+        "test requires 4+ accelerators",
+    )
     @with_comms
     @with_temp_dir
     @parametrize("compile", [True, False])
@@ -222,7 +228,10 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
     def test_e2e(self, compile, model_type):
         self._run_e2e_test(compile, model_type)
 
-    @skip_if_lt_x_gpu(4)
+    @skip_but_pass_in_sandcastle_if(
+        torch.accelerator.device_count() < 4,
+        "test requires 4+ accelerators",
+    )
     @with_comms
     @with_temp_dir
     @parametrize(
@@ -386,7 +395,10 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
         # Validate that the non-stateful state dict was replaced with the loaded state dict
         self.assertTrue(sd.set_sd_item_called)
 
-    @skip_if_lt_x_gpu(4)
+    @skip_but_pass_in_sandcastle_if(
+        torch.accelerator.device_count() < 4,
+        "test requires 4+ accelerators",
+    )
     @with_comms
     @with_temp_dir
     def test_different_ordered_state_dict_keys(self):
@@ -445,7 +457,10 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
         DCP.save({}, checkpoint_id=self.temp_dir)
         DCP.load({}, checkpoint_id=self.temp_dir)
 
-    @skip_if_lt_x_gpu(4)
+    @skip_but_pass_in_sandcastle_if(
+        torch.accelerator.device_count() < 4,
+        "test requires 4+ accelerators",
+    )
     @with_comms
     @with_temp_dir
     def test_partial_load(self):
@@ -484,7 +499,10 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
                     loaded_optim_state[k][optim_key], v[optim_key], offload_to_cpu=True
                 )
 
-    @skip_if_lt_x_gpu(4)
+    @skip_but_pass_in_sandcastle_if(
+        torch.accelerator.device_count() < 4,
+        "test requires 4+ accelerators",
+    )
     @with_comms
     @with_temp_dir
     def test_overwrite(self):
@@ -510,12 +528,16 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
 
 
 class TestNoCPU(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def backend(self):
-        return "nccl"
+        return dist.get_default_backend_for_device(self.device_type)
 
     @with_comms
     def test_no_cpu(self):
+        if self.device_type == "cpu":
+            self.skipTest("test_no_cpu requires a non-CPU device")
         with self.assertRaisesRegex(
             AssertionError, r"A CPU backend must be enabled for async save;.*?"
         ):
@@ -524,6 +546,8 @@ class TestNoCPU(DTensorTestBase):
 
 
 class TestInitStateDict(DTensorTestBase):
+    hw_classification = HardwareClassification.CPU
+
     @with_temp_dir
     def test_init_state_dict(self):
         temp_dir = self.temp_dir

--- a/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
+++ b/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
@@ -40,6 +40,8 @@ from torch.distributed.tensor.parallel import (
     RowwiseParallel,
 )
 from torch.nn.parallel import DistributedDataParallel
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_distributed import MultiProcContinuousTest
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     instantiate_parametrized_tests,
@@ -512,22 +514,33 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
             )
 
 
-class TestNoCPU(DTensorTestBase):
+class TestNoCPU(MultiProcContinuousTest):
     hw_classification = HardwareClassification.ACCELERATOR
 
-    @property
-    def backend(self):
-        return dist.get_default_backend_for_device(self.device_type)
+    @classmethod
+    def backend_str(cls) -> str:
+        return dist.get_default_backend_for_device(cls.device_type)
 
-    @with_comms
-    def test_no_cpu(self):
-        if self.device_type == "cpu":
+    @property
+    def device(self) -> torch.device:
+        return self._dev
+
+    def test_no_cpu(self, device):
+        self._dev = torch.device(device)
+        if device == "cpu":
             self.skipTest("test_no_cpu requires a non-CPU device")
         with self.assertRaisesRegex(
             AssertionError, r"A CPU backend must be enabled for async save;.*?"
         ):
             f = saver.async_save({})
             f.result()
+
+
+instantiate_device_type_tests(
+    TestNoCPU,
+    globals(),
+    except_for=("cpu",),
+)
 
 
 class TestInitStateDict(DTensorTestBase):

--- a/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
+++ b/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
@@ -266,7 +266,7 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
         dist_model, dist_optim = self._create_model(device, compile, model_type)
         _, original_train_state = _train(dist_model, dist_optim, train_steps=2)
 
-        original_stateful_obj = TestStatefulObj(torch.rand(10, 10, device=device))  # tests arbitrary saving/loading
+        original_stateful_obj = TestStatefulObj(torch.rand(10, 10, device=self.device_type))  # tests arbitrary saving/loading
         sd = {
             "model": dist_model,
             "optimizer": dist_optim,
@@ -318,7 +318,7 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
         else:
             DCP.save(sd, checkpoint_id=self.temp_dir)
 
-        loaded_stateful_obj = TestStatefulObj(torch.rand(10, 10, device=device))
+        loaded_stateful_obj = TestStatefulObj(torch.rand(10, 10, device=self.device_type))
         loaded_train_state = TestTrainState()
         dist_model, dist_optim = self._create_model(device, compile, model_type)
 

--- a/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
+++ b/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
@@ -160,20 +160,21 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
         curr_backend = dist.get_default_backend_for_device(self.device_type)
         return f"cpu:gloo,{self.device_type}:{curr_backend}"
 
-    def _create_model(self, compile, model_type, state_dict_options=None):
-        dummy_model = TestDummyModel().to(self.device_type)
+    def _create_model(self, device, compile, model_type, state_dict_options=None):
+        device_type = torch.device(device).type
+        dummy_model = TestDummyModel().to(device_type)
 
         if model_type not in ModelType:
             raise AssertionError(f"{model_type} is not supported.")
         if model_type == ModelType.FSDP:
-            device_mesh = init_device_mesh(self.device_type, (self.world_size,))
+            device_mesh = init_device_mesh(device_type, (self.world_size,))
             model = FSDP(
                 dummy_model,
                 device_mesh=device_mesh,
                 use_orig_params=True,
             )
         elif model_type == ModelType.HSDP:
-            device_mesh = init_device_mesh(self.device_type, (2, self.world_size // 2))
+            device_mesh = init_device_mesh(device_type, (2, self.world_size // 2))
             model = FSDP(
                 dummy_model,
                 device_mesh=device_mesh,
@@ -182,7 +183,7 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
             )
         elif model_type == ModelType.FSDP_TP:
             mesh_2d = init_device_mesh(
-                self.device_type, (2, self.world_size // 2), mesh_dim_names=("dp", "tp")
+                device_type, (2, self.world_size // 2), mesh_dim_names=("dp", "tp")
             )
             tp_mesh = mesh_2d["tp"]
             dp_mesh = mesh_2d["dp"]
@@ -222,8 +223,8 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
     # TODO: Previously PairwiseParallel does not shard properly, passing ModelType.FSDP_TP test where it
     # should have failed. Disabling the failed test temporarily to unblock the deprecation of PairwiseParallel.
     @parametrize("model_type", [ModelType.FSDP, ModelType.HSDP, ModelType.DDP])
-    def test_e2e(self, compile, model_type):
-        self._run_e2e_test(compile, model_type)
+    def test_e2e(self, device, compile, model_type):
+        self._run_e2e_test(device, compile, model_type)
 
     @skip_if_lt_x_gpu(4)
     @with_comms
@@ -240,9 +241,10 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
         ],
     )
     def test_e2e_async_cached(
-        self, cache_staged_state_dict, async_checkpointer_type, zoc
+        self, device, cache_staged_state_dict, async_checkpointer_type, zoc
     ):
         self._run_e2e_test(
+            device,
             compile=False,
             model_type=ModelType.FSDP,
             async_op=True,
@@ -253,6 +255,7 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
 
     def _run_e2e_test(
         self,
+        device,
         compile,
         model_type,
         async_op=False,
@@ -260,10 +263,10 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
         async_checkpointer_type=None,
         zoc=False,
     ):
-        model, optim = self._create_model(compile, ModelType.NONE)
+        model, optim = self._create_model(device, compile, ModelType.NONE)
         _train(model, optim, train_steps=2)
 
-        dist_model, dist_optim = self._create_model(compile, model_type)
+        dist_model, dist_optim = self._create_model(device, compile, model_type)
         _, original_train_state = _train(dist_model, dist_optim, train_steps=2)
 
         original_stateful_obj = TestStatefulObj()  # tests arbitrary saving/loading
@@ -320,7 +323,7 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
 
         loaded_stateful_obj = TestStatefulObj()
         loaded_train_state = TestTrainState()
-        dist_model, dist_optim = self._create_model(compile, model_type)
+        dist_model, dist_optim = self._create_model(device, compile, model_type)
 
         DCP.load(
             state_dict={
@@ -347,7 +350,7 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
         self._verify_osd_by_load(model, optim, self._optim(model), dist_osd)
 
     @with_temp_dir
-    def test_stateful_and_non_stateful_loads(self) -> None:
+    def test_stateful_and_non_stateful_loads(self, device) -> None:
         class StateDict(dict):
             def __init__(self):
                 self.set_sd_item_called = False
@@ -392,12 +395,13 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
     @skip_if_lt_x_gpu(4)
     @with_comms
     @with_temp_dir
-    def test_different_ordered_state_dict_keys(self):
+    def test_different_ordered_state_dict_keys(self, device):
         """Tests that the order of keys in the state dict does not matter when loading
         If order was not accounted for, the following test would cause a deadlock.
         """
 
         world_size = self.world_size
+        device_type = torch.device(device).type
 
         class Foo:
             def state_dict(self):
@@ -442,7 +446,7 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
         DCP.load(sd, checkpoint_id=self.temp_dir)
 
     @with_temp_dir
-    def test_no_dist(self):
+    def test_no_dist(self, device):
         # since comm's are not initialized in this method, `no_dist`
         # is assumed False
         DCP.save({}, checkpoint_id=self.temp_dir)
@@ -451,12 +455,12 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
     @skip_if_lt_x_gpu(4)
     @with_comms
     @with_temp_dir
-    def test_partial_load(self):
-        model, optim = self._create_model(compile=False, model_type=ModelType.NONE)
+    def test_partial_load(self, device):
+        model, optim = self._create_model(device, compile=False, model_type=ModelType.NONE)
         _train(model, optim, train_steps=2)
 
         dist_model, dist_optim = self._create_model(
-            compile=False, model_type=ModelType.FSDP
+            device, compile=False, model_type=ModelType.FSDP
         )
         _train(dist_model, dist_optim, train_steps=2)
 
@@ -464,7 +468,7 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
             {"model": dist_model, "optimizer": dist_optim}, checkpoint_id=self.temp_dir
         )
 
-        dist_model, _ = self._create_model(compile=False, model_type=ModelType.FSDP)
+        dist_model, _ = self._create_model(device, compile=False, model_type=ModelType.FSDP)
         DCP.load({"model": dist_model}, checkpoint_id=self.temp_dir)
 
         dist_msd = get_model_state_dict(dist_model)
@@ -490,7 +494,7 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
     @skip_if_lt_x_gpu(4)
     @with_comms
     @with_temp_dir
-    def test_overwrite(self):
+    def test_overwrite(self, device):
         t1, t2 = torch.randn(10), torch.randn(10)
         DCP.save({"random": t1}, checkpoint_id=self.temp_dir)
         DCP.save(
@@ -520,21 +524,14 @@ class TestNoCPU(DTensorTestBase):
         return dist.get_default_backend_for_device(self.device_type)
 
     @with_comms
-    def test_no_cpu(self):
-        if self.device_type == "cpu":
+    def test_no_cpu(self, device):
+        if torch.device(device).type == "cpu":
             self.skipTest("test_no_cpu requires a non-CPU device")
         with self.assertRaisesRegex(
             AssertionError, r"A CPU backend must be enabled for async save;.*?"
         ):
             f = saver.async_save({})
             f.result()
-
-
-instantiate_device_type_tests(
-    TestNoCPU,
-    globals(),
-    except_for=("cpu",),
-)
 
 
 class TestInitStateDict(DTensorTestBase):
@@ -580,6 +577,12 @@ class TestInitStateDict(DTensorTestBase):
         self.assertEqual(osd, get_optimizer_state_dict(model_2, optim_2))
         self.assertEqual(optim_2.param_groups[0]["lr"], 0.1)
 
+
+instantiate_device_type_tests(
+    TestNoCPU,
+    globals(),
+    except_for=("cpu",),
+)
 
 instantiate_device_type_tests(
     TestE2ESaveAndLoad,

--- a/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
+++ b/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
@@ -47,7 +47,6 @@ from torch.testing._internal.common_utils import (
     run_tests,
 )
 from torch.testing._internal.distributed._tensor.common_dtensor import (
-    DTensorContinuousTestBase,
     DTensorTestBase,
     skip_if_lt_x_gpu,
     with_comms,
@@ -513,11 +512,16 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
             )
 
 
-class TestNoCPU(DTensorContinuousTestBase):
+class TestNoCPU(DTensorTestBase):
     hw_classification = HardwareClassification.ACCELERATOR
 
-    def test_no_cpu(self, device):
-        if device == "cpu":
+    @property
+    def backend(self):
+        return dist.get_default_backend_for_device(self.device_type)
+
+    @with_comms
+    def test_no_cpu(self):
+        if self.device_type == "cpu":
             self.skipTest("test_no_cpu requires a non-CPU device")
         with self.assertRaisesRegex(
             AssertionError, r"A CPU backend must be enabled for async save;.*?"

--- a/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
+++ b/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
@@ -161,6 +161,13 @@ class TestE2ESaveAndLoad(DTensorContinuousTestBase, VerifyStateDictMixin):
     def world_size(self) -> int:
         return NUM_DEVICES
 
+    @classmethod
+    def backend_str(cls) -> str:
+        # async_save requires a CPU backend for staging, so include cpu:gloo
+        # alongside the accelerator backend.
+        curr_backend = dist.get_default_backend_for_device(device_type)
+        return f"cpu:gloo,{device_type}:{curr_backend}"
+
     def _create_model(self, compile, model_type, state_dict_options=None):
         dummy_model = TestDummyModel().to(self.device_type)
 

--- a/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
+++ b/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
@@ -73,7 +73,7 @@ class TestDummyModel(torch.nn.Module):
         return x
 
     def get_input(self):
-        return torch.rand(8, 8, device=self.net1.weight.device)
+        return torch.rand(8, 8, device=next(self.parameters()).device)
 
 
 class TestStatefulObj:

--- a/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
+++ b/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
@@ -49,7 +49,6 @@ from torch.testing._internal.common_utils import (
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorContinuousTestBase,
     DTensorTestBase,
-    NUM_DEVICES,
     skip_if_lt_x_gpu,
     with_comms,
 )
@@ -154,19 +153,13 @@ def _train(model, optim, train_steps=1):
     return loss, train_state
 
 
-class TestE2ESaveAndLoad(DTensorContinuousTestBase, VerifyStateDictMixin):
+class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
     hw_classification = HardwareClassification.ACCELERATOR
 
     @property
-    def world_size(self) -> int:
-        return NUM_DEVICES
-
-    @classmethod
-    def backend_str(cls) -> str:
-        # async_save requires a CPU backend for staging, so include cpu:gloo
-        # alongside the accelerator backend.
-        curr_backend = dist.get_default_backend_for_device(device_type)
-        return f"cpu:gloo,{device_type}:{curr_backend}"
+    def backend(self):
+        curr_backend = dist.get_default_backend_for_device(self.device_type)
+        return f"cpu:gloo,{self.device_type}:{curr_backend}"
 
     def _create_model(self, compile, model_type, state_dict_options=None):
         dummy_model = TestDummyModel().to(self.device_type)

--- a/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
+++ b/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
@@ -55,9 +55,6 @@ from torch.testing._internal.distributed.checkpoint_utils import with_temp_dir
 from torch.testing._internal.distributed.common_state_dict import VerifyStateDictMixin
 
 
-device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
-
-
 # Simple and boring model
 class TestDummyModel(torch.nn.Module):
     def __init__(self) -> None:
@@ -76,12 +73,12 @@ class TestDummyModel(torch.nn.Module):
         return x
 
     def get_input(self):
-        return torch.rand(8, 8, device=device_type)
+        return torch.rand(8, 8, device=self.net1.weight.device)
 
 
 class TestStatefulObj:
     def __init__(self) -> None:
-        self.data = torch.rand(10, 10, device=device_type)
+        self.data = torch.rand(10, 10)
 
     def state_dict(self):
         return {"data": self.data}


### PR DESCRIPTION
## Summary
This PR removes the hardcoded NCCL backend in TestNoCPU and replaces it
with a device-agnostic lookup via get_default_backend_for_device(), so
the test can run on non-CUDA accelerators (NPU, XPU, etc.).

## Changes
* Replaced `return "nccl"` with `return dist.get_default_backend_for_device(self.device_type)`
  in TestNoCPU.backend, delegating backend selection to the parent class
  DTensorTestBase's device-aware resolution.

## Motivation
TestNoCPU tests that async_save raises an error when no CPU backend is
enabled. Previously the test hardcoded "nccl" as the backend, which
causes init_process_group to fail on machines without NCCL (e.g. NPU
systems using HCCL). The parent class already computes the correct
backend for the current device, so the fix is a one-line change.

## Test Plan
python test/distributed/checkpoint/e2e/test_e2e_save_and_load.py TestNoCPU.test_no_cpu -v 

@fffrog @FuDdd @lyriexs666

