### PR TITLE
[CI] Exclude inductor OpInfo from macOS test config

### DIFF
--- a/.ci/pytorch/macos-test.sh
+++ b/.ci/pytorch/macos-test.sh
@@ -32,7 +32,7 @@ setup_test_python() {
 test_python_all() {
   setup_test_python
 
-  time python test/run_test.py --verbose --exclude-jit-executor
+  time python test/run_test.py --verbose --exclude-jit-executor --exclude inductor/test_torchinductor_opinfo
 
   assert_git_not_dirty
 }
@@ -65,7 +65,7 @@ test_python_shard() {
 
   setup_test_python
 
-  time python test/run_test.py --verbose --exclude-jit-executor --exclude-distributed-tests --exclude-quantization-tests --shard "$1" "$NUM_TEST_SHARDS"
+  time python test/run_test.py --verbose --exclude-jit-executor --exclude-distributed-tests --exclude-quantization-tests --exclude inductor/test_torchinductor_opinfo --shard "$1" "$NUM_TEST_SHARDS"
 
   assert_git_not_dirty
 }


### PR DESCRIPTION
test_torchinductor_opinfo runs only on CPU on macOS (no MPS variant). Similar to https://github.com/pytorch/pytorch/pull/190635 to use exclusion for this target.

Authored with assistance from Claude (AI).