### PR TITLE
Handle out variants without recursive dispatch for ComplexTensor

### DIFF
--- a/test/complex_tensor/test_complex_tensor.py
+++ b/test/complex_tensor/test_complex_tensor.py
@@ -157,6 +157,41 @@ class TestComplexTensor(TestCase):
         self.assertEqual(c.imag, torch.tensor([7, 8], dtype=torch.float32))
         self.assertEqual(c, torch.tensor([5 + 7j, 6 + 8j], dtype=torch.complex64))
 
+    def test_out_variants_do_not_redispatch(self):
+        from torch._subclasses.complex_tensor import ComplexTensor
+
+        def make_complex(shape):
+            return ComplexTensor(torch.randn(shape), torch.randn(shape))
+
+        vector_a = make_complex((4,))
+        vector_b = make_complex((4,))
+        matrix_a = make_complex((2, 3))
+        matrix_b = make_complex((3, 2))
+        batched_a = make_complex((2, 2, 3))
+        batched_b = make_complex((2, 3, 2))
+
+        cases = (
+            ("add", torch.add, (vector_a, vector_b), {}, (4,)),
+            ("add_alpha", torch.add, (vector_a, vector_b), {"alpha": 2}, (4,)),
+            ("mul", torch.mul, (vector_a, vector_b), {}, (4,)),
+            ("mm", torch.mm, (matrix_a, matrix_b), {}, (2, 2)),
+            ("bmm", torch.bmm, (batched_a, batched_b), {}, (2, 2, 2)),
+            ("dot", torch.dot, (vector_a, vector_b), {}, ()),
+            ("sum", torch.sum, (matrix_a, 1), {}, (2,)),
+            ("cumprod", torch.cumprod, (matrix_a, 1), {}, (2, 3)),
+            ("stack", torch.stack, ([vector_a, vector_b], 0), {}, (2, 4)),
+        )
+
+        for name, op, args, kwargs, out_shape in cases:
+            with self.subTest(name=name):
+                expected = op(*args, **kwargs)
+                out = ComplexTensor(torch.zeros(out_shape), torch.zeros(out_shape))
+                result = op(*args, out=out, **kwargs)
+
+                self.assertIs(result, out)
+                self.assertEqual(out.re, expected.re)
+                self.assertEqual(out.im, expected.im)
+
     def test_mul_inplace_complex(self):
         from torch._subclasses.complex_tensor import ComplexTensor
 

--- a/torch/_subclasses/complex_tensor/_ops/aten.py
+++ b/torch/_subclasses/complex_tensor/_ops/aten.py
@@ -20,6 +20,7 @@ from .common import (
     register_simple,
     split_complex_arg,
     split_complex_tensor,
+    write_complex_out,
 )
 
 
@@ -43,15 +44,20 @@ def register_binary_linear(op: OpType) -> Callable[..., Any]:
     def impl(
         lhs: ComplexTensor, rhs: ComplexTensor, *args: Any, **kwargs: Any
     ) -> ComplexTensor:
+        out = kwargs.pop("out", None)
         alpha = kwargs.pop("alpha", None)
         if alpha is not None:
-            return impl_with_alpha(lhs, rhs, *args, alpha=alpha, **kwargs)
+            result = impl_with_alpha(lhs, rhs, *args, alpha=alpha, **kwargs)
+            return write_complex_out(out, result) if out is not None else result
         a_r, a_i = split_complex_arg(lhs)
         b_r, b_i = split_complex_arg(rhs)
         out_dt, (a_r, a_i, b_r, b_i) = promote_tensors(a_r, a_i, b_r, b_i)
         u = op(a_r, b_r, *args, **kwargs)
         v = op(a_i, b_i, *args, **kwargs)
-        return ComplexTensor(u.to(out_dt), v.to(out_dt))
+        result = ComplexTensor(u.to(out_dt), v.to(out_dt))
+        if out is not None:
+            return write_complex_out(out, result)
+        return result
 
     return register_complex(op, impl)
 
@@ -238,6 +244,7 @@ def pow_impl(self: ComplexTensor, exponent: ComplexTensor) -> ComplexTensor:
 
 @register_complex(aten.cumprod)
 def cumprod_impl(self: ComplexTensor, *args: Any, **kwargs: Any) -> ComplexTensor:
+    out = kwargs.pop("out", None)
     dtype = kwargs.pop("dtype", self.dtype)
     kwargs["dtype"] = complex_to_real_dtype(dtype)
 
@@ -245,7 +252,10 @@ def cumprod_impl(self: ComplexTensor, *args: Any, **kwargs: Any) -> ComplexTenso
     sum_phi = torch.cumsum(torch.angle(self), *args, **kwargs)
     u = prod_r * torch.cos(sum_phi)
     v = prod_r * torch.sin(sum_phi)
-    return ComplexTensor(u, v)
+    result = ComplexTensor(u, v)
+    if out is not None:
+        return write_complex_out(out, result)
+    return result
 
 
 # unary funcs,
@@ -790,10 +800,14 @@ def allclose_impl(
 
 @register_complex(aten.stack)
 def stack_impl(self: list[ComplexTensor], *args: Any, **kwargs: Any) -> ComplexTensor:
+    out = kwargs.pop("out", None)
     re_im_tuples = [split_complex_arg(self_i) for self_i in self]
     u = torch.stack([c[0] for c in re_im_tuples], *args, **kwargs)
     v = torch.stack([c[1] for c in re_im_tuples], *args, **kwargs)
-    return ComplexTensor(u, v)
+    result = ComplexTensor(u, v)
+    if out is not None:
+        return write_complex_out(out, result)
+    return result
 
 
 # TODO (hameerabbasi): Not being tested

--- a/torch/_subclasses/complex_tensor/_ops/common.py
+++ b/torch/_subclasses/complex_tensor/_ops/common.py
@@ -232,6 +232,16 @@ def register_error(
     return register_force_test(op, ordered_impl)
 
 
+def write_complex_out(
+    out: ComplexTensor,
+    result: ComplexTensor,
+) -> ComplexTensor:
+    re, im = split_complex_arg(result)
+    out.re.copy_(re)
+    out.im.copy_(im)
+    return out
+
+
 def register_binary_nonlinear(
     op: OpType,
 ) -> Callable[[Callable[_P, _R]], Callable[_P, _R]] | Callable[..., Any]:
@@ -241,12 +251,16 @@ def register_binary_nonlinear(
     def impl(
         a: ComplexTensor, b: ComplexTensor, *args: Any, **kwargs: Any
     ) -> ComplexTensor:
+        out = kwargs.pop("out", None)
         out_dt, (a, b) = promote_tensors(a, b)
         a_r, a_i = split_complex_arg(a)
         b_r, b_i = split_complex_arg(b)
         real = op(a_r, b_r, *args, **kwargs) - op(a_i, b_i, *args, **kwargs)
         imag = op(a_r, b_i, *args, **kwargs) + op(a_i, b_r, *args, **kwargs)
-        return ComplexTensor(real, imag).to(out_dt)  # type: ignore[bad-return]
+        result = ComplexTensor(real, imag).to(out_dt)  # type: ignore[bad-return]
+        if out is not None:
+            return write_complex_out(out, result)
+        return result
 
     func_name = _get_func_name(op)
     impl.__name__ = func_name
@@ -263,6 +277,7 @@ def register_simple(
     def impl(
         self: ComplexTensor, *args: Any, dtype: torch.dtype | None = None, **kwargs: Any
     ) -> ComplexTensor:
+        out = kwargs.pop("out", None)
         x, y = split_complex_tensor(self)
         if dtype is not None and dtype not in COMPLEX_TO_REAL:
             raise RuntimeError(
@@ -284,7 +299,16 @@ def register_simple(
         out_flat = [
             ComplexTensor(ui, vi) for ui, vi in zip(u_flat, v_flat, strict=False)
         ]
-        return tree_unflatten(out_flat, u_spec)
+        result = tree_unflatten(out_flat, u_spec)
+        if out is not None:
+            outputs = out if isinstance(out, (tuple, list)) else [out]
+            results = result if isinstance(result, (tuple, list)) else [result]
+
+            for output, computed in zip(outputs, results, strict=True):
+                write_complex_out(output, computed)
+
+            return out
+        return result
 
     func_name = _get_func_name(op)
     impl.__name__ = func_name


### PR DESCRIPTION
## Summary

`ComplexTensor` handlers forwarded the caller-provided `out` tensor to their internal real and imag ops. Because `out` is itself a `ComplexTensor`, those component ops are redispatched to the same handler instead of writing into ordinary tensors, causing recursive dispatch for `out=` variants. 

PR removes `out` before computing the real and imaginary components, and then copies the completed components into the supplied `ComplexTensor` through a shared `write_complex_out` helper. Adds regression coverage for `add`, `add` with `alpha`, `mul`, `mm`, `bmm`, `dot`, `sum`, `cumprod`, and `stack`.

## Test Plan

The new regression test failed before the implementation change because forwarding the `ComplexTensor` output to component ops recursively invokes the same ComplexTensor handler.

After applying the fix and running:

```
python test/complex_tensor/test_complex_tensor.py \
  -k out_variants_do_not_redispatch \
  -v
```
Tests pass.

## Checklist

- [ ] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [x] Updated documentation (not applicable; internal correctness fix)
- [x] Included benchmark results (not applicable; no performance impact expected)
