### PR TITLE
[CI] Exclude inductor OpInfo test from pull CPU default config

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -160,6 +160,12 @@ if [[ -n $TESTS_TO_INCLUDE ]]; then
   INCLUDE_CLAUSE="--include $TESTS_TO_INCLUDE"
 fi
 
+# Exclude tests from run_test.py (symmetric to TESTS_TO_INCLUDE).
+if [[ -n $TESTS_TO_EXCLUDE ]]; then
+  echo "Setting EXCLUDE_CLAUSE"
+  EXCLUDE_CLAUSE="--exclude $TESTS_TO_EXCLUDE"
+fi
+
 echo "Environment variables"
 env
 
@@ -407,14 +413,14 @@ test_python_shard() {
 
   # modify LD_LIBRARY_PATH to ensure it has the conda env.
   # This set of tests has been shown to be buggy without it for the split-build
-  time python test/run_test.py --exclude-jit-executor --exclude-distributed-tests --exclude-quantization-tests $INCLUDE_CLAUSE --shard "$1" "$NUM_TEST_SHARDS" --verbose $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
+  time python test/run_test.py --exclude-jit-executor --exclude-distributed-tests --exclude-quantization-tests $EXCLUDE_CLAUSE $INCLUDE_CLAUSE --shard "$1" "$NUM_TEST_SHARDS" --verbose $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
 
   assert_git_not_dirty
 }
 
 test_python() {
   # shellcheck disable=SC2086
-  time python test/run_test.py --exclude-jit-executor --exclude-distributed-tests --exclude-quantization-tests $INCLUDE_CLAUSE --verbose $PYTHON_TEST_EXTRA_OPTION
+  time python test/run_test.py --exclude-jit-executor --exclude-distributed-tests --exclude-quantization-tests $EXCLUDE_CLAUSE $INCLUDE_CLAUSE --verbose $PYTHON_TEST_EXTRA_OPTION
   assert_git_not_dirty
 }
 

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -34,6 +34,11 @@ on:
         type: string
         default: ""
         description: Space-separated tests to include (empty string implies default list)
+      tests-to-exclude:
+        required: false
+        type: string
+        default: ""
+        description: Space-separated tests to exclude (empty string implies none)
       use-gha:
         required: false
         type: string
@@ -291,6 +296,7 @@ jobs:
           XLA_CLANG_CACHE_S3_BUCKET_NAME: ossci-compiler-clang-cache-circleci-xla
           PYTORCH_TEST_RERUN_DISABLED_TESTS: ${{ matrix.rerun_disabled_tests && '1' || '0' }}
           TESTS_TO_INCLUDE: ${{ inputs.tests-to-include }}
+          TESTS_TO_EXCLUDE: ${{ inputs.tests-to-exclude }}
           DASHBOARD_TAG: ${{ inputs.dashboard-tag }}
           ENABLE_TORCH_TRACE: ${{ inputs.enable-torch-trace }}
           VLLM_TEST_HUGGING_FACE_TOKEN: ${{ secrets.VLLM_TEST_HUGGING_FACE_TOKEN }}

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -128,6 +128,7 @@ jobs:
       docker-image: ${{ needs.linux-jammy-py3_10-gcc11-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-py3_10-gcc11-build.outputs.test-matrix }}
       tests-to-include: ${{ github.event.inputs.tests-to-include || '' }}
+      tests-to-exclude: "inductor/test_torchinductor_opinfo"
       python-version: "3.10"
       compiler: gcc11
     secrets: inherit
@@ -175,6 +176,7 @@ jobs:
       docker-image: ${{ needs.linux-jammy-aarch64-py3_10-gcc13-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-aarch64-py3_10-gcc13-build.outputs.test-matrix }}
       tests-to-include: ${{ github.event.inputs.tests-to-include || '' }}
+      tests-to-exclude: "inductor/test_torchinductor_opinfo"
       python-version: "3.10"
       compiler: gcc13
     secrets: inherit
@@ -238,6 +240,7 @@ jobs:
       build-environment: linux-jammy-py3.14t-clang18
       docker-image: ${{ needs.linux-jammy-py3_14t-clang18-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-py3_14t-clang18-build.outputs.test-matrix }}
+      tests-to-exclude: "inductor/test_torchinductor_opinfo"
       python-version: "3.14t"
       compiler: clang18
     secrets: inherit
@@ -329,6 +332,7 @@ jobs:
       docker-image: ${{ needs.linux-jammy-py3_10-clang18-asan-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-py3_10-clang18-asan-build.outputs.test-matrix }}
       tests-to-include: ${{ github.event.inputs.tests-to-include || '' }}
+      tests-to-exclude: "inductor/test_torchinductor_opinfo"
       python-version: "3.10"
       compiler: clang18
       # TODO (huydhn): Add this back once other workflow migrates
@@ -396,6 +400,7 @@ jobs:
       docker-image: ${{ needs.linux-jammy-py3_10-clang18-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-py3_10-clang18-build.outputs.test-matrix }}
       tests-to-include: ${{ github.event.inputs.tests-to-include || '' }}
+      tests-to-exclude: "inductor/test_torchinductor_opinfo"
       python-version: "3.10"
       compiler: clang18
     secrets: inherit
@@ -460,6 +465,7 @@ jobs:
       docker-image: ${{ needs.linux-jammy-py3_14-clang18-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-py3_14-clang18-build.outputs.test-matrix }}
       tests-to-include: ${{ github.event.inputs.tests-to-include || '' }}
+      tests-to-exclude: "inductor/test_torchinductor_opinfo"
       python-version: "3.14"
       compiler: clang18
     secrets: inherit


### PR DESCRIPTION
test_torchinductor_opinfo runs heavily in the default config on pull's CPU builds, and the same coverage also runs in inductor_amx / inductor_core (trunk/default, ciflow/inductor, periodic,...etc). Add a generic TESTS_TO_EXCLUDE (symmetric to TESTS_TO_INCLUDE) and set it on the six CPU default jobs to drop the file from default via run_test.py --exclude.

Test Plan:
- validate overall test runtimes (shard balancing should stabilize after landing)
- check that inductor coverage for opinfo is still maintained outside of pull

Authored with assistance from Claude (AI).