### PR TITLE
[distributed] Fix broadcast subgroup gradient rank comparison

### DIFF
--- a/test/distributed/test_c10d_spawn_gloo.py
+++ b/test/distributed/test_c10d_spawn_gloo.py
@@ -137,6 +137,26 @@ if not TEST_WITH_DEV_DBG_ASAN:
             self._test_broadcast("gloo")
 
         @requires_gloo()
+        @skip_but_pass_in_sandcastle_if(
+            not _torch_dist_nn_available, "torch.distributed.nn is not available"
+        )
+        def test_broadcast_subgroup_with_nonzero_global_src(self):
+            store = c10d.FileStore(self.file_name, self.world_size)
+            c10d.init_process_group(
+                store=store,
+                rank=self.rank,
+                world_size=self.world_size,
+                backend="gloo",
+            )
+            group = c10d.new_group([1])
+
+            if self.rank == 1:
+                x = torch.ones(5, 5, requires_grad=True)
+                y = torch.distributed.nn.broadcast(x, 1, group=group)
+                y.sum().backward()
+                self.assertEqual(x.grad, torch.ones_like(x))
+
+        @requires_gloo()
         @skip_if_lt_x_gpu(2)
         @skip_but_pass_in_sandcastle_if(
             not _torch_dist_nn_available, "torch.distributed.nn is not available"

--- a/torch/distributed/nn/functional.py
+++ b/torch/distributed/nn/functional.py
@@ -297,7 +297,7 @@ class _Broadcast(Function):
     def forward(ctx, src, group, tensor):
         ctx.src = src
         ctx.group = group
-        ctx.rank = dist.get_rank(group=group)
+        ctx.global_rank = dist.get_rank()
         # torch.distributed makes all the calls in place
         # we allocate new tensors to avoid this
         tensor = tensor.clone()
@@ -308,7 +308,7 @@ class _Broadcast(Function):
     # pyrefly: ignore [bad-override]
     def backward(ctx, grad_output):
         gx = _Reduce.apply(ctx.src, ReduceOp.SUM, ctx.group, grad_output)
-        if ctx.src != ctx.rank:
+        if ctx.src != ctx.global_rank:
             gx.zero_()
         return (None, None, gx)
 


### PR DESCRIPTION
## Summary

Fixes #130515.

`torch.distributed.nn.functional.broadcast` stores the current rank during the forward pass and uses it in backward to keep the reduced gradient only on the source rank. The source passed to `broadcast(src=...)` is a global rank, but the implementation stored a process-group-local rank. For subgroups whose local and global ranks differ, this comparison incorrectly zeroed the source gradient.

Store the global rank so both sides of the backward comparison use the same rank namespace. Add a two-process Gloo regression test using subgroup `[1]`, where source global rank 1 is subgroup-local rank 0.

## Test plan

- Two-process Gloo reproducer against unpatched PyTorch 2.13: fails because the source gradient is all zeros.
- The same reproducer with this patch: passes with the expected all-ones gradient.
- `python3 -m py_compile torch/distributed/nn/functional.py test/distributed/test_c10d_spawn_gloo.py`
- `git diff --check`

## AI assistance

This change was developed with assistance from OpenAI Codex. I reviewed the implementation, regression test, and diff and take responsibility for the contribution.