### PR TITLE
flex_gemm: add fast math kernel option

### DIFF
--- a/test/inductor/test_cutedsl_template.py
+++ b/test/inductor/test_cutedsl_template.py
@@ -744,6 +744,72 @@ SCALE_FACTOR: cutlass.Constexpr = 1.5
         )
         self.assertEqual(tensor_result, "tensor_a")
 
+    def test_cutedsl_op_overrides_fast_math(self):
+        from torch._inductor.codegen.common import CSEVariable
+        from torch._inductor.codegen.cutedsl.cutedsl_op_overrides import (
+            CuteDSLOpOverrides,
+            use_cutedsl_fast_math,
+        )
+        from torch.utils._sympy.value_ranges import ValueRanges
+
+        mock_cse_a = MagicMock(spec=CSEVariable)
+        mock_cse_a.__str__.return_value = "tensor_a"
+        mock_cse_a.dtype = torch.float32
+        mock_cse_a.bounds = ValueRanges.unknown()
+        mock_cse_a.shape = (32, 64)
+
+        mock_cse_b = MagicMock(spec=CSEVariable)
+        mock_cse_b.__str__.return_value = "tensor_b"
+        mock_cse_b.dtype = torch.float32
+        mock_cse_b.bounds = ValueRanges.unknown()
+        mock_cse_b.shape = (32, 64)
+
+        def generate(fast_math):
+            kernel = CuteDSLTemplateKernel(
+                kernel_name="test_fast_math",
+                input_nodes=[],
+                output_node=None,
+            )
+            with (
+                V.set_kernel_handler(kernel),
+                use_cutedsl_fast_math(fast_math),
+            ):
+                for op_name in (
+                    "exp",
+                    "exp2",
+                    "sqrt",
+                    "rsqrt",
+                    "log",
+                    "log2",
+                    "log10",
+                    "cos",
+                    "sin",
+                    "tan",
+                    "acos",
+                    "asin",
+                    "atan",
+                    "erf",
+                    "floor",
+                    "tanh",
+                    "sigmoid",
+                ):
+                    result = getattr(CuteDSLOpOverrides, op_name)(mock_cse_a)
+                    self.assertIsInstance(result, CSEVariable)
+                result = CuteDSLOpOverrides.atan2(mock_cse_a, mock_cse_b)
+                self.assertIsInstance(result, CSEVariable)
+            return kernel.body.getvalue()
+
+        with V.set_graph_handler(MockGraphHandler()):
+            fast_math_body = generate(True)
+            precise_body = generate(False)
+
+        math_lines = [
+            line for line in fast_math_body.splitlines() if "cute.math." in line
+        ]
+        self.assertGreater(len(math_lines), 0)
+        self.assertTrue(all("fastmath=True" in line for line in math_lines))
+        self.assertNotIn("fastmath=True", precise_body)
+
     def test_cse_integration(self):
         """Test CSE (Common Subexpression Elimination) integration."""
         from torch._inductor.codegen.common import CSE

--- a/test/inductor/test_flex_gemm.py
+++ b/test/inductor/test_flex_gemm.py
@@ -235,9 +235,7 @@ class TestFlexGemmRuntimeHelpers(TestCase):
         name_fn=lambda case: case[0],
     )
     def test_fast_math_decompositions_preserve_type_promotion(self, case):
-        from torch._higher_order_ops.flex_gemm import (
-            flex_gemm_body_decomposition_table,
-        )
+        from torch._higher_order_ops.flex_gemm import flex_gemm_body_decomposition_table
         from torch._inductor.decomposition import decompositions
         from torch.fx.experimental.proxy_tensor import make_fx
 

--- a/test/inductor/test_flex_gemm.py
+++ b/test/inductor/test_flex_gemm.py
@@ -1788,6 +1788,7 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
             return (
                 torch.tanh(acc)
                 + torch.sigmoid(acc)
+                + torch.exp(-acc.abs())
                 + torch.log1p(acc.abs())
                 + torch.sqrt(magnitude)
                 + torch.rsqrt(magnitude)
@@ -1821,6 +1822,43 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
             self.assertIn(f"cute.math.{op_name}", fast_code)
         self.assertIn("fastmath=True", fast_code)
         self.assertNotIn("fastmath=True", precise_code)
+
+    @skipIfNoCuteDSL
+    @unittest.skipIf(not TEST_CUDA, "CUDA required")
+    @unittest.skipIf(not SM100OrLater, "SM100+ required")
+    def test_mm_fast_math_sigmoid_uses_tanh_decomposition(self):
+        def epilogue_fn(acc):
+            return torch.sigmoid(acc)
+
+        def compile_with_fast_math(a, b, fast_math):
+            def fn(a, b):
+                return flex_gemm(
+                    torch.mm,
+                    (a, b),
+                    epilogue_fn,
+                    kernel_options={"backend": "QUACK", "fast_math": fast_math},
+                )
+
+            torch._dynamo.reset()
+            return run_and_get_code(
+                torch.compile(fn, backend="inductor", fullgraph=True), a, b
+            )
+
+        a = self.makeTensor(128, 64)
+        b = self.makeTensor(64, 128)
+        fast_result, (fast_code,) = compile_with_fast_math(a, b, True)
+        precise_result, (precise_code,) = compile_with_fast_math(a, b, False)
+        expected = epilogue_fn(a.double() @ b.double())
+
+        torch.testing.assert_close(fast_result.double(), expected, atol=0.2, rtol=0.02)
+        torch.testing.assert_close(
+            precise_result.double(), expected, atol=0.02, rtol=0.002
+        )
+        self.assertIn("cute.math.tanh", fast_code)
+        self.assertIn("fastmath=True", fast_code)
+        self.assertNotIn("cute.math.exp2", fast_code)
+        self.assertIn("cute.math.exp2", precise_code)
+        self.assertNotIn("cute.math.tanh", precise_code)
 
     @skipIfNoCuteDSL
     @unittest.skipIf(not TEST_CUDA, "CUDA required")

--- a/test/inductor/test_flex_gemm.py
+++ b/test/inductor/test_flex_gemm.py
@@ -1825,6 +1825,43 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
     @skipIfNoCuteDSL
     @unittest.skipIf(not TEST_CUDA, "CUDA required")
     @unittest.skipIf(not SM100OrLater, "SM100+ required")
+    def test_mm_fast_math_silu_uses_tanh_decomposition(self):
+        def epilogue_fn(acc):
+            return torch.nn.functional.silu(acc)
+
+        def compile_with_fast_math(a, b, fast_math):
+            def fn(a, b):
+                return flex_gemm(
+                    torch.mm,
+                    (a, b),
+                    epilogue_fn,
+                    kernel_options={"backend": "QUACK", "fast_math": fast_math},
+                )
+
+            torch._dynamo.reset()
+            return run_and_get_code(
+                torch.compile(fn, backend="inductor", fullgraph=True), a, b
+            )
+
+        a = self.makeTensor(128, 64)
+        b = self.makeTensor(64, 128)
+        fast_result, (fast_code,) = compile_with_fast_math(a, b, True)
+        precise_result, (precise_code,) = compile_with_fast_math(a, b, False)
+        expected = epilogue_fn(a.double() @ b.double())
+
+        torch.testing.assert_close(fast_result.double(), expected, atol=0.2, rtol=0.02)
+        torch.testing.assert_close(
+            precise_result.double(), expected, atol=0.02, rtol=0.002
+        )
+        self.assertIn("cute.math.tanh", fast_code)
+        self.assertIn("fastmath=True", fast_code)
+        self.assertNotIn("cute.math.exp2", fast_code)
+        self.assertIn("cute.math.exp2", precise_code)
+        self.assertNotIn("cute.math.tanh", precise_code)
+
+    @skipIfNoCuteDSL
+    @unittest.skipIf(not TEST_CUDA, "CUDA required")
+    @unittest.skipIf(not SM100OrLater, "SM100+ required")
     def test_mm_dynamic_shapes_compiled_matches_reference(self):
         def epilogue_fn(acc):
             return (acc + 1).relu()

--- a/test/inductor/test_flex_gemm.py
+++ b/test/inductor/test_flex_gemm.py
@@ -1782,6 +1782,49 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
     @skipIfNoCuteDSL
     @unittest.skipIf(not TEST_CUDA, "CUDA required")
     @unittest.skipIf(not SM100OrLater, "SM100+ required")
+    def test_mm_fast_math_kernel_option_controls_cutedsl_math(self):
+        def epilogue_fn(acc):
+            magnitude = acc.abs() + 1.0
+            return (
+                torch.tanh(acc)
+                + torch.sigmoid(acc)
+                + torch.log1p(acc.abs())
+                + torch.sqrt(magnitude)
+                + torch.rsqrt(magnitude)
+            )
+
+        def compile_with_fast_math(a, b, fast_math):
+            def fn(a, b):
+                return flex_gemm(
+                    torch.mm,
+                    (a, b),
+                    epilogue_fn,
+                    kernel_options={"backend": "QUACK", "fast_math": fast_math},
+                )
+
+            torch._dynamo.reset()
+            return run_and_get_code(
+                torch.compile(fn, backend="inductor", fullgraph=True), a, b
+            )
+
+        a = self.makeTensor(128, 64)
+        b = self.makeTensor(64, 128)
+        fast_result, (fast_code,) = compile_with_fast_math(a, b, True)
+        precise_result, (precise_code,) = compile_with_fast_math(a, b, False)
+        expected = epilogue_fn(a.double() @ b.double())
+
+        torch.testing.assert_close(fast_result.double(), expected, atol=0.2, rtol=0.02)
+        torch.testing.assert_close(
+            precise_result.double(), expected, atol=0.02, rtol=0.002
+        )
+        for op_name in ("tanh", "exp2", "log", "sqrt", "rsqrt"):
+            self.assertIn(f"cute.math.{op_name}", fast_code)
+        self.assertIn("fastmath=True", fast_code)
+        self.assertNotIn("fastmath=True", precise_code)
+
+    @skipIfNoCuteDSL
+    @unittest.skipIf(not TEST_CUDA, "CUDA required")
+    @unittest.skipIf(not SM100OrLater, "SM100+ required")
     def test_mm_dynamic_shapes_compiled_matches_reference(self):
         def epilogue_fn(acc):
             return (acc + 1).relu()
@@ -5364,6 +5407,12 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
                 lambda acc: acc.relu(),
                 {"backend": "QUACK", "split_k": 2},
                 "unsupported FlexGEMM kernel options",
+            ),
+            (
+                "invalid_fast_math_option",
+                lambda acc: acc.relu(),
+                {"backend": "QUACK", "fast_math": 1},
+                "fast_math kernel option must be bool",
             ),
         ),
         name_fn=lambda case: case[0],

--- a/test/inductor/test_flex_gemm.py
+++ b/test/inductor/test_flex_gemm.py
@@ -186,6 +186,87 @@ class TestFlexGemmRuntimeHelpers(TestCase):
             expected[reduction_type],
         )
 
+    @parametrize(
+        "case",
+        (
+            (
+                "sigmoid_fp16",
+                torch.ops.aten.sigmoid.default,
+                torch.float16,
+                (torch.float32, torch.float16),
+                torch.float16,
+            ),
+            (
+                "sigmoid_bf16",
+                torch.ops.aten.sigmoid.default,
+                torch.bfloat16,
+                (torch.float32, torch.bfloat16),
+                torch.bfloat16,
+            ),
+            (
+                "sigmoid_int",
+                torch.ops.aten.sigmoid.default,
+                torch.int32,
+                (torch.float32,),
+                torch.float32,
+            ),
+            (
+                "sigmoid_bool",
+                torch.ops.aten.sigmoid.default,
+                torch.bool,
+                (torch.float32,),
+                torch.float32,
+            ),
+            (
+                "silu_fp16",
+                torch.ops.aten.silu.default,
+                torch.float16,
+                (torch.float32, torch.float16),
+                torch.float16,
+            ),
+            (
+                "silu_bf16",
+                torch.ops.aten.silu.default,
+                torch.bfloat16,
+                (torch.float32, torch.bfloat16),
+                torch.bfloat16,
+            ),
+        ),
+        name_fn=lambda case: case[0],
+    )
+    def test_fast_math_decompositions_preserve_type_promotion(self, case):
+        from torch._higher_order_ops.flex_gemm import (
+            flex_gemm_body_decomposition_table,
+        )
+        from torch._inductor.decomposition import decompositions
+        from torch.fx.experimental.proxy_tensor import make_fx
+
+        _, op, input_dtype, conversion_dtypes, result_dtype = case
+        decomposition_table = flex_gemm_body_decomposition_table(
+            {"backend": "QUACK", "fast_math": True}, decompositions
+        )
+        graph_module = make_fx(
+            lambda x: op(x), decomposition_table=decomposition_table
+        )(torch.ones(4, dtype=input_dtype))
+
+        self.assertEqual(
+            tuple(
+                node.args[1]
+                for node in graph_module.graph.nodes
+                if node.target is torch.ops.prims.convert_element_type.default
+            ),
+            conversion_dtypes,
+        )
+        self.assertEqual(
+            graph_module(torch.ones(4, dtype=input_dtype)).dtype, result_dtype
+        )
+        self.assertTrue(
+            any(
+                node.target is torch.ops.aten.tanh.default
+                for node in graph_module.graph.nodes
+            )
+        )
+
     def test_dense_config_selection_is_explicit_and_sm110_reuses_sm100(self):
         from torch._inductor.heuristics.template import (
             flex_gemm as flex_gemm_heuristics,

--- a/test/inductor/test_flex_gemm.py
+++ b/test/inductor/test_flex_gemm.py
@@ -16,6 +16,7 @@ from torch._inductor.ops_handler import ReductionType
 from torch._inductor.utils import run_and_get_code
 from torch.testing import FileCheck
 from torch.testing._internal.common_cuda import SM100OrLater, TEST_CUDA
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
@@ -347,10 +348,26 @@ class TestFlexGemmRuntimeHelpers(TestCase):
 
 
 class FlexGemmTestCase(TestCase):
-    def makeTensor(self, *shape, dtype=torch.bfloat16):
+    def makeTensor(self, *shape, device="cuda", dtype=torch.bfloat16):
         return torch.testing.make_tensor(
-            *shape, device="cuda", dtype=dtype, low=-0.1, high=0.1
+            *shape, device=device, dtype=dtype, low=-0.1, high=0.1
         )
+
+    def assertFlexGemmGeneratedCode(self, code, *checks):
+        file_check = (
+            FileCheck()
+            .check("from torch._inductor.kernel.flex_gemm.runtime import (")
+            .check("FlexGemmRuntimeLocalReducePlan")
+            .check("gemm_epilogue as flex_gemm_epilogue")
+            .check("flex_gemm_epilogue(")
+        )
+        for check in checks:
+            file_check = file_check.check(check)
+        file_check = (
+            file_check.check("stream=stream").check("config_key=").check_not("tuned=")
+        )
+        file_check = file_check.check_not("epilogue_source=")
+        file_check.check_not("from quack").check_not("import quack").run(code)
 
     def swapAndNonSwapConfigKeys(self, device):
         """Return one swap_ab and one non-swap candidate config key for ``device``."""
@@ -390,11 +407,13 @@ class FlexGemmTestCase(TestCase):
             actual_error.item(),
             eager_error.item() + rounding_atol,
             msg=(
-                lambda msg: f"{msg}\nactual error {actual_error.item()} exceeded low precision eager "
-                f"error {eager_error.item()} with fp32_accumulation_eps="
-                f"{fp32_accumulation_eps}, result_rounding_eps="
-                f"{result_rounding_eps}, output_scale={output_scale}, "
-                f"and atol={rounding_atol}"
+                lambda msg: (
+                    f"{msg}\nactual error {actual_error.item()} exceeded low precision eager "
+                    f"error {eager_error.item()} with fp32_accumulation_eps="
+                    f"{fp32_accumulation_eps}, result_rounding_eps="
+                    f"{result_rounding_eps}, output_scale={output_scale}, "
+                    f"and atol={rounding_atol}"
+                )
             ),
         )
 
