### PR TITLE
[Testcase Refactoring][DCP] Reduce auto-detect test device requirement

### DIFF
--- a/test/distributed/checkpoint/test_save_load_api.py
+++ b/test/distributed/checkpoint/test_save_load_api.py
@@ -34,7 +34,7 @@ class TestSaveAndLoadAPI(DTensorTestBase):
         return 2
 
     @with_comms
-    @skip_if_lt_x_gpu(4)
+    @skip_if_lt_x_gpu(2)
     @with_temp_dir
     def test_auto_detect(self):
         model = FSDP(MyTestModule().to(self.device_type))


### PR DESCRIPTION
## Summary

This PR reduces the device-count prerequisite for `TestSaveAndLoadAPI.test_auto_detect` from four devices to two. The test uses `world_size = 2` and creates a two-rank device mesh, so two accelerator devices are sufficient.

This allows the distributed checkpoint auto-detection test to run in valid two-device environments instead of being unnecessarily skipped.

## Changes

- Replaced `@skip_if_lt_x_gpu(4)` with `@skip_if_lt_x_gpu(2)` in `test/distributed/checkpoint/test_save_load_api.py`.
- Kept the existing decorator implementation, decorator ordering, and test logic unchanged.

## Motivation

`test_auto_detect` starts two distributed workers and constructs its device mesh from `self.world_size`, which is two. Requiring four devices prevents coverage on two-device configurations even though the test does not use the additional devices.

## Test Plan

- Full test file:
  - `python test/distributed/checkpoint/test_save_load_api.py -v`
  - Result: 2 tests passed, 0 skipped.
- Targeted test with exactly two visible accelerator devices:
  - `python test/distributed/checkpoint/test_save_load_api.py TestSaveAndLoadAPI.test_auto_detect -v`
  - Result: 1 test passed, 0 skipped; two distributed workers started.

## Notes

- This PR does not change `skip_if_lt_x_gpu` or introduce a new decorator.
- The change is limited to correcting the test's over-restrictive device-count prerequisite.
