### PR TITLE
Fix misleading full-backward-hook warning for pre-hook-only modules

### DIFF
--- a/test/nn/test_module_hooks.py
+++ b/test/nn/test_module_hooks.py
@@ -1482,6 +1482,7 @@ class TestModuleHookNN(NNTestCase):
         with self.assertRaisesRegex(RuntimeError, "where no input requires gradient"):
             mod(inp).sum().backward()
 
+    @skipIfTorchDynamo("TorchDynamo does not work well with hooks")
     def test_pre_hook_no_requires_grad_no_warning(self):
         # A full backward pre-hook only receives grad_output, so firing from the
         # output side when no input requires grad is expected and must not emit

--- a/test/nn/test_module_hooks.py
+++ b/test/nn/test_module_hooks.py
@@ -1482,6 +1482,21 @@ class TestModuleHookNN(NNTestCase):
         with self.assertRaisesRegex(RuntimeError, "where no input requires gradient"):
             mod(inp).sum().backward()
 
+    def test_pre_hook_no_requires_grad_no_warning(self):
+        # A full backward pre-hook only receives grad_output, so firing from the
+        # output side when no input requires grad is expected and must not emit
+        # the full-backward-hook warning. See
+        # https://github.com/pytorch/pytorch/issues/189093
+        mod = nn.Linear(2, 3)
+        inp = torch.rand(1, 2)
+        mod.register_full_backward_pre_hook(lambda mod, gO: None)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            mod(inp).sum().backward()
+        self.assertEqual(
+            [x for x in w if "Full backward hook is firing" in str(x.message)], []
+        )
+
     def test_hook_last_arg_requires_grad(self):
         mod = nn.L1Loss()
         inp = torch.rand(1, requires_grad=True)

--- a/test/nn/test_module_hooks.py
+++ b/test/nn/test_module_hooks.py
@@ -1490,12 +1490,7 @@ class TestModuleHookNN(NNTestCase):
         mod = nn.Linear(2, 3)
         inp = torch.rand(1, 2)
         mod.register_full_backward_pre_hook(lambda mod, gO: None)
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            mod(inp).sum().backward()
-        self.assertEqual(
-            [x for x in w if "Full backward hook is firing" in str(x.message)], []
-        )
+        self.assertNotWarn(lambda: mod(inp).sum().backward())
 
     def test_hook_last_arg_requires_grad(self):
         mod = nn.L1Loss()

--- a/torch/utils/hooks.py
+++ b/torch/utils/hooks.py
@@ -224,19 +224,20 @@ class BackwardHook:
                 # hook directly
                 if self.input_tensors_index is None:
                     # Only full backward hooks (not pre-hooks) receive grad_input
-                    # here, so only warn when one is actually registered.
+                    # and are the subject of the warning; pre-hooks already ran
+                    # above from grad_output. Skip both when none are registered.
                     if self.user_hooks:
                         warnings.warn("Full backward hook is firing when gradients are computed "
                                       "with respect to module outputs since no inputs require gradients. See "
                                       "https://docs.pytorch.org/docs/main/generated/torch.nn.Module.html#torch.nn.Module.register_full_backward_hook "
                                       "for more details.",
                                       stacklevel=5)
-                    grad_inputs = self._pack_with_none([], [], self.n_inputs)
-                    for user_hook in self.user_hooks:
-                        res = user_hook(self.module, grad_inputs, self.grad_outputs)
-                        if res is not None and not (isinstance(res, tuple) and all(el is None for el in res)):
-                            raise RuntimeError("Backward hook for Modules where no input requires "
-                                               "gradient should always return None or None for all gradients.")
+                        grad_inputs = self._pack_with_none([], [], self.n_inputs)
+                        for user_hook in self.user_hooks:
+                            res = user_hook(self.module, grad_inputs, self.grad_outputs)
+                            if res is not None and not (isinstance(res, tuple) and all(el is None for el in res)):
+                                raise RuntimeError("Backward hook for Modules where no input requires "
+                                                   "gradient should always return None or None for all gradients.")
                     self.grad_outputs = None
 
                 if local_grad_outputs is not None:

--- a/torch/utils/hooks.py
+++ b/torch/utils/hooks.py
@@ -223,11 +223,14 @@ class BackwardHook:
                 # Special case if no input required gradients, this hook should call the user
                 # hook directly
                 if self.input_tensors_index is None:
-                    warnings.warn("Full backward hook is firing when gradients are computed "
-                                  "with respect to module outputs since no inputs require gradients. See "
-                                  "https://docs.pytorch.org/docs/main/generated/torch.nn.Module.html#torch.nn.Module.register_full_backward_hook "
-                                  "for more details.",
-                                  stacklevel=5)
+                    # Only full backward hooks (not pre-hooks) receive grad_input
+                    # here, so only warn when one is actually registered.
+                    if self.user_hooks:
+                        warnings.warn("Full backward hook is firing when gradients are computed "
+                                      "with respect to module outputs since no inputs require gradients. See "
+                                      "https://docs.pytorch.org/docs/main/generated/torch.nn.Module.html#torch.nn.Module.register_full_backward_hook "
+                                      "for more details.",
+                                      stacklevel=5)
                     grad_inputs = self._pack_with_none([], [], self.n_inputs)
                     for user_hook in self.user_hooks:
                         res = user_hook(self.module, grad_inputs, self.grad_outputs)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #190685

`nn.Module.register_full_backward_pre_hook` emitted a warning worded for
`register_full_backward_hook` when a module's forward inputs do not require
grad, even when no full backward hook was registered.

Root cause: in `BackwardHook.setup_output_hook` (torch/utils/hooks.py), the
`if self.input_tensors_index is None:` branch is entered whenever no module
input requires grad. Everything in that branch except the `self.grad_outputs`
cleanup concerns full backward hooks only: the warning, the empty-`grad_input`
packing, and the user-hook loop that passes it. Full backward hooks are the
sole consumers of `grad_input`; full backward pre-hooks only receive
`grad_output` (already delivered above), so firing there is expected.

Fix: gate the warning, the `grad_input` packing, and the full-backward-hook
loop on `self.user_hooks`. Only `self.grad_outputs = None` stays unconditional
so per-backward state lifetime is unchanged whether or not a full backward
hook is registered.

Test Plan:

```
python test/nn/test_module_hooks.py TestModuleHookNN.test_pre_hook_no_requires_grad_no_warning
python test/nn/test_module_hooks.py TestModuleHookNN.test_hook_no_requires_grad
```

The new test asserts a pre-hook-only module with a non-grad input emits no
"Full backward hook is firing" warning; the existing test confirms a real
full backward hook still warns, still fires, and still raises when it returns
an invalid `grad_input`.

Fixes #189093

This PR was authored with the assistance of an AI coding assistant.