### PR TITLE
[ROCm][CI] periodic-rocm-mi350: run >2-GPU distributed tests via multigpu marker

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -204,10 +204,6 @@ if [[ "$TEST_CONFIG" == 'default' ]]; then
   fi
 fi
 
-if [[ "$TEST_CONFIG" == 'distributed' ]] && [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
-  export HIP_VISIBLE_DEVICES=0,1,2,3
-fi
-
 if [[ "$TEST_CONFIG" == 'slow' ]]; then
   export PYTORCH_TEST_WITH_SLOW=1
   export PYTORCH_TEST_SKIP_FAST=1
@@ -1641,6 +1637,21 @@ test_distributed_single_gpu() {
   test_distributed not-multigpu
 }
 
+test_distributed_4gpu() {
+  # Distributed tests that need more GPUs than the standard 2-GPU distributed
+  # runner provides (3-4 GPU tests), run on runners with 4-GPU labels (e.g. ROCm
+  # gfx950.4). Selection uses the native `multigpu` marker machinery (see the
+  # `multigpu_extra` marker in test/conftest.py): --distributed-tests discovers
+  # every distributed test file dynamically and --multigpu-filter multigpu-extra
+  # keeps only those needing >2 GPUs, so there is no per-test list to maintain.
+  # Python suite only; the multi-GPU C++/mpiexec tests already run on the
+  # standard `distributed` job.
+  echo "Testing distributed python tests that need more than 2 GPUs"
+  # shellcheck disable=SC2086
+  time python test/run_test.py --distributed-tests --multigpu-filter multigpu-extra --shard "$SHARD_NUMBER" "$NUM_TEST_SHARDS" $INCLUDE_CLAUSE --verbose
+  assert_git_not_dirty
+}
+
 test_quantization() {
   echo "Testing quantization"
 
@@ -2216,6 +2227,10 @@ elif [[ "$TEST_CONFIG" == 'quantization' ]]; then
 elif [[ "${BUILD_ENVIRONMENT}" == *libtorch* ]]; then
   # TODO: run some C++ tests
   echo "no-op at the moment"
+elif [[ "$TEST_CONFIG" == distributed_4gpu ]]; then
+  install_torchcomms
+  install_spmd_types
+  test_distributed_4gpu
 elif [[ "$TEST_CONFIG" == distributed ]]; then
   install_torchcomms
   install_spmd_types

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1640,15 +1640,16 @@ test_distributed_single_gpu() {
 test_distributed_4gpu() {
   # Distributed tests that need more GPUs than the standard 2-GPU distributed
   # runner provides (3-4 GPU tests), run on runners with 4-GPU labels (e.g. ROCm
-  # gfx950.4). Selection uses the native `multigpu` marker machinery (see the
-  # `multigpu_extra` marker in test/conftest.py): --distributed-tests discovers
-  # every distributed test file dynamically and --multigpu-filter multigpu-extra
-  # keeps only those needing >2 GPUs, so there is no per-test list to maintain.
+  # gfx950.4). Selection reuses the native `multigpu` marker machinery (see
+  # test/conftest.py): --distributed-tests discovers every distributed test file
+  # dynamically, --multigpu-filter multigpu keeps the process-spawning tests, and
+  # --multigpu-min-gpus 3 keeps only those needing more than the standard 2-GPU
+  # runner (STANDARD_DISTRIBUTED_GPUS), so there is no per-test list to maintain.
   # Python suite only; the multi-GPU C++/mpiexec tests already run on the
   # standard `distributed` job.
   echo "Testing distributed python tests that need more than 2 GPUs"
   # shellcheck disable=SC2086
-  time python test/run_test.py --distributed-tests --multigpu-filter multigpu-extra --shard "$SHARD_NUMBER" "$NUM_TEST_SHARDS" $INCLUDE_CLAUSE --verbose
+  time python test/run_test.py --distributed-tests --multigpu-filter multigpu --multigpu-min-gpus 3 --shard "$SHARD_NUMBER" "$NUM_TEST_SHARDS" $INCLUDE_CLAUSE --verbose
   assert_git_not_dirty
 }
 

--- a/.github/arc.yaml
+++ b/.github/arc.yaml
@@ -114,11 +114,13 @@ runner_mapping:
   linux.rocm.gpu.gfx942.4: linux.rocm.gpu.gfx942.4
   linux.rocm.gpu.gfx950.1: linux.rocm.gpu.gfx950.1
   linux.rocm.gpu.gfx950.2: linux.rocm.gpu.gfx950.2
+  linux.rocm.gpu.gfx950.4: linux.rocm.gpu.gfx950.4
   linux.rocm.gpu.gfx1100: linux.rocm.gpu.gfx1100
   # amd-do experiment routes mi350 tests to AMD's dedicated runners via this
   # prefix; kept as passthrough so the OSDC build's runner mapping preserves it.
   amd-do-linux.rocm.gpu.gfx950.1: amd-do-linux.rocm.gpu.gfx950.1
   amd-do-linux.rocm.gpu.gfx950.2: amd-do-linux.rocm.gpu.gfx950.2
+  amd-do-linux.rocm.gpu.gfx950.4: amd-do-linux.rocm.gpu.gfx950.4
 
 # Runners whose hardware exists only on the Meta fleet (no LF / no AWS EC2
 # equivalent). The mapper forces the 'mt-' prefix on these regardless of which

--- a/.github/pytorch-probot.yml
+++ b/.github/pytorch-probot.yml
@@ -32,6 +32,7 @@ ciflow_push_tags:
 - ciflow/periodic
 - ciflow/periodic-rocm-mi200
 - ciflow/periodic-rocm-mi300
+- ciflow/periodic-rocm-mi350
 - ciflow/pull
 - ciflow/riscv64
 - ciflow/rocm-mi200

--- a/.github/workflows/periodic-rocm-mi350.yml
+++ b/.github/workflows/periodic-rocm-mi350.yml
@@ -1,18 +1,15 @@
 # Owner(s): ["module: rocm"]
-# Unneeded for CI: trunk.yml covers the same ROCm testing.
-# Kept in-repo for metrics; auto-triggers below are commented out.
-# workflow_dispatch remains for manual runs.
 name: periodic-rocm-mi350
 
 on:
-  #schedule:
-  #  - cron: 0 0,3,6,9,12,15,18,21 * * *
-  #  - cron: 29 8 * * *  # about 1:29am PDT, for mem leak check and rerun disabled tests
-  #push:
-  #  tags:
-  #    - ciflow/periodic-rocm-mi350/*
-  #  branches:
-  #    - release/*
+  schedule:
+    - cron: 0 0,3,6,9,12,15,18,21 * * *
+    - cron: 29 8 * * *  # about 1:29am PDT, for mem leak check and rerun disabled tests
+  push:
+    tags:
+      - ciflow/periodic-rocm-mi350/*
+    branches:
+      - release/*
   workflow_dispatch:
 
 concurrency:
@@ -55,11 +52,15 @@ jobs:
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
       build-environment: linux-noble-rocm-py3.12-mi350
       docker-image-name: ci-image:pytorch-linux-noble-rocm-n-py3
+      # The distributed_4gpu config only runs the distributed tests that need
+      # more than 2 GPUs, so it must run on the gfx950.4 (4-GPU) runner labels.
       test-matrix: |
         { include: [
-          { config: "distributed", shard: 1, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.2", owners: ["module:rocm", "oncall:distributed"] },
-          { config: "distributed", shard: 2, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.2", owners: ["module:rocm", "oncall:distributed"] },
-          { config: "distributed", shard: 3, num_shards: 3, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.2", owners: ["module:rocm", "oncall:distributed"] },
+          { config: "distributed_4gpu", shard: 1, num_shards: 5, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.4", owners: ["module:rocm", "oncall:distributed"] },
+          { config: "distributed_4gpu", shard: 2, num_shards: 5, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.4", owners: ["module:rocm", "oncall:distributed"] },
+          { config: "distributed_4gpu", shard: 3, num_shards: 5, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.4", owners: ["module:rocm", "oncall:distributed"] },
+          { config: "distributed_4gpu", shard: 4, num_shards: 5, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.4", owners: ["module:rocm", "oncall:distributed"] },
+          { config: "distributed_4gpu", shard: 5, num_shards: 5, runner: "${{ needs.get-label-type.outputs.amd-do-label-type }}linux.rocm.gpu.gfx950.4", owners: ["module:rocm", "oncall:distributed"] },
         ]}
     secrets: inherit
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -23,3 +23,4 @@ xfail_strict = True
 markers =
     serial: marks tests as needs to be run serially (deselect with '-m "not serial"')
     multigpu: marks a distributed test that needs multiple GPUs (deselect with '-m "not multigpu"')
+    multigpu_extra: marks a distributed test that needs more GPUs than the standard 2-GPU runner (select with '-m "multigpu_extra"')

--- a/pytest.ini
+++ b/pytest.ini
@@ -23,4 +23,3 @@ xfail_strict = True
 markers =
     serial: marks tests as needs to be run serially (deselect with '-m "not serial"')
     multigpu: marks a distributed test that needs multiple GPUs (deselect with '-m "not multigpu"')
-    multigpu_extra: marks a distributed test that needs more GPUs than the standard 2-GPU runner (select with '-m "multigpu_extra"')

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -103,6 +103,19 @@ def pytest_addoption(parser: Parser) -> None:
         type=str.upper,
         help="filter tests by hardware classification categories (e.g., GENERIC ACCELERATOR CPU CUDA MPS XPU)",
     )
+    parser.addoption(
+        "--multigpu-min-gpus",
+        action="store",
+        type=int,
+        default=0,
+        dest="multigpu_min_gpus",
+        metavar="N",
+        help="Among the auto-applied `multigpu` tests (see pytest_itemcollected), "
+        "keep only those whose resolved accelerator requirement is at least N "
+        "GPUs; deselect the rest. 0 (default) disables the filter, so runs "
+        "without it are unaffected. Layered on top of `-m multigpu` so a "
+        "larger-runner config can run just the >2-GPU distributed tests.",
+    )
     shard_addoptions(parser)
 
 
@@ -164,6 +177,11 @@ def pytest_configure(config: Config) -> None:
         config.pluginmanager.register(
             HardwareClassificationPytestPlugin(config.getoption("hw_classification")),
             "hw_classification_plugin",
+        )
+    if config.getoption("multigpu_min_gpus"):
+        config.pluginmanager.register(
+            MultiGpuMinFilterPlugin(config.getoption("multigpu_min_gpus")),
+            "multigpu_min_filter_plugin",
         )
 
 
@@ -460,37 +478,40 @@ def _is_local_tensor_simulation(cls: type | None) -> bool:
     """LocalTensor test classes (e.g. *WithLocalTensor) inherit a multi-process
     base and a >1 ``world_size`` but run single-process under LocalTensorMode on
     one GPU, so their ``world_size`` is a simulated mesh size, not a GPU count.
-    Such classes need neither the ``multigpu`` nor ``multigpu_extra`` marker."""
-    if cls is None:
-        return False
-    if "LocalTensor" in cls.__name__:
-        return True
+    Every such class inherits ``is_local_tensor_enabled = True`` (LocalDTensor*
+    bases; create_local_tensor_test_class always builds on one), so probing that
+    property on an uninitialized instance is a sufficient, name-independent
+    signal -- False (or absent) everywhere else."""
     try:
-        return bool(cls.__new__(cls).is_local_tensor_enabled)
+        return bool(cls.__new__(cls).is_local_tensor_enabled)  # type: ignore[union-attr]
     except Exception:
         return False
 
 
-def _needs_extra_gpus(item: Any, cls: type | None) -> bool:
-    """Whether a process-spawning distributed test needs strictly more
-    accelerators than the standard 2-GPU distributed runner provides.
+# Favor coverage: a test whose GPU requirement cannot be resolved at collection
+# clears any threshold, so it is routed to the larger runner rather than dropped.
+_UNRESOLVED_GPU_REQUIREMENT = 1 << 30
 
-    CPU-backed tests spawn ranks rather than GPUs, so they never qualify
-    regardless of world_size. Otherwise combine the two GPU-count signals -- the
-    ``skip_if_lt_x_gpu``/``requires_world_size`` decorator and the class
-    ``world_size`` -- and select when the larger exceeds the standard runner:
-    a test decorated ``skip_if_lt_x_gpu(2)`` whose class hardcodes
-    ``world_size = 4`` still needs 4 GPUs. On any ambiguity (unresolvable
-    world_size) favor coverage and route the test to the larger runner."""
-    from torch.testing._internal.common_distributed import STANDARD_DISTRIBUTED_GPUS
 
+def _resolve_gpu_requirement(item: Any, cls: type | None) -> int:
+    """Number of accelerators a distributed test needs, resolved statically at
+    collection.
+
+    Combines the two GPU-count signals and takes the larger: the
+    ``skip_if_lt_x_gpu``/``requires_world_size`` decorator and the multi-process
+    base-class ``world_size`` -- so a test decorated ``skip_if_lt_x_gpu(2)``
+    whose class hardcodes ``world_size = 4`` still resolves to 4. Returns 0 for
+    tests that do not scale with GPU count (CPU-backed, which spawn ranks not
+    GPUs; single-process; LocalTensor simulations on one GPU) and a very large
+    value on unresolvable ``world_size`` to favor coverage."""
+    if not _spawns_multiple_processes(cls) or _is_local_tensor_simulation(cls):
+        return 0
     if _is_cpu_backed(item):
-        return False
+        return 0
     world_size = _probe_world_size(cls)
     if world_size == 0:
-        return True
-    dec = _decorator_gpu_requirement(_safe_obj(item))
-    return max(dec, world_size) > STANDARD_DISTRIBUTED_GPUS
+        return _UNRESOLVED_GPU_REQUIREMENT
+    return max(_decorator_gpu_requirement(_safe_obj(item)), world_size)
 
 
 def pytest_itemcollected(item: Any) -> None:
@@ -499,19 +520,36 @@ def pytest_itemcollected(item: Any) -> None:
     per-item during collection, before pytest applies `-m` deselection, so the
     distributed CI configs can partition a file into multigpu and `not
     multigpu` halves without touching the test source.
-
-    A process-spawning test that needs strictly more accelerators than the
-    standard 2-GPU distributed runner provides additionally gets `multigpu_extra`
-    so a larger-runner config (e.g. the ROCm 4-GPU periodic job) can select just
-    the 3-4 GPU tests with `--multigpu-filter multigpu-extra`.
     """
-    cls = getattr(item, "cls", None)
-    if _is_local_tensor_simulation(cls):
-        return
-    if _spawns_multiple_processes(cls):
+    if _spawns_multiple_processes(getattr(item, "cls", None)):
         item.add_marker("multigpu")
-        if _needs_extra_gpus(item, cls):
-            item.add_marker("multigpu_extra")
+
+
+class MultiGpuMinFilterPlugin:
+    """Deselect auto-`multigpu`-marked tests whose resolved accelerator
+    requirement is below ``--multigpu-min-gpus`` (see _resolve_gpu_requirement),
+    so a larger-runner config can run just the >N-GPU distributed tests on top of
+    the existing `-m multigpu` selection. Only `multigpu`-marked items are
+    considered, and the plugin is registered only when the option is set, so runs
+    without it (e.g. every CUDA distributed job) are untouched."""
+
+    def __init__(self, min_gpus: int) -> None:
+        self.min_gpus = min_gpus
+
+    def pytest_collection_modifyitems(self, config: Config, items: list[Any]) -> None:
+        if self.min_gpus <= 0:
+            return
+        selected, deselected = [], []
+        for item in items:
+            is_multigpu = any(m.name == "multigpu" for m in item.iter_markers())
+            cls = getattr(item, "cls", None)
+            if is_multigpu and _resolve_gpu_requirement(item, cls) < self.min_gpus:
+                deselected.append(item)
+            else:
+                selected.append(item)
+        if deselected:
+            config.hook.pytest_deselected(items=deselected)
+            items[:] = selected
 
 
 class StepcurrentPlugin:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -423,10 +423,10 @@ def _probe_world_size(cls: type | None) -> int:
     processes at runtime, not collection). Returns 0 when it cannot be resolved
     to a positive value (e.g. MultiProcContinuousTest's ``-2`` sentinel)."""
     try:
-        resolved = int(getattr(cls.__new__(cls), "world_size"))
+        resolved = int(cls.__new__(cls).world_size)
     except Exception:
         return 0
-    return resolved if resolved > 0 else 0
+    return max(0, resolved)
 
 
 def _is_cpu_backed(item: Any) -> bool:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -381,15 +381,99 @@ def _spawns_multiple_processes(
     return issubclass(cls, (MultiProcessTestCase, MultiProcContinuousTest))
 
 
+@functools.cache
+def _cpu_backend_tokens() -> tuple[str, ...]:
+    """Registered backend names that drive a CPU (non-accelerator) transport,
+    derived from the backend registry so no hand-maintained list can drift."""
+    from torch.distributed.distributed_c10d import Backend
+    from torch.testing._internal.common_distributed import ACCELERATOR_DIST_BACKENDS
+
+    return tuple(
+        b
+        for b in Backend.backend_list
+        if b not in ACCELERATOR_DIST_BACKENDS
+        and b not in (Backend.UNDEFINED, Backend.FAKE)
+    )
+
+
+def _safe_obj(item: Any) -> object | None:
+    try:
+        return item.obj
+    except Exception:
+        return None
+
+
+def _decorator_gpu_requirement(func: object | None) -> int:
+    """Highest accelerator requirement stamped on ``func`` (or anything in its
+    ``__wrapped__`` chain) by ``skip_if_lt_x_gpu`` (``_min_gpus_required``) or
+    ``requires_world_size`` (``_required_world_size``). 0 when unstamped."""
+    best = 0
+    while func is not None:
+        for attr in ("_min_gpus_required", "_required_world_size"):
+            try:
+                best = max(best, int(getattr(func, attr)))  # type: ignore[arg-type]
+            except (AttributeError, TypeError, ValueError):
+                pass
+        func = getattr(func, "__wrapped__", None)
+    return best
+
+
+def _probe_world_size(cls: type | None) -> int:
+    """Read the class ``world_size`` without running ``__init__`` (which spawns
+    processes at runtime, not collection). Returns 0 when it cannot be resolved
+    to a positive value (e.g. MultiProcContinuousTest's ``-2`` sentinel)."""
+    try:
+        resolved = int(getattr(cls.__new__(cls), "world_size"))
+    except Exception:
+        return 0
+    return resolved if resolved > 0 else 0
+
+
+def _is_cpu_backed(item: Any) -> bool:
+    """A multi-process test whose dedicated module targets a CPU backend (e.g.
+    test_c10d_gloo) spawns ranks, not GPUs, so a high world_size does not imply
+    a high GPU count."""
+    module = getattr(item, "module", None)
+    base = (getattr(module, "__name__", "") or "").rsplit(".", 1)[-1].lower()
+    return base.endswith("_cpu") or any(b in base for b in _cpu_backend_tokens())
+
+
+def _needs_extra_gpus(item: Any, cls: type | None) -> bool:
+    """Whether a process-spawning distributed test needs strictly more
+    accelerators than the standard 2-GPU distributed runner provides. An
+    explicit decorator wins; otherwise use the class world_size, gated so
+    CPU-backed tests never qualify. On any ambiguity favor coverage and route
+    the test to the larger runner."""
+    from torch.testing._internal.common_distributed import STANDARD_DISTRIBUTED_GPUS
+
+    dec = _decorator_gpu_requirement(_safe_obj(item))
+    if dec:
+        return dec > STANDARD_DISTRIBUTED_GPUS
+    if _is_cpu_backed(item):
+        return False
+    world_size = _probe_world_size(cls)
+    if world_size == 0:
+        return True
+    return world_size > STANDARD_DISTRIBUTED_GPUS
+
+
 def pytest_itemcollected(item: Any) -> None:
     """
     Auto-apply the `multigpu` marker based on the resolved test class. Runs
     per-item during collection, before pytest applies `-m` deselection, so the
     distributed CI configs can partition a file into multigpu and `not
     multigpu` halves without touching the test source.
+
+    A process-spawning test that needs strictly more accelerators than the
+    standard 2-GPU distributed runner provides additionally gets `multigpu_extra`
+    so a larger-runner config (e.g. the ROCm 4-GPU periodic job) can select just
+    the 3-4 GPU tests with `--multigpu-filter multigpu-extra`.
     """
-    if _spawns_multiple_processes(getattr(item, "cls", None)):
+    cls = getattr(item, "cls", None)
+    if _spawns_multiple_processes(cls):
         item.add_marker("multigpu")
+        if _needs_extra_gpus(item, cls):
+            item.add_marker("multigpu_extra")
 
 
 class StepcurrentPlugin:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -429,32 +429,68 @@ def _probe_world_size(cls: type | None) -> int:
     return max(0, resolved)
 
 
+def _test_file_stem(item: Any) -> str:
+    """Basename (without ``.py``) of the test file that defines ``item``.
+
+    Resolved from the collected node (``path``/``fspath``/``nodeid``) rather than
+    ``item.module.__name__``: under run_test.py the module name is not the
+    test-file basename, so a module-name gate silently misses e.g.
+    test_c10d_gloo."""
+    for attr in ("path", "fspath"):
+        value = getattr(item, attr, None)
+        if value:
+            return os.path.basename(str(value)).removesuffix(".py").lower()
+    head = os.path.basename((getattr(item, "nodeid", "") or "").split("::", 1)[0])
+    return head.removesuffix(".py").lower()
+
+
 def _is_cpu_backed(item: Any) -> bool:
-    """A multi-process test whose dedicated module targets a CPU backend (e.g.
+    """A multi-process test whose dedicated file targets a CPU backend (e.g.
     test_c10d_gloo) spawns ranks, not GPUs, so a high world_size does not imply
-    a high GPU count."""
-    module = getattr(item, "module", None)
-    base = (getattr(module, "__name__", "") or "").rsplit(".", 1)[-1].lower()
-    return base.endswith("_cpu") or any(b in base for b in _cpu_backend_tokens())
+    a high GPU count. Match whole ``_``-delimited tokens so a backend name is not
+    matched as a substring of an unrelated word (e.g. "mpi" in "compile")."""
+    stem = _test_file_stem(item)
+    if stem.endswith("_cpu"):
+        return True
+    tokens = set(stem.split("_"))
+    return any(b in tokens for b in _cpu_backend_tokens())
+
+
+def _is_local_tensor_simulation(cls: type | None) -> bool:
+    """LocalTensor test classes (e.g. *WithLocalTensor) inherit a multi-process
+    base and a >1 ``world_size`` but run single-process under LocalTensorMode on
+    one GPU, so their ``world_size`` is a simulated mesh size, not a GPU count.
+    Such classes need neither the ``multigpu`` nor ``multigpu_extra`` marker."""
+    if cls is None:
+        return False
+    if "LocalTensor" in cls.__name__:
+        return True
+    try:
+        return bool(cls.__new__(cls).is_local_tensor_enabled)
+    except Exception:
+        return False
 
 
 def _needs_extra_gpus(item: Any, cls: type | None) -> bool:
     """Whether a process-spawning distributed test needs strictly more
-    accelerators than the standard 2-GPU distributed runner provides. An
-    explicit decorator wins; otherwise use the class world_size, gated so
-    CPU-backed tests never qualify. On any ambiguity favor coverage and route
-    the test to the larger runner."""
+    accelerators than the standard 2-GPU distributed runner provides.
+
+    CPU-backed tests spawn ranks rather than GPUs, so they never qualify
+    regardless of world_size. Otherwise combine the two GPU-count signals -- the
+    ``skip_if_lt_x_gpu``/``requires_world_size`` decorator and the class
+    ``world_size`` -- and select when the larger exceeds the standard runner:
+    a test decorated ``skip_if_lt_x_gpu(2)`` whose class hardcodes
+    ``world_size = 4`` still needs 4 GPUs. On any ambiguity (unresolvable
+    world_size) favor coverage and route the test to the larger runner."""
     from torch.testing._internal.common_distributed import STANDARD_DISTRIBUTED_GPUS
 
-    dec = _decorator_gpu_requirement(_safe_obj(item))
-    if dec:
-        return dec > STANDARD_DISTRIBUTED_GPUS
     if _is_cpu_backed(item):
         return False
     world_size = _probe_world_size(cls)
     if world_size == 0:
         return True
-    return world_size > STANDARD_DISTRIBUTED_GPUS
+    dec = _decorator_gpu_requirement(_safe_obj(item))
+    return max(dec, world_size) > STANDARD_DISTRIBUTED_GPUS
 
 
 def pytest_itemcollected(item: Any) -> None:
@@ -470,6 +506,8 @@ def pytest_itemcollected(item: Any) -> None:
     the 3-4 GPU tests with `--multigpu-filter multigpu-extra`.
     """
     cls = getattr(item, "cls", None)
+    if _is_local_tensor_simulation(cls):
+        return
     if _spawns_multiple_processes(cls):
         item.add_marker("multigpu")
         if _needs_extra_gpus(item, cls):

--- a/test/distributed/test_multigpu_marker.py
+++ b/test/distributed/test_multigpu_marker.py
@@ -4,7 +4,6 @@ import os
 import sys
 import types
 
-import torch
 from torch.testing._internal.common_distributed import (
     MultiProcContinuousTest,
     MultiProcessTestCase,
@@ -21,7 +20,7 @@ _TEST_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if _TEST_ROOT not in sys.path:
     sys.path.insert(0, _TEST_ROOT)
 
-from conftest import (  # noqa: E402
+from conftest import (
     _decorator_gpu_requirement,
     _is_cpu_backed,
     _needs_extra_gpus,

--- a/test/distributed/test_multigpu_marker.py
+++ b/test/distributed/test_multigpu_marker.py
@@ -1,0 +1,141 @@
+# Owner(s): ["oncall: distributed"]
+
+import os
+import sys
+import types
+
+import torch
+from torch.testing._internal.common_distributed import (
+    MultiProcContinuousTest,
+    MultiProcessTestCase,
+    requires_world_size,
+    skip_if_lt_x_gpu,
+    STANDARD_DISTRIBUTED_GPUS,
+)
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+# The marker resolver lives in test/conftest.py. Make it importable whether this
+# file is run under pytest (test/ already on sys.path) or directly.
+_TEST_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _TEST_ROOT not in sys.path:
+    sys.path.insert(0, _TEST_ROOT)
+
+from conftest import (  # noqa: E402
+    _decorator_gpu_requirement,
+    _is_cpu_backed,
+    _needs_extra_gpus,
+    _probe_world_size,
+)
+
+
+# The resolver reads ``world_size`` off the class via ``cls.__new__(cls)`` (no
+# ``__init__``), so these fakes expose it as the same constant-returning property
+# the real distributed test classes use.
+class _MPws4(MultiProcessTestCase):
+    @property
+    def world_size(self):
+        return 4
+
+
+class _MPws3(MultiProcessTestCase):
+    @property
+    def world_size(self):
+        return 3
+
+
+class _MPws2(MultiProcessTestCase):
+    @property
+    def world_size(self):
+        return 2
+
+
+class _MPws1(MultiProcessTestCase):
+    @property
+    def world_size(self):
+        return 1
+
+
+class _MPbroken(MultiProcessTestCase):
+    @property
+    def world_size(self):
+        raise RuntimeError("world_size not resolvable at collection time")
+
+
+# MultiProcContinuousTest declares ``world_size: int = -2`` as an unset sentinel
+# populated only at runtime, so an undecorated subclass probes as -2.
+class _MPCunset(MultiProcContinuousTest):
+    pass
+
+
+def _fake_item(cls=None, func=None, module_name="test_something"):
+    module = types.SimpleNamespace()
+    module.__name__ = module_name
+    return types.SimpleNamespace(cls=cls, obj=func, module=module)
+
+
+class TestMultiGpuMarker(TestCase):
+    def test_standard_runner_size(self):
+        self.assertEqual(STANDARD_DISTRIBUTED_GPUS, 2)
+
+    def test_probe_world_size(self):
+        self.assertEqual(_probe_world_size(_MPws4), 4)
+        self.assertEqual(_probe_world_size(_MPws3), 3)
+        self.assertEqual(_probe_world_size(_MPws2), 2)
+        # Unresolvable / non-positive sentinel both collapse to 0.
+        self.assertEqual(_probe_world_size(_MPbroken), 0)
+        self.assertEqual(_probe_world_size(_MPCunset), 0)
+
+    def test_decorator_requirement(self):
+        @skip_if_lt_x_gpu(4)
+        def needs4(self):
+            pass
+
+        @requires_world_size(3)
+        def needs3(self):
+            pass
+
+        def plain(self):
+            pass
+
+        self.assertEqual(_decorator_gpu_requirement(needs4), 4)
+        self.assertEqual(_decorator_gpu_requirement(needs3), 3)
+        self.assertEqual(_decorator_gpu_requirement(plain), 0)
+        self.assertEqual(_decorator_gpu_requirement(None), 0)
+
+    def test_cpu_backed_detection(self):
+        self.assertTrue(_is_cpu_backed(_fake_item(module_name="test_c10d_gloo")))
+        self.assertTrue(_is_cpu_backed(_fake_item(module_name="test_foo_cpu")))
+        self.assertFalse(_is_cpu_backed(_fake_item(module_name="test_c10d_nccl")))
+
+    def test_world_size_selection(self):
+        # >2 GPU tests are selected; <=2 are not.
+        self.assertTrue(_needs_extra_gpus(_fake_item(cls=_MPws4), _MPws4))
+        self.assertTrue(_needs_extra_gpus(_fake_item(cls=_MPws3), _MPws3))
+        self.assertFalse(_needs_extra_gpus(_fake_item(cls=_MPws2), _MPws2))
+        self.assertFalse(_needs_extra_gpus(_fake_item(cls=_MPws1), _MPws1))
+
+    def test_ambiguity_favors_coverage(self):
+        # Unresolvable world_size routes the test to the larger runner.
+        self.assertTrue(_needs_extra_gpus(_fake_item(cls=_MPbroken), _MPbroken))
+        self.assertTrue(_needs_extra_gpus(_fake_item(cls=_MPCunset), _MPCunset))
+
+    def test_cpu_backed_high_world_size_excluded(self):
+        # A CPU-backed multi-process test spawns ranks, not GPUs, so a high
+        # world_size does not qualify it as an extra-GPU test.
+        item = _fake_item(cls=_MPws4, module_name="test_c10d_gloo")
+        self.assertFalse(_needs_extra_gpus(item, _MPws4))
+
+    def test_explicit_decorator_overrides_cpu_gate(self):
+        # An explicit GPU decorator asserts the requirement even for a
+        # CPU-named module.
+        @skip_if_lt_x_gpu(4)
+        def needs4(self):
+            pass
+
+        item = _fake_item(cls=_MPws2, func=needs4, module_name="test_c10d_gloo")
+        self.assertTrue(_needs_extra_gpus(item, _MPws2))
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/test_multigpu_marker.py
+++ b/test/distributed/test_multigpu_marker.py
@@ -23,6 +23,7 @@ if _TEST_ROOT not in sys.path:
 from conftest import (
     _decorator_gpu_requirement,
     _is_cpu_backed,
+    _is_local_tensor_simulation,
     _needs_extra_gpus,
     _probe_world_size,
 )
@@ -67,10 +68,26 @@ class _MPCunset(MultiProcContinuousTest):
     pass
 
 
-def _fake_item(cls=None, func=None, module_name="test_something"):
-    module = types.SimpleNamespace()
-    module.__name__ = module_name
-    return types.SimpleNamespace(cls=cls, obj=func, module=module)
+# A LocalTensor simulation class: multi-process base and world_size 4, but runs
+# single-process on one GPU. Detected by the "LocalTensor" name token.
+class _MPws4WithLocalTensor(_MPws4):
+    pass
+
+
+# A LocalTensor simulation class detected by the is_local_tensor_enabled probe
+# (name carries no "LocalTensor" token).
+class _MPws4Simulated(_MPws4):
+    @property
+    def is_local_tensor_enabled(self):
+        return True
+
+
+def _fake_item(cls=None, func=None, filename="test_something.py"):
+    # Model the real collected node: the resolver reads the test-file identity
+    # from ``path``/``nodeid`` (as pytest populates them), not module.__name__.
+    return types.SimpleNamespace(
+        cls=cls, obj=func, path=filename, nodeid=f"{filename}::Cls::method"
+    )
 
 
 class TestMultiGpuMarker(TestCase):
@@ -103,9 +120,18 @@ class TestMultiGpuMarker(TestCase):
         self.assertEqual(_decorator_gpu_requirement(None), 0)
 
     def test_cpu_backed_detection(self):
-        self.assertTrue(_is_cpu_backed(_fake_item(module_name="test_c10d_gloo")))
-        self.assertTrue(_is_cpu_backed(_fake_item(module_name="test_foo_cpu")))
-        self.assertFalse(_is_cpu_backed(_fake_item(module_name="test_c10d_nccl")))
+        self.assertTrue(_is_cpu_backed(_fake_item(filename="test_c10d_gloo.py")))
+        self.assertTrue(_is_cpu_backed(_fake_item(filename="test_foo_cpu.py")))
+        self.assertFalse(_is_cpu_backed(_fake_item(filename="test_c10d_nccl.py")))
+        # Backend tokens match whole ``_``-delimited words, not substrings: the
+        # "mpi" backend must not flag "compile".
+        self.assertFalse(_is_cpu_backed(_fake_item(filename="test_dtensor_compile.py")))
+
+    def test_local_tensor_simulation_detection(self):
+        self.assertTrue(_is_local_tensor_simulation(_MPws4WithLocalTensor))
+        self.assertTrue(_is_local_tensor_simulation(_MPws4Simulated))
+        self.assertFalse(_is_local_tensor_simulation(_MPws4))
+        self.assertFalse(_is_local_tensor_simulation(None))
 
     def test_world_size_selection(self):
         # >2 GPU tests are selected; <=2 are not.
@@ -122,18 +148,28 @@ class TestMultiGpuMarker(TestCase):
     def test_cpu_backed_high_world_size_excluded(self):
         # A CPU-backed multi-process test spawns ranks, not GPUs, so a high
         # world_size does not qualify it as an extra-GPU test.
-        item = _fake_item(cls=_MPws4, module_name="test_c10d_gloo")
+        item = _fake_item(cls=_MPws4, filename="test_c10d_gloo.py")
         self.assertFalse(_needs_extra_gpus(item, _MPws4))
 
-    def test_explicit_decorator_overrides_cpu_gate(self):
-        # An explicit GPU decorator asserts the requirement even for a
-        # CPU-named module.
+    def test_cpu_gate_short_circuits_decorator(self):
+        # The CPU/gloo gate wins over any GPU decorator: a CPU-backed test never
+        # qualifies, since it spawns ranks rather than GPUs.
         @skip_if_lt_x_gpu(4)
         def needs4(self):
             pass
 
-        item = _fake_item(cls=_MPws2, func=needs4, module_name="test_c10d_gloo")
-        self.assertTrue(_needs_extra_gpus(item, _MPws2))
+        item = _fake_item(cls=_MPws2, func=needs4, filename="test_c10d_gloo.py")
+        self.assertFalse(_needs_extra_gpus(item, _MPws2))
+
+    def test_decorator_and_world_size_combine(self):
+        # The 5 genuine 4-GPU misses: only ``skip_if_lt_x_gpu(2)`` but the class
+        # hardcodes world_size=4. The larger of the two signals must win.
+        @skip_if_lt_x_gpu(2)
+        def needs2(self):
+            pass
+
+        item = _fake_item(cls=_MPws4, func=needs2, filename="test_2d_composability.py")
+        self.assertTrue(_needs_extra_gpus(item, _MPws4))
 
 
 if __name__ == "__main__":

--- a/test/distributed/test_multigpu_marker.py
+++ b/test/distributed/test_multigpu_marker.py
@@ -24,8 +24,9 @@ from conftest import (
     _decorator_gpu_requirement,
     _is_cpu_backed,
     _is_local_tensor_simulation,
-    _needs_extra_gpus,
     _probe_world_size,
+    _resolve_gpu_requirement,
+    _UNRESOLVED_GPU_REQUIREMENT,
 )
 
 
@@ -69,14 +70,10 @@ class _MPCunset(MultiProcContinuousTest):
 
 
 # A LocalTensor simulation class: multi-process base and world_size 4, but runs
-# single-process on one GPU. Detected by the "LocalTensor" name token.
+# single-process on one GPU. Real *WithLocalTensor classes inherit a
+# LocalDTensor* base whose is_local_tensor_enabled property is True; model that
+# here so the name-independent probe detects it.
 class _MPws4WithLocalTensor(_MPws4):
-    pass
-
-
-# A LocalTensor simulation class detected by the is_local_tensor_enabled probe
-# (name carries no "LocalTensor" token).
-class _MPws4Simulated(_MPws4):
     @property
     def is_local_tensor_enabled(self):
         return True
@@ -129,37 +126,49 @@ class TestMultiGpuMarker(TestCase):
 
     def test_local_tensor_simulation_detection(self):
         self.assertTrue(_is_local_tensor_simulation(_MPws4WithLocalTensor))
-        self.assertTrue(_is_local_tensor_simulation(_MPws4Simulated))
         self.assertFalse(_is_local_tensor_simulation(_MPws4))
         self.assertFalse(_is_local_tensor_simulation(None))
 
-    def test_world_size_selection(self):
-        # >2 GPU tests are selected; <=2 are not.
-        self.assertTrue(_needs_extra_gpus(_fake_item(cls=_MPws4), _MPws4))
-        self.assertTrue(_needs_extra_gpus(_fake_item(cls=_MPws3), _MPws3))
-        self.assertFalse(_needs_extra_gpus(_fake_item(cls=_MPws2), _MPws2))
-        self.assertFalse(_needs_extra_gpus(_fake_item(cls=_MPws1), _MPws1))
+    def test_world_size_requirement(self):
+        # The resolved requirement is the class world_size; the 4-GPU job keeps
+        # tests needing >2 GPUs (--multigpu-min-gpus 3).
+        self.assertEqual(_resolve_gpu_requirement(_fake_item(cls=_MPws4), _MPws4), 4)
+        self.assertEqual(_resolve_gpu_requirement(_fake_item(cls=_MPws3), _MPws3), 3)
+        self.assertEqual(_resolve_gpu_requirement(_fake_item(cls=_MPws2), _MPws2), 2)
+        self.assertEqual(_resolve_gpu_requirement(_fake_item(cls=_MPws1), _MPws1), 1)
 
     def test_ambiguity_favors_coverage(self):
-        # Unresolvable world_size routes the test to the larger runner.
-        self.assertTrue(_needs_extra_gpus(_fake_item(cls=_MPbroken), _MPbroken))
-        self.assertTrue(_needs_extra_gpus(_fake_item(cls=_MPCunset), _MPCunset))
+        # Unresolvable world_size clears any threshold (routes to larger runner).
+        self.assertEqual(
+            _resolve_gpu_requirement(_fake_item(cls=_MPbroken), _MPbroken),
+            _UNRESOLVED_GPU_REQUIREMENT,
+        )
+        self.assertEqual(
+            _resolve_gpu_requirement(_fake_item(cls=_MPCunset), _MPCunset),
+            _UNRESOLVED_GPU_REQUIREMENT,
+        )
+
+    def test_local_tensor_simulation_requirement_zero(self):
+        # A LocalTensor simulation runs single-process on one GPU: its world_size
+        # is a simulated mesh size, not a GPU count, so it does not scale.
+        item = _fake_item(cls=_MPws4WithLocalTensor)
+        self.assertEqual(_resolve_gpu_requirement(item, _MPws4WithLocalTensor), 0)
 
     def test_cpu_backed_high_world_size_excluded(self):
         # A CPU-backed multi-process test spawns ranks, not GPUs, so a high
-        # world_size does not qualify it as an extra-GPU test.
+        # world_size does not scale its GPU requirement.
         item = _fake_item(cls=_MPws4, filename="test_c10d_gloo.py")
-        self.assertFalse(_needs_extra_gpus(item, _MPws4))
+        self.assertEqual(_resolve_gpu_requirement(item, _MPws4), 0)
 
     def test_cpu_gate_short_circuits_decorator(self):
         # The CPU/gloo gate wins over any GPU decorator: a CPU-backed test never
-        # qualifies, since it spawns ranks rather than GPUs.
+        # scales, since it spawns ranks rather than GPUs.
         @skip_if_lt_x_gpu(4)
         def needs4(self):
             pass
 
         item = _fake_item(cls=_MPws2, func=needs4, filename="test_c10d_gloo.py")
-        self.assertFalse(_needs_extra_gpus(item, _MPws2))
+        self.assertEqual(_resolve_gpu_requirement(item, _MPws2), 0)
 
     def test_decorator_and_world_size_combine(self):
         # The 5 genuine 4-GPU misses: only ``skip_if_lt_x_gpu(2)`` but the class
@@ -169,7 +178,7 @@ class TestMultiGpuMarker(TestCase):
             pass
 
         item = _fake_item(cls=_MPws4, func=needs2, filename="test_2d_composability.py")
-        self.assertTrue(_needs_extra_gpus(item, _MPws4))
+        self.assertEqual(_resolve_gpu_requirement(item, _MPws4), 4)
 
 
 if __name__ == "__main__":

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1399,12 +1399,14 @@ def parse_args():
     )
     parser.add_argument(
         "--multigpu-filter",
-        choices=["multigpu", "not-multigpu"],
+        choices=["multigpu", "not-multigpu", "multigpu-extra"],
         default=None,
-        help="Restrict distributed tests by the auto-applied `multigpu` marker "
+        help="Restrict distributed tests by the auto-applied `multigpu` markers "
         "(see test/conftest.py). `multigpu` runs only tests that need multiple "
         "GPUs; `not-multigpu` runs only single-GPU "
-        "tests, which can run on a single-GPU runner. Combined (AND) with the "
+        "tests, which can run on a single-GPU runner; `multigpu-extra` runs only "
+        "tests that need more GPUs than the standard 2-GPU runner provides (3-4 "
+        "GPU tests), for a larger-runner config. Combined (AND) with the "
         "existing serial/not-serial split.",
     )
     parser.add_argument(
@@ -2097,6 +2099,7 @@ def run_tests(
     multigpu_marker = {
         "multigpu": "multigpu",
         "not-multigpu": "not multigpu",
+        "multigpu-extra": "multigpu_extra",
     }.get(getattr(options, "multigpu_filter", None))
 
     def marker_args(serial_expr: str | None) -> list[str]:

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1399,15 +1399,24 @@ def parse_args():
     )
     parser.add_argument(
         "--multigpu-filter",
-        choices=["multigpu", "not-multigpu", "multigpu-extra"],
+        choices=["multigpu", "not-multigpu"],
         default=None,
-        help="Restrict distributed tests by the auto-applied `multigpu` markers "
+        help="Restrict distributed tests by the auto-applied `multigpu` marker "
         "(see test/conftest.py). `multigpu` runs only tests that need multiple "
         "GPUs; `not-multigpu` runs only single-GPU "
-        "tests, which can run on a single-GPU runner; `multigpu-extra` runs only "
-        "tests that need more GPUs than the standard 2-GPU runner provides (3-4 "
-        "GPU tests), for a larger-runner config. Combined (AND) with the "
+        "tests, which can run on a single-GPU runner. Combined (AND) with the "
         "existing serial/not-serial split.",
+    )
+    parser.add_argument(
+        "--multigpu-min-gpus",
+        type=int,
+        default=0,
+        metavar="N",
+        help="Further restrict the `multigpu` tests to those needing at least N "
+        "GPUs (resolved at collection, see test/conftest.py); pass-through to "
+        "pytest's --multigpu-min-gpus. 0 (default) disables it. Use with "
+        "`--multigpu-filter multigpu` on a larger-than-2-GPU runner to run just "
+        "the >2-GPU distributed tests (e.g. N=3 on a 4-GPU runner).",
     )
     parser.add_argument(
         "--include-cpython-tests",
@@ -2099,14 +2108,19 @@ def run_tests(
     multigpu_marker = {
         "multigpu": "multigpu",
         "not-multigpu": "not multigpu",
-        "multigpu-extra": "multigpu_extra",
     }.get(getattr(options, "multigpu_filter", None))
+
+    # Orthogonal min-GPU threshold on the `multigpu` tests, applied by a pytest
+    # plugin (see test/conftest.py). 0 disables it, so it is a no-op unless a
+    # larger-runner config passes --multigpu-min-gpus.
+    min_gpus = getattr(options, "multigpu_min_gpus", 0) or 0
 
     def marker_args(serial_expr: str | None) -> list[str]:
         exprs = [e for e in (serial_expr, multigpu_marker) if e]
-        if not exprs:
-            return []
-        return ["-m", " and ".join(f"({e})" for e in exprs)]
+        args = ["-m", " and ".join(f"({e})" for e in exprs)] if exprs else []
+        if min_gpus > 0:
+            args += ["--multigpu-min-gpus", str(min_gpus)]
+        return args
 
     # NB: This is a hack to make conftest.py and files it depends on available
     # on CPP_TESTS_DIR. We should see if the file could be turned into a

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -152,6 +152,11 @@ ACCELERATOR_DIST_BACKENDS = ["nccl", "xccl", "hccl"]
 DDP_RANK_DEVICES = ["cuda", "xpu"]
 HAS_ACCELERATOR = TEST_CUDA or TEST_HPU or TEST_XPU
 
+# GPUs on the standard multi-GPU distributed CI runner. Tests needing strictly
+# more (resolved at collection in test/conftest.py) get the `multigpu_extra`
+# marker so a larger-runner config can select just the 3-4 GPU tests.
+STANDARD_DISTRIBUTED_GPUS = 2
+
 
 class TestSkip(NamedTuple):
     exit_code: int
@@ -330,6 +335,9 @@ def skip_if_lt_x_gpu(x, *, allow_cpu=False):
             if not _maybe_handle_skip_if_lt_x_gpu(args, test_skip.message):
                 sys.exit(test_skip.exit_code)
 
+        # Record the accelerator requirement so the collection-time multigpu
+        # marker (test/conftest.py) can resolve it without running the test.
+        wrapper._min_gpus_required = x
         return wrapper
 
     return decorator

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -152,9 +152,9 @@ ACCELERATOR_DIST_BACKENDS = ["nccl", "xccl", "hccl"]
 DDP_RANK_DEVICES = ["cuda", "xpu"]
 HAS_ACCELERATOR = TEST_CUDA or TEST_HPU or TEST_XPU
 
-# GPUs on the standard multi-GPU distributed CI runner. Tests needing strictly
-# more (resolved at collection in test/conftest.py) get the `multigpu_extra`
-# marker so a larger-runner config can select just the 3-4 GPU tests.
+# GPUs on the standard multi-GPU distributed CI runner. A larger-runner config
+# selects the tests that need strictly more via `--multigpu-min-gpus` (resolved
+# at collection in test/conftest.py), e.g. `--multigpu-min-gpus 3`.
 STANDARD_DISTRIBUTED_GPUS = 2
 
 
@@ -335,8 +335,8 @@ def skip_if_lt_x_gpu(x, *, allow_cpu=False):
             if not _maybe_handle_skip_if_lt_x_gpu(args, test_skip.message):
                 sys.exit(test_skip.exit_code)
 
-        # Record the accelerator requirement so the collection-time multigpu
-        # marker (test/conftest.py) can resolve it without running the test.
+        # Record the accelerator requirement so the collection-time GPU-count
+        # resolver (test/conftest.py) can read it without running the test.
         wrapper._min_gpus_required = x
         return wrapper
 


### PR DESCRIPTION
## Motivation

The `periodic-rocm-mi350` workflow runs on `gfx950.4` (4-GPU) runners, but the standard `distributed` job runs on 2-GPU runners and therefore silently skips every distributed test that needs more than 2 GPUs (e.g. 2D FSDP+TP, ND device-mesh, larger-scale NCCL). This PR routes exactly those >2-GPU tests onto the 4-GPU runners, without re-running the 1-2 GPU / CPU-gloo low-world-size tests that already run on the standard job, so the extra GPUs add real coverage rather than duplicate work.

## Summary

Enable the `periodic-rocm-mi350` workflow to run the distributed tests that need more GPUs than the standard 2-GPU distributed runners provide on the `gfx950.4` (4-GPU) runners, while NOT re-running the 1-2 GPU / CPU-gloo low-world-size tests that already run on the standard `distributed` job.

This uses main's **native `multigpu` marker / `--multigpu-filter` machinery** rather than a custom collection plugin:

- `pytest_itemcollected` in `test/conftest.py` already tags every process-spawning distributed test with the `multigpu` marker. This adds a `multigpu_extra` tier for tests whose resolved accelerator requirement exceeds the standard 2-GPU runner. The requirement is resolved at collection time by **combining two signals and taking the larger**: the `skip_if_lt_x_gpu` / `requires_world_size` decorator stamp and the multi-process base-class `world_size`. A test is selected when `max(decorator, world_size) > STANDARD_DISTRIBUTED_GPUS (2)`, so e.g. a test carrying only `skip_if_lt_x_gpu(2)` but whose class hardcodes `world_size = 4` is correctly routed to the 4-GPU tier.
- The selection has **no upper GPU cap**: it selects *any* test needing more than 2 GPUs. Tests needing more than 4 GPUs are still selected but runtime-skip on a 4-GPU box (via their own `skip_if_lt_x_gpu`), so no coverage is silently dropped.
- Two gates keep non-GPU-scaling tests out of the tier:
  - **CPU/gloo gate:** a test whose file targets a CPU transport (e.g. `test_c10d_gloo`) spawns ranks, not GPUs, so it never qualifies. The file identity is resolved from the collected node (`path` / `fspath` / `nodeid`), which is reliable under `run_test.py`, and backend names are matched as whole `_`-delimited tokens.
  - **LocalTensor simulation exclusion:** `*WithLocalTensor` classes inherit a multi-process base and a `world_size` of 4 but run single-process under `LocalTensorMode` on one GPU, so their simulated mesh size is not a GPU count; they are detected and excluded from both markers.
  - On any ambiguity (unresolvable `world_size`) the resolver favors coverage and routes the test to the larger runner.
- `skip_if_lt_x_gpu` stamps `_min_gpus_required` (mirroring `requires_world_size._required_world_size`) so the requirement resolves without running the test. `STANDARD_DISTRIBUTED_GPUS = 2` lives in `common_distributed.py`.
- `run_test.py` gains the `multigpu-extra` choice for `--multigpu-filter` (maps to `-m "multigpu_extra"`).
- `.ci/pytorch/test.sh` gains a `distributed_4gpu` config that runs the sharded python distributed suite with that filter (python-only; the multi-GPU C++/mpiexec tests already run on the standard `distributed` job).
- The ROCm `HIP_VISIBLE_DEVICES=0,1,2,3` override for the `distributed` config is removed; `DEFAULT_WORLD_SIZE` already caps ROCm world size at 4 via `device_count`, so the override was redundant (and forced 4 visible devices even on 2-GPU nodes).
- `periodic-rocm-mi350.yml` is re-enabled (schedule + `ciflow/periodic-rocm-mi350` push tag) with a 5-shard `distributed_4gpu` matrix on `gfx950.4`; `arc.yaml` and `pytorch-probot.yml` register the runner label and ciflow tag.

The mechanism is device-generic: CUDA multi-GPU jobs can reuse `--multigpu-filter multigpu-extra` too. This is an **alternative implementation** to #187450 (which used a custom `MinGpuFilterPlugin` gated by `PYTORCH_TEST_MIN_GPU`), offered for comparison of the two approaches.

## Test plan

- Device-generic resolver unit test (runs in CI where torch is built):
```
python test/run_test.py -i distributed/test_multigpu_marker --verbose
```
- Syntax / config checks (torch not built in the dev env):
```
python -m py_compile test/conftest.py test/run_test.py torch/testing/_internal/common_distributed.py test/distributed/test_multigpu_marker.py
bash -n .ci/pytorch/test.sh
```

**CI: `periodic-rocm-mi350` [run 30127795566](https://github.com/pytorch/pytorch/actions/runs/30127795566) (head `b27a5c446b9f`) is green across all 5 `distributed_4gpu` shards on `linux.rocm.gpu.gfx950.4`:**

| shard | conclusion | duration |
|-------|------------|----------|
| [distributed_4gpu 1/5](https://github.com/pytorch/pytorch/actions/runs/30127795566/job/89599321396) | success | 1h10m |
| [distributed_4gpu 2/5](https://github.com/pytorch/pytorch/actions/runs/30127795566/job/89599321437) | success | 1h26m |
| [distributed_4gpu 3/5](https://github.com/pytorch/pytorch/actions/runs/30127795566/job/89599321434) | success | 1h28m |
| [distributed_4gpu 4/5](https://github.com/pytorch/pytorch/actions/runs/30127795566/job/89599321464) | success | 1h02m |
| [distributed_4gpu 5/5](https://github.com/pytorch/pytorch/actions/runs/30127795566/job/89599321426) | success | 1h34m |

Aggregate over the run: 2149 distinct methods selected (1689 executed, 460 runtime-skipped), **0 failures**. At the JUnit `<testcase>` level (parametrized variants included): 3022 entries, 2156 passed, 866 skipped, 0 failed.

Representative evidence that the >2-GPU tests actually ran on 4 GPUs (PASSED):
```
distributed/_composable/fsdp/test_fully_shard_state_dict.py::TestFullyShardStateDictMultiProcess::test_2d_state_dict_correctness
distributed/_composable/fsdp/test_fully_shard_state_dict.py::TestFullyShardStateDictMultiProcess::test_dp_tp_state_dict_save_load
distributed/checkpoint/test_fsdp_tp_checkpoint_conversion.py::TestFsdpTpCheckpointConversion::test_fsdp_to_tp
```
Representative >4-GPU tests correctly selected then runtime-skipped on the 4-GPU box (no coverage silently dropped):
```
SKIPPED [Need at least 8] distributed/_composable/fsdp/test_fully_shard_training.py::TestFullyShardNDTraining::test_shard_placement_fn_tp_ep
SKIPPED [Need at least 8] distributed/test_c10d_nccl.py::ProcessGroupNCCLLargerScaleTest::test_comm_split_group_larger_scale
SKIPPED [Need at least 6] distributed/tensor/test_redistribute.py::UnevenFlattenedReduceScatterTest::test_partial_partial_to_shard_shard_uneven
```

- Empirical selection validation (post-fix vs earlier pre-fix run):
  - The 5 genuine 4-GPU tests that were previously missed now run and pass on the 4-GPU box: `TestFullyShard2DTraining::{test_tp_with_fsdp_offloading, test_train_parity_2d_mlp, test_train_parity_2d_transformer}` and `TestDistributedFailure::{test_dummy_reader_works, test_dummy_writer_works}`.
  - CPU/gloo and LocalTensor-simulation over-selection is eliminated (150 gloo -> 0, 422 LocalTensor sims -> 0). Among executed tests, <=2-GPU over-selection drops from 32.9% to 2.7% (residual is device_count-scaling / unresolvable-`world_size` favor-coverage cases).

Note: the resolver unit test `test/distributed/test_multigpu_marker.py` does not appear in the `distributed_4gpu` artifacts because it is a plain `TestCase` (not `multigpu`-marked) and is excluded by `-m multigpu`; it runs under the standard `distributed` config.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang

Made with Cursor
