### PR TITLE
[TEST] Refactor test_dtensor_logging.py and test_shmem_triton.py with hw_classification

### DIFF
--- a/test/distributed/tensor/test_dtensor_logging.py
+++ b/test/distributed/tensor/test_dtensor_logging.py
@@ -8,13 +8,19 @@ from torch.distributed.tensor import DeviceMesh, DTensor, Replicate, Shard
 from torch.distributed.tensor._dtensor_spec import DTensorSpec, TensorMeta
 from torch.distributed.tensor._op_schema import OpSchema
 from torch.distributed.tensor.debug import _clear_sharding_prop_cache
-from torch.testing._internal.common_utils import requires_cuda, run_tests, TestCase
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 from torch.testing._internal.distributed.fake_pg import FakeStore
 
 
-@requires_cuda
 class TestDTensorLogging(TestCase):
     """Test DTensor logging."""
+
+    hw_classification = HardwareClassification.ACCELERATOR
 
     def tearDown(self):
         super().tearDown()
@@ -28,7 +34,6 @@ class TestDTensorLogging(TestCase):
         dist.init_process_group(
             backend="fake", rank=0, world_size=self.world_size, store=store
         )
-        self.device_type = "cuda"
 
     def test_sharding_prop_cache_logging(self):
         mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
@@ -60,11 +65,11 @@ class TestDTensorLogging(TestCase):
 
         self.assertExpectedInline(
             log_string(),
-            """\
-sharding_prop MISS (C++ fast path): aten.add.Tensor(Spec(f32[4, 4](S(0))), Spec(f32[4, 4](S(0)))) on DeviceMesh((2,), 'cuda', stride=(1,))) -> Spec(f32[4, 4](S(0)))
+            f"""\
+sharding_prop MISS (C++ fast path): aten.add.Tensor(Spec(f32[4, 4](S(0))), Spec(f32[4, 4](S(0)))) on DeviceMesh((2,), '{self.device_type}', stride=(1,))) -> Spec(f32[4, 4](S(0)))
 sharding_prop HIT (C++ fast path): aten::add.Tensor(Spec(f32[4, 4](S(0))), Spec(f32[4, 4](S(0))), 4822678189205111) -> Spec(f32[4, 4](S(0)))
-sharding_prop MISS (C++ fast path): aten.add.Tensor(Spec(f32[4, 4](R)), Spec(f32[4, 4](R))) on DeviceMesh((2,), 'cuda', stride=(1,))) -> Spec(f32[4, 4](R))
-sharding_prop MISS (C++ fast path): aten.add.Tensor(Spec(f32[8, 4](S(0))), Spec(f32[8, 4](S(0)))) on DeviceMesh((2,), 'cuda', stride=(1,))) -> Spec(f32[8, 4](S(0)))""",
+sharding_prop MISS (C++ fast path): aten.add.Tensor(Spec(f32[4, 4](R)), Spec(f32[4, 4](R))) on DeviceMesh((2,), '{self.device_type}', stride=(1,))) -> Spec(f32[4, 4](R))
+sharding_prop MISS (C++ fast path): aten.add.Tensor(Spec(f32[8, 4](S(0))), Spec(f32[8, 4](S(0)))) on DeviceMesh((2,), '{self.device_type}', stride=(1,))) -> Spec(f32[8, 4](S(0)))""",
         )
 
         # Test Python LRU cache, directly with ShardingPropagator
@@ -88,9 +93,9 @@ sharding_prop MISS (C++ fast path): aten.add.Tensor(Spec(f32[8, 4](S(0))), Spec(
         propagator.propagate_op_sharding(op_schema)  # Python cache hit
         self.assertExpectedInline(
             log_string(),
-            """\
-sharding_prop python cache MISS: aten.add.Tensor(Spec(f32[4, 4](S(0))), Spec(f32[4, 4](S(0)))) on DeviceMesh((2,), 'cuda', stride=(1,))) -> Spec(f32[4, 4](S(0)))
-sharding_prop python cache HIT: aten.add.Tensor(Spec(f32[4, 4](S(0))), Spec(f32[4, 4](S(0)))) on DeviceMesh((2,), 'cuda', stride=(1,))) -> Spec(f32[4, 4](S(0)))""",
+            f"""\
+sharding_prop python cache MISS: aten.add.Tensor(Spec(f32[4, 4](S(0))), Spec(f32[4, 4](S(0)))) on DeviceMesh((2,), '{self.device_type}', stride=(1,))) -> Spec(f32[4, 4](S(0)))
+sharding_prop python cache HIT: aten.add.Tensor(Spec(f32[4, 4](S(0))), Spec(f32[4, 4](S(0)))) on DeviceMesh((2,), '{self.device_type}', stride=(1,))) -> Spec(f32[4, 4](S(0)))""",
         )
 
     def test_logging_level_change_resets_cpp_cache(self):
@@ -122,6 +127,8 @@ sharding_prop python cache HIT: aten.add.Tensor(Spec(f32[4, 4](S(0))), Spec(f32[
         self.assertIn("MISS", log_records[0].getMessage())
         self.assertIn("HIT", log_records[1].getMessage())
 
+
+instantiate_device_type_tests(TestDTensorLogging, globals())
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/tensor/test_dtensor_logging.py
+++ b/test/distributed/tensor/test_dtensor_logging.py
@@ -63,7 +63,7 @@ class TestDTensorLogging(TestCase):
         x_dt2 = DTensor.from_local(torch.randn(4, 4), mesh, [Shard(0)], run_check=False)
         x_dt2 + x_dt2
 
-        self.assertExpectedInline(
+        self.assertEqual(
             log_string(),
             f"""\
 sharding_prop MISS (C++ fast path): aten.add.Tensor(Spec(f32[4, 4](S(0))), Spec(f32[4, 4](S(0)))) on DeviceMesh((2,), '{self.device_type}', stride=(1,))) -> Spec(f32[4, 4](S(0)))
@@ -91,7 +91,7 @@ sharding_prop MISS (C++ fast path): aten.add.Tensor(Spec(f32[8, 4](S(0))), Spec(
         )
         propagator.propagate_op_sharding(op_schema)  # Python cache miss
         propagator.propagate_op_sharding(op_schema)  # Python cache hit
-        self.assertExpectedInline(
+        self.assertEqual(
             log_string(),
             f"""\
 sharding_prop python cache MISS: aten.add.Tensor(Spec(f32[4, 4](S(0))), Spec(f32[4, 4](S(0)))) on DeviceMesh((2,), '{self.device_type}', stride=(1,))) -> Spec(f32[4, 4](S(0)))

--- a/test/distributed/test_shmem_triton.py
+++ b/test/distributed/test_shmem_triton.py
@@ -31,6 +31,7 @@ import torch.distributed._symmetric_memory._shmem_triton as shmem_triton
 from torch._inductor.runtime.triton_compat import triton
 from torch.distributed._symmetric_memory._shmem_triton import requires_shmem
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
@@ -282,6 +283,8 @@ def my_reduce_kernel(
 
 @instantiate_parametrized_tests
 class SHMEMTritonTest(MultiProcContinuousTest):
+    hw_classification = HardwareClassification.MULTI_ACCELERATOR_CUDA
+
     def _init_device(self) -> None:
         # TODO: relieve this (seems to hang if without)
         device_module.set_device(self.device)

--- a/test/distributed/test_shmem_triton.py
+++ b/test/distributed/test_shmem_triton.py
@@ -283,7 +283,7 @@ def my_reduce_kernel(
 
 @instantiate_parametrized_tests
 class SHMEMTritonTest(MultiProcContinuousTest):
-    hw_classification = HardwareClassification.MULTI_ACCELERATOR_CUDA
+    hw_classification = HardwareClassification.CUDA
 
     def _init_device(self) -> None:
         # TODO: relieve this (seems to hang if without)


### PR DESCRIPTION
- Refactored `test/distributed/tensor/test_dtensor_logging.py` to be device-agnostic: removed `@requires_cuda` / hardcoded `"cuda"`, used `instantiate_device_type_tests` for both the tests with `self.device_type` for `DeviceMesh` and expected log strings, and set `hw_classification = HardwareClassification.ACCELERATOR` (FakePG logging; does not require multiple GPUs).

- Annotate `test/distributed/test_shmem_triton.py` with `hw_classification = HardwareClassification.MULTI_ACCELERATOR_CUDA` for `SHMEMTritonTest`, because multi-rank NVSHMEM/rocSHMEM Triton tests locked to the CUDA device type. These tests only run on the CUDA device type because NVSHMEM/rocSHMEM don’t exist for other accelerators.`

Depends on: #190082 

## Test plan
```bash
python test/distributed/tensor/test_dtensor_logging.py -v
python test/distributed/test_shmem_triton.py -v
```

CC: @mansiag05 @vishalgoyal316 @RiyaP2508 