### PR TITLE
[FSDP2] Apply reduce_dtype to the non-DP-mesh gradient all-reduce

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_mixed_precision.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_mixed_precision.py
@@ -14,7 +14,7 @@ from torch.distributed.fsdp import fully_shard, MixedPrecisionPolicy
 from torch.distributed.fsdp._fully_shard._fsdp_collectives import (
     _get_gradient_divide_factors,
 )
-from torch.distributed.tensor import Shard
+from torch.distributed.tensor import distribute_tensor, DTensor, Replicate, Shard
 from torch.testing._internal.common_distributed import (
     requires_nccl_version,
     SaveForwardInputsModel,
@@ -253,6 +253,48 @@ class TestFullyShardMixedPrecisionTraining(FSDPTest):
 
             self.assertEqual(fsdp_loss, ref_loss)
             check_sharded_parity(self, ref_model, model)
+
+    @skip_if_lt_x_gpu(2)
+    def test_reduce_dtype_tp_grad_all_reduce(self):
+        # A parameter left Replicate on the TP mesh (e.g. a norm weight under
+        # sequence parallelism) has a Partial gradient, and FSDP itself issues
+        # the Partial -> Replicate all-reduce during post-backward.
+        # reduce_dtype must cover that collective, not only the reduce-scatter.
+        # The two TP-local partials are 1.0 and 2^-10, both exact in bf16;
+        # their sum is exact in fp32 but rounds back to 1.0 in bf16 (spacing
+        # 2^-8 at 1.0), so the low term is an exact witness of the collective
+        # dtype.
+        class Scale(nn.Module):
+            def __init__(self, dim: int):
+                super().__init__()
+                self.weight = nn.Parameter(torch.ones(dim))
+
+            def forward(self, x):
+                return x * self.weight
+
+        dp_size, tp_size = self.world_size // 2, 2
+        global_mesh = init_device_mesh(
+            device_type.type, (dp_size, tp_size), mesh_dim_names=("dp", "tp")
+        )
+        tp_mesh = global_mesh["tp"]
+        dim = 32
+        model = Scale(dim).to(device_type)
+        model.weight = nn.Parameter(
+            distribute_tensor(model.weight.detach(), tp_mesh, [Replicate()])
+        )
+        fully_shard(
+            model,
+            mesh=global_mesh["dp"],
+            mp_policy=MixedPrecisionPolicy(
+                param_dtype=torch.bfloat16, reduce_dtype=torch.float32
+            ),
+        )
+        x_local = torch.zeros(8, dim, device=device_type, dtype=torch.bfloat16)
+        x_local[0].fill_(1.0 if tp_mesh.get_local_rank() == 0 else 2.0**-10)
+        x = DTensor.from_local(x_local, tp_mesh, [Shard(0)], run_check=False)
+        model(x).to_local().sum().backward()
+        grad = model.weight.grad.full_tensor()
+        self.assertEqual(grad, torch.full_like(grad, 1.0 + 2.0**-10), atol=0, rtol=0)
 
     @skipIfRocmVersionLessThan((7, 0))
     @skip_if_lt_x_gpu(2)

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
@@ -1149,6 +1149,8 @@ class FSDPParam:
         return self._get_grad_inner_tensor(torch.zeros_like(self.unsharded_param))
 
     def _get_grad_inner_tensor(self, grad: torch.Tensor) -> torch.Tensor:
+        if isinstance(grad, AsyncCollectiveTensor):
+            grad = grad.wait()
         if self.reduce_dtype is not None and grad.dtype != self.reduce_dtype:
             # This method may issue a Partial -> Replicate all-reduce over
             # non-DP mesh dims (e.g. for a TP-replicated norm weight), and
@@ -1176,8 +1178,6 @@ class FSDPParam:
                 )
 
         if self.is_dtensor:
-            if isinstance(grad, AsyncCollectiveTensor):
-                grad = grad.wait()
             if not isinstance(grad, DTensor):
                 raise AssertionError(f"Expected DTensor, got {type(grad)}")
             if self._unsharded_dtensor_spec is None:

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
@@ -1149,6 +1149,15 @@ class FSDPParam:
         return self._get_grad_inner_tensor(torch.zeros_like(self.unsharded_param))
 
     def _get_grad_inner_tensor(self, grad: torch.Tensor) -> torch.Tensor:
+        if self.reduce_dtype is not None and grad.dtype != self.reduce_dtype:
+            # This method may issue a Partial -> Replicate all-reduce over
+            # non-DP mesh dims (e.g. for a TP-replicated norm weight), and
+            # reduce_dtype is documented to apply to gradient reduction
+            # including all-reduce. Upcast before the redistribute, mirroring
+            # to_accumulated_grad_if_needed on the accumulation path; this
+            # also keeps the gradient dtype uniform with accumulated
+            # gradients so foreach_reduce sees one dtype.
+            grad = grad.to(self.reduce_dtype)
         if self.is_spmd_types:
             if self._unsharded_dtensor_spec is None:
                 raise AssertionError(


### PR DESCRIPTION
Fixes #190626

## Summary

`MixedPrecisionPolicy(reduce_dtype=...)` is documented to apply to gradient reduction (reduce-scatter or all-reduce), but it only took effect at the reduce-scatter buffer allocation in `foreach_reduce`. The `Partial -> Replicate` all-reduce that `_get_grad_inner_tensor` issues over non-DP mesh dims (e.g. for a TP-replicated norm weight under sequence parallelism) ran in the gradient's own dtype, so with `param_dtype=bf16` and `reduce_dtype=fp32` half of the 2D reduction still happened in bf16. See the issue for the bit-exact witness repro and the torchtitan shipped-default reachability.

The fix upcasts the gradient to `reduce_dtype` at the top of `_get_grad_inner_tensor`, mirroring what `to_accumulated_grad_if_needed` already does on the gradient-accumulation path (introduced in #125191). The accumulation path was already correct; the plain path now takes the same two operations in the same order.

## Why this placement

- It covers all three gradient sources uniformly (`unsharded_grad_data`, `unsharded_accumulated_grad_data` where it is a no-op since the grad is already fp32, and `unsharded_zero_grad_data`).
- It keeps the collected gradient dtypes uniform when fresh and accumulated gradients meet in one post-backward. `foreach_reduce` asserts a single gradient dtype and `fsdp.chunk_cat` requires uniform input dtypes, so a selective per-parameter upcast would trip both; today a mixed post-backward (some parameters accumulated in fp32, others fresh in bf16) would already hit that assert, and this change removes that latent failure as well.
- Memory cost is transient and matches what the accumulation path already pays: the bf16 gradient reference is dropped immediately after collection in `post_backward` and the fp32 copy is freed when `unsharded_grads.clear()` runs after the reduce-scatter copy-in.

## Test

`test_reduce_dtype_tp_grad_all_reduce` (2+ GPUs, `dp x tp` mesh with `tp=2`): a Replicate-on-TP scale parameter receives TP-local partial gradients of exactly `1.0` and `2^-10`, both exact in bf16. Their sum is exact in fp32 but rounds back to `1.0` in bf16 (spacing `2^-8` at 1.0), so the final master-weight gradient being exactly `1.0 + 2^-10` is a bit-exact witness that the collective ran in fp32. The test fails on main and passes with this change.

```
pytest test/distributed/_composable/fsdp/test_fully_shard_mixed_precision.py -k test_reduce_dtype -v
```

*This PR was authored with assistance from Claude; the fix design and test oracle were human-reviewed.*
