### PR TITLE
[Inductor] Reuse DeviceInterface for out-of-tree C++ device options

### DIFF
--- a/test/inductor/test_cpp_builder.py
+++ b/test/inductor/test_cpp_builder.py
@@ -1,35 +1,33 @@
 # Owner(s): ["oncall: cpu inductor"]
 
-import warnings
-
-from torch._inductor.cpp_builder import (
-    _cpp_device_options_registry,
-    get_cpp_torch_device_options,
-    register_cpp_device_options,
+from torch._dynamo.device_interface import (
+    DeviceInterface,
+    device_interfaces,
+    register_interface_for_device,
 )
+from torch._inductor.cpp_builder import get_cpp_torch_device_options
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 
 class TestCppBuilder(TestCase):
-    def tearDown(self) -> None:
-        _cpp_device_options_registry.clear()
+    def test_device_interface_cpp_options(self) -> None:
+        class MockDeviceInterface(DeviceInterface):
+            @staticmethod
+            def get_cpp_device_options(aot_mode, compile_only):
+                self.assertFalse(aot_mode)
+                self.assertFalse(compile_only)
+                return (
+                    ["USE_MOCK"],
+                    ["/mock/include"],
+                    ["mock_cflag"],
+                    ["mock_ldflag"],
+                    ["/mock/lib"],
+                    ["mocklib"],
+                    ["-DMOCK_PASSTHROUGH"],
+                )
 
-    def test_register_cpp_device_options(self) -> None:
-        def mock_options(device_type, aot_mode, compile_only):
-            self.assertEqual(device_type, "mock")
-            self.assertFalse(aot_mode)
-            self.assertFalse(compile_only)
-            return (
-                ["USE_MOCK"],
-                ["/mock/include"],
-                ["mock_cflag"],
-                ["mock_ldflag"],
-                ["/mock/lib"],
-                ["mocklib"],
-                ["-DMOCK_PASSTHROUGH"],
-            )
-
-        register_cpp_device_options("mock", mock_options)
+        self.addCleanup(device_interfaces.pop, "mock", None)
+        register_interface_for_device("mock", MockDeviceInterface)
         result = get_cpp_torch_device_options("mock", False, False)
         self.assertEqual(
             result,
@@ -44,19 +42,13 @@ class TestCppBuilder(TestCase):
             ),
         )
 
-    def test_register_duplicate_warns(self) -> None:
-        def mock_options(device_type, aot_mode, compile_only):
-            return ([], [], [], [], [], [], [])
+    def test_device_interface_without_cpp_options_uses_default_options(self) -> None:
+        class MockDeviceInterface(DeviceInterface):
+            pass
 
-        register_cpp_device_options("mock", mock_options)
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            register_cpp_device_options("mock", mock_options)
-        self.assertEqual(len(w), 1)
-        self.assertIn("already registered", str(w[0].message))
-
-    def test_unregistered_device_options_unchanged(self) -> None:
-        result = get_cpp_torch_device_options("unregistered_device_xyz", False, False)
+        self.addCleanup(device_interfaces.pop, "mock_no_options", None)
+        register_interface_for_device("mock_no_options", MockDeviceInterface)
+        result = get_cpp_torch_device_options("mock_no_options", False, False)
         definitions, _inc, cflags, _ld, _libdirs, libraries, passthrough = result
         self.assertEqual(definitions, [])
         self.assertEqual(cflags, [])

