### PR TITLE
[cuda] Add replay and graph-destroy lifecycle hooks to CUDAGraph

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3283,6 +3283,143 @@ torch.cuda.synchronize()
         self.assertEqual(len(instantiated), 2)
 
     @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    def test_graph_replay_hooks(self):
+        x = torch.randn(8, device="cuda")
+
+        # replay hooks fire start-then-end, in registration order, on every
+        # replay; removable, and a no-op (hot path) once removed.
+        events: list[str] = []
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g):
+            x + 1
+        start_handle = g.register_replay_start_hook(lambda _g: events.append("start"))
+        end_handle = g.register_replay_end_hook(lambda _g: events.append("end"))
+        g.replay()
+        g.replay()
+        self.assertEqual(events, ["start", "end", "start", "end"])
+        end_handle.remove()
+        events.clear()
+        g.replay()
+        self.assertEqual(events, ["start"])
+        start_handle.remove()
+        events.clear()
+        g.replay()
+        self.assertEqual(events, [])
+
+        # end hook fires even if the launch raises (start balanced by end), and
+        # the launch error still propagates.
+        events.clear()
+        g.register_replay_start_hook(lambda _g: events.append("start"))
+        g.register_replay_end_hook(lambda _g: events.append("end"))
+        with unittest.mock.patch.object(
+            torch._C._CUDAGraph, "replay", side_effect=RuntimeError("boom")
+        ):
+            with self.assertRaisesRegex(RuntimeError, "boom"):
+                g.replay()
+        self.assertEqual(events, ["start", "end"])
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    @unittest.skipIf(
+        torch.cuda.graphs._cuda_runtime is None,
+        "graph destroy callbacks require the cuda-bindings package",
+    )
+    def test_graph_destroy_callback(self):
+        import gc
+        import time
+
+        def wait_for(pred, timeout=5.0):
+            # The user-object destructor runs asynchronously on a CUDA driver
+            # thread (cudaUserObjectNoDestructorSync), so poll for it.
+            end = time.time() + timeout
+            while time.time() < end and not pred():
+                time.sleep(0.005)
+            return pred()
+
+        x = torch.randn(8, device="cuda")
+
+        # fires once when the graph is destroyed (reset), not on capture/replay.
+        fired = []
+        g = torch.cuda.CUDAGraph()
+        g.register_graph_destroy_callback(lambda: fired.append(1))
+        with torch.cuda.graph(g):
+            x + 1
+        g.replay()
+        torch.cuda.synchronize()
+        self.assertEqual(fired, [])  # not on capture or replay
+        g.reset()
+        self.assertTrue(wait_for(lambda: fired == [1]), fired)  # on destruction
+
+        # fires via garbage collection of the wrapper too.
+        gc_fired = []
+        g2 = torch.cuda.CUDAGraph()
+        g2.register_graph_destroy_callback(lambda: gc_fired.append(1))
+        with torch.cuda.graph(g2):
+            x + 1
+        del g2
+        gc.collect()
+        self.assertTrue(wait_for(lambda: gc_fired == [1]), gc_fired)
+
+        # remove() before capture deregisters.
+        removed = []
+        g3 = torch.cuda.CUDAGraph()
+        handle = g3.register_graph_destroy_callback(lambda: removed.append(1))
+        handle.remove()
+        with torch.cuda.graph(g3):
+            x + 1
+        g3.reset()
+        self.assertFalse(wait_for(lambda: removed == [1], timeout=0.5), removed)
+
+        # registering after capture ends is rejected.
+        g4 = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g4):
+            x + 1
+        with self.assertRaisesRegex(RuntimeError, "before the graph's capture ends"):
+            g4.register_graph_destroy_callback(lambda: None)
+
+        # keep_graph=True: fires once both the template and exec are destroyed by
+        # reset(), not on instantiate/replay.
+        kept_fired = []
+        g5 = torch.cuda.CUDAGraph(keep_graph=True)
+        g5.register_graph_destroy_callback(lambda: kept_fired.append(1))
+        with torch.cuda.graph(g5, capture_error_mode="relaxed"):
+            x + 1
+        g5.instantiate()
+        g5.replay()
+        torch.cuda.synchronize()
+        self.assertEqual(kept_fired, [])
+        g5.reset()
+        self.assertTrue(wait_for(lambda: kept_fired == [1]), kept_fired)
+
+        # multiple callbacks all fire on destruction.
+        multi = []
+        g6 = torch.cuda.CUDAGraph()
+        g6.register_graph_destroy_callback(lambda: multi.append("a"))
+        g6.register_graph_destroy_callback(lambda: multi.append("b"))
+        with torch.cuda.graph(g6):
+            x + 1
+        g6.reset()
+        self.assertTrue(wait_for(lambda: sorted(multi) == ["a", "b"]), multi)
+
+        # re-capturing after reset() re-arms: a fresh callback fires on the next
+        # destruction (reset clears the prior registration).
+        rearm = []
+        g7 = torch.cuda.CUDAGraph()
+        g7.register_graph_destroy_callback(lambda: rearm.append("first"))
+        with torch.cuda.graph(g7):
+            x + 1
+        g7.reset()
+        self.assertTrue(wait_for(lambda: rearm == ["first"]), rearm)
+        g7.register_graph_destroy_callback(lambda: rearm.append("second"))
+        with torch.cuda.graph(g7):
+            x + 1
+        g7.reset()
+        self.assertTrue(wait_for(lambda: rearm == ["first", "second"]), rearm)
+
+    @unittest.skipIf(
         not TEST_CUDA_GRAPH,
         "CUDA >= 11.0 / ROCm >= 7.0 required for external events in cuda graphs",
     )

--- a/torch/cuda/graphs.py
+++ b/torch/cuda/graphs.py
@@ -108,6 +108,75 @@ def _require_cuda_bindings() -> None:
         )
 
 
+# Graph-destroy callbacks are retained on a CUDA user object (see
+# CUDAGraph.register_graph_destroy_callback). CUDA invokes the destructor on a
+# driver thread once the graph -- and every executable graph instantiated from it
+# -- is destroyed, possibly after the CUDAGraph wrapper is gone, so the ctypes
+# trampoline and the snapshotted callbacks must outlive the wrapper. Keep them
+# here, keyed by a token passed as the user object's pointer and echoed back to
+# the destructor, and drop the entry when it fires. The trampoline is a single
+# shared, stateless C callback.
+_graph_destroy_callbacks: dict[int, list[Callable[[], None]]] = {}
+_graph_destroy_next_token = 0
+_graph_destroy_trampoline: typing.Any = None
+
+
+def _graph_destroy_dispatch(user_ptr: typing.Any) -> None:
+    # Runs on a CUDA driver thread once a graph holding our user object is fully
+    # destroyed. user_ptr is the token passed to cudaUserObjectCreate. The user
+    # object destructor is a CUDA host function, bound by the cuLaunchHostFunc_v2
+    # restrictions: "The host function must not make any CUDA API calls. Attempting
+    # to use a CUDA API may result in CUDA_ERROR_NOT_PERMITTED, but this is not
+    # required. The host function must not perform any synchronization that may
+    # depend on outstanding CUDA work not mandated to run earlier. Host functions
+    # without a mandated order (such as in independent streams) execute in undefined
+    # order and may be serialized." So: no CUDA calls, never raise into the driver,
+    # stay cheap.
+    # https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__EXEC.html#group__CUDA__EXEC_1g455b2a1a09e543e5f0cd058acd6c55ab
+    import sys
+
+    entry = _graph_destroy_callbacks.pop(int(user_ptr or 0), None)
+    if entry is None or sys.is_finalizing():
+        return
+    for cb in entry:
+        try:
+            cb()
+        except Exception:
+            pass
+
+
+def _retain_graph_destroy_callbacks(
+    raw_graph: int, callbacks: list[Callable[[], None]]
+) -> None:
+    """Retain a CUDA user object on ``raw_graph`` (a live ``cudaGraph_t``
+    template) whose destructor fires ``callbacks`` once the graph and every
+    executable graph instantiated from it are destroyed."""
+    import ctypes
+
+    assert _cuda_runtime is not None  # noqa: S101
+    global _graph_destroy_next_token, _graph_destroy_trampoline
+    if _graph_destroy_trampoline is None:
+        _graph_destroy_trampoline = ctypes.CFUNCTYPE(None, ctypes.c_void_p)(
+            _graph_destroy_dispatch
+        )
+    _graph_destroy_next_token += 1
+    token = _graph_destroy_next_token
+    _graph_destroy_callbacks[token] = list(callbacks)
+    addr = ctypes.cast(_graph_destroy_trampoline, ctypes.c_void_p).value
+    no_sync = int(_cuda_runtime.cudaUserObjectFlags.cudaUserObjectNoDestructorSync)
+    move = int(_cuda_runtime.cudaUserObjectRetainFlags.cudaGraphUserObjectMove)
+    try:
+        obj = _check_cuda_bindings(
+            _cuda_runtime.cudaUserObjectCreate(token, addr, 1, no_sync)
+        )
+        _check_cuda_bindings(
+            _cuda_runtime.cudaGraphRetainUserObject(raw_graph, obj, 1, move)
+        )
+    except Exception:
+        _graph_destroy_callbacks.pop(token, None)
+        raise
+
+
 # Python shim helps Sphinx process docstrings more reliably.
 class CUDAGraph(_CUDAGraph):
     r"""Wrapper around a CUDA graph.
@@ -151,6 +220,17 @@ class CUDAGraph(_CUDAGraph):
     # User hooks fired by capture_end / instantiate (see register_*_hook).
     _capture_end_hooks: dict[int, Callable[[CUDAGraph], None]]
     _post_instantiate_hooks: dict[int, Callable[[CUDAGraph], None]]
+    # Replay lifecycle hooks, fired around each replay (hot path -- only iterated
+    # when non-empty). See register_replay_start_hook / register_replay_end_hook.
+    _replay_start_hooks: dict[int, Callable[[CUDAGraph], None]]
+    _replay_end_hooks: dict[int, Callable[[CUDAGraph], None]]
+    # Callbacks retained on a CUDA user object (see register_graph_destroy_callback):
+    # snapshotted and retained on the template at capture_end so CUDA fires them
+    # once the graph is fully destroyed.
+    _destroy_callbacks: dict[int, Callable[[], None]]
+    # Set at capture_end (registration must precede it, while the template is
+    # live); cleared on reset() so a re-captured graph can register again.
+    _capture_finalized: bool
 
     def __new__(cls, keep_graph: bool = False) -> Self:
         instance = super().__new__(cls, keep_graph)
@@ -161,6 +241,10 @@ class CUDAGraph(_CUDAGraph):
         # OrderedDict (not dict): RemovableHandle weak-references the mapping.
         instance._capture_end_hooks = OrderedDict()
         instance._post_instantiate_hooks = OrderedDict()
+        instance._replay_start_hooks = OrderedDict()
+        instance._replay_end_hooks = OrderedDict()
+        instance._destroy_callbacks = OrderedDict()
+        instance._capture_finalized = False
         return instance
 
     def register_capture_end_hook(
@@ -192,6 +276,99 @@ class CUDAGraph(_CUDAGraph):
         handle = RemovableHandle(self._post_instantiate_hooks)
         self._post_instantiate_hooks[handle.id] = hook
         return handle
+
+    def register_replay_start_hook(
+        self, hook: Callable[[CUDAGraph], None]
+    ) -> RemovableHandle:
+        r"""Register ``hook(graph)`` to run at the start of every :meth:`replay`,
+        just before the graph is launched (after any on-demand instantiation, so
+        :meth:`raw_cuda_graph_exec` is valid). Hooks fire in registration order.
+        Returns a handle whose ``remove()`` deregisters the hook.
+
+        .. note::
+            Replay is the hot path and a registered hook runs on every replay --
+            keep it cheap. With no hook registered the cost is a single dict
+            emptiness check.
+        """
+        from torch.utils.hooks import RemovableHandle
+
+        handle = RemovableHandle(self._replay_start_hooks)
+        self._replay_start_hooks[handle.id] = hook
+        return handle
+
+    def register_replay_end_hook(
+        self, hook: Callable[[CUDAGraph], None]
+    ) -> RemovableHandle:
+        r"""Register ``hook(graph)`` to run at the end of every :meth:`replay`,
+        just after the graph is launched. The launch is asynchronous, so the hook
+        runs once the replay is *enqueued*, not once the GPU work completes. Hooks
+        fire in registration order. Returns a handle whose ``remove()``
+        deregisters the hook. See the hot-path note on
+        :meth:`register_replay_start_hook`.
+
+        End hooks fire even if the launch raises -- so a start hook is always
+        balanced by an end -- and the launch error then propagates. (Start hooks
+        that raise abort the replay before launch, and no end hook fires.)
+        """
+        from torch.utils.hooks import RemovableHandle
+
+        handle = RemovableHandle(self._replay_end_hooks)
+        self._replay_end_hooks[handle.id] = hook
+        return handle
+
+    def register_graph_destroy_callback(
+        self, callback: Callable[[], None]
+    ) -> RemovableHandle:
+        r"""Register ``callback()`` to run once when this graph is destroyed by
+        CUDA -- after the captured ``cudaGraph_t`` and every ``cudaGraphExec_t``
+        instantiated from it are released (via :meth:`reset` or garbage collection
+        of this wrapper). Implemented by retaining a CUDA user object on the graph
+        (``cudaGraphRetainUserObject``), so it is tied to the graph's true
+        lifetime: it fires only once the graph is fully gone and no replay can
+        still reference its resources -- it does not fire on capture or replay.
+
+        The callback takes no arguments; capture any needed context (e.g. an exec
+        graph id) in a closure. It must be registered before capture ends (the
+        user object is retained at :meth:`capture_end`, while the template is
+        live). Returns a handle whose ``remove()`` deregisters the callback, which
+        is only effective before capture ends. Requires the ``cuda.bindings``
+        package.
+
+        Because it fires only once nothing can reference the graph anymore, this
+        is the correct signal for releasing resources whose lifetime must outlast
+        the graph and its replays (e.g. host/pinned buffers it read) and for
+        evicting per-graph external state keyed by its ids.
+
+        .. warning::
+            The callback runs on a CUDA driver thread, asynchronously, at
+            graph-destruction time -- not the Python thread. Per CUDA
+            host-function rules it must not call the CUDA runtime/driver API, must
+            be cheap and non-blocking, and must not capture this ``CUDAGraph``
+            (that would keep it alive and prevent destruction). Exceptions are
+            swallowed. To actually free CUDA resources, hand off to a normal thread
+            that this callback signals rather than calling CUDA here.
+        """
+        if self._capture_finalized:
+            raise RuntimeError(
+                "register_graph_destroy_callback must be called before the graph's "
+                "capture ends; the destroy user object is retained at capture_end."
+            )
+        from torch.utils.hooks import RemovableHandle
+
+        handle = RemovableHandle(self._destroy_callbacks)
+        self._destroy_callbacks[handle.id] = callback
+        return handle
+
+    def _retain_destroy_user_object(self) -> None:
+        # Retain one CUDA user object on the live template so the registered
+        # destroy callbacks fire when the graph is fully destroyed. Called from
+        # capture_end before instantiate().
+        if not self._destroy_callbacks:
+            return
+        _require_cuda_bindings()
+        _retain_graph_destroy_callbacks(
+            self.raw_cuda_graph(), list(self._destroy_callbacks.values())
+        )
 
     def _maybe_remap_annotations(self) -> None:
         # Remap recorded kernel annotations to the current exec graph id. No-op
@@ -291,6 +468,8 @@ class CUDAGraph(_CUDAGraph):
         maybe_stamp_capture_graph_id(self)
         for hook in list(self._capture_end_hooks.values()):
             hook(self)
+        self._retain_destroy_user_object()
+        self._capture_finalized = True
         if not self._keep_graph:
             # Route keep_graph=False instantiation through Python so the remap
             # and post-instantiate hooks fire from instantiate().
@@ -318,7 +497,15 @@ class CUDAGraph(_CUDAGraph):
         # annotation remap rides on instantiate(), so it is handled by that call.
         if not self._has_graph_exec:
             self.instantiate()
-        super().replay()
+        if self._replay_start_hooks:
+            for hook in list(self._replay_start_hooks.values()):
+                hook(self)
+        try:
+            super().replay()
+        finally:
+            if self._replay_end_hooks:
+                for hook in list(self._replay_end_hooks.values()):
+                    hook(self)
 
     def reset(self) -> None:
         r"""Delete the graph currently held by this instance."""
@@ -327,6 +514,8 @@ class CUDAGraph(_CUDAGraph):
             self._tracker = None
         self._capture_graph_id = None
         self._remapped_exec_id = None
+        self._destroy_callbacks.clear()
+        self._capture_finalized = False
         super().reset()
 
     def pool(self) -> _POOL_HANDLE:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #190570

Extends the capture-end / post-instantiate hooks from #187749 with the
remaining CUDAGraph lifecycle points.

register_replay_start_hook / register_replay_end_hook run around each replay().
Replay is the hot path, so the hook lists are only iterated when non-empty; the
end hooks run in a finally so a start is always balanced by an end even if the
launch raises (the error still propagates).

register_graph_destroy_callback ties a callback to the graph's true CUDA
lifetime by retaining a CUDA user object on the template at capture_end
(cudaGraphRetainUserObject); CUDA fires the destructor once the graph and every
executable graph instantiated from it are destroyed -- via reset() or wrapper
GC -- so it does not fire on capture or replay and cannot tear down state the
graph or an in-flight replay still references. The destructor runs on a CUDA
driver thread under the cuLaunchHostFunc_v2 restrictions (no CUDA calls, cheap,
non-blocking); the retained user object and the module-level dispatch registry
self-clean when the destructor fires.

Implemented purely in Python via cuda.bindings, matching how debug_dump /
get_graph_data already call the runtime.

This PR was authored with the assistance of an AI coding assistant.