### PR TITLE
[Inductor] Migrate loop ordering after fusion to declarative Config rollout control

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -960,11 +960,10 @@ aggressive_fusion = False
 debug_fusion: bool = os.environ.get("TORCHINDUCTOR_DEBUG_FUSION") == "1"
 benchmark_fusion: bool = os.environ.get("TORCHINDUCTOR_BENCHMARK_FUSION") == "1"
 enabled_metric_tables = os.environ.get("TORCHINDUCTOR_ENABLED_METRIC_TABLES", "")
-loop_ordering_after_fusion: bool = (
-    os.environ.get(
-        "TORCHINDUCTOR_LOOP_ORDERING_AFTER_FUSION", "0" if is_fbcode() else "1"
-    )
-    == "1"
+loop_ordering_after_fusion: bool = Config(
+    justknob="pytorch/inductor:loop_ordering_after_fusion",
+    env_name_force="TORCHINDUCTOR_LOOP_ORDERING_AFTER_FUSION",
+    default=True,
 )
 loop_reindexing_after_fusion: bool = (
     os.environ.get("TORCHINDUCTOR_LOOP_REINDEXING_AFTER_FUSION", "1") == "1"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #190720

Migrate the internal rollout control for loop ordering after fusion to the standard justknob mechanism. This preserves the existing TORCHINDUCTOR_LOOP_ORDERING_AFTER_FUSION environment override and enabled OSS default while allowing internal rollout through pytorch/inductor:loop_ordering_after_fusion.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo