### PR TITLE
[distributed] Allow symmetric memory allocators to customize tensor wrapping

### DIFF
--- a/test/cpp/c10d/CMakeLists.txt
+++ b/test/cpp/c10d/CMakeLists.txt
@@ -40,6 +40,8 @@ function(c10d_add_test test_src)
   endif()
 endfunction()
 
+c10d_add_test(SymmetricMemoryTest.cpp LINK_LIBRARIES torch_cpu gtest_main INSTALL_TEST OFF)
+
 if(USE_ROCM)
   c10d_add_test(hip/BackoffTest.cpp LINK_LIBRARIES torch_cpu gtest_main INSTALL_TEST OFF)
   c10d_add_test(hip/FileStoreTest.cpp LINK_LIBRARIES torch_cpu gtest_main INSTALL_TEST ${INSTALL_TEST})

--- a/test/cpp/c10d/SymmetricMemoryTest.cpp
+++ b/test/cpp/c10d/SymmetricMemoryTest.cpp
@@ -40,13 +40,7 @@ class TestSymmetricMemoryAllocator final : public SymmetricMemoryAllocator {
       ptr = static_cast<uint8_t*>(ptr) + 1;
     }
     return SymmetricMemoryAllocator::make_tensor(
-        ptr,
-        sizes,
-        strides,
-        dtype,
-        device,
-        group_name,
-        std::move(deleter));
+        ptr, sizes, strides, dtype, device, group_name, std::move(deleter));
   }
 
   void* alloc(

--- a/test/cpp/c10d/SymmetricMemoryTest.cpp
+++ b/test/cpp/c10d/SymmetricMemoryTest.cpp
@@ -20,12 +20,14 @@ class TestSymmetricMemoryAllocator final : public SymmetricMemoryAllocator {
       c10::IntArrayRef strides,
       c10::ScalarType dtype,
       c10::Device device,
+      const std::optional<std::string>& group_name,
       std::function<void(void*)> deleter) override {
     ++make_tensor_calls_;
     sizes_ = sizes.vec();
     strides_ = strides.vec();
     dtype_ = dtype;
     device_ = device;
+    make_tensor_group_name_ = group_name;
     saw_deleter_ = static_cast<bool>(deleter);
     if (offset_storage_ptr_) {
       EXPECT_FALSE(deleter);
@@ -37,6 +39,7 @@ class TestSymmetricMemoryAllocator final : public SymmetricMemoryAllocator {
         strides,
         dtype,
         device,
+        group_name,
         std::move(deleter));
   }
 
@@ -97,6 +100,7 @@ class TestSymmetricMemoryAllocator final : public SymmetricMemoryAllocator {
   void* rendezvous_ptr_ = nullptr;
   void* has_allocation_ptr_ = nullptr;
   size_t allocation_size_ = 0;
+  std::optional<std::string> make_tensor_group_name_;
   std::vector<int64_t> sizes_;
   std::vector<int64_t> strides_;
   c10::ScalarType dtype_ = c10::ScalarType::Undefined;
@@ -106,13 +110,14 @@ class TestSymmetricMemoryAllocator final : public SymmetricMemoryAllocator {
 TEST(SymmetricMemoryAllocatorTest, EmptyUsesBackendTensorWrapper) {
   auto allocator = c10::make_intrusive<TestSymmetricMemoryAllocator>();
   register_allocator(c10::DeviceType::CPU, allocator);
+  const std::optional<std::string> group_name = "test_group";
 
   auto tensor = empty_strided_p2p(
       {2, 3},
       {3, 1},
       c10::ScalarType::Float,
       c10::Device(c10::DeviceType::CPU),
-      std::nullopt,
+      group_name,
       std::nullopt);
 
   EXPECT_EQ(allocator->make_tensor_calls_, 1);
@@ -121,11 +126,12 @@ TEST(SymmetricMemoryAllocatorTest, EmptyUsesBackendTensorWrapper) {
   EXPECT_EQ(allocator->strides_, (std::vector<int64_t>{3, 1}));
   EXPECT_EQ(allocator->dtype_, c10::ScalarType::Float);
   EXPECT_EQ(allocator->device_, c10::Device(c10::DeviceType::CPU));
+  EXPECT_EQ(allocator->make_tensor_group_name_, group_name);
   EXPECT_EQ(tensor.sizes(), (c10::IntArrayRef{2, 3}));
   EXPECT_EQ(tensor.strides(), (c10::IntArrayRef{3, 1}));
   EXPECT_EQ(tensor.storage().data_ptr().get(), allocator->allocation_);
 
-  EXPECT_EQ(rendezvous(tensor, std::nullopt), nullptr);
+  EXPECT_EQ(rendezvous(tensor, group_name), nullptr);
   EXPECT_EQ(allocator->rendezvous_calls_, 1);
   EXPECT_EQ(allocator->rendezvous_ptr_, allocator->allocation_);
 
@@ -140,6 +146,7 @@ TEST(SymmetricMemoryAllocatorTest, EmptyUsesBackendTensorWrapper) {
 TEST(SymmetricMemoryAllocatorTest, PersistentEmptyUsesBackendTensorWrapper) {
   auto allocator = c10::make_intrusive<TestSymmetricMemoryAllocator>();
   register_allocator(c10::DeviceType::CPU, allocator);
+  const std::optional<std::string> group_name = "persistent_group";
 
   constexpr uint64_t alloc_id = 0x53594d4d;
   auto tensor = empty_strided_p2p(
@@ -147,23 +154,26 @@ TEST(SymmetricMemoryAllocatorTest, PersistentEmptyUsesBackendTensorWrapper) {
       {3, 1},
       c10::ScalarType::Float,
       c10::Device(c10::DeviceType::CPU),
-      std::nullopt,
+      group_name,
       alloc_id);
   auto* data_ptr = tensor.data_ptr();
 
   EXPECT_EQ(allocator->make_tensor_calls_, 1);
   EXPECT_FALSE(allocator->saw_deleter_);
+  EXPECT_EQ(allocator->make_tensor_group_name_, group_name);
 
   tensor.reset();
+  allocator->make_tensor_group_name_.reset();
   tensor = empty_strided_p2p(
       {2, 3},
       {3, 1},
       c10::ScalarType::Float,
       c10::Device(c10::DeviceType::CPU),
-      std::nullopt,
+      group_name,
       alloc_id);
 
   EXPECT_EQ(allocator->make_tensor_calls_, 2);
+  EXPECT_EQ(allocator->make_tensor_group_name_, group_name);
   EXPECT_EQ(tensor.data_ptr(), data_ptr);
   EXPECT_EQ(allocator->free_calls_, 0);
 }

--- a/test/cpp/c10d/SymmetricMemoryTest.cpp
+++ b/test/cpp/c10d/SymmetricMemoryTest.cpp
@@ -1,0 +1,146 @@
+#include <gtest/gtest.h>
+
+#include <torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp>
+
+#include <cstdint>
+#include <utility>
+
+namespace c10d::symmetric_memory {
+namespace {
+
+class TestSymmetricMemoryAllocator final : public SymmetricMemoryAllocator {
+ public:
+  ~TestSymmetricMemoryAllocator() override {
+    delete[] static_cast<uint8_t*>(allocation_);
+  }
+
+  at::Tensor make_tensor(
+      void* ptr,
+      c10::IntArrayRef sizes,
+      c10::IntArrayRef strides,
+      c10::ScalarType dtype,
+      c10::Device device,
+      std::function<void(void*)> deleter) override {
+    ++make_tensor_calls_;
+    sizes_ = sizes.vec();
+    strides_ = strides.vec();
+    dtype_ = dtype;
+    device_ = device;
+    saw_deleter_ = static_cast<bool>(deleter);
+    return SymmetricMemoryAllocator::make_tensor(
+        ptr,
+        sizes,
+        strides,
+        dtype,
+        device,
+        std::move(deleter));
+  }
+
+  void* alloc(
+      size_t size,
+      int /*device_idx*/,
+      const std::optional<std::string>& /*group_name*/) override {
+    allocation_ = new uint8_t[size];
+    allocation_size_ = size;
+    return allocation_;
+  }
+
+  void free(void* ptr) override {
+    EXPECT_EQ(ptr, allocation_);
+    delete[] static_cast<uint8_t*>(ptr);
+    allocation_ = nullptr;
+    ++free_calls_;
+  }
+
+  size_t get_alloc_size(void* ptr) override {
+    EXPECT_EQ(ptr, allocation_);
+    return allocation_size_;
+  }
+
+  c10::intrusive_ptr<SymmetricMemory> rendezvous(
+      void* /*ptr*/,
+      const std::optional<std::string>& /*group_name*/) override {
+    return nullptr;
+  }
+
+  bool has_multicast_support(int /*device_idx*/) override {
+    return false;
+  }
+
+  c10::DeviceType supported_device_type() override {
+    return c10::DeviceType::CPU;
+  }
+
+  std::string name() override {
+    return "TEST";
+  }
+
+  int make_tensor_calls_ = 0;
+  int free_calls_ = 0;
+  bool saw_deleter_ = false;
+  void* allocation_ = nullptr;
+  size_t allocation_size_ = 0;
+  std::vector<int64_t> sizes_;
+  std::vector<int64_t> strides_;
+  c10::ScalarType dtype_ = c10::ScalarType::Undefined;
+  c10::Device device_ = c10::Device(c10::DeviceType::CPU);
+};
+
+TEST(SymmetricMemoryAllocatorTest, EmptyUsesBackendTensorWrapper) {
+  auto allocator = c10::make_intrusive<TestSymmetricMemoryAllocator>();
+  register_allocator(c10::DeviceType::CPU, allocator);
+
+  auto tensor = empty_strided_p2p(
+      {2, 3},
+      {3, 1},
+      c10::ScalarType::Float,
+      c10::Device(c10::DeviceType::CPU),
+      std::nullopt,
+      std::nullopt);
+
+  EXPECT_EQ(allocator->make_tensor_calls_, 1);
+  EXPECT_TRUE(allocator->saw_deleter_);
+  EXPECT_EQ(allocator->sizes_, (std::vector<int64_t>{2, 3}));
+  EXPECT_EQ(allocator->strides_, (std::vector<int64_t>{3, 1}));
+  EXPECT_EQ(allocator->dtype_, c10::ScalarType::Float);
+  EXPECT_EQ(allocator->device_, c10::Device(c10::DeviceType::CPU));
+  EXPECT_EQ(tensor.sizes(), (c10::IntArrayRef{2, 3}));
+  EXPECT_EQ(tensor.strides(), (c10::IntArrayRef{3, 1}));
+
+  tensor.reset();
+  EXPECT_EQ(allocator->free_calls_, 1);
+}
+
+TEST(SymmetricMemoryAllocatorTest, PersistentEmptyUsesBackendTensorWrapper) {
+  auto allocator = c10::make_intrusive<TestSymmetricMemoryAllocator>();
+  register_allocator(c10::DeviceType::CPU, allocator);
+
+  constexpr uint64_t alloc_id = 0x53594d4d;
+  auto tensor = empty_strided_p2p(
+      {2, 3},
+      {3, 1},
+      c10::ScalarType::Float,
+      c10::Device(c10::DeviceType::CPU),
+      std::nullopt,
+      alloc_id);
+  auto* data_ptr = tensor.data_ptr();
+
+  EXPECT_EQ(allocator->make_tensor_calls_, 1);
+  EXPECT_FALSE(allocator->saw_deleter_);
+
+  tensor.reset();
+  tensor = empty_strided_p2p(
+      {2, 3},
+      {3, 1},
+      c10::ScalarType::Float,
+      c10::Device(c10::DeviceType::CPU),
+      std::nullopt,
+      alloc_id);
+
+  EXPECT_EQ(allocator->make_tensor_calls_, 2);
+  EXPECT_EQ(tensor.data_ptr(), data_ptr);
+  EXPECT_EQ(allocator->free_calls_, 0);
+}
+
+} // namespace
+} // namespace c10d::symmetric_memory

--- a/test/cpp/c10d/SymmetricMemoryTest.cpp
+++ b/test/cpp/c10d/SymmetricMemoryTest.cpp
@@ -2,11 +2,17 @@
 
 #include <torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp>
 
+#include <atomic>
 #include <cstdint>
 #include <utility>
 
 namespace c10d::symmetric_memory {
 namespace {
+
+uint64_t get_unique_test_alloc_id() {
+  static std::atomic<uint64_t> next_alloc_id{1};
+  return next_alloc_id.fetch_add(1, std::memory_order_relaxed);
+}
 
 class TestSymmetricMemoryAllocator final : public SymmetricMemoryAllocator {
  public:
@@ -148,7 +154,7 @@ TEST(SymmetricMemoryAllocatorTest, PersistentEmptyUsesBackendTensorWrapper) {
   register_allocator(c10::DeviceType::CPU, allocator);
   const std::optional<std::string> group_name = "persistent_group";
 
-  constexpr uint64_t alloc_id = 0x53594d4d;
+  const uint64_t alloc_id = get_unique_test_alloc_id();
   auto tensor = empty_strided_p2p(
       {2, 3},
       {3, 1},
@@ -183,7 +189,7 @@ TEST(SymmetricMemoryAllocatorTest, RejectsChangedStoragePointer) {
   allocator->offset_storage_ptr_ = true;
   register_allocator(c10::DeviceType::CPU, allocator);
 
-  constexpr uint64_t alloc_id = 0x53594d4e;
+  const uint64_t alloc_id = get_unique_test_alloc_id();
   EXPECT_THROW(
       empty_strided_p2p(
           {2, 3},

--- a/test/cpp/c10d/SymmetricMemoryTest.cpp
+++ b/test/cpp/c10d/SymmetricMemoryTest.cpp
@@ -27,6 +27,10 @@ class TestSymmetricMemoryAllocator final : public SymmetricMemoryAllocator {
     dtype_ = dtype;
     device_ = device;
     saw_deleter_ = static_cast<bool>(deleter);
+    if (offset_storage_ptr_) {
+      EXPECT_FALSE(deleter);
+      ptr = static_cast<uint8_t*>(ptr) + 1;
+    }
     return SymmetricMemoryAllocator::make_tensor(
         ptr,
         sizes,
@@ -58,8 +62,10 @@ class TestSymmetricMemoryAllocator final : public SymmetricMemoryAllocator {
   }
 
   c10::intrusive_ptr<SymmetricMemory> rendezvous(
-      void* /*ptr*/,
+      void* ptr,
       const std::optional<std::string>& /*group_name*/) override {
+    rendezvous_ptr_ = ptr;
+    ++rendezvous_calls_;
     return nullptr;
   }
 
@@ -75,10 +81,21 @@ class TestSymmetricMemoryAllocator final : public SymmetricMemoryAllocator {
     return "TEST";
   }
 
+  bool has_allocation(void* ptr) override {
+    has_allocation_ptr_ = ptr;
+    ++has_allocation_calls_;
+    return ptr == allocation_;
+  }
+
   int make_tensor_calls_ = 0;
   int free_calls_ = 0;
+  int rendezvous_calls_ = 0;
+  int has_allocation_calls_ = 0;
   bool saw_deleter_ = false;
+  bool offset_storage_ptr_ = false;
   void* allocation_ = nullptr;
+  void* rendezvous_ptr_ = nullptr;
+  void* has_allocation_ptr_ = nullptr;
   size_t allocation_size_ = 0;
   std::vector<int64_t> sizes_;
   std::vector<int64_t> strides_;
@@ -106,6 +123,15 @@ TEST(SymmetricMemoryAllocatorTest, EmptyUsesBackendTensorWrapper) {
   EXPECT_EQ(allocator->device_, c10::Device(c10::DeviceType::CPU));
   EXPECT_EQ(tensor.sizes(), (c10::IntArrayRef{2, 3}));
   EXPECT_EQ(tensor.strides(), (c10::IntArrayRef{3, 1}));
+  EXPECT_EQ(tensor.storage().data_ptr().get(), allocator->allocation_);
+
+  EXPECT_EQ(rendezvous(tensor, std::nullopt), nullptr);
+  EXPECT_EQ(allocator->rendezvous_calls_, 1);
+  EXPECT_EQ(allocator->rendezvous_ptr_, allocator->allocation_);
+
+  EXPECT_TRUE(is_symm_mem_tensor(tensor));
+  EXPECT_EQ(allocator->has_allocation_calls_, 1);
+  EXPECT_EQ(allocator->has_allocation_ptr_, allocator->allocation_);
 
   tensor.reset();
   EXPECT_EQ(allocator->free_calls_, 1);
@@ -140,6 +166,23 @@ TEST(SymmetricMemoryAllocatorTest, PersistentEmptyUsesBackendTensorWrapper) {
   EXPECT_EQ(allocator->make_tensor_calls_, 2);
   EXPECT_EQ(tensor.data_ptr(), data_ptr);
   EXPECT_EQ(allocator->free_calls_, 0);
+}
+
+TEST(SymmetricMemoryAllocatorTest, RejectsChangedStoragePointer) {
+  auto allocator = c10::make_intrusive<TestSymmetricMemoryAllocator>();
+  allocator->offset_storage_ptr_ = true;
+  register_allocator(c10::DeviceType::CPU, allocator);
+
+  constexpr uint64_t alloc_id = 0x53594d4e;
+  EXPECT_THROW(
+      empty_strided_p2p(
+          {2, 3},
+          {3, 1},
+          c10::ScalarType::Float,
+          c10::Device(c10::DeviceType::CPU),
+          std::nullopt,
+          alloc_id),
+      c10::Error);
 }
 
 } // namespace

--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
@@ -187,7 +187,7 @@ static at::Tensor empty_strided_p2p_persistent(
   }
 
   auto allocated =
-      allocator->make_tensor(dev_ptr, size, stride, dtype, device);
+      allocator->make_tensor(dev_ptr, size, stride, dtype, device, group_name);
   check_tensor_storage_ptr(allocated, dev_ptr);
 
   // Track the allocation's activeness
@@ -210,6 +210,7 @@ at::Tensor SymmetricMemoryAllocator::make_tensor(
     c10::IntArrayRef strides,
     c10::ScalarType dtype,
     c10::Device device,
+    const std::optional<std::string>& /*group_name*/,
     std::function<void(void*)> deleter) {
   auto options = at::TensorOptions().dtype(dtype).device(device);
   if (deleter) {
@@ -310,6 +311,7 @@ at::Tensor empty_strided_p2p(
       stride,
       dtype,
       device,
+      group_name,
       std::move(deleter));
   check_tensor_storage_ptr(allocated, dev_ptr);
   return allocated;

--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
@@ -130,6 +130,15 @@ static std::unordered_map<uint64_t, void*> alloc_id_to_dev_ptr{};
 static std::unordered_map<uint64_t, c10::weak_intrusive_ptr<c10::StorageImpl>>
     alloc_id_to_storage{};
 
+static void check_tensor_storage_ptr(
+    const at::Tensor& tensor,
+    const void* expected_ptr) {
+  TORCH_CHECK(
+      tensor.storage().data_ptr().get() == expected_ptr,
+      "SymmetricMemoryAllocator::make_tensor() must return a tensor whose ",
+      "storage data pointer is the exact pointer returned by alloc()");
+}
+
 static at::Tensor empty_strided_p2p_persistent(
     c10::IntArrayRef size,
     c10::IntArrayRef stride,
@@ -179,6 +188,7 @@ static at::Tensor empty_strided_p2p_persistent(
 
   auto allocated =
       allocator->make_tensor(dev_ptr, size, stride, dtype, device);
+  check_tensor_storage_ptr(allocated, dev_ptr);
 
   // Track the allocation's activeness
   alloc_id_to_storage.insert_or_assign(
@@ -294,13 +304,15 @@ at::Tensor empty_strided_p2p(
   void* dev_ptr = allocator->alloc(alloc_size, device.index(), group_name);
 
   auto deleter = [allocator](void* ptr) { allocator->free(ptr); };
-  return allocator->make_tensor(
+  auto allocated = allocator->make_tensor(
       dev_ptr,
       size,
       stride,
       dtype,
       device,
       std::move(deleter));
+  check_tensor_storage_ptr(allocated, dev_ptr);
+  return allocated;
 }
 
 TORCH_API c10::intrusive_ptr<SymmetricMemory> rendezvous(

--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
@@ -306,13 +306,7 @@ at::Tensor empty_strided_p2p(
 
   auto deleter = [allocator](void* ptr) { allocator->free(ptr); };
   auto allocated = allocator->make_tensor(
-      dev_ptr,
-      size,
-      stride,
-      dtype,
-      device,
-      group_name,
-      std::move(deleter));
+      dev_ptr, size, stride, dtype, device, group_name, std::move(deleter));
   check_tensor_storage_ptr(allocated, dev_ptr);
   return allocated;
 }

--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
@@ -177,8 +177,8 @@ static at::Tensor empty_strided_p2p_persistent(
     alloc_id_to_dev_ptr[alloc_id] = dev_ptr;
   }
 
-  auto options = at::TensorOptions().dtype(dtype).device(device);
-  auto allocated = at::from_blob(dev_ptr, size, stride, options);
+  auto allocated =
+      allocator->make_tensor(dev_ptr, size, stride, dtype, device);
 
   // Track the allocation's activeness
   alloc_id_to_storage.insert_or_assign(
@@ -192,6 +192,20 @@ namespace c10d::symmetric_memory {
 
 bool is_finalizing() {
   return is_finalizing_;
+}
+
+at::Tensor SymmetricMemoryAllocator::make_tensor(
+    void* ptr,
+    c10::IntArrayRef sizes,
+    c10::IntArrayRef strides,
+    c10::ScalarType dtype,
+    c10::Device device,
+    std::function<void(void*)> deleter) {
+  auto options = at::TensorOptions().dtype(dtype).device(device);
+  if (deleter) {
+    return at::from_blob(ptr, sizes, strides, std::move(deleter), options);
+  }
+  return at::from_blob(ptr, sizes, strides, options);
 }
 
 void register_allocator(
@@ -279,13 +293,14 @@ at::Tensor empty_strided_p2p(
   auto allocator = get_allocator(device.type());
   void* dev_ptr = allocator->alloc(alloc_size, device.index(), group_name);
 
-  auto options = at::TensorOptions().dtype(dtype).device(device);
-  return at::from_blob(
+  auto deleter = [allocator](void* ptr) { allocator->free(ptr); };
+  return allocator->make_tensor(
       dev_ptr,
       size,
       stride,
-      [allocator = std::move(allocator)](void* ptr) { allocator->free(ptr); },
-      options);
+      dtype,
+      device,
+      std::move(deleter));
 }
 
 TORCH_API c10::intrusive_ptr<SymmetricMemory> rendezvous(

--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp
@@ -121,8 +121,10 @@ class SymmetricMemoryAllocator : public c10::intrusive_ptr_target {
 
   // Wraps a pointer returned by alloc() in a tensor. Backends that require
   // custom TensorImpl, StorageImpl, or storage metadata for externally
-  // allocated memory can override this method. The returned tensor must use
-  // ptr as its exact storage data pointer:
+  // allocated memory can override this method. group_name is the logical
+  // group supplied to empty_strided_p2p() and may be ignored by backends whose
+  // tensor wrapping is group-independent. The returned tensor must use ptr as
+  // its exact storage data pointer:
   //
   //   tensor.storage().data_ptr().get() == ptr
   //
@@ -135,6 +137,7 @@ class SymmetricMemoryAllocator : public c10::intrusive_ptr_target {
       c10::IntArrayRef strides,
       c10::ScalarType dtype,
       c10::Device device,
+      const std::optional<std::string>& group_name,
       std::function<void(void*)> deleter = {});
 };
 

--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp
@@ -121,8 +121,14 @@ class SymmetricMemoryAllocator : public c10::intrusive_ptr_target {
 
   // Wraps a pointer returned by alloc() in a tensor. Backends that require
   // custom TensorImpl, StorageImpl, or storage metadata for externally
-  // allocated memory can override this method. The default implementation
-  // preserves the existing at::from_blob() behavior.
+  // allocated memory can override this method. The returned tensor must use
+  // ptr as its exact storage data pointer:
+  //
+  //   tensor.storage().data_ptr().get() == ptr
+  //
+  // rendezvous() and has_allocation() use this pointer as the allocation
+  // identity. Implementations must not copy or rebase the allocation. The
+  // default implementation preserves the existing at::from_blob() behavior.
   virtual at::Tensor make_tensor(
       void* ptr,
       c10::IntArrayRef sizes,

--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp
@@ -4,6 +4,8 @@
 #include <ATen/core/ivalue.h>
 #include <torch/csrc/distributed/c10d/Store.hpp>
 
+#include <functional>
+
 namespace c10d::symmetric_memory {
 
 // SymmetricMemory represents symmetric allocations across a group of devices.
@@ -116,6 +118,18 @@ class SymmetricMemoryAllocator : public c10::intrusive_ptr_target {
   virtual bool has_allocation(void* ptr) {
     return false;
   }
+
+  // Wraps a pointer returned by alloc() in a tensor. Backends that require
+  // custom TensorImpl, StorageImpl, or storage metadata for externally
+  // allocated memory can override this method. The default implementation
+  // preserves the existing at::from_blob() behavior.
+  virtual at::Tensor make_tensor(
+      void* ptr,
+      c10::IntArrayRef sizes,
+      c10::IntArrayRef strides,
+      c10::ScalarType dtype,
+      c10::Device device,
+      std::function<void(void*)> deleter = {});
 };
 
 C10_EXPORT bool is_finalizing();

--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp
@@ -98,7 +98,7 @@ class TORCH_API SymmetricMemory : public torch::CustomClassHolder {
   }
 };
 
-class SymmetricMemoryAllocator : public c10::intrusive_ptr_target {
+class TORCH_API SymmetricMemoryAllocator : public c10::intrusive_ptr_target {
  public:
   ~SymmetricMemoryAllocator() override = default;
 


### PR DESCRIPTION
## Summary

- add a virtual `SymmetricMemoryAllocator::make_tensor()` extension point
- keep the current `at::from_blob()` behavior as the default implementation
- route both regular and persistent `empty_strided_p2p()` allocations through the allocator hook
- forward the optional group name so backend tensor wrapping can use group-specific conventions
- document and enforce that the returned tensor preserves the allocator's exact storage pointer
- add a mock allocator C++ test for custom tensor wrapping, deleter ownership, and persistent pointer reuse

## Motivation

`SymmetricMemoryAllocator` lets backends customize allocation, deallocation, and rendezvous, but `empty_strided_p2p()` currently hardcodes generic `at::from_blob()` calls when wrapping the allocated pointer.

Out-of-tree backends may require a backend-specific TensorImpl, StorageImpl, or storage metadata for externally allocated device memory. The existing allocator interface does not provide a way to perform that wrapping, so later operators can observe incomplete backend metadata.

The new virtual method keeps symmetric-memory core backend-agnostic while allowing an allocator to override only the pointer-to-tensor conversion step.

The hook also receives the optional `group_name` already available at both call sites. Backends whose tensor wrapping is group-independent can ignore it, while multi-group allocators do not need a future ABI-breaking signature change.

Because `rendezvous()` and `has_allocation()` use the tensor's storage pointer as the allocation identity, `make_tensor(ptr, ...)` must return a tensor satisfying `tensor.storage().data_ptr().get() == ptr`. Both allocation paths validate this contract and report a backend error immediately if it is violated.

## Backward compatibility

The default `make_tensor()` implementation preserves the existing `at::from_blob()` behavior. Existing CUDA, NVSHMEM, and NCCL allocators do not need to override the new method.

The method is appended to the end of the allocator's virtual interface to minimize disruption to the existing virtual method layout.

## Test plan

- `git diff --check main...HEAD`
- added `SymmetricMemoryTest` coverage for:
  - forwarding sizes, strides, dtype, and device to the allocator hook
  - forwarding `group_name` in both regular and persistent allocation paths
  - passing a deleter for regular allocations and calling `free()` exactly once
  - omitting the deleter for persistent allocations
  - reusing the same pointer for a persistent allocation ID
  - forwarding the original allocation pointer to `rendezvous()` and `has_allocation()`
  - rejecting a custom wrapper that changes the tensor storage pointer

The new C++ test has not yet been compiled locally because this checkout does not have a configured PyTorch build directory. This PR is opened as a draft for API feedback and CI validation.

Closes #190628
