### PR TITLE
Reject misaligned buffers in torch.frombuffer

### DIFF
--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -4140,6 +4140,13 @@ class TestBufferProtocol(TestCase):
                                        r"The given buffer is not writable."):
             torch.frombuffer(byte_arr, dtype=dtype)
 
+    def test_misaligned_offset(self):
+        buffer = np.zeros(2, dtype=np.complex128)
+        with self.assertRaisesRegex(
+            ValueError, r"buffer is not aligned to element size"
+        ):
+            torch.frombuffer(buffer, dtype=torch.complex128, count=1, offset=6)
+
     def test_byte_to_int(self):
         byte_array = np.array([-1, 0, 0, 0, -1, 0, 0, 0], dtype=np.byte) if sys.byteorder == 'little' \
             else np.array([0, 0, 0, -1, 0, 0, 0, -1], dtype=np.byte)

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -28,6 +28,7 @@
 #include <c10/core/Layout.h>
 #include <c10/util/Exception.h>
 #include <c10/util/irange.h>
+#include <cstdint>
 #include <optional>
 
 #include <stdexcept>
@@ -1618,6 +1619,11 @@ Tensor tensor_frombuffer(
       " bytes)");
 
   auto offset_buf = static_cast<char*>(buf) + offset;
+  TORCH_CHECK_VALUE(
+      reinterpret_cast<std::uintptr_t>(offset_buf) % elsize == 0,
+      "buffer is not aligned to element size (",
+      elsize,
+      " bytes)");
   auto options = TensorOptions().dtype(dtype).device(c10::kCPU);
 
   auto tensor = at::for_blob(offset_buf, static_cast<int64_t>(actual_count))


### PR DESCRIPTION
## Summary

- reject `torch.frombuffer` inputs whose adjusted data pointer is not aligned to the requested dtype's element size
- add a regression test for the reported `complex128` buffer with a six-byte offset

Fixes #190043.

## Root cause

`tensor_frombuffer` validated the offset and requested byte range, but it did not validate the alignment of the pointer after applying the offset. This allowed PyTorch to create a tensor backed by a misaligned address. Native kernels could later perform typed loads from that address and crash instead of rejecting the buffer at construction time.

## Test plan

- `python -m py_compile test/test_tensor_creation_ops.py`
- `python test/test_tensor_creation_ops.py -k TestBufferProtocolCPU.test_with_offset` (14 passed)
- `python test/test_tensor_creation_ops.py -k misaligned_offset` (confirmed the regression test fails against the pre-fix 2.14 nightly because no `ValueError` is raised)
- `git diff --check`
- `uvx --python 3.10 lintrunner@0.12.7 -a` (attempted; PyTorch's C++ lint tools do not initialize on Windows and report `Unsupported platform: Windows/Windows-AMD64`)

A post-fix runtime test was not run because the native C++ extension was not rebuilt in this Windows checkout.

## AI assistance

This draft was prepared with assistance from OpenAI Codex. I will review the implementation and test and take responsibility for the contribution before marking it ready for review.
