### PR TITLE
Restrict test_float8_scale_result to CUDA (builds on #190452)

### DIFF
--- a/aten/src/ATen/native/cuda/ScaledBlas.cpp
+++ b/aten/src/ATen/native/cuda/ScaledBlas.cpp
@@ -384,8 +384,9 @@ _scaled_gemm(
           const std::optional<Tensor>& bias,
           const bool use_fast_accum,
           Tensor& out,
-          const std::optional<Tensor>& alpha = std::nullopt) {
-  cublasCommonArgs args(mat1, mat2, out, scale_a, scale_b, std::nullopt, scaling_choice_a, scaling_choice_b);
+          const std::optional<Tensor>& alpha = std::nullopt,
+          const std::optional<Tensor>& scale_result = std::nullopt) {
+  cublasCommonArgs args(mat1, mat2, out, scale_a, scale_b, scale_result, scaling_choice_a, scaling_choice_b);
   const auto out_dtype_ = args.result->scalar_type();
   // H100 only supports row-major x column-major, but all permutaitons are supported on Blackwells
   if (_scaled_mm_allowed_device(true, false)) {
@@ -662,7 +663,7 @@ _scaled_mm_out_cuda(const Tensor& mat1, const Tensor& mat2,
 #endif
   }
 
-  return _scaled_gemm(mat1, mat2, scale_a, scale_b, scaling_choice_a, scaling_choice_b, bias, use_fast_accum, out);
+  return _scaled_gemm(mat1, mat2, scale_a, scale_b, scaling_choice_a, scaling_choice_b, bias, use_fast_accum, out, /*alpha=*/std::nullopt, scale_result);
 }
 
 Tensor

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -732,6 +732,30 @@ class TestFP8Matmul(TestCase):
         out_fp8_s = scaled_mm_wrap(x, y, scale_a=scale_a, scale_b=scale_b)
         self.assertEqual(out_fp8, out_fp8_s)
 
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
+    def test_float8_scale_result(self, device) -> None:
+        # scale_result must scale the fp8 output. Regression guard for the v1
+        # _scaled_mm path silently dropping scale_result. Integer operands with
+        # K=16 keep the fp32-accumulated products and their 0.5x scaling exact in
+        # e4m3, so any deviation is a real bug rather than floating point rounding.
+        torch.manual_seed(0)
+        M, K, N = 16, 16, 16
+        x = torch.randint(-1, 2, (M, K), device=device).float().to(e4m3_type)
+        # hipblaslt does not yet support mixed e4m3_type input
+        y_type = e4m3_type if torch.version.hip else e5m2_type
+        y = torch.randint(-1, 2, (N, K), device=device).float().to(y_type).t()
+        one = torch.tensor(1.0, device=device)
+        half = torch.tensor(0.5, device=device)
+        out_unscaled = scaled_mm_wrap(
+            x, y, scale_a=one, scale_b=one, scale_result=one,
+            out_dtype=e4m3_type, wrap_v2=False,
+        )
+        out_scaled = scaled_mm_wrap(
+            x, y, scale_a=one, scale_b=one, scale_result=half,
+            out_dtype=e4m3_type, wrap_v2=False,
+        )
+        self.assertEqual(out_scaled.to(torch.float), 0.5 * out_unscaled.to(torch.float))
+
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_MXFP8_GROUPED_GEMM, mxfp8_grouped_mm_skip_msg)
     @parametrize("G", [1, 4, 16])

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -732,6 +732,7 @@ class TestFP8Matmul(TestCase):
         out_fp8_s = scaled_mm_wrap(x, y, scale_a=scale_a, scale_b=scale_b)
         self.assertEqual(out_fp8, out_fp8_s)
 
+    @onlyCUDA
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
     def test_float8_scale_result(self, device) -> None:
         # scale_result must scale the fp8 output. Regression guard for the v1


### PR DESCRIPTION
## Summary
- Builds on #190452, which fixes `_scaled_mm(..., out_dtype=torch.float8_e4m3fn, scale_result=s)` silently dropping `scale_result` on the CUDA cublasLt path (`ScaledBlas.cpp`).
- That PR's new regression test, `test_float8_scale_result`, is device-generic and also gets instantiated for CPU via `instantiate_device_type_tests`. The fix only threads `scale_result` through the CUDA path; the CPU `_scaled_mm` kernel drops `scale_result` independently (a separate, out-of-scope bug), so `TestFP8MatmulCPU::test_float8_scale_result_cpu` fails CI consistently (`AssertionError: Tensor-likes are not close!`) across multiple CI shards.
- This adds `@onlyCUDA` to the test, matching the existing pattern already used for other CUDA-only tests in this file (e.g. `test_error_message_fp8_pre_sm89`, `test_error_message_fp8_pre_sm90`).

## Test plan
- [ ] `test/test_scaled_matmul_cuda.py::TestFP8Matmul::test_float8_scale_result` still runs and passes on CUDA (H100/SM90+).
- [ ] `test/test_scaled_matmul_cuda.py::TestFP8MatmulCPU::test_float8_scale_result_cpu` no longer collected/run (skipped via `@onlyCUDA`).
- [x] Confirmed via CI logs on #190452 that the CPU instance of this test fails consistently pre-fix.