### PR TITLE
[CUDA] Add CUDA 13.4 install in almalinux magma image

### DIFF
--- a/.ci/docker/almalinux/Dockerfile
+++ b/.ci/docker/almalinux/Dockerfile
@@ -70,6 +70,10 @@ FROM cuda as cuda13.2
 RUN bash ./install_cuda.sh 13.2
 ENV DESIRED_CUDA=13.2
 
+FROM cuda as cuda13.4
+RUN bash ./install_cuda.sh 13.4
+ENV DESIRED_CUDA=13.4
+
 FROM ${ROCM_IMAGE} as rocm_base
 ARG DEVTOOLSET_VERSION=13
 ENV LC_ALL en_US.UTF-8
@@ -104,6 +108,7 @@ COPY --from=cuda12.8  /usr/local/cuda-12.8 /usr/local/cuda-12.8
 COPY --from=cuda12.9  /usr/local/cuda-12.9 /usr/local/cuda-12.9
 COPY --from=cuda13.0  /usr/local/cuda-13.0 /usr/local/cuda-13.0
 COPY --from=cuda13.2  /usr/local/cuda-13.2 /usr/local/cuda-13.2
+COPY --from=cuda13.4  /usr/local/cuda-13.4 /usr/local/cuda-13.4
 
 # Final step
 FROM ${BASE_TARGET} as final

--- a/.ci/docker/common/install_cuda.sh
+++ b/.ci/docker/common/install_cuda.sh
@@ -215,6 +215,44 @@ function install_132 {
   ldconfig
 }
 
+function install_134 {
+  CUDNN_VERSION=9.24.0.43
+  CUSPARSELT_VERSION=0.8.1.1
+  echo "Installing CUDA 13.4 and cuDNN ${CUDNN_VERSION} and NVSHMEM and NCCL and cuSparseLt-${CUSPARSELT_VERSION}"
+  # CUDA 13.4 ships no runfile-local installer yet, so install the toolkit from
+  # the NVIDIA preview network repo (https://packages.nvidia.com).
+  ID=$(grep -oP '(?<=^ID=).+' /etc/os-release | tr -d '"')
+  case "$ID" in
+    ubuntu)
+      codename=$(grep -oP '(?<=^VERSION_CODENAME=).+' /etc/os-release | tr -d '"')
+      wget -q https://packages.nvidia.com/${codename}/nvidia-preview-keyring.deb
+      dpkg -i nvidia-preview-keyring.deb
+      apt-get update
+      apt-get -y install cuda-toolkit-13-4
+      rm -f nvidia-preview-keyring.deb
+      ;;
+    almalinux|rhel|centos)
+      wget -q https://packages.nvidia.com/el8/nvidia-preview-keyring.rpm
+      rpm -i nvidia-preview-keyring.rpm
+      dnf clean all
+      dnf -y install cuda-toolkit-13-4
+      rm -f nvidia-preview-keyring.rpm
+      ;;
+    *) echo "install_134: unsupported OS '$ID'"; exit 1 ;;
+  esac
+
+  # cuDNN license: https://developer.nvidia.com/cudnn/license_agreement
+  install_cudnn 13 $CUDNN_VERSION
+
+  install_nvshmem 13 $NVSHMEM_VERSION
+
+  CUDA_VERSION=13.4 bash install_nccl.sh
+
+  CUDA_VERSION=13.4 bash install_cusparselt.sh $CUSPARSELT_VERSION
+
+  ldconfig
+}
+
 # idiomatic parameter and option handling in sh
 while test $# -gt 0
 do
@@ -230,6 +268,8 @@ do
     13.0|13.0.*) install_130;
         ;;
     13.2|13.2.*) install_132;
+        ;;
+    13.4|13.4.*) install_134;
         ;;
     *) echo "bad argument $1"; exit 1
         ;;

--- a/.github/workflows/build-almalinux-images.yml
+++ b/.github/workflows/build-almalinux-images.yml
@@ -39,7 +39,7 @@ jobs:
     timeout-minutes: 240
     strategy:
       matrix:
-        tag: ["cuda12.6", "cuda13.0", "cuda13.2", "rocm7.1", "rocm7.2", "cpu"]
+        tag: ["cuda12.6", "cuda13.0", "cuda13.2", "cuda13.4", "rocm7.1", "rocm7.2", "cpu"]
     steps:
       - name: Build docker image
         uses: pytorch/pytorch/.github/actions/binary-docker-build@main


### PR DESCRIPTION
CUDA 13.4 released developer preview version on 7/17 - https://developer.nvidia.com/cuda-13-4-0-download-archive

This adds CUDA 13.4 to CI, excluding the nightly binary/wheel pipeline. Reviewable in two logical steps. This PR is the step 1. 

**Step 1 - install path + magma image** (mirrors #177083 for 13.2): a new install_134 in install_cuda.sh, a cuda13.4 stage in the almalinux magma Dockerfile, and cuda13.4 in the build-almalinux-images matrix.

Unlike earlier CUDA versions, 13.4 has no runfile-local installer published yet -- only the NVIDIA preview network repo. install_134 installs the cuda-toolkit-13-4 metapackage from that repo, selecting the el8 rpm keyring on rpm images and a codename-matched (VERSION_CODENAME) deb keyring on Ubuntu. The preview repo is self-contained for the toolkit (all cuda-toolkit-13-4 component deps ship at 13.4.0), and it is toolkit-only, matching the old runfile --toolkit.

cuDNN, NCCL, NVSHMEM, and cuSparseLt continue to come from the existing tarball helpers, unchanged from 13.2.

Authored with assistance from an AI coding assistant (Claude).

cc @ptrblck @nWEIdia @eqy @atalman @malfet 