### PR TITLE
[ROCm] Enable TF32 for MIOpen convolution

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -396,15 +396,16 @@ Float32MatmulPrecision Context::float32MatmulPrecision() const {
   return float32_matmul_precision;
 }
 
-Float32Precision Context::float32Precision(Float32Backend backend, Float32Op op) const {
+Float32Precision Context::float32PrecisionImpl(Float32Backend backend, Float32Op op, bool legacy_default_tf32) const {
   std::pair<Float32Backend, Float32Op> key{backend, op};
   auto it = fp32_precision.find(key);
   TORCH_CHECK(it != fp32_precision.end(), "Invalid (backend, op) pair: (", backend, ", ", op, ")");
 
   Float32Precision precision = it->second;
 
-  // DEFAULT means "inherit from parent if set, otherwise use the legacy TF32
-  // default". It is only used as the initial state for CUDA conv/rnn.
+  // DEFAULT means "inherit from parent if set". It is only used as the initial
+  // state for CUDA conv/rnn. With no explicit parent override, legacy_default_tf32
+  // selects between the legacy TF32 default (cuDNN) and strict fp32 (MIOpen).
   if (precision == Float32Precision::DEFAULT) {
     key.second = Float32Op::ALL;
     Float32Precision parent = fp32_precision.find(key)->second;
@@ -418,7 +419,7 @@ Float32Precision Context::float32Precision(Float32Backend backend, Float32Op op)
           ? Float32Precision::NONE
           : parent;
     }
-    return Float32Precision::TF32;
+    return legacy_default_tf32 ? Float32Precision::TF32 : Float32Precision::NONE;
   }
 
   if (precision == Float32Precision::NONE) {
@@ -435,6 +436,14 @@ Float32Precision Context::float32Precision(Float32Backend backend, Float32Op op)
     return Float32Precision::NONE;
   }
   return precision;
+}
+
+Float32Precision Context::float32Precision(Float32Backend backend, Float32Op op) const {
+  return float32PrecisionImpl(backend, op, /*legacy_default_tf32=*/true);
+}
+
+Float32Precision Context::float32PrecisionExplicit(Float32Backend backend, Float32Op op) const {
+  return float32PrecisionImpl(backend, op, /*legacy_default_tf32=*/false);
 }
 
 void Context::setFloat32MatmulPrecision(const std::string &s) {

--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -396,16 +396,15 @@ Float32MatmulPrecision Context::float32MatmulPrecision() const {
   return float32_matmul_precision;
 }
 
-Float32Precision Context::float32PrecisionImpl(Float32Backend backend, Float32Op op, bool legacy_default_tf32) const {
+Float32Precision Context::float32Precision(Float32Backend backend, Float32Op op) const {
   std::pair<Float32Backend, Float32Op> key{backend, op};
   auto it = fp32_precision.find(key);
   TORCH_CHECK(it != fp32_precision.end(), "Invalid (backend, op) pair: (", backend, ", ", op, ")");
 
   Float32Precision precision = it->second;
 
-  // DEFAULT means "inherit from parent if set". It is only used as the initial
-  // state for CUDA conv/rnn. With no explicit parent override, legacy_default_tf32
-  // selects between the legacy TF32 default (cuDNN) and strict fp32 (MIOpen).
+  // DEFAULT means "inherit from parent if set, otherwise use the legacy TF32
+  // default". It is only used as the initial state for CUDA conv/rnn.
   if (precision == Float32Precision::DEFAULT) {
     key.second = Float32Op::ALL;
     Float32Precision parent = fp32_precision.find(key)->second;
@@ -419,7 +418,7 @@ Float32Precision Context::float32PrecisionImpl(Float32Backend backend, Float32Op
           ? Float32Precision::NONE
           : parent;
     }
-    return legacy_default_tf32 ? Float32Precision::TF32 : Float32Precision::NONE;
+    return Float32Precision::TF32;
   }
 
   if (precision == Float32Precision::NONE) {
@@ -436,14 +435,6 @@ Float32Precision Context::float32PrecisionImpl(Float32Backend backend, Float32Op
     return Float32Precision::NONE;
   }
   return precision;
-}
-
-Float32Precision Context::float32Precision(Float32Backend backend, Float32Op op) const {
-  return float32PrecisionImpl(backend, op, /*legacy_default_tf32=*/true);
-}
-
-Float32Precision Context::float32PrecisionExplicit(Float32Backend backend, Float32Op op) const {
-  return float32PrecisionImpl(backend, op, /*legacy_default_tf32=*/false);
 }
 
 void Context::setFloat32MatmulPrecision(const std::string &s) {

--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -235,26 +235,26 @@ void Context::setCuDNNDepthwiseKernel(CuDNNDepthwiseKernel k) {
 }
 
 bool Context::allowTF32CuDNN(std::optional<Float32Op> op) const {
-  if (!op.has_value()) {
-    bool allow_tf32_rnn = float32Precision(Float32Backend::CUDA, Float32Op::RNN) == Float32Precision::TF32;
-    bool allow_tf32_conv = float32Precision(Float32Backend::CUDA, Float32Op::CONV) == Float32Precision::TF32;
-    TORCH_CHECK(
-        allow_tf32_rnn == allow_tf32_conv && allow_tf32_rnn == allow_tf32_cudnn,
-        "PyTorch is checking whether allow_tf32 is enabled for cuDNN without a specific operator name,",
-        "but the current flag(s) indicate that cuDNN conv and cuDNN RNN have different TF32 flags.",
-        "This combination indicates that you have used a mix of the legacy and new APIs to set the TF32 flags. ",
-        "We suggest only using the new API to set the TF32 flag(s). See also: ",
-        "https://pytorch.org/docs/main/notes/cuda.html#tensorfloat-32-tf32-on-ampere-and-later-devices");
-  } else {
+  if (op.has_value()) {
     return float32Precision(Float32Backend::CUDA, op.value()) == Float32Precision::TF32;
   }
-  return allow_tf32_cudnn;
+  // The legacy allow_tf32 flag is derived from the conv/rnn precisions rather
+  // than cached, so the new-style setters cannot desync it.
+  bool allow_tf32_rnn = float32Precision(Float32Backend::CUDA, Float32Op::RNN) == Float32Precision::TF32;
+  bool allow_tf32_conv = float32Precision(Float32Backend::CUDA, Float32Op::CONV) == Float32Precision::TF32;
+  TORCH_CHECK(
+      allow_tf32_rnn == allow_tf32_conv,
+      "PyTorch is checking whether allow_tf32 is enabled for cuDNN without a specific operator name,",
+      "but the current flag(s) indicate that cuDNN conv and cuDNN RNN have different TF32 flags.",
+      "This combination indicates that you have used a mix of the legacy and new APIs to set the TF32 flags. ",
+      "We suggest only using the new API to set the TF32 flag(s). See also: ",
+      "https://pytorch.org/docs/main/notes/cuda.html#tensorfloat-32-tf32-on-ampere-and-later-devices");
+  return allow_tf32_conv;
 }
 
 void Context::setAllowTF32CuDNN(bool b) {
   setFloat32Precision(Float32Backend::CUDA, Float32Op::RNN, b ? Float32Precision::TF32 : Float32Precision::NONE);
   setFloat32Precision(Float32Backend::CUDA, Float32Op::CONV, b ? Float32Precision::TF32 : Float32Precision::NONE);
-  allow_tf32_cudnn = b;
 }
 
 void Context::setSDPPriorityOrder(const std::vector<int64_t>& order) {

--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -425,16 +425,15 @@ Float32MatmulPrecision Context::float32MatmulPrecision() const {
   return float32_matmul_precision;
 }
 
-Float32Precision Context::float32PrecisionImpl(Float32Backend backend, Float32Op op, bool legacy_default_tf32) const {
+Float32Precision Context::float32Precision(Float32Backend backend, Float32Op op) const {
   std::pair<Float32Backend, Float32Op> key{backend, op};
   auto it = fp32_precision.find(key);
   TORCH_CHECK(it != fp32_precision.end(), "Invalid (backend, op) pair: (", backend, ", ", op, ")");
 
   Float32Precision precision = it->second;
 
-  // DEFAULT means "inherit from parent if set". It is only used as the initial
-  // state for CUDA conv/rnn. With no explicit parent override, legacy_default_tf32
-  // selects between the legacy TF32 default (cuDNN) and strict fp32 (MIOpen).
+  // DEFAULT means "inherit from parent if set, otherwise use the legacy TF32
+  // default". It is only used as the initial state for CUDA conv/rnn.
   if (precision == Float32Precision::DEFAULT) {
     key.second = Float32Op::ALL;
     Float32Precision parent = fp32_precision.find(key)->second;
@@ -448,7 +447,7 @@ Float32Precision Context::float32PrecisionImpl(Float32Backend backend, Float32Op
           ? Float32Precision::NONE
           : parent;
     }
-    return legacy_default_tf32 ? Float32Precision::TF32 : Float32Precision::NONE;
+    return Float32Precision::TF32;
   }
 
   if (precision == Float32Precision::NONE) {
@@ -465,14 +464,6 @@ Float32Precision Context::float32PrecisionImpl(Float32Backend backend, Float32Op
     return Float32Precision::NONE;
   }
   return precision;
-}
-
-Float32Precision Context::float32Precision(Float32Backend backend, Float32Op op) const {
-  return float32PrecisionImpl(backend, op, /*legacy_default_tf32=*/true);
-}
-
-Float32Precision Context::float32PrecisionExplicit(Float32Backend backend, Float32Op op) const {
-  return float32PrecisionImpl(backend, op, /*legacy_default_tf32=*/false);
 }
 
 void Context::setFloat32MatmulPrecision(const std::string &s) {

--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -425,15 +425,16 @@ Float32MatmulPrecision Context::float32MatmulPrecision() const {
   return float32_matmul_precision;
 }
 
-Float32Precision Context::float32Precision(Float32Backend backend, Float32Op op) const {
+Float32Precision Context::float32PrecisionImpl(Float32Backend backend, Float32Op op, bool legacy_default_tf32) const {
   std::pair<Float32Backend, Float32Op> key{backend, op};
   auto it = fp32_precision.find(key);
   TORCH_CHECK(it != fp32_precision.end(), "Invalid (backend, op) pair: (", backend, ", ", op, ")");
 
   Float32Precision precision = it->second;
 
-  // DEFAULT means "inherit from parent if set, otherwise use the legacy TF32
-  // default". It is only used as the initial state for CUDA conv/rnn.
+  // DEFAULT means "inherit from parent if set". It is only used as the initial
+  // state for CUDA conv/rnn. With no explicit parent override, legacy_default_tf32
+  // selects between the legacy TF32 default (cuDNN) and strict fp32 (MIOpen).
   if (precision == Float32Precision::DEFAULT) {
     key.second = Float32Op::ALL;
     Float32Precision parent = fp32_precision.find(key)->second;
@@ -447,7 +448,7 @@ Float32Precision Context::float32Precision(Float32Backend backend, Float32Op op)
           ? Float32Precision::NONE
           : parent;
     }
-    return Float32Precision::TF32;
+    return legacy_default_tf32 ? Float32Precision::TF32 : Float32Precision::NONE;
   }
 
   if (precision == Float32Precision::NONE) {
@@ -464,6 +465,14 @@ Float32Precision Context::float32Precision(Float32Backend backend, Float32Op op)
     return Float32Precision::NONE;
   }
   return precision;
+}
+
+Float32Precision Context::float32Precision(Float32Backend backend, Float32Op op) const {
+  return float32PrecisionImpl(backend, op, /*legacy_default_tf32=*/true);
+}
+
+Float32Precision Context::float32PrecisionExplicit(Float32Backend backend, Float32Op op) const {
+  return float32PrecisionImpl(backend, op, /*legacy_default_tf32=*/false);
 }
 
 void Context::setFloat32MatmulPrecision(const std::string &s) {

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -391,10 +391,6 @@ class TORCH_API Context {
   void setAllowTF32CuBLAS(bool /*b*/);
   Float32MatmulPrecision float32MatmulPrecision() const;
   Float32Precision float32Precision(Float32Backend backend, Float32Op op) const;
-  // Same as float32Precision, but a DEFAULT entry with no explicit parent
-  // override resolves to NONE instead of the legacy TF32 default. Used where
-  // TF32 must be strictly opt-in (e.g. MIOpen conv) rather than default-on.
-  Float32Precision float32PrecisionExplicit(Float32Backend backend, Float32Op op) const;
   CuBLASReductionOption allowFP16ReductionCuBLAS() const;
   void setAllowFP16ReductionCuBLAS(
       bool allow_reduced_precision,
@@ -477,11 +473,6 @@ class TORCH_API Context {
   }
 
  private:
-  Float32Precision float32PrecisionImpl(
-      Float32Backend backend,
-      Float32Op op,
-      bool legacy_default_tf32) const;
-
   std::array<c10::once_flag, at::COMPILE_TIME_MAX_DEVICE_TYPES> init_;
   bool enabled_cudnn = true;
   bool deterministic_cudnn = false;
@@ -509,7 +500,12 @@ class TORCH_API Context {
       ? at::Float32MatmulPrecision::HIGH
       : at::Float32MatmulPrecision::HIGHEST;
   int benchmark_limit_cudnn = 10;
+#ifdef USE_ROCM
+  // On ROCm TF32 (MIOpen conv / cuDNN-compatible RNN) is strictly opt-in.
+  bool allow_tf32_cudnn = false;
+#else
   bool allow_tf32_cudnn = true;
+#endif
   CuBLASReductionOption allow_fp16_reduction_cublas =
       CuBLASReductionOption::AllowReducedPrecisionWithSplitK;
   CuBLASReductionOption allow_bf16_reduction_cublas =
@@ -559,8 +555,15 @@ class TORCH_API Context {
       {{Float32Backend::MKLDNN, Float32Op::RNN}, Float32Precision::NONE},
       {{Float32Backend::MKLDNN, Float32Op::MATMUL}, Float32Precision::NONE},
       {{Float32Backend::CUDA, Float32Op::ALL}, Float32Precision::NONE},
+#ifdef USE_ROCM
+      // TF32 is opt-in on ROCm, so with no explicit override conv/rnn resolve
+      // to full fp32 rather than the legacy TF32 default used on NVIDIA.
+      {{Float32Backend::CUDA, Float32Op::CONV}, Float32Precision::NONE},
+      {{Float32Backend::CUDA, Float32Op::RNN}, Float32Precision::NONE},
+#else
       {{Float32Backend::CUDA, Float32Op::CONV}, Float32Precision::DEFAULT},
       {{Float32Backend::CUDA, Float32Op::RNN}, Float32Precision::DEFAULT},
+#endif
       {{Float32Backend::CUDA, Float32Op::MATMUL},
        float32_matmul_precision == at::Float32MatmulPrecision::HIGHEST
            ? Float32Precision::NONE

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -391,6 +391,10 @@ class TORCH_API Context {
   void setAllowTF32CuBLAS(bool /*b*/);
   Float32MatmulPrecision float32MatmulPrecision() const;
   Float32Precision float32Precision(Float32Backend backend, Float32Op op) const;
+  // Same as float32Precision, but a DEFAULT entry with no explicit parent
+  // override resolves to NONE instead of the legacy TF32 default. Used where
+  // TF32 must be strictly opt-in (e.g. MIOpen conv) rather than default-on.
+  Float32Precision float32PrecisionExplicit(Float32Backend backend, Float32Op op) const;
   CuBLASReductionOption allowFP16ReductionCuBLAS() const;
   void setAllowFP16ReductionCuBLAS(
       bool allow_reduced_precision,
@@ -473,6 +477,11 @@ class TORCH_API Context {
   }
 
  private:
+  Float32Precision float32PrecisionImpl(
+      Float32Backend backend,
+      Float32Op op,
+      bool legacy_default_tf32) const;
+
   std::array<c10::once_flag, at::COMPILE_TIME_MAX_DEVICE_TYPES> init_;
   bool enabled_cudnn = true;
   bool deterministic_cudnn = false;

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -401,10 +401,6 @@ class TORCH_API Context {
   void setAllowTF32CuBLAS(bool /*b*/);
   Float32MatmulPrecision float32MatmulPrecision() const;
   Float32Precision float32Precision(Float32Backend backend, Float32Op op) const;
-  // Same as float32Precision, but a DEFAULT entry with no explicit parent
-  // override resolves to NONE instead of the legacy TF32 default. Used where
-  // TF32 must be strictly opt-in (e.g. MIOpen conv) rather than default-on.
-  Float32Precision float32PrecisionExplicit(Float32Backend backend, Float32Op op) const;
   CuBLASReductionOption allowFP16ReductionCuBLAS() const;
   void setAllowFP16ReductionCuBLAS(
       bool allow_reduced_precision,
@@ -498,11 +494,6 @@ class TORCH_API Context {
   }
 
  private:
-  Float32Precision float32PrecisionImpl(
-      Float32Backend backend,
-      Float32Op op,
-      bool legacy_default_tf32) const;
-
   std::array<c10::once_flag, at::COMPILE_TIME_MAX_DEVICE_TYPES> init_;
   bool enabled_cudnn = true;
   bool deterministic_cudnn = false;
@@ -531,7 +522,12 @@ class TORCH_API Context {
       ? at::Float32MatmulPrecision::HIGH
       : at::Float32MatmulPrecision::HIGHEST;
   int benchmark_limit_cudnn = 10;
+#ifdef USE_ROCM
+  // On ROCm TF32 (MIOpen conv / cuDNN-compatible RNN) is strictly opt-in.
+  bool allow_tf32_cudnn = false;
+#else
   bool allow_tf32_cudnn = true;
+#endif
   CuBLASReductionOption allow_fp16_reduction_cublas =
       CuBLASReductionOption::AllowReducedPrecisionWithSplitK;
   CuBLASReductionOption allow_bf16_reduction_cublas =
@@ -583,8 +579,15 @@ class TORCH_API Context {
       {{Float32Backend::MKLDNN, Float32Op::RNN}, Float32Precision::NONE},
       {{Float32Backend::MKLDNN, Float32Op::MATMUL}, Float32Precision::NONE},
       {{Float32Backend::CUDA, Float32Op::ALL}, Float32Precision::NONE},
+#ifdef USE_ROCM
+      // TF32 is opt-in on ROCm, so with no explicit override conv/rnn resolve
+      // to full fp32 rather than the legacy TF32 default used on NVIDIA.
+      {{Float32Backend::CUDA, Float32Op::CONV}, Float32Precision::NONE},
+      {{Float32Backend::CUDA, Float32Op::RNN}, Float32Precision::NONE},
+#else
       {{Float32Backend::CUDA, Float32Op::CONV}, Float32Precision::DEFAULT},
       {{Float32Backend::CUDA, Float32Op::RNN}, Float32Precision::DEFAULT},
+#endif
       {{Float32Backend::CUDA, Float32Op::MATMUL},
        float32_matmul_precision == at::Float32MatmulPrecision::HIGHEST
            ? Float32Precision::NONE

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -401,6 +401,10 @@ class TORCH_API Context {
   void setAllowTF32CuBLAS(bool /*b*/);
   Float32MatmulPrecision float32MatmulPrecision() const;
   Float32Precision float32Precision(Float32Backend backend, Float32Op op) const;
+  // Same as float32Precision, but a DEFAULT entry with no explicit parent
+  // override resolves to NONE instead of the legacy TF32 default. Used where
+  // TF32 must be strictly opt-in (e.g. MIOpen conv) rather than default-on.
+  Float32Precision float32PrecisionExplicit(Float32Backend backend, Float32Op op) const;
   CuBLASReductionOption allowFP16ReductionCuBLAS() const;
   void setAllowFP16ReductionCuBLAS(
       bool allow_reduced_precision,
@@ -494,6 +498,11 @@ class TORCH_API Context {
   }
 
  private:
+  Float32Precision float32PrecisionImpl(
+      Float32Backend backend,
+      Float32Op op,
+      bool legacy_default_tf32) const;
+
   std::array<c10::once_flag, at::COMPILE_TIME_MAX_DEVICE_TYPES> init_;
   bool enabled_cudnn = true;
   bool deterministic_cudnn = false;

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -522,12 +522,6 @@ class TORCH_API Context {
       ? at::Float32MatmulPrecision::HIGH
       : at::Float32MatmulPrecision::HIGHEST;
   int benchmark_limit_cudnn = 10;
-#ifdef USE_ROCM
-  // On ROCm TF32 (MIOpen conv / cuDNN-compatible RNN) is strictly opt-in.
-  bool allow_tf32_cudnn = false;
-#else
-  bool allow_tf32_cudnn = true;
-#endif
   CuBLASReductionOption allow_fp16_reduction_cublas =
       CuBLASReductionOption::AllowReducedPrecisionWithSplitK;
   CuBLASReductionOption allow_bf16_reduction_cublas =
@@ -581,7 +575,8 @@ class TORCH_API Context {
       {{Float32Backend::CUDA, Float32Op::ALL}, Float32Precision::NONE},
 #ifdef USE_ROCM
       // TF32 is opt-in on ROCm, so with no explicit override conv/rnn resolve
-      // to full fp32 rather than the legacy TF32 default used on NVIDIA.
+      // to full fp32 rather than the legacy TF32 default used on NVIDIA. These
+      // two entries are also what allow_tf32 reports, so it defaults to false.
       {{Float32Backend::CUDA, Float32Op::CONV}, Float32Precision::NONE},
       {{Float32Backend::CUDA, Float32Op::RNN}, Float32Precision::NONE},
 #else

--- a/aten/src/ATen/miopen/Descriptors.h
+++ b/aten/src/ATen/miopen/Descriptors.h
@@ -157,8 +157,13 @@ struct TORCH_CUDA_CPP_API ConvolutionDescriptor
     // miopenMathPedantic keeps strict IEEE fp32. Only meaningful for fp32 input.
     // The math-type knob (miopenMathType_t) first exists in MIOpen >= 3.5.2; on
     // older MIOpen there is no math-type attribute, so TF32 conv is never enabled.
+    // TEMPORARY WORKAROUND: force strict fp32 when deterministic is requested.
+    // MIOpen has no deterministic TF32 backward solver, and enabling TF32 makes
+    // the benchmark (find) path hang inside ConvHipImplicitGemmGroupBwdXdlops
+    // auto-tuning. Drop the !deterministic guard once MIOpen fixes this.
     if (dataType == miopenFloat) {
-      MIOPEN_CHECK(miopenSetConvolutionAttribute(mut_desc(), MIOPEN_CONVOLUTION_ATTRIB_MATH_TYPE, allow_tf32 ? miopenMathDefault : miopenMathPedantic));
+      bool use_tf32 = allow_tf32 && !deterministic;
+      MIOPEN_CHECK(miopenSetConvolutionAttribute(mut_desc(), MIOPEN_CONVOLUTION_ATTRIB_MATH_TYPE, use_tf32 ? miopenMathDefault : miopenMathPedantic));
     }
 #else
     // On MIOpen < 3.5.2 allow_tf32 is unused; suppress -Wunused-parameter.

--- a/aten/src/ATen/miopen/Descriptors.h
+++ b/aten/src/ATen/miopen/Descriptors.h
@@ -148,10 +148,22 @@ struct TORCH_CUDA_CPP_API ConvolutionDescriptor
           miopenConvolutionDescriptor,
           &miopenCreateConvolutionDescriptor,
           &miopenDestroyConvolutionDescriptor> {
-  void set(miopenDataType_t dataType, miopenConvolutionMode_t c_mode,  int dim, int* pad, int* stride, int * upscale /* aka dilation */, int groups, bool benchmark, bool deterministic) {
+  void set(miopenDataType_t dataType, miopenConvolutionMode_t c_mode,  int dim, int* pad, int* stride, int * upscale /* aka dilation */, int groups, bool benchmark, bool deterministic, bool allow_tf32) {
     MIOPEN_CHECK(miopenInitConvolutionNdDescriptor(mut_desc(), dim, pad, stride, upscale, c_mode));
     MIOPEN_CHECK(miopenSetConvolutionGroupCount(mut_desc(), groups));
     MIOPEN_CHECK(miopenSetConvolutionAttribute(mut_desc(), MIOPEN_CONVOLUTION_ATTRIB_DETERMINISTIC, deterministic ? 1 : 0));
+#if MIOPEN_VERSION_MAJOR > 3 || (MIOPEN_VERSION_MAJOR == 3 && (MIOPEN_VERSION_MINOR > 5 || (MIOPEN_VERSION_MINOR == 5 && MIOPEN_VERSION_PATCH >= 2)))
+    // TF32 is an fp32 compute mode: miopenMathDefault uses TF32 when possible,
+    // miopenMathPedantic keeps strict IEEE fp32. Only meaningful for fp32 input.
+    // The math-type knob (miopenMathType_t) first exists in MIOpen >= 3.5.2; on
+    // older MIOpen there is no math-type attribute, so TF32 conv is never enabled.
+    if (dataType == miopenFloat) {
+      MIOPEN_CHECK(miopenSetConvolutionAttribute(mut_desc(), MIOPEN_CONVOLUTION_ATTRIB_MATH_TYPE, allow_tf32 ? miopenMathDefault : miopenMathPedantic));
+    }
+#else
+    // On MIOpen < 3.5.2 allow_tf32 is unused; suppress -Wunused-parameter.
+    (void)allow_tf32;
+#endif
     if (benchmark) {
       MIOPEN_CHECK(miopenSetConvolutionFindMode(mut_desc(), miopenConvolutionFindModeNormal));
     }

--- a/aten/src/ATen/miopen/Descriptors.h
+++ b/aten/src/ATen/miopen/Descriptors.h
@@ -157,12 +157,14 @@ struct TORCH_CUDA_CPP_API ConvolutionDescriptor
     // miopenMathPedantic keeps strict IEEE fp32. Only meaningful for fp32 input.
     // The math-type knob (miopenMathType_t) first exists in MIOpen >= 3.5.2; on
     // older MIOpen there is no math-type attribute, so TF32 conv is never enabled.
-    // TEMPORARY WORKAROUND: force strict fp32 when deterministic is requested.
-    // MIOpen has no deterministic TF32 backward solver, and enabling TF32 makes
-    // the benchmark (find) path hang inside ConvHipImplicitGemmGroupBwdXdlops
-    // auto-tuning. Drop the !deterministic guard once MIOpen fixes this.
+    // MIOpen < 3.6.1 has no deterministic TF32 backward solver; enabling TF32
+    // there hangs the find path in ConvHipImplicitGemmGroupBwdXdlops auto-tuning.
     if (dataType == miopenFloat) {
+#if MIOPEN_VERSION_MAJOR > 3 || (MIOPEN_VERSION_MAJOR == 3 && (MIOPEN_VERSION_MINOR > 6 || (MIOPEN_VERSION_MINOR == 6 && MIOPEN_VERSION_PATCH >= 1)))
+      bool use_tf32 = allow_tf32;
+#else
       bool use_tf32 = allow_tf32 && !deterministic;
+#endif
       MIOPEN_CHECK(miopenSetConvolutionAttribute(mut_desc(), MIOPEN_CONVOLUTION_ATTRIB_MATH_TYPE, use_tf32 ? miopenMathDefault : miopenMathPedantic));
     }
 #else

--- a/aten/src/ATen/miopen/Descriptors.h
+++ b/aten/src/ATen/miopen/Descriptors.h
@@ -152,24 +152,23 @@ struct TORCH_CUDA_CPP_API ConvolutionDescriptor
     MIOPEN_CHECK(miopenInitConvolutionNdDescriptor(mut_desc(), dim, pad, stride, upscale, c_mode));
     MIOPEN_CHECK(miopenSetConvolutionGroupCount(mut_desc(), groups));
     MIOPEN_CHECK(miopenSetConvolutionAttribute(mut_desc(), MIOPEN_CONVOLUTION_ATTRIB_DETERMINISTIC, deterministic ? 1 : 0));
-#if MIOPEN_VERSION_MAJOR > 3 || (MIOPEN_VERSION_MAJOR == 3 && (MIOPEN_VERSION_MINOR > 5 || (MIOPEN_VERSION_MINOR == 5 && MIOPEN_VERSION_PATCH >= 2)))
+#if MIOPEN_HAS_TF32_MATH_TYPE
     // TF32 is an fp32 compute mode: miopenMathDefault uses TF32 when possible,
     // miopenMathPedantic keeps strict IEEE fp32. Only meaningful for fp32 input.
-    // The math-type knob (miopenMathType_t) first exists in MIOpen >= 3.5.2; on
-    // older MIOpen there is no math-type attribute, so TF32 conv is never enabled.
-    // MIOpen < 3.6.1 has no deterministic TF32 backward solver; enabling TF32
-    // there hangs the find path in ConvHipImplicitGemmGroupBwdXdlops auto-tuning.
     if (dataType == miopenFloat) {
-#if MIOPEN_VERSION_MAJOR > 3 || (MIOPEN_VERSION_MAJOR == 3 && (MIOPEN_VERSION_MINOR > 6 || (MIOPEN_VERSION_MINOR == 6 && MIOPEN_VERSION_PATCH >= 1)))
+#if MIOPEN_HAS_DETERMINISTIC_TF32
       bool use_tf32 = allow_tf32;
 #else
+      // MIOpen < 3.6.1 inverts the SetNextValue() wraparound test in the
+      // deterministic branch of the grouped Bwd/Wrw xdlops perf configs, so an
+      // exhaustive find with a cold perf-db spins forever once TF32 narrows the
+      // candidate list to a single kernel. Fixed by ROCm/rocm-libraries#10240.
       bool use_tf32 = allow_tf32 && !deterministic;
 #endif
       MIOPEN_CHECK(miopenSetConvolutionAttribute(mut_desc(), MIOPEN_CONVOLUTION_ATTRIB_MATH_TYPE, use_tf32 ? miopenMathDefault : miopenMathPedantic));
     }
 #else
-    // On MIOpen < 3.5.2 allow_tf32 is unused; suppress -Wunused-parameter.
-    (void)allow_tf32;
+    (void)allow_tf32;  // no math-type attribute before MIOpen 3.5.2
 #endif
     if (benchmark) {
       MIOPEN_CHECK(miopenSetConvolutionFindMode(mut_desc(), miopenConvolutionFindModeNormal));

--- a/aten/src/ATen/miopen/miopen-wrapper.h
+++ b/aten/src/ATen/miopen/miopen-wrapper.h
@@ -10,6 +10,18 @@
 #include <miopen/miopen.h>
 #include <miopen/version.h>
 
+// MIOpen 3.5.2 (ROCm 7.14) introduced miopenMathType_t and the conv math-type
+// attribute; TF32 conv cannot be requested at all before that.
+#define MIOPEN_HAS_TF32_MATH_TYPE \
+  (MIOPEN_VERSION_MAJOR > 3 || (MIOPEN_VERSION_MAJOR == 3 && \
+   (MIOPEN_VERSION_MINOR > 5 || (MIOPEN_VERSION_MINOR == 5 && MIOPEN_VERSION_PATCH >= 2))))
+
+// MIOpen 3.6.1 (ROCm 10.1) fixed deterministic perf-config enumeration for the
+// grouped xdlops solvers; see ROCm/rocm-libraries#10240 (ALMIOPEN-2359).
+#define MIOPEN_HAS_DETERMINISTIC_TF32 \
+  (MIOPEN_VERSION_MAJOR > 3 || (MIOPEN_VERSION_MAJOR == 3 && \
+   (MIOPEN_VERSION_MINOR > 6 || (MIOPEN_VERSION_MINOR == 6 && MIOPEN_VERSION_PATCH >= 1))))
+
 #if MIOPEN_VERSION_MAJOR > 3 || (MIOPEN_VERSION_MAJOR == 3 && MIOPEN_VERSION_MINOR >= 4)
 // miopen 3.4 moved find mode from private header to public header
 #else

--- a/aten/src/ATen/native/miopen/Conv_miopen.cpp
+++ b/aten/src/ATen/native/miopen/Conv_miopen.cpp
@@ -166,9 +166,7 @@ namespace at { namespace native {
 // See NOTE [ Convolution design ] in aten/src/ATen/native/cudnn/ConvShared.cpp
 
 static bool allowMiopenTF32() {
-  return at::globalContext().float32PrecisionExplicit(
-      at::Float32Backend::CUDA,
-      at::Float32Op::CONV) == at::Float32Precision::TF32;
+  return at::globalContext().allowTF32CuDNN(at::Float32Op::CONV);
 }
 
 // ---------------------------------------------------------------------

--- a/aten/src/ATen/native/miopen/Conv_miopen.cpp
+++ b/aten/src/ATen/native/miopen/Conv_miopen.cpp
@@ -165,6 +165,12 @@ namespace at { namespace native {
 
 // See NOTE [ Convolution design ] in aten/src/ATen/native/cudnn/ConvShared.cpp
 
+static bool allowMiopenTF32() {
+  return at::globalContext().float32PrecisionExplicit(
+      at::Float32Backend::CUDA,
+      at::Float32Op::CONV) == at::Float32Precision::TF32;
+}
+
 // ---------------------------------------------------------------------
 //
 // Helper classes
@@ -187,6 +193,7 @@ struct ConvolutionParams
   int dilation[max_dim];
   int64_t groups;
   bool deterministic;
+  bool allow_tf32;
   c10::DeviceIndex device_id; //This is needed to distinguish between miopen handles of multiple gpus.
   // NB: transposed purposely omitted: transposed just swaps
   // forward and backward, so you can reuse the benchmark entry,
@@ -202,6 +209,7 @@ void setConvolutionParams(
     IntArrayRef dilation,
     int64_t groups,
     bool deterministic,
+    bool allow_tf32,
     at::MemoryFormat memory_format) {
   miopenDataType_t dataType = getMiopenDataType(input);
   memset(params, 0, sizeof(ConvolutionParams));
@@ -224,6 +232,7 @@ void setConvolutionParams(
   }
   params->groups = groups;
   params->deterministic = deterministic;
+  params->allow_tf32 = allow_tf32;
   params->device_id = at::cuda::current_device();
 }
 
@@ -824,6 +833,7 @@ void raw_miopen_convolution_forward_out_32bit(
     bool depthwise=false) {
   auto dataType = getMiopenDataType(input);
   miopenConvolutionMode_t c_mode = depthwise ? miopenDepthwise : miopenConvolution;
+  bool allow_tf32 = allowMiopenTF32();
 
   ConvolutionArgs args{input, output, weight};
   args.handle = getMiopenHandle();
@@ -838,6 +848,7 @@ void raw_miopen_convolution_forward_out_32bit(
       dilation,
       groups,
       deterministic,
+      allow_tf32,
       memory_format);
   args.idesc.set(input, memory_format);
   args.wdesc.set(weight, memory_format, 0);
@@ -851,7 +862,8 @@ void raw_miopen_convolution_forward_out_32bit(
       args.params.dilation,
       args.params.groups,
       benchmark,
-      deterministic);
+      deterministic,
+      allow_tf32);
 
   if (at::globalContext().immediateMiopen()) {
       uint64_t solution_id;
@@ -1124,6 +1136,7 @@ void raw_miopen_convolution_backward_input_out_32bit(
     bool depthwise=false) {
   auto dataType = getMiopenDataType(grad_output);
   miopenConvolutionMode_t c_mode = depthwise ? miopenDepthwise : miopenConvolution;
+  bool allow_tf32 = allowMiopenTF32();
 
   ConvolutionArgs args{grad_input, grad_output, weight};
   args.handle = getMiopenHandle();
@@ -1139,6 +1152,7 @@ void raw_miopen_convolution_backward_input_out_32bit(
       dilation,
       groups,
       deterministic,
+      allow_tf32,
       memory_format);
   args.idesc.set(grad_input, memory_format);
   args.wdesc.set(weight, memory_format, 0);
@@ -1152,7 +1166,8 @@ void raw_miopen_convolution_backward_input_out_32bit(
       args.params.dilation,
       args.params.groups,
       benchmark,
-      deterministic);
+      deterministic,
+      allow_tf32);
 
   if (at::globalContext().immediateMiopen()) {
       uint64_t solution_id;
@@ -1301,6 +1316,7 @@ void raw_miopen_convolution_backward_weight_out_32bit(
     bool depthwise=false) {
   auto dataType = getMiopenDataType(input);
   miopenConvolutionMode_t c_mode = depthwise ? miopenDepthwise : miopenConvolution;
+  bool allow_tf32 = allowMiopenTF32();
 
   ConvolutionArgs args{input, grad_output, grad_weight};
   args.handle = getMiopenHandle();
@@ -1316,6 +1332,7 @@ void raw_miopen_convolution_backward_weight_out_32bit(
       dilation,
       groups,
       deterministic,
+      allow_tf32,
       memory_format);
   args.idesc.set(input, memory_format);
   args.wdesc.set(grad_weight, memory_format, 0);
@@ -1329,7 +1346,8 @@ void raw_miopen_convolution_backward_weight_out_32bit(
       args.params.dilation,
       args.params.groups,
       benchmark,
-      deterministic);
+      deterministic,
+      allow_tf32);
 
   if (at::globalContext().immediateMiopen()) {
       uint64_t solution_id;

--- a/aten/src/ATen/native/miopen/Conv_miopen.cpp
+++ b/aten/src/ATen/native/miopen/Conv_miopen.cpp
@@ -164,6 +164,12 @@ namespace at { namespace native {
 
 // See NOTE [ Convolution design ] in aten/src/ATen/native/cudnn/ConvShared.cpp
 
+static bool allowMiopenTF32() {
+  return at::globalContext().float32PrecisionExplicit(
+      at::Float32Backend::CUDA,
+      at::Float32Op::CONV) == at::Float32Precision::TF32;
+}
+
 // ---------------------------------------------------------------------
 //
 // Helper classes
@@ -186,6 +192,7 @@ struct ConvolutionParams
   int dilation[max_dim];
   int64_t groups;
   bool deterministic;
+  bool allow_tf32;
   c10::DeviceIndex device_id; //This is needed to distinguish between miopen handles of multiple gpus.
   // NB: transposed purposely omitted: transposed just swaps
   // forward and backward, so you can reuse the benchmark entry,
@@ -201,6 +208,7 @@ void setConvolutionParams(
     IntArrayRef dilation,
     int64_t groups,
     bool deterministic,
+    bool allow_tf32,
     at::MemoryFormat memory_format) {
   miopenDataType_t dataType = getMiopenDataType(input);
   memset(params, 0, sizeof(ConvolutionParams));
@@ -223,6 +231,7 @@ void setConvolutionParams(
   }
   params->groups = groups;
   params->deterministic = deterministic;
+  params->allow_tf32 = allow_tf32;
   params->device_id = at::cuda::current_device();
 }
 
@@ -823,6 +832,7 @@ void raw_miopen_convolution_forward_out_32bit(
     bool depthwise=false) {
   auto dataType = getMiopenDataType(input);
   miopenConvolutionMode_t c_mode = depthwise ? miopenDepthwise : miopenConvolution;
+  bool allow_tf32 = allowMiopenTF32();
 
   ConvolutionArgs args{input, output, weight};
   args.handle = getMiopenHandle();
@@ -837,6 +847,7 @@ void raw_miopen_convolution_forward_out_32bit(
       dilation,
       groups,
       deterministic,
+      allow_tf32,
       memory_format);
   args.idesc.set(input, memory_format);
   args.wdesc.set(weight, memory_format, 0);
@@ -850,7 +861,8 @@ void raw_miopen_convolution_forward_out_32bit(
       args.params.dilation,
       args.params.groups,
       benchmark,
-      deterministic);
+      deterministic,
+      allow_tf32);
 
   if (at::globalContext().immediateMiopen()) {
       uint64_t solution_id;
@@ -1123,6 +1135,7 @@ void raw_miopen_convolution_backward_input_out_32bit(
     bool depthwise=false) {
   auto dataType = getMiopenDataType(grad_output);
   miopenConvolutionMode_t c_mode = depthwise ? miopenDepthwise : miopenConvolution;
+  bool allow_tf32 = allowMiopenTF32();
 
   ConvolutionArgs args{grad_input, grad_output, weight};
   args.handle = getMiopenHandle();
@@ -1138,6 +1151,7 @@ void raw_miopen_convolution_backward_input_out_32bit(
       dilation,
       groups,
       deterministic,
+      allow_tf32,
       memory_format);
   args.idesc.set(grad_input, memory_format);
   args.wdesc.set(weight, memory_format, 0);
@@ -1151,7 +1165,8 @@ void raw_miopen_convolution_backward_input_out_32bit(
       args.params.dilation,
       args.params.groups,
       benchmark,
-      deterministic);
+      deterministic,
+      allow_tf32);
 
   if (at::globalContext().immediateMiopen()) {
       uint64_t solution_id;
@@ -1300,6 +1315,7 @@ void raw_miopen_convolution_backward_weight_out_32bit(
     bool depthwise=false) {
   auto dataType = getMiopenDataType(input);
   miopenConvolutionMode_t c_mode = depthwise ? miopenDepthwise : miopenConvolution;
+  bool allow_tf32 = allowMiopenTF32();
 
   ConvolutionArgs args{input, grad_output, grad_weight};
   args.handle = getMiopenHandle();
@@ -1315,6 +1331,7 @@ void raw_miopen_convolution_backward_weight_out_32bit(
       dilation,
       groups,
       deterministic,
+      allow_tf32,
       memory_format);
   args.idesc.set(input, memory_format);
   args.wdesc.set(grad_weight, memory_format, 0);
@@ -1328,7 +1345,8 @@ void raw_miopen_convolution_backward_weight_out_32bit(
       args.params.dilation,
       args.params.groups,
       benchmark,
-      deterministic);
+      deterministic,
+      allow_tf32);
 
   if (at::globalContext().immediateMiopen()) {
       uint64_t solution_id;

--- a/aten/src/ATen/native/miopen/Conv_miopen.cpp
+++ b/aten/src/ATen/native/miopen/Conv_miopen.cpp
@@ -165,9 +165,7 @@ namespace at { namespace native {
 // See NOTE [ Convolution design ] in aten/src/ATen/native/cudnn/ConvShared.cpp
 
 static bool allowMiopenTF32() {
-  return at::globalContext().float32PrecisionExplicit(
-      at::Float32Backend::CUDA,
-      at::Float32Op::CONV) == at::Float32Precision::TF32;
+  return at::globalContext().allowTF32CuDNN(at::Float32Op::CONV);
 }
 
 // ---------------------------------------------------------------------

--- a/docs/source/notes/hip.rst
+++ b/docs/source/notes/hip.rst
@@ -77,12 +77,20 @@ which version of PyTorch you are using, refer to this example below::
 TensorFloat-32(TF32) on ROCm
 ----------------------------
 
-TF32 is supported on AMD Instinct MI300 (gfx942, CDNA3) via hipBLASLt. The
-same ``torch.backends.cuda.matmul.fp32_precision`` and
-``torch.backends.cuda.matmul.allow_tf32`` controls used on NVIDIA hardware
-also apply on ROCm. The TF32 path on MI300 has hardware-level numerical
-differences from the NVIDIA implementation; see :ref:`tf32_on_mi300` for
-details.
+TF32 is supported on AMD Instinct MI300 (gfx942, CDNA3) and MI355 (gfx950,
+CDNA4). For matmul, TF32 runs through hipBLASLt and is controlled by the same
+``torch.backends.cuda.matmul.fp32_precision`` and
+``torch.backends.cuda.matmul.allow_tf32`` controls used on NVIDIA hardware.
+
+For convolution, TF32 runs through MIOpen and is controlled by the same
+``torch.backends.cudnn.conv.fp32_precision`` and
+``torch.backends.cudnn.allow_tf32`` controls used for cuDNN on NVIDIA
+hardware. MIOpen TF32 convolution requires MIOpen >= 3.5.2 (ROCm >= 7.14); on
+older builds the controls have no effect and convolutions always run in full
+fp32.
+
+The TF32 path on MI300 has hardware-level numerical differences from the
+NVIDIA implementation; see :ref:`tf32_on_mi300` for details.
 
 .. _rocm-memory-management:
 

--- a/docs/source/notes/hip.rst
+++ b/docs/source/notes/hip.rst
@@ -77,14 +77,23 @@ which version of PyTorch you are using, refer to this example below::
 TensorFloat-32(TF32) on ROCm
 ----------------------------
 
-TF32 is supported on AMD Instinct MI300 (gfx942, CDNA3) via hipBLASLt. The
-same ``torch.backends.cuda.matmul.fp32_precision`` and
-``torch.backends.cuda.matmul.allow_tf32`` controls used on NVIDIA hardware
-also apply on ROCm, except that the ``"bfx9"`` precision mode is NVIDIA-only
-and raises an error on ROCm because rocBLAS and hipBLASLt have no corresponding
-nine-product compute mode. The TF32 path on MI300 has hardware-level numerical
-differences from the NVIDIA implementation; see :ref:`tf32_on_mi300` for
-details.
+TF32 is supported on AMD Instinct MI300 (gfx942, CDNA3) and MI355 (gfx950,
+CDNA4). For matmul, TF32 runs through hipBLASLt and is controlled by the same
+``torch.backends.cuda.matmul.fp32_precision`` and
+``torch.backends.cuda.matmul.allow_tf32`` controls used on NVIDIA hardware,
+except that the ``"bfx9"`` precision mode is NVIDIA-only and raises an error on
+ROCm because rocBLAS and hipBLASLt have no corresponding nine-product compute
+mode.
+
+For convolution, TF32 runs through MIOpen and is controlled by the same
+``torch.backends.cudnn.conv.fp32_precision`` and
+``torch.backends.cudnn.allow_tf32`` controls used for cuDNN on NVIDIA
+hardware. MIOpen TF32 convolution requires MIOpen >= 3.5.2 (ROCm >= 7.14); on
+older builds the controls have no effect and convolutions always run in full
+fp32.
+
+The TF32 path on MI300 has hardware-level numerical differences from the
+NVIDIA implementation; see :ref:`tf32_on_mi300` for details.
 
 .. _rocm-memory-management:
 

--- a/docs/source/notes/hip.rst
+++ b/docs/source/notes/hip.rst
@@ -98,13 +98,13 @@ TF32 is opt-in on ROCm. Until they are set explicitly,
 ``torch.backends.cudnn.conv.fp32_precision`` is ``"none"``, so convolutions
 run in full fp32 by default.
 
-Deterministic convolution interacts with TF32. MIOpen < 3.6.1 has no
-deterministic TF32 backward solver, so setting
-``torch.backends.cudnn.deterministic = True`` there forces convolutions back
-to full fp32 and ``allow_tf32`` has no effect. MIOpen >= 3.6.1 lifts that
-restriction and TF32 is permitted alongside deterministic, but MIOpen may
-still pick a non-TF32 solver because its deterministic filter excludes some
-TF32 kernels.
+Deterministic convolution interacts with TF32. MIOpen < 3.6.1 can hang while
+auto-tuning the grouped xdlops solvers in deterministic mode once TF32 narrows
+the candidate list, so setting ``torch.backends.cudnn.deterministic = True``
+there forces convolutions back to full fp32 and ``allow_tf32`` has no effect.
+MIOpen >= 3.6.1 fixes that hang (ROCm/rocm-libraries#10240) and TF32 is
+permitted alongside deterministic, but MIOpen may still pick a non-TF32 solver
+because its deterministic filter excludes some TF32 kernels.
 
 The TF32 path on MI300 has hardware-level numerical differences from the
 NVIDIA implementation; see :ref:`tf32_on_mi300` for details.

--- a/docs/source/notes/hip.rst
+++ b/docs/source/notes/hip.rst
@@ -92,6 +92,20 @@ hardware. MIOpen TF32 convolution requires MIOpen >= 3.5.2 (ROCm >= 7.14); on
 older builds the controls have no effect and convolutions always run in full
 fp32.
 
+Unlike cuDNN on NVIDIA hardware, where convolution and RNN default to TF32,
+TF32 is opt-in on ROCm. Until they are set explicitly,
+``torch.backends.cudnn.allow_tf32`` is ``False`` and
+``torch.backends.cudnn.conv.fp32_precision`` is ``"none"``, so convolutions
+run in full fp32 by default.
+
+Deterministic convolution interacts with TF32. MIOpen < 3.6.1 has no
+deterministic TF32 backward solver, so setting
+``torch.backends.cudnn.deterministic = True`` there forces convolutions back
+to full fp32 and ``allow_tf32`` has no effect. MIOpen >= 3.6.1 lifts that
+restriction and TF32 is permitted alongside deterministic, but MIOpen may
+still pick a non-TF32 solver because its deterministic filter excludes some
+TF32 kernels.
+
 The TF32 path on MI300 has hardware-level numerical differences from the
 NVIDIA implementation; see :ref:`tf32_on_mi300` for details.
 

--- a/docs/source/notes/numerical_accuracy.md
+++ b/docs/source/notes/numerical_accuracy.md
@@ -224,22 +224,36 @@ The following is the list of operations where MIOpen may be used:
   - `ConvBackend::MiopenDepthwise`
   - `ConvBackend::MiopenTranspose`
 
+## TensorFloat-32 (TF32) on AMD Instinct MI300 and MI355 devices
+
+On AMD Instinct GPUs, TF32 is available for matmul (through hipBLASLt) and for convolution (through MIOpen, which requires MIOpen >= 3.5.2 / ROCm >= 7.14). The controls below are the same across supported AMD hardware; the numerical behavior, however, differs by architecture as described in the following subsections.
+
+### Enabling and disabling TF32
+
+On AMD hardware, TF32 is disabled by default for both matmul and convolution, so fp32 operations run in full IEEE FP32 unless you opt in with the controls below.
+
+Operations that dispatch through hipBLASLt (matmul) or MIOpen (convolution) with TF32 enabled are affected. Matmul and convolution are controlled separately:
+
+```python
+# Matmul: full IEEE FP32 (default on AMD)
+torch.backends.cuda.matmul.fp32_precision = "ieee"
+# Matmul: enable TF32 on supported hardware
+torch.backends.cuda.matmul.fp32_precision = "tf32"
+
+# Convolution: full IEEE FP32 (default on AMD)
+torch.backends.cudnn.conv.fp32_precision = "ieee"
+# Convolution: enable TF32 on supported hardware
+torch.backends.cudnn.conv.fp32_precision = "tf32"
+```
+
 (tf32_on_mi300)=
 
-## TensorFloat-32 (TF32) on AMD Instinct MI300 devices
+### TF32 on MI300 (gfx942, CDNA3)
 
-On AMD Instinct MI300 GPUs (gfx942, CDNA3), the `v_mfma_f32_*_xf32` matrix instructions used by hipBLASLt's TF32 path perform round-down accumulation. This is a documented property of the CDNA3 hardware. NVIDIA's TF32 implementation rounds to nearest, so a TF32 GEMM exhibits a small negative-biased error on MI300 that is absent on NVIDIA. The bias scales with `sqrt(K) * 2^-10 * |A|_inf` and reaches the low single-digit milli-units for typical random inputs; the corresponding error on NVIDIA TF32 is roughly half to a third of that.
-
-Only operations that dispatch through hipBLASLt with TF32 enabled are affected. To run a block of code in full IEEE FP32:
-
-```python
-torch.backends.cuda.matmul.fp32_precision = "ieee"
-```
-
-To enable TF32 on supported hardware:
-
-```python
-torch.backends.cuda.matmul.fp32_precision = "tf32"
-```
+On AMD Instinct MI300 GPUs, the `v_mfma_f32_*_xf32` matrix instructions used by the TF32 paths perform round-down accumulation. This is a documented property of the CDNA3 hardware. NVIDIA's TF32 implementation rounds to nearest, so a TF32 GEMM exhibits a small negative-biased error on MI300 that is absent on NVIDIA. The bias scales with `sqrt(K) * 2^-10 * |A|_inf` and reaches the low single-digit milli-units for typical random inputs; the corresponding error on NVIDIA TF32 is roughly half to a third of that.
 
 For a per-shape characterization of the MI300 vs NVIDIA-TF32 numerical gap, see https://github.com/jeffdaily/tf32_analysis.
+
+### TF32 on MI355 (gfx950, CDNA4)
+
+On AMD Instinct MI355 GPUs, TF32 is not a native hardware format; it is emulated with BF16 matrix operations accumulated in FP32. The same controls apply, but the numerics come from this emulation rather than the CDNA3 round-down accumulation, so the MI300 error characterization above does not transfer to MI355. The results are also not bit-compatible with native NVIDIA TF32.

--- a/docs/source/notes/numerical_accuracy.md
+++ b/docs/source/notes/numerical_accuracy.md
@@ -230,22 +230,36 @@ The following is the list of operations where MIOpen may be used:
   - `ConvBackend::MiopenDepthwise`
   - `ConvBackend::MiopenTranspose`
 
+## TensorFloat-32 (TF32) on AMD Instinct MI300 and MI355 devices
+
+On AMD Instinct GPUs, TF32 is available for matmul (through hipBLASLt) and for convolution (through MIOpen, which requires MIOpen >= 3.5.2 / ROCm >= 7.14). The controls below are the same across supported AMD hardware; the numerical behavior, however, differs by architecture as described in the following subsections.
+
+### Enabling and disabling TF32
+
+On AMD hardware, TF32 is disabled by default for both matmul and convolution, so fp32 operations run in full IEEE FP32 unless you opt in with the controls below.
+
+Operations that dispatch through hipBLASLt (matmul) or MIOpen (convolution) with TF32 enabled are affected. Matmul and convolution are controlled separately:
+
+```python
+# Matmul: full IEEE FP32 (default on AMD)
+torch.backends.cuda.matmul.fp32_precision = "ieee"
+# Matmul: enable TF32 on supported hardware
+torch.backends.cuda.matmul.fp32_precision = "tf32"
+
+# Convolution: full IEEE FP32 (default on AMD)
+torch.backends.cudnn.conv.fp32_precision = "ieee"
+# Convolution: enable TF32 on supported hardware
+torch.backends.cudnn.conv.fp32_precision = "tf32"
+```
+
 (tf32_on_mi300)=
 
-## TensorFloat-32 (TF32) on AMD Instinct MI300 devices
+### TF32 on MI300 (gfx942, CDNA3)
 
-On AMD Instinct MI300 GPUs (gfx942, CDNA3), the `v_mfma_f32_*_xf32` matrix instructions used by hipBLASLt's TF32 path perform round-down accumulation. This is a documented property of the CDNA3 hardware. NVIDIA's TF32 implementation rounds to nearest, so a TF32 GEMM exhibits a small negative-biased error on MI300 that is absent on NVIDIA. The bias scales with `sqrt(K) * 2^-10 * |A|_inf` and reaches the low single-digit milli-units for typical random inputs; the corresponding error on NVIDIA TF32 is roughly half to a third of that.
-
-Only operations that dispatch through hipBLASLt with TF32 enabled are affected. To run a block of code in full IEEE FP32:
-
-```python
-torch.backends.cuda.matmul.fp32_precision = "ieee"
-```
-
-To enable TF32 on supported hardware:
-
-```python
-torch.backends.cuda.matmul.fp32_precision = "tf32"
-```
+On AMD Instinct MI300 GPUs, the `v_mfma_f32_*_xf32` matrix instructions used by the TF32 paths perform round-down accumulation. This is a documented property of the CDNA3 hardware. NVIDIA's TF32 implementation rounds to nearest, so a TF32 GEMM exhibits a small negative-biased error on MI300 that is absent on NVIDIA. The bias scales with `sqrt(K) * 2^-10 * |A|_inf` and reaches the low single-digit milli-units for typical random inputs; the corresponding error on NVIDIA TF32 is roughly half to a third of that.
 
 For a per-shape characterization of the MI300 vs NVIDIA-TF32 numerical gap, see https://github.com/jeffdaily/tf32_analysis.
+
+### TF32 on MI355 (gfx950, CDNA4)
+
+On AMD Instinct MI355 GPUs, TF32 is not a native hardware format; it is emulated with BF16 matrix operations accumulated in FP32. The same controls apply, but the numerics come from this emulation rather than the CDNA3 round-down accumulation, so the MI300 error characterization above does not transfer to MI355. The results are also not bit-compatible with native NVIDIA TF32.

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -1352,7 +1352,7 @@ class TestConvolutionNNDeviceType(NNTestCase):
     @dtypes(torch.float)
     @torch.backends.cudnn.flags(enabled=True, deterministic=True, benchmark=False)
     @torch.backends.miopen.flags(immediate=True)
-    @tf32_on_and_off(0.005)
+    @tf32_on_and_off(0.01 if TEST_WITH_ROCM else 0.005)
     def test_Conv2d_groups_nobias(self, device, dtype):
         m = nn.Conv2d(4, 4, kernel_size=3, groups=2, bias=False).to(device, dtype)
         i = torch.randn(2, 4, 6, 6, device=device, dtype=dtype, requires_grad=True)
@@ -1392,7 +1392,7 @@ class TestConvolutionNNDeviceType(NNTestCase):
     @dtypes(torch.float)
     @torch.backends.cudnn.flags(enabled=True, deterministic=True, benchmark=False)
     @torch.backends.miopen.flags(immediate=True)
-    @tf32_on_and_off(0.006)
+    @tf32_on_and_off(0.01 if TEST_WITH_ROCM else 0.006)
     def test_Conv2d_groups_nobias_v2(self, device, dtype):
         torch.manual_seed(123)
         m = nn.Conv2d(4, 16, kernel_size=3, groups=2, bias=False).to(device, dtype)
@@ -1865,7 +1865,7 @@ class TestConvolutionNNDeviceType(NNTestCase):
         actual = F.conv1d(x, y, padding="same", dilation=3)
         self.assertEqual(expect, actual)
 
-    @tf32_on_and_off(0.005)
+    @tf32_on_and_off(0.01 if TEST_WITH_ROCM else 0.005)
     @dtypesIfMPS(
         *([torch.float] if MACOS_VERSION < 14.0 else [torch.float, torch.cfloat])
     )  # Complex not supported on MacOS13
@@ -1892,7 +1892,7 @@ class TestConvolutionNNDeviceType(NNTestCase):
         self.assertEqual(expect, actual)
 
     @dtypes(torch.float, torch.cfloat)
-    @tf32_on_and_off(0.005)
+    @tf32_on_and_off(0.01 if TEST_WITH_ROCM else 0.005)
     def test_conv3d_same_padding(self, device, dtype):
         if dtype is torch.cfloat:
             rtol, atol = 2e-6, 2e-6
@@ -1986,7 +1986,7 @@ class TestConvolutionNNDeviceType(NNTestCase):
     @dtypesIfMPS(
         *([torch.float] if MACOS_VERSION < 14.0 else [torch.float, torch.cfloat])
     )  # Complex not supported on MacOS13
-    @tf32_on_and_off(0.001)
+    @tf32_on_and_off(0.01 if TEST_WITH_ROCM else 0.001)
     def test_conv2d_same_padding_backward(self, device, dtype):
         # Test F.conv2d gradients work with padding='same'
         x = torch.rand(1, 1, 10, 11, device=device, dtype=dtype, requires_grad=True)
@@ -3514,7 +3514,7 @@ class TestConvolutionNNDeviceType(NNTestCase):
     @dtypes(torch.float)
     @torch.backends.cudnn.flags(enabled=True, deterministic=True, benchmark=False)
     @torch.backends.miopen.flags(immediate=True)
-    @tf32_on_and_off(0.005)
+    @tf32_on_and_off(0.01 if TEST_WITH_ROCM else 0.005)
     def test_Conv2d_naive_groups(self, device, dtype):
         # Check that grouped convolutions matches two half convolutions
         m = nn.Conv2d(4, 4, kernel_size=3, groups=2).to(device, dtype)
@@ -3991,7 +3991,7 @@ class TestConvolutionNNDeviceType(NNTestCase):
     @largeTensorTest("40GB")
     @largeTensorTest("24GB", "cpu")
     @serialTest()
-    @tf32_on_and_off(0.005)
+    @tf32_on_and_off(0.01 if TEST_WITH_ROCM else 0.005)
     def test_conv3d_64bit_indexing(self, device):
         x = torch.rand(1, 32, 512, 512, 256)
         m = torch.nn.Conv3d(32, 1, kernel_size=1, padding=0, stride=1, bias=False)
@@ -4133,7 +4133,7 @@ class TestConvolutionNNCUDA(NNTestCase):
         m(x)
 
     @skipCUDAIfNoCudnn
-    @tf32_on_and_off(0.015)
+    @tf32_on_and_off(0.03 if TEST_WITH_ROCM else 0.015)
     def test_cudnn_not_mutate_stride(self, device):
         weight = torch.randn(64, 64, 1, 1, device=device)
         x = torch.randn(2, 64, 10, 10, device=device).to(

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -1376,7 +1376,7 @@ class TestConvolutionNNDevice(NNTestCase):
     @dtypes(torch.float)
     @torch.backends.cudnn.flags(enabled=True, deterministic=True, benchmark=False)
     @torch.backends.miopen.flags(immediate=True)
-    @tf32_on_and_off(0.005)
+    @tf32_on_and_off(0.01 if TEST_WITH_ROCM else 0.005)
     def test_Conv2d_groups_nobias(self, device, dtype):
         m = nn.Conv2d(4, 4, kernel_size=3, groups=2, bias=False).to(device, dtype)
         i = torch.randn(2, 4, 6, 6, device=device, dtype=dtype, requires_grad=True)
@@ -1417,7 +1417,7 @@ class TestConvolutionNNDevice(NNTestCase):
     @dtypes(torch.float)
     @torch.backends.cudnn.flags(enabled=True, deterministic=True, benchmark=False)
     @torch.backends.miopen.flags(immediate=True)
-    @tf32_on_and_off(0.006)
+    @tf32_on_and_off(0.01 if TEST_WITH_ROCM else 0.006)
     def test_Conv2d_groups_nobias_v2(self, device, dtype):
         torch.manual_seed(123)
         m = nn.Conv2d(4, 16, kernel_size=3, groups=2, bias=False).to(device, dtype)
@@ -1892,7 +1892,7 @@ class TestConvolutionNNDevice(NNTestCase):
         actual = F.conv1d(x, y, padding="same", dilation=3)
         self.assertEqual(expect, actual)
 
-    @tf32_on_and_off(0.005)
+    @tf32_on_and_off(0.01 if TEST_WITH_ROCM else 0.005)
     @dtypesIfMPS(
         *([torch.float] if MACOS_VERSION < 14.0 else [torch.float, torch.cfloat])
     )  # Complex not supported on MacOS13
@@ -1919,7 +1919,7 @@ class TestConvolutionNNDevice(NNTestCase):
         self.assertEqual(expect, actual)
 
     @dtypes(torch.float, torch.cfloat)
-    @tf32_on_and_off(0.005)
+    @tf32_on_and_off(0.01 if TEST_WITH_ROCM else 0.005)
     def test_conv3d_same_padding(self, device, dtype):
         if dtype is torch.cfloat:
             rtol, atol = 2e-6, 2e-6
@@ -2013,7 +2013,7 @@ class TestConvolutionNNDevice(NNTestCase):
     @dtypesIfMPS(
         *([torch.float] if MACOS_VERSION < 14.0 else [torch.float, torch.cfloat])
     )  # Complex not supported on MacOS13
-    @tf32_on_and_off(0.001)
+    @tf32_on_and_off(0.01 if TEST_WITH_ROCM else 0.001)
     def test_conv2d_same_padding_backward(self, device, dtype):
         # Test F.conv2d gradients work with padding='same'
         x = torch.rand(1, 1, 10, 11, device=device, dtype=dtype, requires_grad=True)
@@ -3497,7 +3497,7 @@ class TestConvolutionNNDevice(NNTestCase):
     @dtypes(torch.float)
     @torch.backends.cudnn.flags(enabled=True, deterministic=True, benchmark=False)
     @torch.backends.miopen.flags(immediate=True)
-    @tf32_on_and_off(0.005)
+    @tf32_on_and_off(0.01 if TEST_WITH_ROCM else 0.005)
     def test_Conv2d_naive_groups(self, device, dtype):
         # Check that grouped convolutions matches two half convolutions
         m = nn.Conv2d(4, 4, kernel_size=3, groups=2).to(device, dtype)
@@ -3744,7 +3744,7 @@ class TestConvolutionNNDevice(NNTestCase):
     @largeTensorTest("40GB")
     @largeTensorTest("24GB", "cpu")
     @serialTest()
-    @tf32_on_and_off(0.005)
+    @tf32_on_and_off(0.01 if TEST_WITH_ROCM else 0.005)
     def test_conv3d_64bit_indexing(self, device):
         x = torch.rand(1, 32, 512, 512, 256)
         m = torch.nn.Conv3d(32, 1, kernel_size=1, padding=0, stride=1, bias=False)
@@ -4166,7 +4166,7 @@ class TestConvolutionNNCUDA(NNTestCase):
         m(x)
 
     @skipCUDAIfNoCudnn
-    @tf32_on_and_off(0.015)
+    @tf32_on_and_off(0.03 if TEST_WITH_ROCM else 0.015)
     def test_cudnn_not_mutate_stride(self, device):
         weight = torch.randn(64, 64, 1, 1, device=device)
         x = torch.randn(2, 64, 10, 10, device=device).to(

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1598,6 +1598,19 @@ print(mem_after_first, mem_after_set, torch.cuda.memory_allocated())
 
     @recover_orig_fp32_precision
     @serialTest()
+    def test_legacy_allow_tf32_follows_new_api(self):
+        # allow_tf32 is derived from the conv/rnn precisions, so setting both
+        # through the new API leaves it readable instead of raising.
+        for precision, expected in (("none", False), ("tf32", True)):
+            torch.backends.cudnn.conv.fp32_precision = precision
+            torch.backends.cudnn.rnn.fp32_precision = precision
+            self.assertEqual(torch.backends.cudnn.allow_tf32, expected)
+            # cudnn.flags() snapshots allow_tf32 on entry.
+            with torch.backends.cudnn.flags(enabled=True):
+                pass
+
+    @recover_orig_fp32_precision
+    @serialTest()
     def test_invalid_status_for_legacy_api(self):
         torch.backends.cudnn.conv.fp32_precision = "none"
         torch.backends.cudnn.rnn.fp32_precision = "tf32"

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -1145,7 +1145,7 @@ def get_new_module_tests():
             input_size=(2, 4, 10),
             cudnn=True,
             with_tf32=True,
-            tf32_precision=0.005,
+            tf32_precision=0.01 if TEST_WITH_ROCM else 0.005,
             default_dtype=torch.double,
         ),
         dict(
@@ -1156,7 +1156,7 @@ def get_new_module_tests():
             cudnn=True,
             desc='stride',
             with_tf32=True,
-            tf32_precision=0.005,
+            tf32_precision=0.01 if TEST_WITH_ROCM else 0.005,
             default_dtype=torch.double,
         ),
         dict(
@@ -1178,7 +1178,7 @@ def get_new_module_tests():
             cudnn=True,
             desc='pad2',
             with_tf32=True,
-            tf32_precision=0.005,
+            tf32_precision=0.01 if TEST_WITH_ROCM else 0.005,
             default_dtype=torch.double,
         ),
         dict(
@@ -1189,7 +1189,7 @@ def get_new_module_tests():
             cudnn=True,
             desc='pad1size1',
             with_tf32=True,
-            tf32_precision=0.005,
+            tf32_precision=0.01 if TEST_WITH_ROCM else 0.005,
             default_dtype=torch.double,
         ),
         dict(
@@ -1200,7 +1200,7 @@ def get_new_module_tests():
             cudnn=True,
             desc='pad2size1',
             with_tf32=True,
-            tf32_precision=0.005,
+            tf32_precision=0.01 if TEST_WITH_ROCM else 0.005,
             default_dtype=torch.double,
         ),
         dict(
@@ -1211,7 +1211,7 @@ def get_new_module_tests():
             cudnn=True,
             desc='zero_batch',
             with_tf32=True,
-            tf32_precision=0.005,
+            tf32_precision=0.01 if TEST_WITH_ROCM else 0.005,
         ),
         dict(
             fullname='Conv1d_dilated',
@@ -1219,7 +1219,7 @@ def get_new_module_tests():
             cpp_constructor_args='torch::nn::Conv1dOptions(4, 5, 3).dilation(2)',
             input_size=(2, 4, 10),
             with_tf32=True,
-            tf32_precision=0.005,
+            tf32_precision=0.01 if TEST_WITH_ROCM else 0.005,
             default_dtype=torch.double,
         ),
         dict(
@@ -1229,7 +1229,7 @@ def get_new_module_tests():
             input_size=(2, 4, 6),
             cudnn=True,
             with_tf32=True,
-            tf32_precision=0.005,
+            tf32_precision=0.01 if TEST_WITH_ROCM else 0.005,
             default_dtype=torch.double,
         ),
         dict(
@@ -1239,7 +1239,7 @@ def get_new_module_tests():
             input_size=(2, 4, 10),
             cudnn=True,
             with_tf32=True,
-            tf32_precision=0.005,
+            tf32_precision=0.01 if TEST_WITH_ROCM else 0.005,
             default_dtype=torch.double,
         ),
         dict(
@@ -1249,7 +1249,7 @@ def get_new_module_tests():
             input_size=(2, 4, 10),
             cudnn=True,
             with_tf32=True,
-            tf32_precision=0.005,
+            tf32_precision=0.01 if TEST_WITH_ROCM else 0.005,
             default_dtype=torch.double,
         ),
         dict(
@@ -1259,7 +1259,7 @@ def get_new_module_tests():
             input_size=(2, 4, 10),
             cudnn=True,
             with_tf32=True,
-            tf32_precision=0.005,
+            tf32_precision=0.01 if TEST_WITH_ROCM else 0.005,
             default_dtype=torch.double,
         ),
         dict(
@@ -1269,7 +1269,7 @@ def get_new_module_tests():
             input_size=(2, 4, 10),
             cudnn=True,
             with_tf32=True,
-            tf32_precision=0.005,
+            tf32_precision=0.01 if TEST_WITH_ROCM else 0.005,
             default_dtype=torch.double,
         ),
         dict(
@@ -1279,7 +1279,7 @@ def get_new_module_tests():
             cudnn=True,
             input_size=(1, 3, 7),
             with_tf32=True,
-            tf32_precision=0.005,
+            tf32_precision=0.01 if TEST_WITH_ROCM else 0.005,
             default_dtype=torch.double,
         ),
         dict(
@@ -1291,7 +1291,7 @@ def get_new_module_tests():
             cudnn=True,
             desc='no_bias',
             with_tf32=True,
-            tf32_precision=0.005,
+            tf32_precision=0.01 if TEST_WITH_ROCM else 0.005,
             default_dtype=torch.double,
         ),
         dict(
@@ -1303,7 +1303,7 @@ def get_new_module_tests():
             cudnn=True,
             desc='dilated',
             with_tf32=True,
-            tf32_precision=0.005,
+            tf32_precision=0.01 if TEST_WITH_ROCM else 0.005,
             default_dtype=torch.double,
         ),
         dict(
@@ -1314,7 +1314,7 @@ def get_new_module_tests():
             cudnn=True,
             input_size=(2, 4, 7),
             with_tf32=True,
-            tf32_precision=0.005,
+            tf32_precision=0.01 if TEST_WITH_ROCM else 0.005,
             default_dtype=torch.double,
         ),
         dict(
@@ -1325,7 +1325,7 @@ def get_new_module_tests():
             cudnn=True,
             check_with_long_tensor=True,
             with_tf32=True,
-            tf32_precision=0.005,
+            tf32_precision=0.01 if TEST_WITH_ROCM else 0.005,
             default_dtype=torch.double,
         ),
         dict(
@@ -1337,7 +1337,7 @@ def get_new_module_tests():
             desc='strided',
             check_with_long_tensor=True,
             with_tf32=True,
-            tf32_precision=0.005,
+            tf32_precision=0.01 if TEST_WITH_ROCM else 0.005,
             default_dtype=torch.double,
         ),
         dict(
@@ -1349,7 +1349,7 @@ def get_new_module_tests():
             desc='padding',
             check_with_long_tensor=True,
             with_tf32=True,
-            tf32_precision=0.005,
+            tf32_precision=0.01 if TEST_WITH_ROCM else 0.005,
             default_dtype=torch.double,
         ),
         dict(
@@ -1361,7 +1361,7 @@ def get_new_module_tests():
             desc='dilated',
             check_with_long_tensor=True,
             with_tf32=True,
-            tf32_precision=0.005,
+            tf32_precision=0.01 if TEST_WITH_ROCM else 0.005,
             default_dtype=torch.double,
         ),
         dict(
@@ -1374,7 +1374,7 @@ def get_new_module_tests():
             desc='no_bias',
             check_with_long_tensor=True,
             with_tf32=True,
-            tf32_precision=0.015,
+            tf32_precision=0.03 if TEST_WITH_ROCM else 0.015,
             default_dtype=torch.double,
         ),
         dict(
@@ -1395,7 +1395,7 @@ def get_new_module_tests():
             cudnn=True,
             check_with_long_tensor=True,
             with_tf32=True,
-            tf32_precision=0.015,
+            tf32_precision=0.03 if TEST_WITH_ROCM else 0.015,
             default_dtype=torch.double,
         ),
         dict(
@@ -1405,7 +1405,7 @@ def get_new_module_tests():
             input_size=(2, 4, 6, 5),
             check_with_long_tensor=True,
             with_tf32=True,
-            tf32_precision=0.015,
+            tf32_precision=0.03 if TEST_WITH_ROCM else 0.015,
             default_dtype=torch.double,
         ),
         dict(
@@ -1415,7 +1415,7 @@ def get_new_module_tests():
             input_size=(2, 2, 6, 5),
             cudnn=True,
             with_tf32=True,
-            tf32_precision=0.005,
+            tf32_precision=0.01 if TEST_WITH_ROCM else 0.005,
             default_dtype=torch.double,
         ),
         dict(
@@ -1498,7 +1498,7 @@ def get_new_module_tests():
             cpp_constructor_args='torch::nn::Conv2dOptions(4, 4, {3, 3}).groups(4)',
             input_size=(2, 4, 6, 6),
             with_tf32=True,
-            tf32_precision=0.005,
+            tf32_precision=0.01 if TEST_WITH_ROCM else 0.005,
             default_dtype=torch.double,
         ),
         dict(
@@ -1507,7 +1507,7 @@ def get_new_module_tests():
             cpp_constructor_args='torch::nn::Conv2dOptions(4, 8, {3, 3}).groups(4)',
             input_size=(2, 4, 6, 6),
             with_tf32=True,
-            tf32_precision=0.005,
+            tf32_precision=0.01 if TEST_WITH_ROCM else 0.005,
             default_dtype=torch.double,
         ),
         dict(
@@ -1516,7 +1516,7 @@ def get_new_module_tests():
             cpp_constructor_args='torch::nn::Conv2dOptions(4, 4, {3, 3}).stride({2, 2}).groups(4)',
             input_size=(2, 4, 6, 6),
             with_tf32=True,
-            tf32_precision=0.005,
+            tf32_precision=0.01 if TEST_WITH_ROCM else 0.005,
             default_dtype=torch.double,
         ),
         dict(
@@ -1525,7 +1525,7 @@ def get_new_module_tests():
             cpp_constructor_args='torch::nn::Conv2dOptions(4, 4, {3, 3}).padding({1, 1}).groups(4)',
             input_size=(2, 4, 6, 6),
             with_tf32=True,
-            tf32_precision=0.005,
+            tf32_precision=0.01 if TEST_WITH_ROCM else 0.005,
             default_dtype=torch.double,
         ),
         dict(
@@ -1534,7 +1534,7 @@ def get_new_module_tests():
             cpp_constructor_args='torch::nn::Conv2dOptions(4, 4, {2, 2}).dilation({2, 2}).groups(4)',
             input_size=(2, 4, 5, 5),
             with_tf32=True,
-            tf32_precision=0.005,
+            tf32_precision=0.01 if TEST_WITH_ROCM else 0.005,
             default_dtype=torch.double,
         ),
         dict(
@@ -1616,7 +1616,7 @@ def get_new_module_tests():
             cudnn=True,
             check_with_long_tensor=True,
             with_tf32=True,
-            tf32_precision=0.005,
+            tf32_precision=0.01 if TEST_WITH_ROCM else 0.005,
             default_dtype=torch.double,
         ),
         dict(


### PR DESCRIPTION
## Summary

Enable TF32 for MIOpen convolution on ROCm, mirroring the existing cuDNN behavior. When TF32 is enabled through the cuDNN controls (`torch.backends.cudnn.allow_tf32`, or `torch.backends.cudnn.conv.fp32_precision == "tf32"`), fp32 MIOpen convolutions set `MIOPEN_CONVOLUTION_ATTRIB_MATH_TYPE` to `miopenMathDefault` (TF32 when the hardware supports it); otherwise they use `miopenMathPedantic` (strict IEEE fp32).

On ROCm, TF32 is strictly opt-in: conv/RNN precision flags default to full fp32, unlike the legacy TF32-on default used on NVIDIA.

## Motivation

cuDNN convolution already respects the global TF32 flag via `cudnnSetConvolutionMathType`. MIOpen exposes an equivalent knob (`MIOPEN_CONVOLUTION_ATTRIB_MATH_TYPE`), but PyTorch did not wire it up, so ROCm users could not enable TF32 conv through the same API used on CUDA.

## Changes

- **`aten/src/ATen/miopen/Descriptors.h`**
  - Add `allow_tf32` to `ConvolutionDescriptor::set`.
  - For fp32 inputs, set `MIOPEN_CONVOLUTION_ATTRIB_MATH_TYPE` to `miopenMathDefault` when TF32 is allowed and the run is not deterministic, otherwise `miopenMathPedantic`.
  - **Temporary workaround:** deterministic runs always force `miopenMathPedantic`. MIOpen has an issue with deterministic TF32 backward solver. Drop the `!deterministic` guard once MIOpen fixes this.

- **`aten/src/ATen/native/miopen/Conv_miopen.cpp`**
  - Add `allowMiopenTF32()`, reading `at::globalContext().allowTF32CuDNN(at::Float32Op::CONV)`, and use it in the forward, backward-input, and backward-weight paths.
  - Store `allow_tf32` in `ConvolutionParams` so the MIOpen benchmark/solution cache distinguishes TF32 on vs off.

- **`aten/src/ATen/Context.h`**
  - On ROCm, default `allow_tf32_cudnn` to `false` and default the conv/RNN `Float32Precision` entries to `NONE` (strict fp32). NVIDIA defaults are unchanged (`true` / `DEFAULT`). This makes the reported flag and the actual MIOpen compute agree: TF32 is off unless the user opts in.

- **`test/nn/test_convolution.py`, `torch/testing/_internal/common_nn.py`**
  - Relax TF32 conv tolerances on ROCm (`@tf32_on_and_off` and `tf32_precision`) via `... if TEST_WITH_ROCM else <original>`.

- **`docs/source/notes/hip.rst`, `docs/source/notes/numerical_accuracy.md`**
  - Document TF32 conv support on ROCm and that it is opt-in.

## User-facing API

No new Python API. Uses the existing cuDNN TF32 controls on ROCm:

```python
torch.backends.cudnn.allow_tf32 = True   # or False
# or
torch.backends.cudnn.conv.fp32_precision = "tf32"  # or "none"
```

On ROCm both default to off (strict fp32) unless explicitly enabled.

## Version gating

The math-type call is compiled in only for `MIOpen >= 3.5.2`, guarded by a `MIOPEN_VERSION_MAJOR/MINOR/PATCH` check. On older MIOpen the attribute is not set and `allow_tf32` is ignored, so behavior is unchanged.

## Test plan

```bash
# TF32 on/off conv coverage:
python test/nn/test_convolution.py
```

TF32 selection can be confirmed from MIOpen logs (the problem key carries the `...FP32xTF32` suffix on `MI300` when TF32 is active):

```bash
MIOPEN_ENABLE_LOGGING=1 MIOPEN_LOG_LEVEL=6 \
python test/nn/test_convolution.py -k test_cudnn_not_mutate_stride_cuda\
  2>&1 | grep -E 'Returning an invoker for problem .*FP32xTF32.* and algorithm'
  
# Expected: 2
```

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang