### PR TITLE
[AI Codemod][PerfAICT-General] Avoid redundant storage-size pass and SymInt in checkInBoundsForStorage (#190560)

### DIFF
--- a/aten/src/ATen/EmptyTensor.cpp
+++ b/aten/src/ATen/EmptyTensor.cpp
@@ -88,6 +88,18 @@ size_t computeStorageNbytes(
     size_t itemsize_bytes,
     size_t storage_offset
   ) {
+  return static_cast<size_t>(
+      computeStorageNbytesWithOffset(
+          sizes, strides, itemsize_bytes, storage_offset)
+          .withOffset);
+}
+
+StorageNbytes computeStorageNbytesWithOffset(
+    IntArrayRef sizes,
+    IntArrayRef strides,
+    size_t itemsize_bytes,
+    size_t storage_offset
+  ) {
   TORCH_CHECK(
     sizes.size() == strides.size(),
     "dimensionality of sizes (",
@@ -100,35 +112,40 @@ size_t computeStorageNbytes(
 #ifndef C10_MOBILE
   // size of the underlying storage is 1 bigger than the offset
   // of the last element according to stride
-  uint64_t size = storage_offset + 1;
+  uint64_t size = 1;
   bool overflowed = false;
   for (const auto i : c10::irange(sizes.size())) {
     if (sizes[i] == 0) {
-      return 0;
+      return {0, 0};
     }
 
     uint64_t strided_size = 0;
     overflowed |= c10::mul_overflows(strides[i], sizes[i] - 1, &strided_size);
     overflowed |= c10::add_overflows(size, strided_size, &size);
   }
-  overflowed |= c10::mul_overflows(size, itemsize_bytes, &size);
-  overflowed |= size > storage_max();
+  uint64_t without_offset = 0;
+  uint64_t with_offset = 0;
+  overflowed |= c10::mul_overflows(size, itemsize_bytes, &without_offset);
+  overflowed |= c10::add_overflows(size, storage_offset, &with_offset);
+  overflowed |= c10::mul_overflows(with_offset, itemsize_bytes, &with_offset);
+  overflowed |= with_offset > storage_max();
   TORCH_CHECK(!overflowed,
               "Storage size calculation overflowed with sizes=",
               sizes, " and strides=", strides);
-  return static_cast<size_t>(size);
+  return {static_cast<int64_t>(without_offset), static_cast<int64_t>(with_offset)};
 #else
   // size of the underlying storage is 1 bigger than the offset
   // of the last element according to stride
   uint64_t size = 1;
   for (const auto i : c10::irange(sizes.size())) {
     if (sizes[i] == 0) {
-      return 0;
+      return {0, 0};
     }
 
     size += strides[i] * (sizes[i] - 1);
   }
-  return itemsize_bytes * (storage_offset + size);
+  return {static_cast<int64_t>(itemsize_bytes * size),
+          static_cast<int64_t>(itemsize_bytes * (storage_offset + size))};
 #endif
 }
 
@@ -141,9 +158,20 @@ SymInt computeStorageNbytesContiguous(
   return itemsize_bytes * (storage_offset + numel);
 }
 
+SymInt computeStorageNbytes(
+    SymIntArrayRef sizes,
+    SymIntArrayRef strides,
+    const SymInt& itemsize_bytes,
+    const SymInt& storage_offset
+  ) {
+  return computeStorageNbytesWithOffset(
+             sizes, strides, itemsize_bytes, storage_offset)
+      .withOffset;
+}
+
 // not including mobile-only macros in this function,
 // since mobile shouldn't be using symints.
-SymInt computeStorageNbytes(
+SymStorageNbytes computeStorageNbytesWithOffset(
     SymIntArrayRef sizes,
     SymIntArrayRef strides,
     const SymInt& itemsize_bytes,
@@ -162,7 +190,7 @@ SymInt computeStorageNbytes(
   SymInt size = 1;
   for (const auto i : c10::irange(sizes.size())) {
     if (TORCH_GUARD_OR_FALSE(sizes[i].sym_eq(0))) {
-      return 0;
+      return {0, 0};
     }
 
     // NOTE: while this can technically return negative sizes for
@@ -172,7 +200,7 @@ SymInt computeStorageNbytes(
     // once our min/max symbolic reasoning improves.
     size += strides[i] * (sizes[i] - 1);
   }
-  return itemsize_bytes * (storage_offset + size);
+  return {itemsize_bytes * size, itemsize_bytes * (storage_offset + size)};
 }
 
 template <typename T>

--- a/aten/src/ATen/EmptyTensor.h
+++ b/aten/src/ATen/EmptyTensor.h
@@ -44,6 +44,25 @@ TORCH_API SymInt computeStorageNbytes(
     const SymInt& itemsize,
     const SymInt& storage_offset = 0);
 
+struct StorageNbytes {
+  int64_t withoutOffset;
+  int64_t withOffset;
+};
+TORCH_API StorageNbytes computeStorageNbytesWithOffset(
+    IntArrayRef sizes,
+    IntArrayRef strides,
+    size_t itemsize,
+    size_t storage_offset);
+struct SymStorageNbytes {
+  SymInt withoutOffset;
+  SymInt withOffset;
+};
+TORCH_API SymStorageNbytes computeStorageNbytesWithOffset(
+    SymIntArrayRef sizes,
+    SymIntArrayRef strides,
+    const SymInt& itemsize,
+    const SymInt& storage_offset);
+
 TORCH_API TensorBase empty_generic(
     IntArrayRef size,
     c10::Allocator* allocator,

--- a/aten/src/ATen/native/Resize.h
+++ b/aten/src/ATen/native/Resize.h
@@ -99,15 +99,16 @@ inline void checkInBoundsForStorage(
     const Storage& new_storage) {
   T storage_size_bytes, storage_size_plus_offset_bytes;
   if (stride.data()) {
-    storage_size_bytes =
-        at::detail::computeStorageNbytes(size, stride, data_type.itemsize());
-    storage_size_plus_offset_bytes = at::detail::computeStorageNbytes(
+    auto nbytes = at::detail::computeStorageNbytesWithOffset(
         size, stride, data_type.itemsize(), storage_offset);
+    storage_size_bytes = std::move(nbytes.withoutOffset);
+    storage_size_plus_offset_bytes = std::move(nbytes.withOffset);
   } else {
+    const size_t itemsize = data_type.itemsize();
     storage_size_bytes =
-        at::detail::computeStorageNbytesContiguous(size, data_type.itemsize());
+        at::detail::computeStorageNbytesContiguous(size, itemsize);
     storage_size_plus_offset_bytes = at::detail::computeStorageNbytesContiguous(
-        size, data_type.itemsize(), storage_offset);
+        size, itemsize, storage_offset);
   }
   const int64_t element_per_byte = subByteElementPerByte(data_type);
   if (element_per_byte > 1) {

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -10835,10 +10835,10 @@ class GraphModule(torch.nn.Module):
             sum_1: "f32[1, 3]" = torch.ops.aten.sum.dim_IntList(arg1_1, [0], True)
             view: "f32[3]" = torch.ops.aten.view.default(sum_1, [3]);  sum_1 = None
             t_4: "f32[3, 3]" = torch.ops.aten.t.default(t_3);  t_3 = None
-            mul_4: "f32[3, 3]" = torch.ops.aten.mul.Tensor(arg1_1, select)
-            mul_5: "f32[3, 3]" = torch.ops.aten.mul.Tensor(arg1_1, select);  arg1_1 = select = None
-            add_7: "f32[3, 3]" = torch.ops.aten.add.Tensor(mm, mul_5);  mm = mul_5 = None
-            add_8: "f32[3, 3]" = torch.ops.aten.add.Tensor(add_7, mul_4);  add_7 = mul_4 = None
+            mul_5: "f32[3, 3]" = torch.ops.aten.mul.Tensor(arg1_1, select)
+            mul_6: "f32[3, 3]" = torch.ops.aten.mul.Tensor(arg1_1, select);  arg1_1 = select = None
+            add_7: "f32[3, 3]" = torch.ops.aten.add.Tensor(mm, mul_6);  mm = mul_6 = None
+            add_8: "f32[3, 3]" = torch.ops.aten.add.Tensor(add_7, mul_5);  add_7 = mul_5 = None
             add_9: "i64[]" = torch.ops.aten.add.Tensor(arg0_1, 1);  arg0_1 = None
             add_10: "f32[3]" = torch.ops.aten.add.Tensor(view, arg2_1);  view = arg2_1 = None
             add_11: "f32[3, 3]" = torch.ops.aten.add.Tensor(t_4, arg3_1);  t_4 = arg3_1 = None

--- a/test/higher_order_ops/test_invoke_subgraph.py
+++ b/test/higher_order_ops/test_invoke_subgraph.py
@@ -2692,9 +2692,9 @@ class GraphModule(torch.nn.Module):
         partitioned_bw_subgraph_0_3 = self.partitioned_bw_subgraph_0_1
         invoke_subgraph_13 = torch.ops.higher_order.invoke_subgraph(partitioned_bw_subgraph_0_3, 'partitioned_bw_subgraph_0_1', getitem_21, getitem_20, add_16);  partitioned_bw_subgraph_0_3 = getitem_21 = getitem_20 = add_16 = None
         getitem_8: "f32[s77, 16]" = invoke_subgraph_13[1];  invoke_subgraph_13 = None
-        mul_10: "f32[s77, 16]" = torch.ops.aten.mul.Tensor(getitem_8, cos);  getitem_8 = cos = None
+        mul_15: "f32[s77, 16]" = torch.ops.aten.mul.Tensor(getitem_8, cos);  getitem_8 = cos = None
         partitioned_bw_subgraph_0_2 = self.partitioned_bw_subgraph_0_1
-        invoke_subgraph_11 = torch.ops.higher_order.invoke_subgraph(partitioned_bw_subgraph_0_2, 'partitioned_bw_subgraph_0_1', getitem_19, getitem_18, mul_10);  partitioned_bw_subgraph_0_2 = getitem_19 = getitem_18 = mul_10 = None
+        invoke_subgraph_11 = torch.ops.higher_order.invoke_subgraph(partitioned_bw_subgraph_0_2, 'partitioned_bw_subgraph_0_1', getitem_19, getitem_18, mul_15);  partitioned_bw_subgraph_0_2 = getitem_19 = getitem_18 = mul_15 = None
         getitem_11: "f32[s77, 16]" = invoke_subgraph_11[1];  invoke_subgraph_11 = None
         partitioned_bw_subgraph_0_1 = self.partitioned_bw_subgraph_0_1
         invoke_subgraph_9 = torch.ops.higher_order.invoke_subgraph(partitioned_bw_subgraph_0_1, 'partitioned_bw_subgraph_0_1', getitem_17, getitem_16, getitem_11);  partitioned_bw_subgraph_0_1 = getitem_17 = getitem_16 = getitem_11 = None
@@ -2704,14 +2704,14 @@ class GraphModule(torch.nn.Module):
         def forward(self, primals_0: "Sym(s77)", primals_1: "f32[s77, 16]", tangents_0: "f32[s77, 16]"):
             sin: "f32[s77, 16]" = torch.ops.aten.sin.default(primals_1);  primals_1 = None
             neg: "f32[s77, 16]" = torch.ops.aten.neg.default(sin);  sin = None
-            mul_9: "f32[s77, 16]" = torch.ops.aten.mul.Tensor(tangents_0, neg);  tangents_0 = neg = None
-            return (None, mul_9)
+            mul_13: "f32[s77, 16]" = torch.ops.aten.mul.Tensor(tangents_0, neg);  tangents_0 = neg = None
+            return (None, mul_13)
     class partitioned_bw_subgraph_0_1(torch.nn.Module):
         def forward(self, primals_0: "Sym(s77)", primals_1: "f32[s77, 16]", tangents_0: "f32[s77, 16]"):
             sin: "f32[s77, 16]" = torch.ops.aten.sin.default(primals_1);  primals_1 = None
             neg: "f32[s77, 16]" = torch.ops.aten.neg.default(sin);  sin = None
-            mul_10: "f32[s77, 16]" = torch.ops.aten.mul.Tensor(tangents_0, neg);  tangents_0 = neg = None
-            return (None, mul_10)""",
+            mul_15: "f32[s77, 16]" = torch.ops.aten.mul.Tensor(tangents_0, neg);  tangents_0 = neg = None
+            return (None, mul_15)""",
                 ignore_empty_lines=True,
             )
 

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -4426,9 +4426,9 @@ def forward(self, arg0_1: "i64[1][1]cpu", arg1_1: "Sym(u1)", arg2_1: "Sym(s7)", 
         view_1: "i64[u0, u0][s7*u0, s7]cpu" = torch.ops.aten.view.default(arg3_1, [_local_scalar_dense, _local_scalar_dense])
         view_2: "i64[u0, u0][s7*u0, s7]cpu" = torch.ops.aten.view.default(arg3_1, [_local_scalar_dense, _local_scalar_dense]);  arg3_1 = _local_scalar_dense = None
         clone: "i64[u0, u0][Max(1, u0), 1]cpu" = torch.ops.aten.clone.default(view_2);  view_2 = None
-        mul_11: "i64[u0, u0][Max(1, u0), 1]cpu" = torch.ops.aten.mul.Tensor(view, 10);  view = None
-        mul_14: "i64[u0, u0][Max(1, u0), 1]cpu" = torch.ops.aten.mul.Tensor(view_1, 10);  view_1 = None
-        return (mul_11, mul_14, clone)""",
+        mul_14: "i64[u0, u0][Max(1, u0), 1]cpu" = torch.ops.aten.mul.Tensor(view, 10);  view = None
+        mul_18: "i64[u0, u0][Max(1, u0), 1]cpu" = torch.ops.aten.mul.Tensor(view_1, 10);  view_1 = None
+        return (mul_14, mul_18, clone)""",
             ignore_comments=True,
             ignore_empty_lines=True,
         )
@@ -4467,9 +4467,9 @@ def forward(self, arg0_1: "i64[1][1]cpu", arg1_1: "Sym(u1)", arg2_1: "i64[u1][1]
         view_1: "i64[u0, u0][Max(1, u0), 1]cpu" = torch.ops.aten.view.default(arg2_1, [_local_scalar_dense, _local_scalar_dense])
         view_2: "i64[u0, u0][Max(1, u0), 1]cpu" = torch.ops.aten.view.default(arg2_1, [_local_scalar_dense, _local_scalar_dense]);  arg2_1 = _local_scalar_dense = None
         clone: "i64[u0, u0][Max(1, u0), 1]cpu" = torch.ops.aten.clone.default(view_2);  view_2 = None
-        mul_6: "i64[u0, u0][Max(1, u0), 1]cpu" = torch.ops.aten.mul.Tensor(view, 10);  view = None
-        mul_9: "i64[u0, u0][Max(1, u0), 1]cpu" = torch.ops.aten.mul.Tensor(view_1, 10);  view_1 = None
-        return (mul_6, mul_9, clone)""",
+        mul_9: "i64[u0, u0][Max(1, u0), 1]cpu" = torch.ops.aten.mul.Tensor(view, 10);  view = None
+        mul_13: "i64[u0, u0][Max(1, u0), 1]cpu" = torch.ops.aten.mul.Tensor(view_1, 10);  view_1 = None
+        return (mul_9, mul_13, clone)""",
             ignore_comments=True,
             ignore_empty_lines=True,
         )
@@ -4538,8 +4538,8 @@ def forward(self, arg0_1: "i64[2][1]cpu", arg1_1: "Sym(u2)", arg2_1: "Sym(u3)", 
         _assert_scalar_6 = torch.ops.aten._assert_scalar.default(eq, "Runtime assertion failed for expression Eq(u2*u3, u0*u1) on node 'eq'");  eq = _assert_scalar_6 = None
         clone: "f32[u2, u3][Max(1, u3), 1]cpu" = torch.ops.aten.clone.default(arg3_1, memory_format = torch.contiguous_format);  arg3_1 = None
         view: "f32[u0, u1][Max(1, u1), 1]cpu" = torch.ops.aten.view.default(clone, [_local_scalar_dense, _local_scalar_dense_1]);  clone = _local_scalar_dense = _local_scalar_dense_1 = None
-        mul_21: "f32[u0, u1][Max(1, u1), 1]cpu" = torch.ops.aten.mul.Tensor(view, 10);  view = None
-        return (mul_21,)""",
+        mul_23: "f32[u0, u1][Max(1, u1), 1]cpu" = torch.ops.aten.mul.Tensor(view, 10);  view = None
+        return (mul_23,)""",
             ignore_comments=True,
             ignore_empty_lines=True,
         )
@@ -5025,8 +5025,8 @@ def forward(self, arg0_1: "i64[2][1]cpu", arg1_1: "Sym(u2)", arg2_1: "Sym(u3)", 
         _assert_scalar_1 = torch.ops.aten._assert_scalar.default(ge_1, "Runtime assertion failed for expression u1 >= 0 on node 'ge_1'");  ge_1 = _assert_scalar_1 = None
         clone: "f32[u0, u1][Max(1, u1), 1]cpu" = torch.ops.aten.clone.default(arg2_1, memory_format = torch.contiguous_format);  arg2_1 = None
         add_3: "f32[u0, u1][Max(1, u1), 1]cpu" = torch.ops.aten.add.Tensor(clone, 1);  clone = None
-        mul_6: "f32[u0, u1][Max(1, u1), 1]cpu" = torch.ops.aten.mul.Tensor(add_3, 100);  add_3 = None
-        return (mul_6,)""",
+        mul_8: "f32[u0, u1][Max(1, u1), 1]cpu" = torch.ops.aten.mul.Tensor(add_3, 100);  add_3 = None
+        return (mul_8,)""",
             ignore_comments=True,
             ignore_empty_lines=True,
         )
@@ -5053,8 +5053,8 @@ def forward(self, arg0_1: "i64[2][1]cpu", arg1_1: "Sym(u2)", arg2_1: "Sym(u3)", 
         ge_1: "Sym(u1 >= 0)" = arg1_1 >= 0;  arg1_1 = None
         _assert_scalar_1 = torch.ops.aten._assert_scalar.default(ge_1, "Runtime assertion failed for expression u1 >= 0 on node 'ge_1'");  ge_1 = _assert_scalar_1 = None
         add: "f32[u0, u1][Max(1, u1), 1]cpu" = torch.ops.aten.add.Tensor(arg2_1, 1);  arg2_1 = None
-        mul_5: "f32[u0, u1][Max(1, u1), 1]cpu" = torch.ops.aten.mul.Tensor(add, 100);  add = None
-        return (mul_5,)""",
+        mul_6: "f32[u0, u1][Max(1, u1), 1]cpu" = torch.ops.aten.mul.Tensor(add, 100);  add = None
+        return (mul_6,)""",
             ignore_comments=True,
             ignore_empty_lines=True,
         )

--- a/test/test_opaque_obj_v2.py
+++ b/test/test_opaque_obj_v2.py
@@ -1767,8 +1767,8 @@ def forward(self, primals, tangents):
     _local_scalar_dense = torch.ops.aten._local_scalar_dense.default(primals_2);  primals_2 = None
     _opaque_obj0 = self._opaque_obj0
     module_mul = torch.ops._TestOpaqueObject.module_mul.default(_opaque_obj0, primals_1, _local_scalar_dense);  _opaque_obj0 = primals_1 = None
-    mul_1 = torch.ops.aten.mul.Tensor(tangents_1, _local_scalar_dense);  tangents_1 = _local_scalar_dense = None
-    return pytree.tree_unflatten([module_mul, mul_1, None], self._out_spec)""",
+    mul_2 = torch.ops.aten.mul.Tensor(tangents_1, _local_scalar_dense);  tangents_1 = _local_scalar_dense = None
+    return pytree.tree_unflatten([module_mul, mul_2, None], self._out_spec)""",
                 )
                 compiled_fn = aot_compile_joint_with_descriptors(joint)
 

--- a/test/test_view_ops.py
+++ b/test/test_view_ops.py
@@ -13,6 +13,7 @@ from torch.testing._internal.common_device_type import (
     dtypesIfMPS,
     instantiate_device_type_tests,
     onlyCPU,
+    onlyNativeDeviceTypes,
     skipLazy,
     skipMeta,
     skipMPS,
@@ -2123,6 +2124,18 @@ class TestOldViewOps(TestCase):
             RuntimeError, "Storage size calculation overflowed"
         ):
             torch.as_strided(t, [1], [1], 2**61 - 1)
+
+    @onlyNativeDeviceTypes
+    def test_as_strided_storage_offset_bounds(self, device):
+        numel = 10
+        t = torch.arange(numel, device=device)
+        size, stride = [3], [1]
+        max_in_bounds_offset = numel - size[0]
+        view = torch.as_strided(t, size, stride, max_in_bounds_offset)
+        self.assertEqual(view, t[max_in_bounds_offset:])
+        with self.assertRaisesRegex(RuntimeError, "out of bounds for storage of size"):
+            torch.as_strided(t, size, stride, max_in_bounds_offset + 1)
+        self.assertEqual(torch.as_strided(t, [0], [1], numel * 100).numel(), 0)
 
     def test_view_all_dtypes_and_devices(self, device):
         for dt in all_types_and_complex_and(torch.half, torch.bfloat16, torch.bool):


### PR DESCRIPTION
Summary: Pull Request resolved: https://github.com/pytorch/pytorch/pull/190560

Differential Revision: D112272085