@@ -1590,22 +1609,6 @@ class TestFlexGemmRuntime(FlexGemmTestCase):
 
 @instantiate_parametrized_tests
 class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
-    def assertFlexGemmGeneratedCode(self, code, *checks):
-        file_check = (
-            FileCheck()
-            .check("from torch._inductor.kernel.flex_gemm.runtime import (")
-            .check("FlexGemmRuntimeLocalReducePlan")
-            .check("gemm_epilogue as flex_gemm_epilogue")
-            .check("flex_gemm_epilogue(")
-        )
-        for check in checks:
-            file_check = file_check.check(check)
-        file_check = (
-            file_check.check("stream=stream").check("config_key=").check_not("tuned=")
-        )
-        file_check = file_check.check_not("epilogue_source=")
-        file_check.check_not("from quack").check_not("import quack").run(code)
-
     def test_supported_op_names_match_dense_scope(self):
         self.assertEqual(_SUPPORTED_FLEX_GEMM_OP_NAMES, "mm/addmm/bmm/baddbmm")
 
@@ -1778,190 +1781,6 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
             epilogue_fn(a.double() @ b.double()),
             a.shape[1],
         )
-
-    @skipIfNoCuteDSL
-    @unittest.skipIf(not TEST_CUDA, "CUDA required")
-    @unittest.skipIf(not SM100OrLater, "SM100+ required")
-    def test_mm_fast_math_kernel_option_controls_cutedsl_math(self):
-        def epilogue_fn(acc):
-            magnitude = acc.abs() + 1.0
-            return (
-                torch.tanh(acc)
-                + torch.sigmoid(acc)
-                + torch.exp(-acc.abs())
-                + torch.log1p(acc.abs())
-                + torch.sqrt(magnitude)
-                + torch.rsqrt(magnitude)
-            )
-
-        def compile_with_fast_math(a, b, fast_math):
-            def fn(a, b):
-                return flex_gemm(
-                    torch.mm,
-                    (a, b),
-                    epilogue_fn,
-                    kernel_options={"backend": "QUACK", "fast_math": fast_math},
-                )
-
-            torch._dynamo.reset()
-            return run_and_get_code(
-                torch.compile(fn, backend="inductor", fullgraph=True), a, b
-            )
-
-        a = self.makeTensor(128, 64)
-        b = self.makeTensor(64, 128)
-        fast_result, (fast_code,) = compile_with_fast_math(a, b, True)
-        precise_result, (precise_code,) = compile_with_fast_math(a, b, False)
-        expected = epilogue_fn(a.double() @ b.double())
-
-        torch.testing.assert_close(fast_result.double(), expected, atol=0.2, rtol=0.02)
-        torch.testing.assert_close(
-            precise_result.double(), expected, atol=0.02, rtol=0.002
-        )
-        for op_name in ("tanh", "exp2", "log", "sqrt", "rsqrt"):
-            self.assertIn(f"cute.math.{op_name}", fast_code)
-        self.assertIn("fastmath=True", fast_code)
-        self.assertNotIn("fastmath=True", precise_code)
-
-    @skipIfNoCuteDSL
-    @unittest.skipIf(not TEST_CUDA, "CUDA required")
-    @unittest.skipIf(not SM100OrLater, "SM100+ required")
-    def test_mm_fast_math_sigmoid_uses_tanh_decomposition(self):
-        def epilogue_fn(acc):
-            return torch.sigmoid(acc)
-
-        def compile_with_fast_math(a, b, fast_math):
-            def fn(a, b):
-                return flex_gemm(
-                    torch.mm,
-                    (a, b),
-                    epilogue_fn,
-                    kernel_options={"backend": "QUACK", "fast_math": fast_math},
-                )
-
-            torch._dynamo.reset()
-            return run_and_get_code(
-                torch.compile(fn, backend="inductor", fullgraph=True), a, b
-            )
-
-        a = self.makeTensor(128, 64)
-        b = self.makeTensor(64, 128)
-        fast_result, (fast_code,) = compile_with_fast_math(a, b, True)
-        precise_result, (precise_code,) = compile_with_fast_math(a, b, False)
-        expected = epilogue_fn(a.double() @ b.double())
-
-        torch.testing.assert_close(fast_result.double(), expected, atol=0.2, rtol=0.02)
-        torch.testing.assert_close(
-            precise_result.double(), expected, atol=0.02, rtol=0.002
-        )
-        self.assertIn("cute.math.tanh", fast_code)
-        self.assertIn("fastmath=True", fast_code)
-        self.assertNotIn("cute.math.exp2", fast_code)
-        self.assertIn("cute.math.exp2", precise_code)
-        self.assertNotIn("cute.math.tanh", precise_code)
-
-    @skipIfNoCuteDSL
-    @unittest.skipIf(not TEST_CUDA, "CUDA required")
-    @unittest.skipIf(not SM100OrLater, "SM100+ required")
-    def test_mm_fast_math_silu_uses_tanh_decomposition(self):
-        def epilogue_fn(acc):
-            return torch.nn.functional.silu(acc)
-
-        def compile_with_fast_math(a, b, fast_math):
-            def fn(a, b):
-                return flex_gemm(
-                    torch.mm,
-                    (a, b),
-                    epilogue_fn,
-                    kernel_options={"backend": "QUACK", "fast_math": fast_math},
-                )
-
-            torch._dynamo.reset()
-            return run_and_get_code(
-                torch.compile(fn, backend="inductor", fullgraph=True), a, b
-            )
-
-        a = self.makeTensor(128, 64)
-        b = self.makeTensor(64, 128)
-        fast_result, (fast_code,) = compile_with_fast_math(a, b, True)
-        precise_result, (precise_code,) = compile_with_fast_math(a, b, False)
-        expected = epilogue_fn(a.double() @ b.double())
-
-        torch.testing.assert_close(fast_result.double(), expected, atol=0.2, rtol=0.02)
-        torch.testing.assert_close(
-            precise_result.double(), expected, atol=0.02, rtol=0.002
-        )
-        self.assertIn("cute.math.tanh", fast_code)
-        self.assertIn("fastmath=True", fast_code)
-        self.assertNotIn("cute.math.exp2", fast_code)
-        self.assertIn("cute.math.exp2", precise_code)
-        self.assertNotIn("cute.math.tanh", precise_code)
-
-    @skipIfNoCuteDSL
-    @unittest.skipIf(not TEST_CUDA, "CUDA required")
-    @unittest.skipIf(not SM100OrLater, "SM100+ required")
-    def test_mm_fast_math_gelu_none_uses_tanh_decomposition(self):
-        def epilogue_fn(acc):
-            return torch.nn.functional.gelu(acc, approximate="none")
-
-        def compile_with_fast_math(a, b, fast_math):
-            def fn(a, b):
-                return flex_gemm(
-                    torch.mm,
-                    (a, b),
-                    epilogue_fn,
-                    kernel_options={"backend": "QUACK", "fast_math": fast_math},
-                )
-
-            torch._dynamo.reset()
-            return run_and_get_code(
-                torch.compile(fn, backend="inductor", fullgraph=True), a, b
-            )
-
-        a = self.makeTensor(128, 64)
-        b = self.makeTensor(64, 128)
-        fast_result, (fast_code,) = compile_with_fast_math(a, b, True)
-        precise_result, (precise_code,) = compile_with_fast_math(a, b, False)
-        expected = epilogue_fn(a.double() @ b.double())
-
-        torch.testing.assert_close(
-            fast_result.double(), expected, atol=0.02, rtol=0.002
-        )
-        torch.testing.assert_close(
-            precise_result.double(), expected, atol=0.02, rtol=0.002
-        )
-        self.assertIn("cute.math.tanh", fast_code)
-        self.assertIn("fastmath=True", fast_code)
-        self.assertNotIn("cute.math.erf", fast_code)
-        self.assertIn("cute.math.erf", precise_code)
-        self.assertNotIn("cute.math.tanh", precise_code)
-
-    @skipIfNoCuteDSL
-    @unittest.skipIf(not TEST_CUDA, "CUDA required")
-    @unittest.skipIf(not SM100OrLater, "SM100+ required")
-    def test_mm_fast_math_gelu_tanh_preserves_requested_approximation(self):
-        def epilogue_fn(acc):
-            return torch.nn.functional.gelu(acc, approximate="tanh")
-
-        def fn(a, b):
-            return flex_gemm(
-                torch.mm,
-                (a, b),
-                epilogue_fn,
-                kernel_options={"backend": "QUACK", "fast_math": True},
-            )
-
-        a = self.makeTensor(128, 64)
-        b = self.makeTensor(64, 128)
-        actual, (code,) = run_and_get_code(
-            torch.compile(fn, backend="inductor", fullgraph=True), a, b
-        )
-        expected = epilogue_fn(a.double() @ b.double())
-
-        torch.testing.assert_close(actual.double(), expected, atol=0.02, rtol=0.002)
-        self.assertIn("cute.math.tanh", code)
-        self.assertIn("fastmath=True", code)
-        self.assertNotIn("cute.math.erf", code)
 
     @skipIfNoCuteDSL
     @unittest.skipIf(not TEST_CUDA, "CUDA required")
@@ -3495,8 +3314,9 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
         (
             (
                 "variance_like",
-                lambda x: ((x - x.mean(-1, keepdim=True)).square()).mean(-1) * 0.5
-                + 1.0,
+                lambda x: (
+                    ((x - x.mean(-1, keepdim=True)).square()).mean(-1) * 0.5 + 1.0
+                ),
                 " / 4.0",
                 False,
             ),
@@ -5599,6 +5419,181 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
                 kernel_options={"backend": "CUTLASS"},
             )
 
+
+@skipIfNoCuteDSL
+@unittest.skipIf(not SM100OrLater, "SM100+ required")
+class TestFlexGemmFastMathDevice(FlexGemmTestCase):
+    def test_mm_fast_math_kernel_option_controls_cutedsl_math(self, device):
+        def epilogue_fn(acc):
+            magnitude = acc.abs() + 1.0
+            return (
+                torch.tanh(acc)
+                + torch.sigmoid(acc)
+                + torch.exp(-acc.abs())
+                + torch.log1p(acc.abs())
+                + torch.sqrt(magnitude)
+                + torch.rsqrt(magnitude)
+            )
+
+        def compile_with_fast_math(a, b, fast_math):
+            def fn(a, b):
+                return flex_gemm(
+                    torch.mm,
+                    (a, b),
+                    epilogue_fn,
+                    kernel_options={"backend": "QUACK", "fast_math": fast_math},
+                )
+
+            torch._dynamo.reset()
+            return run_and_get_code(
+                torch.compile(fn, backend="inductor", fullgraph=True), a, b
+            )
+
+        a = self.makeTensor(128, 64, device=device)
+        b = self.makeTensor(64, 128, device=device)
+        fast_result, (fast_code,) = compile_with_fast_math(a, b, True)
+        precise_result, (precise_code,) = compile_with_fast_math(a, b, False)
+        expected = epilogue_fn(a.double() @ b.double())
+
+        torch.testing.assert_close(fast_result.double(), expected, atol=0.2, rtol=0.02)
+        torch.testing.assert_close(
+            precise_result.double(), expected, atol=0.02, rtol=0.002
+        )
+        for op_name in ("tanh", "exp2", "log", "sqrt", "rsqrt"):
+            self.assertIn(f"cute.math.{op_name}", fast_code)
+        self.assertIn("fastmath=True", fast_code)
+        self.assertNotIn("fastmath=True", precise_code)
+
+    def test_mm_fast_math_sigmoid_uses_tanh_decomposition(self, device):
+        def epilogue_fn(acc):
+            return torch.sigmoid(acc)
+
+        def compile_with_fast_math(a, b, fast_math):
+            def fn(a, b):
+                return flex_gemm(
+                    torch.mm,
+                    (a, b),
+                    epilogue_fn,
+                    kernel_options={"backend": "QUACK", "fast_math": fast_math},
+                )
+
+            torch._dynamo.reset()
+            return run_and_get_code(
+                torch.compile(fn, backend="inductor", fullgraph=True), a, b
+            )
+
+        a = self.makeTensor(128, 64, device=device)
+        b = self.makeTensor(64, 128, device=device)
+        fast_result, (fast_code,) = compile_with_fast_math(a, b, True)
+        precise_result, (precise_code,) = compile_with_fast_math(a, b, False)
+        expected = epilogue_fn(a.double() @ b.double())
+
+        torch.testing.assert_close(fast_result.double(), expected, atol=0.2, rtol=0.02)
+        torch.testing.assert_close(
+            precise_result.double(), expected, atol=0.02, rtol=0.002
+        )
+        self.assertIn("cute.math.tanh", fast_code)
+        self.assertIn("fastmath=True", fast_code)
+        self.assertNotIn("cute.math.exp2", fast_code)
+        self.assertIn("cute.math.exp2", precise_code)
+        self.assertNotIn("cute.math.tanh", precise_code)
+
+    def test_mm_fast_math_silu_uses_tanh_decomposition(self, device):
+        def epilogue_fn(acc):
+            return torch.nn.functional.silu(acc)
+
+        def compile_with_fast_math(a, b, fast_math):
+            def fn(a, b):
+                return flex_gemm(
+                    torch.mm,
+                    (a, b),
+                    epilogue_fn,
+                    kernel_options={"backend": "QUACK", "fast_math": fast_math},
+                )
+
+            torch._dynamo.reset()
+            return run_and_get_code(
+                torch.compile(fn, backend="inductor", fullgraph=True), a, b
+            )
+
+        a = self.makeTensor(128, 64, device=device)
+        b = self.makeTensor(64, 128, device=device)
+        fast_result, (fast_code,) = compile_with_fast_math(a, b, True)
+        precise_result, (precise_code,) = compile_with_fast_math(a, b, False)
+        expected = epilogue_fn(a.double() @ b.double())
+
+        torch.testing.assert_close(fast_result.double(), expected, atol=0.2, rtol=0.02)
+        torch.testing.assert_close(
+            precise_result.double(), expected, atol=0.02, rtol=0.002
+        )
+        self.assertIn("cute.math.tanh", fast_code)
+        self.assertIn("fastmath=True", fast_code)
+        self.assertNotIn("cute.math.exp2", fast_code)
+        self.assertIn("cute.math.exp2", precise_code)
+        self.assertNotIn("cute.math.tanh", precise_code)
+
+    def test_mm_fast_math_gelu_none_uses_tanh_decomposition(self, device):
+        def epilogue_fn(acc):
+            return torch.nn.functional.gelu(acc, approximate="none")
+
+        def compile_with_fast_math(a, b, fast_math):
+            def fn(a, b):
+                return flex_gemm(
+                    torch.mm,
+                    (a, b),
+                    epilogue_fn,
+                    kernel_options={"backend": "QUACK", "fast_math": fast_math},
+                )
+
+            torch._dynamo.reset()
+            return run_and_get_code(
+                torch.compile(fn, backend="inductor", fullgraph=True), a, b
+            )
+
+        a = self.makeTensor(128, 64, device=device)
+        b = self.makeTensor(64, 128, device=device)
+        fast_result, (fast_code,) = compile_with_fast_math(a, b, True)
+        precise_result, (precise_code,) = compile_with_fast_math(a, b, False)
+        expected = epilogue_fn(a.double() @ b.double())
+
+        torch.testing.assert_close(
+            fast_result.double(), expected, atol=0.02, rtol=0.002
+        )
+        torch.testing.assert_close(
+            precise_result.double(), expected, atol=0.02, rtol=0.002
+        )
+        self.assertIn("cute.math.tanh", fast_code)
+        self.assertIn("fastmath=True", fast_code)
+        self.assertNotIn("cute.math.erf", fast_code)
+        self.assertIn("cute.math.erf", precise_code)
+        self.assertNotIn("cute.math.tanh", precise_code)
+
+    def test_mm_fast_math_gelu_tanh_preserves_requested_approximation(self, device):
+        def epilogue_fn(acc):
+            return torch.nn.functional.gelu(acc, approximate="tanh")
+
+        def fn(a, b):
+            return flex_gemm(
+                torch.mm,
+                (a, b),
+                epilogue_fn,
+                kernel_options={"backend": "QUACK", "fast_math": True},
+            )
+
+        a = self.makeTensor(128, 64, device=device)
+        b = self.makeTensor(64, 128, device=device)
+        actual, (code,) = run_and_get_code(
+            torch.compile(fn, backend="inductor", fullgraph=True), a, b
+        )
+        expected = epilogue_fn(a.double() @ b.double())
+
+        torch.testing.assert_close(actual.double(), expected, atol=0.02, rtol=0.002)
+        self.assertIn("cute.math.tanh", code)
+        self.assertIn("fastmath=True", code)
+        self.assertNotIn("cute.math.erf", code)
+
+
+instantiate_device_type_tests(TestFlexGemmFastMathDevice, globals(), only_for="cuda")
 
 if __name__ == "__main__":
     run_tests()

--- a/test/inductor/test_flex_gemm.py
+++ b/test/inductor/test_flex_gemm.py
@@ -1900,6 +1900,72 @@ class TestFlexGemmEpilogueHOP(FlexGemmTestCase):
     @skipIfNoCuteDSL
     @unittest.skipIf(not TEST_CUDA, "CUDA required")
     @unittest.skipIf(not SM100OrLater, "SM100+ required")
+    def test_mm_fast_math_gelu_none_uses_tanh_decomposition(self):
+        def epilogue_fn(acc):
+            return torch.nn.functional.gelu(acc, approximate="none")
+
+        def compile_with_fast_math(a, b, fast_math):
+            def fn(a, b):
+                return flex_gemm(
+                    torch.mm,
+                    (a, b),
+                    epilogue_fn,
+                    kernel_options={"backend": "QUACK", "fast_math": fast_math},
+                )
+
+            torch._dynamo.reset()
+            return run_and_get_code(
+                torch.compile(fn, backend="inductor", fullgraph=True), a, b
+            )
+
+        a = self.makeTensor(128, 64)
+        b = self.makeTensor(64, 128)
+        fast_result, (fast_code,) = compile_with_fast_math(a, b, True)
+        precise_result, (precise_code,) = compile_with_fast_math(a, b, False)
+        expected = epilogue_fn(a.double() @ b.double())
+
+        torch.testing.assert_close(
+            fast_result.double(), expected, atol=0.02, rtol=0.002
+        )
+        torch.testing.assert_close(
+            precise_result.double(), expected, atol=0.02, rtol=0.002
+        )
+        self.assertIn("cute.math.tanh", fast_code)
+        self.assertIn("fastmath=True", fast_code)
+        self.assertNotIn("cute.math.erf", fast_code)
+        self.assertIn("cute.math.erf", precise_code)
+        self.assertNotIn("cute.math.tanh", precise_code)
+
+    @skipIfNoCuteDSL
+    @unittest.skipIf(not TEST_CUDA, "CUDA required")
+    @unittest.skipIf(not SM100OrLater, "SM100+ required")
+    def test_mm_fast_math_gelu_tanh_preserves_requested_approximation(self):
+        def epilogue_fn(acc):
+            return torch.nn.functional.gelu(acc, approximate="tanh")
+
+        def fn(a, b):
+            return flex_gemm(
+                torch.mm,
+                (a, b),
+                epilogue_fn,
+                kernel_options={"backend": "QUACK", "fast_math": True},
+            )
+
+        a = self.makeTensor(128, 64)
+        b = self.makeTensor(64, 128)
+        actual, (code,) = run_and_get_code(
+            torch.compile(fn, backend="inductor", fullgraph=True), a, b
+        )
+        expected = epilogue_fn(a.double() @ b.double())
+
+        torch.testing.assert_close(actual.double(), expected, atol=0.02, rtol=0.002)
+        self.assertIn("cute.math.tanh", code)
+        self.assertIn("fastmath=True", code)
+        self.assertNotIn("cute.math.erf", code)
+
+    @skipIfNoCuteDSL
+    @unittest.skipIf(not TEST_CUDA, "CUDA required")
+    @unittest.skipIf(not SM100OrLater, "SM100+ required")
     def test_mm_dynamic_shapes_compiled_matches_reference(self):
         def epilogue_fn(acc):
             return (acc + 1).relu()

--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -2,6 +2,8 @@
 
 import builtins
 import importlib.util
+import os
+import sys
 import tempfile
 import unittest
 from collections.abc import Callable, Iterator
@@ -24,6 +26,7 @@ from torch._inductor.fx_utils import (
 from torch._inductor.utils import (
     get_device_tflops,
     load_template,
+    python_subprocess_env,
     sympy_str,
     sympy_subs,
 )
@@ -43,6 +46,22 @@ from torch.utils._sympy.functions import Identity
 
 
 class TestUtils(TestCase):
+    def test_python_subprocess_env_prioritizes_loaded_torch(self):
+        torch_package_root = os.path.dirname(
+            os.path.dirname(os.path.abspath(torch.__file__))
+        )
+        with tempfile.TemporaryDirectory() as shadow_path:
+            with mock.patch.object(sys, "path", [shadow_path, *sys.path]):
+                env = python_subprocess_env()
+        self.assertEqual(env["PYTHONPATH"].split(os.pathsep)[0], torch_package_root)
+
+    def test_python_subprocess_env_respects_override(self):
+        with mock.patch.dict(
+            os.environ, {"TORCH_CUSTOM_PYTHONPATH": "custom_python_path"}
+        ):
+            env = python_subprocess_env()
+        self.assertEqual(env["PYTHONPATH"], "custom_python_path")
+
     def test_zip_schema(self):
         def foo(x: torch.Tensor) -> None:
             pass

--- a/torch/_higher_order_ops/flex_gemm.py
+++ b/torch/_higher_order_ops/flex_gemm.py
@@ -73,6 +73,11 @@ FLEX_GEMM_BODY_GRAPH_PASSES: tuple[
 ] = (mark_flex_gemm_body_gemm_node,)
 
 
+def flex_gemm_fast_math_sigmoid(x: torch.Tensor) -> torch.Tensor:
+    """Use the tanh sigmoid identity selected by QUACK fast math."""
+    return torch.tanh(x * 0.5) * 0.5 + 0.5
+
+
 def flex_gemm_fast_math_silu(x: torch.Tensor) -> torch.Tensor:
     """Use the tanh SiLU identity selected by QUACK fast math."""
     half = x * 0.5
@@ -80,7 +85,8 @@ def flex_gemm_fast_math_silu(x: torch.Tensor) -> torch.Tensor:
 
 
 FLEX_GEMM_FAST_MATH_DECOMPOSITIONS: dict[torch._ops.OpOverload, Callable[..., Any]] = {
-    torch.ops.aten.silu.default: flex_gemm_fast_math_silu
+    torch.ops.aten.sigmoid.default: flex_gemm_fast_math_sigmoid,
+    torch.ops.aten.silu.default: flex_gemm_fast_math_silu,
 }
 
 

--- a/torch/_higher_order_ops/flex_gemm.py
+++ b/torch/_higher_order_ops/flex_gemm.py
@@ -1,6 +1,6 @@
 # mypy: allow-untyped-defs
 import dataclasses
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from typing import Any, cast
 
 import torch
@@ -71,6 +71,32 @@ def mark_flex_gemm_body_gemm_node(
 FLEX_GEMM_BODY_GRAPH_PASSES: tuple[
     Callable[[torch.fx.GraphModule, torch._ops.OpOverload], None], ...
 ] = (mark_flex_gemm_body_gemm_node,)
+
+
+def flex_gemm_fast_math_silu(x: torch.Tensor) -> torch.Tensor:
+    """Use the tanh SiLU identity selected by QUACK fast math."""
+    half = x * 0.5
+    return half * torch.tanh(half) + half
+
+
+FLEX_GEMM_FAST_MATH_DECOMPOSITIONS: dict[torch._ops.OpOverload, Callable[..., Any]] = {
+    torch.ops.aten.silu.default: flex_gemm_fast_math_silu
+}
+
+
+def flex_gemm_body_decomposition_table(
+    kernel_options: dict[str, Any],
+    decomposition_table: Mapping[torch._ops.OpOverload, Callable[..., Any]],
+) -> dict[torch._ops.OpOverload, Callable[..., Any]] | None:
+    """Override composite body decompositions enabled by QUACK fast math."""
+    if (
+        kernel_options.get("backend") != "QUACK"
+        or kernel_options.get("fast_math") is not True
+    ):
+        return None
+    merged_decompositions = dict(decomposition_table)
+    merged_decompositions.update(FLEX_GEMM_FAST_MATH_DECOMPOSITIONS)
+    return merged_decompositions
 
 
 def apply_flex_gemm_body_graph_passes(
@@ -213,7 +239,12 @@ def flex_gemm_proxy_torch_dispatch_mode(
         def tracing_body_fn(*flat_body_args):
             return body_fn(*flat_body_args)
 
-        body_graph = reenter_make_fx(tracing_body_fn)(*flat_args)
+        body_graph = reenter_make_fx(
+            tracing_body_fn,
+            subgraph_decomp_table=flex_gemm_body_decomposition_table(
+                kernel_options, proxy_mode.decomposition_table
+            ),
+        )(*flat_args)
         apply_flex_gemm_body_graph_passes(body_graph, gemm_op)
         _, body_graph_name = unique_graph_id(proxy_mode, prefix="flex_gemm_body_graph")
         proxy_mode.tracer.root.register_module(body_graph_name, body_graph)

--- a/torch/_higher_order_ops/flex_gemm.py
+++ b/torch/_higher_order_ops/flex_gemm.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 import dataclasses
 from collections.abc import Callable, Mapping
+from functools import partial
 from typing import Any, cast
 
 import torch
@@ -84,6 +85,18 @@ def flex_gemm_fast_math_silu(x: torch.Tensor) -> torch.Tensor:
     return half * torch.tanh(half) + half
 
 
+def flex_gemm_fast_math_gelu(
+    x: torch.Tensor,
+    approximate: str = "none",
+    *,
+    fallback: Callable[..., Any],
+) -> torch.Tensor:
+    """Approximate exact GELU with the standard tanh formulation."""
+    if approximate != "none":
+        return fallback(x, approximate)
+    return 0.5 * x * (1.0 + torch.tanh(0.7978845608028654 * (x + 0.044715 * x * x * x)))
+
+
 FLEX_GEMM_FAST_MATH_DECOMPOSITIONS: dict[torch._ops.OpOverload, Callable[..., Any]] = {
     torch.ops.aten.sigmoid.default: flex_gemm_fast_math_sigmoid,
     torch.ops.aten.silu.default: flex_gemm_fast_math_silu,
@@ -102,6 +115,11 @@ def flex_gemm_body_decomposition_table(
         return None
     merged_decompositions = dict(decomposition_table)
     merged_decompositions.update(FLEX_GEMM_FAST_MATH_DECOMPOSITIONS)
+    gelu = torch.ops.aten.gelu.default
+    if gelu in merged_decompositions:
+        merged_decompositions[gelu] = partial(
+            flex_gemm_fast_math_gelu, fallback=merged_decompositions[gelu]
+        )
     return merged_decompositions
 
 

--- a/torch/_higher_order_ops/flex_gemm.py
+++ b/torch/_higher_order_ops/flex_gemm.py
@@ -15,6 +15,8 @@ from torch._higher_order_ops.utils import (
     unique_graph_id,
 )
 from torch._ops import HigherOrderOperator
+from torch._prims_common import ELEMENTWISE_TYPE_PROMOTION_KIND
+from torch._prims_common.wrappers import elementwise_type_promotion_wrapper
 from torch.fx.experimental.proxy_tensor import ProxyTorchDispatchMode, track_tensor_tree
 
 
@@ -74,11 +76,19 @@ FLEX_GEMM_BODY_GRAPH_PASSES: tuple[
 ] = (mark_flex_gemm_body_gemm_node,)
 
 
+@elementwise_type_promotion_wrapper(
+    type_promoting_args=("x",),
+    type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT,
+)
 def flex_gemm_fast_math_sigmoid(x: torch.Tensor) -> torch.Tensor:
     """Use the tanh sigmoid identity selected by QUACK fast math."""
     return torch.tanh(x * 0.5) * 0.5 + 0.5
 
 
+@elementwise_type_promotion_wrapper(
+    type_promoting_args=("x",),
+    type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
+)
 def flex_gemm_fast_math_silu(x: torch.Tensor) -> torch.Tensor:
     """Use the tanh SiLU identity selected by QUACK fast math."""
     half = x * 0.5
@@ -91,10 +101,10 @@ def flex_gemm_fast_math_gelu(
     *,
     fallback: Callable[..., Any],
 ) -> torch.Tensor:
-    """Approximate exact GELU with the standard tanh formulation."""
-    if approximate != "none":
-        return fallback(x, approximate)
-    return 0.5 * x * (1.0 + torch.tanh(0.7978845608028654 * (x + 0.044715 * x * x * x)))
+    """Select the standard tanh GELU approximation for exact GELU calls."""
+    if approximate == "none":
+        approximate = "tanh"
+    return fallback(x, approximate)
 
 
 FLEX_GEMM_FAST_MATH_DECOMPOSITIONS: dict[torch._ops.OpOverload, Callable[..., Any]] = {

--- a/torch/_inductor/codegen/cutedsl/cutedsl_op_overrides.py
+++ b/torch/_inductor/codegen/cutedsl/cutedsl_op_overrides.py
@@ -8,6 +8,9 @@ template kernels, particularly for flex attention modifications.
 
 import dataclasses
 import math
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
 
 import sympy
 
@@ -37,6 +40,19 @@ class CuteDSLCSEVariable(CSEVariable):
 
 
 CuteDSLArg = CSEVariable | str | bool | float | int
+
+
+_CUTEDSL_FAST_MATH: ContextVar[bool] = ContextVar("cutedsl_fast_math", default=False)
+
+
+@contextmanager
+def use_cutedsl_fast_math(enabled: bool) -> Iterator[None]:
+    """Scope whether CuTeDSL math operations request fast-math lowering."""
+    token = _CUTEDSL_FAST_MATH.set(enabled)
+    try:
+        yield
+    finally:
+        _CUTEDSL_FAST_MATH.reset(token)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -302,6 +318,11 @@ class CuteDSLOpOverrides(OpOverrides):
         return f"{cute_type}({expr})"
 
     @staticmethod
+    def _math_call(name: str, *args: str) -> str:
+        fast_math = ", fastmath=True" if _CUTEDSL_FAST_MATH.get() else ""
+        return f"cute.math.{name}({', '.join(args)}{fast_math})"
+
+    @staticmethod
     def _apply_unary_op(
         x: CuteDSLArg, op_format: str, index_expr_fn=None
     ) -> CuteDSLArg:
@@ -336,6 +357,12 @@ class CuteDSLOpOverrides(OpOverrides):
             return result
 
         return op_format.format(x=x)
+
+    @staticmethod
+    def _apply_math_unary_op(x: CuteDSLArg, name: str) -> CuteDSLArg:
+        return CuteDSLOpOverrides._apply_unary_op(
+            x, CuteDSLOpOverrides._math_call(name, "{x}")
+        )
 
     @staticmethod
     def constant(value: bool | float | int, dtype: torch.dtype) -> str:
@@ -418,83 +445,90 @@ class CuteDSLOpOverrides(OpOverrides):
         if CuteDSLOpOverrides._get_cse_var(x) is None:
             x = CuteDSLOpOverrides._cast_expr(str(x), torch.float32)
         return CuteDSLOpOverrides._apply_unary_op(
-            x, f"cute.math.exp2({{x}} * {CuteDSLOpOverrides.LOG2_E})"
+            x,
+            CuteDSLOpOverrides._math_call(
+                "exp2", f"{{x}} * {CuteDSLOpOverrides.LOG2_E}"
+            ),
         )
 
     @staticmethod
     # pyrefly: ignore [bad-override]
     def exp2(x: CuteDSLArg) -> CuteDSLArg:
-        return CuteDSLOpOverrides._apply_unary_op(x, "cute.math.exp2({x})")
+        return CuteDSLOpOverrides._apply_math_unary_op(x, "exp2")
 
     @staticmethod
     # pyrefly: ignore [bad-override]
     def sqrt(x: CuteDSLArg) -> CuteDSLArg:
         """Square root using CuteDSL cute.math.sqrt function."""
-        return CuteDSLOpOverrides._apply_unary_op(x, "cute.math.sqrt({x})")
+        return CuteDSLOpOverrides._apply_math_unary_op(x, "sqrt")
 
     @staticmethod
     # pyrefly: ignore [bad-override]
     def rsqrt(x: CuteDSLArg) -> CuteDSLArg:
-        return CuteDSLOpOverrides._apply_unary_op(x, "cute.math.rsqrt({x})")
+        return CuteDSLOpOverrides._apply_math_unary_op(x, "rsqrt")
 
     @staticmethod
     # pyrefly: ignore [bad-override]
     def log(x: CuteDSLArg) -> CuteDSLArg:
         """Natural logarithm using CuteDSL cute.math.log function."""
-        return CuteDSLOpOverrides._apply_unary_op(x, "cute.math.log({x})")
+        return CuteDSLOpOverrides._apply_math_unary_op(x, "log")
 
     @staticmethod
     # pyrefly: ignore [bad-override]
     def log2(x: CuteDSLArg) -> CuteDSLArg:
-        return CuteDSLOpOverrides._apply_unary_op(x, "cute.math.log2({x})")
+        return CuteDSLOpOverrides._apply_math_unary_op(x, "log2")
 
     @staticmethod
     # pyrefly: ignore [bad-override]
     def log10(x: CuteDSLArg) -> CuteDSLArg:
-        return CuteDSLOpOverrides._apply_unary_op(x, "cute.math.log10({x})")
+        return CuteDSLOpOverrides._apply_math_unary_op(x, "log10")
 
     @staticmethod
     # pyrefly: ignore [bad-override]
     def cos(x: CuteDSLArg) -> CuteDSLArg:
         """Cosine using CuteDSL cute.math.cos function."""
-        return CuteDSLOpOverrides._apply_unary_op(x, "cute.math.cos({x})")
+        return CuteDSLOpOverrides._apply_math_unary_op(x, "cos")
 
     @staticmethod
     # pyrefly: ignore [bad-override]
     def sin(x: CuteDSLArg) -> CuteDSLArg:
         """Sine using CuteDSL cute.math.sin function."""
-        return CuteDSLOpOverrides._apply_unary_op(x, "cute.math.sin({x})")
+        return CuteDSLOpOverrides._apply_math_unary_op(x, "sin")
 
     @staticmethod
     # pyrefly: ignore [bad-override]
     def tan(x: CuteDSLArg) -> CuteDSLArg:
-        return CuteDSLOpOverrides._apply_unary_op(x, "cute.math.tan({x})")
+        return CuteDSLOpOverrides._apply_math_unary_op(x, "tan")
 
     @staticmethod
     # pyrefly: ignore [bad-override]
     def acos(x: CuteDSLArg) -> CuteDSLArg:
-        return CuteDSLOpOverrides._apply_unary_op(x, "cute.math.acos({x})")
+        return CuteDSLOpOverrides._apply_math_unary_op(x, "acos")
 
     @staticmethod
     # pyrefly: ignore [bad-override]
     def asin(x: CuteDSLArg) -> CuteDSLArg:
-        return CuteDSLOpOverrides._apply_unary_op(x, "cute.math.asin({x})")
+        return CuteDSLOpOverrides._apply_math_unary_op(x, "asin")
 
     @staticmethod
     # pyrefly: ignore [bad-override]
     def atan(x: CuteDSLArg) -> CuteDSLArg:
-        return CuteDSLOpOverrides._apply_unary_op(x, "cute.math.atan({x})")
+        return CuteDSLOpOverrides._apply_math_unary_op(x, "atan")
 
     @staticmethod
     # pyrefly: ignore [bad-override]
     def atan2(a: CuteDSLArg, b: CuteDSLArg) -> CuteDSLArg:
-        return CuteDSLOpOverrides._apply_binary_op(a, b, "cute.math.atan2({a}, {b})")
+        return CuteDSLOpOverrides._apply_binary_op(
+            a,
+            b,
+            CuteDSLOpOverrides._math_call("atan2", "{a}", "{b}"),
+        )
 
     @staticmethod
     # pyrefly: ignore [bad-override]
     def erf(x: CuteDSLArg) -> CuteDSLArg:
         """Error function using CuteDSL cute.math.erf function."""
-        return CuteDSLOpOverrides._apply_unary_op(x, "cute.math.erf({x})")
+        return CuteDSLOpOverrides._apply_math_unary_op(x, "erf")
 
     @staticmethod
     # pyrefly: ignore [bad-override]
@@ -510,9 +544,12 @@ class CuteDSLOpOverrides(OpOverrides):
         else:
             x_fp32 = CuteDSLOpOverrides._cast_expr(str(x), torch.float32)
 
+        exp = CuteDSLOpOverrides._math_call(
+            "exp2", f"-{{x}} * {CuteDSLOpOverrides.LOG2_E}"
+        )
         result = CuteDSLOpOverrides._apply_unary_op(
             x_fp32,
-            f"(1.0 / (1.0 + cute.math.exp2(-{{x}} * {CuteDSLOpOverrides.LOG2_E})))",
+            f"(1.0 / (1.0 + {exp}))",
         )
 
         expected = CuteDSLOpOverrides._expected_tensor_val()
@@ -642,7 +679,7 @@ class CuteDSLOpOverrides(OpOverrides):
     @staticmethod
     # pyrefly: ignore [bad-override]
     def floor(x: CuteDSLArg) -> CuteDSLArg:
-        return CuteDSLOpOverrides._apply_unary_op(x, "cute.math.floor({x})")
+        return CuteDSLOpOverrides._apply_math_unary_op(x, "floor")
 
     @staticmethod
     # pyrefly: ignore [bad-override]
@@ -727,7 +764,7 @@ class CuteDSLOpOverrides(OpOverrides):
     @staticmethod
     def tanh(x0: CuteDSLArg) -> CuteDSLArg:
         """Hyperbolic tangent using CuteDSL cute.math.tanh function."""
-        return CuteDSLOpOverrides._apply_unary_op(x0, "cute.math.tanh({x})")
+        return CuteDSLOpOverrides._apply_math_unary_op(x0, "tanh")
 
     # Logical operations
     @staticmethod

--- a/torch/_inductor/kernel/flex_gemm/epilogue.py
+++ b/torch/_inductor/kernel/flex_gemm/epilogue.py
@@ -20,6 +20,7 @@ from torch._inductor.codegen.cutedsl.cutedsl_op_overrides import (
     CuteDSLCSEVariable,
     CuteDSLOpOverrides,
     upcast_compute_type,
+    use_cutedsl_fast_math,
 )
 from torch._inductor.kernel.flex_gemm.constraints import (
     FLEX_GEMM_OUTPUT_PLAN_NODE_ERROR,
@@ -955,9 +956,12 @@ class FlexGemmEpilogueEmitter:
         gemm_op: torch._ops.OpOverload,
         analysis: FlexGemmEpilogueAnalysis,
         epilogue_arg_placeholders: tuple[torch.fx.Node, ...] = (),
+        *,
+        fast_math: bool = False,
     ) -> None:
         self.graph_module = graph_module
         self.epilogue_arg_placeholders = epilogue_arg_placeholders
+        self.fast_math = fast_math
         self.gemm = gemm_node(graph_module, gemm_op)
         self.outputs = analysis.outputs
         self.kernel = FlexGemmCuteDSLKernel()
@@ -1229,8 +1233,8 @@ class FlexGemmEpilogueEmitter:
             )
         )
         key_payload = (
-            f"{self.graph_module.code}\n{body}\nreturn {result}"
-            f"{physical_reduction_payload}"
+            f"fast_math={self.fast_math}\n{self.graph_module.code}\n"
+            f"{body}\nreturn {result}{physical_reduction_payload}"
         )
         key = hashlib.sha256(key_payload.encode()).hexdigest()[:16]
         name = f"flex_gemm_epilogue_{key}"
@@ -1262,6 +1266,7 @@ class FlexGemmEpilogueEmitter:
         with (
             V.set_kernel_handler(self.kernel),
             V.set_ops_handler(FlexGemmCuteDSLOpOverrides()),
+            use_cutedsl_fast_math(self.fast_math),
         ):
             self.bind_epilogue_args()
             self.lower_graph()
@@ -1273,6 +1278,8 @@ def materialize_flex_gemm_epilogue(
     gemm_op: torch._ops.OpOverload,
     analysis: FlexGemmEpilogueAnalysis,
     epilogue_arg_placeholders: tuple[torch.fx.Node, ...] = (),
+    *,
+    fast_math: bool = False,
 ) -> tuple[str, str]:
     """Materialize an analyzed FlexGEMM body as generated CuTeDSL source.
 
@@ -1287,10 +1294,16 @@ def materialize_flex_gemm_epilogue(
         analysis: Shared output and local-reduction analysis for the graph.
         epilogue_arg_placeholders: Captured tensor placeholders exposed as
             generated epilogue parameters.
+        fast_math: Whether supported CuTeDSL math operations may use approximate
+            fast-math lowering.
 
     Returns:
         The generated epilogue function name and complete CuTeDSL source.
     """
     return FlexGemmEpilogueEmitter(
-        graph_module, gemm_op, analysis, epilogue_arg_placeholders
+        graph_module,
+        gemm_op,
+        analysis,
+        epilogue_arg_placeholders,
+        fast_math=fast_math,
     ).materialize()

--- a/torch/_inductor/kernel/flex_gemm/lowering.py
+++ b/torch/_inductor/kernel/flex_gemm/lowering.py
@@ -273,11 +273,16 @@ def lower_quack_flex_gemm(gemm_op, subgraph, args, gemm_kwargs, kernel_options):
             f"FlexGEMM QUACK backend currently supports only aten.{_SUPPORTED_FLEX_GEMM_OP_NAMES}"
         )
     tuned = kernel_options.get("tuned", False)
-    unsupported_options = OrderedSet(kernel_options) - OrderedSet(["backend", "tuned"])
+    fast_math = kernel_options.get("fast_math", False)
+    unsupported_options = OrderedSet(kernel_options) - OrderedSet(
+        ["backend", "tuned", "fast_math"]
+    )
     if unsupported_options:
         raise NotImplementedError(
             f"unsupported FlexGEMM kernel options: {sorted(unsupported_options)}"
         )
+    if not isinstance(fast_math, bool):
+        raise NotImplementedError("FlexGEMM fast_math kernel option must be bool")
 
     from torch._inductor.kernel.flex_gemm.epilogue import (
         analyze_flex_gemm_epilogue,
@@ -387,7 +392,11 @@ def lower_quack_flex_gemm(gemm_op, subgraph, args, gemm_kwargs, kernel_options):
         outputs.local_reduce, local_reduce_out_index
     )
     epilogue_name, epilogue_source = materialize_flex_gemm_epilogue(
-        subgraph.graph_module, gemm_op, epilogue_analysis, epilogue_arg_placeholders
+        subgraph.graph_module,
+        gemm_op,
+        epilogue_analysis,
+        epilogue_arg_placeholders,
+        fast_math=fast_math,
     )
     quack_config_keys = flex_gemm_config_keys_for_local_reduce(
         layout.device,

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -4520,12 +4520,16 @@ def python_subprocess_env() -> dict[str, str]:
     Get a base environment for running Python subprocesses.
     """
 
+    torch_package_root = os.path.dirname(
+        os.path.dirname(os.path.abspath(torch.__file__))
+    )
     env = {
         # Inherit the environment of the current process.
         **os.environ,
         # Set the PYTHONPATH so the subprocess can find torch.
         "PYTHONPATH": os.environ.get(
-            "TORCH_CUSTOM_PYTHONPATH", os.pathsep.join(sys.path)
+            "TORCH_CUSTOM_PYTHONPATH",
+            os.pathsep.join((torch_package_root, *sys.path)),
         ),
     }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #190793
* #190158
* #188739
* #190752
* __->__ #190710


# Summary

Add a `fast_math` to kernel options. This pipes the arg through the stack and enables a few other decomps that are faster

<img width="3419" height="2920" alt="image" src="https://github.com/user-attachments/assets/ff85e767-5d8a-4e17-a845-9efe3eefe10d" />


As well I also fixed a subproc issues causings us to error with multi proc inductor compilation


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo