### PR TITLE
[XPU] Skip CUDA stream event codegen in AOTI cpp_wrapper for XPU

### DIFF
--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -1197,6 +1197,12 @@ class CppWrapperGpu(CppWrapperCpu):
     def _ensure_aoti_stream_helpers_emitted(self) -> None:
         if self._aoti_stream_helpers_emitted:
             return
+        # The stream/event helpers in streams.h are CUDA-specific (cudaEvent_t,
+        # cudaStream_t, cudaEventRecord, ...). Guarding here on the device type
+        # prevents the CUDA-only symbols from being emitted into XPU generated
+        # code, where SYCL in-order queues handle event ordering implicitly.
+        if self.device == "xpu":
+            return
         self._aoti_stream_helpers_emitted = True
         with open(
             os.path.join(os.path.dirname(__file__), "aoti_runtime", "streams.h")
@@ -1271,6 +1277,8 @@ class CppWrapperGpu(CppWrapperCpu):
 
     def _emit_stream_op_inline(self, kernel_name: str | None, args: list[str]) -> bool:
         if kernel_name is None or not V.graph.aot_mode:
+            return False
+        if self.device == "xpu":
             return False
         if kernel_name in AOTI_UNSUPPORTED_STREAM_OP_REASONS:
             raise NotImplementedError(


### PR DESCRIPTION
## Summary

Skip the CUDA-specific stream event codegen (`_aoti_aux_stream_cache` helpers) in the AOTI `cpp_wrapper` for XPU devices. SYCL in-order queues handle events implicitly, making the generated CUDA stream cache code unnecessary and incompatible.

## Root Cause

PR [#182971](https://github.com/pytorch/pytorch/pull/182971) (Jul 8, 2026) added `codegen_stream_info_prologue()` to `cpp_wrapper_gpu.py`, which emits `_aoti_aux_stream_cache.ensure(...)` — a CUDA-specific stream cache helper. When a model uses `torch.Event()`, the AOTI compiler detects `num_strams > 1` and enters this codegen path, generating code that references CUDA-only symbols.

For the XPU backend, these CUDA stream helpers are not needed because:
- SYCL in-order queues handle event synchronization implicitly
- The generated code causes compilation/link errors on XPU

This affected the `AOTInductorTestDualWrapper` test class specifically because it uses `autotune_at_compile_time=False` (lazy Triton compile), which triggers the dual-wrapper codegen path that exercises the multi-stream codegen.

## Timeline

| Date | Event |
|------|-------|
| Jun 10 | `AOTInductorTestDualWrapper` added (PR #184735) — running fine |
| **Jul 8** | **User-streams support added (PR #182971) — introduced CUDA stream codegen** |
| Jul 9 | Auto-disabler detected test failure, created issues #189327 and #189326 |
| Jul 15 | PR #189980 submitted with barrier chaining fix in Copy.cpp |
| Jul 17 | Reviewer rejected barrier fix as unnecessary overhead |
| Jul 21 | **This PR** — correct root cause identified |

## Notes on PR #189980

The earlier PR #189980 attempted to fix this by capturing the `sycl::event` from `q.memcpy()` and chaining it with `ext_oneapi_submit_barrier({copy_event})` in `Copy.cpp`. That approach was rejected by the reviewer ([comment](https://github.com/intel/torch-xpu-ops/pull/4349#issuecomment-4999901072)) as adding unnecessary overhead, and has since been determined to be unrelated to the actual root cause. The DMA engine event tracking gap described there is a separate PVC driver-level issue that does not reproduce on the tested hardware configuration (driver 1.6.33578+15, all D2H non_blocking copy tests pass without the barrier workaround).

## Test Plan

- `test_copy_non_blocking_is_pinned_xpu` on both `AOTInductorTestDualWrapper` and `AOTInductorTestABICompatibleGpu`
- Full XPU CI suite

Fixes #189327
Fixes #189326

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo