### PR TITLE
Allow swap_tensors on tensors with Python weakrefs

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -10976,9 +10976,37 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
                 with self.assertRaisesRegex(RuntimeError, "AccumulateGrad node that was poisoned by swap_tensors"):
                     out.sum().backward()
 
-            _wr = weakref.ref(t1)
-            with self.assertRaisesRegex(RuntimeError, "has weakref"):
-                torch.utils.swap_tensors(t1, t2)
+            # A weakref no longer blocks the swap. It keeps pointing at the
+            # same object (identity is preserved) and observes the new content.
+            wr = weakref.ref(t1)
+            t2_id = id(t2)
+            torch.utils.swap_tensors(t1, t2)
+            self.assertIs(wr(), t1)
+            self.assertEqual(id(t2), t2_id)
+
+
+    def test_swap_allows_weakref(self):
+        from torch.utils.weak import TensorWeakRef
+
+        # Plain weakref on either operand: swap succeeds, identity preserved,
+        # content swapped in.
+        t1 = torch.zeros(4, 4)
+        t2 = torch.ones(4, 4)
+        wr1 = weakref.ref(t1)
+        wr2 = weakref.ref(t2)
+        torch.utils.swap_tensors(t1, t2)
+        self.assertIs(wr1(), t1)
+        self.assertIs(wr2(), t2)
+        self.assertTrue(bool((t1 == 1).all()))
+        self.assertTrue(bool((t2 == 0).all()))
+
+        # Dynamo's guard weakref type on a parameter (the issue's repro).
+        p = torch.nn.Parameter(torch.zeros(4, 4))
+        tw = TensorWeakRef(p)
+        torch.utils.swap_tensors(p, torch.nn.Parameter(torch.ones(4, 4)))
+        self.assertTrue(bool((p == 1).all()))
+        self.assertIs(tw(), p)
+        self.assertTrue(bool((tw() == 1).all()))
 
 
     @unittest.skipIf(TEST_WITH_TORCHDYNAMO, "Dynamo adds weakrefs")

--- a/torch/utils/__init__.py
+++ b/torch/utils/__init__.py
@@ -2,7 +2,6 @@
 
 import copyreg
 import os.path as _osp
-import weakref
 
 import torch
 from torch.utils import (
@@ -40,11 +39,6 @@ def swap_tensors(t1, t2):
 
     This will not work if t1 and t2 have different slots.
     """
-    # Ensure there are no weakrefs
-    if weakref.getweakrefs(t1):
-        raise RuntimeError("Cannot swap t1 because it has weakref associated with it")
-    if weakref.getweakrefs(t2):
-        raise RuntimeError("Cannot swap t2 because it has weakref associated with it")
     t1_slots = set(copyreg._slotnames(t1.__class__))  # type: ignore[attr-defined]
     t2_slots = set(copyreg._slotnames(t2.__class__))  # type: ignore[attr-defined]
     if t1_slots != t2_slots:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #190604

Fixes #186796.

torch.utils.swap_tensors unconditionally rejected either operand that
carried any Python weakref. Dynamo installs TENSOR_MATCH guards that hold
a torch.utils.weak.TensorWeakRef on every traced parameter
(torch/_dynamo/variables/builder.py). While a compiled artifact is live
-- e.g. mid-forward, exactly when a diffusers group-offloading onload hook
runs -- those weakrefs are present on the params, so swap_tensors raised
and blocked offloading that relies on it (required for TorchAO subclass
tensors). PR #180566 did not help because it only clears weakrefs at
compile-context teardown, not during a live forward.

Root cause of the assert: it was a conservative guard from an era when the
CPython PyObject-preservation scheme had real weakref/GC bugs, so swapping
a tensor that carried a live Python weakref was unsafe. That scheme was
reworked in #167564 ("Rework PyObject preservation (v2)", the kHasPyObject
bit in c10/util/intrusive_ptr.h), which explicitly states that "Python
weakrefs on Tensors and Storages should just work as expected now." That
removed the reason for the assert.

Why the fix is sound: swap_tensors swaps the class/dict/slots in Python and
calls torch._C._swap_tensor_impl, which swaps only the cdata (TensorImpl)
member between the two PyObjects and never touches the Python weakref list.
Object identity is preserved, so a weakref keeps pointing at the same object
with the swapped-in content -- the same thing every strong-reference holder
(model.weight, optimizer param lists) already observes by design. A weakref
is strictly weaker than a strong reference and relies on no invariant a
strong reference does not, so rejecting weakref holders while letting strong
holders see the swap protected nothing. For Dynamo specifically, TENSOR_MATCH
re-reads dtype/device/shape/strides from the live tensor each check, so it is
fail-safe: identical metadata runs the graph on the new data (data is a
runtime input, not a guarded constant); changed metadata fails the guard and
recompiles. It cannot silently return a wrong result. The separate C++ guard
in _swap_tensor_impl (weak_use_count() == 1, guarding C++ weak_intrusive_ptrs
to the TensorImpl, an orthogonal concern) is left untouched.

Alternatives considered: PR #186801 made TensorWeakRef a weakref.ref subclass
and filtered on it inside swap_tensors; that was reverted twice by the
swap_tensors owner as unnecessary (and BC-breaking, since it altered a public
class). Removing the now-obsolete assert is the minimal fix and the one the
owner asked for. Keeping the restriction and having diffusers fall back to
`.data =` was rejected because it abandons the swap_tensors path that TorchAO
subclass tensors need, which is the point of the issue.

Test Plan:

```
python test/test_torch.py -k test_swap
python test/dynamo/test_repros.py -k swap_tensors_subclass_not_blocked_by_metaconverter_refcycle
lintrunner -a torch/utils/__init__.py test/test_torch.py
```

test_swap_allows_weakref fails before this change (RuntimeError: Cannot swap
t1 because it has weakref associated with it) and passes after; restoring
either removed assert branch independently reproduces the failure, so both
removed lines are covered.

This change was authored with the assistance of an AI coding assistant
(Claude).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98