### PR TITLE
[TEST] Classify test_store.py with hw_classification

### DIFF
--- a/test/distributed/test_store.py
+++ b/test/distributed/test_store.py
@@ -34,6 +34,7 @@ from torch.testing._internal.common_distributed import (
 from torch.testing._internal.common_utils import (
     ADDRESS_IN_USE,
     CONNECT_TIMEOUT,
+    HardwareClassification,
     load_tests,
     retry_on_connect_failures,
     run_tests,
@@ -58,6 +59,8 @@ device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else 
 
 
 class StoreTestBase:
+    hw_classification = HardwareClassification.GENERIC
+
     def _create_store(self, i):
         raise RuntimeError("not implemented")
 
@@ -262,6 +265,8 @@ class StoreTestBase:
 
 
 class FileStoreTest(TestCase, StoreTestBase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         with tempfile.NamedTemporaryFile(delete=False) as f:
@@ -312,6 +317,8 @@ class FileStoreTest(TestCase, StoreTestBase):
 
 @skip_if_win32()
 class HashStoreTest(TestCase, StoreTestBase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _create_store(self):
         store = dist.HashStore()
         store.set_timeout(timedelta(seconds=300))
@@ -319,6 +326,8 @@ class HashStoreTest(TestCase, StoreTestBase):
 
 
 class PrefixStoreTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         # delete is false as FileStore will automatically clean up the file
@@ -342,6 +351,8 @@ class PrefixStoreTest(TestCase):
 
 
 class PrefixFileStoreTest(TestCase, StoreTestBase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         with tempfile.NamedTemporaryFile(delete=False) as f:
@@ -359,6 +370,7 @@ class PrefixFileStoreTest(TestCase, StoreTestBase):
 
 
 class TCPStoreTest(TestCase, StoreTestBase):
+    hw_classification = HardwareClassification.GENERIC
     _use_libuv = False
 
     def _create_store(self):
@@ -675,6 +687,7 @@ class TCPStoreTest(TestCase, StoreTestBase):
 
 
 class LibUvTCPStoreTest(TCPStoreTest):
+    hw_classification = HardwareClassification.GENERIC
     _use_libuv = True
 
     def _create_store(self):
@@ -689,6 +702,8 @@ class LibUvTCPStoreTest(TCPStoreTest):
 
 
 class PrefixTCPStoreTest(TestCase, StoreTestBase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self.tcpstore = create_tcp_store()
@@ -753,6 +768,8 @@ class MyPythonStore(dist.Store):
 
 
 class PythonStoreTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_set_get(self):
         # If we were to inherit from StoreTestBase and try to use
         # its test_set_get function, we would exercise the Python
@@ -765,6 +782,8 @@ class PythonStoreTest(TestCase):
 
 
 class RendezvousTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_unknown_handler(self):
         with self.assertRaisesRegex(RuntimeError, "^No rendezvous handler"):
             dist.rendezvous("invalid://")
@@ -775,6 +794,8 @@ class RendezvousTest(TestCase):
 
 
 class RendezvousEnvTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @retry_on_connect_failures
     def test_nominal(self):
         os.environ["WORLD_SIZE"] = "1"
@@ -795,6 +816,8 @@ class RendezvousEnvTest(TestCase):
 
 
 class RendezvousFileTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_common_errors(self):
         with self.assertRaisesRegex(ValueError, "path missing"):
             gen = dist.rendezvous("file://?rank=0&world_size=1")
@@ -829,6 +852,8 @@ class RendezvousFileTest(TestCase):
 
 @skip_if_win32()
 class RendezvousTCPTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def create_tcp_url(self):
         addr = DEFAULT_HOSTNAME
         port = common.find_free_port()
@@ -942,6 +967,8 @@ class DummyStore(dist.Store):
 
 
 class TestPythonStore(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_optional_methods_fail(self):
         class TestStore(dist.Store):
             pass
@@ -1011,6 +1038,7 @@ class TestPythonStore(TestCase):
 
 
 class TestMultiThreadedWait(MultiThreadedTestCase):
+    hw_classification = HardwareClassification.GENERIC
     file_store = dist.FileStore(tempfile.NamedTemporaryFile(delete=False).name, 1)  # noqa: SIM115
     hash_store = dist.HashStore()
 
@@ -1072,6 +1100,8 @@ instantiate_parametrized_tests(TestMultiThreadedWait)
 
 @skip_if_win32()
 class TimeoutTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def tearDown(self):
         import signal
 
@@ -1142,6 +1172,8 @@ class InitPgWithNonUvStore(TestCase):
     the default backend.
     """
 
+    hw_classification = HardwareClassification.GENERIC
+
     def tearDown(self):
         super().tearDown()
         os.environ.pop("USE_LIBUV", None)
@@ -1179,6 +1211,8 @@ class InitPgWithNonUvStore(TestCase):
 
 
 class TestClientProtocol(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_client_connect(self) -> None:
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.bind(("localhost", 0))


### PR DESCRIPTION
## Summary
- Add `hw_classification = HardwareClassification.GENERIC` to all store/rendezvous test classes in `test/distributed/test_store.py`.
- These tests cover CPU-side store and rendezvous APIs (FileStore, HashStore, TCPStore, PrefixStore, env/file/tcp rendezvous) with no accelerator dependency.
- No class splits and no `instantiate_device_type_tests`; helpers without `test_*` methods (`MyPythonStore`, `DummyStore`) are left unmarked.

cc: @mansiag05 @RiyaP2508 