### PR TITLE
[CI] Skip inductor OpInfo CPU on macOS

### DIFF
--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -1300,6 +1300,7 @@ class TestInductorOpInfo(TestCase):
         not HAS_XPU_AND_TRITON, "Skipped! Supported XPU compiler and Triton not found"
     )
     @skipCPUIf(not HAS_CPU, "Skipped! Supported CPU compiler not found")
+    @skipCPUIf(IS_MACOS, "Skipped under macOS")
     @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
     @skipIfTorchDynamo("Test uses dynamo already")
     @skipIfCrossRef


### PR DESCRIPTION
Since these tests un-gated CPU, test_torchinductor_opinfo has a greater share of all macOS test-minutes, worsening mac runner queue times. Skip it on macOS via @skipCPUIf(IS_MACOS); Linux/CUDA coverage (inductor_amx) is unaffected.

Authored with assistance from Claude (AI).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo