### PR TITLE
[native dsl] Add Helion backend integration

### DIFF
--- a/test/python_native/test_instrumentation.py
+++ b/test/python_native/test_instrumentation.py
@@ -14,6 +14,7 @@ from torch._logging._internal import TorchLogsFormatter, trace_log
 from torch._native.instrumentation import (
     CompileEvent,
     instrument_cutedsl_compile,
+    instrument_helion_kernel,
     instrument_triton_kernel,
 )
 from torch.testing._internal.common_utils import run_tests, TestCase
@@ -89,6 +90,24 @@ class _FakeJitCache:
             maxsize=None,
             currsize=len(self._cache),
         )
+
+
+class _FakeHelionBoundKernel:
+    def __init__(self):
+        self._compile_cache = {"config": object()}
+
+
+class _FakeHelionKernel:
+    def __init__(self):
+        self._bound_kernels = {}
+        self.raise_on_call = False
+        self.cache_key = "helion-cache"
+
+    def __call__(self, variant="v0"):
+        if self.raise_on_call:
+            raise RuntimeError("helion boom")
+        self._bound_kernels.setdefault(variant, _FakeHelionBoundKernel())
+        return "launched"
 
 
 class _CapturingHandler(logging.Handler):
@@ -340,6 +359,46 @@ class TestTritonKernelInstrumentation(_LoggerCaptureTest):
         self.assertEqual(kernel.cache_key, "abc123")
 
 
+class TestHelionKernelInstrumentation(_LoggerCaptureTest):
+    def _kernel(self, op="aten::add", key_fn=None):
+        return instrument_helion_kernel(op, key_fn=key_fn)(_FakeHelionKernel())
+
+    def test_first_call_reports_compiled(self):
+        kernel = self._kernel()
+        self.assertEqual(kernel(), "launched")
+        self.assertIn("[helion]", self.messages[0])
+        self.assertIn("compiled", self.messages[0])
+        self.assertIn("misses=1", self.messages[0])
+
+    def test_repeated_call_reports_cache_hit(self):
+        kernel = self._kernel()
+        kernel("v0")
+        kernel("v0")
+        self.assertIn("compiled", self.messages[0])
+        self.assertIn("cache_hit", self.messages[1])
+
+    def test_new_variant_recompiles(self):
+        kernel = self._kernel()
+        kernel("v0")
+        kernel("v1")
+        self.assertIn("compiled", self.messages[1])
+        self.assertIn("misses=2", self.messages[1])
+
+    def test_error_is_reported_and_reraised(self):
+        fake = _FakeHelionKernel()
+        fake.raise_on_call = True
+        kernel = instrument_helion_kernel("aten::add")(fake)
+        with self.assertRaisesRegex(RuntimeError, "helion boom"):
+            kernel()
+        self.assertIn("error", self.messages[0])
+
+    def test_raw_kernel_and_attributes_are_exposed(self):
+        fake = _FakeHelionKernel()
+        kernel = instrument_helion_kernel("aten::add")(fake)
+        self.assertIs(kernel.helion_kernel, fake)
+        self.assertEqual(kernel.cache_key, "helion-cache")
+
+
 class TestTlparseOutput(TestCase):
     """The instrumentation's whole point on production jobs is tlparse-
     retrievable artifacts. Assert the structured-trace plumbing actually
@@ -498,13 +557,19 @@ def _decorator_names(fn_node):
 # (instrument names) / the DSL (jit name); test_required_decorators_exist
 # enforces the instrumentation ones.
 _DSL_INSTRUMENTATION_RULES = (
-    # (dsl, jit_decorator, instrument_decorator, combined_decorator)
+    # (dsl, jit_decorator(s), instrument_decorator, combined_decorator)
     ("triton", "triton.jit", "instrument_triton_kernel", "instrumented_triton_cache"),
     (
         "cutedsl",
         "jit_cache",
         "instrument_cutedsl_compile",
         "instrumented_cutedsl_cache",
+    ),
+    (
+        "helion",
+        ("helion.kernel", "helion.jit", "helion.experimental.aot_kernel"),
+        "instrument_helion_kernel",
+        "instrumented_helion_kernel",
     ),
 )
 
@@ -515,7 +580,10 @@ def _is_instrumented(decos, jit_deco, instrument_deco, combined_deco):
     Either the one-shot combined decorator, or the explicit jit + instrument
     stack.
     """
-    return combined_deco in decos or (jit_deco in decos and instrument_deco in decos)
+    jit_decos = (jit_deco,) if isinstance(jit_deco, str) else jit_deco
+    return combined_deco in decos or (
+        any(deco in decos for deco in jit_decos) and instrument_deco in decos
+    )
 
 
 def _scan_for_missing_instrumentation(source, label):
@@ -533,14 +601,16 @@ def _scan_for_missing_instrumentation(source, label):
         if not isinstance(node, ast.FunctionDef):
             continue
         decos = _decorator_names(node)
-        for _, jit_deco, instrument_deco, combined_deco in _DSL_INSTRUMENTATION_RULES:
-            if jit_deco in decos or combined_deco in decos:
+        for dsl, jit_deco, instrument_deco, combined_deco in _DSL_INSTRUMENTATION_RULES:
+            jit_decos = (jit_deco,) if isinstance(jit_deco, str) else jit_deco
+            if any(deco in decos for deco in jit_decos) or combined_deco in decos:
                 n_compile_sites += 1
                 if not _is_instrumented(
                     decos, jit_deco, instrument_deco, combined_deco
                 ):
                     violations.append(
-                        f"{label}:{node.lineno} {node.name} has @{jit_deco} but "
+                        f"{label}:{node.lineno} {node.name} has an uninstrumented "
+                        f"{dsl} decorator but "
                         f"is not instrumented (use @{combined_deco}, or add "
                         f"@{instrument_deco})"
                     )
@@ -674,6 +744,11 @@ class TestInstrumentationCoverage(TestCase):
                 "@instrument_cutedsl_compile('aten::x')\n@jit_cache\ndef c(): ...\n",
                 "@instrumented_cutedsl_cache('aten::x')\ndef c(): ...\n",
             ),
+            "helion": (
+                "@helion.kernel\ndef h(): ...\n",
+                "@instrument_helion_kernel('aten::x')\n@helion.kernel\ndef h(): ...\n",
+                "@instrumented_helion_kernel('aten::x')\ndef h(): ...\n",
+            ),
         }
         for dsl, (bad, explicit_ok, combined_ok) in templates.items():
             bad_v, bad_n = _scan_for_missing_instrumentation(bad, f"<{dsl}-bad>")
@@ -686,6 +761,18 @@ class TestInstrumentationCoverage(TestCase):
                 v, n = _scan_for_missing_instrumentation(src, f"<{dsl}-{form}>")
                 self.assertEqual(n, 1, f"{dsl}/{form}: scan missed the site")
                 self.assertEqual(v, [], f"{dsl}/{form}: wrongly flagged")
+
+        aot_v, aot_n = _scan_for_missing_instrumentation(
+            "@helion.experimental.aot_kernel\ndef h(): ...\n", "<helion-aot-bad>"
+        )
+        self.assertEqual(aot_n, 1)
+        self.assertEqual(len(aot_v), 1)
+
+        jit_v, jit_n = _scan_for_missing_instrumentation(
+            "@helion.jit\ndef h(): ...\n", "<helion-jit-bad>"
+        )
+        self.assertEqual(jit_n, 1)
+        self.assertEqual(len(jit_v), 1)
 
     def test_no_raw_cute_compile_calls(self):
         # Caching is compulsory for cutedsl compiles: every cute.compile() must

--- a/test/python_native/test_native_dsl_ops.py
+++ b/test/python_native/test_native_dsl_ops.py
@@ -67,6 +67,14 @@ class TestNativeDSLOps(TestCase):
                     "check_native_version_skip",
                 ],
             ),
+            (
+                "torch._native.helion_utils",
+                [
+                    "_version_is_sufficient",
+                    "check_native_jit_disabled",
+                    "check_native_version_skip",
+                ],
+            ),
         ]
         self._clear_function_caches()
 
@@ -90,7 +98,7 @@ class TestNativeDSLOps(TestCase):
         dsl_names = get_all_dsls()
         if not dsl_names:
             # Fallback to hardcoded list if registry not available
-            dsl_names = ["triton", "cutedsl"]
+            dsl_names = ["triton", "cutedsl", "helion"]
 
         modules_info = [
             (f"{dsl}_utils.py", f"torch._native.{dsl}_utils") for dsl in dsl_names
@@ -157,7 +165,7 @@ class TestNativeDSLOps(TestCase):
         script = textwrap.dedent("""\
             import sys
             import torch
-            dsl_modules = ["triton", "cutlass", "tvm_ffi"]
+            dsl_modules = ["triton", "cutlass", "tvm_ffi", "helion"]
             leaked = [m for m in dsl_modules if m in sys.modules]
             print(repr(leaked))
         """)
@@ -307,6 +315,7 @@ class TestNativeDSLOps(TestCase):
         modules_to_test = [
             ("triton_utils.py", "torch._native.triton_utils"),
             ("cutedsl_utils.py", "torch._native.cutedsl_utils"),
+            ("helion_utils.py", "torch._native.helion_utils"),
         ]
 
         # Use the preserve_filter_state context manager pattern
@@ -345,7 +354,7 @@ class TestNativeDSLOps(TestCase):
 
     def test_register_op_skips_when_jit_disabled(self):
         """register_op_override does not call through when TORCH_DISABLE_NATIVE_JIT=1."""
-        from torch._native import cutedsl_utils, triton_utils
+        from torch._native import cutedsl_utils, helion_utils, triton_utils
 
         # Test the actual environment variable behavior to ensure it works
         # Set TORCH_DISABLE_NATIVE_JIT=1 and clear caches
@@ -358,12 +367,18 @@ class TestNativeDSLOps(TestCase):
             # Import functions from each module and clear their caches too
             triton_utils.check_native_jit_disabled.cache_clear()
             cutedsl_utils.check_native_jit_disabled.cache_clear()
+            helion_utils.check_native_jit_disabled.cache_clear()
 
             # Verify the function returns True
             self.assertTrue(check_native_jit_disabled())
 
-            # Mock the registry calls to count how many times they would be called
-            with patch("torch._native.registry.register_op_override") as registry_mock:
+            with (
+                patch.object(triton_utils, "_register_op_override_impl") as triton_mock,
+                patch.object(
+                    cutedsl_utils, "_register_op_override_impl"
+                ) as cutedsl_mock,
+                patch.object(helion_utils, "_register_op_override_impl") as helion_mock,
+            ):
                 # Use a unique operation name
                 unique_op = f"test_jit_disabled_{uuid.uuid4().hex[:8]}.Tensor"
                 triton_utils.register_op_override(
@@ -372,26 +387,51 @@ class TestNativeDSLOps(TestCase):
                 cutedsl_utils.register_op_override(
                     "aten", unique_op, "CPU", lambda *a, **k: True, lambda: None
                 )
-                # Should not call the registry function at all since JIT is disabled
-                self.assertEqual(registry_mock.call_count, 0)
+                helion_utils.register_op_override(
+                    "aten", unique_op, "CPU", lambda *a, **k: True, lambda: None
+                )
+                self.assertEqual(triton_mock.call_count, 0)
+                self.assertEqual(cutedsl_mock.call_count, 0)
+                self.assertEqual(helion_mock.call_count, 0)
+
+    def test_helion_availability_requires_supported_backend_and_version(self):
+        from torch._native import helion_utils
+        from torch._vendor.packaging.version import Version
+
+        with patch.dict(os.environ, {"HELION_BACKEND": "metal"}):
+            helion_utils._check_runtime_available.cache_clear()
+            helion_utils._version_is_sufficient.cache_clear()
+            self.assertFalse(helion_utils.runtime_available())
+
+        helion_utils._check_runtime_available.cache_clear()
+        helion_utils._version_is_sufficient.cache_clear()
+        with patch.object(
+            helion_utils,
+            "_check_runtime_available",
+            return_value=(True, Version("1.0.0")),
+        ):
+            self.assertFalse(helion_utils.runtime_available())
+
+        helion_utils._check_runtime_available.cache_clear()
+        helion_utils._version_is_sufficient.cache_clear()
 
     def test_version_skip_env_var_overrides(self):
         """TORCH_NATIVE_SKIP_VERSION_CHECK=1 allows non-blessed versions."""
         from torch._vendor.packaging.version import Version
 
-        fake_version = Version("99.99.99")
+        fake_version = Version("1.0.0")
 
         # Set the environment variable and clear caches
         with patch.dict(os.environ, {"TORCH_NATIVE_SKIP_VERSION_CHECK": "1"}):
             # Import fresh modules to avoid cached state
-            from torch._native import cutedsl_utils, triton_utils
+            from torch._native import cutedsl_utils, helion_utils, triton_utils
             from torch._native.common_utils import check_native_version_skip
 
             # Clear all relevant caches to ensure clean state
             check_native_version_skip.cache_clear()
 
             # Clear module-specific caches for the imported modules
-            for module in [triton_utils, cutedsl_utils]:
+            for module in [triton_utils, cutedsl_utils, helion_utils]:
                 for attr_name in dir(module):
                     attr = getattr(module, attr_name)
                     if hasattr(attr, "cache_clear"):
@@ -408,8 +448,14 @@ class TestNativeDSLOps(TestCase):
                     "_check_runtime_available",
                     return_value=(True, fake_version),
                 ),
+                patch.object(
+                    helion_utils,
+                    "_check_runtime_available",
+                    return_value=(True, fake_version),
+                ),
                 patch.object(triton_utils, "_register_op_override_impl") as triton_mock,
                 patch.object(cutedsl_utils, "_register_op_override_impl") as cute_mock,
+                patch.object(helion_utils, "_register_op_override_impl") as helion_mock,
             ):
                 # Use unique operation names to avoid conflicts
                 op_name = f"test_version_skip_{uuid.uuid4().hex[:8]}.Tensor"
@@ -421,12 +467,22 @@ class TestNativeDSLOps(TestCase):
                 cutedsl_utils.register_op_override(
                     "aten", op_name, "CPU", lambda *a, **k: True, lambda: None
                 )
+                helion_utils.register_op_override(
+                    "aten", op_name, "CPU", lambda *a, **k: True, lambda: None
+                )
 
-                # Verify both implementation functions were called
+                # Verify all implementation functions were called
+                details = (
+                    f"triton: {triton_mock.call_count}, "
+                    f"cutedsl: {cute_mock.call_count}, "
+                    f"helion: {helion_mock.call_count}"
+                )
                 self.assertEqual(
-                    triton_mock.call_count + cute_mock.call_count,
-                    2,
-                    lambda msg: f"{msg}\nExpected 2 calls but got triton: {triton_mock.call_count}, cutedsl: {cute_mock.call_count}",
+                    triton_mock.call_count
+                    + cute_mock.call_count
+                    + helion_mock.call_count,
+                    3,
+                    lambda msg: f"{msg}\nExpected 3 calls but got {details}",
                 )
 
     @parametrize("env_value, expected", [(None, False), ("1", True)])
@@ -460,6 +516,7 @@ class TestNativeDSLOps(TestCase):
         self.assertIsInstance(all_dsls, list)
         self.assertIn("triton", all_dsls)
         self.assertIn("cutedsl", all_dsls)
+        self.assertIn("helion", all_dsls)
 
         # Test available DSLs are subset of all DSLs
         available_dsls = get_available_dsls()
@@ -479,6 +536,7 @@ class TestNativeDSLOps(TestCase):
         """Test that DSL test helper decorators work"""
         from torch.testing._internal.common_utils import (
             skipIfDSLUnavailable,
+            skipIfNoHelionDSL,
             skipIfNoTritonDSL,
             skipUnlessDSLAvailable,
         )
@@ -486,6 +544,7 @@ class TestNativeDSLOps(TestCase):
         # Test that decorators are callable
         self.assertTrue(callable(skipIfNoTritonDSL))
         self.assertTrue(callable(skipIfNoCuteDSL))
+        self.assertTrue(callable(skipIfNoHelionDSL))
         self.assertTrue(callable(skipIfDSLUnavailable))
         self.assertTrue(callable(skipUnlessDSLAvailable))
 

--- a/test/python_native/test_native_dsl_ops.py
+++ b/test/python_native/test_native_dsl_ops.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: dsl-native-ops"]
 
+import contextlib
 import importlib.util
 import os
 import subprocess
@@ -438,59 +439,44 @@ class TestNativeDSLOps(TestCase):
             # Clear all relevant caches to ensure clean state
             check_native_version_skip.cache_clear()
 
+            utils = (triton_utils, cutedsl_utils, helion_utils)
+
             # Clear module-specific caches for the imported modules
-            for module in [triton_utils, cutedsl_utils, helion_utils]:
+            for module in utils:
                 for attr_name in dir(module):
                     attr = getattr(module, attr_name)
                     if hasattr(attr, "cache_clear"):
                         attr.cache_clear()
 
-            with (
-                patch.object(
-                    triton_utils,
-                    "_check_runtime_available",
-                    return_value=(True, fake_version),
-                ),
-                patch.object(
-                    cutedsl_utils,
-                    "_check_runtime_available",
-                    return_value=(True, fake_version),
-                ),
-                patch.object(
-                    helion_utils,
-                    "_check_runtime_available",
-                    return_value=(True, fake_version),
-                ),
-                patch.object(triton_utils, "_register_op_override_impl") as triton_mock,
-                patch.object(cutedsl_utils, "_register_op_override_impl") as cute_mock,
-                patch.object(helion_utils, "_register_op_override_impl") as helion_mock,
-            ):
+            with contextlib.ExitStack() as stack:
+                for module in utils:
+                    stack.enter_context(
+                        patch.object(
+                            module,
+                            "_check_runtime_available",
+                            return_value=(True, fake_version),
+                        )
+                    )
+                mocks = [
+                    stack.enter_context(
+                        patch.object(module, "_register_op_override_impl")
+                    )
+                    for module in utils
+                ]
+
                 # Use unique operation names to avoid conflicts
                 op_name = f"test_version_skip_{uuid.uuid4().hex[:8]}.Tensor"
-
-                # Call the register functions
-                triton_utils.register_op_override(
-                    "aten", op_name, "CPU", lambda *a, **k: True, lambda: None
-                )
-                cutedsl_utils.register_op_override(
-                    "aten", op_name, "CPU", lambda *a, **k: True, lambda: None
-                )
-                helion_utils.register_op_override(
-                    "aten", op_name, "CPU", lambda *a, **k: True, lambda: None
-                )
+                for module in utils:
+                    module.register_op_override(
+                        "aten", op_name, "CPU", lambda *a, **k: True, lambda: None
+                    )
 
                 # Verify all implementation functions were called
-                details = (
-                    f"triton: {triton_mock.call_count}, "
-                    f"cutedsl: {cute_mock.call_count}, "
-                    f"helion: {helion_mock.call_count}"
-                )
+                counts = [m.call_count for m in mocks]
                 self.assertEqual(
-                    triton_mock.call_count
-                    + cute_mock.call_count
-                    + helion_mock.call_count,
-                    3,
-                    lambda msg: f"{msg}\nExpected 3 calls but got {details}",
+                    sum(counts),
+                    len(utils),
+                    f"Expected {len(utils)} calls with skip flag set, got {counts}",
                 )
 
     @parametrize("env_value, expected", [(None, False), ("1", True)])

--- a/test/python_native/test_native_dsl_ops.py
+++ b/test/python_native/test_native_dsl_ops.py
@@ -1,6 +1,5 @@
 # Owner(s): ["module: dsl-native-ops"]
 
-import contextlib
 import importlib.util
 import os
 import subprocess
@@ -440,44 +439,31 @@ class TestNativeDSLOps(TestCase):
             check_native_version_skip.cache_clear()
 
             utils = (triton_utils, cutedsl_utils, helion_utils)
+            op_name = f"test_version_skip_{uuid.uuid4().hex[:8]}.Tensor"
 
-            # Clear module-specific caches for the imported modules
             for module in utils:
+                # Clear cached lookups so the patched runtime takes effect.
                 for attr_name in dir(module):
                     attr = getattr(module, attr_name)
                     if hasattr(attr, "cache_clear"):
                         attr.cache_clear()
 
-            with contextlib.ExitStack() as stack:
-                for module in utils:
-                    stack.enter_context(
-                        patch.object(
-                            module,
-                            "_check_runtime_available",
-                            return_value=(True, fake_version),
-                        )
-                    )
-                mocks = [
-                    stack.enter_context(
-                        patch.object(module, "_register_op_override_impl")
-                    )
-                    for module in utils
-                ]
-
-                # Use unique operation names to avoid conflicts
-                op_name = f"test_version_skip_{uuid.uuid4().hex[:8]}.Tensor"
-                for module in utils:
+                with (
+                    patch.object(
+                        module,
+                        "_check_runtime_available",
+                        return_value=(True, fake_version),
+                    ),
+                    patch.object(module, "_register_op_override_impl") as mock,
+                ):
                     module.register_op_override(
                         "aten", op_name, "CPU", lambda *a, **k: True, lambda: None
                     )
-
-                # Verify all implementation functions were called
-                counts = [m.call_count for m in mocks]
-                self.assertEqual(
-                    sum(counts),
-                    len(utils),
-                    f"Expected {len(utils)} calls with skip flag set, got {counts}",
-                )
+                    self.assertEqual(
+                        mock.call_count,
+                        1,
+                        f"{module.__name__}: impl not called under skip flag",
+                    )
 
     @parametrize("env_value, expected", [(None, False), ("1", True)])
     def test_check_native_version_skip_environment_variable(self, env_value, expected):

--- a/test/python_native/test_native_dsl_ops.py
+++ b/test/python_native/test_native_dsl_ops.py
@@ -408,12 +408,20 @@ class TestNativeDSLOps(TestCase):
         with patch.object(
             helion_utils,
             "_check_runtime_available",
-            return_value=(True, Version("1.0.0")),
+            return_value=(True, Version("1.2.0")),
         ):
-            self.assertFalse(helion_utils.runtime_available())
+            self.assertTrue(helion_utils.runtime_available())
+            self.assertTrue(helion_utils._version_is_sufficient())
 
         helion_utils._check_runtime_available.cache_clear()
         helion_utils._version_is_sufficient.cache_clear()
+        with patch.object(
+            helion_utils,
+            "_check_runtime_available",
+            return_value=(True, Version("1.0.0")),
+        ):
+            self.assertTrue(helion_utils.runtime_available())
+            self.assertFalse(helion_utils._version_is_sufficient())
 
     def test_version_skip_env_var_overrides(self):
         """TORCH_NATIVE_SKIP_VERSION_CHECK=1 allows non-blessed versions."""

--- a/test/python_native/test_torch_backends.py
+++ b/test/python_native/test_torch_backends.py
@@ -1,5 +1,8 @@
 # Owner(s): ["module: dsl-native-ops"]
 
+import os
+from unittest.mock import patch
+
 import torch.backends.python_native as pn
 from torch.testing._internal.common_utils import run_tests, skipIfTorchDynamo, TestCase
 
@@ -112,6 +115,16 @@ class TestTorchBackendsPythonNative(RegistryTestMixin, TestCase):
                 # Test enabled property
                 enabled = dsl.enabled
                 self.assertIsInstance(enabled, bool)
+
+    def test_dsl_backend(self):
+        """Helion exposes a chosen lowering backend; other DSLs do not."""
+        with patch.dict(os.environ):
+            os.environ.pop("HELION_BACKEND", None)
+            self.assertEqual(pn.helion.backend, "triton")
+        with patch.dict(os.environ, {"HELION_BACKEND": "cutedsl"}):
+            self.assertEqual(pn.helion.backend, "cutedsl")
+        with self.assertRaises(AttributeError):
+            pn.triton.backend
 
     def test_dsl_enable_disable(self):
         """Test DSL enable/disable functionality."""

--- a/torch/_native/__init__.py
+++ b/torch/_native/__init__.py
@@ -5,7 +5,7 @@ from typing import cast
 
 # This handles collecting registration of all native ops
 # Also need to import DSL utils to make sure DSL registration is ok
-from . import cutedsl_utils, dsl_registry, ops, registry, triton_utils
+from . import cutedsl_utils, dsl_registry, helion_utils, ops, registry, triton_utils
 
 
 @cache

--- a/torch/_native/helion_utils.py
+++ b/torch/_native/helion_utils.py
@@ -1,0 +1,123 @@
+import functools
+import logging
+import os as _os
+import sys
+from typing import cast
+
+from torch._vendor.packaging.version import Version
+
+from ..backends import cuda as _cuda
+from .common_utils import (
+    _available_version,
+    _unavailable_reason,
+    check_native_jit_disabled,
+    check_native_version_skip,
+)
+from .dsl_registry import dsl_registry, DSLModuleProtocol
+from .registry import (
+    _OpCondFn,
+    _OpImplFn,
+    deregister_op_overrides as _deregister_op_overrides_impl,
+    register_op_override as _register_op_override_impl,
+)
+
+
+log = logging.getLogger(__name__)
+
+
+_HELION_DSL_NAME = "helion"
+# Minimum supported Helion: the latest release verified with the native DSL
+# kernels (older releases carry the same APIs but are untested).
+_HELION_MINIMUM_VERSION = Version("1.2.0")
+# Supported Helion lowering backends. Extend to enable more, e.g. "cutedsl".
+_HELION_BACKENDS = ("triton",)
+
+
+@functools.cache
+def _check_runtime_available() -> tuple[bool, Version | None]:
+    if not _cuda.is_built():
+        return (False, None)
+
+    import torch
+
+    if torch.version.hip is not None:
+        return (False, None)
+
+    backend = _os.getenv("HELION_BACKEND", _HELION_BACKENDS[0])
+    if backend not in _HELION_BACKENDS:
+        log.info(
+            "Helion native DSL ops support backends %s; HELION_BACKEND=%s",
+            _HELION_BACKENDS,
+            backend,
+        )
+        return (False, None)
+
+    reason = _unavailable_reason([("helion", "helion"), ("triton", "triton")])
+    if reason is not None:
+        log.info(
+            "Helion native DSL ops require optional packages `helion` and `triton`; %s",
+            reason,
+        )
+        return (False, None)
+    return (True, _available_version("helion"))
+
+
+def runtime_available() -> bool:
+    available, _ = _check_runtime_available()
+    return available and _version_is_sufficient()
+
+
+def runtime_version() -> Version | None:
+    _, version = _check_runtime_available()
+    return version
+
+
+@functools.cache
+def _version_is_sufficient() -> bool:
+    _, version = _check_runtime_available()
+    if version is not None and (
+        version >= _HELION_MINIMUM_VERSION or check_native_version_skip()
+    ):
+        return True
+
+    log.info(
+        "helion version %s is not sufficient (>= %s); "
+        "set TORCH_NATIVE_SKIP_VERSION_CHECK=1 to override",
+        version,
+        _HELION_MINIMUM_VERSION,
+    )
+    return False
+
+
+def deregister_op_overrides() -> None:
+    _deregister_op_overrides_impl(disable_dsl_names=_HELION_DSL_NAME)
+
+
+def register_op_override(
+    lib_symbol: str,
+    op_symbol: str,
+    dispatch_key: str,
+    cond: _OpCondFn | None,
+    impl: _OpImplFn,
+    *,
+    allow_multiple_override: bool = False,
+    unconditional_override: bool = False,
+) -> None:
+    if not runtime_available() or check_native_jit_disabled():
+        return
+
+    _register_op_override_impl(
+        _HELION_DSL_NAME,
+        lib_symbol,
+        op_symbol,
+        dispatch_key,
+        cond,
+        impl,
+        allow_multiple_override=allow_multiple_override,
+        unconditional_override=unconditional_override,
+    )
+
+
+dsl_registry.register_dsl(
+    _HELION_DSL_NAME, cast(DSLModuleProtocol, sys.modules[__name__])
+)

--- a/torch/_native/helion_utils.py
+++ b/torch/_native/helion_utils.py
@@ -28,8 +28,17 @@ _HELION_DSL_NAME = "helion"
 # Minimum supported Helion: the latest release verified with the native DSL
 # kernels (older releases carry the same APIs but are untested).
 _HELION_MINIMUM_VERSION = Version("1.2.0")
-# Supported Helion lowering backends. Extend to enable more, e.g. "cutedsl".
-_HELION_BACKENDS = ("triton",)
+# HELION_BACKEND name -> (pip package, import module); extend to add more,
+# e.g. "cute": ("nvidia-cutlass-dsl", "cutlass").
+_HELION_BACKENDS: dict[str, tuple[str, str]] = {"triton": ("triton", "triton")}
+_DEFAULT_HELION_BACKEND = "triton"
+
+
+def _chosen_backend() -> str:
+    """Selected Helion lowering backend (HELION_BACKEND env, default triton)."""
+    import os
+
+    return os.getenv("HELION_BACKEND", _DEFAULT_HELION_BACKEND)
 
 
 @functools.cache
@@ -37,26 +46,26 @@ def _check_runtime_available() -> tuple[bool, Version | None]:
     if not _cuda.is_built():
         return (False, None)
 
-    import os
-
     import torch
 
     if torch.version.hip is not None:
         return (False, None)
 
-    backend = os.getenv("HELION_BACKEND", _HELION_BACKENDS[0])
-    if backend not in _HELION_BACKENDS:
+    backend = _chosen_backend()
+    dep = _HELION_BACKENDS.get(backend)
+    if dep is None:
         log.info(
             "Helion native DSL ops support backends %s; HELION_BACKEND=%s",
-            _HELION_BACKENDS,
+            tuple(_HELION_BACKENDS),
             backend,
         )
         return (False, None)
 
