### PR TITLE
[trymerge] Auto-label bot-initiated co-dev merges as "topic: not user facing"

### DIFF
--- a/.github/scripts/label_utils.py
+++ b/.github/scripts/label_utils.py
@@ -16,6 +16,9 @@ if TYPE_CHECKING:
 
 BOT_AUTHORS = ["github-actions", "pytorchmergebot", "pytorch-bot"]
 
+# Label that marks a PR as excluded from release notes.
+NOT_USER_FACING_LABEL = "topic: not user facing"
+
 LABEL_ERR_MSG_TITLE = "This PR needs a `release notes:` label"
 LABEL_ERR_MSG = f"""# {LABEL_ERR_MSG_TITLE}
 If your changes are user facing and intended to be a part of release notes, please use a label starting with `release notes:`.
@@ -112,7 +115,7 @@ def has_required_labels(pr: GitHubPR) -> bool:
     pr_labels = pr.get_labels()
     # Check if PR is not user facing
     is_not_user_facing_pr = any(
-        label.strip() == "topic: not user facing" for label in pr_labels
+        label.strip() == NOT_USER_FACING_LABEL for label in pr_labels
     )
     return is_not_user_facing_pr or any(
         label.strip() in get_release_notes_labels(pr.org, pr.project)

--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -24,8 +24,10 @@ from gitutils import get_git_remote_name, get_git_repo_dir, GitRepo
 from trymerge import (
     _find_non_matching_files,
     _revlist_to_prs,
+    can_skip_internal_checks,
     categorize_checks,
     DRCI_CHECKRUN_NAME,
+    ensure_mergeable_labels,
     find_matching_merge_rule,
     get_classifications,
     get_docker_build_checks,
@@ -33,6 +35,7 @@ from trymerge import (
     get_topmost_docker_pr,
     gh_get_team_members,
     GitHubPR,
+    is_bot_initiated_codev_merge,
     is_docker_affecting_files,
     iter_issue_timeline_until_comment,
     JobCheckState,
@@ -318,6 +321,154 @@ class TestTryMerge(TestCase):
         "Without negative patterns, behavior matches the positive-only case."
         files = [".ci/test.sh", "torch/foo.py"]
         self.assertEqual(_find_non_matching_files([".ci/**"], files), ["torch/foo.py"])
+
+    @staticmethod
+    def _pr_with_merge_comment(
+        author_login: str,
+        author_url: str | None = None,
+        diff_revision: str | None = "D123456",
+        editor_login: str | None = None,
+    ) -> Any:
+        pr = mock.MagicMock()
+        pr.get_diff_revision.return_value = diff_revision
+        pr.get_comment_by_id.return_value = mock.MagicMock(
+            author_login=author_login,
+            author_url=author_url,
+            editor_login=editor_login,
+        )
+        return pr
+
+    def test_is_bot_initiated_codev_merge_meta_codesync(self, *args: Any) -> None:
+        "meta-codesync, the current export bot, is recognized as a co-dev merge."
+        pr = self._pr_with_merge_comment(
+            "meta-codesync[bot]", "https://github.com/apps/meta-codesync"
+        )
+        self.assertTrue(is_bot_initiated_codev_merge(pr, 123))
+
+    def test_is_bot_initiated_codev_merge_legacy_bots(self, *args: Any) -> None:
+        "The bots meta-codesync superseded are still recognized."
+        tools = self._pr_with_merge_comment(
+            "facebook-github-tools[bot]",
+            "https://github.com/apps/facebook-github-tools",
+        )
+        self.assertTrue(is_bot_initiated_codev_merge(tools, 123))
+        legacy = self._pr_with_merge_comment("facebook-github-bot")
+        self.assertTrue(is_bot_initiated_codev_merge(legacy, 123))
+
+    def test_is_bot_initiated_codev_merge_false_without_diff(self, *args: Any) -> None:
+        "A bot-initiated merge without an internal diff is not a co-dev merge."
+        pr = self._pr_with_merge_comment(
+            "meta-codesync[bot]",
+            "https://github.com/apps/meta-codesync",
+            diff_revision=None,
+        )
+        self.assertFalse(is_bot_initiated_codev_merge(pr, 123))
+
+    def test_is_bot_initiated_codev_merge_false_when_human(self, *args: Any) -> None:
+        "A human-initiated merge is never treated as a co-dev merge."
+        pr = self._pr_with_merge_comment("some-human")
+        self.assertFalse(is_bot_initiated_codev_merge(pr, 123))
+
+    def test_is_bot_initiated_codev_merge_false_when_edited(self, *args: Any) -> None:
+        "An edited merge comment can't be trusted to name its real author."
+        pr = self._pr_with_merge_comment(
+            "meta-codesync[bot]",
+            "https://github.com/apps/meta-codesync",
+            editor_login="some-human",
+        )
+        self.assertFalse(is_bot_initiated_codev_merge(pr, 123))
+
+    def test_codev_bot_list_does_not_widen_internal_checks(self, *args: Any) -> None:
+        "Auto-labeling meta-codesync must not also waive the Phabricator guard."
+        pr = self._pr_with_merge_comment(
+            "meta-codesync[bot]", "https://github.com/apps/meta-codesync"
+        )
+        self.assertTrue(is_bot_initiated_codev_merge(pr, 123))
+        self.assertFalse(can_skip_internal_checks(pr, 123))
+
+    def test_is_bot_initiated_codev_merge_without_author_url(self, *args: Any) -> None:
+        """Recognition must not depend on author_url. Only `comments(last: 5)`
+        selects it; GH_GET_PR_PREV_COMMENTS and the reviews fragment select
+        `login` alone, so a merge comment older than the prefetched window comes
+        back with author_url=None."""
+        node = {
+            "bodyText": "@pytorchbot merge",
+            "createdAt": "2026-08-04T22:14:27Z",
+            # No "url" — exactly what the paginated query returns.
+            "author": {"login": "meta-codesync[bot]"},
+            "authorAssociation": "NONE",
+            "editor": None,
+            "databaseId": 5185216222,
+            "url": "https://github.com/pytorch/pytorch/pull/192125#issuecomment-1",
+        }
+        comment = GitHubPR._comment_from_node(node)
+        self.assertIsNone(comment.author_url)
+
+        pr = mock.MagicMock()
+        pr.get_diff_revision.return_value = "D114427100"
+        pr.get_comment_by_id.return_value = comment
+        self.assertTrue(is_bot_initiated_codev_merge(pr, 5185216222))
+
+    @mock.patch("trymerge.gh_post_pr_comment")
+    @mock.patch("trymerge.gh_add_labels")
+    @mock.patch("trymerge.is_bot_initiated_codev_merge", return_value=True)
+    @mock.patch("trymerge.has_required_labels", return_value=False)
+    def test_ensure_mergeable_labels_autolabels_codev_merge(
+        self,
+        mock_labels: Any,
+        mock_codev: Any,
+        mock_add: Any,
+        mock_comment: Any,
+        *args: Any,
+    ) -> None:
+        "An unlabeled co-dev merge is auto-labeled instead of raising."
+        pr = mock.MagicMock(org="pytorch", project="pytorch", pr_num=123)
+        ensure_mergeable_labels(pr, 456, dry_run=False)
+        mock_add.assert_called_once_with(
+            "pytorch", "pytorch", 123, ["topic: not user facing"], False
+        )
+        mock_comment.assert_called_once()
+
+    @mock.patch("trymerge.gh_post_pr_comment", side_effect=RuntimeError("boom"))
+    @mock.patch("trymerge.gh_add_labels")
+    @mock.patch("trymerge.is_bot_initiated_codev_merge", return_value=True)
+    @mock.patch("trymerge.has_required_labels", return_value=False)
+    def test_ensure_mergeable_labels_does_not_label_without_audit_comment(
+        self,
+        mock_labels: Any,
+        mock_codev: Any,
+        mock_add: Any,
+        mock_comment: Any,
+        *args: Any,
+    ) -> None:
+        """A failed audit comment must not leave the label behind: the label alone
+        satisfies has_required_labels, so the retry would silently skip the notice."""
+        pr = mock.MagicMock(org="pytorch", project="pytorch", pr_num=123)
+        with self.assertRaises(RuntimeError):
+            ensure_mergeable_labels(pr, 456, dry_run=False)
+        mock_add.assert_not_called()
+
+    @mock.patch("trymerge.gh_add_labels")
+    @mock.patch("trymerge.is_bot_initiated_codev_merge", return_value=False)
+    @mock.patch("trymerge.has_required_labels", return_value=False)
+    def test_ensure_mergeable_labels_raises_for_human_merge(
+        self, mock_labels: Any, mock_codev: Any, mock_add: Any, *args: Any
+    ) -> None:
+        "An unlabeled human-initiated merge still fails the label check."
+        pr = mock.MagicMock(org="pytorch", project="pytorch", pr_num=123)
+        with self.assertRaises(RuntimeError):
+            ensure_mergeable_labels(pr, 456, dry_run=False)
+        mock_add.assert_not_called()
+
+    @mock.patch("trymerge.gh_add_labels")
+    @mock.patch("trymerge.has_required_labels", return_value=True)
+    def test_ensure_mergeable_labels_noop_when_labeled(
+        self, mock_labels: Any, mock_add: Any, *args: Any
+    ) -> None:
+        "A PR that already has a required label is left untouched."
+        pr = mock.MagicMock(org="pytorch", project="pytorch", pr_num=123)
+        ensure_mergeable_labels(pr, 456, dry_run=False)
+        mock_add.assert_not_called()
 
     @mock.patch("trymerge.read_merge_rules", side_effect=mocked_read_merge_rules)
     def test_match_rules(self, *args: Any) -> None:

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -42,6 +42,7 @@ from label_utils import (
     gh_remove_label,
     has_required_labels,
     LABEL_ERR_MSG,
+    NOT_USER_FACING_LABEL,
 )
 from trymerge_explainer import get_revert_message, TryMergeExplainer
 
@@ -692,16 +693,108 @@ def parse_args() -> Any:
     return parser.parse_args()
 
 
-def can_skip_internal_checks(pr: GitHubPR, comment_id: int | None = None) -> bool:
+def _unedited_comment_author(
+    pr: GitHubPR, comment_id: int | None
+) -> tuple[str, str | None] | None:
+    """(author_login, author_url) of the triggering comment.
+
+    None when there is no comment or it has been edited, so a caller can never
+    act on an identity someone may have rewritten.
+    """
     if comment_id is None:
-        return False
+        return None
     comment = pr.get_comment_by_id(comment_id)
     if comment.editor_login is not None:
+        return None
+    return comment.author_login, comment.author_url
+
+
+def can_skip_internal_checks(pr: GitHubPR, comment_id: int | None = None) -> bool:
+    author = _unedited_comment_author(pr, comment_id)
+    if author is None:
         return False
-    if comment.author_login == "facebook-github-bot":
+    author_login, author_url = author
+    if author_login == "facebook-github-bot":
         return True
     # facebook-github-tools is a GitHub App; identify by its app URL.
-    return comment.author_url == "https://github.com/apps/facebook-github-tools"
+    return author_url == "https://github.com/apps/facebook-github-tools"
+
+
+# Bot identities that auto-merge a co-dev PR once its internal Phabricator diff
+# has landed. `meta-codesync` took this over from `facebook-github-tools`, so
+# both are listed: the older one still appears on long-lived PRs.
+#
+# Matched on login rather than on the App URL that can_skip_internal_checks
+# uses. Only `comments(last: 5)` selects `author { url }` — GH_GET_PR_PREV_COMMENTS
+# and the reviews fragment select `login` alone, so author_url is silently None
+# for any comment older than the prefetched window (see _comment_from_node's
+# `.get("url", None)`). `login` is selected everywhere, and a `[bot]` suffix is
+# unforgeable because GitHub usernames cannot contain brackets.
+#
+# Deliberately NOT reusing can_skip_internal_checks' allowlist. That predicate
+# also waives the "must be landed via Phabricator" guard, so adding an identity
+# to it is a trust decision; this list only decides whether a missing
+# release-notes label is auto-filled.
+CODEV_MERGE_BOT_LOGINS = frozenset(
+    {
+        "facebook-github-bot",
+        "facebook-github-tools[bot]",
+        "meta-codesync[bot]",
+    }
+)
+# Same identities by App URL, for the queries that do select it.
+CODEV_MERGE_BOT_APP_URLS = frozenset(
+    {
+        "https://github.com/apps/facebook-github-tools",
+        "https://github.com/apps/meta-codesync",
+    }
+)
+
+
+def is_bot_initiated_codev_merge(pr: GitHubPR, comment_id: int | None) -> bool:
+    # A co-dev merge is initiated by one of the Meta export bots once the
+    # internal Phabricator diff has landed. Such a PR always carries a
+    # "Differential Revision:" line (get_diff_revision); the local check runs
+    # first so a human merge does not pay a comment fetch just to be rejected.
+    if pr.get_diff_revision() is None:
+        return False
+    author = _unedited_comment_author(pr, comment_id)
+    if author is None:
+        return False
+    author_login, author_url = author
+    return (
+        author_login in CODEV_MERGE_BOT_LOGINS or author_url in CODEV_MERGE_BOT_APP_URLS
+    )
+
+
+def ensure_mergeable_labels(
+    pr: GitHubPR, comment_id: int | None, dry_run: bool
+) -> None:
+    if has_required_labels(pr):
+        return
+    # A co-dev merge runs after the internal diff already landed, so the author
+    # can no longer act on a missing release-notes label. Auto-apply
+    # "topic: not user facing" to unblock (as maintainers do manually today) and
+    # leave a comment so the choice is auditable and can be corrected if the
+    # change is in fact user facing. Human-initiated merges still fail.
+    if is_bot_initiated_codev_merge(pr, comment_id):
+        # Comment BEFORE labeling. If the label went on first and the comment
+        # then failed, the merge would abort with the PR already satisfying
+        # has_required_labels — so the retry would take the early return above
+        # and the promised audit trail would never be written.
+        gh_post_pr_comment(
+            pr.org,
+            pr.project,
+            pr.pr_num,
+            f"Adding the `{NOT_USER_FACING_LABEL}` label automatically: this co-dev "
+            "PR is being merged after its internal diff landed, without a "
+            "release-notes label. If this change is user facing, please replace "
+            "the label with the appropriate `release notes: ...` one.",
+            dry_run,
+        )
+        gh_add_labels(pr.org, pr.project, pr.pr_num, [NOT_USER_FACING_LABEL], dry_run)
+    else:
+        raise RuntimeError(LABEL_ERR_MSG.lstrip(" #"))
 
 
 def _revlist_to_prs(
@@ -2603,8 +2696,7 @@ def merge(
     # Check for approvals
     find_matching_merge_rule(pr, repo, skip_mandatory_checks=True)
 
-    if not has_required_labels(pr):
-        raise RuntimeError(LABEL_ERR_MSG.lstrip(" #"))
+    ensure_mergeable_labels(pr, comment_id, dry_run)
 
     if ignore_current:
         checks = pr.get_checkrun_conclusions()


### PR DESCRIPTION
Co-dev / DiffTrain PRs are merged automatically by a Meta export bot **after**
the internal Phabricator diff has already landed. At that point the PR author
can no longer add a release-notes label, so the merge is blocked by the
required-label check (`has_required_labels`) and the change sits un-mirrored on
GitHub until a maintainer manually adds `topic: not user facing`.

Measured on `pytorch/pytorch` over the 30 days to 2026-08-04: 8 co-dev
auto-merges blocked this way, roughly one every four days, each one an
already-landed internal change waiting on a human for the label.

This automates that manual step, but only for merges that are both:

1. **initiated by a Meta export bot** — the triggering `@pytorchbot merge`
   comment was authored by `meta-codesync[bot]`, `facebook-github-tools[bot]`,
   or the legacy `facebook-github-bot` account, and was not edited; and
2. a **co-dev PR** — carries a `Differential Revision:` line
   (`get_diff_revision()` is not `None`).

Human-initiated merges on unlabeled PRs still fail the check exactly as before,
and the force-merge (`-f`) path is untouched.

## Why the bot list is separate from `can_skip_internal_checks`

The obvious implementation reuses `can_skip_internal_checks` as the actor test.
It shouldn't: that predicate also waives the "This PR has internal changes and
must be landed via Phabricator!" guard, so adding an identity to it is a trust
decision, not a labeling one. `is_bot_initiated_codev_merge` therefore keeps its
own list, and both share the new `_unedited_comment_author` helper for the
fetch-and-reject-if-edited step. `can_skip_internal_checks` is behaviorally
unchanged for every identity, which
`test_codev_bot_list_does_not_widen_internal_checks` pins.

## Why it matches on login, not App URL

`can_skip_internal_checks` identifies GitHub Apps by `author_url`, but only
`comments(last: 5)` selects `author { url }` — `GH_GET_PR_PREV_COMMENTS` and
`GH_PR_REVIEWS_FRAGMENT` select `login` alone, so `_comment_from_node`'s
`.get("url", None)` silently yields `author_url=None` for any comment older than
the prefetched window. Matching on `login`, which every query selects, is robust
to that; a `[bot]` suffix is unforgeable because GitHub usernames cannot contain
brackets. Adding `url` to the other two queries would be the deeper fix, but it
changes the query text that keys `gql_mocks.json.gz` and would require
re-recording every cassette — worth its own PR, and it is a pre-existing issue
for `can_skip_internal_checks` and `validate_revert` either way.

Listing `meta-codesync` is what makes this work at all today: the codev
auto-merge commenter cut over from `facebook-github-tools[bot]` to
`meta-codesync[bot]` on 2026-06-10 and has been the sole actor since, so an
actor test written against the older identities alone would never fire.

## Ordering of the label and the audit comment

The comment is posted **before** the label is applied. The other order is not
safe: if labeling succeeded and the comment then failed, the merge would abort
with the PR already satisfying `has_required_labels`, so the retry would take
the early return and the promised audit trail would never be written.

## What changed

- `label_utils.py`: extract the `topic: not user facing` string into
  `NOT_USER_FACING_LABEL`.
- `trymerge.py`: add `_unedited_comment_author`, `is_bot_initiated_codev_merge`,
  and `ensure_mergeable_labels`; `merge()` calls the latter in place of the
  inline `has_required_labels` raise.
- `test_trymerge.py`: cover each bot identity, a paginated comment with no
  `author_url`, the no-diff / human / edited-comment rejections, the
  `can_skip_internal_checks` non-widening property, and the requirement that a
  failed audit comment leaves no label behind.

---

Rebased onto `main` and reworked after a cross-model review (OpenAI gpt-5.6-sol) of the
original version, which flagged three things: the `author_url` pagination gap, the
label-before-comment ordering, and that "landed via co-dev" is provenance rather than a
release-notes judgement (see the tradeoff note above — this matches what maintainers already
do by hand, and the audit comment is the correction path).

The previous merge attempt (2026-07-22) failed on `lintrunner-noclang-all`, which was a crash
inside `tools/linter/adapters/stable_shim_version_linter.py` ("Linter failed. This a bug,
please file an issue against the linter maintainer") while it shelled out for a git diff. That
linter's `include_patterns` cover only `torch/csrc/**/shim*.h`, none of which this PR touches,
so the failure was not caused by this change. `lintrunner` is clean on all three files at this
revision and all 76 tests in `.github/scripts/test_trymerge.py` pass.

This PR was authored with the assistance of an AI coding assistant.