### PR TITLE
Add basic CUDA 13.4 CI image and periodic test

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -138,6 +138,14 @@ case "$tag" in
     TRITON=yes
     INSTALL_MINGW=yes
     ;;
+  pytorch-linux-jammy-cuda13.4-cudnn9-py3-gcc11)
+    CUDA_VERSION=13.4.0
+    ANACONDA_PYTHON_VERSION=3.10
+    GCC_VERSION=11
+    KATEX=yes
+    TRITON=yes
+    INSTALL_MINGW=yes
+    ;;
   pytorch-linux-jammy-cuda13.0-cudnn9-py3.12-gcc11)
     CUDA_VERSION=13.0.2
     ANACONDA_PYTHON_VERSION=3.12

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -48,6 +48,7 @@ jobs:
           pytorch-linux-jammy-cuda13.2-cudnn9-py3-gcc11-inductor-benchmarks,
           pytorch-linux-jammy-cuda13.2-cudnn9-py3.12-gcc11,
           pytorch-linux-jammy-cuda13.0-cudnn9-py3.12-gcc11,
+          pytorch-linux-jammy-cuda13.4-cudnn9-py3-gcc11,
           pytorch-linux-jammy-cuda13.0-cudnn9-py3.12-gcc11-vllm,
           pytorch-linux-jammy-cuda13.0-cudnn9-py3-gcc11-inductor-benchmarks,
           pytorch-linux-jammy-cuda13.0-cudnn9-py3.12-gcc11-inductor-benchmarks,

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -98,6 +98,41 @@ jobs:
       cuda-version: "13.0"
     secrets: inherit
 
+  linux-jammy-cuda13_4-py3_10-gcc11-build:
+    name: linux-jammy-cuda13.4-py3.10-gcc11
+    uses: ./.github/workflows/_linux-build.yml
+    needs: get-label-type
+    with:
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      build-environment: linux-jammy-cuda13.4-py3.10-gcc11
+      docker-image-name: ci-image:pytorch-linux-jammy-cuda13.4-cudnn9-py3-gcc11
+      ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
+      cuda-arch-list: 7.5
+      test-matrix: |
+        { include: [
+          { config: "jit_legacy", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g4dn.4xlarge.nvidia.gpu" },
+        ]}
+      python-version: "3.10"
+      compiler: gcc11
+      cuda-version: "13.4"
+    secrets: inherit
+
+  linux-jammy-cuda13_4-py3_10-gcc11-test:
+    name: linux-jammy-cuda13.4-py3.10-gcc11
+    uses: ./.github/workflows/_linux-test.yml
+    needs:
+      - linux-jammy-cuda13_4-py3_10-gcc11-build
+      - target-determination
+      - get-label-type
+    with:
+      build-environment: ${{ needs.linux-jammy-cuda13_4-py3_10-gcc11-build.outputs.build-environment }}
+      docker-image: ${{ needs.linux-jammy-cuda13_4-py3_10-gcc11-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-jammy-cuda13_4-py3_10-gcc11-build.outputs.test-matrix }}
+      python-version: "3.10"
+      compiler: gcc11
+      cuda-version: "13.4"
+    secrets: inherit
+
   linux-jammy-cuda13_0-py3_10-gcc11-debug-build:
     name: linux-jammy-cuda13.0-py3.10-gcc11-debug
     uses: ./.github/workflows/_linux-build.yml


### PR DESCRIPTION
Adds CUDA 13.4 CI ubuntu image and periodic tests, mirroring #161013 for CUDA 13.0. Since 13.4 shares the
CUDA 13 major already exercised by 13.0 and 13.2, no ATen/c10/caffe2 source changes
are needed:

- a `pytorch-linux-jammy-cuda13.4-cudnn9-py3-gcc11` image in `build.sh`,
- that image added to the `docker-builds` matrix so it is built and pushed, and
- a `linux-jammy-cuda13.4-py3.10-gcc11` build+test pair in `periodic.yml` running
  `jit_legacy` on an sm_75 g4dn runner.

Follow-up: The `nogpu_AVX512` and `nogpu_NO_AVX2` configs are left out for now.
They run the cpp tests under valgrind, and CUDA 13.4's `libcufft.so.12.4.0.16` reads
uninitialised values while initialising itself (`call_init`/`_dl_init`, before
`main`). valgrind runs with `--error-exitcode=1`, so those reports fail the shard
even though every frame is inside the closed-source library and no PyTorch code is
involved:

```
==132146== Conditional jump or move depends on uninitialised value(s)
==132146==    at 0x2EED9C8A: ??? (in /usr/local/cuda-13.4/targets/x86_64-linux/lib/libcufft.so.12.4.0.16)
==132146==    by 0x21FA0EA7: __pthread_once_slow (pthread_once.c:116)
==132146==    by 0x400647D: call_init.part.0 (dl-init.c:70)
...
==132146== ERROR SUMMARY: 2 errors from 2 contexts (suppressed: 21 from 5)
```

All 7 gtest cases pass; only the valgrind exit code fails the shard. The cuda13.0 and
cuda13.2 periodic jobs run these same configs and pass, so this is specific to 13.4.
The configs can be restored once cuFFT stops reporting these, or once a `libcufft`
suppression is added to `aten/tools/valgrind.sup` next to the existing `libcuda` ones
(cf. #34169).

Test Plan:
Full validation is the docker-builds job building the new image, and the periodic
linux-jammy-cuda13.4-py3.10-gcc11 build+test.

Authored with assistance from an AI coding assistant (Claude).

cc @ptrblck @nWEIdia @eqy @atalman @malfet 