### PR TITLE
[PrismNet][Inductor] respect runtime-assert bounds when hinting unbacked sizes (#190589)

### DIFF
--- a/test/inductor/test_indexing.py
+++ b/test/inductor/test_indexing.py
@@ -1207,6 +1207,30 @@ class TestOptimizationHintWideUnbackedSubstitution(InductorTestCase):
         with unittest.mock.patch.object(sympy.Basic, "subs", fail_subs):
             self.assertEqual(sizevars.optimization_hint(expr, fallback=0), 0)
 
+    def test_hint_respects_symbolic_upper_bound_assert(self):
+        # A reducing slice x[u0:] is sized s0 - u0. The invariant u0 <= s0 lives
+        # only in deferred_runtime_asserts, not var_to_range (which keeps the loose
+        # [0, fallback]). optimization_hint must honor it so u0 is capped at s0's
+        # hint rather than the generic fallback; otherwise s0 - u0 hints negative
+        # (16 - fallback) and overflows downstream allocations such as the AOTI
+        # autotuning example tensors.
+        from torch._dynamo.source import ConstantSource
+        from torch.fx.experimental.symbolic_shapes import DimDynamic
+
+        sizevars = SizeVarAllocator()
+        shape_env = sizevars.shape_env
+        s0 = shape_env.create_symbol(
+            16,
+            source=ConstantSource("__test_s0"),
+            dynamic_dim=DimDynamic.DYNAMIC,
+            constraint_dim=None,
+        )
+        u0 = shape_env.create_unbacked_symint().node.expr
+        shape_env.guard_or_defer_runtime_assert(u0 <= s0, "u0 <= s0")
+
+        self.assertLessEqual(sizevars.optimization_hint(u0, fallback=1024), 16)
+        self.assertGreaterEqual(sizevars.optimization_hint(s0 - u0, fallback=1024), 0)
+
 
 class TestOptimizationHintIdentityExpansion(InductorTestCase):
     """Test that optimization_hint expands Identity wrappers after _sub_unbacked_exprs."""

--- a/torch/fx/experimental/_size_hinting.py
+++ b/torch/fx/experimental/_size_hinting.py
@@ -344,6 +344,67 @@ def _sub_unbacked_exprs(shape_env: ShapeEnv, expr: sympy.Expr) -> sympy.Expr:
     return expr
 
 
+def _hint_bounds_from_runtime_asserts(
+    shape_env: ShapeEnv, s: sympy.Symbol
+) -> tuple[int | None, int | None]:
+    """Concrete ``(lower, upper)`` bounds for an unbacked symbol derived from the
+    runtime asserts, with backed symbols replaced by their hint values.
+
+    Relational invariants such as ``u0 <= s44`` live only in
+    ``deferred_runtime_asserts`` -- ``var_to_range`` keeps the loose
+    ``[0, unbacked_symint_fallback]``. Feeding these bounds into the size hint keeps
+    it consistent with the graph: e.g. a reducing slice ``x[u0:]`` sized ``s44 - u0``
+    cannot hint negative, because ``u0`` is capped at ``s44``'s hint instead of the
+    generic fallback. Only linear single-symbol bounds (``c*s + k <= 0``) with
+    concrete integer coefficients are used, so this never tightens past what the
+    asserts prove; anything else is skipped.
+    """
+    lower: int | None = None
+    upper: int | None = None
+    backed = shape_env.backed_var_to_val
+    # Read only the asserts keyed to this symbol (bounds on an unbacked symbol
+    # only ever live there); guards constrain backed symbols and would just be a
+    # wasted scan.
+    try:
+        for ra in shape_env.deferred_runtime_asserts.get(s, ()):
+            ax = ra.expr
+            if not isinstance(ax, sympy.Basic):
+                continue
+            # Substitute backed hints, so e.g. ``u0 <= s44`` becomes ``u0 <= 16``.
+            ax = ax.xreplace(backed)
+            if s not in ax.free_symbols:
+                continue
+            # Normalize the relation to ``g < 0`` (strict) or ``g <= 0``.
+            if isinstance(ax, sympy.LessThan):
+                g, strict = ax.lhs - ax.rhs, False
+            elif isinstance(ax, sympy.StrictLessThan):
+                g, strict = ax.lhs - ax.rhs, True
+            elif isinstance(ax, sympy.GreaterThan):
+                g, strict = ax.rhs - ax.lhs, False
+            elif isinstance(ax, sympy.StrictGreaterThan):
+                g, strict = ax.rhs - ax.lhs, True
+            else:
+                continue
+            # Require g == c*s + k with concrete integer c, k (no other free syms).
+            c = g.coeff(s, 1)
+            k = g.coeff(s, 0)
+            if g - (c * s + k) != 0 or not (c.is_Integer and k.is_Integer):
+                continue
+            c, k = int(c), int(k)
+            if c == 0:
+                continue
+            thr = sympy.Rational(-k, c)  # c*s + k (<|<=) 0  ->  s (<|<=) thr, c>0
+            if c > 0:
+                bnd = int(sympy.ceiling(thr) - 1) if strict else int(sympy.floor(thr))
+                upper = bnd if upper is None else min(upper, bnd)
+            else:  # dividing by c<0 flips the inequality: s (>|>=) thr
+                bnd = int(sympy.floor(thr) + 1) if strict else int(sympy.ceiling(thr))
+                lower = bnd if lower is None else max(lower, bnd)
+    except Exception:
+        pass
+    return lower, upper
+
+
 def _optimization_hint_base(
     shape_env: ShapeEnv,
     expr: sympy.Expr | int,
@@ -443,16 +504,32 @@ def _optimization_hint_base(
         raise RuntimeError(f"Expected sympy Expr, got {type(expr)}: {expr}")
     free_symbols = expr.free_symbols
 
-    # Constrain fallback per-symbol based on var_to_range bounds
+    # Constrain fallback per-symbol based on var_to_range bounds, then tighten
+    # further with invariants that live only in the runtime asserts (e.g.
+    # u0 <= s44). Without the latter, an unbacked symbol keeps its generic
+    # fallback even when the graph proves it is bounded by a backed dim, so a
+    # size expression like s44 - u0 can hint negative and overflow downstream
+    # allocations (autotuning example tensors, buffer sizing).
     size_dict = {}
     for s in free_symbols:
-        sym_fallback = fallback
+        lower: int | None = None
+        upper: int | None = None
         vr = shape_env.var_to_range.get(s, None)
         if vr is not None:
             if isinstance(vr.lower, (int, sympy.Integer)):
-                sym_fallback = max(sym_fallback, int(vr.lower))
+                lower = int(vr.lower)
             if isinstance(vr.upper, (int, sympy.Integer)):
-                sym_fallback = min(sym_fallback, int(vr.upper))
+                upper = int(vr.upper)
+        ra_lower, ra_upper = _hint_bounds_from_runtime_asserts(shape_env, s)
+        if ra_lower is not None:
+            lower = ra_lower if lower is None else max(lower, ra_lower)
+        if ra_upper is not None:
+            upper = ra_upper if upper is None else min(upper, ra_upper)
+        sym_fallback = fallback
+        if lower is not None:
+            sym_fallback = max(sym_fallback, lower)
+        if upper is not None:
+            sym_fallback = min(sym_fallback, upper)
         size_dict[s] = sym_fallback
 
     try:


### PR DESCRIPTION
Summary:

`_optimization_hint_base` can return a negative size hint for an expression over unbacked symbols, which overflows downstream size math. In AOTI this crashes autotuning with `Storage size calculation overflowed with sizes=[-1008, 64]`; in a full model the same bad size faults later as a CUDA illegal memory access during `torch._inductor.aot_compile`.

Root cause: for a size like `s44 - u0` (backed dim minus unbacked count), each symbol is hinted independently. `s44` gets its real hint, but `u0` only consults `var_to_range` and falls back to `unbacked_symint_fallback`. The bound `u0 <= s44` is not in `var_to_range` -- it lives only in `deferred_runtime_asserts` -- so the hint ignores the graph's own invariant and `s44 - u0` goes negative.

Fix: when hinting an unbacked symbol, tighten its bound using that symbol's runtime asserts with backed symbols substituted (`u0 <= s44` becomes `u0 <= 16`). Only linear single-symbol bounds with concrete integer coefficients are used, so the hint can never tighten past what the asserts prove; `u0` is capped at `s44`'s hint and `s44 - u0` stays non-negative.

Scope: the tightening only runs when the expression still has unbacked free symbols (the all-backed path is untouched), and reads a symbol's own asserts rather than the full axiom set. `optimization_hint` is advisory/non-guarding, so this only affects autotuning and internal sizing choices, never the correctness of the generated code.

Production impact: this blocks the early-exit DHEN GPU lowering. In the failing publish (MAST job `aps-aps_prism_net_two_layers_joint-56bb3ba519`, entity/snapshot 2114359578, `max_batch_size=2048`), the MAST stderr only shows the async `CUDA illegal memory access` (caught at a benign `set_rng_state` sync). The real cause is in the IEN lowering log (`dedicated_log_torch_trace_rank_*`): the generated Triton kernel asserts `index out of bounds: 0 <= tmp4 < 2460` and `tmp16 < 4096` -- the reassembly gather indexing past its buffer. The same inconsistent unbacked hints produce that OOB index at batch 2048 and the synchronous `sizes=[-1008, 64]` overflow in the minimal repro at batch 16.

Test Plan:
Production MAST canary — the early-exit DHEN publish this fix unblocks. Same `two_layers_joint` publish, before vs after this fix:

Before (fails — async CUDA illegal memory access; real cause is the unbacked reducing-slice OOB gather index in the IEN lowering log):
https://www.internalfb.com/mlhub/pipelines/runs/mast/aps-aps_prism_net_two_layers_joint-56bb3ba519

After this fix (passes):
https://www.internalfb.com/mlhub/pipelines/runs/mast/aps-aps_prism_net_two_layers_joint-94fc941987

New regression test (backed `s0` hinted 16 + unbacked `u0` with a symbolic `u0 <= s0` runtime assert; asserts the hint for `u0` is capped at 16 and `s0 - u0` is non-negative):

```
buck2 test fbcode//mode/opt fbcode//caffe2/test/inductor:indexing -- test_hint_respects_symbolic_upper_bound_assert
```

Pass 2 -- https://www.internalfb.com/intern/testinfra/testrun/32932572295074130

No regressions in the existing hint suites:

```
buck2 test fbcode//mode/opt fbcode//caffe2/test/inductor:indexing -- OptimizationHint
```

Pass 9 -- https://www.internalfb.com/intern/testinfra/testrun/35747322062176607

```
buck2 test fbcode//mode/opt fbcode//caffe2/test/inductor:indexing -- PrecomputedSizeHinting
```

Pass 4 -- https://www.internalfb.com/intern/testinfra/testrun/14355223996050746

Broader unbacked-symint sweep:

```
buck2 test fbcode//mode/opt fbcode//caffe2/test/inductor:unbacked_symints
```

Pass 58, Fail 0 -- https://www.internalfb.com/intern/testinfra/testrun/9288674415550883

ShapeEnv suite:

```
buck2 test fbcode//mode/opt fbcode//caffe2/test:dynamic_shapes
```

The only failure is `test_flex_attention_foreign_fake_e2e` (`TestTransferSymbolsFromForeignShapeEnv`), which is PRE-EXISTING and unrelated to this change -- it fails identically on the parent commit (fix absent), so it is not a regression.

End-to-end on the isolated repro `ShrinkingUnbackedExit` (unbacked reducing-slice chain, no PrismNet), CUDA GH200:

```
REPRO_UNBACKED_ONLY=1 buck2 run fbcode//mode/opt fbcode//aps_models/ads/gmp/models/ads_mtml_prism_net_dedicated_model/benchmarks:repro_aoti_inductor_bugs
```

Before: `InductorError: Failed to run autotuning code block: Storage size calculation overflowed with sizes=[-1008, 64]`.
After: export OK (113 nodes), AOTI aot_compile OK, runtime inference (5 iters) OK, zero overflow.

Reviewed By: kqfu

Differential Revision: D112652528




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo