### PR TITLE
[inductor] Serialize top-level partial config values (#190728)

### DIFF
--- a/test/inductor/test_config.py
+++ b/test/inductor/test_config.py
@@ -1,10 +1,12 @@
 # Owner(s): ["module: inductor"]
+import functools
 import math
 import unittest
 
 import torch
 from torch._dynamo.utils import counters
 from torch._inductor import config
+from torch._inductor.choices import InductorChoices
 from torch._inductor.pattern_matcher import PatternMatcherPass
 from torch._inductor.test_case import run_tests, TestCase
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_CPU, HAS_TRITON
@@ -244,6 +246,111 @@ class TestInductorConfig(TestCase):
         ):
             code = torch._inductor.config.codegen_config()
             self.assertNotIn("post_grad_custom", code)
+
+    def test_codegen_serializes_inductor_choices_partial(self):
+        partial_choices = functools.partial(InductorChoices, lb=10, ub=100)
+
+        with torch._inductor.config.patch(inductor_choices_class=partial_choices):
+            code = torch._inductor.config.codegen_config()
+
+            self.assertIn("inductor_choices_class", code)
+            self.assertIn("functools.partial", code)
+            self.assertNotIn("<class ", code)
+            compile(code, "<codegen_config>", "exec")
+            namespace = {"torch": torch}
+            exec(code, namespace)
+            reconstructed = torch._inductor.config.inductor_choices_class
+            self.assertIsInstance(reconstructed, functools.partial)
+            self.assertIs(reconstructed.func, InductorChoices)
+            self.assertEqual(reconstructed.args, ())
+            self.assertEqual(reconstructed.keywords, {"lb": 10, "ub": 100})
+
+    def test_codegen_serializes_builtin_partial_with_container_arg(self):
+        partial_choices = functools.partial(max, [1, (2, {"limit": 3})])
+
+        with torch._inductor.config.patch(inductor_choices_class=partial_choices):
+            code = torch._inductor.config.codegen_config()
+            compile(code, "<codegen_config>", "exec")
+            exec(code, {"torch": torch})
+
+            reconstructed = torch._inductor.config.inductor_choices_class
+            self.assertIs(reconstructed.func, max)
+            self.assertEqual(reconstructed.args, ([1, (2, {"limit": 3})],))
+
+    def test_codegen_partial_over_non_importable_emits_comment(self):
+        non_importable = functools.partial(lambda lb=0: None, lb=5)
+
+        with torch._inductor.config.patch(inductor_choices_class=non_importable):
+            code = torch._inductor.config.codegen_config()
+
+            self.assertIn("omitted", code)
+            self.assertIn("inductor_choices_class", code)
+            self.assertNotIn("config.inductor_choices_class = functools.partial", code)
+            compile(code, "<codegen_config>", "exec")
+
+    def test_codegen_partial_with_unsupported_arg_emits_comment(self):
+        for arg in ({1, 2}, math.inf, math.nan):
+            with self.subTest(arg=arg):
+                partial_choices = functools.partial(InductorChoices, arg)
+                with torch._inductor.config.patch(
+                    inductor_choices_class=partial_choices
+                ):
+                    code = torch._inductor.config.codegen_config()
+
+                self.assertIn("omitted", code)
+                self.assertNotIn("config.inductor_choices_class =", code)
+                compile(code, "<codegen_config>", "exec")
+
+    def test_codegen_partial_with_unresolvable_identity_emits_comment(self):
+        def impostor():
+            pass
+
+        impostor.__module__ = InductorChoices.__module__
+        impostor.__qualname__ = InductorChoices.__qualname__
+        partial_choices = functools.partial(impostor)
+
+        with torch._inductor.config.patch(inductor_choices_class=partial_choices):
+            code = torch._inductor.config.codegen_config()
+
+        self.assertIn("partial callable cannot be re-imported", code)
+        compile(code, "<codegen_config>", "exec")
+
+    def test_codegen_partial_with_raising_metadata_emits_comment(self):
+        class CallableWithRaisingMetadata:
+            @property
+            def __module__(self):
+                raise RuntimeError("module metadata unavailable")
+
+            def __call__(self):
+                pass
+
+        partial_choices = functools.partial(CallableWithRaisingMetadata())
+
+        with torch._inductor.config.patch(inductor_choices_class=partial_choices):
+            code = torch._inductor.config.codegen_config()
+
+        self.assertIn("partial callable cannot be re-imported", code)
+        compile(code, "<codegen_config>", "exec")
+
+    def test_codegen_partial_with_invalid_qualname_emits_comment(self):
+        class CallableWithInvalidQualname:
+            __module__ = __name__
+            __qualname__ = "invalid name"
+
+            def __call__(self):
+                pass
+
+        callable_with_invalid_qualname = CallableWithInvalidQualname()
+        globals()["invalid name"] = callable_with_invalid_qualname
+        try:
+            partial_choices = functools.partial(callable_with_invalid_qualname)
+            with torch._inductor.config.patch(inductor_choices_class=partial_choices):
+                code = torch._inductor.config.codegen_config()
+        finally:
+            del globals()["invalid name"]
+
+        self.assertIn("partial callable cannot be re-imported", code)
+        compile(code, "<codegen_config>", "exec")
 
     def test_select_decomp_table_fallback_embedding_bag_byte_unpack(self):
         """Test that select_decomp_table removes embedding_bag_byte_unpack when fallback is enabled"""

--- a/torch/utils/_config_module.py
+++ b/torch/utils/_config_module.py
@@ -1,9 +1,12 @@
 import contextlib
 import copy
+import functools
 import hashlib
 import importlib
 import inspect
 import io
+import keyword
+import math
 import os
 import pickle
 import tokenize
@@ -705,6 +708,76 @@ class ConfigModule(ModuleType):
             # functools.partial has no attributes below but is a callable
             return callable(v) and hasattr(v, "__module__") and hasattr(v, "__name__")
 
+        def importable_ref(func: Any) -> tuple[str, str] | None:
+            try:
+                module_name = getattr(func, "__module__", None)
+                qualname = getattr(func, "__qualname__", None)
+                if (
+                    not callable(func)
+                    or not isinstance(module_name, str)
+                    or not isinstance(qualname, str)
+                    or not module_name
+                    or not qualname
+                    or module_name == "__main__"
+                    or "<" in qualname
+                ):
+                    return None
+                names = module_name.split(".") + qualname.split(".")
+                if any(
+                    not name.isidentifier() or keyword.iskeyword(name) for name in names
+                ):
+                    return None
+                resolved = importlib.import_module(module_name)
+                for name in qualname.split("."):
+                    resolved = getattr(resolved, name)
+                if resolved is not func:
+                    return None
+                import_name = "" if module_name == "builtins" else module_name
+                prefix = f"{import_name}." if import_name else ""
+                return f"{prefix}{qualname}", import_name
+            except Exception:
+                return None
+
+        def serialize_partial_arg(val: Any) -> str:
+            if type(val) in (type(None), bool, int, str, bytes) or (
+                type(val) is float and math.isfinite(val)
+            ):
+                return repr(val)
+            if type(val) not in (list, tuple, dict):
+                raise ValueError(
+                    f"unsupported functools.partial argument type {type(val).__name__}"
+                )
+
+            if type(val) in (list, tuple):
+                for item in val:
+                    serialize_partial_arg(item)
+            else:
+                for key, item in val.items():
+                    serialize_partial_arg(key)
+                    serialize_partial_arg(item)
+            return repr(val)
+
+        def get_partial_line(mod, k, v) -> str:  # type: ignore[no-untyped-def]
+            if type(v) is not functools.partial:
+                return f"# {mod}.{k} omitted: unsupported partial subclass"
+            func_info = importable_ref(v.func)
+            if func_info is None:
+                return f"# {mod}.{k} omitted: partial callable cannot be re-imported"
+            func_ref, import_name = func_info
+            try:
+                parts = [func_ref]
+                parts.extend(serialize_partial_arg(arg) for arg in v.args)
+                if v.keywords:
+                    parts.append(f"**{serialize_partial_arg(v.keywords)}")
+                expression = f"functools.partial({', '.join(parts)})"
+                compile(expression, "<config>", "eval")
+            except Exception:
+                return f"# {mod}.{k} omitted: partial arguments cannot be serialized"
+            if import_name:
+                imports.add(import_name)
+            imports.add("functools")
+            return f"{mod}.{k} = {expression}"
+
         def get_config_line(mod, k, v) -> str:  # type: ignore[no-untyped-def]
             """
             Return a string version of the config line.
@@ -716,7 +789,9 @@ class ConfigModule(ModuleType):
                 import _warnings
                 torch._dynamo.config.reorderable_logging_functions = { _warnings.warn, logging.warn, print }
             """
-            if importable_callable(v):
+            if isinstance(v, functools.partial):
+                return get_partial_line(mod, k, v)
+            elif importable_callable(v):
                 add_import(v)
                 return f"{mod}.{k} = {get_module_name(v, True)}{v.__name__}"
             elif isinstance(v, (list, set)) and all(


### PR DESCRIPTION
Summary:

`ConfigModule.codegen_config()` previously used `repr()` for `functools.partial` values, producing invalid Python in repro preambles. Serialize top-level partials when their callable can be re-imported and their arguments are literal-safe. Unsupported values emit a diagnostic comment instead of raising, so repro generation cannot mask the original compiler failure.

Partials nested inside config containers remain out of scope.

Test Plan:
`arc lint -a fbcode/caffe2/torch/utils/_config_module.py fbcode/caffe2/test/inductor/test_config.py xplat/caffe2/torch/utils/_config_module.py xplat/caffe2/test/inductor/test_config.py`

`buck2 test fbcode//mode/opt fbcode//caffe2/test/inductor:config -- --regex test_codegen_.*partial`

Result: Pass 8. Fail 0.

Reviewed By: jananisriram

Differential Revision: D112369086




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo