### PR TITLE
[cuda] Support fused Float32 bias with Float32 output for rowwise scaled_mm

### DIFF
--- a/aten/src/ATen/native/cuda/RowwiseScaledMM.cu
+++ b/aten/src/ATen/native/cuda/RowwiseScaledMM.cu
@@ -1106,7 +1106,8 @@ void check_inputs(
     TORCH_CHECK(bias->dim() == 1);
     TORCH_CHECK(bias->size(0) == b.size(1));
     TORCH_CHECK(bias->stride(0) == 1);
-    TORCH_CHECK(out.dtype() != at::kFloat, "Bias is not supported when out_dtype is set to Float32");
+    TORCH_CHECK(out.dtype() != at::kFloat || bias->dtype() == at::kFloat,
+        "Bias must be Float32 when out_dtype is Float32, but got ", bias->dtype());
   }
 
   TORCH_CHECK(out.device() == a.device());

--- a/aten/src/ATen/native/cuda/ScaledBlas.cpp
+++ b/aten/src/ATen/native/cuda/ScaledBlas.cpp
@@ -611,9 +611,13 @@ _scaled_mm_out_cuda(const Tensor& mat1, const Tensor& mat2,
   if (scaling_choice_a == ScalingType::RowWise && scaling_choice_b == ScalingType::RowWise) {
 #ifndef USE_ROCM
     auto dprops = at::cuda::getCurrentDeviceProperties();
-    if ((dprops->major < 9 || CUBLAS_VERSION < 120900 || cublasLtGetVersion() < 120900)
+    // cuBLAS FP8 only accepts a BFloat16/Half bias, so a fused Float32 bias with
+    // Float32 output must go through CUTLASS, which supports it on every arch.
+    const bool bias_needs_cutlass = bias.has_value() && out.dtype() == kFloat;
+    if (bias_needs_cutlass ||
+        ((dprops->major < 9 || CUBLAS_VERSION < 120900 || cublasLtGetVersion() < 120900)
         // cuBLAS only supports tiled 1D factor layout for 1D block scaling, no 2D block scales
-        ||  (dprops->major >= 10 && (!scale_a.sizes().empty() || !scale_b.sizes().empty()))) {
+        ||  (dprops->major >= 10 && (!scale_a.sizes().empty() || !scale_b.sizes().empty())))) {
       TORCH_CHECK_VALUE(
           out.dtype() == kBFloat16 || out.dtype() == kHalf ||
               out.dtype() == kFloat,

--- a/aten/src/ATen/native/cuda/ScaledBlas.cpp
+++ b/aten/src/ATen/native/cuda/ScaledBlas.cpp
@@ -553,23 +553,29 @@ _scaled_mm_out_cuda(const Tensor& mat1, const Tensor& mat2,
   }
 #endif
   if (bias) {
-    TORCH_CHECK(out.scalar_type() != kFloat,
-        "Bias is not supported when out_dtype is set to Float32");
+    if (out.scalar_type() == kFloat) {
+      // Float32 output with a bias is only supported by the rowwise CUTLASS
+      // kernel, which fuses a Float32 bias directly into its Float32 epilogue.
+      const bool rowwise = scaling_choice_a == ScalingType::RowWise &&
+          scaling_choice_b == ScalingType::RowWise;
+      TORCH_CHECK(rowwise && bias->scalar_type() == kFloat,
+          "Bias with Float32 output is only supported for rowwise scaling with "
+          "a Float32 bias, but got bias ", bias->scalar_type());
+    } else {
+      TORCH_CHECK(bias->scalar_type() == ScalarType::BFloat16 ||
+                  bias->scalar_type() == ScalarType::Half,
+          "Bias must be BFloat16 or Half, but got ", bias->scalar_type());
 
-    TORCH_CHECK(bias->scalar_type() == ScalarType::BFloat16 ||
-                bias->scalar_type() == ScalarType::Half,
-        "Bias must be BFloat16 or Half, but got ", bias->scalar_type());
+      TORCH_CHECK(out.scalar_type() != ScalarType::BFloat16 ||
+                  bias->scalar_type() == ScalarType::BFloat16,
+          "Bias must be BFloat16 to compute ", out.scalar_type(),
+          " output, but got ", bias->scalar_type());
 
-    TORCH_CHECK((out.scalar_type() != kFloat &&
-                 out.scalar_type() != ScalarType::BFloat16) ||
-                bias->scalar_type() == ScalarType::BFloat16,
-        "Bias must be BFloat16 to compute ", out.scalar_type(),
-        " output, but got ", bias->scalar_type());
-
-    TORCH_CHECK(out.scalar_type() != ScalarType::Half ||
-                bias->scalar_type() == ScalarType::Half,
-        "Bias must be Float16 to compute ", out.scalar_type(),
-        " output, but got ", bias->scalar_type());
+      TORCH_CHECK(out.scalar_type() != ScalarType::Half ||
+                  bias->scalar_type() == ScalarType::Half,
+          "Bias must be Float16 to compute ", out.scalar_type(),
+          " output, but got ", bias->scalar_type());
+    }
   }
   {
     auto bias_ = bias.value_or(Tensor());
@@ -755,7 +761,12 @@ _scaled_rowwise_rowwise(
 #ifndef USE_ROCM
   // We are doing row-wise scaling
   auto dprops = at::cuda::getCurrentDeviceProperties();
-  if (((dprops->major < 9 || CUBLAS_VERSION < 120900 || cublasLtGetVersion() < 120900)
+  // cuBLAS FP8 only accepts a BFloat16/Half bias, so a fused Float32 bias with
+  // Float32 output must go through CUTLASS, which supports it on every arch.
+  const bool bias_needs_cutlass =
+      bias.has_value() && out.dtype() == kFloat;
+  if (bias_needs_cutlass ||
+      ((dprops->major < 9 || CUBLAS_VERSION < 120900 || cublasLtGetVersion() < 120900)
       // cuBLAS only supports tiled 1D factor layout for 1D block scaling, no 2D block scales
       ||  (dprops->major >= 10 && (!scale_a.sizes().empty() || !scale_b.sizes().empty())))) {
     TORCH_CHECK_VALUE(
@@ -1387,23 +1398,27 @@ TORCH_IMPL_FUNC(_scaled_mm_cuda_v2_out)(
   }
 #endif
   if (bias.has_value()) {
-    TORCH_CHECK_VALUE(out.scalar_type() != kFloat,
-        "Bias is not supported when out_dtype is set to Float32");
+    if (out.scalar_type() == kFloat) {
+      // Float32 output with a bias is only supported by the rowwise CUTLASS
+      // kernel; the scaling-type gate below enforces that once it is known.
+      TORCH_CHECK_VALUE(bias->scalar_type() == kFloat,
+          "Bias with Float32 output must be Float32, but got ",
+          bias->scalar_type());
+    } else {
+      TORCH_CHECK_VALUE(bias->scalar_type() == ScalarType::BFloat16 ||
+                  bias->scalar_type() == ScalarType::Half,
+          "Bias must be BFloat16 or Half, but got ", bias->scalar_type());
 
-    TORCH_CHECK_VALUE(bias->scalar_type() == ScalarType::BFloat16 ||
-                bias->scalar_type() == ScalarType::Half,
-        "Bias must be BFloat16 or Half, but got ", bias->scalar_type());
+      TORCH_CHECK_VALUE(out.scalar_type() != ScalarType::BFloat16 ||
+                  bias->scalar_type() == ScalarType::BFloat16,
+          "Bias must be BFloat16 to compute ", out.scalar_type(),
+          " output, but got ", bias->scalar_type());
 
-    TORCH_CHECK_VALUE((out.scalar_type() != kFloat &&
-                 out.scalar_type() != ScalarType::BFloat16) ||
-                bias->scalar_type() == ScalarType::BFloat16,
-        "Bias must be BFloat16 to compute ", out.scalar_type(),
-        " output, but got ", bias->scalar_type());
-
-    TORCH_CHECK_VALUE(out.scalar_type() != ScalarType::Half ||
-                bias->scalar_type() == ScalarType::Half,
-        "Bias must be Float16 to compute ", out.scalar_type(),
-        " output, but got ", bias->scalar_type());
+      TORCH_CHECK_VALUE(out.scalar_type() != ScalarType::Half ||
+                  bias->scalar_type() == ScalarType::Half,
+          "Bias must be Float16 to compute ", out.scalar_type(),
+          " output, but got ", bias->scalar_type());
+    }
   }
   {
     auto bias_ = bias.has_value() ? *bias : Tensor();
@@ -1453,6 +1468,12 @@ TORCH_IMPL_FUNC(_scaled_mm_cuda_v2_out)(
   );
 
   check_swizzle_lengths(gemm_impl, swizzle_a_enum, swizzle_b_enum);
+
+  if (bias.has_value() && out.scalar_type() == kFloat) {
+    TORCH_CHECK_VALUE(
+        gemm_impl == ScaledGemmImplementation::ROWWISE_ROWWISE,
+        "Bias with Float32 output is only supported for rowwise scaling");
+  }
 
   // dispatch to appropriate lower-level calls for error checking & execution
   if (gemm_impl == ScaledGemmImplementation::TENSORWISE_TENSORWISE) {

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -1105,10 +1105,12 @@ class TestFP8Matmul(TestCase):
         scale_b = torch.tensor(1.0, device=device)
         bias = torch.full((m,), 4.0, device=device, dtype=torch.bfloat16)
         # XPU and CPU supports the case when out_dtype is fp32 + bias. So we just test it with normal run.
+        # On CUDA a bf16 bias with fp32 output is only supported for rowwise scaling with a fp32 bias;
+        # here the scaling is tensorwise, so it still errors.
         if "xpu" not in device and "cpu" not in device:
             self.assertRaisesRegex(
                 ValueError if torch.cuda.is_available() else RuntimeError,
-                "Bias is not supported when out_dtype is set to Float32",
+                "Bias with Float32 output",
                 lambda: scaled_mm_wrap(x, y, scale_a, scale_b, bias=bias, out_dtype=torch.float32),
             )
 
@@ -1385,12 +1387,15 @@ class TestFP8Matmul(TestCase):
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8 or IS_WINDOWS, f8_msg)
     @skipCUDAIf(not SM89OrLater, "rowwise implementation is currently sm89-sm100 specific")
     @parametrize("wrap_v2", [True, False])
-    def test_scaled_mm_row_wise_fp32_out_with_bias_errors(self, wrap_v2, device):
-        # fp32 output combined with a bias is not supported on the row-wise path.
+    @with_tf32_off
+    def test_scaled_mm_row_wise_fp32_out_with_bias(self, wrap_v2, device):
+        # A Float32 bias fuses into the row-wise CUTLASS epilogue with fp32
+        # output; other bias dtypes are still rejected for fp32 output.
         if torch.version.hip:
             raise unittest.SkipTest("hipblaslt rowwise _scaled_mm only supports BFloat16")
 
-        M, K, N = 16, 32, 48
+        M, K, N = 256, 512, 768
+        torch.manual_seed(42)
         input_dtype = e4m3_type
         x = random_matrix_with_scaled_reduction_dim(M, K, dtype=torch.float32, device=device, reduction_dim=-1)
         y = random_matrix_with_scaled_reduction_dim(N, K, dtype=torch.float32, device=device, reduction_dim=-1).t()
@@ -1398,11 +1403,30 @@ class TestFP8Matmul(TestCase):
         y_scales = tensor_to_scale(y, input_dtype, dim=0).float()
         x_fp8 = to_fp8_saturated(x * x_scales, e4m3_type)
         y_fp8 = to_fp8_saturated(y * y_scales, e4m3_type)
-        bias = torch.randn((N,), device=device, dtype=torch.bfloat16)
+        bias = torch.randn((N,), device=device, dtype=torch.float32)
 
+        out = scaled_mm_wrap(
+            x_fp8,
+            y_fp8,
+            scale_a=x_scales.reciprocal(),
+            scale_b=y_scales.reciprocal(),
+            out_dtype=torch.float32,
+            bias=bias,
+            wrap_v2=wrap_v2,
+        )
+        out_emulated = mm_float8_emulated(
+            x_fp8, x_scales, y_fp8, y_scales, torch.float32, bias
+        )
+        self.assertEqual(out.dtype, torch.float32)
+        cosine_sim = torch.nn.functional.cosine_similarity(
+            out.flatten().float(), out_emulated.flatten().float(), dim=0
+        )
+        self.assertGreaterEqual(float(cosine_sim), 0.999)
+
+        # A non-Float32 bias with fp32 output remains unsupported.
         with self.assertRaisesRegex(
             (ValueError, RuntimeError),
-            "Bias is not supported when out_dtype is set to Float32",
+            "Bias with Float32 output",
         ):
             scaled_mm_wrap(
                 x_fp8,
@@ -1410,7 +1434,7 @@ class TestFP8Matmul(TestCase):
                 scale_a=x_scales.reciprocal(),
                 scale_b=y_scales.reciprocal(),
                 out_dtype=torch.float32,
-                bias=bias,
+                bias=bias.bfloat16(),
                 wrap_v2=wrap_v2,
             )
 


### PR DESCRIPTION
## Summary

Row-wise FP8 `torch._scaled_mm` refused to take a bias whenever you asked for a
`float32` output, raising `"Bias is not supported when out_dtype is set to
Float32"`. This PR lets you pass a `float32` bias together with a `float32`
output on the row-wise path.

The bias was never actually a problem for the kernel. The row-wise path is
served by a CUTLASS kernel, and that kernel already knows how to add a
`float32` bias while it is still working in `float32`, before it writes the
result out. The check that blocked it was a blanket "no bias with fp32 output"
guard that ran before we picked a backend.

The reason we could not simply delete the guard is the other backend. On Hopper
with a recent enough cuBLAS, the row-wise path can instead go through cuBLAS,
and cuBLAS's FP8 bias support only accepts a `bfloat16` or `float16` bias. So a
`float32` bias with `float32` output is fine on CUTLASS but not on cuBLAS.

So this PR keeps the combination on the CUTLASS kernel and gates it carefully:

- A bias with `float32` output is now allowed, but only when the bias itself is
  `float32`. Any other bias dtype with `float32` output still errors, with a
  clearer message.
- When someone asks for a `float32` bias and `float32` output, the row-wise
  path is routed to CUTLASS instead of cuBLAS, which is correct on every
  supported GPU.
- The lower-level input checks in the CUTLASS kernel were updated to match. The
  dtype dispatch there already builds the `float` bias / `float` output variant
  of the kernel, so no new kernel code was needed.

Existing `bfloat16` and `float16` bias combinations are unchanged.

## Test Plan

Built from source and ran on an H100 NVL (sm90, CUDA 12.4):

```
python -m pip install -e . -v --no-build-isolation
python -m pytest test/test_scaled_matmul_cuda.py -k row_wise_fp32_out_with_bias -v
python -m pytest test/test_scaled_matmul_cuda.py -q
```

`test_scaled_mm_row_wise_fp32_out_with_bias` (which replaces the old
`..._errors` test) runs the fused `float32` bias + `float32` output and compares
it against the emulated dequantized reference (cosine similarity >= 0.999) for
both the v1 and v2 entry points, and confirms that a `bfloat16` bias with
`float32` output still raises. The full test file passes with no regressions
(the only non-passing item was an unrelated profiler test that needs a
Kineto-enabled build).

This change was written with help from an AI assistant. I have read the diff and
can explain every line.
