### PR TITLE
Add avg reduceOp support to all_reduce backward

### DIFF
--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -658,9 +658,9 @@ def all_reduce_backward(ctx, grad_output: torch.Tensor):
     group_name = ctx.group_name
     reduce_op = ctx.reduce_op
 
-    if reduce_op != "sum":
+    if reduce_op not in ("sum", "avg"):
         raise RuntimeError(
-            f"all_reduce backward only supports 'sum' reduction, got '{reduce_op}'"
+            f"all_reduce backward only supports 'sum' and 'avg' reduction, got '{reduce_op}'"
         )
 
     # Backward does all_reduce with the same reduce_op


### PR DESCRIPTION
Fixes #190007

## Summary

The new `_functional_collectives.all_reduce(x, reduceOp="avg")` API silently breaks backward -- forward succeeds, but calling `.backward()` raises `RuntimeError: all_reduce backward only supports 'sum' reduction, got 'avg'`.

## Change

Added `"avg"` to the allowed reduce operations in `all_reduce_backward`. The backward already calls `all_reduce(grad_output.contiguous(), reduce_op, group_name)` with the same `reduce_op` from forward, so when `reduce_op="avg"` it correctly averages the gradient across ranks -- which is the mathematically correct backward for average reduction.

## Testing

```
import torch
import torch.distributed as dist
from torch.distributed._functional_collectives import all_reduce as all_reduce_with_grad

dist.init_process_group("gloo", rank=0, world_size=1)
x = torch.tensor([1.0], requires_grad=True)
y = all_reduce_with_grad(x, reduceOp="avg", group=dist.group.WORLD)
y.sum().backward()  # no longer raises RuntimeError
```
