### PR TITLE
[ROCm] Disable CK GEMM/SDPA when gfx1250 is the only arch

### DIFF
--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -642,12 +642,6 @@ if(USE_ROCM)
   )
   file(GLOB native_hip_bgemm CONFIGURE_DEPENDS "native/hip/bgemm_kernels/*.hip")
   file(GLOB native_hip_ck CONFIGURE_DEPENDS "native/hip/ck*.hip")
-  # composable_kernel has no gfx1250 support yet. If gfx1250 is the only arch,
-  # disable CK GEMM so we do not create ck_gemm with empty HIP_ARCHITECTURES.
-  if(USE_ROCM AND "${PYTORCH_ROCM_ARCH}" STREQUAL "gfx1250")
-    message(WARNING "gfx1250 is the only arch in PYTORCH_ROCM_ARCH: disabling USE_ROCM_CK_GEMM (composable_kernel lacks gfx1250 support)")
-    caffe2_update_option(USE_ROCM_CK_GEMM OFF)
-  endif()
   if(NOT USE_ROCM_CK_GEMM)
     exclude(ATen_HIP_SRCS "${ATen_HIP_SRCS}"
       ${native_hip_bgemm} ${native_hip_ck})

--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -642,6 +642,12 @@ if(USE_ROCM)
   )
   file(GLOB native_hip_bgemm CONFIGURE_DEPENDS "native/hip/bgemm_kernels/*.hip")
   file(GLOB native_hip_ck CONFIGURE_DEPENDS "native/hip/ck*.hip")
+  # composable_kernel has no gfx1250 support yet. If gfx1250 is the only arch,
+  # disable CK GEMM so we do not create ck_gemm with empty HIP_ARCHITECTURES.
+  if(USE_ROCM AND "${PYTORCH_ROCM_ARCH}" STREQUAL "gfx1250")
+    message(WARNING "gfx1250 is the only arch in PYTORCH_ROCM_ARCH: disabling USE_ROCM_CK_GEMM (composable_kernel lacks gfx1250 support)")
+    caffe2_update_option(USE_ROCM_CK_GEMM OFF)
+  endif()
   if(NOT USE_ROCM_CK_GEMM)
     exclude(ATen_HIP_SRCS "${ATen_HIP_SRCS}"
       ${native_hip_bgemm} ${native_hip_ck})

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1042,6 +1042,16 @@ if(USE_ROCM)
     if(HIPBLASLT_VEC_EXT)
       list(APPEND HIP_CXX_FLAGS -DHIPBLASLT_VEC_EXT)
     endif()
+    # composable_kernel has no gfx1250 support yet. If gfx1250 is the only arch,
+    # disable CK GEMM here (before -DUSE_ROCM_CK_GEMM is added) so that both the
+    # CK GEMM sources and their call sites (guarded by USE_ROCM_CK_GEMM in
+    # CUDABlas.cpp/GroupedBlas.cpp) are compiled out consistently. Doing this in
+    # aten/src/ATen/CMakeLists.txt instead excludes the sources but still defines
+    # USE_ROCM_CK_GEMM, leaving undefined references to gemm_internal_ck at link.
+    if("${PYTORCH_ROCM_ARCH}" STREQUAL "gfx1250")
+      message(WARNING "gfx1250 is the only arch in PYTORCH_ROCM_ARCH: disabling USE_ROCM_CK_GEMM (composable_kernel lacks gfx1250 support)")
+      caffe2_update_option(USE_ROCM_CK_GEMM OFF)
+    endif()
     if(USE_ROCM_CK_GEMM)
       list(APPEND HIP_CXX_FLAGS -DUSE_ROCM_CK_GEMM)
     endif()


### PR DESCRIPTION
## Summary

When **gfx1250** is the only arch in `PYTORCH_ROCM_ARCH`, disable
`USE_ROCM_CK_GEMM` in `cmake/Dependencies.cmake` **before** the
`-DUSE_ROCM_CK_GEMM` compile flag is added. composable_kernel has no gfx1250
support yet, so this ensures both the CK GEMM sources and their call sites
(guarded by `USE_ROCM_CK_GEMM` in `CUDABlas.cpp` / `GroupedBlas.cpp`) are
compiled out consistently. Doing this only in `aten/src/ATen/CMakeLists.txt`
excludes the sources but still defines `USE_ROCM_CK_GEMM`, leaving undefined
references to `gemm_internal_ck` at link time.

## Scope / impact

- **Single-arch gfx1250-only builds**: previously failed to link; this fixes them.
- **Multi-arch builds** (e.g. gfx942 + gfx1250): unaffected. `ck_gemm` is still
  built as a separate library with gfx1250 filtered out of `HIP_ARCHITECTURES`,
  so CK GEMM stays enabled for the other archs.

## Related

- ROCm/pytorch#3458 — same guard on ROCm's `release/2.12`.
- ROCm/pytorch#3507 — full gfx1250 enablement + this guard on ROCm's `release/2.13`.

## Validation

Validated via TheRock dev wheel builds for gfx1250 (single-arch and multi-arch,
Python 3.12, ROCm 7.15 nightly). Single-arch gfx1250-only builds link cleanly
with this change; multi-arch builds are unaffected.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang
