### PR TITLE
Fix typos and grammar in code comments and docstrings

### DIFF
--- a/torch/ao/quantization/observer.py
+++ b/torch/ao/quantization/observer.py
@@ -618,7 +618,7 @@ class MovingAverageMinMaxObserver(MinMaxObserver):
                 \end{cases}\\
         \end{array}
 
-    where :math:`x_\text{min/max}` is the running average min/max, :math:`X` is
+    where :math:`x_\text{min/max}` is the running average min/max, :math:`X`
     is the incoming tensor, and :math:`c` is the ``averaging_constant``.
 
     The scale and zero point are then computed as in

--- a/torch/fx/experimental/accelerator_partitioner.py
+++ b/torch/fx/experimental/accelerator_partitioner.py
@@ -69,7 +69,7 @@ class PartitionResult(NamedTuple):
     module_with_submodules: GraphModule
 
 
-"""Followings are some helper functions for partition manipulation"""
+"""Following are some helper functions for partition manipulation"""
 
 
 def reset_partition_device(partitions: list[Partition]) -> None:

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -876,7 +876,7 @@ class {module_name}(torch.nn.Module):
                 # ["foo", "bar", "baz"]
                 fullpath = node.target.split(".")
 
-                # If we're looking at multiple parts of a path, join
+                # If we're looking at multiple parts of a path,
                 # join them with a dot. Otherwise, return that single
                 # element without doing anything to it.
                 def join_fn(x: str, y: str) -> str:

--- a/torch/fx/passes/regional_inductor_invoke_subgraph.py
+++ b/torch/fx/passes/regional_inductor_invoke_subgraph.py
@@ -42,7 +42,7 @@ def _compile_submod(
 
     for inp_node in sub_node.all_input_nodes[
         1:
-    ]:  # exlucde the graph module input to torch.ops.higher_order.invoke_subgraph
+    ]:  # exclude the graph module input to torch.ops.higher_order.invoke_subgraph
         if hasattr(inp_node, "meta") and "val" in inp_node.meta:
             fake_inputs.append(inp_node.meta["val"])
         else:

--- a/torch/nn/utils/prune.py
+++ b/torch/nn/utils/prune.py
@@ -165,7 +165,7 @@ class BasePruningMethod(ABC):
             importance_scores = orig
 
         # If this is the first time pruning is applied, take care of moving
-        # the original tensor to a new parameter called name + '_orig' and
+        # the original tensor to a new parameter called name + '_orig'
         # and deleting the original parameter
         if not isinstance(method, PruningContainer):
             # copy `module[name]` to `module[name + '_orig']`


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #190722

Correct several minor wording issues in comments and docstrings: a
duplicated "is"/"and"/"join" across line breaks, "Followings" to
"Following", and a misspelled "exlucde".