### PR TITLE
[ROCm][CI] Add rocm7.14 manylinux2_28-builder image (TheRock wheels)

### DIFF
--- a/.ci/docker/common/install_rocm.sh
+++ b/.ci/docker/common/install_rocm.sh
@@ -2,11 +2,6 @@
 
 set -ex
 
-# for pip_install function
-source "$(dirname "${BASH_SOURCE[0]}")/common_utils.sh"
-
-ROCM_COMPOSABLE_KERNEL_VERSION="$(cat $(dirname $0)/../ci_commit_pins/rocm-composable-kernel.txt)"
-
 ver() {
     printf "%3d%03d%03d%03d" $(echo "$1" | tr '.' ' ');
 }
@@ -267,11 +262,54 @@ ROCM_ENV
     fi
 }
 
+install_almalinux() {
+    # ROCm from the multi-arch TheRock wheel index (used by the manywheel builder
+    # image). Distro-agnostic pip install; no OS packages. The ROCm SDK unpacks
+    # under <site-packages>/_rocm_sdk_* and its real install root is discovered via
+    # `rocm-sdk path` and exported through /etc/rocm_env.sh (no /opt/rocm symlink);
+    # build_env_setup.py / repair_wheel.py discover ROCM_HOME from there. Mirrors #188429.
+    local THEROCK_INDEX_URL="${THEROCK_INDEX_URL:-https://repo.amd.com/rocm/whl-multi-arch/}"
+    # ROCM_VERSION is the ROCm minor line (e.g. "7.14"); resolve to newest 7.14.x.
+    local ROCM_VERSION="${ROCM_VERSION:-7.14}"
+    local ROCM_PIP_SPEC="rocm[libraries,devel,device-all]==${ROCM_VERSION}.*"
+
+    echo "=============================================="
+    echo "ROCm Multi-Arch Wheel Installation (TheRock)"
+    echo "Index URL:  ${THEROCK_INDEX_URL}"
+    echo "ROCm spec:  ${ROCM_PIP_SPEC}"
+    echo "=============================================="
+
+    # device-all pulls kernels for every supported gfx target (multi-arch wheel);
+    # libraries+devel provide the runtime libs + headers/hipcc to compile against ROCm.
+    python3 -m pip install --index-url "${THEROCK_INDEX_URL}" "${ROCM_PIP_SPEC}"
+
+    # Discover the real install root/bin via the rocm-sdk CLI (rocm-sdk-core wheel).
+    local ROCM_HOME ROCM_BIN ROCM_SYSDEPS_LIB
+    ROCM_HOME="$(rocm-sdk path --root)"
+    ROCM_BIN="$(rocm-sdk path --bin)"
+    ROCM_SYSDEPS_LIB="${ROCM_HOME}/lib/rocm_sysdeps/lib"
+
+    # Environment file (sourced by CI scripts); paths point at the real wheel root,
+    # not /opt/rocm.
+    cat > /etc/rocm_env.sh << ROCM_ENV
+export ROCM_PATH="${ROCM_HOME}"
+export ROCM_HOME="${ROCM_HOME}"
+export PATH="${ROCM_BIN}:\${PATH}"
+export LD_LIBRARY_PATH="${ROCM_HOME}/lib:${ROCM_SYSDEPS_LIB}:\${LD_LIBRARY_PATH:-}"
+ROCM_ENV
+    echo "source /etc/rocm_env.sh" >> /etc/bashrc || true
+
+    echo "TheRock ROCm wheel install complete: ROCM_HOME=${ROCM_HOME}"
+}
+
 # Install Python packages depending on the base OS
 ID=$(grep -oP '(?<=^ID=).+' /etc/os-release | tr -d '"')
 case "$ID" in
   ubuntu)
     install_ubuntu
+    ;;
+  almalinux)
+    install_almalinux
     ;;
   *)
     echo "Unable to determine OS..."

--- a/.ci/docker/common/install_rocm.sh
+++ b/.ci/docker/common/install_rocm.sh
@@ -295,7 +295,6 @@ install_almalinux() {
 export ROCM_PATH="${ROCM_HOME}"
 export ROCM_HOME="${ROCM_HOME}"
 export PATH="${ROCM_BIN}:\${PATH}"
-export LD_LIBRARY_PATH="${ROCM_HOME}/lib:${ROCM_SYSDEPS_LIB}:\${LD_LIBRARY_PATH:-}"
 ROCM_ENV
     echo "source /etc/rocm_env.sh" >> /etc/bashrc || true
 

--- a/.ci/docker/manywheel/Dockerfile_2_28
+++ b/.ci/docker/manywheel/Dockerfile_2_28
@@ -142,7 +142,7 @@ COPY --from=cuda     /usr/local/cupti-headers-13.3         /usr/local/cupti-head
 RUN ln -sf /usr/local/cuda-${BASE_CUDA_VERSION} /usr/local/cuda
 ENV PATH=/usr/local/cuda/bin:$PATH
 
-FROM cpu_final as rocm_final
+FROM cpu_final as rocm_final_legacy
 ARG ROCM_VERSION=6.0
 ARG PYTORCH_ROCM_ARCH
 ENV PYTORCH_ROCM_ARCH ${PYTORCH_ROCM_ARCH}
@@ -170,6 +170,26 @@ RUN bash ./install_rocSHMEM.sh ${ROCM_VERSION} && rm install_rocSHMEM.sh
 
 ADD ./common/install_miopen.sh install_miopen.sh
 RUN bash ./install_miopen.sh ${ROCM_VERSION} && rm install_miopen.sh
+
+FROM cpu_final as rocm_final
+ARG PYTORCH_ROCM_ARCH
+ENV PYTORCH_ROCM_ARCH ${PYTORCH_ROCM_ARCH}
+ARG DEVTOOLSET_VERSION=13
+ARG ROCM_VERSION=7.14
+# ROCm is installed from the multi-arch TheRock wheel index instead of the
+# rocm/dev-almalinux-8 OS packages. install_rocm.sh dispatches to install_almalinux
+# on this AlmaLinux base (THEROCK_INDEX_URL set): it pip-installs the ROCm SDK and
+# writes /etc/rocm_env.sh pointing at the real _rocm_sdk_* root; build_env_setup.py /
+# repair_wheel.py discover ROCM_HOME from there. No /opt/rocm symlink.
+ARG THEROCK_INDEX_URL=https://repo.amd.com/rocm/whl-multi-arch/
+ENV MKLROOT /opt/intel
+# cmake-3.28.4 from pip to get enable_language(HIP)
+RUN python3 -m pip install --upgrade pip && \
+    python3 -mpip install cmake==3.28.4
+ADD ./common/install_rocm.sh install_rocm.sh
+RUN THEROCK_INDEX_URL=${THEROCK_INDEX_URL} ROCM_VERSION=${ROCM_VERSION} bash ./install_rocm.sh && rm install_rocm.sh
+# ROCm rocm-smi depends on the system drm.h header
+RUN yum install -y libdrm-devel
 
 FROM cpu_final as xpu_final
 # XPU CD use rolling driver

--- a/.ci/docker/manywheel/build.sh
+++ b/.ci/docker/manywheel/build.sh
@@ -75,28 +75,42 @@ case ${image} in
         DOCKERFILE_SUFFIX="_cuda_aarch64"
         ;;
     manylinux2_28-builder:rocm*)
-        # we want the patch version of 7.2 instead
-        if [[ "$GPU_ARCH_VERSION" == *"7.2"* ]]; then
-            GPU_ARCH_VERSION="${GPU_ARCH_VERSION}.1"
-        fi
-        # we want the patch version of 7.1 instead
-        if [[ "$GPU_ARCH_VERSION" == *"7.1"* ]]; then
-            GPU_ARCH_VERSION="${GPU_ARCH_VERSION}.1"
-        fi
-        # we want the patch version of 7.0 instead
-        if [[ "$GPU_ARCH_VERSION" == *"7.0"* ]]; then
-            GPU_ARCH_VERSION="${GPU_ARCH_VERSION}.2"
-        fi
-        # we want the patch version of 6.4 instead
-        if [[ "$GPU_ARCH_VERSION" == *"6.4"* ]]; then
-            GPU_ARCH_VERSION="${GPU_ARCH_VERSION}.4"
-        fi
-        TARGET=rocm_final
         MANY_LINUX_VERSION="2_28"
         DEVTOOLSET_VERSION="13"
-        GPU_IMAGE=rocm/dev-almalinux-8:${GPU_ARCH_VERSION}-complete
-        PYTORCH_ROCM_ARCH="gfx900;gfx906;gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1103;gfx1200;gfx1201;gfx950;gfx1150;gfx1151"
-        DOCKER_GPU_BUILD_ARG="--build-arg ROCM_VERSION=${GPU_ARCH_VERSION} --build-arg PYTORCH_ROCM_ARCH=${PYTORCH_ROCM_ARCH} --build-arg DEVTOOLSET_VERSION=${DEVTOOLSET_VERSION}"
+        # Common gfx arch list shared by all ROCm builds; each path extends it.
+        PYTORCH_ROCM_ARCH="gfx908;gfx90a;gfx942;gfx950;gfx1030;gfx1100;gfx1101;gfx1102;gfx1103;gfx1200;gfx1201;gfx1150;gfx1151"
+        if [[ "$GPU_ARCH_VERSION" == *"7.14"* ]]; then
+            # ROCm 7.14 installs from the multi-arch TheRock wheel index
+            # (https://repo.amd.com/rocm/whl-multi-arch/) instead of the
+            # rocm/dev-almalinux-8 OS packages, so start from a plain almalinux base.
+            TARGET=rocm_final
+            GPU_IMAGE=amd64/almalinux:8
+            THEROCK_INDEX_URL="https://repo.amd.com/rocm/whl-multi-arch/"
+            DOCKER_GPU_BUILD_ARG="--build-arg ROCM_VERSION=${GPU_ARCH_VERSION} --build-arg PYTORCH_ROCM_ARCH=${PYTORCH_ROCM_ARCH} --build-arg DEVTOOLSET_VERSION=${DEVTOOLSET_VERSION} --build-arg THEROCK_INDEX_URL=${THEROCK_INDEX_URL}"
+        else
+            # Earlier ROCm versions install from the rocm/dev-almalinux-8 OS packages.
+            # we want the patch version of 7.2 instead
+            if [[ "$GPU_ARCH_VERSION" == *"7.2"* ]]; then
+                GPU_ARCH_VERSION="${GPU_ARCH_VERSION}.1"
+            fi
+            # we want the patch version of 7.1 instead
+            if [[ "$GPU_ARCH_VERSION" == *"7.1"* ]]; then
+                GPU_ARCH_VERSION="${GPU_ARCH_VERSION}.1"
+            fi
+            # we want the patch version of 7.0 instead
+            if [[ "$GPU_ARCH_VERSION" == *"7.0"* ]]; then
+                GPU_ARCH_VERSION="${GPU_ARCH_VERSION}.2"
+            fi
+            # we want the patch version of 6.4 instead
+            if [[ "$GPU_ARCH_VERSION" == *"6.4"* ]]; then
+                GPU_ARCH_VERSION="${GPU_ARCH_VERSION}.4"
+            fi
+            TARGET=rocm_final_legacy
+            GPU_IMAGE=rocm/dev-almalinux-8:${GPU_ARCH_VERSION}-complete
+            # Legacy images also cover the older gfx900/gfx906 targets.
+            PYTORCH_ROCM_ARCH="gfx900;gfx906;${PYTORCH_ROCM_ARCH}"
+            DOCKER_GPU_BUILD_ARG="--build-arg ROCM_VERSION=${GPU_ARCH_VERSION} --build-arg PYTORCH_ROCM_ARCH=${PYTORCH_ROCM_ARCH} --build-arg DEVTOOLSET_VERSION=${DEVTOOLSET_VERSION}"
+        fi
         ;;
     manylinux2_28-builder:xpu)
         TARGET=xpu_final

--- a/.github/workflows/build-manywheel-images.yml
+++ b/.github/workflows/build-manywheel-images.yml
@@ -69,6 +69,7 @@ jobs:
           { name: "manylinuxaarch64-builder",       tag: "cuda12.6",          runner: "${{ needs.select-runner.outputs.arm64 }}" },
           { name: "manylinux2_28-builder",          tag: "rocm7.1",           runner: "${{ needs.select-runner.outputs.x86 }}" },
           { name: "manylinux2_28-builder",          tag: "rocm7.2",           runner: "${{ needs.select-runner.outputs.x86 }}" },
+          { name: "manylinux2_28-builder",          tag: "rocm7.14",          runner: "${{ needs.select-runner.outputs.x86 }}" },
           { name: "manylinux2_28-builder",          tag: "cpu",               runner: "${{ needs.select-runner.outputs.x86 }}" },
           { name: "manylinux2_28_aarch64-builder",  tag: "cpu-aarch64",       runner: "${{ needs.select-runner.outputs.arm64 }}" },
           { name: "manylinux2_28-builder",          tag: "xpu",               runner: "${{ needs.select-runner.outputs.x86 }}" },


### PR DESCRIPTION
## Summary

Adds the ROCm 7.14 `manylinux2_28-builder` image, installing ROCm from the multi-arch TheRock wheel index (`https://repo.amd.com/rocm/whl-multi-arch/`) instead of the `rocm/dev-almalinux-8` OS packages.

**Split from the wheel-matrix PR #190276** so this image lands and publishes first; #190276 then consumes it. With `ciflow/docker` this builds + pushes the content-addressed image to ECR for PR testing (per #190749); on merge to `main` it publishes `pytorch/manylinux2_28-builder:rocm7.14` to Docker Hub.

## Changes

- `.ci/docker/common/install_rocm.sh`: add `install_almalinux()` (mirrors `install_ubuntu()`) that installs ROCm from the TheRock wheel index (`rocm[libraries,devel,device-all]==7.14.*`), discovers the root via `rocm-sdk path`, and writes `/etc/rocm_env.sh` pointing at the real `_rocm_sdk_*` root (no `/opt/rocm` symlink); dispatched on `ID=almalinux`. The `common_utils`/composable-kernel sourcing moves into `install_ubuntu()` (apt path only).
- `.ci/docker/manywheel/Dockerfile_2_28`: `rocm_final` stage uses plain almalinux base running `install_rocm.sh` with `THEROCK_INDEX_URL`/`ROCM_VERSION`; `rocm_final_legacy` stage uses rocm/dev-almalinux-8 docker images as base (not published for any ROCm versions >7.2), which already has ROCm installed. 
- `.ci/docker/manywheel/build.sh`: `rocm7.14` case (`TARGET=rocm_wheel_final`, `GPU_IMAGE=amd64/almalinux:8`).
- `.github/workflows/build-manywheel-images.yml`: add the `rocm7.14` builder-image tag.

## Validation

Built `manylinux2_28-builder:rocm7.14` locally end-to-end: `install_almalinux` installs 7.14 from `repo.amd.com`; `hipcc --version` reports HIP 7.14.60850; `$ROCM_HOME/lib` has the runtime `.so`s and `lib/rocm_sysdeps/lib`.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang
