### PR TITLE
[DTensor][Test] Remove hardcoded CUDA queries from dispatch and RNG tests

### DIFF
--- a/test/distributed/tensor/test_dtensor_dispatch_overhead.py
+++ b/test/distributed/tensor/test_dtensor_dispatch_overhead.py
@@ -8,12 +8,11 @@ import time
 from collections import namedtuple
 
 import torch
-from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.tensor import distribute_tensor, DTensor, Shard
-from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
+    skip_unless_torch_gpu,
     with_comms,
 )
 from torch.utils._python_dispatch import TorchDispatchMode
@@ -66,22 +65,22 @@ class DistOpDispatchOverHead(DTensorTestBase):
     def world_size(self) -> int:
         return 4
 
-    @skip_if_lt_x_gpu(4)
+    @skip_unless_torch_gpu
     @with_comms
     def test_dtensor_add_op_dispatch_overhead(self):
-        if torch.cuda.is_available():
-            device_props = torch.cuda.get_device_name(0)
-            gpu_name = device_props
-            logger.info("running on %s", gpu_name)
-            # TODO: adjust `expected_propagate_time` and `expected_dispatch_time` to target different hardware
+        device_module = torch.get_device_module(self.device_type)
+        if hasattr(device_module, "get_device_name"):
+            device_name = device_module.get_device_name(0)
         else:
-            self.skipTest("CUDA not available")
+            device_name = self.device_type
+        logger.info("running on %s", device_name)
+        # TODO: adjust `expected_propagate_time` and `expected_dispatch_time` to target different hardware
         expected_propagate_time = 880  # noqa: F841
         expected_dispatch_time = 90  # noqa: F841
         diff_percent_threshold = 0.20  # noqa: F841
         propagator = DTensor._op_dispatcher.sharding_propagator
-        device_mesh = init_device_mesh("cuda", (self.world_size,))
-        input_data = torch.rand(512, 512, device="cuda")
+        device_mesh = self.build_device_mesh()
+        input_data = torch.rand(512, 512, device=self.device_type)
         a = distribute_tensor(input_data, device_mesh, [Shard(0)])
         # warm up
         with TimeCaptureMode() as tcm:

--- a/test/distributed/tensor/test_random_ops.py
+++ b/test/distributed/tensor/test_random_ops.py
@@ -734,14 +734,18 @@ class DistTensorRandomOpTest(DTensorTestBase):
 class DistTensorRandomOpCompileTest(DTensorTestBase):
     def _run_with_seed(self, fn, create_input, num_runs):
         """Run fn num_runs times after resetting RNG, returning results and states."""
+        device_module = torch.get_device_module(self.device_type)
+        if not hasattr(device_module, "get_rng_state"):
+            self.skipTest(f"{self.device_type} does not support get_rng_state")
+
         torch.manual_seed(0)
         results = []
-        rng_states = [torch.cuda.get_rng_state()]
+        rng_states = [device_module.get_rng_state()]
         for _ in range(num_runs):
             x = create_input()
             result = fn(x)
             results.append(result.to_local().clone())
-            rng_states.append(torch.cuda.get_rng_state())
+            rng_states.append(device_module.get_rng_state())
         # verify RNG state advances after each call
         for i in range(len(rng_states) - 1):
             self.assertFalse(

--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -57,7 +57,6 @@ from torch.testing._internal.common_distributed import (
     MultiProcessTestCase,
     MultiThreadedTestCase,
     run_subtests,
-    skip_if_lt_x_gpu,
     TEST_SKIPS,
 )
 from torch.testing._internal.common_utils import (
@@ -621,7 +620,8 @@ class Transformer(nn.Module):
 
 def skip_unless_torch_gpu(method: T) -> T:
     """
-    Test decorator which skips the test unless there's a GPU available to torch.
+    Test decorator which skips the test unless there are enough accelerator
+    devices available to torch.
 
     >>> # xdoctest: +SKIP
     >>> @skip_unless_torch_gpu
@@ -629,7 +629,21 @@ def skip_unless_torch_gpu(method: T) -> T:
     >>>   ...
     """
     # The builtin @skip_if_no_gpu relies on os.environ['WORLD_SIZE'] being set.
-    return cast(T, skip_if_lt_x_gpu(NUM_DEVICES)(method))
+    # Keep the historical name for compatibility, but use torch.accelerator so
+    # PrivateUse1 and other accelerator backends are handled consistently.
+    @wraps(method)
+    def wrapper(*args, **kwargs):
+        if torch.accelerator.device_count() >= NUM_DEVICES:
+            return method(*args, **kwargs)
+        test_skip = TEST_SKIPS[f"multi-gpu-{NUM_DEVICES}"]
+        if len(args) > 0:
+            _handle_test_skip = getattr(args[0], "_handle_test_skip", None)
+            if _handle_test_skip is not None:
+                _handle_test_skip(test_skip.message)
+                return None
+        sys.exit(test_skip.exit_code)
+
+    return cast(T, wrapper)
 
 
 class DTensorTestMixin:
@@ -798,42 +812,41 @@ class DTensorTestBase(DTensorTestMixin, MultiProcessTestCase):
         if backend is None:
             backend = self.backend
 
-        requires_gpu = any(
-            gpu_backend in backend for gpu_backend in ACCELERATOR_DIST_BACKENDS
+        requires_accelerator = any(
+            accelerator_backend in backend
+            for accelerator_backend in ACCELERATOR_DIST_BACKENDS
         )
-        if requires_gpu and torch.accelerator.device_count() < self.world_size:
+        if requires_accelerator and torch.accelerator.device_count() < self.world_size:
             sys.exit(TEST_SKIPS[f"multi-gpu-{self.world_size}"].exit_code)
 
         curr_backend = dist.get_default_backend_for_device(self.device_type)
-
-        if backend not in [
-            "nccl",
+        supported_backends = {
             "gloo",
             "mpi",
+            "fake",
             f"cpu:gloo,{self.device_type}:{curr_backend}",
             "cpu:gloo,cuda:ncclx",
             "cuda:ncclx",
-            "hccl",
-            "xccl",
-            "fake",
             "cpu:gloo,xpu:xccl",
-        ]:
+            *ACCELERATOR_DIST_BACKENDS,
+        }
+
+        if backend not in supported_backends:
             raise RuntimeError(f"Backend {backend} not supported!")
 
         device_id = None
-        if "nccl" in backend or "xccl" in backend:
-            # set device for nccl pg for collectives
+        if requires_accelerator:
+            # set device for accelerator pg for collectives
             # TODO: if users want to enable testing across hosts, we may need
             # to change this part.
             torch.accelerator.set_device_index(self.rank)
-            # we only need to set device_id for nccl backend with eager init
+            # we only need to set device_id for accelerator backend with eager init
             device_id = (
                 torch.device(f"{self.device_type}:{self.rank}") if eager_init else None
             )
 
-        # For nccl backend, bind the device to the process if device_id is not None
-        # so the nccl communicator is immediately formed and we can use `ncclCommSplit`
-        # for form subgroup to avoid unnecessary overhead.
+        # For accelerator backends, bind the device to the process if device_id
+        # is not None so the communicator can be eagerly formed when supported.
         dist.init_process_group(
             backend=backend,
             world_size=self.world_size,


### PR DESCRIPTION
## Summary

This PR removes hardcoded CUDA device queries from the DTensor dispatch overhead and compile RNG tests. The tests now use the device selected by `DTensorTestBase` and resolve device-specific APIs through `torch.get_device_module()`.

## Changes

- Updated `test_dtensor_dispatch_overhead.py` to:
  - use the DTensor accelerator availability helper;
  - obtain the device name from the current device module when available;
  - build the mesh through `self.build_device_mesh()`;
  - create the input tensor on `self.device_type`.

- Updated `test_random_ops.py` to:
  - resolve the current device module with `torch.get_device_module(self.device_type)`;
  - replace hardcoded `torch.cuda.get_rng_state()` calls with the current device module;
  - skip RNG state checks when the device module does not provide `get_rng_state`.

## Not changed

- The dispatch overhead benchmark structure and disabled performance assertions are unchanged.
- The RNG tests still validate eager execution, `aot_eager` graph capture, and Inductor execution.
- This PR does not add backend support for tracing RNG state through Dynamo FakeTensor.
