### PR TITLE
Promote Python complex scalars in ComplexTensor operations

### DIFF
--- a/test/complex_tensor/test_complex_tensor.py
+++ b/test/complex_tensor/test_complex_tensor.py
@@ -157,6 +157,27 @@ class TestComplexTensor(TestCase):
         self.assertEqual(c.imag, torch.tensor([7, 8], dtype=torch.float32))
         self.assertEqual(c, torch.tensor([5 + 7j, 6 + 8j], dtype=torch.complex64))
 
+    def test_promote_tensors_python_complex_scalar(self):
+        from torch._subclasses.complex_tensor._ops.common import promote_tensors
+
+        cases = (
+            (torch.float32, torch.complex64),
+            (torch.float64, torch.complex128),
+            (torch.complex64, torch.complex64),
+            (torch.complex128, torch.complex128),
+        )
+
+        for input_dtype, expected_dtype in cases:
+            with self.subTest(input_dtype=input_dtype):
+                tensor = torch.ones(2, dtype=input_dtype)
+                output_dtype, promoted = promote_tensors(tensor, 1j)
+
+                self.assertEqual(output_dtype, expected_dtype)
+                self.assertEqual(
+                    [value.dtype for value in promoted],
+                    [expected_dtype, expected_dtype],
+                )
+
     def test_mul_inplace_complex(self):
         from torch._subclasses.complex_tensor import ComplexTensor
 

--- a/torch/_subclasses/complex_tensor/_ops/common.py
+++ b/torch/_subclasses/complex_tensor/_ops/common.py
@@ -87,6 +87,8 @@ def promote_tensors(
     for t in tensors:
         if isinstance(t, Tensor):
             out_dt = torch.promote_types(out_dt, t.dtype)
+        elif isinstance(t, complex) and not out_dt.is_complex:
+            out_dt = REAL_TO_COMPLEX.get(out_dt, torch.complex64)
 
     prom_dt = PROMOTE_TYPES.get(out_dt, out_dt)
     return out_dt, tuple(


### PR DESCRIPTION
## Summary

`ComplexTensor`'s `promote_tensors` computes the common dtype from tensor operands but previously ignored Python `complex` scalars. For a real tensor combined with a scalar such as `1j`, the common dtype remained real, and materializing the scalar with `torch.asarray` raised `TypeError: must be real number, not complex`. 

PR lifts a real common dtype through `REAL_TO_COMPLEX` when a Python complex scalar is present, while preserving existing complex dtypes. The regression test covers `float32` to `complex64`, `float64` to `complex128`, and preservation of `complex64` and `complex128`.

## Test Plan

Before the implementation change, the regression reproduced the Python-complex conversion failure:

```
torch.float32 + 1j: TypeError: must be real number, not complex
torch.float64 + 1j: TypeError: must be real number, not complex
```

Focused regression test:

```
python test/complex_tensor/test_complex_tensor.py \
    -k promote_tensors_python_complex_scalar \
    -v
```


With Fix, the tests pass.

## Checklist

- [ ] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [x] Updated documentation (not applicable; internal correctness fix)
- [x] Included benchmark results (not applicable; no performance impact expected)