--- a/test/inductor/test_cpp_builder.py
+++ b/test/inductor/test_cpp_builder.py
@@ -1,0 +1,68 @@
+# Owner(s): ["oncall: cpu inductor"]
+
+import warnings
+
+from torch._inductor.cpp_builder import (
+    _cpp_device_options_registry,
+    get_cpp_torch_device_options,
+    register_cpp_device_options,
+)
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestCppBuilder(TestCase):
+    def tearDown(self) -> None:
+        _cpp_device_options_registry.clear()
+
+    def test_register_cpp_device_options(self) -> None:
+        def mock_options(device_type, aot_mode, compile_only):
+            self.assertEqual(device_type, "mock")
+            self.assertFalse(aot_mode)
+            self.assertFalse(compile_only)
+            return (
+                ["USE_MOCK"],
+                ["/mock/include"],
+                ["mock_cflag"],
+                ["mock_ldflag"],
+                ["/mock/lib"],
+                ["mocklib"],
+                ["-DMOCK_PASSTHROUGH"],
+            )
+
+        register_cpp_device_options("mock", mock_options)
+        result = get_cpp_torch_device_options("mock", False, False)
+        self.assertEqual(
+            result,
+            (
+                ["USE_MOCK"],
+                ["/mock/include"],
+                ["mock_cflag"],
+                ["mock_ldflag"],
+                ["/mock/lib"],
+                ["mocklib"],
+                ["-DMOCK_PASSTHROUGH"],
+            ),
+        )
+
+    def test_register_duplicate_warns(self) -> None:
+        def mock_options(device_type, aot_mode, compile_only):
+            return ([], [], [], [], [], [], [])
+
+        register_cpp_device_options("mock", mock_options)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            register_cpp_device_options("mock", mock_options)
+        self.assertEqual(len(w), 1)
+        self.assertIn("already registered", str(w[0].message))
+
+    def test_unregistered_device_options_unchanged(self) -> None:
+        result = get_cpp_torch_device_options("unregistered_device_xyz", False, False)
+        definitions, _include_dirs, cflags, _ldflags, _lib_dirs, libraries, passthrough = result
+        self.assertEqual(definitions, [])
+        self.assertEqual(cflags, [])
+        self.assertEqual(libraries, [])
+        self.assertEqual(passthrough, [])
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/inductor/test_cpp_builder.py
+++ b/test/inductor/test_cpp_builder.py
@@ -57,7 +57,7 @@ class TestCppBuilder(TestCase):
 
     def test_unregistered_device_options_unchanged(self) -> None:
         result = get_cpp_torch_device_options("unregistered_device_xyz", False, False)
-        definitions, _include_dirs, cflags, _ldflags, _lib_dirs, libraries, passthrough = result
+        definitions, _inc, cflags, _ld, _libdirs, libraries, passthrough = result
         self.assertEqual(definitions, [])
         self.assertEqual(cflags, [])
         self.assertEqual(libraries, [])

--- a/test/inductor/test_cpp_builder.py
+++ b/test/inductor/test_cpp_builder.py
@@ -1,8 +1,8 @@
 # Owner(s): ["oncall: cpu inductor"]
 
 from torch._dynamo.device_interface import (
-    DeviceInterface,
     device_interfaces,
+    DeviceInterface,
     register_interface_for_device,
 )
 from torch._inductor.cpp_builder import get_cpp_torch_device_options

--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -43,6 +43,26 @@ class DeviceInterface:
     backends to be integrated with Inductor in a device-agnostic semantic.
     """
 
+    @staticmethod
+    def get_cpp_device_options(
+        aot_mode: bool, compile_only: bool
+    ) -> tuple[
+        list[str],
+        list[str],
+        list[str],
+        list[str],
+        list[str],
+        list[str],
+        list[str],
+    ] | None:
+        """Return device-specific C++ build options, if the backend provides them.
+
+        Out-of-tree backends may override this to return
+        ``(definitions, include_dirs, cflags, ldflags, library_dirs,
+        libraries, passthrough_args)`` for Inductor C++ compilation.
+        """
+        return None
+
     class device:
         def __new__(cls, device: torch.types.Device) -> Any:
             raise NotImplementedError

--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -46,15 +46,18 @@ class DeviceInterface:
     @staticmethod
     def get_cpp_device_options(
         aot_mode: bool, compile_only: bool
-    ) -> tuple[
-        list[str],
-        list[str],
-        list[str],
-        list[str],
-        list[str],
-        list[str],
-        list[str],
-    ] | None:
+    ) -> (
+        tuple[
+            list[str],
+            list[str],
+            list[str],
+            list[str],
+            list[str],
+            list[str],
+            list[str],
+        ]
+        | None
+    ):
         """Return device-specific C++ build options, if the backend provides them.
 
         Out-of-tree backends may override this to return

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -19,13 +19,14 @@ import sysconfig
 import tempfile
 import textwrap
 import warnings
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 from ctypes import cdll, wintypes
 from ctypes.util import find_library
 from pathlib import Path
 from typing import Any, Literal
 
 import torch
+from torch._dynamo.device_interface import get_interface_for_device
 from torch._dynamo.utils import dynamo_timed
 from torch._inductor import config, exc
 from torch._inductor.cpu_vec_isa import invalid_vec_isa, VecISA
@@ -2152,37 +2153,6 @@ def _transform_rocm_paths(lpaths: list[str]) -> None:
             lpaths.append(sdk_lib)
 
 
-# Registry for out-of-tree device backends to provide C++ compile options.
-# Maps device_type (e.g. "npu") to a callback with the same signature as
-# get_cpp_torch_device_options.
-_cpp_device_options_registry: dict[str, Callable] = {}
-
-
-def register_cpp_device_options(
-    device_type: str,
-    callback: Callable,
-) -> None:
-    """Register C++ build options for a device type.
-
-    Allows out-of-tree device backends (e.g., PrivateUse1 devices like NPU)
-    to inject their own compile options into Inductor's C++ compilation
-    pipeline without monkey-patching.
-
-    Args:
-        device_type: The device type string (e.g. "npu").
-        callback: A callable with the same signature as
-            :func:`get_cpp_torch_device_options`:
-            ``(device_type, aot_mode, compile_only) ->
-            tuple[definitions, include_dirs, cflags, ldflags,
-                  libraries_dirs, libraries, passthrough_args]``
-    """
-    if device_type in _cpp_device_options_registry:
-        warnings.warn(
-            f"Device options for '{device_type}' is already registered, overwriting."
-        )
-    _cpp_device_options_registry[device_type] = callback
-
-
 def get_cpp_torch_device_options(
     device_type: str,
     aot_mode: bool = False,
@@ -2199,6 +2169,15 @@ def get_cpp_torch_device_options(
     # CppTorchDeviceOptions validates too, but this is a public entry point in
     # its own right.
     _validate_cpp_stdlib(cpp_stdlib, device_type, aot_mode)
+
+    try:
+        device_options = get_interface_for_device(
+            device_type
+        ).get_cpp_device_options(aot_mode, compile_only)
+    except NotImplementedError:
+        device_options = None
+    if device_options is not None:
+        return device_options
 
     definitions: list[str] = []
     include_dirs: list[str] = []
@@ -2277,12 +2256,6 @@ def get_cpp_torch_device_options(
 
     if device_type == "mps":
         definitions.append(" USE_MPS")
-
-    # Check registered device backends (e.g., PrivateUse1 devices like NPU)
-    if device_type in _cpp_device_options_registry:
-        return _cpp_device_options_registry[device_type](
-            device_type, aot_mode, compile_only
-        )
 
     if config.is_fbcode():
         include_dirs.append(build_paths.sdk_include)

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -19,7 +19,7 @@ import sysconfig
 import tempfile
 import textwrap
 import warnings
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from ctypes import cdll, wintypes
 from ctypes.util import find_library
 from pathlib import Path
@@ -2152,6 +2152,37 @@ def _transform_rocm_paths(lpaths: list[str]) -> None:
             lpaths.append(sdk_lib)
 
 
+# Registry for out-of-tree device backends to provide C++ compile options.
+# Maps device_type (e.g. "npu") to a callback with the same signature as
+# get_cpp_torch_device_options.
+_cpp_device_options_registry: dict[str, Callable] = {}
+
+
+def register_cpp_device_options(
+    device_type: str,
+    callback: Callable,
+) -> None:
+    """Register C++ build options for a device type.
+
+    Allows out-of-tree device backends (e.g., PrivateUse1 devices like NPU)
+    to inject their own compile options into Inductor's C++ compilation
+    pipeline without monkey-patching.
+
+    Args:
+        device_type: The device type string (e.g. "npu").
+        callback: A callable with the same signature as
+            :func:`get_cpp_torch_device_options`:
+            ``(device_type, aot_mode, compile_only) ->
+            tuple[definitions, include_dirs, cflags, ldflags,
+                  libraries_dirs, libraries, passthrough_args]``
+    """
+    if device_type in _cpp_device_options_registry:
+        warnings.warn(
+            f"Device options for '{device_type}' is already registered, overwriting."
+        )
+    _cpp_device_options_registry[device_type] = callback
+
+
 def get_cpp_torch_device_options(
     device_type: str,
     aot_mode: bool = False,
@@ -2246,6 +2277,12 @@ def get_cpp_torch_device_options(
 
     if device_type == "mps":
         definitions.append(" USE_MPS")
+
+    # Check registered device backends (e.g., PrivateUse1 devices like NPU)
+    if device_type in _cpp_device_options_registry:
+        return _cpp_device_options_registry[device_type](
+            device_type, aot_mode, compile_only
+        )
 
     if config.is_fbcode():
         include_dirs.append(build_paths.sdk_include)

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -2171,9 +2171,9 @@ def get_cpp_torch_device_options(
     _validate_cpp_stdlib(cpp_stdlib, device_type, aot_mode)
 
     try:
-        device_options = get_interface_for_device(
-            device_type
-        ).get_cpp_device_options(aot_mode, compile_only)
+        device_options = get_interface_for_device(device_type).get_cpp_device_options(
+            aot_mode, compile_only
+        )
     except NotImplementedError:
         device_options = None
     if device_options is not None:

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -19,7 +19,7 @@ import sysconfig
 import tempfile
 import textwrap
 import warnings
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from ctypes import cdll, wintypes
 from ctypes.util import find_library
 from pathlib import Path
@@ -2017,6 +2017,37 @@ def _transform_rocm_paths(lpaths: list[str]) -> None:
             lpaths.append(sdk_lib)
 
 
+# Registry for out-of-tree device backends to provide C++ compile options.
+# Maps device_type (e.g. "npu") to a callback with the same signature as
+# get_cpp_torch_device_options.
+_cpp_device_options_registry: dict[str, Callable] = {}
+
+
+def register_cpp_device_options(
+    device_type: str,
+    callback: Callable,
+) -> None:
+    """Register C++ build options for a device type.
+
+    Allows out-of-tree device backends (e.g., PrivateUse1 devices like NPU)
+    to inject their own compile options into Inductor's C++ compilation
+    pipeline without monkey-patching.
+
+    Args:
+        device_type: The device type string (e.g. "npu").
+        callback: A callable with the same signature as
+            :func:`get_cpp_torch_device_options`:
+            ``(device_type, aot_mode, compile_only) ->
+            tuple[definitions, include_dirs, cflags, ldflags,
+                  libraries_dirs, libraries, passthrough_args]``
+    """
+    if device_type in _cpp_device_options_registry:
+        warnings.warn(
+            f"Device options for '{device_type}' is already registered, overwriting."
+        )
+    _cpp_device_options_registry[device_type] = callback
+
+
 def get_cpp_torch_device_options(
     device_type: str,
     aot_mode: bool = False,
@@ -2099,6 +2130,12 @@ def get_cpp_torch_device_options(
 
     if device_type == "mps":
         definitions.append(" USE_MPS")
+
+    # Check registered device backends (e.g., PrivateUse1 devices like NPU)
+    if device_type in _cpp_device_options_registry:
+        return _cpp_device_options_registry[device_type](
+            device_type, aot_mode, compile_only
+        )
 
     if config.is_fbcode():
         include_dirs.append(build_paths.sdk_include)


### PR DESCRIPTION
Reuse the existing DeviceInterface registration path so out-of-tree backends
(e.g. NPU) can provide device-specific C++ compile options without
monkey-patching `get_cpp_torch_device_options()`.

Changes:

- Add an optional `get_cpp_device_options()` method to `DeviceInterface`
- `get_cpp_torch_device_options()` queries the registered device interface
  for device-specific C++ options
- Preserve existing behavior when the device interface does not provide
  C++ options

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98
@XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy
@kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben
@jataylo @azahed98