### PR TITLE
Add magma-cuda134 build for CUDA 13.4

### DIFF
--- a/.ci/magma/Makefile
+++ b/.ci/magma/Makefile
@@ -16,6 +16,7 @@ DOCKER_RUN = set -eou pipefail; ${DOCKER_CMD} run --rm -i \
 	magma/build_magma.sh
 
 .PHONY: all
+all: magma-cuda134
 all: magma-cuda132
 all: magma-cuda130
 all: magma-cuda129
@@ -26,6 +27,12 @@ all: magma-cuda126
 clean:
 	$(RM) -r magma-*
 	$(RM) -r output
+
+.PHONY: magma-cuda134
+magma-cuda134: DESIRED_CUDA := 13.4
+magma-cuda134: CUDA_ARCH_LIST := -gencode arch=compute_80,code=sm_80 -gencode arch=compute_86,code=sm_86 -gencode arch=compute_90,code=sm_90 -gencode arch=compute_100,code=sm_100 -gencode arch=compute_120,code=sm_120
+magma-cuda134:
+	$(DOCKER_RUN)
 
 .PHONY: magma-cuda132
 magma-cuda132: DESIRED_CUDA := 13.2

--- a/.github/workflows/build-magma-linux.yml
+++ b/.github/workflows/build-magma-linux.yml
@@ -35,7 +35,7 @@ jobs:
       id-token: write
     strategy:
       matrix:
-        cuda_version: ["132", "130", "129", "128", "126"]
+        cuda_version: ["134", "132", "130", "129", "128", "126"]
     steps:
       - name: Checkout PyTorch
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Adds a magma-cuda134 target to .ci/magma/Makefile and "134" to the build-magma-linux matrix, so the magma static-lib tarball for CUDA 13.4 (magma-cuda134-2.6.1-1.tar.bz2) is built against the cuda13.4 almalinux builder image and uploaded to the ossci-linux S3 bucket. Arch list mirrors magma-cuda132 (sm_80/86/90/100/120).

This is the missing prerequisite between the almalinux magma image and the CI build/test image: install_magma.sh in the CI image downloads magma-cuda134 from S3, which 404'd because the tarball was never built. Note the S3 upload only runs on push to main, so the artifact publishes after this lands, not on the PR.

Test Plan:
```
make -n -C .ci/magma magma-cuda134
```
confirms the target resolves to the cuda13.4-main builder image with PACKAGE_NAME=magma-cuda134. Full validation is the build-linux-magma job.

cc @ptrblck @nWEIdia @atalman @malfet 