### PR TITLE
[TEST] Refactor test/test_import_stats.py to make it device-generic

### DIFF
--- a/test/test_import_stats.py
+++ b/test/test_import_stats.py
@@ -10,9 +10,9 @@ class TestImportTime(TestCase):
     def test_time_import_torch(self):
         TestCase.runWithPytorchAPIUsageStderr("import torch")
 
-    def test_time_cuda_device_count(self):
+    def test_time_device_count(self):
         TestCase.runWithPytorchAPIUsageStderr(
-            "import torch; torch.cuda.device_count()",
+            "import torch;torch.accelerator.device_count()",
         )
 
 


### PR DESCRIPTION
## Description
This PR refactors the `test/test_import_stats.py` to be device-generic. Specifically, it renames `test_time_cuda_device_count` to `test_time_device_count` and replaces the hardcoded `torch.cuda.device_count()` call with the new `torch.accelerator.device_count()` API.

## Motivation
This change ensures that import timing tests execute accurately across all supported hardware backends rather than being tightly coupled exclusively to CUDA environments. 

## How Has This Been Tested?
Ran the relevant local test suite: `pytest test/test_import_stats.py`: 2 passed in 18.70s