### PR TITLE
[dynamo] Handle non-UTF-8 minifier subprocess output

### DIFF
--- a/test/dynamo/test_minifier.py
+++ b/test/dynamo/test_minifier.py
@@ -5,12 +5,21 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import torch._dynamo
-from torch._dynamo.test_minifier_common import MinifierTestBase
+from torch._dynamo.test_minifier_common import (
+    _decode_subprocess_output,
+    MinifierTestBase,
+)
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import skipIfNNModuleInlined
 
 
 class MinifierTests(MinifierTestBase):
+    def test_decode_subprocess_output_handles_non_utf8_bytes(self):
+        self.assertEqual(
+            _decode_subprocess_output(b"readable output\xb1continues"),
+            "readable output\ufffdcontinues",
+        )
+
     # Test that compile, runtime, and accuracy errors after dynamo can be repro'd
     def _test_after_dynamo(self, device, backend, expected_error):
         run_code = f"""\

--- a/torch/_dynamo/test_minifier_common.py
+++ b/torch/_dynamo/test_minifier_common.py
@@ -34,6 +34,10 @@ from torch._dynamo.trace_rules import _as_posix_path
 from torch.utils._traceback import report_compile_source_on_error
 
 
+def _decode_subprocess_output(output: bytes) -> str:
+    return output.decode("utf-8", errors="replace")
+
+
 @dataclasses.dataclass
 class MinifierTestResult:
     minifier_code: str
@@ -195,11 +199,10 @@ torch._inductor.config.{"cpp" if device == "cpu" else "triton"}.inject_relu_bug_
             ["python3", "-c", code], isolate=isolate, cwd=self.DEBUG_DIR
         )
 
-        print("test stdout:", proc.stdout.decode("utf-8"))
-        print("test stderr:", proc.stderr.decode("utf-8"))
-        repro_dir_match = re.search(
-            r"(\S+)minifier_launcher.py", proc.stderr.decode("utf-8")
-        )
+        print("test stdout:", _decode_subprocess_output(proc.stdout))
+        stderr = _decode_subprocess_output(proc.stderr)
+        print("test stderr:", stderr)
+        repro_dir_match = re.search(r"(\S+)minifier_launcher.py", stderr)
         if repro_dir_match is not None:
             return proc, repro_dir_match.group(1)
         return proc, None
@@ -226,8 +229,8 @@ torch._inductor.config.{"cpp" if device == "cpu" else "triton"}.inject_relu_bug_
             # Everything in AOTI minifier is in no-isolate mode.
             args.append("--no-isolate")
         launch_proc = self._maybe_subprocess_run(args, isolate=isolate, cwd=repro_dir)
-        print("minifier stdout:", launch_proc.stdout.decode("utf-8"))
-        stderr = launch_proc.stderr.decode("utf-8")
+        print("minifier stdout:", _decode_subprocess_output(launch_proc.stdout))
+        stderr = _decode_subprocess_output(launch_proc.stderr)
         print("minifier stderr:", stderr)
 
         self.assertNotIn("Input graph did not fail the tester", stderr)
@@ -248,8 +251,8 @@ torch._inductor.config.{"cpp" if device == "cpu" else "triton"}.inject_relu_bug_
         repro_proc = self._maybe_subprocess_run(
             ["python3", repro_file], isolate=isolate, cwd=repro_dir
         )
-        print("repro stdout:", repro_proc.stdout.decode("utf-8"))
-        print("repro stderr:", repro_proc.stderr.decode("utf-8"))
+        print("repro stdout:", _decode_subprocess_output(repro_proc.stdout))
+        print("repro stderr:", _decode_subprocess_output(repro_proc.stderr))
         return repro_proc, repro_code
 
     # Template for testing code.
@@ -315,7 +318,7 @@ torch._dynamo.config.debug_dir_root = "{_as_posix_path(self.DEBUG_DIR)}"
         # NB: Intentionally do not test return code; we only care about
         # actually generating the repro, we don't have to crash
 
-        self.assertIn(expected_error, test_proc.stderr.decode("utf-8"))
+        self.assertIn(expected_error, _decode_subprocess_output(test_proc.stderr))
 
         self.assertIsNotNone(repro_dir)
         print("running minifier", file=sys.stderr)
@@ -328,6 +331,6 @@ torch._dynamo.config.debug_dir_root = "{_as_posix_path(self.DEBUG_DIR)}"
         print("running repro", file=sys.stderr)
         repro_proc, repro_code = self._run_repro(repro_dir, isolate=isolate)
 
-        self.assertIn(expected_error, repro_proc.stderr.decode("utf-8"))
+        self.assertIn(expected_error, _decode_subprocess_output(repro_proc.stderr))
         self.assertNotEqual(repro_proc.returncode, 0)
         return MinifierTestResult(minifier_code=minifier_code, repro_code=repro_code)


### PR DESCRIPTION
## Summary

Fixes #190681.

PyTorch's minifier test harness decodes captured subprocess output as strict UTF-8. ROCm runtime diagnostics can contain isolated non-UTF-8 bytes, causing the harness to raise `UnicodeDecodeError` before it can locate the generated launcher or assert on the expected failure.

Add a shared replacement-safe decoder and use it consistently for the initial test process, minifier launcher, repro process, and expected-error checks. This preserves readable diagnostics and prevents the same invalid byte from failing at a later decode site.

Add a regression test covering an invalid byte embedded between readable output.

## Test plan

- `PYTHONPATH=/private/tmp/codex-pytorch-wheel python test/dynamo/test_minifier.py -k decode_subprocess_output`
- `python3 -m py_compile torch/_dynamo/test_minifier_common.py test/dynamo/test_minifier.py`
- `ruff check torch/_dynamo/test_minifier_common.py test/dynamo/test_minifier.py`
- `ruff format --check torch/_dynamo/test_minifier_common.py test/dynamo/test_minifier.py`
- `git diff --check`

## AI assistance

This change was developed with assistance from OpenAI Codex. I reviewed the implementation, regression test, and diff and take responsibility for the contribution.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98