-    reason = _unavailable_reason([("helion", "helion"), ("triton", "triton")])
+    reason = _unavailable_reason([("helion", "helion"), dep])
     if reason is not None:
         log.info(
-            "Helion native DSL ops require optional packages `helion` and `triton`; %s",
+            "Helion native DSL ops require optional packages `helion` and `%s`; %s",
+            dep[0],
             reason,
         )
         return (False, None)

--- a/torch/_native/helion_utils.py
+++ b/torch/_native/helion_utils.py
@@ -1,6 +1,6 @@
 import functools
 import logging
-import os as _os
+import os as _os  # aliased to keep `os` out of the module public API
 import sys
 from typing import cast
 
@@ -63,8 +63,9 @@ def _check_runtime_available() -> tuple[bool, Version | None]:
 
 
 def runtime_available() -> bool:
+    # Package presence only, like triton/cutedsl; version gated in register_op_override.
     available, _ = _check_runtime_available()
-    return available and _version_is_sufficient()
+    return available
 
 
 def runtime_version() -> Version | None:
@@ -103,7 +104,11 @@ def register_op_override(
     allow_multiple_override: bool = False,
     unconditional_override: bool = False,
 ) -> None:
-    if not runtime_available() or check_native_jit_disabled():
+    available, _ = _check_runtime_available()
+    if (not available) or check_native_jit_disabled():
+        return
+
+    if not _version_is_sufficient():
         return
 
     _register_op_override_impl(

--- a/torch/_native/helion_utils.py
+++ b/torch/_native/helion_utils.py
@@ -1,6 +1,5 @@
 import functools
 import logging
-import os as _os  # aliased to keep `os` out of the module public API
 import sys
 from typing import cast
 
@@ -38,12 +37,14 @@ def _check_runtime_available() -> tuple[bool, Version | None]:
     if not _cuda.is_built():
         return (False, None)
 
+    import os
+
     import torch
 
     if torch.version.hip is not None:
         return (False, None)
 
-    backend = _os.getenv("HELION_BACKEND", _HELION_BACKENDS[0])
+    backend = os.getenv("HELION_BACKEND", _HELION_BACKENDS[0])
     if backend not in _HELION_BACKENDS:
         log.info(
             "Helion native DSL ops support backends %s; HELION_BACKEND=%s",

--- a/torch/_native/instrumentation.py
+++ b/torch/_native/instrumentation.py
@@ -13,8 +13,8 @@ Two sinks, both fed by a single :class:`CompileEvent`:
 * ``trace_structured`` artifacts (tlparse): a JSON record per compile, for
   production jobs where only the structured trace is retrievable.
 
-Two DSLs compile through different machinery, so there are two entry points.
-Both reduce to the same shared core (:func:`_make_wrapper`): snapshot the
+The DSLs compile through different machinery, so each has an entry point.
+All reduce to the same shared core (:func:`_make_wrapper`): snapshot the
 cache, time the call, snapshot again, and flag ``compiled`` when the miss
 counter advanced. They differ only in how a snapshot is sampled:
 
@@ -40,7 +40,11 @@ counter advanced. They differ only in how a snapshot is sampled:
   fused, ``wall_ms`` on a miss is compile + host-launch latency (compile
   dominates); on a hit it is just host-launch latency.
 
-Both DSLs only expose miss-side signal directly (CuTeDSL's vendored cache
+* :func:`instrument_helion_kernel` -- for regular and AOT Helion kernels. It
+  tracks compiled configurations across the kernel's bound specialization
+  cache; a growing count means the call compiled a new configuration.
+
+The DSLs only expose miss-side signal directly (CuTeDSL's vendored cache
 reports aggregate counters; Triton's cache only grows), so finer reasons
 (disk-hit vs lock-timeout, Triton's on-disk cache) are not distinguished
 here -- the boolean ``compiled`` flag plus wall time covers the common case.
@@ -65,10 +69,13 @@ if TYPE_CHECKING:
 
 __all__ = [
     "CompileEvent",
+    "InstrumentedHelionKernel",
     "InstrumentedTritonKernel",
     "instrument_cutedsl_compile",
+    "instrument_helion_kernel",
     "instrument_triton_kernel",
     "instrumented_cutedsl_cache",
+    "instrumented_helion_kernel",
     "instrumented_triton_cache",
 ]
 
@@ -389,6 +396,58 @@ def instrument_triton_kernel(
     return decorator
 
 
+def _helion_cache_size(kernel: Any) -> int | None:
+    bound_kernels = getattr(kernel, "_bound_kernels", None)
+    if bound_kernels is None:
+        return None
+    try:
+        return sum(
+            len(getattr(bound, "_compile_cache", ()))
+            for bound in bound_kernels.values()
+        )
+    except Exception:
+        return None
+
+
+class InstrumentedHelionKernel:
+    """Transparent proxy over a Helion ``Kernel`` compile cache."""
+
+    def __init__(
+        self,
+        kernel: Any,
+        op: str,
+        key_fn: Callable[..., str] | None,
+    ) -> None:
+        self._kernel = kernel
+        self._wrapped = _make_wrapper(kernel, op, "helion", key_fn, self._sample)
+
+    @property
+    def helion_kernel(self) -> Any:
+        return self._kernel
+
+    def _sample(self) -> tuple[int | None, int | None]:
+        return None, _helion_cache_size(self._kernel)
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        return self._wrapped(*args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._kernel, name)
+
+
+def instrument_helion_kernel(
+    op: str,
+    *,
+    key_fn: Callable[..., str] | None = None,
+) -> Callable[[Any], InstrumentedHelionKernel]:
+    """Instrument a Helion ``Kernel`` without importing Helion eagerly."""
+
+    def decorator(kernel: Any) -> InstrumentedHelionKernel:
+        return InstrumentedHelionKernel(kernel, op, key_fn)
+
+    return decorator
+
+
 # ---------------------------------------------------------------------------
 # Combined decorators: the recommended one-decorator surface for native ops.
 # They apply the DSL's own cache/jit *and* the instrumentation, so the op
@@ -442,5 +501,26 @@ def instrumented_triton_cache(
 
     def decorator(fn: Callable[..., R]) -> InstrumentedTritonKernel:
         return instrument_triton_kernel(op, key_fn=key_fn)(triton.jit(fn))
+
+    return decorator
+
+
+def instrumented_helion_kernel(
+    op: str,
+    *,
+    aot: bool = False,
+    key_fn: Callable[..., str] | None = None,
+    **settings: object,
+) -> Callable[[Callable[..., R]], InstrumentedHelionKernel]:
+    """Create and instrument a regular or AOT Helion kernel."""
+    import helion  # pyrefly: ignore[missing-import]
+    import helion.experimental  # pyrefly: ignore[missing-import]
+
+    kernel_decorator = helion.experimental.aot_kernel if aot else helion.kernel
+
+    def decorator(fn: Callable[..., R]) -> InstrumentedHelionKernel:
+        return instrument_helion_kernel(op, key_fn=key_fn)(
+            kernel_decorator(**settings)(fn)
+        )
 
     return decorator

--- a/torch/_native/instrumentation.py
+++ b/torch/_native/instrumentation.py
@@ -397,6 +397,14 @@ def instrument_triton_kernel(
 
 
 def _helion_cache_size(kernel: Any) -> int | None:
+    """Compiled-config count across a Helion Kernel's bound specializations.
+
+    Helion stores compiled configs in ``Kernel._bound_kernels[*]._compile_cache``;
+    the total grows by one each time a new configuration compiles, so a delta
+    across a call tells us whether *this* kernel compiled. Returns None if the
+    object doesn't expose these private attributes (a future Helion that renames
+    them, or a non-kernel in tests).
+    """
     bound_kernels = getattr(kernel, "_bound_kernels", None)
     if bound_kernels is None:
         return None

--- a/torch/backends/python_native/__init__.py
+++ b/torch/backends/python_native/__init__.py
@@ -138,6 +138,14 @@ class DSLController:
         return registry.get_dsl_version(self._dsl_name)
 
     @property
+    def backend(self) -> str:
+        """Chosen lowering backend for DSLs that have one (e.g. helion)."""
+        chosen = getattr(_get_dsl_module(self._dsl_name), "_chosen_backend", None)
+        if chosen is None:
+            raise AttributeError(f"{self._dsl_name} DSL has no configurable backend")
+        return chosen()
+
+    @property
     def enabled(self) -> bool:
         """Check if DSL is currently enabled."""
         filter_state = _get_filter_state()

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1763,6 +1763,7 @@ _dsl_checker = LazyDSLCheck()
 # Lazy constants to avoid import-time overhead
 TEST_TRITON_DSL = LazyVal(lambda: _dsl_checker.is_available('triton'))
 TEST_CUTEDSL = LazyVal(lambda: _dsl_checker.is_available('cutedsl'))
+TEST_HELION_DSL = LazyVal(lambda: _dsl_checker.is_available('helion'))
 
 def split_if_not_empty(x: str):
     return x.split(",") if len(x) != 0 else []
@@ -1774,6 +1775,7 @@ skipIfNoDill = unittest.skipIf(not TEST_DILL, "no dill")
 # DSL skip decorators (following existing pattern)
 skipIfNoTritonDSL = unittest.skipIf(not TEST_TRITON_DSL, "Triton DSL not available")
 skipIfNoCuteDSL = unittest.skipIf(not TEST_CUTEDSL, "CuTeDSL not available")
+skipIfNoHelionDSL = unittest.skipIf(not TEST_HELION_DSL, "Helion DSL not available")
 
 def skipIfDSLUnavailable(dsl_name: str, reason: str | None = None):
     """Skip test if specific DSL is not available"""


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #190300
* __->__ #190636

Register Helion with the native DSL registry behind lazy runtime and version checks. Add reusable Helion kernel instrumentation and the corresponding generic test helpers without introducing any operator registrations.

Test Plan:

```
conda run -n hl-core lintrunner -a
conda run -n hl-core python test/python_native/test_native_dsl_ops.py -v
conda run -n hl-core python test/python_native/test_instrumentation.py -v
```

Authored with an AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo