### PR TITLE
[dynamo] Support torch.compile applied directly on a staticmethod

### DIFF
--- a/test/dynamo/test_decorators.py
+++ b/test/dynamo/test_decorators.py
@@ -1404,6 +1404,35 @@ class DecoratorTests(PytreeRegisteringTestCase):
     def test_mark_static_address_unguarded(self):
         self._test_mark_static_address(guarded=False)
 
+    @parametrize("compile_outer", [False, True])
+    @parametrize("fullgraph", [False, True])
+    def test_compile_staticmethod(self, compile_outer, fullgraph):
+        cnt = torch._dynamo.testing.CompileCounter()
+        compile_decorator = torch.compile(backend=cnt, fullgraph=fullgraph)
+
+        if compile_outer:
+
+            class Foo:
+                @compile_decorator
+                @staticmethod
+                def bar(x):
+                    return x.sin()
+
+        else:
+
+            class Foo:
+                @staticmethod
+                @compile_decorator
+                def bar(x):
+                    return x.sin()
+
+        x = torch.randn(4)
+        expected = x.sin()
+        self.assertEqual(Foo.bar(x), expected)
+        self.assertEqual(Foo().bar(x), expected)
+        self.assertEqual(cnt.frame_count, 1)
+        self.assertEqual(cnt.op_count, 1)
+
     def test_class_methods(self):
         class A:
             @classmethod

--- a/test/dynamo/test_decorators.py
+++ b/test/dynamo/test_decorators.py
@@ -1433,6 +1433,25 @@ class DecoratorTests(PytreeRegisteringTestCase):
         self.assertEqual(cnt.frame_count, 1)
         self.assertEqual(cnt.op_count, 1)
 
+    @torch._dynamo.config.patch(caching_precompile=True)
+    def test_compile_staticmethod_caching_precompile(self):
+        from torch._dynamo.package import DynamoCache
+
+        DynamoCache.clear()
+        cnt = torch._dynamo.testing.CompileCounter()
+
+        class Foo:
+            @torch.compile(backend=cnt)
+            @staticmethod
+            def bar(x):
+                return x.sin()
+
+        x = torch.randn(4)
+        expected = x.sin()
+        self.assertEqual(Foo.bar(x), expected)
+        self.assertEqual(Foo().bar(x), expected)
+        self.assertEqual(cnt.frame_count, 1)
+
     def test_class_methods(self):
         class A:
             @classmethod

--- a/test/dynamo/test_nested_graph_breaks_wrapped.py
+++ b/test/dynamo/test_nested_graph_breaks_wrapped.py
@@ -116,6 +116,7 @@ xfails = [
     NestedGraphBreaksMiscTests.test_precompile_entries_nested_graph_breaks,  # noqa: F821
     NestedGraphBreaksMiscTests.test_precompile_entry_hit_nested_graph_breaks,  # noqa: F821
     NestedGraphBreaksMiscTests.test_precompile_fail_on_recompile_nested_graph_breaks,  # noqa: F821
+    NestedGraphBreaksDecoratorTests.test_compile_staticmethod_caching_precompile_nested_graph_breaks,  # noqa: F821
     NestedGraphBreaksMiscTests.test_torch_guards_stack_frame_register_inlining_deep_nested_graph_breaks,  # noqa: F821
     NestedGraphBreaksMiscTests.test_torch_guards_stack_frame_register_inlining_nested_graph_breaks,  # noqa: F821
     # differing op_count

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -934,6 +934,9 @@ class _TorchDynamoContext:
         return None
 
     def __call__(self, fn: Any) -> Any:
+        if isinstance(fn, staticmethod):
+            return staticmethod(self(fn.__func__))
+
         # public api for compiler config/options
         def get_compiler_config() -> CompilerConfig | None:
             return self.compiler_config
@@ -963,9 +966,6 @@ class _TorchDynamoContext:
                         )
 
         fn = innermost_fn(fn)
-
-        if isinstance(fn, staticmethod):
-            return staticmethod(self(fn.__func__))
 
         def aot_compile(example_inputs: tuple[tuple[Any, ...], dict[str, Any]]) -> Any:
             from torch._dynamo.aot_compile import aot_compile_fullgraph

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -964,6 +964,9 @@ class _TorchDynamoContext:
 
         fn = innermost_fn(fn)
 
+        if isinstance(fn, staticmethod):
+            return staticmethod(self(fn.__func__))
+
         def aot_compile(example_inputs: tuple[tuple[Any, ...], dict[str, Any]]) -> Any:
             from torch._dynamo.aot_compile import aot_compile_fullgraph
 


### PR DESCRIPTION
this is Fable-Assisted, had a lot of discussion with Fable and revisions before submitting.

> Fixes #190659
>
> `@torch.compile()` on top of `@staticmethod` hands the staticmethod
> object to `_TorchDynamoContext.__call__`, which had no case for it.
> Dynamo cannot trace `staticmethod.__call__`: without `fullgraph` it
> silently graph-breaks to eager, with `fullgraph=True` it raises
> "Unsupported: call to a callable object with no traceable __call__".
>
> Fix: unwrap to `__func__`, apply the context, re-wrap in
> `staticmethod()` — same approach as the existing class/`nn.Module`
> special cases. The check runs first in `__call__`, before the
> `caching_precompile` block, because that block would otherwise access
> `fn.__code__` on the raw staticmethod and crash at decoration time.
> Both decorator orders now behave the same, including `fullgraph=True`.
> `classmethod` is not callable, fails earlier with a clear
> `AssertionError`, and is left unchanged.
>
> Tests: new parametrized `test_compile_staticmethod` (both orders x
> fullgraph on/off, class and instance access, CompileCounter proves
> real compilation). Full `test_decorators.py` run: 97 OK (2 skipped).
> `test_misc.py -k static`: 5 OK. `lintrunner` on changed files: clean.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98