### PR TITLE
[Dynamo] Reject non-iterators passed to next

### DIFF
--- a/test/dynamo/test_iterators.py
+++ b/test/dynamo/test_iterators.py
@@ -1452,6 +1452,16 @@ class TestIterErrors(torch._dynamo.test_case.TestCase):
         self.assertEqual(result, "default")
 
     @make_dynamo_test
+    def test_next_non_iterator_raises_type_error(self):
+        with self.assertRaisesRegex(TypeError, "'list' object is not an iterator"):
+            next([1, 2])
+
+    @make_dynamo_test
+    def test_next_non_iterator_with_default_raises_type_error(self):
+        with self.assertRaisesRegex(TypeError, "'list' object is not an iterator"):
+            next([1, 2], "default")
+
+    @make_dynamo_test
     def test_error_on_dict_keys_mutation_during_iteration(self):
         """Test that mutating a dict during iteration raises RuntimeError"""
         d = {"a": 1, "b": 2, "c": 3}

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -118,6 +118,7 @@ from .object_protocol import (
     generic_str,
     maybe_get_python_type,
     pycallable_check,
+    pyiter_check,
     pysequence_check,
     ternary_iop,
     ternary_op,
@@ -2463,16 +2464,15 @@ class BuiltinVariable(BaseBuiltinVariable):
         if len(args) > 2:
             raise_type_error(tx, f"next expected at most 2 arguments, got {len(args)}")
         arg = args[0]
+        if not pyiter_check(maybe_get_python_type(arg)):
+            raise_type_error(
+                tx, f"'{arg.python_type_name()}' object is not an iterator"
+            )
         try:
             return arg.next_variable(tx)
         except ObservedUserStopIteration:
             if len(args) == 2:
                 return args[1]
-            raise
-        except Unsupported as ex:
-            if isinstance(arg, variables.BaseListVariable):
-                ex.remove_from_stats()
-                return arg.items[0]
             raise
 
     def call_map(


### PR DESCRIPTION
# Fixing an Issue

## Human commentary

我的判断是 OK。

## Issue

Fixes #190584

## Summary

> **AI-assisted implementation summary, prepared with OpenAI Codex:**
>
> `BuiltinVariable.call_next` previously skipped CPython's iterator check and
> returned the first item for `BaseListVariable` when iterator advancement was
> unsupported. The patch uses Dynamo's existing `pyiter_check` before advancing
> an iterator and removes that fallback. Regression tests cover plain lists both
> with and without a default argument.

## Checklist

- [x] Passes lint (`lintrunner -a`)
- [x] Added/updated tests
- [x] Updated documentation (not applicable)
- [x] Included benchmark results (not applicable; no performance impact)

## BC-breaking?

No. This corrects silently incorrect behavior to match CPython semantics.

## Test plan

> **Commands selected and run with OpenAI Codex assistance:**
>
> ```shell
> .venv/bin/python test/dynamo/test_iterators.py TestIterErrors.test_next_non_iterator_raises_type_error TestIterErrors.test_next_non_iterator_with_default_raises_type_error TestIterErrors.test_next_on_exhausted_raises_stop_iteration TestIterErrors.test_next_default_on_exhausted TestIterators.test_next_with_default -v
> .venv/bin/python test/dynamo/test_iterators.py -v
> PATH="$PWD/.venv/bin:$PATH" lintrunner -a torch/_dynamo/variables/builtin.py test/dynamo/test_iterators.py
> ```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98