### PR TITLE
[inductor] Emit combo sub-kernel bodies as noinline device functions

### DIFF
--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -1865,6 +1865,69 @@ class ComboKernelDynamicShapesTests(TestCase):
 class ComboKernelTestsPerSubkernelBlocks(ComboKernelTests):
     combo_kernel_per_subkernel_blocks = True
 
+    @requires_gpu_and_triton
+    def test_noinline_sub_kernel_bodies(self):
+        # Per-subkernel combos emit each body as a @triton.jit(noinline=True)
+        # device function called from its dispatch branch, so ptxas allocates
+        # registers per body instead of jointly over the merged control-flow
+        # graph (a register-fat member cannot degrade the others' occupancy).
+        def fn(x, y, z):
+            return x + 1, torch.sigmoid(y), torch.tanh(z)
+
+        inps = (
+            torch.rand(8192, device=GPU_TYPE),
+            torch.rand(6144, device=GPU_TYPE),
+            torch.rand(4096, device=GPU_TYPE),
+        )
+
+        out, code = run_and_get_code(torch.compile(fn), *inps)
+        self.assertEqual(out, fn(*inps))
+        code = " ".join(code)
+
+        # Three sub-function definitions before the combo kernel, each
+        # dispatch branch reduced to a call.
+        fc = FileCheck()
+        for num in range(3):
+            fc = fc.check("@triton.jit(noinline=True)").check(f"_body_{num}(")
+        fc = fc.check("pid = tl.program_id(0)")
+        for num in range(3):
+            fc = fc.check(f"pid < num_blocks_{num}:").check(f"_body_{num}(")
+        fc.run(code)
+
+    @requires_gpu_and_triton
+    @torch._inductor.config.patch("combo_kernels_autotune", 0)
+    def test_noinline_sub_kernel_bodies_no_bench(self):
+        # No-benchmark path (combo_kernels_autotune=0 -> bake_blocks): block
+        # sizes are kernel-scope constexprs, threaded into each sub-function
+        # as constexpr call arguments.
+        def fn(x, y):
+            return x + 1, torch.tanh(y)
+
+        inps = (
+            torch.rand(8192, device=GPU_TYPE),
+            torch.rand(4096, device=GPU_TYPE),
+        )
+
+        out, code = run_and_get_code(torch.compile(fn), *inps)
+        self.assertEqual(out, fn(*inps))
+        code = " ".join(code)
+
+        (
+            FileCheck()
+            .check("@triton.jit(noinline=True)")
+            .check("_body_0(")
+            .check("XBLOCK_0 : tl.constexpr")
+            .check("@triton.jit(noinline=True)")
+            .check("_body_1(")
+            .check("XBLOCK_1 : tl.constexpr")
+            .check("XBLOCK_0: tl.constexpr =")
+            .check("pid < num_blocks_0:")
+            .check("_body_0(")
+            .check("pid < num_blocks_1:")
+            .check("_body_1(")
+            .run(code)
+        )
+
 
 class ComboKernelBenchmarkTestsPerSubkernelBlocks(ComboKernelBenchmarkTests):
     combo_kernel_per_subkernel_blocks = True

--- a/torch/_inductor/codegen/triton_combo_kernel.py
+++ b/torch/_inductor/codegen/triton_combo_kernel.py
@@ -1403,6 +1403,82 @@ class ComboKernel(Kernel):
             code.splice(sub_kernel_code.setup)
             code.splice(sub_kernel_code.body)
 
+    def _noinline_sub_kernel_params(
+        self,
+        sub_kernel_code: SubKernelCode,
+        num: int,
+        argdefs: list[ArgName],
+    ) -> list[ArgName] | None:
+        """Parameter list for emitting this sub-kernel body as a separate
+        device function: the outer names its code actually references (main
+        kernel args plus the dispatch-computed pid offsets), minus names the
+        sub-kernel's own setup defines. None when the body cannot be
+        tokenized."""
+        lines = self._plain_lines(sub_kernel_code.setup)
+        body_lines = self._plain_lines(sub_kernel_code.body)
+        if lines is None or body_lines is None:
+            return None
+        used = self._names_in_lines(lines + body_lines)
+        if used is None:
+            return None
+        defined = OrderedSet(sub_kernel_code.setup_lhs_names)
+        params = [
+            arg
+            for arg in argdefs
+            if arg.name in used and arg.name not in defined and not arg.is_constexpr
+        ]
+        params.append(ArgName("x_pid_offset"))
+        if self.y_tree_list[num]:
+            params.append(ArgName("y_pid_offset"))
+        params.extend(
+            arg
+            for arg in argdefs
+            if arg.name in used and arg.name not in defined and arg.is_constexpr
+        )
+        if self.bake_blocks:
+            # Baked block sizes are kernel-scope constexprs (codegen_blocks),
+            # not kernel args; thread them through as constexpr parameters.
+            params.extend(
+                ArgName(block, is_constexpr=True)
+                for block in self.block_args
+                if block in used and block not in defined
+            )
+        return params
+
+    def _codegen_noinline_sub_kernels(
+        self,
+        code: IndentedBuffer,
+        kernel_name: str,
+        sub_kernel_codes: list[SubKernelCode],
+        argdefs: list[ArgName],
+    ) -> list[str] | None:
+        """Emit each sub-kernel body as a @triton.jit(noinline=True) device
+        function and return the per-branch call lines. The call boundary makes
+        ptxas allocate registers per body instead of jointly over the merged
+        control-flow graph, so one register-fat member cannot inflate the
+        whole combo binary's allocation (and with it every member's
+        residency). Returns None when any body cannot be emitted this way
+        (caller falls back to inline splicing)."""
+        call_lines: list[str] = []
+        defs = IndentedBuffer()
+        for num, sub_kernel_code in enumerate(sub_kernel_codes):
+            params = self._noinline_sub_kernel_params(sub_kernel_code, num, argdefs)
+            if params is None:
+                return None
+            sub_name = f"{kernel_name}_body_{num}"
+            defs.writeline("")
+            defs.writeline("@triton.jit(noinline=True)")
+            defs.writeline(
+                f"def {sub_name}({', '.join(p.full_name() for p in params)}):"
+            )
+            with defs.indent():
+                defs.splice(sub_kernel_code.setup)
+                defs.splice(sub_kernel_code.body)
+            call_lines.append(f"{sub_name}({', '.join(p.name for p in params)})")
+        defs.writeline("")
+        code.splice(defs)
+        return call_lines
+
     def _codegen_shared_branches(
         self,
         code: IndentedBuffer,
@@ -1474,6 +1550,23 @@ class ComboKernel(Kernel):
             if triton_version_uses_attrs_dict():
                 signature.extend(block_args)
 
+        kernel_name = name or str(Placeholder.KERNEL_NAME)
+
+        sub_kernel_codes = self._codegen_sub_kernel_bodies()
+        shared_body = self._try_get_shared_body(
+            sub_kernel_codes, signature, heuristics_list
+        )
+        # Sub-functions must be emitted before the main kernel's heuristics
+        # decorator line (triton reads the decorated function's source by
+        # inspection). PDL intrinsics move with each body and proton scopes
+        # wrap the main kernel around the calls, so neither needs the inline
+        # form.
+        noinline_calls: list[str] | None = None
+        if self.per_subkernel_blocks:
+            noinline_calls = self._codegen_noinline_sub_kernels(
+                code, kernel_name, sub_kernel_codes, argdefs
+            )
+
         code.splice(
             self.jit_line(
                 heuristics,
@@ -1485,7 +1578,6 @@ class ComboKernel(Kernel):
                 size_hints_list=size_hints_list,
             )
         )
-        kernel_name = name or str(Placeholder.KERNEL_NAME)
         code.writeline(
             f"def {kernel_name}({', '.join(x.full_name() for x in argdefs)}):"
         )
@@ -1497,12 +1589,18 @@ class ComboKernel(Kernel):
             if self.bake_blocks:
                 self.codegen_blocks(code)
 
-            sub_kernel_codes = self._codegen_sub_kernel_bodies()
-            shared_body = self._try_get_shared_body(
-                sub_kernel_codes, signature, heuristics_list
-            )
             if shared_body is not None:
                 self._codegen_shared_branches(code, sub_kernel_codes, shared_body)
+            elif noinline_calls is not None:
+                if self.dispatch_class is None:
+                    raise AssertionError("dispatch_class must not be None")
+                for num, call_line in enumerate(noinline_calls):
+                    self.dispatch_class.codegen_pid_range(self, num, code)
+                    with code.indent():
+                        code.writeline(call_line)
+                code.splice("else:")
+                with code.indent():
+                    code.splice("pass")
             else:
                 for num, sub_kernel_code in enumerate(sub_kernel_codes):
                     self._codegen_branch(code, num, sub_kernel_code)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

Per-subkernel-blocks combo kernels inline every member's body into one
merged function, so ptxas performs a single joint register allocation
over the combined control-flow graph. One register-fat member then
inflates the whole binary's allocation and degrades every member's
occupancy: on the Qwen3-0.6B QK-norm pair, two 128-register members
merge into a 151-register binary (SASS-verified), dropping residency
from 8 to 6 blocks per SM and slowing the fused pair below its parts.
Restructuring the dispatch (nested-if) does not help; the joint
allocation is inherent to the single-body form.

Fix in codegen: emit each sub-kernel body as a @triton.jit(noinline=True)
device function called from its dispatch branch. The call boundary makes
ptxas allocate registers per body, so the combo binary's allocation
matches the fattest member instead of exceeding it (Qwen pair: 151 -> 128
registers, one kernel, one launch). Applies to all per-subkernel modes:
compile-time autotune, benchmark, and the no-benchmark/deterministic path
(baked block constexprs are threaded through as call arguments). PDL
intrinsics move with the body, preserving their placement relative to its
loads; sub-functions are emitted before the heuristics decorator line
because triton reads the decorated function's source by inspection.
Members whose body cannot be tokenized fall back to inline splicing.

An alternative considered was carving register-fat members out of combos
entirely; noinline keeps the launch-count win while removing the register
coupling, so it strictly dominates for this failure class.

Test Plan:

New test pins the emitted structure (sub-function defs + call-only
dispatch branches) in both autotune modes; PDL tests updated for the
sub-function form. Full combo suite:

```
python test/inductor/test_combo_kernels.py
```

215 tests, OK (6 skipped). Register fix verified on the real Qwen3-0.6B
graph (combo binary 151 -> 128 regs) and A/B benchmarked on 58 hf
combo-forming full graphs (median +0.01%, Qwen -4.9%; locked clocks,
fresh caches per arm).

Authored with Claude Code.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo