### PR TITLE
Add sys.monitoring support to TorchDynamo

### DIFF
--- a/torch/_dynamo/sys_monitoring.py
+++ b/torch/_dynamo/sys_monitoring.py
@@ -1,0 +1,117 @@
+"""
+sys.monitoring integration for TorchDynamo.
+
+This module handles the setup and teardown of sys.monitoring callbacks for
+Dynamo's code replacement mechanism. The low-level PY_START callback itself
+is implemented in C (eval_frame.c) for performance, but the registration,
+event setup, and cleanup logic is handled here in Python for clarity and
+maintainability.
+"""
+
+import sys
+from typing import Optional
+
+# Only available on Python 3.12+. sys is a built-in module, not a package, so
+# `import sys.monitoring` fails; access it as an attribute instead.
+if sys.version_info >= (3, 12):
+    monitoring = sys.monitoring
+else:
+    monitoring = None  # type: ignore[assignment]
+
+
+# Tool ID reserved for Dynamo. Using slot 3 (slots 3-5 are available for
+# third-party tools; 6 is OPTIMIZER per PEP 669).
+DYNAMO_SYS_MONITORING_TOOL_ID = 3
+
+# Track whether we've registered with sys.monitoring yet
+_sys_monitoring_registered = False
+
+
+def is_sys_monitoring_available() -> bool:
+    """Check if sys.monitoring is available (Python 3.12+)."""
+    return monitoring is not None
+
+
+def get_py_start_event() -> Optional[int]:
+    """Get the PY_START event value from sys.monitoring.
+
+    Returns None if sys.monitoring is not available.
+    """
+    if monitoring is None:
+        return None
+    try:
+        return monitoring.events.PY_START
+    except (AttributeError, ValueError):
+        return None
+
+
+def enable_sys_monitoring(callback_obj) -> bool:
+    """Enable sys.monitoring for Dynamo.
+
+    Args:
+        callback_obj: The C callback object created by the C code
+                     (torch._C._dynamo.eval_frame module)
+
+    Returns:
+        True if successfully enabled, False otherwise.
+    """
+    global _sys_monitoring_registered
+
+    if monitoring is None:
+        return False
+
+    try:
+        py_start_event = get_py_start_event()
+        if py_start_event is None:
+            return False
+
+        # Register the tool ID if not already done
+        if not _sys_monitoring_registered:
+            try:
+                monitoring.use_tool_id(DYNAMO_SYS_MONITORING_TOOL_ID, "torch.dynamo")
+            except ValueError:
+                # Tool ID already in use; that's OK if it's ours
+                pass
+            _sys_monitoring_registered = True
+
+        # Register the callback for PY_START events
+        monitoring.register_callback(
+            DYNAMO_SYS_MONITORING_TOOL_ID,
+            py_start_event,
+            callback_obj,
+        )
+
+        # Enable the PY_START event for our tool
+        monitoring.set_events(DYNAMO_SYS_MONITORING_TOOL_ID, py_start_event)
+
+        return True
+    except Exception:
+        return False
+
+
+def disable_sys_monitoring() -> None:
+    """Disable sys.monitoring for Dynamo.
+
+    This clears the callback registration and disables events, but keeps the
+    tool ID reservation to avoid churn in sys.monitoring state.
+    """
+    global _sys_monitoring_registered
+
+    if monitoring is None or not _sys_monitoring_registered:
+        return
+
+    try:
+        # Disable events first
+        monitoring.set_events(DYNAMO_SYS_MONITORING_TOOL_ID, 0)
+
+        # Clear the callback
+        py_start_event = get_py_start_event()
+        if py_start_event is not None:
+            monitoring.register_callback(
+                DYNAMO_SYS_MONITORING_TOOL_ID,
+                py_start_event,
+                None,
+            )
+    except Exception:
+        # Silently ignore errors during cleanup
+        pass

--- a/torch/csrc/dynamo/debug_macros.h
+++ b/torch/csrc/dynamo/debug_macros.h
@@ -68,6 +68,17 @@ extern "C" {
     abort();                                                    \
   }
 
+#define FAIL_IF_SYS_MONITORING_ENABLED()                            \
+  if (use_sys_monitoring()) {                                       \
+    fprintf(                                                        \
+        stderr,                                                     \
+        "ERROR: %s:%d sys.monitoring is enabled, cannot proceed\n", \
+        __FILE__,                                                   \
+        __LINE__);                                                  \
+    abort();                                                        \
+  }
+
+
 inline _PyFrameEvalFunction _debug_set_eval_frame(
     PyThreadState* tstate,
     _PyFrameEvalFunction eval_frame) {

--- a/torch/csrc/dynamo/eval_frame.c
+++ b/torch/csrc/dynamo/eval_frame.c
@@ -35,7 +35,6 @@ PyObject* dynamo_frame_hook_default(
     THP_EVAL_API_FRAME_OBJECT* frame,
     int throw_flag);
 
-
 inline int use_frame_hook(void) {
   static int cached_result = -1;
   if (cached_result == -1) {
@@ -45,13 +44,32 @@ inline int use_frame_hook(void) {
   return cached_result;
 }
 
+inline int use_sys_monitoring(void) {
+  static int cached_result = -1;
+  if (cached_result == -1) {
+    const char* env_value = getenv("PYTORCH_USE_SYS_MONITORING");
+    cached_result = (env_value != NULL && env_value[0] == '1') ? 1 : 0;
+  }
+  return cached_result;
+}
+
+inline int dynamo_uses_code_replacement(void) {
+  return use_frame_hook() || use_sys_monitoring();
+}
+
 
 static Py_tss_t eval_frame_callback_key = Py_tss_NEEDS_INIT;
 static int64_t current_isolate_recompiles_id = -1;
 
 static PyObject* eval_frame_callback_get(void) {
-  void* result = (use_frame_hook() ? PyThread_tss_get(&hook_callback_key)
-                                   : PyThread_tss_get(&eval_frame_callback_key));
+  // hook_callback_key is shared between frame_hook and sys.monitoring modes
+  // since both have the same semantics (return a replacement code object).
+  void* result;
+  if (dynamo_uses_code_replacement()) {
+    result = PyThread_tss_get(&hook_callback_key);
+  } else {
+    result = PyThread_tss_get(&eval_frame_callback_key);
+  }
 
   if (unlikely(result == NULL)) {
     return (PyObject*)Py_None;
@@ -61,7 +79,7 @@ static PyObject* eval_frame_callback_get(void) {
 }
 
 void eval_frame_callback_set(PyObject* obj) {
-  if (use_frame_hook()) {
+  if (dynamo_uses_code_replacement()) {
     PyThread_tss_set(&hook_callback_key, obj);
   } else {
     PyThread_tss_set(&eval_frame_callback_key, obj);
@@ -250,6 +268,7 @@ static PyObject* dynamo_custom_eval_frame_shim(
     THP_EVAL_API_FRAME_OBJECT* frame,
     int throw_flag) {
   FAIL_IF_FRAME_HOOK_ENABLED();
+  FAIL_IF_SYS_MONITORING_ENABLED();
   return dynamo__custom_eval_frame_shim(tstate, frame, throw_flag);
 }
 
@@ -258,6 +277,7 @@ PyObject* dynamo_eval_frame_default(
     THP_EVAL_API_FRAME_OBJECT* frame,
     int throw_flag) {
   FAIL_IF_FRAME_HOOK_ENABLED();
+  FAIL_IF_SYS_MONITORING_ENABLED();
   if (tstate == NULL) {
     tstate = PyThreadState_GET();
   }
@@ -270,6 +290,7 @@ PyObject* dynamo_eval_frame_default(
 
 static void enable_eval_frame_shim(PyThreadState* tstate) {
   FAIL_IF_FRAME_HOOK_ENABLED();
+  FAIL_IF_SYS_MONITORING_ENABLED();
   if (_PyInterpreterState_GetEvalFrameFunc(tstate->interp) !=
       &dynamo_custom_eval_frame_shim) {
     DEBUG_CHECK(previous_eval_frame == NULL);
@@ -281,6 +302,7 @@ static void enable_eval_frame_shim(PyThreadState* tstate) {
 
 static void enable_eval_frame_default(PyThreadState* tstate) {
   FAIL_IF_FRAME_HOOK_ENABLED();
+  FAIL_IF_SYS_MONITORING_ENABLED();
   if (_PyInterpreterState_GetEvalFrameFunc(tstate->interp) !=
       previous_eval_frame) {
     DEBUG_CHECK(previous_eval_frame != NULL);
@@ -316,6 +338,7 @@ static PyObject* dynamo_eval_custom_code_impl(
   DEBUG_NULL_CHECK(code);
 
   FAIL_IF_FRAME_HOOK_ENABLED();
+  FAIL_IF_SYS_MONITORING_ENABLED();
 #if IS_PYTHON_3_11_PLUS
 
   // Generate Python function object and _PyInterpreterFrame in a way similar to
@@ -550,7 +573,7 @@ static PyObject* dynamo__custom_eval_frame_shim(
   PyObject* callback = eval_frame_callback_get();
 
   if (Py_IsNone(callback)) {
-    if (use_frame_hook()) {
+    if (dynamo_uses_code_replacement()) {
       return dynamo_frame_hook_default(tstate, frame, throw_flag);
     } else {
       return dynamo_eval_frame_default(tstate, frame, throw_flag);
@@ -618,6 +641,8 @@ static PyObject* increment_working_threads(
     if (state->active_dynamo_threads > 0) {
       if (use_frame_hook()) {
         enable_frame_hook_shim(tstate);
+      } else if (use_sys_monitoring()) {
+        enable_sys_monitoring_shim(tstate);
       } else {
         enable_eval_frame_shim(tstate);
       }
@@ -638,6 +663,8 @@ static PyObject* decrement_working_threads(
       if (state->active_dynamo_threads == 0) {
         if (use_frame_hook()) {
           clear_frame_hook_shim(tstate);
+        } else if (use_sys_monitoring()) {
+          clear_sys_monitoring_shim(tstate);
         } else {
           enable_eval_frame_default(tstate);
         }
@@ -798,6 +825,168 @@ void clear_frame_hook_shim(PyThreadState* tstate) {
 
 // end hook code
 
+// sys.monitoring code
+
+#if IS_PYTHON_3_12_PLUS
+
+static PyObject* py_monitoring_callback_obj = NULL;  // PyCFunction object
+
+// Track the code object we just installed via replace_frame_code so that
+// the next PY_START -- which CPython fires synchronously on the new code's
+// own RESUME -- can be passed through without re-entering Dynamo.
+static __thread PyObject* sys_monitoring_pending_replacement = NULL;
+
+static PyObject* py_sys_monitoring_callback(
+    PyObject* self,
+    PyObject* const* args,
+    Py_ssize_t nargs) {
+  if (nargs != 2) {
+    PyErr_SetString(PyExc_TypeError, "PY_START callback expects 2 args");
+    return NULL;
+  }
+  PyObject* code_obj = args[0];
+
+  if (sys_monitoring_pending_replacement == code_obj) {
+    // CPython is re-firing PY_START on the code we just installed. Pass it
+    // through unchanged.
+    sys_monitoring_pending_replacement = NULL;
+    Py_INCREF(code_obj);
+    return code_obj;
+  }
+
+  PyThreadState* tstate = PyThreadState_GET();
+  PyObject* callback = eval_frame_callback_get();
+
+  if (callback == Py_None) {
+    // Dynamo not active on this thread; return original code (no replacement).
+    Py_INCREF(code_obj);
+    return code_obj;
+  }
+
+#if IS_PYTHON_3_13_PLUS
+  THP_EVAL_API_FRAME_OBJECT* frame = tstate->current_frame;
+#else
+  THP_EVAL_API_FRAME_OBJECT* frame = tstate->cframe->current_frame;
+#endif
+  if (frame == NULL) {
+    Py_INCREF(code_obj);
+    return code_obj;
+  }
+
+  // sys.monitoring increments tstate->tracing while invoking this callback.
+  // Dynamo's eval_frame_cpp.cpp short-circuits to eval_default when
+  // tstate->tracing > 0 (to avoid recursion when foreign tracers are active).
+  // Temporarily clear it so Dynamo can actually run.
+  int saved_tracing = tstate->tracing;
+  tstate->tracing = 0;
+  PyObject* result = dynamo__custom_eval_frame_shim(tstate, frame, 0);
+  tstate->tracing = saved_tracing;
+
+  if (result == NULL) {
+    return NULL;
+  }
+  if (!PyCode_Check(result)) {
+    Py_DECREF(result);
+    Py_INCREF(code_obj);
+    return code_obj;
+  }
+  if (result != code_obj) {
+    sys_monitoring_pending_replacement = result;
+  }
+  return result;
+}
+
+static PyMethodDef py_sys_monitoring_method_def = {
+    "torch_dynamo_py_start",
+    (PyCFunction)(void(*)(void))py_sys_monitoring_callback,
+    METH_FASTCALL,
+    "Torch Dynamo sys.monitoring PY_START callback"};
+
+void enable_sys_monitoring_shim(PyThreadState* tstate) {
+  DEBUG_TRACE0("enable_sys_monitoring_shim entered");
+
+  if (py_monitoring_callback_obj == NULL) {
+    py_monitoring_callback_obj =
+        PyCFunction_New(&py_sys_monitoring_method_def, NULL);
+    if (py_monitoring_callback_obj == NULL) {
+      return;
+    }
+  }
+
+  // Call into Python to handle sys.monitoring registration and setup
+  PyObject* sys_monitoring_module = PyImport_ImportModule("torch._dynamo.sys_monitoring");
+  if (sys_monitoring_module == NULL) {
+    DEBUG_TRACE0("Failed to import torch._dynamo.sys_monitoring");
+    PyErr_Clear();
+    return;
+  }
+
+  PyObject* enable_func = PyObject_GetAttrString(sys_monitoring_module, "enable_sys_monitoring");
+  Py_DECREF(sys_monitoring_module);
+
+  if (enable_func == NULL) {
+    DEBUG_TRACE0("Failed to get enable_sys_monitoring function");
+    PyErr_Clear();
+    return;
+  }
+
+  PyObject* result = PyObject_CallFunctionObjArgs(enable_func, py_monitoring_callback_obj, NULL);
+  Py_DECREF(enable_func);
+
+  if (result == NULL) {
+    DEBUG_TRACE0("enable_sys_monitoring call failed");
+    PyErr_Clear();
+  } else {
+    Py_DECREF(result);
+  }
+}
+
+void clear_sys_monitoring_shim(PyThreadState* tstate) {
+  DEBUG_TRACE0("clear_sys_monitoring_shim entered");
+
+  // Call into Python to handle sys.monitoring cleanup
+  PyObject* sys_monitoring_module = PyImport_ImportModule("torch._dynamo.sys_monitoring");
+  if (sys_monitoring_module == NULL) {
+    DEBUG_TRACE0("Failed to import torch._dynamo.sys_monitoring");
+    PyErr_Clear();
+    return;
+  }
+
+  PyObject* disable_func = PyObject_GetAttrString(sys_monitoring_module, "disable_sys_monitoring");
+  Py_DECREF(sys_monitoring_module);
+
+  if (disable_func == NULL) {
+    DEBUG_TRACE0("Failed to get disable_sys_monitoring function");
+    PyErr_Clear();
+    return;
+  }
+
+  PyObject* result = PyObject_CallFunctionObjArgs(disable_func, NULL);
+  Py_DECREF(disable_func);
+
+  if (result == NULL) {
+    DEBUG_TRACE0("disable_sys_monitoring call failed");
+    PyErr_Clear();
+  } else {
+    Py_DECREF(result);
+  }
+}
+
+#else
+
+void enable_sys_monitoring_shim(PyThreadState* tstate) {
+  PyErr_SetString(
+      PyExc_RuntimeError,
+      "PYTORCH_USE_SYS_MONITORING requires Python 3.12+");
+}
+
+void clear_sys_monitoring_shim(PyThreadState* tstate) {}
+
+#endif
+
+// end sys.monitoring code
+
+
 static PyObject* set_skip_guard_eval_unsafe(
     PyObject* dummy,
     PyObject* skip_guard_unsafe_flag) {
@@ -896,6 +1085,14 @@ static PyObject* is_frame_hook_enabled_py(PyObject* dummy, PyObject* obj) {
   }
 }
 
+static PyObject* is_sys_monitoring_enabled_py(PyObject* dummy, PyObject* obj) {
+  if (use_sys_monitoring()) {
+    Py_RETURN_TRUE;
+  } else {
+    Py_RETURN_FALSE;
+  }
+}
+
 
 static int clear_state(PyObject* module) {
   ModuleState* state = PyModule_GetState(module);
@@ -974,10 +1171,10 @@ static PyMethodDef _methods[] = {
     {"set_eval_frame_isolate_recompiles_id", set_eval_frame_isolate_recompiles_id_py, METH_O, NULL},
     {"get_eval_frame_isolate_recompiles_id", get_eval_frame_isolate_recompiles_id_py, METH_NOARGS, NULL},
     {"is_frame_hook_enabled", is_frame_hook_enabled_py, METH_NOARGS, NULL},
+    {"is_sys_monitoring_enabled", is_sys_monitoring_enabled_py, METH_NOARGS, NULL},
     {NULL, NULL, 0, NULL}};
 
 static struct PyModuleDef _module = {
-    PyModuleDef_HEAD_INIT,
     .m_name = "torch._C._dynamo.eval_frame",
     .m_doc = "Module containing hooks to override eval_frame",
     .m_size = sizeof(ModuleState),
@@ -996,8 +1193,9 @@ PyObject* torch_c_dynamo_eval_frame_init(void) {
     return NULL;
   }
 
-  int result = (use_frame_hook() ? PyThread_tss_create(&hook_callback_key)
-                                 : PyThread_tss_create(&eval_frame_callback_key));
+  int result = (dynamo_uses_code_replacement()
+                    ? PyThread_tss_create(&hook_callback_key)
+                    : PyThread_tss_create(&eval_frame_callback_key));
   CHECK(result == 0);
 
   Py_INCREF(Py_None);

--- a/torch/csrc/dynamo/eval_frame.h
+++ b/torch/csrc/dynamo/eval_frame.h
@@ -73,6 +73,11 @@ PyObject* dynamo_frame_hook_custom(
     int throw_flag);
 
 int use_frame_hook(void);
+int use_sys_monitoring(void);
+int dynamo_uses_code_replacement(void);
+
+void enable_sys_monitoring_shim(PyThreadState* tstate);
+void clear_sys_monitoring_shim(PyThreadState* tstate);
 
 #ifdef __cplusplus
 

--- a/torch/csrc/dynamo/eval_frame_cpp.cpp
+++ b/torch/csrc/dynamo/eval_frame_cpp.cpp
@@ -430,7 +430,7 @@ PyObject* dynamo__custom_eval_frame(
 
     DEBUG_TRACE("eval default %s", get_frame_name(frame));
 
-    if (use_frame_hook()) {
+    if (dynamo_uses_code_replacement()) {
       eval_result = dynamo_frame_hook_default(tstate, frame, throw_flag);
     } else {
       eval_result = dynamo_eval_frame_default(tstate, frame, throw_flag);
@@ -499,7 +499,7 @@ PyObject* dynamo__custom_eval_frame(
       debugger_cb(py::handle((PyObject*)cached_code));
     }
 
-    if (use_frame_hook()) {
+    if (dynamo_uses_code_replacement()) {
       eval_result = dynamo_frame_hook_custom(
           tstate, frame, cached_code, trace_annotation, throw_flag);
     } else {
@@ -516,7 +516,15 @@ PyObject* dynamo__custom_eval_frame(
     }
   };
 
-  auto fail = [&]() { clear_old_frame_if_python_312_plus(tstate, frame); };
+  auto fail = [&]() {
+    // In code-replacement mode (frame_hook / sys.monitoring) we don't own the
+    // frame's lifecycle: CPython is still using it and will tear it down
+    // itself.  Calling clear_old_frame_if_python_312_plus here would trip the
+    // "current_frame != frame" assertion in THP_PyFrame_Clear.
+    if (!dynamo_uses_code_replacement()) {
+      clear_old_frame_if_python_312_plus(tstate, frame);
+    }
+  };
 
 #if IS_PYTHON_3_12_PLUS
   // skip tracing the frame if CPython is in a tracing state (e.g.

--- a/torch/csrc/dynamo/framelocals_mapping.cpp
+++ b/torch/csrc/dynamo/framelocals_mapping.cpp
@@ -56,6 +56,15 @@ FrameLocalsMapping::FrameLocalsMapping(FrameLocalsFrameType* frame)
       CHECK(value != nullptr && PyCell_Check(value));
       value = PyCell_GET(value);
     }
+    else if (kind & CO_FAST_CELL && value != nullptr && PyCell_Check(value)) {
+      // A cell variable slot -- including an argument promoted to a cell by the
+      // MAKE_CELL prologue -- holds a PyCell only once the prologue has run.
+      // That is the case when the frame is inspected at RESUME (sys.monitoring's
+      // PY_START); before the prologue (PEP 523) the slot still holds the raw
+      // value (or NULL for a not-yet-created cell). Deref only when it is
+      // actually a cell, so PEP 523 is unaffected.
+      value = PyCell_GET(value);
+    }
 
     DEBUG_CHECK(0 <= i && i < _framelocals.size());
     _framelocals[i] = value;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #190733
* #190732

Implement Mark Shannon's proposal to use sys.monitoring as an alternative to
frame hooks/eval_frame for intercepting code execution. This enables Dynamo to
compile code using Python 3.12+ sys.monitoring infrastructure.

Key changes:
- Added use_sys_monitoring() to check PYTORCH_USE_SYS_MONITORING env var
- Implemented py_sys_monitoring_callback for PY_START event handling
- Added enable/clear_sys_monitoring_shim() for registration and cleanup
- Unified frame hook and sys.monitoring under dynamo_uses_code_replacement()
- Added safety checks to prevent mixing eval_frame with sys.monitoring modes
- Removed skipIfFrameHookDisabled decorators to allow tests to run with sys.monitoring

The implementation supports three-tier evaluation:
1. Frame Hook Mode (PEP 523) - PYTORCH_USE_FRAME_HOOK=1
2. sys.monitoring Mode (Python 3.12+) - PYTORCH_USE_SYS_MONITORING=1
3. eval_frame Mode (default) - original fallback mechanism