### PR TITLE
[Testcase Refactoring] Decouple test_autoheuristic.py from CUDA-specific

### DIFF
--- a/test/inductor/test_autoheuristic.py
+++ b/test/inductor/test_autoheuristic.py
@@ -15,6 +15,138 @@ from torch.testing._internal.common_utils import HardwareClassification, skipIfX
 from torch.testing._internal.inductor_utils import HAS_TRITON, IS_A100, IS_H100
 
 
+class AutoHeuristicTestCuda(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
+    def count_lines_in_file(self, file_path):
+        with open(file_path) as file:
+            line_count = sum(1 for line in file)
+        return line_count
+
+    def run_mm(self, device):
+        def f(a, b):
+            return torch.mm(a, b)
+
+        cf = torch.compile(f)
+        a = torch.randn(2047, 2048, device=device, dtype=torch.float16)
+        b = torch.randn(2048, 2048, device=device, dtype=torch.float16)
+        cf(a, b)
+
+    def get_path_to_autoheuristic_log(self, name):
+        device_name = AutoHeuristic.get_device_identifier()
+        path = cache_dir() + "/autoheuristic/" + device_name + "/" + name + ".txt"
+        return path
+
+    def run_mixed_mm(self, device):
+        def fn(a, b):
+            return torch.mm(a, b.to(a.dtype))
+
+        a = torch.randn(8, 1024, device=device, dtype=torch.float16)
+        b = torch.randint(
+            -128, 127, (1024, 1024), dtype=torch.int8, device=device
+        ).t()
+        torch.compile(fn, mode="max-autotune-no-cudagraphs")(a, b)
+
+    @patch.dict(os.environ, {"TORCHINDUCTOR_AUTOHEURISTIC_COLLECT": "test"})
+    def test_autoheuristic(self):
+        # test basic functionality of autoheuristic
+        def fallback():
+            return "fallback"
+
+        choices = ["a", "b", "c"]
+
+        def feedback_fn(choice):
+            if choice == "a":
+                return 1
+            elif choice == "b":
+                return 2
+            elif choice == "c":
+                return 3
+            else:
+                raise RuntimeError("unexpected choice")
+
+        feedback = LocalFeedback(feedback_fn)
+        context = AHContext()
+        context.add_feature("fa", 5)
+        name = "test"
+        autoheuristic = AutoHeuristic(fallback, choices, feedback, context, name)
+
+        # when autoheuristic is configured to only collect data, we always return fallback
+        self.assertEqual(autoheuristic.get_choice(), "fallback")
+        self.assertEqual(autoheuristic.get_collected_feedback("a"), 1)
+        self.assertEqual(autoheuristic.get_collected_feedback("b"), 2)
+        self.assertEqual(autoheuristic.get_collected_feedback("c"), 3)
+
+        path = self.get_path_to_autoheuristic_log(name)
+        self.assertTrue(os.path.exists(path))
+        num_lines = self.count_lines_in_file(path)
+        self.assertEqual(num_lines, 5)
+
+        shared_memory = get_gpu_shared_memory()
+        device_capa = list(torch.cuda.get_device_capability())
+
+        with open(path) as file:
+            lines = file.readlines()
+            self.assertTrue('"numerical_features": ["fa"]' in lines[0])
+            self.assertTrue('"categorical_features": []' in lines[0])
+            self.assertTrue(f'"shared_memory": {shared_memory}' in lines[0])
+            self.assertTrue(f'"device_capa": {device_capa}' in lines[0])
+            self.assertTrue('"name": "test"' in lines[0])
+            self.assertEqual("fa,choice,feedback", lines[1].rstrip())
+            self.assertEqual("5,a,1", lines[2].rstrip())
+            self.assertEqual("5,b,2", lines[3].rstrip())
+            self.assertEqual("5,c,3", lines[4].rstrip())
+
+    @unittest.skipIf(not IS_A100, "heuristic only run on A100")
+    @inductor_config.patch("autoheuristic_use.pad_mm", True)
+    def test_autoheuristic_a100(self, device):
+        # Make sure heuristic does not break anything
+        # TODO (AlnisM): Find a way to check whether heuristic is used
+        self.run_mm(device)
+
+    @unittest.skipIf(not IS_H100, "heuristic only run on H100")
+    @inductor_config.patch("autoheuristic_use.pad_mm", True)
+    def test_autoheuristic_h100(self, device):
+        # Make sure heuristic does not break anything
+        # TODO (AlnisM): Find a way to check whether heuristic is used
+        self.run_mm(device)
+
+    @inductor_config.patch("autoheuristic_use.mixed_mm", True)
+    @unittest.skipIf(not IS_A100, "heuristic only run on A100")
+    def test_mixed_mm_a100(self, device):
+        self.run_mixed_mm(device)
+        # TODO (AlnisM): Find a way to check whether heuristic is used
+
+    @unittest.skipIf(not IS_H100 and not IS_A100, "heuristic only run on H100")
+    @inductor_config.patch(deterministic=True)
+    @inductor_config.patch("autoheuristic_use.pad_mm", True)
+    def test_pad_mm_autoheuristic_deterministic_mode(self, device):
+        """Test that pad_mm AutoHeuristics works in deterministic mode."""
+        from torch._dynamo.utils import counters
+
+        counters.clear()
+
+        def f(a, b):
+            return torch.mm(a, b)
+
+        cf = torch.compile(f)
+        # Use shapes that would normally trigger padding but aren't well-aligned
+        a = torch.randn(2047, 2048, device=device, dtype=torch.float16)
+        b = torch.randn(2048, 2049, device=device, dtype=torch.float16)
+
+        # Run the compiled function
+        result = cf(a, b)
+
+        # Verify correctness with tolerance for potential padding differences
+        expected = torch.mm(a, b)
+        torch.testing.assert_close(result, expected, atol=0.1, rtol=0.05)
+
+        # In deterministic mode with AutoHeuristics enabled,
+        # we should not do any benchmarking (pad_mm_bench should stay 0)
+        # because AutoHeuristics makes the decision without benchmarking
+        self.assertEqual(counters["inductor"]["pad_mm_bench"], 0)
+
+
 class AutoHeuristicTest(TestCase):
     hw_classification = HardwareClassification.ACCELERATOR
 
@@ -72,73 +204,6 @@ class AutoHeuristicTest(TestCase):
         # this test ensures that data is collected for pad_mm when autoheuristic_collect.pad_mm=True
         self.assert_autoheuristic_collected_data()
 
-    @skipIfXpu(msg="AutoHeuristic doesn't currently work on the XPU stack")
-    @patch.dict(os.environ, {"TORCHINDUCTOR_AUTOHEURISTIC_COLLECT": "test"})
-    def test_autoheuristic(self):
-        # test basic functionality of autoheuristic
-        def fallback():
-            return "fallback"
-
-        choices = ["a", "b", "c"]
-
-        def feedback_fn(choice):
-            if choice == "a":
-                return 1
-            elif choice == "b":
-                return 2
-            elif choice == "c":
-                return 3
-            else:
-                raise RuntimeError("unexpected choice")
-
-        feedback = LocalFeedback(feedback_fn)
-        context = AHContext()
-        context.add_feature("fa", 5)
-        name = "test"
-        autoheuristic = AutoHeuristic(fallback, choices, feedback, context, name)
-
-        # when autoheuristic is configured to only collect data, we always return fallback
-        self.assertEqual(autoheuristic.get_choice(), "fallback")
-        self.assertEqual(autoheuristic.get_collected_feedback("a"), 1)
-        self.assertEqual(autoheuristic.get_collected_feedback("b"), 2)
-        self.assertEqual(autoheuristic.get_collected_feedback("c"), 3)
-
-        path = self.get_path_to_autoheuristic_log(name)
-        self.assertTrue(os.path.exists(path))
-        num_lines = self.count_lines_in_file(path)
-        self.assertEqual(num_lines, 5)
-
-        shared_memory = get_gpu_shared_memory()
-        device_capa = list(torch.accelerator.get_device_capability())
-
-        with open(path) as file:
-            lines = file.readlines()
-            self.assertTrue('"numerical_features": ["fa"]' in lines[0])
-            self.assertTrue('"categorical_features": []' in lines[0])
-            self.assertTrue(f'"shared_memory": {shared_memory}' in lines[0])
-            self.assertTrue(f'"device_capa": {device_capa}' in lines[0])
-            self.assertTrue('"name": "test"' in lines[0])
-            self.assertEqual("fa,choice,feedback", lines[1].rstrip())
-            self.assertEqual("5,a,1", lines[2].rstrip())
-            self.assertEqual("5,b,2", lines[3].rstrip())
-            self.assertEqual("5,c,3", lines[4].rstrip())
-
-    @skipIfXpu(msg="AutoHeuristic doesn't currently work on the XPU stack")
-    @unittest.skipIf(not IS_A100, "heuristic only run on A100")
-    @inductor_config.patch("autoheuristic_use.pad_mm", True)
-    def test_autoheuristic_a100(self, device):
-        # Make sure heuristic does not break anything
-        # TODO (AlnisM): Find a way to check whether heuristic is used
-        self.run_mm(device)
-
-    @skipIfXpu(msg="AutoHeuristic doesn't currently work on the XPU stack")
-    @unittest.skipIf(not IS_H100, "heuristic only run on H100")
-    @inductor_config.patch("autoheuristic_use.pad_mm", True)
-    def test_autoheuristic_h100(self, device):
-        # Make sure heuristic does not break anything
-        # TODO (AlnisM): Find a way to check whether heuristic is used
-        self.run_mm(device)
-
     def run_mixed_mm(self, device):
         def fn(a, b):
             return torch.mm(a, b.to(a.dtype))
@@ -171,43 +236,6 @@ class AutoHeuristicTest(TestCase):
         # 1 line for metadata, 1 line for header
         # 1 line for fallback + at least 1 config
         self.assertTrue(num_lines > 4)
-
-    @skipIfXpu(msg="AutoHeuristic doesn't currently work on the XPU stack")
-    @inductor_config.patch("autoheuristic_use.mixed_mm", True)
-    @unittest.skipIf(not IS_A100, "heuristic only run on A100")
-    def test_mixed_mm_a100(self, device):
-        self.run_mixed_mm(device)
-        # TODO (AlnisM): Find a way to check whether heuristic is used
-
-    @skipIfXpu(msg="AutoHeuristic doesn't currently work on the XPU stack")
-    @unittest.skipIf(not IS_H100 and not IS_A100, "heuristic only run on H100")
-    @inductor_config.patch(deterministic=True)
-    @inductor_config.patch("autoheuristic_use.pad_mm", True)
-    def test_pad_mm_autoheuristic_deterministic_mode(self, device):
-        """Test that pad_mm AutoHeuristics works in deterministic mode."""
-        from torch._dynamo.utils import counters
-
-        counters.clear()
-
-        def f(a, b):
-            return torch.mm(a, b)
-
-        cf = torch.compile(f)
-        # Use shapes that would normally trigger padding but aren't well-aligned
-        a = torch.randn(2047, 2048, device=device, dtype=torch.float16)
-        b = torch.randn(2048, 2049, device=device, dtype=torch.float16)
-
-        # Run the compiled function
-        result = cf(a, b)
-
-        # Verify correctness with tolerance for potential padding differences
-        expected = torch.mm(a, b)
-        torch.testing.assert_close(result, expected, atol=0.1, rtol=0.05)
-
-        # In deterministic mode with AutoHeuristics enabled,
-        # we should not do any benchmarking (pad_mm_bench should stay 0)
-        # because AutoHeuristics makes the decision without benchmarking
-        self.assertEqual(counters["inductor"]["pad_mm_bench"], 0)
 
     @inductor_config.patch(deterministic=True)
     def test_use_autoheuristic_pad_mm_enabled_in_deterministic_mode(self):

--- a/test/inductor/test_autoheuristic.py
+++ b/test/inductor/test_autoheuristic.py
@@ -10,23 +10,26 @@ from torch._inductor.autoheuristic.autoheuristic_utils import AHContext
 from torch._inductor.runtime.runtime_utils import cache_dir
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import get_gpu_shared_memory
-from torch.testing._internal.common_utils import skipIfXpu
-from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU, IS_A100, IS_H100
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification, skipIfXpu
+from torch.testing._internal.inductor_utils import HAS_TRITON, IS_A100, IS_H100
 
 
 class AutoHeuristicTest(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def count_lines_in_file(self, file_path):
         with open(file_path) as file:
             line_count = sum(1 for line in file)
         return line_count
 
-    def run_mm(self):
+    def run_mm(self, device):
         def f(a, b):
             return torch.mm(a, b)
 
         cf = torch.compile(f)
-        a = torch.randn(2047, 2048, device=GPU_TYPE, dtype=torch.float16)
-        b = torch.randn(2048, 2048, device=GPU_TYPE, dtype=torch.float16)
+        a = torch.randn(2047, 2048, device=device, dtype=torch.float16)
+        b = torch.randn(2048, 2048, device=device, dtype=torch.float16)
         cf(a, b)
 
     def get_path_to_autoheuristic_log(self, name):
@@ -35,20 +38,20 @@ class AutoHeuristicTest(TestCase):
         return path
 
     @skipIfXpu(msg="AutoHeuristic doesn't currently work on the XPU stack")
-    def test_autoheuristic_pad_mm_default(self):
+    def test_autoheuristic_pad_mm_default(self, device):
         # this test ensures that data is not collected for pad_mm when autoheuristic config is set to its default value
-        self.run_mm()
+        self.run_mm(device)
         self.assertFalse(os.path.exists(self.get_path_to_autoheuristic_log("pad_mm")))
 
     @skipIfXpu(msg="AutoHeuristic doesn't currently work on the XPU stack")
     @inductor_config.patch("autoheuristic_collect.pad_mm", False)
-    def test_autoheuristic_pad_mm_off(self):
+    def test_autoheuristic_pad_mm_off(self, device):
         # this test ensures that data is not collected for pad_mm when autoheuristic_collect does not contain "pad_mm"
-        self.run_mm()
+        self.run_mm(device)
         self.assertFalse(os.path.exists(self.get_path_to_autoheuristic_log("pad_mm")))
 
-    def assert_autoheuristic_collected_data(self):
-        self.run_mm()
+    def assert_autoheuristic_collected_data(self, device):
+        self.run_mm(device)
         AutoHeuristic.get_device_identifier()
         path = self.get_path_to_autoheuristic_log("pad_mm")
         self.assertTrue(os.path.exists(path))
@@ -106,7 +109,7 @@ class AutoHeuristicTest(TestCase):
         self.assertEqual(num_lines, 5)
 
         shared_memory = get_gpu_shared_memory()
-        device_capa = list(torch.cuda.get_device_capability())
+        device_capa = list(torch.accelerator.get_device_capability())
 
         with open(path) as file:
             lines = file.readlines()
@@ -123,26 +126,26 @@ class AutoHeuristicTest(TestCase):
     @skipIfXpu(msg="AutoHeuristic doesn't currently work on the XPU stack")
     @unittest.skipIf(not IS_A100, "heuristic only run on A100")
     @inductor_config.patch("autoheuristic_use.pad_mm", True)
-    def test_autoheuristic_a100(self):
+    def test_autoheuristic_a100(self, device):
         # Make sure heuristic does not break anything
         # TODO (AlnisM): Find a way to check whether heuristic is used
-        self.run_mm()
+        self.run_mm(device)
 
     @skipIfXpu(msg="AutoHeuristic doesn't currently work on the XPU stack")
     @unittest.skipIf(not IS_H100, "heuristic only run on H100")
     @inductor_config.patch("autoheuristic_use.pad_mm", True)
-    def test_autoheuristic_h100(self):
+    def test_autoheuristic_h100(self, device):
         # Make sure heuristic does not break anything
         # TODO (AlnisM): Find a way to check whether heuristic is used
-        self.run_mm()
+        self.run_mm(device)
 
-    def run_mixed_mm(self):
+    def run_mixed_mm(self, device):
         def fn(a, b):
             return torch.mm(a, b.to(a.dtype))
 
-        a = torch.randn(8, 1024, device=GPU_TYPE, dtype=torch.float16)
+        a = torch.randn(8, 1024, device=device, dtype=torch.float16)
         b = torch.randint(
-            -128, 127, (1024, 1024), dtype=torch.int8, device=GPU_TYPE
+            -128, 127, (1024, 1024), dtype=torch.int8, device=device
         ).t()
         torch.compile(fn, mode="max-autotune-no-cudagraphs")(a, b)
 
@@ -159,8 +162,8 @@ class AutoHeuristicTest(TestCase):
     @inductor_config.patch("autoheuristic_use.mixed_mm", False)
     @inductor_config.patch(fx_graph_cache=False)
     @inductor_config.patch(fx_graph_remote_cache=False)
-    def test_global_feedback(self):
-        self.run_mixed_mm()
+    def test_global_feedback(self, device):
+        self.run_mixed_mm(device)
         path = self.get_path_to_autoheuristic_log("mixed_mm")
         self.assertTrue(os.path.exists(path))
         num_lines = self.count_lines_in_file(path)
@@ -172,15 +175,15 @@ class AutoHeuristicTest(TestCase):
     @skipIfXpu(msg="AutoHeuristic doesn't currently work on the XPU stack")
     @inductor_config.patch("autoheuristic_use.mixed_mm", True)
     @unittest.skipIf(not IS_A100, "heuristic only run on A100")
-    def test_mixed_mm_a100(self):
-        self.run_mixed_mm()
+    def test_mixed_mm_a100(self, device):
+        self.run_mixed_mm(device)
         # TODO (AlnisM): Find a way to check whether heuristic is used
 
     @skipIfXpu(msg="AutoHeuristic doesn't currently work on the XPU stack")
     @unittest.skipIf(not IS_H100 and not IS_A100, "heuristic only run on H100")
     @inductor_config.patch(deterministic=True)
     @inductor_config.patch("autoheuristic_use.pad_mm", True)
-    def test_pad_mm_autoheuristic_deterministic_mode(self):
+    def test_pad_mm_autoheuristic_deterministic_mode(self, device):
         """Test that pad_mm AutoHeuristics works in deterministic mode."""
         from torch._dynamo.utils import counters
 
@@ -191,8 +194,8 @@ class AutoHeuristicTest(TestCase):
 
         cf = torch.compile(f)
         # Use shapes that would normally trigger padding but aren't well-aligned
-        a = torch.randn(2047, 2048, device=GPU_TYPE, dtype=torch.float16)
-        b = torch.randn(2048, 2049, device=GPU_TYPE, dtype=torch.float16)
+        a = torch.randn(2047, 2048, device=device, dtype=torch.float16)
+        b = torch.randn(2048, 2049, device=device, dtype=torch.float16)
 
         # Run the compiled function
         result = cf(a, b)
@@ -212,7 +215,7 @@ class AutoHeuristicTest(TestCase):
         """pad_mm set to None; with deterministic=True, use_autoheuristic should return True."""
         self.assertTrue(inductor_config.use_autoheuristic("pad_mm"))
 
-    def test_autoheuristic_init_no_cuda(self):
+    def test_autoheuristic_init_no_accel(self):
         """AutoHeuristic.__init__ must not crash in non-CUDA environments."""
 
         def fallback():
@@ -222,17 +225,19 @@ class AutoHeuristicTest(TestCase):
         context.add_feature("x", 1)
 
         with (
-            patch("torch.cuda.is_available", return_value=False),
+            patch("torch.accelerator.is_available", return_value=False),
             patch(
                 "torch._inductor.autoheuristic.autoheuristic.get_gpu_shared_memory",
                 return_value=0,
             ),
         ):
-            ah = AutoHeuristic(fallback, ["a", "b"], None, context, "test_no_cuda")
+            ah = AutoHeuristic(fallback, ["a", "b"], None, context, "test_no_accel")
 
         self.assertEqual(ah.metadata.device_capa, (0, 0))
 
 
+instantiate_device_type_tests(AutoHeuristicTest, globals(), except_for="cpu", allow_xpu=True)
+
 if __name__ == "__main__":
-    if HAS_GPU:
+    if HAS_TRITON:
         run_tests()

--- a/test/inductor/test_autoheuristic.py
+++ b/test/inductor/test_autoheuristic.py
@@ -10,45 +10,67 @@ from torch._inductor.autoheuristic.autoheuristic_utils import AHContext
 from torch._inductor.runtime.runtime_utils import cache_dir
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import get_gpu_shared_memory
-from torch.testing._internal.common_utils import skipIfXpu
-from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU, IS_A100, IS_H100
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification, skipIfXpu
+from torch.testing._internal.inductor_utils import HAS_TRITON, IS_A100, IS_H100
 
 
 class AutoHeuristicTest(TestCase):
-    def count_lines_in_file(self, file_path):
-        with open(file_path) as file:
-            line_count = sum(1 for line in file)
-        return line_count
+    hw_classification = HardwareClassification.GENERIC
 
-    def run_mm(self):
+    @inductor_config.patch(deterministic=True)
+    def test_use_autoheuristic_pad_mm_enabled_in_deterministic_mode(self):
+        inductor_config.autoheuristic_use.pad_mm = None
+        """pad_mm set to None; with deterministic=True, use_autoheuristic should return True."""
+        self.assertTrue(inductor_config.use_autoheuristic("pad_mm"))
+
+    def test_autoheuristic_init_no_accel(self):
+        """AutoHeuristic.__init__ must not crash in non-CUDA environments."""
+
+        def fallback():
+            return "fallback"
+
+        context = AHContext()
+        context.add_feature("x", 1)
+
+        with (
+            patch("torch.accelerator.is_available", return_value=False),
+            patch(
+                "torch._inductor.autoheuristic.autoheuristic.get_gpu_shared_memory",
+                return_value=0,
+            ),
+        ):
+            ah = AutoHeuristic(fallback, ["a", "b"], None, context, "test_no_accel")
+
+        self.assertEqual(ah.metadata.device_capa, (0, 0))
+
+
+class AutoHeuristicTestBase(TestCase):
+    def run_mm(self, device):
         def f(a, b):
             return torch.mm(a, b)
 
         cf = torch.compile(f)
-        a = torch.randn(2047, 2048, device=GPU_TYPE, dtype=torch.float16)
-        b = torch.randn(2048, 2048, device=GPU_TYPE, dtype=torch.float16)
+        a = torch.randn(2047, 2048, device=device, dtype=torch.float16)
+        b = torch.randn(2048, 2048, device=device, dtype=torch.float16)
         cf(a, b)
+
+
+class AutoHeuristicTestDevice(AutoHeuristicTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def count_lines_in_file(self, file_path):
+        with open(file_path) as file:
+            line_count = sum(1 for line in file)
+        return line_count
 
     def get_path_to_autoheuristic_log(self, name):
         device_name = AutoHeuristic.get_device_identifier()
         path = cache_dir() + "/autoheuristic/" + device_name + "/" + name + ".txt"
         return path
 
-    @skipIfXpu(msg="AutoHeuristic doesn't currently work on the XPU stack")
-    def test_autoheuristic_pad_mm_default(self):
-        # this test ensures that data is not collected for pad_mm when autoheuristic config is set to its default value
-        self.run_mm()
-        self.assertFalse(os.path.exists(self.get_path_to_autoheuristic_log("pad_mm")))
-
-    @skipIfXpu(msg="AutoHeuristic doesn't currently work on the XPU stack")
-    @inductor_config.patch("autoheuristic_collect.pad_mm", False)
-    def test_autoheuristic_pad_mm_off(self):
-        # this test ensures that data is not collected for pad_mm when autoheuristic_collect does not contain "pad_mm"
-        self.run_mm()
-        self.assertFalse(os.path.exists(self.get_path_to_autoheuristic_log("pad_mm")))
-
-    def assert_autoheuristic_collected_data(self):
-        self.run_mm()
+    def assert_autoheuristic_collected_data(self, device):
+        self.run_mm(device)
         AutoHeuristic.get_device_identifier()
         path = self.get_path_to_autoheuristic_log("pad_mm")
         self.assertTrue(os.path.exists(path))
@@ -58,20 +80,33 @@ class AutoHeuristicTest(TestCase):
         self.assertEqual(num_lines, 4)
 
     @skipIfXpu(msg="AutoHeuristic doesn't currently work on the XPU stack")
-    @inductor_config.patch("autoheuristic_collect.pad_mm", True)
-    def test_autoheuristic_pad_mm_collect_data(self):
-        # this test ensures that data is collected for pad_mm when autoheuristic_collect.pad_mm=True
-        self.assert_autoheuristic_collected_data()
+    def test_autoheuristic_pad_mm_default(self, device):
+        # this test ensures that data is not collected for pad_mm when autoheuristic config is set to its default value
+        self.run_mm(device)
+        self.assertFalse(os.path.exists(self.get_path_to_autoheuristic_log("pad_mm")))
+
+    @skipIfXpu(msg="AutoHeuristic doesn't currently work on the XPU stack")
+    @inductor_config.patch("autoheuristic_collect.pad_mm", False)
+    def test_autoheuristic_pad_mm_off(self, device):
+        # this test ensures that data is not collected for pad_mm when autoheuristic_collect does not contain "pad_mm"
+        self.run_mm(device)
+        self.assertFalse(os.path.exists(self.get_path_to_autoheuristic_log("pad_mm")))
 
     @skipIfXpu(msg="AutoHeuristic doesn't currently work on the XPU stack")
     @inductor_config.patch("autoheuristic_collect.pad_mm", True)
-    def test_autoheuristic_pad_mm_collect_data2(self):
+    def test_autoheuristic_pad_mm_collect_data(self, device):
         # this test ensures that data is collected for pad_mm when autoheuristic_collect.pad_mm=True
-        self.assert_autoheuristic_collected_data()
+        self.assert_autoheuristic_collected_data(device)
+
+    @skipIfXpu(msg="AutoHeuristic doesn't currently work on the XPU stack")
+    @inductor_config.patch("autoheuristic_collect.pad_mm", True)
+    def test_autoheuristic_pad_mm_collect_data2(self, device):
+        # this test ensures that data is collected for pad_mm when autoheuristic_collect.pad_mm=True
+        self.assert_autoheuristic_collected_data(device)
 
     @skipIfXpu(msg="AutoHeuristic doesn't currently work on the XPU stack")
     @patch.dict(os.environ, {"TORCHINDUCTOR_AUTOHEURISTIC_COLLECT": "test"})
-    def test_autoheuristic(self):
+    def test_autoheuristic(self, device):
         # test basic functionality of autoheuristic
         def fallback():
             return "fallback"
@@ -106,7 +141,7 @@ class AutoHeuristicTest(TestCase):
         self.assertEqual(num_lines, 5)
 
         shared_memory = get_gpu_shared_memory()
-        device_capa = list(torch.cuda.get_device_capability())
+        device_capa = list(torch.get_device_module(device).get_device_capability())
 
         with open(path) as file:
             lines = file.readlines()
@@ -120,27 +155,28 @@ class AutoHeuristicTest(TestCase):
             self.assertEqual("5,b,2", lines[3].rstrip())
             self.assertEqual("5,c,3", lines[4].rstrip())
 
-    @skipIfXpu(msg="AutoHeuristic doesn't currently work on the XPU stack")
+
+class AutoHeuristicTestCuda(AutoHeuristicTestBase):
+    hw_classification = HardwareClassification.CUDA
+
     @unittest.skipIf(not IS_A100, "heuristic only run on A100")
     @inductor_config.patch("autoheuristic_use.pad_mm", True)
-    def test_autoheuristic_a100(self):
+    def test_autoheuristic_a100(self, device):
         # Make sure heuristic does not break anything
         # TODO (AlnisM): Find a way to check whether heuristic is used
-        self.run_mm()
+        self.run_mm(device)
 
-    @skipIfXpu(msg="AutoHeuristic doesn't currently work on the XPU stack")
     @unittest.skipIf(not IS_H100, "heuristic only run on H100")
     @inductor_config.patch("autoheuristic_use.pad_mm", True)
-    def test_autoheuristic_h100(self):
+    def test_autoheuristic_h100(self, device):
         # Make sure heuristic does not break anything
         # TODO (AlnisM): Find a way to check whether heuristic is used
-        self.run_mm()
+        self.run_mm(device)
 
-    @skipIfXpu(msg="AutoHeuristic doesn't currently work on the XPU stack")
     @unittest.skipIf(not IS_H100 and not IS_A100, "heuristic only run on H100")
     @inductor_config.patch(deterministic=True)
     @inductor_config.patch("autoheuristic_use.pad_mm", True)
-    def test_pad_mm_autoheuristic_deterministic_mode(self):
+    def test_pad_mm_autoheuristic_deterministic_mode(self, device):
         """Test that pad_mm AutoHeuristics works in deterministic mode."""
         from torch._dynamo.utils import counters
 
@@ -151,8 +187,8 @@ class AutoHeuristicTest(TestCase):
 
         cf = torch.compile(f)
         # Use shapes that would normally trigger padding but aren't well-aligned
-        a = torch.randn(2047, 2048, device=GPU_TYPE, dtype=torch.float16)
-        b = torch.randn(2048, 2049, device=GPU_TYPE, dtype=torch.float16)
+        a = torch.randn(2047, 2048, device=device, dtype=torch.float16)
+        b = torch.randn(2048, 2049, device=device, dtype=torch.float16)
 
         # Run the compiled function
         result = cf(a, b)
@@ -166,33 +202,12 @@ class AutoHeuristicTest(TestCase):
         # because AutoHeuristics makes the decision without benchmarking
         self.assertEqual(counters["inductor"]["pad_mm_bench"], 0)
 
-    @inductor_config.patch(deterministic=True)
-    def test_use_autoheuristic_pad_mm_enabled_in_deterministic_mode(self):
-        inductor_config.autoheuristic_use.pad_mm = None
-        """pad_mm set to None; with deterministic=True, use_autoheuristic should return True."""
-        self.assertTrue(inductor_config.use_autoheuristic("pad_mm"))
 
-    def test_autoheuristic_init_no_cuda(self):
-        """AutoHeuristic.__init__ must not crash in non-CUDA environments."""
-
-        def fallback():
-            return "fallback"
-
-        context = AHContext()
-        context.add_feature("x", 1)
-
-        with (
-            patch("torch.cuda.is_available", return_value=False),
-            patch(
-                "torch._inductor.autoheuristic.autoheuristic.get_gpu_shared_memory",
-                return_value=0,
-            ),
-        ):
-            ah = AutoHeuristic(fallback, ["a", "b"], None, context, "test_no_cuda")
-
-        self.assertEqual(ah.metadata.device_capa, (0, 0))
-
+instantiate_device_type_tests(
+    AutoHeuristicTestDevice, globals(), allow_xpu=True, except_for="cpu"
+)
+instantiate_device_type_tests(AutoHeuristicTestCuda, globals(), only_for="cuda")
 
 if __name__ == "__main__":
-    if HAS_GPU:
+    if HAS_TRITON:
         run_tests()

--- a/torch/_inductor/autoheuristic/autoheuristic.py
+++ b/torch/_inductor/autoheuristic/autoheuristic.py
@@ -85,7 +85,7 @@ class AutoHeuristic:
         self.augment_context = augment_context
         self.metadata = AHMetadata(
             get_gpu_shared_memory(),
-            torch.cuda.get_device_capability() if torch.cuda.is_available() else (0, 0),
+            torch.cuda.get_device_capability() if torch.accelerator.is_available() else (0, 0),
             self.choices,
             self.name,
         )
@@ -166,8 +166,9 @@ class AutoHeuristic:
         # we store the collected data per GPU model and learn a heuristic per GPU model
 
         # TODO(AlnisM): just using the device name for now, but the same GPU model can have different names
-        if torch.cuda.is_available():
-            device_name = torch.cuda.get_device_name().replace(" ", "_")
+        if torch.accelerator.is_available():
+            accel = torch.accelerator.current_accelerator()
+            device_name = torch.get_device_module(accel.type).get_device_name().replace(" ", "_")
             return device_name
         return "non_cuda_device"
 

--- a/torch/_inductor/autoheuristic/autoheuristic.py
+++ b/torch/_inductor/autoheuristic/autoheuristic.py
@@ -83,9 +83,13 @@ class AutoHeuristic:
         self.name = name
         self.collected_feedback = {}
         self.augment_context = augment_context
+        if torch.accelerator.is_available():
+            capability = torch.get_device_module().get_device_capability()
+        else:
+            capability = (0, 0)
         self.metadata = AHMetadata(
             get_gpu_shared_memory(),
-            torch.cuda.get_device_capability() if torch.cuda.is_available() else (0, 0),
+            capability,
             self.choices,
             self.name,
         )
@@ -166,10 +170,10 @@ class AutoHeuristic:
         # we store the collected data per GPU model and learn a heuristic per GPU model
 
         # TODO(AlnisM): just using the device name for now, but the same GPU model can have different names
-        if torch.cuda.is_available():
-            device_name = torch.cuda.get_device_name().replace(" ", "_")
+        if torch.accelerator.is_available():
+            device_name = torch.get_device_module().get_device_name().replace(" ", "_")
             return device_name
-        return "non_cuda_device"
+        return "non_accel_device"
 
     def get_default_log_path(self) -> str:
         device_name = self.get_device_identifier()


### PR DESCRIPTION
## Summary
This PR replaces hardcoded CUDA references with device-agnostic equivalents so out-of-tree accelerator backends can run these tests.

## Changes
- Uses `torch.accelerator.is_available()` to detect the available accelerator type.
- Replace hardcoded CUDA references with device-agnostic equivalents.
- Split cuda tests of class AutoHeuristicTest into class AutoHeuristicTestCuda.
- Instantiate device-agnostic test templates as device-specific test classes for multiple differrent device backends.
- Add `hw_classification = HardwareClassification.GENERIC|ACCELERATOR|CUDA` to tests class.

## Motivation
`torch.cuda` and `torch.xpu` only recognizes CUDA and XPU. New accelerators (e.g., `PrivateUse1`-based out-of-tree backends) are silently skipped even when enough devices are available. A generic decorator lets inductor tests adapt to any accelerator supported by `torch.accelerator`.

## Test Plan
- CI: `python test/inductor/test_autoheuristic.py`
- Verified locally that `torch.accelerator.xxx()` correctly on CPU, GPU, and XPU.

## Notes
- This is part of the test case refactoring initiative tracked in #185590.
- Make CUDA/XPU device-generic in #189138.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo