### PR TITLE
[FX] Fix TorchScript scripting on Python 3.14 (#190580)

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -215,6 +215,13 @@ def side_effect_func(x: torch.Tensor):
     print(x)
 
 
+@torch.fx.wrap
+def wrapped_optional_typing_dict(
+    value: dict[int, tuple[torch.Tensor, torch.Tensor]] | None,
+):
+    return value
+
+
 def _enrich_profiler_traces(prof):
     """
     Helper function to extract and augment profiler events with stack traces.
@@ -2580,6 +2587,25 @@ def forward(self, x : _torch_Tensor_) -> _torch_Tensor_:
             return a[0]
 
         torch.jit.script(symbolic_trace(forward))
+
+    def test_optional_typing_dict_placeholder_annotation_python314(self):
+        class OptionalTypingDictModule(torch.nn.Module):
+            def forward(
+                self,
+                value: typing.Optional[  # noqa: UP045
+                    typing.Dict[  # noqa: UP006
+                        int, typing.Tuple[torch.Tensor, torch.Tensor]  # noqa: UP006
+                    ]
+                ],
+            ):
+                return wrapped_optional_typing_dict(value)
+
+        traced = symbolic_trace(OptionalTypingDictModule())
+
+        FileCheck().check("value : typing_Union[typing_Dict").check(
+            "typing_Tuple"
+        ).check("NoneType]").run(traced.code)
+        torch.jit.script(traced)
 
     def test_wrapped_method(self):
         def wrap_with_relu(fn):

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -566,9 +566,11 @@ class CodeGen:
 
             typename = _type_repr(o)
             if isinstance(o, types.UnionType) and "|" in typename:
-                # str | int
+                # TorchScript's PEP604 parser does not resolve generated globals
+                # for nested aliases such as typing_Dict.
+                origin_typename = add_global(_type_repr(typing.Union), typing.Union)
                 args = [type_repr(arg) for arg in typing.get_args(o)]
-                return "|".join(args)
+                return f"{origin_typename}[{','.join(args)}]"
 
             if origin_type := getattr(o, "__origin__", None):
                 # list[...], typing.List[...], TensorType[...]


### PR DESCRIPTION
Summary:

Flow `f1112878456` exposed a Python 3.14-only FX/TorchScript interaction. `typing.Optional[typing.Dict[...]]` can now reach FX codegen as a `types.UnionType`, and we were printing it as raw PEP604 source:

```
typing_Dict[int,typing_Tuple[Tensor,Tensor]]|NoneType
```

That sends TorchScript through its PEP604 parser, which does not resolve FX generated nested globals like `typing_Dict`, and `torch.jit.script` fails with `Unknown type constructor typing_Dict`.

Keep generated union annotations on the resolver-backed `typing_Union[...]` path instead. The regression test traces the failing optional typing-dict placeholder, checks the fixed source, and scripts it.

Test Plan: Added a testcase which fails on 3.14 without this diff

Differential Revision: D112880667


