### PR TITLE
[inductor][NVGEMM] Subtract clone overhead when benchmarking fused epilogues

### DIFF
--- a/torch/_inductor/codegen/cuda_combined_scheduling.py
+++ b/torch/_inductor/codegen/cuda_combined_scheduling.py
@@ -248,6 +248,17 @@ class CUDACombinedScheduling(BaseScheduling):
                     lambda: call(clone_args(args)),
                     device=device,
                 )
+                # Subtract the per-iteration clone cost so we measure the kernel
+                # alone, matching TritonScheduling.benchmark_codegened_module.
+                # The GEMM operands must be cloned each iteration (the launch
+                # mutates `out`), but cloning the (often multi-MB) operands
+                # otherwise dominates the timing and makes fused NVGEMM epilogues
+                # look many-x slower than the clone-free unfused autotune timing,
+                # so epilogue fusion never wins the speedup_by_fusion benchmark.
+                ms = ms - benchmarker.benchmark(
+                    lambda: clone_args(args),
+                    device=device,
+                )
             except Exception as e:
                 log.debug(
                     "Exception (%s) while benchmarking NVGEMM fused kernel",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #190643
* __->__ #190642
* #189841
* #189807
* #189806
* #189781
* #189780
* #189779
* #189778
* #189777
* #189776

The NVGEMM epilogue-fusion benchmark (`_benchmark_nvgemm_module` in
cuda_combined_scheduling.py) timed `call(clone_args(args))` but, unlike
`TritonScheduling.benchmark_codegened_module`, never subtracted the
per-iteration clone cost. Cloning the GEMM operands (often multi-MB) every
iteration then dominated the measurement, so `speedup_by_fusion` saw the fused
EFC kernel as ~14x slower than the clone-free unfused autotune timing and
rejected essentially every NVGEMM epilogue fusion -- general pointwise epilogues
(relu, activations, same-shape adds) silently never fused; only the forced
addmm bias path did.

Fix: subtract a clone-only benchmark from the measured time so we compare the
kernel alone, matching the Triton benchmark. With this, relu(x@w) fuses into the
NVGEMM epilogue and speedup_by_fusion reports a 1.63x speedup instead of a 14.7x
slowdown.

Note: the existing epilogue-fusion tests mock benchmark_fused_nodes/
benchmark_codegened_module to force the fused path, so they validated fusion
codegen but never exercised this benchmark -- which is why the misprediction
went unnoticed.

Test Plan: compile relu(x@w) with the NVGEMM backend and epilogue_fusion on;
the generated kernel now contains `_epilogue_fn(accum): D = relu(accum)` fused
into the nv_universal_gemm kernel with zero separate triton_poi_fused_relu
kernels; numerically exact vs eager (max_abs 0.0).

Authored with an AI assistant (Claude).