### PR TITLE
[ROCm] Fix efficient attention LSE metadata

### DIFF
--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -7329,8 +7329,6 @@ torch.cuda.synchronize()
     @skipIfTorchDynamo("SDPA test compiles internally")
     @skipCUDAIf(not SM70OrLater, "GPU capability is < SM70")
     @onlyCUDA
-    # efficient_attention_forward meta kernel shape mismatch on CDNA - see issue #171568
-    @skipIfRocm
     @dtypes(
         *(
             [torch.float16, torch.bfloat16, torch.float32]

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -6624,7 +6624,7 @@ def meta__scaled_dot_product_efficient_attention(
 
     if torch.version.hip and torch.cuda.is_available():
         """Please see: https://github.com/pytorch/pytorch/issues/146848
-        longsumexp last dim should be seq length
+        logsumexp last dim should be seq length
         """
         logsumexp_dim = M if compute_log_sumexp else 0
     else:
@@ -6971,9 +6971,16 @@ def meta__efficient_attention_forward(
             )
         actual_max_seqlen_q = max_seqlen_q
     actual_max_seqlen_k = max_seqlen_k if max_seqlen_k is not None else N
-    logsumexp_dim = (
-        math.ceil(actual_max_seqlen_q / 32) * 32 if compute_log_sumexp else 0
-    )
+
+    if torch.version.hip is not None:
+        # ROCm efficient-attention backends return compact LSE. CUDA's
+        # memory-efficient attention kernel pads LSE to its kernel alignment.
+        logsumexp_dim = actual_max_seqlen_q if compute_log_sumexp else 0
+    else:
+        logsumexp_dim = (
+            math.ceil(actual_max_seqlen_q / 32) * 32 if compute_log_sumexp else 0
+        )
+
     logsum_exp = torch.empty(
         (logsumexp_batch_dim, num_heads, logsumexp_dim),
         dtype=torch.float,


### PR DESCRIPTION
### Investigation summary

FIXES https://github.com/pytorch/pytorch/issues/168788

On a machine with an MI300X GPU, Torch `2.14.0a0+gitbb208f9` and HIP `7.2.53211`. Tests verified on main @ 5e3cb3e.

### Default behaviour
```
$ PYTHONPATH="$PWD${PYTHONPATH:+:$PYTHONPATH}" PYTORCH_TEST_WITH_ROCM=1 python -m pytest test/test_nestedtensor.py -k "test_sdpa_backwards" -v
test/test_nestedtensor.py::TestNestedTensorSubclassCPU::test_sdpa_backwards_cpu_bfloat16 SKIPPED [0.0015s] (Only runs on cuda)                                                                           [ 16%]
test/test_nestedtensor.py::TestNestedTensorSubclassCPU::test_sdpa_backwards_cpu_float16 SKIPPED [0.0004s] (Only runs on cuda)                                                                            [ 33%]
test/test_nestedtensor.py::TestNestedTensorSubclassCPU::test_sdpa_backwards_cpu_float32 SKIPPED [0.0004s] (Only runs on cuda)                                                                            [ 50%]
test/test_nestedtensor.py::TestNestedTensorSubclassCUDA::test_sdpa_backwards_cuda_bfloat16 SKIPPED [0.0005s] (skipIfRocm: test doesn't currently work on the ROCm stack)                                 [ 66%]
test/test_nestedtensor.py::TestNestedTensorSubclassCUDA::test_sdpa_backwards_cuda_float16 SKIPPED [0.0004s] (skipIfRocm: test doesn't currently work on the ROCm stack)                                  [ 83%]
test/test_nestedtensor.py::TestNestedTensorSubclassCUDA::test_sdpa_backwards_cuda_float32 SKIPPED [0.0005s] (skipIfRocm: test doesn't currently work on the ROCm stack)                                  [100%]

===================================================================================== 6 skipped, 3243 deselected in 1.77s ======================================================================================
```

### Behaviour after removing `@skipIfRocm`
```
test/test_nestedtensor.py::TestNestedTensorSubclassCPU::test_sdpa_backwards_cpu_bfloat16 SKIPPED [0.0018s] (Only runs on cuda)                       [ 16%]
test/test_nestedtensor.py::TestNestedTensorSubclassCPU::test_sdpa_backwards_cpu_float16 SKIPPED [0.0008s] (Only runs on cuda)                        [ 33%]
test/test_nestedtensor.py::TestNestedTensorSubclassCPU::test_sdpa_backwards_cpu_float32 SKIPPED [0.0004s] (Only runs on cuda)                        [ 50%]
test/test_nestedtensor.py::TestNestedTensorSubclassCUDA::test_sdpa_backwards_cuda_bfloat16 PASSED [2.5399s]                                          [ 66%]
test/test_nestedtensor.py::TestNestedTensorSubclassCUDA::test_sdpa_backwards_cuda_float16 PASSED [0.2487s]                                           [ 83%]
test/test_nestedtensor.py::TestNestedTensorSubclassCUDA::test_sdpa_backwards_cuda_float32 FAILED [0.3242s]                                           [100%]

========================================================================= FAILURES =========================================================================
______________________________________________ TestNestedTensorSubclassCUDA.test_sdpa_backwards_cuda_float32 _______________________________________________
AssertionError: expected size 4==4, stride 12==96 at dim=0; expected size 3==3, stride 4==32 at dim=1; expected size 4==32, stride 1==1 at dim=2
Error in op: torch.ops.aten._efficient_attention_forward.default
This error most often comes from a incorrect fake (aka meta) kernel for a custom op.
```

### Root cause
The test shows an inconsistency between compilation metadata and runtime behaviour on ROCm. Specifically, the log-sum-exponent (LSE) length for this test is 4, Nvidia CUDA's mem-efficient attention layout pads LSE to a multiple of 32 as in `meta__efficient_attention_forward()` in `torch/_meta_registrations.py`. However, ROCm AOTriton returns compact LSE with the last dimension being `max_seqlen_q`, hence the breakage. Specifically, for this test, the meta kernel predicts an LSE shape of `[4, 3, 32]`, while AOTriton returns `[4, 3, 4]`

### Proposed fix
	• Model compact LSE metadata for ROCm in `meta__efficient_attention_forward()`.
	• Remove `@skipIfRocm` in `test/test_nestedtensor.py::TestNestedTensorSubclass::test_sdpa_backwards`
	• Correct typo in a comment in `meta__scaled_dot_product_efficient_attention()`: longsumexp --> logsumexp

### Behaviour after the fix
```
test/test_nestedtensor.py::TestNestedTensorSubclassCPU::test_sdpa_backwards_cpu_bfloat16 SKIPPED [0.0015s] (Only runs on cuda)                                                                           [ 16%]
test/test_nestedtensor.py::TestNestedTensorSubclassCPU::test_sdpa_backwards_cpu_float16 SKIPPED [0.0005s] (Only runs on cuda)                                                                            [ 33%]
test/test_nestedtensor.py::TestNestedTensorSubclassCPU::test_sdpa_backwards_cpu_float32 SKIPPED [0.0004s] (Only runs on cuda)                                                                            [ 50%]
test/test_nestedtensor.py::TestNestedTensorSubclassCUDA::test_sdpa_backwards_cuda_bfloat16 PASSED [2.2749s]                                                                                              [ 66%]
test/test_nestedtensor.py::TestNestedTensorSubclassCUDA::test_sdpa_backwards_cuda_float16 PASSED [0.2331s]                                                                                               [ 83%]
test/test_nestedtensor.py::TestNestedTensorSubclassCUDA::test_sdpa_backwards_cuda_float32 PASSED [0.2617s]                                                                                               [100%]

================================================================================ 3 passed, 3 skipped, 3243 deselected in 4.35s =================================================================================
```

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang