### PR TITLE
[dynamic shapes] Use durable ShapeEnv identity for foreign symbol cache

### DIFF
--- a/test/fx/test_graph_pickler.py
+++ b/test/fx/test_graph_pickler.py
@@ -1095,6 +1095,89 @@ class TestWeakrefPickle(TestCase):
         self.assertIs(restored_weak(), restored_strong)
 
 
+class TestShapeEnvPickle(TestCase):
+    """Regression tests for pickling a ShapeEnv whose
+    foreign_unbacked_symbol_cache (a weakref.WeakKeyDictionary keyed by live
+    ShapeEnvs) is populated. The cache is derived, reconstructed-on-demand
+    state and must not enter the pickle payload: stock pickle cannot serialize
+    the WeakKeyDictionary's internal remove-closure, and dill would resolve its
+    weakref keys and drag foreign ShapeEnvs across the boundary."""
+
+    def _make_source(self, name="t"):
+        from torch._dynamo.source import ConstantSource
+
+        return ConstantSource(name)
+
+    def _populate_foreign_cache(self, local_env, foreign_env):
+        """Mint an unbacked symint in foreign_env and transfer it into
+        local_env, which populates local_env.foreign_unbacked_symbol_cache
+        with a weakref key pointing at foreign_env."""
+        u = foreign_env.create_unbacked_symint()
+        new_expr = local_env._transfer_foreign_expr_as_unbacked(
+            u, source=self._make_source("local")
+        )
+        local_env.create_symintnode(
+            new_expr, hint=None, source=self._make_source("local")
+        )
+
+    def test_foreign_cache_populated_before_test(self):
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        local_env = ShapeEnv()
+        foreign_env = ShapeEnv()
+        self.assertEqual(len(local_env.foreign_unbacked_symbol_cache), 0)
+        self._populate_foreign_cache(local_env, foreign_env)
+        # Sanity: the transfer actually populated the cache with foreign_env.
+        self.assertIn(foreign_env, local_env.foreign_unbacked_symbol_cache)
+
+    def test_shape_env_pickle_data_drops_foreign_cache(self):
+        """_ShapeEnvPickleData must strip foreign_unbacked_symbol_cache so the
+        payload pickles cleanly (repro of the bug: before the fix this raises
+        PicklingError: Can't pickle local object
+        'WeakKeyDictionary.__init__.<locals>.remove')."""
+        import pickle
+
+        from torch.fx._graph_pickler import _ShapeEnvPickleData
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        local_env = ShapeEnv()
+        foreign_env = ShapeEnv()
+        self._populate_foreign_cache(local_env, foreign_env)
+
+        data = _ShapeEnvPickleData(local_env)
+        # The WeakKeyDictionary must not be carried in the payload.
+        self.assertNotIn("foreign_unbacked_symbol_cache", data.data)
+        # And the payload must pickle without error.
+        pickle.dumps(data)
+
+    def test_shape_env_pickle_data_roundtrip_restores_empty_cache(self):
+        """After unpickle onto a fresh fake_mode's ShapeEnv, the destination
+        keeps its own empty foreign_unbacked_symbol_cache (the WeakKeyDictionary
+        never crosses the boundary)."""
+        import pickle
+
+        from torch._subclasses.fake_tensor import FakeTensorMode
+        from torch.fx._graph_pickler import _ShapeEnvPickleData, _UnpickleState
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        local_env = ShapeEnv()
+        foreign_env = ShapeEnv()
+        self._populate_foreign_cache(local_env, foreign_env)
+
+        data = _ShapeEnvPickleData(local_env)
+        # Roundtrip the payload dict itself to prove it is picklable.
+        restored_data = pickle.loads(pickle.dumps(data))
+
+        dst_env = ShapeEnv()
+        fake_mode = FakeTensorMode(shape_env=dst_env)
+        state = _UnpickleState(fake_mode)
+        restored_env = restored_data.unpickle(state)
+
+        self.assertIs(restored_env, dst_env)
+        # Destination keeps its own empty cache; nothing was clobbered.
+        self.assertEqual(len(restored_env.foreign_unbacked_symbol_cache), 0)
+
+
 if __name__ == "__main__":
     from torch.testing._internal.common_utils import run_tests
 

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -2,10 +2,12 @@
 # ruff: noqa: F841
 import contextlib
 import copy
+import gc
 import itertools
 import math
 import operator
 import unittest
+import weakref
 
 import numpy as np
 import sympy
@@ -6817,6 +6819,26 @@ class TestTransferSymbolsFromForeignShapeEnv(TestCase):
         self.assertEqual(
             len(local_env.foreign_unbacked_symbol_cache), cache_size_before
         )
+
+    def test_foreign_cache_does_not_retain_shape_env(self):
+        foreign_env = ShapeEnv()
+        foreign_u0 = foreign_env.create_unbacked_symint()
+        foreign_ref = weakref.ref(foreign_env)
+        local_env = ShapeEnv()
+
+        self._transfer_symint(
+            local_env,
+            foreign_u0,
+            source=self._make_source("foreign_u0"),
+        )
+        self.assertIn(foreign_env, local_env.foreign_unbacked_symbol_cache)
+
+        del foreign_u0
+        del foreign_env
+        gc.collect()
+
+        self.assertIsNone(foreign_ref())
+        self.assertEqual(len(local_env.foreign_unbacked_symbol_cache), 0)
 
     def test_transfer_constrains_size_on_cache_hit(self):
         """When is_size=True and the expression resolves to a single Symbol

--- a/torch/fx/_graph_pickler.py
+++ b/torch/fx/_graph_pickler.py
@@ -464,6 +464,14 @@ class _ShapeEnvPickleData:
         self.data = env.__dict__.copy()
         del self.data["tracked_fakes"]
         del self.data["fake_tensor_cache"]
+        # foreign_unbacked_symbol_cache is a WeakKeyDictionary keyed by live
+        # ShapeEnvs. It is derived, reconstructed-on-demand state that must not
+        # cross the pickle boundary: stock pickle cannot serialize the
+        # WeakKeyDictionary's internal remove-closure, and with dill its weakref
+        # keys would drag foreign ShapeEnvs into the payload and clobber the
+        # destination fake_mode.shape_env on unpickle. It is already treated as
+        # non-state (see ShapeEnv.non_state_variable_names).
+        del self.data["foreign_unbacked_symbol_cache"]
 
     def unpickle(self, unpickle_state: _UnpickleState) -> ShapeEnv:
         # Fill in the existing ShapeEnv rather than creating a new one

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -31,6 +31,7 @@ import re
 import sys
 import threading
 import traceback
+import weakref
 from collections import Counter, defaultdict
 from collections.abc import Callable, Generator, Iterator, Mapping, Sequence
 from contextlib import _GeneratorContextManager, contextmanager
@@ -4043,11 +4044,12 @@ class ShapeEnv:
         # While doing so, we try to preserve the relations from the original
         # shape env by avoiding re-emitting new symbols for foreign expressions
         # that already got bound symbols here. This cache does that by mapping
-        # (foreign_shape_env_id, foreign_expr) -> the local symbol we
-        # already minted for it.
-        self.foreign_unbacked_symbol_cache: dict[
-            tuple[int, sympy.Expr], sympy.Symbol
-        ] = {}
+        # foreign ShapeEnv -> foreign expression -> the local symbol we
+        # already minted for it. Weak keys prevent this cache from extending
+        # the lifetime of foreign ShapeEnvs.
+        self.foreign_unbacked_symbol_cache: weakref.WeakKeyDictionary[
+            ShapeEnv, dict[sympy.Expr, sympy.Symbol]
+        ] = weakref.WeakKeyDictionary()
         # Maps a source to the *original* symbol that was assigned to it
         self.source_to_var: dict[str, sympy.Symbol] = {}
         # Maps from sympy ints to expressions representing them
@@ -4905,12 +4907,11 @@ class ShapeEnv:
                 f"to a foreign ShapeEnv, got {value!r} with shape_env=None"
             )
         expr = value.node.expr
+        foreign_cache = self.foreign_unbacked_symbol_cache.setdefault(src_shape_env, {})
 
         # Step 1: cache-only replacement.
         cache_map = {
-            sym: self.foreign_unbacked_symbol_cache[(id(src_shape_env), sym)]
-            for sym in expr.free_symbols
-            if (id(src_shape_env), sym) in self.foreign_unbacked_symbol_cache
+            sym: foreign_cache[sym] for sym in expr.free_symbols if sym in foreign_cache
         }
         new_expr = expr.xreplace(cache_map) if cache_map else expr
 
@@ -4933,13 +4934,12 @@ class ShapeEnv:
         # TODO we can do better here: we lose all structural info about the
         # foreign expression (e.g. that it was u0 + u1) by collapsing it to a
         # single opaque local symbol.
-        expr_key = (id(src_shape_env), expr)
-        cached = self.foreign_unbacked_symbol_cache.get(expr_key)
+        cached = foreign_cache.get(expr)
         if cached is None:
             with self.ignore_fresh_unbacked_symbols():
                 new_symint = self.create_unbacked_symint(source)
             cached = new_symint.node.expr
-            self.foreign_unbacked_symbol_cache[expr_key] = cached
+            foreign_cache[expr] = cached
             # Only carry the foreign optimization hint forward when every
             # free symbol in expr has an explicit backed value or hint
             # override; otherwise optimization_hint would return a generic


### PR DESCRIPTION
Split from #188994 following review.

The foreign symbol cache currently uses `(id(shape_env), expression)` keys. A cache entry can outlive its source `ShapeEnv`, and CPython may later reuse that integer id for a different environment, allowing a stale local symbol mapping to be returned.

This changes the outer cache to a `WeakKeyDictionary` keyed by the live `ShapeEnv` object, with a per-environment expression map. Object identity is stable while the environment is alive, and weak-key cleanup removes its mappings once it is unreachable. The regression test drops the last foreign references, runs collection, and verifies the cache no longer retains the environment.

Test Plan:

```
PYTHONPATH=/tmp/pytorch-identity-final-882cc6 python test/test_dynamic_shapes.py TestTransferSymbolsFromForeignShapeEnv
```

```
PATH=/root/.local/bin:$PATH /usr/local/bin/lintrunner -a -r HEAD --take FLAKE8,PYFMT,RUFF,NEWLINE,SPACES,TABS --output oneline
```

This change was authored with assistance from Codex.