### PR TITLE
StorageMethods: reject negative requested storage size (don't wrap to size_t)

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5420,6 +5420,13 @@ class TestResizeStorageWithAddr(TestCase):
         self.assertEqual(t.untyped_storage().data_ptr(), original_ptr)
         self.assertNotEqual(other.untyped_storage().data_ptr(), original_ptr)
 
+    def test_resize_storage_negative_size_raises(self):
+        # A negative requested storage size must be rejected, not silently
+        # wrapped to a huge size_t (c10::overflows strict_unsigned path).
+        t = torch.empty(8, dtype=torch.uint8, device="cuda")
+        with self.assertRaisesRegex(RuntimeError, "cannot be represented as a size_t"):
+            t.untyped_storage().resize_(-1)
+
     @unittest.skipIf(
         TEST_CUDAMALLOCASYNC,
         "CUDAMallocAsync does not support exact-address allocation",

--- a/torch/csrc/StorageMethods.cpp
+++ b/torch/csrc/StorageMethods.cpp
@@ -150,7 +150,7 @@ static PyObject* THPStorage_resize_(PyObject* self, PyObject* number_arg) {
 #ifdef USE_CUDA
     ptrdiff_t size_bytes_i = newsize;
     TORCH_CHECK(
-        !c10::overflows<size_t>(size_bytes_i),
+        !c10::overflows<size_t>(size_bytes_i, /*strict_unsigned=*/true),
         "Requested storage size (",
         size_bytes_i,
         ") cannot be represented as a size_t");
@@ -202,7 +202,7 @@ static PyObject* THPStorage_resize_with_addr_(PyObject* self, PyObject* args) {
     }
     ptrdiff_t size_bytes_i = newsize;
     TORCH_CHECK(
-        !c10::overflows<size_t>(size_bytes_i),
+        !c10::overflows<size_t>(size_bytes_i, /*strict_unsigned=*/true),
         "Requested storage size (",
         size_bytes_i,
         ") cannot be represented as a size_t");


### PR DESCRIPTION
## Summary

The CUDA storage-resize paths in `torch/csrc/StorageMethods.cpp` checked `!c10::overflows<size_t>(size_bytes_i)` where `size_bytes_i` is a signed `ptrdiff_t`. `c10::overflows`' default (`strict_unsigned=false`) deliberately permits signed->unsigned two's-complement wrap, so a **negative** requested size passed the check and was then `static_cast<size_t>`-ed into a huge allocation request (OOM / crash) rather than being rejected.

Fix: pass `strict_unsigned=true` at both sites so a negative size is rejected with the existing `"Requested storage size (...) cannot be represented as a size_t"` error. A negative storage size is unambiguously a bug, so this is strictly safer with no valid-input behavior change.

## Test

Adds `TestResizeStorageWithAddr.test_resize_storage_negative_size_raises` (test/test_cuda.py): `untyped_storage().resize_(-1)` on CUDA now raises `RuntimeError`.

`lintrunner -a` clean. This is a CUDA-only code path, so it relies on CUDA CI to exercise the test.

Part of a series cleaning up `c10::checked_convert`/`overflows` narrowing semantics (companion to #190092 and #190651).

Authored with the assistance of Claude Code.