### PR TITLE
[inductor] Fix floor-division lowering crash on scalar dividend (#190566)

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3977,6 +3977,18 @@ class CommonTemplate:
 
         self.common(fn, (torch.randn(8),))
 
+    def test_div10(self):
+        # A Python-scalar dividend with floor rounding: the floor-division
+        # lowering seeds constants from an operand via get_dtype(), which fails
+        # when the dividend is a scalar (no get_dtype()) rather than a tensor.
+        def fn(x):
+            return (
+                torch.div(5.0, x, rounding_mode="floor"),
+                torch.floor_divide(5.0, x),
+            )
+
+        self.common(fn, (torch.randn(8),))
+
     @skip_if_triton_cpu  # divide by zero; cannot xfail because it crashes process
     def test_div_zero_dim(self):
         def fn(a, b):

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -7653,9 +7653,13 @@ def _div_rn(a, b):
 
 
 def _floor_div_floating(a, b):
-    nan = constant_like(float("nan"))(a)
-    neg_one = constant_like(-1.0)(a)
-    zero = constant_like(0.0)(a)
+    # Either operand may be a python scalar (e.g. torch.floor_divide(scalar,
+    # tensor)); constant_like needs a tensor for dtype/device/size, so seed the
+    # constants from whichever operand is a tensor.
+    ref = a if isinstance(a, (TensorBox, IRNode)) else b
+    nan = constant_like(float("nan"))(ref)
+    neg_one = constant_like(-1.0)(ref)
+    zero = constant_like(0.0)(ref)
 
     def fn(a, b, nan, neg_one, zero):
         quotient = ops.div_rn(a, b)


### PR DESCRIPTION
Summary:

`_floor_div_floating` in `torch/_inductor/lowering.py` seeds its `nan`/`-1`/`0`
constants with `constant_like(...)(a)`, which calls `a.get_dtype()` and therefore
assumes the dividend `a` is a tensor. When the dividend is a Python scalar --
e.g. `torch.floor_divide(5.0, x)` or `torch.div(5.0, x, rounding_mode="floor")` --
lowering raised `AttributeError: 'float' object has no attribute 'get_dtype'`,
surfaced as `InductorError: LoweringException` / `torch.inductor compilation failed`.

This regressed scalar-numerator floor division after the floor-div nonfinite fix
(#188049) introduced `_floor_div_floating`.

Fix: seed the constants from whichever operand is a tensor (`TensorBox`/`IRNode`).
The tensor // tensor path is unchanged (`ref` is still `a`); only the previously
crashing scalar-dividend case is affected. `make_pointwise` still handles the
broadcast and type promotion of both operands.

Test Plan:
Added `test_div10` in `test/inductor/test_torchinductor.py`, exercising floor
rounding and `torch.floor_divide` with a Python-scalar dividend. It raises a
`LoweringException` before this change and matches eager afterwards.

Reviewed By: jansel

Differential Revision: D112846962




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo