### PR TITLE
[decomp][bugfix] Add aten.cov decomposition for compilation (#190669)

### DIFF
--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -644,6 +644,32 @@ class TestDecomp(TestCase):
         self.assertEqual(ref, res)
         self.assertEqual(res.dtype, torch.float64)
 
+    def test_cov_decomp(self, device):
+        # The OpInfo cross-ref (test_comprehensive) already exercises this decomp
+        # against eager, but its aweights floor is 0. This guards the weighted
+        # branches with strictly positive weights across correction values, plus
+        # the 1-D reshape/squeeze path.
+        from torch._decomp.decompositions import cov
+
+        torch.manual_seed(0)
+        x = torch.randn(3, 8, device=device)
+        num_observations = x.size(1)
+        fweights = torch.randint(1, 10, (num_observations,), device=device)
+        aweights = make_tensor(
+            (num_observations,), dtype=torch.float, device=device, low=1, high=3
+        )
+        for fw, aw in ((None, None), (fweights, None), (None, aweights), (fweights, aweights)):
+            # Larger corrections can drive the weighted norm_factor non-positive,
+            # where eager clamps to zero; stay in the well-defined regime.
+            corrections = (0, 1, 2) if fw is None and aw is None else (0, 1)
+            for correction in corrections:
+                ref = torch.cov(x, correction=correction, fweights=fw, aweights=aw)
+                res = cov(x, correction=correction, fweights=fw, aweights=aw)
+                self.assertEqual(ref, res)
+
+        v = torch.randn(5, device=device)
+        self.assertEqual(torch.cov(v), cov(v))
+
     def test_uniform(self, device):
         size = (2, 3, 4, 5)
         dtype = torch.float32

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1275,6 +1275,51 @@ def dropout(input: Tensor, p: float, train: bool | None):
         return input
 
 
+@register_decomposition(aten.cov)
+@aten.cov.default.py_impl(DispatchKey.CompositeImplicitAutograd)
+@aten.cov.default.py_impl(DispatchKey.Autograd)
+def cov(
+    self: Tensor,
+    correction: int = 1,
+    fweights: Tensor | None = None,
+    aweights: Tensor | None = None,
+) -> Tensor:
+    # The ATen composite (Correlation.cpp) reads concrete shapes via
+    # .numel() and takes data-dependent branches (is_scalar_tensor_true) on
+    # the weights, neither of which is traceable under symbolic shapes. This
+    # decomposition expresses cov purely in terms of shape arithmetic and
+    # elementwise/matmul ops so it can be captured and lowered by a compiler.
+    if self.dim() < 2:
+        self = self.view(1, -1)
+    num_observations = self.size(1)
+
+    w: Tensor | None = None
+    if fweights is not None:
+        w = fweights
+    if aweights is not None:
+        w = aweights if w is None else w * aweights
+
+    if w is not None:
+        w_sum = w.sum()
+        avg = (self * w).sum(1) / w_sum
+    else:
+        avg = self.sum(1) / num_observations
+
+    if w is None:
+        norm_factor = num_observations - correction
+    elif correction == 0:
+        norm_factor = w_sum
+    elif aweights is None:
+        norm_factor = w_sum - correction
+    else:
+        norm_factor = w_sum - correction * (w * aweights).sum() / w_sum
+
+    self = self - avg.unsqueeze(1)
+    weighted = self * w if w is not None else self
+    c = torch.mm(self, weighted.t().conj())
+    return torch.true_divide(c, norm_factor).squeeze()
+
+
 @register_decomposition(aten.native_dropout)
 @out_wrapper("out0", "out1")
 def native_dropout(input: Tensor, p: float, train: bool | None):


### PR DESCRIPTION
Summary:

`torch.cov` (`aten::cov`) is a `CompositeImplicitAutograd` op implemented only in C++ (`caffe2/aten/src/ATen/native/Correlation.cpp`) with no Python decomposition or meta kernel. Under `torch.compile`/`export` with dynamic (symbolic) shapes, tracing runs the C++ composite under `FakeTensorMode`, which is not symbolic-safe and fails in two distinct ways: (1) with `fweights`/`aweights`, the weight-validation path calls `.numel()` on a symbolic-shaped tensor and raises `Cannot call numel() on tensor with symbolic sizes/strides`; (2) without weights, the degrees-of-freedom check calls `is_scalar_tensor_true(...)` (a data-dependent `aten.equal`) which triggers a graph break so no graph is captured.

This adds a Python decomposition for `aten.cov`, registered as a `CompositeImplicitAutograd` (and `Autograd`) `py_impl` exactly like the existing `dropout` and `native_batch_norm` decompositions, so `OpOverload.decompose` uses it during capture instead of the C++ composite. The decomposition expresses cov purely with shape arithmetic and elementwise/matmul ops (mean-centering followed by a normalized matmul), which the symbolic tracer carries through cleanly.

Eager execution is unchanged: `py_impl` only populates the Python kernel table (`py_kernels`), which is consulted under the Python dispatcher / fake-tensor / decomposition-tracing paths; plain eager dispatch still resolves to the C++ composite. The decomposition reproduces the general-case math of the composite (mean-centering, the four `norm_factor` branches, the normalized conj-transpose matmul, and the final `squeeze`), so traced/compiled numerics match eager on the general path. It intentionally omits the composite data-dependent guard paths (input validation, the `norm_factor <= 0` clamp/warning, and the `num_observations == 1` and complex single-variable fixups), so compiled results can differ from eager only on degenerate or invalid inputs (for example `correction >= num_observations`, or inputs that eager would reject).

## Changes

- `caffe2/torch/_decomp/decompositions.py`: add a symbolic-safe `cov` decomposition mirroring the general path of the C++ composite.
- `caffe2/test/test_decomp.py`: add `test_cov_decomp`, an explicit strictly-positive-weights numeric guard for the weighted branches (the OpInfo cross-ref in `test_decomp` already covers the decomposition against eager, but its `aweights` floor is 0).
- add a few representative passing `cov` cases (device-verified) to an internal per-diff regression list; the nightly full suite carries exhaustive coverage.

## Not addressed (independent of this change)

- `f64` inputs: some backends do not support `aten.mm` on `float64`.
- Weight-bearing cases in the device regression harness: its generic input generator produces random (negative) `fweights`/`aweights`, which eager `cov` legitimately rejects, so there is no valid reference to compare against.
- Small integer inputs (`i8`/`i16`/`u8`) combined with integer `fweights`: a separate Triton compiler `SizeInfo` assertion in the fused reduction kernel.

Test Plan:
Unit test (CPU): added `test_cov_decomp` in `caffe2/test/test_decomp.py`, verifying the decomposition matches eager `torch.cov` for no-weights, `fweights`-only, `aweights`-only, and combined strictly-positive weights across correction values, plus the 1-D reshape/squeeze path. The existing `test_decomp` cross-ref (`test_comprehensive`/`test_quick`) also exercises the registered decomposition against eager over all `cov` OpInfo samples.

End-to-end (2-stage compile + run under automatic dynamic shapes):
Before this change: 0/360 enumerated `cov` cases compiled (all failed at graph capture). After: 305/360 compile (the remaining 55 are the independent limitations noted in the summary).

Device-verified representative no-weights cases across dtypes and shapes; all pass numerically (rtol=atol=5e-2): `f32`/`f16`/`bf16`/`i8`/`i16`/`i32`/`i64`/`u8` at 2-D shapes, plus `correction=1` and `correction=2` variants.

Reviewed By: kalpit-meta-1

Differential Revision: D111477318


