### PR TITLE
Add destroy-callbacks and object retention to torch.cuda.CUDAGraph

### DIFF
--- a/aten/src/ATen/cuda/CUDAGraph.cpp
+++ b/aten/src/ATen/cuda/CUDAGraph.cpp
@@ -337,20 +337,12 @@ cudaGraphExec_t CUDAGraph::raw_cuda_graph_exec() {
 }
 
 void CUDAGraph::reset() {
-  // I'd prefer these checks throw exceptions, not print warnings,
-  // but the destructor calls reset(), and at least one CI build
-  // refuses to compile with a throwing destructor.
-  //
-  // Instead of calling reset() in the destructor to clean up, I could
-  // call reset() in the __del__ method of a thin Python wrapper,
-  // in which case reset would be allowed to throw exceptions.
-  // But Stackoverflow does not like user-defined __del__.
-  // __del__ prevents Graph instances from EVER being garbage collected
-  // if they participate in a reference cycle.
-  // And exceptions thrown in __del__ only print a warning anyway.
-  //
-  // Calling reset() in the C++ destructor, with warnings instead of exceptions
-  // if calls fail, is the compromise we chose.
+  // These checks warn instead of throwing: reset() is called from the
+  // destructor, and at least one CI build refuses to compile with a throwing
+  // destructor. Resource cleanup lives here in C++ so it runs on garbage
+  // collection regardless of Python state; the Python __del__ on
+  // torch.cuda.CUDAGraph only tears down bookkeeping and intentionally does not
+  // call reset().
   //
   // If capture_begin, the capture, or capture_end failed at some point, this CUDAGraph, the generator,
   // and the allocator could end up in all kinds of weird states depending where failure occurred.

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -16,6 +16,7 @@ import threading
 import time
 import unittest
 import warnings
+import weakref
 from collections import defaultdict
 from copy import deepcopy
 from itertools import product
@@ -3281,6 +3282,161 @@ torch.cuda.synchronize()
         g.instantiate()
         g.instantiate()
         self.assertEqual(len(instantiated), 2)
+
+    def _capture_trivial_graph(self):
+        g = torch.cuda.CUDAGraph()
+        x = torch.zeros(8, device="cuda")
+        s = torch.cuda.Stream()
+        s.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(s):
+            for _ in range(3):
+                x = x + 1
+        torch.cuda.current_stream().wait_stream(s)
+        with torch.cuda.graph(g):
+            x + 1
+        return g
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    def test_graph_register_destroy_callback(self):
+        # Fires once on destruction; a graph-free sentinel observes it.
+        g = self._capture_trivial_graph()
+        calls = []
+        g.register_destroy_callback(lambda: calls.append(1))
+        del g
+        gc.collect()
+        self.assertEqual(calls, [1])
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    def test_graph_retain_fires_on_reset_and_rearms(self):
+        g = self._capture_trivial_graph()
+        calls = []
+        g.register_destroy_callback(lambda: calls.append("first"))
+        g.reset()
+        # also-fire-on-reset: fires once, then the holder re-arms empty.
+        self.assertEqual(calls, ["first"])
+        # A fresh capture cycle can register on the re-armed holder.
+        g = self._capture_trivial_graph()
+        g.register_destroy_callback(lambda: calls.append("second"))
+        del g
+        gc.collect()
+        self.assertEqual(calls, ["first", "second"])
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    def test_graph_retain_no_double_fire(self):
+        g = self._capture_trivial_graph()
+        calls = []
+        g.register_destroy_callback(lambda: calls.append(1))
+        g.reset()
+        del g
+        gc.collect()
+        self.assertEqual(calls, [1])
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    def test_graph_retain_object_released_on_destroy(self):
+        g = self._capture_trivial_graph()
+
+        class _Obj:
+            pass
+
+        obj = [_Obj()]
+        ref = weakref.ref(obj[0])
+        g.retain_object(obj[0])
+        obj.clear()
+        gc.collect()
+        self.assertIsNotNone(ref(), "retained object stays alive while graph is alive")
+        del g
+        gc.collect()
+        self.assertIsNone(ref(), "retained object released when graph is destroyed")
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    def test_graph_retain_callback_exception_isolated(self):
+        g = self._capture_trivial_graph()
+        calls = []
+        g.register_destroy_callback(lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+        g.register_destroy_callback(lambda: calls.append("after"))
+        del g
+        gc.collect()  # must not raise out of finalization
+        self.assertEqual(calls, ["after"])
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    def test_graph_retain_removable_handle(self):
+        g = self._capture_trivial_graph()
+        calls = []
+        handle = g.register_destroy_callback(lambda: calls.append(1))
+        handle.remove()
+        del g
+        gc.collect()
+        self.assertEqual(calls, [])
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    def test_graph_retain_sync_before_release_records_stream(self):
+        g = self._capture_trivial_graph()
+        freed = []
+        g.register_destroy_callback(
+            lambda: freed.append(1), synchronize_before_release=True
+        )
+        self.assertTrue(g._retained.sync_before_fire)
+        # Same-stream replays dedup to a single recorded stream.
+        for _ in range(4):
+            g.replay()
+        self.assertEqual(len(g._retained.replay_streams), 1)
+        del g
+        gc.collect()
+        self.assertEqual(freed, [1])
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    def test_graph_retain_sync_records_all_replay_streams(self):
+        g = self._capture_trivial_graph()
+        freed = []
+        g.register_destroy_callback(
+            lambda: freed.append(1), synchronize_before_release=True
+        )
+        # Concurrent replays on distinct streams must all be recorded so fire()
+        # drains every stream that may still have work in flight.
+        streams = [torch.cuda.Stream() for _ in range(3)]
+        for s in streams:
+            with torch.cuda.stream(s):
+                g.replay()
+        self.assertEqual(g._retained.replay_streams, set(streams))
+        del g
+        gc.collect()
+        self.assertEqual(freed, [1])
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    def test_graph_retain_graph_reference_pins_graph(self):
+        # Documented footgun: a retained object reachable to the graph makes the
+        # globally-held finalizer reach the graph, so it is never collected.
+        g = self._capture_trivial_graph()
+        g.retain_object([g])
+        ref = weakref.ref(g)
+        del g
+        gc.collect()
+        pinned = ref()
+        self.assertIsNotNone(pinned, "graph reachable from a retained object is pinned")
+        # Break the deliberate leak so the test does not strand a graph.
+        pinned._retained_finalizer.detach()
+        pinned._retained.objects.clear()
+        del pinned
+        gc.collect()
+        self.assertIsNone(ref())
 
     @unittest.skipIf(
         not TEST_CUDA_GRAPH,

--- a/torch/cuda/graphs.py
+++ b/torch/cuda/graphs.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import gc
 import typing
+import weakref
 from collections import OrderedDict
 from collections.abc import Callable
 from typing import overload, TYPE_CHECKING, TypeAlias, TypeGuard, Union
@@ -108,6 +109,52 @@ def _require_cuda_bindings() -> None:
         )
 
 
+class _RetainedCallbacks:
+    r"""Holds destroy callbacks and retained objects for a single capture cycle
+    of a :class:`CUDAGraph`.
+
+    A :class:`CUDAGraph` owns one of these and arms a :func:`weakref.finalize`
+    bound to :meth:`fire`. The holder deliberately does NOT reference the graph,
+    so the finalizer cannot keep the graph alive; :meth:`fire` can still sync the
+    replay streams because they are mirrored onto the holder, not read off the
+    graph. Callbacks and objects live in ``OrderedDict``s keyed by
+    ``RemovableHandle`` id so registrations can be individually removed.
+    """
+
+    def __init__(self) -> None:
+        self.callbacks: OrderedDict[int, Callable[[], None]] = OrderedDict()
+        self.objects: OrderedDict[int, object] = OrderedDict()
+        # Streams the graph was replayed on; drained before firing. A set (not a
+        # single stream) because concurrent replays on multiple streams leave
+        # work in flight on all of them and we cannot know which finishes last.
+        # Stream hashes/compares by value, so same-stream replays dedup to one
+        # entry -- the common case. Only populated when a caller requested sync.
+        self.replay_streams: set[torch.cuda.Stream] = set()
+        self.sync_before_fire: bool = False
+        self._fired: bool = False
+
+    def fire(self) -> None:
+        # Fired at most once (guards the reset()-then-destroy double trigger).
+        if self._fired:
+            return
+        self._fired = True
+        if self.sync_before_fire:
+            # Drain in-flight replays before releasing anything the graph may
+            # reference. Guarded so a sync failure does not skip the callbacks.
+            for stream in self.replay_streams:
+                try:
+                    stream.synchronize()
+                except Exception:
+                    pass
+        for cb in list(self.callbacks.values()):
+            try:
+                cb()
+            except Exception:
+                pass  # match finalizer semantics: swallow, don't abort the rest
+        self.callbacks.clear()
+        self.objects.clear()
+
+
 # Python shim helps Sphinx process docstrings more reliably.
 class CUDAGraph(_CUDAGraph):
     r"""Wrapper around a CUDA graph.
@@ -151,6 +198,11 @@ class CUDAGraph(_CUDAGraph):
     # User hooks fired by capture_end / instantiate (see register_*_hook).
     _capture_end_hooks: dict[int, Callable[[CUDAGraph], None]]
     _post_instantiate_hooks: dict[int, Callable[[CUDAGraph], None]]
+    # Destroy callbacks / retained objects for the current capture cycle, plus
+    # the weakref.finalize armed on this graph that fires the holder on
+    # collection. reset() fires the current holder and re-arms a fresh pair.
+    _retained: _RetainedCallbacks
+    _retained_finalizer: weakref.finalize | None
 
     def __new__(cls, keep_graph: bool = False) -> Self:
         instance = super().__new__(cls, keep_graph)
@@ -161,7 +213,18 @@ class CUDAGraph(_CUDAGraph):
         # OrderedDict (not dict): RemovableHandle weak-references the mapping.
         instance._capture_end_hooks = OrderedDict()
         instance._post_instantiate_hooks = OrderedDict()
+        instance._retained_finalizer = None
+        instance._arm_retained()
         return instance
+
+    def _arm_retained(self) -> None:
+        # Install a fresh destroy-callback holder and finalizer. The finalizer is
+        # bound to the holder, NOT to `self`: a finalizer arg referencing the
+        # graph would keep it alive forever and never fire. The holder does not
+        # point back at the graph, so fire() can still sync the last replay
+        # stream off it without pinning the graph.
+        self._retained = _RetainedCallbacks()
+        self._retained_finalizer = weakref.finalize(self, self._retained.fire)
 
     def register_capture_end_hook(
         self, hook: Callable[[CUDAGraph], None]
@@ -193,6 +256,63 @@ class CUDAGraph(_CUDAGraph):
         self._post_instantiate_hooks[handle.id] = hook
         return handle
 
+    def register_destroy_callback(
+        self,
+        cb: Callable[[], None],
+        *,
+        synchronize_before_release: bool = False,
+    ) -> RemovableHandle:
+        r"""Register ``cb()`` to run when this graph is destroyed (finalized) or
+        explicitly :meth:`reset`, just before its CUDA resources are freed.
+        Callbacks fire once per capture cycle, in registration order; exceptions
+        are swallowed so one failure does not abort the rest. ``cb`` must NOT
+        reference this graph: the finalizer that fires it is held by a global
+        registry, so a callback reachable to the graph keeps the graph alive
+        until interpreter exit (it is never collected, hence never fired).
+        Returns a handle whose ``remove()`` deregisters the callback.
+
+        Teardown does not synchronize CUDA, and ``cudaGraphExecDestroy`` frees an
+        in-flight graph only asynchronously, so a callback that frees device
+        memory the graph reads/writes is a use-after-free if a replay is still
+        in flight. Pass ``synchronize_before_release=True`` to synchronize every
+        stream this graph was replayed on before firing. Otherwise callbacks
+        must not free anything the graph references.
+        """
+        from torch.utils.hooks import RemovableHandle
+
+        if synchronize_before_release:
+            self._retained.sync_before_fire = True
+        handle = RemovableHandle(self._retained.callbacks)
+        self._retained.callbacks[handle.id] = cb
+        return handle
+
+    def retain_object(
+        self,
+        obj: object,
+        *,
+        synchronize_before_release: bool = False,
+    ) -> RemovableHandle:
+        r"""Keep ``obj`` alive for this graph's current capture cycle and release
+        it when the graph is destroyed (finalized) or explicitly :meth:`reset`.
+        No callback runs; normal refcounting drops ``obj`` when the retained
+        reference is released. Returns a handle whose ``remove()`` drops the
+        retained reference early. As with :meth:`register_destroy_callback`,
+        ``obj`` must NOT reference this graph, or the graph is kept alive until
+        interpreter exit and ``obj`` is never released.
+
+        ``synchronize_before_release`` has the same meaning and caveats as in
+        :meth:`register_destroy_callback`: set it if releasing ``obj`` frees device
+        memory the graph reads/writes (e.g. ``obj`` is the last reference to a
+        tensor the graph uses) and replays may still be in flight.
+        """
+        from torch.utils.hooks import RemovableHandle
+
+        if synchronize_before_release:
+            self._retained.sync_before_fire = True
+        handle = RemovableHandle(self._retained.objects)
+        self._retained.objects[handle.id] = obj
+        return handle
+
     def _maybe_remap_annotations(self) -> None:
         # Remap recorded kernel annotations to the current exec graph id. No-op
         # unless a capture id was stamped (annotations enabled). Called from
@@ -206,11 +326,19 @@ class CUDAGraph(_CUDAGraph):
 
         remap_to_exec_graph(self)
 
+    def _release_python_resources(self) -> None:
+        # Single source of truth for GC-critical Python resources released by
+        # both reset() and __del__. Destroy callbacks are NOT fired here: on the
+        # destruction path the armed weakref.finalize fires them (after __del__,
+        # before the C++ resources are freed), so user code stays out of
+        # __del__; reset() fires + re-arms the holder itself (see reset()).
+        tracker, self._tracker = self._tracker, None
+        if tracker is not None:
+            tracker.stop()
+
     def __del__(self) -> None:
         try:
-            tracker, self._tracker = self._tracker, None
-            if tracker is not None:
-                tracker.stop()
+            self._release_python_resources()
         except Exception:
             pass  # don't raise under GC
 
@@ -313,6 +441,11 @@ class CUDAGraph(_CUDAGraph):
         r"""Replay the CUDA work captured by this graph."""
         if self._tracker is not None:
             self._tracker.check_alive(self.pools())
+        if self._retained.sync_before_fire:
+            # Record the replay stream on the holder so fire() can drain it
+            # before releasing graph-referenced resources, without the holder
+            # referencing the graph. Only recorded when a caller opted into sync.
+            self._retained.replay_streams.add(torch.cuda.current_stream())
         # With keep_graph=True the exec graph is instantiated on demand here on
         # the first replay; the C++ replay() requires it to already exist. The
         # annotation remap rides on instantiate(), so it is handled by that call.
@@ -322,9 +455,18 @@ class CUDAGraph(_CUDAGraph):
 
     def reset(self) -> None:
         r"""Delete the graph currently held by this instance."""
-        if self._tracker is not None:
-            self._tracker.stop()
-            self._tracker = None
+        self._release_python_resources()
+        # also-fire-on-reset: reset() destroys this capture's CUDA resources and
+        # the graph may be re-captured, so fire the current destroy callbacks and
+        # re-arm a fresh holder + finalizer for the next capture cycle (the old
+        # finalizer is bound to the now-spent holder). detach() cancels it and
+        # drops its reference to the spent holder promptly.
+        self._retained.fire()
+        if self._retained_finalizer is not None:
+            self._retained_finalizer.detach()
+        self._arm_retained()
+        # Reset-only state: scrubbed here because the object is reused after
+        # reset(); on death these ints die with the object.
         self._capture_graph_id = None
         self._remapped_exec_id = None
         super().reset()


### PR DESCRIPTION
Let a user attach cleanup callbacks and/or keep Python objects alive on a torch.cuda.CUDAGraph so the callbacks fire (and the objects are released) when the graph is destroyed. The implementation is pure Python and ties cleanup to the Python wrapper's finalization.

The C++ CUDAGraph destroys graph_ / graph_exec_ in ~CUDAGraph -> reset(), which runs from pybind's tp_dealloc, so "graph destroyed" is observable purely in Python via the wrapper's finalization. Registration is backed by a _RetainedCallbacks holder plus a weakref.finalize armed on the graph and bound to the holder (never to the graph): a finalizer that referenced the graph would keep it alive forever. On the destruction path the finalizer fires the holder after __del__ but before the C++ destructor frees the CUDA resources.

Public API on CUDAGraph:
- register_destroy_callback(cb, *, synchronize_before_release=False)
- retain_object(obj, *, synchronize_before_release=False) both return a RemovableHandle for deregistration.

Design decisions:
- Fire on both destruction and explicit reset(). reset() destroys this capture's CUDA resources and the graph may be re-captured, so it fires the current holder and re-arms a fresh holder + finalizer for the next cycle. A _fired guard makes the reset()-then-destroy sequence fire at most once.
-  Opt-in stream sync for the async-teardown hazard: teardown doesn't
    synchronize and `cudaGraphExecDestroy` frees an in-flight graph only
    asynchronously, so freeing graph-referenced memory while a replay is in
    flight is a UAF. With `synchronize_before_release=True`, `replay()` records
    the replay stream on the holder and `fire()` drains it before running
    callbacks. Streams are tracked in a `set`, so concurrent replays on multiple
    streams are all synchronized (we can't know which finishes last); since
    `Stream` compares by value, repeated same-stream replays dedup to one entry.
    Streams are recorded only when sync was requested, keeping the common replay
    path free of the extra `Stream` construction.

With weakref.finalize (unlike a PEP-442 __del__), a retained callback/object that references the graph keeps the graph alive until interpreter exit, because the finalizer's bound method is held by a global registry and transitively reaches the graph. The API docstrings state this and a test locks in the behavior.

Alternatives considered and rejected: keeping cudaUserObject (async destructor on an arbitrary CUDA thread, global token registry, behavior differing by keep_graph); and firing callbacks from __del__ instead of weakref.finalize (inherits shutdown-ordering and exception-swallowing footguns, and cannot be bound to a non-graph-referencing holder as cleanly).

Also folds in two adjacent cleanups: a single _release_python_resources helper now backs the tracker teardown shared by reset() and __del__ (previously open-coded), and the obsolete pre-Python-3.4 comment in C++ reset() about __del__ and reference cycles is corrected.

Test Plan:

```
python test/test_cuda.py \
  TestCuda.test_graph_retain_destroy_callback \
  TestCuda.test_graph_retain_fires_on_reset_and_rearms \
  TestCuda.test_graph_retain_no_double_fire \
  TestCuda.test_graph_retain_object_released_on_destroy \
  TestCuda.test_graph_retain_callback_exception_isolated \
  TestCuda.test_graph_retain_removable_handle \
  TestCuda.test_graph_retain_sync_before_release_records_stream \
  TestCuda.test_graph_retain_graph_reference_pins_graph
```

Full CUDA graph suite (all TestCuda test_*graph* methods) and the graph util / debug suites:

```
python test/test_cuda.py <all TestCuda graph tests>
python test/test_cuda_graph_utils.py
python test/test_cuda_graph_debug.py
```

This change was authored with the assistance of an AI coding assistant.