### PR TITLE
[inductor] Partition cross-device fallbacks from CUDA graphs

### DIFF
--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -19,7 +19,7 @@ import torch.nn as nn
 from torch._dynamo.backends.debugging import aot_eager_decomp_partition_with_mode
 from torch._dynamo.utils import counters
 from torch._functorch._aot_autograd.autograd_cache import AOTAutogradCache
-from torch._inductor import config
+from torch._inductor import config, lowering
 from torch._inductor.codecache import FxGraphCache
 from torch._inductor.compile_fx import compile_fx_inner
 from torch._inductor.cudagraph_trees import (
@@ -4315,10 +4315,8 @@ if HAS_CUDA_AND_TRITON:
             # 2 graph partitions lead to 2 cudagraph
             self.assertEqual(self.get_manager().new_graph_id().id, 2)
 
-        @unittest.skip(
-            "Disabled due to CI failures; see "
-            "https://github.com/pytorch/pytorch/issues/190233"
-        )
+        @torch._inductor.config.patch("graph_partition", True)
+        @lowering.force_fallback(torch.ops.prims.device_put.default)
         def test_graph_partition_view_fallback(self):
             def f(x):
                 y = x + 1
@@ -4329,11 +4327,14 @@ if HAS_CUDA_AND_TRITON:
 
             compiled_f = torch.compile(f, mode="reduce-overhead")
 
-            for _ in range(3):
-                x = torch.ones(2, dtype=torch.int32, device="cuda")
+            for i in range(3):
+                x = torch.full((2,), i, dtype=torch.int32, device="cuda")
                 eager_out = f(x)
                 compiled_out = compiled_f(x)
                 self.assertEqual(eager_out, compiled_out)
+
+            # Without the device_put partition, the H2D fallback forms a second graph.
+            self.assertEqual(self.get_manager().new_graph_id().id, 1)
 
         @torch._inductor.config.patch("graph_partition", True)
         @skipIfRocm

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -4317,13 +4317,9 @@ if HAS_CUDA_AND_TRITON:
 
         @torch._inductor.config.patch("graph_partition", True)
         @lowering.force_fallback(torch.ops.prims.device_put.default)
-        def test_graph_partition_view_fallback(self):
+        def test_graph_partition_device_put_fallback(self):
             def f(x):
-                y = x + 1
-                z = torch.ops.aten.view.dtype(y, torch.float8_e4m3fn)
-                z_cpu = z.cpu()
-                u_cuda = z_cpu.cuda()
-                return u_cuda
+                return (x + 1).cpu().cuda()
 
             compiled_f = torch.compile(f, mode="reduce-overhead")
 
@@ -4333,7 +4329,34 @@ if HAS_CUDA_AND_TRITON:
                 compiled_out = compiled_f(x)
                 self.assertEqual(eager_out, compiled_out)
 
-            # Without the device_put partition, the H2D fallback forms a second graph.
+            # Without partitioning the H2D fallback, it forms a second graph.
+            self.assertEqual(self.get_manager().new_graph_id().id, 1)
+
+        @config.patch(implicit_fallbacks=True)
+        @torch._inductor.config.patch("graph_partition", True)
+        def test_graph_partition_cross_device_custom_op_fallback(self):
+            device = torch.device("cuda", self.device_idx)
+
+            @torch.library.custom_op("mylib::cpu_to_cuda", mutates_args=())
+            def cpu_to_cuda(x: torch.Tensor) -> torch.Tensor:
+                return x.to(device)
+
+            @cpu_to_cuda.register_fake
+            def _(x):
+                return torch.empty_like(x, device=device)
+
+            def f(x):
+                return cpu_to_cuda(x) + 1
+
+            compiled_f = torch.compile(f, mode="reduce-overhead", fullgraph=True)
+
+            for i in range(3):
+                x = torch.full((2,), i, dtype=torch.int32)
+                eager_out = f(x)
+                compiled_out = compiled_f(x)
+                self.assertEqual(eager_out, compiled_out)
+
+            # Only the downstream CUDA add should be recorded.
             self.assertEqual(self.get_manager().new_graph_id().id, 1)
 
         @torch._inductor.config.patch("graph_partition", True)

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -9050,7 +9050,10 @@ class Scheduler:
         if not node.is_gpu():
             return f"{node.get_device()} ops"
 
-        if isinstance(node.node, ir.DeviceCopy):
+        if isinstance(node.node, ir.DeviceCopy) or (
+            isinstance(node.node, ir.FallbackKernel)
+            and node.node.op_overload is torch.ops.prims.device_put.default
+        ):
             return "DeviceCopy ops"
 
         if isinstance(node.node, ir.Conditional):

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -9050,11 +9050,17 @@ class Scheduler:
         if not node.is_gpu():
             return f"{node.get_device()} ops"
 
-        if isinstance(node.node, ir.DeviceCopy) or (
-            isinstance(node.node, ir.FallbackKernel)
-            and node.node.op_overload is torch.ops.prims.device_put.default
+        output_device = node.get_device()
+        if isinstance(ir_node, ir.DeviceCopy) or (
+            isinstance(ir_node, ir.FallbackKernel)
+            and ir.is_node_sequence(ir_node.inputs)
+            and any(
+                (input_device := input_node.get_device()) is not None
+                and input_device != output_device
+                for input_node in ir_node.inputs
+            )
         ):
-            return "DeviceCopy ops"
+            return "cross-device copy ops"
 
         if isinstance(node.node, ir.Conditional):
             return "Conditional ops"


### PR DESCRIPTION
## Summary

- partition `FallbackKernel` nodes when a concrete tensor input device differs from the fallback output device
- preserve same-device fallback behavior while covering both `prims.device_put.default` and other cross-device fallback operators
- rename and simplify the deterministic `device_put` regression
- add an untagged, op-agnostic CPU-to-CUDA custom-op regression with varied replay inputs and graph-count assertions

## Root cause

CUDAGraph partitions must not read tensor storage allocated outside the active CUDA memory pool. `Scheduler.should_partition` recognized explicit `ir.DeviceCopy` nodes, but a fallback kernel could report a CUDA output device while reading a CPU tensor input. That fallback passed the normal GPU-node check and could be recorded in a CUDA partition, where `check_memory_pool` rejected the CPU storage.

The scheduler now compares each fallback tensor input with the fallback output device and ignores inputs that do not expose a concrete device. A real input/output device mismatch forms a partition boundary; same-device fallbacks remain eligible for CUDA graph capture. The partition reason is now `cross-device copy ops`.

Issue #188677 is the earlier CI quarantine of this same regression; #190233 tracks the underlying failure.

Fixes #190233
Fixes #188677

## Test plan

- pre-fix counterfactual: the generic CPU-to-CUDA custom-op regression fails in `check_memory_pool`
- focused device-copy, `device_put`, generic cross-device fallback, and same-device fallback tests pass
- graph-partition subset: 58 passed, 2 skipped
- both positive regressions: 10/10 repeated passes with CUDA memory-leak checking
- `TRITON_OVERRIDE_ARCH=sm86`: both positive regressions pass
- targeted `spin lint` on both changed files, including NEWLINE, Pyrefly, Ruff, Flake8, ClangFormat, and the remaining configured linters
- `git diff --check`

ROCm runtime was not available locally, so this PR does not claim ROCm execution coverage.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo
