### PR TITLE
[Inductor] Migrate alignment assertions to declarative Config rollout control

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -236,10 +236,10 @@ runtime_triton_nan_asserts = (
 )
 scalar_asserts = os.environ.get("TORCHINDUCTOR_SCALAR_ASSERTS", "1") == "1"
 
-# Disable by default in fbcode
-alignment_asserts = (
-    os.environ.get("TORCHINDUCTOR_ALIGNMENT_ASSERTS", "0" if is_fbcode() else "1")
-    == "1"
+alignment_asserts: bool = Config(
+    justknob="pytorch/inductor:alignment_asserts",
+    env_name_force="TORCHINDUCTOR_ALIGNMENT_ASSERTS",
+    default=True,
 )
 
 # enable loop reordering based on input orders


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #190719

Migrate the internal rollout control for alignment assertions to the standard declarative Justknob Config. This keeps the existing environment override and OSS default while allowing internal rollout through pytorch/inductor:alignment_asserts without bespoke fbcode defaulting logic.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo