### PR TITLE
[c10d][nccl2] Wrap single-op P2P send/recv in ncclGroupStart/End

### DIFF
--- a/test/distributed/test_c10d_nccl2.py
+++ b/test/distributed/test_c10d_nccl2.py
@@ -56,6 +56,59 @@ class ProcessGroupNCCLLazyTest(MultiProcContinuousTest):
         self.assertGreaterEqual(backend._num_active_channels(), expected)
 
 
+class ProcessGroupNCCL2Test(MultiProcContinuousTest):
+    @classmethod
+    def backend_str(cls) -> str:
+        return "nccl2"
+
+    @classmethod
+    def device_type(cls) -> str:
+        return "cuda"
+
+    @property
+    def device(self) -> torch.device:
+        return torch.device("cuda", self.rank)
+
+    def setUp(self) -> None:
+        super().setUp()
+        torch.cuda.set_device(self.rank)
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_p2p_send_recv_event_ordering(self) -> None:
+        # Regression test for the single-op P2P group-wrap fix (TorchComms
+        # D109625550). sendImpl/recvImpl now wrap ncclSend/ncclRecv in
+        # ncclGroupStart/End so the kernel is enqueued before the end CUDA
+        # event is recorded. Loop with distinct per-iteration values and read
+        # back immediately after wait(): an early event completion (the bug)
+        # would surface as a value mismatch.
+        #
+        # Exchange within disjoint rank pairs (r ^ 1). send and recv share the
+        # backend's internal stream, so the two ops run in issue order on it;
+        # even ranks issue send-then-recv and odd ranks recv-then-send so the
+        # matching kernels rendezvous instead of deadlocking. A leftover odd
+        # rank (odd world_size) has no partner and sits out.
+        paired = (self.world_size // 2) * 2
+        if self.rank >= paired:
+            return
+        partner = self.rank ^ 1
+        numel = 1024 * 1024
+        for i in range(50):
+            send_val = float(i + 1) + self.rank
+            recv_val = float(i + 1) + partner
+            send_t = torch.full((numel,), send_val, device=self.device)
+            recv_t = torch.empty((numel,), device=self.device)
+            if self.rank % 2 == 0:
+                send_work = dist.isend(send_t, partner)
+                recv_work = dist.irecv(recv_t, partner)
+            else:
+                recv_work = dist.irecv(recv_t, partner)
+                send_work = dist.isend(send_t, partner)
+            send_work.wait()
+            recv_work.wait()
+            self.assertEqual(recv_t, torch.full((numel,), recv_val, device=self.device))
+
+
 if __name__ == "__main__":
     if TEST_CUDA:
         run_tests()

--- a/test/distributed/test_c10d_torchcomms.py
+++ b/test/distributed/test_c10d_torchcomms.py
@@ -707,5 +707,101 @@ class TestC10dTorchCommsNewGroupHelper(TestCase):
         split_src.perform_nocolor_split.assert_called_once_with(torch.device("cuda:0"))
 
 
+class TestC10dGroupNameHashSalt(TestCase):
+    """Unit-test the collective-consistent group-name hash salt.
+
+    ``_hash_ranks_to_str`` / ``_process_group_name`` are generic c10d helpers
+    (not TorchComms-specific), but the divergence they can produce was surfaced
+    by the TorchComms subgroup work. After an earlier asymmetric-membership
+    ``new_group`` (e.g. ``new_group([0])``), member and non-member ranks hold
+    different ``len(_world.pg_names)`` because only members register a PG.
+    Salting the hash with that length makes ranks compute DIFFERENT names for the
+    same later group; backends that use the group name as a rendezvous store
+    prefix (e.g. Gloo split's ``connectFullMesh``) then key off mismatched
+    prefixes and deadlock. The salt must instead be ``_world.group_count``, which
+    every rank advances in lockstep -- ``_process_group_name`` increments it
+    before the membership check, on BOTH the hashed and non-hashed paths.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self._saved_group_count = c10d._world.group_count
+        self._saved_pg_names = dict(c10d._world.pg_names)
+
+    def tearDown(self):
+        c10d._world.group_count = self._saved_group_count
+        c10d._world.pg_names.clear()
+        c10d._world.pg_names.update(self._saved_pg_names)
+        super().tearDown()
+
+    def _register_dummy_pgs(self, n):
+        # Simulate a rank that registered extra PGs (asymmetric membership).
+        for i in range(n):
+            c10d._world.pg_names[object()] = c10d.GroupName(f"dummy_{i}")
+
+    def test_hash_salt_uses_group_count(self):
+        # Same ranks, different group_count -> different name (salt is live).
+        ranks = [0, 1, 2, 3]
+        c10d._world.group_count = 5
+        name_a = c10d._hash_ranks_to_str(ranks)
+        c10d._world.group_count = 6
+        name_b = c10d._hash_ranks_to_str(ranks)
+        self.assertNotEqual(name_a, name_b)
+
+    def test_hash_independent_of_pg_names_length(self):
+        # ROOT-CAUSE regression: the hash must NOT depend on len(_world.pg_names),
+        # the quantity that diverges across ranks under asymmetric membership.
+        ranks = [0, 1, 2, 3]
+        c10d._world.group_count = 9
+        c10d._world.pg_names.clear()
+        name_few = c10d._hash_ranks_to_str(ranks)
+        self._register_dummy_pgs(5)
+        name_many = c10d._hash_ranks_to_str(ranks)
+        self.assertEqual(name_few, name_many)
+
+    def test_two_asymmetric_ranks_agree_on_name(self):
+        # The deadlock scenario end-to-end through _process_group_name: two ranks
+        # that made the SAME sequence of group-creation calls (equal group_count)
+        # but registered a DIFFERENT number of PGs must compute the same name.
+        ranks = [0, 1, 2, 3]
+        # Rank that was a member of earlier subgroups: more pg_names.
+        c10d._world.group_count = 3
+        c10d._world.pg_names.clear()
+        self._register_dummy_pgs(2)
+        name_member = c10d._process_group_name(ranks, use_hashed_name=True)
+        # Rank that was a non-member: fewer pg_names, but same group_count because
+        # every rank advances it in lockstep regardless of membership.
+        c10d._world.group_count = 3
+        c10d._world.pg_names.clear()
+        name_non_member = c10d._process_group_name(ranks, use_hashed_name=True)
+        self.assertEqual(name_member, name_non_member)
+
+    def test_process_group_name_increments_on_hashed_path(self):
+        c10d._world.group_count = 10
+        c10d._process_group_name([0, 1], use_hashed_name=True)
+        self.assertEqual(c10d._world.group_count, 11)
+
+    def test_process_group_name_increments_on_nonhashed_path(self):
+        c10d._world.group_count = 20
+        c10d._process_group_name([0, 1], use_hashed_name=False)
+        self.assertEqual(c10d._world.group_count, 21)
+
+    def test_nonhashed_name_is_group_count_before_increment(self):
+        c10d._world.group_count = 42
+        name = c10d._process_group_name([0, 1], use_hashed_name=False)
+        self.assertEqual(name, "42")
+        self.assertEqual(c10d._world.group_count, 43)
+
+    def test_repeated_hashed_same_ranks_get_distinct_names(self):
+        # Two distinct PGs over identical ranks must get distinct names; the salt
+        # advancing on the hashed path (fixed by this commit) is what
+        # disambiguates them. Before the fix the hashed path left group_count
+        # unchanged, so back-to-back splits over the same ranks collided.
+        c10d._world.group_count = 0
+        first = c10d._process_group_name([2, 3], use_hashed_name=True)
+        second = c10d._process_group_name([2, 3], use_hashed_name=True)
+        self.assertNotEqual(first, second)
+
+
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/test_c10d_torchcomms.py
+++ b/test/distributed/test_c10d_torchcomms.py
@@ -538,5 +538,174 @@ class TestTorchCommsHandlesBackend(TestCase):
             self.assertTrue(c10d._torchcomms_handles_backend(" nccl , "))
 
 
+class TestC10dTorchCommsNewGroupHelper(TestCase):
+    """Unit-test the TorchComms-specific branches of ``_new_process_group_helper``.
+
+    These cover the three subgroup-init fixes: the device handed to ``new_comm``
+    carries this rank's device index (``device_id``) rather than a device-type-only
+    device; ``TORCHCOMM_RANK``/``TORCHCOMM_SIZE`` are seeded from the group's
+    rank/size around the ``new_comm`` call and restored afterwards; and a
+    non-member of a subgroup must NOT issue a no-color parent split under
+    TorchComms. Everything TorchComms-specific is patched (``create=True``), so
+    these run even when TorchComms is not installed.
+    """
+
+    TIMEOUT = datetime.timedelta(seconds=30)
+
+    def _drive_member(self, *, backend, device_id, group_rank, group_size):
+        """Drive the members path down to ``new_comm``.
+
+        ``new_comm`` is mocked to capture its device argument and the live env,
+        then abort with a sentinel so we never touch real comm machinery. Uses
+        the default-group path (``global_ranks_in_group == []``) so no
+        initialized world is required. Returns the captured dict.
+        """
+        captured = {}
+
+        def fake_new_comm(backend_str, device, name=None, store=None, hints=None):
+            captured["backend_str"] = backend_str
+            captured["device"] = device
+            captured["rank_env"] = os.environ.get("TORCHCOMM_RANK")
+            captured["size_env"] = os.environ.get("TORCHCOMM_SIZE")
+            raise RuntimeError("stop-after-new_comm")
+
+        with mock.patch.multiple(
+            c10d,
+            _use_torchcomms_enabled=lambda: True,
+            _torchcomms_handles_backend=lambda b: True,
+            new_comm=fake_new_comm,
+            create=True,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "stop-after-new_comm"):
+                c10d._new_process_group_helper(
+                    group_size=group_size,
+                    group_rank=group_rank,
+                    global_ranks_in_group=[],
+                    backend=backend,
+                    store=dist.HashStore(),
+                    group_name=c10d.GroupName(self.id()),
+                    timeout=self.TIMEOUT,
+                    device_id=device_id,
+                )
+        return captured
+
+    def test_new_comm_gets_indexed_device_id(self):
+        # A subgroup's group-local rank differs from the rank's physical device,
+        # so new_comm must receive device_id (WITH index), not a device-type-only
+        # device. group_rank (2) deliberately differs from the device index (3).
+        cap = self._drive_member(
+            backend="nccl",
+            device_id=torch.device("cuda:3"),
+            group_rank=2,
+            group_size=4,
+        )
+        self.assertEqual(cap["device"], torch.device("cuda:3"))
+
+    def test_new_comm_device_type_mismatch_not_overridden(self):
+        # gloo maps to the cpu device; device_id is a cuda device, so the type
+        # guard must leave cpu alone rather than substituting cuda:3.
+        cap = self._drive_member(
+            backend="gloo",
+            device_id=torch.device("cuda:3"),
+            group_rank=1,
+            group_size=4,
+        )
+        self.assertEqual(cap["device"], torch.device("cpu"))
+
+    def test_new_comm_without_device_id_keeps_type_only_device(self):
+        # World-group path: no device_id bound, so the guard must not fire and
+        # new_comm gets the device-type-only device from the backend map.
+        cap = self._drive_member(
+            backend="nccl",
+            device_id=None,
+            group_rank=0,
+            group_size=4,
+        )
+        self.assertEqual(cap["device"], torch.device("cuda"))
+
+    def test_torchcomm_rank_size_seeded_from_group(self):
+        cap = self._drive_member(
+            backend="nccl",
+            device_id=torch.device("cuda:1"),
+            group_rank=2,
+            group_size=7,
+        )
+        self.assertEqual(cap["rank_env"], "2")
+        self.assertEqual(cap["size_env"], "7")
+
+    def test_torchcomm_rank_size_restored_after_call(self):
+        saved = {k: os.environ.get(k) for k in ("TORCHCOMM_RANK", "TORCHCOMM_SIZE")}
+        try:
+            for k in ("TORCHCOMM_RANK", "TORCHCOMM_SIZE"):
+                os.environ.pop(k, None)
+            # Unset before -> unset after.
+            self._drive_member(
+                backend="nccl",
+                device_id=torch.device("cuda:0"),
+                group_rank=0,
+                group_size=2,
+            )
+            self.assertIsNone(os.environ.get("TORCHCOMM_RANK"))
+            self.assertIsNone(os.environ.get("TORCHCOMM_SIZE"))
+            # Set before -> original values restored after.
+            os.environ["TORCHCOMM_RANK"] = "99"
+            os.environ["TORCHCOMM_SIZE"] = "77"
+            self._drive_member(
+                backend="nccl",
+                device_id=torch.device("cuda:0"),
+                group_rank=0,
+                group_size=2,
+            )
+            self.assertEqual(os.environ["TORCHCOMM_RANK"], "99")
+            self.assertEqual(os.environ["TORCHCOMM_SIZE"], "77")
+        finally:
+            for k, v in saved.items():
+                if v is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = v
+
+    def _drive_non_member(self, *, torchcomms_enabled):
+        """Drive the non-member early-return path of a subgroup.
+
+        The default group is faked as initialized and device-bound with this
+        rank (0) absent from the requested subgroup, so ``_new_process_group_helper``
+        takes the ``NON_GROUP_MEMBER`` branch. Returns (result, split_source_mock).
+        """
+        split_src = mock.MagicMock()
+        default = mock.MagicMock()
+        default.rank.return_value = 0
+        default.bound_device_id = torch.device("cuda:0")
+        with mock.patch.multiple(
+            c10d,
+            _use_torchcomms_enabled=lambda: torchcomms_enabled,
+            is_initialized=lambda: True,
+            _get_default_group=lambda: default,
+            _get_split_source=lambda pg: split_src,
+        ):
+            res = c10d._new_process_group_helper(
+                group_size=2,
+                group_rank=0,
+                global_ranks_in_group=[1, 2],  # rank 0 is NOT a member
+                backend="nccl",
+                store=dist.HashStore(),
+                group_name=c10d.GroupName(self.id()),
+                timeout=self.TIMEOUT,
+            )
+        return res, split_src
+
+    def test_non_member_skips_nocolor_split_under_torchcomms(self):
+        res, split_src = self._drive_non_member(torchcomms_enabled=True)
+        self.assertEqual(res, (dist.GroupMember.NON_GROUP_MEMBER, None))
+        split_src.perform_nocolor_split.assert_not_called()
+
+    def test_non_member_performs_nocolor_split_without_torchcomms(self):
+        # Contrast: with TorchComms disabled the NCCL-style path still requires
+        # non-members to issue the no-color split to stay in sync.
+        res, split_src = self._drive_non_member(torchcomms_enabled=False)
+        self.assertEqual(res, (dist.GroupMember.NON_GROUP_MEMBER, None))
+        split_src.perform_nocolor_split.assert_called_once_with(torch.device("cuda:0"))
+
+
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/test_c10d_torchcomms.py
+++ b/test/distributed/test_c10d_torchcomms.py
@@ -1,5 +1,6 @@
 # Owner(s): ["oncall: distributed"]
 
+import datetime
 import os
 import unittest
 from unittest import mock
@@ -221,6 +222,21 @@ class TestC10dTorchCommsBasic(C10dTorchCommsTestBase):
         # If we reach this point, the barrier succeeded without deadlock
         self.assertTrue(True)
 
+    def test_monitored_barrier(self):
+        # monitored_barrier is gloo-only; the default PG is gloo only on the
+        # cpu variant (nccl on cuda/xpu), so run there. This drives the full
+        # dist.monitored_barrier dispatch onto BackendWrapper::monitoredBarrier
+        # (the torchcomms reimplementation of ProcessGroupGloo::monitoredBarrier).
+        if self.device_type != "cpu":
+            return
+        self.assertEqual(dist.get_backend(self.pg), dist.Backend.GLOO)
+        # All ranks check in -> the health-checking barrier returns cleanly.
+        dist.monitored_barrier(
+            group=self.pg,
+            timeout=datetime.timedelta(seconds=30),
+            wait_all_ranks=True,
+        )
+
     def test_new_group_delegates_to_split_group(self):
         # Under torchcomms, `new_group` routes through `split_group`. The
         # resulting subgroup must contain the requested ranks and be usable
@@ -355,6 +371,24 @@ class TestC10dTorchCommsInitAutoQualify(C10dTorchCommsTestBase):
         default_pg = dist.distributed_c10d._get_default_group()
         self.assertIsNotNone(default_pg.bound_device_id)
         self.assertEqual(default_pg.bound_device_id.type, "cuda")
+
+    def test_monitored_barrier_on_multi_backend_group(self):
+        # A device-bound world reports a multi-backend string from get_backend
+        # (e.g. "cpu:gloo,cuda:nccl"), which is NOT equal to Backend.GLOO. The
+        # relaxed monitored_barrier guard must still accept it under torchcomms
+        # (because it contains a gloo backend) and dispatch to the gloo CPU
+        # backend's BackendWrapper::monitoredBarrier, rather than raising
+        # "monitored_barrier is only implemented for GLOO backend".
+        backend = dist.get_backend(self.pg)
+        self.assertNotEqual(backend, dist.Backend.GLOO)
+        self.assertIn("gloo", str(backend))
+        # All ranks check in -> the barrier returns cleanly. Reaching past this
+        # call proves the guard accepted the group and the barrier ran.
+        dist.monitored_barrier(
+            group=self.pg,
+            timeout=datetime.timedelta(seconds=30),
+            wait_all_ranks=True,
+        )
 
     def test_new_group_nccl_lazy_builds_per_peer_group(self):
         # Passing backend="nccl-lazy" builds a per-peer, lazily-initialized

--- a/test/distributed/test_c10d_torchcomms.py
+++ b/test/distributed/test_c10d_torchcomms.py
@@ -803,5 +803,136 @@ class TestC10dGroupNameHashSalt(TestCase):
         self.assertNotEqual(first, second)
 
 
+class _FakeComm:
+    """Stand-in for a TorchComm whose ``finalize`` is not idempotent.
+
+    Mirrors the real comm: the second ``finalize`` raises, exactly the failure
+    ``destroy_process_group`` must avoid when a comm is shared across device
+    types.
+    """
+
+    def __init__(self):
+        self.finalize_calls = 0
+
+    def finalize(self):
+        self.finalize_calls += 1
+        if self.finalize_calls > 1:
+            raise RuntimeError("already finalized")
+
+
+class _FakeBackendWrapper:
+    def __init__(self, comm):
+        self._comm = comm
+
+    def get_comm(self):
+        return self._comm
+
+
+class _FakeOtherBackend:
+    """A c10d backend that is not a _BackendWrapper (must be left untouched)."""
+
+
+class TestC10dTorchCommsDestroyDedup(TestCase):
+    """Unit-test the comm-deduplication in ``destroy_process_group``.
+
+    A gloo subgroup reports both ``cuda`` and ``cpu`` device types backed by the
+    same _BackendWrapper/comm; the destroy loop must finalize each comm exactly
+    once because ``finalize()`` is not idempotent. Everything TorchComms-specific
+    is patched (``create=True``), so these run even when TorchComms is not
+    installed.
+    """
+
+    _WORLD_ATTRS = (
+        "pg_map",
+        "pg_names",
+        "pg_group_ranks",
+        "pg_backend_config",
+        "pg_to_tag",
+        "pg_coalesce_state",
+        "comms",
+    )
+
+    def setUp(self):
+        super().setUp()
+        self._saved_world = {
+            attr: getattr(c10d._world, attr).copy() for attr in self._WORLD_ATTRS
+        }
+
+    def tearDown(self):
+        for attr, value in self._saved_world.items():
+            container = getattr(c10d._world, attr)
+            container.clear()
+            if isinstance(value, dict):
+                container.update(value)
+            else:
+                container.extend(value)
+        super().tearDown()
+
+    def _drive_destroy(self, device_backends):
+        """Register a fake subgroup PG and run ``destroy_process_group`` on it.
+
+        ``device_backends`` maps device type -> backend object; the PG reports
+        those device types and returns the matching backend from
+        ``_get_backend``. Returns the PG mock so callers can assert on teardown.
+        """
+        pg = mock.MagicMock()
+        pg._device_types = list(device_backends)
+        pg._get_backend.side_effect = lambda dev: device_backends[dev]
+        name = c10d.GroupName(self.id())
+        pg.group_name = name
+
+        c10d._world.pg_map[pg] = (None, None)
+        c10d._world.pg_names[pg] = name
+        c10d._world.pg_group_ranks[pg] = {}
+        c10d._world.pg_backend_config[pg] = ""
+        c10d._world.pg_to_tag[pg] = None
+
+        with mock.patch.multiple(
+            c10d,
+            _TORCHCOMM_AVAILABLE=True,
+            _BackendWrapper=_FakeBackendWrapper,
+            _unregister_process_group=lambda group_name: None,
+            create=True,
+        ):
+            c10d.destroy_process_group(pg)
+        return pg
+
+    def test_shared_comm_finalized_once(self):
+        # gloo scenario: one _BackendWrapper/comm shared across cuda and cpu.
+        comm = _FakeComm()
+        wrapper = _FakeBackendWrapper(comm)
+        pg = self._drive_destroy({"cuda": wrapper, "cpu": wrapper})
+        self.assertEqual(comm.finalize_calls, 1)
+        pg.shutdown.assert_called_once()
+        self.assertNotIn(pg, c10d._world.pg_map)
+
+    def test_same_comm_distinct_wrappers_finalized_once(self):
+        # Dedup keys on comm identity, not wrapper identity: two distinct
+        # _BackendWrapper objects sharing one comm still finalize it once.
+        comm = _FakeComm()
+        pg = self._drive_destroy(
+            {"cuda": _FakeBackendWrapper(comm), "cpu": _FakeBackendWrapper(comm)}
+        )
+        self.assertEqual(comm.finalize_calls, 1)
+        pg.shutdown.assert_called_once()
+
+    def test_distinct_comms_each_finalized_once(self):
+        comm_a, comm_b = _FakeComm(), _FakeComm()
+        self._drive_destroy(
+            {"cuda": _FakeBackendWrapper(comm_a), "cpu": _FakeBackendWrapper(comm_b)}
+        )
+        self.assertEqual(comm_a.finalize_calls, 1)
+        self.assertEqual(comm_b.finalize_calls, 1)
+
+    def test_non_backendwrapper_backend_is_skipped(self):
+        # A non-_BackendWrapper backend must not be finalized; the wrapped comm
+        # still finalizes exactly once.
+        comm = _FakeComm()
+        self._drive_destroy(
+            {"cuda": _FakeBackendWrapper(comm), "cpu": _FakeOtherBackend()}
+        )
+        self.assertEqual(comm.finalize_calls, 1)
+
+
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/test_c10d_torchcomms.py
+++ b/test/distributed/test_c10d_torchcomms.py
@@ -233,25 +233,6 @@ class TestC10dTorchCommsBasic(C10dTorchCommsTestBase):
         else:
             self.assertIs(ng, dist.GroupMember.NON_GROUP_MEMBER)
 
-    def test_new_group_via_split_group_raises_on_unsupported_args(self):
-        # `split_group` has a narrower surface than `new_group`; under
-        # torchcomms the delegation must surface that mismatch instead of
-        # silently falling back to the legacy path.
-        ranks = list(range(self.world_size))
-        with self.assertRaisesRegex(NotImplementedError, "use_local_synchronization"):
-            dist.new_group(ranks=ranks, use_local_synchronization=True)
-
-    def test_new_group_sort_ranks_false_preserves_order(self):
-        reversed_ranks = list(range(self.world_size - 1, -1, -1))
-        ng = dist.new_group(ranks=reversed_ranks, sort_ranks=False)
-        self.assertEqual(dist.get_process_group_ranks(ng), reversed_ranks)
-        self.assertEqual(
-            dist.get_group_rank(ng, self.rank), reversed_ranks.index(self.rank)
-        )
-        tensor = torch.tensor([self._rank_value], dtype=torch.float32)
-        dist.all_reduce(tensor, group=ng)
-        self.assertEqual(tensor.item(), sum(range(1, self.world_size + 1)))
-
     def test_new_group_backend_none_narrows_to_default_device(self):
         ranks = list(range(self.world_size))
         ng = dist.new_group(ranks=ranks, backend=None)

--- a/test/distributed/test_c10d_torchcomms.py
+++ b/test/distributed/test_c10d_torchcomms.py
@@ -2,9 +2,11 @@
 
 import os
 import unittest
+from unittest import mock
 
 import torch
 import torch.distributed as dist
+import torch.distributed.distributed_c10d as c10d
 from torch.distributed.distributed_c10d import _TORCHCOMM_AVAILABLE
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import C10dTorchCommsTestBase
@@ -13,6 +15,7 @@ from torch.testing._internal.common_utils import (
     parametrize,
     run_tests,
     subtest,
+    TestCase,
 )
 
 
@@ -353,10 +356,186 @@ class TestC10dTorchCommsInitAutoQualify(C10dTorchCommsTestBase):
         self.assertIsNotNone(default_pg.bound_device_id)
         self.assertEqual(default_pg.bound_device_id.type, "cuda")
 
+    def test_new_group_nccl_lazy_builds_per_peer_group(self):
+        # Passing backend="nccl-lazy" builds a per-peer, lazily-initialized
+        # group (a dedicated comm + stream per send/recv peer) usable for P2P.
+        # use_local_synchronization makes it members-only. The parent must be
+        # device-bound (it is, in this class).
+        ranks = list(range(self.world_size))
+        g = dist.new_group(
+            ranks=ranks, backend="nccl-lazy", use_local_synchronization=True
+        )
+        self.assertEqual(dist.get_process_group_ranks(g), ranks)
+        # P2P round-trip over the lazy group: 0 -> 1 -> ... -> 0
+        dev = torch.device(f"cuda:{self.rank}")
+        send_to = (self.rank + 1) % self.world_size
+        recv_from = (self.rank - 1) % self.world_size
+        if self.rank % 2 == 0:
+            dist.send(
+                torch.full((4,), float(self.rank), device=dev), dst=send_to, group=g
+            )
+            r = torch.empty(4, device=dev)
+            dist.recv(r, src=recv_from, group=g)
+        else:
+            r = torch.empty(4, device=dev)
+            dist.recv(r, src=recv_from, group=g)
+            dist.send(
+                torch.full((4,), float(self.rank), device=dev), dst=send_to, group=g
+            )
+        self.assertEqual(r[0].item(), float(recv_from))
+
+    def test_non_torchcomms_backend_falls_through_to_c10d(self):
+        # Under torchcomms, a backend TorchComms does not own (registered the way
+        # mooncake registers a custom c10d backend) must route through the normal
+        # ProcessGroup path, not new_comm. Use a gloo-backed stand-in.
+        def _creator(store, grank, gsize, timeout):
+            return dist.ProcessGroupGloo(store, grank, gsize, timeout)
+
+        name = "tc_gate_stub"
+        if name not in dist.Backend.backend_list:
+            dist.Backend.register_backend(name, _creator, devices=["cpu", "cuda"])
+
+        ranks = list(range(self.world_size))
+        g = dist.new_group(ranks=ranks, backend=name)
+        be = g._get_backend(torch.device("cpu"))
+        # The c10d creator ran (real ProcessGroupGloo), not a TorchComms wrapper.
+        self.assertNotIn("BackendWrapper", type(be).__name__)
+        t = torch.tensor([self._rank_value], dtype=torch.float32)
+        dist.all_reduce(t, group=g)
+        self.assertEqual(t.item(), sum(range(1, self.world_size + 1)))
+
 
 instantiate_device_type_tests(
     TestC10dTorchCommsInitAutoQualify, globals(), only_for=["cuda"]
 )
+
+
+@unittest.skipIf(not _TORCHCOMM_AVAILABLE, "TorchComms is not installed")
+class TestC10dTorchCommsMixedBackends(C10dTorchCommsTestBase):
+    """Verify subgroup creation from a mixed-backend parent under torchcomms.
+
+    The parent PG mixes ``cuda:nccl`` with ``cpu:fake``. Under torchcomms,
+    ``new_group`` builds each subgroup directly via ``new_comm`` (a members-only
+    store rendezvous), so a non-splittable device backend in the parent (here
+    ``cpu:fake``) is no obstacle: members construct the subgroup and non-members
+    return ``NON_GROUP_MEMBER`` without any parent split.
+    """
+
+    @classmethod
+    def _init_pg(cls, rank, world_size, rdvz_file):
+        torch.distributed.config.use_torchcomms = True
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        os.environ["RANK"] = str(rank)
+        os.environ["WORLD_SIZE"] = str(world_size)
+        os.environ["TORCHCOMM_STORE_PATH"] = rdvz_file
+        os.environ["LOCAL_RANK"] = str(rank)
+
+        store = dist.FileStore(rdvz_file, world_size)
+        device_id = torch.device(f"cuda:{rank}")
+        torch.cuda.set_device(rank)
+
+        dist.init_process_group(
+            backend="cuda:nccl,cpu:fake",
+            world_size=world_size,
+            rank=rank,
+            store=store,
+            device_id=device_id,
+        )
+        cls.pg = dist.distributed_c10d._get_default_group()
+        torch.set_default_device(device_id)
+
+    @property
+    def _rank_value(self):
+        return self.rank + 1
+
+    def test_mixed_backend_subgroup(self):
+        subg_ranks = list(range(self.world_size // 2))
+        ng = dist.new_group(ranks=subg_ranks)
+
+        if self.rank in subg_ranks:
+            self.assertEqual(dist.get_process_group_ranks(ng), subg_ranks)
+            tensor = torch.tensor([self._rank_value], dtype=torch.float32)
+            dist.all_reduce(tensor, group=ng)
+            self.assertEqual(tensor.item(), sum(r + 1 for r in subg_ranks))
+        else:
+            self.assertIs(ng, dist.GroupMember.NON_GROUP_MEMBER)
+
+
+instantiate_device_type_tests(
+    TestC10dTorchCommsMixedBackends, globals(), only_for=["cuda"]
+)
+
+
+class TestTorchCommsHandlesBackend(TestCase):
+    """Unit-test the pure routing logic of ``_torchcomms_handles_backend``.
+
+    This decides whether a backend is one TorchComms can construct (so it goes
+    through ``new_comm`` / ``split_group``) versus a custom c10d plugin such as
+    ``mooncake`` that must fall through to the normal ProcessGroup path. The
+    function depends only on ``_TORCHCOMM_AVAILABLE`` and the two
+    ``is_backend_*`` callables, all of which we patch -- so these tests run even
+    when torchcomms is not installed.
+    """
+
+    def _patch(self, available=True, built=(), registered=()):
+        built, registered = set(built), set(registered)
+        return mock.patch.multiple(
+            c10d,
+            _TORCHCOMM_AVAILABLE=available,
+            _torchcomms_is_backend_built=lambda name: name in built,
+            _torchcomms_is_backend_registered=lambda name: name in registered,
+            create=True,
+        )
+
+    def test_unavailable_returns_false(self):
+        with self._patch(available=False, built=["nccl"]):
+            self.assertFalse(c10d._torchcomms_handles_backend("nccl"))
+            self.assertFalse(c10d._torchcomms_handles_backend(None))
+
+    def test_none_backend_inherits_parent(self):
+        with self._patch(built=[]):
+            self.assertTrue(c10d._torchcomms_handles_backend(None))
+
+    def test_builtin_backend(self):
+        with self._patch(built=["nccl"]):
+            self.assertTrue(c10d._torchcomms_handles_backend("nccl"))
+
+    def test_registered_backend(self):
+        with self._patch(registered=["myadapter"]):
+            self.assertTrue(c10d._torchcomms_handles_backend("myadapter"))
+
+    def test_custom_backend_falls_through(self):
+        with self._patch(built=["nccl"]):
+            self.assertFalse(c10d._torchcomms_handles_backend("mooncake"))
+            self.assertFalse(c10d._torchcomms_handles_backend("ucc"))
+
+    def test_case_insensitive(self):
+        with self._patch(built=["nccl"]):
+            self.assertTrue(c10d._torchcomms_handles_backend("NCCL"))
+
+    def test_nccl_lazy_is_own_backend(self):
+        # nccl-lazy is a distinct built torchcomms backend, not aliased to nccl:
+        # it is handled iff nccl-lazy itself is built/registered.
+        with self._patch(built=["nccl-lazy"]):
+            self.assertTrue(c10d._torchcomms_handles_backend("nccl-lazy"))
+        with self._patch(built=["nccl"]):
+            self.assertFalse(c10d._torchcomms_handles_backend("nccl-lazy"))
+        with self._patch(built=[]):
+            self.assertFalse(c10d._torchcomms_handles_backend("nccl-lazy"))
+
+    def test_qualified_all_handled(self):
+        with self._patch(built=["gloo", "nccl"]):
+            self.assertTrue(c10d._torchcomms_handles_backend("cpu:gloo,cuda:nccl"))
+
+    def test_qualified_one_unhandled_falls_through(self):
+        with self._patch(built=["gloo"]):
+            self.assertFalse(c10d._torchcomms_handles_backend("cpu:gloo,cuda:mooncake"))
+
+    def test_empty_parts_are_skipped(self):
+        with self._patch(built=["nccl"]):
+            self.assertTrue(c10d._torchcomms_handles_backend("nccl,"))
+            self.assertTrue(c10d._torchcomms_handles_backend(" nccl , "))
 
 
 if __name__ == "__main__":

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
@@ -375,17 +375,35 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::sendImpl(
   // Record start event before NCCL operation
   work->recordStart("send");
 
+  // Wrap in ncclGroupStart/End so the kernel is enqueued on the stream before
+  // we record the end event. Without the group wrapper, a non-blocking NCCL
+  // comm may defer the kernel launch past the end-event record, so the event
+  // can fire before the transfer completes and work.wait() returns with
+  // stale/partial data. Matches batch_op_issue and stock
+  // ProcessGroupNCCL::pointToPoint. (TorchComms fix D109625550.)
   NCCL_CHECK(
-      nccl_api_,
-      nccl_comm_,
-      nccl_api_->send(
-          tensor.data_ptr(),
-          tensor.numel(),
-          getNcclDataType(tensor),
-          dst,
-          nccl_comm_,
-          stream),
-      "NCCL Send failed");
+      nccl_api_, nccl_comm_, nccl_api_->groupStart(), "NCCL GroupStart failed");
+  try {
+    NCCL_CHECK(
+        nccl_api_,
+        nccl_comm_,
+        nccl_api_->send(
+            tensor.data_ptr(),
+            tensor.numel(),
+            getNcclDataType(tensor),
+            dst,
+            nccl_comm_,
+            stream),
+        "NCCL Send failed");
+  } catch (...) {
+    // Close the group even on failure so the comm is not left mid-group for
+    // subsequent operations on this thread. groupEnd's own error is only logged
+    // since we are already propagating the original error.
+    NCCL_CHECK_IGNORE(nccl_api_, nccl_api_->groupEnd(), "NCCL GroupEnd failed");
+    throw;
+  }
+  NCCL_CHECK(
+      nccl_api_, nccl_comm_, nccl_api_->groupEnd(), "NCCL GroupEnd failed");
 
   // Record end event after NCCL operation
   work->recordEnd();
@@ -414,17 +432,31 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::recvImpl(
   // Record start event before NCCL operation
   work->recordStart("recv");
 
+  // Wrap in ncclGroupStart/End -- see sendImpl comment for rationale.
+  // (TorchComms fix D109625550.)
   NCCL_CHECK(
-      nccl_api_,
-      nccl_comm_,
-      nccl_api_->recv(
-          tensor.data_ptr(),
-          tensor.numel(),
-          getNcclDataType(tensor),
-          src,
-          nccl_comm_,
-          stream),
-      "NCCL Recv failed");
+      nccl_api_, nccl_comm_, nccl_api_->groupStart(), "NCCL GroupStart failed");
+  try {
+    NCCL_CHECK(
+        nccl_api_,
+        nccl_comm_,
+        nccl_api_->recv(
+            tensor.data_ptr(),
+            tensor.numel(),
+            getNcclDataType(tensor),
+            src,
+            nccl_comm_,
+            stream),
+        "NCCL Recv failed");
+  } catch (...) {
+    // Close the group even on failure so the comm is not left mid-group for
+    // subsequent operations on this thread. groupEnd's own error is only logged
+    // since we are already propagating the original error.
+    NCCL_CHECK_IGNORE(nccl_api_, nccl_api_->groupEnd(), "NCCL GroupEnd failed");
+    throw;
+  }
+  NCCL_CHECK(
+      nccl_api_, nccl_comm_, nccl_api_->groupEnd(), "NCCL GroupEnd failed");
 
   // Record end event after NCCL operation
   work->recordEnd();

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -185,7 +185,13 @@ try:
         from torchcomms._backend_wrapper import _BackendWrapper
 
     # pyrefly: ignore [missing-import]
-    from torchcomms import new_comm
+    # pyrefly: ignore [missing-import]
+    from torchcomms import is_backend_built as _torchcomms_is_backend_built, new_comm
+
+    # pyrefly: ignore [missing-import]
+    from torchcomms._comms import (
+        _is_backend_registered as _torchcomms_is_backend_registered,
+    )
 
     # pyrefly: ignore [missing-import]
     from torchcomms.hooks import FlightRecorderHook
@@ -198,6 +204,39 @@ except ImportError:
 def _use_torchcomms_enabled() -> bool:
     """Check if torchcomms is enabled via config."""
     return _TORCHCOMM_AVAILABLE and dist_config.use_torchcomms
+
+
+def _torchcomms_handles_backend(backend) -> bool:
+    """True if TorchComms can create a comm for *backend*.
+
+    Backends TorchComms doesn't own -- custom c10d plugins such as ``mooncake``
+    or ``ucc`` -- must fall through to the normal ProcessGroup path even when
+    TorchComms is enabled, rather than being routed through ``new_comm`` /
+    ``split_group`` (which cannot construct them).
+
+    ``backend`` may be ``None`` (inherits the parent's TorchComms-owned
+    backend), a bare name (``"nccl"``), or a device-qualified string
+    (``"cpu:gloo,cuda:nccl"``). A built-in backend reports via
+    ``is_backend_built``; a backend dynamically registered through
+    ``torchcomms.register_backend`` (e.g. a Python adapter) reports via
+    ``_is_backend_registered`` -- so registering such an adapter is enough to
+    move that backend onto the native TorchComms path with no change here.
+    """
+    if not _TORCHCOMM_AVAILABLE:
+        return False
+    if backend is None:
+        return True
+    for part in str(backend).lower().split(","):
+        part = part.strip()
+        name = part.split(":", 1)[1] if ":" in part else part
+        if not name:
+            continue
+        if not (
+            _torchcomms_is_backend_registered(name)
+            or _torchcomms_is_backend_built(name)
+        ):
+            return False
+    return True
 
 
 def _pg_options_to_hints(pg_options: Any) -> dict[str, str] | None:
@@ -2320,6 +2359,7 @@ def init_process_group(
         and device_id is not None
         and ":" not in backend
         and backend not in (Backend.UNDEFINED, Backend.MPI, Backend.FAKE)
+        and _torchcomms_handles_backend(backend)
     ):
         bare = backend.lower()
         qualified: dict[str, str] = {}
@@ -2600,7 +2640,11 @@ def _new_process_group_helper(
         # a single store can be reused by multiple groups.
         backend_prefix_store = PrefixStore(f"{device}/", prefix_store)
 
-        if _use_torchcomms_enabled() and backend_str not in [Backend.FAKE]:
+        if (
+            _use_torchcomms_enabled()
+            and backend_str not in [Backend.FAKE]
+            and _torchcomms_handles_backend(backend_str)
+        ):
             torch_device = torch.device(device)
             logger.warning(
                 "Using TorchComms backend (enabled via %s) for device %s with backend %s",

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -2591,7 +2591,12 @@ def _new_process_group_helper(
             # parent group, even those not in the new group.  This is
             # a requirement of the NCCL API as otherwise we would get
             # out of sync.
-            if split_from:
+            #
+            # Under TorchComms, subgroups are built with `new_comm` (a
+            # members-only store rendezvous), not by splitting the parent, so
+            # non-members must NOT issue a no-color split -- doing so would
+            # desync against members that never split.
+            if split_from and not _use_torchcomms_enabled():
                 split_from.perform_nocolor_split(_get_default_group().bound_device_id)
             return GroupMember.NON_GROUP_MEMBER, None
 
@@ -2646,6 +2651,20 @@ def _new_process_group_helper(
             and _torchcomms_handles_backend(backend_str)
         ):
             torch_device = torch.device(device)
+            # Pass this rank's actual device WITH its index. A device-type-only
+            # torch.device(device) makes the TorchComms bootstrap default the
+            # device to (group-local rank % device_count) -- correct only for the
+            # world group (group-local == global rank). For a subgroup the
+            # group-local rank differs from the rank's physical device, so the
+            # comm (and its lazy P2P pair comms) would be created on the wrong
+            # device, causing illegal memory access. The default PG's
+            # bound_device_id is this rank's device for every group it joins.
+            if (
+                device_id is not None
+                and device_id.index is not None
+                and device_id.type == torch_device.type
+            ):
+                torch_device = device_id
             logger.warning(
                 "Using TorchComms backend (enabled via %s) for device %s with backend %s",
                 "TORCH_DISTRIBUTED_USE_TORCHCOMMS env var"
@@ -2664,13 +2683,31 @@ def _new_process_group_helper(
                 extra = _pg_options_to_hints(backend_options)
                 if extra:
                     hints.update(extra)
-            comm = new_comm(
-                backend_str,
-                torch_device,
-                name=group_name,
-                store=backend_prefix_store,
-                hints=hints,
+            # new_comm has no rank/size params -- the TorchComms bootstrap reads
+            # them from TORCHCOMM_RANK/SIZE. Seed from this group's rank/size so
+            # non-Torchrun launchers (which TorchComms cannot auto-detect, e.g.
+            # process-spawning inference servers) work without each caller having
+            # to set these. Save/restore around the call (single-threaded here).
+            _tc_saved = (
+                os.environ.get("TORCHCOMM_RANK"),
+                os.environ.get("TORCHCOMM_SIZE"),
             )
+            os.environ["TORCHCOMM_RANK"] = str(group_rank)
+            os.environ["TORCHCOMM_SIZE"] = str(group_size)
+            try:
+                comm = new_comm(
+                    backend_str,
+                    torch_device,
+                    name=group_name,
+                    store=backend_prefix_store,
+                    hints=hints,
+                )
+            finally:
+                for _k, _v in zip(("TORCHCOMM_RANK", "TORCHCOMM_SIZE"), _tc_saved):
+                    if _v is None:
+                        os.environ.pop(_k, None)
+                    else:
+                        os.environ[_k] = _v
             buffer_size = os.environ.get(
                 "TORCH_FR_BUFFER_SIZE",
                 os.environ.get("TORCH_NCCL_TRACE_BUFFER_SIZE", "0"),

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -6010,8 +6010,16 @@ def _create_process_group_wrapper(
 # helper function for hashing a list of ranks to a unique string
 def _hash_ranks_to_str(ranks: list[int]) -> str:
     rank_join: str = "_".join(map(str, ranks))
-    # In case there is already a PG with the same rank composition
-    unique_str = "_".join([rank_join, str(len(_world.pg_names))])
+    # Disambiguate multiple PGs with the same rank composition. The salt MUST be
+    # identical across all ranks that create this group, otherwise ranks compute
+    # different group names for the same group. Backends that use the group name
+    # as a rendezvous store prefix (e.g. Gloo split's connectFullMesh) then key
+    # off different prefixes and deadlock. len(_world.pg_names) is NOT safe here:
+    # it diverges across ranks after an earlier asymmetric-membership new_group()
+    # (non-member ranks register fewer PGs). _world.group_count is incremented by
+    # _process_group_name() on every rank that reaches it (before the member
+    # check), so it stays consistent and monotonic across ranks.
+    unique_str = "_".join([rank_join, str(_world.group_count)])
     return hashlib.sha1(bytes(unique_str, "utf-8"), usedforsecurity=False).hexdigest()
 
 
@@ -6037,8 +6045,12 @@ def _process_group_name(ranks, use_hashed_name) -> GroupName:
         pg_name = GroupName(_hash_ranks_to_str(ranks))
     else:
         pg_name = GroupName(str(_world.group_count))
-        _world.group_count += 1
-    # TODO: why is group count incremented only in the else path?
+    # Increment on BOTH paths so group_count advances once per group-creation
+    # call on every rank that reaches here. This keeps it a collective-consistent,
+    # monotonic counter usable as the uniqueness salt in _hash_ranks_to_str
+    # (see the comment there). Names need only be unique, not contiguous, so the
+    # hashed path consuming counter values is harmless for the non-hashed names.
+    _world.group_count += 1
     return pg_name
 
 

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -5972,7 +5972,12 @@ def monitored_barrier(
         _warn_not_in_group("monitored_barrier")
         return
 
-    if get_backend(group) != Backend.GLOO:
+    # monitored_barrier runs on a CPU backend (GLOO, or its torchcomms
+    # BackendWrapper equivalent). Require the group to have a CPU backend rather
+    # than matching the "gloo" name, so a device-qualified group (e.g.
+    # "cpu:gloo,cuda:nccl") is accepted for its CPU backend.
+    pg = group or _get_default_group()
+    if torch.device("cpu") not in pg._device_types:
         raise ValueError("monitored_barrier is only implemented for GLOO backend.")
 
     if timeout is None:

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -2914,10 +2914,19 @@ def destroy_process_group(group: ProcessGroup | None = None):
         _world.group_count = 0
     else:
         if _TORCHCOMM_AVAILABLE:
+            # A single comm may be shared across multiple device types (e.g. a
+            # gloo group reports both 'cuda' and 'cpu' device types backed by the
+            # same _BackendWrapper). Deduplicate by comm identity so we finalize
+            # each comm exactly once — finalize() is not idempotent and raises
+            # "already finalized" on a second call.
+            finalized_comm_ids: set[int] = set()
             for device_type in pg._device_types:
                 backend = pg._get_backend(device_type)
                 if isinstance(backend, _BackendWrapper):
-                    backend.get_comm().finalize()
+                    comm = backend.get_comm()
+                    if id(comm) not in finalized_comm_ids:
+                        comm.finalize()
+                        finalized_comm_ids.add(id(comm))
             _world.comms.clear()
         pg.shutdown()
         del _world.pg_map[pg]

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -6296,40 +6296,13 @@ def new_group(
     same global creation order.
 
     N.B. When TorchComms is enabled (``torch.distributed.config.use_torchcomms``
-    / ``TORCH_DISTRIBUTED_USE_TORCHCOMMS=1``), this function delegates to
-    :func:`split_group` so subgroup creation goes through the TorchComms path.
-    The delegation raises ``NotImplementedError`` for arguments that
-    :func:`split_group` cannot honor (e.g. ``use_local_synchronization=True``,
-    or an explicit ``device_id`` that diverges from the default group's bound
-    device).
+    / ``TORCH_DISTRIBUTED_USE_TORCHCOMMS=1``), subgroups are created directly via
+    TorchComms' ``new_comm`` (the normal ``_new_group_with_tag`` path), not by
+    splitting the parent communicator. Pass ``backend="nccl-lazy"`` to build a
+    per-peer, lazily-initialized group (a dedicated comm + stream per send/recv
+    peer, like ``ProcessGroupNCCL``) so concurrent P2P to different peers can
+    overlap; pass the default / ``"nccl"`` backend for an eager group.
     """
-    if _use_torchcomms_enabled():
-        # split_group can only split the parent's existing communicator, so it
-        # cannot produce a child whose backend differs from the parent's. A
-        # "fake" subgroup of a real parent -- how DeviceMesh creates disabled /
-        # unflattened dims, with use_local_synchronization for hashed names -- is
-        # exactly that case: route it through the normal path, which builds the
-        # FakeProcessGroup directly (see ``_new_group_with_tag``). When the
-        # requested backend matches the parent (including a fake parent), split
-        # delegation is fine.
-        parent_backend, _ = _world.pg_map[_get_default_group()]
-        is_fake_subgroup = (
-            backend is not None
-            and str(backend).lower() == "fake"
-            and str(backend).lower() != str(parent_backend).lower()
-        )
-        if not is_fake_subgroup:
-            return _new_group_via_split_group(
-                ranks=ranks,
-                timeout=timeout,
-                backend=backend,
-                pg_options=pg_options,
-                use_local_synchronization=use_local_synchronization,
-                group_desc=group_desc,
-                device_id=device_id,
-                sort_ranks=sort_ranks,
-            )
-
     return _new_group_with_tag(
         ranks,
         timeout,
@@ -6340,108 +6313,6 @@ def new_group(
         group_desc=group_desc,
         device_id=device_id,
         sort_ranks=sort_ranks,
-    )
-
-
-def _new_group_via_split_group(
-    ranks,
-    timeout,
-    backend,
-    pg_options,
-    use_local_synchronization,
-    group_desc,
-    device_id,
-    sort_ranks,
-):
-    """Implement `new_group` semantics on top of `split_group`.
-
-    Used on the TorchComms path so subgroup creation goes through
-    :func:`split_group`. Raises ``NotImplementedError`` (or ``ValueError``
-    for inconsistent args) when the requested ``new_group`` configuration
-    cannot be expressed through ``split_group``.
-    """
-    if use_local_synchronization:
-        raise NotImplementedError(
-            "new_group cannot delegate to split_group with "
-            "use_local_synchronization=True; split_group requires all ranks "
-            "in the parent group to participate."
-        )
-    default_pg = _get_default_group()
-    if device_id is not None:
-        bound = default_pg.bound_device_id
-        if bound is not None and device_id != bound:
-            raise ValueError(
-                f"device_id={device_id} does not match the default process "
-                f"group's bound_device_id={bound}; split_group inherits the "
-                "default group's device binding."
-            )
-
-    global_world_size = default_pg.size()
-    if ranks is None:
-        group_ranks = list(range(global_world_size))
-    elif sort_ranks:
-        group_ranks = sorted(ranks)
-    else:
-        group_ranks = list(ranks)
-
-    # Auto-qualify the requested backend so it always names just the parent's
-    # default device backend (the one matching ``bound_device_id``) plus any
-    # explicitly-requested extra device entry.
-    #
-    # split_group's filter has two requirements:
-    #   (1) it must contain the parent's default device backend, and
-    #   (2) device entries it omits are not included in the new subgroup.
-    #
-    # The naive default (``backend=None``) inherits the parent's full set,
-    # which creates an extra gloo comm per subgroup on every nccl-with-gloo
-    # parent — expensive and racy. Explicitly narrowing to the default
-    # device backend gives every torchcomms caller the same single-backend
-    # subgroup they almost always want, while still letting an explicit
-    # device-qualified string (``"cpu:gloo,cuda:nccl"``) opt back into the
-    # multi-backend behavior
-    bound = default_pg.bound_device_id
-    if bound is not None and (backend is None or ":" not in str(backend)):
-        parent_backend_str, _ = _world.pg_map[default_pg]
-        parent_devices = {d.type for d in default_pg._device_types}
-        parent_device_backends = _parse_backend_string(
-            parent_backend_str, available_devices=parent_devices
-        )
-        default_dev = bound.type
-        default_be = parent_device_backends.get(default_dev)
-        if default_be is not None:
-            if backend is None:
-                # Inherit just the default-device backend, not all parent
-                # device backends.
-                backend = f"{default_dev}:{default_be}"
-            else:
-                bare = str(backend)
-                matched_device = next(
-                    (d for d, be in parent_device_backends.items() if be == bare),
-                    None,
-                )
-                if matched_device is not None:
-                    qualified: dict[str, str] = {matched_device: bare}
-                    backend = ",".join(f"{d}:{b}" for d, b in qualified.items())
-
-    # torchcomms backends expect every parent rank to participate in split:
-    # members pass their ranks list, non-members pass [] (NCCL_SPLIT_NOCOLOR
-    # for nccl, no-op for gloo). `ProcessGroup::splitGroup` rejects empty
-    # ranks, so for non-members invoke each underlying TorchComm directly
-    # with [] to satisfy the collective contract without creating a PG.
-    if default_pg.rank() not in group_ranks:
-        group_name = _process_group_name(group_ranks, use_hashed_name=True)
-        for device in default_pg._device_types:
-            # pyrefly: ignore[missing-attribute]
-            default_pg._get_backend(device).get_comm().split([], group_name)
-        return GroupMember.NON_GROUP_MEMBER
-
-    return split_group(
-        parent_pg=default_pg,
-        split_ranks=[group_ranks],
-        timeout=timeout,
-        pg_options=pg_options,
-        group_desc=group_desc,
-        backend=backend,
     )
 
 


### PR DESCRIPTION

Test Plan:

Built into the test conda env:

```
USE_DISTRIBUTED=1 USE_CUDA=1 USE_GOLD_LINKER=1 USE_NNPACK=0 USE_FBGEMM=0 \
  python -m pip install -e . -v --no-build-isolation
```

Ran the c10d nccl2 tests (4xH100, NCCL 2.29.7+cuda13):

```
python -m pytest test/distributed/test_c10d_nccl2.py -q
# 2 passed in 14.18s
```

The new ProcessGroupNCCL2Test::test_p2p_send_recv_event_ordering loops async
isend/irecv within disjoint rank pairs with distinct per-iteration values and
reads back immediately after wait(), so an early event completion surfaces as a
value mismatch. Also cross-checked an out-of-tree 2-rank sender/receiver harness
against stock nccl and nccl2 (both EVENT_ORDER_PASS, 0/200 mismatches under the
default blocking comm).

This change was authored with the assistance of an AI coding agent (Claude).
