### PR TITLE
[inductor][cpp-wrapper] Fix null handle from single-element Tensor[] fallback op (#190551)

### DIFF
--- a/test/inductor/test_cpp_wrapper_custom_ops.py
+++ b/test/inductor/test_cpp_wrapper_custom_ops.py
@@ -188,6 +188,29 @@ class TestCppWrapperCustomOps(InductorTestCase):
         )
         self.assertIn("callBoxed", code_str)
 
+    @unittest.skipIf(not HAS_CPU, "requires CPU")
+    @config.patch(cpp_wrapper=True, implicit_fallbacks=True)
+    def test_cpp_wrapper_single_element_tensor_list_return(self):
+        # A Tensor[]-returning op goes through the Python custom_op_wrapper
+        # fallback, which always returns a Python list. A single-element result
+        # must be unwrapped with PyList_GET_ITEM, not as a bare capsule (which
+        # yields a null handle and segfaults downstream).
+        with torch.library._scoped_library("mylib_single_list", "FRAGMENT") as m:
+            m.define("single_list(Tensor x) -> Tensor[]")
+            m.impl("single_list", lambda x: [x + 1], "CPU")
+            m.impl("single_list", lambda x: [torch.empty_like(x)], "Meta")
+
+            def fn(x):
+                (y,) = torch.ops.mylib_single_list.single_list.default(x)
+                return y * 2
+
+            x = torch.randn(4)
+            out, code = run_and_get_code(torch.compile(fn, fullgraph=True), x)
+            self.assertEqual(out, (x + 1) * 2)
+            code_str = "\n".join(code)
+            self.assertIn("custom_op_wrapper", code_str)
+            self.assertIn("PyList_GET_ITEM", code_str)
+
 
 if __name__ == "__main__":
     run_tests(needs="filelock")

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -4046,12 +4046,23 @@ if (!custom_op_wrapper) {
                 if output_arg is not None
             ]
 
-        if num_returned_outputs == 1 and returned_output_slots:
+        # custom_op_wrapper returns a bare capsule only for a single, non-list
+        # Tensor return. A Tensor[] return (even of length 1) or multiple returns
+        # come back as a Python list that must be indexed with PyList_GET_ITEM.
+        schema_returns = op_overload._schema.returns
+        returns_python_list = len(schema_returns) != 1 or isinstance(
+            schema_returns[0].real_type, torch.ListType
+        )
+        if (
+            num_returned_outputs == 1
+            and returned_output_slots
+            and not returns_python_list
+        ):
             # result is a single tensor
             _, output = returned_output_slots[0]
             lines += f"{output} = reinterpret_cast<AtenTensorHandle>(PyCapsule_GetPointer(py_{buf_name}.get(), NULL));\n"
         else:
-            # result is a tuple of tensors
+            # result is a list of tensors (Tensor[] or multiple returns)
             for idx, output_arg in returned_output_slots:
                 lines += f"{output_arg} = reinterpret_cast<AtenTensorHandle>(PyCapsule_GetPointer(PyList_GET_ITEM(py_{buf_name}.get(), {idx}), NULL));\n"
 


### PR DESCRIPTION
Summary:

When an op returning `Tensor[]` is code-generated as a Python fallback in cpp_wrapper mode (`generate_fallback_kernel_with_runtime_lookup_python` in `cpp_wrapper_cpu.py`), the result was unwrapped based on the number of IR output nodes (`num_returned_outputs`) instead of the op schema. `custom_op_wrapper` always returns a Python list for a list/tuple result, so a `Tensor[]` result of length 1 still comes back as a 1-element Python list; the codegen took the single-output branch and called `PyCapsule_GetPointer(py_buf, NULL)` directly on that list, which returns `NULL`. The resulting null `AtenTensorHandle` later SIGSEGVs when the buffer is consumed by a Triton kernel (`convertArgToPython` -> `tensor_handle_to_tensor_pointer` -> null dereference).

This was hit in production by a Distributed Shampoo optimizer step compiled with `cpp_wrapper`: `aten._foreach_norm.Scalar` over a foreach group that a gradient-selection recompile had compressed down to a single element. The default Python wrapper is unaffected because it unpacks the list with normal Python semantics.

Fix: choose the single-capsule vs `PyList_GET_ITEM` extraction from the op schema. A single, non-list `Tensor` return uses the bare capsule (matching `custom_op_wrapper`'s `unsafe_alloc_void_ptr_from_tensor`); a `Tensor[]` return (even of length 1) or multiple returns use `PyList_GET_ITEM`, matching `unsafe_alloc_void_ptrs_from_tensors`.

Test Plan:
fbcode:

```
buck2 test fbcode//mode/dev-nosan fbcode//caffe2/test/inductor:cpp_wrapper_custom_ops -- test_cpp_wrapper_single_element_tensor_list_return
```

Authored-with: Claude Code (AI coding agent)

Differential Revision: D112572003




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo