### PR TITLE
Fix CompilerBisector state cleanup to eliminate order-dependent XPU test failures

### DIFF
--- a/torch/_inductor/compiler_bisector.py
+++ b/torch/_inductor/compiler_bisector.py
@@ -673,10 +673,11 @@ class CompilerBisector:
                     print(f"Failed to delete bisect status during cleanup: {e}")
                 cls.in_process_cache = in_process_cache_orig
             if pre_grad_graph_subsystem is not None:
-                try:
-                    BACKENDS["inductor"].remove(pre_grad_graph_subsystem)
-                except ValueError:
-                    pass
+                inductor_backends = BACKENDS["inductor"]
+                for i, subsystem in enumerate(inductor_backends):
+                    if subsystem is pre_grad_graph_subsystem:
+                        del inductor_backends[i]
+                        break
 
 
 HELP_TEXT = """\

--- a/torch/_inductor/compiler_bisector.py
+++ b/torch/_inductor/compiler_bisector.py
@@ -571,6 +571,7 @@ class CompilerBisector:
             added_pre_grad_graph = True
 
         bisection_enabled_orig = cls.bisection_enabled
+        in_process_cache_orig = cls.in_process_cache
         try:
             if not cli_interface:
                 cls.delete_bisect_status()
@@ -667,7 +668,7 @@ class CompilerBisector:
             if not cli_interface:
                 cls.bisection_enabled = bisection_enabled_orig
                 cls.delete_bisect_status()
-                cls.in_process_cache = None
+                cls.in_process_cache = in_process_cache_orig
             if added_pre_grad_graph and BACKENDS["inductor"]:
                 if BACKENDS["inductor"][0].name == "pre_grad_graph":
                     del BACKENDS["inductor"][0]

--- a/torch/_inductor/compiler_bisector.py
+++ b/torch/_inductor/compiler_bisector.py
@@ -565,10 +565,10 @@ class CompilerBisector:
         # bisector so far. Use a config to opt-in
         import torch._inductor.config as inductor_config
 
-        added_pre_grad_graph = False
+        pre_grad_graph_subsystem: BisectSubsystem | None = None
         if inductor_config.test_configs.bisect_pre_grad_graph:
-            BACKENDS["inductor"].insert(0, BisectSubsystem("pre_grad_graph"))
-            added_pre_grad_graph = True
+            pre_grad_graph_subsystem = BisectSubsystem("pre_grad_graph")
+            BACKENDS["inductor"].insert(0, pre_grad_graph_subsystem)
 
         bisection_enabled_orig = cls.bisection_enabled
         in_process_cache_orig = cls.in_process_cache
@@ -672,9 +672,11 @@ class CompilerBisector:
                 except Exception:
                     pass
                 cls.in_process_cache = in_process_cache_orig
-            if added_pre_grad_graph and BACKENDS["inductor"]:
-                if BACKENDS["inductor"][0].name == "pre_grad_graph":
-                    del BACKENDS["inductor"][0]
+            if pre_grad_graph_subsystem is not None:
+                try:
+                    BACKENDS["inductor"].remove(pre_grad_graph_subsystem)
+                except ValueError:
+                    pass
 
 
 HELP_TEXT = """\

--- a/torch/_inductor/compiler_bisector.py
+++ b/torch/_inductor/compiler_bisector.py
@@ -667,7 +667,10 @@ class CompilerBisector:
         finally:
             if not cli_interface:
                 cls.bisection_enabled = bisection_enabled_orig
-                cls.delete_bisect_status()
+                try:
+                    cls.delete_bisect_status()
+                except Exception:
+                    pass
                 cls.in_process_cache = in_process_cache_orig
             if added_pre_grad_graph and BACKENDS["inductor"]:
                 if BACKENDS["inductor"][0].name == "pre_grad_graph":

--- a/torch/_inductor/compiler_bisector.py
+++ b/torch/_inductor/compiler_bisector.py
@@ -669,8 +669,8 @@ class CompilerBisector:
                 cls.bisection_enabled = bisection_enabled_orig
                 try:
                     cls.delete_bisect_status()
-                except Exception:
-                    pass
+                except OSError as e:
+                    print(f"Failed to delete bisect status during cleanup: {e}")
                 cls.in_process_cache = in_process_cache_orig
             if pre_grad_graph_subsystem is not None:
                 try:

--- a/torch/_inductor/compiler_bisector.py
+++ b/torch/_inductor/compiler_bisector.py
@@ -1,4 +1,3 @@
-import atexit
 import collections
 import dataclasses
 import functools
@@ -566,118 +565,112 @@ class CompilerBisector:
         # bisector so far. Use a config to opt-in
         import torch._inductor.config as inductor_config
 
+        added_pre_grad_graph = False
         if inductor_config.test_configs.bisect_pre_grad_graph:
             BACKENDS["inductor"].insert(0, BisectSubsystem("pre_grad_graph"))
+            added_pre_grad_graph = True
 
-        if not cli_interface:
-            bisection_enabled_orig = cls.bisection_enabled
-            cls.delete_bisect_status()
-            cls.bisection_enabled = True
-            # Only create temp dir if not already set (CLI run mode pre-sets it)
-            if not cls.in_process_cache:
-                cls.in_process_cache = tempfile.mkdtemp()
-
-            def cleanup() -> None:
-                cls.bisection_enabled = bisection_enabled_orig
+        bisection_enabled_orig = cls.bisection_enabled
+        try:
+            if not cli_interface:
                 cls.delete_bisect_status()
-                cls.in_process_cache = None
+                cls.bisection_enabled = True
+                # Only create temp dir if not already set (CLI run mode pre-sets it)
+                if not cls.in_process_cache:
+                    cls.in_process_cache = tempfile.mkdtemp()
 
-                if BACKENDS["inductor"][0].name == "pre_grad_graph":
-                    del BACKENDS["inductor"][0]
-
-            cleanup_handler = atexit.register(cleanup)
-
-            class DisableBisect:
-                def __del__(self) -> None:
-                    cleanup()
-                    atexit.unregister(cleanup_handler)
-
-            _cleanup = DisableBisect()
-
-        curr_backend = cls.get_backend()
-        curr_subsystem_name = cls.get_subsystem()
-
-        if not curr_backend:
-            cls.initialize_system()
             curr_backend = cls.get_backend()
-            if curr_backend is None:
-                raise AssertionError(
-                    "expected curr_backend to be set after initialize_system"
-                )
             curr_subsystem_name = cls.get_subsystem()
 
-        curr_subsystem = (
-            cls.get_subsystem_object(curr_backend, curr_subsystem_name)
-            if curr_subsystem_name is not None
-            else None
-        )
-        while True:
-            if curr_backend is None:
-                raise AssertionError("expected curr_backend to be set")
-            cls.reset_counters()
-            if curr_subsystem:
-                result = cls.process_subsystem(
-                    curr_backend, curr_subsystem, fn, cli_interface=cli_interface
-                )
-                if result:
-                    curr_subsystem = cls.get_subsystem_object(
-                        curr_backend,
-                        cls.get_subsystem(),  # type: ignore[arg-type]
+            if not curr_backend:
+                cls.initialize_system()
+                curr_backend = cls.get_backend()
+                if curr_backend is None:
+                    raise AssertionError(
+                        "expected curr_backend to be set after initialize_system"
                     )
+                curr_subsystem_name = cls.get_subsystem()
 
-                    if isinstance(curr_subsystem, BinarySubsystem):
+            curr_subsystem = (
+                cls.get_subsystem_object(curr_backend, curr_subsystem_name)
+                if curr_subsystem_name is not None
+                else None
+            )
+            while True:
+                if curr_backend is None:
+                    raise AssertionError("expected curr_backend to be set")
+                cls.reset_counters()
+                if curr_subsystem:
+                    result = cls.process_subsystem(
+                        curr_backend, curr_subsystem, fn, cli_interface=cli_interface
+                    )
+                    if result:
+                        curr_subsystem = cls.get_subsystem_object(
+                            curr_backend,
+                            cls.get_subsystem(),  # type: ignore[arg-type]
+                        )
+
+                        if isinstance(curr_subsystem, BinarySubsystem):
+                            return BisectionResult(
+                                curr_backend,
+                                curr_subsystem.name,
+                                0,
+                                curr_subsystem.name,
+                            )
+
+                        low, _ = cls.get_bisect_range(curr_backend, curr_subsystem.name)
                         return BisectionResult(
                             curr_backend,
                             curr_subsystem.name,
-                            0,
-                            curr_subsystem.name,
+                            low,
+                            cls.get_call_counter_debug_info(
+                                curr_backend, curr_subsystem.name, low
+                            ),
                         )
 
-                    low, _ = cls.get_bisect_range(curr_backend, curr_subsystem.name)
-                    return BisectionResult(
-                        curr_backend,
-                        curr_subsystem.name,
-                        low,
-                        cls.get_call_counter_debug_info(
-                            curr_backend, curr_subsystem.name, low
-                        ),
-                    )
-
-                next_subsystem = cls.advance_subsystem(curr_backend, curr_subsystem)
-                if not next_subsystem:
-                    print(
-                        f"The issue is in the {curr_backend} system, but could not identify subsystem."
-                    )
-                    if curr_backend is None:
-                        raise AssertionError("expected curr_backend to be set")
-                    return BisectionResult(curr_backend)
-
-                curr_subsystem = next_subsystem
-            else:
-                if fn():
-                    next_backend = cls.advance_backend(curr_backend)
-                    if not next_backend:
-                        print("All systems have been checked.")
-                        return None
-
-                    curr_backend = next_backend
-                else:
-                    current_subsystems = BACKENDS[curr_backend]
-                    if current_subsystems:
-                        curr_subsystem = current_subsystems[0]
-                        cls.update_bisect_status(curr_backend, curr_subsystem.name)
-                        cls.update_run_state(
-                            curr_backend, curr_subsystem, "test_disable"
-                        )
+                    next_subsystem = cls.advance_subsystem(curr_backend, curr_subsystem)
+                    if not next_subsystem:
                         print(
-                            f"The issue is in the {curr_backend} system. Moving to the first subsystem: {curr_subsystem}"
+                            f"The issue is in the {curr_backend} system, but could not identify subsystem."
                         )
-                    else:
-                        print(f"The issue is in the {curr_backend} system.")
+                        if curr_backend is None:
+                            raise AssertionError("expected curr_backend to be set")
                         return BisectionResult(curr_backend)
 
-            if cli_interface:
-                sys.exit(0)
+                    curr_subsystem = next_subsystem
+                else:
+                    if fn():
+                        next_backend = cls.advance_backend(curr_backend)
+                        if not next_backend:
+                            print("All systems have been checked.")
+                            return None
+
+                        curr_backend = next_backend
+                    else:
+                        current_subsystems = BACKENDS[curr_backend]
+                        if current_subsystems:
+                            curr_subsystem = current_subsystems[0]
+                            cls.update_bisect_status(curr_backend, curr_subsystem.name)
+                            cls.update_run_state(
+                                curr_backend, curr_subsystem, "test_disable"
+                            )
+                            print(
+                                f"The issue is in the {curr_backend} system. Moving to the first subsystem: {curr_subsystem}"
+                            )
+                        else:
+                            print(f"The issue is in the {curr_backend} system.")
+                            return BisectionResult(curr_backend)
+
+                if cli_interface:
+                    sys.exit(0)
+        finally:
+            if not cli_interface:
+                cls.bisection_enabled = bisection_enabled_orig
+                cls.delete_bisect_status()
+                cls.in_process_cache = None
+            if added_pre_grad_graph and BACKENDS["inductor"]:
+                if BACKENDS["inductor"][0].name == "pre_grad_graph":
+                    del BACKENDS["inductor"][0]
 
 
 HELP_TEXT = """\


### PR DESCRIPTION
### Summary
This PR fixes flaky, order-dependent XPU bisector tests by making CompilerBisector cleanup deterministic per invocation.

The root cause was state leakage between test runs. Cleanup tied to process lifetime (for example, atexit/destructor-style behavior) is too late for pytest, where many tests execute in the same interpreter. As a result, mutable bisector state could bleed into subsequent tests and change subsystem classification outcomes.

### Changes
- Switched cleanup semantics to `try/finally` inside `CompilerBisector.do_bisect()`.
- Ensured cleanup always runs after each bisect call, including:
  - normal return
  - exception path
  - `SystemExit` path from CLI flow
- Explicitly restores/removes runtime state modified during bisect execution:
  - `bisection_enabled`
  - bisect status/cache data
  - temporary `pre_grad_graph` insertion in backend list

### Why `try/finally` instead of `atexit`
`atexit` runs only when the Python process exits, which is too late for test isolation.  
`try/finally` runs at function scope, guaranteeing cleanup after each invocation and preventing cross-test contamination.

### Issue context
Fixes:
- https://github.com/intel/torch-xpu-ops/issues/3851

Reported symptom family:
- Assertion mismatches in XPU CompilerBisector tests (for example, subsystem unexpectedly `None` or wrong subsystem), depending on execution order.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo