### PR TITLE
xplat/caffe2/c10: add missing <fmt/format.h> include to signal_handler.cpp (#190691)

### DIFF
--- a/c10/util/signal_handler.cpp
+++ b/c10/util/signal_handler.cpp
@@ -6,7 +6,7 @@
 
 // Normal signal handler implementation.
 #include <dirent.h>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <sys/syscall.h>
 #include <unistd.h>
 


### PR DESCRIPTION
Summary:

signal_handler.cpp calls fmt::format() but only includes <fmt/core.h>,
relying on it transitively declaring fmt::format() under fmt 9.1.0.
fmt 12.2.0 split fmt::format() out into <fmt/format.h>.

Test Plan: Verified locally via buck2 build that fbsource//xplat/caffe2/c10:c10_full_ovrsource compiles cleanly with the fmt include fixed.

Differential Revision: D112667750


