### PR TITLE
[c10d][nccl2] Host-block the synchronous barrier

### DIFF
--- a/test/distributed/test_c10d_collectives.py
+++ b/test/distributed/test_c10d_collectives.py
@@ -347,6 +347,31 @@ class AbstractCollectivesTest(C10dBackendTest):
             work = dist.barrier(async_op=async_op)
             self._wait(work, async_op)
 
+    def test_sync_barrier_blocks_host_on_stream(self):
+        # A synchronous barrier must host-block the CPU thread until prior work
+        # on the current stream has completed, not merely stream-order after it.
+        # Downstream code relies on this (e.g. the flashinfer trtllm one-shot
+        # Lamport all_reduce clears its IPC buffers on the stream, then issues a
+        # barrier before the first all_reduce; a stream-order-only barrier lets
+        # the all_reduce race the clear and both ranks spin forever). Enqueue a
+        # long-running kernel, confirm the stream is still busy, then run a
+        # synchronous barrier: once it returns the stream must have drained
+        # (stream.query()). Only the synchronous path (async_op=False) host-
+        # blocks; an async barrier stays stream-ordered and is not tested here.
+        if self.device_type != "cuda":
+            self.skipTest(f"{self.backend_name} host-block test requires CUDA")
+        self._init_pg()
+        stream = torch.cuda.current_stream()
+        torch.cuda._sleep(1_000_000_000)
+        self.assertFalse(
+            stream.query(), "precondition: enqueued work should leave stream busy"
+        )
+        self.assertIsNone(dist.barrier(async_op=False))
+        self.assertTrue(
+            stream.query(),
+            "synchronous barrier must host-block until prior stream work completes",
+        )
+
     def test_all_reduce_coalesced(self):
         self._init_pg()
         for dtype in self.dtypes:

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
@@ -1265,6 +1265,10 @@ c10::intrusive_ptr<WorkNCCL> ProcessGroupNCCL::barrierImpl(
   cudaStream_t stream = getOperationStream(async_op);
   auto work = createWork(stream, timeout);
 
+  // A synchronous barrier host-blocks the CPU thread in synchronizeInternal(),
+  // matching stock ProcessGroupNCCL; async barriers stay stream-ordered.
+  work->hostBlocking_ = !async_op;
+
   // Record start event before NCCL operation
   work->recordStart("barrier");
 

--- a/torch/csrc/distributed/c10d/nccl2/WorkNCCL.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/WorkNCCL.cpp
@@ -7,6 +7,8 @@
 #include <ATen/core/ivalue.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/core/DeviceGuard.h>
+#include <c10/cuda/CUDAException.h>
+#include <c10/cuda/CUDAGraphsC10Utils.h>
 
 #include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
 #include <torch/csrc/distributed/c10d/nccl2/Logging.hpp>
@@ -162,6 +164,20 @@ void WorkNCCL::synchronizeInternal() {
   auto current_stream =
       at::cuda::getCurrentCUDAStream(comm_->getDevice().index());
   end_event_->block(current_stream);
+
+  // For a synchronous barrier, mirror stock ProcessGroupNCCL by host-blocking
+  // the CPU thread until prior current-stream work has completed, not just
+  // stream-ordering it. Callers rely on this to flush async device work before
+  // proceeding (e.g. the flashinfer trtllm one-shot Lamport all_reduce clears
+  // its IPC buffers on the stream, then issues a synchronous barrier before the
+  // first all_reduce; a stream-order-only barrier lets the all_reduce race the
+  // clear and both ranks spin forever). Skip while the stream is capturing a
+  // CUDA graph: cudaStreamSynchronize is illegal during capture and the
+  // captured work is replayed on-device where a host sync is meaningless.
+  if (hostBlocking_ &&
+      !c10::cuda::isStreamCapturingMayInitCtx(current_stream)) {
+    C10_CUDA_CHECK(cudaStreamSynchronize(current_stream));
+  }
 
   // Release tensor references. The CUDA caching allocator manages stream
   // semantics and will not reclaim memory until the stream operations complete.

--- a/torch/csrc/distributed/c10d/nccl2/WorkNCCL.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/WorkNCCL.hpp
@@ -120,6 +120,11 @@ class WorkNCCL : public c10d::Work {
   std::optional<std::chrono::steady_clock::time_point> start_completed_time_;
   std::optional<at::RecordFunction> recordFunction_;
   c10::intrusive_ptr<c10::ivalue::Future> future_;
+
+  // Set by the backend for a synchronous barrier: synchronizeInternal() then
+  // host-blocks the CPU thread (in addition to the stream-ordered wait) to
+  // mirror stock ProcessGroupNCCL, whose barrier host-blocks. See barrierImpl.
+  bool hostBlocking_{false};
 };
 
 class WorkNCCLQueue {


### PR DESCRIPTION

Test Plan:
Build:
  pip install -e . -v --no-build-isolation

New regression test test_sync_barrier_blocks_host_on_stream: enqueue a long
torch.cuda._sleep on the current stream, assert stream.query() is False, run a
synchronous barrier + wait(), then assert stream.query() is True. Passes on
stock nccl, fails pre-fix on nccl2 (stream still busy after wait), passes
post-fix.

  python test/distributed/test_c10d_nccl2.py -v
  # Ran 3 tests ... OK (incl. test_sync_barrier_blocks_host_on_stream, nccl2)

Cross-backend + post-graft (d4l3k StoreManager removal) sanity on 4xH100, all
pass on nccl-lazy and stock nccl: barrier host-block, all_reduce/P2P smoke,
non-contiguous [0,2]/[1,3] PP subgroup bootstrap, and process-group destroy.

Authored with the assistance of an AI coding agent (Claude).

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/pytorch/pull/190682).
* #190943
* __->__ #190682