### PR TITLE
[inductor] Enable scalar online softmax for oversized reductions

### DIFF
--- a/test/inductor/test_online_softmax.py
+++ b/test/inductor/test_online_softmax.py
@@ -447,6 +447,23 @@ class TestOnlineSoftmax(TestCase):
             "triton.scalar_online_softmax_accumulators": True,
         }
     )
+    def test_scalar_online_softmax_supports_large_reductions(self):
+        if GPU_TYPE != "cuda" or torch.version.hip is not None:
+            self.skipTest("scalar online-softmax accumulators are CUDA-only")
+
+        x = torch.randn(4, 2**20 + 13, dtype=torch.float32, device=GPU_TYPE)
+        act, (code,) = run_and_get_code(torch.compile(_prepare_softmax), x, -1)
+
+        self.assertTrue(same(_prepare_softmax(x, -1), act, tol=1e-3))
+        self.assertIn("online_softmax_reduce_scalar_combine", code)
+
+    @inductor_config.patch(
+        {
+            "triton.persistent_reductions": False,
+            "split_reductions": False,
+            "triton.scalar_online_softmax_accumulators": True,
+        }
+    )
     def test_scalar_online_softmax_skips_extra_reductions(self):
         if GPU_TYPE != "cuda" or torch.version.hip is not None:
             self.skipTest("scalar online-softmax accumulators are CUDA-only")

--- a/test/inductor/test_online_softmax.py
+++ b/test/inductor/test_online_softmax.py
@@ -196,16 +196,36 @@ class TestOnlineSoftmax(TestCase):
             "triton.scalar_online_softmax_accumulators": True,
         }
     )
-    def test_scalar_online_softmax_skips_50k_reduction_bucket(self):
+    def test_scalar_online_softmax_supports_50k_reduction_bucket(self):
         if GPU_TYPE != "cuda" or torch.version.hip is not None:
             self.skipTest("scalar online-softmax accumulators are CUDA-only")
 
-        x = torch.randn(4, 50005, dtype=torch.float32, device=GPU_TYPE)
+        storage = torch.randn(4, 50272, dtype=torch.bfloat16, device=GPU_TYPE)
+        x = storage[:, :50265]
+        act, (code,) = run_and_get_code(torch.compile(_prepare_softmax), x, -1)
+
+        self.assertTrue(same(_prepare_softmax(x, -1), act, tol=1e-2))
+        self.assertIn("online_softmax_reduce_scalar_combine", code)
+
+    @parametrize("reduction_numel", [32768, 32769, 65536, 65537])
+    @inductor_config.patch(
+        {
+            "triton.persistent_reductions": False,
+            "split_reductions": False,
+            "triton.scalar_online_softmax_accumulators": True,
+        }
+    )
+    def test_scalar_online_softmax_reduction_bucket_boundaries(
+        self, reduction_numel
+    ):
+        if GPU_TYPE != "cuda" or torch.version.hip is not None:
+            self.skipTest("scalar online-softmax accumulators are CUDA-only")
+
+        x = torch.randn(2, reduction_numel, dtype=torch.float32, device=GPU_TYPE)
         act, (code,) = run_and_get_code(torch.compile(_prepare_softmax), x, -1)
 
         self.assertTrue(same(_prepare_softmax(x, -1), act, tol=1e-3))
-        self.assertIn("online_softmax_combine(", code)
-        self.assertNotIn("online_softmax_reduce_scalar_combine", code)
+        self.assertIn("online_softmax_reduce_scalar_combine", code)
 
     @inductor_config.patch(
         {
@@ -409,7 +429,7 @@ class TestOnlineSoftmax(TestCase):
             "triton.scalar_online_softmax_accumulators": True,
         }
     )
-    def test_scalar_online_softmax_skips_dynamic_50k_reduction_bucket(self):
+    def test_scalar_online_softmax_dynamic_50k_uses_vector_path(self):
         if GPU_TYPE != "cuda" or torch.version.hip is not None:
             self.skipTest("scalar online-softmax accumulators are CUDA-only")
 
@@ -421,9 +441,10 @@ class TestOnlineSoftmax(TestCase):
         self.assertIn("prepare_softmax_online", code)
         self.assertNotIn("online_softmax_reduce_scalar_combine", code)
 
-        # Dynamic scalar accumulation is deliberately disabled. Confirm that a
-        # graph first compiled in an otherwise eligible bucket remains safe
-        # when reused in the excluded 50k bucket.
+        # Dynamic online softmax lowers to separate max and sum reductions. A
+        # graph first compiled at 8k keeps that vector schedule when reused at
+        # 50k. Confirm that cross-bucket reuse remains correct and does not
+        # recompile.
         torch._dynamo.reset()
         compile_counter = torch._dynamo.testing.CompileCounterWithBackend("inductor")
         opt_f = torch.compile(

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -5421,12 +5421,6 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                         names.add(dep.name)
                 return len(names)
 
-            # Small reductions are already cheap on the vector path, and the
-            # 65536 hint bucket covers vocab-sized softmax reductions where
-            # scalar accumulation is slower than the vector path.
-            skip_scalar_online_softmax = (
-                reduction_numel_hint < 8192 or reduction_numel_hint == 65536
-            )
             use_scalar_online_softmax = (
                 config.triton.scalar_online_softmax_accumulators
                 and reduction_type == "online_softmax_reduce"
@@ -5438,7 +5432,8 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 and self.num_reduction_dims == 1
                 and reduction_hint == ReductionHint.INNER
                 and num_reduction_ops <= 2
-                and not skip_scalar_online_softmax
+                # Small reductions are already cheap on the vector path.
+                and reduction_numel_hint >= 8192
             )
             if use_scalar_online_softmax:
                 device = next(iter(self.features.scheduler_nodes())).get_device()

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -5423,11 +5423,9 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
             # Small reductions are already cheap on the vector path, and the
             # 65536 hint bucket covers vocab-sized softmax reductions where
-            # scalar accumulation is slower than the vector path. Keep this
-            # first change within the measured scheduling range.
+            # scalar accumulation is slower than the vector path.
             skip_scalar_online_softmax = (
                 reduction_numel_hint < 8192 or reduction_numel_hint == 65536
-                or reduction_numel_hint > 1 << 20
             )
             use_scalar_online_softmax = (
                 config.triton.scalar_online_softmax_accumulators


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #190693
* #190692

Remove the 2^20 staging limit and rounded-65536 vocabulary exclusion now that scalar-friendly 8K and 16K reduction-block candidates are generated at every eligible size. The native maximum in #190692 makes scalar accumulation profitable for 50k vocabulary softmaxes, while runtime-scaled candidates keep the in-loop reduction cost amortized for truly oversized kernels.

<details>
<summary>Full Perf Rollup</summary>

Clean all-shapes B200 sweeps for the corpus-moving rounded-65536 delta, no coordinate descent, fresh caches, strict GPU locking, locked clocks, 4977/4977 points passed in each arm.

```text
MODEL (per-model e2e, genai excluded)
  median +0.069%   mean +0.410%   geomean +0.419%   n=158

FUSIBLE KERNEL (all fusible kernels)
  median +0.000%   mean +0.213%   geomean +0.130%   n=4977

SUITE/MODE (by model geomean)
   +0.822%  median  +0.082%  mean  +0.798%  n= 38  hf/infer
   +0.658%  median  +0.072%  mean  +0.643%  n= 32  hf/train
   +0.469%  median  +0.372%  mean  +0.464%  n= 23  torchbench/train
   +0.127%  median  +0.082%  mean  +0.126%  n= 18  timm/train
   +0.086%  median  +0.046%  mean  +0.085%  n= 18  timm/infer
   -0.019%  median  +0.000%  mean  -0.020%  n= 29  torchbench/infer

TOP MODELS
    +7.69%  hf/infer/DistillGPT2
    +5.43%  hf/train/OPTForCausalLM
    +3.97%  hf/infer/RobertaForCausalLM
    +3.82%  hf/infer/PegasusForCausalLM
    +3.75%  hf/infer/OPTForCausalLM
    +3.53%  hf/train/PegasusForCausalLM
    +3.52%  hf/infer/TrOCRForCausalLM
    +3.42%  hf/train/TrOCRForCausalLM
    +3.09%  hf/train/BartForCausalLM
    +3.07%  hf/train/MBartForCausalLM
    +3.00%  hf/infer/BartForCausalLM
    +2.92%  hf/infer/MBartForCausalLM
    +2.92%  torchbench/train/tts_angular
    +2.14%  torchbench/train/lennard_jones
    +1.75%  hf/infer/Qwen__Qwen3-0.6B
    +1.35%  hf/train/DistillGPT2
    +1.20%  hf/infer/AllenaiLongformerBase
    +1.10%  hf/infer/PLBartForCausalLM
    +1.08%  torchbench/infer/tts_angular
    +1.03%  hf/train/RobertaForCausalLM

BOTTOM MODELS
    -0.22%  torchbench/train/resnet50
    -0.23%  torchbench/infer/dcgan
    -0.23%  hf/train/BlenderbotForCausalLM
    -0.24%  torchbench/infer/mnasnet1_0
    -0.25%  torchbench/infer/densenet121
    -0.25%  hf/infer/DebertaV2ForMaskedLM
    -0.27%  hf/infer/XLNetLMHeadModel
    -0.29%  torchbench/infer/squeezenet1_1
    -0.29%  torchbench/train/squeezenet1_1
    -0.33%  torchbench/infer/pyhpc_turbulent_kinetic_energy
    -0.38%  hf/train/MT5ForConditionalGeneration
    -0.41%  torchbench/infer/resnext50_32x4d
    -0.44%  hf/train/T5ForConditionalGeneration
    -0.44%  hf/train/T5Small
    -0.56%  torchbench/infer/mobilenet_v3_large
    -1.11%  hf/infer/GPTJForCausalLM
    -1.15%  hf/infer/GPTJForQuestionAnswering
    -1.21%  hf/infer/T5ForConditionalGeneration
    -1.21%  hf/infer/T5Small
    -1.64%  torchbench/infer/phlippe_resnet

TOP TARGET KERNEL INSTANCES
   1.75x  -43.0%   520.3->296.6us  amax_sum_sum_f58f591dd576[OPT]
   1.75x  -42.8%   519.2->296.8us  amax_sum_sum_c94a0970300f[OPT]
   1.41x  -29.2%  1250.2->885.7us  amax_sum_sum_822c7c06b882[Pegasus]
   1.41x  -29.1%  1246.1->883.7us  amax_sum_sum_4bf8a79efec4[Roberta]
   1.41x  -28.9%  1247.1->886.9us  amax_sum_sum_822c7c06b882[TrOCR]
   1.40x  -28.7%  1246.0->888.6us  amax_sum_sum_42988b64e7f9[DistillGPT2]
   1.40x  -28.6%   638.9->456.5us  amax_sum_sum_822c7c06b882[Bart]
   1.39x  -27.8%   328.7->237.3us  amax_sum_sum_4bf8a79efec4[GPTNeo]
   1.38x  -27.7%  1222.8->884.6us  amax_sum_sum_3f000d9caa57[Pegasus]
   1.38x  -27.6%  1223.7->885.7us  amax_sum_sum_3f000d9caa57[TrOCR]
   1.38x  -27.6%  1220.7->883.6us  amax_sum_sum_52903d400fef[Roberta]
   1.38x  -27.5%   625.5->453.7us  amax_sum_sum_3f000d9caa57[Bart]
   1.38x  -27.3%  1220.5->886.9us  amax_sum_sum_fb4ae0eb915f[DistillGPT2]
   1.36x  -26.4%   325.4->239.4us  amax_sum_sum_a4f202093213[GPTNeo]
```

The amax_sum_sum family geomean is 1.0985x. Substantive 50k vocabulary kernels improve 26.4-29.2%; Bart/Pegasus/TrOCR are 1.073x/1.069x/1.070x from their handwritten oracle. Four apparent full-sweep regressions reran neutral with fresh caches, strict locking, 100 warmups, and 500 repetitions.

MODEL is the shape-matched per-model estimate diluted by extern/GEMM/SDPA time. FUSIBLE KERNEL is the raw per-(kernel, shape) base/head geomean and is included for direction, not as the model headline.

</details>

<details>
<summary>Oversized exact stack-boundary A/B</summary>

This commit versus #190692 is neutral on the existing 14-point online-softmax landing cohort (+0.15%) and improves forced one-kernel reductions around 1M/2M/4M by 54.6-55.6%. All oversized winners use the existing runtime-scaled R0_BLOCK=16384, 8-warp schedule.

The winning 50k schedule is R0_BLOCK=4096 with 4 warps: it cuts loop trips from 50 to 13 and avoids lane-wise online-combine/exp work. It uses 77 registers versus 30 for the vector baseline; lower register pressure is not the cause. An explicit 8192/8 candidate used 95 registers, was not selected, and was removed.

</details>

Validation: full test/inductor/test_online_softmax.py is 60/60; Ruff, compileall, and git diff --check pass. Dynamic reduction extents remain on the vector path; dynamic non-reduction dimensions are supported.