### PR TITLE
fix: Validate groups in convolution meta kernel

### DIFF
--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -2252,7 +2252,44 @@ class TestMetaKernelConv(TestCase):
         self.assertTrue(gi2.is_contiguous(memory_format=torch.channels_last))
         self.assertTrue(gw2.is_contiguous(memory_format=torch.channels_last))
 
+    @skipIfTorchDynamo("tests raw meta kernel, not dynamo")
+    def test_convolution_meta_kernel_groups_validation(self):
+        """The meta kernel must reject invalid groups/weight configs the same
+        way as the real backend, instead of returning an output shape.
+        """
+        x = torch.randn(2, 12, 30, device="meta")
+        with self.assertRaisesRegex(
+            RuntimeError, "expected weight to be at least 6 at dimension 0"
+        ):
+            torch.nn.functional.conv1d(x, torch.randn(3, 2, 3, device="meta"), groups=6)
 
+        x = torch.randn(2, 6, 30, device="meta")
+        with self.assertRaisesRegex(
+            RuntimeError, "expected weight to be divisible by 2 at dimension 0"
+        ):
+            torch.nn.functional.conv1d(x, torch.randn(3, 3, 3, device="meta"), groups=2)
+
+        with self.assertRaisesRegex(RuntimeError, "non-positive groups is not supported"):
+            torch.nn.functional.conv1d(x, torch.randn(3, 3, 3, device="meta"), groups=0)
+
+        # weight checks also apply to the transposed path
+        with self.assertRaisesRegex(
+            RuntimeError, "expected weight to be divisible by 2 at dimension 0"
+        ):
+            torch.nn.functional.conv_transpose1d(
+                torch.randn(2, 3, 8, device="meta"),
+                torch.randn(3, 2, 3, device="meta"),
+                groups=2,
+            )
+
+        # mismatched input channels report the detailed message
+        with self.assertRaisesRegex(
+            RuntimeError, "expected input.* to have 2 channels, but got 8 channels"
+        ):
+            torch.nn.functional.conv1d(
+                torch.randn(2, 8, 30, device="meta"),
+                torch.randn(4, 2, 3, device="meta"),
+            )
 
 
 class TestMetaKernelRegistrations(TestCase):

--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -2291,6 +2291,15 @@ class TestMetaKernelConv(TestCase):
                 torch.randn(4, 2, 3, device="meta"),
             )
 
+        # transposed conv validates input channels against weight[0]
+        with self.assertRaisesRegex(
+            RuntimeError, "expected input.* to have 6 channels, but got 8 channels"
+        ):
+            torch.nn.functional.conv_transpose1d(
+                torch.randn(2, 8, 10, device="meta"),
+                torch.randn(6, 4, 3, device="meta"),
+            )
+
 
 class TestMetaKernelRegistrations(TestCase):
     @skipIfTorchDynamo("tests raw meta kernel, not dynamo")

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2674,6 +2674,19 @@ def calc_conv_nd_return_shape(
         """
         return (ln - 1) * s - 2 * p + d * (k - 1) + op + 1
 
+    # groups/weight checks mirror C++ check_shape_forward (Convolution.cpp)
+    torch._check(groups > 0, lambda: "non-positive groups is not supported")
+    torch._check(
+        weight.shape[0] >= groups,
+        lambda: f"Given groups={groups}, expected weight to be at least {groups} "
+        f"at dimension 0, but got weight of size {list(weight.shape)} instead",
+    )
+    torch._check(
+        weight.shape[0] % groups == 0,
+        lambda: f"Given groups={groups}, expected weight to be divisible by {groups} "
+        f"at dimension 0, but got weight of size [{list(weight.shape)}] instead",
+    )
+
     kernel_size = weight.shape[2:]
     dims = input_tensor.shape[2:]
     if is_transposed:
@@ -2682,7 +2695,10 @@ def calc_conv_nd_return_shape(
         out_channels = weight.shape[0]
         torch._check(
             weight.shape[1] * groups == input_tensor.shape[1],
-            lambda: "Invalid channel dimensions",
+            lambda: f"Given groups={groups}, weight of size {list(weight.shape)}, "
+            f"expected input{list(input_tensor.shape)} to have "
+            f"{weight.shape[1] * groups} channels, but got {input_tensor.shape[1]} "
+            "channels instead",
         )
 
     ret_shape = [input_tensor.shape[0], out_channels]

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2691,6 +2691,12 @@ def calc_conv_nd_return_shape(
     dims = input_tensor.shape[2:]
     if is_transposed:
         out_channels = groups * weight.shape[1]
+        torch._check(
+            input_tensor.shape[1] == weight.shape[0],
+            lambda: f"Given transposed=1, weight of size {list(weight.shape)}, "
+            f"expected input{list(input_tensor.shape)} to have {weight.shape[0]} "
+            f"channels, but got {input_tensor.shape[1]} channels instead",
+        )
     else:
         out_channels = weight.shape[0]
         torch._check(


### PR DESCRIPTION
### What does this PR do?

→ The bug is in [calc_conv_nd_return_shape](https://github.com/pytorch/pytorch/blob/5339e63cc08f87eb4ba1fe151164f0bb5e429c51/torch/_meta_registrations.py#L2682-L2686); the non-transposed branch only checked input channels and omitted the checks the real backend enforces, so an invalid config silently gave `torch.Size(foo)` instead of raising.
→ Fixed by adding the missing checks ahead of the channel check mirroring the C++ [check_shape_forward](https://github.com/pytorch/pytorch/blob/5339e63cc08f87eb4ba1fe151164f0bb5e429c51/aten/src/ATen/native/Convolution.cpp#L687-L700) so the meta error is now identical to the eager backend :)

Fixes #178472. This also fixes a related `groups=0` bug in the same meta helper. It returned a transposed shape and raised `Invalid channel dimensions` instead of matching eager's `"non-positive groups is not supported"` error. Builds on the closed/stale #178563; credited the original author as a co-author.

cc @mikaylagawarecki @ezyang @albanD

### Verification and Testing

→ <ins>Locally</ins> full `-k conv` meta suite (269 tests) and the new `TestMetaKernelConv` test pass with no new failures.

```
python test/test_meta.py -k "TestMetaKernelConv" -v
python test/test_meta.py -k "conv" -v
```

**Before (meta silently returns a shape)**

<img src="https://github.com/user-attachments/assets/dd59e7b8-16db-4d9f-9b07-3c360235374b" /><br>

**After (matches the eager backend exactly)**

<img src="https://github.com/user-attachments/assets/050d11d0-f17f-4c46-b5ed-9312df3204c1" />

### Environment

* `torch` version: `2.14.0a0+git5339e63` (source build, `USE_CUDA=0`)
* Platform: `Linux-6.8.0-1064-gcp-x86_64-with-glibc2.35`
* Python version: `3.10.12`
* The bug and fix are device-independent (raised from the `@register_meta` shape function); reproduced and fixed on CPU.