### PR TITLE
skip test_hip_device_count on ROCm

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5061,6 +5061,7 @@ with torch.cuda.graph(g):
             )
             self.assertEqual(rc, "3")
 
+    @unittest.skipIf(TEST_WITH_ROCM, "Failed on ROCm 7.14+ due to a rocprofiler-sdk issue")
     @unittest.skipIf(not TEST_WITH_ROCM, "not relevant for CUDA testing")
     def test_hip_device_count(self):
         """Validate device_count works with both CUDA/HIP visible devices"""


### PR DESCRIPTION
Temporary skipping `test_cuda.py::TestCuda::test_hip_device_count` on ROCm due to a rocprofiler-sdk issue

Pytorch with ROCm 7.14+ uses rocprofiler-sdk instead of roctracer.
rocprofiler-sdk crashes with message "Conflicting visibility between HIP_VISIBLE_DEVICES and CUDA_VISIBLE_DEVICES" and SIGABRT

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang