### PR TITLE
fix flaky test_memory_snapshot

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5487,6 +5487,7 @@ class TestCudaAllocator(TestCase):
                         self.assertTrue("test_cuda.py" in f2.read())
             del unused
             del x
+            torch._C._cuda_clearCublasWorkspaces()
             torch.cuda.empty_cache()
             ss = torch.cuda.memory._snapshot()
             self.assertTrue(


### PR DESCRIPTION
`test_memory_snapshot` asserts that the last allocator action after cleanup is `segment_free` or `segment_unmap`. cuBLAS workspace allocations on the default stream can keep segments alive and make that assertion flaky.

Call `torch._C._cuda_clearCublasWorkspaces()` before `empty_cache()` in `test_memory_snapshot`, so segment teardown is not blocked by lingering cuBLAS workspace allocations.

Fixes https://github.com/pytorch/pytorch/issues/179745