### PR TITLE
Note MI300 accuracy issues in set_float32_matmul_precision

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -2132,6 +2132,13 @@ def set_float32_matmul_precision(precision: str) -> None:
         is set then the float32 datatype is used for internal computations, equivalent
         to setting `torch.backends.cuda.matmul.allow_tf32 = False`.
 
+    .. note::
+
+        The implementation of "high" precision in AMD Instinct MI300 series devices uses 10
+        mantissa bits but always rounds down instead of rounding to nearest, reducing accuracy
+        slightly and introducing a downward bias. See 
+        :doc:`/notes/numerical_accuracy`#tensorfloat-32-tf32-on-amd-instinct-mi300-devices
+
     Args:
         precision(str): can be set to "highest" (default), "high", or "medium" (see above).
 


### PR DESCRIPTION
Makes this issue more discoverable. I wasn't sure about the preferred doc linking style. It looks like there's a mix of URL links and relative links [in the repo](https://github.com/search?q=repo%3Apytorch%2Fpytorch%20numerical_accuracy&type=code). And I wasn't sure whether attaching a fragment to a relative link would work.