### PR TITLE
[Testcase Refactoring] Enable PrivateUse1 Device in test_attention

### DIFF
--- a/test/distributed/tensor/test_attention.py
+++ b/test/distributed/tensor/test_attention.py
@@ -102,7 +102,7 @@ class SDPAWrapper(torch.nn.Module):
 class RingAttentionTest(DTensorTestBase):
     @property
     def world_size(self) -> int:
-        return torch.cuda.device_count()
+        return torch.accelerator.device_count()
 
     @property
     def destroy_pg_upon_exit(self) -> bool:
@@ -551,7 +551,7 @@ class CPFlexAttentionTest(DTensorTestBase):
         document_lengths: list[list[int]] | None = None,
     ) -> None:
         torch.use_deterministic_algorithms(True)
-        torch.cuda.manual_seed(1234)
+        torch.manual_seed(1234)
 
         dtype = torch.float32
         bs = B if B > 1 else 8

--- a/test/distributed/tensor/test_attention.py
+++ b/test/distributed/tensor/test_attention.py
@@ -551,7 +551,8 @@ class CPFlexAttentionTest(DTensorTestBase):
         document_lengths: list[list[int]] | None = None,
     ) -> None:
         torch.use_deterministic_algorithms(True)
-        torch.manual_seed(1234)
+        device_mod = torch.get_device_module(self.device_type)
+        device_mod.manual_seed(1234)
 
         dtype = torch.float32
         bs = B if B > 1 else 8

--- a/torch/testing/_internal/optests/autograd_registration.py
+++ b/torch/testing/_internal/optests/autograd_registration.py
@@ -84,17 +84,18 @@ def autograd_registration_check(op, args, kwargs):
 
     # Determine which AutogradBACKEND key to check
     all_device_types = {arg.device.type for arg in all_tensors}
-    if not all_device_types.issubset(["cpu", "cuda", "xpu"]):
-        # Don't want to support other keys yet
-        raise NotImplementedError(
-            f"autograd_registration_check: NYI devices other than CPU/CUDA/XPU, got {all_device_types}"
-        )
-    if "cuda" in all_device_types:
-        key = "AutogradCUDA"
-    elif "cpu" in all_device_types:
-        key = "AutogradCPU"
-    elif "xpu" in all_device_types:
-        key = "AutogradXPU"
+    key = None
+    for device_type in all_device_types:
+        # torch._C._dispatch_key_for_device maps device type to dispatch key
+        # (e.g. "cuda" -> "CUDA", "npu" -> "PrivateUse1")
+        autograd_key = "Autograd" + torch._C._dispatch_key_for_device(device_type)
+        if key is None:
+            key = autograd_key
+        elif key != autograd_key:
+            raise NotImplementedError(
+                f"autograd_registration_check: mixed device types with different "
+                f"Autograd dispatch keys are not supported, got {all_device_types}"
+            )
 
     if torch._C._dispatch_has_kernel_for_dispatch_key(op.name(), key):
         return

--- a/torch/testing/_internal/optests/autograd_registration.py
+++ b/torch/testing/_internal/optests/autograd_registration.py
@@ -87,7 +87,6 @@ def autograd_registration_check(op, args, kwargs):
     key = None
     for device_type in all_device_types:
         # torch._C._dispatch_key_for_device maps device type to dispatch key
-        # (e.g. "cuda" -> "CUDA", "npu" -> "PrivateUse1")
         autograd_key = "Autograd" + torch._C._dispatch_key_for_device(device_type)
         if key is None:
             key = autograd_key


### PR DESCRIPTION
## Summary
This PR makes test_attention.py hardware-agnostic by replacing CUDA-specific device count APIs, skip decorators, and RNG seeding with the accelerator-agnostic `torch.accelerator.*` APIs helper. It also fixes `autograd_registration_check` in `torch/testing/_internal/optests/autograd_registration.py` to support PrivateUse1-based out-of-tree backends (e.g., NPU) by removing the hard-coded `{cpu, cuda, xpu}` whitelist and using `torch._C._dispatch_key_for_device()` to dynamically resolve the autograd dispatch key. After these changes, `test_attention.py` runs on any accelerator registered with `torch.accelerator` (CUDA, XPU, HPU, MPS, and PrivateUse1-based backends such as NPU), and `torch.library.opcheck(...)` no longer fails with `NYI devices other than CPU/CUDA/XPU, got {'npu'}` on NPU hosts.

## Changes
Updated `test/distributed/tensor/test_attention.py`:
- Changed `RingAttentionTest.world_size` from `return torch.cuda.device_count()` to `return torch.accelerator.device_count()`, so the test discovers the world size from the current accelerator rather than hard-coding CUDA.
- Replaced the two `torch.cuda.manual_seed(...)` calls (inside `CPFlexAttentionTest._test_cp_flex_attention`, so the RNG is seeded for the current device via the framework's device-agnostic API rather than CUDA exclusively.

Updated `torch/testing/_internal/optests/autograd_registration.py`:
- Replaced the hard-coded device-type whitelist `{"cpu", "cuda", "xpu"}` and the per-device-type if/elif chain that mapped device types to autograd dispatch keys (e.g. `"cuda" -> "AutogradCUDA"`) with a single dynamic lookup based on `torch._C._dispatch_key_for_device(device_type)`. The autograd dispatch key is now constructed as `"Autograd" + torch._C._dispatch_key_for_device(device_type)`, so any device type registered with the dispatcher (including PrivateUse1-based backends such as NPU, which maps to `"PrivateUse1"`) is supported automatically.
- Removed the `raise NotImplementedError("NYI devices other than CPU/CUDA/XPU, got {all_device_types}")` guard, since the new lookup handles arbitrary device types uniformly.
- Added a mixed-device-type guard: if the inputs contain multiple device types that resolve to different autograd dispatch keys (e.g. `{"cpu", "cuda"}` -> `{"AutogradCPU", "AutogradCUDA"}`), the check raises a clear `NotImplementedError` rather than silently picking one key.
- The rest of the check (looking up `Autograd` / `CompositeImplicitAutograd` kernels, running the op under `set_autograd_fallback_mode("nothing")`, asserting outputs do not incorrectly require grad) is unchanged.

## Motivation
`test_attention.py` hard-coded CUDA-specific APIs (`torch.cuda.device_count()`, `torch.cuda.manual_seed`) that silently skipped NPU and other PrivateUse1-based accelerators even when enough devices were available. Similarly, `autograd_registration_check` hard-coded a `{cpu, cuda, xpu}` whitelist and raised `NYI devices other than CPU/CUDA/XPU, got {'npu'}` on NPU, blocking `torch.library.opcheck(...)` calls in `test_flex_cp_custom_op` and similar tests. Using `torch.accelerator.*` APIs and `torch._C._dispatch_key_for_device()` lets both the test and the opcheck infrastructure adapt to any accelerator supported by PyTorch without enumerating device types in test code.

## Test Plan
Verified on CPU and across multiple accelerator types:
```
python test/distributed/tensor/test_attention.py -v
python test/distributed/tensor/test_attention.py RingAttentionTest -v
python test/distributed/tensor/test_attention.py CPFAttentionTest -v
```

## Notes
- It depends on [PR 193550](https://github.com/pytorch/pytorch/pull/193550) and  [PR187650](https://github.com/pytorch/pytorch/pull/187650)

@wjlFlyer @pjyFight @FuDdd @fffrog @lyriexs666 @jishuangfeng @JamesD18 @JiasenTian