### PR TITLE
[distributed][linter] Catch OSError during checkpoint fsync & handle missing build directory gracefully in clang-tidy

### DIFF
--- a/tools/linter/adapters/clangtidy_linter.py
+++ b/tools/linter/adapters/clangtidy_linter.py
@@ -306,6 +306,24 @@ def main() -> None:
 
     abs_build_dir = Path(args.build_dir).resolve()
 
+    if not abs_build_dir.exists():
+        err_msg = LintMessage(
+            path="<none>",
+            line=None,
+            char=None,
+            code="CLANGTIDY",
+            severity=LintSeverity.ERROR,
+            name="command-failed",
+            original=None,
+            replacement=None,
+            description=(
+                f"Could not find build directory at {args.build_dir},"
+                " you may need to run compiler configuration first or check your workflow group settings."
+            ),
+        )
+        print(json.dumps(err_msg._asdict()), flush=True)
+        sys.exit(0)
+
     # Get the absolute path to clang-tidy and use this instead of the relative
     # path such as .lintbin/clang-tidy. The problem here is that os.chdir is
     # per process, and the linter uses it to move between the current directory

--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -472,7 +472,7 @@ def _write_files_from_queue(
                     stream.flush()
                     try:
                         os.fsync(stream.fileno())
-                    except (AttributeError, UnsupportedOperation) as e:
+                    except (AttributeError, UnsupportedOperation, OSError) as e:
                         warnings.warn(
                             f"fsync not supported for this stream, relying on flush(): {e}"
                         )
@@ -781,7 +781,7 @@ class _FileSystemWriter(StorageWriter):
                 metadata_file.flush()
                 try:
                     os.fsync(metadata_file.fileno())
-                except (AttributeError, UnsupportedOperation) as e:
+                except (AttributeError, UnsupportedOperation, OSError) as e:
                     warnings.warn(
                         f"fsync not supported for this stream, relying on flush(): {e}"
                     )


### PR DESCRIPTION
### Description
This PR addresses two independent issues:
1. **distributed**: Catch `OSError` in `checkpoint/filesystem.py` when calling `os.fsync`. While issue #144752 was closed by PR #144753, that PR only added `UnsupportedOperation` to catch cases where `fileno()` is not supported. It did not catch `OSError` which is raised when `os.fsync(...)` itself fails on file descriptors that do not support fsync (common for cloud/network storage mounts like S3, HDFS, or GCS via `fsspec`). This PR adds `OSError` to the caught exceptions.
2. **linter**: Gracefully handle missing build directories in the `clang-tidy` linter adapter. This prevents linter crash failures in CI runs where compilation has not run (such as the `noclang` or `pyrefly` jobs).

### Test Plan
1. For the linter, verified that `python3 tools/linter/adapters/clangtidy_linter.py` handles missing build directories gracefully (exiting with 0 and a warning JSON LintMessage) rather than raising a `FileNotFoundError`.
2. Verified both modified files pass style guidelines via `spin lint`.

Disclosing that this PR was authored with the assistance of an AI assistant.
