### PR TITLE
[Test] Add hw_classification to test/distributed/test_backends.py 

### DIFF
--- a/test/distributed/test_backends.py
+++ b/test/distributed/test_backends.py
@@ -4,7 +4,11 @@ import os
 
 import torch.distributed as dist
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 """
@@ -13,6 +17,8 @@ common backend API tests
 
 
 class TestMiscCollectiveUtils(TestCase):
+    hw_classification = HardwareClassification.MULTI_ACCELERATOR
+
     def test_device_to_backend_mapping(self, device) -> None:
         """
         Test device to backend mapping

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -123,7 +123,7 @@ class HardwareClassification(Enum):
     values are executed.  When the flag is not specified, all test discovery
     and execution paths remain unchanged.
 
-    Currently there are three hardware classification categories:
+    Currently there are five hardware classification categories:
 
     * ``GENERIC`` – tests that exercise shared, device-agnostic logic
       (e.g. Dynamo dispatcher, FX passes, and other framework internals
@@ -139,6 +139,22 @@ class HardwareClassification(Enum):
     * ``CPU``, ``CUDA``, ``MPS``, ``XPU`` – tests tied to a specific device.
       Use sparingly, and only for device-specific behavior.  These replace
       ``@onlyCPU``, ``@onlyCUDA``, and similar decorators
+
+    * ``MULTI_ACCELERATOR`` – multi-device tests that work across
+      accelerator types (e.g. ``ProcessGroup`` tests using
+      ``DistributedTestBase`` with a runtime-determined backend, or
+      backend-agnostic collective API tests). These test classes typically
+      use :class:`~torch.testing._internal.common_distributed.MultiProcessTestCase`
+      rather than
+      :func:`~torch.testing._internal.common_utils.instantiate_device_type_tests`.
+      FakePG distributed tests should use ``GENERIC`` instead.
+
+    * ``MULTI_ACCELERATOR_CUDA``, ``MULTI_ACCELERATOR_XPU``,
+      ``MULTI_ACCELERATOR_MPS`` – multi-device tests locked to a specific
+      accelerator (e.g. NCCL collectives, NVLink, and peer-to-peer transfers
+      for CUDA; CCL/oneCCL collectives for XPU; or other backend-specific
+      collective libraries). Use sparingly, and only for backend-specific
+      multi-device behavior.
 
     Usage::
 
@@ -159,6 +175,10 @@ class HardwareClassification(Enum):
     CUDA = "cuda"
     MPS = "mps"
     XPU = "xpu"
+    MULTI_ACCELERATOR = "multi_accelerator"
+    MULTI_ACCELERATOR_CUDA = "multi_accelerator_cuda"
+    MULTI_ACCELERATOR_XPU = "multi_accelerator_xpu"
+    MULTI_ACCELERATOR_MPS = "multi_accelerator_mps"
 
 
 # Set by parse_cmd_line_args() if called


### PR DESCRIPTION
## Summary

- Extends `HardwareClassification` enum with `MULTI_ACCELERATOR`, `MULTI_ACCELERATOR_CUDA`, `MULTI_ACCELERATOR_XPU`, `MULTI_ACCELERATOR_MPS` for multi-device distributed tests
- Classifies `TestMiscCollectiveUtils` as `MULTI_ACCELERATOR` (tests backend-agnostic distributed APIs across cpu/cuda/mps/xpu)

Depends on: #190082

## Test Plan

```bash
python test/distributed/test_backends.py -v
python test/distributed/test_backends.py --hw-classification MULTI_ACCELERATOR -v
