### PR TITLE
[fx] const_fold: forward an is_impure_node callback to eliminate_dead_code (#190716)

### DIFF
--- a/test/fx/test_fx_const_fold.py
+++ b/test/fx/test_fx_const_fold.py
@@ -873,6 +873,53 @@ class TestConstFold(TestCase):
         )
         self._verify_const_fold_mod(mod_folded)
 
+    def test_const_fold_is_impure_node_preserves_dead_node(self):
+        r"""
+        Const folding runs dead-code elimination, which by default drops a node
+        with no users when ``Node.is_impure()`` is False. A caller can pass
+        ``is_impure_node`` to preserve such a node -- e.g. a destination-passing
+        op whose only effect is writing a buffer through an ``out=`` kwarg its
+        schema does not declare as mutated, so the default check treats it as
+        pure dead code.
+        """
+
+        class ConstFoldTestModule(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.attr1 = torch.nn.Parameter(torch.randn(2, 3))
+                self.attr2 = torch.nn.Parameter(torch.randn(2, 3))
+
+            def forward(self, x):
+                folded = self.attr1 + self.attr2  # const-foldable subgraph
+                _unused = torch.relu(x)  # no users -> dead-code candidate
+                return x + folded
+
+        def _num_userless_relus(gm: torch.fx.GraphModule) -> int:
+            return sum(
+                1
+                for n in gm.graph.nodes
+                if n.op == "call_function"
+                and "relu" in str(n.target)
+                and len(n.users) == 0
+            )
+
+        def _is_userless_relu(n: torch.fx.Node) -> bool:
+            return (
+                n.op == "call_function"
+                and "relu" in str(n.target)
+                and len(n.users) == 0
+            )
+
+        # Default: the user-less relu is dead-code-eliminated.
+        mod_default = const_fold.split_const_subgraphs(ConstFoldTestModule())
+        self.assertEqual(_num_userless_relus(mod_default), 0)
+
+        # With is_impure_node marking the user-less relu impure, it survives.
+        mod_kept = const_fold.split_const_subgraphs(
+            ConstFoldTestModule(), is_impure_node=_is_userless_relu
+        )
+        self.assertEqual(_num_userless_relus(mod_kept), 1)
+
 
 if __name__ == "__main__":
     raise_on_run_directly("test/test_fx.py")

--- a/torch/fx/experimental/const_fold.py
+++ b/torch/fx/experimental/const_fold.py
@@ -82,7 +82,10 @@ class FoldedGraphModule(torch.fx.GraphModule):
 
 
 def _inline_module(
-    gm: torch.fx.GraphModule, inline_mod_name: str, run_dce: bool = True
+    gm: torch.fx.GraphModule,
+    inline_mod_name: str,
+    run_dce: bool = True,
+    is_impure_node: Callable[[torch.fx.Node], bool] | None = None,
 ) -> dict[torch.fx.Node, torch.fx.Node]:
     """
     Given `gm` and some graph module which is called with target name `inline_mod_name`,
@@ -166,7 +169,7 @@ def _inline_module(
     # this module is unneeded as it's just inlined back to main graph.
     gm.graph.erase_node(call_mod_node_to_replace)
     if run_dce:
-        gm.graph.eliminate_dead_code()
+        gm.graph.eliminate_dead_code(is_impure_node=is_impure_node)
 
     return replacement_mapping
 
@@ -195,6 +198,7 @@ def split_const_subgraphs(
     module: torch.nn.Module | torch.fx.GraphModule,
     skip_folding_node_fn: Callable[[torch.fx.Node], bool] | None = None,
     device_for_folded_attrs: str = "cpu",
+    is_impure_node: Callable[[torch.fx.Node], bool] | None = None,
 ) -> FoldedGraphModule:
     """
     Looks through `module` for any nodes that have all constant attribute inputs
@@ -209,6 +213,11 @@ def split_const_subgraphs(
     skipped. Predicates must therefore be node-local; one that needs to resolve a
     node's `target` to a submodule must use `node.graph.owning_module` rather than
     a captured top-level module.
+
+    `is_impure_node`, if provided, is forwarded to `eliminate_dead_code` so DCE
+    preserves nodes the caller considers impure beyond the default
+    `Node.is_impure()` check (e.g. out-variant ops that write a pre-allocated
+    buffer via an `out=` kwarg not declared mutable in their schema).
     """
 
     import sympy
@@ -435,9 +444,9 @@ def split_const_subgraphs(
     # This is so that the original caller who may have passed in a graph module will
     # get back out a graph module whose graph is traced to the same granularity.
     if hasattr(split, non_const_mod_name):
-        _inline_module(split, non_const_mod_name)
+        _inline_module(split, non_const_mod_name, is_impure_node=is_impure_node)
 
-    split.graph.eliminate_dead_code()
+    split.graph.eliminate_dead_code(is_impure_node=is_impure_node)
 
     return FoldedGraphModule(
         split,


### PR DESCRIPTION
Summary:

A backend or lowering pass may rewrite ops into destination-passing style, where a call writes its result into a pre-allocated buffer through an `out=` kwarg instead of returning a value. Concretely, a block like this may appear in the graph as:
```
  %es  = empty_strided(...)                         # activation buffer
  %lin = mtia.linear.default(..., out=%es)          # writes %es; num_users=0
  %sum = mtia.sum.default(other=%es, ..., out=%es)  # residual add into %es; num_users=0
  %rms = mtia.rms_norm.default(input=%es)           # reads %es
```
Because `%lin` and `%sum` produce their effect only through the `out` buffer, their SSA results are unused (num_users=0), and their op schemas do not declare `out` as a mutated argument — and consequently `torch.fx.Node.is_impure()` reports them as pure. When const folding runs [split_const_subgraphs](https://www.internalfb.com/code/fbsource/[bc91e1ef5f62c0cd9fe54cc9e77bf2af08225d72]/fbcode/caffe2/torch/fx/experimental/const_fold.py?lines=194-208), its internal dead code elimination therefore treats these two nodes as pure dead code and deletes them, leaving `%rms` reading a buffer that nothing writes. 

This diff adds an optional `is_impure_node` callback to `split_const_subgraphs` so a caller can mark such destination-passing writes as impure and keep them alive through DCE.

Test Plan:
Added `test_const_fold_is_impure_node_preserves_dead_node` in
`test/fx/test_fx_const_fold.py`: a user-less node that default const folding
dead-code-eliminates is preserved when `is_impure_node` marks it impure.

```
buck test @//mode/opt fbcode//caffe2/test:fx_const_fold -- \
  test_const_fold_is_impure_node_preserves_dead_node
```

Reviewed By: blaine-rister, mrob94

Differential Revision: D113082976


