### PR TITLE
Remove obsolete CUTLASS compatibility versioning

### DIFF
--- a/cmake/FileMirroring.cmake
+++ b/cmake/FileMirroring.cmake
@@ -39,10 +39,6 @@ install(DIRECTORY
 # on CUDA-enabled builds (cutlass submodule should be present).
 set(_cutedsl_rel_path "examples/python/CuTeDSL/cute/blackwell/kernel/grouped_gemm/grouped_gemm.py")
 set(_cutedsl_src "${PROJECT_SOURCE_DIR}/third_party/cutlass/${_cutedsl_rel_path}")
-if(NOT EXISTS "${_cutedsl_src}")
-  set(_cutedsl_rel_path "examples/python/CuTeDSL/blackwell/grouped_gemm.py")
-  set(_cutedsl_src "${PROJECT_SOURCE_DIR}/third_party/cutlass/${_cutedsl_rel_path}")
-endif()
 if(EXISTS "${_cutedsl_src}")
   set(_cutedsl_dest "${SKBUILD_PLATLIB_DIR}/torch/_inductor/kernel/vendored_templates/cutedsl/kernels")
   install(FILES "${_cutedsl_src}"

--- a/torch/csrc/distributed/c10d/cuda/cutlass/gemm/kernel/persistent_async_input_scheduler.cuh
+++ b/torch/csrc/distributed/c10d/cuda/cutlass/gemm/kernel/persistent_async_input_scheduler.cuh
@@ -32,7 +32,6 @@
 
 #pragma once
 #include <cutlass/gemm/kernel/static_tile_scheduler.hpp>
-#include <cutlass/version.h>
 
 namespace {
 
@@ -219,11 +218,7 @@ public:
 
   CUTLASS_HOST_DEVICE
   static bool
-#if defined(CUTLASS_VERSION) && CUTLASS_VERSION >= 450
   can_implement(Arguments const& args, KernelHardwareInfo const&) {
-#else
-  can_implement(Arguments const& args) {
-#endif
     return args.max_swizzle_size >= 1;
   }
 


### PR DESCRIPTION
## Summary

PR #189332 temporarily kept compatibility with older CUTLASS checkouts while pins converged on 4.5.3. All CUTLASS pins now use 4.5.3, so remove the old CuTeDSL path fallback and make the current scheduler signature unconditional. This also removes the now-unused `cutlass/version.h` include.

## Test Plan

```
conda run -p /home/henrylhtsang/pytorch/agent_space/lintrunner-env spin quicklint
```

```
conda run -p /home/henrylhtsang/pytorch/agent_space/lintrunner-env lintrunner -a
```

```
git diff HEAD^ --check
```

```
test -f third_party/cutlass/examples/python/CuTeDSL/cute/blackwell/kernel/grouped_gemm/grouped_gemm.py
```

Authored with assistance from an AI assistant.