### PR TITLE
Add regression test for empty-tensor all_gather on gloo (#85234)

### DIFF
--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -310,6 +310,17 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         self.assertEqual(0, output[0].numel())
         self.assertEqual(xs[0], output[0])
 
+        # allgather of an empty tensor previously aborted with SIGFPE on gloo
+        # (a modulo-by-zero in the ring algorithm when the buffer is empty).
+        ys = [[torch.FloatTensor([]) for _ in range(self.world_size)]]
+        fut = pg.allgather(ys, xs).get_future()
+        fut.wait()
+        result = fut.value()
+        self.assertEqual(self.world_size, len(result))
+        for t in result:
+            self.assertEqual(0, t.numel())
+            self.assertEqual(xs[0], t)
+
     @requires_gloo()
     def test_broadcast_checks(self):
         store = c10d.FileStore(self.file_name, self.world_size)


### PR DESCRIPTION
## Issue

Fixes #85234

## Summary

This adds an all_gather case to `test_empty_tensors` in `test_c10d_gloo.py`. The crash itself (SIGFPE when all_gather runs on a zero-element tensor over gloo) was already fixed upstream in the vendored gloo library by `d96897b` ("fix allgather for empty buffers"), which is in the current submodule pin. But `test_empty_tensors` only exercised `broadcast`, so the all_gather path had no regression coverage. The new assertions check that all_gather of an empty tensor finishes without crashing and returns `world_size` empty tensors.

## Checklist

- [ ] Passes lint (`spin fixlint`) — could not run the full linter locally on Windows (the clang-format bootstrap is unsupported there); the change is ASCII-only and `test/distributed` is skipped by the formatter, so CI lint should cover it
- [x] Added/updated tests
- [ ] Updated documentation (if applicable) — N/A
- [ ] Included benchmark results (for PRs impacting perf) — N/A

## BC-breaking?

No.

---

_This change was prepared with the help of an AI coding assistant and reviewed by me before submission._
