### PR TITLE
Turn capture_sparse_compute on by default internally (#190617)

### DIFF
--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -522,7 +522,7 @@ allow_rnn = False
 # exported FX graph. This flag should become the default eventually
 # and be removed, but currently provides a way to fall back to old
 # graph breaking behavior.
-capture_sparse_compute = not is_fbcode()
+capture_sparse_compute = True
 
 # If true, error if we try to compile a function that has
 # been seen before.


### PR DESCRIPTION
Summary:

As title

Test Plan: Green signals

Reviewed By: angelayi

Differential Revision: D112015590




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98