### PR TITLE
Clarify scrub-issue skill trigger

### DIFF
--- a/.claude/skills/scrub-issue/SKILL.md
+++ b/.claude/skills/scrub-issue/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: scrub-issue
 disable-model-invocation: true
-description: Fetch, analyze, reproduce, and minimize GitHub issue reproductions. Use when asked to check if an issue reproduces, minimize a repro, analyze a bug report, or scrub/triage an issue for reproducibility.
+description: Fetch, analyze, reproduce, and minimize GitHub issue reproductions. Use only when the user asks to check whether a GitHub issue reproduces, minimize a GitHub issue's repro, analyze a GitHub bug report, or scrub/triage a GitHub issue for reproducibility. Do not use for standalone reproduction requests without a GitHub issue.
 ---
 
 # Minimize Issue Reproduction


### PR DESCRIPTION
## Author Notes

It triggered 3 times already spuriously, leading to codex to post on github even though I never asked and triggered even when asking to run a script and see if it fails locally.

## Agent Notes

Restrict the `scrub-issue` skill description to requests that explicitly involve reproducing, minimizing, analyzing, or scrubbing a GitHub issue. This preserves the detailed use cases while preventing standalone local reproduction requests from invoking a workflow that can interact with GitHub.

Authored with an AI assistant.

## Test Plan

```
spin lint .claude/skills/scrub-issue/SKILL.md
```