### PR TITLE
Tidy cmake config templates

### DIFF
--- a/cmake/Caffe2Config.cmake.in
+++ b/cmake/Caffe2Config.cmake.in
@@ -1,9 +1,7 @@
 # - Config file for the Caffe2 package
 # It defines the following variable(s)
-#   CAFFE2_INCLUDE_DIRS     - include directories for FooBar
+#   CAFFE2_INCLUDE_DIRS     - include directories for Caffe2
 # as well as Caffe2 targets for other cmake libraries to use.
-
-# library version information
 
 # Utils functions.
 include("${CMAKE_CURRENT_LIST_DIR}/public/utils.cmake")
@@ -127,14 +125,10 @@ set(Caffe2_MAIN_LIBS torch_library)
 
 # include directory.
 #
-# Newer versions of CMake set the INTERFACE_INCLUDE_DIRECTORIES property
-# of the imported targets. It is hence not necessary to add this path
-# manually to the include search path for targets which link to gflags.
-# The following lines are here for backward compatibility, in case one
-# would like to use the old-style include path.
-get_filename_component(
-    CMAKE_CURRENT_LIST_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-# Note: the current list dir is _INSTALL_PREFIX/share/cmake/Gloo.
+# The imported targets carry INTERFACE_INCLUDE_DIRECTORIES, so linking them
+# already adds this path. CAFFE2_INCLUDE_DIRS is kept only for backward
+# compatibility with consumers that use the old-style include path.
+# Note: the current list dir is _INSTALL_PREFIX/share/cmake/Caffe2.
 get_filename_component(
     _INSTALL_PREFIX "${CMAKE_CURRENT_LIST_DIR}/../../../" ABSOLUTE)
 set(CAFFE2_INCLUDE_DIRS "${_INSTALL_PREFIX}/include")

--- a/cmake/TorchConfig.cmake.in
+++ b/cmake/TorchConfig.cmake.in
@@ -43,12 +43,12 @@ macro(append_wholearchive_lib_if_found)
 endmacro()
 
 include(FindPackageHandleStandardArgs)
+include(CMakeFindDependencyMacro)
 
 if(DEFINED ENV{TORCH_INSTALL_PREFIX})
   set(TORCH_INSTALL_PREFIX $ENV{TORCH_INSTALL_PREFIX})
 else()
   # Assume we are in <install-prefix>/share/cmake/Torch/TorchConfig.cmake
-  get_filename_component(CMAKE_CURRENT_LIST_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
   get_filename_component(TORCH_INSTALL_PREFIX "${CMAKE_CURRENT_LIST_DIR}/../../../" ABSOLUTE)
 endif()
 
@@ -59,7 +59,7 @@ set(TORCH_INCLUDE_DIRS
 
 # Library dependencies.
 if(@BUILD_SHARED_LIBS@)
-  find_package(Caffe2 REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../Caffe2)
+  find_dependency(Caffe2 PATHS ${CMAKE_CURRENT_LIST_DIR}/../Caffe2)
   set(TORCH_LIBRARIES torch ${Caffe2_MAIN_LIBS})
   append_torchlib_if_found(c10)
 else()
@@ -143,7 +143,7 @@ endif()
 
 find_library(TORCH_LIBRARY torch PATHS "${TORCH_INSTALL_PREFIX}/lib")
 # the statements below changes target properties on
-# - the imported target from Caffe2Targets.cmake in shared library mode (see the find_package above)
+# - the imported target from Caffe2Targets.cmake in shared library mode (see the find_dependency above)
 #    - this is untested whether it is the correct (or desired) methodology in CMake
 # - the imported target created in this file in static library mode
 if(NOT @BUILD_SHARED_LIBS@)


### PR DESCRIPTION
Small cleanups to the installed config templates (`TorchConfig.cmake.in`, `Caffe2Config.cmake.in`):

- Drop the redundant `get_filename_component(CMAKE_CURRENT_LIST_DIR ...)` — it recomputes a builtin that's held this value since CMake 2.8.3 (< our 3.27 floor).
- `find_package(Caffe2 REQUIRED)` → `find_dependency(Caffe2)`, the standard config-file idiom. Behavior change: a non-REQUIRED `find_package(Torch)` with Caffe2 missing now sets `Torch_FOUND=FALSE` instead of hard-erroring.
- Fix two stale comments (`FooBar`, a stray `Gloo` path).

_Authored with AI assistance (Claude Code)._