### PR TITLE
Skip test_swap_allows_tensor_weakref under TorchDynamo

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -10980,6 +10980,10 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
             with self.assertRaisesRegex(RuntimeError, "has weakref"):
                 torch.utils.swap_tensors(t1, t2)
 
+    @skipIfTorchDynamo(
+        "asserts exact tensor weakref counts; torch.compile holds transient "
+        "WeakIdRefs on traced tensors (#190165)"
+    )
     def test_swap_allows_tensor_weakref(self):
         from torch.utils.weak import TensorWeakRef
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #190556

TestTorch.test_swap_allows_tensor_weakref was auto-disabled (#190165) after
flaking on the linux-jammy-py3.14-clang18 job under PYTORCH_TEST_WITH_DYNAMO=1,
with `len(weakref.getweakrefs(t2))` returning 4 instead of the expected 1.

Root cause: the test asserts exact tensor weakref counts to check swap_tensors /
TensorWeakRef semantics, which is an eager-only invariant. Under
PYTORCH_TEST_WITH_DYNAMO the whole method is run through torch.compile and, with
a graph break on nearly every line, each traced sub-frame registers a WeakIdRef
on the tensors via FakeTensorMode's describer / TracingContext.tensor_to_context.
Those refs are cleared at each compile's end (clear_compile_context_weakrefs runs
for the eager backend too), but a cleared WeakIdRef only stops showing up in
weakref.getweakrefs() once it is actually freed. On CPython 3.10 refcounting frees
them immediately (the test passes), but on 3.14 GC timing lets the freed-but-
uncollected WeakIdRefs linger, so the count exceeds 1. The failure precedes the
swap_tensors call, so this is not a swap_tensors bug -- it is an eager-semantics
test running under the dynamo test harness.

Skip it under TorchDynamo, matching the existing pattern for such tests in this
file, so the flaky-test shield (#190165) can be closed.

Test Plan:

Skipped under dynamo:

```
PYTORCH_TEST_WITH_DYNAMO=1 python test/test_torch.py TestTorch.test_swap_allows_tensor_weakref
# OK (skipped=1)
```

Still runs in eager:

```
python test/test_torch.py TestTorch.test_swap_allows_tensor_weakref
# OK
```

Authored with Claude.